### PR TITLE
metrics/collect: Read valid metrics each time the handler is called rather than once on startup

### DIFF
--- a/worker/metrics/collect/handler.go
+++ b/worker/metrics/collect/handler.go
@@ -46,7 +46,7 @@ func (l *handler) Handle(c net.Conn) (err error) {
 func (l *handler) do(c net.Conn) (err error) {
 	defer func() {
 		if err != nil {
-			fmt.Fprintf(c, "%v\n", err.Error())
+			fmt.Fprintf(c, "error: %v\n", err.Error())
 		} else {
 			fmt.Fprintf(c, "ok\n")
 		}

--- a/worker/metrics/collect/handler.go
+++ b/worker/metrics/collect/handler.go
@@ -10,16 +10,18 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
-	corecharm "gopkg.in/juju/charm.v6-unstable"
 
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/metrics/spool"
+	"github.com/juju/juju/worker/uniter"
 )
 
 // handlerConfig stores configuration values for the socketListener.
 type handlerConfig struct {
+	charmdir       fortress.Guest
+	agent          agent.Agent
 	unitTag        names.UnitTag
-	charmURL       *corecharm.URL
-	validMetrics   map[string]corecharm.Metric
 	metricsFactory spool.MetricFactory
 	runner         *hookRunner
 }
@@ -35,6 +37,13 @@ type handler struct {
 // Handle triggers the collect-metrics hook and writes collected metrics
 // to the specified connection.
 func (l *handler) Handle(c net.Conn) (err error) {
+	err = l.config.charmdir.Visit(func() error {
+		return l.do(c)
+	}, nil)
+	return errors.Trace(err)
+}
+
+func (l *handler) do(c net.Conn) (err error) {
 	defer func() {
 		if err != nil {
 			fmt.Fprintf(c, "%v\n", err.Error())
@@ -43,14 +52,21 @@ func (l *handler) Handle(c net.Conn) (err error) {
 		}
 		c.Close()
 	}()
+
+	paths := uniter.NewWorkerPaths(l.config.agent.CurrentConfig().DataDir(), l.config.unitTag, "metrics-collect")
+	charmURL, validMetrics, err := readCharm(l.config.unitTag, paths)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	// TODO(fwereade): 2016-03-17 lp:1558657
 	err = c.SetDeadline(time.Now().Add(spool.DefaultTimeout))
 	if err != nil {
 		return errors.Annotate(err, "failed to set the deadline")
 	}
 	recorder, err := l.config.metricsFactory.Recorder(
-		l.config.validMetrics,
-		l.config.charmURL.String(),
+		validMetrics,
+		charmURL.String(),
 		l.config.unitTag.String(),
 	)
 	if err != nil {

--- a/worker/metrics/collect/handler_test.go
+++ b/worker/metrics/collect/handler_test.go
@@ -33,6 +33,7 @@ type handlerSuite struct {
 	resources      dt.StubResources
 	recorder       *dummyRecorder
 	listener       *mockListener
+	mockReadCharm  *mockReadCharm
 }
 
 var _ = gc.Suite(&handlerSuite{})
@@ -88,15 +89,8 @@ func (s *handlerSuite) SetUpTest(c *gc.C) {
 			}, nil
 		},
 	)
-	s.PatchValue(collect.ReadCharm,
-		func(_ names.UnitTag, _ context.Paths) (*corecharm.URL, map[string]corecharm.Metric, error) {
-			return corecharm.MustParseURL("local:trusty/metered-1"),
-				map[string]corecharm.Metric{
-					"pings":      corecharm.Metric{Description: "test metric", Type: corecharm.MetricTypeAbsolute},
-					"juju-units": corecharm.Metric{},
-				}, nil
-		},
-	)
+	s.mockReadCharm = &mockReadCharm{}
+	s.PatchValue(collect.ReadCharm, s.mockReadCharm.ReadCharm)
 	s.listener = &mockListener{}
 	s.PatchValue(collect.NewSocketListener, collect.NewSocketListenerFnc(s.listener))
 }
@@ -126,6 +120,27 @@ func (s *handlerSuite) TestJujuUnitsBuiltinMetric(c *gc.C) {
 	responseString := strings.Trim(string(conn.data), " \n\t")
 	c.Assert(responseString, gc.Equals, "ok")
 	c.Assert(s.recorder.batches, gc.HasLen, 1)
+
+	worker.Kill()
+	err = worker.Wait()
+	c.Assert(err, jc.ErrorIsNil)
+	s.listener.CheckCall(c, 0, "Stop")
+}
+
+func (s *handlerSuite) TestReadCharmCalledOnEachTrigger(c *gc.C) {
+	worker, err := s.manifold.Start(s.resources.Context())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(worker, gc.NotNil)
+	c.Assert(s.listener.Calls(), gc.HasLen, 0)
+
+	_, err = s.listener.trigger()
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.listener.trigger()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.PatchValue(collect.ReadCharm, s.mockReadCharm.ReadCharm)
+	// Expect 3 calls to ReadCharm, one on start and one per handler call
+	s.mockReadCharm.CheckCallNames(c, "ReadCharm", "ReadCharm", "ReadCharm")
 
 	worker.Kill()
 	err = worker.Wait()
@@ -213,4 +228,17 @@ type mockMetricFactory struct {
 // Recorder implements the spool.MetricFactory interface.
 func (f *mockMetricFactory) Recorder(metrics map[string]corecharm.Metric, charmURL, unitTag string) (spool.MetricRecorder, error) {
 	return f.recorder, nil
+}
+
+type mockReadCharm struct {
+	testing.Stub
+}
+
+func (m *mockReadCharm) ReadCharm(unitTag names.UnitTag, paths context.Paths) (*corecharm.URL, map[string]corecharm.Metric, error) {
+	m.MethodCall(m, "ReadCharm", unitTag, paths)
+	return corecharm.MustParseURL("local:trusty/metered-1"),
+		map[string]corecharm.Metric{
+			"pings":      corecharm.Metric{Description: "test metric", Type: corecharm.MetricTypeAbsolute},
+			"juju-units": corecharm.Metric{},
+		}, nil
 }

--- a/worker/metrics/collect/handler_test.go
+++ b/worker/metrics/collect/handler_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/worker/metrics/collect"
 	"github.com/juju/juju/worker/metrics/spool"
 	"github.com/juju/juju/worker/uniter/runner/context"
+	"github.com/juju/juju/worker/workertest"
 )
 
 type handlerSuite struct {
@@ -100,9 +101,7 @@ func (s *handlerSuite) TestListenerStart(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(worker, gc.NotNil)
 	c.Assert(s.listener.Calls(), gc.HasLen, 0)
-	worker.Kill()
-	err = worker.Wait()
-	c.Assert(err, jc.ErrorIsNil)
+	workertest.CleanKill(c, worker)
 	s.listener.CheckCall(c, 0, "Stop")
 }
 
@@ -121,9 +120,7 @@ func (s *handlerSuite) TestJujuUnitsBuiltinMetric(c *gc.C) {
 	c.Assert(responseString, gc.Equals, "ok")
 	c.Assert(s.recorder.batches, gc.HasLen, 1)
 
-	worker.Kill()
-	err = worker.Wait()
-	c.Assert(err, jc.ErrorIsNil)
+	workertest.CleanKill(c, worker)
 	s.listener.CheckCall(c, 0, "Stop")
 }
 
@@ -139,12 +136,10 @@ func (s *handlerSuite) TestReadCharmCalledOnEachTrigger(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.PatchValue(collect.ReadCharm, s.mockReadCharm.ReadCharm)
+	workertest.CleanKill(c, worker)
+
 	// Expect 3 calls to ReadCharm, one on start and one per handler call
 	s.mockReadCharm.CheckCallNames(c, "ReadCharm", "ReadCharm", "ReadCharm")
-
-	worker.Kill()
-	err = worker.Wait()
-	c.Assert(err, jc.ErrorIsNil)
 	s.listener.CheckCall(c, 0, "Stop")
 }
 
@@ -165,9 +160,7 @@ func (s *handlerSuite) TestHandlerError(c *gc.C) {
 	c.Assert(responseString, gc.Matches, ".*well, this is embarassing")
 	c.Assert(s.recorder.batches, gc.HasLen, 0)
 
-	worker.Kill()
-	err = worker.Wait()
-	c.Assert(err, jc.ErrorIsNil)
+	workertest.CleanKill(c, worker)
 	s.listener.CheckCall(c, 0, "Stop")
 }
 

--- a/worker/metrics/collect/manifold.go
+++ b/worker/metrics/collect/manifold.go
@@ -156,11 +156,12 @@ func newCollect(config ManifoldConfig, context dependency.Context) (*collect, er
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
 	if len(validMetrics) > 0 && charmURL.Schema == "local" {
 		h := newHandler(handlerConfig{
+			charmdir:       charmdir,
+			agent:          agent,
 			unitTag:        unitTag,
-			charmURL:       charmURL,
-			validMetrics:   validMetrics,
 			metricsFactory: metricFactory,
 			runner:         runner,
 		})

--- a/worker/metrics/sender/sender.go
+++ b/worker/metrics/sender/sender.go
@@ -75,7 +75,7 @@ func (s *sender) sendMetrics(reader spool.MetricReader) error {
 
 // Handle sends metrics from the spool directory to the
 // controller.
-func (s *sender) Handle(c net.Conn) (err error) {
+func (s *sender) Handle(c net.Conn, _ <-chan struct{}) (err error) {
 	defer func() {
 		if err != nil {
 			fmt.Fprintf(c, "%v\n", err)

--- a/worker/metrics/sender/sender_test.go
+++ b/worker/metrics/sender/sender_test.go
@@ -86,7 +86,8 @@ func (s *senderSuite) TestHandler(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	conn := &mockConnection{data: []byte(fmt.Sprintf("%v\n", tmpDir))}
-	err = metricSender.Handle(conn)
+	ch := make(chan struct{})
+	err = metricSender.Handle(conn, ch)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(apiSender.batches, gc.HasLen, 1)

--- a/worker/metrics/spool/listener.go
+++ b/worker/metrics/spool/listener.go
@@ -21,7 +21,7 @@ const (
 
 // ConnectionHandler defines the method needed to handle socket connections.
 type ConnectionHandler interface {
-	Handle(net.Conn) error
+	Handle(net.Conn, <-chan struct{}) error
 }
 
 type socketListener struct {
@@ -63,7 +63,9 @@ func (l *socketListener) loop() error {
 			return errors.Trace(err)
 		}
 		go func() {
-			if err := l.handler.Handle(conn); err != nil {
+			err := l.handler.Handle(conn, l.t.Dying())
+			if err != nil {
+				// log the error and continue
 				logger.Errorf("request handling failed: %v", err)
 			}
 		}()

--- a/worker/metrics/spool/listener_test.go
+++ b/worker/metrics/spool/listener_test.go
@@ -65,7 +65,7 @@ type mockHandler struct {
 }
 
 // Handle implements the spool.ConnectionHandler interface.
-func (h *mockHandler) Handle(c net.Conn) error {
+func (h *mockHandler) Handle(c net.Conn, _ <-chan struct{}) error {
 	defer c.Close()
 	h.AddCall("Handle")
 	fmt.Fprintf(c, "Hello socket.")


### PR DESCRIPTION


(Review request: http://reviews.vapour.ws/r/4851/)