### PR TITLE
all: don't log errors at warning level (part iii)

### DIFF
--- a/apiserver/common/modeldestroy.go
+++ b/apiserver/common/modeldestroy.go
@@ -83,7 +83,7 @@ func destroyModel(st *state.State, modelTag names.ModelTag, destroyHostedModels 
 
 	err = sendMetrics(st)
 	if err != nil {
-		logger.Warningf("failed to send leftover metrics: %v", err)
+		logger.Errorf("failed to send leftover metrics: %v", err)
 	}
 
 	// Return to the caller. If it's the CLI, it will finish up by calling the

--- a/apiserver/common/networkingcommon/spaces.go
+++ b/apiserver/common/networkingcommon/spaces.go
@@ -32,7 +32,7 @@ func SupportsSpaces(backing environ.ConfigGetter) error {
 	ok, err = netEnv.SupportsSpaces()
 	if !ok {
 		if err != nil && !errors.IsNotSupported(err) {
-			logger.Warningf("checking model spaces support failed with: %v", err)
+			logger.Errorf("checking model spaces support failed with: %v", err)
 		}
 		return errors.NotSupportedf("spaces")
 	}

--- a/cmd/juju/commands/synctools.go
+++ b/cmd/juju/commands/synctools.go
@@ -79,7 +79,7 @@ func (c *syncToolsCommand) Init(args []string) error {
 	if c.destination != "" {
 		// Override localDir with destination as localDir now replaces destination
 		c.localDir = c.destination
-		logger.Warningf("Use of the --destination flag is deprecated in 1.18. Please use --local-dir instead.")
+		logger.Infof("Use of the --destination flag is deprecated in 1.18. Please use --local-dir instead.")
 	}
 	if c.versionStr != "" {
 		var err error
@@ -136,7 +136,7 @@ func (c *syncToolsCommand) Run(ctx *cmd.Context) (resultErr error) {
 		}
 	} else {
 		if c.public {
-			logger.Warningf("--public is ignored unless --local-dir is specified")
+			logger.Infof("--public is ignored unless --local-dir is specified")
 		}
 		api, err := getSyncToolsAPI(c)
 		if err != nil {

--- a/cmd/juju/commands/synctools_test.go
+++ b/cmd/juju/commands/synctools_test.go
@@ -203,7 +203,7 @@ func (s *syncToolsSuite) TestSyncToolsCommandDeprecatedDestination(c *gc.C) {
 	defer loggo.RemoveWriter("deprecated-tester")
 	// Add deprecated message to be checked.
 	messages := []jc.SimpleMessage{
-		{loggo.WARNING, "Use of the --destination flag is deprecated in 1.18. Please use --local-dir instead."},
+		{loggo.INFO, "Use of the --destination flag is deprecated in 1.18. Please use --local-dir instead."},
 	}
 	// Run sync-tools command with --destination flag.
 	ctx, err := s.runSyncToolsCommand(c, "-m", "test-target", "--destination", dir, "--stream", "released")

--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -286,7 +286,7 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 	ctx.Infof("available tools:\n%s", formatTools(context.tools))
 	ctx.Infof("best version:\n    %s", context.chosen)
 	if warnCompat {
-		logger.Warningf("version %s incompatible with this client (%s)", context.chosen, jujuversion.Current)
+		logger.Infof("version %s incompatible with this client (%s)", context.chosen, jujuversion.Current)
 	}
 	if c.DryRun {
 		ctx.Infof("upgrade to this version by running\n    juju upgrade-juju --version=\"%s\"\n", context.chosen)

--- a/cmd/juju/common/cloud.go
+++ b/cmd/juju/common/cloud.go
@@ -40,7 +40,7 @@ func BuiltInClouds() map[string]cloud.Cloud {
 		if err != nil {
 			// Should never happen but it will on go 1.2
 			// because lxd provider is not built.
-			logger.Warningf("cloud %q not available on this platform", name)
+			logger.Errorf("cloud %q not available on this platform", name)
 			continue
 		}
 		builtIn[name] = aCloud

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -41,7 +41,7 @@ func SetBootstrapEndpointAddress(store jujuclient.ControllerStore, controllerNam
 		return errors.Errorf("found no instances, expected at least one")
 	}
 	if length > 1 {
-		logger.Warningf("expected one instance, got %d", length)
+		return errors.Errorf("expected one instance, got %d", length)
 	}
 	bootstrapInstance := instances[0]
 

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1438,7 +1438,7 @@ func (cfg *Config) ValidateUnknownAttrs(fields schema.Fields, defaults schema.De
 		if fields[name] == nil {
 			if val, isString := value.(string); isString && val != "" {
 				// only warn about attributes with non-empty string values
-				logger.Warningf("unknown config field %q", name)
+				logger.Errorf("unknown config field %q", name)
 			}
 			result[name] = value
 		}

--- a/environs/sync/sync.go
+++ b/environs/sync/sync.go
@@ -191,7 +191,7 @@ func copyOneToolsPackage(toolsDir, stream string, tools *coretools.Tools, u Tool
 		return err
 	}
 	if tools.SHA256 == "" {
-		logger.Warningf("no SHA-256 hash for %v", tools.SHA256)
+		logger.Errorf("no SHA-256 hash for %v", tools.SHA256) // TODO(dfc) can you spot the bug ?
 	} else if sha256 != tools.SHA256 {
 		return errors.Errorf("SHA-256 hash mismatch (%v/%v)", sha256, tools.SHA256)
 	}

--- a/environs/testing/bootstrap.go
+++ b/environs/testing/bootstrap.go
@@ -24,7 +24,7 @@ var logger = loggo.GetLogger("juju.environs.testing")
 // that restores finishBootstrap.
 func DisableFinishBootstrap() func() {
 	f := func(environs.BootstrapContext, ssh.Client, environs.Environ, instance.Instance, *instancecfg.InstanceConfig) error {
-		logger.Warningf("provider/common.FinishBootstrap is disabled")
+		logger.Infof("provider/common.FinishBootstrap is disabled")
 		return nil
 	}
 	return testing.PatchValue(&common.FinishBootstrap, f)

--- a/provider/ec2/credentials.go
+++ b/provider/ec2/credentials.go
@@ -73,7 +73,7 @@ func (e environProviderCredentials) DetectCredentials() (*cloud.CloudCredential,
 		}
 		// Basic validation check
 		if values.AwsAccessKeyId == "" || values.AwsSecretAccessKey == "" {
-			logger.Warningf("missing aws credential attributes in credentials file section %q", credName)
+			logger.Errorf("missing aws credential attributes in credentials file section %q", credName)
 			continue
 		}
 		accessKeyCredential := cloud.NewCredential(

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -310,7 +310,7 @@ func (v *ebsVolumeSource) createVolume(p storage.VolumeParams, instances instanc
 			return
 		}
 		if _, err := v.ec2.DeleteVolume(volumeId); err != nil {
-			logger.Warningf("error cleaning up volume %v: %v", volumeId, err)
+			logger.Errorf("error cleaning up volume %v: %v", volumeId, err)
 		}
 	}()
 

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -533,7 +533,7 @@ func validateModelVPC(apiClient vpcAPIClient, modelName, vpcID string) error {
 	case isVPCNotRecommendedError(err):
 		// VPC does not meet minumum validation criteria, but that's less
 		// important for hosted models, as the controller is already accessible.
-		logger.Warningf(
+		logger.Infof(
 			"Juju will use, but does not recommend using VPC %q: %v",
 			vpcID, err.Error(),
 		)

--- a/provider/ec2/environ_vpc_test.go
+++ b/provider/ec2/environ_vpc_test.go
@@ -188,7 +188,7 @@ func (s *vpcSuite) TestValidateModelVPCNotRecommendedStillOK(c *gc.C) {
 
 	s.stubAPI.CheckCallNames(c, "VPCs", "Subnets")
 	testLog := c.GetTestLog()
-	c.Check(testLog, jc.Contains, `WARNING juju.provider.ec2 Juju will use, but does not recommend `+
+	c.Check(testLog, jc.Contains, `INFO juju.provider.ec2 Juju will use, but does not recommend `+
 		`using VPC "vpc-anything": VPC contains no public subnets`)
 	c.Check(testLog, jc.Contains, `INFO juju.provider.ec2 Using VPC "vpc-anything" for model "model"`)
 }

--- a/provider/gce/disks.go
+++ b/provider/gce/disks.go
@@ -164,7 +164,7 @@ func (v *volumeSource) createOneVolume(p storage.VolumeParams, instances instanc
 			return
 		}
 		if err := v.gce.RemoveDisk(zone, volumeName); err != nil {
-			logger.Warningf("error cleaning up volume %v: %v", volumeName, err)
+			logger.Errorf("error cleaning up volume %v: %v", volumeName, err)
 		}
 	}()
 

--- a/state/database.go
+++ b/state/database.go
@@ -171,7 +171,7 @@ func (db *database) CopySession() (Database, SessionCloser) {
 func (db *database) GetCollection(name string) (collection mongo.Collection, closer SessionCloser) {
 	info, found := db.schema[name]
 	if !found {
-		logger.Warningf("using unknown collection %q", name)
+		logger.Errorf("using unknown collection %q", name)
 	}
 
 	// Copy session if necessary.

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -389,12 +389,13 @@ func (fw *Firewaller) reconcileInstances() error {
 				return err
 			}
 			continue
-		} else if err != nil {
+		}
+		if err != nil {
 			return err
 		}
 		instanceId, err := m.InstanceId()
 		if errors.IsNotProvisioned(err) {
-			logger.Warningf("Machine not yet provisioned: %v", err)
+			logger.Errorf("Machine not yet provisioned: %v", err)
 			continue
 		}
 		if err != nil {
@@ -403,7 +404,8 @@ func (fw *Firewaller) reconcileInstances() error {
 		instances, err := fw.environ.Instances([]instance.Id{instanceId})
 		if err == environs.ErrNoInstances {
 			return nil
-		} else if err != nil {
+		}
+		if err != nil {
 			return err
 		}
 		machineId := machined.tag.Id()

--- a/worker/hostkeyreporter/worker.go
+++ b/worker/hostkeyreporter/worker.go
@@ -89,10 +89,12 @@ func (w *hostkeyreporter) run() error {
 
 func (w *hostkeyreporter) readSSHKeys() ([]string, error) {
 	sshDir := w.sshDir()
-	if _, err := os.Stat(sshDir); os.IsNotExist(err) {
-		logger.Warningf("%s doesn't exist - giving up", sshDir)
+	_, err := os.Stat(sshDir)
+	if os.IsNotExist(err) {
+		logger.Errorf("%s doesn't exist - giving up", sshDir)
 		return nil, dependency.ErrUninstall
-	} else if err != nil {
+	}
+	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -104,7 +106,7 @@ func (w *hostkeyreporter) readSSHKeys() ([]string, error) {
 	for _, filename := range filenames {
 		key, err := ioutil.ReadFile(filename)
 		if err != nil {
-			logger.Warningf("unable to read SSH host key (skipping): %v", err)
+			logger.Debugf("unable to read SSH host key (skipping): %v", err)
 			continue
 		}
 		keys = append(keys, string(key))

--- a/worker/instancepoller/updater.go
+++ b/worker/instancepoller/updater.go
@@ -124,17 +124,13 @@ func (p *updater) startMachines(tags []names.MachineTag) error {
 			// We don't know about the machine - start
 			// a goroutine to deal with it.
 			m, err := p.context.getMachine(tag)
-			if params.IsCodeNotFound(err) {
-				logger.Warningf("watcher gave notification of non-existent machine %q", tag.Id())
-				continue
-			}
 			if err != nil {
-				return err
+				return errors.Trace(err)
 			}
 			// We don't poll manual machines.
 			isManual, err := m.IsManual()
 			if err != nil {
-				return err
+				return errors.Trace(err)
 			}
 			if isManual {
 				continue

--- a/worker/leadership/tracker.go
+++ b/worker/leadership/tracker.go
@@ -209,7 +209,7 @@ func (t *Tracker) setMinion() error {
 			logger.Debugf("%s waiting for %s leadership release", t.unitName, t.serviceName)
 			err := t.claimer.BlockUntilLeadershipReleased(t.serviceName)
 			if err != nil {
-				logger.Warningf("error while %s waiting for %s leadership release: %v", t.unitName, t.serviceName, err)
+				logger.Debugf("error while %s waiting for %s leadership release: %v", t.unitName, t.serviceName, err)
 			}
 			// We don't need to do anything else with the error, because we just
 			// close the claimLease channel and trigger a leadership claim on the


### PR DESCRIPTION
- Don't log errors at warning level
- Don't log ignored errors at warning level, make them debug as there is nothing the user is required to do.
- Don't log errors and return them, just return the error
- Don't log informational errors at warning level.
- Don't log multiline messages.

(Review request: http://reviews.vapour.ws/r/4857/)