### PR TITLE
Use providerIDsC for link layer devices

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -298,19 +298,13 @@ func allCollections() collectionSchema {
 			}},
 		},
 		// TODO(dimitern): End of obsolete networking collections.
-		providerIDsC: {},
-		spacesC:      {},
-		subnetsC:     {},
+		providerIDsC:          {},
+		spacesC:               {},
+		subnetsC:              {},
+		linkLayerDevicesC:     {},
+		linkLayerDevicesRefsC: {},
 		// TODO(mfoord): remove providerid indices here and switch to
 		// using providerIDsC to track unique provider ids.
-		linkLayerDevicesC: {
-			indexes: []mgo.Index{{
-				Key:    []string{"providerid"},
-				Unique: true,
-				Sparse: true,
-			}},
-		},
-		linkLayerDevicesRefsC: {},
 		ipAddressesC: {
 			indexes: []mgo.Index{{
 				Key:    []string{"providerid"},

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -118,11 +118,7 @@ func (dev *LinkLayerDevice) MTU() uint {
 
 // ProviderID returns the provider-specific device ID, if set.
 func (dev *LinkLayerDevice) ProviderID() network.Id {
-	return network.Id(dev.localProviderID())
-}
-
-func (dev *LinkLayerDevice) localProviderID() string {
-	return dev.st.localID(dev.doc.ProviderID)
+	return network.Id(dev.doc.ProviderID)
 }
 
 // MachineID returns the ID of the machine this device belongs to.

--- a/state/linklayerdevices_internal_test.go
+++ b/state/linklayerdevices_internal_test.go
@@ -56,15 +56,9 @@ func (s *linkLayerDevicesInternalSuite) TestProviderIDIsEmptyWhenNotSet(c *gc.C)
 
 func (s *linkLayerDevicesInternalSuite) TestProviderIDDoesNotIncludeModelUUIDWhenSet(c *gc.C) {
 	const localProviderID = "foo"
-	globalProviderID := coretesting.ModelTag.Id() + ":" + localProviderID
-
 	result := s.newLinkLayerDeviceWithDummyState(linkLayerDeviceDoc{ProviderID: localProviderID})
 	c.Assert(result.ProviderID(), gc.Equals, network.Id(localProviderID))
-	c.Assert(result.localProviderID(), gc.Equals, localProviderID)
 
-	result = s.newLinkLayerDeviceWithDummyState(linkLayerDeviceDoc{ProviderID: globalProviderID})
-	c.Assert(result.ProviderID(), gc.Equals, network.Id(localProviderID))
-	c.Assert(result.localProviderID(), gc.Equals, localProviderID)
 }
 
 func (s *linkLayerDevicesInternalSuite) TestParentDeviceReturnsNoErrorWhenParentNameNotSet(c *gc.C) {

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -264,18 +264,6 @@ func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesWithDuplicateNameAnd
 	s.assertMachineSetLinkLayerDevicesSucceedsAndResultMatchesArgs(c, s.otherStateMachine, args, s.otherState.ModelUUID())
 }
 
-func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesWithDuplicateNameAndProviderIDFailsInSameModel(c *gc.C) {
-	args := state.LinkLayerDeviceArgs{
-		Name:       "foo",
-		Type:       state.EthernetDevice,
-		ProviderID: "42",
-	}
-	s.assertSetLinkLayerDevicesSucceedsAndResultMatchesArgs(c, args)
-
-	err := s.assertSetLinkLayerDevicesFailsValidationForArgs(c, args, `ProviderID\(s\) not unique: 42`)
-	c.Assert(err, jc.Satisfies, state.IsProviderIDNotUniqueError)
-}
-
 func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesUpdatesProviderIDWhenNotSetOriginally(c *gc.C) {
 	args := state.LinkLayerDeviceArgs{
 		Name: "foo",
@@ -285,6 +273,34 @@ func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesUpdatesProviderIDWhe
 
 	args.ProviderID = "42"
 	s.assertSetLinkLayerDevicesSucceedsAndResultMatchesArgs(c, args)
+}
+
+func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesFailsForProviderIDChange(c *gc.C) {
+	args := state.LinkLayerDeviceArgs{
+		Name:       "foo",
+		Type:       state.EthernetDevice,
+		ProviderID: "42",
+	}
+	s.assertSetLinkLayerDevicesSucceedsAndResultMatchesArgs(c, args)
+
+	args.ProviderID = "43"
+	s.assertSetLinkLayerDevicesFailsForArgs(c, args, `cannot change ProviderID of link layer device "foo"`)
+}
+
+func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesUpdateWithDuplicateProviderIDFails(c *gc.C) {
+	args := state.LinkLayerDeviceArgs{
+		Name:       "foo",
+		Type:       state.EthernetDevice,
+		ProviderID: "42",
+	}
+	s.assertSetLinkLayerDevicesSucceedsAndResultMatchesArgs(c, args)
+	args.Name = "bar"
+	args.ProviderID = ""
+	s.assertSetLinkLayerDevicesSucceedsAndResultMatchesArgs(c, args)
+
+	args.ProviderID = "42"
+	err := s.assertSetLinkLayerDevicesFailsValidationForArgs(c, args, `ProviderID\(s\) not unique: 42`)
+	c.Assert(err, jc.Satisfies, state.IsProviderIDNotUniqueError)
 }
 
 func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesDoesNotClearProviderIDOnceSet(c *gc.C) {

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -190,7 +190,6 @@ func (m *Machine) SetLinkLayerDevices(devicesArgs ...LinkLayerDeviceArgs) (err e
 					return nil, errors.Annotatef(err, "invalid device %q", args.Name)
 				}
 			}
-			panic("foo")
 		}
 
 		ops := []txn.Op{

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -213,6 +213,9 @@ func (s *Space) Remove() (err error) {
 		Remove: true,
 		Assert: isDeadDoc,
 	}}
+	if s.ProviderId() != "" {
+		ops = append(ops, s.st.networkEntityGlobalKeyRemoveOp("space", s.ProviderId()))
+	}
 
 	txnErr := s.st.runTransaction(ops)
 	if txnErr == nil {

--- a/state/state.go
+++ b/state/state.go
@@ -2318,6 +2318,15 @@ func (st *State) networkEntityGlobalKeyOp(globalKey string, providerId network.I
 	}
 }
 
+func (st *State) networkEntityGlobalKeyRemoveOp(globalKey string, providerId network.Id) txn.Op {
+	key := st.networkEntityGlobalKey(globalKey, providerId)
+	return txn.Op{
+		C:      providerIDsC,
+		Id:     key,
+		Remove: true,
+	}
+}
+
 func (st *State) networkEntityGlobalKey(globalKey string, providerId network.Id) string {
 	return st.docID(globalKey + ":" + string(providerId))
 }

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -146,12 +146,8 @@ func (s *Subnet) Remove() (err error) {
 		Assert: isDeadDoc,
 	})
 	if s.doc.ProviderId != "" {
-		id := s.st.networkEntityGlobalKey("subnet", s.ProviderId())
-		ops = append(ops, txn.Op{
-			C:      providerIDsC,
-			Id:     id,
-			Remove: true,
-		})
+		op := s.st.networkEntityGlobalKeyRemoveOp("subnet", s.ProviderId())
+		ops = append(ops, op)
 	}
 
 	txnErr := s.st.runTransaction(ops)


### PR DESCRIPTION
Link layer devices now uses providerIDsC to check and enforce uniqueness of provider IDs.

(Review request: http://reviews.vapour.ws/r/4859/)