### PR TITLE
Fix uniter tests on windows

### DIFF
--- a/cmd/jujud/main_windows.go
+++ b/cmd/jujud/main_windows.go
@@ -17,8 +17,18 @@ import (
 	"github.com/juju/juju/juju/osenv"
 )
 
+// FLAGSFROMENVIRONMENT can control whether we read featureflags from the
+// environment or from the registry. This is only needed because we build the
+// jujud binary in uniter tests and we cannot mock the registry out easily.
+// Once uniter tests are fixed this should be removed.
+var FLAGSFROMENVIRONMENT string
+
 func init() {
-	featureflag.SetFlagsFromRegistry(osenv.JujuRegistryKey, osenv.JujuFeatureFlagEnvKey)
+	if FLAGSFROMENVIRONMENT == "true" {
+		featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
+	} else {
+		featureflag.SetFlagsFromRegistry(osenv.JujuRegistryKey, osenv.JujuFeatureFlagEnvKey)
+	}
 }
 
 func main() {

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -60,7 +60,7 @@ func (s *UniterSuite) SetUpSuite(c *gc.C) {
 	err := os.MkdirAll(toolsDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
 	// TODO(fwereade) GAAAAAAAAAAAAAAAAAH this is LUDICROUS.
-	cmd := exec.Command("go", "build", "github.com/juju/juju/cmd/jujud")
+	cmd := exec.Command(jujudBuildArgs[0], jujudBuildArgs[1:]...)
 	cmd.Dir = toolsDir
 	out, err := cmd.CombinedOutput()
 	c.Logf(string(out))

--- a/worker/uniter/util_unix_test.go
+++ b/worker/uniter/util_unix_test.go
@@ -13,10 +13,12 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
-// Command suffix for the hooks
-var cmdSuffix = ""
-
 var (
+	jujudBuildArgs = []string{"go", "build", "github.com/juju/juju/cmd/jujud"}
+
+	// Command suffix for the hooks
+	cmdSuffix = ""
+
 	// Variables for changed hooks. These are used in uniter_test
 	appendConfigChanged            = "config-get --format yaml --output config.out"
 	uniterRelationsCustomizeScript = "relation-ids db > relations.out && chmod 644 relations.out"

--- a/worker/uniter/util_windows_test.go
+++ b/worker/uniter/util_windows_test.go
@@ -13,10 +13,16 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
-// Command suffix for the hooks
-var cmdSuffix = ".cmd"
-
 var (
+	// We use -ldflags -X main.FLAGSFROMENVIRONMENT=true to toggle a
+	// variable that will force windows to read flags from the environment
+	// instead of the registry.
+	// If this gets removed FLAGSFROMENVIRONMENT should also be abolished.
+	jujudBuildArgs = []string{"go", "build", "-ldflags", "-X main.FLAGSFROMENVIRONMENT=true", "github.com/juju/juju/cmd/jujud"}
+
+	// Command suffix for the hooks
+	cmdSuffix = ".cmd"
+
 	// Variables for changed hooks. These are used in uniter_test
 	appendConfigChanged            = "config-get.exe --format yaml --output config.out"
 	uniterRelationsCustomizeScript = "relation-ids.exe db > relations.out"


### PR DESCRIPTION
We currently build the jujud binary during tests. It normally reads
feature flags from the registry and we cannot control that externally.
This patch forces it to read feature flags from the environment.

(Review request: http://reviews.vapour.ws/r/4860/)