### PR TITLE
Remove network.PreferIPv6, "prefer-ipv6" config settings, and related stuff

### DIFF
--- a/agent/format-1.18.go
+++ b/agent/format-1.18.go
@@ -47,8 +47,6 @@ type format_1_18Serialization struct {
 	OldPassword string
 	Values      map[string]string
 
-	PreferIPv6 bool `yaml:"prefer-ipv6,omitempty"`
-
 	// Only controller machines have these next items set.
 	ControllerCert string `yaml:",omitempty"`
 	ControllerKey  string `yaml:",omitempty"`
@@ -105,7 +103,6 @@ func (formatter_1_18) unmarshal(data []byte) (*configInternal, error) {
 		caCert:            format.CACert,
 		oldPassword:       format.OldPassword,
 		values:            format.Values,
-		preferIPv6:        format.PreferIPv6,
 	}
 	if len(format.StateAddresses) > 0 {
 		config.stateDetails = &connectionDetails{
@@ -173,7 +170,6 @@ func (formatter_1_18) marshal(config *configInternal) ([]byte, error) {
 		CACert:            string(config.caCert),
 		OldPassword:       config.oldPassword,
 		Values:            config.values,
-		PreferIPv6:        config.preferIPv6,
 	}
 	if config.servingInfo != nil {
 		format.ControllerCert = config.servingInfo.Cert

--- a/agent/format-1.18_whitebox_test.go
+++ b/agent/format-1.18_whitebox_test.go
@@ -47,7 +47,6 @@ func (*format_1_18Suite) TestReadConfWithExisting1_18ConfigFileContents(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(config.UpgradedToVersion(), jc.DeepEquals, version.MustParse("1.17.5.1"))
 	c.Assert(config.Jobs(), jc.DeepEquals, []multiwatcher.MachineJob{multiwatcher.JobManageModel})
-	c.Assert(config.PreferIPv6(), jc.IsTrue)
 }
 
 var agentConfig1_18Contents = `
@@ -196,7 +195,6 @@ caprivatekey: '-----BEGIN RSA PRIVATE KEY-----
 
 '
 apiport: 17070
-prefer-ipv6: true
 `[1:]
 
 var agentConfig1_18NotStateMachine = `
@@ -255,5 +253,4 @@ values:
   STORAGE_ADDR: 10.0.3.1:8040
   STORAGE_DIR: /home/user/.local/share/juju/local/storage
 apiport: 17070
-prefer-ipv6: true
 `[1:]

--- a/agent/format_whitebox_test.go
+++ b/agent/format_whitebox_test.go
@@ -37,7 +37,6 @@ var agentParams = AgentConfigParams{
 	StateAddresses:    []string{"localhost:1234"},
 	APIAddresses:      []string{"localhost:1235"},
 	Nonce:             "a nonce",
-	PreferIPv6:        false,
 	Model:             testing.ModelTag,
 }
 

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -685,7 +685,6 @@ func (s *provisionerSuite) TestContainerConfig(c *gc.C) {
 	c.Assert(result.ProviderType, gc.Equals, "dummy")
 	c.Assert(result.AuthorizedKeys, gc.Equals, s.Environ.Config().AuthorizedKeys())
 	c.Assert(result.SSLHostnameVerification, jc.IsTrue)
-	c.Assert(result.PreferIPv6, jc.IsFalse)
 }
 
 func (s *provisionerSuite) TestSetSupportedContainers(c *gc.C) {

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -749,7 +749,6 @@ func (s *clientSuite) TestClientPublicAddressErrors(c *gc.C) {
 
 func (s *clientSuite) TestClientPublicAddressMachine(c *gc.C) {
 	s.setUpScenario(c)
-	network.SetPreferIPv6(false)
 
 	// Internally, network.SelectPublicAddress is used; the "most public"
 	// address is returned.
@@ -792,7 +791,6 @@ func (s *clientSuite) TestClientPrivateAddressErrors(c *gc.C) {
 
 func (s *clientSuite) TestClientPrivateAddress(c *gc.C) {
 	s.setUpScenario(c)
-	network.SetPreferIPv6(false)
 
 	// Internally, network.SelectInternalAddress is used; the public
 	// address if no cloud-local one is available.

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -513,7 +513,6 @@ type ContainerConfig struct {
 	Proxy                   proxy.Settings
 	AptProxy                proxy.Settings
 	AptMirror               string
-	PreferIPv6              bool
 	AllowLXCLoopMounts      bool
 	*UpdateBehavior
 }

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -308,7 +308,6 @@ func (p *ProvisionerAPI) ContainerConfig() (params.ContainerConfig, error) {
 	result.Proxy = config.ProxySettings()
 	result.AptProxy = config.AptProxySettings()
 	result.AptMirror = config.AptMirror()
-	result.PreferIPv6 = config.PreferIPv6()
 	result.AllowLXCLoopMounts, _ = config.AllowLXCLoopMounts()
 
 	return result, nil

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -1100,7 +1100,6 @@ func (s *withoutControllerSuite) TestContainerConfig(c *gc.C) {
 	c.Check(results.Proxy, gc.DeepEquals, expectedProxy)
 	c.Check(results.AptProxy, gc.DeepEquals, expectedProxy)
 	c.Check(results.AptMirror, gc.DeepEquals, "http://example.mirror.com")
-	c.Check(results.PreferIPv6, jc.IsFalse)
 	c.Check(results.AllowLXCLoopMounts, jc.IsTrue)
 }
 

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -168,11 +168,6 @@ type InstanceConfig struct {
 	// override the default APT sources.
 	AptMirror string
 
-	// PreferIPv6 mirrors the value of prefer-ipv6 environment setting
-	// and when set IPv6 addresses for connecting to the API/state
-	// servers will be preferred over IPv4 ones.
-	PreferIPv6 bool
-
 	// The type of Simple Stream to download and deploy on this instance.
 	ImageStream string
 
@@ -246,7 +241,6 @@ func (cfg *InstanceConfig) AgentConfig(
 		APIAddresses:      cfg.ApiHostAddrs(),
 		CACert:            cfg.MongoInfo.CACert,
 		Values:            cfg.AgentEnvironment,
-		PreferIPv6:        cfg.PreferIPv6,
 		Model:             cfg.APIInfo.ModelTag,
 	}
 	if !cfg.Bootstrap {
@@ -268,11 +262,7 @@ func (cfg *InstanceConfig) GUITools() string {
 func (cfg *InstanceConfig) stateHostAddrs() []string {
 	var hosts []string
 	if cfg.Bootstrap {
-		if cfg.PreferIPv6 {
-			hosts = append(hosts, net.JoinHostPort("::1", strconv.Itoa(cfg.StateServingInfo.StatePort)))
-		} else {
-			hosts = append(hosts, net.JoinHostPort("localhost", strconv.Itoa(cfg.StateServingInfo.StatePort)))
-		}
+		hosts = append(hosts, net.JoinHostPort("localhost", strconv.Itoa(cfg.StateServingInfo.StatePort)))
 	}
 	if cfg.MongoInfo != nil {
 		hosts = append(hosts, cfg.MongoInfo.Addrs...)
@@ -283,11 +273,7 @@ func (cfg *InstanceConfig) stateHostAddrs() []string {
 func (cfg *InstanceConfig) ApiHostAddrs() []string {
 	var hosts []string
 	if cfg.Bootstrap {
-		if cfg.PreferIPv6 {
-			hosts = append(hosts, net.JoinHostPort("::1", strconv.Itoa(cfg.StateServingInfo.APIPort)))
-		} else {
-			hosts = append(hosts, net.JoinHostPort("localhost", strconv.Itoa(cfg.StateServingInfo.APIPort)))
-		}
+		hosts = append(hosts, net.JoinHostPort("localhost", strconv.Itoa(cfg.StateServingInfo.APIPort)))
 	}
 	if cfg.APIInfo != nil {
 		hosts = append(hosts, cfg.APIInfo.Addrs...)
@@ -556,7 +542,6 @@ func PopulateInstanceConfig(icfg *InstanceConfig,
 	sslHostnameVerification bool,
 	proxySettings, aptProxySettings proxy.Settings,
 	aptMirror string,
-	preferIPv6 bool,
 	enableOSRefreshUpdates bool,
 	enableOSUpgrade bool,
 ) error {
@@ -573,7 +558,6 @@ func PopulateInstanceConfig(icfg *InstanceConfig,
 	icfg.ProxySettings = proxySettings
 	icfg.AptProxySettings = aptProxySettings
 	icfg.AptMirror = aptMirror
-	icfg.PreferIPv6 = preferIPv6
 	icfg.EnableOSRefreshUpdate = enableOSRefreshUpdates
 	icfg.EnableOSUpgrade = enableOSUpgrade
 	return nil
@@ -600,7 +584,6 @@ func FinishInstanceConfig(icfg *InstanceConfig, cfg *config.Config) (err error) 
 		cfg.ProxySettings(),
 		cfg.AptProxySettings(),
 		cfg.AptMirror(),
-		cfg.PreferIPv6(),
 		cfg.EnableOSRefreshUpdate(),
 		cfg.EnableOSUpgrade(),
 	); err != nil {

--- a/cloudconfig/providerinit/providerinit_test.go
+++ b/cloudconfig/providerinit/providerinit_test.go
@@ -73,7 +73,6 @@ func (s *CloudInitSuite) TestFinishInstanceConfig(c *gc.C) {
 		MongoInfo: &mongo.MongoInfo{Tag: userTag},
 		APIInfo:   &api.Info{Tag: userTag},
 		DisableSSLHostnameVerification: false,
-		PreferIPv6:                     false,
 		EnableOSRefreshUpdate:          true,
 		EnableOSUpgrade:                true,
 	}
@@ -129,7 +128,6 @@ func (s *CloudInitSuite) TestFinishInstanceConfigNonDefault(c *gc.C) {
 		MongoInfo: &mongo.MongoInfo{Tag: userTag},
 		APIInfo:   &api.Info{Tag: userTag},
 		DisableSSLHostnameVerification: true,
-		PreferIPv6:                     false,
 		EnableOSRefreshUpdate:          true,
 		EnableOSUpgrade:                true,
 	})

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -55,7 +55,6 @@ import (
 	jujunames "github.com/juju/juju/juju/names"
 	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/mongo"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/common"
 	"github.com/juju/juju/state"
@@ -403,7 +402,6 @@ func (a *MachineAgent) Run(*cmd.Context) error {
 
 	agentConfig := a.CurrentConfig()
 	createEngine := a.makeEngineCreator(agentConfig.UpgradedToVersion())
-	network.SetPreferIPv6(agentConfig.PreferIPv6())
 	charmrepo.CacheDir = filepath.Join(agentConfig.DataDir(), "charmcache")
 	if err := a.createJujudSymlinks(agentConfig.DataDir()); err != nil {
 		return err

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cmd/jujud/agent/unit"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
-	"github.com/juju/juju/network"
 	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
@@ -127,7 +126,6 @@ func (a *UnitAgent) Run(ctx *cmd.Context) error {
 	if flags := featureflag.String(); flags != "" {
 		logger.Warningf("developer feature flags enabled: %s", flags)
 	}
-	network.SetPreferIPv6(agentConfig.PreferIPv6())
 
 	// Sometimes there are upgrade steps that are needed for each unit.
 	// There are plans afoot to unify the unit and machine agents. When

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -130,7 +130,6 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		return err
 	}
 	agentConfig := c.CurrentConfig()
-	network.SetPreferIPv6(agentConfig.PreferIPv6())
 
 	// agent.Jobs is an optional field in the agent config, and was
 	// introduced after 1.17.2. We default to allowing units on

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -30,7 +30,6 @@ import (
 	"github.com/juju/juju/environs/storage"
 	"github.com/juju/juju/environs/sync"
 	"github.com/juju/juju/environs/tools"
-	"github.com/juju/juju/network"
 	coretools "github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -100,7 +99,6 @@ type BootstrapParams struct {
 // environment.
 func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args BootstrapParams) error {
 	cfg := environ.Config()
-	network.SetPreferIPv6(cfg.PreferIPv6())
 	if secret := cfg.AdminSecret(); secret == "" {
 		return errors.Errorf("model configuration has no admin-secret")
 	}

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1011,13 +1011,6 @@ func (c *Config) Development() bool {
 	return c.defined["development"].(bool)
 }
 
-// PreferIPv6 returns whether IPv6 addresses for API endpoints and
-// machines will be preferred (when available) over IPv4.
-func (c *Config) PreferIPv6() bool {
-	v, _ := c.defined["prefer-ipv6"].(bool)
-	return v
-}
-
 // EnableOSRefreshUpdate returns whether or not newly provisioned
 // instances should run their respective OS's update capability.
 func (c *Config) EnableOSRefreshUpdate() bool {
@@ -1335,7 +1328,6 @@ var alwaysOptional = schema.Defaults{
 	"test-mode":                false,
 	"proxy-ssh":                false,
 	"lxc-clone-aufs":           false,
-	"prefer-ipv6":              false,
 	"enable-os-refresh-update": schema.Omit,
 	"enable-os-upgrade":        schema.Omit,
 }
@@ -1360,7 +1352,6 @@ func allDefaults() schema.Defaults {
 		"bootstrap-retry-delay":      DefaultBootstrapSSHRetryDelay,
 		"bootstrap-addresses-delay":  DefaultBootstrapSSHAddressesDelay,
 		"proxy-ssh":                  false,
-		"prefer-ipv6":                false,
 		"disable-network-management": false,
 		IgnoreMachineAddresses:       false,
 		SetNumaControlPolicyKey:      DefaultNumaControlPolicy,
@@ -1407,7 +1398,6 @@ var immutableAttributes = []string{
 	LxcClone,
 	LXCDefaultMTU,
 	"lxc-clone-aufs",
-	"prefer-ipv6",
 	IdentityURL,
 	IdentityPublicKey,
 }
@@ -1777,12 +1767,6 @@ global or per instance security groups.`,
 	NoProxyKey: {
 		Description: "List of domain addresses not to be proxied (comma-separated)",
 		Type:        environschema.Tstring,
-		Group:       environschema.EnvironGroup,
-	},
-	"prefer-ipv6": {
-		Description: `Whether to prefer IPv6 over IPv4 addresses for API endpoints and machines`,
-		Type:        environschema.Tbool,
-		Immutable:   true,
 		Group:       environschema.EnvironGroup,
 	},
 	ProvisionerHarvestModeKey: {

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -407,26 +407,6 @@ var configTests = []configTest{
 			"block-all-changest": false,
 		}),
 	}, {
-		about:       "Invalid prefer-ipv6 flag",
-		useDefaults: config.UseDefaults,
-		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"authorized-keys": testing.FakeAuthKeys,
-			"prefer-ipv6":     "invalid",
-		}),
-		err: `prefer-ipv6: expected bool, got string\("invalid"\)`,
-	}, {
-		about:       "prefer-ipv6 off",
-		useDefaults: config.UseDefaults,
-		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"prefer-ipv6": false,
-		}),
-	}, {
-		about:       "prefer-ipv6 on",
-		useDefaults: config.UseDefaults,
-		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"prefer-ipv6": true,
-		}),
-	}, {
 		about:       "Invalid agent version",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
@@ -1290,7 +1270,6 @@ func (s *ConfigSuite) TestConfigAttrs(c *gc.C) {
 	attrs["image-stream"] = ""
 	attrs["proxy-ssh"] = false
 	attrs["lxc-clone-aufs"] = false
-	attrs["prefer-ipv6"] = false
 	attrs["set-numa-control-policy"] = false
 	attrs["allow-lxc-loop-mounts"] = false
 
@@ -1402,11 +1381,6 @@ var validationTests = []validationTest{{
 	old:   testing.Attrs{"lxc-default-mtu": 9000},
 	new:   testing.Attrs{"lxc-default-mtu": 42},
 	err:   `cannot change lxc-default-mtu from 9000 to 42`,
-}, {
-	about: "Cannot change prefer-ipv6",
-	old:   testing.Attrs{"prefer-ipv6": false},
-	new:   testing.Attrs{"prefer-ipv6": true},
-	err:   `cannot change prefer-ipv6 from false to true`,
 }, {
 	about: "Cannot change uuid",
 	old:   testing.Attrs{"uuid": "90168e4c-2f10-4e9c-83c2-1fb55a58e5a9"},

--- a/juju/api.go
+++ b/juju/api.go
@@ -330,7 +330,7 @@ func PrepareEndpointsForCaching(
 		collapsedHPs := network.CollapseHostPorts(allHostPorts)
 		filteredHPs := network.FilterUnusableHostPorts(collapsedHPs)
 		uniqueHPs := network.DropDuplicatedHostPorts(filteredHPs)
-		network.SortHostPorts(uniqueHPs, false)
+		network.SortHostPorts(uniqueHPs)
 
 		for _, addr := range addrConnectedTo {
 			uniqueHPs = network.EnsureFirstHostPort(addr, uniqueHPs)

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -402,7 +402,7 @@ var selectInternalTests = []selectTest{{
 	},
 	1,
 }, {
-	"an IPv6 cloud local address is preferred to a public address the former appears first",
+	"an IPv6 cloud local address is preferred to a public address if the former appears first",
 	[]network.Address{
 		network.NewScopedAddress("8.8.8.8", network.ScopePublic),
 		network.NewScopedAddress("2001:db8::1", network.ScopePublic),

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -248,7 +248,6 @@ type selectTest struct {
 	about         string
 	addresses     []network.Address
 	expectedIndex int
-	preferIPv6    bool
 }
 
 // expected returns the expected address for the test.
@@ -263,21 +262,18 @@ var selectPublicTests = []selectTest{{
 	"no addresses gives empty string result",
 	[]network.Address{},
 	-1,
-	false,
 }, {
 	"a public IPv4 address is selected",
 	[]network.Address{
 		network.NewScopedAddress("8.8.8.8", network.ScopePublic),
 	},
 	0,
-	false,
 }, {
 	"a public IPv6 address is selected",
 	[]network.Address{
 		network.NewScopedAddress("2001:db8::1", network.ScopePublic),
 	},
 	0,
-	false,
 }, {
 	"first public address is selected",
 	[]network.Address{
@@ -285,7 +281,6 @@ var selectPublicTests = []selectTest{{
 		network.NewScopedAddress("2001:db8::1", network.ScopePublic),
 	},
 	0,
-	false,
 }, {
 	"the first public address is selected when cloud local fallbacks exist",
 	[]network.Address{
@@ -295,38 +290,24 @@ var selectPublicTests = []selectTest{{
 		network.NewScopedAddress("2001:db8::1", network.ScopePublic),
 	},
 	1,
-	false,
-}, {
-	"IPv6 public address is preferred to a cloud local one when preferIPv6 is true",
-	[]network.Address{
-		network.NewScopedAddress("8.8.8.8", network.ScopePublic),
-		network.NewScopedAddress("172.16.1.1", network.ScopeCloudLocal),
-		network.NewScopedAddress("fc00:1", network.ScopeCloudLocal),
-		network.NewScopedAddress("2001:db8::1", network.ScopePublic),
-	},
-	3,
-	true,
 }, {
 	"a machine IPv4 local address is not selected",
 	[]network.Address{
 		network.NewScopedAddress("127.0.0.1", network.ScopeMachineLocal),
 	},
 	-1,
-	false,
 }, {
 	"a machine IPv6 local address is not selected",
 	[]network.Address{
 		network.NewScopedAddress("::1", network.ScopeMachineLocal),
 	},
 	-1,
-	false,
 }, {
 	"a link-local IPv4 address is not selected",
 	[]network.Address{
 		network.NewScopedAddress("169.254.1.1", network.ScopeLinkLocal),
 	},
 	-1,
-	false,
 }, {
 	"a link-local (multicast or not) IPv6 address is not selected",
 	[]network.Address{
@@ -335,7 +316,6 @@ var selectPublicTests = []selectTest{{
 		network.NewScopedAddress("ff02::1:1", network.ScopeLinkLocal),
 	},
 	-1,
-	false,
 }, {
 	"a public name is preferred to an unknown or cloud local address",
 	[]network.Address{
@@ -345,7 +325,6 @@ var selectPublicTests = []selectTest{{
 		network.NewScopedAddress("public.invalid.testing", network.ScopePublic),
 	},
 	3,
-	false,
 }, {
 	"first unknown address selected",
 	// NOTE(dimitern): Not using NewScopedAddress() below as it derives the
@@ -355,7 +334,6 @@ var selectPublicTests = []selectTest{{
 		{Value: "8.8.8.8", Scope: network.ScopeUnknown},
 	},
 	0,
-	false,
 }, {
 	"first public address is picked when both public IPs and public hostnames exist",
 	[]network.Address{
@@ -364,27 +342,11 @@ var selectPublicTests = []selectTest{{
 		network.NewScopedAddress("8.8.8.8", network.ScopePublic),
 	},
 	1,
-	false,
-}, {
-	"first public IPv6 address is picked when both public IPs and public hostnames exist when preferIPv6 is true",
-	[]network.Address{
-		network.NewScopedAddress("10.0.0.1", network.ScopeUnknown),
-		network.NewScopedAddress("8.8.8.8", network.ScopePublic),
-		network.NewScopedAddress("example.com", network.ScopePublic),
-		network.NewScopedAddress("2001:db8::1", network.ScopePublic),
-	},
-	3,
-	true,
 }}
 
 func (s *AddressSuite) TestSelectPublicAddress(c *gc.C) {
-	oldValue := network.PreferIPv6()
-	defer func() {
-		network.SetPreferIPv6(oldValue)
-	}()
 	for i, t := range selectPublicTests {
 		c.Logf("test %d: %s", i, t.about)
-		network.SetPreferIPv6(t.preferIPv6)
 		expectAddr, expectOK := t.expected()
 		actualAddr, actualOK := network.SelectPublicAddress(t.addresses)
 		c.Check(actualOK, gc.Equals, expectOK)
@@ -396,39 +358,18 @@ var selectInternalTests = []selectTest{{
 	"no addresses gives empty string result",
 	[]network.Address{},
 	-1,
-	false,
 }, {
 	"a public IPv4 address is selected",
 	[]network.Address{
 		network.NewScopedAddress("8.8.8.8", network.ScopePublic),
 	},
 	0,
-	false,
 }, {
 	"a public IPv6 address is selected",
 	[]network.Address{
 		network.NewScopedAddress("2001:db8::1", network.ScopePublic),
 	},
 	0,
-	false,
-}, {
-	"a public IPv6 address is selected when both IPv4 and IPv6 addresses exist and preferIPv6 is true",
-	[]network.Address{
-		network.NewScopedAddress("8.8.8.8", network.ScopePublic),
-		network.NewScopedAddress("2001:db8::1", network.ScopePublic),
-	},
-	1,
-	true,
-}, {
-	"the first public IPv4 address is selected when preferIPv6 is true and no IPv6 addresses",
-	[]network.Address{
-		network.NewScopedAddress("127.0.0.1", network.ScopeMachineLocal),
-		network.NewScopedAddress("8.8.8.8", network.ScopePublic),
-		network.NewScopedAddress("169.254.1.1", network.ScopeLinkLocal),
-		network.NewScopedAddress("8.8.4.4", network.ScopePublic),
-	},
-	1,
-	true,
 }, {
 	"a cloud local IPv4 address is selected",
 	[]network.Address{
@@ -436,7 +377,6 @@ var selectInternalTests = []selectTest{{
 		network.NewScopedAddress("10.0.0.1", network.ScopeCloudLocal),
 	},
 	1,
-	false,
 }, {
 	"a cloud local IPv6 address is selected",
 	[]network.Address{
@@ -444,7 +384,6 @@ var selectInternalTests = []selectTest{{
 		network.NewScopedAddress("2001:db8::1", network.ScopePublic),
 	},
 	0,
-	false,
 }, {
 	"a machine local or link-local address is not selected",
 	[]network.Address{
@@ -453,7 +392,6 @@ var selectInternalTests = []selectTest{{
 		network.NewScopedAddress("fe80::1", network.ScopeLinkLocal),
 	},
 	-1,
-	false,
 }, {
 	"a cloud local address is preferred to a public address",
 	[]network.Address{
@@ -463,9 +401,8 @@ var selectInternalTests = []selectTest{{
 		network.NewScopedAddress("10.0.0.1", network.ScopeCloudLocal),
 	},
 	1,
-	false,
 }, {
-	"an IPv6 cloud local address is preferred to a public address when preferIPv6 is true",
+	"an IPv6 cloud local address is preferred to a public address the former appears first",
 	[]network.Address{
 		network.NewScopedAddress("8.8.8.8", network.ScopePublic),
 		network.NewScopedAddress("2001:db8::1", network.ScopePublic),
@@ -473,17 +410,11 @@ var selectInternalTests = []selectTest{{
 		network.NewScopedAddress("10.0.0.1", network.ScopeCloudLocal),
 	},
 	2,
-	false,
 }}
 
 func (s *AddressSuite) TestSelectInternalAddress(c *gc.C) {
-	oldValue := network.PreferIPv6()
-	defer func() {
-		network.SetPreferIPv6(oldValue)
-	}()
 	for i, t := range selectInternalTests {
 		c.Logf("test %d: %s", i, t.about)
-		network.SetPreferIPv6(t.preferIPv6)
 		expectAddr, expectOK := t.expected()
 		actualAddr, actualOK := network.SelectInternalAddress(t.addresses, false)
 		c.Check(actualOK, gc.Equals, expectOK)
@@ -500,9 +431,8 @@ var selectInternalMachineTests = []selectTest{{
 		network.NewScopedAddress("8.8.8.8", network.ScopePublic),
 	},
 	0,
-	false,
 }, {
-	"first cloud local hostname is selected when preferIPv6 is false",
+	"first cloud local hostname is selected",
 	[]network.Address{
 		network.NewScopedAddress("example.com", network.ScopePublic),
 		network.NewScopedAddress("cloud1.internal", network.ScopeCloudLocal),
@@ -510,46 +440,6 @@ var selectInternalMachineTests = []selectTest{{
 		network.NewScopedAddress("example.org", network.ScopePublic),
 	},
 	1,
-	false,
-}, {
-	"first cloud local hostname is selected when preferIPv6 is true (public first)",
-	[]network.Address{
-		network.NewScopedAddress("example.org", network.ScopePublic),
-		network.NewScopedAddress("example.com", network.ScopePublic),
-		network.NewScopedAddress("cloud1.internal", network.ScopeCloudLocal),
-		network.NewScopedAddress("cloud2.internal", network.ScopeCloudLocal),
-	},
-	2,
-	true,
-}, {
-	"first cloud local hostname is selected when preferIPv6 is true (public last)",
-	[]network.Address{
-		network.NewScopedAddress("cloud1.internal", network.ScopeCloudLocal),
-		network.NewScopedAddress("cloud2.internal", network.ScopeCloudLocal),
-		network.NewScopedAddress("example.org", network.ScopePublic),
-		network.NewScopedAddress("example.com", network.ScopePublic),
-	},
-	0,
-	true,
-}, {
-	"first IPv6 cloud local address is selected when preferIPv6 is true",
-	[]network.Address{
-		network.NewScopedAddress("10.0.0.1", network.ScopeCloudLocal),
-		network.NewScopedAddress("8.8.8.8", network.ScopePublic),
-		network.NewScopedAddress("fc00::1", network.ScopeCloudLocal),
-		network.NewScopedAddress("2001:db8::1", network.ScopePublic),
-	},
-	2,
-	true,
-}, {
-	"first IPv4 cloud local address is selected when preferIPv6 is true and no IPv6 addresses",
-	[]network.Address{
-		network.NewScopedAddress("169.254.1.1", network.ScopeLinkLocal),
-		network.NewScopedAddress("10.0.0.1", network.ScopeCloudLocal),
-		network.NewScopedAddress("172.16.1.1", network.ScopeCloudLocal),
-	},
-	1,
-	true,
 }, {
 	"first machine local address is selected",
 	[]network.Address{
@@ -557,27 +447,8 @@ var selectInternalMachineTests = []selectTest{{
 		network.NewScopedAddress("::1", network.ScopeMachineLocal),
 	},
 	0,
-	false,
 }, {
-	"first IPv6 machine local address is selected when preferIPv6 is true",
-	[]network.Address{
-		network.NewScopedAddress("127.0.0.1", network.ScopeMachineLocal),
-		network.NewScopedAddress("::1", network.ScopeMachineLocal),
-		network.NewScopedAddress("fe80::1", network.ScopeLinkLocal),
-	},
-	1,
-	true,
-}, {
-	"first IPv4 machine local address is selected when preferIPv6 is true and no IPv6 addresses",
-	[]network.Address{
-		network.NewScopedAddress("169.254.1.1", network.ScopeLinkLocal),
-		network.NewScopedAddress("127.0.0.1", network.ScopeMachineLocal),
-		network.NewScopedAddress("127.0.0.2", network.ScopeMachineLocal),
-	},
-	1,
-	true,
-}, {
-	"first machine local address is selected when preferIPv6 is false even with public/cloud hostnames",
+	"first machine local address is selected even with public/cloud hostnames",
 	[]network.Address{
 		network.NewScopedAddress("public.example.com", network.ScopePublic),
 		network.NewScopedAddress("::1", network.ScopeMachineLocal),
@@ -588,9 +459,8 @@ var selectInternalMachineTests = []selectTest{{
 		network.NewScopedAddress("127.0.0.2", network.ScopeMachineLocal),
 	},
 	1,
-	false,
 }, {
-	"first cloud local hostname is selected when preferIPv6 is false even with other machine/cloud addresses",
+	"first cloud local hostname is selected even with other machine/cloud addresses",
 	[]network.Address{
 		network.NewScopedAddress("169.254.1.1", network.ScopeLinkLocal),
 		network.NewScopedAddress("cloud-unknown.internal", network.ScopeUnknown),
@@ -600,42 +470,11 @@ var selectInternalMachineTests = []selectTest{{
 		network.NewScopedAddress("127.0.0.2", network.ScopeMachineLocal),
 	},
 	2,
-	false,
-}, {
-	"first IPv6 machine local address is selected when preferIPv6 is true even with public/cloud hostnames",
-	[]network.Address{
-		network.NewScopedAddress("127.0.0.1", network.ScopeMachineLocal),
-		network.NewScopedAddress("public.example.com", network.ScopePublic),
-		network.NewScopedAddress("unknown.example.com", network.ScopeUnknown),
-		network.NewScopedAddress("cloud.internal", network.ScopeCloudLocal),
-		network.NewScopedAddress("::1", network.ScopeMachineLocal),
-		network.NewScopedAddress("fe80::1", network.ScopeLinkLocal),
-	},
-	4,
-	true,
-}, {
-	"first IPv6 cloud local address is selected when preferIPv6 is true even with cloud local hostnames",
-	[]network.Address{
-		network.NewScopedAddress("169.254.1.1", network.ScopeLinkLocal),
-		network.NewScopedAddress("cloud-unknown.internal", network.ScopeUnknown),
-		network.NewScopedAddress("cloud-local.internal", network.ScopeCloudLocal),
-		network.NewScopedAddress("fc00::1", network.ScopeCloudLocal),
-		network.NewScopedAddress("127.0.0.1", network.ScopeMachineLocal),
-		network.NewScopedAddress("fc00::2", network.ScopeCloudLocal),
-		network.NewScopedAddress("127.0.0.2", network.ScopeMachineLocal),
-	},
-	3,
-	true,
 }}
 
 func (s *AddressSuite) TestSelectInternalMachineAddress(c *gc.C) {
-	oldValue := network.PreferIPv6()
-	defer func() {
-		network.SetPreferIPv6(oldValue)
-	}()
 	for i, t := range selectInternalMachineTests {
 		c.Logf("test %d: %s", i, t.about)
-		network.SetPreferIPv6(t.preferIPv6)
 		expectAddr, expectOK := t.expected()
 		actualAddr, actualOK := network.SelectInternalAddress(t.addresses, true)
 		c.Check(actualOK, gc.Equals, expectOK)
@@ -644,33 +483,21 @@ func (s *AddressSuite) TestSelectInternalMachineAddress(c *gc.C) {
 }
 
 type selectInternalHostPortsTest struct {
-	about      string
-	addresses  []network.HostPort
-	expected   []string
-	preferIPv6 bool
+	about     string
+	addresses []network.HostPort
+	expected  []string
 }
 
 var selectInternalHostPortsTests = []selectInternalHostPortsTest{{
 	"no addresses gives empty string result",
 	[]network.HostPort{},
 	[]string{},
-	false,
 }, {
 	"a public IPv4 address is selected",
 	[]network.HostPort{
 		{network.NewScopedAddress("8.8.8.8", network.ScopePublic), 9999},
 	},
 	[]string{"8.8.8.8:9999"},
-	false,
-}, {
-	"public IPv6 addresses selected when both IPv4 and IPv6 addresses exist and preferIPv6 is true",
-	[]network.HostPort{
-		{network.NewScopedAddress("8.8.8.8", network.ScopePublic), 9999},
-		{network.NewScopedAddress("2001:db8::1", network.ScopePublic), 8888},
-		{network.NewScopedAddress("2002:db8::1", network.ScopePublic), 9999},
-	},
-	[]string{"[2001:db8::1]:8888", "[2002:db8::1]:9999"},
-	true,
 }, {
 	"a cloud local IPv4 addresses are selected",
 	[]network.HostPort{
@@ -679,7 +506,6 @@ var selectInternalHostPortsTests = []selectInternalHostPortsTest{{
 		{network.NewScopedAddress("10.0.0.1", network.ScopeCloudLocal), 1234},
 	},
 	[]string{"10.1.0.1:8888", "10.0.0.1:1234"},
-	false,
 }, {
 	"a machine local or link-local address is not selected",
 	[]network.HostPort{
@@ -688,7 +514,6 @@ var selectInternalHostPortsTests = []selectInternalHostPortsTest{{
 		{network.NewScopedAddress("fe80::1", network.ScopeLinkLocal), 333},
 	},
 	[]string{},
-	false,
 }, {
 	"cloud local addresses are preferred to a public addresses",
 	[]network.HostPort{
@@ -698,25 +523,11 @@ var selectInternalHostPortsTests = []selectInternalHostPortsTest{{
 		{network.NewScopedAddress("10.0.0.1", network.ScopeCloudLocal), 4444},
 	},
 	[]string{"[fc00::1]:123", "10.0.0.1:4444"},
-	false,
-}, {
-	"IPv4 addresses are used when prefer-IPv6 is set but no IPv6 addresses are available",
-	[]network.HostPort{
-		{network.NewScopedAddress("8.8.8.8", network.ScopePublic), 123},
-		{network.NewScopedAddress("10.0.0.1", network.ScopeCloudLocal), 4444},
-	},
-	[]string{"10.0.0.1:4444"},
-	true,
 }}
 
 func (s *AddressSuite) TestSelectInternalHostPorts(c *gc.C) {
-	oldValue := network.PreferIPv6()
-	defer func() {
-		network.SetPreferIPv6(oldValue)
-	}()
 	for i, t := range selectInternalHostPortsTests {
 		c.Logf("test %d: %s", i, t.about)
-		network.SetPreferIPv6(t.preferIPv6)
 		c.Check(network.SelectInternalHostPorts(t.addresses, false), gc.DeepEquals, t.expected)
 	}
 }
@@ -725,23 +536,12 @@ var prioritizeInternalHostPortsTests = []selectInternalHostPortsTest{{
 	"no addresses gives empty string result",
 	[]network.HostPort{},
 	[]string{},
-	false,
 }, {
 	"a public IPv4 address is selected",
 	[]network.HostPort{
 		{network.NewScopedAddress("8.8.8.8", network.ScopePublic), 9999},
 	},
 	[]string{"8.8.8.8:9999"},
-	false,
-}, {
-	"public IPv6 addresses selected when both IPv4 and IPv6 addresses exist and preferIPv6 is true",
-	[]network.HostPort{
-		{network.NewScopedAddress("8.8.8.8", network.ScopePublic), 9999},
-		{network.NewScopedAddress("2001:db8::1", network.ScopePublic), 8888},
-		{network.NewScopedAddress("2002:db8::1", network.ScopePublic), 9999},
-	},
-	[]string{"[2001:db8::1]:8888", "[2002:db8::1]:9999", "8.8.8.8:9999"},
-	true,
 }, {
 	"a cloud local IPv4 addresses are selected",
 	[]network.HostPort{
@@ -750,7 +550,6 @@ var prioritizeInternalHostPortsTests = []selectInternalHostPortsTest{{
 		{network.NewScopedAddress("10.0.0.1", network.ScopeCloudLocal), 1234},
 	},
 	[]string{"10.1.0.1:8888", "10.0.0.1:1234", "8.8.8.8:123"},
-	false,
 }, {
 	"a machine local or link-local address is not selected",
 	[]network.HostPort{
@@ -759,7 +558,6 @@ var prioritizeInternalHostPortsTests = []selectInternalHostPortsTest{{
 		{network.NewScopedAddress("fe80::1", network.ScopeLinkLocal), 333},
 	},
 	[]string{},
-	false,
 }, {
 	"cloud local addresses are preferred to a public addresses",
 	[]network.HostPort{
@@ -769,25 +567,11 @@ var prioritizeInternalHostPortsTests = []selectInternalHostPortsTest{{
 		{network.NewScopedAddress("10.0.0.1", network.ScopeCloudLocal), 4444},
 	},
 	[]string{"[fc00::1]:123", "10.0.0.1:4444", "[2001:db8::1]:123", "8.8.8.8:123"},
-	false,
-}, {
-	"IPv4 addresses are used when prefer-IPv6 is set but no IPv6 addresses are available",
-	[]network.HostPort{
-		{network.NewScopedAddress("8.8.8.8", network.ScopePublic), 123},
-		{network.NewScopedAddress("10.0.0.1", network.ScopeCloudLocal), 4444},
-	},
-	[]string{"10.0.0.1:4444", "8.8.8.8:123"},
-	true,
 }}
 
 func (s *AddressSuite) TestPrioritizeInternalHostPorts(c *gc.C) {
-	oldValue := network.PreferIPv6()
-	defer func() {
-		network.SetPreferIPv6(oldValue)
-	}()
 	for i, t := range prioritizeInternalHostPortsTests {
 		c.Logf("test %d: %s", i, t.about)
-		network.SetPreferIPv6(t.preferIPv6)
 		prioritized := network.PrioritizeInternalHostPorts(t.addresses, false)
 		c.Check(prioritized, gc.DeepEquals, t.expected)
 	}
@@ -878,8 +662,7 @@ func (*AddressSuite) TestSortAddresses(c *gc.C) {
 		"example.com",
 		"8.8.8.8",
 	)
-	// Simulate prefer-ipv6: false first.
-	network.SortAddresses(addrs, false)
+	network.SortAddresses(addrs)
 	c.Assert(addrs, jc.DeepEquals, network.NewAddresses(
 		// Public IPv4 addresses on top.
 		"7.8.8.8",
@@ -901,31 +684,6 @@ func (*AddressSuite) TestSortAddresses(c *gc.C) {
 		"169.254.1.2",
 		// Finally, link-local IPv6 addresses.
 		"fe80::2",
-	))
-
-	// Now, simulate prefer-ipv6: true.
-	network.SortAddresses(addrs, true)
-	c.Assert(addrs, jc.DeepEquals, network.NewAddresses(
-		// Public IPv6 addresses on top.
-		"2001:db8::1",
-		// After that public IPv4 addresses.
-		"7.8.8.8",
-		"8.8.8.8",
-		// Then hostnames.
-		"example.com",
-		"localhost",
-		// Then IPv6 cloud-local addresses.
-		"fc00::1",
-		// Then IPv4 cloud-local addresses.
-		"172.16.0.1",
-		// Then machine-local IPv6 addresses.
-		"::1",
-		// Then machine-local IPv4 addresses.
-		"127.0.0.1",
-		// Then link-local IPv6 addresses.
-		"fe80::2",
-		// Finally, link-local IPv4 addresses.
-		"169.254.1.2",
 	))
 }
 
@@ -955,7 +713,6 @@ func (*AddressSuite) TestDecimalToIPv4(c *gc.C) {
 }
 
 func (*AddressSuite) TestExactScopeMatch(c *gc.C) {
-	network.SetPreferIPv6(false)
 	addr := network.NewScopedAddress("10.0.0.2", network.ScopeCloudLocal)
 	match := network.ExactScopeMatch(addr, network.ScopeCloudLocal)
 	c.Assert(match, jc.IsTrue)
@@ -967,33 +724,6 @@ func (*AddressSuite) TestExactScopeMatch(c *gc.C) {
 	c.Assert(match, jc.IsFalse)
 	match = network.ExactScopeMatch(addr, network.ScopePublic)
 	c.Assert(match, jc.IsTrue)
-}
-
-func (*AddressSuite) TestExactScopeMatchHonoursPreferIPv6(c *gc.C) {
-	network.SetPreferIPv6(true)
-	addr := network.NewScopedAddress("10.0.0.2", network.ScopeCloudLocal)
-	match := network.ExactScopeMatch(addr, network.ScopeCloudLocal)
-	c.Assert(match, jc.IsFalse)
-	match = network.ExactScopeMatch(addr, network.ScopePublic)
-	c.Assert(match, jc.IsFalse)
-
-	addr = network.NewScopedAddress("8.8.8.8", network.ScopePublic)
-	match = network.ExactScopeMatch(addr, network.ScopeCloudLocal)
-	c.Assert(match, jc.IsFalse)
-	match = network.ExactScopeMatch(addr, network.ScopePublic)
-	c.Assert(match, jc.IsFalse)
-
-	addr = network.NewScopedAddress("2001:db8::ff00:42:8329", network.ScopePublic)
-	match = network.ExactScopeMatch(addr, network.ScopeCloudLocal)
-	c.Assert(match, jc.IsFalse)
-	match = network.ExactScopeMatch(addr, network.ScopePublic)
-	c.Assert(match, jc.IsTrue)
-
-	addr = network.NewScopedAddress("fc00::1", network.ScopeCloudLocal)
-	match = network.ExactScopeMatch(addr, network.ScopeCloudLocal)
-	c.Assert(match, jc.IsTrue)
-	match = network.ExactScopeMatch(addr, network.ScopePublic)
-	c.Assert(match, jc.IsFalse)
 }
 
 func (s *AddressSuite) TestResolvableHostnames(c *gc.C) {

--- a/network/hostport.go
+++ b/network/hostport.go
@@ -109,8 +109,8 @@ func (hp hostPortsPreferringIPv4Slice) Swap(i, j int) { hp[i], hp[j] = hp[j], hp
 func (hp hostPortsPreferringIPv4Slice) Less(i, j int) bool {
 	hp1 := hp[i]
 	hp2 := hp[j]
-	order1 := hp1.sortOrder(false)
-	order2 := hp2.sortOrder(false)
+	order1 := hp1.sortOrder()
+	order2 := hp2.sortOrder()
 	if order1 == order2 {
 		if hp1.Address.Value == hp2.Address.Value {
 			return hp1.Port < hp2.Port
@@ -120,33 +120,10 @@ func (hp hostPortsPreferringIPv4Slice) Less(i, j int) bool {
 	return order1 < order2
 }
 
-type hostPortsPreferringIPv6Slice struct {
-	hostPortsPreferringIPv4Slice
-}
-
-func (hp hostPortsPreferringIPv6Slice) Less(i, j int) bool {
-	hp1 := hp.hostPortsPreferringIPv4Slice[i]
-	hp2 := hp.hostPortsPreferringIPv4Slice[j]
-	order1 := hp1.sortOrder(true)
-	order2 := hp2.sortOrder(true)
-	if order1 == order2 {
-		if hp1.Address.Value == hp2.Address.Value {
-			return hp1.Port < hp2.Port
-		}
-		return hp1.Address.Value < hp2.Address.Value
-	}
-	return order1 < order2
-}
-
-// SortHostPorts sorts the given HostPort slice according to the
-// sortOrder of each HostPort's embedded Address and the preferIpv6
-// flag. See Address.sortOrder() for more info.
-func SortHostPorts(hps []HostPort, preferIPv6 bool) {
-	if preferIPv6 {
-		sort.Sort(hostPortsPreferringIPv6Slice{hostPortsPreferringIPv4Slice(hps)})
-	} else {
-		sort.Sort(hostPortsPreferringIPv4Slice(hps))
-	}
+// SortHostPorts sorts the given HostPort slice according to the sortOrder of
+// each HostPort's embedded Address. See Address.sortOrder() for more info.
+func SortHostPorts(hps []HostPort) {
+	sort.Sort(hostPortsPreferringIPv4Slice(hps))
 }
 
 var netLookupIP = net.LookupIP

--- a/network/network.go
+++ b/network/network.go
@@ -11,7 +11,6 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"sync/atomic"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -306,27 +305,6 @@ func (i *InterfaceInfo) CIDRAddress() string {
 	}
 	ipNet.IP = ip
 	return ipNet.String()
-}
-
-var preferIPv6 uint32
-
-// PreferIPV6 returns true if this process prefers IPv6.
-func PreferIPv6() bool { return atomic.LoadUint32(&preferIPv6) > 0 }
-
-// SetPreferIPv6 determines whether IPv6 addresses will be preferred when
-// selecting a public or internal addresses, using the Select*() methods.
-// SetPreferIPV6 needs to be called to set this flag globally at the
-// earliest time possible (e.g. at bootstrap, agent startup, before any
-// CLI command).
-func SetPreferIPv6(prefer bool) {
-	var b uint32
-	if prefer {
-		b = 1
-	}
-	atomic.StoreUint32(&preferIPv6, b)
-	// TODO(dimitern): Drop prefer-ipv6 entirely.
-	prefer = false
-	logger.Infof("setting prefer-ipv6 to %v", prefer)
 }
 
 // LXCNetDefaultConfig is the location of the default network config

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -112,22 +112,6 @@ func (s *NetworkSuite) TestConvertSpaceName(c *gc.C) {
 	}
 }
 
-func (*NetworkSuite) TestInitializeFromConfig(c *gc.C) {
-	c.Check(network.PreferIPv6(), jc.IsFalse)
-
-	envConfig := testing.CustomModelConfig(c, testing.Attrs{
-		"prefer-ipv6": true,
-	})
-	network.SetPreferIPv6(envConfig.PreferIPv6())
-	c.Check(network.PreferIPv6(), jc.IsTrue)
-
-	envConfig = testing.CustomModelConfig(c, testing.Attrs{
-		"prefer-ipv6": false,
-	})
-	network.SetPreferIPv6(envConfig.PreferIPv6())
-	c.Check(network.PreferIPv6(), jc.IsFalse)
-}
-
 func (s *NetworkSuite) TestFilterLXCAddresses(c *gc.C) {
 	lxcFakeNetConfig := filepath.Join(c.MkDir(), "lxc-net")
 	netConf := []byte(`

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -90,9 +90,8 @@ func SampleConfig() testing.Attrs {
 		"api-port":                  4321,
 		"default-series":            series.LatestLts(),
 
-		"secret":      "pork",
-		"controller":  true,
-		"prefer-ipv6": false,
+		"secret":     "pork",
+		"controller": true,
 	}
 }
 
@@ -107,22 +106,13 @@ func PatchTransientErrorInjectionChannel(c chan error) func() {
 }
 
 // stateInfo returns a *state.Info which allows clients to connect to the
-// shared dummy state, if it exists. If preferIPv6 is true, an IPv6 endpoint
-// will be added as primary.
-func stateInfo(preferIPv6 bool) *mongo.MongoInfo {
+// shared dummy state, if it exists.
+func stateInfo() *mongo.MongoInfo {
 	if gitjujutesting.MgoServer.Addr() == "" {
 		panic("dummy environ state tests must be run with MgoTestPackage")
 	}
 	mongoPort := strconv.Itoa(gitjujutesting.MgoServer.Port())
-	var addrs []string
-	if preferIPv6 {
-		addrs = []string{
-			net.JoinHostPort("::1", mongoPort),
-			net.JoinHostPort("localhost", mongoPort),
-		}
-	} else {
-		addrs = []string{net.JoinHostPort("localhost", mongoPort)}
-	}
+	addrs := []string{net.JoinHostPort("localhost", mongoPort)}
 	return &mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  addrs,
@@ -253,7 +243,6 @@ type environState struct {
 	apiState        *state.State
 	apiStatePool    *state.StatePool
 	bootstrapConfig *config.Config
-	preferIPv6      bool
 }
 
 // environ represents a client's connection to a given environment's
@@ -687,7 +676,6 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 	if err := e.checkBroken("Bootstrap"); err != nil {
 		return nil, err
 	}
-	network.SetPreferIPv6(e.Config().PreferIPv6())
 	password := e.Config().AdminSecret()
 	if password == "" {
 		return nil, fmt.Errorf("admin-secret is required for bootstrap")
@@ -711,7 +699,6 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 	if estate.bootstrapped {
 		return nil, fmt.Errorf("model is already bootstrapped")
 	}
-	estate.preferIPv6 = e.Config().PreferIPv6()
 
 	// Create an instance for the bootstrap node.
 	logger.Infof("creating bootstrap instance")
@@ -731,7 +718,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 		// TODO(rog) factor out relevant code from cmd/jujud/bootstrap.go
 		// so that we can call it here.
 
-		info := stateInfo(estate.preferIPv6)
+		info := stateInfo()
 		// Since the admin user isn't setup until after here,
 		// the password in the info structure is empty, so the admin
 		// user is constructed with an empty password here.
@@ -922,9 +909,6 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 
 	idString := fmt.Sprintf("%s-%d", e.name, estate.maxId)
 	addrs := network.NewAddresses(idString+".dns", "127.0.0.1")
-	if estate.preferIPv6 {
-		addrs = append(addrs, network.NewAddress(fmt.Sprintf("fc00::%x", estate.maxId+1)))
-	}
 	logger.Debugf("StartInstance addresses: %v", addrs)
 	i := &dummyInstance{
 		id:           instance.Id(idString),

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -114,8 +114,7 @@ func (s *suite) TearDownTest(c *gc.C) {
 	s.BaseSuite.TearDownTest(c)
 }
 
-func (s *suite) bootstrapTestEnviron(c *gc.C, preferIPv6 bool) environs.NetworkingEnviron {
-	s.TestConfig["prefer-ipv6"] = preferIPv6
+func (s *suite) bootstrapTestEnviron(c *gc.C) environs.NetworkingEnviron {
 	env, err := environs.Prepare(
 		envtesting.BootstrapContext(c),
 		s.ControllerStore,
@@ -136,7 +135,7 @@ func (s *suite) bootstrapTestEnviron(c *gc.C, preferIPv6 bool) environs.Networki
 }
 
 func (s *suite) TestAvailabilityZone(c *gc.C) {
-	e := s.bootstrapTestEnviron(c, true)
+	e := s.bootstrapTestEnviron(c)
 	defer func() {
 		err := e.Destroy()
 		c.Assert(err, jc.ErrorIsNil)
@@ -148,7 +147,7 @@ func (s *suite) TestAvailabilityZone(c *gc.C) {
 }
 
 func (s *suite) TestSupportsAddressAllocation(c *gc.C) {
-	e := s.bootstrapTestEnviron(c, false)
+	e := s.bootstrapTestEnviron(c)
 	defer func() {
 		err := e.Destroy()
 		c.Assert(err, jc.ErrorIsNil)
@@ -181,7 +180,7 @@ func (s *suite) TestSupportsAddressAllocation(c *gc.C) {
 }
 
 func (s *suite) TestSupportsSpaces(c *gc.C) {
-	e := s.bootstrapTestEnviron(c, false)
+	e := s.bootstrapTestEnviron(c)
 	defer func() {
 		err := e.Destroy()
 		c.Assert(err, jc.ErrorIsNil)
@@ -208,7 +207,7 @@ func (s *suite) TestSupportsSpaces(c *gc.C) {
 }
 
 func (s *suite) TestSupportsSpaceDiscovery(c *gc.C) {
-	e := s.bootstrapTestEnviron(c, false)
+	e := s.bootstrapTestEnviron(c)
 	defer func() {
 		err := e.Destroy()
 		c.Assert(err, jc.ErrorIsNil)
@@ -245,7 +244,7 @@ func (s *suite) breakMethods(c *gc.C, e environs.NetworkingEnviron, names ...str
 }
 
 func (s *suite) TestAllocateAddress(c *gc.C) {
-	e := s.bootstrapTestEnviron(c, false)
+	e := s.bootstrapTestEnviron(c)
 	defer func() {
 		err := e.Destroy()
 		c.Assert(err, jc.ErrorIsNil)
@@ -284,7 +283,7 @@ func (s *suite) TestAllocateAddress(c *gc.C) {
 }
 
 func (s *suite) TestReleaseAddress(c *gc.C) {
-	e := s.bootstrapTestEnviron(c, false)
+	e := s.bootstrapTestEnviron(c)
 	defer func() {
 		err := e.Destroy()
 		c.Assert(err, jc.ErrorIsNil)
@@ -325,7 +324,7 @@ func (s *suite) TestReleaseAddress(c *gc.C) {
 }
 
 func (s *suite) TestNetworkInterfaces(c *gc.C) {
-	e := s.bootstrapTestEnviron(c, false)
+	e := s.bootstrapTestEnviron(c)
 	defer func() {
 		err := e.Destroy()
 		c.Assert(err, jc.ErrorIsNil)
@@ -439,7 +438,7 @@ func (s *suite) TestNetworkInterfaces(c *gc.C) {
 }
 
 func (s *suite) TestSubnets(c *gc.C) {
-	e := s.bootstrapTestEnviron(c, false)
+	e := s.bootstrapTestEnviron(c)
 	defer func() {
 		err := e.Destroy()
 		c.Assert(err, jc.ErrorIsNil)
@@ -550,34 +549,6 @@ func (s *suite) TestSubnets(c *gc.C) {
 	netInfo, err = e.Subnets("i-any", nil)
 	c.Assert(err, gc.ErrorMatches, `dummy\.Subnets is broken`)
 	c.Assert(netInfo, gc.HasLen, 0)
-}
-
-func (s *suite) TestPreferIPv6On(c *gc.C) {
-	e := s.bootstrapTestEnviron(c, true)
-	defer func() {
-		err := e.Destroy()
-		c.Assert(err, jc.ErrorIsNil)
-	}()
-
-	inst, _ := jujutesting.AssertStartInstance(c, e, "0")
-	c.Assert(inst, gc.NotNil)
-	addrs, err := inst.Addresses()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addrs, jc.DeepEquals, network.NewAddresses("only-0.dns", "127.0.0.1", "fc00::1"))
-}
-
-func (s *suite) TestPreferIPv6Off(c *gc.C) {
-	e := s.bootstrapTestEnviron(c, false)
-	defer func() {
-		err := e.Destroy()
-		c.Assert(err, jc.ErrorIsNil)
-	}()
-
-	inst, _ := jujutesting.AssertStartInstance(c, e, "0")
-	c.Assert(inst, gc.NotNil)
-	addrs, err := inst.Addresses()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addrs, jc.DeepEquals, network.NewAddresses("only-0.dns", "127.0.0.1"))
 }
 
 func assertAllocateAddress(

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -1709,35 +1709,6 @@ func (s *MachineSuite) TestMergedAddresses(c *gc.C) {
 		"127.0.0.1",
 		"fe80::1",
 	))
-
-	// Now simulate prefer-ipv6: true
-	c.Assert(
-		s.State.UpdateModelConfig(
-			map[string]interface{}{"prefer-ipv6": true},
-			nil, nil,
-		),
-		gc.IsNil,
-	)
-
-	err = machine.SetProviderAddresses(providerAddresses...)
-	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetMachineAddresses(machineAddresses...)
-	c.Assert(err, jc.ErrorIsNil)
-	err = machine.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machine.Addresses(), jc.DeepEquals, network.NewAddresses(
-		"2001:db8::1",
-		"8.8.8.8",
-		"example.org",
-		"fc00::1",
-		"::1",
-		"127.0.0.2",
-		"localhost",
-		"fd00::1",
-		"192.168.0.1",
-		"127.0.0.1",
-		"fe80::1",
-	))
 }
 
 func (s *MachineSuite) TestSetProviderAddressesConcurrentChangeDifferent(c *gc.C) {

--- a/testing/base.go
+++ b/testing/base.go
@@ -21,7 +21,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/juju/osenv"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/wrench"
 )
 
@@ -161,7 +160,6 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	// We can't always just use IsolationSuite because we still need
 	// PATH and possibly a couple other envars.
 	s.PatchEnvironment("BASH_ENV", "")
-	network.SetPreferIPv6(false)
 }
 
 func (s *BaseSuite) TearDownTest(c *gc.C) {

--- a/worker/instancepoller/updater.go
+++ b/worker/instancepoller/updater.go
@@ -288,10 +288,10 @@ func addressesEqual(a0, a1 []network.Address) bool {
 
 	ca0 := make([]network.Address, len(a0))
 	copy(ca0, a0)
-	network.SortAddresses(ca0, true)
+	network.SortAddresses(ca0)
 	ca1 := make([]network.Address, len(a1))
 	copy(ca1, a1)
-	network.SortAddresses(ca1, true)
+	network.SortAddresses(ca1)
 
 	for i := range ca0 {
 		if ca0[i] != ca1[i] {

--- a/worker/peergrouper/publish.go
+++ b/worker/peergrouper/publish.go
@@ -17,18 +17,14 @@ type apiHostPortsSetter interface {
 }
 
 type publisher struct {
-	st         apiHostPortsSetter
-	preferIPv6 bool
+	st apiHostPortsSetter
 
 	mu             sync.Mutex
 	lastAPIServers [][]network.HostPort
 }
 
-func newPublisher(st apiHostPortsSetter, preferIPv6 bool) *publisher {
-	return &publisher{
-		st:         st,
-		preferIPv6: preferIPv6,
-	}
+func newPublisher(st apiHostPortsSetter) *publisher {
+	return &publisher{st: st}
 }
 
 func (pub *publisher) publishAPIServers(apiServers [][]network.HostPort, instanceIds []instance.Id) error {
@@ -41,7 +37,7 @@ func (pub *publisher) publishAPIServers(apiServers [][]network.HostPort, instanc
 	sortedAPIServers := make([][]network.HostPort, len(apiServers))
 	for i, hostPorts := range apiServers {
 		sortedAPIServers[i] = append([]network.HostPort{}, hostPorts...)
-		network.SortHostPorts(sortedAPIServers[i], pub.preferIPv6)
+		network.SortHostPorts(sortedAPIServers[i])
 	}
 	if apiServersEqual(sortedAPIServers, pub.lastAPIServers) {
 		logger.Debugf("API host ports have not changed")

--- a/worker/peergrouper/publish_test.go
+++ b/worker/peergrouper/publish_test.go
@@ -30,7 +30,7 @@ func (s *mockAPIHostPortsSetter) SetAPIHostPorts(apiHostPorts [][]network.HostPo
 
 func (s *publishSuite) TestPublisherSetsAPIHostPortsOnce(c *gc.C) {
 	var mock mockAPIHostPortsSetter
-	statePublish := newPublisher(&mock, false)
+	statePublish := newPublisher(&mock)
 
 	hostPorts1 := network.NewHostPorts(1234, "testing1.invalid", "127.0.0.1")
 	hostPorts2 := network.NewHostPorts(1234, "testing2.invalid", "127.0.0.2")
@@ -58,9 +58,9 @@ func (s *publishSuite) TestPublisherSortsHostPorts(c *gc.C) {
 	ipV4First := network.NewHostPorts(1234, "testing1.invalid", "127.0.0.1", "::1")
 	ipV6First := network.NewHostPorts(1234, "testing1.invalid", "::1", "127.0.0.1")
 
-	check := func(preferIPv6 bool, publish, expect []network.HostPort) {
+	check := func(publish, expect []network.HostPort) {
 		var mock mockAPIHostPortsSetter
-		statePublish := newPublisher(&mock, preferIPv6)
+		statePublish := newPublisher(&mock)
 		for i := 0; i < 2; i++ {
 			err := statePublish.publishAPIServers([][]network.HostPort{publish}, nil)
 			c.Assert(err, jc.ErrorIsNil)
@@ -69,19 +69,13 @@ func (s *publishSuite) TestPublisherSortsHostPorts(c *gc.C) {
 		c.Assert(mock.apiHostPorts, gc.DeepEquals, [][]network.HostPort{expect})
 	}
 
-	check(false, ipV6First, ipV4First)
-	check(false, ipV4First, ipV4First)
-	check(true, ipV4First, ipV6First)
-	check(true, ipV6First, ipV6First)
+	check(ipV6First, ipV4First)
+	check(ipV4First, ipV4First)
 }
 
 func (s *publishSuite) TestPublisherRejectsNoServers(c *gc.C) {
-	check := func(preferIPv6 bool) {
-		var mock mockAPIHostPortsSetter
-		statePublish := newPublisher(&mock, preferIPv6)
-		err := statePublish.PublishAPIServers(nil, nil)
-		c.Assert(err, gc.ErrorMatches, "no api servers specified")
-	}
-	check(false)
-	check(true)
+	var mock mockAPIHostPortsSetter
+	statePublish := newPublisher(&mock)
+	err := statePublish.PublishAPIServers(nil, nil)
+	c.Assert(err, gc.ErrorMatches, "no api servers specified")
 }

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -119,7 +119,7 @@ func New(st *state.State) (worker.Worker, error) {
 		apiPort:   cfg.APIPort(),
 	}
 	supportsSpaces := networkingcommon.SupportsSpaces(shim) == nil
-	return newWorker(shim, newPublisher(st, cfg.PreferIPv6()), supportsSpaces)
+	return newWorker(shim, newPublisher(st), supportsSpaces)
 }
 
 func newWorker(st stateInterface, pub publisherInterface, supportsSpaces bool) (worker.Worker, error) {

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -114,7 +114,6 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		config.Proxy,
 		config.AptProxy,
 		config.AptMirror,
-		config.PreferIPv6,
 		config.EnableOSRefreshUpdate,
 		config.EnableOSUpgrade,
 	); err != nil {

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -143,7 +143,6 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		config.Proxy,
 		config.AptProxy,
 		config.AptMirror,
-		config.PreferIPv6,
 		config.EnableOSRefreshUpdate,
 		config.EnableOSUpgrade,
 	); err != nil {

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -99,7 +99,6 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		config.Proxy,
 		config.AptProxy,
 		config.AptMirror,
-		config.PreferIPv6,
 		config.EnableOSRefreshUpdate,
 		config.EnableOSUpgrade,
 	); err != nil {


### PR DESCRIPTION
PreferIPv6 was a (failed) attempt at adding "better support" for IPv6,
but unfortunately it was not well designed, overcomplicated the address
selection logic and tests, and hardly provided any real benefits. Also,
since a few releases back, the "prefer-ipv6" config setting was always
set to false as a first step towards completely removing it.

It's high time to remove the dead code and tests around preferIPv6, and
it turns out doing this makes fixing bug http://pad.lv/1574844/ I'm
working on a lot easier.

(Review request: http://reviews.vapour.ws/r/4865/)