### PR TITLE
apiserver/common/networkingcommon: return an error, don't log it at warning

### DIFF
--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -480,7 +480,7 @@ func GetObservedNetworkConfig() ([]params.NetworkConfig, error) {
 
 // MergeProviderAndObservedNetworkConfigs returns the effective, sorted, network
 // configs after merging providerConfig with observedConfig.
-func MergeProviderAndObservedNetworkConfigs(providerConfigs, observedConfigs []params.NetworkConfig) []params.NetworkConfig {
+func MergeProviderAndObservedNetworkConfigs(providerConfigs, observedConfigs []params.NetworkConfig) ([]params.NetworkConfig, error) {
 	providerConfigsByName := make(map[string][]params.NetworkConfig)
 	sortedProviderConfigs := SortNetworkConfigsByParents(providerConfigs)
 	for _, config := range sortedProviderConfigs {
@@ -490,19 +490,16 @@ func MergeProviderAndObservedNetworkConfigs(providerConfigs, observedConfigs []p
 
 	jsonProviderConfig, err := NetworkConfigsToIndentedJSON(sortedProviderConfigs)
 	if err != nil {
-		logger.Warningf("cannot serialize provider config %#v as JSON: %v", sortedProviderConfigs, err)
-	} else {
-		logger.Debugf("provider network config of machine:\n%s", jsonProviderConfig)
+		return nil, errors.Annotatef(err, "cannot serialize provider config %#v as JSON", sortedProviderConfigs)
 	}
+	logger.Debugf("provider network config of machine:\n%s", jsonProviderConfig)
 
 	sortedObservedConfigs := SortNetworkConfigsByParents(observedConfigs)
-
 	jsonObservedConfig, err := NetworkConfigsToIndentedJSON(sortedObservedConfigs)
 	if err != nil {
-		logger.Warningf("cannot serialize observed config %#v as JSON: %v", sortedObservedConfigs, err)
-	} else {
-		logger.Debugf("observed network config of machine:\n%s", jsonObservedConfig)
+		return nil, errors.Annotatef(err, "cannot serialize observed config %#v as JSON", sortedObservedConfigs)
 	}
+	logger.Debugf("observed network config of machine:\n%s", jsonObservedConfig)
 
 	var mergedConfigs []params.NetworkConfig
 	for _, config := range sortedObservedConfigs {
@@ -591,10 +588,9 @@ func MergeProviderAndObservedNetworkConfigs(providerConfigs, observedConfigs []p
 
 	jsonMergedConfig, err := NetworkConfigsToIndentedJSON(sortedMergedConfigs)
 	if err != nil {
-		logger.Warningf("cannot serialize merged config %#v as JSON: %v", sortedMergedConfigs, err)
-	} else {
-		logger.Debugf("combined machine network config:\n%s", jsonMergedConfig)
+		errors.Annotatef(err, "cannot serialize merged config %#v as JSON", sortedMergedConfigs)
 	}
+	logger.Debugf("combined machine network config:\n%s", jsonMergedConfig)
 
-	return mergedConfigs
+	return mergedConfigs, nil
 }

--- a/apiserver/common/networkingcommon/types_test.go
+++ b/apiserver/common/networkingcommon/types_test.go
@@ -940,7 +940,8 @@ func (s *TypesSuite) TestMergeProviderAndObservedNetworkConfigs(c *gc.C) {
 		for j := 0; j < providerConfigsLength; j++ {
 			shuffledProviderConfigs := shuffleNetworkConfigs(expectedSortedProviderNetworkConfigs)
 
-			mergedConfigs := networkingcommon.MergeProviderAndObservedNetworkConfigs(shuffledProviderConfigs, shuffledObservedConfigs)
+			mergedConfigs, err := networkingcommon.MergeProviderAndObservedNetworkConfigs(shuffledProviderConfigs, shuffledObservedConfigs)
+			c.Assert(err, jc.ErrorIsNil)
 			jsonResult := s.networkConfigsAsJSON(c, mergedConfigs)
 			c.Check(jsonResult, gc.Equals, jsonExpected)
 		}

--- a/apiserver/machine/machiner.go
+++ b/apiserver/machine/machiner.go
@@ -156,7 +156,8 @@ func (api *MachinerAPI) SetObservedNetworkConfig(args params.SetMachineNetworkCo
 	if errors.IsNotProvisioned(err) {
 		logger.Infof("not updating provider network config: %v", err)
 		return nil
-	} else if err != nil {
+	}
+	if err != nil {
 		return errors.Trace(err)
 	}
 	if len(providerConfig) == 0 {
@@ -164,7 +165,10 @@ func (api *MachinerAPI) SetObservedNetworkConfig(args params.SetMachineNetworkCo
 		return nil
 	}
 
-	mergedConfig := networkingcommon.MergeProviderAndObservedNetworkConfigs(providerConfig, observedConfig)
+	mergedConfig, err := networkingcommon.MergeProviderAndObservedNetworkConfigs(providerConfig, observedConfig)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	logger.Tracef("merged observed and provider network config: %+v", mergedConfig)
 
 	return api.setOneMachineNetworkConfig(m, mergedConfig)


### PR DESCRIPTION
If an error occurs, we cannot continue because the other return values are undefined. Rather than logging an error (at warning level), return the error to the caller.


(Review request: http://reviews.vapour.ws/r/4870/)