### PR TITLE
IP Addresses use providerIDsC to track provider ids

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -303,17 +303,9 @@ func allCollections() collectionSchema {
 		subnetsC:              {},
 		linkLayerDevicesC:     {},
 		linkLayerDevicesRefsC: {},
-		// TODO(mfoord): remove providerid indices here and switch to
-		// using providerIDsC to track unique provider ids.
-		ipAddressesC: {
-			indexes: []mgo.Index{{
-				Key:    []string{"providerid"},
-				Unique: true,
-				Sparse: true,
-			}},
-		},
-		endpointBindingsC: {},
-		openedPortsC:      {},
+		ipAddressesC:          {},
+		endpointBindingsC:     {},
+		openedPortsC:          {},
 
 		// -----
 

--- a/state/ipaddresses_internal_test.go
+++ b/state/ipaddresses_internal_test.go
@@ -51,17 +51,9 @@ func (s *ipAddressesInternalSuite) TestProviderIDIsEmptyWhenNotSet(c *gc.C) {
 	c.Assert(result.ProviderID(), gc.Equals, network.Id(""))
 }
 
-func (s *ipAddressesInternalSuite) TestProviderIDDoesNotIncludeModelUUIDWhenSet(c *gc.C) {
-	const localProviderID = "foo"
-	globalProviderID := coretesting.ModelTag.Id() + ":" + localProviderID
-
-	result := s.newIPAddressWithDummyState(ipAddressDoc{ProviderID: localProviderID})
-	c.Assert(result.ProviderID(), gc.Equals, network.Id(localProviderID))
-	c.Assert(result.localProviderID(), gc.Equals, localProviderID)
-
-	result = s.newIPAddressWithDummyState(ipAddressDoc{ProviderID: globalProviderID})
-	c.Assert(result.ProviderID(), gc.Equals, network.Id(localProviderID))
-	c.Assert(result.localProviderID(), gc.Equals, localProviderID)
+func (s *ipAddressesInternalSuite) TestProviderID(c *gc.C) {
+	result := s.newIPAddressWithDummyState(ipAddressDoc{ProviderID: "foo"})
+	c.Assert(result.ProviderID(), gc.Equals, network.Id("foo"))
 }
 
 func (s *ipAddressesInternalSuite) TestIPAddressGlobalKeyHelper(c *gc.C) {

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -479,6 +479,26 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesUpdatesExistingDocs(c *gc
 	}
 }
 
+func (s *ipAddressesStateSuite) TestRemoveAddressRemovesProviderID(c *gc.C) {
+	device := s.addNamedDevice(c, "eth0")
+	addrArgs := state.LinkLayerDeviceAddress{
+		DeviceName:   "eth0",
+		ConfigMethod: state.ManualAddress,
+		CIDRAddress:  "0.1.2.3/24",
+		ProviderID:   "id-0123",
+	}
+	err := s.machine.SetDevicesAddresses(addrArgs)
+	c.Assert(err, jc.ErrorIsNil)
+	addresses, err := device.Addresses()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addresses, gc.HasLen, 1)
+	addr := addresses[0]
+	err = addr.Remove()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.SetDevicesAddresses(addrArgs)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *ipAddressesStateSuite) checkAddressMatchesArgs(c *gc.C, address *state.Address, args state.LinkLayerDeviceAddress) {
 	c.Check(address.DeviceName(), gc.Equals, args.DeviceName)
 	c.Check(address.MachineID(), gc.Equals, s.machine.Id())

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -240,6 +240,23 @@ func (s *ipAddressesStateSuite) TestMachineRemoveAllAddressesSuccess(c *gc.C) {
 	s.removeAllAddressesOnMachineAndAssertNoneRemain(c)
 }
 
+func (s *ipAddressesStateSuite) TestMachineRemoveAllAddressesRemovesProviderIDReferences(c *gc.C) {
+	s.addNamedDevice(c, "foo")
+	addrArgs := state.LinkLayerDeviceAddress{
+		DeviceName:   "foo",
+		ConfigMethod: state.StaticAddress,
+		CIDRAddress:  "0.1.2.3/24",
+		ProviderID:   "bar",
+	}
+	err := s.machine.SetDevicesAddresses(addrArgs)
+	c.Assert(err, jc.ErrorIsNil)
+	s.removeAllAddressesOnMachineAndAssertNoneRemain(c)
+
+	// Re-adding the same address to a new device should now succeed.
+	err = s.machine.SetDevicesAddresses(addrArgs)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *ipAddressesStateSuite) addTwoDevicesWithTwoAddressesEach(c *gc.C) []*state.Address {
 	_, device1Addresses := s.addNamedDeviceWithAddresses(c, "eth1", "10.20.0.1/16", "10.20.0.2/16")
 	_, device2Addresses := s.addNamedDeviceWithAddresses(c, "eth0", "10.20.100.2/16", "fc00::/64")

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -499,6 +499,21 @@ func (s *ipAddressesStateSuite) TestRemoveAddressRemovesProviderID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *ipAddressesStateSuite) TestUpdateAddressFailsToChangeProviderID(c *gc.C) {
+	s.addNamedDevice(c, "eth0")
+	addrArgs := state.LinkLayerDeviceAddress{
+		DeviceName:   "eth0",
+		ConfigMethod: state.ManualAddress,
+		CIDRAddress:  "0.1.2.3/24",
+		ProviderID:   "id-0123",
+	}
+	err := s.machine.SetDevicesAddresses(addrArgs)
+	c.Assert(err, jc.ErrorIsNil)
+	addrArgs.ProviderID = "id-0124"
+	err = s.machine.SetDevicesAddresses(addrArgs)
+	c.Assert(err, gc.ErrorMatches, `.*cannot change ProviderID of link address "0.1.2.3"`)
+}
+
 func (s *ipAddressesStateSuite) checkAddressMatchesArgs(c *gc.C, address *state.Address, args state.LinkLayerDeviceAddress) {
 	c.Check(address.DeviceName(), gc.Equals, args.DeviceName)
 	c.Check(address.MachineID(), gc.Equals, s.machine.Id())

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -222,7 +222,15 @@ func (dev *LinkLayerDevice) Remove() (err error) {
 				return nil, err
 			}
 		}
-		return removeLinkLayerDeviceOps(dev.st, dev.DocID(), dev.parentDocID())
+		ops, err := removeLinkLayerDeviceOps(dev.st, dev.DocID(), dev.parentDocID())
+		if err != nil {
+			return nil, err
+		}
+		if dev.ProviderID() != "" {
+			op := dev.st.networkEntityGlobalKeyRemoveOp("linklayerdevice", dev.ProviderID())
+			ops = append(ops, op)
+		}
+		return ops, nil
 	}
 	return dev.st.run(buildTxn)
 }

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -213,6 +213,7 @@ func (dev *LinkLayerDevice) machineProxy(machineID string) *Machine {
 // was already removed. ErrParentDeviceHasChildren is returned if this device is
 // a parent to one or more existing devices and therefore cannot be removed.
 func (dev *LinkLayerDevice) Remove() (err error) {
+	// XXX remove providerIDsC records.
 	defer errors.DeferredAnnotatef(&err, "cannot remove %s", dev)
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -464,7 +464,7 @@ func (dev *LinkLayerDevice) Addresses() ([]*Address, error) {
 	}
 
 	findQuery := findAddressesQuery(dev.doc.MachineID, dev.doc.Name)
-	if err := dev.st.forEachIPAddressDoc(findQuery, nil, callbackFunc); err != nil {
+	if err := dev.st.forEachIPAddressDoc(findQuery, callbackFunc); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return allAddresses, nil

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -213,7 +213,6 @@ func (dev *LinkLayerDevice) machineProxy(machineID string) *Machine {
 // was already removed. ErrParentDeviceHasChildren is returned if this device is
 // a parent to one or more existing devices and therefore cannot be removed.
 func (dev *LinkLayerDevice) Remove() (err error) {
-	// XXX remove providerIDsC records.
 	defer errors.DeferredAnnotatef(&err, "cannot remove %s", dev)
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -112,7 +112,7 @@ func (addr *Address) ProviderID() network.Id {
 }
 
 func (addr *Address) localProviderID() string {
-	return addr.st.localID(addr.doc.ProviderID)
+	return addr.doc.ProviderID
 }
 
 // MachineID returns the ID of the machine this IP address belongs to.
@@ -295,6 +295,7 @@ func findAddressesQuery(machineID, deviceName string) bson.D {
 }
 
 func (st *State) removeMatchingIPAddressesDocOps(findQuery bson.D) ([]txn.Op, error) {
+	// XXX remove providerIDsC records
 	var ops []txn.Op
 	callbackFunc := func(resultDoc *ipAddressDoc) {
 		ops = append(ops, removeIPAddressDocOp(resultDoc.DocID))

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -108,11 +108,7 @@ func (addr *Address) DocID() string {
 
 // ProviderID returns the provider-specific IP address ID, if set.
 func (addr *Address) ProviderID() network.Id {
-	return network.Id(addr.localProviderID())
-}
-
-func (addr *Address) localProviderID() string {
-	return addr.doc.ProviderID
+	return network.Id(addr.doc.ProviderID)
 }
 
 // MachineID returns the ID of the machine this IP address belongs to.

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -203,7 +203,12 @@ func (addr *Address) Remove() (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot remove %s", addr)
 
 	removeOp := removeIPAddressDocOp(addr.doc.DocID)
-	return addr.st.runTransaction([]txn.Op{removeOp})
+	ops := []txn.Op{removeOp}
+	if addr.ProviderID() != "" {
+		op := addr.st.networkEntityGlobalKeyRemoveOp("address", addr.ProviderID())
+		ops = append(ops, op)
+	}
+	return addr.st.runTransaction(ops)
 }
 
 // removeIPAddressDocOpOp returns an operation to remove the ipAddressDoc

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -560,6 +560,23 @@ func (s *linkLayerDevicesStateSuite) TestLinkLayerDeviceRemoveSuccess(c *gc.C) {
 	s.assertNoDevicesOnMachine(c, s.machine)
 }
 
+func (s *linkLayerDevicesStateSuite) TestLinkLayerDeviceRemoveRemovesProviderID(c *gc.C) {
+	args := state.LinkLayerDeviceArgs{
+		Name:       "foo",
+		Type:       state.EthernetDevice,
+		ProviderID: "bar",
+	}
+	err := s.machine.SetLinkLayerDevices(args)
+	c.Assert(err, jc.ErrorIsNil)
+	device, err := s.machine.LinkLayerDevice("foo")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.removeDeviceAndAssertSuccess(c, device)
+	// Re-adding the same device should now succeed.
+	err = s.machine.SetLinkLayerDevices(args)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *linkLayerDevicesStateSuite) removeDeviceAndAssertSuccess(c *gc.C, givenDevice *state.LinkLayerDevice) {
 	err := givenDevice.Remove()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -822,7 +822,7 @@ func (m *Machine) AllAddresses() ([]*Address, error) {
 	}
 
 	findQuery := findAddressesQuery(m.doc.Id, "")
-	if err := m.st.forEachIPAddressDoc(findQuery, nil, callbackFunc); err != nil {
+	if err := m.st.forEachIPAddressDoc(findQuery, callbackFunc); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return allAddresses, nil


### PR DESCRIPTION
Use the new providerIDsC collection for tracking address provider ids and enforcing uniqueness. Also remove linklayerdevice provider id on removal.

(Review request: http://reviews.vapour.ws/r/4874/)