### PR TITLE
Clean up how ensure availability command gets HA client.

### DIFF
--- a/cmd/juju/commands/ensureavailability_test.go
+++ b/cmd/juju/commands/ensureavailability_test.go
@@ -101,7 +101,9 @@ func (f *fakeHAClient) EnsureAvailability(numStateServers int, cons constraints.
 var _ = gc.Suite(&EnsureAvailabilitySuite{})
 
 func (s *EnsureAvailabilitySuite) runEnsureAvailability(c *gc.C, args ...string) (*cmd.Context, error) {
-	command := &EnsureAvailabilityCommand{haClient: s.fake}
+	command := &EnsureAvailabilityCommand{newHAClientFunc: func() (EnsureAvailabilityClient, error) {
+		return s.fake, nil
+	}}
 	return coretesting.RunCommand(c, envcmd.Wrap(command), args...)
 }
 
@@ -252,7 +254,7 @@ func (s *EnsureAvailabilitySuite) TestEnsureAvailabilityEndToEnd(c *gc.C) {
 	s.Factory.MakeMachine(c, &factory.MachineParams{
 		Jobs: []state.MachineJob{state.JobManageEnviron},
 	})
-	ctx, err := coretesting.RunCommand(c, envcmd.Wrap(&EnsureAvailabilityCommand{}), "-n", "3")
+	ctx, err := coretesting.RunCommand(c, envcmd.Wrap(NewEnsureAvailabilityCommand()), "-n", "3")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Machine 0 is demoted because it hasn't reported its presence

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -202,7 +202,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(action.NewSuperCommand())
 
 	// Manage state server availability
-	r.Register(wrapEnvCommand(&EnsureAvailabilityCommand{}))
+	r.Register(wrapEnvCommand(NewEnsureAvailabilityCommand()))
 
 	// Manage and control services
 	r.Register(service.NewSuperCommand())


### PR DESCRIPTION
Follow consistent pattern of getting api client - using a func parameter that can be overwritten when needed.

This also ensures that there are no previously closed clients in use.

(Review request: http://reviews.vapour.ws/r/4876/)