### PR TITLE
Ha api cleanup 125

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -862,36 +862,6 @@ func (c *Client) APIHostPorts() ([][]network.HostPort, error) {
 	return result.NetworkHostsPorts(), nil
 }
 
-// EnsureAvailability ensures the availability of Juju state servers.
-// DEPRECATED: remove when we stop supporting 1.20 and earlier servers.
-// This API is now on the HighAvailability facade.
-func (c *Client) EnsureAvailability(numStateServers int, cons constraints.Value, series string) (params.StateServersChanges, error) {
-	var results params.StateServersChangeResults
-	envTag, err := c.st.EnvironTag()
-	if err != nil {
-		return params.StateServersChanges{}, errors.Trace(err)
-	}
-	arg := params.StateServersSpecs{
-		Specs: []params.StateServersSpec{{
-			EnvironTag:      envTag.String(),
-			NumStateServers: numStateServers,
-			Constraints:     cons,
-			Series:          series,
-		}}}
-	err = c.facade.FacadeCall("EnsureAvailability", arg, &results)
-	if err != nil {
-		return params.StateServersChanges{}, err
-	}
-	if len(results.Results) != 1 {
-		return params.StateServersChanges{}, errors.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return params.StateServersChanges{}, result.Error
-	}
-	return result.Result, nil
-}
-
 // AgentVersion reports the version number of the api server.
 func (c *Client) AgentVersion() (version.Number, error) {
 	var result params.AgentVersionResult

--- a/api/highavailability/client_test.go
+++ b/api/highavailability/client_test.go
@@ -92,10 +92,6 @@ func (s *clientLegacySuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 }
 
-func (s *clientLegacySuite) TestEnsureAvailabilityLegacy(c *gc.C) {
-	assertEnsureAvailability(c, &s.JujuConnSuite)
-}
-
 func (s *clientLegacySuite) TestEnsureAvailabilityLegacyRejectsPlacement(c *gc.C) {
 	client := highavailability.NewClient(s.APIState)
 	_, err := client.EnsureAvailability(3, constraints.Value{}, "", []string{"machine"})

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/juju/juju/apiserver/environment"
 	_ "github.com/juju/juju/apiserver/environmentmanager"
 	_ "github.com/juju/juju/apiserver/firewaller"
+	_ "github.com/juju/juju/apiserver/highavailability"
 	_ "github.com/juju/juju/apiserver/imagemanager"
 	_ "github.com/juju/juju/apiserver/imagemetadata"
 	_ "github.com/juju/juju/apiserver/instancepoller"

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/apiserver/highavailability"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/service"
 	"github.com/juju/juju/environs/config"
@@ -1046,22 +1045,6 @@ func (c *Client) APIHostPorts() (result params.APIHostPortsResult, err error) {
 	}
 	result.Servers = params.FromNetworkHostsPorts(servers)
 	return result, nil
-}
-
-// EnsureAvailability ensures the availability of Juju state servers.
-// DEPRECATED: remove when we stop supporting 1.20 and earlier clients.
-// This API is now on the HighAvailability facade.
-func (c *Client) EnsureAvailability(args params.StateServersSpecs) (params.StateServersChangeResults, error) {
-	if err := c.check.ChangeAllowed(); err != nil {
-		return params.StateServersChangeResults{}, errors.Trace(err)
-	}
-	results := params.StateServersChangeResults{Results: make([]params.StateServersChangeResult, len(args.Specs))}
-	for i, stateServersSpec := range args.Specs {
-		result, err := highavailability.EnsureAvailabilitySingle(c.api.state, stateServersSpec)
-		results.Results[i].Result = result
-		results.Results[i].Error = common.ServerError(err)
-	}
-	return results, nil
 }
 
 // DestroyEnvironment will try to destroy the current environment.


### PR DESCRIPTION
Remove redundant code. Obsolete since 1.20 is not supported.

(Review request: http://reviews.vapour.ws/r/4877/)