### PR TITLE
HA cmd cleanup - retrieval of api client.

### DIFF
--- a/cmd/juju/commands/enableha_test.go
+++ b/cmd/juju/commands/enableha_test.go
@@ -101,7 +101,7 @@ func (f *fakeHAClient) EnableHA(numControllers int, cons constraints.Value,
 var _ = gc.Suite(&EnableHASuite{})
 
 func (s *EnableHASuite) runEnableHA(c *gc.C, args ...string) (*cmd.Context, error) {
-	command := &enableHACommand{haClient: s.fake}
+	command := &enableHACommand{newHAClientFunc: func() (MakeHAClient, error) { return s.fake, nil }}
 	return coretesting.RunCommand(c, modelcmd.Wrap(command), args...)
 }
 


### PR DESCRIPTION
Follow consistent pattern of getting api client - using a func parameter that can be overwritten when needed.

This also ensures that there are no previously closed clients in use.


(Review request: http://reviews.vapour.ws/r/4878/)