### PR TITLE
Add controller/model config fields for log forwarding.

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -152,19 +152,19 @@ const (
 	CloudImageBaseURL = "cloudimg-base-url"
 
 	// LogFwdSyslogHost sets the hostname:port of the syslog server.
-	LogFwdSyslogHost = "logfwd-syslog-host"
+	LogFwdSyslogHost = "syslog-host"
 
 	// LogFwdSyslogCACert sets the certificate of the CA that signed the syslog
 	// server certificate.
-	LogFwdSyslogCACert = "logfwd-syslog-ca-cert"
+	LogFwdSyslogCACert = "syslog-ca-cert"
 
 	// LogFwdSyslogClientCert sets the client certificate for syslog
 	// forwarding.
-	LogFwdSyslogClientCert = "logfwd-syslog-client-cert"
+	LogFwdSyslogClientCert = "syslog-client-cert"
 
 	// LogFwdSyslogClientKey sets the client key for syslog
 	// forwarding.
-	LogFwdSyslogClientKey = "logfwd-syslog-client-key"
+	LogFwdSyslogClientKey = "syslog-client-key"
 
 	// AutomaticallyRetryHooks determines whether the uniter will
 	// automatically retry a hook that has failed

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -154,6 +154,10 @@ const (
 	// LogFwdSyslogHost sets the hostname:port of the syslog server.
 	LogFwdSyslogHost = "syslog-host"
 
+	// LogFwdSyslogServerCert sets the expected server certificate for
+	// syslog forwarding.
+	LogFwdSyslogServerCert = "syslog-server-cert"
+
 	// LogFwdSyslogCACert sets the certificate of the CA that signed the syslog
 	// server certificate.
 	LogFwdSyslogCACert = "syslog-ca-cert"
@@ -732,6 +736,11 @@ func (c *Config) LogFwdSyslog() (*syslog.RawConfig, bool) {
 		lfCfg.Host = s.(string)
 	}
 
+	if s, ok := c.defined[LogFwdSyslogServerCert]; ok && s != "" {
+		partial = true
+		lfCfg.ExpectedServerCert = s.(string)
+	}
+
 	if s, ok := c.defined[LogFwdSyslogCACert]; ok && s != "" {
 		partial = true
 		lfCfg.ClientCACert = s.(string)
@@ -1029,6 +1038,7 @@ var alwaysOptional = schema.Defaults{
 	"bootstrap-retry-delay":      schema.Omit,
 	"bootstrap-addresses-delay":  schema.Omit,
 	LogFwdSyslogHost:             schema.Omit,
+	LogFwdSyslogServerCert:       schema.Omit,
 	LogFwdSyslogCACert:           schema.Omit,
 	LogFwdSyslogClientCert:       schema.Omit,
 	LogFwdSyslogClientKey:        schema.Omit,
@@ -1439,6 +1449,11 @@ global or per instance security groups.`,
 	},
 	LogFwdSyslogHost: {
 		Description: `LogFwdSyslogHost specifies the hostname:port of the syslog server.`,
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
+	LogFwdSyslogServerCert: {
+		Description: `The expected syslog server certificate in PEM format.`,
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -487,7 +487,24 @@ func Validate(cfg, old *Config) error {
 
 	if lfCfg, ok := cfg.LogFwdSyslog(); ok {
 		if err := lfCfg.Validate(); err != nil {
-			return errors.Trace(err)
+			// Clean up the error messages a bit.
+			msg := err.Error()
+			var field string
+			switch {
+			case strings.Contains(msg, "Host"):
+				field = LogFwdSyslogHost
+			case strings.Contains(msg, "ExpectedServerCert"):
+				field = LogFwdSyslogServerCert
+			case strings.Contains(msg, "ClientCACert"):
+				field = LogFwdSyslogCACert
+			case strings.Contains(msg, "ClientCert"):
+				field = LogFwdSyslogClientCert
+			case strings.Contains(msg, "ClientKey"):
+				field = LogFwdSyslogClientKey
+			default:
+				return errors.Annotate(err, "invalid syslog forwarding config")
+			}
+			return errors.Annotatef(errors.Cause(err), "invalid %q", field)
 		}
 	}
 

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -664,7 +664,7 @@ var configTests = []configTest{
 			"syslog-client-cert": caCert,
 			"syslog-client-key":  caKey,
 		}),
-		err: "syslog forwarding config has invalid server cert: asn1: syntax error: data truncated",
+		err: `invalid "syslog-server-cert": asn1: syntax error: data truncated`,
 	}, {
 		about:       "Invalid syslog ca cert format",
 		useDefaults: config.UseDefaults,
@@ -677,7 +677,7 @@ var configTests = []configTest{
 			"syslog-client-cert": caCert,
 			"syslog-client-key":  caKey,
 		}),
-		err: "syslog forwarding config has invalid CA certificate: no certificates found",
+		err: `invalid "syslog-ca-cert": no certificates found`,
 	}, {
 		about:       "Invalid syslog ca cert",
 		useDefaults: config.UseDefaults,
@@ -690,7 +690,7 @@ var configTests = []configTest{
 			"syslog-client-cert": caCert,
 			"syslog-client-key":  caKey,
 		}),
-		err: "syslog forwarding config has invalid CA certificate: asn1: syntax error: data truncated",
+		err: `invalid "syslog-ca-cert": asn1: syntax error: data truncated`,
 	}, {
 		about:       "invalid syslog cert",
 		useDefaults: config.UseDefaults,
@@ -701,7 +701,7 @@ var configTests = []configTest{
 			"syslog-client-cert": invalidCACert,
 			"syslog-client-key":  caKey,
 		}),
-		err: "syslog forwarding config has invalid SSL certificate: asn1: syntax error: data truncated",
+		err: `invalid "syslog-client-cert": asn1: syntax error: data truncated`,
 	}, {
 		about:       "invalid syslog key",
 		useDefaults: config.UseDefaults,
@@ -712,7 +712,7 @@ var configTests = []configTest{
 			"syslog-client-cert": caCert,
 			"syslog-client-key":  invalidCAKey,
 		}),
-		err: "syslog forwarding config has invalid client key or key does not match certificate: crypto/tls: failed to parse private key",
+		err: `invalid "syslog-client-key": bad key or key does not match certificate: crypto/tls: failed to parse private key`,
 	}, {
 		about:       "Mismatched syslog cert and key",
 		useDefaults: config.UseDefaults,
@@ -723,7 +723,7 @@ var configTests = []configTest{
 			"syslog-client-cert": caCert,
 			"syslog-client-key":  caKey2,
 		}),
-		err: "syslog forwarding config has invalid client key or key does not match certificate: crypto/tls: private key does not match public key",
+		err: `invalid "syslog-client-key": bad key or key does not match certificate: crypto/tls: private key does not match public key`,
 	}, {
 		about:       "Valid syslog config values",
 		useDefaults: config.UseDefaults,

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -656,66 +656,66 @@ var configTests = []configTest{
 		about:       "Invalid syslog ca cert format",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"type":                      "my-type",
-			"name":                      "my-name",
-			"logfwd-syslog-host":        "localhost:1234",
-			"logfwd-syslog-ca-cert":     "abc",
-			"logfwd-syslog-client-cert": caCert,
-			"logfwd-syslog-client-key":  caKey,
+			"type":               "my-type",
+			"name":               "my-name",
+			"syslog-host":        "localhost:1234",
+			"syslog-ca-cert":     "abc",
+			"syslog-client-cert": caCert,
+			"syslog-client-key":  caKey,
 		}),
 		err: "syslog forwarding config has invalid CA certificate: no certificates found",
 	}, {
 		about:       "Invalid syslog ca cert",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"type":                      "my-type",
-			"name":                      "my-name",
-			"logfwd-syslog-host":        "localhost:1234",
-			"logfwd-syslog-ca-cert":     invalidCACert,
-			"logfwd-syslog-client-cert": caCert,
-			"logfwd-syslog-client-key":  caKey,
+			"type":               "my-type",
+			"name":               "my-name",
+			"syslog-host":        "localhost:1234",
+			"syslog-ca-cert":     invalidCACert,
+			"syslog-client-cert": caCert,
+			"syslog-client-key":  caKey,
 		}),
 		err: "syslog forwarding config has invalid CA certificate: asn1: syntax error: data truncated",
 	}, {
 		about:       "invalid syslog cert",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"logfwd-syslog-host":        "10.0.0.1:12345",
-			"logfwd-syslog-ca-cert":     caCert,
-			"logfwd-syslog-client-cert": invalidCACert,
-			"logfwd-syslog-client-key":  caKey,
+			"syslog-host":        "10.0.0.1:12345",
+			"syslog-ca-cert":     caCert,
+			"syslog-client-cert": invalidCACert,
+			"syslog-client-key":  caKey,
 		}),
 		err: "syslog forwarding config has invalid SSL certificate: asn1: syntax error: data truncated",
 	}, {
 		about:       "invalid syslog key",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"logfwd-syslog-host":        "10.0.0.1:12345",
-			"logfwd-syslog-ca-cert":     caCert,
-			"logfwd-syslog-client-cert": caCert,
-			"logfwd-syslog-client-key":  invalidCAKey,
+			"syslog-host":        "10.0.0.1:12345",
+			"syslog-ca-cert":     caCert,
+			"syslog-client-cert": caCert,
+			"syslog-client-key":  invalidCAKey,
 		}),
 		err: "syslog forwarding config has invalid client key or key does not match certificate: crypto/tls: failed to parse private key",
 	}, {
 		about:       "Mismatched syslog cert and key",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"logfwd-syslog-host":        "10.0.0.1:12345",
-			"logfwd-syslog-ca-cert":     caCert,
-			"logfwd-syslog-client-cert": caCert,
-			"logfwd-syslog-client-key":  caKey2,
+			"syslog-host":        "10.0.0.1:12345",
+			"syslog-ca-cert":     caCert,
+			"syslog-client-cert": caCert,
+			"syslog-client-key":  caKey2,
 		}),
 		err: "syslog forwarding config has invalid client key or key does not match certificate: crypto/tls: private key does not match public key",
 	}, {
 		about:       "Valid syslog config values",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"type":                      "my-type",
-			"name":                      "my-name",
-			"logfwd-syslog-host":        "localhost:1234",
-			"logfwd-syslog-ca-cert":     caCert,
-			"logfwd-syslog-client-cert": caCert,
-			"logfwd-syslog-client-key":  caKey,
+			"type":               "my-type",
+			"name":               "my-name",
+			"syslog-host":        "localhost:1234",
+			"syslog-ca-cert":     caCert,
+			"syslog-client-cert": caCert,
+			"syslog-client-key":  caKey,
 		}),
 	}, {
 		about:       "Invalid identity URL value",
@@ -988,21 +988,21 @@ func (test configTest) check(c *gc.C, home *gitjujutesting.FakeHome) {
 	}
 
 	lfCfg, hasLogCfg := cfg.LogFwdSyslog()
-	if v, ok := test.attrs["logcfg-syslog-ca-cert"].(string); v != "" {
+	if v, ok := test.attrs["syslog-ca-cert"].(string); v != "" {
 		c.Assert(hasLogCfg, jc.IsTrue)
 		c.Assert(lfCfg.ClientCACert, gc.Equals, v)
 	} else if ok {
 		c.Assert(hasLogCfg, jc.IsTrue)
 		c.Check(lfCfg.ClientCACert, gc.Equals, "")
 	}
-	if v, ok := test.attrs["logcfg-syslog-client-cert"].(string); v != "" {
+	if v, ok := test.attrs["syslog-client-cert"].(string); v != "" {
 		c.Assert(hasLogCfg, jc.IsTrue)
 		c.Assert(lfCfg.ClientCert, gc.Equals, v)
 	} else if ok {
 		c.Assert(hasLogCfg, jc.IsTrue)
 		c.Check(lfCfg.ClientCert, gc.Equals, "")
 	}
-	if v, ok := test.attrs["logcfg-syslog-client-key"].(string); v != "" {
+	if v, ok := test.attrs["syslog-client-key"].(string); v != "" {
 		c.Assert(hasLogCfg, jc.IsTrue)
 		c.Assert(lfCfg.ClientKey, gc.Equals, v)
 	} else if ok {

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -732,9 +732,9 @@ var configTests = []configTest{
 			"name":               "my-name",
 			"syslog-host":        "localhost:1234",
 			"syslog-server-cert": caCert2,
-			"syslog-ca-cert":     caCert,
-			"syslog-client-cert": caCert,
-			"syslog-client-key":  caKey,
+			"syslog-ca-cert":     testing.CACert,
+			"syslog-client-cert": testing.ServerCert,
+			"syslog-client-key":  testing.ServerKey,
 		}),
 	}, {
 		about:       "Invalid identity URL value",

--- a/logfwd/syslog/config.go
+++ b/logfwd/syslog/config.go
@@ -1,0 +1,133 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package syslog
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+	"strings"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/cert"
+	"github.com/juju/juju/network"
+)
+
+const (
+	// TLSPort is the TCP port used for syslog-over-TLS.
+	TLSPort = 6514
+)
+
+// RawConfig holds the raw configuration data for a connection to a
+// syslog forwarding target.
+type RawConfig struct {
+	// Host is the host-port of the syslog host. The format is:
+	//
+	//   [domain-or-ip-addr] or [domain-or-ip-addr][:port]
+	//
+	// If the port is not set then the default TLS port (6514) will
+	// be used.
+	Host string
+
+	// TODO(ericsnow) Add ExpectedServerCert?
+
+	// CACert is the CA cert PEM to use for the client cert.
+	ClientCACert string
+
+	// ClientCert is the TLS certificate (x.509, PEM-encoded) to use
+	// when connecting.
+	ClientCert string
+
+	// ClientCert is the TLS private key (x.509, PEM-encoded) to use
+	// when connecting.
+	ClientKey string
+}
+
+// Validate ensures that the config is currently valid.
+func (cfg RawConfig) Validate() error {
+	if err := cfg.validateHost(); err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := cfg.validateSSL(); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+func (cfg RawConfig) validateHost() error {
+	if cfg.Host == "" {
+		return errors.NewNotValid(nil, "syslog forwarding config missing host")
+	}
+
+	hostport, err := parseHost(cfg.Host)
+	if err != nil {
+		return errors.NewNotValid(err, "syslog forwarding config has bad host")
+	}
+	if hostport.Type == network.HostName && hostport.Value == "" {
+		return errors.NewNotValid(nil, "syslog forwarding config host missing hostname")
+	}
+
+	return nil
+}
+
+// TODO(ericsnow) network.ParseHostPort() should do this for us...
+
+var hostRE = regexp.MustCompile(`^.*:\d+$`)
+
+func parseHost(host string) (*network.HostPort, error) {
+	if _, _, err := net.SplitHostPort(host); err != nil {
+		if hostRE.MatchString(host) {
+			return nil, errors.Trace(err)
+		}
+		host = fmt.Sprintf("%s:%d", host, TLSPort)
+	}
+
+	hostport, err := network.ParseHostPort(host)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if hostport.Type == network.HostName {
+		// network.ParseHostPort() *should* do this for us, but currently does not.
+		// TODO(ericsnow) This needs better criteria.
+		if strings.ContainsAny(hostport.Value, "#") {
+			return nil, errors.Errorf("invalid domain name %q", hostport.Value)
+		}
+	}
+
+	return hostport, nil
+}
+
+// TODO(ericsnow) Split up validateSSL() to make it more follow-able?
+
+func (cfg RawConfig) validateSSL() error {
+	if cfg.ClientCert == "" {
+		return errors.NewNotValid(nil, "syslog forwarding config missing client cert")
+	}
+
+	if cfg.ClientKey == "" {
+		return errors.NewNotValid(nil, "syslog forwarding config missing client SSL key")
+	}
+
+	if _, _, err := cert.ParseCertAndKey(cfg.ClientCert, cfg.ClientKey); err != nil {
+		if _, err := cert.ParseCert(cfg.ClientCert); err != nil {
+			return errors.NewNotValid(err, "syslog forwarding config has invalid SSL certificate")
+		}
+		return errors.NewNotValid(err, "syslog forwarding config has invalid client key or key does not match certificate")
+	}
+
+	if cfg.ClientCACert == "" {
+		return errors.NewNotValid(nil, "syslog forwarding config missing SSL CA cert")
+	}
+	if _, err := cert.ParseCert(cfg.ClientCACert); err != nil {
+		return errors.NewNotValid(err, "syslog forwarding config has invalid CA certificate")
+	}
+
+	// TODO(ericsnow) Also call cert.Verify() to ensure the CA cert matches?
+
+	return nil
+}

--- a/logfwd/syslog/config.go
+++ b/logfwd/syslog/config.go
@@ -31,7 +31,9 @@ type RawConfig struct {
 	// be used.
 	Host string
 
-	// TODO(ericsnow) Add ExpectedServerCert?
+	// ExpectedServerCert is the TLS certificate that the server must
+	// use when the client connects.
+	ExpectedServerCert string
 
 	// CACert is the CA cert PEM to use for the client cert.
 	ClientCACert string
@@ -105,6 +107,13 @@ func parseHost(host string) (*network.HostPort, error) {
 // TODO(ericsnow) Split up validateSSL() to make it more follow-able?
 
 func (cfg RawConfig) validateSSL() error {
+	if cfg.ExpectedServerCert == "" {
+		return errors.NewNotValid(nil, "syslog forwarding config missing server cert")
+	}
+	if _, err := cert.ParseCert(cfg.ExpectedServerCert); err != nil {
+		return errors.NewNotValid(err, "syslog forwarding config has invalid server cert")
+	}
+
 	if cfg.ClientCert == "" {
 		return errors.NewNotValid(nil, "syslog forwarding config missing client cert")
 	}

--- a/logfwd/syslog/config.go
+++ b/logfwd/syslog/config.go
@@ -62,15 +62,15 @@ func (cfg RawConfig) Validate() error {
 
 func (cfg RawConfig) validateHost() error {
 	if cfg.Host == "" {
-		return errors.NewNotValid(nil, "syslog forwarding config missing host")
+		return errors.NewNotValid(nil, "empty Host")
 	}
 
 	hostport, err := parseHost(cfg.Host)
 	if err != nil {
-		return errors.NewNotValid(err, "syslog forwarding config has bad host")
+		return errors.NewNotValid(err, "bad Host")
 	}
 	if hostport.Type == network.HostName && hostport.Value == "" {
-		return errors.NewNotValid(nil, "syslog forwarding config host missing hostname")
+		return errors.NewNotValid(nil, "empty hostname in Host")
 	}
 
 	return nil
@@ -108,32 +108,36 @@ func parseHost(host string) (*network.HostPort, error) {
 
 func (cfg RawConfig) validateSSL() error {
 	if cfg.ExpectedServerCert == "" {
-		return errors.NewNotValid(nil, "syslog forwarding config missing server cert")
+		return errors.NewNotValid(nil, "empty ExpectedServerCert")
 	}
 	if _, err := cert.ParseCert(cfg.ExpectedServerCert); err != nil {
-		return errors.NewNotValid(err, "syslog forwarding config has invalid server cert")
+		err = errors.NewNotValid(err, "")
+		return errors.Annotate(err, "invalid ExpectedServerCert")
 	}
 
 	if cfg.ClientCert == "" {
-		return errors.NewNotValid(nil, "syslog forwarding config missing client cert")
+		return errors.NewNotValid(nil, "empty ClientCert")
 	}
 
 	if cfg.ClientKey == "" {
-		return errors.NewNotValid(nil, "syslog forwarding config missing client SSL key")
+		return errors.NewNotValid(nil, "empty ClientKey")
 	}
 
 	if _, _, err := cert.ParseCertAndKey(cfg.ClientCert, cfg.ClientKey); err != nil {
 		if _, err := cert.ParseCert(cfg.ClientCert); err != nil {
-			return errors.NewNotValid(err, "syslog forwarding config has invalid SSL certificate")
+			err = errors.NewNotValid(err, "")
+			return errors.Annotate(err, "invalid ClientCert")
 		}
-		return errors.NewNotValid(err, "syslog forwarding config has invalid client key or key does not match certificate")
+		err = errors.NewNotValid(err, "bad key or key does not match certificate")
+		return errors.Annotate(err, "invalid ClientKey")
 	}
 
 	if cfg.ClientCACert == "" {
-		return errors.NewNotValid(nil, "syslog forwarding config missing SSL CA cert")
+		return errors.NewNotValid(nil, "empty ClientCACert")
 	}
 	if _, err := cert.ParseCert(cfg.ClientCACert); err != nil {
-		return errors.NewNotValid(err, "syslog forwarding config has invalid CA certificate")
+		err = errors.NewNotValid(err, "")
+		return errors.Annotate(err, "invalid ClientCACert")
 	}
 
 	// TODO(ericsnow) Also call cert.Verify() to ensure the CA cert matches?

--- a/logfwd/syslog/config_test.go
+++ b/logfwd/syslog/config_test.go
@@ -66,7 +66,7 @@ func (s *ConfigSuite) TestRawValidateMissingHost(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `syslog forwarding config missing host`)
+	c.Check(err, gc.ErrorMatches, `empty Host`)
 }
 
 func (s *ConfigSuite) TestRawValidateMissingHostname(c *gc.C) {
@@ -81,7 +81,7 @@ func (s *ConfigSuite) TestRawValidateMissingHostname(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `syslog forwarding config host missing hostname`)
+	c.Check(err, gc.ErrorMatches, `empty hostname in Host`)
 }
 
 func (s *ConfigSuite) TestRawValidateBadHostname(c *gc.C) {
@@ -96,7 +96,7 @@ func (s *ConfigSuite) TestRawValidateBadHostname(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `syslog forwarding config has bad host: invalid domain name "###"`)
+	c.Check(err, gc.ErrorMatches, `bad Host: invalid domain name "###"`)
 }
 
 func (s *ConfigSuite) TestRawValidateMissingPort(c *gc.C) {
@@ -111,7 +111,7 @@ func (s *ConfigSuite) TestRawValidateMissingPort(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `syslog forwarding config has bad host: cannot parse "a.b.c:" port: strconv.ParseInt: parsing "": invalid syntax`)
+	c.Check(err, gc.ErrorMatches, `bad Host: cannot parse "a.b.c:" port: strconv.ParseInt: parsing "": invalid syntax`)
 }
 
 func (s *ConfigSuite) TestRawValidateBadPort(c *gc.C) {
@@ -126,7 +126,7 @@ func (s *ConfigSuite) TestRawValidateBadPort(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `syslog forwarding config has bad host: cannot parse "a.b.c:xyz" port: strconv.ParseInt: parsing "xyz": invalid syntax`)
+	c.Check(err, gc.ErrorMatches, `bad Host: cannot parse "a.b.c:xyz" port: strconv.ParseInt: parsing "xyz": invalid syntax`)
 }
 
 func (s *ConfigSuite) TestRawValidateMissingServerCert(c *gc.C) {
@@ -141,7 +141,7 @@ func (s *ConfigSuite) TestRawValidateMissingServerCert(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `syslog forwarding config missing server cert`)
+	c.Check(err, gc.ErrorMatches, `empty ExpectedServerCert`)
 }
 
 func (s *ConfigSuite) TestRawValidateBadServerCert(c *gc.C) {
@@ -156,7 +156,7 @@ func (s *ConfigSuite) TestRawValidateBadServerCert(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `syslog forwarding config has invalid server cert: asn1: syntax error: data truncated`)
+	c.Check(err, gc.ErrorMatches, `invalid ExpectedServerCert: asn1: syntax error: data truncated`)
 }
 
 func (s *ConfigSuite) TestRawValidateBadServerCertFormat(c *gc.C) {
@@ -171,7 +171,7 @@ func (s *ConfigSuite) TestRawValidateBadServerCertFormat(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `syslog forwarding config has invalid server cert: no certificates found`)
+	c.Check(err, gc.ErrorMatches, `invalid ExpectedServerCert: no certificates found`)
 }
 
 func (s *ConfigSuite) TestRawValidateMissingCACert(c *gc.C) {
@@ -186,7 +186,7 @@ func (s *ConfigSuite) TestRawValidateMissingCACert(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `syslog forwarding config missing SSL CA cert`)
+	c.Check(err, gc.ErrorMatches, `empty ClientCACert`)
 }
 
 func (s *ConfigSuite) TestRawValidateBadCACert(c *gc.C) {
@@ -201,7 +201,7 @@ func (s *ConfigSuite) TestRawValidateBadCACert(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `syslog forwarding config has invalid CA certificate: asn1: syntax error: data truncated`)
+	c.Check(err, gc.ErrorMatches, `invalid ClientCACert: asn1: syntax error: data truncated`)
 }
 
 func (s *ConfigSuite) TestRawValidateBadCACertFormat(c *gc.C) {
@@ -216,7 +216,7 @@ func (s *ConfigSuite) TestRawValidateBadCACertFormat(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `syslog forwarding config has invalid CA certificate: no certificates found`)
+	c.Check(err, gc.ErrorMatches, `invalid ClientCACert: no certificates found`)
 }
 
 func (s *ConfigSuite) TestRawValidateMissingCert(c *gc.C) {
@@ -231,7 +231,7 @@ func (s *ConfigSuite) TestRawValidateMissingCert(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `syslog forwarding config missing client cert`)
+	c.Check(err, gc.ErrorMatches, `empty ClientCert`)
 }
 
 func (s *ConfigSuite) TestRawValidateBadCert(c *gc.C) {
@@ -246,7 +246,7 @@ func (s *ConfigSuite) TestRawValidateBadCert(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `syslog forwarding config has invalid SSL certificate: asn1: syntax error: data truncated`)
+	c.Check(err, gc.ErrorMatches, `invalid ClientCert: asn1: syntax error: data truncated`)
 }
 
 func (s *ConfigSuite) TestRawValidateBadCertFormat(c *gc.C) {
@@ -261,7 +261,7 @@ func (s *ConfigSuite) TestRawValidateBadCertFormat(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `syslog forwarding config has invalid SSL certificate: no certificates found`)
+	c.Check(err, gc.ErrorMatches, `invalid ClientCert: no certificates found`)
 }
 
 func (s *ConfigSuite) TestRawValidateMissingKey(c *gc.C) {
@@ -276,7 +276,7 @@ func (s *ConfigSuite) TestRawValidateMissingKey(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `syslog forwarding config missing client SSL key`)
+	c.Check(err, gc.ErrorMatches, `empty ClientKey`)
 }
 
 func (s *ConfigSuite) TestRawValidateBadKey(c *gc.C) {
@@ -291,7 +291,7 @@ func (s *ConfigSuite) TestRawValidateBadKey(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `syslog forwarding config has invalid client key or key does not match certificate: crypto/tls: failed to parse private key`)
+	c.Check(err, gc.ErrorMatches, `invalid ClientKey: bad key or key does not match certificate: crypto/tls: failed to parse private key`)
 }
 
 func (s *ConfigSuite) TestRawValidateBadKeyFormat(c *gc.C) {
@@ -306,7 +306,7 @@ func (s *ConfigSuite) TestRawValidateBadKeyFormat(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `syslog forwarding config has invalid client key or key does not match certificate: crypto/tls: failed to find any PEM data in key input`)
+	c.Check(err, gc.ErrorMatches, `invalid ClientKey: bad key or key does not match certificate: crypto/tls: failed to find any PEM data in key input`)
 }
 
 func (s *ConfigSuite) TestRawValidateCertKeyMismatch(c *gc.C) {
@@ -321,7 +321,7 @@ func (s *ConfigSuite) TestRawValidateCertKeyMismatch(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `syslog forwarding config has invalid client key or key does not match certificate: crypto/tls: private key does not match public key`)
+	c.Check(err, gc.ErrorMatches, `invalid ClientKey: bad key or key does not match certificate: crypto/tls: private key does not match public key`)
 }
 
 var validCACert = `

--- a/logfwd/syslog/config_test.go
+++ b/logfwd/syslog/config_test.go
@@ -1,0 +1,347 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package syslog_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/logfwd/syslog"
+)
+
+type ConfigSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ConfigSuite{})
+
+func (s *ConfigSuite) TestRawValidateFull(c *gc.C) {
+	cfg := syslog.RawConfig{
+		Host:         "a.b.c:9876",
+		ClientCACert: validCACert,
+		ClientCert:   validCert,
+		ClientKey:    validKey,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *ConfigSuite) TestRawValidateWithoutPort(c *gc.C) {
+	cfg := syslog.RawConfig{
+		Host:         "a.b.c",
+		ClientCACert: validCACert,
+		ClientCert:   validCert,
+		ClientKey:    validKey,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *ConfigSuite) TestRawValidateZeroValue(c *gc.C) {
+	var cfg syslog.RawConfig
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *ConfigSuite) TestRawValidateMissingHost(c *gc.C) {
+	cfg := syslog.RawConfig{
+		Host:         "",
+		ClientCACert: validCACert,
+		ClientCert:   validCert,
+		ClientKey:    validKey,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `syslog forwarding config missing host`)
+}
+
+func (s *ConfigSuite) TestRawValidateMissingHostname(c *gc.C) {
+	cfg := syslog.RawConfig{
+		Host:         ":9876",
+		ClientCACert: validCACert,
+		ClientCert:   validCert,
+		ClientKey:    validKey,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `syslog forwarding config host missing hostname`)
+}
+
+func (s *ConfigSuite) TestRawValidateBadHostname(c *gc.C) {
+	cfg := syslog.RawConfig{
+		Host:         "###:9876",
+		ClientCACert: validCACert,
+		ClientCert:   validCert,
+		ClientKey:    validKey,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `syslog forwarding config has bad host: invalid domain name "###"`)
+}
+
+func (s *ConfigSuite) TestRawValidateMissingPort(c *gc.C) {
+	cfg := syslog.RawConfig{
+		Host:         "a.b.c:",
+		ClientCACert: validCACert,
+		ClientCert:   validCert,
+		ClientKey:    validKey,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `syslog forwarding config has bad host: cannot parse "a.b.c:" port: strconv.ParseInt: parsing "": invalid syntax`)
+}
+
+func (s *ConfigSuite) TestRawValidateBadPort(c *gc.C) {
+	cfg := syslog.RawConfig{
+		Host:         "a.b.c:xyz",
+		ClientCACert: validCACert,
+		ClientCert:   validCert,
+		ClientKey:    validKey,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `syslog forwarding config has bad host: cannot parse "a.b.c:xyz" port: strconv.ParseInt: parsing "xyz": invalid syntax`)
+}
+
+func (s *ConfigSuite) TestRawValidateMissingCACert(c *gc.C) {
+	cfg := syslog.RawConfig{
+		Host:         "a.b.c:9876",
+		ClientCACert: "",
+		ClientCert:   validCert,
+		ClientKey:    validKey,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `syslog forwarding config missing SSL CA cert`)
+}
+
+func (s *ConfigSuite) TestRawValidateBadCACert(c *gc.C) {
+	cfg := syslog.RawConfig{
+		Host:         "a.b.c:9876",
+		ClientCACert: invalidCACert,
+		ClientCert:   validCert,
+		ClientKey:    validKey,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `syslog forwarding config has invalid CA certificate: asn1: syntax error: data truncated`)
+}
+
+func (s *ConfigSuite) TestRawValidateBadCACertFormat(c *gc.C) {
+	cfg := syslog.RawConfig{
+		Host:         "a.b.c:9876",
+		ClientCACert: "abc",
+		ClientCert:   validCert,
+		ClientKey:    validKey,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `syslog forwarding config has invalid CA certificate: no certificates found`)
+}
+
+func (s *ConfigSuite) TestRawValidateMissingCert(c *gc.C) {
+	cfg := syslog.RawConfig{
+		Host:         "a.b.c:9876",
+		ClientCACert: validCACert,
+		ClientCert:   "",
+		ClientKey:    validKey,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `syslog forwarding config missing client cert`)
+}
+
+func (s *ConfigSuite) TestRawValidateBadCert(c *gc.C) {
+	cfg := syslog.RawConfig{
+		Host:         "a.b.c:9876",
+		ClientCACert: validCACert,
+		ClientCert:   invalidCert,
+		ClientKey:    validKey,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `syslog forwarding config has invalid SSL certificate: asn1: syntax error: data truncated`)
+}
+
+func (s *ConfigSuite) TestRawValidateBadCertFormat(c *gc.C) {
+	cfg := syslog.RawConfig{
+		Host:         "a.b.c:9876",
+		ClientCACert: validCACert,
+		ClientCert:   "abc",
+		ClientKey:    validKey,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `syslog forwarding config has invalid SSL certificate: no certificates found`)
+}
+
+func (s *ConfigSuite) TestRawValidateMissingKey(c *gc.C) {
+	cfg := syslog.RawConfig{
+		Host:         "a.b.c:9876",
+		ClientCACert: validCACert,
+		ClientCert:   validCert,
+		ClientKey:    "",
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `syslog forwarding config missing client SSL key`)
+}
+
+func (s *ConfigSuite) TestRawValidateBadKey(c *gc.C) {
+	cfg := syslog.RawConfig{
+		Host:         "a.b.c:9876",
+		ClientCACert: validCACert,
+		ClientCert:   validCert,
+		ClientKey:    invalidKey,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `syslog forwarding config has invalid client key or key does not match certificate: crypto/tls: failed to parse private key`)
+}
+
+func (s *ConfigSuite) TestRawValidateBadKeyFormat(c *gc.C) {
+	cfg := syslog.RawConfig{
+		Host:         "a.b.c:9876",
+		ClientCACert: validCACert,
+		ClientCert:   validCert,
+		ClientKey:    "abc",
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `syslog forwarding config has invalid client key or key does not match certificate: crypto/tls: failed to find any PEM data in key input`)
+}
+
+func (s *ConfigSuite) TestRawValidateCertKeyMismatch(c *gc.C) {
+	cfg := syslog.RawConfig{
+		Host:         "a.b.c:9876",
+		ClientCACert: validCACert,
+		ClientCert:   validCert,
+		ClientKey:    validKey2,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `syslog forwarding config has invalid client key or key does not match certificate: crypto/tls: private key does not match public key`)
+}
+
+var validCACert = `
+-----BEGIN CERTIFICATE-----
+MIIBjTCCATmgAwIBAgIBADALBgkqhkiG9w0BAQUwHjENMAsGA1UEChMEanVqdTEN
+MAsGA1UEAxMEcm9vdDAeFw0xMjExMDkxNjQxMjlaFw0yMjExMDkxNjQ2MjlaMB4x
+DTALBgNVBAoTBGp1anUxDTALBgNVBAMTBHJvb3QwWjALBgkqhkiG9w0BAQEDSwAw
+SAJBAIW7CbHFJivvV9V6mO8AGzJS9lqjUf6MdEPsdF6wx2Cpzr/lSFIggCwRA138
+9MuFxflxb/3U8Nq+rd8rVtTgFMECAwEAAaNmMGQwDgYDVR0PAQH/BAQDAgCkMBIG
+A1UdEwEB/wQIMAYBAf8CAQEwHQYDVR0OBBYEFJafrxqByMN9BwGfcmuF0Lw/1QII
+MB8GA1UdIwQYMBaAFJafrxqByMN9BwGfcmuF0Lw/1QIIMAsGCSqGSIb3DQEBBQNB
+AHq3vqNhxya3s33DlQfSj9whsnqM0Nm+u8mBX/T76TF5rV7+B33XmYzSyfA3yBi/
+zHaUR/dbHuiNTO+KXs3/+Y4=
+-----END CERTIFICATE-----
+`[1:]
+
+var validCert = `
+-----BEGIN CERTIFICATE-----
+MIIBjDCCATigAwIBAgIBADALBgkqhkiG9w0BAQUwHjENMAsGA1UEChMEanVqdTEN
+MAsGA1UEAxMEcm9vdDAeFw0xMjExMDkxNjQwMjhaFw0yMjExMDkxNjQ1MjhaMB4x
+DTALBgNVBAoTBGp1anUxDTALBgNVBAMTBHJvb3QwWTALBgkqhkiG9w0BAQEDSgAw
+RwJAduA1Gnb2VJLxNGfG4St0Qy48Y3q5Z5HheGtTGmti/FjlvQvScCFGCnJG7fKA
+Knd7ia3vWg7lxYkIvMPVP88LAQIDAQABo2YwZDAOBgNVHQ8BAf8EBAMCAKQwEgYD
+VR0TAQH/BAgwBgEB/wIBATAdBgNVHQ4EFgQUlvKX8vwp0o+VdhdhoA9O6KlOm00w
+HwYDVR0jBBgwFoAUlvKX8vwp0o+VdhdhoA9O6KlOm00wCwYJKoZIhvcNAQEFA0EA
+LlNpevtFr8gngjAFFAO/FXc7KiZcCrA5rBfb/rEy297lIqmKt5++aVbLEPyxCIFC
+r71Sj63TUTFWtRZAxvn9qQ==
+-----END CERTIFICATE-----
+`[1:]
+
+var validKey = `
+-----BEGIN RSA PRIVATE KEY-----
+MIIBOQIBAAJAduA1Gnb2VJLxNGfG4St0Qy48Y3q5Z5HheGtTGmti/FjlvQvScCFG
+CnJG7fKAKnd7ia3vWg7lxYkIvMPVP88LAQIDAQABAkEAsFOdMSYn+AcF1M/iBfjo
+uQWJ+Zz+CgwuvumjGNsUtmwxjA+hh0fCn0Ah2nAt4Ma81vKOKOdQ8W6bapvsVDH0
+6QIhAJOkLmEKm4H5POQV7qunRbRsLbft/n/SHlOBz165WFvPAiEAzh9fMf70std1
+sVCHJRQWKK+vw3oaEvPKvkPiV5ui0C8CIGNsvybuo8ald5IKCw5huRlFeIxSo36k
+m3OVCXc6zfwVAiBnTUe7WcivPNZqOC6TAZ8dYvdWo4Ifz3jjpEfymjid1wIgBIJv
+ERPyv2NQqIFQZIyzUP7LVRIWfpFFOo9/Ww/7s5Y=
+-----END RSA PRIVATE KEY-----
+`[1:]
+
+var validCert2 = `
+-----BEGIN CERTIFICATE-----
+MIIBjTCCATmgAwIBAgIBADALBgkqhkiG9w0BAQUwHjENMAsGA1UEChMEanVqdTEN
+MAsGA1UEAxMEcm9vdDAeFw0xMjExMDkxNjQxMDhaFw0yMjExMDkxNjQ2MDhaMB4x
+DTALBgNVBAoTBGp1anUxDTALBgNVBAMTBHJvb3QwWjALBgkqhkiG9w0BAQEDSwAw
+SAJBAJkSWRrr81y8pY4dbNgt+8miSKg4z6glp2KO2NnxxAhyyNtQHKvC+fJALJj+
+C2NhuvOv9xImxOl3Hg8fFPCXCtcCAwEAAaNmMGQwDgYDVR0PAQH/BAQDAgCkMBIG
+A1UdEwEB/wQIMAYBAf8CAQEwHQYDVR0OBBYEFOsX/ZCqKzWCAaTTVcWsWKT5Msow
+MB8GA1UdIwQYMBaAFOsX/ZCqKzWCAaTTVcWsWKT5MsowMAsGCSqGSIb3DQEBBQNB
+AAVV57jetEzJQnjgBzhvx/UwauFn78jGhXfV5BrQmxIb4SF4DgSCFstPwUQOAr8h
+XXzJqBQH92KYmp+y3YXDoMQ=
+-----END CERTIFICATE-----
+`[1:]
+
+var validKey2 = `
+-----BEGIN RSA PRIVATE KEY-----
+MIIBOQIBAAJBAJkSWRrr81y8pY4dbNgt+8miSKg4z6glp2KO2NnxxAhyyNtQHKvC
++fJALJj+C2NhuvOv9xImxOl3Hg8fFPCXCtcCAwEAAQJATQNzO11NQvJS5U6eraFt
+FgSFQ8XZjILtVWQDbJv8AjdbEgKMHEy33icsAKIUAx8jL9kjq6K9kTdAKXZi9grF
+UQIhAPD7jccIDUVm785E5eR9eisq0+xpgUIa24Jkn8cAlst5AiEAopxVFl1auer3
+GP2In3pjdL4ydzU/gcRcYisoJqwHpM8CIHtqmaXBPeq5WT9ukb5/dL3+5SJCtmxA
+jQMuvZWRe6khAiBvMztYtPSDKXRbCZ4xeQ+kWSDHtok8Y5zNoTeu4nvDrwIgb3Al
+fikzPveC5g6S6OvEQmyDz59tYBubm2XHgvxqww0=
+-----END RSA PRIVATE KEY-----
+`[1:]
+
+var invalidCACert = `
+-----BEGIN CERTIFICATE-----
+MIIBOgIBAAJAZabKgKInuOxj5vDWLwHHQtK3/45KB+32D15w94Nt83BmuGxo90lw
+-----END CERTIFICATE-----
+`[1:]
+
+var invalidCert = `
+-----BEGIN CERTIFICATE-----
+MIIBOgIBAAJAZabKgKInuOxj5vDWLwHHQtK3/45KB+32D15w94Nt83BmuGxo90lw
+-----END CERTIFICATE-----
+`[1:]
+
+var invalidKey = `
+-----BEGIN RSA PRIVATE KEY-----
+MIIBOgIBAAJAZabKgKInuOxj5vDWLwHHQtK3/45KB+32D15w94Nt83BmuGxo90lw
+-----END RSA PRIVATE KEY-----
+`[1:]

--- a/logfwd/syslog/package_test.go
+++ b/logfwd/syslog/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package syslog_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
For the MVP we're aimed at, we limit the config to five specific, flat fields rather than a structured config.

(Review request: http://reviews.vapour.ws/r/4892/)