### PR TITLE
state: re-enable tests under race detector

### DIFF
--- a/state/package_test.go
+++ b/state/package_test.go
@@ -6,14 +6,9 @@ package state_test
 import (
 	stdtesting "testing"
 
-	"github.com/juju/testing"
-
 	coretesting "github.com/juju/juju/testing"
 )
 
 func TestPackage(t *stdtesting.T) {
-	if testing.RaceEnabled {
-		t.Skip("skipping package under -race, see LP 1519095")
-	}
 	coretesting.MgoTestPackage(t)
 }


### PR DESCRIPTION
Fixes LP 1519095

The good news, there are no data races in state currently.
The bad news, the tests take about 1.5x the time to run. On my machine
it is the difference between 15 minutes and 25 minutes to run the -race
tests for this package. Those times will be higher if other tests are
run in parallel (which is the default mode when testing multiple
packages).

(Review request: http://reviews.vapour.ws/r/4893/)