### PR TITLE
cmd/modelcmd: qualified names in GetCurrentModel

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -507,11 +507,12 @@ func (s *BootstrapSuite) TestBootstrapPropagatesStoreErrors(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
 
 	store := jujuclienttesting.NewStubStore()
-	store.SetErrors(nil, nil, nil, errors.New("oh noes"))
+	store.SetErrors(errors.New("oh noes"))
 	cmd := &bootstrapCommand{}
 	cmd.SetClientStore(store)
-	_, err := coretesting.RunCommand(c, modelcmd.Wrap(cmd), controllerName, "dummy", "--auto-upgrade")
-	store.CheckCallNames(c, "CurrentController", "CurrentAccount", "CurrentModel", "CredentialForCloud")
+	wrapped := modelcmd.Wrap(cmd, modelcmd.ModelSkipFlags, modelcmd.ModelSkipDefault)
+	_, err := coretesting.RunCommand(c, wrapped, controllerName, "dummy", "--auto-upgrade")
+	store.CheckCallNames(c, "CredentialForCloud")
 	c.Assert(err, gc.ErrorMatches, `loading credentials: oh noes`)
 }
 

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -32,6 +32,7 @@ func (s *ModelCommandSuite) SetUpTest(c *gc.C) {
 
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = "foo"
+	s.store.Controllers["foo"] = jujuclient.ControllerDetails{}
 	s.store.Accounts["foo"] = &jujuclient.ControllerAccounts{
 		Accounts: map[string]jujuclient.AccountDetails{
 			"bar@baz": {User: "b@r", Password: "hunter2"},
@@ -58,7 +59,7 @@ func (s *ModelCommandSuite) TestGetCurrentModelCurrentControllerNoCurrentAccount
 
 func (s *ModelCommandSuite) TestGetCurrentModelCurrentControllerNoCurrentModel(c *gc.C) {
 	env, err := modelcmd.GetCurrentModel(s.store)
-	c.Assert(env, gc.Equals, "")
+	c.Assert(env, gc.Equals, "foo:")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -70,7 +71,7 @@ func (s *ModelCommandSuite) TestGetCurrentModelCurrentControllerAccountModel(c *
 
 	env, err := modelcmd.GetCurrentModel(s.store)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env, gc.Equals, "mymodel")
+	c.Assert(env, gc.Equals, "foo:mymodel")
 }
 
 func (s *ModelCommandSuite) TestGetCurrentModelJujuEnvSet(c *gc.C) {


### PR DESCRIPTION
Change modelcmd.GetCurrentModel to qualify the returned
model name with the controller name, except in the case
of $JUJU_MODEL being set. Then, if there's a current
controller but no current model, we return "<controller>:"
to print out a more useful error message.

Fixes https://bugs.launchpad.net/juju-core/+bug/1505504

(Review request: http://reviews.vapour.ws/r/4894/)