### PR TITLE
apiserver: fix data race on tls config

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -110,8 +110,11 @@ func (cl *changeCertListener) Accept() (net.Conn, error) {
 	}
 	cl.m.Lock()
 	defer cl.m.Unlock()
-	config := cl.config
-	return tls.Server(conn, config), nil
+
+	// make a copy of cl.config so that update certificate does not mutate
+	// the config passed to the tls.Server for this conn.
+	config := *cl.config
+	return tls.Server(conn, &config), nil
 }
 
 // Close closes the listener.

--- a/apiserver/package_test.go
+++ b/apiserver/package_test.go
@@ -6,14 +6,9 @@ package apiserver_test
 import (
 	stdtesting "testing"
 
-	"github.com/juju/testing"
-
 	coretesting "github.com/juju/juju/testing"
 )
 
 func TestPackage(t *stdtesting.T) {
-	if testing.RaceEnabled {
-		t.Skip("skipping package under -race, see LP 1518806")
-	}
 	coretesting.MgoTestPackage(t)
 }

--- a/cmd/jujud/agent/package_test.go
+++ b/cmd/jujud/agent/package_test.go
@@ -6,15 +6,10 @@ package agent // not agent_test for no good reason
 import (
 	stdtesting "testing"
 
-	"github.com/juju/testing"
-
 	coretesting "github.com/juju/juju/testing"
 )
 
 func TestPackage(t *stdtesting.T) {
-	if testing.RaceEnabled {
-		t.Skip("skipping package under -race, see LP 1519133, 1519097")
-	}
 	// TODO(waigani) 2014-03-19 bug 1294458
 	// Refactor to use base suites
 	coretesting.MgoTestPackage(t)

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -68,7 +68,7 @@ func modelMatchFunc(c *gc.C, tracker *modelTracker, workers []string) func(strin
 	expect := set.NewStrings(workers...)
 	return func(uuid string) bool {
 		actual := tracker.Workers(uuid)
-		c.Logf("\n%s: has workers %v", uuid, actual.SortedValues())
+		c.Logf("%s: has workers %v", uuid, actual.SortedValues())
 		extras := actual.Difference(expect)
 		missed := expect.Difference(actual)
 		if len(extras) == 0 && len(missed) == 0 {


### PR DESCRIPTION
Fixes LP 1518806
Fixes LP 1519097

Pass a _copy_ of the current TLS config to the TLS server for the
accepted connection. This fixes a race where updateCertificate may
mutate its config, a reference to which has been passed to _all_ the
active TLS connections.

This bug is at the bottom of a chain of other data race blockers so we
can remove a bunch of test skips under the race detector.

(Review request: http://reviews.vapour.ws/r/4896/)