### PR TITLE
Add config to clouds.yaml

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -68,6 +68,12 @@ type Cloud struct {
 	// The first region in the slice is the default region for the
 	// cloud.
 	Regions []Region
+
+	// Config contains optional cloud-specific configuration to use
+	// when bootstrapping Juju in this cloud. The cloud configuration
+	// will be combined with Juju-generated, and user-supplied values;
+	// user-supplied values taking precedence.
+	Config map[string]interface{}
 }
 
 // Region is a cloud region.
@@ -93,11 +99,12 @@ type cloudSet struct {
 
 // cloud is equivalent to Cloud, for marshalling and unmarshalling.
 type cloud struct {
-	Type            string     `yaml:"type"`
-	AuthTypes       []AuthType `yaml:"auth-types,omitempty,flow"`
-	Endpoint        string     `yaml:"endpoint,omitempty"`
-	StorageEndpoint string     `yaml:"storage-endpoint,omitempty"`
-	Regions         regions    `yaml:"regions,omitempty"`
+	Type            string                 `yaml:"type"`
+	AuthTypes       []AuthType             `yaml:"auth-types,omitempty,flow"`
+	Endpoint        string                 `yaml:"endpoint,omitempty"`
+	StorageEndpoint string                 `yaml:"storage-endpoint,omitempty"`
+	Regions         regions                `yaml:"regions,omitempty"`
+	Config          map[string]interface{} `yaml:"config,omitempty"`
 }
 
 // regions is a collection of regions, either as a map and/or
@@ -217,6 +224,7 @@ func ParseCloudMetadata(data []byte) (map[string]Cloud, error) {
 			Endpoint:        cloud.Endpoint,
 			StorageEndpoint: cloud.StorageEndpoint,
 			Regions:         regions,
+			Config:          cloud.Config,
 		}
 		meta.denormaliseMetadata()
 		clouds[name] = meta
@@ -265,6 +273,7 @@ func marshalCloudMetadata(cloudsMap map[string]Cloud) ([]byte, error) {
 			Endpoint:        metadata.Endpoint,
 			StorageEndpoint: metadata.StorageEndpoint,
 			Regions:         regions,
+			Config:          metadata.Config,
 		}
 	}
 	data, err := yaml.Marshal(clouds)

--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -64,6 +64,26 @@ func (s *cloudSuite) TestParseCloudsAuthTypes(c *gc.C) {
 	c.Assert(rackspace.AuthTypes, jc.SameContents, []cloud.AuthType{"access-key", "userpass"})
 }
 
+func (s *cloudSuite) TestParseCloudsConfig(c *gc.C) {
+	clouds, err := cloud.ParseCloudMetadata([]byte(`clouds:
+  testing:
+    type: dummy
+    config:
+      k1: v1
+      k2: 2.0
+`))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(clouds, gc.HasLen, 1)
+	testingCloud := clouds["testing"]
+	c.Assert(testingCloud, jc.DeepEquals, cloud.Cloud{
+		Type: "dummy",
+		Config: map[string]interface{}{
+			"k1": "v1",
+			"k2": float64(2.0),
+		},
+	})
+}
+
 func (s *cloudSuite) TestPublicCloudsMetadataFallback(c *gc.C) {
 	clouds, fallbackUsed, err := cloud.PublicCloudMetadata("badfile.yaml")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -91,6 +91,7 @@ type cloudDetails struct {
 	Regions yaml.MapSlice `yaml:"regions,omitempty" json:"-"`
 	// Regions map is for json marshalling where format is important but not order.
 	RegionsMap map[string]regionDetails `yaml:"-" json:"regions,omitempty"`
+	Config     map[string]interface{}   `yaml:"config,omitempty" json:"config,omitempty"`
 }
 
 func makeCloudDetails(cloud jujucloud.Cloud) *cloudDetails {
@@ -99,6 +100,7 @@ func makeCloudDetails(cloud jujucloud.Cloud) *cloudDetails {
 		CloudType:       cloud.Type,
 		Endpoint:        cloud.Endpoint,
 		StorageEndpoint: cloud.StorageEndpoint,
+		Config:          cloud.Config,
 	}
 	result.AuthTypes = make([]string, len(cloud.AuthTypes))
 	for i, at := range cloud.AuthTypes {

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -344,6 +344,9 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		config.UUIDKey:           controllerUUID.String(),
 		config.ControllerUUIDKey: controllerUUID.String(),
 	}
+	for k, v := range cloud.Config {
+		configAttrs[k] = v
+	}
 	userConfigAttrs, err := c.config.ReadAttrs(ctx)
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1022,6 +1022,18 @@ func (s *BootstrapSuite) TestBootstrapConfigFileAndAdHoc(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *BootstrapSuite) TestBootstrapCloudConfigAndAdHoc(c *gc.C) {
+	s.patchVersionAndSeries(c, "raring")
+	_, err := coretesting.RunCommand(
+		c, s.newBootstrapCommand(), "ctrl", "dummy-cloud-with-config",
+		"--auto-upgrade",
+		// Configuration specified on the command line overrides
+		// anything specified in files, no matter what the order.
+		"--config", "controller=false",
+	)
+	c.Assert(err, gc.ErrorMatches, "failed to bootstrap model: dummy.Bootstrap is broken")
+}
+
 // createToolsSource writes the mock tools and metadata into a temporary
 // directory and returns it.
 func createToolsSource(c *gc.C, versions []version.Binary) string {
@@ -1050,6 +1062,11 @@ clouds:
             region-2:
     dummy-cloud-without-regions:
         type: dummy
+    dummy-cloud-with-config:
+        type: dummy
+        config:
+            broken: Bootstrap
+            controller: not-a-bool
 `[1:]), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 }


### PR DESCRIPTION
Add "config" field to cloud definitions,
which defines cloud-specific configuration
attributes to use when bootstrapping.

Also add config to the output of show-cloud
and list-clouds --format=yaml.

Fixes https://bugs.launchpad.net/juju-core/+bug/1576750

**QA**

1. Add a cloud with config:
```
$ cat > /tmp/lxd.yaml <<'EOF'
clouds:
  lxd:
    defined: local
    type: lxd
    config:
      enable-os-refresh-update: false
      enable-os-upgrade: false
EOF

$ juju add-cloud lxd /tmp/lxd.yaml
```

2. Confirm config shows up in output
   of "juju show-cloud" and "juju list-clouds --format=yaml"

3. Bootstrap that cloud

4. Observe that the admin and default models contain the
   cloud config.

(Review request: http://reviews.vapour.ws/r/4898/)