### PR TITLE
Resolve bug in userdata, unsupported format.

### DIFF
--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -5,7 +5,8 @@ package cloud
 
 // Generated code - do not edit.
 
-const fallbackPublicCloudInfo = `# DO NOT EDIT, will be overwritten, use "juju update-clouds" to refresh.
+const fallbackPublicCloudInfo = `
+# DO NOT EDIT, will be overwritten, use "juju update-clouds" to refresh.
 clouds:
   aws:
     type: ec2

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -5,8 +5,7 @@ package cloud
 
 // Generated code - do not edit.
 
-const fallbackPublicCloudInfo = `
-# DO NOT EDIT, will be overwritten, use "juju update-clouds" to refresh.
+const fallbackPublicCloudInfo = `# DO NOT EDIT, will be overwritten, use "juju update-clouds" to refresh.
 clouds:
   aws:
     type: ec2

--- a/cloudconfig/providerinit/providerinit_test.go
+++ b/cloudconfig/providerinit/providerinit_test.go
@@ -385,12 +385,18 @@ func (s *CloudInitSuite) TestWindowsUserdataEncoding(c *gc.C) {
 	data, err := ci.RenderYAML()
 	c.Assert(err, jc.ErrorIsNil)
 	base64Data := base64.StdEncoding.EncodeToString(utils.Gzip(data))
-	got := []byte(fmt.Sprintf(cloudconfig.UserDataScript, base64Data))
+	// first part
+	ugot := []byte(fmt.Sprintf(cloudconfig.UserDataScript, base64Data))
+	// append header
+	header := "#ps1_sysnative\r\n"
+	var got []byte
+	// concat them
+	got = append(got, header...)
+	got = append(got, ugot...)
 
 	cicompose, err := cloudinit.New("win8")
 	c.Assert(err, jc.ErrorIsNil)
 	expected, err := providerinit.ComposeUserData(&cfg, cicompose, openstack.OpenstackRenderer{})
 	c.Assert(err, jc.ErrorIsNil)
-
 	c.Assert(string(expected), gc.Equals, string(got))
 }

--- a/cloudconfig/providerinit/renderers/common.go
+++ b/cloudconfig/providerinit/renderers/common.go
@@ -24,7 +24,12 @@ func ToBase64(data []byte) []byte {
 // which has the userdata embedded as base64(gzip(userdata))
 func WinEmbedInScript(udata []byte) []byte {
 	encUserdata := ToBase64(utils.Gzip(udata))
-	return []byte(fmt.Sprintf(cloudconfig.UserDataScript, encUserdata))
+	var wrapped []byte
+	header := "#ps1_sysnative\r\n"
+	script := fmt.Sprintf(cloudconfig.UserDataScript, encUserdata)
+	wrapped = append(wrapped, header...)
+	wrapped = append(wrapped, script...)
+	return wrapped
 }
 
 // AddPowershellTags adds <powershell>...</powershell> to it's input

--- a/cloudconfig/providerinit/renderers/common_test.go
+++ b/cloudconfig/providerinit/renderers/common_test.go
@@ -33,7 +33,12 @@ func (s *RenderersSuite) TestToBase64(c *gc.C) {
 
 func (s *RenderersSuite) TestWinEmbedInScript(c *gc.C) {
 	in := []byte("test")
-	expected := []byte(fmt.Sprintf(cloudconfig.UserDataScript, renderers.ToBase64(utils.Gzip(in))))
+	encUserdata := renderers.ToBase64(utils.Gzip(in))
+	var expected []byte
+	header := "#ps1_sysnative\r\n"
+	script := fmt.Sprintf(cloudconfig.UserDataScript, encUserdata)
+	expected = append(expected, header...)
+	expected = append(expected, script...)
 	out := renderers.WinEmbedInScript(in)
 	c.Assert(out, jc.DeepEquals, expected)
 }

--- a/cloudconfig/providerinit/renderers/common_test.go
+++ b/cloudconfig/providerinit/renderers/common_test.go
@@ -43,6 +43,13 @@ func (s *RenderersSuite) TestWinEmbedInScript(c *gc.C) {
 	c.Assert(out, jc.DeepEquals, expected)
 }
 
+func (s *RenderersSuite) TestPrependWinPS1Header(c *gc.C) {
+	in := []byte("test")
+	expected := []byte("#ps1_sysnative\r\ntest")
+	out := renderers.PrependWinPS1Header(in)
+	c.Assert(out, jc.DeepEquals, expected)
+}
+
 func (s *RenderersSuite) TestAddPowershellTags(c *gc.C) {
 	in := []byte("test")
 	expected := []byte(`<powershell>` + string(in) + `</powershell>`)

--- a/cloudconfig/windows_userdata_test.go
+++ b/cloudconfig/windows_userdata_test.go
@@ -16,6 +16,7 @@ package cloudconfig_test
 var WindowsUserdata = `#ps1_sysnative
 
 
+
 $ErrorActionPreference = "Stop"
 
 function ExecRetry($command, $retryInterval = 15)
@@ -253,6 +254,7 @@ Function Invoke-FastWebRequest {
 }
 
 
+
 function create-account ([string]$accountName, [string]$accountDescription, [string]$password) {
 	$hostname = hostname
 	$comp = [adsi]"WinNT://$hostname"
@@ -303,7 +305,6 @@ namespace PSCloudbase
 		public static extern uint GetLastError();
 	}
 }
-
 "@
 
 Add-Type -TypeDefinition $Source -Language CSharp
@@ -635,7 +636,6 @@ namespace PSCarbon
 		}
 	}
 }
-
 "@
 
 Add-Type -TypeDefinition $SourcePolicy -Language CSharp

--- a/cloudconfig/windowsuserdatafiles/addJujuUser.ps1
+++ b/cloudconfig/windowsuserdatafiles/addJujuUser.ps1
@@ -18,8 +18,7 @@ function create-account ([string]$accountName, [string]$accountDescription, [str
 }
 
 $Source = @"
-%s
-"@
+%s"@
 
 Add-Type -TypeDefinition $Source -Language CSharp
 
@@ -64,8 +63,7 @@ function Get-RandomPassword
 }
 
 $SourcePolicy = @"
-%s
-"@
+%s"@
 
 Add-Type -TypeDefinition $SourcePolicy -Language CSharp
 

--- a/cloudconfig/windowsuserdatafiles/invokewebrequest.ps1
+++ b/cloudconfig/windowsuserdatafiles/invokewebrequest.ps1
@@ -28,3 +28,4 @@ Function Invoke-FastWebRequest {
 		$outStream.Close()
 	}
 }
+

--- a/cloudconfig/windowsuserdatafiles/retry.ps1
+++ b/cloudconfig/windowsuserdatafiles/retry.ps1
@@ -1,3 +1,4 @@
+
 $ErrorActionPreference = "Stop"
 
 function ExecRetry($command, $retryInterval = 15)

--- a/cloudconfig/windowsuserdatafiles/userdata.ps1
+++ b/cloudconfig/windowsuserdatafiles/userdata.ps1
@@ -1,4 +1,4 @@
-#ps1_sysnative
+$ErrorActionPreference = "Stop"
 $userdata=@"
 %s
 "@

--- a/cloudconfig/winuserdata.go
+++ b/cloudconfig/winuserdata.go
@@ -57,7 +57,6 @@ namespace PSCloudbase
 		public static extern uint GetLastError();
 	}
 }
-
 "@
 
 Add-Type -TypeDefinition $Source -Language CSharp
@@ -389,7 +388,6 @@ namespace PSCarbon
 		}
 	}
 }
-
 "@
 
 Add-Type -TypeDefinition $SourcePolicy -Language CSharp
@@ -431,6 +429,7 @@ $secpasswd = ConvertTo-SecureString $juju_passwd -AsPlainText -Force
 $jujuCreds = New-Object System.Management.Automation.PSCredential ($juju_user, $secpasswd)
 `
 const windowsPowershellHelpers = `
+
 $ErrorActionPreference = "Stop"
 
 function ExecRetry($command, $retryInterval = 15)
@@ -666,4 +665,5 @@ Function Invoke-FastWebRequest {
 		$outStream.Close()
 	}
 }
+
 `

--- a/cloudconfig/winuserdatawrapper.go
+++ b/cloudconfig/winuserdatawrapper.go
@@ -6,7 +6,7 @@ package cloudconfig
 // Generated code - do not edit.
 
 const UserDataScript = `
-#ps1_sysnative
+$ErrorActionPreference = "Stop"
 $userdata=@"
 %s
 "@


### PR DESCRIPTION
This is happening when the UserDataScript string is formatted
it adds in the process two new "\n\n". In order to prevent this we must
add the powershell header separate and cocat it. Bug:
(https://bugs.launchpad.net/juju-core/+bug/1585430).

(Review request: http://reviews.vapour.ws/r/4900/)