### PR TITLE
Migrate Subnets

### DIFF
--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -310,4 +310,11 @@ type Endpoint interface {
 
 // Subnet represents a network subnet.
 type Subnet interface {
+	ProviderId() string
+	CIDR() string
+	VLANTag() int
+	AvailabilityZone() string
+	SpaceName() string
+	AllocatableIPHigh() string
+	AllocatableIPLow() string
 }

--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -60,6 +60,9 @@ type Model interface {
 	Relations() []Relation
 	AddRelation(RelationArgs) Relation
 
+	Subnets() []Subnet
+	AddSubnet(SubnetArgs) Subnet
+
 	Sequences() map[string]int
 	SetSequence(name string, value int)
 
@@ -303,4 +306,8 @@ type Endpoint interface {
 
 	Settings(unitName string) map[string]interface{}
 	SetUnitSettings(unitName string, settings map[string]interface{})
+}
+
+// Subnet represents a network subnet.
+type Subnet interface {
 }

--- a/core/description/model.go
+++ b/core/description/model.go
@@ -458,7 +458,7 @@ func importModelV1(source map[string]interface{}) (*model, error) {
 	subnetsMap := valid["subnets"].(map[string]interface{})
 	subnets, err := importSubnets(subnetsMap)
 	if err != nil {
-		return nil, erros.Annotate(err, "subnets")
+		return nil, errors.Annotate(err, "subnets")
 	}
 	result.setSubnets(subnets)
 

--- a/core/description/model_test.go
+++ b/core/description/model_test.go
@@ -326,3 +326,19 @@ func (s *ModelSerializationSuite) TestModelSerializationWithRelations(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(model, jc.DeepEquals, initial)
 }
+
+func (s *ModelSerializationSuite) TestSubnets(c *gc.C) {
+	initial := NewModel(ModelArgs{Owner: names.NewUserTag("owner")})
+	subnet := initial.AddSubnet(SubnetArgs{CIDR: "10.0.0.0/24"})
+	c.Assert(subnet.CIDR(), gc.Equals, "10.0.0.0/24")
+	subnets := initial.Subnets()
+	c.Assert(subnets, gc.HasLen, 1)
+	c.Assert(subnets[0], jc.DeepEquals, subnet)
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := Deserialize(bytes)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(model.Subnets(), jc.DeepEquals, subnets)
+}

--- a/core/description/subnet.go
+++ b/core/description/subnet.go
@@ -132,6 +132,7 @@ var subnetDeserializationFuncs = map[int]subnetDeserializationFunc{
 
 func importSubnetV1(source map[string]interface{}) (*subnet, error) {
 	fields := schema.Fields{
+		"cidr":              schema.String(),
 		"provider-id":       schema.String(),
 		"vlantag":           schema.Int(),
 		"spacename":         schema.String(),
@@ -157,8 +158,9 @@ func importSubnetV1(source map[string]interface{}) (*subnet, error) {
 	// From here we know that the map returned from the schema coercion
 	// contains fields of the right type.
 	return &subnet{
+		CIDR_:              valid["cidr"].(string),
 		ProviderId_:        valid["provider-id"].(string),
-		VLANTag_:           valid["vlantag"].(int),
+		VLANTag_:           int(valid["vlantag"].(int64)),
 		SpaceName_:         valid["spacename"].(string),
 		AvailabilityZone_:  valid["availabilityzone"].(string),
 		AllocatableIPHigh_: valid["allocatableiphigh"].(string),

--- a/core/description/subnet.go
+++ b/core/description/subnet.go
@@ -18,8 +18,6 @@ type subnet struct {
 	CIDR_       string `yaml:"cidr"`
 	VLANTag_    int    `yaml:"vlantag"`
 
-	// XXX should AvailabilityZone and SpaceName be omitempty? (i.e.
-	// optional)
 	AvailabilityZone_ string `yaml:"availabilityzone"`
 	SpaceName_        string `yaml:"spacename"`
 
@@ -32,7 +30,6 @@ type subnet struct {
 // SubnetArgs is an argument struct used to create a
 // new internal subnet type that supports the Subnet interface.
 type SubnetArgs struct {
-	// XXX should this be network.Id? It isn't in space.go
 	ProviderId       string
 	CIDR             string
 	VLANTag          int
@@ -142,7 +139,6 @@ func importSubnetV1(source map[string]interface{}) (*subnet, error) {
 		"allocatableiplow":  schema.String(),
 	}
 
-	// XXX are spacename and availabilityzone optional?
 	defaults := schema.Defaults{
 		"provider-id":       "",
 		"allocatableiphigh": "",

--- a/core/description/subnet.go
+++ b/core/description/subnet.go
@@ -48,6 +48,7 @@ type SubnetArgs struct {
 func newSubnet(args SubnetArgs) *subnet {
 	return &subnet{
 		ProviderId_:        string(args.ProviderId),
+		SpaceName_:         args.SpaceName,
 		CIDR_:              args.CIDR,
 		VLANTag_:           args.VLANTag,
 		AvailabilityZone_:  args.AvailabilityZone,

--- a/core/description/subnet.go
+++ b/core/description/subnet.go
@@ -73,7 +73,8 @@ func importSubnetV1(source map[string]interface{}) (*subnet, error) {
 	if err != nil {
 		return nil, errors.Annotatef(err, "subnet v1 schema check failed")
 	}
-	valid := coerced.(map[string]interface{})
+	// XXX valid
+	_ := coerced.(map[string]interface{})
 
 	// From here we know that the map returned from the schema coercion
 	// contains fields of the right type.

--- a/core/description/subnet.go
+++ b/core/description/subnet.go
@@ -74,7 +74,7 @@ func importSubnetV1(source map[string]interface{}) (*subnet, error) {
 		return nil, errors.Annotatef(err, "subnet v1 schema check failed")
 	}
 	// XXX valid
-	_ := coerced.(map[string]interface{})
+	_ = coerced.(map[string]interface{})
 
 	// From here we know that the map returned from the schema coercion
 	// contains fields of the right type.

--- a/core/description/subnet.go
+++ b/core/description/subnet.go
@@ -61,6 +61,11 @@ func (s *subnet) ProviderId() string {
 	return s.ProviderId_
 }
 
+// SpaceName implements Subnet.
+func (s *subnet) SpaceName() string {
+	return s.SpaceName_
+}
+
 // CIDR implements Subnet.
 func (s *subnet) CIDR() string {
 	return s.CIDR_

--- a/core/description/subnet.go
+++ b/core/description/subnet.go
@@ -147,10 +147,16 @@ func importSubnetV1(source map[string]interface{}) (*subnet, error) {
 	if err != nil {
 		return nil, errors.Annotatef(err, "subnet v1 schema check failed")
 	}
-	// XXX valid
-	_ = coerced.(map[string]interface{})
+	valid := coerced.(map[string]interface{})
 
 	// From here we know that the map returned from the schema coercion
 	// contains fields of the right type.
-	return &subnet{}, nil
+	return &subnet{
+		ProviderId_:        valid["provider-id"].(string),
+		VLANTag_:           valid["vlantag"].(int),
+		SpaceName_:         valid["spacename"].(string),
+		AvailabilityZone_:  valid["availabilityzone"].(string),
+		AllocatableIPHigh_: valid["allocatableiphigh"].(string),
+		AllocatableIPLow_:  valid["allocatableiplow"].(string),
+	}, nil
 }

--- a/core/description/subnet.go
+++ b/core/description/subnet.go
@@ -1,0 +1,81 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+)
+
+type subnets struct {
+	Version  int       `yaml:"version"`
+	Subnets_ []*subnet `yaml:"subnets"`
+}
+
+type subnet struct {
+}
+
+// SubnetArgs is an argument struct used to create a
+// new internal subnet type that supports the Subnet interface.
+type SubnetArgs struct {
+}
+
+func newSubnet(args SubnetArgs) *subnet {
+	return &subnet{}
+}
+
+func importSubnets(source map[string]interface{}) ([]*subnet, error) {
+	checker := versionedChecker("subnets")
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "subnets version schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+
+	version := int(valid["version"].(int64))
+	importFunc, ok := subnetDeserializationFuncs[version]
+	if !ok {
+		return nil, errors.NotValidf("version %d", version)
+	}
+	sourceList := valid["subnets"].([]interface{})
+	return importSubnetList(sourceList, importFunc)
+}
+
+func importSubnetList(sourceList []interface{}, importFunc subnetDeserializationFunc) ([]*subnet, error) {
+	result := make([]*subnet, 0, len(sourceList))
+	for i, value := range sourceList {
+		source, ok := value.(map[string]interface{})
+		if !ok {
+			return nil, errors.Errorf("unexpected value for subnet %d, %T", i, value)
+		}
+		subnet, err := importFunc(source)
+		if err != nil {
+			return nil, errors.Annotatef(err, "subnet %d", i)
+		}
+		result = append(result, subnet)
+	}
+	return result, nil
+}
+
+type subnetDeserializationFunc func(map[string]interface{}) (*subnet, error)
+
+var subnetDeserializationFuncs = map[int]subnetDeserializationFunc{
+	1: importSubnetV1,
+}
+
+func importSubnetV1(source map[string]interface{}) (*subnet, error) {
+	fields := schema.Fields{}
+	defaults := schema.Defaults{}
+	checker := schema.FieldMap(fields, defaults)
+
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "subnet v1 schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+
+	// From here we know that the map returned from the schema coercion
+	// contains fields of the right type.
+	return &subnet{}, nil
+}

--- a/core/description/subnet.go
+++ b/core/description/subnet.go
@@ -14,9 +14,12 @@ type subnets struct {
 }
 
 type subnet struct {
-	ProviderId_       string `yaml:"provider-id,omitempty"`
-	CIDR_             string `yaml:"cidr"`
-	VLANTag_          int    `yaml:"vlantag"`
+	ProviderId_ string `yaml:"provider-id,omitempty"`
+	CIDR_       string `yaml:"cidr"`
+	VLANTag_    int    `yaml:"vlantag"`
+
+	// XXX should AvailabilityZone and SpaceName be omitempty? (i.e.
+	// optional)
 	AvailabilityZone_ string `yaml:"availabilityzone"`
 	SpaceName_        string `yaml:"spacename"`
 
@@ -123,8 +126,21 @@ var subnetDeserializationFuncs = map[int]subnetDeserializationFunc{
 }
 
 func importSubnetV1(source map[string]interface{}) (*subnet, error) {
-	fields := schema.Fields{}
-	defaults := schema.Defaults{}
+	fields := schema.Fields{
+		"provider-id":       schema.String(),
+		"vlantag":           schema.Int(),
+		"spacename":         schema.String(),
+		"availabilityzone":  schema.String(),
+		"allocatableiphigh": schema.String(),
+		"allocatableiplow":  schema.String(),
+	}
+
+	// XXX are spacename and availabilityzone optional?
+	defaults := schema.Defaults{
+		"provider-id":       "",
+		"allocatableiphigh": "",
+		"allocatableiplow":  "",
+	}
 	checker := schema.FieldMap(fields, defaults)
 
 	coerced, err := checker.Coerce(source, nil)

--- a/core/description/subnet.go
+++ b/core/description/subnet.go
@@ -14,15 +14,73 @@ type subnets struct {
 }
 
 type subnet struct {
+	ProviderId_       string `yaml:"provider-id,omitempty"`
+	CIDR_             string `yaml:"cidr"`
+	VLANTag_          int    `yaml:"vlantag"`
+	AvailabilityZone_ string `yaml:"availabilityzone"`
+	SpaceName_        string `yaml:"spacename"`
+
+	// These will be deprecated once the address allocation strategy for
+	// EC2 is changed. They are unused already on MAAS.
+	AllocatableIPHigh_ string `yaml:"allocatableiphigh,omitempty"`
+	AllocatableIPLow_  string `yaml:"allocatableiplow,omitempty"`
 }
 
 // SubnetArgs is an argument struct used to create a
 // new internal subnet type that supports the Subnet interface.
 type SubnetArgs struct {
+	// XXX should this be network.Id? It isn't in space.go
+	ProviderId       string
+	CIDR             string
+	VLANTag          int
+	AvailabilityZone string
+	SpaceName        string
+
+	// These will be deprecated once the address allocation strategy for
+	// EC2 is changed. They are unused already on MAAS.
+	AllocatableIPHigh string
+	AllocatableIPLow  string
 }
 
 func newSubnet(args SubnetArgs) *subnet {
-	return &subnet{}
+	return &subnet{
+		ProviderId_:        string(args.ProviderId),
+		CIDR_:              args.CIDR,
+		VLANTag_:           args.VLANTag,
+		AvailabilityZone_:  args.AvailabilityZone,
+		AllocatableIPHigh_: args.AllocatableIPHigh,
+		AllocatableIPLow_:  args.AllocatableIPLow,
+	}
+}
+
+// ProviderId implements Subnet.
+func (s *subnet) ProviderId() string {
+	return s.ProviderId_
+}
+
+// CIDR implements Subnet.
+func (s *subnet) CIDR() string {
+	return s.CIDR_
+}
+
+// VLANTag implements Subnet.
+func (s *subnet) VLANTag() int {
+	return s.VLANTag_
+}
+
+// AvailabilityZone implements Subnet.
+func (s *subnet) AvailabilityZone() string {
+	return s.AvailabilityZone_
+}
+
+// AllocatableIPHigh implements Subnet.
+func (s *subnet) AllocatableIPHigh() string {
+	return s.AllocatableIPHigh_
+}
+
+// AllocatableIPLow implements Subnet.
+func (s *subnet) AllocatableIPLow() string {
+	return s.AllocatableIPLow_
 }
 
 func importSubnets(source map[string]interface{}) ([]*subnet, error) {

--- a/core/description/subnet_test.go
+++ b/core/description/subnet_test.go
@@ -29,14 +29,22 @@ func (s *SubnetSerializationSuite) SetUpTest(c *gc.C) {
 
 func (s *SubnetSerializationSuite) TestNewSubnet(c *gc.C) {
 	args := SubnetArgs{
-		Name:       "special",
-		Public:     true,
-		ProviderID: "magic",
+		CIDR:              "10.0.0.0/24",
+		ProviderId:        "magic",
+		VLANTag:           64,
+		SpaceName:         "foo",
+		AvailabilityZone:  "bar",
+		AllocatableIPHigh: "10.0.0.255",
+		AllocatableIPLow:  "10.0.0.0",
 	}
 	subnet := newSubnet(args)
-	c.Assert(subnet.Name(), gc.Equals, args.Name)
-	c.Assert(subnet.Public(), gc.Equals, args.Public)
-	c.Assert(subnet.ProviderID(), gc.Equals, args.ProviderID)
+	c.Assert(subnet.CIDR(), gc.Equals, args.CIDR)
+	c.Assert(subnet.ProviderId(), gc.Equals, args.ProviderId)
+	c.Assert(subnet.VLANTag(), gc.Equals, args.VLANTag)
+	c.Assert(subnet.SpaceName(), gc.Equals, args.SpaceName)
+	c.Assert(subnet.AvailabilityZone(), gc.Equals, args.AvailabilityZone)
+	c.Assert(subnet.AllocatableIPHigh(), gc.Equals, args.AllocatableIPHigh)
+	c.Assert(subnet.AllocatableIPLow(), gc.Equals, args.AllocatableIPLow)
 }
 
 func (s *SubnetSerializationSuite) TestParsingSerializedData(c *gc.C) {
@@ -44,11 +52,15 @@ func (s *SubnetSerializationSuite) TestParsingSerializedData(c *gc.C) {
 		Version: 1,
 		Subnets_: []*subnet{
 			newSubnet(SubnetArgs{
-				Name:       "special",
-				Public:     true,
-				ProviderID: "magic",
+				CIDR:              "10.0.0.0/24",
+				ProviderId:        "magic",
+				VLANTag:           64,
+				SpaceName:         "foo",
+				AvailabilityZone:  "bar",
+				AllocatableIPHigh: "10.0.0.255",
+				AllocatableIPLow:  "10.0.0.0",
 			}),
-			newSubnet(SubnetArgs{Name: "foo"}),
+			newSubnet(SubnetArgs{CIDR: "10.0.1.0/24"}),
 		},
 	}
 

--- a/core/description/subnet_test.go
+++ b/core/description/subnet_test.go
@@ -1,0 +1,66 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+)
+
+type SubnetSerializationSuite struct {
+	SliceSerializationSuite
+}
+
+var _ = gc.Suite(&SubnetSerializationSuite{})
+
+func (s *SubnetSerializationSuite) SetUpTest(c *gc.C) {
+	s.SliceSerializationSuite.SetUpTest(c)
+	s.importName = "subnets"
+	s.sliceName = "subnets"
+	s.importFunc = func(m map[string]interface{}) (interface{}, error) {
+		return importSubnets(m)
+	}
+	s.testFields = func(m map[string]interface{}) {
+		m["subnets"] = []interface{}{}
+	}
+}
+
+func (s *SubnetSerializationSuite) TestNewSubnet(c *gc.C) {
+	args := SubnetArgs{
+		Name:       "special",
+		Public:     true,
+		ProviderID: "magic",
+	}
+	subnet := newSubnet(args)
+	c.Assert(subnet.Name(), gc.Equals, args.Name)
+	c.Assert(subnet.Public(), gc.Equals, args.Public)
+	c.Assert(subnet.ProviderID(), gc.Equals, args.ProviderID)
+}
+
+func (s *SubnetSerializationSuite) TestParsingSerializedData(c *gc.C) {
+	initial := subnets{
+		Version: 1,
+		Subnets_: []*subnet{
+			newSubnet(SubnetArgs{
+				Name:       "special",
+				Public:     true,
+				ProviderID: "magic",
+			}),
+			newSubnet(SubnetArgs{Name: "foo"}),
+		},
+	}
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	subnets, err := importSubnets(source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(subnets, jc.DeepEquals, initial.Subnets_)
+}

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -597,6 +597,7 @@ func (e *exporter) subnets() error {
 
 	for _, subnet := range subnets {
 		e.model.AddSubnet(description.SubnetArgs{
+			CIDR:              subnet.CIDR(),
 			ProviderId:        string(subnet.ProviderId()),
 			VLANTag:           subnet.VLANTag(),
 			AvailabilityZone:  subnet.AvailabilityZone(),

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -84,6 +84,9 @@ func (st *State) Export() (description.Model, error) {
 	if err := export.relations(); err != nil {
 		return nil, errors.Trace(err)
 	}
+	if err := export.subnets(); err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	if err := export.model.Validate(); err != nil {
 		return nil, errors.Trace(err)
@@ -581,6 +584,19 @@ func (e *exporter) relations() error {
 				exEndPoint.SetUnitSettings(unit.Name(), settingsDoc.Settings)
 			}
 		}
+	}
+	return nil
+}
+
+func (e *exporter) subnets() error {
+	subnets, err := e.st.AllSubnets()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	e.logger.Debugf("read %d subnets", len(subnets))
+
+	for _ = range subnets {
+		e.model.AddSubnet(description.SubnetArgs{})
 	}
 	return nil
 }

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -595,8 +595,15 @@ func (e *exporter) subnets() error {
 	}
 	e.logger.Debugf("read %d subnets", len(subnets))
 
-	for _ = range subnets {
-		e.model.AddSubnet(description.SubnetArgs{})
+	for _, subnet := range subnets {
+		e.model.AddSubnet(description.SubnetArgs{
+			ProviderId:        string(subnet.ProviderId()),
+			VLANTag:           subnet.VLANTag(),
+			AvailabilityZone:  subnet.AvailabilityZone(),
+			SpaceName:         subnet.SpaceName(),
+			AllocatableIPHigh: subnet.AllocatableIPHigh(),
+			AllocatableIPLow:  subnet.AllocatableIPLow(),
+		})
 	}
 	return nil
 }

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/description"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/testing/factory"
@@ -426,6 +427,29 @@ func (s *MigrationExportSuite) TestRelations(c *gc.C) {
 	}
 	checkEndpoint(exEps[0], mysql_0.Name(), msEp, mysqlSettings)
 	checkEndpoint(exEps[1], wordpress_0.Name(), wpEp, wordpressSettings)
+}
+
+func (s *MigrationExportSuite) TestSubnets(c *gc.C) {
+	_, err := s.State.AddSubnet(state.SubnetInfo{
+		CIDR:             "10.0.0.0/24",
+		ProviderId:       network.Id("foo"),
+		VLANTag:          64,
+		AvailabilityZone: "bar",
+		SpaceName:        "bam",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := s.State.Export()
+	c.Assert(err, jc.ErrorIsNil)
+
+	subnets := model.Subnets()
+	c.Assert(subnets, gc.HasLen, 1)
+	subnet := subnets[0]
+	c.Assert(subnet.CIDR(), gc.Equals, "10.0.0.0/24")
+	c.Assert(subnet.ProviderId(), gc.Equals, "foo")
+	c.Assert(subnet.VLANTag(), gc.Equals, 64)
+	c.Assert(subnet.AvailabilityZone(), gc.Equals, "bar")
+	c.Assert(subnet.SpaceName(), gc.Equals, "bam")
 }
 
 type goodToken struct{}

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -808,6 +808,7 @@ func (i *importer) subnets() error {
 	i.logger.Debugf("importing subnets")
 	for _, subnet := range i.model.Subnets() {
 		_, err := i.st.AddSubnet(SubnetInfo{
+			CIDR:              subnet.CIDR(),
 			ProviderId:        network.Id(subnet.ProviderId()),
 			VLANTag:           subnet.VLANTag(),
 			AvailabilityZone:  subnet.AvailabilityZone(),

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -826,10 +826,11 @@ func (i *importer) subnets() error {
 
 func (i *importer) addSubnet(args SubnetInfo) error {
 	buildTxn := func(attempt int) ([]txn.Op, error) {
-		subnet, ops, err := i.st.addSubnetOps(args)
+		subnet, err := i.st.newSubnetFromArgs(args)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		ops := i.st.addSubnetOps(args)
 		if attempt != 0 {
 			if _, err = i.st.Subnet(args.CIDR); err == nil {
 				return nil, errors.AlreadyExistsf("subnet %q", args.CIDR)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/tools"
 )
@@ -805,8 +806,15 @@ func (i *importer) makeRelationDoc(rel description.Relation) *relationDoc {
 
 func (i *importer) subnets() error {
 	i.logger.Debugf("importing subnets")
-	for _ = range i.model.Subnets() {
-		_, err := i.st.AddSubnet(SubnetInfo{})
+	for _, subnet := range i.model.Subnets() {
+		_, err := i.st.AddSubnet(SubnetInfo{
+			ProviderId:        network.Id(subnet.ProviderId()),
+			VLANTag:           subnet.VLANTag(),
+			AvailabilityZone:  subnet.AvailabilityZone(),
+			SpaceName:         subnet.SpaceName(),
+			AllocatableIPHigh: subnet.AllocatableIPHigh(),
+			AllocatableIPLow:  subnet.AllocatableIPLow(),
+		})
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -94,6 +94,9 @@ func (st *State) Import(model description.Model) (_ *Model, _ *State, err error)
 	if err := restore.relations(); err != nil {
 		return nil, nil, errors.Annotate(err, "relations")
 	}
+	if err := restore.subnets(); err != nil {
+		return nil, nil, errors.Annotate(err, "subnets")
+	}
 
 	// NOTE: at the end of the import make sure that the mode of the model
 	// is set to "imported" not "active" (or whatever we call it). This way
@@ -798,6 +801,18 @@ func (i *importer) makeRelationDoc(rel description.Relation) *relationDoc {
 		doc.UnitCount += ep.UnitCount()
 	}
 	return doc
+}
+
+func (i *importer) subnets() error {
+	i.logger.Debugf("importing subnets")
+	for _ = range i.model.Subnets() {
+		_, err := i.st.AddSubnet(SubnetInfo{})
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	i.logger.Debugf("importing subnets succeeded")
+	return nil
 }
 
 func (i *importer) importStatusHistory(globalKey string, history []description.Status) error {

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -513,11 +513,10 @@ func (s *MigrationImportSuite) TestSubnets(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(subnet.CIDR(), gc.Equals, "10.0.0.0/24")
-	c.Assert(subnet.ProviderId(), gc.Equals, "foo")
+	c.Assert(subnet.ProviderId(), gc.Equals, network.Id("foo"))
 	c.Assert(subnet.VLANTag(), gc.Equals, 64)
 	c.Assert(subnet.AvailabilityZone(), gc.Equals, "bar")
 	c.Assert(subnet.SpaceName(), gc.Equals, "bam")
-	c.Assert(subnet.CIDR(), gc.Equals, "")
 }
 
 // newModel replaces the uuid and name of the config attributes so we

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -494,6 +494,32 @@ func (s *MigrationImportSuite) assertDestroyModelAdvancesLife(c *gc.C, m *state.
 	c.Assert(m.Life(), gc.Equals, life)
 }
 
+func (s *MigrationImportSuite) TestSubnets(c *gc.C) {
+	original, err := s.State.AddSubnet(state.SubnetInfo{
+		CIDR:             "10.0.0.0/24",
+		ProviderId:       network.Id("foo"),
+		VLANTag:          64,
+		AvailabilityZone: "bar",
+		SpaceName:        "bam",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, newSt := s.importModel(c)
+	defer func() {
+		c.Assert(newSt.Close(), jc.ErrorIsNil)
+	}()
+
+	subnet, err := newSt.Subnet(original.CIDR())
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(subnet.CIDR(), gc.Equals, "10.0.0.0/24")
+	c.Assert(subnet.ProviderId(), gc.Equals, "foo")
+	c.Assert(subnet.VLANTag(), gc.Equals, 64)
+	c.Assert(subnet.AvailabilityZone(), gc.Equals, "bar")
+	c.Assert(subnet.SpaceName(), gc.Equals, "bam")
+	c.Assert(subnet.CIDR(), gc.Equals, "")
+}
+
 // newModel replaces the uuid and name of the config attributes so we
 // can use all the other data to validate imports. An owner and name of the
 // model are unique together in a controller.

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -45,6 +45,9 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// relation
 		relationsC,
 		relationScopesC,
+
+		// networking
+		subnetsC,
 	)
 
 	ignoredCollections := set.NewStrings(
@@ -143,7 +146,6 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		providerIDsC,
 		linkLayerDevicesC,
 		linkLayerDevicesRefsC,
-		subnetsC,
 		spacesC,
 
 		// actions

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -516,6 +516,31 @@ func (s *MigrationSuite) TestHistoricalStatusDocFields(c *gc.C) {
 	s.AssertExportedFields(c, historicalStatusDoc{}, fields)
 }
 
+func (s *MigrationSuite) TestSubnetDocFields(c *gc.C) {
+	ignored := set.NewStrings(
+		// DocID is the env + name
+		"DocID",
+		// ModelUUID shouldn't be exported, and is inherited
+		// from the model definition.
+		"ModelUUID",
+		// Always alive, not explicitly exported.
+		"Life",
+
+		// Currently unused (never set or exposed).
+		"IsPublic",
+	)
+	migrated := set.NewStrings(
+		"CIDR",
+		"VLANTag",
+		"SpaceName",
+		"ProviderId",
+		"AvailabilityZone",
+		"AllocatableIPHigh",
+		"AllocatableIPLow",
+	)
+	s.AssertExportedFields(c, subnetDoc{}, migrated.Union(ignored))
+}
+
 func (s *MigrationSuite) AssertExportedFields(c *gc.C, doc interface{}, fields set.Strings) {
 	expected := getExportedFields(doc)
 	unknown := expected.Difference(fields)


### PR DESCRIPTION
Add subnets to the core/description model, and add the methods to export and import subnets.

(Review request: http://reviews.vapour.ws/r/4901/)