### PR TITLE
provider/azure: don't log unknown sizes as errors

### DIFF
--- a/provider/azure/instancetype.go
+++ b/provider/azure/instancetype.go
@@ -97,7 +97,7 @@ func newInstanceType(size compute.VirtualMachineSize) instances.InstanceType {
 		}
 	}
 	if cost == len(machineSizeCost) {
-		logger.Errorf("found unknown VM size %q", sizeName)
+		logger.Debugf("found unknown VM size %q", sizeName)
 	}
 
 	vtype := "Hyper-V"


### PR DESCRIPTION
It's not an error if we don't know a VM size. The
sizes that Azure supports grow over time, and the
Juju code will need to be updated eventually to
support them completely. In the mean time we just
say the unknown ones are more expensive than the
ones we know about, so they're not chosen without
explicit request.

(Review request: http://reviews.vapour.ws/r/4906/)