### PR TITLE
Remove test skip under race detector

### DIFF
--- a/worker/addresser/package_test.go
+++ b/worker/addresser/package_test.go
@@ -6,14 +6,9 @@ package addresser_test
 import (
 	stdtesting "testing"
 
-	"github.com/juju/testing"
-
 	coretesting "github.com/juju/juju/testing"
 )
 
 func TestPackage(t *stdtesting.T) {
-	if testing.RaceEnabled {
-		t.Skip("skipping package under -race, see LP 1519191")
-	}
 	coretesting.MgoTestPackage(t)
 }


### PR DESCRIPTION
Fixes LP 1519191

The underlying race was removed, re-enable the race test for this
package.

(Review request: http://reviews.vapour.ws/r/4907/)