### PR TITLE
provider/joyent: re-enable data race tests

### DIFF
--- a/provider/joyent/package_test.go
+++ b/provider/joyent/package_test.go
@@ -6,15 +6,10 @@ package joyent_test
 import (
 	stdtesting "testing"
 
-	"github.com/juju/testing"
-
 	gc "gopkg.in/check.v1"
 )
 
 func TestPackage(t *stdtesting.T) {
-	if testing.RaceEnabled {
-		t.Skip("skipping package under -race, see LP 1497801")
-	}
 	registerLocalTests()
 	gc.TestingT(t)
 }


### PR DESCRIPTION
Fixes LP 1497801
Fixes LP 1460882

Re-enable data race tests for this package which were fixed in 1460882.

(Review request: http://reviews.vapour.ws/r/4908/)