### PR TITLE
apiserver/uniter: re-enable race tests

### DIFF
--- a/apiserver/uniter/package_test.go
+++ b/apiserver/uniter/package_test.go
@@ -6,14 +6,9 @@ package uniter_test
 import (
 	stdtesting "testing"
 
-	"github.com/juju/testing"
-
 	coretesting "github.com/juju/juju/testing"
 )
 
 func TestPackage(t *stdtesting.T) {
-	if testing.RaceEnabled {
-		t.Skip("skipping package under -race, see LP 1518809")
-	}
 	coretesting.MgoTestPackage(t)
 }


### PR DESCRIPTION
Fixes LP 1518809

Re-enable race tests for this package, the underlying issues has been
solved.

(Review request: http://reviews.vapour.ws/r/4909/)