### PR TITLE
apiserver/provisioner: re-enable race test

### DIFF
--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
-	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/proxy"
 	gc "gopkg.in/check.v1"
@@ -35,9 +34,6 @@ import (
 )
 
 func TestPackage(t *stdtesting.T) {
-	if jujutesting.RaceEnabled {
-		t.Skip("skipping package under -race, see LP 1517632")
-	}
 	coretesting.MgoTestPackage(t)
 }
 


### PR DESCRIPTION
Fixes LP 1517632

The tests pass under the race detector and the bug listed in the skip
message is incorrect so re-enable the test.

(Review request: http://reviews.vapour.ws/r/4910/)