### PR TITLE
provider/azure: fix races

### DIFF
--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -81,7 +81,7 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 	s.retryClock = mockClock{Clock: testing.NewClock(time.Time{})}
 
 	s.provider, _ = newProviders(c, azure.ProviderConfig{
-		Sender:           &s.sender,
+		Sender:           azuretesting.NewSerialSender(&s.sender),
 		RequestInspector: requestRecorder(&s.requests),
 		NewStorageClient: s.storageClient.NewClient,
 		RetryClock: &testing.AutoAdvancingClock{

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/Godeps/_workspace/src/github.com/Azure/go-autorest/autorest"
@@ -107,6 +108,7 @@ func requestRecorder(requests *[]*http.Request) autorest.PrepareDecorator {
 	if requests == nil {
 		return nil
 	}
+	var mu sync.Mutex
 	return func(p autorest.Preparer) autorest.Preparer {
 		return autorest.PreparerFunc(func(req *http.Request) (*http.Request, error) {
 			// Save the request body, since it will be consumed.
@@ -122,7 +124,9 @@ func requestRecorder(requests *[]*http.Request) autorest.PrepareDecorator {
 				reqCopy.Body = ioutil.NopCloser(&buf)
 				req.Body = ioutil.NopCloser(bytes.NewReader(buf.Bytes()))
 			}
+			mu.Lock()
 			*requests = append(*requests, &reqCopy)
+			mu.Unlock()
 			return req, nil
 		})
 	}


### PR DESCRIPTION
A recent change introduced concurrent API calls,
which in turn introduced a race in the tests. In
the tests we will now serialise all Azure API
calls and isolate concurrent calls during request
recording.

Fixes https://bugs.launchpad.net/juju-core/+bug/1585836

(Review request: http://reviews.vapour.ws/r/4911/)