### PR TITLE
 Add juju unregister command

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/jujuclient"
 	jujuversion "github.com/juju/juju/version"
 	// Import the providers.
 	_ "github.com/juju/juju/provider/all"
@@ -359,6 +360,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(controller.NewListControllersCommand())
 	r.Register(controller.NewListBlocksCommand())
 	r.Register(controller.NewRegisterCommand())
+	r.Register(controller.NewUnregisterCommand(jujuclient.NewFileClientStore()))
 	r.Register(controller.NewRemoveBlocksCommand())
 	r.Register(controller.NewShowControllerCommand())
 

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -488,6 +488,7 @@ var commandNames = []string{
 	"unexpose",
 	"update-allocation",
 	"upload-backup",
+	"unregister",
 	"unset-model-config",
 	"update-clouds",
 	"upgrade-charm",

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -77,6 +77,8 @@ See also:
     change-user-password`
 
 // Info implements Command.Info
+// `register` may seem generic, but is seen as simple and without potential
+// naming collisions in any current or planned features.
 func (c *registerCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "register",

--- a/cmd/juju/controller/unregister.go
+++ b/cmd/juju/controller/unregister.go
@@ -1,0 +1,105 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"launchpad.net/gnuflag"
+
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+)
+
+// NewUnregisterCommand returns a command to allow the user to unregister a controller.
+func NewUnregisterCommand(store jujuclient.ClientStore) cmd.Command {
+	if store == nil {
+		panic("valid store must be specified")
+	}
+	cmd := &unregisterCommand{store: store}
+	return modelcmd.WrapBase(cmd)
+}
+
+// unregisterCommand removes a Juju controller from the local store.
+type unregisterCommand struct {
+	modelcmd.JujuCommandBase
+	controllerName string
+	assumeYes      bool
+	store          jujuclient.ClientStore
+}
+
+var usageUnregisterDetails = `
+Removes local connection information for the specified controller.
+This command does not destroy the controller.  In order to regain
+access to an unregistered controller, it will need to be added
+again using the juju register command.
+
+Examples:
+
+    juju unregister my-controller
+
+See Also:
+    juju register`
+
+// Info implements Command.Info
+// `unregister` may seem generic as a command, but aligns with `register`.
+func (c *unregisterCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "unregister",
+		Args:    "<controller name>",
+		Purpose: "Unregisters a Juju controller",
+		Doc:     usageUnregisterDetails,
+	}
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *unregisterCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.BoolVar(&c.assumeYes, "y", false, "Do not prompt for confirmation")
+	f.BoolVar(&c.assumeYes, "yes", false, "")
+}
+
+// Init implements Command.Init.
+func (c *unregisterCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("controller name must be specified")
+	}
+	c.controllerName, args = args[0], args[1:]
+
+	if err := jujuclient.ValidateControllerName(c.controllerName); err != nil {
+		return err
+	}
+
+	if err := cmd.CheckEmpty(args); err != nil {
+		return err
+	}
+	return nil
+}
+
+var unregisterMsg = `
+This command will remove connection information for controller %q.
+Doing so will prevent you from accessing this controller until
+you register it again.
+
+Continue [y/N]?`[1:]
+
+func (c *unregisterCommand) Run(ctx *cmd.Context) error {
+
+	_, err := c.store.ControllerByName(c.controllerName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if !c.assumeYes {
+		fmt.Fprintf(ctx.Stdout, unregisterMsg, c.controllerName)
+
+		if err := jujucmd.UserConfirmYes(ctx); err != nil {
+			return errors.Annotate(err, "unregistering controller")
+		}
+	}
+
+	return (c.store.RemoveController(c.controllerName))
+}

--- a/cmd/juju/controller/unregister_test.go
+++ b/cmd/juju/controller/unregister_test.go
@@ -1,0 +1,146 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller_test
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	jt "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/controller"
+	cmdtesting "github.com/juju/juju/cmd/testing"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/testing"
+)
+
+// Test that the expected methods are called during unregister:
+// ControllerByName and RemoveController.
+type fakeStore struct {
+	jujuclient.ClientStore
+	lookupName  string
+	removedName string
+}
+
+func (s *fakeStore) ControllerByName(name string) (*jujuclient.ControllerDetails, error) {
+	s.lookupName = name
+	if name != "fake1" {
+		return nil, errors.NotFoundf("controller %s", name)
+	}
+	return &jujuclient.ControllerDetails{}, nil
+}
+
+func (s *fakeStore) RemoveController(name string) error {
+	// Removing a controller that doesn't exist also returns nil,
+	// so no need to check.
+	s.removedName = name
+	return nil
+}
+
+type UnregisterSuite struct {
+	jt.IsolationSuite
+	store *fakeStore
+}
+
+var _ = gc.Suite(&UnregisterSuite{})
+
+func (s *UnregisterSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.store = &fakeStore{}
+}
+
+func (s *UnregisterSuite) TestInit(c *gc.C) {
+	unregisterCommand := controller.NewUnregisterCommand(s.store)
+
+	err := testing.InitCommand(unregisterCommand, []string{})
+	c.Assert(err, gc.ErrorMatches, "controller name must be specified")
+
+	err = testing.InitCommand(unregisterCommand, []string{"foo", "bar"})
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["bar"\]`)
+}
+
+func (s *UnregisterSuite) TestUnregisterUnknownController(c *gc.C) {
+	command := controller.NewUnregisterCommand(s.store)
+	_, err := testing.RunCommand(c, command, "fake3")
+
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	c.Assert(err, gc.ErrorMatches, "controller fake3 not found")
+	c.Check(s.store.lookupName, gc.Equals, "fake3")
+}
+
+func (s *UnregisterSuite) TestUnregisterController(c *gc.C) {
+	command := controller.NewUnregisterCommand(s.store)
+	_, err := testing.RunCommand(c, command, "fake1", "-y")
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(s.store.lookupName, gc.Equals, "fake1")
+	c.Check(s.store.removedName, gc.Equals, "fake1")
+}
+
+var unregisterMsg = `
+This command will remove connection information for controller "fake1".
+Doing so will prevent you from accessing this controller until
+you register it again.
+
+Continue [y/N]?`[1:]
+
+func (s *UnregisterSuite) unregisterCommandAborts(c *gc.C, answer string) {
+	var stdin, stdout bytes.Buffer
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, jc.ErrorIsNil)
+	ctx.Stdout = &stdout
+	ctx.Stdin = &stdin
+
+	// Ensure confirmation is requested if "-y" is not specified.
+	stdin.WriteString(answer)
+	_, errc := cmdtesting.RunCommand(ctx, controller.NewUnregisterCommand(s.store), "fake1")
+	select {
+	case err, ok := <-errc:
+		c.Assert(ok, jc.IsTrue)
+		c.Check(err, gc.ErrorMatches, "unregistering controller: aborted")
+	case <-time.After(testing.LongWait):
+		c.Fatalf("command took too long")
+	}
+	c.Check(testing.Stdout(ctx), gc.Equals, unregisterMsg)
+	c.Check(s.store.lookupName, gc.Equals, "fake1")
+	c.Check(s.store.removedName, gc.Equals, "")
+}
+
+func (s *UnregisterSuite) TestUnregisterCommandAbortsOnN(c *gc.C) {
+	s.unregisterCommandAborts(c, "n")
+}
+
+func (s *UnregisterSuite) TestUnregisterCommandAbortsOnNotY(c *gc.C) {
+	s.unregisterCommandAborts(c, "foo")
+}
+
+func (s *UnregisterSuite) unregisterCommandConfirms(c *gc.C, answer string) {
+	var stdin, stdout bytes.Buffer
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, jc.ErrorIsNil)
+	ctx.Stdout = &stdout
+	ctx.Stdin = &stdin
+
+	stdin.Reset()
+	stdout.Reset()
+	stdin.WriteString(answer)
+	_, errc := cmdtesting.RunCommand(ctx, controller.NewUnregisterCommand(s.store), "fake1")
+	select {
+	case err, ok := <-errc:
+		c.Assert(ok, jc.IsTrue)
+		c.Check(err, jc.ErrorIsNil)
+	case <-time.After(testing.LongWait):
+		c.Fatalf("command took too long")
+	}
+	c.Check(s.store.lookupName, gc.Equals, "fake1")
+	c.Check(s.store.removedName, gc.Equals, "fake1")
+}
+
+func (s *UnregisterSuite) TestUnregisterCommandConfirmsOnY(c *gc.C) {
+	s.unregisterCommandConfirms(c, "y")
+}


### PR DESCRIPTION
`juju unregister <name>` will remove references to the controller
from the local store.

Fixes lp#1553059

QA Steps

  * bootstrap
  * add user
  * as another user
    - run `juju register` command from previous step
    -  verify controller shows up in `juju list-controllers`
    -  `juju unregister` the controller
    - verify the controller is no longer listed in `juju list-controllers`
    - verify that `juju switch` does not show the unregistered controller as the current controller;
      will show "ERROR no currently specified model"

(Review request: http://reviews.vapour.ws/r/4913/)