### PR TITLE
Limit that model names may only contain safe characters

### DIFF
--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -4,7 +4,6 @@
 package controller
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -16,11 +15,9 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/jujuclient"
 )
-
-// Lowercase letters, digits and (non-leading) hyphens, as per LP:1568944 #5.
-var validModelName = regexp.MustCompile(`^[a-z0-9]+[a-z0-9-]*$`)
 
 // NewAddModelCommand returns a command to add a model.
 func NewAddModelCommand() cmd.Command {
@@ -88,7 +85,7 @@ func (c *addModelCommand) Init(args []string) error {
 	}
 	c.Name, args = args[0], args[1:]
 
-	if !validModelName.MatchString(c.Name) {
+	if !config.IsValidModelName(c.Name) {
 		return errors.Errorf("%q is not a valid name: model names may only contain lowercase letters, digits and hyphens", c.Name)
 	}
 

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -85,7 +84,7 @@ func (c *addModelCommand) Init(args []string) error {
 	}
 	c.Name, args = args[0], args[1:]
 
-	if !config.IsValidModelName(c.Name) {
+	if !names.IsValidModelName(c.Name) {
 		return errors.Errorf("%q is not a valid name: model names may only contain lowercase letters, digits and hyphens", c.Name)
 	}
 

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -43,18 +43,20 @@ type addModelCommand struct {
 const addModelHelpDoc = `
 Adding a model is typically done in order to run a specific workload. The
 model is of the same cloud type as the controller and resides within that
-controller. By default, the controller is the current controller.
-The credentials used to add the model are the ones used to create any
-future resources within the model (` + "`juju deploy`, `juju add-unit`" + `).
+controller. By default, the controller is the current controller. The
+credentials used to add the model are the ones used to create any future
+resources within the model (` + "`juju deploy`, `juju add-unit`" + `).
+
 Model names can be duplicated across controllers but must be unique for
-any given controller.
-Model names may only contain lowercase letters, digits and hyphens.
+any given controller. Model names may only contain lowercase letters,
+digits and hyphens, and may not start with a hyphen.
+
 The necessary configuration must be available, either via the controller
 configuration (known to Juju upon its creation), command line arguments,
 or configuration file (--config). For 'ec2' and 'openstack' cloud types,
-the access and secret keys need to be provided.
-If the same configuration values are passed by both command line arguments
-and the --config option, the former take priority.
+the access and secret keys need to be provided. If the same configuration
+values are passed by both command line arguments and the --config option,
+the former take priority.
 
 Examples:
 

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -4,6 +4,7 @@
 package controller_test
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	"github.com/juju/cmd"
@@ -71,7 +72,7 @@ func (s *addSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
 }
 
 func (s *addSuite) TestInit(c *gc.C) {
-
+	modelNameErr := "%q is not a valid name: model names may only contain lowercase letters, digits and hyphens"
 	for i, test := range []struct {
 		args   []string
 		err    string
@@ -84,6 +85,21 @@ func (s *addSuite) TestInit(c *gc.C) {
 		}, {
 			args: []string{"new-model"},
 			name: "new-model",
+		}, {
+			args: []string{"n"},
+			name: "n",
+		}, {
+			args: []string{"new model"},
+			err:  fmt.Sprintf(modelNameErr, "new model"),
+		}, {
+			args: []string{"newModel"},
+			err:  fmt.Sprintf(modelNameErr, "newModel"),
+		}, {
+			args: []string{"-"},
+			err:  fmt.Sprintf(modelNameErr, "-"),
+		}, {
+			args: []string{"new@model"},
+			err:  fmt.Sprintf(modelNameErr, "new@model"),
 		}, {
 			args:  []string{"new-model", "--owner", "foo"},
 			name:  "new-model",

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -26,7 +26,7 @@ github.com/juju/httprequest	git	796aaafaf712f666df58d31a482c51233038bf9f	2016-05
 github.com/juju/idmclient	git	1995850da11150fb9247e43c6089e54eaeaae44a	2016-04-01T13:35:05Z
 github.com/juju/loggo	git	8477fc936adf0e382d680310047ca27e128a309a	2015-05-27T03:58:39Z
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z
-github.com/juju/names	git	de32cd839a952c8a04a52b38c12edefa34557014	2016-05-27T13:57:27Z
+github.com/juju/names	git	8624c3313100108a2e3037f81abf55de9f90a75e	2016-06-01T09:39:46Z
 github.com/juju/persistent-cookiejar	git	e710b897c13ca52828ca2fc9769465186fd6d15c	2016-03-31T17:12:27Z
 github.com/juju/ratelimit	git	aa5bb718d4d435629821789cb90970319f57bfe5	2015-03-30T01:41:32Z
 github.com/juju/replicaset	git	fb7294cf57a1e2f08a57691f1246d129a87ab7e8	2015-05-08T02:21:43Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -26,7 +26,7 @@ github.com/juju/httprequest	git	796aaafaf712f666df58d31a482c51233038bf9f	2016-05
 github.com/juju/idmclient	git	1995850da11150fb9247e43c6089e54eaeaae44a	2016-04-01T13:35:05Z
 github.com/juju/loggo	git	8477fc936adf0e382d680310047ca27e128a309a	2015-05-27T03:58:39Z
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z
-github.com/juju/names	git	bf96ae6a2948d5180f42021af8684c0c884b2e98	2016-05-23T20:39:41Z
+github.com/juju/names	git	de32cd839a952c8a04a52b38c12edefa34557014	2016-05-27T13:57:27Z
 github.com/juju/persistent-cookiejar	git	e710b897c13ca52828ca2fc9769465186fd6d15c	2016-03-31T17:12:27Z
 github.com/juju/ratelimit	git	aa5bb718d4d435629821789cb90970319f57bfe5	2015-03-30T01:41:32Z
 github.com/juju/replicaset	git	fb7294cf57a1e2f08a57691f1246d129a87ab7e8	2015-05-08T02:21:43Z

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -9,12 +9,12 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/names"
 	"github.com/juju/schema"
 	"github.com/juju/utils"
 	"github.com/juju/utils/proxy"
@@ -540,13 +540,6 @@ func (e *InvalidConfigValueError) Error() string {
 	return msg
 }
 
-// Lowercase letters, digits and (non-leading) hyphens, as per LP:1568944 #5.
-var validModelName = regexp.MustCompile(`^[a-z0-9]+[a-z0-9-]*$`)
-
-func IsValidModelName(name string) bool {
-	return validModelName.MatchString(name)
-}
-
 // Validate ensures that config is a valid configuration.  If old is not nil,
 // it holds the previous environment configuration for consideration when
 // validating changes.
@@ -575,7 +568,7 @@ func Validate(cfg, old *Config) error {
 		}
 	}
 
-	if !IsValidModelName(cfg.mustString(NameKey)) {
+	if !names.IsValidModelName(cfg.mustString(NameKey)) {
 		return fmt.Errorf("%q is not a valid name: model names may only contain lowercase letters, digits and hyphens", NameKey)
 	}
 

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -539,6 +540,13 @@ func (e *InvalidConfigValueError) Error() string {
 	return msg
 }
 
+// Lowercase letters, digits and (non-leading) hyphens, as per LP:1568944 #5.
+var validModelName = regexp.MustCompile(`^[a-z0-9]+[a-z0-9-]*$`)
+
+func IsValidModelName(name string) bool {
+	return validModelName.MatchString(name)
+}
+
 // Validate ensures that config is a valid configuration.  If old is not nil,
 // it holds the previous environment configuration for consideration when
 // validating changes.
@@ -567,8 +575,8 @@ func Validate(cfg, old *Config) error {
 		}
 	}
 
-	if strings.ContainsAny(cfg.mustString(NameKey), "/\\") {
-		return fmt.Errorf("model name contains unsafe characters")
+	if !IsValidModelName(cfg.mustString(NameKey)) {
+		return fmt.Errorf("%q is not a valid name: model names may only contain lowercase letters, digits and hyphens", NameKey)
 	}
 
 	// Check that the agent version parses ok if set explicitly; otherwise leave

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -439,28 +439,28 @@ var configTests = []configTest{
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"name": "foo/bar",
 		}),
-		err:  fmt.Sprintf(modelNameErr, "name"),
+		err: fmt.Sprintf(modelNameErr, "name"),
 	}, {
 		about:       "Bad name, no backslash",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"name": "foo\\bar",
 		}),
-		err:  fmt.Sprintf(modelNameErr, "name"),
+		err: fmt.Sprintf(modelNameErr, "name"),
 	}, {
 		about:       "Bad name, no space",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"name": "foo bar",
 		}),
-		err:  fmt.Sprintf(modelNameErr, "name"),
+		err: fmt.Sprintf(modelNameErr, "name"),
 	}, {
 		about:       "Bad name, no capital",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"name": "fooBar",
 		}),
-		err:  fmt.Sprintf(modelNameErr, "name"),
+		err: fmt.Sprintf(modelNameErr, "name"),
 	}, {
 		about:       "Empty name",
 		useDefaults: config.UseDefaults,

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -88,6 +88,8 @@ var minimalConfigAttrs = testing.Attrs{
 	"controller-uuid": testing.ModelTag.Id(),
 }
 
+var modelNameErr = "%q is not a valid name: model names may only contain lowercase letters, digits and hyphens"
+
 var configTests = []configTest{
 	{
 		about:       "The minimum good configuration",
@@ -437,14 +439,28 @@ var configTests = []configTest{
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"name": "foo/bar",
 		}),
-		err: "model name contains unsafe characters",
+		err:  fmt.Sprintf(modelNameErr, "name"),
 	}, {
 		about:       "Bad name, no backslash",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"name": "foo\\bar",
 		}),
-		err: "model name contains unsafe characters",
+		err:  fmt.Sprintf(modelNameErr, "name"),
+	}, {
+		about:       "Bad name, no space",
+		useDefaults: config.UseDefaults,
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
+			"name": "foo bar",
+		}),
+		err:  fmt.Sprintf(modelNameErr, "name"),
+	}, {
+		about:       "Bad name, no capital",
+		useDefaults: config.UseDefaults,
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
+			"name": "fooBar",
+		}),
+		err:  fmt.Sprintf(modelNameErr, "name"),
 	}, {
 		about:       "Empty name",
 		useDefaults: config.UseDefaults,

--- a/featuretests/api_undertaker_test.go
+++ b/featuretests/api_undertaker_test.go
@@ -101,8 +101,8 @@ func (s *undertakerSuite) TestHostedEnvironInfo(c *gc.C) {
 	c.Assert(result.Error, gc.IsNil)
 	envInfo := result.Result
 	c.Assert(envInfo.UUID, gc.Equals, otherSt.ModelUUID())
-	c.Assert(envInfo.Name, gc.Equals, "hosted_env")
-	c.Assert(envInfo.GlobalName, gc.Equals, "user-admin@local/hosted_env")
+	c.Assert(envInfo.Name, gc.Equals, "hosted-env")
+	c.Assert(envInfo.GlobalName, gc.Equals, "user-admin@local/hosted-env")
 	c.Assert(envInfo.IsSystem, jc.IsFalse)
 	c.Assert(envInfo.Life, gc.Equals, params.Alive)
 }
@@ -167,7 +167,7 @@ func (s *undertakerSuite) TestHostedRemoveEnviron(c *gc.C) {
 }
 
 func (s *undertakerSuite) hostedAPI(c *gc.C) (*undertaker.Client, *state.State) {
-	otherState := s.Factory.MakeModel(c, &factory.ModelParams{Name: "hosted_env"})
+	otherState := s.Factory.MakeModel(c, &factory.ModelParams{Name: "hosted-env"})
 
 	password, err := utils.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/joyent/joyent_test.go
+++ b/provider/joyent/joyent_test.go
@@ -72,7 +72,7 @@ func (s *providerSuite) TearDownTest(c *gc.C) {
 
 func GetFakeConfig(sdcUrl string) coretesting.Attrs {
 	return coretesting.FakeConfig().Merge(coretesting.Attrs{
-		"name":          "joyent test model",
+		"name":          "joyent-test-model",
 		"type":          "joyent",
 		"sdc-user":      testUser,
 		"sdc-key-id":    testKeyFingerprint,

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -124,7 +124,7 @@ func (s *providerSuite) TearDownSuite(c *gc.C) {
 }
 
 var maasEnvAttrs = coretesting.Attrs{
-	"name":            "test env",
+	"name":            "test-env",
 	"type":            "maas",
 	"maas-oauth":      "a:b:c",
 	"maas-agent-name": exampleAgentName,


### PR DESCRIPTION
Safe characters are lowercase letters, digits and hyphens.

Fixes lp#1568944

QA steps:

  * requires names as per juju/names/pull/66

  * attempt to `juju add-model` using model names including characters outside the definition of safe above

(Review request: http://reviews.vapour.ws/r/4914/)