### PR TITLE
Fixes lp:1574844: Skip IPv6 addresses when chosing preferred private|pub

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -23,7 +23,7 @@ func AddPreferredAddressesToMachines(st *State) error {
 	}
 
 	for _, machine := range machines {
-		if machine.Life() == Dead {
+		if machine.Life() != Alive {
 			continue
 		}
 		// Setting the addresses is enough to trigger setting the preferred


### PR DESCRIPTION
This is almost the simplest fix I managed to do (on the 3rd attempt) to
fix http://pad.lv/1574844. No major changes, except where necessary to
allow proper testing.

Live tested on LXD with deploying 20 ubuntu units.

(Review request: http://reviews.vapour.ws/r/4915/)