### PR TITLE
cmd/juju/commands: Fix SSH proxy command

### DIFF
--- a/cmd/juju/commands/ssh_common.go
+++ b/cmd/juju/commands/ssh_common.go
@@ -245,7 +245,7 @@ func (c *SSHCommon) setProxyCommand(options *ssh.Options) error {
 		"--proxy=false",
 		"--no-host-key-checks",
 		"--pty=false",
-		apiServerHost,
+		"ubuntu@"+apiServerHost,
 		"-q",
 		"nc %h %p",
 	)

--- a/cmd/juju/commands/ssh_common_test.go
+++ b/cmd/juju/commands/ssh_common_test.go
@@ -67,7 +67,7 @@ func (s *argsSpec) check(c *gc.C, output string) {
 
 	if s.withProxy {
 		expect("-o ProxyCommand juju ssh --proxy=false --no-host-key-checks " +
-			"--pty=false localhost -q \"nc %h %p\"")
+			"--pty=false ubuntu@localhost -q \"nc %h %p\"")
 	}
 	expect("-o PasswordAuthentication no -o ServerAliveInterval 30")
 	if s.enablePty {


### PR DESCRIPTION
In recent work, juju ssh was changed so that the "ubuntu" user was no longer assumed when an arbitrary machine address was supplied. This broke the ProxyCommand option when --proxy is passed, breaking SSH access to containers (for MAAS and when the "address-allocation" feature flag is enabled).

Fixes LP #1585388.

(Review request: http://reviews.vapour.ws/r/4916/)