### PR TITLE
state/multiwatcher: remove unused field from StatusInfo

### DIFF
--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -301,9 +301,6 @@ func (u *backingUnit) updated(st *State, store *multiwatcherStore, id string) er
 			Data:    normaliseStatusData(unitStatus.Data),
 			Since:   unitStatus.Since,
 		}
-		if u.Tools != nil {
-			info.JujuStatus.Version = u.Tools.Version.Number.String()
-		}
 		info.JujuStatus = multiwatcher.StatusInfo{
 			Current: status.Status(agentStatus.Status),
 			Message: agentStatus.Message,

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -146,7 +146,6 @@ type StatusInfo struct {
 	Current status.Status
 	Message string
 	Since   *time.Time
-	Version string
 	Data    map[string]interface{}
 }
 


### PR DESCRIPTION
Remove StatusInfo.Version, it is only set in one place and never read.

(Review request: http://reviews.vapour.ws/r/4920/)