### PR TITLE
Fixes lp# 1514874: failures of valid credentials.

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -229,7 +229,7 @@ func (a *admin) checkCredsOfControllerMachine(req params.LoginRequest) (state.En
 	}
 	// The machine does exist in the controller model, but it
 	// doesn't manage models, so reject it.
-	return nil, errors.Trace(common.ErrBadCreds)
+	return nil, errors.Trace(common.ErrPerm)
 }
 
 func (a *admin) maintenanceInProgress() bool {

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -753,7 +753,7 @@ func (s *loginSuite) TestOtherEnvironmentWhenNotController(c *gc.C) {
 
 	err := st.Login(machine.Tag(), password, "nonce", nil)
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
-		Message: "invalid entity name or password",
+		Message: "permission denied",
 		Code:    "unauthorized access",
 	})
 }

--- a/apiserver/backup_test.go
+++ b/apiserver/backup_test.go
@@ -108,7 +108,7 @@ func (s *backupsSuite) TestAuthRequiresClientNotMachine(c *gc.C) {
 		url:      s.backupURL(c),
 		nonce:    "fake_nonce",
 	})
-	s.assertErrorResponse(c, resp, http.StatusUnauthorized, "invalid entity name or password")
+	s.assertErrorResponse(c, resp, http.StatusInternalServerError, "tag kind machine not valid")
 
 	// Now try a user login.
 	resp = s.authRequest(c, httpRequestParams{method: "POST", url: s.backupURL(c)})

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -139,7 +139,7 @@ func (s *charmsSuite) TestAuthRequiresUser(c *gc.C) {
 		url:      s.charmsURI(c, ""),
 		nonce:    "fake_nonce",
 	})
-	s.assertErrorResponse(c, resp, http.StatusUnauthorized, "invalid entity name or password")
+	s.assertErrorResponse(c, resp, http.StatusInternalServerError, "tag kind machine not valid")
 
 	// Now try a user login.
 	resp = s.authRequest(c, httpRequestParams{method: "POST", url: s.charmsURI(c, "")})

--- a/apiserver/debuglog_test.go
+++ b/apiserver/debuglog_test.go
@@ -62,7 +62,7 @@ func (s *debugLogBaseSuite) TestAgentLoginsRejected(c *gc.C) {
 	defer conn.Close()
 	reader := bufio.NewReader(conn)
 
-	assertJSONError(c, reader, "invalid entity name or password")
+	assertJSONError(c, reader, "tag kind machine not valid")
 	s.assertWebsocketClosed(c, reader)
 }
 

--- a/apiserver/keymanager/keymanager_test.go
+++ b/apiserver/keymanager/keymanager_test.go
@@ -205,6 +205,7 @@ func (s *keyManagerSuite) TestAddJujuSystemKeyNotMachine(c *gc.C) {
 	}
 	_, err = s.keymanager.AddKeys(args)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
+	c.Assert(params.ErrCode(err), gc.Equals, params.CodeUnauthorized)
 	s.assertEnvironKeys(c, []string{key1})
 }
 

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -71,13 +71,13 @@ func (s *logsinkSuite) TestNoAuth(c *gc.C) {
 func (s *logsinkSuite) TestRejectsUserLogins(c *gc.C) {
 	user := s.Factory.MakeUser(c, &factory.UserParams{Password: "sekrit"})
 	header := utils.BasicAuthHeader(user.Tag().String(), "sekrit")
-	s.checkAuthFailsWithEntityError(c, header)
+	s.checkAuthFailsWithEntityError(c, header, "tag kind user not valid")
 }
 
 func (s *logsinkSuite) TestRejectsBadPassword(c *gc.C) {
 	header := utils.BasicAuthHeader(s.machineTag.String(), "wrong")
 	header.Add(params.MachineNonceHeader, s.nonce)
-	s.checkAuthFailsWithEntityError(c, header)
+	s.checkAuthFailsWithEntityError(c, header, "invalid entity name or password")
 }
 
 func (s *logsinkSuite) TestRejectsIncorrectNonce(c *gc.C) {
@@ -86,8 +86,8 @@ func (s *logsinkSuite) TestRejectsIncorrectNonce(c *gc.C) {
 	s.checkAuthFails(c, header, "machine 0 not provisioned")
 }
 
-func (s *logsinkSuite) checkAuthFailsWithEntityError(c *gc.C, header http.Header) {
-	s.checkAuthFails(c, header, "invalid entity name or password")
+func (s *logsinkSuite) checkAuthFailsWithEntityError(c *gc.C, header http.Header, msg string) {
+	s.checkAuthFails(c, header, msg)
 }
 
 func (s *logsinkSuite) checkAuthFails(c *gc.C, header http.Header, message string) {


### PR DESCRIPTION
Failure to authorise is not the same as failure to authenticate.
Changed some BadCreds instances to ErrPerm and updated relevant tests.

(Review request: http://reviews.vapour.ws/r/4921/)