### PR TITLE
Add cloud/region to controller details

### DIFF
--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -25,7 +25,7 @@ var _ = gc.Suite(&ListControllersSuite{})
 
 func (s *ListControllersSuite) TestListControllersEmptyStore(c *gc.C) {
 	s.expectedOutput = `
-CONTROLLER  MODEL  USER  SERVER
+CONTROLLER  MODEL  USER  CLOUD/REGION
 
 `[1:]
 
@@ -35,10 +35,10 @@ CONTROLLER  MODEL  USER  SERVER
 
 func (s *ListControllersSuite) TestListControllers(c *gc.C) {
 	s.expectedOutput = `
-CONTROLLER                 MODEL     USER         SERVER
-local.aws-test             -         -            this-is-aws-test-of-many-api-endpoints
-local.mallards*            my-model  admin@local  this-is-another-of-many-api-endpoints
-local.mark-test-prodstack  -         -            this-is-one-of-many-api-endpoints
+CONTROLLER                 MODEL     USER         CLOUD/REGION
+local.aws-test             -         -            aws/us-east-1
+local.mallards*            my-model  admin@local  mallards/mallards1
+local.mark-test-prodstack  -         -            prodstack
 
 `[1:]
 
@@ -54,6 +54,8 @@ controllers:
     uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
     ca-cert: this-is-aws-test-ca-cert
+    cloud: aws
+    region: us-east-1
   local.mallards:
     current-model: my-model
     user: admin@local
@@ -61,11 +63,14 @@ controllers:
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
+    cloud: mallards
+    region: mallards1
   local.mark-test-prodstack:
     recent-server: this-is-one-of-many-api-endpoints
     uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
     ca-cert: this-is-a-ca-cert
+    cloud: prodstack
 current-controller: local.mallards
 `[1:]
 
@@ -87,6 +92,8 @@ func (s *ListControllersSuite) TestListControllersJson(c *gc.C) {
 				Server:         "this-is-aws-test-of-many-api-endpoints",
 				APIEndpoints:   []string{"this-is-aws-test-of-many-api-endpoints"},
 				CACert:         "this-is-aws-test-ca-cert",
+				Cloud:          "aws",
+				CloudRegion:    "us-east-1",
 			},
 			"local.mallards": {
 				ControllerUUID: "this-is-another-uuid",
@@ -95,12 +102,15 @@ func (s *ListControllersSuite) TestListControllersJson(c *gc.C) {
 				Server:         "this-is-another-of-many-api-endpoints",
 				APIEndpoints:   []string{"this-is-another-of-many-api-endpoints", "this-is-one-more-of-many-api-endpoints"},
 				CACert:         "this-is-another-ca-cert",
+				Cloud:          "mallards",
+				CloudRegion:    "mallards1",
 			},
 			"local.mark-test-prodstack": {
 				ControllerUUID: "this-is-a-uuid",
 				Server:         "this-is-one-of-many-api-endpoints",
 				APIEndpoints:   []string{"this-is-one-of-many-api-endpoints"},
 				CACert:         "this-is-a-ca-cert",
+				Cloud:          "prodstack",
 			},
 		},
 		CurrentController: "local.mallards",

--- a/cmd/juju/controller/listcontrollersconverters.go
+++ b/cmd/juju/controller/listcontrollersconverters.go
@@ -26,6 +26,8 @@ type ControllerItem struct {
 	ControllerUUID string   `yaml:"uuid" json:"uuid"`
 	APIEndpoints   []string `yaml:"api-endpoints,flow" json:"api-endpoints"`
 	CACert         string   `yaml:"ca-cert" json:"ca-cert"`
+	Cloud          string   `yaml:"cloud" json:"cloud"`
+	CloudRegion    string   `yaml:"region,omitempty" json:"region,omitempty"`
 }
 
 // convertControllerDetails takes a map of Controllers and
@@ -83,6 +85,8 @@ func (c *listControllersCommand) convertControllerDetails(storeControllers map[s
 			APIEndpoints:   details.APIEndpoints,
 			ControllerUUID: details.ControllerUUID,
 			CACert:         details.CACert,
+			Cloud:          details.Cloud,
+			CloudRegion:    details.CloudRegion,
 		}
 	}
 	return controllers, errs

--- a/cmd/juju/controller/listcontrollersformatters.go
+++ b/cmd/juju/controller/listcontrollersformatters.go
@@ -41,7 +41,7 @@ func formatControllersTabular(set ControllerSet) ([]byte, error) {
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
 	}
 
-	print("CONTROLLER", "MODEL", "USER", "SERVER")
+	print("CONTROLLER", "MODEL", "USER", "CLOUD/REGION")
 
 	names := []string{}
 	for name, _ := range set.Controllers {
@@ -62,7 +62,11 @@ func formatControllersTabular(set ControllerSet) ([]byte, error) {
 		if name == set.CurrentController {
 			name += "*"
 		}
-		print(name, modelName, userName, c.Server)
+		cloudRegion := c.Cloud
+		if c.CloudRegion != "" {
+			cloudRegion += "/" + c.CloudRegion
+		}
+		print(name, modelName, userName, cloudRegion)
 	}
 	tw.Flush()
 

--- a/cmd/juju/controller/package_test.go
+++ b/cmd/juju/controller/package_test.go
@@ -58,14 +58,19 @@ controllers:
     uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
     ca-cert: this-is-aws-test-ca-cert
+    cloud: aws
+    region: us-east-1
   local.mallards:
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
+    cloud: mallards
+    region: mallards1
   local.mark-test-prodstack:
     uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
     ca-cert: this-is-a-ca-cert
+    cloud: prodstack
 current-controller: local.mallards
 `
 

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -119,6 +119,12 @@ type ControllerDetails struct {
 
 	// CACert is a security certificate for this controller.
 	CACert string `yaml:"ca-cert" json:"ca-cert"`
+
+	// Cloud is the name of the cloud that this controller runs in.
+	Cloud string `yaml:"cloud" json:"cloud"`
+
+	// CloudRegion is the name of the cloud region that this controller runs in.
+	CloudRegion string `yaml:"region,omitempty" json:"region,omitempty"`
 }
 
 // ModelDetails holds details of a model to show.
@@ -159,6 +165,8 @@ func (c *showControllerCommand) convertControllerForShow(controllerName string, 
 			ControllerUUID: details.ControllerUUID,
 			APIEndpoints:   details.APIEndpoints,
 			CACert:         details.CACert,
+			Cloud:          details.Cloud,
+			CloudRegion:    details.CloudRegion,
 		},
 	}
 	c.convertAccountsForShow(controllerName, &controller)

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -29,6 +29,7 @@ func (s *ShowControllerSuite) TestShowOneControllerOneInStore(c *gc.C) {
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
+    cloud: mallards
 `
 	s.createTestClientStore(c)
 
@@ -38,6 +39,7 @@ local.mallards:
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
+    cloud: mallards
   accounts:
     admin@local:
       user: admin@local
@@ -63,6 +65,7 @@ func (s *ShowControllerSuite) TestShowControllerWithPasswords(c *gc.C) {
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
+    cloud: mallards
 `
 	s.createTestClientStore(c)
 
@@ -72,6 +75,7 @@ local.mallards:
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
+    cloud: mallards
   accounts:
     admin@local:
       user: admin@local
@@ -99,6 +103,8 @@ func (s *ShowControllerSuite) TestShowControllerWithBootstrapConfig(c *gc.C) {
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
+    cloud: mallards
+    region: mallards1
 `
 	store := s.createTestClientStore(c)
 	store.BootstrapConfig["local.mallards"] = jujuclient.BootstrapConfig{
@@ -119,6 +125,8 @@ local.mallards:
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
+    cloud: mallards
+    region: mallards1
   accounts:
     admin@local:
       user: admin@local
@@ -155,6 +163,8 @@ local.aws-test:
     uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
     ca-cert: this-is-aws-test-ca-cert
+    cloud: aws
+    region: us-east-1
   accounts:
     admin@local:
       user: admin@local
@@ -174,6 +184,8 @@ local.aws-test:
     uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
     ca-cert: this-is-aws-test-ca-cert
+    cloud: aws
+    region: us-east-1
   accounts:
     admin@local:
       user: admin@local
@@ -186,6 +198,7 @@ local.mark-test-prodstack:
     uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
     ca-cert: this-is-a-ca-cert
+    cloud: prodstack
   accounts:
     admin@local:
       user: admin@local
@@ -198,7 +211,7 @@ func (s *ShowControllerSuite) TestShowControllerJsonOne(c *gc.C) {
 	s.createTestClientStore(c)
 
 	s.expectedOutput = `
-{"local.aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}}}
+{"local.aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}}}
 `[1:]
 
 	s.assertShowController(c, "--format", "json", "local.aws-test")
@@ -207,7 +220,7 @@ func (s *ShowControllerSuite) TestShowControllerJsonOne(c *gc.C) {
 func (s *ShowControllerSuite) TestShowControllerJsonMany(c *gc.C) {
 	s.createTestClientStore(c)
 	s.expectedOutput = `
-{"local.aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}},"local.mark-test-prodstack":{"details":{"uuid":"this-is-a-uuid","api-endpoints":["this-is-one-of-many-api-endpoints"],"ca-cert":"this-is-a-ca-cert"},"accounts":{"admin@local":{"user":"admin@local"}}}}
+{"local.aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}},"local.mark-test-prodstack":{"details":{"uuid":"this-is-a-uuid","api-endpoints":["this-is-one-of-many-api-endpoints"],"ca-cert":"this-is-a-ca-cert","cloud":"prodstack"},"accounts":{"admin@local":{"user":"admin@local"}}}}
 `[1:]
 	s.assertShowController(c, "--format", "json", "local.aws-test", "local.mark-test-prodstack")
 }
@@ -229,7 +242,7 @@ func (s *ShowControllerSuite) TestShowControllerNoArgs(c *gc.C) {
 	store := s.createTestClientStore(c)
 
 	s.expectedOutput = `
-{"local.aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}}}
+{"local.aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}}}
 `[1:]
 	store.CurrentControllerName = "local.aws-test"
 	s.assertShowController(c, "--format", "json")

--- a/environs/open.go
+++ b/environs/open.go
@@ -103,8 +103,6 @@ func Prepare(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	details.Cloud = args.CloudName
-	details.Credential = args.CredentialName
 
 	if err := decorateAndWriteInfo(
 		store, details, args.ControllerName, env.Config().Name(),
@@ -191,9 +189,13 @@ func prepare(
 	details.User = AdminUser
 	details.Password = adminSecret
 	details.ModelUUID = cfg.UUID()
-	details.CloudRegion = args.CloudRegion
+	details.ControllerDetails.Cloud = args.CloudName
+	details.ControllerDetails.CloudRegion = args.CloudRegion
+	details.BootstrapConfig.Cloud = args.CloudName
+	details.BootstrapConfig.CloudRegion = args.CloudRegion
 	details.CloudEndpoint = args.CloudEndpoint
 	details.CloudStorageEndpoint = args.CloudStorageEndpoint
+	details.Credential = args.CredentialName
 
 	return env, details, nil
 }

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -165,6 +165,7 @@ func (*OpenSuite) TestPrepare(c *gc.C) {
 	foundController, err := controllerStore.ControllerByName(cfg.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(foundController.ControllerUUID, gc.DeepEquals, cfg.UUID())
+	c.Assert(foundController.Cloud, gc.Equals, "dummy")
 
 	// Check we cannot call Prepare again.
 	env, err = environs.Prepare(ctx, controllerStore, environs.PrepareParams{

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -67,11 +67,11 @@ func (s *cmdControllerSuite) createModelNormalUser(c *gc.C, modelname string, is
 
 func (s *cmdControllerSuite) TestControllerListCommand(c *gc.C) {
 	context := s.run(c, "list-controllers")
-	expectedOutput := fmt.Sprintf(`
-CONTROLLER  MODEL  USER         SERVER
-kontroll*   admin  admin@local  %s
+	expectedOutput := `
+CONTROLLER  MODEL  USER         CLOUD/REGION
+kontroll*   admin  admin@local  dummy
 
-`[1:], s.APIState.Addr())
+`[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expectedOutput)
 }
 

--- a/jujuclient/controllers_test.go
+++ b/jujuclient/controllers_test.go
@@ -31,6 +31,8 @@ func (s *ControllersSuite) SetUpTest(c *gc.C) {
 		"test.uuid",
 		[]string{"test.api.endpoint"},
 		"test.ca.cert",
+		"aws",
+		"southeastasia",
 	}
 }
 

--- a/jujuclient/controllersfile_test.go
+++ b/jujuclient/controllersfile_test.go
@@ -27,16 +27,20 @@ controllers:
     uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
     ca-cert: this-is-aws-test-ca-cert
+    cloud: aws
+    region: us-east-1
   local.mallards:
     unresolved-api-endpoints: [maas-1-05.cluster.mallards]
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
+    cloud: mallards
   local.mark-test-prodstack:
     unresolved-api-endpoints: [vm-23532.prodstack.canonical.com, great.test.server.hostname.co.nz]
     uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
     ca-cert: this-is-a-ca-cert
+    cloud: prodstack
 current-controller: local.mallards
 `
 

--- a/jujuclient/controllervalidation_test.go
+++ b/jujuclient/controllervalidation_test.go
@@ -22,6 +22,8 @@ func (s *ControllerValidationSuite) SetUpTest(c *gc.C) {
 		"test.uuid",
 		[]string{"test.api.endpoint"},
 		"test.ca.cert",
+		"aws",
+		"southeastasia",
 	}
 }
 

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -24,6 +24,13 @@ type ControllerDetails struct {
 
 	// CACert is a security certificate for this controller.
 	CACert string `yaml:"ca-cert"`
+
+	// Cloud is the name of the cloud that this controller runs in.
+	Cloud string `yaml:"cloud"`
+
+	// CloudRegion is the name of the cloud region that this controller
+	// runs in. This will be empty for clouds without regions.
+	CloudRegion string `yaml:"region,omitempty"`
 }
 
 // ModelDetails holds details of a model.


### PR DESCRIPTION
Add the name of the cloud and region (if applicable)
to the controller details. This is included in the
output of list-controllers and show-controller, and
is stored in controllers.yaml. The existing "SERVER"
field in list-controllers tabular format is removed.

In a follow-up, we will store cloud and credential
information in the controller (i.e. in mongo), which
will enable us to display the same information for
"registered" controllers. For now, registered
controllers lack that information.

**QA**

1. Bootstrap (e.g. AWS)
2. Inspect output of "juju list-controllers", with
   and without --format=yaml.
3. Inspect output of "juju show-controller <controller>"
4. Repeat with "localhost" (lxd), or some other cloud
   without regions.

(Review request: http://reviews.vapour.ws/r/4922/)