### PR TITLE
Better way of removing the leading \n\n in the front of the UserDataScript

### DIFF
--- a/cloudconfig/providerinit/providerinit_test.go
+++ b/cloudconfig/providerinit/providerinit_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cloudconfig/providerinit"
-	"github.com/juju/juju/cloudconfig/providerinit/renderers"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/juju/paths"
@@ -392,10 +391,8 @@ func (s *CloudInitSuite) TestWindowsUserdataEncoding(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	base64Data := base64.StdEncoding.EncodeToString(utils.Gzip(data))
-	// first part
 	got := []byte(fmt.Sprintf(cloudconfig.UserDataScript, base64Data))
-	got = renderers.PrependWinPS1Header(got)
 	expected, err := providerinit.ComposeUserData(&cfg, cicompose, openstack.OpenstackRenderer{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(expected), gc.Equals, string(got))
+	c.Assert(string(got), gc.Equals, string(expected))
 }

--- a/cloudconfig/providerinit/renderers/common.go
+++ b/cloudconfig/providerinit/renderers/common.go
@@ -25,22 +25,7 @@ func ToBase64(data []byte) []byte {
 func WinEmbedInScript(udata []byte) []byte {
 	encUserdata := ToBase64(utils.Gzip(udata))
 	// place the encUseData inside the "%s" marked sign
-	userDataScript := []byte(fmt.Sprintf(cloudconfig.UserDataScript, encUserdata))
-	// prepend the powershell script in a safe mode
-	return PrependWinPS1Header(userDataScript)
-}
-
-// PrependWinPS1Header appends in the begining the header "#ps1_sysnative\r\n"
-// for powershell scripts. In order to fix the cloudbase-init unsupported
-// format error, the powershell needs a custom header like this one, else
-// it will complain like in this bug.
-// https://bugs.launchpad.net/juju-core/+bug/1585430
-func PrependWinPS1Header(userDataScript []byte) []byte {
-	var wrapped []byte
-	header := "#ps1_sysnative\r\n"
-	wrapped = append(wrapped, header...)
-	wrapped = append(wrapped, userDataScript...)
-	return wrapped
+	return []byte(fmt.Sprintf(cloudconfig.UserDataScript, encUserdata))
 }
 
 // AddPowershellTags adds <powershell>...</powershell> to it's input

--- a/cloudconfig/providerinit/renderers/common_test.go
+++ b/cloudconfig/providerinit/renderers/common_test.go
@@ -33,20 +33,9 @@ func (s *RenderersSuite) TestToBase64(c *gc.C) {
 
 func (s *RenderersSuite) TestWinEmbedInScript(c *gc.C) {
 	in := []byte("test")
+	out := string(renderers.WinEmbedInScript(in))
 	encUserdata := renderers.ToBase64(utils.Gzip(in))
-	var expected []byte
-	header := "#ps1_sysnative\r\n"
-	script := fmt.Sprintf(cloudconfig.UserDataScript, encUserdata)
-	expected = append(expected, header...)
-	expected = append(expected, script...)
-	out := renderers.WinEmbedInScript(in)
-	c.Assert(out, jc.DeepEquals, expected)
-}
-
-func (s *RenderersSuite) TestPrependWinPS1Header(c *gc.C) {
-	in := []byte("test")
-	expected := []byte("#ps1_sysnative\r\ntest")
-	out := renderers.PrependWinPS1Header(in)
+	expected := fmt.Sprintf(cloudconfig.UserDataScript, encUserdata)
 	c.Assert(out, jc.DeepEquals, expected)
 }
 

--- a/cloudconfig/windowsuserdatafiles/userdata.ps1
+++ b/cloudconfig/windowsuserdatafiles/userdata.ps1
@@ -1,3 +1,4 @@
+#ps1_sysnative
 $ErrorActionPreference = "Stop"
 $userdata=@"
 %s

--- a/cloudconfig/winuserdatawrapper.go
+++ b/cloudconfig/winuserdatawrapper.go
@@ -5,7 +5,7 @@ package cloudconfig
 
 // Generated code - do not edit.
 
-const UserDataScript = `
+const UserDataScript = `#ps1_sysnative
 $ErrorActionPreference = "Stop"
 $userdata=@"
 %s

--- a/generate/filetoconst/filetoconst.go
+++ b/generate/filetoconst/filetoconst.go
@@ -47,7 +47,7 @@ func main() {
 		CopyrightYear string
 		Pkgname       string
 	}
-	contextData := fmt.Sprintf("\n%s", string(data))
+	contextData := fmt.Sprintf("%s", string(data))
 	// Quote any ` in the data.
 	contextData = strings.Replace(contextData, "`", "`+\"`\"+`", -1)
 	t.Execute(&buf, content{


### PR DESCRIPTION
That was a bug back a few days and I managed to fix it quickly (in a hacky fashion) but from the comments on the review board, @dimitern , @babbageclunk,  was not so happy with my solution but now I found a better way to remove those '\n\n' chars in the powershell script without add more functions.

(Review request: http://reviews.vapour.ws/r/4924/)