### PR TITLE
Fix restore for newer mongo and juju versions

### DIFF
--- a/api/backups/download_test.go
+++ b/api/backups/download_test.go
@@ -27,7 +27,7 @@ func (s *downloadSuite) TestSuccessfulRequest(c *gc.C) {
 	backupsState := backups.NewBackups(store)
 
 	r := strings.NewReader("<compressed archive data>")
-	meta, err := backups.NewMetadataState(s.State, "0")
+	meta, err := backups.NewMetadataState(s.State, "0", "xenial")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(meta.CACert, gc.Equals, testing.CACert)
 	c.Assert(meta.CAPrivateKey, gc.Equals, testing.CAKey)

--- a/api/backups/restore.go
+++ b/api/backups/restore.go
@@ -23,7 +23,7 @@ var (
 	// the server is upgrading.
 	restoreStrategy = utils.AttemptStrategy{
 		Delay: 10 * time.Second,
-		Min:   10,
+		Min:   1,
 	}
 )
 

--- a/api/backups/upload.go
+++ b/api/backups/upload.go
@@ -29,7 +29,7 @@ func (c *Client) Upload(archive io.ReadSeeker, meta params.BackupsMetadataResult
 		return "", errors.Annotatef(err, "cannot create multipart body")
 	}
 	req.Header.Set("Content-Type", contentType)
-	var result params.BackupsMetadataResult
+	var result params.BackupsUploadResult
 	if err := c.client.Do(req, body, &result); err != nil {
 		return "", errors.Trace(err)
 	}

--- a/apiserver/backups/backups.go
+++ b/apiserver/backups/backups.go
@@ -8,36 +8,48 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/names"
+	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/backups"
 )
 
-func init() {
-	common.RegisterStandardFacade("Backups", 1, NewAPI)
-}
-
 var logger = loggo.GetLogger("juju.apiserver.backups")
+
+// Backend exposes state.State functionality needed by the backups Facade.
+type Backend interface {
+	IsController() bool
+	Machine(id string) (Machine, error)
+	MongoConnectionInfo() *mongo.MongoInfo
+	MongoSession() *mgo.Session
+	ModelTag() names.ModelTag
+	ModelConfig() (*config.Config, error)
+	StateServingInfo() (state.StateServingInfo, error)
+	RestoreInfo() *state.RestoreInfo
+}
 
 // API serves backup-specific API methods.
 type API struct {
-	st    *state.State
-	paths *backups.Paths
+	backend Backend
+	paths   *backups.Paths
 
 	// machineID is the ID of the machine where the API server is running.
 	machineID string
 }
 
 // NewAPI creates a new instance of the Backups API facade.
-func NewAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*API, error) {
+func NewAPI(backend Backend, resources *common.Resources, authorizer common.Authorizer) (*API, error) {
 	if !authorizer.AuthClient() {
 		return nil, errors.Trace(common.ErrPerm)
 	}
 
 	// For now, backup operations are only permitted on the controller environment.
-	if !st.IsController() {
+	if !backend.IsController() {
 		return nil, errors.New("backups are not supported for hosted models")
 	}
 
@@ -61,7 +73,7 @@ func NewAPI(st *state.State, resources *common.Resources, authorizer common.Auth
 		return nil, errors.Trace(err)
 	}
 	b := API{
-		st:        st,
+		backend:   backend,
 		paths:     &paths,
 		machineID: machineID,
 	}
@@ -81,8 +93,8 @@ func extractResourceValue(resources *common.Resources, key string) (string, erro
 	return strRes.String(), nil
 }
 
-var newBackups = func(st *state.State) (backups.Backups, io.Closer) {
-	stor := backups.NewStorage(st)
+var newBackups = func(backend Backend) (backups.Backups, io.Closer) {
+	stor := backups.NewStorage(backend)
 	return backups.NewBackups(stor), stor
 }
 

--- a/apiserver/backups/backups.go
+++ b/apiserver/backups/backups.go
@@ -24,7 +24,8 @@ var logger = loggo.GetLogger("juju.apiserver.backups")
 // Backend exposes state.State functionality needed by the backups Facade.
 type Backend interface {
 	IsController() bool
-	Machine(id string) (Machine, error)
+	Machine(id string) (*state.Machine, error)
+	MachineSeries(id string) (string, error)
 	MongoConnectionInfo() *mongo.MongoInfo
 	MongoSession() *mgo.Session
 	ModelTag() names.ModelTag

--- a/apiserver/backups/backups.go
+++ b/apiserver/backups/backups.go
@@ -110,6 +110,7 @@ func ResultFromMetadata(meta *backups.Metadata) params.BackupsMetadataResult {
 	result.Machine = meta.Origin.Machine
 	result.Hostname = meta.Origin.Hostname
 	result.Version = meta.Origin.Version
+	result.Series = meta.Origin.Series
 
 	// TODO(wallyworld) - remove these ASAP
 	// These are only used by the restore CLI when re-bootstrapping.
@@ -136,6 +137,7 @@ func MetadataFromResult(result params.BackupsMetadataResult) *backups.Metadata {
 	meta.Origin.Machine = result.Machine
 	meta.Origin.Hostname = result.Hostname
 	meta.Origin.Version = result.Version
+	meta.Origin.Series = result.Series
 	meta.Notes = result.Notes
 	meta.SetFileInfo(result.Size, result.Checksum, result.ChecksumFormat)
 	return meta

--- a/apiserver/backups/backups_test.go
+++ b/apiserver/backups/backups_test.go
@@ -11,17 +11,11 @@ import (
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/mgo.v2"
 
 	backupsAPI "github.com/juju/juju/apiserver/backups"
 	"github.com/juju/juju/apiserver/common"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/mongo"
-	"github.com/juju/juju/network"
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/backups"
 	backupstesting "github.com/juju/juju/state/backups/testing"
 	"github.com/juju/juju/testing/factory"
@@ -89,68 +83,4 @@ func (s *backupsSuite) TestNewAPIHostedEnvironmentFails(c *gc.C) {
 	defer otherState.Close()
 	_, err := backupsAPI.NewAPI(&stateShim{otherState}, s.resources, s.authorizer)
 	c.Check(err, gc.ErrorMatches, "backups are not supported for hosted models")
-}
-
-type stateShim struct {
-	st *state.State
-}
-
-type machine struct {
-	m *state.Machine
-}
-
-func (m *machine) PublicAddress() (network.Address, error) {
-	return m.PublicAddress()
-}
-
-func (m *machine) PrivateAddress() (network.Address, error) {
-	return m.PrivateAddress()
-}
-
-func (m *machine) InstanceId() (instance.Id, error) {
-	return m.InstanceId()
-}
-
-func (m *machine) Tag() names.Tag {
-	return m.Tag()
-}
-
-func (_ *machine) Series() string {
-	return "xenial"
-}
-
-func (s *stateShim) IsController() bool {
-	return s.st.IsController()
-}
-
-func (s *stateShim) MongoSession() *mgo.Session {
-	return s.st.MongoSession()
-}
-
-func (s *stateShim) MongoConnectionInfo() *mongo.MongoInfo {
-	return s.st.MongoConnectionInfo()
-}
-
-func (s *stateShim) ModelTag() names.ModelTag {
-	return s.st.ModelTag()
-}
-
-func (s *stateShim) Machine(id string) (backupsAPI.Machine, error) {
-	m, err := s.st.Machine(id)
-	if err != nil && !errors.IsNotFound(err) {
-		return m, err
-	}
-	return &machine{m}, nil
-}
-
-func (s *stateShim) ModelConfig() (*config.Config, error) {
-	return s.st.ModelConfig()
-}
-
-func (s *stateShim) StateServingInfo() (state.StateServingInfo, error) {
-	return s.st.StateServingInfo()
-}
-
-func (s *stateShim) RestoreInfo() *state.RestoreInfo {
-	return s.st.RestoreInfo()
 }

--- a/apiserver/backups/backups_test.go
+++ b/apiserver/backups/backups_test.go
@@ -11,11 +11,16 @@ import (
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
 
 	backupsAPI "github.com/juju/juju/apiserver/backups"
 	"github.com/juju/juju/apiserver/common"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/backups"
 	backupstesting "github.com/juju/juju/state/backups/testing"
@@ -39,7 +44,7 @@ func (s *backupsSuite) SetUpTest(c *gc.C) {
 	tag := names.NewLocalUserTag("spam")
 	s.authorizer = &apiservertesting.FakeAuthorizer{Tag: tag}
 	var err error
-	s.api, err = backupsAPI.NewAPI(s.State, s.resources, s.authorizer)
+	s.api, err = backupsAPI.NewAPI(&stateShim{s.State}, s.resources, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 	s.meta = backupstesting.NewMetadataStarted()
 }
@@ -55,7 +60,7 @@ func (s *backupsSuite) setBackups(c *gc.C, meta *backups.Metadata, err string) *
 		fake.Error = errors.Errorf(err)
 	}
 	s.PatchValue(backupsAPI.NewBackups,
-		func(*state.State) (backups.Backups, io.Closer) {
+		func(backupsAPI.Backend) (backups.Backups, io.Closer) {
 			return &fake, ioutil.NopCloser(nil)
 		},
 	)
@@ -68,13 +73,13 @@ func (s *backupsSuite) TestRegistered(c *gc.C) {
 }
 
 func (s *backupsSuite) TestNewAPIOkay(c *gc.C) {
-	_, err := backupsAPI.NewAPI(s.State, s.resources, s.authorizer)
+	_, err := backupsAPI.NewAPI(&stateShim{s.State}, s.resources, s.authorizer)
 	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *backupsSuite) TestNewAPINotAuthorized(c *gc.C) {
 	s.authorizer.Tag = names.NewServiceTag("eggs")
-	_, err := backupsAPI.NewAPI(s.State, s.resources, s.authorizer)
+	_, err := backupsAPI.NewAPI(&stateShim{s.State}, s.resources, s.authorizer)
 
 	c.Check(errors.Cause(err), gc.Equals, common.ErrPerm)
 }
@@ -82,6 +87,70 @@ func (s *backupsSuite) TestNewAPINotAuthorized(c *gc.C) {
 func (s *backupsSuite) TestNewAPIHostedEnvironmentFails(c *gc.C) {
 	otherState := factory.NewFactory(s.State).MakeModel(c, nil)
 	defer otherState.Close()
-	_, err := backupsAPI.NewAPI(otherState, s.resources, s.authorizer)
+	_, err := backupsAPI.NewAPI(&stateShim{otherState}, s.resources, s.authorizer)
 	c.Check(err, gc.ErrorMatches, "backups are not supported for hosted models")
+}
+
+type stateShim struct {
+	st *state.State
+}
+
+type machine struct {
+	m *state.Machine
+}
+
+func (m *machine) PublicAddress() (network.Address, error) {
+	return m.PublicAddress()
+}
+
+func (m *machine) PrivateAddress() (network.Address, error) {
+	return m.PrivateAddress()
+}
+
+func (m *machine) InstanceId() (instance.Id, error) {
+	return m.InstanceId()
+}
+
+func (m *machine) Tag() names.Tag {
+	return m.Tag()
+}
+
+func (_ *machine) Series() string {
+	return "xenial"
+}
+
+func (s *stateShim) IsController() bool {
+	return s.st.IsController()
+}
+
+func (s *stateShim) MongoSession() *mgo.Session {
+	return s.st.MongoSession()
+}
+
+func (s *stateShim) MongoConnectionInfo() *mongo.MongoInfo {
+	return s.st.MongoConnectionInfo()
+}
+
+func (s *stateShim) ModelTag() names.ModelTag {
+	return s.st.ModelTag()
+}
+
+func (s *stateShim) Machine(id string) (backupsAPI.Machine, error) {
+	m, err := s.st.Machine(id)
+	if err != nil && !errors.IsNotFound(err) {
+		return m, err
+	}
+	return &machine{m}, nil
+}
+
+func (s *stateShim) ModelConfig() (*config.Config, error) {
+	return s.st.ModelConfig()
+}
+
+func (s *stateShim) StateServingInfo() (state.StateServingInfo, error) {
+	return s.st.StateServingInfo()
+}
+
+func (s *stateShim) RestoreInfo() *state.RestoreInfo {
+	return s.st.RestoreInfo()
 }

--- a/apiserver/backups/create.go
+++ b/apiserver/backups/create.go
@@ -33,12 +33,12 @@ func (a *API) Create(args params.BackupsCreateArgs) (p params.BackupsMetadataRes
 	if err != nil {
 		return p, errors.Trace(err)
 	}
-	m, err := a.backend.Machine(a.machineID)
+	mSeries, err := a.backend.MachineSeries(a.machineID)
 	if err != nil {
 		return p, errors.Trace(err)
 	}
 
-	meta, err := backups.NewMetadataState(a.backend, a.machineID, m.Series())
+	meta, err := backups.NewMetadataState(a.backend, a.machineID, mSeries)
 	if err != nil {
 		return p, errors.Trace(err)
 	}

--- a/apiserver/backups/create.go
+++ b/apiserver/backups/create.go
@@ -8,33 +8,18 @@ import (
 	"github.com/juju/replicaset"
 
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/backups"
 )
 
 var waitUntilReady = replicaset.WaitUntilReady
 
-type Machine interface {
-	Series() string
-}
-
-func machine(st *state.State, ID string) (Machine, error) {
-	m, err := st.Machine(ID)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return m, nil
-}
-
-var getMachine = machine
-
 // Create is the API method that requests juju to create a new backup
 // of its state.  It returns the metadata for that backup.
 func (a *API) Create(args params.BackupsCreateArgs) (p params.BackupsMetadataResult, err error) {
-	backupsMethods, closer := newBackups(a.st)
+	backupsMethods, closer := newBackups(a.backend)
 	defer closer.Close()
 
-	session := a.st.MongoSession().Copy()
+	session := a.backend.MongoSession().Copy()
 	defer session.Close()
 
 	// Don't go if HA isn't ready.
@@ -43,17 +28,17 @@ func (a *API) Create(args params.BackupsCreateArgs) (p params.BackupsMetadataRes
 		return p, errors.Annotatef(err, "HA not ready; try again later")
 	}
 
-	mgoInfo := a.st.MongoConnectionInfo()
+	mgoInfo := a.backend.MongoConnectionInfo()
 	dbInfo, err := backups.NewDBInfo(mgoInfo, session)
 	if err != nil {
 		return p, errors.Trace(err)
 	}
-	m, err := getMachine(a.st, a.machineID)
+	m, err := a.backend.Machine(a.machineID)
 	if err != nil {
 		return p, errors.Trace(err)
 	}
 
-	meta, err := backups.NewMetadataState(a.st, a.machineID, m.Series())
+	meta, err := backups.NewMetadataState(a.backend, a.machineID, m.Series())
 	if err != nil {
 		return p, errors.Trace(err)
 	}

--- a/apiserver/backups/create_test.go
+++ b/apiserver/backups/create_test.go
@@ -10,26 +10,12 @@ import (
 
 	"github.com/juju/juju/apiserver/backups"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/state"
 )
-
-type fakeMachine struct {
-}
-
-// Series implements backups.Machine
-func (_ *fakeMachine) Series() string {
-	return "xenial"
-}
-
-func fakeGetMachine(_ *state.State, _ string) (backups.Machine, error) {
-	return &fakeMachine{}, nil
-}
 
 func (s *backupsSuite) TestCreateOkay(c *gc.C) {
 	s.PatchValue(backups.WaitUntilReady,
 		func(*mgo.Session, int) error { return nil },
 	)
-	s.PatchValue(backups.GetMachine, fakeGetMachine)
 	s.setBackups(c, s.meta, "")
 	var args params.BackupsCreateArgs
 	result, err := s.api.Create(args)
@@ -43,7 +29,6 @@ func (s *backupsSuite) TestCreateNotes(c *gc.C) {
 	s.PatchValue(backups.WaitUntilReady,
 		func(*mgo.Session, int) error { return nil },
 	)
-	s.PatchValue(backups.GetMachine, fakeGetMachine)
 	s.meta.Notes = "this backup is important"
 	s.setBackups(c, s.meta, "")
 	args := params.BackupsCreateArgs{
@@ -62,7 +47,6 @@ func (s *backupsSuite) TestCreateError(c *gc.C) {
 	s.PatchValue(backups.WaitUntilReady,
 		func(*mgo.Session, int) error { return nil },
 	)
-	s.PatchValue(backups.GetMachine, fakeGetMachine)
 	var args params.BackupsCreateArgs
 	_, err := s.api.Create(args)
 

--- a/apiserver/backups/export_test.go
+++ b/apiserver/backups/export_test.go
@@ -6,5 +6,4 @@ package backups
 var (
 	NewBackups     = &newBackups
 	WaitUntilReady = &waitUntilReady
-	GetMachine     = &getMachine
 )

--- a/apiserver/backups/export_test.go
+++ b/apiserver/backups/export_test.go
@@ -6,4 +6,5 @@ package backups
 var (
 	NewBackups     = &newBackups
 	WaitUntilReady = &waitUntilReady
+	GetMachine     = &getMachine
 )

--- a/apiserver/backups/info.go
+++ b/apiserver/backups/info.go
@@ -11,7 +11,7 @@ import (
 
 // Info provides the implementation of the API method.
 func (a *API) Info(args params.BackupsInfoArgs) (params.BackupsMetadataResult, error) {
-	backups, closer := newBackups(a.st)
+	backups, closer := newBackups(a.backend)
 	defer closer.Close()
 
 	meta, file, err := backups.Get(args.ID)

--- a/apiserver/backups/list.go
+++ b/apiserver/backups/list.go
@@ -13,7 +13,7 @@ import (
 func (a *API) List(args params.BackupsListArgs) (params.BackupsListResult, error) {
 	var result params.BackupsListResult
 
-	backups, closer := newBackups(a.st)
+	backups, closer := newBackups(a.backend)
 	defer closer.Close()
 
 	metaList, err := backups.List()

--- a/apiserver/backups/mock_test.go
+++ b/apiserver/backups/mock_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backups_test
+
+import "github.com/juju/juju/state"
+
+type stateShim struct {
+	*state.State
+}
+
+func (s *stateShim) MachineSeries(id string) (string, error) {
+	return "xenial", nil
+}

--- a/apiserver/backups/remove.go
+++ b/apiserver/backups/remove.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (a *API) Remove(args params.BackupsRemoveArgs) error {
-	backups, closer := newBackups(a.st)
+	backups, closer := newBackups(a.backend)
 	defer closer.Close()
 
 	err := backups.Remove(args.ID)

--- a/apiserver/backups/restore.go
+++ b/apiserver/backups/restore.go
@@ -80,7 +80,7 @@ func (a *API) Restore(p params.RestoreArgs) error {
 	}
 
 	mgoInfo := a.backend.MongoConnectionInfo()
-	logger.Infof("mongo info from state %+v", mgoInfo)
+	logger.Debugf("mongo info from state %+v", mgoInfo)
 	dbInfo, err := backups.NewDBInfo(mgoInfo, session)
 	if err != nil {
 		return errors.Trace(err)

--- a/apiserver/backups/shim.go
+++ b/apiserver/backups/shim.go
@@ -4,14 +4,8 @@
 package backups
 
 import (
-	"github.com/juju/names"
-	"gopkg.in/mgo.v2"
-
+	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/instance"
-	"github.com/juju/juju/mongo"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 )
 
@@ -24,50 +18,17 @@ func init() {
 	common.RegisterStandardFacade("Backups", 1, newAPI)
 }
 
-// Machine represents a state.Machine, it is used to break dependency
-// to state.
-type Machine interface {
-	Series() string
-	PublicAddress() (network.Address, error)
-	PrivateAddress() (network.Address, error)
-	InstanceId() (instance.Id, error)
-	Tag() names.Tag
-}
-
 type stateShim struct {
-	st *state.State
+	*state.State
 }
 
-func (s *stateShim) IsController() bool {
-	return s.st.IsController()
-}
-
-func (s *stateShim) MongoSession() *mgo.Session {
-	return s.st.MongoSession()
-}
-
-func (s *stateShim) MongoConnectionInfo() *mongo.MongoInfo {
-	return s.st.MongoConnectionInfo()
-}
-
-func (s *stateShim) ModelTag() names.ModelTag {
-	return s.st.ModelTag()
-}
-
-func (s *stateShim) Machine(id string) (Machine, error) {
-	return s.st.Machine(id)
-}
-
-func (s *stateShim) ModelConfig() (*config.Config, error) {
-	return s.st.ModelConfig()
-}
-
-func (s *stateShim) StateServingInfo() (state.StateServingInfo, error) {
-	return s.st.StateServingInfo()
-}
-
-func (s *stateShim) RestoreInfo() *state.RestoreInfo {
-	return s.st.RestoreInfo()
+// MachineSeries implements backups.Backend
+func (s *stateShim) MachineSeries(id string) (string, error) {
+	m, err := s.State.Machine(id)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return m.Series(), nil
 }
 
 func newAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*API, error) {

--- a/apiserver/backups/shim.go
+++ b/apiserver/backups/shim.go
@@ -1,0 +1,75 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backups
+
+import (
+	"github.com/juju/names"
+	"gopkg.in/mgo.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/state"
+)
+
+// This file contains untested shims to let us wrap state in a sensible
+// interface and avoid writing tests that depend on mongodb. If you were
+// to change any part of it so that it were no longer *obviously* and
+// *trivially* correct, you would be Doing It Wrong.
+
+func init() {
+	common.RegisterStandardFacade("Backups", 1, newAPI)
+}
+
+// Machine represents a state.Machine, it is used to break dependency
+// to state.
+type Machine interface {
+	Series() string
+	PublicAddress() (network.Address, error)
+	PrivateAddress() (network.Address, error)
+	InstanceId() (instance.Id, error)
+	Tag() names.Tag
+}
+
+type stateShim struct {
+	st *state.State
+}
+
+func (s *stateShim) IsController() bool {
+	return s.st.IsController()
+}
+
+func (s *stateShim) MongoSession() *mgo.Session {
+	return s.st.MongoSession()
+}
+
+func (s *stateShim) MongoConnectionInfo() *mongo.MongoInfo {
+	return s.st.MongoConnectionInfo()
+}
+
+func (s *stateShim) ModelTag() names.ModelTag {
+	return s.st.ModelTag()
+}
+
+func (s *stateShim) Machine(id string) (Machine, error) {
+	return s.st.Machine(id)
+}
+
+func (s *stateShim) ModelConfig() (*config.Config, error) {
+	return s.st.ModelConfig()
+}
+
+func (s *stateShim) StateServingInfo() (state.StateServingInfo, error) {
+	return s.st.StateServingInfo()
+}
+
+func (s *stateShim) RestoreInfo() *state.RestoreInfo {
+	return s.st.RestoreInfo()
+}
+
+func newAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*API, error) {
+	return NewAPI(&stateShim{st}, resources, authorizer)
+}

--- a/apiserver/params/backups.go
+++ b/apiserver/params/backups.go
@@ -66,6 +66,7 @@ type BackupsMetadataResult struct {
 	Machine  string
 	Hostname string
 	Version  version.Number
+	Series   string
 
 	CACert       string
 	CAPrivateKey string

--- a/apiserver/upgrading_root.go
+++ b/apiserver/upgrading_root.go
@@ -44,6 +44,9 @@ var allowedMethodsDuringUpgrades = map[string]set.Strings{
 	"Pinger": set.NewStrings(
 		"Ping",
 	),
+	"Backups": set.NewStrings(
+		"FinishRestore",
+	),
 }
 
 func IsMethodAllowedDuringUpgrade(rootName, methodName string) bool {

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -236,13 +236,17 @@ func (c *restoreCommand) rebootstrap(ctx *cmd.Context, meta *params.BackupsMetad
 		return errors.Annotatef(err, "cannot bootstrap new instance")
 	}
 
+	// We remove models from the client store as the cached values will be used
+	// to dial after re-bootstraping (if present) and the process will fail.
 	store := c.ClientStore()
+	// TODO(perrito666) there is no authoritative source for this model's name
+	// see if one can be added.
 	err = store.RemoveModel(c.ControllerName(), c.AccountName(), "default")
 	if err != nil && !errors.IsNotFound(err) {
 		return errors.Trace(err)
 	}
 
-	err = store.RemoveModel(c.ControllerName(), c.AccountName(), "controller")
+	err = store.RemoveModel(c.ControllerName(), c.AccountName(), environs.ControllerModelName)
 	if err != nil && !errors.IsNotFound(err) {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -303,7 +303,7 @@ func (c *restoreCommand) Run(ctx *cmd.Context) error {
 		err = client.Restore(c.backupId, c.newClient)
 	}
 	if err != nil {
-		return nil
+		return err
 	}
 	fmt.Fprintf(ctx.Stdout, "restore from %q completed\n", target)
 	return nil

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -145,7 +145,7 @@ func (c *restoreCommand) getEnviron(controllerName string, meta *params.BackupsM
 	}
 
 	// Reset current model to admin so first bootstrap succeeds.
-	err = store.SetCurrentModel(controllerName, environs.AdminUser, "controller")
+	err = store.SetCurrentModel(controllerName, environs.AdminUser, environs.ControllerModelName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -253,7 +253,7 @@ func (c *restoreCommand) rebootstrap(ctx *cmd.Context, meta *params.BackupsMetad
 
 	// New controller is bootstrapped, so now record the API address so
 	// we can connect.
-	err = common.SetBootstrapEndpointAddress(c.ClientStore(), c.ControllerName(), env)
+	err = common.SetBootstrapEndpointAddress(store, c.ControllerName(), env)
 	if err != nil {
 		errors.Trace(err)
 	}

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -67,7 +67,7 @@ var (
 func getBlockAPI(c *modelcmd.ModelCommandBase) (block.BlockListAPI, error) {
 	root, err := c.NewAPIRoot()
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	return apiblock.NewClient(root), nil
 }

--- a/mongo/service.go
+++ b/mongo/service.go
@@ -210,10 +210,8 @@ func EnsureServiceInstalled(dataDir string, statePort, oplogSizeMB int, setNumaC
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err := svc.Remove(); err != nil {
-		return errors.Trace(err)
-	}
 
+	logger.Debugf("installing mongo service")
 	if err := svc.Install(); err != nil {
 		return errors.Trace(err)
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -203,6 +203,7 @@ var installStartRetryAttempts = utils.AttemptStrategy{
 // InstallAndStart installs the provided service and tries starting it.
 // The first few Start failures are ignored.
 func InstallAndStart(svc ServiceActions) error {
+	logger.Infof("Installing and starting service %+v", svc)
 	if err := svc.Install(); err != nil {
 		return errors.Trace(err)
 	}

--- a/state/backups/backups.go
+++ b/state/backups/backups.go
@@ -102,7 +102,7 @@ type Backups interface {
 	// Restore updates juju's state to the contents of the backup archive,
 	// it returns the tag string for the machine where the backup originated
 	// or error if the process fails.
-	Restore(backupId string, args RestoreArgs) (names.Tag, error)
+	Restore(backupId string, dbInfo *DBInfo, args RestoreArgs) (names.Tag, error)
 }
 
 type backups struct {

--- a/state/backups/backups_linux.go
+++ b/state/backups/backups_linux.go
@@ -75,6 +75,11 @@ func (b *backups) Restore(backupId string, dbInfo *DBInfo, args RestoreArgs) (na
 	}
 	defer workspace.Close()
 
+	// This might actually work, but we don't have a guarantee so we don't allow it.
+	if meta.Origin.Series != args.NewInstSeries {
+		return nil, errors.Errorf("cannot restore a backup made in a machine with series %q into a machine with series %q, %#v", meta.Origin.Series, args.NewInstSeries, meta)
+	}
+
 	// TODO(perrito666) Create a compatibility table of sorts.
 	vers := meta.Origin.Version
 	if vers.Major != 2 {
@@ -178,6 +183,11 @@ func (b *backups) Restore(backupId string, dbInfo *DBInfo, args RestoreArgs) (na
 		Version:         mgoVer,
 		TagUser:         tagUser,
 		TagUserPassword: tagUserPassword,
+		RunCommandFn:    runCommand,
+		StartMongo:      mongo.StartService,
+		StopMongo:       mongo.StopService,
+		NewMongoSession: NewMongoSession,
+		GetDB:           GetDB,
 	}
 
 	// Restore mongodb from backup

--- a/state/backups/db_restore_test.go
+++ b/state/backups/db_restore_test.go
@@ -89,6 +89,9 @@ func (s *mongoRestoreSuite) TestRestoreDatabase32(c *gc.C) {
 		return nil
 	}
 	s.PatchValue(backups.RunCommand, fakeRunCommand)
+	mgoDb := &mongoDb{}
+	mgoSession := &mongoSession{}
+
 	args := backups.RestorerArgs{
 		DialInfo: &mgo.DialInfo{
 			Username: "fakeUsername",
@@ -98,13 +101,11 @@ func (s *mongoRestoreSuite) TestRestoreDatabase32(c *gc.C) {
 		Version:         mongo.Mongo32wt,
 		TagUser:         "machine-0",
 		TagUserPassword: "fakePassword",
+		GetDB:           func(string, backups.MongoSession) backups.MongoDB { return mgoDb },
+		NewMongoSession: func(dialInfo *mgo.DialInfo) (backups.MongoSession, error) {
+			return mgoSession, nil
+		},
 	}
-	mgoDb := &mongoDb{}
-	mgoSession := &mongoSession{}
-	s.PatchValue(backups.GetDb, func(string, backups.MongoSession) backups.MongoDB { return mgoDb })
-	s.PatchValue(backups.NewMongoSession, func(dialInfo *mgo.DialInfo) (backups.MongoSession, error) {
-		return mgoSession, nil
-	})
 	restorer, err := backups.NewDBRestorer(args)
 	c.Assert(err, jc.ErrorIsNil)
 	err = restorer.Restore("fakePath", nil)

--- a/state/backups/db_restore_test.go
+++ b/state/backups/db_restore_test.go
@@ -31,13 +31,13 @@ func (s *mongoRestoreSuite) TestRestoreDatabase24(c *gc.C) {
 		ranWithArgs = args
 		return nil
 	}
-	s.PatchValue(backups.RunCommand, fakeRunCommand)
-	s.PatchValue(backups.StartMongo, func() error { return nil })
-	s.PatchValue(backups.StopMongo, func() error { return nil })
 	args := backups.RestorerArgs{
 		Version:         mongo.Mongo24,
 		TagUser:         "machine-0",
 		TagUserPassword: "fakePassword",
+		RunCommandFn:    fakeRunCommand,
+		StartMongo:      func() error { return nil },
+		StopMongo:       func() error { return nil },
 	}
 
 	s.PatchValue(backups.MongoInstalledVersion, func() mongo.Version { return mongo.Mongo24 })
@@ -90,7 +90,6 @@ func (s *mongoRestoreSuite) TestRestoreDatabase32(c *gc.C) {
 		ranWithArgs = args
 		return nil
 	}
-	s.PatchValue(backups.RunCommand, fakeRunCommand)
 	mgoDb := &mongoDb{}
 	mgoSession := &mongoSession{}
 
@@ -107,6 +106,7 @@ func (s *mongoRestoreSuite) TestRestoreDatabase32(c *gc.C) {
 		NewMongoSession: func(dialInfo *mgo.DialInfo) (backups.MongoSession, error) {
 			return mgoSession, nil
 		},
+		RunCommandFn: fakeRunCommand,
 	}
 	s.PatchValue(backups.MongoInstalledVersion, func() mongo.Version { return mongo.Mongo32wt })
 	restorer, err := backups.NewDBRestorer(args)

--- a/state/backups/db_restore_test.go
+++ b/state/backups/db_restore_test.go
@@ -21,59 +21,6 @@ type mongoRestoreSuite struct {
 	testing.BaseSuite
 }
 
-func (s *mongoRestoreSuite) TestMongoRestoreArgsForVersion121(c *gc.C) {
-	dir := filepath.Join(agent.DefaultPaths.DataDir, "db")
-	versionNumber := version.Number{}
-	versionNumber.Major = 1
-	versionNumber.Minor = 21
-	args, err := backups.MongoRestoreArgsForVersion(versionNumber, "/some/fake/path")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(args, gc.HasLen, 5)
-	c.Assert(args[0:5], jc.DeepEquals, []string{
-		"--drop",
-		"--journal",
-		"--dbpath",
-		dir,
-		"/some/fake/path",
-	})
-}
-
-func (s *mongoRestoreSuite) TestMongoRestoreArgsForVersion122(c *gc.C) {
-	dir := filepath.Join(agent.DefaultPaths.DataDir, "db")
-	versionNumber := version.Number{}
-	versionNumber.Major = 1
-	versionNumber.Minor = 22
-	args, err := backups.MongoRestoreArgsForVersion(versionNumber, "/some/fake/path")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(args, gc.HasLen, 6)
-	c.Assert(args[0:6], jc.DeepEquals, []string{
-		"--drop",
-		"--journal",
-		"--oplogReplay",
-		"--dbpath",
-		dir,
-		"/some/fake/path",
-	})
-}
-
-func (s *mongoRestoreSuite) TestMongoRestoreArgsForVersion2(c *gc.C) {
-	dir := filepath.Join(agent.DefaultPaths.DataDir, "db")
-	versionNumber := version.Number{}
-	versionNumber.Major = 2
-	versionNumber.Minor = 0
-	args, err := backups.MongoRestoreArgsForVersion(versionNumber, "/some/fake/path")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(args, gc.HasLen, 6)
-	c.Assert(args[0:6], jc.DeepEquals, []string{
-		"--drop",
-		"--journal",
-		"--oplogReplay",
-		"--dbpath",
-		dir,
-		"/some/fake/path",
-	})
-}
-
 func (s *mongoRestoreSuite) TestMongoRestoreArgsForOldVersion(c *gc.C) {
 	versionNumber := version.Number{}
 	versionNumber.Major = 0
@@ -82,7 +29,7 @@ func (s *mongoRestoreSuite) TestMongoRestoreArgsForOldVersion(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "this backup file is incompatible with the current version of juju")
 }
 
-func (s *mongoRestoreSuite) TestPlaceNewMongo(c *gc.C) {
+func (s *mongoRestoreSuite) TestRestoreDatabase(c *gc.C) {
 	var argsVersion version.Number
 	var newMongoDumpPath string
 	ranArgs := make([][]string, 0, 3)

--- a/state/backups/export_test.go
+++ b/state/backups/export_test.go
@@ -29,8 +29,6 @@ var (
 	GetMongorestorePath   = &getMongorestorePath
 	RunCommand            = &runCommandFn
 	ReplaceableFolders    = &replaceableFolders
-	StartMongo            = &startMongo
-	StopMongo             = &stopMongo
 	MongoInstalledVersion = &mongoInstalledVersion
 )
 

--- a/state/backups/export_test.go
+++ b/state/backups/export_test.go
@@ -31,8 +31,6 @@ var (
 	ReplaceableFolders   = &replaceableFolders
 	StartMongo           = &startMongo
 	StopMongo            = &stopMongo
-	NewMongoSession      = &newMongoSession
-	GetDb                = &getDb
 )
 
 var _ filestorage.DocStorage = (*backupsDocStorage)(nil)

--- a/state/backups/export_test.go
+++ b/state/backups/export_test.go
@@ -20,17 +20,18 @@ var (
 	Create        = create
 	FileTimestamp = fileTimestamp
 
-	TestGetFilesToBackUp = &getFilesToBackUp
-	GetDBDumper          = &getDBDumper
-	RunCreate            = &runCreate
-	FinishMeta           = &finishMeta
-	StoreArchiveRef      = &storeArchive
-	GetMongodumpPath     = &getMongodumpPath
-	GetMongorestorePath  = &getMongorestorePath
-	RunCommand           = &runCommandFn
-	ReplaceableFolders   = &replaceableFolders
-	StartMongo           = &startMongo
-	StopMongo            = &stopMongo
+	TestGetFilesToBackUp  = &getFilesToBackUp
+	GetDBDumper           = &getDBDumper
+	RunCreate             = &runCreate
+	FinishMeta            = &finishMeta
+	StoreArchiveRef       = &storeArchive
+	GetMongodumpPath      = &getMongodumpPath
+	GetMongorestorePath   = &getMongorestorePath
+	RunCommand            = &runCommandFn
+	ReplaceableFolders    = &replaceableFolders
+	StartMongo            = &startMongo
+	StopMongo             = &stopMongo
+	MongoInstalledVersion = &mongoInstalledVersion
 )
 
 var _ filestorage.DocStorage = (*backupsDocStorage)(nil)

--- a/state/backups/export_test.go
+++ b/state/backups/export_test.go
@@ -26,8 +26,13 @@ var (
 	FinishMeta           = &finishMeta
 	StoreArchiveRef      = &storeArchive
 	GetMongodumpPath     = &getMongodumpPath
+	GetMongorestorePath  = &getMongorestorePath
 	RunCommand           = &runCommandFn
 	ReplaceableFolders   = &replaceableFolders
+	StartMongo           = &startMongo
+	StopMongo            = &stopMongo
+	NewMongoSession      = &newMongoSession
+	GetDb                = &getDb
 )
 
 var _ filestorage.DocStorage = (*backupsDocStorage)(nil)

--- a/state/backups/export_test.go
+++ b/state/backups/export_test.go
@@ -164,7 +164,4 @@ func NewTestArchiveStorer(failure string) func(filestorage.FileStorage, *Metadat
 }
 
 // Export for patching in tests
-var PlaceNewMongo = placeNewMongo
-var MongoRestoreArgsForVersion = mongoRestoreArgsForVersion
 var RestorePath = &getMongorestorePath
-var RestoreArgsForVersion = &restoreArgsForVersion

--- a/state/backups/files.go
+++ b/state/backups/files.go
@@ -56,7 +56,6 @@ func GetFilesToBackUp(rootDir string, paths *Paths, oldmachine string) ([]string
 	}
 
 	backupFiles := []string{
-		filepath.Join(rootDir, paths.DataDir, initDir),
 		filepath.Join(rootDir, paths.DataDir, toolsDir),
 
 		filepath.Join(rootDir, paths.DataDir, sshIdentFile),
@@ -104,9 +103,11 @@ func replaceableFoldersFunc() (map[string]os.FileMode, error) {
 		filepath.Join(dataDir, "db"),
 		filepath.Join(dataDir, "init"),
 		dataDir,
-		//logsDir,
 	} {
 		dirStat, err := os.Stat(replaceable)
+		if os.IsNotExist(err) {
+			continue
+		}
 		if err != nil {
 			return map[string]os.FileMode{}, errors.Annotatef(err, "cannot stat %q", replaceable)
 		}

--- a/state/backups/files.go
+++ b/state/backups/files.go
@@ -4,7 +4,6 @@
 package backups
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -23,10 +22,10 @@ const (
 	agentsDir   = "agents"
 	agentsConfs = "machine-*"
 	toolsDir    = "tools"
+	initDir     = "init"
 
 	sshIdentFile = "system-identity"
 	nonceFile    = "nonce.txt"
-	machineLog   = "machine-%s.log"
 	authKeysFile = "authorized_keys"
 
 	dbPEM    = "server.pem"
@@ -50,7 +49,14 @@ func GetFilesToBackUp(rootDir string, paths *Paths, oldmachine string) ([]string
 		return nil, errors.Annotate(err, "failed to fetch agent config files")
 	}
 
+	glob = filepath.Join(rootDir, paths.DataDir, initDir, "*")
+	serviceConfs, err := filepath.Glob(glob)
+	if err != nil {
+		return nil, errors.Annotate(err, "failed to fetch service config files")
+	}
+
 	backupFiles := []string{
+		filepath.Join(rootDir, paths.DataDir, initDir),
 		filepath.Join(rootDir, paths.DataDir, toolsDir),
 
 		filepath.Join(rootDir, paths.DataDir, sshIdentFile),
@@ -59,17 +65,7 @@ func GetFilesToBackUp(rootDir string, paths *Paths, oldmachine string) ([]string
 		filepath.Join(rootDir, paths.DataDir, dbSecret),
 	}
 	backupFiles = append(backupFiles, agentConfs...)
-
-	// TODO(ericsnow) It might not be machine 0...
-	machinelog := filepath.Join(rootDir, paths.LogsDir, fmt.Sprintf(machineLog, oldmachine))
-	if _, err := os.Stat(machinelog); err != nil {
-		if !os.IsNotExist(err) {
-			return nil, errors.Trace(err)
-		}
-		logger.Errorf("skipping missing file %q", machinelog)
-	} else {
-		backupFiles = append(backupFiles, machinelog)
-	}
+	backupFiles = append(backupFiles, serviceConfs...)
 
 	// Handle nonce.txt (might not exist).
 	nonce := filepath.Join(rootDir, paths.DataDir, nonceFile)
@@ -106,8 +102,9 @@ func replaceableFoldersFunc() (map[string]os.FileMode, error) {
 
 	for _, replaceable := range []string{
 		filepath.Join(dataDir, "db"),
+		filepath.Join(dataDir, "init"),
 		dataDir,
-		logsDir,
+		//logsDir,
 	} {
 		dirStat, err := os.Stat(replaceable)
 		if err != nil {

--- a/state/backups/files_test.go
+++ b/state/backups/files_test.go
@@ -112,7 +112,6 @@ func (s *filesSuite) TestGetFilesToBackUpMachine0(c *gc.C) {
 		filepath.Join(s.root, "/var/lib/juju/shared-secret"),
 		filepath.Join(s.root, "/var/lib/juju/system-identity"),
 		filepath.Join(s.root, "/var/lib/juju/tools"),
-		filepath.Join(s.root, "/var/lib/juju/init"),
 		filepath.Join(s.root, "/var/lib/juju/init/juju-db"),
 	}
 	c.Check(files, jc.SameContents, expected)
@@ -194,7 +193,6 @@ func (s *filesSuite) TestGetFilesToBackUpMachine10(c *gc.C) {
 		filepath.Join(s.root, "/var/lib/juju/shared-secret"),
 		filepath.Join(s.root, "/var/lib/juju/system-identity"),
 		filepath.Join(s.root, "/var/lib/juju/tools"),
-		filepath.Join(s.root, "/var/lib/juju/init"),
 		filepath.Join(s.root, "/var/lib/juju/init/juju-db"),
 	}
 	c.Check(files, jc.SameContents, expected)
@@ -226,7 +224,6 @@ func (s *filesSuite) TestGetFilesToBackUpMissing(c *gc.C) {
 		filepath.Join(s.root, "/var/lib/juju/shared-secret"),
 		filepath.Join(s.root, "/var/lib/juju/system-identity"),
 		filepath.Join(s.root, "/var/lib/juju/tools"),
-		filepath.Join(s.root, "/var/lib/juju/init"),
 		filepath.Join(s.root, "/var/lib/juju/init/juju-db"),
 	}
 	// This got re-created.

--- a/state/backups/files_test.go
+++ b/state/backups/files_test.go
@@ -58,11 +58,11 @@ func (s *filesSuite) createFiles(c *gc.C, paths backups.Paths, root, machineID s
 	dirname = mkdir(filepath.Join(paths.DataDir, "agents"))
 	touch(dirname, "machine-"+machineID+".conf")
 
-	dirname = mkdir(paths.LogsDir)
-	touch(dirname, "machine-"+machineID+".log")
-
 	dirname = mkdir("/home/ubuntu/.ssh")
 	touch(dirname, "authorized_keys")
+
+	dirname = mkdir(filepath.Join(paths.DataDir, "init", "juju-db"))
+	touch(dirname, "juju-db.service")
 }
 
 func (s *filesSuite) checkSameStrings(c *gc.C, actual, expected []string) {
@@ -112,7 +112,8 @@ func (s *filesSuite) TestGetFilesToBackUpMachine0(c *gc.C) {
 		filepath.Join(s.root, "/var/lib/juju/shared-secret"),
 		filepath.Join(s.root, "/var/lib/juju/system-identity"),
 		filepath.Join(s.root, "/var/lib/juju/tools"),
-		filepath.Join(s.root, "/var/log/juju/machine-0.log"),
+		filepath.Join(s.root, "/var/lib/juju/init"),
+		filepath.Join(s.root, "/var/lib/juju/init/juju-db"),
 	}
 	c.Check(files, jc.SameContents, expected)
 	s.checkSameStrings(c, files, expected)
@@ -193,7 +194,8 @@ func (s *filesSuite) TestGetFilesToBackUpMachine10(c *gc.C) {
 		filepath.Join(s.root, "/var/lib/juju/shared-secret"),
 		filepath.Join(s.root, "/var/lib/juju/system-identity"),
 		filepath.Join(s.root, "/var/lib/juju/tools"),
-		filepath.Join(s.root, "/var/log/juju/machine-10.log"),
+		filepath.Join(s.root, "/var/lib/juju/init"),
+		filepath.Join(s.root, "/var/lib/juju/init/juju-db"),
 	}
 	c.Check(files, jc.SameContents, expected)
 	s.checkSameStrings(c, files, expected)
@@ -209,7 +211,6 @@ func (s *filesSuite) TestGetFilesToBackUpMissing(c *gc.C) {
 	missing := []string{
 		"/var/lib/juju/nonce.txt",
 		"/home/ubuntu/.ssh/authorized_keys",
-		"/var/log/juju/machine-0.log",
 	}
 	for _, filename := range missing {
 		err := os.Remove(filepath.Join(s.root, filename))
@@ -225,6 +226,8 @@ func (s *filesSuite) TestGetFilesToBackUpMissing(c *gc.C) {
 		filepath.Join(s.root, "/var/lib/juju/shared-secret"),
 		filepath.Join(s.root, "/var/lib/juju/system-identity"),
 		filepath.Join(s.root, "/var/lib/juju/tools"),
+		filepath.Join(s.root, "/var/lib/juju/init"),
+		filepath.Join(s.root, "/var/lib/juju/init/juju-db"),
 	}
 	// This got re-created.
 	expected = append(expected, filepath.Join(s.root, "/home/ubuntu/.ssh/authorized_keys"))

--- a/state/backups/metadata.go
+++ b/state/backups/metadata.go
@@ -68,7 +68,8 @@ type Metadata struct {
 	Notes string
 
 	// Series holds the series of the backed up machine, when
-	// restoring the series should be maintained if possible.
+	// restoring the series should be the same or newer than
+	// the backup one.
 	Series string
 
 	// TODO(wallyworld) - remove these ASAP

--- a/state/backups/metadata.go
+++ b/state/backups/metadata.go
@@ -67,9 +67,7 @@ type Metadata struct {
 	// Notes is an optional user-supplied annotation.
 	Notes string
 
-	// Series holds the series of the backed up machine, when
-	// restoring the series should be the same or newer than
-	// the backup one.
+	// Series holds the series of the backed up machine.
 	Series string
 
 	// TODO(wallyworld) - remove these ASAP

--- a/state/backups/metadata.go
+++ b/state/backups/metadata.go
@@ -67,9 +67,6 @@ type Metadata struct {
 	// Notes is an optional user-supplied annotation.
 	Notes string
 
-	// Series holds the series of the backed up machine.
-	Series string
-
 	// TODO(wallyworld) - remove these ASAP
 	// These are only used by the restore CLI when re-bootstrapping.
 	// We will use a better solution but the way restore currently

--- a/state/backups/metadata.go
+++ b/state/backups/metadata.go
@@ -32,6 +32,7 @@ type Origin struct {
 	Machine  string
 	Hostname string
 	Version  version.Number
+	Series   string
 }
 
 // UnknownString is a marker value for string fields with unknown values.
@@ -66,6 +67,10 @@ type Metadata struct {
 	// Notes is an optional user-supplied annotation.
 	Notes string
 
+	// Series holds the series of the backed up machine, when
+	// restoring the series should be maintained if possible.
+	Series string
+
 	// TODO(wallyworld) - remove these ASAP
 	// These are only used by the restore CLI when re-bootstrapping.
 	// We will use a better solution but the way restore currently
@@ -96,7 +101,7 @@ func NewMetadata() *Metadata {
 // NewMetadataState composes a new backup metadata with its origin
 // values set.  The model UUID comes from state.  The hostname is
 // retrieved from the OS.
-func NewMetadataState(db DB, machine string) (*Metadata, error) {
+func NewMetadataState(db DB, machine, series string) (*Metadata, error) {
 	// hostname could be derived from the model...
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -109,6 +114,7 @@ func NewMetadataState(db DB, machine string) (*Metadata, error) {
 	meta.Origin.Model = db.ModelTag().Id()
 	meta.Origin.Machine = machine
 	meta.Origin.Hostname = hostname
+	meta.Origin.Series = series
 
 	si, err := db.StateServingInfo()
 	if err != nil {
@@ -163,6 +169,7 @@ type flatMetadata struct {
 	Machine     string
 	Hostname    string
 	Version     version.Number
+	Series      string
 
 	CACert       string
 	CAPrivateKey string
@@ -185,6 +192,7 @@ func (m *Metadata) AsJSONBuffer() (io.Reader, error) {
 		Machine:      m.Origin.Machine,
 		Hostname:     m.Origin.Hostname,
 		Version:      m.Origin.Version,
+		Series:       m.Origin.Series,
 		CACert:       m.CACert,
 		CAPrivateKey: m.CAPrivateKey,
 	}
@@ -234,6 +242,7 @@ func NewMetadataJSONReader(in io.Reader) (*Metadata, error) {
 		Machine:  flat.Machine,
 		Hostname: flat.Hostname,
 		Version:  flat.Version,
+		Series:   flat.Series,
 	}
 
 	// TODO(wallyworld) - put these in a separate file.

--- a/state/backups/metadata_test.go
+++ b/state/backups/metadata_test.go
@@ -30,6 +30,7 @@ func (s *metadataSuite) TestAsJSONBuffer(c *gc.C) {
 		Machine:  "0",
 		Hostname: "myhost",
 		Version:  version.MustParse("1.21-alpha3"),
+		Series:   "trusty",
 	}
 	meta.Started = time.Date(2014, time.Month(9), 9, 11, 59, 34, 0, time.UTC)
 
@@ -59,6 +60,7 @@ func (s *metadataSuite) TestAsJSONBuffer(c *gc.C) {
 		`"Machine":"0",`+
 		`"Hostname":"myhost",`+
 		`"Version":"1.21-alpha3",`+
+		`"Series":"trusty",`+
 		`"CACert":"ca-cert",`+
 		`"CAPrivateKey":"ca-private-key"`+
 		`}`+"\n")

--- a/state/backups/params.go
+++ b/state/backups/params.go
@@ -4,9 +4,8 @@
 package backups
 
 import (
-	"github.com/juju/names"
-
 	"github.com/juju/juju/instance"
+	"github.com/juju/names"
 )
 
 // RestoreArgs holds the args to be used to call state/backups.Restore

--- a/state/backups/restore.go
+++ b/state/backups/restore.go
@@ -49,6 +49,27 @@ func getFilesystemRoot() string {
 	return string(os.PathSeparator)
 }
 
+// tagUserCredentials is a convenience function that extracts the
+// tag user and apipassword, required to access mongodb.
+func tagUserCredentials(conf agent.Config) (string, string, error) {
+	username := conf.Tag().String()
+	var password string
+	// TODO(perrito) we might need an accessor for the actual state password
+	// just in case it ever changes from the same as api password.
+	apiInfo, ok := conf.APIInfo()
+	if ok {
+		password = apiInfo.Password
+	} else {
+		// There seems to be no way to reach this inconsistence other than making a
+		// backup on a machine where these fields are corrupted and even so I find
+		// no reasonable way to reach this state, yet since APIInfo has it as a
+		// possibility I prefer to handle it, we cannot recover from this since
+		// it would mean that the agent.conf is corrupted.
+		return "", "", errors.New("cannot obtain password to access the controller")
+	}
+	return username, password, nil
+}
+
 // newDialInfo returns mgo.DialInfo with the given address using the minimal
 // possible setup.
 func newDialInfo(privateAddr string, conf agent.Config) (*mgo.DialInfo, error) {
@@ -70,20 +91,9 @@ func newDialInfo(privateAddr string, conf agent.Config) (*mgo.DialInfo, error) {
 		dialInfo.Username = "admin"
 		dialInfo.Password = conf.OldPassword()
 	} else {
-		dialInfo.Username = conf.Tag().String()
-		// TODO(perrito) we might need an accessor for the actual state password
-		// just in case it ever changes from the same as api password.
-		apiInfo, ok := conf.APIInfo()
-		if ok {
-			dialInfo.Password = apiInfo.Password
-			logger.Infof("using API password to access controller.")
-		} else {
-			// There seems to be no way to reach this inconsistence other than making a
-			// backup on a machine where these fields are corrupted and even so I find
-			// no reasonable way to reach this state, yet since APIInfo has it as a
-			// possibility I prefer to handle it, we cannot recover from this since
-			// it would mean that the agent.conf is corrupted.
-			return nil, errors.New("cannot obtain password to access the controller")
+		dialInfo.Username, dialInfo.Password, err = tagUserCredentials(conf)
+		if err != nil {
+			return nil, errors.Trace(err)
 		}
 	}
 	return dialInfo, nil

--- a/state/backups/storage.go
+++ b/state/backups/storage.go
@@ -52,6 +52,7 @@ type storageMetaDoc struct {
 	Machine  string         `bson:"machine"`
 	Hostname string         `bson:"hostname"`
 	Version  version.Number `bson:"version"`
+	Series   string         `bson:"series"`
 }
 
 func (doc *storageMetaDoc) isFileInfoComplete() bool {
@@ -126,6 +127,7 @@ func docAsMetadata(doc *storageMetaDoc) *Metadata {
 	meta.Origin.Machine = doc.Machine
 	meta.Origin.Hostname = doc.Hostname
 	meta.Origin.Version = doc.Version
+	meta.Origin.Series = doc.Series
 
 	meta.SetID(doc.ID)
 
@@ -176,6 +178,7 @@ func newStorageMetaDoc(meta *Metadata) storageMetaDoc {
 	doc.Machine = meta.Origin.Machine
 	doc.Hostname = meta.Origin.Hostname
 	doc.Version = meta.Origin.Version
+	doc.Series = meta.Origin.Series
 
 	return doc
 }

--- a/state/backups/testing/fakes.go
+++ b/state/backups/testing/fakes.go
@@ -97,7 +97,7 @@ func (b *FakeBackups) Remove(id string) error {
 }
 
 // Restore restores a machine to a backed up status.
-func (b *FakeBackups) Restore(bkpId string, args backups.RestoreArgs) (names.Tag, error) {
+func (b *FakeBackups) Restore(bkpId string, dbInfo *backups.DBInfo, args backups.RestoreArgs) (names.Tag, error) {
 	b.Calls = append(b.Calls, "Restore")
 	b.PrivateAddr = args.PrivateAddress
 	b.InstanceId = args.NewInstId

--- a/state/restore.go
+++ b/state/restore.go
@@ -84,6 +84,9 @@ func (info *RestoreInfo) Status() (RestoreStatus, error) {
 	return doc.Status, nil
 }
 
+// PurgeTxn purges missing transation from restoreInfoC collection.
+// These can be caused because this collection is heavy use while backing
+// up and mongo 3.2 does not like this.
 func (info *RestoreInfo) PurgeTxn() error {
 	restoreInfo, closer := info.st.getRawCollection(restoreInfoC)
 	defer closer()

--- a/state/restore_test.go
+++ b/state/restore_test.go
@@ -106,7 +106,7 @@ func (s *RestoreInfoSuite) TestUpdateRaceExhaustion(c *gc.C) {
 		perturb,
 	).Check()
 	err := s.info.SetStatus(state.RestoreInProgress)
-	c.Check(err, gc.ErrorMatches, ".*state changing too quickly; try again soon")
+	c.Check(err, gc.ErrorMatches, "setting status \"RESTORING\": state changing too quickly; try again soon")
 }
 
 //--------------------------------------

--- a/state/restore_test.go
+++ b/state/restore_test.go
@@ -106,7 +106,7 @@ func (s *RestoreInfoSuite) TestUpdateRaceExhaustion(c *gc.C) {
 		perturb,
 	).Check()
 	err := s.info.SetStatus(state.RestoreInProgress)
-	c.Check(err, gc.ErrorMatches, "state changing too quickly; try again soon")
+	c.Check(err, gc.ErrorMatches, ".*state changing too quickly; try again soon")
 }
 
 //--------------------------------------
@@ -120,11 +120,7 @@ func (s *RestoreInfoSuite) TestNotActiveSetPending(c *gc.C) {
 }
 
 func (s *RestoreInfoSuite) TestNotActiveSetInProgress(c *gc.C) {
-	s.checkBadSetStatus(c, state.RestoreFinished)
-}
-
-func (s *RestoreInfoSuite) TestNotActiveSetFinished(c *gc.C) {
-	s.checkBadSetStatus(c, state.RestoreFinished)
+	s.checkBadSetStatus(c, state.RestoreInProgress)
 }
 
 func (s *RestoreInfoSuite) TestNotActiveSetChecked(c *gc.C) {
@@ -154,11 +150,6 @@ func (s *RestoreInfoSuite) TestPendingSetPending(c *gc.C) {
 func (s *RestoreInfoSuite) TestPendingSetInProgress(c *gc.C) {
 	s.setupPending(c)
 	s.checkSetStatus(c, state.RestoreInProgress)
-}
-
-func (s *RestoreInfoSuite) TestPendingSetFinished(c *gc.C) {
-	s.setupPending(c)
-	s.checkBadSetStatus(c, state.RestoreFinished)
 }
 
 func (s *RestoreInfoSuite) TestPendingSetChecked(c *gc.C) {
@@ -270,11 +261,6 @@ func (s *RestoreInfoSuite) TestCheckedSetInProgress(c *gc.C) {
 	s.checkBadSetStatus(c, state.RestoreInProgress)
 }
 
-func (s *RestoreInfoSuite) TestCheckedSetFinished(c *gc.C) {
-	s.setupChecked(c)
-	s.checkBadSetStatus(c, state.RestoreFinished)
-}
-
 func (s *RestoreInfoSuite) TestCheckedSetChecked(c *gc.C) {
 	s.setupChecked(c)
 	s.checkSetStatus(c, state.RestoreChecked)
@@ -338,6 +324,6 @@ func (s *RestoreInfoSuite) checkSetStatus(c *gc.C, status state.RestoreStatus) {
 
 func (s *RestoreInfoSuite) checkBadSetStatus(c *gc.C, status state.RestoreStatus) {
 	err := s.info.SetStatus(status)
-	expect := fmt.Sprintf("invalid restore transition: [-A-Z]+ => %s", status)
+	expect := fmt.Sprintf("setting status %q: invalid restore transition: [-A-Z]+ => %s", status, status)
 	c.Check(err, gc.ErrorMatches, expect)
 }

--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -64,7 +64,7 @@ func (p *lxdLogProxy) render(msg string, ctx []interface{}) string {
 }
 
 func (p *lxdLogProxy) Debug(msg string, ctx ...interface{}) {
-	//p.logger.Debugf(p.render(msg, ctx))
+	p.logger.Debugf(p.render(msg, ctx))
 }
 
 func (p *lxdLogProxy) Info(msg string, ctx ...interface{}) {

--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -64,7 +64,7 @@ func (p *lxdLogProxy) render(msg string, ctx []interface{}) string {
 }
 
 func (p *lxdLogProxy) Debug(msg string, ctx ...interface{}) {
-	p.logger.Debugf(p.render(msg, ctx))
+	//p.logger.Debugf(p.render(msg, ctx))
 }
 
 func (p *lxdLogProxy) Info(msg string, ctx ...interface{}) {


### PR DESCRIPTION
Restore broke for mongo 3.2 this patch adds a separate restore functionality for the cases of 2.4 and 3.2 and also fixes restore after the change from admin to controller on the controller model.
Fixes: 1576874 
Fixes: 1585851

(Review request: http://reviews.vapour.ws/r/4928/)