### PR TITLE
cmd/juju/{service,commands}: re-enable race tests

### DIFF
--- a/cmd/juju/commands/package_test.go
+++ b/cmd/juju/commands/package_test.go
@@ -9,8 +9,6 @@ import (
 	"runtime"
 	stdtesting "testing"
 
-	gittesting "github.com/juju/testing"
-
 	cmdtesting "github.com/juju/juju/cmd/testing"
 	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
@@ -19,9 +17,6 @@ import (
 func TestPackage(t *stdtesting.T) {
 	if runtime.GOARCH == "386" {
 		t.Skipf("skipping package for %v/%v, see http://pad.lv/1425569", runtime.GOOS, runtime.GOARCH)
-	}
-	if gittesting.RaceEnabled {
-		t.Skip("skipping test in -race mode, see LP 1518810")
 	}
 	testing.MgoTestPackage(t)
 }

--- a/cmd/juju/service/package_test.go
+++ b/cmd/juju/service/package_test.go
@@ -7,8 +7,6 @@ import (
 	"runtime"
 	stdtesting "testing"
 
-	gittesting "github.com/juju/testing"
-
 	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
 )
@@ -18,9 +16,6 @@ import (
 func TestPackage(t *stdtesting.T) {
 	if runtime.GOARCH == "386" {
 		t.Skipf("skipping package for %v/%v, see http://pad.lv/1425569", runtime.GOOS, runtime.GOARCH)
-	}
-	if gittesting.RaceEnabled {
-		t.Skip("skipping test in -race mode, see LP 1518810")
 	}
 	testing.MgoTestPackage(t)
 }


### PR DESCRIPTION
Fixes LP 1518810

(and the copy pasta in cmd/juju/service)

(Review request: http://reviews.vapour.ws/r/4935/)