### PR TITLE
Migrate IP Addresses

### DIFF
--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -60,6 +60,9 @@ type Model interface {
 	Relations() []Relation
 	AddRelation(RelationArgs) Relation
 
+	IPAddresses() []IPAddress
+	AddIPAddress(IPAddressArgs) IPAddress
+
 	Sequences() map[string]int
 	SetSequence(name string, value int)
 
@@ -303,4 +306,8 @@ type Endpoint interface {
 
 	Settings(unitName string) map[string]interface{}
 	SetUnitSettings(unitName string, settings map[string]interface{})
+}
+
+// IPAddress represents an IP address.
+type IPAddress interface {
 }

--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -310,4 +310,13 @@ type Endpoint interface {
 
 // IPAddress represents an IP address.
 type IPAddress interface {
+	ProviderID() string
+	DeviceName() string
+	MachineID() string
+	SubnetCIDR() string
+	ConfigMethod() string
+	Value() string
+	DNSServers() []string
+	DNSSearchDomains() []string
+	GatewayAddress() string
 }

--- a/core/description/ipaddress_test.go
+++ b/core/description/ipaddress_test.go
@@ -17,13 +17,13 @@ var _ = gc.Suite(&IPAddressSerializationSuite{})
 
 func (s *IPAddressSerializationSuite) SetUpTest(c *gc.C) {
 	s.SliceSerializationSuite.SetUpTest(c)
-	s.importName = "addresses"
-	s.sliceName = "addresses"
+	s.importName = "ipaddresses"
+	s.sliceName = "ipaddresses"
 	s.importFunc = func(m map[string]interface{}) (interface{}, error) {
 		return importIPAddresses(m)
 	}
 	s.testFields = func(m map[string]interface{}) {
-		m["addresses"] = []interface{}{}
+		m["ipaddresses"] = []interface{}{}
 	}
 }
 
@@ -46,8 +46,8 @@ func (s *IPAddressSerializationSuite) TestNewIPAddress(c *gc.C) {
 	c.Assert(address.MachineID(), gc.Equals, args.MachineID)
 	c.Assert(address.ConfigMethod(), gc.Equals, args.ConfigMethod)
 	c.Assert(address.Value(), gc.Equals, args.Value)
-	c.Assert(address.DNSServers(), gc.Equals, args.DNSServers)
-	c.Assert(address.DNSSearchDomains(), gc.Equals, args.DNSSearchDomains)
+	c.Assert(address.DNSServers(), jc.DeepEquals, args.DNSServers)
+	c.Assert(address.DNSSearchDomains(), jc.DeepEquals, args.DNSSearchDomains)
 	c.Assert(address.GatewayAddress(), gc.Equals, args.GatewayAddress)
 }
 

--- a/core/description/ipaddress_test.go
+++ b/core/description/ipaddress_test.go
@@ -1,0 +1,78 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+)
+
+type IPAddressSerializationSuite struct {
+	SliceSerializationSuite
+}
+
+var _ = gc.Suite(&IPAddressSerializationSuite{})
+
+func (s *IPAddressSerializationSuite) SetUpTest(c *gc.C) {
+	s.SliceSerializationSuite.SetUpTest(c)
+	s.importName = "addresss"
+	s.sliceName = "addresss"
+	s.importFunc = func(m map[string]interface{}) (interface{}, error) {
+		return importIPAddresss(m)
+	}
+	s.testFields = func(m map[string]interface{}) {
+		m["addresss"] = []interface{}{}
+	}
+}
+
+func (s *IPAddressSerializationSuite) TestNewIPAddress(c *gc.C) {
+	args := IPAddressArgs{
+		CIDR:              "10.0.0.0/24",
+		ProviderId:        "magic",
+		VLANTag:           64,
+		SpaceName:         "foo",
+		AvailabilityZone:  "bar",
+		AllocatableIPHigh: "10.0.0.255",
+		AllocatableIPLow:  "10.0.0.0",
+	}
+	address := newIPAddress(args)
+	c.Assert(address.CIDR(), gc.Equals, args.CIDR)
+	c.Assert(address.ProviderId(), gc.Equals, args.ProviderId)
+	c.Assert(address.VLANTag(), gc.Equals, args.VLANTag)
+	c.Assert(address.SpaceName(), gc.Equals, args.SpaceName)
+	c.Assert(address.AvailabilityZone(), gc.Equals, args.AvailabilityZone)
+	c.Assert(address.AllocatableIPHigh(), gc.Equals, args.AllocatableIPHigh)
+	c.Assert(address.AllocatableIPLow(), gc.Equals, args.AllocatableIPLow)
+}
+
+func (s *IPAddressSerializationSuite) TestParsingSerializedData(c *gc.C) {
+	initial := addresss{
+		Version: 1,
+		IPAddresss_: []*address{
+			newIPAddress(IPAddressArgs{
+				CIDR:              "10.0.0.0/24",
+				ProviderId:        "magic",
+				VLANTag:           64,
+				SpaceName:         "foo",
+				AvailabilityZone:  "bar",
+				AllocatableIPHigh: "10.0.0.255",
+				AllocatableIPLow:  "10.0.0.0",
+			}),
+			newIPAddress(IPAddressArgs{CIDR: "10.0.1.0/24"}),
+		},
+	}
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	addresss, err := importIPAddresss(source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(addresss, jc.DeepEquals, initial.IPAddresss_)
+}

--- a/core/description/ipaddress_test.go
+++ b/core/description/ipaddress_test.go
@@ -17,50 +17,56 @@ var _ = gc.Suite(&IPAddressSerializationSuite{})
 
 func (s *IPAddressSerializationSuite) SetUpTest(c *gc.C) {
 	s.SliceSerializationSuite.SetUpTest(c)
-	s.importName = "addresss"
-	s.sliceName = "addresss"
+	s.importName = "addresses"
+	s.sliceName = "addresses"
 	s.importFunc = func(m map[string]interface{}) (interface{}, error) {
-		return importIPAddresss(m)
+		return importIPAddresses(m)
 	}
 	s.testFields = func(m map[string]interface{}) {
-		m["addresss"] = []interface{}{}
+		m["addresses"] = []interface{}{}
 	}
 }
 
 func (s *IPAddressSerializationSuite) TestNewIPAddress(c *gc.C) {
 	args := IPAddressArgs{
-		CIDR:              "10.0.0.0/24",
-		ProviderId:        "magic",
-		VLANTag:           64,
-		SpaceName:         "foo",
-		AvailabilityZone:  "bar",
-		AllocatableIPHigh: "10.0.0.255",
-		AllocatableIPLow:  "10.0.0.0",
+		SubnetCIDR:       "10.0.0.0/24",
+		ProviderID:       "magic",
+		DeviceName:       "foo",
+		MachineID:        "bar",
+		ConfigMethod:     "static",
+		Value:            "10.0.0.4",
+		DNSServers:       []string{"10.1.0.1", "10.2.0.1"},
+		DNSSearchDomains: []string{"bam", "mam"},
+		GatewayAddress:   "10.0.0.1",
 	}
 	address := newIPAddress(args)
-	c.Assert(address.CIDR(), gc.Equals, args.CIDR)
-	c.Assert(address.ProviderId(), gc.Equals, args.ProviderId)
-	c.Assert(address.VLANTag(), gc.Equals, args.VLANTag)
-	c.Assert(address.SpaceName(), gc.Equals, args.SpaceName)
-	c.Assert(address.AvailabilityZone(), gc.Equals, args.AvailabilityZone)
-	c.Assert(address.AllocatableIPHigh(), gc.Equals, args.AllocatableIPHigh)
-	c.Assert(address.AllocatableIPLow(), gc.Equals, args.AllocatableIPLow)
+	c.Assert(address.SubnetCIDR(), gc.Equals, args.SubnetCIDR)
+	c.Assert(address.ProviderID(), gc.Equals, args.ProviderID)
+	c.Assert(address.DeviceName(), gc.Equals, args.DeviceName)
+	c.Assert(address.MachineID(), gc.Equals, args.MachineID)
+	c.Assert(address.ConfigMethod(), gc.Equals, args.ConfigMethod)
+	c.Assert(address.Value(), gc.Equals, args.Value)
+	c.Assert(address.DNSServers(), gc.Equals, args.DNSServers)
+	c.Assert(address.DNSSearchDomains(), gc.Equals, args.DNSSearchDomains)
+	c.Assert(address.GatewayAddress(), gc.Equals, args.GatewayAddress)
 }
 
 func (s *IPAddressSerializationSuite) TestParsingSerializedData(c *gc.C) {
-	initial := addresss{
+	initial := ipaddresses{
 		Version: 1,
-		IPAddresss_: []*address{
+		IPAddresses_: []*ipaddress{
 			newIPAddress(IPAddressArgs{
-				CIDR:              "10.0.0.0/24",
-				ProviderId:        "magic",
-				VLANTag:           64,
-				SpaceName:         "foo",
-				AvailabilityZone:  "bar",
-				AllocatableIPHigh: "10.0.0.255",
-				AllocatableIPLow:  "10.0.0.0",
+				SubnetCIDR:       "10.0.0.0/24",
+				ProviderID:       "magic",
+				DeviceName:       "foo",
+				MachineID:        "bar",
+				ConfigMethod:     "static",
+				Value:            "10.0.0.4",
+				DNSServers:       []string{"10.1.0.1", "10.2.0.1"},
+				DNSSearchDomains: []string{"bam", "mam"},
+				GatewayAddress:   "10.0.0.1",
 			}),
-			newIPAddress(IPAddressArgs{CIDR: "10.0.1.0/24"}),
+			newIPAddress(IPAddressArgs{Value: "10.0.0.5"}),
 		},
 	}
 
@@ -71,8 +77,8 @@ func (s *IPAddressSerializationSuite) TestParsingSerializedData(c *gc.C) {
 	err = yaml.Unmarshal(bytes, &source)
 	c.Assert(err, jc.ErrorIsNil)
 
-	addresss, err := importIPAddresss(source)
+	addresses, err := importIPAddresses(source)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(addresss, jc.DeepEquals, initial.IPAddresss_)
+	c.Assert(addresses, jc.DeepEquals, initial.IPAddresses_)
 }

--- a/core/description/ipaddresses.go
+++ b/core/description/ipaddresses.go
@@ -14,15 +14,88 @@ type ipaddresses struct {
 }
 
 type ipaddress struct {
+	ProviderID_       string
+	DeviceName_       string
+	MachineID_        string
+	SubnetCIDR_       string
+	ConfigMethod_     string
+	Value_            string
+	DNSServers_       []string
+	DNSSearchDomains_ []string
+	GatewayAddress_   string
+}
+
+// ProviderID implements IPAddress.
+func (i *ipaddress) ProviderID() string {
+	return i.ProviderID_
+}
+
+// DeviceName implements IPAddress.
+func (i *ipaddress) DeviceName() string {
+	return i.DeviceName_
+}
+
+// MachineID implements IPAddress.
+func (i *ipaddress) MachineID() string {
+	return i.MachineID_
+}
+
+// SubnetCIDR implements IPAddress.
+func (i *ipaddress) SubnetCIDR() string {
+	return i.SubnetCIDR_
+}
+
+// ConfigMethod implements IPAddress.
+func (i *ipaddress) ConfigMethod() string {
+	return i.ConfigMethod_
+}
+
+// Value implements IPAddress.
+func (i *ipaddress) Value() string {
+	return i.Value_
+}
+
+// DNSServers implements IPAddress.
+func (i *ipaddress) DNSServers() []string {
+	return i.DNSServers_
+}
+
+// DNSSearchDomains implements IPAddress.
+func (i *ipaddress) DNSSearchDomains() []string {
+	return i.DNSSearchDomains_
+}
+
+// GatewayAddress implements IPAddress.
+func (i *ipaddress) GatewayAddress() string {
+	return i.GatewayAddress_
 }
 
 // IPAddressArgs is an argument struct used to create a
 // new internal ipaddress type that supports the IPAddress interface.
 type IPAddressArgs struct {
+	ProviderID       string
+	DeviceName       string
+	MachineID        string
+	SubnetCIDR       string
+	ConfigMethod     string
+	Value            string
+	DNSServers       []string
+	DNSSearchDomains []string
+	GatewayAddress   string
 }
 
 func newIPAddress(args IPAddressArgs) *ipaddress {
-	return &ipaddress{}
+	return &ipaddress{
+		ProviderID_:       args.ProviderID,
+		DeviceName_:       args.DeviceName,
+		MachineID_:        args.MachineID,
+		SubnetCIDR_:       args.SubnetCIDR,
+		ConfigMethod_:     args.ConfigMethod,
+		Value_:            args.Value,
+		DNSServers_:       args.DNSServers,
+		DNSSearchDomains_: args.DNSSearchDomains,
+		GatewayAddress_:   args.GatewayAddress,
+	}
 }
 
 func importIPAddresses(source map[string]interface{}) ([]*ipaddress, error) {

--- a/core/description/ipaddresses.go
+++ b/core/description/ipaddresses.go
@@ -1,0 +1,84 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+)
+
+type ipaddresss struct {
+	Version     int          `yaml:"version"`
+	IPAddresss_ []*ipaddress `yaml:"ipaddresss"`
+}
+
+type ipaddress struct {
+}
+
+// IPAddressArgs is an argument struct used to create a
+// new internal ipaddress type that supports the IPAddress interface.
+type IPAddressArgs struct {
+}
+
+func newIPAddress(args IPAddressArgs) *ipaddress {
+	return &ipaddress{}
+}
+
+func importIPAddresss(source map[string]interface{}) ([]*ipaddress, error) {
+	checker := versionedChecker("ipaddresss")
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "ipaddresss version schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+
+	version := int(valid["version"].(int64))
+	importFunc, ok := ipaddressDeserializationFuncs[version]
+	if !ok {
+		return nil, errors.NotValidf("version %d", version)
+	}
+	sourceList := valid["ipaddresss"].([]interface{})
+	return importIPAddressList(sourceList, importFunc)
+}
+
+func importIPAddressList(sourceList []interface{}, importFunc ipaddressDeserializationFunc) ([]*ipaddress, error) {
+	result := make([]*ipaddress, 0, len(sourceList))
+	for i, value := range sourceList {
+		source, ok := value.(map[string]interface{})
+		if !ok {
+			return nil, errors.Errorf("unexpected value for ipaddress %d, %T", i, value)
+		}
+		ipaddress, err := importFunc(source)
+		if err != nil {
+			return nil, errors.Annotatef(err, "ipaddress %d", i)
+		}
+		result = append(result, ipaddress)
+	}
+	return result, nil
+}
+
+type ipaddressDeserializationFunc func(map[string]interface{}) (*ipaddress, error)
+
+var ipaddressDeserializationFuncs = map[int]ipaddressDeserializationFunc{
+	1: importIPAddressV1,
+}
+
+func importIPAddressV1(source map[string]interface{}) (*ipaddress, error) {
+	fields := schema.Fields{}
+	// Some values don't have to be there.
+	defaults := schema.Defaults{
+		"provider-id": "",
+	}
+	checker := schema.FieldMap(fields, defaults)
+
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "ipaddress v1 schema check failed")
+	}
+	// XXX valid :=
+	_ = coerced.(map[string]interface{})
+	// From here we know that the map returned from the schema coercion
+	// contains fields of the right type.
+	return &ipaddress{}, nil
+}

--- a/core/description/ipaddresses.go
+++ b/core/description/ipaddresses.go
@@ -138,7 +138,17 @@ var ipaddressDeserializationFuncs = map[int]ipaddressDeserializationFunc{
 }
 
 func importIPAddressV1(source map[string]interface{}) (*ipaddress, error) {
-	fields := schema.Fields{}
+	fields := schema.Fields{
+		"provider-id":      schema.String(),
+		"devicename":       schema.String(),
+		"machineid":        schema.String(),
+		"subnetcidr":       schema.String(),
+		"configmethod":     schema.String(),
+		"value":            schema.String(),
+		"dnsservers":       schema.List(schema.String()),
+		"dnssearchdomains": schema.List(schema.String()),
+		"gatewayaddress":   schema.String(),
+	}
 	// Some values don't have to be there.
 	defaults := schema.Defaults{
 		"provider-id": "",
@@ -149,9 +159,18 @@ func importIPAddressV1(source map[string]interface{}) (*ipaddress, error) {
 	if err != nil {
 		return nil, errors.Annotatef(err, "ipaddress v1 schema check failed")
 	}
-	// XXX valid :=
-	_ = coerced.(map[string]interface{})
+	valid := coerced.(map[string]interface{})
 	// From here we know that the map returned from the schema coercion
 	// contains fields of the right type.
-	return &ipaddress{}, nil
+	return &ipaddress{
+		ProviderID_:       valid["provider-id"].(string),
+		DeviceName_:       valid["devicename"].(string),
+		MachineID_:        valid["machinename"].(string),
+		SubnetCIDR_:       valid["subnetcidr"].(string),
+		ConfigMethod_:     valid["configmethod"].(string),
+		Value_:            valid["value"].(string),
+		DNSServers_:       valid["dnsservers"].([]string),
+		DNSSearchDomains_: valid["dnssearchdomains"].([]string),
+		GatewayAddress_:   valid["gatewayaddress"].(string),
+	}, nil
 }

--- a/core/description/ipaddresses.go
+++ b/core/description/ipaddresses.go
@@ -8,9 +8,9 @@ import (
 	"github.com/juju/schema"
 )
 
-type ipaddresss struct {
-	Version     int          `yaml:"version"`
-	IPAddresss_ []*ipaddress `yaml:"ipaddresss"`
+type ipaddresses struct {
+	Version      int          `yaml:"version"`
+	IPAddresses_ []*ipaddress `yaml:"ipaddresses"`
 }
 
 type ipaddress struct {
@@ -25,11 +25,11 @@ func newIPAddress(args IPAddressArgs) *ipaddress {
 	return &ipaddress{}
 }
 
-func importIPAddresss(source map[string]interface{}) ([]*ipaddress, error) {
-	checker := versionedChecker("ipaddresss")
+func importIPAddresses(source map[string]interface{}) ([]*ipaddress, error) {
+	checker := versionedChecker("ipaddresses")
 	coerced, err := checker.Coerce(source, nil)
 	if err != nil {
-		return nil, errors.Annotatef(err, "ipaddresss version schema check failed")
+		return nil, errors.Annotatef(err, "ipaddresses version schema check failed")
 	}
 	valid := coerced.(map[string]interface{})
 
@@ -38,7 +38,7 @@ func importIPAddresss(source map[string]interface{}) ([]*ipaddress, error) {
 	if !ok {
 		return nil, errors.NotValidf("version %d", version)
 	}
-	sourceList := valid["ipaddresss"].([]interface{})
+	sourceList := valid["ipaddresses"].([]interface{})
 	return importIPAddressList(sourceList, importFunc)
 }
 

--- a/core/description/ipaddresses.go
+++ b/core/description/ipaddresses.go
@@ -14,15 +14,15 @@ type ipaddresses struct {
 }
 
 type ipaddress struct {
-	ProviderID_       string
-	DeviceName_       string
-	MachineID_        string
-	SubnetCIDR_       string
-	ConfigMethod_     string
-	Value_            string
-	DNSServers_       []string
-	DNSSearchDomains_ []string
-	GatewayAddress_   string
+	ProviderID_       string   `yaml:"provider-id,omitempty"`
+	DeviceName_       string   `yaml:"devicename"`
+	MachineID_        string   `yaml:"machineid"`
+	SubnetCIDR_       string   `yaml:"subnetcidr"`
+	ConfigMethod_     string   `yaml:"configmethod"`
+	Value_            string   `yaml:"value"`
+	DNSServers_       []string `yaml:"dnsservers"`
+	DNSSearchDomains_ []string `yaml:"dnssearchdomains"`
+	GatewayAddress_   string   `yaml:"gatewayaddress"`
 }
 
 // ProviderID implements IPAddress.
@@ -160,17 +160,25 @@ func importIPAddressV1(source map[string]interface{}) (*ipaddress, error) {
 		return nil, errors.Annotatef(err, "ipaddress v1 schema check failed")
 	}
 	valid := coerced.(map[string]interface{})
-	// From here we know that the map returned from the schema coercion
-	// contains fields of the right type.
+	dnsserversInterface := valid["dnsservers"].([]interface{})
+	dnsservers := make([]string, len(dnsserversInterface))
+	for i, d := range dnsserversInterface {
+		dnsservers[i] = d.(string)
+	}
+	dnssearchInterface := valid["dnssearchdomains"].([]interface{})
+	dnssearch := make([]string, len(dnssearchInterface))
+	for i, d := range dnssearchInterface {
+		dnssearch[i] = d.(string)
+	}
 	return &ipaddress{
 		ProviderID_:       valid["provider-id"].(string),
 		DeviceName_:       valid["devicename"].(string),
-		MachineID_:        valid["machinename"].(string),
+		MachineID_:        valid["machineid"].(string),
 		SubnetCIDR_:       valid["subnetcidr"].(string),
 		ConfigMethod_:     valid["configmethod"].(string),
 		Value_:            valid["value"].(string),
-		DNSServers_:       valid["dnsservers"].([]string),
-		DNSSearchDomains_: valid["dnssearchdomains"].([]string),
+		DNSServers_:       dnsservers,
+		DNSSearchDomains_: dnssearch,
 		GatewayAddress_:   valid["gatewayaddress"].(string),
 	}, nil
 }

--- a/core/description/model.go
+++ b/core/description/model.go
@@ -251,7 +251,7 @@ func (m *model) IPAddresses() []IPAddress {
 // AddIPAddress implements Model.
 func (m *model) AddIPAddress(args IPAddressArgs) IPAddress {
 	addr := newIPAddress(args)
-	m.IPAddresses_.IPAddresses = append(m.IPAddresses_.IPAddresses_, addr)
+	m.IPAddresses_.IPAddresses_ = append(m.IPAddresses_.IPAddresses_, addr)
 	return addr
 }
 

--- a/core/description/model_test.go
+++ b/core/description/model_test.go
@@ -326,3 +326,19 @@ func (s *ModelSerializationSuite) TestModelSerializationWithRelations(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(model, jc.DeepEquals, initial)
 }
+
+func (s *ModelSerializationSuite) TestIPAddress(c *gc.C) {
+	initial := NewModel(ModelArgs{Owner: names.NewUserTag("owner")})
+	addr := initial.AddIPAddress(IPAddressArgs{Value: "10.0.0.4"})
+	c.Assert(addr.Value(), gc.Equals, "10.0.0.4")
+	addresses := initial.IPAddresses()
+	c.Assert(addresses, gc.HasLen, 1)
+	c.Assert(addresses[0], jc.DeepEquals, addr)
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := Deserialize(bytes)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(model.IPAddresses(), jc.DeepEquals, addresses)
+}

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -328,3 +328,19 @@ func (st *State) forEachIPAddressDoc(findQuery bson.D, callbackFunc func(resultD
 
 	return errors.Trace(iter.Close())
 }
+
+// AllIPAddresses returns all ip addresses in the model.
+func (st *State) AllIPAddresses() (addresses []*Address, err error) {
+	addressesCollection, closer := st.getCollection(ipAddressesC)
+	defer closer()
+
+	sdocs := []ipAddressDoc{}
+	err = addressesCollection.Find(bson.D{}).All(&sdocs)
+	if err != nil {
+		return nil, errors.Errorf("cannot get all ip addresses")
+	}
+	for _, a := range sdocs {
+		addresses = append(services, newIPAddress(st, &a))
+	}
+	return address, nil
+}

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -340,7 +340,7 @@ func (st *State) AllIPAddresses() (addresses []*Address, err error) {
 		return nil, errors.Errorf("cannot get all ip addresses")
 	}
 	for _, a := range sdocs {
-		addresses = append(services, newIPAddress(st, &a))
+		addresses = append(addresses, newIPAddress(st, a))
 	}
-	return address, nil
+	return addresses, nil
 }

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -595,8 +595,18 @@ func (e *exporter) ipaddresses() error {
 		return errors.Trace(err)
 	}
 	e.logger.Debugf("read %d ip addresses", len(ipaddresses))
-	for _, address := range ipaddresses {
-		e.model.AddIPAddress(description.IPAddressArgs{})
+	for _, addr := range ipaddresses {
+		e.model.AddIPAddress(description.IPAddressArgs{
+			ProviderID:       string(addr.ProviderID()),
+			DeviceName:       addr.DeviceName(),
+			MachineID:        addr.MachineID(),
+			SubnetCIDR:       addr.SubnetCIDR(),
+			ConfigMethod:     string(addr.ConfigMethod()),
+			Value:            addr.Value(),
+			DNSServers:       addr.DNSServers(),
+			DNSSearchDomains: addr.DNSSearchDomains(),
+			GatewayAddress:   addr.GatewayAddress(),
+		})
 	}
 	return nil
 }

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -85,6 +85,10 @@ func (st *State) Export() (description.Model, error) {
 		return nil, errors.Trace(err)
 	}
 
+	if err := export.ipaddresses(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	if err := export.model.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -583,6 +587,10 @@ func (e *exporter) relations() error {
 		}
 	}
 	return nil
+}
+
+func (e *exporter) ipaddresses() error {
+	ipaddresses, err := e.st.AllIPAddresses()
 }
 
 func (e *exporter) readAllRelationScopes() (set.Strings, error) {

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -591,6 +591,14 @@ func (e *exporter) relations() error {
 
 func (e *exporter) ipaddresses() error {
 	ipaddresses, err := e.st.AllIPAddresses()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	e.logger.Debugf("read %d ip addresses", len(ipaddresses))
+	for _, address := range ipaddresses {
+		e.model.AddIPAddress(description.IPAddressArgs{})
+	}
+	return nil
 }
 
 func (e *exporter) readAllRelationScopes() (set.Strings, error) {

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -459,7 +459,7 @@ func (s *MigrationExportSuite) TestIPAddresses(c *gc.C) {
 	c.Assert(addresses, gc.HasLen, 1)
 	addr := addresses[0]
 	c.Assert(addr.Value(), gc.Equals, "0.1.2.3")
-	c.Assert(addr.MachineID(), gc.Equals, string(machine.Id()))
+	c.Assert(addr.MachineID(), gc.Equals, machine.Id())
 	c.Assert(addr.DeviceName(), gc.Equals, "foo")
 	c.Assert(addr.ConfigMethod(), gc.Equals, string(state.StaticAddress))
 	c.Assert(addr.SubnetCIDR(), gc.Equals, "0.1.2.0/24")

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -428,6 +428,47 @@ func (s *MigrationExportSuite) TestRelations(c *gc.C) {
 	checkEndpoint(exEps[1], wordpress_0.Name(), wpEp, wordpressSettings)
 }
 
+func (s *MigrationExportSuite) TestIPAddresses(c *gc.C) {
+	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
+		Constraints: constraints.MustParse("arch=amd64 mem=8G"),
+	})
+	_, err := s.State.AddSubnet(state.SubnetInfo{CIDR: "0.1.2.0/24"})
+	c.Assert(err, jc.ErrorIsNil)
+	deviceArgs := state.LinkLayerDeviceArgs{
+		Name: "foo",
+		Type: state.EthernetDevice,
+	}
+	err = machine.SetLinkLayerDevices(deviceArgs)
+	c.Assert(err, jc.ErrorIsNil)
+	args := state.LinkLayerDeviceAddress{
+		DeviceName:       "foo",
+		ConfigMethod:     state.StaticAddress,
+		CIDRAddress:      "0.1.2.3/24",
+		ProviderID:       "bar",
+		DNSServers:       []string{"bam", "mam"},
+		DNSSearchDomains: []string{"weeee"},
+		GatewayAddress:   "0.1.2.1",
+	}
+	err = machine.SetDevicesAddresses(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := s.State.Export()
+	c.Assert(err, jc.ErrorIsNil)
+
+	addresses := model.IPAddresses()
+	c.Assert(addresses, gc.HasLen, 1)
+	addr := addresses[0]
+	c.Assert(addr.Value(), gc.Equals, "0.1.2.3")
+	c.Assert(addr.MachineID(), gc.Equals, string(machine.Id()))
+	c.Assert(addr.DeviceName(), gc.Equals, "foo")
+	c.Assert(addr.ConfigMethod(), gc.Equals, string(state.StaticAddress))
+	c.Assert(addr.SubnetCIDR(), gc.Equals, "0.1.2.0/24")
+	c.Assert(addr.ProviderID(), gc.Equals, "bar")
+	c.Assert(addr.DNSServers(), jc.DeepEquals, []string{"bam", "mam"})
+	c.Assert(addr.DNSSearchDomains(), jc.DeepEquals, []string{"weeee"})
+	c.Assert(addr.GatewayAddress(), gc.Equals, "0.1.2.1")
+}
+
 type goodToken struct{}
 
 // Check implements leadership.Token

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -94,6 +94,9 @@ func (st *State) Import(model description.Model) (_ *Model, _ *State, err error)
 	if err := restore.relations(); err != nil {
 		return nil, nil, errors.Annotate(err, "relations")
 	}
+	if err := restore.ipaddresses(); err != nil {
+		return nil, nil, errors.Annotate(err, "ipaddresses")
+	}
 
 	// NOTE: at the end of the import make sure that the mode of the model
 	// is set to "imported" not "active" (or whatever we call it). This way
@@ -798,6 +801,19 @@ func (i *importer) makeRelationDoc(rel description.Relation) *relationDoc {
 		doc.UnitCount += ep.UnitCount()
 	}
 	return doc
+}
+
+func (i *importer) ipaddresses() error {
+	i.logger.Debugf("importing ip addresses")
+	for _ = range i.model.IPAddresses() {
+		_, err := i.st.AddIPAddress()
+		if err != nil {
+			i.logger.Errorf("error importing ip address: %s", err)
+			return errors.Trace(err)
+		}
+	}
+	i.logger.Debugf("importing ip addresses succeeded")
+	return nil
 }
 
 func (i *importer) importStatusHistory(globalKey string, history []description.Status) error {

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -494,6 +494,50 @@ func (s *MigrationImportSuite) assertDestroyModelAdvancesLife(c *gc.C, m *state.
 	c.Assert(m.Life(), gc.Equals, life)
 }
 
+func (s *MigrationImportSuite) TestIPAddress(c *gc.C) {
+	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
+		Constraints: constraints.MustParse("arch=amd64 mem=8G"),
+	})
+	_, err := s.State.AddSubnet(state.SubnetInfo{CIDR: "0.1.2.0/24"})
+	c.Assert(err, jc.ErrorIsNil)
+	deviceArgs := state.LinkLayerDeviceArgs{
+		Name: "foo",
+		Type: state.EthernetDevice,
+	}
+	err = machine.SetLinkLayerDevices(deviceArgs)
+	c.Assert(err, jc.ErrorIsNil)
+	args := state.LinkLayerDeviceAddress{
+		DeviceName:       "foo",
+		ConfigMethod:     state.StaticAddress,
+		CIDRAddress:      "0.1.2.3/24",
+		ProviderID:       "bar",
+		DNSServers:       []string{"bam", "mam"},
+		DNSSearchDomains: []string{"weeee"},
+		GatewayAddress:   "0.1.2.1",
+	}
+	err = machine.SetDevicesAddresses(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, newSt := s.importModel(c)
+	defer func() {
+		c.Assert(newSt.Close(), jc.ErrorIsNil)
+	}()
+
+	addresses, _ := newSt.AllIPAddresses()
+	c.Assert(addresses, gc.HasLen, 1)
+	c.Assert(err, jc.ErrorIsNil)
+	addr := addresses[0]
+	c.Assert(addr.Value(), gc.Equals, "0.1.2.3")
+	c.Assert(addr.MachineID(), gc.Equals, machine.Id())
+	c.Assert(addr.DeviceName(), gc.Equals, "foo")
+	c.Assert(addr.ConfigMethod(), gc.Equals, state.StaticAddress)
+	c.Assert(addr.SubnetCIDR(), gc.Equals, "0.1.2.0/24")
+	c.Assert(addr.ProviderID(), gc.Equals, network.Id("bar"))
+	c.Assert(addr.DNSServers(), jc.DeepEquals, []string{"bam", "mam"})
+	c.Assert(addr.DNSSearchDomains(), jc.DeepEquals, []string{"weeee"})
+	c.Assert(addr.GatewayAddress(), gc.Equals, "0.1.2.1")
+}
+
 // newModel replaces the uuid and name of the config attributes so we
 // can use all the other data to validate imports. An owner and name of the
 // model are unique together in a controller.

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -45,6 +45,9 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// relation
 		relationsC,
 		relationScopesC,
+
+		// networking
+		ipAddressesC,
 	)
 
 	ignoredCollections := set.NewStrings(
@@ -139,7 +142,6 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		volumeAttachmentsC,
 
 		// network
-		ipAddressesC,
 		providerIDsC,
 		linkLayerDevicesC,
 		linkLayerDevicesRefsC,
@@ -512,6 +514,25 @@ func (s *MigrationSuite) TestHistoricalStatusDocFields(c *gc.C) {
 		"Updated",
 	)
 	s.AssertExportedFields(c, historicalStatusDoc{}, fields)
+}
+
+func (s *MigrationSuite) TestIPAddressDocFields(c *gc.C) {
+	ignored := set.NewStrings(
+		"DocID",
+		"ModelUUID",
+	)
+	migrated := set.NewStrings(
+		"DeviceName",
+		"MachineID",
+		"DNSSearchDomains",
+		"GatewayAddress",
+		"ProviderID",
+		"DNSServers",
+		"SubnetCIDR",
+		"ConfigMethod",
+		"Value",
+	)
+	s.AssertExportedFields(c, ipAddressDoc{}, migrated.Union(ignored))
 }
 
 func (s *MigrationSuite) AssertExportedFields(c *gc.C, doc interface{}, fields set.Strings) {


### PR DESCRIPTION
Add ip addresses to the core/description model, and add the methods to export and import addresses.

(Review request: http://reviews.vapour.ws/r/4947/)