### PR TITLE
Don't run state or state/backup tests on non-Ubuntu machines.

### DIFF
--- a/state/backups/package_test.go
+++ b/state/backups/package_test.go
@@ -6,9 +6,13 @@ package backups_test
 import (
 	stdtesting "testing"
 
+	"github.com/juju/utils/os"
+
 	"github.com/juju/juju/testing"
 )
 
 func Test(t *stdtesting.T) {
-	testing.MgoTestPackage(t)
+	if os.HostOS() == os.Ubuntu {
+		testing.MgoTestPackage(t)
+	}
 }

--- a/state/package_test.go
+++ b/state/package_test.go
@@ -6,9 +6,16 @@ package state_test
 import (
 	stdtesting "testing"
 
+	"github.com/juju/utils/os"
+
 	coretesting "github.com/juju/juju/testing"
 )
 
 func TestPackage(t *stdtesting.T) {
-	coretesting.MgoTestPackage(t)
+	// At this stage, Juju only supports running the apiservers and database
+	// on Ubuntu. If we end up officially supporting CentOS, then we should
+	// make sure we run the tests there.
+	if os.HostOS() == os.Ubuntu {
+		coretesting.MgoTestPackage(t)
+	}
 }


### PR DESCRIPTION
Use the os package to determine OS.

(Review request: http://reviews.vapour.ws/r/4949/)