### PR TITLE
Fixes LP#1514874: login failures with valid credentials.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -368,7 +368,11 @@ func NewAgentConfig(configParams AgentConfigParams) (ConfigSetterWriter, error) 
 		return nil, errors.Trace(requiredError("CA certificate"))
 	}
 	// Note that the password parts of the state and api information are
-	// blank.  This is by design.
+	// blank.  This is by design: we want to generate a secure password
+	// for new agents. So, we create this config without a current password
+	// which signals to apicaller worker that it should try to connect using old password.
+	// When/if this connection is successful, apicaller worker will generate
+	// a new secure password and update this agent's config.
 	config := &configInternal{
 		logDir:            logDir,
 		dataDir:           configParams.DataDir,

--- a/worker/apicaller/open.go
+++ b/worker/apicaller/open.go
@@ -99,8 +99,6 @@ func OpenAPIState(a agent.Agent) (_ api.Connection, err error) {
 			return nil, err
 		}
 
-		// Before we reconnect to the API with the new password,
-		// let's close established connection.
 		if err := st.Close(); err != nil {
 			logger.Errorf("while closing API connection with old password: %v", err)
 		}

--- a/worker/apicaller/open.go
+++ b/worker/apicaller/open.go
@@ -52,12 +52,6 @@ func OpenAPIState(a agent.Agent) (_ api.Connection, err error) {
 	if err != nil {
 		return nil, err
 	}
-	if info.Password == agentConfig.OldPassword() {
-		// If current password and old password are the same,
-		// we need to generate new password.
-		logger.Debugf("password sent over wire worked")
-		usedOldPassword = true
-	}
 	defer func() {
 		// NOTE(fwereade): we may close and overwrite st below,
 		// so we need to double-check what we need to do here.
@@ -171,6 +165,7 @@ func openAPIStateUsingInfo(info *api.Info, oldPassword string) (api.Connection, 
 		infoCopy := *info
 		info = &infoCopy
 		info.Password = oldPassword
+		logger.Debugf("connecting with old password")
 		st, err = apiOpen(info, api.DialOpts{})
 	}
 	// The provisioner may take some time to record the agent's


### PR DESCRIPTION
When we create agent configuration for juju entities, we do not specify password since we want to generate a new one. However, we do have access to the old password sent over wire.

Prior to this PR, we would try to login 3 times:
1.  with no password and, as expected, we would fail with authentication issues;
2. with old password and will connect;
3. with newly generated/updated password.

This PR ensures that we do not try to login with no password \o/

I am still running tests suites but am proposing the actual code change to get early feedback.

(Review request: http://reviews.vapour.ws/r/4951/)