### PR TITLE
Fixes LP#1514874 (master): login failures with valid credentials.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -418,7 +418,11 @@ func NewAgentConfig(configParams AgentConfigParams) (ConfigSetterWriter, error) 
 		return nil, errors.Trace(requiredError("CA certificate"))
 	}
 	// Note that the password parts of the state and api information are
-	// blank.  This is by design.
+	// blank.  This is by design: we want to generate a secure password
+	// for new agents. So, we create this config without a current password
+	// which signals to apicaller worker that it should try to connect using old password.
+	// When/if this connection is successful, apicaller worker will generate
+	// a new secure password and update this agent's config.
 	config := &configInternal{
 		paths:             NewPathsWithDefaults(configParams.Paths),
 		jobs:              configParams.Jobs,

--- a/worker/apicaller/connect.go
+++ b/worker/apicaller/connect.go
@@ -103,17 +103,24 @@ func connectFallback(
 		conn, err = apiOpen(info, api.DialOpts{})
 	}
 
+	didFallback = info.Password == ""
 	// Try to connect, trying both the primary and fallback
 	// passwords if necessary; and update info, and remember
 	// which password we used.
-	tryConnect()
-	if params.IsCodeUnauthorized(err) {
+	if !didFallback {
+		tryConnect()
+		if params.IsCodeUnauthorized(err) {
+			didFallback = true
+
+		}
+	}
+	if didFallback {
 		// We've perhaps used the wrong password, so
 		// try again with the fallback password.
 		infoCopy := *info
 		info = &infoCopy
 		info.Password = fallbackPassword
-		didFallback = true
+		logger.Debugf("connecting with old password")
 		tryConnect()
 	}
 


### PR DESCRIPTION
When we create agent configuration for juju entities, we do not specify password since we want to generate a new one. However, we do have access to the old password sent over wire.

Prior to this PR, we would try to login 3 times:
1. with no password and, as expected, we would fail with authentication issues;
2. with old password and will connect;
3. with newly generated/updated password.

This PR ensures that we do not try to login with no password.

(Review request: http://reviews.vapour.ws/r/4954/)