### PR TITLE
Fixed lp:1576674: Refactored network config in userdata for containers

### DIFF
--- a/apiserver/uniter/uniter.go
+++ b/apiserver/uniter/uniter.go
@@ -1585,7 +1585,7 @@ func (u *UniterAPIV3) getOneNetworkConfig(canAccess common.AuthFunc, unitTagArg,
 		)
 
 		privateAddress, err := machine.PrivateAddress()
-		if err != nil && !network.IsNoAddressError(err) {
+		if err != nil {
 			return nil, errors.Annotatef(err, "getting machine %q preferred private address", machineID)
 		}
 
@@ -1613,13 +1613,13 @@ func (u *UniterAPIV3) getOneNetworkConfig(canAccess common.AuthFunc, unitTagArg,
 
 	for _, addr := range addresses {
 		subnet, err := addr.Subnet()
-		if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Debugf("skipping %s: not linked to a known subnet (%v)", addr, err)
+			continue
+		} else if err != nil {
 			return nil, errors.Annotatef(err, "cannot get subnet for address %q", addr)
 		}
-		if subnet == nil {
-			logger.Debugf("skipping %s: not linked to a known subnet", addr)
-			continue
-		}
+
 		if space := subnet.SpaceName(); space != boundSpace {
 			logger.Debugf("skipping %s: want bound to space %q, got space %q", addr, boundSpace, space)
 			continue

--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -10,11 +10,11 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"strings"
-	"text/template"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/proxy"
+	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/cloudconfig"
 	"github.com/juju/juju/cloudconfig/cloudinit"
@@ -58,90 +58,126 @@ func WriteCloudInitFile(directory string, userData []byte) (string, error) {
 	return userDataFilename, nil
 }
 
-// networkConfigTemplate defines how to render /etc/network/interfaces
-// file for a container with one or more NICs.
-const networkConfigTemplate = `
-# loopback interface
-auto lo
-iface lo inet loopback{{define "static"}}
-{{.InterfaceName | printf "# interface %q"}}{{if not .NoAutoStart}}
-auto {{.InterfaceName}}{{end}}
-iface {{.InterfaceName}} inet manual{{if gt (len .DNSServers) 0}}
-    dns-nameservers{{range $dns := .DNSServers}} {{$dns.Value}}{{end}}{{end}}{{if gt (len .DNSSearch) 0}}
-    dns-search {{.DNSSearch}}{{end}}
-    pre-up ip address add {{.Address.Value}}/32 dev {{.InterfaceName}} &> /dev/null || true
-    up ip route replace {{.GatewayAddress.Value}} dev {{.InterfaceName}}
-    up ip route replace default via {{.GatewayAddress.Value}}
-    down ip route del default via {{.GatewayAddress.Value}} &> /dev/null || true
-    down ip route del {{.GatewayAddress.Value}} dev {{.InterfaceName}} &> /dev/null || true
-    post-down ip address del {{.Address.Value}}/32 dev {{.InterfaceName}} &> /dev/null || true
-{{end}}{{define "dhcp"}}
-{{.InterfaceName | printf "# interface %q"}}{{if not .NoAutoStart}}
-auto {{.InterfaceName}}{{end}}
-iface {{.InterfaceName}} inet dhcp
-{{end}}{{range $nic := . }}{{if eq $nic.ConfigType "static"}}
-{{template "static" $nic}}{{else}}{{template "dhcp" $nic}}{{end}}{{end}}`
+var networkInterfacesFile = "/etc/network/interfaces"
 
-// multiBridgeNetworkConfigTemplate defines how to render /etc/network/interfaces
-// file for a multi-NIC container.
-const multiBridgeNetworkConfigTemplate = `
-auto lo
-iface lo inet loopback
-{{range $nic := .}}{{template "single" $nic}}{{end}}
-{{define "single"}}{{if not .NoAutoStart}}
-auto {{.InterfaceName}}{{end}}
-iface {{.InterfaceName}} inet manual{{if .DNSServers}}
-  dns-nameservers{{range $srv := .DNSServers}} {{$srv.Value}}{{end}}{{end}}{{if .DNSSearchDomains}}
-  dns-search{{range $dom := .DNSSearchDomains}} {{$dom}}{{end}}{{end}}
-  pre-up ip address add {{.CIDRAddress}} dev {{.InterfaceName}} || true
-  up ip route replace {{.CIDR}} dev {{.InterfaceName}} || true
-  down ip route del {{.CIDR}} dev {{.InterfaceName}} || true
-  post-down address del {{.CIDRAddress}} dev {{.InterfaceName}} || true{{if .GatewayAddress.Value}}
-  up ip route replace default via {{.GatewayAddress.Value}} || true
-  down ip route del default via {{.GatewayAddress.Value}} || true{{end}}
-{{end}}`
-
-var networkInterfacesFile = "/etc/network/interfaces.d/00-juju.cfg"
-
-// GenerateNetworkConfig renders a network config for one or more
-// network interfaces, using the given non-nil networkConfig
-// containing a non-empty Interfaces field.
+// GenerateNetworkConfig renders a network config for one or more network
+// interfaces, using the given non-nil networkConfig containing a non-empty
+// Interfaces field.
 func GenerateNetworkConfig(networkConfig *container.NetworkConfig) (string, error) {
 	if networkConfig == nil || len(networkConfig.Interfaces) == 0 {
-		// Don't generate networking config.
 		logger.Tracef("no network config to generate")
 		return "", nil
 	}
 	logger.Debugf("generating network config from %#v", *networkConfig)
 
-	// Copy the InterfaceInfo before modifying the original.
-	interfacesCopy := make([]network.InterfaceInfo, len(networkConfig.Interfaces))
-	copy(interfacesCopy, networkConfig.Interfaces)
-	for i, info := range interfacesCopy {
-		if info.MACAddress != "" {
-			info.MACAddress = ""
+	prepared := PrepareNetworkConfigFromInterfaces(networkConfig.Interfaces)
+
+	var output bytes.Buffer
+	gatewayWritten := false
+	for _, name := range prepared.InterfaceNames {
+		output.WriteString("\n")
+		if name == "lo" {
+			output.WriteString("auto ")
+			autoStarted := strings.Join(prepared.AutoStarted, " ")
+			output.WriteString(autoStarted + "\n\n")
+			output.WriteString("iface lo inet loopback\n")
+
+			dnsServers := strings.Join(prepared.DNSServers, " ")
+			if dnsServers != "" {
+				output.WriteString("  dns-nameservers ")
+				output.WriteString(dnsServers + "\n")
+			}
+
+			dnsSearchDomains := strings.Join(prepared.DNSSearchDomains, " ")
+			if dnsSearchDomains != "" {
+				output.WriteString("  dns-search ")
+				output.WriteString(dnsSearchDomains + "\n")
+			}
+			continue
 		}
-		if info.InterfaceName != "eth0" {
-			info.GatewayAddress = network.Address{}
+
+		address, hasAddress := prepared.NameToAddress[name]
+		if !hasAddress {
+			output.WriteString("iface " + name + " inet manual\n")
+			continue
 		}
-		interfacesCopy[i] = info
+
+		output.WriteString("iface " + name + " inet static\n")
+		output.WriteString("  address " + address + "\n")
+		if !gatewayWritten && prepared.GatewayAddress != "" {
+			output.WriteString("  gateway " + prepared.GatewayAddress + "\n")
+			gatewayWritten = true // write it only once
+		}
 	}
 
-	// Render the config first.
-	tmpl, err := template.New("config").Parse(multiBridgeNetworkConfigTemplate)
-	if err != nil {
-		return "", errors.Annotate(err, "cannot parse network config template")
-	}
-
-	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, interfacesCopy); err != nil {
-		return "", errors.Annotate(err, "cannot render network config")
-	}
-
-	generatedConfig := buf.String()
-	logger.Debugf("generated network config from %#v\nusing%#v:\n%s", interfacesCopy, networkConfig.Interfaces, generatedConfig)
+	generatedConfig := output.String()
+	logger.Debugf("generated network config:\n%s", generatedConfig)
 
 	return generatedConfig, nil
+}
+
+// PreparedConfig holds all the necessary information to render a persistent
+// network config to a file.
+type PreparedConfig struct {
+	InterfaceNames   []string
+	AutoStarted      []string
+	DNSServers       []string
+	DNSSearchDomains []string
+	NameToAddress    map[string]string
+	GatewayAddress   string
+}
+
+// PrepareNetworkConfigFromInterfaces collects the necessary information to
+// render a persistent network config from the given slice of
+// network.InterfaceInfo. The result always includes the loopback interface.
+func PrepareNetworkConfigFromInterfaces(interfaces []network.InterfaceInfo) *PreparedConfig {
+	// Collect those two as they need all to rendered once.
+	dnsServers := set.NewStrings()
+	dnsSearchDomains := set.NewStrings()
+	gatewayAddress := ""
+
+	// Collect those for later rendering.
+	namesInOrder := make([]string, 1, len(interfaces)+1)
+	nameToAddress := make(map[string]string)
+
+	// Always include the loopback.
+	namesInOrder[0] = "lo"
+	autoStarted := set.NewStrings("lo")
+
+	for _, info := range interfaces {
+		if !info.NoAutoStart {
+			autoStarted.Add(info.InterfaceName)
+		}
+
+		if cidr := info.CIDRAddress(); cidr != "" {
+			nameToAddress[info.InterfaceName] = cidr
+		}
+
+		for _, dns := range info.DNSServers {
+			dnsServers.Add(dns.Value)
+		}
+
+		dnsSearchDomains = dnsSearchDomains.Union(set.NewStrings(info.DNSSearchDomains...))
+
+		if info.InterfaceName == "eth0" && gatewayAddress == "" {
+			// Only set gateway once for the primary NIC.
+			gatewayAddress = info.GatewayAddress.Value
+		}
+
+		namesInOrder = append(namesInOrder, info.InterfaceName)
+	}
+
+	prepared := &PreparedConfig{
+		InterfaceNames:   namesInOrder,
+		NameToAddress:    nameToAddress,
+		AutoStarted:      autoStarted.SortedValues(),
+		DNSServers:       dnsServers.SortedValues(),
+		DNSSearchDomains: dnsSearchDomains.SortedValues(),
+		GatewayAddress:   gatewayAddress,
+	}
+
+	logger.Debugf("prepared network config for rendering: %+v", prepared)
+	return prepared
 }
 
 // newCloudInitConfigWithNetworks creates a cloud-init config which

--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -131,12 +131,9 @@ type PreparedConfig struct {
 // render a persistent network config from the given slice of
 // network.InterfaceInfo. The result always includes the loopback interface.
 func PrepareNetworkConfigFromInterfaces(interfaces []network.InterfaceInfo) *PreparedConfig {
-	// Collect those two as they need all to rendered once.
 	dnsServers := set.NewStrings()
 	dnsSearchDomains := set.NewStrings()
 	gatewayAddress := ""
-
-	// Collect those for later rendering.
 	namesInOrder := make([]string, 1, len(interfaces)+1)
 	nameToAddress := make(map[string]string)
 

--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -168,8 +168,6 @@ class LogicalInterface(object):
         stanzas.append(AutoStanza(bridge_name))
         options = list(self.options)
         options.append("bridge_ports {}".format(self.name))
-        options.append("bridge_stp on")
-        options.append("bridge_maxwait 0")
         stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
         return stanzas
 
@@ -179,8 +177,6 @@ class LogicalInterface(object):
             stanzas.append(AutoStanza(bridge_name))
         options = [x for x in self.options if not x.startswith("vlan_id")]
         options.append("bridge_ports {}".format(self.name))
-        options.append("bridge_stp on")
-        options.append("bridge_maxwait 0")
         stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
         return stanzas
 
@@ -198,8 +194,6 @@ class LogicalInterface(object):
         stanzas.append(IfaceStanza(self.name, self.family, "manual", list(self.options)))
         options = [x for x in self.options if not x.startswith("bond")]
         options.append("bridge_ports {}".format(self.name))
-        options.append("bridge_stp on")
-        options.append("bridge_maxwait 0")
         stanzas.append(AutoStanza(bridge_name))
         stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
         return stanzas
@@ -455,11 +449,6 @@ def main(args):
     print_shell_cmd("cat {}".format(args.filename))
     print_shell_cmd("ip -d addr show")
     print_shell_cmd("ip route show")
-
-    # Remove any other config that can cause issues (i.e. DHCP on eth0 in
-    # addition to static)
-    print_shell_cmd("rm -f /etc/network/interfaces.d/*.cfg > /dev/null")
-    print_shell_cmd("rm -f /etc/systemd/network/50-cloud-init* > /dev/null")
 
 # This script re-renders an interfaces(5) file to add a bridge to
 # either all active interfaces, or a specific interface.

--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -456,6 +456,9 @@ def main(args):
     print_shell_cmd("ip -d addr show")
     print_shell_cmd("ip route show")
 
+    # Remove any other config that can cause issues (i.e. DHCP on eth0 in
+    # addition to static)
+    print_shell_cmd("rm -f /etc/network/interfaces.d/*.cfg > /dev/null")
     print_shell_cmd("rm -f /etc/systemd/network/50-cloud-init* > /dev/null")
 
 # This script re-renders an interfaces(5) file to add a bridge to

--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -164,51 +164,50 @@ class LogicalInterface(object):
             return self._bridge_device(bridge_name)
 
     def _bridge_device(self, bridge_name):
-        s1 = IfaceStanza(self.name, self.family, "manual", [])
-        s2 = AutoStanza(bridge_name)
+        stanzas = []
+        stanzas.append(AutoStanza(bridge_name))
         options = list(self.options)
         options.append("bridge_ports {}".format(self.name))
-        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
-        return [s1, s2, s3]
+        options.append("bridge_stp on")
+        options.append("bridge_maxwait 0")
+        stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
+        return stanzas
 
     def _bridge_vlan(self, bridge_name, add_auto_stanza):
         stanzas = []
-        s1 = IfaceStanza(self.name, self.family, "manual", self.options)
-        stanzas.append(s1)
         if add_auto_stanza:
             stanzas.append(AutoStanza(bridge_name))
-        options = [x for x in self.options if not x.startswith("vlan")]
+        options = [x for x in self.options if not x.startswith("vlan_id")]
         options.append("bridge_ports {}".format(self.name))
-        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
-        stanzas.append(s3)
+        options.append("bridge_stp on")
+        options.append("bridge_maxwait 0")
+        stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
         return stanzas
 
     def _bridge_alias(self, add_auto_stanza):
         stanzas = []
         if add_auto_stanza:
             stanzas.append(AutoStanza(self.name))
-        s1 = IfaceStanza(self.name, self.family, self.method, list(self.options))
-        stanzas.append(s1)
+        stanzas.append(IfaceStanza(self.name, self.family, self.method, list(self.options)))
         return stanzas
 
     def _bridge_bond(self, bridge_name, add_auto_stanza):
         stanzas = []
         if add_auto_stanza:
             stanzas.append(AutoStanza(self.name))
-        s1 = IfaceStanza(self.name, self.family, "manual", list(self.options))
-        s2 = AutoStanza(bridge_name)
+        stanzas.append(AutoStanza(bridge_name))
         options = [x for x in self.options if not x.startswith("bond")]
         options.append("bridge_ports {}".format(self.name))
-        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
-        stanzas.extend([s1, s2, s3])
+        options.append("bridge_stp on")
+        options.append("bridge_maxwait 0")
+        stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
         return stanzas
 
     def _bridge_unchanged(self, add_auto_stanza):
         stanzas = []
         if add_auto_stanza:
             stanzas.append(AutoStanza(self.name))
-        s1 = IfaceStanza(self.name, self.family, self.method, list(self.options))
-        stanzas.append(s1)
+        stanzas.append(IfaceStanza(self.name, self.family, self.method, list(self.options)))
         return stanzas
 
 
@@ -455,6 +454,8 @@ def main(args):
     print_shell_cmd("cat {}".format(args.filename))
     print_shell_cmd("ip -d addr show")
     print_shell_cmd("ip route show")
+
+    print_shell_cmd("rm -f /etc/systemd/network/50-cloud-init* > /dev/null")
 
 # This script re-renders an interfaces(5) file to add a bridge to
 # either all active interfaces, or a specific interface.

--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -195,11 +195,12 @@ class LogicalInterface(object):
         stanzas = []
         if add_auto_stanza:
             stanzas.append(AutoStanza(self.name))
-        stanzas.append(AutoStanza(bridge_name))
+        stanzas.append(IfaceStanza(self.name, self.family, "manual", list(self.options)))
         options = [x for x in self.options if not x.startswith("bond")]
         options.append("bridge_ports {}".format(self.name))
         options.append("bridge_stp on")
         options.append("bridge_maxwait 0")
+        stanzas.append(AutoStanza(bridge_name))
         stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
         return stanzas
 

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -468,6 +468,9 @@ def main(args):
     print_shell_cmd("ip -d addr show")
     print_shell_cmd("ip route show")
 
+    # Remove any other config that can cause issues (i.e. DHCP on eth0 in
+    # addition to static)
+    print_shell_cmd("rm -f /etc/network/interfaces.d/*.cfg > /dev/null")
     print_shell_cmd("rm -f /etc/systemd/network/50-cloud-init* > /dev/null")
 
 # This script re-renders an interfaces(5) file to add a bridge to

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -207,11 +207,12 @@ class LogicalInterface(object):
         stanzas = []
         if add_auto_stanza:
             stanzas.append(AutoStanza(self.name))
-        stanzas.append(AutoStanza(bridge_name))
+        stanzas.append(IfaceStanza(self.name, self.family, "manual", list(self.options)))
         options = [x for x in self.options if not x.startswith("bond")]
         options.append("bridge_ports {}".format(self.name))
         options.append("bridge_stp on")
         options.append("bridge_maxwait 0")
+        stanzas.append(AutoStanza(bridge_name))
         stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
         return stanzas
 

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -180,8 +180,6 @@ class LogicalInterface(object):
         stanzas.append(AutoStanza(bridge_name))
         options = list(self.options)
         options.append("bridge_ports {}".format(self.name))
-        options.append("bridge_stp on")
-        options.append("bridge_maxwait 0")
         stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
         return stanzas
 
@@ -191,8 +189,6 @@ class LogicalInterface(object):
             stanzas.append(AutoStanza(bridge_name))
         options = [x for x in self.options if not x.startswith("vlan_id")]
         options.append("bridge_ports {}".format(self.name))
-        options.append("bridge_stp on")
-        options.append("bridge_maxwait 0")
         stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
         return stanzas
 
@@ -210,8 +206,6 @@ class LogicalInterface(object):
         stanzas.append(IfaceStanza(self.name, self.family, "manual", list(self.options)))
         options = [x for x in self.options if not x.startswith("bond")]
         options.append("bridge_ports {}".format(self.name))
-        options.append("bridge_stp on")
-        options.append("bridge_maxwait 0")
         stanzas.append(AutoStanza(bridge_name))
         stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
         return stanzas
@@ -467,11 +461,6 @@ def main(args):
     print_shell_cmd("cat {}".format(args.filename))
     print_shell_cmd("ip -d addr show")
     print_shell_cmd("ip route show")
-
-    # Remove any other config that can cause issues (i.e. DHCP on eth0 in
-    # addition to static)
-    print_shell_cmd("rm -f /etc/network/interfaces.d/*.cfg > /dev/null")
-    print_shell_cmd("rm -f /etc/systemd/network/50-cloud-init* > /dev/null")
 
 # This script re-renders an interfaces(5) file to add a bridge to
 # either all active interfaces, or a specific interface.

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -215,9 +215,7 @@ iface test-br-eth0 inet static
     address 1.2.3.4
     netmask 255.255.255.0
     gateway 4.3.2.1
-    bridge_ports eth0
-    bridge_stp on
-    bridge_maxwait 0`
+    bridge_ports eth0`
 
 const networkDHCPInitial = `auto lo
 iface lo inet loopback
@@ -230,9 +228,7 @@ iface lo inet loopback
 
 auto test-br-eth0
 iface test-br-eth0 inet dhcp
-    bridge_ports eth0
-    bridge_stp on
-    bridge_maxwait 0`
+    bridge_ports eth0`
 
 const networkDualNICInitial = `auto lo
 iface lo inet loopback
@@ -258,17 +254,13 @@ iface test-br-eth0 inet static
     netmask 255.255.255.0
     gateway 4.3.2.1
     bridge_ports eth0
-    bridge_stp on
-    bridge_maxwait 0
 
 auto test-br-eth1
 iface test-br-eth1 inet static
     address 1.2.3.5
     netmask 255.255.255.0
     gateway 4.3.2.1
-    bridge_ports eth1
-    bridge_stp on
-    bridge_maxwait 0`
+    bridge_ports eth1`
 
 const networkWithAliasInitial = `auto lo
 iface lo inet loopback
@@ -292,8 +284,6 @@ iface test-br-eth0 inet static
     netmask 255.255.255.0
     gateway 4.3.2.1
     bridge_ports eth0
-    bridge_stp on
-    bridge_maxwait 0
 
 auto eth0:1
 iface eth0:1 inet static
@@ -325,8 +315,6 @@ iface test-br-eth0 inet static
     gateway 10.14.0.1
     address 10.14.0.102/24
     bridge_ports eth0
-    bridge_stp on
-    bridge_maxwait 0
 
 auto eth0:1
 iface eth0:1 inet static
@@ -362,8 +350,6 @@ iface test-br-eth0 inet static
     address 10.17.20.201/24
     mtu 1500
     bridge_ports eth0
-    bridge_stp on
-    bridge_maxwait 0
 
 auto eth0:1
 iface eth0:1 inet static
@@ -442,8 +428,6 @@ iface test-br-bond0 inet dhcp
     mtu 1500
     hwaddress 52:54:00:1c:f1:5b
     bridge_ports bond0
-    bridge_stp on
-    bridge_maxwait 0
     dns-nameservers 10.17.20.200
     dns-search maas19`
 
@@ -475,14 +459,10 @@ dns-search maas19`
 const networkMultipleAliasesExpected = `auto test-br-eth0
 iface test-br-eth0 inet dhcp
     bridge_ports eth0
-    bridge_stp on
-    bridge_maxwait 0
 
 auto test-br-eth1
 iface test-br-eth1 inet dhcp
     bridge_ports eth1
-    bridge_stp on
-    bridge_maxwait 0
 
 auto test-br-eth10
 iface test-br-eth10 inet static
@@ -490,8 +470,6 @@ iface test-br-eth10 inet static
     address 10.17.20.201/24
     mtu 1500
     bridge_ports eth10
-    bridge_stp on
-    bridge_maxwait 0
 
 auto eth10:1
 iface eth10:1 inet static
@@ -641,23 +619,17 @@ iface juju-br-eth4 inet static
     address 10.17.20.202/24
     mtu 1500
     bridge_ports eth4
-    bridge_stp on
-    bridge_maxwait 0
 
 auto juju-br-eth5
 iface juju-br-eth5 inet dhcp
     mtu 1500
     bridge_ports eth5
-    bridge_stp on
-    bridge_maxwait 0
 
 auto juju-br-eth6
 iface juju-br-eth6 inet static
     address 10.17.20.203/24
     mtu 1500
     bridge_ports eth6
-    bridge_stp on
-    bridge_maxwait 0
 
 auto eth6:1
 iface eth6:1 inet static
@@ -698,8 +670,6 @@ iface juju-br-bond0 inet static
     mtu 1500
     hwaddress 52:54:00:6a:4f:fd
     bridge_ports bond0
-    bridge_stp on
-    bridge_maxwait 0
 
 auto bond1
 iface bond1 inet manual
@@ -718,8 +688,6 @@ iface juju-br-bond1 inet dhcp
     mtu 1500
     hwaddress 52:54:00:8e:6e:b0
     bridge_ports bond1
-    bridge_stp on
-    bridge_maxwait 0
     dns-nameservers 10.17.20.200
     dns-search maas19`
 
@@ -756,8 +724,6 @@ iface vlan-br-eth0 inet static
     address 10.17.20.212/24
     mtu 1500
     bridge_ports eth0
-    bridge_stp on
-    bridge_maxwait 0
 
 auto eth1
 iface eth1 inet manual
@@ -769,8 +735,6 @@ iface vlan-br-eth0.2 inet static
     vlan-raw-device eth0
     mtu 1500
     bridge_ports eth0.2
-    bridge_stp on
-    bridge_maxwait 0
 
 auto vlan-br-eth1.3
 iface vlan-br-eth1.3 inet static
@@ -778,8 +742,6 @@ iface vlan-br-eth1.3 inet static
     vlan-raw-device eth1
     mtu 1500
     bridge_ports eth1.3
-    bridge_stp on
-    bridge_maxwait 0
     dns-nameservers 10.17.20.200
     dns-search maas19`
 
@@ -843,8 +805,6 @@ iface br-eth0 inet static
     address 10.245.168.11/21
     mtu 1500
     bridge_ports eth0
-    bridge_stp on
-    bridge_maxwait 0
     dns-nameservers 10.245.168.2
 
 auto eth1
@@ -865,8 +825,6 @@ iface br-eth1.2667 inet static
     vlan-raw-device eth1
     mtu 1500
     bridge_ports eth1.2667
-    bridge_stp on
-    bridge_maxwait 0
     dns-nameservers 10.245.168.2
 
 auto br-eth1.2668
@@ -875,8 +833,6 @@ iface br-eth1.2668 inet static
     vlan-raw-device eth1
     mtu 1500
     bridge_ports eth1.2668
-    bridge_stp on
-    bridge_maxwait 0
     dns-nameservers 10.245.168.2
 
 auto br-eth1.2669
@@ -885,8 +841,6 @@ iface br-eth1.2669 inet static
     vlan-raw-device eth1
     mtu 1500
     bridge_ports eth1.2669
-    bridge_stp on
-    bridge_maxwait 0
     dns-nameservers 10.245.168.2
 
 auto br-eth1.2670
@@ -895,8 +849,6 @@ iface br-eth1.2670 inet static
     vlan-raw-device eth1
     mtu 1500
     bridge_ports eth1.2670
-    bridge_stp on
-    bridge_maxwait 0
     dns-nameservers 10.245.168.2
     dns-search dellstack`
 
@@ -992,8 +944,6 @@ iface br-bond0 inet static
     mtu 1500
     hwaddress 52:54:00:1c:f1:5b
     bridge_ports bond0
-    bridge_stp on
-    bridge_maxwait 0
     dns-nameservers 10.17.20.200
 
 auto br-bond0.2
@@ -1002,8 +952,6 @@ iface br-bond0.2 inet static
     vlan-raw-device bond0
     mtu 1500
     bridge_ports bond0.2
-    bridge_stp on
-    bridge_maxwait 0
 
 auto br-bond0.3
 iface br-bond0.3 inet static
@@ -1011,8 +959,6 @@ iface br-bond0.3 inet static
     vlan-raw-device bond0
     mtu 1500
     bridge_ports bond0.3
-    bridge_stp on
-    bridge_maxwait 0
     dns-nameservers 10.17.20.200
     dns-search maas19`
 
@@ -1043,8 +989,6 @@ iface br-eth0 inet static
     address 10.17.20.211/24
     mtu 1500
     bridge_ports eth0
-    bridge_stp on
-    bridge_maxwait 0
     dns-nameservers 10.17.20.200
 
 auto eth1
@@ -1056,8 +1000,6 @@ iface br-eth1.2 inet dhcp
     vlan-raw-device eth1
     mtu 1500
     bridge_ports eth1.2
-    bridge_stp on
-    bridge_maxwait 0
     dns-nameservers 10.17.20.200
     dns-search maas19`
 
@@ -1088,24 +1030,18 @@ iface br-eth0 inet static
     address 10.17.20.211/24
     mtu 1500
     bridge_ports eth0
-    bridge_stp on
-    bridge_maxwait 0
     dns-nameservers 10.17.20.200
 
 auto br-eth1
 iface br-eth1 inet dhcp
     mtu 1500
     bridge_ports eth1
-    bridge_stp on
-    bridge_maxwait 0
 
 auto br-eth1.2
 iface br-eth1.2 inet dhcp
     vlan-raw-device eth1
     mtu 1500
     bridge_ports eth1.2
-    bridge_stp on
-    bridge_maxwait 0
     dns-nameservers 10.17.20.200
     dns-search maas19`
 
@@ -1155,8 +1091,6 @@ iface br-eth0 inet static
     address 10.245.168.11/21
     mtu 1500
     bridge_ports eth0
-    bridge_stp on
-    bridge_maxwait 0
     dns-nameservers 10.245.168.2 192.168.1.1
 
 auto br-eth1
@@ -1165,8 +1099,6 @@ iface br-eth1 inet static
     address 10.245.168.12/21
     mtu 1500
     bridge_ports eth1
-    bridge_stp on
-    bridge_maxwait 0
     dns-sortlist 192.168.1.0/24 10.245.168.0/21
 
 auto br-eth2
@@ -1175,8 +1107,6 @@ iface br-eth2 inet static
     address 10.245.168.13/21
     mtu 1500
     bridge_ports eth2
-    bridge_stp on
-    bridge_maxwait 0
     dns-search juju ubuntu dellstack
 
 auto br-eth3
@@ -1185,8 +1115,6 @@ iface br-eth3 inet static
     address 10.245.168.14/21
     mtu 1500
     bridge_ports eth3
-    bridge_stp on
-    bridge_maxwait 0
     dns-nameservers 192.168.1.1 10.245.168.2
     dns-search juju ubuntu dellstack
     dns-sortlist 192.168.1.0/24 10.245.168.0/21`
@@ -1219,17 +1147,13 @@ iface br-eth0 inet static
     address 10.245.168.11/21
     mtu 1500
     bridge_ports eth0
-    bridge_stp on
-    bridge_maxwait 0
 
 auto br-eth1
 iface br-eth1 inet static
     gateway 10.245.168.1
     address 10.245.168.12/21
     mtu 1500
-    bridge_ports eth1
-    bridge_stp on
-    bridge_maxwait 0`
+    bridge_ports eth1`
 
 const networkLP1532167Initial = `auto eth0
 iface eth0 inet manual
@@ -1396,8 +1320,6 @@ iface juju-br0 inet static
     mtu 1500
     hwaddress 44:a8:42:41:ab:37
     bridge_ports bond0
-    bridge_stp on
-    bridge_maxwait 0
 
 auto bond1
 iface bond1 inet manual
@@ -1487,9 +1409,7 @@ iface juju-br0 inet static
     address 1.2.3.4
     netmask 255.255.255.0
     gateway 4.3.2.1
-    bridge_ports eth1
-    bridge_stp on
-    bridge_maxwait 0`
+    bridge_ports eth1`
 
 const networkPartiallyBridgedInitial = `auto lo
 iface lo inet loopback
@@ -1526,6 +1446,4 @@ iface br-eth1 inet static
     address 1.2.3.5
     netmask 255.255.255.0
     gateway 4.3.2.1
-    bridge_ports eth1
-    bridge_stp on
-    bridge_maxwait 0`
+    bridge_ports eth1`

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -210,14 +210,14 @@ iface eth0 inet static
 const networkStaticExpected = `auto lo
 iface lo inet loopback
 
-iface eth0 inet manual
-
 auto test-br-eth0
 iface test-br-eth0 inet static
     address 1.2.3.4
     netmask 255.255.255.0
     gateway 4.3.2.1
-    bridge_ports eth0`
+    bridge_ports eth0
+    bridge_stp on
+    bridge_maxwait 0`
 
 const networkDHCPInitial = `auto lo
 iface lo inet loopback
@@ -228,11 +228,11 @@ iface eth0 inet dhcp`
 const networkDHCPExpected = `auto lo
 iface lo inet loopback
 
-iface eth0 inet manual
-
 auto test-br-eth0
 iface test-br-eth0 inet dhcp
-    bridge_ports eth0`
+    bridge_ports eth0
+    bridge_stp on
+    bridge_maxwait 0`
 
 const networkDualNICInitial = `auto lo
 iface lo inet loopback
@@ -252,23 +252,23 @@ iface eth1 inet static
 const networkDualNICExpected = `auto lo
 iface lo inet loopback
 
-iface eth0 inet manual
-
 auto test-br-eth0
 iface test-br-eth0 inet static
     address 1.2.3.4
     netmask 255.255.255.0
     gateway 4.3.2.1
     bridge_ports eth0
-
-iface eth1 inet manual
+    bridge_stp on
+    bridge_maxwait 0
 
 auto test-br-eth1
 iface test-br-eth1 inet static
     address 1.2.3.5
     netmask 255.255.255.0
     gateway 4.3.2.1
-    bridge_ports eth1`
+    bridge_ports eth1
+    bridge_stp on
+    bridge_maxwait 0`
 
 const networkWithAliasInitial = `auto lo
 iface lo inet loopback
@@ -286,14 +286,14 @@ iface eth0:1 inet static
 const networkWithAliasExpected = `auto lo
 iface lo inet loopback
 
-iface eth0 inet manual
-
 auto test-br-eth0
 iface test-br-eth0 inet static
     address 1.2.3.4
     netmask 255.255.255.0
     gateway 4.3.2.1
     bridge_ports eth0
+    bridge_stp on
+    bridge_maxwait 0
 
 auto eth0:1
 iface eth0:1 inet static
@@ -320,13 +320,13 @@ dns-nameserver 192.168.1.142`
 const networkDHCPWithAliasExpected = `auto lo
 iface lo inet loopback
 
-iface eth0 inet manual
-
 auto test-br-eth0
 iface test-br-eth0 inet static
     gateway 10.14.0.1
     address 10.14.0.102/24
     bridge_ports eth0
+    bridge_stp on
+    bridge_maxwait 0
 
 auto eth0:1
 iface eth0:1 inet static
@@ -356,14 +356,14 @@ iface eth1 inet manual
 dns-nameservers 10.17.20.200
 dns-search maas`
 
-const networkMultipleStaticWithAliasesExpected = `iface eth0 inet manual
-
-auto test-br-eth0
+const networkMultipleStaticWithAliasesExpected = `auto test-br-eth0
 iface test-br-eth0 inet static
     gateway 10.17.20.1
     address 10.17.20.201/24
     mtu 1500
     bridge_ports eth0
+    bridge_stp on
+    bridge_maxwait 0
 
 auto eth0:1
 iface eth0:1 inet static
@@ -442,6 +442,8 @@ iface test-br-bond0 inet dhcp
     mtu 1500
     hwaddress 52:54:00:1c:f1:5b
     bridge_ports bond0
+    bridge_stp on
+    bridge_maxwait 0
     dns-nameservers 10.17.20.200
     dns-search maas19`
 
@@ -470,19 +472,17 @@ iface eth10:2 inet static
 dns-nameservers 10.17.20.200
 dns-search maas19`
 
-const networkMultipleAliasesExpected = `iface eth0 inet manual
-
-auto test-br-eth0
+const networkMultipleAliasesExpected = `auto test-br-eth0
 iface test-br-eth0 inet dhcp
     bridge_ports eth0
-
-iface eth1 inet manual
+    bridge_stp on
+    bridge_maxwait 0
 
 auto test-br-eth1
 iface test-br-eth1 inet dhcp
     bridge_ports eth1
-
-iface eth10 inet manual
+    bridge_stp on
+    bridge_maxwait 0
 
 auto test-br-eth10
 iface test-br-eth10 inet static
@@ -490,6 +490,8 @@ iface test-br-eth10 inet static
     address 10.17.20.201/24
     mtu 1500
     bridge_ports eth10
+    bridge_stp on
+    bridge_maxwait 0
 
 auto eth10:1
 iface eth10:1 inet static
@@ -634,28 +636,28 @@ iface eth3 inet manual
     mtu 1500
     bond-mode active-backup
 
-iface eth4 inet manual
-
 auto juju-br-eth4
 iface juju-br-eth4 inet static
     address 10.17.20.202/24
     mtu 1500
     bridge_ports eth4
-
-iface eth5 inet manual
+    bridge_stp on
+    bridge_maxwait 0
 
 auto juju-br-eth5
 iface juju-br-eth5 inet dhcp
     mtu 1500
     bridge_ports eth5
-
-iface eth6 inet manual
+    bridge_stp on
+    bridge_maxwait 0
 
 auto juju-br-eth6
 iface juju-br-eth6 inet static
     address 10.17.20.203/24
     mtu 1500
     bridge_ports eth6
+    bridge_stp on
+    bridge_maxwait 0
 
 auto eth6:1
 iface eth6:1 inet static
@@ -696,6 +698,8 @@ iface juju-br-bond0 inet static
     mtu 1500
     hwaddress 52:54:00:6a:4f:fd
     bridge_ports bond0
+    bridge_stp on
+    bridge_maxwait 0
 
 auto bond1
 iface bond1 inet manual
@@ -714,6 +718,8 @@ iface juju-br-bond1 inet dhcp
     mtu 1500
     hwaddress 52:54:00:8e:6e:b0
     bridge_ports bond1
+    bridge_stp on
+    bridge_maxwait 0
     dns-nameservers 10.17.20.200
     dns-search maas19`
 
@@ -744,44 +750,36 @@ iface eth1.3 inet static
 dns-nameservers 10.17.20.200
 dns-search maas19`
 
-const networkVLANExpected = `iface eth0 inet manual
-
-auto vlan-br-eth0
+const networkVLANExpected = `auto vlan-br-eth0
 iface vlan-br-eth0 inet static
     gateway 10.17.20.1
     address 10.17.20.212/24
     mtu 1500
     bridge_ports eth0
+    bridge_stp on
+    bridge_maxwait 0
 
 auto eth1
 iface eth1 inet manual
     mtu 1500
 
-iface eth0.2 inet manual
-    address 192.168.2.3/24
-    vlan-raw-device eth0
-    mtu 1500
-    vlan_id 2
-
 auto vlan-br-eth0.2
 iface vlan-br-eth0.2 inet static
     address 192.168.2.3/24
+    vlan-raw-device eth0
     mtu 1500
     bridge_ports eth0.2
-
-iface eth1.3 inet manual
-    address 192.168.3.3/24
-    vlan-raw-device eth1
-    mtu 1500
-    vlan_id 3
-    dns-nameservers 10.17.20.200
-    dns-search maas19
+    bridge_stp on
+    bridge_maxwait 0
 
 auto vlan-br-eth1.3
 iface vlan-br-eth1.3 inet static
     address 192.168.3.3/24
+    vlan-raw-device eth1
     mtu 1500
     bridge_ports eth1.3
+    bridge_stp on
+    bridge_maxwait 0
     dns-nameservers 10.17.20.200
     dns-search maas19`
 
@@ -839,14 +837,14 @@ iface eth1.2670 inet static
 dns-nameservers 10.245.168.2
 dns-search dellstack`
 
-const networkVLANWithMultipleNameserversExpected = `iface eth0 inet manual
-
-auto br-eth0
+const networkVLANWithMultipleNameserversExpected = `auto br-eth0
 iface br-eth0 inet static
     gateway 10.245.168.1
     address 10.245.168.11/21
     mtu 1500
     bridge_ports eth0
+    bridge_stp on
+    bridge_maxwait 0
     dns-nameservers 10.245.168.2
 
 auto eth1
@@ -861,61 +859,44 @@ auto eth3
 iface eth3 inet manual
     mtu 1500
 
-iface eth1.2667 inet manual
-    address 10.245.184.2/24
-    vlan-raw-device eth1
-    mtu 1500
-    vlan_id 2667
-    dns-nameservers 10.245.168.2
-
 auto br-eth1.2667
 iface br-eth1.2667 inet static
     address 10.245.184.2/24
-    mtu 1500
-    bridge_ports eth1.2667
-    dns-nameservers 10.245.168.2
-
-iface eth1.2668 inet manual
-    address 10.245.185.1/24
     vlan-raw-device eth1
     mtu 1500
-    vlan_id 2668
+    bridge_ports eth1.2667
+    bridge_stp on
+    bridge_maxwait 0
     dns-nameservers 10.245.168.2
 
 auto br-eth1.2668
 iface br-eth1.2668 inet static
     address 10.245.185.1/24
-    mtu 1500
-    bridge_ports eth1.2668
-    dns-nameservers 10.245.168.2
-
-iface eth1.2669 inet manual
-    address 10.245.186.1/24
     vlan-raw-device eth1
     mtu 1500
-    vlan_id 2669
+    bridge_ports eth1.2668
+    bridge_stp on
+    bridge_maxwait 0
     dns-nameservers 10.245.168.2
 
 auto br-eth1.2669
 iface br-eth1.2669 inet static
     address 10.245.186.1/24
-    mtu 1500
-    bridge_ports eth1.2669
-    dns-nameservers 10.245.168.2
-
-iface eth1.2670 inet manual
-    address 10.245.187.2/24
     vlan-raw-device eth1
     mtu 1500
-    vlan_id 2670
+    bridge_ports eth1.2669
+    bridge_stp on
+    bridge_maxwait 0
     dns-nameservers 10.245.168.2
-    dns-search dellstack
 
 auto br-eth1.2670
 iface br-eth1.2670 inet static
     address 10.245.187.2/24
+    vlan-raw-device eth1
     mtu 1500
     bridge_ports eth1.2670
+    bridge_stp on
+    bridge_maxwait 0
     dns-nameservers 10.245.168.2
     dns-search dellstack`
 
@@ -1011,33 +992,27 @@ iface br-bond0 inet static
     mtu 1500
     hwaddress 52:54:00:1c:f1:5b
     bridge_ports bond0
+    bridge_stp on
+    bridge_maxwait 0
     dns-nameservers 10.17.20.200
-
-iface bond0.2 inet manual
-    address 192.168.2.102/24
-    vlan-raw-device bond0
-    mtu 1500
-    vlan_id 2
 
 auto br-bond0.2
 iface br-bond0.2 inet static
     address 192.168.2.102/24
-    mtu 1500
-    bridge_ports bond0.2
-
-iface bond0.3 inet manual
-    address 192.168.3.101/24
     vlan-raw-device bond0
     mtu 1500
-    vlan_id 3
-    dns-nameservers 10.17.20.200
-    dns-search maas19
+    bridge_ports bond0.2
+    bridge_stp on
+    bridge_maxwait 0
 
 auto br-bond0.3
 iface br-bond0.3 inet static
     address 192.168.3.101/24
+    vlan-raw-device bond0
     mtu 1500
     bridge_ports bond0.3
+    bridge_stp on
+    bridge_maxwait 0
     dns-nameservers 10.17.20.200
     dns-search maas19`
 
@@ -1062,31 +1037,27 @@ dns-nameservers 10.17.20.200
 dns-search maas19
 `
 
-const networkVLANWithInactiveDeviceExpected = `iface eth0 inet manual
-
-auto br-eth0
+const networkVLANWithInactiveDeviceExpected = `auto br-eth0
 iface br-eth0 inet static
     gateway 10.17.20.1
     address 10.17.20.211/24
     mtu 1500
     bridge_ports eth0
+    bridge_stp on
+    bridge_maxwait 0
     dns-nameservers 10.17.20.200
 
 auto eth1
 iface eth1 inet manual
     mtu 1500
 
-iface eth1.2 inet manual
-    vlan-raw-device eth1
-    mtu 1500
-    vlan_id 2
-    dns-nameservers 10.17.20.200
-    dns-search maas19
-
 auto br-eth1.2
 iface br-eth1.2 inet dhcp
+    vlan-raw-device eth1
     mtu 1500
     bridge_ports eth1.2
+    bridge_stp on
+    bridge_maxwait 0
     dns-nameservers 10.17.20.200
     dns-search maas19`
 
@@ -1111,34 +1082,30 @@ dns-nameservers 10.17.20.200
 dns-search maas19
 `
 
-const networkVLANWithActiveDHCPDeviceExpected = `iface eth0 inet manual
-
-auto br-eth0
+const networkVLANWithActiveDHCPDeviceExpected = `auto br-eth0
 iface br-eth0 inet static
     gateway 10.17.20.1
     address 10.17.20.211/24
     mtu 1500
     bridge_ports eth0
+    bridge_stp on
+    bridge_maxwait 0
     dns-nameservers 10.17.20.200
-
-iface eth1 inet manual
 
 auto br-eth1
 iface br-eth1 inet dhcp
     mtu 1500
     bridge_ports eth1
-
-iface eth1.2 inet manual
-    vlan-raw-device eth1
-    mtu 1500
-    vlan_id 2
-    dns-nameservers 10.17.20.200
-    dns-search maas19
+    bridge_stp on
+    bridge_maxwait 0
 
 auto br-eth1.2
 iface br-eth1.2 inet dhcp
+    vlan-raw-device eth1
     mtu 1500
     bridge_ports eth1.2
+    bridge_stp on
+    bridge_maxwait 0
     dns-nameservers 10.17.20.200
     dns-search maas19`
 
@@ -1182,17 +1149,15 @@ iface eth3 inet static
 dns-search ubuntu juju
 dns-search dellstack ubuntu dellstack`
 
-const networkWithMultipleDNSValuesExpected = `iface eth0 inet manual
-
-auto br-eth0
+const networkWithMultipleDNSValuesExpected = `auto br-eth0
 iface br-eth0 inet static
     gateway 10.245.168.1
     address 10.245.168.11/21
     mtu 1500
     bridge_ports eth0
+    bridge_stp on
+    bridge_maxwait 0
     dns-nameservers 10.245.168.2 192.168.1.1
-
-iface eth1 inet manual
 
 auto br-eth1
 iface br-eth1 inet static
@@ -1200,9 +1165,9 @@ iface br-eth1 inet static
     address 10.245.168.12/21
     mtu 1500
     bridge_ports eth1
+    bridge_stp on
+    bridge_maxwait 0
     dns-sortlist 192.168.1.0/24 10.245.168.0/21
-
-iface eth2 inet manual
 
 auto br-eth2
 iface br-eth2 inet static
@@ -1210,9 +1175,9 @@ iface br-eth2 inet static
     address 10.245.168.13/21
     mtu 1500
     bridge_ports eth2
+    bridge_stp on
+    bridge_maxwait 0
     dns-search juju ubuntu dellstack
-
-iface eth3 inet manual
 
 auto br-eth3
 iface br-eth3 inet static
@@ -1220,6 +1185,8 @@ iface br-eth3 inet static
     address 10.245.168.14/21
     mtu 1500
     bridge_ports eth3
+    bridge_stp on
+    bridge_maxwait 0
     dns-nameservers 192.168.1.1 10.245.168.2
     dns-search juju ubuntu dellstack
     dns-sortlist 192.168.1.0/24 10.245.168.0/21`
@@ -1246,23 +1213,23 @@ dns-nameservers
 dns-search
 dns-sortlist`
 
-const networkWithEmptyDNSValuesExpected = `iface eth0 inet manual
-
-auto br-eth0
+const networkWithEmptyDNSValuesExpected = `auto br-eth0
 iface br-eth0 inet static
     gateway 10.245.168.1
     address 10.245.168.11/21
     mtu 1500
     bridge_ports eth0
-
-iface eth1 inet manual
+    bridge_stp on
+    bridge_maxwait 0
 
 auto br-eth1
 iface br-eth1 inet static
     gateway 10.245.168.1
     address 10.245.168.12/21
     mtu 1500
-    bridge_ports eth1`
+    bridge_ports eth1
+    bridge_stp on
+    bridge_maxwait 0`
 
 const networkLP1532167Initial = `auto eth0
 iface eth0 inet manual
@@ -1429,6 +1396,8 @@ iface juju-br0 inet static
     mtu 1500
     hwaddress 44:a8:42:41:ab:37
     bridge_ports bond0
+    bridge_stp on
+    bridge_maxwait 0
 
 auto bond1
 iface bond1 inet manual
@@ -1513,14 +1482,14 @@ iface eth0 inet static
     netmask 255.255.255.0
     gateway 4.3.2.1
 
-iface eth1 inet manual
-
 auto juju-br0
 iface juju-br0 inet static
     address 1.2.3.4
     netmask 255.255.255.0
     gateway 4.3.2.1
-    bridge_ports eth1`
+    bridge_ports eth1
+    bridge_stp on
+    bridge_maxwait 0`
 
 const networkPartiallyBridgedInitial = `auto lo
 iface lo inet loopback
@@ -1552,11 +1521,11 @@ iface br-eth0 inet static
     gateway 4.3.2.1
     bridge_ports eth0
 
-iface eth1 inet manual
-
 auto br-eth1
 iface br-eth1 inet static
     address 1.2.3.5
     netmask 255.255.255.0
     gateway 4.3.2.1
-    bridge_ports eth1`
+    bridge_ports eth1
+    bridge_stp on
+    bridge_maxwait 0`


### PR DESCRIPTION
Simplified the rendered /etc/network/interfaces for containers to use
static or manual stanzas. Moved all auto-starting interface names in a
single "auto" stanza in sorted order. Any dns servers or search domains
on any of the interfaces are collected, de-duped and put together on the
loopback interface. Also, as before the gateway stanza is rendered once
only for the primary "eth0" interface.

Live tested on MAAS 2.0.0rc1 with a full openstack-base bundle
deployment on 4 dual-NIC Intel NUCs, each with multiple VLANs.

Tested on MAAS 1.9.3 as well with a dual-NIC instances and multiple
VLANs on each NIC; bootstrapped with xenial, trusty, and precise and
added a couple of LXC and LXD containers on machine-0.

Can be tested on any MAAS 1.9+ with nodes having 2 or more NICs, each
configured on the same managed subnet, and checking the output of `ip
route show` to ensure all lines include "src" address as well as the
corresponding NIC. See http://pad.lv/1576674 for details.

Includes a drive-by fix in apiserver/uniter/ to allow network-get to
work properly in multi-NIC, multi-VLAN setups like the ones described.

(Review request: http://reviews.vapour.ws/r/4959/)