### PR TITLE
Bump juju/cmd dependency

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -13,7 +13,7 @@ github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	a1fcaa2fc3b55305d064d16cb56bf87541efb8a4	2016-04-18T04:33:00Z
-github.com/juju/cmd	git	ca63dd8ba13f8fbbbe16a917696a7ce68cc3dc0b	2016-03-31T03:26:51Z
+github.com/juju/cmd	git	a11ae7a7436c133e799f025998cbbefd3f6eef7e	2016-06-01T03:55:00Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:32:58Z
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z


### PR DESCRIPTION
This pulls in the change to update the formatting of the help summaries for command aliases to match what we're doing throughout Juju.

This changes the formatting of aliases in the `juju help commands` output from:

```
spaces                  alias for 'list-spaces'
```
to
```
spaces                  Alias for 'list-spaces'.
```

(Review request: http://reviews.vapour.ws/r/4961/)