### PR TITLE
All controller machines to access HTTP endpoints for hosted models

### DIFF
--- a/api/http.go
+++ b/api/http.go
@@ -77,6 +77,12 @@ func (doer httpRequestDoer) DoWithBody(req *http.Request, body io.ReadSeeker) (*
 		// indicates that we're using macaroon authentication.
 		req.SetBasicAuth(doer.st.tag, doer.st.password)
 	}
+
+	// Set the machine nonce if it was provided.
+	if doer.st.nonce != "" {
+		req.Header.Set(params.MachineNonceHeader, doer.st.nonce)
+	}
+
 	// Add any explicitly-specified macaroons.
 	for _, ms := range doer.st.macaroons {
 		encoded, err := encodeMacaroonSlice(ms)
@@ -202,7 +208,6 @@ func openBlob(httpClient HTTPDoer, endpoint string, args url.Values) (io.ReadClo
 		return nil, errors.Trace(err)
 	}
 	apiURL.RawQuery = args.Encode()
-
 	req, err := http.NewRequest("GET", apiURL.String(), nil)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot create HTTP request")

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -280,8 +280,7 @@ func checkCreds(st *state.State, req params.LoginRequest, lookForModelUser bool,
 
 // checkControllerMachineCreds checks the special case of a controller
 // machine creating an API connection for a different model so it can
-// run API workers for that model to do things like provisioning
-// machines.
+// run workers that act on behalf of a hosted model.
 func checkControllerMachineCreds(
 	controllerSt *state.State,
 	req params.LoginRequest,


### PR DESCRIPTION
HTTP endpoint authentication didn't handle the special case of workers in the controller which act on behalf of a hosted model. Also the HTTP client side code didn't send the machince nonce.

This is required for model migration to support the migration of binary resources such as charms and tools.



(Review request: http://reviews.vapour.ws/r/4963/)