### PR TITLE
all: restructure instancecfg

### DIFF
--- a/apiserver/client/instanceconfig.go
+++ b/apiserver/client/instanceconfig.go
@@ -86,7 +86,7 @@ func InstanceConfig(st *state.State, machineId, nonce, dataDir string) (*instanc
 	}
 
 	auth := authentication.NewAuthenticator(st.MongoConnectionInfo(), apiInfo)
-	mongoInfo, apiInfo, err := auth.SetupAuthentication(machine)
+	_, apiInfo, err = auth.SetupAuthentication(machine)
 	if err != nil {
 		return nil, errors.Annotate(err, "setting up machine authentication")
 	}
@@ -97,8 +97,8 @@ func InstanceConfig(st *state.State, machineId, nonce, dataDir string) (*instanc
 		return nil, errors.Annotate(err, "getting state serving info")
 	}
 	secureServerConnection := info.CAPrivateKey != ""
-	icfg, err := instancecfg.NewInstanceConfig(machineId, nonce, environConfig.ImageStream(), machine.Series(), "",
-		secureServerConnection, mongoInfo, apiInfo,
+	icfg, err := instancecfg.NewInstanceConfig(machineId, nonce, environConfig.ImageStream(), machine.Series(),
+		secureServerConnection, apiInfo,
 	)
 	if err != nil {
 		return nil, errors.Annotate(err, "initializing instance config")

--- a/apiserver/client/instanceconfig_test.go
+++ b/apiserver/client/instanceconfig_test.go
@@ -51,17 +51,14 @@ func (s *machineConfigSuite) TestMachineConfig(c *gc.C) {
 
 	envConfig, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	mongoAddrs := s.State.MongoConnectionInfo().Addrs
 	apiAddrs := []string{net.JoinHostPort("localhost", strconv.Itoa(envConfig.APIPort()))}
 
-	c.Check(instanceConfig.MongoInfo.Addrs, gc.DeepEquals, mongoAddrs)
 	c.Check(instanceConfig.APIInfo.Addrs, gc.DeepEquals, apiAddrs)
 	toolsURL := fmt.Sprintf("https://%s/model/%s/tools/%s",
 		apiAddrs[0], jujutesting.ModelTag.Id(), instanceConfig.AgentVersion())
 	c.Assert(instanceConfig.ToolsList().URLs(), jc.DeepEquals, map[version.Binary][]string{
 		instanceConfig.AgentVersion(): []string{toolsURL},
 	})
-	//c.Assert(instanceConfig.ToolsList()[0].URL, gc.Equals, toolsURL)
 	c.Assert(instanceConfig.AgentEnvironment[agent.AllowsSecureConnection], gc.Equals, "true")
 }
 

--- a/cloudconfig/cloudinit/renderscript_test.go
+++ b/cloudconfig/cloudinit/renderscript_test.go
@@ -62,13 +62,13 @@ func (s *configureSuite) getCloudConfig(c *gc.C, controller bool, vers version.B
 			vers.Series, "",
 		)
 		c.Assert(err, jc.ErrorIsNil)
-		icfg.InstanceId = "instance-id"
-		icfg.HostedModelConfig = map[string]interface{}{
+		icfg.Bootstrap.InstanceId = "instance-id"
+		icfg.Bootstrap.HostedModelConfig = map[string]interface{}{
 			"name": "hosted-model",
 		}
 		icfg.Jobs = []multiwatcher.MachineJob{multiwatcher.JobManageModel, multiwatcher.JobHostUnits}
 	} else {
-		icfg, err = instancecfg.NewInstanceConfig("0", "ya", imagemetadata.ReleasedStream, vers.Series, "", true, nil, nil)
+		icfg, err = instancecfg.NewInstanceConfig("0", "ya", imagemetadata.ReleasedStream, vers.Series, true, nil)
 		c.Assert(err, jc.ErrorIsNil)
 		icfg.Jobs = []multiwatcher.MachineJob{multiwatcher.JobHostUnits}
 	}

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -426,6 +426,7 @@ func (e requiresError) Error() string {
 	return "invalid machine configuration: missing " + string(e)
 }
 
+// VerifyConfig verifies that the InstanceConfig is valid.
 func (cfg *InstanceConfig) VerifyConfig() (err error) {
 	defer errors.DeferredAnnotatef(&err, "invalid machine configuration")
 	if !names.IsValidMachine(cfg.MachineId) {
@@ -516,6 +517,7 @@ func (cfg *InstanceConfig) verifyControllerConfig() (err error) {
 	return nil
 }
 
+// VerifyConfig verifies that the BootstrapConfig is valid.
 func (cfg *BootstrapConfig) VerifyConfig() (err error) {
 	if cfg.Config == nil {
 		return errors.New("missing model configuration")
@@ -544,6 +546,7 @@ func (cfg *BootstrapConfig) VerifyConfig() (err error) {
 	return nil
 }
 
+// VerifyConfig verifies that the ControllerConfig is valid.
 func (cfg *ControllerConfig) VerifyConfig() error {
 	if cfg.MongoInfo == nil {
 		return errors.New("missing state info")

--- a/cloudconfig/providerinit/providerinit.go
+++ b/cloudconfig/providerinit/providerinit.go
@@ -26,7 +26,7 @@ func configureCloudinit(icfg *instancecfg.InstanceConfig, cloudcfg cloudinit.Clo
 	if err != nil {
 		return nil, err
 	}
-	if icfg.Bootstrap {
+	if icfg.Bootstrap != nil {
 		err = udata.ConfigureBasic()
 		if err != nil {
 			return nil, err

--- a/cloudconfig/providerinit/providerinit_test.go
+++ b/cloudconfig/providerinit/providerinit_test.go
@@ -71,8 +71,7 @@ func (s *CloudInitSuite) TestFinishInstanceConfig(c *gc.C) {
 			agent.ProviderType:  "dummy",
 			agent.ContainerType: "",
 		},
-		MongoInfo: &mongo.MongoInfo{Tag: userTag},
-		APIInfo:   &api.Info{Tag: userTag},
+		APIInfo: &api.Info{Tag: userTag},
 		DisableSSLHostnameVerification: false,
 		EnableOSRefreshUpdate:          true,
 		EnableOSUpgrade:                true,
@@ -84,8 +83,7 @@ func (s *CloudInitSuite) TestFinishInstanceConfig(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	icfg := &instancecfg.InstanceConfig{
-		MongoInfo: &mongo.MongoInfo{Tag: userTag},
-		APIInfo:   &api.Info{Tag: userTag},
+		APIInfo: &api.Info{Tag: userTag},
 	}
 	err = instancecfg.FinishInstanceConfig(icfg, cfg)
 
@@ -115,8 +113,7 @@ func (s *CloudInitSuite) TestFinishInstanceConfigNonDefault(c *gc.C) {
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 	icfg := &instancecfg.InstanceConfig{
-		MongoInfo: &mongo.MongoInfo{Tag: userTag},
-		APIInfo:   &api.Info{Tag: userTag},
+		APIInfo: &api.Info{Tag: userTag},
 	}
 	err = instancecfg.FinishInstanceConfig(icfg, cfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -126,8 +123,7 @@ func (s *CloudInitSuite) TestFinishInstanceConfigNonDefault(c *gc.C) {
 			agent.ProviderType:  "dummy",
 			agent.ContainerType: "",
 		},
-		MongoInfo: &mongo.MongoInfo{Tag: userTag},
-		APIInfo:   &api.Info{Tag: userTag},
+		APIInfo: &api.Info{Tag: userTag},
 		DisableSSLHostnameVerification: true,
 		EnableOSRefreshUpdate:          true,
 		EnableOSUpgrade:                true,
@@ -145,7 +141,8 @@ func (s *CloudInitSuite) TestFinishBootstrapConfig(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	oldAttrs := cfg.AllAttrs()
 	icfg := &instancecfg.InstanceConfig{
-		Bootstrap: true,
+		Bootstrap:  &instancecfg.BootstrapConfig{},
+		Controller: &instancecfg.ControllerConfig{},
 	}
 	err = instancecfg.FinishInstanceConfig(icfg, cfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -156,18 +153,18 @@ func (s *CloudInitSuite) TestFinishBootstrapConfig(c *gc.C) {
 		Password: password, CACert: testing.CACert,
 		ModelTag: testing.ModelTag,
 	})
-	c.Check(icfg.MongoInfo, gc.DeepEquals, &mongo.MongoInfo{
+	c.Check(icfg.Controller.MongoInfo, gc.DeepEquals, &mongo.MongoInfo{
 		Password: password, Info: mongo.Info{CACert: testing.CACert},
 	})
-	c.Check(icfg.StateServingInfo.StatePort, gc.Equals, cfg.StatePort())
-	c.Check(icfg.StateServingInfo.APIPort, gc.Equals, cfg.APIPort())
-	c.Check(icfg.StateServingInfo.CAPrivateKey, gc.Equals, oldAttrs["ca-private-key"])
+	c.Check(icfg.Bootstrap.StateServingInfo.StatePort, gc.Equals, cfg.StatePort())
+	c.Check(icfg.Bootstrap.StateServingInfo.APIPort, gc.Equals, cfg.APIPort())
+	c.Check(icfg.Bootstrap.StateServingInfo.CAPrivateKey, gc.Equals, oldAttrs["ca-private-key"])
 
 	oldAttrs["ca-private-key"] = ""
 	oldAttrs["admin-secret"] = ""
-	c.Check(icfg.Config.AllAttrs(), gc.DeepEquals, oldAttrs)
-	srvCertPEM := icfg.StateServingInfo.Cert
-	srvKeyPEM := icfg.StateServingInfo.PrivateKey
+	c.Check(icfg.Bootstrap.Config.AllAttrs(), gc.DeepEquals, oldAttrs)
+	srvCertPEM := icfg.Bootstrap.StateServingInfo.Cert
+	srvKeyPEM := icfg.Bootstrap.StateServingInfo.PrivateKey
 	_, _, err = cert.ParseCertAndKey(srvCertPEM, srvKeyPEM)
 	c.Check(err, jc.ErrorIsNil)
 
@@ -217,14 +214,6 @@ func (*CloudInitSuite) testUserData(c *gc.C, series string, bootstrap bool) {
 		MachineId:    "10",
 		MachineNonce: "5432",
 		Series:       series,
-		MongoInfo: &mongo.MongoInfo{
-			Info: mongo.Info{
-				Addrs:  []string{"127.0.0.1:1234"},
-				CACert: "CA CERT\n" + testing.CACert,
-			},
-			Password: "pw1",
-			Tag:      names.NewMachineTag("10"),
-		},
 		APIInfo: &api.Info{
 			Addrs:    []string{"127.0.0.1:1234"},
 			Password: "pw2",
@@ -237,7 +226,6 @@ func (*CloudInitSuite) testUserData(c *gc.C, series string, bootstrap bool) {
 		MetricsSpoolDir:         metricsSpoolDir,
 		Jobs:                    allJobs,
 		CloudInitOutputLog:      path.Join(logDir, "cloud-init-output.log"),
-		Config:                  envConfig,
 		AgentEnvironment:        map[string]string{agent.ProviderType: "dummy"},
 		AuthorizedKeys:          "wheredidileavemykeys",
 		MachineAgentServiceName: "jujud-machine-10",
@@ -246,13 +234,27 @@ func (*CloudInitSuite) testUserData(c *gc.C, series string, bootstrap bool) {
 	err = cfg.SetTools(toolsList)
 	c.Assert(err, jc.ErrorIsNil)
 	if bootstrap {
-		cfg.Bootstrap = true
-		cfg.StateServingInfo = &params.StateServingInfo{
-			StatePort:    envConfig.StatePort(),
-			APIPort:      envConfig.APIPort(),
-			Cert:         testing.ServerCert,
-			PrivateKey:   testing.ServerKey,
-			CAPrivateKey: testing.CAKey,
+		cfg.Bootstrap = &instancecfg.BootstrapConfig{
+			StateInitializationParams: instancecfg.StateInitializationParams{
+				Config: envConfig,
+			},
+			StateServingInfo: params.StateServingInfo{
+				StatePort:    envConfig.StatePort(),
+				APIPort:      envConfig.APIPort(),
+				Cert:         testing.ServerCert,
+				PrivateKey:   testing.ServerKey,
+				CAPrivateKey: testing.CAKey,
+			},
+		}
+		cfg.Controller = &instancecfg.ControllerConfig{
+			MongoInfo: &mongo.MongoInfo{
+				Info: mongo.Info{
+					Addrs:  []string{"127.0.0.1:1234"},
+					CACert: "CA CERT\n" + testing.CACert,
+				},
+				Password: "pw1",
+				Tag:      names.NewMachineTag("10"),
+			},
 		}
 	}
 	script1 := "script1"
@@ -349,17 +351,8 @@ func (s *CloudInitSuite) TestWindowsUserdataEncoding(c *gc.C) {
 		MachineId:        "10",
 		AgentEnvironment: map[string]string{agent.ProviderType: "dummy"},
 		Series:           series,
-		Bootstrap:        false,
 		Jobs:             []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 		MachineNonce:     "FAKE_NONCE",
-		MongoInfo: &mongo.MongoInfo{
-			Tag:      names.NewMachineTag("10"),
-			Password: "arble",
-			Info: mongo.Info{
-				CACert: "CA CERT\n" + testing.CACert,
-				Addrs:  []string{"state-addr.testing.invalid:12345"},
-			},
-		},
 		APIInfo: &api.Info{
 			Addrs:    []string{"state-addr.testing.invalid:54321"},
 			Password: "bletch",

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -84,7 +84,7 @@ func must(s string, err error) string {
 	return s
 }
 
-var stateServingInfo = &params.StateServingInfo{
+var stateServingInfo = params.StateServingInfo{
 	Cert:         string(serverCert),
 	PrivateKey:   string(serverKey),
 	CAPrivateKey: "ca-private-key",
@@ -109,18 +109,9 @@ func makeTestConfig(series string, bootstrap bool) *testInstanceConfig {
 		agent.ProviderType: "dummy",
 	}
 	cfg.MachineNonce = "FAKE_NONCE"
-	cfg.InstanceId = "i-machine"
 	cfg.Jobs = normalMachineJobs
 	cfg.MetricsSpoolDir = metricsSpoolDir(series)
-	// MongoInfo and APIInfo (sans Tag) must be initialized before
-	// calling setMachineID().
-	cfg.MongoInfo = &mongo.MongoInfo{
-		Password: "arble",
-		Info: mongo.Info{
-			Addrs:  []string{"state-addr.testing.invalid:12345"},
-			CACert: "CA CERT\n" + testing.CACert,
-		},
-	}
+	// APIInfo (sans Tag) must be initialized before calling setMachineID().
 	cfg.APIInfo = &api.Info{
 		Addrs:    []string{"state-addr.testing.invalid:54321"},
 		Password: "bletch",
@@ -170,9 +161,6 @@ func makeNormalConfig(series string) *testInstanceConfig {
 func (cfg *testInstanceConfig) setMachineID(id string) *testInstanceConfig {
 	cfg.MachineId = id
 	cfg.MachineAgentServiceName = fmt.Sprintf("jujud-%s", names.NewMachineTag(id).String())
-	if cfg.MongoInfo != nil {
-		cfg.MongoInfo.Tag = names.NewMachineTag(id)
-	}
 	if cfg.APIInfo != nil {
 		cfg.APIInfo.Tag = names.NewMachineTag(id)
 	}
@@ -181,7 +169,7 @@ func (cfg *testInstanceConfig) setMachineID(id string) *testInstanceConfig {
 
 // setGUI populates the configuration with the Juju GUI tools.
 func (cfg *testInstanceConfig) setGUI(url string) *testInstanceConfig {
-	cfg.GUI = &tools.GUIArchive{
+	cfg.Bootstrap.GUI = &tools.GUIArchive{
 		URL:     url,
 		Version: version.MustParse("1.2.3"),
 		Size:    42,
@@ -191,13 +179,11 @@ func (cfg *testInstanceConfig) setGUI(url string) *testInstanceConfig {
 }
 
 // maybeSetModelConfig sets the Config field to the given envConfig, if not
-// nil.
+// nil, and the instance config is for a bootstrap machine.
 func (cfg *testInstanceConfig) maybeSetModelConfig(envConfig *config.Config) *testInstanceConfig {
-	if envConfig != nil {
-		cfg.Config = envConfig
-		if cfg.Bootstrap {
-			cfg.HostedModelConfig = map[string]interface{}{"name": "hosted-model"}
-		}
+	if envConfig != nil && cfg.Bootstrap != nil {
+		cfg.Bootstrap.Config = envConfig
+		cfg.Bootstrap.HostedModelConfig = map[string]interface{}{"name": "hosted-model"}
 	}
 	return cfg
 }
@@ -230,13 +216,24 @@ func (cfg *testInstanceConfig) setSeries(series string) *testInstanceConfig {
 // a controller instance.
 func (cfg *testInstanceConfig) setController() *testInstanceConfig {
 	cfg.setMachineID("0")
-	cfg.Constraints = bootstrapConstraints
-	cfg.ModelConstraints = envConstraints
-	cfg.Bootstrap = true
-	cfg.StateServingInfo = stateServingInfo
+	cfg.Controller = &instancecfg.ControllerConfig{
+		MongoInfo: &mongo.MongoInfo{
+			Password: "arble",
+			Info: mongo.Info{
+				Addrs:  []string{"state-addr.testing.invalid:12345"},
+				CACert: "CA CERT\n" + testing.CACert,
+			},
+		},
+	}
+	cfg.Bootstrap = &instancecfg.BootstrapConfig{
+		StateInitializationParams: instancecfg.StateInitializationParams{
+			InstanceId:                  "i-bootstrap",
+			BootstrapMachineConstraints: bootstrapConstraints,
+			ModelConstraints:            envConstraints,
+		},
+		StateServingInfo: stateServingInfo,
+	}
 	cfg.Jobs = allMachineJobs
-	cfg.InstanceId = "i-bootstrap"
-	cfg.MongoInfo.Tag = nil
 	cfg.APIInfo.Tag = nil
 	return cfg.setEnableOSUpdateAndUpgrade(true, false)
 }
@@ -347,8 +344,10 @@ printf %s '{"version":"1\.2\.3-precise-amd64","url":"http://foo\.com/tools/relea
 mkdir -p '/var/lib/juju/agents/machine-0'
 cat > '/var/lib/juju/agents/machine-0/agent\.conf' << 'EOF'\\n.*\\nEOF
 chmod 0600 '/var/lib/juju/agents/machine-0/agent\.conf'
+install -D -m 600 /dev/null '/var/lib/juju/bootstrap-params'
+printf '%s\\n' '.*' > '/var/lib/juju/bootstrap-params'
 echo 'Bootstrapping Juju machine agent'.*
-/var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --model-config '[^']*' --hosted-model-config '[^']*' --instance-id 'i-bootstrap' --bootstrap-constraints 'mem=4096M' --constraints 'mem=2048M' --debug
+/var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --debug '/var/lib/juju/bootstrap-params'
 ln -s 1\.2\.3-precise-amd64 '/var/lib/juju/tools/machine-0'
 echo 'Starting Juju machine agent \(jujud-machine-0\)'.*
 cat > /etc/init/jujud-machine-0\.conf << 'EOF'\\ndescription "juju agent for machine-0"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-0\.log\\n  chown syslog:syslog /var/log/juju/machine-0\.log\\n  chmod 0600 /var/log/juju/machine-0\.log\\n\\n  exec '/var/lib/juju/tools/machine-0/jujud' machine --data-dir '/var/lib/juju' --machine-id 0 --debug >> /var/log/juju/machine-0\.log 2>&1\\nend script\\nEOF\\n
@@ -368,7 +367,9 @@ curl .* '.*' --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-raring-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-raring-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 printf %s '{"version":"1\.2\.3-raring-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3-raring-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
-/var/lib/juju/tools/1\.2\.3-raring-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --model-config '[^']*' --hosted-model-config '[^']*' --instance-id 'i-bootstrap' --bootstrap-constraints 'mem=4096M' --constraints 'mem=2048M' --debug
+install -D -m 600 /dev/null '/var/lib/juju/bootstrap-params'
+printf '%s\\n' '.*' > '/var/lib/juju/bootstrap-params'
+/var/lib/juju/tools/1\.2\.3-raring-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --debug '/var/lib/juju/bootstrap-params'
 ln -s 1\.2\.3-raring-amd64 '/var/lib/juju/tools/machine-0'
 rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-raring-amd64\.sha256
 `,
@@ -423,40 +424,6 @@ printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 `,
 	},
 
-	// non controller with GUI (the GUI is not installed)
-	{
-		cfg: makeNormalConfig("quantal").setGUI("file:///path/to/gui.tar.bz2"),
-		expectScripts: `
-set -xe
-install -D -m 644 /dev/null '/etc/init/juju-clean-shutdown\.conf'
-printf '%s\\n' '.*"Stop all network interfaces on shutdown".*' > '/etc/init/juju-clean-shutdown\.conf'
-install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
-printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
-test -e /proc/self/fd/9 \|\| exec 9>&2
-\(\[ ! -e /home/ubuntu/\.profile \] \|\| grep -q '.juju-proxy' /home/ubuntu/.profile\) \|\| printf .* >> /home/ubuntu/.profile
-mkdir -p /var/lib/juju/locks
-\(id ubuntu &> /dev/null\) && chown ubuntu:ubuntu /var/lib/juju/locks
-mkdir -p /var/log/juju
-chown syslog:adm /var/log/juju
-bin='/var/lib/juju/tools/1\.2\.3-quantal-amd64'
-mkdir -p \$bin
-echo 'Fetching tools.*
-curl .* --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-quantal-amd64'
-sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-quantal-amd64\.sha256
-grep '1234' \$bin/juju1\.2\.3-quantal-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
-tar zxf \$bin/tools.tar.gz -C \$bin
-printf %s '{"version":"1\.2\.3-quantal-amd64","url":"https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-quantal-amd64","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
-mkdir -p '/var/lib/juju/agents/machine-99'
-cat > '/var/lib/juju/agents/machine-99/agent\.conf' << 'EOF'\\n.*\\nEOF
-chmod 0600 '/var/lib/juju/agents/machine-99/agent\.conf'
-ln -s 1\.2\.3-quantal-amd64 '/var/lib/juju/tools/machine-99'
-echo 'Starting Juju machine agent \(jujud-machine-99\)'.*
-cat > /etc/init/jujud-machine-99\.conf << 'EOF'\\ndescription "juju agent for machine-99"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-99\.log\\n  chown syslog:syslog /var/log/juju/machine-99\.log\\n  chmod 0600 /var/log/juju/machine-99\.log\\n\\n  exec '/var/lib/juju/tools/machine-99/jujud' machine --data-dir '/var/lib/juju' --machine-id 99 --debug >> /var/log/juju/machine-99\.log 2>&1\\nend script\\nEOF\\n
-start jujud-machine-99
-rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-quantal-amd64\.sha256
-`,
-	},
-
 	// CentOS non controller with systemd
 	{
 		cfg:          makeNormalConfig("centos7"),
@@ -498,31 +465,31 @@ curl .* --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.t
 	// empty bootstrap contraints.
 	{
 		cfg: makeBootstrapConfig("precise").mutate(func(cfg *testInstanceConfig) {
-			cfg.Constraints = constraints.Value{}
+			cfg.Bootstrap.BootstrapMachineConstraints = constraints.Value{}
 		}),
 		setEnvConfig: true,
 		inexactMatch: true,
 		expectScripts: `
-/var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --model-config '[^']*' --hosted-model-config '[^']*' --instance-id 'i-bootstrap' --constraints 'mem=2048M' --debug
+printf '%s\\n' '.*bootstrap-machine-constraints: {}.*' > '/var/lib/juju/bootstrap-params'
 `,
 	},
 
 	// empty environ contraints.
 	{
 		cfg: makeBootstrapConfig("precise").mutate(func(cfg *testInstanceConfig) {
-			cfg.ModelConstraints = constraints.Value{}
+			cfg.Bootstrap.ModelConstraints = constraints.Value{}
 		}),
 		setEnvConfig: true,
 		inexactMatch: true,
 		expectScripts: `
-/var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --model-config '[^']*' --hosted-model-config '[^']*' --instance-id 'i-bootstrap' --bootstrap-constraints 'mem=4096M' --debug
+printf '%s\\n' '.*model-constraints: {}.*' > '/var/lib/juju/bootstrap-params'
 `,
 	},
 
 	// custom image metadata (at bootstrap).
 	{
 		cfg: makeBootstrapConfig("trusty").mutate(func(cfg *testInstanceConfig) {
-			cfg.CustomImageMetadata = []*imagemetadata.ImageMetadata{{
+			cfg.Bootstrap.CustomImageMetadata = []*imagemetadata.ImageMetadata{{
 				Id:         "image-id",
 				Storage:    "ebs",
 				VirtType:   "pv",
@@ -534,15 +501,14 @@ curl .* --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.t
 		setEnvConfig: true,
 		inexactMatch: true,
 		expectScripts: `
-printf '%s\\n' '.*' > '/var/lib/juju/simplestreams/images/streams/v1/index\.json'
-printf '%s\\n' '.*' > '/var/lib/juju/simplestreams/images/streams/v1/com.ubuntu.cloud-released-imagemetadata\.json'
+printf '%s\\n' '.*custom-image-metadata:.*us-east1.*.*' > '/var/lib/juju/bootstrap-params'
 `,
 	},
 
 	// custom image metadata signing key.
 	{
 		cfg: makeBootstrapConfig("trusty").mutate(func(cfg *testInstanceConfig) {
-			cfg.PublicImageSigningKey = "publickey"
+			cfg.Controller.PublicImageSigningKey = "publickey"
 		}),
 		setEnvConfig: true,
 		inexactMatch: true,
@@ -585,24 +551,27 @@ func getAgentConfig(c *gc.C, tag string, scripts []string) (cfg string) {
 }
 
 // check that any --model-config $base64 is valid and matches t.cfg.Config
-func checkEnvConfig(c *gc.C, cfg *config.Config, x map[interface{}]interface{}, scripts []string) {
+func checkEnvConfig(c *gc.C, cfg *config.Config, scripts []string) {
+	args := getStateInitializationParams(c, scripts)
+	c.Assert(cfg.AllAttrs(), jc.DeepEquals, args.Config.AllAttrs())
+}
+
+func getStateInitializationParams(c *gc.C, scripts []string) instancecfg.StateInitializationParams {
+	var args instancecfg.StateInitializationParams
 	c.Assert(scripts, gc.Not(gc.HasLen), 0)
-	re := regexp.MustCompile(`--model-config '([^']+)'`)
-	found := false
+	re := regexp.MustCompile(`printf '%s\\n' '(?s:(.+))' > '/var/lib/juju/bootstrap-params'`)
 	for _, s := range scripts {
 		m := re.FindStringSubmatch(s)
 		if m == nil {
 			continue
 		}
-		found = true
-		buf, err := base64.StdEncoding.DecodeString(m[1])
+		str := strings.Replace(m[1], "'\"'\"'", "'", -1)
+		err := args.Unmarshal([]byte(str))
 		c.Assert(err, jc.ErrorIsNil)
-		var actual map[string]interface{}
-		err = goyaml.Unmarshal(buf, &actual)
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(cfg.AllAttrs(), jc.DeepEquals, actual)
+		return args
 	}
-	c.Assert(found, jc.IsTrue)
+	c.Fatal("could not find state initialization params")
+	panic("unreachable")
 }
 
 // TestCloudInit checks that the output from the various tests
@@ -649,8 +618,8 @@ func (*cloudinitSuite) TestCloudInit(c *gc.C) {
 
 		scripts := getScripts(configKeyValues)
 		assertScriptMatch(c, scripts, test.expectScripts, !test.inexactMatch)
-		if testConfig.Config != nil {
-			checkEnvConfig(c, testConfig.Config, configKeyValues, scripts)
+		if testConfig.Bootstrap != nil {
+			checkEnvConfig(c, testConfig.Bootstrap.Config, scripts)
 		}
 
 		// curl should always be installed, since it's required by jujud.
@@ -672,7 +641,7 @@ func (*cloudinitSuite) TestCloudInitWithLocalGUI(c *gc.C) {
 	err := ioutil.WriteFile(guiPath, content, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	cfg := makeBootstrapConfig("precise").setGUI("file://" + filepath.ToSlash(guiPath))
-	guiJson, err := json.Marshal(cfg.GUI)
+	guiJson, err := json.Marshal(cfg.Bootstrap.GUI)
 	c.Assert(err, jc.ErrorIsNil)
 	base64Content := base64.StdEncoding.EncodeToString(content)
 	expectedScripts := regexp.QuoteMeta(fmt.Sprintf(`gui='/var/lib/juju/gui'
@@ -688,7 +657,7 @@ rm -f $gui/gui.tar.bz2 $gui/jujugui.sha256 $gui/downloaded-gui.txt
 
 func (*cloudinitSuite) TestCloudInitWithRemoteGUI(c *gc.C) {
 	cfg := makeBootstrapConfig("precise").setGUI("https://1.2.3.4/gui.tar.bz2")
-	guiJson, err := json.Marshal(cfg.GUI)
+	guiJson, err := json.Marshal(cfg.Bootstrap.GUI)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedScripts := regexp.QuoteMeta(fmt.Sprintf(`gui='/var/lib/juju/gui'
 mkdir -p $gui
@@ -779,10 +748,7 @@ func (*cloudinitSuite) bootstrapConfigScripts(c *gc.C) []string {
 
 func (s *cloudinitSuite) TestCloudInitConfigureBootstrapLogging(c *gc.C) {
 	scripts := s.bootstrapConfigScripts(c)
-	expected := "jujud bootstrap-state --data-dir '.*' --model-config '.*'" +
-		" --hosted-model-config '[^']*'" +
-		" --instance-id '.*' --bootstrap-constraints 'mem=4096M'" +
-		" --constraints 'mem=2048M' --show-log"
+	expected := "jujud bootstrap-state .* --show-log .*"
 	assertScriptMatch(c, scripts, expected, false)
 }
 
@@ -957,11 +923,11 @@ var verifyTests = []struct {
 	{"invalid machine id", func(cfg *instancecfg.InstanceConfig) {
 		cfg.MachineId = "-1"
 	}},
-	{"missing model configuration", func(cfg *instancecfg.InstanceConfig) {
-		cfg.Config = nil
+	{"invalid bootstrap configuration: missing model configuration", func(cfg *instancecfg.InstanceConfig) {
+		cfg.Bootstrap.Config = nil
 	}},
-	{"missing state info", func(cfg *instancecfg.InstanceConfig) {
-		cfg.MongoInfo = nil
+	{"invalid controller configuration: missing state info", func(cfg *instancecfg.InstanceConfig) {
+		cfg.Controller.MongoInfo = nil
 	}},
 	{"missing API info", func(cfg *instancecfg.InstanceConfig) {
 		cfg.APIInfo = nil
@@ -973,72 +939,41 @@ var verifyTests = []struct {
 			CACert: testing.CACert,
 		}
 	}},
-	{"missing state hosts", func(cfg *instancecfg.InstanceConfig) {
-		cfg.Bootstrap = false
-		cfg.MongoInfo = &mongo.MongoInfo{
+	{"invalid controller configuration: missing state hosts", func(cfg *instancecfg.InstanceConfig) {
+		cfg.Bootstrap = nil
+		cfg.Controller.MongoInfo = &mongo.MongoInfo{
 			Tag: names.NewMachineTag("99"),
 			Info: mongo.Info{
 				CACert: testing.CACert,
 			},
-		}
-		cfg.APIInfo = &api.Info{
-			Addrs:    []string{"foo:35"},
-			Tag:      names.NewMachineTag("99"),
-			CACert:   testing.CACert,
-			ModelTag: testing.ModelTag,
 		}
 	}},
 	{"missing API hosts", func(cfg *instancecfg.InstanceConfig) {
-		cfg.Bootstrap = false
-		cfg.MongoInfo = &mongo.MongoInfo{
-			Info: mongo.Info{
-				Addrs:  []string{"foo:35"},
-				CACert: testing.CACert,
-			},
-			Tag: names.NewMachineTag("99"),
-		}
+		cfg.Bootstrap = nil
+		cfg.Controller.MongoInfo.Tag = names.NewMachineTag("99")
 		cfg.APIInfo = &api.Info{
 			Tag:      names.NewMachineTag("99"),
 			CACert:   testing.CACert,
 			ModelTag: testing.ModelTag,
 		}
 	}},
-	{"missing CA certificate", func(cfg *instancecfg.InstanceConfig) {
-		cfg.MongoInfo = &mongo.MongoInfo{Info: mongo.Info{Addrs: []string{"host:98765"}}}
+	{"invalid controller configuration: missing CA certificate", func(cfg *instancecfg.InstanceConfig) {
+		cfg.Controller.MongoInfo.CACert = ""
 	}},
-	{"missing CA certificate", func(cfg *instancecfg.InstanceConfig) {
-		cfg.Bootstrap = false
-		cfg.MongoInfo = &mongo.MongoInfo{
-			Tag: names.NewMachineTag("99"),
-			Info: mongo.Info{
-				Addrs: []string{"host:98765"},
-			},
-		}
+	{"invalid bootstrap configuration: missing controller certificate", func(cfg *instancecfg.InstanceConfig) {
+		cfg.Bootstrap.StateServingInfo.Cert = ""
 	}},
-	{"missing controller certificate", func(cfg *instancecfg.InstanceConfig) {
-		info := *cfg.StateServingInfo
-		info.Cert = ""
-		cfg.StateServingInfo = &info
+	{"invalid bootstrap configuration: missing controller private key", func(cfg *instancecfg.InstanceConfig) {
+		cfg.Bootstrap.StateServingInfo.PrivateKey = ""
 	}},
-	{"missing controller private key", func(cfg *instancecfg.InstanceConfig) {
-		info := *cfg.StateServingInfo
-		info.PrivateKey = ""
-		cfg.StateServingInfo = &info
+	{"invalid bootstrap configuration: missing ca cert private key", func(cfg *instancecfg.InstanceConfig) {
+		cfg.Bootstrap.StateServingInfo.CAPrivateKey = ""
 	}},
-	{"missing ca cert private key", func(cfg *instancecfg.InstanceConfig) {
-		info := *cfg.StateServingInfo
-		info.CAPrivateKey = ""
-		cfg.StateServingInfo = &info
+	{"invalid bootstrap configuration: missing state port", func(cfg *instancecfg.InstanceConfig) {
+		cfg.Bootstrap.StateServingInfo.StatePort = 0
 	}},
-	{"missing state port", func(cfg *instancecfg.InstanceConfig) {
-		info := *cfg.StateServingInfo
-		info.StatePort = 0
-		cfg.StateServingInfo = &info
-	}},
-	{"missing API port", func(cfg *instancecfg.InstanceConfig) {
-		info := *cfg.StateServingInfo
-		info.APIPort = 0
-		cfg.StateServingInfo = &info
+	{"invalid bootstrap configuration: missing API port", func(cfg *instancecfg.InstanceConfig) {
+		cfg.Bootstrap.StateServingInfo.APIPort = 0
 	}},
 	{"missing var directory", func(cfg *instancecfg.InstanceConfig) {
 		cfg.DataDir = ""
@@ -1049,42 +984,29 @@ var verifyTests = []struct {
 	{"missing cloud-init output log path", func(cfg *instancecfg.InstanceConfig) {
 		cfg.CloudInitOutputLog = ""
 	}},
-	{"missing tools", func(cfg *instancecfg.InstanceConfig) {
-		// This is handled directly in the loop.
+	{"invalid controller configuration: entity tag must match started machine", func(cfg *instancecfg.InstanceConfig) {
+		cfg.Bootstrap = nil
+		cfg.Controller.MongoInfo.Tag = names.NewMachineTag("0")
 	}},
-	{"entity tag must match started machine", func(cfg *instancecfg.InstanceConfig) {
-		cfg.Bootstrap = false
-		info := *cfg.MongoInfo
-		info.Tag = names.NewMachineTag("0")
-		cfg.MongoInfo = &info
+	{"invalid controller configuration: entity tag must match started machine", func(cfg *instancecfg.InstanceConfig) {
+		cfg.Bootstrap = nil
+		cfg.Controller.MongoInfo.Tag = nil // admin user
 	}},
-	{"entity tag must match started machine", func(cfg *instancecfg.InstanceConfig) {
-		cfg.Bootstrap = false
-		info := *cfg.MongoInfo
-		info.Tag = nil // admin user
-		cfg.MongoInfo = &info
+	{"API entity tag must match started machine", func(cfg *instancecfg.InstanceConfig) {
+		cfg.Bootstrap = nil
+		cfg.Controller.MongoInfo.Tag = names.NewMachineTag("99")
+		cfg.APIInfo.Tag = names.NewMachineTag("0")
 	}},
-	{"entity tag must match started machine", func(cfg *instancecfg.InstanceConfig) {
-		cfg.Bootstrap = false
-		info := *cfg.APIInfo
-		info.Tag = names.NewMachineTag("0")
-		cfg.APIInfo = &info
+	{"API entity tag must match started machine", func(cfg *instancecfg.InstanceConfig) {
+		cfg.Bootstrap = nil
+		cfg.Controller.MongoInfo.Tag = names.NewMachineTag("99")
+		cfg.APIInfo.Tag = nil
 	}},
-	{"entity tag must match started machine", func(cfg *instancecfg.InstanceConfig) {
-		cfg.Bootstrap = false
-		info := *cfg.APIInfo
-		info.Tag = nil
-		cfg.APIInfo = &info
+	{"invalid bootstrap configuration: entity tag must be nil when bootstrapping", func(cfg *instancecfg.InstanceConfig) {
+		cfg.Controller.MongoInfo.Tag = names.NewMachineTag("0")
 	}},
-	{"entity tag must be nil when starting a controller", func(cfg *instancecfg.InstanceConfig) {
-		info := *cfg.MongoInfo
-		info.Tag = names.NewMachineTag("0")
-		cfg.MongoInfo = &info
-	}},
-	{"entity tag must be nil when starting a controller", func(cfg *instancecfg.InstanceConfig) {
-		info := *cfg.APIInfo
-		info.Tag = names.NewMachineTag("0")
-		cfg.APIInfo = &info
+	{"invalid bootstrap configuration: entity tag must be nil when bootstrapping", func(cfg *instancecfg.InstanceConfig) {
+		cfg.APIInfo.Tag = names.NewMachineTag("0")
 	}},
 	{"missing machine nonce", func(cfg *instancecfg.InstanceConfig) {
 		cfg.MachineNonce = ""
@@ -1092,17 +1014,8 @@ var verifyTests = []struct {
 	{"missing machine agent service name", func(cfg *instancecfg.InstanceConfig) {
 		cfg.MachineAgentServiceName = ""
 	}},
-	{"missing instance-id", func(cfg *instancecfg.InstanceConfig) {
-		cfg.InstanceId = ""
-	}},
-	{"state serving info unexpectedly present", func(cfg *instancecfg.InstanceConfig) {
-		cfg.Bootstrap = false
-		apiInfo := *cfg.APIInfo
-		apiInfo.Tag = names.NewMachineTag("99")
-		cfg.APIInfo = &apiInfo
-		stateInfo := *cfg.MongoInfo
-		stateInfo.Tag = names.NewMachineTag("99")
-		cfg.MongoInfo = &stateInfo
+	{"invalid bootstrap configuration: missing instance-id", func(cfg *instancecfg.InstanceConfig) {
+		cfg.Bootstrap.InstanceId = ""
 	}},
 }
 
@@ -1112,61 +1025,70 @@ func (*cloudinitSuite) TestCloudInitVerify(c *gc.C) {
 	toolsList := tools.List{
 		newSimpleTools("9.9.9-quantal-arble"),
 	}
-	cfgWithoutTools := &instancecfg.InstanceConfig{
-		Bootstrap:        true,
-		StateServingInfo: stateServingInfo,
-		MachineId:        "99",
-		AuthorizedKeys:   "sshkey1",
-		Series:           "quantal",
-		AgentEnvironment: map[string]string{agent.ProviderType: "dummy"},
-		MongoInfo: &mongo.MongoInfo{
-			Info: mongo.Info{
-				Addrs:  []string{"host:98765"},
-				CACert: testing.CACert,
+
+	makeCfgWithoutTools := func() instancecfg.InstanceConfig {
+		return instancecfg.InstanceConfig{
+			Bootstrap: &instancecfg.BootstrapConfig{
+				StateInitializationParams: instancecfg.StateInitializationParams{
+					InstanceId:        "i-bootstrap",
+					Config:            minimalModelConfig(c),
+					HostedModelConfig: map[string]interface{}{"name": "hosted-model"},
+				},
+				StateServingInfo: stateServingInfo,
 			},
-			Password: "password",
-		},
-		APIInfo: &api.Info{
-			Addrs:    []string{"host:9999"},
-			CACert:   testing.CACert,
-			ModelTag: testing.ModelTag,
-		},
-		Config:                  minimalModelConfig(c),
-		HostedModelConfig:       map[string]interface{}{"name": "hosted-model"},
-		DataDir:                 jujuDataDir("quantal"),
-		LogDir:                  jujuLogDir("quantal"),
-		MetricsSpoolDir:         metricsSpoolDir("quantal"),
-		Jobs:                    normalMachineJobs,
-		CloudInitOutputLog:      cloudInitOutputLog("quantal"),
-		InstanceId:              "i-bootstrap",
-		MachineNonce:            "FAKE_NONCE",
-		MachineAgentServiceName: "jujud-machine-99",
+			Controller: &instancecfg.ControllerConfig{
+				MongoInfo: &mongo.MongoInfo{
+					Info: mongo.Info{
+						Addrs:  []string{"host:98765"},
+						CACert: testing.CACert,
+					},
+					Password: "password",
+				},
+			},
+			MachineId:        "99",
+			AuthorizedKeys:   "sshkey1",
+			Series:           "quantal",
+			AgentEnvironment: map[string]string{agent.ProviderType: "dummy"},
+			APIInfo: &api.Info{
+				Addrs:    []string{"host:9999"},
+				CACert:   testing.CACert,
+				ModelTag: testing.ModelTag,
+			},
+			DataDir:                 jujuDataDir("quantal"),
+			LogDir:                  jujuLogDir("quantal"),
+			MetricsSpoolDir:         metricsSpoolDir("quantal"),
+			Jobs:                    normalMachineJobs,
+			CloudInitOutputLog:      cloudInitOutputLog("quantal"),
+			MachineNonce:            "FAKE_NONCE",
+			MachineAgentServiceName: "jujud-machine-99",
+		}
 	}
-	copied := *cfgWithoutTools
-	cfg := &copied
-	err := cfg.SetTools(toolsList)
-	c.Assert(err, jc.ErrorIsNil)
+
 	// check that the base configuration does not give an error
 	ci, err := cloudinit.New("quantal")
 	c.Assert(err, jc.ErrorIsNil)
 
+	// check that missing tools causes an error.
+	cfg := makeCfgWithoutTools()
+	udata, err := cloudconfig.NewUserdataConfig(&cfg, ci)
+	c.Assert(err, jc.ErrorIsNil)
+	err = udata.Configure()
+	c.Assert(err, gc.ErrorMatches, "invalid machine configuration: missing tools")
+
 	for i, test := range verifyTests {
+		c.Logf("test %d. %s", i, test.err)
+		cfg := makeCfgWithoutTools()
+		err := cfg.SetTools(toolsList)
+		c.Assert(err, jc.ErrorIsNil)
+
 		// check that the base configuration does not give an error
-		// and that a previous test hasn't mutated it accidentially.
-		udata, err := cloudconfig.NewUserdataConfig(cfg, ci)
+		udata, err := cloudconfig.NewUserdataConfig(&cfg, ci)
 		c.Assert(err, jc.ErrorIsNil)
 		err = udata.Configure()
 		c.Assert(err, jc.ErrorIsNil)
 
-		c.Logf("test %d. %s", i, test.err)
-
-		cfg1 := *cfg
-		if test.err == "missing tools" {
-			cfg1 = *cfgWithoutTools
-		}
-		test.mutate(&cfg1)
-
-		udata, err = cloudconfig.NewUserdataConfig(&cfg1, ci)
+		test.mutate(&cfg)
+		udata, err = cloudconfig.NewUserdataConfig(&cfg, ci)
 		c.Assert(err, jc.ErrorIsNil)
 		err = udata.Configure()
 		c.Check(err, gc.ErrorMatches, "invalid machine configuration: "+test.err)
@@ -1176,9 +1098,8 @@ func (*cloudinitSuite) TestCloudInitVerify(c *gc.C) {
 func (*cloudinitSuite) createInstanceConfig(c *gc.C, environConfig *config.Config) *instancecfg.InstanceConfig {
 	machineId := "42"
 	machineNonce := "fake-nonce"
-	stateInfo := jujutesting.FakeStateInfo(machineId)
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
-	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, machineNonce, imagemetadata.ReleasedStream, "quantal", "", true, stateInfo, apiInfo)
+	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, machineNonce, imagemetadata.ReleasedStream, "quantal", true, apiInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	instanceConfig.SetTools(tools.List{
 		&tools.Tools{
@@ -1319,7 +1240,6 @@ JzPMDvZ0fYS30ukCIA1stlJxpFiCXQuFn0nG+jH4Q52FTv8xxBhrbLOFvHRRAiEA
 
 var windowsCloudinitTests = []cloudinitTest{{
 	cfg: makeNormalConfig("win8").setMachineID("10").mutate(func(cfg *testInstanceConfig) {
-		cfg.MongoInfo.Info.CACert = "CA CERT\n" + string(serverCert)
 		cfg.APIInfo.CACert = "CA CERT\n" + string(serverCert)
 	}),
 	setEnvConfig:  false,

--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -94,9 +94,8 @@ func (w *windowsConfigure) ConfigureJuju() error {
 	if err := w.icfg.VerifyConfig(); err != nil {
 		return errors.Trace(err)
 	}
-	if w.icfg.Bootstrap == true {
-		// Bootstrap machine not supported on windows
-		return errors.Errorf("bootstrapping is not supported on windows")
+	if w.icfg.Controller != nil {
+		return errors.Errorf("controllers not supported on windows")
 	}
 
 	tools := w.icfg.ToolsList()[0]
@@ -113,7 +112,7 @@ func (w *windowsConfigure) ConfigureJuju() error {
 	)
 
 	toolsDownloadCmds, err := addDownloadToolsCmds(
-		w.icfg.Series, w.icfg.MongoInfo.CACert, w.icfg.ToolsList(),
+		w.icfg.Series, w.icfg.APIInfo.CACert, w.icfg.ToolsList(),
 	)
 	if err != nil {
 		return errors.Trace(err)

--- a/cloudconfig/windows_userdata_test.go
+++ b/cloudconfig/windows_userdata_test.go
@@ -734,12 +734,10 @@ cacert: |
   fR+gLQjslxf64w0wCwYJKoZIhvcNAQEFA0EAbn0MaxWVgGYBomeLYfDdb8vCq/5/
   G/2iCUQCXsVrBparMLFnor/iKOkJB5n3z3rtu70rFt+DpX6L8uBR3LB3+A==
   -----END CERTIFICATE-----
-stateaddresses:
-- state-addr.testing.invalid:12345
 model: model-deadbeef-0bad-400d-8000-4b1d0d06f00d
 apiaddresses:
 - state-addr.testing.invalid:54321
-oldpassword: arble
+oldpassword: bletch
 values:
   AGENT_SERVICE_NAME: jujud-machine-10
   PROVIDER_TYPE: dummy

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -18,20 +17,18 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
-	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/series"
 	"github.com/juju/utils/ssh"
 	"github.com/juju/version"
-	goyaml "gopkg.in/yaml.v2"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/agentbootstrap"
 	agenttools "github.com/juju/juju/agent/tools"
+	"github.com/juju/juju/cloudconfig/instancecfg"
 	agentcmd "github.com/juju/juju/cmd/jujud/agent"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
-	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/imagemetadata"
@@ -60,18 +57,13 @@ var (
 	logger               = loggo.GetLogger("juju.cmd.jujud")
 )
 
+const adminUserName = "admin"
+
 // BootstrapCommand represents a jujud bootstrap command.
 type BootstrapCommand struct {
 	cmd.CommandBase
 	agentcmd.AgentConf
-	ControllerModelConfig map[string]interface{}
-	HostedModelConfig     map[string]interface{}
-	BootstrapConstraints  constraints.Value
-	ModelConstraints      constraints.Value
-	Hardware              instance.HardwareCharacteristics
-	InstanceId            string
-	AdminUsername         string
-	ImageMetadataDir      string
+	BootstrapParamsFile string
 }
 
 // NewBootstrapCommand returns a new BootstrapCommand that has been initialized.
@@ -92,39 +84,31 @@ func (c *BootstrapCommand) Info() *cmd.Info {
 // SetFlags adds the flags for this command to the passed gnuflag.FlagSet.
 func (c *BootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.AgentConf.AddFlags(f)
-	yamlBase64Var(f, &c.ControllerModelConfig, "model-config", "", "controller model configuration (yaml, base64 encoded)")
-	yamlBase64Var(f, &c.HostedModelConfig, "hosted-model-config", "", "initial hosted model configuration (yaml, base64 encoded)")
-	f.Var(constraints.ConstraintsValue{Target: &c.BootstrapConstraints}, "bootstrap-constraints", "bootstrap machine constraints (space-separated strings)")
-	f.Var(constraints.ConstraintsValue{Target: &c.ModelConstraints}, "constraints", "initial constraints (space-separated strings)")
-	f.Var(&c.Hardware, "hardware", "hardware characteristics (space-separated strings)")
-	f.StringVar(&c.InstanceId, "instance-id", "", "unique instance-id for bootstrap machine")
-	f.StringVar(&c.AdminUsername, "admin-user", "admin", "set the name for the juju admin user")
-	f.StringVar(&c.ImageMetadataDir, "image-metadata", "", "custom image metadata source dir")
 }
 
 // Init initializes the command for running.
 func (c *BootstrapCommand) Init(args []string) error {
-	if len(c.ControllerModelConfig) == 0 {
-		return cmdutil.RequiredError("model-config")
+	if len(args) == 0 {
+		return errors.New("bootstrap-params file must be specified")
 	}
-	if len(c.HostedModelConfig) == 0 {
-		return cmdutil.RequiredError("hosted-model-config")
+	if err := cmd.CheckEmpty(args[1:]); err != nil {
+		return err
 	}
-	if c.InstanceId == "" {
-		return cmdutil.RequiredError("instance-id")
-	}
-	if !names.IsValidUser(c.AdminUsername) {
-		return errors.Errorf("%q is not a valid username", c.AdminUsername)
-	}
-	return c.AgentConf.CheckArgs(args)
+	c.BootstrapParamsFile = args[0]
+	return c.AgentConf.CheckArgs(args[1:])
 }
 
 // Run initializes state for an environment.
 func (c *BootstrapCommand) Run(_ *cmd.Context) error {
-	envCfg, err := config.New(config.NoDefaults, c.ControllerModelConfig)
+	bootstrapParamsData, err := ioutil.ReadFile(c.BootstrapParamsFile)
 	if err != nil {
-		return err
+		return errors.Annotate(err, "reading bootstrap params file")
 	}
+	var args instancecfg.StateInitializationParams
+	if err := args.Unmarshal(bootstrapParamsData); err != nil {
+		return errors.Trace(err)
+	}
+
 	err = c.ReadConfig("machine-0")
 	if err != nil {
 		return err
@@ -144,7 +128,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 	}
 
 	// Get the bootstrap machine's addresses from the provider.
-	env, err := environs.New(envCfg)
+	env, err := environs.New(args.Config)
 	if err != nil {
 		return err
 	}
@@ -152,11 +136,11 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 
 	// Check to see if a newer agent version has been requested
 	// by the bootstrap client.
-	desiredVersion, ok := envCfg.AgentVersion()
+	desiredVersion, ok := args.Config.AgentVersion()
 	if ok && desiredVersion != jujuversion.Current {
 		// If we have been asked for a newer version, ensure the newer
 		// tools can actually be found, or else bootstrap won't complete.
-		stream := envtools.PreferredStream(&desiredVersion, envCfg.Development(), envCfg.AgentStream())
+		stream := envtools.PreferredStream(&desiredVersion, args.Config.Development(), args.Config.AgentStream())
 		logger.Infof("newer tools requested, looking for %v in stream %v", desiredVersion, stream)
 		filter := tools.Filter{
 			Number: desiredVersion,
@@ -178,8 +162,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		}
 	}
 
-	instanceId := instance.Id(c.InstanceId)
-	instances, err := env.Instances([]instance.Id{instanceId})
+	instances, err := env.Instances([]instance.Id{args.InstanceId})
 	if err != nil {
 		return err
 	}
@@ -202,7 +185,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 	if err != nil {
 		return errors.Annotate(err, "failed to generate system key")
 	}
-	authorizedKeys := config.ConcatAuthKeys(envCfg.AuthorizedKeys(), publicKey)
+	authorizedKeys := config.ConcatAuthKeys(args.Config.AuthorizedKeys(), publicKey)
 	newConfigAttrs[config.AuthKeysConfig] = authorizedKeys
 
 	// Generate a shared secret for the Mongo replica set, and write it out.
@@ -237,7 +220,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 
 	logger.Infof("started mongo")
 	// Initialise state, and store any agent config (e.g. password) changes.
-	envCfg, err = env.Config().Apply(newConfigAttrs)
+	envCfg, err := env.Config().Apply(newConfigAttrs)
 	if err != nil {
 		return errors.Annotate(err, "failed to update model config")
 	}
@@ -259,18 +242,24 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		// We shouldn't attempt to dial peers until we have some.
 		dialOpts.Direct = true
 
-		adminTag := names.NewLocalUserTag(c.AdminUsername)
+		var hardware instance.HardwareCharacteristics
+		if args.HardwareCharacteristics != nil {
+			hardware = *args.HardwareCharacteristics
+		}
+
+		adminTag := names.NewLocalUserTag(adminUserName)
 		st, m, stateErr = agentInitializeState(
 			adminTag,
 			agentConfig,
-			envCfg, c.HostedModelConfig,
+			envCfg,
+			args.HostedModelConfig,
 			agentbootstrap.BootstrapMachineConfig{
 				Addresses:            addrs,
-				BootstrapConstraints: c.BootstrapConstraints,
-				ModelConstraints:     c.ModelConstraints,
+				BootstrapConstraints: args.BootstrapMachineConstraints,
+				ModelConstraints:     args.ModelConstraints,
 				Jobs:                 jobs,
-				InstanceId:           instanceId,
-				Characteristics:      c.Hardware,
+				InstanceId:           args.InstanceId,
+				Characteristics:      hardware,
 				SharedSecret:         sharedSecret,
 			},
 			dialOpts,
@@ -297,13 +286,8 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 	}
 
 	// Add custom image metadata to environment storage.
-	if c.ImageMetadataDir != "" {
-		if err := c.saveCustomImageMetadata(st, env); err != nil {
-			return err
-		}
-
-		stor := newStateStorage(st.ModelUUID(), st.MongoSession())
-		if err := c.storeCustomImageMetadata(stor); err != nil {
+	if len(args.CustomImageMetadata) > 0 {
+		if err := c.saveCustomImageMetadata(st, args.CustomImageMetadata); err != nil {
 			return err
 		}
 	}
@@ -465,66 +449,13 @@ func (c *BootstrapCommand) populateGUIArchive(st *state.State, env environs.Envi
 	return nil
 }
 
-// storeCustomImageMetadata reads the custom image metadata from disk,
-// and stores the files in environment storage with the same relative
-// paths.
-func (c *BootstrapCommand) storeCustomImageMetadata(stor storage.Storage) error {
-	logger.Debugf("storing custom image metadata from %q", c.ImageMetadataDir)
-	return filepath.Walk(c.ImageMetadataDir, func(abspath string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.Mode().IsRegular() {
-			return nil
-		}
-		relpath, err := filepath.Rel(c.ImageMetadataDir, abspath)
-		if err != nil {
-			return err
-		}
-		f, err := os.Open(abspath)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		relpath = filepath.ToSlash(relpath)
-		logger.Debugf("storing %q in model storage (%d bytes)", relpath, info.Size())
-		return stor.Put(relpath, f, info.Size())
-	})
-}
-
 // Override for testing.
 var seriesFromVersion = series.VersionSeries
 
-// saveCustomImageMetadata reads the custom image metadata from disk,
-// and saves it in controller.
-func (c *BootstrapCommand) saveCustomImageMetadata(st *state.State, env environs.Environ) error {
-	logger.Debugf("saving custom image metadata from %q", c.ImageMetadataDir)
-	baseURL := fmt.Sprintf("file://%s", filepath.ToSlash(c.ImageMetadataDir))
-	publicKey, _ := simplestreams.UserPublicSigningKey()
-	datasource := simplestreams.NewURLSignedDataSource("custom", baseURL, publicKey, utils.NoVerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false)
-	return storeImageMetadataFromFiles(st, env, datasource)
-}
-
-// storeImageMetadataFromFiles puts image metadata found in sources into state.
-// Declared as var to facilitate tests.
-var storeImageMetadataFromFiles = func(st *state.State, env environs.Environ, source simplestreams.DataSource) error {
-	// Read the image metadata, as we'll want to upload it to the environment.
-	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{})
-	if inst, ok := env.(simplestreams.HasRegion); ok {
-		// If we can determine current region,
-		// we want only metadata specific to this region.
-		cloud, err := inst.Region()
-		if err != nil {
-			return err
-		}
-		imageConstraint.CloudSpec = cloud
-	}
-
-	existingMetadata, info, err := imagemetadata.Fetch([]simplestreams.DataSource{source}, imageConstraint)
-	if err != nil && !errors.IsNotFound(err) {
-		return errors.Annotate(err, "cannot read image metadata")
-	}
-	return storeImageMetadataInState(st, info.Source, source.Priority(), existingMetadata)
+// saveCustomImageMetadata stores the custom image metadata to the database,
+func (c *BootstrapCommand) saveCustomImageMetadata(st *state.State, imageMetadata []*imagemetadata.ImageMetadata) error {
+	logger.Debugf("saving custom image metadata")
+	return storeImageMetadataInState(st, "custom", simplestreams.CUSTOM_CLOUD_DATA, imageMetadata)
 }
 
 // storeImageMetadataInState writes image metadata into state store.
@@ -557,25 +488,4 @@ func storeImageMetadataInState(st *state.State, source string, priority int, exi
 		return errors.Annotatef(err, "cannot cache image metadata")
 	}
 	return nil
-}
-
-// yamlBase64Value implements gnuflag.Value on a map[string]interface{}.
-type yamlBase64Value map[string]interface{}
-
-// Set decodes the base64 value into yaml then expands that into a map.
-func (v *yamlBase64Value) Set(value string) error {
-	decoded, err := base64.StdEncoding.DecodeString(value)
-	if err != nil {
-		return err
-	}
-	return goyaml.Unmarshal(decoded, v)
-}
-
-func (v *yamlBase64Value) String() string {
-	return fmt.Sprintf("%v", *v)
-}
-
-// yamlBase64Var sets up a gnuflag flag analogous to the FlagSet.*Var methods.
-func yamlBase64Var(fs *gnuflag.FlagSet, target *map[string]interface{}, name string, value string, usage string) {
-	fs.Var((*yamlBase64Value)(target), name, usage)
 }

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -26,13 +26,13 @@ import (
 	"github.com/juju/utils/set"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/mgo.v2"
 	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/agentbootstrap"
 	agenttools "github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -40,6 +40,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/filestorage"
+	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/simplestreams"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/environs/storage"
@@ -55,8 +56,6 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/cloudimagemetadata"
 	"github.com/juju/juju/state/multiwatcher"
-	statestorage "github.com/juju/juju/state/storage"
-	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
@@ -68,16 +67,16 @@ import (
 type BootstrapSuite struct {
 	testing.BaseSuite
 	gitjujutesting.MgoSuite
-	envcfg                       *config.Config
-	b64yamlControllerModelConfig string
-	b64yamlHostedModelConfig     string
-	instanceId                   instance.Id
-	dataDir                      string
-	logDir                       string
-	mongoOplogSize               string
-	fakeEnsureMongo              *agenttest.FakeEnsureMongo
-	bootstrapName                string
-	hostedModelUUID              string
+
+	bootstrapParamsFile string
+	bootstrapParams     instancecfg.StateInitializationParams
+
+	dataDir         string
+	logDir          string
+	mongoOplogSize  string
+	fakeEnsureMongo *agenttest.FakeEnsureMongo
+	bootstrapName   string
+	hostedModelUUID string
 
 	toolsStorage storage.Storage
 }
@@ -97,7 +96,6 @@ func (s *BootstrapSuite) SetUpSuite(c *gc.C) {
 	})
 	s.MgoSuite.SetUpSuite(c)
 	s.PatchValue(&jujuversion.Current, testing.FakeVersionNumber)
-	s.makeTestEnv(c)
 }
 
 func (s *BootstrapSuite) TearDownSuite(c *gc.C) {
@@ -115,9 +113,11 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 	s.MgoSuite.SetUpTest(c)
 	s.dataDir = c.MkDir()
 	s.logDir = c.MkDir()
+	s.bootstrapParamsFile = filepath.Join(s.dataDir, "bootstrap-params")
 	s.mongoOplogSize = "1234"
 	s.fakeEnsureMongo = agenttest.InstallFakeEnsureMongo(s)
 	s.PatchValue(&initiateMongoServer, s.fakeEnsureMongo.InitiateMongo)
+	s.makeTestEnv(c)
 
 	// Create fake tools.tar.gz and downloaded-tools.txt.
 	current := version.Binary{
@@ -173,10 +173,7 @@ func (s *BootstrapSuite) TestGUIArchiveInfoNotFound(c *gc.C) {
 	info := filepath.Join(dir, "downloaded-gui.txt")
 	err := os.Remove(info)
 	c.Assert(err, jc.ErrorIsNil)
-	_, cmd, err := s.initBootstrapCommand(
-		c, nil, "--model-config", s.b64yamlControllerModelConfig,
-		"--hosted-model-config", s.b64yamlHostedModelConfig,
-		"--instance-id", string(s.instanceId))
+	_, cmd, err := s.initBootstrapCommand(c, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	var tw loggo.TestWriter
@@ -203,10 +200,7 @@ func (s *BootstrapSuite) TestGUIArchiveInfoError(c *gc.C) {
 	err := os.Chmod(info, 0000)
 	c.Assert(err, jc.ErrorIsNil)
 	defer os.Chmod(info, 0600)
-	_, cmd, err := s.initBootstrapCommand(
-		c, nil, "--model-config", s.b64yamlControllerModelConfig,
-		"--hosted-model-config", s.b64yamlHostedModelConfig,
-		"--instance-id", string(s.instanceId))
+	_, cmd, err := s.initBootstrapCommand(c, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	var tw loggo.TestWriter
@@ -227,10 +221,7 @@ func (s *BootstrapSuite) TestGUIArchiveError(c *gc.C) {
 	archive := filepath.Join(dir, "gui.tar.bz2")
 	err := os.Remove(archive)
 	c.Assert(err, jc.ErrorIsNil)
-	_, cmd, err := s.initBootstrapCommand(
-		c, nil, "--model-config", s.b64yamlControllerModelConfig,
-		"--hosted-model-config", s.b64yamlHostedModelConfig,
-		"--instance-id", string(s.instanceId))
+	_, cmd, err := s.initBootstrapCommand(c, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	var tw loggo.TestWriter
@@ -246,10 +237,7 @@ func (s *BootstrapSuite) TestGUIArchiveError(c *gc.C) {
 }
 
 func (s *BootstrapSuite) TestGUIArchiveSuccess(c *gc.C) {
-	_, cmd, err := s.initBootstrapCommand(
-		c, nil, "--model-config", s.b64yamlControllerModelConfig,
-		"--hosted-model-config", s.b64yamlHostedModelConfig,
-		"--instance-id", string(s.instanceId))
+	_, cmd, err := s.initBootstrapCommand(c, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	var tw loggo.TestWriter
@@ -335,19 +323,16 @@ func (s *BootstrapSuite) initBootstrapCommand(c *gc.C, jobs []multiwatcher.Machi
 	err = machineConf.Write()
 	c.Assert(err, jc.ErrorIsNil)
 
+	if len(args) == 0 {
+		args = []string{s.bootstrapParamsFile}
+	}
 	cmd = NewBootstrapCommand()
-
 	err = testing.InitCommand(cmd, append([]string{"--data-dir", s.dataDir}, args...))
 	return machineConf, cmd, err
 }
 
 func (s *BootstrapSuite) TestInitializeEnvironment(c *gc.C) {
-	hw := instance.MustParseHardware("arch=amd64 mem=8G")
-	machConf, cmd, err := s.initBootstrapCommand(
-		c, nil, "--model-config", s.b64yamlControllerModelConfig,
-		"--hosted-model-config", s.b64yamlHostedModelConfig,
-		"--instance-id", string(s.instanceId), "--hardware", hw.String(),
-	)
+	machConf, cmd, err := s.initBootstrapCommand(c, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -393,12 +378,12 @@ func (s *BootstrapSuite) TestInitializeEnvironment(c *gc.C) {
 
 	instid, err := machines[0].InstanceId()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(instid, gc.Equals, instance.Id(string(s.instanceId)))
+	c.Assert(instid, gc.Equals, s.bootstrapParams.InstanceId)
 
 	stateHw, err := machines[0].HardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(stateHw, gc.NotNil)
-	c.Assert(*stateHw, gc.DeepEquals, hw)
+	c.Assert(stateHw, gc.DeepEquals, s.bootstrapParams.HardwareCharacteristics)
 
 	cons, err := st.ModelConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -406,17 +391,12 @@ func (s *BootstrapSuite) TestInitializeEnvironment(c *gc.C) {
 
 	cfg, err := st.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg.AuthorizedKeys(), gc.Equals, s.envcfg.AuthorizedKeys()+"\npublic-key")
+	c.Assert(cfg.AuthorizedKeys(), gc.Equals, s.bootstrapParams.Config.AuthorizedKeys()+"\npublic-key")
 }
 
 func (s *BootstrapSuite) TestInitializeEnvironmentInvalidOplogSize(c *gc.C) {
 	s.mongoOplogSize = "NaN"
-	hw := instance.MustParseHardware("arch=amd64 mem=8G")
-	_, cmd, err := s.initBootstrapCommand(
-		c, nil, "--model-config", s.b64yamlControllerModelConfig,
-		"--hosted-model-config", s.b64yamlHostedModelConfig,
-		"--instance-id", string(s.instanceId), "--hardware", hw.String(),
-	)
+	_, cmd, err := s.initBootstrapCommand(c, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, gc.ErrorMatches, `invalid oplog size: "NaN"`)
@@ -424,18 +404,14 @@ func (s *BootstrapSuite) TestInitializeEnvironmentInvalidOplogSize(c *gc.C) {
 
 func (s *BootstrapSuite) TestInitializeEnvironmentToolsNotFound(c *gc.C) {
 	// bootstrap with 1.99.1 but there will be no tools so version will be reset.
-	envcfg, err := s.envcfg.Apply(map[string]interface{}{
+	cfg, err := s.bootstrapParams.Config.Apply(map[string]interface{}{
 		"agent-version": "1.99.1",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	b64yamlControllerModelConfig := b64yaml(envcfg.AllAttrs()).encode()
+	s.bootstrapParams.Config = cfg
+	s.writeBootstrapParamsFile(c)
 
-	hw := instance.MustParseHardware("arch=amd64 mem=8G")
-	_, cmd, err := s.initBootstrapCommand(
-		c, nil, "--model-config", b64yamlControllerModelConfig,
-		"--hosted-model-config", s.b64yamlHostedModelConfig,
-		"--instance-id", string(s.instanceId), "--hardware", hw.String(),
-	)
+	_, cmd, err := s.initBootstrapCommand(c, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -450,7 +426,7 @@ func (s *BootstrapSuite) TestInitializeEnvironmentToolsNotFound(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
-	cfg, err := st.ModelConfig()
+	cfg, err = st.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	vers, ok := cfg.AgentVersion()
 	c.Assert(ok, jc.IsTrue)
@@ -458,15 +434,11 @@ func (s *BootstrapSuite) TestInitializeEnvironmentToolsNotFound(c *gc.C) {
 }
 
 func (s *BootstrapSuite) TestSetConstraints(c *gc.C) {
-	bootstrapCons := constraints.Value{Mem: uint64p(4096), CpuCores: uint64p(4)}
-	modelCons := constraints.Value{Mem: uint64p(2048), CpuCores: uint64p(2)}
-	_, cmd, err := s.initBootstrapCommand(c, nil,
-		"--model-config", s.b64yamlControllerModelConfig,
-		"--hosted-model-config", s.b64yamlHostedModelConfig,
-		"--instance-id", string(s.instanceId),
-		"--bootstrap-constraints", bootstrapCons.String(),
-		"--constraints", modelCons.String(),
-	)
+	s.bootstrapParams.BootstrapMachineConstraints = constraints.Value{Mem: uint64p(4096), CpuCores: uint64p(4)}
+	s.bootstrapParams.ModelConstraints = constraints.Value{Mem: uint64p(2048), CpuCores: uint64p(2)}
+	s.writeBootstrapParamsFile(c)
+
+	_, cmd, err := s.initBootstrapCommand(c, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -483,14 +455,14 @@ func (s *BootstrapSuite) TestSetConstraints(c *gc.C) {
 
 	cons, err := st.ModelConstraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cons, gc.DeepEquals, modelCons)
+	c.Assert(cons, gc.DeepEquals, s.bootstrapParams.ModelConstraints)
 
 	machines, err := st.AllMachines()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 1)
 	cons, err = machines[0].Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cons, gc.DeepEquals, bootstrapCons)
+	c.Assert(cons, gc.DeepEquals, s.bootstrapParams.BootstrapMachineConstraints)
 }
 
 func uint64p(v uint64) *uint64 {
@@ -503,11 +475,7 @@ func (s *BootstrapSuite) TestDefaultMachineJobs(c *gc.C) {
 		state.JobHostUnits,
 		state.JobManageNetworking,
 	}
-	_, cmd, err := s.initBootstrapCommand(c, nil,
-		"--model-config", s.b64yamlControllerModelConfig,
-		"--hosted-model-config", s.b64yamlHostedModelConfig,
-		"--instance-id", string(s.instanceId),
-	)
+	_, cmd, err := s.initBootstrapCommand(c, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -528,11 +496,7 @@ func (s *BootstrapSuite) TestDefaultMachineJobs(c *gc.C) {
 
 func (s *BootstrapSuite) TestConfiguredMachineJobs(c *gc.C) {
 	jobs := []multiwatcher.MachineJob{multiwatcher.JobManageModel}
-	_, cmd, err := s.initBootstrapCommand(c, jobs,
-		"--model-config", s.b64yamlControllerModelConfig,
-		"--hosted-model-config", s.b64yamlHostedModelConfig,
-		"--instance-id", string(s.instanceId),
-	)
+	_, cmd, err := s.initBootstrapCommand(c, jobs)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -564,11 +528,7 @@ func testOpenState(c *gc.C, info *mongo.MongoInfo, expectErrType error) {
 }
 
 func (s *BootstrapSuite) TestInitialPassword(c *gc.C) {
-	machineConf, cmd, err := s.initBootstrapCommand(c, nil,
-		"--model-config", s.b64yamlControllerModelConfig,
-		"--hosted-model-config", s.b64yamlHostedModelConfig,
-		"--instance-id", string(s.instanceId),
-	)
+	machineConf, cmd, err := s.initBootstrapCommand(c, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = cmd.Run(nil)
@@ -621,70 +581,16 @@ func (s *BootstrapSuite) TestInitialPassword(c *gc.C) {
 }
 
 var bootstrapArgTests = []struct {
-	input              []string
-	err                string
-	expectedInstanceId string
-	expectedHardware   instance.HardwareCharacteristics
-	expectedConfig     map[string]interface{}
+	input                       []string
+	err                         string
+	expectedBootstrapParamsFile string
 }{
 	{
-		// no value supplied for model-config
-		err: "--model-config option must be set",
+		err:   "bootstrap-params file must be specified",
+		input: []string{"--data-dir", "/tmp/juju/data/dir"},
 	}, {
-		// empty model-config
-		input: []string{"--model-config", ""},
-		err:   "--model-config option must be set",
-	}, {
-		// wrong, should be base64
-		input: []string{"--model-config", "name: banana\n"},
-		err:   ".*illegal base64 data at input byte.*",
-	}, {
-		// no value supplied for hosted-model-config
-		input: []string{
-			"--model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
-		},
-		err: "--hosted-model-config option must be set",
-	}, {
-		// no value supplied for instance-id
-		input: []string{
-			"--model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
-			"--hosted-model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
-		},
-		err: "--instance-id option must be set",
-	}, {
-		// empty instance-id
-		input: []string{
-			"--model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
-			"--hosted-model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
-			"--instance-id", "",
-		},
-		err: "--instance-id option must be set",
-	}, {
-		input: []string{
-			"--model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
-			"--hosted-model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
-			"--instance-id", "anything",
-		},
-		expectedInstanceId: "anything",
-		expectedConfig:     map[string]interface{}{"name": "banana"},
-	}, {
-		input: []string{
-			"--model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
-			"--hosted-model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
-			"--instance-id", "anything",
-			"--hardware", "nonsense",
-		},
-		err: `invalid value "nonsense" for flag --hardware: malformed characteristic "nonsense"`,
-	}, {
-		input: []string{
-			"--model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
-			"--hosted-model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
-			"--instance-id", "anything",
-			"--hardware", "arch=amd64 cpu-cores=4 root-disk=2T",
-		},
-		expectedInstanceId: "anything",
-		expectedHardware:   instance.MustParseHardware("arch=amd64 cpu-cores=4 root-disk=2T"),
-		expectedConfig:     map[string]interface{}{"name": "banana"},
+		input: []string{"/some/where"},
+		expectedBootstrapParamsFile: "/some/where",
 	},
 }
 
@@ -697,9 +603,7 @@ func (s *BootstrapSuite) TestBootstrapArgs(c *gc.C) {
 		if t.err == "" {
 			c.Assert(cmd, gc.NotNil)
 			c.Assert(err, jc.ErrorIsNil)
-			c.Assert(cmd.ControllerModelConfig, gc.DeepEquals, t.expectedConfig)
-			c.Assert(cmd.InstanceId, gc.Equals, t.expectedInstanceId)
-			c.Assert(cmd.Hardware, gc.DeepEquals, t.expectedHardware)
+			c.Assert(cmd.BootstrapParamsFile, gc.Equals, t.expectedBootstrapParamsFile)
 		} else {
 			c.Assert(err, gc.ErrorMatches, t.err)
 		}
@@ -720,11 +624,7 @@ func (s *BootstrapSuite) TestInitializeStateArgs(c *gc.C) {
 		return nil, nil, errors.New("failed to initialize state")
 	}
 	s.PatchValue(&agentInitializeState, initializeState)
-	_, cmd, err := s.initBootstrapCommand(c, nil,
-		"--model-config", s.b64yamlControllerModelConfig,
-		"--hosted-model-config", s.b64yamlHostedModelConfig,
-		"--instance-id", string(s.instanceId),
-	)
+	_, cmd, err := s.initBootstrapCommand(c, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, gc.ErrorMatches, "failed to initialize state")
@@ -740,18 +640,15 @@ func (s *BootstrapSuite) TestInitializeStateMinSocketTimeout(c *gc.C) {
 		return nil, nil, errors.New("failed to initialize state")
 	}
 
-	envcfg, err := s.envcfg.Apply(map[string]interface{}{
+	cfg, err := s.bootstrapParams.Config.Apply(map[string]interface{}{
 		"bootstrap-timeout": "13",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	b64yamlControllerModelConfig := b64yaml(envcfg.AllAttrs()).encode()
+	s.bootstrapParams.Config = cfg
+	s.writeBootstrapParamsFile(c)
 
 	s.PatchValue(&agentInitializeState, initializeState)
-	_, cmd, err := s.initBootstrapCommand(c, nil,
-		"--model-config", b64yamlControllerModelConfig,
-		"--hosted-model-config", s.b64yamlHostedModelConfig,
-		"--instance-id", string(s.instanceId),
-	)
+	_, cmd, err := s.initBootstrapCommand(c, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, gc.ErrorMatches, "failed to initialize state")
@@ -762,11 +659,7 @@ func (s *BootstrapSuite) TestSystemIdentityWritten(c *gc.C) {
 	_, err := os.Stat(filepath.Join(s.dataDir, agent.SystemIdentity))
 	c.Assert(err, jc.Satisfies, os.IsNotExist)
 
-	_, cmd, err := s.initBootstrapCommand(c, nil,
-		"--model-config", s.b64yamlControllerModelConfig,
-		"--hosted-model-config", s.b64yamlHostedModelConfig,
-		"--instance-id", string(s.instanceId),
-	)
+	_, cmd, err := s.initBootstrapCommand(c, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -797,11 +690,8 @@ func (s *BootstrapSuite) TestUploadedToolsMetadata(c *gc.C) {
 func (s *BootstrapSuite) testToolsMetadata(c *gc.C, exploded bool) {
 	envtesting.RemoveFakeToolsMetadata(c, s.toolsStorage)
 
-	_, cmd, err := s.initBootstrapCommand(c, nil,
-		"--model-config", s.b64yamlControllerModelConfig,
-		"--hosted-model-config", s.b64yamlHostedModelConfig,
-		"--instance-id", string(s.instanceId),
-	)
+	_, cmd, err := s.initBootstrapCommand(c, nil)
+
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -850,93 +740,16 @@ func (s *BootstrapSuite) testToolsMetadata(c *gc.C, exploded bool) {
 	}
 }
 
-const (
-	indexContent = `{
-    "index": {
-        "com.ubuntu.cloud:%v": {
-            "updated": "Fri, 17 Jul 2015 13:42:48 +1000",
-            "format": "products:1.0",
-            "datatype": "image-ids",
-            "cloudname": "custom",
-            "clouds": [
-                {
-                    "region": "%v",
-                    "endpoint": "endpoint"
-                }
-            ],
-            "path": "streams/v1/products.json",
-            "products": [
-                "com.ubuntu.cloud:server:14.04:%v"
-            ]
-        }
-    },
-    "updated": "Fri, 17 Jul 2015 13:42:48 +1000",
-    "format": "index:1.0"
-}`
-
-	productContent = `{
-    "products": {
-        "com.ubuntu.cloud:server:14.04:%v": {
-            "version": "14.04",
-            "arch": "%v",
-            "versions": {
-                "20151707": {
-                    "items": {
-                        "%v": {
-                            "id": "%v",
-                            "root_store": "%v",
-                            "virt": "%v",
-                            "region": "%v",
-                            "endpoint": "endpoint"
-                        }
-                    }
-                }
-            }
-        }
-     },
-    "updated": "Fri, 17 Jul 2015 13:42:48 +1000",
-    "format": "products:1.0",
-    "content_id": "com.ubuntu.cloud:%v"
-}`
-)
-
-func writeTempFiles(c *gc.C, metadataDir string, expected []struct{ path, content string }) {
-	for _, pair := range expected {
-		path := filepath.Join(metadataDir, pair.path)
-		err := os.MkdirAll(filepath.Dir(path), 0755)
-		c.Assert(err, jc.ErrorIsNil)
-		err = ioutil.WriteFile(path, []byte(pair.content), 0644)
-		c.Assert(err, jc.ErrorIsNil)
-	}
-}
-
-func createImageMetadata(c *gc.C) (string, cloudimagemetadata.Metadata, []struct{ path, content string }) {
-	// setup data for this test
-	metadata := cloudimagemetadata.Metadata{
-		MetadataAttributes: cloudimagemetadata.MetadataAttributes{
-			Region:          "region",
-			Series:          "trusty",
-			Arch:            "amd64",
-			VirtType:        "virtType",
-			RootStorageType: "rootStore",
-			Source:          "custom"},
-		Priority: simplestreams.CUSTOM_CLOUD_DATA,
-		ImageId:  "imageId"}
-
-	// setup files containing test's data
-	metadataDir := c.MkDir()
-	expected := []struct{ path, content string }{{
-		path:    "streams/v1/index.json",
-		content: fmt.Sprintf(indexContent, metadata.Source, metadata.Region, metadata.Arch),
-	}, {
-		path:    "streams/v1/products.json",
-		content: fmt.Sprintf(productContent, metadata.Arch, metadata.Arch, metadata.ImageId, metadata.ImageId, metadata.RootStorageType, metadata.VirtType, metadata.Region, metadata.Source),
-	}, {
-		path:    "wayward/file.txt",
-		content: "ghi",
+func createImageMetadata(c *gc.C) []*imagemetadata.ImageMetadata {
+	return []*imagemetadata.ImageMetadata{{
+		Id:         "imageId",
+		Storage:    "rootStore",
+		VirtType:   "virtType",
+		Arch:       "amd64",
+		Version:    "14.04",
+		Endpoint:   "endpoint",
+		RegionName: "region",
 	}}
-	writeTempFiles(c, metadataDir, expected)
-	return metadataDir, metadata, expected
 }
 
 func assertWrittenToState(c *gc.C, metadata cloudimagemetadata.Metadata) {
@@ -959,104 +772,39 @@ func assertWrittenToState(c *gc.C, metadata cloudimagemetadata.Metadata) {
 }
 
 func (s *BootstrapSuite) TestStructuredImageMetadataStored(c *gc.C) {
-	dir, m, _ := createImageMetadata(c)
-	_, cmd, err := s.initBootstrapCommand(
-		c, nil,
-		"--model-config", s.b64yamlControllerModelConfig,
-		"--hosted-model-config", s.b64yamlHostedModelConfig,
-		"--instance-id", string(s.instanceId),
-		"--image-metadata", dir,
-	)
+	s.bootstrapParams.CustomImageMetadata = createImageMetadata(c)
+	s.writeBootstrapParamsFile(c)
+	_, cmd, err := s.initBootstrapCommand(c, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// This metadata should have also been written to state...
-	// m.Version would be deduced from m.Series
-	m.Version = "14.04"
-	assertWrittenToState(c, m)
-
-}
-
-func (s *BootstrapSuite) TestCustomDataSourceHasKey(c *gc.C) {
-	dir, _, _ := createImageMetadata(c)
-	_, cmd, err := s.initBootstrapCommand(
-		c, nil,
-		"--model-config", s.b64yamlControllerModelConfig,
-		"--hosted-model-config", s.b64yamlHostedModelConfig,
-		"--instance-id", string(s.instanceId),
-		"--image-metadata", dir,
-	)
-	c.Assert(err, jc.ErrorIsNil)
-
-	called := false
-	s.PatchValue(&storeImageMetadataFromFiles, func(st *state.State, env environs.Environ, source simplestreams.DataSource) error {
-		called = true
-		// This data source does not require to contain signed data.
-		// However, it may still contain it.
-		// Since we will always try to read signed data first,
-		// we want to be able to try to read this signed data
-		// with a user provided public key. For this test, none is provided.
-		// Bugs #1542127, #1542131
-		c.Assert(source.PublicSigningKey(), gc.Equals, "")
-		return nil
-	})
-	err = cmd.Run(nil)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
+	expect := cloudimagemetadata.Metadata{
+		cloudimagemetadata.MetadataAttributes{
+			Region:          "region",
+			Arch:            "amd64",
+			Version:         "14.04",
+			Series:          "trusty",
+			RootStorageType: "rootStore",
+			VirtType:        "virtType",
+			Source:          "custom",
+		},
+		simplestreams.CUSTOM_CLOUD_DATA,
+		"imageId",
+	}
+	assertWrittenToState(c, expect)
 }
 
 func (s *BootstrapSuite) TestStructuredImageMetadataInvalidSeries(c *gc.C) {
-	dir, _, _ := createImageMetadata(c)
+	s.bootstrapParams.CustomImageMetadata = createImageMetadata(c)
+	s.bootstrapParams.CustomImageMetadata[0].Version = "woat"
+	s.writeBootstrapParamsFile(c)
 
-	msg := "my test error"
-	s.PatchValue(&seriesFromVersion, func(string) (string, error) {
-		return "", errors.New(msg)
-	})
-
-	_, cmd, err := s.initBootstrapCommand(
-		c, nil,
-		"--model-config", s.b64yamlControllerModelConfig,
-		"--hosted-model-config", s.b64yamlHostedModelConfig,
-		"--instance-id", string(s.instanceId),
-		"--image-metadata", dir,
-	)
+	_, cmd, err := s.initBootstrapCommand(c, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
-	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(".*%v.*", msg))
-}
-
-func (s *BootstrapSuite) TestImageMetadata(c *gc.C) {
-	metadataDir, _, expected := createImageMetadata(c)
-
-	var stor statetesting.MapStorage
-	s.PatchValue(&newStateStorage, func(string, *mgo.Session) statestorage.Storage {
-		return &stor
-	})
-
-	_, cmd, err := s.initBootstrapCommand(
-		c, nil,
-		"--model-config", s.b64yamlControllerModelConfig,
-		"--hosted-model-config", s.b64yamlHostedModelConfig,
-		"--instance-id", string(s.instanceId),
-		"--image-metadata", metadataDir,
-	)
-	c.Assert(err, jc.ErrorIsNil)
-	err = cmd.Run(nil)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// The contents of the directory should have been added to
-	// environment storage.
-	for _, pair := range expected {
-		r, length, err := stor.Get(pair.path)
-		c.Assert(err, jc.ErrorIsNil)
-		data, err := ioutil.ReadAll(r)
-		r.Close()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(length, gc.Equals, int64(len(pair.content)))
-		c.Assert(data, gc.HasLen, int(length))
-		c.Assert(string(data), gc.Equals, pair.content)
-	}
+	c.Assert(err, gc.ErrorMatches, `cannot determine series for version woat: unknown series for version: \"woat\"`)
 }
 
 func (s *BootstrapSuite) makeTestEnv(c *gc.C) {
@@ -1079,21 +827,31 @@ func (s *BootstrapSuite) makeTestEnv(c *gc.C) {
 	envtesting.MustUploadFakeTools(s.toolsStorage, cfg.AgentStream(), cfg.AgentStream())
 	inst, _, _, err := jujutesting.StartInstance(env, "0")
 	c.Assert(err, jc.ErrorIsNil)
-	s.instanceId = inst.Id()
 
 	addresses, err := inst.Addresses()
 	c.Assert(err, jc.ErrorIsNil)
 	addr, _ := network.SelectPublicAddress(addresses)
 	s.bootstrapName = addr.Value
-	s.envcfg = env.Config()
-	s.b64yamlControllerModelConfig = b64yaml(s.envcfg.AllAttrs()).encode()
-
 	s.hostedModelUUID = utils.MustNewUUID().String()
-	hostedModelConfigAttrs := map[string]interface{}{
+
+	var args instancecfg.StateInitializationParams
+	args.InstanceId = inst.Id()
+	args.Config = env.Config()
+	hw := instance.MustParseHardware("arch=amd64 mem=8G")
+	args.HardwareCharacteristics = &hw
+	args.HostedModelConfig = map[string]interface{}{
 		"name": "hosted-model",
 		"uuid": s.hostedModelUUID,
 	}
-	s.b64yamlHostedModelConfig = b64yaml(hostedModelConfigAttrs).encode()
+	s.bootstrapParams = args
+	s.writeBootstrapParamsFile(c)
+}
+
+func (s *BootstrapSuite) writeBootstrapParamsFile(c *gc.C) {
+	data, err := s.bootstrapParams.Marshal()
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(s.bootstrapParamsFile, data, 0600)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func nullContext() environs.BootstrapContext {
@@ -1115,11 +873,7 @@ func (m b64yaml) encode() string {
 }
 
 func (s *BootstrapSuite) TestDefaultStoragePools(c *gc.C) {
-	_, cmd, err := s.initBootstrapCommand(
-		c, nil, "--model-config", s.b64yamlControllerModelConfig,
-		"--hosted-model-config", s.b64yamlHostedModelConfig,
-		"--instance-id", string(s.instanceId),
-	)
+	_, cmd, err := s.initBootstrapCommand(c, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/jujud/main_test.go
+++ b/cmd/jujud/main_test.go
@@ -101,9 +101,7 @@ func (s *MainSuite) TestParseErrors(c *gc.C) {
 	msga := `unrecognized args: ["toastie"]`
 	checkMessage(c, msga,
 		"bootstrap-state",
-		"--model-config", b64yaml{"blah": "blah"}.encode(),
-		"--hosted-model-config", b64yaml{"blah": "blah"}.encode(),
-		"--instance-id", "inst",
+		"bootstrap-params-file",
 		"toastie")
 	checkMessage(c, msga, "unit",
 		"--unit-name", "un/0",

--- a/container/interface.go
+++ b/container/interface.go
@@ -5,6 +5,7 @@ package container
 
 import (
 	"github.com/juju/juju/cloudconfig/instancecfg"
+	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/status"
 )
@@ -46,6 +47,7 @@ type Manager interface {
 	// machine.
 	CreateContainer(
 		instanceConfig *instancecfg.InstanceConfig,
+		cons constraints.Value,
 		series string,
 		network *NetworkConfig,
 		storage *StorageConfig,

--- a/container/kvm/kvm.go
+++ b/container/kvm/kvm.go
@@ -110,6 +110,7 @@ var startParams StartParams
 
 func (manager *containerManager) CreateContainer(
 	instanceConfig *instancecfg.InstanceConfig,
+	cons constraints.Value,
 	series string,
 	networkConfig *container.NetworkConfig,
 	storageConfig *container.StorageConfig,
@@ -149,7 +150,7 @@ func (manager *containerManager) CreateContainer(
 		return nil, nil, err
 	}
 	// Create the container.
-	startParams = ParseConstraintsToStartParams(instanceConfig.Constraints)
+	startParams = ParseConstraintsToStartParams(cons)
 	startParams.Arch = arch.HostArch()
 	startParams.Series = series
 	startParams.Network = networkConfig
@@ -170,7 +171,7 @@ func (manager *containerManager) CreateContainer(
 	}
 
 	callback(status.StatusAllocating, "Creating container; it might take some time", nil)
-	logger.Tracef("create the container, constraints: %v", instanceConfig.Constraints)
+	logger.Tracef("create the container, constraints: %v", cons)
 	if err := kvmContainer.Start(startParams); err != nil {
 		err = errors.Annotate(err, "kvm container creation failed")
 		logger.Infof(err.Error())

--- a/container/kvm/kvm_test.go
+++ b/container/kvm/kvm_test.go
@@ -20,10 +20,8 @@ import (
 	"github.com/juju/juju/container/kvm"
 	kvmtesting "github.com/juju/juju/container/kvm/testing"
 	containertesting "github.com/juju/juju/container/testing"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/provider/dummy"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -176,18 +174,9 @@ func (s *KVMSuite) TestDestroyContainer(c *gc.C) {
 // Test that CreateContainer creates proper startParams.
 func (s *KVMSuite) TestCreateContainerUtilizesReleaseSimpleStream(c *gc.C) {
 
-	envCfg, err := config.New(
-		config.NoDefaults,
-		dummy.SampleConfig().Merge(
-			coretesting.Attrs{"image-stream": "released"},
-		),
-	)
-	c.Assert(err, jc.ErrorIsNil)
-
 	// Mock machineConfig with a mocked simple stream URL.
 	instanceConfig, err := containertesting.MockMachineConfig("1/kvm/0")
 	c.Assert(err, jc.ErrorIsNil)
-	instanceConfig.Config = envCfg
 
 	// CreateContainer sets TestStartParams internally; we call this
 	// purely for the side-effect.

--- a/container/kvm/live_test.go
+++ b/container/kvm/live_test.go
@@ -15,6 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloudconfig/instancecfg"
+	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/kvm"
 	"github.com/juju/juju/environs/config"
@@ -86,9 +87,8 @@ func shutdownMachines(manager container.Manager) func(*gc.C) {
 
 func createContainer(c *gc.C, manager container.Manager, machineId string) instance.Instance {
 	machineNonce := "fake-nonce"
-	stateInfo := jujutesting.FakeStateInfo(machineId)
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
-	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, machineNonce, imagemetadata.ReleasedStream, "quantal", "", true, stateInfo, apiInfo)
+	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, machineNonce, imagemetadata.ReleasedStream, "quantal", true, apiInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	network := container.BridgeNetworkConfig("virbr0", 0, nil)
 
@@ -103,7 +103,7 @@ func createContainer(c *gc.C, manager container.Manager, machineId string) insta
 	err = instancecfg.FinishInstanceConfig(instanceConfig, environConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error { return nil }
-	inst, hardware, err := manager.CreateContainer(instanceConfig, "precise", network, nil, callback)
+	inst, hardware, err := manager.CreateContainer(instanceConfig, constraints.Value{}, "precise", network, nil, callback)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hardware, gc.NotNil)
 	expected := fmt.Sprintf("arch=%s cpu-cores=1 mem=512M root-disk=8192M", arch.HostArch())

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cloudconfig/containerinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
+	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/status"
@@ -173,6 +174,7 @@ func (manager *containerManager) Namespace() instance.Namespace {
 // CreateContainer creates or clones an LXC container.
 func (manager *containerManager) CreateContainer(
 	instanceConfig *instancecfg.InstanceConfig,
+	cons constraints.Value,
 	series string,
 	networkConfig *container.NetworkConfig,
 	storageConfig *container.StorageConfig,

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -30,12 +30,10 @@ import (
 	"github.com/juju/juju/container/lxc/mock"
 	lxctesting "github.com/juju/juju/container/lxc/testing"
 	containertesting "github.com/juju/juju/container/testing"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	instancetest "github.com/juju/juju/instance/testing"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -283,9 +281,6 @@ func (s *LxcSuite) TestUpdateContainerConfig(c *gc.C) {
 	manager := s.makeManager(c, modelUUID)
 	instanceConfig, err := containertesting.MockMachineConfig("1/lxc/0")
 	c.Assert(err, jc.ErrorIsNil)
-	envConfig, err := config.New(config.NoDefaults, dummy.SampleConfig())
-	c.Assert(err, jc.ErrorIsNil)
-	instanceConfig.Config = envConfig
 	instance := containertesting.CreateContainerWithMachineAndNetworkAndStorageConfig(
 		c, manager, instanceConfig, networkConfig, storageConfig,
 	)

--- a/container/lxd/lxd.go
+++ b/container/lxd/lxd.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/cloudconfig/containerinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
+	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
@@ -86,6 +87,7 @@ func (manager *containerManager) Namespace() instance.Namespace {
 
 func (manager *containerManager) CreateContainer(
 	instanceConfig *instancecfg.InstanceConfig,
+	cons constraints.Value,
 	series string,
 	networkConfig *container.NetworkConfig,
 	storageConfig *container.StorageConfig,

--- a/container/lxd/lxd_test.go
+++ b/container/lxd/lxd_test.go
@@ -12,12 +12,11 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/lxd"
 	containertesting "github.com/juju/juju/container/testing"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/tools/lxdclient"
@@ -70,9 +69,6 @@ func (t *LxdSuite) TestNotAllContainersAreDeleted(c *gc.C) {
 
 	instanceConfig, err := containertesting.MockMachineConfig("1/lxd/0")
 	c.Assert(err, jc.ErrorIsNil)
-	envConfig, err := config.New(config.NoDefaults, dummy.SampleConfig())
-	c.Assert(err, jc.ErrorIsNil)
-	instanceConfig.Config = envConfig
 	storageConfig := &container.StorageConfig{}
 	networkConfig := container.BridgeNetworkConfig("nic42", 4321, nil)
 
@@ -80,6 +76,7 @@ func (t *LxdSuite) TestNotAllContainersAreDeleted(c *gc.C) {
 	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error { return nil }
 	_, _, err = manager.CreateContainer(
 		instanceConfig,
+		constraints.Value{},
 		"xenial",
 		networkConfig,
 		storageConfig,

--- a/container/testing/common.go
+++ b/container/testing/common.go
@@ -50,10 +50,6 @@ func MockMachineConfig(machineId string) (*instancecfg.InstanceConfig, error) {
 func CreateContainer(c *gc.C, manager container.Manager, machineId string) instance.Instance {
 	instanceConfig, err := MockMachineConfig(machineId)
 	c.Assert(err, jc.ErrorIsNil)
-
-	//envConfig, err := config.New(config.NoDefaults, dummy.SampleConfig())
-	//c.Assert(err, jc.ErrorIsNil)
-	//instanceConfig.Config = envConfig
 	return CreateContainerWithMachineConfig(c, manager, instanceConfig)
 }
 
@@ -116,12 +112,6 @@ func CreateContainerTest(c *gc.C, manager container.Manager, machineId string) (
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
-	//envConfig, err := config.New(config.NoDefaults, dummy.SampleConfig())
-	//if err != nil {
-	//	return nil, errors.Trace(err)
-	//}
-	//instanceConfig.Config = envConfig
 
 	network := container.BridgeNetworkConfig("nic42", 0, nil)
 	storage := &container.StorageConfig{}

--- a/container/testing/common.go
+++ b/container/testing/common.go
@@ -15,13 +15,12 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloudconfig/instancecfg"
+	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/lxc"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/instance"
 	jujutesting "github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/tools"
 )
@@ -30,9 +29,8 @@ var logger = loggo.GetLogger("juju.container.testing")
 
 func MockMachineConfig(machineId string) (*instancecfg.InstanceConfig, error) {
 
-	stateInfo := jujutesting.FakeStateInfo(machineId)
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
-	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, "fake-nonce", imagemetadata.ReleasedStream, "quantal", "", true, stateInfo, apiInfo)
+	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, "fake-nonce", imagemetadata.ReleasedStream, "quantal", true, apiInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -53,9 +51,9 @@ func CreateContainer(c *gc.C, manager container.Manager, machineId string) insta
 	instanceConfig, err := MockMachineConfig(machineId)
 	c.Assert(err, jc.ErrorIsNil)
 
-	envConfig, err := config.New(config.NoDefaults, dummy.SampleConfig())
-	c.Assert(err, jc.ErrorIsNil)
-	instanceConfig.Config = envConfig
+	//envConfig, err := config.New(config.NoDefaults, dummy.SampleConfig())
+	//c.Assert(err, jc.ErrorIsNil)
+	//instanceConfig.Config = envConfig
 	return CreateContainerWithMachineConfig(c, manager, instanceConfig)
 }
 
@@ -84,7 +82,7 @@ func CreateContainerWithMachineAndNetworkAndStorageConfig(
 		EnsureLXCRootFSEtcNetwork(c, name)
 	}
 	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error { return nil }
-	inst, hardware, err := manager.CreateContainer(instanceConfig, "quantal", networkConfig, storageConfig, callback)
+	inst, hardware, err := manager.CreateContainer(instanceConfig, constraints.Value{}, "quantal", networkConfig, storageConfig, callback)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hardware, gc.NotNil)
 	c.Assert(hardware.String(), gc.Not(gc.Equals), "")
@@ -119,17 +117,17 @@ func CreateContainerTest(c *gc.C, manager container.Manager, machineId string) (
 		return nil, errors.Trace(err)
 	}
 
-	envConfig, err := config.New(config.NoDefaults, dummy.SampleConfig())
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	instanceConfig.Config = envConfig
+	//envConfig, err := config.New(config.NoDefaults, dummy.SampleConfig())
+	//if err != nil {
+	//	return nil, errors.Trace(err)
+	//}
+	//instanceConfig.Config = envConfig
 
 	network := container.BridgeNetworkConfig("nic42", 0, nil)
 	storage := &container.StorageConfig{}
 
 	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error { return nil }
-	inst, hardware, err := manager.CreateContainer(instanceConfig, "quantal", network, storage, callback)
+	inst, hardware, err := manager.CreateContainer(instanceConfig, constraints.Value{}, "quantal", network, storage, callback)
 
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -262,10 +262,9 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	if err := instanceConfig.SetTools(selectedToolsList); err != nil {
 		return errors.Trace(err)
 	}
-	instanceConfig.CustomImageMetadata = customImageMetadata
-	instanceConfig.HostedModelConfig = args.HostedModelConfig
-
-	instanceConfig.GUI = guiArchive(args.GUIDataSourceBaseURL, func(msg string) {
+	instanceConfig.Bootstrap.CustomImageMetadata = customImageMetadata
+	instanceConfig.Bootstrap.HostedModelConfig = args.HostedModelConfig
+	instanceConfig.Bootstrap.GUI = guiArchive(args.GUIDataSourceBaseURL, func(msg string) {
 		ctx.Infof(msg)
 	})
 

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -194,10 +194,10 @@ func (s *bootstrapSuite) TestBootstrapImage(c *gc.C) {
 		Endpoint:   "hearnoretheir",
 		Stream:     "released",
 	})
-	c.Assert(env.instanceConfig.CustomImageMetadata, gc.HasLen, 2)
-	c.Assert(env.instanceConfig.CustomImageMetadata[0], jc.DeepEquals, metadata[0])
-	c.Assert(env.instanceConfig.CustomImageMetadata[1], jc.DeepEquals, env.args.ImageMetadata[0])
-	c.Assert(env.instanceConfig.Constraints, jc.DeepEquals, bootstrapCons)
+	c.Assert(env.instanceConfig.Bootstrap.CustomImageMetadata, gc.HasLen, 2)
+	c.Assert(env.instanceConfig.Bootstrap.CustomImageMetadata[0], jc.DeepEquals, metadata[0])
+	c.Assert(env.instanceConfig.Bootstrap.CustomImageMetadata[1], jc.DeepEquals, env.args.ImageMetadata[0])
+	c.Assert(env.instanceConfig.Bootstrap.BootstrapMachineConstraints, jc.DeepEquals, bootstrapCons)
 }
 
 // TestBootstrapImageMetadataFromAllSources tests that we are looking for
@@ -369,10 +369,10 @@ func (s *bootstrapSuite) TestBootstrapGUISuccessRemote(c *gc.C) {
 	c.Assert(coretesting.Stderr(ctx), jc.Contains, "Preparing for Juju GUI 2.0.42 release installation\n")
 
 	// The most recent GUI release info has been stored.
-	c.Assert(env.instanceConfig.GUI.URL, gc.Equals, "https://1.2.3.4/juju-gui-2.0.42.tar.bz2")
-	c.Assert(env.instanceConfig.GUI.Version.String(), gc.Equals, "2.0.42")
-	c.Assert(env.instanceConfig.GUI.Size, gc.Equals, int64(42))
-	c.Assert(env.instanceConfig.GUI.SHA256, gc.Equals, "hash-2.0.42")
+	c.Assert(env.instanceConfig.Bootstrap.GUI.URL, gc.Equals, "https://1.2.3.4/juju-gui-2.0.42.tar.bz2")
+	c.Assert(env.instanceConfig.Bootstrap.GUI.Version.String(), gc.Equals, "2.0.42")
+	c.Assert(env.instanceConfig.Bootstrap.GUI.Size, gc.Equals, int64(42))
+	c.Assert(env.instanceConfig.Bootstrap.GUI.SHA256, gc.Equals, "hash-2.0.42")
 }
 
 func (s *bootstrapSuite) TestBootstrapGUISuccessLocal(c *gc.C) {
@@ -385,8 +385,8 @@ func (s *bootstrapSuite) TestBootstrapGUISuccessLocal(c *gc.C) {
 	c.Assert(coretesting.Stderr(ctx), jc.Contains, "Preparing for Juju GUI 2.2.0 installation from local archive\n")
 
 	// Check GUI URL and version.
-	c.Assert(env.instanceConfig.GUI.URL, gc.Equals, "file://"+path)
-	c.Assert(env.instanceConfig.GUI.Version.String(), gc.Equals, "2.2.0")
+	c.Assert(env.instanceConfig.Bootstrap.GUI.URL, gc.Equals, "file://"+path)
+	c.Assert(env.instanceConfig.Bootstrap.GUI.Version.String(), gc.Equals, "2.2.0")
 
 	// Check GUI size.
 	f, err := os.Open(path)
@@ -394,13 +394,13 @@ func (s *bootstrapSuite) TestBootstrapGUISuccessLocal(c *gc.C) {
 	defer f.Close()
 	info, err := f.Stat()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env.instanceConfig.GUI.Size, gc.Equals, info.Size())
+	c.Assert(env.instanceConfig.Bootstrap.GUI.Size, gc.Equals, info.Size())
 
 	// Check GUI hash.
 	h := sha256.New()
 	_, err = io.Copy(h, f)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env.instanceConfig.GUI.SHA256, gc.Equals, fmt.Sprintf("%x", h.Sum(nil)))
+	c.Assert(env.instanceConfig.Bootstrap.GUI.SHA256, gc.Equals, fmt.Sprintf("%x", h.Sum(nil)))
 }
 
 func (s *bootstrapSuite) TestBootstrapGUISuccessNoGUI(c *gc.C) {
@@ -409,7 +409,7 @@ func (s *bootstrapSuite) TestBootstrapGUISuccessNoGUI(c *gc.C) {
 	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env, bootstrap.BootstrapParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(coretesting.Stderr(ctx), jc.Contains, "Juju GUI installation has been disabled\n")
-	c.Assert(env.instanceConfig.GUI, gc.IsNil)
+	c.Assert(env.instanceConfig.Bootstrap.GUI, gc.IsNil)
 }
 
 func (s *bootstrapSuite) TestBootstrapGUINoStreams(c *gc.C) {
@@ -423,7 +423,7 @@ func (s *bootstrapSuite) TestBootstrapGUINoStreams(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(coretesting.Stderr(ctx), jc.Contains, "No available Juju GUI archives found\n")
-	c.Assert(env.instanceConfig.GUI, gc.IsNil)
+	c.Assert(env.instanceConfig.Bootstrap.GUI, gc.IsNil)
 }
 
 func (s *bootstrapSuite) TestBootstrapGUIStreamsFailure(c *gc.C) {
@@ -437,7 +437,7 @@ func (s *bootstrapSuite) TestBootstrapGUIStreamsFailure(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(coretesting.Stderr(ctx), jc.Contains, "Unable to fetch Juju GUI info: bad wolf\n")
-	c.Assert(env.instanceConfig.GUI, gc.IsNil)
+	c.Assert(env.instanceConfig.Bootstrap.GUI, gc.IsNil)
 }
 
 func (s *bootstrapSuite) TestBootstrapGUIErrorNotFound(c *gc.C) {
@@ -546,8 +546,8 @@ func (s *bootstrapSuite) TestBootstrapMetadata(c *gc.C) {
 	// Bugs #1542127, #1542131
 	c.Assert(datasources[0].PublicSigningKey(), gc.Equals, "")
 	c.Assert(env.instanceConfig, gc.NotNil)
-	c.Assert(env.instanceConfig.CustomImageMetadata, gc.HasLen, 1)
-	c.Assert(env.instanceConfig.CustomImageMetadata[0], gc.DeepEquals, metadata[0])
+	c.Assert(env.instanceConfig.Bootstrap.CustomImageMetadata, gc.HasLen, 1)
+	c.Assert(env.instanceConfig.Bootstrap.CustomImageMetadata[0], gc.DeepEquals, metadata[0])
 }
 
 func (s *bootstrapSuite) TestPublicKeyEnvVar(c *gc.C) {
@@ -558,7 +558,7 @@ func (s *bootstrapSuite) TestPublicKeyEnvVar(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env.instanceConfig.PublicImageSigningKey, gc.Equals, "publickey")
+	c.Assert(env.instanceConfig.Controller.PublicImageSigningKey, gc.Equals, "publickey")
 }
 
 func (s *bootstrapSuite) TestBootstrapMetadataImagesMissing(c *gc.C) {

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -711,9 +711,8 @@ func (t *LiveTests) assertStopInstance(c *gc.C, env environs.Environ, instId ins
 // a valid machine config.
 func (t *LiveTests) TestStartInstanceWithEmptyNonceFails(c *gc.C) {
 	machineId := "4"
-	stateInfo := jujutesting.FakeStateInfo(machineId)
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
-	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, "", "released", "quantal", "", true, stateInfo, apiInfo)
+	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, "", "released", "quantal", true, apiInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	t.PrepareOnce(c)

--- a/environs/manual/provisioner_test.go
+++ b/environs/manual/provisioner_test.go
@@ -139,12 +139,9 @@ func (s *provisionerSuite) TestFinishInstancConfig(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(icfg, gc.NotNil)
 	c.Check(icfg.APIInfo, gc.NotNil)
-	c.Check(icfg.MongoInfo, gc.NotNil)
 
-	stateInfo := s.MongoInfo(c)
 	apiInfo := s.APIInfo(c)
 	c.Check(icfg.APIInfo.Addrs, gc.DeepEquals, apiInfo.Addrs)
-	c.Check(icfg.MongoInfo.Addrs, gc.DeepEquals, stateInfo.Addrs)
 }
 
 func (s *provisionerSuite) TestProvisioningScript(c *gc.C) {

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -160,16 +160,13 @@ func StartInstanceWithParams(
 	}
 
 	machineNonce := "fake_nonce"
-	stateInfo := FakeStateInfo(machineId)
 	apiInfo := FakeAPIInfo(machineId)
 	instanceConfig, err := instancecfg.NewInstanceConfig(
 		machineId,
 		machineNonce,
 		imagemetadata.ReleasedStream,
 		preferredSeries,
-		"",
 		true,
-		stateInfo,
 		apiInfo,
 	)
 	if err != nil {

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -37,7 +37,6 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/provider/azure"
 	"github.com/juju/juju/provider/azure/internal/azuretesting"
 	"github.com/juju/juju/testing"
@@ -410,14 +409,6 @@ func (s *environSuite) makeSender(pattern string, v interface{}) *azuretesting.M
 
 func makeStartInstanceParams(c *gc.C, series string) environs.StartInstanceParams {
 	machineTag := names.NewMachineTag("0")
-	stateInfo := &mongo.MongoInfo{
-		Info: mongo.Info{
-			CACert: testing.CACert,
-			Addrs:  []string{"localhost:123"},
-		},
-		Password: "password",
-		Tag:      machineTag,
-	}
 	apiInfo := &api.Info{
 		Addrs:    []string{"localhost:246"},
 		CACert:   testing.CACert,
@@ -429,7 +420,7 @@ func makeStartInstanceParams(c *gc.C, series string) environs.StartInstanceParam
 	const secureServerConnections = true
 	icfg, err := instancecfg.NewInstanceConfig(
 		machineTag.Id(), "yanonce", imagemetadata.ReleasedStream,
-		series, "", secureServerConnections, stateInfo, apiInfo,
+		series, secureServerConnections, apiInfo,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/provider/cloudsigma/client.go
+++ b/provider/cloudsigma/client.go
@@ -174,7 +174,7 @@ func (c *environClient) newInstance(args environs.StartInstanceParams, img *imag
 	logger.Debugf("Juju Constraints:" + args.Constraints.String())
 	logger.Debugf("InstanceConfig: %#v", args.InstanceConfig)
 
-	constraints := newConstraints(args.InstanceConfig.Bootstrap, args.Constraints, img)
+	constraints := newConstraints(args.InstanceConfig.Bootstrap != nil, args.Constraints, img)
 	logger.Debugf("CloudSigma Constraints: %v", constraints)
 
 	originalDrive, err := c.conn.Drive(constraints.driveTemplate, gosigma.LibraryMedia)

--- a/provider/cloudsigma/client_test.go
+++ b/provider/cloudsigma/client_test.go
@@ -178,10 +178,7 @@ func (s *clientSuite) TestClientNewInstanceInvalidTemplate(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	params := environs.StartInstanceParams{
-		Constraints: constraints.Value{},
-		InstanceConfig: &instancecfg.InstanceConfig{
-			Bootstrap: true,
-		},
+		InstanceConfig: &instancecfg.InstanceConfig{},
 	}
 	err = params.InstanceConfig.SetTools(tools.List{
 		&tools.Tools{
@@ -209,10 +206,7 @@ func (s *clientSuite) TestClientNewInstance(c *gc.C) {
 	cli.conn.OperationTimeout(1 * time.Second)
 
 	params := environs.StartInstanceParams{
-		Constraints: constraints.Value{},
-		InstanceConfig: &instancecfg.InstanceConfig{
-			Bootstrap: true,
-		},
+		InstanceConfig: &instancecfg.InstanceConfig{},
 	}
 	err = params.InstanceConfig.SetTools(tools.List{
 		&tools.Tools{
@@ -226,7 +220,7 @@ func (s *clientSuite) TestClientNewInstance(c *gc.C) {
 	img := &imagemetadata.ImageMetadata{
 		Id: validImageId,
 	}
-	cs := newConstraints(params.InstanceConfig.Bootstrap, params.Constraints, img)
+	cs := newConstraints(true, params.Constraints, img)
 	c.Assert(cs, gc.NotNil)
 	c.Check(err, gc.IsNil)
 

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -149,8 +149,8 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 	fmt.Fprintf(ctx.GetStderr(), " - %s\n", result.Instance.Id())
 
 	finalize := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig) error {
-		icfg.InstanceId = result.Instance.Id()
-		icfg.HardwareCharacteristics = result.Hardware
+		icfg.Bootstrap.InstanceId = result.Instance.Id()
+		icfg.Bootstrap.HardwareCharacteristics = result.Hardware
 		envConfig := env.Config()
 		if result.Config != nil {
 			updated, err := envConfig.Apply(result.Config.UnknownAttrs())
@@ -188,7 +188,7 @@ var FinishBootstrap = func(
 		client,
 		GetCheckNonceCommand(instanceConfig),
 		&RefreshableInstance{inst, env},
-		instanceConfig.Config.BootstrapSSHOpts(),
+		instanceConfig.Bootstrap.Config.BootstrapSSHOpts(),
 	)
 	if err != nil {
 		return err

--- a/provider/gce/environ_broker.go
+++ b/provider/gce/environ_broker.go
@@ -57,10 +57,10 @@ func (env *environ) StartInstance(args environs.StartInstanceParams) (*environs.
 	// Ensure the API server port is open (globally for all instances
 	// on the network, not just for the specific node of the state
 	// server). See LP bug #1436191 for details.
-	if isController(args.InstanceConfig) {
+	if args.InstanceConfig.Bootstrap != nil {
 		ports := network.PortRange{
-			FromPort: args.InstanceConfig.StateServingInfo.APIPort,
-			ToPort:   args.InstanceConfig.StateServingInfo.APIPort,
+			FromPort: args.InstanceConfig.Bootstrap.StateServingInfo.APIPort,
+			ToPort:   args.InstanceConfig.Bootstrap.StateServingInfo.APIPort,
 			Protocol: "tcp",
 		}
 		if err := env.gce.OpenPorts(env.globalFirewallName(), ports); err != nil {

--- a/provider/gce/environ_broker_test.go
+++ b/provider/gce/environ_broker_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/simplestreams"
@@ -110,8 +111,10 @@ func (s *environBrokerSuite) TestStartInstanceOpensAPIPort(c *gc.C) {
 
 	// When StateServingInfo is not nil, verify OpenPorts was called
 	// for the API port.
-	s.StartInstArgs.InstanceConfig.StateServingInfo = &params.StateServingInfo{
-		APIPort: apiPort,
+	s.StartInstArgs.InstanceConfig.Bootstrap = &instancecfg.BootstrapConfig{
+		StateServingInfo: params.StateServingInfo{
+			APIPort: apiPort,
+		},
 	}
 
 	result, err := s.Env.StartInstance(s.StartInstArgs)

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -84,11 +84,6 @@ func (env *environ) finishInstanceConfig(args environs.StartInstanceParams) erro
 		return errors.Trace(err)
 	}
 
-	// TODO: evaluate the impact of setting the constraints on the
-	// instanceConfig for all machines rather than just controller nodes.
-	// This limitation is why the constraints are assigned directly here.
-	args.InstanceConfig.Constraints = args.Constraints
-
 	return nil
 }
 

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -105,8 +105,8 @@ func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 		return nil, err
 	}
 	finalize := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig) error {
-		icfg.InstanceId = BootstrapInstanceId
-		icfg.HardwareCharacteristics = &hc
+		icfg.Bootstrap.InstanceId = BootstrapInstanceId
+		icfg.Bootstrap.HardwareCharacteristics = &hc
 		if err := instancecfg.FinishInstanceConfig(icfg, e.Config()); err != nil {
 			return err
 		}

--- a/provider/rackspace/environ.go
+++ b/provider/rackspace/environ.go
@@ -66,8 +66,10 @@ func (e environ) StartInstance(args environs.StartInstanceParams) (*environs.Sta
 		}
 		client := newInstanceConfigurator(addr)
 		apiPort := 0
-		if isController(args.InstanceConfig) {
-			apiPort = args.InstanceConfig.StateServingInfo.APIPort
+		if isController(args.InstanceConfig) && args.InstanceConfig.Bootstrap != nil {
+			// TODO(axw) 2016-06-01 #1587739
+			// We should be doing this for non-bootstrap machines as well.
+			apiPort = args.InstanceConfig.Bootstrap.StateServingInfo.APIPort
 		}
 		err = client.DropAllPorts([]int{apiPort, 22}, addr)
 		if err != nil {

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -68,9 +68,7 @@ func (s *environSuite) TestStartInstance(c *gc.C) {
 	err = s.environ.SetConfig(config)
 	c.Assert(err, gc.IsNil)
 	_, err = s.environ.StartInstance(environs.StartInstanceParams{
-		InstanceConfig: &instancecfg.InstanceConfig{
-			Config: config,
-		},
+		InstanceConfig: &instancecfg.InstanceConfig{},
 		Tools: tools.List{&tools.Tools{
 			Version: version.Binary{Series: "trusty"},
 		}},

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -134,8 +134,10 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams, img *OvaFi
 			continue
 		}
 		apiPort := 0
-		if isController(args.InstanceConfig) {
-			apiPort = args.InstanceConfig.StateServingInfo.APIPort
+		if isController(args.InstanceConfig) && args.InstanceConfig.Bootstrap != nil {
+			// TODO(axw) 2016-06-01 #1587739
+			// We should be doing this for non-bootstrap machines as well.
+			apiPort = args.InstanceConfig.Bootstrap.StateServingInfo.APIPort
 		}
 		spec := &instanceSpec{
 			machineID: machineID,

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -121,7 +121,10 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	storageConfig := &container.StorageConfig{
 		AllowMount: true,
 	}
-	inst, hardware, err := broker.manager.CreateContainer(args.InstanceConfig, series, network, storageConfig, args.StatusCallback)
+	inst, hardware, err := broker.manager.CreateContainer(
+		args.InstanceConfig, args.Constraints,
+		series, network, storageConfig, args.StatusCallback,
+	)
 	if err != nil {
 		kvmLogger.Errorf("failed to start container: %v", err)
 		return nil, err

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -105,9 +105,8 @@ func (s *kvmBrokerSuite) instanceConfig(c *gc.C, machineId string) *instancecfg.
 	machineNonce := "fake-nonce"
 	// To isolate the tests from the host's architecture, we override it here.
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	stateInfo := jujutesting.FakeStateInfo(machineId)
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
-	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, machineNonce, "released", "quantal", "", true, stateInfo, apiInfo)
+	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, machineNonce, "released", "quantal", true, apiInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	return instanceConfig
 }
@@ -138,9 +137,8 @@ func (s *kvmBrokerSuite) startInstance(c *gc.C, machineId string) instance.Insta
 
 func (s *kvmBrokerSuite) maintainInstance(c *gc.C, machineId string) {
 	machineNonce := "fake-nonce"
-	stateInfo := jujutesting.FakeStateInfo(machineId)
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
-	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, machineNonce, "released", "quantal", "", true, stateInfo, apiInfo)
+	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, machineNonce, "released", "quantal", true, apiInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	cons := constraints.Value{}
 	possibleTools := coretools.List{&coretools.Tools{

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -147,7 +147,10 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		return nil, err
 	}
 
-	inst, hardware, err := broker.manager.CreateContainer(args.InstanceConfig, series, network, storageConfig, args.StatusCallback)
+	inst, hardware, err := broker.manager.CreateContainer(
+		args.InstanceConfig, args.Constraints,
+		series, network, storageConfig, args.StatusCallback,
+	)
 	if err != nil {
 		lxcLogger.Errorf("failed to start container: %v", err)
 		return nil, err

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -123,9 +123,8 @@ func (s *lxcBrokerSuite) instanceConfig(c *gc.C, machineId string) *instancecfg.
 	machineNonce := "fake-nonce"
 	// To isolate the tests from the host's architecture, we override it here.
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	stateInfo := jujutesting.FakeStateInfo(machineId)
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
-	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, machineNonce, "released", "quantal", "", true, stateInfo, apiInfo)
+	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, machineNonce, "released", "quantal", true, apiInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	hostname, err := s.namespace.Hostname(machineId)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -104,7 +104,10 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	}
 
 	storageConfig := &container.StorageConfig{}
-	inst, hardware, err := broker.manager.CreateContainer(args.InstanceConfig, series, network, storageConfig, args.StatusCallback)
+	inst, hardware, err := broker.manager.CreateContainer(
+		args.InstanceConfig, args.Constraints,
+		series, network, storageConfig, args.StatusCallback,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/worker/provisioner/lxd-broker_test.go
+++ b/worker/provisioner/lxd-broker_test.go
@@ -76,9 +76,8 @@ func (s *lxdBrokerSuite) SetUpTest(c *gc.C) {
 
 func (s *lxdBrokerSuite) instanceConfig(c *gc.C, machineId string) *instancecfg.InstanceConfig {
 	machineNonce := "fake-nonce"
-	stateInfo := jujutesting.FakeStateInfo(machineId)
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
-	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, machineNonce, "released", "quantal", "", true, stateInfo, apiInfo)
+	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, machineNonce, "released", "quantal", true, apiInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	return instanceConfig
 }
@@ -129,12 +128,13 @@ type fakeContainerManager struct {
 }
 
 func (m *fakeContainerManager) CreateContainer(instanceConfig *instancecfg.InstanceConfig,
+	cons constraints.Value,
 	series string,
 	network *container.NetworkConfig,
 	storage *container.StorageConfig,
 	callback container.StatusCallback,
 ) (instance.Instance, *instance.HardwareCharacteristics, error) {
-	m.MethodCall(m, "CreateContainer", instanceConfig, series, network, storage, callback)
+	m.MethodCall(m, "CreateContainer", instanceConfig, cons, series, network, storage, callback)
 	return nil, nil, m.NextErr()
 }
 

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage"
 	coretools "github.com/juju/juju/tools"
@@ -499,21 +500,36 @@ func (task *provisionerTask) constructInstanceConfig(
 		return nil, errors.Annotate(err, "failed to generate a nonce for machine "+machine.Id())
 	}
 
-	publicKey, err := simplestreams.UserPublicSigningKey()
-	if err != nil {
-		return nil, err
-	}
 	nonce := fmt.Sprintf("%s:%s", task.machineTag, uuid)
-	return instancecfg.NewInstanceConfig(
+	instanceConfig, err := instancecfg.NewInstanceConfig(
 		machine.Id(),
 		nonce,
 		task.imageStream,
 		pInfo.Series,
-		publicKey,
 		task.secureServerConnection,
-		stateInfo,
 		apiInfo,
 	)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	instanceConfig.Tags = pInfo.Tags
+	if len(pInfo.Jobs) > 0 {
+		instanceConfig.Jobs = pInfo.Jobs
+	}
+
+	if multiwatcher.AnyJobNeedsState(instanceConfig.Jobs...) {
+		publicKey, err := simplestreams.UserPublicSigningKey()
+		if err != nil {
+			return nil, err
+		}
+		instanceConfig.Controller = &instancecfg.ControllerConfig{
+			PublicImageSigningKey: publicKey,
+			MongoInfo:             stateInfo,
+		}
+	}
+
+	return instanceConfig, nil
 }
 
 func constructStartInstanceParams(
@@ -745,13 +761,6 @@ func assocProvInfoAndMachCfg(
 	provInfo *params.ProvisioningInfo,
 	instanceConfig *instancecfg.InstanceConfig,
 ) *provisioningInfo {
-
-	instanceConfig.Tags = provInfo.Tags
-
-	if len(provInfo.Jobs) > 0 {
-		instanceConfig.Jobs = provInfo.Jobs
-	}
-
 	return &provisioningInfo{
 		Constraints:    provInfo.Constraints,
 		Series:         provInfo.Series,


### PR DESCRIPTION
We restructure instancecfg.InstanceConfig such that the
common, controller-specific, and bootstrap-specific parts
are separated. We also define a structure in instancecfg
that is serialised and sent through to the bootstrap agent,
which can deserialise it into the same format. This will
simplify the task of adding bootstrap-agent parameters.

These changes shook out a couple of bugs (filed), and
some inappropriate uses of InstanceConfig (removed/rewritten).
We no longer expect MongoInfo to be present in non-controller
machines, and so we remove it from the common instance config.

container/kvm was relying on InstanceConfig.Constraints,
which is really inappropriate: those constraints are meant
to be for initialising the state database. The CreateContainer
method now takes a constraints.Value, which is passed by the
provisioner from StartInstanceParams.

Custom image metadata no longer needs to be written to the
blob store in Mongo, so that code has been removed from
cmd/jujud/bootstrap.go. Consequently, we no longer need to
marshal the metadata to the on-disk format, and we can keep
it in the in-memory format and avoid the simplestreams
marshal/unmarshal dance we used to do.

(Review request: http://reviews.vapour.ws/r/4965/)