### PR TITLE
Readd accidentally removed windows dependency

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -4,6 +4,7 @@ github.com/altoros/gosigma	git	31228935eec685587914528585da4eb9b073c76d	2015-04-
 github.com/bmizerany/pat	git	c068ca2f0aacee5ac3681d68e4d0a003b7d1fd2c	2016-02-17T10:32:42Z
 github.com/coreos/go-systemd	git	2d21675230a81a503f4363f4aa3490af06d52bb8	2015-01-26T19:09:17Z
 github.com/dustin/go-humanize	git	145fabdb1ab757076a70a886d092a3af27f66f4c	2014-12-28T07:11:48Z
+github.com/gabriel-samfira/sys	git	9ddc60d56b511544223adecea68da1e4f2153beb	2015-06-08T13:21:19Z
 github.com/godbus/dbus	git	88765d85c0fdadcd98a54e30694fa4e4f5b51133	2015-01-22T18:02:51Z
 github.com/gorilla/websocket	git	13e4d0621caa4d77fd9aa470ef6d7ab63d1a5e41	2015-09-23T22:29:30Z
 github.com/gosuri/uitable	git	36ee7e946282a3fb1cfecd476ddc9b35d8847e42	2016-04-04T20:39:58Z


### PR DESCRIPTION
The github.com/gabriel-samfira/sys dep was mistakenly removed
in f4ef9abdc08bfb374adbcb8b27f2c17c6261c988 which breaks
windows builds.

(Review request: http://reviews.vapour.ws/r/4968/)