### PR TITLE
Restore ModelUUID parameter to registration POST.

### DIFF
--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -927,6 +927,7 @@ func (s *DeployCharmStoreSuite) TestAddMetricCredentials(c *gc.C) {
 	c.Assert(called, jc.IsTrue)
 	stub.CheckCalls(c, []jujutesting.StubCall{{
 		"Authorize", []interface{}{metricRegistrationPost{
+			ModelUUID:       "deadbeef-0bad-400d-8000-4b1d0d06f00d",
 			CharmURL:        "cs:quantal/metered-1",
 			ApplicationName: "metered",
 			PlanURL:         "someplan",
@@ -974,6 +975,7 @@ func (s *DeployCharmStoreSuite) TestAddMetricCredentialsDefaultPlan(c *gc.C) {
 		"DefaultPlan", []interface{}{"cs:quantal/metered-1"},
 	}, {
 		"Authorize", []interface{}{metricRegistrationPost{
+			ModelUUID:       "deadbeef-0bad-400d-8000-4b1d0d06f00d",
 			CharmURL:        "cs:quantal/metered-1",
 			ApplicationName: "metered",
 			PlanURL:         "thisplan",

--- a/cmd/juju/application/register.go
+++ b/cmd/juju/application/register.go
@@ -26,7 +26,7 @@ var budgetWithLimitRe = regexp.MustCompile(`^[a-zA-Z0-9\-]+:[0-9]+$`)
 type metricRegistrationPost struct {
 	ModelUUID       string `json:"env-uuid"`
 	CharmURL        string `json:"charm-url"`
-	ApplicationName string `json:"application-name"`
+	ApplicationName string `json:"service-name"`
 	PlanURL         string `json:"plan-url"`
 	Budget          string `json:"budget"`
 	Limit           string `json:"limit"`

--- a/cmd/juju/application/register.go
+++ b/cmd/juju/application/register.go
@@ -24,6 +24,7 @@ import (
 var budgetWithLimitRe = regexp.MustCompile(`^[a-zA-Z0-9\-]+:[0-9]+$`)
 
 type metricRegistrationPost struct {
+	ModelUUID       string `json:"env-uuid"`
 	CharmURL        string `json:"charm-url"`
 	ApplicationName string `json:"application-name"`
 	PlanURL         string `json:"plan-url"`
@@ -82,6 +83,7 @@ func (r *RegisterMeteredCharm) RunPre(state api.Connection, bakeryClient *httpba
 	}
 
 	r.credentials, err = r.registerMetrics(
+		deployInfo.ModelUUID,
 		deployInfo.CharmID.URL.String(),
 		deployInfo.ApplicationName,
 		r.budget,
@@ -220,7 +222,7 @@ func (r *RegisterMeteredCharm) getCharmPlans(client *httpbakery.Client, cURL str
 	return info, nil
 }
 
-func (r *RegisterMeteredCharm) registerMetrics(charmURL, serviceName, budget, limit string, client *httpbakery.Client) ([]byte, error) {
+func (r *RegisterMeteredCharm) registerMetrics(modelUUID, charmURL, serviceName, budget, limit string, client *httpbakery.Client) ([]byte, error) {
 	if r.RegisterURL == "" {
 		return nil, errors.Errorf("no metric registration url is specified")
 	}
@@ -230,6 +232,7 @@ func (r *RegisterMeteredCharm) registerMetrics(charmURL, serviceName, budget, li
 	}
 
 	registrationPost := metricRegistrationPost{
+		ModelUUID:       modelUUID,
 		CharmURL:        charmURL,
 		ApplicationName: serviceName,
 		PlanURL:         r.Plan,

--- a/cmd/juju/application/register_test.go
+++ b/cmd/juju/application/register_test.go
@@ -71,6 +71,7 @@ func (s *registrationSuite) TestMeteredCharm(c *gc.C) {
 		"APICall", []interface{}{"Charms", "IsMetered", params.CharmInfo{CharmURL: "cs:quantal/metered-1"}},
 	}, {
 		"Authorize", []interface{}{metricRegistrationPost{
+			ModelUUID:       "model uuid",
 			CharmURL:        "cs:quantal/metered-1",
 			ApplicationName: "application name",
 			PlanURL:         "someplan",
@@ -103,6 +104,7 @@ func (s *registrationSuite) TestMeteredCharmAPIError(c *gc.C) {
 		"APICall", []interface{}{"Charms", "IsMetered", params.CharmInfo{CharmURL: "cs:quantal/metered-1"}},
 	}, {
 		"Authorize", []interface{}{metricRegistrationPost{
+			ModelUUID:       "model uuid",
 			CharmURL:        "cs:quantal/metered-1",
 			ApplicationName: "application name",
 			PlanURL:         "someplan",
@@ -153,6 +155,7 @@ func (s *registrationSuite) TestMeteredCharmDeployError(c *gc.C) {
 		"APICall", []interface{}{"Charms", "IsMetered", params.CharmInfo{CharmURL: "cs:quantal/metered-1"}},
 	}, {
 		"Authorize", []interface{}{metricRegistrationPost{
+			ModelUUID:       "model uuid",
 			CharmURL:        "cs:quantal/metered-1",
 			ApplicationName: "application name",
 			PlanURL:         "someplan",
@@ -181,6 +184,7 @@ func (s *registrationSuite) TestMeteredLocalCharmWithPlan(c *gc.C) {
 		"APICall", []interface{}{"Charms", "IsMetered", params.CharmInfo{CharmURL: "local:quantal/metered-1"}},
 	}, {
 		"Authorize", []interface{}{metricRegistrationPost{
+			ModelUUID:       "model uuid",
 			CharmURL:        "local:quantal/metered-1",
 			ApplicationName: "application name",
 			PlanURL:         "someplan",
@@ -221,6 +225,7 @@ func (s *registrationSuite) TestMeteredLocalCharmNoPlan(c *gc.C) {
 		"APICall", []interface{}{"Charms", "IsMetered", params.CharmInfo{CharmURL: "local:quantal/metered-1"}},
 	}, {
 		"Authorize", []interface{}{metricRegistrationPost{
+			ModelUUID:       "model uuid",
 			CharmURL:        "local:quantal/metered-1",
 			ApplicationName: "application name",
 			PlanURL:         "",
@@ -263,6 +268,7 @@ func (s *registrationSuite) TestMeteredCharmNoPlanSet(c *gc.C) {
 		"DefaultPlan", []interface{}{"cs:quantal/metered-1"},
 	}, {
 		"Authorize", []interface{}{metricRegistrationPost{
+			ModelUUID:       "model uuid",
 			CharmURL:        "cs:quantal/metered-1",
 			ApplicationName: "application name",
 			PlanURL:         "thisplan",
@@ -366,6 +372,7 @@ func (s *registrationSuite) TestFailedAuth(c *gc.C) {
 		"APICall", []interface{}{"Charms", "IsMetered", params.CharmInfo{CharmURL: "cs:quantal/metered-1"}},
 	}, {
 		"Authorize", []interface{}{metricRegistrationPost{
+			ModelUUID:       "model uuid",
 			CharmURL:        "cs:quantal/metered-1",
 			ApplicationName: "application name",
 			PlanURL:         "someplan",


### PR DESCRIPTION
This parameter is required and was somehow removed.

(Review request: http://reviews.vapour.ws/r/4971/)