### PR TITLE
Bootstrap print clouds

### DIFF
--- a/cmd/juju/commands/bootstrap_clouds.go
+++ b/cmd/juju/commands/bootstrap_clouds.go
@@ -1,0 +1,127 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+
+	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/jujuclient"
+)
+
+type cloudList struct {
+	public   []string
+	builtin  []string
+	personal []string
+}
+
+func formatCloudDetailsTabular(clouds cloudList, credStore jujuclient.CredentialStore) ([]byte, error) {
+	var out bytes.Buffer
+	const (
+		// To format things into columns.
+		minwidth = 0
+		tabwidth = 1
+		padding  = 2
+		padchar  = ' '
+		flags    = 0
+	)
+	tw := tabwriter.NewWriter(&out, minwidth, tabwidth, padding, padchar, flags)
+	p := func(values ...string) {
+		text := strings.Join(values, "\t")
+		fmt.Fprintln(tw, text)
+	}
+	p("Cloud\tCredentials\tDefault Region")
+	printClouds := func(cloudNames []string) error {
+		sort.Strings(cloudNames)
+		for _, name := range cloudNames {
+			cred, err := credStore.CredentialForCloud(name)
+			if err != nil && !errors.IsNotFound(err) {
+				return errors.Annotatef(err, "error loading credential for cloud %q", name)
+			}
+			if err != nil || len(cred.AuthCredentials) == 0 {
+				p(name, "", "")
+				continue
+			}
+			i := 0
+			for credName := range cred.AuthCredentials {
+				if i == 0 {
+					p(name, credName, cred.DefaultRegion)
+				} else {
+					p("", credName, "")
+				}
+				i++
+			}
+		}
+		return nil
+	}
+	if err := printClouds(clouds.public); err != nil {
+		return nil, err
+	}
+	if err := printClouds(clouds.builtin); err != nil {
+		return nil, err
+	}
+	if err := printClouds(clouds.personal); err != nil {
+		return nil, err
+	}
+
+	tw.Flush()
+	return out.Bytes(), nil
+}
+
+func printClouds(ctx *cmd.Context, credStore jujuclient.CredentialStore) error {
+	publicClouds, _, err := jujucloud.PublicCloudMetadata(jujucloud.JujuPublicCloudsPath())
+	if err != nil {
+		return err
+	}
+
+	personalClouds, err := jujucloud.PersonalCloudMetadata()
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(ctx.Stdout, "You can bootstrap on these clouds. See ‘--regions <cloud>’ for all regions.")
+	clouds := cloudList{}
+	for name := range publicClouds {
+		clouds.public = append(clouds.public, name)
+	}
+	// Add in built in clouds like localhost (lxd).
+	for name := range common.BuiltInClouds() {
+		clouds.builtin = append(clouds.builtin, name)
+	}
+	for name := range personalClouds {
+		clouds.personal = append(clouds.personal, name)
+	}
+	out, err := formatCloudDetailsTabular(clouds, credStore)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(ctx.Stdout, string(out))
+	credHelpText := `
+You will need to have a credential if you want to bootstrap on a cloud, see
+‘juju autoload-credentials’ and ‘juju add-credential’. The first credential
+listed is the default. Add more clouds with ‘juju add-cloud’.
+`
+	fmt.Fprintf(ctx.Stdout, credHelpText[1:])
+	return nil
+}
+
+func printCloudRegions(ctx *cmd.Context, cloudName string) error {
+	cloud, err := jujucloud.CloudByName(cloudName)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(ctx.Stdout, "Showing regions for %s:\n", cloudName)
+	for _, region := range cloud.Regions {
+		fmt.Fprintln(ctx.Stdout, region.Name)
+	}
+	return nil
+}

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -218,25 +218,23 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 		c.Check(opFinalizeBootstrap.InstanceConfig.AgentVersion().String(), gc.Equals, test.upload)
 	}
 
-	expectedBootstrappedControllerName := bootstrappedControllerName(controllerName)
-
 	// Check controllers.yaml controller details.
 	addrConnectedTo := []string{"localhost:17070"}
 
-	controller, err := s.store.ControllerByName(expectedBootstrappedControllerName)
+	controller, err := s.store.ControllerByName(controllerName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(controller.CACert, gc.Not(gc.Equals), "")
 	c.Assert(controller.UnresolvedAPIEndpoints, gc.DeepEquals, addrConnectedTo)
 	c.Assert(controller.APIEndpoints, gc.DeepEquals, addrConnectedTo)
 	c.Assert(utils.IsValidUUIDString(controller.ControllerUUID), jc.IsTrue)
 
-	controllerModel, err := s.store.ModelByName(expectedBootstrappedControllerName, "admin@local", environs.ControllerModelName)
+	controllerModel, err := s.store.ModelByName(controllerName, "admin@local", environs.ControllerModelName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(controllerModel.ModelUUID, gc.Equals, controller.ControllerUUID)
 
 	// Bootstrap config should have been saved, and should only contain
 	// the type, name, and any user-supplied configuration.
-	bootstrapConfig, err := s.store.BootstrapConfigForController(expectedBootstrappedControllerName)
+	bootstrapConfig, err := s.store.BootstrapConfigForController(controllerName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(bootstrapConfig.Cloud, gc.Equals, "dummy")
 	c.Assert(bootstrapConfig.Credential, gc.Equals, "")
@@ -332,6 +330,10 @@ var bootstrapTests = []bootstrapTest{{
 	version: "1.3.3-saucy-ppc64el",
 	args:    []string{"--agent-version", "1.4.0"},
 	err:     `requested agent version major.minor mismatch`,
+}, {
+	info: "--clouds with --regions",
+	args: []string{"--clouds", "--regions", "aws"},
+	err:  `--clouds and --regions can't be used together`,
 }}
 
 func (s *BootstrapSuite) TestRunControllerNameMissing(c *gc.C) {
@@ -377,7 +379,7 @@ func (s *BootstrapSuite) TestBootstrapTwice(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = coretesting.RunCommand(c, s.newBootstrapCommand(), controllerName, "dummy", "--auto-upgrade")
-	c.Assert(err, gc.ErrorMatches, `controller "local.dev" already exists`)
+	c.Assert(err, gc.ErrorMatches, `controller "dev" already exists`)
 }
 
 func (s *BootstrapSuite) TestBootstrapSetsCurrentModel(c *gc.C) {
@@ -386,7 +388,7 @@ func (s *BootstrapSuite) TestBootstrapSetsCurrentModel(c *gc.C) {
 	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "devcontroller", "dummy", "--auto-upgrade")
 	c.Assert(err, jc.ErrorIsNil)
 	currentController := s.store.CurrentControllerName
-	c.Assert(currentController, gc.Equals, bootstrappedControllerName("devcontroller"))
+	c.Assert(currentController, gc.Equals, "devcontroller")
 	modelName, err := s.store.CurrentModel(currentController, "admin@local")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelName, gc.Equals, "default")
@@ -503,7 +505,6 @@ func (*mockBootstrapInstance) Addresses() ([]network.Address, error) {
 // error to propagate back up to the user.
 func (s *BootstrapSuite) TestBootstrapPropagatesStoreErrors(c *gc.C) {
 	const controllerName = "devcontroller"
-	bootstrappedControllerName(controllerName)
 	s.patchVersionAndSeries(c, "raring")
 
 	store := jujuclienttesting.NewStubStore()
@@ -577,12 +578,12 @@ func (s *BootstrapSuite) TestBootstrapErrorRestoresOldMetadata(c *gc.C) {
 		return nil, fmt.Errorf("mock-prepare")
 	})
 
-	s.writeControllerModelAccountInfo(c, "local.olddevcontroller", "fredmodel", "fred@local")
+	s.writeControllerModelAccountInfo(c, "olddevcontroller", "fredmodel", "fred@local")
 	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "devcontroller", "dummy", "--auto-upgrade")
 	c.Assert(err, gc.ErrorMatches, "mock-prepare")
 
 	oldCurrentController := s.store.CurrentControllerName
-	c.Assert(oldCurrentController, gc.Equals, bootstrappedControllerName("olddevcontroller"))
+	c.Assert(oldCurrentController, gc.Equals, "olddevcontroller")
 	oldCurrentAccount, err := s.store.CurrentAccount(oldCurrentController)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(oldCurrentAccount, gc.Equals, "fred@local")
@@ -593,18 +594,17 @@ func (s *BootstrapSuite) TestBootstrapErrorRestoresOldMetadata(c *gc.C) {
 
 func (s *BootstrapSuite) TestBootstrapAlreadyExists(c *gc.C) {
 	const controllerName = "devcontroller"
-	expectedBootstrappedName := bootstrappedControllerName(controllerName)
 	s.patchVersionAndSeries(c, "raring")
 
-	s.writeControllerModelAccountInfo(c, "local.devcontroller", "fredmodel", "fred@local")
+	s.writeControllerModelAccountInfo(c, "devcontroller", "fredmodel", "fred@local")
 
 	ctx := coretesting.Context(c)
 	_, errc := cmdtesting.RunCommand(ctx, s.newBootstrapCommand(), controllerName, "dummy", "--auto-upgrade")
 	err := <-errc
 	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
-	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(`controller %q already exists`, expectedBootstrappedName))
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(`controller %q already exists`, controllerName))
 	currentController := s.store.CurrentControllerName
-	c.Assert(currentController, gc.Equals, "local.devcontroller")
+	c.Assert(currentController, gc.Equals, "devcontroller")
 	currentAccount, err := s.store.CurrentAccount(currentController)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(currentAccount, gc.Equals, "fred@local")
@@ -814,7 +814,7 @@ func (s *BootstrapSuite) TestMissingToolsUploadFailedError(c *gc.C) {
 	)
 
 	c.Check(coretesting.Stderr(ctx), gc.Equals, fmt.Sprintf(`
-Creating Juju controller "local.devcontroller" on dummy-cloud/region-1
+Creating Juju controller "devcontroller" on dummy-cloud/region-1
 Bootstrapping model %q
 Starting new instance for initial controller
 Building tools to upload (1.7.3.1-raring-%s)
@@ -898,7 +898,7 @@ func (s *BootstrapSuite) TestBootstrapProviderNoRegions(c *gc.C) {
 		c, s.newBootstrapCommand(), "ctrl", "no-cloud-regions",
 		"--config", "default-series=precise",
 	)
-	c.Check(coretesting.Stderr(ctx), gc.Matches, "Creating Juju controller \"local.ctrl\" on no-cloud-regions(.|\n)*")
+	c.Check(coretesting.Stderr(ctx), gc.Matches, "Creating Juju controller \"ctrl\" on no-cloud-regions(.|\n)*")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -908,7 +908,7 @@ func (s *BootstrapSuite) TestBootstrapCloudNoRegions(c *gc.C) {
 		c, s.newBootstrapCommand(), "ctrl", "dummy-cloud-without-regions",
 		"--config", "default-series=precise",
 	)
-	c.Check(coretesting.Stderr(ctx), gc.Matches, "Creating Juju controller \"local.ctrl\" on dummy-cloud-without-regions(.|\n)*")
+	c.Check(coretesting.Stderr(ctx), gc.Matches, "Creating Juju controller \"ctrl\" on dummy-cloud-without-regions(.|\n)*")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -924,7 +924,7 @@ func (s *BootstrapSuite) TestBootstrapCloudNoRegionsOneSpecified(c *gc.C) {
 	// enable the lxd provider to take the lxd remote from the region
 	// name.
 	c.Check(coretesting.Stderr(ctx), gc.Matches,
-		"Creating Juju controller \"local.ctrl\" on dummy-cloud-without-regions/my-region(.|\n)*")
+		"Creating Juju controller \"ctrl\" on dummy-cloud-without-regions/my-region(.|\n)*")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1033,6 +1033,78 @@ func (s *BootstrapSuite) TestBootstrapCloudConfigAndAdHoc(c *gc.C) {
 		"--config", "controller=false",
 	)
 	c.Assert(err, gc.ErrorMatches, "failed to bootstrap model: dummy.Bootstrap is broken")
+}
+
+func (s *BootstrapSuite) TestBootstrapPrintClouds(c *gc.C) {
+	resetJujuXDGDataHome(c)
+	s.store.Credentials = map[string]cloud.CloudCredential{
+		"aws": {
+			DefaultRegion: "us-west-1",
+			AuthCredentials: map[string]cloud.Credential{
+				"fred": {},
+				"mary": {},
+			},
+		},
+		"dummy-cloud": {
+			DefaultRegion: "home",
+			AuthCredentials: map[string]cloud.Credential{
+				"joe": {},
+			},
+		},
+	}
+	defer func() {
+		s.store = jujuclienttesting.NewMemStore()
+	}()
+
+	ctx, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "--clouds")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(coretesting.Stdout(ctx), jc.DeepEquals, `
+You can bootstrap on these clouds. See ‘--regions <cloud>’ for all regions.
+Cloud                        Credentials  Default Region
+aws                          fred         us-west-1
+                             mary         
+aws-china                                 
+aws-gov                                   
+azure                                     
+azure-china                               
+cloudsigma                                
+google                                    
+joyent                                    
+rackspace                                 
+localhost                                 
+dummy-cloud                  joe          home
+dummy-cloud-with-config                   
+dummy-cloud-without-regions               
+
+You will need to have a credential if you want to bootstrap on a cloud, see
+‘juju autoload-credentials’ and ‘juju add-credential’. The first credential
+listed is the default. Add more clouds with ‘juju add-cloud’.
+`[1:])
+}
+
+func (s *BootstrapSuite) TestBootstrapPrintCloudRegions(c *gc.C) {
+	resetJujuXDGDataHome(c)
+	ctx, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "--regions", "aws")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(coretesting.Stdout(ctx), jc.DeepEquals, `
+Showing regions for aws:
+us-east-1
+us-west-1
+us-west-2
+eu-west-1
+eu-central-1
+ap-southeast-1
+ap-southeast-2
+ap-northeast-1
+ap-northeast-2
+sa-east-1
+`[1:])
+}
+
+func (s *BootstrapSuite) TestBootstrapPrintCloudRegionsNoSuchCloud(c *gc.C) {
+	resetJujuXDGDataHome(c)
+	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "--regions", "foo")
+	c.Assert(err, gc.ErrorMatches, "cloud foo not found")
 }
 
 // createToolsSource writes the mock tools and metadata into a temporary

--- a/cmd/juju/commands/migrate.go
+++ b/cmd/juju/commands/migrate.go
@@ -92,22 +92,17 @@ func (c *migrateCommand) getMigrationSpec() (*controller.ModelMigrationSpec, err
 		return nil, err
 	}
 
-	controllerName, err := modelcmd.ResolveControllerName(store, c.targetController)
+	controllerInfo, err := store.ControllerByName(c.targetController)
 	if err != nil {
 		return nil, err
 	}
 
-	controllerInfo, err := store.ControllerByName(controllerName)
+	accountName, err := store.CurrentAccount(c.targetController)
 	if err != nil {
 		return nil, err
 	}
 
-	accountName, err := store.CurrentAccount(controllerName)
-	if err != nil {
-		return nil, err
-	}
-
-	accountInfo, err := store.AccountByName(controllerName, accountName)
+	accountInfo, err := store.AccountByName(c.targetController, accountName)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/juju/commands/switch.go
+++ b/cmd/juju/commands/switch.go
@@ -113,8 +113,8 @@ func (c *switchCommand) Run(ctx *cmd.Context) (resultErr error) {
 	}
 
 	// If the target identifies a controller, then set that as the current controller.
-	var newControllerName string
-	if newControllerName, err = modelcmd.ResolveControllerName(c.Store, c.Target); err == nil {
+	var newControllerName = c.Target
+	if _, err = c.Store.ControllerByName(c.Target); err == nil {
 		if newControllerName == currentControllerName {
 			newName = currentName
 			return nil
@@ -135,9 +135,7 @@ func (c *switchCommand) Run(ctx *cmd.Context) (resultErr error) {
 	// case, the model must exist in the current controller.
 	newControllerName, modelName := modelcmd.SplitModelName(c.Target)
 	if newControllerName != "" {
-		// A controller was specified so see if we should use a local version.
-		newControllerName, err = modelcmd.ResolveControllerName(c.Store, newControllerName)
-		if err != nil {
+		if _, err = c.Store.ControllerByName(newControllerName); err != nil {
 			return errors.Trace(err)
 		}
 		newName = modelcmd.JoinModelName(newControllerName, modelName)

--- a/cmd/juju/commands/switch_test.go
+++ b/cmd/juju/commands/switch_test.go
@@ -113,10 +113,10 @@ func (s *SwitchSimpleSuite) TestSwitchWithCurrentController(c *gc.C) {
 
 func (s *SwitchSimpleSuite) TestSwitchLocalControllerWithCurrent(c *gc.C) {
 	s.store.CurrentControllerName = "old"
-	s.addController(c, "local.new")
+	s.addController(c, "new")
 	context, err := s.run(c, "new")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(context), gc.Equals, "old (controller) -> local.new (controller)\n")
+	c.Assert(coretesting.Stderr(context), gc.Equals, "old (controller) -> new (controller)\n")
 }
 
 func (s *SwitchSimpleSuite) TestSwitchSameController(c *gc.C) {
@@ -151,7 +151,6 @@ func (s *SwitchSimpleSuite) TestSwitchControllerToModel(c *gc.C) {
 		{"CurrentAccount", []interface{}{"ctrl"}},
 		{"CurrentModel", []interface{}{"ctrl", "admin@local"}},
 		{"ControllerByName", []interface{}{"mymodel"}},
-		{"ControllerByName", []interface{}{"local.mymodel"}},
 		{"CurrentAccount", []interface{}{"ctrl"}},
 		{"SetCurrentModel", []interface{}{"ctrl", "admin@local", "mymodel"}},
 	})
@@ -175,7 +174,6 @@ func (s *SwitchSimpleSuite) TestSwitchControllerToModelDifferentController(c *gc
 		{"CurrentController", nil},
 		{"CurrentAccount", []interface{}{"old"}},
 		{"ControllerByName", []interface{}{"new:mymodel"}},
-		{"ControllerByName", []interface{}{"local.new:mymodel"}},
 		{"ControllerByName", []interface{}{"new"}},
 		{"CurrentAccount", []interface{}{"new"}},
 		{"SetCurrentModel", []interface{}{"new", "admin@local", "mymodel"}},
@@ -186,8 +184,8 @@ func (s *SwitchSimpleSuite) TestSwitchControllerToModelDifferentController(c *gc
 
 func (s *SwitchSimpleSuite) TestSwitchLocalControllerToModelDifferentController(c *gc.C) {
 	s.store.CurrentControllerName = "old"
-	s.addController(c, "local.new")
-	s.store.Models["local.new"] = jujuclient.ControllerAccountModels{
+	s.addController(c, "new")
+	s.store.Models["new"] = jujuclient.ControllerAccountModels{
 		map[string]*jujuclient.AccountModels{
 			"admin@local": {
 				Models: map[string]jujuclient.ModelDetails{"mymodel": {}},
@@ -196,19 +194,17 @@ func (s *SwitchSimpleSuite) TestSwitchLocalControllerToModelDifferentController(
 	}
 	context, err := s.run(c, "new:mymodel")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(context), gc.Equals, "old (controller) -> local.new:mymodel\n")
+	c.Assert(coretesting.Stderr(context), gc.Equals, "old (controller) -> new:mymodel\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
 		{"CurrentAccount", []interface{}{"old"}},
 		{"ControllerByName", []interface{}{"new:mymodel"}},
-		{"ControllerByName", []interface{}{"local.new:mymodel"}},
 		{"ControllerByName", []interface{}{"new"}},
-		{"ControllerByName", []interface{}{"local.new"}},
-		{"CurrentAccount", []interface{}{"local.new"}},
-		{"SetCurrentModel", []interface{}{"local.new", "admin@local", "mymodel"}},
-		{"SetCurrentController", []interface{}{"local.new"}},
+		{"CurrentAccount", []interface{}{"new"}},
+		{"SetCurrentModel", []interface{}{"new", "admin@local", "mymodel"}},
+		{"SetCurrentController", []interface{}{"new"}},
 	})
-	c.Assert(s.store.Models["local.new"].AccountModels["admin@local"].CurrentModel, gc.Equals, "mymodel")
+	c.Assert(s.store.Models["new"].AccountModels["admin@local"].CurrentModel, gc.Equals, "mymodel")
 }
 
 func (s *SwitchSimpleSuite) TestSwitchControllerToDifferentControllerCurrentModel(c *gc.C) {
@@ -229,7 +225,6 @@ func (s *SwitchSimpleSuite) TestSwitchControllerToDifferentControllerCurrentMode
 		{"CurrentController", nil},
 		{"CurrentAccount", []interface{}{"old"}},
 		{"ControllerByName", []interface{}{"new:mymodel"}},
-		{"ControllerByName", []interface{}{"local.new:mymodel"}},
 		{"ControllerByName", []interface{}{"new"}},
 		{"CurrentAccount", []interface{}{"new"}},
 		{"SetCurrentModel", []interface{}{"new", "admin@local", "mymodel"}},
@@ -243,7 +238,6 @@ func (s *SwitchSimpleSuite) TestSwitchUnknownNoCurrentController(c *gc.C) {
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
 		{"ControllerByName", []interface{}{"unknown"}},
-		{"ControllerByName", []interface{}{"local.unknown"}},
 	})
 }
 

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -42,7 +42,7 @@ func (s *addSuite) SetUpTest(c *gc.C) {
 
 	// Set up the current controller, and write just enough info
 	// so we don't try to refresh
-	controllerName := "local.test-master"
+	controllerName := "test-master"
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = controllerName
 	s.store.Controllers[controllerName] = jujuclient.ControllerDetails{}
@@ -123,7 +123,7 @@ func (s *addSuite) TestAddExistingName(c *gc.C) {
 	// controller will error out if the model already exists. Overwriting
 	// means we'll replace any stale details from an previously existing
 	// model with the same name.
-	err := s.store.UpdateModel("local.test-master", "bob@local", "test", jujuclient.ModelDetails{
+	err := s.store.UpdateModel("test-master", "bob@local", "test", jujuclient.ModelDetails{
 		"stale-uuid",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -131,7 +131,7 @@ func (s *addSuite) TestAddExistingName(c *gc.C) {
 	_, err = s.run(c, "test")
 	c.Assert(err, jc.ErrorIsNil)
 
-	details, err := s.store.ModelByName("local.test-master", "bob@local", "test")
+	details, err := s.store.ModelByName("test-master", "bob@local", "test")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(details, jc.DeepEquals, &jujuclient.ModelDetails{"fake-model-uuid"})
 }
@@ -255,7 +255,7 @@ func (s *addSuite) TestAddErrorRemoveConfigstoreInfo(c *gc.C) {
 	_, err := s.run(c, "test")
 	c.Assert(err, gc.ErrorMatches, "bah humbug")
 
-	_, err = s.store.ModelByName("local.test-master", "bob@local", "test")
+	_, err = s.store.ModelByName("test-master", "bob@local", "test")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
@@ -263,7 +263,7 @@ func (s *addSuite) TestAddStoresValues(c *gc.C) {
 	_, err := s.run(c, "test")
 	c.Assert(err, jc.ErrorIsNil)
 
-	model, err := s.store.ModelByName("local.test-master", "bob@local", "test")
+	model, err := s.store.ModelByName("test-master", "bob@local", "test")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(model, jc.DeepEquals, &jujuclient.ModelDetails{"fake-model-uuid"})
 }
@@ -273,9 +273,9 @@ func (s *addSuite) TestNoEnvCacheOtherUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Creating a model for another user does not update the model cache.
-	_, err = s.store.ModelByName("local.test-master", "bob@local", "test")
+	_, err = s.store.ModelByName("test-master", "bob@local", "test")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	_, err = s.store.ModelByName("local.test-master", "zeus@local", "test")
+	_, err = s.store.ModelByName("test-master", "zeus@local", "test")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -139,7 +139,7 @@ func (s *baseDestroySuite) SetUpTest(c *gc.C) {
 	s.apierror = nil
 
 	s.store = jujuclienttesting.NewMemStore()
-	s.store.Controllers["local.test1"] = jujuclient.ControllerDetails{
+	s.store.Controllers["test1"] = jujuclient.ControllerDetails{
 		APIEndpoints:   []string{"localhost"},
 		CACert:         testing.CACert,
 		ControllerUUID: test1UUID,
@@ -149,7 +149,7 @@ func (s *baseDestroySuite) SetUpTest(c *gc.C) {
 		CACert:         testing.CACert,
 		ControllerUUID: test3UUID,
 	}
-	s.store.Accounts["local.test1"] = &jujuclient.ControllerAccounts{
+	s.store.Accounts["test1"] = &jujuclient.ControllerAccounts{
 		CurrentAccount: "admin@local",
 	}
 
@@ -160,7 +160,7 @@ func (s *baseDestroySuite) SetUpTest(c *gc.C) {
 		bootstrapCfg map[string]interface{}
 	}{
 		{
-			name:         "local.test1:admin",
+			name:         "test1:admin",
 			serverUUID:   test1UUID,
 			modelUUID:    test1UUID,
 			bootstrapCfg: createBootstrapInfo(c, "admin"),
@@ -245,27 +245,27 @@ func (s *DestroySuite) TestDestroyUnknownController(c *gc.C) {
 }
 
 func (s *DestroySuite) TestDestroyControllerNotFoundNotRemovedFromStore(c *gc.C) {
-	s.apierror = errors.NotFoundf("local.test1")
-	_, err := s.runDestroyCommand(c, "local.test1", "-y")
-	c.Assert(err, gc.ErrorMatches, "cannot connect to API: local.test1 not found")
+	s.apierror = errors.NotFoundf("test1")
+	_, err := s.runDestroyCommand(c, "test1", "-y")
+	c.Assert(err, gc.ErrorMatches, "cannot connect to API: test1 not found")
 	c.Check(c.GetTestLog(), jc.Contains, "If the controller is unusable")
-	checkControllerExistsInStore(c, "local.test1", s.store)
+	checkControllerExistsInStore(c, "test1", s.store)
 }
 
 func (s *DestroySuite) TestDestroyCannotConnectToAPI(c *gc.C) {
 	s.apierror = errors.New("connection refused")
-	_, err := s.runDestroyCommand(c, "local.test1", "-y")
+	_, err := s.runDestroyCommand(c, "test1", "-y")
 	c.Assert(err, gc.ErrorMatches, "cannot connect to API: connection refused")
 	c.Check(c.GetTestLog(), jc.Contains, "If the controller is unusable")
-	checkControllerExistsInStore(c, "local.test1", s.store)
+	checkControllerExistsInStore(c, "test1", s.store)
 }
 
 func (s *DestroySuite) TestDestroy(c *gc.C) {
-	_, err := s.runDestroyCommand(c, "local.test1", "-y")
+	_, err := s.runDestroyCommand(c, "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.destroyAll, jc.IsFalse)
 	c.Assert(s.clientapi.destroycalled, jc.IsFalse)
-	checkControllerRemovedFromStore(c, "local.test1", s.store)
+	checkControllerRemovedFromStore(c, "test1", s.store)
 }
 
 func (s *DestroySuite) TestDestroyAlias(c *gc.C) {
@@ -273,14 +273,14 @@ func (s *DestroySuite) TestDestroyAlias(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.destroyAll, jc.IsFalse)
 	c.Assert(s.clientapi.destroycalled, jc.IsFalse)
-	checkControllerRemovedFromStore(c, "local.test1", s.store)
+	checkControllerRemovedFromStore(c, "test1", s.store)
 }
 
 func (s *DestroySuite) TestDestroyWithDestroyAllEnvsFlag(c *gc.C) {
-	_, err := s.runDestroyCommand(c, "local.test1", "-y", "--destroy-all-models")
+	_, err := s.runDestroyCommand(c, "test1", "-y", "--destroy-all-models")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.destroyAll, jc.IsTrue)
-	checkControllerRemovedFromStore(c, "local.test1", s.store)
+	checkControllerRemovedFromStore(c, "test1", s.store)
 }
 
 func (s *DestroySuite) TestDestroyControllerGetFails(c *gc.C) {
@@ -294,10 +294,10 @@ func (s *DestroySuite) TestDestroyControllerGetFails(c *gc.C) {
 
 func (s *DestroySuite) TestFailedDestroyController(c *gc.C) {
 	s.api.SetErrors(errors.New("permission denied"))
-	_, err := s.runDestroyCommand(c, "local.test1", "-y")
+	_, err := s.runDestroyCommand(c, "test1", "-y")
 	c.Assert(err, gc.ErrorMatches, "cannot destroy controller: permission denied")
 	c.Assert(s.api.destroyAll, jc.IsFalse)
-	checkControllerExistsInStore(c, "local.test1", s.store)
+	checkControllerExistsInStore(c, "test1", s.store)
 }
 
 func (s *DestroySuite) TestDestroyControllerAliveModels(c *gc.C) {
@@ -306,8 +306,8 @@ func (s *DestroySuite) TestDestroyControllerAliveModels(c *gc.C) {
 		s.api.envStatus[uuid] = status
 	}
 	s.api.SetErrors(&params.Error{Code: params.CodeHasHostedModels})
-	_, err := s.runDestroyCommand(c, "local.test1", "-y")
-	c.Assert(err.Error(), gc.Equals, `cannot destroy controller "local.test1"
+	_, err := s.runDestroyCommand(c, "test1", "-y")
+	c.Assert(err.Error(), gc.Equals, `cannot destroy controller "test1"
 
 The controller has live hosted models. If you want
 to destroy all hosted models in the controller,
@@ -328,7 +328,7 @@ func (s *DestroySuite) TestDestroyControllerReattempt(c *gc.C) {
 	// and reattempt the destroy the controller; this time
 	// it succeeds.
 	s.api.SetErrors(&params.Error{Code: params.CodeHasHostedModels})
-	_, err := s.runDestroyCommand(c, "local.test1", "-y")
+	_, err := s.runDestroyCommand(c, "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
 	s.api.CheckCallNames(c,
 		"DestroyController",
@@ -344,15 +344,15 @@ func (s *DestroySuite) TestDestroyControllerReattempt(c *gc.C) {
 }
 
 func (s *DestroySuite) resetController(c *gc.C) {
-	s.store.Controllers["local.test1"] = jujuclient.ControllerDetails{
+	s.store.Controllers["test1"] = jujuclient.ControllerDetails{
 		APIEndpoints:   []string{"localhost"},
 		CACert:         testing.CACert,
 		ControllerUUID: test1UUID,
 	}
-	s.store.Accounts["local.test1"] = &jujuclient.ControllerAccounts{
+	s.store.Accounts["test1"] = &jujuclient.ControllerAccounts{
 		CurrentAccount: "admin@local",
 	}
-	s.store.BootstrapConfig["local.test1"] = jujuclient.BootstrapConfig{
+	s.store.BootstrapConfig["test1"] = jujuclient.BootstrapConfig{
 		Config: createBootstrapInfo(c, "admin"),
 	}
 }
@@ -365,50 +365,50 @@ func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 
 	// Ensure confirmation is requested if "-y" is not specified.
 	stdin.WriteString("n")
-	_, errc := cmdtesting.RunCommand(ctx, s.newDestroyCommand(), "local.test1")
+	_, errc := cmdtesting.RunCommand(ctx, s.newDestroyCommand(), "test1")
 	select {
 	case err := <-errc:
 		c.Check(err, gc.ErrorMatches, "controller destruction aborted")
 	case <-time.After(testing.LongWait):
 		c.Fatalf("command took too long")
 	}
-	c.Check(testing.Stdout(ctx), gc.Matches, "WARNING!.*local.test1(.|\n)*")
-	checkControllerExistsInStore(c, "local.test1", s.store)
+	c.Check(testing.Stdout(ctx), gc.Matches, "WARNING!.*test1(.|\n)*")
+	checkControllerExistsInStore(c, "test1", s.store)
 
 	// EOF on stdin: equivalent to answering no.
 	stdin.Reset()
 	stdout.Reset()
-	_, errc = cmdtesting.RunCommand(ctx, s.newDestroyCommand(), "local.test1")
+	_, errc = cmdtesting.RunCommand(ctx, s.newDestroyCommand(), "test1")
 	select {
 	case err := <-errc:
 		c.Check(err, gc.ErrorMatches, "controller destruction aborted")
 	case <-time.After(testing.LongWait):
 		c.Fatalf("command took too long")
 	}
-	c.Check(testing.Stdout(ctx), gc.Matches, "WARNING!.*local.test1(.|\n)*")
-	checkControllerExistsInStore(c, "local.test1", s.store)
+	c.Check(testing.Stdout(ctx), gc.Matches, "WARNING!.*test1(.|\n)*")
+	checkControllerExistsInStore(c, "test1", s.store)
 
 	for _, answer := range []string{"y", "Y", "yes", "YES"} {
 		stdin.Reset()
 		stdout.Reset()
 		stdin.WriteString(answer)
-		_, errc = cmdtesting.RunCommand(ctx, s.newDestroyCommand(), "local.test1")
+		_, errc = cmdtesting.RunCommand(ctx, s.newDestroyCommand(), "test1")
 		select {
 		case err := <-errc:
 			c.Check(err, jc.ErrorIsNil)
 		case <-time.After(testing.LongWait):
 			c.Fatalf("command took too long")
 		}
-		checkControllerRemovedFromStore(c, "local.test1", s.store)
+		checkControllerRemovedFromStore(c, "test1", s.store)
 
-		// Add the local.test1 controller back into the store for the next test
+		// Add the test1 controller back into the store for the next test
 		s.resetController(c)
 	}
 }
 
 func (s *DestroySuite) TestBlockedDestroy(c *gc.C) {
 	s.api.SetErrors(&params.Error{Code: params.CodeOperationBlocked})
-	s.runDestroyCommand(c, "local.test1", "-y")
+	s.runDestroyCommand(c, "test1", "-y")
 	testLog := c.GetTestLog()
 	c.Check(testLog, jc.Contains, "To remove all blocks in the controller, please run:")
 	c.Check(testLog, jc.Contains, "juju controller remove-blocks")
@@ -419,7 +419,7 @@ func (s *DestroySuite) TestDestroyListBlocksError(c *gc.C) {
 		&params.Error{Code: params.CodeOperationBlocked},
 		errors.New("unexpected api error"),
 	)
-	s.runDestroyCommand(c, "local.test1", "-y")
+	s.runDestroyCommand(c, "test1", "-y")
 	testLog := c.GetTestLog()
 	c.Check(testLog, jc.Contains, "To remove all blocks in the controller, please run:")
 	c.Check(testLog, jc.Contains, "juju controller remove-blocks")
@@ -447,7 +447,7 @@ func (s *DestroySuite) TestDestroyReturnsBlocks(c *gc.C) {
 			},
 		},
 	}
-	ctx, _ := s.runDestroyCommand(c, "local.test1", "-y", "--destroy-all-models")
+	ctx, _ := s.runDestroyCommand(c, "test1", "-y", "--destroy-all-models")
 	c.Assert(testing.Stderr(ctx), gc.Equals, "Destroying controller\n"+
 		"NAME   MODEL UUID                            OWNER         BLOCKS\n"+
 		"test1  1871299e-1370-4f3e-83ab-1849ed7b1076  cheryl@local  destroy-model\n"+

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -63,18 +63,18 @@ func (s *KillSuite) TestKillUnknownController(c *gc.C) {
 
 func (s *KillSuite) TestKillCannotConnectToAPISucceeds(c *gc.C) {
 	s.apierror = errors.New("connection refused")
-	ctx, err := s.runKillCommand(c, "local.test1", "-y")
+	ctx, err := s.runKillCommand(c, "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(testing.Stderr(ctx), jc.Contains, "Unable to open API: connection refused")
-	checkControllerRemovedFromStore(c, "local.test1", s.store)
+	checkControllerRemovedFromStore(c, "test1", s.store)
 }
 
 func (s *KillSuite) TestKillWithAPIConnection(c *gc.C) {
-	_, err := s.runKillCommand(c, "local.test1", "-y")
+	_, err := s.runKillCommand(c, "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.destroyAll, jc.IsTrue)
 	c.Assert(s.clientapi.destroycalled, jc.IsFalse)
-	checkControllerRemovedFromStore(c, "local.test1", s.store)
+	checkControllerRemovedFromStore(c, "test1", s.store)
 }
 
 func (s *KillSuite) TestKillEnvironmentGetFailsWithoutAPIConnection(c *gc.C) {
@@ -98,11 +98,11 @@ func (s *KillSuite) TestKillEnvironmentGetFailsWithAPIConnection(c *gc.C) {
 
 func (s *KillSuite) TestKillDestroysControllerWithAPIError(c *gc.C) {
 	s.api.SetErrors(errors.New("some destroy error"))
-	ctx, err := s.runKillCommand(c, "local.test1", "-y")
+	ctx, err := s.runKillCommand(c, "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(testing.Stderr(ctx), jc.Contains, "Unable to destroy controller through the API: some destroy error.  Destroying through provider.")
 	c.Assert(s.api.destroyAll, jc.IsTrue)
-	checkControllerRemovedFromStore(c, "local.test1", s.store)
+	checkControllerRemovedFromStore(c, "test1", s.store)
 }
 
 func (s *KillSuite) TestKillCommandConfirmation(c *gc.C) {
@@ -114,21 +114,21 @@ func (s *KillSuite) TestKillCommandConfirmation(c *gc.C) {
 
 	// Ensure confirmation is requested if "-y" is not specified.
 	stdin.WriteString("n")
-	_, errc := cmdtesting.RunCommand(ctx, s.newKillCommand(), "local.test1")
+	_, errc := cmdtesting.RunCommand(ctx, s.newKillCommand(), "test1")
 	select {
 	case err := <-errc:
 		c.Check(err, gc.ErrorMatches, "controller destruction aborted")
 	case <-time.After(testing.LongWait):
 		c.Fatalf("command took too long")
 	}
-	c.Check(testing.Stdout(ctx), gc.Matches, "WARNING!.*local.test1(.|\n)*")
-	checkControllerExistsInStore(c, "local.test1", s.store)
+	c.Check(testing.Stdout(ctx), gc.Matches, "WARNING!.*test1(.|\n)*")
+	checkControllerExistsInStore(c, "test1", s.store)
 }
 
 func (s *KillSuite) TestKillCommandControllerAlias(c *gc.C) {
-	_, err := testing.RunCommand(c, s.newKillCommand(), "local.test1", "-y")
+	_, err := testing.RunCommand(c, s.newKillCommand(), "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
-	checkControllerRemovedFromStore(c, "local.test1:test1", s.store)
+	checkControllerRemovedFromStore(c, "test1:test1", s.store)
 }
 
 func (s *KillSuite) TestKillAPIPermErrFails(c *gc.C) {
@@ -136,9 +136,9 @@ func (s *KillSuite) TestKillAPIPermErrFails(c *gc.C) {
 		return nil, common.ErrPerm
 	}
 	cmd := controller.NewKillCommandForTest(nil, nil, s.store, nil, clock.WallClock, modelcmd.OpenFunc(testDialer))
-	_, err := testing.RunCommand(c, cmd, "local.test1", "-y")
+	_, err := testing.RunCommand(c, cmd, "test1", "-y")
 	c.Assert(err, gc.ErrorMatches, "cannot destroy controller: permission denied")
-	checkControllerExistsInStore(c, "local.test1", s.store)
+	checkControllerExistsInStore(c, "test1", s.store)
 }
 
 func (s *KillSuite) TestKillEarlyAPIConnectionTimeout(c *gc.C) {
@@ -152,10 +152,10 @@ func (s *KillSuite) TestKillEarlyAPIConnectionTimeout(c *gc.C) {
 	}
 
 	cmd := controller.NewKillCommandForTest(nil, nil, s.store, nil, clock, modelcmd.OpenFunc(testDialer))
-	ctx, err := testing.RunCommand(c, cmd, "local.test1", "-y")
+	ctx, err := testing.RunCommand(c, cmd, "test1", "-y")
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(testing.Stderr(ctx), jc.Contains, "Unable to open API: open connection timed out")
-	checkControllerRemovedFromStore(c, "local.test1", s.store)
+	checkControllerRemovedFromStore(c, "test1", s.store)
 	// Check that we were actually told to wait for 10s.
 	c.Assert(clock.wait, gc.Equals, 10*time.Second)
 }

--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -35,10 +35,10 @@ CONTROLLER  MODEL  USER  CLOUD/REGION
 
 func (s *ListControllersSuite) TestListControllers(c *gc.C) {
 	s.expectedOutput = `
-CONTROLLER                 MODEL     USER         CLOUD/REGION
-local.aws-test             -         -            aws/us-east-1
-local.mallards*            my-model  admin@local  mallards/mallards1
-local.mark-test-prodstack  -         -            prodstack
+CONTROLLER           MODEL     USER         CLOUD/REGION
+aws-test             -         -            aws/us-east-1
+mallards*            my-model  admin@local  mallards/mallards1
+mark-test-prodstack  -         -            prodstack
 
 `[1:]
 
@@ -49,14 +49,14 @@ local.mark-test-prodstack  -         -            prodstack
 func (s *ListControllersSuite) TestListControllersYaml(c *gc.C) {
 	s.expectedOutput = `
 controllers:
-  local.aws-test:
+  aws-test:
     recent-server: this-is-aws-test-of-many-api-endpoints
     uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
     ca-cert: this-is-aws-test-ca-cert
     cloud: aws
     region: us-east-1
-  local.mallards:
+  mallards:
     current-model: my-model
     user: admin@local
     recent-server: this-is-another-of-many-api-endpoints
@@ -65,13 +65,13 @@ controllers:
     ca-cert: this-is-another-ca-cert
     cloud: mallards
     region: mallards1
-  local.mark-test-prodstack:
+  mark-test-prodstack:
     recent-server: this-is-one-of-many-api-endpoints
     uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
     ca-cert: this-is-a-ca-cert
     cloud: prodstack
-current-controller: local.mallards
+current-controller: mallards
 `[1:]
 
 	s.createTestClientStore(c)
@@ -87,7 +87,7 @@ func (s *ListControllersSuite) TestListControllersJson(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, controller.ControllerSet{
 		Controllers: map[string]controller.ControllerItem{
-			"local.aws-test": {
+			"aws-test": {
 				ControllerUUID: "this-is-the-aws-test-uuid",
 				Server:         "this-is-aws-test-of-many-api-endpoints",
 				APIEndpoints:   []string{"this-is-aws-test-of-many-api-endpoints"},
@@ -95,7 +95,7 @@ func (s *ListControllersSuite) TestListControllersJson(c *gc.C) {
 				Cloud:          "aws",
 				CloudRegion:    "us-east-1",
 			},
-			"local.mallards": {
+			"mallards": {
 				ControllerUUID: "this-is-another-uuid",
 				ModelName:      "my-model",
 				User:           "admin@local",
@@ -105,7 +105,7 @@ func (s *ListControllersSuite) TestListControllersJson(c *gc.C) {
 				Cloud:          "mallards",
 				CloudRegion:    "mallards1",
 			},
-			"local.mark-test-prodstack": {
+			"mark-test-prodstack": {
 				ControllerUUID: "this-is-a-uuid",
 				Server:         "this-is-one-of-many-api-endpoints",
 				APIEndpoints:   []string{"this-is-one-of-many-api-endpoints"},
@@ -113,7 +113,7 @@ func (s *ListControllersSuite) TestListControllersJson(c *gc.C) {
 				Cloud:          "prodstack",
 			},
 		},
-		CurrentController: "local.mallards",
+		CurrentController: "mallards",
 	})
 }
 

--- a/cmd/juju/controller/package_test.go
+++ b/cmd/juju/controller/package_test.go
@@ -54,36 +54,36 @@ func (s *baseControllerSuite) createTestClientStore(c *gc.C) *jujuclienttesting.
 
 const testControllersYaml = `
 controllers:
-  local.aws-test:
+  aws-test:
     uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
     ca-cert: this-is-aws-test-ca-cert
     cloud: aws
     region: us-east-1
-  local.mallards:
+  mallards:
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
     cloud: mallards
     region: mallards1
-  local.mark-test-prodstack:
+  mark-test-prodstack:
     uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
     ca-cert: this-is-a-ca-cert
     cloud: prodstack
-current-controller: local.mallards
+current-controller: mallards
 `
 
 const testModelsYaml = `
 controllers:
-  local.aws-test:
+  aws-test:
     accounts:
       admin@local:
         models:
           admin:
             uuid: ghi
         current-model: admin
-  local.mallards:
+  mallards:
     accounts:
       admin@local:
         models:
@@ -96,17 +96,17 @@ controllers:
 
 const testAccountsYaml = `
 controllers:
-  local.aws-test:
+  aws-test:
     accounts:
       admin@local:
         user: admin@local
         password: hun+er2
-  local.mark-test-prodstack:
+  mark-test-prodstack:
     accounts:
       admin@local:
         user: admin@local
         password: hunter2
-  local.mallards:
+  mallards:
     accounts:
       admin@local:
         user: admin@local

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -78,15 +78,11 @@ func (c *showControllerCommand) Run(ctx *cmd.Context) error {
 	}
 	controllers := make(map[string]ShowControllerDetails)
 	for _, name := range controllerNames {
-		actualName, err := modelcmd.ResolveControllerName(c.store, name)
+		one, err := c.store.ControllerByName(name)
 		if err != nil {
 			return err
 		}
-		one, err := c.store.ControllerByName(actualName)
-		if err != nil {
-			return err
-		}
-		controllers[name] = c.convertControllerForShow(actualName, one)
+		controllers[name] = c.convertControllerForShow(name, one)
 	}
 	return c.out.Write(ctx, controllers)
 }

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -25,7 +25,7 @@ var _ = gc.Suite(&ShowControllerSuite{})
 
 func (s *ShowControllerSuite) TestShowOneControllerOneInStore(c *gc.C) {
 	s.controllersYaml = `controllers:
-  local.mallards:
+  mallards:
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
@@ -34,7 +34,7 @@ func (s *ShowControllerSuite) TestShowOneControllerOneInStore(c *gc.C) {
 	s.createTestClientStore(c)
 
 	s.expectedOutput = `
-local.mallards:
+mallards:
   details:
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
@@ -56,12 +56,12 @@ local.mallards:
   current-account: admin@local
 `[1:]
 
-	s.assertShowController(c, "local.mallards")
+	s.assertShowController(c, "mallards")
 }
 
 func (s *ShowControllerSuite) TestShowControllerWithPasswords(c *gc.C) {
 	s.controllersYaml = `controllers:
-  local.mallards:
+  mallards:
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
@@ -70,7 +70,7 @@ func (s *ShowControllerSuite) TestShowControllerWithPasswords(c *gc.C) {
 	s.createTestClientStore(c)
 
 	s.expectedOutput = `
-local.mallards:
+mallards:
   details:
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
@@ -94,12 +94,12 @@ local.mallards:
   current-account: admin@local
 `[1:]
 
-	s.assertShowController(c, "local.mallards", "--show-passwords")
+	s.assertShowController(c, "mallards", "--show-passwords")
 }
 
 func (s *ShowControllerSuite) TestShowControllerWithBootstrapConfig(c *gc.C) {
 	s.controllersYaml = `controllers:
-  local.mallards:
+  mallards:
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
@@ -107,7 +107,7 @@ func (s *ShowControllerSuite) TestShowControllerWithBootstrapConfig(c *gc.C) {
     region: mallards1
 `
 	store := s.createTestClientStore(c)
-	store.BootstrapConfig["local.mallards"] = jujuclient.BootstrapConfig{
+	store.BootstrapConfig["mallards"] = jujuclient.BootstrapConfig{
 		Config: map[string]interface{}{
 			"name":  "admin",
 			"type":  "maas",
@@ -120,7 +120,7 @@ func (s *ShowControllerSuite) TestShowControllerWithBootstrapConfig(c *gc.C) {
 	}
 
 	s.expectedOutput = `
-local.mallards:
+mallards:
   details:
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
@@ -151,14 +151,14 @@ local.mallards:
     credential: my-credential
 `[1:]
 
-	s.assertShowController(c, "local.mallards")
+	s.assertShowController(c, "mallards")
 }
 
 func (s *ShowControllerSuite) TestShowOneControllerManyInStore(c *gc.C) {
 	s.createTestClientStore(c)
 
 	s.expectedOutput = `
-local.aws-test:
+aws-test:
   details:
     uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
@@ -173,13 +173,13 @@ local.aws-test:
           uuid: ghi
       current-model: admin
 `[1:]
-	s.assertShowController(c, "local.aws-test")
+	s.assertShowController(c, "aws-test")
 }
 
 func (s *ShowControllerSuite) TestShowSomeControllerMoreInStore(c *gc.C) {
 	s.createTestClientStore(c)
 	s.expectedOutput = `
-local.aws-test:
+aws-test:
   details:
     uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
@@ -193,7 +193,7 @@ local.aws-test:
         admin:
           uuid: ghi
       current-model: admin
-local.mark-test-prodstack:
+mark-test-prodstack:
   details:
     uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
@@ -204,25 +204,25 @@ local.mark-test-prodstack:
       user: admin@local
 `[1:]
 
-	s.assertShowController(c, "local.aws-test", "local.mark-test-prodstack")
+	s.assertShowController(c, "aws-test", "mark-test-prodstack")
 }
 
 func (s *ShowControllerSuite) TestShowControllerJsonOne(c *gc.C) {
 	s.createTestClientStore(c)
 
 	s.expectedOutput = `
-{"local.aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}}}
 `[1:]
 
-	s.assertShowController(c, "--format", "json", "local.aws-test")
+	s.assertShowController(c, "--format", "json", "aws-test")
 }
 
 func (s *ShowControllerSuite) TestShowControllerJsonMany(c *gc.C) {
 	s.createTestClientStore(c)
 	s.expectedOutput = `
-{"local.aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}},"local.mark-test-prodstack":{"details":{"uuid":"this-is-a-uuid","api-endpoints":["this-is-one-of-many-api-endpoints"],"ca-cert":"this-is-a-ca-cert","cloud":"prodstack"},"accounts":{"admin@local":{"user":"admin@local"}}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}},"mark-test-prodstack":{"details":{"uuid":"this-is-a-uuid","api-endpoints":["this-is-one-of-many-api-endpoints"],"ca-cert":"this-is-a-ca-cert","cloud":"prodstack"},"accounts":{"admin@local":{"user":"admin@local"}}}}
 `[1:]
-	s.assertShowController(c, "--format", "json", "local.aws-test", "local.mark-test-prodstack")
+	s.assertShowController(c, "--format", "json", "aws-test", "mark-test-prodstack")
 }
 
 func (s *ShowControllerSuite) TestShowControllerReadFromStoreErr(c *gc.C) {
@@ -242,9 +242,9 @@ func (s *ShowControllerSuite) TestShowControllerNoArgs(c *gc.C) {
 	store := s.createTestClientStore(c)
 
 	s.expectedOutput = `
-{"local.aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}}}
 `[1:]
-	store.CurrentControllerName = "local.aws-test"
+	store.CurrentControllerName = "aws-test"
 	s.assertShowController(c, "--format", "json")
 }
 

--- a/cmd/juju/model/grantrevoke_test.go
+++ b/cmd/juju/model/grantrevoke_test.go
@@ -36,7 +36,7 @@ func (s *grantRevokeSuite) SetUpTest(c *gc.C) {
 
 	// Set up the current controller, and write just enough info
 	// so we don't try to refresh
-	controllerName := "local.test-master"
+	controllerName := "test-master"
 
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = controllerName

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -264,8 +264,7 @@ type bootstrapConfigGetter struct {
 }
 
 func (g bootstrapConfigGetter) getBootstrapConfig(controllerName string) (*config.Config, error) {
-	controllerName, err := ResolveControllerName(g.ClientStore, controllerName)
-	if err != nil {
+	if _, err := g.ClientStore.ControllerByName(controllerName); err != nil {
 		return nil, errors.Annotate(err, "resolving controller name")
 	}
 	bootstrapConfig, err := g.BootstrapConfigForController(controllerName)

--- a/cmd/modelcmd/controller_test.go
+++ b/cmd/modelcmd/controller_test.go
@@ -6,7 +6,6 @@ package modelcmd_test
 import (
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -80,53 +79,4 @@ func testEnsureControllerName(c *gc.C, store jujuclient.ClientStore, expect stri
 	cmd, err := initTestControllerCommand(c, store, args...)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmd.ControllerName(), gc.Equals, expect)
-}
-
-type ControllerSuite struct {
-	store jujuclient.ControllerStore
-}
-
-var _ = gc.Suite(&ControllerSuite{})
-
-func (s *ControllerSuite) SetUpTest(c *gc.C) {
-	controller := jujuclient.ControllerDetails{ControllerUUID: "controller-uuid"}
-	anothercontroller := jujuclient.ControllerDetails{ControllerUUID: "another-uuid"}
-	s.store = &jujuclienttesting.MemStore{
-		Controllers: map[string]jujuclient.ControllerDetails{
-			"local.controller":        controller,
-			"anothercontroller":       anothercontroller,
-			"local.anothercontroller": jujuclient.ControllerDetails{},
-		},
-	}
-}
-
-func (s *ControllerSuite) TestLocalNameFound(c *gc.C) {
-	name, err := modelcmd.ResolveControllerName(s.store, "local.controller")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(name, gc.DeepEquals, "local.controller")
-}
-
-func (s *ControllerSuite) TestLocalNameFallback(c *gc.C) {
-	name, err := modelcmd.ResolveControllerName(s.store, "controller")
-	c.Assert(name, gc.DeepEquals, "local.controller")
-	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *ControllerSuite) TestNonLocalController(c *gc.C) {
-	name, err := modelcmd.ResolveControllerName(s.store, "anothercontroller")
-	c.Assert(name, gc.DeepEquals, "anothercontroller")
-	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *ControllerSuite) TestOnlyLocalController(c *gc.C) {
-	name, err := modelcmd.ResolveControllerName(s.store, "local.anothercontroller")
-	c.Assert(name, gc.DeepEquals, "local.anothercontroller")
-	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *ControllerSuite) TestNotFound(c *gc.C) {
-	_, err := modelcmd.ResolveControllerName(s.store, "foo")
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	// We should report on the passed in controller name.
-	c.Assert(err, gc.ErrorMatches, ".* foo .*")
 }

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -149,8 +149,7 @@ func (c *ModelCommandBase) SetModelName(modelName string) error {
 		controllerName = currentController
 	} else {
 		var err error
-		controllerName, err = ResolveControllerName(c.store, controllerName)
-		if err != nil {
+		if _, err = c.store.ControllerByName(controllerName); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -83,7 +83,7 @@ func (cs *NewAPIClientSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *NewAPIClientSuite) bootstrapModel(c *gc.C) (environs.Environ, jujuclient.ClientStore) {
-	const controllerName = "local.my-controller"
+	const controllerName = "my-controller"
 
 	store := jujuclienttesting.NewMemStore()
 
@@ -264,7 +264,7 @@ func (s *NewAPIClientSuite) TestWithSlowInfoConnect(c *gc.C) {
 
 	startTime := time.Now()
 	st, err := newAPIConnectionFromNames(c,
-		"local.my-controller", "admin@local", "only", store, apiOpen,
+		"my-controller", "admin@local", "only", store, apiOpen,
 		modelcmd.NewGetBootstrapConfigFunc(store),
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -290,11 +290,11 @@ func (s *NewAPIClientSuite) TestWithSlowInfoConnect(c *gc.C) {
 
 func setEndpointAddressAndHostname(c *gc.C, store jujuclient.ControllerStore, addr, host string) {
 	// Populate the controller details with known address and hostname.
-	details, err := store.ControllerByName("local.my-controller")
+	details, err := store.ControllerByName("my-controller")
 	c.Assert(err, jc.ErrorIsNil)
 	details.APIEndpoints = []string{addr}
 	details.UnresolvedAPIEndpoints = []string{host}
-	err = store.UpdateController("local.my-controller", *details)
+	err = store.UpdateController("my-controller", *details)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -331,7 +331,7 @@ func (s *NewAPIClientSuite) TestWithSlowConfigConnect(c *gc.C) {
 	done := make(chan struct{})
 	go func() {
 		st, err := newAPIConnectionFromNames(c,
-			"local.my-controller", "admin@local", "only", store, apiOpen,
+			"my-controller", "admin@local", "only", store, apiOpen,
 			modelcmd.NewGetBootstrapConfigFunc(store),
 		)
 		c.Check(err, jc.ErrorIsNil)
@@ -386,7 +386,7 @@ func (s *NewAPIClientSuite) TestBothError(c *gc.C) {
 		}
 		return nil, fmt.Errorf("config connect failed")
 	}
-	st, err := newAPIConnectionFromNames(c, "local.my-controller", "admin@local", "only", store, apiOpen, getBootstrapConfig)
+	st, err := newAPIConnectionFromNames(c, "my-controller", "admin@local", "only", store, apiOpen, getBootstrapConfig)
 	c.Check(err, gc.ErrorMatches, "connecting with bootstrap config: config connect failed")
 	c.Check(st, gc.IsNil)
 }

--- a/jujuclient/bootstrapconfig_test.go
+++ b/jujuclient/bootstrapconfig_test.go
@@ -41,24 +41,24 @@ func (s *BootstrapConfigSuite) TestBootstrapConfigForControllerNotFound(c *gc.C)
 }
 
 func (s *BootstrapConfigSuite) TestBootstrapConfigForController(c *gc.C) {
-	cfg, err := s.store.BootstrapConfigForController("local.aws-test")
+	cfg, err := s.store.BootstrapConfigForController("aws-test")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg, gc.NotNil)
-	c.Assert(*cfg, jc.DeepEquals, testBootstrapConfig["local.aws-test"])
+	c.Assert(*cfg, jc.DeepEquals, testBootstrapConfig["aws-test"])
 }
 
 func (s *BootstrapConfigSuite) TestUpdateBootstrapConfigNewController(c *gc.C) {
-	err := s.store.UpdateBootstrapConfig("new-controller", testBootstrapConfig["local.mallards"])
+	err := s.store.UpdateBootstrapConfig("new-controller", testBootstrapConfig["mallards"])
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := s.store.BootstrapConfigForController("new-controller")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(*cfg, jc.DeepEquals, testBootstrapConfig["local.mallards"])
+	c.Assert(*cfg, jc.DeepEquals, testBootstrapConfig["mallards"])
 }
 
 func (s *BootstrapConfigSuite) TestUpdateBootstrapConfigOverwrites(c *gc.C) {
-	err := s.store.UpdateBootstrapConfig("local.aws-test", testBootstrapConfig["local.mallards"])
+	err := s.store.UpdateBootstrapConfig("aws-test", testBootstrapConfig["mallards"])
 	c.Assert(err, jc.ErrorIsNil)
-	cfg, err := s.store.BootstrapConfigForController("local.aws-test")
+	cfg, err := s.store.BootstrapConfigForController("aws-test")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(*cfg, jc.DeepEquals, testBootstrapConfig["local.mallards"])
+	c.Assert(*cfg, jc.DeepEquals, testBootstrapConfig["mallards"])
 }

--- a/jujuclient/bootstrapconfigfile_test.go
+++ b/jujuclient/bootstrapconfigfile_test.go
@@ -22,7 +22,7 @@ var _ = gc.Suite(&BootstrapConfigFileSuite{})
 
 const testBootstrapConfigYAML = `
 controllers:
-  local.aws-test:
+  aws-test:
     config:
       name: admin
       type: ec2
@@ -30,7 +30,7 @@ controllers:
     cloud: aws
     region: us-east-1
     endpoint: https://us-east-1.amazonaws.com
-  local.mallards:
+  mallards:
     config:
       name: admin
       type: maas
@@ -39,7 +39,7 @@ controllers:
 `
 
 var testBootstrapConfig = map[string]jujuclient.BootstrapConfig{
-	"local.aws-test": {
+	"aws-test": {
 		Config: map[string]interface{}{
 			"type": "ec2",
 			"name": "admin",
@@ -49,7 +49,7 @@ var testBootstrapConfig = map[string]jujuclient.BootstrapConfig{
 		CloudRegion:   "us-east-1",
 		CloudEndpoint: "https://us-east-1.amazonaws.com",
 	},
-	"local.mallards": {
+	"mallards": {
 		Config: map[string]interface{}{
 			"type": "maas",
 			"name": "admin",
@@ -101,7 +101,7 @@ func (s *BootstrapConfigFileSuite) TestParseControllerMetadata(c *gc.C) {
 	for name, _ := range controllers {
 		names = append(names, name)
 	}
-	c.Assert(names, jc.SameContents, []string{"local.mallards", "local.aws-test"})
+	c.Assert(names, jc.SameContents, []string{"mallards", "aws-test"})
 }
 
 func (s *BootstrapConfigFileSuite) TestParseControllerMetadataError(c *gc.C) {

--- a/jujuclient/controllersfile_test.go
+++ b/jujuclient/controllersfile_test.go
@@ -22,26 +22,26 @@ var _ = gc.Suite(&ControllersFileSuite{})
 
 const testControllersYAML = `
 controllers:
-  local.aws-test:
+  aws-test:
     unresolved-api-endpoints: [instance-1-2-4.useast.aws.com]
     uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
     ca-cert: this-is-aws-test-ca-cert
     cloud: aws
     region: us-east-1
-  local.mallards:
+  mallards:
     unresolved-api-endpoints: [maas-1-05.cluster.mallards]
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
     cloud: mallards
-  local.mark-test-prodstack:
+  mark-test-prodstack:
     unresolved-api-endpoints: [vm-23532.prodstack.canonical.com, great.test.server.hostname.co.nz]
     uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
     ca-cert: this-is-a-ca-cert
     cloud: prodstack
-current-controller: local.mallards
+current-controller: mallards
 `
 
 func (s *ControllersFileSuite) TestWriteFile(c *gc.C) {
@@ -74,8 +74,8 @@ func parseControllers(c *gc.C) *jujuclient.Controllers {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// ensure that multiple server hostnames and eapi endpoints are parsed correctly
-	c.Assert(controllers.Controllers["local.mark-test-prodstack"].UnresolvedAPIEndpoints, gc.HasLen, 2)
-	c.Assert(controllers.Controllers["local.mallards"].APIEndpoints, gc.HasLen, 2)
+	c.Assert(controllers.Controllers["mark-test-prodstack"].UnresolvedAPIEndpoints, gc.HasLen, 2)
+	c.Assert(controllers.Controllers["mallards"].APIEndpoints, gc.HasLen, 2)
 	return controllers
 }
 
@@ -93,9 +93,9 @@ func (s *ControllersFileSuite) TestParseControllerMetadata(c *gc.C) {
 		names = append(names, name)
 	}
 	c.Assert(names, jc.SameContents,
-		[]string{"local.mark-test-prodstack", "local.mallards", "local.aws-test"},
+		[]string{"mark-test-prodstack", "mallards", "aws-test"},
 	)
-	c.Assert(controllers.CurrentController, gc.Equals, "local.mallards")
+	c.Assert(controllers.CurrentController, gc.Equals, "mallards")
 }
 
 func (s *ControllersFileSuite) TestParseControllerMetadataError(c *gc.C) {


### PR DESCRIPTION
We now support:
bootstrap --clouds
bootstrap --regions <cloud>

The "local." prefix is also removed from controller names on bootstrap.

This is the first in a series of changes to introduce interactive bootstrap.

Tested using lxd provider. Ran commands such as switch, list-controllers, show-controller etc

(Review request: http://reviews.vapour.ws/r/4972/)