### PR TITLE
state/presence: fix error handling in sync

### DIFF
--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -406,7 +406,7 @@ func (w *Watcher) sync() error {
 	var ping []pingInfo
 	q := bson.D{{"$or", []pingInfo{{DocID: slot}, {DocID: previousSlot}}}}
 	err := pings.Find(q).All(&ping)
-	if err != nil && err == mgo.ErrNotFound {
+	if err != nil && err != mgo.ErrNotFound {
 		return errors.Trace(err)
 	}
 
@@ -467,7 +467,8 @@ func (w *Watcher) sync() error {
 					if err == mgo.ErrNotFound {
 						logger.Tracef("found seq=%d unowned", seq)
 						continue
-					} else if err != nil {
+					}
+					if err != nil {
 						return errors.Trace(err)
 					}
 				}


### PR DESCRIPTION
Updates LP 1588574

While investigating LP 1588574 I came across this piece of error
handling logic that was addedin back in 2012 in 93d52ed7.

The logic was non sensical; if err was not nil, but was MgoNotFound then
wrap it and return it, _otherwise_ continue on. I'm assuming that this
should actually be err was not nil and not MgoNotFound then return the
error.

(Review request: http://reviews.vapour.ws/r/4982/)