### PR TITLE
Migrate subnets

### DIFF
--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -63,6 +63,9 @@ type Model interface {
 	Spaces() []Space
 	AddSpace(SpaceArgs) Space
 
+	Subnets() []Subnet
+	AddSubnet(SubnetArgs) Subnet
+
 	Sequences() map[string]int
 	SetSequence(name string, value int)
 
@@ -316,4 +319,15 @@ type Space interface {
 	Name() string
 	Public() bool
 	ProviderID() string
+}
+
+// Subnet represents a network subnet.
+type Subnet interface {
+	ProviderId() string
+	CIDR() string
+	VLANTag() int
+	AvailabilityZone() string
+	SpaceName() string
+	AllocatableIPHigh() string
+	AllocatableIPLow() string
 }

--- a/core/description/model_test.go
+++ b/core/description/model_test.go
@@ -342,3 +342,19 @@ func (s *ModelSerializationSuite) TestSpaces(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(model.Spaces(), jc.DeepEquals, spaces)
 }
+
+func (s *ModelSerializationSuite) TestSubnets(c *gc.C) {
+	initial := NewModel(ModelArgs{Owner: names.NewUserTag("owner")})
+	subnet := initial.AddSubnet(SubnetArgs{CIDR: "10.0.0.0/24"})
+	c.Assert(subnet.CIDR(), gc.Equals, "10.0.0.0/24")
+	subnets := initial.Subnets()
+	c.Assert(subnets, gc.HasLen, 1)
+	c.Assert(subnets[0], jc.DeepEquals, subnet)
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := Deserialize(bytes)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(model.Subnets(), jc.DeepEquals, subnets)
+}

--- a/core/description/subnet.go
+++ b/core/description/subnet.go
@@ -1,0 +1,166 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+)
+
+type subnets struct {
+	Version  int       `yaml:"version"`
+	Subnets_ []*subnet `yaml:"subnets"`
+}
+
+type subnet struct {
+	ProviderId_ string `yaml:"provider-id,omitempty"`
+	CIDR_       string `yaml:"cidr"`
+	VLANTag_    int    `yaml:"vlantag"`
+
+	AvailabilityZone_ string `yaml:"availabilityzone"`
+	SpaceName_        string `yaml:"spacename"`
+
+	// These will be deprecated once the address allocation strategy for
+	// EC2 is changed. They are unused already on MAAS.
+	AllocatableIPHigh_ string `yaml:"allocatableiphigh,omitempty"`
+	AllocatableIPLow_  string `yaml:"allocatableiplow,omitempty"`
+}
+
+// SubnetArgs is an argument struct used to create a
+// new internal subnet type that supports the Subnet interface.
+type SubnetArgs struct {
+	ProviderId       string
+	CIDR             string
+	VLANTag          int
+	AvailabilityZone string
+	SpaceName        string
+
+	// These will be deprecated once the address allocation strategy for
+	// EC2 is changed. They are unused already on MAAS.
+	AllocatableIPHigh string
+	AllocatableIPLow  string
+}
+
+func newSubnet(args SubnetArgs) *subnet {
+	return &subnet{
+		ProviderId_:        string(args.ProviderId),
+		SpaceName_:         args.SpaceName,
+		CIDR_:              args.CIDR,
+		VLANTag_:           args.VLANTag,
+		AvailabilityZone_:  args.AvailabilityZone,
+		AllocatableIPHigh_: args.AllocatableIPHigh,
+		AllocatableIPLow_:  args.AllocatableIPLow,
+	}
+}
+
+// ProviderId implements Subnet.
+func (s *subnet) ProviderId() string {
+	return s.ProviderId_
+}
+
+// SpaceName implements Subnet.
+func (s *subnet) SpaceName() string {
+	return s.SpaceName_
+}
+
+// CIDR implements Subnet.
+func (s *subnet) CIDR() string {
+	return s.CIDR_
+}
+
+// VLANTag implements Subnet.
+func (s *subnet) VLANTag() int {
+	return s.VLANTag_
+}
+
+// AvailabilityZone implements Subnet.
+func (s *subnet) AvailabilityZone() string {
+	return s.AvailabilityZone_
+}
+
+// AllocatableIPHigh implements Subnet.
+func (s *subnet) AllocatableIPHigh() string {
+	return s.AllocatableIPHigh_
+}
+
+// AllocatableIPLow implements Subnet.
+func (s *subnet) AllocatableIPLow() string {
+	return s.AllocatableIPLow_
+}
+
+func importSubnets(source map[string]interface{}) ([]*subnet, error) {
+	checker := versionedChecker("subnets")
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "subnets version schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+
+	version := int(valid["version"].(int64))
+	importFunc, ok := subnetDeserializationFuncs[version]
+	if !ok {
+		return nil, errors.NotValidf("version %d", version)
+	}
+	sourceList := valid["subnets"].([]interface{})
+	return importSubnetList(sourceList, importFunc)
+}
+
+func importSubnetList(sourceList []interface{}, importFunc subnetDeserializationFunc) ([]*subnet, error) {
+	result := make([]*subnet, 0, len(sourceList))
+	for i, value := range sourceList {
+		source, ok := value.(map[string]interface{})
+		if !ok {
+			return nil, errors.Errorf("unexpected value for subnet %d, %T", i, value)
+		}
+		subnet, err := importFunc(source)
+		if err != nil {
+			return nil, errors.Annotatef(err, "subnet %d", i)
+		}
+		result = append(result, subnet)
+	}
+	return result, nil
+}
+
+type subnetDeserializationFunc func(map[string]interface{}) (*subnet, error)
+
+var subnetDeserializationFuncs = map[int]subnetDeserializationFunc{
+	1: importSubnetV1,
+}
+
+func importSubnetV1(source map[string]interface{}) (*subnet, error) {
+	fields := schema.Fields{
+		"cidr":              schema.String(),
+		"provider-id":       schema.String(),
+		"vlantag":           schema.Int(),
+		"spacename":         schema.String(),
+		"availabilityzone":  schema.String(),
+		"allocatableiphigh": schema.String(),
+		"allocatableiplow":  schema.String(),
+	}
+
+	defaults := schema.Defaults{
+		"provider-id":       "",
+		"allocatableiphigh": "",
+		"allocatableiplow":  "",
+	}
+	checker := schema.FieldMap(fields, defaults)
+
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "subnet v1 schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+
+	// From here we know that the map returned from the schema coercion
+	// contains fields of the right type.
+	return &subnet{
+		CIDR_:              valid["cidr"].(string),
+		ProviderId_:        valid["provider-id"].(string),
+		VLANTag_:           int(valid["vlantag"].(int64)),
+		SpaceName_:         valid["spacename"].(string),
+		AvailabilityZone_:  valid["availabilityzone"].(string),
+		AllocatableIPHigh_: valid["allocatableiphigh"].(string),
+		AllocatableIPLow_:  valid["allocatableiplow"].(string),
+	}, nil
+}

--- a/core/description/subnet_test.go
+++ b/core/description/subnet_test.go
@@ -1,0 +1,78 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+)
+
+type SubnetSerializationSuite struct {
+	SliceSerializationSuite
+}
+
+var _ = gc.Suite(&SubnetSerializationSuite{})
+
+func (s *SubnetSerializationSuite) SetUpTest(c *gc.C) {
+	s.SliceSerializationSuite.SetUpTest(c)
+	s.importName = "subnets"
+	s.sliceName = "subnets"
+	s.importFunc = func(m map[string]interface{}) (interface{}, error) {
+		return importSubnets(m)
+	}
+	s.testFields = func(m map[string]interface{}) {
+		m["subnets"] = []interface{}{}
+	}
+}
+
+func (s *SubnetSerializationSuite) TestNewSubnet(c *gc.C) {
+	args := SubnetArgs{
+		CIDR:              "10.0.0.0/24",
+		ProviderId:        "magic",
+		VLANTag:           64,
+		SpaceName:         "foo",
+		AvailabilityZone:  "bar",
+		AllocatableIPHigh: "10.0.0.255",
+		AllocatableIPLow:  "10.0.0.0",
+	}
+	subnet := newSubnet(args)
+	c.Assert(subnet.CIDR(), gc.Equals, args.CIDR)
+	c.Assert(subnet.ProviderId(), gc.Equals, args.ProviderId)
+	c.Assert(subnet.VLANTag(), gc.Equals, args.VLANTag)
+	c.Assert(subnet.SpaceName(), gc.Equals, args.SpaceName)
+	c.Assert(subnet.AvailabilityZone(), gc.Equals, args.AvailabilityZone)
+	c.Assert(subnet.AllocatableIPHigh(), gc.Equals, args.AllocatableIPHigh)
+	c.Assert(subnet.AllocatableIPLow(), gc.Equals, args.AllocatableIPLow)
+}
+
+func (s *SubnetSerializationSuite) TestParsingSerializedData(c *gc.C) {
+	initial := subnets{
+		Version: 1,
+		Subnets_: []*subnet{
+			newSubnet(SubnetArgs{
+				CIDR:              "10.0.0.0/24",
+				ProviderId:        "magic",
+				VLANTag:           64,
+				SpaceName:         "foo",
+				AvailabilityZone:  "bar",
+				AllocatableIPHigh: "10.0.0.255",
+				AllocatableIPLow:  "10.0.0.0",
+			}),
+			newSubnet(SubnetArgs{CIDR: "10.0.1.0/24"}),
+		},
+	}
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	subnets, err := importSubnets(source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(subnets, jc.DeepEquals, initial.Subnets_)
+}

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -87,6 +87,9 @@ func (st *State) Export() (description.Model, error) {
 	if err := export.spaces(); err != nil {
 		return nil, errors.Trace(err)
 	}
+	if err := export.subnets(); err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	if err := export.model.Validate(); err != nil {
 		return nil, errors.Trace(err)
@@ -645,6 +648,27 @@ func (e *exporter) spaces() error {
 			Name:       space.Name(),
 			Public:     space.IsPublic(),
 			ProviderID: string(space.ProviderId()),
+		})
+	}
+	return nil
+}
+
+func (e *exporter) subnets() error {
+	subnets, err := e.st.AllSubnets()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	e.logger.Debugf("read %d subnets", len(subnets))
+
+	for _, subnet := range subnets {
+		e.model.AddSubnet(description.SubnetArgs{
+			CIDR:              subnet.CIDR(),
+			ProviderId:        string(subnet.ProviderId()),
+			VLANTag:           subnet.VLANTag(),
+			AvailabilityZone:  subnet.AvailabilityZone(),
+			SpaceName:         subnet.SpaceName(),
+			AllocatableIPHigh: subnet.AllocatableIPHigh(),
+			AllocatableIPLow:  subnet.AllocatableIPLow(),
 		})
 	}
 	return nil

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -499,6 +499,29 @@ func (s *MigrationExportSuite) TestMultipleSpaces(c *gc.C) {
 	c.Assert(model.Spaces(), gc.HasLen, 3)
 }
 
+func (s *MigrationExportSuite) TestSubnets(c *gc.C) {
+	_, err := s.State.AddSubnet(state.SubnetInfo{
+		CIDR:             "10.0.0.0/24",
+		ProviderId:       network.Id("foo"),
+		VLANTag:          64,
+		AvailabilityZone: "bar",
+		SpaceName:        "bam",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := s.State.Export()
+	c.Assert(err, jc.ErrorIsNil)
+
+	subnets := model.Subnets()
+	c.Assert(subnets, gc.HasLen, 1)
+	subnet := subnets[0]
+	c.Assert(subnet.CIDR(), gc.Equals, "10.0.0.0/24")
+	c.Assert(subnet.ProviderId(), gc.Equals, "foo")
+	c.Assert(subnet.VLANTag(), gc.Equals, 64)
+	c.Assert(subnet.AvailabilityZone(), gc.Equals, "bar")
+	c.Assert(subnet.SpaceName(), gc.Equals, "bam")
+}
+
 type goodToken struct{}
 
 // Check implements leadership.Token

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -98,6 +98,9 @@ func (st *State) Import(model description.Model) (_ *Model, _ *State, err error)
 	if err := restore.spaces(); err != nil {
 		return nil, nil, errors.Annotate(err, "spaces")
 	}
+	if err := restore.subnets(); err != nil {
+		return nil, nil, errors.Annotate(err, "subnets")
+	}
 
 	// NOTE: at the end of the import make sure that the mode of the model
 	// is set to "imported" not "active" (or whatever we call it). This way
@@ -842,6 +845,53 @@ func (i *importer) spaces() error {
 	}
 
 	i.logger.Debugf("importing spaces succeeded")
+	return nil
+}
+
+func (i *importer) subnets() error {
+	i.logger.Debugf("importing subnets")
+	for _, subnet := range i.model.Subnets() {
+		err := i.addSubnet(SubnetInfo{
+			CIDR:              subnet.CIDR(),
+			ProviderId:        network.Id(subnet.ProviderId()),
+			VLANTag:           subnet.VLANTag(),
+			AvailabilityZone:  subnet.AvailabilityZone(),
+			SpaceName:         subnet.SpaceName(),
+			AllocatableIPHigh: subnet.AllocatableIPHigh(),
+			AllocatableIPLow:  subnet.AllocatableIPLow(),
+		})
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	i.logger.Debugf("importing subnets succeeded")
+	return nil
+}
+
+func (i *importer) addSubnet(args SubnetInfo) error {
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		subnet, err := i.st.newSubnetFromArgs(args)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		ops := i.st.addSubnetOps(args)
+		if attempt != 0 {
+			if _, err = i.st.Subnet(args.CIDR); err == nil {
+				return nil, errors.AlreadyExistsf("subnet %q", args.CIDR)
+			}
+			if err := subnet.Refresh(); err != nil {
+				if errors.IsNotFound(err) {
+					return nil, errors.Errorf("ProviderId %q not unique", args.ProviderId)
+				}
+				return nil, errors.Trace(err)
+			}
+		}
+		return ops, nil
+	}
+	err := i.st.run(buildTxn)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	return nil
 }
 

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -533,6 +533,31 @@ func (s *MigrationImportSuite) assertDestroyModelAdvancesLife(c *gc.C, m *state.
 	c.Assert(m.Life(), gc.Equals, life)
 }
 
+func (s *MigrationImportSuite) TestSubnets(c *gc.C) {
+	original, err := s.State.AddSubnet(state.SubnetInfo{
+		CIDR:             "10.0.0.0/24",
+		ProviderId:       network.Id("foo"),
+		VLANTag:          64,
+		AvailabilityZone: "bar",
+		SpaceName:        "bam",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, newSt := s.importModel(c)
+	defer func() {
+		c.Assert(newSt.Close(), jc.ErrorIsNil)
+	}()
+
+	subnet, err := newSt.Subnet(original.CIDR())
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(subnet.CIDR(), gc.Equals, "10.0.0.0/24")
+	c.Assert(subnet.ProviderId(), gc.Equals, network.Id("foo"))
+	c.Assert(subnet.VLANTag(), gc.Equals, 64)
+	c.Assert(subnet.AvailabilityZone(), gc.Equals, "bar")
+	c.Assert(subnet.SpaceName(), gc.Equals, "bam")
+}
+
 // newModel replaces the uuid and name of the config attributes so we
 // can use all the other data to validate imports. An owner and name of the
 // model are unique together in a controller.

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -48,6 +48,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 
 		// networking
 		spacesC,
+		subnetsC,
 
 		// storage
 		blockDevicesC,
@@ -151,7 +152,6 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		providerIDsC,
 		linkLayerDevicesC,
 		linkLayerDevicesRefsC,
-		subnetsC,
 
 		// actions
 		actionsC,
@@ -558,6 +558,31 @@ func (s *MigrationSuite) TestBlockDeviceFields(c *gc.C) {
 		"MountPoint",
 	)
 	s.AssertExportedFields(c, BlockDeviceInfo{}, migrated)
+}
+
+func (s *MigrationSuite) TestSubnetDocFields(c *gc.C) {
+	ignored := set.NewStrings(
+		// DocID is the env + name
+		"DocID",
+		// ModelUUID shouldn't be exported, and is inherited
+		// from the model definition.
+		"ModelUUID",
+		// Always alive, not explicitly exported.
+		"Life",
+
+		// Currently unused (never set or exposed).
+		"IsPublic",
+	)
+	migrated := set.NewStrings(
+		"CIDR",
+		"VLANTag",
+		"SpaceName",
+		"ProviderId",
+		"AvailabilityZone",
+		"AllocatableIPHigh",
+		"AllocatableIPLow",
+	)
+	s.AssertExportedFields(c, subnetDoc{}, migrated.Union(ignored))
 }
 
 func (s *MigrationSuite) AssertExportedFields(c *gc.C, doc interface{}, fields set.Strings) {

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -59,7 +59,9 @@ type subnetDoc struct {
 	AllocatableIPLow  string `bson:"allocatableiplow,omitempty"`
 	VLANTag           int    `bson:"vlantag,omitempty"`
 	AvailabilityZone  string `bson:"availabilityzone,omitempty"`
-	IsPublic          bool   `bson:"is-public,omitempty"`
+	// TODO: add IsPublic to SubnetArgs, add an IsPublic method and add
+	// IsPublic to migration import/export.
+	IsPublic bool `bson:"is-public,omitempty"`
 	// TODO(dooferlad 2015-08-03): add an upgrade step to insert IsPublic=false
 	SpaceName string `bson:"space-name,omitempty"`
 }
@@ -365,38 +367,13 @@ var pickAddress = func(low, high uint32, allocated map[uint32]bool) uint32 {
 func (st *State) AddSubnet(args SubnetInfo) (subnet *Subnet, err error) {
 	defer errors.DeferredAnnotatef(&err, "adding subnet %q", args.CIDR)
 
-	subnetID := st.docID(args.CIDR)
-	subDoc := subnetDoc{
-		DocID:             subnetID,
-		ModelUUID:         st.ModelUUID(),
-		Life:              Alive,
-		CIDR:              args.CIDR,
-		VLANTag:           args.VLANTag,
-		ProviderId:        string(args.ProviderId),
-		AllocatableIPHigh: args.AllocatableIPHigh,
-		AllocatableIPLow:  args.AllocatableIPLow,
-		AvailabilityZone:  args.AvailabilityZone,
-		SpaceName:         args.SpaceName,
-	}
-	subnet = &Subnet{doc: subDoc, st: st}
-	err = subnet.Validate()
+	subnet, err = st.newSubnetFromArgs(args)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
-
+	ops := st.addSubnetOps(args)
+	ops = append(ops, assertModelActiveOp(st.ModelUUID()))
 	buildTxn := func(attempt int) ([]txn.Op, error) {
-		ops := []txn.Op{
-			assertModelActiveOp(st.ModelUUID()),
-			{
-				C:      subnetsC,
-				Id:     subnetID,
-				Assert: txn.DocMissing,
-				Insert: subDoc,
-			},
-		}
-		if args.ProviderId != "" {
-			ops = append(ops, st.networkEntityGlobalKeyOp("subnet", args.ProviderId))
-		}
 
 		if attempt != 0 {
 			if err := checkModelActive(st); err != nil {
@@ -419,6 +396,56 @@ func (st *State) AddSubnet(args SubnetInfo) (subnet *Subnet, err error) {
 		return nil, errors.Trace(err)
 	}
 	return subnet, nil
+}
+
+func (st *State) newSubnetFromArgs(args SubnetInfo) (*Subnet, error) {
+	subnetID := st.docID(args.CIDR)
+	subDoc := subnetDoc{
+		DocID:             subnetID,
+		ModelUUID:         st.ModelUUID(),
+		Life:              Alive,
+		CIDR:              args.CIDR,
+		VLANTag:           args.VLANTag,
+		ProviderId:        string(args.ProviderId),
+		AllocatableIPHigh: args.AllocatableIPHigh,
+		AllocatableIPLow:  args.AllocatableIPLow,
+		AvailabilityZone:  args.AvailabilityZone,
+		SpaceName:         args.SpaceName,
+	}
+	subnet := &Subnet{doc: subDoc, st: st}
+	err := subnet.Validate()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return subnet, nil
+}
+
+func (st *State) addSubnetOps(args SubnetInfo) []txn.Op {
+	subnetID := st.docID(args.CIDR)
+	subDoc := subnetDoc{
+		DocID:             subnetID,
+		ModelUUID:         st.ModelUUID(),
+		Life:              Alive,
+		CIDR:              args.CIDR,
+		VLANTag:           args.VLANTag,
+		ProviderId:        string(args.ProviderId),
+		AllocatableIPHigh: args.AllocatableIPHigh,
+		AllocatableIPLow:  args.AllocatableIPLow,
+		AvailabilityZone:  args.AvailabilityZone,
+		SpaceName:         args.SpaceName,
+	}
+	ops := []txn.Op{
+		{
+			C:      subnetsC,
+			Id:     subnetID,
+			Assert: txn.DocMissing,
+			Insert: subDoc,
+		},
+	}
+	if args.ProviderId != "" {
+		ops = append(ops, st.networkEntityGlobalKeyOp("subnet", args.ProviderId))
+	}
+	return ops
 }
 
 // Subnet returns the subnet specified by the cidr.


### PR DESCRIPTION
Add subnets to the core/description model, and add the methods to export and import subnets.