### PR TITLE
state/presence: stop watchers/pingers before TearDownTest

### DIFF
--- a/state/package_test.go
+++ b/state/package_test.go
@@ -6,9 +6,8 @@ package state_test
 import (
 	"testing"
 
-	"github.com/juju/utils/os"
-
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/utils/os"
 )
 
 func TestPackage(t *testing.T) {

--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -696,6 +696,13 @@ func (p *Pinger) prepare() error {
 // sequence in use by the pinger.
 func (p *Pinger) ping() (err error) {
 	logger.Tracef("pinging %q with seq=%d", p.beingKey, p.beingSeq)
+	defer func() {
+		// If the session is killed from underneath us, it panics when we
+		// try to copy it, so deal with that here.
+		if v := recover(); v != nil {
+			err = fmt.Errorf("%v", v)
+		}
+	}()
 	session := p.pings.Database.Session.Copy()
 	defer session.Close()
 	if p.delta == 0 {

--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -696,13 +696,6 @@ func (p *Pinger) prepare() error {
 // sequence in use by the pinger.
 func (p *Pinger) ping() (err error) {
 	logger.Tracef("pinging %q with seq=%d", p.beingKey, p.beingSeq)
-	defer func() {
-		// If the session is killed from underneath us, it panics when we
-		// try to copy it, so deal with that here.
-		if v := recover(); v != nil {
-			err = fmt.Errorf("%v", v)
-		}
-	}()
 	session := p.pings.Database.Session.Copy()
 	defer session.Close()
 	if p.delta == 0 {


### PR DESCRIPTION
Fixes LP 1588574

The `panic: session already closed` comes from a watcher or pinger that
is still running when the test case returns to TearDownTest. This
happens because while we always call w.Stop in a defer, w.Stop does not
actually stop the worker, it just asks it to stop.

To ensure the worker is stopped, introduce a new function `assertStopped`
which stops a worker and waits until it reports stopped.  This method should
be used in favor of defer w.Stop() because you _must_ ensure that all workers
that share a mongo connection (which is _all_ of them) have stopped, and thus
are no longer using a mgo session before `TearDownTest` shuts down the connection.

Because this pattern of stopping and not waiting was common to both the
pinter and watcher tests, and is now resolved, we can remove the
`recover` in the `ping()` method.

(Review request: http://reviews.vapour.ws/r/4990/)