### PR TITLE
Clarify password creation in register command

### DIFF
--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -351,7 +351,7 @@ func (c *registerCommand) secretKeyLogin(addrs []string, request params.SecretKe
 }
 
 func (c *registerCommand) promptNewPassword(stderr io.Writer, stdin io.Reader) (string, error) {
-	password, err := c.readPassword("Enter password: ", stderr, stdin)
+	password, err := c.readPassword("Enter a new password: ", stderr, stdin)
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -136,7 +136,7 @@ func (s *RegisterSuite) TestRegister(c *gc.C) {
 	stderr := testing.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `
 Please set a name for this controller: 
-Enter password: 
+Enter a new password: 
 Confirm password: 
 
 Welcome, bob. You are now logged into "controller-name".
@@ -184,7 +184,7 @@ func (s *RegisterSuite) TestRegisterMultipleModels(c *gc.C) {
 	stderr := testing.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `
 Please set a name for this controller: 
-Enter password: 
+Enter a new password: 
 Confirm password: 
 
 Welcome, bob. You are now logged into "controller-name".

--- a/featuretests/cmd_juju_register_test.go
+++ b/featuretests/cmd_juju_register_test.go
@@ -61,7 +61,7 @@ Please send this command to bob:
 	c.Check(testing.Stdout(context), gc.Equals, "")
 	c.Check(testing.Stderr(context), gc.Equals, `
 Please set a name for this controller: 
-Enter password: 
+Enter a new password: 
 Confirm password: 
 
 Welcome, bob. You are now logged into "bob-controller".


### PR DESCRIPTION
Fixes lp#1576318

QA steps:

  * `juju add-user <username>` to get a registration command and argument
  * When running the `juju register` command, note the "Enter a new password:" prompt

(Review request: http://reviews.vapour.ws/r/4993/)