### PR TITLE
Fixes lp#1589061 - feedback when no known controller or model specified for commands. 

### DIFF
--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -21,8 +21,8 @@ var (
 	// explicitly specified, and there is no default controller.
 	ErrNoControllerSpecified = errors.New(`no controller
 
-Please create a new controller using "juju bootstrap" or 
-use "juju switch" to set the current controller/model.
+Please either create your own new controller using "juju bootstrap" or
+connect to another controller that you have been given access to using "juju register".
 `)
 	// ErrNotLoggedInToController is returned by commands that operate on
 	// a controller if there is no current controller, no controller has been

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -160,7 +160,14 @@ func (c *ControllerCommandBase) NewUserManagerAPIClient() (*usermanager.Client, 
 // through this API connection.
 func (c *ControllerCommandBase) NewAPIRoot() (api.Connection, error) {
 	if c.controllerName == "" {
-		return nil, errors.Trace(ErrNoControllerSpecified)
+		controllers, err := c.store.AllControllers()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if len(controllers) == 0 {
+			return nil, errors.Trace(ErrNoControllerSpecified)
+		}
+		return nil, errors.Trace(ErrNotLoggedInToController)
 	}
 	if c.accountName == "" {
 		return nil, errors.Trace(ErrNoAccountSpecified)

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -16,10 +16,10 @@ import (
 )
 
 var (
-	// ErrNoControllerSpecified is returned by commands that operate on
+	// ErrNoControllersDefined is returned by commands that operate on
 	// a controller if there is no current controller, no controller has been
 	// explicitly specified, and there is no default controller.
-	ErrNoControllerSpecified = errors.New(`no controller
+	ErrNoControllersDefined = errors.New(`no controller
 
 Please either create your own new controller using "juju bootstrap" or
 connect to another controller that you have been given access to using "juju register".
@@ -165,7 +165,7 @@ func (c *ControllerCommandBase) NewAPIRoot() (api.Connection, error) {
 			return nil, errors.Trace(err)
 		}
 		if len(controllers) == 0 {
-			return nil, errors.Trace(ErrNoControllerSpecified)
+			return nil, errors.Trace(ErrNoControllersDefined)
 		}
 		return nil, errors.Trace(ErrNotLoggedInToController)
 	}
@@ -268,7 +268,7 @@ func (w *sysCommandWrapper) Init(args []string) error {
 		if w.controllerName == "" && w.useDefaultControllerName {
 			currentController, err := store.CurrentController()
 			if errors.IsNotFound(err) {
-				return ErrNoControllerSpecified
+				return ErrNoControllersDefined
 			}
 			if err != nil {
 				return errors.Trace(err)
@@ -276,7 +276,7 @@ func (w *sysCommandWrapper) Init(args []string) error {
 			w.controllerName = currentController
 		}
 		if w.controllerName == "" && !w.useDefaultControllerName {
-			return ErrNoControllerSpecified
+			return ErrNoControllersDefined
 		}
 	}
 	if w.controllerName != "" {

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -19,11 +19,19 @@ var (
 	// ErrNoControllerSpecified is returned by commands that operate on
 	// a controller if there is no current controller, no controller has been
 	// explicitly specified, and there is no default controller.
-	ErrNoControllerSpecified = errors.New(`no controller specified
+	ErrNoControllerSpecified = errors.New(`no controller
 
-There is no current controller. Please use "juju switch" to
-set the current controller/model, or create a new controller
-using "juju bootstrap".
+Please create a new controller using "juju bootstrap" or 
+use "juju switch" to set the current controller/model.
+`)
+	// ErrNotLoggedInToController is returned by commands that operate on
+	// a controller if there is no current controller, no controller has been
+	// explicitly specified, and there is no default controller but there are
+	// controllers that client knows about, i.e. the user needs to log in to one of them.
+	ErrNotLoggedInToController = errors.New(`not logged in
+
+Please use "juju controllers" to view all controllers available to you. 
+You can login into an existing controller using "juju login -c <controller>".
 `)
 
 	// ErrNoAccountSpecified is returned by commands that operate on a

--- a/cmd/modelcmd/controller_test.go
+++ b/cmd/modelcmd/controller_test.go
@@ -24,7 +24,7 @@ var _ = gc.Suite(&ControllerCommandSuite{})
 
 func (s *ControllerCommandSuite) TestControllerCommandNoneSpecified(c *gc.C) {
 	_, err := initTestControllerCommand(c, nil)
-	c.Assert(err, gc.ErrorMatches, "no controller specified(.|\n)*")
+	c.Assert(err, gc.ErrorMatches, "no controller(.|\n)*")
 }
 
 func (s *ControllerCommandSuite) TestControllerCommandInitCurrentController(c *gc.C) {

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -203,7 +203,7 @@ func (c *ModelCommandBase) NewAPIRoot() (api.Connection, error) {
 			return nil, errors.Trace(err)
 		}
 		if len(controllers) == 0 {
-			return nil, errors.Trace(ErrNoControllerSpecified)
+			return nil, errors.Trace(ErrNoControllersDefined)
 		}
 		return nil, errors.Trace(ErrNotLoggedInToController)
 	}

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -24,12 +24,11 @@ var logger = loggo.GetLogger("juju.cmd.modelcmd")
 // ErrNoModelSpecified is returned by commands that operate on
 // an environment if there is no current model, no model
 // has been explicitly specified, and there is no default model.
-var ErrNoModelSpecified = errors.New(`no model specified
+var ErrNoModelSpecified = errors.New(`no model in focus
 
-There is no current model specified for the current controller,
-and none specified on the command line. Please use "juju switch"
-to set the current model, or specify a model on the command line
-using the "-m" flag.
+Please use "juju models" to see models available to you.
+You can set current model by running "juju switch"
+or specify any other model on the command line using the "-m" flag.
 `)
 
 // GetCurrentModel returns the name of the current Juju model.
@@ -199,6 +198,14 @@ func (c *ModelCommandBase) NewAPIRoot() (api.Connection, error) {
 	// We want to be able to specify the environment in a number of ways, one of
 	// which is the connection name on the client machine.
 	if c.controllerName == "" {
+		controllers, err := c.store.AllControllers()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if len(controllers) > 0 {
+			return nil, ErrNotLoggedInToController
+		}
+
 		return nil, errors.Trace(ErrNoControllerSpecified)
 	}
 	if c.modelName == "" {

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -202,11 +202,10 @@ func (c *ModelCommandBase) NewAPIRoot() (api.Connection, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		if len(controllers) > 0 {
-			return nil, ErrNotLoggedInToController
+		if len(controllers) == 0 {
+			return nil, errors.Trace(ErrNoControllerSpecified)
 		}
-
-		return nil, errors.Trace(ErrNoControllerSpecified)
+		return nil, errors.Trace(ErrNotLoggedInToController)
 	}
 	if c.modelName == "" {
 		return nil, errors.Trace(ErrNoModelSpecified)


### PR DESCRIPTION
The bug refers to output specific to juju status command.

This PR ensures that all commands that require controller or model have similar output.

This is proposed now for early feedback. I am working on making sure that tests are aligned accordingly.

(Review request: http://reviews.vapour.ws/r/4997/)