### PR TITLE
Migration of charm binaries

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/juju/errors"
@@ -358,10 +359,15 @@ func (c *Client) AddLocalCharm(curl *charm.URL, ch charm.Charm) (*charm.URL, err
 
 // UploadCharm sends the content to the API server using an HTTP post.
 func (c *Client) UploadCharm(curl *charm.URL, content io.ReadSeeker) (*charm.URL, error) {
-	endpoint := "/charms?series=" + curl.Series
+	args := url.Values{}
+	args.Add("series", curl.Series)
+	args.Add("schema", curl.Schema)
+	args.Add("revision", strconv.Itoa(curl.Revision))
+	apiURI := url.URL{Path: "/charms", RawQuery: args.Encode()}
+
 	contentType := "application/zip"
 	var resp params.CharmsResponse
-	if err := c.httpPost(content, endpoint, contentType, &resp); err != nil {
+	if err := c.httpPost(content, apiURI.String(), contentType, &resp); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/api/client_macaroon_test.go
+++ b/api/client_macaroon_test.go
@@ -51,7 +51,7 @@ func (s *clientMacaroonSuite) TestAddLocalCharmWithFailedDischarge(c *gc.C) {
 		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),
 	)
 	savedURL, err := s.client.AddLocalCharm(curl, charmArchive)
-	c.Assert(err, gc.ErrorMatches, `POST https://.*/model/deadbeef-0bad-400d-8000-4b1d0d06f00d/charms\?series=quantal: cannot get discharge from "https://.*": third party refused discharge: cannot discharge: login denied by discharger`)
+	c.Assert(err, gc.ErrorMatches, `POST https://.+: cannot get discharge from "https://.*": third party refused discharge: cannot discharge: login denied by discharger`)
 	c.Assert(savedURL, gc.IsNil)
 }
 
@@ -76,5 +76,5 @@ func (s *clientMacaroonSuite) TestAddLocalCharmUnauthorized(c *gc.C) {
 	)
 	// Upload an archive with its original revision.
 	_, err := s.client.AddLocalCharm(curl, charmArchive)
-	c.Assert(err, gc.ErrorMatches, `POST https://.*/model/deadbeef-0bad-400d-8000-4b1d0d06f00d/charms\?series=quantal: invalid entity name or password`)
+	c.Assert(err, gc.ErrorMatches, `POST https://.+: invalid entity name or password`)
 }

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -168,7 +168,7 @@ func (s *clientSuite) TestAddLocalCharmError(c *gc.C) {
 	)
 
 	_, err := client.AddLocalCharm(curl, charmArchive)
-	c.Assert(err, gc.ErrorMatches, `POST http://.*/model/deadbeef-0bad-400d-8000-4b1d0d06f00d/charms\?series=quantal: the POST method is not allowed`)
+	c.Assert(err, gc.ErrorMatches, `POST http://.+: the POST method is not allowed`)
 }
 
 func (s *clientSuite) TestMinVersionLocalCharm(c *gc.C) {

--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -103,14 +103,15 @@ func (c *Client) SetPhase(phase migration.Phase) error {
 }
 
 // Export returns a serialized representation of the model associated
-// with the API connection.
-func (c *Client) Export() ([]byte, error) {
+// with the API connection. The charms used by the model are also
+// returned.
+func (c *Client) Export() (params.SerializedModel, error) {
 	var serialized params.SerializedModel
 	err := c.caller.FacadeCall("Export", nil, &serialized)
 	if err != nil {
-		return nil, err
+		return params.SerializedModel{}, err
 	}
-	return serialized.Bytes, nil
+	return serialized, nil
 }
 
 // Reap removes the documents for the model associated with the API

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -150,19 +150,23 @@ func (s *ClientSuite) TestSetPhaseError(c *gc.C) {
 
 func (s *ClientSuite) TestExport(c *gc.C) {
 	var stub jujutesting.Stub
+	serialized := params.SerializedModel{
+		Bytes:  []byte("foo"),
+		Charms: []string{"cs:foo-1"},
+	}
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		stub.AddCall(objType+"."+request, id, arg)
 		out := result.(*params.SerializedModel)
-		*out = params.SerializedModel{Bytes: []byte("foo")}
+		*out = serialized
 		return nil
 	})
 	client := migrationmaster.NewClient(apiCaller)
-	bytes, err := client.Export()
+	out, err := client.Export()
 	c.Assert(err, jc.ErrorIsNil)
 	stub.CheckCalls(c, []jujutesting.StubCall{
 		{"MigrationMaster.Export", []interface{}{"", nil}},
 	})
-	c.Assert(string(bytes), gc.Equals, "foo")
+	c.Assert(out, gc.DeepEquals, serialized)
 }
 
 func (s *ClientSuite) TestExportError(c *gc.C) {

--- a/apiserver/migrationmaster/facade.go
+++ b/apiserver/migrationmaster/facade.go
@@ -6,6 +6,7 @@ package migrationmaster
 import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
+	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
@@ -130,8 +131,8 @@ func (api *API) Export() (params.SerializedModel, error) {
 	if err != nil {
 		return serialized, err
 	}
-
 	serialized.Bytes = bytes
+	serialized.Charms = getUsedCharms(model)
 	return serialized, nil
 }
 
@@ -139,4 +140,12 @@ func (api *API) Export() (params.SerializedModel, error) {
 // connection.
 func (api *API) Reap() error {
 	return api.backend.RemoveExportingModelDocs()
+}
+
+func getUsedCharms(model description.Model) []string {
+	result := set.NewStrings()
+	for _, service := range model.Services() {
+		result.Add(service.CharmURL())
+	}
+	return result.Values()
 }

--- a/apiserver/migrationmaster/facade_test.go
+++ b/apiserver/migrationmaster/facade_test.go
@@ -134,6 +134,10 @@ func (s *Suite) TestSetPhaseError(c *gc.C) {
 }
 
 func (s *Suite) TestExport(c *gc.C) {
+	s.model.AddService(description.ServiceArgs{
+		Tag:      names.NewServiceTag("foo"),
+		CharmURL: "cs:foo-0",
+	})
 	api := s.mustMakeAPI(c)
 
 	serialized, err := api.Export()
@@ -143,6 +147,7 @@ func (s *Suite) TestExport(c *gc.C) {
 	// tested elsewhere). Just check that at least one thing we expect
 	// is in the serialised output.
 	c.Assert(string(serialized.Bytes), jc.Contains, version.Current.String())
+	c.Assert(serialized.Charms, gc.DeepEquals, []string{"cs:foo-0"})
 }
 
 func (s *Suite) TestReap(c *gc.C) {

--- a/apiserver/migrationmaster/shim.go
+++ b/apiserver/migrationmaster/shim.go
@@ -5,7 +5,6 @@ package migrationmaster
 
 import (
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/migration"
 	"github.com/juju/juju/state"
 )
 
@@ -16,5 +15,5 @@ func newAPIForRegistration(
 	resources *common.Resources,
 	authorizer common.Authorizer,
 ) (*API, error) {
-	return NewAPI(st, resources, authorizer, migration.ExportModel)
+	return NewAPI(st, resources, authorizer)
 }

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -46,9 +46,11 @@ type SetMigrationPhaseArgs struct {
 	Phase string `json:"phase"`
 }
 
-// SerializedModel wraps a buffer contain a serialised Juju model.
+// SerializedModel wraps a buffer contain a serialised Juju model. It
+// also contains lists of the charms and tools used in the model.
 type SerializedModel struct {
-	Bytes []byte `json:"bytes"`
+	Bytes  []byte   `json:"bytes"`
+	Charms []string `json:"charms"`
 }
 
 // ModelArgs wraps a simple model tag.

--- a/migration/export_test.go
+++ b/migration/export_test.go
@@ -6,5 +6,4 @@ package migration
 var (
 	ControllerValues         = controllerValues
 	UpdateConfigFromProvider = updateConfigFromProvider
-	GetCharmStoragePath      = getCharmStoragePath
 )

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -10,18 +10,14 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/utils/set"
 	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6-unstable"
-	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/binarystorage"
-	"github.com/juju/juju/state/storage"
 	"github.com/juju/juju/tools"
 )
 
@@ -115,82 +111,70 @@ func updateConfigFromProvider(model description.Model, controllerConfig *config.
 	return nil
 }
 
-// UploadBackend define the methods on *state.State that are needed for
-// uploading the tools and charms from the current controller to a different
-// controller.
-type UploadBackend interface {
-	Charm(*charm.URL) (*state.Charm, error)
-	ModelUUID() string
-	MongoSession() *mgo.Session
-	ToolsStorage() (binarystorage.StorageCloser, error)
+// CharmDownlaoder defines a single method that is used to download a
+// charm from the source controller in a migration.
+type CharmDownloader interface {
+	OpenCharm(*charm.URL) (io.ReadCloser, error)
 }
 
-// CharmUploader defines a simple single method interface that is used to
-// upload a charm to the target controller
+// CharmUploader defines a single method that is used to upload a
+// charm to the target controller in a migration.
 type CharmUploader interface {
 	UploadCharm(*charm.URL, io.ReadSeeker) (*charm.URL, error)
 }
 
-// ToolsUploader defines a simple single method interface that is used to
-// upload tools to the target controller
+// ToolsUploader defines a single method that is used to upload tools
+// to the target controller in a migration.
 type ToolsUploader interface {
 	UploadTools(io.ReadSeeker, version.Binary, ...string) (tools.List, error)
 }
 
-// UploadBinariesConfig provides all the configuration that the UploadBinaries
-// function needs to operate. The functions are configurable for testing
-// purposes. To construct the config with the default functions, use
-// `NewUploadBinariesConfig`.
+// UploadBinariesConfig provides all the configuration that the
+// UploadBinaries function needs to operate. To construct the config
+// with the default helper functions, use `NewUploadBinariesConfig`.
 type UploadBinariesConfig struct {
-	State  UploadBackend
-	Model  description.Model
+	Source api.Connection
 	Target api.Connection
 
-	GetCharmUploader func(api.Connection) CharmUploader
-	GetToolsUploader func(api.Connection) ToolsUploader
+	Charms             []string
+	GetCharmDownloader func(api.Connection) CharmDownloader
+	GetCharmUploader   func(api.Connection) CharmUploader
 
-	GetStateStorage     func(UploadBackend) storage.Storage
-	GetCharmStoragePath func(UploadBackend, *charm.URL) (string, error)
+	GetToolsUploader func(api.Connection) ToolsUploader
 }
 
 // NewUploadBinariesConfig constructs a `UploadBinariesConfig` with the default
 // functions to get the uploaders for the target api connection, and functions
 // used to get the charm data out of the database.
-func NewUploadBinariesConfig(backend UploadBackend, model description.Model, target api.Connection) UploadBinariesConfig {
+func NewUploadBinariesConfig(source, target api.Connection, charms []string) UploadBinariesConfig {
 	return UploadBinariesConfig{
-		State:  backend,
-		Model:  model,
+		Source: source,
 		Target: target,
 
-		GetCharmUploader:    getCharmUploader,
-		GetStateStorage:     getStateStorage,
-		GetToolsUploader:    getToolsUploader,
-		GetCharmStoragePath: getCharmStoragePath,
+		Charms:             charms,
+		GetCharmDownloader: getCharmDownloader,
+		GetCharmUploader:   getCharmUploader,
+
+		GetToolsUploader: getToolsUploader,
 	}
 }
 
 // Validate makes sure that all the config values are non-nil.
 func (c *UploadBinariesConfig) Validate() error {
-	if c.State == nil {
-		return errors.NotValidf("missing UploadBackend")
-	}
-	if c.Model == nil {
-		return errors.NotValidf("missing Model")
+	if c.Source == nil {
+		return errors.NotValidf("missing Source")
 	}
 	if c.Target == nil {
 		return errors.NotValidf("missing Target")
 	}
+	if c.GetCharmDownloader == nil {
+		return errors.NotValidf("missing GetCharmDownloader")
+	}
 	if c.GetCharmUploader == nil {
 		return errors.NotValidf("missing GetCharmUploader")
 	}
-	if c.GetStateStorage == nil {
-		return errors.NotValidf("missing GetStateStorage")
-	}
 	if c.GetToolsUploader == nil {
 		return errors.NotValidf("missing GetToolsUploader")
-	}
-	if c.GetCharmStoragePath == nil {
-		return errors.NotValidf("missing GetCharmStoragePath")
 	}
 	return nil
 }
@@ -201,9 +185,6 @@ func UploadBinaries(config UploadBinariesConfig) error {
 	if err := config.Validate(); err != nil {
 		return errors.Trace(err)
 	}
-	if err := uploadTools(config); err != nil {
-		return errors.Trace(err)
-	}
 
 	if err := uploadCharms(config); err != nil {
 		return errors.Trace(err)
@@ -212,54 +193,25 @@ func UploadBinaries(config UploadBinariesConfig) error {
 	return nil
 }
 
-func getStateStorage(backend UploadBackend) storage.Storage {
-	return storage.NewStorage(backend.ModelUUID(), backend.MongoSession())
-}
-
-func getToolsUploader(target api.Connection) ToolsUploader {
-	return target.Client()
+func getCharmDownloader(source api.Connection) CharmDownloader {
+	// Client is the wrong facade for a non-client to use but that's
+	// where the functionality already lives and I don't have time to
+	// fix the world.
+	return source.Client()
 }
 
 func getCharmUploader(target api.Connection) CharmUploader {
+	// Client is wrong. See above.
 	return target.Client()
 }
 
-func uploadTools(config UploadBinariesConfig) error {
-	storage, err := config.State.ToolsStorage()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	defer storage.Close()
-
-	usedVersions := getUsedToolsVersions(config.Model)
-	toolsUploader := config.GetToolsUploader(config.Target)
-
-	for toolsVersion := range usedVersions {
-		logger.Debugf("send tools version %s to target", toolsVersion)
-		_, reader, err := storage.Open(toolsVersion.String())
-		if err != nil {
-			return errors.Trace(err)
-		}
-		defer reader.Close()
-
-		content, cleanup, err := streamThroughTempFile(reader)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		defer cleanup()
-
-		// UploadTools encapsulates the HTTP POST necessary to send the tools
-		// to the target API server.
-		if _, err := toolsUploader.UploadTools(content, toolsVersion); err != nil {
-			return errors.Trace(err)
-		}
-	}
-
-	return nil
+func getToolsUploader(target api.Connection) ToolsUploader {
+	// Client is wrong. See above.
+	return target.Client()
 }
 
 func streamThroughTempFile(r io.Reader) (_ io.ReadSeeker, cleanup func(), err error) {
-	tempFile, err := ioutil.TempFile("", "juju-tools")
+	tempFile, err := ioutil.TempFile("", "juju-migrate-binary")
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
@@ -282,38 +234,11 @@ func streamThroughTempFile(r io.Reader) (_ io.ReadSeeker, cleanup func(), err er
 	return tempFile, rmTempFile, nil
 }
 
-func getUsedToolsVersions(model description.Model) map[version.Binary]bool {
-	// Iterate through the model for all tools, and make a map of them.
-	usedVersions := make(map[version.Binary]bool)
-	// It is most likely that the preconditions will limit the number of
-	// tools versions in use, but that is not depended on here.
-	for _, machine := range model.Machines() {
-		addToolsVersionForMachine(machine, usedVersions)
-	}
-
-	for _, service := range model.Services() {
-		for _, unit := range service.Units() {
-			tools := unit.Tools()
-			usedVersions[tools.Version()] = true
-		}
-	}
-	return usedVersions
-}
-
-func addToolsVersionForMachine(machine description.Machine, usedVersions map[version.Binary]bool) {
-	tools := machine.Tools()
-	usedVersions[tools.Version()] = true
-	for _, container := range machine.Containers() {
-		addToolsVersionForMachine(container, usedVersions)
-	}
-}
-
 func uploadCharms(config UploadBinariesConfig) error {
-	storage := config.GetStateStorage(config.State)
-	usedCharms := getUsedCharms(config.Model)
-	charmUploader := config.GetCharmUploader(config.Target)
+	downloader := config.GetCharmDownloader(config.Source)
+	uploader := config.GetCharmUploader(config.Target)
 
-	for _, charmUrl := range usedCharms.Values() {
+	for _, charmUrl := range config.Charms {
 		logger.Debugf("send charm %s to target", charmUrl)
 
 		curl, err := charm.ParseURL(charmUrl)
@@ -321,14 +246,9 @@ func uploadCharms(config UploadBinariesConfig) error {
 			return errors.Annotate(err, "bad charm URL")
 		}
 
-		path, err := config.GetCharmStoragePath(config.State, curl)
+		reader, err := downloader.OpenCharm(curl)
 		if err != nil {
-			return errors.Trace(err)
-		}
-
-		reader, _, err := storage.Get(path)
-		if err != nil {
-			return errors.Annotate(err, "cannot get charm from storage")
+			return errors.Annotate(err, "cannot open charm")
 		}
 		defer reader.Close()
 
@@ -338,28 +258,11 @@ func uploadCharms(config UploadBinariesConfig) error {
 		}
 		defer cleanup()
 
-		if _, err := charmUploader.UploadCharm(curl, content); err != nil {
+		if _, err := uploader.UploadCharm(curl, content); err != nil {
 			return errors.Annotate(err, "cannot upload charm")
 		}
 	}
 	return nil
-}
-
-func getUsedCharms(model description.Model) set.Strings {
-	result := set.NewStrings()
-	for _, service := range model.Services() {
-		result.Add(service.CharmURL())
-	}
-	return result
-}
-
-func getCharmStoragePath(st UploadBackend, curl *charm.URL) (string, error) {
-	ch, err := st.Charm(curl)
-	if err != nil {
-		return "", errors.Annotate(err, "cannot get charm from state")
-	}
-
-	return ch.StoragePath(), nil
 }
 
 // PrecheckBackend is implemented by *state.State but defined as an interface

--- a/worker/migrationmaster/manifold.go
+++ b/worker/migrationmaster/manifold.go
@@ -5,7 +5,9 @@ package migrationmaster
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/migration"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/fortress"
@@ -43,21 +45,23 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	if err := config.validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	var apiCaller base.APICaller
-	if err := context.Get(config.APICallerName, &apiCaller); err != nil {
+	var apiConn api.Connection
+	if err := context.Get(config.APICallerName, &apiConn); err != nil {
 		return nil, errors.Trace(err)
 	}
 	var guard fortress.Guard
 	if err := context.Get(config.FortressName, &guard); err != nil {
 		return nil, errors.Trace(err)
 	}
-	facade, err := config.NewFacade(apiCaller)
+	facade, err := config.NewFacade(apiConn)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	worker, err := config.NewWorker(Config{
-		Facade: facade,
-		Guard:  guard,
+		Facade:         facade,
+		Guard:          guard,
+		SourceConn:     apiConn,
+		UploadBinaries: migration.UploadBinaries,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/migrationmaster/validate_test.go
+++ b/worker/migrationmaster/validate_test.go
@@ -5,6 +5,8 @@ package migrationmaster_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/migration"
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/migrationmaster"
 	"github.com/juju/testing"
@@ -35,10 +37,24 @@ func (*ValidateSuite) TestMissingFacade(c *gc.C) {
 	checkNotValid(c, config, "nil Facade not valid")
 }
 
+func (*ValidateSuite) TestMissingConn(c *gc.C) {
+	config := validConfig()
+	config.SourceConn = nil
+	checkNotValid(c, config, "nil SourceConn not valid")
+}
+
+func (*ValidateSuite) TestMissingUploadBinaries(c *gc.C) {
+	config := validConfig()
+	config.UploadBinaries = nil
+	checkNotValid(c, config, "nil UploadBinaries not valid")
+}
+
 func validConfig() migrationmaster.Config {
 	return migrationmaster.Config{
-		Guard:  struct{ fortress.Guard }{},
-		Facade: struct{ migrationmaster.Facade }{},
+		Guard:          struct{ fortress.Guard }{},
+		Facade:         struct{ migrationmaster.Facade }{},
+		SourceConn:     struct{ api.Connection }{},
+		UploadBinaries: func(migration.UploadBinariesConfig) error { return nil },
 	}
 }
 

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -8,12 +8,14 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/names"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/migrationmaster"
 	"github.com/juju/juju/api/migrationtarget"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/core/migration"
+	coremigration "github.com/juju/juju/core/migration"
+	"github.com/juju/juju/migration"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker/catacomb"
 	"github.com/juju/juju/worker/dependency"
@@ -22,12 +24,14 @@ import (
 
 var (
 	logger           = loggo.GetLogger("juju.worker.migrationmaster")
-	apiOpen          = api.Open
 	tempSuccessSleep = 10 * time.Second
 
 	// ErrDoneForNow indicates a temporary issue was encountered and
 	// that the worker should restart and retry.
 	ErrDoneForNow = errors.New("done for now")
+
+	// TODO(mjs) - this should be explicitly passed in via Config
+	apiOpen = api.Open
 )
 
 // Facade exposes controller functionality to a Worker.
@@ -43,7 +47,7 @@ type Facade interface {
 
 	// SetPhase updates the phase of the currently active model
 	// migration.
-	SetPhase(migration.Phase) error
+	SetPhase(coremigration.Phase) error
 
 	// Export returns a serialized representation of the model
 	// associated with the API connection.
@@ -58,6 +62,10 @@ type Facade interface {
 type Config struct {
 	Facade Facade
 	Guard  fortress.Guard
+	// TODO(mjs) - this is not ideal. Figure out a better abstraction
+	// (will require changes to migration.UploadBinaries).
+	SourceConn     api.Connection
+	UploadBinaries func(migration.UploadBinariesConfig) error
 }
 
 // Validate returns an error if config cannot drive a Worker.
@@ -67,6 +75,12 @@ func (config Config) Validate() error {
 	}
 	if config.Guard == nil {
 		return errors.NotValidf("nil Guard")
+	}
+	if config.SourceConn == nil {
+		return errors.NotValidf("nil SourceConn")
+	}
+	if config.UploadBinaries == nil {
+		return errors.NotValidf("nil UploadBinaries")
 	}
 	return nil
 }
@@ -126,23 +140,23 @@ func (w *Worker) run() error {
 	for {
 		var err error
 		switch phase {
-		case migration.QUIESCE:
+		case coremigration.QUIESCE:
 			phase, err = w.doQUIESCE()
-		case migration.READONLY:
+		case coremigration.READONLY:
 			phase, err = w.doREADONLY()
-		case migration.PRECHECK:
+		case coremigration.PRECHECK:
 			phase, err = w.doPRECHECK()
-		case migration.IMPORT:
-			phase, err = w.doIMPORT(status.TargetInfo)
-		case migration.VALIDATION:
+		case coremigration.IMPORT:
+			phase, err = w.doIMPORT(status.TargetInfo, status.ModelUUID)
+		case coremigration.VALIDATION:
 			phase, err = w.doVALIDATION(status.TargetInfo, status.ModelUUID)
-		case migration.SUCCESS:
+		case coremigration.SUCCESS:
 			phase, err = w.doSUCCESS()
-		case migration.LOGTRANSFER:
+		case coremigration.LOGTRANSFER:
 			phase, err = w.doLOGTRANSFER()
-		case migration.REAP:
+		case coremigration.REAP:
 			phase, err = w.doREAP()
-		case migration.ABORT:
+		case coremigration.ABORT:
 			phase, err = w.doABORT(status.TargetInfo, status.ModelUUID)
 		default:
 			return errors.Errorf("unknown phase: %v [%d]", phase.String(), phase)
@@ -186,34 +200,34 @@ func (w *Worker) killed() bool {
 	}
 }
 
-func (w *Worker) doQUIESCE() (migration.Phase, error) {
+func (w *Worker) doQUIESCE() (coremigration.Phase, error) {
 	// TODO(mjs) - Wait for all agents to report back.
-	return migration.READONLY, nil
+	return coremigration.READONLY, nil
 }
 
-func (w *Worker) doREADONLY() (migration.Phase, error) {
+func (w *Worker) doREADONLY() (coremigration.Phase, error) {
 	// TODO(mjs) - To be implemented.
-	return migration.PRECHECK, nil
+	return coremigration.PRECHECK, nil
 }
 
-func (w *Worker) doPRECHECK() (migration.Phase, error) {
+func (w *Worker) doPRECHECK() (coremigration.Phase, error) {
 	// TODO(mjs) - To be implemented.
-	return migration.IMPORT, nil
+	return coremigration.IMPORT, nil
 }
 
-func (w *Worker) doIMPORT(targetInfo migration.TargetInfo) (migration.Phase, error) {
+func (w *Worker) doIMPORT(targetInfo coremigration.TargetInfo, modelUUID string) (coremigration.Phase, error) {
 	logger.Infof("exporting model")
 	serialized, err := w.config.Facade.Export()
 	if err != nil {
 		logger.Errorf("model export failed: %v", err)
-		return migration.ABORT, nil
+		return coremigration.ABORT, nil
 	}
 
 	logger.Infof("opening API connection to target controller")
 	conn, err := openAPIConn(targetInfo)
 	if err != nil {
 		logger.Errorf("failed to connect to target controller: %v", err)
-		return migration.ABORT, nil
+		return coremigration.ABORT, nil
 	}
 	defer conn.Close()
 
@@ -222,24 +236,41 @@ func (w *Worker) doIMPORT(targetInfo migration.TargetInfo) (migration.Phase, err
 	err = targetClient.Import(serialized.Bytes)
 	if err != nil {
 		logger.Errorf("failed to import model into target controller: %v", err)
-		return migration.ABORT, nil
+		return coremigration.ABORT, nil
 	}
 
-	return migration.VALIDATION, nil
+	targetModelConn, err := openAPIConnForModel(targetInfo, modelUUID)
+	if err != nil {
+		logger.Errorf("failed to open connection to target model: %v", err)
+		return coremigration.ABORT, nil
+	}
+	defer targetModelConn.Close()
+
+	err = w.config.UploadBinaries(migration.NewUploadBinariesConfig(
+		w.config.SourceConn,
+		targetModelConn,
+		serialized.Charms,
+	))
+	if err != nil {
+		logger.Errorf("failed migration binaries: %v", err)
+		return coremigration.ABORT, nil
+	}
+
+	return coremigration.VALIDATION, nil
 }
 
-func (w *Worker) doVALIDATION(targetInfo migration.TargetInfo, modelUUID string) (migration.Phase, error) {
+func (w *Worker) doVALIDATION(targetInfo coremigration.TargetInfo, modelUUID string) (coremigration.Phase, error) {
 	// TODO(mjs) - Wait for all agents to report back.
 
 	// Once all agents have validated, activate the model.
 	err := activateModel(targetInfo, modelUUID)
 	if err != nil {
-		return migration.ABORT, nil
+		return coremigration.ABORT, nil
 	}
-	return migration.SUCCESS, nil
+	return coremigration.SUCCESS, nil
 }
 
-func activateModel(targetInfo migration.TargetInfo, modelUUID string) error {
+func activateModel(targetInfo coremigration.TargetInfo, modelUUID string) error {
 	conn, err := openAPIConn(targetInfo)
 	if err != nil {
 		return errors.Trace(err)
@@ -251,37 +282,37 @@ func activateModel(targetInfo migration.TargetInfo, modelUUID string) error {
 	return errors.Trace(err)
 }
 
-func (w *Worker) doSUCCESS() (migration.Phase, error) {
+func (w *Worker) doSUCCESS() (coremigration.Phase, error) {
 	// XXX(mjs) - this is a horrible hack, which helps to ensure that
 	// minions will see the SUCCESS state (due to watcher event
 	// coalescing). It will go away soon.
 	time.Sleep(tempSuccessSleep)
-	return migration.LOGTRANSFER, nil
+	return coremigration.LOGTRANSFER, nil
 }
 
-func (w *Worker) doLOGTRANSFER() (migration.Phase, error) {
+func (w *Worker) doLOGTRANSFER() (coremigration.Phase, error) {
 	// TODO(mjs) - To be implemented.
-	return migration.REAP, nil
+	return coremigration.REAP, nil
 }
 
-func (w *Worker) doREAP() (migration.Phase, error) {
+func (w *Worker) doREAP() (coremigration.Phase, error) {
 	err := w.config.Facade.Reap()
 	if err != nil {
-		return migration.REAPFAILED, errors.Trace(err)
+		return coremigration.REAPFAILED, errors.Trace(err)
 	}
-	return migration.DONE, nil
+	return coremigration.DONE, nil
 }
 
-func (w *Worker) doABORT(targetInfo migration.TargetInfo, modelUUID string) (migration.Phase, error) {
+func (w *Worker) doABORT(targetInfo coremigration.TargetInfo, modelUUID string) (coremigration.Phase, error) {
 	if err := removeImportedModel(targetInfo, modelUUID); err != nil {
 		// This isn't fatal. Removing the imported model is a best
 		// efforts attempt.
 		logger.Errorf("failed to reverse model import: %v", err)
 	}
-	return migration.ABORTDONE, nil
+	return coremigration.ABORTDONE, nil
 }
 
-func removeImportedModel(targetInfo migration.TargetInfo, modelUUID string) error {
+func removeImportedModel(targetInfo coremigration.TargetInfo, modelUUID string) error {
 	conn, err := openAPIConn(targetInfo)
 	if err != nil {
 		return errors.Trace(err)
@@ -330,12 +361,17 @@ func (w *Worker) waitForActiveMigration() (migrationmaster.MigrationStatus, erro
 	}
 }
 
-func openAPIConn(targetInfo migration.TargetInfo) (api.Connection, error) {
+func openAPIConn(targetInfo coremigration.TargetInfo) (api.Connection, error) {
+	return openAPIConnForModel(targetInfo, "")
+}
+
+func openAPIConnForModel(targetInfo coremigration.TargetInfo, modelUUID string) (api.Connection, error) {
 	apiInfo := &api.Info{
 		Addrs:    targetInfo.Addrs,
 		CACert:   targetInfo.CACert,
 		Tag:      targetInfo.AuthTag,
 		Password: targetInfo.Password,
+		ModelTag: names.NewModelTag(modelUUID),
 	}
 	// Use zero DialOpts (no retries) because the worker must stay
 	// responsive to Kill requests. We don't want it to be blocked by
@@ -343,6 +379,6 @@ func openAPIConn(targetInfo migration.TargetInfo) (api.Connection, error) {
 	return apiOpen(apiInfo, api.DialOpts{})
 }
 
-func modelHasMigrated(phase migration.Phase) bool {
-	return phase == migration.DONE || phase == migration.REAPFAILED
+func modelHasMigrated(phase coremigration.Phase) bool {
+	return phase == coremigration.DONE || phase == coremigration.REAPFAILED
 }

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -47,7 +47,7 @@ type Facade interface {
 
 	// Export returns a serialized representation of the model
 	// associated with the API connection.
-	Export() ([]byte, error)
+	Export() (params.SerializedModel, error)
 
 	// Reap removes all documents of the model associated with the API
 	// connection.
@@ -203,7 +203,7 @@ func (w *Worker) doPRECHECK() (migration.Phase, error) {
 
 func (w *Worker) doIMPORT(targetInfo migration.TargetInfo) (migration.Phase, error) {
 	logger.Infof("exporting model")
-	bytes, err := w.config.Facade.Export()
+	serialized, err := w.config.Facade.Export()
 	if err != nil {
 		logger.Errorf("model export failed: %v", err)
 		return migration.ABORT, nil
@@ -219,7 +219,7 @@ func (w *Worker) doIMPORT(targetInfo migration.TargetInfo) (migration.Phase, err
 
 	logger.Infof("importing model into target controller")
 	targetClient := migrationtarget.NewClient(conn)
-	err = targetClient.Import(bytes)
+	err = targetClient.Import(serialized.Bytes)
 	if err != nil {
 		logger.Errorf("failed to import model into target controller: %v", err)
 		return migration.ABORT, nil

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -15,7 +15,8 @@ import (
 	"github.com/juju/juju/api"
 	masterapi "github.com/juju/juju/api/migrationmaster"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/core/migration"
+	coremigration "github.com/juju/juju/core/migration"
+	"github.com/juju/juju/migration"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker"
@@ -36,10 +37,11 @@ var _ = gc.Suite(&Suite{})
 
 var (
 	fakeModelBytes = []byte("model")
-	modelTagString = names.NewModelTag("model-uuid").String()
+	modelTag       = names.NewModelTag("model-uuid")
+	modelTagString = modelTag.String()
 
 	// Define stub calls that commonly appear in tests here to allow reuse.
-	apiOpenCall = jujutesting.StubCall{
+	apiOpenCallController = jujutesting.StubCall{
 		"apiOpen",
 		[]interface{}{
 			&api.Info{
@@ -47,6 +49,19 @@ var (
 				CACert:   "cert",
 				Tag:      names.NewUserTag("admin"),
 				Password: "secret",
+			},
+			api.DialOpts{},
+		},
+	}
+	apiOpenCallModel = jujutesting.StubCall{
+		"apiOpen",
+		[]interface{}{
+			&api.Info{
+				Addrs:    []string{"1.2.3.4:5"},
+				CACert:   "cert",
+				Tag:      names.NewUserTag("admin"),
+				Password: "secret",
+				ModelTag: modelTag,
 			},
 			api.DialOpts{},
 		},
@@ -96,9 +111,12 @@ func (s *Suite) triggerMigration(masterFacade *stubMasterFacade) {
 
 func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 	masterFacade := newStubMasterFacade(s.stub)
+	sourceConn := &stubConnection{stub: s.stub}
 	worker, err := migrationmaster.New(migrationmaster.Config{
-		Facade: masterFacade,
-		Guard:  newStubGuard(s.stub),
+		Facade:         masterFacade,
+		Guard:          newStubGuard(s.stub),
+		SourceConn:     sourceConn,
+		UploadBinaries: makeStubUploadBinaries(s.stub),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.triggerMigration(masterFacade)
@@ -113,22 +131,25 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 		{"masterFacade.Watch", nil},
 		{"masterFacade.GetMigrationStatus", nil},
 		{"guard.Lockdown", nil},
-		{"masterFacade.SetPhase", []interface{}{migration.READONLY}},
-		{"masterFacade.SetPhase", []interface{}{migration.PRECHECK}},
-		{"masterFacade.SetPhase", []interface{}{migration.IMPORT}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.READONLY}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.PRECHECK}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.IMPORT}},
 		{"masterFacade.Export", nil},
-		apiOpenCall,
+		apiOpenCallController,
 		importCall,
-		connCloseCall,
-		{"masterFacade.SetPhase", []interface{}{migration.VALIDATION}},
-		apiOpenCall,
+		apiOpenCallModel,
+		{"UploadBinaries", []interface{}{sourceConn, []string{"charm0", "charm1"}}},
+		connCloseCall, // for target model
+		connCloseCall, // for target controller
+		{"masterFacade.SetPhase", []interface{}{coremigration.VALIDATION}},
+		apiOpenCallController,
 		activateCall,
 		connCloseCall,
-		{"masterFacade.SetPhase", []interface{}{migration.SUCCESS}},
-		{"masterFacade.SetPhase", []interface{}{migration.LOGTRANSFER}},
-		{"masterFacade.SetPhase", []interface{}{migration.REAP}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.SUCCESS}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.REAP}},
 		{"masterFacade.Reap", nil},
-		{"masterFacade.SetPhase", []interface{}{migration.DONE}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.DONE}},
 	})
 }
 
@@ -137,11 +158,13 @@ func (s *Suite) TestMigrationResume(c *gc.C) {
 
 	masterFacade := newStubMasterFacade(s.stub)
 	worker, err := migrationmaster.New(migrationmaster.Config{
-		Facade: masterFacade,
-		Guard:  newStubGuard(s.stub),
+		Facade:         masterFacade,
+		Guard:          newStubGuard(s.stub),
+		SourceConn:     struct{ api.Connection }{},
+		UploadBinaries: nullUploadBinaries,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	masterFacade.status.Phase = migration.SUCCESS
+	masterFacade.status.Phase = coremigration.SUCCESS
 	s.triggerMigration(masterFacade)
 
 	err = workertest.CheckKilled(c, worker)
@@ -151,20 +174,22 @@ func (s *Suite) TestMigrationResume(c *gc.C) {
 		{"masterFacade.Watch", nil},
 		{"masterFacade.GetMigrationStatus", nil},
 		{"guard.Lockdown", nil},
-		{"masterFacade.SetPhase", []interface{}{migration.LOGTRANSFER}},
-		{"masterFacade.SetPhase", []interface{}{migration.REAP}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.REAP}},
 		{"masterFacade.Reap", nil},
-		{"masterFacade.SetPhase", []interface{}{migration.DONE}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.DONE}},
 	})
 }
 
 func (s *Suite) TestPreviouslyAbortedMigration(c *gc.C) {
 	masterFacade := newStubMasterFacade(s.stub)
-	masterFacade.status.Phase = migration.ABORTDONE
+	masterFacade.status.Phase = coremigration.ABORTDONE
 	s.triggerMigration(masterFacade)
 	worker, err := migrationmaster.New(migrationmaster.Config{
-		Facade: masterFacade,
-		Guard:  newStubGuard(s.stub),
+		Facade:         masterFacade,
+		Guard:          newStubGuard(s.stub),
+		SourceConn:     struct{ api.Connection }{},
+		UploadBinaries: nullUploadBinaries,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	workertest.CheckAlive(c, worker)
@@ -175,11 +200,13 @@ func (s *Suite) TestPreviouslyAbortedMigration(c *gc.C) {
 
 func (s *Suite) TestPreviouslyCompletedMigration(c *gc.C) {
 	masterFacade := newStubMasterFacade(s.stub)
-	masterFacade.status.Phase = migration.DONE
+	masterFacade.status.Phase = coremigration.DONE
 	s.triggerMigration(masterFacade)
 	worker, err := migrationmaster.New(migrationmaster.Config{
-		Facade: masterFacade,
-		Guard:  newStubGuard(s.stub),
+		Facade:         masterFacade,
+		Guard:          newStubGuard(s.stub),
+		SourceConn:     struct{ api.Connection }{},
+		UploadBinaries: nullUploadBinaries,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -196,8 +223,10 @@ func (s *Suite) TestWatchFailure(c *gc.C) {
 	masterFacade := newStubMasterFacade(s.stub)
 	masterFacade.watchErr = errors.New("boom")
 	worker, err := migrationmaster.New(migrationmaster.Config{
-		Facade: masterFacade,
-		Guard:  newStubGuard(s.stub),
+		Facade:         masterFacade,
+		Guard:          newStubGuard(s.stub),
+		SourceConn:     struct{ api.Connection }{},
+		UploadBinaries: nullUploadBinaries,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = workertest.CheckKilled(c, worker)
@@ -208,8 +237,10 @@ func (s *Suite) TestStatusError(c *gc.C) {
 	masterFacade := newStubMasterFacade(s.stub)
 	masterFacade.statusErr = errors.New("splat")
 	worker, err := migrationmaster.New(migrationmaster.Config{
-		Facade: masterFacade,
-		Guard:  newStubGuard(s.stub),
+		Facade:         masterFacade,
+		Guard:          newStubGuard(s.stub),
+		SourceConn:     struct{ api.Connection }{},
+		UploadBinaries: nullUploadBinaries,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.triggerMigration(masterFacade)
@@ -226,8 +257,10 @@ func (s *Suite) TestStatusNotFound(c *gc.C) {
 	masterFacade := newStubMasterFacade(s.stub)
 	masterFacade.statusErr = &params.Error{Code: params.CodeNotFound}
 	worker, err := migrationmaster.New(migrationmaster.Config{
-		Facade: masterFacade,
-		Guard:  newStubGuard(s.stub),
+		Facade:         masterFacade,
+		Guard:          newStubGuard(s.stub),
+		SourceConn:     struct{ api.Connection }{},
+		UploadBinaries: nullUploadBinaries,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.triggerMigration(masterFacade)
@@ -248,8 +281,10 @@ func (s *Suite) TestUnlockError(c *gc.C) {
 	guard := newStubGuard(s.stub)
 	guard.unlockErr = errors.New("pow")
 	worker, err := migrationmaster.New(migrationmaster.Config{
-		Facade: masterFacade,
-		Guard:  guard,
+		Facade:         masterFacade,
+		Guard:          guard,
+		SourceConn:     struct{ api.Connection }{},
+		UploadBinaries: nullUploadBinaries,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.triggerMigration(masterFacade)
@@ -269,8 +304,10 @@ func (s *Suite) TestLockdownError(c *gc.C) {
 	guard := newStubGuard(s.stub)
 	guard.lockdownErr = errors.New("biff")
 	worker, err := migrationmaster.New(migrationmaster.Config{
-		Facade: masterFacade,
-		Guard:  guard,
+		Facade:         masterFacade,
+		Guard:          guard,
+		SourceConn:     struct{ api.Connection }{},
+		UploadBinaries: nullUploadBinaries,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.triggerMigration(masterFacade)
@@ -289,8 +326,10 @@ func (s *Suite) TestExportFailure(c *gc.C) {
 	masterFacade := newStubMasterFacade(s.stub)
 	masterFacade.exportErr = errors.New("boom")
 	worker, err := migrationmaster.New(migrationmaster.Config{
-		Facade: masterFacade,
-		Guard:  newStubGuard(s.stub),
+		Facade:         masterFacade,
+		Guard:          newStubGuard(s.stub),
+		SourceConn:     struct{ api.Connection }{},
+		UploadBinaries: nullUploadBinaries,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.triggerMigration(masterFacade)
@@ -302,23 +341,25 @@ func (s *Suite) TestExportFailure(c *gc.C) {
 		{"masterFacade.Watch", nil},
 		{"masterFacade.GetMigrationStatus", nil},
 		{"guard.Lockdown", nil},
-		{"masterFacade.SetPhase", []interface{}{migration.READONLY}},
-		{"masterFacade.SetPhase", []interface{}{migration.PRECHECK}},
-		{"masterFacade.SetPhase", []interface{}{migration.IMPORT}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.READONLY}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.PRECHECK}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.IMPORT}},
 		{"masterFacade.Export", nil},
-		{"masterFacade.SetPhase", []interface{}{migration.ABORT}},
-		apiOpenCall,
+		{"masterFacade.SetPhase", []interface{}{coremigration.ABORT}},
+		apiOpenCallController,
 		abortCall,
 		connCloseCall,
-		{"masterFacade.SetPhase", []interface{}{migration.ABORTDONE}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.ABORTDONE}},
 	})
 }
 
 func (s *Suite) TestAPIOpenFailure(c *gc.C) {
 	masterFacade := newStubMasterFacade(s.stub)
 	worker, err := migrationmaster.New(migrationmaster.Config{
-		Facade: masterFacade,
-		Guard:  newStubGuard(s.stub),
+		Facade:         masterFacade,
+		Guard:          newStubGuard(s.stub),
+		SourceConn:     struct{ api.Connection }{},
+		UploadBinaries: nullUploadBinaries,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.connectionErr = errors.New("boom")
@@ -331,22 +372,24 @@ func (s *Suite) TestAPIOpenFailure(c *gc.C) {
 		{"masterFacade.Watch", nil},
 		{"masterFacade.GetMigrationStatus", nil},
 		{"guard.Lockdown", nil},
-		{"masterFacade.SetPhase", []interface{}{migration.READONLY}},
-		{"masterFacade.SetPhase", []interface{}{migration.PRECHECK}},
-		{"masterFacade.SetPhase", []interface{}{migration.IMPORT}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.READONLY}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.PRECHECK}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.IMPORT}},
 		{"masterFacade.Export", nil},
-		apiOpenCall,
-		{"masterFacade.SetPhase", []interface{}{migration.ABORT}},
-		apiOpenCall,
-		{"masterFacade.SetPhase", []interface{}{migration.ABORTDONE}},
+		apiOpenCallController,
+		{"masterFacade.SetPhase", []interface{}{coremigration.ABORT}},
+		apiOpenCallController,
+		{"masterFacade.SetPhase", []interface{}{coremigration.ABORTDONE}},
 	})
 }
 
 func (s *Suite) TestImportFailure(c *gc.C) {
 	masterFacade := newStubMasterFacade(s.stub)
 	worker, err := migrationmaster.New(migrationmaster.Config{
-		Facade: masterFacade,
-		Guard:  newStubGuard(s.stub),
+		Facade:         masterFacade,
+		Guard:          newStubGuard(s.stub),
+		SourceConn:     struct{ api.Connection }{},
+		UploadBinaries: nullUploadBinaries,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.connection.importErr = errors.New("boom")
@@ -359,18 +402,18 @@ func (s *Suite) TestImportFailure(c *gc.C) {
 		{"masterFacade.Watch", nil},
 		{"masterFacade.GetMigrationStatus", nil},
 		{"guard.Lockdown", nil},
-		{"masterFacade.SetPhase", []interface{}{migration.READONLY}},
-		{"masterFacade.SetPhase", []interface{}{migration.PRECHECK}},
-		{"masterFacade.SetPhase", []interface{}{migration.IMPORT}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.READONLY}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.PRECHECK}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.IMPORT}},
 		{"masterFacade.Export", nil},
-		apiOpenCall,
+		apiOpenCallController,
 		importCall,
 		connCloseCall,
-		{"masterFacade.SetPhase", []interface{}{migration.ABORT}},
-		apiOpenCall,
+		{"masterFacade.SetPhase", []interface{}{coremigration.ABORT}},
+		apiOpenCallController,
 		abortCall,
 		connCloseCall,
-		{"masterFacade.SetPhase", []interface{}{migration.ABORTDONE}},
+		{"masterFacade.SetPhase", []interface{}{coremigration.ABORTDONE}},
 	})
 }
 
@@ -401,8 +444,8 @@ func newStubMasterFacade(stub *jujutesting.Stub) *stubMasterFacade {
 		status: masterapi.MigrationStatus{
 			ModelUUID: "model-uuid",
 			Attempt:   2,
-			Phase:     migration.QUIESCE,
-			TargetInfo: migration.TargetInfo{
+			Phase:     coremigration.QUIESCE,
+			TargetInfo: coremigration.TargetInfo{
 				ControllerTag: names.NewModelTag("controller-uuid"),
 				Addrs:         []string{"1.2.3.4:5"},
 				CACert:        "cert",
@@ -447,11 +490,12 @@ func (c *stubMasterFacade) Export() (params.SerializedModel, error) {
 		return params.SerializedModel{}, c.exportErr
 	}
 	return params.SerializedModel{
-		Bytes: fakeModelBytes,
+		Bytes:  fakeModelBytes,
+		Charms: []string{"charm0", "charm1"},
 	}, nil
 }
 
-func (c *stubMasterFacade) SetPhase(phase migration.Phase) error {
+func (c *stubMasterFacade) SetPhase(phase coremigration.Phase) error {
 	c.stub.AddCall("masterFacade.SetPhase", phase)
 	return nil
 }
@@ -505,3 +549,14 @@ func (c *stubConnection) Close() error {
 	c.stub.AddCall("Connection.Close")
 	return nil
 }
+
+func makeStubUploadBinaries(stub *jujutesting.Stub) func(migration.UploadBinariesConfig) error {
+	return func(config migration.UploadBinariesConfig) error {
+		stub.AddCall("UploadBinaries", config.Source, config.Charms)
+		return nil
+	}
+}
+
+// nullUploadBinaries is a UploadBinaries variant which should never
+// get called.
+var nullUploadBinaries = makeStubUploadBinaries(nil)

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -35,8 +35,8 @@ type Suite struct {
 var _ = gc.Suite(&Suite{})
 
 var (
-	fakeSerializedModel = []byte("model")
-	modelTagString      = names.NewModelTag("model-uuid").String()
+	fakeModelBytes = []byte("model")
+	modelTagString = names.NewModelTag("model-uuid").String()
 
 	// Define stub calls that commonly appear in tests here to allow reuse.
 	apiOpenCall = jujutesting.StubCall{
@@ -54,7 +54,7 @@ var (
 	importCall = jujutesting.StubCall{
 		"APICall:MigrationTarget.Import",
 		[]interface{}{
-			params.SerializedModel{Bytes: fakeSerializedModel},
+			params.SerializedModel{Bytes: fakeModelBytes},
 		},
 	}
 	activateCall = jujutesting.StubCall{
@@ -441,12 +441,14 @@ func (c *stubMasterFacade) GetMigrationStatus() (masterapi.MigrationStatus, erro
 	return c.status, nil
 }
 
-func (c *stubMasterFacade) Export() ([]byte, error) {
+func (c *stubMasterFacade) Export() (params.SerializedModel, error) {
 	c.stub.AddCall("masterFacade.Export")
 	if c.exportErr != nil {
-		return nil, c.exportErr
+		return params.SerializedModel{}, c.exportErr
 	}
-	return fakeSerializedModel, nil
+	return params.SerializedModel{
+		Bytes: fakeModelBytes,
+	}, nil
 }
 
 func (c *stubMasterFacade) SetPhase(phase migration.Phase) error {


### PR DESCRIPTION
This PR makes the changes required to the apiserver, api client and migrationmaster worker to migrate charms during model migration. This also lays the groundwork for migration of tools.

Highlights:
- the migration top-level package no longer uses state.State
- the migrationmaster.Export API now returns the charms used by a model
- the charm upload endpoint now accepts charm store charms (previously it would only accept local charms). This is only allow for models that are importing during migration.
- uploads of multi-series charms are now supported (drive-by fix)


(Review request: http://reviews.vapour.ws/r/4998/)