### PR TITLE
all: add clouds/credentials to state

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/agentbootstrap"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -28,6 +29,7 @@ import (
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
+	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -108,15 +110,6 @@ LXC_BRIDGE="ignored"`[1:])
 		"10.0.3.4", // lxc bridge address filtered (-"-).
 		"10.0.3.3", // not a lxc bridge address
 	)
-	mcfg := agentbootstrap.BootstrapMachineConfig{
-		Addresses:            initialAddrs,
-		BootstrapConstraints: expectBootstrapConstraints,
-		ModelConstraints:     expectModelConstraints,
-		Jobs:                 []multiwatcher.MachineJob{multiwatcher.JobManageModel},
-		InstanceId:           "i-bootstrap",
-		Characteristics:      expectHW,
-		SharedSecret:         "abc123",
-	}
 	filteredAddrs := network.NewAddresses(
 		"zeroonetwothree",
 		"0.1.2.3",
@@ -142,10 +135,26 @@ LXC_BRIDGE="ignored"`[1:])
 		"uuid": hostedModelUUID,
 	}
 
+	mcfg := agentbootstrap.InitializeStateParams{
+		StateInitializationParams: instancecfg.StateInitializationParams{
+			BootstrapMachineConstraints:             expectBootstrapConstraints,
+			ModelConstraints:                        expectModelConstraints,
+			BootstrapMachineInstanceId:              "i-bootstrap",
+			BootstrapMachineHardwareCharacteristics: &expectHW,
+			Config:            envCfg,
+			HostedModelConfig: hostedModelConfigAttrs,
+			PublicClouds:      statetesting.TestClouds(),
+			ControllerCloud:   "dummy",
+		},
+		Addresses:    initialAddrs,
+		Jobs:         []multiwatcher.MachineJob{multiwatcher.JobManageModel},
+		SharedSecret: "abc123",
+	}
+
 	adminUser := names.NewLocalUserTag("agent-admin")
 	st, m, err := agentbootstrap.InitializeState(
-		adminUser, cfg, envCfg, hostedModelConfigAttrs, mcfg,
-		mongotest.DialOpts(), environs.NewStatePolicy(),
+		adminUser, cfg, mcfg, mongotest.DialOpts(),
+		environs.NewStatePolicy(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
@@ -255,7 +264,7 @@ func (s *bootstrapSuite) TestInitializeStateWithStateServingInfoNotAvailable(c *
 	c.Assert(available, jc.IsFalse)
 
 	adminUser := names.NewLocalUserTag("agent-admin")
-	_, _, err = agentbootstrap.InitializeState(adminUser, cfg, nil, nil, agentbootstrap.BootstrapMachineConfig{}, mongotest.DialOpts(), environs.NewStatePolicy())
+	_, _, err = agentbootstrap.InitializeState(adminUser, cfg, agentbootstrap.InitializeStateParams{}, mongotest.DialOpts(), environs.NewStatePolicy())
 	// InitializeState will fail attempting to get the api port information
 	c.Assert(err, gc.ErrorMatches, "state serving information not available")
 }
@@ -283,12 +292,6 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 		SystemIdentity: "qux",
 	})
 	expectHW := instance.MustParseHardware("mem=2048M")
-	mcfg := agentbootstrap.BootstrapMachineConfig{
-		BootstrapConstraints: constraints.MustParse("mem=1024M"),
-		Jobs:                 []multiwatcher.MachineJob{multiwatcher.JobManageModel},
-		InstanceId:           "i-bootstrap",
-		Characteristics:      expectHW,
-	}
 	envAttrs := dummy.SampleConfig().Delete("admin-secret").Merge(testing.Attrs{
 		"agent-version": jujuversion.Current.String(),
 	})
@@ -300,15 +303,29 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 		"uuid": utils.MustNewUUID().String(),
 	}
 
+	args := agentbootstrap.InitializeStateParams{
+		StateInitializationParams: instancecfg.StateInitializationParams{
+			BootstrapMachineConstraints:             constraints.MustParse("mem=1024M"),
+			BootstrapMachineInstanceId:              "i-bootstrap",
+			BootstrapMachineHardwareCharacteristics: &expectHW,
+			Config:            envCfg,
+			HostedModelConfig: hostedModelConfigAttrs,
+			PublicClouds:      statetesting.TestClouds(),
+			ControllerCloud:   "dummy",
+		},
+		Jobs: []multiwatcher.MachineJob{multiwatcher.JobManageModel},
+	}
+
 	adminUser := names.NewLocalUserTag("agent-admin")
 	st, _, err := agentbootstrap.InitializeState(
-		adminUser, cfg, envCfg, hostedModelConfigAttrs, mcfg,
-		mongotest.DialOpts(), state.Policy(nil),
+		adminUser, cfg, args, mongotest.DialOpts(), state.Policy(nil),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	st.Close()
 
-	st, _, err = agentbootstrap.InitializeState(adminUser, cfg, envCfg, nil, mcfg, mongotest.DialOpts(), environs.NewStatePolicy())
+	st, _, err = agentbootstrap.InitializeState(
+		adminUser, cfg, args, mongotest.DialOpts(), state.Policy(nil),
+	)
 	if err == nil {
 		st.Close()
 	}

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -345,17 +345,18 @@ func (c *Client) ModelInfo() (params.ModelInfo, error) {
 	if err != nil {
 		return params.ModelInfo{}, err
 	}
-	env, err := state.Model()
+	model, err := state.Model()
 	if err != nil {
 		return params.ModelInfo{}, err
 	}
 
 	info := params.ModelInfo{
 		DefaultSeries:  config.PreferredSeries(conf),
-		ProviderType:   conf.Type(),
+		Cloud:          model.Cloud(),
+		CloudRegion:    model.CloudRegion(),
 		Name:           conf.Name(),
-		UUID:           env.UUID(),
-		ControllerUUID: env.ControllerUUID(),
+		UUID:           model.UUID(),
+		ControllerUUID: model.ControllerUUID(),
 	}
 	return info, nil
 }

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -459,13 +459,16 @@ func (s *clientSuite) TestClientCharmInfo(c *gc.C) {
 }
 
 func (s *clientSuite) TestClientModelInfo(c *gc.C) {
+	model, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
 	conf, _ := s.State.ModelConfig()
 	info, err := s.APIState.Client().ModelInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.DefaultSeries, gc.Equals, config.PreferredSeries(conf))
-	c.Assert(info.ProviderType, gc.Equals, conf.Type())
+	c.Assert(info.Cloud, gc.Equals, model.Cloud())
+	c.Assert(info.CloudRegion, gc.Equals, model.CloudRegion())
 	c.Assert(info.Name, gc.Equals, conf.Name())
 	c.Assert(info.UUID, gc.Equals, env.UUID())
 	c.Assert(info.ControllerUUID, gc.Equals, env.ControllerUUID())

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -83,7 +83,8 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		UUID:           s.st.model.cfg.UUID(),
 		ControllerUUID: s.st.model.cfg.UUID(),
 		OwnerTag:       "user-bob@local",
-		ProviderType:   "someprovider",
+		Cloud:          "mycloud",
+		CloudRegion:    "mycloudregion",
 		DefaultSeries:  series.LatestLts(),
 		Life:           params.Dying,
 		Status: params.EntityStatus{
@@ -119,6 +120,8 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		{"Status", nil},
 		{"Owner", nil},
 		{"Life", nil},
+		{"Cloud", nil},
+		{"CloudRegion", nil},
 	})
 }
 
@@ -284,6 +287,18 @@ func (m *mockModel) Life() state.Life {
 func (m *mockModel) Status() (status.StatusInfo, error) {
 	m.MethodCall(m, "Status")
 	return m.status, m.NextErr()
+}
+
+func (m *mockModel) Cloud() string {
+	m.MethodCall(m, "Cloud")
+	m.PopNoErr()
+	return "mycloud"
+}
+
+func (m *mockModel) CloudRegion() string {
+	m.MethodCall(m, "CloudRegion")
+	m.PopNoErr()
+	return "mycloudregion"
 }
 
 func (m *mockModel) Users() ([]common.ModelUser, error) {

--- a/apiserver/modelmanager/state.go
+++ b/apiserver/modelmanager/state.go
@@ -36,6 +36,8 @@ type Model interface {
 	Owner() names.UserTag
 	Status() (status.StatusInfo, error)
 	Users() ([]common.ModelUser, error)
+	Cloud() string
+	CloudRegion() string
 }
 
 type stateShim struct {

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -41,8 +41,9 @@ type ModelInfo struct {
 	Name           string `json:"Name"`
 	UUID           string `json:"UUID"`
 	ControllerUUID string `json:"ServerUUID"`
-	ProviderType   string `json:"ProviderType"`
 	DefaultSeries  string `json:"DefaultSeries"`
+	Cloud          string `json:"Cloud"`
+	CloudRegion    string `json:"CloudRegion,omitempty"`
 
 	// OwnerTag is the tag of the user that owns the model.
 	OwnerTag string `json:"OwnerTag"`

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -235,7 +235,7 @@ func ParseCloudMetadata(data []byte) (map[string]Cloud, error) {
 // WritePublicCloudMetadata marshals to YAML and writes the cloud metadata
 // to the public cloud file.
 func WritePublicCloudMetadata(cloudsMap map[string]Cloud) error {
-	data, err := marshalCloudMetadata(cloudsMap)
+	data, err := MarshalCloudMetadata(cloudsMap)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -246,19 +246,19 @@ func WritePublicCloudMetadata(cloudsMap map[string]Cloud) error {
 // same cloud metadata.
 func IsSameCloudMetadata(meta1, meta2 map[string]Cloud) (bool, error) {
 	// The easiest approach is to simply marshall to YAML and compare.
-	yaml1, err := marshalCloudMetadata(meta1)
+	yaml1, err := MarshalCloudMetadata(meta1)
 	if err != nil {
 		return false, err
 	}
-	yaml2, err := marshalCloudMetadata(meta2)
+	yaml2, err := MarshalCloudMetadata(meta2)
 	if err != nil {
 		return false, err
 	}
 	return string(yaml1) == string(yaml2), nil
 }
 
-// marshalCloudMetadata marshals the given clouds to YAML.
-func marshalCloudMetadata(cloudsMap map[string]Cloud) ([]byte, error) {
+// MarshalCloudMetadata marshals the given clouds to YAML.
+func MarshalCloudMetadata(cloudsMap map[string]Cloud) ([]byte, error) {
 	clouds := cloudSet{make(map[string]*cloud)}
 	for name, metadata := range cloudsMap {
 		var regions regions

--- a/cloud/personalclouds.go
+++ b/cloud/personalclouds.go
@@ -49,7 +49,7 @@ func ParseCloudMetadataFile(file string) (map[string]Cloud, error) {
 // WritePersonalCloudMetadata marshals to YAMl and writes the cloud metadata
 // to the personal cloud file.
 func WritePersonalCloudMetadata(cloudsMap map[string]Cloud) error {
-	data, err := marshalCloudMetadata(cloudsMap)
+	data, err := MarshalCloudMetadata(cloudsMap)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -227,7 +227,7 @@ func (cfg *testInstanceConfig) setController() *testInstanceConfig {
 	}
 	cfg.Bootstrap = &instancecfg.BootstrapConfig{
 		StateInitializationParams: instancecfg.StateInitializationParams{
-			InstanceId:                  "i-bootstrap",
+			BootstrapMachineInstanceId:  "i-bootstrap",
 			BootstrapMachineConstraints: bootstrapConstraints,
 			ModelConstraints:            envConstraints,
 		},
@@ -1014,8 +1014,8 @@ var verifyTests = []struct {
 	{"missing machine agent service name", func(cfg *instancecfg.InstanceConfig) {
 		cfg.MachineAgentServiceName = ""
 	}},
-	{"invalid bootstrap configuration: missing instance-id", func(cfg *instancecfg.InstanceConfig) {
-		cfg.Bootstrap.InstanceId = ""
+	{"invalid bootstrap configuration: missing bootstrap machine instance-id", func(cfg *instancecfg.InstanceConfig) {
+		cfg.Bootstrap.BootstrapMachineInstanceId = ""
 	}},
 }
 
@@ -1030,7 +1030,7 @@ func (*cloudinitSuite) TestCloudInitVerify(c *gc.C) {
 		return instancecfg.InstanceConfig{
 			Bootstrap: &instancecfg.BootstrapConfig{
 				StateInitializationParams: instancecfg.StateInitializationParams{
-					InstanceId:        "i-bootstrap",
+					BootstrapMachineInstanceId: "i-bootstrap",
 					Config:            minimalModelConfig(c),
 					HostedModelConfig: map[string]interface{}{"name": "hosted-model"},
 				},

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -539,6 +539,39 @@ to clean up the model.`[1:])
 		guiDataSourceBaseURL = common.GUIDataSourceBaseURL()
 	}
 
+	// Load public and personal clouds to store in the controller.
+	// We also pass the credential used for bootstrapping, but not
+	// any of the others.
+	//
+	// TODO(axw) load clouds first, and pass into anything that needs
+	// them above? That would cut down on filesystem reads, and
+	// eliminate potential inconsistencies.
+	publicClouds, _, err := jujucloud.PublicCloudMetadata()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	personalClouds, err := jujucloud.PersonalCloudMetadata()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if credentialName == "" {
+		// TODO(axw) consider storing an additional property in
+		// client-side bootstrap config indicating that the
+		// credential was auto-detected, rather than relying on
+		// the name being the empty string. Then we could move
+		// this code up to the point where we detect credentials.
+		credentialName = c.Cloud
+	}
+	cloudCredentials := map[string]jujucloud.CloudCredential{
+		c.Cloud: {
+			DefaultRegion:     region.Name,
+			DefaultCredential: credentialName,
+			AuthCredentials: map[string]jujucloud.Credential{
+				credentialName: *credential,
+			},
+		},
+	}
+
 	err = bootstrapFuncs.Bootstrap(modelcmd.BootstrapContext(ctx), environ, bootstrap.BootstrapParams{
 		ModelConstraints:     c.Constraints,
 		BootstrapConstraints: bootstrapConstraints,
@@ -551,6 +584,12 @@ to clean up the model.`[1:])
 		MetadataDir:          metadataDir,
 		HostedModelConfig:    hostedModelConfig,
 		GUIDataSourceBaseURL: guiDataSourceBaseURL,
+		PublicClouds:         publicClouds,
+		PersonalClouds:       personalClouds,
+		CloudCredentials:     cloudCredentials,
+		Cloud:                c.Cloud,
+		CloudRegion:          region.Name,
+		CloudCredential:      credentialName,
 	})
 	if err != nil {
 		return errors.Annotate(err, "failed to bootstrap model")

--- a/cmd/juju/common/model.go
+++ b/cmd/juju/common/model.go
@@ -18,7 +18,8 @@ type ModelInfo struct {
 	UUID           string                   `json:"model-uuid" yaml:"model-uuid"`
 	ControllerUUID string                   `json:"controller-uuid" yaml:"controller-uuid"`
 	Owner          string                   `json:"owner" yaml:"owner"`
-	ProviderType   string                   `json:"type" yaml:"type"`
+	Cloud          string                   `json:"cloud" yaml:"cloud"`
+	CloudRegion    string                   `json:"region,omitempty" yaml:"region,omitempty"`
 	Life           string                   `json:"life" yaml:"life"`
 	Status         ModelStatus              `json:"status" yaml:"status"`
 	Users          map[string]ModelUserInfo `json:"users" yaml:"users"`
@@ -59,7 +60,8 @@ func ModelInfoFromParams(info params.ModelInfo, now time.Time) (ModelInfo, error
 		Owner:          tag.Id(),
 		Life:           string(info.Life),
 		Status:         status,
-		ProviderType:   info.ProviderType,
+		Cloud:          info.Cloud,
+		CloudRegion:    info.CloudRegion,
 		Users:          ModelUserInfoFromParams(info.Users, now),
 	}, nil
 }

--- a/cmd/juju/model/show_test.go
+++ b/cmd/juju/model/show_test.go
@@ -75,7 +75,8 @@ func (s *ShowCommandSuite) SetUpTest(c *gc.C) {
 		UUID:           testing.ModelTag.Id(),
 		ControllerUUID: "1ca2293b-fdb9-4299-97d6-55583bb39364",
 		OwnerTag:       "user-admin@local",
-		ProviderType:   "openstack",
+		Cloud:          "canonistack",
+		CloudRegion:    "lcy01",
 		Life:           params.Alive,
 		Status: params.EntityStatus{
 			Status: status.StatusActive,
@@ -90,7 +91,8 @@ func (s *ShowCommandSuite) SetUpTest(c *gc.C) {
 			"model-uuid":      "deadbeef-0bad-400d-8000-4b1d0d06f00d",
 			"controller-uuid": "1ca2293b-fdb9-4299-97d6-55583bb39364",
 			"owner":           "admin@local",
-			"type":            "openstack",
+			"cloud":           "canonistack",
+			"region":          "lcy01",
 			"life":            "alive",
 			"status": attrs{
 				"current": "active",

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/cloudimagemetadata"
 	"github.com/juju/juju/state/multiwatcher"
+	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
@@ -612,12 +613,12 @@ func (s *BootstrapSuite) TestBootstrapArgs(c *gc.C) {
 
 func (s *BootstrapSuite) TestInitializeStateArgs(c *gc.C) {
 	var called int
-	initializeState := func(_ names.UserTag, _ agent.ConfigSetter, envCfg *config.Config, hostedModelConfig map[string]interface{}, machineCfg agentbootstrap.BootstrapMachineConfig, dialOpts mongo.DialOpts, policy state.Policy) (_ *state.State, _ *state.Machine, resultErr error) {
+	initializeState := func(_ names.UserTag, _ agent.ConfigSetter, args agentbootstrap.InitializeStateParams, dialOpts mongo.DialOpts, policy state.Policy) (_ *state.State, _ *state.Machine, resultErr error) {
 		called++
 		c.Assert(dialOpts.Direct, jc.IsTrue)
 		c.Assert(dialOpts.Timeout, gc.Equals, 30*time.Second)
 		c.Assert(dialOpts.SocketTimeout, gc.Equals, 123*time.Second)
-		c.Assert(hostedModelConfig, jc.DeepEquals, map[string]interface{}{
+		c.Assert(args.HostedModelConfig, jc.DeepEquals, map[string]interface{}{
 			"name": "hosted-model",
 			"uuid": s.hostedModelUUID,
 		})
@@ -633,7 +634,7 @@ func (s *BootstrapSuite) TestInitializeStateArgs(c *gc.C) {
 
 func (s *BootstrapSuite) TestInitializeStateMinSocketTimeout(c *gc.C) {
 	var called int
-	initializeState := func(_ names.UserTag, _ agent.ConfigSetter, envCfg *config.Config, hostedModelConfig map[string]interface{}, machineCfg agentbootstrap.BootstrapMachineConfig, dialOpts mongo.DialOpts, policy state.Policy) (_ *state.State, _ *state.Machine, resultErr error) {
+	initializeState := func(_ names.UserTag, _ agent.ConfigSetter, args agentbootstrap.InitializeStateParams, dialOpts mongo.DialOpts, policy state.Policy) (_ *state.State, _ *state.Machine, resultErr error) {
 		called++
 		c.Assert(dialOpts.Direct, jc.IsTrue)
 		c.Assert(dialOpts.SocketTimeout, gc.Equals, 1*time.Minute)
@@ -843,6 +844,8 @@ func (s *BootstrapSuite) makeTestEnv(c *gc.C) {
 		"name": "hosted-model",
 		"uuid": s.hostedModelUUID,
 	}
+	args.Cloud = "dummy"
+	args.PublicClouds = statetesting.TestClouds()
 	s.bootstrapParams = args
 	s.writeBootstrapParamsFile(c)
 }

--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -40,6 +40,9 @@ type Model interface {
 	Owner() names.UserTag
 	Config() map[string]interface{}
 	LatestToolsVersion() version.Number
+	Cloud() string
+	CloudRegion() string
+	CloudCredential() string
 
 	// UpdateConfig overwrites existing config values with those specified.
 	UpdateConfig(map[string]interface{})

--- a/core/description/model_test.go
+++ b/core/description/model_test.go
@@ -48,10 +48,13 @@ func (*ModelSerializationSuite) TestUnknownVersion(c *gc.C) {
 }
 
 func (*ModelSerializationSuite) TestUpdateConfig(c *gc.C) {
-	model := NewModel(ModelArgs{Config: map[string]interface{}{
-		"name": "awesome",
-		"uuid": "some-uuid",
-	}})
+	model := NewModel(ModelArgs{
+		Config: map[string]interface{}{
+			"name": "awesome",
+			"uuid": "some-uuid",
+		},
+		Cloud: "dummy",
+	})
 	model.UpdateConfig(map[string]interface{}{
 		"name": "something else",
 		"key":  "value",
@@ -181,7 +184,7 @@ func (*ModelSerializationSuite) TestModelValidation(c *gc.C) {
 }
 
 func (*ModelSerializationSuite) TestModelValidationChecksMachines(c *gc.C) {
-	model := NewModel(ModelArgs{Owner: names.NewUserTag("owner")})
+	model := NewModel(ModelArgs{Owner: names.NewUserTag("owner"), Cloud: "dummy"})
 	model.AddMachine(MachineArgs{})
 	err := model.Validate()
 	c.Assert(err, gc.ErrorMatches, "machine missing id not valid")
@@ -197,14 +200,14 @@ func (s *ModelSerializationSuite) addMachineToModel(model Model, id string) Mach
 }
 
 func (s *ModelSerializationSuite) TestModelValidationChecksMachinesGood(c *gc.C) {
-	model := NewModel(ModelArgs{Owner: names.NewUserTag("owner")})
+	model := NewModel(ModelArgs{Owner: names.NewUserTag("owner"), Cloud: "dummy"})
 	s.addMachineToModel(model, "0")
 	err := model.Validate()
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *ModelSerializationSuite) TestModelValidationChecksOpenPortsUnits(c *gc.C) {
-	model := NewModel(ModelArgs{Owner: names.NewUserTag("owner")})
+	model := NewModel(ModelArgs{Owner: names.NewUserTag("owner"), Cloud: "dummy"})
 	machine := s.addMachineToModel(model, "0")
 	machine.AddOpenedPorts(OpenedPortsArgs{
 		OpenedPorts: []PortRangeArgs{
@@ -221,7 +224,7 @@ func (s *ModelSerializationSuite) TestModelValidationChecksOpenPortsUnits(c *gc.
 }
 
 func (*ModelSerializationSuite) TestModelValidationChecksApplications(c *gc.C) {
-	model := NewModel(ModelArgs{Owner: names.NewUserTag("owner")})
+	model := NewModel(ModelArgs{Owner: names.NewUserTag("owner"), Cloud: "dummy"})
 	model.AddApplication(ApplicationArgs{})
 	err := model.Validate()
 	c.Assert(err, gc.ErrorMatches, "application missing name not valid")
@@ -256,7 +259,9 @@ func (s *ModelSerializationSuite) wordpressModel() (Model, Endpoint, Endpoint) {
 		Owner: names.NewUserTag("owner"),
 		Config: map[string]interface{}{
 			"uuid": "some-uuid",
-		}})
+		},
+		Cloud: "dummy",
+	})
 	s.addApplicationToModel(model, "wordpress", 2)
 	s.addApplicationToModel(model, "mysql", 1)
 

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/utils/ssh"
 	"github.com/juju/version"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
@@ -92,6 +93,30 @@ type BootstrapParams struct {
 	// used to retrieve the Juju GUI archive installed in the controller.
 	// If not set, the Juju GUI is not installed from simplestreams.
 	GUIDataSourceBaseURL string
+
+	// PublicClouds contains the public clouds known to the client, which
+	// will be stored in the controller.
+	PublicClouds map[string]cloud.Cloud
+
+	// PersonalClouds contains the bootstrapping user's personal clouds,
+	// which will be stored in the controller.
+	PersonalClouds map[string]cloud.Cloud
+
+	// CloudCredentials contains the cloud credentials which will be stored
+	// in the controller for the admin user.
+	CloudCredentials map[string]cloud.CloudCredential
+
+	// Cloud is the name of the cloud that Juju will be bootstrapped in.
+	Cloud string
+
+	// CloudRegion is the name of the cloud region that Juju will be
+	// bootstrapped in. This will be empty for clouds that do not support
+	// regions.
+	CloudRegion string
+
+	// CloudCredential is the name of the cloud credential used to
+	// bootstrap Juju.
+	CloudCredential string
 }
 
 // Bootstrap bootstraps the given environment. The supplied constraints are
@@ -267,6 +292,12 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	instanceConfig.Bootstrap.GUI = guiArchive(args.GUIDataSourceBaseURL, func(msg string) {
 		ctx.Infof(msg)
 	})
+	instanceConfig.Bootstrap.PublicClouds = args.PublicClouds
+	instanceConfig.Bootstrap.PersonalClouds = args.PersonalClouds
+	instanceConfig.Bootstrap.CloudCredentials = args.CloudCredentials
+	instanceConfig.Bootstrap.ControllerCloud = args.Cloud
+	instanceConfig.Bootstrap.ControllerCloudRegion = args.CloudRegion
+	instanceConfig.Bootstrap.ControllerCloudCredential = args.CloudCredential
 
 	if err := result.Finalize(ctx, instanceConfig); err != nil {
 		return err

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -103,7 +103,7 @@ models:
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
   controller-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
   owner: admin@local
-  type: dummy
+  cloud: dummy
   life: alive
   status:
     current: available

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -288,7 +288,9 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	s.DefaultToolsStorage = stor
 
 	s.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
-	err = bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), environ, bootstrap.BootstrapParams{})
+	err = bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), environ, bootstrap.BootstrapParams{
+		Cloud: "dummy",
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	getStater := environ.(GetStater)

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -149,8 +149,8 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 	fmt.Fprintf(ctx.GetStderr(), " - %s\n", result.Instance.Id())
 
 	finalize := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig) error {
-		icfg.Bootstrap.InstanceId = result.Instance.Id()
-		icfg.Bootstrap.HardwareCharacteristics = result.Hardware
+		icfg.Bootstrap.BootstrapMachineInstanceId = result.Instance.Id()
+		icfg.Bootstrap.BootstrapMachineHardwareCharacteristics = result.Hardware
 		envConfig := env.Config()
 		if result.Config != nil {
 			updated, err := envConfig.Apply(result.Config.UnknownAttrs())

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -723,9 +723,22 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 		// the password in the info structure is empty, so the admin
 		// user is constructed with an empty password here.
 		// It is set just below.
-		st, err := state.Initialize(
-			names.NewUserTag("admin@local"), info, cfg,
-			mongotest.DialOpts(), estate.statePolicy)
+		st, err := state.Initialize(state.InitializeParams{
+			ControllerModelArgs: state.ModelArgs{
+				Owner:  names.NewUserTag("admin@local"),
+				Config: cfg,
+				Cloud:  "dummy",
+			},
+			PublicClouds: map[string]cloud.Cloud{
+				"dummy": {
+					Type:      "dummy",
+					AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
+				},
+			},
+			Policy:        estate.statePolicy,
+			MongoInfo:     info,
+			MongoDialOpts: mongotest.DialOpts(),
+		})
 		if err != nil {
 			panic(err)
 		}

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -105,8 +105,8 @@ func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 		return nil, err
 	}
 	finalize := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig) error {
-		icfg.Bootstrap.InstanceId = BootstrapInstanceId
-		icfg.Bootstrap.HardwareCharacteristics = &hc
+		icfg.Bootstrap.BootstrapMachineInstanceId = BootstrapInstanceId
+		icfg.Bootstrap.BootstrapMachineHardwareCharacteristics = &hc
 		if err := instancecfg.FinishInstanceConfig(icfg, e.Config()); err != nil {
 			return err
 		}

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -124,6 +124,21 @@ func allCollections() collectionSchema {
 		// one model migration document exists per environment.
 		migrationsActiveC: {global: true},
 
+		// This collection holds information about clouds, and is
+		// global. Any user may have an entry in the collection,
+		// with the document ID keyed on the canonicalized user tag.
+		cloudsC: {
+			global: true,
+		},
+
+		// This collection holds information about cloud credentials,
+		// and is user-specific. Any user may have an entry in the
+		// collection, with the document ID keyed on the canonicalized
+		// user tag.
+		cloudCredentialsC: {
+			global: true,
+		},
+
 		// This collection holds user information that's not specific to any
 		// one model.
 		usersC: {
@@ -383,6 +398,8 @@ const (
 	charmsC                  = "charms"
 	cleanupsC                = "cleanups"
 	cloudimagemetadataC      = "cloudimagemetadata"
+	cloudsC                  = "clouds"
+	cloudCredentialsC        = "cloudCredentials"
 	constraintsC             = "constraints"
 	containerRefsC           = "containerRefs"
 	controllersC             = "controllers"

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -55,7 +55,7 @@ func (s *allWatcherBaseSuite) newState(c *gc.C) *State {
 		"name": fmt.Sprintf("testenv%d", s.envCount),
 		"uuid": utils.MustNewUUID().String(),
 	})
-	_, st, err := s.state.NewModel(ModelArgs{Config: cfg, Owner: s.owner})
+	_, st, err := s.state.NewModel(ModelArgs{Config: cfg, Owner: s.owner, Cloud: "dummy"})
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(*gc.C) { st.Close() })
 	return st

--- a/state/annotations_test.go
+++ b/state/annotations_test.go
@@ -179,7 +179,11 @@ func (s *AnnotationsEnvSuite) createTestEnv(c *gc.C) (*state.Model, *state.State
 		"uuid": uuid.String(),
 	})
 	owner := names.NewUserTag("test@remote")
-	env, st, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: owner})
+	env, st, err := s.State.NewModel(state.ModelArgs{
+		Config: cfg,
+		Owner:  owner,
+		Cloud:  "dummy",
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	return env, st
 }

--- a/state/binarystorage_test.go
+++ b/state/binarystorage_test.go
@@ -85,6 +85,7 @@ func (s *binaryStorageSuite) SetUpTest(c *gc.C) {
 	_, s.st, err = s.State.NewModel(state.ModelArgs{
 		Config: cfg,
 		Owner:  names.NewLocalUserTag("test-admin"),
+		Cloud:  "dummy",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(*gc.C) {

--- a/state/block_test.go
+++ b/state/block_test.go
@@ -194,7 +194,11 @@ func (s *blockSuite) createTestEnv(c *gc.C) (*state.Model, *state.State) {
 		"uuid": uuid.String(),
 	})
 	owner := names.NewUserTag("test@remote")
-	env, st, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: owner})
+	env, st, err := s.State.NewModel(state.ModelArgs{
+		Config: cfg,
+		Owner:  owner,
+		Cloud:  "dummy",
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	return env, st
 }

--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -1,0 +1,116 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/cloud"
+)
+
+// cloudCredentialsDoc records information about a user's cloud credentials.
+type cloudCredentialsDoc struct {
+	DocID            string                            `bson:"_id"`
+	CloudCredentials map[string]cloudCredentialsSubdoc `bson:"cloud-credentials,omitempty"`
+}
+
+// cloudCredentialsSubdoc records credentials and related information
+// for a cloud.
+type cloudCredentialsSubdoc struct {
+	Credentials       map[string]cloudCredentialSubdoc `bson:"credentials"`
+	DefaultCredential string                           `bson:"default-credential,omitempty"`
+	DefaultRegion     string                           `bson:"default-region,omitempty"`
+}
+
+// cloudCredentialSubdoc records a credential for a cloud.
+type cloudCredentialSubdoc struct {
+	AuthType   string            `bson:"auth-type"`
+	Label      string            `bson:"label,omitempty"`
+	Attributes map[string]string `bson:"attributes"`
+}
+
+// initCloudCredentialsOps returns a list of txn.Ops that will initialize
+// a set of cloud credentials for a user.
+func initCloudCredentialsOps(user names.UserTag, cloudCredentials map[string]cloud.CloudCredential) []txn.Op {
+	// TODO(axw) another document and collection to record references
+	// to credentials from models. That would be needed to prevent
+	// removal of credentials while models are still using them.
+	id := names.NewUserTag(user.Canonical()).String()
+	return []txn.Op{{
+		C:      cloudCredentialsC,
+		Id:     id,
+		Assert: txn.DocMissing,
+		Insert: &cloudCredentialsDoc{
+			CloudCredentials: makeCloudCredentials(cloudCredentials),
+		},
+	}}
+}
+
+func makeCloudCredentials(in map[string]cloud.CloudCredential) map[string]cloudCredentialsSubdoc {
+	out := make(map[string]cloudCredentialsSubdoc)
+	for cloudName, cloudCredential := range in {
+		cloudCredentials := make(map[string]cloudCredentialSubdoc)
+		for name, credential := range cloudCredential.AuthCredentials {
+			cloudCredentials[name] = cloudCredentialSubdoc{
+				string(credential.AuthType()),
+				credential.Label,
+				credential.Attributes(),
+			}
+		}
+		out[cloudName] = cloudCredentialsSubdoc{
+			cloudCredentials,
+			cloudCredential.DefaultCredential,
+			cloudCredential.DefaultRegion,
+		}
+	}
+	return out
+}
+
+func (c cloudCredentialsSubdoc) toCloudCredential() cloud.CloudCredential {
+	credentials := make(map[string]cloud.Credential)
+	for name, credential := range c.Credentials {
+		credentials[name] = credential.toCredential()
+	}
+	return cloud.CloudCredential{
+		c.DefaultCredential,
+		c.DefaultRegion,
+		credentials,
+	}
+}
+
+func (c cloudCredentialSubdoc) toCredential() cloud.Credential {
+	out := cloud.NewCredential(cloud.AuthType(c.AuthType), c.Attributes)
+	out.Label = c.Label
+	return out
+}
+
+// CloudCredentials returns the user's cloud credentials, keyed by cloud name.
+func (st *State) CloudCredentials(user names.UserTag) (map[string]cloud.CloudCredential, error) {
+	key := names.NewUserTag(user.Canonical()).String()
+	credentials, err := st.getCloudCredentials(key)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot get cloud credentials for %q")
+	}
+	return credentials, nil
+}
+
+func (st *State) getCloudCredentials(key string) (map[string]cloud.CloudCredential, error) {
+	coll, cleanup := st.getCollection(cloudCredentialsC)
+	defer cleanup()
+
+	var d cloudCredentialsDoc
+	err := coll.FindId(key).One(&d)
+	if err != nil && err != mgo.ErrNotFound {
+		return nil, errors.Trace(err)
+	}
+
+	cloudCredentials := make(map[string]cloud.CloudCredential, len(d.CloudCredentials))
+	for name, subdoc := range d.CloudCredentials {
+		cloudCredentials[name] = subdoc.toCloudCredential()
+	}
+	return cloudCredentials, nil
+}

--- a/state/clouds.go
+++ b/state/clouds.go
@@ -1,0 +1,159 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/cloud"
+)
+
+const publicCloudsKey = "public"
+
+// cloudsDoc records information about a set of clouds.
+type cloudsDoc struct {
+	DocID  string                 `bson:"_id"`
+	Clouds map[string]cloudSubdoc `bson:"clouds,omitempty"`
+}
+
+// cloudSubdoc records information about a cloud.
+type cloudSubdoc struct {
+	Type            string                 `bson:"type"`
+	AuthTypes       []string               `bson:"auth-types,omitempty"`
+	Endpoint        string                 `bson:"endpoint,omitempty"`
+	StorageEndpoint string                 `bson:"storage-endpoint,omitempty"`
+	Regions         []cloudRegionSubdoc    `bson:"regions,omitempty"`
+	Config          map[string]interface{} `bson:"config,omitempty"`
+}
+
+// cloudRegionSubdoc records information about a cloud region.
+type cloudRegionSubdoc struct {
+	Name            string `bson:"name"`
+	Endpoint        string `bson:"endpoint,omitempty"`
+	StorageEndpoint string `bson:"storage-endpoint,omitempty"`
+}
+
+// initPublicCloudsOps returns a list of txn.Ops that will
+// initialize the public clouds for the controller.
+func initPublicCloudsOps(clouds map[string]cloud.Cloud) []txn.Op {
+	id := publicCloudsKey
+	return initCloudsOps(id, clouds)
+}
+
+// initPersonalCloudsOps returns a list of txn.Ops that will
+// initialize the personal clouds for a given user.
+func initPersonalCloudsOps(user names.UserTag, clouds map[string]cloud.Cloud) []txn.Op {
+	id := names.NewUserTag(user.Canonical()).String()
+	return initCloudsOps(id, clouds)
+}
+
+// initCloudsOps returns a list of txn.Ops that will initialize
+// a set of clouds.
+func initCloudsOps(id string, clouds map[string]cloud.Cloud) []txn.Op {
+	// TODO(axw) add another document to record references to clouds
+	// from models. That would be needed to prevent removal of clouds
+	// while models are still using them.
+	return []txn.Op{{
+		C:      cloudsC,
+		Id:     id,
+		Assert: txn.DocMissing,
+		Insert: &cloudsDoc{Clouds: makeClouds(clouds)},
+	}}
+}
+
+func makeClouds(in map[string]cloud.Cloud) map[string]cloudSubdoc {
+	out := make(map[string]cloudSubdoc)
+	for name, cloud := range in {
+		authTypes := make([]string, len(cloud.AuthTypes))
+		for i, authType := range cloud.AuthTypes {
+			authTypes[i] = string(authType)
+		}
+		regions := make([]cloudRegionSubdoc, len(cloud.Regions))
+		for i, region := range cloud.Regions {
+			regions[i] = cloudRegionSubdoc{
+				region.Name,
+				region.Endpoint,
+				region.StorageEndpoint,
+			}
+		}
+		out[name] = cloudSubdoc{
+			cloud.Type,
+			authTypes,
+			cloud.Endpoint,
+			cloud.StorageEndpoint,
+			regions,
+			cloud.Config,
+		}
+	}
+	return out
+}
+
+func (c cloudSubdoc) toCloud() cloud.Cloud {
+	authTypes := make([]cloud.AuthType, len(c.AuthTypes))
+	for i, authType := range c.AuthTypes {
+		authTypes[i] = cloud.AuthType(authType)
+	}
+	regions := make([]cloud.Region, len(c.Regions))
+	for i, region := range c.Regions {
+		regions[i] = region.toRegion()
+	}
+	return cloud.Cloud{
+		c.Type,
+		authTypes,
+		c.Endpoint,
+		c.StorageEndpoint,
+		regions,
+		c.Config,
+	}
+}
+
+func (r cloudRegionSubdoc) toRegion() cloud.Region {
+	return cloud.Region{
+		r.Name,
+		r.Endpoint,
+		r.StorageEndpoint,
+	}
+}
+
+// PublicClouds returns information about all public clouds known to the
+// controller.
+func (st *State) PublicClouds() (map[string]cloud.Cloud, error) {
+	clouds, err := st.getClouds(publicCloudsKey)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot get public clouds")
+	}
+	return clouds, nil
+}
+
+// PersonalClouds returns information about personal clouds known to the
+// controller. Each user may have their own set of personal clouds.
+func (st *State) PersonalClouds(user names.UserTag) (map[string]cloud.Cloud, error) {
+	key := names.NewUserTag(user.Canonical()).String()
+	clouds, err := st.getClouds(key)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot get clouds for %s", user.String())
+	}
+	return clouds, nil
+}
+
+func (st *State) getClouds(key string) (map[string]cloud.Cloud, error) {
+	coll, cleanup := st.getCollection(cloudsC)
+	defer cleanup()
+
+	var d cloudsDoc
+	err := coll.FindId(key).One(&d)
+	if err != nil && err != mgo.ErrNotFound {
+		return nil, errors.Trace(err)
+	}
+
+	clouds := make(map[string]cloud.Cloud, len(d.Clouds))
+	for name, subdoc := range d.Clouds {
+		cloud := subdoc.toCloud()
+		clouds[name] = cloud
+	}
+	return clouds, nil
+}

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -107,7 +107,11 @@ func (s *ConnSuite) NewStateForModelNamed(c *gc.C, modelName string) *state.Stat
 		"uuid": utils.MustNewUUID().String(),
 	})
 	otherOwner := names.NewLocalUserTag("test-admin")
-	_, otherState, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: otherOwner})
+	_, otherState, err := s.State.NewModel(state.ModelArgs{
+		Config: cfg,
+		Owner:  otherOwner,
+		Cloud:  "dummy",
+	})
 
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(*gc.C) { otherState.Close() })

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -9,6 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/testing"
@@ -49,7 +50,21 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 		},
 	}
 	dialopts := mongotest.DialOpts()
-	st, err := Initialize(s.owner, info, testing.ModelConfig(c), dialopts, nil)
+	st, err := Initialize(InitializeParams{
+		ControllerModelArgs: ModelArgs{
+			Owner:  s.owner,
+			Config: testing.ModelConfig(c),
+			Cloud:  "dummy",
+		},
+		PublicClouds: map[string]cloud.Cloud{
+			"dummy": {
+				Type:      "dummy",
+				AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
+			},
+		},
+		MongoInfo:     info,
+		MongoDialOpts: dialopts,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.state = st
 	s.AddCleanup(func(*gc.C) { s.state.Close() })

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -59,6 +59,9 @@ func (st *State) Export() (description.Model, error) {
 		Config:             modelConfig.Settings,
 		LatestToolsVersion: dbModel.LatestToolsVersion(),
 		Blocks:             blocks,
+		Cloud:              dbModel.Cloud(),
+		CloudRegion:        dbModel.CloudRegion(),
+		CloudCredential:    dbModel.CloudCredential(),
 	}
 	export.model = description.NewModel(args)
 	modelKey := dbModel.globalKey()

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -57,9 +57,12 @@ func (st *State) Import(model description.Model) (_ *Model, _ *State, err error)
 		return nil, nil, errors.Trace(err)
 	}
 	dbModel, newSt, err := st.NewModel(ModelArgs{
-		Config:        cfg,
-		Owner:         model.Owner(),
-		MigrationMode: MigrationModeImporting,
+		Config:          cfg,
+		Owner:           model.Owner(),
+		Cloud:           model.Cloud(),
+		CloudRegion:     model.CloudRegion(),
+		CloudCredential: model.CloudCredential(),
+		MigrationMode:   MigrationModeImporting,
 	})
 	if err != nil {
 		return nil, nil, errors.Trace(err)

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -116,6 +116,10 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 
 	// THIS SET WILL BE REMOVED WHEN MIGRATIONS ARE COMPLETE
 	todoCollections := set.NewStrings(
+		// controller
+		cloudsC,
+		cloudCredentialsC,
+
 		// model
 		cloudimagemetadataC,
 
@@ -184,6 +188,9 @@ func (s *MigrationSuite) TestModelDocFields(c *gc.C) {
 		"MigrationMode",
 		"Owner",
 		"LatestAvailableTools",
+		"Cloud",
+		"CloudRegion",
+		"CloudCredential",
 	)
 	s.AssertExportedFields(c, modelDoc{}, fields)
 }

--- a/state/model.go
+++ b/state/model.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
+	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -17,7 +18,6 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/status"
-	"github.com/juju/version"
 )
 
 // modelGlobalKey is the key for the model, its
@@ -59,6 +59,17 @@ type modelDoc struct {
 	Owner         string        `bson:"owner"`
 	ServerUUID    string        `bson:"server-uuid"`
 	MigrationMode MigrationMode `bson:"migration-mode"`
+
+	// Cloud is the name of the cloud that the model is managed within.
+	Cloud string `bson:"cloud"`
+
+	// CloudRegion is the name of the cloud region that the model is
+	// managed within. For clouds without regions, this will be empty.
+	CloudRegion string `bson:"cloud-region,omitempty"`
+
+	// TODO(axw) put this in config? Probably better off here, since
+	// we'll need to refer to the field in transactions.
+	CloudCredential string `bson:"cloud-credential,omitempty"`
 
 	// LatestAvailableTools is a string representing the newest version
 	// found while checking streams for new versions.
@@ -145,9 +156,45 @@ func (st *State) AllModels() ([]*Model, error) {
 
 // ModelArgs is a params struct for creating a new model.
 type ModelArgs struct {
-	Config        *config.Config
-	Owner         names.UserTag
+	// Cloud is the name of the cloud that the model is deployed to.
+	Cloud string
+
+	// CloudRegion is the name of the cloud region that the model is
+	// deployed to. For clouds without regions, this will be empty.
+	CloudRegion string
+
+	// CloudCredential is the name of the cloud credential. The name is
+	// relative to the model owner and the cloud name. For clouds that
+	// do not require authentication, this will be empty.
+	CloudCredential string
+
+	// Config is the model config.
+	Config *config.Config
+
+	// Owner is the user that owns the model.
+	Owner names.UserTag
+
+	// MigrationMode is the initial migration mode of the model.
 	MigrationMode MigrationMode
+}
+
+// Validate validates the ModelArgs.
+func (m ModelArgs) Validate() error {
+	if m.Cloud == "" {
+		return errors.NotValidf("empty Cloud")
+	}
+	if m.Config == nil {
+		return errors.NotValidf("nil Config")
+	}
+	if m.Owner == (names.UserTag{}) {
+		return errors.NotValidf("empty Owner")
+	}
+	switch m.MigrationMode {
+	case MigrationModeActive, MigrationModeImporting:
+	default:
+		return errors.NotValidf("initial migration mode %q", m.MigrationMode)
+	}
+	return nil
 }
 
 // NewModel creates a new model with its own UUID and
@@ -160,6 +207,10 @@ type ModelArgs struct {
 // models, perhaps for future use around cross model
 // relations.
 func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
+	if err := args.Validate(); err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
 	owner := args.Owner
 	if owner.IsLocal() {
 		if _, err := st.User(owner); err != nil {
@@ -178,7 +229,10 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 		}
 	}()
 
-	ops, err := newState.modelSetupOps(args.Config, owner, args.MigrationMode)
+	ops, err := newState.modelSetupOps(
+		args.Config, args.Cloud, args.CloudRegion, args.CloudCredential,
+		owner, args.MigrationMode,
+	)
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "failed to create new model")
 	}
@@ -248,6 +302,23 @@ func (m *Model) ControllerUUID() string {
 // Name returns the human friendly name of the model.
 func (m *Model) Name() string {
 	return m.doc.Name
+}
+
+// Cloud returns the name of the cloud that the model is deployed to.
+func (m *Model) Cloud() string {
+	return m.doc.Cloud
+}
+
+// CloudRegion returns the name of the cloud region that the model is
+// deployed to.
+func (m *Model) CloudRegion() string {
+	return m.doc.CloudRegion
+}
+
+// CloudCredential returns the name of the cloud credential for the
+// model.
+func (m *Model) CloudCredential() string {
+	return m.doc.CloudCredential
 }
 
 // MigrationMode returns whether the model is active or being migrated.
@@ -738,14 +809,21 @@ func ensureDestroyable(st *State) error {
 
 // createModelOp returns the operation needed to create
 // an model document with the given name and UUID.
-func createModelOp(st *State, owner names.UserTag, name, uuid, server string, mode MigrationMode) txn.Op {
+func createModelOp(
+	st *State, owner names.UserTag,
+	name, uuid, server, cloud, cloudRegion, cloudCredential string,
+	mode MigrationMode,
+) txn.Op {
 	doc := &modelDoc{
-		UUID:          uuid,
-		Name:          name,
-		Life:          Alive,
-		Owner:         owner.Canonical(),
-		ServerUUID:    server,
-		MigrationMode: mode,
+		UUID:            uuid,
+		Name:            name,
+		Life:            Alive,
+		Owner:           owner.Canonical(),
+		ServerUUID:      server,
+		MigrationMode:   mode,
+		Cloud:           cloud,
+		CloudRegion:     cloudRegion,
+		CloudCredential: cloudCredential,
 	}
 	return txn.Op{
 		C:      modelsC,

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -58,7 +58,11 @@ func (s *ModelSuite) TestNewModelNonExistentLocalUser(c *gc.C) {
 	cfg, _ := s.createTestModelConfig(c)
 	owner := names.NewUserTag("non-existent@local")
 
-	_, _, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: owner})
+	_, _, err := s.State.NewModel(state.ModelArgs{
+		Config: cfg,
+		Owner:  owner,
+		Cloud:  "dummy",
+	})
 	c.Assert(err, gc.ErrorMatches, `cannot create model: user "non-existent" not found`)
 }
 
@@ -67,7 +71,11 @@ func (s *ModelSuite) TestNewModelSameUserSameNameFails(c *gc.C) {
 	owner := s.Factory.MakeUser(c, nil).UserTag()
 
 	// Create the first model.
-	_, st1, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: owner})
+	_, st1, err := s.State.NewModel(state.ModelArgs{
+		Config: cfg,
+		Owner:  owner,
+		Cloud:  "dummy",
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer st1.Close()
 
@@ -79,7 +87,11 @@ func (s *ModelSuite) TestNewModelSameUserSameNameFails(c *gc.C) {
 		"name": cfg.Name(),
 		"uuid": newUUID.String(),
 	})
-	_, _, err = s.State.NewModel(state.ModelArgs{Config: cfg2, Owner: owner})
+	_, _, err = s.State.NewModel(state.ModelArgs{
+		Config: cfg2,
+		Owner:  owner,
+		Cloud:  "dummy",
+	})
 	errMsg := fmt.Sprintf("model %q for %s already exists", cfg2.Name(), owner.Canonical())
 	c.Assert(err, gc.ErrorMatches, errMsg)
 	c.Assert(errors.IsAlreadyExists(err), jc.IsTrue)
@@ -98,7 +110,11 @@ func (s *ModelSuite) TestNewModelSameUserSameNameFails(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// We should now be able to create the other model.
-	env2, st2, err := s.State.NewModel(state.ModelArgs{Config: cfg2, Owner: owner})
+	env2, st2, err := s.State.NewModel(state.ModelArgs{
+		Config: cfg2,
+		Owner:  owner,
+		Cloud:  "dummy",
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer st2.Close()
 	c.Assert(env2, gc.NotNil)
@@ -109,7 +125,7 @@ func (s *ModelSuite) TestNewModel(c *gc.C) {
 	cfg, uuid := s.createTestModelConfig(c)
 	owner := names.NewUserTag("test@remote")
 
-	model, st, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: owner})
+	model, st, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: owner, Cloud: "dummy"})
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -153,6 +169,7 @@ func (s *ModelSuite) TestNewModelImportingMode(c *gc.C) {
 	env, st, err := s.State.NewModel(state.ModelArgs{
 		Config:        cfg,
 		Owner:         owner,
+		Cloud:         "dummy",
 		MigrationMode: state.MigrationModeImporting,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -165,7 +182,11 @@ func (s *ModelSuite) TestSetMigrationMode(c *gc.C) {
 	cfg, _ := s.createTestModelConfig(c)
 	owner := names.NewUserTag("test@remote")
 
-	env, st, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: owner})
+	env, st, err := s.State.NewModel(state.ModelArgs{
+		Config: cfg,
+		Owner:  owner,
+		Cloud:  "dummy",
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -191,7 +212,9 @@ func (s *ModelSuite) TestControllerModelAccessibleFromOtherModels(c *gc.C) {
 	_, st, err := s.State.NewModel(state.ModelArgs{
 		Config: cfg,
 		Owner:  names.NewUserTag("test@remote"),
+		Cloud:  "dummy",
 	})
+	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
 	env, err := st.ControllerModel()

--- a/state/modeluser_test.go
+++ b/state/modeluser_test.go
@@ -290,7 +290,11 @@ func (s *ModelUserSuite) newEnvWithOwner(c *gc.C, name string, owner names.UserT
 		"name": name,
 		"uuid": uuid.String(),
 	})
-	model, st, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: owner})
+	model, st, err := s.State.NewModel(state.ModelArgs{
+		Config: cfg,
+		Owner:  owner,
+		Cloud:  "dummy",
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	return model

--- a/state/open.go
+++ b/state/open.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo"
@@ -103,19 +104,65 @@ func mongodbLogin(session *mgo.Session, mongoInfo *mongo.MongoInfo) error {
 	return nil
 }
 
+// InitializeParams contains the parameters for Initialize.
+type InitializeParams struct {
+	// ControllerModelArgs contains the arguments for creating
+	// the controller model.
+	ControllerModelArgs ModelArgs
+
+	// PublicClouds contains the public clouds to store in the
+	// controller.
+	PublicClouds map[string]cloud.Cloud
+
+	// PersonalClouds contains the personal clouds for the owner
+	// of the controller model to store in the controller.
+	PersonalClouds map[string]cloud.Cloud
+
+	// Credentials contains the credentials for the owner of the
+	// controller model to store in the controller.
+	CloudCredentials map[string]cloud.CloudCredential
+
+	// Policy is the set of state policies to apply.
+	Policy Policy
+
+	// MongoInfo contains the information required to address and
+	// authenticate with Mongo.
+	MongoInfo *mongo.MongoInfo
+
+	// MongoDialOpts contains the dial options for connecting to
+	// Mongo.
+	MongoDialOpts mongo.DialOpts
+}
+
+func (p InitializeParams) Validate() error {
+	if err := p.ControllerModelArgs.Validate(); err != nil {
+		return errors.Trace(err)
+	}
+	uuid := p.ControllerModelArgs.Config.UUID()
+	controllerUUID := p.ControllerModelArgs.Config.ControllerUUID()
+	if uuid != controllerUUID {
+		return errors.NotValidf("mismatching uuid (%v) and controller-uuid (%v)", uuid, controllerUUID)
+	}
+	if p.MongoInfo == nil {
+		return errors.NotValidf("nil MongoInfo")
+	}
+	if len(p.PublicClouds) == 0 {
+		return errors.NotValidf("empty public clouds")
+	}
+	return nil
+}
+
 // Initialize sets up an initial empty state and returns it.
 // This needs to be performed only once for the initial controller model.
 // It returns unauthorizedError if access is unauthorized.
-func Initialize(owner names.UserTag, info *mongo.MongoInfo, cfg *config.Config, opts mongo.DialOpts, policy Policy) (_ *State, err error) {
-	uuid := cfg.UUID()
-	// When creating the controller model, the new model
-	// UUID is also used as the controller UUID.
-	controllerUUID := cfg.ControllerUUID()
-	if controllerUUID != uuid {
-		return nil, errors.Errorf("when initialising state, model and controller UUIDs must be equal, got %v and %v", uuid, controllerUUID)
+func Initialize(args InitializeParams) (_ *State, err error) {
+	if err := args.Validate(); err != nil {
+		return nil, errors.Trace(err)
 	}
+
+	uuid := args.ControllerModelArgs.Config.UUID()
 	modelTag := names.NewModelTag(uuid)
-	st, err := open(modelTag, info, opts, policy)
+	st, err := open(modelTag, args.MongoInfo, args.MongoDialOpts, args.Policy)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -137,7 +184,14 @@ func Initialize(owner names.UserTag, info *mongo.MongoInfo, cfg *config.Config, 
 	}
 
 	logger.Infof("initializing controller model %s", uuid)
-	modelOps, err := st.modelSetupOps(cfg, owner, MigrationModeActive)
+	modelOps, err := st.modelSetupOps(
+		args.ControllerModelArgs.Config,
+		args.ControllerModelArgs.Cloud,
+		args.ControllerModelArgs.CloudRegion,
+		args.ControllerModelArgs.CloudCredential,
+		args.ControllerModelArgs.Owner,
+		MigrationModeActive,
+	)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -145,11 +199,15 @@ func Initialize(owner names.UserTag, info *mongo.MongoInfo, cfg *config.Config, 
 	if err != nil {
 		return nil, err
 	}
+
 	// Extract just the controller config.
-	controllerCfg := controllerConfig(cfg.AllAttrs())
+	controllerCfg := controllerConfig(args.ControllerModelArgs.Config.AllAttrs())
 
 	ops := []txn.Op{
-		createInitialUserOp(st, owner, info.Password, salt),
+		createInitialUserOp(
+			st, args.ControllerModelArgs.Owner,
+			args.MongoInfo.Password, salt,
+		),
 		txn.Op{
 			C:      controllersC,
 			Id:     modelGlobalKey,
@@ -178,6 +236,9 @@ func Initialize(owner names.UserTag, info *mongo.MongoInfo, cfg *config.Config, 
 		},
 		createSettingsOp(controllersC, controllerSettingsGlobalKey, controllerCfg),
 	}
+	ops = append(ops, initPublicCloudsOps(args.PublicClouds)...)
+	ops = append(ops, initPersonalCloudsOps(args.ControllerModelArgs.Owner, args.PersonalClouds)...)
+	ops = append(ops, initCloudCredentialsOps(args.ControllerModelArgs.Owner, args.CloudCredentials)...)
 	ops = append(ops, modelOps...)
 
 	if err := st.runTransaction(ops); err != nil {
@@ -190,7 +251,11 @@ func Initialize(owner names.UserTag, info *mongo.MongoInfo, cfg *config.Config, 
 }
 
 // modelSetupOps returns the transaction operations necessary to set up a model.
-func (st *State) modelSetupOps(cfg *config.Config, owner names.UserTag, mode MigrationMode) ([]txn.Op, error) {
+func (st *State) modelSetupOps(
+	cfg *config.Config,
+	cloud, cloudRegion, cloudCredential string,
+	owner names.UserTag, mode MigrationMode,
+) ([]txn.Op, error) {
 	if err := checkModelConfig(cfg); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -231,7 +296,7 @@ func (st *State) modelSetupOps(cfg *config.Config, owner names.UserTag, mode Mig
 	ops = append(ops,
 		createSettingsOp(settingsC, modelGlobalKey, modelCfg),
 		createModelEntityRefsOp(st, modelUUID),
-		createModelOp(st, owner, cfg.Name(), modelUUID, controllerUUID, mode),
+		createModelOp(st, owner, cfg.Name(), modelUUID, controllerUUID, cloud, cloudRegion, cloudCredential, mode),
 		createUniqueOwnerModelNameOp(owner, cfg.Name()),
 		modelUserOp,
 	)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4149,7 +4149,16 @@ func (s *SetAdminMongoPasswordSuite) TestSetAdminMongoPassword(c *gc.C) {
 		Password: password,
 	}
 	cfg := testing.ModelConfig(c)
-	st, err := state.Initialize(owner, authInfo, cfg, mongotest.DialOpts(), nil)
+	st, err := state.Initialize(state.InitializeParams{
+		ControllerModelArgs: state.ModelArgs{
+			Owner:  owner,
+			Config: cfg,
+			Cloud:  "dummy",
+		},
+		PublicClouds:  statetesting.TestClouds(),
+		MongoInfo:     authInfo,
+		MongoDialOpts: mongotest.DialOpts(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 

--- a/state/testing/clouds.go
+++ b/state/testing/clouds.go
@@ -1,0 +1,48 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import "github.com/juju/juju/cloud"
+
+func TestClouds() map[string]cloud.Cloud {
+	return map[string]cloud.Cloud{
+		"dummy": {
+			Type:      "dummy",
+			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
+		},
+		"dummy-regions": {
+			Type:      "dummy",
+			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
+			Regions: []cloud.Region{{
+				Name: "region-1",
+			}, {
+				Name: "region-2",
+			}},
+		},
+		"dummy-auth": {
+			Type:      "dummy",
+			AuthTypes: []cloud.AuthType{cloud.UserPassAuthType},
+			Regions: []cloud.Region{{
+				Name: "region-1",
+			}, {
+				Name: "region-2",
+			}},
+		},
+	}
+}
+
+func TestCredentials() map[string]cloud.CloudCredential {
+	return map[string]cloud.CloudCredential{
+		"dummy-auth": {
+			DefaultCredential: "street",
+			DefaultRegion:     "region-1",
+			AuthCredentials: map[string]cloud.Credential{
+				"street": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+					"username": "vulture",
+					"password": "hunter2",
+				}),
+			},
+		},
+	}
+}

--- a/state/testing/conn.go
+++ b/state/testing/conn.go
@@ -26,7 +26,18 @@ func Initialize(c *gc.C, owner names.UserTag, cfg *config.Config, policy state.P
 	mgoInfo := NewMongoInfo()
 	dialOpts := mongotest.DialOpts()
 
-	st, err := state.Initialize(owner, mgoInfo, cfg, dialOpts, policy)
+	st, err := state.Initialize(state.InitializeParams{
+		ControllerModelArgs: state.ModelArgs{
+			Owner:  owner,
+			Config: cfg,
+			Cloud:  "dummy",
+		},
+		MongoInfo:        mgoInfo,
+		MongoDialOpts:    dialOpts,
+		Policy:           policy,
+		PublicClouds:     TestClouds(),
+		CloudCredentials: TestCredentials(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	return st
 }

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -592,6 +592,7 @@ func (factory *Factory) MakeModel(c *gc.C, params *ModelParams) *state.State {
 	_, st, err := factory.st.NewModel(state.ModelArgs{
 		Config: cfg,
 		Owner:  params.Owner.(names.UserTag),
+		Cloud:  "dummy",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return st


### PR DESCRIPTION
Add global collections for cloud definitions
and cloud credentials to state. There will be
one document containing the public clouds,
and one per user for personal clouds. Each
user will have their own personal credentials.

TODO:
 - update add-model to take a cloud, region
   and credential name and pass them through to
   the backend. The backend will refer to the
   collections in state.
 - remove cloud-specific credential attributes
   from model config, instead just pass cloud/region
   definitions and credentials to provider (probably
   all as part of environs/config.Config).
 - change how we flag that credentials were auto-
   discovered in bootstrap-config.yaml, so it's not
   dependent on an empty credential name.
 - add reference tracking from models to clouds and
   credentials.
 - add commands to manage clouds and credentials
   in the controller.
 - add a command to switch a model's cloud credentials.
 - probably other things I have forgotten or haven't
   yet encountered.

(Review request: http://reviews.vapour.ws/r/5000/)