### PR TITLE
Update run-action helper text

### DIFF
--- a/cmd/juju/action/run.go
+++ b/cmd/juju/action/run.go
@@ -39,8 +39,9 @@ type runCommand struct {
 
 const runDoc = `
 Queue an Action for execution on a given unit, with a given set of params.
-Displays the ID of the Action for use with 'juju kill', 'juju status', etc.
-
+The Action ID is returned for use with 'juju show-action-output <ID>' or
+'juju show-action-status <ID>'.
+ 
 Params are validated according to the charm for the unit's application.  The 
 valid params can be seen using "juju action defined <application> --schema".
 Params may be in a yaml file which is passed with the --params flag, or they


### PR DESCRIPTION
`juju kill` and `juju status` do not appear to have anything to do with Action IDs anymore.
Following what the latest charmstore documentation has, I added the relevant commands:
```
juju show-action-output
juju show-action-status
```
https://jujucharms.com/docs/devel/actions