### PR TITLE
state/presence: make presence workers implement worker.Worker

### DIFF
--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -566,6 +566,11 @@ func (p *Pinger) Start() error {
 	return nil
 }
 
+// Kill is part of the worker.Worker interface.
+func (p *Pinger) Kill() {
+	p.tomb.Kill(nil)
+}
+
 // Wait returns when the Pinger has stopped, and returns the first error
 // it encountered.
 func (p *Pinger) Wait() error {

--- a/state/presence/presence_test.go
+++ b/state/presence/presence_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/juju/juju/state/presence"
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
 )
 
 func TestPackage(t *stdtesting.T) {
@@ -96,12 +97,8 @@ func assertAlive(c *gc.C, w *presence.Watcher, key string, alive bool) {
 // Use this method in favor of defer w.Stop() because you _must_ ensure
 // that the worker has stopped, and thus is no longer using its mgo
 // session before TearDownTest shuts down the connection.
-func assertStopped(c *gc.C, w interface {
-	Stop() error
-	Wait() error
-}) {
-	c.Assert(w.Stop(), gc.IsNil)
-	w.Wait()
+func assertStopped(c *gc.C, w worker.Worker) {
+	c.Assert(worker.Stop(w), gc.IsNil)
 }
 
 func (s *PresenceSuite) TestErrAndDead(c *gc.C) {


### PR DESCRIPTION
Updates LP 1590161

Followup to juju/juju#5543 as requested by @fwreade

This change makes presence worker types implement worker.Worker which
allows us to use the worker.Stop(w) helper. This in turn unblocks parts
of juju/juju#5543 which had to be rolled back. See 1590161 for details.

(Review request: http://reviews.vapour.ws/r/5007/)