### PR TITLE
all: don't leak pingers in tests

### DIFF
--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/juju/storage/provider"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
+	"github.com/juju/juju/worker"
 )
 
 type baseSuite struct {
@@ -486,8 +487,12 @@ func (s *baseSuite) setupStoragePool(c *gc.C) {
 }
 
 func (s *baseSuite) setAgentPresence(c *gc.C, u *state.Unit) {
-	_, err := u.SetAgentPresence()
+	pinger, err := u.SetAgentPresence()
 	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		c.Assert(worker.Stop(pinger), jc.ErrorIsNil)
+	})
+
 	s.State.StartSync()
 	s.BackingState.StartSync()
 	err = u.WaitAgentPresence(coretesting.LongWait)

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -40,6 +40,7 @@ import (
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	jujuversion "github.com/juju/juju/version"
+	"github.com/juju/juju/worker"
 )
 
 type serverSuite struct {
@@ -66,6 +67,9 @@ func (s *serverSuite) setAgentPresence(c *gc.C, machineId string) *presence.Ping
 	c.Assert(err, jc.ErrorIsNil)
 	pinger, err := m.SetAgentPresence()
 	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		c.Assert(worker.Stop(pinger), jc.ErrorIsNil)
+	})
 	s.State.StartSync()
 	err = m.WaitAgentPresence(coretesting.LongWait)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/jujud/agent/imagemetadataworker_test.go
+++ b/cmd/jujud/agent/imagemetadataworker_test.go
@@ -23,11 +23,6 @@ type MachineMockProviderSuite struct {
 
 var _ = gc.Suite(&MachineMockProviderSuite{})
 
-func (s *MachineMockProviderSuite) SetUpTest(c *gc.C) {
-	// Change to environ that supports HasRegion
-	s.commonMachineSuite.SetUpTest(c)
-}
-
 func (s *MachineMockProviderSuite) TestMachineAgentRunsMetadataWorker(c *gc.C) {
 	// Patch out the worker func before starting the agent.
 	started := make(chan struct{})

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -498,7 +498,7 @@ func (s *MachineSuite) waitProvisioned(c *gc.C, unit *state.Unit) (*state.Machin
 	m, err := s.State.Machine(machineId)
 	c.Assert(err, jc.ErrorIsNil)
 	w := m.Watch()
-	defer w.Stop()
+	defer worker.Stop(w)
 	timeout := time.After(coretesting.LongWait)
 	for {
 		select {
@@ -706,7 +706,7 @@ func (s *MachineSuite) TestManageModelRunsCleaner(c *gc.C) {
 		err = unit.Refresh()
 		c.Assert(err, jc.ErrorIsNil)
 		w := unit.Watch()
-		defer w.Stop()
+		defer worker.Stop(w)
 
 		// Trigger a sync on the state used by the agent, and wait
 		// for the unit to be removed.
@@ -739,7 +739,7 @@ func (s *MachineSuite) TestJobManageModelRunsMinUnitsWorker(c *gc.C) {
 		err := service.SetMinUnits(1)
 		c.Assert(err, jc.ErrorIsNil)
 		w := service.Watch()
-		defer w.Stop()
+		defer worker.Stop(w)
 
 		// Trigger a sync on the state used by the agent, and wait for the unit
 		// to be created.

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -153,8 +153,7 @@ func (s *commonMachineSuite) primeAgentWithMachine(c *gc.C, m *state.Machine, ve
 	pinger, err := m.SetAgentPresence()
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(c *gc.C) {
-		err := pinger.Stop()
-		c.Check(err, jc.ErrorIsNil)
+		c.Assert(worker.Stop(pinger), jc.ErrorIsNil)
 	})
 	return s.configureMachine(c, m.Id(), vers)
 }

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/storage/provider/registry"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
 )
 
 type MachineSuite struct {
@@ -627,7 +628,9 @@ func (s *MachineSuite) TestMachineSetAgentPresence(c *gc.C) {
 	pinger, err := s.machine.SetAgentPresence()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(pinger, gc.NotNil)
-	defer pinger.Stop()
+	defer func() {
+		c.Assert(worker.Stop(pinger), jc.ErrorIsNil)
+	}()
 
 	s.State.StartSync()
 	alive, err = s.machine.AgentPresence()

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/state/testing"
 	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
 )
 
 const (
@@ -875,8 +876,9 @@ func (s *UnitSuite) TestUnitSetAgentPresence(c *gc.C) {
 	pinger, err := s.unit.SetAgentPresence()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(pinger, gc.NotNil)
-	defer pinger.Stop()
-
+	defer func() {
+		c.Assert(worker.Stop(pinger), jc.ErrorIsNil)
+	}()
 	s.State.StartSync()
 	alive, err = s.unit.AgentPresence()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/upgrade_test.go
+++ b/state/upgrade_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/worker"
 )
 
 type UpgradeSuite struct {
@@ -61,8 +62,7 @@ func (s *UpgradeSuite) SetUpTest(c *gc.C) {
 	pinger, err := controller.SetAgentPresence()
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(c *gc.C) {
-		err := pinger.Stop()
-		c.Check(err, jc.ErrorIsNil)
+		c.Assert(worker.Stop(pinger), jc.ErrorIsNil)
 	})
 	s.serverIdA = controller.Id()
 	s.provision(c, s.serverIdA)

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/upgrades"
 	jujuversion "github.com/juju/juju/version"
+	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/gate"
 	"github.com/juju/version"
 )
@@ -461,7 +462,9 @@ func (s *UpgradeSuite) setMachineAlive(c *gc.C, id string) {
 	c.Assert(err, jc.ErrorIsNil)
 	pinger, err := machine.SetAgentPresence()
 	c.Assert(err, jc.ErrorIsNil)
-	s.AddCleanup(func(c *gc.C) { pinger.Stop() })
+	s.AddCleanup(func(c *gc.C) {
+		c.Assert(worker.Stop(pinger), jc.ErrorIsNil)
+	})
 }
 
 // Return a version the same as the current software version, but with


### PR DESCRIPTION
Fixes LP 1590161

The fixtures for the many  tests were starting pingers and loosing
track of them; assuming that they would die eventually when mongodb
shuts down ... which is true, except their death was not as private
an affair as previously assumed.

Fix the pinger leak by adding a cleanup action. This lets us remove the
recover in pinger.ping which previously would silently discard this
panic.

Editorial: the root cause of this problem is the mgo driver's copying
semantics -- rather than obtaining a connection to the database, you
copy a collection which is assumed to be already connected. Because this
copy operation does not return an error, the driver has forced itself
into using a panic.

Additionally the SetAgentPresence API on various 'present' things comes
with a footgun of not making clear just how important it is to keep
track of the thing that is tracking presence. The name of that API,
`SetAgentPresence` lulls the reader into thinking it's some kind of
boolean setter "yes, I'd like to track the presence of this thing."
There is little clue that calling that method returns a resource that
if not handled carefully will cause your program to panic randomly.