### PR TITLE
Fixes LP#1576705: cloud image metadata test assertion.

### DIFF
--- a/state/cloudimagemetadata/image_test.go
+++ b/state/cloudimagemetadata/image_test.go
@@ -239,15 +239,25 @@ func (s *cloudImageMetadataSuite) assertRecordMetadata(c *gc.C, m cloudimagemeta
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *cloudImageMetadataSuite) assertMetadataRecorded(c *gc.C, criteria cloudimagemetadata.MetadataAttributes, expected ...cloudimagemetadata.Metadata) {
+func (s *cloudImageMetadataSuite) assertMetadataRecorded(
+	c *gc.C,
+	criteria cloudimagemetadata.MetadataAttributes,
+	expected ...cloudimagemetadata.Metadata,
+) {
 	metadata, err := s.storage.FindMetadata(buildAttributesFilter(criteria))
 	c.Assert(err, jc.ErrorIsNil)
 
+	// Collate expected into a map
 	groups := make(map[cloudimagemetadata.SourceType][]cloudimagemetadata.Metadata)
-	for _, one := range expected {
-		groups[one.Source] = append(groups[one.Source], one)
+	for _, expectedMetadata := range expected {
+		groups[expectedMetadata.Source] = append(groups[expectedMetadata.Source], expectedMetadata)
 	}
-	c.Assert(metadata, jc.DeepEquals, groups)
+
+	// Compare maps by key; order of slices does not matter
+	c.Assert(groups, gc.HasLen, len(metadata))
+	for source, expectedMetadata := range groups {
+		c.Assert(metadata[source], jc.SameContents, expectedMetadata)
+	}
 }
 
 type TestMongo struct {


### PR DESCRIPTION
Straight backport of cloud image metadata test fix.

(Review request: http://reviews.vapour.ws/r/5010/)