### PR TITLE
1585300 - Create windows safe URL for tools

### DIFF
--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"text/template"
 
@@ -70,7 +71,8 @@ func getTestConfig(name, server, oauth, secret string) *config.Config {
 
 func (suite *environSuite) setupFakeTools(c *gc.C) {
 	storageDir := c.MkDir()
-	suite.PatchValue(&envtools.DefaultBaseURL, "file://"+storageDir+"/tools")
+	toolsDir := path.Join(storageDir, "tools")
+	suite.PatchValue(&envtools.DefaultBaseURL, utils.MakeFileURL(toolsDir))
 	suite.UploadFakeToolsToDirectory(c, storageDir, "released", "released")
 }
 


### PR DESCRIPTION
Use path.Join + utils.MakeFileURL to construct the tools
URL before patching.

Tested on Windows and Ubuntu.

(Review request: http://reviews.vapour.ws/r/5017/)