### PR TITLE
Add a Record type to use for log forwarding.

### DIFF
--- a/logfwd/origin.go
+++ b/logfwd/origin.go
@@ -27,16 +27,6 @@ var originTypes = map[OriginType]string{
 
 // OriginType is the "enum" type for the different kinds of log record
 // origin.
-//
-// Go does not have native enum support, nor support for struct literal
-// constants.  Thus to use constants for the enum values we must
-// "typedef" a type that Go supports for constants (e.g. int). One
-// downside is that the underlying concrete value is exposed to type
-// conversion as well as the operators for the underlying type. It also
-// means that any value of the underlying type may be type converted to
-// the enum type, even though the enum type doesn't support the value.
-// Consequently the enum type must have a Validate() method to ensure
-// this did not happen.
 type OriginType int
 
 // ParseOriginType converts a string to an OriginType or fails if

--- a/logfwd/origin.go
+++ b/logfwd/origin.go
@@ -11,8 +11,12 @@ import (
 	"github.com/juju/version"
 )
 
+// canonicalPEN is the IANA-registered Private Enterprise Number
+// assigned to Canonical. Among other things, this is used in RFC 5424
+// structured data.
+//
 // See https://www.iana.org/assignments/enterprise-numbers/enterprise-numbers.
-const canonicalIANAid = "28978"
+const canonicalPEN = 28978
 
 // These are the recognized origin types.
 const (
@@ -82,11 +86,12 @@ type Origin struct {
 	JujuVersion    version.Number
 }
 
-// PrivateEnterpriseCode returns the IANA-registered "SMI Network
+// PrivateEnterpriseNumber returns the IANA-registered "SMI Network
 // Management Private Enterprise Code" to use for the log record.
-// (see https://tools.ietf.org/html/rfc5424#section-7.2.2)
-func (o Origin) PrivateEnterpriseCode() string {
-	return canonicalIANAid
+//
+// See https://tools.ietf.org/html/rfc5424#section-7.2.2.
+func (o Origin) PrivateEnterpriseNumber() int {
+	return canonicalPEN
 }
 
 // SofwareName identifies the software that generated the log message.

--- a/logfwd/origin.go
+++ b/logfwd/origin.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
-	"github.com/juju/names"
 	"github.com/juju/version"
+	"gopkg.in/juju/names.v2"
 )
 
 // canonicalPEN is the IANA-registered Private Enterprise Number

--- a/logfwd/origin.go
+++ b/logfwd/origin.go
@@ -4,6 +4,8 @@
 package logfwd
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	"github.com/juju/version"
@@ -109,16 +111,14 @@ func (o Origin) Validate() error {
 		return errors.NewNotValid(nil, "empty ControllerUUID")
 	}
 	if !names.IsValidModel(o.ControllerUUID) {
-		err := errors.NewNotValid(nil, "must be UUID")
-		return errors.Annotatef(err, "invalid ControllerUUID %q", o.ControllerUUID)
+		return errors.NewNotValid(nil, fmt.Sprintf("ControllerUUID %q not a valid UUID", o.ControllerUUID))
 	}
 
 	if o.ModelUUID == "" {
 		return errors.NewNotValid(nil, "empty ModelUUID")
 	}
 	if !names.IsValidModel(o.ModelUUID) {
-		err := errors.NewNotValid(nil, "must be UUID")
-		return errors.Annotatef(err, "invalid ModelUUID %q", o.ModelUUID)
+		return errors.NewNotValid(nil, fmt.Sprintf("ModelUUID %q not a valid UUID", o.ModelUUID))
 	}
 
 	if err := o.Type.Validate(); err != nil {

--- a/logfwd/origin.go
+++ b/logfwd/origin.go
@@ -79,10 +79,10 @@ type Origin struct {
 	JujuVersion    version.Number
 }
 
-// EnterpriseID returns the IANA-registered "SMI Network Management
-// Private Enterprise Code" to use for the log record.
+// PrivateEnterpriseCode returns the IANA-registered "SMI Network
+// Management Private Enterprise Code" to use for the log record.
 // (see https://tools.ietf.org/html/rfc5424#section-7.2.2)
-func (o Origin) EnterpriseID() string {
+func (o Origin) PrivateEnterpriseCode() string {
 	return canonicalIANAid
 }
 

--- a/logfwd/origin.go
+++ b/logfwd/origin.go
@@ -1,0 +1,129 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logfwd
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/version"
+)
+
+// See https://www.iana.org/assignments/enterprise-numbers/enterprise-numbers.
+const canonicalIANAid = "28978"
+
+// These are the recognized origin types.
+const (
+	originTypeInvalid OriginType = -1
+	OriginTypeUnknown OriginType = 0
+	OriginTypeUser               = iota
+)
+
+var originTypes = map[OriginType]string{
+	OriginTypeUnknown: "unknown",
+	OriginTypeUser:    names.UserTagKind,
+}
+
+// OriginType is the "enum" type for the different kinds of log record origin.
+type OriginType int
+
+// ParseOriginType converts a string to an OriginType or fails if
+// not able. It round-trips with String().
+func ParseOriginType(value string) (OriginType, error) {
+	for ot, str := range originTypes {
+		if value == str {
+			return ot, nil
+		}
+	}
+	return originTypeInvalid, errors.Errorf("unrecognized origin type %q", value)
+}
+
+// String returns a string representation of the origin type.
+func (ot OriginType) String() string {
+	return originTypes[ot]
+}
+
+// Validate ensures that the origin type is correct.
+func (ot OriginType) Validate() error {
+	// Ideally, only the (unavoidable) zero value would be invalid.
+	// However, typedef'ing int means that the use of int literals
+	// could result in invalid values other than the zero value.
+	if _, ok := originTypes[ot]; !ok {
+		return errors.NewNotValid(nil, "unknown origin type")
+	}
+	return nil
+}
+
+// ValidateName ensures that the given origin name is valid within the
+// context of the origin type.
+func (ot OriginType) ValidateName(name string) error {
+	switch ot {
+	case OriginTypeUnknown:
+		if name != "" {
+			return errors.NewNotValid(nil, "origin name must not be set if type is unknown")
+		}
+	case OriginTypeUser:
+		if !names.IsValidUser(name) {
+			return errors.NewNotValid(nil, "bad user")
+		}
+	}
+	return nil
+}
+
+// Validate ensures that the origin is correct.
+type Origin struct {
+	ControllerUUID string
+	ModelUUID      string
+	Type           OriginType
+	Name           string
+	JujuVersion    version.Number
+}
+
+// EnterpriseID returns the IANA-registered "SMI Network Management
+// Private Enterprise Code" to use for the log record.
+// (see https://tools.ietf.org/html/rfc5424#section-7.2.2)
+func (o Origin) EnterpriseID() string {
+	return canonicalIANAid
+}
+
+// SofwareName identifies the software that generated the log message.
+// It is unique within the context of the enterprise ID.
+func (o Origin) SoftwareName() string {
+	return "jujud"
+}
+
+// Validate ensures that the origin is correct.
+func (o Origin) Validate() error {
+	if o.ControllerUUID == "" {
+		return errors.NewNotValid(nil, "empty ControllerUUID")
+	}
+	if !names.IsValidModel(o.ControllerUUID) {
+		err := errors.NewNotValid(nil, "must be UUID")
+		return errors.Annotatef(err, "invalid ControllerUUID %q", o.ControllerUUID)
+	}
+
+	if o.ModelUUID == "" {
+		return errors.NewNotValid(nil, "empty ModelUUID")
+	}
+	if !names.IsValidModel(o.ModelUUID) {
+		err := errors.NewNotValid(nil, "must be UUID")
+		return errors.Annotatef(err, "invalid ModelUUID %q", o.ModelUUID)
+	}
+
+	if err := o.Type.Validate(); err != nil {
+		return errors.Annotate(err, "invalid Type")
+	}
+
+	if o.Name == "" && o.Type != OriginTypeUnknown {
+		return errors.NewNotValid(nil, "empty Name")
+	}
+	if err := o.Type.ValidateName(o.Name); err != nil {
+		return errors.Annotatef(err, "invalid Name %q", o.Name)
+	}
+
+	if o.JujuVersion == version.Zero {
+		return errors.NewNotValid(nil, "empty JujuVersion")
+	}
+
+	return nil
+}

--- a/logfwd/origin_test.go
+++ b/logfwd/origin_test.go
@@ -1,0 +1,262 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logfwd_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/logfwd"
+)
+
+type OriginTypeSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&OriginTypeSuite{})
+
+func (s *OriginTypeSuite) TestZeroValue(c *gc.C) {
+	var ot logfwd.OriginType
+
+	c.Check(ot, gc.Equals, logfwd.OriginTypeUnknown)
+}
+
+func (s *OriginTypeSuite) TestParseOriginTypeValid(c *gc.C) {
+	tests := map[string]logfwd.OriginType{
+		"unknown": logfwd.OriginTypeUnknown,
+		"user":    logfwd.OriginTypeUser,
+	}
+	for str, expected := range tests {
+		c.Logf("trying %q", str)
+
+		ot, err := logfwd.ParseOriginType(str)
+		c.Assert(err, jc.ErrorIsNil)
+
+		c.Check(ot, gc.Equals, expected)
+	}
+}
+
+func (s *OriginTypeSuite) TestParseOriginTypeEmpty(c *gc.C) {
+	_, err := logfwd.ParseOriginType("")
+
+	c.Check(err, gc.ErrorMatches, `unrecognized origin type ""`)
+}
+
+func (s *OriginTypeSuite) TestParseOriginTypeInvalid(c *gc.C) {
+	_, err := logfwd.ParseOriginType("spam")
+
+	c.Check(err, gc.ErrorMatches, `unrecognized origin type "spam"`)
+}
+
+func (s *OriginTypeSuite) TestString(c *gc.C) {
+	tests := map[logfwd.OriginType]string{
+		logfwd.OriginTypeUnknown: "unknown",
+		logfwd.OriginTypeUser:    "user",
+	}
+	for ot, expected := range tests {
+		c.Logf("trying %q", ot)
+
+		str := ot.String()
+
+		c.Check(str, gc.Equals, expected)
+	}
+}
+
+func (s *OriginTypeSuite) TestValidateValid(c *gc.C) {
+	tests := []logfwd.OriginType{
+		logfwd.OriginTypeUnknown,
+		logfwd.OriginTypeUser,
+	}
+	for _, ot := range tests {
+		c.Logf("trying %q", ot)
+
+		err := ot.Validate()
+
+		c.Check(err, jc.ErrorIsNil)
+	}
+}
+
+func (s *OriginTypeSuite) TestValidateZero(c *gc.C) {
+	var ot logfwd.OriginType
+
+	err := ot.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *OriginTypeSuite) TestValidateInvalid(c *gc.C) {
+	ot := logfwd.OriginType(999)
+
+	err := ot.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `unknown origin type`)
+}
+
+func (s *OriginTypeSuite) TestValidateNameValid(c *gc.C) {
+	tests := map[logfwd.OriginType]string{
+		logfwd.OriginTypeUnknown: "",
+		logfwd.OriginTypeUser:    "a-user",
+	}
+	for ot, name := range tests {
+		c.Logf("trying %q + %q", ot, name)
+
+		err := ot.ValidateName(name)
+
+		c.Check(err, jc.ErrorIsNil)
+	}
+}
+
+func (s *OriginTypeSuite) TestValidateNameInvalid(c *gc.C) {
+	tests := []struct {
+		ot   logfwd.OriginType
+		name string
+		err  string
+	}{{
+		ot:   logfwd.OriginTypeUnknown,
+		name: "...",
+		err:  `origin name must not be set if type is unknown`,
+	}, {
+		ot:   logfwd.OriginTypeUser,
+		name: "...",
+		err:  `bad user`,
+	}}
+	for _, test := range tests {
+		c.Logf("trying %q + %q", test.ot, test.name)
+
+		err := test.ot.ValidateName(test.name)
+
+		c.Check(err, jc.Satisfies, errors.IsNotValid)
+		c.Check(err, gc.ErrorMatches, test.err)
+	}
+}
+
+type OriginSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&OriginSuite{})
+
+func (s *OriginSuite) TestEnterpriseID(c *gc.C) {
+	var origin logfwd.Origin
+
+	id := origin.EnterpriseID()
+
+	c.Check(id, gc.Equals, "28978")
+}
+
+func (s *OriginSuite) TestSoftwareName(c *gc.C) {
+	var origin logfwd.Origin
+
+	swName := origin.SoftwareName()
+
+	c.Check(swName, gc.Equals, "jujud")
+}
+
+func (s *OriginSuite) TestValidateValid(c *gc.C) {
+	origin := validOrigin
+
+	err := origin.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *OriginSuite) TestValidateEmpty(c *gc.C) {
+	var origin logfwd.Origin
+
+	err := origin.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *OriginSuite) TestValidateEmptyControllerUUID(c *gc.C) {
+	origin := validOrigin
+	origin.ControllerUUID = ""
+
+	err := origin.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `empty ControllerUUID`)
+}
+
+func (s *OriginSuite) TestValidateBadControllerUUID(c *gc.C) {
+	origin := validOrigin
+	origin.ControllerUUID = "..."
+
+	err := origin.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `invalid ControllerUUID "...": must be UUID`)
+}
+
+func (s *OriginSuite) TestValidateEmptyModelUUID(c *gc.C) {
+	origin := validOrigin
+	origin.ModelUUID = ""
+
+	err := origin.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `empty ModelUUID`)
+}
+
+func (s *OriginSuite) TestValidateBadModelUUID(c *gc.C) {
+	origin := validOrigin
+	origin.ModelUUID = "..."
+
+	err := origin.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `invalid ModelUUID "...": must be UUID`)
+}
+
+func (s *OriginSuite) TestValidateBadOriginType(c *gc.C) {
+	origin := validOrigin
+	origin.Type = logfwd.OriginType(999)
+
+	err := origin.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `invalid Type: unknown origin type`)
+}
+
+func (s *OriginSuite) TestValidateEmptyName(c *gc.C) {
+	origin := validOrigin
+	origin.Name = ""
+
+	err := origin.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `empty Name`)
+}
+
+func (s *OriginSuite) TestValidateBadName(c *gc.C) {
+	origin := validOrigin
+	origin.Name = "..."
+
+	err := origin.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `invalid Name "...": bad user`)
+}
+
+func (s *OriginSuite) TestValidateEmptyVersion(c *gc.C) {
+	origin := validOrigin
+	origin.JujuVersion = version.Zero
+
+	err := origin.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `empty JujuVersion`)
+}
+
+var validOrigin = logfwd.Origin{
+	ControllerUUID: "9f484882-2f18-4fd2-967d-db9663db7bea",
+	ModelUUID:      "deadbeef-2f18-4fd2-967d-db9663db7bea",
+	Type:           logfwd.OriginTypeUser,
+	Name:           "a-user",
+	JujuVersion:    version.MustParse("2.0.1"),
+}

--- a/logfwd/origin_test.go
+++ b/logfwd/origin_test.go
@@ -141,10 +141,10 @@ type OriginSuite struct {
 
 var _ = gc.Suite(&OriginSuite{})
 
-func (s *OriginSuite) TestEnterpriseID(c *gc.C) {
+func (s *OriginSuite) TestPrivateEnterpriseCode(c *gc.C) {
 	var origin logfwd.Origin
 
-	id := origin.EnterpriseID()
+	id := origin.PrivateEnterpriseCode()
 
 	c.Check(id, gc.Equals, "28978")
 }

--- a/logfwd/origin_test.go
+++ b/logfwd/origin_test.go
@@ -190,7 +190,7 @@ func (s *OriginSuite) TestValidateBadControllerUUID(c *gc.C) {
 	err := origin.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `invalid ControllerUUID "...": must be UUID`)
+	c.Check(err, gc.ErrorMatches, `ControllerUUID "..." not a valid UUID`)
 }
 
 func (s *OriginSuite) TestValidateEmptyModelUUID(c *gc.C) {
@@ -210,7 +210,7 @@ func (s *OriginSuite) TestValidateBadModelUUID(c *gc.C) {
 	err := origin.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `invalid ModelUUID "...": must be UUID`)
+	c.Check(err, gc.ErrorMatches, `ModelUUID "..." not a valid UUID`)
 }
 
 func (s *OriginSuite) TestValidateBadOriginType(c *gc.C) {

--- a/logfwd/origin_test.go
+++ b/logfwd/origin_test.go
@@ -94,7 +94,7 @@ func (s *OriginTypeSuite) TestValidateInvalid(c *gc.C) {
 	err := ot.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `unknown origin type`)
+	c.Check(err, gc.ErrorMatches, `unsupported origin type`)
 }
 
 func (s *OriginTypeSuite) TestValidateNameValid(c *gc.C) {
@@ -123,7 +123,7 @@ func (s *OriginTypeSuite) TestValidateNameInvalid(c *gc.C) {
 	}, {
 		ot:   logfwd.OriginTypeUser,
 		name: "...",
-		err:  `bad user`,
+		err:  `bad user name`,
 	}}
 	for _, test := range tests {
 		c.Logf("trying %q + %q", test.ot, test.name)
@@ -220,7 +220,7 @@ func (s *OriginSuite) TestValidateBadOriginType(c *gc.C) {
 	err := origin.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `invalid Type: unknown origin type`)
+	c.Check(err, gc.ErrorMatches, `invalid Type: unsupported origin type`)
 }
 
 func (s *OriginSuite) TestValidateEmptyName(c *gc.C) {
@@ -240,7 +240,7 @@ func (s *OriginSuite) TestValidateBadName(c *gc.C) {
 	err := origin.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `invalid Name "...": bad user`)
+	c.Check(err, gc.ErrorMatches, `invalid Name "...": bad user name`)
 }
 
 func (s *OriginSuite) TestValidateEmptyVersion(c *gc.C) {

--- a/logfwd/origin_test.go
+++ b/logfwd/origin_test.go
@@ -141,12 +141,12 @@ type OriginSuite struct {
 
 var _ = gc.Suite(&OriginSuite{})
 
-func (s *OriginSuite) TestPrivateEnterpriseCode(c *gc.C) {
+func (s *OriginSuite) TestPrivateEnterpriseNumber(c *gc.C) {
 	var origin logfwd.Origin
 
-	id := origin.PrivateEnterpriseCode()
+	id := origin.PrivateEnterpriseNumber()
 
-	c.Check(id, gc.Equals, "28978")
+	c.Check(id, gc.Equals, 28978)
 }
 
 func (s *OriginSuite) TestSoftwareName(c *gc.C) {

--- a/logfwd/package_test.go
+++ b/logfwd/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logfwd_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/logfwd/record.go
+++ b/logfwd/record.go
@@ -1,0 +1,124 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logfwd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+)
+
+// Record holds all the information for a single log record.
+type Record struct {
+	// Origin describes what created the record.
+	Origin Origin
+
+	// Timestamp is when the record was created.
+	Timestamp time.Time
+
+	// Level is the basic logging level of the record.
+	Level loggo.Level
+
+	// Location describes where the record was created.
+	Location SourceLocation
+
+	// Message is the record's body. It may be empty.
+	Message string
+}
+
+// Validate ensures that the record is correct.
+func (rec Record) Validate() error {
+	if err := rec.Origin.Validate(); err != nil {
+		return errors.Annotate(err, "invalid Origin")
+	}
+
+	if rec.Timestamp.IsZero() {
+		return errors.NewNotValid(nil, "empty Timestamp")
+	}
+
+	// rec.Level may be anything, so we don't check it.
+
+	if err := rec.Location.Validate(); err != nil {
+		return errors.Annotate(err, "invalid Location")
+	}
+
+	// rec.Message may be anything, so we don't check it.
+
+	return nil
+}
+
+// SourceLocation holds all the information about the source code that
+// caused the record to be created.
+type SourceLocation struct {
+	// Module is the source "module" (e.g. package) where the record
+	// originated. This is optional.
+	Module string
+
+	// Filename is the path to the source file. This is required only
+	// if Line is greater than 0.
+	Filename string
+
+	// Line is the line number in the source. It is optional. A negative
+	// value means "not set". So does 0 if Filename is not set. If Line
+	// is greater than 0 then Filename must be set.
+	Line int
+}
+
+// ParseLocation converts the given info into a SourceLocation. The
+// caller is responsible for validating the result.
+func ParseLocation(module, location string) (SourceLocation, error) {
+	loc, err := parseLocation(module, location)
+	if err != nil {
+		return loc, errors.Annotate(err, "failed to parse location")
+	}
+	return loc, nil
+}
+
+func parseLocation(module, location string) (SourceLocation, error) {
+	loc := SourceLocation{
+		Module:   module,
+		Filename: location,
+	}
+	if location != "" {
+		loc.Line = -1
+		pos := strings.LastIndex(location, ":")
+		if pos >= 0 {
+			loc.Filename = location[:pos]
+			lineno, err := strconv.Atoi(location[pos+1:])
+			if err != nil {
+				return SourceLocation{}, errors.Trace(err)
+			}
+			loc.Line = lineno
+		}
+	}
+	return loc, nil
+}
+
+// String returns a string representation of the location.
+func (loc SourceLocation) String() string {
+	if loc.Line < 0 {
+		return loc.Filename
+	}
+	if loc.Line == 0 && loc.Filename == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s:%d", loc.Filename, loc.Line)
+}
+
+// Validate ensures that the location is correct.
+func (loc SourceLocation) Validate() error {
+	// Module may be anything, so there's nothing to check.
+
+	// Filename may be set with no line number set, but not the other
+	// way around.
+	if loc.Line > 0 && loc.Filename == "" {
+		return errors.NewNotValid(nil, "Line set but Filename empty")
+	}
+
+	return nil
+}

--- a/logfwd/record_test.go
+++ b/logfwd/record_test.go
@@ -44,7 +44,7 @@ func (s *RecordSuite) TestValidateBadOrigin(c *gc.C) {
 	err := rec.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `invalid Origin: invalid Name "...": bad user`)
+	c.Check(err, gc.ErrorMatches, `invalid Origin: invalid Name "...": bad user name`)
 }
 
 func (s *RecordSuite) TestValidateEmptyTimestamp(c *gc.C) {

--- a/logfwd/record_test.go
+++ b/logfwd/record_test.go
@@ -82,6 +82,16 @@ func (s *LocationSuite) TestParseLocationTooLegitToQuit(c *gc.C) {
 	c.Check(loc, jc.DeepEquals, expected)
 }
 
+func (s *LocationSuite) TestParseLocationIsValid(c *gc.C) {
+	expected := validLocation
+	loc, err := logfwd.ParseLocation(expected.Module, expected.String())
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = loc.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+}
+
 func (s *LocationSuite) TestParseLocationMissingFilename(c *gc.C) {
 	expected := validLocation
 	expected.Filename = ""
@@ -115,13 +125,13 @@ func (s *LocationSuite) TestParseLocationFilenameOnly(c *gc.C) {
 func (s *LocationSuite) TestParseLocationMissingLine(c *gc.C) {
 	_, err := logfwd.ParseLocation(validLocation.Module, "spam.go:")
 
-	c.Check(err, gc.ErrorMatches, `failed to parse location: strconv.ParseInt: parsing "": invalid syntax`)
+	c.Check(err, gc.ErrorMatches, `failed to parse sourceLine: missing line number after ":"`)
 }
 
 func (s *LocationSuite) TestParseLocationBogusLine(c *gc.C) {
 	_, err := logfwd.ParseLocation(validLocation.Module, "spam.go:xxx")
 
-	c.Check(err, gc.ErrorMatches, `failed to parse location: strconv.ParseInt: parsing "xxx": invalid syntax`)
+	c.Check(err, gc.ErrorMatches, `failed to parse sourceLine: line number must be non-negative integer: strconv.ParseInt: parsing "xxx": invalid syntax`)
 }
 
 func (s *LocationSuite) TestValidateValid(c *gc.C) {

--- a/logfwd/record_test.go
+++ b/logfwd/record_test.go
@@ -1,0 +1,165 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logfwd_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/logfwd"
+)
+
+type RecordSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&RecordSuite{})
+
+func (s *RecordSuite) TestValidateValid(c *gc.C) {
+	rec := validRecord
+
+	err := rec.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *RecordSuite) TestValidateZero(c *gc.C) {
+	var rec logfwd.Record
+
+	err := rec.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *RecordSuite) TestValidateBadOrigin(c *gc.C) {
+	rec := validRecord
+	rec.Origin.Name = "..."
+
+	err := rec.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `invalid Origin: invalid Name "...": bad user`)
+}
+
+func (s *RecordSuite) TestValidateEmptyTimestamp(c *gc.C) {
+	rec := validRecord
+	rec.Timestamp = time.Time{}
+
+	err := rec.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `empty Timestamp`)
+}
+
+func (s *RecordSuite) TestValidateBadLocation(c *gc.C) {
+	rec := validRecord
+	rec.Location.Filename = ""
+
+	err := rec.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `invalid Location: Line set but Filename empty`)
+}
+
+type LocationSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&LocationSuite{})
+
+func (s *LocationSuite) TestParseLocationTooLegitToQuit(c *gc.C) {
+	expected := validLocation
+
+	loc, err := logfwd.ParseLocation(expected.Module, expected.String())
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(loc, jc.DeepEquals, expected)
+}
+
+func (s *LocationSuite) TestParseLocationMissingFilename(c *gc.C) {
+	expected := validLocation
+	expected.Filename = ""
+
+	loc, err := logfwd.ParseLocation(expected.Module, ":42")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(loc, jc.DeepEquals, expected)
+}
+
+func (s *LocationSuite) TestParseLocationBogusFilename(c *gc.C) {
+	expected := validLocation
+	expected.Filename = "..."
+
+	loc, err := logfwd.ParseLocation(expected.Module, "...:42")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(loc, jc.DeepEquals, expected)
+}
+
+func (s *LocationSuite) TestParseLocationFilenameOnly(c *gc.C) {
+	expected := validLocation
+	expected.Line = -1
+
+	loc, err := logfwd.ParseLocation(expected.Module, expected.Filename)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(loc, jc.DeepEquals, expected)
+}
+
+func (s *LocationSuite) TestParseLocationMissingLine(c *gc.C) {
+	_, err := logfwd.ParseLocation(validLocation.Module, "spam.go:")
+
+	c.Check(err, gc.ErrorMatches, `failed to parse location: strconv.ParseInt: parsing "": invalid syntax`)
+}
+
+func (s *LocationSuite) TestParseLocationBogusLine(c *gc.C) {
+	_, err := logfwd.ParseLocation(validLocation.Module, "spam.go:xxx")
+
+	c.Check(err, gc.ErrorMatches, `failed to parse location: strconv.ParseInt: parsing "xxx": invalid syntax`)
+}
+
+func (s *LocationSuite) TestValidateValid(c *gc.C) {
+	loc := validLocation
+
+	err := loc.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *LocationSuite) TestValidateEmpty(c *gc.C) {
+	var loc logfwd.SourceLocation
+
+	err := loc.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *LocationSuite) TestValidateBadLine(c *gc.C) {
+	loc := validLocation
+	loc.Filename = ""
+
+	err := loc.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `Line set but Filename empty`)
+}
+
+var validLocation = logfwd.SourceLocation{
+	Module:   "spam",
+	Filename: "eggs.go",
+	Line:     42,
+}
+
+var validRecord = logfwd.Record{
+	Origin:    validOrigin,
+	Timestamp: time.Now(),
+	Level:     loggo.ERROR,
+	Location:  validLocation,
+	Message:   "uh-oh",
+}


### PR DESCRIPTION
The type aligns well with the structured data we'll be sending for our syslog wire format.  The new type will be used in a follow-up patch.

(Review request: http://reviews.vapour.ws/r/5020/)