### PR TITLE
worker/catacomb: do not deincrement catacomb.wg until worker has stopped

### DIFF
--- a/worker/catacomb/catacomb.go
+++ b/worker/catacomb/catacomb.go
@@ -163,8 +163,12 @@ func (catacomb *Catacomb) Add(w worker.Worker) error {
 // error encountered by the worker; and (2) kill the worker when the
 // catacomb starts dying.
 func (catacomb *Catacomb) add(w worker.Worker) {
-	catacomb.wg.Add(1)
+	// We must wait for _both_ goroutines to exit in
+	// arbitrary order depending on the order of the worker
+	// and the catacomb shutting down.
+	catacomb.wg.Add(2)
 	go func() {
+		defer catacomb.wg.Done()
 		if err := w.Wait(); err != nil {
 			catacomb.Kill(err)
 		}

--- a/worker/catacomb/catacomb.go
+++ b/worker/catacomb/catacomb.go
@@ -163,25 +163,16 @@ func (catacomb *Catacomb) Add(w worker.Worker) error {
 // error encountered by the worker; and (2) kill the worker when the
 // catacomb starts dying.
 func (catacomb *Catacomb) add(w worker.Worker) {
-
-	// The coordination via stopped is not reliably observable, and hence not
-	// tested, but it's yucky to leave the second goroutine running when we
-	// don't need to.
-	stopped := make(chan struct{})
 	catacomb.wg.Add(1)
 	go func() {
-		defer catacomb.wg.Done()
-		defer close(stopped)
 		if err := w.Wait(); err != nil {
 			catacomb.Kill(err)
 		}
 	}()
 	go func() {
-		select {
-		case <-stopped:
-		case <-catacomb.tomb.Dying():
-			w.Kill()
-		}
+		defer catacomb.wg.Done()
+		<-catacomb.tomb.Dying()
+		worker.Stop(w)
 	}()
 }
 


### PR DESCRIPTION
This change is a prerequisite of #5564, LP 1590161

Prior to this change, with #5564 applied, the cmd/jujud/agent tests
would reliably cause a 'session already closed' panic because the
workers owned by the catacomb had not yet stopped.

This change alters the catacomb.add logic to use the worker.Stop helper
that ensures the worker has stopped before deincrementing
catacomb.wg. In turn, assuming that the catacomb's owner waits until
its tomb is Dead, this ensures that the catacomb is not considered dead
until all its workers are fully stopped.

With this change in place, the cmd/jujud/agent tests pass reliably.

(Review request: http://reviews.vapour.ws/r/5022/)