### PR TITLE
Fixes lp#1577614: gce bootstrap region is ignored.

### DIFF
--- a/provider/gce/config.go
+++ b/provider/gce/config.go
@@ -97,11 +97,9 @@ var configFields = func() schema.Fields {
 // TODO(ericsnow) Do we need custom defaults for "image-metadata-url" or
 // "agent-metadata-url"? The defaults are the official ones (e.g.
 // cloud-images).
-
 var configDefaults = schema.Defaults{
 	// See http://cloud-images.ubuntu.com/releases/streams/v1/com.ubuntu.cloud:released:gce.json
 	cfgImageEndpoint: "https://www.googleapis.com",
-	cfgRegion:        "us-central1",
 }
 
 var configImmutableFields = []string{

--- a/provider/gce/config_test.go
+++ b/provider/gce/config_test.go
@@ -130,10 +130,6 @@ var newConfigTests = []configTestSpec{{
 	insert: testing.Attrs{"client-email": ""},
 	err:    "client-email: must not be empty",
 }, {
-	info:   "region is optional",
-	remove: []string{"region"},
-	expect: testing.Attrs{"region": "us-central1"},
-}, {
 	info:   "region cannot be empty",
 	insert: testing.Attrs{"region": ""},
 	err:    "region: must not be empty",
@@ -257,7 +253,7 @@ func (s *ConfigSuite) TestValidateChange(c *gc.C) {
 
 func (s *ConfigSuite) TestValidateChangeFromOldConfigWithMissingAttributeWithDefault(c *gc.C) {
 	// If the provider implementation is changed to add a new configuration attribute
-	// that has a default value, and the controller is upgraded to the new implementaton,
+	// that has a default value, and the controller is upgraded to the new implementation,
 	// the validated configuration in the state will have no value for that attribute,
 	// even though newly validated configurations will.
 	//
@@ -266,18 +262,18 @@ func (s *ConfigSuite) TestValidateChangeFromOldConfigWithMissingAttributeWithDef
 	// still validate OK.
 
 	oldCfg := configTestSpec{
-		remove: []string{"region"},
+		remove: []string{"image-endpoint"},
 	}.newConfig(c)
 
 	newCfg, err := testing.ModelConfig(c).Apply(gce.ConfigAttrs.Merge(testing.Attrs{
-		"region": "us-central1",
+		"image-endpoint": "https://www.googleapis.com",
 	}))
 	c.Assert(err, jc.ErrorIsNil)
 
 	validatedConfig, err := gce.Provider.Validate(newCfg, oldCfg)
 
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(validatedConfig.AllAttrs()["region"], gc.Equals, "us-central1")
+	c.Assert(validatedConfig.AllAttrs()["image-endpoint"], gc.Equals, "https://www.googleapis.com")
 }
 
 func (s *ConfigSuite) TestSetConfig(c *gc.C) {

--- a/provider/gce/provider.go
+++ b/provider/gce/provider.go
@@ -52,6 +52,17 @@ func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*
 	default:
 		return nil, errors.NotSupportedf("%q auth-type", authType)
 	}
+	// Ensure cloud info is in config.
+	var err error
+	cfg, err = cfg.Apply(map[string]interface{}{
+		cfgRegion: args.CloudRegion,
+		// TODO (anastasiamac 2016-06-09) at some stage will need to
+		//  also add endpoint and storage endpoint.
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	return p.PrepareForCreateEnvironment(cfg)
 }
 


### PR DESCRIPTION
We should not have default region hard-coded in the provider. This PR removes default region hard-coding from GCE provider.

We were also missing region passed in from bootstrap configuration parameters when constructing new provider environ configuration. This means that everyone was bootstrapping on GCE using hard-coded default region. This PR ensures that the region is set from bootstrap configuration parameters. 

Adjusted tests accordingly.

(Review request: http://reviews.vapour.ws/r/5024/)