### PR TITLE
Clean up interface migration binary uploads

### DIFF
--- a/worker/migrationmaster/manifold.go
+++ b/worker/migrationmaster/manifold.go
@@ -58,10 +58,10 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		return nil, errors.Trace(err)
 	}
 	worker, err := config.NewWorker(Config{
-		Facade:         facade,
-		Guard:          guard,
-		SourceConn:     apiConn,
-		UploadBinaries: migration.UploadBinaries,
+		Facade:          facade,
+		Guard:           guard,
+		UploadBinaries:  migration.UploadBinaries,
+		CharmDownloader: apiConn.Client(),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/migrationmaster/validate_test.go
+++ b/worker/migrationmaster/validate_test.go
@@ -5,7 +5,6 @@ package migrationmaster_test
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/migrationmaster"
@@ -37,24 +36,24 @@ func (*ValidateSuite) TestMissingFacade(c *gc.C) {
 	checkNotValid(c, config, "nil Facade not valid")
 }
 
-func (*ValidateSuite) TestMissingConn(c *gc.C) {
-	config := validConfig()
-	config.SourceConn = nil
-	checkNotValid(c, config, "nil SourceConn not valid")
-}
-
 func (*ValidateSuite) TestMissingUploadBinaries(c *gc.C) {
 	config := validConfig()
 	config.UploadBinaries = nil
 	checkNotValid(c, config, "nil UploadBinaries not valid")
 }
 
+func (*ValidateSuite) TestMissingCharmDownloader(c *gc.C) {
+	config := validConfig()
+	config.CharmDownloader = nil
+	checkNotValid(c, config, "nil CharmDownloader not valid")
+}
+
 func validConfig() migrationmaster.Config {
 	return migrationmaster.Config{
-		Guard:          struct{ fortress.Guard }{},
-		Facade:         struct{ migrationmaster.Facade }{},
-		SourceConn:     struct{ api.Connection }{},
-		UploadBinaries: func(migration.UploadBinariesConfig) error { return nil },
+		Guard:           struct{ fortress.Guard }{},
+		Facade:          struct{ migrationmaster.Facade }{},
+		UploadBinaries:  func(migration.UploadBinariesConfig) error { return nil },
+		CharmDownloader: struct{ migration.CharmDownloader }{},
 	}
 }
 


### PR DESCRIPTION
This change removes unnecessary indirection in migration.UploadBinaries. Instead of dealing with api.Connection and conversion helpers the desired interfaces are accepted directly. This cleans up the testing and implementation of both UploadBinaries and where it is used in the migrationmaster worker.

The NewUploadBinariesConfig function has been removed now that UploadBinariesConfig is easier to construct. It's good to be explicit anyway.

(Review request: http://reviews.vapour.ws/r/5025/)