### PR TITLE
cmd/...: prompt to login on macaroon expiry

### DIFF
--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -89,6 +89,7 @@ func IsUpgradeInProgressError(err error) bool {
 var (
 	ErrBadId              = errors.New("id not found")
 	ErrBadCreds           = errors.New("invalid entity name or password")
+	ErrLoginExpired       = errors.New("login expired")
 	ErrPerm               = errors.New("permission denied")
 	ErrNotLoggedIn        = errors.New("not logged in")
 	ErrUnknownWatcher     = errors.New("unknown watcher id")
@@ -122,6 +123,7 @@ var singletonErrorCodes = map[error]string{
 	lease.ErrClaimDenied:         params.CodeLeaseClaimDenied,
 	ErrBadId:                     params.CodeNotFound,
 	ErrBadCreds:                  params.CodeUnauthorized,
+	ErrLoginExpired:              params.CodeLoginExpired,
 	ErrPerm:                      params.CodeUnauthorized,
 	ErrNotLoggedIn:               params.CodeUnauthorized,
 	ErrUnknownWatcher:            params.CodeNotFound,

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -59,6 +59,7 @@ func (e Error) GoString() string {
 const (
 	CodeNotFound                  = "not found"
 	CodeUnauthorized              = "unauthorized access"
+	CodeLoginExpired              = "login expired"
 	CodeCannotEnterScope          = "cannot enter scope"
 	CodeCannotEnterScopeYet       = "cannot enter scope yet"
 	CodeExcessiveContention       = "excessive contention"
@@ -111,6 +112,10 @@ func IsCodeNotFound(err error) bool {
 
 func IsCodeUnauthorized(err error) bool {
 	return ErrCode(err) == CodeUnauthorized
+}
+
+func IsCodeLoginExpired(err error) bool {
+	return ErrCode(err) == CodeLoginExpired
 }
 
 // IsCodeNotFoundOrCodeUnauthorized is used in API clients which,

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -1,0 +1,56 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelcmd_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/testing"
+)
+
+type BaseCommandSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
+	store *jujuclienttesting.MemStore
+}
+
+var _ = gc.Suite(&BaseCommandSuite{})
+
+func (s *BaseCommandSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	//s.PatchEnvironment("JUJU_CLI_VERSION", "")
+
+	s.store = jujuclienttesting.NewMemStore()
+	s.store.CurrentControllerName = "foo"
+	s.store.Controllers["foo"] = jujuclient.ControllerDetails{
+		APIEndpoints: []string{"testing.invalid:1234"},
+	}
+	s.store.Accounts["foo"] = &jujuclient.ControllerAccounts{
+		Accounts: map[string]jujuclient.AccountDetails{
+			"bar@local": {User: "bar@local", Password: "hunter2"},
+		},
+		CurrentAccount: "bar@local",
+	}
+}
+
+func (s *BaseCommandSuite) TestLoginExpiry(c *gc.C) {
+	apiOpen := func(*api.Info, api.DialOpts) (api.Connection, error) {
+		return nil, &params.Error{Code: params.CodeLoginExpired, Message: "meep"}
+	}
+	var cmd modelcmd.JujuCommandBase
+	cmd.SetAPIOpen(apiOpen)
+	conn, err := cmd.NewAPIRoot(s.store, "foo", "bar@local", "")
+	c.Assert(conn, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, `login expired
+
+Your login for the "foo" controller has expired.
+To log back in, run the following command:
+
+    juju login bar
+`)
+}

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -248,7 +248,7 @@ func (s *macaroonLoginSuite) TestsFailToObtainDischargeLogin(c *gc.C) {
 
 	cmd := modelcmd.NewModelCommandBase(s.store, s.controllerName, s.accountName, s.modelName)
 	_, err := cmd.NewAPIRoot()
-	c.Assert(err, gc.ErrorMatches, "connecting with cached addresses: cannot get discharge.*")
+	c.Assert(err, gc.ErrorMatches, "cannot get discharge.*")
 }
 
 func (s *macaroonLoginSuite) TestsUnknownUserLogin(c *gc.C) {
@@ -258,5 +258,5 @@ func (s *macaroonLoginSuite) TestsUnknownUserLogin(c *gc.C) {
 
 	cmd := modelcmd.NewModelCommandBase(s.store, s.controllerName, s.accountName, s.modelName)
 	_, err := cmd.NewAPIRoot()
-	c.Assert(err, gc.ErrorMatches, "connecting with cached addresses: invalid entity name or password \\(unauthorized access\\)")
+	c.Assert(err, gc.ErrorMatches, "invalid entity name or password \\(unauthorized access\\)")
 }

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -166,6 +166,7 @@ func (s *cmdControllerSuite) TestAddModel(c *gc.C) {
 		ModelUUID:       modelDetails.ModelUUID,
 		BootstrapConfig: noBootstrapConfig,
 		DialOpts:        api.DefaultDialOpts(),
+		OpenAPI:         api.Open,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	api.Close()

--- a/featuretests/cmd_juju_register_test.go
+++ b/featuretests/cmd_juju_register_test.go
@@ -82,6 +82,7 @@ of a model to grant access to that model with "juju grant".
 		AccountDetails:  accountDetails,
 		BootstrapConfig: noBootstrapConfig,
 		DialOpts:        api.DefaultDialOpts(),
+		OpenAPI:         api.Open,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(api.Close(), jc.ErrorIsNil)

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -230,7 +230,7 @@ func (s *NewAPIClientSuite) TestWithInfoAPIOpenError(c *gc.C) {
 	st, err := newAPIConnectionFromNames(c, "noconfig", "", "", jujuClient, apiOpen, noBootstrapConfig)
 	// We expect to get the error from apiOpen, because it is not
 	// fatal to have no bootstrap config.
-	c.Assert(err, gc.ErrorMatches, "connecting with cached addresses: an error")
+	c.Assert(err, gc.ErrorMatches, "an error")
 	c.Assert(st, gc.IsNil)
 }
 
@@ -351,7 +351,7 @@ func (s *NewAPIClientSuite) TestWithSlowConfigConnect(c *gc.C) {
 		c.Fatalf("api never opened via config")
 	}
 	// Let the info endpoint open go ahead and
-	// check that the NewAPIFromStore call returns.
+	// check that the NewAPIConnection call returns.
 	infoEndpointOpened <- struct{}{}
 	select {
 	case <-done:
@@ -814,6 +814,7 @@ func newAPIConnectionFromNames(
 		ControllerName:  controller,
 		BootstrapConfig: getBootstrapConfig,
 		DialOpts:        api.DefaultDialOpts(),
+		OpenAPI:         apiOpen,
 	}
 	if account != "" {
 		accountDetails, err := store.AccountByName(controller, account)
@@ -825,5 +826,5 @@ func newAPIConnectionFromNames(
 		c.Assert(err, jc.ErrorIsNil)
 		params.ModelUUID = modelDetails.ModelUUID
 	}
-	return juju.NewAPIFromStore(params, apiOpen)
+	return juju.NewAPIConnection(params)
 }

--- a/juju/export_test.go
+++ b/juju/export_test.go
@@ -1,13 +1,7 @@
 package juju
 
-import "github.com/juju/juju/api"
-
 var (
 	ProviderConnectDelay   = &providerConnectDelay
 	ResolveOrDropHostnames = &resolveOrDropHostnames
 	ServerAddress          = &serverAddress
 )
-
-func NewAPIFromStore(args NewAPIConnectionParams, open api.OpenFunc) (api.Connection, error) {
-	return newAPIFromStore(args, open)
-}


### PR DESCRIPTION
If the user attempts to login with an expired
macaroon, return an error code to prompt them
to log back in.

Also cleaned up a couple of ugly bits in API
connection code:
 - dropped the "connecting with cached addresses"
   annotation on errors. This was being sent up
   to users, to whom this means nothing.
 - don't bother attempting to connect with
   bootstrap config if we're able to connect to
   the API, but authentication fails. It will
   fail either way we connect.

Fixes https://bugs.launchpad.net/bugs/1589748

(Review request: http://reviews.vapour.ws/r/5026/)