### PR TITLE
worker/migrationmaster: Inject API opener instead of patching

### DIFF
--- a/worker/migrationmaster/export_test.go
+++ b/worker/migrationmaster/export_test.go
@@ -3,5 +3,4 @@
 
 package migrationmaster
 
-var ApiOpen = &apiOpen
 var TempSuccessSleep = &tempSuccessSleep

--- a/worker/migrationmaster/manifold.go
+++ b/worker/migrationmaster/manifold.go
@@ -60,6 +60,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	worker, err := config.NewWorker(Config{
 		Facade:          facade,
 		Guard:           guard,
+		APIOpen:         api.Open,
 		UploadBinaries:  migration.UploadBinaries,
 		CharmDownloader: apiConn.Client(),
 	})

--- a/worker/migrationmaster/validate_test.go
+++ b/worker/migrationmaster/validate_test.go
@@ -5,6 +5,7 @@ package migrationmaster_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/migrationmaster"
@@ -36,6 +37,12 @@ func (*ValidateSuite) TestMissingFacade(c *gc.C) {
 	checkNotValid(c, config, "nil Facade not valid")
 }
 
+func (*ValidateSuite) TestMissingAPIOpen(c *gc.C) {
+	config := validConfig()
+	config.APIOpen = nil
+	checkNotValid(c, config, "nil APIOpen not valid")
+}
+
 func (*ValidateSuite) TestMissingUploadBinaries(c *gc.C) {
 	config := validConfig()
 	config.UploadBinaries = nil
@@ -52,6 +59,7 @@ func validConfig() migrationmaster.Config {
 	return migrationmaster.Config{
 		Guard:           struct{ fortress.Guard }{},
 		Facade:          struct{ migrationmaster.Facade }{},
+		APIOpen:         func(*api.Info, api.DialOpts) (api.Connection, error) { return nil, nil },
 		UploadBinaries:  func(migration.UploadBinariesConfig) error { return nil },
 		CharmDownloader: struct{ migration.CharmDownloader }{},
 	}

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -93,7 +93,6 @@ func (s *Suite) SetUpTest(c *gc.C) {
 	s.stub = new(jujutesting.Stub)
 	s.connection = &stubConnection{stub: s.stub}
 	s.connectionErr = nil
-	s.PatchValue(migrationmaster.ApiOpen, s.apiOpen)
 	s.PatchValue(migrationmaster.TempSuccessSleep, time.Millisecond)
 }
 
@@ -114,6 +113,7 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 	worker, err := migrationmaster.New(migrationmaster.Config{
 		Facade:          masterFacade,
 		Guard:           newStubGuard(s.stub),
+		APIOpen:         s.apiOpen,
 		UploadBinaries:  makeStubUploadBinaries(s.stub),
 		CharmDownloader: fakeCharmDownloader,
 	})
@@ -159,6 +159,7 @@ func (s *Suite) TestMigrationResume(c *gc.C) {
 	worker, err := migrationmaster.New(migrationmaster.Config{
 		Facade:          masterFacade,
 		Guard:           newStubGuard(s.stub),
+		APIOpen:         s.apiOpen,
 		UploadBinaries:  nullUploadBinaries,
 		CharmDownloader: fakeCharmDownloader,
 	})
@@ -187,6 +188,7 @@ func (s *Suite) TestPreviouslyAbortedMigration(c *gc.C) {
 	worker, err := migrationmaster.New(migrationmaster.Config{
 		Facade:          masterFacade,
 		Guard:           newStubGuard(s.stub),
+		APIOpen:         s.apiOpen,
 		UploadBinaries:  nullUploadBinaries,
 		CharmDownloader: fakeCharmDownloader,
 	})
@@ -204,6 +206,7 @@ func (s *Suite) TestPreviouslyCompletedMigration(c *gc.C) {
 	worker, err := migrationmaster.New(migrationmaster.Config{
 		Facade:          masterFacade,
 		Guard:           newStubGuard(s.stub),
+		APIOpen:         s.apiOpen,
 		UploadBinaries:  nullUploadBinaries,
 		CharmDownloader: fakeCharmDownloader,
 	})
@@ -224,6 +227,7 @@ func (s *Suite) TestWatchFailure(c *gc.C) {
 	worker, err := migrationmaster.New(migrationmaster.Config{
 		Facade:          masterFacade,
 		Guard:           newStubGuard(s.stub),
+		APIOpen:         s.apiOpen,
 		UploadBinaries:  nullUploadBinaries,
 		CharmDownloader: fakeCharmDownloader,
 	})
@@ -238,6 +242,7 @@ func (s *Suite) TestStatusError(c *gc.C) {
 	worker, err := migrationmaster.New(migrationmaster.Config{
 		Facade:          masterFacade,
 		Guard:           newStubGuard(s.stub),
+		APIOpen:         s.apiOpen,
 		UploadBinaries:  nullUploadBinaries,
 		CharmDownloader: fakeCharmDownloader,
 	})
@@ -258,6 +263,7 @@ func (s *Suite) TestStatusNotFound(c *gc.C) {
 	worker, err := migrationmaster.New(migrationmaster.Config{
 		Facade:          masterFacade,
 		Guard:           newStubGuard(s.stub),
+		APIOpen:         s.apiOpen,
 		UploadBinaries:  nullUploadBinaries,
 		CharmDownloader: fakeCharmDownloader,
 	})
@@ -282,6 +288,7 @@ func (s *Suite) TestUnlockError(c *gc.C) {
 	worker, err := migrationmaster.New(migrationmaster.Config{
 		Facade:          masterFacade,
 		Guard:           guard,
+		APIOpen:         s.apiOpen,
 		UploadBinaries:  nullUploadBinaries,
 		CharmDownloader: fakeCharmDownloader,
 	})
@@ -305,6 +312,7 @@ func (s *Suite) TestLockdownError(c *gc.C) {
 	worker, err := migrationmaster.New(migrationmaster.Config{
 		Facade:          masterFacade,
 		Guard:           guard,
+		APIOpen:         s.apiOpen,
 		UploadBinaries:  nullUploadBinaries,
 		CharmDownloader: fakeCharmDownloader,
 	})
@@ -327,6 +335,7 @@ func (s *Suite) TestExportFailure(c *gc.C) {
 	worker, err := migrationmaster.New(migrationmaster.Config{
 		Facade:          masterFacade,
 		Guard:           newStubGuard(s.stub),
+		APIOpen:         s.apiOpen,
 		UploadBinaries:  nullUploadBinaries,
 		CharmDownloader: fakeCharmDownloader,
 	})
@@ -357,6 +366,7 @@ func (s *Suite) TestAPIOpenFailure(c *gc.C) {
 	worker, err := migrationmaster.New(migrationmaster.Config{
 		Facade:          masterFacade,
 		Guard:           newStubGuard(s.stub),
+		APIOpen:         s.apiOpen,
 		UploadBinaries:  nullUploadBinaries,
 		CharmDownloader: fakeCharmDownloader,
 	})
@@ -387,6 +397,7 @@ func (s *Suite) TestImportFailure(c *gc.C) {
 	worker, err := migrationmaster.New(migrationmaster.Config{
 		Facade:          masterFacade,
 		Guard:           newStubGuard(s.stub),
+		APIOpen:         s.apiOpen,
 		UploadBinaries:  nullUploadBinaries,
 		CharmDownloader: fakeCharmDownloader,
 	})


### PR DESCRIPTION
This change cleans up the testing of worker/migrationmaster by having the API opener function passed in instead of patching it out.

(Review request: http://reviews.vapour.ws/r/5028/)