### PR TITLE
state: extract Passive type

### DIFF
--- a/state/ipaddresses_internal_test.go
+++ b/state/ipaddresses_internal_test.go
@@ -9,7 +9,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/network"
-	coretesting "github.com/juju/juju/testing"
 )
 
 // ipAddressesInternalSuite contains black-box tests for IP addresses'
@@ -28,31 +27,13 @@ func (s *ipAddressesInternalSuite) TestNewIPAddressCreatesAddress(c *gc.C) {
 	c.Assert(result.doc, jc.DeepEquals, ipAddressDoc{})
 }
 
-func (s *ipAddressesInternalSuite) TestDocIDIncludesModelUUID(c *gc.C) {
-	const localDocID = "foo"
-	globalDocID := coretesting.ModelTag.Id() + ":" + localDocID
-
-	result := s.newIPAddressWithDummyState(ipAddressDoc{DocID: localDocID})
-	c.Assert(result.DocID(), gc.Equals, globalDocID)
-
-	result = s.newIPAddressWithDummyState(ipAddressDoc{DocID: globalDocID})
-	c.Assert(result.DocID(), gc.Equals, globalDocID)
-}
-
-func (s *ipAddressesInternalSuite) newIPAddressWithDummyState(doc ipAddressDoc) *Address {
-	// We only need the model UUID set for localID() and docID() to work.
-	// The rest is tested in ipAddressesStateSuite.
-	dummyState := &State{modelTag: coretesting.ModelTag}
-	return newIPAddress(dummyState, doc)
-}
-
 func (s *ipAddressesInternalSuite) TestProviderIDIsEmptyWhenNotSet(c *gc.C) {
-	result := s.newIPAddressWithDummyState(ipAddressDoc{})
+	result := newIPAddress(nil, ipAddressDoc{})
 	c.Assert(result.ProviderID(), gc.Equals, network.Id(""))
 }
 
 func (s *ipAddressesInternalSuite) TestProviderID(c *gc.C) {
-	result := s.newIPAddressWithDummyState(ipAddressDoc{ProviderID: "foo"})
+	result := newIPAddress(nil, ipAddressDoc{ProviderID: "foo"})
 	c.Assert(result.ProviderID(), gc.Equals, network.Id("foo"))
 }
 
@@ -79,10 +60,10 @@ func (s *ipAddressesInternalSuite) TestGlobalKeyMethod(c *gc.C) {
 		DeviceName: "br-eth1.250",
 		Value:      "fc00:1234::/64",
 	}
-	address := s.newIPAddressWithDummyState(doc)
+	address := newIPAddress(nil, doc)
 	c.Check(address.globalKey(), gc.Equals, "m#99#d#br-eth1.250#ip#fc00:1234::/64")
 
-	address = s.newIPAddressWithDummyState(ipAddressDoc{})
+	address = newIPAddress(nil, ipAddressDoc{})
 	c.Check(address.globalKey(), gc.Equals, "")
 }
 
@@ -93,12 +74,12 @@ func (s *ipAddressesInternalSuite) TestStringIncludesConfigMethodAndValue(c *gc.
 		MachineID:    "42",
 		DeviceName:   "eno1",
 	}
-	result := s.newIPAddressWithDummyState(doc)
+	result := newIPAddress(nil, doc)
 	expectedString := `manual address "0.1.2.3" of device "eno1" on machine "42"`
 
 	c.Assert(result.String(), gc.Equals, expectedString)
 
-	result = s.newIPAddressWithDummyState(ipAddressDoc{})
+	result = newIPAddress(nil, ipAddressDoc{})
 	c.Assert(result.String(), gc.Equals, ` address "" of device "" on machine ""`)
 }
 
@@ -113,7 +94,7 @@ func (s *ipAddressesInternalSuite) TestRemainingSimpleGetterMethods(c *gc.C) {
 		DNSSearchDomains: []string{"example.com", "example.org"},
 		GatewayAddress:   "10.20.30.1",
 	}
-	result := s.newIPAddressWithDummyState(doc)
+	result := newIPAddress(nil, doc)
 
 	c.Check(result.DeviceName(), gc.Equals, "eth0")
 	c.Check(result.MachineID(), gc.Equals, "42")

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -100,9 +100,9 @@ func newLinkLayerDevice(st *State, doc linkLayerDeviceDoc) *LinkLayerDevice {
 	return &LinkLayerDevice{st: st, doc: doc}
 }
 
-// DocID returns the globally unique ID of the link-layer device, including the
+// docID returns the globally unique ID of the link-layer device, including the
 // model UUID as prefix.
-func (dev *LinkLayerDevice) DocID() string {
+func (dev *LinkLayerDevice) docID() string {
 	return dev.st.docID(dev.doc.DocID)
 }
 
@@ -221,7 +221,7 @@ func (dev *LinkLayerDevice) Remove() (err error) {
 				return nil, err
 			}
 		}
-		ops, err := removeLinkLayerDeviceOps(dev.st, dev.DocID(), dev.parentDocID())
+		ops, err := removeLinkLayerDeviceOps(dev.st, dev.docID(), dev.parentDocID())
 		if err != nil {
 			return nil, err
 		}

--- a/state/linklayerdevices_internal_test.go
+++ b/state/linklayerdevices_internal_test.go
@@ -12,7 +12,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/network"
-	coretesting "github.com/juju/juju/testing"
 )
 
 // linkLayerDevicesInternalSuite contains black-box tests for link-layer network
@@ -31,38 +30,20 @@ func (s *linkLayerDevicesInternalSuite) TestNewLinkLayerDeviceCreatesLinkLayerDe
 	c.Assert(result.doc, jc.DeepEquals, linkLayerDeviceDoc{})
 }
 
-func (s *linkLayerDevicesInternalSuite) TestDocIDIncludesModelUUID(c *gc.C) {
-	const localDocID = "foo"
-	globalDocID := coretesting.ModelTag.Id() + ":" + localDocID
-
-	result := s.newLinkLayerDeviceWithDummyState(linkLayerDeviceDoc{DocID: localDocID})
-	c.Assert(result.DocID(), gc.Equals, globalDocID)
-
-	result = s.newLinkLayerDeviceWithDummyState(linkLayerDeviceDoc{DocID: globalDocID})
-	c.Assert(result.DocID(), gc.Equals, globalDocID)
-}
-
-func (s *linkLayerDevicesInternalSuite) newLinkLayerDeviceWithDummyState(doc linkLayerDeviceDoc) *LinkLayerDevice {
-	// We only need the model UUID set for localID() and docID() to work.
-	// The rest is tested in linkLayerDevicesStateSuite.
-	dummyState := &State{modelTag: coretesting.ModelTag}
-	return newLinkLayerDevice(dummyState, doc)
-}
-
 func (s *linkLayerDevicesInternalSuite) TestProviderIDIsEmptyWhenNotSet(c *gc.C) {
-	result := s.newLinkLayerDeviceWithDummyState(linkLayerDeviceDoc{})
+	result := newLinkLayerDevice(nil, linkLayerDeviceDoc{})
 	c.Assert(result.ProviderID(), gc.Equals, network.Id(""))
 }
 
 func (s *linkLayerDevicesInternalSuite) TestProviderIDDoesNotIncludeModelUUIDWhenSet(c *gc.C) {
 	const localProviderID = "foo"
-	result := s.newLinkLayerDeviceWithDummyState(linkLayerDeviceDoc{ProviderID: localProviderID})
+	result := newLinkLayerDevice(nil, linkLayerDeviceDoc{ProviderID: localProviderID})
 	c.Assert(result.ProviderID(), gc.Equals, network.Id(localProviderID))
 
 }
 
 func (s *linkLayerDevicesInternalSuite) TestParentDeviceReturnsNoErrorWhenParentNameNotSet(c *gc.C) {
-	result := s.newLinkLayerDeviceWithDummyState(linkLayerDeviceDoc{})
+	result := newLinkLayerDevice(nil, linkLayerDeviceDoc{})
 	parent, err := result.ParentDevice()
 	c.Check(parent, gc.IsNil)
 	c.Check(err, jc.ErrorIsNil)
@@ -81,10 +62,10 @@ func (s *linkLayerDevicesInternalSuite) TestGlobalKeyMethod(c *gc.C) {
 		MachineID: "42",
 		Name:      "foo",
 	}
-	config := s.newLinkLayerDeviceWithDummyState(doc)
+	config := newLinkLayerDevice(nil, doc)
 	c.Check(config.globalKey(), gc.Equals, "m#42#d#foo")
 
-	config = s.newLinkLayerDeviceWithDummyState(linkLayerDeviceDoc{})
+	config = newLinkLayerDevice(nil, linkLayerDeviceDoc{})
 	c.Check(config.globalKey(), gc.Equals, "")
 }
 
@@ -134,7 +115,7 @@ func (s *linkLayerDevicesInternalSuite) TestStringIncludesTypeNameAndMachineID(c
 		Name:      "foo",
 		Type:      BondDevice,
 	}
-	result := s.newLinkLayerDeviceWithDummyState(doc)
+	result := newLinkLayerDevice(nil, doc)
 	expectedString := `bond device "foo" on machine "42"`
 
 	c.Assert(result.String(), gc.Equals, expectedString)
@@ -151,7 +132,7 @@ func (s *linkLayerDevicesInternalSuite) TestRemainingSimpleGetterMethods(c *gc.C
 		IsUp:        true,
 		ParentName:  "br-bond0",
 	}
-	result := s.newLinkLayerDeviceWithDummyState(doc)
+	result := newLinkLayerDevice(nil, doc)
 
 	c.Check(result.Name(), gc.Equals, "bond0")
 	c.Check(result.MachineID(), gc.Equals, "99")

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -100,9 +100,9 @@ func newIPAddress(st *State, doc ipAddressDoc) *Address {
 	return &Address{st: st, doc: doc}
 }
 
-// DocID returns the globally unique ID of the IP address, including the model
+// docID returns the globally unique ID of the IP address, including the model
 // UUID as prefix.
-func (addr *Address) DocID() string {
+func (addr *Address) docID() string {
 	return addr.st.docID(addr.doc.DocID)
 }
 

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -210,7 +210,7 @@ func (s *linkLayerDevicesStateSuite) assertMachineSetLinkLayerDevicesSucceedsAnd
 	c.Assert(result, gc.NotNil)
 
 	s.checkSetDeviceMatchesArgs(c, result, args)
-	s.checkSetDeviceMatchesMachineIDAndModelUUID(c, result, s.machine.Id(), modelUUID)
+	c.Check(result.MachineID(), gc.Equals, s.machine.Id())
 	return result
 }
 
@@ -223,12 +223,6 @@ func (s *linkLayerDevicesStateSuite) checkSetDeviceMatchesArgs(c *gc.C, setDevic
 	c.Check(setDevice.IsAutoStart(), gc.Equals, args.IsAutoStart)
 	c.Check(setDevice.IsUp(), gc.Equals, args.IsUp)
 	c.Check(setDevice.ParentName(), gc.Equals, args.ParentName)
-}
-
-func (s *linkLayerDevicesStateSuite) checkSetDeviceMatchesMachineIDAndModelUUID(c *gc.C, setDevice *state.LinkLayerDevice, machineID, modelUUID string) {
-	globalKey := fmt.Sprintf("m#%s#d#%s", machineID, setDevice.Name())
-	c.Check(setDevice.DocID(), gc.Equals, modelUUID+":"+globalKey)
-	c.Check(setDevice.MachineID(), gc.Equals, machineID)
 }
 
 func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesNoProviderIDSuccess(c *gc.C) {
@@ -357,12 +351,11 @@ func (s *linkLayerDevicesStateSuite) setMultipleDevicesSucceedsAndCheckAllAdded(
 	c.Assert(err, jc.ErrorIsNil)
 
 	var results []*state.LinkLayerDevice
-	machineID, modelUUID := s.machine.Id(), s.State.ModelUUID()
 	for _, args := range allArgs {
 		device, err := s.machine.LinkLayerDevice(args.Name)
 		c.Check(err, jc.ErrorIsNil)
 		s.checkSetDeviceMatchesArgs(c, device, args)
-		s.checkSetDeviceMatchesMachineIDAndModelUUID(c, device, machineID, modelUUID)
+		c.Check(device.MachineID(), gc.Equals, s.machine.Id())
 		results = append(results, device)
 	}
 	return results
@@ -651,7 +644,7 @@ func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesUpdatesExistingDocs(
 		} else {
 			s.checkSetDeviceMatchesArgs(c, device, updateArgs[1])
 		}
-		s.checkSetDeviceMatchesMachineIDAndModelUUID(c, device, s.machine.Id(), s.State.ModelUUID())
+		c.Check(device.MachineID(), gc.Equals, s.machine.Id())
 	}
 }
 

--- a/state/machine.go
+++ b/state/machine.go
@@ -948,7 +948,7 @@ func (m *Machine) WaitAgentPresence(timeout time.Duration) (err error) {
 // It returns the started pinger.
 func (m *Machine) SetAgentPresence() (*presence.Pinger, error) {
 	presenceCollection := m.st.getPresenceCollection()
-	p := presence.NewPinger(presenceCollection, m.st.modelTag, m.globalKey())
+	p := presence.NewPinger(presenceCollection, m.st.ModelTag(), m.globalKey())
 	err := p.Start()
 	if err != nil {
 		return nil, err

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -1060,6 +1060,7 @@ func (s *MachineSuite) TestMachinePrincipalUnits(c *gc.C) {
 	}
 	units[3], err = s3.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
+	sort.Sort(byName(units[3])) // necessary for index shenanigans below
 	c.Assert(sortedUnitNames(units[3]), jc.DeepEquals, []string{"s3/0", "s3/1", "s3/2"})
 
 	assignments := []struct {
@@ -1103,6 +1104,12 @@ func sortedUnitNames(units []*state.Unit) []string {
 	sort.Strings(names)
 	return names
 }
+
+type byName []*state.Unit
+
+func (s byName) Len() int           { return len(s) }
+func (s byName) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s byName) Less(i, j int) bool { return s[i].Name() < s[j].Name() }
 
 func (s *MachineSuite) assertMachineDirtyAfterAddingUnit(c *gc.C) (*state.Machine, *state.Application, *state.Unit) {
 	m, err := s.State.AddMachine("quantal", state.JobHostUnits)

--- a/state/model.go
+++ b/state/model.go
@@ -105,7 +105,7 @@ func (st *State) Model() (*Model, error) {
 	defer closer()
 
 	model := &Model{st: st}
-	uuid := st.modelTag.Id()
+	uuid := st.ModelUUID()
 	if err := model.refresh(models.FindId(uuid)); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -838,7 +838,7 @@ func (m *Model) assertActiveOp() txn.Op {
 // find a way to guarantee that every Model is associated with the
 // appropriate State. The current work-around is too easy to get wrong.
 func (m *Model) getState() (*State, func(), error) {
-	if m.st.modelTag == m.ModelTag() {
+	if m.st.ModelTag() == m.ModelTag() {
 		return m.st, func() {}, nil
 	}
 	st, err := m.st.ForModel(m.ModelTag())

--- a/state/open.go
+++ b/state/open.go
@@ -273,8 +273,9 @@ func isUnauthorized(err error) bool {
 // function correctly.
 func newState(modelTag names.ModelTag, session *mgo.Session, mongoInfo *mongo.MongoInfo, dialOpts mongo.DialOpts, policy Policy) (_ *State, resultErr error) {
 	// Set up database.
+	modelUUID := modelTag.Id()
 	rawDB := session.DB(jujuDB)
-	database, err := allCollections().Load(rawDB, modelTag.Id())
+	database, err := allCollections().Load(rawDB, modelUUID)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -284,11 +285,13 @@ func newState(modelTag names.ModelTag, session *mgo.Session, mongoInfo *mongo.Mo
 
 	// Create State.
 	return &State{
-		modelTag:      modelTag,
+		Passive: Passive{
+			modelUUID: modelUUID,
+			database:  database,
+		},
 		mongoInfo:     mongoInfo,
 		mongoDialOpts: dialOpts,
 		session:       session,
-		database:      database,
 		policy:        policy,
 	}, nil
 }

--- a/state/state.go
+++ b/state/state.go
@@ -72,12 +72,12 @@ type providerIdDoc struct {
 // State represents the state of an model
 // managed by juju.
 type State struct {
-	modelTag      names.ModelTag
+	Passive
+
 	controllerTag names.ModelTag
 	mongoInfo     *mongo.MongoInfo
 	mongoDialOpts mongo.DialOpts
 	session       *mgo.Session
-	database      Database
 	policy        Policy
 
 	// leaseClientId is used by the lease infrastructure to
@@ -127,7 +127,7 @@ type StateServingInfo struct {
 // IsController returns true if this state instance has the bootstrap
 // model UUID.
 func (st *State) IsController() bool {
-	return st.modelTag == st.controllerTag
+	return st.ModelTag() == st.controllerTag
 }
 
 // RemoveAllModelDocs removes all documents from multi-model
@@ -287,7 +287,7 @@ func (st *State) start(controllerTag names.ModelTag) error {
 		&environMongo{st},
 	)
 
-	logger.Infof("started state for %s successfully", st.modelTag)
+	logger.Infof("started state for %s successfully", st.ModelTag())
 	return nil
 }
 
@@ -317,18 +317,6 @@ func (st *State) getSingularLeaseClient() (lease.Client, error) {
 		return nil, errors.Annotatef(err, "cannot create singular lease client")
 	}
 	return client, nil
-}
-
-// ModelTag() returns the model tag for the model controlled by
-// this state instance.
-func (st *State) ModelTag() names.ModelTag {
-	return st.modelTag
-}
-
-// ModelUUID returns the model UUID for the model
-// controlled by this state instance.
-func (st *State) ModelUUID() string {
-	return st.modelTag.Id()
 }
 
 // userModelNameIndex returns a string to be used as a usermodelnameC unique index.

--- a/state/txns.go
+++ b/state/txns.go
@@ -10,44 +10,6 @@ import (
 	"gopkg.in/mgo.v2/txn"
 )
 
-// readTxnRevno is a convenience method delegating to the state's Database.
-func (st *State) readTxnRevno(collectionName string, id interface{}) (int64, error) {
-	collection, closer := st.database.GetCollection(collectionName)
-	defer closer()
-	query := collection.FindId(id).Select(bson.D{{"txn-revno", 1}})
-	var result struct {
-		TxnRevno int64 `bson:"txn-revno"`
-	}
-	err := query.One(&result)
-	return result.TxnRevno, errors.Trace(err)
-}
-
-// runTransaction is a convenience method delegating to the state's Database.
-func (st *State) runTransaction(ops []txn.Op) error {
-	runner, closer := st.database.TransactionRunner()
-	defer closer()
-	return runner.RunTransaction(ops)
-}
-
-// runRawTransaction is a convenience method that will run a single
-// transaction using a "raw" transaction runner that won't perform
-// model filtering.
-func (st *State) runRawTransaction(ops []txn.Op) error {
-	runner, closer := st.database.TransactionRunner()
-	defer closer()
-	if multiRunner, ok := runner.(*multiModelRunner); ok {
-		runner = multiRunner.rawRunner
-	}
-	return runner.RunTransaction(ops)
-}
-
-// run is a convenience method delegating to the state's Database.
-func (st *State) run(transactions jujutxn.TransactionSource) error {
-	runner, closer := st.database.TransactionRunner()
-	defer closer()
-	return runner.Run(transactions)
-}
-
 // ResumeTransactions resumes all pending transactions.
 func (st *State) ResumeTransactions() error {
 	runner, closer := st.database.TransactionRunner()


### PR DESCRIPTION
Purpose as documented on the type; collects various low-level *State
methods, subject to change in future; currently embedded for minimal
churn/impact. Includes drivebys:

  * intermittent failure in machine_test.go
  * unexported LinkLayerDevice.DocID method
  * dropped/simplified various network-related internal tests.

(Review request: http://reviews.vapour.ws/r/5029/)