### PR TITLE
Cloudsigma: Remove default config values.

### DIFF
--- a/provider/cloudsigma/config.go
+++ b/provider/cloudsigma/config.go
@@ -4,7 +4,6 @@
 package cloudsigma
 
 import (
-	"github.com/altoros/gosigma"
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 
@@ -18,12 +17,7 @@ var configFields = schema.Fields{
 	"endpoint": schema.String(),
 }
 
-var configDefaultFields = schema.Defaults{
-	"username": "",
-	"password": "",
-	"region":   gosigma.DefaultRegion,
-	"endpoint": "",
-}
+var configDefaultFields = schema.Defaults{}
 
 var configSecretFields = []string{
 	"password",

--- a/provider/cloudsigma/config_test.go
+++ b/provider/cloudsigma/config_test.go
@@ -64,7 +64,7 @@ func (s *configSuite) TestNewModelConfig(c *gc.C) {
 	}{{
 		info:   "username is required",
 		remove: []string{"username"},
-		err:    "username: must not be empty",
+		err:    "username: expected string, got nothing",
 	}, {
 		info:   "username cannot be empty",
 		insert: testing.Attrs{"username": ""},
@@ -72,17 +72,17 @@ func (s *configSuite) TestNewModelConfig(c *gc.C) {
 	}, {
 		info:   "password is required",
 		remove: []string{"password"},
-		err:    "password: must not be empty",
+		err:    "password: expected string, got nothing",
 	}, {
 		info:   "password cannot be empty",
 		insert: testing.Attrs{"password": ""},
 		err:    "password: must not be empty",
 	}, {
-		info:   "region is inserted if missing",
+		info:   "region cannot be empty",
 		remove: []string{"region"},
-		expect: testing.Attrs{"region": "zrh"},
+		err:    "region: expected string, got nothing",
 	}, {
-		info:   "region must not be empty",
+		info:   "region cannot not be empty",
 		insert: testing.Attrs{"region": ""},
 		err:    "region: must not be empty",
 	}}

--- a/provider/cloudsigma/environ.go
+++ b/provider/cloudsigma/environ.go
@@ -136,9 +136,6 @@ func (env *environ) Region() (simplestreams.CloudSpec, error) {
 }
 
 func (env *environ) MetadataLookupParams(region string) (*simplestreams.MetadataLookupParams, error) {
-	if region == "" {
-		region = gosigma.DefaultRegion
-	}
 	env.lock.Lock()
 	defer env.lock.Unlock()
 	return &simplestreams.MetadataLookupParams{

--- a/provider/cloudsigma/provider.go
+++ b/provider/cloudsigma/provider.go
@@ -103,8 +103,6 @@ func (environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*co
 	cfg, err := cfg.Apply(map[string]interface{}{
 		"region":   args.CloudRegion,
 		"endpoint": args.CloudEndpoint,
-		// TODO (anastasiamac 2016-06-09) at some stage, may need to
-		// add storage endpoint.
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/provider/cloudsigma/provider.go
+++ b/provider/cloudsigma/provider.go
@@ -92,14 +92,22 @@ func (environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*co
 		cfg, err = cfg.Apply(map[string]interface{}{
 			"username": credentialAttributes["username"],
 			"password": credentialAttributes["password"],
-			"region":   args.CloudRegion,
-			"endpoint": args.CloudEndpoint,
 		})
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 	default:
 		return nil, errors.NotSupportedf("%q auth-type", authType)
+	}
+	// Ensure cloud info is in config.
+	cfg, err := cfg.Apply(map[string]interface{}{
+		"region":   args.CloudRegion,
+		"endpoint": args.CloudEndpoint,
+		// TODO (anastasiamac 2016-06-09) at some stage, may need to
+		// add storage endpoint.
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
Empty default values are invalidated by the provider. This PR removes them.
In addition, region should not have a default defined/hardcoded at provider level - it's now defined in clouds.yaml.

 Fixed tests accordingly.

(Review request: http://reviews.vapour.ws/r/5030/)