### PR TITLE
ec2: Remove region from default config values.

### DIFF
--- a/provider/ec2/config.go
+++ b/provider/ec2/config.go
@@ -59,7 +59,6 @@ var configFields = func() schema.Fields {
 var configDefaults = schema.Defaults{
 	"access-key":   "",
 	"secret-key":   "",
-	"region":       "us-east-1",
 	"vpc-id":       "",
 	"vpc-id-force": false,
 }

--- a/provider/ec2/config_test.go
+++ b/provider/ec2/config_test.go
@@ -63,7 +63,8 @@ type attrs map[string]interface{}
 
 func (t configTest) check(c *gc.C) {
 	attrs := testing.FakeConfig().Merge(testing.Attrs{
-		"type": "ec2",
+		"type":   "ec2",
+		"region": "us-east-1",
 	}).Merge(t.config)
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
@@ -127,10 +128,6 @@ func (t configTest) check(c *gc.C) {
 var configTests = []configTest{
 	{
 		config: attrs{},
-	}, {
-		// check that region defaults to us-east-1
-		config: attrs{},
-		region: "us-east-1",
 	}, {
 		config: attrs{
 			"region": "eu-west-1",


### PR DESCRIPTION
 Region should not have a default defined/hardcoded at this level - it's now defined in clouds.yaml.

 Fixed tests accordingly.

(Review request: http://reviews.vapour.ws/r/5031/)