### PR TITLE
Migrated requestNotifier to internal observers pkg

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/apiserver/authentication"
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/internal/observers"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/presence"
 	"github.com/juju/juju/rpc"
@@ -22,14 +23,14 @@ import (
 	jujuversion "github.com/juju/juju/version"
 )
 
-type adminApiFactory func(srv *Server, root *apiHandler, reqNotifier *requestNotifier) interface{}
+type adminApiFactory func(srv *Server, root *apiHandler, reqNotifier *observers.RequestNotifier) interface{}
 
 // admin is the only object that unlogged-in clients can access. It holds any
 // methods that are needed to log in.
 type admin struct {
 	srv         *Server
 	root        *apiHandler
-	reqNotifier *requestNotifier
+	reqNotifier *observers.RequestNotifier
 
 	mu       sync.Mutex
 	loggedIn bool
@@ -132,7 +133,7 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 	a.root.entity = entity
 
 	if a.reqNotifier != nil {
-		a.reqNotifier.login(entity.Tag().String())
+		a.reqNotifier.Login(entity.Tag().String())
 	}
 
 	// We have authenticated the user; enable the appropriate API

--- a/apiserver/adminv3.go
+++ b/apiserver/adminv3.go
@@ -5,6 +5,7 @@ package apiserver
 
 import (
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/internal/observers"
 	"github.com/juju/juju/apiserver/params"
 )
 
@@ -12,7 +13,7 @@ type adminApiV3 struct {
 	*admin
 }
 
-func newAdminApiV3(srv *Server, root *apiHandler, reqNotifier *requestNotifier) interface{} {
+func newAdminApiV3(srv *Server, root *apiHandler, reqNotifier *observers.RequestNotifier) interface{} {
 	return &adminApiV3{
 		&admin{
 			srv:         srv,

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/apiserver/authentication"
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/internal/observers"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
@@ -119,7 +120,7 @@ func TestingRestrictedApiHandler(st *state.State) rpc.MethodFinder {
 
 type preFacadeAdminApi struct{}
 
-func newPreFacadeAdminApi(srv *Server, root *apiHandler, reqNotifier *requestNotifier) interface{} {
+func newPreFacadeAdminApi(srv *Server, root *apiHandler, reqNotifier *observers.RequestNotifier) interface{} {
 	return &preFacadeAdminApi{}
 }
 
@@ -137,7 +138,7 @@ func (r *preFacadeAdminApi) Login(c params.Creds) (params.LoginResult, error) {
 
 type failAdminApi struct{}
 
-func newFailAdminApi(srv *Server, root *apiHandler, reqNotifier *requestNotifier) interface{} {
+func newFailAdminApi(srv *Server, root *apiHandler, reqNotifier *observers.RequestNotifier) interface{} {
 	return &failAdminApi{}
 }
 

--- a/apiserver/internal/observers/request_notifier.go
+++ b/apiserver/internal/observers/request_notifier.go
@@ -1,0 +1,102 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package observers
+
+import (
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/rpc"
+	"github.com/juju/juju/rpc/jsoncodec"
+)
+
+var logger = loggo.GetLogger("juju.apiserver")
+
+// RequestNotifier serves as a sink for API server requests and
+// responses. As of 2016-06-09, the ServerRequest method is called
+// from github.com/juju/juju/rpc/server.go in the
+// Conn::handleRequest(...) method.
+type RequestNotifier struct {
+	id    int64
+	start time.Time
+
+	mu   sync.Mutex
+	tag_ string
+
+	// count is incremented by calls to join, and deincremented
+	// by calls to leave.
+	count *int32
+}
+
+var globalCounter int64
+
+func NewRequestNotifier(count *int32) *RequestNotifier {
+	return &RequestNotifier{
+		id:   atomic.AddInt64(&globalCounter, 1),
+		tag_: "<unknown>",
+		// TODO(fwereade): 2016-03-17 lp:1558657
+		start: time.Now(),
+		count: count,
+	}
+}
+
+func (n *RequestNotifier) Login(tag string) {
+	n.mu.Lock()
+	n.tag_ = tag
+	n.mu.Unlock()
+}
+
+func (n *RequestNotifier) tag() (tag string) {
+	n.mu.Lock()
+	tag = n.tag_
+	n.mu.Unlock()
+	return
+}
+
+func (n *RequestNotifier) ServerRequest(hdr *rpc.Header, body interface{}) {
+	if hdr.Request.Type == "Pinger" && hdr.Request.Action == "Ping" {
+		return
+	}
+	// TODO(rog) 2013-10-11 remove secrets from some requests.
+	// Until secrets are removed, we only log the body of the requests at trace level
+	// which is below the default level of debug.
+	if logger.IsTraceEnabled() {
+		logger.Tracef("<- [%X] %s %s", n.id, n.tag(), jsoncodec.DumpRequest(hdr, body))
+	} else {
+		logger.Debugf("<- [%X] %s %s", n.id, n.tag(), jsoncodec.DumpRequest(hdr, "'params redacted'"))
+	}
+}
+
+func (n *RequestNotifier) ServerReply(req rpc.Request, hdr *rpc.Header, body interface{}, timeSpent time.Duration) {
+	if req.Type == "Pinger" && req.Action == "Ping" {
+		return
+	}
+	// TODO(rog) 2013-10-11 remove secrets from some responses.
+	// Until secrets are removed, we only log the body of the requests at trace level
+	// which is below the default level of debug.
+	if logger.IsTraceEnabled() {
+		logger.Tracef("-> [%X] %s %s", n.id, n.tag(), jsoncodec.DumpRequest(hdr, body))
+	} else {
+		logger.Debugf("-> [%X] %s %s %s %s[%q].%s", n.id, n.tag(), timeSpent, jsoncodec.DumpRequest(hdr, "'body redacted'"), req.Type, req.Id, req.Action)
+	}
+}
+
+func (n *RequestNotifier) Join(req *http.Request) {
+	active := atomic.AddInt32(n.count, 1)
+	logger.Infof("[%X] API connection from %s, active connections: %d", n.id, req.RemoteAddr, active)
+}
+
+func (n *RequestNotifier) Leave() {
+	active := atomic.AddInt32(n.count, -1)
+	logger.Infof("[%X] %s API connection terminated after %v, active connections: %d", n.id, n.tag(), time.Since(n.start), active)
+}
+
+func (n *RequestNotifier) ClientRequest(hdr *rpc.Header, body interface{}) {
+}
+
+func (n *RequestNotifier) ClientReply(req rpc.Request, hdr *rpc.Header, body interface{}) {
+}

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/internal/observers"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/rpcreflect"
@@ -56,7 +57,7 @@ type apiHandler struct {
 var _ = (*apiHandler)(nil)
 
 // newApiHandler returns a new apiHandler.
-func newApiHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, reqNotifier *requestNotifier, modelUUID string) (*apiHandler, error) {
+func newApiHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, reqNotifier *observers.RequestNotifier, modelUUID string) (*apiHandler, error) {
 	r := &apiHandler{
 		state:     st,
 		resources: common.NewResources(),


### PR DESCRIPTION
This is a mechanical move of existing code to prepare the way for other observers of API server requests/responses.

(Review request: http://reviews.vapour.ws/r/5032/)