### PR TITLE
Restructure 'juju status' output.

### DIFF
--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -160,7 +160,10 @@ func (s *baseSuite) openAs(c *gc.C, tag names.Tag) api.Connection {
 // but this behavior is already tested in cmd/juju/status_test.go and
 // also tested live and it works.
 var scenarioStatus = &params.FullStatus{
-	ModelName: "admin",
+	Model: params.ModelStatusInfo{
+		Name:    "admin",
+		Version: "1.2.3",
+	},
 	Machines: map[string]params.MachineStatus{
 		"0": {
 			Id:         "0",
@@ -377,6 +380,9 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 	c.Assert(err, jc.ErrorIsNil)
 	setDefaultPassword(c, u)
 	add(u)
+	err = s.State.UpdateModelConfig(map[string]interface{}{
+		config.AgentVersionKey: "1.2.3"}, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	u = s.Factory.MakeUser(c, &factory.UserParams{Name: "other"})
 	setDefaultPassword(c, u)

--- a/apiserver/client/perm_test.go
+++ b/apiserver/client/perm_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
-	jujuversion "github.com/juju/juju/version"
 )
 
 type permSuite struct {
@@ -434,7 +433,8 @@ func opClientSetEnvironAgentVersion(c *gc.C, st api.Connection, mst *state.State
 	if err != nil {
 		return func() {}, err
 	}
-	err = st.Client().SetModelAgentVersion(jujuversion.Current)
+	ver := version.Number{Major: 1, Minor: 2, Patch: 3}
+	err = st.Client().SetModelAgentVersion(ver)
 	if err != nil {
 		return func() {}, err
 	}

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -264,12 +264,19 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 	if err != nil {
 		return noStatus, errors.Annotate(err, "cannot determine mongo information")
 	}
+	modelVersion := ""
+	if v, ok := cfg.AgentVersion(); ok {
+		modelVersion = v.String()
+	}
 	return params.FullStatus{
-		ModelName:        cfg.Name(),
-		AvailableVersion: newToolsVersion,
-		Machines:         processMachines(context.machines),
-		Applications:     context.processServices(),
-		Relations:        context.processRelations(),
+		Model: params.ModelStatusInfo{
+			Name:             cfg.Name(),
+			Version:          modelVersion,
+			AvailableVersion: newToolsVersion,
+		},
+		Machines:     processMachines(context.machines),
+		Applications: context.processServices(),
+		Relations:    context.processRelations(),
 	}, nil
 }
 

--- a/apiserver/client/status_test.go
+++ b/apiserver/client/status_test.go
@@ -39,7 +39,7 @@ func (s *statusSuite) TestFullStatus(c *gc.C) {
 	client := s.APIState.Client()
 	status, err := client.Status(nil)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(status.ModelName, gc.Equals, "admin")
+	c.Check(status.Model.Name, gc.Equals, "admin")
 	c.Check(status.Applications, gc.HasLen, 0)
 	c.Check(status.Machines, gc.HasLen, 1)
 	resultMachine, ok := status.Machines[machine.Id()]

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -16,86 +16,92 @@ import (
 
 // StatusParams holds parameters for the Status call.
 type StatusParams struct {
-	Patterns []string
+	Patterns []string `json:"patterns"`
 }
 
 // TODO(ericsnow) Add FullStatusResult.
 
 // FullStatus holds information about the status of a juju model.
 type FullStatus struct {
-	ModelName        string
-	AvailableVersion string
-	Machines         map[string]MachineStatus
-	Applications     map[string]ApplicationStatus
-	Relations        []RelationStatus
+	Model        ModelStatusInfo              `json:"model"`
+	Machines     map[string]MachineStatus     `json:"machines"`
+	Applications map[string]ApplicationStatus `json:"applications"`
+	Relations    []RelationStatus             `json:"relations"`
+}
+
+// ModelStatusInfo holds status information about the model itself.
+type ModelStatusInfo struct {
+	Name             string `json:"name"`
+	Version          string `json:"version"`
+	AvailableVersion string `json:"available-version"`
 }
 
 // MachineStatus holds status info about a machine.
 type MachineStatus struct {
-	AgentStatus    DetailedStatus
-	InstanceStatus DetailedStatus
+	AgentStatus    DetailedStatus `json:"agent-status"`
+	InstanceStatus DetailedStatus `json:"instance-status"`
 
-	DNSName    string
-	InstanceId instance.Id
-	Series     string
-	Id         string
-	Containers map[string]MachineStatus
-	Hardware   string
-	Jobs       []multiwatcher.MachineJob
-	HasVote    bool
-	WantsVote  bool
+	DNSName    string                    `json:"dns-name"`
+	InstanceId instance.Id               `json:"instance-id"`
+	Series     string                    `json:"series"`
+	Id         string                    `json:"id"`
+	Containers map[string]MachineStatus  `json:"containers"`
+	Hardware   string                    `json:"hardware"`
+	Jobs       []multiwatcher.MachineJob `json:"jobs"`
+	HasVote    bool                      `json:"has-vote"`
+	WantsVote  bool                      `json:"wants-vote"`
 }
 
 // ApplicationStatus holds status info about an application.
 type ApplicationStatus struct {
-	Err           error
-	Charm         string
-	Exposed       bool
-	Life          string
-	Relations     map[string][]string
-	CanUpgradeTo  string
-	SubordinateTo []string
-	Units         map[string]UnitStatus
-	MeterStatuses map[string]MeterStatus
-	Status        DetailedStatus
+	Err           error                  `json:"err,omitempty"`
+	Charm         string                 `json:"charm"` // series isn't always defined in the charm now
+	Exposed       bool                   `json:"exposed"`
+	Life          string                 `json:"life"`
+	Relations     map[string][]string    `json:"relations"`
+	CanUpgradeTo  string                 `json:"can-upgrade-to"`
+	SubordinateTo []string               `json:"subordinate-to"`
+	Units         map[string]UnitStatus  `json:"units"`
+	MeterStatuses map[string]MeterStatus `json:"meter-statuses"`
+	Status        DetailedStatus         `json:"status"`
 }
 
 // MeterStatus represents the meter status of a unit.
 type MeterStatus struct {
-	Color   string
-	Message string
+	Color   string `json:"color"`
+	Message string `json:"message"`
 }
 
 // UnitStatus holds status info about a unit.
 type UnitStatus struct {
 	// AgentStatus holds the status for a unit's agent.
-	AgentStatus DetailedStatus
+	AgentStatus DetailedStatus `json:"agent-status"`
 
 	// WorkloadStatus holds the status for a unit's workload
-	WorkloadStatus DetailedStatus
+	WorkloadStatus DetailedStatus `json:"workload-status"`
 
-	Machine       string
-	OpenedPorts   []string
-	PublicAddress string
-	Charm         string
-	Subordinates  map[string]UnitStatus
+	Machine       string                `json:"machine"`
+	OpenedPorts   []string              `json:"opened-ports"`
+	PublicAddress string                `json:"public-address"`
+	Charm         string                `json:"charm"`
+	Subordinates  map[string]UnitStatus `json:"subordinates"`
 }
 
 // RelationStatus holds status info about a relation.
 type RelationStatus struct {
-	Id        int
-	Key       string
-	Interface string
-	Scope     charm.RelationScope
-	Endpoints []EndpointStatus
+	Id        int                 `json:"id"`
+	Key       string              `json:"key"`
+	Interface string              `json:"interface"`
+	Scope     charm.RelationScope `json:"scope"`
+	Endpoints []EndpointStatus    `json:"endpoints"`
 }
 
 // EndpointStatus holds status info about a single endpoint
 type EndpointStatus struct {
-	ApplicationName string
-	Name            string
-	Role            charm.RelationRole
-	Subordinate     bool
+	ApplicationName string             `json:"application"`
+	Name            string             `json:"name"`
+	Role            charm.RelationRole `json:"role"`
+	Subordinate     bool               `json:"subordinate"`
 }
 
 // TODO(ericsnow) Eliminate the String method.
@@ -106,87 +112,87 @@ func (epStatus *EndpointStatus) String() string {
 
 // DetailedStatus holds status info about a machine or unit agent.
 type DetailedStatus struct {
-	Status  string                 `json:"Status"`
-	Info    string                 `json:"Info"`
-	Data    map[string]interface{} `json:"Data"`
-	Since   *time.Time             `json:"Since"`
-	Kind    string                 `json:"Kind"`
-	Version string                 `json:"Version"`
-	Life    string                 `json:"Life"`
-	Err     error                  `json:"Err"`
+	Status  string                 `json:"status"`
+	Info    string                 `json:"info"`
+	Data    map[string]interface{} `json:"data"`
+	Since   *time.Time             `json:"since"`
+	Kind    string                 `json:"kind"`
+	Version string                 `json:"version"`
+	Life    string                 `json:"life"`
+	Err     error                  `json:"err,omitempty"`
 }
 
 // History holds many DetailedStatus,
 type History struct {
-	Statuses []DetailedStatus `json:"Statuses"`
-	Error    *Error           `json:"Error,omitempty"`
+	Statuses []DetailedStatus `json:"statuses"`
+	Error    *Error           `json:"error,omitempty"`
 }
 
 // StatusHistoryFilter holds arguments that can be use to filter a status history backlog.
 type StatusHistoryFilter struct {
-	Size  int            `json:"Size"`
-	Date  *time.Time     `json:"Date"`
-	Delta *time.Duration `json:"Delta"`
+	Size  int            `json:"size"`
+	Date  *time.Time     `json:"date"`
+	Delta *time.Duration `json:"delta"`
 }
 
 // StatusHistoryRequest holds the parameters to filter a status history query.
 type StatusHistoryRequest struct {
-	Kind   string              `json:"HistoryKind"`
-	Size   int                 `json:"Size"`
-	Filter StatusHistoryFilter `json:"Filter"`
-	Tag    string              `json:"Tag"`
+	Kind   string              `json:"historyKind"`
+	Size   int                 `json:"size"`
+	Filter StatusHistoryFilter `json:"filter"`
+	Tag    string              `json:"tag"`
 }
 
 // StatusHistoryRequests holds a slice of StatusHistoryArgs
 type StatusHistoryRequests struct {
-	Requests []StatusHistoryRequest `json:"Requests"`
+	Requests []StatusHistoryRequest `json:"requests"`
 }
 
 // StatusHistoryResult holds a slice of statuses.
 type StatusHistoryResult struct {
-	History History `json:"History"`
-	Error   *Error  `json:"Error,omitempty"`
+	History History `json:"history"`
+	Error   *Error  `json:"error,omitempty"`
 }
 
 // StatusHistoryResults holds a slice of StatusHistoryResult.
 type StatusHistoryResults struct {
-	Results []StatusHistoryResult `json:"Results"`
+	Results []StatusHistoryResult `json:"results"`
 }
 
 // StatusHistoryPruneArgs holds arguments for status history
 // prunning process.
 type StatusHistoryPruneArgs struct {
-	MaxHistoryTime time.Duration `json:"MaxHistoryTime"`
-	MaxHistoryMB   int           `json:"MaxHistoryMB"`
+	MaxHistoryTime time.Duration `json:"max-history-time"`
+	MaxHistoryMB   int           `json:"max-history-mb"`
 }
 
 // StatusResult holds an entity status, extra information, or an
 // error.
 type StatusResult struct {
-	Error  *Error
-	Id     string
-	Life   Life
-	Status string
-	Info   string
-	Data   map[string]interface{}
-	Since  *time.Time
+	Error  *Error                 `json:"error,omitempty"`
+	Id     string                 `json:"id"`
+	Life   Life                   `json:"life"`
+	Status string                 `json:"status"`
+	Info   string                 `json:"info"`
+	Data   map[string]interface{} `json:"data"`
+	Since  *time.Time             `json:"since"`
 }
 
 // StatusResults holds multiple status results.
 type StatusResults struct {
-	Results []StatusResult
+	Results []StatusResult `json:"results"`
 }
 
 // ApplicationStatusResult holds results for an application Full Status
 type ApplicationStatusResult struct {
-	Application StatusResult
-	Units       map[string]StatusResult
-	Error       *Error
+	Application StatusResult            `json:"application"`
+	Units       map[string]StatusResult `json:"units"`
+	Error       *Error                  `json:"error,omitempty"`
 }
 
 // ApplicationStatusResults holds multiple StatusResult.
 type ApplicationStatusResults struct {
-	Results []ApplicationStatusResult
+	Results []ApplicationStatusResult `json:"results"`
 }
 
 // Life describes the lifecycle state of an entity ("alive", "dying" or "dead").

--- a/cmd/juju/machine/list_test.go
+++ b/cmd/juju/machine/list_test.go
@@ -27,7 +27,10 @@ type fakeStatusAPI struct{}
 
 func (*fakeStatusAPI) Status(c []string) (*params.FullStatus, error) {
 	result := &params.FullStatus{
-		ModelName: "dummyenv",
+		Model: params.ModelStatusInfo{
+			Name:    "dummyenv",
+			Version: "1.2.3",
+		},
 		Machines: map[string]params.MachineStatus{
 			"0": {
 				Id: "0",
@@ -35,18 +38,29 @@ func (*fakeStatusAPI) Status(c []string) (*params.FullStatus, error) {
 					Status: "started",
 				},
 				DNSName:    "10.0.0.1",
-				InstanceId: "juju-dummy-machine-0",
+				InstanceId: "juju-badd06-0",
 				Series:     "trusty",
 				Hardware:   "availability-zone=us-east-1",
 			},
 			"1": {
 				Id: "1",
 				AgentStatus: params.DetailedStatus{
-					Status: "pending",
+					Status: "started",
 				},
 				DNSName:    "10.0.0.2",
-				InstanceId: "juju-dummy-machine-1",
+				InstanceId: "juju-badd06-1",
 				Series:     "trusty",
+				Containers: map[string]params.MachineStatus{
+					"1/lxd/0": {
+						Id: "1/lxd/0",
+						AgentStatus: params.DetailedStatus{
+							Status: "pending",
+						},
+						DNSName:    "10.0.0.3",
+						InstanceId: "juju-badd06-1-lxd-0",
+						Series:     "trusty",
+					},
+				},
 			},
 		},
 	}
@@ -65,11 +79,10 @@ func (s *MachineListCommandSuite) TestMachine(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineListCommand())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"\n"+
-		"[Machines] \n"+
-		"ID         STATE   DNS      INS-ID               SERIES AZ        \n"+
-		"0          started 10.0.0.1 juju-dummy-machine-0 trusty us-east-1 \n"+
-		"1          pending 10.0.0.2 juju-dummy-machine-1 trusty           \n"+
+		"MACHINE    STATE    DNS       INS-ID               SERIES  AZ         \n"+
+		"0          started  10.0.0.1  juju-badd06-0        trusty  us-east-1  \n"+
+		"1          started  10.0.0.2  juju-badd06-1        trusty             \n"+
+		"  1/lxd/0  pending  10.0.0.3  juju-badd06-1-lxd-0  trusty             \n"+
 		"\n")
 }
 
@@ -83,22 +96,29 @@ func (s *MachineListCommandSuite) TestListMachineYaml(c *gc.C) {
 		"    juju-status:\n"+
 		"      current: started\n"+
 		"    dns-name: 10.0.0.1\n"+
-		"    instance-id: juju-dummy-machine-0\n"+
+		"    instance-id: juju-badd06-0\n"+
 		"    series: trusty\n"+
 		"    hardware: availability-zone=us-east-1\n"+
 		"  \"1\":\n"+
 		"    juju-status:\n"+
-		"      current: pending\n"+
+		"      current: started\n"+
 		"    dns-name: 10.0.0.2\n"+
-		"    instance-id: juju-dummy-machine-1\n"+
-		"    series: trusty\n")
+		"    instance-id: juju-badd06-1\n"+
+		"    series: trusty\n"+
+		"    containers:\n"+
+		"      1/lxd/0:\n"+
+		"        juju-status:\n"+
+		"          current: pending\n"+
+		"        dns-name: 10.0.0.3\n"+
+		"        instance-id: juju-badd06-1-lxd-0\n"+
+		"        series: trusty\n")
 }
 
 func (s *MachineListCommandSuite) TestListMachineJson(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineListCommand(), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"{\"model\":\"dummyenv\",\"machines\":{\"0\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.1\",\"instance-id\":\"juju-dummy-machine-0\",\"machine-status\":{},\"series\":\"trusty\",\"hardware\":\"availability-zone=us-east-1\"},\"1\":{\"juju-status\":{\"current\":\"pending\"},\"dns-name\":\"10.0.0.2\",\"instance-id\":\"juju-dummy-machine-1\",\"machine-status\":{},\"series\":\"trusty\"}}}\n")
+		"{\"model\":\"dummyenv\",\"machines\":{\"0\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.1\",\"instance-id\":\"juju-badd06-0\",\"machine-status\":{},\"series\":\"trusty\",\"hardware\":\"availability-zone=us-east-1\"},\"1\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.2\",\"instance-id\":\"juju-badd06-1\",\"machine-status\":{},\"series\":\"trusty\",\"containers\":{\"1/lxd/0\":{\"juju-status\":{\"current\":\"pending\"},\"dns-name\":\"10.0.0.3\",\"instance-id\":\"juju-badd06-1-lxd-0\",\"machine-status\":{},\"series\":\"trusty\"}}}}}\n")
 }
 
 func (s *MachineListCommandSuite) TestListMachineArgsError(c *gc.C) {

--- a/cmd/juju/machine/show_test.go
+++ b/cmd/juju/machine/show_test.go
@@ -36,15 +36,22 @@ func (s *MachineShowCommandSuite) TestShowMachine(c *gc.C) {
 		"    juju-status:\n"+
 		"      current: started\n"+
 		"    dns-name: 10.0.0.1\n"+
-		"    instance-id: juju-dummy-machine-0\n"+
+		"    instance-id: juju-badd06-0\n"+
 		"    series: trusty\n"+
 		"    hardware: availability-zone=us-east-1\n"+
 		"  \"1\":\n"+
 		"    juju-status:\n"+
-		"      current: pending\n"+
+		"      current: started\n"+
 		"    dns-name: 10.0.0.2\n"+
-		"    instance-id: juju-dummy-machine-1\n"+
-		"    series: trusty\n")
+		"    instance-id: juju-badd06-1\n"+
+		"    series: trusty\n"+
+		"    containers:\n"+
+		"      1/lxd/0:\n"+
+		"        juju-status:\n"+
+		"          current: pending\n"+
+		"        dns-name: 10.0.0.3\n"+
+		"        instance-id: juju-badd06-1-lxd-0\n"+
+		"        series: trusty\n")
 }
 func (s *MachineShowCommandSuite) TestShowSingleMachine(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineShowCommand(), "0")
@@ -56,7 +63,7 @@ func (s *MachineShowCommandSuite) TestShowSingleMachine(c *gc.C) {
 		"    juju-status:\n"+
 		"      current: started\n"+
 		"    dns-name: 10.0.0.1\n"+
-		"    instance-id: juju-dummy-machine-0\n"+
+		"    instance-id: juju-badd06-0\n"+
 		"    series: trusty\n"+
 		"    hardware: availability-zone=us-east-1\n")
 }
@@ -65,11 +72,10 @@ func (s *MachineShowCommandSuite) TestShowTabularMachine(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineShowCommand(), "--format", "tabular", "0", "1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"\n"+
-		"[Machines] \n"+
-		"ID         STATE   DNS      INS-ID               SERIES AZ        \n"+
-		"0          started 10.0.0.1 juju-dummy-machine-0 trusty us-east-1 \n"+
-		"1          pending 10.0.0.2 juju-dummy-machine-1 trusty           \n"+
+		"MACHINE    STATE    DNS       INS-ID               SERIES  AZ         \n"+
+		"0          started  10.0.0.1  juju-badd06-0        trusty  us-east-1  \n"+
+		"1          started  10.0.0.2  juju-badd06-1        trusty             \n"+
+		"  1/lxd/0  pending  10.0.0.3  juju-badd06-1-lxd-0  trusty             \n"+
 		"\n")
 }
 
@@ -77,5 +83,5 @@ func (s *MachineShowCommandSuite) TestShowJsonMachine(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineShowCommand(), "--format", "json", "0", "1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"{\"model\":\"dummyenv\",\"machines\":{\"0\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.1\",\"instance-id\":\"juju-dummy-machine-0\",\"machine-status\":{},\"series\":\"trusty\",\"hardware\":\"availability-zone=us-east-1\"},\"1\":{\"juju-status\":{\"current\":\"pending\"},\"dns-name\":\"10.0.0.2\",\"instance-id\":\"juju-dummy-machine-1\",\"machine-status\":{},\"series\":\"trusty\"}}}\n")
+		"{\"model\":\"dummyenv\",\"machines\":{\"0\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.1\",\"instance-id\":\"juju-badd06-0\",\"machine-status\":{},\"series\":\"trusty\",\"hardware\":\"availability-zone=us-east-1\"},\"1\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.2\",\"instance-id\":\"juju-badd06-1\",\"machine-status\":{},\"series\":\"trusty\",\"containers\":{\"1/lxd/0\":{\"juju-status\":{\"current\":\"pending\"},\"dns-name\":\"10.0.0.3\",\"instance-id\":\"juju-badd06-1-lxd-0\",\"machine-status\":{},\"series\":\"trusty\"}}}}}\n")
 }

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -11,8 +11,7 @@ import (
 )
 
 type formattedStatus struct {
-	Model        string                       `json:"model"`
-	ModelStatus  *modelStatus                 `json:"model-status,omitempty" yaml:"model-status,omitempty"`
+	Model        modelStatus                  `json:"model"`
 	Machines     map[string]machineStatus     `json:"machines"`
 	Applications map[string]applicationStatus `json:"applications"`
 }
@@ -27,6 +26,10 @@ type errorStatus struct {
 }
 
 type modelStatus struct {
+	Name             string `json:"name"`
+	Controller       string `json:"controller"`
+	Cloud            string `json:"cloud"`
+	Version          string `json:"version"`
 	AvailableVersion string `json:"upgrade-available,omitempty" yaml:"upgrade-available,omitempty"`
 }
 

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -6,6 +6,7 @@ package status
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"regexp"
 	"sort"
 	"strings"
@@ -75,6 +76,20 @@ func (r *relationFormatter) get(k string) *statusRelation {
 	return r.relations[k]
 }
 
+func printHelper(tw *tabwriter.Writer) func(...interface{}) {
+	return func(values ...interface{}) {
+		for _, v := range values {
+			fmt.Fprintf(tw, "%s\t", v)
+		}
+		fmt.Fprintln(tw)
+	}
+}
+
+func getTabWriter(out io.Writer) *tabwriter.Writer {
+	padding := 2
+	return tabwriter.NewWriter(out, 0, 1, padding, ' ', 0)
+}
+
 // FormatTabular returns a tabular summary of machines, applications, and
 // units. Any subordinate items are indented by two spaces beneath
 // their superior.
@@ -85,29 +100,27 @@ func FormatTabular(value interface{}) ([]byte, error) {
 	}
 	var out bytes.Buffer
 	// To format things into columns.
-	tw := tabwriter.NewWriter(&out, 0, 1, 1, ' ', 0)
-	p := func(values ...interface{}) {
-		for _, v := range values {
-			fmt.Fprintf(tw, "%s\t", v)
-		}
-		fmt.Fprintln(tw)
+	tw := getTabWriter(&out)
+	p := printHelper(tw)
+	outputHeaders := func(values ...interface{}) {
+		p()
+		p(values...)
 	}
 
-	if envStatus := fs.ModelStatus; envStatus != nil {
-		p("[Model]")
-		if envStatus.AvailableVersion != "" {
-			p("UPGRADE-AVAILABLE")
-			p(envStatus.AvailableVersion)
-		}
-		p()
-		tw.Flush()
+	header := []interface{}{"MODEL", "CONTROLLER", "CLOUD", "VERSION"}
+	values := []interface{}{fs.Model.Name, fs.Model.Controller, fs.Model.Cloud, fs.Model.Version}
+	if fs.Model.AvailableVersion != "" {
+		header = append(header, "UPGRADE-AVAILABLE")
+		values = append(values, fs.Model.AvailableVersion)
 	}
+	// The first set of headers don't use outputHeaders because it adds the blank line.
+	p(header...)
+	p(values...)
 
 	units := make(map[string]unitStatus)
 	metering := false
 	relations := newRelationFormatter()
-	p("[Applications]")
-	p("NAME\tSTATUS\tEXPOSED\tCHARM")
+	outputHeaders("APP", "STATUS", "EXPOSED", "CHARM")
 	for _, svcName := range common.SortStringsNaturally(stringKeysFromMap(fs.Applications)) {
 		svc := fs.Applications[svcName]
 		for un, u := range svc.Units {
@@ -127,17 +140,14 @@ func FormatTabular(value interface{}) ([]byte, error) {
 
 	}
 	if relations.len() > 0 {
-		p()
-		p("[Relations]")
-		p("APPLICATION1\tAPPLICATION2\tRELATION\tTYPE")
+		outputHeaders("RELATION", "PROVIDES", "CONSUMES", "TYPE")
 		for _, k := range relations.sorted() {
 			r := relations.get(k)
 			if r != nil {
-				p(r.application1, r.application2, r.relation, r.relationType())
+				p(r.relation, r.application1, r.application2, r.relationType())
 			}
 		}
 	}
-	tw.Flush()
 
 	pUnit := func(name string, u unitStatus, level int) {
 		message := u.WorkloadStatusInfo.Message
@@ -149,7 +159,6 @@ func FormatTabular(value interface{}) ([]byte, error) {
 			indent("", level*2, name),
 			u.WorkloadStatusInfo.Current,
 			u.JujuStatusInfo.Current,
-			u.JujuStatusInfo.Version,
 			u.Machine,
 			strings.Join(u.OpenedPorts, ","),
 			u.PublicAddress,
@@ -157,21 +166,16 @@ func FormatTabular(value interface{}) ([]byte, error) {
 		)
 	}
 
-	header := []string{"ID", "WORKLOAD-STATUS", "JUJU-STATUS", "VERSION", "MACHINE", "PORTS", "PUBLIC-ADDRESS", "MESSAGE"}
-
-	p("\n[Units]")
-	p(strings.Join(header, "\t"))
+	outputHeaders("UNIT", "WORKLOAD", "AGENT", "MACHINE", "PORTS", "PUBLIC-ADDRESS", "MESSAGE")
 	for _, name := range common.SortStringsNaturally(stringKeysFromMap(units)) {
 		u := units[name]
 		pUnit(name, u, 0)
 		const indentationLevel = 1
 		recurseUnits(u, indentationLevel, pUnit)
 	}
-	tw.Flush()
 
 	if metering {
-		p("\n[Metering]")
-		p("ID\tSTATUS\tMESSAGE")
+		outputHeaders("METER", "STATUS", "MESSAGE")
 		for _, name := range common.SortStringsNaturally(stringKeysFromMap(units)) {
 			u := units[name]
 			if u.MeterStatus != nil {
@@ -180,10 +184,8 @@ func FormatTabular(value interface{}) ([]byte, error) {
 		}
 	}
 
-	p("\n[Machines]")
-	p("ID\tSTATE\tDNS\tINS-ID\tSERIES\tAZ")
-	for _, name := range common.SortStringsNaturally(stringKeysFromMap(fs.Machines)) {
-		m := fs.Machines[name]
+	var pMachine func(machineStatus)
+	pMachine = func(m machineStatus) {
 		// We want to display availability zone so extract from hardware info".
 		hw, err := instance.ParseHardware(m.Hardware)
 		if err != nil {
@@ -194,9 +196,39 @@ func FormatTabular(value interface{}) ([]byte, error) {
 			az = *hw.AvailabilityZone
 		}
 		p(m.Id, m.JujuStatus.Current, m.DNSName, m.InstanceId, m.Series, az)
+		for _, name := range common.SortStringsNaturally(stringKeysFromMap(m.Containers)) {
+			pMachine(m.Containers[name])
+		}
 	}
+
+	p()
+	printMachines(tw, fs.Machines)
 	tw.Flush()
 	return out.Bytes(), nil
+}
+
+func printMachines(tw *tabwriter.Writer, machines map[string]machineStatus) {
+	p := printHelper(tw)
+	p("MACHINE", "STATE", "DNS", "INS-ID", "SERIES", "AZ")
+	for _, name := range common.SortStringsNaturally(stringKeysFromMap(machines)) {
+		printMachine(p, machines[name], "")
+	}
+}
+
+func printMachine(p func(...interface{}), m machineStatus, prefix string) {
+	// We want to display availability zone so extract from hardware info".
+	hw, err := instance.ParseHardware(m.Hardware)
+	if err != nil {
+		logger.Warningf("invalid hardware info %s for machine %v", m.Hardware, m)
+	}
+	az := ""
+	if hw.AvailabilityZone != nil {
+		az = *hw.AvailabilityZone
+	}
+	p(prefix+m.Id, m.JujuStatus.Current, m.DNSName, m.InstanceId, m.Series, az)
+	for _, name := range common.SortStringsNaturally(stringKeysFromMap(m.Containers)) {
+		printMachine(p, m.Containers[name], prefix+"  ")
+	}
 }
 
 // FormatMachineTabular returns a tabular summary of machine
@@ -207,29 +239,9 @@ func FormatMachineTabular(value interface{}) ([]byte, error) {
 	}
 	var out bytes.Buffer
 	// To format things into columns.
-	tw := tabwriter.NewWriter(&out, 0, 1, 1, ' ', 0)
-	p := func(values ...interface{}) {
-		for _, v := range values {
-			fmt.Fprintf(tw, "%s\t", v)
-		}
-		fmt.Fprintln(tw)
-	}
+	tw := getTabWriter(&out)
 
-	p("\n[Machines]")
-	p("ID\tSTATE\tDNS\tINS-ID\tSERIES\tAZ")
-	for _, name := range common.SortStringsNaturally(stringKeysFromMap(fs.Machines)) {
-		m := fs.Machines[name]
-		// We want to display availability zone so extract from hardware info".
-		hw, err := instance.ParseHardware(m.Hardware)
-		if err != nil {
-			logger.Warningf("invalid hardware info %s for machine %v", m.Hardware, m)
-		}
-		az := ""
-		if hw.AvailabilityZone != nil {
-			az = *hw.AvailabilityZone
-		}
-		p(m.Id, m.JujuStatus.Current, m.DNSName, m.InstanceId, m.Series, az)
-	}
+	printMachines(tw, fs.Machines)
 	tw.Flush()
 
 	return out.Bytes(), nil

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -138,7 +138,18 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 		return errors.Errorf("unable to obtain the current status")
 	}
 
-	formatter := NewStatusFormatter(status, c.isoTime)
+	clientStore := c.ClientStore()
+	controllerDetails, err := clientStore.ControllerByName(c.ControllerName())
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	model := modelStatus{
+		Name:       c.ModelName(),
+		Controller: c.ControllerName(),
+		Cloud:      controllerDetails.Cloud,
+	}
+	formatter := newStatusFormatter(status, model, c.isoTime)
 	formatted := formatter.format()
 	return c.out.Write(ctx, formatted)
 }

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -33,14 +33,13 @@ import (
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
-	jujuversion "github.com/juju/juju/version"
+	coreversion "github.com/juju/juju/version"
 )
 
-func nextVersion() version.Number {
-	ver := jujuversion.Current
-	ver.Patch++
-	return ver
-}
+var (
+	currentVersion = version.Number{Major: 1, Minor: 2, Patch: 3}
+	nextVersion    = version.Number{Major: 1, Minor: 2, Patch: 4}
+)
 
 func runStatus(c *gc.C, args ...string) (code int, stdout, stderr []byte) {
 	ctx := coretesting.Context(c)
@@ -55,6 +54,18 @@ type StatusSuite struct {
 }
 
 var _ = gc.Suite(&StatusSuite{})
+
+func (s *StatusSuite) SetUpSuite(c *gc.C) {
+	s.JujuConnSuite.SetUpSuite(c)
+	s.PatchValue(&coreversion.Current, currentVersion)
+}
+
+func (s *StatusSuite) SetUpTest(c *gc.C) {
+	s.ConfigAttrs = map[string]interface{}{
+		"agent-version": currentVersion.String(),
+	}
+	s.JujuConnSuite.SetUpTest(c)
+}
 
 type M map[string]interface{}
 
@@ -314,7 +325,12 @@ var statusTests = []testCase{
 		expect{
 			"simulate juju bootstrap by adding machine/0 to the state",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": M{
 						"juju-status": M{
@@ -342,7 +358,12 @@ var statusTests = []testCase{
 		expect{
 			"simulate the PA starting an instance in response to the state change",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": M{
 						"juju-status": M{
@@ -368,7 +389,12 @@ var statusTests = []testCase{
 		expect{
 			"simulate the MA started and set the machine status",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": machine0,
 				},
@@ -380,7 +406,12 @@ var statusTests = []testCase{
 		expect{
 			"simulate the MA setting the version",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": M{
 						"dns-name":    "admin-0.dns",
@@ -415,7 +446,12 @@ var statusTests = []testCase{
 		expect{
 			"machine 0 has specific hardware characteristics",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": M{
 						"juju-status": M{
@@ -445,7 +481,12 @@ var statusTests = []testCase{
 		expect{
 			"machine 0 has no dns-name",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": M{
 						"juju-status": M{
@@ -472,7 +513,12 @@ var statusTests = []testCase{
 		expect{
 			"machine 0 reports pending",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": M{
 						"juju-status": M{
@@ -496,7 +542,12 @@ var statusTests = []testCase{
 		expect{
 			"machine 0 reports missing",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": M{
 						"instance-id": "i-missing",
@@ -531,7 +582,12 @@ var statusTests = []testCase{
 		expect{
 			"no applications exposed yet",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": machine0,
 				},
@@ -547,7 +603,12 @@ var statusTests = []testCase{
 		expect{
 			"one exposed application",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": machine0,
 				},
@@ -570,7 +631,12 @@ var statusTests = []testCase{
 		expect{
 			"two more machines added",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -602,7 +668,12 @@ var statusTests = []testCase{
 		expect{
 			"add two units, one alive (in error state), one started",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -678,7 +749,12 @@ var statusTests = []testCase{
 		expect{
 			"add three more machine, one with a dead agent, one in error state and one dead itself; also one dying unit",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -786,7 +862,12 @@ var statusTests = []testCase{
 			"scope status on dummy-application/0 unit",
 			[]string{"dummy-application/0"},
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"1": machine1,
 				},
@@ -820,7 +901,12 @@ var statusTests = []testCase{
 			"scope status on exposed-application application",
 			[]string{"exposed-application"},
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"2": machine2,
 				},
@@ -859,7 +945,12 @@ var statusTests = []testCase{
 			"scope status on application pattern",
 			[]string{"d*-application"},
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"1": machine1,
 				},
@@ -893,7 +984,12 @@ var statusTests = []testCase{
 			"scope status on unit pattern",
 			[]string{"e*posed-application/*"},
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"2": machine2,
 				},
@@ -932,7 +1028,12 @@ var statusTests = []testCase{
 			"scope status on combination of application and unit patterns",
 			[]string{"exposed-application", "dummy-application", "e*posed-application/*", "dummy-application/*"},
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"1": machine1,
 					"2": machine2,
@@ -1020,7 +1121,12 @@ var statusTests = []testCase{
 		expect{
 			"a unit with a hook relation error",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -1113,7 +1219,12 @@ var statusTests = []testCase{
 		expect{
 			"a unit with a hook relation error when the agent is down",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -1187,7 +1298,12 @@ var statusTests = []testCase{
 		expect{
 			"application shows life==dying",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": M{
 						"juju-status": M{
@@ -1245,7 +1361,12 @@ var statusTests = []testCase{
 		expect{
 			"unit shows that agent is lost",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": M{
 						"juju-status": M{
@@ -1345,7 +1466,12 @@ var statusTests = []testCase{
 		expect{
 			"multiples services with relations between some of them",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -1499,7 +1625,12 @@ var statusTests = []testCase{
 		expect{
 			"multiples related peer units",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -1610,7 +1741,12 @@ var statusTests = []testCase{
 		expect{
 			"multiples related peer units",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -1715,7 +1851,12 @@ var statusTests = []testCase{
 			"subordinates scoped on logging",
 			[]string{"logging"},
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"1": machine1,
 					"2": machine2,
@@ -1819,7 +1960,12 @@ var statusTests = []testCase{
 			"subordinates scoped on logging",
 			[]string{"wordpress/0"},
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"1": machine1,
 				},
@@ -1916,7 +2062,12 @@ var statusTests = []testCase{
 		expect{
 			"machines with nested containers",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": machine0,
 					"1": machine1WithContainers,
@@ -1965,7 +2116,12 @@ var statusTests = []testCase{
 			"machines with nested containers 2",
 			[]string{"mysql/1"},
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"1": M{
 						"juju-status": M{
@@ -2045,7 +2201,12 @@ var statusTests = []testCase{
 		expect{
 			"services and units with correct charm status",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -2101,7 +2262,12 @@ var statusTests = []testCase{
 		expect{
 			"services and units with correct charm status",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -2156,7 +2322,12 @@ var statusTests = []testCase{
 		expect{
 			"services and units with correct charm status",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -2212,7 +2383,12 @@ var statusTests = []testCase{
 		expect{
 			"services and units with correct charm status",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -2300,7 +2476,12 @@ var statusTests = []testCase{
 		expect{
 			"simulate just the two services and a bootstrap node",
 			M{
-				"model": "admin",
+				"model": M{
+					"name":       "admin",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"version":    "1.2.3",
+				},
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -2396,9 +2577,12 @@ var statusTests = []testCase{
 		expect{
 			"upgrade availability should be shown in model-status",
 			M{
-				"model": "admin",
-				"model-status": M{
-					"upgrade-available": nextVersion().String(),
+				"model": M{
+					"name":              "admin",
+					"controller":        "kontroll",
+					"cloud":             "dummy",
+					"version":           "1.2.3",
+					"upgrade-available": "1.2.4",
 				},
 				"machines":     M{},
 				"applications": M{},
@@ -2959,7 +3143,7 @@ type setToolsUpgradeAvailable struct{}
 func (ua setToolsUpgradeAvailable) step(c *gc.C, ctx *context) {
 	env, err := ctx.st.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	err = env.UpdateLatestToolsVersion(nextVersion())
+	err = env.UpdateLatestToolsVersion(nextVersion)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -3195,42 +3379,35 @@ func (s *StatusSuite) testStatusWithFormatTabular(c *gc.C, useFeatureFlag bool) 
 	code, stdout, stderr := runStatus(c, args...)
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
-	const expected = `
-[Model]           
-UPGRADE-AVAILABLE 
-%s
+	expected := `
+MODEL  CONTROLLER  CLOUD  VERSION  UPGRADE-AVAILABLE  
+admin  kontroll    dummy  1.2.3    1.2.4              
 
-[Applications] 
-NAME           STATUS      EXPOSED CHARM                  
-logging                    true    cs:quantal/logging-1   
-mysql          maintenance true    cs:quantal/mysql-1     
-wordpress      active      true    cs:quantal/wordpress-3 
+APP        STATUS       EXPOSED  CHARM                   
+logging                 true     cs:quantal/logging-1    
+mysql      maintenance  true     cs:quantal/mysql-1      
+wordpress  active       true     cs:quantal/wordpress-3  
 
-[Relations]  
-APPLICATION1 APPLICATION2 RELATION          TYPE        
-logging      mysql        juju-info         regular     
-logging      wordpress    logging-dir       regular     
-mysql        logging      info              subordinate 
-mysql        wordpress    db                regular     
-wordpress    logging      logging-directory subordinate 
+RELATION           PROVIDES   CONSUMES   TYPE         
+juju-info          logging    mysql      regular      
+logging-dir        logging    wordpress  regular      
+info               mysql      logging    subordinate  
+db                 mysql      wordpress  regular      
+logging-directory  wordpress  logging    subordinate  
 
-[Units]     
-ID          WORKLOAD-STATUS JUJU-STATUS VERSION MACHINE PORTS PUBLIC-ADDRESS MESSAGE                        
-mysql/0     maintenance     idle        1.2.3   2             admin-2.dns    installing all the things      
-  logging/1 error           idle                              admin-2.dns    somehow lost in all those logs 
-wordpress/0 active          idle        1.2.3   1             admin-1.dns                                   
-  logging/0 active          idle                              admin-1.dns                                   
+UNIT         WORKLOAD     AGENT  MACHINE  PORTS  PUBLIC-ADDRESS  MESSAGE                         
+mysql/0      maintenance  idle   2               admin-2.dns     installing all the things       
+  logging/1  error        idle                   admin-2.dns     somehow lost in all those logs  
+wordpress/0  active       idle   1               admin-1.dns                                     
+  logging/0  active       idle                   admin-1.dns                                     
 
-[Machines] 
-ID         STATE   DNS         INS-ID  SERIES  AZ         
-0          started admin-0.dns admin-0 quantal us-east-1a 
-1          started admin-1.dns admin-1 quantal            
-2          started admin-2.dns admin-2 quantal            
+MACHINE  STATE    DNS          INS-ID   SERIES   AZ          
+0        started  admin-0.dns  admin-0  quantal  us-east-1a  
+1        started  admin-1.dns  admin-1  quantal              
+2        started  admin-2.dns  admin-2  quantal              
 
-`
-	nextVersionStr := nextVersion().String()
-	spaces := strings.Repeat(" ", len("UPGRADE-AVAILABLE")-len(nextVersionStr)+1)
-	c.Assert(string(stdout), gc.Equals, fmt.Sprintf(expected[1:], nextVersionStr+spaces))
+`[1:]
+	c.Assert(string(stdout), gc.Equals, expected)
 }
 
 func (s *StatusSuite) TestStatusWithFormatTabular(c *gc.C) {
@@ -3269,17 +3446,17 @@ func (s *StatusSuite) TestFormatTabularHookActionName(c *gc.C) {
 	out, err := FormatTabular(status)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), gc.Equals, `
-[Applications] 
-NAME           STATUS EXPOSED CHARM 
-foo                   false         
+MODEL  CONTROLLER  CLOUD  VERSION  
+                                   
 
-[Units] 
-ID      WORKLOAD-STATUS JUJU-STATUS VERSION MACHINE PORTS PUBLIC-ADDRESS MESSAGE                           
-foo/0   maintenance     executing                                        (config-changed) doing some work  
-foo/1   maintenance     executing                                        (backup database) doing some work 
+APP  STATUS  EXPOSED  CHARM  
+foo          false           
 
-[Machines] 
-ID         STATE DNS INS-ID SERIES AZ 
+UNIT   WORKLOAD     AGENT      MACHINE  PORTS  PUBLIC-ADDRESS  MESSAGE                            
+foo/0  maintenance  executing                                  (config-changed) doing some work   
+foo/1  maintenance  executing                                  (backup database) doing some work  
+
+MACHINE  STATE  DNS  INS-ID  SERIES  AZ  
 `[1:])
 }
 
@@ -3335,22 +3512,21 @@ func (s *StatusSuite) TestFormatTabularMetering(c *gc.C) {
 	out, err := FormatTabular(status)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), gc.Equals, `
-[Applications] 
-NAME           STATUS EXPOSED CHARM 
-foo                   false         
+MODEL  CONTROLLER  CLOUD  VERSION  
+                                   
 
-[Units] 
-ID      WORKLOAD-STATUS JUJU-STATUS VERSION MACHINE PORTS PUBLIC-ADDRESS MESSAGE 
-foo/0                                                                            
-foo/1                                                                            
+APP  STATUS  EXPOSED  CHARM  
+foo          false           
 
-[Metering] 
-ID         STATUS  MESSAGE                     
-foo/0      strange warning: stable strangelets 
-foo/1      up      things are looking up       
+UNIT   WORKLOAD  AGENT  MACHINE  PORTS  PUBLIC-ADDRESS  MESSAGE  
+foo/0                                                            
+foo/1                                                            
 
-[Machines] 
-ID         STATE DNS INS-ID SERIES AZ 
+METER  STATUS   MESSAGE                      
+foo/0  strange  warning: stable strangelets  
+foo/1  up       things are looking up        
+
+MACHINE  STATE  DNS  INS-ID  SERIES  AZ  
 `[1:])
 }
 
@@ -3496,7 +3672,11 @@ func (s *StatusSuite) TestFilterToContainer(c *gc.C) {
 	c.Assert(string(stderr), gc.Equals, "")
 	out := substituteFakeSinceTime(c, stdout, ctx.expectIsoTime)
 	const expected = "" +
-		"model: admin\n" +
+		"model:\n" +
+		"  name: admin\n" +
+		"  controller: kontroll\n" +
+		"  cloud: dummy\n" +
+		"  version: 1.2.3\n" +
 		"machines:\n" +
 		"  \"0\":\n" +
 		"    juju-status:\n" +
@@ -3784,7 +3964,12 @@ var statusTimeTest = test(
 	expect{
 		"add two units, one alive (in error state), one started",
 		M{
-			"model": "admin",
+			"model": M{
+				"name":       "admin",
+				"controller": "kontroll",
+				"cloud":      "dummy",
+				"version":    "1.2.3",
+			},
 			"machines": M{
 				"0": machine0,
 				"1": machine1,

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -210,15 +210,19 @@ func DefaultVersions(conf *config.Config) []version.Binary {
 	defaultSeries := set.NewStrings(supported...)
 	defaultSeries.Add(config.PreferredSeries(conf))
 	defaultSeries.Add(series.HostSeries())
+	agentVersion, set := conf.AgentVersion()
+	if !set {
+		agentVersion = jujuversion.Current
+	}
 	for _, s := range defaultSeries.Values() {
 		versions = append(versions, version.Binary{
-			Number: jujuversion.Current,
+			Number: agentVersion,
 			Arch:   arch.HostArch(),
 			Series: s,
 		})
 		if arch.HostArch() != "amd64" {
 			versions = append(versions, version.Binary{
-				Number: jujuversion.Current,
+				Number: agentVersion,
 				Arch:   "amd64",
 				Series: s,
 			})


### PR DESCRIPTION
Also added explicit serialization directives to the API params.
Fix the bug where containers were not being shown in tabular output.
Refactored a bunch of status code for reuse.

(Review request: http://reviews.vapour.ws/r/5035/)