### PR TITLE
worker/firewaller: register machined with firewaller's catacomb

### DIFF
--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -249,7 +249,9 @@ func (fw *Firewaller) startMachine(tag names.MachineTag) error {
 		delete(fw.machineds, tag)
 		return errors.Trace(err)
 	}
-	return nil
+
+	// register the machined with the firewaller's catacomb.
+	return fw.catacomb.Add(machined)
 }
 
 // startUnit creates a new data value for tracking details of the unit


### PR DESCRIPTION
Updates 1590161

Firewaller.startMachine registers the unitd with the containing
firewaller's catacomb, but the machined which mangers units is not
tracked. This machined will die when any of its component units dies,
but its lifetime is not bound to the containing firewaller's catacomb,
so it can remain alive when the firewaller is considered stopped.

This can lead to panics when pingers for the machine that the machined
is responsible for have not died by the time the test is being torn
down.