### PR TITLE
Always render /e/n/i in containers (using DHCP eth0 as fallback)

### DIFF
--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -65,8 +65,7 @@ var networkInterfacesFile = "/etc/network/interfaces"
 // Interfaces field.
 func GenerateNetworkConfig(networkConfig *container.NetworkConfig) (string, error) {
 	if networkConfig == nil || len(networkConfig.Interfaces) == 0 {
-		logger.Tracef("no network config to generate")
-		return "", nil
+		return "", errors.Errorf("missing container network config")
 	}
 	logger.Debugf("generating network config from %#v", *networkConfig)
 
@@ -99,6 +98,9 @@ func GenerateNetworkConfig(networkConfig *container.NetworkConfig) (string, erro
 		address, hasAddress := prepared.NameToAddress[name]
 		if !hasAddress {
 			output.WriteString("iface " + name + " inet manual\n")
+			continue
+		} else if address == string(network.ConfigDHCP) {
+			output.WriteString("iface " + name + " inet dhcp\n")
 			continue
 		}
 
@@ -148,6 +150,8 @@ func PrepareNetworkConfigFromInterfaces(interfaces []network.InterfaceInfo) *Pre
 
 		if cidr := info.CIDRAddress(); cidr != "" {
 			nameToAddress[info.InterfaceName] = cidr
+		} else if info.ConfigType == network.ConfigDHCP {
+			nameToAddress[info.InterfaceName] = string(network.ConfigDHCP)
 		}
 
 		for _, dns := range info.DNSServers {
@@ -181,13 +185,13 @@ func PrepareNetworkConfigFromInterfaces(interfaces []network.InterfaceInfo) *Pre
 // might include per-interface networking config if both networkConfig
 // is not nil and its Interfaces field is not empty.
 func newCloudInitConfigWithNetworks(series string, networkConfig *container.NetworkConfig) (cloudinit.CloudConfig, error) {
-	cloudConfig, err := cloudinit.New(series)
+	config, err := GenerateNetworkConfig(networkConfig)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	config, err := GenerateNetworkConfig(networkConfig)
-	if err != nil || len(config) == 0 {
-		return cloudConfig, errors.Trace(err)
+	cloudConfig, err := cloudinit.New(series)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 
 	cloudConfig.AddBootTextFile(networkInterfacesFile, config, 0644)

--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -195,7 +195,6 @@ func newCloudInitConfigWithNetworks(series string, networkConfig *container.Netw
 	}
 
 	cloudConfig.AddBootTextFile(networkInterfacesFile, config, 0644)
-	cloudConfig.AddRunCmd("ifup -a || true")
 	return cloudConfig, nil
 }
 

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -34,7 +34,11 @@ type UserDataSuite struct {
 
 	networkInterfacesFile string
 	fakeInterfaces        []network.InterfaceInfo
-	expectedNetConfig     string
+
+	expectedSampleConfig     string
+	expectedSampleUserData   string
+	expectedFallbackConfig   string
+	expectedFallbackUserData string
 }
 
 var _ = gc.Suite(&UserDataSuite{})
@@ -75,7 +79,7 @@ func (s *UserDataSuite) SetUpTest(c *gc.C) {
 		ConfigType:    network.ConfigManual,
 		NoAutoStart:   true,
 	}}
-	s.expectedNetConfig = `
+	s.expectedSampleConfig = `
 auto eth0 eth1 eth3 lo
 
 iface lo inet loopback
@@ -95,35 +99,7 @@ iface eth3 inet dhcp
 
 iface eth4 inet manual
 `
-	s.PatchValue(containerinit.NetworkInterfacesFile, s.networkInterfacesFile)
-}
-
-func (s *UserDataSuite) TestGenerateNetworkConfig(c *gc.C) {
-	data, err := containerinit.GenerateNetworkConfig(nil)
-	c.Assert(err, gc.ErrorMatches, "missing container network config")
-	c.Assert(data, gc.Equals, "")
-	netConfig := container.BridgeNetworkConfig("foo", 0, nil)
-	data, err = containerinit.GenerateNetworkConfig(netConfig)
-	c.Assert(err, gc.ErrorMatches, "missing container network config")
-	c.Assert(data, gc.Equals, "")
-
-	// Test with all interface types.
-	netConfig = container.BridgeNetworkConfig("foo", 0, s.fakeInterfaces)
-	data, err = containerinit.GenerateNetworkConfig(netConfig)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(data, gc.Equals, s.expectedNetConfig)
-}
-
-func (s *UserDataSuite) TestNewCloudInitConfigWithNetworks(c *gc.C) {
-	netConfig := container.BridgeNetworkConfig("foo", 0, s.fakeInterfaces)
-	cloudConf, err := containerinit.NewCloudInitConfigWithNetworks("quantal", netConfig)
-	c.Assert(err, jc.ErrorIsNil)
-	// We need to indent expectNetConfig to make it valid YAML,
-	// dropping the last new line and using unindented blank lines.
-	lines := strings.Split(s.expectedNetConfig, "\n")
-	indentedNetConfig := strings.Join(lines[:len(lines)-2], "\n  ")
-	indentedNetConfig = strings.Replace(indentedNetConfig, "\n  \n", "\n\n", -1)
-	expected := `
+	s.expectedSampleUserData = `
 #cloud-config
 bootcmd:
 - install -D -m 644 /dev/null '%[1]s'
@@ -148,32 +124,109 @@ bootcmd:
 
   iface eth4 inet manual
   ' > '%[1]s'
-runcmd:
-- ifup -a || true
 `[1:]
-	assertUserData(c, cloudConf, fmt.Sprintf(expected, s.networkInterfacesFile))
+
+	s.expectedFallbackConfig = `
+auto eth0 lo
+
+iface lo inet loopback
+
+iface eth0 inet dhcp
+`
+	s.expectedFallbackUserData = `
+#cloud-config
+bootcmd:
+- install -D -m 644 /dev/null '%[1]s'
+- |-
+  printf '%%s\n' '
+  auto eth0 lo
+
+  iface lo inet loopback
+
+  iface eth0 inet dhcp
+  ' > '%[1]s'
+`[1:]
+
+	s.PatchValue(containerinit.NetworkInterfacesFile, s.networkInterfacesFile)
 }
 
-func (s *UserDataSuite) TestNewCloudInitConfigWithNetworksNoConfig(c *gc.C) {
+func (s *UserDataSuite) TestGenerateNetworkConfig(c *gc.C) {
+	data, err := containerinit.GenerateNetworkConfig(nil)
+	c.Assert(err, gc.ErrorMatches, "missing container network config")
+	c.Assert(data, gc.Equals, "")
+
+	netConfig := container.BridgeNetworkConfig("foo", 0, nil)
+	data, err = containerinit.GenerateNetworkConfig(netConfig)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, gc.Equals, s.expectedFallbackConfig)
+
+	// Test with all interface types.
+	netConfig = container.BridgeNetworkConfig("foo", 0, s.fakeInterfaces)
+	data, err = containerinit.GenerateNetworkConfig(netConfig)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, gc.Equals, s.expectedSampleConfig)
+}
+
+func (s *UserDataSuite) TestNewCloudInitConfigWithNetworksSampleConfig(c *gc.C) {
+	netConfig := container.BridgeNetworkConfig("foo", 0, s.fakeInterfaces)
+	cloudConf, err := containerinit.NewCloudInitConfigWithNetworks("quantal", netConfig)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloudConf, gc.NotNil)
+
+	expected := fmt.Sprintf(s.expectedSampleUserData, s.networkInterfacesFile)
+	assertUserData(c, cloudConf, expected)
+}
+
+func (s *UserDataSuite) TestNewCloudInitConfigWithNetworksFallbackConfig(c *gc.C) {
 	netConfig := container.BridgeNetworkConfig("foo", 0, nil)
 	cloudConf, err := containerinit.NewCloudInitConfigWithNetworks("quantal", netConfig)
-	c.Assert(err, gc.ErrorMatches, "missing container network config")
-	c.Assert(cloudConf, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloudConf, gc.NotNil)
+
+	expected := fmt.Sprintf(s.expectedFallbackUserData, s.networkInterfacesFile)
+	assertUserData(c, cloudConf, expected)
 }
 
-func (s *UserDataSuite) TestCloudInitUserData(c *gc.C) {
+func (s *UserDataSuite) TestCloudInitUserDataFallbackConfig(c *gc.C) {
 	instanceConfig, err := containertesting.MockMachineConfig("1/lxc/0")
 	c.Assert(err, jc.ErrorIsNil)
 	networkConfig := container.BridgeNetworkConfig("foo", 0, nil)
 	data, err := containerinit.CloudInitUserData(instanceConfig, networkConfig)
-	c.Assert(err, gc.ErrorMatches, "missing container network config")
-	c.Assert(data, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, gc.NotNil)
+
+	// Extract the "#cloud-config" header and all lines between from the
+	// "bootcmd" section up to (but not including) the "output" sections to
+	// match against expected.
+	var linesToMatch []string
+	seenBootcmd := false
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "#cloud-config") {
+			linesToMatch = append(linesToMatch, line)
+			continue
+		}
+
+		if strings.HasPrefix(line, "bootcmd:") {
+			seenBootcmd = true
+		}
+
+		if strings.HasPrefix(line, "output:") && seenBootcmd {
+			break
+		}
+
+		if seenBootcmd {
+			linesToMatch = append(linesToMatch, line)
+		}
+	}
+	expected := fmt.Sprintf(s.expectedFallbackUserData, s.networkInterfacesFile)
+	c.Assert(strings.Join(linesToMatch, "\n")+"\n", gc.Equals, expected)
 }
 
 func assertUserData(c *gc.C, cloudConf cloudinit.CloudConfig, expected string) {
 	data, err := cloudConf.RenderYAML()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, expected)
+
 	// Make sure it's valid YAML as well.
 	out := make(map[string]interface{})
 	err = yaml.Unmarshal(data, &out)

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -821,7 +821,8 @@ func (s *LxcSuite) createTemplate(c *gc.C) golxc.Container {
 lxc.network.type = veth
 lxc.network.link = nic42
 lxc.network.flags = up
-lxc.network.mtu = 4321
+lxc.network.name = eth0
+
 
 `
 	// NOTE: no autostart, no mounting the log dir
@@ -988,6 +989,8 @@ func (s *LxcSuite) TestCreateContainerNoRestartDir(c *gc.C) {
 lxc.network.type = veth
 lxc.network.link = nic42
 lxc.network.flags = up
+lxc.network.name = eth0
+
 
 lxc.start.auto = 1
 lxc.mount.entry = %s var/log/juju none defaults,bind 0 0
@@ -1016,7 +1019,8 @@ func (s *LxcSuite) TestCreateContainerWithBlockStorage(c *gc.C) {
 lxc.network.type = veth
 lxc.network.link = nic42
 lxc.network.flags = up
-lxc.network.mtu = 4321
+lxc.network.name = eth0
+
 
 lxc.start.auto = 1
 lxc.mount.entry = %s var/log/juju none defaults,bind 0 0
@@ -1108,6 +1112,7 @@ func (*NetworkSuite) TestGenerateNetworkConfig(c *gc.C) {
 			"lxc.network.type = veth",
 			"lxc.network.link = lxcbr0",
 			"lxc.network.flags = up",
+			"lxc.network.name = eth0",
 		},
 		logContains:       `INFO juju.container.lxc network type missing, using the default "bridge" config`,
 		logDoesNotContain: `INFO juju.container.lxc setting MTU to 0 for LXC network interfaces`,
@@ -1118,17 +1123,9 @@ func (*NetworkSuite) TestGenerateNetworkConfig(c *gc.C) {
 			"lxc.network.type = veth",
 			"lxc.network.link = lxcbr0",
 			"lxc.network.flags = up",
+			"lxc.network.name = eth0",
 		},
 		logDoesNotContain: `INFO juju.container.lxc setting MTU to 0 for LXC network interfaces`,
-	}, {
-		about:  "bridge config with MTU 1500, device foo, no NICs",
-		config: container.BridgeNetworkConfig("foo", 1500, nil),
-		rendered: []string{
-			"lxc.network.type = veth",
-			"lxc.network.link = foo",
-			"lxc.network.flags = up",
-			"lxc.network.mtu = 1500",
-		},
 	}, {
 		about:  "phys config with MTU 9000, device foo, no NICs",
 		config: container.PhysicalNetworkConfig("foo", 9000, nil),

--- a/container/lxc/testing/test.go
+++ b/container/lxc/testing/test.go
@@ -31,7 +31,7 @@ func (s *TestSuite) SetUpTest(c *gc.C) {
 	s.RemovedDir = c.MkDir()
 	s.PatchValue(&container.RemovedContainerDir, s.RemovedDir)
 	c.Logf("container.RemovedContainerDir = %q", s.RemovedDir)
-	s.LxcDir = c.MkDir()
+	s.LxcDir = s.ContainerDir
 	s.PatchValue(&lxc.LxcContainerDir, s.LxcDir)
 	c.Logf("lxc.LxcContainerDir = %q", s.LxcDir)
 	s.RestartDir = c.MkDir()

--- a/container/network.go
+++ b/container/network.go
@@ -29,12 +29,24 @@ type NetworkConfig struct {
 	Interfaces []network.InterfaceInfo
 }
 
-// BridgeNetworkConfig returns a valid NetworkConfig to use the
-// specified device as a network bridge for the container. It also
-// allows passing in specific configuration for the container's
-// network interfaces and default MTU to use. If interfaces is nil the
-// default configuration is used for the respective container type.
+// FallbackInterfaceInfo returns a single "eth0" interface configured with DHCP.
+func FallbackInterfaceInfo() []network.InterfaceInfo {
+	return []network.InterfaceInfo{{
+		InterfaceName: "eth0",
+		InterfaceType: network.EthernetInterface,
+		ConfigType:    network.ConfigDHCP,
+	}}
+}
+
+// BridgeNetworkConfig returns a valid NetworkConfig to use the specified device
+// as a network bridge for the container. It also allows passing in specific
+// configuration for the container's network interfaces and default MTU to use.
+// If interfaces is empty, FallbackInterfaceInfo() is used to get the a sane
+// default
 func BridgeNetworkConfig(device string, mtu int, interfaces []network.InterfaceInfo) *NetworkConfig {
+	if len(interfaces) == 0 {
+		interfaces = FallbackInterfaceInfo()
+	}
 	return &NetworkConfig{BridgeNetwork, device, mtu, interfaces}
 }
 

--- a/container/testing/common.go
+++ b/container/testing/common.go
@@ -72,11 +72,10 @@ func CreateContainerWithMachineAndNetworkAndStorageConfig(
 	storageConfig *container.StorageConfig,
 ) instance.Instance {
 
-	if networkConfig != nil && len(networkConfig.Interfaces) > 0 {
-		name, err := manager.Namespace().Hostname(instanceConfig.MachineId)
-		c.Assert(err, jc.ErrorIsNil)
-		EnsureLXCRootFSEtcNetwork(c, name)
-	}
+	name, err := manager.Namespace().Hostname(instanceConfig.MachineId)
+	c.Assert(err, jc.ErrorIsNil)
+	EnsureLXCRootFSEtcNetwork(c, name)
+
 	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error { return nil }
 	inst, hardware, err := manager.CreateContainer(instanceConfig, constraints.Value{}, "quantal", networkConfig, storageConfig, callback)
 	c.Assert(err, jc.ErrorIsNil)
@@ -115,6 +114,10 @@ func CreateContainerTest(c *gc.C, manager container.Manager, machineId string) (
 
 	network := container.BridgeNetworkConfig("nic42", 0, nil)
 	storage := &container.StorageConfig{}
+
+	name, err := manager.Namespace().Hostname(instanceConfig.MachineId)
+	c.Assert(err, jc.ErrorIsNil)
+	EnsureLXCRootFSEtcNetwork(c, name)
 
 	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error { return nil }
 	inst, hardware, err := manager.CreateContainer(instanceConfig, constraints.Value{}, "quantal", network, storage, callback)

--- a/container/testing/common.go
+++ b/container/testing/common.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/container"
-	"github.com/juju/juju/container/lxc"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/instance"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -74,7 +73,7 @@ func CreateContainerWithMachineAndNetworkAndStorageConfig(
 
 	name, err := manager.Namespace().Hostname(instanceConfig.MachineId)
 	c.Assert(err, jc.ErrorIsNil)
-	EnsureLXCRootFSEtcNetwork(c, name)
+	EnsureContainerRootFSEtcNetwork(c, name)
 
 	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error { return nil }
 	inst, hardware, err := manager.CreateContainer(instanceConfig, constraints.Value{}, "quantal", networkConfig, storageConfig, callback)
@@ -84,11 +83,11 @@ func CreateContainerWithMachineAndNetworkAndStorageConfig(
 	return inst
 }
 
-func EnsureLXCRootFSEtcNetwork(c *gc.C, containerName string) {
+func EnsureContainerRootFSEtcNetwork(c *gc.C, containerName string) {
 	// Pre-create the mock rootfs dir for the container and
 	// /etc/network/ inside it, where the interfaces file will be
 	// pre-rendered (unless AUFS is used).
-	etcNetwork := filepath.Join(lxc.LxcContainerDir, containerName, "rootfs", "etc", "network")
+	etcNetwork := filepath.Join(container.ContainerDir, containerName, "rootfs", "etc", "network")
 	logger.Debugf("ensuring root fs /etc/network in %s", etcNetwork)
 	err := os.MkdirAll(etcNetwork, 0755)
 	c.Assert(err, jc.ErrorIsNil)
@@ -117,7 +116,7 @@ func CreateContainerTest(c *gc.C, manager container.Manager, machineId string) (
 
 	name, err := manager.Namespace().Hostname(instanceConfig.MachineId)
 	c.Assert(err, jc.ErrorIsNil)
-	EnsureLXCRootFSEtcNetwork(c, name)
+	EnsureContainerRootFSEtcNetwork(c, name)
 
 	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error { return nil }
 	inst, hardware, err := manager.CreateContainer(instanceConfig, constraints.Value{}, "quantal", network, storage, callback)

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -129,7 +129,7 @@ func (s *lxcBrokerSuite) instanceConfig(c *gc.C, machineId string) *instancecfg.
 	hostname, err := s.namespace.Hostname(machineId)
 	c.Assert(err, jc.ErrorIsNil)
 	// Ensure the <rootfs>/etc/network path exists.
-	containertesting.EnsureLXCRootFSEtcNetwork(c, hostname)
+	containertesting.EnsureContainerRootFSEtcNetwork(c, hostname)
 	return instanceConfig
 }
 
@@ -1211,7 +1211,7 @@ func (s *lxcProvisionerSuite) TestContainerStartedAndStopped(c *gc.C) {
 	container := s.addContainer(c)
 	hostname, err := s.namespace.Hostname(container.MachineTag().Id())
 	c.Assert(err, jc.ErrorIsNil)
-	containertesting.EnsureLXCRootFSEtcNetwork(c, hostname)
+	containertesting.EnsureContainerRootFSEtcNetwork(c, hostname)
 	instId := s.expectStarted(c, container)
 
 	// ...and removed, along with the machine, when the machine is Dead.


### PR DESCRIPTION
If address allocation fails for containers, Juju will now use a fallback
network config with a single "eth0" Ethernet NIC configured with DHCP.

This means Juju is completely in charge of rendering a valid
/etc/network/interfaces file inside all supported containers, avoiding
issues previously present due to differences in the cloud images on
various clouds.

Tested on MAAS 1.9/2.0, AWS with and with address-allocation feature
flag, and LXC and LXD containers.

(Review request: http://reviews.vapour.ws/r/5040/)