### PR TITLE
Clean up DB model.

### DIFF
--- a/api/uniter/application.go
+++ b/api/uniter/application.go
@@ -140,31 +140,6 @@ func (s *Application) CharmURL() (*charm.URL, bool, error) {
 	return nil, false, fmt.Errorf("%q has no charm url set", s.tag)
 }
 
-// OwnerTag returns the service's owner user tag.
-func (s *Application) OwnerTag() (names.UserTag, error) {
-	return s.ApplicationOwnerTag()
-}
-
-func (s *Application) ApplicationOwnerTag() (names.UserTag, error) {
-	var invalidTag names.UserTag
-	var results params.StringResults
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: s.tag.String()}},
-	}
-	err := s.st.facade.FacadeCall("ApplicationOwner", args, &results)
-	if err != nil {
-		return invalidTag, err
-	}
-	if len(results.Results) != 1 {
-		return invalidTag, fmt.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return invalidTag, result.Error
-	}
-	return names.ParseUserTag(result.Result)
-}
-
 // SetStatus sets the status of the service if the passed unitName,
 // corresponding to the calling unit, is of the leader.
 func (s *Application) SetStatus(unitName string, serviceStatus status.Status, info string, data map[string]interface{}) error {

--- a/api/uniter/application_test.go
+++ b/api/uniter/application_test.go
@@ -122,12 +122,6 @@ func (s *serviceSuite) TestCharmModifiedVersion(c *gc.C) {
 	c.Assert(ver, gc.Equals, s.wordpressService.CharmModifiedVersion())
 }
 
-func (s *serviceSuite) TestOwnerTag(c *gc.C) {
-	tag, err := s.apiService.OwnerTag()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(tag, gc.Equals, s.AdminUserTag(c))
-}
-
 func (s *serviceSuite) TestSetServiceStatus(c *gc.C) {
 	message := "a test message"
 	stat, err := s.wordpressService.Status()

--- a/api/uniter/uniter_test.go
+++ b/api/uniter/uniter_test.go
@@ -76,10 +76,8 @@ func (s *uniterSuite) addMachineBoundServiceCharmAndUnit(c *gc.C, serviceName st
 	c.Assert(err, jc.ErrorIsNil)
 	charm := s.AddTestingCharm(c, serviceName)
 
-	owner := s.AdminUserTag(c).String()
 	service, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:             serviceName,
-		Owner:            owner,
 		Charm:            charm,
 		EndpointBindings: bindings,
 	})

--- a/apiserver/action/action_test.go
+++ b/apiserver/action/action_test.go
@@ -71,12 +71,10 @@ func (s *actionSuite) SetUpTest(c *gc.C) {
 		Charm: factory.MakeCharm(c, &jujuFactory.CharmParams{
 			Name: "dummy",
 		}),
-		Creator: s.AdminUserTag(c),
 	})
 	s.wordpress = factory.MakeApplication(c, &jujuFactory.ApplicationParams{
-		Name:    "wordpress",
-		Charm:   s.charm,
-		Creator: s.AdminUserTag(c),
+		Name:  "wordpress",
+		Charm: s.charm,
 	})
 	s.machine0 = factory.MakeMachine(c, &jujuFactory.MachineParams{
 		Series: "quantal",
@@ -91,9 +89,8 @@ func (s *actionSuite) SetUpTest(c *gc.C) {
 		Name: "mysql",
 	})
 	s.mysql = factory.MakeApplication(c, &jujuFactory.ApplicationParams{
-		Name:    "mysql",
-		Charm:   mysqlCharm,
-		Creator: s.AdminUserTag(c),
+		Name:  "mysql",
+		Charm: mysqlCharm,
 	})
 	s.machine1 = factory.MakeMachine(c, &jujuFactory.MachineParams{
 		Series: "quantal",

--- a/apiserver/action/run_test.go
+++ b/apiserver/action/run_test.go
@@ -55,23 +55,22 @@ func (s *runSuite) addUnit(c *gc.C, service *state.Application) *state.Unit {
 
 func (s *runSuite) TestGetAllUnitNames(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	owner := s.AdminUserTag(c)
-	magic, err := s.State.AddApplication(state.AddApplicationArgs{Name: "magic", Owner: owner.String(), Charm: charm})
+	magic, err := s.State.AddApplication(state.AddApplicationArgs{Name: "magic", Charm: charm})
 	s.addUnit(c, magic)
 	s.addUnit(c, magic)
 
-	notAssigned, err := s.State.AddApplication(state.AddApplicationArgs{Name: "not-assigned", Owner: owner.String(), Charm: charm})
+	notAssigned, err := s.State.AddApplication(state.AddApplicationArgs{Name: "not-assigned", Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = notAssigned.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "no-units", Owner: owner.String(), Charm: charm})
+	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "no-units", Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 
-	wordpress, err := s.State.AddApplication(state.AddApplicationArgs{Name: "wordpress", Owner: owner.String(), Charm: s.AddTestingCharm(c, "wordpress")})
+	wordpress, err := s.State.AddApplication(state.AddApplicationArgs{Name: "wordpress", Charm: s.AddTestingCharm(c, "wordpress")})
 	c.Assert(err, jc.ErrorIsNil)
 	wordpress0 := s.addUnit(c, wordpress)
-	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "logging", Owner: owner.String(), Charm: s.AddTestingCharm(c, "logging")})
+	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "logging", Charm: s.AddTestingCharm(c, "logging")})
 	c.Assert(err, jc.ErrorIsNil)
 
 	eps, err := s.State.InferEndpoints("logging", "wordpress")
@@ -195,8 +194,7 @@ func (s *runSuite) TestRunMachineAndService(c *gc.C) {
 	s.addMachine(c)
 
 	charm := s.AddTestingCharm(c, "dummy")
-	owner := s.Factory.MakeUser(c, nil).Tag()
-	magic, err := s.State.AddApplication(state.AddApplicationArgs{Name: "magic", Owner: owner.String(), Charm: charm})
+	magic, err := s.State.AddApplication(state.AddApplicationArgs{Name: "magic", Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 	s.addUnit(c, magic)
 	s.addUnit(c, magic)

--- a/apiserver/application/application.go
+++ b/apiserver/application/application.go
@@ -92,9 +92,8 @@ func (api *API) Deploy(args params.ApplicationsDeploy) (params.ErrorResults, err
 	if err := api.check.ChangeAllowed(); err != nil {
 		return result, errors.Trace(err)
 	}
-	owner := api.authorizer.GetAuthTag().String()
 	for i, arg := range args.Applications {
-		err := deployApplication(api.state, owner, arg)
+		err := deployApplication(api.state, arg)
 		result.Results[i].Error = common.ServerError(err)
 	}
 	return result, nil
@@ -103,7 +102,7 @@ func (api *API) Deploy(args params.ApplicationsDeploy) (params.ErrorResults, err
 // deployApplication fetches the charm from the charm store and deploys it.
 // The logic has been factored out into a common function which is called by
 // both the legacy API on the client facade, as well as the new application facade.
-func deployApplication(st *state.State, owner string, args params.ApplicationDeploy) error {
+func deployApplication(st *state.State, args params.ApplicationDeploy) error {
 	curl, err := charm.ParseURL(args.CharmUrl)
 	if err != nil {
 		return errors.Trace(err)
@@ -160,10 +159,8 @@ func deployApplication(st *state.State, owner string, args params.ApplicationDep
 
 	_, err = jjj.DeployApplication(st,
 		jjj.DeployApplicationParams{
-			ApplicationName: args.ApplicationName,
-			Series:          args.Series,
-			// TODO(dfc) ApplicationOwner should be a tag
-			ApplicationOwner: owner,
+			ApplicationName:  args.ApplicationName,
+			Series:           args.Series,
 			Charm:            ch,
 			Channel:          channel,
 			NumUnits:         args.NumUnits,

--- a/apiserver/application/application_test.go
+++ b/apiserver/application/application_test.go
@@ -1191,28 +1191,6 @@ func (s *serviceSuite) TestServiceDeployToMachineNotFound(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `application "application-name" not found`)
 }
 
-func (s *serviceSuite) TestServiceDeployApplicationOwner(c *gc.C) {
-	curl, _ := s.UploadCharm(c, "precise/dummy-0", "dummy")
-	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
-		URL: curl.String(),
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
-		Applications: []params.ApplicationDeploy{{
-			CharmUrl:        curl.String(),
-			ApplicationName: "application",
-			NumUnits:        3,
-		}}})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results.Results, gc.HasLen, 1)
-	c.Assert(results.Results[0].Error, gc.IsNil)
-
-	application, err := s.State.Application("application")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(application.GetOwnerTag(), gc.Equals, s.authorizer.GetAuthTag().String())
-}
-
 func (s *serviceSuite) deployServiceForUpdateTests(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-1", "dummy")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{

--- a/apiserver/charmrevisionupdater/testing/suite.go
+++ b/apiserver/charmrevisionupdater/testing/suite.go
@@ -117,8 +117,7 @@ func (s *CharmSuite) AddCharmWithRevision(c *gc.C, charmName string, rev int) *s
 func (s *CharmSuite) AddService(c *gc.C, charmName, serviceName string) {
 	ch, ok := s.charms[charmName]
 	c.Assert(ok, jc.IsTrue)
-	owner := s.jcSuite.AdminUserTag(c)
-	_, err := s.jcSuite.State.AddApplication(state.AddApplicationArgs{Name: serviceName, Owner: owner.String(), Charm: ch})
+	_, err := s.jcSuite.State.AddApplication(state.AddApplicationArgs{Name: serviceName, Charm: ch})
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/metricsadder/metricsadder_test.go
+++ b/apiserver/metricsadder/metricsadder_test.go
@@ -59,9 +59,8 @@ func (s *metricsAdderSuite) SetUpTest(c *gc.C) {
 		Name: "mysql",
 	})
 	s.mysql = s.factory.MakeApplication(c, &jujuFactory.ApplicationParams{
-		Name:    "mysql",
-		Charm:   mysqlCharm,
-		Creator: s.AdminUserTag(c),
+		Name:  "mysql",
+		Charm: mysqlCharm,
 	})
 	s.mysqlUnit = s.factory.MakeUnit(c, &jujuFactory.UnitParams{
 		Application: s.mysql,

--- a/apiserver/uniter/uniter.go
+++ b/apiserver/uniter/uniter.go
@@ -155,35 +155,6 @@ func (u *UniterAPIV3) AllMachinePorts(args params.Entities) (params.MachinePorts
 	return result, nil
 }
 
-// ApplicationOwner returns the owner user for each given service tag.
-func (u *UniterAPIV3) ApplicationOwner(args params.Entities) (params.StringResults, error) {
-	result := params.StringResults{
-		Results: make([]params.StringResult, len(args.Entities)),
-	}
-	canAccess, err := u.accessService()
-	if err != nil {
-		return params.StringResults{}, err
-	}
-	for i, entity := range args.Entities {
-		tag, err := names.ParseApplicationTag(entity.Tag)
-		if err != nil {
-			result.Results[i].Error = common.ServerError(common.ErrPerm)
-			continue
-		}
-		if !canAccess(tag) {
-			result.Results[i].Error = common.ServerError(common.ErrPerm)
-			continue
-		}
-		service, err := u.getService(tag)
-		if err != nil {
-			result.Results[i].Error = common.ServerError(err)
-			continue
-		}
-		result.Results[i].Result = service.GetOwnerTag()
-	}
-	return result, nil
-}
-
 // AssignedMachine returns the machine tag for each given unit tag, or
 // an error satisfying params.IsCodeNotAssigned when a unit has no
 // assigned machine.

--- a/apiserver/uniter/uniter_test.go
+++ b/apiserver/uniter/uniter_test.go
@@ -72,17 +72,15 @@ func (s *uniterSuite) SetUpTest(c *gc.C) {
 		URL:  "cs:quantal/wordpress-3",
 	})
 	s.wordpress = factory.MakeApplication(c, &jujuFactory.ApplicationParams{
-		Name:    "wordpress",
-		Charm:   s.wpCharm,
-		Creator: s.AdminUserTag(c),
+		Name:  "wordpress",
+		Charm: s.wpCharm,
 	})
 	mysqlCharm := factory.MakeCharm(c, &jujuFactory.CharmParams{
 		Name: "mysql",
 	})
 	s.mysql = factory.MakeApplication(c, &jujuFactory.ApplicationParams{
-		Name:    "mysql",
-		Charm:   mysqlCharm,
-		Creator: s.AdminUserTag(c),
+		Name:  "mysql",
+		Charm: mysqlCharm,
 	})
 	s.wordpressUnit = factory.MakeUnit(c, &jujuFactory.UnitParams{
 		Application: s.wordpress,
@@ -2128,29 +2126,6 @@ func (s *uniterSuite) TestUnitStatus(c *gc.C) {
 	})
 }
 
-func (s *uniterSuite) TestApplicationOwner(c *gc.C) {
-	args := params.Entities{Entities: []params.Entity{
-		{Tag: "unit-mysql-0"},
-		{Tag: "application-wordpress"},
-		{Tag: "unit-wordpress-0"},
-		{Tag: "unit-foo-42"},
-		{Tag: "machine-0"},
-		{Tag: "application-foo"},
-	}}
-	result, err := s.uniter.ApplicationOwner(args)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, params.StringResults{
-		Results: []params.StringResult{
-			{Error: apiservertesting.ErrUnauthorized},
-			{Result: s.AdminUserTag(c).String()},
-			{Error: apiservertesting.ErrUnauthorized},
-			{Error: apiservertesting.ErrUnauthorized},
-			{Error: apiservertesting.ErrUnauthorized},
-			{Error: apiservertesting.ErrUnauthorized},
-		},
-	})
-}
-
 func (s *uniterSuite) TestAssignedMachine(c *gc.C) {
 	args := params.Entities{Entities: []params.Entity{
 		{Tag: "unit-mysql-0"},
@@ -2417,7 +2392,6 @@ func (s *uniterNetworkConfigSuite) SetUpTest(c *gc.C) {
 	s.base.wordpress, err = s.base.State.AddApplication(state.AddApplicationArgs{
 		Name:  "wordpress",
 		Charm: s.base.wpCharm,
-		Owner: s.base.AdminUserTag(c).String(),
 		EndpointBindings: map[string]string{
 			"db":        "internal", // relation name
 			"admin-api": "public",   // extra-binding name
@@ -2435,9 +2409,8 @@ func (s *uniterNetworkConfigSuite) SetUpTest(c *gc.C) {
 		Name: "mysql",
 	})
 	s.base.mysql = factory.MakeApplication(c, &jujuFactory.ApplicationParams{
-		Name:    "mysql",
-		Charm:   mysqlCharm,
-		Creator: s.base.AdminUserTag(c),
+		Name:  "mysql",
+		Charm: mysqlCharm,
 	})
 	s.base.wordpressUnit = factory.MakeUnit(c, &jujuFactory.UnitParams{
 		Application: s.base.wordpress,

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -2774,7 +2774,7 @@ type addService struct {
 func (as addService) step(c *gc.C, ctx *context) {
 	ch, ok := ctx.charms[as.charm]
 	c.Assert(ok, jc.IsTrue)
-	svc, err := ctx.st.AddApplication(state.AddApplicationArgs{Name: as.name, Owner: ctx.adminUserTag, Charm: ch})
+	svc, err := ctx.st.AddApplication(state.AddApplicationArgs{Name: as.name, Charm: ch})
 	c.Assert(err, jc.ErrorIsNil)
 	if svc.IsPrincipal() {
 		err = svc.SetConstraints(as.cons)

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -494,7 +494,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	url := testcharms.Repo.ClonedURL(repoDir, mtools0.Version.Series, "dummy")
 	sch, err := jujutesting.PutCharm(st, url, &charmrepo.LocalRepository{Path: repoDir}, false)
 	c.Assert(err, jc.ErrorIsNil)
-	svc, err := st.AddApplication(state.AddApplicationArgs{Name: "dummy", Owner: owner.String(), Charm: sch})
+	svc, err := st.AddApplication(state.AddApplicationArgs{Name: "dummy", Charm: sch})
 	c.Assert(err, jc.ErrorIsNil)
 	units, err := juju.AddUnits(st, svc, 1, nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/juju/deploy.go
+++ b/juju/deploy.go
@@ -19,14 +19,13 @@ import (
 // DeployApplicationParams contains the arguments required to deploy the referenced
 // charm.
 type DeployApplicationParams struct {
-	ApplicationName  string
-	Series           string
-	ApplicationOwner string
-	Charm            *state.Charm
-	Channel          csparams.Channel
-	ConfigSettings   charm.Settings
-	Constraints      constraints.Value
-	NumUnits         int
+	ApplicationName string
+	Series          string
+	Charm           *state.Charm
+	Channel         csparams.Channel
+	ConfigSettings  charm.Settings
+	Constraints     constraints.Value
+	NumUnits        int
 	// Placement is a list of placement directives which may be used
 	// instead of a machine spec.
 	Placement        []*instance.Placement
@@ -55,13 +54,6 @@ func DeployApplication(st ApplicationDeployer, args DeployApplicationParams) (*s
 			return nil, fmt.Errorf("subordinate application must be deployed without constraints")
 		}
 	}
-	if args.ApplicationOwner == "" {
-		env, err := st.Model()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		args.ApplicationOwner = env.Owner().String()
-	}
 	// TODO(fwereade): transactional State.AddApplication including settings, constraints
 	// (minimumUnitCount, initialMachineIds?).
 
@@ -70,7 +62,6 @@ func DeployApplication(st ApplicationDeployer, args DeployApplicationParams) (*s
 	asa := state.AddApplicationArgs{
 		Name:             args.ApplicationName,
 		Series:           args.Series,
-		Owner:            args.ApplicationOwner,
 		Charm:            args.Charm,
 		Channel:          args.Channel,
 		Storage:          stateStorageConstraints(args.Storage),

--- a/juju/deploy_test.go
+++ b/juju/deploy_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/juju/testing/factory"
 )
 
 func Test(t *stdtesting.T) {
@@ -64,20 +63,7 @@ func (s *DeployLocalSuite) TestDeployMinimal(c *gc.C) {
 	s.assertCharm(c, service, s.charm.URL())
 	s.assertSettings(c, service, charm.Settings{})
 	s.assertConstraints(c, service, constraints.Value{})
-	c.Assert(service.GetOwnerTag(), gc.Equals, s.AdminUserTag(c).String())
 	s.assertMachines(c, service, constraints.Value{})
-}
-
-func (s *DeployLocalSuite) TestDeployOwnerTag(c *gc.C) {
-	s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar"})
-	service, err := juju.DeployApplication(s.State,
-		juju.DeployApplicationParams{
-			ApplicationName:  "bobwithowner",
-			Charm:            s.charm,
-			ApplicationOwner: "user-foobar",
-		})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(service.GetOwnerTag(), gc.Equals, "user-foobar")
 }
 
 func (s *DeployLocalSuite) TestDeploySeries(c *gc.C) {

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -609,23 +609,22 @@ func (s *JujuConnSuite) AddTestingCharm(c *gc.C, name string) *state.Charm {
 }
 
 func (s *JujuConnSuite) AddTestingService(c *gc.C, name string, ch *state.Charm) *state.Application {
-	return s.AddOwnedTestingServiceWithArgs(c, state.AddApplicationArgs{Name: name, Charm: ch})
-}
-
-func (s *JujuConnSuite) AddOwnedTestingServiceWithArgs(c *gc.C, args state.AddApplicationArgs) *state.Application {
-	c.Assert(s.State, gc.NotNil)
-	args.Owner = s.AdminUserTag(c).String()
-	service, err := s.State.AddApplication(args)
+	app, err := s.State.AddApplication(state.AddApplicationArgs{Name: name, Charm: ch})
 	c.Assert(err, jc.ErrorIsNil)
-	return service
+	return app
+
 }
 
 func (s *JujuConnSuite) AddTestingServiceWithStorage(c *gc.C, name string, ch *state.Charm, storage map[string]state.StorageConstraints) *state.Application {
-	return s.AddOwnedTestingServiceWithArgs(c, state.AddApplicationArgs{Name: name, Charm: ch, Storage: storage})
+	app, err := s.State.AddApplication(state.AddApplicationArgs{Name: name, Charm: ch, Storage: storage})
+	c.Assert(err, jc.ErrorIsNil)
+	return app
 }
 
 func (s *JujuConnSuite) AddTestingServiceWithBindings(c *gc.C, name string, ch *state.Charm, bindings map[string]string) *state.Application {
-	return s.AddOwnedTestingServiceWithArgs(c, state.AddApplicationArgs{Name: name, Charm: ch, EndpointBindings: bindings})
+	app, err := s.State.AddApplication(state.AddApplicationArgs{Name: name, Charm: ch, EndpointBindings: bindings})
+	c.Assert(err, jc.ErrorIsNil)
+	return app
 }
 
 func (s *JujuConnSuite) AgentConfigForTag(c *gc.C, tag names.Tag) agent.ConfigSetter {

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -128,10 +128,6 @@ func allCollections() collectionSchema {
 		// one model.
 		usersC: {
 			global: true,
-			indexes: []mgo.Index{{
-				// TODO(thumper): schema change to remove this index.
-				Key: []string{"name"},
-			}},
 		},
 
 		// This collection holds the last time the user connected to the API server.
@@ -152,12 +148,6 @@ func allCollections() collectionSchema {
 
 		// This collection holds persistent state for the metrics manager.
 		metricsManagerC: {global: true},
-
-		// This collection holds lease data, which is per-model, but is
-		// not itself multi-model-aware; happily it will imminently be
-		// deprecated in favour of the non-global leasesC below.
-		// TODO(fwereade): drop leaseC entirely so can't use wrong const.
-		leaseC: {global: true},
 
 		// This collection was deprecated before multi-model support
 		// was implemented.
@@ -392,7 +382,6 @@ const (
 	guisettingsC             = "guisettings"
 	instanceDataC            = "instanceData"
 	legacyipaddressesC       = "ipaddresses"
-	leaseC                   = "lease"
 	leasesC                  = "leases"
 	machinesC                = "machines"
 	meterStatusC             = "meterStatus"

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -378,16 +378,11 @@ func (svc *backingApplication) updated(st *State, store *multiwatcherStore, id s
 	if svc.CharmURL == nil {
 		return errors.Errorf("charm url is nil")
 	}
-	env, err := st.Model()
-	if err != nil {
-		return errors.Trace(err)
-	}
 	info := &multiwatcher.ApplicationInfo{
 		ModelUUID:   st.ModelUUID(),
 		Name:        svc.Name,
 		Exposed:     svc.Exposed,
 		CharmURL:    svc.CharmURL.String(),
-		OwnerTag:    svc.fixOwnerTag(env),
 		Life:        multiwatcher.Life(svc.Life.String()),
 		MinUnits:    svc.MinUnits,
 		Subordinate: svc.Subordinate,
@@ -467,15 +462,6 @@ func (svc *backingApplication) removed(store *multiwatcherStore, modelUUID, id s
 		Id:        id,
 	})
 	return nil
-}
-
-// SCHEMACHANGE
-// TODO(mattyw) remove when schema upgrades are possible
-func (svc *backingApplication) fixOwnerTag(env *Model) string {
-	if svc.OwnerTag != "" {
-		return svc.OwnerTag
-	}
-	return env.Owner().String()
 }
 
 func (svc *backingApplication) mongoId() string {

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -102,7 +102,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 		WantsVote:               false,
 	})
 
-	wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), s.owner)
+	wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 	err = wordpress.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 	err = wordpress.SetMinUnits(units)
@@ -115,7 +115,6 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 		Name:        "wordpress",
 		Exposed:     true,
 		CharmURL:    serviceCharmURL(wordpress).String(),
-		OwnerTag:    s.owner.String(),
 		Life:        multiwatcher.Life("alive"),
 		MinUnits:    units,
 		Constraints: constraints.MustParse("mem=100M"),
@@ -136,12 +135,11 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 		Annotations: pairs,
 	})
 
-	logging := AddTestingService(c, st, "logging", AddTestingCharm(c, st, "logging"), s.owner)
+	logging := AddTestingService(c, st, "logging", AddTestingCharm(c, st, "logging"))
 	add(&multiwatcher.ApplicationInfo{
 		ModelUUID:   modelUUID,
 		Name:        "logging",
 		CharmURL:    serviceCharmURL(logging).String(),
-		OwnerTag:    s.owner.String(),
 		Life:        multiwatcher.Life("alive"),
 		Config:      charm.Settings{},
 		Subordinate: true,
@@ -456,7 +454,7 @@ func (s *allWatcherStateSuite) TestChangeUnitsNonNilPorts(c *gc.C) {
 func (s *allWatcherStateSuite) TestChangeActions(c *gc.C) {
 	changeTestFuncs := []changeTestFunc{
 		func(c *gc.C, st *State) changeTestCase {
-			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), s.owner)
+			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			u, err := wordpress.AddUnit()
 			c.Assert(err, jc.ErrorIsNil)
 			action, err := st.EnqueueAction(u.Tag(), "vacuumdb", map[string]interface{}{})
@@ -559,7 +557,7 @@ func (s *allWatcherStateSuite) TestChangeBlocks(c *gc.C) {
 func (s *allWatcherStateSuite) TestClosingPorts(c *gc.C) {
 	defer s.Reset(c)
 	// Init the test model.
-	wordpress := AddTestingService(c, s.state, "wordpress", AddTestingCharm(c, s.state, "wordpress"), s.owner)
+	wordpress := AddTestingService(c, s.state, "wordpress", AddTestingCharm(c, s.state, "wordpress"))
 	u, err := wordpress.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 	m, err := s.state.AddMachine("quantal", JobHostUnits)
@@ -654,7 +652,7 @@ func (s *allWatcherStateSuite) TestClosingPorts(c *gc.C) {
 func (s *allWatcherStateSuite) TestSettings(c *gc.C) {
 	defer s.Reset(c)
 	// Init the test model.
-	svc := AddTestingService(c, s.state, "dummy-application", AddTestingCharm(c, s.state, "dummy"), s.owner)
+	svc := AddTestingService(c, s.state, "dummy-application", AddTestingCharm(c, s.state, "dummy"))
 	b := newAllWatcherStateBacking(s.state)
 	all := newStore()
 	// 1st scenario part: set settings and signal change.
@@ -834,7 +832,7 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m2.Id(), gc.Equals, "2")
 
-	wordpress := AddTestingService(c, s.state, "wordpress", AddTestingCharm(c, s.state, "wordpress"), s.owner)
+	wordpress := AddTestingService(c, s.state, "wordpress", AddTestingCharm(c, s.state, "wordpress"))
 	wu, err := wordpress.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 	err = wu.AssignToMachine(m2)
@@ -900,7 +898,6 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			ModelUUID: s.state.ModelUUID(),
 			Name:      "wordpress",
 			CharmURL:  "local:quantal/quantal-wordpress-3",
-			OwnerTag:  s.owner.String(),
 			Life:      "alive",
 			Config:    make(map[string]interface{}),
 			Status: multiwatcher.StatusInfo{
@@ -947,12 +944,12 @@ func (s *allWatcherStateSuite) TestStateWatcherTwoModels(c *gc.C) {
 		}, {
 			about: "applications",
 			triggerEvent: func(st *State) {
-				AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), s.owner)
+				AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			},
 		}, {
 			about: "units",
 			setUpState: func(st *State) {
-				AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), s.owner)
+				AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			},
 			triggerEvent: func(st *State) {
 				svc, err := st.Application("wordpress")
@@ -964,8 +961,8 @@ func (s *allWatcherStateSuite) TestStateWatcherTwoModels(c *gc.C) {
 		}, {
 			about: "relations",
 			setUpState: func(st *State) {
-				AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), s.owner)
-				AddTestingService(c, st, "mysql", AddTestingCharm(c, st, "mysql"), s.owner)
+				AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
+				AddTestingService(c, st, "mysql", AddTestingCharm(c, st, "mysql"))
 			},
 			triggerEvent: func(st *State) {
 				eps, err := st.InferEndpoints("mysql", "wordpress")
@@ -1012,7 +1009,7 @@ func (s *allWatcherStateSuite) TestStateWatcherTwoModels(c *gc.C) {
 		}, {
 			about: "constraints",
 			setUpState: func(st *State) {
-				AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), s.owner)
+				AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			},
 			triggerEvent: func(st *State) {
 				svc, err := st.Application("wordpress")
@@ -1025,7 +1022,7 @@ func (s *allWatcherStateSuite) TestStateWatcherTwoModels(c *gc.C) {
 		}, {
 			about: "settings",
 			setUpState: func(st *State) {
-				AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), s.owner)
+				AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			},
 			triggerEvent: func(st *State) {
 				svc, err := st.Application("wordpress")
@@ -1246,7 +1243,7 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 					}}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
-			svc := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), s.owner)
+			svc := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			err := svc.SetConstraints(constraints.MustParse("mem=4G arch=amd64"))
 			c.Assert(err, jc.ErrorIsNil)
 
@@ -1486,7 +1483,7 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m11.Id(), gc.Equals, "1")
 
-	wordpress := AddTestingService(c, st1, "wordpress", AddTestingCharm(c, st1, "wordpress"), s.owner)
+	wordpress := AddTestingService(c, st1, "wordpress", AddTestingCharm(c, st1, "wordpress"))
 	wu, err := wordpress.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 	err = wu.AssignToMachine(m11)
@@ -1555,7 +1552,6 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			ModelUUID: st1.ModelUUID(),
 			Name:      "wordpress",
 			CharmURL:  "local:quantal/quantal-wordpress-3",
-			OwnerTag:  s.owner.String(),
 			Life:      "alive",
 			Config:    make(map[string]interface{}),
 			Status: multiwatcher.StatusInfo{
@@ -1928,8 +1924,8 @@ func testChangeRelations(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C
 				}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
-			AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), owner)
-			AddTestingService(c, st, "logging", AddTestingCharm(c, st, "logging"), owner)
+			AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
+			AddTestingService(c, st, "logging", AddTestingCharm(c, st, "logging"))
 			eps, err := st.InferEndpoints("logging", "wordpress")
 			c.Assert(err, jc.ErrorIsNil)
 			_, err = st.AddRelation(eps...)
@@ -1981,7 +1977,7 @@ func testChangeServices(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C,
 				}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
-			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), owner)
+			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			err := wordpress.SetExposed()
 			c.Assert(err, jc.ErrorIsNil)
 			err = wordpress.SetMinUnits(42)
@@ -1999,7 +1995,6 @@ func testChangeServices(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C,
 						Name:      "wordpress",
 						Exposed:   true,
 						CharmURL:  "local:quantal/quantal-wordpress-3",
-						OwnerTag:  owner.String(),
 						Life:      multiwatcher.Life("alive"),
 						MinUnits:  42,
 						Config:    charm.Settings{},
@@ -2011,7 +2006,7 @@ func testChangeServices(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C,
 					}}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
-			svc := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), owner)
+			svc := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			setServiceConfigAttr(c, svc, "blog-title", "boring")
 
 			return changeTestCase{
@@ -2034,14 +2029,13 @@ func testChangeServices(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C,
 						ModelUUID:   st.ModelUUID(),
 						Name:        "wordpress",
 						CharmURL:    "local:quantal/quantal-wordpress-3",
-						OwnerTag:    owner.String(),
 						Life:        multiwatcher.Life("alive"),
 						Constraints: constraints.MustParse("mem=99M"),
 						Config:      charm.Settings{"blog-title": "boring"},
 					}}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
-			svc := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), owner)
+			svc := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			setServiceConfigAttr(c, svc, "blog-title", "boring")
 
 			return changeTestCase{
@@ -2063,7 +2057,6 @@ func testChangeServices(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C,
 						ModelUUID: st.ModelUUID(),
 						Name:      "wordpress",
 						CharmURL:  "local:quantal/quantal-wordpress-3",
-						OwnerTag:  owner.String(),
 						Life:      multiwatcher.Life("alive"),
 						Config:    charm.Settings{"blog-title": "boring"},
 					}}}
@@ -2096,7 +2089,7 @@ func testChangeServices(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C,
 				}}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
-			svc := AddTestingService(c, st, "dummy-application", AddTestingCharm(c, st, "dummy"), owner)
+			svc := AddTestingService(c, st, "dummy-application", AddTestingCharm(c, st, "dummy"))
 			setServiceConfigAttr(c, svc, "username", "foo")
 			setServiceConfigAttr(c, svc, "outlook", "foo@bar")
 
@@ -2120,7 +2113,7 @@ func testChangeServices(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C,
 					}}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
-			svc := AddTestingService(c, st, "dummy-application", AddTestingCharm(c, st, "dummy"), owner)
+			svc := AddTestingService(c, st, "dummy-application", AddTestingCharm(c, st, "dummy"))
 			setServiceConfigAttr(c, svc, "username", "foo")
 			setServiceConfigAttr(c, svc, "outlook", "foo@bar")
 			setServiceConfigAttr(c, svc, "username", nil)
@@ -2150,7 +2143,7 @@ func testChangeServices(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C,
 				c, st, "dummy",
 				"config.yaml", dottedConfig,
 				"quantal", 1)
-			svc := AddTestingService(c, st, "dummy-application", testCharm, owner)
+			svc := AddTestingService(c, st, "dummy-application", testCharm)
 			setServiceConfigAttr(c, svc, "key.dotted", "foo")
 
 			return changeTestCase{
@@ -2174,7 +2167,7 @@ func testChangeServices(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C,
 					}}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
-			svc := AddTestingService(c, st, "dummy-application", AddTestingCharm(c, st, "dummy"), owner)
+			svc := AddTestingService(c, st, "dummy-application", AddTestingCharm(c, st, "dummy"))
 			setServiceConfigAttr(c, svc, "username", "foo")
 
 			return changeTestCase{
@@ -2246,7 +2239,7 @@ func testChangeServicesConstraints(c *gc.C, owner names.UserTag, runChangeTests 
 				}}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
-			svc := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), owner)
+			svc := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			err := svc.SetConstraints(constraints.MustParse("mem=4G arch=amd64"))
 			c.Assert(err, jc.ErrorIsNil)
 
@@ -2298,7 +2291,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 				}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
-			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), owner)
+			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			u, err := wordpress.AddUnit()
 			c.Assert(err, jc.ErrorIsNil)
 			m, err := st.AddMachine("quantal", JobHostUnits)
@@ -2359,7 +2352,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 					}}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
-			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), owner)
+			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			u, err := wordpress.AddUnit()
 			c.Assert(err, jc.ErrorIsNil)
 			m, err := st.AddMachine("quantal", JobHostUnits)
@@ -2415,7 +2408,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 					}}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
-			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), owner)
+			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			u, err := wordpress.AddUnit()
 			c.Assert(err, jc.ErrorIsNil)
 			m, err := st.AddMachine("quantal", JobHostUnits)
@@ -2455,7 +2448,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 				}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
-			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), owner)
+			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			u, err := wordpress.AddUnit()
 			c.Assert(err, jc.ErrorIsNil)
 			m, err := st.AddMachine("quantal", JobHostUnits)
@@ -2503,7 +2496,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 				}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
-			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), owner)
+			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			u, err := wordpress.AddUnit()
 			c.Assert(err, jc.ErrorIsNil)
 			m, err := st.AddMachine("quantal", JobHostUnits)
@@ -2604,7 +2597,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 					}}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
-			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), owner)
+			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			u, err := wordpress.AddUnit()
 			c.Assert(err, jc.ErrorIsNil)
 			now := time.Now()
@@ -2657,7 +2650,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 					}}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
-			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), owner)
+			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			u, err := wordpress.AddUnit()
 			c.Assert(err, jc.ErrorIsNil)
 			now := time.Now()
@@ -2717,7 +2710,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 					}}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
-			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), owner)
+			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			u, err := wordpress.AddUnit()
 			c.Assert(err, jc.ErrorIsNil)
 			now := time.Now()
@@ -2777,7 +2770,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 					}}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
-			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), owner)
+			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			u, err := wordpress.AddUnit()
 			c.Assert(err, jc.ErrorIsNil)
 			now := time.Now()
@@ -2867,7 +2860,7 @@ const (
 
 func testChangeUnitsNonNilPorts(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []changeTestFunc)) {
 	initEnv := func(c *gc.C, st *State, flag initFlag) {
-		wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), owner)
+		wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 		u, err := wordpress.AddUnit()
 		c.Assert(err, jc.ErrorIsNil)
 		m, err := st.AddMachine("quantal", JobHostUnits)

--- a/state/application.go
+++ b/state/application.go
@@ -49,7 +49,6 @@ type applicationDoc struct {
 	RelationCount        int        `bson:"relationcount"`
 	Exposed              bool       `bson:"exposed"`
 	MinUnits             int        `bson:"minunits"`
-	OwnerTag             string     `bson:"ownertag"`
 	TxnRevno             int64      `bson:"txn-revno"`
 	MetricCredentials    []byte     `bson:"metric-credentials"`
 }
@@ -1032,18 +1031,6 @@ func (s *Application) unitStorageOps(unitName string, cons map[string]StorageCon
 		return nil, -1, errors.Trace(err)
 	}
 	return ops, numStorageAttachments, nil
-}
-
-// SCHEMACHANGE
-// TODO(mattyw) remove when schema upgrades are possible
-func (s *Application) GetOwnerTag() string {
-	owner := s.doc.OwnerTag
-	if owner == "" {
-		// We know that if there was no owner, it was created with an early
-		// version of juju, and that admin was the only user.
-		owner = names.NewUserTag("admin").String()
-	}
-	return owner
 }
 
 // AddUnit adds a new principal unit to the service.

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -88,7 +88,7 @@ func (s *ServiceSuite) TestSetCharmLegacy(c *gc.C) {
 
 func (s *ServiceSuite) TestClientServiceSetCharmUnsupportedSeries(c *gc.C) {
 	ch := state.AddTestingCharmMultiSeries(c, s.State, "multi-series")
-	svc := state.AddTestingServiceForSeries(c, s.State, "precise", "application", ch, s.Owner)
+	svc := state.AddTestingServiceForSeries(c, s.State, "precise", "application", ch)
 
 	chDifferentSeries := state.AddTestingCharmMultiSeries(c, s.State, "multi-series2")
 	cfg := state.SetCharmConfig{
@@ -100,7 +100,7 @@ func (s *ServiceSuite) TestClientServiceSetCharmUnsupportedSeries(c *gc.C) {
 
 func (s *ServiceSuite) TestClientServiceSetCharmUnsupportedSeriesForce(c *gc.C) {
 	ch := state.AddTestingCharmMultiSeries(c, s.State, "multi-series")
-	svc := state.AddTestingServiceForSeries(c, s.State, "precise", "application", ch, s.Owner)
+	svc := state.AddTestingServiceForSeries(c, s.State, "precise", "application", ch)
 
 	chDifferentSeries := state.AddTestingCharmMultiSeries(c, s.State, "multi-series2")
 	cfg := state.SetCharmConfig{
@@ -118,7 +118,7 @@ func (s *ServiceSuite) TestClientServiceSetCharmUnsupportedSeriesForce(c *gc.C) 
 
 func (s *ServiceSuite) TestClientServiceSetCharmWrongOS(c *gc.C) {
 	ch := state.AddTestingCharmMultiSeries(c, s.State, "multi-series")
-	svc := state.AddTestingServiceForSeries(c, s.State, "precise", "application", ch, s.Owner)
+	svc := state.AddTestingServiceForSeries(c, s.State, "precise", "application", ch)
 
 	chDifferentSeries := state.AddTestingCharmMultiSeries(c, s.State, "multi-series-windows")
 	cfg := state.SetCharmConfig{
@@ -150,7 +150,6 @@ func (s *ServiceSuite) TestSetCharmUpdatesBindings(c *gc.C) {
 
 	service, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:  "yoursql",
-		Owner: s.Owner.String(),
 		Charm: oldCharm,
 		EndpointBindings: map[string]string{
 			"server": "db",
@@ -1718,7 +1717,7 @@ func (s *ServiceSuite) TestRemoveQueuesLocalCharmCleanup(c *gc.C) {
 
 func (s *ServiceSuite) TestRemoveStoreCharmNoCleanup(c *gc.C) {
 	ch := state.AddTestingCharmMultiSeries(c, s.State, "multi-series")
-	svc := state.AddTestingServiceForSeries(c, s.State, "precise", "application", ch, s.Owner)
+	svc := state.AddTestingServiceForSeries(c, s.State, "precise", "application", ch)
 
 	err := svc.Destroy()
 	dirty, err := s.State.NeedsCleanup()
@@ -2072,17 +2071,6 @@ func (s *ServiceSuite) TestWatchService(c *gc.C) {
 	w = s.mysql.Watch()
 	defer testing.AssertStop(c, w)
 	testing.NewNotifyWatcherC(c, s.State, w).AssertOneChange()
-}
-
-// SCHEMACHANGE
-// TODO(mattyw) remove when schema upgrades are possible
-// Check that GetOwnerTag returns user-admin even
-// when the service has no owner
-func (s *ServiceSuite) TestOwnerTagSchemaProtection(c *gc.C) {
-	service := s.AddTestingService(c, "foobar", s.charm)
-	state.SetApplicationOwnerTag(service, "")
-	c.Assert(state.GetApplicationOwnerTag(service), gc.Equals, "")
-	c.Assert(service.GetOwnerTag(), gc.Equals, "user-admin")
 }
 
 func (s *ServiceSuite) TestMetricCredentials(c *gc.C) {

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -136,7 +136,7 @@ func (s *CleanupSuite) TestCleanupModelMachines(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create a relation with a unit in scope and assigned to the hosted machine.
-	pr := NewPeerRelation(c, s.State, s.Owner)
+	pr := NewPeerRelation(c, s.State)
 	err = pr.u0.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 	err = pr.ru0.EnterScope(nil)
@@ -209,7 +209,7 @@ func (s *CleanupSuite) TestCleanupModelServices(c *gc.C) {
 
 func (s *CleanupSuite) TestCleanupRelationSettings(c *gc.C) {
 	// Create a relation with a unit in scope.
-	pr := NewPeerRelation(c, s.State, s.Owner)
+	pr := NewPeerRelation(c, s.State)
 	rel := pr.ru0.Relation()
 	err := pr.ru0.EnterScope(map[string]interface{}{"some": "settings"})
 	c.Assert(err, jc.ErrorIsNil)
@@ -256,7 +256,7 @@ func (s *CleanupSuite) TestCleanupForceDestroyedMachineUnit(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create a relation with a unit in scope and assigned to the machine.
-	pr := NewPeerRelation(c, s.State, s.Owner)
+	pr := NewPeerRelation(c, s.State)
 	err = pr.u0.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 	err = pr.ru0.EnterScope(nil)

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -59,15 +59,15 @@ func (s *ConnSuite) AddTestingCharm(c *gc.C, name string) *state.Charm {
 }
 
 func (s *ConnSuite) AddTestingService(c *gc.C, name string, ch *state.Charm) *state.Application {
-	return state.AddTestingService(c, s.State, name, ch, s.Owner)
+	return state.AddTestingService(c, s.State, name, ch)
 }
 
 func (s *ConnSuite) AddTestingServiceWithStorage(c *gc.C, name string, ch *state.Charm, storage map[string]state.StorageConstraints) *state.Application {
-	return state.AddTestingServiceWithStorage(c, s.State, name, ch, s.Owner, storage)
+	return state.AddTestingServiceWithStorage(c, s.State, name, ch, storage)
 }
 
 func (s *ConnSuite) AddTestingServiceWithBindings(c *gc.C, name string, ch *state.Charm, bindings map[string]string) *state.Application {
-	return state.AddTestingServiceWithBindings(c, s.State, name, ch, s.Owner, bindings)
+	return state.AddTestingServiceWithBindings(c, s.State, name, ch, bindings)
 }
 
 func (s *ConnSuite) AddSeriesCharm(c *gc.C, name, series string) *state.Charm {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -138,28 +138,27 @@ func AddTestingCharmMultiSeries(c *gc.C, st *State, name string) *Charm {
 	return sch
 }
 
-func AddTestingService(c *gc.C, st *State, name string, ch *Charm, owner names.UserTag) *Application {
-	return addTestingService(c, st, "", name, ch, owner, nil, nil)
+func AddTestingService(c *gc.C, st *State, name string, ch *Charm) *Application {
+	return addTestingService(c, st, "", name, ch, nil, nil)
 }
 
-func AddTestingServiceForSeries(c *gc.C, st *State, series, name string, ch *Charm, owner names.UserTag) *Application {
-	return addTestingService(c, st, series, name, ch, owner, nil, nil)
+func AddTestingServiceForSeries(c *gc.C, st *State, series, name string, ch *Charm) *Application {
+	return addTestingService(c, st, series, name, ch, nil, nil)
 }
 
-func AddTestingServiceWithStorage(c *gc.C, st *State, name string, ch *Charm, owner names.UserTag, storage map[string]StorageConstraints) *Application {
-	return addTestingService(c, st, "", name, ch, owner, nil, storage)
+func AddTestingServiceWithStorage(c *gc.C, st *State, name string, ch *Charm, storage map[string]StorageConstraints) *Application {
+	return addTestingService(c, st, "", name, ch, nil, storage)
 }
 
-func AddTestingServiceWithBindings(c *gc.C, st *State, name string, ch *Charm, owner names.UserTag, bindings map[string]string) *Application {
-	return addTestingService(c, st, "", name, ch, owner, bindings, nil)
+func AddTestingServiceWithBindings(c *gc.C, st *State, name string, ch *Charm, bindings map[string]string) *Application {
+	return addTestingService(c, st, "", name, ch, bindings, nil)
 }
 
-func addTestingService(c *gc.C, st *State, series, name string, ch *Charm, owner names.UserTag, bindings map[string]string, storage map[string]StorageConstraints) *Application {
+func addTestingService(c *gc.C, st *State, series, name string, ch *Charm, bindings map[string]string, storage map[string]StorageConstraints) *Application {
 	c.Assert(ch, gc.NotNil)
 	service, err := st.AddApplication(AddApplicationArgs{
 		Name:             name,
 		Series:           series,
-		Owner:            owner.String(),
 		Charm:            ch,
 		EndpointBindings: bindings,
 		Storage:          storage,
@@ -213,18 +212,6 @@ func SetCharmBundleURL(c *gc.C, st *State, curl *charm.URL, bundleURL string) {
 	}}
 	err := st.runTransaction(ops)
 	c.Assert(err, jc.ErrorIsNil)
-}
-
-// SCHEMACHANGE
-// This method is used to reset the ownertag attribute
-func SetApplicationOwnerTag(s *Application, ownerTag string) {
-	s.doc.OwnerTag = ownerTag
-}
-
-// SCHEMACHANGE
-// Get the owner directly
-func GetApplicationOwnerTag(s *Application) string {
-	return s.doc.OwnerTag
 }
 
 func SetPasswordHash(e Authenticator, passwordHash string) error {

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -25,7 +25,7 @@ func (s *FilesystemStateSuite) TestAddServiceInvalidPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("invalid-pool", 1024, 1),
 	}
-	_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-filesystem", Owner: s.Owner.String(), Charm: ch, Storage: storage})
+	_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-filesystem", Charm: ch, Storage: storage})
 	c.Assert(err, gc.ErrorMatches, `.* pool "invalid-pool" not found`)
 }
 
@@ -58,7 +58,6 @@ func (s *FilesystemStateSuite) testAddServiceDefaultPool(c *gc.C, expectedPool s
 
 	args := state.AddApplicationArgs{
 		Name:     "storage-filesystem",
-		Owner:    s.Owner.String(),
 		Charm:    ch,
 		Storage:  storage,
 		NumUnits: numUnits,

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -712,30 +712,6 @@ func (s *MachineSuite) TestSetPassword(c *gc.C) {
 	})
 }
 
-func (s *MachineSuite) TestSetPasswordPreModelUUID(c *gc.C) {
-	// Ensure that SetPassword works for machines even when the env
-	// UUID upgrade migrations haven't run yet.
-	type oldMachineDoc struct {
-		Id     string `bson:"_id"`
-		Series string
-	}
-	s.machines.Insert(&oldMachineDoc{"99", "quantal"})
-
-	m, err := s.State.Machine("99")
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Set the password and make sure it sticks.
-	c.Assert(m.PasswordValid(goodPassword), jc.IsFalse)
-	err = m.SetPassword(goodPassword)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m.PasswordValid(goodPassword), jc.IsTrue)
-
-	// Check a newly-fetched entity has the same password.
-	err = m.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m.PasswordValid(goodPassword), jc.IsTrue)
-}
-
 func (s *MachineSuite) TestMachineWaitAgentPresence(c *gc.C) {
 	alive, err := s.machine.AgentPresence()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -377,10 +377,8 @@ func (s *MigrationExportSuite) TestUnitsOpenPorts(c *gc.C) {
 }
 
 func (s *MigrationExportSuite) TestRelations(c *gc.C) {
-	// Need to remove owner from application.
-	ignored := s.Owner
-	wordpress := state.AddTestingService(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"), ignored)
-	mysql := state.AddTestingService(c, s.State, "mysql", state.AddTestingCharm(c, s.State, "mysql"), ignored)
+	wordpress := state.AddTestingService(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"))
+	mysql := state.AddTestingService(c, s.State, "mysql", state.AddTestingCharm(c, s.State, "mysql"))
 	// InferEndpoints will always return provider, requirer
 	eps, err := s.State.InferEndpoints("mysql", "wordpress")
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -404,10 +404,8 @@ func (s *MigrationImportSuite) TestUnits(c *gc.C) {
 }
 
 func (s *MigrationImportSuite) TestRelations(c *gc.C) {
-	// Need to remove owner from service.
-	ignored := s.Owner
-	wordpress := state.AddTestingService(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"), ignored)
-	state.AddTestingService(c, s.State, "mysql", state.AddTestingCharm(c, s.State, "mysql"), ignored)
+	wordpress := state.AddTestingService(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"))
+	state.AddTestingService(c, s.State, "mysql", state.AddTestingCharm(c, s.State, "mysql"))
 	eps, err := s.State.InferEndpoints("mysql", "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	rel, err := s.State.AddRelation(eps...)

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -64,8 +64,6 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		usermodelnameC,
 		// Metrics aren't migrated.
 		metricsC,
-		// leaseC is deprecated in favour of leasesC.
-		leaseC,
 		// Backup and restore information is not migrated.
 		restoreInfoC,
 		// upgradeInfoC is used to coordinate upgrades and schema migrations,
@@ -292,8 +290,6 @@ func (s *MigrationSuite) TestServiceDocFields(c *gc.C) {
 		"ModelUUID",
 		// Always alive, not explicitly exported.
 		"Life",
-		// OwnerTag is deprecated and should be deleted.
-		"OwnerTag",
 		// TxnRevno is mgo internals and should not be migrated.
 		"TxnRevno",
 		// UnitCount is handled by the number of units for the exported service.
@@ -352,10 +348,6 @@ func (s *MigrationSuite) TestUnitDocFields(c *gc.C) {
 		// TxnRevno isn't migrated.
 		"TxnRevno",
 		"PasswordHash",
-		// Obsolete and not migrated.
-		"Ports",
-		"PublicAddress",
-		"PrivateAddress",
 	)
 	todo := set.NewStrings(
 		"StorageAttachmentCount",

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -364,13 +364,12 @@ func (s *ModelSuite) TestDestroyControllerAndHostedModelsWithResources(c *gc.C) 
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = otherSt.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	service := s.Factory.MakeApplication(c, &factory.ApplicationParams{Creator: otherEnv.Owner()})
+	service := s.Factory.MakeApplication(c, nil)
 	ch, _, err := service.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := state.AddApplicationArgs{
 		Name:  service.Name(),
-		Owner: service.GetOwnerTag(),
 		Charm: ch,
 	}
 	service, err = otherSt.AddApplication(args)
@@ -580,12 +579,11 @@ func (s *ModelSuite) TestProcessDyingEnvironWithMachinesAndServicesNoOp(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = st.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	service := s.Factory.MakeApplication(c, &factory.ApplicationParams{Creator: env.Owner()})
+	service := s.Factory.MakeApplication(c, nil)
 	ch, _, err := service.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 	args := state.AddApplicationArgs{
 		Name:  service.Name(),
-		Owner: service.GetOwnerTag(),
 		Charm: ch,
 	}
 	service, err = st.AddApplication(args)

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -327,7 +327,6 @@ func (st *State) ModelsForUser(user names.UserTag) ([]*UserModel, error) {
 	modelUsers, userCloser := st.getRawCollection(modelUsersC)
 	defer userCloser()
 
-	// TODO: consider adding an index to the modelUsers collection on the username.
 	var userSlice []modelUserDoc
 	err := modelUsers.Find(bson.D{{"user", user.Canonical()}}).Select(bson.D{{"model-uuid", 1}, {"_id", 1}}).All(&userSlice)
 	if err != nil {

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -13,7 +13,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
-	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -77,7 +76,7 @@ func (s *RelationUnitSuite) TestReadSettingsErrors(c *gc.C) {
 }
 
 func (s *RelationUnitSuite) TestPeerSettings(c *gc.C) {
-	pr := NewPeerRelation(c, s.State, s.Owner)
+	pr := NewPeerRelation(c, s.State)
 	rus := RUs{pr.ru0, pr.ru1}
 
 	// Check missing settings cannot be read by any RU.
@@ -294,7 +293,7 @@ func (s *RelationUnitSuite) TestContainerCreateSubordinate(c *gc.C) {
 }
 
 func (s *RelationUnitSuite) TestDestroyRelationWithUnitsInScope(c *gc.C) {
-	pr := NewPeerRelation(c, s.State, s.Owner)
+	pr := NewPeerRelation(c, s.State)
 	rel := pr.ru0.Relation()
 
 	// Enter two units, and check that Destroying the service sets the
@@ -361,7 +360,7 @@ func (s *RelationUnitSuite) TestDestroyRelationWithUnitsInScope(c *gc.C) {
 }
 
 func (s *RelationUnitSuite) TestAliveRelationScope(c *gc.C) {
-	pr := NewPeerRelation(c, s.State, s.Owner)
+	pr := NewPeerRelation(c, s.State)
 	rel := pr.ru0.Relation()
 
 	// Two units enter...
@@ -412,7 +411,7 @@ func (s *RelationUnitSuite) TestAliveRelationScope(c *gc.C) {
 
 func (s *StateSuite) TestWatchWatchScopeDiesOnStateClose(c *gc.C) {
 	testWatcherDiesWhenStateCloses(c, s.modelTag, func(c *gc.C, st *state.State) waiter {
-		pr := NewPeerRelation(c, st, s.Owner)
+		pr := NewPeerRelation(c, st)
 		w := pr.ru0.WatchScope()
 		<-w.Changes()
 		return w
@@ -420,7 +419,7 @@ func (s *StateSuite) TestWatchWatchScopeDiesOnStateClose(c *gc.C) {
 }
 
 func (s *RelationUnitSuite) TestPeerWatchScope(c *gc.C) {
-	pr := NewPeerRelation(c, s.State, s.Owner)
+	pr := NewPeerRelation(c, s.State)
 
 	// Test empty initial event.
 	w0 := pr.ru0.WatchScope()
@@ -637,7 +636,7 @@ func (s *RelationUnitSuite) TestContainerWatchScope(c *gc.C) {
 }
 
 func (s *RelationUnitSuite) TestCoalesceWatchScope(c *gc.C) {
-	pr := NewPeerRelation(c, s.State, s.Owner)
+	pr := NewPeerRelation(c, s.State)
 
 	// Test empty initial event.
 	w0 := pr.ru0.WatchScope()
@@ -751,8 +750,8 @@ type PeerRelation struct {
 	ru0, ru1, ru2, ru3 *state.RelationUnit
 }
 
-func NewPeerRelation(c *gc.C, st *state.State, owner names.UserTag) *PeerRelation {
-	svc := state.AddTestingService(c, st, "riak", state.AddTestingCharm(c, st, "riak"), owner)
+func NewPeerRelation(c *gc.C, st *state.State) *PeerRelation {
+	svc := state.AddTestingService(c, st, "riak", state.AddTestingCharm(c, st, "riak"))
 	ep, err := svc.Endpoint("ring")
 	c.Assert(err, jc.ErrorIsNil)
 	rel, err := st.EndpointsRelation(ep)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1268,21 +1268,6 @@ func (s *StateSuite) TestReadMachine(c *gc.C) {
 	c.Assert(machine.Id(), gc.Equals, expectedId)
 }
 
-func (s *StateSuite) TestReadPreModelUUIDMachine(c *gc.C) {
-	type oldMachineDoc struct {
-		Id     string `bson:"_id"`
-		Series string
-	}
-
-	s.machines.Insert(&oldMachineDoc{"99", "quantal"})
-
-	machine, err := s.State.Machine("99")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machine.Id(), gc.Equals, "99")
-	c.Assert(machine.Tag(), gc.Equals, names.NewMachineTag("99"))
-	c.Assert(machine.Series(), gc.Equals, "quantal") // Sanity check.
-}
-
 func (s *StateSuite) TestMachineNotFound(c *gc.C) {
 	_, err := s.State.Machine("0")
 	c.Assert(err, gc.ErrorMatches, "machine 0 not found")
@@ -1358,25 +1343,25 @@ func (s *StateSuite) TestAllRelations(c *gc.C) {
 
 func (s *StateSuite) TestAddApplication(c *gc.C) {
 	ch := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "haha/borken", Owner: s.Owner.String(), Charm: ch})
+	_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "haha/borken", Charm: ch})
 	c.Assert(err, gc.ErrorMatches, `cannot add application "haha/borken": invalid name`)
 	_, err = s.State.Application("haha/borken")
 	c.Assert(err, gc.ErrorMatches, `"haha/borken" is not a valid application name`)
 
 	// set that a nil charm is handled correctly
-	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "umadbro", Owner: s.Owner.String()})
+	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "umadbro"})
 	c.Assert(err, gc.ErrorMatches, `cannot add application "umadbro": charm is nil`)
 
 	insettings := charm.Settings{"tuning": "optimized"}
 
-	wordpress, err := s.State.AddApplication(state.AddApplicationArgs{Name: "wordpress", Owner: s.Owner.String(), Charm: ch, Settings: insettings})
+	wordpress, err := s.State.AddApplication(state.AddApplicationArgs{Name: "wordpress", Charm: ch, Settings: insettings})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(wordpress.Name(), gc.Equals, "wordpress")
 	outsettings, err := wordpress.ConfigSettings()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(outsettings, gc.DeepEquals, insettings)
 
-	mysql, err := s.State.AddApplication(state.AddApplicationArgs{Name: "mysql", Owner: s.Owner.String(), Charm: ch})
+	mysql, err := s.State.AddApplication(state.AddApplicationArgs{Name: "mysql", Charm: ch})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mysql.Name(), gc.Equals, "mysql")
 
@@ -1402,7 +1387,7 @@ func (s *StateSuite) TestAddServiceEnvironmentDying(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = env.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "s1", Owner: s.Owner.String(), Charm: charm})
+	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "s1", Charm: charm})
 	c.Assert(err, gc.ErrorMatches, `cannot add application "s1": model "testenv" is no longer alive`)
 }
 
@@ -1413,7 +1398,7 @@ func (s *StateSuite) TestAddServiceEnvironmentMigrating(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = env.SetMigrationMode(state.MigrationModeExporting)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "s1", Owner: s.Owner.String(), Charm: charm})
+	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "s1", Charm: charm})
 	c.Assert(err, gc.ErrorMatches, `cannot add application "s1": model "testenv" is being migrated`)
 }
 
@@ -1428,7 +1413,7 @@ func (s *StateSuite) TestAddServiceEnvironmentDyingAfterInitial(c *gc.C) {
 		c.Assert(env.Life(), gc.Equals, state.Alive)
 		c.Assert(env.Destroy(), gc.IsNil)
 	}).Check()
-	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "s1", Owner: s.Owner.String(), Charm: charm})
+	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "s1", Charm: charm})
 	c.Assert(err, gc.ErrorMatches, `cannot add application "s1": model "testenv" is no longer alive`)
 }
 
@@ -1438,29 +1423,10 @@ func (s *StateSuite) TestServiceNotFound(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
-func (s *StateSuite) TestAddServiceNoTag(c *gc.C) {
-	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "wordpress", Owner: "admin", Charm: charm})
-	c.Assert(err, gc.ErrorMatches, "cannot add application \"wordpress\": Invalid ownertag admin: \"admin\" is not a valid tag")
-}
-
-func (s *StateSuite) TestAddServiceNotUserTag(c *gc.C) {
-	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "wordpress", Owner: "machine-3", Charm: charm})
-	c.Assert(err, gc.ErrorMatches, "cannot add application \"wordpress\": Invalid ownertag machine-3: \"machine-3\" is not a valid user tag")
-}
-
-func (s *StateSuite) TestAddServiceNonExistentUser(c *gc.C) {
-	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "wordpress", Owner: "user-notAuser", Charm: charm})
-	c.Assert(err, gc.ErrorMatches, `cannot add application "wordpress": model user "notAuser@local" not found`)
-}
-
 func (s *StateSuite) TestAddServiceWithDefaultBindings(c *gc.C) {
 	ch := s.AddMetaCharm(c, "mysql", metaBase, 42)
 	svc, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:  "yoursql",
-		Owner: s.Owner.String(),
 		Charm: ch,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1494,7 +1460,6 @@ func (s *StateSuite) TestAddServiceWithSpecifiedBindings(c *gc.C) {
 	ch := s.AddMetaCharm(c, "mysql", metaBase, 43)
 	svc, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:  "yoursql",
-		Owner: s.Owner.String(),
 		Charm: ch,
 		EndpointBindings: map[string]string{
 			"client":  "client",
@@ -1559,7 +1524,6 @@ func (s *StateSuite) TestAddServiceWithInvalidBindings(c *gc.C) {
 
 		_, err := s.State.AddApplication(state.AddApplicationArgs{
 			Name:             "yoursql",
-			Owner:            s.Owner.String(),
 			Charm:            charm,
 			EndpointBindings: test.bindings,
 		})
@@ -1574,7 +1538,7 @@ func (s *StateSuite) TestAddServiceMachinePlacementInvalidSeries(c *gc.C) {
 
 	charm := s.AddTestingCharm(c, "dummy")
 	_, err = s.State.AddApplication(state.AddApplicationArgs{
-		Name: "wordpress", Owner: s.Owner.String(), Charm: charm,
+		Name: "wordpress", Charm: charm,
 		Placement: []*instance.Placement{
 			{instance.MachineScope, m.Id()},
 		},
@@ -1587,7 +1551,7 @@ func (s *StateSuite) TestAddServiceIncompatibleOSWithSeriesInURL(c *gc.C) {
 	// A charm with a series in its URL is implicitly supported by that
 	// series only.
 	_, err := s.State.AddApplication(state.AddApplicationArgs{
-		Name: "wordpress", Owner: s.Owner.String(), Charm: charm,
+		Name: "wordpress", Charm: charm,
 		Series: "centos7",
 	})
 	c.Assert(err, gc.ErrorMatches, `cannot add application "wordpress": series "centos7" \(OS \"CentOS"\) not supported by charm, supported series are "quantal"`)
@@ -1598,7 +1562,7 @@ func (s *StateSuite) TestAddServiceCompatibleOSWithSeriesInURL(c *gc.C) {
 	// A charm with a series in its URL is implicitly supported by that
 	// series only.
 	_, err := s.State.AddApplication(state.AddApplicationArgs{
-		Name: "wordpress", Owner: s.Owner.String(), Charm: charm,
+		Name: "wordpress", Charm: charm,
 		Series: charm.URL().Series,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1608,7 +1572,7 @@ func (s *StateSuite) TestAddServiceCompatibleOSWithNoExplicitSupportedSeries(c *
 	// If a charm doesn't declare any series, we can add it with any series we choose.
 	charm := s.AddSeriesCharm(c, "dummy", "")
 	_, err := s.State.AddApplication(state.AddApplicationArgs{
-		Name: "wordpress", Owner: s.Owner.String(), Charm: charm,
+		Name: "wordpress", Charm: charm,
 		Series: "quantal",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1619,7 +1583,7 @@ func (s *StateSuite) TestAddServiceOSIncompatibleWithSupportedSeries(c *gc.C) {
 	// A charm with supported series can only be force-deployed to series
 	// of the same operating systems as the suppoted series.
 	_, err := s.State.AddApplication(state.AddApplicationArgs{
-		Name: "wordpress", Owner: s.Owner.String(), Charm: charm,
+		Name: "wordpress", Charm: charm,
 		Series: "centos7",
 	})
 	c.Assert(err, gc.ErrorMatches, `cannot add application "wordpress": series "centos7" \(OS "CentOS"\) not supported by charm, supported series are "precise, trusty"`)
@@ -1632,13 +1596,13 @@ func (s *StateSuite) TestAllApplications(c *gc.C) {
 	c.Assert(len(services), gc.Equals, 0)
 
 	// Check that after adding services the result is ok.
-	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "wordpress", Owner: s.Owner.String(), Charm: charm})
+	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "wordpress", Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 	services, err = s.State.AllApplications()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(services), gc.Equals, 1)
 
-	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "mysql", Owner: s.Owner.String(), Charm: charm})
+	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "mysql", Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 	services, err = s.State.AllApplications()
 	c.Assert(err, jc.ErrorIsNil)
@@ -3130,7 +3094,7 @@ func (s *StateSuite) TestSetEnvironAgentVersionErrors(c *gc.C) {
 	// Add a service and 4 units: one with a different version, one
 	// with an empty version, one with the current version, and one
 	// with the new version.
-	service, err := s.State.AddApplication(state.AddApplicationArgs{Name: "wordpress", Owner: s.Owner.String(), Charm: s.AddTestingCharm(c, "wordpress")})
+	service, err := s.State.AddApplication(state.AddApplicationArgs{Name: "wordpress", Charm: s.AddTestingCharm(c, "wordpress")})
 	c.Assert(err, jc.ErrorIsNil)
 	unit0, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
@@ -3180,7 +3144,7 @@ func (s *StateSuite) prepareAgentVersionTests(c *gc.C, st *state.State) (*config
 	// Add a machine and a unit with the current version.
 	machine, err := st.AddMachine("series", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	service, err := st.AddApplication(state.AddApplicationArgs{Name: "wordpress", Owner: s.Owner.String(), Charm: s.AddTestingCharm(c, "wordpress")})
+	service, err := st.AddApplication(state.AddApplicationArgs{Name: "wordpress", Charm: s.AddTestingCharm(c, "wordpress")})
 	c.Assert(err, jc.ErrorIsNil)
 	unit, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -30,7 +30,7 @@ func (s *storageAddSuite) setupMultipleStoragesForAdd(c *gc.C) *state.Unit {
 		"multi1to10": makeStorageCons("loop", 0, 3),
 	}
 	charm := s.AddTestingCharm(c, "storage-block2")
-	service, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Owner: "user-test-admin@local", Charm: charm, Storage: storageCons})
+	service, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Charm: charm, Storage: storageCons})
 	c.Assert(err, jc.ErrorIsNil)
 	u, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -369,7 +369,7 @@ func makeStorageCons(pool string, size, count uint64) state.StorageConstraints {
 
 func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block")
-	storageBlock, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block", Owner: "user-test-admin@local", Charm: ch})
+	storageBlock, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block", Charm: ch})
 	c.Assert(err, jc.ErrorIsNil)
 	constraints, err := storageBlock.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -387,7 +387,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
 	})
 
 	ch = s.AddTestingCharm(c, "storage-filesystem")
-	storageFilesystem, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-filesystem", Owner: "user-test-admin@local", Charm: ch})
+	storageFilesystem, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-filesystem", Charm: ch})
 	c.Assert(err, jc.ErrorIsNil)
 	constraints, err = storageFilesystem.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -403,7 +403,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
 func (s *StorageStateSuite) TestAddServiceStorageConstraintsValidation(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block2")
 	addService := func(storage map[string]state.StorageConstraints) (*state.Application, error) {
-		return s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Owner: "user-test-admin@local", Charm: ch, Storage: storage})
+		return s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Charm: ch, Storage: storage})
 	}
 	assertErr := func(storage map[string]state.StorageConstraints, expect string) {
 		_, err := addService(storage)
@@ -435,7 +435,7 @@ func (s *StorageStateSuite) assertAddServiceStorageConstraintsDefaults(c *gc.C, 
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	ch := s.AddTestingCharm(c, "storage-block")
-	service, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Owner: "user-test-admin@local", Charm: ch, Storage: cons})
+	service, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Charm: ch, Storage: cons})
 	c.Assert(err, jc.ErrorIsNil)
 	savedCons, err := service.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -507,7 +507,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSizeFromCharm
 		"multi2up":   makeStorageCons("loop", 2048, 2),
 	}
 	ch := s.AddTestingCharm(c, "storage-block2")
-	service, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Owner: "user-test-admin@local", Charm: ch, Storage: storageCons})
+	service, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Charm: ch, Storage: storageCons})
 	c.Assert(err, jc.ErrorIsNil)
 	savedCons, err := service.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -517,7 +517,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSizeFromCharm
 func (s *StorageStateSuite) TestProviderFallbackToType(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block")
 	addService := func(storage map[string]state.StorageConstraints) (*state.Application, error) {
-		return s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block", Owner: "user-test-admin@local", Charm: ch, Storage: storage})
+		return s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block", Charm: ch, Storage: storage})
 	}
 	storageCons := map[string]state.StorageConstraints{
 		"data": makeStorageCons("loop", 1024, 1),

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -60,8 +60,7 @@ type subnetDoc struct {
 	VLANTag           int    `bson:"vlantag,omitempty"`
 	AvailabilityZone  string `bson:"availabilityzone,omitempty"`
 	IsPublic          bool   `bson:"is-public,omitempty"`
-	// TODO(dooferlad 2015-08-03): add an upgrade step to insert IsPublic=false
-	SpaceName string `bson:"space-name,omitempty"`
+	SpaceName         string `bson:"space-name,omitempty"`
 }
 
 // Life returns whether the subnet is Alive, Dying or Dead.

--- a/state/unit.go
+++ b/state/unit.go
@@ -91,12 +91,6 @@ type unitDoc struct {
 	Life                   Life
 	TxnRevno               int64 `bson:"txn-revno"`
 	PasswordHash           string
-
-	// TODO(mue) No longer actively used, only in upgrades.go.
-	// To be removed later.
-	Ports          []port `bson:"ports"`
-	PublicAddress  string `bson:"publicaddress"`
-	PrivateAddress string `bson:"privateaddress"`
 }
 
 // Unit represents the state of a service unit.

--- a/state/unit_assignment_test.go
+++ b/state/unit_assignment_test.go
@@ -21,8 +21,7 @@ var _ = gc.Suite(&UnitAssignmentSuite{})
 func (s *UnitAssignmentSuite) testAddServiceUnitAssignment(c *gc.C) (*state.Application, []state.UnitAssignment) {
 	charm := s.AddTestingCharm(c, "dummy")
 	svc, err := s.State.AddApplication(state.AddApplicationArgs{
-		Name: "dummy", Owner: s.Owner.String(),
-		Charm: charm, NumUnits: 2,
+		Name: "dummy", Charm: charm, NumUnits: 2,
 		Placement: []*instance.Placement{{s.State.ModelUUID(), "abc"}},
 	})
 	units, err := svc.AllUnits()

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -490,14 +490,14 @@ func (s *upgradesSuite) setupAddDefaultEndpointBindingsToServices(c *gc.C) []*Ap
 		"server": "db",
 	}
 	services := []*Application{
-		AddTestingService(c, s.state, "wp-no-bindings", charms[0], ownerTag),
-		AddTestingService(c, s.state, "ms-no-bindings", charms[1], ownerTag),
+		AddTestingService(c, s.state, "wp-no-bindings", charms[0]),
+		AddTestingService(c, s.state, "ms-no-bindings", charms[1]),
 
-		AddTestingService(c, s.state, "wp-default-bindings", charms[0], ownerTag),
-		AddTestingService(c, s.state, "ms-default-bindings", charms[1], ownerTag),
+		AddTestingService(c, s.state, "wp-default-bindings", charms[0]),
+		AddTestingService(c, s.state, "ms-default-bindings", charms[1]),
 
-		AddTestingServiceWithBindings(c, s.state, "wp-given-bindings", charms[0], ownerTag, wpBindings),
-		AddTestingServiceWithBindings(c, s.state, "ms-given-bindings", charms[1], ownerTag, msBindings),
+		AddTestingServiceWithBindings(c, s.state, "wp-given-bindings", charms[0], wpBindings),
+		AddTestingServiceWithBindings(c, s.state, "ms-given-bindings", charms[1], msBindings),
 	}
 
 	// Drop the added endpoint bindings doc directly for the first two services.

--- a/state/user.go
+++ b/state/user.go
@@ -240,11 +240,6 @@ func (u *User) Tag() names.Tag {
 // UserTag returns the Tag for the User.
 func (u *User) UserTag() names.UserTag {
 	name := u.doc.Name
-	if name == "" {
-		// TODO(waigani) This is a hack for upgrades to 1.23. Once we are no
-		// longer tied to 1.23, we can confidently always use u.doc.Name.
-		name = u.doc.DocID
-	}
 	return names.NewLocalUserTag(name)
 }
 

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -83,7 +83,7 @@ func (s *VolumeStateSuite) TestAddServiceInvalidPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("invalid-pool", 1024, 1),
 	}
-	_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block", Owner: s.Owner.String(), Charm: ch, Storage: storage})
+	_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block", Charm: ch, Storage: storage})
 	c.Assert(err, gc.ErrorMatches, `.* pool "invalid-pool" not found`)
 }
 
@@ -92,7 +92,7 @@ func (s *VolumeStateSuite) TestAddServiceNoUserDefaultPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 1024, 1),
 	}
-	service, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block", Owner: s.Owner.String(), Charm: ch, Storage: storage})
+	service, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block", Charm: ch, Storage: storage})
 	c.Assert(err, jc.ErrorIsNil)
 	cons, err := service.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -89,7 +89,6 @@ type MachineParams struct {
 type ApplicationParams struct {
 	Name        string
 	Charm       *state.Charm
-	Creator     names.Tag
 	Status      *status.StatusInfo
 	Settings    map[string]interface{}
 	Constraints constraints.Value
@@ -389,14 +388,8 @@ func (factory *Factory) MakeApplication(c *gc.C, params *ApplicationParams) *sta
 	if params.Name == "" {
 		params.Name = params.Charm.Meta().Name
 	}
-	if params.Creator == nil {
-		creator := factory.MakeUser(c, nil)
-		params.Creator = creator.Tag()
-	}
-	_ = params.Creator.(names.UserTag)
 	application, err := factory.st.AddApplication(state.AddApplicationArgs{
 		Name:        params.Name,
-		Owner:       params.Creator.String(),
 		Charm:       params.Charm,
 		Settings:    charm.Settings(params.Settings),
 		Constraints: params.Constraints,

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -346,15 +346,12 @@ func (s *factorySuite) TestMakeApplicationNil(c *gc.C) {
 
 func (s *factorySuite) TestMakeApplication(c *gc.C) {
 	charm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "wordpress"})
-	creator := s.Factory.MakeUser(c, &factory.UserParams{Name: "bill"}).Tag()
 	application := s.Factory.MakeApplication(c, &factory.ApplicationParams{
-		Charm:   charm,
-		Creator: creator,
+		Charm: charm,
 	})
 	c.Assert(application, gc.NotNil)
 
 	c.Assert(application.Name(), gc.Equals, "wordpress")
-	c.Assert(application.GetOwnerTag(), gc.Equals, creator.String())
 	curl, _ := application.CharmURL()
 	c.Assert(curl, gc.DeepEquals, charm.URL())
 
@@ -364,20 +361,6 @@ func (s *factorySuite) TestMakeApplication(c *gc.C) {
 	c.Assert(saved.Name(), gc.Equals, application.Name())
 	c.Assert(saved.Tag(), gc.Equals, application.Tag())
 	c.Assert(saved.Life(), gc.Equals, application.Life())
-}
-
-func (s *factorySuite) TestMakeApplicationInvalidCreator(c *gc.C) {
-	applicationName := "mysql"
-	invalidFunc := func() {
-		s.Factory.MakeApplication(c, &factory.ApplicationParams{
-			Name:    applicationName,
-			Creator: names.NewMachineTag("0"),
-		})
-	}
-	c.Assert(invalidFunc, gc.PanicMatches, `interface conversion: .*`)
-	saved, err := s.State.Application(applicationName)
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Assert(saved, gc.IsNil)
 }
 
 func (s *factorySuite) TestMakeUnitNil(c *gc.C) {


### PR DESCRIPTION
Removed the Owner from Applications, and the functions that add them in tests.
Removed old fields from the Unit document.
Removed old fallback code to load machines.

(Review request: http://reviews.vapour.ws/r/5043/)