### PR TITLE
all: store cloud/credentials in state

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -12,9 +12,8 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/controller/modelmanager"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
@@ -24,27 +23,17 @@ import (
 
 var logger = loggo.GetLogger("juju.agent.agentbootstrap")
 
-// BootstrapMachineConfig holds configuration information
-// to attach to the bootstrap machine.
-type BootstrapMachineConfig struct {
-	// Addresses holds the bootstrap machine's addresses.
-	Addresses []network.Address
+// InitializeStateParams holds parameters used for initializing the state
+// database.
+type InitializeStateParams struct {
+	instancecfg.StateInitializationParams
 
-	// BootstrapConstraints holds the bootstrap machine's constraints.
-	BootstrapConstraints constraints.Value
+	// BootstrapMachineAddresses holds the bootstrap machine's addresses.
+	BootstrapMachineAddresses []network.Address
 
-	// ModelConstraints holds the model-level constraints.
-	ModelConstraints constraints.Value
-
-	// Jobs holds the jobs that the machine agent will run.
-	Jobs []multiwatcher.MachineJob
-
-	// InstanceId holds the instance id of the bootstrap machine.
-	InstanceId instance.Id
-
-	// Characteristics holds hardware information on the
-	// bootstrap machine.
-	Characteristics instance.HardwareCharacteristics
+	// BootstrapMachineJobs holds the jobs that the bootstrap machine
+	// agent will run.
+	BootstrapMachineJobs []multiwatcher.MachineJob
 
 	// SharedSecret is the Mongo replica set shared secret (keyfile).
 	SharedSecret string
@@ -66,12 +55,7 @@ type BootstrapMachineConfig struct {
 func InitializeState(
 	adminUser names.UserTag,
 	c agent.ConfigSetter,
-	cfg *config.Config,
-	cloudName string,
-	cloudRegion string,
-	cloudConfigAttrs map[string]interface{},
-	hostedModelConfigAttrs map[string]interface{},
-	machineCfg BootstrapMachineConfig,
+	args InitializeStateParams,
 	dialOpts mongo.DialOpts,
 	policy state.Policy,
 ) (_ *state.State, _ *state.Machine, resultErr error) {
@@ -96,7 +80,20 @@ func InitializeState(
 	}
 
 	logger.Debugf("initializing address %v", info.Addrs)
-	st, err := state.Initialize(adminUser, info, cloudName, cloudRegion, cloudConfigAttrs, cfg, dialOpts, policy)
+	st, err := state.Initialize(state.InitializeParams{
+		ControllerModelArgs: state.ModelArgs{
+			Owner:       adminUser,
+			Config:      args.ControllerModelConfig,
+			CloudRegion: args.ControllerCloudRegion,
+			Constraints: args.ModelConstraints,
+		},
+		CloudName:           args.ControllerCloudName,
+		Cloud:               args.ControllerCloud,
+		ModelConfigDefaults: args.ModelConfigDefaults,
+		MongoInfo:           info,
+		MongoDialOpts:       dialOpts,
+		Policy:              policy,
+	})
 	if err != nil {
 		return nil, nil, errors.Errorf("failed to initialize state: %v", err)
 	}
@@ -106,45 +103,45 @@ func InitializeState(
 			st.Close()
 		}
 	}()
-	servingInfo.SharedSecret = machineCfg.SharedSecret
+	servingInfo.SharedSecret = args.SharedSecret
 	c.SetStateServingInfo(servingInfo)
 
 	// Filter out any LXC bridge addresses from the machine addresses.
-	machineCfg.Addresses = network.FilterLXCAddresses(machineCfg.Addresses)
+	args.BootstrapMachineAddresses = network.FilterLXCAddresses(args.BootstrapMachineAddresses)
 
-	if err = initAPIHostPorts(c, st, machineCfg.Addresses, servingInfo.APIPort); err != nil {
+	if err = initAPIHostPorts(c, st, args.BootstrapMachineAddresses, servingInfo.APIPort); err != nil {
 		return nil, nil, err
 	}
 	ssi := paramsStateServingInfoToStateStateServingInfo(servingInfo)
 	if err := st.SetStateServingInfo(ssi); err != nil {
 		return nil, nil, errors.Errorf("cannot set state serving info: %v", err)
 	}
-	m, err := initConstraintsAndBootstrapMachine(c, st, machineCfg)
+	m, err := initBootstrapMachine(c, st, args)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Annotate(err, "cannot initialize bootstrap machine")
 	}
 
 	// Create the initial hosted model, with the model config passed to
 	// bootstrap, which contains the UUID, name for the hosted model,
 	// and any user supplied config.
 	attrs := make(map[string]interface{})
-	for k, v := range hostedModelConfigAttrs {
+	for k, v := range args.HostedModelConfig {
 		attrs[k] = v
 	}
-	hostedModelConfig, err := modelmanager.ModelConfigCreator{}.NewModelConfig(modelmanager.IsAdmin, cfg, attrs)
+	hostedModelConfig, err := modelmanager.ModelConfigCreator{}.NewModelConfig(
+		modelmanager.IsAdmin, args.ControllerModelConfig, attrs,
+	)
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "creating hosted model config")
 	}
 	_, hostedModelState, err := st.NewModel(state.ModelArgs{
-		CloudRegion: cloudRegion,
-		Config:      hostedModelConfig,
 		Owner:       adminUser,
+		Config:      hostedModelConfig,
+		CloudRegion: args.ControllerCloudRegion,
+		Constraints: args.ModelConstraints,
 	})
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "creating hosted model")
-	}
-	if err := hostedModelState.SetModelConstraints(machineCfg.ModelConstraints); err != nil {
-		return nil, nil, errors.Annotate(err, "cannot set initial hosted model constraints")
 	}
 	hostedModelState.Close()
 
@@ -163,17 +160,6 @@ func paramsStateServingInfoToStateStateServingInfo(i params.StateServingInfo) st
 	}
 }
 
-func initConstraintsAndBootstrapMachine(c agent.ConfigSetter, st *state.State, cfg BootstrapMachineConfig) (*state.Machine, error) {
-	if err := st.SetModelConstraints(cfg.ModelConstraints); err != nil {
-		return nil, errors.Annotate(err, "cannot set initial model constraints")
-	}
-	m, err := initBootstrapMachine(c, st, cfg)
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot initialize bootstrap machine")
-	}
-	return m, nil
-}
-
 // initMongoAdminUser adds the admin user with the specified
 // password to the admin database in Mongo.
 func initMongoAdminUser(info mongo.Info, dialOpts mongo.DialOpts, password string) error {
@@ -186,24 +172,28 @@ func initMongoAdminUser(info mongo.Info, dialOpts mongo.DialOpts, password strin
 }
 
 // initBootstrapMachine initializes the initial bootstrap machine in state.
-func initBootstrapMachine(c agent.ConfigSetter, st *state.State, cfg BootstrapMachineConfig) (*state.Machine, error) {
-	logger.Infof("initialising bootstrap machine with config: %+v", cfg)
+func initBootstrapMachine(c agent.ConfigSetter, st *state.State, args InitializeStateParams) (*state.Machine, error) {
+	logger.Infof("initialising bootstrap machine with config: %+v", args)
 
-	jobs := make([]state.MachineJob, len(cfg.Jobs))
-	for i, job := range cfg.Jobs {
+	jobs := make([]state.MachineJob, len(args.BootstrapMachineJobs))
+	for i, job := range args.BootstrapMachineJobs {
 		machineJob, err := machineJobFromParams(job)
 		if err != nil {
 			return nil, errors.Errorf("invalid bootstrap machine job %q: %v", job, err)
 		}
 		jobs[i] = machineJob
 	}
+	var hardware instance.HardwareCharacteristics
+	if args.BootstrapMachineHardwareCharacteristics != nil {
+		hardware = *args.BootstrapMachineHardwareCharacteristics
+	}
 	m, err := st.AddOneMachine(state.MachineTemplate{
-		Addresses:               cfg.Addresses,
+		Addresses:               args.BootstrapMachineAddresses,
 		Series:                  series.HostSeries(),
 		Nonce:                   agent.BootstrapNonce,
-		Constraints:             cfg.BootstrapConstraints,
-		InstanceId:              cfg.InstanceId,
-		HardwareCharacteristics: cfg.Characteristics,
+		Constraints:             args.BootstrapMachineConstraints,
+		InstanceId:              args.BootstrapMachineInstanceId,
+		HardwareCharacteristics: hardware,
 		Jobs: jobs,
 	})
 	if err != nil {

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/agentbootstrap"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs"
@@ -109,15 +111,6 @@ LXC_BRIDGE="ignored"`[1:])
 		"10.0.3.4", // lxc bridge address filtered (-"-).
 		"10.0.3.3", // not a lxc bridge address
 	)
-	mcfg := agentbootstrap.BootstrapMachineConfig{
-		Addresses:            initialAddrs,
-		BootstrapConstraints: expectBootstrapConstraints,
-		ModelConstraints:     expectModelConstraints,
-		Jobs:                 []multiwatcher.MachineJob{multiwatcher.JobManageModel},
-		InstanceId:           "i-bootstrap",
-		Characteristics:      expectHW,
-		SharedSecret:         "abc123",
-	}
 	filteredAddrs := network.NewAddresses(
 		"zeroonetwothree",
 		"0.1.2.3",
@@ -142,14 +135,31 @@ LXC_BRIDGE="ignored"`[1:])
 		"name": "hosted",
 		"uuid": hostedModelUUID,
 	}
-	cloudConfigAttrs := map[string]interface{}{
+	modelConfigDefaults := map[string]interface{}{
 		"apt-mirror": "http://mirror",
+	}
+
+	args := agentbootstrap.InitializeStateParams{
+		StateInitializationParams: instancecfg.StateInitializationParams{
+			BootstrapMachineConstraints:             expectBootstrapConstraints,
+			BootstrapMachineInstanceId:              "i-bootstrap",
+			BootstrapMachineHardwareCharacteristics: &expectHW,
+			ControllerCloud:                         cloud.Cloud{Type: "dummy"},
+			ControllerCloudName:                     "dummy",
+			ControllerCloudRegion:                   "some-region",
+			ControllerModelConfig:                   modelCfg,
+			ModelConstraints:                        expectModelConstraints,
+			ModelConfigDefaults:                     modelConfigDefaults,
+			HostedModelConfig:                       hostedModelConfigAttrs,
+		},
+		BootstrapMachineAddresses: initialAddrs,
+		BootstrapMachineJobs:      []multiwatcher.MachineJob{multiwatcher.JobManageModel},
+		SharedSecret:              "abc123",
 	}
 
 	adminUser := names.NewLocalUserTag("agent-admin")
 	st, m, err := agentbootstrap.InitializeState(
-		adminUser, cfg, modelCfg, "dummy", "some-region", cloudConfigAttrs, hostedModelConfigAttrs, mcfg,
-		mongotest.DialOpts(), environs.NewStatePolicy(),
+		adminUser, cfg, args, mongotest.DialOpts(), environs.NewStatePolicy(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
@@ -276,9 +286,10 @@ func (s *bootstrapSuite) TestInitializeStateWithStateServingInfoNotAvailable(c *
 	_, available := cfg.StateServingInfo()
 	c.Assert(available, jc.IsFalse)
 
+	args := agentbootstrap.InitializeStateParams{}
+
 	adminUser := names.NewLocalUserTag("agent-admin")
-	_, _, err = agentbootstrap.InitializeState(adminUser, cfg,
-		nil, "dummy", "some-region", nil, nil, agentbootstrap.BootstrapMachineConfig{}, mongotest.DialOpts(), environs.NewStatePolicy())
+	_, _, err = agentbootstrap.InitializeState(adminUser, cfg, args, mongotest.DialOpts(), environs.NewStatePolicy())
 	// InitializeState will fail attempting to get the api port information
 	c.Assert(err, gc.ErrorMatches, "state serving information not available")
 }
@@ -305,13 +316,6 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 		SharedSecret:   "baz",
 		SystemIdentity: "qux",
 	})
-	expectHW := instance.MustParseHardware("mem=2048M")
-	mcfg := agentbootstrap.BootstrapMachineConfig{
-		BootstrapConstraints: constraints.MustParse("mem=1024M"),
-		Jobs:                 []multiwatcher.MachineJob{multiwatcher.JobManageModel},
-		InstanceId:           "i-bootstrap",
-		Characteristics:      expectHW,
-	}
 	modelAttrs := dummy.SampleConfig().Delete("admin-secret").Merge(testing.Attrs{
 		"agent-version": jujuversion.Current.String(),
 	})
@@ -323,16 +327,29 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 		"uuid": utils.MustNewUUID().String(),
 	}
 
+	args := agentbootstrap.InitializeStateParams{
+		StateInitializationParams: instancecfg.StateInitializationParams{
+			BootstrapMachineInstanceId: "i-bootstrap",
+			ControllerCloud:            cloud.Cloud{Type: "dummy"},
+			ControllerCloudName:        "dummy",
+			ControllerCloudRegion:      "some-region",
+			ControllerModelConfig:      modelCfg,
+			HostedModelConfig:          hostedModelConfigAttrs,
+		},
+		BootstrapMachineJobs: []multiwatcher.MachineJob{multiwatcher.JobManageModel},
+		SharedSecret:         "abc123",
+	}
+
 	adminUser := names.NewLocalUserTag("agent-admin")
 	st, _, err := agentbootstrap.InitializeState(
-		adminUser, cfg, modelCfg, "dummy", "some-region", nil, hostedModelConfigAttrs, mcfg,
-		mongotest.DialOpts(), state.Policy(nil),
+		adminUser, cfg, args, mongotest.DialOpts(), state.Policy(nil),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	st.Close()
 
-	st, _, err = agentbootstrap.InitializeState(adminUser, cfg, modelCfg,
-		"dummy", "some-region", nil, nil, mcfg, mongotest.DialOpts(), environs.NewStatePolicy())
+	st, _, err = agentbootstrap.InitializeState(
+		adminUser, cfg, args, mongotest.DialOpts(), state.Policy(nil),
+	)
 	if err == nil {
 		st.Close()
 	}

--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -43,6 +43,9 @@ func (c Credential) AuthType() AuthType {
 }
 
 func copyStringMap(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
 	out := make(map[string]string)
 	for k, v := range in {
 		out[k] = v
@@ -344,6 +347,9 @@ func (c cloudCredentialValueChecker) Coerce(v interface{}, path []string) (inter
 	delete(mapv, "auth-type")
 	for k, v := range mapv {
 		attrs[k] = v.(string)
+	}
+	if len(attrs) == 0 {
+		attrs = nil
 	}
 	return Credential{authType: AuthType(authType), attributes: attrs}, nil
 }

--- a/cloudconfig/cloudinit/renderscript_test.go
+++ b/cloudconfig/cloudinit/renderscript_test.go
@@ -62,7 +62,7 @@ func (s *configureSuite) getCloudConfig(c *gc.C, controller bool, vers version.B
 			vers.Series, "",
 		)
 		c.Assert(err, jc.ErrorIsNil)
-		icfg.Bootstrap.InstanceId = "instance-id"
+		icfg.Bootstrap.BootstrapMachineInstanceId = "instance-id"
 		icfg.Bootstrap.HostedModelConfig = map[string]interface{}{
 			"name": "hosted-model",
 		}

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -24,6 +24,7 @@ import (
 	agenttools "github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
@@ -180,38 +181,49 @@ type BootstrapConfig struct {
 // This structure will be passed to the bootstrap agent. To do so, the
 // Marshal and Unmarshal methods must be used.
 type StateInitializationParams struct {
-	// InstanceId is the instance ID of the instance being initialised.
-	// This is required when bootstrapping, and ignored otherwise.
-	InstanceId instance.Id
-
-	// HardwareCharacteristics contains the harrdware characteristics of
-	// the instance being initialised. This optional, and is only used by
-	// the bootstrap agent during state initialisation.
-	HardwareCharacteristics *instance.HardwareCharacteristics
-
 	// ControllerModelConfig holds the initial controller model configuration.
 	ControllerModelConfig *config.Config
 
-	// ControllerCloud is the name of the cloud that Juju will be
+	// ControllerCloudName is the name of the cloud that Juju will be
 	// bootstrapped in.
-	ControllerCloud string
+	ControllerCloudName string
+
+	// ControllerCloud contains the properties of the cloud that Juju will
+	// be bootstrapped in.
+	ControllerCloud cloud.Cloud
 
 	// ControllerCloudRegion is the name of the cloud region that Juju will be
 	// bootstrapped in.
 	ControllerCloudRegion string
 
-	// CloudConfig is a set of config attributes to be shared by all
-	// models hosted by this controller on the same cloud.
-	CloudConfig map[string]interface{}
+	// ControllerCloudCredentialName is the name of the cloud credential that
+	// Juju will be bootstrapped with.
+	ControllerCloudCredentialName string
+
+	// ControllerCloudCredential contains the cloud credential that Juju will
+	// be bootstrapped with.
+	ControllerCloudCredential *cloud.Credential
+
+	// ModelConfigDefaults is a set of config attributes to be shared by all
+	// models managed by this controller.
+	ModelConfigDefaults map[string]interface{}
 
 	// HostedModelConfig is a set of config attributes to be overlaid
 	// on the controller model config (Config, above) to construct the
 	// initial hosted model config.
 	HostedModelConfig map[string]interface{}
 
+	// BootstrapMachineInstanceId is the instance ID of the bootstrap
+	// machine instance being initialized.
+	BootstrapMachineInstanceId instance.Id
+
 	// BootstrapMachineConstraints holds the constraints for the bootstrap
 	// machine.
 	BootstrapMachineConstraints constraints.Value
+
+	// BootstrapMachineHardwareCharacteristics contains the harrdware
+	// characteristics of the bootstrap machine instance being initialized.
+	BootstrapMachineHardwareCharacteristics *instance.HardwareCharacteristics
 
 	// ModelConstraints holds the initial model constraints.
 	ModelConstraints constraints.Value
@@ -223,16 +235,19 @@ type StateInitializationParams struct {
 }
 
 type stateInitializationParamsInternal struct {
-	InstanceId                  instance.Id                       `yaml:"instance-id"`
-	HardwareCharacteristics     *instance.HardwareCharacteristics `yaml:"hardware,omitempty"`
-	ControllerModelConfig       map[string]interface{}            `yaml:"controller-model-config"`
-	CloudConfig                 map[string]interface{}            `yaml:"cloud-config,omitempty"`
-	HostedModelConfig           map[string]interface{}            `yaml:"hosted-model-config,omitempty"`
-	BootstrapMachineConstraints constraints.Value                 `yaml:"bootstrap-machine-constraints"`
-	ModelConstraints            constraints.Value                 `yaml:"model-constraints"`
-	CustomImageMetadataJSON     string                            `yaml:"custom-image-metadata,omitempty"`
-	ControllerCloud             string                            `yaml:"controller-cloud"`
-	ControllerCloudRegion       string                            `yaml:"controller-cloud-region"`
+	ControllerModelConfig                   map[string]interface{}            `yaml:"controller-model-config"`
+	ModelConfigDefaults                     map[string]interface{}            `yaml:"model-config-defaults,omitempty"`
+	HostedModelConfig                       map[string]interface{}            `yaml:"hosted-model-config,omitempty"`
+	BootstrapMachineInstanceId              instance.Id                       `yaml:"bootstrap-machine-instance-id"`
+	BootstrapMachineConstraints             constraints.Value                 `yaml:"bootstrap-machine-constraints"`
+	BootstrapMachineHardwareCharacteristics *instance.HardwareCharacteristics `yaml:"bootstrap-machine-hardware,omitempty"`
+	ModelConstraints                        constraints.Value                 `yaml:"model-constraints"`
+	CustomImageMetadataJSON                 string                            `yaml:"custom-image-metadata,omitempty"`
+	ControllerCloudName                     string                            `yaml:"controller-cloud-name"`
+	ControllerCloud                         string                            `yaml:"controller-cloud"`
+	ControllerCloudRegion                   string                            `yaml:"controller-cloud-region"`
+	ControllerCloudCredentialName           string                            `yaml:"controller-cloud-credential-name,omitempty"`
+	ControllerCloudCredential               *cloud.Credential                 `yaml:"controller-cloud-credential,omitempty"`
 }
 
 // Marshal marshals StateInitializationParams to an opaque byte array.
@@ -241,17 +256,24 @@ func (p *StateInitializationParams) Marshal() ([]byte, error) {
 	if err != nil {
 		return nil, errors.Annotate(err, "marshalling custom image metadata")
 	}
+	controllerCloud, err := cloud.MarshalCloud(p.ControllerCloud)
+	if err != nil {
+		return nil, errors.Annotate(err, "marshalling cloud definition")
+	}
 	internal := stateInitializationParamsInternal{
-		p.InstanceId,
-		p.HardwareCharacteristics,
 		p.ControllerModelConfig.AllAttrs(),
-		p.CloudConfig,
+		p.ModelConfigDefaults,
 		p.HostedModelConfig,
+		p.BootstrapMachineInstanceId,
 		p.BootstrapMachineConstraints,
+		p.BootstrapMachineHardwareCharacteristics,
 		p.ModelConstraints,
 		string(customImageMetadataJSON),
-		p.ControllerCloud,
+		p.ControllerCloudName,
+		string(controllerCloud),
 		p.ControllerCloudRegion,
+		p.ControllerCloudCredentialName,
+		p.ControllerCloudCredential,
 	}
 	return yaml.Marshal(&internal)
 }
@@ -271,17 +293,24 @@ func (p *StateInitializationParams) Unmarshal(data []byte) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	controllerCloud, err := cloud.UnmarshalCloud([]byte(internal.ControllerCloud))
+	if err != nil {
+		return errors.Trace(err)
+	}
 	*p = StateInitializationParams{
-		InstanceId:                  internal.InstanceId,
-		HardwareCharacteristics:     internal.HardwareCharacteristics,
-		ControllerModelConfig:       cfg,
-		CloudConfig:                 internal.CloudConfig,
-		HostedModelConfig:           internal.HostedModelConfig,
-		BootstrapMachineConstraints: internal.BootstrapMachineConstraints,
-		ModelConstraints:            internal.ModelConstraints,
-		CustomImageMetadata:         imageMetadata,
-		ControllerCloud:             internal.ControllerCloud,
-		ControllerCloudRegion:       internal.ControllerCloudRegion,
+		ControllerModelConfig:                   cfg,
+		ModelConfigDefaults:                     internal.ModelConfigDefaults,
+		HostedModelConfig:                       internal.HostedModelConfig,
+		BootstrapMachineInstanceId:              internal.BootstrapMachineInstanceId,
+		BootstrapMachineConstraints:             internal.BootstrapMachineConstraints,
+		BootstrapMachineHardwareCharacteristics: internal.BootstrapMachineHardwareCharacteristics,
+		ModelConstraints:                        internal.ModelConstraints,
+		CustomImageMetadata:                     imageMetadata,
+		ControllerCloudName:                     internal.ControllerCloudName,
+		ControllerCloud:                         controllerCloud,
+		ControllerCloudRegion:                   internal.ControllerCloudRegion,
+		ControllerCloudCredentialName:           internal.ControllerCloudCredentialName,
+		ControllerCloudCredential:               internal.ControllerCloudCredential,
 	}
 	return nil
 }
@@ -559,8 +588,8 @@ func (cfg *BootstrapConfig) VerifyConfig() (err error) {
 	if cfg.StateServingInfo.APIPort == 0 {
 		return errors.New("missing API port")
 	}
-	if cfg.InstanceId == "" {
-		return errors.New("missing instance-id")
+	if cfg.BootstrapMachineInstanceId == "" {
+		return errors.New("missing bootstrap machine instance ID")
 	}
 	if len(cfg.HostedModelConfig) == 0 {
 		return errors.New("missing hosted model config")

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -227,7 +227,7 @@ func (cfg *testInstanceConfig) setController() *testInstanceConfig {
 	}
 	cfg.Bootstrap = &instancecfg.BootstrapConfig{
 		StateInitializationParams: instancecfg.StateInitializationParams{
-			InstanceId:                  "i-bootstrap",
+			BootstrapMachineInstanceId:  "i-bootstrap",
 			BootstrapMachineConstraints: bootstrapConstraints,
 			ModelConstraints:            envConstraints,
 		},
@@ -1014,8 +1014,8 @@ var verifyTests = []struct {
 	{"missing machine agent service name", func(cfg *instancecfg.InstanceConfig) {
 		cfg.MachineAgentServiceName = ""
 	}},
-	{"invalid bootstrap configuration: missing instance-id", func(cfg *instancecfg.InstanceConfig) {
-		cfg.Bootstrap.InstanceId = ""
+	{"invalid bootstrap configuration: missing bootstrap machine instance ID", func(cfg *instancecfg.InstanceConfig) {
+		cfg.Bootstrap.BootstrapMachineInstanceId = ""
 	}},
 }
 
@@ -1030,9 +1030,9 @@ func (*cloudinitSuite) TestCloudInitVerify(c *gc.C) {
 		return instancecfg.InstanceConfig{
 			Bootstrap: &instancecfg.BootstrapConfig{
 				StateInitializationParams: instancecfg.StateInitializationParams{
-					InstanceId:            "i-bootstrap",
-					ControllerModelConfig: minimalModelConfig(c),
-					HostedModelConfig:     map[string]interface{}{"name": "hosted-model"},
+					BootstrapMachineInstanceId: "i-bootstrap",
+					ControllerModelConfig:      minimalModelConfig(c),
+					HostedModelConfig:          map[string]interface{}{"name": "hosted-model"},
 				},
 				StateServingInfo: stateServingInfo,
 			},

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -559,9 +559,12 @@ to clean up the model.`[1:])
 		BuildToolsTarball:    sync.BuildToolsTarball,
 		AgentVersion:         c.AgentVersion,
 		MetadataDir:          metadataDir,
-		Cloud:                c.Cloud,
+		Cloud:                *cloud,
+		CloudName:            c.Cloud,
 		CloudRegion:          region.Name,
-		CloudConfig:          sharedAttrs,
+		CloudCredential:      credential,
+		CloudCredentialName:  credentialName,
+		ModelConfigDefaults:  sharedAttrs,
 		HostedModelConfig:    hostedModelConfig,
 		GUIDataSourceBaseURL: guiDataSourceBaseURL,
 	})
@@ -605,6 +608,7 @@ func getRegion(cloud *jujucloud.Cloud, cloudName, regionName string) (jujucloud.
 			cloud.Endpoint,
 			cloud.StorageEndpoint,
 		}
+		cloud.Regions = []jujucloud.Region{region}
 		return region, nil
 	}
 	if regionName == "" {

--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -37,6 +37,7 @@ type Model interface {
 	HasConstraints
 
 	CloudRegion() string
+	CloudCredential() string
 	Tag() names.ModelTag
 	Owner() names.UserTag
 	Config() map[string]interface{}

--- a/core/description/model.go
+++ b/core/description/model.go
@@ -22,6 +22,7 @@ type ModelArgs struct {
 	LatestToolsVersion version.Number
 	Blocks             map[string]string
 	CloudRegion        string
+	CloudCredential    string
 }
 
 // NewModel returns a Model based on the args specified.
@@ -34,6 +35,7 @@ func NewModel(args ModelArgs) Model {
 		Sequences_:          make(map[string]int),
 		Blocks_:             args.Blocks,
 		CloudRegion_:        args.CloudRegion,
+		CloudCredential_:    args.CloudCredential,
 	}
 	m.setUsers(nil)
 	m.setMachines(nil)
@@ -85,7 +87,8 @@ type model struct {
 
 	Constraints_ *constraints `yaml:"constraints,omitempty"`
 
-	CloudRegion_ string `yaml:"cloud-region"`
+	CloudRegion_     string `yaml:"cloud-region,omitempty"`
+	CloudCredential_ string `yaml:"cloud-credential,omitempty"`
 
 	// TODO:
 	// Spaces
@@ -266,6 +269,11 @@ func (m *model) CloudRegion() string {
 	return m.CloudRegion_
 }
 
+// CloudCredential implements Model.
+func (m *model) CloudCredential() string {
+	return m.CloudCredential_
+}
+
 // Validate implements Model.
 func (m *model) Validate() error {
 	// A model needs an owner.
@@ -381,12 +389,11 @@ func importModelV1(source map[string]interface{}) (*model, error) {
 	// contains fields of the right type.
 
 	result := &model{
-		Version:      1,
-		Owner_:       valid["owner"].(string),
-		Config_:      valid["config"].(map[string]interface{}),
-		Sequences_:   make(map[string]int),
-		Blocks_:      convertToStringMap(valid["blocks"]),
-		CloudRegion_: valid["cloud-region"].(string),
+		Version:    1,
+		Owner_:     valid["owner"].(string),
+		Config_:    valid["config"].(map[string]interface{}),
+		Sequences_: make(map[string]int),
+		Blocks_:    convertToStringMap(valid["blocks"]),
 	}
 	result.importAnnotations(valid)
 	sequences := valid["sequences"].(map[string]interface{})
@@ -412,6 +419,10 @@ func importModelV1(source map[string]interface{}) (*model, error) {
 
 	if region, ok := valid["cloud-region"]; ok {
 		result.CloudRegion_ = region.(string)
+	}
+
+	if credential, ok := valid["cloud-credential"]; ok {
+		result.CloudCredential_ = credential.(string)
 	}
 
 	userMap := valid["users"].(map[string]interface{})

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/utils/ssh"
 	"github.com/juju/version"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/controller"
@@ -62,15 +63,29 @@ type BootstrapParams struct {
 	// initial bootstrap machine.
 	BootstrapImage string
 
-	// Cloud is the name of the cloud that Juju will be bootstrapped in.
-	Cloud string
+	// CloudName is the name of the cloud that Juju will be bootstrapped in.
+	CloudName string
 
-	// Cloud is the name of the cloud region that Juju will be bootstrapped in.
+	// Cloud contains the properties of the cloud that Juju will be
+	// bootstrapped in.
+	Cloud cloud.Cloud
+
+	// CloudRegion is the name of the cloud region that Juju will be bootstrapped in.
 	CloudRegion string
 
-	// CloudConfig is the set of config attributes to be shared
-	// across all models on the same cloud.
-	CloudConfig map[string]interface{}
+	// CloudCredentialName is the name of the cloud credential that Juju will be
+	// bootstrapped with. This may be empty, for clouds that do not require
+	// credentials.
+	CloudCredentialName string
+
+	// CloudCredential contains the cloud credential that Juju will be
+	// bootstrapped with. This may be nil, for clouds that do not require
+	// credentialis.
+	CloudCredential *cloud.Credential
+
+	// ModelConfigDefaults is the set of config attributes to be shared
+	// across all models in the same controller.
+	ModelConfigDefaults map[string]interface{}
 
 	// HostedModelConfig is the set of config attributes to be overlaid
 	// on the controller config to construct the initial hosted model
@@ -275,9 +290,10 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 		return errors.Trace(err)
 	}
 	instanceConfig.Bootstrap.CustomImageMetadata = customImageMetadata
+	instanceConfig.Bootstrap.ControllerCloudName = args.CloudName
 	instanceConfig.Bootstrap.ControllerCloud = args.Cloud
 	instanceConfig.Bootstrap.ControllerCloudRegion = args.CloudRegion
-	instanceConfig.Bootstrap.CloudConfig = args.CloudConfig
+	instanceConfig.Bootstrap.ModelConfigDefaults = args.ModelConfigDefaults
 	instanceConfig.Bootstrap.HostedModelConfig = args.HostedModelConfig
 	instanceConfig.Bootstrap.GUI = guiArchive(args.GUIDataSourceBaseURL, func(msg string) {
 		ctx.Infof(msg)

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -295,7 +295,8 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 
 	s.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	err = bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), environ, bootstrap.BootstrapParams{
-		Cloud:       "dummy",
+		CloudName:   "dummy",
+		Cloud:       cloud.Cloud{Type: "dummy"},
 		CloudRegion: "some-region",
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -151,8 +151,8 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 	fmt.Fprintf(ctx.GetStderr(), " - %s\n", result.Instance.Id())
 
 	finalize := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig) error {
-		icfg.Bootstrap.InstanceId = result.Instance.Id()
-		icfg.Bootstrap.HardwareCharacteristics = result.Hardware
+		icfg.Bootstrap.BootstrapMachineInstanceId = result.Instance.Id()
+		icfg.Bootstrap.BootstrapMachineHardwareCharacteristics = result.Hardware
 		envConfig := env.Config()
 		if result.Config != nil {
 			updated, err := envConfig.Apply(result.Config.UnknownAttrs())

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -724,9 +724,18 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 		// the password in the info structure is empty, so the admin
 		// user is constructed with an empty password here.
 		// It is set just below.
-		st, err := state.Initialize(
-			names.NewUserTag("admin@local"), info, "dummy", "some-region", nil, cfg,
-			mongotest.DialOpts(), estate.statePolicy)
+		st, err := state.Initialize(state.InitializeParams{
+			ControllerModelArgs: state.ModelArgs{
+				Owner:       names.NewUserTag("admin@local"),
+				CloudRegion: "some-region",
+				Config:      cfg,
+			},
+			CloudName:     "dummy",
+			Cloud:         cloud.Cloud{Type: "dummy"},
+			MongoInfo:     info,
+			MongoDialOpts: mongotest.DialOpts(),
+			Policy:        estate.statePolicy,
+		})
 		if err != nil {
 			panic(err)
 		}

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -105,8 +105,8 @@ func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 		return nil, err
 	}
 	finalize := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig) error {
-		icfg.Bootstrap.InstanceId = BootstrapInstanceId
-		icfg.Bootstrap.HardwareCharacteristics = &hc
+		icfg.Bootstrap.BootstrapMachineInstanceId = BootstrapInstanceId
+		icfg.Bootstrap.BootstrapMachineHardwareCharacteristics = &hc
 		if err := instancecfg.FinishInstanceConfig(icfg, e.Config()); err != nil {
 			return err
 		}

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -142,6 +142,14 @@ func allCollections() collectionSchema {
 		// different models at a time.
 		usermodelnameC: {global: true},
 
+		// This collection holds users' cloud credentials.
+		cloudCredentialsC: {
+			global: true,
+			indexes: []mgo.Index{{
+				Key: []string{"owner"},
+			}},
+		},
+
 		// This collection holds workload metrics reported by certain charms
 		// for passing onward to other tools.
 		metricsC: {global: true},
@@ -373,6 +381,7 @@ const (
 	charmsC                  = "charms"
 	cleanupsC                = "cleanups"
 	cloudimagemetadataC      = "cloudimagemetadata"
+	cloudCredentialsC        = "cloudCredentials"
 	constraintsC             = "constraints"
 	containerRefsC           = "containerRefs"
 	controllersC             = "controllers"

--- a/state/cloud.go
+++ b/state/cloud.go
@@ -1,0 +1,101 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/utils/set"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/cloud"
+)
+
+const controllerCloudKey = "controller"
+
+// cloudDoc records information about the cloud that the controller operates in.
+type cloudDoc struct {
+	DocID           string                       `bson:"_id"`
+	Name            string                       `bson:"name"`
+	Type            string                       `bson:"type"`
+	AuthTypes       []string                     `bson:"auth-types"`
+	Endpoint        string                       `bson:"endpoint"`
+	StorageEndpoint string                       `bson:"storage-endpoint,omitempty"`
+	Regions         map[string]cloudRegionSubdoc `bson:"regions,omitempty"`
+}
+
+// cloudRegionSubdoc records information about cloud regions.
+type cloudRegionSubdoc struct {
+	Endpoint        string `bson:"endpoint,omitempty"`
+	StorageEndpoint string `bson:"storage-endpoint,omitempty"`
+}
+
+// createCloudOp returns a list of txn.Ops that will initialize
+// the cloud definition for the controller.
+func createCloudOp(cloud cloud.Cloud, cloudName string) txn.Op {
+	authTypes := make([]string, len(cloud.AuthTypes))
+	for i, authType := range cloud.AuthTypes {
+		authTypes[i] = string(authType)
+	}
+	regions := make(map[string]cloudRegionSubdoc)
+	for _, region := range cloud.Regions {
+		regions[region.Name] = cloudRegionSubdoc{
+			region.Endpoint,
+			region.StorageEndpoint,
+		}
+	}
+	return txn.Op{
+		C:      controllersC,
+		Id:     controllerCloudKey,
+		Assert: txn.DocMissing,
+		Insert: &cloudDoc{
+			Name:            cloudName,
+			Type:            cloud.Type,
+			AuthTypes:       authTypes,
+			Endpoint:        cloud.Endpoint,
+			StorageEndpoint: cloud.StorageEndpoint,
+			Regions:         regions,
+		},
+	}
+}
+
+func (d cloudDoc) toCloud() cloud.Cloud {
+	authTypes := make([]cloud.AuthType, len(d.AuthTypes))
+	for i, authType := range d.AuthTypes {
+		authTypes[i] = cloud.AuthType(authType)
+	}
+	regionNames := make(set.Strings)
+	for name := range d.Regions {
+		regionNames.Add(name)
+	}
+	regions := make([]cloud.Region, len(d.Regions))
+	for i, name := range regionNames.SortedValues() {
+		region := d.Regions[name]
+		regions[i] = cloud.Region{
+			name,
+			region.Endpoint,
+			region.StorageEndpoint,
+		}
+	}
+	return cloud.Cloud{
+		d.Type,
+		authTypes,
+		d.Endpoint,
+		d.StorageEndpoint,
+		regions,
+		nil, // Config is not stored, only relevant to bootstrap
+	}
+}
+
+// Cloud returns the controller's cloud definition.
+func (st *State) Cloud() (cloud.Cloud, error) {
+	coll, cleanup := st.getCollection(controllersC)
+	defer cleanup()
+
+	var doc cloudDoc
+	err := coll.FindId(controllerCloudKey).One(&doc)
+	if err != nil {
+		return cloud.Cloud{}, errors.Annotatef(err, "cannot get cloud definition")
+	}
+	return doc.toCloud(), nil
+}

--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -1,0 +1,72 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/cloud"
+)
+
+// cloudCredentialDoc records information about a user's cloud credentials.
+type cloudCredentialDoc struct {
+	DocID      string            `bson:"_id"`
+	Owner      string            `bson:"owner"`
+	Name       string            `bson:"name"`
+	AuthType   string            `bson:"auth-type"`
+	Attributes map[string]string `bson:"attributes,omitempty"`
+}
+
+// initCloudCredentialsOps returns a list of txn.Ops that will initialize
+// a set of cloud credentials for a user.
+func initCloudCredentialsOps(user names.UserTag, credentials map[string]cloud.Credential) []txn.Op {
+	owner := user.Canonical()
+	ops := make([]txn.Op, 0, len(credentials))
+	for name, credential := range credentials {
+		ops = append(ops, txn.Op{
+			C:      cloudCredentialsC,
+			Id:     cloudCredentialDocID(user, name),
+			Assert: txn.DocMissing,
+			Insert: &cloudCredentialDoc{
+				Owner:      owner,
+				Name:       name,
+				AuthType:   string(credential.AuthType()),
+				Attributes: credential.Attributes(),
+			},
+		})
+	}
+	return ops
+}
+
+func cloudCredentialDocID(user names.UserTag, credentialName string) string {
+	return fmt.Sprintf("%s#%s", user.Canonical(), credentialName)
+}
+
+func (c cloudCredentialDoc) toCredential() cloud.Credential {
+	out := cloud.NewCredential(cloud.AuthType(c.AuthType), c.Attributes)
+	out.Label = c.Name
+	return out
+}
+
+// CloudCredentials returns the user's cloud credentials, keyed by cloud name.
+func (st *State) CloudCredentials(user names.UserTag) (map[string]cloud.Credential, error) {
+	coll, cleanup := st.getCollection(cloudCredentialsC)
+	defer cleanup()
+
+	var doc cloudCredentialDoc
+	credentials := make(map[string]cloud.Credential)
+	iter := coll.Find(bson.D{{"owner", user.Canonical()}}).Iter()
+	for iter.Next(&doc) {
+		credentials[doc.Name] = doc.toCredential()
+	}
+	if err := iter.Close(); err != nil {
+		return nil, errors.Annotatef(err, "cannot get cloud credentials for %q", user.Canonical())
+	}
+	return credentials, nil
+}

--- a/state/controller.go
+++ b/state/controller.go
@@ -56,8 +56,8 @@ func (st *State) ControllerConfig() (jujucontroller.Config, error) {
 	return settings.Map(), nil
 }
 
-// CloudConfig returns the config values shared across models.
-func (st *State) CloudConfig() (map[string]interface{}, error) {
+// ModelConfigDefaults returns the config values shared across models.
+func (st *State) ModelConfigDefaults() (map[string]interface{}, error) {
 	settings, err := readSettings(st, controllersC, defaultModelSettingsGlobalKey)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -9,6 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
@@ -66,7 +67,35 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	uuid := cfg.UUID()
 	initial := cfg.AllAttrs()
 	owner := names.NewLocalUserTag("initialize-admin")
-	st, err := state.Initialize(owner, statetesting.NewMongoInfo(), "dummy", "some-region", nil, cfg, mongotest.DialOpts(), nil)
+
+	userpassCredential := cloud.NewCredential(
+		cloud.UserPassAuthType,
+		map[string]string{
+			"username": "alice",
+			"password": "hunter2",
+		},
+	)
+	userpassCredential.Label = "some-credential"
+	emptyCredential := cloud.NewEmptyCredential()
+	emptyCredential.Label = "empty-credential"
+	cloudCredentialsIn := map[string]cloud.Credential{
+		userpassCredential.Label: userpassCredential,
+		emptyCredential.Label:    emptyCredential,
+	}
+
+	st, err := state.Initialize(state.InitializeParams{
+		ControllerModelArgs: state.ModelArgs{
+			Owner:           owner,
+			Config:          cfg,
+			CloudRegion:     "some-region",
+			CloudCredential: "some-credential",
+		},
+		CloudName:        "dummy",
+		Cloud:            cloud.Cloud{Type: "dummy"},
+		CloudCredentials: cloudCredentialsIn,
+		MongoInfo:        statetesting.NewMongoInfo(),
+		MongoDialOpts:    mongotest.DialOpts(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st, gc.NotNil)
 	modelTag := st.ModelTag()
@@ -111,17 +140,36 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	info, err := s.State.ControllerInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, &state.ControllerInfo{ModelTag: modelTag, CloudName: "dummy"})
+
+	// Check that the model's credential name is as
+	// expected, and the owner's cloud credentials
+	// are initialised.
+	c.Assert(model.CloudCredential(), gc.Equals, "some-credential")
+	cloudCredentials, err := s.State.CloudCredentials(model.Owner())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloudCredentials, jc.DeepEquals, cloudCredentialsIn)
 }
 
-func (s *InitializeSuite) TestInitializeWithCloudConfig(c *gc.C) {
+func (s *InitializeSuite) TestInitializeWithModelConfigDefaults(c *gc.C) {
 	cfg := testing.ModelConfig(c)
 	uuid := cfg.UUID()
 	initial := cfg.AllAttrs()
-	cloudAttrs := map[string]interface{}{
+	modelConfigDefaultsIn := map[string]interface{}{
 		"default-series": initial["default-series"],
 	}
 	owner := names.NewLocalUserTag("initialize-admin")
-	st, err := state.Initialize(owner, statetesting.NewMongoInfo(), "dummy", "some-region", cloudAttrs, cfg, mongotest.DialOpts(), nil)
+	st, err := state.Initialize(state.InitializeParams{
+		ControllerModelArgs: state.ModelArgs{
+			Owner:       owner,
+			CloudRegion: "some-region",
+			Config:      cfg,
+		},
+		CloudName:           "dummy",
+		Cloud:               cloud.Cloud{Type: "dummy"},
+		ModelConfigDefaults: modelConfigDefaultsIn,
+		MongoInfo:           statetesting.NewMongoInfo(),
+		MongoDialOpts:       mongotest.DialOpts(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st, gc.NotNil)
 	modelTag := st.ModelTag()
@@ -131,9 +179,9 @@ func (s *InitializeSuite) TestInitializeWithCloudConfig(c *gc.C) {
 
 	s.openState(c, modelTag)
 
-	cloudCfg, err := s.State.CloudConfig()
+	modelConfigDefaults, err := s.State.ModelConfigDefaults()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cloudCfg, jc.DeepEquals, cloudAttrs)
+	c.Assert(modelConfigDefaults, jc.DeepEquals, modelConfigDefaultsIn)
 
 	cfg, err = s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
@@ -147,12 +195,23 @@ func (s *InitializeSuite) TestDoubleInitializeConfig(c *gc.C) {
 
 	mgoInfo := statetesting.NewMongoInfo()
 	dialOpts := mongotest.DialOpts()
-	st, err := state.Initialize(owner, mgoInfo, "dummy", "some-region", nil, cfg, dialOpts, state.Policy(nil))
+	args := state.InitializeParams{
+		ControllerModelArgs: state.ModelArgs{
+			Owner:       owner,
+			CloudRegion: "some-region",
+			Config:      cfg,
+		},
+		CloudName:     "dummy",
+		Cloud:         cloud.Cloud{Type: "dummy"},
+		MongoInfo:     mgoInfo,
+		MongoDialOpts: dialOpts,
+	}
+	st, err := state.Initialize(args)
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.Close()
 	c.Check(err, jc.ErrorIsNil)
 
-	st, err = state.Initialize(owner, mgoInfo, "dummy", "some-region", nil, cfg, dialOpts, state.Policy(nil))
+	st, err = state.Initialize(args)
 	c.Check(err, gc.ErrorMatches, "already initialized")
 	if !c.Check(st, gc.IsNil) {
 		err = st.Close()
@@ -167,11 +226,24 @@ func (s *InitializeSuite) TestModelConfigWithAdminSecret(c *gc.C) {
 	bad, err := good.Apply(badUpdateAttrs)
 	owner := names.NewLocalUserTag("initialize-admin")
 
-	_, err = state.Initialize(owner, statetesting.NewMongoInfo(), "dummy", "some-region", nil, bad, mongotest.DialOpts(), state.Policy(nil))
+	args := state.InitializeParams{
+		ControllerModelArgs: state.ModelArgs{
+			Owner:       owner,
+			CloudRegion: "some-region",
+			Config:      bad,
+		},
+		CloudName:     "dummy",
+		Cloud:         cloud.Cloud{Type: "dummy"},
+		MongoInfo:     statetesting.NewMongoInfo(),
+		MongoDialOpts: mongotest.DialOpts(),
+	}
+	_, err = state.Initialize(args)
 	c.Assert(err, gc.ErrorMatches, "admin-secret should never be written to the state")
 
 	// admin-secret blocks UpdateModelConfig.
-	st := statetesting.Initialize(c, owner, good, nil)
+	args.ControllerModelArgs.Config = good
+	st, err := state.Initialize(args)
+	c.Assert(err, jc.ErrorIsNil)
 	st.Close()
 
 	s.openState(c, st.ModelTag())
@@ -195,11 +267,23 @@ func (s *InitializeSuite) TestModelConfigWithoutAgentVersion(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	owner := names.NewLocalUserTag("initialize-admin")
 
-	_, err = state.Initialize(owner, statetesting.NewMongoInfo(), "dummy", "some-region", nil, bad, mongotest.DialOpts(), state.Policy(nil))
+	args := state.InitializeParams{
+		ControllerModelArgs: state.ModelArgs{
+			Owner:       owner,
+			CloudRegion: "some-region",
+			Config:      bad,
+		},
+		CloudName:     "dummy",
+		Cloud:         cloud.Cloud{Type: "dummy"},
+		MongoInfo:     statetesting.NewMongoInfo(),
+		MongoDialOpts: mongotest.DialOpts(),
+	}
+	_, err = state.Initialize(args)
 	c.Assert(err, gc.ErrorMatches, "agent-version must always be set in state")
 
-	st := statetesting.Initialize(c, owner, good, nil)
-	// yay side effects
+	args.ControllerModelArgs.Config = good
+	st, err := state.Initialize(args)
+	c.Assert(err, jc.ErrorIsNil)
 	st.Close()
 
 	s.openState(c, st.ModelTag())
@@ -223,13 +307,23 @@ func (s *InitializeSuite) TestCloudConfigWithForbiddenValues(c *gc.C) {
 	for _, attr := range controller.ControllerOnlyConfigAttributes {
 		badAttrNames = append(badAttrNames, attr)
 	}
-	good := testing.ModelConfig(c)
+
+	args := state.InitializeParams{
+		ControllerModelArgs: state.ModelArgs{
+			Owner:       names.NewLocalUserTag("initialize-admin"),
+			CloudRegion: "some-region",
+			Config:      testing.ModelConfig(c),
+		},
+		CloudName:     "dummy",
+		Cloud:         cloud.Cloud{Type: "dummy"},
+		MongoInfo:     statetesting.NewMongoInfo(),
+		MongoDialOpts: mongotest.DialOpts(),
+	}
 
 	for _, badAttrName := range badAttrNames {
-		badCloudAttrs := map[string]interface{}{badAttrName: "foo"}
-		owner := names.NewLocalUserTag("initialize-admin")
-
-		_, err := state.Initialize(owner, statetesting.NewMongoInfo(), "dummy", "some-region", badCloudAttrs, good, mongotest.DialOpts(), state.Policy(nil))
-		c.Assert(err, gc.ErrorMatches, "cloud config cannot contain .*")
+		badAttrs := map[string]interface{}{badAttrName: "foo"}
+		args.ModelConfigDefaults = badAttrs
+		_, err := state.Initialize(args)
+		c.Assert(err, gc.ErrorMatches, "config defaults cannot contain .*")
 	}
 }

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -9,6 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/testing"
@@ -48,8 +49,17 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 			CACert: testing.CACert,
 		},
 	}
-	dialopts := mongotest.DialOpts()
-	st, err := Initialize(s.owner, info, "dummy", "some-region", nil, testing.ModelConfig(c), dialopts, nil)
+	st, err := Initialize(InitializeParams{
+		ControllerModelArgs: ModelArgs{
+			Owner:       s.owner,
+			CloudRegion: "some-region",
+			Config:      testing.ModelConfig(c),
+		},
+		CloudName:     "dummy",
+		Cloud:         cloud.Cloud{Type: "dummy"},
+		MongoInfo:     info,
+		MongoDialOpts: mongotest.DialOpts(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.state = st
 	s.AddCleanup(func(*gc.C) { s.state.Close() })

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -52,6 +52,9 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		cleanupsC,
 		// We don't export the controller model at this stage.
 		controllersC,
+		// Cloud credentials aren't migrated. They must exist in the
+		// target controller already.
+		cloudCredentialsC,
 		// This is controller global, and related to the system state of the
 		// embedded GUI.
 		guimetadataC,
@@ -182,6 +185,7 @@ func (s *MigrationSuite) TestModelDocFields(c *gc.C) {
 		"MigrationMode",
 		"Owner",
 		"CloudRegion",
+		"CloudCredential",
 		"LatestAvailableTools",
 	)
 	s.AssertExportedFields(c, modelDoc{}, fields)

--- a/state/model.go
+++ b/state/model.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/status"
@@ -60,8 +61,14 @@ type modelDoc struct {
 	ServerUUID    string        `bson:"server-uuid"`
 	MigrationMode MigrationMode `bson:"migration-mode"`
 
-	// CloudRegion is the name of the cloud region to which the model is deployed.
+	// CloudRegion is the name of the cloud region to which the model is
+	// deployed. This will be empty for clouds that do not support regions.
 	CloudRegion string `bson:"cloud-region,omitempty"`
+
+	// CloudCredential is the name of the cloud credential that is used
+	// for managing cloud resources for this model. This will be empty
+	// for clouds that do not require credentials.
+	CloudCredential string `bson:"cloud-credential,omitempty"`
 
 	// LatestAvailableTools is a string representing the newest version
 	// found while checking streams for new versions.
@@ -140,11 +147,20 @@ func (st *State) AllModels() ([]*Model, error) {
 
 // ModelArgs is a params struct for creating a new model.
 type ModelArgs struct {
-	// CloudRegion is the name of the cloud region to which the model is deployed.
+	// CloudRegion is the name of the cloud region to which the model is
+	// deployed. This will be empty for clouds that do not support regions.
 	CloudRegion string
+
+	// CloudCredential is the name of the cloud credential that will be
+	// used for managing cloud resources for this model. This will be empty
+	// for clouds that do not require credentials.
+	CloudCredential string
 
 	// Config is the model config.
 	Config *config.Config
+
+	// Constraints contains the initial constraints for the model.
+	Constraints constraints.Value
 
 	// Owner is the user that owns the model.
 	Owner names.UserTag
@@ -183,6 +199,14 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 		return nil, nil, errors.Trace(err)
 	}
 
+	// TODO(axw) check that args.CloudRegion exists in the cloud definition.
+	// If there is no CloudRegion specified, ensure that the cloud does not
+	// specify any regions.
+
+	// TODO(axw) check that args.CloudCredential refers to a valid credential
+	// for the model owner. If args.CloudCredential is empty, then make sure
+	// the cloud supports AuthTypeEmpty.
+
 	owner := args.Owner
 	if owner.IsLocal() {
 		if _, err := st.User(owner); err != nil {
@@ -201,16 +225,13 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 			newSt.Close()
 		}
 	}()
+	newSt.controllerTag = st.controllerTag
 
-	cloudCfg, err := st.CloudConfig()
+	configDefaults, err := st.ModelConfigDefaults()
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "could not read cloud config for new model")
 	}
-	controllerCfg, err := st.ControllerConfig()
-	if err != nil {
-		return nil, nil, errors.Annotate(err, "could not read controller config for new model")
-	}
-	ops, err := newSt.modelSetupOps(args.Config, controllerCfg.ControllerUUID(), args.CloudRegion, cloudCfg, owner, args.MigrationMode)
+	ops, err := newSt.modelSetupOps(args, configDefaults)
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "failed to create new model")
 	}
@@ -290,6 +311,12 @@ func (m *Model) Name() string {
 // CloudRegion returns the name of the cloud region to which the model is deployed.
 func (m *Model) CloudRegion() string {
 	return m.doc.CloudRegion
+}
+
+// CloudCredential returns the name of the cloud credential used for managing the
+// model's cloud resources.
+func (m *Model) CloudCredential() string {
+	return m.doc.CloudCredential
 }
 
 // MigrationMode returns whether the model is active or being migrated.
@@ -780,15 +807,20 @@ func ensureDestroyable(st *State) error {
 
 // createModelOp returns the operation needed to create
 // an model document with the given name and UUID.
-func createModelOp(st *State, owner names.UserTag, name, uuid, server, cloudRegion string, mode MigrationMode) txn.Op {
+func createModelOp(
+	owner names.UserTag,
+	name, uuid, server, cloudRegion, cloudCredential string,
+	migrationMode MigrationMode,
+) txn.Op {
 	doc := &modelDoc{
-		UUID:          uuid,
-		Name:          name,
-		Life:          Alive,
-		Owner:         owner.Canonical(),
-		ServerUUID:    server,
-		MigrationMode: mode,
-		CloudRegion:   cloudRegion,
+		UUID:            uuid,
+		Name:            name,
+		Life:            Alive,
+		Owner:           owner.Canonical(),
+		ServerUUID:      server,
+		MigrationMode:   migrationMode,
+		CloudRegion:     cloudRegion,
+		CloudCredential: cloudCredential,
 	}
 	return txn.Op{
 		C:      modelsC,

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -49,17 +49,17 @@ func checkModelConfig(cfg *config.Config) error {
 	return nil
 }
 
-// checkCloudConfig returns an error if the shared config is definitely invalid.
-func checkCloudConfig(attrs map[string]interface{}) error {
+// checkModelConfigDefaults returns an error if the shared config is definitely invalid.
+func checkModelConfigDefaults(attrs map[string]interface{}) error {
 	if _, ok := attrs[config.AdminSecretKey]; ok {
-		return errors.Errorf("cloud config cannot contain admin-secret")
+		return errors.Errorf("config defaults cannot contain admin-secret")
 	}
 	if _, ok := attrs[config.AgentVersionKey]; ok {
-		return errors.Errorf("cloud config cannot contain agent-version")
+		return errors.Errorf("config defaults cannot contain agent-version")
 	}
 	for _, attrName := range controller.ControllerOnlyConfigAttributes {
 		if _, ok := attrs[attrName]; ok {
-			return errors.Errorf("cloud config cannot contain controller attribute %q", attrName)
+			return errors.Errorf("config defaults cannot contain controller attribute %q", attrName)
 		}
 	}
 	return nil
@@ -133,13 +133,14 @@ func (st *State) UpdateModelConfig(updateAttrs map[string]interface{}, removeAtt
 	}
 
 	// Remove any attributes that are the same as what's in cloud config.
-	//TODO(wallyworld) if/when cloud config becomes mutable, we must check for concurrent changes
-	// when writing config to ensure the validation we do here remains true
-	cloudAttrs, err := st.CloudConfig()
+	// TODO(wallyworld) if/when cloud config becomes mutable, we must check
+	// for concurrent changes when writing config to ensure the validation
+	// we do here remains true
+	defaultAttrs, err := st.ModelConfigDefaults()
 	if err != nil {
 		return errors.Trace(err)
 	}
-	for attr, sharedValue := range cloudAttrs {
+	for attr, sharedValue := range defaultAttrs {
 		if newValue, ok := validAttrs[attr]; ok && newValue == sharedValue {
 			delete(validAttrs, attr)
 			modelSettings.Delete(attr)

--- a/state/open.go
+++ b/state/open.go
@@ -14,9 +14,8 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/txn"
 
-	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/worker"
@@ -103,20 +102,80 @@ func mongodbLogin(session *mgo.Session, mongoInfo *mongo.MongoInfo) error {
 	return nil
 }
 
+// InitializeParams contains the parameters for initializing the state database.
+type InitializeParams struct {
+	// ControllerModelArgs contains the arguments for creating
+	// the controller model.
+	ControllerModelArgs ModelArgs
+
+	// CloudName is the name of the cloud that the controller
+	// runs in.
+	CloudName string
+
+	// Cloud contains the properties of the cloud that the
+	// controller runs in.
+	Cloud cloud.Cloud
+
+	// CloudCredentials contains the credentials for the owner of
+	// the controller model to store in the controller.
+	CloudCredentials map[string]cloud.Credential
+
+	// ModelConfigDefaults contains default config attributes for
+	// models.
+	ModelConfigDefaults map[string]interface{}
+
+	// Policy is the set of state policies to apply.
+	Policy Policy
+
+	// MongoInfo contains the information required to address and
+	// authenticate with Mongo.
+	MongoInfo *mongo.MongoInfo
+
+	// MongoDialOpts contains the dial options for connecting to
+	// Mongo.
+	MongoDialOpts mongo.DialOpts
+}
+
+// Validate checks that the state initialization parameters are valid.
+func (p InitializeParams) Validate() error {
+	if err := p.ControllerModelArgs.Validate(); err != nil {
+		return errors.Trace(err)
+	}
+	if p.ControllerModelArgs.MigrationMode != MigrationModeActive {
+		return errors.NotValidf("migration mode %q", p.ControllerModelArgs.MigrationMode)
+	}
+	uuid := p.ControllerModelArgs.Config.UUID()
+	controllerUUID := p.ControllerModelArgs.Config.ControllerUUID()
+	if uuid != controllerUUID {
+		return errors.NotValidf("mismatching uuid (%v) and controller-uuid (%v)", uuid, controllerUUID)
+	}
+	if p.MongoInfo == nil {
+		return errors.NotValidf("nil MongoInfo")
+	}
+	if p.CloudName == "" {
+		return errors.NotValidf("empty CloudName")
+	}
+	if p.Cloud.Type == "" {
+		return errors.NotValidf("empty Cloud")
+	}
+	// TODO(axw) check that the controller model region exists in the
+	// cloud definition. If no region is specified, ensure that the
+	// cloud specifies no regions.
+	return nil
+}
+
 // Initialize sets up an initial empty state and returns it.
 // This needs to be performed only once for the initial controller model.
 // It returns unauthorizedError if access is unauthorized.
-func Initialize(owner names.UserTag, info *mongo.MongoInfo, cloudName, cloudRegion string, cloudCfg map[string]interface{}, cfg *config.Config, opts mongo.DialOpts, policy Policy) (_ *State, err error) {
-	uuid := cfg.UUID()
+func Initialize(args InitializeParams) (_ *State, err error) {
+	if err := args.Validate(); err != nil {
+		return nil, errors.Annotate(err, "validating initialization args")
+	}
+
 	// When creating the controller model, the new model
 	// UUID is also used as the controller UUID.
-	controllerCfg := controller.ControllerConfig(cfg.AllAttrs())
-	controllerUUID := controllerCfg.ControllerUUID()
-	if controllerUUID != uuid {
-		return nil, errors.Errorf("when initialising state, model and controller UUIDs must be equal, got %v and %v", uuid, controllerUUID)
-	}
-	modelTag := names.NewModelTag(uuid)
-	st, err := open(modelTag, info, opts, policy)
+	modelTag := names.NewModelTag(args.ControllerModelArgs.Config.UUID())
+	st, err := open(modelTag, args.MongoInfo, args.MongoDialOpts, args.Policy)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -127,6 +186,7 @@ func Initialize(owner names.UserTag, info *mongo.MongoInfo, cloudName, cloudRegi
 			}
 		}
 	}()
+	st.controllerTag = modelTag
 
 	// A valid model is used as a signal that the
 	// state has already been initalized. If this is the case
@@ -137,9 +197,9 @@ func Initialize(owner names.UserTag, info *mongo.MongoInfo, cloudName, cloudRegi
 		return nil, errors.Trace(err)
 	}
 
-	logger.Infof("initializing controller model %s", uuid)
+	logger.Infof("initializing controller model %s", modelTag.Id())
 
-	modelOps, err := st.modelSetupOps(cfg, controllerUUID, cloudRegion, cloudCfg, owner, MigrationModeActive)
+	modelOps, err := st.modelSetupOps(args.ControllerModelArgs, args.ModelConfigDefaults)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -148,17 +208,21 @@ func Initialize(owner names.UserTag, info *mongo.MongoInfo, cloudName, cloudRegi
 		return nil, err
 	}
 
+	// Extract just the controller config.
+	controllerCfg := controller.ControllerConfig(args.ControllerModelArgs.Config.AllAttrs())
+
 	ops := []txn.Op{
-		createInitialUserOp(st, owner, info.Password, salt),
+		createInitialUserOp(st, args.ControllerModelArgs.Owner, args.MongoInfo.Password, salt),
 		txn.Op{
 			C:      controllersC,
 			Id:     modelGlobalKey,
 			Assert: txn.DocMissing,
 			Insert: &controllersDoc{
-				CloudName: cloudName,
+				CloudName: args.CloudName,
 				ModelUUID: st.ModelUUID(),
 			},
 		},
+		createCloudOp(args.Cloud, args.CloudName),
 		txn.Op{
 			C:      controllersC,
 			Id:     apiHostPortsKey,
@@ -178,7 +242,13 @@ func Initialize(owner names.UserTag, info *mongo.MongoInfo, cloudName, cloudRegi
 			Insert: &hostedModelCountDoc{},
 		},
 		createSettingsOp(controllersC, controllerSettingsGlobalKey, controllerCfg),
-		createSettingsOp(controllersC, defaultModelSettingsGlobalKey, cloudCfg),
+		createSettingsOp(controllersC, defaultModelSettingsGlobalKey, args.ModelConfigDefaults),
+	}
+	if len(args.CloudCredentials) > 0 {
+		credentialsOps := initCloudCredentialsOps(
+			args.ControllerModelArgs.Owner, args.CloudCredentials,
+		)
+		ops = append(ops, credentialsOps...)
 	}
 	ops = append(ops, modelOps...)
 
@@ -192,15 +262,16 @@ func Initialize(owner names.UserTag, info *mongo.MongoInfo, cloudName, cloudRegi
 }
 
 // modelSetupOps returns the transactions necessary to set up a model.
-func (st *State) modelSetupOps(cfg *config.Config, controllerUUID, cloudRegion string, cloudCfg map[string]interface{}, owner names.UserTag, mode MigrationMode) ([]txn.Op, error) {
-	if err := checkCloudConfig(cloudCfg); err != nil {
+func (st *State) modelSetupOps(args ModelArgs, configDefaults map[string]interface{}) ([]txn.Op, error) {
+	if err := checkModelConfigDefaults(configDefaults); err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := checkModelConfig(cfg); err != nil {
+	if err := checkModelConfig(args.Config); err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	modelUUID := cfg.UUID()
+	controllerUUID := st.controllerTag.Id()
+	modelUUID := args.Config.UUID()
 	modelStatusDoc := statusDoc{
 		ModelUUID: modelUUID,
 		// TODO(fwereade): 2016-03-17 lp:1558657
@@ -215,21 +286,29 @@ func (st *State) modelSetupOps(cfg *config.Config, controllerUUID, cloudRegion s
 	// UUID is also used as the controller UUID.
 	isHostedModel := controllerUUID != modelUUID
 
-	modelUserOp := createModelUserOp(modelUUID, owner, owner, owner.Name(), nowToTheSecond(), ModelAdminAccess)
+	modelUserOp := createModelUserOp(
+		modelUUID, args.Owner, args.Owner, args.Owner.Name(), nowToTheSecond(), ModelAdminAccess,
+	)
 	ops := []txn.Op{
 		createStatusOp(st, modelGlobalKey, modelStatusDoc),
-		createConstraintsOp(st, modelGlobalKey, constraints.Value{}),
+		createConstraintsOp(st, modelGlobalKey, args.Constraints),
 	}
 	if isHostedModel {
 		ops = append(ops, incHostedModelCountOp())
 	}
 
-	modelCfg := modelConfig(cloudCfg, cfg.AllAttrs())
+	modelCfg := modelConfig(configDefaults, args.Config.AllAttrs())
 	ops = append(ops,
 		createSettingsOp(settingsC, modelGlobalKey, modelCfg),
 		createModelEntityRefsOp(st, modelUUID),
-		createModelOp(st, owner, cfg.Name(), modelUUID, controllerUUID, cloudRegion, mode),
-		createUniqueOwnerModelNameOp(owner, cfg.Name()),
+		createModelOp(
+			args.Owner,
+			args.Config.Name(),
+			modelUUID, controllerUUID,
+			args.CloudRegion, args.CloudCredential,
+			args.MigrationMode,
+		),
+		createUniqueOwnerModelNameOp(args.Owner, args.Config.Name()),
 		modelUserOp,
 	)
 	return ops, nil

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -26,6 +26,7 @@ import (
 	mgotxn "gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
@@ -4116,7 +4117,17 @@ func (s *SetAdminMongoPasswordSuite) TestSetAdminMongoPassword(c *gc.C) {
 		Password: password,
 	}
 	cfg := testing.ModelConfig(c)
-	st, err := state.Initialize(owner, authInfo, "dummy", "some-region", nil, cfg, mongotest.DialOpts(), nil)
+	st, err := state.Initialize(state.InitializeParams{
+		ControllerModelArgs: state.ModelArgs{
+			Owner:       owner,
+			CloudRegion: "some-region",
+			Config:      cfg,
+		},
+		CloudName:     "dummy",
+		Cloud:         cloud.Cloud{Type: "dummy"},
+		MongoInfo:     authInfo,
+		MongoDialOpts: mongotest.DialOpts(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 

--- a/state/testing/conn.go
+++ b/state/testing/conn.go
@@ -9,6 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/mongo/mongotest"
@@ -26,7 +27,18 @@ func Initialize(c *gc.C, owner names.UserTag, cfg *config.Config, policy state.P
 	mgoInfo := NewMongoInfo()
 	dialOpts := mongotest.DialOpts()
 
-	st, err := state.Initialize(owner, mgoInfo, "dummy", "some-region", nil, cfg, dialOpts, policy)
+	st, err := state.Initialize(state.InitializeParams{
+		ControllerModelArgs: state.ModelArgs{
+			CloudRegion: "some-region",
+			Config:      cfg,
+			Owner:       owner,
+		},
+		CloudName:     "dummy",
+		Cloud:         cloud.Cloud{Type: "dummy"},
+		MongoInfo:     mgoInfo,
+		MongoDialOpts: dialOpts,
+		Policy:        policy,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	return st
 }


### PR DESCRIPTION
When bootstrapping, we now store the cloud definition
in the state database. We also store the cloud credential
used to bootstrap against the admin user, and the name
of the credential against the controller and default
models.

(Review request: http://reviews.vapour.ws/r/5045/)