### PR TITLE
Add get-controller-config command

### DIFF
--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -5,15 +5,12 @@ package controller
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 )
-
-var logger = loggo.GetLogger("juju.api.controller")
 
 // Client provides methods that the Juju client command uses to interact
 // with the Juju controller.
@@ -58,6 +55,14 @@ func (c *Client) AllModels() ([]base.UserModel, error) {
 func (c *Client) ModelConfig() (map[string]interface{}, error) {
 	result := params.ModelConfigResults{}
 	err := c.facade.FacadeCall("ModelConfig", nil, &result)
+	return result.Config, err
+}
+
+// ControllerConfig returns settings for the
+// controller itself.
+func (c *Client) ControllerConfig() (map[string]interface{}, error) {
+	result := params.ControllerConfigResult{}
+	err := c.facade.FacadeCall("ControllerConfig", nil, &result)
 	return result.Config, err
 }
 

--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -65,9 +65,20 @@ func (s *controllerSuite) TestAllModels(c *gc.C) {
 
 func (s *controllerSuite) TestModelConfig(c *gc.C) {
 	sysManager := s.OpenAPI(c)
-	env, err := sysManager.ModelConfig()
+	cfg, err := sysManager.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env["name"], gc.Equals, "admin")
+	c.Assert(cfg["name"], gc.Equals, "admin")
+}
+
+func (s *controllerSuite) TestControllerConfig(c *gc.C) {
+	sysManager := s.OpenAPI(c)
+	cfg, err := sysManager.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	cfgFromDB, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg["controller-uuid"], gc.Equals, cfgFromDB.ControllerUUID())
+	c.Assert(int(cfg["state-port"].(float64)), gc.Equals, cfgFromDB.StatePort())
+	c.Assert(int(cfg["api-port"].(float64)), gc.Equals, cfgFromDB.APIPort())
 }
 
 func (s *controllerSuite) TestDestroyController(c *gc.C) {
@@ -89,7 +100,7 @@ func (s *controllerSuite) TestListBlockedModels(c *gc.C) {
 	results, err := sysManager.ListBlockedModels()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, []params.ModelBlockInfo{
-		params.ModelBlockInfo{
+		{
 			Name:     "admin",
 			UUID:     s.State.ModelUUID(),
 			OwnerTag: s.AdminUserTag(c).String(),

--- a/apiserver/application/charmstore.go
+++ b/apiserver/application/charmstore.go
@@ -68,11 +68,11 @@ func AddCharmWithAuthorization(st *state.State, args params.AddCharmWithAuthoriz
 	if err != nil {
 		return err
 	}
-	envConfig, err := st.ModelConfig()
+	modelConfig, err := st.ModelConfig()
 	if err != nil {
 		return err
 	}
-	repo = config.SpecializeCharmRepo(repo, envConfig).(*charmrepo.CharmStore)
+	repo = config.SpecializeCharmRepo(repo, modelConfig).(*charmrepo.CharmStore)
 
 	// Get the charm and its information from the store.
 	downloadedCharm, err := repo.Get(charmURL)

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -395,7 +395,7 @@ func (c *Client) AgentVersion() (params.AgentVersionResult, error) {
 // get-model-config CLI command.
 func (c *Client) ModelGet() (params.ModelConfigResults, error) {
 	result := params.ModelConfigResults{}
-	// Get the existing environment config from the state.
+	// Get the existing model config from the state.
 	config, err := c.api.stateAccessor.ModelConfig()
 	if err != nil {
 		return result, err

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -172,9 +172,9 @@ func (s *serverSuite) TestSetEnvironAgentVersion(c *gc.C) {
 	err := s.client.SetModelAgentVersion(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	envConfig, err := s.State.ModelConfig()
+	modelConfig, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	agentVersion, found := envConfig.AllAttrs()["agent-version"]
+	agentVersion, found := modelConfig.AllAttrs()["agent-version"]
 	c.Assert(found, jc.IsTrue)
 	c.Assert(agentVersion, gc.Equals, "9.8.7")
 }
@@ -223,9 +223,9 @@ func (s *serverSuite) assertSetEnvironAgentVersion(c *gc.C) {
 	}
 	err := s.client.SetModelAgentVersion(args)
 	c.Assert(err, jc.ErrorIsNil)
-	envConfig, err := s.State.ModelConfig()
+	modelConfig, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	agentVersion, found := envConfig.AllAttrs()["agent-version"]
+	agentVersion, found := modelConfig.AllAttrs()["agent-version"]
 	c.Assert(found, jc.IsTrue)
 	c.Assert(agentVersion, gc.Equals, "9.8.7")
 }
@@ -483,10 +483,6 @@ func assertLife(c *gc.C, entity state.Living, life state.Life) {
 func assertRemoved(c *gc.C, entity state.Living) {
 	err := entity.Refresh()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-}
-
-func assertKill(c *gc.C, killer Killer) {
-	c.Assert(killer.Kill(), gc.IsNil)
 }
 
 func (s *clientSuite) setupDestroyMachinesTest(c *gc.C) (*state.Machine, *state.Machine, *state.Machine, *state.Unit) {
@@ -825,32 +821,32 @@ func (s *clientSuite) TestClientPrivateAddressUnit(c *gc.C) {
 }
 
 func (s *serverSuite) TestClientModelGet(c *gc.C) {
-	envConfig, err := s.State.ModelConfig()
+	modelConfig, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	result, err := s.client.ModelGet()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Config, gc.DeepEquals, envConfig.AllAttrs())
+	c.Assert(result.Config, gc.DeepEquals, modelConfig.AllAttrs())
 }
 
 func (s *serverSuite) assertEnvValue(c *gc.C, key string, expected interface{}) {
-	envConfig, err := s.State.ModelConfig()
+	modelConfig, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	value, found := envConfig.AllAttrs()[key]
+	value, found := modelConfig.AllAttrs()[key]
 	c.Assert(found, jc.IsTrue)
 	c.Assert(value, gc.Equals, expected)
 }
 
 func (s *serverSuite) assertEnvValueMissing(c *gc.C, key string) {
-	envConfig, err := s.State.ModelConfig()
+	modelConfig, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	_, found := envConfig.AllAttrs()[key]
+	_, found := modelConfig.AllAttrs()[key]
 	c.Assert(found, jc.IsFalse)
 }
 
 func (s *serverSuite) TestClientModelSet(c *gc.C) {
-	envConfig, err := s.State.ModelConfig()
+	modelConfig, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	_, found := envConfig.AllAttrs()["some-key"]
+	_, found := modelConfig.AllAttrs()["some-key"]
 	c.Assert(found, jc.IsFalse)
 
 	params := params.ModelSet{

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -41,10 +41,6 @@ import (
 	jujuversion "github.com/juju/juju/version"
 )
 
-type Killer interface {
-	Kill() error
-}
-
 type serverSuite struct {
 	baseSuite
 	client *client.Client

--- a/apiserver/client/instanceconfig.go
+++ b/apiserver/client/instanceconfig.go
@@ -22,7 +22,7 @@ import (
 // is exposed for testing purposes.
 // TODO(rog) fix environs/manual tests so they do not need to call this, or move this elsewhere.
 func InstanceConfig(st *state.State, machineId, nonce, dataDir string) (*instancecfg.InstanceConfig, error) {
-	environConfig, err := st.ModelConfig()
+	modelConfig, err := st.ModelConfig()
 	if err != nil {
 		return nil, errors.Annotate(err, "getting model config")
 	}
@@ -43,7 +43,7 @@ func InstanceConfig(st *state.State, machineId, nonce, dataDir string) (*instanc
 	}
 
 	// Find the appropriate tools information.
-	agentVersion, ok := environConfig.AgentVersion()
+	agentVersion, ok := modelConfig.AgentVersion()
 	if !ok {
 		return nil, errors.New("no agent version set in model configuration")
 	}
@@ -97,7 +97,7 @@ func InstanceConfig(st *state.State, machineId, nonce, dataDir string) (*instanc
 		return nil, errors.Annotate(err, "getting state serving info")
 	}
 	secureServerConnection := info.CAPrivateKey != ""
-	icfg, err := instancecfg.NewInstanceConfig(machineId, nonce, environConfig.ImageStream(), machine.Series(),
+	icfg, err := instancecfg.NewInstanceConfig(machineId, nonce, modelConfig.ImageStream(), machine.Series(),
 		secureServerConnection, apiInfo,
 	)
 	if err != nil {
@@ -109,7 +109,7 @@ func InstanceConfig(st *state.State, machineId, nonce, dataDir string) (*instanc
 	if err := icfg.SetTools(toolsList); err != nil {
 		return nil, errors.Trace(err)
 	}
-	err = instancecfg.FinishInstanceConfig(icfg, environConfig)
+	err = instancecfg.FinishInstanceConfig(icfg, modelConfig)
 	if err != nil {
 		return nil, errors.Annotate(err, "finishing instance config")
 	}

--- a/apiserver/common/modelwatcher.go
+++ b/apiserver/common/modelwatcher.go
@@ -82,3 +82,14 @@ func (m *ModelWatcher) ModelConfig() (params.ModelConfigResult, error) {
 	result.Config = allAttrs
 	return result, nil
 }
+
+// ControllerConfig returns the controller's configuration.
+func (m *ModelWatcher) ControllerConfig() (params.ControllerConfigResult, error) {
+	result := params.ControllerConfigResult{}
+	config, err := m.st.ControllerConfig()
+	if err != nil {
+		return result, err
+	}
+	result.Config = params.ControllerConfig(config)
+	return result, nil
+}

--- a/apiserver/common/modelwatcher.go
+++ b/apiserver/common/modelwatcher.go
@@ -82,14 +82,3 @@ func (m *ModelWatcher) ModelConfig() (params.ModelConfigResult, error) {
 	result.Config = allAttrs
 	return result, nil
 }
-
-// ControllerConfig returns the controller's configuration.
-func (m *ModelWatcher) ControllerConfig() (params.ControllerConfigResult, error) {
-	result := params.ControllerConfigResult{}
-	config, err := m.st.ControllerConfig()
-	if err != nil {
-		return result, err
-	}
-	result.Config = params.ControllerConfig(config)
-	return result, nil
-}

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -30,6 +30,7 @@ type Controller interface {
 	AllModels() (params.UserModelList, error)
 	DestroyController(args params.DestroyControllerArgs) error
 	ModelConfig() (params.ModelConfigResults, error)
+	ControllerConfig() (params.ControllerConfigResult, error)
 	ListBlockedModels() (params.ModelBlockInfoList, error)
 	RemoveBlocks(args params.RemoveBlocksArgs) error
 	WatchAllModels() (params.AllWatcherId, error)
@@ -184,17 +185,28 @@ func (s *ControllerAPI) ListBlockedModels() (params.ModelBlockInfoList, error) {
 func (s *ControllerAPI) ModelConfig() (params.ModelConfigResults, error) {
 	result := params.ModelConfigResults{}
 
-	controllerEnv, err := s.state.ControllerModel()
+	controllerModel, err := s.state.ControllerModel()
 	if err != nil {
 		return result, errors.Trace(err)
 	}
 
-	config, err := controllerEnv.Config()
+	config, err := controllerModel.Config()
 	if err != nil {
 		return result, errors.Trace(err)
 	}
 
 	result.Config = config.AllAttrs()
+	return result, nil
+}
+
+// ControllerConfig returns the controller's configuration.
+func (s *ControllerAPI) ControllerConfig() (params.ControllerConfigResult, error) {
+	result := params.ControllerConfigResult{}
+	config, err := s.state.ControllerConfig()
+	if err != nil {
+		return result, err
+	}
+	result.Config = params.ControllerConfig(config)
 	return result, nil
 }
 

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -162,9 +162,36 @@ func (s *controllerSuite) TestModelConfigFromNonController(c *gc.C) {
 	authorizer := &apiservertesting.FakeAuthorizer{Tag: s.AdminUserTag(c)}
 	controller, err := controller.NewControllerAPI(st, common.NewResources(), authorizer)
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := controller.ModelConfig()
+	cfg, err := controller.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env.Config["name"], gc.Equals, "admin")
+	c.Assert(cfg.Config["name"], gc.Equals, "admin")
+}
+
+func (s *controllerSuite) TestControllerConfig(c *gc.C) {
+	cfg, err := s.controller.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	cfgFromDB, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.Config["controller-uuid"], gc.Equals, cfgFromDB.ControllerUUID())
+	c.Assert(cfg.Config["state-port"], gc.Equals, cfgFromDB.StatePort())
+	c.Assert(cfg.Config["api-port"], gc.Equals, cfgFromDB.APIPort())
+}
+
+func (s *controllerSuite) TestControllerConfigFromNonController(c *gc.C) {
+	st := s.Factory.MakeModel(c, &factory.ModelParams{
+		Name: "test"})
+	defer st.Close()
+
+	authorizer := &apiservertesting.FakeAuthorizer{Tag: s.AdminUserTag(c)}
+	controller, err := controller.NewControllerAPI(st, common.NewResources(), authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	cfg, err := controller.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	cfgFromDB, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.Config["controller-uuid"], gc.Equals, cfgFromDB.ControllerUUID())
+	c.Assert(cfg.Config["state-port"], gc.Equals, cfgFromDB.StatePort())
+	c.Assert(cfg.Config["api-port"], gc.Equals, cfgFromDB.APIPort())
 }
 
 func (s *controllerSuite) TestRemoveBlocks(c *gc.C) {

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -363,6 +363,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(controller.NewUnregisterCommand(jujuclient.NewFileClientStore()))
 	r.Register(controller.NewRemoveBlocksCommand())
 	r.Register(controller.NewShowControllerCommand())
+	r.Register(controller.NewGetConfigCommand())
 
 	// Debug Metrics
 	r.Register(metricsdebug.New())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -403,6 +403,7 @@ var commandNames = []string{
 	"get-config",
 	"get-configs",
 	"get-constraints",
+	"get-controller-config",
 	"get-model-config",
 	"get-model-constraints",
 	"grant",

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -129,6 +129,14 @@ func NewListBlocksCommandForTest(api listBlocksAPI, apierr error, store jujuclie
 	return modelcmd.WrapController(c)
 }
 
+// NewGetConfigCommandCommandForTest returns a GetConfigCommandCommand with
+// the api provided as specified.
+func NewGetConfigCommandForTest(api controllerAPI, store jujuclient.ClientStore) cmd.Command {
+	c := &getConfigCommand{api: api}
+	c.SetClientStore(store)
+	return modelcmd.WrapController(c)
+}
+
 type CtrData ctrData
 type ModelData modelData
 

--- a/cmd/juju/controller/getconfig.go
+++ b/cmd/juju/controller/getconfig.go
@@ -1,0 +1,98 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/cmd"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/errors"
+	apicontroller "github.com/juju/juju/api/controller"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+func NewGetConfigCommand() cmd.Command {
+	return modelcmd.WrapController(&getConfigCommand{})
+}
+
+// getConfigCommand is able to output either the entire environment or
+// the requested value in a format of the user's choosing.
+type getConfigCommand struct {
+	modelcmd.ControllerCommandBase
+	api controllerAPI
+	key string
+	out cmd.Output
+}
+
+const getControllerHelpDoc = `
+By default, all configuration (keys and values) for the controller are
+displayed if a key is not specified.
+
+Examples:
+
+    juju get-controller-config
+    juju get-controller-config api-port
+    juju get-controller-config -c mycontroller
+
+See also: controllers
+`
+
+func (c *getConfigCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "get-controller-config",
+		Args:    "[<attribute key>]",
+		Purpose: "Displays configuration settings for a controller.",
+		Doc:     strings.TrimSpace(getControllerHelpDoc),
+	}
+}
+
+func (c *getConfigCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+}
+
+func (c *getConfigCommand) Init(args []string) (err error) {
+	c.key, err = cmd.ZeroOrOneArgs(args)
+	return
+}
+
+type controllerAPI interface {
+	Close() error
+	ControllerConfig() (map[string]interface{}, error)
+}
+
+func (c *getConfigCommand) getAPI() (controllerAPI, error) {
+	if c.api != nil {
+		return c.api, nil
+	}
+	root, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return apicontroller.NewClient(root), nil
+}
+
+func (c *getConfigCommand) Run(ctx *cmd.Context) error {
+	client, err := c.getAPI()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	attrs, err := client.ControllerConfig()
+	if err != nil {
+		return err
+	}
+
+	if c.key != "" {
+		if value, found := attrs[c.key]; found {
+			return c.out.Write(ctx, value)
+		}
+		return fmt.Errorf("key %q not found in %q controller.", c.key, c.ControllerName())
+	}
+	// If key is empty, write out the whole lot.
+	return c.out.Write(ctx, attrs)
+}

--- a/cmd/juju/controller/getconfig_test.go
+++ b/cmd/juju/controller/getconfig_test.go
@@ -1,0 +1,103 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller_test
+
+import (
+	"strings"
+
+	"github.com/juju/cmd"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/cmd/juju/controller"
+	"github.com/juju/juju/testing"
+)
+
+type GetConfigSuite struct {
+	baseControllerSuite
+}
+
+var _ = gc.Suite(&GetConfigSuite{})
+
+func (s *GetConfigSuite) SetUpTest(c *gc.C) {
+	s.baseControllerSuite.SetUpTest(c)
+	s.createTestClientStore(c)
+}
+
+func (s *GetConfigSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
+	command := controller.NewGetConfigCommandForTest(&fakeControllerAPI{}, s.store)
+	return testing.RunCommand(c, command, args...)
+}
+
+func (s *GetConfigSuite) TestInit(c *gc.C) {
+	// zero or one args is fine.
+	err := testing.InitCommand(controller.NewGetConfigCommandForTest(&fakeControllerAPI{}, s.store), nil)
+	c.Check(err, jc.ErrorIsNil)
+	err = testing.InitCommand(controller.NewGetConfigCommandForTest(&fakeControllerAPI{}, s.store), []string{"one"})
+	c.Check(err, jc.ErrorIsNil)
+	// More than one is not allowed.
+	err = testing.InitCommand(controller.NewGetConfigCommandForTest(&fakeControllerAPI{}, s.store), []string{"one", "two"})
+	c.Check(err, gc.ErrorMatches, `unrecognized args: \["two"\]`)
+}
+
+func (s *GetConfigSuite) TestSingleValue(c *gc.C) {
+	context, err := s.run(c, "controller-uuid")
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(testing.Stdout(context))
+	c.Assert(output, gc.Equals, "uuid")
+}
+
+func (s *GetConfigSuite) TestSingleValueJSON(c *gc.C) {
+	context, err := s.run(c, "--format=json", "controller-uuid")
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(testing.Stdout(context))
+	c.Assert(output, gc.Equals, `"uuid"`)
+}
+
+func (s *GetConfigSuite) TestAllValues(c *gc.C) {
+	context, err := s.run(c)
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(testing.Stdout(context))
+	expected := "" +
+		"api-port: 1234\n" +
+		"controller-uuid: uuid"
+	c.Assert(output, gc.Equals, expected)
+}
+
+func (s *GetConfigSuite) TestAllValuesJSON(c *gc.C) {
+	context, err := s.run(c, "--format=json")
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(testing.Stdout(context))
+	expected := `{"api-port":1234,"controller-uuid":"uuid"}`
+	c.Assert(output, gc.Equals, expected)
+}
+
+func (s *GetConfigSuite) TestError(c *gc.C) {
+	command := controller.NewGetConfigCommandForTest(&fakeControllerAPI{err: errors.New("error")}, s.store)
+	_, err := testing.RunCommand(c, command)
+	c.Assert(err, gc.ErrorMatches, "error")
+}
+
+type fakeControllerAPI struct {
+	err error
+}
+
+func (f *fakeControllerAPI) Close() error {
+	return nil
+}
+
+func (f *fakeControllerAPI) ControllerConfig() (map[string]interface{}, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return map[string]interface{}{
+		"controller-uuid": "uuid",
+		"api-port":        1234,
+	}, nil
+}

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -45,7 +45,7 @@ Displays the current status of Juju, applications, and units.`[1:]
 var usageDetails = `
 By default (without argument), the status of Juju and all applications and all
 units will be displayed. 
-Appliction or unit names may be used as output filters (the '*' can be used
+Application or unit names may be used as output filters (the '*' can be used
 as a wildcard character).  
 In addition to matched applications and units, related machines, applications, and
 units will also be displayed. If a subordinate unit is matched, then its

--- a/cmd/juju/user/disenable.go
+++ b/cmd/juju/user/disenable.go
@@ -17,7 +17,7 @@ Disables a Juju user.`[1:]
 var usageDisableUserDetails = `
 A disabled Juju user is one that cannot log in to any controller.
 This command has no affect on models that the disabled user may have
-created and/or shared nor any applictions associated with that user.
+created and/or shared nor any applications associated with that user.
 
 Examples:
     juju disable-user bob

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -319,5 +319,5 @@ func (s *cmdControllerSuite) TestGetControllerConfigYAML(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	cfgYaml, err := yaml.Marshal(controllerCfg)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Matches, string(cfgYaml))
+	c.Assert(testing.Stdout(context), gc.Equals, string(cfgYaml))
 }

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -15,6 +15,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/modelmanager"
@@ -310,4 +311,13 @@ func opRecvTimeout(c *gc.C, st *state.State, opc <-chan dummy.Operation, kinds .
 
 func noBootstrapConfig(controllerName string) (*config.Config, error) {
 	return nil, errors.NotFoundf("bootstrap config for controller %s", controllerName)
+}
+
+func (s *cmdControllerSuite) TestGetControllerConfigYAML(c *gc.C) {
+	context := s.run(c, "get-controller-config", "--format=yaml")
+	controllerCfg, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	cfgYaml, err := yaml.Marshal(controllerCfg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stdout(context), gc.Matches, string(cfgYaml))
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2585,8 +2585,8 @@ func (s *StateSuite) TestWatchForModelConfigControllerChanges(c *gc.C) {
 	// Initially we get one change notification
 	wc.AssertOneChange()
 
-	// Updating a controller setting value triggers the watcher.
-	controllerSettings, err := s.State.ReadSettings(state.ControllersC, "controllerSettings")
+	// Updating shared model settings triggers the watcher.
+	controllerSettings, err := s.State.ReadSettings(state.ControllersC, "defaultModelSettings")
 	c.Assert(err, jc.ErrorIsNil)
 	controllerSettings.Set("apt-mirror", "http://mirror")
 	_, err = controllerSettings.Write()

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1316,9 +1316,6 @@ func (st *State) WatchForModelConfigChanges() NotifyWatcher {
 			st.docID(modelGlobalKey),
 		}, {
 			controllersC,
-			controllerSettingsGlobalKey,
-		}, {
-			controllersC,
 			defaultModelSettingsGlobalKey,
 		},
 	})


### PR DESCRIPTION
A new get-controller-config command is added.
Plus a few drive by fixes for var names and unused structs.

(Review request: http://reviews.vapour.ws/r/5046/)