### PR TITLE
state: Add backend for migration minion reporting

### DIFF
--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -93,11 +93,14 @@ type FullMigrationStatus struct {
 	Phase   string             `json:"phase"`
 }
 
-type PhaseResult struct {
-	Phase string `json:"phase"`
-	Error *Error
+// PhasesResults holds the phase of one or more model migrations.
+type PhaseResults struct {
+	Results []PhaseResult `json:"results"`
 }
 
-type PhaseResults struct {
-	Results []PhaseResult `json:"Results"`
+// PhaseResult holds the phase of a single model migration, or an
+// error if the phase could not be determined.
+type PhaseResult struct {
+	Phase string `json:"phase,omitempty"`
+	Error *Error `json:"error,omitempty"`
 }

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -121,8 +121,12 @@ func allCollections() collectionSchema {
 
 		// This collection records the model migrations which
 		// are currently in progress. It is used to ensure that only
-		// one model migration document exists per environment.
+		// one model migration document exists per model.
 		migrationsActiveC: {global: true},
+
+		// This collection tracks migration progress reports from the
+		// migration minions.
+		migrationsMinionSyncC: {global: true},
 
 		// This collection holds user information that's not specific to any
 		// one model.
@@ -399,9 +403,10 @@ const (
 	metricsC                 = "metrics"
 	metricsManagerC          = "metricsmanager"
 	minUnitsC                = "minunits"
-	migrationsStatusC        = "migrations.status"
 	migrationsActiveC        = "migrations.active"
 	migrationsC              = "migrations"
+	migrationsMinionSyncC    = "migrations.minionsync"
+	migrationsStatusC        = "migrations.status"
 	modelUserLastConnectionC = "modelUserLastConnection"
 	modelUsersC              = "modelusers"
 	modelsC                  = "models"

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -94,6 +94,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		migrationsC,
 		migrationsStatusC,
 		migrationsActiveC,
+		migrationsMinionSyncC,
 
 		// The container ref document is primarily there to keep track
 		// of a particular machine's containers. The migration format

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
 )
 
 type ModelMigrationSuite struct {
@@ -554,6 +555,109 @@ func (s *ModelMigrationSuite) TestWatchMigrationStatusMultiModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	wc2.AssertOneChange()
 	wc3.AssertNoChange()
+}
+
+func (s *ModelMigrationSuite) TestMinionReports(c *gc.C) {
+	// Create some machines and units to report with.
+	factory2 := factory.NewFactory(s.State2)
+	m0 := factory2.MakeMachine(c, nil)
+	u0 := factory2.MakeUnit(c, &factory.UnitParams{Machine: m0})
+	m1 := factory2.MakeMachine(c, nil)
+	m2 := factory2.MakeMachine(c, nil)
+
+	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	c.Assert(err, jc.ErrorIsNil)
+
+	const phase = migration.QUIESCE
+	c.Assert(mig.MinionReport(m0.Tag(), phase, true), jc.ErrorIsNil)
+	c.Assert(mig.MinionReport(m1.Tag(), phase, false), jc.ErrorIsNil)
+	c.Assert(mig.MinionReport(m2.Tag(), phase, true), jc.ErrorIsNil)
+
+	reports, err := mig.GetMinionReports()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(reports.Succeeded, jc.SameContents, []names.Tag{m0.Tag(), m2.Tag()})
+	c.Check(reports.Failed, jc.SameContents, []names.Tag{m1.Tag()})
+	c.Check(reports.Unknown, jc.SameContents, []names.Tag{u0.Tag()})
+}
+
+func (s *ModelMigrationSuite) TestDuplicateMinionReportsSameSuccess(c *gc.C) {
+	// It should be OK for a minion report to arrive more than once
+	// for the same migration, agent and phase as long as the value of
+	// "success" is the same.
+	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	c.Assert(err, jc.ErrorIsNil)
+	tag := names.NewMachineTag("42")
+	c.Check(mig.MinionReport(tag, migration.QUIESCE, true), jc.ErrorIsNil)
+	c.Check(mig.MinionReport(tag, migration.QUIESCE, true), jc.ErrorIsNil)
+}
+
+func (s *ModelMigrationSuite) TestDuplicateMinionReportsDifferingSuccess(c *gc.C) {
+	// It is not OK for a minion report to arrive more than once for
+	// the same migration, agent and phase when the "success" value
+	// changes.
+	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	c.Assert(err, jc.ErrorIsNil)
+	tag := names.NewMachineTag("42")
+	c.Check(mig.MinionReport(tag, migration.QUIESCE, true), jc.ErrorIsNil)
+	err = mig.MinionReport(tag, migration.QUIESCE, false)
+	c.Check(err, gc.ErrorMatches,
+		fmt.Sprintf("conflicting reports received for %s/QUIESCE/machine-42", mig.Id()))
+}
+
+func (s *ModelMigrationSuite) TestMinionReportWithOldPhase(c *gc.C) {
+	// It is OK for a report to arrive for even a migration has moved
+	// on.
+	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Get another reference to the same migration.
+	migalt, err := s.State2.GetModelMigration()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Confirm that there's no reports when starting.
+	reports, err := mig.GetMinionReports()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(reports.Succeeded, gc.HasLen, 0)
+
+	// Advance the migration
+	c.Assert(mig.SetPhase(migration.READONLY), jc.ErrorIsNil)
+
+	// Submit minion report for the old phase.
+	tag := names.NewMachineTag("42")
+	c.Assert(mig.MinionReport(tag, migration.QUIESCE, true), jc.ErrorIsNil)
+
+	// The report should still have been recorded.
+	reports, err = migalt.GetMinionReports()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(reports.Succeeded, jc.SameContents, []names.Tag{tag})
+}
+
+func (s *ModelMigrationSuite) TestMinionReportWithInactiveMigration(c *gc.C) {
+	// Create a migration.
+	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Get another reference to the same migration.
+	migalt, err := s.State2.GetModelMigration()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Abort the migration.
+	c.Assert(mig.SetPhase(migration.ABORT), jc.ErrorIsNil)
+	c.Assert(mig.SetPhase(migration.ABORTDONE), jc.ErrorIsNil)
+
+	// Confirm that there's no reports when starting.
+	reports, err := mig.GetMinionReports()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(reports.Succeeded, gc.HasLen, 0)
+
+	// Submit a minion report for it.
+	tag := names.NewMachineTag("42")
+	c.Assert(mig.MinionReport(tag, migration.QUIESCE, true), jc.ErrorIsNil)
+
+	// The report should still have been recorded.
+	reports, err = migalt.GetMinionReports()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(reports.Succeeded, jc.SameContents, []names.Tag{tag})
 }
 
 func (s *ModelMigrationSuite) createStatusWatcher(c *gc.C, st *state.State) (


### PR DESCRIPTION
The migration minion workers which run in each agent need to report when they have completed, or failed to complete, their actions for a given migration phase. This change add the required state functionality to support this.

(Review request: http://reviews.vapour.ws/r/5047/)