### PR TITLE
state: Introduce notifyCollWatcher

### DIFF
--- a/apiserver/migrationflag/facade.go
+++ b/apiserver/migrationflag/facade.go
@@ -18,7 +18,7 @@ import (
 type Backend interface {
 	ModelUUID() string
 	MigrationPhase() (migration.Phase, error)
-	WatchMigrationPhase() (state.NotifyWatcher, error)
+	WatchMigrationPhase() state.NotifyWatcher
 }
 
 // Facade lets clients watch and get models' migration phases.
@@ -101,10 +101,7 @@ func (facade *Facade) oneWatch(tagString string) (string, error) {
 	if err := facade.auth(tagString); err != nil {
 		return "", errors.Trace(err)
 	}
-	watch, err := facade.backend.WatchMigrationPhase()
-	if err != nil {
-		return "", errors.Trace(err)
-	}
+	watch := facade.backend.WatchMigrationPhase()
 	if _, ok := <-watch.Changes(); ok {
 		return facade.resources.Register(watch), nil
 	}

--- a/apiserver/migrationflag/shim.go
+++ b/apiserver/migrationflag/shim.go
@@ -35,12 +35,8 @@ func (shim *backend) ModelUUID() string {
 }
 
 // WatchMigrationPhase is part of the Backend interface.
-func (shim *backend) WatchMigrationPhase() (state.NotifyWatcher, error) {
-	watcher, err := shim.st.WatchMigrationStatus()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return watcher, nil
+func (shim *backend) WatchMigrationPhase() state.NotifyWatcher {
+	return shim.st.WatchMigrationStatus()
 }
 
 // MigrationPhase is part of the Backend interface.

--- a/apiserver/migrationflag/util_test.go
+++ b/apiserver/migrationflag/util_test.go
@@ -59,12 +59,9 @@ func (mock *mockBackend) MigrationPhase() (migration.Phase, error) {
 }
 
 // WatchMigrationPhase is part of the migrationflag.Backend interface.
-func (mock *mockBackend) WatchMigrationPhase() (state.NotifyWatcher, error) {
+func (mock *mockBackend) WatchMigrationPhase() state.NotifyWatcher {
 	mock.stub.AddCall("WatchMigrationPhase")
-	if err := mock.stub.NextErr(); err != nil {
-		return nil, err
-	}
-	return newMockWatcher(mock.stub), nil
+	return newMockWatcher(mock.stub)
 }
 
 // newMockWatcher consumes an error from the supplied testing.Stub, and

--- a/apiserver/migrationminion/migrationminion.go
+++ b/apiserver/migrationminion/migrationminion.go
@@ -4,8 +4,6 @@
 package migrationminion
 
 import (
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
@@ -48,10 +46,7 @@ func NewAPI(
 // The MigrationStatusWatcher facade must be used to receive events
 // from the watcher.
 func (api *API) Watch() (params.NotifyWatchResult, error) {
-	w, err := api.backend.WatchMigrationStatus()
-	if err != nil {
-		return params.NotifyWatchResult{}, errors.Trace(err)
-	}
+	w := api.backend.WatchMigrationStatus()
 	return params.NotifyWatchResult{
 		NotifyWatcherId: api.resources.Register(w),
 	}, nil

--- a/apiserver/migrationminion/migrationminion_test.go
+++ b/apiserver/migrationminion/migrationminion_test.go
@@ -4,7 +4,6 @@
 package migrationminion_test
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -59,14 +58,6 @@ func (s *Suite) TestAuthNotAgent(c *gc.C) {
 	c.Assert(err, gc.Equals, common.ErrPerm)
 }
 
-func (s *Suite) TestWatchError(c *gc.C) {
-	s.backend.watchError = errors.New("boom")
-	api := s.mustMakeAPI(c)
-	_, err := api.Watch()
-	c.Assert(err, gc.ErrorMatches, "boom")
-	c.Assert(s.resources.Count(), gc.Equals, 0)
-}
-
 func (s *Suite) TestWatch(c *gc.C) {
 	api := s.mustMakeAPI(c)
 	result, err := api.Watch()
@@ -86,12 +77,8 @@ func (s *Suite) mustMakeAPI(c *gc.C) *migrationminion.API {
 
 type stubBackend struct {
 	migrationminion.Backend
-	watchError error
 }
 
-func (b *stubBackend) WatchMigrationStatus() (state.NotifyWatcher, error) {
-	if b.watchError != nil {
-		return nil, b.watchError
-	}
-	return apiservertesting.NewFakeNotifyWatcher(), nil
+func (b *stubBackend) WatchMigrationStatus() state.NotifyWatcher {
+	return apiservertesting.NewFakeNotifyWatcher()
 }

--- a/apiserver/migrationminion/state.go
+++ b/apiserver/migrationminion/state.go
@@ -8,7 +8,7 @@ import "github.com/juju/juju/state"
 // Backend defines the state functionality required by the
 // MigrationMinion facade.
 type Backend interface {
-	WatchMigrationStatus() (state.NotifyWatcher, error)
+	WatchMigrationStatus() state.NotifyWatcher
 }
 
 var getBackend = func(st *state.State) Backend {

--- a/apiserver/reboot/reboot.go
+++ b/apiserver/reboot/reboot.go
@@ -71,11 +71,8 @@ func (r *RebootAPI) WatchForRebootEvent() (params.NotifyWatchResult, error) {
 	var result params.NotifyWatchResult
 
 	if r.auth.AuthOwner(r.machine.Tag()) {
-		watch, err = r.machine.WatchForRebootEvent()
-		if err != nil {
-			result.Error = common.ServerError(err)
-			return result, nil
-		}
+		watch = r.machine.WatchForRebootEvent()
+		err = nil
 		// Consume the initial event. Technically, API
 		// calls to Watch 'transmit' the initial event
 		// in the Watch response. But NotifyWatchers

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -529,14 +529,14 @@ func (s *ModelMigrationSuite) TestWatchMigrationStatusPreexisting(c *gc.C) {
 
 func (s *ModelMigrationSuite) TestWatchMigrationStatusMultiModel(c *gc.C) {
 	_, wc2 := s.createStatusWatcher(c, s.State2)
-	wc2.AssertOneChange()
+	wc2.AssertOneChange() // initial event
 
 	// Create another hosted model to migrate and watch for
 	// migrations.
 	State3 := s.Factory.MakeModel(c, nil)
 	s.AddCleanup(func(*gc.C) { State3.Close() })
 	_, wc3 := s.createStatusWatcher(c, State3)
-	wc3.AssertOneChange()
+	wc3.AssertOneChange() // initial event
 
 	// Create a migration for 2.
 	mig, err := s.State2.CreateModelMigration(s.stdSpec)
@@ -663,8 +663,7 @@ func (s *ModelMigrationSuite) TestMinionReportWithInactiveMigration(c *gc.C) {
 func (s *ModelMigrationSuite) createStatusWatcher(c *gc.C, st *state.State) (
 	state.NotifyWatcher, statetesting.NotifyWatcherC,
 ) {
-	w, err := st.WatchMigrationStatus()
-	c.Assert(err, jc.ErrorIsNil)
+	w := st.WatchMigrationStatus()
 	s.AddCleanup(func(c *gc.C) { statetesting.AssertStop(c, w) })
 	return w, statetesting.NewNotifyWatcherC(c, st, w)
 }

--- a/state/reboot_test.go
+++ b/state/reboot_test.go
@@ -61,30 +61,26 @@ func (s *RebootSuite) SetUpTest(c *gc.C) {
 	}, s.machine.Id(), instance.LXC)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.w, err = s.machine.WatchForRebootEvent()
-	c.Assert(err, jc.ErrorIsNil)
+	s.w = s.machine.WatchForRebootEvent()
 
 	s.wc = statetesting.NewNotifyWatcherC(c, s.State, s.w)
 	s.wc.AssertOneChange()
 
-	s.wC1, err = s.c1.WatchForRebootEvent()
-	c.Assert(err, jc.ErrorIsNil)
+	s.wC1 = s.c1.WatchForRebootEvent()
 
 	// Initial event on container 1.
 	s.wcC1 = statetesting.NewNotifyWatcherC(c, s.State, s.wC1)
 	s.wcC1.AssertOneChange()
 
 	// Get reboot watcher on container 2
-	s.wC2, err = s.c2.WatchForRebootEvent()
-	c.Assert(err, jc.ErrorIsNil)
+	s.wC2 = s.c2.WatchForRebootEvent()
 
 	// Initial event on container 2.
 	s.wcC2 = statetesting.NewNotifyWatcherC(c, s.State, s.wC2)
 	s.wcC2.AssertOneChange()
 
 	// Get reboot watcher on container 3
-	s.wC3, err = s.c3.WatchForRebootEvent()
-	c.Assert(err, jc.ErrorIsNil)
+	s.wC3 = s.c3.WatchForRebootEvent()
 
 	// Initial event on container 3.
 	s.wcC3 = statetesting.NewNotifyWatcherC(c, s.State, s.wC3)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -446,8 +446,7 @@ func (s *MultiEnvStateSuite) TestWatchTwoEnvironments(c *gc.C) {
 				f := factory.NewFactory(st)
 				m := f.MakeMachine(c, &factory.MachineParams{})
 				c.Assert(m.Id(), gc.Equals, "0")
-				w, err := m.WatchForRebootEvent()
-				c.Assert(err, jc.ErrorIsNil)
+				w := m.WatchForRebootEvent()
 				return w
 			},
 			triggerEvent: func(st *state.State) {


### PR DESCRIPTION
The rebootWatcher, migrationStatusWatcher and cleanupWatcher were slight variations of the same watcher. The implementations have been extracted into a single notifyCollWatcher which handles all of them.

This is a precursor to a new watcher for migration minion reports which will also be based on notifyCollWatcher.

Drive-by: the unused error return on a number of Watch* methods was removed (leading to additional fallout in the apiserver).

Drive-by: removed silly collectionWatcher StringWatcher interface check. newcollectionWatcher ensure this already by returning a collectionWatcher as a StringWatcher.


(Review request: http://reviews.vapour.ws/r/5049/)