### PR TITLE
Use value, not key, in model name validation error

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -464,8 +464,8 @@ func Validate(cfg, old *Config) error {
 		}
 	}
 
-	if !names.IsValidModelName(cfg.mustString(NameKey)) {
-		return fmt.Errorf("%q is not a valid name: model names may only contain lowercase letters, digits and hyphens", NameKey)
+	if modelName := cfg.mustString(NameKey); !names.IsValidModelName(modelName) {
+		return fmt.Errorf("%q is not a valid name: model names may only contain lowercase letters, digits and hyphens", modelName)
 	}
 
 	// Check that the agent version parses ok if set explicitly; otherwise leave

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -364,28 +364,29 @@ var configTests = []configTest{
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"name": "foo/bar",
 		}),
-		err: fmt.Sprintf(modelNameErr, "name"),
+		err: fmt.Sprintf(modelNameErr, "foo/bar"),
 	}, {
 		about:       "Bad name, no backslash",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"name": "foo\\bar",
 		}),
-		err: fmt.Sprintf(modelNameErr, "name"),
+		// Double escape to keep the safe quote in the format string happy
+		err: fmt.Sprintf(modelNameErr, "foo\\\\bar"),
 	}, {
 		about:       "Bad name, no space",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"name": "foo bar",
 		}),
-		err: fmt.Sprintf(modelNameErr, "name"),
+		err: fmt.Sprintf(modelNameErr, "foo bar"),
 	}, {
 		about:       "Bad name, no capital",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"name": "fooBar",
 		}),
-		err: fmt.Sprintf(modelNameErr, "name"),
+		err: fmt.Sprintf(modelNameErr, "fooBar"),
 	}, {
 		about:       "Empty name",
 		useDefaults: config.UseDefaults,


### PR DESCRIPTION
Fixes: #1590095

(Review request: http://reviews.vapour.ws/r/5056/)