### PR TITLE
Ensure restore bootstrap params are all populated

### DIFF
--- a/cmd/juju/backups/export_test.go
+++ b/cmd/juju/backups/export_test.go
@@ -69,7 +69,7 @@ func NewRestoreCommandForTest(
 	store jujuclient.ClientStore,
 	api RestoreAPI,
 	getArchive func(string) (ArchiveReader, *params.BackupsMetadataResult, error),
-	getEnviron func(string, *params.BackupsMetadataResult) (environs.Environ, error),
+	getEnviron func(string, *params.BackupsMetadataResult) (environs.Environ, *environs.BootstrapCloudParams, error),
 ) cmd.Command {
 	c := &restoreCommand{
 		getArchiveFunc: getArchive,
@@ -81,7 +81,7 @@ func NewRestoreCommandForTest(
 			return nil
 		}}
 	if getEnviron == nil {
-		c.getEnvironFunc = func(controllerNme string, meta *params.BackupsMetadataResult) (environs.Environ, error) {
+		c.getEnvironFunc = func(controllerNme string, meta *params.BackupsMetadataResult) (environs.Environ, *environs.BootstrapCloudParams, error) {
 			return c.getEnviron(controllerNme, meta)
 		}
 	}

--- a/cmd/juju/backups/export_test.go
+++ b/cmd/juju/backups/export_test.go
@@ -69,7 +69,7 @@ func NewRestoreCommandForTest(
 	store jujuclient.ClientStore,
 	api RestoreAPI,
 	getArchive func(string) (ArchiveReader, *params.BackupsMetadataResult, error),
-	getEnviron func(string, *params.BackupsMetadataResult) (environs.Environ, *environs.BootstrapCloudParams, error),
+	getEnviron func(string, *params.BackupsMetadataResult) (environs.Environ, *restoreBootstrapParams, error),
 ) cmd.Command {
 	c := &restoreCommand{
 		getArchiveFunc: getArchive,
@@ -81,11 +81,17 @@ func NewRestoreCommandForTest(
 			return nil
 		}}
 	if getEnviron == nil {
-		c.getEnvironFunc = func(controllerNme string, meta *params.BackupsMetadataResult) (environs.Environ, *environs.BootstrapCloudParams, error) {
+		c.getEnvironFunc = func(controllerNme string, meta *params.BackupsMetadataResult) (environs.Environ, *restoreBootstrapParams, error) {
 			return c.getEnviron(controllerNme, meta)
 		}
 	}
 	c.Log = &cmd.Log{}
 	c.SetClientStore(store)
 	return modelcmd.Wrap(c)
+}
+
+func GetEnvironFunc(e environs.Environ, cloud string) func(string, *params.BackupsMetadataResult) (environs.Environ, *restoreBootstrapParams, error) {
+	return func(string, *params.BackupsMetadataResult) (environs.Environ, *restoreBootstrapParams, error) {
+		return e, &restoreBootstrapParams{CloudName: cloud}, nil
+	}
 }

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -69,18 +69,6 @@ type ProviderSchema interface {
 	Schema() environschema.Fields
 }
 
-// BootstrapCloudParams contains the parameters need to re-bootstrap a
-// controller from scratch.
-type BootstrapCloudParams struct {
-	BootstrapConfigParams
-
-	// CloudName is the name of the cloud on which to bootstrap.
-	CloudName string
-
-	// CredentialName is the name of the credentials being used.
-	CredentialName string
-}
-
 // BootstrapConfigParams contains the parameters for EnvironProvider.BootstrapConfig.
 type BootstrapConfigParams struct {
 	// Config is the base configuration for the provider. This should

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -69,6 +69,18 @@ type ProviderSchema interface {
 	Schema() environschema.Fields
 }
 
+// BootstrapCloudParams contains the parameters need to re-bootstrap a
+// controller from scratch.
+type BootstrapCloudParams struct {
+	BootstrapConfigParams
+
+	// CloudName is the name of the cloud on which to bootstrap.
+	CloudName string
+
+	// CredentialName is the name of the credentials being used.
+	CredentialName string
+}
+
 // BootstrapConfigParams contains the parameters for EnvironProvider.BootstrapConfig.
 type BootstrapConfigParams struct {
 	// Config is the base configuration for the provider. This should


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1592221

We read extra cloud information from bootstrap config when restoring.

(Review request: http://reviews.vapour.ws/r/5059/)