### PR TITLE
Add deprecated --service option to status-set hook tool

### DIFF
--- a/worker/uniter/runner/jujuc/status-set.go
+++ b/worker/uniter/runner/jujuc/status-set.go
@@ -48,6 +48,7 @@ var validStatus = []status.Status{
 
 func (c *StatusSetCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.service, "application", false, "set this status for the application to which the unit belongs if the unit is the leader")
+	f.BoolVar(&c.service, "service", false, "set this status for the application to which the unit belongs if the unit is the leader")
 }
 
 func (c *StatusSetCommand) Init(args []string) error {

--- a/worker/uniter/runner/jujuc/status-set_test.go
+++ b/worker/uniter/runner/jujuc/status-set_test.go
@@ -58,7 +58,7 @@ func (s *statusSetSuite) TestHelp(c *gc.C) {
 		"set status information\n" +
 		"\n" +
 		"Options:\n" +
-		"--application  (= false)\n" +
+		"--service, --application  (= false)\n" +
 		"    set this status for the application to which the unit belongs if the unit is the leader\n" +
 		"\n" +
 		"Details:\n" +
@@ -95,6 +95,7 @@ func (s *statusSetSuite) TestServiceStatus(c *gc.C) {
 	for i, args := range [][]string{
 		[]string{"--application", "maintenance", "doing some work"},
 		[]string{"--application", "active", ""},
+		[]string{"--service", "maintenance", "doing some work"},
 	} {
 		c.Logf("test %d: %#v", i, args)
 		hctx := s.GetStatusHookContext(c)


### PR DESCRIPTION
To allow status-set to work with existing charms, add support for --service as well as --application

(Review request: http://reviews.vapour.ws/r/5062/)