### PR TITLE
bootstrap: fixes for lxd/manual/maas

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -940,12 +940,53 @@ func (s *BootstrapSuite) TestBootstrapProviderManyCredentials(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, ambiguousCredentialError.Error())
 }
 
-func (s *BootstrapSuite) TestBootstrapProviderDetectRegions(c *gc.C) {
+func (s *BootstrapSuite) TestBootstrapProviderDetectRegionsInvalid(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
 	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "ctrl", "dummy/not-dummy")
 	c.Assert(err, gc.NotNil)
 	errMsg := strings.Replace(err.Error(), "\n", "", -1)
 	c.Assert(errMsg, gc.Matches, `region "not-dummy" in cloud "dummy" not found \(expected one of \["dummy"\]\)alternatively, try "juju update-clouds"`)
+}
+
+func (s *BootstrapSuite) TestBootstrapProviderDetectRegions(c *gc.C) {
+	resetJujuXDGDataHome(c)
+
+	var bootstrap fakeBootstrapFuncs
+	bootstrap.cloudRegionDetector = cloudRegionDetectorFunc(func() ([]cloud.Region, error) {
+		return []cloud.Region{{Name: "bruce", Endpoint: "endpoint"}}, nil
+	})
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return &bootstrap
+	})
+
+	s.patchVersionAndSeries(c, "raring")
+	coretesting.RunCommand(c, s.newBootstrapCommand(), "ctrl", "dummy")
+	c.Assert(bootstrap.args.CloudRegion, gc.Equals, "bruce")
+	c.Assert(bootstrap.args.Cloud, jc.DeepEquals, cloud.Cloud{
+		Type:      "dummy",
+		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
+		Regions:   []cloud.Region{{Name: "bruce", Endpoint: "endpoint"}},
+	})
+}
+
+func (s *BootstrapSuite) TestBootstrapProviderDetectNoRegions(c *gc.C) {
+	resetJujuXDGDataHome(c)
+
+	var bootstrap fakeBootstrapFuncs
+	bootstrap.cloudRegionDetector = cloudRegionDetectorFunc(func() ([]cloud.Region, error) {
+		return nil, errors.NotFoundf("regions")
+	})
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return &bootstrap
+	})
+
+	s.patchVersionAndSeries(c, "raring")
+	coretesting.RunCommand(c, s.newBootstrapCommand(), "ctrl", "dummy")
+	c.Assert(bootstrap.args.CloudRegion, gc.Equals, "")
+	c.Assert(bootstrap.args.Cloud, jc.DeepEquals, cloud.Cloud{
+		Type:      "dummy",
+		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
+	})
 }
 
 func (s *BootstrapSuite) TestBootstrapProviderCaseInsensitiveRegionCheck(c *gc.C) {
@@ -1196,12 +1237,23 @@ func joinBinaryVersions(versions ...[]version.Binary) []version.Binary {
 // test scenarios. This could help improve some of the tests in this
 // file which execute large amounts of external functionality.
 type fakeBootstrapFuncs struct {
-	args bootstrap.BootstrapParams
+	args                bootstrap.BootstrapParams
+	cloudRegionDetector environs.CloudRegionDetector
 }
 
 func (fake *fakeBootstrapFuncs) Bootstrap(ctx environs.BootstrapContext, env environs.Environ, args bootstrap.BootstrapParams) error {
 	fake.args = args
 	return nil
+}
+
+func (fake *fakeBootstrapFuncs) CloudRegionDetector(environs.EnvironProvider) (environs.CloudRegionDetector, bool) {
+	detector := fake.cloudRegionDetector
+	if detector == nil {
+		detector = cloudRegionDetectorFunc(func() ([]cloud.Region, error) {
+			return nil, errors.NotFoundf("regions")
+		})
+	}
+	return detector, true
 }
 
 type noCloudRegionDetectionProvider struct {
@@ -1216,6 +1268,10 @@ func (noCloudRegionsProvider) DetectRegions() ([]cloud.Region, error) {
 	return nil, errors.NotFoundf("regions")
 }
 
+func (noCloudRegionsProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
+	return nil
+}
+
 type noCredentialsProvider struct {
 	environs.EnvironProvider
 }
@@ -1226,6 +1282,10 @@ func (noCredentialsProvider) DetectRegions() ([]cloud.Region, error) {
 
 func (noCredentialsProvider) DetectCredentials() (*cloud.CloudCredential, error) {
 	return nil, errors.NotFoundf("credentials")
+}
+
+func (noCredentialsProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
+	return nil
 }
 
 type manyCredentialsProvider struct {
@@ -1242,4 +1302,14 @@ func (manyCredentialsProvider) DetectCredentials() (*cloud.CloudCredential, erro
 			"one": {}, "two": {},
 		},
 	}, nil
+}
+
+func (manyCredentialsProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
+	return map[cloud.AuthType]cloud.CredentialSchema{"one": {}, "two": {}}
+}
+
+type cloudRegionDetectorFunc func() ([]cloud.Region, error)
+
+func (c cloudRegionDetectorFunc) DetectRegions() ([]cloud.Region, error) {
+	return c()
 }


### PR DESCRIPTION
When bootstrapping, add all of the provider's
supported auth-types to the synthesized cloud
structure. Also, fix a bug where we were adding
an empty Region to the cloud definition when
no region is specified (e.g. for maas).

Drive-by: check auth on cloud facade

Fixes https://bugs.launchpad.net/juju-core/+bug/1592987
Fixes https://bugs.launchpad.net/juju-core/+bug/1592981

(Review request: http://reviews.vapour.ws/r/5072/)