### PR TITLE
core/migration: Add Phase.IsRunning

### DIFF
--- a/core/migration/phase.go
+++ b/core/migration/phase.go
@@ -76,6 +76,22 @@ func (p Phase) IsTerminal() bool {
 	return false
 }
 
+// IsRunning returns true if the phase indicates the migration is
+// active and up to or at the SUCCESS phase. It returns false if the
+// phase is one of the final cleanup phases or indicates an failed
+// migration.
+func (p Phase) IsRunning() bool {
+	if p.IsTerminal() {
+		return false
+	}
+	switch p {
+	case QUIESCE, READONLY, PRECHECK, IMPORT, VALIDATION, SUCCESS:
+		return true
+	default:
+		return false
+	}
+}
+
 // Define all possible phase transitions.
 //
 // The keys are the "from" states and the values enumerate the

--- a/core/migration/phase_test.go
+++ b/core/migration/phase_test.go
@@ -55,6 +55,22 @@ func (s *PhaseSuite) TestIsTerminal(c *gc.C) {
 	c.Check(migration.DONE.IsTerminal(), jc.IsTrue)
 }
 
+func (s *PhaseSuite) TestIsRunning(c *gc.C) {
+	c.Check(migration.UNKNOWN.IsRunning(), jc.IsFalse)
+	c.Check(migration.NONE.IsRunning(), jc.IsFalse)
+
+	c.Check(migration.QUIESCE.IsRunning(), jc.IsTrue)
+	c.Check(migration.IMPORT.IsRunning(), jc.IsTrue)
+	c.Check(migration.SUCCESS.IsRunning(), jc.IsTrue)
+
+	c.Check(migration.LOGTRANSFER.IsRunning(), jc.IsFalse)
+	c.Check(migration.REAP.IsRunning(), jc.IsFalse)
+	c.Check(migration.REAPFAILED.IsRunning(), jc.IsFalse)
+	c.Check(migration.DONE.IsRunning(), jc.IsFalse)
+	c.Check(migration.ABORT.IsRunning(), jc.IsFalse)
+	c.Check(migration.ABORTDONE.IsRunning(), jc.IsFalse)
+}
+
 func (s *PhaseSuite) TestCanTransitionTo(c *gc.C) {
 	c.Check(migration.QUIESCE.CanTransitionTo(migration.SUCCESS), jc.IsFalse)
 	c.Check(migration.QUIESCE.CanTransitionTo(migration.ABORT), jc.IsTrue)


### PR DESCRIPTION
IsRunning returns true if the phase indicates the migration is active and up to or at the SUCCESS phase. This will be used during migrations to decide whether workers should be running or not in relation to
migration activity.

(Review request: http://reviews.vapour.ws/r/5074/)