### PR TITLE
bootstrap: interpret provider/<thing> as endpoint

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -173,7 +173,18 @@ func RegionByName(regions []Region, name string) (*Region, error) {
 		}
 		return &region, nil
 	}
-	return nil, errors.NotFoundf("region %q", name)
+	return nil, errors.NewNotFound(nil, fmt.Sprintf(
+		"region %q not found (expected one of %q)",
+		name, cloudRegionNames(regions),
+	))
+}
+
+func cloudRegionNames(regions []Region) []string {
+	names := make([]string, len(regions))
+	for i, region := range regions {
+		names[i] = region.Name
+	}
+	return names
 }
 
 // JujuPublicCloudsPath is the location where public cloud information is

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -6,6 +6,7 @@ package maas
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/juju/errors"
 	"github.com/juju/gomaasapi"
@@ -57,18 +58,16 @@ func (p maasEnvironProvider) PrepareForCreateEnvironment(cfg *config.Config) (*c
 
 // BootstrapConfig is specified in the EnvironProvider interface.
 func (p maasEnvironProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
-	// For MAAS, either:
-	// 1. the endpoint from the cloud definition defines the MAAS server URL
-	//    (if a full cloud definition had been set up)
-	// 2. the region defines the MAAS server ip/host
-	//    (if the bootstrap shortcut is used)
-	server := args.CloudEndpoint
-	if server == "" && args.CloudRegion != "" {
-		server = fmt.Sprintf("http://%s/MAAS", args.CloudRegion)
-	}
-	if server == "" {
+	// For MAAS, the cloud endpoint may be either a full URL
+	// for the MAAS server, or just the IP/host.
+	if args.CloudEndpoint == "" {
 		return nil, errors.New("MAAS server not specified")
 	}
+	server := args.CloudEndpoint
+	if url, err := url.Parse(server); err != nil || url.Scheme == "" {
+		server = fmt.Sprintf("http://%s/MAAS", args.CloudEndpoint)
+	}
+
 	attrs := map[string]interface{}{
 		"maas-server": server,
 	}

--- a/provider/maas/environprovider_test.go
+++ b/provider/maas/environprovider_test.go
@@ -95,7 +95,7 @@ func (suite *EnvironProviderSuite) TestUnknownAttrsContainAgentName(c *gc.C) {
 	c.Assert(uuid, jc.Satisfies, utils.IsValidUUIDString)
 }
 
-func (suite *EnvironProviderSuite) TestMAASServerFromRegion(c *gc.C) {
+func (suite *EnvironProviderSuite) TestMAASServerFromEndpoint(c *gc.C) {
 	attrs := testing.FakeConfig().Merge(testing.Attrs{
 		"type": "maas",
 	})
@@ -103,8 +103,8 @@ func (suite *EnvironProviderSuite) TestMAASServerFromRegion(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	cfg, err := providerInstance.BootstrapConfig(environs.BootstrapConfigParams{
-		Config:      config,
-		CloudRegion: "maas.testing",
+		Config:        config,
+		CloudEndpoint: "maas.testing",
 		Credentials: cloud.NewCredential(
 			cloud.OAuth1AuthType,
 			map[string]string{

--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -52,26 +52,14 @@ func (p manualProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config
 
 // BootstrapConfig is specified in the EnvironProvider interface.
 func (p manualProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
-	var bootstrapHost string
-	switch {
-	case args.CloudEndpoint != "":
-		// If an endpoint is specified, then we expect that the user
-		// has specified in their clouds.yaml a region with the
-		// bootstrap host as the endpoint.
-		bootstrapHost = args.CloudEndpoint
-	case args.CloudRegion != "":
-		// If only a region is specified, then we expect that the user
-		// has run "juju bootstrap manual/<host>", and treat the region
-		// name as the name of the bootstrap machine.
-		bootstrapHost = args.CloudRegion
-	default:
+	if args.CloudEndpoint == "" {
 		return nil, errors.Errorf(
 			"missing address of host to bootstrap: " +
 				`please specify "juju bootstrap manual/<host>"`,
 		)
 	}
 	cfg, err := args.Config.Apply(map[string]interface{}{
-		"bootstrap-host": bootstrapHost,
+		"bootstrap-host": args.CloudEndpoint,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -47,14 +47,8 @@ func (s *providerSuite) TestPrepareForBootstrapCloudEndpointAndRegion(c *gc.C) {
 	s.CheckCall(c, 0, "InitUbuntuUser", "endpoint", "", "public auth key\n", ctx.GetStdin(), ctx.GetStdout())
 }
 
-func (s *providerSuite) TestPrepareForBootstrapCloudRegionOnly(c *gc.C) {
-	ctx, err := s.testPrepareForBootstrap(c, "", "region")
-	c.Assert(err, jc.ErrorIsNil)
-	s.CheckCall(c, 0, "InitUbuntuUser", "region", "", "public auth key\n", ctx.GetStdin(), ctx.GetStdout())
-}
-
-func (s *providerSuite) TestPrepareForBootstrapNoCloudEndpointOrRegion(c *gc.C) {
-	_, err := s.testPrepareForBootstrap(c, "", "")
+func (s *providerSuite) TestPrepareForBootstrapNoCloudEndpoint(c *gc.C) {
+	_, err := s.testPrepareForBootstrap(c, "", "region")
 	c.Assert(err, gc.ErrorMatches,
 		`missing address of host to bootstrap: please specify "juju bootstrap manual/<host>"`)
 }

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -779,7 +779,7 @@ func (s *ModelCloudValidationSuite) TestNewModelUnknownCloudRegion(c *gc.C) {
 	_, _, err := st.NewModel(state.ModelArgs{
 		Config: cfg, Owner: owner, CloudRegion: "missing-region",
 	})
-	c.Assert(err, gc.ErrorMatches, `region "missing-region" not found`)
+	c.Assert(err, gc.ErrorMatches, `region "missing-region" not found \(expected one of \["some-region"\]\)`)
 }
 
 func (s *ModelCloudValidationSuite) TestNewModelMissingCloudRegion(c *gc.C) {


### PR DESCRIPTION
When bootstrapping and specifying a cloud *type*,
e.g. "manual" or "maas", then the bit after /
will now be interpreted as the cloud endpoint
rather than as a region name. This means that
it won't show up in the controller or model
details as a region anymore, but also means
we can simplify some logic: no need to deal with
the possibility of a region that the cloud does
not support.

Fixes https://bugs.launchpad.net/juju-core/+bug/1593033

(Review request: http://reviews.vapour.ws/r/5075/)