### PR TITLE
apiserver/modelmanager: reintroduce ConfigSkeleton

### DIFF
--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -116,10 +116,15 @@ func (mm *ModelManagerAPI) newModelConfig(
 	if _, ok := joint["uuid"]; ok {
 		return nil, errors.New("uuid is generated, you cannot specify one")
 	}
-	if _, ok := joint[config.NameKey]; ok {
-		return nil, errors.New("name must not be specified in config")
+	if args.Name != "" {
+		// TODO(axw) we should always expect args.Name to be non-empty,
+		// and always fail if the name was specified in config. The
+		// GUI needs to be updated for this to work.
+		if _, ok := joint[config.NameKey]; ok {
+			return nil, errors.New("name must not be specified in config")
+		}
+		joint[config.NameKey] = args.Name
 	}
-	joint[config.NameKey] = args.Name
 
 	// Copy credential attributes across to model config.
 	// TODO(axw) credentials should not be going into model config.
@@ -145,6 +150,27 @@ func (mm *ModelManagerAPI) newModelConfig(
 		},
 	}
 	return creator.NewModelConfig(mm.isAdmin, baseConfig, joint)
+}
+
+type modelSkeletonConfigArgs struct {
+	Provider string
+	Region   string
+}
+
+// TODO(axw) drop this after beta9. The GUI needs to be updated to stop using this.
+func (mm *ModelManagerAPI) ConfigSkeleton(args modelSkeletonConfigArgs) (params.ModelConfigResult, error) {
+	var result params.ModelConfigResult
+	if args.Region != "" {
+		return result, errors.NotValidf("region value %q", args.Region)
+	}
+	cloud, err := mm.state.Cloud()
+	if err != nil {
+		return result, err
+	}
+	result.Config = params.ModelConfig{
+		config.TypeKey: cloud.Type,
+	}
+	return result, nil
 }
 
 // CreateModel creates a new model using the account and


### PR DESCRIPTION
Needed by GUI until we update it. Also, don't require Name in params.

Fixes https://bugs.launchpad.net/juju-core/+bug/1593042

(Review request: http://reviews.vapour.ws/r/5076/)