### PR TITLE
migrationminion now reports to master on SUCCESS

### DIFF
--- a/api/migrationminion/client.go
+++ b/api/migrationminion/client.go
@@ -12,17 +12,8 @@ import (
 	"github.com/juju/juju/watcher"
 )
 
-// Client describes the client side API for the MigrationMinion facade
-// (used by the migration minion worker).
-type Client interface {
-	// Watch returns a watcher which reports when the status changes
-	// for the migration for the model associated with the API
-	// connection.
-	Watch() (watcher.MigrationStatusWatcher, error)
-}
-
 // NewClient returns a new Client based on an existing API connection.
-func NewClient(caller base.APICaller) Client {
+func NewClient(caller base.APICaller) *client {
 	return &client{base.NewFacadeCaller(caller, "MigrationMinion")}
 }
 
@@ -31,7 +22,8 @@ type client struct {
 	caller base.FacadeCaller
 }
 
-// Watch implements Client.
+// Watch returns a watcher which reports when the status changes for
+// the migration for the model associated with the API connection.
 func (c *client) Watch() (watcher.MigrationStatusWatcher, error) {
 	var result params.NotifyWatchResult
 	err := c.caller.FacadeCall("Watch", nil, &result)

--- a/api/migrationminion/client.go
+++ b/api/migrationminion/client.go
@@ -9,22 +9,22 @@ import (
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/watcher"
 )
 
 // NewClient returns a new Client based on an existing API connection.
-func NewClient(caller base.APICaller) *client {
-	return &client{base.NewFacadeCaller(caller, "MigrationMinion")}
+func NewClient(caller base.APICaller) *Client {
+	return &Client{base.NewFacadeCaller(caller, "MigrationMinion")}
 }
 
-// client implements Client.
-type client struct {
+type Client struct {
 	caller base.FacadeCaller
 }
 
 // Watch returns a watcher which reports when the status changes for
 // the migration for the model associated with the API connection.
-func (c *client) Watch() (watcher.MigrationStatusWatcher, error) {
+func (c *Client) Watch() (watcher.MigrationStatusWatcher, error) {
 	var result params.NotifyWatchResult
 	err := c.caller.FacadeCall("Watch", nil, &result)
 	if err != nil {
@@ -35,4 +35,16 @@ func (c *client) Watch() (watcher.MigrationStatusWatcher, error) {
 	}
 	w := apiwatcher.NewMigrationStatusWatcher(c.caller.RawAPICaller(), result.NotifyWatcherId)
 	return w, nil
+}
+
+// Report allows a migration minion to report if it successfully
+// completed its activities for a given migration phase.
+func (c *Client) Report(migrationId string, phase migration.Phase, success bool) error {
+	args := params.MinionReport{
+		MigrationId: migrationId,
+		Phase:       phase.String(),
+		Success:     success,
+	}
+	err := c.caller.FacadeCall("Report", args, nil)
+	return errors.Trace(err)
 }

--- a/api/watcher/watcher.go
+++ b/api/watcher/watcher.go
@@ -492,6 +492,7 @@ func (w *migrationStatusWatcher) loop() error {
 			return errors.Errorf("invalid phase %q", inStatus.Phase)
 		}
 		outStatus := watcher.MigrationStatus{
+			MigrationId:    inStatus.MigrationId,
 			Attempt:        inStatus.Attempt,
 			Phase:          phase,
 			SourceAPIAddrs: inStatus.SourceAPIAddrs,

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -315,12 +315,13 @@ func (s *migrationSuite) TestMigrationStatusWatcher(c *gc.C) {
 		}
 	}
 
-	assertChange := func(phase migration.Phase) {
+	assertChange := func(id string, phase migration.Phase) {
 		s.startSync(c, hostedState)
 		select {
 		case status, ok := <-w.Changes():
 			c.Assert(ok, jc.IsTrue)
-			c.Assert(status.Phase, gc.Equals, phase)
+			c.Check(status.MigrationId, gc.Equals, id)
+			c.Check(status.Phase, gc.Equals, phase)
 		case <-time.After(coretesting.LongWait):
 			c.Fatalf("watcher didn't emit an event")
 		}
@@ -328,7 +329,7 @@ func (s *migrationSuite) TestMigrationStatusWatcher(c *gc.C) {
 	}
 
 	// Initial event with no migration in progress.
-	assertChange(migration.NONE)
+	assertChange("", migration.NONE)
 
 	// Now create a migration, should trigger watcher.
 	spec := state.ModelMigrationSpec{
@@ -343,16 +344,16 @@ func (s *migrationSuite) TestMigrationStatusWatcher(c *gc.C) {
 	}
 	mig, err := hostedState.CreateModelMigration(spec)
 	c.Assert(err, jc.ErrorIsNil)
-	assertChange(migration.QUIESCE)
+	assertChange(mig.Id(), migration.QUIESCE)
 
 	// Now abort the migration, this should be reported too.
 	c.Assert(mig.SetPhase(migration.ABORT), jc.ErrorIsNil)
-	assertChange(migration.ABORT)
+	assertChange(mig.Id(), migration.ABORT)
 	c.Assert(mig.SetPhase(migration.ABORTDONE), jc.ErrorIsNil)
-	assertChange(migration.ABORTDONE)
+	assertChange(mig.Id(), migration.ABORTDONE)
 
 	// Start a new migration, this should also trigger.
-	_, err = hostedState.CreateModelMigration(spec)
+	mig2, err := hostedState.CreateModelMigration(spec)
 	c.Assert(err, jc.ErrorIsNil)
-	assertChange(migration.QUIESCE)
+	assertChange(mig2.Id(), migration.QUIESCE)
 }

--- a/watcher/migrationstatus.go
+++ b/watcher/migrationstatus.go
@@ -8,6 +8,7 @@ import "github.com/juju/juju/core/migration"
 // MigrationStatus is the client side version of
 // params.MigrationStatus.
 type MigrationStatus struct {
+	MigrationId    string
 	Attempt        int
 	Phase          migration.Phase
 	SourceAPIAddrs []string


### PR DESCRIPTION
The migrationminion now reports to the master when it has processed the SUCCESS phase. The master will wait for reports from all minions before moving on to the next phase. 

To support this the Report API was added to the the migrationminion client facade and the migration id was added to the migration status watcher (the id is required in order to make a report).

This change also cleans up handling of phases which aren't interesting to the migration minion. The Guard (aka Fortress) gets unlocked for all such phases. Some unimplemented and untested handling for QUIESCE and VALIDATION have also been removed.

Drive-by: Remove unnecessary and unused interface in api/migrationminion


(Review request: http://reviews.vapour.ws/r/5077/)