### PR TITLE
provider/dummy: do not close previous ops listener

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -202,7 +202,9 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 		return restore
 	}
 
-	opBootstrap := (<-opc).(dummy.OpBootstrap)
+	op, ok := <-opc
+	c.Assert(ok, gc.Equals, true)
+	opBootstrap := op.(dummy.OpBootstrap)
 	c.Check(opBootstrap.Env, gc.Equals, environs.ControllerModelName)
 	c.Check(opBootstrap.Args.ModelConstraints, gc.DeepEquals, test.constraints)
 	if test.bootstrapConstraints == (constraints.Value{}) {

--- a/cmd/testing/testing.go
+++ b/cmd/testing/testing.go
@@ -69,17 +69,21 @@ func RunCommand(ctx *cmd.Context, com cmd.Command, args ...string) (opc chan dum
 	opc = make(chan dummy.Operation, 200)
 	dummy.Listen(opc)
 	go func() {
-		// signal that we're done with this ops channel.
-		defer dummy.Listen(nil)
+		defer func() {
+			// signal that we're done with this ops channel.
+			dummy.Listen(nil)
+			// now that dummy is no longer going to send ops on
+			// this channel, close it to signal to test cases
+			// that we are done.
+			close(opc)
+		}()
 
-		err := coretesting.InitCommand(com, args)
-		if err != nil {
+		if err := coretesting.InitCommand(com, args); err != nil {
 			errc <- err
 			return
 		}
 
-		err = com.Run(ctx)
-		errc <- err
+		errc <- com.Run(ctx)
 	}()
 	return
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -398,17 +398,13 @@ func SetSupportsSpaceDiscovery(supports bool) bool {
 	return current
 }
 
-// Listen closes the previously registered listener (if any).
-// Subsequent operations on any dummy environment can be received on c
-// (if not nil).
+// Listen directs subsequent operations on any dummy environment
+// to channel c (if not nil).
 func Listen(c chan<- Operation) {
 	dummy.mu.Lock()
 	defer dummy.mu.Unlock()
 	if c == nil {
 		c = discardOperations
-	}
-	if dummy.ops != discardOperations {
-		close(dummy.ops)
 	}
 	dummy.ops = c
 	for _, st := range dummy.state {


### PR DESCRIPTION
Fixes LP 1588143

This PR removes the logic inside dummy.Listen that closes the previous
ops listener channel when being _replaced_. By not closing we avoid the
race condition with another goroutine which is trying to send a final
ops message. This change had no effect on the test cases and passes all
my stress tests.

Therefore this test not only fixes the bug, but increases test coverage :)

(Review request: http://reviews.vapour.ws/r/5078/)