### PR TITLE
Add get-model-defaults command

### DIFF
--- a/api/common/modelwatcher.go
+++ b/api/common/modelwatcher.go
@@ -56,5 +56,5 @@ func (e *ModelWatcher) ControllerConfig() (controller.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	return controller.Config(result.Config), nil
+	return controller.Config(result.ControllerConfig), nil
 }

--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -63,7 +63,15 @@ func (c *Client) ModelConfig() (map[string]interface{}, error) {
 func (c *Client) ControllerConfig() (map[string]interface{}, error) {
 	result := params.ControllerConfigResult{}
 	err := c.facade.FacadeCall("ControllerConfig", nil, &result)
-	return result.Config, err
+	return result.ControllerConfig, err
+}
+
+// DefaultModelConfig returns default settings shared by
+// all hosted models.
+func (c *Client) DefaultModelConfig() (map[string]interface{}, error) {
+	result := params.ControllerConfigResult{}
+	err := c.facade.FacadeCall("DefaultModelConfig", nil, &result)
+	return result.DefaultModelConfig, err
 }
 
 // DestroyController puts the controller model into a "dying" state,

--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -32,6 +32,7 @@ type controllerSuite struct {
 var _ = gc.Suite(&controllerSuite{})
 
 func (s *controllerSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.ModelDefaultAttrs = map[string]interface{}{"apt-mirror": "http://mirror"}
 	s.JujuConnSuite.SetUpTest(c)
 }
 
@@ -79,6 +80,16 @@ func (s *controllerSuite) TestControllerConfig(c *gc.C) {
 	c.Assert(cfg["controller-uuid"], gc.Equals, cfgFromDB.ControllerUUID())
 	c.Assert(int(cfg["state-port"].(float64)), gc.Equals, cfgFromDB.StatePort())
 	c.Assert(int(cfg["api-port"].(float64)), gc.Equals, cfgFromDB.APIPort())
+}
+
+func (s *controllerSuite) TestDefaultModelConfig(c *gc.C) {
+	sysManager := s.OpenAPI(c)
+	cfg, err := sysManager.DefaultModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	cfgFromDB, err := s.State.ModelConfigDefaults()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg["apt-mirror"], gc.Equals, "http://mirror")
+	c.Assert(cfg["apt-mirror"], gc.Equals, cfgFromDB["apt-mirror"])
 }
 
 func (s *controllerSuite) TestDestroyController(c *gc.C) {

--- a/apiserver/common/modelwatcher.go
+++ b/apiserver/common/modelwatcher.go
@@ -90,6 +90,6 @@ func (m *ModelWatcher) ControllerConfig() (params.ControllerConfigResult, error)
 	if err != nil {
 		return result, err
 	}
-	result.Config = params.ControllerConfig(config)
+	result.ControllerConfig = params.ControllerConfig(config)
 	return result, nil
 }

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -206,7 +206,19 @@ func (s *ControllerAPI) ControllerConfig() (params.ControllerConfigResult, error
 	if err != nil {
 		return result, err
 	}
-	result.Config = params.ControllerConfig(config)
+	result.ControllerConfig = params.ControllerConfig(config)
+	return result, nil
+}
+
+// DefaultModelConfig returns the shared configuration defaults
+// for all hosted models.
+func (s *ControllerAPI) DefaultModelConfig() (params.ControllerConfigResult, error) {
+	result := params.ControllerConfigResult{}
+	config, err := s.state.ModelConfigDefaults()
+	if err != nil {
+		return result, err
+	}
+	result.DefaultModelConfig = config
 	return result, nil
 }
 

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -35,6 +35,7 @@ type controllerSuite struct {
 var _ = gc.Suite(&controllerSuite{})
 
 func (s *controllerSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.ModelDefaultAttrs = map[string]interface{}{"apt-mirror": "http://mirror"}
 	s.JujuConnSuite.SetUpTest(c)
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
@@ -172,9 +173,18 @@ func (s *controllerSuite) TestControllerConfig(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	cfgFromDB, err := s.State.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg.Config["controller-uuid"], gc.Equals, cfgFromDB.ControllerUUID())
-	c.Assert(cfg.Config["state-port"], gc.Equals, cfgFromDB.StatePort())
-	c.Assert(cfg.Config["api-port"], gc.Equals, cfgFromDB.APIPort())
+	c.Assert(cfg.ControllerConfig["controller-uuid"], gc.Equals, cfgFromDB.ControllerUUID())
+	c.Assert(cfg.ControllerConfig["state-port"], gc.Equals, cfgFromDB.StatePort())
+	c.Assert(cfg.ControllerConfig["api-port"], gc.Equals, cfgFromDB.APIPort())
+}
+
+func (s *controllerSuite) TestDefaultModelConfig(c *gc.C) {
+	cfg, err := s.controller.DefaultModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	cfgFromDB, err := s.State.ModelConfigDefaults()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.DefaultModelConfig["apt-mirror"], gc.Equals, "http://mirror")
+	c.Assert(cfg.DefaultModelConfig["apt-mirror"], gc.Equals, cfgFromDB["apt-mirror"])
 }
 
 func (s *controllerSuite) TestControllerConfigFromNonController(c *gc.C) {
@@ -189,9 +199,9 @@ func (s *controllerSuite) TestControllerConfigFromNonController(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	cfgFromDB, err := s.State.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg.Config["controller-uuid"], gc.Equals, cfgFromDB.ControllerUUID())
-	c.Assert(cfg.Config["state-port"], gc.Equals, cfgFromDB.StatePort())
-	c.Assert(cfg.Config["api-port"], gc.Equals, cfgFromDB.APIPort())
+	c.Assert(cfg.ControllerConfig["controller-uuid"], gc.Equals, cfgFromDB.ControllerUUID())
+	c.Assert(cfg.ControllerConfig["state-port"], gc.Equals, cfgFromDB.StatePort())
+	c.Assert(cfg.ControllerConfig["api-port"], gc.Equals, cfgFromDB.APIPort())
 }
 
 func (s *controllerSuite) TestRemoveBlocks(c *gc.C) {

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -224,6 +224,9 @@ type ModelConfig map[string]interface{}
 // ControllerConfig holds a controller configuration.
 type ControllerConfig map[string]interface{}
 
+// DefaultModelConfig holds default configuration for models.
+type DefaultModelConfig map[string]interface{}
+
 // ModelConfigResult holds model configuration.
 type ModelConfigResult struct {
 	Config ModelConfig
@@ -231,7 +234,8 @@ type ModelConfigResult struct {
 
 // ControllerConfigResult holds controller configuration.
 type ControllerConfigResult struct {
-	Config ControllerConfig
+	ControllerConfig   ControllerConfig   `json:"controller-config,omitempty"`
+	DefaultModelConfig DefaultModelConfig `json:"default-model-config,omitempty"`
 }
 
 // RelationUnit holds a relation and a unit tag.

--- a/apiserver/read_only_calls.go
+++ b/apiserver/read_only_calls.go
@@ -48,7 +48,9 @@ var readOnlyCalls = set.NewStrings(
 	"Client.WatchAll",
 	"Cloud.Cloud",
 	"Cloud.Credentials",
-	// TODO: add controller work.
+	// TODO(thumper): add all controller work.
+	"Controller.ControllerConfig",
+	"Controller.DefaultModelConfig",
 	"KeyManager.ListKeys",
 	"ModelManager.ModelInfo",
 	"Spaces.ListSpaces",

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -364,6 +364,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(controller.NewRemoveBlocksCommand())
 	r.Register(controller.NewShowControllerCommand())
 	r.Register(controller.NewGetConfigCommand())
+	r.Register(controller.NewGetSharedConfigCommand())
 
 	// Debug Metrics
 	r.Register(metricsdebug.New())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -406,6 +406,7 @@ var commandNames = []string{
 	"get-controller-config",
 	"get-model-config",
 	"get-model-constraints",
+	"get-model-defaults",
 	"grant",
 	"gui",
 	"help",

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -138,8 +138,16 @@ func NewListBlocksCommandForTest(api listBlocksAPI, apierr error, store jujuclie
 
 // NewGetConfigCommandCommandForTest returns a GetConfigCommandCommand with
 // the api provided as specified.
-func NewGetConfigCommandForTest(api controllerAPI, store jujuclient.ClientStore) cmd.Command {
+func NewGetConfigCommandForTest(api controllerConfigAPI, store jujuclient.ClientStore) cmd.Command {
 	c := &getConfigCommand{api: api}
+	c.SetClientStore(store)
+	return modelcmd.WrapController(c)
+}
+
+// NewGetSharedConfigCommandForTest returns a GetSharedConfigCommandCommand with
+// the api provided as specified.
+func NewGetSharedConfigCommandForTest(api controllerSharedConfigAPI, store jujuclient.ClientStore) cmd.Command {
+	c := &getSharedConfigCommand{api: api}
 	c.SetClientStore(store)
 	return modelcmd.WrapController(c)
 }

--- a/cmd/juju/controller/getconfig.go
+++ b/cmd/juju/controller/getconfig.go
@@ -23,7 +23,7 @@ func NewGetConfigCommand() cmd.Command {
 // the requested value in a format of the user's choosing.
 type getConfigCommand struct {
 	modelcmd.ControllerCommandBase
-	api controllerAPI
+	api controllerConfigAPI
 	key string
 	out cmd.Output
 }
@@ -59,12 +59,12 @@ func (c *getConfigCommand) Init(args []string) (err error) {
 	return
 }
 
-type controllerAPI interface {
+type controllerConfigAPI interface {
 	Close() error
 	ControllerConfig() (map[string]interface{}, error)
 }
 
-func (c *getConfigCommand) getAPI() (controllerAPI, error) {
+func (c *getConfigCommand) getAPI() (controllerConfigAPI, error) {
 	if c.api != nil {
 		return c.api, nil
 	}

--- a/cmd/juju/controller/getsharedconfig.go
+++ b/cmd/juju/controller/getsharedconfig.go
@@ -1,0 +1,102 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/cmd"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/errors"
+	apicontroller "github.com/juju/juju/api/controller"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+func NewGetSharedConfigCommand() cmd.Command {
+	return modelcmd.WrapController(&getSharedConfigCommand{})
+}
+
+// getSharedConfigCommand is able to output either the entire default
+// model config settings or the requested value in a format of the
+// user's choosing.
+type getSharedConfigCommand struct {
+	modelcmd.ControllerCommandBase
+	api controllerSharedConfigAPI
+	key string
+	out cmd.Output
+}
+
+const getSharedConfigHelpDoc = `
+By default, all configuration (keys and values) used as the
+defaults for all models are displayed if a key is not specified.
+
+Examples:
+
+    juju get-model-defaults
+    juju get-model-defaults apt-mirror
+    juju get-model-defaults -c mycontroller
+
+See also:
+    set-model-defaults
+    unset-model-defaults
+    get-model-config
+`
+
+func (c *getSharedConfigCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "get-model-defaults",
+		Args:    "[<attribute key>]",
+		Purpose: "Displays default configuration settings for a controller's hosted models.",
+		Doc:     strings.TrimSpace(getSharedConfigHelpDoc),
+	}
+}
+
+func (c *getSharedConfigCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+}
+
+func (c *getSharedConfigCommand) Init(args []string) (err error) {
+	c.key, err = cmd.ZeroOrOneArgs(args)
+	return
+}
+
+type controllerSharedConfigAPI interface {
+	Close() error
+	DefaultModelConfig() (map[string]interface{}, error)
+}
+
+func (c *getSharedConfigCommand) getAPI() (controllerSharedConfigAPI, error) {
+	if c.api != nil {
+		return c.api, nil
+	}
+	root, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return apicontroller.NewClient(root), nil
+}
+
+func (c *getSharedConfigCommand) Run(ctx *cmd.Context) error {
+	client, err := c.getAPI()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	attrs, err := client.DefaultModelConfig()
+	if err != nil {
+		return err
+	}
+
+	if c.key != "" {
+		if value, found := attrs[c.key]; found {
+			return c.out.Write(ctx, value)
+		}
+		return fmt.Errorf("key %q not found in %q default model settings.", c.key, c.ControllerName())
+	}
+	// If key is empty, write out the whole lot.
+	return c.out.Write(ctx, attrs)
+}

--- a/cmd/juju/controller/getsharedconfig_test.go
+++ b/cmd/juju/controller/getsharedconfig_test.go
@@ -1,0 +1,95 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller_test
+
+import (
+	"strings"
+
+	"github.com/juju/cmd"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/cmd/juju/controller"
+	"github.com/juju/juju/testing"
+)
+
+type GetSharedConfigSuite struct {
+	baseControllerSuite
+}
+
+var _ = gc.Suite(&GetSharedConfigSuite{})
+
+func (s *GetSharedConfigSuite) SetUpTest(c *gc.C) {
+	s.baseControllerSuite.SetUpTest(c)
+	s.createTestClientStore(c)
+}
+
+func (s *GetSharedConfigSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
+	command := controller.NewGetSharedConfigCommandForTest(&fakeControllerAPI{}, s.store)
+	return testing.RunCommand(c, command, args...)
+}
+
+func (s *GetSharedConfigSuite) TestInit(c *gc.C) {
+	// zero or one args is fine.
+	err := testing.InitCommand(controller.NewGetSharedConfigCommandForTest(&fakeControllerAPI{}, s.store), nil)
+	c.Check(err, jc.ErrorIsNil)
+	err = testing.InitCommand(controller.NewGetSharedConfigCommandForTest(&fakeControllerAPI{}, s.store), []string{"one"})
+	c.Check(err, jc.ErrorIsNil)
+	// More than one is not allowed.
+	err = testing.InitCommand(controller.NewGetSharedConfigCommandForTest(&fakeControllerAPI{}, s.store), []string{"one", "two"})
+	c.Check(err, gc.ErrorMatches, `unrecognized args: \["two"\]`)
+}
+
+func (s *GetSharedConfigSuite) TestSingleValue(c *gc.C) {
+	context, err := s.run(c, "apt-mirror")
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(testing.Stdout(context))
+	c.Assert(output, gc.Equals, "http://mirror")
+}
+
+func (s *GetSharedConfigSuite) TestSingleValueJSON(c *gc.C) {
+	context, err := s.run(c, "--format=json", "apt-mirror")
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(testing.Stdout(context))
+	c.Assert(output, gc.Equals, `"http://mirror"`)
+}
+
+func (s *GetSharedConfigSuite) TestAllValues(c *gc.C) {
+	context, err := s.run(c)
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(testing.Stdout(context))
+	expected := "" +
+		"apt-mirror: http://mirror\n" +
+		"http-proxy: http://proxy"
+	c.Assert(output, gc.Equals, expected)
+}
+
+func (s *GetSharedConfigSuite) TestAllValuesJSON(c *gc.C) {
+	context, err := s.run(c, "--format=json")
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(testing.Stdout(context))
+	expected := `{"apt-mirror":"http://mirror","http-proxy":"http://proxy"}`
+	c.Assert(output, gc.Equals, expected)
+}
+
+func (s *GetSharedConfigSuite) TestError(c *gc.C) {
+	command := controller.NewGetSharedConfigCommandForTest(&fakeControllerAPI{err: errors.New("error")}, s.store)
+	_, err := testing.RunCommand(c, command)
+	c.Assert(err, gc.ErrorMatches, "error")
+}
+
+func (f *fakeControllerAPI) DefaultModelConfig() (map[string]interface{}, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return map[string]interface{}{
+		"apt-mirror": "http://mirror",
+		"http-proxy": "http://proxy",
+	}, nil
+}

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -71,6 +71,11 @@ type JujuConnSuite struct {
 	// added to the suite's environment configuration.
 	ConfigAttrs map[string]interface{}
 
+	// ModelConfigAttrs can be set up before SetUpTest
+	// is invoked. Any attributes set here will be
+	// added to the suite's default model configuration.
+	ModelDefaultAttrs map[string]interface{}
+
 	// TODO: JujuConnSuite should not be concerned both with JUJU_DATA and with
 	// /var/lib/juju: the use cases are completely non-overlapping, and any tests that
 	// really do need both to exist ought to be embedding distinct fixtures for the
@@ -294,8 +299,13 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	s.DefaultToolsStorage = stor
 
 	s.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
+	defaultConfig := make(map[string]interface{})
+	for attr, val := range s.ModelDefaultAttrs {
+		defaultConfig[attr] = val
+	}
 	err = bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), environ, bootstrap.BootstrapParams{
-		CloudName: "dummy",
+		ModelConfigDefaults: defaultConfig,
+		CloudName:           "dummy",
 		Cloud: cloud.Cloud{
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -739,12 +739,13 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 					CloudRegion:     icfg.Bootstrap.ControllerCloudRegion,
 					CloudCredential: icfg.Bootstrap.ControllerCloudCredentialName,
 				},
-				Cloud:            icfg.Bootstrap.ControllerCloud,
-				CloudName:        icfg.Bootstrap.ControllerCloudName,
-				CloudCredentials: cloudCredentials,
-				MongoInfo:        info,
-				MongoDialOpts:    mongotest.DialOpts(),
-				Policy:           estate.statePolicy,
+				Cloud:               icfg.Bootstrap.ControllerCloud,
+				CloudName:           icfg.Bootstrap.ControllerCloudName,
+				CloudCredentials:    cloudCredentials,
+				MongoInfo:           info,
+				MongoDialOpts:       mongotest.DialOpts(),
+				Policy:              estate.statePolicy,
+				ModelConfigDefaults: icfg.Bootstrap.ModelConfigDefaults,
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
Add a new command: get-model-defaults
This works similarly to get-model-config and get-controller-config.
It lists the shared config that is used across models.

(Review request: http://reviews.vapour.ws/r/5079/)