### PR TITLE
Fixes lp#1576003: Double default bootstrap timeout for maas.

### DIFF
--- a/provider/maas/config.go
+++ b/provider/maas/config.go
@@ -87,8 +87,6 @@ func (maasEnvironProvider) Schema() environschema.Fields {
 
 var errMalformedMaasOAuth = errors.New("malformed maas-oauth (3 items separated by colons)")
 
-var minBootstrapTimeout = config.DefaultBootstrapSSHTimeout * 2
-
 func (prov maasEnvironProvider) Validate(cfg, oldCfg *config.Config) (*config.Config, error) {
 	// Validate base configuration change before validating MAAS specifics.
 	err := config.Validate(cfg, oldCfg)
@@ -109,8 +107,12 @@ func (prov maasEnvironProvider) Validate(cfg, oldCfg *config.Config) (*config.Co
 		providerDefaults[config.StorageDefaultBlockSourceKey] = maasStorageProviderType
 	}
 
-	// MAAS bootstrap timeout default should be marginally longer than commonly specified provider default.
-	providerDefaults["bootstrap-timeout"] = minBootstrapTimeout
+	// If user has not psecified bootstrap timeout,
+	// set provider default setting.
+	// MAAS bootstrap timeout default should be longer than standard timeout.
+	if _, ok := cfg.AllAttrs()["bootstrap-timeout"]; !ok {
+		providerDefaults["bootstrap-timeout"] = config.DefaultBootstrapSSHTimeout * 2
+	}
 
 	if len(providerDefaults) > 0 {
 		if cfg, err = cfg.Apply(providerDefaults); err != nil {

--- a/provider/maas/config.go
+++ b/provider/maas/config.go
@@ -108,6 +108,10 @@ func (prov maasEnvironProvider) Validate(cfg, oldCfg *config.Config) (*config.Co
 	if _, ok := cfg.StorageDefaultBlockSource(); !ok {
 		providerDefaults[config.StorageDefaultBlockSourceKey] = maasStorageProviderType
 	}
+
+	// MAAS bootstrap timeout default should be marginally longer than commonly specified provider default.
+	providerDefaults["bootstrap-timeout"] = minBootstrapTimeout
+
 	if len(providerDefaults) > 0 {
 		if cfg, err = cfg.Apply(providerDefaults); err != nil {
 			return nil, err
@@ -141,9 +145,6 @@ func (prov maasEnvironProvider) Validate(cfg, oldCfg *config.Config) (*config.Co
 	if strings.Count(oauth, ":") != 2 {
 		return nil, errMalformedMaasOAuth
 	}
-
-	// MAAS bootstrap needs more time to complete.
-	envCfg.attrs["bootstrap-timeout"] = minBootstrapTimeout
 
 	return cfg.Apply(envCfg.attrs)
 }

--- a/provider/maas/config.go
+++ b/provider/maas/config.go
@@ -87,6 +87,8 @@ func (maasEnvironProvider) Schema() environschema.Fields {
 
 var errMalformedMaasOAuth = errors.New("malformed maas-oauth (3 items separated by colons)")
 
+var minBootstrapTimeout = config.DefaultBootstrapSSHTimeout * 2
+
 func (prov maasEnvironProvider) Validate(cfg, oldCfg *config.Config) (*config.Config, error) {
 	// Validate base configuration change before validating MAAS specifics.
 	err := config.Validate(cfg, oldCfg)
@@ -139,5 +141,9 @@ func (prov maasEnvironProvider) Validate(cfg, oldCfg *config.Config) (*config.Co
 	if strings.Count(oauth, ":") != 2 {
 		return nil, errMalformedMaasOAuth
 	}
+
+	// MAAS bootstrap needs more time to complete.
+	envCfg.attrs["bootstrap-timeout"] = minBootstrapTimeout
+
 	return cfg.Apply(envCfg.attrs)
 }

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -71,7 +71,7 @@ func getSimpleTestConfig(c *gc.C, extraAttrs coretesting.Attrs) *config.Config {
 	attrs["type"] = "maas"
 	attrs["maas-server"] = "http://maas.testing.invalid"
 	attrs["maas-oauth"] = "a:b:c"
-	attrs["bootstrap-timeout"] = maas.MinBootstrapTimeout
+	attrs["bootstrap-timeout"] = "1200"
 	for k, v := range extraAttrs {
 		attrs[k] = v
 	}
@@ -145,7 +145,7 @@ func (*environSuite) TestSetConfigAllowsEmptyFromNilAgentName(c *gc.C) {
 	// These are attrs we need to make it a valid Config, but would usually
 	// be set by other infrastructure
 	attrs["type"] = "maas"
-	attrs["bootstrap-timeout"] = maas.MinBootstrapTimeout
+	attrs["bootstrap-timeout"] = "1200"
 	nilCfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 	validatedConfig, err := provider.Validate(baseCfg, nilCfg)

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -5,6 +5,7 @@ package maas_test
 
 import (
 	stdtesting "testing"
+	"time"
 
 	"github.com/juju/gomaasapi"
 	jc "github.com/juju/testing/checkers"
@@ -165,6 +166,60 @@ func (*environSuite) TestDestroyWithEmptyAgentName(c *gc.C) {
 
 	err = env.Destroy()
 	c.Assert(err, gc.ErrorMatches, "unsafe destruction")
+}
+
+func (*environSuite) TestProviderDefaultBootstrapTimeoutSet(c *gc.C) {
+	attrs := coretesting.FakeConfig()
+	attrs["type"] = "maas"
+	attrs["maas-server"] = "http://maas.testing.invalid"
+	attrs["maas-oauth"] = "a:b:c"
+	attrs["maas-agent-name"] = ""
+	cfg, err := config.New(config.NoDefaults, attrs)
+	c.Assert(err, jc.ErrorIsNil)
+
+	env, err := maas.NewEnviron(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	envConfig := env.Config()
+	c.Assert(envConfig.BootstrapSSHOpts().Timeout, gc.Equals, time.Duration(config.DefaultBootstrapSSHTimeout*2)*time.Second)
+}
+
+func (*environSuite) TestUserSpecifiedBootstrapTimeoutOverridesProviderDefault(c *gc.C) {
+	expectedTimeout := 2400
+
+	attrs := coretesting.FakeConfig()
+	attrs["type"] = "maas"
+	attrs["maas-server"] = "http://maas.testing.invalid"
+	attrs["maas-oauth"] = "a:b:c"
+	attrs["maas-agent-name"] = ""
+	attrs["bootstrap-timeout"] = expectedTimeout
+	cfg, err := config.New(config.NoDefaults, attrs)
+	c.Assert(err, jc.ErrorIsNil)
+
+	env, err := maas.NewEnviron(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	envConfig := env.Config()
+	c.Assert(envConfig.BootstrapSSHOpts().Timeout, gc.Equals, time.Duration(expectedTimeout)*time.Second)
+}
+
+func (*environSuite) TestUserSpecifiedBootstrapTimeoutLessThanProviderDefault(c *gc.C) {
+	expectedTimeout := 600
+
+	attrs := coretesting.FakeConfig()
+	attrs["type"] = "maas"
+	attrs["maas-server"] = "http://maas.testing.invalid"
+	attrs["maas-oauth"] = "a:b:c"
+	attrs["maas-agent-name"] = ""
+	attrs["bootstrap-timeout"] = expectedTimeout
+	cfg, err := config.New(config.NoDefaults, attrs)
+	c.Assert(err, jc.ErrorIsNil)
+
+	env, err := maas.NewEnviron(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	envConfig := env.Config()
+	c.Assert(envConfig.BootstrapSSHOpts().Timeout, gc.Equals, time.Duration(expectedTimeout)*time.Second)
 }
 
 func (*environSuite) TestSetConfigAllowsChangingNilAgentNameToEmptyString(c *gc.C) {

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -71,6 +71,7 @@ func getSimpleTestConfig(c *gc.C, extraAttrs coretesting.Attrs) *config.Config {
 	attrs["type"] = "maas"
 	attrs["maas-server"] = "http://maas.testing.invalid"
 	attrs["maas-oauth"] = "a:b:c"
+	attrs["bootstrap-timeout"] = maas.MinBootstrapTimeout
 	for k, v := range extraAttrs {
 		attrs[k] = v
 	}
@@ -144,6 +145,7 @@ func (*environSuite) TestSetConfigAllowsEmptyFromNilAgentName(c *gc.C) {
 	// These are attrs we need to make it a valid Config, but would usually
 	// be set by other infrastructure
 	attrs["type"] = "maas"
+	attrs["bootstrap-timeout"] = maas.MinBootstrapTimeout
 	nilCfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 	validatedConfig, err := provider.Validate(baseCfg, nilCfg)

--- a/provider/maas/export_test.go
+++ b/provider/maas/export_test.go
@@ -13,6 +13,7 @@ import (
 var (
 	ShortAttempt            = &shortAttempt
 	MaasStorageProviderType = maasStorageProviderType
+	MinBootstrapTimeout     = minBootstrapTimeout
 )
 
 func MAASAgentName(env environs.Environ) string {

--- a/provider/maas/export_test.go
+++ b/provider/maas/export_test.go
@@ -11,9 +11,7 @@ import (
 )
 
 var (
-	ShortAttempt            = &shortAttempt
-	MaasStorageProviderType = maasStorageProviderType
-	MinBootstrapTimeout     = minBootstrapTimeout
+	ShortAttempt = &shortAttempt
 )
 
 func MAASAgentName(env environs.Environ) string {

--- a/provider/maas/init_test.go
+++ b/provider/maas/init_test.go
@@ -7,7 +7,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/provider/maas"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/provider/registry"
 	"github.com/juju/juju/testing"
@@ -20,14 +19,14 @@ type maasProviderSuite struct {
 var _ = gc.Suite(&maasProviderSuite{})
 
 func (*maasProviderSuite) TestMAASProviderRegistered(c *gc.C) {
-	p, err := registry.StorageProvider(maas.MaasStorageProviderType)
+	p, err := registry.StorageProvider(storage.ProviderType("maas"))
 	c.Assert(err, jc.ErrorIsNil)
 	_, ok := p.(storage.Provider)
 	c.Assert(ok, jc.IsTrue)
 }
 
 func (*maasProviderSuite) TestSupportedProviders(c *gc.C) {
-	supported := []storage.ProviderType{maas.MaasStorageProviderType}
+	supported := []storage.ProviderType{storage.ProviderType("maas")}
 	for _, providerType := range supported {
 		ok := registry.IsProviderSupported("maas", providerType)
 		c.Assert(ok, jc.IsTrue)


### PR DESCRIPTION
Bootstrap-timeout is a duration that is highly provider specific.

We do well with common timeout defaults on all providers except for MAAS. Juju users bootstraping on MAAS have to overwrite default time in configuration for each controller deployment. More details in the bug.

This PR improves user experience with Juju on MAAS.

(Review request: http://reviews.vapour.ws/r/5082/)