### PR TITLE
apiserver: include metrics information on Client.CharmInfo response.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -190,6 +190,7 @@ type CharmInfo struct {
 	Config   *charm.Config
 	Meta     *charm.Meta
 	Actions  *charm.Actions
+	Metrics  *charm.Metrics `json:"Metrics,omitempty"`
 }
 
 // CharmInfo returns information about the requested charm.

--- a/apiserver/charms/client.go
+++ b/apiserver/charms/client.go
@@ -69,6 +69,10 @@ func (a *API) CharmInfo(args params.CharmInfo) (api.CharmInfo, error) {
 		Meta:     aCharm.Meta(),
 		Actions:  aCharm.Actions(),
 	}
+	metrics := aCharm.Metrics()
+	if metrics != nil && len(metrics.Metrics) > 0 {
+		info.Metrics = metrics
+	}
 	return info, nil
 }
 

--- a/apiserver/charms/client_test.go
+++ b/apiserver/charms/client_test.go
@@ -132,6 +132,17 @@ func (s *baseCharmsSuite) TestClientCharmInfo(c *gc.C) {
 		c.Check(info.Actions, jc.DeepEquals, t.expectedActions)
 	}
 }
+
+func (s *charmsSuite) TestMeteredCharmInfo(c *gc.C) {
+	meteredCharm := s.Factory.MakeCharm(
+		c, &factory.CharmParams{Name: "metered", URL: "cs:xenial/metered"})
+	info, err := s.api.CharmInfo(params.CharmInfo{
+		CharmURL: meteredCharm.URL().String(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info.Metrics, jc.DeepEquals, meteredCharm.Metrics())
+}
+
 func (s *charmsSuite) TestListCharmsNoFilter(c *gc.C) {
 	s.assertListCharms(c, []string{"dummy"}, []string{}, []string{"local:quantal/dummy-1"})
 }


### PR DESCRIPTION


(Review request: http://reviews.vapour.ws/r/5083/)