### PR TITLE
Fixes lp:1576674 and lp:1590689

### DIFF
--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -309,11 +309,6 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 		InterfaceName: "eth1.69",
 		IsVirtual:     true,
 	}, {
-		MACAddress:    "aa:bb:cc:dd:ee:f1", // duplicated mac+net; ignored
-		NetworkTag:    "network-vlan42",
-		InterfaceName: "eth2",
-		IsVirtual:     true,
-	}, {
 		MACAddress:    "aa:bb:cc:dd:ee:f4",
 		NetworkTag:    "network-net1",
 		InterfaceName: "eth1", // duplicated name+machine id; ignored

--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -10,17 +10,18 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"strings"
-	"text/template"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/proxy"
+	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/cloudconfig"
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/common"
 )
@@ -57,30 +58,6 @@ func WriteCloudInitFile(directory string, userData []byte) (string, error) {
 	return userDataFilename, nil
 }
 
-// networkConfigTemplate defines how to render /etc/network/interfaces
-// file for a container with one or more NICs.
-const networkConfigTemplate = `
-# loopback interface
-auto lo
-iface lo inet loopback{{define "static"}}
-{{.InterfaceName | printf "# interface %q"}}{{if not .NoAutoStart}}
-auto {{.InterfaceName}}{{end}}
-iface {{.InterfaceName}} inet manual{{if gt (len .DNSServers) 0}}
-    dns-nameservers{{range $dns := .DNSServers}} {{$dns.Value}}{{end}}{{end}}{{if gt (len .DNSSearch) 0}}
-    dns-search {{.DNSSearch}}{{end}}
-    pre-up ip address add {{.Address.Value}}/32 dev {{.InterfaceName}} &> /dev/null || true
-    up ip route replace {{.GatewayAddress.Value}} dev {{.InterfaceName}}
-    up ip route replace default via {{.GatewayAddress.Value}}
-    down ip route del default via {{.GatewayAddress.Value}} &> /dev/null || true
-    down ip route del {{.GatewayAddress.Value}} dev {{.InterfaceName}} &> /dev/null || true
-    post-down ip address del {{.Address.Value}}/32 dev {{.InterfaceName}} &> /dev/null || true
-{{end}}{{define "dhcp"}}
-{{.InterfaceName | printf "# interface %q"}}{{if not .NoAutoStart}}
-auto {{.InterfaceName}}{{end}}
-iface {{.InterfaceName}} inet dhcp
-{{end}}{{range $nic := . }}{{if eq $nic.ConfigType "static"}}
-{{template "static" $nic}}{{else}}{{template "dhcp" $nic}}{{end}}{{end}}`
-
 var networkInterfacesFile = "/etc/network/interfaces"
 
 // GenerateNetworkConfig renders a network config for one or more
@@ -88,36 +65,134 @@ var networkInterfacesFile = "/etc/network/interfaces"
 // containing a non-empty Interfaces field.
 func GenerateNetworkConfig(networkConfig *container.NetworkConfig) (string, error) {
 	if networkConfig == nil || len(networkConfig.Interfaces) == 0 {
-		// Don't generate networking config.
-		logger.Tracef("no network config to generate")
-		return "", nil
+		return "", errors.Errorf("missing container network config")
 	}
 
-	// Render the config first.
-	tmpl, err := template.New("config").Parse(networkConfigTemplate)
-	if err != nil {
-		return "", errors.Annotate(err, "cannot parse network config template")
+	prepared := PrepareNetworkConfigFromInterfaces(networkConfig.Interfaces)
+
+	var output bytes.Buffer
+	gatewayWritten := false
+	for _, name := range prepared.InterfaceNames {
+		output.WriteString("\n")
+		if name == "lo" {
+			output.WriteString("auto ")
+			autoStarted := strings.Join(prepared.AutoStarted, " ")
+			output.WriteString(autoStarted + "\n\n")
+			output.WriteString("iface lo inet loopback\n")
+
+			dnsServers := strings.Join(prepared.DNSServers, " ")
+			if dnsServers != "" {
+				output.WriteString("  dns-nameservers ")
+				output.WriteString(dnsServers + "\n")
+			}
+
+			dnsSearchDomains := strings.Join(prepared.DNSSearchDomains, " ")
+			if dnsSearchDomains != "" {
+				output.WriteString("  dns-search ")
+				output.WriteString(dnsSearchDomains + "\n")
+			}
+			continue
+		}
+
+		address, hasAddress := prepared.NameToAddress[name]
+		if !hasAddress {
+			output.WriteString("iface " + name + " inet manual\n")
+			continue
+		} else if address == string(network.ConfigDHCP) {
+			output.WriteString("iface " + name + " inet dhcp\n")
+			continue
+		}
+
+		output.WriteString("iface " + name + " inet static\n")
+		output.WriteString("  address " + address + "\n")
+		if !gatewayWritten && prepared.GatewayAddress != "" {
+			output.WriteString("  gateway " + prepared.GatewayAddress + "\n")
+			gatewayWritten = true // write it only once
+		}
 	}
 
-	var buf bytes.Buffer
-	if err = tmpl.Execute(&buf, networkConfig.Interfaces); err != nil {
-		return "", errors.Annotate(err, "cannot render network config")
+	generatedConfig := output.String()
+	logger.Debugf("generated network config:\n%s", generatedConfig)
+
+	return generatedConfig, nil
+}
+
+// PreparedConfig holds all the necessary information to render a persistent
+// network config to a file.
+type PreparedConfig struct {
+	InterfaceNames   []string
+	AutoStarted      []string
+	DNSServers       []string
+	DNSSearchDomains []string
+	NameToAddress    map[string]string
+	GatewayAddress   string
+}
+
+// PrepareNetworkConfigFromInterfaces collects the necessary information to
+// render a persistent network config from the given slice of
+// network.InterfaceInfo. The result always includes the loopback interface.
+func PrepareNetworkConfigFromInterfaces(interfaces []network.InterfaceInfo) *PreparedConfig {
+	dnsServers := set.NewStrings()
+	dnsSearchDomains := set.NewStrings()
+	gatewayAddress := ""
+	namesInOrder := make([]string, 1, len(interfaces)+1)
+	nameToAddress := make(map[string]string)
+
+	// Always include the loopback.
+	namesInOrder[0] = "lo"
+	autoStarted := set.NewStrings("lo")
+
+	for _, info := range interfaces {
+		if !info.NoAutoStart {
+			autoStarted.Add(info.InterfaceName)
+		}
+
+		if cidr := info.CIDRAddress(); cidr != "" {
+			nameToAddress[info.InterfaceName] = cidr
+		} else if info.ConfigType == network.ConfigDHCP {
+			nameToAddress[info.InterfaceName] = string(network.ConfigDHCP)
+		}
+
+		for _, dns := range info.DNSServers {
+			dnsServers.Add(dns.Value)
+		}
+
+		if info.DNSSearch != "" {
+			dnsSearchDomains.Add(info.DNSSearch)
+		}
+
+		if info.InterfaceName == "eth0" && gatewayAddress == "" {
+			// Only set gateway once for the primary NIC.
+			gatewayAddress = info.GatewayAddress.Value
+		}
+
+		namesInOrder = append(namesInOrder, info.InterfaceName)
 	}
 
-	return buf.String(), nil
+	prepared := &PreparedConfig{
+		InterfaceNames:   namesInOrder,
+		NameToAddress:    nameToAddress,
+		AutoStarted:      autoStarted.SortedValues(),
+		DNSServers:       dnsServers.SortedValues(),
+		DNSSearchDomains: dnsSearchDomains.SortedValues(),
+		GatewayAddress:   gatewayAddress,
+	}
+
+	logger.Debugf("prepared network config for rendering: %+v", prepared)
+	return prepared
 }
 
 // newCloudInitConfigWithNetworks creates a cloud-init config which
 // might include per-interface networking config if both networkConfig
 // is not nil and its Interfaces field is not empty.
 func newCloudInitConfigWithNetworks(series string, networkConfig *container.NetworkConfig) (cloudinit.CloudConfig, error) {
-	cloudConfig, err := cloudinit.New(series)
+	config, err := GenerateNetworkConfig(networkConfig)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	config, err := GenerateNetworkConfig(networkConfig)
-	if err != nil || len(config) == 0 {
-		return cloudConfig, errors.Trace(err)
+	cloudConfig, err := cloudinit.New(series)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 
 	// Now add it to cloud-init as a file created early in the boot process.
@@ -130,13 +205,15 @@ func cloudInitUserData(
 	networkConfig *container.NetworkConfig,
 ) ([]byte, error) {
 	cloudConfig, err := newCloudInitConfigWithNetworks(instanceConfig.Series, networkConfig)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	udata, err := cloudconfig.NewUserdataConfig(instanceConfig, cloudConfig)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
-	err = udata.Configure()
-	if err != nil {
-		return nil, err
+	if err := udata.Configure(); err != nil {
+		return nil, errors.Trace(err)
 	}
 	// Run ifconfig to get the addresses of the internal container at least
 	// logged in the host.
@@ -148,7 +225,7 @@ func cloudInitUserData(
 
 	data, err := cloudConfig.RenderYAML()
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	return data, nil
 }

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -5,6 +5,7 @@
 package containerinit_test
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	stdtesting "testing"
@@ -33,7 +34,11 @@ type UserDataSuite struct {
 
 	networkInterfacesFile string
 	fakeInterfaces        []network.InterfaceInfo
-	expectedNetConfig     string
+
+	expectedSampleConfig     string
+	expectedSampleUserData   string
+	expectedFallbackConfig   string
+	expectedFallbackUserData string
 }
 
 var _ = gc.Suite(&UserDataSuite{})
@@ -51,93 +56,175 @@ func (s *UserDataSuite) SetUpTest(c *gc.C) {
 		DNSSearch:      "foo.bar",
 		GatewayAddress: network.NewAddress("0.1.2.1"),
 	}, {
-		InterfaceName: "eth1",
+		InterfaceName:  "eth1",
+		CIDR:           "0.1.2.0/24",
+		ConfigType:     network.ConfigStatic,
+		NoAutoStart:    false,
+		Address:        network.NewAddress("0.1.2.4"),
+		DNSServers:     network.NewAddresses("ns2.invalid", "ns3.invalid"),
+		DNSSearch:      "bar.bar",
+		GatewayAddress: network.NewAddress("0.1.2.1"),
+	}, {
+		InterfaceName: "eth2",
 		ConfigType:    network.ConfigDHCP,
 		NoAutoStart:   true,
+	}, {
+		InterfaceName: "eth3",
+		ConfigType:    network.ConfigDHCP,
+		NoAutoStart:   false,
+	}, {
+		InterfaceName: "eth4",
+		ConfigType:    network.ConfigManual,
+		NoAutoStart:   true,
 	}}
-	s.expectedNetConfig = `
-# loopback interface
-auto lo
+	s.expectedSampleConfig = `
+auto eth0 eth1 eth3 lo
+
+iface lo inet loopback
+  dns-nameservers ns1.invalid ns2.invalid ns3.invalid
+  dns-search bar.bar foo.bar
+
+iface eth0 inet static
+  address 0.1.2.3/24
+  gateway 0.1.2.1
+
+iface eth1 inet static
+  address 0.1.2.4/24
+
+iface eth2 inet dhcp
+
+iface eth3 inet dhcp
+
+iface eth4 inet manual
+`
+	s.expectedSampleUserData = `
+#cloud-config
+bootcmd:
+- install -D -m 644 /dev/null '%[1]s'
+- |-
+  printf '%%s\n' '
+  auto eth0 eth1 eth3 lo
+
+  iface lo inet loopback
+    dns-nameservers ns1.invalid ns2.invalid ns3.invalid
+    dns-search bar.bar foo.bar
+
+  iface eth0 inet static
+    address 0.1.2.3/24
+    gateway 0.1.2.1
+
+  iface eth1 inet static
+    address 0.1.2.4/24
+
+  iface eth2 inet dhcp
+
+  iface eth3 inet dhcp
+
+  iface eth4 inet manual
+  ' > '%[1]s'
+`[1:]
+
+	s.expectedFallbackConfig = `
+auto eth0 lo
+
 iface lo inet loopback
 
-# interface "eth0"
-auto eth0
-iface eth0 inet manual
-    dns-nameservers ns1.invalid ns2.invalid
-    dns-search foo.bar
-    pre-up ip address add 0.1.2.3/32 dev eth0 &> /dev/null || true
-    up ip route replace 0.1.2.1 dev eth0
-    up ip route replace default via 0.1.2.1
-    down ip route del default via 0.1.2.1 &> /dev/null || true
-    down ip route del 0.1.2.1 dev eth0 &> /dev/null || true
-    post-down ip address del 0.1.2.3/32 dev eth0 &> /dev/null || true
-
-# interface "eth1"
-iface eth1 inet dhcp
+iface eth0 inet dhcp
 `
+	s.expectedFallbackUserData = `
+#cloud-config
+bootcmd:
+- install -D -m 644 /dev/null '%[1]s'
+- |-
+  printf '%%s\n' '
+  auto eth0 lo
+
+  iface lo inet loopback
+
+  iface eth0 inet dhcp
+  ' > '%[1]s'
+`[1:]
+
 	s.PatchValue(containerinit.NetworkInterfacesFile, s.networkInterfacesFile)
 }
 
 func (s *UserDataSuite) TestGenerateNetworkConfig(c *gc.C) {
-	// No config or no interfaces - no error, but also noting to generate.
 	data, err := containerinit.GenerateNetworkConfig(nil)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(data, gc.HasLen, 0)
+	c.Assert(err, gc.ErrorMatches, "missing container network config")
+	c.Assert(data, gc.Equals, "")
+
 	netConfig := container.BridgeNetworkConfig("foo", 0, nil)
 	data, err = containerinit.GenerateNetworkConfig(netConfig)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(data, gc.HasLen, 0)
+	c.Assert(data, gc.Equals, s.expectedFallbackConfig)
 
 	// Test with all interface types.
 	netConfig = container.BridgeNetworkConfig("foo", 0, s.fakeInterfaces)
 	data, err = containerinit.GenerateNetworkConfig(netConfig)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(data, gc.Equals, s.expectedNetConfig)
+	c.Assert(data, gc.Equals, s.expectedSampleConfig)
 }
 
-func (s *UserDataSuite) TestNewCloudInitConfigWithNetworks(c *gc.C) {
+func (s *UserDataSuite) TestNewCloudInitConfigWithNetworksSampleConfig(c *gc.C) {
 	netConfig := container.BridgeNetworkConfig("foo", 0, s.fakeInterfaces)
 	cloudConf, err := containerinit.NewCloudInitConfigWithNetworks("quantal", netConfig)
 	c.Assert(err, jc.ErrorIsNil)
-	// We need to indent expectNetConfig to make it valid YAML,
-	// dropping the last new line and using unindented blank lines.
-	lines := strings.Split(s.expectedNetConfig, "\n")
-	indentedNetConfig := strings.Join(lines[:len(lines)-1], "\n  ")
-	indentedNetConfig = strings.Replace(indentedNetConfig, "\n  \n", "\n\n", -1)
-	expected := `
-#cloud-config
-bootcmd:
-- install -D -m 644 /dev/null '`[1:] + s.networkInterfacesFile + `'
-- |-
-  printf '%s\n' '` + indentedNetConfig + `
-  ' > '` + s.networkInterfacesFile + `'
-`
+	c.Assert(cloudConf, gc.NotNil)
+
+	expected := fmt.Sprintf(s.expectedSampleUserData, s.networkInterfacesFile)
 	assertUserData(c, cloudConf, expected)
 }
 
-func (s *UserDataSuite) TestNewCloudInitConfigWithNetworksNoConfig(c *gc.C) {
+func (s *UserDataSuite) TestNewCloudInitConfigWithNetworksFallbackConfig(c *gc.C) {
 	netConfig := container.BridgeNetworkConfig("foo", 0, nil)
 	cloudConf, err := containerinit.NewCloudInitConfigWithNetworks("quantal", netConfig)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := "#cloud-config\n{}\n"
+	c.Assert(cloudConf, gc.NotNil)
+
+	expected := fmt.Sprintf(s.expectedFallbackUserData, s.networkInterfacesFile)
 	assertUserData(c, cloudConf, expected)
 }
 
-func (s *UserDataSuite) TestCloudInitUserData(c *gc.C) {
+func (s *UserDataSuite) TestCloudInitUserDataFallbackConfig(c *gc.C) {
 	instanceConfig, err := containertesting.MockMachineConfig("1/lxc/0")
 	c.Assert(err, jc.ErrorIsNil)
 	networkConfig := container.BridgeNetworkConfig("foo", 0, nil)
 	data, err := containerinit.CloudInitUserData(instanceConfig, networkConfig)
 	c.Assert(err, jc.ErrorIsNil)
-	// No need to test the exact contents here, as they are already
-	// tested separately.
-	c.Assert(string(data), jc.HasPrefix, "#cloud-config\n")
+	c.Assert(data, gc.NotNil)
+
+	// Extract the "#cloud-config" header and all lines between from the
+	// "bootcmd" section up to (but not including) the "output" sections to
+	// match against expected.
+	var linesToMatch []string
+	seenBootcmd := false
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "#cloud-config") {
+			linesToMatch = append(linesToMatch, line)
+			continue
+		}
+
+		if strings.HasPrefix(line, "bootcmd:") {
+			seenBootcmd = true
+		}
+
+		if strings.HasPrefix(line, "output:") && seenBootcmd {
+			break
+		}
+
+		if seenBootcmd {
+			linesToMatch = append(linesToMatch, line)
+		}
+	}
+	expected := fmt.Sprintf(s.expectedFallbackUserData, s.networkInterfacesFile)
+	c.Assert(strings.Join(linesToMatch, "\n")+"\n", gc.Equals, expected)
 }
 
 func assertUserData(c *gc.C, cloudConf cloudinit.CloudConfig, expected string) {
 	data, err := cloudConf.RenderYAML()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, expected)
+
 	// Make sure it's valid YAML as well.
 	out := make(map[string]interface{})
 	err = yaml.Unmarshal(data, &out)

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -320,26 +320,6 @@ func (manager *containerManager) CreateContainer(
 		return nil, nil, errors.Annotate(err, "failed to reorder network settings")
 	}
 
-	// To speed-up the initial container startup we pre-render the
-	// /etc/network/interfaces directly inside the rootfs. This won't
-	// work if we use AUFS snapshots, so it's disabled if useAUFS is
-	// true (for now).
-	if networkConfig != nil && len(networkConfig.Interfaces) > 0 {
-		interfacesFile := filepath.Join(LxcContainerDir, name, "rootfs", etcNetworkInterfaces)
-		if manager.useAUFS {
-			logger.Tracef("not pre-rendering %q when using AUFS-backed rootfs", interfacesFile)
-		} else {
-			data, err := containerinit.GenerateNetworkConfig(networkConfig)
-			if err != nil {
-				return nil, nil, errors.Annotatef(err, "failed to generate %q", interfacesFile)
-			}
-			if err := utils.AtomicWriteFile(interfacesFile, []byte(data), 0644); err != nil {
-				return nil, nil, errors.Annotatef(err, "cannot write generated %q", interfacesFile)
-			}
-			logger.Tracef("pre-rendered network config in %q", interfacesFile)
-		}
-	}
-
 	// Start the lxc container with the appropriate settings for
 	// grabbing the console output and a log file.
 	consoleFile := filepath.Join(directory, "console.log")

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -831,7 +831,9 @@ func (s *LxcSuite) createTemplate(c *gc.C) golxc.Container {
 lxc.network.type = veth
 lxc.network.link = nic42
 lxc.network.flags = up
+lxc.network.name = eth0
 lxc.network.mtu = 4321
+
 
 `
 	// NOTE: no autostart, no mounting the log dir
@@ -981,6 +983,8 @@ func (s *LxcSuite) TestCreateContainerNoRestartDir(c *gc.C) {
 lxc.network.type = veth
 lxc.network.link = nic42
 lxc.network.flags = up
+lxc.network.name = eth0
+
 
 lxc.start.auto = 1
 lxc.mount.entry = %s var/log/juju none defaults,bind 0 0
@@ -1009,7 +1013,9 @@ func (s *LxcSuite) TestCreateContainerWithBlockStorage(c *gc.C) {
 lxc.network.type = veth
 lxc.network.link = nic42
 lxc.network.flags = up
+lxc.network.name = eth0
 lxc.network.mtu = 4321
+
 
 lxc.start.auto = 1
 lxc.mount.entry = %s var/log/juju none defaults,bind 0 0
@@ -1107,6 +1113,7 @@ func (*NetworkSuite) TestGenerateNetworkConfig(c *gc.C) {
 			"lxc.network.type = veth",
 			"lxc.network.link = lxcbr0",
 			"lxc.network.flags = up",
+			"lxc.network.name = eth0", // from FallbackInterfaceInfo()
 		},
 		logContains:       `WARNING juju.container.lxc network type missing, using the default "bridge" config`,
 		logDoesNotContain: `INFO juju.container.lxc setting MTU to 0 for LXC network interfaces`,
@@ -1117,20 +1124,22 @@ func (*NetworkSuite) TestGenerateNetworkConfig(c *gc.C) {
 			"lxc.network.type = veth",
 			"lxc.network.link = lxcbr0",
 			"lxc.network.flags = up",
+			"lxc.network.name = eth0", // from FallbackInterfaceInfo()
 		},
 		logDoesNotContain: `INFO juju.container.lxc setting MTU to 0 for LXC network interfaces`,
 	}, {
-		about:  "bridge config with MTU 1500, device foo, no NICs",
+		about:  "bridge config with MTU 1500, device foo, no NICs (i.e. fallback)",
 		config: container.BridgeNetworkConfig("foo", 1500, nil),
 		rendered: []string{
 			"lxc.network.type = veth",
 			"lxc.network.link = foo",
 			"lxc.network.flags = up",
+			"lxc.network.name = eth0", // from FallbackInterfaceInfo()
 			"lxc.network.mtu = 1500",
 		},
 		logContains: `INFO juju.container.lxc setting MTU to 1500 for all LXC network interfaces`,
 	}, {
-		about:  "phys config with MTU 9000, device foo, no NICs",
+		about:  "phys config with MTU 9000, device foo, no NICs (no fallback)",
 		config: container.PhysicalNetworkConfig("foo", 9000, nil),
 		rendered: []string{
 			"lxc.network.type = phys",

--- a/container/network.go
+++ b/container/network.go
@@ -23,12 +23,23 @@ type NetworkConfig struct {
 	Interfaces []network.InterfaceInfo
 }
 
-// BridgeNetworkConfig returns a valid NetworkConfig to use the
-// specified device as a network bridge for the container. It also
-// allows passing in specific configuration for the container's
-// network interfaces and default MTU to use. If interfaces is nil the
-// default configuration is used for the respective container type.
+// FallbackInterfaceInfo returns a single "eth0" interface configured with DHCP.
+func FallbackInterfaceInfo() []network.InterfaceInfo {
+	return []network.InterfaceInfo{{
+		InterfaceName: "eth0",
+		ConfigType:    network.ConfigDHCP,
+	}}
+}
+
+// BridgeNetworkConfig returns a valid NetworkConfig to use the specified device
+// as a network bridge for the container. It also allows passing in specific
+// configuration for the container's network interfaces and default MTU to use.
+// If interfaces is empty, FallbackInterfaceInfo() is used to get the a sane
+// default
 func BridgeNetworkConfig(device string, mtu int, interfaces []network.InterfaceInfo) *NetworkConfig {
+	if len(interfaces) == 0 {
+		interfaces = FallbackInterfaceInfo()
+	}
 	return &NetworkConfig{BridgeNetwork, device, mtu, interfaces}
 }
 

--- a/network/network.go
+++ b/network/network.go
@@ -228,6 +228,23 @@ func (i *InterfaceInfo) IsVLAN() bool {
 	return i.VLANTag > 0
 }
 
+// CIDRAddress returns Address.Value combined with CIDR mask.
+func (i *InterfaceInfo) CIDRAddress() string {
+	if i.CIDR == "" || i.Address.Value == "" {
+		return ""
+	}
+	_, ipNet, err := net.ParseCIDR(i.CIDR)
+	if err != nil {
+		return errors.Trace(err).Error()
+	}
+	ip := net.ParseIP(i.Address.Value)
+	if ip == nil {
+		return errors.Errorf("cannot parse IP address %q", i.Address.Value).Error()
+	}
+	ipNet.IP = ip
+	return ipNet.String()
+}
+
 // PreferIPv6Getter will be implemented by both the environment and agent
 // config.
 type PreferIPv6Getter interface {

--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -170,8 +170,7 @@ class LogicalInterface(object):
             return self._bridge_device(bridge_name)
 
     def _bridge_device(self, bridge_name):
-        stanzas = []
-        stanzas.append(AutoStanza(bridge_name))
+        stanzas = [AutoStanza(bridge_name)]
         options = list(self.options)
         options.append("bridge_ports {}".format(self.name))
         stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))

--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -223,6 +223,7 @@ class Stanza(object):
         self.options = options
         self.is_logical_interface = definition.startswith('iface ')
         self.is_physical_interface = definition.startswith('auto ')
+        self.is_source = definition.startswith('source')
         self.iface = None
         self.phy = None
         if self.is_logical_interface:
@@ -264,7 +265,7 @@ class NetworkInterfaceParser(object):
         return Stanza(stanza_line.strip(), stanza_options)
 
     def stanzas(self):
-        return [x for x in self._stanzas]
+        return [x for x in self._stanzas if not x.is_source]
 
     def physical_interfaces(self):
         return {x.phy.name: x.phy for x in [y for y in self._stanzas if y.is_physical_interface]}

--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -170,51 +170,47 @@ class LogicalInterface(object):
             return self._bridge_device(bridge_name)
 
     def _bridge_device(self, bridge_name):
-        s1 = IfaceStanza(self.name, self.family, "manual", [])
-        s2 = AutoStanza(bridge_name)
+        stanzas = []
+        stanzas.append(AutoStanza(bridge_name))
         options = list(self.options)
         options.append("bridge_ports {}".format(self.name))
-        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
-        return [s1, s2, s3]
+        stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
+        return stanzas
 
     def _bridge_vlan(self, bridge_name, add_auto_stanza):
         stanzas = []
-        s1 = IfaceStanza(self.name, self.family, "manual", self.options)
-        stanzas.append(s1)
         if add_auto_stanza:
             stanzas.append(AutoStanza(bridge_name))
-        options = [x for x in self.options if not x.startswith("vlan")]
+        options = [x for x in self.options if not x.startswith("vlan_id")]
         options.append("bridge_ports {}".format(self.name))
-        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
-        stanzas.append(s3)
+        stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
         return stanzas
 
     def _bridge_alias(self, add_auto_stanza):
         stanzas = []
         if add_auto_stanza:
             stanzas.append(AutoStanza(self.name))
-        s1 = IfaceStanza(self.name, self.family, self.method, list(self.options))
-        stanzas.append(s1)
+        stanzas.append(IfaceStanza(self.name, self.family, self.method, list(self.options)))
         return stanzas
 
     def _bridge_bond(self, bridge_name, add_auto_stanza):
         stanzas = []
         if add_auto_stanza:
             stanzas.append(AutoStanza(self.name))
-        s1 = IfaceStanza(self.name, self.family, "manual", list(self.options))
-        s2 = AutoStanza(bridge_name)
+        options = [x for x in self.options if not x.startswith("address") and not x.startswith("gateway")]
+        stanzas.append(IfaceStanza(self.name, self.family, "manual", list(options)))
+
+        stanzas.append(AutoStanza(bridge_name))
         options = [x for x in self.options if not x.startswith("bond")]
         options.append("bridge_ports {}".format(self.name))
-        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
-        stanzas.extend([s1, s2, s3])
+        stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
         return stanzas
 
     def _bridge_unchanged(self, add_auto_stanza):
         stanzas = []
         if add_auto_stanza:
             stanzas.append(AutoStanza(self.name))
-        s1 = IfaceStanza(self.name, self.family, self.method, list(self.options))
-        stanzas.append(s1)
+        stanzas.append(IfaceStanza(self.name, self.family, self.method, list(self.options)))
         return stanzas
 
 

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -182,8 +182,7 @@ class LogicalInterface(object):
             return self._bridge_device(bridge_name)
 
     def _bridge_device(self, bridge_name):
-        stanzas = []
-        stanzas.append(AutoStanza(bridge_name))
+        stanzas = [AutoStanza(bridge_name)]
         options = list(self.options)
         options.append("bridge_ports {}".format(self.name))
         stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -235,6 +235,7 @@ class Stanza(object):
         self.options = options
         self.is_logical_interface = definition.startswith('iface ')
         self.is_physical_interface = definition.startswith('auto ')
+        self.is_source = definition.startswith('source')
         self.iface = None
         self.phy = None
         if self.is_logical_interface:
@@ -276,7 +277,7 @@ class NetworkInterfaceParser(object):
         return Stanza(stanza_line.strip(), stanza_options)
 
     def stanzas(self):
-        return [x for x in self._stanzas]
+        return [x for x in self._stanzas if not x.is_source]
 
     def physical_interfaces(self):
         return {x.phy.name: x.phy for x in [y for y in self._stanzas if y.is_physical_interface]}

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -277,7 +277,7 @@ class NetworkInterfaceParser(object):
         return Stanza(stanza_line.strip(), stanza_options)
 
     def stanzas(self):
-        return [x for x in self._stanzas if not x.is_source]
+        return [x for x in self._stanzas]
 
     def physical_interfaces(self):
         return {x.phy.name: x.phy for x in [y for y in self._stanzas if y.is_physical_interface]}
@@ -346,9 +346,11 @@ def print_stanza(s, stream=sys.stdout):
         print("   ", o, file=stream)
 
 
-def print_stanzas(stanzas, stream=sys.stdout):
+def print_stanzas(stanzas, stream=sys.stdout, keep_source_stanzas=True):
     n = len(stanzas)
     for i, stanza in enumerate(stanzas):
+        if not keep_source_stanzas and stanza.is_source:
+            continue
         print_stanza(stanza, stream)
         if stanza.is_logical_interface and i + 1 < n:
             print(file=stream)
@@ -388,6 +390,7 @@ def arg_parser():
     parser.add_argument('--activate', help='activate new configuration', action='store_true', default=False, required=False)
     parser.add_argument('--interface-to-bridge', help="interface to bridge", type=str, required=False)
     parser.add_argument('--bridge-name', help="bridge name", type=str, required=False)
+    parser.add_argument('--keep-source-stanzas', help='keep any "source" and "source-dir" lines in the new configuration', action='store_true', default=False, required=False)
     parser.add_argument('filename', help="interfaces(5) based filename")
     return parser
 
@@ -429,7 +432,7 @@ def main(args):
             stanzas.append(s)
 
     if not args.activate:
-        print_stanzas(stanzas)
+        print_stanzas(stanzas, sys.stdout, args.keep_source_stanzas)
         exit(0)
 
     print("**** Original configuration")
@@ -448,7 +451,7 @@ def main(args):
             shutil.copy2(args.filename, backup_file)
 
     with open(args.filename, 'w') as f:
-        print_stanzas(stanzas, f)
+        print_stanzas(stanzas, f, args.keep_source_stanzas)
         f.close()
 
     print("**** New configuration")

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -182,51 +182,47 @@ class LogicalInterface(object):
             return self._bridge_device(bridge_name)
 
     def _bridge_device(self, bridge_name):
-        s1 = IfaceStanza(self.name, self.family, "manual", [])
-        s2 = AutoStanza(bridge_name)
+        stanzas = []
+        stanzas.append(AutoStanza(bridge_name))
         options = list(self.options)
         options.append("bridge_ports {}".format(self.name))
-        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
-        return [s1, s2, s3]
+        stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
+        return stanzas
 
     def _bridge_vlan(self, bridge_name, add_auto_stanza):
         stanzas = []
-        s1 = IfaceStanza(self.name, self.family, "manual", self.options)
-        stanzas.append(s1)
         if add_auto_stanza:
             stanzas.append(AutoStanza(bridge_name))
-        options = [x for x in self.options if not x.startswith("vlan")]
+        options = [x for x in self.options if not x.startswith("vlan_id")]
         options.append("bridge_ports {}".format(self.name))
-        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
-        stanzas.append(s3)
+        stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
         return stanzas
 
     def _bridge_alias(self, add_auto_stanza):
         stanzas = []
         if add_auto_stanza:
             stanzas.append(AutoStanza(self.name))
-        s1 = IfaceStanza(self.name, self.family, self.method, list(self.options))
-        stanzas.append(s1)
+        stanzas.append(IfaceStanza(self.name, self.family, self.method, list(self.options)))
         return stanzas
 
     def _bridge_bond(self, bridge_name, add_auto_stanza):
         stanzas = []
         if add_auto_stanza:
             stanzas.append(AutoStanza(self.name))
-        s1 = IfaceStanza(self.name, self.family, "manual", list(self.options))
-        s2 = AutoStanza(bridge_name)
+        options = [x for x in self.options if not x.startswith("address") and not x.startswith("gateway")]
+        stanzas.append(IfaceStanza(self.name, self.family, "manual", list(options)))
+
+        stanzas.append(AutoStanza(bridge_name))
         options = [x for x in self.options if not x.startswith("bond")]
         options.append("bridge_ports {}".format(self.name))
-        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
-        stanzas.extend([s1, s2, s3])
+        stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
         return stanzas
 
     def _bridge_unchanged(self, add_auto_stanza):
         stanzas = []
         if add_auto_stanza:
             stanzas.append(AutoStanza(self.name))
-        s1 = IfaceStanza(self.name, self.family, self.method, list(self.options))
-        stanzas.append(s1)
+        stanzas.append(IfaceStanza(self.name, self.family, self.method, list(self.options)))
         return stanzas
 
 

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -70,7 +70,7 @@ func (s *bridgeConfigSuite) assertScript(c *gc.C, initialConfig, expectedConfig,
 		// Run the script and verify the modified config.
 		output, retcode := s.runScript(c, python, s.testConfigPath, bridgePrefix, bridgeName, interfaceToBridge)
 		c.Check(retcode, gc.Equals, 0)
-		c.Check(strings.Trim(output, "\n"), gc.Equals, expectedConfig)
+		c.Check(strings.Trim(output, "\n"), gc.Equals, expectedConfig, gc.Commentf("initial was:\n%s", initialConfig))
 	}
 }
 
@@ -210,8 +210,6 @@ iface eth0 inet static
 const networkStaticExpected = `auto lo
 iface lo inet loopback
 
-iface eth0 inet manual
-
 auto test-br-eth0
 iface test-br-eth0 inet static
     address 1.2.3.4
@@ -227,8 +225,6 @@ iface eth0 inet dhcp`
 
 const networkDHCPExpected = `auto lo
 iface lo inet loopback
-
-iface eth0 inet manual
 
 auto test-br-eth0
 iface test-br-eth0 inet dhcp
@@ -252,16 +248,12 @@ iface eth1 inet static
 const networkDualNICExpected = `auto lo
 iface lo inet loopback
 
-iface eth0 inet manual
-
 auto test-br-eth0
 iface test-br-eth0 inet static
     address 1.2.3.4
     netmask 255.255.255.0
     gateway 4.3.2.1
     bridge_ports eth0
-
-iface eth1 inet manual
 
 auto test-br-eth1
 iface test-br-eth1 inet static
@@ -285,8 +277,6 @@ iface eth0:1 inet static
 
 const networkWithAliasExpected = `auto lo
 iface lo inet loopback
-
-iface eth0 inet manual
 
 auto test-br-eth0
 iface test-br-eth0 inet static
@@ -319,8 +309,6 @@ dns-nameserver 192.168.1.142`
 
 const networkDHCPWithAliasExpected = `auto lo
 iface lo inet loopback
-
-iface eth0 inet manual
 
 auto test-br-eth0
 iface test-br-eth0 inet static
@@ -356,9 +344,7 @@ iface eth1 inet manual
 dns-nameservers 10.17.20.200
 dns-search maas`
 
-const networkMultipleStaticWithAliasesExpected = `iface eth0 inet manual
-
-auto test-br-eth0
+const networkMultipleStaticWithAliasesExpected = `auto test-br-eth0
 iface test-br-eth0 inet static
     gateway 10.17.20.1
     address 10.17.20.201/24
@@ -470,19 +456,13 @@ iface eth10:2 inet static
 dns-nameservers 10.17.20.200
 dns-search maas19`
 
-const networkMultipleAliasesExpected = `iface eth0 inet manual
-
-auto test-br-eth0
+const networkMultipleAliasesExpected = `auto test-br-eth0
 iface test-br-eth0 inet dhcp
     bridge_ports eth0
-
-iface eth1 inet manual
 
 auto test-br-eth1
 iface test-br-eth1 inet dhcp
     bridge_ports eth1
-
-iface eth10 inet manual
 
 auto test-br-eth10
 iface test-br-eth10 inet static
@@ -634,22 +614,16 @@ iface eth3 inet manual
     mtu 1500
     bond-mode active-backup
 
-iface eth4 inet manual
-
 auto juju-br-eth4
 iface juju-br-eth4 inet static
     address 10.17.20.202/24
     mtu 1500
     bridge_ports eth4
 
-iface eth5 inet manual
-
 auto juju-br-eth5
 iface juju-br-eth5 inet dhcp
     mtu 1500
     bridge_ports eth5
-
-iface eth6 inet manual
 
 auto juju-br-eth6
 iface juju-br-eth6 inet static
@@ -679,8 +653,6 @@ iface eth6:4 inet static
 
 auto bond0
 iface bond0 inet manual
-    gateway 10.17.20.1
-    address 10.17.20.201/24
     bond-lacp_rate slow
     bond-xmit_hash_policy layer2
     bond-miimon 100
@@ -744,9 +716,7 @@ iface eth1.3 inet static
 dns-nameservers 10.17.20.200
 dns-search maas19`
 
-const networkVLANExpected = `iface eth0 inet manual
-
-auto vlan-br-eth0
+const networkVLANExpected = `auto vlan-br-eth0
 iface vlan-br-eth0 inet static
     gateway 10.17.20.1
     address 10.17.20.212/24
@@ -757,29 +727,17 @@ auto eth1
 iface eth1 inet manual
     mtu 1500
 
-iface eth0.2 inet manual
-    address 192.168.2.3/24
-    vlan-raw-device eth0
-    mtu 1500
-    vlan_id 2
-
 auto vlan-br-eth0.2
 iface vlan-br-eth0.2 inet static
     address 192.168.2.3/24
+    vlan-raw-device eth0
     mtu 1500
     bridge_ports eth0.2
-
-iface eth1.3 inet manual
-    address 192.168.3.3/24
-    vlan-raw-device eth1
-    mtu 1500
-    vlan_id 3
-    dns-nameservers 10.17.20.200
-    dns-search maas19
 
 auto vlan-br-eth1.3
 iface vlan-br-eth1.3 inet static
     address 192.168.3.3/24
+    vlan-raw-device eth1
     mtu 1500
     bridge_ports eth1.3
     dns-nameservers 10.17.20.200
@@ -839,9 +797,7 @@ iface eth1.2670 inet static
 dns-nameservers 10.245.168.2
 dns-search dellstack`
 
-const networkVLANWithMultipleNameserversExpected = `iface eth0 inet manual
-
-auto br-eth0
+const networkVLANWithMultipleNameserversExpected = `auto br-eth0
 iface br-eth0 inet static
     gateway 10.245.168.1
     address 10.245.168.11/21
@@ -861,59 +817,34 @@ auto eth3
 iface eth3 inet manual
     mtu 1500
 
-iface eth1.2667 inet manual
-    address 10.245.184.2/24
-    vlan-raw-device eth1
-    mtu 1500
-    vlan_id 2667
-    dns-nameservers 10.245.168.2
-
 auto br-eth1.2667
 iface br-eth1.2667 inet static
     address 10.245.184.2/24
-    mtu 1500
-    bridge_ports eth1.2667
-    dns-nameservers 10.245.168.2
-
-iface eth1.2668 inet manual
-    address 10.245.185.1/24
     vlan-raw-device eth1
     mtu 1500
-    vlan_id 2668
+    bridge_ports eth1.2667
     dns-nameservers 10.245.168.2
 
 auto br-eth1.2668
 iface br-eth1.2668 inet static
     address 10.245.185.1/24
-    mtu 1500
-    bridge_ports eth1.2668
-    dns-nameservers 10.245.168.2
-
-iface eth1.2669 inet manual
-    address 10.245.186.1/24
     vlan-raw-device eth1
     mtu 1500
-    vlan_id 2669
+    bridge_ports eth1.2668
     dns-nameservers 10.245.168.2
 
 auto br-eth1.2669
 iface br-eth1.2669 inet static
     address 10.245.186.1/24
+    vlan-raw-device eth1
     mtu 1500
     bridge_ports eth1.2669
     dns-nameservers 10.245.168.2
 
-iface eth1.2670 inet manual
-    address 10.245.187.2/24
-    vlan-raw-device eth1
-    mtu 1500
-    vlan_id 2670
-    dns-nameservers 10.245.168.2
-    dns-search dellstack
-
 auto br-eth1.2670
 iface br-eth1.2670 inet static
     address 10.245.187.2/24
+    vlan-raw-device eth1
     mtu 1500
     bridge_ports eth1.2670
     dns-nameservers 10.245.168.2
@@ -993,8 +924,6 @@ iface eth1 inet manual
 
 auto bond0
 iface bond0 inet manual
-    address 10.17.20.211/24
-    gateway 10.17.20.1
     bond-slaves none
     bond-mode active-backup
     bond-xmit_hash_policy layer2
@@ -1013,29 +942,17 @@ iface br-bond0 inet static
     bridge_ports bond0
     dns-nameservers 10.17.20.200
 
-iface bond0.2 inet manual
-    address 192.168.2.102/24
-    vlan-raw-device bond0
-    mtu 1500
-    vlan_id 2
-
 auto br-bond0.2
 iface br-bond0.2 inet static
     address 192.168.2.102/24
-    mtu 1500
-    bridge_ports bond0.2
-
-iface bond0.3 inet manual
-    address 192.168.3.101/24
     vlan-raw-device bond0
     mtu 1500
-    vlan_id 3
-    dns-nameservers 10.17.20.200
-    dns-search maas19
+    bridge_ports bond0.2
 
 auto br-bond0.3
 iface br-bond0.3 inet static
     address 192.168.3.101/24
+    vlan-raw-device bond0
     mtu 1500
     bridge_ports bond0.3
     dns-nameservers 10.17.20.200
@@ -1062,9 +979,7 @@ dns-nameservers 10.17.20.200
 dns-search maas19
 `
 
-const networkVLANWithInactiveDeviceExpected = `iface eth0 inet manual
-
-auto br-eth0
+const networkVLANWithInactiveDeviceExpected = `auto br-eth0
 iface br-eth0 inet static
     gateway 10.17.20.1
     address 10.17.20.211/24
@@ -1076,15 +991,9 @@ auto eth1
 iface eth1 inet manual
     mtu 1500
 
-iface eth1.2 inet manual
-    vlan-raw-device eth1
-    mtu 1500
-    vlan_id 2
-    dns-nameservers 10.17.20.200
-    dns-search maas19
-
 auto br-eth1.2
 iface br-eth1.2 inet dhcp
+    vlan-raw-device eth1
     mtu 1500
     bridge_ports eth1.2
     dns-nameservers 10.17.20.200
@@ -1111,9 +1020,7 @@ dns-nameservers 10.17.20.200
 dns-search maas19
 `
 
-const networkVLANWithActiveDHCPDeviceExpected = `iface eth0 inet manual
-
-auto br-eth0
+const networkVLANWithActiveDHCPDeviceExpected = `auto br-eth0
 iface br-eth0 inet static
     gateway 10.17.20.1
     address 10.17.20.211/24
@@ -1121,22 +1028,14 @@ iface br-eth0 inet static
     bridge_ports eth0
     dns-nameservers 10.17.20.200
 
-iface eth1 inet manual
-
 auto br-eth1
 iface br-eth1 inet dhcp
     mtu 1500
     bridge_ports eth1
 
-iface eth1.2 inet manual
-    vlan-raw-device eth1
-    mtu 1500
-    vlan_id 2
-    dns-nameservers 10.17.20.200
-    dns-search maas19
-
 auto br-eth1.2
 iface br-eth1.2 inet dhcp
+    vlan-raw-device eth1
     mtu 1500
     bridge_ports eth1.2
     dns-nameservers 10.17.20.200
@@ -1182,17 +1081,13 @@ iface eth3 inet static
 dns-search ubuntu juju
 dns-search dellstack ubuntu dellstack`
 
-const networkWithMultipleDNSValuesExpected = `iface eth0 inet manual
-
-auto br-eth0
+const networkWithMultipleDNSValuesExpected = `auto br-eth0
 iface br-eth0 inet static
     gateway 10.245.168.1
     address 10.245.168.11/21
     mtu 1500
     bridge_ports eth0
     dns-nameservers 10.245.168.2 192.168.1.1
-
-iface eth1 inet manual
 
 auto br-eth1
 iface br-eth1 inet static
@@ -1202,8 +1097,6 @@ iface br-eth1 inet static
     bridge_ports eth1
     dns-sortlist 192.168.1.0/24 10.245.168.0/21
 
-iface eth2 inet manual
-
 auto br-eth2
 iface br-eth2 inet static
     gateway 10.245.168.1
@@ -1211,8 +1104,6 @@ iface br-eth2 inet static
     mtu 1500
     bridge_ports eth2
     dns-search juju ubuntu dellstack
-
-iface eth3 inet manual
 
 auto br-eth3
 iface br-eth3 inet static
@@ -1246,16 +1137,12 @@ dns-nameservers
 dns-search
 dns-sortlist`
 
-const networkWithEmptyDNSValuesExpected = `iface eth0 inet manual
-
-auto br-eth0
+const networkWithEmptyDNSValuesExpected = `auto br-eth0
 iface br-eth0 inet static
     gateway 10.245.168.1
     address 10.245.168.11/21
     mtu 1500
     bridge_ports eth0
-
-iface eth1 inet manual
 
 auto br-eth1
 iface br-eth1 inet static
@@ -1412,8 +1299,6 @@ iface eth3 inet manual
 
 auto bond0
 iface bond0 inet manual
-    gateway 10.38.160.1
-    address 10.38.160.24/24
     bond-lacp_rate fast
     bond-xmit_hash_policy layer2+3
     bond-miimon 100
@@ -1513,8 +1398,6 @@ iface eth0 inet static
     netmask 255.255.255.0
     gateway 4.3.2.1
 
-iface eth1 inet manual
-
 auto juju-br0
 iface juju-br0 inet static
     address 1.2.3.4
@@ -1551,8 +1434,6 @@ iface br-eth0 inet static
     netmask 255.255.255.0
     gateway 4.3.2.1
     bridge_ports eth0
-
-iface eth1 inet manual
 
 auto br-eth1
 iface br-eth1 inet static

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -256,9 +256,6 @@ func allCollections() collectionSchema {
 				Key:    []string{"env-uuid", "interfacename", "machineid"},
 				Unique: true,
 			}, {
-				Key:    []string{"env-uuid", "macaddress", "networkname"},
-				Unique: true,
-			}, {
 				Key: []string{"env-uuid", "machineid"},
 			}, {
 				Key: []string{"env-uuid", "networkname"},

--- a/state/machine.go
+++ b/state/machine.go
@@ -1504,12 +1504,11 @@ func (m *Machine) NetworkInterfaces() ([]*NetworkInterface, error) {
 	return ifaces, nil
 }
 
-// AddNetworkInterface creates a new network interface with the given
-// args for this machine. The machine must be alive and not yet
-// provisioned, and there must be no other interface with the same MAC
-// address on the same network, or the same name on that machine for
-// this to succeed. If a network interface already exists, the
-// returned error satisfies errors.IsAlreadyExists.
+// AddNetworkInterface creates a new network interface with the given args for
+// this machine. The machine must be alive and not yet provisioned, and there
+// must be no other interface with the same name on that machine for this to
+// succeed. If a network interface already exists, the returned error satisfies
+// errors.IsAlreadyExists.
 func (m *Machine) AddNetworkInterface(args NetworkInterfaceInfo) (iface *NetworkInterface, err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot add network interface %q to machine %q", args.InterfaceName, m.doc.Id)
 
@@ -1518,6 +1517,7 @@ func (m *Machine) AddNetworkInterface(args NetworkInterfaceInfo) (iface *Network
 			return nil, err
 		}
 	}
+
 	if args.InterfaceName == "" {
 		return nil, fmt.Errorf("interface name must be not empty")
 	}
@@ -1556,7 +1556,6 @@ func (m *Machine) AddNetworkInterface(args NetworkInterfaceInfo) (iface *Network
 	case nil:
 		// We have a unique key restrictions on the following fields:
 		// - InterfaceName, MachineId
-		// - MACAddress, NetworkName
 		// These will cause the insert to fail if there is another record
 		// with the same combination of values in the table.
 		// The txn logic does not report insertion errors, so we check
@@ -1572,14 +1571,8 @@ func (m *Machine) AddNetworkInterface(args NetworkInterfaceInfo) (iface *Network
 		if err = networkInterfaces.Find(sel).One(nil); err == nil {
 			return nil, errors.AlreadyExistsf("%q on machine %q", args.InterfaceName, m.doc.Id)
 		}
-		if args.MACAddress != "" {
-			sel = bson.D{{"macaddress", args.MACAddress}, {"networkname", args.NetworkName}}
-			if err = networkInterfaces.Find(sel).One(nil); err == nil {
-				return nil, errors.AlreadyExistsf("MAC address %q on network %q", args.MACAddress, args.NetworkName)
-			}
-		}
 		// Should never happen.
-		logger.Errorf("unknown error while adding network interface doc %#v", doc)
+		logger.Errorf("unknown error while adding network interface doc %#v: %v", doc, err)
 	}
 	return nil, err
 }

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -850,10 +850,6 @@ var addNetworkInterfaceErrorsTests = []struct {
 	beforeAdding func(*gc.C, *state.Machine)
 	expectErr    string
 }{{
-	state.NetworkInterfaceInfo{"", "eth1", "net1", false, false},
-	nil,
-	`cannot add network interface "eth1" to machine "2": MAC address must be not empty`,
-}, {
 	state.NetworkInterfaceInfo{"invalid", "eth1", "net1", false, false},
 	nil,
 	`cannot add network interface "eth1" to machine "2": invalid MAC address.*`,
@@ -1064,9 +1060,9 @@ func (s *MachineSuite) TestMachineSetInstanceInfoFailureDoesNotProvision(c *gc.C
 	c.Assert(err, gc.ErrorMatches, `cannot add network "": name must be not empty`)
 	assertNotProvisioned()
 
-	invalidInterfaces := []state.NetworkInterfaceInfo{{MACAddress: ""}}
+	invalidInterfaces := []state.NetworkInterfaceInfo{{InterfaceName: ""}}
 	err = s.machine.SetInstanceInfo("umbrella/0", "fake_nonce", nil, nil, invalidInterfaces, nil, nil)
-	c.Assert(err, gc.ErrorMatches, `cannot add network interface "" to machine "1": MAC address must be not empty`)
+	c.Assert(err, gc.ErrorMatches, `cannot add network interface "" to machine "1": interface name must be not empty`)
 	assertNotProvisioned()
 
 	invalidVolumes := map[names.VolumeTag]state.VolumeInfo{

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -854,10 +854,6 @@ var addNetworkInterfaceErrorsTests = []struct {
 	nil,
 	`cannot add network interface "eth1" to machine "2": invalid MAC address.*`,
 }, {
-	state.NetworkInterfaceInfo{"aa:bb:cc:dd:ee:f0", "eth1", "net1", false, false},
-	nil,
-	`cannot add network interface "eth1" to machine "2": MAC address "aa:bb:cc:dd:ee:f0" on network "net1" already exists`,
-}, {
 	state.NetworkInterfaceInfo{"aa:bb:cc:dd:ee:ff", "", "net1", false, false},
 	nil,
 	`cannot add network interface "" to machine "2": interface name must be not empty`,

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -87,6 +87,7 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 
 	// Unlike with LXC, we don't override the default MTU to use.
 	network := container.BridgeNetworkConfig(bridgeDevice, 0, args.NetworkInfo)
+	interfaces := maybePopulateNetworkNameAndProviderId(network.Interfaces)
 
 	series := args.Tools.OneSeries()
 	args.InstanceConfig.MachineContainerType = instance.KVM
@@ -126,7 +127,7 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	return &environs.StartInstanceResult{
 		Instance:    inst,
 		Hardware:    hardware,
-		NetworkInfo: network.Interfaces,
+		NetworkInfo: interfaces,
 	}, nil
 }
 


### PR DESCRIPTION
Backported and adapted from master PR #5597 and #5512.
Includes additional work inside the MAAS bridge script
to handle bonds, confirmed to work on the customer site.

Important changes include, moving addresses from bond
slave interfaces to the bond, like we do on bridges, and
no longer sourcing /etc/network/interfaces.d/*.cfg.

Live tested with address-allocation feature flag on/off on
AWS with trusty and xenial, as well as on MAAS 1.9.3.
Verified independently on bootstack.

(Review request: http://reviews.vapour.ws/r/5087/)