### PR TITLE
Introduce API observers

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -27,6 +27,7 @@ import (
 	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/rpc"
@@ -172,7 +173,7 @@ func open(
 		return nil, errors.Trace(err)
 	}
 
-	client := rpc.NewConn(jsoncodec.NewWebsocket(conn), nil)
+	client := rpc.NewConn(jsoncodec.NewWebsocket(conn), observer.None())
 	client.Start()
 
 	bakeryClient := opts.BakeryClient

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -21,6 +21,8 @@ import (
 	apimachiner "github.com/juju/juju/api/machiner"
 	apitesting "github.com/juju/juju/api/testing"
 	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/apiserver/observer"
+	"github.com/juju/juju/apiserver/observer/fakeobserver"
 	"github.com/juju/juju/apiserver/params"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
@@ -576,11 +578,12 @@ func (s *baseLoginSuite) setupServerForEnvironmentWithValidator(c *gc.C, modelTa
 		s.State,
 		listener,
 		apiserver.ServerConfig{
-			Cert:      []byte(coretesting.ServerCert),
-			Key:       []byte(coretesting.ServerKey),
-			Validator: validator,
-			Tag:       names.NewMachineTag("0"),
-			LogDir:    c.MkDir(),
+			Cert:        []byte(coretesting.ServerCert),
+			Key:         []byte(coretesting.ServerKey),
+			Validator:   validator,
+			Tag:         names.NewMachineTag("0"),
+			LogDir:      c.MkDir(),
+			NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/adminv3.go
+++ b/apiserver/adminv3.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/params"
 )
 
@@ -14,12 +15,12 @@ type adminApiV3 struct {
 	*admin
 }
 
-func newAdminApiV3(srv *Server, root *apiHandler, reqNotifier *requestNotifier) interface{} {
+func newAdminApiV3(srv *Server, root *apiHandler, apiObserver observer.Observer) interface{} {
 	return &adminApiV3{
 		&admin{
 			srv:         srv,
 			root:        root,
-			reqNotifier: reqNotifier,
+			apiObserver: apiObserver,
 		},
 	}
 }

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/bmizerany/pat"
@@ -23,6 +22,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/apihttp"
+	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
@@ -50,7 +50,11 @@ type Server struct {
 	adminApiFactories map[int]adminApiFactory
 	modelUUID         string
 	authCtxt          *authContext
-	connections       int32 // count of active websocket connections
+	newObserver       observer.ObserverFactory
+	connCount         struct {
+		sync.RWMutex
+		value int64
+	}
 }
 
 // LoginValidator functions are used to decide whether login requests
@@ -68,8 +72,21 @@ type ServerConfig struct {
 	Validator   LoginValidator
 	CertChanged chan params.StateServingInfo
 
-	// This field only exists to support testing.
+	// NewObserver is a function which will return an observer. This
+	// is used per-connection to instantiate a new observer to be
+	// notified of key events during API requests.
+	NewObserver observer.ObserverFactory
+
+	// StatePool only exists to support testing.
 	StatePool *state.StatePool
+}
+
+func (c *ServerConfig) Validate() error {
+	if c.NewObserver == nil {
+		return errors.NotAssignedf("NewObserver")
+	}
+
+	return nil
 }
 
 // changeCertListener wraps a TLS net.Listener.
@@ -165,6 +182,10 @@ func (cl *changeCertListener) updateCertificate(cert, key []byte) {
 //
 // The Server will close the listener when it exits, even if returns an error.
 func NewServer(s *state.State, lis net.Listener, cfg ServerConfig) (*Server, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	// Important note:
 	// Do not manipulate the state within NewServer as the API
 	// server needs to run before mongo upgrades have happened and
@@ -199,14 +220,15 @@ func newServer(s *state.State, lis *net.TCPListener, cfg ServerConfig) (_ *Serve
 	}
 
 	srv := &Server{
-		state:     s,
-		statePool: stPool,
-		lis:       newChangeCertListener(lis, cfg.CertChanged, tlsConfig),
-		tag:       cfg.Tag,
-		dataDir:   cfg.DataDir,
-		logDir:    cfg.LogDir,
-		limiter:   utils.NewLimiter(loginRateLimit),
-		validator: cfg.Validator,
+		newObserver: cfg.NewObserver,
+		state:       s,
+		statePool:   stPool,
+		lis:         newChangeCertListener(lis, cfg.CertChanged, tlsConfig),
+		tag:         cfg.Tag,
+		dataDir:     cfg.DataDir,
+		logDir:      cfg.LogDir,
+		limiter:     utils.NewLimiter(loginRateLimit),
+		validator:   cfg.Validator,
 		adminApiFactories: map[int]adminApiFactory{
 			3: newAdminApiV3,
 		},
@@ -217,6 +239,12 @@ func newServer(s *state.State, lis *net.TCPListener, cfg ServerConfig) (_ *Serve
 	}
 	go srv.run()
 	return srv, nil
+}
+
+func (srv *Server) ConnectionCount() int64 {
+	srv.connCount.RLock()
+	defer srv.connCount.Unlock()
+	return srv.connCount.value
 }
 
 // Dead returns a channel that signals when the server has exited.
@@ -239,87 +267,6 @@ func (srv *Server) Kill() {
 // Wait implements worker.Worker.Wait.
 func (srv *Server) Wait() error {
 	return srv.tomb.Wait()
-}
-
-type requestNotifier struct {
-	id    int64
-	start time.Time
-
-	mu   sync.Mutex
-	tag_ string
-
-	// count is incremented by calls to join, and deincremented
-	// by calls to leave.
-	count *int32
-}
-
-var globalCounter int64
-
-func newRequestNotifier(count *int32) *requestNotifier {
-	return &requestNotifier{
-		id:   atomic.AddInt64(&globalCounter, 1),
-		tag_: "<unknown>",
-		// TODO(fwereade): 2016-03-17 lp:1558657
-		start: time.Now(),
-		count: count,
-	}
-}
-
-func (n *requestNotifier) login(tag string) {
-	n.mu.Lock()
-	n.tag_ = tag
-	n.mu.Unlock()
-}
-
-func (n *requestNotifier) tag() (tag string) {
-	n.mu.Lock()
-	tag = n.tag_
-	n.mu.Unlock()
-	return
-}
-
-func (n *requestNotifier) ServerRequest(hdr *rpc.Header, body interface{}) {
-	if hdr.Request.Type == "Pinger" && hdr.Request.Action == "Ping" {
-		return
-	}
-	// TODO(rog) 2013-10-11 remove secrets from some requests.
-	// Until secrets are removed, we only log the body of the requests at trace level
-	// which is below the default level of debug.
-	if logger.IsTraceEnabled() {
-		logger.Tracef("<- [%X] %s %s", n.id, n.tag(), jsoncodec.DumpRequest(hdr, body))
-	} else {
-		logger.Debugf("<- [%X] %s %s", n.id, n.tag(), jsoncodec.DumpRequest(hdr, "'params redacted'"))
-	}
-}
-
-func (n *requestNotifier) ServerReply(req rpc.Request, hdr *rpc.Header, body interface{}, timeSpent time.Duration) {
-	if req.Type == "Pinger" && req.Action == "Ping" {
-		return
-	}
-	// TODO(rog) 2013-10-11 remove secrets from some responses.
-	// Until secrets are removed, we only log the body of the requests at trace level
-	// which is below the default level of debug.
-	if logger.IsTraceEnabled() {
-		logger.Tracef("-> [%X] %s %s", n.id, n.tag(), jsoncodec.DumpRequest(hdr, body))
-	} else {
-		logger.Debugf("-> [%X] %s %s %s %s[%q].%s", n.id, n.tag(), timeSpent, jsoncodec.DumpRequest(hdr, "'body redacted'"), req.Type, req.Id, req.Action)
-	}
-}
-
-func (n *requestNotifier) join(req *http.Request) {
-	active := atomic.AddInt32(n.count, 1)
-	logger.Infof("[%X] API connection from %s, active connections: %d", n.id, req.RemoteAddr, active)
-}
-
-func (n *requestNotifier) leave() {
-	active := atomic.AddInt32(n.count, -1)
-	logger.Infof("[%X] %s API connection terminated after %v, active connections: %d", n.id, n.tag(), time.Since(n.start), active)
-}
-
-func (n *requestNotifier) ClientRequest(hdr *rpc.Header, body interface{}) {
-}
-
-func (n *requestNotifier) ClientReply(req rpc.Request, hdr *rpc.Header, body interface{}) {
 }
 
 func (srv *Server) run() {
@@ -531,14 +478,24 @@ func registerEndpoint(ep apihttp.Endpoint, mux *pat.PatternServeMux) {
 }
 
 func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
-	reqNotifier := newRequestNotifier(&srv.connections)
-	reqNotifier.join(req)
-	defer reqNotifier.leave()
+	addCount := func(delta int64) {
+		srv.connCount.Lock()
+		srv.connCount.value += delta
+		srv.connCount.Unlock()
+	}
+
+	addCount(1)
+	defer addCount(-1)
+
+	apiObserver := srv.newObserver()
+	apiObserver.Join(req)
+	defer apiObserver.Leave()
+
 	wsServer := websocket.Server{
 		Handler: func(conn *websocket.Conn) {
 			modelUUID := req.URL.Query().Get(":modeluuid")
 			logger.Tracef("got a request for model %q", modelUUID)
-			if err := srv.serveConn(conn, reqNotifier, modelUUID); err != nil {
+			if err := srv.serveConn(conn, modelUUID, apiObserver); err != nil {
 				logger.Errorf("error serving RPCs: %v", err)
 			}
 		},
@@ -546,23 +503,18 @@ func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
 	wsServer.ServeHTTP(w, req)
 }
 
-func (srv *Server) serveConn(wsConn *websocket.Conn, reqNotifier *requestNotifier, modelUUID string) error {
+func (srv *Server) serveConn(wsConn *websocket.Conn, modelUUID string, apiObserver observer.Observer) error {
 	codec := jsoncodec.NewWebsocket(wsConn)
-	var notifier rpc.RequestNotifier
-	if logger.EffectiveLogLevel() <= loggo.DEBUG {
-		// Incur request monitoring overhead only if we
-		// know we'll need it.
-		notifier = reqNotifier
-	}
-	conn := rpc.NewConn(codec, notifier)
 
-	h, err := srv.newAPIHandler(conn, reqNotifier, modelUUID)
+	conn := rpc.NewConn(codec, apiObserver)
+
+	h, err := srv.newAPIHandler(conn, modelUUID)
 	if err != nil {
 		conn.ServeFinder(&errRoot{err}, serverError)
 	} else {
 		adminApis := make(map[int]interface{})
 		for apiVersion, factory := range srv.adminApiFactories {
-			adminApis[apiVersion] = factory(srv, h, reqNotifier)
+			adminApis[apiVersion] = factory(srv, h, apiObserver)
 		}
 		conn.ServeFinder(newAnonRoot(h, adminApis), serverError)
 	}
@@ -574,7 +526,7 @@ func (srv *Server) serveConn(wsConn *websocket.Conn, reqNotifier *requestNotifie
 	return conn.Close()
 }
 
-func (srv *Server) newAPIHandler(conn *rpc.Conn, reqNotifier *requestNotifier, modelUUID string) (*apiHandler, error) {
+func (srv *Server) newAPIHandler(conn *rpc.Conn, modelUUID string) (*apiHandler, error) {
 	// Note that we don't overwrite modelUUID here because
 	// newAPIHandler treats an empty modelUUID as signifying
 	// the API version used.
@@ -589,7 +541,7 @@ func (srv *Server) newAPIHandler(conn *rpc.Conn, reqNotifier *requestNotifier, m
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return newApiHandler(srv, st, conn, reqNotifier, modelUUID)
+	return newApiHandler(srv, st, conn, modelUUID)
 }
 
 func (srv *Server) mongoPinger() error {

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/apiserver/authentication"
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
@@ -98,7 +99,7 @@ func TestingApiHandler(c *gc.C, srvSt, st *state.State) (*apiHandler, *common.Re
 		state:    srvSt,
 		tag:      names.NewMachineTag("0"),
 	}
-	h, err := newApiHandler(srv, st, nil, nil, st.ModelUUID())
+	h, err := newApiHandler(srv, st, nil, st.ModelUUID())
 	c.Assert(err, jc.ErrorIsNil)
 	return h, h.getResources()
 }
@@ -119,7 +120,7 @@ func TestingRestrictedApiHandler(st *state.State) rpc.MethodFinder {
 
 type preFacadeAdminApi struct{}
 
-func newPreFacadeAdminApi(srv *Server, root *apiHandler, reqNotifier *requestNotifier) interface{} {
+func newPreFacadeAdminApi(srv *Server, root *apiHandler, observer observer.Observer) interface{} {
 	return &preFacadeAdminApi{}
 }
 
@@ -137,7 +138,7 @@ func (r *preFacadeAdminApi) Login(c params.Creds) (params.LoginResult, error) {
 
 type failAdminApi struct{}
 
-func newFailAdminApi(srv *Server, root *apiHandler, reqNotifier *requestNotifier) interface{} {
+func newFailAdminApi(srv *Server, root *apiHandler, observer observer.Observer) interface{} {
 	return &failAdminApi{}
 }
 

--- a/apiserver/observer/fakeobserver/instance.go
+++ b/apiserver/observer/fakeobserver/instance.go
@@ -1,0 +1,62 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package fakeobserver
+
+import (
+	"net/http"
+	"runtime"
+
+	"strings"
+
+	"github.com/juju/juju/rpc"
+	"github.com/juju/testing"
+)
+
+type Instance struct {
+	testing.Stub
+}
+
+func (f *Instance) Join(req *http.Request) {
+	f.AddCall(funcName(), req)
+}
+
+func (f *Instance) Leave() {
+	f.AddCall(funcName())
+}
+
+// ServerReply implements Observer.
+func (f *Instance) ServerReply(req rpc.Request, hdr *rpc.Header, body interface{}) {
+	f.AddCall(funcName(), req, hdr, body)
+}
+
+// ServerRequest implements Observer.
+func (f *Instance) ServerRequest(hdr *rpc.Header, body interface{}) {
+	f.AddCall(funcName(), hdr, body)
+}
+
+// Login implements Observer.
+func (f *Instance) Login(entityName string) {
+	f.AddCall(funcName(), entityName)
+}
+
+// ClientRequest implements Observer.
+func (f *Instance) ClientRequest(hdr *rpc.Header, body interface{}) {
+	f.AddCall(funcName(), hdr, body)
+}
+
+// ClientReply implements Observer.
+func (f *Instance) ClientReply(req rpc.Request, hdr *rpc.Header, body interface{}) {
+	f.AddCall(funcName(), req, hdr, body)
+}
+
+// funcName returns the name of the function/method that called
+// funcName() It panics if this is not possible.
+func funcName() string {
+	if pc, _, _, ok := runtime.Caller(1); ok == false {
+		panic("could not find function name")
+	} else {
+		parts := strings.Split(runtime.FuncForPC(pc).Name(), ".")
+		return parts[len(parts)-1]
+	}
+}

--- a/apiserver/observer/observer.go
+++ b/apiserver/observer/observer.go
@@ -1,0 +1,115 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package observer
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/juju/juju/rpc"
+)
+
+// Observer defines a type which will observe API server events as
+// they happen.
+type Observer interface {
+	rpc.RequestNotifier
+
+	// Login informs an Observer that an entity has logged in.
+	Login(string)
+
+	// Join is called when the connection to the API server's
+	// WebSocket is opened.
+	Join(req *http.Request)
+
+	// Leave is called when the connection to the API server's
+	// WebSocket is closed.
+	Leave()
+}
+
+// ObserverFactory is a function which creates an Observer.
+type ObserverFactory func() Observer
+
+// ObserverFactoryMultiplexer returns an ObserverFactory which will
+// return a Multiplexer of all the observers instantiated from the
+// factories passed in.
+func ObserverFactoryMultiplexer(factories ...ObserverFactory) ObserverFactory {
+	return func() Observer {
+		observers := make([]Observer, 0, len(factories))
+		for _, newObserver := range factories {
+			observers = append(observers, newObserver())
+		}
+		return NewMultiplexer(observers...)
+	}
+}
+
+// None is a wrapper around the Multiplexer factory to add clarity to
+// code that doesn't need any observers.
+func None() *Multiplexer {
+	return NewMultiplexer()
+}
+
+// NewMultiplexer creates a new Multiplexer with the provided
+// observers.
+func NewMultiplexer(observers ...Observer) *Multiplexer {
+	return &Multiplexer{
+		observers: removeNilObservers(observers),
+	}
+}
+
+func removeNilObservers(observers []Observer) []Observer {
+	var validatedObservers []Observer
+	for _, o := range observers {
+		if o == nil {
+			continue
+		}
+		validatedObservers = append(validatedObservers, o)
+	}
+	return validatedObservers
+}
+
+// Multiplexer multiplexes calls to an arbitray number of observers.
+type Multiplexer struct {
+	observers []Observer
+}
+
+// Join is called when the connection to the API server's WebSocket is
+// opened.
+func (m *Multiplexer) Join(req *http.Request) {
+	mapConcurrent(func(o Observer) { o.Join(req) }, m.observers)
+}
+
+// Leave implements Observer.
+func (m *Multiplexer) Leave() {
+	mapConcurrent(Observer.Leave, m.observers)
+}
+
+// ServerReply implements Observer.
+func (m *Multiplexer) ServerReply(req rpc.Request, hdr *rpc.Header, body interface{}) {
+	mapConcurrent(func(o Observer) { o.ServerReply(req, hdr, body) }, m.observers)
+}
+
+// ServerRequest implements Observer.
+func (m *Multiplexer) ServerRequest(hdr *rpc.Header, body interface{}) {
+	mapConcurrent(func(o Observer) { o.ServerRequest(hdr, body) }, m.observers)
+}
+
+// Login implements Observer.
+func (m *Multiplexer) Login(entityName string) {
+	mapConcurrent(func(o Observer) { o.Login(entityName) }, m.observers)
+}
+
+// mapConcurrent calls fn on all observers concurrently and then waits
+// for all calls to exit before returning.
+func mapConcurrent(fn func(Observer), observers []Observer) {
+	var wg sync.WaitGroup
+	wg.Add(len(observers))
+	defer wg.Wait()
+
+	for _, o := range observers {
+		go func(obs Observer) {
+			defer wg.Done()
+			fn(obs)
+		}(o)
+	}
+}

--- a/apiserver/observer/observer_test.go
+++ b/apiserver/observer/observer_test.go
@@ -1,0 +1,117 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package observer_test
+
+import (
+	"net/http"
+
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/observer"
+	"github.com/juju/juju/apiserver/observer/fakeobserver"
+	"github.com/juju/juju/rpc"
+)
+
+type observerSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&observerSuite{})
+
+func (*observerSuite) TestObserverFactoryMultiplexer_CallsAllFactories(c *gc.C) {
+	callCount := 0
+	factories := []observer.ObserverFactory{
+		func() observer.Observer { callCount++; return nil },
+		func() observer.Observer { callCount++; return nil },
+	}
+
+	newMultiplexObserver := observer.ObserverFactoryMultiplexer(factories...)
+	c.Assert(callCount, gc.Equals, 0)
+
+	multiplexedObserver := newMultiplexObserver()
+	c.Check(multiplexedObserver, gc.NotNil)
+	c.Check(callCount, gc.Equals, 2)
+}
+
+func (*observerSuite) TestJoin_CallsAllObservers(c *gc.C) {
+	observers := []*fakeobserver.Instance{
+		&fakeobserver.Instance{},
+		&fakeobserver.Instance{},
+	}
+
+	o := observer.NewMultiplexer(observers[0], observers[1])
+	var req http.Request
+	o.Join(&req)
+
+	for _, f := range observers {
+		f.CheckCall(c, 0, "Join", &req)
+	}
+}
+
+func (*observerSuite) TestLeave_CallsAllObservers(c *gc.C) {
+	observers := []*fakeobserver.Instance{
+		&fakeobserver.Instance{},
+		&fakeobserver.Instance{},
+	}
+
+	o := observer.NewMultiplexer(observers[0], observers[1])
+	o.Leave()
+
+	for _, f := range observers {
+		f.CheckCall(c, 0, "Leave")
+	}
+}
+
+func (*observerSuite) TestServerReply_CallsAllObservers(c *gc.C) {
+	observers := []*fakeobserver.Instance{
+		&fakeobserver.Instance{},
+		&fakeobserver.Instance{},
+	}
+
+	o := observer.NewMultiplexer(observers[0], observers[1])
+	var (
+		req  rpc.Request
+		hdr  rpc.Header
+		body string
+	)
+	o.ServerReply(req, &hdr, body)
+
+	for _, f := range observers {
+		f.CheckCall(c, 0, "ServerReply", req, &hdr, body)
+	}
+}
+
+func (*observerSuite) TestServerRequest_CallsAllObservers(c *gc.C) {
+	observers := []*fakeobserver.Instance{
+		&fakeobserver.Instance{},
+		&fakeobserver.Instance{},
+	}
+
+	o := observer.NewMultiplexer(observers[0], observers[1])
+	var (
+		hdr  rpc.Header
+		body string
+	)
+	o.ServerRequest(&hdr, body)
+
+	for _, f := range observers {
+		f.CheckCall(c, 0, "ServerRequest", &hdr, body)
+	}
+}
+
+func (*observerSuite) TestLogin_CallsAllObservers(c *gc.C) {
+	observers := []*fakeobserver.Instance{
+		&fakeobserver.Instance{},
+		&fakeobserver.Instance{},
+	}
+
+	o := observer.NewMultiplexer(observers[0], observers[1])
+	tag := "foo"
+	o.Login(tag)
+
+	for _, f := range observers {
+		f.CheckCall(c, 0, "Login", tag)
+	}
+}

--- a/apiserver/observer/package_test.go
+++ b/apiserver/observer/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package observer_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/observer/request_notifier.go
+++ b/apiserver/observer/request_notifier.go
@@ -1,0 +1,119 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package observer
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/juju/loggo"
+	"github.com/juju/utils/clock"
+
+	"github.com/juju/juju/rpc"
+	"github.com/juju/juju/rpc/jsoncodec"
+)
+
+// RequestNotifier serves as a sink for API server requests and
+// responses.
+type RequestNotifier struct {
+	clock              clock.Clock
+	logger             loggo.Logger
+	apiConnectionCount func() int64
+	id                 int64
+
+	// state represents information that's built up as methods on this
+	// type are called. We segregate this to ensure it's clear what
+	// information is transient in case we want to extract it
+	// later. It's an anonymous struct so this doesn't leak outside
+	// this type.
+	state struct {
+		websocketConnected time.Time
+		requestStart       time.Time
+		tag                string
+	}
+}
+
+// RequestNotifierContext provides information needed for a
+// RequestNotifier to operate correctly.
+type RequestNotifierContext struct {
+
+	// Clock is the clock to use for all time operations on this type.
+	Clock clock.Clock
+
+	// Logger is the log to use to write log statements.
+	Logger loggo.Logger
+}
+
+// NewRequestNotifier returns a new RequestNotifier.
+func NewRequestNotifier(ctx RequestNotifierContext, id int64) *RequestNotifier {
+	return &RequestNotifier{
+		clock:  ctx.Clock,
+		logger: ctx.Logger,
+		id:     id,
+	}
+}
+
+// Login implements Observer.
+func (n *RequestNotifier) Login(tag string) {
+	n.state.tag = tag
+}
+
+// ServerReques timplements Observer.
+func (n *RequestNotifier) ServerRequest(hdr *rpc.Header, body interface{}) {
+	n.state.requestStart = n.clock.Now()
+	if hdr.Request.Type == "Pinger" && hdr.Request.Action == "Ping" {
+		return
+	}
+	// TODO(rog) 2013-10-11 remove secrets from some requests.
+	// Until secrets are removed, we only log the body of the requests at trace level
+	// which is below the default level of debug.
+	if n.logger.IsTraceEnabled() {
+		n.logger.Tracef("<- [%X] %s %s", n.id, n.state.tag, jsoncodec.DumpRequest(hdr, body))
+	} else {
+		n.logger.Debugf("<- [%X] %s %s", n.id, n.state.tag, jsoncodec.DumpRequest(hdr, "'params redacted'"))
+	}
+}
+
+// ServerReply implements Observer.
+func (n *RequestNotifier) ServerReply(req rpc.Request, hdr *rpc.Header, body interface{}) {
+	if req.Type == "Pinger" && req.Action == "Ping" {
+		return
+	}
+	// TODO(rog) 2013-10-11 remove secrets from some responses.
+	// Until secrets are removed, we only log the body of the requests at trace level
+	// which is below the default level of debug.
+	if n.logger.IsTraceEnabled() {
+		n.logger.Tracef("-> [%X] %s %s", n.id, n.state.tag, jsoncodec.DumpRequest(hdr, body))
+	} else {
+		n.logger.Debugf(
+			"-> [%X] %s %s %s %s[%q].%s",
+			n.id,
+			n.state.tag,
+			time.Since(n.state.requestStart),
+			jsoncodec.DumpRequest(hdr, "'body redacted'"),
+			req.Type,
+			req.Id,
+			req.Action,
+		)
+	}
+}
+
+// Join implements Observer.
+func (n *RequestNotifier) Join(req *http.Request) {
+	n.state.websocketConnected = n.clock.Now()
+	n.logger.Infof(
+		"[%X] API connection from %s",
+		n.id,
+		req.RemoteAddr,
+	)
+}
+
+// Leave implements Observer.
+func (n *RequestNotifier) Leave() {
+	n.logger.Infof(
+		"[%X] %s API connection terminated after %v",
+		n.id,
+		n.state.tag,
+		time.Since(n.state.websocketConnected),
+	)
+}

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -56,7 +56,7 @@ type apiHandler struct {
 var _ = (*apiHandler)(nil)
 
 // newApiHandler returns a new apiHandler.
-func newApiHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, reqNotifier *requestNotifier, modelUUID string) (*apiHandler, error) {
+func newApiHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID string) (*apiHandler, error) {
 	r := &apiHandler{
 		state:     st,
 		resources: common.NewResources(),

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/juju/juju/api"
 	apimachiner "github.com/juju/juju/api/machiner"
 	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/apiserver/observer"
+	"github.com/juju/juju/apiserver/observer/fakeobserver"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cert"
 	"github.com/juju/juju/controller"
@@ -448,10 +450,11 @@ func newServer(c *gc.C, st *state.State) *apiserver.Server {
 	listener, err := net.Listen("tcp", ":0")
 	c.Assert(err, jc.ErrorIsNil)
 	srv, err := apiserver.NewServer(st, listener, apiserver.ServerConfig{
-		Cert:   []byte(coretesting.ServerCert),
-		Key:    []byte(coretesting.ServerKey),
-		Tag:    names.NewMachineTag("0"),
-		LogDir: c.MkDir(),
+		Cert:        []byte(coretesting.ServerCert),
+		Key:         []byte(coretesting.ServerKey),
+		Tag:         names.NewMachineTag("0"),
+		LogDir:      c.MkDir(),
+		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return srv

--- a/apiserver/testing/fakeapi.go
+++ b/apiserver/testing/fakeapi.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/utils"
 	"golang.org/x/net/websocket"
 
+	"github.com/juju/juju/apiserver/observer/fakeobserver"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
 	"github.com/juju/juju/rpc/rpcreflect"
@@ -76,7 +77,7 @@ func (srv *Server) serveAPI(w http.ResponseWriter, req *http.Request) {
 
 func (srv *Server) serveConn(wsConn *websocket.Conn, modelUUID string) {
 	codec := jsoncodec.NewWebsocket(wsConn)
-	conn := rpc.NewConn(codec, nil)
+	conn := rpc.NewConn(codec, &fakeobserver.Instance{})
 
 	root := allVersions{
 		rpcreflect.ValueOf(reflect.ValueOf(srv.newRoot(modelUUID))),

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -45,6 +45,8 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/apiserver/observer"
+	"github.com/juju/juju/apiserver/observer/fakeobserver"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/constraints"
@@ -751,12 +753,13 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 			estate.apiStatePool = state.NewStatePool(st)
 
 			estate.apiServer, err = apiserver.NewServer(st, estate.apiListener, apiserver.ServerConfig{
-				Cert:      []byte(testing.ServerCert),
-				Key:       []byte(testing.ServerKey),
-				Tag:       names.NewMachineTag("0"),
-				DataDir:   DataDir,
-				LogDir:    LogDir,
-				StatePool: estate.apiStatePool,
+				Cert:        []byte(testing.ServerCert),
+				Key:         []byte(testing.ServerKey),
+				Tag:         names.NewMachineTag("0"),
+				DataDir:     DataDir,
+				LogDir:      LogDir,
+				StatePool:   estate.apiStatePool,
+				NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
 			})
 			if err != nil {
 				panic(err)

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -71,9 +71,7 @@ func (conn *Conn) send(call *Call) {
 	if params == nil {
 		params = struct{}{}
 	}
-	if conn.notifier != nil {
-		conn.notifier.ClientRequest(hdr, params)
-	}
+
 	if err := conn.codec.WriteMessage(hdr, params); err != nil {
 		conn.mutex.Lock()
 		call = conn.clientPending[reqId]
@@ -101,9 +99,6 @@ func (conn *Conn) handleResponse(hdr *Header) error {
 		// removed; response is a server telling us about an
 		// error reading request body. We should still attempt
 		// to read error body, but there's no one to give it to.
-		if conn.notifier != nil {
-			conn.notifier.ClientReply(Request{}, hdr, nil)
-		}
 		err = conn.readBody(nil, false)
 	case hdr.Error != "":
 		// Report rpcreflect.NoSuchMethodError with CodeNotImplemented.
@@ -118,15 +113,9 @@ func (conn *Conn) handleResponse(hdr *Header) error {
 			Code:    hdr.ErrorCode,
 		}
 		err = conn.readBody(nil, false)
-		if conn.notifier != nil {
-			conn.notifier.ClientReply(call.Request, hdr, nil)
-		}
 		call.done()
 	default:
 		err = conn.readBody(call.Response, false)
-		if conn.notifier != nil {
-			conn.notifier.ClientReply(call.Request, hdr, call.Response)
-		}
 		call.done()
 	}
 	return errors.Annotate(err, "error handling response")

--- a/rpc/dispatch_test.go
+++ b/rpc/dispatch_test.go
@@ -32,7 +32,7 @@ func (s *dispatchSuite) SetUpSuite(c *gc.C) {
 	s.BaseSuite.SetUpSuite(c)
 	rpcServer := func(ws *websocket.Conn) {
 		codec := jsoncodec.NewWebsocket(ws)
-		conn := rpc.NewConn(codec, nil)
+		conn := rpc.NewConn(codec, &notifier{})
 
 		conn.Serve(&DispatchRoot{}, nil)
 		conn.Start()

--- a/rpc/export_test.go
+++ b/rpc/export_test.go
@@ -4,3 +4,11 @@
 package rpc
 
 const CodeNotImplemented = codeNotImplemented
+
+// TODO(katco): Remove this as it is exposing internal state of Conn. Age old story: ran out of time to rewrite the tests to do this correctly.
+
+// ClientRequestID exposes the client's request ID which is
+// incremented everytime a connection sends a request.
+func (c *Conn) ClientRequestID() uint64 {
+	return c.reqId
+}

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -379,7 +379,7 @@ func SimpleRoot() *Root {
 
 func (*rpcSuite) TestRPC(c *gc.C) {
 	root := SimpleRoot()
-	client, srvDone, clientNotifier, serverNotifier := newRPCClientServer(c, root, nil, false)
+	client, srvDone, serverNotifier := newRPCClientServer(c, root, nil, false)
 	defer closeClient(c, client, srvDone)
 	for narg := 0; narg < 2; narg++ {
 		for nret := 0; nret < 2; nret++ {
@@ -387,7 +387,6 @@ func (*rpcSuite) TestRPC(c *gc.C) {
 				retErr := nerr != 0
 				p := testCallParams{
 					client:         client,
-					clientNotifier: clientNotifier,
 					serverNotifier: serverNotifier,
 					entry:          "SimpleMethods",
 					narg:           narg,
@@ -417,9 +416,6 @@ type testCallParams struct {
 	// client holds the client-side of the rpc connection that
 	// will be used to make the call.
 	client *rpc.Conn
-
-	// clientNotifier holds the notifier for the client side.
-	clientNotifier *notifier
 
 	// serverNotifier holds the notifier for the server side.
 	serverNotifier *notifier
@@ -462,24 +458,23 @@ func (p testCallParams) errorMessage() string {
 	return fmt.Sprintf("error calling %s", p.request().Action)
 }
 
-func (root *Root) testCall(c *gc.C, p testCallParams) {
-	p.clientNotifier.reset()
-	p.serverNotifier.reset()
+func (root *Root) testCall(c *gc.C, args testCallParams) {
+	args.serverNotifier.reset()
 	root.calls = nil
-	root.returnErr = p.testErr
-	c.Logf("test call %s", p.request().Action)
-	var r stringVal
-	err := p.client.Call(p.request(), stringVal{"arg"}, &r)
+	root.returnErr = args.testErr
+	c.Logf("test call %s", args.request().Action)
+	var response stringVal
+	err := args.client.Call(args.request(), stringVal{"arg"}, &response)
 	switch {
-	case p.retErr && p.testErr:
+	case args.retErr && args.testErr:
 		c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
-			Message: p.errorMessage(),
+			Message: args.errorMessage(),
 		})
-		c.Assert(r, gc.Equals, stringVal{})
-	case p.nret > 0:
-		c.Check(r, gc.Equals, stringVal{p.request().Action + " ret"})
+		c.Assert(response, gc.Equals, stringVal{})
+	case args.nret > 0:
+		c.Check(response, gc.Equals, stringVal{args.request().Action + " ret"})
 	}
-	if !p.testErr {
+	if !args.testErr {
 		c.Check(err, jc.ErrorIsNil)
 	}
 
@@ -488,11 +483,8 @@ func (root *Root) testCall(c *gc.C, p testCallParams) {
 	root.mu.Lock()
 	defer root.mu.Unlock()
 
-	root.assertCallMade(c, p)
-
-	requestId := root.assertClientNotified(c, p, &r)
-
-	root.assertServerNotified(c, p, requestId)
+	root.assertCallMade(c, args)
+	root.assertServerNotified(c, args, args.client.ClientRequestID())
 }
 
 func (root *Root) assertCallMade(c *gc.C, p testCallParams) {
@@ -507,57 +499,10 @@ func (root *Root) assertCallMade(c *gc.C, p testCallParams) {
 	c.Assert(*root.calls[0], gc.Equals, expectCall)
 }
 
-// assertClientNotified asserts that the right client notifications
-// were made for the given test call parameters. The value of r
-// holds the result parameter passed to the call.
-// It returns the request id.
-func (root *Root) assertClientNotified(c *gc.C, p testCallParams, r interface{}) uint64 {
-	c.Assert(p.clientNotifier.serverRequests, gc.HasLen, 0)
-	c.Assert(p.clientNotifier.serverReplies, gc.HasLen, 0)
-
-	// Test that there was a notification for the request.
-	c.Assert(p.clientNotifier.clientRequests, gc.HasLen, 1)
-	clientReq := p.clientNotifier.clientRequests[0]
-	requestId := clientReq.hdr.RequestId
-	clientReq.hdr.RequestId = 0 // Ignore the exact value of the request id to start with.
-	c.Assert(clientReq.hdr, gc.DeepEquals, rpc.Header{
-		Request: p.request(),
-		Version: 1,
-	})
-	c.Assert(clientReq.body, gc.Equals, stringVal{"arg"})
-
-	// Test that there was a notification for the reply.
-	c.Assert(p.clientNotifier.clientReplies, gc.HasLen, 1)
-	clientReply := p.clientNotifier.clientReplies[0]
-	c.Assert(clientReply.req, gc.Equals, p.request())
-	if p.retErr && p.testErr {
-		c.Assert(clientReply.body, gc.Equals, nil)
-	} else {
-		c.Assert(clientReply.body, gc.Equals, r)
-	}
-	if p.retErr && p.testErr {
-		c.Assert(clientReply.hdr, gc.DeepEquals, rpc.Header{
-			RequestId: requestId,
-			Error:     p.errorMessage(),
-			Version:   1,
-		})
-	} else {
-		c.Assert(clientReply.hdr, gc.DeepEquals, rpc.Header{
-			RequestId: requestId,
-			Version:   1,
-		})
-	}
-	return requestId
-}
-
 // assertServerNotified asserts that the right server notifications
 // were made for the given test call parameters. The id of the request
 // is held in requestId.
 func (root *Root) assertServerNotified(c *gc.C, p testCallParams, requestId uint64) {
-	// Check that the right server notifications were made.
-	c.Assert(p.serverNotifier.clientRequests, gc.HasLen, 0)
-	c.Assert(p.serverNotifier.clientReplies, gc.HasLen, 0)
-
 	// Test that there was a notification for the request.
 	c.Assert(p.serverNotifier.serverRequests, gc.HasLen, 1)
 	serverReq := p.serverNotifier.serverRequests[0]
@@ -597,11 +542,10 @@ func (root *Root) assertServerNotified(c *gc.C, p testCallParams, requestId uint
 
 func (*rpcSuite) TestInterfaceMethods(c *gc.C) {
 	root := SimpleRoot()
-	client, srvDone, clientNotifier, serverNotifier := newRPCClientServer(c, root, nil, false)
+	client, srvDone, serverNotifier := newRPCClientServer(c, root, nil, false)
 	defer closeClient(c, client, srvDone)
 	p := testCallParams{
 		client:         client,
-		clientNotifier: clientNotifier,
 		serverNotifier: serverNotifier,
 		entry:          "InterfaceMethods",
 		narg:           1,
@@ -626,12 +570,11 @@ func (*rpcSuite) TestInterfaceMethods(c *gc.C) {
 
 func (*rpcSuite) TestCustomMethodFinderV0(c *gc.C) {
 	root := &CustomMethodFinder{SimpleRoot()}
-	client, srvDone, clientNotifier, serverNotifier := newRPCClientServer(c, root, nil, false)
+	client, srvDone, serverNotifier := newRPCClientServer(c, root, nil, false)
 	defer closeClient(c, client, srvDone)
 	// V0 of MultiVersion implements only VariableMethods1.Call0r1.
 	p := testCallParams{
 		client:         client,
-		clientNotifier: clientNotifier,
 		serverNotifier: serverNotifier,
 		entry:          "MultiVersion",
 		version:        0,
@@ -653,12 +596,11 @@ func (*rpcSuite) TestCustomMethodFinderV0(c *gc.C) {
 
 func (*rpcSuite) TestCustomMethodFinderV1(c *gc.C) {
 	root := &CustomMethodFinder{SimpleRoot()}
-	client, srvDone, clientNotifier, serverNotifier := newRPCClientServer(c, root, nil, false)
+	client, srvDone, serverNotifier := newRPCClientServer(c, root, nil, false)
 	defer closeClient(c, client, srvDone)
 	// V1 of MultiVersion implements only VariableMethods2.Call1r1.
 	p := testCallParams{
 		client:         client,
-		clientNotifier: clientNotifier,
 		serverNotifier: serverNotifier,
 		entry:          "MultiVersion",
 		version:        1,
@@ -680,11 +622,10 @@ func (*rpcSuite) TestCustomMethodFinderV1(c *gc.C) {
 
 func (*rpcSuite) TestCustomMethodFinderV2(c *gc.C) {
 	root := &CustomMethodFinder{SimpleRoot()}
-	client, srvDone, clientNotifier, serverNotifier := newRPCClientServer(c, root, nil, false)
+	client, srvDone, serverNotifier := newRPCClientServer(c, root, nil, false)
 	defer closeClient(c, client, srvDone)
 	p := testCallParams{
 		client:         client,
-		clientNotifier: clientNotifier,
 		serverNotifier: serverNotifier,
 		entry:          "MultiVersion",
 		version:        2,
@@ -708,7 +649,7 @@ func (*rpcSuite) TestCustomMethodFinderV2(c *gc.C) {
 
 func (*rpcSuite) TestCustomMethodFinderUnknownVersion(c *gc.C) {
 	root := &CustomMethodFinder{SimpleRoot()}
-	client, srvDone, _, _ := newRPCClientServer(c, root, nil, false)
+	client, srvDone, _ := newRPCClientServer(c, root, nil, false)
 	defer closeClient(c, client, srvDone)
 	var r stringVal
 	// Unknown version 5
@@ -732,7 +673,7 @@ func (*rpcSuite) TestConcurrentCalls(c *gc.C) {
 		},
 	}
 
-	client, srvDone, _, _ := newRPCClientServer(c, root, nil, false)
+	client, srvDone, _ := newRPCClientServer(c, root, nil, false)
 	defer closeClient(c, client, srvDone)
 	call := func(id string, done chan<- struct{}) {
 		var r stringVal
@@ -774,7 +715,7 @@ func (*rpcSuite) TestErrorCode(c *gc.C) {
 	root := &Root{
 		errorInst: &ErrorMethods{&codedError{"message", "code"}},
 	}
-	client, srvDone, _, _ := newRPCClientServer(c, root, nil, false)
+	client, srvDone, _ := newRPCClientServer(c, root, nil, false)
 	defer closeClient(c, client, srvDone)
 	err := client.Call(rpc.Request{"ErrorMethods", 0, "", "Call"}, nil, nil)
 	c.Assert(err, gc.ErrorMatches, `message \(code\)`)
@@ -795,7 +736,7 @@ func (*rpcSuite) TestTransformErrors(c *gc.C) {
 		}
 		return fmt.Errorf("transformed: %v", err)
 	}
-	client, srvDone, _, _ := newRPCClientServer(c, root, tfErr, false)
+	client, srvDone, _ := newRPCClientServer(c, root, tfErr, false)
 	defer closeClient(c, client, srvDone)
 	// First, we don't transform methods we can't find.
 	err := client.Call(rpc.Request{"foo", 0, "", "bar"}, nil, nil)
@@ -841,7 +782,7 @@ func (*rpcSuite) TestServerWaitsForOutstandingCalls(c *gc.C) {
 			},
 		},
 	}
-	client, srvDone, _, _ := newRPCClientServer(c, root, nil, false)
+	client, srvDone, _ := newRPCClientServer(c, root, nil, false)
 	defer closeClient(c, client, srvDone)
 	done := make(chan struct{})
 	go func() {
@@ -877,7 +818,7 @@ func (*rpcSuite) TestCompatibility(c *gc.C) {
 	a0 := &SimpleMethods{root: root, id: "a0"}
 	root.simple["a0"] = a0
 
-	client, srvDone, _, _ := newRPCClientServer(c, root, nil, false)
+	client, srvDone, _ := newRPCClientServer(c, root, nil, false)
 	defer closeClient(c, client, srvDone)
 	call := func(method string, arg, ret interface{}) (passedArg interface{}) {
 		root.calls = nil
@@ -921,22 +862,22 @@ func (*rpcSuite) TestBadCall(c *gc.C) {
 	}
 	a0 := &SimpleMethods{root: root, id: "a0"}
 	root.simple["a0"] = a0
-	client, srvDone, clientNotifier, serverNotifier := newRPCClientServer(c, root, nil, false)
+	client, srvDone, serverNotifier := newRPCClientServer(c, root, nil, false)
 	defer closeClient(c, client, srvDone)
 
-	testBadCall(c, client, clientNotifier, serverNotifier,
+	testBadCall(c, client, serverNotifier,
 		rpc.Request{"BadSomething", 0, "a0", "No"},
 		`unknown object type "BadSomething"`,
 		rpc.CodeNotImplemented,
 		false,
 	)
-	testBadCall(c, client, clientNotifier, serverNotifier,
+	testBadCall(c, client, serverNotifier,
 		rpc.Request{"SimpleMethods", 0, "xx", "No"},
 		"no such request - method SimpleMethods.No is not implemented",
 		rpc.CodeNotImplemented,
 		false,
 	)
-	testBadCall(c, client, clientNotifier, serverNotifier,
+	testBadCall(c, client, serverNotifier,
 		rpc.Request{"SimpleMethods", 0, "xx", "Call0r0"},
 		`unknown SimpleMethods id`,
 		"",
@@ -947,13 +888,12 @@ func (*rpcSuite) TestBadCall(c *gc.C) {
 func testBadCall(
 	c *gc.C,
 	client *rpc.Conn,
-	clientNotifier, serverNotifier *notifier,
+	serverNotifier *notifier,
 	req rpc.Request,
 	expectedErr string,
 	expectedErrCode string,
 	requestKnown bool,
 ) {
-	clientNotifier.reset()
 	serverNotifier.reset()
 	err := client.Call(req, nil, nil)
 	msg := expectedErr
@@ -962,35 +902,6 @@ func testBadCall(
 	}
 	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(msg))
 
-	// Test that there was a notification for the client request.
-	c.Assert(clientNotifier.clientRequests, gc.HasLen, 1)
-	clientReq := clientNotifier.clientRequests[0]
-	requestId := clientReq.hdr.RequestId
-	c.Assert(clientReq, gc.DeepEquals, requestEvent{
-		hdr: rpc.Header{
-			RequestId: requestId,
-			Request:   req,
-			Version:   1,
-		},
-		body: struct{}{},
-	})
-	// Test that there was a notification for the client reply.
-	c.Assert(clientNotifier.clientReplies, gc.HasLen, 1)
-	clientReply := clientNotifier.clientReplies[0]
-	c.Assert(clientReply, gc.DeepEquals, replyEvent{
-		req: req,
-		hdr: rpc.Header{
-			RequestId: requestId,
-			Error:     expectedErr,
-			ErrorCode: expectedErrCode,
-			Version:   1,
-		},
-	})
-
-	// Test that there was a notification for the server request.
-	c.Assert(serverNotifier.serverRequests, gc.HasLen, 1)
-	serverReq := serverNotifier.serverRequests[0]
-
 	// From docs on ServerRequest:
 	// 	If the request was not recognized or there was
 	//	an error reading the body, body will be nil.
@@ -998,9 +909,9 @@ func testBadCall(
 	if requestKnown {
 		expectBody = struct{}{}
 	}
-	c.Assert(serverReq, gc.DeepEquals, requestEvent{
+	c.Assert(serverNotifier.serverRequests[0], gc.DeepEquals, requestEvent{
 		hdr: rpc.Header{
-			RequestId: requestId,
+			RequestId: client.ClientRequestID(),
 			Request:   req,
 			Version:   1,
 		},
@@ -1012,7 +923,7 @@ func testBadCall(
 	serverReply := serverNotifier.serverReplies[0]
 	c.Assert(serverReply, gc.DeepEquals, replyEvent{
 		hdr: rpc.Header{
-			RequestId: requestId,
+			RequestId: client.ClientRequestID(),
 			Error:     expectedErr,
 			ErrorCode: expectedErrCode,
 			Version:   1,
@@ -1028,7 +939,7 @@ func (*rpcSuite) TestContinueAfterReadBodyError(c *gc.C) {
 	}
 	a0 := &SimpleMethods{root: root, id: "a0"}
 	root.simple["a0"] = a0
-	client, srvDone, _, _ := newRPCClientServer(c, root, nil, false)
+	client, srvDone, _ := newRPCClientServer(c, root, nil, false)
 	defer closeClient(c, client, srvDone)
 
 	var ret stringVal
@@ -1054,7 +965,7 @@ func (*rpcSuite) TestContinueAfterReadBodyError(c *gc.C) {
 }
 
 func (*rpcSuite) TestErrorAfterClientClose(c *gc.C) {
-	client, srvDone, _, _ := newRPCClientServer(c, &Root{}, nil, false)
+	client, srvDone, _ := newRPCClientServer(c, &Root{}, nil, false)
 	err := client.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	err = client.Call(rpc.Request{"Foo", 0, "", "Bar"}, nil, nil)
@@ -1064,7 +975,7 @@ func (*rpcSuite) TestErrorAfterClientClose(c *gc.C) {
 }
 
 func (*rpcSuite) TestClientCloseIdempotent(c *gc.C) {
-	client, _, _, _ := newRPCClientServer(c, &Root{}, nil, false)
+	client, _, _ := newRPCClientServer(c, &Root{}, nil, false)
 	err := client.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	err = client.Close()
@@ -1088,7 +999,7 @@ func (r *KillerCleanerRoot) Cleanup() {
 
 func (*rpcSuite) TestRootIsKilledAndCleaned(c *gc.C) {
 	root := &KillerCleanerRoot{}
-	client, srvDone, _, _ := newRPCClientServer(c, root, nil, false)
+	client, srvDone, _ := newRPCClientServer(c, root, nil, false)
 	err := client.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	err = chanReadError(c, srvDone, "server done")
@@ -1099,7 +1010,7 @@ func (*rpcSuite) TestRootIsKilledAndCleaned(c *gc.C) {
 
 func (*rpcSuite) TestBidirectional(c *gc.C) {
 	srvRoot := &Root{}
-	client, srvDone, _, _ := newRPCClientServer(c, srvRoot, nil, true)
+	client, srvDone, _ := newRPCClientServer(c, srvRoot, nil, true)
 	defer closeClient(c, client, srvDone)
 	clientRoot := &Root{conn: client}
 	client.Serve(clientRoot, nil)
@@ -1111,7 +1022,7 @@ func (*rpcSuite) TestBidirectional(c *gc.C) {
 
 func (*rpcSuite) TestServerRequestWhenNotServing(c *gc.C) {
 	srvRoot := &Root{}
-	client, srvDone, _, _ := newRPCClientServer(c, srvRoot, nil, true)
+	client, srvDone, _ := newRPCClientServer(c, srvRoot, nil, true)
 	defer closeClient(c, client, srvDone)
 	var r int64val
 	err := client.Call(rpc.Request{"CallbackMethods", 0, "", "Factorial"}, int64val{12}, &r)
@@ -1120,7 +1031,7 @@ func (*rpcSuite) TestServerRequestWhenNotServing(c *gc.C) {
 
 func (*rpcSuite) TestChangeAPI(c *gc.C) {
 	srvRoot := &Root{}
-	client, srvDone, _, _ := newRPCClientServer(c, srvRoot, nil, true)
+	client, srvDone, _ := newRPCClientServer(c, srvRoot, nil, true)
 	defer closeClient(c, client, srvDone)
 	var s stringVal
 	err := client.Call(rpc.Request{"NewlyAvailable", 0, "", "NewMethod"}, nil, &s)
@@ -1136,7 +1047,7 @@ func (*rpcSuite) TestChangeAPI(c *gc.C) {
 
 func (*rpcSuite) TestChangeAPIToNil(c *gc.C) {
 	srvRoot := &Root{}
-	client, srvDone, _, _ := newRPCClientServer(c, srvRoot, nil, true)
+	client, srvDone, _ := newRPCClientServer(c, srvRoot, nil, true)
 	defer closeClient(c, client, srvDone)
 
 	err := client.Call(rpc.Request{"ChangeAPIMethods", 0, "", "RemoveAPI"}, nil, nil)
@@ -1157,7 +1068,7 @@ func (*rpcSuite) TestChangeAPIWhileServingRequest(c *gc.C) {
 	transform := func(err error) error {
 		return fmt.Errorf("transformed: %v", err)
 	}
-	client, srvDone, _, _ := newRPCClientServer(c, srvRoot, transform, true)
+	client, srvDone, _ := newRPCClientServer(c, srvRoot, transform, true)
 	defer closeClient(c, client, srvDone)
 
 	result := make(chan error)
@@ -1198,12 +1109,16 @@ func chanReadError(c *gc.C, ch <-chan error, what string) error {
 // single client.  When the server has finished serving the connection,
 // it sends a value on the returned channel.
 // If bidir is true, requests can flow in both directions.
-func newRPCClientServer(c *gc.C, root interface{}, tfErr func(error) error, bidir bool) (client *rpc.Conn, srvDone chan error, clientNotifier, serverNotifier *notifier) {
+func newRPCClientServer(
+	c *gc.C,
+	root interface{},
+	tfErr func(error) error,
+	bidir bool,
+) (client *rpc.Conn, srvDone chan error, serverNotifier *notifier) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	c.Assert(err, jc.ErrorIsNil)
 
 	srvDone = make(chan error, 1)
-	clientNotifier = new(notifier)
 	serverNotifier = new(notifier)
 	go func() {
 		conn, err := l.Accept()
@@ -1236,9 +1151,9 @@ func newRPCClientServer(c *gc.C, root interface{}, tfErr func(error) error, bidi
 	if bidir {
 		role = roleBoth
 	}
-	client = rpc.NewConn(NewJSONCodec(conn, role), clientNotifier)
+	client = rpc.NewConn(NewJSONCodec(conn, role), &notifier{})
 	client.Start()
-	return client, srvDone, clientNotifier, serverNotifier
+	return client, srvDone, serverNotifier
 }
 
 func closeClient(c *gc.C, client *rpc.Conn, srvDone <-chan error) {
@@ -1334,8 +1249,6 @@ type notifier struct {
 	mu             sync.Mutex
 	serverRequests []requestEvent
 	serverReplies  []replyEvent
-	clientRequests []requestEvent
-	clientReplies  []replyEvent
 }
 
 func (n *notifier) reset() {
@@ -1343,8 +1256,6 @@ func (n *notifier) reset() {
 	defer n.mu.Unlock()
 	n.serverRequests = nil
 	n.serverReplies = nil
-	n.clientRequests = nil
-	n.clientReplies = nil
 }
 
 func (n *notifier) ServerRequest(hdr *rpc.Header, body interface{}) {
@@ -1356,29 +1267,10 @@ func (n *notifier) ServerRequest(hdr *rpc.Header, body interface{}) {
 	})
 }
 
-func (n *notifier) ServerReply(req rpc.Request, hdr *rpc.Header, body interface{}, timeSpent time.Duration) {
+func (n *notifier) ServerReply(req rpc.Request, hdr *rpc.Header, body interface{}) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	n.serverReplies = append(n.serverReplies, replyEvent{
-		req:  req,
-		hdr:  *hdr,
-		body: body,
-	})
-}
-
-func (n *notifier) ClientRequest(hdr *rpc.Header, body interface{}) {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	n.clientRequests = append(n.clientRequests, requestEvent{
-		hdr:  *hdr,
-		body: body,
-	})
-}
-
-func (n *notifier) ClientReply(req rpc.Request, hdr *rpc.Header, body interface{}) {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	n.clientReplies = append(n.clientReplies, replyEvent{
 		req:  req,
 		hdr:  *hdr,
 		body: body,

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"reflect"
 	"sync"
-	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -171,22 +170,7 @@ type RequestNotifier interface {
 	// body sent as reply.
 	//
 	// ServerReply is called just before the reply is written.
-	ServerReply(req Request, hdr *Header, body interface{}, timeSpent time.Duration)
-
-	// ClientRequest informs the RequestNotifier of a request
-	// made from the Conn. It is called just before the request is
-	// written.
-	ClientRequest(hdr *Header, body interface{})
-
-	// ClientReply informs the RequestNotifier of a reply received
-	// to a request. If the reply was to an unrecognised request,
-	// the Request will be zero-valued. If the reply contained an
-	// error, body will be nil; otherwise body will be the value that
-	// was passed to the Conn.Call method.
-	//
-	// ClientReply is called just before the reply is handed to
-	// back to the caller.
-	ClientReply(req Request, hdr *Header, body interface{})
+	ServerReply(req Request, hdr *Header, body interface{})
 }
 
 // NewConn creates a new connection that uses the given codec for
@@ -194,23 +178,12 @@ type RequestNotifier interface {
 // any requests are sent or received. If notifier is non-nil, the
 // appropriate method will be called for every RPC request.
 func NewConn(codec Codec, notifier RequestNotifier) *Conn {
-	if notifier == nil {
-		notifier = new(dummyNotifier)
-	}
 	return &Conn{
 		codec:         codec,
 		clientPending: make(map[uint64]*Call),
 		notifier:      notifier,
 	}
 }
-
-// dummyNotifier is used when no notifier is provided to NewConn.
-type dummyNotifier struct{}
-
-func (*dummyNotifier) ServerRequest(*Header, interface{})                       {}
-func (*dummyNotifier) ServerReply(Request, *Header, interface{}, time.Duration) {}
-func (*dummyNotifier) ClientRequest(*Header, interface{})                       {}
-func (*dummyNotifier) ClientReply(Request, *Header, interface{})                {}
 
 // Start starts the RPC connection running.  It must be called at least
 // once for any RPC connection (client or server side) It has no effect
@@ -445,8 +418,6 @@ func (conn *Conn) readBody(resp interface{}, isRequest bool) error {
 }
 
 func (conn *Conn) handleRequest(hdr *Header) error {
-	// TODO(perrito666) 2016-05-02 lp:1558657
-	startTime := time.Now()
 	req, err := conn.bindRequest(hdr)
 	if err != nil {
 		conn.notifier.ServerRequest(hdr, nil)
@@ -455,7 +426,7 @@ func (conn *Conn) handleRequest(hdr *Header) error {
 		}
 		// We don't transform the error here. bindRequest will have
 		// already transformed it and returned a zero req.
-		return conn.writeErrorResponse(hdr, err, startTime)
+		return conn.writeErrorResponse(hdr, err)
 	}
 	var argp interface{}
 	var arg reflect.Value
@@ -466,6 +437,7 @@ func (conn *Conn) handleRequest(hdr *Header) error {
 	}
 	if err := conn.readBody(argp, true); err != nil {
 		conn.notifier.ServerRequest(hdr, nil)
+
 		// If we get EOF, we know the connection is a
 		// goner, so don't try to respond.
 		if err == io.EOF || err == io.ErrUnexpectedEOF {
@@ -479,7 +451,7 @@ func (conn *Conn) handleRequest(hdr *Header) error {
 		// the error is actually a framing or syntax
 		// problem, then the next ReadHeader should pick
 		// up the problem and abort.
-		return conn.writeErrorResponse(hdr, req.transformErrors(err), startTime)
+		return conn.writeErrorResponse(hdr, req.transformErrors(err))
 	}
 	if req.ParamsType() != nil {
 		conn.notifier.ServerRequest(hdr, arg.Interface())
@@ -490,17 +462,17 @@ func (conn *Conn) handleRequest(hdr *Header) error {
 	closing := conn.closing
 	if !closing {
 		conn.srvPending.Add(1)
-		go conn.runRequest(req, arg, startTime, hdr.Version)
+		go conn.runRequest(req, arg, hdr.Version)
 	}
 	conn.mutex.Unlock()
 	if closing {
 		// We're closing down - no new requests may be initiated.
-		return conn.writeErrorResponse(hdr, req.transformErrors(ErrShutdown), startTime)
+		return conn.writeErrorResponse(hdr, req.transformErrors(ErrShutdown))
 	}
 	return nil
 }
 
-func (conn *Conn) writeErrorResponse(reqHdr *Header, err error, startTime time.Time) error {
+func (conn *Conn) writeErrorResponse(reqHdr *Header, err error) error {
 	conn.sending.Lock()
 	defer conn.sending.Unlock()
 	hdr := &Header{
@@ -513,7 +485,8 @@ func (conn *Conn) writeErrorResponse(reqHdr *Header, err error, startTime time.T
 		hdr.ErrorCode = ""
 	}
 	hdr.Error = err.Error()
-	conn.notifier.ServerReply(reqHdr.Request, hdr, struct{}{}, time.Since(startTime))
+	conn.notifier.ServerReply(reqHdr.Request, hdr, struct{}{})
+
 	return conn.codec.WriteMessage(hdr, struct{}{})
 }
 
@@ -557,11 +530,11 @@ func (conn *Conn) bindRequest(hdr *Header) (boundRequest, error) {
 }
 
 // runRequest runs the given request and sends the reply.
-func (conn *Conn) runRequest(req boundRequest, arg reflect.Value, startTime time.Time, version int) {
+func (conn *Conn) runRequest(req boundRequest, arg reflect.Value, version int) {
 	defer conn.srvPending.Done()
 	rv, err := req.Call(req.hdr.Request.Id, arg)
 	if err != nil {
-		err = conn.writeErrorResponse(&req.hdr, req.transformErrors(err), startTime)
+		err = conn.writeErrorResponse(&req.hdr, req.transformErrors(err))
 	} else {
 		hdr := &Header{
 			RequestId: req.hdr.RequestId,
@@ -573,7 +546,7 @@ func (conn *Conn) runRequest(req boundRequest, arg reflect.Value, startTime time
 		} else {
 			rvi = struct{}{}
 		}
-		conn.notifier.ServerReply(req.hdr.Request, hdr, rvi, time.Since(startTime))
+		conn.notifier.ServerReply(req.hdr.Request, hdr, rvi)
 		conn.sending.Lock()
 		err = conn.codec.WriteMessage(hdr, rvi)
 		conn.sending.Unlock()


### PR DESCRIPTION
The `apiserver and `rpc` packages previously had a type which would observe RPC connections, and API requests. This type is `apiserver/observers/RequestNotifier`. Because the auditing feature also requires this kind of functionality, we have broadened the injection points to take in N observers, and notify N observers when notable events occur. Currently, the `RequestNotifier` type is the only type which is being registered.

The registration occurs in the `MachineAgent` as composition of a workable apiserver is a concern best raised as far up in the stack as possible.

Functionally, this change maintains the same functionality as before with 1 notable exception: prior, the `rpc` package would send all connections to the log, but only log `apiserver` events if the logging level of `apiserver` was <= DEBUG. After discussing with fwereade and thumper, this behavior has now been coupled. If the logging level of `apiserver` is <= DEBUG, all functionality will be logged; otherwise, none of it will be.

(Review request: http://reviews.vapour.ws/r/5089/)