### PR TITLE
 Do not allow register of alternative controller names

### DIFF
--- a/cmd/juju/commands/migrate_test.go
+++ b/cmd/juju/commands/migrate_test.go
@@ -35,7 +35,7 @@ func (s *MigrateSuite) SetUpTest(c *gc.C) {
 	s.store = jujuclienttesting.NewMemStore()
 
 	// Define the source controller in the config and set it as the default.
-	err := s.store.UpdateController("source", jujuclient.ControllerDetails{
+	err := s.store.AddController("source", jujuclient.ControllerDetails{
 		ControllerUUID: "eeeeeeee-0bad-400d-8000-4b1d0d06f00d",
 		CACert:         "somecert",
 	})
@@ -63,7 +63,7 @@ func (s *MigrateSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Define the target controller in the config.
-	err = s.store.UpdateController("target", jujuclient.ControllerDetails{
+	err = s.store.AddController("target", jujuclient.ControllerDetails{
 		ControllerUUID: targetControllerUUID,
 		APIEndpoints:   []string{"1.2.3.4:5"},
 		CACert:         "cert",

--- a/cmd/juju/commands/plugin_test.go
+++ b/cmd/juju/commands/plugin_test.go
@@ -165,7 +165,7 @@ func (suite *PluginSuite) TestJujuEnvVars(c *gc.C) {
 	// Plugins are run as model commands, and so require a current
 	// account and model.
 	store := jujuclient.NewFileClientStore()
-	err := store.UpdateController("myctrl", jujuclient.ControllerDetails{
+	err := store.AddController("myctrl", jujuclient.ControllerDetails{
 		ControllerUUID: testing.ModelTag.Id(),
 		CACert:         "fake",
 	})

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -163,7 +163,7 @@ func (c *registerCommand) Run(ctx *cmd.Context) error {
 		ControllerUUID: responsePayload.ControllerUUID,
 		CACert:         responsePayload.CACert,
 	}
-	if err := store.UpdateController(registrationParams.controllerName, controllerDetails); err != nil {
+	if err := store.AddController(registrationParams.controllerName, controllerDetails); err != nil {
 		return errors.Trace(err)
 	}
 	macaroonJSON, err := responsePayload.Macaroon.MarshalJSON()
@@ -394,8 +394,7 @@ func (c *registerCommand) promptNewPassword(stderr io.Writer, stdin io.Reader) (
 	return password, nil
 }
 
-const errControllerConflicts = `WARNING: The controller proposed %q which clashes with an existing` +
-	` controller. The two controllers are entirely different.
+const errControllerConflicts = `WARNING: You already have a controller registered with the name %q. Please choose a different name for the new controller.
 
 `
 

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -309,7 +309,7 @@ func (s *RegisterSuite) TestRegisterEmptyControllerName(c *gc.C) {
 }
 
 func (s *RegisterSuite) TestRegisterControllerNameExists(c *gc.C) {
-	err := s.store.UpdateController("controller-name", jujuclient.ControllerDetails{
+	err := s.store.AddController("controller-name", jujuclient.ControllerDetails{
 		ControllerUUID: "df136476-12e9-11e4-8a70-b2227cce2b54",
 		CACert:         testing.CACert,
 	})
@@ -321,9 +321,37 @@ func (s *RegisterSuite) TestRegisterControllerNameExists(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `controller "controller-name" already exists`)
 }
 
-func (s *RegisterSuite) TestProposedControllerNameExists(c *gc.C) {
-	err := s.store.UpdateController("controller-name", jujuclient.ControllerDetails{
+func (s *RegisterSuite) TestControllerUUIDExists(c *gc.C) {
+	// Controller has the UUID from s.testRegister to mimic a user with
+	// this controller already registered (regardless of its name).
+	err := s.store.AddController("controller-name", jujuclient.ControllerDetails{
 		ControllerUUID: "df136476-12e9-11e4-8a70-b2227cce2b54",
+		CACert:         testing.CACert,
+	})
+
+	s.listModels = func(_ jujuclient.ClientStore, controllerName, userName string) ([]base.UserModel, error) {
+		return []base.UserModel{{
+			Name:  "model-name",
+			Owner: "bob@local",
+			UUID:  "df136476-12e9-11e4-8a70-b2227cce2b54",
+		}}, nil
+	}
+
+	s.testRegister(c, "you must specify a non-empty controller name")
+
+	secretKey := []byte(strings.Repeat("X", 32))
+	registrationData := s.encodeRegistrationDataWithControllerName(c, "bob", secretKey, "controller-name")
+
+	stdin := strings.NewReader("another-controller-name\nhunter2\nhunter2\n")
+	_, err = s.run(c, stdin, registrationData)
+	c.Assert(err, gc.ErrorMatches, "controller with UUID.*already exists")
+}
+
+func (s *RegisterSuite) TestProposedControllerNameExists(c *gc.C) {
+	// Controller does not have the UUID from s.testRegister, thereby
+	// mimicing a user with an already registered 'foreign' controller.
+	err := s.store.AddController("controller-name", jujuclient.ControllerDetails{
+		ControllerUUID: "0d75314a-5266-4f4f-8523-415be76f92dc",
 		CACert:         testing.CACert,
 	})
 
@@ -339,12 +367,13 @@ func (s *RegisterSuite) TestProposedControllerNameExists(c *gc.C) {
 
 	secretKey := []byte(strings.Repeat("X", 32))
 	registrationData := s.encodeRegistrationDataWithControllerName(c, "bob", secretKey, "controller-name")
-	stdin := strings.NewReader("controller-name1\nhunter2\nhunter2\n")
+
+	stdin := strings.NewReader("another-controller-name\nhunter2\nhunter2\n")
 	_, err = s.run(c, stdin, registrationData)
 	c.Assert(err, jc.ErrorIsNil)
 	stderr := testing.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `
-WARNING: The controller proposed "controller-name" which clashes with an existing controller. The two controllers are entirely different.
+WARNING: You already have a controller registered with the name "controller-name". Please choose a different name for the new controller.
 
 Enter a name for this controller: 
 `[1:])

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -117,7 +117,7 @@ func decorateAndWriteInfo(
 		names.NewUserTag(details.AccountDetails.User),
 		modelName,
 	)
-	if err := store.UpdateController(controllerName, details.ControllerDetails); err != nil {
+	if err := store.AddController(controllerName, details.ControllerDetails); err != nil {
 		return errors.Trace(err)
 	}
 	if err := store.UpdateBootstrapConfig(controllerName, details.BootstrapConfig); err != nil {

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -250,10 +250,10 @@ func setEndpointAddressAndHostname(c *gc.C, store jujuclient.ControllerStore, ad
 }
 
 // newClientStore returns a client store that contains information
-// based on the given controller namd and info.
+// based on the given controller name and info.
 func newClientStore(c *gc.C, controllerName string) *jujuclienttesting.MemStore {
 	store := jujuclienttesting.NewMemStore()
-	err := store.UpdateController(controllerName, jujuclient.ControllerDetails{
+	err := store.AddController(controllerName, jujuclient.ControllerDetails{
 		ControllerUUID: fakeUUID,
 		CACert:         "certificate",
 		APIEndpoints:   []string{"0.1.2.3:5678"},
@@ -339,7 +339,7 @@ func (s *CacheAPIEndpointsSuite) assertCreateController(c *gc.C, name string) ju
 		ControllerUUID: fakeUUID,
 		CACert:         "certificate",
 	}
-	err := s.ControllerStore.UpdateController(name, controllerDetails)
+	err := s.ControllerStore.AddController(name, controllerDetails)
 	c.Assert(err, jc.ErrorIsNil)
 	return controllerDetails
 }
@@ -383,7 +383,7 @@ func (s *CacheAPIEndpointsSuite) TestResolveSkippedWhenHostnamesUnchanged(c *gc.
 		CACert:                 "certificate",
 		UnresolvedAPIEndpoints: network.HostPortsToStrings(hps),
 	}
-	err := s.ControllerStore.UpdateController("controller-name", controllerDetails)
+	err := s.ControllerStore.AddController("controller-name", controllerDetails)
 	c.Assert(err, jc.ErrorIsNil)
 
 	addrs, hosts, changed := juju.PrepareEndpointsForCaching(
@@ -432,7 +432,7 @@ func (s *CacheAPIEndpointsSuite) TestResolveCalledWithChangedHostnames(c *gc.C) 
 		CACert:                 "certificate",
 		UnresolvedAPIEndpoints: strUnsorted,
 	}
-	err := s.ControllerStore.UpdateController("controller-name", controllerDetails)
+	err := s.ControllerStore.AddController("controller-name", controllerDetails)
 	c.Assert(err, jc.ErrorIsNil)
 
 	addrs, hosts, changed := juju.PrepareEndpointsForCaching(
@@ -482,7 +482,7 @@ func (s *CacheAPIEndpointsSuite) TestAfterResolvingUnchangedAddressesNotCached(c
 		UnresolvedAPIEndpoints: strUnsorted,
 		APIEndpoints:           strResolved,
 	}
-	err := s.ControllerStore.UpdateController("controller-name", controllerDetails)
+	err := s.ControllerStore.AddController("controller-name", controllerDetails)
 	c.Assert(err, jc.ErrorIsNil)
 
 	addrs, hosts, changed := juju.PrepareEndpointsForCaching(
@@ -530,7 +530,7 @@ func (s *CacheAPIEndpointsSuite) TestResolveCalledWithInitialEndpoints(c *gc.C) 
 		ControllerUUID: fakeUUID,
 		CACert:         "certificate",
 	}
-	err := s.ControllerStore.UpdateController("controller-name", controllerDetails)
+	err := s.ControllerStore.AddController("controller-name", controllerDetails)
 	c.Assert(err, jc.ErrorIsNil)
 
 	addrs, hosts, changed := juju.PrepareEndpointsForCaching(

--- a/jujuclient/accounts_test.go
+++ b/jujuclient/accounts_test.go
@@ -94,7 +94,7 @@ func (s *AccountsSuite) TestRemoveAccount(c *gc.C) {
 
 func (s *AccountsSuite) TestRemoveControllerRemovesaccounts(c *gc.C) {
 	store := jujuclient.NewFileClientStore()
-	err := store.UpdateController("kontroll", jujuclient.ControllerDetails{
+	err := store.AddController("kontroll", jujuclient.ControllerDetails{
 		ControllerUUID: "abc",
 		CACert:         "woop",
 	})

--- a/jujuclient/controllers_test.go
+++ b/jujuclient/controllers_test.go
@@ -62,25 +62,68 @@ func (s *ControllersSuite) TestControllerByName(c *gc.C) {
 	c.Assert(found, gc.DeepEquals, &expected)
 }
 
-func (s *ControllersSuite) TestUpdateControllerAddFirst(c *gc.C) {
-	err := s.store.UpdateController(s.controllerName, s.controller)
+func (s *ControllersSuite) TestAddController(c *gc.C) {
+	err := s.store.AddController(s.controllerName, s.controller)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertUpdateSucceeded(c)
 }
 
-func (s *ControllersSuite) TestUpdateControllerAddNew(c *gc.C) {
-	s.assertControllerNotExists(c)
-	err := s.store.UpdateController(s.controllerName, s.controller)
+func (s *ControllersSuite) TestAddControllerDupUUIDFails(c *gc.C) {
+	err := s.store.AddController(s.controllerName, s.controller)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertUpdateSucceeded(c)
+	// Try to add it again
+	err = s.store.AddController(s.controllerName+"-copy", s.controller)
+	c.Assert(err, gc.ErrorMatches, `controller with UUID .* already exists`)
+}
+
+func (s *ControllersSuite) TestAddControllerDupNameFails(c *gc.C) {
+	err := s.store.AddController(s.controllerName, s.controller)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertUpdateSucceeded(c)
+	// Try to add it again
+	err = s.store.AddController(s.controllerName, s.controller)
+	c.Assert(err, gc.ErrorMatches, `controller with name .* already exists`)
+}
+
+func (s *ControllersSuite) TestUpdateControllerAddFirst(c *gc.C) {
+	// UpdateController should fail if no controller has first been added
+	// with AddController.
+	err := s.store.UpdateController(s.controllerName, s.controller)
+	c.Assert(err, gc.ErrorMatches, `controllers not found`)
+}
+
+func (s *ControllersSuite) TestUpdateControllerAddNew(c *gc.C) {
+	// UpdateController should fail if no controller has first been added
+	// with AddController.
+	s.assertControllerNotExists(c)
+	err := s.store.UpdateController(s.controllerName, s.controller)
+	c.Assert(err, gc.ErrorMatches, `controller .*not found`)
 }
 
 func (s *ControllersSuite) TestUpdateController(c *gc.C) {
 	s.controllerName = firstTestControllerName(c)
-
+	all := writeTestControllersFile(c)
+	// This is not a restore (backup), so update with the existing UUID.
+	s.controller.ControllerUUID = all.Controllers[s.controllerName].ControllerUUID
 	err := s.store.UpdateController(s.controllerName, s.controller)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertUpdateSucceeded(c)
+}
+
+// Try and fail to use an existing controller's UUID to update another exisiting
+// controller's config.
+func (s *ControllersSuite) TestUpdateControllerDupUUID(c *gc.C) {
+	firstControllerName := firstTestControllerName(c)
+	all := writeTestControllersFile(c)
+	firstControllerUUID := all.Controllers[firstControllerName].ControllerUUID
+	for name, details := range all.Controllers {
+		if details.ControllerUUID != firstControllerUUID {
+			details.ControllerUUID = firstControllerUUID
+			err := s.store.UpdateController(name, details)
+			c.Assert(err, gc.ErrorMatches, `controller .* with UUID .* already exists`)
+		}
+	}
 }
 
 func (s *ControllersSuite) TestRemoveControllerNoFile(c *gc.C) {
@@ -105,23 +148,6 @@ func (s *ControllersSuite) TestRemoveController(c *gc.C) {
 	c.Assert(found, gc.IsNil)
 }
 
-func (s *ControllersSuite) TestRemoveControllerRemovesIdenticalControllers(c *gc.C) {
-	name := firstTestControllerName(c)
-	details, err := s.store.ControllerByName(name)
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.store.UpdateController(name+"-copy", *details)
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = s.store.RemoveController(name)
-	c.Assert(err, jc.ErrorIsNil)
-
-	for _, name := range []string{name, name + "-copy"} {
-		found, err := s.store.ControllerByName(name)
-		c.Assert(err, gc.ErrorMatches, fmt.Sprintf("controller %v not found", name))
-		c.Assert(found, gc.IsNil)
-	}
-}
-
 func (s *ControllersSuite) TestCurrentControllerNoneExists(c *gc.C) {
 	_, err := s.store.CurrentController()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
@@ -137,7 +163,7 @@ func (s *ControllersSuite) TestCurrentController(c *gc.C) {
 }
 
 func (s *ControllersSuite) TestSetCurrentController(c *gc.C) {
-	err := s.store.UpdateController(s.controllerName, s.controller)
+	err := s.store.AddController(s.controllerName, s.controller)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.store.SetCurrentController(s.controllerName)
 	c.Assert(err, jc.ErrorIsNil)

--- a/jujuclient/file.go
+++ b/jujuclient/file.go
@@ -108,7 +108,46 @@ func (s *store) ControllerByName(name string) (*ControllerDetails, error) {
 	return nil, errors.NotFoundf("controller %s", name)
 }
 
-// UpdateController implements ControllersUpdater.
+// AddController implements ControllerUpdater.
+func (s *store) AddController(name string, details ControllerDetails) error {
+	if err := ValidateControllerName(name); err != nil {
+		return errors.Trace(err)
+	}
+	if err := ValidateControllerDetails(details); err != nil {
+		return errors.Trace(err)
+	}
+
+	releaser, err := s.acquireLock()
+	if err != nil {
+		return errors.Annotatef(err, "cannot add controller %v", name)
+	}
+	defer releaser.Release()
+
+	all, err := ReadControllersFile(JujuControllersPath())
+	if err != nil {
+		return errors.Annotate(err, "cannot get controllers")
+	}
+
+	if len(all.Controllers) == 0 {
+		all.Controllers = make(map[string]ControllerDetails)
+	}
+
+	if _, ok := all.Controllers[name]; ok {
+		return errors.AlreadyExistsf("controller with name %s", name)
+	}
+
+	for k, v := range all.Controllers {
+		if v.ControllerUUID == details.ControllerUUID {
+			return errors.AlreadyExistsf("controller with UUID %s (%s)",
+				details.ControllerUUID, k)
+		}
+	}
+
+	all.Controllers[name] = details
+	return WriteControllersFile(all)
+}
+
+// UpdateController implements ControllerUpdater.
 func (s *store) UpdateController(name string, details ControllerDetails) error {
 	if err := ValidateControllerName(name); err != nil {
 		return errors.Trace(err)
@@ -129,14 +168,25 @@ func (s *store) UpdateController(name string, details ControllerDetails) error {
 	}
 
 	if len(all.Controllers) == 0 {
-		all.Controllers = make(map[string]ControllerDetails)
+		return errors.NotFoundf("controllers")
+	}
+
+	for k, v := range all.Controllers {
+		if v.ControllerUUID == details.ControllerUUID && k != name {
+			return errors.AlreadyExistsf("controller %s with UUID %s",
+				k, v.ControllerUUID)
+		}
+	}
+
+	if _, ok := all.Controllers[name]; !ok {
+		return errors.NotFoundf("controller %s", name)
 	}
 
 	all.Controllers[name] = details
 	return WriteControllersFile(all)
 }
 
-// SetCurrentController implements ControllersUpdater.
+// SetCurrentController implements ControllerUpdater.
 func (s *store) SetCurrentController(name string) error {
 	if err := ValidateControllerName(name); err != nil {
 		return errors.Trace(err)

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -106,11 +106,19 @@ type BootstrapConfig struct {
 
 // ControllerUpdater stores controller details.
 type ControllerUpdater interface {
-	// UpdateController adds the given controller to the controller
+	// AddController adds the given controller to the controller
 	// collection.
 	//
-	// If the controller does not already exist, it will be added.
-	// Otherwise, it will be overwritten with the new details.
+	// Where UpdateController is concerned with the controller name,
+	// AddController uses the controller UUID and will not add a
+	// duplicate even if the name is different.
+	AddController(controllerName string, details ControllerDetails) error
+
+	// UpdateController updates the given controller in the controller
+	// collection.
+	//
+	// If a controller of controllerName exists it will be overwritten
+	// with the new details.
 	UpdateController(controllerName string, details ControllerDetails) error
 
 	// SetCurrentController sets the name of the current controller.

--- a/jujuclient/jujuclienttesting/mem.go
+++ b/jujuclient/jujuclienttesting/mem.go
@@ -68,6 +68,29 @@ func (c *MemStore) SetCurrentController(name string) error {
 	return nil
 }
 
+// AddController implements ControllerUpdater.AddController
+func (c *MemStore) AddController(name string, one jujuclient.ControllerDetails) error {
+	if err := jujuclient.ValidateControllerName(name); err != nil {
+		return err
+	}
+	if err := jujuclient.ValidateControllerDetails(one); err != nil {
+		return err
+	}
+
+	if _, ok := c.Controllers[name]; ok {
+		return errors.AlreadyExistsf("controller with name %s", name)
+	}
+
+	for k, v := range c.Controllers {
+		if v.ControllerUUID == one.ControllerUUID {
+			return errors.AlreadyExistsf("controller with UUID %s (%s)",
+				one.ControllerUUID, k)
+		}
+	}
+	c.Controllers[name] = one
+	return nil
+}
+
 // UpdateController implements ControllerUpdater.UpdateController
 func (c *MemStore) UpdateController(name string, one jujuclient.ControllerDetails) error {
 	if err := jujuclient.ValidateControllerName(name); err != nil {
@@ -76,6 +99,22 @@ func (c *MemStore) UpdateController(name string, one jujuclient.ControllerDetail
 	if err := jujuclient.ValidateControllerDetails(one); err != nil {
 		return err
 	}
+
+	if len(c.Controllers) == 0 {
+		return errors.NotFoundf("controllers")
+	}
+
+	for k, v := range c.Controllers {
+		if v.ControllerUUID == one.ControllerUUID && k != name {
+			return errors.AlreadyExistsf("controller %s with UUID %s",
+				k, v.ControllerUUID)
+		}
+	}
+
+	if _, ok := c.Controllers[name]; !ok {
+		return errors.NotFoundf("controller %s", name)
+	}
+
 	c.Controllers[name] = one
 	return nil
 }

--- a/jujuclient/jujuclienttesting/stub.go
+++ b/jujuclient/jujuclienttesting/stub.go
@@ -15,6 +15,7 @@ type StubStore struct {
 
 	AllControllersFunc       func() (map[string]jujuclient.ControllerDetails, error)
 	ControllerByNameFunc     func(name string) (*jujuclient.ControllerDetails, error)
+	AddControllerFunc        func(name string, one jujuclient.ControllerDetails) error
 	UpdateControllerFunc     func(name string, one jujuclient.ControllerDetails) error
 	RemoveControllerFunc     func(name string) error
 	SetCurrentControllerFunc func(name string) error
@@ -48,6 +49,9 @@ func NewStubStore() *StubStore {
 	}
 	result.ControllerByNameFunc = func(name string) (*jujuclient.ControllerDetails, error) {
 		return nil, result.Stub.NextErr()
+	}
+	result.AddControllerFunc = func(name string, one jujuclient.ControllerDetails) error {
+		return result.Stub.NextErr()
 	}
 	result.UpdateControllerFunc = func(name string, one jujuclient.ControllerDetails) error {
 		return result.Stub.NextErr()
@@ -117,6 +121,7 @@ func WrapClientStore(underlying jujuclient.ClientStore) *StubStore {
 	stub := NewStubStore()
 	stub.AllControllersFunc = underlying.AllControllers
 	stub.ControllerByNameFunc = underlying.ControllerByName
+	stub.AddControllerFunc = underlying.AddController
 	stub.UpdateControllerFunc = underlying.UpdateController
 	stub.RemoveControllerFunc = underlying.RemoveController
 	stub.SetCurrentControllerFunc = underlying.SetCurrentController
@@ -147,7 +152,13 @@ func (c *StubStore) ControllerByName(name string) (*jujuclient.ControllerDetails
 	return c.ControllerByNameFunc(name)
 }
 
-// UpdateController implements ControllersUpdater.UpdateController
+// AddController implements ControllerUpdater.AddController
+func (c *StubStore) AddController(name string, one jujuclient.ControllerDetails) error {
+	c.MethodCall(c, "AddController", name, one)
+	return c.AddControllerFunc(name, one)
+}
+
+// UpdateController implements ControllerUpdater.UpdateController
 func (c *StubStore) UpdateController(name string, one jujuclient.ControllerDetails) error {
 	c.MethodCall(c, "UpdateController", name, one)
 	return c.UpdateControllerFunc(name, one)
@@ -159,7 +170,7 @@ func (c *StubStore) RemoveController(name string) error {
 	return c.RemoveControllerFunc(name)
 }
 
-// SetCurrentController implements ControllersUpdater.SetCurrentController.
+// SetCurrentController implements ControllerUpdater.SetCurrentController.
 func (c *StubStore) SetCurrentController(name string) error {
 	c.MethodCall(c, "SetCurrentController", name)
 	return c.SetCurrentControllerFunc(name)

--- a/jujuclient/models_test.go
+++ b/jujuclient/models_test.go
@@ -187,7 +187,7 @@ func (s *ModelsSuite) TestRemoveModel(c *gc.C) {
 
 func (s *ModelsSuite) TestRemoveControllerRemovesModels(c *gc.C) {
 	store := jujuclient.NewFileClientStore()
-	err := store.UpdateController("kontroll", jujuclient.ControllerDetails{
+	err := store.AddController("kontroll", jujuclient.ControllerDetails{
 		ControllerUUID: "abc",
 		CACert:         "woop",
 	})


### PR DESCRIPTION
The register command should not allow a controller to be added
more than once, with alternative names, to a controller collection.

jujuclient/file.go now implements AddController in addition to
UpdateController, always using AddController to add, and UpdateController
to update. Update had previously updated any existing controller of the
same name in the local store, and otherwise added a controller as new,
even if it was effectively an alias of an existing controller by UUID.

juju/testing/conn.go JujuConnSuite can now create additional user home
environments within a test. This allows `add-user` and `register` to be
tested without controller UUID contention.

Fixes: #1593350

(Review request: http://reviews.vapour.ws/r/5091/)