### PR TITLE
apiserver/{application,modelmanager}: drop compat

### DIFF
--- a/apiserver/application/application.go
+++ b/apiserver/application/application.go
@@ -124,18 +124,6 @@ func deployApplication(st *state.State, args params.ApplicationDeploy) error {
 
 	// Try to find the charm URL in state first.
 	ch, err := st.Charm(curl)
-	// TODO(wallyworld) - remove for 2.0 beta4
-	if errors.IsNotFound(err) {
-		// Clients written to expect 1.16 compatibility require this next block.
-		if curl.Schema != "cs" {
-			return errors.Errorf(`charm url has unsupported schema %q`, curl.Schema)
-		}
-		if err = AddCharmWithAuthorization(st, params.AddCharmWithAuthorization{
-			URL: args.CharmUrl,
-		}); err == nil {
-			ch, err = st.Charm(curl)
-		}
-	}
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -116,15 +116,13 @@ func (mm *ModelManagerAPI) newModelConfig(
 	if _, ok := joint["uuid"]; ok {
 		return nil, errors.New("uuid is generated, you cannot specify one")
 	}
-	if args.Name != "" {
-		// TODO(axw) we should always expect args.Name to be non-empty,
-		// and always fail if the name was specified in config. The
-		// GUI needs to be updated for this to work.
-		if _, ok := joint[config.NameKey]; ok {
-			return nil, errors.New("name must not be specified in config")
-		}
-		joint[config.NameKey] = args.Name
+	if args.Name == "" {
+		return nil, errors.NewNotValid(nil, "Name must be specified")
 	}
+	if _, ok := joint[config.NameKey]; ok {
+		return nil, errors.New("name must not be specified in config")
+	}
+	joint[config.NameKey] = args.Name
 
 	// Copy credential attributes across to model config.
 	// TODO(axw) credentials should not be going into model config.
@@ -150,27 +148,6 @@ func (mm *ModelManagerAPI) newModelConfig(
 		},
 	}
 	return creator.NewModelConfig(mm.isAdmin, baseConfig, joint)
-}
-
-type modelSkeletonConfigArgs struct {
-	Provider string
-	Region   string
-}
-
-// TODO(axw) drop this after beta9. The GUI needs to be updated to stop using this.
-func (mm *ModelManagerAPI) ConfigSkeleton(args modelSkeletonConfigArgs) (params.ModelConfigResult, error) {
-	var result params.ModelConfigResult
-	if args.Region != "" {
-		return result, errors.NotValidf("region value %q", args.Region)
-	}
-	cloud, err := mm.state.Cloud()
-	if err != nil {
-		return result, err
-	}
-	result.Config = params.ModelConfig{
-		config.TypeKey: cloud.Type,
-	}
-	return result, nil
 }
 
 // CreateModel creates a new model using the account and


### PR DESCRIPTION
Drop compatibility with the GUI. The GUI will need
to be updated before beta10, to:
 (a) upload charms before deploying
 (b) adjust to the new way of creating models

(Review request: http://reviews.vapour.ws/r/5092/)