### PR TITLE
state: Use correct func for generating unit global key

### DIFF
--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -727,7 +727,7 @@ func agentTagToGlobalKey(tag names.Tag) (string, error) {
 	case names.MachineTag:
 		return machineGlobalKey(t.Id()), nil
 	case names.UnitTag:
-		return unitGlobalKey(t.Id()), nil
+		return unitAgentGlobalKey(t.Id()), nil
 	default:
 		return "", errors.Errorf("%s is not an agent tag", tag)
 	}

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -587,13 +587,13 @@ func (s *ModelMigrationSuite) TestMinionReports(c *gc.C) {
 	const phase = migration.QUIESCE
 	c.Assert(mig.MinionReport(m0.Tag(), phase, true), jc.ErrorIsNil)
 	c.Assert(mig.MinionReport(m1.Tag(), phase, false), jc.ErrorIsNil)
-	c.Assert(mig.MinionReport(m2.Tag(), phase, true), jc.ErrorIsNil)
+	c.Assert(mig.MinionReport(u0.Tag(), phase, true), jc.ErrorIsNil)
 
 	reports, err := mig.GetMinionReports()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(reports.Succeeded, jc.SameContents, []names.Tag{m0.Tag(), m2.Tag()})
+	c.Check(reports.Succeeded, jc.SameContents, []names.Tag{m0.Tag(), u0.Tag()})
 	c.Check(reports.Failed, jc.SameContents, []names.Tag{m1.Tag()})
-	c.Check(reports.Unknown, jc.SameContents, []names.Tag{u0.Tag()})
+	c.Check(reports.Unknown, jc.SameContents, []names.Tag{m2.Tag()})
 }
 
 func (s *ModelMigrationSuite) TestDuplicateMinionReportsSameSuccess(c *gc.C) {


### PR DESCRIPTION
There are 2 types of unit global keys and the migraiton minion reporting mechanism was using the wrong one. The test coverage gap that would have caught this earlier has been plugged.

(Review request: http://reviews.vapour.ws/r/5093/)