### PR TITLE
Update juju/testing dependency

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -31,7 +31,7 @@ github.com/juju/replicaset	git	fb7294cf57a1e2f08a57691f1246d129a87ab7e8	2015-05-
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/romulus	git	2cae2c5c0166a6fe0155111814b5ce5b2e149731	2016-06-07T17:29:43Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
-github.com/juju/testing	git	83c7742005b3b6be70c14a980c95d5473e781180	2016-06-06T10:00:20Z
+github.com/juju/testing	git	b718b7113d48d317bd81805963e64f72d75bd667	2016-06-17T13:39:55Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	ffea6ead0c374583e876c8357c9db6e98bc71476	2016-05-26T02:52:51Z


### PR DESCRIPTION
This version will detect the Mongo version to determine whether mongod
should be started with or without journalling, which has a significant
impact on the performance of the tests (but in different directions for
mongo version before or after 3.2).

(Review request: http://reviews.vapour.ws/r/5096/)