### PR TITLE
Ensure controller uuid is available when creating models

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/controller/modelmanager"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
@@ -142,8 +143,9 @@ func InitializeState(
 			attrs[k] = v
 		}
 	}
+	controllerUUID := controller.Config(args.ControllerModelConfig.AllAttrs()).ControllerUUID()
 	hostedModelConfig, err := modelmanager.ModelConfigCreator{}.NewModelConfig(
-		modelmanager.IsAdmin, args.ControllerModelConfig, attrs,
+		modelmanager.IsAdmin, controllerUUID, args.ControllerModelConfig, attrs,
 	)
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "creating hosted model config")

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -104,7 +104,7 @@ type ConfigSource interface {
 }
 
 func (mm *ModelManagerAPI) newModelConfig(
-	args params.ModelCreateArgs, source ConfigSource, credential *cloud.Credential,
+	args params.ModelCreateArgs, controllerUUID string, source ConfigSource, credential *cloud.Credential,
 ) (*config.Config, error) {
 	// For now, we just smash to the two maps together as we store
 	// the account values and the model config together in the
@@ -147,7 +147,7 @@ func (mm *ModelManagerAPI) newModelConfig(
 			return result.List, nil
 		},
 	}
-	return creator.NewModelConfig(mm.isAdmin, baseConfig, joint)
+	return creator.NewModelConfig(mm.isAdmin, controllerUUID, baseConfig, joint)
 }
 
 // CreateModel creates a new model using the account and
@@ -221,7 +221,12 @@ func (mm *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Mode
 		credential = &elem
 	}
 
-	newConfig, err := mm.newModelConfig(args, controllerModel, credential)
+	controllerCfg, err := mm.state.ControllerConfig()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	newConfig, err := mm.newModelConfig(args, controllerCfg.ControllerUUID(), controllerModel, credential)
 	if err != nil {
 		return result, errors.Annotate(err, "failed to create config")
 	}

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -116,6 +116,7 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 		"ModelUUID",
 		"ControllerModel",
 		"CloudCredentials",
+		"ControllerConfig",
 		"NewModel",
 		"ForModel",
 		"Model",
@@ -127,7 +128,7 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 	// We cannot predict the UUID, because it's generated,
 	// so we just extract it and ensure that it's not the
 	// same as the controller UUID.
-	newModelArgs := s.st.Calls()[4].Args[0].(state.ModelArgs)
+	newModelArgs := s.st.Calls()[5].Args[0].(state.ModelArgs)
 	uuid := newModelArgs.Config.UUID()
 	c.Assert(uuid, gc.Not(gc.Equals), s.st.controllerModel.cfg.UUID())
 
@@ -135,6 +136,7 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 		"name":            "foo",
 		"type":            "dummy",
 		"authorized-keys": s.st.controllerModel.cfg.AuthorizedKeys(),
+		"controller-uuid": coretesting.ModelTag.Id(),
 		"uuid":            uuid,
 		"agent-version":   jujuversion.Current.String(),
 		"bar":             "baz",
@@ -160,7 +162,7 @@ func (s *modelManagerSuite) TestCreateModelDefaultRegion(c *gc.C) {
 	_, err := s.api.CreateModel(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newModelArgs := s.st.Calls()[4].Args[0].(state.ModelArgs)
+	newModelArgs := s.st.Calls()[5].Args[0].(state.ModelArgs)
 	c.Assert(newModelArgs.CloudRegion, gc.Equals, "some-region")
 }
 
@@ -172,7 +174,7 @@ func (s *modelManagerSuite) TestCreateModelDefaultCredentialAdmin(c *gc.C) {
 	_, err := s.api.CreateModel(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newModelArgs := s.st.Calls()[4].Args[0].(state.ModelArgs)
+	newModelArgs := s.st.Calls()[5].Args[0].(state.ModelArgs)
 	c.Assert(newModelArgs.CloudCredential, gc.Equals, "some-credential")
 }
 
@@ -184,7 +186,7 @@ func (s *modelManagerSuite) TestCreateModelEmptyCredentialNonAdmin(c *gc.C) {
 	_, err := s.api.CreateModel(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newModelArgs := s.st.Calls()[4].Args[0].(state.ModelArgs)
+	newModelArgs := s.st.Calls()[5].Args[0].(state.ModelArgs)
 	c.Assert(newModelArgs.CloudCredential, gc.Equals, "")
 }
 

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -583,6 +583,7 @@ to clean up the model.`[1:])
 	}
 
 	err = bootstrapFuncs.Bootstrap(modelcmd.BootstrapContext(ctx), environ, bootstrap.BootstrapParams{
+		ControllerUUID:       controllerUUID.String(),
 		ModelConstraints:     c.Constraints,
 		BootstrapConstraints: bootstrapConstraints,
 		BootstrapSeries:      c.BootstrapSeries,

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -411,6 +411,7 @@ func (s *BootstrapSuite) TestBootstrapDefaultModel(c *gc.C) {
 		"--default-model", "mymodel",
 		"--config", "foo=bar",
 	)
+	c.Assert(utils.IsValidUUIDString(bootstrap.args.ControllerUUID), jc.IsTrue)
 	c.Assert(bootstrap.args.HostedModelConfig["name"], gc.Equals, "mymodel")
 	c.Assert(bootstrap.args.HostedModelConfig["foo"], gc.Equals, "bar")
 }

--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -51,11 +51,11 @@ func (s *ModelConfigCreatorSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ModelConfigCreatorSuite) newModelConfig(attrs map[string]interface{}) (*config.Config, error) {
-	return s.creator.NewModelConfig(modelmanager.IsNotAdmin, s.baseConfig, attrs)
+	return s.creator.NewModelConfig(modelmanager.IsNotAdmin, coretesting.ModelTag.Id(), s.baseConfig, attrs)
 }
 
 func (s *ModelConfigCreatorSuite) newModelConfigAdmin(attrs map[string]interface{}) (*config.Config, error) {
-	return s.creator.NewModelConfig(modelmanager.IsAdmin, s.baseConfig, attrs)
+	return s.creator.NewModelConfig(modelmanager.IsAdmin, coretesting.ModelTag.Id(), s.baseConfig, attrs)
 }
 
 func (s *ModelConfigCreatorSuite) TestCreateModelValidatesConfig(c *gc.C) {

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -139,11 +139,10 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 		// we'll be here to catch this problem early.
 		return errors.Errorf("model configuration has no authorized-keys")
 	}
-	controllerCfg := controller.ControllerConfig(cfg.AllAttrs())
-	controllerUUID := controllerCfg.ControllerUUID()
-	if controllerUUID == "" {
+	if args.ControllerUUID == "" {
 		return errors.Errorf("bootstrap configuration has no controller UUID")
 	}
+	controllerCfg := controller.ControllerConfig(cfg.AllAttrs())
 	if _, hasCACert := controllerCfg.CACert(); !hasCACert {
 		return errors.Errorf("model configuration has no ca-cert")
 	}

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -539,7 +539,8 @@ func (s *bootstrapSuite) TestBootstrapMetadata(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		MetadataDir: metadataDir,
+		ControllerUUID: coretesting.ModelTag.Id(),
+		MetadataDir:    metadataDir,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.bootstrapCount, gc.Equals, 1)
@@ -567,6 +568,7 @@ func (s *bootstrapSuite) TestBootstrapCloudCredential(c *gc.C) {
 	s.setDummyStorage(c, env)
 	credential := cloud.NewCredential(cloud.EmptyAuthType, map[string]string{"what": "ever"})
 	args := bootstrap.BootstrapParams{
+		ControllerUUID: coretesting.ModelTag.Id(),
 		Cloud: cloud.Cloud{
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},

--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -159,7 +159,9 @@ func bootstrapContext(c *gc.C) environs.BootstrapContext {
 // allocate a public address.
 func (s *localServerSuite) TestStartInstance(c *gc.C) {
 	env := s.Prepare(c)
-	err := bootstrap.Bootstrap(bootstrapContext(c), env, bootstrap.BootstrapParams{})
+	err := bootstrap.Bootstrap(bootstrapContext(c), env, bootstrap.BootstrapParams{
+		ControllerUUID: s.ControllerUUID,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	inst, _ := testing.AssertStartInstance(c, env, s.ControllerUUID, "100")
 	err = env.StopInstances(inst.Id())
@@ -168,7 +170,9 @@ func (s *localServerSuite) TestStartInstance(c *gc.C) {
 
 func (s *localServerSuite) TestStartInstanceAvailabilityZone(c *gc.C) {
 	env := s.Prepare(c)
-	err := bootstrap.Bootstrap(bootstrapContext(c), env, bootstrap.BootstrapParams{})
+	err := bootstrap.Bootstrap(bootstrapContext(c), env, bootstrap.BootstrapParams{
+		ControllerUUID: s.ControllerUUID,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	inst, hwc := testing.AssertStartInstance(c, env, s.ControllerUUID, "100")
 	err = env.StopInstances(inst.Id())
@@ -179,7 +183,9 @@ func (s *localServerSuite) TestStartInstanceAvailabilityZone(c *gc.C) {
 
 func (s *localServerSuite) TestStartInstanceHardwareCharacteristics(c *gc.C) {
 	env := s.Prepare(c)
-	err := bootstrap.Bootstrap(bootstrapContext(c), env, bootstrap.BootstrapParams{})
+	err := bootstrap.Bootstrap(bootstrapContext(c), env, bootstrap.BootstrapParams{
+		ControllerUUID: s.ControllerUUID,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	_, hc := testing.AssertStartInstanceWithConstraints(c, env, s.ControllerUUID, "100", constraints.MustParse("mem=1024"))
 	c.Check(*hc.Arch, gc.Equals, "amd64")
@@ -286,7 +292,9 @@ func (s *localServerSuite) TestInstancesGathering(c *gc.C) {
 // It should be moved to environs.jujutests.Tests.
 func (s *localServerSuite) TestBootstrapInstanceUserDataAndState(c *gc.C) {
 	env := s.Prepare(c)
-	err := bootstrap.Bootstrap(bootstrapContext(c), env, bootstrap.BootstrapParams{})
+	err := bootstrap.Bootstrap(bootstrapContext(c), env, bootstrap.BootstrapParams{
+		ControllerUUID: s.ControllerUUID,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// check that ControllerInstances returns the id of the bootstrap machine.


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1593812

Ensure controller uuid is available as needed when creating a model, either at bootstrap or adding a model.

Tested on AWS.

(Review request: http://reviews.vapour.ws/r/5100/)