### PR TITLE
cmd/jujud/agent: synchronise migration workers

### DIFF
--- a/cmd/jujud/agent/engine_test.go
+++ b/cmd/jujud/agent/engine_test.go
@@ -4,14 +4,18 @@
 package agent
 
 import (
+	"fmt"
 	"sync"
+	"time"
 
 	"github.com/juju/errors"
-	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
+	goyaml "gopkg.in/yaml.v2"
 
+	"github.com/juju/juju/cmd/jujud/agent/machine"
 	"github.com/juju/juju/cmd/jujud/agent/model"
+	"github.com/juju/juju/cmd/jujud/agent/unit"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
@@ -40,6 +44,7 @@ var (
 		"instance-poller",
 		"metric-worker",
 		"migration-fortress",
+		"migration-inactive-flag",
 		"migration-master",
 		"application-scaler",
 		"space-importer",
@@ -48,106 +53,243 @@ var (
 		"storage-provisioner",
 		"unit-assigner",
 	}
-
+	migratingModelWorkers = []string{
+		"environ-tracker",
+		"migration-fortress",
+		"migration-inactive-flag",
+		"migration-master",
+	}
 	// ReallyLongTimeout should be long enough for the model-tracker
 	// tests that depend on a hosted model; its backing state is not
 	// accessible for StartSyncs, so we generally have to wait for at
 	// least two 5s ticks to pass, and should expect rare circumstances
 	// to take even longer.
 	ReallyLongWait = coretesting.LongWait * 3
+
+	alwaysUnitWorkers = []string{
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"log-sender",
+		"machine-lock",
+		"migration-fortress",
+		"migration-inactive-flag",
+		"migration-minion",
+		"upgrader",
+	}
+	notMigratingUnitWorkers = []string{
+		"api-address-updater",
+		"charm-dir",
+		"hook-retry-strategy",
+		"leadership-tracker",
+		"logging-config-updater",
+		"meter-status",
+		"proxy-config-updater",
+		"uniter",
+	}
+
+	alwaysMachineWorkers = []string{
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"migration-fortress",
+		"migration-inactive-flag",
+		"migration-minion",
+		"state-config-watcher",
+		"termination-signal-handler",
+		"upgrade-check-flag",
+		"upgrade-check-gate",
+		"upgrade-steps-flag",
+		"upgrade-steps-gate",
+		"upgrader",
+	}
+	notMigratingMachineWorkers = []string{
+		"api-address-updater",
+		"disk-manager",
+		// "host-key-reporter", not stable, exits when done
+		"log-sender",
+		"logging-config-updater",
+		"machine-action-runner",
+		"machiner",
+		"proxy-config-updater",
+		// "reboot-executor", not stable, fails due to lp:1588186
+		"ssh-authkeys-updater",
+		"storage-provisioner",
+		"unconverted-api-workers",
+		"unit-agent-deployer",
+	}
 )
 
-// modelMatchFunc returns a func that will return whether the current
-// set of workers running for the supplied model matches those supplied;
-// and will log what it saw in some detail.
-func modelMatchFunc(c *gc.C, tracker *modelTracker, workers []string) func(string) bool {
+type ModelManifoldsFunc func(config model.ManifoldsConfig) dependency.Manifolds
+
+func TrackModels(c *gc.C, tracker *engineTracker, inner ModelManifoldsFunc) ModelManifoldsFunc {
+	return func(config model.ManifoldsConfig) dependency.Manifolds {
+		raw := inner(config)
+		id := config.Agent.CurrentConfig().Model().Id()
+		if err := tracker.Install(raw, id); err != nil {
+			c.Errorf("cannot install tracker: %v", err)
+		}
+		return raw
+	}
+}
+
+type MachineManifoldsFunc func(config machine.ManifoldsConfig) dependency.Manifolds
+
+func TrackMachines(c *gc.C, tracker *engineTracker, inner MachineManifoldsFunc) MachineManifoldsFunc {
+	return func(config machine.ManifoldsConfig) dependency.Manifolds {
+		raw := inner(config)
+		id := config.Agent.CurrentConfig().Tag().String()
+		if err := tracker.Install(raw, id); err != nil {
+			c.Errorf("cannot install tracker: %v", err)
+		}
+		return raw
+	}
+}
+
+type UnitManifoldsFunc func(config unit.ManifoldsConfig) dependency.Manifolds
+
+func TrackUnits(c *gc.C, tracker *engineTracker, inner UnitManifoldsFunc) UnitManifoldsFunc {
+	return func(config unit.ManifoldsConfig) dependency.Manifolds {
+		raw := inner(config)
+		id := config.Agent.CurrentConfig().Tag().String()
+		if err := tracker.Install(raw, id); err != nil {
+			c.Errorf("cannot install tracker: %v", err)
+		}
+		return raw
+	}
+}
+
+// EngineMatchFunc returns a func that accepts an identifier for a
+// single engine manager by the tracker; that will return true if the
+// workers running in that engine match the supplied workers.
+func EngineMatchFunc(c *gc.C, tracker *engineTracker, workers []string) func(string) bool {
 	expect := set.NewStrings(workers...)
-	return func(uuid string) bool {
-		actual := tracker.Workers(uuid)
-		c.Logf("\n%s: has workers %v", uuid, actual.SortedValues())
+	return func(id string) bool {
+		actual := tracker.Workers(id)
+		c.Logf("\n%s: has workers %v", id, actual.SortedValues())
 		extras := actual.Difference(expect)
 		missed := expect.Difference(actual)
 		if len(extras) == 0 && len(missed) == 0 {
 			return true
 		}
-		c.Logf("%s: waiting for %v", uuid, missed.SortedValues())
-		c.Logf("%s: unexpected %v", uuid, extras.SortedValues())
+		c.Logf("%s: waiting for %v", id, missed.SortedValues())
+		c.Logf("%s: unexpected %v", id, extras.SortedValues())
+
+		report, _ := goyaml.Marshal(tracker.Report(id))
+		c.Logf("%s: report: \n%s\n", id, report)
 		return false
 	}
 }
 
-// newModelTracker creates a type whose Manifolds method can
-// be patched over modelManifolds, and whose Workers method
-// will tell you what workers are currently running stably
-// within the requested model's dependency engine.
-func newModelTracker(c *gc.C) *modelTracker {
-	return &modelTracker{
-		c:       c,
-		current: make(map[string]set.Strings),
+// WaitMatch returns only when the match func succeeds, or it times out.
+func WaitMatch(c *gc.C, match func(string) bool, id string, sync func()) {
+	timeout := time.After(coretesting.LongWait)
+	for {
+		if match(id) {
+			return
+		}
+		select {
+		case <-time.After(coretesting.ShortWait):
+			sync()
+		case <-timeout:
+			c.Fatalf("timed out waiting for workers")
+		}
 	}
 }
 
-type modelTracker struct {
-	c       *gc.C
+// NewEngineTracker creates a type that can Install itself into a
+// Manifolds map, and expose recent snapshots of running Workers.
+func NewEngineTracker() *engineTracker {
+	return &engineTracker{
+		current: make(map[string]set.Strings),
+		reports: make(map[string]map[string]interface{}),
+	}
+}
+
+type engineTracker struct {
 	mu      sync.Mutex
 	current map[string]set.Strings
+	reports map[string]map[string]interface{}
 }
 
-func (tracker *modelTracker) Workers(model string) set.Strings {
+// Workers returns the most-recently-reported set of running workers.
+func (tracker *engineTracker) Workers(id string) set.Strings {
 	tracker.mu.Lock()
 	defer tracker.mu.Unlock()
-	return tracker.current[model]
+	return tracker.current[id]
 }
 
-func (tracker *modelTracker) Manifolds(config model.ManifoldsConfig) dependency.Manifolds {
+// Report returns the most-recently-reported self-report. It will
+// only work if you hack up the relevant engine-starting code to
+// include:
+//
+//    manifolds["self"] = dependency.SelfManifold(engine)
+//
+// or otherwise inject a suitable "self" manifold.
+func (tracker *engineTracker) Report(id string) map[string]interface{} {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	return tracker.reports[id]
+}
+
+// Install injects a manifold named TEST-TRACKER into raw, which will
+// depend on all other manifolds in raw and write currently-available
+// worker information to the tracker (differentiating it from other
+// tracked engines via the id param).
+func (tracker *engineTracker) Install(raw dependency.Manifolds, id string) error {
 	const trackerName = "TEST-TRACKER"
-	raw := model.Manifolds(config)
-	uuid := config.Agent.CurrentConfig().Model().Id()
 
 	names := make([]string, 0, len(raw))
 	for name := range raw {
 		if name == trackerName {
-			tracker.c.Errorf("manifold tracker used repeatedly")
-			return raw
-		} else {
-			names = append(names, name)
+			return errors.New("engine tracker installed repeatedly")
 		}
+		names = append(names, name)
 	}
 
 	tracker.mu.Lock()
 	defer tracker.mu.Unlock()
-	if _, exists := tracker.current[uuid]; exists {
-		tracker.c.Errorf("model %s started repeatedly", uuid)
-		return raw
+	if _, exists := tracker.current[id]; exists {
+		return errors.Errorf("manifolds for %s created repeatedly", id)
 	}
-
-	raw[trackerName] = tracker.manifold(uuid, names)
-	return raw
+	raw[trackerName] = dependency.Manifold{
+		Inputs: append(names, "self"),
+		Start:  tracker.startFunc(id, names),
+	}
+	return nil
 }
 
-func (tracker *modelTracker) manifold(uuid string, names []string) dependency.Manifold {
-	return dependency.Manifold{
-		Inputs: names,
-		Start: func(context dependency.Context) (worker.Worker, error) {
-			seen := set.NewStrings()
-			for _, name := range names {
-				err := context.Get(name, nil)
-				if errors.Cause(err) == dependency.ErrMissing {
-					continue
-				}
-				if tracker.c.Check(err, jc.ErrorIsNil) {
-					seen.Add(name)
-				}
-			}
-			select {
-			case <-context.Abort():
-				// don't bother to report if it's about to change
+func (tracker *engineTracker) startFunc(id string, names []string) dependency.StartFunc {
+	return func(context dependency.Context) (worker.Worker, error) {
+
+		seen := set.NewStrings()
+		for _, name := range names {
+			err := context.Get(name, nil)
+			switch errors.Cause(err) {
+			case nil:
+			case dependency.ErrMissing:
+				continue
 			default:
-				tracker.mu.Lock()
-				defer tracker.mu.Unlock()
-				tracker.current[uuid] = seen
+				name = fmt.Sprintf("%s [%v]", name, err)
 			}
-			return nil, dependency.ErrMissing
-		},
+			seen.Add(name)
+		}
+
+		var report map[string]interface{}
+		var reporter dependency.Reporter
+		if err := context.Get("self", &reporter); err == nil {
+			report = reporter.Report()
+		}
+
+		select {
+		case <-context.Abort():
+			// don't bother to report if it's about to change
+		default:
+			tracker.mu.Lock()
+			defer tracker.mu.Unlock()
+			tracker.current[id] = seen
+			tracker.reports[id] = report
+		}
+		return nil, dependency.ErrMissing
 	}
 }

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -87,15 +87,20 @@ var (
 	jujuDumpLogs = paths.MustSucceed(paths.JujuDumpLogs(series.HostSeries()))
 
 	// The following are defined as variables to allow the tests to
-	// intercept calls to the functions.
+	// intercept calls to the functions. In every case, they should
+	// be expressed as explicit dependencies, but nobody has yet had
+	// the intestinal fortitude to untangle this package. Be that
+	// person! Juju Needs You.
 	useMultipleCPUs       = utils.UseMultipleCPUs
-	modelManifolds        = model.Manifolds
 	newSingularRunner     = singular.New
 	peergrouperNew        = peergrouper.New
 	newCertificateUpdater = certupdater.NewCertificateUpdater
 	newMetadataUpdater    = imagemetadataworker.NewWorker
 	newUpgradeMongoWorker = mongoupgrader.New
 	reportOpenedState     = func(*state.State) {}
+
+	modelManifolds   = model.Manifolds
+	machineManifolds = machine.Manifolds
 )
 
 // Variable to override in tests, default is true
@@ -437,7 +442,7 @@ func (a *MachineAgent) makeEngineCreator(previousAgentVersion version.Number) fu
 		if err != nil {
 			return nil, err
 		}
-		manifolds := machine.Manifolds(machine.ManifoldsConfig{
+		manifolds := machineManifolds(machine.ManifoldsConfig{
 			PreviousAgentVersion: previousAgentVersion,
 			Agent:                agent.APIHostPortsSetter{Agent: a},
 			RootDir:              a.rootDir,

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/juju/worker/logsender"
 	"github.com/juju/juju/worker/machineactions"
 	"github.com/juju/juju/worker/machiner"
+	"github.com/juju/juju/worker/migrationflag"
 	"github.com/juju/juju/worker/migrationminion"
 	"github.com/juju/juju/worker/proxyupdater"
 	"github.com/juju/juju/worker/reboot"
@@ -255,21 +256,38 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			PreUpgradeSteps:      config.PreUpgradeSteps,
 		}),
 
-		// The migration minion handles the agent side aspects of model migrations.
+		// The migration workers collaborate to run migrations;
+		// and to create a mechanism for running other workers
+		// so they can't accidentally interfere with a migration
+		// in progress. Such a manifold should (1) depend on the
+		// migration-inactive flag, to know when to start or die;
+		// and (2) occupy the migration-fortress, so as to avoid
+		// possible interference with the minion (which will not
+		// take action until it's gained sole control of the
+		// fortress).
+		//
+		// Note that the fortress itself will not be created
+		// until the upgrade process is complete; this frees all
+		// its dependencies from upgrade concerns.
 		migrationFortressName: ifFullyUpgraded(fortress.Manifold()),
-		migrationMinionName: ifFullyUpgraded(migrationminion.Manifold(migrationminion.ManifoldConfig{
+		migrationInactiveFlagName: migrationflag.Manifold(migrationflag.ManifoldConfig{
+			APICallerName: apiCallerName,
+			Check:         migrationflag.IsNone,
+			NewFacade:     migrationflag.NewFacade,
+			NewWorker:     migrationflag.NewWorker,
+		}),
+		migrationMinionName: migrationminion.Manifold(migrationminion.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 			FortressName:  migrationFortressName,
-
-			NewFacade: migrationminion.NewFacade,
-			NewWorker: migrationminion.NewWorker,
-		})),
+			NewFacade:     migrationminion.NewFacade,
+			NewWorker:     migrationminion.NewWorker,
+		}),
 
 		// The serving-info-setter manifold sets grabs the state
 		// serving info from the API connection and writes it to the
 		// agent config.
-		servingInfoSetterName: ifFullyUpgraded(ServingInfoSetterManifold(ServingInfoSetterConfig{
+		servingInfoSetterName: ifNotMigrating(ServingInfoSetterManifold(ServingInfoSetterConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 		})),
@@ -278,7 +296,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// machine agent's API connection but have not been converted
 		// to work directly under the dependency engine. It waits for
 		// upgrades to be finished before starting these workers.
-		apiWorkersName: ifFullyUpgraded(APIWorkersManifold(APIWorkersConfig{
+		apiWorkersName: ifNotMigrating(APIWorkersManifold(APIWorkersConfig{
 			APICallerName:   apiCallerName,
 			StartAPIWorkers: config.StartAPIWorkers,
 		})),
@@ -286,7 +304,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The reboot manifold manages a worker which will reboot the
 		// machine when requested. It needs an API connection and
 		// waits for upgrades to be complete.
-		rebootName: ifFullyUpgraded(reboot.Manifold(reboot.ManifoldConfig{
+		rebootName: ifNotMigrating(reboot.Manifold(reboot.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 		})),
@@ -295,7 +313,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// controls the messages sent via the log sender or rsyslog,
 		// according to changes in environment config. We should only need
 		// one of these in a consolidated agent.
-		loggingConfigUpdaterName: ifFullyUpgraded(logger.Manifold(logger.ManifoldConfig{
+		loggingConfigUpdaterName: ifNotMigrating(logger.Manifold(logger.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 		})),
@@ -303,14 +321,14 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The diskmanager worker periodically lists block devices on the
 		// machine it runs on. This worker will be run on all Juju-managed
 		// machines (one per machine agent).
-		diskManagerName: ifFullyUpgraded(diskmanager.Manifold(diskmanager.ManifoldConfig{
+		diskManagerName: ifNotMigrating(diskmanager.Manifold(diskmanager.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 		})),
 
 		// The proxy config updater is a leaf worker that sets http/https/apt/etc
 		// proxy settings.
-		proxyConfigUpdater: ifFullyUpgraded(proxyupdater.Manifold(proxyupdater.ManifoldConfig{
+		proxyConfigUpdater: ifNotMigrating(proxyupdater.Manifold(proxyupdater.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 		})),
@@ -318,7 +336,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The api address updater is a leaf worker that rewrites agent config
 		// as the state server addresses change. We should only need one of
 		// these in a consolidated agent.
-		apiAddressUpdaterName: ifFullyUpgraded(apiaddressupdater.Manifold(apiaddressupdater.ManifoldConfig{
+		apiAddressUpdaterName: ifNotMigrating(apiaddressupdater.Manifold(apiaddressupdater.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 		})),
@@ -326,7 +344,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The machiner Worker will wait for the identified machine to become
 		// Dying and make it Dead; or until the machine becomes Dead by other
 		// means.
-		machinerName: ifFullyUpgraded(machiner.Manifold(machiner.ManifoldConfig{
+		machinerName: ifNotMigrating(machiner.Manifold(machiner.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 		})),
@@ -339,7 +357,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// runs; it currently seems better to fill the buffer and send when stable,
 		// optimising for stable controller upgrades rather than up-to-the-moment
 		// observable normal-machine upgrades.
-		logSenderName: ifFullyUpgraded(logsender.Manifold(logsender.ManifoldConfig{
+		logSenderName: ifNotMigrating(logsender.Manifold(logsender.ManifoldConfig{
 			APICallerName: apiCallerName,
 			LogSource:     config.LogSource,
 		})),
@@ -348,13 +366,13 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// agents, according to changes in a set of state units; and for the
 		// final removal of its agents' units from state when they are no
 		// longer needed.
-		deployerName: ifFullyUpgraded(deployer.Manifold(deployer.ManifoldConfig{
+		deployerName: ifNotMigrating(deployer.Manifold(deployer.ManifoldConfig{
 			NewDeployContext: config.NewDeployContext,
 			AgentName:        agentName,
 			APICallerName:    apiCallerName,
 		})),
 
-		authenticationWorkerName: ifFullyUpgraded(authenticationworker.Manifold(authenticationworker.ManifoldConfig{
+		authenticationWorkerName: ifNotMigrating(authenticationworker.Manifold(authenticationworker.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 		})),
@@ -362,35 +380,35 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The storageProvisioner worker manages provisioning
 		// (deprovisioning), and attachment (detachment) of first-class
 		// volumes and filesystems.
-		storageProvisionerName: ifFullyUpgraded(storageprovisioner.MachineManifold(storageprovisioner.MachineManifoldConfig{
+		storageProvisionerName: ifNotMigrating(storageprovisioner.MachineManifold(storageprovisioner.MachineManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 			Clock:         config.Clock,
 		})),
 
-		resumerName: ifFullyUpgraded(resumer.Manifold(resumer.ManifoldConfig{
+		resumerName: ifNotMigrating(resumer.Manifold(resumer.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 		})),
 
-		identityFileWriterName: ifFullyUpgraded(identityfilewriter.Manifold(identityfilewriter.ManifoldConfig{
+		identityFileWriterName: ifNotMigrating(identityfilewriter.Manifold(identityfilewriter.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 		})),
 
-		toolsVersionCheckerName: ifFullyUpgraded(toolsversionchecker.Manifold(toolsversionchecker.ManifoldConfig{
+		toolsVersionCheckerName: ifNotMigrating(toolsversionchecker.Manifold(toolsversionchecker.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 		})),
 
-		machineActionName: ifFullyUpgraded(machineactions.Manifold(machineactions.ManifoldConfig{
+		machineActionName: ifNotMigrating(machineactions.Manifold(machineactions.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 			NewFacade:     machineactions.NewFacade,
 			NewWorker:     machineactions.NewMachineActionsWorker,
 		})),
 
-		hostKeyReporterName: ifFullyUpgraded(hostkeyreporter.Manifold(hostkeyreporter.ManifoldConfig{
+		hostKeyReporterName: ifNotMigrating(hostkeyreporter.Manifold(hostkeyreporter.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 			RootDir:       config.RootDir,
@@ -407,6 +425,13 @@ var ifFullyUpgraded = engine.Housing{
 	},
 }.Decorate
 
+var ifNotMigrating = engine.Housing{
+	Flags: []string{
+		migrationInactiveFlagName,
+	},
+	Occupy: migrationFortressName,
+}.Decorate
+
 const (
 	agentName              = "agent"
 	terminationName        = "termination-signal-handler"
@@ -414,6 +439,7 @@ const (
 	stateName              = "state"
 	stateWorkersName       = "unconverted-state-workers"
 	apiCallerName          = "api-caller"
+	apiConfigWatcherName   = "api-config-watcher"
 
 	upgraderName         = "upgrader"
 	upgradeStepsName     = "upgrade-steps-runner"
@@ -422,8 +448,9 @@ const (
 	upgradeCheckGateName = "upgrade-check-gate"
 	upgradeCheckFlagName = "upgrade-check-flag"
 
-	migrationFortressName = "migration-fortress"
-	migrationMinionName   = "migration-minion"
+	migrationFortressName     = "migration-fortress"
+	migrationInactiveFlagName = "migration-inactive-flag"
+	migrationMinionName       = "migration-minion"
 
 	servingInfoSetterName    = "serving-info-setter"
 	apiWorkersName           = "unconverted-api-workers"
@@ -440,7 +467,6 @@ const (
 	resumerName              = "mgo-txn-resumer"
 	identityFileWriterName   = "ssh-identity-writer"
 	toolsVersionCheckerName  = "tools-version-checker"
-	apiConfigWatcherName     = "api-config-watcher"
 	machineActionName        = "machine-action-runner"
 	hostKeyReporterName      = "host-key-reporter"
 )

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -55,6 +55,7 @@ func (*ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"mgo-txn-resumer",
 		"migration-fortress",
 		"migration-minion",
+		"migration-inactive-flag",
 		"proxy-config-updater",
 		"reboot-executor",
 		"serving-info-setter",
@@ -78,7 +79,16 @@ func (*ManifoldsSuite) TestManifoldNames(c *gc.C) {
 	c.Assert(keys, jc.SameContents, expectedKeys)
 }
 
-func (*ManifoldsSuite) TestUpgradeGuardsUsed(c *gc.C) {
+func (*ManifoldsSuite) TestUpgradesBlockMigration(c *gc.C) {
+	manifolds := machine.Manifolds(machine.ManifoldsConfig{})
+	manifold, ok := manifolds["migration-fortress"]
+	c.Assert(ok, jc.IsTrue)
+
+	checkContains(c, manifold.Inputs, "upgrade-check-flag")
+	checkContains(c, manifold.Inputs, "upgrade-steps-flag")
+}
+
+func (*ManifoldsSuite) TestMigrationGuardsUsed(c *gc.C) {
 	exempt := set.NewStrings(
 		"agent",
 		"api-caller",
@@ -87,6 +97,9 @@ func (*ManifoldsSuite) TestUpgradeGuardsUsed(c *gc.C) {
 		"state-config-watcher",
 		"termination-signal-handler",
 		"unconverted-state-workers",
+		"migration-fortress",
+		"migration-inactive-flag",
+		"migration-minion",
 		"upgrade-check-flag",
 		"upgrade-check-gate",
 		"upgrade-steps-flag",
@@ -95,26 +108,22 @@ func (*ManifoldsSuite) TestUpgradeGuardsUsed(c *gc.C) {
 		"upgrader",
 	)
 	manifolds := machine.Manifolds(machine.ManifoldsConfig{})
-	keys := make([]string, 0, len(manifolds))
-	for key := range manifolds {
-		if !exempt.Contains(key) {
-			keys = append(keys, key)
+	for name, manifold := range manifolds {
+		c.Logf(name)
+		if !exempt.Contains(name) {
+			checkContains(c, manifold.Inputs, "migration-fortress")
+			checkContains(c, manifold.Inputs, "migration-inactive-flag")
 		}
 	}
-	for _, key := range keys {
-		c.Logf("checking %s...", key)
-		var sawCheck, sawSteps bool
-		for _, name := range manifolds[key].Inputs {
-			if name == "upgrade-check-flag" {
-				sawCheck = true
-			}
-			if name == "upgrade-steps-flag" {
-				sawSteps = true
-			}
+}
+
+func checkContains(c *gc.C, names []string, seek string) {
+	for _, name := range names {
+		if name == seek {
+			return
 		}
-		c.Check(sawSteps, jc.IsTrue)
-		c.Check(sawCheck, jc.IsTrue)
 	}
+	c.Errorf("%q not found in %v", seek, names)
 }
 
 func (*ManifoldsSuite) TestUpgradeGates(c *gc.C) {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -35,6 +35,7 @@ import (
 	apimachiner "github.com/juju/juju/api/machiner"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cert"
+	"github.com/juju/juju/core/migration"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju"
@@ -1241,12 +1242,31 @@ func (s *MachineSuite) TestMachineAgentRestoreRequiresPrepare(c *gc.C) {
 	c.Assert(a.IsRestoreRunning(), jc.IsFalse)
 }
 
+func (s *MachineSuite) TestMachineWorkers(c *gc.C) {
+	tracker := NewEngineTracker()
+	instrumented := TrackMachines(c, tracker, machineManifolds)
+	s.PatchValue(&machineManifolds, instrumented)
+
+	m, _, _ := s.primeAgent(c, state.JobHostUnits)
+	a := s.newAgent(c, m)
+	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
+	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
+
+	// Wait for it to stabilise, running as normal.
+	id := a.Tag().String()
+	checkNotMigrating := EngineMatchFunc(c, tracker, append(
+		alwaysMachineWorkers, notMigratingMachineWorkers...,
+	))
+	WaitMatch(c, checkNotMigrating, id, s.BackingState.StartSync)
+}
+
 func (s *MachineSuite) TestControllerModelWorkers(c *gc.C) {
-	tracker := newModelTracker(c)
-	check := modelMatchFunc(c, tracker, append(
+	tracker := NewEngineTracker()
+	check := EngineMatchFunc(c, tracker, append(
 		alwaysModelWorkers, aliveModelWorkers...,
 	))
-	s.PatchValue(&modelManifolds, tracker.Manifolds)
+	instrumented := TrackModels(c, tracker, modelManifolds)
+	s.PatchValue(&modelManifolds, instrumented)
 
 	uuid := s.BackingState.ModelUUID()
 	timeout := time.After(coretesting.LongWait)
@@ -1267,16 +1287,58 @@ func (s *MachineSuite) TestControllerModelWorkers(c *gc.C) {
 }
 
 func (s *MachineSuite) TestHostedModelWorkers(c *gc.C) {
-	tracker := newModelTracker(c)
-	check := modelMatchFunc(c, tracker, append(
+	tracker := NewEngineTracker()
+	check := EngineMatchFunc(c, tracker, append(
 		alwaysModelWorkers, aliveModelWorkers...,
 	))
-	s.PatchValue(&modelManifolds, tracker.Manifolds)
+	instrumented := TrackModels(c, tracker, modelManifolds)
+	s.PatchValue(&modelManifolds, instrumented)
 
 	st, closer := s.setUpNewModel(c)
 	defer closer()
 	uuid := st.ModelUUID()
 	timeout := time.After(ReallyLongWait)
+
+	s.assertJobWithState(c, state.JobManageModel, func(_ agent.Config, _ *state.State) {
+		for {
+			if check(uuid) {
+				break
+			}
+			select {
+			case <-time.After(coretesting.ShortWait):
+				s.BackingState.StartSync()
+			case <-timeout:
+				c.Fatalf("timed out waiting for workers")
+			}
+		}
+	})
+}
+
+func (s *MachineSuite) TestMigratingModelWorkers(c *gc.C) {
+	tracker := NewEngineTracker()
+	check := EngineMatchFunc(c, tracker, append(
+		alwaysModelWorkers, migratingModelWorkers...,
+	))
+	instrumented := TrackModels(c, tracker, modelManifolds)
+	s.PatchValue(&modelManifolds, instrumented)
+
+	st, closer := s.setUpNewModel(c)
+	defer closer()
+	uuid := st.ModelUUID()
+	timeout := time.After(ReallyLongWait)
+
+	targetControllerTag := names.NewModelTag(utils.MustNewUUID().String())
+	_, err := st.CreateModelMigration(state.ModelMigrationSpec{
+		InitiatedBy: names.NewUserTag("admin"),
+		TargetInfo: migration.TargetInfo{
+			ControllerTag: targetControllerTag,
+			Addrs:         []string{"1.2.3.4:5555", "4.3.2.1:6666"},
+			CACert:        "cert",
+			AuthTag:       names.NewUserTag("user"),
+			Password:      "password",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
 
 	s.assertJobWithState(c, state.JobManageModel, func(_ agent.Config, _ *state.State) {
 		for {
@@ -1306,8 +1368,6 @@ func (s *MachineSuite) TestDyingModelCleanedUp(c *gc.C) {
 
 		err = model.Destroy()
 		c.Assert(err, jc.ErrorIsNil)
-
-		// Wait for the model to go away.
 		for {
 			select {
 			case <-watch.Changes():
@@ -1338,9 +1398,10 @@ func (s *MachineSuite) TestModelWorkersRespectSingularResponsibilityFlag(c *gc.C
 
 	// Then run a normal model-tracking test, just checking for
 	// a different set of workers.
-	tracker := newModelTracker(c)
-	check := modelMatchFunc(c, tracker, alwaysModelWorkers)
-	s.PatchValue(&modelManifolds, tracker.Manifolds)
+	tracker := NewEngineTracker()
+	check := EngineMatchFunc(c, tracker, alwaysModelWorkers)
+	instrumented := TrackModels(c, tracker, modelManifolds)
+	s.PatchValue(&modelManifolds, instrumented)
 
 	timeout := time.After(coretesting.LongWait)
 	s.assertJobWithState(c, state.JobManageModel, func(_ agent.Config, _ *state.State) {

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/juju/worker/instancepoller"
 	"github.com/juju/juju/worker/lifeflag"
 	"github.com/juju/juju/worker/metricworker"
+	"github.com/juju/juju/worker/migrationflag"
 	"github.com/juju/juju/worker/migrationmaster"
 	"github.com/juju/juju/worker/provisioner"
 	"github.com/juju/juju/worker/singular"
@@ -144,33 +145,55 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewWorker: singular.NewWorker,
 		}),
 
+		// The migration workers collaborate to run migrations;
+		// and to create a mechanism for running other workers
+		// so they can't accidentally interfere with a migration
+		// in progress. Such a manifold should (1) depend on the
+		// migration-inactive flag, to know when to start or die;
+		// and (2) occupy the migration-fortress, so as to avoid
+		// possible interference with the minion (which will not
+		// take action until it's gained sole control of the
+		// fortress).
+		//
+		// Note that the fortress and flag will only exist while
+		// the model is not dead; this frees their dependencies
+		// from model-lifetime concerns.
 		migrationFortressName: ifNotDead(fortress.Manifold()),
+		migrationInactiveFlagName: ifNotDead(migrationflag.Manifold(migrationflag.ManifoldConfig{
+			APICallerName: apiCallerName,
+			Check:         migrationflag.IsNone,
+			NewFacade:     migrationflag.NewFacade,
+			NewWorker:     migrationflag.NewWorker,
+		})),
 		migrationMasterName: ifNotDead(migrationmaster.Manifold(migrationmaster.ManifoldConfig{
 			APICallerName: apiCallerName,
 			FortressName:  migrationFortressName,
-
-			NewFacade: migrationmaster.NewFacade,
-			NewWorker: migrationmaster.NewWorker,
+			NewFacade:     migrationmaster.NewFacade,
+			NewWorker:     migrationmaster.NewWorker,
 		})),
 
 		// Everything else should be wrapped in ifResponsible,
-		// ifNotAlive, or ifNotDead, to ensure that only a single
-		// controller is administering this model at a time.
+		// ifNotAlive, ifNotDead, or ifNotMigrating (which also
+		// implies NotDead), to ensure that only a single
+		// controller is attempting to administer this model at
+		// any one time.
 		//
-		// NOTE: not perfectly reliable at this stage? i.e. a worker
-		// that ignores its stop signal for "too long" might continue
-		// to take admin actions after the window of responsibility
-		// closes. This *is* a pre-existing problem, but demands some
-		// thought/care: e.g. should we make sure the apiserver also
-		// closes any connections that lose responsibility..? can we
-		// make sure all possible environ operations are either time-
+		// NOTE: not perfectly reliable at this stage? i.e. a
+		// worker that ignores its stop signal for "too long"
+		// might continue to take admin actions after the window
+		// of responsibility closes. This *is* a pre-existing
+		// problem, but demands some thought/care: e.g. should
+		// we make sure the apiserver also closes any
+		// connections that lose responsibility..? can we make
+		// sure all possible environ operations are either time-
 		// bounded or interruptible? etc
 		//
-		// On the other hand, all workers *should* be written in the
-		// expectation of dealing with a sucky infrastructure running
-		// things in parallel unexpectedly, just because the universe
-		// hates us and will engineer matters such that it happens
-		// sometimes, even when we try to avoid it.
+		// On the other hand, all workers *should* be written in
+		// the expectation of dealing with sucky infrastructure
+		// running things in parallel unexpectedly, just because
+		// the universe hates us and will engineer matters such
+		// that it happens sometimes, even when we try to avoid
+		// it.
 
 		// The environ tracker could/should be used by several other
 		// workers (firewaller, provisioners, address-cleaner?).
@@ -188,8 +211,8 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewWorker: undertaker.NewWorker,
 		})),
 
-		// All the rest depend on ifNotDead.
-		spaceImporterName: ifNotDead(discoverspaces.Manifold(discoverspaces.ManifoldConfig{
+		// All the rest depend on ifNotMigrating.
+		spaceImporterName: ifNotMigrating(discoverspaces.Manifold(discoverspaces.ManifoldConfig{
 			EnvironName:   environTrackerName,
 			APICallerName: apiCallerName,
 			UnlockerName:  spacesImportedGateName,
@@ -197,34 +220,33 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewFacade: discoverspaces.NewFacade,
 			NewWorker: discoverspaces.NewWorker,
 		})),
-
-		computeProvisionerName: ifNotDead(provisioner.Manifold(provisioner.ManifoldConfig{
+		computeProvisionerName: ifNotMigrating(provisioner.Manifold(provisioner.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 		})),
-		storageProvisionerName: ifNotDead(storageprovisioner.ModelManifold(storageprovisioner.ModelManifoldConfig{
+		storageProvisionerName: ifNotMigrating(storageprovisioner.ModelManifold(storageprovisioner.ModelManifoldConfig{
 			APICallerName: apiCallerName,
 			ClockName:     clockName,
 			Scope:         modelTag,
 		})),
-		firewallerName: ifNotDead(firewaller.Manifold(firewaller.ManifoldConfig{
+		firewallerName: ifNotMigrating(firewaller.Manifold(firewaller.ManifoldConfig{
 			APICallerName: apiCallerName,
 		})),
-		unitAssignerName: ifNotDead(unitassigner.Manifold(unitassigner.ManifoldConfig{
+		unitAssignerName: ifNotMigrating(unitassigner.Manifold(unitassigner.ManifoldConfig{
 			APICallerName: apiCallerName,
 		})),
-		applicationscalerName: ifNotDead(applicationscaler.Manifold(applicationscaler.ManifoldConfig{
+		applicationScalerName: ifNotMigrating(applicationscaler.Manifold(applicationscaler.ManifoldConfig{
 			APICallerName: apiCallerName,
 			NewFacade:     applicationscaler.NewFacade,
 			NewWorker:     applicationscaler.New,
 		})),
-		instancePollerName: ifNotDead(instancepoller.Manifold(instancepoller.ManifoldConfig{
-			ClockName:     clockName,
-			Delay:         config.InstPollerAggregationDelay,
+		instancePollerName: ifNotMigrating(instancepoller.Manifold(instancepoller.ManifoldConfig{
 			APICallerName: apiCallerName,
 			EnvironName:   environTrackerName,
+			ClockName:     clockName,
+			Delay:         config.InstPollerAggregationDelay,
 		})),
-		charmRevisionUpdaterName: ifNotDead(charmrevisionmanifold.Manifold(charmrevisionmanifold.ManifoldConfig{
+		charmRevisionUpdaterName: ifNotMigrating(charmrevisionmanifold.Manifold(charmrevisionmanifold.ManifoldConfig{
 			APICallerName: apiCallerName,
 			ClockName:     clockName,
 			Period:        config.CharmRevisionUpdateInterval,
@@ -232,13 +254,13 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewFacade: charmrevisionmanifold.NewAPIFacade,
 			NewWorker: charmrevision.NewWorker,
 		})),
-		metricWorkerName: ifNotDead(metricworker.Manifold(metricworker.ManifoldConfig{
+		metricWorkerName: ifNotMigrating(metricworker.Manifold(metricworker.ManifoldConfig{
 			APICallerName: apiCallerName,
 		})),
-		stateCleanerName: ifNotDead(cleaner.Manifold(cleaner.ManifoldConfig{
+		stateCleanerName: ifNotMigrating(cleaner.Manifold(cleaner.ManifoldConfig{
 			APICallerName: apiCallerName,
 		})),
-		statusHistoryPrunerName: ifNotDead(statushistorypruner.Manifold(statushistorypruner.ManifoldConfig{
+		statusHistoryPrunerName: ifNotMigrating(statushistorypruner.Manifold(statushistorypruner.ManifoldConfig{
 			APICallerName:  apiCallerName,
 			MaxHistoryTime: config.StatusHistoryPrunerMaxHistoryTime,
 			MaxHistoryMB:   config.StatusHistoryPrunerMaxHistoryMB,
@@ -285,6 +307,19 @@ var (
 			notDeadFlagName,
 		},
 	}.Decorate
+
+	// ifNotMigrating wraps a manifold such that it only runs if the
+	// migration-inactive flag is set; and then runs workers only
+	// within Visits to the migration fortress. To avoid redundancy,
+	// it takes advantage of the fact that those migration manifolds
+	// themselves depend on ifNotDead, and eschews repeating those
+	// dependencies.
+	ifNotMigrating = engine.Housing{
+		Flags: []string{
+			migrationInactiveFlagName,
+		},
+		Occupy: migrationFortressName,
+	}.Decorate
 )
 
 const (
@@ -298,8 +333,9 @@ const (
 	notDeadFlagName        = "not-dead-flag"
 	notAliveFlagName       = "not-alive-flag"
 
-	migrationFortressName = "migration-fortress"
-	migrationMasterName   = "migration-master"
+	migrationFortressName     = "migration-fortress"
+	migrationInactiveFlagName = "migration-inactive-flag"
+	migrationMasterName       = "migration-master"
 
 	environTrackerName       = "environ-tracker"
 	undertakerName           = "undertaker"
@@ -308,7 +344,7 @@ const (
 	storageProvisionerName   = "storage-provisioner"
 	firewallerName           = "firewaller"
 	unitAssignerName         = "unit-assigner"
-	applicationscalerName    = "application-scaler"
+	applicationScalerName    = "application-scaler"
 	instancePollerName       = "instance-poller"
 	charmRevisionUpdaterName = "charm-revision-updater"
 	metricWorkerName         = "metric-worker"

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -31,10 +31,11 @@ func (s *ManifoldsSuite) TestNames(c *gc.C) {
 	}
 	// NOTE: if this test failed, the cmd/jujud/agent tests will
 	// also fail. Search for 'ModelWorkers' to find affected vars.
-	c.Check(actual.Values(), jc.SameContents, []string{
+	c.Check(actual.SortedValues(), jc.DeepEquals, []string{
 		"agent",
 		"api-caller",
 		"api-config-watcher",
+		"application-scaler",
 		"charm-revision-updater",
 		"clock",
 		"compute-provisioner",
@@ -44,10 +45,10 @@ func (s *ManifoldsSuite) TestNames(c *gc.C) {
 		"is-responsible-flag",
 		"metric-worker",
 		"migration-fortress",
+		"migration-inactive-flag",
 		"migration-master",
 		"not-alive-flag",
 		"not-dead-flag",
-		"application-scaler",
 		"space-importer",
 		"spaces-imported-gate",
 		"state-cleaner",
@@ -58,7 +59,7 @@ func (s *ManifoldsSuite) TestNames(c *gc.C) {
 	})
 }
 
-func (s *ManifoldsSuite) TestResponsibleFlagDependencies(c *gc.C) {
+func (s *ManifoldsSuite) TestFlagDependencies(c *gc.C) {
 	exclusions := set.NewStrings(
 		"agent",
 		"api-caller",
@@ -78,7 +79,10 @@ func (s *ManifoldsSuite) TestResponsibleFlagDependencies(c *gc.C) {
 			continue
 		}
 		inputs := set.NewStrings(manifold.Inputs...)
-		c.Check(inputs.Contains("is-responsible-flag"), jc.IsTrue)
+		if !inputs.Contains("is-responsible-flag") {
+			c.Check(inputs.Contains("migration-fortress"), jc.IsTrue)
+			c.Check(inputs.Contains("migration-inactive-flag"), jc.IsTrue)
+		}
 	}
 }
 

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -29,6 +29,9 @@ import (
 
 var (
 	agentLogger = loggo.GetLogger("juju.jujud")
+
+	// should be an explicit dependency, can't do it cleanly yet
+	unitManifolds = unit.Manifolds
 )
 
 // UnitAgent is a cmd.Command responsible for running a unit agent.
@@ -132,7 +135,7 @@ func (a *UnitAgent) Run(ctx *cmd.Context) error {
 
 // APIWorkers returns a dependency.Engine running the unit agent's responsibilities.
 func (a *UnitAgent) APIWorkers() (worker.Worker, error) {
-	manifolds := unit.Manifolds(unit.ManifoldsConfig{
+	manifolds := unitManifolds(unit.ManifoldsConfig{
 		Agent:               agent.APIHostPortsSetter{a},
 		LogSource:           a.bufferedLogs,
 		LeadershipGuarantee: 30 * time.Second,

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -11,6 +11,7 @@ import (
 
 	coreagent "github.com/juju/juju/agent"
 	msapi "github.com/juju/juju/api/meterstatus"
+	"github.com/juju/juju/cmd/jujud/agent/engine"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/apiaddressupdater"
@@ -26,6 +27,7 @@ import (
 	"github.com/juju/juju/worker/metrics/collect"
 	"github.com/juju/juju/worker/metrics/sender"
 	"github.com/juju/juju/worker/metrics/spool"
+	"github.com/juju/juju/worker/migrationflag"
 	"github.com/juju/juju/worker/migrationminion"
 	"github.com/juju/juju/worker/proxyupdater"
 	"github.com/juju/juju/worker/retrystrategy"
@@ -126,34 +128,46 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName: apiCallerName,
 		}),
 
+		// The migration workers collaborate to run migrations;
+		// and to create a mechanism for running other workers
+		// so they can't accidentally interfere with a migration
+		// in progress. Such a manifold should (1) depend on the
+		// migration-inactive flag, to know when to start or die;
+		// and (2) occupy the migration-fortress, so as to avoid
+		// possible interference with the minion (which will not
+		// take action until it's gained sole control of the
+		// fortress).
 		migrationFortressName: fortress.Manifold(),
-
-		// The migration minion handles the agent side aspects of model migrations.
+		migrationInactiveFlagName: migrationflag.Manifold(migrationflag.ManifoldConfig{
+			APICallerName: apiCallerName,
+			Check:         migrationflag.IsNone,
+			NewFacade:     migrationflag.NewFacade,
+			NewWorker:     migrationflag.NewWorker,
+		}),
 		migrationMinionName: migrationminion.Manifold(migrationminion.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 			FortressName:  migrationFortressName,
-
-			NewFacade: migrationminion.NewFacade,
-			NewWorker: migrationminion.NewWorker,
+			NewFacade:     migrationminion.NewFacade,
+			NewWorker:     migrationminion.NewWorker,
 		}),
 
 		// The logging config updater is a leaf worker that indirectly
 		// controls the messages sent via the log sender according to
 		// changes in environment config. We should only need one of
 		// these in a consolidated agent.
-		loggingConfigUpdaterName: logger.Manifold(logger.ManifoldConfig{
+		loggingConfigUpdaterName: ifNotMigrating(logger.Manifold(logger.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
-		}),
+		})),
 
 		// The api address updater is a leaf worker that rewrites agent config
 		// as the controller addresses change. We should only need one of
 		// these in a consolidated agent.
-		apiAddressUpdaterName: apiaddressupdater.Manifold(apiaddressupdater.ManifoldConfig{
+		apiAddressUpdaterName: ifNotMigrating(apiaddressupdater.Manifold(apiaddressupdater.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
-		}),
+		})),
 
 		// The proxy config updater is a leaf worker that sets http/https/apt/etc
 		// proxy settings.
@@ -161,64 +175,65 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// code trying to run this early; if that ever helped, it was only by
 		// coincidence. Probably we ought to be making components that might
 		// need proxy config into explicit dependencies of the proxy updater...
-		proxyConfigUpdaterName: proxyupdater.Manifold(proxyupdater.ManifoldConfig{
+		proxyConfigUpdaterName: ifNotMigrating(proxyupdater.Manifold(proxyupdater.ManifoldConfig{
+			AgentName:     agentName,
 			APICallerName: apiCallerName,
-		}),
+		})),
 
 		// The charmdir resource coordinates whether the charm directory is
 		// available or not; after 'start' hook and before 'stop' hook
 		// executes, and not during upgrades.
-		charmDirName: fortress.Manifold(),
+		charmDirName: ifNotMigrating(fortress.Manifold()),
 
 		// The leadership tracker attempts to secure and retain leadership of
 		// the unit's service, and is consulted on such matters by the
 		// uniter. As it stannds today, we'll need one per unit in a
 		// consolidated agent.
-		leadershipTrackerName: leadership.Manifold(leadership.ManifoldConfig{
+		leadershipTrackerName: ifNotMigrating(leadership.Manifold(leadership.ManifoldConfig{
 			AgentName:           agentName,
 			APICallerName:       apiCallerName,
 			LeadershipGuarantee: config.LeadershipGuarantee,
-		}),
+		})),
 
 		// HookRetryStrategy uses a retrystrategy worker to get a
 		// retry strategy that will be used by the uniter to run its hooks.
-		hookRetryStrategyName: retrystrategy.Manifold(retrystrategy.ManifoldConfig{
+		hookRetryStrategyName: ifNotMigrating(retrystrategy.Manifold(retrystrategy.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 			NewFacade:     retrystrategy.NewFacade,
 			NewWorker:     retrystrategy.NewRetryStrategyWorker,
-		}),
+		})),
 
 		// The uniter installs charms; manages the unit's presence in its
 		// relations; creates suboordinate units; runs all the hooks; sends
 		// metrics; etc etc etc. We expect to break it up further in the
 		// coming weeks, and to need one per unit in a consolidated agent
 		// (and probably one for each component broken out).
-		uniterName: uniter.Manifold(uniter.ManifoldConfig{
+		uniterName: ifNotMigrating(uniter.Manifold(uniter.ManifoldConfig{
 			AgentName:             agentName,
 			APICallerName:         apiCallerName,
 			LeadershipTrackerName: leadershipTrackerName,
 			MachineLockName:       machineLockName,
 			CharmDirName:          charmDirName,
 			HookRetryStrategyName: hookRetryStrategyName,
-		}),
+		})),
 
 		// TODO (mattyw) should be added to machine agent.
-		metricSpoolName: spool.Manifold(spool.ManifoldConfig{
+		metricSpoolName: ifNotMigrating(spool.Manifold(spool.ManifoldConfig{
 			AgentName: agentName,
-		}),
+		})),
 
 		// The metric collect worker executes the collect-metrics hook in a
 		// restricted context that can safely run concurrently with other hooks.
-		metricCollectName: collect.Manifold(collect.ManifoldConfig{
+		metricCollectName: ifNotMigrating(collect.Manifold(collect.ManifoldConfig{
 			AgentName:       agentName,
 			MetricSpoolName: metricSpoolName,
 			CharmDirName:    charmDirName,
-		}),
+		})),
 
 		// The meter status worker executes the meter-status-changed hook when it detects
 		// that the meter status has changed.
-		meterStatusName: meterstatus.Manifold(meterstatus.ManifoldConfig{
+		meterStatusName: ifNotMigrating(meterstatus.Manifold(meterstatus.ManifoldConfig{
 			AgentName:                agentName,
 			APICallerName:            apiCallerName,
 			MachineLockName:          machineLockName,
@@ -226,16 +241,23 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewMeterStatusAPIClient:  msapi.NewClient,
 			NewConnectedStatusWorker: meterstatus.NewConnectedStatusWorker,
 			NewIsolatedStatusWorker:  meterstatus.NewIsolatedStatusWorker,
-		}),
+		})),
 
 		// The metric sender worker periodically sends accumulated metrics to the controller.
-		metricSenderName: sender.Manifold(sender.ManifoldConfig{
+		metricSenderName: ifNotMigrating(sender.Manifold(sender.ManifoldConfig{
 			AgentName:       agentName,
 			APICallerName:   apiCallerName,
 			MetricSpoolName: metricSpoolName,
-		}),
+		})),
 	}
 }
+
+var ifNotMigrating = engine.Housing{
+	Flags: []string{
+		migrationInactiveFlagName,
+	},
+	Occupy: migrationFortressName,
+}.Decorate
 
 const (
 	agentName            = "agent"
@@ -245,8 +267,9 @@ const (
 	logSenderName        = "log-sender"
 	upgraderName         = "upgrader"
 
-	migrationFortressName = "migration-fortress"
-	migrationMinionName   = "migration-minion"
+	migrationFortressName     = "migration-fortress"
+	migrationInactiveFlagName = "migration-inactive-flag"
+	migrationMinionName       = "migration-minion"
 
 	loggingConfigUpdaterName = "logging-config-updater"
 	proxyConfigUpdaterName   = "proxy-config-updater"

--- a/cmd/jujud/agent/unit/manifolds_test.go
+++ b/cmd/jujud/agent/unit/manifolds_test.go
@@ -5,6 +5,7 @@ package unit_test
 
 import (
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
@@ -30,12 +31,7 @@ func (s *ManifoldsSuite) TestStartFuncs(c *gc.C) {
 }
 
 func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
-	config := unit.ManifoldsConfig{
-		Agent:               nil,
-		LogSource:           nil,
-		LeadershipGuarantee: 0,
-	}
-
+	config := unit.ManifoldsConfig{}
 	manifolds := unit.Manifolds(config)
 	expectedKeys := []string{
 		"agent",
@@ -46,6 +42,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"upgrader",
 		"migration-fortress",
 		"migration-minion",
+		"migration-inactive-flag",
 		"logging-config-updater",
 		"proxy-config-updater",
 		"api-address-updater",
@@ -63,6 +60,38 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		keys = append(keys, k)
 	}
 	c.Assert(expectedKeys, jc.SameContents, keys)
+}
+
+func (*ManifoldsSuite) TestMigrationGuards(c *gc.C) {
+	exempt := set.NewStrings(
+		"agent",
+		"machine-lock",
+		"api-config-watcher",
+		"api-caller",
+		"log-sender",
+		"upgrader",
+		"migration-fortress",
+		"migration-minion",
+		"migration-inactive-flag",
+	)
+	config := unit.ManifoldsConfig{}
+	manifolds := unit.Manifolds(config)
+	for name, manifold := range manifolds {
+		c.Logf(name)
+		if !exempt.Contains(name) {
+			checkContains(c, manifold.Inputs, "migration-inactive-flag")
+			checkContains(c, manifold.Inputs, "migration-fortress")
+		}
+	}
+}
+
+func checkContains(c *gc.C, names []string, seek string) {
+	for _, name := range names {
+		if name == seek {
+			return
+		}
+	}
+	c.Errorf("%q not present in %v", seek, names)
 }
 
 type fakeAgent struct {

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/series"
@@ -24,11 +25,11 @@ import (
 	agenttools "github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
 	envtesting "github.com/juju/juju/environs/testing"
-	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker/upgrader"
@@ -64,22 +65,13 @@ func (s *UnitSuite) TearDownTest(c *gc.C) {
 // primeAgent creates a unit, and sets up the unit agent's directory.
 // It returns the assigned machine, new unit and the agent's configuration.
 func (s *UnitSuite) primeAgent(c *gc.C) (*state.Machine, *state.Unit, agent.Config, *tools.Tools) {
-	jujutesting.AddControllerMachine(c, s.State)
-	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	unit, err := svc.AddUnit()
-	c.Assert(err, jc.ErrorIsNil)
-	err = unit.SetPassword(initialUnitPassword)
-	c.Assert(err, jc.ErrorIsNil)
-	// Assign the unit to a machine.
-	err = unit.AssignToNewMachine()
-	c.Assert(err, jc.ErrorIsNil)
-	id, err := unit.AssignedMachineId()
-	c.Assert(err, jc.ErrorIsNil)
-	machine, err := s.State.Machine(id)
-	c.Assert(err, jc.ErrorIsNil)
-	inst, md := jujutesting.AssertStartInstance(c, s.Environ, id)
-	err = machine.SetProvisioned(inst.Id(), agent.BootstrapNonce, md)
-	c.Assert(err, jc.ErrorIsNil)
+	machine := s.Factory.MakeMachine(c, nil)
+	app := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+		Machine:     machine,
+		Password:    initialUnitPassword,
+	})
 	conf, tools := s.PrimeAgent(c, unit.Tag(), initialUnitPassword)
 	return machine, unit, conf, tools
 }
@@ -402,4 +394,24 @@ func (s *UnitSuite) TestChangeConfig(c *gc.C) {
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("timed out waiting for config changed signal")
 	}
+}
+
+func (s *UnitSuite) TestWorkers(c *gc.C) {
+	tracker := NewEngineTracker()
+	instrumented := TrackUnits(c, tracker, unitManifolds)
+	s.PatchValue(&unitManifolds, instrumented)
+
+	_, unit, _, _ := s.primeAgent(c)
+	ctx := cmdtesting.Context(c)
+	a := NewUnitAgent(ctx, nil)
+	s.InitAgent(c, a, "--unit-name", unit.Name())
+
+	go func() { c.Check(a.Run(nil), gc.IsNil) }()
+	defer func() { c.Check(a.Stop(), gc.IsNil) }()
+
+	id := a.Tag().String()
+	checkNotMigrating := EngineMatchFunc(c, tracker, append(
+		alwaysUnitWorkers, notMigratingUnitWorkers...,
+	))
+	WaitMatch(c, checkNotMigrating, id, s.BackingState.StartSync)
 }

--- a/worker/dependency/context.go
+++ b/worker/dependency/context.go
@@ -95,11 +95,14 @@ type resourceAccess struct {
 
 // report returns a convenient representation of ra.
 func (ra resourceAccess) report() map[string]interface{} {
-	return map[string]interface{}{
-		KeyName:  ra.name,
-		KeyType:  ra.as,
-		KeyError: ra.err,
+	report := map[string]interface{}{
+		KeyName: ra.name,
+		KeyType: ra.as,
 	}
+	if ra.err != nil {
+		report[KeyError] = ra.err.Error()
+	}
+	return report
 }
 
 // resourceLogReport returns a convenient representation of accessLog.

--- a/worker/dependency/reporter_test.go
+++ b/worker/dependency/reporter_test.go
@@ -32,7 +32,6 @@ func (s *ReportSuite) TestReportStarted(c *gc.C) {
 		report := engine.Report()
 		c.Check(report, jc.DeepEquals, map[string]interface{}{
 			"state":     "started",
-			"error":     nil,
 			"manifolds": map[string]interface{}{},
 		})
 	})
@@ -44,7 +43,6 @@ func (s *ReportSuite) TestReportStopped(c *gc.C) {
 		report := engine.Report()
 		c.Check(report, jc.DeepEquals, map[string]interface{}{
 			"state":     "stopped",
-			"error":     nil,
 			"manifolds": map[string]interface{}{},
 		})
 	})
@@ -91,11 +89,9 @@ func (s *ReportSuite) TestReportStopping(c *gc.C) {
 		}
 		c.Check(report, jc.DeepEquals, map[string]interface{}{
 			"state": "stopping",
-			"error": nil,
 			"manifolds": map[string]interface{}{
 				"task": map[string]interface{}{
 					"state":        "stopping",
-					"error":        nil,
 					"inputs":       ([]string)(nil),
 					"resource-log": []map[string]interface{}{},
 					"report": map[string]interface{}{
@@ -122,11 +118,9 @@ func (s *ReportSuite) TestReportInputs(c *gc.C) {
 		report := engine.Report()
 		c.Check(report, jc.DeepEquals, map[string]interface{}{
 			"state": "started",
-			"error": nil,
 			"manifolds": map[string]interface{}{
 				"task": map[string]interface{}{
 					"state":        "started",
-					"error":        nil,
 					"inputs":       ([]string)(nil),
 					"resource-log": []map[string]interface{}{},
 					"report": map[string]interface{}{
@@ -135,12 +129,10 @@ func (s *ReportSuite) TestReportInputs(c *gc.C) {
 				},
 				"another task": map[string]interface{}{
 					"state":  "started",
-					"error":  nil,
 					"inputs": []string{"task"},
 					"resource-log": []map[string]interface{}{{
-						"name":  "task",
-						"type":  "<nil>",
-						"error": nil,
+						"name": "task",
+						"type": "<nil>",
 					}},
 					"report": map[string]interface{}{
 						"key1": "hello there",
@@ -163,18 +155,16 @@ func (s *ReportSuite) TestReportError(c *gc.C) {
 		report := engine.Report()
 		c.Check(report, jc.DeepEquals, map[string]interface{}{
 			"state": "stopped",
-			"error": nil,
 			"manifolds": map[string]interface{}{
 				"task": map[string]interface{}{
 					"state":  "stopped",
-					"error":  dependency.ErrMissing,
+					"error":  dependency.ErrMissing.Error(),
 					"inputs": []string{"missing"},
 					"resource-log": []map[string]interface{}{{
 						"name":  "missing",
 						"type":  "<nil>",
-						"error": dependency.ErrMissing,
+						"error": dependency.ErrMissing.Error(),
 					}},
-					"report": (map[string]interface{})(nil),
 				},
 			},
 		})


### PR DESCRIPTION
All agent manifold sets now contain the workers:

  * migration-fortress
  * migration-inactive-flag
  * migration-(master|minion)

...and define an engine.Housing that is used to prevent other workers
from running at the same time as any migration activity.

Several agent test bugs were uncovered, noted, and left unaddressed.

Issues with dependency.Engine, which would deadlock when reporting on
itself, and produce reports that were unhelpful in some respects, were
addressed and used to help discover the aforementioned agent test bugs.

Previously reviewed at http://reviews.vapour.ws/r/4960/

(Review request: http://reviews.vapour.ws/r/5101/)