### PR TITLE
apiserver/migrationmaster: Add accces to minion reports

### DIFF
--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -113,3 +113,27 @@ type MinionReport struct {
 	Phase       string `json:"phase"`
 	Success     bool   `json:"success"`
 }
+
+// MinionReports holds the details of whether a migration minion
+// succeeded or failed for a specific migration phase.
+type MinionReports struct {
+	MigrationId string `json:"migration-id"`
+	Phase       string `json:"phase"`
+
+	// SuccessCount holds the number of agents which have successfully
+	// completed a given migration phase.
+	SuccessCount int `json:"success-count"`
+
+	// UnknownCount holds the number of agents still to report for a
+	// given migration phase.
+	UnknownCount int `json:"unknown-count"`
+
+	// UnknownSample holds the tags of a limited number of agents
+	// that are still to report for a given migration phase (for
+	// logging or showing in a user interface).
+	UnknownSample []string `json:"unknown-sample"`
+
+	// Failed contains the tags of all agents which have reported a
+	// failed to complete a given migration phase.
+	Failed []string `json:"failed"`
+}


### PR DESCRIPTION
This change adds calls to the MigrationMaster apiserver facade to allow watching for new migration minion reports, and extraction of the details of the current reports. This will be used by the migration
master when waiting for minions to report back regarding their actions for specific migration phases.

(Review request: http://reviews.vapour.ws/r/5105/)