### PR TITLE
Separate model and controller config

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/controller/modelmanager"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
@@ -95,13 +94,14 @@ func InitializeState(
 			CloudRegion:     args.ControllerCloudRegion,
 			CloudCredential: args.ControllerCloudCredentialName,
 		},
-		CloudName:           args.ControllerCloudName,
-		Cloud:               args.ControllerCloud,
-		CloudCredentials:    cloudCredentials,
-		ModelConfigDefaults: args.ModelConfigDefaults,
-		MongoInfo:           info,
-		MongoDialOpts:       dialOpts,
-		Policy:              policy,
+		CloudName:        args.ControllerCloudName,
+		Cloud:            args.ControllerCloud,
+		CloudCredentials: cloudCredentials,
+		ControllerConfig: args.ControllerConfig,
+		LocalCloudConfig: args.LocalCloudConfig,
+		MongoInfo:        info,
+		MongoDialOpts:    dialOpts,
+		Policy:           policy,
 	})
 	if err != nil {
 		return nil, nil, errors.Errorf("failed to initialize state: %v", err)
@@ -143,7 +143,7 @@ func InitializeState(
 			attrs[k] = v
 		}
 	}
-	controllerUUID := controller.Config(args.ControllerModelConfig.AllAttrs()).ControllerUUID()
+	controllerUUID := args.ControllerConfig.ControllerUUID()
 	hostedModelConfig, err := modelmanager.ModelConfigCreator{}.NewModelConfig(
 		modelmanager.IsAdmin, controllerUUID, args.ControllerModelConfig, attrs,
 	)

--- a/apiserver/common/modeldestroy_test.go
+++ b/apiserver/common/modeldestroy_test.go
@@ -57,13 +57,13 @@ func (s *destroyModelSuite) setUpManual(c *gc.C) (m0, m1 *state.Machine) {
 func (s *destroyModelSuite) setUpInstances(c *gc.C) (m0, m1, m2 *state.Machine) {
 	m0, err := s.State.AddMachine("precise", state.JobManageModel)
 	c.Assert(err, jc.ErrorIsNil)
-	inst, _ := testing.AssertStartInstance(c, s.Environ, s.ControllerUUID, m0.Id())
+	inst, _ := testing.AssertStartInstance(c, s.Environ, s.ControllerConfig.ControllerUUID(), m0.Id())
 	err = m0.SetProvisioned(inst.Id(), "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	m1, err = s.State.AddMachine("precise", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	inst, _ = testing.AssertStartInstance(c, s.Environ, s.ControllerUUID, m1.Id())
+	inst, _ = testing.AssertStartInstance(c, s.Environ, s.ControllerConfig.ControllerUUID(), m1.Id())
 	err = m1.SetProvisioned(inst.Id(), "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/common/modelwatcher_test.go
+++ b/apiserver/common/modelwatcher_test.go
@@ -124,9 +124,10 @@ func testingEnvConfig(c *gc.C) *config.Config {
 		modelcmd.BootstrapContext(testing.Context(c)),
 		jujuclienttesting.NewMemStore(),
 		environs.PrepareParams{
-			ControllerName: "dummycontroller",
-			BaseConfig:     dummy.SampleConfig(),
-			CloudName:      "dummy",
+			ControllerConfig: testing.FakeControllerBootstrapConfig(),
+			ControllerName:   "dummycontroller",
+			BaseConfig:       dummy.SampleConfig(),
+			CloudName:        "dummy",
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/imagemetadata/functions_test.go
+++ b/apiserver/imagemetadata/functions_test.go
@@ -36,9 +36,10 @@ func (s *funcSuite) SetUpTest(c *gc.C) {
 		envtesting.BootstrapContext(c),
 		jujuclienttesting.NewMemStore(),
 		environs.PrepareParams{
-			ControllerName: "dummycontroller",
-			BaseConfig:     mockConfig(),
-			CloudName:      "dummy",
+			ControllerConfig: testing.FakeControllerBootstrapConfig(),
+			ControllerName:   "dummycontroller",
+			BaseConfig:       mockConfig(),
+			CloudName:        "dummy",
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/imagemetadata/package_test.go
+++ b/apiserver/imagemetadata/package_test.go
@@ -126,9 +126,10 @@ func testConfig(c *gc.C) *config.Config {
 		envtesting.BootstrapContext(c),
 		jujuclienttesting.NewMemStore(),
 		environs.PrepareParams{
-			ControllerName: "dummycontroller",
-			BaseConfig:     attrs,
-			CloudName:      "dummy",
+			ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
+			ControllerName:   "dummycontroller",
+			BaseConfig:       attrs,
+			CloudName:        "dummy",
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/imagemetadata/updatefrompublished_test.go
+++ b/apiserver/imagemetadata/updatefrompublished_test.go
@@ -167,9 +167,10 @@ func (s *imageMetadataUpdateSuite) TestUpdateFromPublishedImagesForProviderWithN
 			modelcmd.BootstrapContext(testing.Context(c)),
 			jujuclienttesting.NewMemStore(),
 			environs.PrepareParams{
-				ControllerName: "dummycontroller",
-				BaseConfig:     dummy.SampleConfig(),
-				CloudName:      "dummy",
+				ControllerConfig: testing.FakeControllerBootstrapConfig(),
+				ControllerName:   "dummycontroller",
+				BaseConfig:       dummy.SampleConfig(),
+				CloudName:        "dummy",
 			},
 		)
 		c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/migrationtarget/migrationtarget_test.go
+++ b/apiserver/migrationtarget/migrationtarget_test.go
@@ -39,9 +39,10 @@ func (s *Suite) SetUpTest(c *gc.C) {
 		modelcmd.BootstrapContext(testing.Context(c)),
 		jujuclienttesting.NewMemStore(),
 		environs.PrepareParams{
-			ControllerName: "dummycontroller",
-			BaseConfig:     dummy.SampleConfig(),
-			CloudName:      "dummy",
+			ControllerConfig: testing.FakeControllerBootstrapConfig(),
+			ControllerName:   "dummycontroller",
+			BaseConfig:       dummy.SampleConfig(),
+			CloudName:        "dummy",
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/status"
 	jujuversion "github.com/juju/juju/version"
 	// Register the providers for the field check test
+	"github.com/juju/juju/controller"
 	_ "github.com/juju/juju/provider/azure"
 	"github.com/juju/juju/provider/dummy"
 	_ "github.com/juju/juju/provider/ec2"
@@ -136,7 +137,6 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 		"name":            "foo",
 		"type":            "dummy",
 		"authorized-keys": s.st.controllerModel.cfg.AuthorizedKeys(),
-		"controller-uuid": coretesting.ModelTag.Id(),
 		"uuid":            uuid,
 		"agent-version":   jujuversion.Current.String(),
 		"bar":             "baz",
@@ -144,6 +144,10 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 		"broken":          "",
 		"secret":          "pork",
 	})
+	c.Assert(err, jc.ErrorIsNil)
+	// TODO(wallyworld) - we need to separate controller and model schemas
+	// Remove any remaining controller attributes from the env config.
+	cfg, err = cfg.Remove(controller.ControllerOnlyConfigAttributes)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(newModelArgs, jc.DeepEquals, state.ModelArgs{
@@ -768,7 +772,7 @@ func (*fakeProvider) Validate(cfg, old *config.Config) (*config.Config, error) {
 	return cfg, nil
 }
 
-func (*fakeProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+func (*fakeProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
 	return cfg, nil
 }
 

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -584,6 +584,7 @@ type ProvisioningInfo struct {
 	SubnetsToZones   map[string][]string
 	ImageMetadata    []CloudImageMetadata
 	EndpointBindings map[string]string
+	ControllerConfig map[string]interface{}
 }
 
 // ProvisioningInfoResult holds machine provisioning info or an error.

--- a/apiserver/provisioner/provisioninginfo.go
+++ b/apiserver/provisioner/provisioninginfo.go
@@ -88,6 +88,10 @@ func (p *ProvisionerAPI) getProvisioningInfo(m *state.Machine) (*params.Provisio
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get available image metadata")
 	}
+	controllerCfg, err := p.st.ControllerConfig()
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot get controller configuration")
+	}
 
 	return &params.ProvisioningInfo{
 		Constraints:      cons,
@@ -99,6 +103,7 @@ func (p *ProvisionerAPI) getProvisioningInfo(m *state.Machine) (*params.Provisio
 		SubnetsToZones:   subnetsToZones,
 		EndpointBindings: endpointBindings,
 		ImageMetadata:    imageMetadata,
+		ControllerConfig: controllerCfg,
 	}, nil
 }
 

--- a/apiserver/provisioner/provisioninginfo_test.go
+++ b/apiserver/provisioner/provisioninginfo_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/storage"
@@ -50,21 +51,27 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithStorage(c *gc.C) {
 	result, err := s.provisioner.ProvisioningInfo(args)
 	c.Assert(err, jc.ErrorIsNil)
 
+	controllerCfg := coretesting.FakeControllerConfig()
+	// Dummy provider uses a random port, which is added to cfg used to create environment.
+	apiPort := dummy.ApiPort(s.Environ.Provider())
+	controllerCfg["api-port"] = apiPort
 	expected := params.ProvisioningInfoResults{
 		Results: []params.ProvisioningInfoResult{
 			{Result: &params.ProvisioningInfo{
-				Series: "quantal",
-				Jobs:   []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
+				ControllerConfig: controllerCfg,
+				Series:           "quantal",
+				Jobs:             []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 				Tags: map[string]string{
 					tags.JujuController: coretesting.ModelTag.Id(),
 					tags.JujuModel:      coretesting.ModelTag.Id(),
 				},
 			}},
 			{Result: &params.ProvisioningInfo{
-				Series:      "quantal",
-				Constraints: template.Constraints,
-				Placement:   template.Placement,
-				Jobs:        []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
+				ControllerConfig: controllerCfg,
+				Series:           "quantal",
+				Constraints:      template.Constraints,
+				Placement:        template.Placement,
+				Jobs:             []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 				Tags: map[string]string{
 					tags.JujuController: coretesting.ModelTag.Id(),
 					tags.JujuModel:      coretesting.ModelTag.Id(),
@@ -159,13 +166,18 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithSingleNegativeAndPositi
 	result, err := s.provisioner.ProvisioningInfo(args)
 	c.Assert(err, jc.ErrorIsNil)
 
+	controllerCfg := coretesting.FakeControllerConfig()
+	// Dummy provider uses a random port, which is added to cfg used to create environment.
+	apiPort := dummy.ApiPort(s.Environ.Provider())
+	controllerCfg["api-port"] = apiPort
 	expected := params.ProvisioningInfoResults{
 		Results: []params.ProvisioningInfoResult{{
 			Result: &params.ProvisioningInfo{
-				Series:      "quantal",
-				Constraints: template.Constraints,
-				Placement:   template.Placement,
-				Jobs:        []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
+				ControllerConfig: controllerCfg,
+				Series:           "quantal",
+				Constraints:      template.Constraints,
+				Placement:        template.Placement,
+				Jobs:             []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 				Tags: map[string]string{
 					tags.JujuController: coretesting.ModelTag.Id(),
 					tags.JujuModel:      coretesting.ModelTag.Id(),
@@ -224,11 +236,16 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindings(c *gc.
 	result, err := s.provisioner.ProvisioningInfo(args)
 	c.Assert(err, jc.ErrorIsNil)
 
+	controllerCfg := coretesting.FakeControllerConfig()
+	// Dummy provider uses a random port, which is added to cfg used to create environment.
+	apiPort := dummy.ApiPort(s.Environ.Provider())
+	controllerCfg["api-port"] = apiPort
 	expected := params.ProvisioningInfoResults{
 		Results: []params.ProvisioningInfoResult{{
 			Result: &params.ProvisioningInfo{
-				Series: "quantal",
-				Jobs:   []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
+				ControllerConfig: controllerCfg,
+				Series:           "quantal",
+				Jobs:             []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 				Tags: map[string]string{
 					tags.JujuController:    coretesting.ModelTag.Id(),
 					tags.JujuModel:         coretesting.ModelTag.Id(),
@@ -307,13 +324,18 @@ func (s *withoutControllerSuite) TestStorageProviderFallbackToType(c *gc.C) {
 	result, err := s.provisioner.ProvisioningInfo(args)
 	c.Assert(err, jc.ErrorIsNil)
 
+	controllerCfg := coretesting.FakeControllerConfig()
+	// Dummy provider uses a random port, which is added to cfg used to create environment.
+	apiPort := dummy.ApiPort(s.Environ.Provider())
+	controllerCfg["api-port"] = apiPort
 	c.Assert(result, jc.DeepEquals, params.ProvisioningInfoResults{
 		Results: []params.ProvisioningInfoResult{
 			{Result: &params.ProvisioningInfo{
-				Series:      "quantal",
-				Constraints: template.Constraints,
-				Placement:   template.Placement,
-				Jobs:        []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
+				ControllerConfig: controllerCfg,
+				Series:           "quantal",
+				Constraints:      template.Constraints,
+				Placement:        template.Placement,
+				Jobs:             []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 				Tags: map[string]string{
 					tags.JujuController: coretesting.ModelTag.Id(),
 					tags.JujuModel:      coretesting.ModelTag.Id(),
@@ -357,11 +379,16 @@ func (s *withoutControllerSuite) TestProvisioningInfoPermissions(c *gc.C) {
 
 	// Only machine 0 and containers therein can be accessed.
 	results, err := aProvisioner.ProvisioningInfo(args)
+	controllerCfg := coretesting.FakeControllerConfig()
+	// Dummy provider uses a random port, which is added to cfg used to create environment.
+	apiPort := dummy.ApiPort(s.Environ.Provider())
+	controllerCfg["api-port"] = apiPort
 	c.Assert(results, jc.DeepEquals, params.ProvisioningInfoResults{
 		Results: []params.ProvisioningInfoResult{
 			{Result: &params.ProvisioningInfo{
-				Series: "quantal",
-				Jobs:   []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
+				ControllerConfig: controllerCfg,
+				Series:           "quantal",
+				Jobs:             []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 				Tags: map[string]string{
 					tags.JujuController: coretesting.ModelTag.Id(),
 					tags.JujuModel:      coretesting.ModelTag.Id(),

--- a/cloudconfig/cloudinit/renderscript_test.go
+++ b/cloudconfig/cloudinit/renderscript_test.go
@@ -58,6 +58,7 @@ func (s *configureSuite) getCloudConfig(c *gc.C, controller bool, vers version.B
 	var err error
 	if controller {
 		icfg, err = instancecfg.NewBootstrapInstanceConfig(
+			coretesting.FakeControllerBootstrapConfig(),
 			constraints.Value{}, constraints.Value{},
 			vers.Series, "",
 		)

--- a/cmd/juju/backups/export_test.go
+++ b/cmd/juju/backups/export_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/testing"
 )
 
 const (
@@ -93,8 +94,8 @@ func NewRestoreCommandForTest(
 func GetEnvironFunc(e environs.Environ, cloud string) func(string, *params.BackupsMetadataResult) (environs.Environ, *restoreBootstrapParams, error) {
 	return func(string, *params.BackupsMetadataResult) (environs.Environ, *restoreBootstrapParams, error) {
 		return e, &restoreBootstrapParams{
-			ControllerUUID: "deadbeef-0bad-400d-8000-5b1d0d06f00d",
-			CloudName:      cloud,
+			ControllerConfig: testing.FakeControllerConfig(),
+			CloudName:        cloud,
 		}, nil
 	}
 }

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -133,11 +133,11 @@ func (c *restoreCommand) Init(args []string) error {
 }
 
 type restoreBootstrapParams struct {
-	ControllerUUID string
-	CloudName      string
-	CloudRegion    string
-	CredentialName string
-	Credential     cloud.Credential
+	ControllerConfig controller.Config
+	CloudName        string
+	CloudRegion      string
+	CredentialName   string
+	Credential       cloud.Credential
 }
 
 // getEnviron returns the environ for the specified controller, or
@@ -164,13 +164,18 @@ func (c *restoreCommand) getEnviron(
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	controllerUUID := controller.Config(cfg.AllAttrs()).ControllerUUID()
+
+	controllerCfg := controller.Config{
+		controller.ControllerUUIDKey: params.ControllerUUID,
+		controller.CACertKey:         meta.CACert,
+		controller.CAPrivateKey:      meta.CAPrivateKey,
+	}
 
 	// We may have previous controller metadata. We need to update that so it
 	// will contain the new CA Cert and UUID required to connect to the newly
 	// bootstrapped controller API.
 	details := jujuclient.ControllerDetails{
-		ControllerUUID: controllerUUID,
+		ControllerUUID: controllerCfg.ControllerUUID(),
 		CACert:         meta.CACert,
 	}
 	err = store.UpdateController(controllerName, details)
@@ -200,19 +205,17 @@ func (c *restoreCommand) getEnviron(
 	cfg, err = cfg.Apply(map[string]interface{}{
 		"provisioner-safe-mode": true,
 		"admin-secret":          adminSecret,
-		"ca-private-key":        meta.CAPrivateKey,
-		"ca-cert":               meta.CACert,
 	})
 	if err != nil {
 		return nil, nil, errors.Annotatef(err, "cannot enable provisioner-safe-mode")
 	}
 	env, err := environs.New(cfg)
 	return env, &restoreBootstrapParams{
-		ControllerUUID: controllerUUID,
-		CloudName:      config.Cloud,
-		CloudRegion:    config.CloudRegion,
-		CredentialName: config.Credential,
-		Credential:     params.Credentials,
+		ControllerConfig: controllerCfg,
+		CloudName:        config.Cloud,
+		CloudRegion:      config.CloudRegion,
+		CredentialName:   config.Credential,
+		Credential:       params.Credentials,
 	}, err
 }
 
@@ -223,7 +226,7 @@ func (c *restoreCommand) rebootstrap(ctx *cmd.Context, meta *params.BackupsMetad
 	if err != nil {
 		return errors.Trace(err)
 	}
-	instanceIds, err := env.ControllerInstances(params.ControllerUUID)
+	instanceIds, err := env.ControllerInstances(params.ControllerConfig.ControllerUUID())
 	if err != nil && errors.Cause(err) != environs.ErrNotBootstrapped {
 		return errors.Annotatef(err, "cannot determine controller instances")
 	}
@@ -259,7 +262,6 @@ func (c *restoreCommand) rebootstrap(ctx *cmd.Context, meta *params.BackupsMetad
 		cred = &params.Credential
 	}
 	args := bootstrap.BootstrapParams{
-		ControllerUUID:      params.ControllerUUID,
 		Cloud:               *cloudParam,
 		CloudName:           params.CloudName,
 		CloudRegion:         params.CloudRegion,
@@ -268,6 +270,7 @@ func (c *restoreCommand) rebootstrap(ctx *cmd.Context, meta *params.BackupsMetad
 		ModelConstraints:    c.constraints,
 		UploadTools:         c.uploadTools,
 		BuildToolsTarball:   sync.BuildToolsTarball,
+		ControllerConfig:    params.ControllerConfig,
 		HostedModelConfig:   hostedModelConfig,
 		BootstrapSeries:     meta.Series,
 		AgentVersion:        &bootVers,

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -411,7 +411,7 @@ func (s *BootstrapSuite) TestBootstrapDefaultModel(c *gc.C) {
 		"--default-model", "mymodel",
 		"--config", "foo=bar",
 	)
-	c.Assert(utils.IsValidUUIDString(bootstrap.args.ControllerUUID), jc.IsTrue)
+	c.Assert(utils.IsValidUUIDString(bootstrap.args.ControllerConfig.ControllerUUID()), jc.IsTrue)
 	c.Assert(bootstrap.args.HostedModelConfig["name"], gc.Equals, "mymodel")
 	c.Assert(bootstrap.args.HostedModelConfig["foo"], gc.Equals, "bar")
 }

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -117,6 +117,7 @@ func WaitForAgentInitialisation(ctx *cmd.Context, c *modelcmd.ModelCommandBase, 
 		switch {
 		case errors.Cause(err) == io.EOF,
 			strings.HasSuffix(errorMessage, "connection is shut down"),
+			strings.HasSuffix(errorMessage, "no api connection available"),
 			strings.Contains(errorMessage, "spaces are still being discovered"):
 			ctx.Infof("Waiting for API to become available")
 			continue

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/cmd/modelcmd"
 	cmdtesting "github.com/juju/juju/cmd/testing"
+	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
@@ -119,12 +120,15 @@ func (f *fakeDestroyAPIClient) DestroyModel() error {
 
 func createBootstrapInfo(c *gc.C, name string) map[string]interface{} {
 	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
-		"type":            "dummy",
-		"name":            name,
-		"uuid":            testing.ModelTag.Id(),
-		"controller-uuid": testing.ModelTag.Id(),
-		"controller":      "true",
+		"type":       "dummy",
+		"name":       name,
+		"uuid":       testing.ModelTag.Id(),
+		"controller": "true",
 	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// TODO(wallyworld) - we need to separate controller and model schemas
+	cfg, err = cfg.Remove(jujucontroller.ControllerOnlyConfigAttributes)
 	c.Assert(err, jc.ErrorIsNil)
 	return cfg.AllAttrs()
 }

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -77,7 +77,7 @@ func (s *UnitSuite) primeAgent(c *gc.C) (*state.Machine, *state.Unit, agent.Conf
 	c.Assert(err, jc.ErrorIsNil)
 	machine, err := s.State.Machine(id)
 	c.Assert(err, jc.ErrorIsNil)
-	inst, md := jujutesting.AssertStartInstance(c, s.Environ, s.ControllerUUID, id)
+	inst, md := jujutesting.AssertStartInstance(c, s.Environ, s.ControllerConfig.ControllerUUID(), id)
 	err = machine.SetProvisioned(inst.Id(), agent.BootstrapNonce, md)
 	c.Assert(err, jc.ErrorIsNil)
 	conf, tools := s.PrimeAgent(c, unit.Tag(), initialUnitPassword)

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -159,7 +159,7 @@ func (s *commonMachineSuite) configureMachine(c *gc.C, machineId string, vers ve
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Add a machine and ensure it is provisioned.
-	inst, md := jujutesting.AssertStartInstance(c, s.Environ, s.ControllerUUID, machineId)
+	inst, md := jujutesting.AssertStartInstance(c, s.Environ, s.ControllerConfig.ControllerUUID(), machineId)
 	c.Assert(m.SetProvisioned(inst.Id(), agent.BootstrapNonce, md), jc.ErrorIsNil)
 
 	// Add an address for the tests in case the initiateMongoServer

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -388,6 +388,7 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 			CloudStorageEndpoint: bootstrapConfig.CloudStorageEndpoint,
 		},
 		&environs.BootstrapConfigParams{
+			controllerDetails.ControllerUUID,
 			cfg, *credential,
 			bootstrapConfig.CloudRegion,
 			bootstrapConfig.CloudEndpoint,

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -57,9 +57,10 @@ func (s *ToolsMetadataSuite) SetUpTest(c *gc.C) {
 		modelcmd.BootstrapContextNoVerify(coretesting.Context(c)),
 		jujuclienttesting.NewMemStore(),
 		environs.PrepareParams{
-			ControllerName: cfg.Name(),
-			BaseConfig:     cfg.AllAttrs(),
-			CloudName:      "dummy",
+			ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
+			ControllerName:   cfg.Name(),
+			BaseConfig:       cfg.AllAttrs(),
+			CloudName:        "dummy",
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/controller/config.go
+++ b/controller/config.go
@@ -44,6 +44,21 @@ const (
 
 	// IdentityPublicKey sets the public key of the identity manager.
 	IdentityPublicKey = "identity-public-key"
+
+	// NumaControlPolicyKey stores the value for this setting
+	SetNumaControlPolicyKey = "set-numa-control-policy"
+
+	// Attribute Defaults
+
+	// DefaultNumaControlPolicy should not be used by default.
+	// Only use numactl if user specifically requests it
+	DefaultNumaControlPolicy = false
+
+	// DefaultStatePort is the default port the controller is listening on.
+	DefaultStatePort int = 37017
+
+	// DefaultApiPort is the default port the API server is listening on.
+	DefaultAPIPort int = 17070
 )
 
 // ControllerOnlyConfigAttributes are attributes which are only relevant
@@ -56,6 +71,18 @@ var ControllerOnlyConfigAttributes = []string{
 	ControllerUUIDKey,
 	IdentityURL,
 	IdentityPublicKey,
+	SetNumaControlPolicyKey,
+}
+
+// ControllerOnlyAttribute returns true if the specified attribute name
+// is only relevant for a controller.
+func ControllerOnlyAttribute(attr string) bool {
+	for _, a := range ControllerOnlyConfigAttributes {
+		if attr == a {
+			return true
+		}
+	}
+	return false
 }
 
 type Config map[string]interface{}
@@ -69,13 +96,6 @@ func ControllerConfig(cfg map[string]interface{}) Config {
 		}
 	}
 	return controllerCfg
-}
-
-// RemoveControllerAttributes removes any controller attributes from attrs.
-func RemoveControllerAttributes(attrs map[string]interface{}) {
-	for _, attr := range ControllerOnlyConfigAttributes {
-		delete(attrs, attr)
-	}
 }
 
 // mustInt returns the named attribute as an integer, panicking if
@@ -159,6 +179,14 @@ func (c Config) IdentityPublicKey() *bakery.PublicKey {
 		panic(err)
 	}
 	return &pubKey
+}
+
+// NumaCtlPreference returns if numactl is preferred.
+func (c Config) NumaCtlPreference() bool {
+	if numa, ok := c[SetNumaControlPolicyKey]; ok {
+		return numa.(bool)
+	}
+	return DefaultNumaControlPolicy
 }
 
 // maybeReadAttrFromFile sets defined[attr] to:
@@ -310,6 +338,11 @@ var ConfigSchema = environschema.Fields{
 		Type:        environschema.Tstring,
 		Group:       environschema.JujuGroup,
 		Immutable:   true,
+	},
+	SetNumaControlPolicyKey: {
+		Description: "Tune Juju controller to work with NUMA if present (default false)",
+		Type:        environschema.Tbool,
+		Group:       environschema.EnvironGroup,
 	},
 	IdentityURL: {
 		Description: "IdentityURL specifies the URL of the identity manager",

--- a/environs/bootstrap.go
+++ b/environs/bootstrap.go
@@ -9,14 +9,16 @@ import (
 
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/tools"
 )
 
 // BootstrapParams holds the parameters for bootstrapping an environment.
 type BootstrapParams struct {
-	// ControllerUUID is the uuid of the controller to be bootstrapped.
-	ControllerUUID string
+	// ControllerConfig contains the configuration attributes for the
+	// bootstrapped controller.
+	ControllerConfig controller.Config
 
 	// ModelConstraints are merged with the bootstrap constraints
 	// to choose the initial instance, and will be stored in the new

--- a/environs/config.go
+++ b/environs/config.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-
-	"github.com/juju/juju/environs/config"
 )
 
 var logger = loggo.GetLogger("juju.environs")
@@ -102,23 +100,4 @@ func RegisteredProviders() []string {
 // Provider returns the previously registered provider with the given type.
 func Provider(providerType string) (EnvironProvider, error) {
 	return GlobalProviderRegistry().Provider(providerType)
-}
-
-// BootstrapConfig returns a copy of the supplied configuration with the
-// admin-secret and ca-private-key attributes removed. If the resulting
-// config is not suitable for bootstrapping an environment, an error is
-// returned.
-func BootstrapConfig(cfg *config.Config) (*config.Config, error) {
-	m := cfg.AllAttrs()
-	// We never want to push admin-secret or the root CA private key to the cloud.
-	delete(m, "admin-secret")
-	delete(m, "ca-private-key")
-	cfg, err := config.New(config.NoDefaults, m)
-	if err != nil {
-		return nil, err
-	}
-	if _, ok := cfg.AgentVersion(); !ok {
-		return nil, fmt.Errorf("model configuration has no agent-version")
-	}
-	return cfg, nil
 }

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -1074,7 +1074,6 @@ func (s *ConfigSuite) TestConfigAttrs(c *gc.C) {
 
 	// These attributes are added if not set.
 	attrs["logging-config"] = "<root>=WARNING;unit=DEBUG"
-	attrs["set-numa-control-policy"] = false
 
 	// Default firewall mode is instance
 	attrs["firewall-mode"] = string(config.FwInstance)
@@ -1137,26 +1136,26 @@ var validationTests = []validationTest{{
 	err:   `cannot change firewall-mode from "global" to "none"`,
 }, {
 	about: "Cannot change the state-port",
-	old:   testing.Attrs{"state-port": config.DefaultStatePort},
+	old:   testing.Attrs{"state-port": controller.DefaultStatePort},
 	new:   testing.Attrs{"state-port": 42},
 	err:   `cannot change state-port from 37017 to 42`,
 }, {
 	about: "Cannot change the api-port",
-	old:   testing.Attrs{"api-port": config.DefaultAPIPort},
+	old:   testing.Attrs{"api-port": controller.DefaultAPIPort},
 	new:   testing.Attrs{"api-port": 42},
 	err:   `cannot change api-port from 17070 to 42`,
 }, {
 	about: "Can change the state-port from explicit-default to implicit-default",
-	old:   testing.Attrs{"state-port": config.DefaultStatePort},
+	old:   testing.Attrs{"state-port": controller.DefaultStatePort},
 }, {
 	about: "Can change the api-port from explicit-default to implicit-default",
-	old:   testing.Attrs{"api-port": config.DefaultAPIPort},
+	old:   testing.Attrs{"api-port": controller.DefaultAPIPort},
 }, {
 	about: "Can change the state-port from implicit-default to explicit-default",
-	new:   testing.Attrs{"state-port": config.DefaultStatePort},
+	new:   testing.Attrs{"state-port": controller.DefaultStatePort},
 }, {
 	about: "Can change the api-port from implicit-default to explicit-default",
-	new:   testing.Attrs{"api-port": config.DefaultAPIPort},
+	new:   testing.Attrs{"api-port": controller.DefaultAPIPort},
 }, {
 	about: "Cannot change the state-port from implicit-default to different value",
 	new:   testing.Attrs{"state-port": 42},

--- a/environs/imagemetadata_test.go
+++ b/environs/imagemetadata_test.go
@@ -47,9 +47,10 @@ func (s *ImageMetadataSuite) env(c *gc.C, imageMetadataURL, stream string) envir
 		envtesting.BootstrapContext(c),
 		jujuclienttesting.NewMemStore(),
 		environs.PrepareParams{
-			ControllerName: attrs["name"].(string),
-			BaseConfig:     attrs,
-			CloudName:      "dummy",
+			ControllerConfig: testing.FakeControllerBootstrapConfig(),
+			ControllerName:   attrs["name"].(string),
+			BaseConfig:       attrs,
+			CloudName:        "dummy",
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -27,7 +27,7 @@ type EnvironProvider interface {
 	// for new environments that may be created in an existing juju server.
 	// Note that this is not called in a client context, so environment variables,
 	// local files, etc are not available.
-	PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error)
+	PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error)
 
 	// PrepareForBootstrap prepares an environment for use.
 	PrepareForBootstrap(ctx BootstrapContext, cfg *config.Config) (Environ, error)
@@ -71,6 +71,9 @@ type ProviderSchema interface {
 
 // BootstrapConfigParams contains the parameters for EnvironProvider.BootstrapConfig.
 type BootstrapConfigParams struct {
+	// ControllerUUID is the UUID of the controller to be bootstrapped.
+	ControllerUUID string
+
 	// Config is the base configuration for the provider. This should
 	// be updated with the region, endpoint and credentials.
 	Config *config.Config

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
@@ -143,7 +142,7 @@ func (t *LiveTests) PrepareOnce(c *gc.C) {
 	c.Assert(e, gc.NotNil)
 	t.Env = e
 	t.prepared = true
-	t.ControllerUUID = controller.Config(t.Env.Config().AllAttrs()).ControllerUUID()
+	t.ControllerUUID = coretesting.FakeControllerConfig().ControllerUUID()
 }
 
 func (t *LiveTests) prepareForBootstrapParams(c *gc.C) environs.PrepareParams {
@@ -152,12 +151,13 @@ func (t *LiveTests) prepareForBootstrapParams(c *gc.C) environs.PrepareParams {
 		credential = cloud.NewEmptyCredential()
 	}
 	return environs.PrepareParams{
-		BaseConfig:     t.TestConfig,
-		Credential:     credential,
-		CloudEndpoint:  t.CloudEndpoint,
-		CloudRegion:    t.CloudRegion,
-		ControllerName: t.TestConfig["name"].(string),
-		CloudName:      t.TestConfig["type"].(string),
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
+		BaseConfig:       t.TestConfig,
+		Credential:       credential,
+		CloudEndpoint:    t.CloudEndpoint,
+		CloudRegion:      t.CloudRegion,
+		ControllerName:   t.TestConfig["name"].(string),
+		CloudName:        t.TestConfig["type"].(string),
 	}
 }
 
@@ -174,8 +174,8 @@ func (t *LiveTests) bootstrapParams() bootstrap.BootstrapParams {
 		}}
 	}
 	return bootstrap.BootstrapParams{
-		ControllerUUID: t.ControllerUUID,
-		CloudName:      t.TestConfig["type"].(string),
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
+		CloudName:        t.TestConfig["type"].(string),
 		Cloud: cloud.Cloud{
 			Type:      t.TestConfig["type"].(string),
 			AuthTypes: []cloud.AuthType{credential.AuthType()},

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -65,12 +65,13 @@ func (t *Tests) PrepareParams(c *gc.C) environs.PrepareParams {
 		credential = cloud.NewEmptyCredential()
 	}
 	return environs.PrepareParams{
-		BaseConfig:     testConfigCopy,
-		Credential:     credential,
-		ControllerName: t.TestConfig["name"].(string),
-		CloudName:      t.TestConfig["type"].(string),
-		CloudEndpoint:  t.CloudEndpoint,
-		CloudRegion:    t.CloudRegion,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
+		BaseConfig:       testConfigCopy,
+		Credential:       credential,
+		ControllerName:   t.TestConfig["name"].(string),
+		CloudName:        t.TestConfig["type"].(string),
+		CloudEndpoint:    t.CloudEndpoint,
+		CloudRegion:      t.CloudRegion,
 	}
 }
 
@@ -107,7 +108,7 @@ func (t *Tests) SetUpTest(c *gc.C) {
 	t.UploadFakeTools(c, stor, "released", "released")
 	t.toolsStorage = stor
 	t.ControllerStore = jujuclienttesting.NewMemStore()
-	t.ControllerUUID = coretesting.ModelTag.Id()
+	t.ControllerUUID = coretesting.FakeControllerConfig().ControllerUUID()
 }
 
 func (t *Tests) TearDownTest(c *gc.C) {
@@ -179,8 +180,8 @@ func (t *Tests) TestBootstrap(c *gc.C) {
 	}
 
 	args := bootstrap.BootstrapParams{
-		ControllerUUID: t.ControllerUUID,
-		CloudName:      t.TestConfig["type"].(string),
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
+		CloudName:        t.TestConfig["type"].(string),
 		Cloud: cloud.Cloud{
 			Type:      t.TestConfig["type"].(string),
 			AuthTypes: []cloud.AuthType{credential.AuthType()},

--- a/environs/tools/tools_test.go
+++ b/environs/tools/tools_test.go
@@ -100,9 +100,10 @@ func (s *SimpleStreamsToolsSuite) resetEnv(c *gc.C, attrs map[string]interface{}
 	env, err := environs.Prepare(envtesting.BootstrapContext(c),
 		jujuclienttesting.NewMemStore(),
 		environs.PrepareParams{
-			ControllerName: attrs["name"].(string),
-			BaseConfig:     attrs,
-			CloudName:      "dummy",
+			ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
+			ControllerName:   attrs["name"].(string),
+			BaseConfig:       attrs,
+			CloudName:        "dummy",
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/tools/urls_test.go
+++ b/environs/tools/urls_test.go
@@ -46,9 +46,10 @@ func (s *URLsSuite) env(c *gc.C, toolsMetadataURL string) environs.Environ {
 	env, err := environs.Prepare(envtesting.BootstrapContext(c),
 		jujuclienttesting.NewMemStore(),
 		environs.PrepareParams{
-			ControllerName: attrs["name"].(string),
-			BaseConfig:     attrs,
-			CloudName:      "dummy",
+			ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
+			ControllerName:   attrs["name"].(string),
+			BaseConfig:       attrs,
+			CloudName:        "dummy",
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -244,7 +244,7 @@ func (s *upgradeSuite) configureMachine(c *gc.C, machineId string, vers version.
 
 	// Provision the machine if it isn't already
 	if _, err := m.InstanceId(); err != nil {
-		inst, md := jujutesting.AssertStartInstance(c, s.Environ, s.ControllerUUID, machineId)
+		inst, md := jujutesting.AssertStartInstance(c, s.Environ, s.ControllerConfig.ControllerUUID(), machineId)
 		c.Assert(m.SetProvisioned(inst.Id(), agent.BootstrapNonce, md), jc.ErrorIsNil)
 	}
 

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -59,7 +59,7 @@ type AccountDetails struct {
 // bootstrap configuration. A reference to the credential used will be
 // stored, rather than the credential itself.
 type BootstrapConfig struct {
-	// Config is the base configuration for the provider. This should
+	// ModelConfig is the base configuration for the provider. This should
 	// be updated with the region, endpoint and credentials.
 	Config map[string]interface{} `yaml:"config"`
 

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -52,9 +52,10 @@ func (s *ImportSuite) SetUpTest(c *gc.C) {
 		modelcmd.BootstrapContext(testing.Context(c)),
 		jujuclienttesting.NewMemStore(),
 		environs.PrepareParams{
-			ControllerName: "dummycontroller",
-			BaseConfig:     dummy.SampleConfig(),
-			CloudName:      "dummy",
+			ControllerConfig: testing.FakeControllerBootstrapConfig(),
+			ControllerName:   "dummycontroller",
+			BaseConfig:       dummy.SampleConfig(),
+			CloudName:        "dummy",
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -24,7 +24,7 @@ import (
 	"github.com/juju/utils/series"
 	"gopkg.in/mgo.v2"
 
-	environs "github.com/juju/juju/environs/config"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/service"
 )
@@ -591,12 +591,12 @@ func installMongod(operatingsystem string, numaCtl bool) error {
 			return err
 		}
 
-		cmd = []string{"semanage", "port", "-a", "-t", "mongod_port_t", "-p", "tcp", strconv.Itoa(environs.DefaultStatePort)}
+		cmd = []string{"semanage", "port", "-a", "-t", "mongod_port_t", "-p", "tcp", strconv.Itoa(controller.DefaultStatePort)}
 		logger.Infof("running %s %v", cmd[0], cmd[1:])
 		_, err = utils.RunCommand(cmd[0], cmd[1:]...)
 		if err != nil {
 			if !strings.Contains(err.Error(), "exit status 1") {
-				logger.Errorf("semanage failed to provide access on port %d error %s", environs.DefaultStatePort, err)
+				logger.Errorf("semanage failed to provide access on port %d error %s", controller.DefaultStatePort, err)
 				return err
 			}
 		}

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
-	environs "github.com/juju/juju/environs/config"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/service/common"
@@ -86,7 +86,7 @@ var expectedArgs = struct {
 		"mongod_port_t",
 		"-p",
 		"tcp",
-		strconv.Itoa(environs.DefaultStatePort),
+		strconv.Itoa(controller.DefaultStatePort),
 	},
 	Chcon: []string{
 		"-R",
@@ -451,7 +451,7 @@ func (s *MongoSuite) TestInstallFailSemanageMongodCentOS(c *gc.C) {
 	expectedResult := append(expectedArgs.MongoInstall, []jc.SimpleMessage{
 		{loggo.INFO, "running chcon .*"},
 		{loggo.INFO, "running " + execNameFail + " .*"},
-		{loggo.ERROR, execNameFail + " failed to provide access on port " + strconv.Itoa(environs.DefaultStatePort) + " error exit status " + strconv.Itoa(returnCode)},
+		{loggo.ERROR, execNameFail + " failed to provide access on port " + strconv.Itoa(controller.DefaultStatePort) + " error exit status " + strconv.Itoa(returnCode)},
 		{loggo.ERROR, regexp.QuoteMeta("cannot install/upgrade mongod (will proceed anyway): exit status " + strconv.Itoa(returnCode))},
 	}...)
 	s.assertSuccessWithInstallStepFailCentOS(c, exec, execNameFail, returnCode, expectedResult)
@@ -657,16 +657,16 @@ func (s *MongoSuite) TestSelectPeerHostPort(c *gc.C) {
 			Type:  network.IPv4Address,
 			Scope: network.ScopeCloudLocal,
 		},
-		Port: environs.DefaultStatePort}, {
+		Port: controller.DefaultStatePort}, {
 		Address: network.Address{
 			Value: "8.8.8.8",
 			Type:  network.IPv4Address,
 			Scope: network.ScopePublic,
 		},
-		Port: environs.DefaultStatePort}}
+		Port: controller.DefaultStatePort}}
 
 	address := mongo.SelectPeerHostPort(hostPorts)
-	c.Assert(address, gc.Equals, "10.0.0.1:"+strconv.Itoa(environs.DefaultStatePort))
+	c.Assert(address, gc.Equals, "10.0.0.1:"+strconv.Itoa(controller.DefaultStatePort))
 }
 
 func (s *MongoSuite) TestGenerateSharedSecret(c *gc.C) {

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -89,7 +89,7 @@ func (env *azureEnviron) Bootstrap(
 	args environs.BootstrapParams,
 ) (*environs.BootstrapResult, error) {
 
-	cfg, err := env.initResourceGroup(args.ControllerUUID)
+	cfg, err := env.initResourceGroup(args.ControllerConfig.ControllerUUID())
 	if err != nil {
 		return nil, errors.Annotate(err, "creating controller resource group")
 	}

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -688,8 +688,8 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 	s.requests = nil
 	result, err := env.Bootstrap(
 		ctx, environs.BootstrapParams{
-			ControllerUUID: s.controllerUUID,
-			AvailableTools: makeToolsList(series.LatestLts()),
+			ControllerConfig: testing.FakeControllerBootstrapConfig(),
+			AvailableTools:   makeToolsList(series.LatestLts()),
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/utils/clock"
 
 	"github.com/juju/juju/cloud"
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/provider/azure/internal/azurestorage"
@@ -94,14 +93,10 @@ func (prov *azureEnvironProvider) RestrictedConfigAttributes() []string {
 }
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.
-func (prov *azureEnvironProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+func (prov *azureEnvironProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
 	env, err := newEnviron(prov, cfg)
 	if err != nil {
 		return nil, errors.Annotate(err, "opening model")
-	}
-	controllerUUID := controller.Config(cfg.AllAttrs()).ControllerUUID()
-	if controllerUUID == "" {
-		return nil, errors.New("missing controller UUID")
 	}
 	return env.initResourceGroup(controllerUUID)
 }

--- a/provider/cloudsigma/provider.go
+++ b/provider/cloudsigma/provider.go
@@ -77,7 +77,7 @@ func (environProvider) RestrictedConfigAttributes() []string {
 // additional configuration attributes are added to the config passed in
 // and returned.  This allows providers to add additional required config
 // for new environments that may be created in an existing juju server.
-func (environProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+func (environProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
 	// Not even sure if this will ever make sense.
 	return nil, errors.NotImplementedf("PrepareForCreateEnvironment")
 }

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -107,8 +107,9 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 	if err != nil {
 		return nil, "", nil, err
 	}
+	envCfg := env.Config()
 	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(
-		args.BootstrapConstraints, args.ModelConstraints, selectedSeries, publicKey,
+		args.ControllerConfig, args.BootstrapConstraints, args.ModelConstraints, selectedSeries, publicKey,
 	)
 	if err != nil {
 		return nil, "", nil, err
@@ -116,8 +117,7 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 	instanceConfig.EnableOSRefreshUpdate = env.Config().EnableOSRefreshUpdate()
 	instanceConfig.EnableOSUpgrade = env.Config().EnableOSUpgrade()
 
-	envCfg := env.Config()
-	instanceConfig.Tags = instancecfg.InstanceTags(envCfg.UUID(), args.ControllerUUID, envCfg, instanceConfig.Jobs)
+	instanceConfig.Tags = instancecfg.InstanceTags(envCfg.UUID(), args.ControllerConfig.ControllerUUID(), envCfg, instanceConfig.Jobs)
 	maybeSetBridge := func(icfg *instancecfg.InstanceConfig) {
 		// If we need to override the default bridge name, do it now. When
 		// args.ContainerBridgeName is empty, the default names for LXC
@@ -138,7 +138,7 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 		return nil
 	}
 	result, err := env.StartInstance(environs.StartInstanceParams{
-		ControllerUUID: args.ControllerUUID,
+		ControllerUUID: args.ControllerConfig.ControllerUUID(),
 		Constraints:    args.BootstrapConstraints,
 		Tools:          availableTools,
 		InstanceConfig: instanceConfig,

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -102,7 +102,7 @@ func (s *BootstrapSuite) TestCannotStartInstance(c *gc.C) {
 
 		// The machine config should set its upgrade behavior based on
 		// the environment config.
-		expectedMcfg, err := instancecfg.NewBootstrapInstanceConfig(cons, cons, icfg.Series, "")
+		expectedMcfg, err := instancecfg.NewBootstrapInstanceConfig(coretesting.FakeControllerConfig(), cons, cons, icfg.Series, "")
 		c.Assert(err, jc.ErrorIsNil)
 		expectedMcfg.EnableOSRefreshUpdate = env.Config().EnableOSRefreshUpdate()
 		expectedMcfg.EnableOSUpgrade = env.Config().EnableOSUpgrade()
@@ -120,7 +120,7 @@ func (s *BootstrapSuite) TestCannotStartInstance(c *gc.C) {
 
 	ctx := envtesting.BootstrapContext(c)
 	_, err := common.Bootstrap(ctx, env, environs.BootstrapParams{
-		ControllerUUID:       coretesting.ModelTag.Id(),
+		ControllerConfig:     coretesting.FakeControllerConfig(),
 		BootstrapConstraints: checkCons,
 		ModelConstraints:     checkCons,
 		Placement:            checkPlacement,
@@ -167,7 +167,8 @@ func (s *BootstrapSuite) TestBootstrapSeries(c *gc.C) {
 	ctx := envtesting.BootstrapContext(c)
 	bootstrapSeries := "utopic"
 	result, err := common.Bootstrap(ctx, env, environs.BootstrapParams{
-		BootstrapSeries: bootstrapSeries,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
+		BootstrapSeries:  bootstrapSeries,
 		AvailableTools: tools.List{
 			&tools.Tools{
 				Version: version.Binary{
@@ -214,6 +215,7 @@ func (s *BootstrapSuite) TestSuccess(c *gc.C) {
 	}
 	ctx := envtesting.BootstrapContext(c)
 	result, err := common.Bootstrap(ctx, env, environs.BootstrapParams{
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 		AvailableTools: tools.List{
 			&tools.Tools{
 				Version: version.Binary{

--- a/provider/dummy/config_test.go
+++ b/provider/dummy/config_test.go
@@ -32,9 +32,10 @@ func (*ConfigSuite) TestSecretAttrs(c *gc.C) {
 	env, err := environs.Prepare(
 		ctx, jujuclienttesting.NewMemStore(),
 		environs.PrepareParams{
-			BaseConfig:     attrs,
-			ControllerName: attrs["name"].(string),
-			CloudName:      "dummy",
+			ControllerConfig: testing.FakeControllerBootstrapConfig(),
+			BaseConfig:       attrs,
+			ControllerName:   attrs["name"].(string),
+			CloudName:        "dummy",
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -94,9 +95,10 @@ func (s *ConfigSuite) TestFirewallMode(c *gc.C) {
 		env, err := environs.Prepare(
 			ctx, jujuclienttesting.NewMemStore(),
 			environs.PrepareParams{
-				ControllerName: cfg.Name(),
-				BaseConfig:     cfg.AllAttrs(),
-				CloudName:      "dummy",
+				ControllerConfig: testing.FakeControllerBootstrapConfig(),
+				ControllerName:   cfg.Name(),
+				BaseConfig:       cfg.AllAttrs(),
+				CloudName:        "dummy",
 			},
 		)
 		if test.errorMsg != "" {

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -116,9 +116,10 @@ func (s *suite) bootstrapTestEnviron(c *gc.C) environs.NetworkingEnviron {
 		envtesting.BootstrapContext(c),
 		s.ControllerStore,
 		environs.PrepareParams{
-			BaseConfig:     s.TestConfig,
-			ControllerName: s.TestConfig["name"].(string),
-			CloudName:      "dummy",
+			ControllerConfig: testing.FakeControllerBootstrapConfig(),
+			BaseConfig:       s.TestConfig,
+			ControllerName:   s.TestConfig["name"].(string),
+			CloudName:        "dummy",
 		},
 	)
 	c.Assert(err, gc.IsNil, gc.Commentf("preparing environ %#v", s.TestConfig))
@@ -127,8 +128,8 @@ func (s *suite) bootstrapTestEnviron(c *gc.C) environs.NetworkingEnviron {
 	c.Assert(supported, jc.IsTrue)
 
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), netenv, bootstrap.BootstrapParams{
-		ControllerUUID: s.ControllerUUID,
-		CloudName:      "dummy",
+		ControllerConfig: testing.FakeControllerBootstrapConfig(),
+		CloudName:        "dummy",
 		Cloud: cloud.Cloud{
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -15,7 +15,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/jujutest"
@@ -151,8 +150,7 @@ func (t *LiveTests) TestControllerInstances(c *gc.C) {
 	inst1, _ := testing.AssertStartInstance(c, t.Env, t.ControllerUUID, "99")
 	defer t.Env.StopInstances(inst1.Id())
 
-	controllerUUID := controller.Config(t.TestConfig).ControllerUUID()
-	insts, err := t.Env.ControllerInstances(controllerUUID)
+	insts, err := t.Env.ControllerInstances(t.ControllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(insts, gc.DeepEquals, []instance.Id{bootstrapInstId})
 }
@@ -238,7 +236,7 @@ func (t *LiveTests) TestInstanceGroups(c *gc.C) {
 	perms := info[0].IPPerms
 	c.Assert(perms, gc.HasLen, 5)
 	checkPortAllowed(c, perms, 22) // SSH
-	checkPortAllowed(c, perms, coretesting.FakeConfig()["api-port"].(int))
+	checkPortAllowed(c, perms, coretesting.FakeControllerConfig().APIPort())
 	checkSecurityGroupAllowed(c, perms, groups[0])
 
 	// The old machine group should have been reused also.

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -33,7 +33,7 @@ func (p environProvider) RestrictedConfigAttributes() []string {
 }
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.
-func (p environProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+func (p environProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
 	e, err := p.Open(cfg)
 	if err != nil {
 		return nil, err

--- a/provider/gce/environ_broker_test.go
+++ b/provider/gce/environ_broker_test.go
@@ -102,13 +102,7 @@ func (s *environBrokerSuite) TestStartInstanceOpensAPIPort(c *gc.C) {
 	s.FakeEnviron.Inst = s.BaseInstance
 	s.FakeEnviron.Hwc = s.hardware
 
-	// Get the API port from the fake environment config used to
-	// "bootstrap".
-	envConfig := testing.FakeConfig()
-	apiPort, ok := envConfig["api-port"].(int)
-	c.Assert(ok, jc.IsTrue)
-	c.Assert(apiPort, gc.Not(gc.Equals), 0)
-
+	apiPort := testing.FakeControllerConfig().APIPort()
 	// When StateServingInfo is not nil, verify OpenPorts was called
 	// for the API port.
 	s.StartInstArgs.InstanceConfig.Bootstrap = &instancecfg.BootstrapConfig{

--- a/provider/gce/environ_instance_test.go
+++ b/provider/gce/environ_instance_test.go
@@ -102,7 +102,7 @@ func (s *environInstSuite) TestBasicInstancesAPI(c *gc.C) {
 func (s *environInstSuite) TestControllerInstances(c *gc.C) {
 	s.FakeConn.Insts = []google.Instance{*s.BaseInstance}
 
-	ids, err := s.Env.ControllerInstances(s.ControllerUUID())
+	ids, err := s.Env.ControllerInstances(s.ControllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(ids, jc.DeepEquals, []instance.Id{"spam"})
@@ -111,7 +111,7 @@ func (s *environInstSuite) TestControllerInstances(c *gc.C) {
 func (s *environInstSuite) TestControllerInstancesAPI(c *gc.C) {
 	s.FakeConn.Insts = []google.Instance{*s.BaseInstance}
 
-	_, err := s.Env.ControllerInstances(s.ControllerUUID())
+	_, err := s.Env.ControllerInstances(s.ControllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(s.FakeConn.Calls, gc.HasLen, 1)
@@ -121,7 +121,7 @@ func (s *environInstSuite) TestControllerInstancesAPI(c *gc.C) {
 }
 
 func (s *environInstSuite) TestControllerInstancesNotBootstrapped(c *gc.C) {
-	_, err := s.Env.ControllerInstances(s.ControllerUUID())
+	_, err := s.Env.ControllerInstances(s.ControllerUUID)
 
 	c.Check(err, gc.Equals, environs.ErrNotBootstrapped)
 }
@@ -130,7 +130,7 @@ func (s *environInstSuite) TestControllerInstancesMixed(c *gc.C) {
 	other := google.NewInstance(google.InstanceSummary{}, nil)
 	s.FakeConn.Insts = []google.Instance{*s.BaseInstance, *other}
 
-	ids, err := s.Env.ControllerInstances(s.ControllerUUID())
+	ids, err := s.Env.ControllerInstances(s.ControllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(ids, jc.DeepEquals, []instance.Id{"spam"})

--- a/provider/gce/environ_test.go
+++ b/provider/gce/environ_test.go
@@ -12,6 +12,7 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/gce"
+	"github.com/juju/juju/testing"
 )
 
 type environSuite struct {
@@ -71,7 +72,7 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 
 	ctx := envtesting.BootstrapContext(c)
 	params := environs.BootstrapParams{
-		ControllerUUID: s.ControllerUUID(),
+		ControllerConfig: testing.FakeControllerBootstrapConfig(),
 	}
 	result, err := s.Env.Bootstrap(ctx, params)
 	c.Assert(err, jc.ErrorIsNil)
@@ -85,7 +86,7 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 func (s *environSuite) TestBootstrapCommon(c *gc.C) {
 	ctx := envtesting.BootstrapContext(c)
 	params := environs.BootstrapParams{
-		ControllerUUID: s.ControllerUUID(),
+		ControllerConfig: testing.FakeControllerBootstrapConfig(),
 	}
 	_, err := s.Env.Bootstrap(ctx, params)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/gce/provider.go
+++ b/provider/gce/provider.go
@@ -63,7 +63,7 @@ func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*
 		return nil, errors.Trace(err)
 	}
 
-	return p.PrepareForCreateEnvironment(cfg)
+	return p.PrepareForCreateEnvironment(args.ControllerUUID, cfg)
 }
 
 // PrepareForBootstrap implements environs.EnvironProvider.
@@ -90,7 +90,7 @@ func (environProvider) Schema() environschema.Fields {
 }
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.
-func (p environProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+func (p environProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
 	return configWithDefaults(cfg)
 }
 

--- a/provider/joyent/export_test.go
+++ b/provider/joyent/export_test.go
@@ -214,9 +214,10 @@ func MakeConfig(c *gc.C, attrs testing.Attrs) *environConfig {
 		envtesting.BootstrapContext(c),
 		jujuclienttesting.NewMemStore(),
 		environs.PrepareParams{
-			BaseConfig:     attrs,
-			ControllerName: attrs["name"].(string),
-			CloudName:      "joyent",
+			ControllerConfig: testing.FakeControllerBootstrapConfig(),
+			BaseConfig:       attrs,
+			ControllerName:   attrs["name"].(string),
+			CloudName:        "joyent",
 			Credential: cloud.NewCredential(
 				cloud.UserPassAuthType,
 				CredentialsAttributes(attrs),

--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/imagemetadata"
@@ -160,7 +159,7 @@ func bootstrapContext(c *gc.C) environs.BootstrapContext {
 func (s *localServerSuite) TestStartInstance(c *gc.C) {
 	env := s.Prepare(c)
 	err := bootstrap.Bootstrap(bootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: s.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	inst, _ := testing.AssertStartInstance(c, env, s.ControllerUUID, "100")
@@ -171,7 +170,7 @@ func (s *localServerSuite) TestStartInstance(c *gc.C) {
 func (s *localServerSuite) TestStartInstanceAvailabilityZone(c *gc.C) {
 	env := s.Prepare(c)
 	err := bootstrap.Bootstrap(bootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: s.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	inst, hwc := testing.AssertStartInstance(c, env, s.ControllerUUID, "100")
@@ -184,7 +183,7 @@ func (s *localServerSuite) TestStartInstanceAvailabilityZone(c *gc.C) {
 func (s *localServerSuite) TestStartInstanceHardwareCharacteristics(c *gc.C) {
 	env := s.Prepare(c)
 	err := bootstrap.Bootstrap(bootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: s.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	_, hc := testing.AssertStartInstanceWithConstraints(c, env, s.ControllerUUID, "100", constraints.MustParse("mem=1024"))
@@ -293,13 +292,12 @@ func (s *localServerSuite) TestInstancesGathering(c *gc.C) {
 func (s *localServerSuite) TestBootstrapInstanceUserDataAndState(c *gc.C) {
 	env := s.Prepare(c)
 	err := bootstrap.Bootstrap(bootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: s.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// check that ControllerInstances returns the id of the bootstrap machine.
-	controllerUUID := controller.Config(s.TestConfig).ControllerUUID()
-	instanceIds, err := env.ControllerInstances(controllerUUID)
+	instanceIds, err := env.ControllerInstances(s.ControllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instanceIds, gc.HasLen, 1)
 

--- a/provider/joyent/provider.go
+++ b/provider/joyent/provider.go
@@ -52,7 +52,7 @@ func (joyentProvider) RestrictedConfigAttributes() []string {
 }
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.
-func (joyentProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+func (joyentProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
 	return cfg, nil
 }
 
@@ -76,7 +76,7 @@ func (p joyentProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*c
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return p.PrepareForCreateEnvironment(cfg)
+	return p.PrepareForCreateEnvironment(args.ControllerUUID, cfg)
 }
 
 // PrepareForBootstrap is specified in the EnvironProvider interface.

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -31,7 +31,6 @@ func (s *environBrokerSuite) TestStartInstance(c *gc.C) {
 	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
 
 	result, err := s.Env.StartInstance(s.StartInstArgs)
-
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result.Instance, gc.DeepEquals, s.Instance)
 	c.Check(result.Hardware, gc.DeepEquals, s.HWC)

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -15,6 +15,7 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/lxd"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/tools/lxdclient"
 )
 
@@ -77,7 +78,7 @@ func (s *environSuite) TestBootstrapOkay(c *gc.C) {
 
 	ctx := envtesting.BootstrapContext(c)
 	params := environs.BootstrapParams{
-		ControllerUUID: "uuid",
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	}
 	result, err := s.Env.Bootstrap(ctx, params)
 	c.Assert(err, jc.ErrorIsNil)
@@ -91,7 +92,7 @@ func (s *environSuite) TestBootstrapOkay(c *gc.C) {
 func (s *environSuite) TestBootstrapAPI(c *gc.C) {
 	ctx := envtesting.BootstrapContext(c)
 	params := environs.BootstrapParams{
-		ControllerUUID: "uuid",
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	}
 	_, err := s.Env.Bootstrap(ctx, params)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -32,7 +32,7 @@ func (environProvider) Open(cfg *config.Config) (environs.Environ, error) {
 
 // BootstrapConfig implements environs.EnvironProvider.
 func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
-	return p.PrepareForCreateEnvironment(args.Config)
+	return p.PrepareForCreateEnvironment(args.ControllerUUID, args.Config)
 }
 
 // PrepareForBootstrap implements environs.EnvironProvider.
@@ -54,7 +54,7 @@ func (p environProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg 
 }
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.
-func (environProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+func (environProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
 	return cfg, nil
 }
 

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -158,7 +158,7 @@ func (s *BaseSuiteUnpatched) initInst(c *gc.C) {
 	// nothing
 	}
 
-	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(cons, cons, "trusty", "")
+	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(testing.FakeControllerBootstrapConfig(), cons, cons, "trusty", "")
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = instanceConfig.SetTools(coretools.List{
@@ -204,6 +204,7 @@ func (s *BaseSuiteUnpatched) initInst(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.StartInstArgs = environs.StartInstanceParams{
+		ControllerUUID: instanceConfig.Controller.Config.ControllerUUID(),
 		InstanceConfig: instanceConfig,
 		Tools:          tools,
 		Constraints:    cons,

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/storage"
+	coretesting "github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
 )
 
@@ -149,7 +150,7 @@ func (suite *environSuite) TestStartInstanceStartsInstance(c *gc.C) {
 	suite.testMAASObject.TestServer.AddNodeDetails("node0", lshwXML)
 	suite.addSubnet(c, 9, 9, "node0")
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: suite.controllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	// The bootstrap node has been acquired and started.
@@ -388,7 +389,7 @@ func (suite *environSuite) TestBootstrapSucceeds(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	suite.testMAASObject.TestServer.AddNodeDetails("thenode", lshwXML)
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: suite.controllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -407,7 +408,7 @@ func (suite *environSuite) TestBootstrapNodeNotDeployed(c *gc.C) {
 	// Ensure node will not be reported as deployed by changing its status.
 	suite.testMAASObject.TestServer.ChangeNode("thenode", "status", "4")
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: suite.controllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, gc.ErrorMatches, "bootstrap instance started but did not change to Deployed state.*")
 }
@@ -426,7 +427,7 @@ func (suite *environSuite) TestBootstrapNodeFailedDeploy(c *gc.C) {
 	// Set the node status to "Failed deployment"
 	suite.testMAASObject.TestServer.ChangeNode("thenode", "status", "11")
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: suite.controllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, gc.ErrorMatches, "bootstrap instance started but did not change to Deployed state. instance \"/api/.*/nodes/thenode/\" failed to deploy")
 }
@@ -441,7 +442,7 @@ func (suite *environSuite) TestBootstrapFailsIfNoTools(c *gc.C) {
 	err = env.SetConfig(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: suite.controllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Check(err, gc.ErrorMatches, "Juju cannot bootstrap because no tools are available for your model(.|\n)*")
 }
@@ -450,7 +451,7 @@ func (suite *environSuite) TestBootstrapFailsIfNoNodes(c *gc.C) {
 	suite.setupFakeTools(c)
 	env := suite.makeEnviron()
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: suite.controllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	// Since there are no nodes, the attempt to allocate one returns a
 	// 409: Conflict.
@@ -979,8 +980,8 @@ func (s *environSuite) bootstrap(c *gc.C) environs.Environ {
 	s.setupFakeTools(c)
 	env := s.makeEnviron()
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: s.controllerUUID,
-		Placement:      "bootstrap-host",
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
+		Placement:        "bootstrap-host",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return env

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -46,7 +46,7 @@ func (p maasEnvironProvider) RestrictedConfigAttributes() []string {
 }
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.
-func (p maasEnvironProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+func (p maasEnvironProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
 	attrs := cfg.UnknownAttrs()
 	oldName, found := attrs["maas-agent-name"]
 	if found && oldName != "" {
@@ -85,7 +85,7 @@ func (p maasEnvironProvider) BootstrapConfig(args environs.BootstrapConfigParams
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return p.PrepareForCreateEnvironment(cfg)
+	return p.PrepareForCreateEnvironment(args.ControllerUUID, cfg)
 }
 
 // PrepareForBootstrap is specified in the EnvironProvider interface.

--- a/provider/maas/environprovider_test.go
+++ b/provider/maas/environprovider_test.go
@@ -127,7 +127,7 @@ func (suite *EnvironProviderSuite) TestPrepareSetsAgentName(c *gc.C) {
 	config, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 
-	config, err = providerInstance.PrepareForCreateEnvironment(config)
+	config, err = providerInstance.PrepareForCreateEnvironment(suite.controllerUUID, config)
 	c.Assert(err, jc.ErrorIsNil)
 
 	uuid, ok := config.UnknownAttrs()["maas-agent-name"]
@@ -145,7 +145,7 @@ func (suite *EnvironProviderSuite) TestPrepareExistingAgentName(c *gc.C) {
 	config, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = providerInstance.PrepareForCreateEnvironment(config)
+	_, err = providerInstance.PrepareForCreateEnvironment(suite.controllerUUID, config)
 	c.Assert(err, gc.Equals, errAgentNameAlreadySet)
 }
 

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -29,7 +29,7 @@ import (
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
-	corejujutesting "github.com/juju/juju/testing"
+	coretesting "github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
 )
 
@@ -48,12 +48,12 @@ func (suite *maas2EnvironSuite) getEnvWithServer(c *gc.C) (*maasEnviron, error) 
 	testServer.AddGetResponse("/api/1.0/version/", http.StatusOK, "<html></html>")
 	testServer.Start()
 	suite.AddCleanup(func(*gc.C) { testServer.Close() })
-	testAttrs := corejujutesting.Attrs{}
+	testAttrs := coretesting.Attrs{}
 	for k, v := range maasEnvAttrs {
 		testAttrs[k] = v
 	}
 	testAttrs["maas-server"] = testServer.Server.URL
-	attrs := corejujutesting.FakeConfig().Merge(testAttrs)
+	attrs := coretesting.FakeConfig().Merge(testAttrs)
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 	return NewEnviron(cfg)
@@ -682,7 +682,7 @@ func (suite *maas2EnvironSuite) TestWaitForNodeDeploymentError(c *gc.C) {
 	suite.setupFakeTools(c)
 	env := suite.makeEnviron(c, nil)
 	err := bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: suite.controllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, gc.ErrorMatches, "bootstrap instance started but did not change to Deployed state.*")
 }
@@ -699,7 +699,7 @@ func (suite *maas2EnvironSuite) TestWaitForNodeDeploymentSucceeds(c *gc.C) {
 	suite.setupFakeTools(c)
 	env := suite.makeEnviron(c, nil)
 	err := bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: suite.controllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -1505,7 +1505,7 @@ func (suite *maas2EnvironSuite) TestStartInstanceEndToEnd(c *gc.C) {
 
 	env := suite.makeEnviron(c, controller)
 	err := bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: suite.controllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1623,7 +1623,7 @@ func (suite *maas2EnvironSuite) TestBootstrapFailsIfNoTools(c *gc.C) {
 	err = env.SetConfig(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	err = bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: suite.controllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Check(err, gc.ErrorMatches, "Juju cannot bootstrap because no tools are available for your model(.|\n)*")
 }
@@ -1634,7 +1634,7 @@ func (suite *maas2EnvironSuite) TestBootstrapFailsIfNoNodes(c *gc.C) {
 	controller.allocateMachineError = gomaasapi.NewNoMatchError("oops")
 	env := suite.makeEnviron(c, controller)
 	err := bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: suite.controllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	// Since there are no nodes, the attempt to allocate one returns a
 	// 409: Conflict.

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
-	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
@@ -41,7 +40,7 @@ func (suite *maas2Suite) makeEnviron(c *gc.C, controller gomaasapi.Controller) *
 	testAttrs["maas-agent-name"] = "agent-prefix"
 
 	attrs := coretesting.FakeConfig().Merge(testAttrs)
-	suite.controllerUUID = jujucontroller.Config(attrs).ControllerUUID()
+	suite.controllerUUID = coretesting.FakeControllerConfig().ControllerUUID()
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := NewEnviron(cfg)

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	envtesting "github.com/juju/juju/environs/testing"
@@ -137,7 +136,7 @@ func (suite *providerSuite) makeEnviron() *maasEnviron {
 	}
 	testAttrs["maas-server"] = suite.testMAASObject.TestServer.URL
 	attrs := coretesting.FakeConfig().Merge(testAttrs)
-	suite.controllerUUID = controller.Config(attrs).ControllerUUID()
+	suite.controllerUUID = coretesting.FakeControllerConfig().ControllerUUID()
 	cfg, err := config.New(config.NoDefaults, attrs)
 	if err != nil {
 		panic(err)

--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -46,7 +46,7 @@ func (p manualProvider) DetectRegions() ([]cloud.Region, error) {
 }
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.
-func (p manualProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+func (p manualProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
 	return cfg, nil
 }
 

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -36,7 +36,7 @@ func (s *providerSuite) SetUpTest(c *gc.C) {
 func (s *providerSuite) TestPrepareForCreateEnvironment(c *gc.C) {
 	testConfig, err := config.New(config.UseDefaults, manual.MinimalConfigValues())
 	c.Assert(err, jc.ErrorIsNil)
-	cfg, err := manual.ProviderInstance.PrepareForCreateEnvironment(testConfig)
+	cfg, err := manual.ProviderInstance.PrepareForCreateEnvironment(coretesting.ModelTag.Id(), testConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg, gc.Equals, testConfig)
 }

--- a/provider/openstack/live_test.go
+++ b/provider/openstack/live_test.go
@@ -224,7 +224,7 @@ func (s *LiveTests) assertStartInstanceDefaultSecurityGroup(c *gc.C, useDefault 
 	defer env.Destroy()
 	// Bootstrap and start an instance.
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: s.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	inst, _ := jujutesting.AssertStartInstance(c, env, s.ControllerUUID, "100")

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
@@ -317,7 +316,7 @@ func (s *localServerSuite) TestBootstrapFailsWhenPublicIPError(c *gc.C) {
 	env, err := environs.New(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: s.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, gc.ErrorMatches, "(.|\n)*cannot allocate a public IP as needed(.|\n)*")
 }
@@ -353,7 +352,7 @@ func (s *localServerSuite) TestAddressesWithPublicIP(c *gc.C) {
 	env, err := environs.New(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: s.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(bootstrapFinished, jc.IsTrue)
@@ -387,7 +386,7 @@ func (s *localServerSuite) TestAddressesWithoutPublicIP(c *gc.C) {
 	env, err := environs.New(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: s.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(bootstrapFinished, jc.IsTrue)
@@ -423,7 +422,7 @@ func (s *localServerSuite) TestStartInstanceWithoutPublicIP(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: s.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	inst, _ := testing.AssertStartInstance(c, env, s.ControllerUUID, "100")
@@ -448,7 +447,7 @@ func (s *localServerSuite) TestStartInstanceHardwareCharacteristics(c *gc.C) {
 
 	env := s.Prepare(c)
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerUUID: s.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	_, hc := testing.AssertStartInstanceWithConstraints(c, env, s.ControllerUUID, "100", constraints.MustParse("mem=1024"))
@@ -941,13 +940,12 @@ func (s *localServerSuite) TestInstancesMultiErrorResponse(c *gc.C) {
 // It should be moved to environs.jujutests.Tests.
 func (s *localServerSuite) TestBootstrapInstanceUserDataAndState(c *gc.C) {
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), s.env, bootstrap.BootstrapParams{
-		ControllerUUID: s.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check that ControllerInstances returns the ID of the bootstrap machine.
-	controllerUUID := controller.Config(s.TestConfig).ControllerUUID()
-	ids, err := s.env.ControllerInstances(controllerUUID)
+	ids, err := s.env.ControllerInstances(s.ControllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ids, gc.HasLen, 1)
 
@@ -1395,7 +1393,7 @@ func (s *localHTTPSServerSuite) TestCanBootstrap(c *gc.C) {
 	defer openstack.RemoveTestImageData(metadataStorage)
 
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), s.env, bootstrap.BootstrapParams{
-		ControllerUUID: coretesting.ModelTag.Id(),
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -1524,7 +1522,7 @@ func (s *localServerSuite) TestRemoveBlankContainer(c *gc.C) {
 
 func (s *localServerSuite) TestAllInstancesIgnoresOtherMachines(c *gc.C) {
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), s.env, bootstrap.BootstrapParams{
-		ControllerUUID: s.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1604,7 +1602,7 @@ func (t *localServerSuite) TestStartInstanceAvailZoneUnknown(c *gc.C) {
 
 func (t *localServerSuite) testStartInstanceAvailZone(c *gc.C, zone string) (instance.Instance, error) {
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), t.env, bootstrap.BootstrapParams{
-		ControllerUUID: t.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1686,7 +1684,7 @@ func (t *mockAvailabilityZoneAllocations) AvailabilityZoneAllocations(
 
 func (t *localServerSuite) TestStartInstanceDistributionParams(c *gc.C) {
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), t.env, bootstrap.BootstrapParams{
-		ControllerUUID: t.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1712,7 +1710,7 @@ func (t *localServerSuite) TestStartInstanceDistributionParams(c *gc.C) {
 
 func (t *localServerSuite) TestStartInstanceDistributionErrors(c *gc.C) {
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), t.env, bootstrap.BootstrapParams{
-		ControllerUUID: t.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1737,7 +1735,7 @@ func (t *localServerSuite) TestStartInstanceDistributionErrors(c *gc.C) {
 
 func (t *localServerSuite) TestStartInstanceDistribution(c *gc.C) {
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), t.env, bootstrap.BootstrapParams{
-		ControllerUUID: t.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1775,7 +1773,7 @@ func (t *localServerSuite) TestStartInstancePicksValidZoneForHost(c *gc.C) {
 	)
 
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), t.env, bootstrap.BootstrapParams{
-		ControllerUUID: t.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1815,7 +1813,7 @@ func (t *localServerSuite) TestStartInstanceWithUnknownAZError(c *gc.C) {
 	)
 
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), t.env, bootstrap.BootstrapParams{
-		ControllerUUID: t.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1836,7 +1834,7 @@ func (t *localServerSuite) TestStartInstanceWithUnknownAZError(c *gc.C) {
 
 func (t *localServerSuite) TestStartInstanceDistributionAZNotImplemented(c *gc.C) {
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), t.env, bootstrap.BootstrapParams{
-		ControllerUUID: t.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1852,7 +1850,7 @@ func (t *localServerSuite) TestStartInstanceDistributionAZNotImplemented(c *gc.C
 
 func (t *localServerSuite) TestInstanceTags(c *gc.C) {
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), t.env, bootstrap.BootstrapParams{
-		ControllerUUID: t.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1873,7 +1871,7 @@ func (t *localServerSuite) TestInstanceTags(c *gc.C) {
 
 func (t *localServerSuite) TestTagInstance(c *gc.C) {
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), t.env, bootstrap.BootstrapParams{
-		ControllerUUID: t.ControllerUUID,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1917,12 +1915,13 @@ func (t *localServerSuite) TestTagInstance(c *gc.C) {
 
 func prepareParams(attrs map[string]interface{}, cred *identity.Credentials) environs.PrepareParams {
 	return environs.PrepareParams{
-		BaseConfig:     attrs,
-		ControllerName: attrs["name"].(string),
-		Credential:     makeCredential(cred),
-		CloudName:      "openstack",
-		CloudEndpoint:  cred.URL,
-		CloudRegion:    cred.Region,
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
+		BaseConfig:       attrs,
+		ControllerName:   attrs["name"].(string),
+		Credential:       makeCredential(cred),
+		CloudName:        "openstack",
+		CloudEndpoint:    cred.URL,
+		CloudRegion:      cred.Region,
 	}
 }
 
@@ -2006,7 +2005,7 @@ func (s *noSwiftSuite) TearDownTest(c *gc.C) {
 
 func (s *noSwiftSuite) TestBootstrap(c *gc.C) {
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), s.env, bootstrap.BootstrapParams{
-		ControllerUUID: coretesting.ModelTag.Id(),
+		ControllerConfig: coretesting.FakeControllerBootstrapConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -108,7 +108,7 @@ func (EnvironProvider) DetectRegions() ([]cloud.Region, error) {
 }
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.
-func (p EnvironProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+func (p EnvironProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
 	return cfg, nil
 }
 
@@ -146,7 +146,7 @@ func (p EnvironProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return p.PrepareForCreateEnvironment(cfg)
+	return p.PrepareForCreateEnvironment(args.ControllerUUID, cfg)
 }
 
 // PrepareForBootstrap is specified in the EnvironProvider interface.

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -42,7 +42,7 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 		return s.innerEnviron.Bootstrap(ctx, args)
 	})
 	s.environ.Bootstrap(nil, environs.BootstrapParams{
-		ControllerUUID: "uuid",
+		ControllerConfig: testing.FakeControllerBootstrapConfig(),
 	})
 	c.Check(s.innerEnviron.Pop().name, gc.Equals, "Bootstrap")
 }

--- a/provider/rackspace/provider_test.go
+++ b/provider/rackspace/provider_test.go
@@ -66,8 +66,8 @@ func (p *fakeProvider) RestrictedConfigAttributes() []string {
 	return nil
 }
 
-func (p *fakeProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
-	p.MethodCall(p, "PrepareForCreateEnvironment", cfg)
+func (p *fakeProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
+	p.MethodCall(p, "PrepareForCreateEnvironment", controllerUUID, cfg)
 	return nil, nil
 }
 

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/vsphere"
+	coretesting "github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
 )
 
@@ -56,7 +57,7 @@ func (s *environBrokerSuite) CreateStartInstanceArgs(c *gc.C) environs.StartInst
 
 	cons := constraints.Value{}
 
-	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(cons, cons, "trusty", "")
+	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(coretesting.FakeControllerBootstrapConfig(), cons, cons, "trusty", "")
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = instanceConfig.SetTools(coretools.List{
@@ -66,6 +67,7 @@ func (s *environBrokerSuite) CreateStartInstanceArgs(c *gc.C) environs.StartInst
 	instanceConfig.AuthorizedKeys = s.Config.AuthorizedKeys()
 
 	return environs.StartInstanceParams{
+		ControllerUUID: instanceConfig.Controller.Config.ControllerUUID(),
 		InstanceConfig: instanceConfig,
 		Tools:          tools,
 		Constraints:    cons,

--- a/provider/vsphere/environ_test.go
+++ b/provider/vsphere/environ_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/provider/vsphere"
+	"github.com/juju/juju/testing"
 )
 
 type environSuite struct {
@@ -34,7 +35,7 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 	})
 
 	os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.VSphereProvider)
-	_, err := s.Env.Bootstrap(nil, environs.BootstrapParams{ControllerUUID: "uuid"})
+	_, err := s.Env.Bootstrap(nil, environs.BootstrapParams{ControllerConfig: testing.FakeControllerBootstrapConfig()})
 	c.Assert(err, gc.ErrorMatches, "Bootstrap called")
 }
 

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -46,7 +46,7 @@ func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*
 	default:
 		return nil, errors.NotSupportedf("%q auth-type", authType)
 	}
-	return p.PrepareForCreateEnvironment(cfg)
+	return p.PrepareForCreateEnvironment(args.ControllerUUID, cfg)
 }
 
 // PrepareForBootstrap implements environs.EnvironProvider.
@@ -60,7 +60,7 @@ func (p environProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg 
 }
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.
-func (environProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+func (environProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
 	return cfg, nil
 }
 

--- a/state/controller.go
+++ b/state/controller.go
@@ -17,15 +17,6 @@ const (
 	defaultModelSettingsGlobalKey = "defaultModelSettings"
 )
 
-func controllerOnlyAttribute(attr string) bool {
-	for _, a := range jujucontroller.ControllerOnlyConfigAttributes {
-		if attr == a {
-			return true
-		}
-	}
-	return false
-}
-
 // modelConfig returns the model config attributes that result when we
 // take what is required for the model and remove any attributes that
 // are specifically controller related or are already present in the
@@ -33,7 +24,7 @@ func controllerOnlyAttribute(attr string) bool {
 func modelConfig(sharedCloudCfg, cfg map[string]interface{}) map[string]interface{} {
 	modelCfg := make(map[string]interface{})
 	for attr, cfgValue := range cfg {
-		if controllerOnlyAttribute(attr) {
+		if jujucontroller.ControllerOnlyAttribute(attr) {
 			continue
 		}
 		if sharedValue, ok := sharedCloudCfg[attr]; !ok || sharedValue != cfgValue {

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -49,10 +49,14 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 			CACert: testing.CACert,
 		},
 	}
+	modelCfg := testing.ModelConfig(c)
+	controllerCfg := testing.FakeControllerConfig()
+	controllerCfg["controller-uuid"] = modelCfg.UUID()
 	st, err := Initialize(InitializeParams{
+		ControllerConfig: controllerCfg,
 		ControllerModelArgs: ModelArgs{
 			Owner:  s.owner,
-			Config: testing.ModelConfig(c),
+			Config: modelCfg,
 		},
 		CloudName: "dummy",
 		Cloud: cloud.Cloud{

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -13,7 +13,6 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
@@ -129,8 +128,6 @@ func (s *MigrationExportSuite) TestModelInfo(c *gc.C) {
 	modelAttrs := dbModelCfg.AllAttrs()
 	c.Assert(modelAttrs["apt-mirror"], gc.Equals, "http://mirror")
 
-	// Remove all controller and cloud config before comparison.
-	controller.RemoveControllerAttributes(modelAttrs)
 	delete(modelAttrs, "apt-mirror")
 	c.Assert(model.Config(), jc.DeepEquals, modelAttrs)
 	c.Assert(model.LatestToolsVersion(), gc.Equals, latestTools)

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -846,7 +846,10 @@ func (s *ModelCloudValidationSuite) initializeState(
 		for controllerCredential = range credentials {
 		}
 	}
+	controllerCfg := testing.FakeControllerBootstrapConfig()
+	controllerCfg["controller-uuid"] = cfg.UUID()
 	st, err := state.Initialize(state.InitializeParams{
+		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
 			Owner:           owner,
 			Config:          cfg,

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -60,7 +60,7 @@ func checkModelConfigDefaults(attrs map[string]interface{}) error {
 
 func (st *State) buildAndValidateModelConfig(updateAttrs map[string]interface{}, removeAttrs []string, oldConfig *config.Config) (validCfg *config.Config, err error) {
 	for attr := range updateAttrs {
-		if controllerOnlyAttribute(attr) {
+		if controller.ControllerOnlyAttribute(attr) {
 			return nil, errors.Errorf("cannot set controller attribute %q on a model", attr)
 		}
 	}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
@@ -3144,7 +3143,6 @@ func (s *StateSuite) prepareAgentVersionTests(c *gc.C, st *state.State) (*config
 func (s *StateSuite) changeEnviron(c *gc.C, envConfig *config.Config, name string, value interface{}) {
 	attrs := envConfig.AllAttrs()
 	attrs[name] = value
-	controller.RemoveControllerAttributes(attrs)
 	c.Assert(s.State.UpdateModelConfig(attrs, nil, nil), gc.IsNil)
 }
 
@@ -4100,7 +4098,10 @@ func (s *SetAdminMongoPasswordSuite) TestSetAdminMongoPassword(c *gc.C) {
 		Password: password,
 	}
 	cfg := testing.ModelConfig(c)
+	controllerCfg := testing.FakeControllerConfig()
+	controllerCfg["controller-uuid"] = cfg.UUID()
 	st, err := state.Initialize(state.InitializeParams{
+		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
 			Owner:  owner,
 			Config: cfg,

--- a/state/testing/conn.go
+++ b/state/testing/conn.go
@@ -27,7 +27,10 @@ func Initialize(c *gc.C, owner names.UserTag, cfg *config.Config, policy state.P
 	mgoInfo := NewMongoInfo()
 	dialOpts := mongotest.DialOpts()
 
+	controllerCfg := testing.FakeControllerConfig()
+	controllerCfg["controller-uuid"] = cfg.UUID()
 	st, err := state.Initialize(state.InitializeParams{
+		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
 			Config: cfg,
 			Owner:  owner,

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -15,6 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/juju/osenv"
 )
@@ -37,6 +38,26 @@ var FakeVersionNumber = version.MustParse("1.99.0")
 // ModelTag is a defined known valid UUID that can be used in testing.
 var ModelTag = names.NewModelTag("deadbeef-0bad-400d-8000-4b1d0d06f00d")
 
+// FakeControllerConfig() returns an environment configuration
+// that is expected to be found in state for a fake controller.
+func FakeControllerConfig() controller.Config {
+	return controller.Config{
+		"controller-uuid":         ModelTag.Id(),
+		"ca-cert":                 CACert,
+		"state-port":              1234,
+		"api-port":                17777,
+		"set-numa-control-policy": false,
+	}
+}
+
+// FakeControllerBootstrapConfig() returns an environment configuration
+// for a fake provider with all required attributes set for bootstrap.
+func FakeControllerBootstrapConfig() controller.Config {
+	cfg := FakeControllerConfig()
+	cfg["ca-private-key"] = CAKey
+	return cfg
+}
+
 // FakeConfig() returns an environment configuration for a
 // fake provider with all required attributes set.
 func FakeConfig() Attrs {
@@ -44,16 +65,11 @@ func FakeConfig() Attrs {
 		"type":                      "someprovider",
 		"name":                      "testenv",
 		"uuid":                      ModelTag.Id(),
-		"controller-uuid":           ModelTag.Id(),
 		"authorized-keys":           FakeAuthKeys,
 		"firewall-mode":             config.FwInstance,
 		"admin-secret":              "fish",
-		"ca-cert":                   CACert,
-		"ca-private-key":            CAKey,
 		"ssl-hostname-verification": true,
 		"development":               false,
-		"state-port":                19034,
-		"api-port":                  17777,
 		"default-series":            series.LatestLts(),
 	}
 }
@@ -62,7 +78,7 @@ func FakeConfig() Attrs {
 // setting in the state.
 func ModelConfig(c *gc.C) *config.Config {
 	uuid := mustUUID()
-	return CustomModelConfig(c, Attrs{"uuid": uuid, "controller-uuid": uuid})
+	return CustomModelConfig(c, Attrs{"uuid": uuid})
 }
 
 // mustUUID returns a stringified uuid or panics
@@ -79,7 +95,7 @@ func mustUUID() string {
 func CustomModelConfig(c *gc.C, extra Attrs) *config.Config {
 	attrs := FakeConfig().Merge(Attrs{
 		"agent-version": "1.2.3",
-	}).Merge(extra).Delete("admin-secret", "ca-private-key")
+	}).Merge(extra).Delete("admin-secret")
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 	return cfg

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -42,7 +42,7 @@ var _ worker.Worker = (*firewaller.Firewaller)(nil)
 
 func (s *firewallerBaseSuite) setUpTest(c *gc.C, firewallMode string) {
 	add := map[string]interface{}{"firewall-mode": firewallMode}
-	s.DummyConfig = dummy.SampleConfig().Merge(add).Delete("admin-secret", "ca-private-key")
+	s.DummyConfig = dummy.SampleConfig().Merge(add).Delete("admin-secret")
 
 	s.JujuConnSuite.SetUpTest(c)
 	s.charm = s.AddTestingCharm(c, "dummy")
@@ -127,7 +127,7 @@ func (s *firewallerBaseSuite) addUnit(c *gc.C, svc *state.Application) (*state.U
 
 // startInstance starts a new instance for the given machine.
 func (s *firewallerBaseSuite) startInstance(c *gc.C, m *state.Machine) instance.Instance {
-	inst, hc := testing.AssertStartInstance(c, s.Environ, s.ControllerUUID, m.Id())
+	inst, hc := testing.AssertStartInstance(c, s.Environ, s.ControllerConfig.ControllerUUID(), m.Id())
 	err := m.SetProvisioned(inst.Id(), "fake_nonce", hc)
 	c.Assert(err, jc.ErrorIsNil)
 	return inst

--- a/worker/instancepoller/worker_test.go
+++ b/worker/instancepoller/worker_test.go
@@ -185,7 +185,7 @@ func (s *workerSuite) setupScenario(c *gc.C) ([]*apiinstancepoller.Machine, []in
 		apiMachine, err := s.api.Machine(names.NewMachineTag(m.Id()))
 		c.Assert(err, jc.ErrorIsNil)
 		machines = append(machines, apiMachine)
-		inst, _ := testing.AssertStartInstance(c, s.Environ, s.ControllerUUID, m.Id())
+		inst, _ := testing.AssertStartInstance(c, s.Environ, s.ControllerConfig.ControllerUUID(), m.Id())
 		insts = append(insts, inst)
 	}
 	// Associate the odd-numbered machines with an instance.

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/juju/juju/agent"
 	apiprovisioner "github.com/juju/juju/api/provisioner"
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/controller/authentication"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -154,7 +153,7 @@ func (p *provisioner) getStartTask(harvestMode config.HarvestMode) (ProvisionerT
 		secureServerConnection = info.CAPrivateKey != ""
 	}
 	task, err := NewProvisionerTask(
-		controller.Config(controllerCfg).ControllerUUID(),
+		controllerCfg.ControllerUUID(),
 		machineTag,
 		harvestMode,
 		p.st,

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -526,6 +526,10 @@ func (task *provisionerTask) constructInstanceConfig(
 			PublicImageSigningKey: publicKey,
 			MongoInfo:             stateInfo,
 		}
+		instanceConfig.Controller.Config = make(map[string]interface{})
+		for k, v := range pInfo.ControllerConfig {
+			instanceConfig.Controller.Config[k] = v
+		}
 	}
 
 	return instanceConfig, nil

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -192,7 +192,7 @@ func stop(c *gc.C, w worker.Worker) {
 }
 
 func (s *CommonProvisionerSuite) startUnknownInstance(c *gc.C, id string) instance.Instance {
-	instance, _ := testing.AssertStartInstance(c, s.Environ, s.ControllerUUID, id)
+	instance, _ := testing.AssertStartInstance(c, s.Environ, s.ControllerConfig.ControllerUUID(), id)
 	select {
 	case o := <-s.op:
 		switch o := o.(type) {
@@ -1231,7 +1231,7 @@ func (s *ProvisionerSuite) newProvisionerTask(
 	retryStrategy := provisioner.NewRetryStrategy(0*time.Second, 0)
 
 	w, err := provisioner.NewProvisionerTask(
-		s.ControllerUUID,
+		s.ControllerConfig.ControllerUUID(),
 		names.NewMachineTag("0"),
 		harvestingMethod,
 		machineGetter,


### PR DESCRIPTION
When bootstrapping and creating models, controller config is separated out from model config. Previously, it was intermingled which meant that we could pass around an environ.Config and extract the controller config from that. Now, we must explicitly pass the controller config everywhere it is needed. This includes BootstrapParams and ProvisioningInfo.
As part of the above, the NumaControlPolicy setting is moved to controller settings as it is relevant when setting up a controller.

Because the environ.Config doesn't contain controller-uuid any more, we must add the controller uuid as an argument to Environs.PrepareForCreateEnvironment()

The only place where model and controller config are still mingled is when constructing new config with defaults (since there's still a single schema for both). We separate these prior to calling bootstrap and when creating new hosted models.

Tested with lxd and aws. Bootstrapped and added a new model.

(Review request: http://reviews.vapour.ws/r/5109/)