### PR TITLE
apiserver/migrationmaster: Better tag sorting algorithm

### DIFF
--- a/apiserver/migrationmaster/facade_test.go
+++ b/apiserver/migrationmaster/facade_test.go
@@ -211,6 +211,8 @@ func (s *Suite) TestGetMinionReports(c *gc.C) {
 	for i := cap(unknown) - 1; i >= 0; i-- {
 		unknown = append(unknown, names.NewMachineTag(fmt.Sprintf("%d", i)))
 	}
+	m50c0 := names.NewMachineTag("50/lxd/0")
+	m50c1 := names.NewMachineTag("50/lxd/1")
 	m50 := names.NewMachineTag("50")
 	m51 := names.NewMachineTag("51")
 	m52 := names.NewMachineTag("52")
@@ -218,7 +220,7 @@ func (s *Suite) TestGetMinionReports(c *gc.C) {
 	u1 := names.NewUnitTag("foo/1")
 	s.backend.migration.minionReports = &state.MinionReports{
 		Succeeded: []names.Tag{m50, m51, u0},
-		Failed:    []names.Tag{u1, m52},
+		Failed:    []names.Tag{u1, m52, m50c1, m50c0},
 		Unknown:   unknown,
 	}
 
@@ -238,7 +240,13 @@ func (s *Suite) TestGetMinionReports(c *gc.C) {
 		SuccessCount:  3,
 		UnknownCount:  len(unknown),
 		UnknownSample: expectedSample,
-		Failed:        []string{m52.String(), u1.String()}, // Note sorting
+		Failed: []string{
+			// Note sorting
+			m50c0.String(),
+			m50c1.String(),
+			m52.String(),
+			u1.String(),
+		},
 	})
 }
 

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -109,16 +109,27 @@ type PhaseResult struct {
 // MinionReport holds the details of whether a migration minion
 // succeeded or failed for a specific migration phase.
 type MinionReport struct {
+	// MigrationId holds the id of the migration the agent is
+	// reporting about.
 	MigrationId string `json:"migration-id"`
-	Phase       string `json:"phase"`
-	Success     bool   `json:"success"`
+
+	// Phase holds the phase of the migration the agent is
+	// reporting about.
+	Phase string `json:"phase"`
+
+	// Success is true if the agent successfully completed its actions
+	// for the migration phase, false otherwise.
+	Success bool `json:"success"`
 }
 
 // MinionReports holds the details of whether a migration minion
 // succeeded or failed for a specific migration phase.
 type MinionReports struct {
+	// MigrationId holds the id of the migration the reports related to.
 	MigrationId string `json:"migration-id"`
-	Phase       string `json:"phase"`
+
+	// Phase holds the phase of the migration the reports related to.
+	Phase string `json:"phase"`
 
 	// SuccessCount holds the number of agents which have successfully
 	// completed a given migration phase.


### PR DESCRIPTION
Remove tagSlice in favour of the (actually correct) utils.SortStringsNaturally.

Drive-by: add missed docstrings

(Review request: http://reviews.vapour.ws/r/5112/)