### PR TITLE
1594232: Fix capitalization in command help

### DIFF
--- a/cmd/juju/action/list.go
+++ b/cmd/juju/action/list.go
@@ -40,14 +40,14 @@ For more information, see also the 'run-ation' command, which executes actions.
 // Set up the output.
 func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
-	f.BoolVar(&c.fullSchema, "schema", false, "display the full action schema")
+	f.BoolVar(&c.fullSchema, "schema", false, "Display the full action schema")
 }
 
 func (c *listCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "actions",
 		Args:    "<application name>",
-		Purpose: "list actions defined for a service",
+		Purpose: "List actions defined for a service.",
 		Doc:     listDoc,
 		Aliases: []string{"list-actions"},
 	}

--- a/cmd/juju/action/run.go
+++ b/cmd/juju/action/run.go
@@ -112,15 +112,15 @@ var ActionNameRule = regexp.MustCompile("^[a-z](?:[a-z-]*[a-z])?$")
 // SetFlags offers an option for YAML output.
 func (c *runCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
-	f.Var(&c.paramsYAML, "params", "path to yaml-formatted params file")
-	f.BoolVar(&c.parseStrings, "string-args", false, "use raw string values of CLI args")
+	f.Var(&c.paramsYAML, "params", "Path to yaml-formatted params file")
+	f.BoolVar(&c.parseStrings, "string-args", false, "Use raw string values of CLI args")
 }
 
 func (c *runCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "run-action",
 		Args:    "<unit> <action name> [key.key.key...=value]",
-		Purpose: "queue an action for execution",
+		Purpose: "Queue an action for execution.",
 		Doc:     runDoc,
 	}
 }

--- a/cmd/juju/action/showoutput.go
+++ b/cmd/juju/action/showoutput.go
@@ -42,14 +42,14 @@ displayed.  This is also the behavior when any negative time is given.
 // Set up the output.
 func (c *showOutputCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
-	f.StringVar(&c.wait, "wait", "-1s", "wait for results")
+	f.StringVar(&c.wait, "wait", "-1s", "Wait for results")
 }
 
 func (c *showOutputCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "show-action-output",
 		Args:    "<action ID>",
-		Purpose: "show results of an action by ID",
+		Purpose: "Show results of an action by ID.",
 		Doc:     showOutputDoc,
 	}
 }

--- a/cmd/juju/action/status.go
+++ b/cmd/juju/action/status.go
@@ -33,14 +33,14 @@ If --name <name> is provided the search will be done by name rather than by ID.
 // Set up the output.
 func (c *statusCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
-	f.StringVar(&c.name, "name", "", "an action name")
+	f.StringVar(&c.name, "name", "", "Action name")
 }
 
 func (c *statusCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "show-action-status",
 		Args:    "[<action ID>|<action ID prefix>]",
-		Purpose: "show results of all actions filtered by optional ID prefix",
+		Purpose: "Show results of all actions filtered by optional ID prefix.",
 		Doc:     statusDoc,
 	}
 }

--- a/cmd/juju/application/addrelation.go
+++ b/cmd/juju/application/addrelation.go
@@ -30,7 +30,7 @@ func (c *addRelationCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "add-relation",
 		Args:    "<application1>[:<relation name1>] <application2>[:<relation name2>]",
-		Purpose: "add a relation between two applications",
+		Purpose: "Add a relation between two applications.",
 	}
 }
 

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -202,7 +202,7 @@ func (c *DeployCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "deploy",
 		Args:    "<charm or bundle> [<application name>]",
-		Purpose: "deploy a new application or bundle",
+		Purpose: "Deploy a new application or bundle.",
 		Doc:     deployDoc,
 	}
 }
@@ -218,14 +218,14 @@ func (c *DeployCommand) SetFlags(f *gnuflag.FlagSet) {
 	// Keep above charmOnlyFlags and bundleOnlyFlags lists updated when adding
 	// new flags.
 	c.UnitCommandBase.SetFlags(f)
-	f.IntVar(&c.NumUnits, "n", 1, "number of application units to deploy for principal charms")
-	f.StringVar((*string)(&c.Channel), "channel", "", "channel to use when getting the charm or bundle from the charm store")
-	f.Var(&c.Config, "config", "path to yaml-formatted application config")
-	f.Var(constraints.ConstraintsValue{Target: &c.Constraints}, "constraints", "set application constraints")
-	f.StringVar(&c.Series, "series", "", "the series on which to deploy")
-	f.BoolVar(&c.Force, "force", false, "allow a charm to be deployed to a machine running an unsupported series")
-	f.Var(storageFlag{&c.Storage, &c.BundleStorage}, "storage", "charm storage constraints")
-	f.Var(stringMap{&c.Resources}, "resource", "resource to be uploaded to the controller")
+	f.IntVar(&c.NumUnits, "n", 1, "Number of application units to deploy for principal charms")
+	f.StringVar((*string)(&c.Channel), "channel", "", "Channel to use when getting the charm or bundle from the charm store")
+	f.Var(&c.Config, "config", "Path to yaml-formatted application config")
+	f.Var(constraints.ConstraintsValue{Target: &c.Constraints}, "constraints", "Set application constraints")
+	f.StringVar(&c.Series, "series", "", "The series on which to deploy")
+	f.BoolVar(&c.Force, "force", false, "Allow a charm to be deployed to a machine running an unsupported series")
+	f.Var(storageFlag{&c.Storage, &c.BundleStorage}, "storage", "Charm storage constraints")
+	f.Var(stringMap{&c.Resources}, "resource", "Resource to be uploaded to the controller")
 	f.StringVar(&c.BindToSpaces, "bind", "", "Configure application endpoint bindings to spaces")
 
 	for _, step := range c.Steps {

--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -51,7 +51,7 @@ func (c *removeUnitCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "remove-unit",
 		Args:    "<unit> [...]",
-		Purpose: "remove application units from the model",
+		Purpose: "Remove application units from the model.",
 		Doc:     removeUnitDoc,
 		Aliases: []string{"destroy-unit"},
 	}

--- a/cmd/juju/application/upgradecharm.go
+++ b/cmd/juju/application/upgradecharm.go
@@ -114,19 +114,19 @@ func (c *upgradeCharmCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "upgrade-charm",
 		Args:    "<application>",
-		Purpose: "upgrade an application's charm",
+		Purpose: "Upgrade an application's charm.",
 		Doc:     upgradeCharmDoc,
 	}
 }
 
 func (c *upgradeCharmCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.ForceUnits, "force-units", false, "upgrade all units immediately, even if in error state")
-	f.StringVar((*string)(&c.Channel), "channel", "", "channel to use when getting the charm or bundle from the charm store")
-	f.BoolVar(&c.ForceSeries, "force-series", false, "upgrade even if series of deployed applications are not supported by the new charm")
-	f.StringVar(&c.SwitchURL, "switch", "", "crossgrade to a different charm")
-	f.StringVar(&c.CharmPath, "path", "", "upgrade to a charm located at path")
-	f.IntVar(&c.Revision, "revision", -1, "explicit revision of current charm")
-	f.Var(stringMap{&c.Resources}, "resource", "resource to be uploaded to the controller")
+	f.BoolVar(&c.ForceUnits, "force-units", false, "Upgrade all units immediately, even if in error state")
+	f.StringVar((*string)(&c.Channel), "channel", "", "Channel to use when getting the charm or bundle from the charm store")
+	f.BoolVar(&c.ForceSeries, "force-series", false, "Upgrade even if series of deployed applications are not supported by the new charm")
+	f.StringVar(&c.SwitchURL, "switch", "", "Crossgrade to a different charm")
+	f.StringVar(&c.CharmPath, "path", "", "Upgrade to a charm located at path")
+	f.IntVar(&c.Revision, "revision", -1, "Explicit revision of current charm")
+	f.Var(stringMap{&c.Resources}, "resource", "Resource to be uploaded to the controller")
 }
 
 func (c *upgradeCharmCommand) Init(args []string) error {

--- a/cmd/juju/backups/create.go
+++ b/cmd/juju/backups/create.go
@@ -67,7 +67,7 @@ func (c *createCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "create-backup",
 		Args:    "[<notes>]",
-		Purpose: "create a backup",
+		Purpose: "Create a backup.",
 		Doc:     createDoc,
 	}
 }
@@ -75,8 +75,8 @@ func (c *createCommand) Info() *cmd.Info {
 // SetFlags implements Command.SetFlags.
 func (c *createCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CommandBase.SetFlags(f)
-	f.BoolVar(&c.NoDownload, "no-download", false, "do not download the archive")
-	f.StringVar(&c.Filename, "filename", notset, "download to this file")
+	f.BoolVar(&c.NoDownload, "no-download", false, "Do not download the archive")
+	f.StringVar(&c.Filename, "filename", notset, "Download to this file")
 }
 
 // Init implements Command.Init.

--- a/cmd/juju/backups/download.go
+++ b/cmd/juju/backups/download.go
@@ -42,7 +42,7 @@ func (c *downloadCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "download-backup",
 		Args:    "<ID>",
-		Purpose: "get an archive file",
+		Purpose: "Get an archive file.",
 		Doc:     downloadDoc,
 	}
 }
@@ -50,7 +50,7 @@ func (c *downloadCommand) Info() *cmd.Info {
 // SetFlags implements Command.SetFlags.
 func (c *downloadCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CommandBase.SetFlags(f)
-	f.StringVar(&c.Filename, "filename", "", "download target")
+	f.StringVar(&c.Filename, "filename", "", "Download target")
 }
 
 // Init implements Command.Init.

--- a/cmd/juju/backups/list.go
+++ b/cmd/juju/backups/list.go
@@ -31,7 +31,7 @@ func (c *listCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "backups",
 		Args:    "",
-		Purpose: "get all metadata",
+		Purpose: "Displays information about all backups.",
 		Doc:     listDoc,
 		Aliases: []string{"list-backups"},
 	}

--- a/cmd/juju/backups/remove.go
+++ b/cmd/juju/backups/remove.go
@@ -33,7 +33,7 @@ func (c *removeCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "remove-backup",
 		Args:    "<ID>",
-		Purpose: "delete a backup",
+		Purpose: "Remove the spcified backup from remote storage.",
 		Doc:     removeDoc,
 	}
 }

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -93,7 +93,7 @@ var BootstrapFunc = bootstrap.Bootstrap
 func (c *restoreCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "restore-backup",
-		Purpose: "restore from a backup archive to a new controller",
+		Purpose: "Restore from a backup archive to a new controller.",
 		Args:    "",
 		Doc:     strings.TrimSpace(restoreDoc),
 	}
@@ -105,10 +105,10 @@ func (c *restoreCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(constraints.ConstraintsValue{Target: &c.constraints},
 		"constraints", "set model constraints")
 
-	f.BoolVar(&c.bootstrap, "b", false, "bootstrap a new state machine")
-	f.StringVar(&c.filename, "file", "", "provide a file to be used as the backup.")
-	f.StringVar(&c.backupId, "id", "", "provide the name of the backup to be restored.")
-	f.BoolVar(&c.uploadTools, "upload-tools", false, "upload tools if bootstraping a new machine.")
+	f.BoolVar(&c.bootstrap, "b", false, "Bootstrap a new state machine")
+	f.StringVar(&c.filename, "file", "", "Provide a file to be used as the backup.")
+	f.StringVar(&c.backupId, "id", "", "Provide the name of the backup to be restored")
+	f.BoolVar(&c.uploadTools, "upload-tools", false, "Upload tools if bootstraping a new machine")
 }
 
 // Init is where the preconditions for this commands can be checked.

--- a/cmd/juju/backups/show.go
+++ b/cmd/juju/backups/show.go
@@ -31,7 +31,7 @@ func (c *showCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "show-backup",
 		Args:    "<ID>",
-		Purpose: "get metadata",
+		Purpose: "Show metadata for the specified backup.",
 		Doc:     showDoc,
 	}
 }

--- a/cmd/juju/backups/upload.go
+++ b/cmd/juju/backups/upload.go
@@ -35,7 +35,7 @@ func (c *uploadCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "upload-backup",
 		Args:    "<filename>",
-		Purpose: "store a backup archive file remotely in juju",
+		Purpose: "Store a backup archive file remotely in Juju.",
 		Doc:     uploadDoc,
 	}
 }

--- a/cmd/juju/block/block.go
+++ b/cmd/juju/block/block.go
@@ -67,7 +67,6 @@ type destroyCommand struct {
 }
 
 var destroyBlockDoc = `
-
 This command allows to block model destruction.
 
 To disable the block, run unblock command - see "juju help unblock". 
@@ -76,8 +75,8 @@ To by-pass the block, run destroy-model with --force option.
 "juju block destroy-model" only blocks destroy-model command.
    
 Examples:
-   To prevent the model from being destroyed:
-   juju block destroy-model
+    # To prevent the model from being destroyed:
+    juju block destroy-model
 
 `
 
@@ -86,7 +85,7 @@ Examples:
 func (c *destroyCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "destroy-model",
-		Purpose: "block an operation that would destroy Juju model",
+		Purpose: "Block an operation that would destroy Juju model.",
 		Doc:     destroyBlockDoc,
 	}
 }
@@ -106,7 +105,6 @@ type removeCommand struct {
 }
 
 var removeBlockDoc = `
-
 This command allows to block all operations that would remove an object 
 from Juju model.
 
@@ -121,8 +119,8 @@ To by-pass the block, where available, run desired remove command with --force o
     remove-unit
    
 Examples:
-   To prevent the machines, applications, units and relations from being removed:
-   juju block remove-object
+    # To prevent the machines, applications, units and relations from being removed:
+    juju block remove-object
 
 `
 
@@ -131,7 +129,7 @@ Examples:
 func (c *removeCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "remove-object",
-		Purpose: "block an operation that would remove an object",
+		Purpose: "Block an operation that would remove an object.",
 		Doc:     removeBlockDoc,
 	}
 }
@@ -151,7 +149,6 @@ type changeCommand struct {
 }
 
 var changeBlockDoc = `
-
 This command allows to block all operations that would alter
 Juju model.
 
@@ -191,8 +188,8 @@ To by-pass the block, where available, run desired remove command with --force o
     enable-user
    
 Examples:
-   To prevent changes to the model:
-   juju block all-changes
+    # To prevent changes to the model:
+    juju block all-changes
 
 `
 
@@ -201,7 +198,7 @@ Examples:
 func (c *changeCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "all-changes",
-		Purpose: "block operations that could change Juju model",
+		Purpose: "Block operations that could change Juju model.",
 		Doc:     changeBlockDoc,
 	}
 }

--- a/cmd/juju/block/blocksuper.go
+++ b/cmd/juju/block/blocksuper.go
@@ -19,7 +19,7 @@ must be manually unblocked to proceed.
  the Juju model.
 `
 
-const superBlockCmdPurpose = "list and enable model blocks"
+const superBlockCmdPurpose = "List and enable model blocks."
 
 // Command is the top-level command wrapping all storage functionality.
 type Command struct {

--- a/cmd/juju/block/list.go
+++ b/cmd/juju/block/list.go
@@ -41,7 +41,7 @@ func (c *listCommand) Init(args []string) (err error) {
 func (c *listCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list",
-		Purpose: "list juju blocks",
+		Purpose: "List Juju blocks.",
 		Doc:     listCommandDoc,
 	}
 }

--- a/cmd/juju/block/unblock.go
+++ b/cmd/juju/block/unblock.go
@@ -33,7 +33,6 @@ type unblockCommand struct {
 
 var (
 	unblockDoc = `
-
 Juju allows to safeguard deployed models from unintentional damage by preventing
 execution of operations that could alter model.
 
@@ -87,17 +86,17 @@ all-changes includes all alteration commands
     enable-user
 
 Examples:
-   To allow the model to be destroyed:
-   juju unblock destroy-model
+    # To allow the model to be destroyed:
+    juju unblock destroy-model
 
-   To allow the machines, applications, units and relations to be removed:
-   juju unblock remove-object
+    # To allow the machines, applications, units and relations to be removed:
+    juju unblock remove-object
 
-   To allow changes to the model:
-   juju unblock all-changes
+    # To allow changes to the model:
+    juju unblock all-changes
 
 See Also:
-   juju help block
+   juju block
 `
 
 	// blockArgsFmt has formatted representation of block command valid arguments.
@@ -132,7 +131,7 @@ func (c *unblockCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "unblock",
 		Args:    blockArgsFmt,
-		Purpose: "unblock an operation that would alter a running model",
+		Purpose: "Unblock an operation that would alter a running model.",
 		Doc:     unblockDoc,
 	}
 }

--- a/cmd/juju/cachedimages/list.go
+++ b/cmd/juju/cachedimages/list.go
@@ -24,7 +24,6 @@ Images can be filtered on:
 The filter attributes are optional.
 
 Examples:
-
   # List all cached images.
   juju cached-images
 
@@ -51,7 +50,7 @@ type listCommand struct {
 func (c *listCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "cached-images",
-		Purpose: "shows cached os images",
+		Purpose: "Shows cached os images.",
 		Doc:     listCommandDoc,
 		Aliases: []string{"list-cached-images"},
 	}
@@ -60,9 +59,9 @@ func (c *listCommand) Info() *cmd.Info {
 // SetFlags implements Command.SetFlags.
 func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CachedImagesCommandBase.SetFlags(f)
-	f.StringVar(&c.Kind, "kind", "", "the image kind to list eg lxd")
-	f.StringVar(&c.Series, "series", "", "the series of the image to list eg xenial")
-	f.StringVar(&c.Arch, "arch", "", "the architecture of the image to list eg amd64")
+	f.StringVar(&c.Kind, "kind", "", "The image kind to list eg lxd")
+	f.StringVar(&c.Series, "series", "", "The series of the image to list eg xenial")
+	f.StringVar(&c.Arch, "arch", "", "The architecture of the image to list eg amd64")
 	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
 		"yaml": cmd.FormatYaml,
 		"json": cmd.FormatJson,

--- a/cmd/juju/cachedimages/remove.go
+++ b/cmd/juju/cachedimages/remove.go
@@ -20,7 +20,6 @@ Images are identified by:
   Architecture eg "amd64"
 
 Examples:
-
   # Remove cached lxd image for xenial amd64.
   juju remove-cached-images --kind lxd --series xenial --arch amd64
 `
@@ -40,7 +39,7 @@ type removeCommand struct {
 func (c *removeCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "remove-cached-images",
-		Purpose: "remove cached os images",
+		Purpose: "Remove cached OS images.",
 		Doc:     removeCommandDoc,
 	}
 }
@@ -48,9 +47,9 @@ func (c *removeCommand) Info() *cmd.Info {
 // SetFlags implements Command.SetFlags.
 func (c *removeCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CachedImagesCommandBase.SetFlags(f)
-	f.StringVar(&c.Kind, "kind", "", "the image kind to remove eg lxd")
-	f.StringVar(&c.Series, "series", "", "the series of the image to remove eg xenial")
-	f.StringVar(&c.Arch, "arch", "", "the architecture of the image to remove eg amd64")
+	f.StringVar(&c.Kind, "kind", "", "The image kind to remove eg lxd")
+	f.StringVar(&c.Series, "series", "", "The series of the image to remove eg xenial")
+	f.StringVar(&c.Arch, "arch", "", "The architecture of the image to remove eg amd64")
 }
 
 // Init implements Command.Init.

--- a/cmd/juju/charmcmd/charm.go
+++ b/cmd/juju/charmcmd/charm.go
@@ -12,7 +12,7 @@ var charmDoc = `
 by charm authors, though only applicable functionality is mirrored.
 `
 
-const charmPurpose = "interact with charms"
+const charmPurpose = "Interact with charms."
 
 // Command is the top-level command wrapping all charm functionality.
 type Command struct {

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -86,7 +86,7 @@ func NewDetectCredentialsCommand() cmd.Command {
 func (c *detectCredentialsCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "autoload-credentials",
-		Purpose: "looks for cloud credentials and caches those for use by Juju when bootstrapping",
+		Purpose: "Looks for cloud credentials and caches those for use by Juju when bootstrapping.",
 		Doc:     detectCredentialsDoc,
 	}
 }

--- a/cmd/juju/commands/debughooks.go
+++ b/cmd/juju/commands/debughooks.go
@@ -39,7 +39,7 @@ func (c *debugHooksCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "debug-hooks",
 		Args:    "<unit name> [hook names]",
-		Purpose: "launch a tmux session to debug a hook",
+		Purpose: "Launch a tmux session to debug a hook.",
 		Doc:     debugHooksDoc,
 	}
 }

--- a/cmd/juju/commands/enableha.go
+++ b/cmd/juju/commands/enableha.go
@@ -68,22 +68,25 @@ to ensure that the specified number of controllers are made available.
 An odd number of controllers is required.
 
 Examples:
- juju enable-ha
-     Ensure that the controller is still in highly available mode. If
-     there is only 1 controller running, this will ensure there
-     are 3 running. If you have previously requested more than 3,
-     then that number will be ensured.
- juju enable-ha -n 5 --series=trusty
-     Ensure that 5 controllers are available, with newly created
-     controller machines having the "trusty" series.
- juju enable-ha -n 7 --constraints mem=8G
-     Ensure that 7 controllers are available, with newly created
-     controller machines having the default series, and at least
-     8GB RAM.
- juju enable-ha -n 7 --to server1,server2 --constraints mem=8G
-     Ensure that 7 controllers are available, with machines server1 and
-     server2 used first, and if necessary, newly created controller
-     machines having the default series, and at least 8GB RAM.
+    # Ensure that the controller is still in highly available mode. If
+    # there is only 1 controller running, this will ensure there
+    # are 3 running. If you have previously requested more than 3,
+    # then that number will be ensured.
+    juju enable-ha
+
+    # Ensure that 5 controllers are available, with newly created
+    # controller machines having the "trusty" series.
+    juju enable-ha -n 5 --series=trusty
+
+    # Ensure that 7 controllers are available, with newly created
+    # controller machines having the default series, and at least
+    # 8GB RAM.
+    juju enable-ha -n 7 --constraints mem=8G
+
+    # Ensure that 7 controllers are available, with machines server1 and
+    # server2 used first, and if necessary, newly created controller
+    # machines having the default series, and at least 8GB RAM.
+    juju enable-ha -n 7 --to server1,server2 --constraints mem=8G
 `
 
 // formatSimple marshals value to a yaml-formatted []byte, unless value is nil.
@@ -139,16 +142,16 @@ func formatSimple(value interface{}) ([]byte, error) {
 func (c *enableHACommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "enable-ha",
-		Purpose: "ensure that sufficient controllers exist to provide redundancy",
+		Purpose: "Ensure that sufficient controllers exist to provide redundancy.",
 		Doc:     enableHADoc,
 	}
 }
 
 func (c *enableHACommand) SetFlags(f *gnuflag.FlagSet) {
-	f.IntVar(&c.NumControllers, "n", 0, "number of controllers to make available")
-	f.StringVar(&c.Series, "series", "", "the charm series")
-	f.StringVar(&c.PlacementSpec, "to", "", "the machine(s) to become controllers, bypasses constraints")
-	f.Var(constraints.ConstraintsValue{&c.Constraints}, "constraints", "additional machine constraints")
+	f.IntVar(&c.NumControllers, "n", 0, "Number of controllers to make available")
+	f.StringVar(&c.Series, "series", "", "The charm series")
+	f.StringVar(&c.PlacementSpec, "to", "", "The machine(s) to become controllers, bypasses constraints")
+	f.Var(constraints.ConstraintsValue{&c.Constraints}, "constraints", "Additional machine constraints")
 	c.out.AddFlags(f, "simple", map[string]cmd.Formatter{
 		"yaml":   cmd.FormatYaml,
 		"json":   cmd.FormatJson,

--- a/cmd/juju/commands/helptool.go
+++ b/cmd/juju/commands/helptool.go
@@ -98,7 +98,7 @@ func (t *helpToolCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "help-tool",
 		Args:    "[tool]",
-		Purpose: "show help on a juju charm tool",
+		Purpose: "Show help on a Juju charm tool.",
 	}
 }
 

--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -24,7 +24,7 @@ func (suite *HelpToolSuite) TestHelpToolHelp(c *gc.C) {
 	c.Assert(output, gc.Equals, `Usage: juju help-tool [tool]
 
 Summary:
-show help on a juju charm tool
+Show help on a Juju charm tool.
 `)
 }
 

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -683,9 +683,12 @@ func (s *MainSuite) TestAllCommandsPurposeDocCapitalization(c *gc.C) {
 		}
 
 		c.Check(purpose, gc.Not(gc.Equals), "", comment("has empty Purpose"))
-		// TODO (cherylj) Add back in the check for capitalization of
-		// purpose, but check for upper case.  This requires all commands
-		// to have been updated first.
+		if purpose != "" {
+			prefix := string(purpose[0])
+			c.Check(prefix, gc.Equals, strings.ToUpper(prefix),
+				comment("expected uppercase first-letter Purpose"),
+			)
+		}
 		if doc != "" && !strings.HasPrefix(doc, info.Name) {
 			prefix := string(doc[0])
 			c.Check(prefix, gc.Equals, strings.ToUpper(prefix),

--- a/cmd/juju/commands/publish.go
+++ b/cmd/juju/commands/publish.go
@@ -54,13 +54,13 @@ func (c *publishCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "publish",
 		Args:    "[<charm url>]",
-		Purpose: "publish charm to the store",
+		Purpose: "Publish charm to the store.",
 		Doc:     publishDoc,
 	}
 }
 
 func (c *publishCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.StringVar(&c.CharmPath, "from", ".", "path for charm to be published")
+	f.StringVar(&c.CharmPath, "from", ".", "Path for charm to be published")
 }
 
 func (c *publishCommand) Init(args []string) error {

--- a/cmd/juju/commands/resolved.go
+++ b/cmd/juju/commands/resolved.go
@@ -29,12 +29,12 @@ func (c *resolvedCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "resolved",
 		Args:    "<unit>",
-		Purpose: "marks unit errors resolved",
+		Purpose: "Marks unit errors resolved.",
 	}
 }
 
 func (c *resolvedCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.Retry, "r", false, "re-execute failed hooks")
+	f.BoolVar(&c.Retry, "r", false, "Re-execute failed hooks")
 	f.BoolVar(&c.Retry, "retry", false, "")
 }
 

--- a/cmd/juju/commands/run.go
+++ b/cmd/juju/commands/run.go
@@ -72,18 +72,18 @@ func (c *runCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "run",
 		Args:    "<commands>",
-		Purpose: "run the commands on the remote targets specified",
+		Purpose: "Run the commands on the remote targets specified.",
 		Doc:     runDoc,
 	}
 }
 
 func (c *runCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
-	f.BoolVar(&c.all, "all", false, "run the commands on all the machines")
-	f.DurationVar(&c.timeout, "timeout", 5*time.Minute, "how long to wait before the remote command is considered to have failed")
-	f.Var(cmd.NewStringsValue(nil, &c.machines), "machine", "one or more machine ids")
-	f.Var(cmd.NewStringsValue(nil, &c.services), "application", "one or more application names")
-	f.Var(cmd.NewStringsValue(nil, &c.units), "unit", "one or more unit ids")
+	f.BoolVar(&c.all, "all", false, "Run the commands on all the machines")
+	f.DurationVar(&c.timeout, "timeout", 5*time.Minute, "How long to wait before the remote command is considered to have failed")
+	f.Var(cmd.NewStringsValue(nil, &c.machines), "machine", "One or more machine ids")
+	f.Var(cmd.NewStringsValue(nil, &c.services), "application", "One or more application names")
+	f.Var(cmd.NewStringsValue(nil, &c.units), "unit", "One or more unit ids")
 }
 
 func (c *runCommand) Init(args []string) error {

--- a/cmd/juju/commands/synctools.go
+++ b/cmd/juju/commands/synctools.go
@@ -56,20 +56,17 @@ The online store will, of course, need to be contacted at some point to get
 the software.
 
 Examples:
-
-Download the software (version auto-selected) to the model:
-
+    # Download the software (version auto-selected) to the model:
     juju sync-tools --debug
 
-Download a specific version of the software locally:
-
+    # Download a specific version of the software locally:
     juju sync-tools --debug --version 2.0 --local-dir=/home/ubuntu/sync-tools
 
-Get locally available software to the model:
-
+    # Get locally available software to the model:
     juju sync-tools --debug --source=/home/ubuntu/sync-tools
 
-See also: upgrade-juju
+See Also:
+    juju upgrade-juju
 
 `
 
@@ -82,15 +79,15 @@ func (c *syncToolsCommand) Info() *cmd.Info {
 }
 
 func (c *syncToolsCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.allVersions, "all", false, "copy all versions, not just the latest")
-	f.StringVar(&c.versionStr, "version", "", "copy a specific major[.minor] version")
-	f.BoolVar(&c.dryRun, "dry-run", false, "don't copy, just print what would be copied")
-	f.BoolVar(&c.dev, "dev", false, "consider development versions as well as released ones\n    DEPRECATED: use --stream instead")
-	f.BoolVar(&c.public, "public", false, "tools are for a public cloud, so generate mirrors information")
-	f.StringVar(&c.source, "source", "", "local source directory")
-	f.StringVar(&c.stream, "stream", "", "simplestreams stream for which to sync metadata")
-	f.StringVar(&c.localDir, "local-dir", "", "local destination directory")
-	f.StringVar(&c.destination, "destination", "", "local destination directory\n    DEPRECATED: use --local-dir instead")
+	f.BoolVar(&c.allVersions, "all", false, "Copy all versions, not just the latest")
+	f.StringVar(&c.versionStr, "version", "", "Copy a specific major[.minor] version")
+	f.BoolVar(&c.dryRun, "dry-run", false, "Don't copy, just print what would be copied")
+	f.BoolVar(&c.dev, "dev", false, "Consider development versions as well as released ones\n    DEPRECATED: use --stream instead")
+	f.BoolVar(&c.public, "public", false, "Tools are for a public cloud, so generate mirrors information")
+	f.StringVar(&c.source, "source", "", "Local source directory")
+	f.StringVar(&c.stream, "stream", "", "Simplestreams stream for which to sync metadata")
+	f.StringVar(&c.localDir, "local-dir", "", "Local destination directory")
+	f.StringVar(&c.destination, "destination", "", "Local destination directory\n    DEPRECATED: use --local-dir instead")
 }
 
 func (c *syncToolsCommand) Init(args []string) error {

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -64,14 +64,14 @@ func (c *killCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "kill-controller",
 		Args:    "<controller name>",
-		Purpose: "forcibly terminate all machines and other associated resources for a juju controller",
+		Purpose: "Forcibly terminate all machines and other associated resources for a Juju controller.",
 		Doc:     killDoc,
 	}
 }
 
 // SetFlags implements Command.SetFlags.
 func (c *killCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.assumeYes, "y", false, "do not ask for confirmation")
+	f.BoolVar(&c.assumeYes, "y", false, "Do not ask for confirmation")
 	f.BoolVar(&c.assumeYes, "yes", false, "")
 }
 

--- a/cmd/juju/controller/listblocks.go
+++ b/cmd/juju/controller/listblocks.go
@@ -38,7 +38,7 @@ type listBlocksAPI interface {
 func (c *listBlocksCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "blocks",
-		Purpose: "list all blocks within the controller",
+		Purpose: "List all blocks within the controller.",
 		Doc:     listBlocksDoc,
 		Aliases: []string{"list-all-blocks", "list-blocks"},
 	}

--- a/cmd/juju/controller/removeblocks.go
+++ b/cmd/juju/controller/removeblocks.go
@@ -33,15 +33,15 @@ A controller administrator is able to remove all the blocks that have been added
 in a Juju controller.
 
 See Also:
-    juju help block
-    juju help unblock
+    juju block
+    juju unblock
 `
 
 // Info implements Command.Info
 func (c *removeBlocksCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "remove-all-blocks",
-		Purpose: "remove all blocks in the Juju controller",
+		Purpose: "Remove all blocks in the Juju controller.",
 		Doc:     removeBlocksDoc,
 	}
 }

--- a/cmd/juju/gui/gui.go
+++ b/cmd/juju/gui/gui.go
@@ -50,15 +50,15 @@ An error is returned if the Juju GUI is not available in the controller.
 func (c *guiCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "gui",
-		Purpose: "open the Juju GUI in the default browser",
+		Purpose: "Open the Juju GUI in the default browser.",
 		Doc:     guiDoc,
 	}
 }
 
 // SetFlags implements the cmd.Command interface.
 func (c *guiCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.showCreds, "show-credentials", false, "show admin credentials to use for logging into the Juju GUI")
-	f.BoolVar(&c.noBrowser, "no-browser", false, "do not try to open the web browser, just print the Juju GUI URL")
+	f.BoolVar(&c.showCreds, "show-credentials", false, "Show admin credentials to use for logging into the Juju GUI")
+	f.BoolVar(&c.noBrowser, "no-browser", false, "Do not try to open the web browser, just print the Juju GUI URL")
 }
 
 // Run implements the cmd.Command interface.

--- a/cmd/juju/gui/upgradegui.go
+++ b/cmd/juju/gui/upgradegui.go
@@ -61,14 +61,14 @@ List available Juju GUI releases without upgrading:
 func (c *upgradeGUICommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "upgrade-gui",
-		Purpose: "upgrade to a new Juju GUI version",
+		Purpose: "Upgrade to a new Juju GUI version.",
 		Doc:     upgradeGUIDoc,
 	}
 }
 
 // SetFlags implements the cmd.Command interface.
 func (c *upgradeGUICommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.list, "list", false, "list available Juju GUI release versions without upgrading")
+	f.BoolVar(&c.list, "list", false, "List available Juju GUI release versions without upgrading")
 }
 
 // Init implements the cmd.Command interface.

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -25,7 +25,6 @@ import (
 )
 
 var addMachineDoc = `
-
 Juju supports adding machines using provider-specific machine instances
 (EC2 instances, OpenStack servers, MAAS nodes, etc.); existing machines
 running a supported operating system (see "manual provisioning" below),
@@ -67,8 +66,8 @@ Examples:
    juju add-machine zone=us-east-1a      (start a machine in zone us-east-1a on AWS)
    juju add-machine maas2.name           (acquire machine maas2.name on MAAS)
 
-See also:
-    remove-machine
+See Also:
+    juju remove-machine
 `
 
 func init() {
@@ -110,17 +109,17 @@ func (c *addCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "add-machine",
 		Args:    "[<container>:machine | <container> | ssh:[user@]host | placement]",
-		Purpose: "start a new, empty machine and optionally a container, or add a container to a machine",
+		Purpose: "Start a new, empty machine and optionally a container, or add a container to a machine.",
 		Doc:     addMachineDoc,
 		Aliases: []string{"add-machines"},
 	}
 }
 
 func (c *addCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.StringVar(&c.Series, "series", "", "the charm series")
+	f.StringVar(&c.Series, "series", "", "The charm series")
 	f.IntVar(&c.NumMachines, "n", 1, "The number of machines to add")
-	f.Var(constraints.ConstraintsValue{Target: &c.Constraints}, "constraints", "additional machine constraints")
-	f.Var(disksFlag{&c.Disks}, "disks", "constraints for disks to attach to the machine")
+	f.Var(constraints.ConstraintsValue{Target: &c.Constraints}, "constraints", "Additional machine constraints")
+	f.Var(disksFlag{&c.Disks}, "disks", "Constraints for disks to attach to the machine")
 }
 
 func (c *addCommand) Init(args []string) error {

--- a/cmd/juju/machine/show.go
+++ b/cmd/juju/machine/show.go
@@ -10,22 +10,17 @@ import (
 )
 
 const showMachineCommandDoc = `
-Show a specified machine on a model:
+Show a specified machine on a model.  Default format is in yaml,
+other formats can be specified with the "--format" option.
+Available formats are yaml, tabular, and json
 
-juju show-machine <machineID> ...
+Examples:
+    # Display status for machine 0
+    juju show-machine 0
 
-For example:
+    # Display status for machines 1, 2 & 3
+    juju show-machine 1 2 3
 
-juju show-machine 0
-
-or for multiple machines
-(the following will display status for machines 1, 2 & 3):
-
-juju show-machine 1 2 3
-
-Default format is in yaml, other formats can be specified
-with the "--format" option.  Available formats are yaml,
-tabular, and json
 `
 
 // NewShowMachineCommand returns a command that shows details on the specified machine[s].
@@ -50,7 +45,7 @@ func (c *showMachineCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "show-machine",
 		Args:    "<machineID> ...",
-		Purpose: "show a machines status",
+		Purpose: "Show a machine's status.",
 		Doc:     showMachineCommandDoc,
 		Aliases: []string{"show-machines"},
 	}

--- a/cmd/juju/metricsdebug/collectmetrics.go
+++ b/cmd/juju/metricsdebug/collectmetrics.go
@@ -25,8 +25,7 @@ import (
 
 // TODO(bogdanteleaga): update this once querying for actions by name is implemented.
 const collectMetricsDoc = `
-collect-metrics
-trigger metrics collection
+Trigger metrics collection
 
 This command waits for the metric collection to finish before returning.
 You may abort this command and it will continue to run asynchronously.
@@ -58,7 +57,7 @@ func (c *collectMetricsCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "collect-metrics",
 		Args:    "[application or unit]",
-		Purpose: "collect metrics on the given unit/application",
+		Purpose: "Collect metrics on the given unit/application.",
 		Doc:     collectMetricsDoc,
 	}
 }

--- a/cmd/juju/metricsdebug/metricsdebug.go
+++ b/cmd/juju/metricsdebug/metricsdebug.go
@@ -21,8 +21,7 @@ import (
 )
 
 const debugMetricsDoc = `
-debug-metrics
-display recently collected metrics and exit
+Display recently collected metrics and exit
 `
 
 // DebugMetricsCommand retrieves metrics stored in the juju controller.
@@ -43,7 +42,7 @@ func (c *DebugMetricsCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "debug-metrics",
 		Args:    "[application or unit]",
-		Purpose: "retrieve metrics collected by the given unit/application",
+		Purpose: "Retrieve metrics collected by the given unit/application.",
 		Doc:     debugMetricsDoc,
 	}
 }
@@ -69,8 +68,8 @@ func (c *DebugMetricsCommand) Init(args []string) error {
 // SetFlags implements Command.SetFlags.
 func (c *DebugMetricsCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	f.IntVar(&c.Count, "n", 0, "number of metrics to retrieve")
-	f.BoolVar(&c.Json, "json", false, "output metrics as json")
+	f.IntVar(&c.Count, "n", 0, "Number of metrics to retrieve")
+	f.BoolVar(&c.Json, "json", false, "Output metrics as json")
 }
 
 type GetMetricsClient interface {

--- a/cmd/juju/model/retryprovisioning.go
+++ b/cmd/juju/model/retryprovisioning.go
@@ -38,7 +38,7 @@ func (c *retryProvisioningCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "retry-provisioning",
 		Args:    "<machine> [...]",
-		Purpose: "retries provisioning for failed machines",
+		Purpose: "Retries provisioning for failed machines.",
 	}
 }
 

--- a/cmd/juju/model/show.go
+++ b/cmd/juju/model/show.go
@@ -52,7 +52,7 @@ func (c *showModelCommand) getAPI() (ShowModelAPI, error) {
 func (c *showModelCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "show-model",
-		Purpose: "shows information about the current or specified model",
+		Purpose: "Shows information about the current or specified model.",
 		Doc:     showModelCommandDoc,
 	}
 }

--- a/cmd/juju/setmeterstatus/setmeterstatus.go
+++ b/cmd/juju/setmeterstatus/setmeterstatus.go
@@ -16,10 +16,15 @@ import (
 )
 
 const setMeterStatusDoc = `
-Set meter status on the given application or unit. This command is used to test the meter-status-changed hook for charms in development.
+Set meter status on the given application or unit. This command is used
+to test the meter-status-changed hook for charms in development.
+
 Examples:
-  juju set-meter-status myapp RED # Set Red meter status on all units of myapp
-  juju set-meter-status myapp/0 AMBER --info "my message" # Set AMBER meter status with "my message" as info on unit myapp/0
+    # Set Red meter status on all units of myapp
+    juju set-meter-status myapp RED
+
+    # Set AMBER meter status with "my message" as info on unit myapp/0
+    juju set-meter-status myapp/0 AMBER --info "my message"
 `
 
 // SetMeterStatusCommand sets the meter status on an application or unit. Useful for charm authors.
@@ -40,7 +45,7 @@ func (c *SetMeterStatusCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "set-meter-status",
 		Args:    "[application or unit] status",
-		Purpose: "sets the meter status on an application or unit",
+		Purpose: "Sets the meter status on an application or unit.",
 		Doc:     setMeterStatusDoc,
 	}
 }

--- a/cmd/juju/status/history.go
+++ b/cmd/juju/status/history.go
@@ -58,17 +58,17 @@ func (c *statusHistoryCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "status-history",
 		Args:    "<entity name>",
-		Purpose: "output past statuses for the passed entity",
+		Purpose: "Output past statuses for the specified entity.",
 		Doc:     statusHistoryDoc,
 	}
 }
 
 func (c *statusHistoryCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.StringVar(&c.outputContent, "type", "unit", "type of statuses to be displayed [agent|workload|combined|machine|machineInstance|container|containerinstance].")
-	f.IntVar(&c.backlogSize, "n", 0, "returns the last N logs (cannot be combined with --days or --date).")
-	f.IntVar(&c.backlogSizeDays, "days", 0, "returns the logs for the past <days> days (cannot be combined with -n or --date).")
-	f.StringVar(&c.backlogDate, "date", "", "returns logs for any date after the passed one, the expected date format is YYYY-MM-DD (cannot be combined with -n or --days).")
-	f.BoolVar(&c.isoTime, "utc", false, "display time as UTC in RFC3339 format")
+	f.StringVar(&c.outputContent, "type", "unit", "Type of statuses to be displayed [agent|workload|combined|machine|machineInstance|container|containerinstance]")
+	f.IntVar(&c.backlogSize, "n", 0, "Returns the last N logs (cannot be combined with --days or --date)")
+	f.IntVar(&c.backlogSizeDays, "days", 0, "Returns the logs for the past <days> days (cannot be combined with -n or --date)")
+	f.StringVar(&c.backlogDate, "date", "", "Returns logs for any date after the passed one, the expected date format is YYYY-MM-DD (cannot be combined with -n or --days)")
+	f.BoolVar(&c.isoTime, "utc", false, "Display time as UTC in RFC3339 format")
 }
 
 func (c *statusHistoryCommand) Init(args []string) error {

--- a/cmd/juju/storage/add.go
+++ b/cmd/juju/storage/add.go
@@ -56,8 +56,8 @@ Storage constraints can be optionally ommitted.
 Model default values will be used for all ommitted constraint values.
 There is no need to comma-separate ommitted constraints. 
 
-Example:
-    Add 3 ebs storage instances for "data" storage to unit u/0:
+Examples:
+    # Add 3 ebs storage instances for "data" storage to unit u/0:
 
       juju add-storage u/0 data=ebs,1024,3 
     or
@@ -66,8 +66,8 @@ Example:
       juju add-storage u/0 data=ebs,,3 
     
     
-    Add 1 storage instances for "data" storage to unit u/0 
-    using default model provider pool:
+    # Add 1 storage instances for "data" storage to unit u/0
+    # using default model provider pool:
 
       juju add-storage u/0 data=1 
     or
@@ -113,7 +113,7 @@ func (c *addCommand) Init(args []string) (err error) {
 func (c *addCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "add-storage",
-		Purpose: "adds unit storage dynamically",
+		Purpose: "Adds unit storage dynamically.",
 		Doc:     addCommandDoc,
 		Args:    addCommandAgs,
 	}

--- a/cmd/juju/storage/list.go
+++ b/cmd/juju/storage/list.go
@@ -23,14 +23,6 @@ func NewListCommand() cmd.Command {
 
 const listCommandDoc = `
 List information about storage instances.
-
-options:
--m, --model (= "")
-   juju model to operate in
--o, --output (= "")
-   specify an output file
---format (= tabular)
-   specify output format (json|tabular|yaml)
 `
 
 // listCommand returns storage instances.
@@ -54,7 +46,7 @@ func (c *listCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "storage",
 		Args:    "<machineID> ...",
-		Purpose: "lists storage details",
+		Purpose: "Lists storage details.",
 		Doc:     listCommandDoc,
 		Aliases: []string{"list-storage"},
 	}
@@ -68,8 +60,8 @@ func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 		"json":    cmd.FormatJson,
 		"tabular": formatListTabular,
 	})
-	f.BoolVar(&c.filesystem, "filesystem", false, "list filesystem storage")
-	f.BoolVar(&c.volume, "volume", false, "list volume storage")
+	f.BoolVar(&c.filesystem, "filesystem", false, "List filesystem storage")
+	f.BoolVar(&c.volume, "volume", false, "List volume storage")
 }
 
 // Run implements Command.Run.

--- a/cmd/juju/storage/poolcreate.go
+++ b/cmd/juju/storage/poolcreate.go
@@ -19,8 +19,6 @@ type PoolCreateAPI interface {
 }
 
 const poolCreateCommandDoc = `
-Create or define a storage pool.
-
 Pools are a mechanism for administrators to define sources of storage that
 they will use to satisfy application storage requirements.
 
@@ -37,19 +35,8 @@ Creating pools there maps provider specific settings
 into named resources that can be used during deployment.
 
 Pools defined at the model level are easily reused across applications.
-
-options:
-    -m, --model (= "")
-        juju model to operate in
-    -o, --output (= "")
-        specify an output file
-    <name>
-        pool name
-    <provider type>
-        pool provider type
-    <key>=<value> (<key>=<value> ...)
-        pool configuration attributes as space-separated pairs, 
-        for e.g. tags, size, path, etc...
+Pool creation requires a pool name, the provider type and attributes for
+configuration as space-separated pairs, e.g. tags, size, path, etc.
 `
 
 // NewPoolCreateCommand returns a command that creates or defines a storage pool
@@ -101,7 +88,7 @@ func (c *poolCreateCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "create-storage-pool",
 		Args:    "<name> <provider> [<key>=<value> [<key>=<value>...]]",
-		Purpose: "create storage pool",
+		Purpose: "Create or define a storage pool.",
 		Doc:     poolCreateCommandDoc,
 	}
 }

--- a/cmd/juju/storage/poollist.go
+++ b/cmd/juju/storage/poollist.go
@@ -34,7 +34,6 @@ func formatPoolInfo(all []params.StoragePool) map[string]PoolInfo {
 }
 
 const poolListCommandDoc = `
-Lists storage pools.
 The user can filter on pool type, name.
 
 If no filter is specified, all current pools are listed.
@@ -45,19 +44,6 @@ If only types are specified, all pools of the specified types will be listed.
 
 Both pool types and names must be valid.
 Valid pool types are pool types that are registered for Juju model.
-
-options:
--m, --model (= "")
-   juju model to operate in
--o, --output (= "")
-   specify an output file
---format (= yaml)
-   specify output format (json|tabular|yaml)
---provider
-   pool provider type
---name
-   pool name
-
 `
 
 // NewPoolListCommand returns a command that lists storage pools on a model
@@ -87,7 +73,7 @@ func (c *poolListCommand) Init(args []string) (err error) {
 func (c *poolListCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "storage-pools",
-		Purpose: "list storage pools",
+		Purpose: "List storage pools.",
 		Doc:     poolListCommandDoc,
 		Aliases: []string{"list-storage-pools"},
 	}
@@ -96,8 +82,8 @@ func (c *poolListCommand) Info() *cmd.Info {
 // SetFlags implements Command.SetFlags.
 func (c *poolListCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.StorageCommandBase.SetFlags(f)
-	f.Var(cmd.NewAppendStringsValue(&c.Providers), "provider", "only show pools of these provider types")
-	f.Var(cmd.NewAppendStringsValue(&c.Names), "name", "only show pools with these names")
+	f.Var(cmd.NewAppendStringsValue(&c.Providers), "provider", "Only show pools of these provider types")
+	f.Var(cmd.NewAppendStringsValue(&c.Names), "name", "Only show pools with these names")
 
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"yaml":    cmd.FormatYaml,

--- a/cmd/juju/storage/show.go
+++ b/cmd/juju/storage/show.go
@@ -28,15 +28,6 @@ Show extended information about storage instances.
 Storage instances to display are specified by storage ids.
 
 * note use of positional arguments
-
-options:
--m, --model (= "")
-   juju model to operate in
--o, --output (= "")
-   specify an output file
---format (= yaml)
-   specify output format (json|yaml)
-[space separated storage ids]
 `
 
 // showCommand attempts to release storage instance.
@@ -60,7 +51,8 @@ func (c *showCommand) Init(args []string) (err error) {
 func (c *showCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "show-storage",
-		Purpose: "shows storage instance",
+		Args:    "<storage ID> [...]",
+		Purpose: "Shows storage instance information.",
 		Doc:     showCommandDoc,
 	}
 }

--- a/cmd/juju/subnet/add.go
+++ b/cmd/juju/subnet/add.go
@@ -53,7 +53,7 @@ func (c *addCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "add-subnet",
 		Args:    "<CIDR>|<provider-id> <space> [<zone1> <zone2> ...]",
-		Purpose: "add an existing subnet to Juju",
+		Purpose: "Add an existing subnet to Juju.",
 		Doc:     strings.TrimSpace(addCommandDoc),
 	}
 }

--- a/cmd/juju/subnet/list.go
+++ b/cmd/juju/subnet/list.go
@@ -51,7 +51,7 @@ func (c *listCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "subnets",
 		Args:    "[--space <name>] [--zone <name>] [--format yaml|json] [--output <path>]",
-		Purpose: "list subnets known to Juju",
+		Purpose: "List subnets known to Juju.",
 		Doc:     strings.TrimSpace(listCommandDoc),
 		Aliases: []string{"list-subnets"},
 	}
@@ -65,8 +65,8 @@ func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 		"json": cmd.FormatJson,
 	})
 
-	f.StringVar(&c.SpaceName, "space", "", "filter results by space name")
-	f.StringVar(&c.ZoneName, "zone", "", "filter results by zone name")
+	f.StringVar(&c.SpaceName, "space", "", "Filter results by space name")
+	f.StringVar(&c.ZoneName, "zone", "", "Filter results by zone name")
 }
 
 // Init is defined on the cmd.Command interface. It checks the

--- a/cmd/juju/user/logout.go
+++ b/cmd/juju/user/logout.go
@@ -27,12 +27,11 @@ will not be affected by this command; it only affects the local client.
 By default, the controller is the current controller.
 
 Examples:
-
     juju logout
 
-See also:
-    change-user-password
-    login
+See Also:
+    juju change-user-password
+    juju login
 
 `
 
@@ -64,7 +63,7 @@ func (c *logoutCommand) Init(args []string) error {
 // SetFlags implements Command.SetFlags.
 func (c *logoutCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ControllerCommandBase.SetFlags(f)
-	f.BoolVar(&c.Force, "force", false, "force logout when a locally recorded password is detected")
+	f.BoolVar(&c.Force, "force", false, "Force logout when a locally recorded password is detected")
 }
 
 // Run implements Command.Run.

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -30,7 +30,7 @@ github.com/juju/mutex	git	59c26ee163447c5c57f63ff71610d433862013de	2016-06-17T01
 github.com/juju/persistent-cookiejar	git	e710b897c13ca52828ca2fc9769465186fd6d15c	2016-03-31T17:12:27Z
 github.com/juju/replicaset	git	fb7294cf57a1e2f08a57691f1246d129a87ab7e8	2015-05-08T02:21:43Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
-github.com/juju/romulus	git	2cae2c5c0166a6fe0155111814b5ce5b2e149731	2016-06-07T17:29:43Z
+github.com/juju/romulus	git	6bf2184bf0e9fe3e74d317e81a9a49a4cdcdf20b	2016-06-20T21:29:55Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/testing	git	83c7742005b3b6be70c14a980c95d5473e781180	2016-06-06T10:00:20Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z


### PR DESCRIPTION
This PR updates the command help text to follow
conventions used in the juju project, such as:

- Summary / Purpose begins with a capital letter
  and ends with a period
- Flag descriptions begin with a capital letter,
  but do not have a period
- Examples are of the format:
    Examples:
        # Description
        juju command

This is not a complete update, as many commands
need to update their 'See Also' sections, but it
gets us closer.

(Review request: http://reviews.vapour.ws/r/5116/)