### PR TITLE
apiserver/migrationmaster: Add accces to minion reports

### DIFF
--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -144,3 +144,87 @@ func (c *Client) Export() (SerializedModel, error) {
 func (c *Client) Reap() error {
 	return c.caller.FacadeCall("Reap", nil, nil)
 }
+
+// WatchMinionReports returns a watcher which reports when a migration
+// minion has made a report for the current migration phase.
+func (c *Client) WatchMinionReports() (watcher.NotifyWatcher, error) {
+	var result params.NotifyWatchResult
+	err := c.caller.FacadeCall("WatchMinionReports", nil, &result)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	w := apiwatcher.NewNotifyWatcher(c.caller.RawAPICaller(), result)
+	return w, nil
+}
+
+// MinionReports returns information about the migration minion
+// reports received so far for a given migration phase.
+type MinionReports struct {
+	MigrationId         string
+	Phase               migration.Phase
+	SuccessCount        int
+	UnknownCount        int
+	SomeUnknownMachines []string // machine ids
+	SomeUnknownUnits    []string // unit names
+	FailedMachines      []string // machine ids
+	FailedUnits         []string // unit names
+}
+
+// GetMinionReports returns details of the reports made by migration
+// minions to the controller for the current migration phase.
+func (c *Client) GetMinionReports() (MinionReports, error) {
+	var in params.MinionReports
+	var out MinionReports
+
+	err := c.caller.FacadeCall("GetMinionReports", nil, &in)
+	if err != nil {
+		return out, errors.Trace(err)
+	}
+
+	out.MigrationId = in.MigrationId
+
+	phase, ok := migration.ParsePhase(in.Phase)
+	if !ok {
+		return out, errors.Errorf("invalid phase: %q", in.Phase)
+	}
+	out.Phase = phase
+
+	out.SuccessCount = in.SuccessCount
+	out.UnknownCount = in.UnknownCount
+
+	out.SomeUnknownMachines, out.SomeUnknownUnits, err = groupTagIds(in.UnknownSample)
+	if err != nil {
+		return out, errors.Annotate(err, "processing unknown agents")
+	}
+
+	out.FailedMachines, out.FailedUnits, err = groupTagIds(in.Failed)
+	if err != nil {
+		return out, errors.Annotate(err, "processing failed agents")
+	}
+
+	return out, nil
+}
+
+func groupTagIds(tagStrs []string) ([]string, []string, error) {
+	var machines []string
+	var units []string
+
+	for i := 0; i < len(tagStrs); i++ {
+		tag, err := names.ParseTag(tagStrs[i])
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		switch t := tag.(type) {
+		case names.MachineTag:
+			machines = append(machines, t.Id())
+		case names.UnitTag:
+			units = append(units, t.Id())
+		default:
+			return nil, nil, errors.Errorf("unsupported tag: %q", tag)
+		}
+	}
+	return machines, units, nil
+}

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -38,7 +38,6 @@ func (s *ClientSuite) TestWatch(c *gc.C) {
 				NotifyWatcherId: "abc",
 			}
 		case "Next":
-			// The full success case is tested in api/watcher.
 			return errors.New("boom")
 		case "Stop":
 		}
@@ -209,4 +208,143 @@ func (s *ClientSuite) TestReapError(c *gc.C) {
 	client := migrationmaster.NewClient(apiCaller)
 	err := client.Reap()
 	c.Assert(err, gc.ErrorMatches, "blam")
+}
+
+func (s *ClientSuite) TestWatchMinionReports(c *gc.C) {
+	var stub jujutesting.Stub
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		stub.AddCall(objType+"."+request, id, arg)
+		switch request {
+		case "WatchMinionReports":
+			*(result.(*params.NotifyWatchResult)) = params.NotifyWatchResult{
+				NotifyWatcherId: "abc",
+			}
+		case "Next":
+			return errors.New("boom")
+		case "Stop":
+		}
+		return nil
+	})
+
+	client := migrationmaster.NewClient(apiCaller)
+	w, err := client.WatchMinionReports()
+	c.Assert(err, jc.ErrorIsNil)
+	defer worker.Stop(w)
+
+	errC := make(chan error)
+	go func() {
+		errC <- w.Wait()
+	}()
+
+	select {
+	case err := <-errC:
+		c.Assert(err, gc.ErrorMatches, "boom")
+		expectedCalls := []jujutesting.StubCall{
+			{"MigrationMaster.WatchMinionReports", []interface{}{"", nil}},
+			{"NotifyWatcher.Next", []interface{}{"abc", nil}},
+			{"NotifyWatcher.Stop", []interface{}{"abc", nil}},
+		}
+		// The Stop API call happens in a separate goroutine which
+		// might execute after the worker has exited so wait for the
+		// expected calls to arrive.
+		for a := coretesting.LongAttempt.Start(); a.Next(); {
+			if len(stub.Calls()) >= len(expectedCalls) {
+				return
+			}
+		}
+		stub.CheckCalls(c, expectedCalls)
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for watcher to die")
+	}
+}
+
+func (s *ClientSuite) TestGetMinionReports(c *gc.C) {
+	var stub jujutesting.Stub
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		stub.AddCall(objType+"."+request, id, arg)
+		out := result.(*params.MinionReports)
+		*out = params.MinionReports{
+			MigrationId:  "id",
+			Phase:        "READONLY",
+			SuccessCount: 4,
+			UnknownCount: 3,
+			UnknownSample: []string{
+				names.NewMachineTag("3").String(),
+				names.NewMachineTag("4").String(),
+				names.NewUnitTag("foo/0").String(),
+			},
+			Failed: []string{
+				names.NewMachineTag("5").String(),
+				names.NewUnitTag("foo/1").String(),
+				names.NewUnitTag("foo/2").String(),
+			},
+		}
+		return nil
+	})
+	client := migrationmaster.NewClient(apiCaller)
+	out, err := client.GetMinionReports()
+	c.Assert(err, jc.ErrorIsNil)
+	stub.CheckCalls(c, []jujutesting.StubCall{
+		{"MigrationMaster.GetMinionReports", []interface{}{"", nil}},
+	})
+	c.Assert(out, gc.DeepEquals, migrationmaster.MinionReports{
+		MigrationId:         "id",
+		Phase:               migration.READONLY,
+		SuccessCount:        4,
+		UnknownCount:        3,
+		SomeUnknownMachines: []string{"3", "4"},
+		SomeUnknownUnits:    []string{"foo/0"},
+		FailedMachines:      []string{"5"},
+		FailedUnits:         []string{"foo/1", "foo/2"},
+	})
+}
+
+func (s *ClientSuite) TestGetMinionReportsFailedCall(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(string, int, string, string, interface{}, interface{}) error {
+		return errors.New("blam")
+	})
+	client := migrationmaster.NewClient(apiCaller)
+	_, err := client.GetMinionReports()
+	c.Assert(err, gc.ErrorMatches, "blam")
+}
+
+func (s *ClientSuite) TestGetMinionReportsInvalidPhase(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(_ string, _ int, _ string, _ string, _ interface{}, result interface{}) error {
+		out := result.(*params.MinionReports)
+		*out = params.MinionReports{
+			Phase: "BLARGH",
+		}
+		return nil
+	})
+	client := migrationmaster.NewClient(apiCaller)
+	_, err := client.GetMinionReports()
+	c.Assert(err, gc.ErrorMatches, `invalid phase: "BLARGH"`)
+}
+
+func (s *ClientSuite) TestGetMinionReportsBadUnknownTag(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(_ string, _ int, _ string, _ string, _ interface{}, result interface{}) error {
+		out := result.(*params.MinionReports)
+		*out = params.MinionReports{
+			Phase:         "READONLY",
+			UnknownSample: []string{"carl"},
+		}
+		return nil
+	})
+	client := migrationmaster.NewClient(apiCaller)
+	_, err := client.GetMinionReports()
+	c.Assert(err, gc.ErrorMatches, `processing unknown agents: "carl" is not a valid tag`)
+}
+
+func (s *ClientSuite) TestGetMinionReportsBadFailedTag(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(_ string, _ int, _ string, _ string, _ interface{}, result interface{}) error {
+		out := result.(*params.MinionReports)
+		*out = params.MinionReports{
+			Phase:  "READONLY",
+			Failed: []string{"dave"},
+		}
+		return nil
+	})
+	client := migrationmaster.NewClient(apiCaller)
+	_, err := client.GetMinionReports()
+	c.Assert(err, gc.ErrorMatches, `processing failed agents: "dave" is not a valid tag`)
 }

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -110,7 +110,7 @@ func (s *ClientSuite) TestGetMigrationStatus(c *gc.C) {
 
 	status, err := client.GetMigrationStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.DeepEquals, migrationmaster.MigrationStatus{
+	c.Assert(status, gc.DeepEquals, migration.MigrationStatus{
 		ModelUUID: modelUUID,
 		Attempt:   3,
 		Phase:     migration.READONLY,
@@ -169,7 +169,7 @@ func (s *ClientSuite) TestExport(c *gc.C) {
 	stub.CheckCalls(c, []jujutesting.StubCall{
 		{"MigrationMaster.Export", []interface{}{"", nil}},
 	})
-	c.Assert(out, gc.DeepEquals, migrationmaster.SerializedModel{
+	c.Assert(out, gc.DeepEquals, migration.SerializedModel{
 		Bytes:  []byte("foo"),
 		Charms: []string{"cs:foo-1"},
 		Tools: map[version.Binary]string{
@@ -287,7 +287,7 @@ func (s *ClientSuite) TestGetMinionReports(c *gc.C) {
 	stub.CheckCalls(c, []jujutesting.StubCall{
 		{"MigrationMaster.GetMinionReports", []interface{}{"", nil}},
 	})
-	c.Assert(out, gc.DeepEquals, migrationmaster.MinionReports{
+	c.Assert(out, gc.DeepEquals, migration.MinionReports{
 		MigrationId:         "id",
 		Phase:               migration.READONLY,
 		SuccessCount:        4,

--- a/core/migration/migration.go
+++ b/core/migration/migration.go
@@ -1,0 +1,74 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migration
+
+import "github.com/juju/version"
+
+// MigrationStatus returns the details for a migration as needed by
+// the migration master worker.
+type MigrationStatus struct {
+	// ModelUUID holds the UUID of the model being migrated.
+	ModelUUID string
+
+	// Attempt specifies the migration attempt number. This is
+	// incremeted for each attempt to migrate a model.
+	Attempt int
+
+	// Phases indicates the current migration phase.
+	Phase Phase
+
+	// TargetInfo contains the details of how to connect to the target
+	// controller.
+	TargetInfo TargetInfo
+}
+
+// SerializedModel wraps a buffer contain a serialised Juju model as
+// well as containing metadata about the charms and tools used by the
+// model.
+type SerializedModel struct {
+	// Bytes contains the serialized data for the model.
+	Bytes []byte
+
+	// Charms lists the charm URLs in use in the model.
+	Charms []string
+
+	// Tools lists the tools versions in use with the model along with
+	// their URIs. The URIs can be used to download the tools from the
+	// source controller.
+	Tools map[version.Binary]string // version -> tools URI
+}
+
+// MinionReports returns information about the migration minion
+// reports received so far for a given migration phase.
+type MinionReports struct {
+	// ModelUUID holds the unique identifier for the model migration.
+	MigrationId string
+
+	// Phases indicates the migration phase the reports relate to.
+	Phase Phase
+
+	// SuccesCount indicates how many agents have successfully
+	// completed the migration phase.
+	SuccessCount int
+
+	// UnknownCount indicates how many agents are yet to report
+	// regarding the migration phase.
+	UnknownCount int
+
+	// SomeUnknownMachines holds the ids of some of the machines which
+	// have not yet reported in.
+	SomeUnknownMachines []string
+
+	// SomeUnknownUnits holds the names of some of the units which
+	// have not yet reported in.
+	SomeUnknownUnits []string
+
+	// FailedMachines holds the ids of machines which have failed to
+	// complete the migration phase.
+	FailedMachines []string
+
+	// FailedUnits holds the names of units which have failed to
+	// complete the migration phase.
+	FailedUnits []string
+}

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -11,7 +11,6 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api"
-	"github.com/juju/juju/api/migrationmaster"
 	"github.com/juju/juju/api/migrationtarget"
 	"github.com/juju/juju/apiserver/params"
 	coremigration "github.com/juju/juju/core/migration"
@@ -40,7 +39,7 @@ type Facade interface {
 
 	// GetMigrationStatus returns the details and progress of the
 	// latest model migration.
-	GetMigrationStatus() (migrationmaster.MigrationStatus, error)
+	GetMigrationStatus() (coremigration.MigrationStatus, error)
 
 	// SetPhase updates the phase of the currently active model
 	// migration.
@@ -48,7 +47,7 @@ type Facade interface {
 
 	// Export returns a serialized representation of the model
 	// associated with the API connection.
-	Export() (migrationmaster.SerializedModel, error)
+	Export() (coremigration.SerializedModel, error)
 
 	// Reap removes all documents of the model associated with the API
 	// connection.
@@ -333,8 +332,8 @@ func (w *Worker) removeImportedModel(targetInfo coremigration.TargetInfo, modelU
 	return errors.Trace(err)
 }
 
-func (w *Worker) waitForActiveMigration() (migrationmaster.MigrationStatus, error) {
-	var empty migrationmaster.MigrationStatus
+func (w *Worker) waitForActiveMigration() (coremigration.MigrationStatus, error) {
+	var empty coremigration.MigrationStatus
 
 	watcher, err := w.config.Facade.Watch()
 	if err != nil {

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -14,7 +14,6 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api"
-	masterapi "github.com/juju/juju/api/migrationmaster"
 	"github.com/juju/juju/apiserver/params"
 	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/juju/migration"
@@ -471,7 +470,7 @@ func newStubMasterFacade(stub *jujutesting.Stub) *stubMasterFacade {
 	return &stubMasterFacade{
 		stub:           stub,
 		watcherChanges: make(chan struct{}, 1),
-		status: masterapi.MigrationStatus{
+		status: coremigration.MigrationStatus{
 			ModelUUID: "model-uuid",
 			Attempt:   2,
 			Phase:     coremigration.QUIESCE,
@@ -492,7 +491,7 @@ type stubMasterFacade struct {
 	stub           *jujutesting.Stub
 	watcherChanges chan struct{}
 	watchErr       error
-	status         masterapi.MigrationStatus
+	status         coremigration.MigrationStatus
 	statusErr      error
 	exportErr      error
 }
@@ -506,20 +505,20 @@ func (c *stubMasterFacade) Watch() (watcher.NotifyWatcher, error) {
 	return newMockWatcher(c.watcherChanges), nil
 }
 
-func (c *stubMasterFacade) GetMigrationStatus() (masterapi.MigrationStatus, error) {
+func (c *stubMasterFacade) GetMigrationStatus() (coremigration.MigrationStatus, error) {
 	c.stub.AddCall("masterFacade.GetMigrationStatus")
 	if c.statusErr != nil {
-		return masterapi.MigrationStatus{}, c.statusErr
+		return coremigration.MigrationStatus{}, c.statusErr
 	}
 	return c.status, nil
 }
 
-func (c *stubMasterFacade) Export() (masterapi.SerializedModel, error) {
+func (c *stubMasterFacade) Export() (coremigration.SerializedModel, error) {
 	c.stub.AddCall("masterFacade.Export")
 	if c.exportErr != nil {
-		return masterapi.SerializedModel{}, c.exportErr
+		return coremigration.SerializedModel{}, c.exportErr
 	}
-	return masterapi.SerializedModel{
+	return coremigration.SerializedModel{
 		Bytes:  fakeModelBytes,
 		Charms: []string{"charm0", "charm1"},
 		Tools: map[version.Binary]string{


### PR DESCRIPTION
This change adds calls to the MigrationMaster apiserver facade to allow watching for new migration minion reports, and extraction of the details of the current reports. This will be used by the migration master when waiting for minions to report back regarding their actions for specific migration phases.

Already reviewed at: http://reviews.vapour.ws/r/5106/

