### PR TITLE
Reintroduce consistent tagging to all apiserver param structures.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -237,16 +237,11 @@ func (c *Client) ModelUserInfo() ([]params.ModelUserInfo, error) {
 	return info, nil
 }
 
-// WatchAll holds the id of the newly-created AllWatcher/AllModelWatcher.
-type WatchAll struct {
-	AllWatcherId string
-}
-
 // WatchAll returns an AllWatcher, from which you can request the Next
 // collection of Deltas.
 func (c *Client) WatchAll() (*AllWatcher, error) {
-	info := new(WatchAll)
-	if err := c.facade.FacadeCall("WatchAll", nil, info); err != nil {
+	var info params.AllWatcherId
+	if err := c.facade.FacadeCall("WatchAll", nil, &info); err != nil {
 		return nil, err
 	}
 	return NewAllWatcher(c.st, &info.AllWatcherId), nil

--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -92,8 +92,8 @@ func (c *Client) RemoveBlocks() error {
 // WatchAllModels returns an AllWatcher, from which you can request
 // the Next collection of Deltas (for all models).
 func (c *Client) WatchAllModels() (*api.AllWatcher, error) {
-	info := new(api.WatchAll)
-	if err := c.facade.FacadeCall("WatchAllModels", nil, info); err != nil {
+	var info params.AllWatcherId
+	if err := c.facade.FacadeCall("WatchAllModels", nil, &info); err != nil {
 		return nil, err
 	}
 	return api.NewAllModelWatcher(c.facade.RawAPICaller(), &info.AllWatcherId), nil

--- a/api/http.go
+++ b/api/http.go
@@ -126,7 +126,7 @@ func unmarshalHTTPErrorResponse(resp *http.Response) error {
 	// and determine the expected error type from that, but that
 	// seems more fragile than this approach.
 	type genericErrorResponse struct {
-		Error json.RawMessage
+		Error json.RawMessage `json:"error"`
 	}
 	var generic genericErrorResponse
 	if err := json.Unmarshal(body, &generic); err != nil {

--- a/api/http_test.go
+++ b/api/http_test.go
@@ -73,8 +73,8 @@ var httpClientTests = []struct {
 	about: "bad charms error response",
 	handler: func(w http.ResponseWriter, req *http.Request) {
 		type badResponse struct {
-			Error    string
-			CharmURL map[string]int
+			Error    string         `json:"error"`
+			CharmURL map[string]int `json:"charm-url"`
 		}
 		httprequest.WriteJSON(w, http.StatusUnauthorized, badResponse{
 			Error:    "something",
@@ -150,17 +150,17 @@ func (s *httpSuite) TestHTTPClient(c *gc.C) {
 		}
 		err := s.client.Get("/", resp)
 		if test.expectError != "" {
-			c.Assert(err, gc.ErrorMatches, test.expectError)
-			c.Assert(params.ErrCode(err), gc.Equals, test.expectErrorCode)
+			c.Check(err, gc.ErrorMatches, test.expectError)
+			c.Check(params.ErrCode(err), gc.Equals, test.expectErrorCode)
 			if err, ok := errors.Cause(err).(*params.Error); ok {
-				c.Assert(err.Info, jc.DeepEquals, test.expectErrorInfo)
+				c.Check(err.Info, jc.DeepEquals, test.expectErrorInfo)
 			} else if test.expectErrorInfo != nil {
 				c.Fatalf("no error info found in error")
 			}
 			continue
 		}
-		c.Assert(err, gc.IsNil)
-		c.Assert(resp, jc.DeepEquals, test.expectResponse)
+		c.Check(err, gc.IsNil)
+		c.Check(resp, jc.DeepEquals, test.expectResponse)
 	}
 }
 

--- a/apiserver/agent/agent.go
+++ b/apiserver/agent/agent.go
@@ -92,12 +92,26 @@ func (api *AgentAPIV2) getEntity(tag names.Tag) (result params.AgentGetEntitiesR
 	return
 }
 
-func (api *AgentAPIV2) StateServingInfo() (result state.StateServingInfo, err error) {
+func (api *AgentAPIV2) StateServingInfo() (result params.StateServingInfo, err error) {
 	if !api.auth.AuthModelManager() {
 		err = common.ErrPerm
 		return
 	}
-	return api.st.StateServingInfo()
+	info, err := api.st.StateServingInfo()
+	if err != nil {
+		return params.StateServingInfo{}, errors.Trace(err)
+	}
+	result = params.StateServingInfo{
+		APIPort:        info.APIPort,
+		StatePort:      info.StatePort,
+		Cert:           info.Cert,
+		PrivateKey:     info.PrivateKey,
+		CAPrivateKey:   info.CAPrivateKey,
+		SharedSecret:   info.SharedSecret,
+		SystemIdentity: info.SystemIdentity,
+	}
+
+	return result, nil
 }
 
 // MongoIsMaster is called by the IsMaster API call

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/series"
 	"github.com/juju/version"
@@ -625,6 +626,7 @@ func (s *clientRepoSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *clientSuite) TestClientWatchAll(c *gc.C) {
+	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
 	// A very simple end-to-end test, because
 	// all the logic is tested elsewhere.
 	m, err := s.State.AddMachine("quantal", state.JobManageModel)

--- a/apiserver/params/actions.go
+++ b/apiserver/params/actions.go
@@ -115,7 +115,7 @@ type ActionExecutionResults struct {
 // ActionExecutionResult holds the action tag and output used when
 // recording the result of an action.
 type ActionExecutionResult struct {
-	ActionTag string                 `json:"actiontag"`
+	ActionTag string                 `json:"action-tag"`
 	Status    string                 `json:"status"`
 	Results   map[string]interface{} `json:"results,omitempty"`
 	Message   string                 `json:"message,omitempty"`
@@ -131,7 +131,7 @@ type ApplicationsCharmActionsResults struct {
 // If an error such as a missing charm or malformed application name occurs, it
 // is encapsulated in this type.
 type ApplicationCharmActionsResult struct {
-	ApplicationTag string         `json:"ApplicationTag,omitempty"`
+	ApplicationTag string         `json:"application-tag,omitempty"`
 	Actions        *charm.Actions `json:"actions,omitempty"`
 	Error          *Error         `json:"error,omitempty"`
 }

--- a/apiserver/params/annotations.go
+++ b/apiserver/params/annotations.go
@@ -5,23 +5,23 @@ package params
 
 // AnnotationsGetResult holds entity annotations or retrieval error.
 type AnnotationsGetResult struct {
-	EntityTag   string
-	Annotations map[string]string
-	Error       ErrorResult
+	EntityTag   string            `json:"entity"`
+	Annotations map[string]string `json:"annotations"`
+	Error       ErrorResult       `json:"error,omitempty"`
 }
 
 // AnnotationsGetResults holds annotations associated with entities.
 type AnnotationsGetResults struct {
-	Results []AnnotationsGetResult
+	Results []AnnotationsGetResult `json:"results"`
 }
 
 // AnnotationsSet stores parameters for making Set call on Annotations client.
 type AnnotationsSet struct {
-	Annotations []EntityAnnotations
+	Annotations []EntityAnnotations `json:"annotations"`
 }
 
 // EntityAnnotations stores annotations for an entity.
 type EntityAnnotations struct {
-	EntityTag   string
-	Annotations map[string]string
+	EntityTag   string            `json:"entity"`
+	Annotations map[string]string `json:"annotations"`
 }

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -15,9 +15,9 @@ var UpgradeInProgressError = errors.New(CodeUpgradeInProgress)
 
 // Error is the type of error returned by any call to the state API.
 type Error struct {
-	Message string
-	Code    string
-	Info    *ErrorInfo `json:",omitempty"`
+	Message string     `json:"message"`
+	Code    string     `json:"code"`
+	Info    *ErrorInfo `json:"info,omitempty"`
 }
 
 // ErrorInfo holds additional information provided by an error.
@@ -31,14 +31,14 @@ type ErrorInfo struct {
 	// discharged, may allow access to the juju API.
 	// This field is associated with the ErrDischargeRequired
 	// error code.
-	Macaroon *macaroon.Macaroon `json:",omitempty"`
+	Macaroon *macaroon.Macaroon `json:"macaroon,omitempty"`
 
 	// MacaroonPath holds the URL path to be associated
 	// with the macaroon. The macaroon is potentially
 	// valid for all URLs under the given path.
 	// If it is empty, the macaroon will be associated with
 	// the original URL from which the error was returned.
-	MacaroonPath string `json:",omitempty"`
+	MacaroonPath string `json:"macaroon-path,omitempty"`
 }
 
 func (e Error) Error() string {

--- a/apiserver/params/backups.go
+++ b/apiserver/params/backups.go
@@ -11,12 +11,12 @@ import (
 
 // BackupsCreateArgs holds the args for the API Create method.
 type BackupsCreateArgs struct {
-	Notes string
+	Notes string `json:"notes"`
 }
 
 // BackupsInfoArgs holds the args for the API Info method.
 type BackupsInfoArgs struct {
-	ID string
+	ID string `json:"id"`
 }
 
 // BackupsListArgs holds the args for the API List method.
@@ -25,55 +25,55 @@ type BackupsListArgs struct {
 
 // BackupsDownloadArgs holds the args for the API Download method.
 type BackupsDownloadArgs struct {
-	ID string
+	ID string `json:"id"`
 }
 
 // BackupsUploadArgs holds the args for the API Upload method.
 type BackupsUploadArgs struct {
-	Data     []byte
-	Metadata BackupsMetadataResult
+	Data     []byte                `json:"data"`
+	Metadata BackupsMetadataResult `json:"metadata"`
 }
 
 // BackupsRemoveArgs holds the args for the API Remove method.
 type BackupsRemoveArgs struct {
-	ID string
+	ID string `json:"id"`
 }
 
 // BackupsListResult holds the list of all stored backups.
 type BackupsListResult struct {
-	List []BackupsMetadataResult
+	List []BackupsMetadataResult `json:"list"`
 }
 
 // BackupsListResult holds the list of all stored backups.
 type BackupsUploadResult struct {
-	ID string
+	ID string `json:"id"`
 }
 
 // BackupsMetadataResult holds the metadata for a backup as returned by
 // an API backups method (such as Create).
 type BackupsMetadataResult struct {
-	ID string
+	ID string `json:"id"`
 
-	Checksum       string
-	ChecksumFormat string
-	Size           int64
-	Stored         time.Time // May be zero...
+	Checksum       string    `json:"checksum"`
+	ChecksumFormat string    `json:"checksum-format"`
+	Size           int64     `json:"size"`
+	Stored         time.Time `json:"stored"` // May be zero...
 
-	Started  time.Time
-	Finished time.Time // May be zero...
-	Notes    string
-	Model    string
-	Machine  string
-	Hostname string
-	Version  version.Number
-	Series   string
+	Started  time.Time      `json:"started"`
+	Finished time.Time      `json:"finished"` // May be zero...
+	Notes    string         `json:"notes"`
+	Model    string         `json:"model"`
+	Machine  string         `json:"machine"`
+	Hostname string         `json:"hostname"`
+	Version  version.Number `json:"version"`
+	Series   string         `json:"series"`
 
-	CACert       string
-	CAPrivateKey string
+	CACert       string `json:"ca-cert"`
+	CAPrivateKey string `json:"ca-private-key"`
 }
 
 // RestoreArgs Holds the backup file or id
 type RestoreArgs struct {
 	// BackupId holds the id of the backup in server if any
-	BackupId string
+	BackupId string `json:"backup-id"`
 }

--- a/apiserver/params/charms.go
+++ b/apiserver/params/charms.go
@@ -5,20 +5,20 @@ package params
 
 // CharmInfo stores parameters for a charms.CharmInfo call.
 type CharmInfo struct {
-	CharmURL string
+	CharmURL string `json:"charm-url"`
 }
 
 // CharmsList stores parameters for a charms.List call
 type CharmsList struct {
-	Names []string
+	Names []string `json:"names"`
 }
 
 // CharmsListResult stores result from a charms.List call
 type CharmsListResult struct {
-	CharmURLs []string
+	CharmURLs []string `json:"charm-urls"`
 }
 
 // IsMeteredResult stores result from a charms.IsMetered call
 type IsMeteredResult struct {
-	Metered bool
+	Metered bool `json:"metered"`
 }

--- a/apiserver/params/image_metadata.go
+++ b/apiserver/params/image_metadata.go
@@ -22,7 +22,7 @@ type ImageMetadataFilter struct {
 	Stream string `json:"stream,omitempty"`
 
 	// VirtType stores virtualisation type.
-	VirtType string `json:"virt_type,omitempty"`
+	VirtType string `json:"virt-type,omitempty"`
 
 	// RootStorageType stores storage type.
 	RootStorageType string `json:"root-storage-type,omitempty"`
@@ -31,7 +31,7 @@ type ImageMetadataFilter struct {
 // CloudImageMetadata holds cloud image metadata properties.
 type CloudImageMetadata struct {
 	// ImageId is an image identifier.
-	ImageId string `json:"image_id"`
+	ImageId string `json:"image-id"`
 
 	// Stream contains reference to a particular stream,
 	// for e.g. "daily" or "released"
@@ -50,13 +50,13 @@ type CloudImageMetadata struct {
 	Arch string `json:"arch"`
 
 	// VirtType contains the virtualisation type of the cloud image, for e.g. "pv", "hvm". "kvm".
-	VirtType string `json:"virt_type,omitempty"`
+	VirtType string `json:"virt-type,omitempty"`
 
 	// RootStorageType contains type of root storage, for e.g. "ebs", "instance".
-	RootStorageType string `json:"root_storage_type,omitempty"`
+	RootStorageType string `json:"root-storage-type,omitempty"`
 
 	// RootStorageSize contains size of root storage in gigabytes (GB).
-	RootStorageSize *uint64 `json:"root_storage_size,omitempty"`
+	RootStorageSize *uint64 `json:"root-storage-size,omitempty"`
 
 	// Source describes where this image is coming from: is it public? custom?
 	Source string `json:"source"`
@@ -85,5 +85,5 @@ type CloudImageMetadataList struct {
 
 // MetadataImageIds holds image ids and can be used to identify related image metadata.
 type MetadataImageIds struct {
-	Ids []string `json:"image_ids"`
+	Ids []string `json:"image-ids"`
 }

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -6,7 +6,6 @@ package params
 import (
 	"time"
 
-	"github.com/juju/utils/exec"
 	"github.com/juju/version"
 
 	"github.com/juju/juju/constraints"
@@ -19,173 +18,173 @@ import (
 // MachineContainersParams holds the arguments for making a SetSupportedContainers
 // API call.
 type MachineContainersParams struct {
-	Params []MachineContainers
+	Params []MachineContainers `json:"params"`
 }
 
 // MachineContainers holds the arguments for making an SetSupportedContainers call
 // on a given machine.
 type MachineContainers struct {
-	MachineTag     string
-	ContainerTypes []instance.ContainerType
+	MachineTag     string                   `json:"machine-tag"`
+	ContainerTypes []instance.ContainerType `json:"container-types"`
 }
 
 // WatchContainer identifies a single container type within a machine.
 type WatchContainer struct {
-	MachineTag    string
-	ContainerType string
+	MachineTag    string `json:"machine-tag"`
+	ContainerType string `json:"container-type"`
 }
 
 // WatchContainers holds the arguments for making a WatchContainers
 // API call.
 type WatchContainers struct {
-	Params []WatchContainer
+	Params []WatchContainer `json:"params"`
 }
 
 // CharmURL identifies a single charm URL.
 type CharmURL struct {
-	URL string
+	URL string `json:"url"`
 }
 
 // CharmURLs identifies multiple charm URLs.
 type CharmURLs struct {
-	URLs []CharmURL
+	URLs []CharmURL `json:"urls"`
 }
 
 // StringsResult holds the result of an API call that returns a slice
 // of strings or an error.
 type StringsResult struct {
-	Error  *Error
-	Result []string
+	Error  *Error   `json:"error,omitempty"`
+	Result []string `json:"result,omitempty"`
 }
 
 // StringsResults holds the bulk operation result of an API call
 // that returns a slice of strings or an error.
 type StringsResults struct {
-	Results []StringsResult
+	Results []StringsResult `json:"results"`
 }
 
 // StringResult holds a string or an error.
 type StringResult struct {
-	Error  *Error
-	Result string
+	Error  *Error `json:"error,omitempty"`
+	Result string `json:"result"`
 }
 
 // StringResults holds the bulk operation result of an API call
 // that returns a string or an error.
 type StringResults struct {
-	Results []StringResult
+	Results []StringResult `json:"results"`
 }
 
 // ModelResult holds the result of an API call returning a name and UUID
 // for a model.
 type ModelResult struct {
-	Error *Error
-	Name  string
-	UUID  string
+	Error *Error `json:"error,omitempty"`
+	Name  string `json:"name"`
+	UUID  string `json:"uuid"`
 }
 
 // ModelCreateArgs holds the arguments that are necessary to create
 // a model.
 type ModelCreateArgs struct {
 	// Name is the name for the new model.
-	Name string
+	Name string `json:"name"`
 
 	// OwnerTag represents the user that will own the new model.
 	// The OwnerTag must be a valid user tag.  If the user tag represents
 	// a local user, that user must exist.
-	OwnerTag string
+	OwnerTag string `json:"owner-tag"`
 
 	// Config defines the model config, which includes the name of the
 	// model. A model UUID is allocated by the API server during the
 	// creation of the model.
-	Config map[string]interface{}
+	Config map[string]interface{} `json:"config,omitempty"`
 
 	// CloudRegion is the name of the cloud region to create the
 	// model in. If the cloud does not support regions, this must
 	// be empty. If this is empty, the model will be created in
 	// the same region as the controller model.
-	CloudRegion string
+	CloudRegion string `json:"region,omitempty"`
 
 	// CloudCredential is the name of the cloud credential to use
 	// for managing the model's resources. If the cloud does not
 	// require credentials, this may be empty. If this is empty,
 	// and the owner is the controller owner, the same credential
 	// used for the controller model will be used.
-	CloudCredential string
+	CloudCredential string `json:"credential,omitempty"`
 }
 
 // Model holds the result of an API call returning a name and UUID
 // for a model and the tag of the server in which it is running.
 type Model struct {
-	Name     string `json:"Name"`
-	UUID     string `json:"UUID"`
-	OwnerTag string `json:"OwnerTag"`
+	Name     string `json:"name"`
+	UUID     string `json:"uuid"`
+	OwnerTag string `json:"owner-tag"`
 }
 
 // UserModel holds information about a model and the last
 // time the model was accessed for a particular user.
 type UserModel struct {
-	Model
-	LastConnection *time.Time
+	Model          `json:"model"`
+	LastConnection *time.Time `json:"last-connection"`
 }
 
 // UserModelList holds information about a list of models
 // for a particular user.
 type UserModelList struct {
-	UserModels []UserModel
+	UserModels []UserModel `json:"user-models"`
 }
 
 // ResolvedModeResult holds a resolved mode or an error.
 type ResolvedModeResult struct {
-	Error *Error
-	Mode  ResolvedMode
+	Error *Error       `json:"error,omitempty"`
+	Mode  ResolvedMode `json:"mode"`
 }
 
 // ResolvedModeResults holds the bulk operation result of an API call
 // that returns a resolved mode or an error.
 type ResolvedModeResults struct {
-	Results []ResolvedModeResult
+	Results []ResolvedModeResult `json:"results"`
 }
 
 // StringBoolResult holds the result of an API call that returns a
 // string and a boolean.
 type StringBoolResult struct {
-	Error  *Error
-	Result string
-	Ok     bool
+	Error  *Error `json:"error,omitempty"`
+	Result string `json:"result"`
+	Ok     bool   `json:"ok"`
 }
 
 // StringBoolResults holds multiple results with a string and a bool
 // each.
 type StringBoolResults struct {
-	Results []StringBoolResult
+	Results []StringBoolResult `json:"results"`
 }
 
 // BoolResult holds the result of an API call that returns a
 // a boolean or an error.
 type BoolResult struct {
-	Error  *Error
-	Result bool
+	Error  *Error `json:"error,omitempty"`
+	Result bool   `json:"result"`
 }
 
 // BoolResults holds multiple results with BoolResult each.
 type BoolResults struct {
-	Results []BoolResult
+	Results []BoolResult `json:"results"`
 }
 
 // IntResults holds multiple results with an int in each.
 type IntResults struct {
 	// Results holds a list of results for calls that return an int or error.
-	Results []IntResult
+	Results []IntResult `json:"results"`
 }
 
 // IntResult holds the result of an API call that returns a
 // int or an error.
 type IntResult struct {
 	// Error holds the error (if any) of this call.
-	Error *Error
+	Error *Error `json:"error,omitempty"`
 	// Result holds the integer result of the call (if Error is nil).
-	Result int
+	Result int `json:"result"`
 }
 
 // Settings holds relation settings names and values.
@@ -193,14 +192,14 @@ type Settings map[string]string
 
 // SettingsResult holds a relation settings map or an error.
 type SettingsResult struct {
-	Error    *Error
-	Settings Settings
+	Error    *Error   `json:"error,omitempty"`
+	Settings Settings `json:"settings"`
 }
 
 // SettingsResults holds the result of an API calls that
 // returns settings for multiple relations.
 type SettingsResults struct {
-	Results []SettingsResult
+	Results []SettingsResult `json:"results"`
 }
 
 // ConfigSettings holds unit, application or cham configuration settings
@@ -209,13 +208,13 @@ type ConfigSettings map[string]interface{}
 
 // ConfigSettingsResult holds a configuration map or an error.
 type ConfigSettingsResult struct {
-	Error    *Error
-	Settings ConfigSettings
+	Error    *Error         `json:"error,omitempty"`
+	Settings ConfigSettings `json:"settings"`
 }
 
 // ConfigSettingsResults holds multiple configuration maps or errors.
 type ConfigSettingsResults struct {
-	Results []ConfigSettingsResult
+	Results []ConfigSettingsResult `json:"results"`
 }
 
 // ModelConfig holds a model configuration.
@@ -226,260 +225,260 @@ type ControllerConfig map[string]interface{}
 
 // ModelConfigResult holds model configuration.
 type ModelConfigResult struct {
-	Config ModelConfig
+	Config ModelConfig `json:"config"`
 }
 
 // ControllerConfigResult holds controller configuration.
 type ControllerConfigResult struct {
-	Config ControllerConfig
+	Config ControllerConfig `json:"config"`
 }
 
 // RelationUnit holds a relation and a unit tag.
 type RelationUnit struct {
-	Relation string
-	Unit     string
+	Relation string `json:"relation"`
+	Unit     string `json:"unit"`
 }
 
 // RelationUnits holds the parameters for API calls expecting a pair
 // of relation and unit tags.
 type RelationUnits struct {
-	RelationUnits []RelationUnit
+	RelationUnits []RelationUnit `json:"relation-units"`
 }
 
 // RelationIds holds multiple relation ids.
 type RelationIds struct {
-	RelationIds []int
+	RelationIds []int `json:"relation-ids"`
 }
 
 // RelationUnitPair holds a relation tag, a local and remote unit tags.
 type RelationUnitPair struct {
-	Relation   string
-	LocalUnit  string
-	RemoteUnit string
+	Relation   string `json:"relation"`
+	LocalUnit  string `json:"local-unit"`
+	RemoteUnit string `json:"remote-unit"`
 }
 
 // RelationUnitPairs holds the parameters for API calls expecting
 // multiple sets of a relation tag, a local and remote unit tags.
 type RelationUnitPairs struct {
-	RelationUnitPairs []RelationUnitPair
+	RelationUnitPairs []RelationUnitPair `json:"relation-unit-pairs"`
 }
 
 // RelationUnitSettings holds a relation tag, a unit tag and local
 // unit settings.
 type RelationUnitSettings struct {
-	Relation string
-	Unit     string
-	Settings Settings
+	Relation string   `json:"relation"`
+	Unit     string   `json:"unit"`
+	Settings Settings `json:"settings"`
 }
 
 // RelationUnitsSettings holds the arguments for making a EnterScope
 // or WriteSettings API calls.
 type RelationUnitsSettings struct {
-	RelationUnits []RelationUnitSettings
+	RelationUnits []RelationUnitSettings `json:"relation-units"`
 }
 
 // RelationResult returns information about a single relation,
 // or an error.
 type RelationResult struct {
-	Error    *Error
-	Life     Life
-	Id       int
-	Key      string
-	Endpoint multiwatcher.Endpoint
+	Error    *Error                `json:"error,omitempty"`
+	Life     Life                  `json:"life"`
+	Id       int                   `json:"id"`
+	Key      string                `json:"key"`
+	Endpoint multiwatcher.Endpoint `json:"endpoint"`
 }
 
 // RelationResults holds the result of an API call that returns
 // information about multiple relations.
 type RelationResults struct {
-	Results []RelationResult
+	Results []RelationResult `json:"results"`
 }
 
 // EntityCharmURL holds an entity's tag and a charm URL.
 type EntityCharmURL struct {
-	Tag      string
-	CharmURL string
+	Tag      string `json:"tag"`
+	CharmURL string `json:"charm-url"`
 }
 
 // EntitiesCharmURL holds the parameters for making a SetCharmURL API
 // call.
 type EntitiesCharmURL struct {
-	Entities []EntityCharmURL
+	Entities []EntityCharmURL `json:"entities"`
 }
 
 // BytesResult holds the result of an API call that returns a slice
 // of bytes.
 type BytesResult struct {
-	Result []byte
+	Result []byte `json:"result"`
 }
 
 // LifeResult holds the life status of a single entity, or an error
 // indicating why it is not available.
 type LifeResult struct {
-	Life  Life
-	Error *Error
+	Life  Life   `json:"life"`
+	Error *Error `json:"error,omitempty"`
 }
 
 // LifeResults holds the life or error status of multiple entities.
 type LifeResults struct {
-	Results []LifeResult
+	Results []LifeResult `json:"results"`
 }
 
 // InstanceInfo holds a machine tag, provider-specific instance id, a nonce, and
 // network config.
 type InstanceInfo struct {
-	Tag             string
-	InstanceId      instance.Id
-	Nonce           string
-	Characteristics *instance.HardwareCharacteristics
-	Volumes         []Volume
+	Tag             string                            `json:"tag"`
+	InstanceId      instance.Id                       `json:"instance-id"`
+	Nonce           string                            `json:"nonce"`
+	Characteristics *instance.HardwareCharacteristics `json:"characteristics"`
+	Volumes         []Volume                          `json:"volumes"`
 	// VolumeAttachments is a mapping from volume tag to
 	// volume attachment info.
-	VolumeAttachments map[string]VolumeAttachmentInfo
+	VolumeAttachments map[string]VolumeAttachmentInfo `json:"volume-attachments"`
 
-	NetworkConfig []NetworkConfig
+	NetworkConfig []NetworkConfig `json:"network-config"`
 }
 
 // InstancesInfo holds the parameters for making a SetInstanceInfo
 // call for multiple machines.
 type InstancesInfo struct {
-	Machines []InstanceInfo
+	Machines []InstanceInfo `json:"machines"`
 }
 
 // EntityStatus holds the status of an entity.
 type EntityStatus struct {
-	Status status.Status
-	Info   string
-	Data   map[string]interface{}
-	Since  *time.Time
+	Status status.Status          `json:"status"`
+	Info   string                 `json:"info"`
+	Data   map[string]interface{} `json:"data,omitempty"`
+	Since  *time.Time             `json:"since"`
 }
 
 // EntityStatusArgs holds parameters for setting the status of a single entity.
 type EntityStatusArgs struct {
-	Tag    string                 `json:"Tag"`
-	Status string                 `json:"Status"`
-	Info   string                 `json:"Info"`
-	Data   map[string]interface{} `json:"Data"`
+	Tag    string                 `json:"tag"`
+	Status string                 `json:"status"`
+	Info   string                 `json:"info"`
+	Data   map[string]interface{} `json:"data"`
 }
 
 // SetStatus holds the parameters for making a SetStatus/UpdateStatus call.
 type SetStatus struct {
-	Entities []EntityStatusArgs
+	Entities []EntityStatusArgs `json:"entities"`
 }
 
 // ConstraintsResult holds machine constraints or an error.
 type ConstraintsResult struct {
-	Error       *Error
-	Constraints constraints.Value
+	Error       *Error            `json:"error,omitempty"`
+	Constraints constraints.Value `json:"constraints"`
 }
 
 // ConstraintsResults holds multiple constraints results.
 type ConstraintsResults struct {
-	Results []ConstraintsResult
+	Results []ConstraintsResult `json:"results"`
 }
 
 // AgentGetEntitiesResults holds the results of a
 // agent.API.GetEntities call.
 type AgentGetEntitiesResults struct {
-	Entities []AgentGetEntitiesResult
+	Entities []AgentGetEntitiesResult `json:"entities"`
 }
 
 // AgentGetEntitiesResult holds the results of a
 // machineagent.API.GetEntities call for a single entity.
 type AgentGetEntitiesResult struct {
-	Life          Life
-	Jobs          []multiwatcher.MachineJob
-	ContainerType instance.ContainerType
-	Error         *Error
+	Life          Life                      `json:"life"`
+	Jobs          []multiwatcher.MachineJob `json:"jobs"`
+	ContainerType instance.ContainerType    `json:"container-type"`
+	Error         *Error                    `json:"error,omitempty"`
 }
 
 // VersionResult holds the version and possibly error for a given
 // DesiredVersion() API call.
 type VersionResult struct {
-	Version *version.Number
-	Error   *Error
+	Version *version.Number `json:"version,omitempty"`
+	Error   *Error          `json:"error,omitempty"`
 }
 
 // VersionResults is a list of versions for the requested entities.
 type VersionResults struct {
-	Results []VersionResult
+	Results []VersionResult `json:"results"`
 }
 
 // ToolsResult holds the tools and possibly error for a given
 // Tools() API call.
 type ToolsResult struct {
-	ToolsList                      tools.List
-	DisableSSLHostnameVerification bool
-	Error                          *Error
+	ToolsList                      tools.List `json:"tools"`
+	DisableSSLHostnameVerification bool       `json:"disable-ssl-hostname-verification"`
+	Error                          *Error     `json:"error,omitempty"`
 }
 
 // ToolsResults is a list of tools for various requested agents.
 type ToolsResults struct {
-	Results []ToolsResult
+	Results []ToolsResult `json:"results"`
 }
 
 // Version holds a specific binary version.
 type Version struct {
-	Version version.Binary
+	Version version.Binary `json:"version"`
 }
 
 // EntityVersion specifies the tools version to be set for an entity
 // with the given tag.
 // version.Binary directly.
 type EntityVersion struct {
-	Tag   string
-	Tools *Version
+	Tag   string   `json:"tag"`
+	Tools *Version `json:"tools"`
 }
 
 // EntitiesVersion specifies what tools are being run for
 // multiple entities.
 type EntitiesVersion struct {
-	AgentTools []EntityVersion
+	AgentTools []EntityVersion `json:"agent-tools"`
 }
 
 // NotifyWatchResult holds a NotifyWatcher id and an error (if any).
 type NotifyWatchResult struct {
 	NotifyWatcherId string
-	Error           *Error
+	Error           *Error `json:"error,omitempty"`
 }
 
 // NotifyWatchResults holds the results for any API call which ends up
 // returning a list of NotifyWatchers
 type NotifyWatchResults struct {
-	Results []NotifyWatchResult
+	Results []NotifyWatchResult `json:"results"`
 }
 
 // StringsWatchResult holds a StringsWatcher id, changes and an error
 // (if any).
 type StringsWatchResult struct {
-	StringsWatcherId string
-	Changes          []string
-	Error            *Error
+	StringsWatcherId string   `json:"watcher-id"`
+	Changes          []string `json:"changes,omitempty"`
+	Error            *Error   `json:"error,omitempty"`
 }
 
 // StringsWatchResults holds the results for any API call which ends up
 // returning a list of StringsWatchers.
 type StringsWatchResults struct {
-	Results []StringsWatchResult
+	Results []StringsWatchResult `json:"results"`
 }
 
 // EntitiesWatchResult holds a EntitiesWatcher id, changes and an error
 // (if any).
 type EntitiesWatchResult struct {
 	// Note legacy serialization tag.
-	EntitiesWatcherId string   `json:"EntityWatcherId"`
-	Changes           []string `json:"Changes"`
-	Error             *Error   `json:"Error"`
+	EntitiesWatcherId string   `json:"watcher-id"`
+	Changes           []string `json:"changes,omitempty"`
+	Error             *Error   `json:"error,omitempty"`
 }
 
 // EntitiesWatchResults holds the results for any API call which ends up
 // returning a list of EntitiesWatchers.
 type EntitiesWatchResults struct {
-	Results []EntitiesWatchResult `json:"Results"`
+	Results []EntitiesWatchResult `json:"results"`
 }
 
 // UnitSettings specifies the version of some unit's settings in some relation.
 type UnitSettings struct {
-	Version int64 `json:"Version"`
+	Version int64 `json:"version"`
 }
 
 // RelationUnitsChange describes the membership and settings of; or changes to;
@@ -488,176 +487,179 @@ type RelationUnitsChange struct {
 
 	// Changed holds a set of units that are known to be in scope, and the
 	// latest known settings version for each.
-	Changed map[string]UnitSettings `json:"Changed"`
+	Changed map[string]UnitSettings `json:"changed"`
 
 	// Departed holds a set of units that have previously been reported to
 	// be in scope, but which no longer are.
-	Departed []string `json:"Departed"`
+	Departed []string `json:"departed,omitempty"`
 }
 
 // RelationUnitsWatchResult holds a RelationUnitsWatcher id, baseline state
 // (in the Changes field), and an error (if any).
 type RelationUnitsWatchResult struct {
-	RelationUnitsWatcherId string              `json:"RelationUnitsWatcherId"`
-	Changes                RelationUnitsChange `json:"Changes"`
-	Error                  *Error              `json:"Error"`
+	RelationUnitsWatcherId string              `json:"watcher-id"`
+	Changes                RelationUnitsChange `json:"changes"`
+	Error                  *Error              `json:"error,omitempty"`
 }
 
 // RelationUnitsWatchResults holds the results for any API call which ends up
 // returning a list of RelationUnitsWatchers.
 type RelationUnitsWatchResults struct {
-	Results []RelationUnitsWatchResult
+	Results []RelationUnitsWatchResult `json:"results"`
 }
 
 // MachineStorageIdsWatchResult holds a MachineStorageIdsWatcher id,
 // changes and an error (if any).
 type MachineStorageIdsWatchResult struct {
-	MachineStorageIdsWatcherId string
-	Changes                    []MachineStorageId
-	Error                      *Error
+	MachineStorageIdsWatcherId string             `json:"watcher-id"`
+	Changes                    []MachineStorageId `json:"changes"`
+	Error                      *Error             `json:"error,omitempty"`
 }
 
 // MachineStorageIdsWatchResults holds the results for any API call which ends
 // up returning a list of MachineStorageIdsWatchers.
 type MachineStorageIdsWatchResults struct {
-	Results []MachineStorageIdsWatchResult
+	Results []MachineStorageIdsWatchResult `json:"results"`
 }
 
 // CharmsResponse is the server response to charm upload or GET requests.
 type CharmsResponse struct {
-	Error string `json:",omitempty"`
+	Error string `json:"error,omitempty"`
 
 	// ErrorCode holds the code associated with the error.
 	// Ideally, Error would hold an Error object and the
 	// code would be in that, but for backward compatibility,
 	// we cannot do that.
-	ErrorCode string `json:",omitempty"`
+	ErrorCode string `json:"error-code,omitempty"`
 
 	// ErrorInfo holds extra information associated with the error.
 	// Like ErrorCode, this should really be in an Error object.
-	ErrorInfo *ErrorInfo
+	ErrorInfo *ErrorInfo `json:"error-info,omitempty"`
 
-	CharmURL string   `json:",omitempty"`
-	Files    []string `json:",omitempty"`
+	CharmURL string   `json:"charm-url,omitempty"`
+	Files    []string `json:"files,omitempty"`
 }
 
 // RunParams is used to provide the parameters to the Run method.
 // Commands and Timeout are expected to have values, and one or more
 // values should be in the Machines, Applications, or Units slices.
 type RunParams struct {
-	Commands     string
-	Timeout      time.Duration
-	Machines     []string
-	Applications []string
-	Units        []string
+	Commands     string        `json:"commands"`
+	Timeout      time.Duration `json:"timeout"`
+	Machines     []string      `json:"machines,omitempty"`
+	Applications []string      `json:"applications,omitempty"`
+	Units        []string      `json:"units,omitempty"`
 }
 
 // RunResult contains the result from an individual run call on a machine.
 // UnitId is populated if the command was run inside the unit context.
 type RunResult struct {
-	exec.ExecResponse
-	MachineId string
-	UnitId    string
-	Error     string
+	Code   int    `json:"code-id"`
+	Stdout []byte `json:"stdout,omitempty"`
+	Stderr []byte `json:"stderr,omitempty"`
+	// FIXME: should be tags not id strings
+	MachineId string `json:"machine-id"`
+	UnitId    string `json:"unit-id"`
+	Error     string `json:"error"`
 }
 
 // RunResults is used to return the slice of results.  API server side calls
 // need to return single structure values.
 type RunResults struct {
-	Results []RunResult
+	Results []RunResult `json:"results"`
 }
 
 // AgentVersionResult is used to return the current version number of the
 // agent running the API server.
 type AgentVersionResult struct {
-	Version version.Number
+	Version version.Number `json:"version"`
 }
 
 // ProvisioningInfo holds machine provisioning info.
 type ProvisioningInfo struct {
-	Constraints      constraints.Value
-	Series           string
-	Placement        string
-	Jobs             []multiwatcher.MachineJob
-	Volumes          []VolumeParams
-	Tags             map[string]string
-	SubnetsToZones   map[string][]string
-	ImageMetadata    []CloudImageMetadata
-	EndpointBindings map[string]string
-	ControllerConfig map[string]interface{}
+	Constraints      constraints.Value         `json:"constraints"`
+	Series           string                    `json:"series"`
+	Placement        string                    `json:"placement"`
+	Jobs             []multiwatcher.MachineJob `json:"jobs"`
+	Volumes          []VolumeParams            `json:"volumes,omitempty"`
+	Tags             map[string]string         `json:"tags,omitempty"`
+	SubnetsToZones   map[string][]string       `json:"subnets-to-zones,omitempty"`
+	ImageMetadata    []CloudImageMetadata      `json:"image-metadata,omitempty"`
+	EndpointBindings map[string]string         `json:"endpoint-bindings,omitempty"`
+	ControllerConfig map[string]interface{}    `json:"controller-config,omitempty"`
 }
 
 // ProvisioningInfoResult holds machine provisioning info or an error.
 type ProvisioningInfoResult struct {
-	Error  *Error
-	Result *ProvisioningInfo
+	Error  *Error            `json:"error,omitempty"`
+	Result *ProvisioningInfo `json:"result"`
 }
 
 // ProvisioningInfoResults holds multiple machine provisioning info results.
 type ProvisioningInfoResults struct {
-	Results []ProvisioningInfoResult
+	Results []ProvisioningInfoResult `json:"results"`
 }
 
 // Metric holds a single metric.
 type Metric struct {
-	Key   string
-	Value string
-	Time  time.Time
+	Key   string    `json:"key"`
+	Value string    `json:"value"`
+	Time  time.Time `json:"time"`
 }
 
 // MetricsParam contains the metrics for a single unit.
 type MetricsParam struct {
-	Tag     string
-	Metrics []Metric
+	Tag     string   `json:"tag"`
+	Metrics []Metric `json:"metrics"`
 }
 
 // MetricsParams contains the metrics for multiple units.
 type MetricsParams struct {
-	Metrics []MetricsParam
+	Metrics []MetricsParam `json:"metrics"`
 }
 
 // MetricBatch is a list of metrics with metadata.
 type MetricBatch struct {
-	UUID     string
-	CharmURL string
-	Created  time.Time
-	Metrics  []Metric
+	UUID     string    `json:"uuid"`
+	CharmURL string    `json:"charm-url"`
+	Created  time.Time `json:"created"`
+	Metrics  []Metric  `json:"metrics"`
 }
 
 // MetricBatchParam contains a single metric batch.
 type MetricBatchParam struct {
-	Tag   string
-	Batch MetricBatch
+	Tag   string      `json:"tag"`
+	Batch MetricBatch `json:"batch"`
 }
 
 // MetricBatchParams contains multiple metric batches.
 type MetricBatchParams struct {
-	Batches []MetricBatchParam
+	Batches []MetricBatchParam `json:"batches"`
 }
 
 // MeterStatusResult holds unit meter status or error.
 type MeterStatusResult struct {
-	Code  string
-	Info  string
-	Error *Error
+	Code  string `json:"code"`
+	Info  string `json:"info"`
+	Error *Error `json:"error,omitempty"`
 }
 
 // MeterStatusResults holds meter status results for multiple units.
 type MeterStatusResults struct {
-	Results []MeterStatusResult
+	Results []MeterStatusResult `json:"results"`
 }
 
 // SingularClaim represents a request for exclusive model administration access
 // on the part of some controller.
 type SingularClaim struct {
-	ModelTag      string        `json:"ModelTag"`
-	ControllerTag string        `json:"ControllerTag"`
-	Duration      time.Duration `json:"Duration"`
+	ModelTag      string        `json:"model-tag"`
+	ControllerTag string        `json:"controller-tag"`
+	Duration      time.Duration `json:"duration"`
 }
 
 // SingularClaims holds any number of SingularClaim~s.
 type SingularClaims struct {
-	Claims []SingularClaim `json:"Claims"`
+	Claims []SingularClaim `json:"claims"`
 }
 
 // GUIArchiveVersion holds information on a specific GUI archive version.

--- a/apiserver/params/leadership.go
+++ b/apiserver/params/leadership.go
@@ -8,7 +8,7 @@ package params
 type ClaimLeadershipBulkParams struct {
 
 	// Params are the parameters for making a bulk leadership claim.
-	Params []ClaimLeadershipParams
+	Params []ClaimLeadershipParams `json:"params"`
 }
 
 // ClaimLeadershipParams are the parameters needed for making a
@@ -17,13 +17,13 @@ type ClaimLeadershipParams struct {
 
 	// ApplicationTag is the application for which you want to make a
 	// leadership claim.
-	ApplicationTag string
+	ApplicationTag string `json:"application-tag"`
 
 	// UnitTag is the unit which is making the leadership claim.
-	UnitTag string
+	UnitTag string `json:"unit-tag"`
 
 	// DurationSeconds is the number of seconds for which the lease is required.
-	DurationSeconds float64
+	DurationSeconds float64 `json:"duration"`
 }
 
 // ClaimLeadershipBulkResults is the collection of results from a bulk
@@ -33,7 +33,7 @@ type ClaimLeadershipBulkResults ErrorResults
 // ReleaseLeadershipBulkParams is a collection of parameters needed to
 // make a bulk release leadership call.
 type ReleaseLeadershipBulkParams struct {
-	Params []ReleaseLeadershipParams
+	Params []ReleaseLeadershipParams `json:"params"`
 }
 
 // ReleaseLeadershipParams are the parameters needed to release a
@@ -42,10 +42,10 @@ type ReleaseLeadershipParams struct {
 
 	// ApplicationTag is the application for which you want to make a
 	// leadership claim.
-	ApplicationTag string
+	ApplicationTag string `json:"application-tag"`
 
 	// UnitTag is the unit which is making the leadership claim.
-	UnitTag string
+	UnitTag string `json:"unit-tag"`
 }
 
 // ReleaseLeadershipBulkResults is a type which contains results from
@@ -55,14 +55,14 @@ type ReleaseLeadershipBulkResults ErrorResults
 // GetLeadershipSettingsBulkResults is the collection of results from
 // a bulk request for leadership settings.
 type GetLeadershipSettingsBulkResults struct {
-	Results []GetLeadershipSettingsResult
+	Results []GetLeadershipSettingsResult `json:"results"`
 }
 
 // GetLeadershipSettingsResult is the results from requesting
 // leadership settings.
 type GetLeadershipSettingsResult struct {
-	Settings Settings
-	Error    *Error
+	Settings Settings `json:"settings"`
+	Error    *Error   `json:"error,omitempty"`
 }
 
 // MergeLeadershipSettingsBulkParams is a collection of parameters for
@@ -71,7 +71,7 @@ type MergeLeadershipSettingsBulkParams struct {
 
 	// Params are the parameters for making a bulk leadership settings
 	// merge.
-	Params []MergeLeadershipSettingsParam
+	Params []MergeLeadershipSettingsParam `json:"params"`
 }
 
 // MergeLeadershipSettingsParam are the parameters needed for merging
@@ -79,8 +79,8 @@ type MergeLeadershipSettingsBulkParams struct {
 type MergeLeadershipSettingsParam struct {
 	// ApplicationTag is the application for which you want to merge
 	// leadership settings.
-	ApplicationTag string
+	ApplicationTag string `json:"application-tag"`
 
 	// Settings are the Leadership settings you wish to merge in.
-	Settings Settings
+	Settings Settings `json:"settings"`
 }

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -36,7 +36,7 @@ type InitiateModelMigrationResults struct {
 // model migration initiation attempt.
 type InitiateModelMigrationResult struct {
 	ModelTag string `json:"model-tag"`
-	Error    *Error `json:"error"`
+	Error    *Error `json:"error,omitempty"`
 	Id       string `json:"id"` // the ID for the migration attempt
 }
 
@@ -80,9 +80,9 @@ type FullMigrationStatus struct {
 
 type PhaseResult struct {
 	Phase string `json:"phase"`
-	Error *Error
+	Error *Error `json:"error,omitempty"`
 }
 
 type PhaseResults struct {
-	Results []PhaseResult `json:"Results"`
+	Results []PhaseResult `json:"results"`
 }

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -12,25 +12,25 @@ import (
 // ModelConfigResults contains the result of client API calls
 // to get model config values.
 type ModelConfigResults struct {
-	Config map[string]interface{}
+	Config map[string]interface{} `json:"config"`
 }
 
 // ModelSet contains the arguments for ModelSet client API
 // call.
 type ModelSet struct {
-	Config map[string]interface{}
+	Config map[string]interface{} `json:"config"`
 }
 
 // ModelUnset contains the arguments for ModelUnset client API
 // call.
 type ModelUnset struct {
-	Keys []string
+	Keys []string `json:"keys"`
 }
 
 // SetModelAgentVersion contains the arguments for
 // SetModelAgentVersion client API call.
 type SetModelAgentVersion struct {
-	Version version.Number
+	Version version.Number `json:"version"`
 }
 
 // ModelInfo holds information about the Juju model.
@@ -38,28 +38,28 @@ type ModelInfo struct {
 	// The json names for the fields below are as per the older
 	// field names for backward compatibility. New fields are
 	// camel-cased for consistency within this type only.
-	Name           string `json:"Name"`
-	UUID           string `json:"UUID"`
-	ControllerUUID string `json:"ServerUUID"`
-	ProviderType   string `json:"ProviderType"`
-	DefaultSeries  string `json:"DefaultSeries"`
-	CloudRegion    string `json:"CloudRegion,omitempty"`
+	Name           string `json:"name"`
+	UUID           string `json:"uuid"`
+	ControllerUUID string `json:"controller-uuid"`
+	ProviderType   string `json:"provider-type"`
+	DefaultSeries  string `json:"default-series"`
+	CloudRegion    string `json:"cloud-region,omitempty"`
 	// TODO(axw) make sure we're setting this everywhere
-	CloudCredential string `json:"CloudCredential,omitempty"`
+	CloudCredential string `json:"cloud-credential,omitempty"`
 
 	// OwnerTag is the tag of the user that owns the model.
-	OwnerTag string `json:"OwnerTag"`
+	OwnerTag string `json:"owner-tag"`
 
 	// Life is the current lifecycle state of the model.
-	Life Life `json:"Life"`
+	Life Life `json:"life"`
 
 	// Status is the current status of the model.
-	Status EntityStatus `json:"Status"`
+	Status EntityStatus `json:"status"`
 
 	// Users contains information about the users that have access
 	// to the model. Owners and administrators can see all users
 	// that have access; other users can only see their own details.
-	Users []ModelUserInfo `json:"Users"`
+	Users []ModelUserInfo `json:"users"`
 }
 
 // ModelInfoResult holds the result of a ModelInfo call.
@@ -96,8 +96,8 @@ type ModelInfoListResults struct {
 // who have access, so it should not include sensitive information.
 type ModelUserInfo struct {
 	UserName       string                `json:"user"`
-	DisplayName    string                `json:"displayname"`
-	LastConnection *time.Time            `json:"lastconnection"`
+	DisplayName    string                `json:"display-name"`
+	LastConnection *time.Time            `json:"last-connection"`
 	Access         ModelAccessPermission `json:"access"`
 }
 

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -14,31 +14,31 @@ import (
 // Subnet describes a single subnet within a network.
 type Subnet struct {
 	// CIDR of the subnet in IPv4 or IPv6 notation.
-	CIDR string `json:"CIDR"`
+	CIDR string `json:"cidr"`
 
 	// ProviderId is the provider-specific subnet ID (if applicable).
-	ProviderId string `json:"ProviderId,omitempty"`
+	ProviderId string `json:"provider-id,omitempty"`
 
 	// VLANTag needs to be between 1 and 4094 for VLANs and 0 for
 	// normal networks. It's defined by IEEE 802.1Q standard.
-	VLANTag int `json:"VLANTag"`
+	VLANTag int `json:"vlan-tag"`
 
 	// Life is the subnet's life cycle value - Alive means the subnet
 	// is in use by one or more machines, Dying or Dead means the
 	// subnet is about to be removed.
-	Life Life `json:"Life"`
+	Life Life `json:"life"`
 
 	// SpaceTag is the Juju network space this subnet is associated
 	// with.
-	SpaceTag string `json:"SpaceTag"`
+	SpaceTag string `json:"space-tag"`
 
 	// Zones contain one or more availability zones this subnet is
 	// associated with.
-	Zones []string `json:"Zones"`
+	Zones []string `json:"zones"`
 
 	// Status returns the status of the subnet, whether it is in use, not
 	// in use or terminating.
-	Status string `json:"Status,omitempty"`
+	Status string `json:"status,omitempty"`
 }
 
 // NetworkConfig describes the necessary information to configure
@@ -49,101 +49,101 @@ type Subnet struct {
 type NetworkConfig struct {
 	// DeviceIndex specifies the order in which the network interface
 	// appears on the host. The primary interface has an index of 0.
-	DeviceIndex int `json:"DeviceIndex"`
+	DeviceIndex int `json:"device-index"`
 
 	// MACAddress is the network interface's hardware MAC address
 	// (e.g. "aa:bb:cc:dd:ee:ff").
-	MACAddress string `json:"MACAddress"`
+	MACAddress string `json:"mac-address"`
 
 	// CIDR of the network, in 123.45.67.89/24 format.
-	CIDR string `json:"CIDR"`
+	CIDR string `json:"cidr"`
 
 	// MTU is the Maximum Transmission Unit controlling the maximum size of the
 	// protocol packats that the interface can pass through. It is only used
 	// when > 0.
-	MTU int `json:"MTU"`
+	MTU int `json:"mtu"`
 
 	// ProviderId is a provider-specific network interface id.
-	ProviderId string `json:"ProviderId"`
+	ProviderId string `json:"provider-id"`
 
 	// ProviderSubnetId is a provider-specific subnet id, to which the
 	// interface is attached to.
-	ProviderSubnetId string `json:"ProviderSubnetId"`
+	ProviderSubnetId string `json:"provider-subnet-id"`
 
 	// ProviderSpaceId is a provider-specific space id, to which the interface
 	// is attached to, if known and supported.
-	ProviderSpaceId string `json:"ProviderSpaceId"`
+	ProviderSpaceId string `json:"provider-space-id"`
 
 	// ProviderAddressId is the provider-specific id of the assigned address, if
 	// supported and known.
-	ProviderAddressId string `json:"ProviderAddressId"`
+	ProviderAddressId string `json:"provider-address-id"`
 
 	// ProviderVLANId is the provider-specific id of the assigned address's
 	// VLAN, if supported and known.
-	ProviderVLANId string `json:"ProviderVLANId"`
+	ProviderVLANId string `json:"provider-vlan-id"`
 
 	// VLANTag needs to be between 1 and 4094 for VLANs and 0 for
 	// normal networks. It's defined by IEEE 802.1Q standard.
-	VLANTag int `json:"VLANTag"`
+	VLANTag int `json:"vlan-tag"`
 
 	// InterfaceName is the raw OS-specific network device name (e.g.
 	// "eth1", even for a VLAN eth1.42 virtual interface).
-	InterfaceName string `json:"InterfaceName"`
+	InterfaceName string `json:"interface-name"`
 
 	// ParentInterfaceName is the name of the parent interface to use, if known.
-	ParentInterfaceName string `json:"ParentInterfaceName"`
+	ParentInterfaceName string `json:"parent-interface-name"`
 
 	// InterfaceType is the type of the interface.
-	InterfaceType string `json:"InterfaceType"`
+	InterfaceType string `json:"interface-type"`
 
 	// Disabled is true when the interface needs to be disabled on the
 	// machine, e.g. not to configure it at all or stop it if running.
-	Disabled bool `json:"Disabled"`
+	Disabled bool `json:"disabled"`
 
 	// NoAutoStart is true when the interface should not be configured
 	// to start automatically on boot. By default and for
 	// backwards-compatibility, interfaces are configured to
 	// auto-start.
-	NoAutoStart bool `json:"NoAutoStart,omitempty"`
+	NoAutoStart bool `json:"no-auto-start,omitempty"`
 
 	// ConfigType, if set, defines what type of configuration to use.
 	// See network.InterfaceConfigType for more info. If not set, for
 	// backwards-compatibility, "dhcp" is assumed.
-	ConfigType string `json:"ConfigType,omitempty"`
+	ConfigType string `json:"config-type,omitempty"`
 
 	// Address contains an optional static IP address to configure for
 	// this network interface. The subnet mask to set will be inferred
 	// from the CIDR value.
-	Address string `json:"Address,omitempty"`
+	Address string `json:"address,omitempty"`
 
 	// DNSServers contains an optional list of IP addresses and/or
 	// hostnames to configure as DNS servers for this network
 	// interface.
-	DNSServers []string `json:"DNSServers,omitempty"`
+	DNSServers []string `json:"dns-servers,omitempty"`
 
 	// DNSServers contains an optional list of IP addresses and/or
 	// hostnames to configure as DNS servers for this network
 	// interface.
-	DNSSearchDomains []string `json:"DNSSearchDomains,omitempty"`
+	DNSSearchDomains []string `json:"dns-search-domains,omitempty"`
 
 	// Gateway address, if set, defines the default gateway to
 	// configure for this network interface. For containers this
 	// usually (one of) the host address(es).
-	GatewayAddress string `json:"GatewayAddress,omitempty"`
+	GatewayAddress string `json:"gateway-address,omitempty"`
 }
 
 // NetworkConfigs holds the network configuration for multiple networks
 type NetworkConfigs struct {
-	Results []NetworkConfig
-	Errors  []error
+	Results []NetworkConfig `json:"results"`
+	Errors  []error         `json:"errors,omitempty"`
 }
 
 // Port encapsulates a protocol and port number. It is used in API
 // requests/responses. See also network.Port, from/to which this is
 // transformed.
 type Port struct {
-	Protocol string `json:"Protocol"`
-	Number   int    `json:"Number"`
+	Protocol string `json:"protocol"`
+	Number   int    `json:"number"`
 }
 
 // FromNetworkPort is a convenience helper to create a parameter
@@ -168,9 +168,9 @@ func (p Port) NetworkPort() network.Port {
 // requests/responses. See also network.PortRange, from/to which this is
 // transformed.
 type PortRange struct {
-	FromPort int    `json:"FromPort"`
-	ToPort   int    `json:"ToPort"`
-	Protocol string `json:"Protocol"`
+	FromPort int    `json:"from-port"`
+	ToPort   int    `json:"to-port"`
+	Protocol string `json:"protocol"`
 }
 
 // FromNetworkPortRange is a convenience helper to create a parameter
@@ -195,29 +195,29 @@ func (pr PortRange) NetworkPortRange() network.PortRange {
 
 // EntityPort holds an entity's tag, a protocol and a port.
 type EntityPort struct {
-	Tag      string `json:"Tag"`
-	Protocol string `json:"Protocol"`
-	Port     int    `json:"Port"`
+	Tag      string `json:"tag"`
+	Protocol string `json:"protocol"`
+	Port     int    `json:"port"`
 }
 
 // EntitiesPorts holds the parameters for making an OpenPort or
 // ClosePort on some entities.
 type EntitiesPorts struct {
-	Entities []EntityPort `json:"Entities"`
+	Entities []EntityPort `json:"entities"`
 }
 
 // EntityPortRange holds an entity's tag, a protocol and a port range.
 type EntityPortRange struct {
-	Tag      string `json:"Tag"`
-	Protocol string `json:"Protocol"`
-	FromPort int    `json:"FromPort"`
-	ToPort   int    `json:"ToPort"`
+	Tag      string `json:"tag"`
+	Protocol string `json:"protocol"`
+	FromPort int    `json:"from-port"`
+	ToPort   int    `json:"to-port"`
 }
 
 // EntitiesPortRanges holds the parameters for making an OpenPorts or
 // ClosePorts on some entities.
 type EntitiesPortRanges struct {
-	Entities []EntityPortRange `json:"Entities"`
+	Entities []EntityPortRange `json:"entities"`
 }
 
 // Address represents the location of a machine, including metadata
@@ -225,10 +225,10 @@ type EntitiesPortRanges struct {
 // the API requests/responses. See also network.Address, from/to
 // which this is transformed.
 type Address struct {
-	Value     string `json:"Value"`
-	Type      string `json:"Type"`
-	Scope     string `json:"Scope"`
-	SpaceName string `json:"SpaceName,omitempty"`
+	Value     string `json:"value"`
+	Type      string `json:"type"`
+	Scope     string `json:"scope"`
+	SpaceName string `json:"space-name,omitempty"`
 }
 
 // FromNetworkAddress is a convenience helper to create a parameter
@@ -278,7 +278,7 @@ func NetworkAddresses(addrs ...Address) []network.Address {
 // which this is transformed.
 type HostPort struct {
 	Address
-	Port int `json:"Port"`
+	Port int `json:"port"`
 }
 
 // FromNetworkHostPort is a convenience helper to create a parameter
@@ -336,60 +336,60 @@ func NetworkHostsPorts(hpm [][]HostPort) [][]network.HostPort {
 // UnitsNetworkConfig holds the parameters for calling Uniter.NetworkConfig()
 // API.
 type UnitsNetworkConfig struct {
-	Args []UnitNetworkConfig `json:"Args"`
+	Args []UnitNetworkConfig `json:"args"`
 }
 
 // UnitNetworkConfig holds a unit tag and an endpoint binding name.
 type UnitNetworkConfig struct {
-	UnitTag     string `json:"UnitTag"`
-	BindingName string `json:"BindingName"`
+	UnitTag     string `json:"unit-tag"`
+	BindingName string `json:"binding-name"`
 }
 
 // MachineAddresses holds an machine tag and addresses.
 type MachineAddresses struct {
-	Tag       string    `json:"Tag"`
-	Addresses []Address `json:"Addresses"`
+	Tag       string    `json:"tag"`
+	Addresses []Address `json:"addresses"`
 }
 
 // SetMachinesAddresses holds the parameters for making an
 // API call to update machine addresses.
 type SetMachinesAddresses struct {
-	MachineAddresses []MachineAddresses `json:"MachineAddresses"`
+	MachineAddresses []MachineAddresses `json:"machine-addresses"`
 }
 
 // SetMachineNetworkConfig holds the parameters for making an API call to update
 // machine network config.
 type SetMachineNetworkConfig struct {
-	Tag    string          `json:"Tag"`
-	Config []NetworkConfig `json:"Config"`
+	Tag    string          `json:"tag"`
+	Config []NetworkConfig `json:"config"`
 }
 
 // MachineAddressesResult holds a list of machine addresses or an
 // error.
 type MachineAddressesResult struct {
-	Error     *Error    `json:"Error"`
-	Addresses []Address `json:"Addresses"`
+	Error     *Error    `json:"error,omitempty"`
+	Addresses []Address `json:"addresses"`
 }
 
 // MachineAddressesResults holds the results of calling an API method
 // returning a list of addresses per machine.
 type MachineAddressesResults struct {
-	Results []MachineAddressesResult `json:"Results"`
+	Results []MachineAddressesResult `json:"results"`
 }
 
 // MachinePortRange holds a single port range open on a machine for
 // the given unit and relation tags.
 type MachinePortRange struct {
-	UnitTag     string    `json:"UnitTag"`
-	RelationTag string    `json:"RelationTag"`
-	PortRange   PortRange `json:"PortRange"`
+	UnitTag     string    `json:"unit-tag"`
+	RelationTag string    `json:"relation-tag"`
+	PortRange   PortRange `json:"port-range"`
 }
 
 // MachinePorts holds a machine and subnet tags. It's used when referring to
 // opened ports on the machine for a subnet.
 type MachinePorts struct {
-	MachineTag string `json:"MachineTag"`
-	SubnetTag  string `json:"SubnetTag"`
+	MachineTag string `json:"machine-tag"`
+	SubnetTag  string `json:"subnet-tag"`
 }
 
 // -----
@@ -399,68 +399,68 @@ type MachinePorts struct {
 // PortsResults holds the bulk operation result of an API call
 // that returns a slice of Port.
 type PortsResults struct {
-	Results []PortsResult `json:"Results"`
+	Results []PortsResult `json:"results"`
 }
 
 // PortsResult holds the result of an API call that returns a slice
 // of Port or an error.
 type PortsResult struct {
-	Error *Error `json:"Error"`
-	Ports []Port `json:"Ports"`
+	Error *Error `json:"error,omitempty"`
+	Ports []Port `json:"ports"`
 }
 
 // UnitNetworkConfigResult holds network configuration for a single unit.
 type UnitNetworkConfigResult struct {
-	Error *Error `json:"Error"`
+	Error *Error `json:"error,omitempty"`
 
 	// Tagged to Info due to compatibility reasons.
-	Config []NetworkConfig `json:"Info"`
+	Config []NetworkConfig `json:"info"`
 }
 
 // UnitNetworkConfigResults holds network configuration for multiple machines.
 type UnitNetworkConfigResults struct {
-	Results []UnitNetworkConfigResult `json:"Results"`
+	Results []UnitNetworkConfigResult `json:"results"`
 }
 
 // MachineNetworkConfigResult holds network configuration for a single machine.
 type MachineNetworkConfigResult struct {
-	Error *Error `json:"Error"`
+	Error *Error `json:"error,omitempty"`
 
 	// Tagged to Info due to compatibility reasons.
-	Config []NetworkConfig `json:"Info"`
+	Config []NetworkConfig `json:"info"`
 }
 
 // MachineNetworkConfigResults holds network configuration for multiple machines.
 type MachineNetworkConfigResults struct {
-	Results []MachineNetworkConfigResult `json:"Results"`
+	Results []MachineNetworkConfigResult `json:"results"`
 }
 
 // MachinePortsParams holds the arguments for making a
 // FirewallerAPIV1.GetMachinePorts() API call.
 type MachinePortsParams struct {
-	Params []MachinePorts `json:"Params"`
+	Params []MachinePorts `json:"params"`
 }
 
 // MachinePortsResult holds a single result of the
 // FirewallerAPIV1.GetMachinePorts() and UniterAPI.AllMachinePorts()
 // API calls.
 type MachinePortsResult struct {
-	Error *Error             `json:"Error"`
-	Ports []MachinePortRange `json:"Ports"`
+	Error *Error             `json:"error,omitempty"`
+	Ports []MachinePortRange `json:"ports"`
 }
 
 // MachinePortsResults holds all the results of the
 // FirewallerAPIV1.GetMachinePorts() and UniterAPI.AllMachinePorts()
 // API calls.
 type MachinePortsResults struct {
-	Results []MachinePortsResult `json:"Results"`
+	Results []MachinePortsResult `json:"results"`
 }
 
 // APIHostPortsResult holds the result of an APIHostPorts
 // call. Each element in the top level slice holds
 // the addresses for one API server.
 type APIHostPortsResult struct {
-	Servers [][]HostPort `json:"Servers"`
+	Servers [][]HostPort `json:"servers"`
 }
 
 // NetworkHostsPorts is a convenience helper to return the contained
@@ -472,43 +472,43 @@ func (r APIHostPortsResult) NetworkHostsPorts() [][]network.HostPort {
 // ZoneResult holds the result of an API call that returns an
 // availability zone name and whether it's available for use.
 type ZoneResult struct {
-	Error     *Error `json:"Error"`
-	Name      string `json:"Name"`
-	Available bool   `json:"Available"`
+	Error     *Error `json:"error,omitempty"`
+	Name      string `json:"name"`
+	Available bool   `json:"available"`
 }
 
 // ZoneResults holds multiple ZoneResult results
 type ZoneResults struct {
-	Results []ZoneResult `json:"Results"`
+	Results []ZoneResult `json:"results"`
 }
 
 // SpaceResult holds a single space tag or an error.
 type SpaceResult struct {
-	Error *Error `json:"Error"`
-	Tag   string `json:"Tag"`
+	Error *Error `json:"error,omitempty"`
+	Tag   string `json:"tag"`
 }
 
 // SpaceResults holds the bulk operation result of an API call
 // that returns space tags or an errors.
 type SpaceResults struct {
-	Results []SpaceResult `json:"Results"`
+	Results []SpaceResult `json:"results"`
 }
 
 // ListSubnetsResults holds the result of a ListSubnets API call.
 type ListSubnetsResults struct {
-	Results []Subnet `json:"Results"`
+	Results []Subnet `json:"results"`
 }
 
 // SubnetsFilters holds an optional SpaceTag and Zone for filtering
 // the subnets returned by a ListSubnets call.
 type SubnetsFilters struct {
-	SpaceTag string `json:"SpaceTag,omitempty"`
-	Zone     string `json:"Zone,omitempty"`
+	SpaceTag string `json:"space-tag,omitempty"`
+	Zone     string `json:"zone,omitempty"`
 }
 
 // AddSubnetsParams holds the arguments of AddSubnets API call.
 type AddSubnetsParams struct {
-	Subnets []AddSubnetParams `json:"Subnets"`
+	Subnets []AddSubnetParams `json:"subnets"`
 }
 
 // AddSubnetParams holds a subnet and space tags, subnet provider ID,
@@ -516,81 +516,81 @@ type AddSubnetsParams struct {
 // SubnetProviderId must be set, but not both. Zones can be empty if
 // they can be discovered
 type AddSubnetParams struct {
-	SubnetTag        string   `json:"SubnetTag,omitempty"`
-	SubnetProviderId string   `json:"SubnetProviderId,omitempty"`
-	SpaceTag         string   `json:"SpaceTag"`
-	Zones            []string `json:"Zones,omitempty"`
+	SubnetTag        string   `json:"subnet-tag,omitempty"`
+	SubnetProviderId string   `json:"subnet-provider-id,omitempty"`
+	SpaceTag         string   `json:"space-tag"`
+	Zones            []string `json:"zones,omitempty"`
 }
 
 // CreateSubnetsParams holds the arguments of CreateSubnets API call.
 type CreateSubnetsParams struct {
-	Subnets []CreateSubnetParams `json:"Subnets"`
+	Subnets []CreateSubnetParams `json:"subnets"`
 }
 
 // CreateSubnetParams holds a subnet and space tags, vlan tag,
 // and a list of zones to associate the subnet to.
 type CreateSubnetParams struct {
-	SubnetTag string   `json:"SubnetTag,omitempty"`
-	SpaceTag  string   `json:"SpaceTag"`
-	Zones     []string `json:"Zones,omitempty"`
-	VLANTag   int      `json:"VLANTag,omitempty"`
-	IsPublic  bool     `json:"IsPublic"`
+	SubnetTag string   `json:"subnet-tag,omitempty"`
+	SpaceTag  string   `json:"space-tag"`
+	Zones     []string `json:"zones,omitempty"`
+	VLANTag   int      `json:"vlan-tag,omitempty"`
+	IsPublic  bool     `json:"is-public"`
 }
 
 // CreateSpacesParams olds the arguments of the AddSpaces API call.
 type CreateSpacesParams struct {
-	Spaces []CreateSpaceParams `json:"Spaces"`
+	Spaces []CreateSpaceParams `json:"spaces"`
 }
 
 // CreateSpaceParams holds the space tag and at least one subnet
 // tag required to create a new space.
 type CreateSpaceParams struct {
-	SubnetTags []string `json:"SubnetTags"`
-	SpaceTag   string   `json:"SpaceTag"`
-	Public     bool     `json:"Public"`
-	ProviderId string   `json:"ProviderId,omitempty"`
+	SubnetTags []string `json:"subnet-tags"`
+	SpaceTag   string   `json:"space-tag"`
+	Public     bool     `json:"public"`
+	ProviderId string   `json:"provider-id,omitempty"`
 }
 
 // ListSpacesResults holds the list of all available spaces.
 type ListSpacesResults struct {
-	Results []Space `json:"Results"`
+	Results []Space `json:"results"`
 }
 
 // Space holds the information about a single space and its associated subnets.
 type Space struct {
-	Name    string   `json:"Name"`
-	Subnets []Subnet `json:"Subnets"`
-	Error   *Error   `json:"Error,omitempty"`
+	Name    string   `json:"name"`
+	Subnets []Subnet `json:"subnets"`
+	Error   *Error   `json:"error,omitempty"`
 }
 
 // DiscoverSpacesResults holds the list of all provider spaces.
 type DiscoverSpacesResults struct {
-	Results []ProviderSpace `json:"Results"`
+	Results []ProviderSpace `json:"results"`
 }
 
 // ProviderSpace holds the information about a single space and its associated subnets.
 type ProviderSpace struct {
-	Name       string   `json:"Name"`
-	ProviderId string   `json:"ProviderId"`
-	Subnets    []Subnet `json:"Subnets"`
-	Error      *Error   `json:"Error,omitempty"`
+	Name       string   `json:"name"`
+	ProviderId string   `json:"provider-id"`
+	Subnets    []Subnet `json:"subnets"`
+	Error      *Error   `json:"error,omitempty"`
 }
 
 type ProxyConfig struct {
-	HTTP    string `json:"HTTP"`
-	HTTPS   string `json:"HTTPS"`
-	FTP     string `json:"FTP"`
-	NoProxy string `json:"NoProxy"`
+	HTTP    string `json:"http"`
+	HTTPS   string `json:"https"`
+	FTP     string `json:"ftp"`
+	NoProxy string `json:"no-proxy"`
 }
 
 // ProxyConfigResult contains information needed to configure a clients proxy settings
 type ProxyConfigResult struct {
-	ProxySettings    ProxyConfig `json:"ProxySettings"`
-	APTProxySettings ProxyConfig `json:"APTProxySettings"`
-	Error            *Error      `json:"Error,omitempty"`
+	ProxySettings    ProxyConfig `json:"proxy-settings"`
+	APTProxySettings ProxyConfig `json:"apt-proxy-settings"`
+	Error            *Error      `json:"error,omitempty"`
 }
 
 // ProxyConfigResults contains information needed to configure multiple clients proxy settings
 type ProxyConfigResults struct {
-	Results []ProxyConfigResult `json:"Results"`
+	Results []ProxyConfigResult `json:"results"`
 }

--- a/apiserver/params/network_test.go
+++ b/apiserver/params/network_test.go
@@ -44,16 +44,20 @@ func (s *NetworkSuite) TestPortsResults(c *gc.C) {
 		return pr
 	}
 	mkResults := func(rs ...interface{}) M {
-		return M{"Results": rs}
+		return M{"results": rs}
 	}
 	mkResult := func(err, ports interface{}) M {
-		return M{"Error": err, "Ports": ports}
+		result := M{"ports": ports}
+		if err != nil {
+			result["error"] = err
+		}
+		return result
 	}
 	mkError := func(msg, code string) M {
-		return M{"Message": msg, "Code": code}
+		return M{"message": msg, "code": code}
 	}
 	mkPort := func(prot string, num int) M {
-		return M{"Protocol": prot, "Number": num}
+		return M{"protocol": prot, "number": num}
 	}
 	// Tests.
 	tests := []struct {
@@ -99,10 +103,10 @@ func (s *NetworkSuite) TestPortsResults(c *gc.C) {
 func (s *NetworkSuite) TestHostPort(c *gc.C) {
 	mkHostPort := func(v, t, s string, p int) M {
 		return M{
-			"Value": v,
-			"Type":  t,
-			"Scope": s,
-			"Port":  p,
+			"value": v,
+			"type":  t,
+			"scope": s,
+			"port":  p,
 		}
 	}
 	tests := []struct {
@@ -175,12 +179,12 @@ func (s *NetworkSuite) TestHostPort(c *gc.C) {
 func (s *NetworkSuite) TestMachinePortRange(c *gc.C) {
 	mkPortRange := func(u, r string, f, t int, p string) M {
 		return M{
-			"UnitTag":     u,
-			"RelationTag": r,
-			"PortRange": M{
-				"FromPort": f,
-				"ToPort":   t,
-				"Protocol": p,
+			"unit-tag":     u,
+			"relation-tag": r,
+			"port-range": M{
+				"from-port": f,
+				"to-port":   t,
+				"protocol":  p,
 			},
 		}
 	}

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -40,24 +40,24 @@ type FindTagsResults struct {
 
 // Entity identifies a single entity.
 type Entity struct {
-	Tag string
+	Tag string `json:"tag"`
 }
 
 // Entities identifies multiple entities.
 type Entities struct {
-	Entities []Entity
+	Entities []Entity `json:"entities"`
 }
 
 // EntityPasswords holds the parameters for making a SetPasswords call.
 type EntityPasswords struct {
-	Changes []EntityPassword
+	Changes []EntityPassword `json:"changes"`
 }
 
 // EntityPassword specifies a password change for the entity
 // with the given tag.
 type EntityPassword struct {
-	Tag      string
-	Password string
+	Tag      string `json:"tag"`
+	Password string `json:"password"`
 }
 
 // ErrorResults holds the results of calling a bulk operation which
@@ -65,7 +65,7 @@ type EntityPassword struct {
 // number of elements matches the operations specified in the request.
 type ErrorResults struct {
 	// Results contains the error results from each operation.
-	Results []ErrorResult
+	Results []ErrorResult `json:"results"`
 }
 
 // OneError returns the error from the result
@@ -98,61 +98,61 @@ func (result ErrorResults) Combine() error {
 
 // ErrorResult holds the error status of a single operation.
 type ErrorResult struct {
-	Error *Error
+	Error *Error `json:"error,omitempty"`
 }
 
 // AddRelation holds the parameters for making the AddRelation call.
 // The endpoints specified are unordered.
 type AddRelation struct {
-	Endpoints []string
+	Endpoints []string `json:"endpoints"`
 }
 
 // AddRelationResults holds the results of a AddRelation call. The Endpoints
 // field maps application names to the involved endpoints.
 type AddRelationResults struct {
-	Endpoints map[string]charm.Relation
+	Endpoints map[string]charm.Relation `json:"endpoints"`
 }
 
 // DestroyRelation holds the parameters for making the DestroyRelation call.
 // The endpoints specified are unordered.
 type DestroyRelation struct {
-	Endpoints []string
+	Endpoints []string `json:"endpoints"`
 }
 
 // AddCharm holds the arguments for making an AddCharm API call.
 type AddCharm struct {
-	URL     string
-	Channel string
+	URL     string `json:"url"`
+	Channel string `json:"channel"`
 }
 
 // AddCharmWithAuthorization holds the arguments for making an AddCharmWithAuthorization API call.
 type AddCharmWithAuthorization struct {
-	URL                string
-	Channel            string
-	CharmStoreMacaroon *macaroon.Macaroon
+	URL                string             `json:"url"`
+	Channel            string             `json:"channel"`
+	CharmStoreMacaroon *macaroon.Macaroon `json:"macaroon"`
 }
 
 // AddMachineParams encapsulates the parameters used to create a new machine.
 type AddMachineParams struct {
 	// The following fields hold attributes that will be given to the
 	// new machine when it is created.
-	Series      string                    `json:"Series"`
-	Constraints constraints.Value         `json:"Constraints"`
-	Jobs        []multiwatcher.MachineJob `json:"Jobs"`
+	Series      string                    `json:"series"`
+	Constraints constraints.Value         `json:"constraints"`
+	Jobs        []multiwatcher.MachineJob `json:"jobs"`
 
 	// Disks describes constraints for disks that must be attached to
 	// the machine when it is provisioned.
-	Disks []storage.Constraints `json:"Disks"`
+	Disks []storage.Constraints `json:"disks,omitempty"`
 
 	// If Placement is non-nil, it contains a placement directive
 	// that will be used to decide how to instantiate the machine.
-	Placement *instance.Placement `json:"Placement"`
+	Placement *instance.Placement `json:"placement,omitempty"`
 
 	// If ParentId is non-empty, it specifies the id of the
 	// parent machine within which the new machine will
 	// be created. In that case, ContainerType must also be
 	// set.
-	ParentId string `json:"ParentId"`
+	ParentId string `json:"parent-id"`
 
 	// ContainerType optionally gives the container type of the
 	// new machine. If it is non-empty, the new machine
@@ -160,214 +160,214 @@ type AddMachineParams struct {
 	// but ParentId is empty, a new top level machine will
 	// be created to hold the container with given series,
 	// constraints and jobs.
-	ContainerType instance.ContainerType `json:"ContainerType"`
+	ContainerType instance.ContainerType `json:"container-type"`
 
 	// If InstanceId is non-empty, it will be associated with
 	// the new machine along with the given nonce,
 	// hardware characteristics and addresses.
 	// All the following fields will be ignored if ContainerType
 	// is set.
-	InstanceId              instance.Id                      `json:"InstanceId"`
-	Nonce                   string                           `json:"Nonce"`
-	HardwareCharacteristics instance.HardwareCharacteristics `json:"HardwareCharacteristics"`
-	Addrs                   []Address                        `json:"Addrs"`
+	InstanceId              instance.Id                      `json:"instance-id"`
+	Nonce                   string                           `json:"nonce"`
+	HardwareCharacteristics instance.HardwareCharacteristics `json:"hardware-characteristics"`
+	Addrs                   []Address                        `json:"addresses"`
 }
 
 // AddMachines holds the parameters for making the AddMachines call.
 type AddMachines struct {
-	MachineParams []AddMachineParams `json:"MachineParams"`
+	MachineParams []AddMachineParams `json:"params"`
 }
 
 // AddMachinesResults holds the results of an AddMachines call.
 type AddMachinesResults struct {
-	Machines []AddMachinesResult `json:"Machines"`
+	Machines []AddMachinesResult `json:"machines"`
 }
 
 // AddMachinesResult holds the name of a machine added by the
 // api.client.AddMachine call for a single machine.
 type AddMachinesResult struct {
-	Machine string `json:"Machine"`
-	Error   *Error `json:"Error"`
+	Machine string `json:"machine"`
+	Error   *Error `json:"error,omitempty"`
 }
 
 // DestroyMachines holds parameters for the DestroyMachines call.
 type DestroyMachines struct {
-	MachineNames []string
-	Force        bool
+	MachineNames []string `json:"machine-names"`
+	Force        bool     `json:"force"`
 }
 
 // ApplicationsDeploy holds the parameters for deploying one or more applications.
 type ApplicationsDeploy struct {
-	Applications []ApplicationDeploy
+	Applications []ApplicationDeploy `json:"applications"`
 }
 
 // ApplicationDeploy holds the parameters for making the application Deploy call.
 type ApplicationDeploy struct {
-	ApplicationName  string
-	Series           string
-	CharmUrl         string
-	Channel          string
-	NumUnits         int
-	Config           map[string]string
-	ConfigYAML       string // Takes precedence over config if both are present.
-	Constraints      constraints.Value
-	Placement        []*instance.Placement
-	Storage          map[string]storage.Constraints
-	EndpointBindings map[string]string
-	Resources        map[string]string
+	ApplicationName  string                         `json:"application"`
+	Series           string                         `json:"series"`
+	CharmUrl         string                         `json:"charm-url"`
+	Channel          string                         `json:"channel"`
+	NumUnits         int                            `json:"num-units"`
+	Config           map[string]string              `json:"config,omitempty"`
+	ConfigYAML       string                         `json:"config-yaml"` // Takes precedence over config if both are present.
+	Constraints      constraints.Value              `json:"constraints"`
+	Placement        []*instance.Placement          `json:"placement,omitempty"`
+	Storage          map[string]storage.Constraints `json:"storage,omitempty"`
+	EndpointBindings map[string]string              `json:"endpoint-bindings,omitempty"`
+	Resources        map[string]string              `json:"resources,omitempty"`
 }
 
 // ApplicationUpdate holds the parameters for making the application Update call.
 type ApplicationUpdate struct {
-	ApplicationName string
-	CharmUrl        string
-	ForceCharmUrl   bool
-	ForceSeries     bool
-	MinUnits        *int
-	SettingsStrings map[string]string
-	SettingsYAML    string // Takes precedence over SettingsStrings if both are present.
-	Constraints     *constraints.Value
+	ApplicationName string             `json:"application"`
+	CharmUrl        string             `json:"charm-url"`
+	ForceCharmUrl   bool               `json:"force-charm-url"`
+	ForceSeries     bool               `json:"force-series"`
+	MinUnits        *int               `json:"min-units,omitempty"`
+	SettingsStrings map[string]string  `json:"settings,omitempty"`
+	SettingsYAML    string             `json:"settings-yaml"` // Takes precedence over SettingsStrings if both are present.
+	Constraints     *constraints.Value `json:"constraints,omitempty"`
 }
 
 // ApplicationSetCharm sets the charm for a given application.
 type ApplicationSetCharm struct {
 	// ApplicationName is the name of the application to set the charm on.
-	ApplicationName string `json:"applicationname"`
+	ApplicationName string `json:"application"`
 	// CharmUrl is the new url for the charm.
-	CharmUrl string `json:"charmurl"`
+	CharmUrl string `json:"charm-url"`
 	// Channel is the charm store channel from which the charm came.
-	Channel string `json:"cs-channel"`
+	Channel string `json:"channel"`
 	// ForceUnits forces the upgrade on units in an error state.
-	ForceUnits bool `json:"forceunits"`
+	ForceUnits bool `json:"force-units"`
 	// ForceSeries forces the use of the charm even if it doesn't match the
 	// series of the unit.
-	ForceSeries bool `json:"forceseries"`
+	ForceSeries bool `json:"force-series"`
 	// ResourceIDs is a map of resource names to resource IDs to activate during
 	// the upgrade.
-	ResourceIDs map[string]string `json:"resourceids"`
+	ResourceIDs map[string]string `json:"resource-ids,omitempty"`
 }
 
 // ApplicationExpose holds the parameters for making the application Expose call.
 type ApplicationExpose struct {
-	ApplicationName string
+	ApplicationName string `json:"application"`
 }
 
 // ApplicationSet holds the parameters for an application Set
 // command. Options contains the configuration data.
 type ApplicationSet struct {
-	ApplicationName string
-	Options         map[string]string
+	ApplicationName string            `json:"application"`
+	Options         map[string]string `json:"options"`
 }
 
 // ApplicationUnset holds the parameters for an application Unset
 // command. Options contains the option attribute names
 // to unset.
 type ApplicationUnset struct {
-	ApplicationName string
-	Options         []string
+	ApplicationName string   `json:"application"`
+	Options         []string `json:"options"`
 }
 
 // ApplicationGet holds parameters for making the Get or
 // GetCharmURL calls.
 type ApplicationGet struct {
-	ApplicationName string
+	ApplicationName string `json:"application"`
 }
 
 // ApplicationGetResults holds results of the application Get call.
 type ApplicationGetResults struct {
-	Application string
-	Charm       string
-	Config      map[string]interface{}
-	Constraints constraints.Value
+	Application string                 `json:"application"`
+	Charm       string                 `json:"charm"`
+	Config      map[string]interface{} `json:"config"`
+	Constraints constraints.Value      `json:"constraints"`
 }
 
 // ApplicationCharmRelations holds parameters for making the application CharmRelations call.
 type ApplicationCharmRelations struct {
-	ApplicationName string
+	ApplicationName string `json:"application"`
 }
 
 // ApplicationCharmRelationsResults holds the results of the application CharmRelations call.
 type ApplicationCharmRelationsResults struct {
-	CharmRelations []string
+	CharmRelations []string `json:"charm-relations"`
 }
 
 // ApplicationUnexpose holds parameters for the application Unexpose call.
 type ApplicationUnexpose struct {
-	ApplicationName string
+	ApplicationName string `json:"application"`
 }
 
 // ApplicationMetricCredential holds parameters for the SetApplicationCredentials call.
 type ApplicationMetricCredential struct {
-	ApplicationName   string
-	MetricCredentials []byte
+	ApplicationName   string `json:"application"`
+	MetricCredentials []byte `json:"metrics-credentials"`
 }
 
 // ApplicationMetricCredentials holds multiple ApplicationMetricCredential parameters.
 type ApplicationMetricCredentials struct {
-	Creds []ApplicationMetricCredential
+	Creds []ApplicationMetricCredential `json:"creds"`
 }
 
 // PublicAddress holds parameters for the PublicAddress call.
 type PublicAddress struct {
-	Target string
+	Target string `json:"target"`
 }
 
 // PublicAddressResults holds results of the PublicAddress call.
 type PublicAddressResults struct {
-	PublicAddress string
+	PublicAddress string `json:"public-address"`
 }
 
 // PrivateAddress holds parameters for the PrivateAddress call.
 type PrivateAddress struct {
-	Target string
+	Target string `json:"target"`
 }
 
 // PrivateAddressResults holds results of the PrivateAddress call.
 type PrivateAddressResults struct {
-	PrivateAddress string
+	PrivateAddress string `json:"private-address"`
 }
 
 // Resolved holds parameters for the Resolved call.
 type Resolved struct {
-	UnitName string
-	Retry    bool
+	UnitName string `json:"unit-name"`
+	Retry    bool   `json:"retry"`
 }
 
 // ResolvedResults holds results of the Resolved call.
 type ResolvedResults struct {
-	Application string
-	Charm       string
-	Settings    map[string]interface{}
+	Application string                 `json:"application"`
+	Charm       string                 `json:"charm"`
+	Settings    map[string]interface{} `json:"settings"`
 }
 
 // AddApplicationUnitsResults holds the names of the units added by the
 // AddUnits call.
 type AddApplicationUnitsResults struct {
-	Units []string
+	Units []string `json:"units"`
 }
 
 // AddApplicationUnits holds parameters for the AddUnits call.
 type AddApplicationUnits struct {
-	ApplicationName string
-	NumUnits        int
-	Placement       []*instance.Placement
+	ApplicationName string                `json:"application"`
+	NumUnits        int                   `json:"num-units"`
+	Placement       []*instance.Placement `json:"placement"`
 }
 
 // DestroyApplicationUnits holds parameters for the DestroyUnits call.
 type DestroyApplicationUnits struct {
-	UnitNames []string
+	UnitNames []string `json:"unit-names"`
 }
 
 // ApplicationDestroy holds the parameters for making the application Destroy call.
 type ApplicationDestroy struct {
-	ApplicationName string
+	ApplicationName string `json:"application"`
 }
 
 // Creds holds credentials for identifying an entity.
 type Creds struct {
-	AuthTag  string
-	Password string
-	Nonce    string
+	AuthTag  string `json:"auth-tag"`
+	Password string `json:"password"`
+	Nonce    string `json:"nonce"`
 }
 
 // LoginRequest holds credentials for identifying an entity to the Login v1
@@ -387,94 +387,94 @@ type LoginRequest struct {
 // LoginRequestCompat holds credentials for identifying an entity to the Login v1
 // or earlier (v0 or even pre-facade).
 type LoginRequestCompat struct {
-	LoginRequest
-	Creds
+	LoginRequest `json:"login-request"`
+	Creds        `json:"creds"`
 }
 
 // GetAnnotationsResults holds annotations associated with an entity.
 type GetAnnotationsResults struct {
-	Annotations map[string]string
+	Annotations map[string]string `json:"annotations"`
 }
 
 // GetAnnotations stores parameters for making the GetAnnotations call.
 type GetAnnotations struct {
-	Tag string
+	Tag string `json:"tag"`
 }
 
 // SetAnnotations stores parameters for making the SetAnnotations call.
 type SetAnnotations struct {
-	Tag   string
-	Pairs map[string]string
+	Tag   string            `json:"tag"`
+	Pairs map[string]string `json:"annotations"`
 }
 
 // GetApplicationConstraints stores parameters for making the GetApplicationConstraints call.
 type GetApplicationConstraints struct {
-	ApplicationName string
+	ApplicationName string `json:"application"`
 }
 
 // GetConstraintsResults holds results of the GetConstraints call.
 type GetConstraintsResults struct {
-	Constraints constraints.Value
+	Constraints constraints.Value `json:"constraints"`
 }
 
 // SetConstraints stores parameters for making the SetConstraints call.
 type SetConstraints struct {
-	ApplicationName string //optional, if empty, model constraints are set.
-	Constraints     constraints.Value
+	ApplicationName string            `json:"application"` //optional, if empty, model constraints are set.
+	Constraints     constraints.Value `json:"constraints"`
 }
 
 // ResolveCharms stores charm references for a ResolveCharms call.
 type ResolveCharms struct {
-	References []charm.URL
+	References []charm.URL `json:"references"`
 }
 
 // ResolveCharmResult holds the result of resolving a charm reference to a URL, or any error that occurred.
 type ResolveCharmResult struct {
-	URL   *charm.URL `json:",omitempty"`
-	Error string     `json:",omitempty"`
+	URL   *charm.URL `json:"url,omitempty"`
+	Error string     `json:"error,omitempty"`
 }
 
 // ResolveCharmResults holds results of the ResolveCharms call.
 type ResolveCharmResults struct {
-	URLs []ResolveCharmResult
+	URLs []ResolveCharmResult `json:"urls"`
 }
 
 // AllWatcherId holds the id of an AllWatcher.
 type AllWatcherId struct {
-	AllWatcherId string
+	AllWatcherId string `json:"watcher-id"`
 }
 
 // AllWatcherNextResults holds deltas returned from calling AllWatcher.Next().
 type AllWatcherNextResults struct {
-	Deltas []multiwatcher.Delta
+	Deltas []multiwatcher.Delta `json:"deltas"`
 }
 
 // ListSSHKeys stores parameters used for a KeyManager.ListKeys call.
 type ListSSHKeys struct {
-	Entities
-	Mode ssh.ListMode
+	Entities `json:"entities"`
+	Mode     ssh.ListMode `json:"mode"`
 }
 
 // ModifyUserSSHKeys stores parameters used for a KeyManager.Add|Delete|Import call for a user.
 type ModifyUserSSHKeys struct {
-	User string
-	Keys []string
+	User string   `json:"user"`
+	Keys []string `json:"ssh-keys"`
 }
 
 // StateServingInfo holds information needed by a state
 // server.
 type StateServingInfo struct {
-	APIPort   int
-	StatePort int
+	APIPort   int `json:"api-port"`
+	StatePort int `json:"state-port"`
 	// The controller cert and corresponding private key.
-	Cert       string
-	PrivateKey string
+	Cert       string `json:"cert"`
+	PrivateKey string `json:"private-key"`
 	// The private key for the CA cert so that a new controller
 	// cert can be generated when needed.
-	CAPrivateKey string
+	CAPrivateKey string `json:"ca-private-key"`
 	// this will be passed as the KeyFile argument to MongoDB
-	SharedSecret   string
-	SystemIdentity string
+	SharedSecret   string `json:"shared-secret"`
+	SystemIdentity string `json:"system-identity"`
 }
 
 // IsMasterResult holds the result of an IsMaster API call.
@@ -482,106 +482,106 @@ type IsMasterResult struct {
 	// Master reports whether the connected agent
 	// lives on the same instance as the mongo replica
 	// set master.
-	Master bool
+	Master bool `json:"master"`
 }
 
 // ContainerManagerConfigParams contains the parameters for the
 // ContainerManagerConfig provisioner API call.
 type ContainerManagerConfigParams struct {
-	Type instance.ContainerType
+	Type instance.ContainerType `json:"type"`
 }
 
 // ContainerManagerConfig contains information from the model config
 // that is needed for configuring the container manager.
 type ContainerManagerConfig struct {
-	ManagerConfig map[string]string
+	ManagerConfig map[string]string `json:"config"`
 }
 
 // UpdateBehavior contains settings that are duplicated in several
 // places. Let's just embed this instead.
 type UpdateBehavior struct {
-	EnableOSRefreshUpdate bool
-	EnableOSUpgrade       bool
+	EnableOSRefreshUpdate bool `json:"enable-os-refresh-update"`
+	EnableOSUpgrade       bool `json:"enable-os-upgrade"`
 }
 
 // ContainerConfig contains information from the model config that is
 // needed for container cloud-init.
 type ContainerConfig struct {
-	ProviderType            string
-	AuthorizedKeys          string
-	SSLHostnameVerification bool
-	Proxy                   proxy.Settings
-	AptProxy                proxy.Settings
-	AptMirror               string
+	ProviderType            string         `json:"provider-type"`
+	AuthorizedKeys          string         `json:"authorized-keys"`
+	SSLHostnameVerification bool           `json:"ssl-hostname-verification"`
+	Proxy                   proxy.Settings `json:"proxy"`
+	AptProxy                proxy.Settings `json:"apt-proxy"`
+	AptMirror               string         `json:"apt-mirror"`
 	*UpdateBehavior
 }
 
 // ProvisioningScriptParams contains the parameters for the
 // ProvisioningScript client API call.
 type ProvisioningScriptParams struct {
-	MachineId string
-	Nonce     string
+	MachineId string `json:"machine-id"`
+	Nonce     string `json:"nonce"`
 
 	// DataDir may be "", in which case the default will be used.
-	DataDir string
+	DataDir string `json:"data-dir"`
 
 	// DisablePackageCommands may be set to disable all
 	// package-related commands. It is then the responsibility of the
 	// provisioner to ensure that all the packages required by Juju
 	// are available.
-	DisablePackageCommands bool
+	DisablePackageCommands bool `json:"disable-package-commands"`
 }
 
 // ProvisioningScriptResult contains the result of the
 // ProvisioningScript client API call.
 type ProvisioningScriptResult struct {
-	Script string
+	Script string `json:"script"`
 }
 
 // DeployerConnectionValues containers the result of deployer.ConnectionInfo
 // API call.
 type DeployerConnectionValues struct {
-	StateAddresses []string
-	APIAddresses   []string
+	StateAddresses []string `json:"state-addresses"`
+	APIAddresses   []string `json:"api-addresses"`
 }
 
 // JobsResult holds the jobs for a machine that are returned by a call to Jobs.
 type JobsResult struct {
-	Jobs  []multiwatcher.MachineJob `json:"Jobs"`
-	Error *Error                    `json:"Error"`
+	Jobs  []multiwatcher.MachineJob `json:"jobs"`
+	Error *Error                    `json:"error,omitempty"`
 }
 
 // JobsResults holds the result of a call to Jobs.
 type JobsResults struct {
-	Results []JobsResult `json:"Results"`
+	Results []JobsResult `json:"results"`
 }
 
 // DistributionGroupResult contains the result of
 // the DistributionGroup provisioner API call.
 type DistributionGroupResult struct {
-	Error  *Error
-	Result []instance.Id
+	Error  *Error        `json:"error,omitempty"`
+	Result []instance.Id `json:"result"`
 }
 
 // DistributionGroupResults is the bulk form of
 // DistributionGroupResult.
 type DistributionGroupResults struct {
-	Results []DistributionGroupResult
+	Results []DistributionGroupResult `json:"results"`
 }
 
 // FacadeVersions describes the available Facades and what versions of each one
 // are available
 type FacadeVersions struct {
-	Name     string
-	Versions []int
+	Name     string `json:"name"`
+	Versions []int  `json:"versions"`
 }
 
 // LoginResult holds the result of a Login call.
 type LoginResult struct {
-	Servers        [][]HostPort     `json:"Servers"`
-	ModelTag       string           `json:"ModelTag"`
-	LastConnection *time.Time       `json:"LastConnection"`
-	Facades        []FacadeVersions `json:"Facades"`
+	Servers        [][]HostPort     `json:"servers"`
+	ModelTag       string           `json:"model-tag"`
+	LastConnection *time.Time       `json:"last-connection"`
+	Facades        []FacadeVersions `json:"facades"`
 }
 
 // ReauthRequest holds a challenge/response token meaningful to the identity
@@ -643,7 +643,7 @@ type LoginResultV1 struct {
 // ControllersServersSpec contains arguments for
 // the EnableHA client API call.
 type ControllersSpec struct {
-	ModelTag       string
+	ModelTag       string            `json:"model-tag"`
 	NumControllers int               `json:"num-controllers"`
 	Constraints    constraints.Value `json:"constraints,omitempty"`
 	// Series is the series to associate with new controller machines.
@@ -656,21 +656,21 @@ type ControllersSpec struct {
 // ControllersServersSpecs contains all the arguments
 // for the EnableHA API call.
 type ControllersSpecs struct {
-	Specs []ControllersSpec
+	Specs []ControllersSpec `json:"specs"`
 }
 
 // ControllersChangeResult contains the results
 // of a single EnableHA API call or
 // an error.
 type ControllersChangeResult struct {
-	Result ControllersChanges
-	Error  *Error
+	Result ControllersChanges `json:"result"`
+	Error  *Error             `json:"error,omitempty"`
 }
 
 // ControllersChangeResults contains the results
 // of the EnableHA API call.
 type ControllersChangeResults struct {
-	Results []ControllersChangeResult
+	Results []ControllersChangeResult `json:"results"`
 }
 
 // ControllersChanges lists the servers
@@ -688,26 +688,26 @@ type ControllersChanges struct {
 // FindToolsParams defines parameters for the FindTools method.
 type FindToolsParams struct {
 	// Number will be used to match tools versions exactly if non-zero.
-	Number version.Number
+	Number version.Number `json:"number"`
 
 	// MajorVersion will be used to match the major version if non-zero.
-	MajorVersion int
+	MajorVersion int `json:"major"`
 
 	// MinorVersion will be used to match the major version if greater
 	// than or equal to zero, and Number is zero.
-	MinorVersion int
+	MinorVersion int `json:"minor"`
 
 	// Arch will be used to match tools by architecture if non-empty.
-	Arch string
+	Arch string `json:"arch"`
 
 	// Series will be used to match tools by series if non-empty.
-	Series string
+	Series string `json:"series"`
 }
 
 // FindToolsResult holds a list of tools from FindTools and any error.
 type FindToolsResult struct {
-	List  tools.List
-	Error *Error
+	List  tools.List `json:"list"`
+	Error *Error     `json:"error,omitempty"`
 }
 
 // ImageFilterParams holds the parameters used to specify images to delete.
@@ -792,29 +792,29 @@ type BundleChangesChange struct {
 // UpgradeMongoParams holds the arguments required to
 // enter upgrade mongo mode.
 type UpgradeMongoParams struct {
-	Target mongo.Version
+	Target mongo.Version `json:"target"`
 }
 
 // HAMember holds information that identifies one member
 // of HA.
 type HAMember struct {
-	Tag           string
-	PublicAddress network.Address
-	Series        string
+	Tag           string          `json:"tag"`
+	PublicAddress network.Address `json:"public-address"`
+	Series        string          `json:"series"`
 }
 
 // MongoUpgradeResults holds the results of an attempt
 // to enter upgrade mongo mode.
 type MongoUpgradeResults struct {
-	RsMembers []replicaset.Member
-	Master    HAMember
-	Members   []HAMember
+	RsMembers []replicaset.Member `json:"rs-members"`
+	Master    HAMember            `json:"master"`
+	Members   []HAMember          `json:"ha-members"`
 }
 
 // ResumeReplicationParams holds the members of a HA that
 // must be resumed.
 type ResumeReplicationParams struct {
-	Members []replicaset.Member
+	Members []replicaset.Member `json:"members"`
 }
 
 // MeterStatusParam holds meter status information to be set for the specified tag.

--- a/apiserver/params/registration.go
+++ b/apiserver/params/registration.go
@@ -24,7 +24,7 @@ type SecretKeyLoginRequest struct {
 	// PayloadCiphertext is the encrypted and authenticated
 	// payload. The payload is encrypted/authenticated using
 	// NaCl Secretbox.
-	PayloadCiphertext []byte `json:"ciphertext"`
+	PayloadCiphertext []byte `json:"cipher-text"`
 }
 
 // SecretKeyLoginRequestPayload is JSON-encoded and then encrypted
@@ -45,7 +45,7 @@ type SecretKeyLoginResponse struct {
 
 	// PayloadCiphertext is the encrypted and authenticated
 	// payload, which is a JSON-encoded SecretKeyLoginResponsePayload.
-	PayloadCiphertext []byte `json:"ciphertext"`
+	PayloadCiphertext []byte `json:"cipher-text"`
 }
 
 // SecretKeyLoginResponsePayload is JSON-encoded and then encrypted

--- a/apiserver/params/retrystrategy.go
+++ b/apiserver/params/retrystrategy.go
@@ -10,21 +10,21 @@ import (
 
 // RetryStrategy holds the necessary information to configure retries.
 type RetryStrategy struct {
-	ShouldRetry     bool
-	MinRetryTime    time.Duration
-	MaxRetryTime    time.Duration
-	JitterRetryTime bool
-	RetryTimeFactor int64
+	ShouldRetry     bool          `json:"should-retry"`
+	MinRetryTime    time.Duration `json:"min-retry-time"`
+	MaxRetryTime    time.Duration `json:"max-retry-time"`
+	JitterRetryTime bool          `json:"jitter-retry-time"`
+	RetryTimeFactor int64         `json:"retry-time-factor"`
 }
 
 // RetryStrategyResult holds a RetryStrategy or an error.
 type RetryStrategyResult struct {
-	Error  *Error
-	Result *RetryStrategy
+	Error  *Error         `json:"error,omitempty"`
+	Result *RetryStrategy `json:"result,omitempty"`
 }
 
 // RetryStrategyResults holds the bulk operation result of an API call
 // that returns a RetryStrategy or an error.
 type RetryStrategyResults struct {
-	Results []RetryStrategyResult
+	Results []RetryStrategyResult `json:"results"`
 }

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -9,13 +9,13 @@ import "github.com/juju/juju/storage"
 // on that machine.
 type MachineBlockDevices struct {
 	Machine      string                `json:"machine"`
-	BlockDevices []storage.BlockDevice `json:"blockdevices,omitempty"`
+	BlockDevices []storage.BlockDevice `json:"block-devices,omitempty"`
 }
 
 // SetMachineBlockDevices holds the arguments for recording the block
 // devices present on a set of machines.
 type SetMachineBlockDevices struct {
-	MachineBlockDevices []MachineBlockDevices `json:"machineblockdevices"`
+	MachineBlockDevices []MachineBlockDevices `json:"machine-block-devices"`
 }
 
 // BlockDeviceResult holds the result of an API call to retrieve details
@@ -46,9 +46,9 @@ type BlockDevicesResults struct {
 
 // StorageInstance describes a storage instance.
 type StorageInstance struct {
-	StorageTag string
-	OwnerTag   string
-	Kind       StorageKind
+	StorageTag string      `json:"storage-tag"`
+	OwnerTag   string      `json:"owner-tag"`
+	Kind       StorageKind `json:"kind"`
 }
 
 // StorageKind is the kind of a storage instance.
@@ -87,20 +87,20 @@ type StorageInstanceResults struct {
 
 // StorageAttachment describes a unit's attached storage instance.
 type StorageAttachment struct {
-	StorageTag string
-	OwnerTag   string
-	UnitTag    string
+	StorageTag string `json:"storage-tag"`
+	OwnerTag   string `json:"owner-tag"`
+	UnitTag    string `json:"unit-tag"`
 
-	Kind     StorageKind
-	Location string
-	Life     Life
+	Kind     StorageKind `json:"kind"`
+	Location string      `json:"location"`
+	Life     Life        `json:"life"`
 }
 
 // StorageAttachmentId identifies a storage attachment by the tags of the
 // related unit and storage instance.
 type StorageAttachmentId struct {
-	StorageTag string `json:"storagetag"`
-	UnitTag    string `json:"unittag"`
+	StorageTag string `json:"storage-tag"`
+	UnitTag    string `json:"unit-tag"`
 }
 
 // StorageAttachmentIds holds a set of storage attachment identifiers.
@@ -150,10 +150,10 @@ type StorageAttachmentResults struct {
 // MachineStorageId identifies the attachment of a storage entity
 // to a machine, by their tags.
 type MachineStorageId struct {
-	MachineTag string `json:"machinetag"`
+	MachineTag string `json:"machine-tag"`
 	// AttachmentTag is the tag of the volume or filesystem whose
 	// attachment to the machine is represented.
-	AttachmentTag string `json:"attachmenttag"`
+	AttachmentTag string `json:"attachment-tag"`
 }
 
 // MachineStorageIds holds a set of machine/storage-entity
@@ -164,14 +164,14 @@ type MachineStorageIds struct {
 
 // Volume identifies and describes a storage volume in the model.
 type Volume struct {
-	VolumeTag string     `json:"volumetag"`
+	VolumeTag string     `json:"volume-tag"`
 	Info      VolumeInfo `json:"info"`
 }
 
 // Volume describes a storage volume in the model.
 type VolumeInfo struct {
-	VolumeId   string `json:"volumeid"`
-	HardwareId string `json:"hardwareid,omitempty"`
+	VolumeId   string `json:"volume-id"`
+	HardwareId string `json:"hardware-id,omitempty"`
 	// Size is the size of the volume in MiB.
 	Size       uint64 `json:"size"`
 	Persistent bool   `json:"persistent"`
@@ -184,27 +184,27 @@ type Volumes struct {
 
 // VolumeAttachment identifies and describes a volume attachment.
 type VolumeAttachment struct {
-	VolumeTag  string               `json:"volumetag"`
-	MachineTag string               `json:"machinetag"`
+	VolumeTag  string               `json:"volume-tag"`
+	MachineTag string               `json:"machine-tag"`
 	Info       VolumeAttachmentInfo `json:"info"`
 }
 
 // VolumeAttachmentInfo describes a volume attachment.
 type VolumeAttachmentInfo struct {
-	DeviceName string `json:"devicename,omitempty"`
-	DeviceLink string `json:"devicelink,omitempty"`
-	BusAddress string `json:"busaddress,omitempty"`
+	DeviceName string `json:"device-name,omitempty"`
+	DeviceLink string `json:"device-link,omitempty"`
+	BusAddress string `json:"bus-address,omitempty"`
 	ReadOnly   bool   `json:"read-only,omitempty"`
 }
 
 // VolumeAttachments describes a set of storage volume attachments.
 type VolumeAttachments struct {
-	VolumeAttachments []VolumeAttachment `json:"volumeattachments"`
+	VolumeAttachments []VolumeAttachment `json:"volume-attachments"`
 }
 
 // VolumeParams holds the parameters for creating a storage volume.
 type VolumeParams struct {
-	VolumeTag  string                  `json:"volumetag"`
+	VolumeTag  string                  `json:"volume-tag"`
 	Size       uint64                  `json:"size"`
 	Provider   string                  `json:"provider"`
 	Attributes map[string]interface{}  `json:"attributes,omitempty"`
@@ -215,10 +215,10 @@ type VolumeParams struct {
 // VolumeAttachmentParams holds the parameters for creating a volume
 // attachment.
 type VolumeAttachmentParams struct {
-	VolumeTag  string `json:"volumetag"`
-	MachineTag string `json:"machinetag"`
-	VolumeId   string `json:"volumeid,omitempty"`
-	InstanceId string `json:"instanceid,omitempty"`
+	VolumeTag  string `json:"volume-tag"`
+	MachineTag string `json:"machine-tag"`
+	VolumeId   string `json:"volume-id,omitempty"`
+	InstanceId string `json:"instance-id,omitempty"`
 	Provider   string `json:"provider"`
 	ReadOnly   bool   `json:"read-only,omitempty"`
 }
@@ -285,14 +285,14 @@ type VolumeAttachmentParamsResults struct {
 
 // Filesystem identifies and describes a storage filesystem in the model.
 type Filesystem struct {
-	FilesystemTag string         `json:"filesystemtag"`
-	VolumeTag     string         `json:"volumetag,omitempty"`
+	FilesystemTag string         `json:"filesystem-tag"`
+	VolumeTag     string         `json:"volume-tag,omitempty"`
 	Info          FilesystemInfo `json:"info"`
 }
 
 // Filesystem describes a storage filesystem in the model.
 type FilesystemInfo struct {
-	FilesystemId string `json:"filesystemid"`
+	FilesystemId string `json:"filesystem-id"`
 	// Size is the size of the filesystem in MiB.
 	Size uint64 `json:"size"`
 }
@@ -304,26 +304,26 @@ type Filesystems struct {
 
 // FilesystemAttachment identifies and describes a filesystem attachment.
 type FilesystemAttachment struct {
-	FilesystemTag string                   `json:"filesystemtag"`
-	MachineTag    string                   `json:"machinetag"`
+	FilesystemTag string                   `json:"filesystem-tag"`
+	MachineTag    string                   `json:"machine-tag"`
 	Info          FilesystemAttachmentInfo `json:"info"`
 }
 
 // FilesystemAttachmentInfo describes a filesystem attachment.
 type FilesystemAttachmentInfo struct {
-	MountPoint string `json:"mountpoint,omitempty"`
+	MountPoint string `json:"mount-point,omitempty"`
 	ReadOnly   bool   `json:"read-only,omitempty"`
 }
 
 // FilesystemAttachments describes a set of storage filesystem attachments.
 type FilesystemAttachments struct {
-	FilesystemAttachments []FilesystemAttachment `json:"filesystemattachments"`
+	FilesystemAttachments []FilesystemAttachment `json:"filesystem-attachments"`
 }
 
 // FilesystemParams holds the parameters for creating a storage filesystem.
 type FilesystemParams struct {
-	FilesystemTag string                      `json:"filesystemtag"`
-	VolumeTag     string                      `json:"volumetag,omitempty"`
+	FilesystemTag string                      `json:"filesystem-tag"`
+	VolumeTag     string                      `json:"volume-tag,omitempty"`
 	Size          uint64                      `json:"size"`
 	Provider      string                      `json:"provider"`
 	Attributes    map[string]interface{}      `json:"attributes,omitempty"`
@@ -334,12 +334,12 @@ type FilesystemParams struct {
 // FilesystemAttachmentParams holds the parameters for creating a filesystem
 // attachment.
 type FilesystemAttachmentParams struct {
-	FilesystemTag string `json:"filesystemtag"`
-	MachineTag    string `json:"machinetag"`
-	FilesystemId  string `json:"filesystemid,omitempty"`
-	InstanceId    string `json:"instanceid,omitempty"`
+	FilesystemTag string `json:"filesystem-tag"`
+	MachineTag    string `json:"machine-tag"`
+	FilesystemId  string `json:"filesystem-id,omitempty"`
+	InstanceId    string `json:"instance-id,omitempty"`
 	Provider      string `json:"provider"`
-	MountPoint    string `json:"mountpoint,omitempty"`
+	MountPoint    string `json:"mount-point,omitempty"`
 	ReadOnly      bool   `json:"read-only,omitempty"`
 }
 
@@ -393,10 +393,10 @@ type FilesystemAttachmentParamsResults struct {
 // StorageDetails holds information about storage.
 type StorageDetails struct {
 	// StorageTag holds tag for this storage.
-	StorageTag string `json:"storagetag"`
+	StorageTag string `json:"storage-tag"`
 
 	// OwnerTag holds tag for the owner of this storage, unit or application.
-	OwnerTag string `json:"ownertag"`
+	OwnerTag string `json:"owner-tag"`
 
 	// Kind holds what kind of storage this instance is.
 	Kind StorageKind `json:"kind"`
@@ -407,7 +407,7 @@ type StorageDetails struct {
 	// Persistent reports whether or not the underlying volume or
 	// filesystem is persistent; i.e. whether or not it outlives
 	// the machine that it is attached to.
-	Persistent bool
+	Persistent bool `json:"persistent"`
 
 	// Attachments contains a mapping from unit tag to
 	// storage attachment details.
@@ -451,13 +451,13 @@ type StorageDetailsListResults struct {
 // StorageAttachmentDetails holds detailed information about a storage attachment.
 type StorageAttachmentDetails struct {
 	// StorageTag is the tag of the storage instance.
-	StorageTag string `json:"storagetag"`
+	StorageTag string `json:"storage-tag"`
 
 	// UnitTag is the tag of the unit attached to the storage instance.
-	UnitTag string `json:"unittag"`
+	UnitTag string `json:"unit-tag"`
 
 	// MachineTag is the tag of the machine that the attached unit is assigned to.
-	MachineTag string `json:"machinetag"`
+	MachineTag string `json:"machine-tag"`
 
 	// Location holds location (mount point/device path) of
 	// the attached storage.
@@ -492,7 +492,7 @@ type StoragePoolFilters struct {
 
 // StoragePoolsResult holds a collection of storage pools.
 type StoragePoolsResult struct {
-	Result []StoragePool `json:"storagepools,omitempty"`
+	Result []StoragePool `json:"storage-pools,omitempty"`
 	Error  *Error        `json:"error,omitempty"`
 }
 
@@ -542,7 +542,7 @@ type FilesystemFilters struct {
 // information (status, attachments, storage).
 type VolumeDetails struct {
 	// VolumeTag is the tag for the volume.
-	VolumeTag string `json:"volumetag"`
+	VolumeTag string `json:"volume-tag"`
 
 	// Info contains information about the volume.
 	Info VolumeInfo `json:"info"`
@@ -552,7 +552,7 @@ type VolumeDetails struct {
 
 	// MachineAttachments contains a mapping from
 	// machine tag to volume attachment information.
-	MachineAttachments map[string]VolumeAttachmentInfo `json:"machineattachments,omitempty"`
+	MachineAttachments map[string]VolumeAttachmentInfo `json:"machine-attachments,omitempty"`
 
 	// Storage contains details about the storage instance
 	// that the volume is assigned to, if any.
@@ -594,11 +594,11 @@ type VolumeDetailsListResults struct {
 // information (status, attachments, storage).
 type FilesystemDetails struct {
 	// FilesystemTag is the tag for the filesystem.
-	FilesystemTag string `json:"filesystemtag"`
+	FilesystemTag string `json:"filesystem-tag"`
 
 	// VolumeTag is the tag for the volume backing the
 	// filesystem, if any.
-	VolumeTag string `json:"volumetag,omitempty"`
+	VolumeTag string `json:"volume-tag,omitempty"`
 
 	// Info contains information about the filesystem.
 	Info FilesystemInfo `json:"info"`
@@ -608,7 +608,7 @@ type FilesystemDetails struct {
 
 	// MachineAttachments contains a mapping from
 	// machine tag to filesystem attachment information.
-	MachineAttachments map[string]FilesystemAttachmentInfo `json:"machineattachments,omitempty"`
+	MachineAttachments map[string]FilesystemAttachmentInfo `json:"machine-attachments,omitempty"`
 
 	// Storage contains details about the storage instance
 	// that the volume is assigned to, if any.
@@ -643,13 +643,13 @@ type FilesystemDetailsListResults struct {
 type StorageConstraints struct {
 	// Pool is the name of the storage pool from which to provision the
 	// storage instance.
-	Pool string `bson:"pool,omitempty"`
+	Pool string `json:"pool,omitempty"`
 
 	// Size is the required size of the storage instance, in MiB.
-	Size *uint64 `bson:"size,omitempty"`
+	Size *uint64 `json:"size,omitempty"`
 
 	// Count is the required number of storage instances.
-	Count *uint64 `bson:"count,omitempty"`
+	Count *uint64 `json:"count,omitempty"`
 }
 
 // StorageAddParams holds storage details to add to a unit dynamically.
@@ -658,7 +658,7 @@ type StorageAddParams struct {
 	UnitTag string `json:"unit"`
 
 	// StorageName is the name of the storage as specified in the charm.
-	StorageName string `bson:"name"`
+	StorageName string `json:"name"`
 
 	// Constraints are specified storage constraints.
 	Constraints StorageConstraints `json:"storage"`

--- a/apiserver/params/undertaker.go
+++ b/apiserver/params/undertaker.go
@@ -5,16 +5,16 @@ package params
 
 // UndertakerModelInfo returns information on an model needed by the undertaker worker.
 type UndertakerModelInfo struct {
-	UUID       string
-	Name       string
-	GlobalName string
-	IsSystem   bool
-	Life       Life
+	UUID       string `json:"uuid"`
+	Name       string `json:"name"`
+	GlobalName string `json:"global-name"`
+	IsSystem   bool   `json:"is-system"`
+	Life       Life   `json:"life"`
 }
 
 // UndertakerModelInfoResult holds the result of an API call that returns an
 // UndertakerModelInfoResult or an error.
 type UndertakerModelInfoResult struct {
-	Error  *Error
-	Result UndertakerModelInfo
+	Error  *Error              `json:"error,omitempty"`
+	Result UndertakerModelInfo `json:"result"`
 }

--- a/apiserver/registration_test.go
+++ b/apiserver/registration_test.go
@@ -174,7 +174,7 @@ func (s *registrationSuite) TestRegisterInvalidRequestPayload(c *gc.C) {
 	ciphertext := s.sealBox(c, validNonce, s.bob.SecretKey(), "[]")
 	s.testInvalidRequest(c,
 		fmt.Sprintf(
-			`{"user": "user-bob", "nonce": "%s", "ciphertext": "%s"}`,
+			`{"user": "user-bob", "nonce": "%s", "cipher-text": "%s"}`,
 			base64.StdEncoding.EncodeToString(validNonce),
 			base64.StdEncoding.EncodeToString(ciphertext),
 		),


### PR DESCRIPTION
All serialisation tags are lower case, with words separated by dashes.

*Error return values are now consistently "omitempty".

(Review request: http://reviews.vapour.ws/r/5118/)