### PR TITLE
api/migrationmaster: Inject watcher factory

### DIFF
--- a/worker/migrationmaster/shim.go
+++ b/worker/migrationmaster/shim.go
@@ -7,11 +7,12 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/migrationmaster"
+	"github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/worker"
 )
 
 func NewFacade(apiCaller base.APICaller) (Facade, error) {
-	facade := migrationmaster.NewClient(apiCaller)
+	facade := migrationmaster.NewClient(apiCaller, watcher.NewNotifyWatcher)
 	return facade, nil
 }
 


### PR DESCRIPTION
Injecting the factory which creates client-side NotifyWatchers greatly simplifies testing.

Also added some missing test coverage for WatchMinionReports.

(Review request: http://reviews.vapour.ws/r/5121/)