### PR TITLE
Fixed lp:1594580: lxd container invalid parent device name

### DIFF
--- a/container/kvm/kvm_test.go
+++ b/container/kvm/kvm_test.go
@@ -105,12 +105,15 @@ func (s *KVMSuite) TestWriteTemplate(c *gc.C) {
 	params := kvm.CreateMachineParams{
 		Hostname:      "foo-bar",
 		NetworkBridge: "br0",
-		Interfaces: []network.InterfaceInfo{
-			{
-				MACAddress:          "00:16:3e:20:b0:11",
-				ParentInterfaceName: "br-eth0.10",
-			},
-		},
+		Interfaces: []network.InterfaceInfo{{
+			InterfaceName:       "eth0",
+			MACAddress:          "00:16:3e:20:b0:11",
+			ParentInterfaceName: "br-eth0.10",
+		}, {
+			InterfaceName:       "eth42",
+			MACAddress:          "00:16:3e:20:b0:12",
+			ParentInterfaceName: "virbr42",
+		}},
 	}
 	tempDir := c.MkDir()
 
@@ -122,10 +125,14 @@ func (s *KVMSuite) TestWriteTemplate(c *gc.C) {
 
 	template := string(templateBytes)
 
-	c.Assert(template, jc.Contains, "<name>foo-bar</name>")
-	c.Assert(template, jc.Contains, "<mac address='00:16:3e:20:b0:11'/>")
-	c.Assert(template, jc.Contains, "<source bridge='br-eth0.10'/>")
-	c.Assert(strings.Count(string(template), "<interface type='bridge'>"), gc.Equals, 1)
+	c.Check(template, jc.Contains, "<name>foo-bar</name>")
+	c.Check(strings.Count(template, "<interface type='bridge'>"), gc.Equals, 2)
+	c.Check(template, jc.Contains, "<source bridge='br-eth0.10'/>")
+	c.Check(template, jc.Contains, "<mac address='00:16:3e:20:b0:11'/>")
+	c.Check(template, jc.Contains, "<guest dev='eth0'/>")
+	c.Check(template, jc.Contains, "<source bridge='virbr42'/>")
+	c.Check(template, jc.Contains, "<mac address='00:16:3e:20:b0:12'/>")
+	c.Check(template, jc.Contains, "<guest dev='eth42'/>")
 }
 
 func (s *KVMSuite) TestCreateMachineUsesTemplate(c *gc.C) {

--- a/container/kvm/template.go
+++ b/container/kvm/template.go
@@ -49,6 +49,7 @@ var kvmTemplate = `
       <mac address='{{$nic.MACAddress}}'/>
       <model type='virtio'/>
       <source bridge='{{$nic.ParentInterfaceName}}'/>
+      <guest dev='{{$nic.InterfaceName}}'/>
     </interface>
     {{end}}
   </devices>

--- a/worker/provisioner/broker_test.go
+++ b/worker/provisioner/broker_test.go
@@ -4,9 +4,13 @@
 package provisioner_test
 
 import (
+	"io/ioutil"
 	"net"
+	"path/filepath"
 
 	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
@@ -90,4 +94,15 @@ func (f *fakeAPI) ReleaseContainerAddresses(tag names.MachineTag) error {
 		return err
 	}
 	return nil
+}
+
+type patcher interface {
+	PatchValue(destination, source interface{})
+}
+
+func patchResolvConf(s patcher, c *gc.C) {
+	fakeResolvConf := filepath.Join(c.MkDir(), "resolv.conf")
+	err := ioutil.WriteFile(fakeResolvConf, []byte("nameserver ns1.dummy\n"), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	s.PatchValue(provisioner.ResolvConf, fakeResolvConf)
 }

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -75,8 +75,12 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		args.NetworkInfo = preparedInfo
 	}
 
-	// Unlike with LXC, we don't override the default MTU to use.
 	network := container.BridgeNetworkConfig(bridgeDevice, 0, args.NetworkInfo)
+	interfaces, err := finishNetworkConfig(bridgeDevice, args.NetworkInfo)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	network.Interfaces = interfaces
 
 	// The provisioner worker will provide all tools it knows about
 	// (after applying explicitly specified constraints), which may
@@ -126,7 +130,7 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	return &environs.StartInstanceResult{
 		Instance:    inst,
 		Hardware:    hardware,
-		NetworkInfo: network.Interfaces,
+		NetworkInfo: interfaces,
 	}, nil
 }
 

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -65,6 +65,11 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	}
 
 	network := container.BridgeNetworkConfig(bridgeDevice, 0, args.NetworkInfo)
+	interfaces, err := finishNetworkConfig(bridgeDevice, args.NetworkInfo)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	network.Interfaces = interfaces
 
 	// The provisioner worker will provide all tools it knows about
 	// (after applying explicitly specified constraints), which may
@@ -108,7 +113,7 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	return &environs.StartInstanceResult{
 		Instance:    inst,
 		Hardware:    hardware,
-		NetworkInfo: network.Interfaces,
+		NetworkInfo: interfaces,
 	}, nil
 }
 

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -738,7 +738,7 @@ func (s *ProvisionerSuite) TestProvisionerStopRetryingIfDying(c *gc.C) {
 	s.checkNoOperations(c)
 }
 
-func (s *ProvisionerSuite) TestProvisioningDoesNotOccurForLXC(c *gc.C) {
+func (s *ProvisionerSuite) TestProvisioningDoesNotOccurForLXD(c *gc.C) {
 	p := s.newEnvironProvisioner(c)
 	defer stop(c, p)
 


### PR DESCRIPTION
Ensure ParentInterfaceName is set to the container bridge, when it's not
otherwise populated (e.g. when using a single-NIC DHCP fallback config).

Includes a drive-by fix for the KVM broker to set the NIC name inside
the container consistently.

See bug http://pad.lv/1594580/ for more info.

Live tested on MAAS 2.0 and AWS.

(Review request: http://reviews.vapour.ws/r/5125/)