### PR TITLE
Model config forks shared cloud config, records attribute source

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -91,6 +91,7 @@ func InitializeState(
 			Owner:           adminUser,
 			Config:          args.ControllerModelConfig,
 			Constraints:     args.ModelConstraints,
+			CloudName:       args.ControllerCloudName,
 			CloudRegion:     args.ControllerCloudRegion,
 			CloudCredential: args.ControllerCloudCredentialName,
 		},
@@ -154,6 +155,7 @@ func InitializeState(
 		Owner:           adminUser,
 		Config:          hostedModelConfig,
 		Constraints:     args.ModelConstraints,
+		CloudName:       args.ControllerCloudName,
 		CloudRegion:     args.ControllerCloudRegion,
 		CloudCredential: args.ControllerCloudCredentialName,
 	})

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -240,6 +240,11 @@ func (st *mockState) ControllerModel() (modelmanager.Model, error) {
 	return st.controllerModel, st.NextErr()
 }
 
+func (st *mockState) ControllerInfo() (*state.ControllerInfo, error) {
+	st.MethodCall(st, "ControllerInfo")
+	return &state.ControllerInfo{CloudName: "dummy"}, st.NextErr()
+}
+
 func (st *mockState) ControllerConfig() (controller.Config, error) {
 	st.MethodCall(st, "ControllerConfig")
 	return controller.Config{

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -231,10 +231,16 @@ func (mm *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Mode
 		return result, errors.Annotate(err, "failed to create config")
 	}
 
+	controllerInfo, err := mm.state.ControllerInfo()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
 	// NOTE: check the agent-version of the config, and if it is > the current
 	// version, it is not supported, also check existing tools, and if we don't
 	// have tools for that version, also die.
 	model, st, err := mm.state.NewModel(state.ModelArgs{
+		CloudName:       controllerInfo.CloudName,
 		CloudRegion:     cloudRegion,
 		CloudCredential: cloudCredentialName,
 		Config:          newConfig,

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -118,6 +118,7 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 		"ControllerModel",
 		"CloudCredentials",
 		"ControllerConfig",
+		"ControllerInfo",
 		"NewModel",
 		"ForModel",
 		"Model",
@@ -129,7 +130,7 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 	// We cannot predict the UUID, because it's generated,
 	// so we just extract it and ensure that it's not the
 	// same as the controller UUID.
-	newModelArgs := s.st.Calls()[5].Args[0].(state.ModelArgs)
+	newModelArgs := s.st.Calls()[6].Args[0].(state.ModelArgs)
 	uuid := newModelArgs.Config.UUID()
 	c.Assert(uuid, gc.Not(gc.Equals), s.st.controllerModel.cfg.UUID())
 
@@ -152,6 +153,7 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 
 	c.Assert(newModelArgs, jc.DeepEquals, state.ModelArgs{
 		Owner:           names.NewUserTag("admin@local"),
+		CloudName:       "dummy",
 		CloudRegion:     "qux",
 		CloudCredential: "some-credential",
 		Config:          cfg,
@@ -166,7 +168,7 @@ func (s *modelManagerSuite) TestCreateModelDefaultRegion(c *gc.C) {
 	_, err := s.api.CreateModel(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newModelArgs := s.st.Calls()[5].Args[0].(state.ModelArgs)
+	newModelArgs := s.st.Calls()[6].Args[0].(state.ModelArgs)
 	c.Assert(newModelArgs.CloudRegion, gc.Equals, "some-region")
 }
 
@@ -178,7 +180,7 @@ func (s *modelManagerSuite) TestCreateModelDefaultCredentialAdmin(c *gc.C) {
 	_, err := s.api.CreateModel(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newModelArgs := s.st.Calls()[5].Args[0].(state.ModelArgs)
+	newModelArgs := s.st.Calls()[6].Args[0].(state.ModelArgs)
 	c.Assert(newModelArgs.CloudCredential, gc.Equals, "some-credential")
 }
 
@@ -190,7 +192,7 @@ func (s *modelManagerSuite) TestCreateModelEmptyCredentialNonAdmin(c *gc.C) {
 	_, err := s.api.CreateModel(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newModelArgs := s.st.Calls()[5].Args[0].(state.ModelArgs)
+	newModelArgs := s.st.Calls()[6].Args[0].(state.ModelArgs)
 	c.Assert(newModelArgs.CloudCredential, gc.Equals, "")
 }
 

--- a/apiserver/modelmanager/state.go
+++ b/apiserver/modelmanager/state.go
@@ -28,6 +28,10 @@ type Backend interface {
 	NewModel(state.ModelArgs) (Model, Backend, error)
 	ControllerModel() (Model, error)
 	ControllerConfig() (controller.Config, error)
+
+	// TODO(wallyworld) - we won't need this once cloud name is stored on model
+	ControllerInfo() (*state.ControllerInfo, error)
+
 	ForModel(tag names.ModelTag) (Backend, error)
 	Model() (Model, error)
 	AddModelUser(state.ModelUserSpec) (*state.ModelUser, error)

--- a/controller/config.go
+++ b/controller/config.go
@@ -102,6 +102,10 @@ func ControllerConfig(cfg map[string]interface{}) Config {
 // it is not found or is zero. Zero values should have been
 // diagnosed at Validate time.
 func (c Config) mustInt(name string) int {
+	// Values obtained over the api are encoded as float64.
+	if value, ok := c[name].(float64); ok {
+		return int(value)
+	}
 	value, _ := c[name].(int)
 	if value == 0 {
 		panic(fmt.Errorf("empty value for %q found in configuration", name))

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -479,8 +479,9 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 	// If the machine will run a controller, then we need to open the
 	// API port for it.
 	var apiPortPtr *int
-	if args.InstanceConfig.Bootstrap != nil {
-		apiPortPtr = &args.InstanceConfig.Bootstrap.StateServingInfo.APIPort
+	if args.InstanceConfig.Controller != nil {
+		apiPort := args.InstanceConfig.Controller.Config.APIPort()
+		apiPortPtr = &apiPort
 	}
 
 	vm, err := createVirtualMachine(

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -708,6 +708,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 			st, err := state.Initialize(state.InitializeParams{
 				ControllerConfig: icfg.Controller.Config,
 				ControllerModelArgs: state.ModelArgs{
+					CloudName:       icfg.Bootstrap.ControllerCloudName,
 					Owner:           names.NewUserTag("admin@local"),
 					Config:          icfg.Bootstrap.ControllerModelConfig,
 					Constraints:     icfg.Bootstrap.BootstrapMachineConstraints,

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -449,10 +449,8 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 	}
 	logger.Debugf("ec2 user data; %d bytes", len(userData))
 	var apiPort int
-	if args.InstanceConfig.Bootstrap != nil {
-		apiPort = args.InstanceConfig.Bootstrap.StateServingInfo.APIPort
-	} else {
-		apiPort = args.InstanceConfig.APIInfo.Ports()[0]
+	if args.InstanceConfig.Controller != nil {
+		apiPort = args.InstanceConfig.Controller.Config.APIPort()
 	}
 	groups, err := e.setUpGroups(args.ControllerUUID, args.InstanceConfig.MachineId, apiPort)
 	if err != nil {

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -196,14 +196,14 @@ func (t *LiveTests) TestInstanceGroups(c *gc.C) {
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
-	inst0, _ := testing.AssertStartInstance(c, t.Env, t.ControllerUUID, "98")
+	inst0, _ := testing.AssertStartControllerInstance(c, t.Env, t.ControllerUUID, "98")
 	defer t.Env.StopInstances(inst0.Id())
 
 	// Create a same-named group for the second instance
 	// before starting it, to check that it's reused correctly.
 	oldMachineGroup := createGroup(c, ec2conn, groups[2].Name, "old machine group")
 
-	inst1, _ := testing.AssertStartInstance(c, t.Env, t.ControllerUUID, "99")
+	inst1, _ := testing.AssertStartControllerInstance(c, t.Env, t.ControllerUUID, "99")
 	defer t.Env.StopInstances(inst1.Id())
 
 	groupsResp, err := ec2conn.SecurityGroups(groups, nil)

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -967,10 +967,8 @@ func (e *Environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 	}
 
 	var apiPort int
-	if args.InstanceConfig.Bootstrap != nil {
-		apiPort = args.InstanceConfig.Bootstrap.StateServingInfo.APIPort
-	} else {
-		apiPort = args.InstanceConfig.APIInfo.Ports()[0]
+	if args.InstanceConfig.Controller != nil {
+		apiPort = args.InstanceConfig.Controller.Config.APIPort()
 	}
 	var groupNames = make([]nova.SecurityGroupName, 0)
 	groups, err := e.firewaller.SetUpGroups(args.ControllerUUID, args.InstanceConfig.MachineId, apiPort)

--- a/provider/rackspace/environ.go
+++ b/provider/rackspace/environ.go
@@ -10,11 +10,9 @@ import (
 
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/provider/common"
-	"github.com/juju/juju/state/multiwatcher"
 	jujuos "github.com/juju/utils/os"
 	"github.com/juju/utils/series"
 	"github.com/juju/utils/ssh"
@@ -30,10 +28,6 @@ var bootstrap = common.Bootstrap
 func (e environ) Bootstrap(ctx environs.BootstrapContext, params environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	// can't redirect to openstack provider as ussually, because correct environ should be passed for common.Bootstrap
 	return bootstrap(ctx, e, params)
-}
-
-func isController(mcfg *instancecfg.InstanceConfig) bool {
-	return multiwatcher.AnyJobNeedsState(mcfg.Jobs...)
 }
 
 var waitSSH = common.WaitSSH
@@ -66,10 +60,8 @@ func (e environ) StartInstance(args environs.StartInstanceParams) (*environs.Sta
 		}
 		client := newInstanceConfigurator(addr)
 		apiPort := 0
-		if isController(args.InstanceConfig) && args.InstanceConfig.Bootstrap != nil {
-			// TODO(axw) 2016-06-01 #1587739
-			// We should be doing this for non-bootstrap machines as well.
-			apiPort = args.InstanceConfig.Bootstrap.StateServingInfo.APIPort
+		if args.InstanceConfig.Controller != nil {
+			apiPort = args.InstanceConfig.Controller.Config.APIPort()
 		}
 		err = client.DropAllPorts([]int{apiPort, 22}, addr)
 		if err != nil {

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/common"
-	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/tools"
 )
 
@@ -24,10 +23,6 @@ const (
 	DefaultCpuPower = uint64(2000)
 	DefaultMemMb    = uint64(2000)
 )
-
-func isController(mcfg *instancecfg.InstanceConfig) bool {
-	return multiwatcher.AnyJobNeedsState(mcfg.Jobs...)
-}
 
 // MaintainInstance is specified in the InstanceBroker interface.
 func (*environ) MaintainInstance(args environs.StartInstanceParams) error {
@@ -134,10 +129,8 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams, img *OvaFi
 			continue
 		}
 		apiPort := 0
-		if isController(args.InstanceConfig) && args.InstanceConfig.Bootstrap != nil {
-			// TODO(axw) 2016-06-01 #1587739
-			// We should be doing this for non-bootstrap machines as well.
-			apiPort = args.InstanceConfig.Bootstrap.StateServingInfo.APIPort
+		if args.InstanceConfig.Controller != nil {
+			apiPort = args.InstanceConfig.Controller.Config.APIPort()
 		}
 		spec := &instanceSpec{
 			machineID:      machineID,
@@ -146,7 +139,7 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams, img *OvaFi
 			img:            img,
 			userData:       userData,
 			sshKey:         args.InstanceConfig.AuthorizedKeys,
-			isController:   isController(args.InstanceConfig),
+			isController:   args.InstanceConfig.Controller != nil,
 			controllerUUID: args.ControllerUUID,
 			apiPort:        apiPort,
 		}

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -150,6 +150,10 @@ func allCollections() collectionSchema {
 			}},
 		},
 
+		// This collection holds settings from various sources which
+		// are inherited and then forked by new models.
+		modelInheritedSettingsC: {global: true},
+
 		// This collection holds workload metrics reported by certain charms
 		// for passing onward to other tools.
 		metricsC: {global: true},
@@ -182,6 +186,9 @@ func allCollections() collectionSchema {
 		modelUserLastConnectionC: {
 			rawAccess: true,
 		},
+
+		// This collection holds the source from where model settings came.
+		modelSettingsSourcesC: {},
 
 		// This collection contains governors that prevent certain kinds of
 		// changes from being accepted.
@@ -387,6 +394,8 @@ const (
 	migrationsStatusC        = "migrations.status"
 	migrationsActiveC        = "migrations.active"
 	migrationsC              = "migrations"
+	modelInheritedSettingsC  = "modelInteritedSettings"
+	modelSettingsSourcesC    = "modelSettingsSources"
 	modelUserLastConnectionC = "modelUserLastConnection"
 	modelUsersC              = "modelusers"
 	modelsC                  = "models"

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -55,7 +55,7 @@ func (s *allWatcherBaseSuite) newState(c *gc.C) *State {
 		"name": fmt.Sprintf("testenv%d", s.envCount),
 		"uuid": utils.MustNewUUID().String(),
 	})
-	_, st, err := s.state.NewModel(ModelArgs{Config: cfg, Owner: s.owner})
+	_, st, err := s.state.NewModel(ModelArgs{CloudName: "dummy", Config: cfg, Owner: s.owner})
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(*gc.C) { st.Close() })
 	return st

--- a/state/annotations_test.go
+++ b/state/annotations_test.go
@@ -179,7 +179,7 @@ func (s *AnnotationsEnvSuite) createTestEnv(c *gc.C) (*state.Model, *state.State
 		"uuid": uuid.String(),
 	})
 	owner := names.NewUserTag("test@remote")
-	env, st, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: owner})
+	env, st, err := s.State.NewModel(state.ModelArgs{CloudName: "dummy", Config: cfg, Owner: owner})
 	c.Assert(err, jc.ErrorIsNil)
 	return env, st
 }

--- a/state/backups/restore_test.go
+++ b/state/backups/restore_test.go
@@ -261,7 +261,7 @@ func (r *RestoreSuite) TestNewConnection(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer server.DestroyWithLog()
 
-	st := statetesting.Initialize(c, names.NewLocalUserTag("test-admin"), nil, nil)
+	st := statetesting.Initialize(c, names.NewLocalUserTag("test-admin"), nil, nil, nil)
 	c.Assert(st.Close(), jc.ErrorIsNil)
 
 	r.PatchValue(&mongoDefaultDialOpts, mongotest.DialOpts)

--- a/state/binarystorage_test.go
+++ b/state/binarystorage_test.go
@@ -83,8 +83,9 @@ func (s *binaryStorageSuite) SetUpTest(c *gc.C) {
 		"uuid": s.modelUUID,
 	})
 	_, s.st, err = s.State.NewModel(state.ModelArgs{
-		Config: cfg,
-		Owner:  names.NewLocalUserTag("test-admin"),
+		CloudName: "dummy",
+		Config:    cfg,
+		Owner:     names.NewLocalUserTag("test-admin"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(*gc.C) {

--- a/state/block_test.go
+++ b/state/block_test.go
@@ -194,7 +194,7 @@ func (s *blockSuite) createTestModel(c *gc.C) (*state.Model, *state.State) {
 		"uuid": uuid.String(),
 	})
 	owner := names.NewUserTag("test@remote")
-	env, st, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: owner})
+	env, st, err := s.State.NewModel(state.ModelArgs{CloudName: "dummy", Config: cfg, Owner: owner})
 	c.Assert(err, jc.ErrorIsNil)
 	return env, st
 }

--- a/state/cloud.go
+++ b/state/cloud.go
@@ -13,6 +13,11 @@ import (
 
 const controllerCloudKey = "controller"
 
+// cloudGlobalKey returns the global database key for the specified cloud.
+func cloudGlobalKey(name string) string {
+	return "cloud#" + name
+}
+
 // cloudDoc records information about the cloud that the controller operates in.
 type cloudDoc struct {
 	DocID           string                       `bson:"_id"`

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -107,7 +107,7 @@ func (s *ConnSuite) NewStateForModelNamed(c *gc.C, modelName string) *state.Stat
 		"uuid": utils.MustNewUUID().String(),
 	})
 	otherOwner := names.NewLocalUserTag("test-admin")
-	_, otherState, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: otherOwner})
+	_, otherState, err := s.State.NewModel(state.ModelArgs{CloudName: "dummy", Config: cfg, Owner: otherOwner})
 
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(*gc.C) { otherState.Close() })

--- a/state/controller.go
+++ b/state/controller.go
@@ -12,40 +12,11 @@ import (
 const (
 	// controllerSettingsGlobalKey is the key for the controller and its settings.
 	controllerSettingsGlobalKey = "controllerSettings"
-
-	// defaultModelSettingsGlobalKey is the key for default settings shared across models.
-	defaultModelSettingsGlobalKey = "defaultModelSettings"
 )
-
-// modelConfig returns the model config attributes that result when we
-// take what is required for the model and remove any attributes that
-// are specifically controller related or are already present in the
-// shared cloud config.
-func modelConfig(sharedCloudCfg, cfg map[string]interface{}) map[string]interface{} {
-	modelCfg := make(map[string]interface{})
-	for attr, cfgValue := range cfg {
-		if jujucontroller.ControllerOnlyAttribute(attr) {
-			continue
-		}
-		if sharedValue, ok := sharedCloudCfg[attr]; !ok || sharedValue != cfgValue {
-			modelCfg[attr] = cfgValue
-		}
-	}
-	return modelCfg
-}
 
 // ControllerConfig returns the config values for the controller.
 func (st *State) ControllerConfig() (jujucontroller.Config, error) {
 	settings, err := readSettings(st, controllersC, controllerSettingsGlobalKey)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return settings.Map(), nil
-}
-
-// ModelConfigDefaults returns the config values shared across models.
-func (st *State) ModelConfigDefaults() (map[string]interface{}, error) {
-	settings, err := readSettings(st, controllersC, defaultModelSettingsGlobalKey)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -28,33 +28,32 @@ import (
 )
 
 const (
-	InstanceDataC     = instanceDataC
-	MachinesC         = machinesC
-	ApplicationsC     = applicationsC
-	EndpointBindingsC = endpointBindingsC
-	SettingsC         = settingsC
-	ControllersC      = controllersC
-	UsersC            = usersC
-	BlockDevicesC     = blockDevicesC
-	StorageInstancesC = storageInstancesC
-	GUISettingsC      = guisettingsC
+	MachinesC               = machinesC
+	ApplicationsC           = applicationsC
+	EndpointBindingsC       = endpointBindingsC
+	ControllersC            = controllersC
+	UsersC                  = usersC
+	BlockDevicesC           = blockDevicesC
+	StorageInstancesC       = storageInstancesC
+	GUISettingsC            = guisettingsC
+	ModelInheritedSettingsC = modelInheritedSettingsC
 )
 
 var (
-	BinarystorageNew              = &binarystorageNew
-	ImageStorageNewStorage        = &imageStorageNewStorage
-	MachineIdLessThan             = machineIdLessThan
-	ControllerAvailable           = &controllerAvailable
-	GetOrCreatePorts              = getOrCreatePorts
-	GetPorts                      = getPorts
-	NowToTheSecond                = nowToTheSecond
-	AddVolumeOps                  = (*State).addVolumeOps
-	CombineMeterStatus            = combineMeterStatus
-	ApplicationGlobalKey          = applicationGlobalKey
-	ReadSettings                  = readSettings
-	DefaultModelSettingsGlobalKey = defaultModelSettingsGlobalKey
-	MergeBindings                 = mergeBindings
-	UpgradeInProgressError        = errUpgradeInProgress
+	BinarystorageNew       = &binarystorageNew
+	ImageStorageNewStorage = &imageStorageNewStorage
+	MachineIdLessThan      = machineIdLessThan
+	ControllerAvailable    = &controllerAvailable
+	GetOrCreatePorts       = getOrCreatePorts
+	GetPorts               = getPorts
+	NowToTheSecond         = nowToTheSecond
+	AddVolumeOps           = (*State).addVolumeOps
+	CombineMeterStatus     = combineMeterStatus
+	ApplicationGlobalKey   = applicationGlobalKey
+	ReadSettings           = readSettings
+	CloudGlobalKey         = cloudGlobalKey
+	MergeBindings          = mergeBindings
+	UpgradeInProgressError = errUpgradeInProgress
 )
 
 type (

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -90,6 +90,7 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 		ControllerModelArgs: state.ModelArgs{
 			Owner:           owner,
 			Config:          cfg,
+			CloudName:       "dummy",
 			CloudRegion:     "some-region",
 			CloudCredential: "some-credential",
 		},
@@ -166,8 +167,9 @@ func (s *InitializeSuite) TestInitializeWithInvalidCredentialType(c *gc.C) {
 	_, err := state.Initialize(state.InitializeParams{
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
-			Owner:  owner,
-			Config: modelCfg,
+			CloudName: "dummy",
+			Owner:     owner,
+			Config:    modelCfg,
 		},
 		CloudName: "dummy",
 		Cloud: cloud.Cloud{
@@ -201,8 +203,9 @@ func (s *InitializeSuite) TestInitializeWithModelConfigDefaults(c *gc.C) {
 	st, err := state.Initialize(state.InitializeParams{
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
-			Owner:  owner,
-			Config: cfg,
+			CloudName: "dummy",
+			Owner:     owner,
+			Config:    cfg,
 		},
 		CloudName: "dummy",
 		Cloud: cloud.Cloud{
@@ -222,9 +225,9 @@ func (s *InitializeSuite) TestInitializeWithModelConfigDefaults(c *gc.C) {
 
 	s.openState(c, modelTag)
 
-	modelConfigDefaults, err := s.State.ModelConfigDefaults()
+	localCloudConfig, err := state.ReadSettings(s.State, state.ModelInheritedSettingsC, state.CloudGlobalKey("dummy"))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modelConfigDefaults, jc.DeepEquals, modelConfigDefaultsIn)
+	c.Assert(localCloudConfig.Map(), jc.DeepEquals, modelConfigDefaultsIn)
 
 	cfg, err = s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
@@ -243,8 +246,9 @@ func (s *InitializeSuite) TestDoubleInitializeConfig(c *gc.C) {
 	args := state.InitializeParams{
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
-			Owner:  owner,
-			Config: cfg,
+			CloudName: "dummy",
+			Owner:     owner,
+			Config:    cfg,
 		},
 		CloudName: "dummy",
 		Cloud: cloud.Cloud{
@@ -279,8 +283,9 @@ func (s *InitializeSuite) TestModelConfigWithAdminSecret(c *gc.C) {
 	args := state.InitializeParams{
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
-			Owner:  owner,
-			Config: bad,
+			CloudName: "dummy",
+			Owner:     owner,
+			Config:    bad,
 		},
 		CloudName: "dummy",
 		Cloud: cloud.Cloud{
@@ -324,8 +329,9 @@ func (s *InitializeSuite) TestModelConfigWithoutAgentVersion(c *gc.C) {
 	args := state.InitializeParams{
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
-			Owner:  owner,
-			Config: bad,
+			CloudName: "dummy",
+			Owner:     owner,
+			Config:    bad,
 		},
 		CloudName: "dummy",
 		Cloud: cloud.Cloud{
@@ -370,8 +376,9 @@ func (s *InitializeSuite) TestCloudConfigWithForbiddenValues(c *gc.C) {
 	args := state.InitializeParams{
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
-			Owner:  names.NewLocalUserTag("initialize-admin"),
-			Config: modelCfg,
+			CloudName: "dummy",
+			Owner:     names.NewLocalUserTag("initialize-admin"),
+			Config:    modelCfg,
 		},
 		CloudName: "dummy",
 		Cloud: cloud.Cloud{
@@ -386,6 +393,6 @@ func (s *InitializeSuite) TestCloudConfigWithForbiddenValues(c *gc.C) {
 		badAttrs := map[string]interface{}{badAttrName: "foo"}
 		args.LocalCloudConfig = badAttrs
 		_, err := state.Initialize(args)
-		c.Assert(err, gc.ErrorMatches, "config defaults cannot contain .*")
+		c.Assert(err, gc.ErrorMatches, "local cloud config cannot contain .*")
 	}
 }

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -55,8 +55,9 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 	st, err := Initialize(InitializeParams{
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: ModelArgs{
-			Owner:  s.owner,
-			Config: modelCfg,
+			CloudName: "dummy",
+			Owner:     s.owner,
+			Config:    modelCfg,
 		},
 		CloudName: "dummy",
 		Cloud: cloud.Cloud{

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -110,11 +110,6 @@ func (s *MigrationExportSuite) TestModelInfo(c *gc.C) {
 	machineSeq := s.setRandSequenceValue(c, "machine")
 	fooSeq := s.setRandSequenceValue(c, "application-foo")
 	s.State.SwitchBlockOn(state.ChangeBlock, "locked down")
-	settings, err := state.ReadSettings(s.State, state.ControllersC, state.DefaultModelSettingsGlobalKey)
-	c.Assert(err, jc.ErrorIsNil)
-	settings.Set("apt-mirror", "http://mirror")
-	_, err = settings.Write()
-	c.Assert(err, jc.ErrorIsNil)
 
 	model, err := s.State.Export()
 	c.Assert(err, jc.ErrorIsNil)
@@ -126,9 +121,6 @@ func (s *MigrationExportSuite) TestModelInfo(c *gc.C) {
 	dbModelCfg, err := dbModel.Config()
 	c.Assert(err, jc.ErrorIsNil)
 	modelAttrs := dbModelCfg.AllAttrs()
-	c.Assert(modelAttrs["apt-mirror"], gc.Equals, "http://mirror")
-
-	delete(modelAttrs, "apt-mirror")
 	c.Assert(model.Config(), jc.DeepEquals, modelAttrs)
 	c.Assert(model.LatestToolsVersion(), gc.Equals, latestTools)
 	c.Assert(model.Annotations(), jc.DeepEquals, testAnnotations)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -56,7 +56,13 @@ func (st *State) Import(model description.Model) (_ *Model, _ *State, err error)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
+	controllerInfo, err := st.ControllerInfo()
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
 	dbModel, newSt, err := st.NewModel(ModelArgs{
+		// TODO(wallyworld) - cloud name needs to be on model
+		CloudName:     controllerInfo.CloudName,
 		CloudRegion:   model.CloudRegion(),
 		Config:        cfg,
 		Owner:         model.Owner(),

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -43,16 +43,8 @@ func (st *State) Import(model description.Model) (_ *Model, _ *State, err error)
 		return nil, nil, errors.Trace(err)
 	}
 
-	// Create the config attributes of the model to import.
-	attr, err := st.ControllerConfig()
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
-	for k, v := range model.Config() {
-		attr[k] = v
-	}
 	// Create the model.
-	cfg, err := config.New(config.NoDefaults, attr)
+	cfg, err := config.New(config.NoDefaults, model.Config())
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -113,6 +113,10 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 
 	// THIS SET WILL BE REMOVED WHEN MIGRATIONS ARE COMPLETE
 	todoCollections := set.NewStrings(
+		// model configuration
+		modelSettingsSourcesC,
+		modelInheritedSettingsC,
+
 		// model
 		cloudimagemetadataC,
 

--- a/state/model.go
+++ b/state/model.go
@@ -211,7 +211,8 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 		return nil, nil, errors.Trace(err)
 	}
 	if controllerInfo.CloudName != args.CloudName {
-		return nil, nil, errors.NotValidf("controller cloud %s does not match model cloud %s", controllerInfo.CloudName, args.CloudName)
+		return nil, nil, errors.NewNotValid(
+			nil, fmt.Sprintf("controller cloud %s does not match model cloud %s", controllerInfo.CloudName, args.CloudName))
 	}
 
 	// Ensure that the cloud region is valid, or if one is not specified,

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -62,7 +62,7 @@ func (s *ModelSuite) TestNewModelNonExistentLocalUser(c *gc.C) {
 	cfg, _ := s.createTestModelConfig(c)
 	owner := names.NewUserTag("non-existent@local")
 
-	_, _, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: owner})
+	_, _, err := s.State.NewModel(state.ModelArgs{CloudName: "dummy", Config: cfg, Owner: owner})
 	c.Assert(err, gc.ErrorMatches, `cannot create model: user "non-existent" not found`)
 }
 
@@ -71,7 +71,7 @@ func (s *ModelSuite) TestNewModelSameUserSameNameFails(c *gc.C) {
 	owner := s.Factory.MakeUser(c, nil).UserTag()
 
 	// Create the first model.
-	_, st1, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: owner})
+	_, st1, err := s.State.NewModel(state.ModelArgs{CloudName: "dummy", Config: cfg, Owner: owner})
 	c.Assert(err, jc.ErrorIsNil)
 	defer st1.Close()
 
@@ -83,7 +83,7 @@ func (s *ModelSuite) TestNewModelSameUserSameNameFails(c *gc.C) {
 		"name": cfg.Name(),
 		"uuid": newUUID.String(),
 	})
-	_, _, err = s.State.NewModel(state.ModelArgs{Config: cfg2, Owner: owner})
+	_, _, err = s.State.NewModel(state.ModelArgs{CloudName: "dummy", Config: cfg2, Owner: owner})
 	errMsg := fmt.Sprintf("model %q for %s already exists", cfg2.Name(), owner.Canonical())
 	c.Assert(err, gc.ErrorMatches, errMsg)
 	c.Assert(errors.IsAlreadyExists(err), jc.IsTrue)
@@ -102,7 +102,7 @@ func (s *ModelSuite) TestNewModelSameUserSameNameFails(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// We should now be able to create the other model.
-	env2, st2, err := s.State.NewModel(state.ModelArgs{Config: cfg2, Owner: owner})
+	env2, st2, err := s.State.NewModel(state.ModelArgs{CloudName: "dummy", Config: cfg2, Owner: owner})
 	c.Assert(err, jc.ErrorIsNil)
 	defer st2.Close()
 	c.Assert(env2, gc.NotNil)
@@ -113,7 +113,7 @@ func (s *ModelSuite) TestNewModel(c *gc.C) {
 	cfg, uuid := s.createTestModelConfig(c)
 	owner := names.NewUserTag("test@remote")
 
-	model, st, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: owner})
+	model, st, err := s.State.NewModel(state.ModelArgs{CloudName: "dummy", Config: cfg, Owner: owner})
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -155,6 +155,7 @@ func (s *ModelSuite) TestNewModelImportingMode(c *gc.C) {
 	owner := names.NewUserTag("test@remote")
 
 	env, st, err := s.State.NewModel(state.ModelArgs{
+		CloudName:     "dummy",
 		Config:        cfg,
 		Owner:         owner,
 		MigrationMode: state.MigrationModeImporting,
@@ -169,7 +170,7 @@ func (s *ModelSuite) TestSetMigrationMode(c *gc.C) {
 	cfg, _ := s.createTestModelConfig(c)
 	owner := names.NewUserTag("test@remote")
 
-	env, st, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: owner})
+	env, st, err := s.State.NewModel(state.ModelArgs{CloudName: "dummy", Config: cfg, Owner: owner})
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -193,8 +194,9 @@ func (s *ModelSuite) TestControllerModel(c *gc.C) {
 func (s *ModelSuite) TestControllerModelAccessibleFromOtherModels(c *gc.C) {
 	cfg, _ := s.createTestModelConfig(c)
 	_, st, err := s.State.NewModel(state.ModelArgs{
-		Config: cfg,
-		Owner:  names.NewUserTag("test@remote"),
+		CloudName: "dummy",
+		Config:    cfg,
+		Owner:     names.NewUserTag("test@remote"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
@@ -777,7 +779,8 @@ func (s *ModelCloudValidationSuite) TestNewModelUnknownCloudRegion(c *gc.C) {
 	defer st.Close()
 	cfg, _ := createTestModelConfig(c, st.ModelUUID())
 	_, _, err := st.NewModel(state.ModelArgs{
-		Config: cfg, Owner: owner, CloudRegion: "missing-region",
+		CloudName: "dummy",
+		Config:    cfg, Owner: owner, CloudRegion: "missing-region",
 	})
 	c.Assert(err, gc.ErrorMatches, `region "missing-region" not found \(expected one of \["some-region"\]\)`)
 }
@@ -786,7 +789,7 @@ func (s *ModelCloudValidationSuite) TestNewModelMissingCloudRegion(c *gc.C) {
 	st, owner := s.initializeState(c, []cloud.Region{{Name: "some-region"}}, []cloud.AuthType{cloud.EmptyAuthType}, nil)
 	defer st.Close()
 	cfg, _ := createTestModelConfig(c, st.ModelUUID())
-	_, _, err := st.NewModel(state.ModelArgs{Config: cfg, Owner: owner})
+	_, _, err := st.NewModel(state.ModelArgs{CloudName: "dummy", Config: cfg, Owner: owner})
 	c.Assert(err, gc.ErrorMatches, "missing CloudRegion not valid")
 }
 
@@ -799,7 +802,8 @@ func (s *ModelCloudValidationSuite) TestNewModelUnknownCloudCredential(c *gc.C) 
 	defer st.Close()
 	cfg, _ := createTestModelConfig(c, st.ModelUUID())
 	_, _, err := st.NewModel(state.ModelArgs{
-		Config: cfg, Owner: owner, CloudCredential: "unknown-credential",
+		CloudName: "dummy",
+		Config:    cfg, Owner: owner, CloudCredential: "unknown-credential",
 	})
 	c.Assert(err, gc.ErrorMatches, `credential "unknown-credential" not found`)
 }
@@ -813,7 +817,8 @@ func (s *ModelCloudValidationSuite) TestNewModelMissingCloudCredential(c *gc.C) 
 	defer st.Close()
 	cfg, _ := createTestModelConfig(c, st.ModelUUID())
 	_, _, err := st.NewModel(state.ModelArgs{
-		Config: cfg, Owner: owner,
+		CloudName: "dummy",
+		Config:    cfg, Owner: owner,
 	})
 	c.Assert(err, gc.ErrorMatches, "missing CloudCredential not valid")
 }
@@ -824,7 +829,7 @@ func (s *ModelCloudValidationSuite) TestNewModelMissingCloudCredentialSupportsEm
 	cfg, _ := createTestModelConfig(c, st.ModelUUID())
 	cfg, err := cfg.Apply(map[string]interface{}{"name": "whatever"})
 	c.Assert(err, jc.ErrorIsNil)
-	_, newSt, err := st.NewModel(state.ModelArgs{Config: cfg, Owner: owner})
+	_, newSt, err := st.NewModel(state.ModelArgs{CloudName: "dummy", Config: cfg, Owner: owner})
 	c.Assert(err, jc.ErrorIsNil)
 	newSt.Close()
 }
@@ -853,6 +858,7 @@ func (s *ModelCloudValidationSuite) initializeState(
 		ControllerModelArgs: state.ModelArgs{
 			Owner:           owner,
 			Config:          cfg,
+			CloudName:       "dummy",
 			CloudRegion:     controllerRegion,
 			CloudCredential: controllerCredential,
 		},

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -7,11 +7,14 @@ import (
 	"fmt"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
 )
 
 type ModelConfigSuite struct {
@@ -84,18 +87,32 @@ func (s *ModelConfigSuite) TestUpdateModelConfigRejectsControllerConfig(c *gc.C)
 	c.Assert(err, gc.ErrorMatches, `cannot set controller attribute "api-port" on a model`)
 }
 
-func (s *ModelConfigSuite) TestModelConfigOverridesCloudValue(c *gc.C) {
-	sharedSettings, err := s.State.ReadSettings(state.ControllersC, state.DefaultModelSettingsGlobalKey)
-	c.Assert(err, jc.ErrorIsNil)
-	sharedSettings.Set("apt-mirror", "http://mirror")
-	_, err = sharedSettings.Write()
-	c.Assert(err, jc.ErrorIsNil)
+type ModelConfigSourceSuite struct {
+	ConnSuite
+}
 
+var _ = gc.Suite(&ModelConfigSourceSuite{})
+
+func (s *ModelConfigSourceSuite) SetUpTest(c *gc.C) {
+	s.LocalCloudConfig = map[string]interface{}{
+		"apt-mirror": "http://cloud-mirror",
+		"http-proxy": "http://proxy",
+	}
+	s.ConnSuite.SetUpTest(c)
+
+	localCloudSettings, err := s.State.ReadSettings(state.ModelInheritedSettingsC, state.CloudGlobalKey("dummy"))
+	c.Assert(err, jc.ErrorIsNil)
+	localCloudSettings.Set("apt-mirror", "http://mirror")
+	_, err = localCloudSettings.Write()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ModelConfigSourceSuite) TestModelConfigWhenSetOverridesCloudValue(c *gc.C) {
 	attrs := map[string]interface{}{
 		"authorized-keys": "different-keys",
 		"apt-mirror":      "http://anothermirror",
 	}
-	err = s.State.UpdateModelConfig(attrs, nil, nil)
+	err := s.State.UpdateModelConfig(attrs, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cfg, err := s.State.ModelConfig()
@@ -103,14 +120,99 @@ func (s *ModelConfigSuite) TestModelConfigOverridesCloudValue(c *gc.C) {
 	c.Assert(cfg.AllAttrs()["apt-mirror"], gc.Equals, "http://anothermirror")
 }
 
-func (s *ModelConfigSuite) TestModelConfigInheritsCloudValue(c *gc.C) {
-	sharedSettings, err := s.State.ReadSettings(state.ControllersC, state.DefaultModelSettingsGlobalKey)
+func (s *ModelConfigSourceSuite) TestControllerModelConfigForksCloudValue(c *gc.C) {
+	modelCfg, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	sharedSettings.Set("apt-mirror", "http://mirror")
-	_, err = sharedSettings.Write()
+	c.Assert(modelCfg.AllAttrs()["apt-mirror"], gc.Equals, "http://cloud-mirror")
+
+	// Change the local cloud settings and ensure the model setting stays the same.
+	localCloudSettings, err := s.State.ReadSettings(state.ModelInheritedSettingsC, state.CloudGlobalKey("dummy"))
+	c.Assert(err, jc.ErrorIsNil)
+	localCloudSettings.Set("apt-mirror", "http://anothermirror")
+	_, err = localCloudSettings.Write()
 	c.Assert(err, jc.ErrorIsNil)
 
-	cfg, err := s.State.ModelConfig()
+	modelCfg, err = s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg.AllAttrs()["apt-mirror"], gc.Equals, "http://mirror")
+	c.Assert(modelCfg.AllAttrs()["apt-mirror"], gc.Equals, "http://cloud-mirror")
+}
+
+func (s *ModelConfigSourceSuite) TestNewModelConfigForksCloudValue(c *gc.C) {
+	uuid, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	cfg := testing.CustomModelConfig(c, testing.Attrs{
+		"name": "another",
+		"uuid": uuid.String(),
+	})
+	owner := names.NewUserTag("test@remote")
+	_, st, err := s.State.NewModel(state.ModelArgs{
+		Config: cfg, Owner: owner, CloudName: "dummy",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	defer st.Close()
+
+	modelCfg, err := st.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(modelCfg.AllAttrs()["apt-mirror"], gc.Equals, "http://mirror")
+
+	// Change the local cloud settings and ensure the model setting stays the same.
+	localCloudSettings, err := s.State.ReadSettings(state.ModelInheritedSettingsC, state.CloudGlobalKey("dummy"))
+	c.Assert(err, jc.ErrorIsNil)
+	localCloudSettings.Set("apt-mirror", "http://anothermirror")
+	_, err = localCloudSettings.Write()
+	c.Assert(err, jc.ErrorIsNil)
+
+	modelCfg, err = st.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(modelCfg.AllAttrs()["apt-mirror"], gc.Equals, "http://mirror")
+}
+
+func (s *ModelConfigSourceSuite) TestModelConfigSource(c *gc.C) {
+	modelCfg, err := s.State.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	expectedSources := make(map[string]string)
+	for attr := range modelCfg.AllAttrs() {
+		expectedSources[attr] = "model"
+	}
+	expectedSources["apt-mirror"] = "juju cloud"
+	expectedSources["http-proxy"] = "juju cloud"
+	sources, err := s.State.ModelConfigSources()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sources, jc.DeepEquals, expectedSources)
+}
+
+func (s *ModelConfigSourceSuite) TestModelConfigUpdateSetsSource(c *gc.C) {
+	attrs := map[string]interface{}{
+		"http-proxy": "http://anotherproxy",
+	}
+	err := s.State.UpdateModelConfig(attrs, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	modelCfg, err := s.State.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	expectedSources := make(map[string]string)
+	for attr := range modelCfg.AllAttrs() {
+		expectedSources[attr] = "model"
+	}
+	expectedSources["apt-mirror"] = "juju cloud"
+	sources, err := s.State.ModelConfigSources()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sources, jc.DeepEquals, expectedSources)
+}
+
+func (s *ModelConfigSourceSuite) TestModelConfigDeleteSetsSource(c *gc.C) {
+	err := s.State.UpdateModelConfig(nil, []string{"apt-mirror"}, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	modelCfg, err := s.State.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	expectedSources := make(map[string]string)
+	for attr := range modelCfg.AllAttrs() {
+		expectedSources[attr] = "model"
+	}
+	expectedSources["http-proxy"] = "juju cloud"
+	expectedSources["apt-mirror"] = "model"
+	sources, err := s.State.ModelConfigSources()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sources, jc.DeepEquals, expectedSources)
 }

--- a/state/modeluser_test.go
+++ b/state/modeluser_test.go
@@ -290,7 +290,7 @@ func (s *ModelUserSuite) newEnvWithOwner(c *gc.C, name string, owner names.UserT
 		"name": name,
 		"uuid": uuid.String(),
 	})
-	model, st, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: owner})
+	model, st, err := s.State.NewModel(state.ModelArgs{CloudName: "dummy", Config: cfg, Owner: owner})
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	return model

--- a/state/state.go
+++ b/state/state.go
@@ -1752,6 +1752,9 @@ func readRawControllerInfo(session *mgo.Session) (*ControllerInfo, error) {
 
 	var doc controllersDoc
 	err := controllers.Find(bson.D{{"_id", modelGlobalKey}}).One(&doc)
+	if err == mgo.ErrNotFound {
+		return nil, errors.NotFoundf("controllers document")
+	}
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot get controllers document")
 	}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -176,7 +176,7 @@ func (s *StateSuite) TestModelUUID(c *gc.C) {
 
 func (s *StateSuite) TestNoModelDocs(c *gc.C) {
 	c.Assert(s.State.EnsureModelRemoved(), gc.ErrorMatches,
-		fmt.Sprintf("found documents for model with uuid %s: 1 constraints doc, 2 leases doc, 1 modelusers doc, 1 settings doc, 1 statuses doc", s.State.ModelUUID()))
+		fmt.Sprintf("found documents for model with uuid %s: 1 constraints doc, 2 leases doc, 1 modelSettingsSources doc, 1 modelusers doc, 1 settings doc, 1 statuses doc", s.State.ModelUUID()))
 }
 
 func (s *StateSuite) TestMongoSession(c *gc.C) {
@@ -2529,15 +2529,6 @@ func (s *StateSuite) TestWatchForModelConfigControllerChanges(c *gc.C) {
 	defer statetesting.AssertStop(c, w)
 
 	wc := statetesting.NewNotifyWatcherC(c, s.State, w)
-	// Initially we get one change notification
-	wc.AssertOneChange()
-
-	// Updating shared model settings triggers the watcher.
-	controllerSettings, err := s.State.ReadSettings(state.ControllersC, "defaultModelSettings")
-	c.Assert(err, jc.ErrorIsNil)
-	controllerSettings.Set("apt-mirror", "http://mirror")
-	_, err = controllerSettings.Write()
-	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 }
 
@@ -4103,8 +4094,9 @@ func (s *SetAdminMongoPasswordSuite) TestSetAdminMongoPassword(c *gc.C) {
 	st, err := state.Initialize(state.InitializeParams{
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
-			Owner:  owner,
-			Config: cfg,
+			CloudName: "dummy",
+			Owner:     owner,
+			Config:    cfg,
 		},
 		CloudName: "dummy",
 		Cloud: cloud.Cloud{

--- a/state/testing/conn.go
+++ b/state/testing/conn.go
@@ -20,7 +20,7 @@ import (
 // Initialize initializes the state and returns it. If state was not
 // already initialized, and cfg is nil, the minimal default model
 // configuration will be used.
-func Initialize(c *gc.C, owner names.UserTag, cfg *config.Config, policy state.Policy) *state.State {
+func Initialize(c *gc.C, owner names.UserTag, cfg *config.Config, localCloudConfig map[string]interface{}, policy state.Policy) *state.State {
 	if cfg == nil {
 		cfg = testing.ModelConfig(c)
 	}
@@ -32,10 +32,12 @@ func Initialize(c *gc.C, owner names.UserTag, cfg *config.Config, policy state.P
 	st, err := state.Initialize(state.InitializeParams{
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
-			Config: cfg,
-			Owner:  owner,
+			CloudName: "dummy",
+			Config:    cfg,
+			Owner:     owner,
 		},
-		CloudName: "dummy",
+		LocalCloudConfig: localCloudConfig,
+		CloudName:        "dummy",
 		Cloud: cloud.Cloud{
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
@@ -65,5 +67,5 @@ func NewState(c *gc.C) *state.State {
 	owner := names.NewLocalUserTag("test-admin")
 	cfg := testing.ModelConfig(c)
 	policy := MockPolicy{}
-	return Initialize(c, owner, cfg, &policy)
+	return Initialize(c, owner, cfg, nil, &policy)
 }

--- a/state/testing/suite.go
+++ b/state/testing/suite.go
@@ -21,11 +21,12 @@ var _ = gc.Suite(&StateSuite{})
 type StateSuite struct {
 	jujutesting.MgoSuite
 	testing.BaseSuite
-	Policy        state.Policy
-	State         *state.State
-	Owner         names.UserTag
-	Factory       *factory.Factory
-	InitialConfig *config.Config
+	Policy           state.Policy
+	State            *state.State
+	Owner            names.UserTag
+	Factory          *factory.Factory
+	InitialConfig    *config.Config
+	LocalCloudConfig map[string]interface{}
 }
 
 func (s *StateSuite) SetUpSuite(c *gc.C) {
@@ -43,7 +44,7 @@ func (s *StateSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
 	s.Owner = names.NewLocalUserTag("test-admin")
-	s.State = Initialize(c, s.Owner, s.InitialConfig, s.Policy)
+	s.State = Initialize(c, s.Owner, s.InitialConfig, s.LocalCloudConfig, s.Policy)
 	s.AddCleanup(func(*gc.C) { s.State.Close() })
 	s.Factory = factory.NewFactory(s.State)
 }

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1304,15 +1304,7 @@ func (st *State) WatchRestoreInfoChanges() NotifyWatcher {
 // WatchForModelConfigChanges returns a NotifyWatcher waiting for the Model
 // Config to change.
 func (st *State) WatchForModelConfigChanges() NotifyWatcher {
-	return newDocWatcher(st, []docKey{
-		{
-			settingsC,
-			st.docID(modelGlobalKey),
-		}, {
-			controllersC,
-			defaultModelSettingsGlobalKey,
-		},
-	})
+	return newEntityWatcher(st, settingsC, st.docID(modelGlobalKey))
 }
 
 // WatchForUnitAssignment watches for new services that request units to be

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -120,6 +120,7 @@ type ModelParams struct {
 	Name            string
 	Owner           names.Tag
 	ConfigAttrs     testing.Attrs
+	CloudName       string
 	CloudRegion     string
 	CloudCredential string
 }
@@ -558,6 +559,9 @@ func (factory *Factory) MakeModel(c *gc.C, params *ModelParams) *state.State {
 	if params.Name == "" {
 		params.Name = uniqueString("testenv")
 	}
+	if params.CloudName == "" {
+		params.CloudName = "dummy"
+	}
 	if params.Owner == nil {
 		origEnv, err := factory.st.Model()
 		c.Assert(err, jc.ErrorIsNil)
@@ -580,6 +584,7 @@ func (factory *Factory) MakeModel(c *gc.C, params *ModelParams) *state.State {
 		"api-port":   controllerCfg.APIPort(),
 	}.Merge(params.ConfigAttrs))
 	_, st, err := factory.st.NewModel(state.ModelArgs{
+		CloudName:       params.CloudName,
 		CloudRegion:     params.CloudRegion,
 		CloudCredential: params.CloudCredential,
 		Config:          cfg,


### PR DESCRIPTION
When a controller is bootstrapped, we record the config from clouds.yaml as local cloud config. This forms the basis for the config of new models. When a model is created, these local cloud attributes are forked and then overridden by any values explicitly in the model config attributes.

We also record in a separate collection the source of each model attribute. There will be many sources, but for now we have "juju cloud" and "model" as per the above. This information will be used to augment the get-model-config output so you can see model config values and from where they originated.

Even when a model attribute is deleted, we still record its source as "model". This will allow us to track that an attribute was provided via shared config but was subsequently deleted.

Models will be recording the cloud name to which they are deployed. For now, we need to add a CloudName parameter to ModelArgs to make this PR work. The cloud name is not recorded yet.

(Review request: http://reviews.vapour.ws/r/5126/)