### PR TITLE
juju: add support for redirection when connecting to a model

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -126,9 +126,29 @@ type state struct {
 	bakeryClient *httpbakery.Client
 }
 
+// RedirectError is returned from Open when the controller
+// needs to inform the client that the model is hosted
+// on a different set of API addresses.
+type RedirectError struct {
+	// Servers holds the sets of addresses of the redirected
+	// servers.
+	Servers [][]network.HostPort
+
+	// CACert holds the certificate of the remote server.
+	CACert string
+}
+
+func (e *RedirectError) Error() string {
+	return fmt.Sprintf("redirection to alternative server required")
+}
+
 // Open establishes a connection to the API server using the Info
 // given, returning a State instance which can be used to make API
 // requests.
+//
+// If the model is hosted on a different server, Open
+// will return an error with a *RedirectError cause
+// holding the details of another server to connect to.
 //
 // See Connect for details of the connection mechanics.
 func Open(info *Info, opts DialOpts) (Connection, error) {
@@ -159,8 +179,7 @@ func open(
 	if bakeryClient == nil {
 		bakeryClient = httpbakery.NewClient()
 	} else {
-		// Make a copy of the bakery client and its
-		// HTTP client
+		// Make a copy of the bakery client and its HTTP client
 		c := *opts.BakeryClient
 		bakeryClient = &c
 		httpc := *bakeryClient.Client
@@ -184,8 +203,10 @@ func open(
 		},
 		serverScheme:      "https",
 		serverRootAddress: conn.Config().Location.Host,
-		// why are the contents of the tag (username and password) written into the
-		// state structure BEFORE login ?!?
+		// We populate the username and password before
+		// login because, when doing HTTP requests, we'll want
+		// to use the same username and password for authenticating
+		// those. If login fails, we discard the connection.
 		tag:          tagToString(info.Tag),
 		password:     info.Password,
 		macaroons:    info.Macaroons,
@@ -196,7 +217,7 @@ func open(
 	if !info.SkipLogin {
 		if err := loginFunc(st, info.Tag, info.Password, info.Nonce, info.Macaroons); err != nil {
 			conn.Close()
-			return nil, err
+			return nil, errors.Trace(err)
 		}
 	}
 	st.broken = make(chan struct{})
@@ -305,7 +326,7 @@ func dialWebSocket(addrs []string, path string, tlsConfig *tls.Config, opts Dial
 	return result.(*websocket.Conn), nil
 }
 
-// ConnectStream implements Connection.ConnectStream.
+// ConnectStream implements Connection.ConnectStream, whatever that is..
 func (st *state) ConnectStream(path string, attrs url.Values) (base.Stream, error) {
 	if !st.isLoggedIn() {
 		return nil, errors.New("cannot use ConnectStream without logging in")

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -17,13 +17,16 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
-	jujutesting "github.com/juju/juju/juju/testing"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	jjtesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/rpc"
+	jtesting "github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
 )
 
 type apiclientSuite struct {
-	jujutesting.JujuConnSuite
+	jjtesting.JujuConnSuite
 }
 
 var _ = gc.Suite(&apiclientSuite{})
@@ -153,6 +156,73 @@ func (s *apiclientSuite) TestDialWebsocketStopped(c *gc.C) {
 	result, err := f(stopped)
 	c.Assert(err, gc.Equals, parallel.ErrStopped)
 	c.Assert(result, gc.IsNil)
+}
+
+func (s *apiclientSuite) TestOpenWithRedirect(c *gc.C) {
+	redirectToHosts := []string{"0.1.2.3:1234", "0.1.2.4:1235"}
+	redirectToCACert := "fake CA cert"
+
+	srv := apiservertesting.NewAPIServer(func(modelUUID string) interface{} {
+		return &redirectAPI{
+			modelUUID:        modelUUID,
+			redirectToHosts:  redirectToHosts,
+			redirectToCACert: redirectToCACert,
+		}
+	})
+	defer srv.Close()
+
+	_, err := api.Open(&api.Info{
+		Addrs:    srv.Addrs,
+		CACert:   jtesting.CACert,
+		ModelTag: names.NewModelTag("beef1beef1-0000-0000-000011112222"),
+	}, api.DialOpts{})
+	c.Assert(err, gc.ErrorMatches, `redirection to alternative server required`)
+
+	hps, _ := network.ParseHostPorts(redirectToHosts...)
+	c.Assert(errors.Cause(err), jc.DeepEquals, &api.RedirectError{
+		Servers: [][]network.HostPort{hps},
+		CACert:  redirectToCACert,
+	})
+}
+
+type redirectAPI struct {
+	redirected       bool
+	modelUUID        string
+	redirectToHosts  []string
+	redirectToCACert string
+}
+
+func (r *redirectAPI) Admin(id string) (*redirectAPIAdmin, error) {
+	return &redirectAPIAdmin{r}, nil
+}
+
+type redirectAPIAdmin struct {
+	r *redirectAPI
+}
+
+func (a *redirectAPIAdmin) Login(req params.LoginRequest) (params.LoginResultV1, error) {
+	if a.r.modelUUID != "beef1beef1-0000-0000-000011112222" {
+		return params.LoginResultV1{}, errors.New("logged into unexpected model")
+	}
+	a.r.redirected = true
+	return params.LoginResultV1{}, params.Error{
+		Message: "redirect",
+		Code:    params.CodeRedirect,
+	}
+}
+
+func (a *redirectAPIAdmin) RedirectInfo() (params.RedirectInfoResult, error) {
+	if !a.r.redirected {
+		return params.RedirectInfoResult{}, errors.New("not redirected")
+	}
+	hps, err := network.ParseHostPorts(a.r.redirectToHosts...)
+	if err != nil {
+		panic(err)
+	}
+	return params.RedirectInfoResult{
+		Servers: [][]params.HostPort{params.FromNetworkHostPorts(hps)},
+		CACert:  a.r.redirectToCACert,
+	}, nil
 }
 
 func assertConnAddrForEnv(c *gc.C, conn *websocket.Conn, addr, modelUUID, tail string) {

--- a/api/interface.go
+++ b/api/interface.go
@@ -91,7 +91,7 @@ func (info *Info) Validate() error {
 		return errors.NotValidf("missing addresses")
 	}
 	if _, err := network.ParseHostPorts(info.Addrs...); err != nil {
-		return errors.NotValidf("host addresses")
+		return errors.NotValidf("host addresses: %v", err)
 	}
 	if info.CACert == "" {
 		return errors.NotValidf("missing CA certificate")

--- a/apiserver/adminv3.go
+++ b/apiserver/adminv3.go
@@ -4,6 +4,8 @@
 package apiserver
 
 import (
+	"fmt"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 )
@@ -36,4 +38,11 @@ func (r *adminApiV3) Admin(id string) (*adminApiV3, error) {
 // connection will act as the authenticated user.
 func (a *adminApiV3) Login(req params.LoginRequest) (params.LoginResultV1, error) {
 	return a.doLogin(req, 3)
+}
+
+// RedirectInfo returns redirected host information for the model.
+// In Juju it always returns an error because the Juju controller
+// does not multiplex controllers.
+func (a *adminApiV3) RedirectInfo() (params.RedirectInfoResult, error) {
+	return params.RedirectInfoResult{}, fmt.Errorf("not redirected")
 }

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -521,19 +521,9 @@ func (srv *Server) trackRequests(handler http.Handler) http.Handler {
 }
 
 func registerEndpoint(ep apihttp.Endpoint, mux *pat.PatternServeMux) {
-	switch ep.Method {
-	case "GET":
-		mux.Get(ep.Pattern, ep.Handler)
-	case "POST":
-		mux.Post(ep.Pattern, ep.Handler)
-	case "HEAD":
-		mux.Head(ep.Pattern, ep.Handler)
-	case "PUT":
-		mux.Put(ep.Pattern, ep.Handler)
-	case "DEL":
-		mux.Del(ep.Pattern, ep.Handler)
-	case "OPTIONS":
-		mux.Options(ep.Pattern, ep.Handler)
+	mux.Add(ep.Method, ep.Pattern, ep.Handler)
+	if ep.Method == "GET" {
+		mux.Add("HEAD", ep.Pattern, ep.Handler)
 	}
 }
 

--- a/apiserver/backup_test.go
+++ b/apiserver/backup_test.go
@@ -57,7 +57,7 @@ func (s *backupsCommonSuite) assertErrorResponse(c *gc.C, resp *http.Response, s
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(resp.StatusCode, gc.Equals, statusCode, gc.Commentf("body: %s", body))
-	c.Assert(resp.Header.Get("Content-Type"), gc.Equals, params.ContentTypeJSON)
+	c.Assert(resp.Header.Get("Content-Type"), gc.Equals, params.ContentTypeJSON, gc.Commentf("body: %q", body))
 
 	var failure params.Error
 	err = json.Unmarshal(body, &failure)

--- a/apiserver/common/registry.go
+++ b/apiserver/common/registry.go
@@ -334,7 +334,7 @@ func registerAPIEndpoint(pattern string, spec apihttp.HandlerSpec) error {
 }
 
 // DefaultHTTPMethods are the HTTP methods supported by default by the API.
-var DefaultHTTPMethods = []string{"GET", "POST", "HEAD", "PUT", "DEL", "OPTIONS"}
+var DefaultHTTPMethods = []string{"GET", "POST", "HEAD", "PUT", "DELETE", "OPTIONS"}
 
 // ResolveAPIEndpoints builds the set of endpoint handlers for all
 // registered API endpoints.

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -85,6 +85,7 @@ const (
 	CodeMethodNotAllowed          = "method not allowed"
 	CodeForbidden                 = "forbidden"
 	CodeDischargeRequired         = "macaroon discharge required"
+	CodeRedirect                  = "redirection required"
 )
 
 // ErrCode returns the error code associated with
@@ -213,4 +214,8 @@ func IsBadRequest(err error) bool {
 
 func IsMethodNotAllowed(err error) bool {
 	return ErrCode(err) == CodeMethodNotAllowed
+}
+
+func IsRedirect(err error) bool {
+	return ErrCode(err) == CodeRedirect
 }

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -584,6 +584,18 @@ type LoginResult struct {
 	Facades        []FacadeVersions `json:"facades"`
 }
 
+// RedirectInfoResult holds the result of a RedirectInfo call.
+type RedirectInfoResult struct {
+	// Servers holds an entry for each server that holds the
+	// addresses for the server.
+	Servers [][]HostPort `json:"servers"`
+
+	// CACert holds the CA certificate for the server.
+	// TODO(rogpeppe) allow this to be empty if the
+	// server has a globally trusted certificate?
+	CACert string `json:"ca-cert"`
+}
+
 // ReauthRequest holds a challenge/response token meaningful to the identity
 // provider.
 type ReauthRequest struct {

--- a/apiserver/testing/fakeapi.go
+++ b/apiserver/testing/fakeapi.go
@@ -1,0 +1,98 @@
+package testing
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+
+	"github.com/bmizerany/pat"
+	"github.com/juju/utils"
+	"golang.org/x/net/websocket"
+
+	"github.com/juju/juju/rpc"
+	"github.com/juju/juju/rpc/jsoncodec"
+	"github.com/juju/juju/rpc/rpcreflect"
+	"github.com/juju/juju/testing"
+)
+
+// Server represents a fake API server. It must be closed
+// after use.
+type Server struct {
+	// Addrs holds the address used for the
+	// server, suitable for including in api.Info.Addrs
+	Addrs []string
+
+	*httptest.Server
+	newRoot func(modelUUID string) interface{}
+}
+
+// NewAPIServer serves RPC methods on a localhost HTTP server.
+// When a connection is made to the API, the newRoot function
+// is called with the requested model UUID and the returned
+// value defines the API (see the juju/rpc package).
+//
+// Note that the root value accepts any facade version number - it
+// is not currently possible to use this to serve several different
+// facade versions.
+//
+// The server uses testing.ServerCert and testing.ServerKey
+// to host the server.
+//
+// The returned server must be closed after use.
+func NewAPIServer(newRoot func(modelUUID string) interface{}) *Server {
+	tlsCert, err := tls.X509KeyPair([]byte(testing.ServerCert), []byte(testing.ServerKey))
+	if err != nil {
+		panic("bad key pair")
+	}
+
+	srv := &Server{
+		newRoot: newRoot,
+	}
+	pmux := pat.New()
+	pmux.Get("/model/:modeluuid/api", http.HandlerFunc(srv.serveAPI))
+
+	srv.Server = httptest.NewUnstartedServer(pmux)
+
+	tlsConfig := utils.SecureTLSConfig()
+	tlsConfig.Certificates = []tls.Certificate{tlsCert}
+	srv.Server.TLS = tlsConfig
+
+	srv.StartTLS()
+	u, _ := url.Parse(srv.URL)
+	srv.Addrs = []string{u.Host}
+	return srv
+}
+
+func (srv *Server) serveAPI(w http.ResponseWriter, req *http.Request) {
+	wsServer := websocket.Server{
+		Handler: func(conn *websocket.Conn) {
+			srv.serveConn(conn, req.URL.Query().Get(":modeluuid"))
+		},
+	}
+	wsServer.ServeHTTP(w, req)
+}
+
+func (srv *Server) serveConn(wsConn *websocket.Conn, modelUUID string) {
+	codec := jsoncodec.NewWebsocket(wsConn)
+	conn := rpc.NewConn(codec, nil)
+
+	root := allVersions{
+		rpcreflect.ValueOf(reflect.ValueOf(srv.newRoot(modelUUID))),
+	}
+	conn.ServeFinder(root, nil)
+	conn.Start()
+	<-conn.Dead()
+	conn.Close()
+}
+
+// allVersions serves the same methods as would be served
+// by rpc.Conn.Serve except that the facade version is ignored.
+type allVersions struct {
+	x rpcreflect.Value
+}
+
+func (av allVersions) FindMethod(rootMethodName string, version int, objMethodName string) (rpcreflect.MethodCaller, error) {
+	return av.x.FindMethod(rootMethodName, 0, objMethodName)
+}

--- a/apiserver/testing/fakeapi_test.go
+++ b/apiserver/testing/fakeapi_test.go
@@ -1,0 +1,63 @@
+package testing_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	jtesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&fakeAPISuite{})
+
+type fakeAPISuite struct {
+	testing.IsolationSuite
+}
+
+func (*fakeAPISuite) TestFakeAPI(c *gc.C) {
+	var r root
+	fakeUUID := "dead-beef"
+	srv := apiservertesting.NewAPIServer(func(modelUUID string) interface{} {
+		c.Check(modelUUID, gc.Equals, fakeUUID)
+		return &r
+	})
+	defer srv.Close()
+	info := &api.Info{
+		Addrs:    srv.Addrs,
+		CACert:   jtesting.CACert,
+		ModelTag: names.NewModelTag("dead-beef"),
+	}
+	_, err := api.Open(info, api.DialOpts{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(r.calledMethods, jc.DeepEquals, []string{"Login"})
+}
+
+type root struct {
+	calledMethods []string
+}
+
+type facade struct {
+	r *root
+}
+
+func (r *root) Admin(id string) (facade, error) {
+	return facade{r}, nil
+}
+
+func (f facade) Login(req params.LoginRequest) (params.LoginResultV1, error) {
+	f.r.calledMethods = append(f.r.calledMethods, "Login")
+	return params.LoginResultV1{
+		ModelTag:      names.NewModelTag("dead-beef").String(),
+		ControllerTag: names.NewModelTag("dead-beef").String(),
+		UserInfo: &params.AuthUserInfo{
+			DisplayName: "foo",
+			Identity:    "user-bar",
+		},
+		ServerVersion: "1.0.0",
+	}, nil
+}

--- a/apiserver/testing/package_test.go
+++ b/apiserver/testing/package_test.go
@@ -1,0 +1,11 @@
+package testing_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/juju/mock_test.go
+++ b/juju/mock_test.go
@@ -4,6 +4,8 @@
 package juju_test
 
 import (
+	"net"
+
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api"
@@ -12,12 +14,54 @@ import (
 
 type mockAPIState struct {
 	api.Connection
+
+	// If non-nil, close is called when the Close method is called.
 	close func(api.Connection) error
 
 	addr          string
 	apiHostPorts  [][]network.HostPort
 	modelTag      string
 	controllerTag string
+}
+
+type mockedStateFlags int
+
+const (
+	noFlags        mockedStateFlags = 0x0000
+	mockedHostPort mockedStateFlags = 0x0001
+	mockedModelTag mockedStateFlags = 0x0002
+)
+
+// mockedAPIState returns a mocked-up implementation
+// of api.Connection. The logical OR of the flags specifies
+// whether to include a fake host port and model tag
+// in the result.
+func mockedAPIState(flags mockedStateFlags) *mockAPIState {
+	hasHostPort := flags&mockedHostPort == mockedHostPort
+	hasModelTag := flags&mockedModelTag == mockedModelTag
+	addr := ""
+
+	apiHostPorts := [][]network.HostPort{}
+	if hasHostPort {
+		var apiAddrs []network.Address
+		ipv4Address := network.NewAddress("0.1.2.3")
+		ipv6Address := network.NewAddress("2001:db8::1")
+		addr = net.JoinHostPort(ipv4Address.Value, "1234")
+		apiAddrs = append(apiAddrs, ipv4Address, ipv6Address)
+		apiHostPorts = [][]network.HostPort{
+			network.AddressesWithPort(apiAddrs, 1234),
+		}
+	}
+	modelTag := ""
+	if hasModelTag {
+		modelTag = "model-df136476-12e9-11e4-8a70-b2227cce2b54"
+	}
+	return &mockAPIState{
+		apiHostPorts:  apiHostPorts,
+		modelTag:      modelTag,
+		controllerTag: modelTag,
+		addr:          addr,
+	}
 }
 
 func (s *mockAPIState) Close() error {

--- a/rpc/rpcreflect/value.go
+++ b/rpc/rpcreflect/value.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 )
 
-// CallNotImplementedError is an error, returned an attempt to call to
+// CallNotImplementedError is the error returned when an attempt to call to
 // an unknown API method is made.
 type CallNotImplementedError struct {
 	RootMethod string


### PR DESCRIPTION
We are going to have controllers which multiplex other
controllers. In such a case, we don't want to require
all the network traffic for the models that the sub-controllers
control to pass through the top level hub, so allow
a controller to return a "redirect required" error to cause
a client to connect to the model API in the sub-controller
(or some other server) directly.

There is more work to be done after this lands. In particular,
we should cache the API addresses that we were redirected
to and associate them with the model, so we can connect
directly on subsequent API opens.

(Review request: http://reviews.vapour.ws/r/5127/)