### PR TITLE
Extracted data cleansing out into a util package

### DIFF
--- a/mongo/utils/data_cleansing.go
+++ b/mongo/utils/data_cleansing.go
@@ -1,0 +1,54 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils
+
+import "strings"
+
+// EscapeKeys is used to escape bad keys in a map. A statusDoc without
+// escaped keys is broken.
+func EscapeKeys(input map[string]interface{}) map[string]interface{} {
+	return mapKeys(escapeReplacer.Replace, input)
+}
+
+// UnescapeKeys is used to restore escaped keys from a map to their
+// original values.
+func UnescapeKeys(input map[string]interface{}) map[string]interface{} {
+	return mapKeys(unescapeReplacer.Replace, input)
+}
+
+// EscapeString escapes a string to be safe to store in Mongo.
+func EscapeString(s string) string {
+	return escapeReplacer.Replace(s)
+}
+
+// UnescapeString restores escaped characters from a string to their
+// original values.
+func UnescapeString(s string) string {
+	return unescapeReplacer.Replace(s)
+}
+
+// See: http://docs.mongodb.org/manual/faq/developers/#faq-dollar-sign-escaping
+// for why we're using those replacements.
+const (
+	fullWidthDot    = "\uff0e"
+	fullWidthDollar = "\uff04"
+)
+
+var (
+	escapeReplacer   = strings.NewReplacer(".", fullWidthDot, "$", fullWidthDollar)
+	unescapeReplacer = strings.NewReplacer(fullWidthDot, ".", fullWidthDollar, "$")
+)
+
+// mapKeys returns a copy of the supplied map, with all nested map[string]interface{}
+// keys transformed by f. All other types are ignored.
+func mapKeys(f func(string) string, input map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	for key, value := range input {
+		if submap, ok := value.(map[string]interface{}); ok {
+			value = mapKeys(f, submap)
+		}
+		result[f(key)] = value
+	}
+	return result
+}

--- a/mongo/utils/data_cleansing_test.go
+++ b/mongo/utils/data_cleansing_test.go
@@ -1,0 +1,110 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils_test
+
+import (
+	"github.com/juju/juju/mongo/utils"
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+)
+
+type dataCleansingSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&dataCleansingSuite{})
+
+func (s *dataCleansingSuite) TestEscapeKeys_EscapesPeriods(c *gc.C) {
+	before := map[string]interface{}{
+		"a.b": "c",
+	}
+	after := utils.EscapeKeys(before)
+
+	c.Check(after, gc.DeepEquals, map[string]interface{}{
+		"a" + "\uff0e" + "b": "c",
+	})
+}
+
+func (s *dataCleansingSuite) TestEscapeKeys_EscapesDollarSigns(c *gc.C) {
+	before := map[string]interface{}{
+		"$a": "c",
+	}
+	after := utils.EscapeKeys(before)
+
+	c.Check(after, gc.DeepEquals, map[string]interface{}{
+		"\uff04" + "a": "c",
+	})
+}
+
+func (s *dataCleansingSuite) TestEscapeKeys_RecursivelyEscapes(c *gc.C) {
+	before := map[string]interface{}{
+		"$a": "c",
+		"b": map[string]interface{}{
+			"$foo.bar": "baz",
+		},
+	}
+	after := utils.EscapeKeys(before)
+
+	c.Check(after, gc.DeepEquals, map[string]interface{}{
+		"\uff04" + "a": "c",
+		"b": map[string]interface{}{
+			"\uff04" + "foo" + "\uff0e" + "bar": "baz",
+		},
+	})
+}
+
+func (s *dataCleansingSuite) TestUnescapeKey_UnescapesPeriods(c *gc.C) {
+	before := map[string]interface{}{
+		"a" + "\uff0e" + "b": "c",
+	}
+	after := utils.UnescapeKeys(before)
+
+	c.Check(after, gc.DeepEquals, map[string]interface{}{
+		"a.b": "c",
+	})
+}
+
+func (s *dataCleansingSuite) TestUnescapeKey_UnescapesDollarSigns(c *gc.C) {
+	before := map[string]interface{}{
+		"\uff04" + "a": "c",
+	}
+	after := utils.UnescapeKeys(before)
+
+	c.Check(after, gc.DeepEquals, map[string]interface{}{
+		"$a": "c",
+	})
+}
+
+func (s *dataCleansingSuite) TestUnescapeKeys_RecursivelyUnescapes(c *gc.C) {
+	before := map[string]interface{}{
+		"\uff04" + "a": "c",
+		"b": map[string]interface{}{
+			"\uff04" + "foo" + "\uff0e" + "bar": "baz",
+		},
+	}
+	after := utils.UnescapeKeys(before)
+
+	c.Check(after, gc.DeepEquals, map[string]interface{}{
+		"$a": "c",
+		"b": map[string]interface{}{
+			"$foo.bar": "baz",
+		},
+	})
+}
+
+func (s *dataCleansingSuite) TestEscapeString_EscapesPeriods(c *gc.C) {
+	c.Check("a"+"\uff0e"+"b", gc.Equals, utils.EscapeString("a.b"))
+}
+
+func (s *dataCleansingSuite) TestEscapeString_EscapesDollarSigns(c *gc.C) {
+	c.Check("\uff04"+"a", gc.Equals, utils.EscapeString("$a"))
+}
+
+func (s *dataCleansingSuite) TestUnescapeString_UnescapesPeriod(c *gc.C) {
+	c.Check(utils.UnescapeString("a"+"\uff0e"+"b"), gc.Equals, "a.b")
+}
+
+func (s *dataCleansingSuite) TestUnescapeString_UnescapesDollarSigns(c *gc.C) {
+	c.Check(utils.UnescapeString("\uff04"+"a"), gc.Equals, "$a")
+}

--- a/mongo/utils/package_test.go
+++ b/mongo/utils/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
This helps encapsulate Mongo specific data cleansing in a Mongo package and allows any package to perform data cleansing for state without having to import all of state.

(Review request: http://reviews.vapour.ws/r/5128/)