### PR TITLE
Prefer juju-mongo3.2 in deps used for testing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ endif
 	@echo Installing dependencies
 	@sudo apt-get --yes install --no-install-recommends \
 	$(strip $(DEPENDENCIES)) \
-	$(shell apt-cache madison juju-mongodb mongodb-server | head -1 | cut -d '|' -f1)
+	$(shell apt-cache madison juju-mongodb3.2 juju-mongodb mongodb-server | head -1 | cut -d '|' -f1)
 
 # Install bash_completion
 install-etc:


### PR DESCRIPTION
This branch adds to the list of mongos the Makefile should install. It is the preferred DB.

The Make file uses "apt-cache madison" to find matching packages, and return them in the ordered queried. 

    apt-cache madison juju-mongodb3.2 juju-mongodb mongodb-server | head -1 | cut -d '|' -f1

Most series have juju-mongodb and that is what is install for unit tests. precise only has mongodb-server (2.4). By adding juju-mongodb3.2, xenial will prefer the newest mongo to test with.



(Review request: http://reviews.vapour.ws/r/5130/)