### PR TITLE
Expose migration phase changed time in GetMigrationStatus

### DIFF
--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -78,9 +78,10 @@ func (c *Client) GetMigrationStatus() (migration.MigrationStatus, error) {
 	}
 
 	return migration.MigrationStatus{
-		ModelUUID: modelTag.Id(),
-		Attempt:   status.Attempt,
-		Phase:     phase,
+		ModelUUID:        modelTag.Id(),
+		Attempt:          status.Attempt,
+		Phase:            phase,
+		PhaseChangedTime: status.PhaseChangedTime,
 		TargetInfo: migration.TargetInfo{
 			ControllerTag: controllerTag,
 			Addrs:         target.Addrs,

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -4,6 +4,8 @@
 package migrationmaster_test
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -61,6 +63,7 @@ func (s *ClientSuite) TestWatchCallError(c *gc.C) {
 func (s *ClientSuite) TestGetMigrationStatus(c *gc.C) {
 	modelUUID := utils.MustNewUUID().String()
 	controllerUUID := utils.MustNewUUID().String()
+	timestamp := time.Date(2016, 6, 22, 16, 42, 44, 0, time.UTC)
 	apiCaller := apitesting.APICallerFunc(func(_ string, _ int, _, _ string, _, result interface{}) error {
 		out := result.(*params.FullMigrationStatus)
 		*out = params.FullMigrationStatus{
@@ -74,8 +77,9 @@ func (s *ClientSuite) TestGetMigrationStatus(c *gc.C) {
 					Password:      "secret",
 				},
 			},
-			Attempt: 3,
-			Phase:   "READONLY",
+			Attempt:          3,
+			Phase:            "READONLY",
+			PhaseChangedTime: timestamp,
 		}
 		return nil
 	})
@@ -84,9 +88,10 @@ func (s *ClientSuite) TestGetMigrationStatus(c *gc.C) {
 	status, err := client.GetMigrationStatus()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.DeepEquals, migration.MigrationStatus{
-		ModelUUID: modelUUID,
-		Attempt:   3,
-		Phase:     migration.READONLY,
+		ModelUUID:        modelUUID,
+		Attempt:          3,
+		Phase:            migration.READONLY,
+		PhaseChangedTime: timestamp,
 		TargetInfo: migration.TargetInfo{
 			ControllerTag: names.NewModelTag(controllerUUID),
 			Addrs:         []string{"2.2.2.2:2"},

--- a/apiserver/migrationmaster/facade.go
+++ b/apiserver/migrationmaster/facade.go
@@ -97,8 +97,9 @@ func (api *API) GetMigrationStatus() (params.FullMigrationStatus, error) {
 				Password:      target.Password,
 			},
 		},
-		Attempt: attempt,
-		Phase:   phase.String(),
+		Attempt:          attempt,
+		Phase:            phase.String(),
+		PhaseChangedTime: mig.PhaseChangedTime(),
 	}, nil
 }
 

--- a/apiserver/migrationmaster/facade_test.go
+++ b/apiserver/migrationmaster/facade_test.go
@@ -102,8 +102,9 @@ func (s *Suite) TestGetMigrationStatus(c *gc.C) {
 				Password:      "secret",
 			},
 		},
-		Attempt: 1,
-		Phase:   "READONLY",
+		Attempt:          1,
+		Phase:            "READONLY",
+		PhaseChangedTime: s.backend.migration.PhaseChangedTime(),
 	})
 }
 
@@ -308,6 +309,10 @@ func (m *stubMigration) Id() string {
 
 func (m *stubMigration) Phase() (coremigration.Phase, error) {
 	return coremigration.READONLY, nil
+}
+
+func (m *stubMigration) PhaseChangedTime() time.Time {
+	return time.Date(2016, 6, 22, 16, 38, 0, 0, time.UTC)
 }
 
 func (m *stubMigration) Attempt() (int, error) {

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -3,6 +3,8 @@
 
 package params
 
+import "time"
+
 // InitiateModelMigrationArgs holds the details required to start one
 // or more model migrations.
 type InitiateModelMigrationArgs struct {
@@ -89,9 +91,10 @@ type MigrationStatus struct {
 // migration, including authentication details for the remote
 // controller.
 type FullMigrationStatus struct {
-	Spec    ModelMigrationSpec `json:"spec"`
-	Attempt int                `json:"attempt"`
-	Phase   string             `json:"phase"`
+	Spec             ModelMigrationSpec `json:"spec"`
+	Attempt          int                `json:"attempt"`
+	Phase            string             `json:"phase"`
+	PhaseChangedTime time.Time          `json:"phase-changed-time"`
 }
 
 // PhasesResults holds the phase of one or more model migrations.

--- a/core/migration/migration.go
+++ b/core/migration/migration.go
@@ -3,7 +3,11 @@
 
 package migration
 
-import "github.com/juju/version"
+import (
+	"time"
+
+	"github.com/juju/version"
+)
 
 // MigrationStatus returns the details for a migration as needed by
 // the migration master worker.
@@ -17,6 +21,10 @@ type MigrationStatus struct {
 
 	// Phases indicates the current migration phase.
 	Phase Phase
+
+	// PhaseChangedTime indicates the time the phase was changed to
+	// its current value.
+	PhaseChangedTime time.Time
 
 	// TargetInfo contains the details of how to connect to the target
 	// controller.


### PR DESCRIPTION
The migrationmaster worker needs to know when a phase changed occured in order to implement timeouts when waiting for minions to report progress.

(Review request: http://reviews.vapour.ws/r/5132/)