### PR TITLE
bootstrap: no auth-types => supports all

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -348,9 +348,17 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		return errors.Trace(err)
 	}
 
-	// Custom clouds may not have explicitly declared support for any auth types.
+	// Custom clouds may not have explicitly declared support for any auth-
+	// types, in which case we'll assume that they support everything that
+	// the provider supports.
 	if len(cloud.AuthTypes) == 0 {
-		cloud.AuthTypes = append(cloud.AuthTypes, jujucloud.EmptyAuthType)
+		provider, err := environs.Provider(cloud.Type)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		for authType := range provider.CredentialSchemas() {
+			cloud.AuthTypes = append(cloud.AuthTypes, authType)
+		}
 	}
 
 	// Get the credentials and region name.

--- a/state/cloud.go
+++ b/state/cloud.go
@@ -99,3 +99,17 @@ func (st *State) Cloud() (cloud.Cloud, error) {
 	}
 	return doc.toCloud(), nil
 }
+
+// validateCloud checks that the supplied cloud is valid.
+func validateCloud(cloud cloud.Cloud) error {
+	if cloud.Type == "" {
+		return errors.NotValidf("empty Type")
+	}
+	if len(cloud.AuthTypes) == 0 {
+		return errors.NotValidf("empty auth-types")
+	}
+	// TODO(axw) we should ensure that the cloud auth-types is a subset
+	// of the auth-types supported by the provider. To do that, we'll
+	// need a new "policy".
+	return nil
+}

--- a/state/open.go
+++ b/state/open.go
@@ -162,8 +162,9 @@ func (p InitializeParams) Validate() error {
 	if p.Cloud.Type == "" {
 		return errors.NotValidf("empty Cloud")
 	}
-	// TODO(wallyworld) - TODO check that the cloud has a non-empty list of auth types
-	//
+	if err := validateCloud(p.Cloud); err != nil {
+		return errors.Annotate(err, "validating cloud")
+	}
 	if _, err := validateCloudRegion(p.Cloud, p.ControllerModelArgs.CloudRegion); err != nil {
 		return errors.Annotate(err, "validating controller model cloud region")
 	}


### PR DESCRIPTION
If a cloud does not specify any auth-types,
we set its auth-types to all of those that
the provider supports.

Fixes https://bugs.launchpad.net/juju-core/+bug/1593566

(Review request: http://reviews.vapour.ws/r/5133/)