### PR TITLE
bootstrap: dirty hack to support gce jsonfile

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/provider/gce"
 	jujuversion "github.com/juju/juju/version"
 )
 
@@ -399,6 +400,17 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	controllerUUID, err := utils.NewUUID()
 	if err != nil {
 		return errors.Trace(err)
+	}
+
+	// TODO(axw) this is a dirty hack to get 2.0-beta10 over the line.
+	// We need to pull this out immediately after, and then update
+	// everything to remove credentials from model config.
+	if cloud.Type == "gce" && credential.AuthType() == jujucloud.JSONFileAuthType {
+		cred, err := gce.ParseJSONAuthFile(credential.Attributes()["file"])
+		if err != nil {
+			return errors.Trace(err)
+		}
+		*credential = cred
 	}
 
 	// Create an environment config from the cloud and credentials.

--- a/provider/gce/credentials.go
+++ b/provider/gce/credentials.go
@@ -73,7 +73,7 @@ func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, e
 	if possibleFilePath == "" {
 		return nil, errors.NotFoundf("gce credentials")
 	}
-	parsedCred, err := parseJSONAuthFile(possibleFilePath)
+	parsedCred, err := ParseJSONAuthFile(possibleFilePath)
 	if err != nil {
 		return nil, errors.Annotatef(err, "invalid json credential file %s", possibleFilePath)
 	}
@@ -105,9 +105,11 @@ func wellKnownCredentialsFile() string {
 	return filepath.Join(utils.Home(), ".config", "gcloud", f)
 }
 
-// parseJSONAuthFile parses the file with the given path, and extracts
+// ParseJSONAuthFile parses the file with the given path, and extracts
 // the OAuth2 credentials within.
-func parseJSONAuthFile(filename string) (cloud.Credential, error) {
+//
+// TODO(axw) unexport this after 2.0-beta10 is out.
+func ParseJSONAuthFile(filename string) (cloud.Credential, error) {
 	authFile, err := os.Open(filename)
 	if err != nil {
 		return cloud.Credential{}, errors.Trace(err)

--- a/provider/gce/provider.go
+++ b/provider/gce/provider.go
@@ -32,7 +32,7 @@ func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*
 	case cloud.JSONFileAuthType:
 		var err error
 		filename := args.Credentials.Attributes()["file"]
-		args.Credentials, err = parseJSONAuthFile(filename)
+		args.Credentials, err = ParseJSONAuthFile(filename)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}


### PR DESCRIPTION
When bootstrapping, we check to see if the auth-type
is "jsonfile", and the provider is "gce". If so, we
read the credentials and transform to the oauth2
credential type.

This is a hack to get things working in beta10. We
will be making major changes following beta10 that
mean this bug will be fixed properly.

Fixes https://bugs.launchpad.net/juju-core/+bug/1593761