### PR TITLE
apiserver/facade: extract types/logic from common

### DIFF
--- a/apiserver/action/action.go
+++ b/apiserver/action/action.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
@@ -19,13 +20,13 @@ func init() {
 // ActionAPI implements the client API for interacting with Actions
 type ActionAPI struct {
 	state      *state.State
-	resources  *common.Resources
-	authorizer common.Authorizer
+	resources  facade.Resources
+	authorizer facade.Authorizer
 	check      *common.BlockChecker
 }
 
 // NewActionAPI returns an initialized ActionAPI
-func NewActionAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*ActionAPI, error) {
+func NewActionAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*ActionAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}

--- a/apiserver/agent/agent.go
+++ b/apiserver/agent/agent.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
@@ -28,12 +29,12 @@ type AgentAPIV2 struct {
 	*common.ModelWatcher
 
 	st   *state.State
-	auth common.Authorizer
+	auth facade.Authorizer
 }
 
 // NewAgentAPIV2 returns an object implementing version 2 of the Agent API
 // with the given authorizer representing the currently logged in client.
-func NewAgentAPIV2(st *state.State, resources *common.Resources, auth common.Authorizer) (*AgentAPIV2, error) {
+func NewAgentAPIV2(st *state.State, resources facade.Resources, auth facade.Authorizer) (*AgentAPIV2, error) {
 	// Agents are defined to be any user that's not a client user.
 	if !auth.AuthMachineAgent() && !auth.AuthUnitAgent() {
 		return nil, common.ErrPerm

--- a/apiserver/agenttools/agenttools.go
+++ b/apiserver/agenttools/agenttools.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/version"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/tools"
@@ -34,14 +35,14 @@ type stateInterface interface {
 // AgentToolsAPI implements the API used by the machine model worker.
 type AgentToolsAPI struct {
 	st         stateInterface
-	authorizer common.Authorizer
+	authorizer facade.Authorizer
 	// tools lookup
 	findTools        toolsFinder
 	envVersionUpdate envVersionUpdater
 }
 
 // NewAgentToolsAPI creates a new instance of the Model API.
-func NewAgentToolsAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*AgentToolsAPI, error) {
+func NewAgentToolsAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*AgentToolsAPI, error) {
 	return &AgentToolsAPI{
 		st:               st,
 		authorizer:       authorizer,

--- a/apiserver/annotations/client.go
+++ b/apiserver/annotations/client.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
@@ -30,14 +31,14 @@ type Annotations interface {
 // implementation of the api end point.
 type API struct {
 	access     annotationAccess
-	authorizer common.Authorizer
+	authorizer facade.Authorizer
 }
 
 // NewAPI returns a new charm annotator API facade.
 func NewAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*API, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm

--- a/apiserver/application/application.go
+++ b/apiserver/application/application.go
@@ -14,6 +14,7 @@ import (
 	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/instance"
 	jjj "github.com/juju/juju/juju"
@@ -41,14 +42,14 @@ type Application interface {
 type API struct {
 	check      *common.BlockChecker
 	state      *state.State
-	authorizer common.Authorizer
+	authorizer facade.Authorizer
 }
 
 // NewAPI returns a new application API facade.
 func NewAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*API, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm

--- a/apiserver/applicationscaler/facade.go
+++ b/apiserver/applicationscaler/facade.go
@@ -6,6 +6,7 @@ package applicationscaler
 import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
@@ -27,11 +28,11 @@ type Backend interface {
 // Facade allows model-manager clients to watch and rescale services.
 type Facade struct {
 	backend   Backend
-	resources *common.Resources
+	resources facade.Resources
 }
 
 // NewFacade creates a new authorized Facade.
-func NewFacade(backend Backend, res *common.Resources, auth common.Authorizer) (*Facade, error) {
+func NewFacade(backend Backend, res facade.Resources, auth facade.Authorizer) (*Facade, error) {
 	if !auth.AuthModelManager() {
 		return nil, common.ErrPerm
 	}

--- a/apiserver/applicationscaler/shim.go
+++ b/apiserver/applicationscaler/shim.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/state"
 )
 
@@ -20,7 +21,7 @@ func init() {
 }
 
 // newFacade wraps the supplied *state.State for the use of the Facade.
-func newFacade(st *state.State, res *common.Resources, auth common.Authorizer) (*Facade, error) {
+func newFacade(st *state.State, res facade.Resources, auth facade.Authorizer) (*Facade, error) {
 	return NewFacade(backendShim{st}, res, auth)
 }
 

--- a/apiserver/applicationscaler/util_test.go
+++ b/apiserver/applicationscaler/util_test.go
@@ -10,13 +10,14 @@ import (
 
 	"github.com/juju/juju/apiserver/applicationscaler"
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
 
-// mockAuth implements common.Authorizer for the tests' convenience.
+// mockAuth implements facade.Authorizer for the tests' convenience.
 type mockAuth struct {
-	common.Authorizer
+	facade.Authorizer
 	modelManager bool
 }
 
@@ -25,7 +26,7 @@ func (mock mockAuth) AuthModelManager() bool {
 }
 
 // auth is a convenience constructor for a mockAuth.
-func auth(modelManager bool) common.Authorizer {
+func auth(modelManager bool) facade.Authorizer {
 	return mockAuth{modelManager: modelManager}
 }
 

--- a/apiserver/backups/backups.go
+++ b/apiserver/backups/backups.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
@@ -46,7 +47,7 @@ type API struct {
 }
 
 // NewAPI creates a new instance of the Backups API facade.
-func NewAPI(backend Backend, resources *common.Resources, authorizer common.Authorizer) (*API, error) {
+func NewAPI(backend Backend, resources facade.Resources, authorizer facade.Authorizer) (*API, error) {
 	if !authorizer.AuthClient() {
 		return nil, errors.Trace(common.ErrPerm)
 	}
@@ -83,7 +84,7 @@ func NewAPI(backend Backend, resources *common.Resources, authorizer common.Auth
 	return &b, nil
 }
 
-func extractResourceValue(resources *common.Resources, key string) (string, error) {
+func extractResourceValue(resources facade.Resources, key string) (string, error) {
 	res := resources.Get(key)
 	strRes, ok := res.(common.StringResource)
 	if !ok {

--- a/apiserver/backups/shim.go
+++ b/apiserver/backups/shim.go
@@ -6,6 +6,7 @@ package backups
 import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/state"
 )
 
@@ -31,6 +32,6 @@ func (s *stateShim) MachineSeries(id string) (string, error) {
 	return m.Series(), nil
 }
 
-func newAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*API, error) {
+func newAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*API, error) {
 	return NewAPI(&stateShim{st}, resources, authorizer)
 }

--- a/apiserver/block/client.go
+++ b/apiserver/block/client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
@@ -33,14 +34,14 @@ type Block interface {
 // implementation of the api end point.
 type API struct {
 	access     blockAccess
-	authorizer common.Authorizer
+	authorizer facade.Authorizer
 }
 
 // NewAPI returns a new block API facade.
 func NewAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*API, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm

--- a/apiserver/charmrevisionupdater/updater.go
+++ b/apiserver/charmrevisionupdater/updater.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/state"
@@ -28,8 +29,8 @@ type CharmRevisionUpdater interface {
 // implementation of the api end point.
 type CharmRevisionUpdaterAPI struct {
 	state      *state.State
-	resources  *common.Resources
-	authorizer common.Authorizer
+	resources  facade.Resources
+	authorizer facade.Authorizer
 }
 
 var _ CharmRevisionUpdater = (*CharmRevisionUpdaterAPI)(nil)
@@ -37,8 +38,8 @@ var _ CharmRevisionUpdater = (*CharmRevisionUpdaterAPI)(nil)
 // NewCharmRevisionUpdaterAPI creates a new server-side charmrevisionupdater API end point.
 func NewCharmRevisionUpdaterAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*CharmRevisionUpdaterAPI, error) {
 	if !authorizer.AuthMachineAgent() && !authorizer.AuthModelManager() {
 		return nil, common.ErrPerm

--- a/apiserver/charms/client.go
+++ b/apiserver/charms/client.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
@@ -33,14 +34,14 @@ type Charms interface {
 // implementation of the api end point.
 type API struct {
 	access     charmsAccess
-	authorizer common.Authorizer
+	authorizer facade.Authorizer
 }
 
 // NewAPI returns a new charms API facade.
 func NewAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*API, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm

--- a/apiserver/cleaner/cleaner.go
+++ b/apiserver/cleaner/cleaner.go
@@ -8,6 +8,7 @@ package cleaner
 
 import (
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
@@ -20,14 +21,14 @@ func init() {
 // CleanerAPI implements the API used by the cleaner worker.
 type CleanerAPI struct {
 	st        StateInterface
-	resources *common.Resources
+	resources facade.Resources
 }
 
 // NewCleanerAPI creates a new instance of the Cleaner API.
 func NewCleanerAPI(
 	st *state.State,
-	res *common.Resources,
-	authorizer common.Authorizer,
+	res facade.Resources,
+	authorizer facade.Authorizer,
 ) (*CleanerAPI, error) {
 	if !authorizer.AuthModelManager() {
 		return nil, common.ErrPerm

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/application"
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -32,8 +33,8 @@ var logger = loggo.GetLogger("juju.apiserver.client")
 
 type API struct {
 	stateAccessor stateInterface
-	auth          common.Authorizer
-	resources     *common.Resources
+	auth          facade.Authorizer
+	resources     facade.Resources
 	client        *Client
 	// statusSetter provides common methods for updating an entity's provisioning status.
 	statusSetter *common.StatusSetter
@@ -59,7 +60,7 @@ var getState = func(st *state.State) stateInterface {
 }
 
 // NewClient creates a new instance of the Client Facade.
-func NewClient(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*Client, error) {
+func NewClient(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*Client, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}

--- a/apiserver/cloud/cloud.go
+++ b/apiserver/cloud/cloud.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/state"
@@ -25,18 +26,18 @@ func init() {
 // the concrete implementation of the api end point.
 type CloudAPI struct {
 	backend                Backend
-	authorizer             common.Authorizer
+	authorizer             facade.Authorizer
 	apiUser                names.UserTag
 	getCredentialsAuthFunc common.GetAuthFunc
 }
 
-func newFacade(st *state.State, resources *common.Resources, auth common.Authorizer) (*CloudAPI, error) {
+func newFacade(st *state.State, resources facade.Resources, auth facade.Authorizer) (*CloudAPI, error) {
 	return NewCloudAPI(NewStateBackend(st), auth)
 }
 
 // NewCloudAPI creates a new API server endpoint for managing the controller's
 // cloud definition and cloud credentials.
-func NewCloudAPI(backend Backend, authorizer common.Authorizer) (*CloudAPI, error) {
+func NewCloudAPI(backend Backend, authorizer facade.Authorizer) (*CloudAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}

--- a/apiserver/common/action.go
+++ b/apiserver/common/action.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
@@ -162,7 +163,7 @@ func Actions(args params.Entities, actionFn func(string) (state.Action, error)) 
 // It needs a tagToActionReceiver function and a registerFunc to register
 // resources.
 // It's a helper function currently used by the uniter and by machineactions
-func WatchOneActionReceiverNotifications(tagToActionReceiver func(tag string) (state.ActionReceiver, error), registerFunc func(r Resource) string) func(names.Tag) (params.StringsWatchResult, error) {
+func WatchOneActionReceiverNotifications(tagToActionReceiver func(tag string) (state.ActionReceiver, error), registerFunc func(r facade.Resource) string) func(names.Tag) (params.StringsWatchResult, error) {
 	return func(tag names.Tag) (params.StringsWatchResult, error) {
 		nothing := params.StringsWatchResult{}
 		receiver, err := tagToActionReceiver(tag.String())

--- a/apiserver/common/action_test.go
+++ b/apiserver/common/action_test.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
@@ -211,7 +212,7 @@ func (s *actionsSuite) TestWatchActionNotifications(c *gc.C) {
 
 func (s *actionsSuite) TestWatchOneActionReceiverNotifications(c *gc.C) {
 	expectErr := errors.New("zwoosh")
-	registerFunc := func(common.Resource) string { return "bambalam" }
+	registerFunc := func(facade.Resource) string { return "bambalam" }
 	tagToActionReceiver := common.TagToActionReceiverFn(makeFindEntity(map[string]state.Entity{
 		"machine-1": &fakeActionReceiver{watcher: &fakeWatcher{}},
 		"machine-2": &fakeActionReceiver{watcher: &fakeWatcher{err: expectErr}},

--- a/apiserver/common/addresses.go
+++ b/apiserver/common/addresses.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -23,13 +24,13 @@ type AddressAndCertGetter interface {
 
 // APIAddresser implements the APIAddresses method
 type APIAddresser struct {
-	resources *Resources
+	resources facade.Resources
 	getter    AddressAndCertGetter
 }
 
 // NewAPIAddresser returns a new APIAddresser that uses the given getter to
 // fetch its addresses.
-func NewAPIAddresser(getter AddressAndCertGetter, resources *Resources) *APIAddresser {
+func NewAPIAddresser(getter AddressAndCertGetter, resources facade.Resources) *APIAddresser {
 	return &APIAddresser{
 		getter:    getter,
 		resources: resources,

--- a/apiserver/common/export_test.go
+++ b/apiserver/common/export_test.go
@@ -3,11 +3,12 @@
 
 package common
 
+import "github.com/juju/juju/apiserver/facade"
+
 var (
 	MachineJobFromParams    = machineJobFromParams
 	ValidateNewFacade       = validateNewFacade
 	WrapNewFacade           = wrapNewFacade
-	NilFacadeRecord         = facadeRecord{}
 	EnvtoolsFindTools       = &envtoolsFindTools
 	SendMetrics             = &sendMetrics
 	MockableDestroyMachines = destroyMachines
@@ -22,12 +23,6 @@ type Patcher interface {
 // a clean slate to work from, and will not accidentally overrite/mutate the
 // real facade registry.
 func SanitizeFacades(patcher Patcher) {
-	emptyFacades := &FacadeRegistry{}
+	emptyFacades := &facade.Registry{}
 	patcher.PatchValue(&Facades, emptyFacades)
-}
-
-type Versions versions
-
-func DescriptionFromVersions(name string, vers Versions) FacadeDescription {
-	return descriptionFromVersions(name, versions(vers))
 }

--- a/apiserver/common/interfaces.go
+++ b/apiserver/common/interfaces.go
@@ -14,35 +14,6 @@ type AuthFunc func(tag names.Tag) bool
 // GetAuthFunc returns an AuthFunc.
 type GetAuthFunc func() (AuthFunc, error)
 
-// Authorizer represents a value that can be asked for authorization
-// information on its associated authenticated entity. It is
-// implemented by an API server to allow an API implementation to ask
-// questions about the client that is currently connected.
-type Authorizer interface {
-	// AuthMachineAgent returns whether the authenticated entity is a
-	// machine agent.
-	AuthMachineAgent() bool
-
-	// AuthUnitAgent returns whether the authenticated entity is a
-	// unit agent.
-	AuthUnitAgent() bool
-
-	// AuthOwner returns whether the authenticated entity is the same
-	// as the given entity.
-	AuthOwner(tag names.Tag) bool
-
-	// AuthModelManager returns whether the authenticated entity is
-	// a machine running the environment manager job.
-	AuthModelManager() bool
-
-	// AuthClient returns whether the authenticated entity
-	// is a client user.
-	AuthClient() bool
-
-	// GetAuthTag returns the tag of the authenticated entity.
-	GetAuthTag() names.Tag
-}
-
 // AuthEither returns an AuthFunc generator that returns an AuthFunc
 // that accepts any tag authorized by either of its arguments.
 func AuthEither(a, b GetAuthFunc) GetAuthFunc {

--- a/apiserver/common/modelmachineswatcher.go
+++ b/apiserver/common/modelmachineswatcher.go
@@ -6,6 +6,7 @@ package common
 import (
 	"fmt"
 
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
@@ -15,14 +16,14 @@ import (
 // method for use by various facades.
 type ModelMachinesWatcher struct {
 	st         state.ModelMachinesWatcher
-	resources  *Resources
-	authorizer Authorizer
+	resources  facade.Resources
+	authorizer facade.Authorizer
 }
 
 // NewModelMachinesWatcher returns a new ModelMachinesWatcher. The
 // GetAuthFunc will be used on each invocation of WatchUnits to
 // determine current permissions.
-func NewModelMachinesWatcher(st state.ModelMachinesWatcher, resources *Resources, authorizer Authorizer) *ModelMachinesWatcher {
+func NewModelMachinesWatcher(st state.ModelMachinesWatcher, resources facade.Resources, authorizer facade.Authorizer) *ModelMachinesWatcher {
 	return &ModelMachinesWatcher{
 		st:         st,
 		resources:  resources,

--- a/apiserver/common/modelwatcher.go
+++ b/apiserver/common/modelwatcher.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/state"
@@ -14,8 +15,8 @@ import (
 // facades - WatchForModelConfigChanges and ModelConfig.
 type ModelWatcher struct {
 	st         state.ModelAccessor
-	resources  *Resources
-	authorizer Authorizer
+	resources  facade.Resources
+	authorizer facade.Authorizer
 }
 
 // NewModelWatcher returns a new ModelWatcher. Active watchers
@@ -24,7 +25,7 @@ type ModelWatcher struct {
 // determine current permissions.
 // Right now, environment tags are not used, so both created AuthFuncs
 // are called with "" for tag, which means "the current environment".
-func NewModelWatcher(st state.ModelAccessor, resources *Resources, authorizer Authorizer) *ModelWatcher {
+func NewModelWatcher(st state.ModelAccessor, resources facade.Resources, authorizer facade.Authorizer) *ModelWatcher {
 	return &ModelWatcher{
 		st:         st,
 		resources:  resources,

--- a/apiserver/common/registry.go
+++ b/apiserver/common/registry.go
@@ -7,48 +7,44 @@ import (
 	"fmt"
 	"reflect"
 	"runtime"
-	"sort"
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common/apihttp"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/state"
 )
 
-// FacadeFactory represent a way of creating a Facade from the current
-// connection to the State.
-type FacadeFactory func(
-	st *state.State, resources *Resources, authorizer Authorizer, id string,
-) (
-	interface{}, error,
-)
-
-type facadeRecord struct {
-	factory    FacadeFactory
-	facadeType reflect.Type
-	// If the feature is not the empty string, then this facade
-	// is only returned when that feature flag is set.
-	feature string
-}
+// Facades is the registry that tracks all of the Facades that will be
+// exposed in the API. It can be used to List/Get/Register facades.
+//
+// Most implementers of a facade will probably want to use
+// RegisterStandardFacade rather than Facades.Register, as it provides
+// much cleaner syntax and semantics for calling during init().
+//
+// Developers in a happy future will not want to use Facades at all,
+// eschewing globals in favour of explicitly building apis and supplying
+// them directly to an apiserver.
+var Facades = &facade.Registry{}
 
 // RegisterFacade updates the global facade registry with a new version of a new type.
-func RegisterFacade(name string, version int, factory FacadeFactory, facadeType reflect.Type) {
+func RegisterFacade(name string, version int, factory facade.Factory, facadeType reflect.Type) {
 	RegisterFacadeForFeature(name, version, factory, facadeType, "")
 }
 
 // RegisterFacadeForFeature updates the global facade registry with a new
 // version of a new type. If the feature is non-empty, this facade is only
 // available when the specified feature flag is set.
-func RegisterFacadeForFeature(name string, version int, factory FacadeFactory, facadeType reflect.Type, feature string) {
+func RegisterFacadeForFeature(name string, version int, factory facade.Factory, facadeType reflect.Type, feature string) {
 	err := Facades.Register(name, version, factory, facadeType, feature)
 	if err != nil {
 		// This is meant to be called during init() so errors should be
 		// considered fatal.
 		panic(err)
 	}
+	logger.Tracef("Registered facade %q v%d", name, version)
 }
 
 // validateNewFacade ensures that the facade factory we have has the right
@@ -66,7 +62,15 @@ func validateNewFacade(funcValue reflect.Value) error {
 		return fmt.Errorf("function %q does not take 3 parameters and return 2",
 			funcName)
 	}
-	facadeType := reflect.TypeOf((*FacadeFactory)(nil)).Elem()
+
+	type nastyFactory func(
+		st *state.State,
+		resources facade.Resources,
+		authorizer facade.Authorizer,
+	) (
+		interface{}, error,
+	)
+	facadeType := reflect.TypeOf((*nastyFactory)(nil)).Elem()
 	isSame := true
 	for i := 0; i < 3; i++ {
 		if funcType.In(i) != facadeType.In(i) {
@@ -78,30 +82,29 @@ func validateNewFacade(funcValue reflect.Value) error {
 		isSame = false
 	}
 	if !isSame {
-		return fmt.Errorf("function %q does not have the signature func (*state.State, *common.Resources, common.Authorizer) (*Type, error)",
+		return fmt.Errorf("function %q does not have the signature func (*state.State, facade.Resources, facade.Authorizer) (*Type, error)",
 			funcName)
 	}
 	return nil
 }
 
 // wrapNewFacade turns a given NewFoo(st, resources, authorizer) (*Instance, error)
-// function and wraps it into a proper FacadeFactory function.
-func wrapNewFacade(newFunc interface{}) (FacadeFactory, reflect.Type, error) {
+// function and wraps it into a proper facade.Factory function.
+func wrapNewFacade(newFunc interface{}) (facade.Factory, reflect.Type, error) {
 	funcValue := reflect.ValueOf(newFunc)
 	err := validateNewFacade(funcValue)
 	if err != nil {
 		return nil, reflect.TypeOf(nil), err
 	}
 	// So we know newFunc is a func with the right args in and out, so
-	// wrap it into a helper function that matches the FacadeFactory.
-	wrapped := func(
-		st *state.State, resources *Resources, auth Authorizer, id string,
-	) (
-		interface{}, error,
-	) {
-		if id != "" {
+	// wrap it into a helper function that matches the facade.Factory.
+	wrapped := func(context facade.Context) (facade.Facade, error) {
+		if context.ID() != "" {
 			return nil, ErrBadId
 		}
+		st := context.State()
+		auth := context.Auth()
+		resources := context.Resources()
 		// st, resources, or auth is nil, then reflect.Call dies
 		// because reflect.ValueOf(anynil) is the Zero Value.
 		// So we use &obj.Elem() which gives us a concrete Value object
@@ -130,9 +133,17 @@ type NewHookContextFacadeFn func(*state.State, *state.Unit) (interface{}, error)
 // hook-context-facade to a standard facade so the caller's factory
 // method can elide unnecessary arguments. This function also handles
 // any necessary authorization for the client.
+//
+// XXX(fwereade): this is fundamentally broken, because it (1)
+// arbitrarily creates a new facade for a tiny fragment of a specific
+// client worker's reponsibilities and (2) actively conceals necessary
+// auth information from the facade. Don't call it; actively work to
+// delete code that uses it, and rewrite it properly.
 func RegisterHookContextFacade(name string, version int, newHookContextFacade NewHookContextFacadeFn, facadeType reflect.Type) {
 
-	newFacade := func(st *state.State, _ *Resources, authorizer Authorizer, _ string) (interface{}, error) {
+	newFacade := func(context facade.Context) (facade.Facade, error) {
+		authorizer := context.Auth()
+		st := context.State()
 
 		if !authorizer.AuthUnitAgent() {
 			return nil, ErrPerm
@@ -158,7 +169,7 @@ func RegisterHookContextFacade(name string, version int, newHookContextFacade Ne
 
 // RegisterStandardFacade registers a factory function for a normal New* style
 // function. This requires that the function has the form:
-// NewFoo(*state.State, *common.Resources, common.Authorizer) (*Type, error)
+// NewFoo(*state.State, facade.Resources, facade.Authorizer) (*Type, error)
 // With that syntax, we will create a helper function that wraps calling NewFoo
 // with the right parameters, and returns the *Type correctly.
 func RegisterStandardFacade(name string, version int, newFunc interface{}) {
@@ -167,7 +178,7 @@ func RegisterStandardFacade(name string, version int, newFunc interface{}) {
 
 // RegisterStandardFacadeForFeature registers a factory function for a normal
 // New* style function. This requires that the function has the form:
-// NewFoo(*state.State, *common.Resources, common.Authorizer) (*Type, error)
+// NewFoo(*state.State, facade.Resources, facade.Authorizer) (*Type, error)
 // With that syntax, we will create a helper function that wraps calling
 // NewFoo with the right parameters, and returns the *Type correctly. If the
 // feature is non-empty, this facade is only available when the specified
@@ -178,137 +189,6 @@ func RegisterStandardFacadeForFeature(name string, version int, newFunc interfac
 		panic(err)
 	}
 	RegisterFacadeForFeature(name, version, wrapped, facadeType, feature)
-}
-
-// Facades is the registry that tracks all of the Facades that will be exposed in the API.
-// It can be used to List/Get/Register facades.
-// Most implementers of a facade will probably want to use
-// RegisterStandardFacade rather than Facades.Register, as it provides much
-// cleaner syntax and semantics for calling during init().
-var Facades = &FacadeRegistry{}
-
-// versions is our internal structure for tracking specific versions of a
-// single facade. We use a map to be able to quickly lookup a version.
-type versions map[int]facadeRecord
-
-// FacadeRegistry is responsible for tracking what Facades are going to be exported in the API.
-// See the variable "Facades" for the singleton that tracks them.
-// It would be possible to have multiple registries if we decide to change how
-// the API exposes methods based on Login information.
-type FacadeRegistry struct {
-	facades map[string]versions
-}
-
-// Register adds a single named facade at a given version to the registry.
-// FacadeFactory will be called when someone wants to instantiate an object of
-// this facade, and facadeType defines the concrete type that the returned object will be.
-// The Type information is used to define what methods will be exported in the
-// API, and it must exactly match the actual object returned by the factory.
-func (f *FacadeRegistry) Register(name string, version int, factory FacadeFactory, facadeType reflect.Type, feature string) error {
-	if f.facades == nil {
-		f.facades = make(map[string]versions, 1)
-	}
-	record := facadeRecord{
-		factory:    factory,
-		facadeType: facadeType,
-		feature:    feature,
-	}
-	if vers, ok := f.facades[name]; ok {
-		if _, ok := vers[version]; ok {
-			fullname := fmt.Sprintf("%s(%d)", name, version)
-			return fmt.Errorf("object %q already registered", fullname)
-		}
-		vers[version] = record
-	} else {
-		f.facades[name] = versions{version: record}
-	}
-	logger.Tracef("Registered facade %q v%d", name, version)
-	return nil
-}
-
-// lookup translates a facade name and version into a facadeRecord.
-func (f *FacadeRegistry) lookup(name string, version int) (facadeRecord, error) {
-	if versions, ok := f.facades[name]; ok {
-		if record, ok := versions[version]; ok {
-			if featureflag.Enabled(record.feature) {
-				return record, nil
-			}
-		}
-	}
-	return facadeRecord{}, errors.NotFoundf("%s(%d)", name, version)
-}
-
-// GetFactory returns just the FacadeFactory for a given Facade name and version.
-// See also GetType for getting the type information instead of the creation factory.
-func (f *FacadeRegistry) GetFactory(name string, version int) (FacadeFactory, error) {
-	record, err := f.lookup(name, version)
-	if err != nil {
-		return nil, err
-	}
-	return record.factory, nil
-}
-
-// GetType returns the type information for a given Facade name and version.
-// This can be used for introspection purposes (to determine what methods are
-// available, etc).
-func (f *FacadeRegistry) GetType(name string, version int) (reflect.Type, error) {
-	record, err := f.lookup(name, version)
-	if err != nil {
-		return nil, err
-	}
-	return record.facadeType, nil
-}
-
-// FacadeDescription describes the name and what versions of a facade have been
-// registered.
-type FacadeDescription struct {
-	Name     string
-	Versions []int
-}
-
-// descriptionFromVersions aggregates the information in a versions map into a
-// more friendly form for List().
-func descriptionFromVersions(name string, vers versions) FacadeDescription {
-	intVersions := make([]int, 0, len(vers))
-	for version, record := range vers {
-		if featureflag.Enabled(record.feature) {
-			intVersions = append(intVersions, version)
-		}
-	}
-	sort.Ints(intVersions)
-	return FacadeDescription{
-		Name:     name,
-		Versions: intVersions,
-	}
-}
-
-// List returns a slice describing each of the registered Facades.
-func (f *FacadeRegistry) List() []FacadeDescription {
-	names := make([]string, 0, len(f.facades))
-	for name := range f.facades {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	descriptions := make([]FacadeDescription, 0, len(f.facades))
-	for _, name := range names {
-		facades := f.facades[name]
-		description := descriptionFromVersions(name, facades)
-		if len(description.Versions) > 0 {
-			descriptions = append(descriptions, description)
-		}
-	}
-	return descriptions
-}
-
-// Discard gets rid of a registration that has already been done. Calling
-// discard on an entry that is not present is not considered an error.
-func (f *FacadeRegistry) Discard(name string, version int) {
-	if versions, ok := f.facades[name]; ok {
-		delete(versions, version)
-		if len(versions) == 0 {
-			delete(f.facades, name)
-		}
-	}
 }
 
 var endpointRegistry = map[string]apihttp.HandlerSpec{}

--- a/apiserver/common/registry_test.go
+++ b/apiserver/common/registry_test.go
@@ -11,6 +11,8 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/facade/facadetest"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/rpc/rpcreflect"
 	"github.com/juju/juju/state"
@@ -23,30 +25,15 @@ type facadeRegistrySuite struct {
 
 var _ = gc.Suite(&facadeRegistrySuite{})
 
-func testFacade(
-	st *state.State, resources *common.Resources,
-	authorizer common.Authorizer, id string,
-) (interface{}, error) {
-	return "myobject", nil
-}
-
 func (s *facadeRegistrySuite) TestRegister(c *gc.C) {
 	common.SanitizeFacades(s)
 	var v interface{}
 	common.RegisterFacade("myfacade", 0, testFacade, reflect.TypeOf(&v).Elem())
 	f, err := common.Facades.GetFactory("myfacade", 0)
 	c.Assert(err, jc.ErrorIsNil)
-	val, err := f(nil, nil, nil, "")
+	val, err := f(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(val, gc.Equals, "myobject")
-}
-
-func (*facadeRegistrySuite) TestGetFactoryUnknown(c *gc.C) {
-	r := &common.FacadeRegistry{}
-	f, err := r.GetFactory("name", 0)
-	c.Check(err, jc.Satisfies, errors.IsNotFound)
-	c.Check(err, gc.ErrorMatches, `name\(0\) not found`)
-	c.Check(f, gc.IsNil)
 }
 
 func (s *facadeRegistrySuite) TestRegisterForFeature(c *gc.C) {
@@ -60,18 +47,9 @@ func (s *facadeRegistrySuite) TestRegisterForFeature(c *gc.C) {
 
 	f, err = common.Facades.GetFactory("myfacade", 0)
 	c.Assert(err, jc.ErrorIsNil)
-	val, err := f(nil, nil, nil, "")
+	val, err := f(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(val, gc.Equals, "myobject")
-}
-
-func (*facadeRegistrySuite) TestGetFactoryUnknownVersion(c *gc.C) {
-	r := &common.FacadeRegistry{}
-	c.Assert(r.Register("name", 0, validIdFactory, intPtrType, ""), gc.IsNil)
-	f, err := r.GetFactory("name", 1)
-	c.Check(err, jc.Satisfies, errors.IsNotFound)
-	c.Check(err, gc.ErrorMatches, `name\(1\) not found`)
-	c.Check(f, gc.IsNil)
 }
 
 func (s *facadeRegistrySuite) TestRegisterFacadePanicsOnDoubleRegistry(c *gc.C) {
@@ -81,36 +59,6 @@ func (s *facadeRegistrySuite) TestRegisterFacadePanicsOnDoubleRegistry(c *gc.C) 
 	}
 	doRegister()
 	c.Assert(doRegister, gc.PanicMatches, `object "myfacade\(0\)" already registered`)
-}
-
-func checkValidateNewFacadeFailsWith(c *gc.C, obj interface{}, errMsg string) {
-	err := common.ValidateNewFacade(reflect.ValueOf(obj))
-	c.Check(err, gc.NotNil)
-	c.Check(err, gc.ErrorMatches, errMsg)
-}
-
-func noArgs() {
-}
-
-func badCountIn(a string) (*int, error) {
-	return nil, nil
-}
-
-func badCountOut(a, b, c string) error {
-	return nil
-}
-
-func wrongIn(a, b, c string) (*int, error) {
-	return nil, nil
-}
-
-func wrongOut(*state.State, *common.Resources, common.Authorizer) (error, *int) {
-	return nil, nil
-}
-
-func validFactory(*state.State, *common.Resources, common.Authorizer) (*int, error) {
-	var i = 100
-	return &i, nil
 }
 
 func (*facadeRegistrySuite) TestValidateNewFacade(c *gc.C) {
@@ -125,9 +73,9 @@ func (*facadeRegistrySuite) TestValidateNewFacade(c *gc.C) {
 	checkValidateNewFacadeFailsWith(c, badCountOut,
 		`function ".*badCountOut" does not take 3 parameters and return 2`)
 	checkValidateNewFacadeFailsWith(c, wrongIn,
-		`function ".*wrongIn" does not have the signature func \(\*state.State, \*common.Resources, common.Authorizer\) \(\*Type, error\)`)
+		`function ".*wrongIn" does not have the signature func \(\*state.State, facade.Resources, facade.Authorizer\) \(\*Type, error\)`)
 	checkValidateNewFacadeFailsWith(c, wrongOut,
-		`function ".*wrongOut" does not have the signature func \(\*state.State, \*common.Resources, common.Authorizer\) \(\*Type, error\)`)
+		`function ".*wrongOut" does not have the signature func \(\*state.State, facade.Resources, facade.Authorizer\) \(\*Type, error\)`)
 	err := common.ValidateNewFacade(reflect.ValueOf(validFactory))
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -140,7 +88,9 @@ func (*facadeRegistrySuite) TestWrapNewFacadeFailure(c *gc.C) {
 func (*facadeRegistrySuite) TestWrapNewFacadeHandlesId(c *gc.C) {
 	wrapped, _, err := common.WrapNewFacade(validFactory)
 	c.Assert(err, jc.ErrorIsNil)
-	val, err := wrapped(nil, nil, nil, "badId")
+	val, err := wrapped(facadetest.Context{
+		ID_: "badId",
+	})
 	c.Check(err, gc.ErrorMatches, "id not found")
 	c.Check(val, gc.Equals, nil)
 }
@@ -148,30 +98,29 @@ func (*facadeRegistrySuite) TestWrapNewFacadeHandlesId(c *gc.C) {
 func (*facadeRegistrySuite) TestWrapNewFacadeCallsFunc(c *gc.C) {
 	wrapped, _, err := common.WrapNewFacade(validFactory)
 	c.Assert(err, jc.ErrorIsNil)
-	val, err := wrapped(nil, nil, nil, "")
+	val, err := wrapped(facadetest.Context{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(*(val.(*int)), gc.Equals, 100)
-}
-
-type myResult struct {
-	st        *state.State
-	resources *common.Resources
-	auth      common.Authorizer
 }
 
 func (*facadeRegistrySuite) TestWrapNewFacadeCallsWithRightParams(c *gc.C) {
 	authorizer := apiservertesting.FakeAuthorizer{}
 	resources := common.NewResources()
 	testFunc := func(
-		st *state.State, resources *common.Resources,
-		authorizer common.Authorizer,
+		st *state.State,
+		resources facade.Resources,
+		authorizer facade.Authorizer,
 	) (*myResult, error) {
 		return &myResult{st, resources, authorizer}, nil
 	}
 	wrapped, facadeType, err := common.WrapNewFacade(testFunc)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(facadeType, gc.Equals, reflect.TypeOf((*myResult)(nil)))
-	val, err := wrapped(nil, resources, authorizer, "")
+
+	val, err := wrapped(facadetest.Context{
+		Resources_: resources,
+		Auth_:      authorizer,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	asResult := val.(*myResult)
 	c.Check(asResult.st, gc.IsNil)
@@ -184,7 +133,7 @@ func (s *facadeRegistrySuite) TestRegisterStandardFacade(c *gc.C) {
 	common.RegisterStandardFacade("testing", 0, validFactory)
 	wrapped, err := common.Facades.GetFactory("testing", 0)
 	c.Assert(err, jc.ErrorIsNil)
-	val, err := wrapped(nil, nil, nil, "")
+	val, err := wrapped(facadetest.Context{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(*(val.(*int)), gc.Equals, 100)
 }
@@ -218,151 +167,42 @@ func (*facadeRegistrySuite) TestDiscardedAPIMethods(c *gc.C) {
 	}
 }
 
-func validIdFactory(*state.State, *common.Resources, common.Authorizer, string) (interface{}, error) {
+func testFacade(facade.Context) (facade.Facade, error) {
+	return "myobject", nil
+}
+
+type myResult struct {
+	st        *state.State
+	resources facade.Resources
+	auth      facade.Authorizer
+}
+
+func checkValidateNewFacadeFailsWith(c *gc.C, obj interface{}, errMsg string) {
+	err := common.ValidateNewFacade(reflect.ValueOf(obj))
+	c.Check(err, gc.NotNil)
+	c.Check(err, gc.ErrorMatches, errMsg)
+}
+
+func noArgs() {
+}
+
+func badCountIn(a string) (*int, error) {
+	return nil, nil
+}
+
+func badCountOut(a, b, c string) error {
+	return nil
+}
+
+func wrongIn(a, b, c string) (*int, error) {
+	return nil, nil
+}
+
+func wrongOut(*state.State, facade.Resources, facade.Authorizer) (error, *int) {
+	return nil, nil
+}
+
+func validFactory(*state.State, facade.Resources, facade.Authorizer) (*int, error) {
 	var i = 100
 	return &i, nil
-}
-
-var intPtr = new(int)
-var intPtrType = reflect.TypeOf(&intPtr).Elem()
-
-func (*facadeRegistrySuite) TestDescriptionFromVersions(c *gc.C) {
-	facades := common.Versions{0: common.NilFacadeRecord}
-	c.Check(common.DescriptionFromVersions("name", facades),
-		gc.DeepEquals,
-		common.FacadeDescription{
-			Name:     "name",
-			Versions: []int{0},
-		})
-	facades[2] = common.NilFacadeRecord
-	c.Check(common.DescriptionFromVersions("name", facades),
-		gc.DeepEquals,
-		common.FacadeDescription{
-			Name:     "name",
-			Versions: []int{0, 2},
-		})
-}
-
-func (*facadeRegistrySuite) TestDescriptionFromVersionsAreSorted(c *gc.C) {
-	facades := common.Versions{
-		10: common.NilFacadeRecord,
-		5:  common.NilFacadeRecord,
-		0:  common.NilFacadeRecord,
-		18: common.NilFacadeRecord,
-		6:  common.NilFacadeRecord,
-		4:  common.NilFacadeRecord,
-	}
-	c.Check(common.DescriptionFromVersions("name", facades),
-		gc.DeepEquals,
-		common.FacadeDescription{
-			Name:     "name",
-			Versions: []int{0, 4, 5, 6, 10, 18},
-		})
-}
-
-func (*facadeRegistrySuite) TestRegisterAndList(c *gc.C) {
-	r := &common.FacadeRegistry{}
-	c.Assert(r.Register("name", 0, validIdFactory, intPtrType, ""), gc.IsNil)
-	c.Check(r.List(), gc.DeepEquals, []common.FacadeDescription{
-		{Name: "name", Versions: []int{0}},
-	})
-}
-
-func (*facadeRegistrySuite) TestRegisterAndListMultiple(c *gc.C) {
-	r := &common.FacadeRegistry{}
-	c.Assert(r.Register("other", 0, validIdFactory, intPtrType, ""), gc.IsNil)
-	c.Assert(r.Register("name", 0, validIdFactory, intPtrType, ""), gc.IsNil)
-	c.Assert(r.Register("third", 2, validIdFactory, intPtrType, ""), gc.IsNil)
-	c.Assert(r.Register("third", 3, validIdFactory, intPtrType, ""), gc.IsNil)
-	c.Check(r.List(), gc.DeepEquals, []common.FacadeDescription{
-		{Name: "name", Versions: []int{0}},
-		{Name: "other", Versions: []int{0}},
-		{Name: "third", Versions: []int{2, 3}},
-	})
-}
-
-func (s *facadeRegistrySuite) TestRegisterAndListMultipleWithFeatures(c *gc.C) {
-	r := &common.FacadeRegistry{}
-	c.Assert(r.Register("other", 0, validIdFactory, intPtrType, "special"), gc.IsNil)
-	c.Assert(r.Register("name", 0, validIdFactory, intPtrType, ""), gc.IsNil)
-	c.Assert(r.Register("name", 1, validIdFactory, intPtrType, "special"), gc.IsNil)
-	c.Assert(r.Register("third", 2, validIdFactory, intPtrType, ""), gc.IsNil)
-	c.Assert(r.Register("third", 3, validIdFactory, intPtrType, "magic"), gc.IsNil)
-	s.SetFeatureFlags("magic")
-	c.Check(r.List(), gc.DeepEquals, []common.FacadeDescription{
-		{Name: "name", Versions: []int{0}},
-		{Name: "third", Versions: []int{2, 3}},
-	})
-}
-
-func (*facadeRegistrySuite) TestRegisterAlreadyPresent(c *gc.C) {
-	r := &common.FacadeRegistry{}
-	err := r.Register("name", 0, validIdFactory, intPtrType, "")
-	c.Assert(err, jc.ErrorIsNil)
-	secondIdFactory := func(*state.State, *common.Resources, common.Authorizer, string) (interface{}, error) {
-		var i = 200
-		return &i, nil
-	}
-	err = r.Register("name", 0, secondIdFactory, intPtrType, "")
-	c.Check(err, gc.ErrorMatches, `object "name\(0\)" already registered`)
-	f, err := r.GetFactory("name", 0)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(f, gc.NotNil)
-	val, err := f(nil, nil, nil, "")
-	c.Assert(err, jc.ErrorIsNil)
-	asIntPtr := val.(*int)
-	c.Check(*asIntPtr, gc.Equals, 100)
-}
-
-func (*facadeRegistrySuite) TestGetFactory(c *gc.C) {
-	r := &common.FacadeRegistry{}
-	c.Assert(r.Register("name", 0, validIdFactory, intPtrType, ""), gc.IsNil)
-	f, err := r.GetFactory("name", 0)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(f, gc.NotNil)
-	res, err := f(nil, nil, nil, "")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(res, gc.NotNil)
-	asIntPtr := res.(*int)
-	c.Check(*asIntPtr, gc.Equals, 100)
-}
-
-func (*facadeRegistrySuite) TestGetType(c *gc.C) {
-	r := &common.FacadeRegistry{}
-	c.Assert(r.Register("name", 0, validIdFactory, intPtrType, ""), gc.IsNil)
-	typ, err := r.GetType("name", 0)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(typ, gc.Equals, intPtrType)
-}
-
-func (*facadeRegistrySuite) TestDiscardHandlesNotPresent(c *gc.C) {
-	r := &common.FacadeRegistry{}
-	r.Discard("name", 1)
-}
-
-func (*facadeRegistrySuite) TestDiscardRemovesEntry(c *gc.C) {
-	r := &common.FacadeRegistry{}
-	c.Assert(r.Register("name", 0, validIdFactory, intPtrType, ""), gc.IsNil)
-	_, err := r.GetFactory("name", 0)
-	c.Assert(err, jc.ErrorIsNil)
-	r.Discard("name", 0)
-	f, err := r.GetFactory("name", 0)
-	c.Check(err, jc.Satisfies, errors.IsNotFound)
-	c.Check(err, gc.ErrorMatches, `name\(0\) not found`)
-	c.Check(f, gc.IsNil)
-	c.Check(r.List(), gc.DeepEquals, []common.FacadeDescription{})
-}
-
-func (*facadeRegistrySuite) TestDiscardLeavesOtherVersions(c *gc.C) {
-	r := &common.FacadeRegistry{}
-	c.Assert(r.Register("name", 0, validIdFactory, intPtrType, ""), gc.IsNil)
-	c.Assert(r.Register("name", 1, validIdFactory, intPtrType, ""), gc.IsNil)
-	r.Discard("name", 0)
-	_, err := r.GetFactory("name", 0)
-	c.Check(err, jc.Satisfies, errors.IsNotFound)
-	_, err = r.GetFactory("name", 1)
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(r.List(), gc.DeepEquals, []common.FacadeDescription{
-		{Name: "name", Versions: []int{1}},
-	})
 }

--- a/apiserver/common/unitswatcher.go
+++ b/apiserver/common/unitswatcher.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
@@ -16,14 +17,14 @@ import (
 // various facades.
 type UnitsWatcher struct {
 	st          state.EntityFinder
-	resources   *Resources
+	resources   facade.Resources
 	getCanWatch GetAuthFunc
 }
 
 // NewUnitsWatcher returns a new UnitsWatcher. The GetAuthFunc will be
 // used on each invocation of WatchUnits to determine current
 // permissions.
-func NewUnitsWatcher(st state.EntityFinder, resources *Resources, getCanWatch GetAuthFunc) *UnitsWatcher {
+func NewUnitsWatcher(st state.EntityFinder, resources facade.Resources, getCanWatch GetAuthFunc) *UnitsWatcher {
 	return &UnitsWatcher{
 		st:          st,
 		resources:   resources,

--- a/apiserver/common/watch.go
+++ b/apiserver/common/watch.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/juju/names.v2"
 	"launchpad.net/tomb"
 
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
@@ -20,14 +21,14 @@ import (
 // various facades.
 type AgentEntityWatcher struct {
 	st          state.EntityFinder
-	resources   *Resources
+	resources   facade.Resources
 	getCanWatch GetAuthFunc
 }
 
 // NewAgentEntityWatcher returns a new AgentEntityWatcher. The
 // GetAuthFunc will be used on each invocation of Watch to determine
 // current permissions.
-func NewAgentEntityWatcher(st state.EntityFinder, resources *Resources, getCanWatch GetAuthFunc) *AgentEntityWatcher {
+func NewAgentEntityWatcher(st state.EntityFinder, resources facade.Resources, getCanWatch GetAuthFunc) *AgentEntityWatcher {
 	return &AgentEntityWatcher{
 		st:          st,
 		resources:   resources,

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/state"
@@ -42,9 +43,9 @@ type Controller interface {
 // the concrete implementation of the api end point.
 type ControllerAPI struct {
 	state      *state.State
-	authorizer common.Authorizer
+	authorizer facade.Authorizer
 	apiUser    names.UserTag
-	resources  *common.Resources
+	resources  facade.Resources
 }
 
 var _ Controller = (*ControllerAPI)(nil)
@@ -53,8 +54,8 @@ var _ Controller = (*ControllerAPI)(nil)
 // environments.
 func NewControllerAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*ControllerAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, errors.Trace(common.ErrPerm)

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/controller"
+	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -221,7 +222,12 @@ func (s *controllerSuite) TestWatchAllModels(c *gc.C) {
 	watcherId, err := s.controller.WatchAllModels()
 	c.Assert(err, jc.ErrorIsNil)
 
-	watcherAPI_, err := apiserver.NewAllWatcher(s.State, s.resources, s.authorizer, watcherId.AllWatcherId)
+	watcherAPI_, err := apiserver.NewAllWatcher(facadetest.Context{
+		State_:     s.State,
+		Resources_: s.resources,
+		Auth_:      s.authorizer,
+		ID_:        watcherId.AllWatcherId,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	watcherAPI := watcherAPI_.(*apiserver.SrvAllWatcher)
 	defer func() {

--- a/apiserver/deployer/deployer.go
+++ b/apiserver/deployer/deployer.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
@@ -27,15 +28,15 @@ type DeployerAPI struct {
 	*common.UnitsWatcher
 
 	st         *state.State
-	resources  *common.Resources
-	authorizer common.Authorizer
+	resources  facade.Resources
+	authorizer facade.Authorizer
 }
 
 // NewDeployerAPI creates a new server-side DeployerAPI facade.
 func NewDeployerAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*DeployerAPI, error) {
 	if !authorizer.AuthMachineAgent() {
 		return nil, common.ErrPerm

--- a/apiserver/discoverspaces/discoverspaces.go
+++ b/apiserver/discoverspaces/discoverspaces.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/networkingcommon"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
@@ -18,16 +19,16 @@ func init() {
 // DiscoverSpacesAPI implements the API used by the discoverspaces worker.
 type DiscoverSpacesAPI struct {
 	st         networkingcommon.NetworkBacking
-	resources  *common.Resources
-	authorizer common.Authorizer
+	resources  facade.Resources
+	authorizer facade.Authorizer
 }
 
 // NewDiscoverSpacesAPI creates a new instance of the DiscoverSpaces API.
-func NewDiscoverSpacesAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*DiscoverSpacesAPI, error) {
+func NewDiscoverSpacesAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*DiscoverSpacesAPI, error) {
 	return NewDiscoverSpacesAPIWithBacking(networkingcommon.NewStateShim(st), resources, authorizer)
 }
 
-func NewDiscoverSpacesAPIWithBacking(st networkingcommon.NetworkBacking, resources *common.Resources, authorizer common.Authorizer) (*DiscoverSpacesAPI, error) {
+func NewDiscoverSpacesAPIWithBacking(st networkingcommon.NetworkBacking, resources facade.Resources, authorizer facade.Authorizer) (*DiscoverSpacesAPI, error) {
 	if !authorizer.AuthModelManager() {
 		return nil, common.ErrPerm
 	}

--- a/apiserver/diskmanager/diskmanager.go
+++ b/apiserver/diskmanager/diskmanager.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
@@ -19,7 +20,7 @@ func init() {
 // DiskManagerAPI provides access to the DiskManager API facade.
 type DiskManagerAPI struct {
 	st          stateInterface
-	authorizer  common.Authorizer
+	authorizer  facade.Authorizer
 	getAuthFunc common.GetAuthFunc
 }
 
@@ -30,8 +31,8 @@ var getState = func(st *state.State) stateInterface {
 // NewDiskManagerAPI creates a new server-side DiskManager API facade.
 func NewDiskManagerAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*DiskManagerAPI, error) {
 
 	if !authorizer.AuthMachineAgent() {

--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -1,0 +1,43 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package facadetest
+
+import (
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/state"
+)
+
+// Context implements facade.Context in the simplest possible way.
+type Context struct {
+	Abort_     <-chan struct{}
+	Auth_      facade.Authorizer
+	Resources_ facade.Resources
+	State_     *state.State
+	ID_        string
+}
+
+// Abort is part of the facade.Context interface.
+func (context Context) Abort() <-chan struct{} {
+	return context.Abort_
+}
+
+// Auth is part of the facade.Context interface.
+func (context Context) Auth() facade.Authorizer {
+	return context.Auth_
+}
+
+// Resources is part of the facade.Context interface.
+func (context Context) Resources() facade.Resources {
+	return context.Resources_
+}
+
+// State is part of the facade.Context interface.
+func (context Context) State() *state.State {
+	return context.State_
+}
+
+// ID is part of the facade.Context interface.
+func (context Context) ID() string {
+	return context.ID_
+}

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -1,0 +1,114 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package facade
+
+import (
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/state"
+)
+
+// Facade could be anything; it will be interpreted by the apiserver
+// machinery such that certain exported methods will be made available
+// as facade methods to connected clients.
+type Facade interface{}
+
+// Factory is a callback used to create a Facade.
+type Factory func(Context) (Facade, error)
+
+// Context exposes useful capabilities to a Facade.
+type Context interface {
+
+	// Abort will be closed with the client connection. Any long-
+	// running methods should pay attention to Abort, and terminate
+	// with a sensible (non-nil) error when requested.
+	Abort() <-chan struct{}
+
+	// Auth represents information about the connected client. You
+	// should always be checking individual requests against Auth:
+	// both state changes *and* data retrieval should be blocked
+	// with common.ErrPerm for any targets for which the client is
+	// not *known* to have a responsibility or requirement.
+	Auth() Authorizer
+
+	// Resources exposes per-connection capabilities. By adding a
+	// resource, you make it accessible by (returned) id to all
+	// other facades used by this connection. It's mostly used to
+	// pass watcher ids over to watcher-specific facades, but that
+	// seems to be an antipattern: it breaks the separate-facades-
+	// by-role advice, and makes it inconvenient to track a given
+	// worker's watcher activity alongside its other communications.
+	//
+	// It's also used to hold some config strings used by various
+	// consumers, because it's convenient; and the Pinger that
+	// reports client presence in state, because every Resource gets
+	// Stop()ped on conn close. Not all of these uses are
+	// necessarily a great idea.
+	Resources() Resources
+
+	// State returns, /sigh, a *State. As yet, there is no way
+	// around this; in the not-too-distant future, we hope, its
+	// capabilities will migrate towards access via Resources.
+	State() *state.State
+
+	// ID returns a string that should almost always be "", unless
+	// this is a watcher facade, in which case it exists in lieu of
+	// actual arguments in the Next() call, and is used as a key
+	// into Resources to get the watcher in play. This is not really
+	// a good idea; see Resources.
+	ID() string
+}
+
+// Authorizer represents the authenticated entity using the API server.
+type Authorizer interface {
+
+	// GetAuthTag returns the entity's tag.
+	GetAuthTag() names.Tag
+
+	// AuthModelManager returns whether the authenticated entity is
+	// a machine running the environment manager job. Can't be
+	// removed from this interface without introducing a dependency
+	// on something else to look up that property: it's not inherent
+	// in the result of GetAuthTag, as the other methods all are.
+	AuthModelManager() bool
+
+	// AuthMachineAgent returns true if the entity is a machine
+	// agent. Doesn't need to be on this interface, should be a
+	// utility func if anything.
+	AuthMachineAgent() bool
+
+	// AuthUnitAgent returns true if the entity is a unit agent.
+	// Doesn't need to be on this interface, should be a utility
+	// func if anything.
+	AuthUnitAgent() bool
+
+	// AuthOwner returns true if tag == .GetAuthTag(). Doesn't need
+	// to be on this interface, should be a utility fun if anything.
+	AuthOwner(tag names.Tag) bool
+
+	// AuthClient returns true if the entity is an external user.
+	// Doesn't need to be on this interface, should be a utility
+	// func if anything.
+	AuthClient() bool
+}
+
+// Resources allows you to store and retrieve Resource implementations.
+//
+// The lack of error returns are in deference to the existing
+// implementation, not because they're a good idea.
+type Resources interface {
+	Register(Resource) string
+	Get(string) Resource
+	Stop(string) error
+}
+
+// Resource should almost certainly be worker.Worker: the current
+// implementation renders the apiserver vulnerable to deadlock when
+// shutting down. (See common.Resources.StopAll -- *that* should be a
+// Kill() and a Wait(), so that connection cleanup can kill the
+// resources early, along with everything else, and then just wait for
+// all those things to finish.)
+type Resource interface {
+	Stop() error
+}

--- a/apiserver/facade/package_test.go
+++ b/apiserver/facade/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package facade_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/facade/registry.go
+++ b/apiserver/facade/registry.go
@@ -1,0 +1,150 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package facade
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/featureflag"
+)
+
+// record represents an entry in a Registry.
+type record struct {
+	factory    Factory
+	facadeType reflect.Type
+	// If the feature is not the empty string, then this facade
+	// is only returned when that feature flag is set.
+	//
+	// It is not a good thing that we depend on yet another flavour
+	// of global in the implementation of the Registry that itself
+	// only meaningfully exists as a global.
+	feature string
+}
+
+// versions is our internal structure for tracking specific versions of a
+// single facade. We use a map to be able to quickly lookup a version.
+type versions map[int]record
+
+// Registry describes Facades the facades exposed by some API server.
+//
+// It's only actually used as a global -- `apiserver/common.Facades` --
+// but if we were smarter we could just create a Registry directly and
+// pass it into the apiserver.
+type Registry struct {
+	facades map[string]versions
+}
+
+// Register adds a single named facade at a given version to the registry.
+// Factory will be called when someone wants to instantiate an object of
+// this facade, and facadeType defines the concrete type that the returned object will be.
+// The Type information is used to define what methods will be exported in the
+// API, and it must exactly match the actual object returned by the factory.
+func (f *Registry) Register(name string, version int, factory Factory, facadeType reflect.Type, feature string) error {
+	if f.facades == nil {
+		f.facades = make(map[string]versions, 1)
+	}
+	record := record{
+		factory:    factory,
+		facadeType: facadeType,
+		feature:    feature,
+	}
+	if vers, ok := f.facades[name]; ok {
+		if _, ok := vers[version]; ok {
+			fullname := fmt.Sprintf("%s(%d)", name, version)
+			return fmt.Errorf("object %q already registered", fullname)
+		}
+		vers[version] = record
+	} else {
+		f.facades[name] = versions{version: record}
+	}
+	return nil
+}
+
+// lookup translates a facade name and version into a record.
+func (f *Registry) lookup(name string, version int) (record, error) {
+	if versions, ok := f.facades[name]; ok {
+		if record, ok := versions[version]; ok {
+			if featureflag.Enabled(record.feature) {
+				return record, nil
+			}
+		}
+	}
+	return record{}, errors.NotFoundf("%s(%d)", name, version)
+}
+
+// GetFactory returns just the Factory for a given Facade name and version.
+// See also GetType for getting the type information instead of the creation factory.
+func (f *Registry) GetFactory(name string, version int) (Factory, error) {
+	record, err := f.lookup(name, version)
+	if err != nil {
+		return nil, err
+	}
+	return record.factory, nil
+}
+
+// GetType returns the type information for a given Facade name and version.
+// This can be used for introspection purposes (to determine what methods are
+// available, etc).
+func (f *Registry) GetType(name string, version int) (reflect.Type, error) {
+	record, err := f.lookup(name, version)
+	if err != nil {
+		return nil, err
+	}
+	return record.facadeType, nil
+}
+
+// Description describes the name and what versions of a facade have been
+// registered.
+type Description struct {
+	Name     string
+	Versions []int
+}
+
+// descriptionFromVersions aggregates the information in a versions map into a
+// more friendly form for List().
+func descriptionFromVersions(name string, vers versions) Description {
+	intVersions := make([]int, 0, len(vers))
+	for version, record := range vers {
+		if featureflag.Enabled(record.feature) {
+			intVersions = append(intVersions, version)
+		}
+	}
+	sort.Ints(intVersions)
+	return Description{
+		Name:     name,
+		Versions: intVersions,
+	}
+}
+
+// List returns a slice describing each of the registered Facades.
+func (f *Registry) List() []Description {
+	names := make([]string, 0, len(f.facades))
+	for name := range f.facades {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	descriptions := make([]Description, 0, len(f.facades))
+	for _, name := range names {
+		facades := f.facades[name]
+		description := descriptionFromVersions(name, facades)
+		if len(description.Versions) > 0 {
+			descriptions = append(descriptions, description)
+		}
+	}
+	return descriptions
+}
+
+// Discard gets rid of a registration that has already been done. Calling
+// discard on an entry that is not present is not considered an error.
+func (f *Registry) Discard(name string, version int) {
+	if versions, ok := f.facades[name]; ok {
+		delete(versions, version)
+		if len(versions) == 0 {
+			delete(f.facades, name)
+		}
+	}
+}

--- a/apiserver/facade/registry_test.go
+++ b/apiserver/facade/registry_test.go
@@ -1,0 +1,198 @@
+// Copyright 2014-2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package facade_test
+
+import (
+	"reflect"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/testing"
+)
+
+type RegistrySuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&RegistrySuite{})
+
+func (s *RegistrySuite) TestRegister(c *gc.C) {
+	registry := &facade.Registry{}
+	var v interface{}
+	facadeType := reflect.TypeOf(&v).Elem()
+	err := registry.Register("myfacade", 123, testFacade, facadeType, "")
+	c.Assert(err, jc.ErrorIsNil)
+
+	factory, err := registry.GetFactory("myfacade", 123)
+	c.Assert(err, jc.ErrorIsNil)
+	val, err := factory(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(val, gc.Equals, "myobject")
+}
+
+func (*RegistrySuite) TestGetFactoryUnknown(c *gc.C) {
+	registry := &facade.Registry{}
+	factory, err := registry.GetFactory("name", 0)
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+	c.Check(err, gc.ErrorMatches, `name\(0\) not found`)
+	c.Check(factory, gc.IsNil)
+}
+
+func (*RegistrySuite) TestGetFactoryUnknownVersion(c *gc.C) {
+	registry := &facade.Registry{}
+	assertRegister(c, registry, "name", 0)
+
+	factory, err := registry.GetFactory("name", 1)
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+	c.Check(err, gc.ErrorMatches, `name\(1\) not found`)
+	c.Check(factory, gc.IsNil)
+}
+
+func (*RegistrySuite) TestRegisterAndList(c *gc.C) {
+	registry := &facade.Registry{}
+	assertRegister(c, registry, "name", 0)
+
+	c.Check(registry.List(), jc.DeepEquals, []facade.Description{
+		{Name: "name", Versions: []int{0}},
+	})
+}
+
+func (*RegistrySuite) TestRegisterAndListSorted(c *gc.C) {
+	registry := &facade.Registry{}
+	assertRegister(c, registry, "name", 10)
+	assertRegister(c, registry, "name", 0)
+	assertRegister(c, registry, "name", 101)
+
+	c.Check(registry.List(), jc.DeepEquals, []facade.Description{
+		{Name: "name", Versions: []int{0, 10, 101}},
+	})
+}
+
+func (*RegistrySuite) TestRegisterAndListMultiple(c *gc.C) {
+	registry := &facade.Registry{}
+	assertRegister(c, registry, "other", 0)
+	assertRegister(c, registry, "name", 0)
+	assertRegister(c, registry, "third", 2)
+	assertRegister(c, registry, "third", 3)
+
+	c.Check(registry.List(), jc.DeepEquals, []facade.Description{
+		{Name: "name", Versions: []int{0}},
+		{Name: "other", Versions: []int{0}},
+		{Name: "third", Versions: []int{2, 3}},
+	})
+}
+
+func (s *RegistrySuite) TestRegisterAndListMultipleWithFeatures(c *gc.C) {
+	registry := &facade.Registry{}
+	assertRegisterFlag(c, registry, "other", 0, "special")
+	assertRegister(c, registry, "name", 0)
+	assertRegisterFlag(c, registry, "name", 1, "special")
+	assertRegister(c, registry, "third", 2)
+	assertRegisterFlag(c, registry, "third", 3, "magic")
+
+	s.SetFeatureFlags("magic")
+	c.Check(registry.List(), jc.DeepEquals, []facade.Description{
+		{Name: "name", Versions: []int{0}},
+		{Name: "third", Versions: []int{2, 3}},
+	})
+}
+
+func (*RegistrySuite) TestRegisterAlreadyPresent(c *gc.C) {
+	registry := &facade.Registry{}
+	assertRegister(c, registry, "name", 0)
+	secondIdFactory := func(context facade.Context) (facade.Facade, error) {
+		var i = 200
+		return &i, nil
+	}
+	err := registry.Register("name", 0, secondIdFactory, intPtrType, "")
+	c.Assert(err, gc.ErrorMatches, `object "name\(0\)" already registered`)
+
+	factory, err := registry.GetFactory("name", 0)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(factory, gc.NotNil)
+	val, err := factory(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	asIntPtr := val.(*int)
+	c.Check(*asIntPtr, gc.Equals, 100)
+}
+
+func (*RegistrySuite) TestGetFactory(c *gc.C) {
+	registry := &facade.Registry{}
+	assertRegister(c, registry, "name", 0)
+
+	factory, err := registry.GetFactory("name", 0)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(factory, gc.NotNil)
+	res, err := factory(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, gc.NotNil)
+	asIntPtr := res.(*int)
+	c.Check(*asIntPtr, gc.Equals, 100)
+}
+
+func (*RegistrySuite) TestGetType(c *gc.C) {
+	registry := &facade.Registry{}
+	assertRegister(c, registry, "name", 0)
+
+	typ, err := registry.GetType("name", 0)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(typ, gc.Equals, intPtrType)
+}
+
+func (*RegistrySuite) TestDiscardHandlesNotPresent(c *gc.C) {
+	registry := &facade.Registry{}
+	registry.Discard("name", 1)
+}
+
+func (*RegistrySuite) TestDiscardRemovesEntry(c *gc.C) {
+	registry := &facade.Registry{}
+	assertRegister(c, registry, "name", 0)
+	_, err := registry.GetFactory("name", 0)
+	c.Assert(err, jc.ErrorIsNil)
+
+	registry.Discard("name", 0)
+	factory, err := registry.GetFactory("name", 0)
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+	c.Check(err, gc.ErrorMatches, `name\(0\) not found`)
+	c.Check(factory, gc.IsNil)
+	c.Check(registry.List(), jc.DeepEquals, []facade.Description{})
+}
+
+func (*RegistrySuite) TestDiscardLeavesOtherVersions(c *gc.C) {
+	registry := &facade.Registry{}
+	assertRegister(c, registry, "name", 0)
+	assertRegister(c, registry, "name", 1)
+
+	registry.Discard("name", 0)
+	_, err := registry.GetFactory("name", 1)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(registry.List(), jc.DeepEquals, []facade.Description{
+		{Name: "name", Versions: []int{1}},
+	})
+}
+
+func testFacade(facade.Context) (facade.Facade, error) {
+	return "myobject", nil
+}
+
+func validIdFactory(facade.Context) (facade.Facade, error) {
+	var i = 100
+	return &i, nil
+}
+
+var intPtr = new(int)
+var intPtrType = reflect.TypeOf(&intPtr).Elem()
+
+func assertRegister(c *gc.C, registry *facade.Registry, name string, version int) {
+	assertRegisterFlag(c, registry, name, version, "")
+}
+
+func assertRegisterFlag(c *gc.C, registry *facade.Registry, name string, version int, flag string) {
+
+	err := registry.Register(name, version, validIdFactory, intPtrType, flag)
+	c.Assert(err, gc.IsNil)
+}

--- a/apiserver/firewaller/firewaller.go
+++ b/apiserver/firewaller/firewaller.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -29,8 +30,8 @@ type FirewallerAPI struct {
 	*common.InstanceIdGetter
 
 	st            *state.State
-	resources     *common.Resources
-	authorizer    common.Authorizer
+	resources     facade.Resources
+	authorizer    facade.Authorizer
 	accessUnit    common.GetAuthFunc
 	accessService common.GetAuthFunc
 	accessMachine common.GetAuthFunc
@@ -40,8 +41,8 @@ type FirewallerAPI struct {
 // NewFirewallerAPI creates a new server-side FirewallerAPI facade.
 func NewFirewallerAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*FirewallerAPI, error) {
 	if !authorizer.AuthModelManager() {
 		// Firewaller must run as environment manager.

--- a/apiserver/firewaller/firewaller_base_test.go
+++ b/apiserver/firewaller/firewaller_base_test.go
@@ -9,6 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/instance"
@@ -71,7 +72,7 @@ func (s *firewallerBaseSuite) setUpTest(c *gc.C) {
 
 func (s *firewallerBaseSuite) testFirewallerFailsWithNonEnvironManagerUser(
 	c *gc.C,
-	factory func(_ *state.State, _ *common.Resources, _ common.Authorizer) error,
+	factory func(_ *state.State, _ facade.Resources, _ facade.Authorizer) error,
 ) {
 	anAuthorizer := s.authorizer
 	anAuthorizer.EnvironManager = false
@@ -211,7 +212,7 @@ const (
 
 func (s *firewallerBaseSuite) testWatch(
 	c *gc.C,
-	facade interface {
+	watcher interface {
 		Watch(args params.Entities) (params.NotifyWatchResults, error)
 	},
 	allowUnits bool,
@@ -223,7 +224,7 @@ func (s *firewallerBaseSuite) testWatch(
 		{Tag: s.service.Tag().String()},
 		{Tag: s.units[0].Tag().String()},
 	}})
-	result, err := facade.Watch(args)
+	result, err := watcher.Watch(args)
 	c.Assert(err, jc.ErrorIsNil)
 	if allowUnits {
 		c.Assert(result, jc.DeepEquals, params.NotifyWatchResults{
@@ -264,7 +265,7 @@ func (s *firewallerBaseSuite) testWatch(
 	c.Assert(result.Results[1].NotifyWatcherId, gc.Equals, "1")
 	watcher1 := s.resources.Get("1")
 	defer statetesting.AssertStop(c, watcher1)
-	var watcher2 common.Resource
+	var watcher2 facade.Resource
 	if allowUnits {
 		c.Assert(result.Results[2].NotifyWatcherId, gc.Equals, "2")
 		watcher2 = s.resources.Get("2")

--- a/apiserver/firewaller/firewaller_test.go
+++ b/apiserver/firewaller/firewaller_test.go
@@ -10,8 +10,8 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/apiserver/common"
 	commontesting "github.com/juju/juju/apiserver/common/testing"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/firewaller"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
@@ -46,7 +46,7 @@ func (s *firewallerSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *firewallerSuite) TestFirewallerFailsWithNonEnvironManagerUser(c *gc.C) {
-	constructor := func(st *state.State, res *common.Resources, auth common.Authorizer) error {
+	constructor := func(st *state.State, res facade.Resources, auth facade.Authorizer) error {
 		_, err := firewaller.NewFirewallerAPI(st, res, auth)
 		return err
 	}

--- a/apiserver/highavailability/highavailability.go
+++ b/apiserver/highavailability/highavailability.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/state"
@@ -32,14 +33,14 @@ type HighAvailability interface {
 // implementation of the api end point.
 type HighAvailabilityAPI struct {
 	state      *state.State
-	resources  *common.Resources
-	authorizer common.Authorizer
+	resources  facade.Resources
+	authorizer facade.Authorizer
 }
 
 var _ HighAvailability = (*HighAvailabilityAPI)(nil)
 
 // NewHighAvailabilityAPI creates a new server-side highavailability API end point.
-func NewHighAvailabilityAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*HighAvailabilityAPI, error) {
+func NewHighAvailabilityAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*HighAvailabilityAPI, error) {
 	// Only clients and environment managers can access the high availability service.
 	if !authorizer.AuthClient() && !authorizer.AuthModelManager() {
 		return nil, common.ErrPerm

--- a/apiserver/hostkeyreporter/facade.go
+++ b/apiserver/hostkeyreporter/facade.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
@@ -29,7 +30,7 @@ type Facade struct {
 }
 
 // New returns a new API facade for the hostkeyreporter worker.
-func New(backend Backend, _ *common.Resources, authorizer common.Authorizer) (*Facade, error) {
+func New(backend Backend, _ facade.Resources, authorizer facade.Authorizer) (*Facade, error) {
 	return &Facade{
 		backend: backend,
 		getCanModify: func() (common.AuthFunc, error) {

--- a/apiserver/hostkeyreporter/shim.go
+++ b/apiserver/hostkeyreporter/shim.go
@@ -4,11 +4,16 @@
 package hostkeyreporter
 
 import (
-	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/errors"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/state"
 )
 
 // newFacade wraps New to express the supplied *state.State as a Backend.
-func newFacade(st *state.State, res *common.Resources, auth common.Authorizer) (*Facade, error) {
-	return New(st, res, auth)
+func newFacade(st *state.State, res facade.Resources, auth facade.Authorizer) (*Facade, error) {
+	facade, err := New(st, res, auth)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return facade, nil
 }

--- a/apiserver/imagemanager/imagemanager.go
+++ b/apiserver/imagemanager/imagemanager.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/imagestorage"
@@ -29,8 +30,8 @@ type ImageManager interface {
 // implementation of the api end point.
 type ImageManagerAPI struct {
 	state      stateInterface
-	resources  *common.Resources
-	authorizer common.Authorizer
+	resources  facade.Resources
+	authorizer facade.Authorizer
 	check      *common.BlockChecker
 }
 
@@ -41,7 +42,7 @@ var getState = func(st *state.State) stateInterface {
 }
 
 // NewImageManagerAPI creates a new server-side imagemanager API end point.
-func NewImageManagerAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*ImageManagerAPI, error) {
+func NewImageManagerAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*ImageManagerAPI, error) {
 	// Only clients can access the image manager service.
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm

--- a/apiserver/imagemetadata/metadata.go
+++ b/apiserver/imagemetadata/metadata.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/utils/series"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -31,14 +32,14 @@ func init() {
 // for loud image metadata manipulations.
 type API struct {
 	metadata   metadataAcess
-	authorizer common.Authorizer
+	authorizer facade.Authorizer
 }
 
 // createAPI returns a new image metadata API facade.
 func createAPI(
 	st metadataAcess,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*API, error) {
 	if !authorizer.AuthClient() && !authorizer.AuthModelManager() {
 		return nil, common.ErrPerm
@@ -53,8 +54,8 @@ func createAPI(
 // NewAPI returns a new cloud image metadata API facade.
 func NewAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*API, error) {
 	return createAPI(getState(st), resources, authorizer)
 }

--- a/apiserver/instancepoller/instancepoller.go
+++ b/apiserver/instancepoller/instancepoller.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
@@ -28,8 +29,8 @@ type InstancePollerAPI struct {
 	*common.StatusGetter
 
 	st            StateInterface
-	resources     *common.Resources
-	authorizer    common.Authorizer
+	resources     facade.Resources
+	authorizer    facade.Authorizer
 	accessMachine common.GetAuthFunc
 	clock         clock.Clock
 }
@@ -37,8 +38,8 @@ type InstancePollerAPI struct {
 // newInstancePollerAPI wraps NewInstancePollerAPI for RegisterStandardFacade.
 func newInstancePollerAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*InstancePollerAPI, error) {
 	return NewInstancePollerAPI(st, resources, authorizer, clock.WallClock)
 }
@@ -47,8 +48,8 @@ func newInstancePollerAPI(
 // facade.
 func NewInstancePollerAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 	clock clock.Clock,
 ) (*InstancePollerAPI, error) {
 

--- a/apiserver/keymanager/keymanager.go
+++ b/apiserver/keymanager/keymanager.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
@@ -38,8 +39,8 @@ type KeyManager interface {
 // implementation of the api end point.
 type KeyManagerAPI struct {
 	state      *state.State
-	resources  *common.Resources
-	authorizer common.Authorizer
+	resources  facade.Resources
+	authorizer facade.Authorizer
 	canRead    func(string) bool
 	canWrite   func(string) bool
 	check      *common.BlockChecker
@@ -48,7 +49,7 @@ type KeyManagerAPI struct {
 var _ KeyManager = (*KeyManagerAPI)(nil)
 
 // NewKeyManagerAPI creates a new server-side keyupdater API end point.
-func NewKeyManagerAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*KeyManagerAPI, error) {
+func NewKeyManagerAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*KeyManagerAPI, error) {
 	// Only clients and environment managers can access the key manager service.
 	if !authorizer.AuthClient() && !authorizer.AuthModelManager() {
 		return nil, common.ErrPerm

--- a/apiserver/keyupdater/authorisedkeys.go
+++ b/apiserver/keyupdater/authorisedkeys.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
@@ -28,8 +29,8 @@ type KeyUpdater interface {
 // implementation of the api end point.
 type KeyUpdaterAPI struct {
 	state      *state.State
-	resources  *common.Resources
-	authorizer common.Authorizer
+	resources  facade.Resources
+	authorizer facade.Authorizer
 	getCanRead common.GetAuthFunc
 }
 
@@ -38,8 +39,8 @@ var _ KeyUpdater = (*KeyUpdaterAPI)(nil)
 // NewKeyUpdaterAPI creates a new server-side keyupdater API end point.
 func NewKeyUpdaterAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*KeyUpdaterAPI, error) {
 	// Only machine agents have access to the keyupdater service.
 	if !authorizer.AuthMachineAgent() {

--- a/apiserver/leadership/leadership.go
+++ b/apiserver/leadership/leadership.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/state"
@@ -41,14 +42,14 @@ func init() {
 // NewLeadershipServiceFacade constructs a new LeadershipService and presents
 // a signature that can be used with RegisterStandardFacade.
 func NewLeadershipServiceFacade(
-	state *state.State, resources *common.Resources, authorizer common.Authorizer,
+	state *state.State, resources facade.Resources, authorizer facade.Authorizer,
 ) (LeadershipService, error) {
 	return NewLeadershipService(state.LeadershipClaimer(), authorizer)
 }
 
 // NewLeadershipService constructs a new LeadershipService.
 func NewLeadershipService(
-	claimer leadership.Claimer, authorizer common.Authorizer,
+	claimer leadership.Claimer, authorizer facade.Authorizer,
 ) (LeadershipService, error) {
 
 	if !authorizer.AuthUnitAgent() {
@@ -65,7 +66,7 @@ func NewLeadershipService(
 // is the concrete implementation of the API endpoint.
 type leadershipService struct {
 	claimer    leadership.Claimer
-	authorizer common.Authorizer
+	authorizer facade.Authorizer
 }
 
 // ClaimLeadership is part of the LeadershipService interface.

--- a/apiserver/leadership/leadership_test.go
+++ b/apiserver/leadership/leadership_test.go
@@ -18,7 +18,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/leadership"
 	"github.com/juju/juju/apiserver/params"
 	coreleadership "github.com/juju/juju/core/leadership"
@@ -55,7 +55,7 @@ func (m *stubClaimer) BlockUntilLeadershipReleased(serviceId string) error {
 }
 
 type stubAuthorizer struct {
-	common.Authorizer
+	facade.Authorizer
 	tag names.Tag
 }
 
@@ -80,7 +80,7 @@ func checkDurationEquals(c *gc.C, actual, expect time.Duration) {
 }
 
 func newLeadershipService(
-	c *gc.C, claimer coreleadership.Claimer, authorizer common.Authorizer,
+	c *gc.C, claimer coreleadership.Claimer, authorizer facade.Authorizer,
 ) leadership.LeadershipService {
 	if authorizer == nil {
 		authorizer = stubAuthorizer{tag: names.NewUnitTag(StubUnitNm)}

--- a/apiserver/leadership/settings.go
+++ b/apiserver/leadership/settings.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/leadership"
 )
@@ -14,7 +15,7 @@ import (
 // NewLeadershipSettingsAccessor creates a new
 // LeadershipSettingsAccessor.
 func NewLeadershipSettingsAccessor(
-	authorizer common.Authorizer,
+	authorizer facade.Authorizer,
 	registerWatcherFn RegisterWatcherFn,
 	getSettingsFn GetSettingsFn,
 	leaderCheckFn LeaderCheckFn,
@@ -52,7 +53,7 @@ type MergeSettingsChunkFn func(token leadership.Token, serviceId string, setting
 // LeadershipSettingsAccessor provides a type which can read, write,
 // and watch leadership settings.
 type LeadershipSettingsAccessor struct {
-	authorizer           common.Authorizer
+	authorizer           facade.Authorizer
 	registerWatcherFn    RegisterWatcherFn
 	getSettingsFn        GetSettingsFn
 	leaderCheckFn        LeaderCheckFn

--- a/apiserver/lifeflag/facade.go
+++ b/apiserver/lifeflag/facade.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/state"
 )
 
@@ -15,7 +16,7 @@ type Backend interface {
 	state.EntityFinder
 }
 
-func NewFacade(backend Backend, resources *common.Resources, authorizer common.Authorizer) (*Facade, error) {
+func NewFacade(backend Backend, resources facade.Resources, authorizer facade.Authorizer) (*Facade, error) {
 	if !authorizer.AuthModelManager() {
 		return nil, common.ErrPerm
 	}

--- a/apiserver/lifeflag/shim.go
+++ b/apiserver/lifeflag/shim.go
@@ -5,13 +5,14 @@ package lifeflag
 
 import (
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/state"
 )
 
 func init() {
 	common.RegisterStandardFacade(
 		"LifeFlag", 1,
-		func(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*Facade, error) {
+		func(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*Facade, error) {
 			return NewFacade(st, resources, authorizer)
 		},
 	)

--- a/apiserver/lifeflag/util_test.go
+++ b/apiserver/lifeflag/util_test.go
@@ -7,15 +7,15 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 )
 
-// mockAuth implements common.Authorizer for the tests' convenience.
+// mockAuth implements facade.Authorizer for the tests' convenience.
 type mockAuth struct {
-	common.Authorizer
+	facade.Authorizer
 	modelManager bool
 }
 
@@ -24,7 +24,7 @@ func (mock mockAuth) AuthModelManager() bool {
 }
 
 // auth is a convenience constructor for a mockAuth.
-func auth(modelManager bool) common.Authorizer {
+func auth(modelManager bool) facade.Authorizer {
 	return mockAuth{modelManager: modelManager}
 }
 

--- a/apiserver/logger/logger.go
+++ b/apiserver/logger/logger.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
@@ -29,8 +30,8 @@ type Logger interface {
 // implementation of the api end point.
 type LoggerAPI struct {
 	state      *state.State
-	resources  *common.Resources
-	authorizer common.Authorizer
+	resources  facade.Resources
+	authorizer facade.Authorizer
 }
 
 var _ Logger = (*LoggerAPI)(nil)
@@ -38,8 +39,8 @@ var _ Logger = (*LoggerAPI)(nil)
 // NewLoggerAPI creates a new server-side logger API end point.
 func NewLoggerAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*LoggerAPI, error) {
 	if !authorizer.AuthMachineAgent() && !authorizer.AuthUnitAgent() {
 		return nil, common.ErrPerm

--- a/apiserver/machine/machiner.go
+++ b/apiserver/machine/machiner.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/networkingcommon"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
@@ -32,13 +33,13 @@ type MachinerAPI struct {
 	*common.APIAddresser
 
 	st           *state.State
-	auth         common.Authorizer
+	auth         facade.Authorizer
 	getCanModify common.GetAuthFunc
 	getCanRead   common.GetAuthFunc
 }
 
 // NewMachinerAPI creates a new instance of the Machiner API.
-func NewMachinerAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*MachinerAPI, error) {
+func NewMachinerAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*MachinerAPI, error) {
 	if !authorizer.AuthMachineAgent() {
 		return nil, common.ErrPerm
 	}

--- a/apiserver/machineactions/machineactions.go
+++ b/apiserver/machineactions/machineactions.go
@@ -8,6 +8,7 @@ package machineactions
 
 import (
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"gopkg.in/juju/names.v2"
@@ -24,15 +25,15 @@ type Backend interface {
 // implementation of the api end point.
 type Facade struct {
 	backend       Backend
-	resources     *common.Resources
+	resources     facade.Resources
 	accessMachine common.AuthFunc
 }
 
 // NewFacade creates a new server-side machineactions API end point.
 func NewFacade(
 	backend Backend,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*Facade, error) {
 	if !authorizer.AuthMachineAgent() {
 		return nil, common.ErrPerm

--- a/apiserver/machineactions/machineactions_test.go
+++ b/apiserver/machineactions/machineactions_test.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/machineactions"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
@@ -84,13 +85,13 @@ func entities(tags ...string) params.Entities {
 	return entities
 }
 
-// agentAuth implements common.Authorizer for use in the tests.
+// agentAuth implements facade.Authorizer for use in the tests.
 type agentAuth struct {
-	common.Authorizer
+	facade.Authorizer
 	machine bool
 }
 
-// AuthMachineAgent is part of the common.Authorizer interface.
+// AuthMachineAgent is part of the facade.Authorizer interface.
 func (auth agentAuth) AuthMachineAgent() bool {
 	return auth.machine
 }

--- a/apiserver/machineactions/shim.go
+++ b/apiserver/machineactions/shim.go
@@ -6,6 +6,7 @@ package machineactions
 
 import (
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"gopkg.in/juju/names.v2"
@@ -15,7 +16,7 @@ func init() {
 	common.RegisterStandardFacade("MachineActions", 1, newFacade)
 }
 
-func newFacade(st *state.State, res *common.Resources, auth common.Authorizer) (*Facade, error) {
+func newFacade(st *state.State, res facade.Resources, auth facade.Authorizer) (*Facade, error) {
 	return NewFacade(backendShim{st}, res, auth)
 }
 

--- a/apiserver/machinemanager/machinemanager.go
+++ b/apiserver/machinemanager/machinemanager.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
@@ -22,7 +23,7 @@ func init() {
 // MachineManagerAPI provides access to the MachineManager API facade.
 type MachineManagerAPI struct {
 	st         stateInterface
-	authorizer common.Authorizer
+	authorizer facade.Authorizer
 	check      *common.BlockChecker
 }
 
@@ -33,8 +34,8 @@ var getState = func(st *state.State) stateInterface {
 // NewMachineManagerAPI creates a new server-side MachineManager API facade.
 func NewMachineManagerAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*MachineManagerAPI, error) {
 
 	if !authorizer.AuthClient() {

--- a/apiserver/meterstatus/meterstatus.go
+++ b/apiserver/meterstatus/meterstatus.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
@@ -28,14 +29,14 @@ type MeterStatus interface {
 type MeterStatusAPI struct {
 	state      *state.State
 	accessUnit common.GetAuthFunc
-	resources  *common.Resources
+	resources  facade.Resources
 }
 
 // NewMeterStatusAPI creates a new API endpoint for dealing with unit meter status.
 func NewMeterStatusAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*MeterStatusAPI, error) {
 	if !authorizer.AuthUnitAgent() {
 		return nil, common.ErrPerm

--- a/apiserver/metricsadder/metricsadder.go
+++ b/apiserver/metricsadder/metricsadder.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
@@ -32,8 +33,8 @@ var _ MetricsAdder = (*MetricsAdderAPI)(nil)
 // NewMetricsAdderAPI creates a new API endpoint for adding metrics to state.
 func NewMetricsAdderAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*MetricsAdderAPI, error) {
 	// TODO(cmars): remove unit agent auth, once worker/metrics/sender manifold
 	// can be righteously relocated to machine agent.

--- a/apiserver/metricsdebug/metricsdebug.go
+++ b/apiserver/metricsdebug/metricsdebug.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
@@ -52,8 +53,8 @@ var _ MetricsDebug = (*MetricsDebugAPI)(nil)
 // NewMetricsDebugAPI creates a new API endpoint for calling metrics debug functions.
 func NewMetricsDebugAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*MetricsDebugAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm

--- a/apiserver/metricsmanager/metricsmanager.go
+++ b/apiserver/metricsmanager/metricsmanager.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/metricsender"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
@@ -46,8 +47,8 @@ var _ MetricsManager = (*MetricsManagerAPI)(nil)
 // NewMetricsManagerAPI creates a new API endpoint for calling metrics manager functions.
 func NewMetricsManagerAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*MetricsManagerAPI, error) {
 	if !(authorizer.AuthMachineAgent() && authorizer.AuthModelManager()) {
 		return nil, common.ErrPerm

--- a/apiserver/migrationflag/facade.go
+++ b/apiserver/migrationflag/facade.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/state"
@@ -24,13 +25,13 @@ type Backend interface {
 // Facade lets clients watch and get models' migration phases.
 type Facade struct {
 	backend   Backend
-	resources *common.Resources
+	resources facade.Resources
 }
 
 // New creates a Facade backed by backend and resources. If auth
 // doesn't identity the client as a machine agent or a unit agent,
 // it will return common.ErrPerm.
-func New(backend Backend, resources *common.Resources, auth common.Authorizer) (*Facade, error) {
+func New(backend Backend, resources facade.Resources, auth facade.Authorizer) (*Facade, error) {
 	if !auth.AuthMachineAgent() && !auth.AuthUnitAgent() {
 		return nil, common.ErrPerm
 	}

--- a/apiserver/migrationflag/shim.go
+++ b/apiserver/migrationflag/shim.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/state"
 )
@@ -16,7 +17,7 @@ func init() {
 }
 
 // newFacade wraps New to express the supplied *state.State as a Backend.
-func newFacade(st *state.State, resources *common.Resources, auth common.Authorizer) (*Facade, error) {
+func newFacade(st *state.State, resources facade.Resources, auth facade.Authorizer) (*Facade, error) {
 	facade, err := New(&backend{st}, resources, auth)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/migrationflag/util_test.go
+++ b/apiserver/migrationflag/util_test.go
@@ -6,21 +6,21 @@ package migrationflag_test
 import (
 	"github.com/juju/testing"
 
-	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 )
 
-// agentAuth implements common.Authorizer for use in the tests.
+// agentAuth implements facade.Authorizer for use in the tests.
 type agentAuth struct {
-	common.Authorizer
+	facade.Authorizer
 	machine bool
 	unit    bool
 }
 
-// AuthMachineAgent is part of the common.Authorizer interface.
+// AuthMachineAgent is part of the facade.Authorizer interface.
 func (auth agentAuth) AuthMachineAgent() bool {
 	return auth.machine
 }

--- a/apiserver/migrationmaster/facade.go
+++ b/apiserver/migrationmaster/facade.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/description"
 	coremigration "github.com/juju/juju/core/migration"
@@ -25,16 +26,16 @@ func init() {
 // master worker.
 type API struct {
 	backend    Backend
-	authorizer common.Authorizer
-	resources  *common.Resources
+	authorizer facade.Authorizer
+	resources  facade.Resources
 }
 
 // NewAPI creates a new API server endpoint for the model migration
 // master worker.
 func NewAPI(
 	backend Backend,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*API, error) {
 	if !authorizer.AuthModelManager() {
 		return nil, common.ErrPerm

--- a/apiserver/migrationmaster/shim.go
+++ b/apiserver/migrationmaster/shim.go
@@ -4,7 +4,7 @@
 package migrationmaster
 
 import (
-	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/state"
 )
 
@@ -12,8 +12,8 @@ import (
 // RegisterStandardFacade, converting st to backend.
 func newAPIForRegistration(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*API, error) {
 	return NewAPI(st, resources, authorizer)
 }

--- a/apiserver/migrationminion/migrationminion.go
+++ b/apiserver/migrationminion/migrationminion.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/migration"
 )
@@ -15,16 +16,16 @@ import (
 // master worker.
 type API struct {
 	backend    Backend
-	authorizer common.Authorizer
-	resources  *common.Resources
+	authorizer facade.Authorizer
+	resources  facade.Resources
 }
 
 // NewAPI creates a new API server endpoint for the model migration
 // master worker.
 func NewAPI(
 	backend Backend,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*API, error) {
 	if !(authorizer.AuthMachineAgent() || authorizer.AuthUnitAgent()) {
 		return nil, common.ErrPerm

--- a/apiserver/migrationminion/register.go
+++ b/apiserver/migrationminion/register.go
@@ -5,6 +5,7 @@ package migrationminion
 
 import (
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/state"
 )
 
@@ -14,8 +15,8 @@ func init() {
 
 func newAPIShim(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*API, error) {
 	return NewAPI(st, resources, authorizer)
 }

--- a/apiserver/migrationtarget/migrationtarget.go
+++ b/apiserver/migrationtarget/migrationtarget.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/state"
@@ -21,15 +22,15 @@ func init() {
 // master worker when communicating with the target controller.
 type API struct {
 	state      *state.State
-	authorizer common.Authorizer
-	resources  *common.Resources
+	authorizer facade.Authorizer
+	resources  facade.Resources
 }
 
 // NewAPI returns a new API.
 func NewAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*API, error) {
 	if err := checkAuth(authorizer, st); err != nil {
 		return nil, errors.Trace(err)
@@ -41,7 +42,7 @@ func NewAPI(
 	}, nil
 }
 
-func checkAuth(authorizer common.Authorizer, st *state.State) error {
+func checkAuth(authorizer facade.Authorizer, st *state.State) error {
 	if !authorizer.AuthClient() {
 		return errors.Trace(common.ErrPerm)
 	}

--- a/apiserver/migrationtarget/migrationtarget_test.go
+++ b/apiserver/migrationtarget/migrationtarget_test.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/migrationtarget"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
@@ -63,7 +64,11 @@ func (s *Suite) TestFacadeRegistered(c *gc.C) {
 	factory, err := common.Facades.GetFactory("MigrationTarget", 1)
 	c.Assert(err, jc.ErrorIsNil)
 
-	api, err := factory(s.State, s.resources, s.authorizer, "")
+	api, err := factory(facadetest.Context{
+		State_:     s.State,
+		Resources_: s.resources,
+		Auth_:      s.authorizer,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(api, gc.FitsTypeOf, new(migrationtarget.API))
 }

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller/modelmanager"
@@ -43,7 +44,7 @@ type ModelManager interface {
 // the concrete implementation of the api end point.
 type ModelManagerAPI struct {
 	state       Backend
-	authorizer  common.Authorizer
+	authorizer  facade.Authorizer
 	toolsFinder *common.ToolsFinder
 	apiUser     names.UserTag
 	isAdmin     bool
@@ -51,13 +52,13 @@ type ModelManagerAPI struct {
 
 var _ ModelManager = (*ModelManagerAPI)(nil)
 
-func newFacade(st *state.State, resources *common.Resources, auth common.Authorizer) (*ModelManagerAPI, error) {
+func newFacade(st *state.State, resources facade.Resources, auth facade.Authorizer) (*ModelManagerAPI, error) {
 	return NewModelManagerAPI(NewStateBackend(st), auth)
 }
 
 // NewModelManagerAPI creates a new api server endpoint for managing
 // models.
-func NewModelManagerAPI(st Backend, authorizer common.Authorizer) (*ModelManagerAPI, error) {
+func NewModelManagerAPI(st Backend, authorizer facade.Authorizer) (*ModelManagerAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}

--- a/apiserver/pinger.go
+++ b/apiserver/pinger.go
@@ -10,6 +10,7 @@ import (
 	"launchpad.net/tomb"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/state"
 )
 
@@ -20,7 +21,7 @@ func init() {
 // NewPinger returns an object that can be pinged by calling its Ping method.
 // If this method is not called frequently enough, the connection will be
 // dropped.
-func NewPinger(st *state.State, resources *common.Resources, authorizer common.Authorizer) (Pinger, error) {
+func NewPinger(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (Pinger, error) {
 	pingTimeout, ok := resources.Get("pingTimeout").(*pingTimeout)
 	if !ok {
 		return nullPinger{}, nil

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/networkingcommon"
 	"github.com/juju/juju/apiserver/common/storagecommon"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/container"
@@ -48,13 +49,13 @@ type ProvisionerAPI struct {
 	*common.ToolsGetter
 
 	st          *state.State
-	resources   *common.Resources
-	authorizer  common.Authorizer
+	resources   facade.Resources
+	authorizer  facade.Authorizer
 	getAuthFunc common.GetAuthFunc
 }
 
 // NewProvisionerAPI creates a new server-side ProvisionerAPI facade.
-func NewProvisionerAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*ProvisionerAPI, error) {
+func NewProvisionerAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*ProvisionerAPI, error) {
 	if !authorizer.AuthMachineAgent() && !authorizer.AuthModelManager() {
 		return nil, common.ErrPerm
 	}

--- a/apiserver/proxyupdater/model.go
+++ b/apiserver/proxyupdater/model.go
@@ -4,11 +4,11 @@
 package proxyupdater
 
 import (
-	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/state"
 )
 
 // NewAPI creates a new API server-side facade with a state.State backing.
-func NewAPI(st *state.State, res *common.Resources, auth common.Authorizer) (*ProxyUpdaterAPI, error) {
+func NewAPI(st *state.State, res facade.Resources, auth facade.Authorizer) (*ProxyUpdaterAPI, error) {
 	return NewAPIWithBacking(&stateShim{st: st}, res, auth)
 }

--- a/apiserver/proxyupdater/proxyupdater.go
+++ b/apiserver/proxyupdater/proxyupdater.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
@@ -28,12 +29,12 @@ type Backend interface {
 
 type ProxyUpdaterAPI struct {
 	backend    Backend
-	resources  *common.Resources
-	authorizer common.Authorizer
+	resources  facade.Resources
+	authorizer facade.Authorizer
 }
 
 // NewAPIWithBacking creates a new server-side API facade with the given Backing.
-func NewAPIWithBacking(st Backend, resources *common.Resources, authorizer common.Authorizer) (*ProxyUpdaterAPI, error) {
+func NewAPIWithBacking(st Backend, resources facade.Resources, authorizer facade.Authorizer) (*ProxyUpdaterAPI, error) {
 	if !(authorizer.AuthMachineAgent() || authorizer.AuthUnitAgent()) {
 		return &ProxyUpdaterAPI{}, common.ErrPerm
 	}

--- a/apiserver/reboot/reboot.go
+++ b/apiserver/reboot/reboot.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
@@ -23,10 +24,10 @@ type RebootAPI struct {
 	*common.RebootRequester
 	*common.RebootFlagClearer
 
-	auth      common.Authorizer
+	auth      facade.Authorizer
 	st        *state.State
 	machine   *state.Machine
-	resources *common.Resources
+	resources facade.Resources
 }
 
 func init() {
@@ -34,7 +35,7 @@ func init() {
 }
 
 // NewRebootAPI creates a new server-side RebootAPI facade.
-func NewRebootAPI(st *state.State, resources *common.Resources, auth common.Authorizer) (*RebootAPI, error) {
+func NewRebootAPI(st *state.State, resources facade.Resources, auth facade.Authorizer) (*RebootAPI, error) {
 	if !auth.AuthMachineAgent() {
 		return nil, common.ErrPerm
 	}

--- a/apiserver/resumer/resumer.go
+++ b/apiserver/resumer/resumer.go
@@ -7,6 +7,7 @@ package resumer
 
 import (
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/state"
 )
 
@@ -17,11 +18,11 @@ func init() {
 // ResumerAPI implements the API used by the resumer worker.
 type ResumerAPI struct {
 	st   stateInterface
-	auth common.Authorizer
+	auth facade.Authorizer
 }
 
 // NewResumerAPI creates a new instance of the Resumer API.
-func NewResumerAPI(st *state.State, _ *common.Resources, authorizer common.Authorizer) (*ResumerAPI, error) {
+func NewResumerAPI(st *state.State, _ facade.Resources, authorizer facade.Authorizer) (*ResumerAPI, error) {
 	if !authorizer.AuthModelManager() {
 		return nil, common.ErrPerm
 	}

--- a/apiserver/retrystrategy/retrystrategy.go
+++ b/apiserver/retrystrategy/retrystrategy.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
@@ -39,7 +40,7 @@ type RetryStrategy interface {
 type RetryStrategyAPI struct {
 	st         *state.State
 	accessUnit common.GetAuthFunc
-	resources  *common.Resources
+	resources  facade.Resources
 }
 
 var _ RetryStrategy = (*RetryStrategyAPI)(nil)
@@ -47,8 +48,8 @@ var _ RetryStrategy = (*RetryStrategyAPI)(nil)
 // NewRetryStrategyAPI creates a new API endpoint for getting retry strategies.
 func NewRetryStrategyAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*RetryStrategyAPI, error) {
 	if !authorizer.AuthUnitAgent() {
 		return nil, common.ErrPerm

--- a/apiserver/singular/fixture_test.go
+++ b/apiserver/singular/fixture_test.go
@@ -9,23 +9,23 @@ import (
 	"github.com/juju/testing"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/core/lease"
 	coretesting "github.com/juju/juju/testing"
 )
 
 // mockAuth represents a machine which may or may not be an environ manager.
 type mockAuth struct {
-	common.Authorizer
+	facade.Authorizer
 	nonManager bool
 }
 
-// AuthModelManager is part of the common.Authorizer interface.
+// AuthModelManager is part of the facade.Authorizer interface.
 func (mock mockAuth) AuthModelManager() bool {
 	return !mock.nonManager
 }
 
-// GetAuthTag is part of the common.Authorizer interface.
+// GetAuthTag is part of the facade.Authorizer interface.
 func (mockAuth) GetAuthTag() names.Tag {
 	return names.NewMachineTag("123")
 }

--- a/apiserver/singular/singular.go
+++ b/apiserver/singular/singular.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/state"
@@ -17,7 +18,7 @@ import (
 func init() {
 	common.RegisterStandardFacade(
 		"Singular", 1,
-		func(st *state.State, _ *common.Resources, auth common.Authorizer) (*Facade, error) {
+		func(st *state.State, _ facade.Resources, auth facade.Authorizer) (*Facade, error) {
 			return NewFacade(st, auth)
 		},
 	)
@@ -35,7 +36,7 @@ type Backend interface {
 
 // NewFacade returns a singular-controller API facade, backed by the supplied
 // state, so long as the authorizer represents a controller machine.
-func NewFacade(backend Backend, auth common.Authorizer) (*Facade, error) {
+func NewFacade(backend Backend, auth facade.Authorizer) (*Facade, error) {
 	if !auth.AuthModelManager() {
 		return nil, common.ErrPerm
 	}
@@ -49,7 +50,7 @@ func NewFacade(backend Backend, auth common.Authorizer) (*Facade, error) {
 // Facade allows controller machines to request exclusive rights to administer
 // some specific model for a limited time.
 type Facade struct {
-	auth    common.Authorizer
+	auth    facade.Authorizer
 	model   names.ModelTag
 	claimer lease.Claimer
 }

--- a/apiserver/spaces/spaces.go
+++ b/apiserver/spaces/spaces.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/networkingcommon"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
@@ -25,19 +26,19 @@ type API interface {
 // spacesAPI implements the API interface.
 type spacesAPI struct {
 	backing    networkingcommon.NetworkBacking
-	resources  *common.Resources
-	authorizer common.Authorizer
+	resources  facade.Resources
+	authorizer facade.Authorizer
 }
 
 // NewAPI creates a new Space API server-side facade with a
 // state.State backing.
-func NewAPI(st *state.State, res *common.Resources, auth common.Authorizer) (API, error) {
+func NewAPI(st *state.State, res facade.Resources, auth facade.Authorizer) (API, error) {
 	return newAPIWithBacking(networkingcommon.NewStateShim(st), res, auth)
 }
 
 // newAPIWithBacking creates a new server-side Spaces API facade with
 // the given Backing.
-func newAPIWithBacking(backing networkingcommon.NetworkBacking, resources *common.Resources, authorizer common.Authorizer) (API, error) {
+func newAPIWithBacking(backing networkingcommon.NetworkBacking, resources facade.Resources, authorizer facade.Authorizer) (API, error) {
 	// Only clients can access the Spaces facade.
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm

--- a/apiserver/sshclient/facade.go
+++ b/apiserver/sshclient/facade.go
@@ -7,6 +7,7 @@ package sshclient
 
 import (
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
 )
@@ -21,7 +22,7 @@ type Facade struct {
 }
 
 // New returns a new API facade for the sshclient worker.
-func New(backend Backend, _ *common.Resources, authorizer common.Authorizer) (*Facade, error) {
+func New(backend Backend, _ facade.Resources, authorizer facade.Authorizer) (*Facade, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}

--- a/apiserver/sshclient/shim.go
+++ b/apiserver/sshclient/shim.go
@@ -7,7 +7,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -29,7 +29,7 @@ type SSHMachine interface {
 }
 
 // newFacade wraps New to express the supplied *state.State as a Backend.
-func newFacade(st *state.State, res *common.Resources, auth common.Authorizer) (*Facade, error) {
+func newFacade(st *state.State, res facade.Resources, auth facade.Authorizer) (*Facade, error) {
 	return New(&backend{st}, res, auth)
 }
 

--- a/apiserver/statushistory/pruner.go
+++ b/apiserver/statushistory/pruner.go
@@ -5,6 +5,7 @@ package statushistory
 
 import (
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
@@ -16,11 +17,11 @@ func init() {
 // API is the concrete implementation of the Pruner endpoint..
 type API struct {
 	st         *state.State
-	authorizer common.Authorizer
+	authorizer facade.Authorizer
 }
 
 // NewAPI returns an API Instance.
-func NewAPI(st *state.State, _ *common.Resources, auth common.Authorizer) (*API, error) {
+func NewAPI(st *state.State, _ facade.Resources, auth facade.Authorizer) (*API, error) {
 	return &API{
 		st:         st,
 		authorizer: auth,

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/storagecommon"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
@@ -29,15 +30,15 @@ func init() {
 type API struct {
 	storage     storageAccess
 	poolManager poolmanager.PoolManager
-	authorizer  common.Authorizer
+	authorizer  facade.Authorizer
 }
 
 // createAPI returns a new storage API facade.
 func createAPI(
 	st storageAccess,
 	pm poolmanager.PoolManager,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*API, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
@@ -52,8 +53,8 @@ func createAPI(
 // NewAPI returns a new storage API facade.
 func NewAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*API, error) {
 	return createAPI(getState(st), poolManager(st), resources, authorizer)
 }

--- a/apiserver/storageprovisioner/storageprovisioner.go
+++ b/apiserver/storageprovisioner/storageprovisioner.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/storagecommon"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
@@ -33,8 +34,8 @@ type StorageProvisionerAPI struct {
 
 	st                       provisionerState
 	settings                 poolmanager.SettingsManager
-	resources                *common.Resources
-	authorizer               common.Authorizer
+	resources                facade.Resources
+	authorizer               facade.Authorizer
 	getScopeAuthFunc         common.GetAuthFunc
 	getStorageEntityAuthFunc common.GetAuthFunc
 	getMachineAuthFunc       common.GetAuthFunc
@@ -51,7 +52,7 @@ var getSettingsManager = func(st *state.State) poolmanager.SettingsManager {
 }
 
 // NewStorageProvisionerAPI creates a new server-side StorageProvisionerAPI facade.
-func NewStorageProvisionerAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*StorageProvisionerAPI, error) {
+func NewStorageProvisionerAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*StorageProvisionerAPI, error) {
 	if !authorizer.AuthMachineAgent() {
 		return nil, common.ErrPerm
 	}

--- a/apiserver/subnets/subnets.go
+++ b/apiserver/subnets/subnets.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/networkingcommon"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
@@ -38,19 +39,19 @@ type SubnetsAPI interface {
 // subnetsAPI implements the SubnetsAPI interface.
 type subnetsAPI struct {
 	backing    networkingcommon.NetworkBacking
-	resources  *common.Resources
-	authorizer common.Authorizer
+	resources  facade.Resources
+	authorizer facade.Authorizer
 }
 
 // NewAPI creates a new Subnets API server-side facade with a
 // state.State backing.
-func NewAPI(st *state.State, res *common.Resources, auth common.Authorizer) (SubnetsAPI, error) {
+func NewAPI(st *state.State, res facade.Resources, auth facade.Authorizer) (SubnetsAPI, error) {
 	return newAPIWithBacking(networkingcommon.NewStateShim(st), res, auth)
 }
 
 // newAPIWithBacking creates a new server-side Subnets API facade with
 // a common.NetworkBacking
-func newAPIWithBacking(backing networkingcommon.NetworkBacking, resources *common.Resources, authorizer common.Authorizer) (SubnetsAPI, error) {
+func newAPIWithBacking(backing networkingcommon.NetworkBacking, resources facade.Resources, authorizer facade.Authorizer) (SubnetsAPI, error) {
 	// Only clients can access the Subnets facade.
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm

--- a/apiserver/testing/fakeauthorizer.go
+++ b/apiserver/testing/fakeauthorizer.go
@@ -7,7 +7,7 @@ import (
 	"gopkg.in/juju/names.v2"
 )
 
-// FakeAuthorizer implements the common.Authorizer interface.
+// FakeAuthorizer implements the facade.Authorizer interface.
 type FakeAuthorizer struct {
 	Tag            names.Tag
 	EnvironManager bool

--- a/apiserver/undertaker/undertaker.go
+++ b/apiserver/undertaker/undertaker.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
@@ -20,16 +21,16 @@ func init() {
 // UndertakerAPI implements the API used by the machine undertaker worker.
 type UndertakerAPI struct {
 	st        State
-	resources *common.Resources
+	resources facade.Resources
 	*common.StatusSetter
 }
 
 // NewUndertakerAPI creates a new instance of the undertaker API.
-func NewUndertakerAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*UndertakerAPI, error) {
+func NewUndertakerAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*UndertakerAPI, error) {
 	return newUndertakerAPI(&stateShim{st}, resources, authorizer)
 }
 
-func newUndertakerAPI(st State, resources *common.Resources, authorizer common.Authorizer) (*UndertakerAPI, error) {
+func newUndertakerAPI(st State, resources facade.Resources, authorizer facade.Authorizer) (*UndertakerAPI, error) {
 	if !authorizer.AuthMachineAgent() || !authorizer.AuthModelManager() {
 		return nil, common.ErrPerm
 	}

--- a/apiserver/unitassigner/unitassigner.go
+++ b/apiserver/unitassigner/unitassigner.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
@@ -31,12 +32,12 @@ type statusSetter interface {
 // API implements the functionality for assigning units to machines.
 type API struct {
 	st           assignerState
-	res          *common.Resources
+	res          facade.Resources
 	statusSetter statusSetter
 }
 
 // New returns a new unitAssigner api instance.
-func New(st *state.State, res *common.Resources, _ common.Authorizer) (*API, error) {
+func New(st *state.State, res facade.Resources, _ facade.Authorizer) (*API, error) {
 	setter := common.NewStatusSetter(&common.UnitAgentFinder{st}, common.AuthAlways())
 	return &API{
 		st:           st,

--- a/apiserver/uniter/export_test.go
+++ b/apiserver/uniter/export_test.go
@@ -5,6 +5,7 @@ package uniter
 
 import (
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/meterstatus"
 )
 
@@ -18,7 +19,7 @@ type StorageStateInterface storageStateInterface
 
 func NewStorageAPI(
 	st StorageStateInterface,
-	resources *common.Resources,
+	resources facade.Resources,
 	accessUnit common.GetAuthFunc,
 ) (*StorageAPI, error) {
 	return newStorageAPI(storageStateInterface(st), resources, accessUnit)

--- a/apiserver/uniter/storage.go
+++ b/apiserver/uniter/storage.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/storagecommon"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
@@ -17,14 +18,14 @@ import (
 // StorageAPI provides access to the Storage API facade.
 type StorageAPI struct {
 	st         storageStateInterface
-	resources  *common.Resources
+	resources  facade.Resources
 	accessUnit common.GetAuthFunc
 }
 
 // newStorageAPI creates a new server-side Storage API facade.
 func newStorageAPI(
 	st storageStateInterface,
-	resources *common.Resources,
+	resources facade.Resources,
 	accessUnit common.GetAuthFunc,
 ) (*StorageAPI, error) {
 

--- a/apiserver/uniter/uniter.go
+++ b/apiserver/uniter/uniter.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	leadershipapiserver "github.com/juju/juju/apiserver/leadership"
 	"github.com/juju/juju/apiserver/meterstatus"
 	"github.com/juju/juju/apiserver/params"
@@ -43,8 +44,8 @@ type UniterAPIV3 struct {
 	meterstatus.MeterStatus
 
 	st            *state.State
-	auth          common.Authorizer
-	resources     *common.Resources
+	auth          facade.Authorizer
+	resources     facade.Resources
 	accessUnit    common.GetAuthFunc
 	accessService common.GetAuthFunc
 	unit          *state.Unit
@@ -53,7 +54,7 @@ type UniterAPIV3 struct {
 }
 
 // NewUniterAPIV4 creates a new instance of the Uniter API, version 3.
-func NewUniterAPIV4(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*UniterAPIV3, error) {
+func NewUniterAPIV4(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*UniterAPIV3, error) {
 	if !authorizer.AuthUnitAgent() {
 		return nil, common.ErrPerm
 	}
@@ -1405,8 +1406,8 @@ func relationsInScopeTags(unit *state.Unit) ([]string, error) {
 
 func leadershipSettingsAccessorFactory(
 	st *state.State,
-	resources *common.Resources,
-	auth common.Authorizer,
+	resources facade.Resources,
+	auth facade.Authorizer,
 ) *leadershipapiserver.LeadershipSettingsAccessor {
 	registerWatcher := func(serviceId string) (string, error) {
 		service, err := st.Application(serviceId)

--- a/apiserver/upgrader/unitupgrader.go
+++ b/apiserver/upgrader/unitupgrader.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
@@ -19,15 +20,15 @@ type UnitUpgraderAPI struct {
 	*common.ToolsSetter
 
 	st         *state.State
-	resources  *common.Resources
-	authorizer common.Authorizer
+	resources  facade.Resources
+	authorizer facade.Authorizer
 }
 
 // NewUnitUpgraderAPI creates a new server-side UnitUpgraderAPI facade.
 func NewUnitUpgraderAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*UnitUpgraderAPI, error) {
 	if !authorizer.AuthUnitAgent() {
 		return nil, common.ErrPerm

--- a/apiserver/upgrader/upgrader.go
+++ b/apiserver/upgrader/upgrader.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
@@ -28,7 +29,7 @@ func init() {
 // returned depends on who is calling.
 // Both of them conform to the exact Upgrader API, so the actual calls that are
 // available do not depend on who is currently connected.
-func upgraderFacade(st *state.State, resources *common.Resources, auth common.Authorizer) (Upgrader, error) {
+func upgraderFacade(st *state.State, resources facade.Resources, auth facade.Authorizer) (Upgrader, error) {
 	// The type of upgrader we return depends on who is asking.
 	// Machines get an UpgraderAPI, units get a UnitUpgraderAPI.
 	// This is tested in the api/upgrader package since there
@@ -61,15 +62,15 @@ type UpgraderAPI struct {
 	*common.ToolsSetter
 
 	st         *state.State
-	resources  *common.Resources
-	authorizer common.Authorizer
+	resources  facade.Resources
+	authorizer facade.Authorizer
 }
 
 // NewUpgraderAPI creates a new server-side UpgraderAPI facade.
 func NewUpgraderAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*UpgraderAPI, error) {
 	if !authorizer.AuthMachineAgent() {
 		return nil, common.ErrPerm

--- a/apiserver/usermanager/usermanager.go
+++ b/apiserver/usermanager/usermanager.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/modelmanager"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
@@ -28,7 +29,7 @@ func init() {
 // implementation of the api end point.
 type UserManagerAPI struct {
 	state                    *state.State
-	authorizer               common.Authorizer
+	authorizer               facade.Authorizer
 	createLocalLoginMacaroon func(names.UserTag) (*macaroon.Macaroon, error)
 	check                    *common.BlockChecker
 	apiUser                  names.UserTag
@@ -37,8 +38,8 @@ type UserManagerAPI struct {
 
 func NewUserManagerAPI(
 	st *state.State,
-	resources *common.Resources,
-	authorizer common.Authorizer,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
 ) (*UserManagerAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/storagecommon"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/migration"
@@ -62,11 +63,14 @@ func init() {
 
 // NewAllWatcher returns a new API server endpoint for interacting
 // with a watcher created by the WatchAll and WatchAllModels API calls.
-func NewAllWatcher(st *state.State, resources *common.Resources, auth common.Authorizer, id string) (interface{}, error) {
+func NewAllWatcher(context facade.Context) (facade.Facade, error) {
+	id := context.ID()
+	auth := context.Auth()
+	resources := context.Resources()
+
 	if !auth.AuthClient() {
 		return nil, common.ErrPerm
 	}
-
 	watcher, ok := resources.Get(id).(*state.Multiwatcher)
 	if !ok {
 		return nil, common.ErrUnknownWatcher
@@ -85,7 +89,7 @@ func NewAllWatcher(st *state.State, resources *common.Resources, auth common.Aut
 type SrvAllWatcher struct {
 	watcher   *state.Multiwatcher
 	id        string
-	resources *common.Resources
+	resources facade.Resources
 }
 
 func (aw *SrvAllWatcher) Next() (params.AllWatcherNextResults, error) {
@@ -104,14 +108,18 @@ func (w *SrvAllWatcher) Stop() error {
 type srvNotifyWatcher struct {
 	watcher   state.NotifyWatcher
 	id        string
-	resources *common.Resources
+	resources facade.Resources
 }
 
-func isAgent(auth common.Authorizer) bool {
+func isAgent(auth facade.Authorizer) bool {
 	return auth.AuthMachineAgent() || auth.AuthUnitAgent()
 }
 
-func newNotifyWatcher(st *state.State, resources *common.Resources, auth common.Authorizer, id string) (interface{}, error) {
+func newNotifyWatcher(context facade.Context) (facade.Facade, error) {
+	id := context.ID()
+	auth := context.Auth()
+	resources := context.Resources()
+
 	if !isAgent(auth) {
 		return nil, common.ErrPerm
 	}
@@ -152,10 +160,14 @@ func (w *srvNotifyWatcher) Stop() error {
 type srvStringsWatcher struct {
 	watcher   state.StringsWatcher
 	id        string
-	resources *common.Resources
+	resources facade.Resources
 }
 
-func newStringsWatcher(st *state.State, resources *common.Resources, auth common.Authorizer, id string) (interface{}, error) {
+func newStringsWatcher(context facade.Context) (facade.Facade, error) {
+	id := context.ID()
+	auth := context.Auth()
+	resources := context.Resources()
+
 	if !isAgent(auth) {
 		return nil, common.ErrPerm
 	}
@@ -197,10 +209,14 @@ func (w *srvStringsWatcher) Stop() error {
 type srvRelationUnitsWatcher struct {
 	watcher   state.RelationUnitsWatcher
 	id        string
-	resources *common.Resources
+	resources facade.Resources
 }
 
-func newRelationUnitsWatcher(st *state.State, resources *common.Resources, auth common.Authorizer, id string) (interface{}, error) {
+func newRelationUnitsWatcher(context facade.Context) (facade.Facade, error) {
+	id := context.ID()
+	auth := context.Auth()
+	resources := context.Resources()
+
 	if !isAgent(auth) {
 		return nil, common.ErrPerm
 	}
@@ -246,27 +262,26 @@ func (w *srvRelationUnitsWatcher) Stop() error {
 type srvMachineStorageIdsWatcher struct {
 	watcher   state.StringsWatcher
 	id        string
-	resources *common.Resources
+	resources facade.Resources
 	parser    func([]string) ([]params.MachineStorageId, error)
 }
 
-func newVolumeAttachmentsWatcher(
-	st *state.State,
-	resources *common.Resources,
-	auth common.Authorizer,
-	id string,
-) (interface{}, error) {
+func newVolumeAttachmentsWatcher(context facade.Context) (facade.Facade, error) {
+	id := context.ID()
+	auth := context.Auth()
+	resources := context.Resources()
+	st := context.State()
+
 	return newMachineStorageIdsWatcher(
 		st, resources, auth, id, storagecommon.ParseVolumeAttachmentIds,
 	)
 }
 
-func newFilesystemAttachmentsWatcher(
-	st *state.State,
-	resources *common.Resources,
-	auth common.Authorizer,
-	id string,
-) (interface{}, error) {
+func newFilesystemAttachmentsWatcher(context facade.Context) (facade.Facade, error) {
+	id := context.ID()
+	auth := context.Auth()
+	resources := context.Resources()
+	st := context.State()
 	return newMachineStorageIdsWatcher(
 		st, resources, auth, id, storagecommon.ParseFilesystemAttachmentIds,
 	)
@@ -274,11 +289,11 @@ func newFilesystemAttachmentsWatcher(
 
 func newMachineStorageIdsWatcher(
 	st *state.State,
-	resources *common.Resources,
-	auth common.Authorizer,
+	resources facade.Resources,
+	auth facade.Authorizer,
 	id string,
 	parser func([]string) ([]params.MachineStorageId, error),
-) (interface{}, error) {
+) (facade.Facade, error) {
 	if !isAgent(auth) {
 		return nil, common.ErrPerm
 	}
@@ -332,13 +347,16 @@ type EntitiesWatcher interface {
 // sending the changes as a list of strings, which could be transformed
 // from state entity ids to their corresponding entity tags.
 type srvEntitiesWatcher struct {
-	st        *state.State
-	resources *common.Resources
+	resources facade.Resources
 	id        string
 	watcher   EntitiesWatcher
 }
 
-func newEntitiesWatcher(st *state.State, resources *common.Resources, auth common.Authorizer, id string) (interface{}, error) {
+func newEntitiesWatcher(context facade.Context) (facade.Facade, error) {
+	id := context.ID()
+	auth := context.Auth()
+	resources := context.Resources()
+
 	if !isAgent(auth) {
 		return nil, common.ErrPerm
 	}
@@ -347,7 +365,6 @@ func newEntitiesWatcher(st *state.State, resources *common.Resources, auth commo
 		return nil, common.ErrUnknownWatcher
 	}
 	return &srvEntitiesWatcher{
-		st:        st,
 		resources: resources,
 		id:        id,
 		watcher:   watcher,
@@ -391,12 +408,12 @@ type migrationBackend interface {
 	ControllerConfig() (controller.Config, error)
 }
 
-func newMigrationStatusWatcher(
-	st *state.State,
-	resources *common.Resources,
-	auth common.Authorizer,
-	id string,
-) (interface{}, error) {
+func newMigrationStatusWatcher(context facade.Context) (facade.Facade, error) {
+	id := context.ID()
+	auth := context.Auth()
+	resources := context.Resources()
+	st := context.State()
+
 	if !(auth.AuthMachineAgent() || auth.AuthUnitAgent()) {
 		return nil, common.ErrPerm
 	}
@@ -415,7 +432,7 @@ func newMigrationStatusWatcher(
 type srvMigrationStatusWatcher struct {
 	watcher   state.NotifyWatcher
 	id        string
-	resources *common.Resources
+	resources facade.Resources
 	st        migrationBackend
 }
 

--- a/apiserver/watcher_test.go
+++ b/apiserver/watcher_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/controller"
@@ -40,7 +41,11 @@ func (s *watcherSuite) SetUpTest(c *gc.C) {
 func (s *watcherSuite) getFacade(c *gc.C, name string, version int, id string) interface{} {
 	factory, err := common.Facades.GetFactory(name, version)
 	c.Assert(err, jc.ErrorIsNil)
-	facade, err := factory(nil, s.resources, s.authorizer, id)
+	facade, err := factory(facadetest.Context{
+		Resources_: s.resources,
+		Auth_:      s.authorizer,
+		ID_:        id,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	return facade
 }
@@ -124,7 +129,11 @@ func (s *watcherSuite) TestMigrationStatusWatcherNotAgent(c *gc.C) {
 
 	factory, err := common.Facades.GetFactory("MigrationStatusWatcher", 1)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = factory(nil, s.resources, s.authorizer, id)
+	_, err = factory(facadetest.Context{
+		Resources_: s.resources,
+		Auth_:      s.authorizer,
+		ID_:        id,
+	})
 	c.Assert(err, gc.Equals, common.ErrPerm)
 }
 

--- a/component/all/payload.go
+++ b/component/all/payload.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/cmd/juju/commands"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/payload"
@@ -43,7 +44,7 @@ func (c payloads) registerForClient() error {
 	return nil
 }
 
-func (payloads) newPublicFacade(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*server.PublicAPI, error) {
+func (payloads) newPublicFacade(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*server.PublicAPI, error) {
 	up, err := st.ModelPayloads()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/resource/resourceadapters/apiserver.go
+++ b/resource/resourceadapters/apiserver.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/apihttp"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/resource"
 	internalserver "github.com/juju/juju/resource/api/private/server"
 	"github.com/juju/juju/resource/api/server"
@@ -19,7 +20,7 @@ import (
 
 // NewPublicFacade provides the public API facade for resources. It is
 // passed into common.RegisterStandardFacade.
-func NewPublicFacade(st *corestate.State, _ *common.Resources, authorizer common.Authorizer) (*server.Facade, error) {
+func NewPublicFacade(st *corestate.State, _ facade.Resources, authorizer facade.Authorizer) (*server.Facade, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}


### PR DESCRIPTION
...and introduce facade.Context, used by the new facade.Factory type.

The global registry remains in place; and RegisterStandardFacade et al
work as they did before; but individual facades can be easily converted
to accept a Context, and this opens the door to facades that can read
and write mongodb data, sanely, without requiring a full *State.

Previously reviewed at http://reviews.vapour.ws/r/5042/

(Review request: http://reviews.vapour.ws/r/5137/)