### PR TITLE
worker/reboot: use correct DataDir

### DIFF
--- a/cmd/jujud/agent/engine_test.go
+++ b/cmd/jujud/agent/engine_test.go
@@ -112,7 +112,7 @@ var (
 		"machine-action-runner",
 		"machiner",
 		"proxy-config-updater",
-		// "reboot-executor", not stable, fails due to lp:1588186
+		"reboot-executor",
 		"ssh-authkeys-updater",
 		"storage-provisioner",
 		"unconverted-api-workers",

--- a/worker/reboot/manifold.go
+++ b/worker/reboot/manifold.go
@@ -38,11 +38,12 @@ func newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	lock, err := cmdutil.HookExecutionLock(cmdutil.DataDir)
+	config := a.CurrentConfig()
+	lock, err := cmdutil.HookExecutionLock(config.DataDir())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	w, err := NewReboot(rebootState, a.CurrentConfig(), lock)
+	w, err := NewReboot(rebootState, lock)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot start reboot worker")
 	}

--- a/worker/reboot/package_test.go
+++ b/worker/reboot/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package reboot_test
+
+import (
+	"testing"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+func TestPackage(t *testing.T) {
+	coretesting.MgoTestPackage(t)
+}

--- a/worker/reboot/reboot.go
+++ b/worker/reboot/reboot.go
@@ -7,10 +7,8 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/fslock"
-	"gopkg.in/juju/names.v2"
 	"launchpad.net/tomb"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/reboot"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/watcher"
@@ -29,18 +27,12 @@ const RebootMessage = "preparing for reboot"
 type Reboot struct {
 	tomb        tomb.Tomb
 	st          reboot.State
-	tag         names.MachineTag
 	machineLock *fslock.Lock
 }
 
-func NewReboot(st reboot.State, agentConfig agent.Config, machineLock *fslock.Lock) (worker.Worker, error) {
-	tag, ok := agentConfig.Tag().(names.MachineTag)
-	if !ok {
-		return nil, errors.Errorf("Expected names.MachineTag, got %T: %v", agentConfig.Tag(), agentConfig.Tag())
-	}
+func NewReboot(st reboot.State, machineLock *fslock.Lock) (worker.Worker, error) {
 	r := &Reboot{
 		st:          st,
-		tag:         tag,
 		machineLock: machineLock,
 	}
 	w, err := watcher.NewNotifyWorker(watcher.NotifyConfig{

--- a/worker/reboot/reboot_test.go
+++ b/worker/reboot/reboot_test.go
@@ -4,8 +4,6 @@
 package reboot_test
 
 import (
-	stdtesting "testing"
-
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/fslock"
@@ -17,20 +15,9 @@ import (
 	"github.com/juju/juju/instance"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
-	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/reboot"
 )
-
-func TestPackage(t *stdtesting.T) {
-	coretesting.MgoTestPackage(t)
-}
-
-type machines struct {
-	machine     *state.Machine
-	stateAPI    api.Connection
-	rebootState apireboot.State
-}
 
 type rebootSuite struct {
 	jujutesting.JujuConnSuite
@@ -87,14 +74,14 @@ func (s *rebootSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *rebootSuite) TestStartStop(c *gc.C) {
-	worker, err := reboot.NewReboot(s.rebootState, s.AgentConfigForTag(c, s.machine.Tag()), s.lock)
+	worker, err := reboot.NewReboot(s.rebootState, s.lock)
 	c.Assert(err, jc.ErrorIsNil)
 	worker.Kill()
 	c.Assert(worker.Wait(), gc.IsNil)
 }
 
 func (s *rebootSuite) TestWorkerCatchesRebootEvent(c *gc.C) {
-	wrk, err := reboot.NewReboot(s.rebootState, s.AgentConfigForTag(c, s.machine.Tag()), s.lock)
+	wrk, err := reboot.NewReboot(s.rebootState, s.lock)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.rebootState.RequestReboot()
 	c.Assert(err, jc.ErrorIsNil)
@@ -102,7 +89,7 @@ func (s *rebootSuite) TestWorkerCatchesRebootEvent(c *gc.C) {
 }
 
 func (s *rebootSuite) TestContainerCatchesParentFlag(c *gc.C) {
-	wrk, err := reboot.NewReboot(s.ctRebootState, s.AgentConfigForTag(c, s.ct.Tag()), s.lock)
+	wrk, err := reboot.NewReboot(s.ctRebootState, s.lock)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.rebootState.RequestReboot()
 	c.Assert(err, jc.ErrorIsNil)
@@ -112,7 +99,7 @@ func (s *rebootSuite) TestContainerCatchesParentFlag(c *gc.C) {
 func (s *rebootSuite) TestCleanupIsDoneOnBoot(c *gc.C) {
 	s.lock.Lock(reboot.RebootMessage)
 
-	wrk, err := reboot.NewReboot(s.rebootState, s.AgentConfigForTag(c, s.machine.Tag()), s.lock)
+	wrk, err := reboot.NewReboot(s.rebootState, s.lock)
 	c.Assert(err, jc.ErrorIsNil)
 	wrk.Kill()
 	c.Assert(wrk.Wait(), gc.IsNil)


### PR DESCRIPTION
The reboot manifold was always using cmdutil.DataDir, instead of one
derived from agent config; fixes lp:1588186, lp:1594665.

Also dropped untested and unnecessary is-this-a-machine checks in reboot
worker; added package_test.go