### PR TITLE
Change content and formatting of add-model message

### DIFF
--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -150,7 +150,7 @@ func (s *cmdControllerSuite) TestAddModel(c *gc.C) {
 	// a config value for 'controller'.
 	context := s.run(c, "add-model", "new-model", "authorized-keys=fake-key", "controller=false")
 	c.Check(testing.Stdout(context), gc.Equals, "")
-	c.Check(testing.Stderr(context), gc.Equals, "added model \"new-model\"\n")
+	c.Check(testing.Stderr(context), gc.Equals, "Added 'new-model' model for user 'admin'\n")
 
 	// Make sure that the saved server details are sufficient to connect
 	// to the api server.


### PR DESCRIPTION
Format is now:
"Added 'modelName' model [on cloudName/regionName] [with credential 'credentialName'] for user 'userNamePart'

Requirements:
  * opening capitalization ('Added')
  * use of ''
  * cloud/region
  * explicit naming of credential and user

Fixes: #1594335

QA steps:

  * `juju add-model <model name>` in local/lxd provider controller, and see that the output message includes cloud/region and username, in the required format (above)
  * `juju add-model <model name> --credential <creds> --owner <some user>`  in a cloud provider controller, and see credential name also included in the output message

(Review request: http://reviews.vapour.ws/r/5141/)