### PR TITLE
Revert a previous change to only open ports on controllers

### DIFF
--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -969,6 +969,9 @@ func (e *Environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 	var apiPort int
 	if args.InstanceConfig.Controller != nil {
 		apiPort = args.InstanceConfig.Controller.Config.APIPort()
+	} else {
+		// All ports are the same so pick the first.
+		apiPort = args.InstanceConfig.APIInfo.Ports()[0]
 	}
 	var groupNames = make([]nova.SecurityGroupName, 0)
 	groups, err := e.firewaller.SetUpGroups(args.ControllerUUID, args.InstanceConfig.MachineId, apiPort)


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1595278

It turns out the api port needs to be set up on all machines, not just controllers. Revert a previous change which cleaned up up port management, but also only opened the port on controllers.

(Review request: http://reviews.vapour.ws/r/5143/)