### PR TITLE
Filter API methods to Admin user.

### DIFF
--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/manual"
@@ -82,8 +83,8 @@ func (s *serverSuite) TestModelUsersInfo(c *gc.C) {
 
 	localUser1 := s.makeLocalModelUser(c, "ralphdoe", "Ralph Doe")
 	localUser2 := s.makeLocalModelUser(c, "samsmith", "Sam Smith")
-	remoteUser1 := s.Factory.MakeModelUser(c, &factory.ModelUserParams{User: "bobjohns@ubuntuone", DisplayName: "Bob Johns", Access: state.WriteAccess})
-	remoteUser2 := s.Factory.MakeModelUser(c, &factory.ModelUserParams{User: "nicshaw@idprovider", DisplayName: "Nic Shaw", Access: state.WriteAccess})
+	remoteUser1 := s.Factory.MakeModelUser(c, &factory.ModelUserParams{User: "bobjohns@ubuntuone", DisplayName: "Bob Johns", Access: description.WriteAccess})
+	remoteUser2 := s.Factory.MakeModelUser(c, &factory.ModelUserParams{User: "nicshaw@idprovider", DisplayName: "Nic Shaw", Access: description.WriteAccess})
 
 	results, err := s.client.ModelUserInfo()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/client_auth_root.go
+++ b/apiserver/client_auth_root.go
@@ -5,6 +5,7 @@ package apiserver
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/rpc"
@@ -45,6 +46,7 @@ func (r *clientAuthRoot) FindMethod(rootName string, version int, methodName str
 
 	// Check if our call requires higher access than the user has.
 	if doesCallRequireAdmin(rootName, methodName) && !r.user.IsAdmin() {
+		logger.Debugf("THE METHOD %s.%s MIGHT REQUIRE ADMIN", rootName, methodName)
 		return nil, errors.Trace(common.ErrPerm)
 	}
 
@@ -61,11 +63,26 @@ func isCallAllowableByReadOnlyUser(facade, _ /*method*/ string) bool {
 	return restrictedRootNames.Contains(facade)
 }
 
+var modelManagerMethods = set.NewStrings(
+	"ModifyModelAccess",
+	"CreateModel",
+)
+
+var controllerMethods = set.NewStrings(
+	"DestroyController",
+)
+
 func doesCallRequireAdmin(facade, method string) bool {
 	// TODO(perrito666) This should filter adding users to controllers.
 	// TODO(perrito666) Add an exaustive list of facades/methods that are
 	// admin only and put them in an authoritative source to be re-used.
 	// TODO(perrito666) This is a stub, the idea is to maintain the current
 	// status of permissions until we decide what goes to admin only.
+	switch facade {
+	case "ModelManager":
+		return modelManagerMethods.Contains(method)
+	case "Controller":
+		return controllerMethods.Contains(method)
+	}
 	return false
 }

--- a/apiserver/common/modeluser.go
+++ b/apiserver/common/modeluser.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/state"
 )
 
@@ -50,4 +51,17 @@ func ModelUserInfo(user ModelUser) (params.ModelUserInfo, error) {
 		Access:         access,
 	}
 	return userInfo, nil
+}
+
+// StateToParamsModelAccess converts description.Access to params.AccessPermission.
+func StateToParamsModelAccess(stateAccess description.Access) (params.ModelAccessPermission, error) {
+	switch stateAccess {
+	case description.ReadAccess:
+		return params.ModelReadAccess, nil
+	case description.WriteAccess:
+		return params.ModelWriteAccess, nil
+	case description.AdminAccess:
+		return params.ModelAdminAccess, nil
+	}
+	return "", errors.Errorf("invalid model access permission %q", stateAccess)
 }

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -20,6 +20,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
@@ -58,15 +59,15 @@ func (s *modelInfoSuite) SetUpTest(c *gc.C) {
 		},
 		users: []*mockModelUser{{
 			userName: "admin",
-			access:   state.AdminAccess,
+			access:   description.AdminAccess,
 		}, {
 			userName:    "bob@local",
 			displayName: "Bob",
-			access:      state.ReadAccess,
+			access:      description.ReadAccess,
 		}, {
 			userName:    "charlotte@local",
 			displayName: "Charlotte",
-			access:      state.ReadAccess,
+			access:      description.ReadAccess,
 		}},
 	}
 	var err error
@@ -240,7 +241,7 @@ func (st *mockState) IsControllerAdministrator(user names.UserTag) (bool, error)
 	}
 
 	for _, u := range st.controllerModel.users {
-		if user.Name() == u.UserName() && u.access == state.AdminAccess {
+		if user.Name() == u.UserName() && u.access == description.AdminAccess {
 			nextErr := st.NextErr()
 			if user.Name() != "admin" {
 				panic(user.Name())
@@ -402,25 +403,25 @@ type mockModelUser struct {
 	userName       string
 	displayName    string
 	lastConnection time.Time
-	access         state.Access
+	access         description.Access
 }
 
 func (u *mockModelUser) IsAdmin() bool {
 	u.MethodCall(u, "IsAdmin")
 	u.PopNoErr()
-	return u.access == state.AdminAccess
+	return u.access == description.AdminAccess
 }
 
 func (u *mockModelUser) IsReadOnly() bool {
 	u.MethodCall(u, "IsReadOnly")
 	u.PopNoErr()
-	return u.access == state.ReadAccess
+	return u.access == description.ReadAccess
 }
 
 func (u *mockModelUser) IsReadWrite() bool {
 	u.MethodCall(u, "IsReadWrite")
 	u.PopNoErr()
-	return u.access == state.WriteAccess
+	return u.access == description.WriteAccess
 }
 
 func (u *mockModelUser) DisplayName() string {

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller/modelmanager"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/juju/permission"
 	"github.com/juju/juju/state"
@@ -451,15 +452,15 @@ func (m *ModelManagerAPI) ModifyModelAccess(args params.ModifyModelAccessRequest
 
 // resolveStateAccess returns the state representation of the logical model
 // access type.
-func resolveStateAccess(access permission.ModelAccess) (state.Access, error) {
-	var fail state.Access
+func resolveStateAccess(access permission.ModelAccess) (description.Access, error) {
+	var fail description.Access
 	switch access {
 	case permission.ModelAdminAccess:
-		return state.AdminAccess, nil
+		return description.AdminAccess, nil
 	case permission.ModelReadAccess:
-		return state.ReadAccess, nil
+		return description.ReadAccess, nil
 	case permission.ModelWriteAccess:
-		return state.WriteAccess, nil
+		return description.WriteAccess, nil
 	}
 	logger.Errorf("invalid access permission: %+v", access)
 	return fail, errors.Errorf("invalid access permission")
@@ -509,6 +510,11 @@ func ChangeModelAccess(accessor common.ModelManagerBackend, modelTag names.Model
 		return errors.Annotate(err, "could not resolve model access")
 	}
 
+	// Default to read access if not otherwise specified.
+	if stateAccess == description.UndefinedAccess {
+		stateAccess = description.ReadAccess
+	}
+
 	switch action {
 	case params.GrantModelAccess:
 		_, err = st.AddModelUser(state.ModelUserSpec{User: targetUserTag, CreatedBy: apiUser, Access: stateAccess})
@@ -537,25 +543,25 @@ func ChangeModelAccess(accessor common.ModelManagerBackend, modelTag names.Model
 
 	case params.RevokeModelAccess:
 		switch stateAccess {
-		case state.ReadAccess:
+		case description.ReadAccess:
 			// Revoking read access removes all access.
 			err := st.RemoveModelUser(targetUserTag)
 			return errors.Annotate(err, "could not revoke model access")
-		case state.WriteAccess:
+		case description.WriteAccess:
 			// Revoking write access sets read-only.
 			modelUser, err := st.ModelUser(targetUserTag)
 			if err != nil {
 				return errors.Annotate(err, "could not look up model access for user")
 			}
-			err = modelUser.SetAccess(state.ReadAccess)
+			err = modelUser.SetAccess(description.ReadAccess)
 			return errors.Annotate(err, "could not set model access to read-only")
-		case state.AdminAccess:
+		case description.AdminAccess:
 			// Revoking admin access sets read-write.
 			modelUser, err := st.ModelUser(targetUserTag)
 			if err != nil {
 				return errors.Annotate(err, "could not look up model access for user")
 			}
-			err = modelUser.SetAccess(state.WriteAccess)
+			err = modelUser.SetAccess(description.WriteAccess)
 			return errors.Annotate(err, "could not set model access to read-write")
 
 		default:

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -73,10 +74,10 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 			},
 			users: []*mockModelUser{{
 				userName: "admin",
-				access:   state.AdminAccess,
+				access:   description.AdminAccess,
 			}, {
 				userName: "otheruser",
-				access:   state.AdminAccess,
+				access:   description.AdminAccess,
 			}},
 		},
 		model: &mockModel{
@@ -89,10 +90,10 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 			},
 			users: []*mockModelUser{{
 				userName: "admin",
-				access:   state.AdminAccess,
+				access:   description.AdminAccess,
 			}, {
 				userName: "otheruser",
-				access:   state.AdminAccess,
+				access:   description.AdminAccess,
 			}},
 		},
 		creds: map[string]cloud.Credential{
@@ -606,7 +607,7 @@ func (s *modelManagerStateSuite) TestGrantMissingModelFails(c *gc.C) {
 
 func (s *modelManagerStateSuite) TestRevokeAdminLeavesReadAccess(c *gc.C) {
 	s.setAPIUser(c, s.AdminUserTag(c))
-	user := s.Factory.MakeModelUser(c, &factory.ModelUserParams{Access: state.WriteAccess})
+	user := s.Factory.MakeModelUser(c, &factory.ModelUserParams{Access: description.WriteAccess})
 
 	err := s.revoke(c, user.UserTag(), params.ModelWriteAccess, user.ModelTag())
 	c.Assert(err, gc.IsNil)
@@ -713,7 +714,7 @@ func (s *modelManagerStateSuite) TestGrantModelIncreaseAccess(c *gc.C) {
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
 	stFactory := factory.NewFactory(st)
-	user := stFactory.MakeModelUser(c, &factory.ModelUserParams{Access: state.ReadAccess})
+	user := stFactory.MakeModelUser(c, &factory.ModelUserParams{Access: description.ReadAccess})
 
 	err := s.grant(c, user.UserTag(), params.ModelWriteAccess, st.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
@@ -743,7 +744,7 @@ func (s *modelManagerStateSuite) TestGrantToModelReadAccess(c *gc.C) {
 	defer st.Close()
 	stFactory := factory.NewFactory(st)
 	stFactory.MakeModelUser(c, &factory.ModelUserParams{
-		User: apiUser.Canonical(), Access: state.ReadAccess})
+		User: apiUser.Canonical(), Access: description.ReadAccess})
 
 	other := names.NewUserTag("other@remote")
 	err := s.grant(c, other, params.ModelReadAccess, st.ModelTag())
@@ -758,7 +759,7 @@ func (s *modelManagerStateSuite) TestGrantToModelWriteAccess(c *gc.C) {
 	defer st.Close()
 	stFactory := factory.NewFactory(st)
 	stFactory.MakeModelUser(c, &factory.ModelUserParams{
-		User: apiUser.Canonical(), Access: state.AdminAccess})
+		User: apiUser.Canonical(), Access: description.AdminAccess})
 
 	other := names.NewUserTag("other@remote")
 	err := s.grant(c, other, params.ModelReadAccess, st.ModelTag())

--- a/core/description/access.go
+++ b/core/description/access.go
@@ -1,0 +1,75 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+)
+
+// Access represents a level of access.
+type Access string
+
+const (
+	// UndefinedAccess is not a valid access type. It is the value
+	// used when access is not defined at all.
+	UndefinedAccess Access = ""
+
+	// ReadAccess allows a user to read information about a permission subject,
+	// without being able to make any changes.
+	ReadAccess Access = "read"
+
+	// WriteAccess allows a user to make changes to a permission subject.
+	WriteAccess Access = "write"
+
+	// AdminAccess allows a user full control over the subject.
+	AdminAccess Access = "admin"
+)
+
+// Validate returns error if the current is not a valid access level.
+func (a Access) Validate() error {
+	switch a {
+	case UndefinedAccess, AdminAccess, ReadAccess, WriteAccess:
+		return nil
+	}
+	return errors.NotValidf("access level %s", a)
+}
+
+// IsGreaterAccess returns true if the provided access is greater than
+// the current.
+func (a Access) IsGreaterAccess(access Access) bool {
+	switch a {
+	case UndefinedAccess:
+		return access == ReadAccess ||
+			access == WriteAccess ||
+			access == AdminAccess
+	case ReadAccess:
+		return access == WriteAccess ||
+			access == AdminAccess
+	case WriteAccess:
+		return access == AdminAccess
+	}
+	return false
+}
+
+// accessField returns a Checker that accepts a string value only and returns
+// it unprocessed.
+func accessField() schema.Checker {
+	return accessC{}
+}
+
+type accessC struct{}
+
+func (c accessC) Coerce(v interface{}, path []string) (interface{}, error) {
+	s := schema.String()
+	in, err := s.Coerce(v, path)
+	if err != nil {
+		return nil, err
+	}
+	access := Access(in.(string))
+	if err := access.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return access, nil
+}

--- a/core/description/user.go
+++ b/core/description/user.go
@@ -22,7 +22,7 @@ type UserArgs struct {
 	CreatedBy      names.UserTag
 	DateCreated    time.Time
 	LastConnection time.Time
-	Access         string
+	Access         Access
 }
 
 func newUser(args UserArgs) *user {
@@ -45,7 +45,7 @@ type user struct {
 	DisplayName_ string    `yaml:"display-name,omitempty"`
 	CreatedBy_   string    `yaml:"created-by"`
 	DateCreated_ time.Time `yaml:"date-created"`
-	Access_      string    `yaml:"access"`
+	Access_      Access    `yaml:"access"`
 	// Can't use omitempty with time.Time, it just doesn't work,
 	// so use a pointer in the struct.
 	LastConnection_ *time.Time `yaml:"last-connection,omitempty"`
@@ -82,20 +82,17 @@ func (u *user) LastConnection() time.Time {
 
 // IsRead implements User.
 func (u *user) IsReadOnly() bool {
-	// string used here to avoid dependency on state.
-	return u.Access_ == "read"
+	return u.Access_ == ReadAccess
 }
 
 // IsReadWrite implements User.
 func (u *user) IsReadWrite() bool {
-	// string used here to avoid dependency on state.
-	return u.Access_ == "write"
+	return u.Access_ == WriteAccess
 }
 
 // IsAdmin implements User.
 func (u *user) IsAdmin() bool {
-	// string used here to avoid dependency on state.
-	return u.Access_ == "admin"
+	return u.Access_ == AdminAccess
 }
 
 func importUsers(source map[string]interface{}) ([]*user, error) {
@@ -145,7 +142,7 @@ func importUserV1(source map[string]interface{}) (*user, error) {
 		"read-only":       schema.Bool(),
 		"date-created":    schema.Time(),
 		"last-connection": schema.Time(),
-		"access":          schema.String(),
+		"access":          accessField(),
 	}
 
 	// Some values don't have to be there.
@@ -168,7 +165,7 @@ func importUserV1(source map[string]interface{}) (*user, error) {
 		DisplayName_: valid["display-name"].(string),
 		CreatedBy_:   valid["created-by"].(string),
 		DateCreated_: valid["date-created"].(time.Time),
-		Access_:      valid["access"].(string),
+		Access_:      valid["access"].(Access),
 	}
 
 	lastConn := valid["last-connection"].(time.Time)

--- a/core/description/user_test.go
+++ b/core/description/user_test.go
@@ -70,7 +70,7 @@ func (*UserSerializationSuite) TestParsingSerializedData(c *gc.C) {
 				DisplayName_: "A read only user",
 				CreatedBy_:   "admin@local",
 				DateCreated_: time.Date(2015, 10, 9, 12, 34, 56, 0, time.UTC),
-				Access_:      "read",
+				Access_:      ReadAccess,
 			},
 		},
 	}

--- a/featuretests/cmd_juju_model_test.go
+++ b/featuretests/cmd_juju_model_test.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/cmd/juju/commands"
+	"github.com/juju/juju/core/description"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
@@ -59,7 +60,7 @@ func (s *cmdModelSuite) TestRevokeModelCmdStack(c *gc.C) {
 	// Firstly share a model with a user
 	username := "bar@ubuntuone"
 	s.Factory.MakeModelUser(c, &factory.ModelUserParams{
-		User: username, Access: state.ReadAccess})
+		User: username, Access: description.ReadAccess})
 
 	// Because we are calling into juju through the main command,
 	// and the main command adds a warning logging writer, we need

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -159,11 +159,11 @@ func (e *exporter) modelUsers() error {
 		var access string
 		switch {
 		case user.IsAdmin():
-			access = string(AdminAccess)
+			access = string(description.AdminAccess)
 		case user.IsReadWrite():
-			access = string(WriteAccess)
+			access = string(description.WriteAccess)
 		default:
-			access = string(ReadAccess)
+			access = string(description.ReadAccess)
 
 		}
 
@@ -174,7 +174,7 @@ func (e *exporter) modelUsers() error {
 			CreatedBy:      names.NewUserTag(user.CreatedBy()),
 			DateCreated:    user.DateCreated(),
 			LastConnection: lastConn,
-			Access:         access,
+			Access:         stringToAccess(access),
 		}
 		e.model.AddUser(arg)
 	}

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -152,7 +152,7 @@ func (s *MigrationExportSuite) TestModelUsers(c *gc.C) {
 	bob, err := s.State.AddModelUser(state.ModelUserSpec{
 		User:      bobTag,
 		CreatedBy: s.Owner,
-		Access:    state.ReadAccess,
+		Access:    description.ReadAccess,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = state.UpdateModelUserLastConnection(bob, lastConnection)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -188,14 +188,14 @@ func (i *importer) modelUsers() error {
 	modelUUID := i.dbModel.UUID()
 	var ops []txn.Op
 	for _, user := range users {
-		var access Access
+		var access description.Access
 		switch {
 		case user.IsReadOnly():
-			access = ReadAccess
+			access = description.ReadAccess
 		case user.IsReadWrite():
-			access = WriteAccess
+			access = description.WriteAccess
 		default:
-			access = AdminAccess
+			access = description.AdminAccess
 		}
 		ops = append(ops, createModelUserOps(
 			modelUUID,

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -134,9 +134,9 @@ func (s *MigrationImportSuite) TestNewModel(c *gc.C) {
 }
 
 func (s *MigrationImportSuite) newModelUser(c *gc.C, name string, readOnly bool, lastConnection time.Time) *state.ModelUser {
-	access := state.AdminAccess
+	access := description.AdminAccess
 	if readOnly {
-		access = state.ReadAccess
+		access = description.ReadAccess
 	}
 	user, err := s.State.AddModelUser(state.ModelUserSpec{
 		User:      names.NewUserTag(name),

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	jujutxn "github.com/juju/txn"
+	"github.com/juju/juju/core/description"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -111,32 +111,33 @@ func (e *ModelUser) IsReadOnly() bool {
 }
 
 // IsAdmin is a convenience method that
-// returns whether or not the user has AdminAccess.
+// returns whether or not the user has description.AdminAccess.
 func (e *ModelUser) IsAdmin() bool {
 	return e.modelPermission.isAdmin()
 }
 
 // IsReadWrite is a convenience method that
-// returns whether or not the user has WriteAccess.
+// returns whether or not the user has description.WriteAccess.
 func (e *ModelUser) IsReadWrite() bool {
 	return e.modelPermission.isReadWrite()
 }
 
 // IsGreaterAccess returns true if provided access is higher than
 // the current one.
-func (e *ModelUser) IsGreaterAccess(a Access) bool {
+func (e *ModelUser) IsGreaterAccess(a description.Access) bool {
 	return e.modelPermission.isGreaterAccess(a)
 }
 
 // SetAccess changes the user's access permissions on the model.
-func (e *ModelUser) SetAccess(access Access) error {
-	switch access {
-	case ReadAccess, AdminAccess, WriteAccess:
-	default:
-		return errors.Errorf("invalid model access %q", access)
+func (e *ModelUser) SetAccess(access description.Access) error {
+	if err := access.Validate(); err != nil {
+		return errors.Trace(err)
 	}
 	op := updatePermissionOp(modelGlobalKey, e.globalKey(), access)
 	err := e.st.runTransaction([]txn.Op{op})
+	if err == txn.ErrAborted {
+		return errors.Errorf("no existing permissions found for %q", e.UserName())
+	}
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -205,8 +206,8 @@ func (e *ModelUser) updateLastConnection(when time.Time) error {
 }
 
 func modelUserGlobalKey(userID string) string {
-	// mu stands for model user.
-	return fmt.Sprintf("mu#%s", userID)
+	// e model us user <name> key.
+	return fmt.Sprintf("%s#us#%s", modelGlobalKey, userID)
 }
 
 func (e *ModelUser) globalKey() string {
@@ -241,7 +242,7 @@ type ModelUserSpec struct {
 	User        names.UserTag
 	CreatedBy   names.UserTag
 	DisplayName string
-	Access      Access
+	Access      description.Access
 }
 
 // AddModelUser adds a new user to the database.
@@ -264,17 +265,10 @@ func (st *State) AddModelUser(spec ModelUserSpec) (*ModelUser, error) {
 		}
 	}
 
-	// Default to read access if not otherwise specified.
-	if spec.Access == UndefinedAccess {
-		spec.Access = ReadAccess
-	}
-
 	modelUUID := st.ModelUUID()
-	buildTxn := func(attempt int) ([]txn.Op, error) {
-		return createModelUserOps(modelUUID, spec.User, spec.CreatedBy, spec.DisplayName, nowToTheSecond(), spec.Access), nil
-	}
-	err := st.run(buildTxn)
-	if err == jujutxn.ErrExcessiveContention {
+	ops := createModelUserOps(modelUUID, spec.User, spec.CreatedBy, spec.DisplayName, nowToTheSecond(), spec.Access)
+	err := st.runTransaction(ops)
+	if err == txn.ErrAborted {
 		err = errors.AlreadyExistsf("model user %q", spec.User.Canonical())
 	}
 	if err != nil {
@@ -289,7 +283,7 @@ func modelUserID(user names.UserTag) string {
 	return strings.ToLower(username)
 }
 
-func createModelUserOps(modelUUID string, user, createdBy names.UserTag, displayName string, dateCreated time.Time, access Access) []txn.Op {
+func createModelUserOps(modelUUID string, user, createdBy names.UserTag, displayName string, dateCreated time.Time, access description.Access) []txn.Op {
 	creatorname := createdBy.Canonical()
 	doc := &modelUserDoc{
 		ID:          modelUserID(user),
@@ -410,7 +404,7 @@ func (st *State) IsControllerAdministrator(user names.UserTag) (bool, error) {
 		{"_id", fmt.Sprintf("%s:%s", serverUUID, permissionID(modelGlobalKey, subjectGlobalKey))},
 		{"object-global-key", modelGlobalKey},
 		{"subject-global-key", subjectGlobalKey},
-		{"access", AdminAccess},
+		{"access", description.AdminAccess},
 	}).Count()
 	if err != nil {
 		return false, errors.Trace(err)

--- a/state/open.go
+++ b/state/open.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/status"
@@ -306,7 +307,7 @@ func (st *State) modelSetupOps(args ModelArgs, ControllerInheritedConfig map[str
 	isHostedModel := controllerUUID != modelUUID
 
 	modelUserOps := createModelUserOps(
-		modelUUID, args.Owner, args.Owner, args.Owner.Name(), nowToTheSecond(), AdminAccess,
+		modelUUID, args.Owner, args.Owner, args.Owner.Name(), nowToTheSecond(), description.AdminAccess,
 	)
 	ops := []txn.Op{
 		createStatusOp(st, modelGlobalKey, modelStatusDoc),

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -19,6 +19,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -51,7 +52,7 @@ type UserParams struct {
 	Creator     names.Tag
 	NoModelUser bool
 	Disabled    bool
-	Access      state.Access
+	Access      description.Access
 }
 
 // ModelUserParams defines the parameters for creating an environment user.
@@ -59,7 +60,7 @@ type ModelUserParams struct {
 	User        string
 	DisplayName string
 	CreatedBy   names.Tag
-	Access      state.Access
+	Access      description.Access
 }
 
 // CharmParams defines the parameters for creating a charm.
@@ -169,8 +170,8 @@ func (factory *Factory) MakeUser(c *gc.C, params *UserParams) *state.User {
 		c.Assert(err, jc.ErrorIsNil)
 		params.Creator = env.Owner()
 	}
-	if params.Access == state.UndefinedAccess {
-		params.Access = state.AdminAccess
+	if params.Access == description.UndefinedAccess {
+		params.Access = description.AdminAccess
 	}
 	creatorUserTag := params.Creator.(names.UserTag)
 	user, err := factory.st.AddUser(
@@ -207,8 +208,8 @@ func (factory *Factory) MakeModelUser(c *gc.C, params *ModelUserParams) *state.M
 	if params.DisplayName == "" {
 		params.DisplayName = uniqueString("display name")
 	}
-	if params.Access == state.UndefinedAccess {
-		params.Access = state.AdminAccess
+	if params.Access == description.UndefinedAccess {
+		params.Access = description.AdminAccess
 	}
 	if params.CreatedBy == nil {
 		env, err := factory.st.Model()


### PR DESCRIPTION
* Filter certain API Methods to users with Admin permission.
* Made everywhere use description.Access instead of former state.Access.
* Minor fixes to the code and tests.

(Review request: http://reviews.vapour.ws/r/5145/)