### PR TITLE
Remove the charm package dependency from apiserver/params.

### DIFF
--- a/api/action/client.go
+++ b/api/action/client.go
@@ -5,7 +5,6 @@ package action
 
 import (
 	"github.com/juju/errors"
-	"gopkg.in/juju/charm.v6-unstable"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
@@ -101,22 +100,21 @@ func (c *Client) applicationsCharmActions(arg params.Entities) (params.Applicati
 
 // ApplicationCharmActions is a single query which uses ApplicationsCharmsActions to
 // get the charm.Actions for a single Service by tag.
-func (c *Client) ApplicationCharmActions(arg params.Entity) (*charm.Actions, error) {
-	none := &charm.Actions{}
+func (c *Client) ApplicationCharmActions(arg params.Entity) (map[string]params.ActionSpec, error) {
 	tags := params.Entities{Entities: []params.Entity{{Tag: arg.Tag}}}
 	results, err := c.applicationsCharmActions(tags)
 	if err != nil {
-		return none, err
+		return nil, errors.Trace(err)
 	}
 	if len(results.Results) != 1 {
-		return none, errors.Errorf("%d results, expected 1", len(results.Results))
+		return nil, errors.Errorf("%d results, expected 1", len(results.Results))
 	}
 	result := results.Results[0]
 	if result.Error != nil {
-		return none, result.Error
+		return nil, result.Error
 	}
 	if result.ApplicationTag != arg.Tag {
-		return none, errors.Errorf("action results received for wrong application %q", result.ApplicationTag)
+		return nil, errors.Errorf("action results received for wrong application %q", result.ApplicationTag)
 	}
 	return result.Actions, nil
 }

--- a/api/action/client_test.go
+++ b/api/action/client_test.go
@@ -8,7 +8,6 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/action"
@@ -33,7 +32,7 @@ func (s *actionSuite) TestApplicationCharmActions(c *gc.C) {
 		patchResults   []params.ApplicationCharmActionsResult
 		patchErr       string
 		expectedErr    string
-		expectedResult *charm.Actions
+		expectedResult map[string]params.ActionSpec
 	}{{
 		description: "result from wrong service",
 		patchResults: []params.ApplicationCharmActionsResult{
@@ -73,25 +72,21 @@ func (s *actionSuite) TestApplicationCharmActions(c *gc.C) {
 		patchResults: []params.ApplicationCharmActionsResult{
 			{
 				ApplicationTag: names.NewApplicationTag("foo").String(),
-				Actions: &charm.Actions{
-					ActionSpecs: map[string]charm.ActionSpec{
-						"action": {
-							Description: "description",
-							Params: map[string]interface{}{
-								"foo": "bar",
-							},
+				Actions: map[string]params.ActionSpec{
+					"action": {
+						Description: "description",
+						Params: map[string]interface{}{
+							"foo": "bar",
 						},
 					},
 				},
 			},
 		},
-		expectedResult: &charm.Actions{
-			ActionSpecs: map[string]charm.ActionSpec{
-				"action": {
-					Description: "description",
-					Params: map[string]interface{}{
-						"foo": "bar",
-					},
+		expectedResult: map[string]params.ActionSpec{
+			"action": {
+				Description: "description",
+				Params: map[string]interface{}{
+					"foo": "bar",
 				},
 			},
 		},

--- a/api/client.go
+++ b/api/client.go
@@ -439,7 +439,7 @@ func (c *Client) AddCharmWithAuthorization(curl *charm.URL, channel csparams.Cha
 // ResolveCharm resolves the best available charm URLs with series, for charm
 // locations without a series specified.
 func (c *Client) ResolveCharm(ref *charm.URL) (*charm.URL, error) {
-	args := params.ResolveCharms{References: []charm.URL{*ref}}
+	args := params.ResolveCharms{References: []string{ref.String()}}
 	result := new(params.ResolveCharmResults)
 	if err := c.facade.FacadeCall("ResolveCharms", args, result); err != nil {
 		return nil, err
@@ -451,7 +451,11 @@ func (c *Client) ResolveCharm(ref *charm.URL) (*charm.URL, error) {
 	if urlInfo.Error != "" {
 		return nil, errors.New(urlInfo.Error)
 	}
-	return urlInfo.URL, nil
+	url, err := charm.ParseURL(urlInfo.URL)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return url, nil
 }
 
 // OpenCharm streams out the identified charm from the controller via

--- a/apiserver/action/action.go
+++ b/apiserver/action/action.go
@@ -227,7 +227,16 @@ func (a *ActionAPI) ApplicationsCharmsActions(args params.Entities) (params.Appl
 			currentResult.Error = common.ServerError(err)
 			continue
 		}
-		currentResult.Actions = ch.Actions()
+		if actions := ch.Actions(); actions != nil {
+			charmActions := make(map[string]params.ActionSpec)
+			for key, value := range actions.ActionSpecs {
+				charmActions[key] = params.ActionSpec{
+					Description: value.Description,
+					Params:      value.Params,
+				}
+			}
+			currentResult.Actions = charmActions
+		}
 	}
 	return result, nil
 }

--- a/apiserver/action/action_test.go
+++ b/apiserver/action/action_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/action"
@@ -661,12 +660,10 @@ func (s *actionSuite) TestApplicationsCharmsActions(c *gc.C) {
 			Results: []params.ApplicationCharmActionsResult{
 				{
 					ApplicationTag: names.NewApplicationTag("dummy").String(),
-					Actions: &charm.Actions{
-						ActionSpecs: map[string]charm.ActionSpec{
-							"snapshot": {
-								Description: "Take a snapshot of the database.",
-								Params:      actionSchemas["snapshot"],
-							},
+					Actions: map[string]params.ActionSpec{
+						"snapshot": {
+							Description: "Take a snapshot of the database.",
+							Params:      actionSchemas["snapshot"],
 						},
 					},
 				},
@@ -678,12 +675,10 @@ func (s *actionSuite) TestApplicationsCharmsActions(c *gc.C) {
 			Results: []params.ApplicationCharmActionsResult{
 				{
 					ApplicationTag: names.NewApplicationTag("wordpress").String(),
-					Actions: &charm.Actions{
-						ActionSpecs: map[string]charm.ActionSpec{
-							"fakeaction": {
-								Description: "No description",
-								Params:      actionSchemas["fakeaction"],
-							},
+					Actions: map[string]params.ActionSpec{
+						"fakeaction": {
+							Description: "No description",
+							Params:      actionSchemas["fakeaction"],
 						},
 					},
 				},

--- a/apiserver/application/application.go
+++ b/apiserver/application/application.go
@@ -545,13 +545,20 @@ func (api *API) AddRelation(args params.AddRelation) (params.AddRelationResults,
 	if err != nil {
 		return params.AddRelationResults{}, err
 	}
-	outEps := make(map[string]charm.Relation)
+	outEps := make(map[string]params.CharmRelation)
 	for _, inEp := range inEps {
 		outEp, err := rel.Endpoint(inEp.ApplicationName)
 		if err != nil {
 			return params.AddRelationResults{}, err
 		}
-		outEps[inEp.ApplicationName] = outEp.Relation
+		outEps[inEp.ApplicationName] = params.CharmRelation{
+			Name:      outEp.Relation.Name,
+			Role:      string(outEp.Relation.Role),
+			Interface: outEp.Relation.Interface,
+			Optional:  outEp.Relation.Optional,
+			Limit:     outEp.Relation.Limit,
+			Scope:     string(outEp.Relation.Scope),
+		}
 	}
 	return params.AddRelationResults{Endpoints: outEps}, nil
 }

--- a/apiserver/application/application_test.go
+++ b/apiserver/application/application_test.go
@@ -2439,22 +2439,22 @@ func (s *serviceSuite) TestClientGetServiceConstraints(c *gc.C) {
 	c.Assert(result.Constraints, gc.DeepEquals, cons)
 }
 
-func (s *serviceSuite) checkEndpoints(c *gc.C, endpoints map[string]charm.Relation) {
-	c.Assert(endpoints["wordpress"], gc.DeepEquals, charm.Relation{
+func (s *serviceSuite) checkEndpoints(c *gc.C, endpoints map[string]params.CharmRelation) {
+	c.Assert(endpoints["wordpress"], gc.DeepEquals, params.CharmRelation{
 		Name:      "db",
-		Role:      charm.RelationRole("requirer"),
+		Role:      "requirer",
 		Interface: "mysql",
 		Optional:  false,
 		Limit:     1,
-		Scope:     charm.RelationScope("global"),
+		Scope:     "global",
 	})
-	c.Assert(endpoints["mysql"], gc.DeepEquals, charm.Relation{
+	c.Assert(endpoints["mysql"], gc.DeepEquals, params.CharmRelation{
 		Name:      "server",
-		Role:      charm.RelationRole("provider"),
+		Role:      "provider",
 		Interface: "mysql",
 		Optional:  false,
 		Limit:     0,
-		Scope:     charm.RelationScope("global"),
+		Scope:     "global",
 	})
 }
 

--- a/apiserver/application/charmstore.go
+++ b/apiserver/application/charmstore.go
@@ -263,11 +263,16 @@ func ResolveCharms(st *state.State, args params.ResolveCharms) (params.ResolveCh
 
 	for _, ref := range args.References {
 		result := params.ResolveCharmResult{}
-		curl, err := resolveCharm(&ref, repo)
+		curl, err := charm.ParseURL(ref)
 		if err != nil {
 			result.Error = err.Error()
 		} else {
-			result.URL = curl
+			curl, err := resolveCharm(curl, repo)
+			if err != nil {
+				result.Error = err.Error()
+			} else {
+				result.URL = curl.String()
+			}
 		}
 		results.URLs = append(results.URLs, result)
 	}

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -508,7 +508,7 @@ func (context *statusContext) processRelations() []params.RelationStatus {
 			eps = append(eps, params.EndpointStatus{
 				ApplicationName: ep.ApplicationName,
 				Name:            ep.Name,
-				Role:            ep.Role,
+				Role:            string(ep.Role),
 				Subordinate:     context.isSubordinate(&ep),
 			})
 			// these should match on both sides so use the last
@@ -519,7 +519,7 @@ func (context *statusContext) processRelations() []params.RelationStatus {
 			Id:        relation.Id(),
 			Key:       relation.String(),
 			Interface: relationInterface,
-			Scope:     scope,
+			Scope:     string(scope),
 			Endpoints: eps,
 		}
 		out = append(out, relStatus)

--- a/apiserver/params/actions.go
+++ b/apiserver/params/actions.go
@@ -3,12 +3,7 @@
 
 package params
 
-import (
-	"time"
-
-	// TODO(jcw4) per fwereade 2014-11-21 remove this dependency
-	"gopkg.in/juju/charm.v6-unstable"
-)
+import "time"
 
 const (
 	// ActionCancelled is the status for an Action that has been
@@ -131,7 +126,15 @@ type ApplicationsCharmActionsResults struct {
 // If an error such as a missing charm or malformed application name occurs, it
 // is encapsulated in this type.
 type ApplicationCharmActionsResult struct {
-	ApplicationTag string         `json:"application-tag,omitempty"`
-	Actions        *charm.Actions `json:"actions,omitempty"`
-	Error          *Error         `json:"error,omitempty"`
+	ApplicationTag string                `json:"application-tag,omitempty"`
+	Actions        map[string]ActionSpec `json:"actions,omitempty"`
+	Error          *Error                `json:"error,omitempty"`
+}
+
+// ActionSpec is a definition of the parameters and traits of an Action.
+// The Params map is expected to conform to JSON-Schema Draft 4 as defined at
+// http://json-schema.org/draft-04/schema# (see http://json-schema.org/latest/json-schema-core.html)
+type ActionSpec struct {
+	Description string                 `json:"description"`
+	Params      map[string]interface{} `json:"params"`
 }

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/utils/proxy"
 	"github.com/juju/utils/ssh"
 	"github.com/juju/version"
-	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/constraints"
@@ -107,10 +106,20 @@ type AddRelation struct {
 	Endpoints []string `json:"endpoints"`
 }
 
+// CharmRelation is a mirror struct for charm.Relation.
+type CharmRelation struct {
+	Name      string `json:"name"`
+	Role      string `json:"role"`
+	Interface string `json:"interface"`
+	Optional  bool   `json:"optional"`
+	Limit     int    `json:"limit"`
+	Scope     string `json:"scope"`
+}
+
 // AddRelationResults holds the results of a AddRelation call. The Endpoints
 // field maps application names to the involved endpoints.
 type AddRelationResults struct {
-	Endpoints map[string]charm.Relation `json:"endpoints"`
+	Endpoints map[string]CharmRelation `json:"endpoints"`
 }
 
 // DestroyRelation holds the parameters for making the DestroyRelation call.
@@ -425,13 +434,14 @@ type SetConstraints struct {
 
 // ResolveCharms stores charm references for a ResolveCharms call.
 type ResolveCharms struct {
-	References []charm.URL `json:"references"`
+	References []string `json:"references"`
 }
 
 // ResolveCharmResult holds the result of resolving a charm reference to a URL, or any error that occurred.
 type ResolveCharmResult struct {
-	URL   *charm.URL `json:"url,omitempty"`
-	Error string     `json:"error,omitempty"`
+	// URL is a string representation of charm.URL.
+	URL   string `json:"url,omitempty"`
+	Error string `json:"error,omitempty"`
 }
 
 // ResolveCharmResults holds results of the ResolveCharms call.

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -8,8 +8,6 @@ package params
 import (
 	"time"
 
-	"gopkg.in/juju/charm.v6-unstable"
-
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state/multiwatcher"
 )
@@ -90,19 +88,19 @@ type UnitStatus struct {
 
 // RelationStatus holds status info about a relation.
 type RelationStatus struct {
-	Id        int                 `json:"id"`
-	Key       string              `json:"key"`
-	Interface string              `json:"interface"`
-	Scope     charm.RelationScope `json:"scope"`
-	Endpoints []EndpointStatus    `json:"endpoints"`
+	Id        int              `json:"id"`
+	Key       string           `json:"key"`
+	Interface string           `json:"interface"`
+	Scope     string           `json:"scope"`
+	Endpoints []EndpointStatus `json:"endpoints"`
 }
 
 // EndpointStatus holds status info about a single endpoint
 type EndpointStatus struct {
-	ApplicationName string             `json:"application"`
-	Name            string             `json:"name"`
-	Role            charm.RelationRole `json:"role"`
-	Subordinate     bool               `json:"subordinate"`
+	ApplicationName string `json:"application"`
+	Name            string `json:"name"`
+	Role            string `json:"role"`
+	Subordinate     bool   `json:"subordinate"`
 }
 
 // TODO(ericsnow) Eliminate the String method.

--- a/cmd/juju/action/action.go
+++ b/cmd/juju/action/action.go
@@ -7,7 +7,6 @@ import (
 	"io"
 
 	"github.com/juju/errors"
-	"gopkg.in/juju/charm.v6-unstable"
 
 	"github.com/juju/juju/api/action"
 	"github.com/juju/juju/apiserver/params"
@@ -44,7 +43,7 @@ type APIClient interface {
 
 	// ApplicationCharmActions is a single query which uses ApplicationsCharmsActions to
 	// get the charm.Actions for a single Service by tag.
-	ApplicationCharmActions(params.Entity) (*charm.Actions, error)
+	ApplicationCharmActions(params.Entity) (map[string]params.ActionSpec, error)
 
 	// Actions fetches actions by tag.  These Actions can be used to get
 	// the ActionReceiver if necessary.

--- a/cmd/juju/action/list.go
+++ b/cmd/juju/action/list.go
@@ -84,14 +84,13 @@ func (c *listCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 
-	output := actions.ActionSpecs
-	if len(output) == 0 {
+	if len(actions) == 0 {
 		return c.out.Write(ctx, "No actions defined for "+c.applicationTag.Id())
 	}
 
 	if c.fullSchema {
 		verboseSpecs := make(map[string]interface{})
-		for k, v := range output {
+		for k, v := range actions {
 			verboseSpecs[k] = v.Params
 		}
 
@@ -100,7 +99,7 @@ func (c *listCommand) Run(ctx *cmd.Context) error {
 
 	shortOutput := make(map[string]string)
 	var sortedNames []string
-	for name, action := range actions.ActionSpecs {
+	for name, action := range actions {
 		shortOutput[name] = action.Description
 		if shortOutput[name] == "" {
 			shortOutput[name] = "No description"

--- a/cmd/juju/action/list_test.go
+++ b/cmd/juju/action/list_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/action"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
@@ -96,7 +96,7 @@ snapshot        Take a snapshot of the database.
 		expectMessage    string
 		withArgs         []string
 		withAPIErr       string
-		withCharmActions *charm.Actions
+		withCharmActions map[string]params.ActionSpec
 		expectedErr      string
 	}{{
 		should:      "pass back API error correctly",
@@ -113,11 +113,10 @@ snapshot        Take a snapshot of the database.
 		expectFullSchema: true,
 		withCharmActions: someCharmActions,
 	}, {
-		should:           "work properly when no results found",
-		withArgs:         []string{validServiceId},
-		expectNoResults:  true,
-		expectMessage:    "No actions defined for " + validServiceId,
-		withCharmActions: &charm.Actions{ActionSpecs: map[string]charm.ActionSpec{}},
+		should:          "work properly when no results found",
+		withArgs:        []string{validServiceId},
+		expectNoResults: true,
+		expectMessage:   "No actions defined for " + validServiceId,
 	}}
 
 	for i, t := range tests {
@@ -155,9 +154,9 @@ snapshot        Take a snapshot of the database.
 	}
 }
 
-func checkFullSchema(c *gc.C, expected *charm.Actions, actual []byte) {
+func checkFullSchema(c *gc.C, expected map[string]params.ActionSpec, actual []byte) {
 	expectedOutput := make(map[string]interface{})
-	for k, v := range expected.ActionSpecs {
+	for k, v := range expected {
 		expectedOutput[k] = v.Params
 	}
 	c.Check(string(actual), jc.YAMLEquals, expectedOutput)

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -13,7 +13,6 @@ import (
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v6-unstable"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/action"
@@ -65,37 +64,35 @@ func (s *BaseActionSuite) patchAPIClient(client *fakeAPIClient) func() {
 	)
 }
 
-var someCharmActions = &charm.Actions{
-	ActionSpecs: map[string]charm.ActionSpec{
-		"snapshot": {
-			Description: "Take a snapshot of the database.",
-			Params: map[string]interface{}{
-				"foo": map[string]interface{}{
-					"bar": "baz",
-				},
-				"baz": "bar",
+var someCharmActions = map[string]params.ActionSpec{
+	"snapshot": {
+		Description: "Take a snapshot of the database.",
+		Params: map[string]interface{}{
+			"foo": map[string]interface{}{
+				"bar": "baz",
 			},
+			"baz": "bar",
 		},
-		"kill": {
-			Description: "Kill the database.",
-			Params: map[string]interface{}{
-				"bar": map[string]interface{}{
-					"baz": "foo",
-				},
-				"foo": "baz",
+	},
+	"kill": {
+		Description: "Kill the database.",
+		Params: map[string]interface{}{
+			"bar": map[string]interface{}{
+				"baz": "foo",
 			},
+			"foo": "baz",
 		},
-		"no-description": {
-			Params: map[string]interface{}{
-				"bar": map[string]interface{}{
-					"baz": "foo",
-				},
-				"foo": "baz",
+	},
+	"no-description": {
+		Params: map[string]interface{}{
+			"bar": map[string]interface{}{
+				"baz": "foo",
 			},
+			"foo": "baz",
 		},
-		"no-params": {
-			Description: "An action with no parameters.",
-		},
+	},
+	"no-params": {
+		Description: "An action with no parameters.",
 	},
 }
 
@@ -129,7 +126,7 @@ type fakeAPIClient struct {
 	actionsByReceivers []params.ActionsByReceiver
 	actionTagMatches   params.FindTagsResults
 	actionsByNames     params.ActionsByNames
-	charmActions       *charm.Actions
+	charmActions       map[string]params.ActionSpec
 	apiErr             error
 }
 
@@ -174,7 +171,7 @@ func (c *fakeAPIClient) Cancel(args params.Actions) (params.ActionResults, error
 	}, c.apiErr
 }
 
-func (c *fakeAPIClient) ApplicationCharmActions(params.Entity) (*charm.Actions, error) {
+func (c *fakeAPIClient) ApplicationCharmActions(params.Entity) (map[string]params.ActionSpec, error) {
 	return c.charmActions, c.apiErr
 }
 


### PR DESCRIPTION
Charm types had uppercase json values. Also not a good idea to use other's structs for our params.

(Review request: http://reviews.vapour.ws/r/5148/)