### PR TITLE
Ship the source of model config values to get-model-config and displayy in tabular format

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/downloader"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/tools"
@@ -259,7 +260,26 @@ func (c *Client) Close() error {
 func (c *Client) ModelGet() (map[string]interface{}, error) {
 	result := params.ModelConfigResults{}
 	err := c.facade.FacadeCall("ModelGet", nil, &result)
-	return result.Config, err
+	values := make(map[string]interface{})
+	for name, val := range result.Config {
+		values[name] = val.Value
+	}
+	return values, err
+}
+
+// ModelGetWithMetadata returns all model settings along with extra
+// metadata like the source of the setting value.
+func (c *Client) ModelGetWithMetadata() (config.ConfigValues, error) {
+	result := params.ModelConfigResults{}
+	err := c.facade.FacadeCall("ModelGet", nil, &result)
+	values := make(config.ConfigValues)
+	for name, val := range result.Config {
+		values[name] = config.ConfigValue{
+			Value:  val.Value,
+			Source: val.Source,
+		}
+	}
+	return values, err
 }
 
 // ModelSet sets the given key-value pairs in the model.

--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -61,7 +61,11 @@ func (c *Client) AllModels() ([]base.UserModel, error) {
 func (c *Client) ModelConfig() (map[string]interface{}, error) {
 	result := params.ModelConfigResults{}
 	err := c.facade.FacadeCall("ModelConfig", nil, &result)
-	return result.Config, err
+	values := make(map[string]interface{})
+	for name, val := range result.Config {
+		values[name] = val.Value
+	}
+	return values, err
 }
 
 // DestroyController puts the controller model into a "dying" state,

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -396,12 +396,17 @@ func (c *Client) AgentVersion() (params.AgentVersionResult, error) {
 // get-model-config CLI command.
 func (c *Client) ModelGet() (params.ModelConfigResults, error) {
 	result := params.ModelConfigResults{}
-	// Get the existing model config from the state.
-	config, err := c.api.stateAccessor.ModelConfig()
+	values, err := c.api.stateAccessor.ModelConfigValues()
 	if err != nil {
 		return result, err
 	}
-	result.Config = config.AllAttrs()
+	result.Config = make(map[string]params.ConfigValue)
+	for attr, val := range values {
+		result.Config[attr] = params.ConfigValue{
+			Value:  val.Value,
+			Source: val.Source,
+		}
+	}
 	return result, nil
 }
 

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -825,7 +825,14 @@ func (s *serverSuite) TestClientModelGet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	result, err := s.client.ModelGet()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Config, gc.DeepEquals, modelConfig.AllAttrs())
+	cfg := make(map[string]params.ConfigValue)
+	for name, val := range modelConfig.AllAttrs() {
+		cfg[name] = params.ConfigValue{
+			Value:  val,
+			Source: "model",
+		}
+	}
+	c.Assert(result.Config, gc.DeepEquals, cfg)
 }
 
 func (s *serverSuite) assertEnvValue(c *gc.C, key string, expected interface{}) {
@@ -892,7 +899,7 @@ func (s *serverSuite) TestClientModelSetCannotChangeAgentVersion(c *gc.C) {
 	result, err := s.client.ModelGet()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Config["agent-version"], gc.NotNil)
-	args.Config["agent-version"] = result.Config["agent-version"]
+	args.Config["agent-version"] = result.Config["agent-version"].Value
 	err = s.client.ModelSet(args)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/apiserver/client/state.go
+++ b/apiserver/client/state.go
@@ -43,6 +43,7 @@ type stateInterface interface {
 	AddMachineInsideNewMachine(template, parentTemplate state.MachineTemplate, containerType instance.ContainerType) (*state.Machine, error)
 	ModelConstraints() (constraints.Value, error)
 	ModelConfig() (*config.Config, error)
+	ModelConfigValues() (config.ConfigValues, error)
 	UpdateModelConfig(map[string]interface{}, []string, state.ValidateConfigFunc) error
 	SetModelConstraints(constraints.Value) error
 	ModelUUID() string

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -192,12 +192,17 @@ func (s *ControllerAPI) ModelConfig() (params.ModelConfigResults, error) {
 		return result, errors.Trace(err)
 	}
 
-	config, err := controllerModel.Config()
+	cfg, err := controllerModel.Config()
 	if err != nil {
 		return result, errors.Trace(err)
 	}
 
-	result.Config = config.AllAttrs()
+	result.Config = make(map[string]params.ConfigValue)
+	for name, val := range cfg.AllAttrs() {
+		result.Config[name] = params.ConfigValue{
+			Value: val,
+		}
+	}
 	return result, nil
 }
 

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -151,7 +151,7 @@ func (s *controllerSuite) TestListBlockedModelsNoBlocks(c *gc.C) {
 func (s *controllerSuite) TestModelConfig(c *gc.C) {
 	env, err := s.controller.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env.Config["name"], gc.Equals, "controller")
+	c.Assert(env.Config["name"], jc.DeepEquals, params.ConfigValue{Value: "controller"})
 }
 
 func (s *controllerSuite) TestModelConfigFromNonController(c *gc.C) {
@@ -164,7 +164,7 @@ func (s *controllerSuite) TestModelConfigFromNonController(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := controller.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg.Config["name"], gc.Equals, "controller")
+	c.Assert(cfg.Config["name"], jc.DeepEquals, params.ConfigValue{Value: "controller"})
 }
 
 func (s *controllerSuite) TestControllerConfig(c *gc.C) {

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -9,10 +9,17 @@ import (
 	"github.com/juju/version"
 )
 
+// ConfigValue encapsulates a configuration
+// value and its source.
+type ConfigValue struct {
+	Value  interface{} `json:"value"`
+	Source string      `json:"source"`
+}
+
 // ModelConfigResults contains the result of client API calls
 // to get model config values.
 type ModelConfigResults struct {
-	Config map[string]interface{} `json:"config"`
+	Config map[string]ConfigValue `json:"config"`
 }
 
 // ModelSet contains the arguments for ModelSet client API

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -97,20 +97,19 @@ func (f *fakeDestroyAPI) AllModels() ([]base.UserModel, error) {
 
 // fakeDestroyAPIClient mocks out the client API
 type fakeDestroyAPIClient struct {
-	err           error
-	env           map[string]interface{}
-	envgetcalled  bool
-	destroycalled bool
+	err            error
+	modelgetcalled bool
+	destroycalled  bool
 }
 
 func (f *fakeDestroyAPIClient) Close() error { return nil }
 
 func (f *fakeDestroyAPIClient) ModelGet() (map[string]interface{}, error) {
-	f.envgetcalled = true
+	f.modelgetcalled = true
 	if f.err != nil {
 		return nil, f.err
 	}
-	return f.env, nil
+	return map[string]interface{}{}, nil
 }
 
 func (f *fakeDestroyAPIClient) DestroyModel() error {

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // NewGetCommandForTest returns a GetCommand with the api provided as specified.
-func NewGetCommandForTest(api GetEnvironmentAPI) cmd.Command {
+func NewGetCommandForTest(api GetModelAPI) cmd.Command {
 	cmd := &getCommand{
 		api: api,
 	}
@@ -27,7 +27,7 @@ func NewSetCommandForTest(api SetModelAPI) cmd.Command {
 }
 
 // NewUnsetCommandForTest returns an UnsetCommand with the api provided as specified.
-func NewUnsetCommandForTest(api UnsetEnvironmentAPI) cmd.Command {
+func NewUnsetCommandForTest(api UnsetModelAPI) cmd.Command {
 	cmd := &unsetCommand{
 		api: api,
 	}

--- a/cmd/juju/model/fakeenv_test.go
+++ b/cmd/juju/model/fakeenv_test.go
@@ -6,6 +6,7 @@ package model_test
 import (
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/testing"
 )
 
@@ -37,6 +38,14 @@ func (f *fakeEnvAPI) Close() error {
 
 func (f *fakeEnvAPI) ModelGet() (map[string]interface{}, error) {
 	return f.values, nil
+}
+
+func (f *fakeEnvAPI) ModelGetWithMetadata() (config.ConfigValues, error) {
+	result := make(config.ConfigValues)
+	for name, val := range f.values {
+		result[name] = config.ConfigValue{Value: val, Source: "model"}
+	}
+	return result, nil
 }
 
 func (f *fakeEnvAPI) ModelSet(config map[string]interface{}) error {

--- a/cmd/juju/model/get.go
+++ b/cmd/juju/model/get.go
@@ -4,13 +4,18 @@
 package model
 
 import (
+	"bytes"
 	"fmt"
+	"sort"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/environs/config"
 )
 
 func NewGetCommand() cmd.Command {
@@ -21,7 +26,7 @@ func NewGetCommand() cmd.Command {
 // the requested value in a format of the user's choosing.
 type getCommand struct {
 	modelcmd.ModelCommandBase
-	api GetEnvironmentAPI
+	api GetModelAPI
 	key string
 	out cmd.Output
 }
@@ -51,7 +56,11 @@ func (c *getCommand) Info() *cmd.Info {
 }
 
 func (c *getCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
+		"yaml":    cmd.FormatYaml,
+		"json":    cmd.FormatJson,
+		"tabular": formatConfigTabular,
+	})
 }
 
 func (c *getCommand) Init(args []string) (err error) {
@@ -59,12 +68,13 @@ func (c *getCommand) Init(args []string) (err error) {
 	return
 }
 
-type GetEnvironmentAPI interface {
+type GetModelAPI interface {
 	Close() error
 	ModelGet() (map[string]interface{}, error)
+	ModelGetWithMetadata() (config.ConfigValues, error)
 }
 
-func (c *getCommand) getAPI() (GetEnvironmentAPI, error) {
+func (c *getCommand) getAPI() (GetModelAPI, error) {
 	if c.api != nil {
 		return c.api, nil
 	}
@@ -78,17 +88,63 @@ func (c *getCommand) Run(ctx *cmd.Context) error {
 	}
 	defer client.Close()
 
-	attrs, err := client.ModelGet()
+	attrs, err := client.ModelGetWithMetadata()
 	if err != nil {
 		return err
 	}
 
 	if c.key != "" {
 		if value, found := attrs[c.key]; found {
-			return c.out.Write(ctx, value)
+			out, err := cmd.FormatSmart(value.Value)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(ctx.Stdout, "%v\n", string(out))
+			return nil
 		}
 		return fmt.Errorf("key %q not found in %q model.", c.key, attrs["name"])
 	}
 	// If key is empty, write out the whole lot.
 	return c.out.Write(ctx, attrs)
+}
+
+// formatConfigTabular returns a tabular summary of config information.
+func formatConfigTabular(value interface{}) ([]byte, error) {
+	configValues, ok := value.(config.ConfigValues)
+	if !ok {
+		return nil, errors.Errorf("expected value of type %T, got %T", configValues, value)
+	}
+
+	var out bytes.Buffer
+	const (
+		// To format things into columns.
+		minwidth = 0
+		tabwidth = 1
+		padding  = 2
+		padchar  = ' '
+		flags    = 0
+	)
+	tw := tabwriter.NewWriter(&out, minwidth, tabwidth, padding, padchar, flags)
+	p := func(values ...string) {
+		text := strings.Join(values, "\t")
+		fmt.Fprintln(tw, text)
+	}
+	var valueNames []string
+	for name := range configValues {
+		valueNames = append(valueNames, name)
+	}
+	sort.Strings(valueNames)
+	p("ATTRIBUTE\tFROM\tVALUE")
+
+	for _, name := range valueNames {
+		info := configValues[name]
+		val, err := cmd.FormatSmart(info.Value)
+		if err != nil {
+			return nil, errors.Annotatef(err, "formatting value for %q", name)
+		}
+		p(name, info.Source, string(val))
+	}
+
+	tw.Flush()
+	return out.Bytes(), nil
 }

--- a/cmd/juju/model/get_test.go
+++ b/cmd/juju/model/get_test.go
@@ -49,18 +49,24 @@ func (s *GetSuite) TestSingleValueJSON(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := strings.TrimSpace(testing.Stdout(context))
-	c.Assert(output, gc.Equals, `"test-model"`)
+	c.Assert(output, gc.Equals, "test-model")
 }
 
-func (s *GetSuite) TestAllValues(c *gc.C) {
-	context, err := s.run(c)
+func (s *GetSuite) TestAllValuesYAML(c *gc.C) {
+	context, err := s.run(c, "--format=yaml")
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := strings.TrimSpace(testing.Stdout(context))
 	expected := "" +
-		"name: test-model\n" +
-		"running: true\n" +
-		"special: special value"
+		"name:\n" +
+		"  value: test-model\n" +
+		"  source: model\n" +
+		"running:\n" +
+		"  value: true\n" +
+		"  source: model\n" +
+		"special:\n" +
+		"  value: special value\n" +
+		"  source: model"
 	c.Assert(output, gc.Equals, expected)
 }
 
@@ -69,6 +75,19 @@ func (s *GetSuite) TestAllValuesJSON(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := strings.TrimSpace(testing.Stdout(context))
-	expected := `{"name":"test-model","running":true,"special":"special value"}`
+	expected := `{"name":{"Value":"test-model","Source":"model"},"running":{"Value":true,"Source":"model"},"special":{"Value":"special value","Source":"model"}}`
+	c.Assert(output, gc.Equals, expected)
+}
+
+func (s *GetSuite) TestAllValuesTabular(c *gc.C) {
+	context, err := s.run(c)
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(testing.Stdout(context))
+	expected := "" +
+		"ATTRIBUTE  FROM   VALUE\n" +
+		"name       model  test-model\n" +
+		"running    model  True\n" +
+		"special    model  special value"
 	c.Assert(output, gc.Equals, expected)
 }

--- a/cmd/juju/model/unset.go
+++ b/cmd/juju/model/unset.go
@@ -19,7 +19,7 @@ func NewUnsetCommand() cmd.Command {
 
 type unsetCommand struct {
 	modelcmd.ModelCommandBase
-	api  UnsetEnvironmentAPI
+	api  UnsetModelAPI
 	keys []string
 }
 
@@ -59,13 +59,13 @@ func (c *unsetCommand) Init(args []string) (err error) {
 	return nil
 }
 
-type UnsetEnvironmentAPI interface {
+type UnsetModelAPI interface {
 	Close() error
 	ModelGet() (map[string]interface{}, error)
 	ModelUnset(keys ...string) error
 }
 
-func (c *unsetCommand) getAPI() (UnsetEnvironmentAPI, error) {
+func (c *unsetCommand) getAPI() (UnsetModelAPI, error) {
 	if c.api != nil {
 		return c.api, nil
 	}

--- a/environs/config/source.go
+++ b/environs/config/source.go
@@ -7,11 +7,34 @@ package config
 // After a call to UpdateModelConfig, any attributes added/removed
 // will have a source of JujuModelConfigSource.
 const (
-	// JujuCloudSource is used to label model config attributes that
-	// come from those associated with the host cloud.
-	JujuCloudSource = "juju cloud"
+	// JujuControllerSource is used to label model config attributes that
+	// come from those associated with the controller.
+	JujuControllerSource = "controller"
 
 	// JujuModelConfigSource is used to label model config attributes that
 	// have been explicitly set by the user.
 	JujuModelConfigSource = "model"
 )
+
+// ConfigValue encapsulates a configuration
+// value and its source.
+type ConfigValue struct {
+	// Value is the configuration value.
+	Value interface{}
+
+	// Source is the name of the inherited config
+	// source from where the value originates.
+	Source string
+}
+
+// ConfigValues is a map of configuration values keyed by attribute name.
+type ConfigValues map[string]ConfigValue
+
+// AllAttrs returns just the attribute values from the config.
+func (c ConfigValues) AllAttrs() map[string]interface{} {
+	result := make(map[string]interface{})
+	for attr, val := range c {
+		result[attr] = val
+	}
+	return result
+}

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -80,7 +80,7 @@ func ImportModel(st *state.State, bytes []byte) (*state.Model, *state.State, err
 	return dbModel, dbState, nil
 }
 
-func updateConfigFromProvider(model description.Model, getter environs.EnvironConfigGetter, controllerConfig *config.Config) error {
+func updateConfigFromProvider(model description.Model, getter environs.EnvironConfigGetter, controllerModelConfig *config.Config) error {
 	provider, err := environs.GetEnviron(getter, environs.New)
 	if err != nil {
 		return errors.Trace(err)
@@ -91,7 +91,7 @@ func updateConfigFromProvider(model description.Model, getter environs.EnvironCo
 		return nil
 	}
 
-	model.UpdateConfig(updater.MigrationConfigUpdate(controllerConfig))
+	model.UpdateConfig(updater.MigrationConfigUpdate(controllerModelConfig))
 	return nil
 }
 

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1531,8 +1531,8 @@ func (e *environ) AllocateContainerAddresses(hostInstanceID instance.Id, contain
 }
 
 // MigrationConfigUpdate implements MigrationConfigUpdater.
-func (*environ) MigrationConfigUpdate(controllerConfig *config.Config) map[string]interface{} {
+func (*environ) MigrationConfigUpdate(controllerModelConfig *config.Config) map[string]interface{} {
 	return map[string]interface{}{
-		"controller-uuid": controllerConfig.UUID(),
+		"controller-uuid": controllerModelConfig.UUID(),
 	}
 }

--- a/state/model.go
+++ b/state/model.go
@@ -501,6 +501,16 @@ func (m *Model) Config() (*config.Config, error) {
 	return st.ModelConfig()
 }
 
+// ConfigValues returns the config values for the model.
+func (m *Model) ConfigValues() (config.ConfigValues, error) {
+	st, closeState, err := m.getState()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer closeState()
+	return st.ModelConfigValues()
+}
+
 // UpdateLatestToolsVersion looks up for the latest available version of
 // juju tools and updates environementDoc with it.
 func (m *Model) UpdateLatestToolsVersion(ver version.Number) error {

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -167,18 +167,23 @@ func (s *ModelConfigSourceSuite) TestNewModelConfigForksCloudValue(c *gc.C) {
 	c.Assert(modelCfg.AllAttrs()["apt-mirror"], gc.Equals, "http://mirror")
 }
 
-func (s *ModelConfigSourceSuite) TestModelConfigSource(c *gc.C) {
+func (s *ModelConfigSourceSuite) TestModelConfigValues(c *gc.C) {
 	modelCfg, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	expectedSources := make(map[string]string)
-	for attr := range modelCfg.AllAttrs() {
-		expectedSources[attr] = "model"
+	expectedValues := make(config.ConfigValues)
+	for attr, val := range modelCfg.AllAttrs() {
+		source := "model"
+		if attr == "apt-mirror" || attr == "http-proxy" {
+			source = "controller"
+		}
+		expectedValues[attr] = config.ConfigValue{
+			Value:  val,
+			Source: source,
+		}
 	}
-	expectedSources["apt-mirror"] = "juju cloud"
-	expectedSources["http-proxy"] = "juju cloud"
-	sources, err := s.State.ModelConfigSources()
+	sources, err := s.State.ModelConfigValues()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sources, jc.DeepEquals, expectedSources)
+	c.Assert(sources, jc.DeepEquals, expectedValues)
 }
 
 func (s *ModelConfigSourceSuite) TestModelConfigUpdateSetsSource(c *gc.C) {
@@ -190,14 +195,20 @@ func (s *ModelConfigSourceSuite) TestModelConfigUpdateSetsSource(c *gc.C) {
 
 	modelCfg, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	expectedSources := make(map[string]string)
-	for attr := range modelCfg.AllAttrs() {
-		expectedSources[attr] = "model"
+	expectedValues := make(config.ConfigValues)
+	for attr, val := range modelCfg.AllAttrs() {
+		source := "model"
+		if attr == "apt-mirror" {
+			source = "controller"
+		}
+		expectedValues[attr] = config.ConfigValue{
+			Value:  val,
+			Source: source,
+		}
 	}
-	expectedSources["apt-mirror"] = "juju cloud"
-	sources, err := s.State.ModelConfigSources()
+	sources, err := s.State.ModelConfigValues()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sources, jc.DeepEquals, expectedSources)
+	c.Assert(sources, jc.DeepEquals, expectedValues)
 }
 
 func (s *ModelConfigSourceSuite) TestModelConfigDeleteSetsSource(c *gc.C) {
@@ -206,13 +217,18 @@ func (s *ModelConfigSourceSuite) TestModelConfigDeleteSetsSource(c *gc.C) {
 
 	modelCfg, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	expectedSources := make(map[string]string)
-	for attr := range modelCfg.AllAttrs() {
-		expectedSources[attr] = "model"
+	expectedValues := make(config.ConfigValues)
+	for attr, val := range modelCfg.AllAttrs() {
+		source := "model"
+		if attr == "http-proxy" {
+			source = "controller"
+		}
+		expectedValues[attr] = config.ConfigValue{
+			Value:  val,
+			Source: source,
+		}
 	}
-	expectedSources["http-proxy"] = "juju cloud"
-	expectedSources["apt-mirror"] = "model"
-	sources, err := s.State.ModelConfigSources()
+	sources, err := s.State.ModelConfigValues()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sources, jc.DeepEquals, expectedSources)
+	c.Assert(sources, jc.DeepEquals, expectedValues)
 }

--- a/state/open.go
+++ b/state/open.go
@@ -319,7 +319,7 @@ func (st *State) modelSetupOps(args ModelArgs, localCloudConfig map[string]inter
 	var configSources []modelConfigSource
 	if len(localCloudConfig) > 0 {
 		configSources = []modelConfigSource{{
-			name: config.JujuCloudSource,
+			name: config.JujuControllerSource,
 			sourceFunc: modelConfigSourceFunc(func() (map[string]interface{}, error) {
 				return localCloudConfig, nil
 			})}}


### PR DESCRIPTION
Add a new client api to get model config information along with metadata pertaining to each config eg the source from where the config was set.
This is now displayed in tabular format in juju get-model-config

(Review request: http://reviews.vapour.ws/r/5150/)