### PR TITLE
juju status: add workload version in yaml/json output

### DIFF
--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -67,20 +67,21 @@ func (s machineStatus) MarshalYAML() (interface{}, error) {
 }
 
 type applicationStatus struct {
-	Err           error                 `json:"-" yaml:",omitempty"`
-	Charm         string                `json:"charm" yaml:"charm"`
-	Series        string                `json:"series"`
-	OS            string                `json:"os"`
-	CharmOrigin   string                `json:"charm-origin" yaml:"charm-origin"`
-	CharmName     string                `json:"charm-name" yaml:"charm-name"`
-	CharmRev      int                   `json:"charm-rev" yaml:"charm-rev"`
-	CanUpgradeTo  string                `json:"can-upgrade-to,omitempty" yaml:"can-upgrade-to,omitempty"`
-	Exposed       bool                  `json:"exposed" yaml:"exposed"`
-	Life          string                `json:"life,omitempty" yaml:"life,omitempty"`
-	StatusInfo    statusInfoContents    `json:"application-status,omitempty" yaml:"application-status"`
-	Relations     map[string][]string   `json:"relations,omitempty" yaml:"relations,omitempty"`
-	SubordinateTo []string              `json:"subordinate-to,omitempty" yaml:"subordinate-to,omitempty"`
-	Units         map[string]unitStatus `json:"units,omitempty" yaml:"units,omitempty"`
+	Err             error                 `json:"-" yaml:",omitempty"`
+	Charm           string                `json:"charm" yaml:"charm"`
+	Series          string                `json:"series"`
+	OS              string                `json:"os"`
+	CharmOrigin     string                `json:"charm-origin" yaml:"charm-origin"`
+	CharmName       string                `json:"charm-name" yaml:"charm-name"`
+	CharmRev        int                   `json:"charm-rev" yaml:"charm-rev"`
+	CanUpgradeTo    string                `json:"can-upgrade-to,omitempty" yaml:"can-upgrade-to,omitempty"`
+	Exposed         bool                  `json:"exposed" yaml:"exposed"`
+	Life            string                `json:"life,omitempty" yaml:"life,omitempty"`
+	StatusInfo      statusInfoContents    `json:"application-status,omitempty" yaml:"application-status"`
+	Relations       map[string][]string   `json:"relations,omitempty" yaml:"relations,omitempty"`
+	SubordinateTo   []string              `json:"subordinate-to,omitempty" yaml:"subordinate-to,omitempty"`
+	Units           map[string]unitStatus `json:"units,omitempty" yaml:"units,omitempty"`
+	WorkloadVersion string                `json:"workload-version,omitempty" yaml:"workload-version,omitempty"`
 }
 
 type applicationStatusNoMarshal applicationStatus
@@ -110,11 +111,12 @@ type unitStatus struct {
 	JujuStatusInfo     statusInfoContents `json:"juju-status,omitempty" yaml:"juju-status"`
 	MeterStatus        *meterStatus       `json:"meter-status,omitempty" yaml:"meter-status,omitempty"`
 
-	Charm         string                `json:"upgrading-from,omitempty" yaml:"upgrading-from,omitempty"`
-	Machine       string                `json:"machine,omitempty" yaml:"machine,omitempty"`
-	OpenedPorts   []string              `json:"open-ports,omitempty" yaml:"open-ports,omitempty"`
-	PublicAddress string                `json:"public-address,omitempty" yaml:"public-address,omitempty"`
-	Subordinates  map[string]unitStatus `json:"subordinates,omitempty" yaml:"subordinates,omitempty"`
+	Charm           string                `json:"upgrading-from,omitempty" yaml:"upgrading-from,omitempty"`
+	Machine         string                `json:"machine,omitempty" yaml:"machine,omitempty"`
+	OpenedPorts     []string              `json:"open-ports,omitempty" yaml:"open-ports,omitempty"`
+	PublicAddress   string                `json:"public-address,omitempty" yaml:"public-address,omitempty"`
+	Subordinates    map[string]unitStatus `json:"subordinates,omitempty" yaml:"subordinates,omitempty"`
+	WorkloadVersion string                `json:"workload-version,omitempty" yaml:"workload-version,omitempty"`
 }
 
 type statusInfoContents struct {

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -137,20 +137,21 @@ func (sf *statusFormatter) formatApplication(name string, application params.App
 	}
 
 	out := applicationStatus{
-		Err:           application.Err,
-		Charm:         application.Charm,
-		Series:        application.Series,
-		OS:            strings.ToLower(appOS.String()),
-		CharmOrigin:   charmOrigin,
-		CharmName:     charmName,
-		CharmRev:      charmRev,
-		Exposed:       application.Exposed,
-		Life:          application.Life,
-		Relations:     application.Relations,
-		CanUpgradeTo:  application.CanUpgradeTo,
-		SubordinateTo: application.SubordinateTo,
-		Units:         make(map[string]unitStatus),
-		StatusInfo:    sf.getServiceStatusInfo(application),
+		Err:             application.Err,
+		Charm:           application.Charm,
+		Series:          application.Series,
+		OS:              strings.ToLower(appOS.String()),
+		CharmOrigin:     charmOrigin,
+		CharmName:       charmName,
+		CharmRev:        charmRev,
+		Exposed:         application.Exposed,
+		Life:            application.Life,
+		Relations:       application.Relations,
+		CanUpgradeTo:    application.CanUpgradeTo,
+		SubordinateTo:   application.SubordinateTo,
+		Units:           make(map[string]unitStatus),
+		StatusInfo:      sf.getServiceStatusInfo(application),
+		WorkloadVersion: application.WorkloadVersion,
 	}
 	for k, m := range application.Units {
 		out.Units[k] = sf.formatUnit(unitFormatInfo{
@@ -196,6 +197,7 @@ func (sf *statusFormatter) formatUnit(info unitFormatInfo) unitStatus {
 		PublicAddress:      info.unit.PublicAddress,
 		Charm:              info.unit.Charm,
 		Subordinates:       make(map[string]unitStatus),
+		WorkloadVersion:    info.unit.WorkloadVersion,
 	}
 
 	if ms, ok := info.meterStatuses[info.unitName]; ok {


### PR DESCRIPTION
Include the unit- and application-level workload versions in the yaml/json format output of `juju status`.

I haven't changed the tabular format yet. The version is completely determined by the charm author, and there's some concern about too-long values breaking the table layout. 

(Review request: http://reviews.vapour.ws/r/5152/)