### PR TITLE
Created an Audit observer for API events

### DIFF
--- a/apiserver/observer/audit.go
+++ b/apiserver/observer/audit.go
@@ -1,0 +1,115 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package observer
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/version"
+
+	"github.com/juju/juju/audit"
+	"github.com/juju/juju/rpc"
+)
+
+// PersistAuditEntryFn defines a function which will persist an
+// AuditEntry to a backing store and return an error upon failure.
+type AuditEntrySinkFn func(audit.AuditEntry) error
+
+// Context defines things an Audit observer need know about to operate
+// correctly.
+type AuditContext struct {
+
+	// JujuServerVersion is the version of jujud.
+	JujuServerVersion version.Number
+
+	// ModelUUID is the UUID of the model the audit observer is
+	// currently running on.
+	ModelUUID string
+}
+
+type ErrorHandler func(error)
+
+// NewAudit creates a new Audit with the information provided via the Context.
+func NewAudit(ctx *AuditContext, handleAuditEntry AuditEntrySinkFn, errorHandler ErrorHandler) *Audit {
+	return &Audit{
+		jujuServerVersion: ctx.JujuServerVersion,
+		modelUUID:         ctx.ModelUUID,
+		errorHandler:      errorHandler,
+		handleAuditEntry:  handleAuditEntry,
+	}
+}
+
+// Audit is an observer which will log APIServer requests using the
+// function provided.
+type Audit struct {
+	jujuServerVersion version.Number
+	modelUUID         string
+	errorHandler      ErrorHandler
+	handleAuditEntry  AuditEntrySinkFn
+
+	// state represents information that's built up as methods on this
+	// type are called. We segregate this to ensure it's clear what
+	// information is transient in case we want to extract it
+	// later. It's an anonymous struct so this doesn't leak outside
+	// this type.
+	state struct {
+		remoteAddress    string
+		authenticatedTag string
+	}
+}
+
+// Login implements Observer.
+func (a *Audit) Login(tag string) {
+	a.state.authenticatedTag = tag
+}
+
+// ServerRequest implements Observer.
+func (a *Audit) ServerRequest(hdr *rpc.Header, body interface{}) {
+	auditEntry := a.boilerplateAuditEntry()
+	//auditEntry.OriginIP =
+	auditEntry.OriginType = "API request"
+	auditEntry.OriginName = a.state.authenticatedTag
+	auditEntry.Operation = rpcRequestToOperation(hdr.Request)
+	auditEntry.Data = map[string]interface{}{"request-body": body}
+	err := a.handleAuditEntry(auditEntry)
+	if err != nil {
+		a.errorHandler(errors.Trace(err))
+	}
+}
+
+// Join implements Observer.
+func (a *Audit) Join(req *http.Request) {
+	a.state.remoteAddress = req.RemoteAddr
+}
+
+// Leave implements Observer.
+func (a *Audit) Leave() {
+	a.state.remoteAddress = ""
+	a.state.authenticatedTag = ""
+}
+
+// ClientRequest implements Observer.
+func (a *Audit) ClientRequest(hdr *rpc.Header, body interface{}) {}
+
+// ServerReply implements Observer.
+func (a *Audit) ServerReply(rpc.Request, *rpc.Header, interface{}) {}
+
+// ClientReply implements Observer.
+func (a *Audit) ClientReply(req rpc.Request, hdr *rpc.Header, body interface{}) {}
+
+func (a *Audit) boilerplateAuditEntry() audit.AuditEntry {
+	return audit.AuditEntry{
+		JujuServerVersion: a.jujuServerVersion,
+		ModelUUID:         a.modelUUID,
+		Timestamp:         time.Now().UTC(),
+		RemoteAddress:     a.state.remoteAddress,
+		OriginName:        a.state.authenticatedTag,
+	}
+}
+
+func rpcRequestToOperation(req rpc.Request) string {
+	return fmt.Sprintf("%s:v%d - %s", req.Type, req.Version, req.Action)
+}

--- a/audit/audit.go
+++ b/audit/audit.go
@@ -5,7 +5,6 @@
 package audit
 
 import (
-	"net"
 	"time"
 
 	"github.com/juju/errors"
@@ -24,9 +23,9 @@ type AuditEntry struct {
 	// Timestamp is when the audit entry was generated. It must be
 	// stored with the UTC locale.
 	Timestamp time.Time
-	// OriginIP is the IP of the machine from which the audit-event
-	// was triggered.
-	OriginIP net.IP
+	// RemoteAddress is the IP of the machine from which the
+	// audit-event was triggered.
+	RemoteAddress string
 	// OriginType is the type of entity (e.g. model, user, action)
 	// which triggered the audit event.
 	OriginType string
@@ -58,8 +57,8 @@ func (e AuditEntry) Validate() error {
 	if e.Timestamp.Location() != time.UTC {
 		return errors.NewNotValid(errors.NotValidf("Timestamp"), "must be set to UTC")
 	}
-	if e.OriginIP == nil || e.OriginIP.IsUnspecified() {
-		return errors.NewNotValid(errors.NotAssignedf("OriginIP"), "")
+	if e.RemoteAddress == "" {
+		return errors.NewNotValid(errors.NotAssignedf("RemoteAddress"), "")
 	}
 	if e.OriginType == "" {
 		return errors.NewNotValid(errors.NotAssignedf("OriginType"), "")

--- a/audit/audit_test.go
+++ b/audit/audit_test.go
@@ -4,7 +4,6 @@
 package audit_test
 
 import (
-	"net"
 	"time"
 
 	"github.com/juju/errors"
@@ -61,20 +60,11 @@ func (s *auditSuite) TestValidate_NonUTCTimestampInvalid(c *gc.C) {
 
 func (s *auditSuite) TestValidate_NilOriginIPErrors(c *gc.C) {
 	invalidEntry := validEntry()
-	invalidEntry.OriginIP = nil
+	invalidEntry.RemoteAddress = ""
 
 	validationErr := invalidEntry.Validate()
 	c.Check(validationErr, jc.Satisfies, errors.IsNotValid)
-	c.Check(validationErr, gc.ErrorMatches, "OriginIP not assigned")
-}
-
-func (s *auditSuite) TestValidate_ZeroOriginIPErrors(c *gc.C) {
-	invalidEntry := validEntry()
-	invalidEntry.OriginIP = net.IPv4zero
-
-	validationErr := invalidEntry.Validate()
-	c.Check(validationErr, jc.Satisfies, errors.IsNotValid)
-	c.Check(validationErr, gc.ErrorMatches, "OriginIP not assigned")
+	c.Check(validationErr, gc.ErrorMatches, "RemoteAddress not assigned")
 }
 
 func (s *auditSuite) TestValidate_EmptyOriginTypeErrors(c *gc.C) {
@@ -118,7 +108,7 @@ func validEntry() audit.AuditEntry {
 		JujuServerVersion: version.MustParse("1.0.0"),
 		ModelUUID:         utils.MustNewUUID().String(),
 		Timestamp:         time.Now().UTC(),
-		OriginIP:          net.IPv4(8, 8, 8, 8),
+		RemoteAddress:     "8.8.8.8",
 		OriginType:        ".",
 		OriginName:        ".",
 		Operation:         ".",

--- a/state/internal/audit/audit.go
+++ b/state/internal/audit/audit.go
@@ -27,9 +27,9 @@ type auditEntryDoc struct {
 	// unmarshaled via time.Time::UnmarshalText.
 	Timestamp string `bson:"timestamp"`
 
-	// OriginIP is the IP of the machine from which the audit-event
-	// was triggered.
-	OriginIP string `bson:"origin-ip"`
+	// RemoteAddress is the IP of the machine from which the
+	// audit-event was triggered.
+	RemoteAddress string `bson:"remote-address"`
 
 	// OriginType is the type of entity (e.g. model, user, action)
 	// which triggered the audit event.
@@ -72,16 +72,11 @@ func auditEntryDocFromAuditEntry(auditEntry audit.AuditEntry) (auditEntryDoc, er
 		return auditEntryDoc{}, errors.Trace(err)
 	}
 
-	ipAsBlob, err := auditEntry.OriginIP.MarshalText()
-	if err != nil {
-		return auditEntryDoc{}, errors.Trace(err)
-	}
-
 	return auditEntryDoc{
 		JujuServerVersion: auditEntry.JujuServerVersion,
 		ModelUUID:         auditEntry.ModelUUID,
 		Timestamp:         string(timeAsBlob),
-		OriginIP:          string(ipAsBlob),
+		RemoteAddress:     auditEntry.RemoteAddress,
 		OriginType:        auditEntry.OriginType,
 		OriginName:        auditEntry.OriginName,
 		Operation:         auditEntry.Operation,

--- a/state/internal/audit/audit_test.go
+++ b/state/internal/audit/audit_test.go
@@ -4,7 +4,6 @@
 package audit_test
 
 import (
-	"net"
 	"time"
 
 	"github.com/juju/errors"
@@ -32,7 +31,7 @@ func (*AuditSuite) TestPutAuditEntry_PersistAuditEntry(c *gc.C) {
 		JujuServerVersion: version.MustParse("1.0.0"),
 		ModelUUID:         utils.MustNewUUID().String(),
 		Timestamp:         time.Now().UTC(),
-		OriginIP:          net.ParseIP("8.8.8.8"),
+		RemoteAddress:     "8.8.8.8",
 		OriginType:        "user",
 		OriginName:        "bob",
 		Operation:         "status",
@@ -53,9 +52,6 @@ func (*AuditSuite) TestPutAuditEntry_PersistAuditEntry(c *gc.C) {
 		serializedAuditDoc, err := bson.Marshal(docs[0])
 		c.Assert(err, jc.ErrorIsNil)
 
-		requestedIPBlob, err := requested.OriginIP.MarshalText()
-		c.Assert(err, jc.ErrorIsNil)
-
 		requestedTimeBlob, err := requested.Timestamp.MarshalText()
 		c.Assert(err, jc.ErrorIsNil)
 
@@ -63,7 +59,7 @@ func (*AuditSuite) TestPutAuditEntry_PersistAuditEntry(c *gc.C) {
 			"juju-server-version": requested.JujuServerVersion,
 			"model-uuid":          requested.ModelUUID,
 			"timestamp":           string(requestedTimeBlob),
-			"origin-ip":           string(requestedIPBlob),
+			"remote-address":      "8.8.8.8",
 			"origin-type":         requested.OriginType,
 			"origin-name":         requested.OriginName,
 			"operation":           requested.Operation,
@@ -94,7 +90,7 @@ func (*AuditSuite) TestPutAuditEntry_PropagatesWriteError(c *gc.C) {
 		JujuServerVersion: version.MustParse("1.0.0"),
 		ModelUUID:         uuid.String(),
 		Timestamp:         time.Now().UTC(),
-		OriginIP:          net.ParseIP("8.8.8.8"),
+		RemoteAddress:     "8.8.8.8",
 		OriginType:        "user",
 		OriginName:        "bob",
 		Operation:         "status",


### PR DESCRIPTION
The Audit observer records all API requests and store them in the Audit collection.

(Review request: http://reviews.vapour.ws/r/5154/)