### PR TITLE
Only require "authorized-keys" at bootstrap

### DIFF
--- a/apiserver/keymanager/keymanager.go
+++ b/apiserver/keymanager/keymanager.go
@@ -145,7 +145,7 @@ func parseKeys(keys []string, mode ssh.ListMode) (keyInfo []string) {
 func (api *KeyManagerAPI) writeSSHKeys(sshKeys []string) error {
 	// Write out the new keys.
 	keyStr := strings.Join(sshKeys, "\n")
-	attrs := map[string]interface{}{config.AuthKeysConfig: keyStr}
+	attrs := map[string]interface{}{config.AuthorizedKeysKey: keyStr}
 	// TODO(waigani) 2014-03-17 bug #1293324
 	// Pass in validation to ensure SSH keys
 	// have not changed underfoot

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -142,15 +142,14 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 	c.Assert(uuid, gc.Not(gc.Equals), s.st.controllerModel.cfg.UUID())
 
 	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
-		"name":            "foo",
-		"type":            "dummy",
-		"authorized-keys": s.st.controllerModel.cfg.AuthorizedKeys(),
-		"uuid":            uuid,
-		"agent-version":   jujuversion.Current.String(),
-		"bar":             "baz",
-		"controller":      false,
-		"broken":          "",
-		"secret":          "pork",
+		"name":          "foo",
+		"type":          "dummy",
+		"uuid":          uuid,
+		"agent-version": jujuversion.Current.String(),
+		"bar":           "baz",
+		"controller":    false,
+		"broken":        "",
+		"secret":        "pork",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	// TODO(wallyworld) - we need to separate controller and model schemas

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -437,6 +437,9 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	for k, v := range userConfigAttrs {
 		configAttrs[k] = v
 	}
+	if err := common.FinalizeAuthorizedKeys(ctx, configAttrs); err != nil {
+		return errors.Trace(err)
+	}
 	logger.Debugf("preparing controller with config: %v", configAttrs)
 
 	// Read existing current controller so we can clean up on error.
@@ -596,7 +599,7 @@ to clean up the model.`[1:])
 	// model config. These attributes may be modified during bootstrap; by
 	// removing them from this map, we ensure the modified values are
 	// inherited.
-	delete(hostedModelConfig, config.AuthKeysConfig)
+	delete(hostedModelConfig, config.AuthorizedKeysKey)
 	delete(hostedModelConfig, config.AgentVersionKey)
 
 	// Based on the attribute names in clouds.yaml, create

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -241,9 +241,10 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 	c.Assert(bootstrapConfig.Cloud, gc.Equals, "dummy")
 	c.Assert(bootstrapConfig.Credential, gc.Equals, "")
 	c.Assert(bootstrapConfig.Config, jc.DeepEquals, map[string]interface{}{
-		"name":           environs.ControllerModelName,
-		"type":           "dummy",
-		"default-series": "raring",
+		"name":            environs.ControllerModelName,
+		"type":            "dummy",
+		"default-series":  "raring",
+		"authorized-keys": "public auth key\n",
 	})
 
 	return restore

--- a/cmd/juju/common/authkeys.go
+++ b/cmd/juju/common/authkeys.go
@@ -1,0 +1,123 @@
+// Copyright 2012-2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/schema"
+	"github.com/juju/utils"
+	"github.com/juju/utils/ssh"
+)
+
+var ErrNoAuthorizedKeys = errors.New("no public ssh keys found")
+
+// FinalizeAuthorizedKeys takes a set of configuration attributes and
+// ensures that it has an authorized-keys setting, or returns
+// ErrNoAuthorizedKeys if it cannot.
+//
+// If the attributes contains a non-empty value for "authorized-keys",
+// then it is left alone. If there is an "authorized-keys-path" setting,
+// its contents will be loaded into "authorized-keys". Otherwise, the
+// contents of standard public keys will be used: ~/.ssh/id_dsa.pub,
+// ~/.ssh/id_rsa.pub, and ~/.ssh/identity.pub.
+func FinalizeAuthorizedKeys(ctx *cmd.Context, attrs map[string]interface{}) error {
+	const authorizedKeysPathKey = "authorized-keys-path"
+	checker := schema.FieldMap(schema.Fields{
+		config.AuthorizedKeysKey: schema.String(),
+		authorizedKeysPathKey:    schema.String(),
+	}, schema.Defaults{
+		config.AuthorizedKeysKey: schema.Omit,
+		authorizedKeysPathKey:    schema.Omit,
+	})
+	coerced, err := checker.Coerce(attrs, nil)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	coercedAttrs := coerced.(map[string]interface{})
+
+	authorizedKeys, haveAuthorizedKeys := coercedAttrs[config.AuthorizedKeysKey].(string)
+	authorizedKeysPath, haveAuthorizedKeysPath := coercedAttrs[authorizedKeysPathKey].(string)
+	if haveAuthorizedKeys && haveAuthorizedKeysPath {
+		return errors.Errorf(
+			"%q and %q may not both be specified",
+			config.AuthorizedKeysKey, authorizedKeysPathKey,
+		)
+	}
+	if haveAuthorizedKeys {
+		// We have authorized-keys already; nothing to do.
+		return nil
+	}
+
+	authorizedKeys, err = ReadAuthorizedKeys(ctx, authorizedKeysPath)
+	if err != nil {
+		return errors.Annotate(err, "reading authorized-keys")
+	}
+	if haveAuthorizedKeysPath {
+		delete(attrs, authorizedKeysPathKey)
+	}
+	attrs[config.AuthorizedKeysKey] = authorizedKeys
+	return nil
+}
+
+// ReadAuthorizedKeys implements the standard juju behaviour for finding
+// authorized_keys. It returns a set of keys in in authorized_keys format
+// (see sshd(8) for a description).  If path is non-empty, it names the
+// file to use; otherwise the user's .ssh directory will be searched.
+// Home directory expansion will be performed on the path if it starts with
+// a ~; if the expanded path is relative, it will be interpreted relative
+// to $HOME/.ssh.
+//
+// The result of utils/ssh.PublicKeyFiles will always be prepended to the
+// result. In practice, this means ReadAuthorizedKeys never returns an
+// error when the call originates in the CLI.
+//
+// If no SSH keys are found, ReadAuthorizedKeys returns
+// ErrNoAuthorizedKeys.
+func ReadAuthorizedKeys(ctx *cmd.Context, path string) (string, error) {
+	files := ssh.PublicKeyFiles()
+	if path == "" {
+		files = append(files, "id_dsa.pub", "id_rsa.pub", "identity.pub")
+	} else {
+		files = append(files, path)
+	}
+	var firstError error
+	var keyData []byte
+	for _, f := range files {
+		f, err := utils.NormalizePath(f)
+		if err != nil {
+			if firstError == nil {
+				firstError = err
+			}
+			continue
+		}
+		if !filepath.IsAbs(f) {
+			f = filepath.Join(utils.Home(), ".ssh", f)
+		}
+		data, err := ioutil.ReadFile(f)
+		if err != nil {
+			if firstError == nil && !os.IsNotExist(err) {
+				firstError = err
+			}
+			continue
+		}
+		keyData = append(keyData, bytes.Trim(data, "\n")...)
+		keyData = append(keyData, '\n')
+		ctx.Verbosef("Adding contents of %q to authorized-keys", f)
+	}
+	if len(keyData) == 0 {
+		if firstError == nil {
+			firstError = ErrNoAuthorizedKeys
+		}
+		return "", firstError
+	}
+	return string(keyData), nil
+
+}

--- a/cmd/juju/common/authkeys_test.go
+++ b/cmd/juju/common/authkeys_test.go
@@ -1,0 +1,124 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	"github.com/juju/utils/ssh"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/testing"
+)
+
+type AuthKeysSuite struct {
+	testing.BaseSuite
+	dotssh string // ~/.ssh
+}
+
+var _ = gc.Suite(&AuthKeysSuite{})
+
+func (s *AuthKeysSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	old := utils.Home()
+	newhome := c.MkDir()
+	err := utils.SetHome(newhome)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(*gc.C) {
+		ssh.ClearClientKeys()
+		err := utils.SetHome(old)
+		c.Assert(err, jc.ErrorIsNil)
+	})
+
+	s.dotssh = filepath.Join(newhome, ".ssh")
+	err = os.Mkdir(s.dotssh, 0755)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *AuthKeysSuite) TestReadAuthorizedKeysErrors(c *gc.C) {
+	ctx := testing.Context(c)
+	_, err := common.ReadAuthorizedKeys(ctx, "")
+	c.Assert(err, gc.ErrorMatches, "no public ssh keys found")
+	c.Assert(err, gc.Equals, common.ErrNoAuthorizedKeys)
+	_, err = common.ReadAuthorizedKeys(ctx, filepath.Join(s.dotssh, "notthere.pub"))
+	c.Assert(err, gc.ErrorMatches, "no public ssh keys found")
+	c.Assert(err, gc.Equals, common.ErrNoAuthorizedKeys)
+}
+
+func writeFile(c *gc.C, filename string, contents string) {
+	err := ioutil.WriteFile(filename, []byte(contents), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *AuthKeysSuite) TestReadAuthorizedKeys(c *gc.C) {
+	ctx := testing.Context(c)
+	writeFile(c, filepath.Join(s.dotssh, "id_rsa.pub"), "id_rsa")
+	writeFile(c, filepath.Join(s.dotssh, "identity.pub"), "identity")
+	writeFile(c, filepath.Join(s.dotssh, "test.pub"), "test")
+	keys, err := common.ReadAuthorizedKeys(ctx, "")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(keys, gc.Equals, "id_rsa\nidentity\n")
+	keys, err = common.ReadAuthorizedKeys(ctx, "test.pub") // relative to ~/.ssh
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(keys, gc.Equals, "test\n")
+}
+
+func (s *AuthKeysSuite) TestReadAuthorizedKeysClientKeys(c *gc.C) {
+	ctx := testing.Context(c)
+	keydir := filepath.Join(s.dotssh, "juju")
+	err := ssh.LoadClientKeys(keydir) // auto-generates a key pair
+	c.Assert(err, jc.ErrorIsNil)
+	pubkeyFiles := ssh.PublicKeyFiles()
+	c.Assert(pubkeyFiles, gc.HasLen, 1)
+	data, err := ioutil.ReadFile(pubkeyFiles[0])
+	c.Assert(err, jc.ErrorIsNil)
+	prefix := strings.Trim(string(data), "\n") + "\n"
+
+	writeFile(c, filepath.Join(s.dotssh, "id_rsa.pub"), "id_rsa")
+	writeFile(c, filepath.Join(s.dotssh, "test.pub"), "test")
+	keys, err := common.ReadAuthorizedKeys(ctx, "")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(keys, gc.Equals, prefix+"id_rsa\n")
+	keys, err = common.ReadAuthorizedKeys(ctx, "test.pub")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(keys, gc.Equals, prefix+"test\n")
+	keys, err = common.ReadAuthorizedKeys(ctx, "notthere.pub")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(keys, gc.Equals, prefix)
+}
+
+func (s *AuthKeysSuite) TestFinalizeAuthorizedKeysNoop(c *gc.C) {
+	attrs := map[string]interface{}{"authorized-keys": "meep"}
+	err := common.FinalizeAuthorizedKeys(testing.Context(c), attrs)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(attrs, jc.DeepEquals, map[string]interface{}{"authorized-keys": "meep"})
+}
+
+func (s *AuthKeysSuite) TestFinalizeAuthorizedKeysPath(c *gc.C) {
+	writeFile(c, filepath.Join(s.dotssh, "whatever"), "meep")
+	attrs := map[string]interface{}{"authorized-keys-path": "whatever"}
+	err := common.FinalizeAuthorizedKeys(testing.Context(c), attrs)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(attrs, jc.DeepEquals, map[string]interface{}{"authorized-keys": "meep\n"})
+}
+
+func (s *AuthKeysSuite) TestFinalizeAuthorizedKeysDefault(c *gc.C) {
+	writeFile(c, filepath.Join(s.dotssh, "id_rsa.pub"), "meep")
+	attrs := map[string]interface{}{}
+	err := common.FinalizeAuthorizedKeys(testing.Context(c), attrs)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(attrs, jc.DeepEquals, map[string]interface{}{"authorized-keys": "meep\n"})
+}
+
+func (s *AuthKeysSuite) TestFinalizeAuthorizedKeysConflict(c *gc.C) {
+	attrs := map[string]interface{}{"authorized-keys": "foo", "authorized-keys-path": "bar"}
+	err := common.FinalizeAuthorizedKeys(testing.Context(c), attrs)
+	c.Assert(err, gc.ErrorMatches, `"authorized-keys" and "authorized-keys-path" may not both be specified`)
+}

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/api/machinemanager"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/block"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
@@ -214,12 +215,17 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 
 	if c.Placement != nil && c.Placement.Scope == "ssh" {
 		logger.Infof("manual provisioning")
+		authKeys, err := common.ReadAuthorizedKeys(ctx, "")
+		if err != nil {
+			return errors.Annotate(err, "reading authorized-keys")
+		}
 		args := manual.ProvisionMachineArgs{
-			Host:   c.Placement.Directive,
-			Client: client,
-			Stdin:  ctx.Stdin,
-			Stdout: ctx.Stdout,
-			Stderr: ctx.Stderr,
+			Host:           c.Placement.Directive,
+			Client:         client,
+			Stdin:          ctx.Stdin,
+			Stdout:         ctx.Stdout,
+			Stderr:         ctx.Stderr,
+			AuthorizedKeys: authKeys,
 			UpdateBehavior: &params.UpdateBehavior{
 				config.EnableOSRefreshUpdate(),
 				config.EnableOSUpgrade(),

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -183,7 +183,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		return errors.Annotate(err, "failed to generate system key")
 	}
 	authorizedKeys := config.ConcatAuthKeys(args.ControllerModelConfig.AuthorizedKeys(), publicKey)
-	newConfigAttrs[config.AuthKeysConfig] = authorizedKeys
+	newConfigAttrs[config.AuthorizedKeysKey] = authorizedKeys
 
 	// Generate a shared secret for the Mongo replica set, and write it out.
 	sharedSecret, err := mongo.GenerateSharedSecret()

--- a/controller/modelmanager/createmodel.go
+++ b/controller/modelmanager/createmodel.go
@@ -200,14 +200,6 @@ func finalizeConfig(isAdmin bool, controllerUUID string, controllerModelCfg *con
 		return nil, errors.Trace(err)
 	}
 
-	if isAdmin {
-		// If the user is an administrator, and has not supplied authorized-keys,
-		// copy across authorized-keys from the controller model.
-		const key = "authorized-keys"
-		if _, ok := attrs[key]; !ok {
-			attrs[key] = controllerModelCfg.AllAttrs()[key]
-		}
-	}
 	cfg, err := config.New(config.UseDefaults, attrs)
 	if err != nil {
 		return nil, errors.Annotate(err, "creating config from values failed")

--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -91,63 +91,11 @@ func (s *ModelConfigCreatorSuite) TestCreateModelValidatesConfig(c *gc.C) {
 	c.Assert(validateCall.Args[1], gc.IsNil)
 }
 
-func (s *ModelConfigCreatorSuite) TestCreateModelForAdminUserCopiesSecrets(c *gc.C) {
-	var err error
-	s.baseConfig, err = s.baseConfig.Apply(coretesting.Attrs{
-		"authorized-keys": "ssh-key",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	newModelUUID := utils.MustNewUUID().String()
-	newAttrs := coretesting.Attrs{
-		"name":       "new-model",
-		"additional": "value",
-		"uuid":       newModelUUID,
-	}
-	cfg, err := s.newModelConfigAdmin(newAttrs)
-	c.Assert(err, jc.ErrorIsNil)
-	expectedCfg, err := config.New(config.UseDefaults, newAttrs)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// TODO(wallyworld) - we need to separate controller and model schemas
-	// Remove any remaining controller attributes from the env config.
-	expectedCfg, err = expectedCfg.Remove(controller.ControllerOnlyConfigAttributes)
-	c.Assert(err, jc.ErrorIsNil)
-
-	expected := expectedCfg.AllAttrs()
-	c.Assert(expected["authorized-keys"], gc.Equals, "ssh-key")
-	c.Assert(cfg.AllAttrs(), jc.DeepEquals, expected)
-
-	fake.Stub.CheckCallNames(c,
-		"RestrictedConfigAttributes",
-		"PrepareForCreateEnvironment",
-		"Validate",
-	)
-	validateCall := fake.Stub.Calls()[2]
-	c.Assert(validateCall.Args, gc.HasLen, 2)
-	c.Assert(validateCall.Args[0], gc.Equals, cfg)
-	c.Assert(validateCall.Args[1], gc.IsNil)
-}
-
-func (s *ModelConfigCreatorSuite) TestCreateModelEnsuresRequiredFields(c *gc.C) {
-	var err error
-	s.baseConfig, err = s.baseConfig.Apply(coretesting.Attrs{
-		"authorized-keys": "ssh-key",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	newAttrs := coretesting.Attrs{
-		"name": "new-model",
-	}
-	_, err = s.newModelConfigAdmin(newAttrs)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newAttrs["authorized-keys"], gc.Equals, "ssh-key")
-}
-
 func (s *ModelConfigCreatorSuite) TestCreateModelForAdminUserPrefersUserSecrets(c *gc.C) {
 	var err error
 	s.baseConfig, err = s.baseConfig.Apply(coretesting.Attrs{
-		"username":        "user",
-		"password":        "password",
-		"authorized-keys": "ssh-key",
+		"username": "user",
+		"password": "password",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	newModelUUID := utils.MustNewUUID().String()
@@ -171,7 +119,6 @@ func (s *ModelConfigCreatorSuite) TestCreateModelForAdminUserPrefersUserSecrets(
 	expected := expectedCfg.AllAttrs()
 	c.Assert(expected["username"], gc.Equals, "anotheruser")
 	c.Assert(expected["password"], gc.Equals, "anotherpassword")
-	c.Assert(expected["authorized-keys"], gc.Equals, "ssh-key")
 	c.Assert(cfg.AllAttrs(), jc.DeepEquals, expected)
 
 	fake.Stub.CheckCallNames(c,

--- a/environs/config/authkeys.go
+++ b/environs/config/authkeys.go
@@ -3,78 +3,10 @@
 
 package config
 
-import (
-	"bytes"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-
-	"github.com/juju/errors"
-	"github.com/juju/utils"
-	"github.com/juju/utils/ssh"
-)
-
 const (
-	// AuthKeysConfig is the configuration key for authorised keys.
-	AuthKeysConfig = "authorized-keys"
 	// JujuSystemKey is the SSH key comment for Juju system keys.
 	JujuSystemKey = "juju-system-key"
 )
-
-var ErrNoAuthorizedKeys = errors.New("no public ssh keys found")
-
-// ReadAuthorizedKeys implements the standard juju behaviour for finding
-// authorized_keys. It returns a set of keys in in authorized_keys format
-// (see sshd(8) for a description).  If path is non-empty, it names the
-// file to use; otherwise the user's .ssh directory will be searched.
-// Home directory expansion will be performed on the path if it starts with
-// a ~; if the expanded path is relative, it will be interpreted relative
-// to $HOME/.ssh.
-//
-// The result of utils/ssh.PublicKeyFiles will always be prepended to the
-// result. In practice, this means ReadAuthorizedKeys never returns an
-// error when the call originates in the CLI.
-//
-// If no SSH keys are found, ReadAuthorizedKeys returns
-// ErrNoAuthorizedKeys.
-func ReadAuthorizedKeys(path string) (string, error) {
-	files := ssh.PublicKeyFiles()
-	if path == "" {
-		files = append(files, "id_dsa.pub", "id_rsa.pub", "identity.pub")
-	} else {
-		files = append(files, path)
-	}
-	var firstError error
-	var keyData []byte
-	for _, f := range files {
-		f, err := utils.NormalizePath(f)
-		if err != nil {
-			if firstError == nil {
-				firstError = err
-			}
-			continue
-		}
-		if !filepath.IsAbs(f) {
-			f = filepath.Join(utils.Home(), ".ssh", f)
-		}
-		data, err := ioutil.ReadFile(f)
-		if err != nil {
-			if firstError == nil && !os.IsNotExist(err) {
-				firstError = err
-			}
-			continue
-		}
-		keyData = append(keyData, bytes.Trim(data, "\n")...)
-		keyData = append(keyData, '\n')
-	}
-	if len(keyData) == 0 {
-		if firstError == nil {
-			firstError = ErrNoAuthorizedKeys
-		}
-		return "", firstError
-	}
-	return string(keyData), nil
-}
 
 // ConcatAuthKeys concatenates the two sets of authorised keys, interposing
 // a newline if necessary, because authorised keys are newline-separated.

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -134,12 +134,6 @@ var configTests = []configTest{
 			"authorized-keys": testing.FakeAuthKeys,
 		}),
 	}, {
-		about:       "Load authorized-keys from path",
-		useDefaults: config.UseDefaults,
-		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"authorized-keys-path": "~/.ssh/authorized_keys2",
-		}),
-	}, {
 		about:       "CA cert & key from path",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
@@ -209,37 +203,32 @@ var configTests = []configTest{
 		about:       "Specified agent version",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"authorized-keys": testing.FakeAuthKeys,
-			"agent-version":   "1.2.3",
+			"agent-version": "1.2.3",
 		}),
 	}, {
 		about:       "Specified development flag",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"authorized-keys": testing.FakeAuthKeys,
-			"development":     true,
+			"development": true,
 		}),
 	}, {
 		about:       "Specified admin secret",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"authorized-keys": testing.FakeAuthKeys,
-			"development":     false,
-			"admin-secret":    "pork",
+			"development":  false,
+			"admin-secret": "pork",
 		}),
 	}, {
 		about:       "Invalid development flag",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"authorized-keys": testing.FakeAuthKeys,
-			"development":     "invalid",
+			"development": "invalid",
 		}),
 		err: `development: expected bool, got string\("invalid"\)`,
 	}, {
 		about:       "Invalid disable-network-management flag",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"authorized-keys":            testing.FakeAuthKeys,
 			"disable-network-management": "invalid",
 		}),
 		err: `disable-network-management: expected bool, got string\("invalid"\)`,
@@ -290,8 +279,7 @@ var configTests = []configTest{
 		about:       "Invalid agent version",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"authorized-keys": testing.FakeAuthKeys,
-			"agent-version":   "2",
+			"agent-version": "2",
 		}),
 		err: `invalid agent version in model configuration: "2"`,
 	}, {
@@ -549,16 +537,6 @@ var configTests = []configTest{
 		attrs:       sampleConfig.Merge(testing.Attrs{"ca-private-key-path": "arble"}),
 		err:         `attribute "ca-private-key-path" is not allowed in configuration`,
 	}, {
-		about:       "No defaults: with authorized-keys-path",
-		useDefaults: config.NoDefaults,
-		attrs:       sampleConfig.Merge(testing.Attrs{"authorized-keys-path": "arble"}),
-		err:         `attribute "authorized-keys-path" is not allowed in configuration`,
-	}, {
-		about:       "No defaults: missing authorized-keys",
-		useDefaults: config.NoDefaults,
-		attrs:       sampleConfig.Delete("authorized-keys"),
-		err:         `authorized-keys missing from model configuration`,
-	}, {
 		about:       "Config settings from juju actual installation",
 		useDefaults: config.NoDefaults,
 		attrs: map[string]interface{}{
@@ -812,7 +790,6 @@ var noCertFilesTests = []configTest{
 			"name":            "my-name",
 			"uuid":            testing.ModelTag.Id(),
 			"controller-uuid": testing.ModelTag.Id(),
-			"authorized-keys": testing.FakeAuthKeys,
 		},
 	}, {
 		about:       "Unspecified certificate, specified key",
@@ -822,7 +799,6 @@ var noCertFilesTests = []configTest{
 			"name":            "my-name",
 			"uuid":            testing.ModelTag.Id(),
 			"controller-uuid": testing.ModelTag.Id(),
-			"authorized-keys": testing.FakeAuthKeys,
 			"ca-private-key":  caKey,
 		},
 		err: "bad CA certificate/key in configuration: .*tls:.*",
@@ -845,7 +821,6 @@ var emptyCertFilesTests = []configTest{
 			"name":            "my-name",
 			"uuid":            testing.ModelTag.Id(),
 			"controller-uuid": testing.ModelTag.Id(),
-			"authorized-keys": testing.FakeAuthKeys,
 			"ca-private-key":  caKey,
 		},
 		err: fmt.Sprintf(`file ".*%smy-name-cert.pem" is empty`, regexp.QuoteMeta(string(os.PathSeparator))),
@@ -857,7 +832,6 @@ var emptyCertFilesTests = []configTest{
 			"name":            "my-name",
 			"uuid":            testing.ModelTag.Id(),
 			"controller-uuid": testing.ModelTag.Id(),
-			"authorized-keys": testing.FakeAuthKeys,
 		},
 		err: fmt.Sprintf(`file ".*%smy-name-cert.pem" is empty`, regexp.QuoteMeta(string(os.PathSeparator))),
 	}, {
@@ -868,7 +842,6 @@ var emptyCertFilesTests = []configTest{
 			"name":            "my-name",
 			"uuid":            testing.ModelTag.Id(),
 			"controller-uuid": testing.ModelTag.Id(),
-			"authorized-keys": testing.FakeAuthKeys,
 			"ca-cert":         caCert,
 		},
 		err: fmt.Sprintf(`file ".*%smy-name-private-key.pem" is empty`, regexp.QuoteMeta(string(os.PathSeparator))),
@@ -878,7 +851,6 @@ var emptyCertFilesTests = []configTest{
 		attrs: testing.Attrs{
 			"type":            "my-type",
 			"name":            "my-name",
-			"authorized-keys": testing.FakeAuthKeys,
 			"ca-cert":         "",
 			"ca-private-key":  "",
 		},
@@ -888,7 +860,6 @@ var emptyCertFilesTests = []configTest{
 		attrs: testing.Attrs{
 			"type":            "my-type",
 			"name":            "my-name",
-			"authorized-keys": testing.FakeAuthKeys,
 			"ca-cert":         "",
 		},
 		err: "bad CA certificate/key in configuration: crypto/tls: .*",
@@ -916,7 +887,6 @@ func (s *ConfigSuite) TestNoDefinedPrivateCert(c *gc.C) {
 		"name":            "my-name",
 		"uuid":            testing.ModelTag.Id(),
 		"controller-uuid": testing.ModelTag.Id(),
-		"authorized-keys": testing.FakeAuthKeys,
 		"ca-cert":         testing.CACert,
 		"ca-private-key":  "",
 	}
@@ -996,15 +966,8 @@ func (test configTest) check(c *gc.C, home *gitjujutesting.FakeHome) {
 		c.Assert(cfg.AdminSecret(), gc.Equals, secret)
 	}
 
-	if path, _ := test.attrs["authorized-keys-path"].(string); path != "" {
-		c.Assert(cfg.AuthorizedKeys(), gc.Equals, home.FileContents(c, path))
-		c.Assert(cfg.AllAttrs()["authorized-keys-path"], gc.IsNil)
-	} else if keys, _ := test.attrs["authorized-keys"].(string); keys != "" {
-		c.Assert(cfg.AuthorizedKeys(), gc.Equals, keys)
-	} else {
-		// Content of all the files that are read by default.
-		c.Assert(cfg.AuthorizedKeys(), gc.Equals, "dsa\nrsa\nidentity\n")
-	}
+	keys, _ := test.attrs["authorized-keys"].(string)
+	c.Assert(cfg.AuthorizedKeys(), gc.Equals, keys)
 
 	lfCfg, hasLogCfg := cfg.LogFwdSyslog()
 	if v, ok := test.attrs["syslog-server-cert"].(string); v != "" {

--- a/environs/manual/provisioner.go
+++ b/environs/manual/provisioner.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cloudconfig/sshinit"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state/multiwatcher"
 )
@@ -58,6 +57,10 @@ type ProvisionMachineArgs struct {
 	// Stderr is required to present machine provisioning progress to the user.
 	Stderr io.Writer
 
+	// AuthorizedKeys contains the concatenated authorized-keys to add to the
+	// ubuntu user's ~/.ssh/authorized_keys.
+	AuthorizedKeys string
+
 	*params.UpdateBehavior
 }
 
@@ -87,8 +90,7 @@ func ProvisionMachine(args ProvisionMachineArgs) (machineId string, err error) {
 	// user's ~/.ssh directory. The authenticationworker will later update the
 	// ubuntu user's authorized_keys.
 	user, hostname := splitUserHost(args.Host)
-	authorizedKeys, err := config.ReadAuthorizedKeys("")
-	if err := InitUbuntuUser(hostname, user, authorizedKeys, args.Stdin, args.Stdout); err != nil {
+	if err := InitUbuntuUser(hostname, user, args.AuthorizedKeys, args.Stdin, args.Stdout); err != nil {
 		return "", err
 	}
 

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -150,7 +150,12 @@ func (s *cmdControllerSuite) TestAddModel(c *gc.C) {
 	// a config value for 'controller'.
 	context := s.run(c, "add-model", "new-model", "authorized-keys=fake-key", "controller=false")
 	c.Check(testing.Stdout(context), gc.Equals, "")
-	c.Check(testing.Stderr(context), gc.Equals, "Added 'new-model' model for user 'admin'\n")
+	c.Check(testing.Stderr(context), gc.Equals, `
+Added 'new-model' model for user 'admin'
+
+No SSH authorized-keys were found. You must use "juju add-ssh-key"
+before "juju ssh", "juju scp", or "juju debug-hooks" will work.
+`[1:])
 
 	// Make sure that the saved server details are sufficient to connect
 	// to the api server.

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -44,7 +44,7 @@ func (s *providerSuite) TestPrepareForCreateEnvironment(c *gc.C) {
 func (s *providerSuite) TestPrepareForBootstrapCloudEndpointAndRegion(c *gc.C) {
 	ctx, err := s.testPrepareForBootstrap(c, "endpoint", "region")
 	c.Assert(err, jc.ErrorIsNil)
-	s.CheckCall(c, 0, "InitUbuntuUser", "endpoint", "", "public auth key\n", ctx.GetStdin(), ctx.GetStdout())
+	s.CheckCall(c, 0, "InitUbuntuUser", "endpoint", "", "", ctx.GetStdin(), ctx.GetStdout())
 }
 
 func (s *providerSuite) TestPrepareForBootstrapNoCloudEndpoint(c *gc.C) {


### PR DESCRIPTION
We make authorized-keys an optional configuration
attribute, except at bootstrap time. This is already
enforced by the bootstrap code, so we're really just
making it an optional config attribute.

Also, move the handling of authorized-keys-path out
of environs/config, and into the client/CLI code.
That is the only place where it makes sense.

Finally, we add authorized-keys to the config when
creating a new model from the CLI, if it is possible
to do so. This means that we no longer need the
special-cased authorized-keys copying for models
created by controller admins.

(Review request: http://reviews.vapour.ws/r/5156/)