### PR TITLE
worker/migrationmaster: Wait for minions at SUCCESS

### DIFF
--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -168,6 +168,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		migrationMasterName: ifNotDead(migrationmaster.Manifold(migrationmaster.ManifoldConfig{
 			APICallerName: apiCallerName,
 			FortressName:  migrationFortressName,
+			Clock:         config.Clock,
 			NewFacade:     migrationmaster.NewFacade,
 			NewWorker:     migrationmaster.NewWorker,
 		})),

--- a/core/migration/migration.go
+++ b/core/migration/migration.go
@@ -46,37 +46,3 @@ type SerializedModel struct {
 	// source controller.
 	Tools map[version.Binary]string // version -> tools URI
 }
-
-// MinionReports returns information about the migration minion
-// reports received so far for a given migration phase.
-type MinionReports struct {
-	// ModelUUID holds the unique identifier for the model migration.
-	MigrationId string
-
-	// Phases indicates the migration phase the reports relate to.
-	Phase Phase
-
-	// SuccesCount indicates how many agents have successfully
-	// completed the migration phase.
-	SuccessCount int
-
-	// UnknownCount indicates how many agents are yet to report
-	// regarding the migration phase.
-	UnknownCount int
-
-	// SomeUnknownMachines holds the ids of some of the machines which
-	// have not yet reported in.
-	SomeUnknownMachines []string
-
-	// SomeUnknownUnits holds the names of some of the units which
-	// have not yet reported in.
-	SomeUnknownUnits []string
-
-	// FailedMachines holds the ids of machines which have failed to
-	// complete the migration phase.
-	FailedMachines []string
-
-	// FailedUnits holds the names of units which have failed to
-	// complete the migration phase.
-	FailedUnits []string
-}

--- a/core/migration/minionreports.go
+++ b/core/migration/minionreports.go
@@ -1,0 +1,43 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migration
+
+// MinionReports returns information about the migration minion
+// reports received so far for a given migration phase.
+type MinionReports struct {
+	// ModelUUID holds the unique identifier for the model migration.
+	MigrationId string
+
+	// Phases indicates the migration phase the reports relate to.
+	Phase Phase
+
+	// SuccesCount indicates how many agents have successfully
+	// completed the migration phase.
+	SuccessCount int
+
+	// UnknownCount indicates how many agents are yet to report
+	// regarding the migration phase.
+	UnknownCount int
+
+	// SomeUnknownMachines holds the ids of some of the machines which
+	// have not yet reported in.
+	SomeUnknownMachines []string
+
+	// SomeUnknownUnits holds the names of some of the units which
+	// have not yet reported in.
+	SomeUnknownUnits []string
+
+	// FailedMachines holds the ids of machines which have failed to
+	// complete the migration phase.
+	FailedMachines []string
+
+	// FailedUnits holds the names of units which have failed to
+	// complete the migration phase.
+	FailedUnits []string
+}
+
+// IsZero returns true if the MinionReports instance hasn't been set.
+func (r *MinionReports) IsZero() bool {
+	return r.MigrationId == "" && r.Phase == UNKNOWN
+}

--- a/core/migration/minionreports_test.go
+++ b/core/migration/minionreports_test.go
@@ -1,0 +1,37 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migration_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/migration"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type MinionReportsSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(new(MinionReportsSuite))
+
+func (s *MinionReportsSuite) TestIsZero(c *gc.C) {
+	reports := migration.MinionReports{}
+	c.Check(reports.IsZero(), jc.IsTrue)
+}
+
+func (s *MinionReportsSuite) TestIsZeroIdSet(c *gc.C) {
+	reports := migration.MinionReports{
+		MigrationId: "foo",
+	}
+	c.Check(reports.IsZero(), jc.IsFalse)
+}
+
+func (s *MinionReportsSuite) TestIsZeroPhaseSet(c *gc.C) {
+	reports := migration.MinionReports{
+		Phase: migration.QUIESCE,
+	}
+	c.Check(reports.IsZero(), jc.IsFalse)
+}

--- a/worker/migrationmaster/export_test.go
+++ b/worker/migrationmaster/export_test.go
@@ -1,6 +1,0 @@
-// Copyright 2016 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
-
-package migrationmaster
-
-var TempSuccessSleep = &tempSuccessSleep

--- a/worker/migrationmaster/manifold.go
+++ b/worker/migrationmaster/manifold.go
@@ -5,6 +5,8 @@ package migrationmaster
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/utils/clock"
+
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/migration"
@@ -19,6 +21,7 @@ type ManifoldConfig struct {
 	APICallerName string
 	FortressName  string
 
+	Clock     clock.Clock
 	NewFacade func(base.APICaller) (Facade, error)
 	NewWorker func(Config) (worker.Worker, error)
 }
@@ -36,6 +39,9 @@ func (config ManifoldConfig) validate() error {
 	}
 	if config.NewWorker == nil {
 		return errors.NotValidf("nil NewWorker")
+	}
+	if config.Clock == nil {
+		return errors.NotValidf("nil Clock")
 	}
 	return nil
 }
@@ -65,6 +71,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		UploadBinaries:  migration.UploadBinaries,
 		CharmDownloader: apiClient,
 		ToolsDownloader: apiClient,
+		Clock:           config.Clock,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/migrationmaster/validate_test.go
+++ b/worker/migrationmaster/validate_test.go
@@ -5,13 +5,15 @@ package migrationmaster_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
+	gc "gopkg.in/check.v1"
+
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/migrationmaster"
-	"github.com/juju/testing"
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
 )
 
 type ValidateSuite struct {
@@ -61,6 +63,12 @@ func (*ValidateSuite) TestMissingToolsDownloader(c *gc.C) {
 	checkNotValid(c, config, "nil ToolsDownloader not valid")
 }
 
+func (*ValidateSuite) TestMissingClock(c *gc.C) {
+	config := validConfig()
+	config.Clock = nil
+	checkNotValid(c, config, "nil Clock not valid")
+}
+
 func validConfig() migrationmaster.Config {
 	return migrationmaster.Config{
 		Guard:           struct{ fortress.Guard }{},
@@ -69,6 +77,7 @@ func validConfig() migrationmaster.Config {
 		UploadBinaries:  func(migration.UploadBinariesConfig) error { return nil },
 		CharmDownloader: struct{ migration.CharmDownloader }{},
 		ToolsDownloader: struct{ migration.ToolsDownloader }{},
+		Clock:           struct{ clock.Clock }{},
 	}
 }
 


### PR DESCRIPTION
This change implements the infrastructure for the migration master to wait for minions to report success or failure for the current migration phase. This is used to wait at the SUCCESS phase, allowing
the removal of the temporary sleep that had been used in lieu of actual synchronisation.

A lot of cleanup has been done in the worker tests to reduce duplication and remove unnecessary setup related "noise".

Note that the many TODOs in the the migrationmaster worker are about to be dealt with in upcoming PRs.

(Review request: http://reviews.vapour.ws/r/5158/)