### PR TITLE
lp:1596045 update juju/testing dependency

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -32,7 +32,7 @@ github.com/juju/replicaset	git	fb7294cf57a1e2f08a57691f1246d129a87ab7e8	2015-05-
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/romulus	git	6bf2184bf0e9fe3e74d317e81a9a49a4cdcdf20b	2016-06-20T21:29:55Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
-github.com/juju/testing	git	b718b7113d48d317bd81805963e64f72d75bd667	2016-06-17T13:39:55Z
+github.com/juju/testing	git	ccf839b5a07a7a05009f8fa3ec41cd05fb2e0b08	2016-06-24T20:35:24Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	ffea6ead0c374583e876c8357c9db6e98bc71476	2016-05-26T02:52:51Z


### PR DESCRIPTION
Fixes Mongo version detection on Windows.

(Review request: http://reviews.vapour.ws/r/5164/)