### PR TITLE
juju: remove BootstrapConfig fallback in API connection

### DIFF
--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -288,13 +288,12 @@ To log back in, run the following command:
 	}
 
 	return juju.NewAPIConnectionParams{
-		Store:           store,
-		ControllerName:  controllerName,
-		BootstrapConfig: NewGetBootstrapConfigFunc(store),
-		AccountDetails:  accountDetails,
-		ModelUUID:       modelUUID,
-		DialOpts:        dialOpts,
-		OpenAPI:         openAPI,
+		Store:          store,
+		ControllerName: controllerName,
+		AccountDetails: accountDetails,
+		ModelUUID:      modelUUID,
+		DialOpts:       dialOpts,
+		OpenAPI:        openAPI,
 	}, nil
 }
 

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/commands"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/juju"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient"
@@ -165,13 +164,12 @@ before "juju ssh", "juju scp", or "juju debug-hooks" will work.
 	modelDetails, err := s.ControllerStore.ModelByName("kontroll", "new-model")
 	c.Assert(err, jc.ErrorIsNil)
 	api, err := juju.NewAPIConnection(juju.NewAPIConnectionParams{
-		Store:           s.ControllerStore,
-		ControllerName:  "kontroll",
-		AccountDetails:  accountDetails,
-		ModelUUID:       modelDetails.ModelUUID,
-		BootstrapConfig: noBootstrapConfig,
-		DialOpts:        api.DefaultDialOpts(),
-		OpenAPI:         api.Open,
+		Store:          s.ControllerStore,
+		ControllerName: "kontroll",
+		AccountDetails: accountDetails,
+		ModelUUID:      modelDetails.ModelUUID,
+		DialOpts:       api.DefaultDialOpts(),
+		OpenAPI:        api.Open,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	api.Close()
@@ -310,10 +308,6 @@ func opRecvTimeout(c *gc.C, st *state.State, opc <-chan dummy.Operation, kinds .
 			c.Fatalf("time out wating for operation")
 		}
 	}
-}
-
-func noBootstrapConfig(controllerName string) (*config.Config, error) {
-	return nil, errors.NotFoundf("bootstrap config for controller %s", controllerName)
 }
 
 func (s *cmdControllerSuite) TestGetControllerConfigYAML(c *gc.C) {

--- a/featuretests/cmd_juju_register_test.go
+++ b/featuretests/cmd_juju_register_test.go
@@ -79,12 +79,11 @@ of a model to grant access to that model with "juju grant".
 	accountDetails, err := s.ControllerStore.AccountDetails("bob-controller")
 	c.Assert(err, jc.ErrorIsNil)
 	api, err := juju.NewAPIConnection(juju.NewAPIConnectionParams{
-		Store:           s.ControllerStore,
-		ControllerName:  "bob-controller",
-		AccountDetails:  accountDetails,
-		BootstrapConfig: noBootstrapConfig,
-		DialOpts:        api.DefaultDialOpts(),
-		OpenAPI:         api.Open,
+		Store:          s.ControllerStore,
+		ControllerName: "bob-controller",
+		AccountDetails: accountDetails,
+		DialOpts:       api.DefaultDialOpts(),
+		OpenAPI:        api.Open,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(api.Close(), jc.ErrorIsNil)


### PR DESCRIPTION
This logic is a significant contributor to the complexity
of this code, and it's only there to support a marginal case
that can be addressed otherwise if needed.

The specific case it's there to address is if this sequence of
events happens:

1) client bootstraps a controller in HA mode.
2) the initial controller nodes go down and are replaced.
3) the client tries to connect to the controller.

In this case, the client has no valid addresses for the controller,
but it does have the initial bootstrap configuration so it
can instantiate an Environ instance and use that to find
out the current controller addresses.

This scenario is not a problem if the client has connected any
time when any of the new servers are up.
The logic is no help if the client trying to connect was not
the specific client that originally bootstrapped, because
other clients don't have the bootstrap configuration available.

Given the relatively unlikelyhood of the scenario in general and
that most clients are unlikely to be the ones that actually bootstrapped
the controller, the complexity of the code doesn't seem warranted.

There are various alternative approaches that could be used if the
scenario really does turn out to be a problem in practice:

- manually get a controller address from the provider's management
console and add it to the controllers.yaml file.

- provide a separate command, say "recover-controller" which could
be used to try to recover controller addresses.

- provide a way to make controllers listen on a DNS address associated
with all the current controller addresses.

- use a server to keep track of current controller addresses and find
the addresses from that.

(Review request: http://reviews.vapour.ws/r/5166/)