### PR TITLE
worker: extend test timeout

### DIFF
--- a/worker/runner_test.go
+++ b/worker/runner_test.go
@@ -347,7 +347,7 @@ func (starter *testWorkerStarter) assertStarted(c *gc.C, started bool) {
 	select {
 	case isStarted := <-starter.startNotify:
 		c.Assert(isStarted, gc.Equals, started)
-	case <-time.After(1 * time.Second):
+	case <-time.After(testing.LongWait):
 		c.Fatalf("timed out waiting for start notification")
 	}
 }


### PR DESCRIPTION
lp:1583771 was an intermittent failure involving a 1s timeout; bumped it
up to LongWait for heavily-loaded situations.

(Review request: http://reviews.vapour.ws/r/5168/)