### PR TITLE
Add a Check for restricted methods

### DIFF
--- a/apiserver/client_auth_root.go
+++ b/apiserver/client_auth_root.go
@@ -34,7 +34,6 @@ func (r *clientAuthRoot) FindMethod(rootName string, version int, methodName str
 	if err != nil {
 		return nil, err
 	}
-
 	// ReadOnly User
 	if r.user.IsReadOnly() {
 		canCall := isCallAllowableByReadOnlyUser(rootName, methodName) ||

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -111,7 +111,7 @@ func TestingUpgradingRoot(st *state.State) rpc.MethodFinder {
 }
 
 // TestingRestrictedApiHandler returns a restricted srvRoot as if accessed
-// from the root of the API path with a recent (verison > 1) login.
+// from the root of the API path.
 func TestingRestrictedApiHandler(st *state.State) rpc.MethodFinder {
 	r := TestingApiRoot(st)
 	return newRestrictedRoot(r)

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -155,6 +155,11 @@ func (mm *ModelManagerAPI) newModelConfig(
 // model config specified in the args.
 func (mm *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.ModelInfo, error) {
 	result := params.ModelInfo{}
+	// TODO(perrito666) this check should be part of the authCheck, without this check
+	// any user in the controller may create models.
+	if !mm.isAdmin {
+		return result, errors.Trace(common.ErrPerm)
+	}
 	// Get the controller model first. We need it both for the state
 	// server owner and the ability to get the config.
 	controllerModel, err := mm.state.ControllerModel()
@@ -452,6 +457,8 @@ func (m *ModelManagerAPI) ModifyModelAccess(args params.ModifyModelAccessRequest
 func resolveStateAccess(access permission.ModelAccess) (state.Access, error) {
 	var fail state.Access
 	switch access {
+	case permission.ModelAdminAccess:
+		return state.AdminAccess, nil
 	case permission.ModelReadAccess:
 		return state.ReadAccess, nil
 	case permission.ModelWriteAccess:

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -74,6 +74,9 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 			users: []*mockModelUser{{
 				userName: "admin",
 				access:   state.AdminAccess,
+			}, {
+				userName: "otheruser",
+				access:   state.AdminAccess,
 			}},
 		},
 		model: &mockModel{
@@ -86,6 +89,9 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 			},
 			users: []*mockModelUser{{
 				userName: "admin",
+				access:   state.AdminAccess,
+			}, {
+				userName: "otheruser",
 				access:   state.AdminAccess,
 			}},
 		},
@@ -283,7 +289,7 @@ func (s *modelManagerStateSuite) createArgsForVersion(c *gc.C, owner names.UserT
 }
 
 func (s *modelManagerStateSuite) TestUserCanCreateModel(c *gc.C) {
-	owner := names.NewUserTag("external@remote")
+	owner := names.NewUserTag("admin@local")
 	s.setAPIUser(c, owner)
 	model, err := s.modelmanager.CreateModel(s.createArgs(c, owner))
 	c.Assert(err, jc.ErrorIsNil)
@@ -318,6 +324,13 @@ func (s *modelManagerStateSuite) TestNonAdminCannotCreateModelForSomeoneElse(c *
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
+func (s *modelManagerStateSuite) TestNonAdminCannotCreateModelForSelf(c *gc.C) {
+	owner := names.NewUserTag("non-admin@remote")
+	s.setAPIUser(c, owner)
+	_, err := s.modelmanager.CreateModel(s.createArgs(c, owner))
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
 func (s *modelManagerStateSuite) TestCreateModelValidatesConfig(c *gc.C) {
 	admin := s.AdminUserTag(c)
 	s.setAPIUser(c, admin)
@@ -330,7 +343,7 @@ func (s *modelManagerStateSuite) TestCreateModelValidatesConfig(c *gc.C) {
 }
 
 func (s *modelManagerStateSuite) TestCreateModelBadConfig(c *gc.C) {
-	owner := names.NewUserTag("external@remote")
+	owner := names.NewUserTag("admin@local")
 	s.setAPIUser(c, owner)
 	for i, test := range []struct {
 		key      string
@@ -467,7 +480,10 @@ func (s *modelManagerStateSuite) TestNonAdminModelManager(c *gc.C) {
 }
 
 func (s *modelManagerStateSuite) TestDestroyOwnModel(c *gc.C) {
-	owner := names.NewUserTag("external@remote")
+	// TODO(perrito666) this test is not valid until we have
+	// proper controller permission since the only users that
+	// can create models are controller admins.
+	owner := names.NewUserTag("admin@local")
 	s.setAPIUser(c, owner)
 	m, err := s.modelmanager.CreateModel(s.createArgs(c, owner))
 	c.Assert(err, jc.ErrorIsNil)
@@ -489,7 +505,9 @@ func (s *modelManagerStateSuite) TestDestroyOwnModel(c *gc.C) {
 }
 
 func (s *modelManagerStateSuite) TestAdminDestroysOtherModel(c *gc.C) {
-	owner := names.NewUserTag("external@remote")
+	// TODO(perrito666) Both users are admins in this case, this tesst is of dubious
+	// usefulness until proper controller permissions are in place.
+	owner := names.NewUserTag("admin@local")
 	s.setAPIUser(c, owner)
 	m, err := s.modelmanager.CreateModel(s.createArgs(c, owner))
 	c.Assert(err, jc.ErrorIsNil)
@@ -514,7 +532,7 @@ func (s *modelManagerStateSuite) TestAdminDestroysOtherModel(c *gc.C) {
 }
 
 func (s *modelManagerStateSuite) TestUserDestroysOtherModelDenied(c *gc.C) {
-	owner := names.NewUserTag("external@remote")
+	owner := names.NewUserTag("admin@local")
 	s.setAPIUser(c, owner)
 	m, err := s.modelmanager.CreateModel(s.createArgs(c, owner))
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/restricted_root.go
+++ b/apiserver/restricted_root.go
@@ -19,7 +19,9 @@ type restrictedRoot struct {
 
 // newRestrictedRoot returns a new restrictedRoot.
 func newRestrictedRoot(finder rpc.MethodFinder) *restrictedRoot {
-	return &restrictedRoot{finder}
+	return &restrictedRoot{
+		MethodFinder: finder,
+	}
 }
 
 // The restrictedRootNames are the root names that can be accessed at the root


### PR DESCRIPTION
Restricted root needed a check for restricted methods to avoid
having unprivileged users create models and call other unrestricted
root actions.
This is a temporary fix while a stronger authentication/acls solution is put in place.

(Review request: http://reviews.vapour.ws/r/5174/)