### PR TITLE
Add serialization tags to the rpc jsoncodec input and output structures.

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -548,9 +548,6 @@ func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
 
 func (srv *Server) serveConn(wsConn *websocket.Conn, reqNotifier *requestNotifier, modelUUID string) error {
 	codec := jsoncodec.NewWebsocket(wsConn)
-	if loggo.GetLogger("juju.rpc.jsoncodec").EffectiveLogLevel() <= loggo.TRACE {
-		codec.SetLogging(true)
-	}
 	var notifier rpc.RequestNotifier
 	if logger.EffectiveLogLevel() <= loggo.DEBUG {
 		// Incur request monitoring overhead only if we

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -65,6 +65,7 @@ func (conn *Conn) send(call *Call) {
 	hdr := &Header{
 		RequestId: reqId,
 		Request:   call.Request,
+		Version:   1,
 	}
 	params := call.Params
 	if params == nil {

--- a/rpc/dispatch_test.go
+++ b/rpc/dispatch_test.go
@@ -8,15 +8,19 @@ import (
 	"net/http"
 	"net/http/httptest"
 
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"golang.org/x/net/websocket"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
+	"github.com/juju/juju/testing"
 )
 
 type dispatchSuite struct {
+	testing.BaseSuite
+
 	server     *httptest.Server
 	serverAddr string
 	ready      chan struct{}
@@ -25,6 +29,7 @@ type dispatchSuite struct {
 var _ = gc.Suite(&dispatchSuite{})
 
 func (s *dispatchSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
 	rpcServer := func(ws *websocket.Conn) {
 		codec := jsoncodec.NewWebsocket(ws)
 		conn := rpc.NewConn(codec, nil)
@@ -38,20 +43,34 @@ func (s *dispatchSuite) SetUpSuite(c *gc.C) {
 	s.server = httptest.NewServer(nil)
 	s.serverAddr = s.server.Listener.Addr().String()
 	s.ready = make(chan struct{}, 1)
+	s.AddCleanup(func(*gc.C) {
+		s.server.Close()
+	})
 }
 
-func (s *dispatchSuite) TearDownSuite(c *gc.C) {
-	s.server.Close()
+func (s *dispatchSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	loggo.GetLogger("juju.rpc").SetLogLevel(loggo.TRACE)
 }
 
-func (s *dispatchSuite) TestWSWithoutParams(c *gc.C) {
+func (s *dispatchSuite) TestWSWithoutParamsV0(c *gc.C) {
 	resp := s.request(c, `{"RequestId":1,"Type": "DispatchDummy","Id": "without","Request":"DoSomething"}`)
 	c.Assert(resp, gc.Equals, `{"RequestId":1,"Response":{}}`)
 }
 
-func (s *dispatchSuite) TestWSWithParams(c *gc.C) {
+func (s *dispatchSuite) TestWSWithParamsV0(c *gc.C) {
 	resp := s.request(c, `{"RequestId":2,"Type": "DispatchDummy","Id": "with","Request":"DoSomething", "Params": {}}`)
 	c.Assert(resp, gc.Equals, `{"RequestId":2,"Response":{}}`)
+}
+
+func (s *dispatchSuite) TestWSWithoutParamsV1(c *gc.C) {
+	resp := s.request(c, `{"request-id":1,"type": "DispatchDummy","id": "without","request":"DoSomething"}`)
+	c.Assert(resp, gc.Equals, `{"request-id":1,"response":{}}`)
+}
+
+func (s *dispatchSuite) TestWSWithParamsV1(c *gc.C) {
+	resp := s.request(c, `{"request-id":2,"type": "DispatchDummy","id": "with","request":"DoSomething", "params": {}}`)
+	c.Assert(resp, gc.Equals, `{"request-id":2,"response":{}}`)
 }
 
 // request performs one request to the test server via websockets.

--- a/rpc/jsoncodec/codec.go
+++ b/rpc/jsoncodec/codec.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"sync"
-	"sync/atomic"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -33,7 +32,7 @@ type JSONConn interface {
 type Codec struct {
 	// msg holds the message that's just been read by ReadHeader, so
 	// that the body can be read by ReadBody.
-	msg         inMsg
+	msg         inMsgV1
 	conn        JSONConn
 	logMessages int32
 	mu          sync.Mutex
@@ -48,24 +47,10 @@ func New(conn JSONConn) *Codec {
 	}
 }
 
-// SetLogging sets whether messages will be logged
-// by the codec.
-func (c *Codec) SetLogging(on bool) {
-	val := int32(0)
-	if on {
-		val = 1
-	}
-	atomic.StoreInt32(&c.logMessages, val)
-}
-
-func (c *Codec) isLogging() bool {
-	return atomic.LoadInt32(&c.logMessages) != 0
-}
-
 // inMsg holds an incoming message.  We don't know the type of the
 // parameters or response yet, so we delay parsing by storing them
 // in a RawMessage.
-type inMsg struct {
+type inMsgV0 struct {
 	RequestId uint64
 	Type      string
 	Version   int
@@ -77,8 +62,20 @@ type inMsg struct {
 	Response  json.RawMessage
 }
 
+type inMsgV1 struct {
+	RequestId uint64          `json:"request-id"`
+	Type      string          `json:"type"`
+	Version   int             `json:"version"`
+	Id        string          `json:"id"`
+	Request   string          `json:"request"`
+	Params    json.RawMessage `json:"params"`
+	Error     string          `json:"error"`
+	ErrorCode string          `json:"error-code"`
+	Response  json.RawMessage `json:"response"`
+}
+
 // outMsg holds an outgoing message.
-type outMsg struct {
+type outMsgV0 struct {
 	RequestId uint64
 	Type      string      `json:",omitempty"`
 	Version   int         `json:",omitempty"`
@@ -88,6 +85,18 @@ type outMsg struct {
 	Error     string      `json:",omitempty"`
 	ErrorCode string      `json:",omitempty"`
 	Response  interface{} `json:",omitempty"`
+}
+
+type outMsgV1 struct {
+	RequestId uint64      `json:"request-id,omitempty"`
+	Type      string      `json:"type,omitempty"`
+	Version   int         `json:"version,omitempty"`
+	Id        string      `json:"id,omitempty"`
+	Request   string      `json:"request,omitempty"`
+	Params    interface{} `json:"params,omitempty"`
+	Error     string      `json:"error,omitempty"`
+	ErrorCode string      `json:"error-code,omitempty"`
+	Response  interface{} `json:"response,omitempty"`
 }
 
 func (c *Codec) Close() error {
@@ -104,19 +113,14 @@ func (c *Codec) isClosing() bool {
 }
 
 func (c *Codec) ReadHeader(hdr *rpc.Header) error {
-	c.msg = inMsg{} // avoid any potential cross-message contamination.
-	var err error
-	if c.isLogging() {
-		var m json.RawMessage
-		err = c.conn.Receive(&m)
-		if err == nil {
-			logger.Tracef("<- %s", m)
-			err = json.Unmarshal(m, &c.msg)
-		} else {
-			logger.Tracef("<- error: %v (closing %v)", err, c.isClosing())
-		}
+	var m json.RawMessage
+	var version int
+	err := c.conn.Receive(&m)
+	if err == nil {
+		logger.Tracef("<- %s", m)
+		c.msg, version, err = c.readMessage(m)
 	} else {
-		err = c.conn.Receive(&c.msg)
+		logger.Tracef("<- error: %v (closing %v)", err, c.isClosing())
 	}
 	if err != nil {
 		// If we've closed the connection, we may get a spurious error,
@@ -135,7 +139,41 @@ func (c *Codec) ReadHeader(hdr *rpc.Header) error {
 	}
 	hdr.Error = c.msg.Error
 	hdr.ErrorCode = c.msg.ErrorCode
+	hdr.Version = version
 	return nil
+}
+
+func (c *Codec) readMessage(m json.RawMessage) (inMsgV1, int, error) {
+	var msg inMsgV1
+	if err := json.Unmarshal(m, &msg); err != nil {
+		return msg, -1, errors.Trace(err)
+	}
+	// In order to support both new style tags (lowercase) and the old style tags (camelcase)
+	// we look at the request id. The request id is always greater than one. If the value is
+	// zero, it means that there wasn't a match for the "request-id" tag. This most likely
+	// means that it was "RequestId" which was from the old style.
+	if msg.RequestId == 0 {
+		return c.readV0Message(m)
+	}
+	return msg, 1, nil
+}
+
+func (c *Codec) readV0Message(m json.RawMessage) (inMsgV1, int, error) {
+	var msg inMsgV0
+	if err := json.Unmarshal(m, &msg); err != nil {
+		return inMsgV1{}, -1, errors.Trace(err)
+	}
+	return inMsgV1{
+		RequestId: msg.RequestId,
+		Type:      msg.Type,
+		Version:   msg.Version,
+		Id:        msg.Id,
+		Request:   msg.Request,
+		Params:    msg.Params,
+		Error:     msg.Error,
+		ErrorCode: msg.ErrorCode,
+		Response:  msg.Response,
+	}, 0, nil
 }
 
 func (c *Codec) ReadBody(body interface{}, isRequest bool) error {
@@ -162,9 +200,11 @@ func (c *Codec) ReadBody(body interface{}, isRequest bool) error {
 // If the body cannot be marshalled as JSON, the data
 // will hold a JSON string describing the error.
 func DumpRequest(hdr *rpc.Header, body interface{}) []byte {
-	var m outMsg
-	m.init(hdr, body)
-	data, err := json.Marshal(&m)
+	msg, err := response(hdr, body)
+	if err != nil {
+		return []byte(fmt.Sprintf("%q", err.Error()))
+	}
+	data, err := json.Marshal(msg)
 	if err != nil {
 		return []byte(fmt.Sprintf("%q", "marshal error: "+err.Error()))
 	}
@@ -172,32 +212,71 @@ func DumpRequest(hdr *rpc.Header, body interface{}) []byte {
 }
 
 func (c *Codec) WriteMessage(hdr *rpc.Header, body interface{}) error {
-	var m outMsg
-	m.init(hdr, body)
-	if c.isLogging() {
-		data, err := json.Marshal(&m)
+	msg, err := response(hdr, body)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if logger.IsTraceEnabled() {
+		data, err := json.Marshal(msg)
 		if err != nil {
 			logger.Tracef("-> marshal error: %v", err)
 			return err
 		}
 		logger.Tracef("-> %s", data)
 	}
-	return c.conn.Send(&m)
+	return c.conn.Send(msg)
 }
 
-// init fills out the receiving outMsg with information from the given
-// header and body.
-func (m *outMsg) init(hdr *rpc.Header, body interface{}) {
-	m.RequestId = hdr.RequestId
-	m.Type = hdr.Request.Type
-	m.Version = hdr.Request.Version
-	m.Id = hdr.Request.Id
-	m.Request = hdr.Request.Action
-	m.Error = hdr.Error
-	m.ErrorCode = hdr.ErrorCode
-	if hdr.IsRequest() {
-		m.Params = body
-	} else {
-		m.Response = body
+func response(hdr *rpc.Header, body interface{}) (interface{}, error) {
+	switch hdr.Version {
+	case 0:
+		return newOutMsgV0(hdr, body), nil
+	case 1:
+		return newOutMsgV1(hdr, body), nil
+	default:
+		return nil, errors.Errorf("unsupported version %d", hdr.Version)
 	}
+}
+
+// newOutMsgV0 fills out a outMsgV0 with information from the given
+// header and body.
+func newOutMsgV0(hdr *rpc.Header, body interface{}) outMsgV0 {
+	result := outMsgV0{
+		RequestId: hdr.RequestId,
+		Type:      hdr.Request.Type,
+		Version:   hdr.Request.Version,
+		Id:        hdr.Request.Id,
+		Request:   hdr.Request.Action,
+		Error:     hdr.Error,
+		ErrorCode: hdr.ErrorCode,
+	}
+	if hdr.IsRequest() {
+		result.Params = body
+	} else {
+		result.Response = body
+	}
+	return result
+}
+
+// newOutMsgV1 fills out a outMsgV1 with information from the given header and
+// body. This might look a lot like the v0 method, and that is because it is.
+// However, since Go determins structs to be sufficiently different if the
+// tags are different, we can't use the same code. Theoretically we could use
+// reflect, but no.
+func newOutMsgV1(hdr *rpc.Header, body interface{}) outMsgV1 {
+	result := outMsgV1{
+		RequestId: hdr.RequestId,
+		Type:      hdr.Request.Type,
+		Version:   hdr.Request.Version,
+		Id:        hdr.Request.Id,
+		Request:   hdr.Request.Action,
+		Error:     hdr.Error,
+		ErrorCode: hdr.ErrorCode,
+	}
+	if hdr.IsRequest() {
+		result.Params = body
+	} else {
+		result.Response = body
+	}
+	return result
 }

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -522,6 +522,7 @@ func (root *Root) assertClientNotified(c *gc.C, p testCallParams, r interface{})
 	clientReq.hdr.RequestId = 0 // Ignore the exact value of the request id to start with.
 	c.Assert(clientReq.hdr, gc.DeepEquals, rpc.Header{
 		Request: p.request(),
+		Version: 1,
 	})
 	c.Assert(clientReq.body, gc.Equals, stringVal{"arg"})
 
@@ -538,10 +539,12 @@ func (root *Root) assertClientNotified(c *gc.C, p testCallParams, r interface{})
 		c.Assert(clientReply.hdr, gc.DeepEquals, rpc.Header{
 			RequestId: requestId,
 			Error:     p.errorMessage(),
+			Version:   1,
 		})
 	} else {
 		c.Assert(clientReply.hdr, gc.DeepEquals, rpc.Header{
 			RequestId: requestId,
+			Version:   1,
 		})
 	}
 	return requestId
@@ -561,6 +564,7 @@ func (root *Root) assertServerNotified(c *gc.C, p testCallParams, requestId uint
 	c.Assert(serverReq.hdr, gc.DeepEquals, rpc.Header{
 		RequestId: requestId,
 		Request:   p.request(),
+		Version:   1,
 	})
 	if p.narg > 0 {
 		c.Assert(serverReq.body, gc.Equals, stringVal{"arg"})
@@ -581,10 +585,12 @@ func (root *Root) assertServerNotified(c *gc.C, p testCallParams, requestId uint
 		c.Assert(serverReply.hdr, gc.Equals, rpc.Header{
 			RequestId: requestId,
 			Error:     p.errorMessage(),
+			Version:   1,
 		})
 	} else {
 		c.Assert(serverReply.hdr, gc.Equals, rpc.Header{
 			RequestId: requestId,
+			Version:   1,
 		})
 	}
 }
@@ -909,6 +915,7 @@ func (*rpcSuite) TestCompatibility(c *gc.C) {
 }
 
 func (*rpcSuite) TestBadCall(c *gc.C) {
+	loggo.GetLogger("juju.rpc").SetLogLevel(loggo.TRACE)
 	root := &Root{
 		simple: make(map[string]*SimpleMethods),
 	}
@@ -963,6 +970,7 @@ func testBadCall(
 		hdr: rpc.Header{
 			RequestId: requestId,
 			Request:   req,
+			Version:   1,
 		},
 		body: struct{}{},
 	})
@@ -975,6 +983,7 @@ func testBadCall(
 			RequestId: requestId,
 			Error:     expectedErr,
 			ErrorCode: expectedErrCode,
+			Version:   1,
 		},
 	})
 
@@ -993,6 +1002,7 @@ func testBadCall(
 		hdr: rpc.Header{
 			RequestId: requestId,
 			Request:   req,
+			Version:   1,
 		},
 		body: expectBody,
 	})
@@ -1005,6 +1015,7 @@ func testBadCall(
 			RequestId: requestId,
 			Error:     expectedErr,
 			ErrorCode: expectedErrCode,
+			Version:   1,
 		},
 		req:  req,
 		body: struct{}{},


### PR DESCRIPTION
The default serialization of the rpc code now uses lowercase names for the structures. There is backwards compatible code that allows the server to deserialize requests from an older client. This is primarily for the ability to tell the caller that they need a more up to date version of the tool.


(Review request: http://reviews.vapour.ws/r/5177/)