### PR TITLE
Restrict plugin names to starting with a letter

### DIFF
--- a/cmd/juju/commands/plugin.go
+++ b/cmd/juju/commands/plugin.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"syscall"
@@ -22,6 +23,7 @@ import (
 )
 
 const JujuPluginPrefix = "juju-"
+const JujuPluginPattern = "^juju-[a-zA-Z]"
 
 // This is a very rudimentary method used to extract common Juju
 // arguments from the full list passed to the plugin. Currently,
@@ -194,9 +196,10 @@ func GetPluginDescriptions() []PluginDescription {
 	return results
 }
 
-// findPlugins searches the current PATH for executable files that start with
-// JujuPluginPrefix.
+// findPlugins searches the current PATH for executable files that match
+// JujuPluginPattern.
 func findPlugins() []string {
+	re := regexp.MustCompile(JujuPluginPattern)
 	path := os.Getenv("PATH")
 	plugins := []string{}
 	for _, name := range filepath.SplitList(path) {
@@ -205,7 +208,7 @@ func findPlugins() []string {
 			continue
 		}
 		for _, entry := range entries {
-			if strings.HasPrefix(entry.Name(), JujuPluginPrefix) && (entry.Mode()&0111) != 0 {
+			if re.Match([]byte(entry.Name())) && (entry.Mode()&0111) != 0 {
 				plugins = append(plugins, entry.Name())
 			}
 		}

--- a/cmd/juju/commands/plugin_test.go
+++ b/cmd/juju/commands/plugin_test.go
@@ -49,22 +49,30 @@ func (*PluginSuite) TestFindPlugins(c *gc.C) {
 }
 
 func (suite *PluginSuite) TestFindPluginsOrder(c *gc.C) {
-	suite.makePlugin("foo", 0744)
-	suite.makePlugin("bar", 0654)
-	suite.makePlugin("baz", 0645)
+	suite.makeWorkingPlugin("foo", 0744)
+	suite.makeWorkingPlugin("bar", 0654)
+	suite.makeWorkingPlugin("baz", 0645)
 	plugins := findPlugins()
 	c.Assert(plugins, gc.DeepEquals, []string{"juju-bar", "juju-baz", "juju-foo"})
 }
 
+func (suite *PluginSuite) TestFindPluginsBadNames(c *gc.C) {
+	suite.makePlugin("juju-1foo", "", 0755)
+	suite.makePlugin("juju--foo", "", 0755)
+	suite.makePlugin("ajuju-foo", "", 0755)
+	plugins := findPlugins()
+	c.Assert(plugins, gc.DeepEquals, []string{})
+}
+
 func (suite *PluginSuite) TestFindPluginsIgnoreNotExec(c *gc.C) {
-	suite.makePlugin("foo", 0644)
-	suite.makePlugin("bar", 0666)
+	suite.makeWorkingPlugin("foo", 0644)
+	suite.makeWorkingPlugin("bar", 0666)
 	plugins := findPlugins()
 	c.Assert(plugins, gc.DeepEquals, []string{})
 }
 
 func (suite *PluginSuite) TestRunPluginExising(c *gc.C) {
-	suite.makePlugin("foo", 0755)
+	suite.makeWorkingPlugin("foo", 0755)
 	ctx := testing.Context(c)
 	err := RunPlugin(ctx, "foo", []string{"some params"})
 	c.Assert(err, jc.ErrorIsNil)
@@ -178,16 +186,20 @@ func (suite *PluginSuite) TestJujuEnvVars(c *gc.C) {
 	c.Assert(output, gc.Matches, expectedDebug)
 }
 
-func (suite *PluginSuite) makePlugin(name string, perm os.FileMode) {
-	content := fmt.Sprintf("#!/bin/bash --norc\necho %s $*", name)
-	filename := gitjujutesting.HomePath(JujuPluginPrefix + name)
+func (suite *PluginSuite) makePlugin(fullName, script string, perm os.FileMode) {
+	filename := gitjujutesting.HomePath(fullName)
+	content := fmt.Sprintf("#!/bin/bash --norc\n%s", script)
 	ioutil.WriteFile(filename, []byte(content), perm)
 }
 
+func (suite *PluginSuite) makeWorkingPlugin(name string, perm os.FileMode) {
+	script := fmt.Sprintf("echo %s $*", name)
+	suite.makePlugin(JujuPluginPrefix+name, script, perm)
+}
+
 func (suite *PluginSuite) makeFailingPlugin(name string, exitStatus int) {
-	content := fmt.Sprintf("#!/bin/bash --norc\necho failing\nexit %d", exitStatus)
-	filename := gitjujutesting.HomePath(JujuPluginPrefix + name)
-	ioutil.WriteFile(filename, []byte(content), 0755)
+	script := fmt.Sprintf("echo failing\nexit %d", exitStatus)
+	suite.makePlugin(JujuPluginPrefix+name, script, 0755)
 }
 
 type PluginParams struct {


### PR DESCRIPTION
Fixes lp:1596967 related to several oddnesses with the juju
versioned aliases included in packaging, which can be invoked
as plugins.

Now, only commands starting `juju-[a-zA-Z]` will be treated
as potentially juju plugins.

(Review request: http://reviews.vapour.ws/r/5178/)