### PR TITLE
Rename local cloud config to inherited controller config

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -95,14 +95,14 @@ func InitializeState(
 			CloudRegion:     args.ControllerCloudRegion,
 			CloudCredential: args.ControllerCloudCredentialName,
 		},
-		CloudName:        args.ControllerCloudName,
-		Cloud:            args.ControllerCloud,
-		CloudCredentials: cloudCredentials,
-		ControllerConfig: args.ControllerConfig,
-		LocalCloudConfig: args.LocalCloudConfig,
-		MongoInfo:        info,
-		MongoDialOpts:    dialOpts,
-		Policy:           policy,
+		CloudName:                 args.ControllerCloudName,
+		Cloud:                     args.ControllerCloud,
+		CloudCredentials:          cloudCredentials,
+		ControllerConfig:          args.ControllerConfig,
+		ControllerInheritedConfig: args.ControllerInheritedConfig,
+		MongoInfo:                 info,
+		MongoDialOpts:             dialOpts,
+		Policy:                    policy,
 	})
 	if err != nil {
 		return nil, nil, errors.Errorf("failed to initialize state: %v", err)

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -142,7 +142,7 @@ LXC_BRIDGE="ignored"`[1:])
 		"name": "hosted",
 		"uuid": hostedModelUUID,
 	}
-	modelConfigDefaults := map[string]interface{}{
+	controllerInheritedConfig := map[string]interface{}{
 		"apt-mirror": "http://mirror",
 	}
 
@@ -156,13 +156,13 @@ LXC_BRIDGE="ignored"`[1:])
 				AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 				Regions:   []cloud.Region{{Name: "some-region"}},
 			},
-			ControllerCloudName:   "dummy",
-			ControllerCloudRegion: "some-region",
-			ControllerConfig:      controllerCfg,
-			ControllerModelConfig: modelCfg,
-			ModelConstraints:      expectModelConstraints,
-			LocalCloudConfig:      modelConfigDefaults,
-			HostedModelConfig:     hostedModelConfigAttrs,
+			ControllerCloudName:       "dummy",
+			ControllerCloudRegion:     "some-region",
+			ControllerConfig:          controllerCfg,
+			ControllerModelConfig:     modelCfg,
+			ModelConstraints:          expectModelConstraints,
+			ControllerInheritedConfig: controllerInheritedConfig,
+			HostedModelConfig:         hostedModelConfigAttrs,
 		},
 		BootstrapMachineAddresses: initialAddrs,
 		BootstrapMachineJobs:      []multiwatcher.MachineJob{multiwatcher.JobManageModel},

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -211,9 +211,9 @@ type StateInitializationParams struct {
 	// to a controller.
 	ControllerConfig controller.Config
 
-	// LocalCloudConfig is a set of config attributes to be shared by all
-	// models managed by this controller on the specified cloud.
-	LocalCloudConfig map[string]interface{}
+	// ControllerInheritedConfig is a set of config attributes to be shared by all
+	// models managed by this controller.
+	ControllerInheritedConfig map[string]interface{}
 
 	// HostedModelConfig is a set of config attributes to be overlaid
 	// on the controller model config (Config, above) to construct the
@@ -244,7 +244,7 @@ type StateInitializationParams struct {
 type stateInitializationParamsInternal struct {
 	ControllerConfig                        map[string]interface{}            `yaml:"controller-config"`
 	ControllerModelConfig                   map[string]interface{}            `yaml:"controller-model-config"`
-	ModelConfigDefaults                     map[string]interface{}            `yaml:"model-config-defaults,omitempty"`
+	ControllerInheritedConfig               map[string]interface{}            `yaml:"controller-config-defaults,omitempty"`
 	HostedModelConfig                       map[string]interface{}            `yaml:"hosted-model-config,omitempty"`
 	BootstrapMachineInstanceId              instance.Id                       `yaml:"bootstrap-machine-instance-id"`
 	BootstrapMachineConstraints             constraints.Value                 `yaml:"bootstrap-machine-constraints"`
@@ -271,7 +271,7 @@ func (p *StateInitializationParams) Marshal() ([]byte, error) {
 	internal := stateInitializationParamsInternal{
 		p.ControllerConfig,
 		p.ControllerModelConfig.AllAttrs(),
-		p.LocalCloudConfig,
+		p.ControllerInheritedConfig,
 		p.HostedModelConfig,
 		p.BootstrapMachineInstanceId,
 		p.BootstrapMachineConstraints,
@@ -309,7 +309,7 @@ func (p *StateInitializationParams) Unmarshal(data []byte) error {
 	*p = StateInitializationParams{
 		ControllerConfig:                        internal.ControllerConfig,
 		ControllerModelConfig:                   cfg,
-		LocalCloudConfig:                        internal.ModelConfigDefaults,
+		ControllerInheritedConfig:               internal.ControllerInheritedConfig,
 		HostedModelConfig:                       internal.HostedModelConfig,
 		BootstrapMachineInstanceId:              internal.BootstrapMachineInstanceId,
 		BootstrapMachineConstraints:             internal.BootstrapMachineConstraints,

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -601,10 +601,10 @@ to clean up the model.`[1:])
 
 	// Based on the attribute names in clouds.yaml, create
 	// a map of shared config for all models on this cloud.
-	localCloudAttrs := make(map[string]interface{})
+	inheritedControllerAttrs := make(map[string]interface{})
 	for k := range cloud.Config {
 		if v, ok := controllerModelConfigAttrs[k]; ok {
-			localCloudAttrs[k] = v
+			inheritedControllerAttrs[k] = v
 		}
 	}
 
@@ -616,24 +616,24 @@ to clean up the model.`[1:])
 	}
 
 	err = bootstrapFuncs.Bootstrap(modelcmd.BootstrapContext(ctx), environ, bootstrap.BootstrapParams{
-		ModelConstraints:     c.Constraints,
-		BootstrapConstraints: bootstrapConstraints,
-		BootstrapSeries:      c.BootstrapSeries,
-		BootstrapImage:       c.BootstrapImage,
-		Placement:            c.Placement,
-		UploadTools:          c.UploadTools,
-		BuildToolsTarball:    sync.BuildToolsTarball,
-		AgentVersion:         c.AgentVersion,
-		MetadataDir:          metadataDir,
-		Cloud:                *cloud,
-		CloudName:            c.Cloud,
-		CloudRegion:          region.Name,
-		CloudCredential:      credential,
-		CloudCredentialName:  credentialName,
-		ControllerConfig:     controllerConfig,
-		LocalCloudConfig:     localCloudAttrs,
-		HostedModelConfig:    hostedModelConfig,
-		GUIDataSourceBaseURL: guiDataSourceBaseURL,
+		ModelConstraints:          c.Constraints,
+		BootstrapConstraints:      bootstrapConstraints,
+		BootstrapSeries:           c.BootstrapSeries,
+		BootstrapImage:            c.BootstrapImage,
+		Placement:                 c.Placement,
+		UploadTools:               c.UploadTools,
+		BuildToolsTarball:         sync.BuildToolsTarball,
+		AgentVersion:              c.AgentVersion,
+		MetadataDir:               metadataDir,
+		Cloud:                     *cloud,
+		CloudName:                 c.Cloud,
+		CloudRegion:               region.Name,
+		CloudCredential:           credential,
+		CloudCredentialName:       credentialName,
+		ControllerConfig:          controllerConfig,
+		ControllerInheritedConfig: inheritedControllerAttrs,
+		HostedModelConfig:         hostedModelConfig,
+		GUIDataSourceBaseURL:      guiDataSourceBaseURL,
 	})
 	if err != nil {
 		return errors.Annotate(err, "failed to bootstrap model")

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -87,9 +87,9 @@ type BootstrapParams struct {
 	// to a controller.
 	ControllerConfig controller.Config
 
-	// LocalCloudConfig is the set of config attributes to be shared
+	// ControllerInheritedConfig is the set of config attributes to be shared
 	// across all models in the same controller on the bootstrap cloud.
-	LocalCloudConfig map[string]interface{}
+	ControllerInheritedConfig map[string]interface{}
 
 	// HostedModelConfig is the set of config attributes to be overlaid
 	// on the controller config to construct the initial hosted model
@@ -300,7 +300,7 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	instanceConfig.Bootstrap.ControllerCloudCredential = args.CloudCredential
 	instanceConfig.Bootstrap.ControllerCloudCredentialName = args.CloudCredentialName
 	instanceConfig.Bootstrap.ControllerConfig = args.ControllerConfig
-	instanceConfig.Bootstrap.LocalCloudConfig = args.LocalCloudConfig
+	instanceConfig.Bootstrap.ControllerInheritedConfig = args.ControllerInheritedConfig
 	instanceConfig.Bootstrap.HostedModelConfig = args.HostedModelConfig
 	instanceConfig.Bootstrap.GUI = guiArchive(args.GUIDataSourceBaseURL, func(msg string) {
 		ctx.Infof(msg)

--- a/state/cloud.go
+++ b/state/cloud.go
@@ -13,11 +13,6 @@ import (
 
 const controllerCloudKey = "controller"
 
-// cloudGlobalKey returns the global database key for the specified cloud.
-func cloudGlobalKey(name string) string {
-	return "cloud#" + name
-}
-
 // cloudDoc records information about the cloud that the controller operates in.
 type cloudDoc struct {
 	DocID           string                       `bson:"_id"`

--- a/state/controller.go
+++ b/state/controller.go
@@ -12,6 +12,9 @@ import (
 const (
 	// controllerSettingsGlobalKey is the key for the controller and its settings.
 	controllerSettingsGlobalKey = "controllerSettings"
+
+	// controllerInheritedSettingsGlobalKey is the key for default settings shared across models.
+	controllerInheritedSettingsGlobalKey = "controllerInheritedSettings"
 )
 
 // ControllerConfig returns the config values for the controller.

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -41,20 +41,20 @@ const (
 )
 
 var (
-	BinarystorageNew       = &binarystorageNew
-	ImageStorageNewStorage = &imageStorageNewStorage
-	MachineIdLessThan      = machineIdLessThan
-	ControllerAvailable    = &controllerAvailable
-	GetOrCreatePorts       = getOrCreatePorts
-	GetPorts               = getPorts
-	NowToTheSecond         = nowToTheSecond
-	AddVolumeOps           = (*State).addVolumeOps
-	CombineMeterStatus     = combineMeterStatus
-	ApplicationGlobalKey   = applicationGlobalKey
-	ReadSettings           = readSettings
-	CloudGlobalKey         = cloudGlobalKey
-	MergeBindings          = mergeBindings
-	UpgradeInProgressError = errUpgradeInProgress
+	BinarystorageNew                     = &binarystorageNew
+	ImageStorageNewStorage               = &imageStorageNewStorage
+	MachineIdLessThan                    = machineIdLessThan
+	ControllerAvailable                  = &controllerAvailable
+	GetOrCreatePorts                     = getOrCreatePorts
+	GetPorts                             = getPorts
+	NowToTheSecond                       = nowToTheSecond
+	AddVolumeOps                         = (*State).addVolumeOps
+	CombineMeterStatus                   = combineMeterStatus
+	ApplicationGlobalKey                 = applicationGlobalKey
+	ReadSettings                         = readSettings
+	ControllerInheritedSettingsGlobalKey = controllerInheritedSettingsGlobalKey
+	MergeBindings                        = mergeBindings
+	UpgradeInProgressError               = errUpgradeInProgress
 )
 
 type (

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -189,11 +189,11 @@ func (s *InitializeSuite) TestInitializeWithInvalidCredentialType(c *gc.C) {
 	)
 }
 
-func (s *InitializeSuite) TestInitializeWithModelConfigDefaults(c *gc.C) {
+func (s *InitializeSuite) TestInitializeWithControllerinheritedconfig(c *gc.C) {
 	cfg := testing.ModelConfig(c)
 	uuid := cfg.UUID()
 	initial := cfg.AllAttrs()
-	modelConfigDefaultsIn := map[string]interface{}{
+	controllerInheritedConfigIn := map[string]interface{}{
 		"default-series": initial["default-series"],
 	}
 	owner := names.NewLocalUserTag("initialize-admin")
@@ -212,9 +212,9 @@ func (s *InitializeSuite) TestInitializeWithModelConfigDefaults(c *gc.C) {
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 		},
-		LocalCloudConfig: modelConfigDefaultsIn,
-		MongoInfo:        statetesting.NewMongoInfo(),
-		MongoDialOpts:    mongotest.DialOpts(),
+		ControllerInheritedConfig: controllerInheritedConfigIn,
+		MongoInfo:                 statetesting.NewMongoInfo(),
+		MongoDialOpts:             mongotest.DialOpts(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st, gc.NotNil)
@@ -225,9 +225,9 @@ func (s *InitializeSuite) TestInitializeWithModelConfigDefaults(c *gc.C) {
 
 	s.openState(c, modelTag)
 
-	localCloudConfig, err := state.ReadSettings(s.State, state.GlobalSettingsC, state.CloudGlobalKey("dummy"))
+	ControllerInheritedConfig, err := state.ReadSettings(s.State, state.GlobalSettingsC, state.ControllerInheritedSettingsGlobalKey)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(localCloudConfig.Map(), jc.DeepEquals, modelConfigDefaultsIn)
+	c.Assert(ControllerInheritedConfig.Map(), jc.DeepEquals, controllerInheritedConfigIn)
 
 	cfg, err = s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
@@ -391,7 +391,7 @@ func (s *InitializeSuite) TestCloudConfigWithForbiddenValues(c *gc.C) {
 
 	for _, badAttrName := range badAttrNames {
 		badAttrs := map[string]interface{}{badAttrName: "foo"}
-		args.LocalCloudConfig = badAttrs
+		args.ControllerInheritedConfig = badAttrs
 		_, err := state.Initialize(args)
 		c.Assert(err, gc.ErrorMatches, "local cloud config cannot contain .*")
 	}

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -67,8 +67,8 @@ func (st *State) ModelConfigValues() (config.ConfigValues, error) {
 	return result, nil
 }
 
-// checkLocalCloudConfigDefaults returns an error if the shared local cloud config is definitely invalid.
-func checkLocalCloudConfigDefaults(attrs map[string]interface{}) error {
+// checkControllerInheritedConfig returns an error if the shared local cloud config is definitely invalid.
+func checkControllerInheritedConfig(attrs map[string]interface{}) error {
 	if _, ok := attrs[config.AdminSecretKey]; ok {
 		return errors.Errorf("local cloud config cannot contain admin-secret")
 	}
@@ -204,19 +204,15 @@ type modelConfigSource struct {
 // overall config values, later values override earlier ones.
 func modelConfigSources(st *State) []modelConfigSource {
 	return []modelConfigSource{
-		{config.JujuControllerSource, st.localCloudConfig},
+		{config.JujuControllerSource, st.ControllerInheritedConfig},
 		// We will also support local cloud region, tenant, user etc
 	}
 }
 
-// localCloudConfig returns the inherited config values
+// ControllerInheritedConfig returns the inherited config values
 // sourced from the local cloud config.
-func (st *State) localCloudConfig() (map[string]interface{}, error) {
-	info, err := st.ControllerInfo()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	settings, err := readSettings(st, globalSettingsC, cloudGlobalKey(info.CloudName))
+func (st *State) ControllerInheritedConfig() (map[string]interface{}, error) {
+	settings, err := readSettings(st, globalSettingsC, controllerInheritedSettingsGlobalKey)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -94,16 +94,16 @@ type ModelConfigSourceSuite struct {
 var _ = gc.Suite(&ModelConfigSourceSuite{})
 
 func (s *ModelConfigSourceSuite) SetUpTest(c *gc.C) {
-	s.LocalCloudConfig = map[string]interface{}{
+	s.ControllerInheritedConfig = map[string]interface{}{
 		"apt-mirror": "http://cloud-mirror",
 		"http-proxy": "http://proxy",
 	}
 	s.ConnSuite.SetUpTest(c)
 
-	localCloudSettings, err := s.State.ReadSettings(state.GlobalSettingsC, state.CloudGlobalKey("dummy"))
+	localControllerSettings, err := s.State.ReadSettings(state.GlobalSettingsC, state.ControllerInheritedSettingsGlobalKey)
 	c.Assert(err, jc.ErrorIsNil)
-	localCloudSettings.Set("apt-mirror", "http://mirror")
-	_, err = localCloudSettings.Write()
+	localControllerSettings.Set("apt-mirror", "http://mirror")
+	_, err = localControllerSettings.Write()
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -120,16 +120,16 @@ func (s *ModelConfigSourceSuite) TestModelConfigWhenSetOverridesCloudValue(c *gc
 	c.Assert(cfg.AllAttrs()["apt-mirror"], gc.Equals, "http://anothermirror")
 }
 
-func (s *ModelConfigSourceSuite) TestControllerModelConfigForksCloudValue(c *gc.C) {
+func (s *ModelConfigSourceSuite) TestControllerModelConfigForksControllerValue(c *gc.C) {
 	modelCfg, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelCfg.AllAttrs()["apt-mirror"], gc.Equals, "http://cloud-mirror")
 
-	// Change the local cloud settings and ensure the model setting stays the same.
-	localCloudSettings, err := s.State.ReadSettings(state.GlobalSettingsC, state.CloudGlobalKey("dummy"))
+	// Change the local controller settings and ensure the model setting stays the same.
+	localControllerSettings, err := s.State.ReadSettings(state.GlobalSettingsC, state.ControllerInheritedSettingsGlobalKey)
 	c.Assert(err, jc.ErrorIsNil)
-	localCloudSettings.Set("apt-mirror", "http://anothermirror")
-	_, err = localCloudSettings.Write()
+	localControllerSettings.Set("apt-mirror", "http://anothermirror")
+	_, err = localControllerSettings.Write()
 	c.Assert(err, jc.ErrorIsNil)
 
 	modelCfg, err = s.State.ModelConfig()
@@ -137,7 +137,7 @@ func (s *ModelConfigSourceSuite) TestControllerModelConfigForksCloudValue(c *gc.
 	c.Assert(modelCfg.AllAttrs()["apt-mirror"], gc.Equals, "http://cloud-mirror")
 }
 
-func (s *ModelConfigSourceSuite) TestNewModelConfigForksCloudValue(c *gc.C) {
+func (s *ModelConfigSourceSuite) TestNewModelConfigForksControllerValue(c *gc.C) {
 	uuid, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	cfg := testing.CustomModelConfig(c, testing.Attrs{
@@ -155,8 +155,8 @@ func (s *ModelConfigSourceSuite) TestNewModelConfigForksCloudValue(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelCfg.AllAttrs()["apt-mirror"], gc.Equals, "http://mirror")
 
-	// Change the local cloud settings and ensure the model setting stays the same.
-	localCloudSettings, err := s.State.ReadSettings(state.GlobalSettingsC, state.CloudGlobalKey("dummy"))
+	// Change the local controller settings and ensure the model setting stays the same.
+	localCloudSettings, err := s.State.ReadSettings(state.GlobalSettingsC, state.ControllerInheritedSettingsGlobalKey)
 	c.Assert(err, jc.ErrorIsNil)
 	localCloudSettings.Set("apt-mirror", "http://anothermirror")
 	_, err = localCloudSettings.Write()

--- a/state/testing/conn.go
+++ b/state/testing/conn.go
@@ -20,7 +20,7 @@ import (
 // Initialize initializes the state and returns it. If state was not
 // already initialized, and cfg is nil, the minimal default model
 // configuration will be used.
-func Initialize(c *gc.C, owner names.UserTag, cfg *config.Config, localCloudConfig map[string]interface{}, policy state.Policy) *state.State {
+func Initialize(c *gc.C, owner names.UserTag, cfg *config.Config, controllerInheritedConfig map[string]interface{}, policy state.Policy) *state.State {
 	if cfg == nil {
 		cfg = testing.ModelConfig(c)
 	}
@@ -36,8 +36,8 @@ func Initialize(c *gc.C, owner names.UserTag, cfg *config.Config, localCloudConf
 			Config:    cfg,
 			Owner:     owner,
 		},
-		LocalCloudConfig: localCloudConfig,
-		CloudName:        "dummy",
+		ControllerInheritedConfig: controllerInheritedConfig,
+		CloudName:                 "dummy",
 		Cloud: cloud.Cloud{
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},

--- a/state/testing/suite.go
+++ b/state/testing/suite.go
@@ -21,12 +21,12 @@ var _ = gc.Suite(&StateSuite{})
 type StateSuite struct {
 	jujutesting.MgoSuite
 	testing.BaseSuite
-	Policy           state.Policy
-	State            *state.State
-	Owner            names.UserTag
-	Factory          *factory.Factory
-	InitialConfig    *config.Config
-	LocalCloudConfig map[string]interface{}
+	Policy                    state.Policy
+	State                     *state.State
+	Owner                     names.UserTag
+	Factory                   *factory.Factory
+	InitialConfig             *config.Config
+	ControllerInheritedConfig map[string]interface{}
 }
 
 func (s *StateSuite) SetUpSuite(c *gc.C) {
@@ -44,7 +44,7 @@ func (s *StateSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
 	s.Owner = names.NewLocalUserTag("test-admin")
-	s.State = Initialize(c, s.Owner, s.InitialConfig, s.LocalCloudConfig, s.Policy)
+	s.State = Initialize(c, s.Owner, s.InitialConfig, s.ControllerInheritedConfig, s.Policy)
 	s.AddCleanup(func(*gc.C) { s.State.Close() })
 	s.Factory = factory.NewFactory(s.State)
 }


### PR DESCRIPTION
We used to consider config from the clouds.yaml file to be local cloud config. This config needs to be tied to the controller instead. So essentially this PR renames LocalCloudConfig to InheritedControllerConfig. Plus we no longer need a cloud global key so that is deleted.

(Review request: http://reviews.vapour.ws/r/5179/)