### PR TITLE
Update catacomb to gracefully handle panic().

### DIFF
--- a/worker/catacomb/catacomb.go
+++ b/worker/catacomb/catacomb.go
@@ -112,7 +112,7 @@ func Invoke(plan Plan) (err error) {
 	go func() {
 		defer catacomb.tomb.Done()
 		defer catacomb.wg.Wait()
-		catacomb.Kill(plan.Work())
+		catacomb.Kill(RunSafely(plan.Work))
 	}()
 	return nil
 }
@@ -246,4 +246,22 @@ type dyingError struct {
 // Error is part of the error interface.
 func (err dyingError) Error() string {
 	return fmt.Sprintf("catacomb %p is dying", err.catacomb)
+}
+
+// RunSafely will ensure that the function is run, and any error is returned.
+// If there is a panic, then that will be returned as an error.
+func RunSafely(f func() error) (err error) {
+	defer func() {
+		if panicResult := recover(); panicResult != nil {
+			var ok bool
+			if err, ok = panicResult.(error); !ok {
+				err = errors.Errorf("panic resulted in: %v", panicResult)
+			}
+		}
+	}()
+	err = f()
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/worker/catacomb/catacomb.go
+++ b/worker/catacomb/catacomb.go
@@ -112,7 +112,7 @@ func Invoke(plan Plan) (err error) {
 	go func() {
 		defer catacomb.tomb.Done()
 		defer catacomb.wg.Wait()
-		catacomb.Kill(RunSafely(plan.Work))
+		catacomb.Kill(runSafely(plan.Work))
 	}()
 	return nil
 }
@@ -250,18 +250,11 @@ func (err dyingError) Error() string {
 
 // RunSafely will ensure that the function is run, and any error is returned.
 // If there is a panic, then that will be returned as an error.
-func RunSafely(f func() error) (err error) {
+func runSafely(f func() error) (err error) {
 	defer func() {
 		if panicResult := recover(); panicResult != nil {
-			var ok bool
-			if err, ok = panicResult.(error); !ok {
-				err = errors.Errorf("panic resulted in: %v", panicResult)
-			}
+			err = errors.Errorf("panic resulted in: %v", panicResult)
 		}
 	}()
-	err = f()
-	if err != nil {
-		return err
-	}
-	return nil
+	return f()
 }

--- a/worker/catacomb/catacomb.go
+++ b/worker/catacomb/catacomb.go
@@ -248,7 +248,7 @@ func (err dyingError) Error() string {
 	return fmt.Sprintf("catacomb %p is dying", err.catacomb)
 }
 
-// RunSafely will ensure that the function is run, and any error is returned.
+// runSafely will ensure that the function is run, and any error is returned.
 // If there is a panic, then that will be returned as an error.
 func runSafely(f func() error) (err error) {
 	defer func() {

--- a/worker/catacomb/catacomb_test.go
+++ b/worker/catacomb/catacomb_test.go
@@ -21,12 +21,7 @@ type CatacombSuite struct {
 	fix *fixture
 }
 
-type RunSafelySuite struct {
-	testing.IsolationSuite
-}
-
 var _ = gc.Suite(&CatacombSuite{})
-var _ = gc.Suite(&RunSafelySuite{})
 
 func (s *CatacombSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
@@ -487,34 +482,4 @@ func checkInvalid(c *gc.C, plan catacomb.Plan, match string) {
 	}
 	check(plan.Validate())
 	check(catacomb.Invoke(plan))
-}
-
-func (s *RunSafelySuite) TestNoError(c *gc.C) {
-	myFunc := func() error {
-		return nil
-	}
-	c.Check(catacomb.RunSafely(myFunc), jc.ErrorIsNil)
-}
-
-func (s *RunSafelySuite) TestWithError(c *gc.C) {
-	err := errors.Errorf("my custom error")
-	myFunc := func() error {
-		return err
-	}
-	c.Check(catacomb.RunSafely(myFunc), gc.Equals, err)
-}
-
-func (s *RunSafelySuite) TestWithPanicString(c *gc.C) {
-	myFunc := func() error {
-		panic("couldn't make it work")
-	}
-	c.Check(catacomb.RunSafely(myFunc), gc.ErrorMatches, "panic resulted in: couldn't make it work")
-}
-
-func (s *RunSafelySuite) TestWithPanicError(c *gc.C) {
-	err := errors.Errorf("my custom error")
-	myFunc := func() error {
-		panic(err)
-	}
-	c.Check(catacomb.RunSafely(myFunc), gc.Equals, err)
 }


### PR DESCRIPTION
Without this patch, if a worker that a catacomb was managing would panic(), it
would end up getting hung in defer catacomb.wg.Wait(), because the Work()
didn't return an error that was being passed into Kill(), that meant the
catacomb's monitoring goroutine never went to Dying(), so the WG was never
decremented. (And it appears that because the catacomb was hung in a defer,
the panic could not escape and crash the rest of the system.)

This changes it so that panic in a work function just gets turned into
a normal error, so that we can continue to clean up and error out.

A possible other alternative is to recover the panic, kill the tomb, and then re-panic.

(Review request: http://reviews.vapour.ws/r/5182/)