### PR TITLE
Add headers to list-actions tabular output

### DIFF
--- a/cmd/juju/action/list.go
+++ b/cmd/juju/action/list.go
@@ -104,8 +104,6 @@ func (c *listCommand) Run(ctx *cmd.Context) error {
 		shortOutput[name] = action.Description
 		if shortOutput[name] == "" {
 			shortOutput[name] = "No description"
-		} else if shortOutput[name] == "\n" {
-			break
 		}
 		sortedNames = append(sortedNames, name)
 	}

--- a/cmd/juju/action/list.go
+++ b/cmd/juju/action/list.go
@@ -6,6 +6,7 @@ package action
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/juju/cmd"
@@ -103,10 +104,13 @@ func (c *listCommand) Run(ctx *cmd.Context) error {
 		shortOutput[name] = action.Description
 		if shortOutput[name] == "" {
 			shortOutput[name] = "No description"
+		} else if shortOutput[name] == "\n" {
+			break
 		}
 		sortedNames = append(sortedNames, name)
 	}
 	sortedNames = common.SortStringsNaturally(sortedNames)
+	fmt.Printf("sortedNames\n")
 	return c.printTabular(ctx, shortOutput, sortedNames)
 }
 
@@ -122,8 +126,9 @@ func (c *listCommand) printTabular(ctx *cmd.Context, actions map[string]string, 
 		flags    = 0
 	)
 	tw := tabwriter.NewWriter(&out, minwidth, tabwidth, padding, padchar, flags)
+	fmt.Fprintf(tw, "%s\t%s\n", "ACTION", "DESCRIPTION")
 	for _, name := range sortedNames {
-		fmt.Fprintf(tw, "%s\t%s\n", name, actions[name])
+		fmt.Fprintf(tw, "%s\t%s\n", name, strings.TrimSpace(actions[name]))
 	}
 	tw.Flush()
 	return c.out.Write(ctx, string(out.Bytes()))

--- a/cmd/juju/action/list.go
+++ b/cmd/juju/action/list.go
@@ -108,7 +108,6 @@ func (c *listCommand) Run(ctx *cmd.Context) error {
 		sortedNames = append(sortedNames, name)
 	}
 	sortedNames = common.SortStringsNaturally(sortedNames)
-	fmt.Printf("sortedNames\n")
 	return c.printTabular(ctx, shortOutput, sortedNames)
 }
 

--- a/cmd/juju/action/list_test.go
+++ b/cmd/juju/action/list_test.go
@@ -82,6 +82,7 @@ func (s *ListSuite) TestInit(c *gc.C) {
 
 func (s *ListSuite) TestRun(c *gc.C) {
 	simpleOutput := `
+ACTION          DESCRIPTION
 kill            Kill the database.
 no-description  No description
 no-params       An action with no parameters.

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -92,7 +92,7 @@ var someCharmActions = map[string]params.ActionSpec{
 		},
 	},
 	"no-params": {
-		Description: "An action with no parameters.",
+		Description: "An action with no parameters.\n",
 	},
 }
 


### PR DESCRIPTION
Add "ACTION" and "DESCRIPTION" headers to list-actions tabular output.  Also proper handling for new line in action description.

https://pad.lv/1590205

Live tested on lxd provider.  Test steps:

juju bootstrap mycontroller lxd --upload-tools
juju deploy apache-hadoop-spark
juju actions resourcemanager

expected output:
ACTION        DESCRIPTION
mrbench       Mapreduce benchmark for small jobs
restart-yarn  All of the YARN processes can be restarted with this Juju action.
smoke-test    Verify that YARN is working as expected by running a small (1MB) terasort.
start-yarn    All of the YARN processes can be started with this Juju action.
stop-yarn     All of the YARN processes can be stopped with this Juju action.
teragen       Generate data with teragen
terasort      Runs teragen to generate sample data, and then runs terasort to sort that data



(Review request: http://reviews.vapour.ws/r/5183/)