### PR TITLE
Quick implementation to log audit info to a file on the controller

### DIFF
--- a/apiserver/observer/audit.go
+++ b/apiserver/observer/audit.go
@@ -14,10 +14,6 @@ import (
 	"github.com/juju/juju/rpc"
 )
 
-// PersistAuditEntryFn defines a function which will persist an
-// AuditEntry to a backing store and return an error upon failure.
-type AuditEntrySinkFn func(audit.AuditEntry) error
-
 // Context defines things an Audit observer need know about to operate
 // correctly.
 type AuditContext struct {
@@ -33,7 +29,7 @@ type AuditContext struct {
 type ErrorHandler func(error)
 
 // NewAudit creates a new Audit with the information provided via the Context.
-func NewAudit(ctx *AuditContext, handleAuditEntry AuditEntrySinkFn, errorHandler ErrorHandler) *Audit {
+func NewAudit(ctx *AuditContext, handleAuditEntry audit.AuditEntrySinkFn, errorHandler ErrorHandler) *Audit {
 	return &Audit{
 		jujuServerVersion: ctx.JujuServerVersion,
 		modelUUID:         ctx.ModelUUID,
@@ -48,7 +44,7 @@ type Audit struct {
 	jujuServerVersion version.Number
 	modelUUID         string
 	errorHandler      ErrorHandler
-	handleAuditEntry  AuditEntrySinkFn
+	handleAuditEntry  audit.AuditEntrySinkFn
 
 	// state represents information that's built up as methods on this
 	// type are called. We segregate this to ensure it's clear what

--- a/audit/audit.go
+++ b/audit/audit.go
@@ -12,6 +12,10 @@ import (
 	"github.com/juju/version"
 )
 
+// AuditEntrySinkFn defines a function which will send an
+// AuditEntry to a backing store and return an error upon failure.
+type AuditEntrySinkFn func(AuditEntry) error
+
 // AuditEntry represents an auditted event.
 type AuditEntry struct {
 	// JujuServerVersion is the version of the jujud that recorded

--- a/audit/auditlogfile.go
+++ b/audit/auditlogfile.go
@@ -1,0 +1,71 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package audit
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"fmt"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/utils"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+var logger = loggo.GetLogger("juju.audit")
+
+// NewLogFileSink returns an audit entry sink which writes
+// to an audit.log file in the specified directory.
+func NewLogFileSink(logDir string) AuditEntrySinkFn {
+	logPath := filepath.Join(logDir, "audit.log")
+	if err := primeLogFile(logPath); err != nil {
+		// This isn't a fatal error so log and continue if priming
+		// fails.
+		logger.Errorf("Unable to prime %s (proceeding anyway): %v", logPath, err)
+	}
+
+	handler := &auditLogFileSink{
+		fileLogger: &lumberjack.Logger{
+			Filename:   logPath,
+			MaxSize:    300, // MB
+			MaxBackups: 10,
+		},
+	}
+	return handler.handle
+}
+
+// primeLogFile ensures the logsink log file is created with the
+// correct mode and ownership.
+func primeLogFile(path string) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := f.Close(); err != nil {
+		return errors.Trace(err)
+	}
+	err = utils.ChownPath(path, "syslog")
+	return errors.Trace(err)
+}
+
+type auditLogFileSink struct {
+	fileLogger io.WriteCloser
+}
+
+func (a *auditLogFileSink) handle(entry AuditEntry) error {
+	_, err := a.fileLogger.Write([]byte(strings.Join([]string{
+		entry.Timestamp.In(time.UTC).Format("2006-01-02 15:04:05"),
+		entry.ModelUUID,
+		entry.RemoteAddress,
+		entry.OriginName,
+		entry.OriginType,
+		entry.Operation,
+		fmt.Sprintf("%v", entry.Data),
+	}, ",") + "\n"))
+	return err
+}

--- a/audit/auditlogfile_test.go
+++ b/audit/auditlogfile_test.go
@@ -1,0 +1,71 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package audit_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/audit"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/testing"
+)
+
+type auditLogFileSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&auditLogFileSuite{})
+
+func (s *auditLogFileSuite) TestLogging(c *gc.C) {
+	dir := c.MkDir()
+	sink := audit.NewLogFileSink(dir)
+
+	modelUUID := coretesting.ModelTag.Id()
+	t0 := time.Date(2015, time.June, 1, 23, 2, 1, 0, time.UTC)
+	t1 := time.Date(2015, time.June, 1, 23, 2, 2, 0, time.UTC)
+
+	err := sink(audit.AuditEntry{
+		Timestamp:     t0,
+		ModelUUID:     modelUUID,
+		RemoteAddress: "10.0.0.1",
+		OriginType:    "API",
+		OriginName:    "user-admin",
+		Operation:     "deploy",
+		Data:          map[string]interface{}{"foo": "bar"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = sink(audit.AuditEntry{
+		Timestamp:     t1,
+		ModelUUID:     modelUUID,
+		RemoteAddress: "10.0.0.2",
+		OriginType:    "API",
+		OriginName:    "user-admin",
+		Operation:     "status",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check that the audit log file was populated as expected
+	logPath := filepath.Join(dir, "audit.log")
+	logContents, err := ioutil.ReadFile(logPath)
+	c.Assert(err, jc.ErrorIsNil)
+	line0 := "2015-06-01 23:02:01," + modelUUID + ",10.0.0.1,user-admin,API,deploy,map[foo:bar]\n"
+	line1 := "2015-06-01 23:02:02," + modelUUID + ",10.0.0.2,user-admin,API,status,map[]\n"
+	c.Assert(string(logContents), gc.Equals, line0+line1)
+
+	// Check the file mode is as expected. This doesn't work on
+	// Windows (but this code is very unlikely to run on Windows so
+	// it's ok).
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(logPath)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(info.Mode(), gc.Equals, os.FileMode(0600))
+	}
+}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -43,6 +44,7 @@ import (
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/audit"
 	"github.com/juju/juju/cert"
 	"github.com/juju/juju/cmd/jujud/agent/machine"
 	"github.com/juju/juju/cmd/jujud/agent/model"
@@ -1066,8 +1068,8 @@ func (a *MachineAgent) newApiserverWorker(st *state.State, certChanged chan para
 		NewObserver: newObserverFn(
 			clock.WallClock,
 			jujuversion.Current,
-			agentConfig.Model().String(),
-			st.PutAuditEntryFn(),
+			agentConfig.Model().Id(),
+			newAuditEntrySink(st, logDir),
 			auditErrorHandler,
 		),
 	})
@@ -1078,11 +1080,35 @@ func (a *MachineAgent) newApiserverWorker(st *state.State, certChanged chan para
 	return server, nil
 }
 
+func newAuditEntrySink(st *state.State, logDir string) audit.AuditEntrySinkFn {
+	persistFn := st.PutAuditEntryFn()
+	fileSinkFn := audit.NewLogFileSink(logDir)
+	return func(entry audit.AuditEntry) error {
+		// We don't care about auditing anything but user actions.
+		if _, err := names.ParseUserTag(entry.OriginName); err != nil {
+			return nil
+		}
+		// TODO(wallyworld) - Pinger requests should not originate as a user action.
+		if strings.HasPrefix(entry.Operation, "Pinger:") {
+			return nil
+		}
+		persistErr := persistFn(entry)
+		sinkErr := fileSinkFn(entry)
+		if persistErr == nil {
+			return errors.Annotate(sinkErr, "cannot save audit record to file")
+		}
+		if sinkErr == nil {
+			return errors.Annotate(persistErr, "cannot save audit record to database")
+		}
+		return errors.Annotate(persistErr, "cannot save audit record to file or database")
+	}
+}
+
 func newObserverFn(
 	clock clock.Clock,
 	jujuServerVersion version.Number,
 	modelUUID string,
-	persistAuditEntry observer.AuditEntrySinkFn,
+	persistAuditEntry audit.AuditEntrySinkFn,
 	auditErrorHandler observer.ErrorHandler,
 ) observer.ObserverFactory {
 	var connectionID int64


### PR DESCRIPTION
Until audit log forwarding is done, we just want to dump audit records to a log file. We add a new audit log file sync for this purpose.

Instead of logging all api requests (including those from agents), we only want to record API requests originating from users. Even then, there are Pinger requests which are recorded as originating from the admin user that don't need to be logged. So these are discarded in the easiest way possible for now.

Also a drive by fix for persisting audit records in state.

(Review request: http://reviews.vapour.ws/r/5187/)