### PR TITLE
apiserver/modelmanager: check canonical user names

### DIFF
--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -182,7 +182,7 @@ func (mm *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Mode
 
 	cloudCredentialName := args.CloudCredential
 	if cloudCredentialName == "" {
-		if ownerTag == controllerModel.Owner() {
+		if ownerTag.Canonical() == controllerModel.Owner().Canonical() {
 			cloudCredentialName = controllerModel.CloudCredential()
 		} else {
 			// TODO(axw) check if the user has one and only one

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -180,9 +180,18 @@ func (s *modelManagerSuite) TestCreateModelDefaultRegion(c *gc.C) {
 }
 
 func (s *modelManagerSuite) TestCreateModelDefaultCredentialAdmin(c *gc.C) {
+	s.testCreateModelDefaultCredentialAdmin(c, "user-admin@local")
+}
+
+func (s *modelManagerSuite) TestCreateModelDefaultCredentialAdminNoDomain(c *gc.C) {
+	s.testCreateModelDefaultCredentialAdmin(c, "user-admin")
+}
+
+func (s *modelManagerSuite) testCreateModelDefaultCredentialAdmin(c *gc.C, ownerTag string) {
+	s.st.cloud.AuthTypes = []cloud.AuthType{"userpass"}
 	args := params.ModelCreateArgs{
 		Name:     "foo",
-		OwnerTag: "user-admin@local",
+		OwnerTag: ownerTag,
 	}
 	_, err := s.api.CreateModel(args)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Fix an issue checking the model owner name. Always
check the canonical user name.