### PR TITLE
Change 'juju status' formatting.

### DIFF
--- a/cmd/juju/machine/list_test.go
+++ b/cmd/juju/machine/list_test.go
@@ -79,10 +79,10 @@ func (s *MachineListCommandSuite) TestMachine(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineListCommand())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"MACHINE    STATE    DNS       INS-ID               SERIES  AZ         \n"+
-		"0          started  10.0.0.1  juju-badd06-0        trusty  us-east-1  \n"+
-		"1          started  10.0.0.2  juju-badd06-1        trusty             \n"+
-		"  1/lxd/0  pending  10.0.0.3  juju-badd06-1-lxd-0  trusty             \n"+
+		"MACHINE    STATE    DNS       INS-ID               SERIES  AZ\n"+
+		"0          started  10.0.0.1  juju-badd06-0        trusty  us-east-1\n"+
+		"1          started  10.0.0.2  juju-badd06-1        trusty  \n"+
+		"  1/lxd/0  pending  10.0.0.3  juju-badd06-1-lxd-0  trusty  \n"+
 		"\n")
 }
 

--- a/cmd/juju/machine/show_test.go
+++ b/cmd/juju/machine/show_test.go
@@ -72,10 +72,10 @@ func (s *MachineShowCommandSuite) TestShowTabularMachine(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineShowCommand(), "--format", "tabular", "0", "1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"MACHINE    STATE    DNS       INS-ID               SERIES  AZ         \n"+
-		"0          started  10.0.0.1  juju-badd06-0        trusty  us-east-1  \n"+
-		"1          started  10.0.0.2  juju-badd06-1        trusty             \n"+
-		"  1/lxd/0  pending  10.0.0.3  juju-badd06-1-lxd-0  trusty             \n"+
+		"MACHINE    STATE    DNS       INS-ID               SERIES  AZ\n"+
+		"0          started  10.0.0.1  juju-badd06-0        trusty  us-east-1\n"+
+		"1          started  10.0.0.2  juju-badd06-1        trusty  \n"+
+		"  1/lxd/0  pending  10.0.0.3  juju-badd06-1-lxd-0  trusty  \n"+
 		"\n")
 }
 

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -78,8 +78,12 @@ func (r *relationFormatter) get(k string) *statusRelation {
 
 func printHelper(tw *tabwriter.Writer) func(...interface{}) {
 	return func(values ...interface{}) {
-		for _, v := range values {
-			fmt.Fprintf(tw, "%v\t", v)
+		for i, v := range values {
+			if i != len(values)-1 {
+				fmt.Fprintf(tw, "%v\t", v)
+			} else {
+				fmt.Fprintf(tw, "%v", v)
+			}
 		}
 		fmt.Fprintln(tw)
 	}

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3372,31 +3372,31 @@ func (s *StatusSuite) testStatusWithFormatTabular(c *gc.C, useFeatureFlag bool) 
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	expected := `
-MODEL       CONTROLLER  CLOUD  VERSION  UPGRADE-AVAILABLE  
-controller  kontroll    dummy  1.2.3    1.2.4              
+MODEL       CONTROLLER  CLOUD  VERSION  UPGRADE-AVAILABLE
+controller  kontroll    dummy  1.2.3    1.2.4
 
-APP        STATUS       EXPOSED  ORIGIN      CHARM      REV  OS      
-logging                 true     jujucharms  logging    1    ubuntu  
-mysql      maintenance  true     jujucharms  mysql      1    ubuntu  
-wordpress  active       true     jujucharms  wordpress  3    ubuntu  
+APP        STATUS       EXPOSED  ORIGIN      CHARM      REV  OS
+logging                 true     jujucharms  logging    1    ubuntu
+mysql      maintenance  true     jujucharms  mysql      1    ubuntu
+wordpress  active       true     jujucharms  wordpress  3    ubuntu
 
-RELATION           PROVIDES   CONSUMES   TYPE         
-juju-info          logging    mysql      regular      
-logging-dir        logging    wordpress  regular      
-info               mysql      logging    subordinate  
-db                 mysql      wordpress  regular      
-logging-directory  wordpress  logging    subordinate  
+RELATION           PROVIDES   CONSUMES   TYPE
+juju-info          logging    mysql      regular
+logging-dir        logging    wordpress  regular
+info               mysql      logging    subordinate
+db                 mysql      wordpress  regular
+logging-directory  wordpress  logging    subordinate
 
-UNIT         WORKLOAD     AGENT  MACHINE  PORTS  PUBLIC-ADDRESS    MESSAGE                         
-mysql/0      maintenance  idle   2               controller-2.dns  installing all the things       
-  logging/1  error        idle                   controller-2.dns  somehow lost in all those logs  
-wordpress/0  active       idle   1               controller-1.dns                                  
-  logging/0  active       idle                   controller-1.dns                                  
+UNIT         WORKLOAD     AGENT  MACHINE  PORTS  PUBLIC-ADDRESS    MESSAGE
+mysql/0      maintenance  idle   2               controller-2.dns  installing all the things
+  logging/1  error        idle                   controller-2.dns  somehow lost in all those logs
+wordpress/0  active       idle   1               controller-1.dns  
+  logging/0  active       idle                   controller-1.dns  
 
-MACHINE  STATE    DNS               INS-ID        SERIES   AZ          
-0        started  controller-0.dns  controller-0  quantal  us-east-1a  
-1        started  controller-1.dns  controller-1  quantal              
-2        started  controller-2.dns  controller-2  quantal              
+MACHINE  STATE    DNS               INS-ID        SERIES   AZ
+0        started  controller-0.dns  controller-0  quantal  us-east-1a
+1        started  controller-1.dns  controller-1  quantal  
+2        started  controller-2.dns  controller-2  quantal  
 
 `[1:]
 	c.Assert(string(stdout), gc.Equals, expected)
@@ -3438,17 +3438,17 @@ func (s *StatusSuite) TestFormatTabularHookActionName(c *gc.C) {
 	out, err := FormatTabular(status)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), gc.Equals, `
-MODEL  CONTROLLER  CLOUD  VERSION  
-                                   
+MODEL  CONTROLLER  CLOUD  VERSION
+                          
 
-APP  STATUS  EXPOSED  ORIGIN  CHARM  REV  OS  
-foo          false                   0        
+APP  STATUS  EXPOSED  ORIGIN  CHARM  REV  OS
+foo          false                   0    
 
-UNIT   WORKLOAD     AGENT      MACHINE  PORTS  PUBLIC-ADDRESS  MESSAGE                            
-foo/0  maintenance  executing                                  (config-changed) doing some work   
-foo/1  maintenance  executing                                  (backup database) doing some work  
+UNIT   WORKLOAD     AGENT      MACHINE  PORTS  PUBLIC-ADDRESS  MESSAGE
+foo/0  maintenance  executing                                  (config-changed) doing some work
+foo/1  maintenance  executing                                  (backup database) doing some work
 
-MACHINE  STATE  DNS  INS-ID  SERIES  AZ  
+MACHINE  STATE  DNS  INS-ID  SERIES  AZ
 `[1:])
 }
 
@@ -3504,21 +3504,21 @@ func (s *StatusSuite) TestFormatTabularMetering(c *gc.C) {
 	out, err := FormatTabular(status)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), gc.Equals, `
-MODEL  CONTROLLER  CLOUD  VERSION  
-                                   
+MODEL  CONTROLLER  CLOUD  VERSION
+                          
 
-APP  STATUS  EXPOSED  ORIGIN  CHARM  REV  OS  
-foo          false                   0        
+APP  STATUS  EXPOSED  ORIGIN  CHARM  REV  OS
+foo          false                   0    
 
-UNIT   WORKLOAD  AGENT  MACHINE  PORTS  PUBLIC-ADDRESS  MESSAGE  
-foo/0                                                            
-foo/1                                                            
+UNIT   WORKLOAD  AGENT  MACHINE  PORTS  PUBLIC-ADDRESS  MESSAGE
+foo/0                                                   
+foo/1                                                   
 
-METER  STATUS   MESSAGE                      
-foo/0  strange  warning: stable strangelets  
-foo/1  up       things are looking up        
+METER  STATUS   MESSAGE
+foo/0  strange  warning: stable strangelets
+foo/1  up       things are looking up
 
-MACHINE  STATE  DNS  INS-ID  SERIES  AZ  
+MACHINE  STATE  DNS  INS-ID  SERIES  AZ
 `[1:])
 }
 


### PR DESCRIPTION
Related to bug: https://pad.lv/1597704
If you have a long message in 'juju status' it causes all items in that section to wrap,
because we were causing all columns to be space filled.
This changes 'juju status' so that the last column is not fixed width.

(Review request: http://reviews.vapour.ws/r/5188/)