### PR TITLE
Ensure that log messages are sent correctly (per wire format).

### DIFF
--- a/featuretests/syslog_test.go
+++ b/featuretests/syslog_test.go
@@ -6,8 +6,11 @@ package featuretests
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
+	"regexp"
 	"time"
 
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -19,12 +22,14 @@ import (
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
+	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker/logsender"
 )
 
 type syslogSuite struct {
 	agenttest.AgentSuite
 	server   *rfc5424test.Server
+	logsCh   logsender.LogRecordCh
 	received chan rfc5424test.Message
 }
 
@@ -65,9 +70,55 @@ func (s *syslogSuite) SetUpTest(c *gc.C) {
 		"syslog-client-key":  coretesting.ServerKey,
 	}, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
+
+	s.logsCh, err = logsender.InstallBufferedLogWriter(1000)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *syslogSuite) TestAuditLogForwarded(c *gc.C) {
+func (s *syslogSuite) newRecord(msg string) *logsender.LogRecord {
+	return &logsender.LogRecord{
+		Time:     time.Now(),
+		Module:   "juju.featuretests.syslog",
+		Location: "syslog_test.go:99999",
+		Level:    loggo.ERROR,
+		Message:  msg,
+	}
+}
+
+func (s *syslogSuite) sendRecord(c *gc.C, rec *logsender.LogRecord) {
+	select {
+	case s.logsCh <- rec:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal(`timed out "sending" message`)
+	}
+}
+
+func (s *syslogSuite) popMessagesUntil(c *gc.C, expected string) rfc5424test.Message {
+	re, err := regexp.Compile(expected)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Logf("popping messages")
+	for {
+		msg := s.nextMessage(c)
+		c.Logf("message: %+v", msg)
+		if re.MatchString(msg.Message) {
+			return msg
+		}
+	}
+}
+
+func (s *syslogSuite) nextMessage(c *gc.C) rfc5424test.Message {
+	select {
+	case msg, ok := <-s.received:
+		c.Assert(ok, jc.IsTrue)
+		return msg
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for message to be forwarded")
+	}
+	return rfc5424test.Message{}
+}
+
+func (s *syslogSuite) TestLogRecordForwarded(c *gc.C) {
 	// Create a machine and an agent for it.
 	m, password := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{
 		Nonce: agent.BootstrapNonce,
@@ -78,9 +129,7 @@ func (s *syslogSuite) TestAuditLogForwarded(c *gc.C) {
 	agentConf := agentcmd.NewAgentConf(s.DataDir())
 	agentConf.ReadConfig(m.Tag().String())
 
-	logsCh, err := logsender.InstallBufferedLogWriter(1000)
-	c.Assert(err, jc.ErrorIsNil)
-	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, logsCh, c.MkDir())
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, s.logsCh, c.MkDir())
 	a := machineAgentFactory(m.Id())
 
 	// Ensure there's no logs to begin with.
@@ -88,11 +137,17 @@ func (s *syslogSuite) TestAuditLogForwarded(c *gc.C) {
 	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
 	defer a.Stop()
 
-	select {
-	case msg, ok := <-s.received:
-		c.Assert(ok, jc.IsTrue)
-		c.Logf("message: %+v", msg)
-	case <-time.After(coretesting.LongWait):
-		c.Fatal("timed out waiting for message to be forwarded")
-	}
+	// Pop off all initial log records.
+	s.sendRecord(c, s.newRecord("<stop here>"))
+	s.popMessagesUntil(c, `.*<stop here>`)
+
+	// Ensure that a specific log record gets forwarded.
+	rec := s.newRecord("something happened!")
+	rec.Time = time.Date(2015, time.June, 1, 23, 2, 1, 23, time.UTC)
+	s.sendRecord(c, rec)
+	msg := s.popMessagesUntil(c, `something happened!`)
+	expected := `<11>1 2015-06-01T23:02:01.000000023Z machine-0.%s jujud-machine-agent-%s - - [origin enterpriseID="28978" sofware="jujud-machine-agent" swVersion="%s"][model@28978 controller-uuid="%s" model-uuid="%s"][log@28978 module="juju.featuretests.syslog" source="syslog_test.go:99999"] something happened!`
+	modelID := coretesting.ModelTag.Id()
+	ctlrID := modelID
+	c.Check(msg.Message, gc.Equals, fmt.Sprintf(expected, modelID, modelID[:28], version.Current, ctlrID, modelID))
 }


### PR DESCRIPTION
We must be sure that the wire format syslog messages we send match the specification (see below).  This patch does so.

--------------

(see https://docs.google.com/document/d/1Dnn85mR8gUqmu9WhPtOMjLS4LftMbnCgtS-3dNomyNw/)

Syslog messages will be sent using the RFC 5424 message format (see more on the syslog protocol below).  We make use of the structured data facility defined in the more recent RFC.

The value of "priority" is set by whether a log or audit message is being recorded.

Log Messages:
The facility code will be 1 (user level message). Severity will be mapped as follows:
Juju ERROR = Error (3)
Juju WARNING = Warning (4)
Juju INFO = Informational (6)
Juju DEBUG = Debug (7)
Juju TRACE = Debug (7)

Messages will use structured data to record relevant environment and user action parameters. Key pair definitions will be:

SDID: origin
enterpriseId: 28978 (Canonical, Ltd.)
software: jujud
swVersion: <the Juju version of the running agent>

SDID: model@28978
controller-uuid: <the uuid of the controller from which the message originates>
model-uuid: <the uuid of the model from which the message originates>

SDID: log@28978
source: <the name of the source filename from which the message originates>:<the source line number>
module: <the name of the source “module”>

Example log (error) message

<11>1 2016-02-28T09:57:10.804642398-05:00 172.12.3.1 juju - - [origin enterpriseId="28978" software="jujud" "2.0.0"] [model@28978 controller-uuid="deadbeef" model-uuid="deadbeef"] [log@28978 source-file="provider/ec2/storage.go" source-line="60"] Could not initialise machine block storage

(Review request: http://reviews.vapour.ws/r/5189/)