### PR TITLE
Suggest controller name on juju register

### DIFF
--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -107,6 +107,21 @@ func (s *RegisterSuite) encodeRegistrationData(c *gc.C, user string, secretKey [
 	return base64.URLEncoding.EncodeToString(data)
 }
 
+func (s *RegisterSuite) encodeRegistrationDataWithControllerName(c *gc.C, user string, secretKey []byte, controller string) string {
+	data, err := asn1.Marshal(jujuclient.RegistrationInfo{
+		User:           user,
+		Addrs:          []string{s.apiConnection.addr},
+		SecretKey:      secretKey,
+		ControllerName: controller,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	// Append some junk to the end of the encoded data to
+	// ensure that, if we have to pad the data in add-user,
+	// register can still decode it.
+	data = append(data, 0, 0, 0)
+	return base64.URLEncoding.EncodeToString(data)
+}
+
 func (s *RegisterSuite) seal(c *gc.C, message, key, nonce []byte) []byte {
 	var keyArray [32]byte
 	var nonceArray [24]byte
@@ -130,12 +145,12 @@ func (s *RegisterSuite) TestInit(c *gc.C) {
 }
 
 func (s *RegisterSuite) TestRegister(c *gc.C) {
-	ctx := s.testRegister(c)
+	ctx := s.testRegister(c, "")
 	c.Assert(s.refreshModelsControllerName, gc.Equals, "controller-name")
 	c.Assert(s.refreshModelsAccountName, gc.Equals, "bob@local")
 	stderr := testing.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `
-Please set a name for this controller: 
+Please set a name for this controller (controller-name):
 Enter a new password: 
 Confirm password: 
 
@@ -156,7 +171,7 @@ func (s *RegisterSuite) TestRegisterOneModel(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		return nil
 	}
-	s.testRegister(c)
+	s.testRegister(c, "")
 	c.Assert(
 		s.store.Models["controller-name"].AccountModels["bob@local"].CurrentModel,
 		gc.Equals, "theoneandonly",
@@ -173,7 +188,7 @@ func (s *RegisterSuite) TestRegisterMultipleModels(c *gc.C) {
 		}
 		return nil
 	}
-	ctx := s.testRegister(c)
+	ctx := s.testRegister(c, "")
 
 	// When there are multiple models, no current model will be set.
 	// Instead, the command will output the list of models and inform
@@ -183,7 +198,7 @@ func (s *RegisterSuite) TestRegisterMultipleModels(c *gc.C) {
 
 	stderr := testing.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `
-Please set a name for this controller: 
+Please set a name for this controller (controller-name):
 Enter a new password: 
 Confirm password: 
 
@@ -197,7 +212,7 @@ one of them:
 `[1:])
 }
 
-func (s *RegisterSuite) testRegister(c *gc.C) *cmd.Context {
+func (s *RegisterSuite) testRegister(c *gc.C, expectedError string) *cmd.Context {
 	secretKey := []byte(strings.Repeat("X", 32))
 	respNonce := []byte(strings.Repeat("X", 24))
 
@@ -229,9 +244,13 @@ func (s *RegisterSuite) testRegister(c *gc.C) *cmd.Context {
 		c.Check(err, jc.ErrorIsNil)
 	})
 
-	registrationData := s.encodeRegistrationData(c, "bob", secretKey)
-	stdin := strings.NewReader("controller-name\nhunter2\nhunter2\n")
+	registrationData := s.encodeRegistrationDataWithControllerName(c, "bob", secretKey, "controller-name")
+	stdin := strings.NewReader("\nhunter2\nhunter2\n")
 	ctx, err := s.run(c, stdin, registrationData)
+	if expectedError != "" {
+		c.Assert(err, gc.ErrorMatches, expectedError)
+		return ctx
+	}
 	c.Assert(err, jc.ErrorIsNil)
 
 	// There should have been one POST command to "/register".
@@ -297,6 +316,36 @@ func (s *RegisterSuite) TestRegisterControllerNameExists(c *gc.C) {
 	stdin := strings.NewReader("controller-name\nhunter2\nhunter2\n")
 	_, err = s.run(c, stdin, registrationData)
 	c.Assert(err, gc.ErrorMatches, `controller "controller-name" already exists`)
+}
+
+func (s *RegisterSuite) TestProposedControllerNameExists(c *gc.C) {
+	err := s.store.UpdateController("controller-name", jujuclient.ControllerDetails{
+		ControllerUUID: "df136476-12e9-11e4-8a70-b2227cce2b54",
+		CACert:         testing.CACert,
+	})
+
+	s.refreshModels = func(store jujuclient.ClientStore, controller, account string) error {
+		err := store.UpdateModel(controller, account, "controller-name", jujuclient.ModelDetails{
+			ModelUUID: "df136476-12e9-11e4-8a70-b2227cce2b54",
+		})
+		c.Assert(err, jc.ErrorIsNil)
+		return nil
+	}
+
+	ctx := s.testRegister(c, "you must specify a non-empty controller name")
+
+	secretKey := []byte(strings.Repeat("X", 32))
+	registrationData := s.encodeRegistrationDataWithControllerName(c, "bob", secretKey, "controller-name")
+	stdin := strings.NewReader("controller-name1\nhunter2\nhunter2\n")
+	_, err = s.run(c, stdin, registrationData)
+	c.Assert(err, jc.ErrorIsNil)
+	stderr := testing.Stderr(ctx)
+	c.Assert(stderr, gc.Equals, `
+WARNING: the controller proposed "controller-name" which clashes with an existing controller. The two controllers are entirely different.
+
+Please set a name for this controller:
+`[1:])
+
 }
 
 func (s *RegisterSuite) TestRegisterEmptyPassword(c *gc.C) {

--- a/cmd/juju/user/add.go
+++ b/cmd/juju/user/add.go
@@ -145,9 +145,10 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	registrationInfo := jujuclient.RegistrationInfo{
-		User:      c.User,
-		Addrs:     controllerDetails.APIEndpoints,
-		SecretKey: secretKey,
+		User:           c.User,
+		Addrs:          controllerDetails.APIEndpoints,
+		SecretKey:      secretKey,
+		ControllerName: c.ControllerName(),
 	}
 	registrationData, err := asn1.Marshal(registrationInfo)
 	if err != nil {

--- a/cmd/juju/user/add_test.go
+++ b/cmd/juju/user/add_test.go
@@ -99,7 +99,7 @@ func (s *UserAddCommandSuite) TestAddUserWithUsername(c *gc.C) {
 	expected := `
 User "foobar" added
 Please send this command to foobar:
-    juju register MD0TBmZvb2JhcjAREw8xMjcuMC4wLjE6MTIzNDUEIFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY
+    juju register MEYTBmZvb2JhcjAREw8xMjcuMC4wLjE6MTIzNDUEIFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYEwd0ZXN0aW5n
 
 "foobar" has not been granted access to any models. You can use "juju grant" to grant access.
 `[1:]
@@ -117,7 +117,7 @@ func (s *UserAddCommandSuite) TestAddUserWithUsernameAndACL(c *gc.C) {
 	expected := `
 User "foobar" added
 Please send this command to foobar:
-    juju register MD0TBmZvb2JhcjAREw8xMjcuMC4wLjE6MTIzNDUEIFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY
+    juju register MEYTBmZvb2JhcjAREw8xMjcuMC4wLjE6MTIzNDUEIFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYEwd0ZXN0aW5n
 
 "foobar" has not been granted access to any models. You can use "juju grant" to grant access.
 `[1:]
@@ -135,7 +135,7 @@ func (s *UserAddCommandSuite) TestAddUserWithUsernameAndDisplayname(c *gc.C) {
 	expected := `
 User "Foo Bar (foobar)" added
 Please send this command to foobar:
-    juju register MD0TBmZvb2JhcjAREw8xMjcuMC4wLjE6MTIzNDUEIFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY
+    juju register MEYTBmZvb2JhcjAREw8xMjcuMC4wLjE6MTIzNDUEIFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYEwd0ZXN0aW5n
 
 "Foo Bar (foobar)" has not been granted access to any models. You can use "juju grant" to grant access.
 `[1:]
@@ -164,7 +164,7 @@ func (s *UserAddCommandSuite) TestAddUserWithModelAccess(c *gc.C) {
 User "foobar" added
 User "foobar" granted read access to model "model"
 Please send this command to foobar:
-    juju register MD0TBmZvb2JhcjAREw8xMjcuMC4wLjE6MTIzNDUEIFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY
+    juju register MEYTBmZvb2JhcjAREw8xMjcuMC4wLjE6MTIzNDUEIFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYEwd0ZXN0aW5n
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)
 	c.Assert(testing.Stderr(context), gc.Equals, "")

--- a/featuretests/cmd_juju_register_test.go
+++ b/featuretests/cmd_juju_register_test.go
@@ -60,7 +60,9 @@ Please send this command to bob:
 	context = s.run(c, stdin, args...)
 	c.Check(testing.Stdout(context), gc.Equals, "")
 	c.Check(testing.Stderr(context), gc.Equals, `
-Please set a name for this controller: 
+WARNING: the controller proposed "kontroll" which clashes with an existing controller. The two controllers are entirely different.
+
+Please set a name for this controller:
 Enter a new password: 
 Confirm password: 
 

--- a/jujuclient/registration.go
+++ b/jujuclient/registration.go
@@ -16,4 +16,9 @@ type RegistrationInfo struct {
 	// SecretKey contains the secret key to use when encrypting
 	// and decrypting registration requests and responses.
 	SecretKey []byte
+
+	// ControllerName contains the name that the controller has for the
+	// caller of "juju add-user" that will be used to suggest a name for
+	// the caller of "juju register".
+	ControllerName string
 }


### PR DESCRIPTION
A controller name is now suggested when user runs
juju register, also in case the name is in user,
pertinent information is displayed.
This fixes lp:1594415

(Review request: http://reviews.vapour.ws/r/5192/)