### PR TITLE
Actually check if the resource file is up to date.

### DIFF
--- a/resource/context/context.go
+++ b/resource/context/context.go
@@ -148,21 +148,7 @@ func (deps contextDeps) Copy(target io.Writer, source io.Reader) error {
 }
 
 func (deps contextDeps) FingerprintMatches(filename string, expected charmresource.Fingerprint) (bool, error) {
-	file, err := os.Open(filename)
-	if os.IsNotExist(errors.Cause(err)) {
-		return false, nil
-	}
-	if err != nil {
-		return false, errors.Trace(err)
-	}
-	defer file.Close()
-
-	fp, err := charmresource.GenerateFingerprint(file)
-	if err != nil {
-		return false, errors.Trace(err)
-	}
-	matches := (fp.String() == expected.String())
-	return matches, nil
+	return FingerprintMatcher{}.FingerprintMatches(filename, expected)
 }
 
 func (deps contextDeps) Join(path ...string) string {

--- a/resource/context/context.go
+++ b/resource/context/context.go
@@ -147,6 +147,24 @@ func (deps contextDeps) Copy(target io.Writer, source io.Reader) error {
 	return err
 }
 
+func (deps contextDeps) FingerprintMatches(filename string, expected charmresource.Fingerprint) (bool, error) {
+	file, err := os.Open(filename)
+	if os.IsNotExist(errors.Cause(err)) {
+		return false, nil
+	}
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	defer file.Close()
+
+	fp, err := charmresource.GenerateFingerprint(file)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	matches := (fp.String() == expected.String())
+	return matches, nil
+}
+
 func (deps contextDeps) Join(path ...string) string {
 	return filepath.Join(path...)
 }

--- a/resource/context/internal/resourcedir.go
+++ b/resource/context/internal/resourcedir.go
@@ -10,6 +10,7 @@ import (
 	"io"
 
 	"github.com/juju/errors"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 )
 
 // DirectorySpec identifies information for a resource directory.
@@ -46,8 +47,9 @@ func (spec DirectorySpec) Resolve(path ...string) string {
 
 // IsUpToDate determines whether or not the content matches the resource directory.
 func (spec DirectorySpec) IsUpToDate(content Content) (bool, error) {
-	// TODO(katco): Check to see if we have latest version
-	return false, nil
+	filename := spec.Resolve(spec.Name)
+	ok, err := spec.Deps.FingerprintMatches(filename, content.Fingerprint)
+	return ok, errors.Trace(err)
 }
 
 // Initialize preps the spec'ed directory and returns it.
@@ -62,6 +64,10 @@ func (spec DirectorySpec) Initialize() (*Directory, error) {
 // DirectorySpecDeps exposes the external depenedencies of DirectorySpec.
 type DirectorySpecDeps interface {
 	DirectoryDeps
+
+	// FingerprintMatches determines whether or not the identified file
+	// exists and has the provided fingerprint.
+	FingerprintMatches(filename string, fp charmresource.Fingerprint) (bool, error)
 
 	// Join exposes the functionality of filepath.Join().
 	Join(...string) string

--- a/resource/context/internal/stub_test.go
+++ b/resource/context/internal/stub_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/testing"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/context/internal"
@@ -25,6 +26,7 @@ type internalStub struct {
 	ReturnNewChecker              internal.ContentChecker
 	ReturnCreateWriter            io.WriteCloser
 	ReturnNewTempDir              string
+	ReturnFingerprintMatches      bool
 }
 
 func newInternalStub() *internalStub {
@@ -168,6 +170,14 @@ func (s *internalStub) Copy(target io.Writer, source io.Reader) error {
 	}
 
 	return nil
+}
+func (s *internalStub) FingerprintMatches(filename string, fp charmresource.Fingerprint) (bool, error) {
+	s.Stub.AddCall("FingerprintMatches", filename, fp)
+	if err := s.Stub.NextErr(); err != nil {
+		return false, errors.Trace(err)
+	}
+
+	return s.ReturnFingerprintMatches, nil
 }
 
 func (s *internalStub) Join(pth ...string) string {

--- a/resource/context/utils.go
+++ b/resource/context/utils.go
@@ -1,0 +1,54 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context
+
+import (
+	"io"
+	"os"
+
+	"github.com/juju/errors"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+)
+
+// TODO(ericsnow) Move FingerprintMatcher to charm/resource (or even utils/hash)?
+
+// FingerprintMatcher supports verifying a file's fingerprint.
+type FingerprintMatcher struct {
+	// Open opens the identified file. It defaults to os.Open.
+	Open func(filename string) (io.ReadCloser, error)
+
+	// GenerateFingerprint produces the fingerprint that corresponds
+	// to the content of the provided reader. It defaults to
+	// charmresource.GenerateFingerprint.
+	GenerateFingerprint func(io.Reader) (charmresource.Fingerprint, error)
+}
+
+// FingerprintMatches determines whether or not the identified file's
+// fingerprint matches the expected fingerprint.
+func (fpm FingerprintMatcher) FingerprintMatches(filename string, expected charmresource.Fingerprint) (bool, error) {
+	open := fpm.Open
+	if open == nil {
+		open = func(filename string) (io.ReadCloser, error) { return os.Open(filename) }
+	}
+	generateFingerprint := fpm.GenerateFingerprint
+	if generateFingerprint == nil {
+		generateFingerprint = charmresource.GenerateFingerprint
+	}
+
+	file, err := open(filename)
+	if os.IsNotExist(errors.Cause(err)) {
+		return false, nil
+	}
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	defer file.Close()
+
+	fp, err := generateFingerprint(file)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	matches := (fp.String() == expected.String())
+	return matches, nil
+}

--- a/resource/context/utils_test.go
+++ b/resource/context/utils_test.go
@@ -1,0 +1,148 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/testing/filetesting"
+	gc "gopkg.in/check.v1"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+
+	"github.com/juju/juju/resource/context"
+)
+
+var _ = gc.Suite(&UtilsSuite{})
+
+type UtilsSuite struct {
+	testing.IsolationSuite
+
+	stub    *testing.Stub
+	matcher *stubMatcher
+}
+
+func (s *UtilsSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.stub = &testing.Stub{}
+	s.matcher = &stubMatcher{stub: s.stub}
+}
+
+func (s *UtilsSuite) newReader(c *gc.C, content string) (io.ReadCloser, charmresource.Fingerprint) {
+	r := filetesting.NewStubFile(s.stub, bytes.NewBufferString(content))
+
+	tmpReader := strings.NewReader(content)
+	fp, err := charmresource.GenerateFingerprint(tmpReader)
+	c.Assert(err, jc.ErrorIsNil)
+
+	return r, fp
+}
+
+func (s *UtilsSuite) TestFingerprintMatchesOkay(c *gc.C) {
+	r, expected := s.newReader(c, "spam")
+	s.matcher.ReturnOpen = r
+	s.matcher.ReturnGenerateFingerprint = expected
+	matcher := context.FingerprintMatcher{
+		Open:                s.matcher.Open,
+		GenerateFingerprint: s.matcher.GenerateFingerprint,
+	}
+
+	matches, err := matcher.FingerprintMatches("some/filename.txt", expected)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(matches, jc.IsTrue)
+}
+
+func (s *UtilsSuite) TestFingerprintMatchesDepCalls(c *gc.C) {
+	r, expected := s.newReader(c, "spam")
+	s.matcher.ReturnOpen = r
+	s.matcher.ReturnGenerateFingerprint = expected
+	matcher := context.FingerprintMatcher{
+		Open:                s.matcher.Open,
+		GenerateFingerprint: s.matcher.GenerateFingerprint,
+	}
+
+	matches, err := matcher.FingerprintMatches("some/filename.txt", expected)
+	c.Assert(matches, jc.IsTrue)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.stub.CheckCallNames(c, "Open", "GenerateFingerprint", "Close")
+	s.stub.CheckCall(c, 0, "Open", "some/filename.txt")
+	s.stub.CheckCall(c, 1, "GenerateFingerprint", r)
+}
+
+func (s *UtilsSuite) TestFingerprintMatchesNotFound(c *gc.C) {
+	_, expected := s.newReader(c, "spam")
+	matcher := context.FingerprintMatcher{
+		Open: s.matcher.Open,
+	}
+	s.stub.SetErrors(os.ErrNotExist)
+
+	matches, err := matcher.FingerprintMatches("some/filename.txt", expected)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(matches, jc.IsFalse)
+	s.stub.CheckCallNames(c, "Open")
+}
+
+func (s *UtilsSuite) TestFingerprintMatchesOpenFailed(c *gc.C) {
+	_, expected := s.newReader(c, "spam")
+	matcher := context.FingerprintMatcher{
+		Open: s.matcher.Open,
+	}
+	failure := errors.New("<failed>")
+	s.stub.SetErrors(failure)
+
+	_, err := matcher.FingerprintMatches("some/filename.txt", expected)
+
+	c.Check(errors.Cause(err), gc.Equals, failure)
+	s.stub.CheckCallNames(c, "Open")
+}
+
+func (s *UtilsSuite) TestFingerprintMatchesGenerateFingerprintFailed(c *gc.C) {
+	r, expected := s.newReader(c, "spam")
+	s.matcher.ReturnOpen = r
+	matcher := context.FingerprintMatcher{
+		Open:                s.matcher.Open,
+		GenerateFingerprint: s.matcher.GenerateFingerprint,
+	}
+	failure := errors.New("<failed>")
+	s.stub.SetErrors(nil, failure)
+
+	_, err := matcher.FingerprintMatches("some/filename.txt", expected)
+
+	c.Check(errors.Cause(err), gc.Equals, failure)
+	s.stub.CheckCallNames(c, "Open", "GenerateFingerprint", "Close")
+}
+
+type stubMatcher struct {
+	stub *testing.Stub
+
+	ReturnOpen                io.ReadCloser
+	ReturnGenerateFingerprint charmresource.Fingerprint
+}
+
+func (s *stubMatcher) Open(filename string) (io.ReadCloser, error) {
+	s.stub.AddCall("Open", filename)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return s.ReturnOpen, nil
+}
+
+func (s *stubMatcher) GenerateFingerprint(r io.Reader) (charmresource.Fingerprint, error) {
+	s.stub.AddCall("GenerateFingerprint", r)
+	if err := s.stub.NextErr(); err != nil {
+		return charmresource.Fingerprint{}, errors.Trace(err)
+	}
+
+	return s.ReturnGenerateFingerprint, nil
+}


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1598113)

Without this change resources are downloaded every time "resource-get" is run, even if it has not changed since the last time.

(Review request: http://reviews.vapour.ws/r/5197/)