### PR TITLE
Add credential detection to MAAS

### DIFF
--- a/provider/maas/credentials.go
+++ b/provider/maas/credentials.go
@@ -4,7 +4,14 @@
 package maas
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
 	"github.com/juju/errors"
+	"github.com/juju/utils"
+
 	"github.com/juju/juju/cloud"
 )
 
@@ -26,6 +33,34 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
 func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
-	// TODO(axw) find out where the MAAS CLI stores credentials.
-	return nil, errors.NotFoundf("credentials")
+	// MAAS stores credentials in a json file: ~/.maasrc
+	// {"Server": "http://<ip>/MAAS", "OAuth": "<key>"}
+	maasrc := filepath.Join(utils.Home(), ".maasrc")
+	fileBytes, err := ioutil.ReadFile(maasrc)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	details := make(map[string]interface{})
+	err = json.Unmarshal(fileBytes, &details)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	oauthKey := details["OAuth"]
+	if oauthKey == "" {
+		return nil, errors.New("MAAS credentials require a value for OAuth token")
+	}
+	cred := cloud.NewCredential(cloud.OAuth1AuthType, map[string]string{
+		"maas-oauth": fmt.Sprintf("%v", oauthKey),
+	})
+	server, ok := details["Server"]
+	if server == "" || !ok {
+		server = "unspecified server"
+	}
+	cred.Label = fmt.Sprintf("MAAS credential for %s", server)
+
+	return &cloud.CloudCredential{
+		AuthCredentials: map[string]cloud.Credential{
+			"default": cred,
+		}}, nil
 }

--- a/provider/maas/credentials_test.go
+++ b/provider/maas/credentials_test.go
@@ -4,24 +4,24 @@
 package maas_test
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
 )
 
 type credentialsSuite struct {
-	testing.IsolationSuite
+	testing.FakeHomeSuite
 	provider environs.EnvironProvider
 }
 
 var _ = gc.Suite(&credentialsSuite{})
 
 func (s *credentialsSuite) SetUpTest(c *gc.C) {
-	s.IsolationSuite.SetUpTest(c)
+	s.FakeHomeSuite.SetUpTest(c)
 
 	var err error
 	s.provider, err = environs.Provider("maas")
@@ -42,7 +42,36 @@ func (s *credentialsSuite) TestOAuth1HiddenAttributes(c *gc.C) {
 	envtesting.AssertProviderCredentialsAttributesHidden(c, s.provider, "oauth1", "maas-oauth")
 }
 
-func (s *credentialsSuite) TestDetectCredentialsNotFound(c *gc.C) {
-	_, err := s.provider.DetectCredentials()
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+func (s *credentialsSuite) TestDetectCredentials(c *gc.C) {
+	s.Home.AddFiles(c, testing.TestFile{
+		Name: ".maasrc",
+		Data: `{"Server": "http://10.0.0.1/MAAS", "OAuth": "key"}`,
+	})
+	creds, err := s.provider.DetectCredentials()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(creds.DefaultRegion, gc.Equals, "")
+	expected := cloud.NewCredential(
+		cloud.OAuth1AuthType, map[string]string{
+			"maas-oauth": "key",
+		},
+	)
+	expected.Label = "MAAS credential for http://10.0.0.1/MAAS"
+	c.Assert(creds.AuthCredentials["default"], jc.DeepEquals, expected)
+}
+
+func (s *credentialsSuite) TestDetectCredentialsNoServer(c *gc.C) {
+	s.Home.AddFiles(c, testing.TestFile{
+		Name: ".maasrc",
+		Data: `{"OAuth": "key"}`,
+	})
+	creds, err := s.provider.DetectCredentials()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(creds.DefaultRegion, gc.Equals, "")
+	expected := cloud.NewCredential(
+		cloud.OAuth1AuthType, map[string]string{
+			"maas-oauth": "key",
+		},
+	)
+	expected.Label = "MAAS credential for unspecified server"
+	c.Assert(creds.AuthCredentials["default"], jc.DeepEquals, expected)
 }


### PR DESCRIPTION
MAAS will have a ~/.maasrc file containing json formatted credentials. We add credential detection to the MAAS provider to make use of this file.

(Review request: http://reviews.vapour.ws/r/5198/)