### PR TITLE
cmd/jujud/agent/model: state-cleaner runs more

### DIFF
--- a/cmd/jujud/agent/engine/housing.go
+++ b/cmd/jujud/agent/engine/housing.go
@@ -5,6 +5,7 @@ package engine
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/fortress"

--- a/cmd/jujud/agent/engine_test.go
+++ b/cmd/jujud/agent/engine_test.go
@@ -27,10 +27,10 @@ var (
 		"api-caller",
 		"api-config-watcher",
 		"clock",
-		"spaces-imported-gate",
 		"is-responsible-flag",
 		"not-alive-flag",
 		"not-dead-flag",
+		"spaces-imported-gate",
 	}
 	aliveModelWorkers = []string{
 		"charm-revision-updater",

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -178,6 +178,9 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName:  apiCallerName,
 			NewEnvironFunc: environs.New,
 		})),
+		stateCleanerName: ifResponsible(cleaner.Manifold(cleaner.ManifoldConfig{
+			APICallerName: apiCallerName,
+		})),
 
 		// The undertaker is currently the only ifNotAlive worker.
 		undertakerName: ifNotAlive(undertaker.Manifold(undertaker.ManifoldConfig{
@@ -233,9 +236,6 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewWorker: charmrevision.NewWorker,
 		})),
 		metricWorkerName: ifNotDead(metricworker.Manifold(metricworker.ManifoldConfig{
-			APICallerName: apiCallerName,
-		})),
-		stateCleanerName: ifNotDead(cleaner.Manifold(cleaner.ManifoldConfig{
 			APICallerName: apiCallerName,
 		})),
 		statusHistoryPrunerName: ifNotDead(statushistorypruner.Manifold(statushistorypruner.ManifoldConfig{

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -81,6 +81,18 @@ func (s *ManifoldsSuite) TestResponsibleFlagDependencies(c *gc.C) {
 	}
 }
 
+func (s *ManifoldsSuite) TestStateCleanerIgnoresLifeFlags(c *gc.C) {
+	manifolds := model.Manifolds(model.ManifoldsConfig{
+		Agent: &mockAgent{},
+	})
+	manifold, found := manifolds["state-cleaner"]
+	c.Assert(found, jc.IsTrue)
+
+	inputs := set.NewStrings(manifold.Inputs...)
+	c.Check(inputs.Contains("not-alive-flag"), jc.IsFalse)
+	c.Check(inputs.Contains("not-dead-flag"), jc.IsFalse)
+}
+
 func (s *ManifoldsSuite) TestClockWrapper(c *gc.C) {
 	expectClock := &fakeClock{}
 	manifolds := model.Manifolds(model.ManifoldsConfig{

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -177,12 +177,9 @@ func (st *State) cleanupModelsForDyingController() (err error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	for _, env := range models {
-
-		if env.Life() == Alive {
-			if err := env.Destroy(); err != nil {
-				return errors.Trace(err)
-			}
+	for _, model := range models {
+		if err := model.Destroy(); err != nil {
+			return errors.Trace(err)
 		}
 	}
 	return nil

--- a/state/model.go
+++ b/state/model.go
@@ -689,22 +689,29 @@ func (m *Model) destroyOps(ensureNoHostedModels, ensureEmpty bool) ([]txn.Op, er
 
 	// Check if the model is empty. If it is, we can advance the model's
 	// lifecycle state directly to Dead.
-	var prereqOps []txn.Op
 	checkEmptyErr := m.checkEmpty()
 	isEmpty := checkEmptyErr == nil
-	uuid := m.UUID()
 	if ensureEmpty && !isEmpty {
 		return nil, errors.Trace(checkEmptyErr)
 	}
+
+	modelUUID := m.UUID()
+	nextLife := Dying
+	var prereqOps []txn.Op
 	if isEmpty {
-		prereqOps = append(prereqOps, txn.Op{
+		prereqOps = []txn.Op{{
 			C:  modelEntityRefsC,
-			Id: uuid,
+			Id: modelUUID,
 			Assert: bson.D{
 				{"machines", bson.D{{"$size", 0}}},
 				{"applications", bson.D{{"$size", 0}}},
 			},
-		})
+		}}
+		if modelUUID != m.doc.ServerUUID {
+			// The model is empty, and is not the controller
+			// model, so we can move it straight to Dead.
+			nextLife = Dead
+		}
 	}
 
 	if ensureNoHostedModels {
@@ -761,18 +768,12 @@ func (m *Model) destroyOps(ensureNoHostedModels, ensureEmpty bool) ([]txn.Op, er
 		prereqOps = append(prereqOps, assertHostedModelsOp(aliveEmpty+dead))
 	}
 
-	life := Dying
-	if isEmpty && uuid != m.doc.ServerUUID {
-		// The model is empty, and is not the controller
-		// model, so we can move it straight to Dead.
-		life = Dead
-	}
 	timeOfDying := nowToTheSecond()
 	modelUpdateValues := bson.D{
-		{"life", life},
+		{"life", nextLife},
 		{"time-of-dying", timeOfDying},
 	}
-	if life == Dead {
+	if nextLife == Dead {
 		modelUpdateValues = append(modelUpdateValues, bson.DocElem{
 			"time-of-death", timeOfDying,
 		})
@@ -780,7 +781,7 @@ func (m *Model) destroyOps(ensureNoHostedModels, ensureEmpty bool) ([]txn.Op, er
 
 	ops := []txn.Op{{
 		C:      modelsC,
-		Id:     uuid,
+		Id:     modelUUID,
 		Assert: isAliveDoc,
 		Update: bson.D{{"$set", modelUpdateValues}},
 	}}
@@ -789,8 +790,8 @@ func (m *Model) destroyOps(ensureNoHostedModels, ensureEmpty bool) ([]txn.Op, er
 	// arbitrarily long delays, we need to make sure every op
 	// causes a state change that's still consistent; so we make
 	// sure the cleanup ops are the last thing that will execute.
-	if uuid == m.doc.ServerUUID {
-		cleanupOp := st.newCleanupOp(cleanupModelsForDyingController, uuid)
+	if modelUUID == m.doc.ServerUUID {
+		cleanupOp := st.newCleanupOp(cleanupModelsForDyingController, modelUUID)
 		ops = append(ops, cleanupOp)
 	}
 	if !isEmpty {
@@ -800,10 +801,9 @@ func (m *Model) destroyOps(ensureNoHostedModels, ensureEmpty bool) ([]txn.Op, er
 		// hosted model in the course of destroying the controller. In
 		// that case we'll get errors if we try to enqueue hosted-model
 		// cleanups, because the cleanups collection is non-global.
-		cleanupMachinesOp := st.newCleanupOp(cleanupMachinesForDyingModel, uuid)
-		ops = append(ops, cleanupMachinesOp)
-		cleanupServicesOp := st.newCleanupOp(cleanupServicesForDyingModel, uuid)
-		ops = append(ops, cleanupServicesOp)
+		cleanupMachinesOp := st.newCleanupOp(cleanupMachinesForDyingModel, modelUUID)
+		cleanupServicesOp := st.newCleanupOp(cleanupServicesForDyingModel, modelUUID)
+		ops = append(ops, cleanupMachinesOp, cleanupServicesOp)
 	}
 	return append(prereqOps, ops...), nil
 }


### PR DESCRIPTION
This *may* fix or mitigate lp:1591387, but is more correct than before
regardless: there's no good reason to stop running cleanups just because
a model is dead, and failing to do so is surprising from the perspective
of someone writing state code and expecting cleanups to run
automatically.

Also includes drive-by refactorings/cleanups that seemed sensible while
hunting for the bug.

(Review request: http://reviews.vapour.ws/r/5200/)