### PR TITLE
Fixes a data-race in audit/logger observers

### DIFF
--- a/apiserver/observer/fakeobserver/instance.go
+++ b/apiserver/observer/fakeobserver/instance.go
@@ -13,26 +13,19 @@ import (
 	"github.com/juju/testing"
 )
 
+// Instance is a fake Observer used for testing.
 type Instance struct {
 	testing.Stub
 }
 
+// Join implements Observer.
 func (f *Instance) Join(req *http.Request) {
 	f.AddCall(funcName(), req)
 }
 
+// Leave implements Observer.
 func (f *Instance) Leave() {
 	f.AddCall(funcName())
-}
-
-// ServerReply implements Observer.
-func (f *Instance) ServerReply(req rpc.Request, hdr *rpc.Header, body interface{}) {
-	f.AddCall(funcName(), req, hdr, body)
-}
-
-// ServerRequest implements Observer.
-func (f *Instance) ServerRequest(hdr *rpc.Header, body interface{}) {
-	f.AddCall(funcName(), hdr, body)
 }
 
 // Login implements Observer.
@@ -40,14 +33,25 @@ func (f *Instance) Login(entityName string) {
 	f.AddCall(funcName(), entityName)
 }
 
-// ClientRequest implements Observer.
-func (f *Instance) ClientRequest(hdr *rpc.Header, body interface{}) {
-	f.AddCall(funcName(), hdr, body)
+// RPCObserver implements Observer.
+func (f *Instance) RPCObserver() rpc.Observer {
+	f.AddCall(funcName())
+	return &RPCInstance{}
 }
 
-// ClientReply implements Observer.
-func (f *Instance) ClientReply(req rpc.Request, hdr *rpc.Header, body interface{}) {
+// RPCInstance is a fake RPCObserver used for testing.
+type RPCInstance struct {
+	testing.Stub
+}
+
+// ServerReply implements Observer.
+func (f *RPCInstance) ServerReply(req rpc.Request, hdr *rpc.Header, body interface{}) {
 	f.AddCall(funcName(), req, hdr, body)
+}
+
+// ServerRequest implements Observer.
+func (f *RPCInstance) ServerRequest(hdr *rpc.Header, body interface{}) {
+	f.AddCall(funcName(), hdr, body)
 }
 
 // funcName returns the name of the function/method that called

--- a/apiserver/observer/observer_test.go
+++ b/apiserver/observer/observer_test.go
@@ -11,16 +11,15 @@ import (
 
 	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/observer/fakeobserver"
-	"github.com/juju/juju/rpc"
 )
 
-type observerSuite struct {
+type multiplexerSuite struct {
 	testing.IsolationSuite
 }
 
-var _ = gc.Suite(&observerSuite{})
+var _ = gc.Suite(&multiplexerSuite{})
 
-func (*observerSuite) TestObserverFactoryMultiplexer_CallsAllFactories(c *gc.C) {
+func (*multiplexerSuite) TestObserverFactoryMultiplexer_CallsAllFactories(c *gc.C) {
 	callCount := 0
 	factories := []observer.ObserverFactory{
 		func() observer.Observer { callCount++; return nil },
@@ -35,7 +34,7 @@ func (*observerSuite) TestObserverFactoryMultiplexer_CallsAllFactories(c *gc.C) 
 	c.Check(callCount, gc.Equals, 2)
 }
 
-func (*observerSuite) TestJoin_CallsAllObservers(c *gc.C) {
+func (*multiplexerSuite) TestJoin_CallsAllObservers(c *gc.C) {
 	observers := []*fakeobserver.Instance{
 		&fakeobserver.Instance{},
 		&fakeobserver.Instance{},
@@ -50,7 +49,7 @@ func (*observerSuite) TestJoin_CallsAllObservers(c *gc.C) {
 	}
 }
 
-func (*observerSuite) TestLeave_CallsAllObservers(c *gc.C) {
+func (*multiplexerSuite) TestLeave_CallsAllObservers(c *gc.C) {
 	observers := []*fakeobserver.Instance{
 		&fakeobserver.Instance{},
 		&fakeobserver.Instance{},
@@ -64,44 +63,21 @@ func (*observerSuite) TestLeave_CallsAllObservers(c *gc.C) {
 	}
 }
 
-func (*observerSuite) TestServerReply_CallsAllObservers(c *gc.C) {
+func (*multiplexerSuite) TestRPCObserver_CallsAllObservers(c *gc.C) {
 	observers := []*fakeobserver.Instance{
 		&fakeobserver.Instance{},
 		&fakeobserver.Instance{},
 	}
 
 	o := observer.NewMultiplexer(observers[0], observers[1])
-	var (
-		req  rpc.Request
-		hdr  rpc.Header
-		body string
-	)
-	o.ServerReply(req, &hdr, body)
+	o.RPCObserver()
 
 	for _, f := range observers {
-		f.CheckCall(c, 0, "ServerReply", req, &hdr, body)
+		f.CheckCall(c, 0, "RPCObserver")
 	}
 }
 
-func (*observerSuite) TestServerRequest_CallsAllObservers(c *gc.C) {
-	observers := []*fakeobserver.Instance{
-		&fakeobserver.Instance{},
-		&fakeobserver.Instance{},
-	}
-
-	o := observer.NewMultiplexer(observers[0], observers[1])
-	var (
-		hdr  rpc.Header
-		body string
-	)
-	o.ServerRequest(&hdr, body)
-
-	for _, f := range observers {
-		f.CheckCall(c, 0, "ServerRequest", &hdr, body)
-	}
-}
-
-func (*observerSuite) TestLogin_CallsAllObservers(c *gc.C) {
+func (*multiplexerSuite) TestLogin_CallsAllObservers(c *gc.C) {
 	observers := []*fakeobserver.Instance{
 		&fakeobserver.Instance{},
 		&fakeobserver.Instance{},

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1115,11 +1115,11 @@ func newObserverFn(
 	return observer.ObserverFactoryMultiplexer(
 		func() observer.Observer {
 			logger := loggo.GetLogger("juju.apiserver")
-			ctx := observer.RequestNotifierContext{
+			ctx := observer.RequestObserverContext{
 				Clock:  clock,
 				Logger: logger,
 			}
-			return observer.NewRequestNotifier(ctx, atomic.AddInt64(&connectionID, 1))
+			return observer.NewRequestObserver(ctx, atomic.AddInt64(&connectionID, 1))
 		},
 		func() observer.Observer {
 			ctx := &observer.AuditContext{

--- a/rpc/observers.go
+++ b/rpc/observers.go
@@ -1,0 +1,68 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rpc
+
+import "sync"
+
+// Observer can be implemented to find out about requests occurring in
+// an RPC conn, for example to print requests for logging
+// purposes. The calls should not block or interact with the Conn
+// object as that can cause delays to the RPC server or deadlock.
+type Observer interface {
+
+	// ServerRequest informs the Observer of a request made
+	// to the Conn. If the request was not recognized or there was
+	// an error reading the body, body will be nil.
+	//
+	// ServerRequest is called just before the server method
+	// is invoked.
+	ServerRequest(hdr *Header, body interface{})
+
+	// ServerReply informs the RequestNotifier of a reply sent to a
+	// server request. The given Request gives details of the call
+	// that was made; the given Header and body are the header and
+	// body sent as reply.
+	//
+	// ServerReply is called just before the reply is written.
+	ServerReply(req Request, hdr *Header, body interface{})
+}
+
+// NewObserverMultiplexer returns a new ObserverMultiplexer
+// with the provided RequestNotifiers.
+func NewObserverMultiplexer(rpcObservers ...Observer) *ObserverMultiplexer {
+	return &ObserverMultiplexer{
+		rpcObservers: rpcObservers,
+	}
+}
+
+// ObserverMultiplexer multiplexes calls to an arbitrary number of
+// Observers.
+type ObserverMultiplexer struct {
+	rpcObservers []Observer
+}
+
+// ServerReply implements Observer.
+func (m *ObserverMultiplexer) ServerReply(req Request, hdr *Header, body interface{}) {
+	mapConcurrent(func(n Observer) { n.ServerReply(req, hdr, body) }, m.rpcObservers)
+}
+
+// ServerRequest implements Observer.
+func (m *ObserverMultiplexer) ServerRequest(hdr *Header, body interface{}) {
+	mapConcurrent(func(n Observer) { n.ServerRequest(hdr, body) }, m.rpcObservers)
+}
+
+// mapConcurrent calls fn on all observers concurrently and then waits
+// for all calls to exit before returning.
+func mapConcurrent(fn func(Observer), requestNotifiers []Observer) {
+	var wg sync.WaitGroup
+	wg.Add(len(requestNotifiers))
+	defer wg.Wait()
+
+	for _, n := range requestNotifiers {
+		go func(notifier Observer) {
+			defer wg.Done()
+			fn(notifier)
+		}(n)
+	}
+}

--- a/rpc/observers_test.go
+++ b/rpc/observers_test.go
@@ -1,0 +1,55 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rpc_test
+
+import (
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/observer/fakeobserver"
+	"github.com/juju/juju/rpc"
+)
+
+type multiplexerSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&multiplexerSuite{})
+
+func (*multiplexerSuite) TestServerReply_CallsAllObservers(c *gc.C) {
+	observers := []*fakeobserver.RPCInstance{
+		(&fakeobserver.Instance{}).RPCObserver().(*fakeobserver.RPCInstance),
+		(&fakeobserver.Instance{}).RPCObserver().(*fakeobserver.RPCInstance),
+	}
+
+	o := rpc.NewObserverMultiplexer(observers[0], observers[1])
+	var (
+		req  rpc.Request
+		hdr  rpc.Header
+		body string
+	)
+	o.ServerReply(req, &hdr, body)
+
+	for _, f := range observers {
+		f.CheckCall(c, 0, "ServerReply", req, &hdr, body)
+	}
+}
+
+func (*multiplexerSuite) TestServerRequest_CallsAllObservers(c *gc.C) {
+	observers := []*fakeobserver.RPCInstance{
+		(&fakeobserver.Instance{}).RPCObserver().(*fakeobserver.RPCInstance),
+		(&fakeobserver.Instance{}).RPCObserver().(*fakeobserver.RPCInstance),
+	}
+
+	o := rpc.NewObserverMultiplexer(observers[0], observers[1])
+	var (
+		hdr  rpc.Header
+		body string
+	)
+	o.ServerRequest(&hdr, body)
+
+	for _, f := range observers {
+		f.CheckCall(c, 0, "ServerRequest", &hdr, body)
+	}
+}

--- a/rpc/package_test.go
+++ b/rpc/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rpc_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"regexp"
 	"sync"
-	stdtesting "testing"
 	"time"
 
 	"github.com/juju/errors"
@@ -32,10 +31,6 @@ type rpcSuite struct {
 }
 
 var _ = gc.Suite(&rpcSuite{})
-
-func TestAll(t *stdtesting.T) {
-	gc.TestingT(t)
-}
 
 type callInfo struct {
 	rcvr   interface{}
@@ -1249,6 +1244,15 @@ type notifier struct {
 	mu             sync.Mutex
 	serverRequests []requestEvent
 	serverReplies  []replyEvent
+}
+
+func (n *notifier) RPCObserver() rpc.Observer {
+	// For testing, we usually won't want an actual copy of the
+	// stub. To avoid confusing test failures (e.g. wondering why your
+	// calls aren't showing up on your stub because the underlying
+	// code has called DeepCopy) and immense complexity, just return
+	// the same value.
+	return n
 }
 
 func (n *notifier) reset() {


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1598063

The incorrect assumption that server requests and replies would happen synchronously was the root cause of this issue. I have introduced a sync.RWMutex around the critical sections to prevent this from happening.

(Review request: http://reviews.vapour.ws/r/5201/)