### PR TITLE
Fixes lp#1583789: use juju public key for image metadata from streams.canonical

### DIFF
--- a/apiserver/imagemetadata/updatefrompublished_test.go
+++ b/apiserver/imagemetadata/updatefrompublished_test.go
@@ -19,6 +19,7 @@ import (
 	imagetesting "github.com/juju/juju/environs/imagemetadata/testing"
 	"github.com/juju/juju/environs/simplestreams"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
+	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state/cloudimagemetadata"
@@ -252,6 +253,7 @@ func (s *regionMetadataSuite) SetUpSuite(c *gc.C) {
 	s.env = &mockEnviron{}
 
 	s.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
+	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	// Prepare mock http transport for overriding metadata and images output in tests.
 	useTestImageData(c, testImagesData)
 }

--- a/apiserver/provisioner/imagemetadata_test.go
+++ b/apiserver/provisioner/imagemetadata_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/environs/imagemetadata"
 	imagetesting "github.com/juju/juju/environs/imagemetadata/testing"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
+	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/state/cloudimagemetadata"
 )
 
@@ -38,6 +39,7 @@ func (s *ImageMetadataSuite) SetUpSuite(c *gc.C) {
 	// Each individual tests will decide if it needs metadata there.
 	imagetesting.PatchOfficialDataSources(&s.CleanupSuite, "test:/daily")
 	s.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
+	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	useTestImageData(c, nil)
 }
 

--- a/cmd/juju/cloud/updateclouds.go
+++ b/cmd/juju/cloud/updateclouds.go
@@ -20,7 +20,7 @@ import (
 	"golang.org/x/crypto/openpgp/clearsign"
 
 	jujucloud "github.com/juju/juju/cloud"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 )
 
 type updateCloudsCommand struct {
@@ -45,7 +45,7 @@ See also: clouds
 // NewUpdateCloudsCommand returns a command to update cloud information.
 func NewUpdateCloudsCommand() cmd.Command {
 	return &updateCloudsCommand{
-		publicSigningKey: juju.JujuPublicKey,
+		publicSigningKey: keys.JujuPublicKey,
 		publicCloudURL:   "https://streams.canonical.com/juju/public-clouds.syaml",
 	}
 }

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -38,7 +38,7 @@ import (
 	envtools "github.com/juju/juju/environs/tools"
 	toolstesting "github.com/juju/juju/environs/tools/testing"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
@@ -72,7 +72,7 @@ func init() {
 func (s *BootstrapSuite) SetUpSuite(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpSuite(c)
 	s.MgoSuite.SetUpSuite(c)
-	s.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
+	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 }
 
 func (s *BootstrapSuite) SetUpTest(c *gc.C) {

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -48,7 +48,7 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/mongo/mongotest"
@@ -815,7 +815,7 @@ func (s *BootstrapSuite) makeTestModel(c *gc.C) {
 	env, err := provider.PrepareForBootstrap(nullContext(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
+	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	envtesting.MustUploadFakeTools(s.toolsStorage, cfg.AgentStream(), cfg.AgentStream())
 	inst, _, _, err := jujutesting.StartInstance(env, testing.FakeControllerConfig().ControllerUUID(), "0")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/plugins/juju-metadata/toolsmetadata.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata.go
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/storage"
 	envtools "github.com/juju/juju/environs/tools"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/juju/osenv"
 	coretools "github.com/juju/juju/tools"
 )
@@ -147,7 +147,7 @@ func toolsDataSources(urls ...string) []simplestreams.DataSource {
 		dataSources[i] = simplestreams.NewURLSignedDataSource(
 			"local source",
 			url,
-			juju.JujuPublicKey,
+			keys.JujuPublicKey,
 			utils.VerifySSLHostnames,
 			simplestreams.CUSTOM_CLOUD_DATA,
 			false)

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/tools"
 	toolstesting "github.com/juju/juju/environs/tools/testing"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/provider/dummy"
@@ -375,5 +375,5 @@ func (s *ToolsMetadataSuite) TestToolsDataSourceHasKey(c *gc.C) {
 	// we want to be able to try to read this signed data
 	// with public key with Juju-known public key for tools.
 	// Bugs #1542127, #1542131
-	c.Assert(ds[0].PublicSigningKey(), gc.DeepEquals, juju.JujuPublicKey)
+	c.Assert(ds[0].PublicSigningKey(), gc.DeepEquals, keys.JujuPublicKey)
 }

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/juju/juju/environs/sync"
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/provider/dummy"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
@@ -60,7 +60,7 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
 
-	s.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
+	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	storageDir := c.MkDir()
 	s.PatchValue(&envtools.DefaultBaseURL, storageDir)
 	stor, err := filestorage.NewFileStorageWriter(storageDir)

--- a/environs/gui/simplestreams.go
+++ b/environs/gui/simplestreams.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/version"
 
 	"github.com/juju/juju/environs/simplestreams"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	jujuversion "github.com/juju/juju/version"
 )
 
@@ -41,7 +41,7 @@ func NewDataSource(baseURL string) simplestreams.DataSource {
 	return simplestreams.NewURLSignedDataSource(
 		sourceDescription,
 		baseURL,
-		juju.JujuPublicKey,
+		keys.JujuPublicKey,
 		utils.VerifySSLHostnames,
 		simplestreams.DEFAULT_CLOUD_DATA,
 		requireSigned)

--- a/environs/gui/simplestreams_test.go
+++ b/environs/gui/simplestreams_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/juju/juju/environs/gui"
 	"github.com/juju/juju/environs/simplestreams"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	coretesting "github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -53,7 +53,7 @@ func (s *simplestreamsSuite) TestNewDataSource(c *gc.C) {
 	c.Assert(url, gc.Equals, "https://1.2.3.4/streams//my/path")
 
 	c.Assert(source.RequireSigned(), jc.IsTrue)
-	c.Assert(source.PublicSigningKey(), gc.Equals, juju.JujuPublicKey)
+	c.Assert(source.PublicSigningKey(), gc.Equals, keys.JujuPublicKey)
 }
 
 var fetchMetadataTests = []struct {

--- a/environs/imagemetadata/simplestreams.go
+++ b/environs/imagemetadata/simplestreams.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/utils"
 
 	"github.com/juju/juju/environs/simplestreams"
+	"github.com/juju/juju/juju/keys"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/series"
 )
@@ -99,7 +100,7 @@ const (
 	// public consumption.
 	UbuntuCloudImagesURL = "http://cloud-images.ubuntu.com"
 
-	// The ;ocation of juju specific image metadata including non-Ubuntu images
+	// The location of juju specific image metadata including non-Ubuntu images
 	// in public clouds.
 	JujuStreamsImagesURL = "https://streams.canonical.com/juju/images"
 
@@ -109,7 +110,6 @@ const (
 
 // This needs to be a var so we can override it for testing and in bootstrap.
 var (
-	//
 	DefaultUbuntuBaseURL = UbuntuCloudImagesURL
 	DefaultJujuBaseURL   = JujuStreamsImagesURL
 )
@@ -130,7 +130,7 @@ func OfficialDataSources(stream string) ([]simplestreams.DataSource, error) {
 			return nil, err
 		}
 		if publicKey == "" {
-			publicKey = SimplestreamsImagesPublicKey
+			publicKey = keys.JujuPublicKey
 		}
 		result = append(
 			result,

--- a/environs/imagemetadata/simplestreams_test.go
+++ b/environs/imagemetadata/simplestreams_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/simplestreams"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
+	"github.com/juju/juju/juju/keys"
 )
 
 var live = flag.Bool("live", false, "Include live simplestreams tests")
@@ -110,6 +111,7 @@ func (s *simplestreamsSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *simplestreamsSuite) TestOfficialSources(c *gc.C) {
+	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	origKey := imagemetadata.SetSigningPublicKey(sstesting.SignedMetadataPublicKey)
 	defer func() {
 		imagemetadata.SetSigningPublicKey(origKey)

--- a/environs/imagemetadata_test.go
+++ b/environs/imagemetadata_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	envtesting "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
@@ -62,7 +63,7 @@ func (s *ImageMetadataSuite) TestImageMetadataURLsNoConfigURL(c *gc.C) {
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
-		{"https://streams.canonical.com/juju/images/releases/", imagemetadata.SimplestreamsImagesPublicKey},
+		{"https://streams.canonical.com/juju/images/releases/", keys.JujuPublicKey},
 		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey},
 	})
 }
@@ -73,7 +74,7 @@ func (s *ImageMetadataSuite) TestImageMetadataURLs(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
 		{"config-image-metadata-url/", ""},
-		{"https://streams.canonical.com/juju/images/releases/", imagemetadata.SimplestreamsImagesPublicKey},
+		{"https://streams.canonical.com/juju/images/releases/", keys.JujuPublicKey},
 		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey},
 	})
 }
@@ -103,7 +104,7 @@ func (s *ImageMetadataSuite) TestImageMetadataURLsRegisteredFuncs(c *gc.C) {
 		{"config-image-metadata-url/", ""},
 		{"foobar/", ""},
 		{"betwixt/releases/", ""},
-		{"https://streams.canonical.com/juju/images/releases/", imagemetadata.SimplestreamsImagesPublicKey},
+		{"https://streams.canonical.com/juju/images/releases/", keys.JujuPublicKey},
 		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey},
 	})
 }
@@ -124,7 +125,7 @@ func (s *ImageMetadataSuite) TestImageMetadataURLsNonReleaseStream(c *gc.C) {
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
-		{"https://streams.canonical.com/juju/images/daily/", imagemetadata.SimplestreamsImagesPublicKey},
+		{"https://streams.canonical.com/juju/images/daily/", keys.JujuPublicKey},
 		{"http://cloud-images.ubuntu.com/daily/", imagemetadata.SimplestreamsImagesPublicKey},
 	})
 }

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -34,6 +34,7 @@ import (
 	envtoolstesting "github.com/juju/juju/environs/tools/testing"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
@@ -102,7 +103,7 @@ func (t *LiveTests) SetUpSuite(c *gc.C) {
 	t.CleanupSuite.SetUpSuite(c)
 	t.TestDataSuite.SetUpSuite(c)
 	t.ControllerStore = jujuclienttesting.NewMemStore()
-	t.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
+	t.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 }
 
 func (t *LiveTests) SetUpTest(c *gc.C) {

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -18,7 +18,7 @@ import (
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/provider/dummy"
@@ -36,7 +36,7 @@ var _ = gc.Suite(&OpenSuite{})
 func (s *OpenSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
-	s.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
+	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 }
 
 func (s *OpenSuite) TearDownTest(c *gc.C) {

--- a/environs/simplestreams/fetchdata_test.go
+++ b/environs/simplestreams/fetchdata_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/simplestreams/testing"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 )
 
 type fetchDataSuite struct {
@@ -44,7 +44,7 @@ func (s *fetchDataSuite) TestFetchSignedDataWithRequireSignedDataSourceWithWrong
 	s.expectedCalls = []string{"Fetch", "PublicSigningKey", "Description"}
 	s.readerData = signedData
 	s.expectedData = unsignedData[1:]
-	s.setupDataSource(juju.JujuPublicKey)
+	s.setupDataSource(keys.JujuPublicKey)
 	s.assertFetchDataFail(c, `cannot read data for source "" at URL this.path.doesnt.matter.for.test.either: openpgp: signature made by unknown entity`)
 }
 

--- a/environs/sync/sync.go
+++ b/environs/sync/sync.go
@@ -21,7 +21,7 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/storage"
 	envtools "github.com/juju/juju/environs/tools"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	coretools "github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -161,7 +161,7 @@ func selectSourceDatasource(syncContext *SyncContext) (simplestreams.DataSource,
 		return nil, err
 	}
 	logger.Infof("using sync tools source: %v", sourceURL)
-	return simplestreams.NewURLSignedDataSource("sync tools source", sourceURL, juju.JujuPublicKey, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false), nil
+	return simplestreams.NewURLSignedDataSource("sync tools source", sourceURL, keys.JujuPublicKey, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false), nil
 }
 
 // copyTools copies a set of tools from the source to the target.

--- a/environs/tools/simplestreams_test.go
+++ b/environs/tools/simplestreams_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/juju/juju/environs/storage"
 	"github.com/juju/juju/environs/tools"
 	toolstesting "github.com/juju/juju/environs/tools/testing"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	coretesting "github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
 )
@@ -1049,7 +1049,7 @@ func (s *signedSuite) SetUpSuite(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	imageData["/signed/streams/v1/tools_metadata.sjson"] = string(signedData)
 	sstesting.SetRoundTripperFiles(imageData, map[string]int{"signedtest://unauth": http.StatusUnauthorized})
-	s.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
+	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 }
 
 func (s *signedSuite) TearDownSuite(c *gc.C) {

--- a/environs/tools/tools_test.go
+++ b/environs/tools/tools_test.go
@@ -20,7 +20,7 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
 	toolstesting "github.com/juju/juju/environs/tools/testing"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/provider/dummy"
 	coretesting "github.com/juju/juju/testing"
@@ -45,7 +45,7 @@ func (s *SimpleStreamsToolsSuite) SetUpSuite(c *gc.C) {
 	s.BaseSuite.SetUpSuite(c)
 	s.customToolsDir = c.MkDir()
 	s.publicToolsDir = c.MkDir()
-	s.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
+	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 }
 
 func (s *SimpleStreamsToolsSuite) SetUpTest(c *gc.C) {

--- a/environs/tools/urls.go
+++ b/environs/tools/urls.go
@@ -14,7 +14,7 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/storage"
 	envutils "github.com/juju/juju/environs/utils"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 )
 
 type toolsDatasourceFuncId struct {
@@ -77,7 +77,7 @@ func GetMetadataSources(env environs.Environ) ([]simplestreams.DataSource, error
 		if !config.SSLHostnameVerification() {
 			verify = utils.NoVerifySSLHostnames
 		}
-		sources = append(sources, simplestreams.NewURLSignedDataSource(conf.AgentMetadataURLKey, userURL, juju.JujuPublicKey, verify, simplestreams.SPECIFIC_CLOUD_DATA, false))
+		sources = append(sources, simplestreams.NewURLSignedDataSource(conf.AgentMetadataURLKey, userURL, keys.JujuPublicKey, verify, simplestreams.SPECIFIC_CLOUD_DATA, false))
 	}
 
 	envDataSources, err := environmentDataSources(env)
@@ -93,7 +93,7 @@ func GetMetadataSources(env environs.Environ) ([]simplestreams.DataSource, error
 	}
 	if defaultURL != "" {
 		sources = append(sources,
-			simplestreams.NewURLSignedDataSource("default simplestreams", defaultURL, juju.JujuPublicKey, utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, true))
+			simplestreams.NewURLSignedDataSource("default simplestreams", defaultURL, keys.JujuPublicKey, utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, true))
 	}
 	return sources, nil
 }

--- a/environs/tools/urls_test.go
+++ b/environs/tools/urls_test.go
@@ -17,7 +17,7 @@ import (
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/environs/tools"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
@@ -60,7 +60,7 @@ func (s *URLsSuite) TestToolsURLsNoConfigURL(c *gc.C) {
 	env := s.env(c, "")
 	sources, err := tools.GetMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
-	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{{"https://streams.canonical.com/juju/tools/", juju.JujuPublicKey}})
+	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{{"https://streams.canonical.com/juju/tools/", keys.JujuPublicKey}})
 }
 
 func (s *URLsSuite) TestToolsSources(c *gc.C) {
@@ -68,8 +68,8 @@ func (s *URLsSuite) TestToolsSources(c *gc.C) {
 	sources, err := tools.GetMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
-		{"config-tools-metadata-url/", juju.JujuPublicKey},
-		{"https://streams.canonical.com/juju/tools/", juju.JujuPublicKey},
+		{"config-tools-metadata-url/", keys.JujuPublicKey},
+		{"https://streams.canonical.com/juju/tools/", keys.JujuPublicKey},
 	})
 }
 
@@ -93,9 +93,9 @@ func (s *URLsSuite) TestToolsMetadataURLsRegisteredFuncs(c *gc.C) {
 	sources, err := tools.GetMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
-		{"config-tools-metadata-url/", juju.JujuPublicKey},
+		{"config-tools-metadata-url/", keys.JujuPublicKey},
 		{"betwixt/releases/", ""},
-		{"https://streams.canonical.com/juju/tools/", juju.JujuPublicKey},
+		{"https://streams.canonical.com/juju/tools/", keys.JujuPublicKey},
 	})
 }
 

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -27,6 +27,7 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
@@ -47,7 +48,7 @@ var _ = gc.Suite(&NewAPIClientSuite{})
 func (cs *NewAPIClientSuite) SetUpSuite(c *gc.C) {
 	cs.FakeJujuXDGDataHomeSuite.SetUpSuite(c)
 	cs.MgoSuite.SetUpSuite(c)
-	cs.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
+	cs.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	// Since most tests use invalid testing API server addresses, we
 	// need to mock this to avoid errors.
 	cs.PatchValue(juju.ServerAddress, func(addr string) (network.HostPort, error) {

--- a/juju/keys/signingkey.go
+++ b/juju/keys/signingkey.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package juju
+package keys
 
 // JujuPublicKey is the public key required to
 // authenticate data on http://streams.canonical.com.

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -38,7 +38,7 @@ import (
 	"github.com/juju/juju/environs/storage"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/environs/tools"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/mongo"
@@ -295,7 +295,7 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	envtesting.AssertUploadFakeToolsVersions(c, stor, "devel", "devel", versions...)
 	s.DefaultToolsStorage = stor
 
-	s.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
+	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	// Dummy provider uses a random port, which is added to cfg used to create environment.
 	apiPort := dummy.ApiPort(environ.Provider())
 	s.ControllerConfig["api-port"] = apiPort

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -20,7 +20,7 @@ import (
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
@@ -57,7 +57,7 @@ func (s *liveSuite) SetUpSuite(c *gc.C) {
 	s.BaseSuite.SetUpSuite(c)
 	s.MgoSuite.SetUpSuite(c)
 	s.LiveTests.SetUpSuite(c)
-	s.BaseSuite.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
+	s.BaseSuite.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 }
 
 func (s *liveSuite) TearDownSuite(c *gc.C) {

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -28,7 +28,7 @@ import (
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/provider/ec2"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
@@ -91,7 +91,7 @@ func (s *ebsVolumeSuite) SetUpSuite(c *gc.C) {
 	})
 	s.restoreEC2Patching = patchEC2ForTesting(c)
 	s.BaseSuite.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
-	s.BaseSuite.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
+	s.BaseSuite.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	imagetesting.PatchOfficialDataSources(&s.BaseSuite.CleanupSuite, "test:")
 	s.BaseSuite.PatchValue(ec2.DeleteSecurityGroupInsistently, deleteSecurityGroupForTestFunc)
 }

--- a/provider/ec2/image_test.go
+++ b/provider/ec2/image_test.go
@@ -15,7 +15,7 @@ import (
 	imagetesting "github.com/juju/juju/environs/imagemetadata/testing"
 	"github.com/juju/juju/environs/instances"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/testing"
 )
 
@@ -32,7 +32,7 @@ func (s *specSuite) SetUpSuite(c *gc.C) {
 
 	imagetesting.PatchOfficialDataSources(&s.CleanupSuite, "test:")
 	s.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
-	s.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
+	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 
 	UseTestImageData(c, TestImagesData)
 	UseTestInstanceTypeData(TestInstanceTypeCosts)

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -100,6 +100,7 @@ func (t *localLiveSuite) SetUpSuite(c *gc.C) {
 	t.restoreEC2Patching = patchEC2ForTesting(c)
 	imagetesting.PatchOfficialDataSources(&t.BaseSuite.CleanupSuite, "test:")
 	t.BaseSuite.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
+	t.BaseSuite.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	t.BaseSuite.PatchValue(ec2.DeleteSecurityGroupInsistently, deleteSecurityGroupForTestFunc)
 	t.srv.createRootDisks = true
 	t.srv.startServer(c)

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -39,7 +39,7 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/network"
@@ -225,7 +225,7 @@ func (t *localServerSuite) SetUpSuite(c *gc.C) {
 	t.restoreEC2Patching = patchEC2ForTesting(c)
 	imagetesting.PatchOfficialDataSources(&t.BaseSuite.CleanupSuite, "test:")
 	t.BaseSuite.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
-	t.BaseSuite.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
+	t.BaseSuite.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	t.BaseSuite.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 	t.BaseSuite.PatchValue(&series.HostSeries, func() string { return series.LatestLts() })
@@ -1448,7 +1448,7 @@ func (t *localNonUSEastSuite) SetUpSuite(c *gc.C) {
 	t.TestDataSuite.SetUpSuite(c)
 
 	t.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
-	t.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
+	t.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 
 	t.restoreEC2Patching = patchEC2ForTesting(c)
 	t.BaseSuite.PatchValue(ec2.DeleteSecurityGroupInsistently, deleteSecurityGroupForTestFunc)

--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -24,7 +24,7 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/provider/joyent"
 	coretesting "github.com/juju/juju/testing"
@@ -116,7 +116,7 @@ type localServerSuite struct {
 func (s *localServerSuite) SetUpSuite(c *gc.C) {
 	s.providerSuite.SetUpSuite(c)
 	s.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
-	s.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
+	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 
 	restoreFinishBootstrap := envtesting.DisableFinishBootstrap()
 	s.AddCleanup(func(*gc.C) { restoreFinishBootstrap() })

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -24,7 +24,7 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/network"
 	coretesting "github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
@@ -39,7 +39,7 @@ type baseProviderSuite struct {
 }
 
 func (suite *baseProviderSuite) setupFakeTools(c *gc.C) {
-	suite.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
+	suite.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	storageDir := c.MkDir()
 	toolsDir := filepath.Join(storageDir, "tools")
 	suite.PatchValue(&envtools.DefaultBaseURL, utils.MakeFileURL(toolsDir))

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -49,7 +49,7 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/network"
@@ -1951,7 +1951,7 @@ func (s *noSwiftSuite) SetUpSuite(c *gc.C) {
 	s.AddCleanup(func(*gc.C) { restoreFinishBootstrap() })
 
 	s.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
-	s.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
+	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 }
 
 func (s *noSwiftSuite) SetUpTest(c *gc.C) {


### PR DESCRIPTION
This requires re-factoring the key into a separate package to avoid cyclic import. This in turn increased diff surface.

The main change is in environs/imagemetadata/simplestreams.go.


(Review request: http://reviews.vapour.ws/r/5202/)