### PR TITLE
status: Use the last version set as the application version

### DIFF
--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -620,9 +620,9 @@ func (context *statusContext) processApplication(service *state.Application) par
 		}
 		versions = append(versions, statuses[0])
 	}
-	sort.Sort(bySince(versions))
 	if len(versions) > 0 {
-		processedStatus.WorkloadVersion = versions[len(versions)-1].Message
+		sort.Sort(bySinceDescending(versions))
+		processedStatus.WorkloadVersion = versions[0].Message
 	}
 
 	return processedStatus
@@ -867,13 +867,13 @@ func processLife(entity lifer) string {
 	return ""
 }
 
-type bySince []status.StatusInfo
+type bySinceDescending []status.StatusInfo
 
 // Len implements sort.Interface.
-func (s bySince) Len() int { return len(s) }
+func (s bySinceDescending) Len() int { return len(s) }
 
 // Swap implements sort.Interface.
-func (s bySince) Swap(a, b int) { s[a], s[b] = s[b], s[a] }
+func (s bySinceDescending) Swap(a, b int) { s[a], s[b] = s[b], s[a] }
 
 // Less implements sort.Interface.
-func (s bySince) Less(a, b int) bool { return s[a].Since.Before(*s[b].Since) }
+func (s bySinceDescending) Less(a, b int) bool { return s[a].Since.After(*s[b].Since) }

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -2472,7 +2472,7 @@ var statusTests = []testCase{
 				},
 				"applications": M{
 					"mysql": mysqlCharm(M{
-						"workload-version": "not as good*",
+						"workload-version": "not as good",
 						"application-status": M{
 							"current": "unknown",
 							"message": "Waiting for agent initialization to finish",

--- a/state/unit.go
+++ b/state/unit.go
@@ -211,6 +211,7 @@ func (u *Unit) SetWorkloadVersion(version string) error {
 	// Store in status rather than an attribute of the unit doc - we
 	// want to avoid everything being an attr of the main docs to
 	// stop a swarm of watchers being notified for irrelevant changes.
+	// TODO(babbageclunk) lp:1558657 - should use clock stored on unit
 	now := time.Now()
 	return setStatus(u.st, setStatusParams{
 		badge:     "workload",


### PR DESCRIPTION
The aggregation logic for unit workload versions was "use the most-common value, with a * to indicate mixed state". Simplify this to always just be the last set value - this is simpler and easier to understand, and is unlikely to cause any problems. (Based on a discussion with jam and rick_h.)

This is part of the application version task: https://docs.google.com/a/canonical.com/document/d/1rSgITOQAbmrpaO7_x88OuXsJ0KN0PBGdt7ypN-mzXJY/

(Review request: http://reviews.vapour.ws/r/5208/)