### PR TITLE
status: add application version to tabular output

### DIFF
--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -66,21 +66,21 @@ func (s machineStatus) MarshalYAML() (interface{}, error) {
 }
 
 type applicationStatus struct {
-	Err             error                 `json:"-" yaml:",omitempty"`
-	Charm           string                `json:"charm" yaml:"charm"`
-	Series          string                `json:"series"`
-	OS              string                `json:"os"`
-	CharmOrigin     string                `json:"charm-origin" yaml:"charm-origin"`
-	CharmName       string                `json:"charm-name" yaml:"charm-name"`
-	CharmRev        int                   `json:"charm-rev" yaml:"charm-rev"`
-	CanUpgradeTo    string                `json:"can-upgrade-to,omitempty" yaml:"can-upgrade-to,omitempty"`
-	Exposed         bool                  `json:"exposed" yaml:"exposed"`
-	Life            string                `json:"life,omitempty" yaml:"life,omitempty"`
-	StatusInfo      statusInfoContents    `json:"application-status,omitempty" yaml:"application-status"`
-	Relations       map[string][]string   `json:"relations,omitempty" yaml:"relations,omitempty"`
-	SubordinateTo   []string              `json:"subordinate-to,omitempty" yaml:"subordinate-to,omitempty"`
-	Units           map[string]unitStatus `json:"units,omitempty" yaml:"units,omitempty"`
-	WorkloadVersion string                `json:"workload-version,omitempty" yaml:"workload-version,omitempty"`
+	Err           error                 `json:"-" yaml:",omitempty"`
+	Charm         string                `json:"charm" yaml:"charm"`
+	Series        string                `json:"series"`
+	OS            string                `json:"os"`
+	CharmOrigin   string                `json:"charm-origin" yaml:"charm-origin"`
+	CharmName     string                `json:"charm-name" yaml:"charm-name"`
+	CharmRev      int                   `json:"charm-rev" yaml:"charm-rev"`
+	CanUpgradeTo  string                `json:"can-upgrade-to,omitempty" yaml:"can-upgrade-to,omitempty"`
+	Exposed       bool                  `json:"exposed" yaml:"exposed"`
+	Life          string                `json:"life,omitempty" yaml:"life,omitempty"`
+	StatusInfo    statusInfoContents    `json:"application-status,omitempty" yaml:"application-status"`
+	Relations     map[string][]string   `json:"relations,omitempty" yaml:"relations,omitempty"`
+	SubordinateTo []string              `json:"subordinate-to,omitempty" yaml:"subordinate-to,omitempty"`
+	Units         map[string]unitStatus `json:"units,omitempty" yaml:"units,omitempty"`
+	Version       string                `json:"version,omitempty" yaml:"version,omitempty"`
 }
 
 type applicationStatusNoMarshal applicationStatus
@@ -110,12 +110,11 @@ type unitStatus struct {
 	JujuStatusInfo     statusInfoContents `json:"juju-status,omitempty" yaml:"juju-status"`
 	MeterStatus        *meterStatus       `json:"meter-status,omitempty" yaml:"meter-status,omitempty"`
 
-	Charm           string                `json:"upgrading-from,omitempty" yaml:"upgrading-from,omitempty"`
-	Machine         string                `json:"machine,omitempty" yaml:"machine,omitempty"`
-	OpenedPorts     []string              `json:"open-ports,omitempty" yaml:"open-ports,omitempty"`
-	PublicAddress   string                `json:"public-address,omitempty" yaml:"public-address,omitempty"`
-	Subordinates    map[string]unitStatus `json:"subordinates,omitempty" yaml:"subordinates,omitempty"`
-	WorkloadVersion string                `json:"workload-version,omitempty" yaml:"workload-version,omitempty"`
+	Charm         string                `json:"upgrading-from,omitempty" yaml:"upgrading-from,omitempty"`
+	Machine       string                `json:"machine,omitempty" yaml:"machine,omitempty"`
+	OpenedPorts   []string              `json:"open-ports,omitempty" yaml:"open-ports,omitempty"`
+	PublicAddress string                `json:"public-address,omitempty" yaml:"public-address,omitempty"`
+	Subordinates  map[string]unitStatus `json:"subordinates,omitempty" yaml:"subordinates,omitempty"`
 }
 
 type statusInfoContents struct {

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -141,21 +141,21 @@ func (sf *statusFormatter) formatApplication(name string, application params.App
 	}
 
 	out := applicationStatus{
-		Err:             application.Err,
-		Charm:           application.Charm,
-		Series:          application.Series,
-		OS:              strings.ToLower(appOS.String()),
-		CharmOrigin:     charmOrigin,
-		CharmName:       charmName,
-		CharmRev:        charmRev,
-		Exposed:         application.Exposed,
-		Life:            application.Life,
-		Relations:       application.Relations,
-		CanUpgradeTo:    application.CanUpgradeTo,
-		SubordinateTo:   application.SubordinateTo,
-		Units:           make(map[string]unitStatus),
-		StatusInfo:      sf.getServiceStatusInfo(application),
-		WorkloadVersion: application.WorkloadVersion,
+		Err:           application.Err,
+		Charm:         application.Charm,
+		Series:        application.Series,
+		OS:            strings.ToLower(appOS.String()),
+		CharmOrigin:   charmOrigin,
+		CharmName:     charmName,
+		CharmRev:      charmRev,
+		Exposed:       application.Exposed,
+		Life:          application.Life,
+		Relations:     application.Relations,
+		CanUpgradeTo:  application.CanUpgradeTo,
+		SubordinateTo: application.SubordinateTo,
+		Units:         make(map[string]unitStatus),
+		StatusInfo:    sf.getServiceStatusInfo(application),
+		Version:       application.WorkloadVersion,
 	}
 	for k, m := range application.Units {
 		out.Units[k] = sf.formatUnit(unitFormatInfo{
@@ -201,7 +201,6 @@ func (sf *statusFormatter) formatUnit(info unitFormatInfo) unitStatus {
 		PublicAddress:      info.unit.PublicAddress,
 		Charm:              info.unit.Charm,
 		Subordinates:       make(map[string]unitStatus),
-		WorkloadVersion:    info.unit.WorkloadVersion,
 	}
 
 	if ms, ok := info.meterStatuses[info.unitName]; ok {

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -98,6 +98,7 @@ func getTabWriter(out io.Writer) *tabwriter.Writer {
 // units. Any subordinate items are indented by two spaces beneath
 // their superior.
 func FormatTabular(value interface{}) ([]byte, error) {
+	const maxVersionWidth = 7
 	fs, valueConverted := value.(formattedStatus)
 	if !valueConverted {
 		return nil, errors.Errorf("expected value of type %T, got %T", fs, value)
@@ -129,10 +130,16 @@ func FormatTabular(value interface{}) ([]byte, error) {
 	units := make(map[string]unitStatus)
 	metering := false
 	relations := newRelationFormatter()
-	outputHeaders("APP", "STATUS", "EXPOSED", "ORIGIN", "CHARM", "REV", "OS")
+	outputHeaders("APP", "VERSION", "STATUS", "EXPOSED", "ORIGIN", "CHARM", "REV", "OS")
 	for _, appName := range common.SortStringsNaturally(stringKeysFromMap(fs.Applications)) {
 		app := fs.Applications[appName]
+		version := app.Version
+		// Don't let a long version push out the version column.
+		if len(version) > maxVersionWidth {
+			version = version[:maxVersionWidth]
+		}
 		p(appName,
+			version,
 			app.StatusInfo.Current,
 			fmt.Sprintf("%t", app.Exposed),
 			app.CharmOrigin,

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -99,6 +99,9 @@ func getTabWriter(out io.Writer) *tabwriter.Writer {
 // their superior.
 func FormatTabular(value interface{}) ([]byte, error) {
 	const maxVersionWidth = 7
+	const ellipsis = "..."
+	const truncatedWidth = maxVersionWidth - len(ellipsis)
+
 	fs, valueConverted := value.(formattedStatus)
 	if !valueConverted {
 		return nil, errors.Errorf("expected value of type %T, got %T", fs, value)
@@ -136,7 +139,7 @@ func FormatTabular(value interface{}) ([]byte, error) {
 		version := app.Version
 		// Don't let a long version push out the version column.
 		if len(version) > maxVersionWidth {
-			version = version[:maxVersionWidth]
+			version = version[:truncatedWidth] + ellipsis
 		}
 		p(appName,
 			version,

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3351,6 +3351,9 @@ func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 		setAgentStatus{"logging/0", status.StatusIdle, "", nil},
 		setUnitStatus{"logging/0", status.StatusActive, "", nil},
 		setAgentStatus{"logging/1", status.StatusError, "somehow lost in all those logs", nil},
+		setUnitWorkloadVersion{"logging/1", "a bit too long, really"},
+		setUnitWorkloadVersion{"wordpress/0", "4.5.3"},
+		setUnitWorkloadVersion{"mysql/0", "5.7.13"},
 	}
 	for _, s := range steps {
 		s.step(c, ctx)
@@ -3372,10 +3375,10 @@ func (s *StatusSuite) testStatusWithFormatTabular(c *gc.C, useFeatureFlag bool) 
 MODEL       CONTROLLER  CLOUD/REGION  VERSION  UPGRADE-AVAILABLE
 controller  kontroll    dummy         1.2.3    1.2.4
 
-APP        STATUS       EXPOSED  ORIGIN      CHARM      REV  OS
-logging                 true     jujucharms  logging    1    ubuntu
-mysql      maintenance  true     jujucharms  mysql      1    ubuntu
-wordpress  active       true     jujucharms  wordpress  3    ubuntu
+APP        VERSION  STATUS       EXPOSED  ORIGIN      CHARM      REV  OS
+logging    a bit t               true     jujucharms  logging    1    ubuntu
+mysql      5.7.13   maintenance  true     jujucharms  mysql      1    ubuntu
+wordpress  4.5.3    active       true     jujucharms  wordpress  3    ubuntu
 
 RELATION           PROVIDES   CONSUMES   TYPE
 juju-info          logging    mysql      regular
@@ -3438,8 +3441,8 @@ func (s *StatusSuite) TestFormatTabularHookActionName(c *gc.C) {
 MODEL  CONTROLLER  CLOUD/REGION  VERSION
                                  
 
-APP  STATUS  EXPOSED  ORIGIN  CHARM  REV  OS
-foo          false                   0    
+APP  VERSION  STATUS  EXPOSED  ORIGIN  CHARM  REV  OS
+foo                   false                   0    
 
 UNIT   WORKLOAD     AGENT      MACHINE  PORTS  PUBLIC-ADDRESS  MESSAGE
 foo/0  maintenance  executing                                  (config-changed) doing some work
@@ -3538,8 +3541,8 @@ func (s *StatusSuite) TestFormatTabularMetering(c *gc.C) {
 MODEL  CONTROLLER  CLOUD/REGION  VERSION
                                  
 
-APP  STATUS  EXPOSED  ORIGIN  CHARM  REV  OS
-foo          false                   0    
+APP  VERSION  STATUS  EXPOSED  ORIGIN  CHARM  REV  OS
+foo                   false                   0    
 
 UNIT   WORKLOAD  AGENT  MACHINE  PORTS  PUBLIC-ADDRESS  MESSAGE
 foo/0                                                   

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3376,7 +3376,7 @@ MODEL       CONTROLLER  CLOUD/REGION  VERSION  UPGRADE-AVAILABLE
 controller  kontroll    dummy         1.2.3    1.2.4
 
 APP        VERSION  STATUS       EXPOSED  ORIGIN      CHARM      REV  OS
-logging    a bit t               true     jujucharms  logging    1    ubuntu
+logging    a bi...               true     jujucharms  logging    1    ubuntu
 mysql      5.7.13   maintenance  true     jujucharms  mysql      1    ubuntu
 wordpress  4.5.3    active       true     jujucharms  wordpress  3    ubuntu
 

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -2410,7 +2410,7 @@ var statusTests = []testCase{
 				},
 				"applications": M{
 					"mysql": mysqlCharm(M{
-						"workload-version": "the best!",
+						"version": "the best!",
 						"application-status": M{
 							"current": "unknown",
 							"message": "Waiting for agent initialization to finish",
@@ -2418,8 +2418,7 @@ var statusTests = []testCase{
 						},
 						"units": M{
 							"mysql/0": M{
-								"machine":          "1",
-								"workload-version": "the best!",
+								"machine": "1",
 								"workload-status": M{
 									"current": "unknown",
 									"message": "Waiting for agent initialization to finish",
@@ -2472,7 +2471,7 @@ var statusTests = []testCase{
 				},
 				"applications": M{
 					"mysql": mysqlCharm(M{
-						"workload-version": "not as good",
+						"version": "not as good",
 						"application-status": M{
 							"current": "unknown",
 							"message": "Waiting for agent initialization to finish",
@@ -2480,8 +2479,7 @@ var statusTests = []testCase{
 						},
 						"units": M{
 							"mysql/0": M{
-								"machine":          "1",
-								"workload-version": "the best!",
+								"machine": "1",
 								"workload-status": M{
 									"current": "unknown",
 									"message": "Waiting for agent initialization to finish",
@@ -2494,8 +2492,7 @@ var statusTests = []testCase{
 								"public-address": "controller-1.dns",
 							},
 							"mysql/1": M{
-								"machine":          "2",
-								"workload-version": "not as good",
+								"machine": "2",
 								"workload-status": M{
 									"current": "unknown",
 									"message": "Waiting for agent initialization to finish",


### PR DESCRIPTION
Display the application version in the tabular status output. Limit the length of the version displayed to 7 characters to prevent the table from being blown out by the charm-supplied information. That's long enough for most 1.2.3-style version numbers and most Git hashes. If the version is truncated by this restriction the full version string will still be visible in the yaml-formatted status. (From discussion with jam and rick_h.)

Also renamed the application workload-version field in the JSON and YAML output to version, and removed the unit-level workload-version field (we don't want to muddy the waters with that extra information).

(Review request: http://reviews.vapour.ws/r/5209/)