### PR TITLE
juju status: fix flickering peer relation name

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -142,9 +142,16 @@ func FormatTabular(value interface{}) ([]byte, error) {
 			}
 		}
 
+		// Ensure that we pick a consistent name for peer relations.
+		sortedRelTypes := make([]string, 0, len(app.Relations))
+		for relType := range app.Relations {
+			sortedRelTypes = append(sortedRelTypes, relType)
+		}
+		sort.Strings(sortedRelTypes)
+
 		subs := set.NewStrings(app.SubordinateTo...)
-		for relType, relatedUnits := range app.Relations {
-			for _, related := range relatedUnits {
+		for _, relType := range sortedRelTypes {
+			for _, related := range app.Relations[relType] {
 				relations.add(related, appName, relType, subs.Contains(related))
 			}
 		}

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3452,6 +3452,40 @@ MACHINE  STATE  DNS  INS-ID  SERIES  AZ
 `[1:])
 }
 
+func (s *StatusSuite) TestFormatTabularConsistentPeerRelationName(c *gc.C) {
+	status := formattedStatus{
+		Applications: map[string]applicationStatus{
+			"foo": {
+				Relations: map[string][]string{
+					"coordinator":  {"foo"},
+					"frobulator":   {"foo"},
+					"encapsulator": {"foo"},
+					"catchulator":  {"foo"},
+					"perforator":   {"foo"},
+					"deliverator":  {"foo"},
+					"replicator":   {"foo"},
+				},
+			},
+		},
+	}
+	out, err := FormatTabular(status)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(out), gc.Equals, `
+MODEL  CONTROLLER  CLOUD  VERSION
+                          
+
+APP  STATUS  EXPOSED  ORIGIN  CHARM  REV  OS
+foo          false                   0    
+
+RELATION    PROVIDES  CONSUMES  TYPE
+replicator  foo       foo       peer
+
+UNIT  WORKLOAD  AGENT  MACHINE  PORTS  PUBLIC-ADDRESS  MESSAGE
+
+MACHINE  STATE  DNS  INS-ID  SERIES  AZ
+`[1:])
+}
+
 func (s *StatusSuite) TestStatusWithNilStatusApi(c *gc.C) {
 	ctx := s.newContext(c)
 	defer s.resetContext(c, ctx)


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/juju-core/+bug/1598897

If you deployed a charm with a peer relation where the ends are named differently (like postgresql), which name was displayed for the relation depended on the map ordering. This meant that running `watch juju status` would show the name flickering between the different options.

Sort the relation types before combining and displaying them so we pick the relation name consistently.

(Review request: http://reviews.vapour.ws/r/5210/)