### PR TITLE
container/lxd: use API capabilities from LXD 2.0.0 only

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -41,7 +41,7 @@ github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 github.com/juju/zip	git	f6b1e93fa2e29a1d7d49b566b2b51efb060c982a	2016-02-05T10:52:21Z
 github.com/julienschmidt/httprouter	git	77a895ad01ebc98a4dc95d8355bc825ce80a56f6	2015-10-13T22:55:20Z
-github.com/lxc/lxd	git	ba236f15fd862ffe588ed9349ea8bf0ff87f68d4	2016-05-09T16:40:25Z
+github.com/lxc/lxd	git	62f62e9d6e0da14947023f99764eac29c26cef8d	2016-03-28T00:14:48Z
 github.com/mattn/go-runewidth	git	d96d1bd051f2bd9e7e43d602782b37b93b1b5666	2015-11-18T07:21:59Z
 github.com/rogpeppe/fastuuid	git	6724a57986aff9bff1a1770e9347036def7c89f6	2015-01-06T09:32:20Z
 golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:06:42Z


### PR DESCRIPTION
Creating and assigning LXD network devices directly to the container is
currently using a breaking LXD API change - as far as Juju 2.0 packaging
is concerned. We revert the dependency on the more convenient LXD API
and switch to using 'init', then 'add device(s)'.

This change mantains the existing behaviour of adding/applying the
network devices to the container directly, and does not require a
discrete network profile per launched container.

You can see the set of [network] devices the container has via:

  $ lxc config show <container-name>

Fixes [LP:#1597342](https://bugs.launchpad.net/juju-core/+bug/1597342)

(Review request: http://reviews.vapour.ws/r/5212/)