### PR TITLE
Only record unit resource download progress once a second.

### DIFF
--- a/resource/state/resource.go
+++ b/resource/state/resource.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils"
+	"github.com/juju/utils/clock"
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2/txn"
@@ -332,6 +333,7 @@ func (st resourceState) OpenResourceForUniter(unit resource.Unit, name string) (
 		unit:       unit,
 		pending:    pending,
 		resource:   resourceInfo,
+		clock:      clock.WallClock,
 	}
 
 	return resourceInfo, resourceReader, nil
@@ -420,11 +422,13 @@ func storagePath(name, applicationID, pendingID string) string {
 // reader has been fully read.
 type unitSetter struct {
 	io.ReadCloser
-	persist  resourcePersistence
-	unit     resource.Unit
-	pending  resource.Resource
-	resource resource.Resource
-	progress int64
+	persist            resourcePersistence
+	unit               resource.Unit
+	pending            resource.Resource
+	resource           resource.Resource
+	progress           int64
+	lastProgressUpdate time.Time
+	clock              clock.Clock
 }
 
 // Read implements io.Reader.
@@ -438,9 +442,11 @@ func (u *unitSetter) Read(p []byte) (n int, err error) {
 		}
 	} else {
 		u.progress += int64(n)
-		// TODO(ericsnow) Don't do this every time?
-		if err := u.persist.SetUnitResourceProgress(u.unit.Name(), u.pending, u.progress); err != nil {
-			logger.Errorf("failed to track progress: %v", err)
+		if time.Since(u.lastProgressUpdate) > time.Second {
+			u.lastProgressUpdate = time.Now()
+			if err := u.persist.SetUnitResourceProgress(u.unit.Name(), u.pending, u.progress); err != nil {
+				logger.Errorf("failed to track progress: %v", err)
+			}
 		}
 	}
 	return n, err

--- a/resource/state/resource.go
+++ b/resource/state/resource.go
@@ -443,7 +443,7 @@ func (u *unitSetter) Read(p []byte) (n int, err error) {
 	} else {
 		u.progress += int64(n)
 		if time.Since(u.lastProgressUpdate) > time.Second {
-			u.lastProgressUpdate = time.Now()
+			u.lastProgressUpdate = u.clock.Now()
 			if err := u.persist.SetUnitResourceProgress(u.unit.Name(), u.pending, u.progress); err != nil {
 				logger.Errorf("failed to track progress: %v", err)
 			}

--- a/resource/state/resource_test.go
+++ b/resource/state/resource_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/resourcetesting"
+	"github.com/juju/utils/clock"
 )
 
 var _ = gc.Suite(&ResourceSuite{})
@@ -611,6 +612,7 @@ func (s *ResourceSuite) TestUnitSetterEOF(c *gc.C) {
 		persist:    &stubPersistence{stub: s.stub},
 		unit:       newUnit(s.stub, "some-application/0"),
 		resource:   newUploadResource(c, "res", "res"),
+		clock:      clock.WallClock,
 	}
 	// have to try to read non-zero data, or bytes.buffer will happily return
 	// nil.
@@ -629,6 +631,7 @@ func (s *ResourceSuite) TestUnitSetterNoEOF(c *gc.C) {
 		persist:    &stubPersistence{stub: s.stub},
 		unit:       newUnit(s.stub, "some-application/0"),
 		resource:   newUploadResource(c, "res", "res"),
+		clock:      clock.WallClock,
 	}
 	// read less than the full buffer
 	p := make([]byte, 3)
@@ -647,6 +650,7 @@ func (s *ResourceSuite) TestUnitSetterSetUnitErr(c *gc.C) {
 		persist:    &stubPersistence{stub: s.stub},
 		unit:       newUnit(s.stub, "some-application/0"),
 		resource:   newUploadResource(c, "res", "res"),
+		clock:      clock.WallClock,
 	}
 
 	s.stub.SetErrors(errors.Errorf("oops!"))
@@ -669,6 +673,7 @@ func (s *ResourceSuite) TestUnitSetterErr(c *gc.C) {
 		persist:    &stubPersistence{stub: s.stub},
 		unit:       newUnit(s.stub, "some-application/0"),
 		resource:   newUploadResource(c, "res", "res"),
+		clock:      clock.WallClock,
 	}
 	expected := errors.Errorf("some-err")
 	s.stub.SetErrors(expected)


### PR DESCRIPTION
func (u *unitSetter) Read(p []byte) (n int, err error) retrieves data from gridfs in order to serve it up as a resource. It was recording the number of bytes that had been read of the stored file every time Read was called. Unfortunately this resulted in massive database contention and would result in resource reads running at about 2MB/s. By recording progress once a second we can obtain optimal throughput.

(Review request: http://reviews.vapour.ws/r/5214/)