### PR TITLE
provider/ec2: Reverted changes from commit f417397

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -451,6 +451,8 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 	var apiPort int
 	if args.InstanceConfig.Controller != nil {
 		apiPort = args.InstanceConfig.Controller.Config.APIPort()
+	} else {
+		apiPort = args.InstanceConfig.APIInfo.Ports()[0]
 	}
 	groups, err := e.setUpGroups(args.ControllerUUID, args.InstanceConfig.MachineId, apiPort)
 	if err != nil {


### PR DESCRIPTION
Fixes http://pad.lv/1598164 - adding a machine to the controller model
on AWS closes of the API port on the controller model's security group.

Confirmed the issue was introduced by commit f417397 (in PR #5683), so
this just reverts that particular change in provider/ec2.

Tested live on AWS with the following steps:

  1. juju bootstrap aws-test aws/eu-central-1 --upload-tools
  2. juju switch controller
  3. juju status        # verify it still responds quickly
  4. juju add-machine   # trigger the issue
  5. sleep 5s           # give the firewaller a few seconds to react
  6. juju status        # blocks forever
  7. juju kill-controller aws-test -y

When the issue happens it's easy to see (using the AWS web UI) the API
port 17070 on the ingress rule inside the controller-machine-0 security
group gets reset to 0, blocking access. With this fix the issue is no
longer reproducible with the steps above. In fact the AWS web UI shows a
different security group getting created for controller machine-1, as
expected (not including a rule for API port), while the controller
machine-0 security group's rules are left intact.

(Review request: http://reviews.vapour.ws/r/5215/)