### PR TITLE
Fix authorized-keys bugs

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/controller/modelmanager"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
@@ -133,11 +134,14 @@ func InitializeState(
 
 	// Create the initial hosted model, with the model config passed to
 	// bootstrap, which contains the UUID, name for the hosted model,
-	// and any user supplied config.
+	// and any user supplied config. We also copy the authorized-keys
+	// from the controller model.
 	attrs := make(map[string]interface{})
 	for k, v := range args.HostedModelConfig {
 		attrs[k] = v
 	}
+	attrs[config.AuthorizedKeysKey] = args.ControllerModelConfig.AuthorizedKeys()
+
 	// TODO(axw) we shouldn't be adding credentials to model config.
 	if args.ControllerCloudCredential != nil {
 		for k, v := range args.ControllerCloudCredential.Attributes() {

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -230,8 +230,9 @@ LXC_BRIDGE="ignored"`[1:])
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotModelConstraints, gc.DeepEquals, expectModelConstraints)
 
-	// Check that the hosted model has been added, and model constraints
-	// set.
+	// Check that the hosted model has been added, model constraints
+	// set, and its config contains the same authorized-keys as the
+	// controller model.
 	hostedModelSt, err := st.ForModel(names.NewModelTag(hostedModelUUID))
 	c.Assert(err, jc.ErrorIsNil)
 	defer hostedModelSt.Close()
@@ -246,6 +247,7 @@ LXC_BRIDGE="ignored"`[1:])
 	c.Assert(err, jc.ErrorIsNil)
 	_, hasUnexpected := hostedCfg.AllAttrs()["not-for-hosted"]
 	c.Assert(hasUnexpected, jc.IsFalse)
+	c.Assert(hostedCfg.AuthorizedKeys(), gc.Equals, newModelCfg.AuthorizedKeys())
 
 	// Check that the bootstrap machine looks correct.
 	c.Assert(m.Id(), gc.Equals, "0")

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -722,9 +722,6 @@ func PopulateInstanceConfig(icfg *InstanceConfig,
 	enableOSRefreshUpdates bool,
 	enableOSUpgrade bool,
 ) error {
-	if authorizedKeys == "" {
-		return fmt.Errorf("model configuration has no authorized-keys")
-	}
 	icfg.AuthorizedKeys = authorizedKeys
 	if icfg.AgentEnvironment == nil {
 		icfg.AgentEnvironment = make(map[string]string)

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -265,7 +265,7 @@ type cloudinitTest struct {
 }
 
 func minimalModelConfig(c *gc.C) *config.Config {
-	cfg, err := config.New(config.NoDefaults, testing.FakeConfig())
+	cfg, err := config.New(config.NoDefaults, testing.FakeConfig().Delete("authorized-keys"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg, gc.NotNil)
 	return cfg


### PR DESCRIPTION
- Copy authorized-keys to default model config
- Don't barf when finalizing instance config
  if there are no authorized-keys.

Fixes https://bugs.launchpad.net/juju-core/+bug/1600237

(Review request: http://reviews.vapour.ws/r/5217/)