### PR TITLE
all: stop abusing SSH bootstrap timeouts

### DIFF
--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"reflect"
 	"strconv"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -170,6 +171,9 @@ type BootstrapConfig struct {
 
 	// GUI is the Juju GUI archive to be installed in the new instance.
 	GUI *coretools.GUIArchive
+
+	// Timeout is the amount of time to wait for bootstrap to complete.
+	Timeout time.Duration
 
 	// StateServingInfo holds the information for serving the state.
 	// This is only specified for bootstrap; controllers started
@@ -682,8 +686,8 @@ func NewBootstrapInstanceConfig(
 	cons, modelCons constraints.Value,
 	series, publicImageSigningKey string,
 ) (*InstanceConfig, error) {
-	// For a bootstrap instance, FinishInstanceConfig will provide the
-	// state.Info and the api.Info. The machine id must *always* be "0".
+	// For a bootstrap instance, the caller must provide the state.Info
+	// and the api.Info. The machine id must *always* be "0".
 	icfg, err := NewInstanceConfig("0", agent.BootstrapNonce, "", series, true, nil)
 	if err != nil {
 		return nil, err
@@ -742,8 +746,8 @@ func PopulateInstanceConfig(icfg *InstanceConfig,
 
 // FinishInstanceConfig sets fields on a InstanceConfig that can be determined by
 // inspecting a plain config.Config and the machine constraints at the last
-// moment before bootstrapping. It assumes that the supplied Config comes from
-// an environment that has passed through all the validation checks in the
+// moment before creating the user-data. It assumes that the supplied Config comes
+// from an environment that has passed through all the validation checks in the
 // Bootstrap func, and that has set an agent-version (via finding the tools to,
 // use for bootstrap, or otherwise).
 // TODO(fwereade) This function is not meant to be "good" in any serious way:
@@ -752,7 +756,6 @@ func PopulateInstanceConfig(icfg *InstanceConfig,
 // redeeming feature.
 func FinishInstanceConfig(icfg *InstanceConfig, cfg *config.Config) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot complete machine configuration")
-
 	if err := PopulateInstanceConfig(
 		icfg,
 		cfg.Type(),
@@ -766,7 +769,6 @@ func FinishInstanceConfig(icfg *InstanceConfig, cfg *config.Config) (err error) 
 	); err != nil {
 		return errors.Trace(err)
 	}
-
 	if icfg.Controller != nil {
 		// Add NUMACTL preference. Needed to work for both bootstrap and high availability
 		// Only makes sense for controller
@@ -774,57 +776,6 @@ func FinishInstanceConfig(icfg *InstanceConfig, cfg *config.Config) (err error) 
 		// Unfortunately, AgentEnvironment can only take strings as values
 		icfg.AgentEnvironment[agent.NumaCtlPreference] = fmt.Sprintf("%v", icfg.Controller.Config.NumaCtlPreference())
 	}
-
-	// The following settings are only appropriate at bootstrap time.
-	if icfg.Bootstrap == nil {
-		return nil
-	}
-	if icfg.APIInfo != nil || icfg.Controller.MongoInfo != nil {
-		return errors.New("machine configuration already has api/state info")
-	}
-	controllerCfg := icfg.Controller.Config
-	caCert, hasCACert := controllerCfg.CACert()
-	if !hasCACert {
-		return errors.New("controller configuration has no ca-cert")
-	}
-	caPrivateKey, hasCAPrivateKey := controllerCfg.CAPrivateKey()
-	if !hasCAPrivateKey {
-		return errors.New("controller configuration has no ca-private-key")
-	}
-	password := cfg.AdminSecret()
-	if password == "" {
-		return errors.New("model configuration has no admin-secret")
-	}
-	icfg.APIInfo = &api.Info{
-		Password: password,
-		CACert:   caCert,
-		ModelTag: names.NewModelTag(cfg.UUID()),
-	}
-	icfg.Controller.MongoInfo = &mongo.MongoInfo{
-		Password: password, Info: mongo.Info{CACert: caCert},
-	}
-
-	// These really are directly relevant to running a controller.
-	// Initially, generate a controller certificate with no host IP
-	// addresses in the SAN field. Once the controller is up and the
-	// NIC addresses become known, the certificate can be regenerated.
-	cert, key, err := controller.GenerateControllerCertAndKey(caCert, caPrivateKey, nil)
-	if err != nil {
-		return errors.Annotate(err, "cannot generate controller certificate")
-	}
-	icfg.Bootstrap.StateServingInfo = params.StateServingInfo{
-		StatePort:    controllerCfg.StatePort(),
-		APIPort:      controllerCfg.APIPort(),
-		Cert:         string(cert),
-		PrivateKey:   string(key),
-		CAPrivateKey: caPrivateKey,
-	}
-	if icfg.Bootstrap.ControllerModelConfig, err = bootstrapConfig(cfg); err != nil {
-		return errors.Trace(err)
-	}
-	// We never want to save the root CA provide key to the cloud.
-	delete(icfg.Controller.Config, controller.CAPrivateKey)
-
 	return nil
 }
 
@@ -840,21 +791,4 @@ func InstanceTags(modelUUID, controllerUUID string, tagger tags.ResourceTagger, 
 		instanceTags[tags.JujuIsController] = "true"
 	}
 	return instanceTags
-}
-
-// bootstrapConfig returns a copy of the supplied configuration with the
-// admin-secret attribute removed. If the resulting config is not suitable
-// for bootstrapping an environment, an error is returned.
-func bootstrapConfig(cfg *config.Config) (*config.Config, error) {
-	m := cfg.AllAttrs()
-	// We never want to push admin-secret to the cloud.
-	delete(m, config.AdminSecretKey)
-	cfg, err := config.New(config.NoDefaults, m)
-	if err != nil {
-		return nil, err
-	}
-	if _, ok := cfg.AgentVersion(); !ok {
-		return nil, fmt.Errorf("model configuration has no agent-version")
-	}
-	return cfg, nil
 }

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
@@ -231,6 +232,7 @@ func (cfg *testInstanceConfig) setController() *testInstanceConfig {
 			ModelConstraints:            envConstraints,
 		},
 		StateServingInfo: stateServingInfo,
+		Timeout:          time.Minute * 10,
 	}
 	cfg.Jobs = allMachineJobs
 	cfg.APIInfo.Tag = nil
@@ -346,7 +348,7 @@ chmod 0600 '/var/lib/juju/agents/machine-0/agent\.conf'
 install -D -m 600 /dev/null '/var/lib/juju/bootstrap-params'
 printf '%s\\n' '.*' > '/var/lib/juju/bootstrap-params'
 echo 'Bootstrapping Juju machine agent'.*
-/var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --debug '/var/lib/juju/bootstrap-params'
+/var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --timeout 10m0s --data-dir '/var/lib/juju' --debug '/var/lib/juju/bootstrap-params'
 ln -s 1\.2\.3-precise-amd64 '/var/lib/juju/tools/machine-0'
 echo 'Starting Juju machine agent \(jujud-machine-0\)'.*
 cat > /etc/init/jujud-machine-0\.conf << 'EOF'\\ndescription "juju agent for machine-0"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-0\.log\\n  chown syslog:syslog /var/log/juju/machine-0\.log\\n  chmod 0600 /var/log/juju/machine-0\.log\\n\\n  exec '/var/lib/juju/tools/machine-0/jujud' machine --data-dir '/var/lib/juju' --machine-id 0 --debug >> /var/log/juju/machine-0\.log 2>&1\\nend script\\nEOF\\n
@@ -368,7 +370,7 @@ grep '1234' \$bin/juju1\.2\.3-raring-amd64.sha256 \|\| \(echo "Tools checksum mi
 printf %s '{"version":"1\.2\.3-raring-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3-raring-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
 install -D -m 600 /dev/null '/var/lib/juju/bootstrap-params'
 printf '%s\\n' '.*' > '/var/lib/juju/bootstrap-params'
-/var/lib/juju/tools/1\.2\.3-raring-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --debug '/var/lib/juju/bootstrap-params'
+/var/lib/juju/tools/1\.2\.3-raring-amd64/jujud bootstrap-state --timeout 10m0s --data-dir '/var/lib/juju' --debug '/var/lib/juju/bootstrap-params'
 ln -s 1\.2\.3-raring-amd64 '/var/lib/juju/tools/machine-0'
 rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-raring-amd64\.sha256
 `,

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -298,6 +298,7 @@ func (w *unixConfigure) configureBootstrap() error {
 	bootstrapAgentArgs := []string{
 		featureFlags + w.icfg.JujuTools() + "/jujud",
 		"bootstrap-state",
+		"--timeout", w.icfg.Bootstrap.Timeout.String(),
 		"--data-dir", shquote(w.icfg.DataDir),
 		loggingOption,
 		shquote(bootstrapParamsFile),

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -256,6 +256,8 @@ func (c *restoreCommand) rebootstrap(ctx *cmd.Context, meta *params.BackupsMetad
 		return errors.Trace(err)
 	}
 
+	sshOpts := env.Config().BootstrapSSHOpts()
+
 	bootVers := version.Current
 	var cred *cloud.Credential
 	if params.Credential.AuthType() != cloud.EmptyAuthType {
@@ -274,6 +276,11 @@ func (c *restoreCommand) rebootstrap(ctx *cmd.Context, meta *params.BackupsMetad
 		HostedModelConfig:   hostedModelConfig,
 		BootstrapSeries:     meta.Series,
 		AgentVersion:        &bootVers,
+		DialOpts: environs.BootstrapDialOpts{
+			Timeout:        sshOpts.Timeout,
+			RetryDelay:     sshOpts.RetryDelay,
+			AddressesDelay: sshOpts.AddressesDelay,
+		},
 	}
 	if err := BootstrapFunc(modelcmd.BootstrapContext(ctx), env, args); err != nil {
 		return errors.Annotatef(err, "cannot bootstrap new instance")

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -630,6 +630,8 @@ to clean up the model.`[1:])
 		credentialName = detectedCredentialName
 	}
 
+	sshOpts := environ.Config().BootstrapSSHOpts()
+
 	err = bootstrapFuncs.Bootstrap(modelcmd.BootstrapContext(ctx), environ, bootstrap.BootstrapParams{
 		ModelConstraints:          c.Constraints,
 		BootstrapConstraints:      bootstrapConstraints,
@@ -649,6 +651,11 @@ to clean up the model.`[1:])
 		ControllerInheritedConfig: inheritedControllerAttrs,
 		HostedModelConfig:         hostedModelConfig,
 		GUIDataSourceBaseURL:      guiDataSourceBaseURL,
+		DialOpts: environs.BootstrapDialOpts{
+			Timeout:        sshOpts.Timeout,
+			RetryDelay:     sshOpts.RetryDelay,
+			AddressesDelay: sshOpts.AddressesDelay,
+		},
 	})
 	if err != nil {
 		return errors.Annotate(err, "failed to bootstrap model")

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -415,6 +416,20 @@ func (s *BootstrapSuite) TestBootstrapDefaultModel(c *gc.C) {
 	c.Assert(utils.IsValidUUIDString(bootstrap.args.ControllerConfig.ControllerUUID()), jc.IsTrue)
 	c.Assert(bootstrap.args.HostedModelConfig["name"], gc.Equals, "mymodel")
 	c.Assert(bootstrap.args.HostedModelConfig["foo"], gc.Equals, "bar")
+}
+
+func (s *BootstrapSuite) TestBootstrapTimeout(c *gc.C) {
+	s.patchVersionAndSeries(c, "raring")
+
+	var bootstrap fakeBootstrapFuncs
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return &bootstrap
+	})
+	coretesting.RunCommand(
+		c, s.newBootstrapCommand(), "devcontroller", "dummy", "--auto-upgrade",
+		"--config", "bootstrap-timeout=99",
+	)
+	c.Assert(bootstrap.args.DialOpts.Timeout, gc.Equals, 99*time.Second)
 }
 
 func (s *BootstrapSuite) TestBootstrapDefaultConfigStripsProcessedAttributes(c *gc.C) {

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -62,6 +62,7 @@ type BootstrapCommand struct {
 	cmd.CommandBase
 	agentcmd.AgentConf
 	BootstrapParamsFile string
+	Timeout             time.Duration
 }
 
 // NewBootstrapCommand returns a new BootstrapCommand that has been initialized.
@@ -82,6 +83,7 @@ func (c *BootstrapCommand) Info() *cmd.Info {
 // SetFlags adds the flags for this command to the passed gnuflag.FlagSet.
 func (c *BootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.AgentConf.AddFlags(f)
+	f.DurationVar(&c.Timeout, "timeout", time.Duration(0), "set the bootstrap timeout")
 }
 
 // Init initializes the command for running.
@@ -231,8 +233,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		// Set a longer socket timeout than usual, as the machine
 		// will be starting up and disk I/O slower than usual. This
 		// has been known to cause timeouts in queries.
-		timeouts := controllerModelCfg.BootstrapSSHOpts()
-		dialOpts.SocketTimeout = timeouts.Timeout
+		dialOpts.SocketTimeout = c.Timeout
 		if dialOpts.SocketTimeout < minSocketTimeout {
 			dialOpts.SocketTimeout = minSocketTimeout
 		}
@@ -296,8 +297,8 @@ func (c *BootstrapCommand) startMongo(addrs []network.Address, agentConfig agent
 	// When bootstrapping, we need to allow enough time for mongo
 	// to start as there's no retry loop in place.
 	// 5 minutes should suffice.
-	bootstrapDialOpts := mongo.DialOpts{Timeout: 5 * time.Minute}
-	dialInfo, err := mongo.DialInfo(info.Info, bootstrapDialOpts)
+	mongoDialOpts := mongo.DialOpts{Timeout: 5 * time.Minute}
+	dialInfo, err := mongo.DialInfo(info.Info, mongoDialOpts)
 	if err != nil {
 		return err
 	}

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -611,7 +611,7 @@ func (s *BootstrapSuite) TestInitializeStateArgs(c *gc.C) {
 		return nil, nil, errors.New("failed to initialize state")
 	}
 	s.PatchValue(&agentInitializeState, initializeState)
-	_, cmd, err := s.initBootstrapCommand(c, nil)
+	_, cmd, err := s.initBootstrapCommand(c, nil, "--timeout", "123s", s.bootstrapParamsFile)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, gc.ErrorMatches, "failed to initialize state")
@@ -627,15 +627,8 @@ func (s *BootstrapSuite) TestInitializeStateMinSocketTimeout(c *gc.C) {
 		return nil, nil, errors.New("failed to initialize state")
 	}
 
-	cfg, err := s.bootstrapParams.ControllerModelConfig.Apply(map[string]interface{}{
-		"bootstrap-timeout": "13",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	s.bootstrapParams.ControllerModelConfig = cfg
-	s.writeBootstrapParamsFile(c)
-
 	s.PatchValue(&agentInitializeState, initializeState)
-	_, cmd, err := s.initBootstrapCommand(c, nil)
+	_, cmd, err := s.initBootstrapCommand(c, nil, "--timeout", "13s", s.bootstrapParamsFile)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, gc.ErrorMatches, "failed to initialize state")
@@ -797,8 +790,7 @@ func (s *BootstrapSuite) TestStructuredImageMetadataInvalidSeries(c *gc.C) {
 func (s *BootstrapSuite) makeTestModel(c *gc.C) {
 	attrs := dummy.SampleConfig().Merge(
 		testing.Attrs{
-			"agent-version":     jujuversion.Current.String(),
-			"bootstrap-timeout": "123",
+			"agent-version": jujuversion.Current.String(),
 		},
 	).Delete("admin-secret", "ca-private-key")
 	cfg, err := config.New(config.NoDefaults, attrs)

--- a/environs/bootstrap.go
+++ b/environs/bootstrap.go
@@ -6,6 +6,7 @@ package environs
 import (
 	"io"
 	"os"
+	"time"
 
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/constraints"
@@ -55,7 +56,24 @@ type BootstrapParams struct {
 
 // BootstrapFinalizer is a function returned from Environ.Bootstrap.
 // The caller must pass a InstanceConfig with the Tools field set.
-type BootstrapFinalizer func(BootstrapContext, *instancecfg.InstanceConfig) error
+type BootstrapFinalizer func(BootstrapContext, *instancecfg.InstanceConfig, BootstrapDialOpts) error
+
+// BootstrapDialOpts contains the options for the synchronous part of the
+// bootstrap procedure, where the CLI connects to the bootstrap machine
+// to complete the process.
+type BootstrapDialOpts struct {
+	// Timeout is the amount of time to wait contacting a state
+	// server.
+	Timeout time.Duration
+
+	// RetryDelay is the amount of time between attempts to connect to
+	// an address.
+	RetryDelay time.Duration
+
+	// AddressesDelay is the amount of time between refreshing the
+	// addresses.
+	AddressesDelay time.Duration
+}
 
 // BootstrapResult holds the data returned by calls to Environ.Bootstrap.
 type BootstrapResult struct {

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -20,18 +20,23 @@ import (
 	"github.com/juju/utils/series"
 	"github.com/juju/utils/ssh"
 	"github.com/juju/version"
+	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/gui"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/storage"
 	"github.com/juju/juju/environs/sync"
 	"github.com/juju/juju/environs/tools"
+	"github.com/juju/juju/mongo"
 	coretools "github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -122,6 +127,9 @@ type BootstrapParams struct {
 	// used to retrieve the Juju GUI archive installed in the controller.
 	// If not set, the Juju GUI is not installed from simplestreams.
 	GUIDataSourceBaseURL string
+
+	// DialOpts contains the bootstrap dial options.
+	DialOpts environs.BootstrapDialOpts
 }
 
 // Bootstrap bootstraps the given environment. The supplied constraints are
@@ -143,10 +151,12 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	if args.ControllerConfig.ControllerUUID() == "" {
 		return errors.Errorf("bootstrap configuration has no controller UUID")
 	}
-	if _, hasCACert := args.ControllerConfig.CACert(); !hasCACert {
+	caCert, hasCACert := args.ControllerConfig.CACert()
+	if !hasCACert {
 		return errors.Errorf("controller configuration has no ca-cert")
 	}
-	if _, hasCAKey := args.ControllerConfig.CAPrivateKey(); !hasCAKey {
+	caKey, hasCAKey := args.ControllerConfig.CAPrivateKey()
+	if !hasCAKey {
 		return errors.Errorf("controller configuration has no ca-private-key")
 	}
 
@@ -285,7 +295,11 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 		return err
 	}
 	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(
-		args.ControllerConfig, args.BootstrapConstraints, args.ModelConstraints, result.Series, publicKey,
+		args.ControllerConfig,
+		args.BootstrapConstraints,
+		args.ModelConstraints,
+		result.Series,
+		publicKey,
 	)
 	if err != nil {
 		return err
@@ -293,23 +307,84 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	if err := instanceConfig.SetTools(selectedToolsList); err != nil {
 		return errors.Trace(err)
 	}
-	instanceConfig.Bootstrap.CustomImageMetadata = customImageMetadata
-	instanceConfig.Bootstrap.ControllerCloudName = args.CloudName
-	instanceConfig.Bootstrap.ControllerCloud = args.Cloud
-	instanceConfig.Bootstrap.ControllerCloudRegion = args.CloudRegion
-	instanceConfig.Bootstrap.ControllerCloudCredential = args.CloudCredential
-	instanceConfig.Bootstrap.ControllerCloudCredentialName = args.CloudCredentialName
-	instanceConfig.Bootstrap.ControllerConfig = args.ControllerConfig
-	instanceConfig.Bootstrap.ControllerInheritedConfig = args.ControllerInheritedConfig
-	instanceConfig.Bootstrap.HostedModelConfig = args.HostedModelConfig
-	instanceConfig.Bootstrap.GUI = guiArchive(args.GUIDataSourceBaseURL, func(msg string) {
-		ctx.Infof(msg)
-	})
-
-	if err := result.Finalize(ctx, instanceConfig); err != nil {
+	if err := finalizeInstanceBootstrapConfig(
+		ctx, instanceConfig, args, cfg, customImageMetadata,
+		caCert, caKey,
+	); err != nil {
+		return errors.Annotate(err, "finalizing bootstrap instance config")
+	}
+	if err := result.Finalize(ctx, instanceConfig, args.DialOpts); err != nil {
 		return err
 	}
 	ctx.Infof("Bootstrap agent installed")
+	return nil
+}
+
+func finalizeInstanceBootstrapConfig(
+	ctx environs.BootstrapContext,
+	icfg *instancecfg.InstanceConfig,
+	args BootstrapParams,
+	cfg *config.Config,
+	customImageMetadata []*imagemetadata.ImageMetadata,
+	caCert, caKey string,
+) error {
+	if icfg.APIInfo != nil || icfg.Controller.MongoInfo != nil {
+		return errors.New("machine configuration already has api/state info")
+	}
+	controllerCfg := icfg.Controller.Config
+	caCert, hasCACert := controllerCfg.CACert()
+	if !hasCACert {
+		return errors.New("controller configuration has no ca-cert")
+	}
+	secret := cfg.AdminSecret()
+	icfg.APIInfo = &api.Info{
+		Password: secret,
+		CACert:   caCert,
+		ModelTag: names.NewModelTag(cfg.UUID()),
+	}
+	icfg.Controller.MongoInfo = &mongo.MongoInfo{
+		Password: secret,
+		Info:     mongo.Info{CACert: caCert},
+	}
+
+	// These really are directly relevant to running a controller.
+	// Initially, generate a controller certificate with no host IP
+	// addresses in the SAN field. Once the controller is up and the
+	// NIC addresses become known, the certificate can be regenerated.
+	cert, key, err := controller.GenerateControllerCertAndKey(caCert, caKey, nil)
+	if err != nil {
+		return errors.Annotate(err, "cannot generate controller certificate")
+	}
+	icfg.Bootstrap.StateServingInfo = params.StateServingInfo{
+		StatePort:    controllerCfg.StatePort(),
+		APIPort:      controllerCfg.APIPort(),
+		Cert:         string(cert),
+		PrivateKey:   string(key),
+		CAPrivateKey: caKey,
+	}
+	if _, ok := cfg.AgentVersion(); !ok {
+		return fmt.Errorf("controller model configuration has no agent-version")
+	}
+
+	cfg, err = bootstrapConfig(cfg)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	icfg.Bootstrap.ControllerModelConfig = cfg
+	icfg.Bootstrap.CustomImageMetadata = customImageMetadata
+	icfg.Bootstrap.ControllerCloudName = args.CloudName
+	icfg.Bootstrap.ControllerCloud = args.Cloud
+	icfg.Bootstrap.ControllerCloudRegion = args.CloudRegion
+	icfg.Bootstrap.ControllerCloudCredential = args.CloudCredential
+	icfg.Bootstrap.ControllerCloudCredentialName = args.CloudCredentialName
+	icfg.Bootstrap.ControllerConfig = args.ControllerConfig
+	icfg.Bootstrap.ControllerInheritedConfig = args.ControllerInheritedConfig
+	icfg.Bootstrap.HostedModelConfig = args.HostedModelConfig
+	icfg.Bootstrap.Timeout = args.DialOpts.Timeout
+	icfg.Bootstrap.GUI = guiArchive(args.GUIDataSourceBaseURL, func(msg string) {
+		ctx.Infof(msg)
+	})
+	delete(icfg.Controller.Config, controller.CAPrivateKey)
 	return nil
 }
 
@@ -635,4 +710,21 @@ func hashAndSize(path string) (hash string, size int64, err error) {
 		return "", 0, errors.Mask(err)
 	}
 	return fmt.Sprintf("%x", h.Sum(nil)), size, nil
+}
+
+// bootstrapConfig returns a copy of the supplied configuration with the
+// admin-secret attribute removed. If the resulting config is not suitable
+// for bootstrapping an environment, an error is returned.
+func bootstrapConfig(cfg *config.Config) (*config.Config, error) {
+	m := cfg.AllAttrs()
+	// We never want to push admin-secret to the cloud.
+	delete(m, config.AdminSecretKey)
+	cfg, err := config.New(config.NoDefaults, m)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := cfg.AgentVersion(); !ok {
+		return nil, fmt.Errorf("model configuration has no agent-version")
+	}
+	return cfg, nil
 }

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -45,7 +45,7 @@ const (
 
 	// DefaultBootstrapSSHTimeout is the amount of time to wait
 	// contacting a controller, in seconds.
-	DefaultBootstrapSSHTimeout int = 600
+	DefaultBootstrapSSHTimeout int = 1200
 
 	// DefaultBootstrapSSHRetryDelay is the amount of time between
 	// attempts to connect to an address, in seconds.

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -1217,7 +1217,7 @@ var validationTests = []validationTest{{
 }, {
 	about: "Cannot change the bootstrap-timeout from implicit-default to different value",
 	new:   testing.Attrs{"bootstrap-timeout": 5},
-	err:   `cannot change bootstrap-timeout from 600 to 5`,
+	err:   `cannot change bootstrap-timeout from 1200 to 5`,
 }, {
 	about: "Cannot change uuid",
 	old:   testing.Attrs{"uuid": "90168e4c-2f10-4e9c-83c2-1fb55a58e5a9"},

--- a/environs/testing/bootstrap.go
+++ b/environs/testing/bootstrap.go
@@ -23,7 +23,7 @@ var logger = loggo.GetLogger("juju.environs.testing")
 // do not attempt to SSH to non-existent machines. The result is a function
 // that restores finishBootstrap.
 func DisableFinishBootstrap() func() {
-	f := func(environs.BootstrapContext, ssh.Client, environs.Environ, instance.Instance, *instancecfg.InstanceConfig) error {
+	f := func(environs.BootstrapContext, ssh.Client, environs.Environ, instance.Instance, *instancecfg.InstanceConfig, environs.BootstrapDialOpts) error {
 		logger.Infof("provider/common.FinishBootstrap is disabled")
 		return nil
 	}

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -245,7 +245,7 @@ func (neverAddresses) Addresses() ([]network.Address, error) {
 	return nil, nil
 }
 
-var testSSHTimeout = config.SSHTimeoutOpts{
+var testSSHTimeout = environs.BootstrapDialOpts{
 	Timeout:        coretesting.ShortWait,
 	RetryDelay:     1 * time.Millisecond,
 	AddressesDelay: 1 * time.Millisecond,

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -689,7 +689,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 	estate.bootstrapped = true
 	estate.ops <- OpBootstrap{Context: ctx, Env: e.name, Args: args}
 
-	finalize := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig) error {
+	finalize := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig, _ environs.BootstrapDialOpts) error {
 		if e.ecfg().controller() {
 			icfg.Bootstrap.BootstrapMachineInstanceId = BootstrapInstanceId
 			if err := instancecfg.FinishInstanceConfig(icfg, e.Config()); err != nil {

--- a/provider/gce/environ_test.go
+++ b/provider/gce/environ_test.go
@@ -65,7 +65,7 @@ func (s *environSuite) TestConfig(c *gc.C) {
 func (s *environSuite) TestBootstrap(c *gc.C) {
 	s.FakeCommon.Arch = "amd64"
 	s.FakeCommon.Series = "trusty"
-	finalizer := func(environs.BootstrapContext, *instancecfg.InstanceConfig) error {
+	finalizer := func(environs.BootstrapContext, *instancecfg.InstanceConfig, environs.BootstrapDialOpts) error {
 		return nil
 	}
 	s.FakeCommon.BSFinalizer = finalizer

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -71,7 +71,7 @@ func (s *environSuite) TestBootstrapOkay(c *gc.C) {
 	s.Common.BootstrapResult = &environs.BootstrapResult{
 		Arch:   "amd64",
 		Series: "trusty",
-		Finalize: func(environs.BootstrapContext, *instancecfg.InstanceConfig) error {
+		Finalize: func(environs.BootstrapContext, *instancecfg.InstanceConfig, environs.BootstrapDialOpts) error {
 			return nil
 		},
 	}

--- a/provider/maas/config.go
+++ b/provider/maas/config.go
@@ -107,13 +107,6 @@ func (prov maasEnvironProvider) Validate(cfg, oldCfg *config.Config) (*config.Co
 		providerDefaults[config.StorageDefaultBlockSourceKey] = maasStorageProviderType
 	}
 
-	// If user has not psecified bootstrap timeout,
-	// set provider default setting.
-	// MAAS bootstrap timeout default should be longer than standard timeout.
-	if _, ok := cfg.AllAttrs()["bootstrap-timeout"]; !ok {
-		providerDefaults["bootstrap-timeout"] = config.DefaultBootstrapSSHTimeout * 2
-	}
-
 	if len(providerDefaults) > 0 {
 		if cfg, err = cfg.Apply(providerDefaults); err != nil {
 			return nil, err

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -140,15 +140,23 @@ func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 			}
 		}
 	}()
-	// Wait for bootstrap instance to change to deployed state.
-	if err := env.waitForNodeDeployment(result.Instance.Id()); err != nil {
-		return nil, errors.Annotate(err, "bootstrap instance started but did not change to Deployed state")
+
+	waitingFinalizer := func(
+		ctx environs.BootstrapContext,
+		icfg *instancecfg.InstanceConfig,
+		dialOpts environs.BootstrapDialOpts,
+	) error {
+		// Wait for bootstrap instance to change to deployed state.
+		if err := env.waitForNodeDeployment(result.Instance.Id(), dialOpts.Timeout); err != nil {
+			return errors.Annotate(err, "bootstrap instance started but did not change to Deployed state")
+		}
+		return finalizer(ctx, icfg, dialOpts)
 	}
 
 	bsResult := &environs.BootstrapResult{
 		Arch:     *result.Hardware.Arch,
 		Series:   series,
-		Finalize: finalizer,
+		Finalize: waitingFinalizer,
 	}
 	return bsResult, nil
 }
@@ -998,21 +1006,15 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 	}, nil
 }
 
-// Override for testing.
-var nodeDeploymentTimeout = func(environ *maasEnviron) time.Duration {
-	sshTimeouts := environ.Config().BootstrapSSHOpts()
-	return sshTimeouts.Timeout
-}
-
-func (environ *maasEnviron) waitForNodeDeployment(id instance.Id) error {
+func (environ *maasEnviron) waitForNodeDeployment(id instance.Id, timeout time.Duration) error {
 	if environ.usingMAAS2() {
-		return environ.waitForNodeDeployment2(id)
+		return environ.waitForNodeDeployment2(id, timeout)
 	}
 	systemId := extractSystemId(id)
 
 	longAttempt := utils.AttemptStrategy{
 		Delay: 10 * time.Second,
-		Total: nodeDeploymentTimeout(environ),
+		Total: timeout,
 	}
 
 	for a := longAttempt.Start(); a.Next(); {
@@ -1033,10 +1035,10 @@ func (environ *maasEnviron) waitForNodeDeployment(id instance.Id) error {
 	return errors.Errorf("instance %q is started but not deployed", id)
 }
 
-func (environ *maasEnviron) waitForNodeDeployment2(id instance.Id) error {
+func (environ *maasEnviron) waitForNodeDeployment2(id instance.Id, timeout time.Duration) error {
 	longAttempt := utils.AttemptStrategy{
 		Delay: 10 * time.Second,
-		Total: nodeDeploymentTimeout(environ),
+		Total: timeout,
 	}
 
 	for a := longAttempt.Start(); a.Next(); {

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -5,7 +5,6 @@ package maas_test
 
 import (
 	stdtesting "testing"
-	"time"
 
 	"github.com/juju/gomaasapi"
 	jc "github.com/juju/testing/checkers"
@@ -166,60 +165,6 @@ func (*environSuite) TestDestroyWithEmptyAgentName(c *gc.C) {
 
 	err = env.Destroy()
 	c.Assert(err, gc.ErrorMatches, "unsafe destruction")
-}
-
-func (*environSuite) TestProviderDefaultBootstrapTimeoutSet(c *gc.C) {
-	attrs := coretesting.FakeConfig()
-	attrs["type"] = "maas"
-	attrs["maas-server"] = "http://maas.testing.invalid"
-	attrs["maas-oauth"] = "a:b:c"
-	attrs["maas-agent-name"] = ""
-	cfg, err := config.New(config.NoDefaults, attrs)
-	c.Assert(err, jc.ErrorIsNil)
-
-	env, err := maas.NewEnviron(cfg)
-	c.Assert(err, jc.ErrorIsNil)
-
-	envConfig := env.Config()
-	c.Assert(envConfig.BootstrapSSHOpts().Timeout, gc.Equals, time.Duration(config.DefaultBootstrapSSHTimeout*2)*time.Second)
-}
-
-func (*environSuite) TestUserSpecifiedBootstrapTimeoutOverridesProviderDefault(c *gc.C) {
-	expectedTimeout := 2400
-
-	attrs := coretesting.FakeConfig()
-	attrs["type"] = "maas"
-	attrs["maas-server"] = "http://maas.testing.invalid"
-	attrs["maas-oauth"] = "a:b:c"
-	attrs["maas-agent-name"] = ""
-	attrs["bootstrap-timeout"] = expectedTimeout
-	cfg, err := config.New(config.NoDefaults, attrs)
-	c.Assert(err, jc.ErrorIsNil)
-
-	env, err := maas.NewEnviron(cfg)
-	c.Assert(err, jc.ErrorIsNil)
-
-	envConfig := env.Config()
-	c.Assert(envConfig.BootstrapSSHOpts().Timeout, gc.Equals, time.Duration(expectedTimeout)*time.Second)
-}
-
-func (*environSuite) TestUserSpecifiedBootstrapTimeoutLessThanProviderDefault(c *gc.C) {
-	expectedTimeout := 600
-
-	attrs := coretesting.FakeConfig()
-	attrs["type"] = "maas"
-	attrs["maas-server"] = "http://maas.testing.invalid"
-	attrs["maas-oauth"] = "a:b:c"
-	attrs["maas-agent-name"] = ""
-	attrs["bootstrap-timeout"] = expectedTimeout
-	cfg, err := config.New(config.NoDefaults, attrs)
-	c.Assert(err, jc.ErrorIsNil)
-
-	env, err := maas.NewEnviron(cfg)
-	c.Assert(err, jc.ErrorIsNil)
-
-	envConfig := env.Config()
-	c.Assert(envConfig.BootstrapSSHOpts().Timeout, gc.Equals, time.Duration(expectedTimeout)*time.Second)
 }
 
 func (*environSuite) TestSetConfigAllowsChangingNilAgentNameToEmptyString(c *gc.C) {

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
-	"time"
 
 	"github.com/juju/gomaasapi"
 	jc "github.com/juju/testing/checkers"
@@ -53,9 +52,6 @@ func (s *baseProviderSuite) SetUpSuite(c *gc.C) {
 	s.AddCleanup(func(*gc.C) {
 		restoreFinishBootstrap()
 		restoreTimeouts()
-	})
-	s.PatchValue(&nodeDeploymentTimeout, func(*maasEnviron) time.Duration {
-		return coretesting.ShortWait
 	})
 }
 

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -104,7 +104,7 @@ func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 	if err != nil {
 		return nil, err
 	}
-	finalize := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig) error {
+	finalize := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig, _ environs.BootstrapDialOpts) error {
 		icfg.Bootstrap.BootstrapMachineInstanceId = BootstrapInstanceId
 		icfg.Bootstrap.BootstrapMachineHardwareCharacteristics = &hc
 		if err := instancecfg.FinishInstanceConfig(icfg, e.Config()); err != nil {

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -330,6 +330,7 @@ func (s *localServerSuite) TestAddressesWithPublicIP(c *gc.C) {
 		env environs.Environ,
 		inst instance.Instance,
 		instanceConfig *instancecfg.InstanceConfig,
+		_ environs.BootstrapDialOpts,
 	) error {
 		addr, err := inst.Addresses()
 		c.Assert(err, jc.ErrorIsNil)
@@ -366,6 +367,7 @@ func (s *localServerSuite) TestAddressesWithoutPublicIP(c *gc.C) {
 		env environs.Environ,
 		inst instance.Instance,
 		instanceConfig *instancecfg.InstanceConfig,
+		_ environs.BootstrapDialOpts,
 	) error {
 		addr, err := inst.Addresses()
 		c.Assert(err, jc.ErrorIsNil)

--- a/provider/rackspace/environ.go
+++ b/provider/rackspace/environ.go
@@ -49,7 +49,7 @@ func (e environ) StartInstance(args environs.StartInstanceParams) (*environs.Sta
 	}
 	if fwmode != config.FwNone {
 		interrupted := make(chan os.Signal, 1)
-		timeout := config.SSHTimeoutOpts{
+		timeout := environs.BootstrapDialOpts{
 			Timeout:        time.Minute * 5,
 			RetryDelay:     time.Second * 5,
 			AddressesDelay: time.Second * 20,

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -49,7 +49,7 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 
 func (s *environSuite) TestStartInstance(c *gc.C) {
 	configurator := &fakeConfigurator{}
-	s.PatchValue(rackspace.WaitSSH, func(stdErr io.Writer, interrupted <-chan os.Signal, client ssh.Client, checkHostScript string, inst common.Addresser, timeout config.SSHTimeoutOpts) (addr string, err error) {
+	s.PatchValue(rackspace.WaitSSH, func(stdErr io.Writer, interrupted <-chan os.Signal, client ssh.Client, checkHostScript string, inst common.Addresser, timeout environs.BootstrapDialOpts) (addr string, err error) {
 		addresses, err := inst.Addresses()
 		if err != nil {
 			return "", err


### PR DESCRIPTION
Rather than using SSH bootstrap timeouts
directly in places where they weren't
intended for use, we now thread the values
through. In particular, we send timeouts
through to the bootstrap "finalizer", and
we add a --timeout flag to the jujud
bootsrap-state "agent".

There is a tangentially related cleanup to
do with instance config: we extract the
bootstrap-specific code from
instancecfg.FinishInstanceConfig, and move
it into the environs/bootstrap package.
This will enable further changes to
separate bootstrap and controller config.

Because bootstrap timeouts will be removed
from model config, and there will initially
be no way for providers to override bootstrap
config defaults, the code in the MAAS provider
to double the default has been dropped. The
default has been doubled across the board.
If this is too long for other providers, we
can look at adding the ability to override
back in later.

(Review request: http://reviews.vapour.ws/r/5221/)