### PR TITLE
Add flag to enable log forwarding; handle config changes

### DIFF
--- a/api/agent/state.go
+++ b/api/agent/state.go
@@ -19,6 +19,7 @@ import (
 type State struct {
 	facade base.FacadeCaller
 	*common.ModelWatcher
+	*common.ControllerConfigAPI
 }
 
 // NewState returns a version of the state that provides functionality
@@ -26,8 +27,9 @@ type State struct {
 func NewState(caller base.APICaller) *State {
 	facadeCaller := base.NewFacadeCaller(caller, "Agent")
 	return &State{
-		facade:       facadeCaller,
-		ModelWatcher: common.NewModelWatcher(facadeCaller),
+		facade:              facadeCaller,
+		ModelWatcher:        common.NewModelWatcher(facadeCaller),
+		ControllerConfigAPI: common.NewControllerConfig(facadeCaller),
 	}
 }
 

--- a/api/common/modelwatcher.go
+++ b/api/common/modelwatcher.go
@@ -8,6 +8,7 @@ import (
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/logfwd/syslog"
 	"github.com/juju/juju/watcher"
 )
 
@@ -46,4 +47,24 @@ func (e *ModelWatcher) ModelConfig() (*config.Config, error) {
 		return nil, err
 	}
 	return conf, nil
+}
+
+// WatchForLogForwardConfigChanges return a NotifyWatcher waiting for the
+// log forward syslog configuration to change.
+func (e *ModelWatcher) WatchForLogForwardConfigChanges() (watcher.NotifyWatcher, error) {
+	// TODO(wallyworld) - lp:1602237 - this needs to have it's own backend implementation.
+	// For now, we'll piggyback off the ModelConfig API.
+	return e.WatchForModelConfigChanges()
+}
+
+// LogForwardConfig returns the current log forward syslog configuration.
+func (e *ModelWatcher) LogForwardConfig() (*syslog.RawConfig, bool, error) {
+	// TODO(wallyworld) - lp:1602237 - this needs to have it's own backend implementation.
+	// For now, we'll piggyback off the ModelConfig API.
+	modelConfig, err := e.ModelConfig()
+	if err != nil {
+		return nil, false, err
+	}
+	cfg, ok := modelConfig.LogFwdSyslog()
+	return cfg, ok, nil
 }

--- a/apiserver/agent/agent.go
+++ b/apiserver/agent/agent.go
@@ -26,6 +26,7 @@ type AgentAPIV2 struct {
 	*common.PasswordChanger
 	*common.RebootFlagClearer
 	*common.ModelWatcher
+	*common.ControllerConfigAPI
 
 	st   *state.State
 	auth common.Authorizer
@@ -42,11 +43,12 @@ func NewAgentAPIV2(st *state.State, resources *common.Resources, auth common.Aut
 		return auth.AuthOwner, nil
 	}
 	return &AgentAPIV2{
-		PasswordChanger:   common.NewPasswordChanger(st, getCanChange),
-		RebootFlagClearer: common.NewRebootFlagClearer(st, getCanChange),
-		ModelWatcher:      common.NewModelWatcher(st, resources, auth),
-		st:                st,
-		auth:              auth,
+		PasswordChanger:     common.NewPasswordChanger(st, getCanChange),
+		RebootFlagClearer:   common.NewRebootFlagClearer(st, getCanChange),
+		ModelWatcher:        common.NewModelWatcher(st, resources, auth),
+		ControllerConfigAPI: common.NewControllerConfig(st),
+		st:                  st,
+		auth:                auth,
 	}, nil
 }
 

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -404,9 +404,10 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		logForwarderName: ifFullyUpgraded(logforwarder.Manifold(logforwarder.ManifoldConfig{
 			StateName:     stateName,
 			APICallerName: apiCallerName,
-			SinkOpeners: []logforwarder.LogSinkFn{
-				sinks.OpenSyslog,
-			},
+			Sinks: []logforwarder.LogSinkSpec{{
+				Name:   "juju-log-forward",
+				OpenFn: sinks.OpenSyslog,
+			}},
 		})),
 	}
 }

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -125,6 +125,9 @@ const (
 	// is primarily for enabling Juju to work cleanly in a closed network.
 	CloudImageBaseURL = "cloudimg-base-url"
 
+	// LogForwardEnabled determines whether the log forward functionality is enabled.
+	LogForwardEnabled = "logforward-enabled"
+
 	// LogFwdSyslogHost sets the hostname:port of the syslog server.
 	LogFwdSyslogHost = "syslog-host"
 
@@ -650,6 +653,11 @@ func (c *Config) LogFwdSyslog() (*syslog.RawConfig, bool) {
 	partial := false
 	var lfCfg syslog.RawConfig
 
+	if s, ok := c.defined[LogForwardEnabled]; ok {
+		partial = true
+		lfCfg.Enabled = s.(bool)
+	}
+
 	if s, ok := c.defined[LogFwdSyslogHost]; ok && s != "" {
 		partial = true
 		lfCfg.Host = s.(string)
@@ -952,6 +960,7 @@ var alwaysOptional = schema.Defaults{
 	"bootstrap-timeout":          schema.Omit,
 	"bootstrap-retry-delay":      schema.Omit,
 	"bootstrap-addresses-delay":  schema.Omit,
+	LogForwardEnabled:            schema.Omit,
 	LogFwdSyslogHost:             schema.Omit,
 	LogFwdSyslogCACert:           schema.Omit,
 	LogFwdSyslogClientCert:       schema.Omit,
@@ -1347,8 +1356,13 @@ global or per instance security groups.`,
 		Type:        environschema.Tattrs,
 		Group:       environschema.EnvironGroup,
 	},
+	LogForwardEnabled: {
+		Description: `Whether syslog forwarding is enabled.`,
+		Type:        environschema.Tbool,
+		Group:       environschema.EnvironGroup,
+	},
 	LogFwdSyslogHost: {
-		Description: `LogFwdSyslogHost specifies the hostname:port of the syslog server.`,
+		Description: `The hostname:port of the syslog server.`,
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -636,6 +636,7 @@ var configTests = []configTest{
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"type":               "my-type",
 			"name":               "my-name",
+			"logforward-enabled": true,
 			"syslog-host":        "localhost:1234",
 			"syslog-ca-cert":     "abc",
 			"syslog-client-cert": caCert,
@@ -648,6 +649,7 @@ var configTests = []configTest{
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"type":               "my-type",
 			"name":               "my-name",
+			"logforward-enabled": true,
 			"syslog-host":        "localhost:1234",
 			"syslog-ca-cert":     invalidCACert,
 			"syslog-client-cert": caCert,
@@ -658,6 +660,7 @@ var configTests = []configTest{
 		about:       "invalid syslog cert",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
+			"logforward-enabled": true,
 			"syslog-host":        "10.0.0.1:12345",
 			"syslog-ca-cert":     caCert,
 			"syslog-client-cert": invalidCACert,
@@ -668,6 +671,7 @@ var configTests = []configTest{
 		about:       "invalid syslog key",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
+			"logforward-enabled": true,
 			"syslog-host":        "10.0.0.1:12345",
 			"syslog-ca-cert":     caCert,
 			"syslog-client-cert": caCert,
@@ -678,6 +682,7 @@ var configTests = []configTest{
 		about:       "Mismatched syslog cert and key",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
+			"logforward-enabled": true,
 			"syslog-host":        "10.0.0.1:12345",
 			"syslog-ca-cert":     caCert,
 			"syslog-client-cert": caCert,
@@ -690,6 +695,7 @@ var configTests = []configTest{
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"type":               "my-type",
 			"name":               "my-name",
+			"logforward-enabled": true,
 			"syslog-host":        "localhost:1234",
 			"syslog-ca-cert":     testing.CACert,
 			"syslog-client-cert": testing.ServerCert,
@@ -951,6 +957,10 @@ func (test configTest) check(c *gc.C, home *gitjujutesting.FakeHome) {
 	c.Assert(cfg.AuthorizedKeys(), gc.Equals, keys)
 
 	lfCfg, hasLogCfg := cfg.LogFwdSyslog()
+	if v, ok := test.attrs["logforward-enabled"].(bool); ok {
+		c.Assert(hasLogCfg, jc.IsTrue)
+		c.Assert(lfCfg.Enabled, gc.Equals, v)
+	}
 	if v, ok := test.attrs["syslog-ca-cert"].(string); v != "" {
 		c.Assert(hasLogCfg, jc.IsTrue)
 		c.Assert(lfCfg.CACert, gc.Equals, v)

--- a/featuretests/syslog_test.go
+++ b/featuretests/syslog_test.go
@@ -34,7 +34,6 @@ import (
 
 type syslogSuite struct {
 	agenttest.AgentSuite
-	server          *rfc5424test.Server
 	logsCh          logsender.LogRecordCh
 	received        chan rfc5424test.Message
 	fakeEnsureMongo *agenttest.FakeEnsureMongo
@@ -65,6 +64,38 @@ func (s *syslogSuite) SetUpSuite(c *gc.C) {
 	})
 }
 
+func (s *syslogSuite) createSyslogServer(c *gc.C, received chan rfc5424test.Message, done chan struct{}) string {
+	server := rfc5424test.NewServer(rfc5424test.HandlerFunc(func(msg rfc5424test.Message) {
+		select {
+		case received <- msg:
+		case <-done:
+		}
+	}))
+	s.AddCleanup(func(*gc.C) { server.Close() })
+	s.AddCleanup(func(*gc.C) { close(done) })
+
+	serverCert, err := tls.X509KeyPair(
+		[]byte(coretesting.ServerCert),
+		[]byte(coretesting.ServerKey),
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	caCert, err := cert.ParseCert(coretesting.CACert)
+	c.Assert(err, jc.ErrorIsNil)
+	clientCAs := x509.NewCertPool()
+	clientCAs.AddCert(caCert)
+	server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientCAs:    clientCAs,
+	}
+	server.StartTLS()
+
+	// We must use "localhost", as the certificate does not
+	// have any IP SANs.
+	port := server.Listener.Addr().(*net.TCPAddr).Port
+	addr := net.JoinHostPort("localhost", fmt.Sprint(port))
+	return addr
+}
+
 func (s *syslogSuite) SetUpTest(c *gc.C) {
 	if runtime.GOOS != "linux" {
 		c.Skip(fmt.Sprintf("this test requires a controller, therefore does not support %q", runtime.GOOS))
@@ -84,35 +115,10 @@ func (s *syslogSuite) SetUpTest(c *gc.C) {
 
 	done := make(chan struct{})
 	s.received = make(chan rfc5424test.Message)
-	s.server = rfc5424test.NewServer(rfc5424test.HandlerFunc(func(msg rfc5424test.Message) {
-		select {
-		case s.received <- msg:
-		case <-done:
-		}
-	}))
-	s.AddCleanup(func(*gc.C) { s.server.Close() })
-	s.AddCleanup(func(*gc.C) { close(done) })
+	addr := s.createSyslogServer(c, s.received, done)
 
-	serverCert, err := tls.X509KeyPair(
-		[]byte(coretesting.ServerCert),
-		[]byte(coretesting.ServerKey),
-	)
-	c.Assert(err, jc.ErrorIsNil)
-	caCert, err := cert.ParseCert(coretesting.CACert)
-	c.Assert(err, jc.ErrorIsNil)
-	clientCAs := x509.NewCertPool()
-	clientCAs.AddCert(caCert)
-	s.server.TLS = &tls.Config{
-		Certificates: []tls.Certificate{serverCert},
-		ClientCAs:    clientCAs,
-	}
-	s.server.StartTLS()
-
-	// We must use "localhost", as the certificate does not
-	// have any IP SANs.
-	port := s.server.Listener.Addr().(*net.TCPAddr).Port
-	addr := net.JoinHostPort("localhost", fmt.Sprint(port))
-
+	// Leave log forwarding disabled initially, it will be enabled
+	// via a model config update in the test.
 	err = s.State.UpdateModelConfig(map[string]interface{}{
 		"syslog-host":        addr,
 		"syslog-ca-cert":     coretesting.CACert,
@@ -143,13 +149,13 @@ func (s *syslogSuite) sendRecord(c *gc.C, rec *logsender.LogRecord) {
 	}
 }
 
-func (s *syslogSuite) popMessagesUntil(c *gc.C, expected string) rfc5424test.Message {
+func (s *syslogSuite) popMessagesUntil(c *gc.C, expected string, received chan rfc5424test.Message) rfc5424test.Message {
 	re, err := regexp.Compile(expected)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Logf("popping messages")
 	for {
-		msg := s.nextMessage(c)
+		msg := s.nextMessage(c, received)
 		c.Logf("message: %+v", msg)
 		if re.MatchString(msg.Message) {
 			return msg
@@ -157,15 +163,31 @@ func (s *syslogSuite) popMessagesUntil(c *gc.C, expected string) rfc5424test.Mes
 	}
 }
 
-func (s *syslogSuite) nextMessage(c *gc.C) rfc5424test.Message {
+func (s *syslogSuite) nextMessage(c *gc.C, received chan rfc5424test.Message) rfc5424test.Message {
 	select {
-	case msg, ok := <-s.received:
+	case msg, ok := <-received:
 		c.Assert(ok, jc.IsTrue)
 		return msg
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("timed out waiting for message to be forwarded")
 	}
 	return rfc5424test.Message{}
+}
+
+func (s *syslogSuite) assertLogRecordForwarded(c *gc.C, received chan rfc5424test.Message) {
+	// Pop off all initial log records.
+	s.sendRecord(c, s.newRecord("<stop here>"))
+	s.popMessagesUntil(c, `.*<stop here>`, received)
+
+	// Ensure that a specific log record gets forwarded.
+	rec := s.newRecord("something happened!")
+	rec.Time = time.Date(2099, time.June, 1, 23, 2, 1, 23, time.UTC)
+	s.sendRecord(c, rec)
+	msg := s.popMessagesUntil(c, `something happened!`, received)
+	expected := `<11>1 2099-06-01T23:02:01.000000023Z machine-0.%s jujud-machine-agent-%s - - [origin enterpriseID="28978" sofware="jujud-machine-agent" swVersion="%s"][model@28978 controller-uuid="%s" model-uuid="%s"][log@28978 module="juju.featuretests.syslog" source="syslog_test.go:99999"] something happened!`
+	modelID := coretesting.ModelTag.Id()
+	ctlrID := modelID
+	c.Check(msg.Message, gc.Equals, fmt.Sprintf(expected, modelID, modelID[:28], version.Current, ctlrID, modelID))
 }
 
 func (s *syslogSuite) TestLogRecordForwarded(c *gc.C) {
@@ -187,17 +209,44 @@ func (s *syslogSuite) TestLogRecordForwarded(c *gc.C) {
 	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
 	defer a.Stop()
 
-	// Pop off all initial log records.
-	s.sendRecord(c, s.newRecord("<stop here>"))
-	s.popMessagesUntil(c, `.*<stop here>`)
+	err := s.State.UpdateModelConfig(map[string]interface{}{
+		"logforward-enabled": true,
+	}, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
 
-	// Ensure that a specific log record gets forwarded.
-	rec := s.newRecord("something happened!")
-	rec.Time = time.Date(2099, time.June, 1, 23, 2, 1, 23, time.UTC)
-	s.sendRecord(c, rec)
-	msg := s.popMessagesUntil(c, `something happened!`)
-	expected := `<11>1 2099-06-01T23:02:01.000000023Z machine-0.%s jujud-machine-agent-%s - - [origin enterpriseID="28978" sofware="jujud-machine-agent" swVersion="%s"][model@28978 controller-uuid="%s" model-uuid="%s"][log@28978 module="juju.featuretests.syslog" source="syslog_test.go:99999"] something happened!`
-	modelID := coretesting.ModelTag.Id()
-	ctlrID := modelID
-	c.Check(msg.Message, gc.Equals, fmt.Sprintf(expected, modelID, modelID[:28], version.Current, ctlrID, modelID))
+	s.assertLogRecordForwarded(c, s.received)
+}
+
+func (s *syslogSuite) TestConfigChange(c *gc.C) {
+	// Create a machine and an agent for it.
+	m, password := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{
+		Nonce: agent.BootstrapNonce,
+		Jobs:  []state.MachineJob{state.JobManageModel},
+	})
+
+	s.PrimeAgent(c, m.Tag(), password)
+	agentConf := agentcmd.NewAgentConf(s.DataDir())
+	agentConf.ReadConfig(m.Tag().String())
+
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, s.logsCh, c.MkDir())
+	a := machineAgentFactory(m.Id())
+
+	// Ensure there's no logs to begin with.
+	// Start the agent.
+	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
+	defer a.Stop()
+
+	done := make(chan struct{})
+	received := make(chan rfc5424test.Message)
+	addr := s.createSyslogServer(c, received, done)
+
+	err := s.State.UpdateModelConfig(map[string]interface{}{
+		"logforward-enabled": true,
+		"syslog-host":        addr,
+		"syslog-ca-cert":     coretesting.CACert,
+		"syslog-client-cert": coretesting.ServerCert,
+		"syslog-client-key":  coretesting.ServerKey,
+	}, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertLogRecordForwarded(c, received)
 }

--- a/logfwd/syslog/client_test.go
+++ b/logfwd/syslog/client_test.go
@@ -40,6 +40,7 @@ func (s *ClientSuite) SetUpTest(c *gc.C) {
 
 func (s *ClientSuite) TestOpen(c *gc.C) {
 	cfg := syslog.RawConfig{
+		Enabled:    true,
 		Host:       "a.b.c:9876",
 		CACert:     coretesting.CACert,
 		ClientCert: coretesting.ServerCert,

--- a/logfwd/syslog/config.go
+++ b/logfwd/syslog/config.go
@@ -15,6 +15,9 @@ import (
 // RawConfig holds the raw configuration data for a connection to a
 // syslog forwarding target.
 type RawConfig struct {
+	// Enabled is true if the log forwarding feature is enabled.
+	Enabled bool
+
 	// Host is the host-port of the syslog host. The format is:
 	//
 	//   [domain-or-ip-addr] or [domain-or-ip-addr][:port]

--- a/worker/logforwarder/logforwarder_test.go
+++ b/worker/logforwarder/logforwarder_test.go
@@ -12,9 +12,13 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/logfwd"
+	"github.com/juju/juju/logfwd/syslog"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
+	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/logforwarder"
 	"github.com/juju/juju/worker/workertest"
@@ -58,7 +62,7 @@ func (s *LogForwarderSuite) SetUpTest(c *gc.C) {
 			Filename: "test.go",
 			Line:     42,
 		},
-		Message: "test message",
+		Message: "send to 10.0.0.1",
 	}
 }
 
@@ -85,23 +89,132 @@ func (s *LogForwarderSuite) checkClose(c *gc.C, lf worker.Worker, expected error
 	s.stub.CheckCallNames(c, "Close")
 }
 
+type mockLogForwardConfig struct {
+	enabled bool
+	host    string
+	changes chan struct{}
+}
+
+type mockWatcher struct {
+	watcher.NotifyWatcher
+	changes chan struct{}
+}
+
+func (m *mockWatcher) Changes() watcher.NotifyChannel {
+	return m.changes
+}
+
+func (*mockWatcher) Kill() {
+}
+
+func (*mockWatcher) Wait() error {
+	return nil
+}
+
+type mockCaller struct {
+	base.APICaller
+}
+
+func (*mockCaller) APICall(objType string, version int, id, request string, params, response interface{}) error {
+	return nil
+}
+
+func (*mockCaller) BestFacadeVersion(facade string) int {
+	return 0
+}
+
+func (c *mockLogForwardConfig) WatchForLogForwardConfigChanges() (watcher.NotifyWatcher, error) {
+	c.changes = make(chan struct{}, 1)
+	c.changes <- struct{}{}
+	return &mockWatcher{
+		changes: c.changes,
+	}, nil
+}
+
+func (c *mockLogForwardConfig) LogForwardConfig() (*syslog.RawConfig, bool, error) {
+	return &syslog.RawConfig{
+		Enabled:    c.enabled,
+		Host:       c.host,
+		CACert:     coretesting.CACert,
+		ClientCert: coretesting.ServerCert,
+		ClientKey:  coretesting.ServerKey,
+	}, true, nil
+}
+
+func (s *LogForwarderSuite) newLogForwarderArgs(c *gc.C, stream logforwarder.LogStream, sender *stubSender) logforwarder.OpenLogForwarderArgs {
+	api := &mockLogForwardConfig{
+		enabled: stream != nil,
+		host:    "10.0.0.1",
+	}
+	return s.newLogForwarderArgsWithAPI(c, api, stream, sender)
+}
+
+func (s *LogForwarderSuite) newLogForwarderArgsWithAPI(c *gc.C, configAPI logforwarder.LogForwardConfig, stream logforwarder.LogStream, sender *stubSender) logforwarder.OpenLogForwarderArgs {
+	return logforwarder.OpenLogForwarderArgs{
+		Caller:           &mockCaller{},
+		LogForwardConfig: configAPI,
+		AllModels:        true,
+		ControllerUUID:   "feebdaed-2f18-4fd2-967d-db9663db7bea",
+		OpenSink: func(cfg *syslog.RawConfig) (*logforwarder.LogSink, error) {
+			sender.host = cfg.Host
+			sink := &logforwarder.LogSink{
+				sender,
+			}
+			return sink, nil
+		},
+		OpenLogStream: func(_ base.APICaller, _ params.LogStreamConfig, controllerUUID string) (logforwarder.LogStream, error) {
+			c.Assert(controllerUUID, gc.Equals, "feebdaed-2f18-4fd2-967d-db9663db7bea")
+			return stream, nil
+		},
+	}
+}
+
 func (s *LogForwarderSuite) TestOne(c *gc.C) {
 	s.stream.setRecords(c, []logfwd.Record{
 		s.rec,
 	})
 
-	lf, err := logforwarder.NewLogForwarder(s.stream, s.sender)
+	lf, err := logforwarder.NewLogForwarder(s.newLogForwarderArgs(c, s.stream, s.sender))
 	c.Assert(err, jc.ErrorIsNil)
 	defer s.checkClose(c, lf, nil)
 
 	s.checkNext(c, s.rec)
 }
 
-func (s *LogForwarderSuite) TestNoStream(c *gc.C) {
-	lf, err := logforwarder.NewLogForwarder(nil, s.sender)
-	c.Assert(err, jc.ErrorIsNil)
+func (s *LogForwarderSuite) TestConfigChange(c *gc.C) {
+	rec2 := s.rec
+	rec2.ID = 11
+	s.stream.setRecords(c, []logfwd.Record{
+		s.rec,
+		rec2,
+	})
 
-	s.checkClose(c, lf, nil)
+	api := &mockLogForwardConfig{
+		enabled: true,
+		host:    "10.0.0.1",
+	}
+	lf, err := logforwarder.NewLogForwarder(s.newLogForwarderArgsWithAPI(c, api, s.stream, s.sender))
+	c.Assert(err, jc.ErrorIsNil)
+	defer s.checkClose(c, lf, nil)
+
+	s.checkNext(c, s.rec)
+
+	api.host = "10.0.0.2"
+	api.changes <- struct{}{}
+	s.sender.waitBeforeClose(c)
+	s.stream.waitBeforeNext(c)
+	s.stream.waitAfterNext(c)
+	s.sender.waitAfterSend(c)
+	s.stub.CheckCallNames(c, "Close", "Next", "Send")
+	rec2.Message = "send to 10.0.0.2"
+	s.stub.CheckCall(c, 2, "Send", rec2)
+	s.stub.ResetCalls()
+}
+
+func (s *LogForwarderSuite) TestNotEnabled(c *gc.C) {
+	lf, err := logforwarder.NewLogForwarder(s.newLogForwarderArgs(c, nil, s.sender))
+	c.Assert(err, jc.ErrorIsNil)
+	workertest.CleanKill(c, lf)
 }
 
 func (s *LogForwarderSuite) TestStreamError(c *gc.C) {
@@ -110,7 +223,7 @@ func (s *LogForwarderSuite) TestStreamError(c *gc.C) {
 	s.stream.setRecords(c, []logfwd.Record{
 		s.rec,
 	})
-	lf, err := logforwarder.NewLogForwarder(s.stream, s.sender)
+	lf, err := logforwarder.NewLogForwarder(s.newLogForwarderArgs(c, s.stream, s.sender))
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.checkNext(c, s.rec)
@@ -130,7 +243,7 @@ func (s *LogForwarderSuite) TestSenderError(c *gc.C) {
 		s.rec,
 		rec2,
 	})
-	lf, err := logforwarder.NewLogForwarder(s.stream, s.sender)
+	lf, err := logforwarder.NewLogForwarder(s.newLogForwarderArgs(c, s.stream, s.sender))
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.checkNext(c, s.rec)
@@ -198,6 +311,7 @@ func (s *stubStream) Next() (logfwd.Record, error) {
 type stubSender struct {
 	stub *testing.Stub
 
+	host        string
 	waitSendCh  chan struct{}
 	waitCloseCh chan struct{}
 }
@@ -227,7 +341,9 @@ func (s *stubSender) waitBeforeClose(c *gc.C) {
 }
 
 func (s *stubSender) Send(rec logfwd.Record) error {
-	s.stub.AddCall("Send", rec)
+	toSend := rec
+	toSend.Message = "send to " + s.host
+	s.stub.AddCall("Send", toSend)
 	s.waitSendCh <- struct{}{}
 	if err := s.stub.NextErr(); err != nil {
 		return errors.Trace(err)

--- a/worker/logforwarder/sink.go
+++ b/worker/logforwarder/sink.go
@@ -5,21 +5,31 @@ package logforwarder
 
 import (
 	"github.com/juju/juju/logfwd/syslog"
+	"github.com/juju/juju/watcher"
 )
 
-// LoggingConfig is the logging config for a model (or controller).
-type LoggingConfig interface {
-	// LogFwdSyslog returns the syslog forwarding config.
-	LogFwdSyslog() (*syslog.RawConfig, bool)
+// LogForwardConfig provides access to the log forwarding config for a model.
+type LogForwardConfig interface {
+	// WatchForLogForwardConfigChanges return a NotifyWatcher waiting for the
+	// log forward configuration to change.
+	WatchForLogForwardConfigChanges() (watcher.NotifyWatcher, error)
+
+	// LogForwardConfig returns the current log forward configuration.
+	LogForwardConfig() (*syslog.RawConfig, bool, error)
+}
+
+type LogSinkSpec struct {
+	// Name is the name of the log sink.
+	Name string
+
+	// OpenFn is a function that opens a log sink.
+	OpenFn LogSinkFn
 }
 
 // LogSinkFn is a function that opens a log sink.
-type LogSinkFn func(LoggingConfig) (*LogSink, error)
+type LogSinkFn func(cfg *syslog.RawConfig) (*LogSink, error)
 
 // LogSink is a single log sink, to which log records may be sent.
 type LogSink struct {
 	SendCloser
-
-	// Name is the name of the sink.
-	Name string
 }

--- a/worker/logforwarder/tracker.go
+++ b/worker/logforwarder/tracker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/api/base"
 	logfwdapi "github.com/juju/juju/api/logfwd"
 	"github.com/juju/juju/logfwd"
+	"github.com/juju/juju/logfwd/syslog"
 )
 
 // TrackingSinkArgs holds the args to OpenTrackingSender.
@@ -18,10 +19,13 @@ type TrackingSinkArgs struct {
 	AllModels bool
 
 	// Config is the logging config that will be used.
-	Config LoggingConfig
+	Config *syslog.RawConfig
 
 	// Caller is the API caller that will be used.
 	Caller base.APICaller
+
+	// Name is the name given to the log sink.
+	Name string
 
 	// OpenSink is the function that opens the underlying log sink that
 	// will be wrapped.
@@ -39,9 +43,8 @@ func OpenTrackingSink(args TrackingSinkArgs) (*LogSink, error) {
 	return &LogSink{
 		&trackingSender{
 			SendCloser: sink,
-			tracker:    newLastSentTracker(sink.Name, args.Caller),
+			tracker:    newLastSentTracker(args.Name, args.Caller),
 		},
-		sink.Name,
 	}, nil
 }
 


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1598289
Fixes: https://bugs.launchpad.net/juju-core/+bug/1598293

Fixes several issues with syslog forwarding. The main fixes are to add a syslog-enabled config attribute to allow the feature to be toggled on/off; also, any config updates are now acted on by the worker which does the forwarding. If invalid config is set, the worker will log this and wait for new config to arrive. In addition, access to controller config was provided to the worker so that the controller uuid can be got directly rather than assuming it is the same as the controller model uuid.

(Review request: http://reviews.vapour.ws/r/5223/)