### PR TITLE
Sort device links as well as device names to reduce log noise

### DIFF
--- a/storage/path_test.go
+++ b/storage/path_test.go
@@ -37,3 +37,24 @@ func testBlockDevicePath(c *gc.C, dev storage.BlockDevice, expect string) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(path, jc.SamePath, expect)
 }
+
+func (s *BlockDevicePathSuite) TestSortBlockDevices(c *gc.C) {
+	devices := []storage.BlockDevice{{
+		DeviceName:  "sdb",
+		DeviceLinks: []string{"by-b", "by-a"},
+	}, {
+		DeviceName:  "sda",
+		DeviceLinks: []string{"by-c", "by-d"},
+	}}
+	storage.SortBlockDevices(devices)
+
+	expected := []storage.BlockDevice{{
+		DeviceName:  "sda",
+		DeviceLinks: []string{"by-c", "by-d"},
+	}, {
+		DeviceName:  "sdb",
+		DeviceLinks: []string{"by-a", "by-b"},
+	}}
+
+	c.Assert(devices, jc.DeepEquals, expected)
+}

--- a/storage/sort.go
+++ b/storage/sort.go
@@ -8,6 +8,10 @@ import "sort"
 // SortBlockDevices sorts block devices by device name.
 func SortBlockDevices(devices []BlockDevice) {
 	sort.Sort(byDeviceName(devices))
+
+	for i := range devices {
+		sort.Strings(devices[i].DeviceLinks)
+	}
 }
 
 type byDeviceName []BlockDevice


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/juju-core/+bug/1600539

We detect block device changes by performing a reflect.DeepEqual. We were sorting the list of block devices by DeviceName to keep that list consistent, we weren't sorting its members. This change also sorts the DeviceLinks list, which eliminates any false block device change detections.

(Review request: http://reviews.vapour.ws/r/5226/)