### PR TITLE
lp1577949: Don't set password if unit installed

### DIFF
--- a/cmd/jujud/agent/deploy_test.go
+++ b/cmd/jujud/agent/deploy_test.go
@@ -32,6 +32,10 @@ type fakeContext struct {
 	inited      chan struct{}
 }
 
+func (ctx *fakeContext) IsUnitInstalled(unitName string) (bool, error) {
+	return false, nil
+}
+
 func (ctx *fakeContext) DeployUnit(unitName, _ string) error {
 	ctx.mu.Lock()
 	ctx.deployed.Add(unitName)

--- a/worker/deployer/deployer_test.go
+++ b/worker/deployer/deployer_test.go
@@ -14,6 +14,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	apideployer "github.com/juju/juju/api/deployer"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -264,4 +265,49 @@ func isRemoved(st *state.State, name string) func(*gc.C) bool {
 
 func stop(c *gc.C, w worker.Worker) {
 	c.Assert(worker.Stop(w), gc.IsNil)
+}
+
+type fakeContext struct {
+	deployer.Context
+	agentConfig agent.Config
+}
+
+func (ctx *fakeContext) IsUnitInstalled(unitName string) (bool, error) {
+	return true, nil
+}
+
+func (ctx *fakeContext) DeployedUnits() ([]string, error) {
+	return []string{}, nil
+}
+
+func (ctx *fakeContext) AgentConfig() agent.Config {
+	return ctx.agentConfig
+}
+
+func (s *deployerSuite) TestDeployFailsWhenUnitAlreadyInstalled(c *gc.C) {
+	// Add a new unit and assign to machine
+	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	u, err := svc.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	err = u.AssignToMachine(s.machine)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Make deployer with our mocked out context
+	ctx := &fakeContext{agentConfig: agentConfig(s.machine.Tag(), s.dataDir, s.logDir)}
+	dep := deployer.NewDeployer(s.deployerState, ctx)
+
+	// Wait for the worker to error out.
+	done := make(chan error)
+	go func() {
+		done <- dep.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		c.Check(err, gc.ErrorMatches, `unit "wordpress/0" is already installed`)
+	case <-time.After(coretesting.ShortWait):
+		c.Errorf("timed out waiting for worker to error")
+		dep.Kill()
+	}
+
 }

--- a/worker/deployer/simple.go
+++ b/worker/deployer/simple.go
@@ -86,6 +86,20 @@ func (ctx *SimpleContext) AgentConfig() agent.Config {
 	return ctx.agentConfig
 }
 
+// IsUnitInstalled returns whether or not the service for the specified
+// unit is installed.
+func (ctx *SimpleContext) IsUnitInstalled(unitName string) (bool, error) {
+	renderer, err := shell.NewRenderer("")
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	svc, err := ctx.service(unitName, renderer)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	return svc.Installed()
+}
+
 func (ctx *SimpleContext) DeployUnit(unitName, initialPassword string) (err error) {
 	// Check sanity.
 	renderer, err := shell.NewRenderer("")


### PR DESCRIPTION
When we switched to building with go 1.6 for all
agents, there was a problem where windows unit agents
could not upgrade.  The issue was that the windows
services for the unit agents did not show up in results
from ListServices immediately after the upgrade.

This resulted in the machine agent thinking the units
were not deployed and it would reset the password for the
unit agent, but then fail to deploy the unit because it
was already installed.  The unit agent would then fail to
log in as its password had been reset.

For 1.25.6, this patch re-checks that the service is
not installed immediately before resetting the password
for the unit.  This change has been tested in CI and I
verified that the problem recreated and this patch fixed
the issue.

This patch does not eliminate the timing window where
this occurs, but shortens it significantly.

For later releases, we need to determine why ListServices
is racy and has a window where it doesn't return the juju
services that are installed.