### PR TITLE
Allow gui required methods in RO user.

### DIFF
--- a/apiserver/read_only_calls.go
+++ b/apiserver/read_only_calls.go
@@ -18,6 +18,7 @@ var readOnlyCalls = set.NewStrings(
 	"Action.ListRunning",
 	"Action.ListCompleted",
 	"Action.ApplicationsCharmsActions",
+	"AllWatcher.Next",
 	"Annotations.Get",
 	"Application.GetConstraints",
 	"Application.CharmRelations",
@@ -50,6 +51,7 @@ var readOnlyCalls = set.NewStrings(
 	// TODO: add controller work.
 	"KeyManager.ListKeys",
 	"ModelManager.ModelInfo",
+	"Pinger.Ping",
 	"Spaces.ListSpaces",
 	"Storage.ListStorageDetails",
 	"Storage.ListFilesystems",


### PR DESCRIPTION
Read Only users where lacking AllWatcher and Pinger methods
rendering the GUI unusable, this was fixed.
The bug for this issue is lp:1599402

(Review request: http://reviews.vapour.ws/r/5228/)