### PR TITLE
Fix test race in LogStreamIntSuite.TestFullRequest

### DIFF
--- a/apiserver/logstream_test.go
+++ b/apiserver/logstream_test.go
@@ -142,9 +142,10 @@ func (s *LogStreamIntSuite) TestFullRequest(c *gc.C) {
 	// Stream out the results from the client. This whole block is
 	// just scaffolding to get the results back out on the records
 	// channel, and should probably be replaced by something more
-	// direct. (Does it *really* need its own goroutine?)
+	// direct. The goroutine is needed here because the JSON Receive
+	// call will block waiting on the server to send the next message.
 	clientDone := make(chan struct{})
-	records := make(chan params.LogStreamRecord, 1000)
+	records := make(chan params.LogStreamRecord)
 	go func() {
 		defer close(clientDone)
 


### PR DESCRIPTION
LogStreamIntSuite.TestFullRequest wasn't waiting for the reader
goroutine to complete before returning from the test method; so, if its
websocket receive ended with a *net.OpError ("use of closed connection",
I think?) rather than the expected io.EOF, it would fail the *gc.C after
it was effectively out of scope.

fixes-1596493

(Review request: http://reviews.vapour.ws/r/5230/)