### PR TITLE
Do not open new state for each SetLastSend api call

### DIFF
--- a/api/logfwd/lastsent.go
+++ b/api/logfwd/lastsent.go
@@ -93,9 +93,9 @@ func (c LastSentClient) GetList(ids []LastSentID) ([]LastSentResult, error) {
 	return results, nil
 }
 
-// SetList makes a "SetLastSent" call on the facade and returns the
+// SetLastSent makes a "SetLastSent" call on the facade and returns the
 // results in the same order.
-func (c LastSentClient) SetList(reqs []LastSentInfo) ([]LastSentResult, error) {
+func (c LastSentClient) SetLastSent(reqs []LastSentInfo) ([]LastSentResult, error) {
 	var args params.LogForwardingSetLastSentParams
 	args.Params = make([]params.LogForwardingSetLastSentParam, len(reqs))
 	for i, req := range reqs {

--- a/api/logfwd/lastsent_test.go
+++ b/api/logfwd/lastsent_test.go
@@ -111,7 +111,7 @@ func (s *LastSentSuite) TestSetLastSent(c *gc.C) {
 	model := "deadbeef-2f18-4fd2-967d-db9663db7bea"
 	modelTag := names.NewModelTag(model)
 
-	results, err := client.SetList([]logfwd.LastSentInfo{{
+	results, err := client.SetLastSent([]logfwd.LastSentInfo{{
 		LastSentID: logfwd.LastSentID{
 			Model: modelTag,
 			Sink:  "spam",

--- a/apiserver/logfwd/lastsent_test.go
+++ b/apiserver/logfwd/lastsent_test.go
@@ -79,7 +79,7 @@ func (s *LastSentSuite) TestGetLastSentBulk(c *gc.C) {
 	trackerEggs := s.state.addTracker()
 	trackerEggs.ReturnGet = 20
 	s.state.addTracker() // ham
-	s.stub.SetErrors(nil, nil, nil, nil, nil, nil, nil, state.ErrNeverForwarded)
+	s.stub.SetErrors(nil, nil, nil, nil, state.ErrNeverForwarded)
 	api, err := logfwd.NewLogForwardingAPI(s.state, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 	model := "deadbeef-2f18-4fd2-967d-db9663db7bea"
@@ -152,7 +152,7 @@ func (s *LastSentSuite) TestSetLastSentBulk(c *gc.C) {
 	s.state.addTracker() // eggs
 	s.state.addTracker() // ham
 	failure := errors.New("<failed>")
-	s.stub.SetErrors(nil, nil, nil, nil, failure)
+	s.stub.SetErrors(nil, nil, failure)
 	api, err := logfwd.NewLogForwardingAPI(s.state, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 	model := "deadbeef-2f18-4fd2-967d-db9663db7bea"
@@ -214,18 +214,14 @@ func (s *stubState) addTracker() *stubTracker {
 	return tracker
 }
 
-func (s *stubState) NewLastSentTracker(tag names.ModelTag, sink string) (logfwd.LastSentTracker, error) {
+func (s *stubState) NewLastSentTracker(tag names.ModelTag, sink string) logfwd.LastSentTracker {
 	s.stub.AddCall("NewLastSentTracker", tag, sink)
-	if err := s.stub.NextErr(); err != nil {
-		return nil, err
-	}
-
 	if len(s.ReturnNewLastSentTracker) == 0 {
 		panic("ran out of trackers")
 	}
 	tracker := s.ReturnNewLastSentTracker[0]
 	s.ReturnNewLastSentTracker = s.ReturnNewLastSentTracker[1:]
-	return tracker, nil
+	return tracker
 }
 
 type stubTracker struct {

--- a/apiserver/logstream_test.go
+++ b/apiserver/logstream_test.go
@@ -87,19 +87,20 @@ func (s *LogStreamIntSuite) TestFullRequest(c *gc.C) {
 	// (It would be better to create those records explicitly --
 	// this is altogether too close to a violation of don't-copy-
 	// the-implementation-into-the-tests.)
-	var expected []params.LogStreamRecord
+	var expected []params.LogStreamRecords
 	for _, rec := range logs {
-		expected = append(expected, params.LogStreamRecord{
-			ID:        rec.ID,
-			ModelUUID: rec.ModelUUID,
-			Entity:    rec.Entity.String(),
-			Version:   version.Current.String(),
-			Timestamp: rec.Time,
-			Module:    rec.Module,
-			Location:  rec.Location,
-			Level:     rec.Level.String(),
-			Message:   rec.Message,
-		})
+		expected = append(expected, params.LogStreamRecords{
+			Records: []params.LogStreamRecord{{
+				ID:        rec.ID,
+				ModelUUID: rec.ModelUUID,
+				Entity:    rec.Entity.String(),
+				Version:   version.Current.String(),
+				Timestamp: rec.Time,
+				Module:    rec.Module,
+				Location:  rec.Location,
+				Level:     rec.Level.String(),
+				Message:   rec.Message,
+			}}})
 	}
 
 	// Create a tailer that will supply the source log records,
@@ -145,7 +146,7 @@ func (s *LogStreamIntSuite) TestFullRequest(c *gc.C) {
 	// direct. The goroutine is needed here because the JSON Receive
 	// call will block waiting on the server to send the next message.
 	clientDone := make(chan struct{})
-	records := make(chan params.LogStreamRecord)
+	records := make(chan params.LogStreamRecords)
 	go func() {
 		defer close(clientDone)
 
@@ -154,7 +155,7 @@ func (s *LogStreamIntSuite) TestFullRequest(c *gc.C) {
 		ok := c.Check(err, jc.ErrorIsNil)
 		if ok && c.Check(result, jc.DeepEquals, params.ErrorResult{}) {
 			for {
-				var apiRec params.LogStreamRecord
+				var apiRec params.LogStreamRecords
 				err = websocket.JSON.Receive(client, &apiRec)
 				if err != nil {
 					break

--- a/apiserver/params/logstream.go
+++ b/apiserver/params/logstream.go
@@ -7,6 +7,11 @@ import (
 	"time"
 )
 
+// LogStreamRecord contains a slice of LogStreamRecords.
+type LogStreamRecords struct {
+	Records []LogStreamRecord `json:"records"`
+}
+
 // LogStreamRecord describes a single log record being streamed from
 // the server.
 type LogStreamRecord struct {

--- a/logfwd/syslog/client.go
+++ b/logfwd/syslog/client.go
@@ -99,13 +99,15 @@ func (client Client) Close() error {
 }
 
 // Send sends the record to the remote syslog host.
-func (client Client) Send(rec logfwd.Record) error {
-	msg, err := messageFromRecord(rec)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if err := client.Sender.Send(msg); err != nil {
-		return errors.Trace(err)
+func (client Client) Send(records []logfwd.Record) error {
+	for _, rec := range records {
+		msg, err := messageFromRecord(rec)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if err := client.Sender.Send(msg); err != nil {
+			return errors.Trace(err)
+		}
 	}
 	return nil
 }

--- a/logfwd/syslog/client_test.go
+++ b/logfwd/syslog/client_test.go
@@ -97,7 +97,7 @@ func (s *ClientSuite) TestSendLogFull(c *gc.C) {
 	}
 	client := syslog.Client{Sender: s.sender}
 
-	err := client.Send(rec)
+	err := client.Send([]logfwd.Record{rec})
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c, "Send")
@@ -178,7 +178,7 @@ func (s *ClientSuite) TestSendLogLevels(c *gc.C) {
 		s.stub.ResetCalls()
 		rec.Level = level
 
-		err := client.Send(rec)
+		err := client.Send([]logfwd.Record{rec})
 		c.Assert(err, jc.ErrorIsNil)
 
 		msg := s.stub.Calls()[0].Args[0].(rfc5424.Message)

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -37,7 +37,8 @@ func (s *LogsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *LogsSuite) TestLastSentLogTrackerSetGet(c *gc.C) {
-	tracker := state.NewLastSentLogTracker(s.State, "test-sink")
+	tracker := state.NewLastSentLogTracker(s.State, s.State.ModelUUID(), "test-sink")
+	defer tracker.Close()
 
 	err := tracker.Set(10)
 	c.Assert(err, jc.ErrorIsNil)
@@ -53,7 +54,8 @@ func (s *LogsSuite) TestLastSentLogTrackerSetGet(c *gc.C) {
 }
 
 func (s *LogsSuite) TestLastSentLogTrackerGetNeverSet(c *gc.C) {
-	tracker := state.NewLastSentLogTracker(s.State, "test")
+	tracker := state.NewLastSentLogTracker(s.State, s.State.ModelUUID(), "test")
+	defer tracker.Close()
 
 	_, err := tracker.Get()
 
@@ -61,10 +63,12 @@ func (s *LogsSuite) TestLastSentLogTrackerGetNeverSet(c *gc.C) {
 }
 
 func (s *LogsSuite) TestLastSentLogTrackerIndependentModels(c *gc.C) {
-	tracker0 := state.NewLastSentLogTracker(s.State, "test-sink")
+	tracker0 := state.NewLastSentLogTracker(s.State, s.State.ModelUUID(), "test-sink")
+	defer tracker0.Close()
 	otherModel := s.NewStateForModelNamed(c, "test-model")
 	defer otherModel.Close()
-	tracker1 := state.NewLastSentLogTracker(otherModel, "test-sink") // same sink
+	tracker1 := state.NewLastSentLogTracker(otherModel, otherModel.ModelUUID(), "test-sink") // same sink
+	defer tracker1.Close()
 	err := tracker0.Set(10)
 	c.Assert(err, jc.ErrorIsNil)
 	id0, err := tracker0.Get()
@@ -85,8 +89,10 @@ func (s *LogsSuite) TestLastSentLogTrackerIndependentModels(c *gc.C) {
 }
 
 func (s *LogsSuite) TestLastSentLogTrackerIndependentSinks(c *gc.C) {
-	tracker0 := state.NewLastSentLogTracker(s.State, "test-sink0")
-	tracker1 := state.NewLastSentLogTracker(s.State, "test-sink1")
+	tracker0 := state.NewLastSentLogTracker(s.State, s.State.ModelUUID(), "test-sink0")
+	defer tracker0.Close()
+	tracker1 := state.NewLastSentLogTracker(s.State, s.State.ModelUUID(), "test-sink1")
+	defer tracker1.Close()
 	err := tracker0.Set(10)
 	c.Assert(err, jc.ErrorIsNil)
 	id0, err := tracker0.Get()
@@ -112,6 +118,7 @@ func (s *LogsSuite) TestAllLastSentLogTrackerSetGet(c *gc.C) {
 	defer st.Close()
 	tracker, err := state.NewAllLastSentLogTracker(st, "test-sink")
 	c.Assert(err, jc.ErrorIsNil)
+	defer tracker.Close()
 
 	err = tracker.Set(10)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/logforwarder/logforwarder.go
+++ b/worker/logforwarder/logforwarder.go
@@ -19,11 +19,10 @@ import (
 
 var logger = loggo.GetLogger("juju.worker.logforwarder")
 
-// LogStream streams log entries from a log source (e.g. the Juju
-// controller).
+// LogStream streams log entries from a log source (e.g. the Juju controller).
 type LogStream interface {
-	// Next returns the next log record from the stream.
-	Next() (logfwd.Record, error)
+	// Next returns the next batch of log records from the stream.
+	Next() ([]logfwd.Record, error)
 }
 
 // LogStreamFn is a function that opens a log stream.
@@ -36,9 +35,9 @@ type SendCloser interface {
 }
 
 type sender interface {
-	// Send sends the record to its log sink. It is also responsible
+	// Send sends the records to its log sink. It is also responsible
 	// for notifying the controller that record was forwarded.
-	Send(logfwd.Record) error
+	Send([]logfwd.Record) error
 }
 
 // TODO(ericsnow) It is likely that eventually we will want to support
@@ -184,7 +183,7 @@ func (lf *LogForwarder) loop() error {
 		return errors.Trace(err)
 	}
 
-	records := make(chan logfwd.Record)
+	records := make(chan []logfwd.Record)
 	defer close(records)
 	var stream LogStream
 	go func() {

--- a/worker/logforwarder/sinks/syslog.go
+++ b/worker/logforwarder/sinks/syslog.go
@@ -35,7 +35,7 @@ func OpenSyslog(cfg *syslog.RawConfig) (*logforwarder.LogSink, error) {
 
 type emptySendCloser struct{}
 
-func (emptySendCloser) Send(logfwd.Record) error {
+func (emptySendCloser) Send([]logfwd.Record) error {
 	return nil
 }
 


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1599779

There's a couple of fixes here:
1. the SetLastSent api call no longer opens a new state object
2. The log stream Next() api allows for batching of log records. The
underlying implementation (log tailer) still emits one record at a time, but
a followup can fix that.

(Review request: http://reviews.vapour.ws/r/5231/)