### PR TITLE
jujuclient: strictly one account per controller

### DIFF
--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -51,8 +51,8 @@ func (s *BaseActionSuite) SetUpTest(c *gc.C) {
 
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = "ctrl"
-	s.store.Accounts["ctrl"] = &jujuclient.ControllerAccounts{
-		CurrentAccount: "admin@local",
+	s.store.Accounts["ctrl"] = jujuclient.AccountDetails{
+		User: "admin@local",
 	}
 }
 

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -186,8 +186,9 @@ func (c *restoreCommand) getEnviron(
 	}
 
 	// Get the local admin user so we can use the password as the admin secret.
+	// TODO(axw) check that account.User is environs.AdminUser.
 	var adminSecret string
-	account, err := store.AccountByName(controllerName, environs.AdminUser)
+	account, err := store.AccountDetails(controllerName)
 	if err == nil {
 		adminSecret = account.Password
 	} else if errors.IsNotFound(err) {

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -54,24 +54,15 @@ func (s *restoreSuite) SetUpTest(c *gc.C) {
 		CloudRegion:    "a-region",
 	}
 	s.store.CurrentControllerName = "testing"
-	s.store.Models["testing"] = jujuclient.ControllerAccountModels{
-		AccountModels: map[string]*jujuclient.AccountModels{
-			"admin@local": {
-				Models: map[string]jujuclient.ModelDetails{
-					"admin": {"test1-uuid"},
-				},
-				CurrentModel: "admin",
-			},
+	s.store.Models["testing"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{
+			"admin": {"test1-uuid"},
 		},
+		CurrentModel: "admin",
 	}
-	s.store.Accounts["testing"] = &jujuclient.ControllerAccounts{
-		Accounts: map[string]jujuclient.AccountDetails{
-			"admin@local": {
-				User:     "current-user@local",
-				Password: "old-password",
-			},
-		},
-		CurrentAccount: "admin@local",
+	s.store.Accounts["testing"] = jujuclient.AccountDetails{
+		User:     "current-user@local",
+		Password: "old-password",
 	}
 	s.store.BootstrapConfig["testing"] = jujuclient.BootstrapConfig{
 		Cloud:       "mycloud",

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -519,16 +519,12 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	}
 
 	// Set the current model to the initial hosted model.
-	accountName, err := store.CurrentAccount(c.controllerName)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if err := store.UpdateModel(c.controllerName, accountName, c.hostedModelName, jujuclient.ModelDetails{
+	if err := store.UpdateModel(c.controllerName, c.hostedModelName, jujuclient.ModelDetails{
 		hostedModelUUID.String(),
 	}); err != nil {
 		return errors.Trace(err)
 	}
-	if err := store.SetCurrentModel(c.controllerName, accountName, c.hostedModelName); err != nil {
+	if err := store.SetCurrentModel(c.controllerName, c.hostedModelName); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/cmd/juju/commands/migrate.go
+++ b/cmd/juju/commands/migrate.go
@@ -87,7 +87,7 @@ func (c *migrateCommand) Init(args []string) error {
 func (c *migrateCommand) getMigrationSpec() (*controller.ModelMigrationSpec, error) {
 	store := c.ClientStore()
 
-	modelInfo, err := store.ModelByName(c.ControllerName(), c.AccountName(), c.model)
+	modelInfo, err := store.ModelByName(c.ControllerName(), c.model)
 	if err != nil {
 		return nil, err
 	}
@@ -97,12 +97,7 @@ func (c *migrateCommand) getMigrationSpec() (*controller.ModelMigrationSpec, err
 		return nil, err
 	}
 
-	accountName, err := store.CurrentAccount(c.targetController)
-	if err != nil {
-		return nil, err
-	}
-
-	accountInfo, err := store.AccountByName(c.targetController, accountName)
+	accountInfo, err := store.AccountDetails(c.targetController)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/juju/commands/migrate_test.go
+++ b/cmd/juju/commands/migrate_test.go
@@ -43,26 +43,22 @@ func (s *MigrateSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Define an account for the model in the source controller in the config.
-	err = s.store.UpdateAccount("source", "source@local", jujuclient.AccountDetails{
-		User: "whatever@local",
+	err = s.store.UpdateAccount("source", jujuclient.AccountDetails{
+		User: "source@local",
 	})
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.store.SetCurrentAccount("source", "source@local")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Define the model to migrate in the config.
-	err = s.store.UpdateModel("source", "source@local", "model", jujuclient.ModelDetails{
+	err = s.store.UpdateModel("source", "model", jujuclient.ModelDetails{
 		ModelUUID: modelUUID,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Define the account for the target controller.
-	err = s.store.UpdateAccount("target", "target@local", jujuclient.AccountDetails{
-		User:     "admin@local",
+	err = s.store.UpdateAccount("target", jujuclient.AccountDetails{
+		User:     "target@local",
 		Password: "secret",
 	})
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.store.SetCurrentAccount("target", "target@local")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Define the target controller in the config.
@@ -101,7 +97,7 @@ func (s *MigrateSuite) TestSuccess(c *gc.C) {
 		TargetControllerUUID: targetControllerUUID,
 		TargetAddrs:          []string{"1.2.3.4:5"},
 		TargetCACert:         "cert",
-		TargetUser:           "admin@local",
+		TargetUser:           "target@local",
 		TargetPassword:       "secret",
 	})
 }

--- a/cmd/juju/commands/plugin_test.go
+++ b/cmd/juju/commands/plugin_test.go
@@ -172,12 +172,10 @@ func (suite *PluginSuite) TestJujuEnvVars(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = store.SetCurrentController("myctrl")
 	c.Assert(err, jc.ErrorIsNil)
-	err = store.UpdateAccount("myctrl", "admin@local", jujuclient.AccountDetails{
+	err = store.UpdateAccount("myctrl", jujuclient.AccountDetails{
 		User:     "admin@local",
 		Password: "hunter2",
 	})
-	c.Assert(err, jc.ErrorIsNil)
-	err = store.SetCurrentAccount("myctrl", "admin@local")
 	c.Assert(err, jc.ErrorIsNil)
 
 	suite.makeFullPlugin(PluginParams{Name: "foo"})

--- a/cmd/juju/commands/switch_test.go
+++ b/cmd/juju/commands/switch_test.go
@@ -37,8 +37,8 @@ func (s *SwitchSimpleSuite) SetUpTest(c *gc.C) {
 	s.onRefresh = nil
 }
 
-func (s *SwitchSimpleSuite) refreshModels(store jujuclient.ClientStore, controllerName, accountName string) error {
-	s.MethodCall(s, "RefreshModels", store, controllerName, accountName)
+func (s *SwitchSimpleSuite) refreshModels(store jujuclient.ClientStore, controllerName string) error {
+	s.MethodCall(s, "RefreshModels", store, controllerName)
 	if s.onRefresh != nil {
 		s.onRefresh()
 	}
@@ -76,13 +76,9 @@ func (s *SwitchSimpleSuite) TestUnknownControllerNameReturnsError(c *gc.C) {
 func (s *SwitchSimpleSuite) TestNoArgsCurrentModel(c *gc.C) {
 	s.addController(c, "a-controller")
 	s.store.CurrentControllerName = "a-controller"
-	s.store.Models["a-controller"] = jujuclient.ControllerAccountModels{
-		map[string]*jujuclient.AccountModels{
-			"admin@local": {
-				Models:       map[string]jujuclient.ModelDetails{"mymodel": {}},
-				CurrentModel: "mymodel",
-			},
-		},
+	s.store.Models["a-controller"] = &jujuclient.ControllerModels{
+		Models:       map[string]jujuclient.ModelDetails{"mymodel": {}},
+		CurrentModel: "mymodel",
 	}
 	ctx, err := s.run(c)
 	c.Assert(err, jc.ErrorIsNil)
@@ -97,8 +93,7 @@ func (s *SwitchSimpleSuite) TestSwitchWritesCurrentController(c *gc.C) {
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
 		{"ControllerByName", []interface{}{"a-controller"}},
-		{"CurrentAccount", []interface{}{"a-controller"}},
-		{"CurrentModel", []interface{}{"a-controller", "admin@local"}},
+		{"CurrentModel", []interface{}{"a-controller"}},
 		{"SetCurrentController", []interface{}{"a-controller"}},
 	})
 }
@@ -127,8 +122,7 @@ func (s *SwitchSimpleSuite) TestSwitchSameController(c *gc.C) {
 	c.Assert(coretesting.Stderr(context), gc.Equals, "same (controller) (no change)\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
-		{"CurrentAccount", []interface{}{"same"}},
-		{"CurrentModel", []interface{}{"same", "admin@local"}},
+		{"CurrentModel", []interface{}{"same"}},
 		{"ControllerByName", []interface{}{"same"}},
 	})
 }
@@ -136,98 +130,77 @@ func (s *SwitchSimpleSuite) TestSwitchSameController(c *gc.C) {
 func (s *SwitchSimpleSuite) TestSwitchControllerToModel(c *gc.C) {
 	s.store.CurrentControllerName = "ctrl"
 	s.addController(c, "ctrl")
-	s.store.Models["ctrl"] = jujuclient.ControllerAccountModels{
-		map[string]*jujuclient.AccountModels{
-			"admin@local": {
-				Models: map[string]jujuclient.ModelDetails{"mymodel": {}},
-			},
-		},
+	s.store.Models["ctrl"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{"mymodel": {}},
 	}
 	context, err := s.run(c, "mymodel")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(coretesting.Stderr(context), gc.Equals, "ctrl (controller) -> ctrl:mymodel\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
-		{"CurrentAccount", []interface{}{"ctrl"}},
-		{"CurrentModel", []interface{}{"ctrl", "admin@local"}},
+		{"CurrentModel", []interface{}{"ctrl"}},
 		{"ControllerByName", []interface{}{"mymodel"}},
-		{"CurrentAccount", []interface{}{"ctrl"}},
-		{"SetCurrentModel", []interface{}{"ctrl", "admin@local", "mymodel"}},
+		{"SetCurrentModel", []interface{}{"ctrl", "mymodel"}},
 	})
-	c.Assert(s.store.Models["ctrl"].AccountModels["admin@local"].CurrentModel, gc.Equals, "mymodel")
+	c.Assert(s.store.Models["ctrl"].CurrentModel, gc.Equals, "mymodel")
 }
 
 func (s *SwitchSimpleSuite) TestSwitchControllerToModelDifferentController(c *gc.C) {
 	s.store.CurrentControllerName = "old"
 	s.addController(c, "new")
-	s.store.Models["new"] = jujuclient.ControllerAccountModels{
-		map[string]*jujuclient.AccountModels{
-			"admin@local": {
-				Models: map[string]jujuclient.ModelDetails{"mymodel": {}},
-			},
-		},
+	s.store.Models["new"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{"mymodel": {}},
 	}
 	context, err := s.run(c, "new:mymodel")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(coretesting.Stderr(context), gc.Equals, "old (controller) -> new:mymodel\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
-		{"CurrentAccount", []interface{}{"old"}},
+		{"CurrentModel", []interface{}{"old"}},
 		{"ControllerByName", []interface{}{"new:mymodel"}},
 		{"ControllerByName", []interface{}{"new"}},
-		{"CurrentAccount", []interface{}{"new"}},
-		{"SetCurrentModel", []interface{}{"new", "admin@local", "mymodel"}},
+		{"SetCurrentModel", []interface{}{"new", "mymodel"}},
 		{"SetCurrentController", []interface{}{"new"}},
 	})
-	c.Assert(s.store.Models["new"].AccountModels["admin@local"].CurrentModel, gc.Equals, "mymodel")
+	c.Assert(s.store.Models["new"].CurrentModel, gc.Equals, "mymodel")
 }
 
 func (s *SwitchSimpleSuite) TestSwitchLocalControllerToModelDifferentController(c *gc.C) {
 	s.store.CurrentControllerName = "old"
 	s.addController(c, "new")
-	s.store.Models["new"] = jujuclient.ControllerAccountModels{
-		map[string]*jujuclient.AccountModels{
-			"admin@local": {
-				Models: map[string]jujuclient.ModelDetails{"mymodel": {}},
-			},
-		},
+	s.store.Models["new"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{"mymodel": {}},
 	}
 	context, err := s.run(c, "new:mymodel")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(coretesting.Stderr(context), gc.Equals, "old (controller) -> new:mymodel\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
-		{"CurrentAccount", []interface{}{"old"}},
+		{"CurrentModel", []interface{}{"old"}},
 		{"ControllerByName", []interface{}{"new:mymodel"}},
 		{"ControllerByName", []interface{}{"new"}},
-		{"CurrentAccount", []interface{}{"new"}},
-		{"SetCurrentModel", []interface{}{"new", "admin@local", "mymodel"}},
+		{"SetCurrentModel", []interface{}{"new", "mymodel"}},
 		{"SetCurrentController", []interface{}{"new"}},
 	})
-	c.Assert(s.store.Models["new"].AccountModels["admin@local"].CurrentModel, gc.Equals, "mymodel")
+	c.Assert(s.store.Models["new"].CurrentModel, gc.Equals, "mymodel")
 }
 
 func (s *SwitchSimpleSuite) TestSwitchControllerToDifferentControllerCurrentModel(c *gc.C) {
 	s.store.CurrentControllerName = "old"
 	s.addController(c, "new")
-	s.store.Models["new"] = jujuclient.ControllerAccountModels{
-		map[string]*jujuclient.AccountModels{
-			"admin@local": {
-				Models:       map[string]jujuclient.ModelDetails{"mymodel": {}},
-				CurrentModel: "mymodel",
-			},
-		},
+	s.store.Models["new"] = &jujuclient.ControllerModels{
+		Models:       map[string]jujuclient.ModelDetails{"mymodel": {}},
+		CurrentModel: "mymodel",
 	}
 	context, err := s.run(c, "new:mymodel")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(coretesting.Stderr(context), gc.Equals, "old (controller) -> new:mymodel\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
-		{"CurrentAccount", []interface{}{"old"}},
+		{"CurrentModel", []interface{}{"old"}},
 		{"ControllerByName", []interface{}{"new:mymodel"}},
 		{"ControllerByName", []interface{}{"new"}},
-		{"CurrentAccount", []interface{}{"new"}},
-		{"SetCurrentModel", []interface{}{"new", "admin@local", "mymodel"}},
+		{"SetCurrentModel", []interface{}{"new", "mymodel"}},
 		{"SetCurrentController", []interface{}{"new"}},
 	})
 }
@@ -245,19 +218,15 @@ func (s *SwitchSimpleSuite) TestSwitchUnknownCurrentControllerRefreshModels(c *g
 	s.store.CurrentControllerName = "ctrl"
 	s.addController(c, "ctrl")
 	s.onRefresh = func() {
-		s.store.Models["ctrl"] = jujuclient.ControllerAccountModels{
-			map[string]*jujuclient.AccountModels{
-				"admin@local": {
-					Models: map[string]jujuclient.ModelDetails{"unknown": {}},
-				},
-			},
+		s.store.Models["ctrl"] = &jujuclient.ControllerModels{
+			Models: map[string]jujuclient.ModelDetails{"unknown": {}},
 		}
 	}
 	ctx, err := s.run(c, "unknown")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(coretesting.Stderr(ctx), gc.Equals, "ctrl (controller) -> ctrl:unknown\n")
 	s.CheckCalls(c, []testing.StubCall{
-		{"RefreshModels", []interface{}{s.stubStore, "ctrl", "admin@local"}},
+		{"RefreshModels", []interface{}{s.stubStore, "ctrl"}},
 	})
 }
 
@@ -267,7 +236,7 @@ func (s *SwitchSimpleSuite) TestSwitchUnknownCurrentControllerRefreshModelsStill
 	_, err := s.run(c, "unknown")
 	c.Assert(err, gc.ErrorMatches, `"unknown" is not the name of a model or controller`)
 	s.CheckCalls(c, []testing.StubCall{
-		{"RefreshModels", []interface{}{s.stubStore, "ctrl", "admin@local"}},
+		{"RefreshModels", []interface{}{s.stubStore, "ctrl"}},
 	})
 }
 
@@ -278,7 +247,7 @@ func (s *SwitchSimpleSuite) TestSwitchUnknownCurrentControllerRefreshModelsFails
 	_, err := s.run(c, "unknown")
 	c.Assert(err, gc.ErrorMatches, "refreshing models cache: not very refreshing")
 	s.CheckCalls(c, []testing.StubCall{
-		{"RefreshModels", []interface{}{s.stubStore, "ctrl", "admin@local"}},
+		{"RefreshModels", []interface{}{s.stubStore, "ctrl"}},
 	})
 }
 
@@ -295,7 +264,7 @@ func (s *SwitchSimpleSuite) TestTooManyParams(c *gc.C) {
 
 func (s *SwitchSimpleSuite) addController(c *gc.C, name string) {
 	s.store.Controllers[name] = jujuclient.ControllerDetails{}
-	s.store.Accounts[name] = &jujuclient.ControllerAccounts{
-		CurrentAccount: "admin@local",
+	s.store.Accounts[name] = jujuclient.AccountDetails{
+		User: "admin@local",
 	}
 }

--- a/cmd/juju/commands/synctools_test.go
+++ b/cmd/juju/commands/synctools_test.go
@@ -46,8 +46,8 @@ func (s *syncToolsSuite) SetUpTest(c *gc.C) {
 	})
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = "ctrl"
-	s.store.Accounts["ctrl"] = &jujuclient.ControllerAccounts{
-		CurrentAccount: "admin@local",
+	s.store.Accounts["ctrl"] = jujuclient.AccountDetails{
+		User: "admin@local",
 	}
 }
 

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -133,16 +133,12 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	accountName, err := store.CurrentAccount(controllerName)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	currentAccount, err := store.AccountByName(controllerName, accountName)
+	accountDetails, err := store.AccountDetails(controllerName)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	modelOwner := currentAccount.User
+	modelOwner := accountDetails.User
 	if c.Owner != "" {
 		if !names.IsValidUser(c.Owner) {
 			return errors.Errorf("%q is not a valid user name", c.Owner)
@@ -203,15 +199,14 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 	messageFormat := "Added '%s' model"
 	messageArgs := []interface{}{c.Name}
 
-	if modelOwner == currentAccount.User {
+	if modelOwner == accountDetails.User {
 		controllerName := c.ControllerName()
-		accountName := c.AccountName()
-		if err := store.UpdateModel(controllerName, accountName, c.Name, jujuclient.ModelDetails{
+		if err := store.UpdateModel(controllerName, c.Name, jujuclient.ModelDetails{
 			model.UUID,
 		}); err != nil {
 			return errors.Trace(err)
 		}
-		if err := store.SetCurrentModel(controllerName, accountName, c.Name); err != nil {
+		if err := store.SetCurrentModel(controllerName, c.Name); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -51,11 +51,8 @@ func (s *addSuite) SetUpTest(c *gc.C) {
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = controllerName
 	s.store.Controllers[controllerName] = jujuclient.ControllerDetails{}
-	s.store.Accounts[controllerName] = &jujuclient.ControllerAccounts{
-		Accounts: map[string]jujuclient.AccountDetails{
-			"bob@local": {User: "bob@local"},
-		},
-		CurrentAccount: "bob@local",
+	s.store.Accounts[controllerName] = jujuclient.AccountDetails{
+		User: "bob@local",
 	}
 	s.store.Credentials["aws"] = cloud.CloudCredential{
 		AuthCredentials: map[string]cloud.Credential{
@@ -148,7 +145,7 @@ func (s *addSuite) TestAddExistingName(c *gc.C) {
 	// controller will error out if the model already exists. Overwriting
 	// means we'll replace any stale details from an previously existing
 	// model with the same name.
-	err := s.store.UpdateModel("test-master", "bob@local", "test", jujuclient.ModelDetails{
+	err := s.store.UpdateModel("test-master", "test", jujuclient.ModelDetails{
 		"stale-uuid",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -156,7 +153,7 @@ func (s *addSuite) TestAddExistingName(c *gc.C) {
 	_, err = s.run(c, "test")
 	c.Assert(err, jc.ErrorIsNil)
 
-	details, err := s.store.ModelByName("test-master", "bob@local", "test")
+	details, err := s.store.ModelByName("test-master", "test")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(details, jc.DeepEquals, &jujuclient.ModelDetails{"fake-model-uuid"})
 }
@@ -278,7 +275,7 @@ func (s *addSuite) TestAddErrorRemoveConfigstoreInfo(c *gc.C) {
 	_, err := s.run(c, "test")
 	c.Assert(err, gc.ErrorMatches, "bah humbug")
 
-	_, err = s.store.ModelByName("test-master", "bob@local", "test")
+	_, err = s.store.ModelByName("test-master", "test")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
@@ -286,7 +283,7 @@ func (s *addSuite) TestAddStoresValues(c *gc.C) {
 	_, err := s.run(c, "test")
 	c.Assert(err, jc.ErrorIsNil)
 
-	model, err := s.store.ModelByName("test-master", "bob@local", "test")
+	model, err := s.store.ModelByName("test-master", "test")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(model, jc.DeepEquals, &jujuclient.ModelDetails{"fake-model-uuid"})
 }
@@ -296,9 +293,7 @@ func (s *addSuite) TestNoEnvCacheOtherUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Creating a model for another user does not update the model cache.
-	_, err = s.store.ModelByName("test-master", "bob@local", "test")
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	_, err = s.store.ModelByName("test-master", "zeus@local", "test")
+	_, err = s.store.ModelByName("test-master", "test")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -152,8 +152,8 @@ func (s *baseDestroySuite) SetUpTest(c *gc.C) {
 		CACert:         testing.CACert,
 		ControllerUUID: test3UUID,
 	}
-	s.store.Accounts["test1"] = &jujuclient.ControllerAccounts{
-		CurrentAccount: "admin@local",
+	s.store.Accounts["test1"] = jujuclient.AccountDetails{
+		User: "admin@local",
 	}
 
 	var modelList = []struct {
@@ -184,7 +184,7 @@ func (s *baseDestroySuite) SetUpTest(c *gc.C) {
 			APIEndpoints:   []string{"localhost"},
 			CACert:         testing.CACert,
 		})
-		s.store.UpdateModel(controllerName, "admin@local", modelName, jujuclient.ModelDetails{
+		s.store.UpdateModel(controllerName, modelName, jujuclient.ModelDetails{
 			ModelUUID: model.modelUUID,
 		})
 		if model.bootstrapCfg != nil {
@@ -352,8 +352,8 @@ func (s *DestroySuite) resetController(c *gc.C) {
 		CACert:         testing.CACert,
 		ControllerUUID: test1UUID,
 	}
-	s.store.Accounts["test1"] = &jujuclient.ControllerAccounts{
-		CurrentAccount: "admin@local",
+	s.store.Accounts["test1"] = jujuclient.AccountDetails{
+		User: "admin@local",
 	}
 	s.store.BootstrapConfig["test1"] = jujuclient.BootstrapConfig{
 		Config: createBootstrapInfo(c, "admin"),

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -67,7 +67,7 @@ func NewListModelsCommandForTest(modelAPI ModelManagerAPI, sysAPI ModelsSysAPI, 
 
 // NewRegisterCommandForTest returns a RegisterCommand with the function used
 // to open the API connection mocked out.
-func NewRegisterCommandForTest(apiOpen api.OpenFunc, refreshModels func(jujuclient.ClientStore, string, string) error, store jujuclient.ClientStore) *registerCommand {
+func NewRegisterCommandForTest(apiOpen api.OpenFunc, refreshModels func(jujuclient.ClientStore, string) error, store jujuclient.ClientStore) *registerCommand {
 	return &registerCommand{apiOpen: apiOpen, refreshModels: refreshModels, store: store}
 }
 

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -132,7 +132,7 @@ func (s *KillSuite) TestKillCommandControllerAlias(c *gc.C) {
 }
 
 func (s *KillSuite) TestKillAPIPermErrFails(c *gc.C) {
-	testDialer := func(_ jujuclient.ClientStore, controllerName, accountName, modelName string) (api.Connection, error) {
+	testDialer := func(_ jujuclient.ClientStore, controllerName, modelName string) (api.Connection, error) {
 		return nil, common.ErrPerm
 	}
 	cmd := controller.NewKillCommandForTest(nil, nil, s.store, nil, clock.WallClock, modelcmd.OpenFunc(testDialer))
@@ -146,7 +146,7 @@ func (s *KillSuite) TestKillEarlyAPIConnectionTimeout(c *gc.C) {
 
 	stop := make(chan struct{})
 	defer close(stop)
-	testDialer := func(_ jujuclient.ClientStore, controllerName, accountName, modelName string) (api.Connection, error) {
+	testDialer := func(_ jujuclient.ClientStore, controllerName, modelName string) (api.Connection, error) {
 		<-stop
 		return nil, errors.New("kill command waited too long")
 	}

--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -36,13 +36,14 @@ CONTROLLER  MODEL  USER  CLOUD/REGION
 func (s *ListControllersSuite) TestListControllers(c *gc.C) {
 	s.expectedOutput = `
 CONTROLLER           MODEL     USER         CLOUD/REGION
-aws-test             -         -            aws/us-east-1
+aws-test             admin     -            aws/us-east-1
 mallards*            my-model  admin@local  mallards/mallards1
-mark-test-prodstack  -         -            prodstack
+mark-test-prodstack  -         admin@local  prodstack
 
 `[1:]
 
-	s.createTestClientStore(c)
+	store := s.createTestClientStore(c)
+	delete(store.Accounts, "aws-test")
 	s.assertListControllers(c)
 }
 
@@ -50,6 +51,8 @@ func (s *ListControllersSuite) TestListControllersYaml(c *gc.C) {
 	s.expectedOutput = `
 controllers:
   aws-test:
+    current-model: admin
+    user: admin@local
     recent-server: this-is-aws-test-of-many-api-endpoints
     uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
@@ -66,6 +69,7 @@ controllers:
     cloud: mallards
     region: mallards1
   mark-test-prodstack:
+    user: admin@local
     recent-server: this-is-one-of-many-api-endpoints
     uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
@@ -89,6 +93,8 @@ func (s *ListControllersSuite) TestListControllersJson(c *gc.C) {
 		Controllers: map[string]controller.ControllerItem{
 			"aws-test": {
 				ControllerUUID: "this-is-the-aws-test-uuid",
+				ModelName:      "admin",
+				User:           "admin@local",
 				Server:         "this-is-aws-test-of-many-api-endpoints",
 				APIEndpoints:   []string{"this-is-aws-test-of-many-api-endpoints"},
 				CACert:         "this-is-aws-test-ca-cert",
@@ -107,6 +113,7 @@ func (s *ListControllersSuite) TestListControllersJson(c *gc.C) {
 			},
 			"mark-test-prodstack": {
 				ControllerUUID: "this-is-a-uuid",
+				User:           "admin@local",
 				Server:         "this-is-one-of-many-api-endpoints",
 				APIEndpoints:   []string{"this-is-one-of-many-api-endpoints"},
 				CACert:         "this-is-a-ca-cert",

--- a/cmd/juju/controller/listcontrollersconverters.go
+++ b/cmd/juju/controller/listcontrollersconverters.go
@@ -53,28 +53,25 @@ func (c *listControllersCommand) convertControllerDetails(storeControllers map[s
 			serverName = details.APIEndpoints[0]
 		}
 
-		var userName, modelName string
-		accountName, err := c.store.CurrentAccount(controllerName)
+		var userName string
+		accountDetails, err := c.store.AccountDetails(controllerName)
 		if err != nil {
 			if !errors.IsNotFound(err) {
-				addError("account name", controllerName, err)
-				continue
-			}
-		} else {
-			currentAccount, err := c.store.AccountByName(controllerName, accountName)
-			if err != nil {
 				addError("account details", controllerName, err)
 				continue
 			}
-			userName = currentAccount.User
+		} else {
+			userName = accountDetails.User
+		}
 
-			currentModel, err := c.store.CurrentModel(controllerName, accountName)
-			if err != nil {
-				if !errors.IsNotFound(err) {
-					addError("model", controllerName, err)
-					continue
-				}
+		var modelName string
+		currentModel, err := c.store.CurrentModel(controllerName)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				addError("model", controllerName, err)
+				continue
 			}
+		} else {
 			modelName = currentModel
 		}
 

--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -116,8 +116,8 @@ type ModelSet struct {
 // Run implements Command.Run
 func (c *modelsCommand) Run(ctx *cmd.Context) error {
 	if c.user == "" {
-		accountDetails, err := c.ClientStore().AccountByName(
-			c.ControllerName(), c.AccountName(),
+		accountDetails, err := c.ClientStore().AccountDetails(
+			c.ControllerName(),
 		)
 		if err != nil {
 			return err
@@ -155,7 +155,7 @@ func (c *modelsCommand) Run(ctx *cmd.Context) error {
 	}
 
 	modelSet := ModelSet{Models: modelInfo}
-	current, err := c.ClientStore().CurrentModel(c.ControllerName(), c.AccountName())
+	current, err := c.ClientStore().CurrentModel(c.ControllerName())
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -122,21 +122,12 @@ func (s *ModelsSuite) SetUpTest(c *gc.C) {
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = "fake"
 	s.store.Controllers["fake"] = jujuclient.ControllerDetails{}
-	s.store.Models["fake"] = jujuclient.ControllerAccountModels{
-		AccountModels: map[string]*jujuclient.AccountModels{
-			"admin@local": {
-				CurrentModel: "test-model1",
-			},
-		},
+	s.store.Models["fake"] = &jujuclient.ControllerModels{
+		CurrentModel: "test-model1",
 	}
-	s.store.Accounts["fake"] = &jujuclient.ControllerAccounts{
-		Accounts: map[string]jujuclient.AccountDetails{
-			"admin@local": {
-				User:     "admin@local",
-				Password: "password",
-			},
-		},
-		CurrentAccount: "admin@local",
+	s.store.Accounts["fake"] = jujuclient.AccountDetails{
+		User:     "admin@local",
+		Password: "password",
 	}
 }
 

--- a/cmd/juju/controller/package_test.go
+++ b/cmd/juju/controller/package_test.go
@@ -77,44 +77,28 @@ current-controller: mallards
 const testModelsYaml = `
 controllers:
   aws-test:
-    accounts:
-      admin@local:
-        models:
-          admin:
-            uuid: ghi
-        current-model: admin
+    models:
+      admin:
+        uuid: ghi
+    current-model: admin
   mallards:
-    accounts:
-      admin@local:
-        models:
-          admin:
-            uuid: abc
-          my-model:
-            uuid: def
-        current-model: my-model
+    models:
+      admin:
+        uuid: abc
+      my-model:
+        uuid: def
+    current-model: my-model
 `
 
 const testAccountsYaml = `
 controllers:
   aws-test:
-    accounts:
-      admin@local:
-        user: admin@local
-        password: hun+er2
+    user: admin@local
+    password: hun+er2
   mark-test-prodstack:
-    accounts:
-      admin@local:
-        user: admin@local
-        password: hunter2
+    user: admin@local
+    password: hunter2
   mallards:
-    accounts:
-      admin@local:
-        user: admin@local
-        password: hunter2
-      bob@local:
-        user: bob@local
-        password: huntert00
-      bob@remote:
-        user: bob@remote
-    current-account: admin@local
+    user: admin@local
+    password: hunter2
 `

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -40,20 +40,14 @@ mallards:
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
     cloud: mallards
-  accounts:
-    admin@local:
-      user: admin@local
-      models:
-        admin:
-          uuid: abc
-        my-model:
-          uuid: def
-      current-model: my-model
-    bob@local:
-      user: bob@local
-    bob@remote:
-      user: bob@remote
-  current-account: admin@local
+  models:
+    admin:
+      uuid: abc
+    my-model:
+      uuid: def
+  current-model: my-model
+  account:
+    user: admin@local
 `[1:]
 
 	s.assertShowController(c, "mallards")
@@ -76,25 +70,18 @@ mallards:
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
     cloud: mallards
-  accounts:
-    admin@local:
-      user: admin@local
-      password: hunter2
-      models:
-        admin:
-          uuid: abc
-        my-model:
-          uuid: def
-      current-model: my-model
-    bob@local:
-      user: bob@local
-      password: huntert00
-    bob@remote:
-      user: bob@remote
-  current-account: admin@local
+  models:
+    admin:
+      uuid: abc
+    my-model:
+      uuid: def
+  current-model: my-model
+  account:
+    user: admin@local
+    password: hunter2
 `[1:]
 
-	s.assertShowController(c, "mallards", "--show-passwords")
+	s.assertShowController(c, "mallards", "--show-password")
 }
 
 func (s *ShowControllerSuite) TestShowControllerWithBootstrapConfig(c *gc.C) {
@@ -127,20 +114,14 @@ mallards:
     ca-cert: this-is-another-ca-cert
     cloud: mallards
     region: mallards1
-  accounts:
-    admin@local:
-      user: admin@local
-      models:
-        admin:
-          uuid: abc
-        my-model:
-          uuid: def
-      current-model: my-model
-    bob@local:
-      user: bob@local
-    bob@remote:
-      user: bob@remote
-  current-account: admin@local
+  models:
+    admin:
+      uuid: abc
+    my-model:
+      uuid: def
+  current-model: my-model
+  account:
+    user: admin@local
   bootstrap-config:
     config:
       extra: value
@@ -165,13 +146,12 @@ aws-test:
     ca-cert: this-is-aws-test-ca-cert
     cloud: aws
     region: us-east-1
-  accounts:
-    admin@local:
-      user: admin@local
-      models:
-        admin:
-          uuid: ghi
-      current-model: admin
+  models:
+    admin:
+      uuid: ghi
+  current-model: admin
+  account:
+    user: admin@local
 `[1:]
 	s.assertShowController(c, "aws-test")
 }
@@ -186,22 +166,20 @@ aws-test:
     ca-cert: this-is-aws-test-ca-cert
     cloud: aws
     region: us-east-1
-  accounts:
-    admin@local:
-      user: admin@local
-      models:
-        admin:
-          uuid: ghi
-      current-model: admin
+  models:
+    admin:
+      uuid: ghi
+  current-model: admin
+  account:
+    user: admin@local
 mark-test-prodstack:
   details:
     uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
     ca-cert: this-is-a-ca-cert
     cloud: prodstack
-  accounts:
-    admin@local:
-      user: admin@local
+  account:
+    user: admin@local
 `[1:]
 
 	s.assertShowController(c, "aws-test", "mark-test-prodstack")
@@ -211,7 +189,7 @@ func (s *ShowControllerSuite) TestShowControllerJsonOne(c *gc.C) {
 	s.createTestClientStore(c)
 
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1"},"models":{"admin":{"uuid":"ghi"}},"current-model":"admin","account":{"user":"admin@local"}}}
 `[1:]
 
 	s.assertShowController(c, "--format", "json", "aws-test")
@@ -220,7 +198,7 @@ func (s *ShowControllerSuite) TestShowControllerJsonOne(c *gc.C) {
 func (s *ShowControllerSuite) TestShowControllerJsonMany(c *gc.C) {
 	s.createTestClientStore(c)
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}},"mark-test-prodstack":{"details":{"uuid":"this-is-a-uuid","api-endpoints":["this-is-one-of-many-api-endpoints"],"ca-cert":"this-is-a-ca-cert","cloud":"prodstack"},"accounts":{"admin@local":{"user":"admin@local"}}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1"},"models":{"admin":{"uuid":"ghi"}},"current-model":"admin","account":{"user":"admin@local"}},"mark-test-prodstack":{"details":{"uuid":"this-is-a-uuid","api-endpoints":["this-is-one-of-many-api-endpoints"],"ca-cert":"this-is-a-ca-cert","cloud":"prodstack"},"account":{"user":"admin@local"}}}
 `[1:]
 	s.assertShowController(c, "--format", "json", "aws-test", "mark-test-prodstack")
 }
@@ -242,7 +220,7 @@ func (s *ShowControllerSuite) TestShowControllerNoArgs(c *gc.C) {
 	store := s.createTestClientStore(c)
 
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1"},"models":{"admin":{"uuid":"ghi"}},"current-model":"admin","account":{"user":"admin@local"}}}
 `[1:]
 	store.CurrentControllerName = "aws-test"
 	s.assertShowController(c, "--format", "json")

--- a/cmd/juju/gui/gui.go
+++ b/cmd/juju/gui/gui.go
@@ -69,7 +69,7 @@ func (c *guiCommand) Run(ctx *cmd.Context) error {
 		return errors.Annotate(err, "cannot establish API connection")
 	}
 	defer conn.Close()
-	details, err := c.ClientStore().ModelByName(c.ControllerName(), c.AccountName(), c.ModelName())
+	details, err := c.ClientStore().ModelByName(c.ControllerName(), c.ModelName())
 	if err != nil {
 		return errors.Annotate(err, "cannot retrieve model details")
 	}
@@ -134,12 +134,7 @@ func (c *guiCommand) showCredentials(ctx *cmd.Context) error {
 		return nil
 	}
 	// TODO(wallyworld) - what to do if we are using a macaroon.
-	if c.AccountName() == "" {
-		return errors.Errorf("no connection credentials available")
-	}
-	accountDetails, err := c.ClientStore().AccountByName(
-		c.ControllerName(), c.AccountName(),
-	)
+	accountDetails, err := c.ClientStore().AccountDetails(c.ControllerName())
 	if err != nil {
 		return errors.Annotate(err, "cannot retrieve credentials")
 	}

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -107,14 +107,13 @@ func (c *destroyCommand) getAPI() (DestroyModelAPI, error) {
 func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	store := c.ClientStore()
 	controllerName := c.ControllerName()
-	accountName := c.AccountName()
 	modelName := c.ModelName()
 
 	controllerDetails, err := store.ControllerByName(controllerName)
 	if err != nil {
 		return errors.Annotate(err, "cannot read controller details")
 	}
-	modelDetails, err := store.ModelByName(controllerName, accountName, modelName)
+	modelDetails, err := store.ModelByName(controllerName, modelName)
 	if err != nil {
 		return errors.Annotate(err, "cannot read model info")
 	}
@@ -143,7 +142,7 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 		return c.handleError(errors.Annotate(err, "cannot destroy model"), modelName)
 	}
 
-	err = store.RemoveModel(controllerName, accountName, modelName)
+	err = store.RemoveModel(controllerName, modelName)
 	if err != nil && !errors.IsNotFound(err) {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -50,18 +50,14 @@ func (s *DestroySuite) SetUpTest(c *gc.C) {
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = "test1"
 	s.store.Controllers["test1"] = jujuclient.ControllerDetails{ControllerUUID: "test1-uuid"}
-	s.store.Models["test1"] = jujuclient.ControllerAccountModels{
-		AccountModels: map[string]*jujuclient.AccountModels{
-			"admin@local": {
-				Models: map[string]jujuclient.ModelDetails{
-					"test1": {"test1-uuid"},
-					"test2": {"test2-uuid"},
-				},
-			},
+	s.store.Models["test1"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{
+			"test1": {"test1-uuid"},
+			"test2": {"test2-uuid"},
 		},
 	}
-	s.store.Accounts["test1"] = &jujuclient.ControllerAccounts{
-		CurrentAccount: "admin@local",
+	s.store.Accounts["test1"] = jujuclient.AccountDetails{
+		User: "admin@local",
 	}
 }
 
@@ -76,13 +72,13 @@ func (s *DestroySuite) NewDestroyCommand() cmd.Command {
 
 func checkModelExistsInStore(c *gc.C, name string, store jujuclient.ClientStore) {
 	controller, model := modelcmd.SplitModelName(name)
-	_, err := store.ModelByName(controller, "admin@local", model)
+	_, err := store.ModelByName(controller, model)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func checkModelRemovedFromStore(c *gc.C, name string, store jujuclient.ClientStore) {
 	controller, model := modelcmd.SplitModelName(name)
-	_, err := store.ModelByName(controller, "admin@local", model)
+	_, err := store.ModelByName(controller, model)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
@@ -103,7 +99,7 @@ func (s *DestroySuite) TestDestroyUnknownArgument(c *gc.C) {
 
 func (s *DestroySuite) TestDestroyUnknownModel(c *gc.C) {
 	_, err := s.runDestroyCommand(c, "foo")
-	c.Assert(err, gc.ErrorMatches, `cannot read model info: model test1:admin@local:foo not found`)
+	c.Assert(err, gc.ErrorMatches, `cannot read model info: model test1:foo not found`)
 }
 
 func (s *DestroySuite) TestDestroyCannotConnectToAPI(c *gc.C) {
@@ -135,14 +131,10 @@ func (s *DestroySuite) TestFailedDestroyModel(c *gc.C) {
 }
 
 func (s *DestroySuite) resetModel(c *gc.C) {
-	s.store.Models["test1"] = jujuclient.ControllerAccountModels{
-		AccountModels: map[string]*jujuclient.AccountModels{
-			"admin@local": {
-				Models: map[string]jujuclient.ModelDetails{
-					"test1": {"test1-uuid"},
-					"test2": {"test2-uuid"},
-				},
-			},
+	s.store.Models["test1"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{
+			"test1": {"test1-uuid"},
+			"test2": {"test2-uuid"},
 		},
 	}
 }

--- a/cmd/juju/model/grantrevoke_test.go
+++ b/cmd/juju/model/grantrevoke_test.go
@@ -41,24 +41,17 @@ func (s *grantRevokeSuite) SetUpTest(c *gc.C) {
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = controllerName
 	s.store.Controllers[controllerName] = jujuclient.ControllerDetails{}
-	s.store.Accounts[controllerName] = &jujuclient.ControllerAccounts{
-		Accounts: map[string]jujuclient.AccountDetails{
-			"bob@local": {User: "bob@local"},
-		},
-		CurrentAccount: "bob@local",
+	s.store.Accounts[controllerName] = jujuclient.AccountDetails{
+		User: "bob@local",
 	}
-	s.store.Models = map[string]jujuclient.ControllerAccountModels{
-		controllerName: jujuclient.ControllerAccountModels{
-			AccountModels: map[string]*jujuclient.AccountModels{
-				"bob@local": &jujuclient.AccountModels{
-					Models: map[string]jujuclient.ModelDetails{
-						"foo":    jujuclient.ModelDetails{fooModelUUID},
-						"bar":    jujuclient.ModelDetails{barModelUUID},
-						"baz":    jujuclient.ModelDetails{bazModelUUID},
-						"model1": jujuclient.ModelDetails{model1ModelUUID},
-						"model2": jujuclient.ModelDetails{model2ModelUUID},
-					},
-				},
+	s.store.Models = map[string]*jujuclient.ControllerModels{
+		controllerName: {
+			Models: map[string]jujuclient.ModelDetails{
+				"foo":    jujuclient.ModelDetails{fooModelUUID},
+				"bar":    jujuclient.ModelDetails{barModelUUID},
+				"baz":    jujuclient.ModelDetails{bazModelUUID},
+				"model1": jujuclient.ModelDetails{model1ModelUUID},
+				"model2": jujuclient.ModelDetails{model2ModelUUID},
 			},
 		},
 	}

--- a/cmd/juju/model/show.go
+++ b/cmd/juju/model/show.go
@@ -76,7 +76,6 @@ func (c *showModelCommand) Run(ctx *cmd.Context) (err error) {
 	store := c.ClientStore()
 	modelDetails, err := store.ModelByName(
 		c.ControllerName(),
-		c.AccountName(),
 		c.ModelName(),
 	)
 	if err != nil {

--- a/cmd/juju/model/show_test.go
+++ b/cmd/juju/model/show_test.go
@@ -117,14 +117,14 @@ func (s *ShowCommandSuite) SetUpTest(c *gc.C) {
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = "testing"
 	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
-	s.store.Accounts["testing"] = &jujuclient.ControllerAccounts{
-		CurrentAccount: "admin@local",
+	s.store.Accounts["testing"] = jujuclient.AccountDetails{
+		User: "admin@local",
 	}
-	err := s.store.UpdateModel("testing", "admin@local", "mymodel", jujuclient.ModelDetails{
+	err := s.store.UpdateModel("testing", "mymodel", jujuclient.ModelDetails{
 		testing.ModelTag.Id(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	s.store.Models["testing"].AccountModels["admin@local"].CurrentModel = "mymodel"
+	s.store.Models["testing"].CurrentModel = "mymodel"
 }
 
 func (s *ShowCommandSuite) TestShow(c *gc.C) {

--- a/cmd/juju/model/users_test.go
+++ b/cmd/juju/model/users_test.go
@@ -63,8 +63,8 @@ func (s *UsersCommandSuite) SetUpTest(c *gc.C) {
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = "testing"
 	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
-	s.store.Accounts["testing"] = &jujuclient.ControllerAccounts{
-		CurrentAccount: "admin@local",
+	s.store.Accounts["testing"] = jujuclient.AccountDetails{
+		User: "admin@local",
 	}
 }
 

--- a/cmd/juju/storage/package_test.go
+++ b/cmd/juju/storage/package_test.go
@@ -43,7 +43,7 @@ func (s *SubStorageSuite) SetUpTest(c *gc.C) {
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = "testing"
 	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
-	s.store.Accounts["testing"] = &jujuclient.ControllerAccounts{
-		CurrentAccount: "admin@local",
+	s.store.Accounts["testing"] = jujuclient.AccountDetails{
+		User: "admin@local",
 	}
 }

--- a/cmd/juju/user/change_password_test.go
+++ b/cmd/juju/user/change_password_test.go
@@ -107,10 +107,7 @@ func (s *ChangePasswordCommandSuite) TestChangePasswordFail(c *gc.C) {
 // We should not call SetPassword subsequently.
 func (s *ChangePasswordCommandSuite) TestNoSetPasswordAfterFailedWrite(c *gc.C) {
 	store := jujuclienttesting.NewStubStore()
-	store.CurrentAccountFunc = func(string) (string, error) {
-		return "account-name", nil
-	}
-	store.AccountByNameFunc = func(string, string) (*jujuclient.AccountDetails, error) {
+	store.AccountDetailsFunc = func(string) (*jujuclient.AccountDetails, error) {
 		return &jujuclient.AccountDetails{"user", "old-password", ""}, nil
 	}
 	store.ControllerByNameFunc = func(string) (*jujuclient.ControllerDetails, error) {

--- a/cmd/juju/user/info.go
+++ b/cmd/juju/user/info.go
@@ -110,9 +110,7 @@ func (c *infoCommand) Run(ctx *cmd.Context) (err error) {
 	defer client.Close()
 	username := c.Username
 	if username == "" {
-		accountDetails, err := c.ClientStore().AccountByName(
-			c.ControllerName(), c.AccountName(),
-		)
+		accountDetails, err := c.ClientStore().AccountDetails(c.ControllerName())
 		if err != nil {
 			return err
 		}

--- a/cmd/juju/user/login_test.go
+++ b/cmd/juju/user/login_test.go
@@ -100,7 +100,7 @@ You are now logged in to "testing" as "current-user@local".
 }
 
 func (s *LoginCommandSuite) TestLoginNewUser(c *gc.C) {
-	err := s.store.RemoveAccount("testing", "current-user@local")
+	err := s.store.RemoveAccount("testing")
 	c.Assert(err, jc.ErrorIsNil)
 	context, args, err := s.run(c, "", "new-user")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/user/logout.go
+++ b/cmd/juju/user/logout.go
@@ -84,7 +84,7 @@ func (c *logoutCommand) Run(ctx *cmd.Context) error {
 		if name == controllerName {
 			continue
 		}
-		_, err := store.CurrentAccount(name)
+		_, err := store.AccountDetails(name)
 		if errors.IsNotFound(err) {
 			continue
 		} else if err != nil {
@@ -104,15 +104,7 @@ func (c *logoutCommand) Run(ctx *cmd.Context) error {
 }
 
 func (c *logoutCommand) logout(store jujuclient.ClientStore, controllerName string) error {
-	accountName, err := store.CurrentAccount(controllerName)
-	if errors.IsNotFound(err) {
-		// Not logged in; nothing else to do.
-		return nil
-	} else if err != nil {
-		return errors.Trace(err)
-	}
-
-	accountDetails, err := store.AccountByName(controllerName, accountName)
+	accountDetails, err := store.AccountDetails(controllerName)
 	if errors.IsNotFound(err) {
 		// Not logged in; nothing else to do.
 		return nil
@@ -140,7 +132,7 @@ this command again with the "--force" flag.
 	}
 
 	// Remove the account credentials.
-	if err := store.RemoveAccount(controllerName, accountName); err != nil {
+	if err := store.RemoveAccount(controllerName); err != nil {
 		return errors.Annotate(err, "failed to clear credentials")
 	}
 	return nil

--- a/cmd/juju/user/user_test.go
+++ b/cmd/juju/user/user_test.go
@@ -28,25 +28,21 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 		CACert:         testing.CACert,
 		ControllerUUID: testing.ModelTag.Id(),
 	}
-	s.store.Accounts["testing"] = &jujuclient.ControllerAccounts{
-		Accounts: map[string]jujuclient.AccountDetails{
-			"current-user@local": {
-				User:     "current-user@local",
-				Password: "old-password",
-			},
-		},
-		CurrentAccount: "current-user@local",
+	s.store.Accounts["testing"] = jujuclient.AccountDetails{
+		User:     "current-user@local",
+		Password: "old-password",
 	}
 }
 
 func (s *BaseSuite) assertStorePassword(c *gc.C, user, pass string) {
-	details, err := s.store.AccountByName("testing", user)
+	details, err := s.store.AccountDetails("testing")
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(details.User, gc.Equals, user)
 	c.Assert(details.Password, gc.Equals, pass)
 }
 
 func (s *BaseSuite) assertStoreMacaroon(c *gc.C, user string, mac *macaroon.Macaroon) {
-	details, err := s.store.AccountByName("testing", user)
+	details, err := s.store.AccountDetails("testing")
 	c.Assert(err, jc.ErrorIsNil)
 	if mac == nil {
 		c.Assert(details.Macaroon, gc.Equals, "")

--- a/cmd/modelcmd/apiopener.go
+++ b/cmd/modelcmd/apiopener.go
@@ -18,13 +18,13 @@ var ErrConnTimedOut = errors.New("open connection timed out")
 // APIOpener provides a way to open a connection to the Juju
 // API Server through the named connection.
 type APIOpener interface {
-	Open(store jujuclient.ClientStore, controllerName, accountName, modelName string) (api.Connection, error)
+	Open(store jujuclient.ClientStore, controllerName, modelName string) (api.Connection, error)
 }
 
-type OpenFunc func(jujuclient.ClientStore, string, string, string) (api.Connection, error)
+type OpenFunc func(jujuclient.ClientStore, string, string) (api.Connection, error)
 
-func (f OpenFunc) Open(store jujuclient.ClientStore, controllerName, accountName, modelName string) (api.Connection, error) {
-	return f(store, controllerName, accountName, modelName)
+func (f OpenFunc) Open(store jujuclient.ClientStore, controllerName, modelName string) (api.Connection, error) {
+	return f(store, controllerName, modelName)
 }
 
 type timeoutOpener struct {
@@ -44,13 +44,13 @@ func NewTimeoutOpener(opener APIOpener, clock clock.Clock, timeout time.Duration
 	}
 }
 
-func (t *timeoutOpener) Open(store jujuclient.ClientStore, controllerName, accountName, modelName string) (api.Connection, error) {
+func (t *timeoutOpener) Open(store jujuclient.ClientStore, controllerName, modelName string) (api.Connection, error) {
 	// Make the channels buffered so the created goroutine is guaranteed
 	// not go get blocked trying to send down the channel.
 	apic := make(chan api.Connection, 1)
 	errc := make(chan error, 1)
 	go func() {
-		api, dialErr := t.opener.Open(store, controllerName, accountName, modelName)
+		api, dialErr := t.opener.Open(store, controllerName, modelName)
 		if dialErr != nil {
 			errc <- dialErr
 			return

--- a/cmd/modelcmd/apiopener_test.go
+++ b/cmd/modelcmd/apiopener_test.go
@@ -23,66 +23,59 @@ type APIOpenerSuite struct {
 var _ = gc.Suite(&APIOpenerSuite{})
 
 func (*APIOpenerSuite) TestPassthrough(c *gc.C) {
-	var controllerName, accountName, modelName string
-	open := func(_ jujuclient.ClientStore, controllerNameArg, accountNameArg, modelNameArg string) (api.Connection, error) {
+	var controllerName, modelName string
+	open := func(_ jujuclient.ClientStore, controllerNameArg, modelNameArg string) (api.Connection, error) {
 		controllerName = controllerNameArg
-		accountName = accountNameArg
 		modelName = modelNameArg
 		// Lets do the bad thing and return both a connection instance
 		// and an error to check they both come through.
 		return &mockConnection{}, errors.New("boom")
 	}
 	opener := modelcmd.OpenFunc(open)
-	conn, err := opener.Open(nil, "a-name", "b-name", "c-name")
+	conn, err := opener.Open(nil, "a-name", "b-name")
 	c.Assert(err, gc.ErrorMatches, "boom")
 	c.Assert(conn, gc.NotNil)
 	c.Assert(controllerName, gc.Equals, "a-name")
-	c.Assert(accountName, gc.Equals, "b-name")
-	c.Assert(modelName, gc.Equals, "c-name")
+	c.Assert(modelName, gc.Equals, "b-name")
 }
 
 func (*APIOpenerSuite) TestTimoutSuccess(c *gc.C) {
-	var controllerName, accountName, modelName string
-	open := func(_ jujuclient.ClientStore, controllerNameArg, accountNameArg, modelNameArg string) (api.Connection, error) {
+	var controllerName, modelName string
+	open := func(_ jujuclient.ClientStore, controllerNameArg, modelNameArg string) (api.Connection, error) {
 		controllerName = controllerNameArg
-		accountName = accountNameArg
 		modelName = modelNameArg
 		return &mockConnection{}, nil
 	}
 	opener := modelcmd.NewTimeoutOpener(modelcmd.OpenFunc(open), clock.WallClock, 10*time.Second)
-	conn, err := opener.Open(nil, "a-name", "b-name", "c-name")
+	conn, err := opener.Open(nil, "a-name", "b-name")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(conn, gc.NotNil)
 	c.Assert(controllerName, gc.Equals, "a-name")
-	c.Assert(accountName, gc.Equals, "b-name")
-	c.Assert(modelName, gc.Equals, "c-name")
+	c.Assert(modelName, gc.Equals, "b-name")
 }
 
 func (*APIOpenerSuite) TestTimoutErrors(c *gc.C) {
-	var controllerName, accountName, modelName string
-	open := func(_ jujuclient.ClientStore, controllerNameArg, accountNameArg, modelNameArg string) (api.Connection, error) {
+	var controllerName, modelName string
+	open := func(_ jujuclient.ClientStore, controllerNameArg, modelNameArg string) (api.Connection, error) {
 		controllerName = controllerNameArg
-		accountName = accountNameArg
 		modelName = modelNameArg
 		return nil, errors.New("boom")
 	}
 	opener := modelcmd.NewTimeoutOpener(modelcmd.OpenFunc(open), clock.WallClock, 10*time.Second)
-	conn, err := opener.Open(nil, "a-name", "b-name", "c-name")
+	conn, err := opener.Open(nil, "a-name", "b-name")
 	c.Assert(err, gc.ErrorMatches, "boom")
 	c.Assert(conn, gc.IsNil)
 	c.Assert(controllerName, gc.Equals, "a-name")
-	c.Assert(accountName, gc.Equals, "b-name")
-	c.Assert(modelName, gc.Equals, "c-name")
+	c.Assert(modelName, gc.Equals, "b-name")
 }
 
 func (*APIOpenerSuite) TestTimoutClosesAPIOnTimeout(c *gc.C) {
-	var controllerName, accountName, modelName string
+	var controllerName, modelName string
 	finished := make(chan struct{})
 	mockConn := &mockConnection{closed: make(chan struct{})}
-	open := func(_ jujuclient.ClientStore, controllerNameArg, accountNameArg, modelNameArg string) (api.Connection, error) {
+	open := func(_ jujuclient.ClientStore, controllerNameArg, modelNameArg string) (api.Connection, error) {
 		<-finished
 		controllerName = controllerNameArg
-		accountName = accountNameArg
 		modelName = modelNameArg
 		return mockConn, nil
 	}
@@ -90,7 +83,7 @@ func (*APIOpenerSuite) TestTimoutClosesAPIOnTimeout(c *gc.C) {
 	clock := &mockClock{wait: time.Microsecond}
 	// but tell it to wait five seconds
 	opener := modelcmd.NewTimeoutOpener(modelcmd.OpenFunc(open), clock, 5*time.Second)
-	conn, err := opener.Open(nil, "a-name", "b-name", "c-name")
+	conn, err := opener.Open(nil, "a-name", "b-name")
 	c.Assert(errors.Cause(err), gc.Equals, modelcmd.ErrConnTimedOut)
 	c.Assert(conn, gc.IsNil)
 	// check it was told to wait for 5 seconds
@@ -105,8 +98,7 @@ func (*APIOpenerSuite) TestTimoutClosesAPIOnTimeout(c *gc.C) {
 		c.Error("API connection was not closed.")
 	}
 	c.Assert(controllerName, gc.Equals, "a-name")
-	c.Assert(accountName, gc.Equals, "b-name")
-	c.Assert(modelName, gc.Equals, "c-name")
+	c.Assert(modelName, gc.Equals, "b-name")
 }
 
 // mockConnection will panic if anything but close is called.

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -72,11 +72,11 @@ func (c *JujuCommandBase) SetAPIOpen(apiOpen api.OpenFunc) {
 	c.apiOpenFunc = apiOpen
 }
 
-func (c *JujuCommandBase) modelAPI(store jujuclient.ClientStore, controllerName, accountName string) (ModelAPI, error) {
+func (c *JujuCommandBase) modelAPI(store jujuclient.ClientStore, controllerName string) (ModelAPI, error) {
 	if c.modelApi != nil {
 		return c.modelApi, nil
 	}
-	conn, err := c.NewAPIRoot(store, controllerName, accountName, "")
+	conn, err := c.NewAPIRoot(store, controllerName, "")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -88,10 +88,17 @@ func (c *JujuCommandBase) modelAPI(store jujuclient.ClientStore, controllerName,
 // model or controller.
 func (c *JujuCommandBase) NewAPIRoot(
 	store jujuclient.ClientStore,
-	controllerName, accountName, modelName string,
+	controllerName, modelName string,
 ) (api.Connection, error) {
+	accountDetails, err := store.AccountDetails(controllerName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, errors.Trace(ErrNotLoggedInToController)
+		}
+		return nil, errors.Trace(err)
+	}
 	params, err := c.NewAPIConnectionParams(
-		store, controllerName, accountName, modelName,
+		store, controllerName, modelName, accountDetails,
 	)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -105,14 +112,16 @@ func (c *JujuCommandBase) NewAPIRoot(
 // the same arguments.
 func (c *JujuCommandBase) NewAPIConnectionParams(
 	store jujuclient.ClientStore,
-	controllerName, accountName, modelName string,
+	controllerName, modelName string,
+	accountDetails *jujuclient.AccountDetails,
 ) (juju.NewAPIConnectionParams, error) {
 	if err := c.initAPIContext(); err != nil {
 		return juju.NewAPIConnectionParams{}, errors.Trace(err)
 	}
 	return newAPIConnectionParams(
-		store, controllerName, accountName, modelName,
-		c.apiContext.BakeryClient, c.apiOpen,
+		store, controllerName, modelName,
+		accountDetails, c.apiContext.BakeryClient,
+		c.apiOpen,
 	)
 }
 
@@ -148,17 +157,17 @@ func (c *JujuCommandBase) APIOpen(info *api.Info, opts api.DialOpts) (api.Connec
 
 // RefreshModels refreshes the local models cache for the current user
 // on the specified controller.
-func (c *JujuCommandBase) RefreshModels(store jujuclient.ClientStore, controllerName, accountName string) error {
-	accountDetails, err := store.AccountByName(controllerName, accountName)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	modelManager, err := c.modelAPI(store, controllerName, accountName)
+func (c *JujuCommandBase) RefreshModels(store jujuclient.ClientStore, controllerName string) error {
+	modelManager, err := c.modelAPI(store, controllerName)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	defer modelManager.Close()
+
+	accountDetails, err := store.AccountDetails(controllerName)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	models, err := modelManager.ListModels(accountDetails.User)
 	if err != nil {
@@ -166,7 +175,7 @@ func (c *JujuCommandBase) RefreshModels(store jujuclient.ClientStore, controller
 	}
 	for _, model := range models {
 		modelDetails := jujuclient.ModelDetails{model.UUID}
-		if err := store.UpdateModel(controllerName, accountName, model.Name, modelDetails); err != nil {
+		if err := store.UpdateModel(controllerName, model.Name, modelDetails); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -233,25 +242,17 @@ func (w *baseCommandWrapper) Init(args []string) error {
 func newAPIConnectionParams(
 	store jujuclient.ClientStore,
 	controllerName,
-	accountName,
 	modelName string,
+	accountDetails *jujuclient.AccountDetails,
 	bakery *httpbakery.Client,
 	apiOpen api.OpenFunc,
 ) (juju.NewAPIConnectionParams, error) {
 	if controllerName == "" {
 		return juju.NewAPIConnectionParams{}, errors.Trace(errNoNameSpecified)
 	}
-	var accountDetails *jujuclient.AccountDetails
-	if accountName != "" {
-		var err error
-		accountDetails, err = store.AccountByName(controllerName, accountName)
-		if err != nil {
-			return juju.NewAPIConnectionParams{}, errors.Trace(err)
-		}
-	}
 	var modelUUID string
 	if modelName != "" {
-		modelDetails, err := store.ModelByName(controllerName, accountName, modelName)
+		modelDetails, err := store.ModelByName(controllerName, modelName)
 		if err != nil {
 			return juju.NewAPIConnectionParams{}, errors.Trace(err)
 		}

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -30,11 +30,8 @@ func (s *BaseCommandSuite) SetUpTest(c *gc.C) {
 	s.store.Controllers["foo"] = jujuclient.ControllerDetails{
 		APIEndpoints: []string{"testing.invalid:1234"},
 	}
-	s.store.Accounts["foo"] = &jujuclient.ControllerAccounts{
-		Accounts: map[string]jujuclient.AccountDetails{
-			"bar@local": {User: "bar@local", Password: "hunter2"},
-		},
-		CurrentAccount: "bar@local",
+	s.store.Accounts["foo"] = jujuclient.AccountDetails{
+		User: "bar@local", Password: "hunter2",
 	}
 }
 
@@ -44,7 +41,7 @@ func (s *BaseCommandSuite) TestLoginExpiry(c *gc.C) {
 	}
 	var cmd modelcmd.JujuCommandBase
 	cmd.SetAPIOpen(apiOpen)
-	conn, err := cmd.NewAPIRoot(s.store, "foo", "bar@local", "")
+	conn, err := cmd.NewAPIRoot(s.store, "foo", "")
 	c.Assert(conn, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, `login expired
 

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -33,11 +33,6 @@ connect to another controller that you have been given access to using "juju reg
 Please use "juju controllers" to view all controllers available to you. 
 You can login into an existing controller using "juju login -c <controller>".
 `)
-
-	// ErrNoAccountSpecified is returned by commands that operate on a
-	// controller if there is no current account associated with the
-	// controller.
-	ErrNoAccountSpecified = errors.New("no account specified")
 )
 
 // ControllerCommand is intended to be a base for all commands
@@ -76,7 +71,6 @@ type ControllerCommandBase struct {
 
 	store          jujuclient.ClientStore
 	controllerName string
-	accountName    string
 
 	// opener is the strategy used to open the API connection.
 	opener APIOpener
@@ -97,23 +91,13 @@ func (c *ControllerCommandBase) SetControllerName(controllerName string) error {
 	if _, err := c.ClientStore().ControllerByName(controllerName); err != nil {
 		return errors.Trace(err)
 	}
-	accountName, err := c.store.CurrentAccount(controllerName)
-	if err != nil && !errors.IsNotFound(err) {
-		return errors.Trace(err)
-	}
 	c.controllerName = controllerName
-	c.accountName = accountName
 	return nil
 }
 
 // ControllerName implements the ControllerCommand interface.
 func (c *ControllerCommandBase) ControllerName() string {
 	return c.controllerName
-}
-
-// AccountName implements the ControllerCommand interface.
-func (c *ControllerCommandBase) AccountName() string {
-	return c.accountName
 }
 
 // SetAPIOpener specifies the strategy used by the command to open
@@ -166,14 +150,11 @@ func (c *ControllerCommandBase) NewAPIRoot() (api.Connection, error) {
 		}
 		return nil, errors.Trace(ErrNotLoggedInToController)
 	}
-	if c.accountName == "" {
-		return nil, errors.Trace(ErrNoAccountSpecified)
-	}
 	opener := c.opener
 	if opener == nil {
 		opener = OpenFunc(c.JujuCommandBase.NewAPIRoot)
 	}
-	return opener.Open(c.store, c.controllerName, c.accountName, "")
+	return opener.Open(c.store, c.controllerName, "")
 }
 
 // ModelUUIDs returns the model UUIDs for the given model names.
@@ -181,16 +162,15 @@ func (c *ControllerCommandBase) ModelUUIDs(modelNames []string) ([]string, error
 	var result []string
 	store := c.ClientStore()
 	controllerName := c.ControllerName()
-	accountName := c.AccountName()
 	for _, modelName := range modelNames {
-		model, err := store.ModelByName(controllerName, accountName, modelName)
+		model, err := store.ModelByName(controllerName, modelName)
 		if errors.IsNotFound(err) {
 			// The model isn't known locally, so query the models available in the controller.
 			logger.Infof("model %q not cached locally, refreshing models from controller", modelName)
-			if err := c.RefreshModels(store, controllerName, accountName); err != nil {
+			if err := c.RefreshModels(store, controllerName); err != nil {
 				return nil, errors.Annotatef(err, "refreshing model %q", modelName)
 			}
-			model, err = store.ModelByName(controllerName, accountName, modelName)
+			model, err = store.ModelByName(controllerName, modelName)
 		}
 		if err != nil {
 			return nil, errors.Annotatef(err, "model %q not found", modelName)

--- a/cmd/modelcmd/controller_test.go
+++ b/cmd/modelcmd/controller_test.go
@@ -29,8 +29,8 @@ func (s *ControllerCommandSuite) TestControllerCommandNoneSpecified(c *gc.C) {
 func (s *ControllerCommandSuite) TestControllerCommandInitCurrentController(c *gc.C) {
 	store := jujuclienttesting.NewMemStore()
 	store.CurrentControllerName = "foo"
-	store.Accounts["foo"] = &jujuclient.ControllerAccounts{
-		CurrentAccount: "bar@baz",
+	store.Accounts["foo"] = jujuclient.AccountDetails{
+		User: "bar@local",
 	}
 	store.Controllers["foo"] = jujuclient.ControllerDetails{}
 	testEnsureControllerName(c, store, "foo")
@@ -41,8 +41,8 @@ func (s *ControllerCommandSuite) TestControllerCommandInitExplicit(c *gc.C) {
 	// controller file.
 	store := jujuclienttesting.NewMemStore()
 	store.CurrentControllerName = "foo"
-	store.Accounts["explicit"] = &jujuclient.ControllerAccounts{
-		CurrentAccount: "bar@baz",
+	store.Accounts["explicit"] = jujuclient.AccountDetails{
+		User: "bar@local",
 	}
 	store.Controllers["explicit"] = jujuclient.ControllerDetails{}
 	testEnsureControllerName(c, store, "explicit", "-c", "explicit")

--- a/cmd/modelcmd/export_test.go
+++ b/cmd/modelcmd/export_test.go
@@ -7,11 +7,10 @@ import "github.com/juju/juju/jujuclient"
 
 // NewModelCommandBase returns a new ModelCommandBase with the given client
 // store, controller name, and model name.
-func NewModelCommandBase(store jujuclient.ClientStore, controller, account, model string) *ModelCommandBase {
+func NewModelCommandBase(store jujuclient.ClientStore, controller, model string) *ModelCommandBase {
 	return &ModelCommandBase{
 		store:          store,
 		controllerName: controller,
-		accountName:    account,
 		modelName:      model,
 	}
 }

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -33,11 +33,8 @@ func (s *ModelCommandSuite) SetUpTest(c *gc.C) {
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = "foo"
 	s.store.Controllers["foo"] = jujuclient.ControllerDetails{}
-	s.store.Accounts["foo"] = &jujuclient.ControllerAccounts{
-		Accounts: map[string]jujuclient.AccountDetails{
-			"bar@baz": {User: "b@r", Password: "hunter2"},
-		},
-		CurrentAccount: "bar@baz",
+	s.store.Accounts["foo"] = jujuclient.AccountDetails{
+		User: "bar@local", Password: "hunter2",
 	}
 }
 
@@ -50,23 +47,16 @@ func (s *ModelCommandSuite) TestGetCurrentModelNothingSet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *ModelCommandSuite) TestGetCurrentModelCurrentControllerNoCurrentAccount(c *gc.C) {
-	delete(s.store.Accounts, "foo")
-	env, err := modelcmd.GetCurrentModel(s.store)
-	c.Assert(env, gc.Equals, "")
-	c.Assert(err, jc.ErrorIsNil)
-}
-
 func (s *ModelCommandSuite) TestGetCurrentModelCurrentControllerNoCurrentModel(c *gc.C) {
 	env, err := modelcmd.GetCurrentModel(s.store)
 	c.Assert(env, gc.Equals, "foo:")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *ModelCommandSuite) TestGetCurrentModelCurrentControllerAccountModel(c *gc.C) {
-	err := s.store.UpdateModel("foo", "bar@baz", "mymodel", jujuclient.ModelDetails{"uuid"})
+func (s *ModelCommandSuite) TestGetCurrentModelCurrentControllerModel(c *gc.C) {
+	err := s.store.UpdateModel("foo", "mymodel", jujuclient.ModelDetails{"uuid"})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.store.SetCurrentModel("foo", "bar@baz", "mymodel")
+	err = s.store.SetCurrentModel("foo", "mymodel")
 	c.Assert(err, jc.ErrorIsNil)
 
 	env, err := modelcmd.GetCurrentModel(s.store)
@@ -84,9 +74,9 @@ func (s *ModelCommandSuite) TestGetCurrentModelJujuEnvSet(c *gc.C) {
 func (s *ModelCommandSuite) TestGetCurrentModelBothSet(c *gc.C) {
 	os.Setenv(osenv.JujuModelEnvKey, "magic")
 
-	err := s.store.UpdateModel("foo", "bar@baz", "mymodel", jujuclient.ModelDetails{"uuid"})
+	err := s.store.UpdateModel("foo", "mymodel", jujuclient.ModelDetails{"uuid"})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.store.SetCurrentModel("foo", "bar@baz", "mymodel")
+	err = s.store.SetCurrentModel("foo", "mymodel")
 	c.Assert(err, jc.ErrorIsNil)
 
 	env, err := modelcmd.GetCurrentModel(s.store)
@@ -105,9 +95,9 @@ func (s *ModelCommandSuite) TestModelCommandInitExplicitLongForm(c *gc.C) {
 }
 
 func (s *ModelCommandSuite) TestModelCommandInitEnvFile(c *gc.C) {
-	err := s.store.UpdateModel("foo", "bar@baz", "mymodel", jujuclient.ModelDetails{"uuid"})
+	err := s.store.UpdateModel("foo", "mymodel", jujuclient.ModelDetails{"uuid"})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.store.SetCurrentModel("foo", "bar@baz", "mymodel")
+	err = s.store.SetCurrentModel("foo", "mymodel")
 	c.Assert(err, jc.ErrorIsNil)
 	s.testEnsureModelName(c, "mymodel")
 }
@@ -191,7 +181,6 @@ type macaroonLoginSuite struct {
 	apitesting.MacaroonSuite
 	store          *jujuclienttesting.MemStore
 	controllerName string
-	accountName    string
 	modelName      string
 }
 
@@ -202,7 +191,6 @@ func (s *macaroonLoginSuite) SetUpTest(c *gc.C) {
 	s.MacaroonSuite.AddModelUser(c, testUser)
 
 	s.controllerName = "my-controller"
-	s.accountName = "my@account"
 	s.modelName = "my-model"
 	modelTag := names.NewModelTag(s.State.ModelUUID())
 	apiInfo := s.APIInfo(c)
@@ -213,20 +201,13 @@ func (s *macaroonLoginSuite) SetUpTest(c *gc.C) {
 		ControllerUUID: apiInfo.ModelTag.Id(),
 		CACert:         apiInfo.CACert,
 	}
-	s.store.Accounts[s.controllerName] = &jujuclient.ControllerAccounts{
-		Accounts: map[string]jujuclient.AccountDetails{
-			// Empty password forces use of macaroons.
-			s.accountName: {User: s.accountName},
-		},
-		CurrentAccount: s.accountName,
+	s.store.Accounts[s.controllerName] = jujuclient.AccountDetails{
+		// External user forces use of macaroons.
+		User: "me@external",
 	}
-	s.store.Models[s.controllerName] = jujuclient.ControllerAccountModels{
-		AccountModels: map[string]*jujuclient.AccountModels{
-			s.accountName: {
-				Models: map[string]jujuclient.ModelDetails{
-					s.modelName: {modelTag.Id()},
-				},
-			},
+	s.store.Models[s.controllerName] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{
+			s.modelName: {modelTag.Id()},
 		},
 	}
 }
@@ -236,7 +217,7 @@ func (s *macaroonLoginSuite) TestsSuccessfulLogin(c *gc.C) {
 		return testUser
 	}
 
-	cmd := modelcmd.NewModelCommandBase(s.store, s.controllerName, s.accountName, s.modelName)
+	cmd := modelcmd.NewModelCommandBase(s.store, s.controllerName, s.modelName)
 	_, err := cmd.NewAPIRoot()
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -246,7 +227,7 @@ func (s *macaroonLoginSuite) TestsFailToObtainDischargeLogin(c *gc.C) {
 		return ""
 	}
 
-	cmd := modelcmd.NewModelCommandBase(s.store, s.controllerName, s.accountName, s.modelName)
+	cmd := modelcmd.NewModelCommandBase(s.store, s.controllerName, s.modelName)
 	_, err := cmd.NewAPIRoot()
 	c.Assert(err, gc.ErrorMatches, "cannot get discharge.*")
 }
@@ -256,7 +237,7 @@ func (s *macaroonLoginSuite) TestsUnknownUserLogin(c *gc.C) {
 		return "testUnknown@nowhere"
 	}
 
-	cmd := modelcmd.NewModelCommandBase(s.store, s.controllerName, s.accountName, s.modelName)
+	cmd := modelcmd.NewModelCommandBase(s.store, s.controllerName, s.modelName)
 	_, err := cmd.NewAPIRoot()
 	c.Assert(err, gc.ErrorMatches, "invalid entity name or password \\(unauthorized access\\)")
 }

--- a/cmd/plugins/juju-metadata/listimages_test.go
+++ b/cmd/plugins/juju-metadata/listimages_test.go
@@ -33,8 +33,8 @@ func (s *BaseCloudImageMetadataSuite) setupBaseSuite(c *gc.C) {
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = "testing"
 	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
-	s.store.Accounts["testing"] = &jujuclient.ControllerAccounts{
-		CurrentAccount: "admin@local",
+	s.store.Accounts["testing"] = jujuclient.AccountDetails{
+		User: "admin@local",
 	}
 }
 

--- a/cmd/plugins/juju-metadata/validateimagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata_test.go
@@ -107,8 +107,8 @@ func cacheTestEnvConfig(c *gc.C, store *jujuclienttesting.MemStore) {
 		ControllerUUID: coretesting.ModelTag.Id(),
 		CACert:         coretesting.CACert,
 	}
-	store.Accounts["ec2-controller"] = &jujuclient.ControllerAccounts{
-		CurrentAccount: "admin@local",
+	store.Accounts["ec2-controller"] = jujuclient.AccountDetails{
+		User: "admin@local",
 	}
 	store.BootstrapConfig["ec2-controller"] = jujuclient.BootstrapConfig{
 		Config:      ec2Config.AllAttrs(),
@@ -134,8 +134,8 @@ func cacheTestEnvConfig(c *gc.C, store *jujuclienttesting.MemStore) {
 		ControllerUUID: coretesting.ModelTag.Id(),
 		CACert:         coretesting.CACert,
 	}
-	store.Accounts["azure-controller"] = &jujuclient.ControllerAccounts{
-		CurrentAccount: "admin@local",
+	store.Accounts["azure-controller"] = jujuclient.AccountDetails{
+		User: "admin@local",
 	}
 	store.BootstrapConfig["azure-controller"] = jujuclient.BootstrapConfig{
 		Config:               azureConfig.AllAttrs(),

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -33,7 +33,7 @@ github.com/juju/persistent-cookiejar	git	e710b897c13ca52828ca2fc9769465186fd6d15
 github.com/juju/replicaset	git	fb7294cf57a1e2f08a57691f1246d129a87ab7e8	2015-05-08T02:21:43Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:42:13Z
-github.com/juju/romulus	git	6bf2184bf0e9fe3e74d317e81a9a49a4cdcdf20b	2016-06-20T21:29:55Z
+github.com/juju/romulus	git	ce1888c89480dfea16e280af34b4b3d7b456a325	2016-07-14T09:41:15Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/testing	git	ccf839b5a07a7a05009f8fa3ec41cd05fb2e0b08	2016-06-24T20:35:24Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -130,23 +130,19 @@ func decorateAndWriteInfo(
 	details prepareDetails,
 	controllerName, modelName string,
 ) error {
-	accountName := details.User
 	if err := store.UpdateController(controllerName, details.ControllerDetails); err != nil {
 		return errors.Trace(err)
 	}
 	if err := store.UpdateBootstrapConfig(controllerName, details.BootstrapConfig); err != nil {
 		return errors.Trace(err)
 	}
-	if err := store.UpdateAccount(controllerName, accountName, details.AccountDetails); err != nil {
+	if err := store.UpdateAccount(controllerName, details.AccountDetails); err != nil {
 		return errors.Trace(err)
 	}
-	if err := store.SetCurrentAccount(controllerName, accountName); err != nil {
+	if err := store.UpdateModel(controllerName, modelName, details.ModelDetails); err != nil {
 		return errors.Trace(err)
 	}
-	if err := store.UpdateModel(controllerName, accountName, modelName, details.ModelDetails); err != nil {
-		return errors.Trace(err)
-	}
-	if err := store.SetCurrentModel(controllerName, accountName, modelName); err != nil {
+	if err := store.SetCurrentModel(controllerName, modelName); err != nil {
 		return errors.Trace(err)
 	}
 	return nil

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -103,7 +103,7 @@ func (s *OpenSuite) TestUpdateEnvInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(foundController.ControllerUUID, gc.Not(gc.Equals), "")
 	c.Assert(foundController.CACert, gc.Not(gc.Equals), "")
-	foundModel, err := store.ModelByName("controller-name", "admin@local", "admin-model")
+	foundModel, err := store.ModelByName("controller-name", "admin-model")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(foundModel, jc.DeepEquals, &jujuclient.ModelDetails{
 		ModelUUID: cfg.UUID(),

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -160,9 +160,9 @@ before "juju ssh", "juju scp", or "juju debug-hooks" will work.
 
 	// Make sure that the saved server details are sufficient to connect
 	// to the api server.
-	accountDetails, err := s.ControllerStore.AccountByName("kontroll", "admin@local")
+	accountDetails, err := s.ControllerStore.AccountDetails("kontroll")
 	c.Assert(err, jc.ErrorIsNil)
-	modelDetails, err := s.ControllerStore.ModelByName("kontroll", "admin@local", "new-model")
+	modelDetails, err := s.ControllerStore.ModelByName("kontroll", "new-model")
 	c.Assert(err, jc.ErrorIsNil)
 	api, err := juju.NewAPIConnection(juju.NewAPIConnectionParams{
 		Store:           s.ControllerStore,

--- a/featuretests/cmd_juju_login_test.go
+++ b/featuretests/cmd_juju_login_test.go
@@ -60,7 +60,7 @@ You are now logged in to "kontroll" as "test@local".
 
 	// We should have a macaroon, but no password, in the client store.
 	store := jujuclient.NewFileClientStore()
-	accountDetails, err := store.AccountByName("kontroll", "test@local")
+	accountDetails, err := store.AccountDetails("kontroll")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(accountDetails.Password, gc.Equals, "")
 	c.Assert(accountDetails.Macaroon, gc.Not(gc.Equals), "")

--- a/featuretests/cmd_juju_register_test.go
+++ b/featuretests/cmd_juju_register_test.go
@@ -76,7 +76,7 @@ of a model to grant access to that model with "juju grant".
 
 	// Make sure that the saved server details are sufficient to connect
 	// to the api server.
-	accountDetails, err := s.ControllerStore.AccountByName("bob-controller", "bob@local")
+	accountDetails, err := s.ControllerStore.AccountDetails("bob-controller")
 	c.Assert(err, jc.ErrorIsNil)
 	api, err := juju.NewAPIConnection(juju.NewAPIConnectionParams{
 		Store:           s.ControllerStore,

--- a/juju/api.go
+++ b/juju/api.go
@@ -225,27 +225,25 @@ func connectionInfo(args NewAPIConnectionParams) (*api.Info, *jujuclient.Control
 		return apiInfo, controller, nil
 	}
 	account := args.AccountDetails
-	// We only set the tag if either a password or
-	// macaroon is found in the accounts.yaml file.
-	// If neither is found, we'll use external
-	// macaroon authentication which requires that
-	// no tag be specified.
-	userTag := names.NewUserTag(account.User)
 	if args.AccountDetails.Password != "" {
 		// If a password is available, we always use
 		// that.
 		//
 		// TODO(axw) make it invalid to store both
 		// password and macaroon in accounts.yaml?
-		apiInfo.Tag = userTag
+		apiInfo.Tag = names.NewUserTag(account.User)
 		apiInfo.Password = account.Password
 	} else if args.AccountDetails.Macaroon != "" {
 		var m macaroon.Macaroon
 		if err := json.Unmarshal([]byte(account.Macaroon), &m); err != nil {
 			return nil, nil, errors.Trace(err)
 		}
-		apiInfo.Tag = userTag
+		apiInfo.Tag = names.NewUserTag(account.User)
 		apiInfo.Macaroons = []macaroon.Slice{{&m}}
+	} else {
+		// Neither a password nor a local user macaroon was
+		// found, so we'll use external macaroon authentication,
+		// which requires that no tag be specified.
 	}
 	return apiInfo, controller, nil
 }

--- a/jujuclient/accounts_test.go
+++ b/jujuclient/accounts_test.go
@@ -6,7 +6,6 @@ package jujuclient_test
 import (
 	"os"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -27,33 +26,28 @@ func (s *AccountsSuite) SetUpTest(c *gc.C) {
 	writeTestAccountsFile(c)
 }
 
-func (s *AccountsSuite) TestAccountByNameNoFile(c *gc.C) {
+func (s *AccountsSuite) TestAccountDetailsNoFile(c *gc.C) {
 	err := os.Remove(jujuclient.JujuAccountsPath())
 	c.Assert(err, jc.ErrorIsNil)
-	details, err := s.store.AccountByName("not-found", "admin@local")
-	c.Assert(err, gc.ErrorMatches, "controller not-found not found")
+	details, err := s.store.AccountDetails("not-found")
+	c.Assert(err, gc.ErrorMatches, "account details for controller not-found not found")
 	c.Assert(details, gc.IsNil)
 }
 
-func (s *AccountsSuite) TestAccountByNameControllerNotFound(c *gc.C) {
-	details, err := s.store.AccountByName("not-found", "admin@local")
-	c.Assert(err, gc.ErrorMatches, "controller not-found not found")
+func (s *AccountsSuite) TestAccountDetailsControllerNotFound(c *gc.C) {
+	details, err := s.store.AccountDetails("not-found")
+	c.Assert(err, gc.ErrorMatches, "account details for controller not-found not found")
 	c.Assert(details, gc.IsNil)
 }
 
-func (s *AccountsSuite) TestAccountByNameAccountNotFound(c *gc.C) {
-	details, err := s.store.AccountByName("kontroll", "admin@nowhere")
-	c.Assert(err, gc.ErrorMatches, "account kontroll:admin@nowhere not found")
-	c.Assert(details, gc.IsNil)
-}
-
-func (s *AccountsSuite) TestAccountByName(c *gc.C) {
-	details, err := s.store.AccountByName("kontroll", "admin@local")
+func (s *AccountsSuite) TestAccountDetails(c *gc.C) {
+	details, err := s.store.AccountDetails("kontroll")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(details, gc.NotNil)
-	c.Assert(*details, jc.DeepEquals, testControllerAccounts["kontroll"].Accounts["admin@local"])
+	c.Assert(*details, jc.DeepEquals, kontrollBobRemoteAccountDetails)
 }
 
+/*
 func (s *AccountsSuite) TestAllAccountsNoFile(c *gc.C) {
 	err := os.Remove(jujuclient.JujuAccountsPath())
 	c.Assert(err, jc.ErrorIsNil)
@@ -151,7 +145,7 @@ func (s *AccountsSuite) TestUpdateAccountOverwrites(c *gc.C) {
 		// identical details.
 		err := s.store.UpdateAccount("kontroll", "admin@local", testAccountDetails)
 		c.Assert(err, jc.ErrorIsNil)
-		details, err := s.store.AccountByName("kontroll", "admin@local")
+		details, err := s.store.AccountDetails("kontroll", "admin@local")
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(*details, jc.DeepEquals, testAccountDetails)
 	}
@@ -177,7 +171,7 @@ func (s *AccountsSuite) TestRemoveAccountNotFound(c *gc.C) {
 func (s *AccountsSuite) TestRemoveAccount(c *gc.C) {
 	err := s.store.RemoveAccount("kontroll", "admin@local")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.store.AccountByName("kontroll", "admin@local")
+	_, err = s.store.AccountDetails("kontroll", "admin@local")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
@@ -196,3 +190,4 @@ func (s *AccountsSuite) TestRemoveControllerRemovesaccounts(c *gc.C) {
 	_, ok := accounts["kontroll"]
 	c.Assert(ok, jc.IsFalse) // kontroll accounts are removed
 }
+*/

--- a/jujuclient/accountsfile_test.go
+++ b/jujuclient/accountsfile_test.go
@@ -23,54 +23,24 @@ var _ = gc.Suite(&AccountsFileSuite{})
 const testAccountsYAML = `
 controllers:
   ctrl:
-    accounts:
-      admin@local:
-        user: admin@local
-        password: hunter2
+    user: admin@local
+    password: hunter2
   kontroll:
-    accounts:
-      admin@local:
-        user: admin@local
-        password: hunter2
-      bob@local:
-        user: bob@local
-        password: huntert00
-      bob@remote:
-        user: bob@remote
-    current-account: admin@local
+    user: bob@remote
 `
 
-var testControllerAccounts = map[string]*jujuclient.ControllerAccounts{
-	"kontroll": {
-		Accounts: map[string]jujuclient.AccountDetails{
-			"admin@local": kontrollAdminAccountDetails,
-			"bob@local":   kontrollBobLocalAccountDetails,
-			"bob@remote":  kontrollBobRemoteAccountDetails,
-		},
-		CurrentAccount: "admin@local",
-	},
-	"ctrl": {
-		Accounts: map[string]jujuclient.AccountDetails{
-			"admin@local": ctrlAdminAccountDetails,
-		},
-	},
+var testControllerAccounts = map[string]jujuclient.AccountDetails{
+	"ctrl":     ctrlAdminAccountDetails,
+	"kontroll": kontrollBobRemoteAccountDetails,
 }
 
 var (
-	kontrollAdminAccountDetails = jujuclient.AccountDetails{
-		User:     "admin@local",
-		Password: "hunter2",
-	}
-	kontrollBobLocalAccountDetails = jujuclient.AccountDetails{
-		User:     "bob@local",
-		Password: "huntert00",
-	}
-	kontrollBobRemoteAccountDetails = jujuclient.AccountDetails{
-		User: "bob@remote",
-	}
 	ctrlAdminAccountDetails = jujuclient.AccountDetails{
 		User:     "admin@local",
 		Password: "hunter2",
+	}
+	kontrollBobRemoteAccountDetails = jujuclient.AccountDetails{
+		User: "bob@remote",
 	}
 )
 

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -134,13 +134,13 @@ type ModelUpdater interface {
 	//
 	// If the model does not already exist, it will be added.
 	// Otherwise, it will be overwritten with the new details.
-	UpdateModel(controllerName, accountName, modelName string, details ModelDetails) error
+	UpdateModel(controllerName, modelName string, details ModelDetails) error
 
 	// SetCurrentModel sets the name of the current model for
 	// the specified controller and account. If there exists no
 	// model with the specified names, an error satisfying
 	// errors.IsNotFound will be returned.
-	SetCurrentModel(controllerName, accountName, modelName string) error
+	SetCurrentModel(controllerName, modelName string) error
 }
 
 // ModelRemover removes models.
@@ -149,79 +149,54 @@ type ModelRemover interface {
 	// and model names from the models collection. If there is no model
 	// with the specified names, an errors satisfying errors.IsNotFound
 	// will be returned.
-	RemoveModel(controllerName, accountName, modelName string) error
+	RemoveModel(controllerName, modelName string) error
 }
 
 // ModelGetter gets models.
 type ModelGetter interface {
-	// AllModels gets all models for the specified controller and
-	// account.
+	// AllModels gets all models for the specified controller as a map
+	// from model name to its details.
 	//
-	// If there is no controller or account with the specified
-	// names, or no models cached for the controller and account,
+	// If there is no controller with the specified
+	// name, or no models cached for the controller and account,
 	// an error satisfying errors.IsNotFound will be returned.
-	AllModels(controllerName, accountName string) (map[string]ModelDetails, error)
+	AllModels(controllerName string) (map[string]ModelDetails, error)
 
 	// CurrentModel returns the name of the current model for
-	// the specified controller and account. If there is no current
-	// model for the controller and account, an error satisfying
+	// the specified controller. If there is no current
+	// model for the controller, an error satisfying
 	// errors.IsNotFound is returned.
-	CurrentModel(controllerName, accountName string) (string, error)
+	CurrentModel(controllerName string) (string, error)
 
 	// ModelByName returns the model with the specified controller,
-	// account, and model names. If there exists no model with the
-	// specified names, an error satisfying errors.IsNotFound will
-	// be returned.
-	ModelByName(controllerName, accountName, modelName string) (*ModelDetails, error)
+	// and model name. If a model with the specified name does not
+	// exist, an error satisfying errors.IsNotFound will be
+	// returned.
+	ModelByName(controllerName, modelName string) (*ModelDetails, error)
 }
 
 // AccountUpdater stores account details.
 type AccountUpdater interface {
-	// UpdateAccount adds the given account to the account collection.
-	//
-	// If the account does not already exist, it will be added.
-	// Otherwise, it will be overwritten with the new details.
-	//
-	// It is currently not permitted to create multiple account entries
-	// for a controller; doing so will result in an error satisfying
-	// errors.IsAlreadyExists.
-	UpdateAccount(controllerName, accountName string, details AccountDetails) error
-
-	// SetCurrentAccount sets the name of the current account for
-	// the specified controller. If there exists no account with
-	// the specified names, an error satisfying errors.IsNotFound
-	// will be returned.
-	SetCurrentAccount(controllerName, accountName string) error
+	// UpdateAccount updates the account associated with the
+	// given controller.
+	UpdateAccount(controllerName string, details AccountDetails) error
 }
 
 // AccountRemover removes accounts.
 type AccountRemover interface {
-	// RemoveAccount removes the account with the given controller and account
-	// names from the accounts collection. If there is no account with the
+	// RemoveAccount removes the account associated with the given controller.
+	// If there is no associated account with the
 	// specified names, an errors satisfying errors.IsNotFound will be
 	// returned.
-	RemoveAccount(controllerName, accountName string) error
+	RemoveAccount(controllerName string) error
 }
 
 // AccountGetter gets accounts.
 type AccountGetter interface {
-	// AllAccounts gets all accounts for the specified controller.
-	//
-	// If there is no controller with the specified name, or
-	// no accounts cached for the controller, an error satisfying
-	// errors.IsNotFound will be returned.
-	AllAccounts(controllerName string) (map[string]AccountDetails, error)
-
-	// CurrentAccount returns the name of the current account for
-	// the specified controller. If there is no current account
-	// for the controller, an error satisfying errors.IsNotFound
-	// is returned.
-	CurrentAccount(controllerName string) (string, error)
-
-	// AccountByName returns the account with the specified controller
-	// and account names. If there exists no account with the specified
-	// names, an error satisfying errors.IsNotFound will be returned.
-	AccountByName(controllerName, accountName string) (*AccountDetails, error)
+	// AccountByName returns the account associated with the given
+	// controller name. If no associated account exists, an error
+	// satisfying errors.IsNotFound will be returned.
+	AccountDetails(controllerName string) (*AccountDetails, error)
 }
 
 // CredentialGetter gets credentials.

--- a/jujuclient/jujuclienttesting/stub.go
+++ b/jujuclient/jujuclienttesting/stub.go
@@ -20,19 +20,16 @@ type StubStore struct {
 	SetCurrentControllerFunc func(name string) error
 	CurrentControllerFunc    func() (string, error)
 
-	UpdateModelFunc     func(controller, account, model string, details jujuclient.ModelDetails) error
-	SetCurrentModelFunc func(controller, account, model string) error
-	RemoveModelFunc     func(controller, account, model string) error
-	AllModelsFunc       func(controller, account string) (map[string]jujuclient.ModelDetails, error)
-	CurrentModelFunc    func(controller, account string) (string, error)
-	ModelByNameFunc     func(controller, account, model string) (*jujuclient.ModelDetails, error)
+	UpdateModelFunc     func(controller, model string, details jujuclient.ModelDetails) error
+	SetCurrentModelFunc func(controller, model string) error
+	RemoveModelFunc     func(controller, model string) error
+	AllModelsFunc       func(controller string) (map[string]jujuclient.ModelDetails, error)
+	CurrentModelFunc    func(controller string) (string, error)
+	ModelByNameFunc     func(controller, model string) (*jujuclient.ModelDetails, error)
 
-	UpdateAccountFunc     func(controllerName, accountName string, details jujuclient.AccountDetails) error
-	SetCurrentAccountFunc func(controllerName, accountName string) error
-	AllAccountsFunc       func(controllerName string) (map[string]jujuclient.AccountDetails, error)
-	CurrentAccountFunc    func(controllerName string) (string, error)
-	AccountByNameFunc     func(controllerName, accountName string) (*jujuclient.AccountDetails, error)
-	RemoveAccountFunc     func(controllerName, accountName string) error
+	UpdateAccountFunc  func(controllerName string, details jujuclient.AccountDetails) error
+	AccountDetailsFunc func(controllerName string) (*jujuclient.AccountDetails, error)
+	RemoveAccountFunc  func(controllerName string) error
 
 	CredentialForCloudFunc func(string) (*cloud.CloudCredential, error)
 	AllCredentialsFunc     func() (map[string]cloud.CloudCredential, error)
@@ -65,41 +62,32 @@ func NewStubStore() *StubStore {
 		return "", result.Stub.NextErr()
 	}
 
-	result.UpdateModelFunc = func(controller, account, model string, details jujuclient.ModelDetails) error {
+	result.UpdateModelFunc = func(controller, model string, details jujuclient.ModelDetails) error {
 		return result.Stub.NextErr()
 	}
-	result.SetCurrentModelFunc = func(controller, account, model string) error {
+	result.SetCurrentModelFunc = func(controller, model string) error {
 		return result.Stub.NextErr()
 	}
-	result.RemoveModelFunc = func(controller, account, model string) error {
+	result.RemoveModelFunc = func(controller, model string) error {
 		return result.Stub.NextErr()
 	}
-	result.AllModelsFunc = func(controller, account string) (map[string]jujuclient.ModelDetails, error) {
+	result.AllModelsFunc = func(controller string) (map[string]jujuclient.ModelDetails, error) {
 		return nil, result.Stub.NextErr()
 	}
-	result.CurrentModelFunc = func(controller, account string) (string, error) {
+	result.CurrentModelFunc = func(controller string) (string, error) {
 		return "", result.Stub.NextErr()
 	}
-	result.ModelByNameFunc = func(controller, account, model string) (*jujuclient.ModelDetails, error) {
+	result.ModelByNameFunc = func(controller, model string) (*jujuclient.ModelDetails, error) {
 		return nil, result.Stub.NextErr()
 	}
 
-	result.UpdateAccountFunc = func(controllerName, accountName string, details jujuclient.AccountDetails) error {
+	result.UpdateAccountFunc = func(controllerName string, details jujuclient.AccountDetails) error {
 		return result.Stub.NextErr()
 	}
-	result.SetCurrentAccountFunc = func(controllerName, accountName string) error {
-		return result.Stub.NextErr()
-	}
-	result.AllAccountsFunc = func(controllerName string) (map[string]jujuclient.AccountDetails, error) {
+	result.AccountDetailsFunc = func(controllerName string) (*jujuclient.AccountDetails, error) {
 		return nil, result.Stub.NextErr()
 	}
-	result.CurrentAccountFunc = func(controllerName string) (string, error) {
-		return "", result.Stub.NextErr()
-	}
-	result.AccountByNameFunc = func(controllerName, accountName string) (*jujuclient.AccountDetails, error) {
-		return nil, result.Stub.NextErr()
-	}
-	result.RemoveAccountFunc = func(controllerName, accountName string) error {
+	result.RemoveAccountFunc = func(controllerName string) error {
 		return result.Stub.NextErr()
 	}
 
@@ -140,10 +128,7 @@ func WrapClientStore(underlying jujuclient.ClientStore) *StubStore {
 	stub.CurrentModelFunc = underlying.CurrentModel
 	stub.ModelByNameFunc = underlying.ModelByName
 	stub.UpdateAccountFunc = underlying.UpdateAccount
-	stub.SetCurrentAccountFunc = underlying.SetCurrentAccount
-	stub.AllAccountsFunc = underlying.AllAccounts
-	stub.CurrentAccountFunc = underlying.CurrentAccount
-	stub.AccountByNameFunc = underlying.AccountByName
+	stub.AccountDetailsFunc = underlying.AccountDetails
 	stub.RemoveAccountFunc = underlying.RemoveAccount
 	stub.BootstrapConfigForControllerFunc = underlying.BootstrapConfigForController
 	stub.UpdateBootstrapConfigFunc = underlying.UpdateBootstrapConfig
@@ -187,75 +172,57 @@ func (c *StubStore) CurrentController() (string, error) {
 }
 
 // UpdateModel implements ModelUpdater.
-func (c *StubStore) UpdateModel(controller, account, model string, details jujuclient.ModelDetails) error {
-	c.MethodCall(c, "UpdateModel", controller, account, model, details)
-	return c.UpdateModelFunc(controller, account, model, details)
+func (c *StubStore) UpdateModel(controller, model string, details jujuclient.ModelDetails) error {
+	c.MethodCall(c, "UpdateModel", controller, model, details)
+	return c.UpdateModelFunc(controller, model, details)
 }
 
 // SetCurrentModel implements ModelUpdater.
-func (c *StubStore) SetCurrentModel(controller, account, model string) error {
-	c.MethodCall(c, "SetCurrentModel", controller, account, model)
-	return c.SetCurrentModelFunc(controller, account, model)
+func (c *StubStore) SetCurrentModel(controller, model string) error {
+	c.MethodCall(c, "SetCurrentModel", controller, model)
+	return c.SetCurrentModelFunc(controller, model)
 }
 
 // RemoveModel implements ModelRemover.
-func (c *StubStore) RemoveModel(controller, account, model string) error {
-	c.MethodCall(c, "RemoveModel", controller, account, model)
-	return c.RemoveModelFunc(controller, account, model)
+func (c *StubStore) RemoveModel(controller, model string) error {
+	c.MethodCall(c, "RemoveModel", controller, model)
+	return c.RemoveModelFunc(controller, model)
 }
 
 // AllModels implements ModelGetter.
-func (c *StubStore) AllModels(controller, account string) (map[string]jujuclient.ModelDetails, error) {
-	c.MethodCall(c, "AllModels", controller, account)
-	return c.AllModelsFunc(controller, account)
+func (c *StubStore) AllModels(controller string) (map[string]jujuclient.ModelDetails, error) {
+	c.MethodCall(c, "AllModels", controller)
+	return c.AllModelsFunc(controller)
 }
 
 // CurrentModel implements ModelGetter.
-func (c *StubStore) CurrentModel(controller, account string) (string, error) {
-	c.MethodCall(c, "CurrentModel", controller, account)
-	return c.CurrentModelFunc(controller, account)
+func (c *StubStore) CurrentModel(controller string) (string, error) {
+	c.MethodCall(c, "CurrentModel", controller)
+	return c.CurrentModelFunc(controller)
 }
 
 // ModelByName implements ModelGetter.
-func (c *StubStore) ModelByName(controller, account, model string) (*jujuclient.ModelDetails, error) {
-	c.MethodCall(c, "ModelByName", controller, account, model)
-	return c.ModelByNameFunc(controller, account, model)
+func (c *StubStore) ModelByName(controller, model string) (*jujuclient.ModelDetails, error) {
+	c.MethodCall(c, "ModelByName", controller, model)
+	return c.ModelByNameFunc(controller, model)
 }
 
 // UpdateAccount implements AccountUpdater.
-func (c *StubStore) UpdateAccount(controllerName, accountName string, details jujuclient.AccountDetails) error {
-	c.MethodCall(c, "UpdateAccount", controllerName, accountName, details)
-	return c.UpdateAccountFunc(controllerName, accountName, details)
+func (c *StubStore) UpdateAccount(controllerName string, details jujuclient.AccountDetails) error {
+	c.MethodCall(c, "UpdateAccount", controllerName, details)
+	return c.UpdateAccountFunc(controllerName, details)
 }
 
-// SetCurrentAccount implements AccountUpdater.
-func (c *StubStore) SetCurrentAccount(controllerName, accountName string) error {
-	c.MethodCall(c, "SetCurrentAccount", controllerName, accountName)
-	return c.SetCurrentAccountFunc(controllerName, accountName)
-}
-
-// AllAccounts implements AccountGetter.
-func (c *StubStore) AllAccounts(controllerName string) (map[string]jujuclient.AccountDetails, error) {
-	c.MethodCall(c, "AllAccounts", controllerName)
-	return c.AllAccountsFunc(controllerName)
-}
-
-// CurrentAccount implements AccountGetter.
-func (c *StubStore) CurrentAccount(controllerName string) (string, error) {
-	c.MethodCall(c, "CurrentAccount", controllerName)
-	return c.CurrentAccountFunc(controllerName)
-}
-
-// AccountByName implements AccountGetter.
-func (c *StubStore) AccountByName(controllerName, accountName string) (*jujuclient.AccountDetails, error) {
-	c.MethodCall(c, "AccountByName", controllerName, accountName)
-	return c.AccountByNameFunc(controllerName, accountName)
+// AccountDetails implements AccountGetter.
+func (c *StubStore) AccountDetails(controllerName string) (*jujuclient.AccountDetails, error) {
+	c.MethodCall(c, "AccountDetails", controllerName)
+	return c.AccountDetailsFunc(controllerName)
 }
 
 // RemoveAccount implements AccountRemover.
-func (c *StubStore) RemoveAccount(controllerName, accountName string) error {
-	c.MethodCall(c, "RemoveAccount", controllerName, accountName)
-	return c.RemoveAccountFunc(controllerName, accountName)
+func (c *StubStore) RemoveAccount(controllerName string) error {
+	c.MethodCall(c, "RemoveAccount", controllerName)
+	return c.RemoveAccountFunc(controllerName)
 }
 
 // CredentialForCloud implements CredentialsGetter.

--- a/jujuclient/models.go
+++ b/jujuclient/models.go
@@ -23,12 +23,15 @@ func JujuModelsPath() string {
 
 // ReadModelsFile loads all models defined in a given file.
 // If the file is not found, it is not an error.
-func ReadModelsFile(file string) (map[string]ControllerAccountModels, error) {
+func ReadModelsFile(file string) (map[string]*ControllerModels, error) {
 	data, err := ioutil.ReadFile(file)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
+		return nil, err
+	}
+	if err := migrateLegacyModels(data); err != nil {
 		return nil, err
 	}
 	models, err := ParseModels(data)
@@ -40,7 +43,7 @@ func ReadModelsFile(file string) (map[string]ControllerAccountModels, error) {
 
 // WriteModelsFile marshals to YAML details of the given models
 // and writes it to the models file.
-func WriteModelsFile(models map[string]ControllerAccountModels) error {
+func WriteModelsFile(models map[string]*ControllerModels) error {
 	data, err := yaml.Marshal(modelsCollection{models})
 	if err != nil {
 		return errors.Annotate(err, "cannot marshal models")
@@ -49,33 +52,73 @@ func WriteModelsFile(models map[string]ControllerAccountModels) error {
 }
 
 // ParseModels parses the given YAML bytes into models metadata.
-func ParseModels(data []byte) (map[string]ControllerAccountModels, error) {
+func ParseModels(data []byte) (map[string]*ControllerModels, error) {
 	var result modelsCollection
 	err := yaml.Unmarshal(data, &result)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot unmarshal models")
 	}
-	return result.ControllerAccountModels, nil
+	return result.ControllerModels, nil
 }
 
 type modelsCollection struct {
-	ControllerAccountModels map[string]ControllerAccountModels `yaml:"controllers"`
+	ControllerModels map[string]*ControllerModels `yaml:"controllers"`
 }
 
-// ControllerAccountModels stores per-controller account-model information.
-type ControllerAccountModels struct {
-	// AccountModels is the collection of account-models for the
-	// controller.
-	AccountModels map[string]*AccountModels `yaml:"accounts"`
-}
-
-// AccountModels stores per-account model information.
-type AccountModels struct {
-	// Models is the collection of models for the account. This should
-	// be treated as a cache only, and not the complete set of models
-	// for the account.
-	Models map[string]ModelDetails `yaml:"models"`
+// ControllerModels stores per-controller account-model information.
+type ControllerModels struct {
+	// Models is the collection of models for the account, indexed
+	// by model name. This should be treated as a cache only, and
+	// not the complete set of models for the account.
+	Models map[string]ModelDetails `yaml:"models,omitempty"`
 
 	// CurrentModel is the name of the active model for the account.
 	CurrentModel string `yaml:"current-model,omitempty"`
+}
+
+// TODO(axw) 2016-07-14 #NNN
+// Drop this code once we get to 2.0-beta13.
+func migrateLegacyModels(data []byte) error {
+	accounts, err := ReadAccountsFile(JujuAccountsPath())
+	if err != nil {
+		return err
+	}
+
+	type legacyAccountModels struct {
+		Models       map[string]ModelDetails `yaml:"models"`
+		CurrentModel string                  `yaml:"current-model,omitempty"`
+	}
+	type legacyControllerAccountModels struct {
+		AccountModels map[string]*legacyAccountModels `yaml:"accounts"`
+	}
+	type legacyModelsCollection struct {
+		ControllerAccountModels map[string]legacyControllerAccountModels `yaml:"controllers"`
+	}
+
+	var legacy legacyModelsCollection
+	if err := yaml.Unmarshal(data, &legacy); err != nil {
+		return errors.Annotate(err, "cannot unmarshal models")
+	}
+	result := make(map[string]*ControllerModels)
+	for controller, controllerAccountModels := range legacy.ControllerAccountModels {
+		accountDetails, ok := accounts[controller]
+		if !ok {
+			continue
+		}
+		accountModels, ok := controllerAccountModels.AccountModels[accountDetails.User]
+		if !ok {
+			continue
+		}
+		result[controller] = &ControllerModels{
+			accountModels.Models,
+			accountModels.CurrentModel,
+		}
+	}
+	if len(result) > 0 {
+		// Only write if we found at least one,
+		// which means the file was in legacy
+		// format. Otherwise leave it alone.
+		return WriteModelsFile(result)
+	}
+	return nil
 }

--- a/jujuclient/models_test.go
+++ b/jujuclient/models_test.go
@@ -30,99 +30,83 @@ func (s *ModelsSuite) SetUpTest(c *gc.C) {
 func (s *ModelsSuite) TestModelByNameNoFile(c *gc.C) {
 	err := os.Remove(jujuclient.JujuModelsPath())
 	c.Assert(err, jc.ErrorIsNil)
-	details, err := s.store.ModelByName("not-found", "admin@local", "admin")
+	details, err := s.store.ModelByName("not-found", "admin")
 	c.Assert(err, gc.ErrorMatches, "models for controller not-found not found")
 	c.Assert(details, gc.IsNil)
 }
 
 func (s *ModelsSuite) TestModelByNameControllerNotFound(c *gc.C) {
-	details, err := s.store.ModelByName("not-found", "admin@local", "admin")
+	details, err := s.store.ModelByName("not-found", "admin")
 	c.Assert(err, gc.ErrorMatches, "models for controller not-found not found")
 	c.Assert(details, gc.IsNil)
 }
 
-func (s *ModelsSuite) TestModelByNameAccountNotFound(c *gc.C) {
-	details, err := s.store.ModelByName("ctrl", "not@found", "admin")
-	c.Assert(err, gc.ErrorMatches, "models for account not@found on controller ctrl not found")
-	c.Assert(details, gc.IsNil)
-}
-
 func (s *ModelsSuite) TestModelByNameModelNotFound(c *gc.C) {
-	details, err := s.store.ModelByName("kontroll", "admin@local", "not-found")
-	c.Assert(err, gc.ErrorMatches, "model kontroll:admin@local:not-found not found")
+	details, err := s.store.ModelByName("kontroll", "not-found")
+	c.Assert(err, gc.ErrorMatches, "model kontroll:not-found not found")
 	c.Assert(details, gc.IsNil)
 }
 
 func (s *ModelsSuite) TestModelByName(c *gc.C) {
-	details, err := s.store.ModelByName("kontroll", "admin@local", "admin")
+	details, err := s.store.ModelByName("kontroll", "admin")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(details, gc.NotNil)
-	c.Assert(*details, jc.DeepEquals, testControllerModels["kontroll"].AccountModels["admin@local"].Models["admin"])
+	c.Assert(*details, jc.DeepEquals, testControllerModels["kontroll"].Models["admin"])
 }
 
 func (s *ModelsSuite) TestAllModelsNoFile(c *gc.C) {
 	err := os.Remove(jujuclient.JujuModelsPath())
 	c.Assert(err, jc.ErrorIsNil)
-	models, err := s.store.AllModels("not-found", "admin@local")
+	models, err := s.store.AllModels("not-found")
 	c.Assert(err, gc.ErrorMatches, "models for controller not-found not found")
 	c.Assert(models, gc.HasLen, 0)
 }
 
 func (s *ModelsSuite) TestAllModels(c *gc.C) {
-	models, err := s.store.AllModels("kontroll", "admin@local")
+	models, err := s.store.AllModels("kontroll")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(models, jc.DeepEquals, testControllerModels["kontroll"].AccountModels["admin@local"].Models)
+	c.Assert(models, jc.DeepEquals, testControllerModels["kontroll"].Models)
 }
 
 func (s *ModelsSuite) TestCurrentModel(c *gc.C) {
-	current, err := s.store.CurrentModel("kontroll", "admin@local")
+	current, err := s.store.CurrentModel("kontroll")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(current, gc.Equals, "my-model")
 }
 
 func (s *ModelsSuite) TestCurrentModelNotSet(c *gc.C) {
-	_, err := s.store.CurrentModel("ctrl", "bob@local")
+	_, err := s.store.CurrentModel("ctrl")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *ModelsSuite) TestCurrentModelControllerNotFound(c *gc.C) {
-	_, err := s.store.CurrentModel("not-found", "admin@local")
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-}
-
-func (s *ModelsSuite) TestCurrentModelAccountNotFound(c *gc.C) {
-	_, err := s.store.CurrentModel("kontroll", "not@found")
+	_, err := s.store.CurrentModel("not-found")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *ModelsSuite) TestSetCurrentModelControllerNotFound(c *gc.C) {
-	err := s.store.SetCurrentModel("not-found", "admin@local", "admin")
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-}
-
-func (s *ModelsSuite) TestSetCurrentModelAccountNotFound(c *gc.C) {
-	err := s.store.SetCurrentModel("kontroll", "not@found", "admin")
+	err := s.store.SetCurrentModel("not-found", "admin")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *ModelsSuite) TestSetCurrentModelModelNotFound(c *gc.C) {
-	err := s.store.SetCurrentModel("kontroll", "admin@local", "not-found")
+	err := s.store.SetCurrentModel("kontroll", "not-found")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *ModelsSuite) TestSetCurrentModel(c *gc.C) {
-	err := s.store.SetCurrentModel("kontroll", "admin@local", "admin")
+	err := s.store.SetCurrentModel("kontroll", "admin")
 	c.Assert(err, jc.ErrorIsNil)
 	all, err := jujuclient.ReadModelsFile(jujuclient.JujuModelsPath())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(all["kontroll"].AccountModels["admin@local"].CurrentModel, gc.Equals, "admin")
+	c.Assert(all["kontroll"].CurrentModel, gc.Equals, "admin")
 }
 
 func (s *ModelsSuite) TestUpdateModelNewController(c *gc.C) {
 	testModelDetails := jujuclient.ModelDetails{"test.uuid"}
-	err := s.store.UpdateModel("new-controller", "new@account", "new-model", testModelDetails)
+	err := s.store.UpdateModel("new-controller", "new-model", testModelDetails)
 	c.Assert(err, jc.ErrorIsNil)
-	models, err := s.store.AllModels("new-controller", "new@account")
+	models, err := s.store.AllModels("new-controller")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(models, jc.DeepEquals, map[string]jujuclient.ModelDetails{
 		"new-model": testModelDetails,
@@ -131,9 +115,9 @@ func (s *ModelsSuite) TestUpdateModelNewController(c *gc.C) {
 
 func (s *ModelsSuite) TestUpdateModelExistingControllerAndModelNewModel(c *gc.C) {
 	testModelDetails := jujuclient.ModelDetails{"test.uuid"}
-	err := s.store.UpdateModel("kontroll", "admin@local", "new-model", testModelDetails)
+	err := s.store.UpdateModel("kontroll", "new-model", testModelDetails)
 	c.Assert(err, jc.ErrorIsNil)
-	models, err := s.store.AllModels("kontroll", "admin@local")
+	models, err := s.store.AllModels("kontroll")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(models, jc.DeepEquals, map[string]jujuclient.ModelDetails{
 		"admin":     kontrollAdminModelDetails,
@@ -147,9 +131,9 @@ func (s *ModelsSuite) TestUpdateModelOverwrites(c *gc.C) {
 	for i := 0; i < 2; i++ {
 		// Twice so we exercise the code path of updating with
 		// identical details.
-		err := s.store.UpdateModel("kontroll", "admin@local", "admin", testModelDetails)
+		err := s.store.UpdateModel("kontroll", "admin", testModelDetails)
 		c.Assert(err, jc.ErrorIsNil)
-		details, err := s.store.ModelByName("kontroll", "admin@local", "admin")
+		details, err := s.store.ModelByName("kontroll", "admin")
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(*details, jc.DeepEquals, testModelDetails)
 	}
@@ -158,29 +142,24 @@ func (s *ModelsSuite) TestUpdateModelOverwrites(c *gc.C) {
 func (s *ModelsSuite) TestRemoveModelNoFile(c *gc.C) {
 	err := os.Remove(jujuclient.JujuModelsPath())
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.store.RemoveModel("not-found", "admin@local", "admin")
+	err = s.store.RemoveModel("not-found", "admin")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *ModelsSuite) TestRemoveModelControllerNotFound(c *gc.C) {
-	err := s.store.RemoveModel("not-found", "admin@local", "admin")
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-}
-
-func (s *ModelsSuite) TestRemoveModelAccountNotFound(c *gc.C) {
-	err := s.store.RemoveModel("kontroll", "not@found", "admin")
+	err := s.store.RemoveModel("not-found", "admin")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *ModelsSuite) TestRemoveModelNotFound(c *gc.C) {
-	err := s.store.RemoveModel("kontroll", "admin@local", "not-found")
+	err := s.store.RemoveModel("kontroll", "not-found")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *ModelsSuite) TestRemoveModel(c *gc.C) {
-	err := s.store.RemoveModel("kontroll", "admin@local", "admin")
+	err := s.store.RemoveModel("kontroll", "admin")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.store.ModelByName("kontroll", "admin@local", "admin")
+	_, err = s.store.ModelByName("kontroll", "admin")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 

--- a/jujuclient/modelsfile_test.go
+++ b/jujuclient/modelsfile_test.go
@@ -23,58 +23,36 @@ var _ = gc.Suite(&ModelsFileSuite{})
 const testModelsYAML = `
 controllers:
   ctrl:
-    accounts:
-      admin@local:
-        models:
-          admin:
-            uuid: ghi
-      bob@local:
-        models:
-          admin:
-            uuid: jkl
+    models:
+      admin:
+        uuid: ghi
   kontroll:
-    accounts:
-      admin@local:
-        models:
-          admin:
-            uuid: abc
-          my-model:
-            uuid: def
-        current-model: my-model
+    models:
+      admin:
+        uuid: abc
+      my-model:
+        uuid: def
+    current-model: my-model
 `
 
-var testControllerModels = map[string]jujuclient.ControllerAccountModels{
+var testControllerModels = map[string]*jujuclient.ControllerModels{
 	"kontroll": {
-		map[string]*jujuclient.AccountModels{
-			"admin@local": {
-				Models: map[string]jujuclient.ModelDetails{
-					"admin":    kontrollAdminModelDetails,
-					"my-model": kontrollMyModelModelDetails,
-				},
-				CurrentModel: "my-model",
-			},
+		Models: map[string]jujuclient.ModelDetails{
+			"admin":    kontrollAdminModelDetails,
+			"my-model": kontrollMyModelModelDetails,
 		},
+		CurrentModel: "my-model",
 	},
 	"ctrl": {
-		map[string]*jujuclient.AccountModels{
-			"admin@local": {
-				Models: map[string]jujuclient.ModelDetails{
-					"admin": ctrlAdminAdminModelDetails,
-				},
-			},
-			"bob@local": {
-				Models: map[string]jujuclient.ModelDetails{
-					"admin": ctrlBobAdminModelDetails,
-				},
-			},
+		Models: map[string]jujuclient.ModelDetails{
+			"admin": ctrlAdminModelDetails,
 		},
 	},
 }
 
 var kontrollAdminModelDetails = jujuclient.ModelDetails{"abc"}
 var kontrollMyModelModelDetails = jujuclient.ModelDetails{"def"}
-var ctrlAdminAdminModelDetails = jujuclient.ModelDetails{"ghi"}
-var ctrlBobAdminModelDetails = jujuclient.ModelDetails{"jkl"}
+var ctrlAdminModelDetails = jujuclient.ModelDetails{"ghi"}
 
 func (s *ModelsFileSuite) TestWriteFile(c *gc.C) {
 	writeTestModelsFile(c)

--- a/jujuclient/validation.go
+++ b/jujuclient/validation.go
@@ -36,7 +36,8 @@ func ValidateAccountDetails(details AccountDetails) error {
 	// may use macaroons instead.
 	//
 	// TODO(axw) expand validation rules to check that at least
-	// one of Password or Macaroon is non-empty.
+	// one of Password or Macaroon is non-empty, for local users.
+	// External users may have neither.
 	return nil
 }
 


### PR DESCRIPTION
jujuclient has been rejiggered again, this time
to stop storing multiple accounts against
controllers. A controller can now have at most
one account entry. This tidies up the commands
considerably, simplifies the output of show/list-
controllers.

We also fix juju/api.go, so that we can once
again use external authentication. There will
be additional changes coming that

(Review request: http://reviews.vapour.ws/r/5232/)