### PR TITLE
storage: move DeviceLink sorting to diskmanager

### DIFF
--- a/storage/path_test.go
+++ b/storage/path_test.go
@@ -37,24 +37,3 @@ func testBlockDevicePath(c *gc.C, dev storage.BlockDevice, expect string) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(path, jc.SamePath, expect)
 }
-
-func (s *BlockDevicePathSuite) TestSortBlockDevices(c *gc.C) {
-	devices := []storage.BlockDevice{{
-		DeviceName:  "sdb",
-		DeviceLinks: []string{"by-b", "by-a"},
-	}, {
-		DeviceName:  "sda",
-		DeviceLinks: []string{"by-c", "by-d"},
-	}}
-	storage.SortBlockDevices(devices)
-
-	expected := []storage.BlockDevice{{
-		DeviceName:  "sda",
-		DeviceLinks: []string{"by-c", "by-d"},
-	}, {
-		DeviceName:  "sdb",
-		DeviceLinks: []string{"by-a", "by-b"},
-	}}
-
-	c.Assert(devices, jc.DeepEquals, expected)
-}

--- a/storage/sort.go
+++ b/storage/sort.go
@@ -8,10 +8,6 @@ import "sort"
 // SortBlockDevices sorts block devices by device name.
 func SortBlockDevices(devices []BlockDevice) {
 	sort.Sort(byDeviceName(devices))
-
-	for i := range devices {
-		sort.Strings(devices[i].DeviceLinks)
-	}
 }
 
 type byDeviceName []BlockDevice

--- a/worker/diskmanager/diskmanager.go
+++ b/worker/diskmanager/diskmanager.go
@@ -5,6 +5,7 @@ package diskmanager
 
 import (
 	"reflect"
+	"sort"
 	"time"
 
 	"github.com/juju/loggo"
@@ -55,6 +56,9 @@ func doWork(listf ListBlockDevicesFunc, b BlockDeviceSetter, old *[]storage.Bloc
 		return err
 	}
 	storage.SortBlockDevices(blockDevices)
+	for _, blockDevice := range blockDevices {
+		sort.Strings(blockDevice.DeviceLinks)
+	}
 	if reflect.DeepEqual(blockDevices, *old) {
 		logger.Tracef("no changes to block devices detected")
 		return nil


### PR DESCRIPTION
SortBlockDevices was changed to alter the contents
of BlockDevices, whereas its intended and documented
purpose is to reorder elements in a slice.

Only the diskmanager cares about the order of contents
of BlockDevices. The sorting of block device contents
has been relocated there.

(Review request: http://reviews.vapour.ws/r/5233/)