### PR TITLE
Alias interface set as an alias of the bridge

### DIFF
--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -87,6 +87,7 @@ class LogicalInterface(object):
         self.is_active = self.method == "dhcp" or self.method == "static"
         self.is_bridged = [x for x in self.options if x.startswith("bridge_ports ")]
         self.has_auto_stanza = None
+        self.parent = None
 
     def __str__(self):
         return self.name
@@ -108,7 +109,12 @@ class LogicalInterface(object):
         if not self.is_active or self.is_bridged:
             return self._bridge_unchanged()
         elif self.is_alias:
-            return self._bridge_alias()
+            if self.parent and self.parent.iface and (not self.parent.iface.is_active or self.parent.iface.is_bridged):
+                # if we didn't change the parent interface
+                # then we don't change the aliases neither.
+                return self._bridge_unchanged()
+            else:
+                return self._bridge_alias(bridge_name)
         elif self.is_vlan:
             return self._bridge_vlan(bridge_name)
         elif self.is_bonded:
@@ -142,11 +148,11 @@ class LogicalInterface(object):
         stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
         return stanzas
 
-    def _bridge_alias(self):
+    def _bridge_alias(self, bridge_name):
         stanzas = []
         if self.has_auto_stanza:
-            stanzas.append(AutoStanza(self.name))
-        stanzas.append(IfaceStanza(self.name, self.family, self.method, list(self.options)))
+            stanzas.append(AutoStanza(bridge_name))
+        stanzas.append(IfaceStanza(bridge_name, self.family, self.method, list(self.options)))
         return stanzas
 
     def _bridge_bond(self, bridge_name):
@@ -213,6 +219,8 @@ class NetworkInterfaceParser(object):
                 continue
             s.iface.has_auto_stanza = s.iface.name in physical_interfaces
 
+        self._connect_aliases()
+
     def _parse_stanza(self, stanza_line, iterable):
         stanza_options = []
         for line in iterable:
@@ -227,6 +235,24 @@ class NetworkInterfaceParser(object):
 
     def stanzas(self):
         return [x for x in self._stanzas]
+
+    def _connect_aliases(self):
+        """Set a reference in the alias interfaces to its related interface"""
+        ifaces = {}
+        aliases = []
+        for stanza in self._stanzas:
+            if stanza.iface is None:
+                continue
+
+            if stanza.iface.is_alias:
+                aliases.append(stanza)
+            else:
+                ifaces[stanza.iface.name] = stanza
+
+        for alias in aliases:
+            parent_name = alias.iface.name.split(':')[0]
+            if parent_name in ifaces:
+                alias.iface.parent = ifaces[parent_name]
 
     def _physical_interfaces(self):
         return {x.phy.name: x.phy for x in [y for y in self._stanzas if y.is_physical_interface]}

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -101,7 +101,7 @@ func (s *bridgeConfigSuite) TestBridgeScriptWithPrefixTransformation(c *gc.C) {
 		prefix   string
 	}{
 		{networkDHCPInitial, networkDHCPExpected, "test-br-"},
-		{networkDHCPWithAliasInitial, networkDHCPWithAliasExpected, "test-br-"},
+		{networkStaticWithAliasInitial, networkStaticWithAliasExpected, "test-br-"},
 		{networkDHCPWithBondInitial, networkDHCPWithBondExpected, "test-br-"},
 		{networkDualNICInitial, networkDualNICExpected, "test-br-"},
 		{networkMultipleAliasesInitial, networkMultipleAliasesExpected, "test-br-"},
@@ -300,11 +300,11 @@ iface test-br-eth0 inet static
     gateway 4.3.2.1
     bridge_ports eth0
 
-auto eth0:1
-iface eth0:1 inet static
+auto test-br-eth0:1
+iface test-br-eth0:1 inet static
     address 1.2.3.5`
 
-const networkDHCPWithAliasInitial = `auto lo
+const networkStaticWithAliasInitial = `auto lo
 iface lo inet loopback
 
 auto eth0
@@ -322,7 +322,7 @@ iface eth0:2 inet static
 
 dns-nameserver 192.168.1.142`
 
-const networkDHCPWithAliasExpected = `auto lo
+const networkStaticWithAliasExpected = `auto lo
 iface lo inet loopback
 
 auto eth0
@@ -334,12 +334,12 @@ iface test-br-eth0 inet static
     address 10.14.0.102/24
     bridge_ports eth0
 
-auto eth0:1
-iface eth0:1 inet static
+auto test-br-eth0:1
+iface test-br-eth0:1 inet static
     address 10.14.0.103/24
 
-auto eth0:2
-iface eth0:2 inet static
+auto test-br-eth0:2
+iface test-br-eth0:2 inet static
     address 10.14.0.100/24
     dns-nameserver 192.168.1.142`
 
@@ -372,8 +372,8 @@ iface test-br-eth0 inet static
     address 10.17.20.201/24
     bridge_ports eth0
 
-auto eth0:1
-iface eth0:1 inet static
+auto test-br-eth0:1
+iface test-br-eth0:1 inet static
     address 10.17.20.202/24
     mtu 1500
 
@@ -498,13 +498,13 @@ iface test-br-eth10 inet static
     address 10.17.20.201/24
     bridge_ports eth10
 
-auto eth10:1
-iface eth10:1 inet static
+auto test-br-eth10:1
+iface test-br-eth10:1 inet static
     address 10.17.20.202/24
     mtu 1500
 
-auto eth10:2
-iface eth10:2 inet static
+auto test-br-eth10:2
+iface test-br-eth10:2 inet static
     address 10.17.20.203/24
     mtu 1500
     dns-nameservers 10.17.20.200
@@ -667,23 +667,23 @@ iface juju-br-eth6 inet static
     address 10.17.20.203/24
     bridge_ports eth6
 
-auto eth6:1
-iface eth6:1 inet static
+auto juju-br-eth6:1
+iface juju-br-eth6:1 inet static
     address 10.17.20.205/24
     mtu 1500
 
-auto eth6:2
-iface eth6:2 inet static
+auto juju-br-eth6:2
+iface juju-br-eth6:2 inet static
     address 10.17.20.204/24
     mtu 1500
 
-auto eth6:3
-iface eth6:3 inet static
+auto juju-br-eth6:3
+iface juju-br-eth6:3 inet static
     address 10.17.20.206/24
     mtu 1500
 
-auto eth6:4
-iface eth6:4 inet static
+auto juju-br-eth6:4
+iface juju-br-eth6:4 inet static
     address 10.17.20.207/24
     mtu 1500
 


### PR DESCRIPTION
When the intefaces file is regenerated alias interfaces are left as
they are, this makes IPv6 aliases unusable.

Example input:
```
iface eth0:1 iface static
    address 192.168.122.2/24
```
Example output:
```
iface br-eth0:1 iface static
    address 192.168.122.2/24
```
Fixes [LP:#1602716](https://bugs.launchpad.net/juju-core/+bug/1602716)