### PR TITLE
provider/gce: get API port from controller config

### DIFF
--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -149,6 +149,17 @@ func (env *environ) Config() *config.Config {
 // that must be called to finalize the bootstrap process by transferring
 // the tools and installing the initial juju controller.
 func (env *environ) Bootstrap(ctx environs.BootstrapContext, params environs.BootstrapParams) (*environs.BootstrapResult, error) {
+	// Ensure the API server port is open (globally for all instances
+	// on the network, not just for the specific node of the state
+	// server). See LP bug #1436191 for details.
+	ports := network.PortRange{
+		FromPort: params.ControllerConfig.APIPort(),
+		ToPort:   params.ControllerConfig.APIPort(),
+		Protocol: "tcp",
+	}
+	if err := env.gce.OpenPorts(env.globalFirewallName(), ports); err != nil {
+		return nil, errors.Trace(err)
+	}
 	return bootstrap(ctx, env, params)
 }
 

--- a/provider/gce/environ_broker.go
+++ b/provider/gce/environ_broker.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/gce/google"
 	"github.com/juju/juju/state/multiwatcher"
@@ -53,20 +52,6 @@ func (env *environ) StartInstance(args environs.StartInstanceParams) (*environs.
 	}
 	logger.Infof("started instance %q in zone %q", raw.ID, raw.ZoneName)
 	inst := newInstance(raw, env)
-
-	// Ensure the API server port is open (globally for all instances
-	// on the network, not just for the specific node of the state
-	// server). See LP bug #1436191 for details.
-	if args.InstanceConfig.Bootstrap != nil {
-		ports := network.PortRange{
-			FromPort: args.InstanceConfig.Bootstrap.StateServingInfo.APIPort,
-			ToPort:   args.InstanceConfig.Bootstrap.StateServingInfo.APIPort,
-			Protocol: "tcp",
-		}
-		if err := env.gce.OpenPorts(env.globalFirewallName(), ports); err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
 
 	// Build the result.
 	hwc := getHardwareCharacteristics(env, spec, inst)


### PR DESCRIPTION
The gce provider was getting the API port from StateServingInfo,
when it should be getting it from ControllerConfig. A recent
change was made that defers initialising StateServingInfo to
later in bootstrap, which meant that the API port in StateServingInfo
was zero.

Fixes https://bugs.launchpad.net/juju-core/+bug/1602732

(Review request: http://reviews.vapour.ws/r/5236/)