### PR TITLE
Don't forward too many log entries

### DIFF
--- a/api/logfwd/lastsent_test.go
+++ b/api/logfwd/lastsent_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
+	"time"
 )
 
 type LastSentSuite struct {
@@ -27,9 +28,11 @@ func (s *LastSentSuite) TestGetLastSent(c *gc.C) {
 	caller := &stubFacadeCaller{stub: stub}
 	caller.ReturnFacadeCallGet = params.LogForwardingGetLastSentResults{
 		Results: []params.LogForwardingGetLastSentResult{{
-			RecordID: 10,
+			RecordID:        10,
+			RecordTimestamp: 100,
 		}, {
-			RecordID: 20,
+			RecordID:        20,
+			RecordTimestamp: 200,
 		}, {
 			Error: common.ServerError(errors.NewNotFound(state.ErrNeverForwarded, "")),
 		}},
@@ -38,7 +41,7 @@ func (s *LastSentSuite) TestGetLastSent(c *gc.C) {
 	model := "deadbeef-2f18-4fd2-967d-db9663db7bea"
 	modelTag := names.NewModelTag(model)
 
-	results, err := client.GetList([]logfwd.LastSentID{{
+	results, err := client.GetLastSent([]logfwd.LastSentID{{
 		Model: modelTag,
 		Sink:  "spam",
 	}, {
@@ -56,7 +59,8 @@ func (s *LastSentSuite) TestGetLastSent(c *gc.C) {
 				Model: modelTag,
 				Sink:  "spam",
 			},
-			RecordID: 10,
+			RecordID:        10,
+			RecordTimestamp: time.Unix(0, 100),
 		},
 	}, {
 		LastSentInfo: logfwd.LastSentInfo{
@@ -64,7 +68,8 @@ func (s *LastSentSuite) TestGetLastSent(c *gc.C) {
 				Model: modelTag,
 				Sink:  "eggs",
 			},
-			RecordID: 20,
+			RecordID:        20,
+			RecordTimestamp: time.Unix(0, 200),
 		},
 	}, {
 		LastSentInfo: logfwd.LastSentInfo{
@@ -116,19 +121,22 @@ func (s *LastSentSuite) TestSetLastSent(c *gc.C) {
 			Model: modelTag,
 			Sink:  "spam",
 		},
-		RecordID: 10,
+		RecordID:        10,
+		RecordTimestamp: time.Unix(0, 100),
 	}, {
 		LastSentID: logfwd.LastSentID{
 			Model: modelTag,
 			Sink:  "eggs",
 		},
-		RecordID: 20,
+		RecordID:        20,
+		RecordTimestamp: time.Unix(0, 200),
 	}, {
 		LastSentID: logfwd.LastSentID{
 			Model: modelTag,
 			Sink:  "ham",
 		},
-		RecordID: 15,
+		RecordID:        15,
+		RecordTimestamp: time.Unix(0, 150),
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -138,7 +146,8 @@ func (s *LastSentSuite) TestSetLastSent(c *gc.C) {
 				Model: modelTag,
 				Sink:  "spam",
 			},
-			RecordID: 10,
+			RecordID:        10,
+			RecordTimestamp: time.Unix(0, 100),
 		},
 	}, {
 		LastSentInfo: logfwd.LastSentInfo{
@@ -146,7 +155,8 @@ func (s *LastSentSuite) TestSetLastSent(c *gc.C) {
 				Model: modelTag,
 				Sink:  "eggs",
 			},
-			RecordID: 20,
+			RecordID:        20,
+			RecordTimestamp: time.Unix(0, 200),
 		},
 	}, {
 		LastSentInfo: logfwd.LastSentInfo{
@@ -154,7 +164,8 @@ func (s *LastSentSuite) TestSetLastSent(c *gc.C) {
 				Model: modelTag,
 				Sink:  "ham",
 			},
-			RecordID: 15,
+			RecordID:        15,
+			RecordTimestamp: time.Unix(0, 150),
 		},
 		Error: common.RestoreError(apiError),
 	}})
@@ -166,19 +177,22 @@ func (s *LastSentSuite) TestSetLastSent(c *gc.C) {
 				ModelTag: modelTag.String(),
 				Sink:     "spam",
 			},
-			RecordID: 10,
+			RecordID:        10,
+			RecordTimestamp: 100,
 		}, {
 			LogForwardingID: params.LogForwardingID{
 				ModelTag: modelTag.String(),
 				Sink:     "eggs",
 			},
-			RecordID: 20,
+			RecordID:        20,
+			RecordTimestamp: 200,
 		}, {
 			LogForwardingID: params.LogForwardingID{
 				ModelTag: modelTag.String(),
 				Sink:     "ham",
 			},
-			RecordID: 15,
+			RecordID:        15,
+			RecordTimestamp: 150,
 		}},
 	})
 }

--- a/apiserver/logfwd/lastsent.go
+++ b/apiserver/logfwd/lastsent.go
@@ -24,11 +24,11 @@ func init() {
 type LastSentTracker interface {
 	io.Closer
 
-	// Get retrieves the record ID.
-	Get() (int64, error)
+	// Get retrieves the record ID and timestamp.
+	Get() (recID int64, recTimestamp int64, err error)
 
-	// Set records the record ID.
-	Set(recID int64) error
+	// Set records the record ID and timestamp.
+	Set(recID int64, recTimestamp int64) error
 }
 
 // LogForwardingState supports interacting with state for the
@@ -76,7 +76,7 @@ func (api *LogForwardingAPI) get(id params.LogForwardingID) params.LogForwarding
 	}
 	defer lst.Close()
 
-	recID, err := lst.Get()
+	recID, recTimestamp, err := lst.Get()
 	if err != nil {
 		res.Error = common.ServerError(err)
 		if errors.Cause(err) == state.ErrNeverForwarded {
@@ -85,6 +85,7 @@ func (api *LogForwardingAPI) get(id params.LogForwardingID) params.LogForwarding
 		return res
 	}
 	res.RecordID = recID
+	res.RecordTimestamp = recTimestamp
 	return res
 }
 
@@ -107,7 +108,7 @@ func (api *LogForwardingAPI) set(arg params.LogForwardingSetLastSentParam) *para
 	}
 	defer lst.Close()
 
-	err = lst.Set(arg.RecordID)
+	err = lst.Set(arg.RecordID, arg.RecordTimestamp)
 	return common.ServerError(err)
 }
 

--- a/apiserver/params/logfwd.go
+++ b/apiserver/params/logfwd.go
@@ -41,6 +41,11 @@ type LogForwardingGetLastSentResult struct {
 	// meaning of this value is undefined.
 	RecordID int64 `json:"record-id"`
 
+	// RecordTimestamp is the timestamp of the last log record that was
+	// forwarded for a given model and sink. If Error is set then the
+	// meaning of this value is undefined.
+	RecordTimestamp int64 `json:"record-timestamp"`
+
 	// Error holds the error, if any, that resulted while handling the
 	// request for a specific ID.
 	Error *Error `json:"err"`
@@ -61,4 +66,7 @@ type LogForwardingSetLastSentParam struct {
 
 	// RecordID identifies the record ID to set for the given ID.
 	RecordID int64 `json:"record-id"`
+
+	// RecordTimestamp identifies the record timestamp to set for the given ID.
+	RecordTimestamp int64 `json:"record-timestamp"`
 }

--- a/apiserver/params/logstream.go
+++ b/apiserver/params/logstream.go
@@ -44,4 +44,11 @@ type LogStreamConfig struct {
 	// This is used as a bookmark for where to start the next time logs
 	// are streamed for the same sink.
 	Sink string `schema:"sink" url:"sink,omitempty"`
+
+	// MaxLookbackDuration is the maximum time duration from the past to stream.
+	// It must be a valid time duration string.
+	MaxLookbackDuration string `schema:"maxlookbackduration" url:"maxlookbackduration,omitempty"`
+
+	// MaxLookbackRecords is the maximum number of log records to stream from the past.
+	MaxLookbackRecords int `schema:"maxlookbackrecords" url:"maxlookbackrecords,omitempty"`
 }

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -40,24 +40,26 @@ func (s *LogsSuite) TestLastSentLogTrackerSetGet(c *gc.C) {
 	tracker := state.NewLastSentLogTracker(s.State, s.State.ModelUUID(), "test-sink")
 	defer tracker.Close()
 
-	err := tracker.Set(10)
+	err := tracker.Set(10, 100)
 	c.Assert(err, jc.ErrorIsNil)
-	id1, err := tracker.Get()
+	id1, ts1, err := tracker.Get()
 	c.Assert(err, jc.ErrorIsNil)
-	err = tracker.Set(20)
+	err = tracker.Set(20, 200)
 	c.Assert(err, jc.ErrorIsNil)
-	id2, err := tracker.Get()
+	id2, ts2, err := tracker.Get()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(id1, gc.Equals, int64(10))
+	c.Check(ts1, gc.Equals, int64(100))
 	c.Check(id2, gc.Equals, int64(20))
+	c.Check(ts2, gc.Equals, int64(200))
 }
 
 func (s *LogsSuite) TestLastSentLogTrackerGetNeverSet(c *gc.C) {
 	tracker := state.NewLastSentLogTracker(s.State, s.State.ModelUUID(), "test")
 	defer tracker.Close()
 
-	_, err := tracker.Get()
+	_, _, err := tracker.Get()
 
 	c.Check(err, gc.ErrorMatches, state.ErrNeverForwarded.Error())
 }
@@ -69,23 +71,26 @@ func (s *LogsSuite) TestLastSentLogTrackerIndependentModels(c *gc.C) {
 	defer otherModel.Close()
 	tracker1 := state.NewLastSentLogTracker(otherModel, otherModel.ModelUUID(), "test-sink") // same sink
 	defer tracker1.Close()
-	err := tracker0.Set(10)
+	err := tracker0.Set(10, 100)
 	c.Assert(err, jc.ErrorIsNil)
-	id0, err := tracker0.Get()
+	id0, ts0, err := tracker0.Get()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(id0, gc.Equals, int64(10))
+	c.Assert(ts0, gc.Equals, int64(100))
 
-	_, errBefore := tracker1.Get()
-	err = tracker1.Set(20)
+	_, _, errBefore := tracker1.Get()
+	err = tracker1.Set(20, 200)
 	c.Assert(err, jc.ErrorIsNil)
-	id1, errAfter := tracker1.Get()
+	id1, ts1, errAfter := tracker1.Get()
 	c.Assert(errAfter, jc.ErrorIsNil)
-	id0, err = tracker0.Get()
+	id0, ts0, err = tracker0.Get()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(errBefore, gc.ErrorMatches, state.ErrNeverForwarded.Error())
 	c.Check(id1, gc.Equals, int64(20))
+	c.Check(ts1, gc.Equals, int64(200))
 	c.Check(id0, gc.Equals, int64(10))
+	c.Check(ts0, gc.Equals, int64(100))
 }
 
 func (s *LogsSuite) TestLastSentLogTrackerIndependentSinks(c *gc.C) {
@@ -93,23 +98,26 @@ func (s *LogsSuite) TestLastSentLogTrackerIndependentSinks(c *gc.C) {
 	defer tracker0.Close()
 	tracker1 := state.NewLastSentLogTracker(s.State, s.State.ModelUUID(), "test-sink1")
 	defer tracker1.Close()
-	err := tracker0.Set(10)
+	err := tracker0.Set(10, 100)
 	c.Assert(err, jc.ErrorIsNil)
-	id0, err := tracker0.Get()
+	id0, ts0, err := tracker0.Get()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(id0, gc.Equals, int64(10))
+	c.Assert(ts0, gc.Equals, int64(100))
 
-	_, errBefore := tracker1.Get()
-	err = tracker1.Set(20)
+	_, _, errBefore := tracker1.Get()
+	err = tracker1.Set(20, 200)
 	c.Assert(err, jc.ErrorIsNil)
-	id1, errAfter := tracker1.Get()
+	id1, ts1, errAfter := tracker1.Get()
 	c.Assert(errAfter, jc.ErrorIsNil)
-	id0, err = tracker0.Get()
+	id0, ts0, err = tracker0.Get()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(errBefore, gc.ErrorMatches, state.ErrNeverForwarded.Error())
 	c.Check(id1, gc.Equals, int64(20))
+	c.Check(ts1, gc.Equals, int64(200))
 	c.Check(id0, gc.Equals, int64(10))
+	c.Check(ts0, gc.Equals, int64(100))
 }
 
 func (s *LogsSuite) TestAllLastSentLogTrackerSetGet(c *gc.C) {
@@ -120,17 +128,19 @@ func (s *LogsSuite) TestAllLastSentLogTrackerSetGet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer tracker.Close()
 
-	err = tracker.Set(10)
+	err = tracker.Set(10, 100)
 	c.Assert(err, jc.ErrorIsNil)
-	id1, err := tracker.Get()
+	id1, ts1, err := tracker.Get()
 	c.Assert(err, jc.ErrorIsNil)
-	err = tracker.Set(20)
+	err = tracker.Set(20, 200)
 	c.Assert(err, jc.ErrorIsNil)
-	id2, err := tracker.Get()
+	id2, ts2, err := tracker.Get()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(id1, gc.Equals, int64(10))
+	c.Check(ts1, gc.Equals, int64(100))
 	c.Check(id2, gc.Equals, int64(20))
+	c.Check(ts2, gc.Equals, int64(200))
 }
 
 func (s *LogsSuite) TestAllLastSentLogTrackerNotController(c *gc.C) {

--- a/worker/logforwarder/logforwarder.go
+++ b/worker/logforwarder/logforwarder.go
@@ -184,7 +184,6 @@ func (lf *LogForwarder) loop() error {
 	}
 
 	records := make(chan []logfwd.Record)
-	defer close(records)
 	var stream LogStream
 	go func() {
 		for {
@@ -200,6 +199,8 @@ func (lf *LogForwarder) loop() error {
 				streamCfg := params.LogStreamConfig{
 					AllModels: lf.args.AllModels,
 					Sink:      lf.args.Name,
+					// TODO(wallyworld) - this should be configurable via lf.args.LogForwardConfig
+					MaxLookbackRecords: 100,
 				}
 				stream, err = lf.args.OpenLogStream(lf.args.Caller, streamCfg, lf.args.ControllerUUID)
 				if err != nil {

--- a/worker/logforwarder/tracker.go
+++ b/worker/logforwarder/tracker.go
@@ -103,7 +103,8 @@ func (lst lastSentTracker) setLastSent(allModels bool, records []logfwd.Record) 
 			Model: modelTag,
 			Sink:  lst.sink,
 		},
-		RecordID: rec.ID,
+		RecordID:        rec.ID,
+		RecordTimestamp: rec.Timestamp,
 	}})
 	if err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1602895

For now it's hardcoded, but we allow the maximum number of log entries to initially forward to be controlled:
1. limit the number of lines
2. limit the time duration to look back

The lookback is current set at 100 lines.

Also fix a race closing the log forward worker.

(Review request: http://reviews.vapour.ws/r/5237/)