### PR TITLE
Interactive bootstrap

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/juju/errors"
@@ -17,6 +18,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/provider/lxd/lxdnames"
 )
 
 //go:generate go run ../generate/filetoconst/filetoconst.go fallbackPublicCloudInfo fallback-public-cloud.yaml fallback_public_cloud.go 2015 cloud
@@ -128,12 +130,15 @@ type region struct {
 	StorageEndpoint string `yaml:"storage-endpoint,omitempty"`
 }
 
+//DefaultLXD is the name of the default lxd cloud.
+const DefaultLXD = "localhost"
+
 // BuiltInClouds work out of the box.
 var BuiltInClouds = map[string]Cloud{
-	"localhost": {
-		Type:      "lxd",
+	DefaultLXD: {
+		Type:      lxdnames.ProviderType,
 		AuthTypes: []AuthType{EmptyAuthType},
-		Regions:   []Region{{Name: "localhost"}},
+		Regions:   []Region{{Name: lxdnames.DefaultRegion}},
 	},
 }
 
@@ -175,15 +180,17 @@ func RegionByName(regions []Region, name string) (*Region, error) {
 	}
 	return nil, errors.NewNotFound(nil, fmt.Sprintf(
 		"region %q not found (expected one of %q)",
-		name, cloudRegionNames(regions),
+		name, RegionNames(regions),
 	))
 }
 
-func cloudRegionNames(regions []Region) []string {
+// RegionNames returns a sorted list of the names of the given regions.
+func RegionNames(regions []Region) []string {
 	names := make([]string, len(regions))
 	for i, region := range regions {
 		names[i] = region.Name
 	}
+	sort.Strings(names)
 	return names
 }
 

--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -191,3 +191,17 @@ clouds:
 `[1:]
 	s.assertCompareClouds(c, metadata, false)
 }
+
+func (s *cloudSuite) TestRegionNames(c *gc.C) {
+	regions := []cloud.Region{
+		{Name: "mars"},
+		{Name: "earth"},
+		{Name: "jupiter"},
+	}
+
+	names := cloud.RegionNames(regions)
+	c.Assert(names, gc.DeepEquals, []string{"earth", "jupiter", "mars"})
+
+	c.Assert(cloud.RegionNames([]cloud.Region{}), gc.HasLen, 0)
+	c.Assert(cloud.RegionNames(nil), gc.HasLen, 0)
+}

--- a/cmd/juju/commands/bootstrap_interactive.go
+++ b/cmd/juju/commands/bootstrap_interactive.go
@@ -1,0 +1,126 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/juju/errors"
+	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/cmd/juju/interact"
+)
+
+// assembleClouds
+func assembleClouds() ([]string, error) {
+	public, _, err := jujucloud.PublicCloudMetadata(jujucloud.JujuPublicCloudsPath())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	personal, err := jujucloud.PersonalCloudMetadata()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return sortClouds(public, common.BuiltInClouds(), personal), nil
+}
+
+// queryCloud asks the user to choose a cloud.
+func queryCloud(clouds []string, defCloud string, scanner *bufio.Scanner, w io.Writer) (string, error) {
+	list := strings.Join(clouds, "\n")
+	if _, err := fmt.Fprint(w, "Clouds\n", list, "\n\n"); err != nil {
+		return "", errors.Trace(err)
+	}
+
+	// add support for a default (empty) selection.
+	clouds = append(clouds, "")
+
+	verify := interact.MatchOptions(clouds, errors.Errorf("Invalid cloud."))
+
+	query := fmt.Sprintf("Select a cloud [%s]: ", defCloud)
+	cloud, err := interact.QueryVerify([]byte(query), scanner, w, verify)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if cloud == "" {
+		return defCloud, nil
+	}
+
+	cloudName, ok := interact.FindMatch(cloud, clouds)
+	if !ok {
+		// should be impossible
+		return "", errors.Errorf("invalid cloud name chosen: %s", cloud)
+	}
+
+	return cloudName, nil
+}
+
+// queryRegion asks the user to pick a region of the ones passed in. The first
+// region in the list will be the default.
+func queryRegion(cloud string, regions []jujucloud.Region, scanner *bufio.Scanner, w io.Writer) (string, error) {
+	fmt.Fprintf(w, "Regions in %s:\n", cloud)
+	names := jujucloud.RegionNames(regions)
+	// add an empty string to allow for a default value. Also gives us an extra
+	// line return after the list of names.
+	names = append(names, "")
+	if _, err := fmt.Fprintln(w, strings.Join(names, "\n")); err != nil {
+		return "", errors.Trace(err)
+	}
+	verify := interact.MatchOptions(names, errors.Errorf("Invalid region."))
+	defaultRegion := regions[0].Name
+	query := fmt.Sprintf("Select a region in %s [%s]: ", cloud, defaultRegion)
+	region, err := interact.QueryVerify([]byte(query), scanner, w, verify)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if region == "" {
+		return defaultRegion, nil
+	}
+	regionName, ok := interact.FindMatch(region, names)
+	if !ok {
+		// should be impossible
+		return "", errors.Errorf("invalid region name chosen: %s", region)
+	}
+
+	return regionName, nil
+}
+
+func defaultControllerName(username, cloudname, region string, cloud *jujucloud.Cloud) string {
+	name := cloudname
+	if len(cloud.Regions) > 1 {
+		name = region
+	}
+	if username == "" {
+		return name
+	}
+	return username + "-" + name
+}
+
+func queryName(defName string, scanner *bufio.Scanner, w io.Writer) (string, error) {
+	query := fmt.Sprintf("Enter a name for the Controller [%s]: ", defName)
+	name, err := interact.QueryVerify([]byte(query), scanner, w, nil)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if name == "" {
+		return defName, nil
+	}
+	return name, nil
+}
+
+func sortClouds(maps ...map[string]jujucloud.Cloud) []string {
+	var clouds []string
+	for _, m := range maps {
+		for name := range m {
+			clouds = append(clouds, name)
+		}
+	}
+	sort.Strings(clouds)
+	return clouds
+}

--- a/cmd/juju/commands/bootstrap_interactive_test.go
+++ b/cmd/juju/commands/bootstrap_interactive_test.go
@@ -1,0 +1,161 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"bufio"
+	"bytes"
+	"io/ioutil"
+	"strings"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	jujucloud "github.com/juju/juju/cloud"
+	jujutesting "github.com/juju/juju/testing"
+)
+
+type BSInteractSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(BSInteractSuite{})
+
+func (BSInteractSuite) TestInitEmpty(c *gc.C) {
+	cmd := &bootstrapCommand{}
+	err := jujutesting.InitCommand(cmd, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmd.interactive, jc.IsTrue)
+}
+
+func (BSInteractSuite) TestInitUploadTools(c *gc.C) {
+	cmd := &bootstrapCommand{}
+	err := jujutesting.InitCommand(cmd, []string{"--upload-tools"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmd.interactive, jc.IsTrue)
+	c.Assert(cmd.UploadTools, jc.IsTrue)
+}
+
+func (BSInteractSuite) TestInitArg(c *gc.C) {
+	cmd := &bootstrapCommand{}
+	err := jujutesting.InitCommand(cmd, []string{"foo"})
+	c.Assert(err, gc.ErrorMatches, "controller name and cloud name are required")
+	c.Assert(cmd.interactive, jc.IsFalse)
+}
+
+func (BSInteractSuite) TestInitTwoArgs(c *gc.C) {
+	cmd := &bootstrapCommand{}
+	err := jujutesting.InitCommand(cmd, []string{"foo", "bar"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmd.interactive, jc.IsFalse)
+}
+
+func (BSInteractSuite) TestInitOtherFlag(c *gc.C) {
+	cmd := &bootstrapCommand{}
+	err := jujutesting.InitCommand(cmd, []string{"--clouds"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmd.interactive, jc.IsFalse)
+}
+
+func (BSInteractSuite) TestQueryCloud(c *gc.C) {
+	input := "search\n"
+
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	clouds := []string{"books", "books-china", "search", "local"}
+
+	buf := bytes.Buffer{}
+	cloud, err := queryCloud(clouds, "local", scanner, &buf)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloud, gc.Equals, "search")
+
+	// clouds should be printed out in the same order as they're given.
+	expected := `
+Clouds
+books
+books-china
+search
+local
+
+Select a cloud [local]: 
+`[1:]
+	c.Assert(buf.String(), gc.Equals, expected)
+}
+
+func (BSInteractSuite) TestQueryCloudDefault(c *gc.C) {
+	input := "\n"
+
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	clouds := []string{"books", "local"}
+
+	cloud, err := queryCloud(clouds, "local", scanner, ioutil.Discard)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloud, gc.Equals, "local")
+}
+
+func (BSInteractSuite) TestQueryRegion(c *gc.C) {
+	input := "mars-west1\n"
+
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	regions := []jujucloud.Region{
+		{Name: "mars-east1"},
+		{Name: "mars-west1"},
+		{Name: "jupiter-central"},
+	}
+
+	buf := bytes.Buffer{}
+	region, err := queryRegion("goggles", regions, scanner, &buf)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(region, gc.Equals, "mars-west1")
+
+	// regions should be alphabetized, and the first one in the original list
+	// should be the default.
+	expected := `
+Regions in goggles:
+jupiter-central
+mars-east1
+mars-west1
+
+Select a region in goggles [mars-east1]: 
+`[1:]
+	c.Assert(buf.String(), gc.Equals, expected)
+}
+
+func (BSInteractSuite) TestQueryRegionDefault(c *gc.C) {
+	input := "\n"
+
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	regions := []jujucloud.Region{
+		{Name: "mars-east1"},
+		{Name: "jupiter-central"},
+	}
+
+	region, err := queryRegion("goggles", regions, scanner, ioutil.Discard)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(region, gc.Equals, regions[0].Name)
+}
+
+func (BSInteractSuite) TestQueryName(c *gc.C) {
+	input := "awesome-cloud\n"
+
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	buf := bytes.Buffer{}
+	name, err := queryName("default-cloud", scanner, &buf)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(name, gc.Equals, "awesome-cloud")
+
+	expected := `
+Enter a name for the Controller [default-cloud]: 
+`[1:]
+	c.Assert(buf.String(), gc.Equals, expected)
+}
+
+func (BSInteractSuite) TestQueryNameDefault(c *gc.C) {
+	input := "\n"
+
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	name, err := queryName("default-cloud", scanner, ioutil.Discard)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(name, gc.Equals, "default-cloud")
+}

--- a/cmd/juju/interact/doc.go
+++ b/cmd/juju/interact/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package interact provides helper methods for interacting with the CLI user at
+// command run time.
+package interact

--- a/cmd/juju/interact/package_test.go
+++ b/cmd/juju/interact/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package interact
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/cmd/juju/interact/query.go
+++ b/cmd/juju/interact/query.go
@@ -1,0 +1,75 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package interact
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// QueryVerify writes a question to w and waits for an answer to be read from
+// scanner.  It will pass the answer into the verify function.  Verify, if
+// non-nil, should check the answer for validity, returning an error that will
+// be written out to the user, or nil if answer is valid.
+//
+// This function takes a scanner rather than an io.Reader to avoid the case
+// where the scanner reads past the delimiter and thus might lose data.  It is
+// expected that this method will be used repeatedly with the same scanner if
+// multiple queries are required.
+func QueryVerify(question []byte, scanner *bufio.Scanner, w io.Writer, verify func(string) error) (answer string, err error) {
+	defer fmt.Fprint(w, "\n")
+	for {
+		if _, err = w.Write(question); err != nil {
+			return "", err
+		}
+
+		if !scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				return "", err
+			}
+			return "", io.EOF
+		}
+		answer = scanner.Text()
+		if verify == nil {
+			return answer, nil
+		}
+		err := verify(answer)
+		// valid answer, return it!
+		if err == nil {
+			return answer, nil
+		}
+		// invalid answer, inform user of problem and retry.
+		_, err = fmt.Fprint(w, err, "\n\n")
+		if err != nil {
+			return "", err
+		}
+	}
+}
+
+// MatchOptions returns a function that performs a case insensitive comparison
+// against the given list of options.  To make a verification function that
+// accepts an empty default, include an empty string in the list.
+func MatchOptions(options []string, err error) func(string) error {
+	return func(s string) error {
+		for _, opt := range options {
+			if strings.ToLower(opt) == strings.ToLower(s) {
+				return nil
+			}
+		}
+		return err
+	}
+}
+
+// FindMatch does a case-insensitive search of the given options and returns the
+// matching option.  Found reports whether s was found in the options.
+func FindMatch(s string, options []string) (match string, found bool) {
+	for _, opt := range options {
+		if strings.ToLower(opt) == strings.ToLower(s) {
+			return opt, true
+		}
+	}
+	return "", false
+}

--- a/cmd/juju/interact/query_test.go
+++ b/cmd/juju/interact/query_test.go
@@ -1,0 +1,105 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package interact
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"strings"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type Suite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(Suite{})
+
+func (Suite) TestAnswer(c *gc.C) {
+	scanner := bufio.NewScanner(strings.NewReader("hi!\n"))
+	answer, err := QueryVerify([]byte("boo: "), scanner, ioutil.Discard, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(answer, gc.Equals, "hi!")
+}
+
+func (Suite) TestVerify(c *gc.C) {
+	scanner := bufio.NewScanner(strings.NewReader("hi!\nok!\n"))
+	out := bytes.Buffer{}
+	verify := func(s string) error {
+		if s == "ok!" {
+			return nil
+		}
+		return errors.New("No!")
+	}
+	answer, err := QueryVerify([]byte("boo: "), scanner, &out, verify)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(answer, gc.Equals, "ok!")
+	// in practice, "No!" will be on a separate line, since the cursor will get
+	// moved down by the user hitting return for their answer, but the output
+	// we generate doesn't do that itself.'
+	expected := `
+boo: No!
+
+boo: 
+`[1:]
+	c.Assert(out.String(), gc.Equals, expected)
+}
+
+func (Suite) TestQueryMultiple(c *gc.C) {
+	scanner := bufio.NewScanner(strings.NewReader(`
+hi!
+ok!
+bob
+`[1:]))
+	verify := func(s string) error {
+		if s == "ok!" {
+			return nil
+		}
+		return errors.New("No!")
+	}
+	answer, err := QueryVerify([]byte("boo: "), scanner, ioutil.Discard, verify)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(answer, gc.Equals, "ok!")
+
+	answer, err = QueryVerify([]byte("name: "), scanner, ioutil.Discard, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(answer, gc.Equals, "bob")
+}
+
+func (Suite) TestMatchOptions(c *gc.C) {
+	err := errors.New("err")
+	f := MatchOptions([]string{"foo", "BAR"}, err)
+	c.Check(f("foo"), jc.ErrorIsNil)
+	c.Check(f("FOO"), jc.ErrorIsNil)
+	c.Check(f("BAR"), jc.ErrorIsNil)
+	c.Check(f("bar"), jc.ErrorIsNil)
+	c.Check(f("baz"), gc.Equals, err)
+}
+
+func (Suite) TestFindMatch(c *gc.C) {
+	options := []string{"foo", "BAR"}
+	m, ok := FindMatch("foo", options)
+	c.Check(m, gc.Equals, "foo")
+	c.Check(ok, jc.IsTrue)
+
+	m, ok = FindMatch("FOO", options)
+	c.Check(m, gc.Equals, "foo")
+	c.Check(ok, jc.IsTrue)
+
+	m, ok = FindMatch("bar", options)
+	c.Check(m, gc.Equals, "BAR")
+	c.Check(ok, jc.IsTrue)
+
+	m, ok = FindMatch("BAR", options)
+	c.Check(m, gc.Equals, "BAR")
+	c.Check(ok, jc.IsTrue)
+
+	m, ok = FindMatch("baz", options)
+	c.Check(ok, jc.IsFalse)
+}

--- a/provider/lxd/init.go
+++ b/provider/lxd/init.go
@@ -7,15 +7,12 @@ package lxd
 
 import (
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/provider/lxd/lxdnames"
 	"github.com/juju/juju/storage/provider/registry"
 )
 
-const (
-	providerType = "lxd"
-)
-
 func init() {
-	environs.RegisterProvider(providerType, providerInstance)
+	environs.RegisterProvider(lxdnames.ProviderType, providerInstance)
 
-	registry.RegisterEnvironStorageProviders(providerType)
+	registry.RegisterEnvironStorageProviders(lxdnames.ProviderType)
 }

--- a/provider/lxd/lxdnames/names.go
+++ b/provider/lxd/lxdnames/names.go
@@ -1,0 +1,15 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package lxdnames provides names for the lxd provider.
+package lxdnames
+
+// NOTE: this package exists to get around circular imports from cloud and
+// provider/lxd.
+
+// DefaultRegion is the name of the only "region" we support in lxd currently,
+// which corresponds to the local lxd daemon.
+const DefaultRegion = "localhost"
+
+// ProviderType defines the provider/cloud type for lxd.
+const ProviderType = "lxd"

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/provider/lxd/lxdnames"
 )
 
 type environProvider struct {
@@ -106,10 +107,7 @@ func (environProvider) DetectRegions() ([]cloud.Region, error) {
 	// For now we just return a hard-coded "localhost" region,
 	// i.e. the local LXD daemon. We may later want to detect
 	// locally-configured remotes.
-	// TODO (anastasiamac 2016-04-14) When/If this value changes,
-	// verify that juju/juju/cloud/clouds.go#BuiltInClouds
-	// with lxd type are up to-date.
-	return []cloud.Region{{Name: "localhost"}}, nil
+	return []cloud.Region{{Name: lxdnames.DefaultRegion}}, nil
 }
 
 // Schema returns the configuration schema for an environment.

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/provider/lxd"
+	"github.com/juju/juju/provider/lxd/lxdnames"
 	"github.com/juju/juju/tools/lxdclient"
 )
 
@@ -59,7 +60,7 @@ func (s *providerSuite) TestDetectRegions(c *gc.C) {
 	c.Assert(s.provider, gc.Implements, new(environs.CloudRegionDetector))
 	regions, err := s.provider.(environs.CloudRegionDetector).DetectRegions()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(regions, jc.DeepEquals, []cloud.Region{{Name: "localhost"}})
+	c.Assert(regions, jc.DeepEquals, []cloud.Region{{Name: lxdnames.DefaultRegion}})
 }
 
 func (s *providerSuite) TestRegistered(c *gc.C) {


### PR DESCRIPTION
add interactive mode to bootstrap
This adds an interactive mode to bootstrap so we can query the user for value needed at bootstrap time.
Some of this code is factored out into a library for reuse by other interactive code in the new interact
package.

Review request here: http://reviews.vapour.ws/r/5238