### PR TITLE
cmd/modelcmd: try macaroon auth if no account

### DIFF
--- a/api/interface.go
+++ b/api/interface.go
@@ -54,9 +54,8 @@ type Info struct {
 	SkipLogin bool `yaml:"-"`
 
 	// Tag holds the name of the entity that is connecting.
-	// If this is nil, and the password is empty, no login attempt will be made.
-	// (this is to allow tests to access the API to check that operations
-	// fail when not logged in).
+	// If this is nil, and the password is empty, macaroon authentication
+	// will be used to log in unless SkipLogin is true.
 	Tag names.Tag
 
 	// Password holds the password for the administrator or connecting entity.


### PR DESCRIPTION
Also record the logged-in username after doing macaroon
authentication.

(Review request: http://reviews.vapour.ws/r/5241/)