### PR TITLE
environs/bootstrap: fix test on windows

### DIFF
--- a/environs/bootstrap/config.go
+++ b/environs/bootstrap/config.go
@@ -200,11 +200,10 @@ func readFileAttr(attrs map[string]interface{}, key, defaultPath string) (conten
 	} else {
 		path = defaultPath
 	}
-	path, err := utils.NormalizePath(path)
+	absPath, err := utils.NormalizePath(path)
 	if err != nil {
 		return "", userSpecified, errors.Trace(err)
 	}
-	absPath := path
 	if !filepath.IsAbs(absPath) {
 		absPath = osenv.JujuXDGDataHomePath(absPath)
 	}


### PR DESCRIPTION
We were using the result of NormalizePath in an
error message, and expecting the path to be the
same on Linux and Windows. NormalizePath converts
slashes to native dir separators.

Rather than changing the test, the implementation
is changed to use the input to NormalizePath instead
of the output, when formatting the error message.

Fixes https://bugs.launchpad.net/juju-core/+bug/1603208

(Review request: http://reviews.vapour.ws/r/5244/)