### PR TITLE
Update mgo dependency

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -66,7 +66,7 @@ gopkg.in/juju/jujusvg.v1	git	cc128825adce31ea13020d24e7b3302bac86a8c3	2016-05-30
 gopkg.in/juju/names.v2	git	5426d66579afd36fc63d809dd58806806c2f161f	2016-06-23T03:33:52Z
 gopkg.in/macaroon-bakery.v1	git	b097c9d99b2537efaf54492e08f7e148f956ba51	2016-05-24T09:38:11Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
-gopkg.in/mgo.v2	git	4d04138ffef2791c479c0c8bbffc30b34081b8d9	2015-10-26T16:34:53Z
+gopkg.in/mgo.v2	git	aee6a64bc8cfb32f09e3996324a828fbcc9456f3	2016-07-14T19:08:04Z
 gopkg.in/natefinch/lumberjack.v2	git	514cbda263a734ae8caac038dadf05f8f3f9f738	2016-01-25T11:17:49Z
 gopkg.in/natefinch/npipe.v2	git	c1b8fa8bdccecb0b8db834ee0b92fdbcfa606dd6	2016-06-21T03:49:01Z
 gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:07Z


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1593828

Pull in new upstream mgo

(Review request: http://reviews.vapour.ws/r/5245/)