### PR TITLE
Only update controller details when restore will commence

### DIFF
--- a/cmd/juju/backups/export_test.go
+++ b/cmd/juju/backups/export_test.go
@@ -96,6 +96,7 @@ func GetEnvironFunc(e environs.Environ, cloud string) func(string, *params.Backu
 		return e, &restoreBootstrapParams{
 			ControllerConfig: testing.FakeControllerConfig(),
 			CloudName:        cloud,
+			CloudRegion:      "a-region",
 		}, nil
 	}
 }

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -133,7 +133,9 @@ func (s *restoreSuite) TestRestoreReboostrapNoControllers(c *gc.C) {
 	s.command = backups.NewRestoreCommandForTest(
 		s.store, &mockRestoreAPI{},
 		func(string) (backups.ArchiveReader, *params.BackupsMetadataResult, error) {
-			return &mockArchiveReader{}, &params.BackupsMetadataResult{}, nil
+			return &mockArchiveReader{}, &params.BackupsMetadataResult{
+				CACert: testing.CACert,
+			}, nil
 		},
 		backups.GetEnvironFunc(fakeEnv, "mycloud"),
 	)
@@ -187,7 +189,7 @@ func (s *restoreSuite) TestRestoreReboostrapWritesUpdatedControllerInfo(c *gc.C)
 		Cloud:                  "mycloud",
 		CloudRegion:            "a-region",
 		CACert:                 testing.CACert,
-		ControllerUUID:         "deadbeef-0bad-400d-8000-5b1d0d06f00d",
+		ControllerUUID:         "deadbeef-0bad-400d-8000-4b1d0d06f00d",
 		APIEndpoints:           []string{"10.0.0.1:17777"},
 		UnresolvedAPIEndpoints: []string{"10.0.0.1:17777"},
 	})


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1595686

When restoring with -b, we wait until we have checked that restore can proceed before we update controller details. Otherwise we may corrupt a running system by deleting endpoints.

(Review request: http://reviews.vapour.ws/r/5247/)