### PR TITLE
jujuclient: fix model update bug

### DIFF
--- a/jujuclient/file.go
+++ b/jujuclient/file.go
@@ -449,10 +449,11 @@ func updateModels(
 		if all == nil {
 			all = make(map[string]*ControllerModels)
 		}
-		controllerModels = &ControllerModels{
-			Models: make(map[string]ModelDetails),
-		}
+		controllerModels = &ControllerModels{}
 		all[controllerName] = controllerModels
+	}
+	if controllerModels.Models == nil {
+		controllerModels.Models = make(map[string]ModelDetails)
 	}
 	updated, err := update(controllerModels)
 	if err != nil {


### PR DESCRIPTION
If models.yaml is updated, then cleared of
all models, and then updated again, a panic
would occur. This diff fixes that panic.

(Review request: http://reviews.vapour.ws/r/5250/)