### PR TITLE
Fixes lp#1600404: don't ignore virt-type constraint on openstack.

### DIFF
--- a/core/description/constraints.go
+++ b/core/description/constraints.go
@@ -20,6 +20,8 @@ type ConstraintsArgs struct {
 
 	Spaces []string
 	Tags   []string
+
+	VirtType string
 }
 
 func newConstraints(args ConstraintsArgs) *constraints {
@@ -44,6 +46,7 @@ func newConstraints(args ConstraintsArgs) *constraints {
 		RootDisk_:     args.RootDisk,
 		Spaces_:       spaces,
 		Tags_:         tags,
+		VirtType_:     args.VirtType,
 	}
 }
 
@@ -60,6 +63,8 @@ type constraints struct {
 
 	Spaces_ []string `yaml:"spaces,omitempty"`
 	Tags_   []string `yaml:"tags,omitempty"`
+
+	VirtType_ string `yaml:"virt-type,omitempty"`
 }
 
 // Architecture implements Constraints.
@@ -117,6 +122,11 @@ func (c *constraints) Tags() []string {
 	return tags
 }
 
+// VirtType implements Constraints.
+func (c *constraints) VirtType() string {
+	return c.VirtType_
+}
+
 func importConstraints(source map[string]interface{}) (*constraints, error) {
 	version, err := getVersion(source)
 	if err != nil {
@@ -149,6 +159,8 @@ func importConstraintsV1(source map[string]interface{}) (*constraints, error) {
 
 		"spaces": schema.List(schema.String()),
 		"tags":   schema.List(schema.String()),
+
+		"virt-type": schema.String(),
 	}
 	// Some values don't have to be there.
 	defaults := schema.Defaults{
@@ -162,6 +174,8 @@ func importConstraintsV1(source map[string]interface{}) (*constraints, error) {
 
 		"spaces": schema.Omit,
 		"tags":   schema.Omit,
+
+		"virt-type": "",
 	}
 	checker := schema.FieldMap(fields, defaults)
 
@@ -185,6 +199,8 @@ func importConstraintsV1(source map[string]interface{}) (*constraints, error) {
 
 		Spaces_: convertToStringSlice(valid["spaces"]),
 		Tags_:   convertToStringSlice(valid["tags"]),
+
+		VirtType_: valid["virt-type"].(string),
 	}, nil
 }
 
@@ -202,5 +218,6 @@ func (c ConstraintsArgs) empty() bool {
 		c.Memory == 0 &&
 		c.RootDisk == 0 &&
 		c.Spaces == nil &&
-		c.Tags == nil
+		c.Tags == nil &&
+		c.VirtType == ""
 }

--- a/core/description/constraints_test.go
+++ b/core/description/constraints_test.go
@@ -65,6 +65,13 @@ func (s *ConstraintsSerializationSuite) TestNewConstraints(c *gc.C) {
 	c.Assert(instance.Tags(), jc.DeepEquals, []string{"much", "strong"})
 }
 
+func (s *ConstraintsSerializationSuite) TestNewConstraintsWithVirt(c *gc.C) {
+	args := s.allArgs()
+	args.VirtType = "kvm"
+	instance := newConstraints(args)
+	c.Assert(instance.VirtType(), gc.Equals, args.VirtType)
+}
+
 func (s *ConstraintsSerializationSuite) TestNewConstraintsEmpty(c *gc.C) {
 	instance := newConstraints(ConstraintsArgs{})
 	c.Assert(instance, gc.IsNil)
@@ -77,8 +84,16 @@ func (s *ConstraintsSerializationSuite) TestEmptyTagsAndSpaces(c *gc.C) {
 	c.Assert(instance.Spaces(), gc.IsNil)
 }
 
+func (s *ConstraintsSerializationSuite) TestEmptyVirt(c *gc.C) {
+	instance := newConstraints(ConstraintsArgs{Architecture: "amd64"})
+	c.Assert(instance.VirtType(), gc.Equals, "")
+}
+
 func (s *ConstraintsSerializationSuite) TestParsingSerializedData(c *gc.C) {
-	initial := newConstraints(s.allArgs())
+	s.assertParsingSerializedConstraints(c, newConstraints(s.allArgs()))
+}
+
+func (s *ConstraintsSerializationSuite) assertParsingSerializedConstraints(c *gc.C, initial Constraints) {
 	bytes, err := yaml.Marshal(initial)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -89,4 +104,10 @@ func (s *ConstraintsSerializationSuite) TestParsingSerializedData(c *gc.C) {
 	instance, err := importConstraints(source)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instance, jc.DeepEquals, initial)
+}
+
+func (s *ConstraintsSerializationSuite) TestParsingSerializedVirt(c *gc.C) {
+	args := s.allArgs()
+	args.VirtType = "kvm"
+	s.assertParsingSerializedConstraints(c, newConstraints(args))
 }

--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -196,6 +196,8 @@ type Constraints interface {
 
 	Spaces() []string
 	Tags() []string
+
+	VirtType() string
 }
 
 // Status represents an agent, application, or workload status.

--- a/state/constraints.go
+++ b/state/constraints.go
@@ -41,9 +41,7 @@ func (doc constraintsDoc) value() constraints.Value {
 		Container:    doc.Container,
 		Tags:         doc.Tags,
 		Spaces:       doc.Spaces,
-	}
-	if doc.VirtType != nil {
-		result.VirtType = doc.VirtType
+		VirtType:     doc.VirtType,
 	}
 	return result
 }
@@ -59,9 +57,7 @@ func newConstraintsDoc(st *State, cons constraints.Value) constraintsDoc {
 		Container:    cons.Container,
 		Tags:         cons.Tags,
 		Spaces:       cons.Spaces,
-	}
-	if cons.VirtType != nil {
-		result.VirtType = cons.VirtType
+		VirtType:     cons.VirtType,
 	}
 	return result
 }

--- a/state/constraints.go
+++ b/state/constraints.go
@@ -27,10 +27,11 @@ type constraintsDoc struct {
 	Container    *instance.ContainerType
 	Tags         *[]string
 	Spaces       *[]string
+	VirtType     *string
 }
 
 func (doc constraintsDoc) value() constraints.Value {
-	return constraints.Value{
+	result := constraints.Value{
 		Arch:         doc.Arch,
 		CpuCores:     doc.CpuCores,
 		CpuPower:     doc.CpuPower,
@@ -41,10 +42,14 @@ func (doc constraintsDoc) value() constraints.Value {
 		Tags:         doc.Tags,
 		Spaces:       doc.Spaces,
 	}
+	if doc.VirtType != nil {
+		result.VirtType = doc.VirtType
+	}
+	return result
 }
 
 func newConstraintsDoc(st *State, cons constraints.Value) constraintsDoc {
-	return constraintsDoc{
+	result := constraintsDoc{
 		Arch:         cons.Arch,
 		CpuCores:     cons.CpuCores,
 		CpuPower:     cons.CpuPower,
@@ -55,6 +60,10 @@ func newConstraintsDoc(st *State, cons constraints.Value) constraintsDoc {
 		Tags:         cons.Tags,
 		Spaces:       cons.Spaces,
 	}
+	if cons.VirtType != nil {
+		result.VirtType = cons.VirtType
+	}
+	return result
 }
 
 func createConstraintsOp(st *State, id string, cons constraints.Value) txn.Op {

--- a/state/constraintsvalidation_test.go
+++ b/state/constraintsvalidation_test.go
@@ -198,6 +198,18 @@ var setConstraintsTests = []struct {
 	effectiveServiceCons: "virt-type=kvm",
 	effectiveUnitCons:    "virt-type=kvm",
 	effectiveMachineCons: "virt-type=kvm",
+}, {
+	about:        "ensure model and application constraints are separate",
+	consToSet:    "virt-type=kvm",
+	consFallback: "mem=2G",
+
+	// application deployment constraints are transformed into machine
+	// provisioning constraints. Unit constraints must also have virt-type set
+	// to ensure consistency in scalability.
+	effectiveModelCons:   "mem=2G",
+	effectiveServiceCons: "virt-type=kvm",
+	effectiveUnitCons:    "mem=2G virt-type=kvm",
+	effectiveMachineCons: "mem=2G virt-type=kvm",
 }}
 
 func (s *constraintsValidationSuite) TestMachineConstraints(c *gc.C) {

--- a/state/constraintsvalidation_test.go
+++ b/state/constraintsvalidation_test.go
@@ -174,6 +174,18 @@ var setConstraintsTests = []struct {
 	effectiveServiceCons: "container=kvm arch=amd64",
 	effectiveUnitCons:    "container=kvm mem=8G arch=amd64",
 	effectiveMachineCons: "mem=8G arch=amd64",
+}, {
+	about:        "specify image virt-type when deploying applications on multi-hypervisor aware openstack",
+	consToSet:    "virt-type=kvm",
+	consFallback: "",
+
+	// application deployment constraints are transformed into machine
+	// provisioning constraints. Unit constraints must also have virt-type set
+	// to ensure consistency in scalability.
+	effectiveModelCons:   "",
+	effectiveServiceCons: "virt-type=kvm",
+	effectiveUnitCons:    "virt-type=kvm",
+	effectiveMachineCons: "virt-type=kvm",
 }}
 
 func (s *constraintsValidationSuite) TestMachineConstraints(c *gc.C) {

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -508,6 +508,7 @@ func (s *MigrationSuite) TestConstraintsDocFields(c *gc.C) {
 		"Container",
 		"Tags",
 		"Spaces",
+		"VirtType",
 	)
 	s.AssertExportedFields(c, constraintsDoc{}, fields)
 }

--- a/state/state.go
+++ b/state/state.go
@@ -947,7 +947,10 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		}
 	}
 
-	args.Constraints, err = st.resolveConstraints(args.Constraints)
+	// Ignore constraints that result from this call as
+	// these would be accumulation of model and application constraints
+	// but we only want application constraints to be persisted here.
+	_, err = st.resolveConstraints(args.Constraints)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -947,6 +947,11 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		}
 	}
 
+	args.Constraints, err = st.resolveConstraints(args.Constraints)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	for _, placement := range args.Placement {
 		data, err := st.parsePlacement(placement)
 		if err != nil {


### PR DESCRIPTION
On application deploy, application constraints were not validated. Added this missing validation.
For valid virt-type constraint for openstack, virt-type application constraint were not persisted. Persisting now. 

Adjusted migration test.

QA:
1. Bootstrap on multi-hypervisor-aware openstack.
2. Deploy using virt-type as constraint, for e.g. 'juju deploy ubuntu --constraints virt-type=kvm' 
3. Verify that application unit was deploy on a machine with kvm image.
(Note this is only applicable to openstack. All other providers must behave as before. Valid virt-type inputs for openstack are only kvm and lxd.)

Questions:
1. @howbazaar, @mjs: I had to adjust migration test. However, I have not touched core/description/constraints yet. Should I? 

(Review request: http://reviews.vapour.ws/r/5251/)