### PR TITLE
Add a patch to correct the mgo duplicate key error

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -66,7 +66,7 @@ gopkg.in/juju/jujusvg.v1	git	cc128825adce31ea13020d24e7b3302bac86a8c3	2016-05-30
 gopkg.in/juju/names.v2	git	5426d66579afd36fc63d809dd58806806c2f161f	2016-06-23T03:33:52Z
 gopkg.in/macaroon-bakery.v1	git	b097c9d99b2537efaf54492e08f7e148f956ba51	2016-05-24T09:38:11Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
-gopkg.in/mgo.v2	git	4d04138ffef2791c479c0c8bbffc30b34081b8d9	2015-10-26T16:34:53Z
+gopkg.in/mgo.v2	git	29cc868a5ca65f401ff318143f9408d02f4799cc	2016-06-09T18:00:28Z
 gopkg.in/natefinch/lumberjack.v2	git	514cbda263a734ae8caac038dadf05f8f3f9f738	2016-01-25T11:17:49Z
 gopkg.in/natefinch/npipe.v2	git	c1b8fa8bdccecb0b8db834ee0b92fdbcfa606dd6	2016-06-21T03:49:01Z
 gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:07Z

--- a/patches/001-mgo.v2-issue-277-fix.diff
+++ b/patches/001-mgo.v2-issue-277-fix.diff
@@ -1,0 +1,55 @@
+diff --git a/session.go b/session.go
+index a8ad115..0949359 100644
+This applies the minimal changes to fix the mgo duplicate key error,
+see https://github.com/go-mgo/mgo/pull/291
+--- a/gopkg.in/mgo.v2/session.go
++++ b/gopkg.in/mgo.v2/session.go
+@@ -146,7 +146,10 @@ var (
+ 	ErrCursor   = errors.New("invalid cursor")
+ )
+ 
+-const defaultPrefetch = 0.25
++const (
++	defaultPrefetch  = 0.25
++	maxUpsertRetries = 5
++)
+ 
+ // Dial establishes a new session to the cluster identified by the given seed
+ // server(s). The session will enable communication with all of the servers in
+@@ -2478,7 +2481,15 @@ func (c *Collection) Upsert(selector interface{}, update interface{}) (info *Cha
+ 		Flags:      1,
+ 		Upsert:     true,
+ 	}
+-	lerr, err := c.writeOp(&op, true)
++	var lerr *LastError
++	for i := 0; i < maxUpsertRetries; i++ {
++		lerr, err = c.writeOp(&op, true)
++		// Retry duplicate key errors on upserts.
++		// https://docs.mongodb.com/v3.2/reference/method/db.collection.update/#use-unique-indexes
++		if !IsDup(err) {
++			break
++		}
++	}
+ 	if err == nil && lerr != nil {
+ 		info = &ChangeInfo{}
+ 		if lerr.UpdatedExisting {
+@@ -4208,8 +4219,17 @@ func (q *Query) Apply(change Change, result interface{}) (info *ChangeInfo, err
+ 	session.SetMode(Strong, false)
+ 
+ 	var doc valueResult
+-	err = session.DB(dbname).Run(&cmd, &doc)
+-	if err != nil {
++	for i := 0; i < maxUpsertRetries; i++ {
++		err = session.DB(dbname).Run(&cmd, &doc)
++
++		if err == nil {
++			break
++		}
++		if change.Upsert && IsDup(err) {
++			// Retry duplicate key errors on upserts.
++			// https://docs.mongodb.com/v3.2/reference/method/db.collection.update/#use-unique-indexes
++			continue
++		}
+ 		if qerr, ok := err.(*QueryError); ok && qerr.Message == "No matching object found" {
+ 			return nil, ErrNotFound
+ 		}


### PR DESCRIPTION
Patch files (under patches/) will be applied to the source tree (with
$GOPATH/src as the current directory) before building.

Also update the mgo.v2 dependency to the latest version (so the patch
doesn't need to include a lot of other extraneous changes).