### PR TITLE
Use controller config when restoring

### DIFF
--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/cmd/modelcmd"
 	cmdtesting "github.com/juju/juju/cmd/testing"
-	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
@@ -124,10 +123,6 @@ func createBootstrapInfo(c *gc.C, name string) map[string]interface{} {
 		"uuid":       testing.ModelTag.Id(),
 		"controller": "true",
 	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	// TODO(wallyworld) - we need to separate controller and model schemas
-	cfg, err = cfg.Remove(jujucontroller.ControllerOnlyConfigAttributes)
 	c.Assert(err, jc.ErrorIsNil)
 	return cfg.AllAttrs()
 }

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -385,6 +385,7 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 		return nil, nil, errors.Trace(err)
 	}
 	return &jujuclient.BootstrapConfig{
+			ControllerConfig:     bootstrapConfig.ControllerConfig,
 			Credential:           bootstrapConfig.Credential,
 			Cloud:                bootstrapConfig.Cloud,
 			CloudRegion:          bootstrapConfig.CloudRegion,

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -190,6 +190,16 @@ func prepare(
 		return nil, details, errors.New("controller config is missing CA certificate")
 	}
 
+	// We want to store attributes describing how a controller has been configured.
+	// These do not include the CACert or UUID since they will be replaced with new
+	// values when/if we need to use this configuration.
+	details.ControllerConfig = make(controller.Config)
+	for k, v := range args.ControllerConfig {
+		if k == controller.CACertKey || k == controller.ControllerUUIDKey {
+			continue
+		}
+		details.ControllerConfig[k] = v
+	}
 	details.CACert = caCert
 	details.ControllerUUID = args.ControllerConfig.ControllerUUID()
 	details.User = environs.AdminUser

--- a/jujuclient/bootstrapconfigfile_test.go
+++ b/jujuclient/bootstrapconfigfile_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
@@ -23,7 +24,10 @@ var _ = gc.Suite(&BootstrapConfigFileSuite{})
 const testBootstrapConfigYAML = `
 controllers:
   aws-test:
-    config:
+    controller-config:
+      api-port: 17070
+      state-port: 37017
+    base-model-config:
       name: admin
       type: ec2
     credential: default
@@ -31,7 +35,10 @@ controllers:
     region: us-east-1
     endpoint: https://us-east-1.amazonaws.com
   mallards:
-    config:
+    controller-config:
+      api-port: 17070
+      state-port: 37017
+    base-model-config:
       name: admin
       type: maas
     cloud: maas
@@ -40,6 +47,10 @@ controllers:
 
 var testBootstrapConfig = map[string]jujuclient.BootstrapConfig{
 	"aws-test": {
+		ControllerConfig: controller.Config{
+			"api-port":   17070,
+			"state-port": 37017,
+		},
 		Config: map[string]interface{}{
 			"type": "ec2",
 			"name": "admin",
@@ -50,6 +61,10 @@ var testBootstrapConfig = map[string]jujuclient.BootstrapConfig{
 		CloudEndpoint: "https://us-east-1.amazonaws.com",
 	},
 	"mallards": {
+		ControllerConfig: controller.Config{
+			"api-port":   17070,
+			"state-port": 37017,
+		},
 		Config: map[string]interface{}{
 			"type": "maas",
 			"name": "admin",

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -3,7 +3,10 @@
 
 package jujuclient
 
-import "github.com/juju/juju/cloud"
+import (
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/controller"
+)
 
 // ControllerDetails holds the details needed to connect to a controller.
 type ControllerDetails struct {
@@ -59,9 +62,12 @@ type AccountDetails struct {
 // bootstrap configuration. A reference to the credential used will be
 // stored, rather than the credential itself.
 type BootstrapConfig struct {
+	// ControllerConfig is the controller configuration.
+	ControllerConfig controller.Config `yaml:"controller-config"`
+
 	// ModelConfig is the base configuration for the provider. This should
 	// be updated with the region, endpoint and credentials.
-	Config map[string]interface{} `yaml:"config"`
+	Config map[string]interface{} `yaml:"base-model-config"`
 
 	// Credential is the name of the credential used to bootstrap.
 	//


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1603577

There were a couple of problems with restore:
1. bootstrap-config.yaml was not storing controller config
This didn't used to matter because controller config was mixed in with model config.
But now it is separate so we need to explicitly store controller config.
2. restoring a backup done on LXD didn't work.


(Review request: http://reviews.vapour.ws/r/5256/)