### PR TITLE
Remove seperate model config source collection

### DIFF
--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -372,7 +372,7 @@ func finalizeInstanceBootstrapConfig(
 		CAPrivateKey: args.CAPrivateKey,
 	}
 	if _, ok := cfg.AgentVersion(); !ok {
-		return fmt.Errorf("controller model configuration has no agent-version")
+		return errors.New("controller model configuration has no agent-version")
 	}
 
 	icfg.Bootstrap.ControllerModelConfig = cfg

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -194,9 +194,6 @@ func allCollections() collectionSchema {
 			rawAccess: true,
 		},
 
-		// This collection holds the source from where model settings came.
-		modelSettingsSourcesC: {},
-
 		// This collection contains governors that prevent certain kinds of
 		// changes from being accepted.
 		blocksC: {},
@@ -409,7 +406,6 @@ const (
 	migrationsStatusC        = "migrations.status"
 	migrationsActiveC        = "migrations.active"
 	migrationsC              = "migrations"
-	modelSettingsSourcesC    = "modelSettingsSources"
 	modelUserLastConnectionC = "modelUserLastConnection"
 	modelUsersC              = "modelusers"
 	modelsC                  = "models"

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -118,7 +118,6 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 	// THIS SET WILL BE REMOVED WHEN MIGRATIONS ARE COMPLETE
 	todoCollections := set.NewStrings(
 		// model configuration
-		modelSettingsSourcesC,
 		globalSettingsC,
 
 		// model

--- a/state/open.go
+++ b/state/open.go
@@ -324,19 +324,18 @@ func (st *State) modelSetupOps(args ModelArgs, ControllerInheritedConfig map[str
 	if len(ControllerInheritedConfig) > 0 {
 		configSources = []modelConfigSource{{
 			name: config.JujuControllerSource,
-			sourceFunc: modelConfigSourceFunc(func() (map[string]interface{}, error) {
+			sourceFunc: modelConfigSourceFunc(func() (attrValues, error) {
 				return ControllerInheritedConfig, nil
 			})}}
 	} else {
 		configSources = modelConfigSources(st)
 	}
-	modelCfg, cfgSource, err := composeModelConfigAttributes(args.Config.AllAttrs(), configSources...)
+	modelCfg, err := composeModelConfigAttributes(args.Config.AllAttrs(), configSources...)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	ops = append(ops,
 		createSettingsOp(settingsC, modelGlobalKey, modelCfg),
-		createSettingsSourceOp(cfgSource),
 		createModelEntityRefsOp(modelUUID),
 		createModelOp(
 			args.Owner,

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -176,7 +176,7 @@ func (s *StateSuite) TestModelUUID(c *gc.C) {
 
 func (s *StateSuite) TestNoModelDocs(c *gc.C) {
 	c.Assert(s.State.EnsureModelRemoved(), gc.ErrorMatches,
-		fmt.Sprintf("found documents for model with uuid %s: 1 constraints doc, 2 leases doc, 1 modelSettingsSources doc, 1 modelusers doc, 1 permissions doc, 1 settings doc, 1 statuses doc", s.State.ModelUUID()))
+		fmt.Sprintf("found documents for model with uuid %s: 1 constraints doc, 2 leases doc, 1 modelusers doc, 1 permissions doc, 1 settings doc, 1 statuses doc", s.State.ModelUUID()))
 }
 
 func (s *StateSuite) TestMongoSession(c *gc.C) {


### PR DESCRIPTION
Instead of storing the source of model config attributes in a separate collection, we determine the source of each attribute dynamically whenever ModelConfig() is called. This is so that a user can update a global default at any time and have that relfected in model config output.

(Review request: http://reviews.vapour.ws/r/5258/)