### PR TITLE
godeps is on github now

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ godeps
 After getting the juju code, you need to get `godeps`:
 
 ```shell
-go get launchpad.net/godeps
+go get github.com/rogpeppe/godeps
 ```
 
 This installs the `godeps` application.  You can then run `godeps` from the


### PR DESCRIPTION
go get should pull from github.com/rogpeppe/godeps not launchpad (it fails without -insecure switch anyway)