### PR TITLE
BCP-ize interactive commands

### DIFF
--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -158,7 +158,7 @@ func (c *addCredentialCommand) Run(ctxt *cmd.Context) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(ctxt.Stdout, "credentials updated for cloud %s\n", c.CloudName)
+	fmt.Fprintf(ctxt.Stdout, "Credentials updated for cloud %q.\n", c.CloudName)
 	return nil
 }
 
@@ -182,7 +182,7 @@ func (c *addCredentialCommand) interactiveAddCredential(ctxt *cmd.Context, schem
 		return errors.Trace(err)
 	}
 	if credentialName == "" {
-		fmt.Fprintln(ctxt.Stderr, "credentials entry aborted")
+		fmt.Fprintln(ctxt.Stderr, "Credentials entry aborted.")
 		return nil
 	}
 
@@ -220,12 +220,12 @@ func (c *addCredentialCommand) interactiveAddCredential(ctxt *cmd.Context, schem
 	if err != nil {
 		return errors.Trace(err)
 	}
-	fmt.Fprintf(ctxt.Stdout, "credentials added for cloud %s\n\n", c.CloudName)
+	fmt.Fprintf(ctxt.Stdout, "Credentials added for cloud %s.\n\n", c.CloudName)
 	return nil
 }
 
 func (c *addCredentialCommand) promptCredentialName(out io.Writer, in io.Reader) (string, error) {
-	fmt.Fprint(out, "  credential name: ")
+	fmt.Fprint(out, "Enter credential name: ")
 	input, err := readLine(in)
 	if err != nil {
 		return "", errors.Trace(err)
@@ -234,7 +234,11 @@ func (c *addCredentialCommand) promptCredentialName(out io.Writer, in io.Reader)
 }
 
 func (c *addCredentialCommand) promptReplace(out io.Writer, in io.Reader) (bool, error) {
-	fmt.Fprint(out, "  replace existing credential? [y/N]: ")
+	fmt.Fprint(out, `
+A credential with that name already exists.
+
+Replace the existing credential? (y/N): `[1:])
+
 	input, err := readLine(in)
 	if err != nil {
 		return false, errors.Trace(err)
@@ -244,7 +248,7 @@ func (c *addCredentialCommand) promptReplace(out io.Writer, in io.Reader) (bool,
 
 func (c *addCredentialCommand) promptAuthType(out io.Writer, in io.Reader, authTypes []jujucloud.AuthType) (jujucloud.AuthType, error) {
 	if len(authTypes) == 1 {
-		fmt.Fprintf(out, "  auth-type: %v\n", authTypes[0])
+		fmt.Fprintf(out, "Using auth-type %q.\n", authTypes[0])
 		return authTypes[0], nil
 	}
 	authType := ""
@@ -256,7 +260,8 @@ func (c *addCredentialCommand) promptAuthType(out io.Writer, in io.Reader, authT
 		}
 	}
 	for {
-		fmt.Fprintf(out, "  select auth-type [%v]: ", strings.Join(choices, ", "))
+		fmt.Fprintf(out, "Auth Types\n%s\n\nSelect auth-type: ",
+			strings.Join(choices, "\n"))
 		input, err := readLine(in)
 		if err != nil {
 			return "", errors.Trace(err)
@@ -275,7 +280,7 @@ func (c *addCredentialCommand) promptAuthType(out io.Writer, in io.Reader, authT
 		if isValid {
 			break
 		}
-		fmt.Fprintf(out, "  ...invalid auth type %q\n", authType)
+		fmt.Fprintf(out, "Invalid auth type %q.\n", authType)
 	}
 	return jujucloud.AuthType(authType), nil
 }
@@ -311,7 +316,7 @@ func (c *addCredentialCommand) promptCredentialAttributes(
 					}
 				}
 				if !isValid {
-					fmt.Fprintf(out, "  ...invalid value %q\n", value)
+					fmt.Fprintf(out, "Invalid value %q.\n", value)
 					continue
 				}
 				if value == "" && !currentAttr.Optional {
@@ -337,7 +342,7 @@ func (c *addCredentialCommand) promptCredentialAttributes(
 			if value != "" && currentAttr.FilePath {
 				value, err = jujucloud.ValidateFileAttrValue(value)
 				if err != nil {
-					fmt.Fprintf(out, "  ...%s\n", err.Error())
+					fmt.Fprintf(out, "Invalid file attribute %q.\n", err.Error())
 					continue
 				}
 			}
@@ -373,7 +378,7 @@ func (c *addCredentialCommand) promptFieldValue(
 	}
 
 	// Prompt for and accept input for field value.
-	fmt.Fprintf(out, "  %s%s: ", name, optionsPrompt)
+	fmt.Fprintf(out, "Enter %s%s: ", name, optionsPrompt)
 	var input string
 	var err error
 	if attr.Hidden {

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -329,7 +329,7 @@ func (c *detectCredentialsCommand) printCredentialOptions(ctxt *cmd.Context, dis
 }
 
 func (c *detectCredentialsCommand) promptCredentialNumber(out io.Writer, in io.Reader) (string, error) {
-	fmt.Fprint(out, "Save any? Type number, or Q to quit, then enter. ")
+	fmt.Fprint(out, "Select a credential to save by number, or type Q to quit: ")
 	defer out.Write([]byte{'\n'})
 	input, err := readLine(in)
 	if err != nil {
@@ -339,7 +339,7 @@ func (c *detectCredentialsCommand) promptCredentialNumber(out io.Writer, in io.R
 }
 
 func (c *detectCredentialsCommand) promptCloudName(out io.Writer, in io.Reader, defaultCloudName, cloudType string) (string, error) {
-	text := fmt.Sprintf(`Enter cloud to which the credential belongs, or Q to quit [%s] `, defaultCloudName)
+	text := fmt.Sprintf(`Select the cloud it belongs to, or type Q to quit [%s]: `, defaultCloudName)
 	fmt.Fprint(out, text)
 	defer out.Write([]byte{'\n'})
 	input, err := readLine(in)

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -68,7 +68,7 @@ var destroySysMsg = `
 WARNING! This command will destroy the %q controller.
 This includes all machines, applications, data and other resources.
 
-Continue [y/N]? `[1:]
+Continue? (y/N):`[1:]
 
 // destroyControllerAPI defines the methods on the controller API endpoint
 // that the destroy command calls.

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -211,7 +211,7 @@ func (c *registerCommand) maybeSetCurrentModel(ctx *cmd.Context, controllerName 
 		if err != nil {
 			return errors.Trace(err)
 		}
-		fmt.Fprintf(ctx.Stderr, "\nCurrent model set to %q\n\n", modelName)
+		fmt.Fprintf(ctx.Stderr, "\nCurrent model set to %q.\n\n", modelName)
 	} else {
 		fmt.Fprintf(ctx.Stderr, `
 There are %d models available. Use "juju switch" to select
@@ -362,8 +362,8 @@ func (c *registerCommand) promptNewPassword(stderr io.Writer, stdin io.Reader) (
 	return password, nil
 }
 
-const errControllerConflicts = `WARNING: the controller proposed %q which clashes with an` +
-	` existing controller. The two controllers are entirely different.
+const errControllerConflicts = `WARNING: The controller proposed %q which clashes with an existing` +
+	` controller. The two controllers are entirely different.
 
 `
 
@@ -373,11 +373,12 @@ func (c *registerCommand) promptControllerName(suggestedName string, stderr io.W
 		fmt.Fprintf(stderr, errControllerConflicts, suggestedName)
 		suggestedName = ""
 	}
-	setMsg := "Please set a name for this controller"
+	var setMsg string
+	setMsg = "Enter a name for this controller: "
 	if suggestedName != "" {
-		setMsg = setMsg + " (" + suggestedName + ")"
+		setMsg = fmt.Sprintf("Enter a name for this controller [%s]: ",
+			suggestedName)
 	}
-	setMsg = setMsg + ":"
 	fmt.Fprintf(stderr, setMsg)
 	defer stderr.Write([]byte{'\n'})
 	name, err := c.readLine(stdin)

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -146,7 +146,7 @@ func (s *RegisterSuite) TestRegister(c *gc.C) {
 	c.Assert(s.refreshModelsControllerName, gc.Equals, "controller-name")
 	stderr := testing.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `
-Please set a name for this controller (controller-name):
+Enter a name for this controller [controller-name]: 
 Enter a new password: 
 Confirm password: 
 
@@ -194,7 +194,7 @@ func (s *RegisterSuite) TestRegisterMultipleModels(c *gc.C) {
 
 	stderr := testing.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `
-Please set a name for this controller (controller-name):
+Enter a name for this controller [controller-name]: 
 Enter a new password: 
 Confirm password: 
 
@@ -337,9 +337,9 @@ func (s *RegisterSuite) TestProposedControllerNameExists(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	stderr := testing.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `
-WARNING: the controller proposed "controller-name" which clashes with an existing controller. The two controllers are entirely different.
+WARNING: The controller proposed "controller-name" which clashes with an existing controller. The two controllers are entirely different.
 
-Please set a name for this controller:
+Enter a name for this controller: 
 `[1:])
 
 }

--- a/featuretests/cmd_juju_register_test.go
+++ b/featuretests/cmd_juju_register_test.go
@@ -60,9 +60,9 @@ Please send this command to bob:
 	context = s.run(c, stdin, args...)
 	c.Check(testing.Stdout(context), gc.Equals, "")
 	c.Check(testing.Stderr(context), gc.Equals, `
-WARNING: the controller proposed "kontroll" which clashes with an existing controller. The two controllers are entirely different.
+WARNING: The controller proposed "kontroll" which clashes with an existing controller. The two controllers are entirely different.
 
-Please set a name for this controller:
+Enter a name for this controller: 
 Enter a new password: 
 Confirm password: 
 


### PR DESCRIPTION
This PR attempts to bring the interactive bits of: `destroy-controller`, `autoload-credential`, `add-credential`, and `register` into compliance with [Interactive Commands in Juju](https://goo.gl/Ycu8AO).

(Review request: http://reviews.vapour.ws/r/5261/)