### PR TITLE
cmd/juju/commands: Set controller on base command during bootstrap

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -668,7 +668,7 @@ to clean up the model.`[1:])
 		return errors.Annotate(err, "failed to bootstrap model")
 	}
 
-	if err := c.SetModelName(c.hostedModelName); err != nil {
+	if err := c.SetModelName(modelcmd.JoinModelName(c.controllerName, c.hostedModelName)); err != nil {
 		return errors.Trace(err)
 	}
 


### PR DESCRIPTION
The controller being bootstrapped wasn't being set on bootstrapCommand's embedded ModelCommandBase meaning that some aspects of bootstrap were relying on the currently selected controller being correct. This would often break concurrent bootstrap attempts on a single machine.

Fixes LP #1604223.

(Review request: http://reviews.vapour.ws/r/5262/)