### PR TITLE
Fixes lp#1603585: skip tests suites that are known to fail on windows.

### DIFF
--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -5,6 +5,7 @@ package modelmanager_test
 
 import (
 	"regexp"
+	"runtime"
 	"time"
 
 	"github.com/juju/errors"
@@ -239,6 +240,14 @@ type modelManagerStateSuite struct {
 }
 
 var _ = gc.Suite(&modelManagerStateSuite{})
+
+func (s *modelManagerStateSuite) SetUpSuite(c *gc.C) {
+	// TODO(anastasiamac 2016-07-19): Fix this on windows
+	if runtime.GOOS != "linux" {
+		c.Skip("bug 1603585: Skipping this on windows for now")
+	}
+	s.JujuConnSuite.SetUpSuite(c)
+}
 
 func (s *modelManagerStateSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -5,6 +5,7 @@ package featuretests
 
 import (
 	"flag"
+	"runtime"
 	stdtesting "testing"
 
 	gc "gopkg.in/check.v1"
@@ -22,23 +23,28 @@ func init() {
 		return
 	}
 	// Initialize all suites here.
-	gc.Suite(&cmdJujuSuite{})
 	gc.Suite(&annotationsSuite{})
 	gc.Suite(&apiEnvironmentSuite{})
-	gc.Suite(&blockSuite{})
-	gc.Suite(&cmdModelSuite{})
-	gc.Suite(&cmdStorageSuite{})
-	gc.Suite(&cmdControllerSuite{})
-	gc.Suite(&dblogSuite{})
-	gc.Suite(&cloudImageMetadataSuite{})
-	gc.Suite(&cmdSpaceSuite{})
-	gc.Suite(&cmdSubnetSuite{})
-	gc.Suite(&undertakerSuite{})
-	gc.Suite(&dumpLogsCommandSuite{})
-	gc.Suite(&upgradeSuite{})
-	gc.Suite(&cmdRegistrationSuite{})
-	gc.Suite(&cmdLoginSuite{})
 	gc.Suite(&BakeryStorageSuite{})
+	gc.Suite(&blockSuite{})
+	gc.Suite(&cmdControllerSuite{})
+	gc.Suite(&cmdJujuSuite{})
+	gc.Suite(&cmdLoginSuite{})
+	gc.Suite(&cmdModelSuite{})
+	gc.Suite(&cmdRegistrationSuite{})
+	gc.Suite(&cmdStorageSuite{})
+	gc.Suite(&cmdSubnetSuite{})
+	gc.Suite(&dblogSuite{})
+	gc.Suite(&dumpLogsCommandSuite{})
+	gc.Suite(&undertakerSuite{})
+	gc.Suite(&upgradeSuite{})
+
+	// TODO (anastasiamac 2016-07-19) Bug#1603585
+	// These tests cannot run on windows - they require a bootstrapped controller.
+	if runtime.GOOS != "linux" {
+		gc.Suite(&cloudImageMetadataSuite{})
+		gc.Suite(&cmdSpaceSuite{})
+	}
 }
 
 func TestPackage(t *stdtesting.T) {


### PR DESCRIPTION
Skip some tests on windows that require bootstrapped controller.
 

(Review request: http://reviews.vapour.ws/r/5263/)