### PR TITLE
Add credential schema for lxd, cleanup get-model-config

### DIFF
--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -50,6 +50,9 @@ type serverSuite struct {
 var _ = gc.Suite(&serverSuite{})
 
 func (s *serverSuite) SetUpTest(c *gc.C) {
+	s.ConfigAttrs = map[string]interface{}{
+		"authorized-keys": coretesting.FakeAuthKeys,
+	}
 	s.baseSuite.SetUpTest(c)
 
 	var err error
@@ -739,6 +742,7 @@ func (s *serverSuite) TestClientModelGet(c *gc.C) {
 			Source: "model",
 		}
 	}
+	delete(cfg, "authorized-keys")
 	c.Assert(result.Config, gc.DeepEquals, cfg)
 }
 

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -41,6 +41,9 @@ const (
 	// a JSON file.
 	JSONFileAuthType AuthType = "jsonfile"
 
+	// CertificateAuthType is an authentication type using certificates.
+	CertificateAuthType AuthType = "certificate"
+
 	// EmptyAuthType is the authentication type used for providers
 	// that require no credentials, e.g. "lxd", and "manual".
 	EmptyAuthType AuthType = "empty"

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -262,7 +262,7 @@ func (s *restoreSuite) TestRestoreReboostrapBuiltInProvider(c *gc.C) {
 		boostrapped = true
 		c.Assert(args.Cloud, jc.DeepEquals, cloud.Cloud{
 			Type:      "lxd",
-			AuthTypes: []cloud.AuthType{"empty"},
+			AuthTypes: []cloud.AuthType{"empty", "certificate"},
 			Regions:   []cloud.Region{{Name: "localhost"}},
 		})
 		return nil

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -439,6 +439,7 @@ var commandNames = []string{
 	"logout",
 	"machine",
 	"machines",
+	"model-config",
 	"models",
 	"plans",
 	"register",

--- a/cmd/juju/model/get.go
+++ b/cmd/juju/model/get.go
@@ -49,6 +49,7 @@ See also: models
 func (c *getCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "get-model-config",
+		Aliases: []string{"model-config"},
 		Args:    "[<model key>]",
 		Purpose: "Displays configuration settings for a model.",
 		Doc:     strings.TrimSpace(getModelHelpDoc),
@@ -142,7 +143,10 @@ func formatConfigTabular(value interface{}) ([]byte, error) {
 		if err != nil {
 			return nil, errors.Annotatef(err, "formatting value for %q", name)
 		}
-		p(name, info.Source, string(val))
+		// Some attribute values have a newline appended
+		// which makes the output messy.
+		valString := strings.TrimSuffix(string(val), "\n")
+		p(name, info.Source, valString)
 	}
 
 	tw.Flush()

--- a/cmd/juju/model/set.go
+++ b/cmd/juju/model/set.go
@@ -4,10 +4,10 @@
 package model
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/utils/keyvalues"
 
 	"github.com/juju/juju/cmd/juju/block"
@@ -52,7 +52,7 @@ func (c *setCommand) Info() *cmd.Info {
 
 func (c *setCommand) Init(args []string) (err error) {
 	if len(args) == 0 {
-		return fmt.Errorf("no key, value pairs specified")
+		return errors.New("no key, value pairs specified")
 	}
 
 	options, err := keyvalues.Parse(args, true)
@@ -63,7 +63,7 @@ func (c *setCommand) Init(args []string) (err error) {
 	c.values = make(attributes)
 	for key, value := range options {
 		if key == "agent-version" {
-			return fmt.Errorf("agent-version must be set via upgrade-juju")
+			return errors.New("agent-version must be set via upgrade-juju")
 		}
 		c.values[key] = value
 	}

--- a/cmd/juju/model/unset.go
+++ b/cmd/juju/model/unset.go
@@ -4,10 +4,10 @@
 package model
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -51,9 +51,9 @@ func (c *unsetCommand) Info() *cmd.Info {
 	}
 }
 
-func (c *unsetCommand) Init(args []string) (err error) {
+func (c *unsetCommand) Init(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("no keys specified")
+		return errors.New("no keys specified")
 	}
 	c.keys = args
 	return nil

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -16,7 +16,19 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 	// TODO (anastasiamac 2016-04-14) When/If this value changes,
 	// verify that juju/juju/cloud/clouds.go#BuiltInClouds
 	// with lxd type are up to-date.
-	return map[cloud.AuthType]cloud.CredentialSchema{cloud.EmptyAuthType: {}}
+	// TODO(wallyworld) update BuiltInClouds to match when we actually take notice of TLSAuthType
+	return map[cloud.AuthType]cloud.CredentialSchema{
+		cloud.EmptyAuthType: {},
+		cloud.CertificateAuthType: {
+			{
+				cfgClientCert, cloud.CredentialAttr{Description: "The client cert used for connecting to a LXD host machine."},
+			}, {
+				cfgClientKey, cloud.CredentialAttr{Description: "The client key used for connecting to a LXD host machine."},
+			}, {
+				cfgServerPEMCert, cloud.CredentialAttr{Description: "The certificate of the LXD server on the host machine."},
+			},
+		},
+	}
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.

--- a/provider/lxd/credentials_test.go
+++ b/provider/lxd/credentials_test.go
@@ -29,7 +29,7 @@ func (s *credentialsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *credentialsSuite) TestCredentialSchemas(c *gc.C) {
-	envtesting.AssertProviderAuthTypes(c, s.provider, "empty")
+	envtesting.AssertProviderAuthTypes(c, s.provider, "certificate", "empty")
 }
 
 func (s *credentialsSuite) TestDetectCredentials(c *gc.C) {


### PR DESCRIPTION
1. Add model-config alias for get-model-config
2. Filter authorized-keys from model-config output 
(these are accessible from juju ssh-keys)
3. Filter credential attributes from model-config output
(these will be removed, but we want clean output until then)

The LXD provider supports a new "certificate" auth type. At the moment, the client and server keys are generated when the LXD server is connected to. So we don't use detect credentials. But we can model the credential attributes used.

(Review request: http://reviews.vapour.ws/r/5264/)