### PR TITLE
Add a dump model command to show the database export.

### DIFF
--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -106,13 +106,24 @@ func (c *Client) ModelInfo(tags []names.ModelTag) ([]params.ModelInfoResult, err
 }
 
 // DumpModel returns the serialized database agnostic model representation.
-func (c *Client) DumpModel(model names.ModelTag) ([]byte, error) {
-	var results params.BytesResult
-	err := c.facade.FacadeCall("DumpModel", params.Entity{model.String()}, &results)
+func (c *Client) DumpModel(model names.ModelTag) (map[string]interface{}, error) {
+	var results params.MapResults
+	entities := params.Entities{
+		Entities: []params.Entity{{Tag: model.String()}},
+	}
+
+	err := c.facade.FacadeCall("DumpModels", entities, &results)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return results.Result, nil
+	if count := len(results.Results); count != 1 {
+		return nil, errors.Errorf("unexpected result count: %d", count)
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return result.Result, nil
 }
 
 // DestroyModel puts the model into a "dying" state,

--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -105,6 +105,16 @@ func (c *Client) ModelInfo(tags []names.ModelTag) ([]params.ModelInfoResult, err
 	return results.Results, nil
 }
 
+// DumpModel returns the serialized database agnostic model representation.
+func (c *Client) DumpModel(model names.ModelTag) ([]byte, error) {
+	var results params.BytesResult
+	err := c.facade.FacadeCall("DumpModel", params.Entity{model.String()}, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return results.Result, nil
+}
+
 // DestroyModel puts the model into a "dying" state,
 // and removes all non-manager machine instances. DestroyModel
 // will fail if there are any manually-provisioned non-manager machines

--- a/api/modelmanager/modelmanager_test.go
+++ b/api/modelmanager/modelmanager_test.go
@@ -9,8 +9,11 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	basetesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/modelmanager"
+	"github.com/juju/juju/apiserver/params"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -87,4 +90,30 @@ func (s *modelmanagerSuite) TestDestroyEnvironment(c *gc.C) {
 	err := modelManagerClient.DestroyModel()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
+}
+
+type dumpModelSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&dumpModelSuite{})
+
+func (s *dumpModelSuite) TestDumpModel(c *gc.C) {
+	results := params.BytesResult{[]byte("serialized model info")}
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, args, result interface{}) error {
+			c.Check(objType, gc.Equals, "ModelManager")
+			c.Check(request, gc.Equals, "DumpModel")
+			in, ok := args.(params.Entity)
+			c.Assert(ok, jc.IsTrue)
+			c.Assert(in.Tag, gc.Equals, testing.ModelTag.String())
+			res, ok := result.(*params.BytesResult)
+			c.Assert(ok, jc.IsTrue)
+			*res = results
+			return nil
+		})
+	client := modelmanager.NewClient(apiCaller)
+	out, err := client.DumpModel(testing.ModelTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out, jc.DeepEquals, results.Result)
 }

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/juju/apiserver/metricsender"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
@@ -42,6 +43,7 @@ type ModelManagerBackend interface {
 	RemoveModelUser(names.UserTag) error
 	ModelUser(names.UserTag) (*state.ModelUser, error)
 	ModelTag() names.ModelTag
+	Export() (description.Model, error)
 	Close() error
 }
 

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -20,6 +20,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
@@ -218,6 +219,16 @@ type mockState struct {
 	controllerModel *mockModel
 	users           []*state.ModelUser
 	creds           map[string]cloud.Credential
+}
+
+type fakeModelDescription struct {
+	description.Model `yaml:"-"`
+
+	UUID string `yaml:"model-uuid"`
+}
+
+func (st *mockState) Export() (description.Model, error) {
+	return &fakeModelDescription{UUID: st.uuid}, nil
 }
 
 func (st *mockState) ModelUUID() string {

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -75,6 +75,18 @@ type StringResults struct {
 	Results []StringResult `json:"results"`
 }
 
+// MapResult holds a generic map or an error.
+type MapResult struct {
+	Result map[string]interface{} `json:"result"`
+	Error  *Error                 `json:"error,omitempty"`
+}
+
+// MapResults holds the bulk operation result of an API call
+// that returns a map or an error.
+type MapResults struct {
+	Results []MapResult `json:"results"`
+}
+
 // ModelResult holds the result of an API call returning a name and UUID
 // for a model.
 type ModelResult struct {

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -301,6 +301,9 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	if featureflag.Enabled(feature.Migration) {
 		r.Register(newMigrateCommand())
 	}
+	if featureflag.Enabled(feature.DeveloperMode) {
+		r.Register(model.NewDumpCommand())
+	}
 
 	// Manage and control actions
 	r.Register(action.NewStatusCommand())

--- a/cmd/juju/commands/migrate.go
+++ b/cmd/juju/commands/migrate.go
@@ -51,10 +51,10 @@ This command only starts a model migration - it does not wait for its
 completion. The progress of a migration can be tracked using the
 "status" command and by consulting the logs.
 
-See Also:
-   juju help login
-   juju help controllers
-   juju help status
+See also:
+    login
+    controllers
+    status
 `
 
 // Info implements cmd.Command.

--- a/cmd/juju/model/constraints.go
+++ b/cmd/juju/model/constraints.go
@@ -30,10 +30,11 @@ Examples:
     juju get-model-constraints
     juju get-model-constraints -m mymodel
 
-See also: models
-          set-model-constraints
-          set-constraints
-          get-constraints
+See also:
+    models
+    get-constraints
+    set-constraints
+    set-model-constraints
 `
 
 // setConstraintsDoc is multi-line since we need to use ` to denote
@@ -53,10 +54,11 @@ Examples:
     juju set-model-constraints cpu-cores=8 mem=16G
     juju set-model-constraints -m mymodel root-disk=64G
 
-See also: models
-          get-model-constraints
-          set-constraints
-          get-constraints
+See also:
+    models
+    get-model-constraints
+    get-constraints
+    set-constraints
 `
 
 // ConstraintsAPI defines methods on the client API that

--- a/cmd/juju/model/dump.go
+++ b/cmd/juju/model/dump.go
@@ -1,0 +1,95 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package model
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/modelmanager"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+// NewDumpCommand returns a fully constructed dump-model command.
+func NewDumpCommand() cmd.Command {
+	return modelcmd.Wrap(&dumpCommand{})
+}
+
+type dumpCommand struct {
+	modelcmd.ModelCommandBase
+	api DumpModelAPI
+}
+
+const dumpModelHelpDoc = `
+Calls export on the model's database representation and writes the
+resulting YAML to stdout.
+
+Examples:
+
+    juju dump-model
+    juju dump-model -m mymodel
+
+See also: models
+`
+
+// Info implements Command.
+func (c *dumpCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "dump-model",
+		Purpose: "Displays the database agnostic representation of the model.",
+		Doc:     strings.TrimSpace(dumpModelHelpDoc),
+	}
+}
+
+// Init implements Command.
+func (c *dumpCommand) Init(args []string) (err error) {
+	return cmd.CheckEmpty(args)
+}
+
+type DumpModelAPI interface {
+	Close() error
+	DumpModel(names.ModelTag) ([]byte, error)
+}
+
+func (c *dumpCommand) getAPI() (DumpModelAPI, error) {
+	if c.api != nil {
+		return c.api, nil
+	}
+	root, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return modelmanager.NewClient(root), nil
+}
+
+func (c *dumpCommand) Run(ctx *cmd.Context) error {
+	client, err := c.getAPI()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	store := c.ClientStore()
+	modelDetails, err := store.ModelByName(
+		c.ControllerName(),
+		c.ModelName(),
+	)
+	if err != nil {
+		return errors.Annotate(err, "getting model details")
+	}
+
+	modelTag := names.NewModelTag(modelDetails.ModelUUID)
+	results, err := client.DumpModel(modelTag)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(ctx.GetStdout(), "%s\n", results)
+	return nil
+}

--- a/cmd/juju/model/dump_test.go
+++ b/cmd/juju/model/dump_test.go
@@ -32,13 +32,15 @@ func (f *fakeDumpClient) Close() error {
 	return f.NextErr()
 }
 
-func (f *fakeDumpClient) DumpModel(model names.ModelTag) ([]byte, error) {
+func (f *fakeDumpClient) DumpModel(model names.ModelTag) (map[string]interface{}, error) {
 	f.MethodCall(f, "DumpModel", model)
 	err := f.NextErr()
 	if err != nil {
 		return nil, err
 	}
-	return []byte("dump model result"), nil
+	return map[string]interface{}{
+		"model-uuid": "fake uuid",
+	}, nil
 }
 
 func (s *DumpCommandSuite) SetUpTest(c *gc.C) {
@@ -66,5 +68,5 @@ func (s *DumpCommandSuite) TestDump(c *gc.C) {
 	})
 
 	out := testing.Stdout(ctx)
-	c.Assert(out, gc.Equals, "dump model result\n")
+	c.Assert(out, gc.Equals, "model-uuid: fake uuid\n")
 }

--- a/cmd/juju/model/dump_test.go
+++ b/cmd/juju/model/dump_test.go
@@ -1,0 +1,70 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for info.
+
+package model_test
+
+import (
+	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/cmd/juju/model"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/testing"
+)
+
+type DumpCommandSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
+	fake  fakeDumpClient
+	store *jujuclienttesting.MemStore
+}
+
+var _ = gc.Suite(&DumpCommandSuite{})
+
+type fakeDumpClient struct {
+	gitjujutesting.Stub
+}
+
+func (f *fakeDumpClient) Close() error {
+	f.MethodCall(f, "Close")
+	return f.NextErr()
+}
+
+func (f *fakeDumpClient) DumpModel(model names.ModelTag) ([]byte, error) {
+	f.MethodCall(f, "DumpModel", model)
+	err := f.NextErr()
+	if err != nil {
+		return nil, err
+	}
+	return []byte("dump model result"), nil
+}
+
+func (s *DumpCommandSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	s.fake.ResetCalls()
+	s.store = jujuclienttesting.NewMemStore()
+	s.store.CurrentControllerName = "testing"
+	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
+	s.store.Accounts["testing"] = jujuclient.AccountDetails{
+		User: "admin@local",
+	}
+	err := s.store.UpdateModel("testing", "mymodel", jujuclient.ModelDetails{
+		testing.ModelTag.Id(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.store.Models["testing"].CurrentModel = "mymodel"
+}
+
+func (s *DumpCommandSuite) TestDump(c *gc.C) {
+	ctx, err := testing.RunCommand(c, model.NewDumpCommandForTest(&s.fake, s.store))
+	c.Assert(err, jc.ErrorIsNil)
+	s.fake.CheckCalls(c, []gitjujutesting.StubCall{
+		{"DumpModel", []interface{}{testing.ModelTag}},
+		{"Close", nil},
+	})
+
+	out := testing.Stdout(ctx)
+	c.Assert(out, gc.Equals, "dump model result\n")
+}

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -56,6 +56,13 @@ func NewShowCommandForTest(api ShowModelAPI, store jujuclient.ClientStore) cmd.C
 	return modelcmd.Wrap(cmd)
 }
 
+// NewDumpCommandForTest returns a DumpCommand with the api provided as specified.
+func NewDumpCommandForTest(api DumpModelAPI, store jujuclient.ClientStore) cmd.Command {
+	cmd := &dumpCommand{api: api}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
+}
+
 // NewDestroyCommandForTest returns a DestroyCommand with the api provided as specified.
 func NewDestroyCommandForTest(api DestroyModelAPI, store jujuclient.ClientStore) cmd.Command {
 	cmd := &destroyCommand{

--- a/cmd/juju/model/get.go
+++ b/cmd/juju/model/get.go
@@ -41,9 +41,10 @@ Examples:
     juju get-model-config default-series
     juju get-model-config -m mymodel type
 
-See also: models
-          set-model-config
-          unset-model-config
+See also:
+    models
+    set-model-config
+    unset-model-config
 `
 
 func (c *getCommand) Info() *cmd.Info {

--- a/cmd/juju/model/set.go
+++ b/cmd/juju/model/set.go
@@ -36,9 +36,10 @@ Examples:
     juju set-model-config logging-config='<root>=WARNING;unit=INFO'
     juju set-model-config -m mymodel api-port=17071 default-series=xenial
 
-See also: models
-          get-model-config
-          unset-model-config
+See also:
+    models
+    get-model-config
+    unset-model-config
 `
 
 func (c *setCommand) Info() *cmd.Info {

--- a/cmd/juju/model/unset.go
+++ b/cmd/juju/model/unset.go
@@ -38,8 +38,9 @@ Examples:
 
     juju unset-model-config api-port test-mode
 
-See also: set-model-config
-          get-model-config
+See also:
+    set-model-config
+    get-model-config
 `
 
 func (c *unsetCommand) Info() *cmd.Info {

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -37,6 +37,5 @@ const ImageMetadata = "image-metadata"
 // Migration enables the 'juju migrate' command.
 const Migration = "migration"
 
-// DeveloperMode allows for certain commands and behaviour to be accessed
-// for developers.
+// DeveloperMode allows access to developer specific commands and behaviour.
 const DeveloperMode = "developer-mode"

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -36,3 +36,7 @@ const ImageMetadata = "image-metadata"
 
 // Migration enables the 'juju migrate' command.
 const Migration = "migration"
+
+// DeveloperMode allows for certain commands and behaviour to be accessed
+// for developers.
+const DeveloperMode = "developer-mode"


### PR DESCRIPTION
Added "developer-mode" feature flag to only show the command to users with that flag set.

Added the DumpModel to the ModelManager facade. Didn't increment the facade version because we are still pre-upgradeability.

(Review request: http://reviews.vapour.ws/r/5265/)