### PR TITLE
provider/azure: remove storage-account from config

### DIFF
--- a/provider/azure/config.go
+++ b/provider/azure/config.go
@@ -29,16 +29,6 @@ const (
 	// The below bits are internal book-keeping things, rather than
 	// configuration. Config is just what we have to work with.
 
-	// configAttrStorageAccount is the name of the storage account. We
-	// can't just use a well-defined name for the storage acocunt because
-	// storage account names must be globally unique; each storage account
-	// has an associated public DNS entry.
-	configAttrStorageAccount = "storage-account"
-
-	// configAttrStorageAccountKey is the primary key for the storage
-	// account.
-	configAttrStorageAccountKey = "storage-account-key"
-
 	// resourceNameLengthMax is the maximum length of resource
 	// names in Azure.
 	resourceNameLengthMax = 80
@@ -52,14 +42,10 @@ var configFields = schema.Fields{
 	configAttrSubscriptionId:     schema.String(),
 	configAttrTenantId:           schema.String(),
 	configAttrAppPassword:        schema.String(),
-	configAttrStorageAccount:     schema.String(),
-	configAttrStorageAccountKey:  schema.String(),
 	configAttrStorageAccountType: schema.String(),
 }
 
 var configDefaults = schema.Defaults{
-	configAttrStorageAccount:     schema.Omit,
-	configAttrStorageAccountKey:  schema.Omit,
 	configAttrStorageAccountType: string(storage.StandardLRS),
 }
 
@@ -76,13 +62,7 @@ var requiredConfigAttributes = []string{
 var immutableConfigAttributes = []string{
 	configAttrSubscriptionId,
 	configAttrTenantId,
-	configAttrStorageAccount,
 	configAttrStorageAccountType,
-}
-
-var internalConfigAttributes = []string{
-	configAttrStorageAccount,
-	configAttrStorageAccountKey,
 }
 
 type azureModelConfig struct {
@@ -92,8 +72,6 @@ type azureModelConfig struct {
 	location           string // canonicalized
 	endpoint           string
 	storageEndpoint    string
-	storageAccount     string
-	storageAccountKey  string
 	storageAccountType storage.AccountType
 }
 
@@ -176,8 +154,6 @@ Please choose a model name of no more than %d characters.`,
 	subscriptionId := validated[configAttrSubscriptionId].(string)
 	tenantId := validated[configAttrTenantId].(string)
 	appPassword := validated[configAttrAppPassword].(string)
-	storageAccount, _ := validated[configAttrStorageAccount].(string)
-	storageAccountKey, _ := validated[configAttrStorageAccountKey].(string)
 	storageAccountType := validated[configAttrStorageAccountType].(string)
 
 	if newCfg.FirewallMode() == config.FwGlobal {
@@ -213,8 +189,6 @@ Please choose a model name of no more than %d characters.`,
 		location,
 		endpoint,
 		storageEndpointURL.Host,
-		storageAccount,
-		storageAccountKey,
 		storage.AccountType(storageAccountType),
 	}
 

--- a/provider/azure/config_test.go
+++ b/provider/azure/config_test.go
@@ -77,18 +77,14 @@ func (s *configSuite) TestValidateInvalidCredentials(c *gc.C) {
 	s.assertConfigInvalid(c, testing.Attrs{"subscription-id": ""}, `"subscription-id" config not specified`)
 }
 
-func (s *configSuite) TestValidateStorageAccountCantChange(c *gc.C) {
-	cfgOld := makeTestModelConfig(c, testing.Attrs{"storage-account": "abc"})
+func (s *configSuite) TestValidateStorageAccountTypeCantChange(c *gc.C) {
+	cfgOld := makeTestModelConfig(c, testing.Attrs{"storage-account-type": "Standard_LRS"})
 	_, err := s.provider.Validate(cfgOld, cfgOld)
 	c.Assert(err, jc.ErrorIsNil)
 
-	cfgNew := makeTestModelConfig(c) // no storage-account attribute
+	cfgNew := makeTestModelConfig(c, testing.Attrs{"storage-account-type": "Premium_LRS"})
 	_, err = s.provider.Validate(cfgNew, cfgOld)
-	c.Assert(err, gc.ErrorMatches, `cannot remove immutable "storage-account" config`)
-
-	cfgNew = makeTestModelConfig(c, testing.Attrs{"storage-account": "def"})
-	_, err = s.provider.Validate(cfgNew, cfgOld)
-	c.Assert(err, gc.ErrorMatches, `cannot change immutable "storage-account" config \(abc -> def\)`)
+	c.Assert(err, gc.ErrorMatches, `cannot change immutable "storage-account-type" config \(Standard_LRS -> Premium_LRS\)`)
 }
 
 func (s *configSuite) assertConfigValid(c *gc.C, attrs testing.Attrs) {

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -5,7 +5,6 @@ package azure_test
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"sync"
@@ -39,20 +38,6 @@ func (s *environProviderSuite) SetUpTest(c *gc.C) {
 		RequestInspector: requestRecorder(&s.requests),
 	})
 	s.sender = nil
-}
-
-func (s *environProviderSuite) TestBootstrapConfigWithInternalConfig(c *gc.C) {
-	s.testBootstrapConfigWithInternalConfig(c, "storage-account")
-}
-
-func (s *environProviderSuite) testBootstrapConfigWithInternalConfig(c *gc.C, key string) {
-	cfg := makeTestModelConfig(c, testing.Attrs{key: "whatever"})
-	s.sender = azuretesting.Senders{tokenRefreshSender()}
-	_, err := s.provider.BootstrapConfig(environs.BootstrapConfigParams{
-		Config:      cfg,
-		Credentials: fakeUserPassCredential(),
-	})
-	c.Check(err, gc.ErrorMatches, fmt.Sprintf(`internal config "%s" must not be specified`, key))
 }
 
 func fakeUserPassCredential() cloud.Credential {


### PR DESCRIPTION
Due to recent changes to bootstrap, we no longer
store config attributes added by Environ.Bootstrap
in the model config. Anything that should be added
to model config needs to come from Environ.BootstrapConfig
instead.

Azure was storing storage-account and storage-account-key
in model config to avoid lookups later. We can't
generate these in BootstrapConfig, as the resource
group doesn't yet exist. For now, we'll just live
with lookups when we open the Environ, caching the
values to reduce the severity.

Fixes https://bugs.launchpad.net/juju-core/+bug/1603596

(Review request: http://reviews.vapour.ws/r/5266/)