### PR TITLE
Fix 2 of lp#1603585: Only register some test suites for linux OS.

### DIFF
--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -41,7 +41,7 @@ func init() {
 
 	// TODO (anastasiamac 2016-07-19) Bug#1603585
 	// These tests cannot run on windows - they require a bootstrapped controller.
-	if runtime.GOOS != "linux" {
+	if runtime.GOOS == "linux" {
 		gc.Suite(&cloudImageMetadataSuite{})
 		gc.Suite(&cmdSpaceSuite{})
 	}


### PR DESCRIPTION
Only register cloud image metadata and cmd space test suites on linux-based OS.

(Review request: http://reviews.vapour.ws/r/5267/)