### PR TITLE
provider/azure: specify OS disk size

### DIFF
--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -268,6 +268,8 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 							fakeStorageAccount,
 						)),
 					},
+					// 30 GiB is roughly 32 GB.
+					DiskSizeGB: to.IntPtr(32),
 				},
 			},
 			OsProfile: &compute.OSProfile{
@@ -504,7 +506,7 @@ func (s *environSuite) TestStartInstance(c *gc.C) {
 
 	arch := "amd64"
 	mem := uint64(3584)
-	rootDisk := uint64(29495) // ~30 GB
+	rootDisk := uint64(30 * 1024) // 30 GiB
 	cpuCores := uint64(1)
 	c.Assert(result.Hardware, jc.DeepEquals, &instance.HardwareCharacteristics{
 		Arch:     &arch,

--- a/provider/azure/instancetype.go
+++ b/provider/azure/instancetype.go
@@ -107,18 +107,19 @@ func newInstanceType(size compute.VirtualMachineSize) instances.InstanceType {
 		Arches:   []string{arch.AMD64},
 		CpuCores: uint64(to.Int(size.NumberOfCores)),
 		Mem:      uint64(to.Int(size.MemoryInMB)),
-		// NOTE(axw) size.OsDiskSizeInMB is the maximum root disk
-		// size, but the actual disk size is limited to the size
-		// of the image/VHD that the machine is backed by. The
-		// Azure Resource Manager APIs do not provide a way of
-		// determining the image size.
-		//
-		// All of the published images that we use are ~30GiB.
-		RootDisk: uint64(29495),
+		// NOTE(axw) size.OsDiskSizeInMB is the *maximum*
+		// OS-disk size. When we create a VM, we can create
+		// one that is smaller.
+		RootDisk: mbToMib(uint64(to.Int(size.OsDiskSizeInMB))),
 		Cost:     uint64(cost),
 		VirtType: &vtype,
 		// tags are not currently supported by azure
 	}
+}
+
+func mbToMib(mb uint64) uint64 {
+	b := mb * 1000 * 1000
+	return uint64(float64(b) / 1024 / 1024)
 }
 
 // findInstanceSpec returns the InstanceSpec that best satisfies the supplied


### PR DESCRIPTION
The Ubuntu images for Azure have a predefined size of 30GB
(GB, not GiB), which was previously the maximum OS disk size.
The Azure API now supports overriding the root disk size. We
default to 30 GiB if no constraints are specified, but otherwise
we honour the root-disk constraint.

(Review request: http://reviews.vapour.ws/r/5268/)