### PR TITLE
Fixes lp#1603865: add missing constraint parameter during migration.

### DIFF
--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1068,6 +1068,7 @@ func (e *exporter) constraintsArgs(globalKey string) (description.ConstraintsArg
 		RootDisk:     optionalInt("rootdisk"),
 		Spaces:       optionalStringSlice("spaces"),
 		Tags:         optionalStringSlice("tags"),
+		VirtType:     optionalString("virttype"),
 	}
 	if optionalErr != nil {
 		return description.ConstraintsArgs{}, errors.Trace(optionalErr)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1123,5 +1123,8 @@ func (i *importer) constraints(cons description.Constraints) constraints.Value {
 	if tags := cons.Tags(); len(tags) > 0 {
 		result.Tags = &tags
 	}
+	if virt := cons.VirtType(); virt != "" {
+		result.VirtType = &virt
+	}
 	return result
 }

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -383,7 +383,14 @@ func (s *MigrationImportSuite) TestApplicationLeaders(c *gc.C) {
 }
 
 func (s *MigrationImportSuite) TestUnits(c *gc.C) {
-	cons := constraints.MustParse("arch=amd64 mem=8G")
+	s.assertUnitsMigrated(c, constraints.MustParse("arch=amd64 mem=8G"))
+}
+
+func (s *MigrationImportSuite) TestUnitsWithVirtConstraint(c *gc.C) {
+	s.assertUnitsMigrated(c, constraints.MustParse("arch=amd64 mem=8G virt-type=kvm"))
+}
+
+func (s *MigrationImportSuite) assertUnitsMigrated(c *gc.C, cons constraints.Value) {
 	exported, pwd := s.Factory.MakeUnitReturningPassword(c, &factory.UnitParams{
 		Constraints: cons,
 	})


### PR DESCRIPTION
Update migration constraints logic to cater for virt type.

(Review request: http://reviews.vapour.ws/r/5269/)