### PR TITLE
Fix the reboot worker tests.

### DIFF
--- a/worker/reboot/reboot.go
+++ b/worker/reboot/reboot.go
@@ -74,11 +74,13 @@ func (r *Reboot) Handle(_ <-chan struct{}) error {
 
 	switch rAction {
 	case params.ShouldReboot:
+		logger.Debugf("acquiring mutex %q for reboot", r.machineLockName)
 		if _, err := mutex.Acquire(spec); err != nil {
 			return errors.Trace(err)
 		}
 		return worker.ErrRebootMachine
 	case params.ShouldShutdown:
+		logger.Debugf("acquiring mutex %q for shutdown", r.machineLockName)
 		if _, err := mutex.Acquire(spec); err != nil {
 			return errors.Trace(err)
 		}


### PR DESCRIPTION
Due to the behaviour of the reboot worker, the tests need to have different machine lock names, otherwise they will block on windows.
The golang garbabe collector means that this isn't a problem on linux as when the old lock is cleaned up, it releases the domain socket,
but on windows, the lock is an external semaphore that relies on the process dying to release it.

(Review request: http://reviews.vapour.ws/r/5271/)