### PR TITLE
Acls controller permissions

### DIFF
--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/manual"
@@ -85,8 +86,8 @@ func (s *serverSuite) TestModelUsersInfo(c *gc.C) {
 
 	localUser1 := s.makeLocalModelUser(c, "ralphdoe", "Ralph Doe")
 	localUser2 := s.makeLocalModelUser(c, "samsmith", "Sam Smith")
-	remoteUser1 := s.Factory.MakeModelUser(c, &factory.ModelUserParams{User: "bobjohns@ubuntuone", DisplayName: "Bob Johns", Access: state.WriteAccess})
-	remoteUser2 := s.Factory.MakeModelUser(c, &factory.ModelUserParams{User: "nicshaw@idprovider", DisplayName: "Nic Shaw", Access: state.WriteAccess})
+	remoteUser1 := s.Factory.MakeModelUser(c, &factory.ModelUserParams{User: "bobjohns@ubuntuone", DisplayName: "Bob Johns", Access: description.WriteAccess})
+	remoteUser2 := s.Factory.MakeModelUser(c, &factory.ModelUserParams{User: "nicshaw@idprovider", DisplayName: "Nic Shaw", Access: description.WriteAccess})
 
 	results, err := s.client.ModelUserInfo()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/client_auth_root.go
+++ b/apiserver/client_auth_root.go
@@ -5,6 +5,7 @@ package apiserver
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/rpc"
@@ -61,11 +62,26 @@ func isCallAllowableByReadOnlyUser(facade, _ /*method*/ string) bool {
 	return restrictedRootNames.Contains(facade)
 }
 
+var modelManagerMethods = set.NewStrings(
+	"ModifyModelAccess",
+	"CreateModel",
+)
+
+var controllerMethods = set.NewStrings(
+	"DestroyController",
+)
+
 func doesCallRequireAdmin(facade, method string) bool {
 	// TODO(perrito666) This should filter adding users to controllers.
 	// TODO(perrito666) Add an exaustive list of facades/methods that are
 	// admin only and put them in an authoritative source to be re-used.
 	// TODO(perrito666) This is a stub, the idea is to maintain the current
 	// status of permissions until we decide what goes to admin only.
+	switch facade {
+	case "ModelManager":
+		return modelManagerMethods.Contains(method)
+	case "Controller":
+		return controllerMethods.Contains(method)
+	}
 	return false
 }

--- a/apiserver/common/modeluser.go
+++ b/apiserver/common/modeluser.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/state"
 )
 
@@ -50,4 +51,17 @@ func ModelUserInfo(user ModelUser) (params.ModelUserInfo, error) {
 		Access:         access,
 	}
 	return userInfo, nil
+}
+
+// StateToParamsModelAccess converts description.Access to params.AccessPermission.
+func StateToParamsModelAccess(stateAccess description.Access) (params.ModelAccessPermission, error) {
+	switch stateAccess {
+	case description.ReadAccess:
+		return params.ModelReadAccess, nil
+	case description.WriteAccess:
+		return params.ModelWriteAccess, nil
+	case description.AdminAccess:
+		return params.ModelAdminAccess, nil
+	}
+	return "", errors.Errorf("invalid model access permission %q", stateAccess)
 }

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -104,6 +104,15 @@ func TestingApiHandler(c *gc.C, srvSt, st *state.State) (*apiHandler, *common.Re
 	return h, h.getResources()
 }
 
+// TestingApiHandlerWithEntity gives you the sane kind of ApiHandler than
+// TestingApiHandler but sets the passed entity as the apiHandler
+// entity.
+func TestingApiHandlerWithEntity(c *gc.C, srvSt, st *state.State, entity state.Entity) (*apiHandler, *common.Resources) {
+	h, hr := TestingApiHandler(c, srvSt, st)
+	h.entity = entity
+	return h, hr
+}
+
 // TestingUpgradingRoot returns a limited srvRoot
 // in an upgrade scenario.
 func TestingUpgradingRoot(st *state.State) rpc.MethodFinder {

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -6,6 +6,7 @@ package facade
 import (
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/state"
 )
 
@@ -91,6 +92,10 @@ type Authorizer interface {
 	// Doesn't need to be on this interface, should be a utility
 	// func if anything.
 	AuthClient() bool
+
+	// HasPermission returns true if the given access is allowed for the given
+	// terget by the authenticated entity.
+	HasPermission(operation description.Access, target names.Tag) bool
 }
 
 // Resources allows you to store and retrieve Resource implementations.

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -241,7 +241,7 @@ func (st *mockState) IsControllerAdministrator(user names.UserTag) (bool, error)
 	}
 
 	for _, u := range st.controllerModel.users {
-		if user.Name() == u.UserName() && u.access == state.AdminAccess {
+		if user.Name() == u.UserName() && u.access == description.AdminAccess {
 			nextErr := st.NextErr()
 			if user.Name() != "admin" {
 				panic(user.Name())

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -20,6 +20,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
@@ -58,15 +59,15 @@ func (s *modelInfoSuite) SetUpTest(c *gc.C) {
 		},
 		users: []*mockModelUser{{
 			userName: "admin",
-			access:   state.AdminAccess,
+			access:   description.AdminAccess,
 		}, {
 			userName:    "bob@local",
 			displayName: "Bob",
-			access:      state.ReadAccess,
+			access:      description.ReadAccess,
 		}, {
 			userName:    "charlotte@local",
 			displayName: "Charlotte",
-			access:      state.ReadAccess,
+			access:      description.ReadAccess,
 		}},
 	}
 	var err error
@@ -402,25 +403,25 @@ type mockModelUser struct {
 	userName       string
 	displayName    string
 	lastConnection time.Time
-	access         state.Access
+	access         description.Access
 }
 
 func (u *mockModelUser) IsAdmin() bool {
 	u.MethodCall(u, "IsAdmin")
 	u.PopNoErr()
-	return u.access == state.AdminAccess
+	return u.access == description.AdminAccess
 }
 
 func (u *mockModelUser) IsReadOnly() bool {
 	u.MethodCall(u, "IsReadOnly")
 	u.PopNoErr()
-	return u.access == state.ReadAccess
+	return u.access == description.ReadAccess
 }
 
 func (u *mockModelUser) IsReadWrite() bool {
 	u.MethodCall(u, "IsReadWrite")
 	u.PopNoErr()
-	return u.access == state.WriteAccess
+	return u.access == description.WriteAccess
 }
 
 func (u *mockModelUser) DisplayName() string {

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -457,7 +457,7 @@ func resolveStateAccess(access permission.ModelAccess) (description.Access, erro
 	var fail description.Access
 	switch access {
 	case permission.ModelAdminAccess:
-		return state.AdminAccess, nil
+		return description.AdminAccess, nil
 	case permission.ModelReadAccess:
 		return description.ReadAccess, nil
 	case permission.ModelWriteAccess:

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller/modelmanager"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/juju/permission"
 	"github.com/juju/juju/state"
@@ -452,15 +453,15 @@ func (m *ModelManagerAPI) ModifyModelAccess(args params.ModifyModelAccessRequest
 
 // resolveStateAccess returns the state representation of the logical model
 // access type.
-func resolveStateAccess(access permission.ModelAccess) (state.Access, error) {
-	var fail state.Access
+func resolveStateAccess(access permission.ModelAccess) (description.Access, error) {
+	var fail description.Access
 	switch access {
 	case permission.ModelAdminAccess:
 		return state.AdminAccess, nil
 	case permission.ModelReadAccess:
-		return state.ReadAccess, nil
+		return description.ReadAccess, nil
 	case permission.ModelWriteAccess:
-		return state.WriteAccess, nil
+		return description.WriteAccess, nil
 	}
 	logger.Errorf("invalid access permission: %+v", access)
 	return fail, errors.Errorf("invalid access permission")
@@ -510,6 +511,13 @@ func ChangeModelAccess(accessor common.ModelManagerBackend, modelTag names.Model
 		return errors.Annotate(err, "could not resolve model access")
 	}
 
+	// Default to read access if not otherwise specified.
+	// TODO(perrito666) If the client does not know what it wants
+	// perhaps we should just err out.
+	if stateAccess == description.UndefinedAccess {
+		stateAccess = description.ReadAccess
+	}
+
 	switch action {
 	case params.GrantModelAccess:
 		_, err = st.AddModelUser(state.ModelUserSpec{User: targetUserTag, CreatedBy: apiUser, Access: stateAccess})
@@ -538,25 +546,25 @@ func ChangeModelAccess(accessor common.ModelManagerBackend, modelTag names.Model
 
 	case params.RevokeModelAccess:
 		switch stateAccess {
-		case state.ReadAccess:
+		case description.ReadAccess:
 			// Revoking read access removes all access.
 			err := st.RemoveModelUser(targetUserTag)
 			return errors.Annotate(err, "could not revoke model access")
-		case state.WriteAccess:
+		case description.WriteAccess:
 			// Revoking write access sets read-only.
 			modelUser, err := st.ModelUser(targetUserTag)
 			if err != nil {
 				return errors.Annotate(err, "could not look up model access for user")
 			}
-			err = modelUser.SetAccess(state.ReadAccess)
+			err = modelUser.SetAccess(description.ReadAccess)
 			return errors.Annotate(err, "could not set model access to read-only")
-		case state.AdminAccess:
+		case description.AdminAccess:
 			// Revoking admin access sets read-write.
 			modelUser, err := st.ModelUser(targetUserTag)
 			if err != nil {
 				return errors.Annotate(err, "could not look up model access for user")
 			}
-			err = modelUser.SetAccess(state.WriteAccess)
+			err = modelUser.SetAccess(description.WriteAccess)
 			return errors.Annotate(err, "could not set model access to read-write")
 
 		default:

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -74,10 +75,7 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 			},
 			users: []*mockModelUser{{
 				userName: "admin",
-				access:   state.AdminAccess,
-			}, {
-				userName: "otheruser",
-				access:   state.AdminAccess,
+				access:   description.AdminAccess,
 			}},
 		},
 		model: &mockModel{
@@ -90,10 +88,7 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 			},
 			users: []*mockModelUser{{
 				userName: "admin",
-				access:   state.AdminAccess,
-			}, {
-				userName: "otheruser",
-				access:   state.AdminAccess,
+				access:   description.AdminAccess,
 			}},
 		},
 		creds: map[string]cloud.Credential{
@@ -615,7 +610,7 @@ func (s *modelManagerStateSuite) TestGrantMissingModelFails(c *gc.C) {
 
 func (s *modelManagerStateSuite) TestRevokeAdminLeavesReadAccess(c *gc.C) {
 	s.setAPIUser(c, s.AdminUserTag(c))
-	user := s.Factory.MakeModelUser(c, &factory.ModelUserParams{Access: state.WriteAccess})
+	user := s.Factory.MakeModelUser(c, &factory.ModelUserParams{Access: description.WriteAccess})
 
 	err := s.revoke(c, user.UserTag(), params.ModelWriteAccess, user.ModelTag())
 	c.Assert(err, gc.IsNil)
@@ -722,7 +717,7 @@ func (s *modelManagerStateSuite) TestGrantModelIncreaseAccess(c *gc.C) {
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
 	stFactory := factory.NewFactory(st)
-	user := stFactory.MakeModelUser(c, &factory.ModelUserParams{Access: state.ReadAccess})
+	user := stFactory.MakeModelUser(c, &factory.ModelUserParams{Access: description.ReadAccess})
 
 	err := s.grant(c, user.UserTag(), params.ModelWriteAccess, st.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
@@ -752,7 +747,7 @@ func (s *modelManagerStateSuite) TestGrantToModelReadAccess(c *gc.C) {
 	defer st.Close()
 	stFactory := factory.NewFactory(st)
 	stFactory.MakeModelUser(c, &factory.ModelUserParams{
-		User: apiUser.Canonical(), Access: state.ReadAccess})
+		User: apiUser.Canonical(), Access: description.ReadAccess})
 
 	other := names.NewUserTag("other@remote")
 	err := s.grant(c, other, params.ModelReadAccess, st.ModelTag())
@@ -767,7 +762,7 @@ func (s *modelManagerStateSuite) TestGrantToModelWriteAccess(c *gc.C) {
 	defer st.Close()
 	stFactory := factory.NewFactory(st)
 	stFactory.MakeModelUser(c, &factory.ModelUserParams{
-		User: apiUser.Canonical(), Access: state.AdminAccess})
+		User: apiUser.Canonical(), Access: description.AdminAccess})
 
 	other := names.NewUserTag("other@remote")
 	err := s.grant(c, other, params.ModelReadAccess, st.ModelTag())

--- a/apiserver/testing/fakeauthorizer.go
+++ b/apiserver/testing/fakeauthorizer.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"github.com/juju/juju/core/description"
 	"gopkg.in/juju/names.v2"
 )
 
@@ -42,4 +43,9 @@ func (fa FakeAuthorizer) AuthClient() bool {
 
 func (fa FakeAuthorizer) GetAuthTag() names.Tag {
 	return fa.Tag
+}
+
+func (fa FakeAuthorizer) HasPermission(operation description.Access, target names.Tag) bool {
+	// TODO(perrito666) provide a way to pre-set the desired result here.
+	return fa.Tag == target
 }

--- a/core/description/access.go
+++ b/core/description/access.go
@@ -1,0 +1,75 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+)
+
+// Access represents a level of access.
+type Access string
+
+const (
+	// UndefinedAccess is not a valid access type. It is the value
+	// used when access is not defined at all.
+	UndefinedAccess Access = ""
+
+	// ReadAccess allows a user to read information about a permission subject,
+	// without being able to make any changes.
+	ReadAccess Access = "read"
+
+	// WriteAccess allows a user to make changes to a permission subject.
+	WriteAccess Access = "write"
+
+	// AdminAccess allows a user full control over the subject.
+	AdminAccess Access = "admin"
+)
+
+// Validate returns error if the current is not a valid access level.
+func (a Access) Validate() error {
+	switch a {
+	case UndefinedAccess, AdminAccess, ReadAccess, WriteAccess:
+		return nil
+	}
+	return errors.NotValidf("access level %s", a)
+}
+
+// LessAccessThan returns true if the provided access is greater than
+// the current.
+func (a Access) LessAccessThan(access Access) bool {
+	switch a {
+	case UndefinedAccess:
+		return access == ReadAccess ||
+			access == WriteAccess ||
+			access == AdminAccess
+	case ReadAccess:
+		return access == WriteAccess ||
+			access == AdminAccess
+	case WriteAccess:
+		return access == AdminAccess
+	}
+	return false
+}
+
+// accessField returns a Checker that accepts a string value only
+// and returns a valid Access or an error.
+func accessField() schema.Checker {
+	return accessC{}
+}
+
+type accessC struct{}
+
+func (c accessC) Coerce(v interface{}, path []string) (interface{}, error) {
+	s := schema.String()
+	in, err := s.Coerce(v, path)
+	if err != nil {
+		return nil, err
+	}
+	access := Access(in.(string))
+	if err := access.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return access, nil
+}

--- a/core/description/access.go
+++ b/core/description/access.go
@@ -16,6 +16,8 @@ const (
 	// used when access is not defined at all.
 	UndefinedAccess Access = ""
 
+	// Model Permissions
+
 	// ReadAccess allows a user to read information about a permission subject,
 	// without being able to make any changes.
 	ReadAccess Access = "read"
@@ -25,15 +27,58 @@ const (
 
 	// AdminAccess allows a user full control over the subject.
 	AdminAccess Access = "admin"
+
+	// Controller permissions
+
+	// LoginAccess allows a user to log-ing into the subject.
+	LoginAccess Access = "login"
+
+	// AddModelAccess allows user to add new models in subjects supporting it.
+	AddModelAccess Access = "addmodel"
+
+	// SuperUserAccess allows user unrestricted permissions in the subject.
+	SuperuserAccess Access = "superuser"
 )
 
 // Validate returns error if the current is not a valid access level.
 func (a Access) Validate() error {
 	switch a {
-	case UndefinedAccess, AdminAccess, ReadAccess, WriteAccess:
+	case UndefinedAccess, AdminAccess, ReadAccess, WriteAccess,
+		LoginAccess, AddModelAccess, SuperuserAccess:
 		return nil
 	}
 	return errors.NotValidf("access level %s", a)
+}
+
+// EqualOrGreaterAccessThan returns true if the provided access is equal or
+// less than the current.
+func (a Access) EqualOrGreaterAccessThan(access Access) bool {
+	if a == access {
+		return true
+	}
+	switch a {
+	case UndefinedAccess:
+		return false
+	case ReadAccess:
+		return access == UndefinedAccess
+	case WriteAccess:
+		return access == ReadAccess ||
+			access == UndefinedAccess
+	case AdminAccess:
+		return access == ReadAccess ||
+			access == WriteAccess
+	// Controller permissions
+	case LoginAccess:
+		return access == UndefinedAccess
+	case AddModelAccess:
+		return access == UndefinedAccess ||
+			access == LoginAccess
+	case SuperuserAccess:
+		return access == UndefinedAccess ||
+			access == LoginAccess ||
+			access == AddModelAccess
+	}
+	return false
 }
 
 // LessAccessThan returns true if the provided access is greater than
@@ -43,12 +88,21 @@ func (a Access) LessAccessThan(access Access) bool {
 	case UndefinedAccess:
 		return access == ReadAccess ||
 			access == WriteAccess ||
-			access == AdminAccess
+			access == AdminAccess ||
+			access == LoginAccess ||
+			access == AddModelAccess ||
+			access == SuperuserAccess
 	case ReadAccess:
 		return access == WriteAccess ||
 			access == AdminAccess
 	case WriteAccess:
 		return access == AdminAccess
+	// Controller permissions
+	case LoginAccess:
+		return access == AddModelAccess ||
+			access == SuperuserAccess
+	case AddModelAccess:
+		return access == SuperuserAccess
 	}
 	return false
 }

--- a/core/description/user.go
+++ b/core/description/user.go
@@ -22,7 +22,7 @@ type UserArgs struct {
 	CreatedBy      names.UserTag
 	DateCreated    time.Time
 	LastConnection time.Time
-	Access         string
+	Access         Access
 }
 
 func newUser(args UserArgs) *user {
@@ -45,7 +45,7 @@ type user struct {
 	DisplayName_ string    `yaml:"display-name,omitempty"`
 	CreatedBy_   string    `yaml:"created-by"`
 	DateCreated_ time.Time `yaml:"date-created"`
-	Access_      string    `yaml:"access"`
+	Access_      Access    `yaml:"access"`
 	// Can't use omitempty with time.Time, it just doesn't work,
 	// so use a pointer in the struct.
 	LastConnection_ *time.Time `yaml:"last-connection,omitempty"`
@@ -82,20 +82,17 @@ func (u *user) LastConnection() time.Time {
 
 // IsRead implements User.
 func (u *user) IsReadOnly() bool {
-	// string used here to avoid dependency on state.
-	return u.Access_ == "read"
+	return u.Access_ == ReadAccess
 }
 
 // IsReadWrite implements User.
 func (u *user) IsReadWrite() bool {
-	// string used here to avoid dependency on state.
-	return u.Access_ == "write"
+	return u.Access_ == WriteAccess
 }
 
 // IsAdmin implements User.
 func (u *user) IsAdmin() bool {
-	// string used here to avoid dependency on state.
-	return u.Access_ == "admin"
+	return u.Access_ == AdminAccess
 }
 
 func importUsers(source map[string]interface{}) ([]*user, error) {
@@ -145,7 +142,7 @@ func importUserV1(source map[string]interface{}) (*user, error) {
 		"read-only":       schema.Bool(),
 		"date-created":    schema.Time(),
 		"last-connection": schema.Time(),
-		"access":          schema.String(),
+		"access":          accessField(),
 	}
 
 	// Some values don't have to be there.
@@ -168,7 +165,7 @@ func importUserV1(source map[string]interface{}) (*user, error) {
 		DisplayName_: valid["display-name"].(string),
 		CreatedBy_:   valid["created-by"].(string),
 		DateCreated_: valid["date-created"].(time.Time),
-		Access_:      valid["access"].(string),
+		Access_:      valid["access"].(Access),
 	}
 
 	lastConn := valid["last-connection"].(time.Time)

--- a/core/description/user_test.go
+++ b/core/description/user_test.go
@@ -70,7 +70,8 @@ func (*UserSerializationSuite) TestParsingSerializedData(c *gc.C) {
 				DisplayName_: "A read only user",
 				CreatedBy_:   "admin@local",
 				DateCreated_: time.Date(2015, 10, 9, 12, 34, 56, 0, time.UTC),
-				Access_:      "read",
+				// We want to fail if someone breaks ReadAccess definition.
+				Access_: Access("read"),
 			},
 		},
 	}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -63,7 +63,7 @@ gopkg.in/juju/charmrepo.v2-unstable	git	6e6733987fb03100f30e494cc1134351fe4a593b
 gopkg.in/juju/charmstore.v5-unstable	git	2cb9f80553dddaae8c5e2161ea45f4be5d9afc00	2016-05-27T11:46:22Z
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/juju/jujusvg.v1	git	cc128825adce31ea13020d24e7b3302bac86a8c3	2016-05-30T22:53:36Z
-gopkg.in/juju/names.v2	git	5426d66579afd36fc63d809dd58806806c2f161f	2016-06-23T03:33:52Z
+gopkg.in/juju/names.v2	git	3e0d33a444fec55aea7269b849eb22da41e73072	2016-07-18T22:31:20Z
 gopkg.in/macaroon-bakery.v1	git	b097c9d99b2537efaf54492e08f7e148f956ba51	2016-05-24T09:38:11Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	29cc868a5ca65f401ff318143f9408d02f4799cc	2016-06-09T18:00:28Z

--- a/featuretests/cmd_juju_model_test.go
+++ b/featuretests/cmd_juju_model_test.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/cmd/juju/commands"
+	"github.com/juju/juju/core/description"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
@@ -59,7 +60,7 @@ func (s *cmdModelSuite) TestRevokeModelCmdStack(c *gc.C) {
 	// Firstly share a model with a user
 	username := "bar@ubuntuone"
 	s.Factory.MakeModelUser(c, &factory.ModelUserParams{
-		User: username, Access: state.ReadAccess})
+		User: username, Access: description.ReadAccess})
 
 	// Because we are calling into juju through the main command,
 	// and the main command adds a warning logging writer, we need

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -134,6 +134,11 @@ func allCollections() collectionSchema {
 			global: true,
 		},
 
+		// This collection holds users that are relative to controllers.
+		controllerUsersC: {
+			global: true,
+		},
+
 		// This collection holds the last time the user connected to the API server.
 		userLastLoginC: {
 			global:    true,
@@ -399,6 +404,7 @@ const (
 	constraintsC             = "constraints"
 	containerRefsC           = "containerRefs"
 	controllersC             = "controllers"
+	controllerUsersC         = "controllerusers"
 	filesystemAttachmentsC   = "filesystemAttachments"
 	filesystemsC             = "filesystems"
 	globalSettingsC          = "globalSettings"

--- a/state/controller.go
+++ b/state/controller.go
@@ -15,6 +15,9 @@ const (
 
 	// controllerInheritedSettingsGlobalKey is the key for default settings shared across models.
 	controllerInheritedSettingsGlobalKey = "controllerInheritedSettings"
+
+	// controllerGlobalKey is the key for controller.
+	controllerGlobalKey = "c"
 )
 
 // ControllerConfig returns the config values for the controller.

--- a/state/controlleruser.go
+++ b/state/controlleruser.go
@@ -1,0 +1,190 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/core/description"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/txn"
+)
+
+const defaultControllerPermission = description.LoginAccess
+
+// ControllerUser represents a user access to an controller
+// controller user always represents a single user for a single controller.
+// There should be no more than one ControllerUser per controller.
+type ControllerUser struct {
+	st                   *State
+	doc                  controllerUserDoc
+	controllerPermission *permission
+}
+
+// NewControllerUser returns a ControllerUser with permissions.
+func NewControllerUser(st *State, doc controllerUserDoc) (*ControllerUser, error) {
+	mu := &ControllerUser{
+		st:  st,
+		doc: doc,
+	}
+	if err := mu.refreshPermission(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return mu, nil
+}
+
+type controllerUserDoc struct {
+	ID             string    `bson:"_id"`
+	ControllerUUID string    `bson:"controller-uuid"`
+	UserName       string    `bson:"user"`
+	DisplayName    string    `bson:"displayname"`
+	CreatedBy      string    `bson:"createdby"`
+	DateCreated    time.Time `bson:"datecreated"`
+}
+
+// Access returns the access level of this controller user.
+func (e *ControllerUser) Access() description.Access {
+	return e.controllerPermission.access()
+}
+
+// ID returns the ID of the controller user.
+func (e *ControllerUser) ID() string {
+	return e.doc.ID
+}
+
+// UserTag returns the tag for the controller user.
+func (e *ControllerUser) UserTag() names.UserTag {
+	return names.NewUserTag(e.doc.UserName)
+}
+
+// UserName returns the user name of the controller user.
+func (e *ControllerUser) UserName() string {
+	return e.doc.UserName
+}
+
+// DisplayName returns the display name of the controller user.
+func (e *ControllerUser) DisplayName() string {
+	return e.doc.DisplayName
+}
+
+// CreatedBy returns the user who created the controller user.
+func (e *ControllerUser) CreatedBy() string {
+	return e.doc.CreatedBy
+}
+
+// DateCreated returns the date the controller user was created in UTC.
+func (e *ControllerUser) DateCreated() time.Time {
+	return e.doc.DateCreated.UTC()
+}
+
+// refreshPermission reloads the permission for this controller user from persistence.
+func (e *ControllerUser) refreshPermission() error {
+	perm, err := e.st.userPermission(controllerGlobalKey, e.globalKey())
+	if err != nil {
+		return errors.Annotate(err, "updating permission")
+	}
+	e.controllerPermission = perm
+	return nil
+}
+
+// IsGreaterAccess returns true if provided access is higher than
+// the current one.
+func (e *ControllerUser) IsGreaterAccess(a description.Access) bool {
+	return e.controllerPermission.isGreaterAccess(a)
+}
+
+// SetAccess changes the user's access permissions on the controller.
+func (e *ControllerUser) SetAccess(access description.Access) error {
+	if err := access.Validate(); err != nil {
+		return errors.Trace(err)
+	}
+	op := updatePermissionOp(controllerGlobalKey, e.globalKey(), access)
+	err := e.st.runTransaction([]txn.Op{op})
+	if err == txn.ErrAborted {
+		return errors.NotFoundf("existing permissions")
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return e.refreshPermission()
+}
+
+func (e *ControllerUser) globalKey() string {
+	// TODO(perrito666) this asumes out of band knowledge of how controllerUserID is crafted
+	username := strings.ToLower(e.UserName())
+	return userWithGlobalKey(username)
+}
+
+// ControllerUser returns the controller user.
+func (st *State) ControllerUser(user names.UserTag) (*ControllerUser, error) {
+	controllerUser := &ControllerUser{st: st}
+	controllerUsers, closer := st.getCollection(controllerUsersC)
+	defer closer()
+
+	username := strings.ToLower(user.Canonical())
+	err := controllerUsers.FindId(username).One(&controllerUser.doc)
+	if err == mgo.ErrNotFound {
+		return nil, errors.NotFoundf("controller user %q", user.Canonical())
+	}
+	// DateCreated is inserted as UTC, but read out as local time. So we
+	// convert it back to UTC here.
+	controllerUser.doc.DateCreated = controllerUser.doc.DateCreated.UTC()
+	if err := controllerUser.refreshPermission(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return controllerUser, nil
+}
+
+// controllerUserID returns the document id of the controller user
+func controllerUserID(user names.UserTag) string {
+	username := user.Canonical()
+	return strings.ToLower(username)
+}
+
+func createControllerUserOps(controllerUUID string, user, createdBy names.UserTag, displayName string, dateCreated time.Time, access description.Access) []txn.Op {
+	creatorname := createdBy.Canonical()
+	doc := &controllerUserDoc{
+		ID:             controllerUserID(user),
+		ControllerUUID: controllerUUID,
+		UserName:       user.Canonical(),
+		DisplayName:    displayName,
+		CreatedBy:      creatorname,
+		DateCreated:    dateCreated,
+	}
+	ops := []txn.Op{
+		createPermissionOp(controllerGlobalKey, userWithGlobalKey(controllerUserID(user)), access),
+		{
+			C:      controllerUsersC,
+			Id:     controllerUserID(user),
+			Assert: txn.DocMissing,
+			Insert: doc,
+		},
+	}
+	return ops
+}
+
+// RemoveControllerUser removes a user from the database.
+func (st *State) RemoveControllerUser(user names.UserTag) error {
+	ops := []txn.Op{
+		removePermissionOp(controllerGlobalKey, userWithGlobalKey(controllerUserID(user))),
+		{
+			C:      controllerUsersC,
+			Id:     controllerUserID(user),
+			Assert: txn.DocExists,
+			Remove: true,
+		}}
+
+	err := st.runTransaction(ops)
+	if err == txn.ErrAborted {
+		err = errors.NewNotFound(nil, fmt.Sprintf("controller user %q does not exist", user.Canonical()))
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}

--- a/state/controlleruser_test.go
+++ b/state/controlleruser_test.go
@@ -1,0 +1,97 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/core/description"
+	"github.com/juju/juju/testing/factory"
+)
+
+type ControllerUserSuite struct {
+	ConnSuite
+}
+
+var _ = gc.Suite(&ControllerUserSuite{})
+
+type accessAwareUser interface {
+	Access() description.Access
+}
+
+func (s *ControllerUserSuite) TestDefaultAccessControllerUser(c *gc.C) {
+	user := s.Factory.MakeUser(c,
+		&factory.UserParams{
+			Name: "validusername",
+		})
+	_ = s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
+	t := user.Tag()
+	userTag := t.(names.UserTag)
+	controllerUser, err := s.State.ControllerUser(userTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(controllerUser.Access(), gc.Equals, description.LoginAccess)
+}
+
+func (s *ControllerUserSuite) TestSetAccessControllerUser(c *gc.C) {
+	user := s.Factory.MakeUser(c,
+		&factory.UserParams{
+			Name: "validusername",
+		})
+	_ = s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
+	t := user.Tag()
+	userTag := t.(names.UserTag)
+	controllerUser, err := s.State.ControllerUser(userTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(controllerUser.Access(), gc.Equals, description.LoginAccess)
+
+	controllerUser.SetAccess(description.AddModelAccess)
+
+	controllerUser, err = s.State.ControllerUser(user.UserTag())
+	c.Assert(controllerUser.Access(), gc.Equals, description.AddModelAccess)
+}
+
+//---------
+func (s *ControllerUserSuite) TestRemoveControllerUser(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "validUsername"})
+	_, err := s.State.ControllerUser(user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.RemoveControllerUser(user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.State.ControllerUser(user.UserTag())
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+// TestCaseSensitiveControllerUserErrors tests that the user id is not case sensitive
+// and adding two times the same username with different capitalization will
+// fail, even though it is actually testing the mechanism for AddUser (which fails
+// before controller user adding) the test is here in case anyone changes the
+// logic behind Adding regular users and forgets to do the same for ControllerUsers.
+func (s *ControllerUserSuite) TestCaseSensitiveControllerUserErrors(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "VALIDuSERNAME"})
+	_, err := s.State.ControllerUser(user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	user = s.Factory.MakeUser(c, &factory.UserParams{Name: "validUsername",
+		ExpectedCreateError: `user already exists`,
+		NoModelUser:         true})
+}
+
+func (s *ControllerUserSuite) TestRemoveControllerUserSucceeds(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{})
+	err := s.State.RemoveControllerUser(user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ControllerUserSuite) TestRemoveControllerUserFails(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{})
+	err := s.State.RemoveControllerUser(user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.RemoveControllerUser(user.UserTag())
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -174,14 +174,14 @@ func (e *exporter) modelUsers() error {
 		return errors.Trace(err)
 	}
 	for _, user := range users {
-		var access string
+		var access description.Access
 		switch {
 		case user.IsAdmin():
-			access = string(AdminAccess)
+			access = description.AdminAccess
 		case user.IsReadWrite():
-			access = string(WriteAccess)
+			access = description.WriteAccess
 		default:
-			access = string(ReadAccess)
+			access = description.ReadAccess
 
 		}
 

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -153,7 +153,7 @@ func (s *MigrationExportSuite) TestModelUsers(c *gc.C) {
 	bob, err := s.State.AddModelUser(state.ModelUserSpec{
 		User:      bobTag,
 		CreatedBy: s.Owner,
-		Access:    state.ReadAccess,
+		Access:    description.ReadAccess,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = state.UpdateModelUserLastConnection(bob, lastConnection)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -205,14 +205,14 @@ func (i *importer) modelUsers() error {
 	modelUUID := i.dbModel.UUID()
 	var ops []txn.Op
 	for _, user := range users {
-		var access Access
+		var access description.Access
 		switch {
 		case user.IsReadOnly():
-			access = ReadAccess
+			access = description.ReadAccess
 		case user.IsReadWrite():
-			access = WriteAccess
+			access = description.WriteAccess
 		default:
-			access = AdminAccess
+			access = description.AdminAccess
 		}
 		ops = append(ops, createModelUserOps(
 			modelUUID,

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -139,9 +139,9 @@ func (s *MigrationImportSuite) TestNewModel(c *gc.C) {
 }
 
 func (s *MigrationImportSuite) newModelUser(c *gc.C, name string, readOnly bool, lastConnection time.Time) *state.ModelUser {
-	access := state.AdminAccess
+	access := description.AdminAccess
 	if readOnly {
-		access = state.ReadAccess
+		access = description.ReadAccess
 	}
 	user, err := s.State.AddModelUser(state.ModelUserSpec{
 		User:      names.NewUserTag(name),

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -77,6 +77,9 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// Users aren't migrated.
 		usersC,
 		userLastLoginC,
+		// Controller users contain extra data about users therefore
+		// are not migrated either.
+		controllerUsersC,
 		// userenvnameC is just to provide a unique key constraint.
 		usermodelnameC,
 		// Metrics aren't migrated.
@@ -176,6 +179,9 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 
 	// If this test fails, it means that a new collection has been added
 	// but migrations for it has not been done. This is a Bad Thing™.
+	// Beware, if your collection is something controller-related it might
+	// not need migration (such as Users or ControllerUsers) in that
+	// case they only need to be accounted for among the ignored collections.
 	c.Assert(remainder, gc.HasLen, 0)
 }
 

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -59,6 +59,11 @@ type modelUserLastConnectionDoc struct {
 	LastConnection time.Time `bson:"last-connection"`
 }
 
+// Access returns the access level of this model user.
+func (e *ModelUser) Access() description.Access {
+	return e.modelPermission.access()
+}
+
 // ID returns the ID of the model user.
 func (e *ModelUser) ID() string {
 	return e.doc.ID
@@ -205,15 +210,10 @@ func (e *ModelUser) updateLastConnection(when time.Time) error {
 	return errors.Trace(err)
 }
 
-func modelUserGlobalKey(userID string) string {
-	// e model us user <name> key.
-	return fmt.Sprintf("%s#us#%s", modelGlobalKey, userID)
-}
-
 func (e *ModelUser) globalKey() string {
 	// TODO(perrito666) this asumes out of band knowledge of how modelUserID is crafted
 	username := strings.ToLower(e.UserName())
-	return modelUserGlobalKey(username)
+	return userWithGlobalKey(username)
 }
 
 // ModelUser returns the model user.
@@ -294,7 +294,7 @@ func createModelUserOps(modelUUID string, user, createdBy names.UserTag, display
 		DateCreated: dateCreated,
 	}
 	ops := []txn.Op{
-		createPermissionOp(modelGlobalKey, modelUserGlobalKey(modelUserID(user)), access),
+		createPermissionOp(modelGlobalKey, userWithGlobalKey(modelUserID(user)), access),
 		{
 			C:      modelUsersC,
 			Id:     modelUserID(user),
@@ -308,7 +308,7 @@ func createModelUserOps(modelUUID string, user, createdBy names.UserTag, display
 // RemoveModelUser removes a user from the database.
 func (st *State) RemoveModelUser(user names.UserTag) error {
 	ops := []txn.Op{
-		removePermissionOp(modelGlobalKey, modelUserGlobalKey(modelUserID(user))),
+		removePermissionOp(modelGlobalKey, userWithGlobalKey(modelUserID(user))),
 		{
 			C:      modelUsersC,
 			Id:     modelUserID(user),
@@ -393,7 +393,7 @@ func (st *State) IsControllerAdministrator(user names.UserTag) (bool, error) {
 	defer closer()
 
 	username := strings.ToLower(user.Canonical())
-	subjectGlobalKey := modelUserGlobalKey(username)
+	subjectGlobalKey := userWithGlobalKey(username)
 
 	// TODO(perrito666) 20160606 this is prone to errors, it will just
 	// yield ErrPerm and be hard to trace, use ModelUser and Permission.

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	jujutxn "github.com/juju/txn"
+	"github.com/juju/juju/core/description"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -111,32 +111,33 @@ func (e *ModelUser) IsReadOnly() bool {
 }
 
 // IsAdmin is a convenience method that
-// returns whether or not the user has AdminAccess.
+// returns whether or not the user has description.AdminAccess.
 func (e *ModelUser) IsAdmin() bool {
 	return e.modelPermission.isAdmin()
 }
 
 // IsReadWrite is a convenience method that
-// returns whether or not the user has WriteAccess.
+// returns whether or not the user has description.WriteAccess.
 func (e *ModelUser) IsReadWrite() bool {
 	return e.modelPermission.isReadWrite()
 }
 
 // IsGreaterAccess returns true if provided access is higher than
 // the current one.
-func (e *ModelUser) IsGreaterAccess(a Access) bool {
+func (e *ModelUser) IsGreaterAccess(a description.Access) bool {
 	return e.modelPermission.isGreaterAccess(a)
 }
 
 // SetAccess changes the user's access permissions on the model.
-func (e *ModelUser) SetAccess(access Access) error {
-	switch access {
-	case ReadAccess, AdminAccess, WriteAccess:
-	default:
-		return errors.Errorf("invalid model access %q", access)
+func (e *ModelUser) SetAccess(access description.Access) error {
+	if err := access.Validate(); err != nil {
+		return errors.Trace(err)
 	}
 	op := updatePermissionOp(modelGlobalKey, e.globalKey(), access)
 	err := e.st.runTransaction([]txn.Op{op})
+	if err == txn.ErrAborted {
+		return errors.NotFoundf("existing permissions")
+	}
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -205,8 +206,8 @@ func (e *ModelUser) updateLastConnection(when time.Time) error {
 }
 
 func modelUserGlobalKey(userID string) string {
-	// mu stands for model user.
-	return fmt.Sprintf("mu#%s", userID)
+	// e model us user <name> key.
+	return fmt.Sprintf("%s#us#%s", modelGlobalKey, userID)
 }
 
 func (e *ModelUser) globalKey() string {
@@ -241,7 +242,7 @@ type ModelUserSpec struct {
 	User        names.UserTag
 	CreatedBy   names.UserTag
 	DisplayName string
-	Access      Access
+	Access      description.Access
 }
 
 // AddModelUser adds a new user to the database.
@@ -264,17 +265,10 @@ func (st *State) AddModelUser(spec ModelUserSpec) (*ModelUser, error) {
 		}
 	}
 
-	// Default to read access if not otherwise specified.
-	if spec.Access == UndefinedAccess {
-		spec.Access = ReadAccess
-	}
-
 	modelUUID := st.ModelUUID()
-	buildTxn := func(attempt int) ([]txn.Op, error) {
-		return createModelUserOps(modelUUID, spec.User, spec.CreatedBy, spec.DisplayName, nowToTheSecond(), spec.Access), nil
-	}
-	err := st.run(buildTxn)
-	if err == jujutxn.ErrExcessiveContention {
+	ops := createModelUserOps(modelUUID, spec.User, spec.CreatedBy, spec.DisplayName, nowToTheSecond(), spec.Access)
+	err := st.runTransaction(ops)
+	if err == txn.ErrAborted {
 		err = errors.AlreadyExistsf("model user %q", spec.User.Canonical())
 	}
 	if err != nil {
@@ -289,7 +283,7 @@ func modelUserID(user names.UserTag) string {
 	return strings.ToLower(username)
 }
 
-func createModelUserOps(modelUUID string, user, createdBy names.UserTag, displayName string, dateCreated time.Time, access Access) []txn.Op {
+func createModelUserOps(modelUUID string, user, createdBy names.UserTag, displayName string, dateCreated time.Time, access description.Access) []txn.Op {
 	creatorname := createdBy.Canonical()
 	doc := &modelUserDoc{
 		ID:          modelUserID(user),
@@ -410,7 +404,7 @@ func (st *State) IsControllerAdministrator(user names.UserTag) (bool, error) {
 		{"_id", fmt.Sprintf("%s:%s", serverUUID, permissionID(modelGlobalKey, subjectGlobalKey))},
 		{"object-global-key", modelGlobalKey},
 		{"subject-global-key", subjectGlobalKey},
-		{"access", AdminAccess},
+		{"access", description.AdminAccess},
 	}).Count()
 	if err != nil {
 		return false, errors.Trace(err)

--- a/state/open.go
+++ b/state/open.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/status"
@@ -306,7 +307,7 @@ func (st *State) modelSetupOps(args ModelArgs, ControllerInheritedConfig map[str
 	isHostedModel := controllerUUID != modelUUID
 
 	modelUserOps := createModelUserOps(
-		modelUUID, args.Owner, args.Owner, args.Owner.Name(), nowToTheSecond(), AdminAccess,
+		modelUUID, args.Owner, args.Owner, args.Owner.Name(), nowToTheSecond(), description.AdminAccess,
 	)
 	ops := []txn.Op{
 		createStatusOp(st, modelGlobalKey, modelStatusDoc),

--- a/state/open.go
+++ b/state/open.go
@@ -229,9 +229,10 @@ func Initialize(args InitializeParams) (_ *State, err error) {
 		return nil, err
 	}
 
-	ops := []txn.Op{
-		createInitialUserOp(st, args.ControllerModelArgs.Owner, args.MongoInfo.Password, salt),
-		{
+	ops := createInitialUserOps(st.ControllerUUID(), args.ControllerModelArgs.Owner, args.MongoInfo.Password, salt)
+	ops = append(ops,
+
+		txn.Op{
 			C:      controllersC,
 			Id:     modelGlobalKey,
 			Assert: txn.DocMissing,
@@ -241,19 +242,19 @@ func Initialize(args InitializeParams) (_ *State, err error) {
 			},
 		},
 		createCloudOp(args.Cloud, args.CloudName),
-		{
+		txn.Op{
 			C:      controllersC,
 			Id:     apiHostPortsKey,
 			Assert: txn.DocMissing,
 			Insert: &apiHostPortsDoc{},
 		},
-		{
+		txn.Op{
 			C:      controllersC,
 			Id:     stateServingInfoKey,
 			Assert: txn.DocMissing,
 			Insert: &StateServingInfo{},
 		},
-		{
+		txn.Op{
 			C:      controllersC,
 			Id:     hostedModelCountKey,
 			Assert: txn.DocMissing,
@@ -261,7 +262,7 @@ func Initialize(args InitializeParams) (_ *State, err error) {
 		},
 		createSettingsOp(controllersC, controllerSettingsGlobalKey, args.ControllerConfig),
 		createSettingsOp(globalSettingsC, controllerInheritedSettingsGlobalKey, args.ControllerInheritedConfig),
-	}
+	)
 	if len(args.CloudCredentials) > 0 {
 		credentialsOps := updateCloudCredentialsOps(
 			args.ControllerModelArgs.Owner,

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -176,7 +176,7 @@ func (s *StateSuite) TestModelUUID(c *gc.C) {
 
 func (s *StateSuite) TestNoModelDocs(c *gc.C) {
 	c.Assert(s.State.EnsureModelRemoved(), gc.ErrorMatches,
-		fmt.Sprintf("found documents for model with uuid %s: 1 constraints doc, 2 leases doc, 1 modelusers doc, 1 permissions doc, 1 settings doc, 1 statuses doc", s.State.ModelUUID()))
+		fmt.Sprintf("found documents for model with uuid %s: 1 constraints doc, 2 leases doc, 1 modelusers doc, 2 permissions doc, 1 settings doc, 1 statuses doc", s.State.ModelUUID()))
 }
 
 func (s *StateSuite) TestMongoSession(c *gc.C) {

--- a/state/userpermission.go
+++ b/state/userpermission.go
@@ -79,9 +79,9 @@ func (p *permission) isGreaterAccess(a description.Access) bool {
 }
 
 func permissionID(objectKey, subjectKey string) string {
-	// example: e#mo#jim
+	// example: e#us#jim
 	// e: model global key (its always e).
-	// mo: model user key prefix.
+	// us: user key prefix.
 	// jim: an arbitrary username.
 	return fmt.Sprintf("%s#%s", objectKey, subjectKey)
 }

--- a/state/userpermission.go
+++ b/state/userpermission.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/core/description"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
@@ -26,7 +27,15 @@ type permissionDoc struct {
 	// SubjectGlobalKey holds the id for the user/group that is given permission.
 	SubjectGlobalKey string `bson:"subject-global-key"`
 	// Access is the permission level.
-	Access Access `bson:"access"`
+	Access string `bson:"access"`
+}
+
+func stringToAccess(a string) description.Access {
+	return description.Access(a)
+}
+
+func accessToString(a description.Access) string {
+	return string(a)
 }
 
 // userPermission returns a Permission for the given Subject and User.
@@ -46,35 +55,27 @@ func (st *State) userPermission(objectKey, subjectKey string) (*permission, erro
 // isReadOnly returns whether or not the user has write access or only
 // read access to the model.
 func (p *permission) isReadOnly() bool {
-	return p.doc.Access == UndefinedAccess || p.doc.Access == ReadAccess
+	return stringToAccess(p.doc.Access) == description.UndefinedAccess || stringToAccess(p.doc.Access) == description.ReadAccess
 }
 
 // isAdmin is a convenience method that
-// returns whether or not the user has AdminAccess.
+// returns whether or not the user has description.AdminAccess.
 func (p *permission) isAdmin() bool {
-	return p.doc.Access == AdminAccess
+	return stringToAccess(p.doc.Access) == description.AdminAccess
 }
 
 // isReadWrite is a convenience method that
-// returns whether or not the user has WriteAccess.
+// returns whether or not the user has description.WriteAccess.
 func (p *permission) isReadWrite() bool {
-	return p.doc.Access == WriteAccess
+	return stringToAccess(p.doc.Access) == description.WriteAccess
 }
 
-func (p *permission) access() Access {
-	return p.doc.Access
+func (p *permission) access() description.Access {
+	return stringToAccess(p.doc.Access)
 }
 
-func (p *permission) isGreaterAccess(a Access) bool {
-	switch p.doc.Access {
-	case UndefinedAccess:
-		return a == ReadAccess || a == WriteAccess || a == AdminAccess
-	case ReadAccess:
-		return a == WriteAccess || a == AdminAccess
-	case WriteAccess:
-		return a == AdminAccess
-	}
-	return false
+func (p *permission) isGreaterAccess(a description.Access) bool {
+	return stringToAccess(p.doc.Access).LessAccessThan(a)
 }
 
 func permissionID(objectKey, subjectKey string) string {
@@ -85,12 +86,12 @@ func permissionID(objectKey, subjectKey string) string {
 	return fmt.Sprintf("%s#%s", objectKey, subjectKey)
 }
 
-func updatePermissionOp(objectGlobalKey, subjectGlobalKey string, access Access) txn.Op {
+func updatePermissionOp(objectGlobalKey, subjectGlobalKey string, access description.Access) txn.Op {
 	return txn.Op{
 		C:      permissionsC,
 		Id:     permissionID(objectGlobalKey, subjectGlobalKey),
 		Assert: txn.DocExists,
-		Update: bson.D{{"$set", bson.D{{"access", access}}}},
+		Update: bson.D{{"$set", bson.D{{"access", accessToString(access)}}}},
 	}
 }
 
@@ -103,12 +104,12 @@ func removePermissionOp(objectGlobalKey, subjectGlobalKey string) txn.Op {
 	}
 
 }
-func createPermissionOp(objectGlobalKey, subjectGlobalKey string, access Access) txn.Op {
+func createPermissionOp(objectGlobalKey, subjectGlobalKey string, access description.Access) txn.Op {
 	doc := &permissionDoc{
 		ID:               permissionID(objectGlobalKey, subjectGlobalKey),
 		SubjectGlobalKey: subjectGlobalKey,
 		ObjectGlobalKey:  objectGlobalKey,
-		Access:           access,
+		Access:           accessToString(access),
 	}
 	return txn.Op{
 		C:      permissionsC,
@@ -117,22 +118,3 @@ func createPermissionOp(objectGlobalKey, subjectGlobalKey string, access Access)
 		Insert: doc,
 	}
 }
-
-// Access represents the level of access granted to a user on a model.
-type Access string
-
-const (
-	// UndefinedAccess is not a valid access type. It is the value
-	// unmarshaled when access is not defined by the document at all.
-	UndefinedAccess Access = ""
-
-	// ReadAccess allows a user to read information about a model, without
-	// being able to make any changes.
-	ReadAccess Access = "read"
-
-	// WriteAccess allows a user to make changes to a model.
-	WriteAccess Access = "write"
-
-	// AdminAccess allows a user full control over the model.
-	AdminAccess Access = "admin"
-)

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -19,6 +19,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -51,7 +52,7 @@ type UserParams struct {
 	Creator     names.Tag
 	NoModelUser bool
 	Disabled    bool
-	Access      state.Access
+	Access      description.Access
 }
 
 // ModelUserParams defines the parameters for creating an environment user.
@@ -59,7 +60,7 @@ type ModelUserParams struct {
 	User        string
 	DisplayName string
 	CreatedBy   names.Tag
-	Access      state.Access
+	Access      description.Access
 }
 
 // CharmParams defines the parameters for creating a charm.
@@ -176,8 +177,8 @@ func (factory *Factory) MakeUser(c *gc.C, params *UserParams) *state.User {
 		c.Assert(err, jc.ErrorIsNil)
 		params.Creator = env.Owner()
 	}
-	if params.Access == state.UndefinedAccess {
-		params.Access = state.AdminAccess
+	if params.Access == description.UndefinedAccess {
+		params.Access = description.AdminAccess
 	}
 	creatorUserTag := params.Creator.(names.UserTag)
 	user, err := factory.st.AddUser(
@@ -214,8 +215,8 @@ func (factory *Factory) MakeModelUser(c *gc.C, params *ModelUserParams) *state.M
 	if params.DisplayName == "" {
 		params.DisplayName = uniqueString("display name")
 	}
-	if params.Access == state.UndefinedAccess {
-		params.Access = state.AdminAccess
+	if params.Access == description.UndefinedAccess {
+		params.Access = description.AdminAccess
 	}
 	if params.CreatedBy == nil {
 		env, err := factory.st.Model()

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -46,13 +46,14 @@ func NewFactory(st *state.State) *Factory {
 
 // UserParams defines the parameters for creating a user with MakeUser.
 type UserParams struct {
-	Name        string
-	DisplayName string
-	Password    string
-	Creator     names.Tag
-	NoModelUser bool
-	Disabled    bool
-	Access      description.Access
+	Name                string
+	DisplayName         string
+	Password            string
+	Creator             names.Tag
+	NoModelUser         bool
+	Disabled            bool
+	Access              description.Access
+	ExpectedCreateError string
 }
 
 // ModelUserParams defines the parameters for creating an environment user.
@@ -183,7 +184,11 @@ func (factory *Factory) MakeUser(c *gc.C, params *UserParams) *state.User {
 	creatorUserTag := params.Creator.(names.UserTag)
 	user, err := factory.st.AddUser(
 		params.Name, params.DisplayName, params.Password, creatorUserTag.Name())
-	c.Assert(err, jc.ErrorIsNil)
+	if params.ExpectedCreateError != "" {
+		c.Assert(err, gc.ErrorMatches, params.ExpectedCreateError)
+	} else {
+		c.Assert(err, jc.ErrorIsNil)
+	}
 	if !params.NoModelUser {
 		_, err := factory.st.AddModelUser(state.ModelUserSpec{
 			User:        user.UserTag(),


### PR DESCRIPTION
WARNING: This branch depends on https://github.com/juju/juju/pull/5701
 * There is now a layer to persist controller level permissions.
 * A ControllerUser with each new User.
 * Three new permission levels have been added for controllers.
 * ControllerUsers get Login permission by default.

(Review request: http://reviews.vapour.ws/r/5272/)