### PR TITLE
Fix the reboot worker tests.

### DIFF
--- a/worker/reboot/reboot.go
+++ b/worker/reboot/reboot.go
@@ -76,11 +76,13 @@ func (r *Reboot) Handle(_ <-chan struct{}) error {
 	}
 	switch rAction {
 	case params.ShouldReboot:
+		logger.Debugf("acquiring mutex %q for reboot", r.machineLockName)
 		if _, err := mutex.Acquire(spec); err != nil {
 			return errors.Trace(err)
 		}
 		return worker.ErrRebootMachine
 	case params.ShouldShutdown:
+		logger.Debugf("acquiring mutex %q for shutdown", r.machineLockName)
 		if _, err := mutex.Acquire(spec); err != nil {
 			return errors.Trace(err)
 		}

--- a/worker/reboot/reboot_test.go
+++ b/worker/reboot/reboot_test.go
@@ -40,8 +40,7 @@ type rebootSuite struct {
 	ct            *state.Machine
 	ctRebootState apireboot.State
 
-	lockName string
-	clock    clock.Clock
+	clock clock.Clock
 }
 
 var _ = gc.Suite(&rebootSuite{})
@@ -77,7 +76,6 @@ func (s *rebootSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.ctRebootState, gc.NotNil)
 
-	s.lockName = "reboot-test"
 	s.clock = &fakeClock{delay: time.Millisecond}
 }
 
@@ -85,15 +83,26 @@ func (s *rebootSuite) TearDownTest(c *gc.C) {
 	s.JujuConnSuite.TearDownTest(c)
 }
 
+// NOTE: the various reboot tests use a different lock name for each test.
+// This is due to the behaviour of the reboot worker. What it does is acquires
+// the named process lock and never releases it. This is fine(ish) on linux as the
+// garbage collector will eventually clean up the old lock which will release the
+// domain socket, but on windows, the actual lock is a system level semaphore wich
+// isn't cleaned up by the golang garbage collector, but instead relies on the process
+// dying to release the semaphore handle.
+//
+// If more tests are added here, they each need their own lock name to avoid blocking
+// forever on windows.
+
 func (s *rebootSuite) TestStartStop(c *gc.C) {
-	worker, err := reboot.NewReboot(s.rebootState, s.AgentConfigForTag(c, s.machine.Tag()), s.lockName, s.clock)
+	worker, err := reboot.NewReboot(s.rebootState, s.AgentConfigForTag(c, s.machine.Tag()), "test-reboot-start-stop", s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 	worker.Kill()
 	c.Assert(worker.Wait(), gc.IsNil)
 }
 
 func (s *rebootSuite) TestWorkerCatchesRebootEvent(c *gc.C) {
-	wrk, err := reboot.NewReboot(s.rebootState, s.AgentConfigForTag(c, s.machine.Tag()), s.lockName, s.clock)
+	wrk, err := reboot.NewReboot(s.rebootState, s.AgentConfigForTag(c, s.machine.Tag()), "test-reboot-event", s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.rebootState.RequestReboot()
 	c.Assert(err, jc.ErrorIsNil)
@@ -101,7 +110,7 @@ func (s *rebootSuite) TestWorkerCatchesRebootEvent(c *gc.C) {
 }
 
 func (s *rebootSuite) TestContainerCatchesParentFlag(c *gc.C) {
-	wrk, err := reboot.NewReboot(s.ctRebootState, s.AgentConfigForTag(c, s.ct.Tag()), s.lockName, s.clock)
+	wrk, err := reboot.NewReboot(s.ctRebootState, s.AgentConfigForTag(c, s.ct.Tag()), "test-reboot-container", s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.rebootState.RequestReboot()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Backport of master fix.

Due to the behaviour of the reboot worker, the tests need to have different machine lock names, otherwise they will block on windows.
The golang garbabe collector means that this isn't a problem on linux as when the old lock is cleaned up, it releases the domain socket,
but on windows, the lock is an external semaphore that relies on the process dying to release it.

(Review request: http://reviews.vapour.ws/r/5274/)