### PR TITLE
A couple of unit test fixes

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -24,6 +24,13 @@ import (
 // AuthType is the type of authentication used by the cloud.
 type AuthType string
 
+// AuthTypes is defined to allow sorting AuthType slices.
+type AuthTypes []AuthType
+
+func (a AuthTypes) Len() int           { return len(a) }
+func (a AuthTypes) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a AuthTypes) Less(i, j int) bool { return a[i] < a[j] }
+
 const (
 	// AccessKeyAuthType is an authentication type using a key and secret.
 	AccessKeyAuthType AuthType = "access-key"
@@ -55,7 +62,7 @@ type Cloud struct {
 	Type string
 
 	// AuthTypes are the authentication modes supported by the cloud.
-	AuthTypes []AuthType
+	AuthTypes AuthTypes
 
 	// Endpoint is the default endpoint for the cloud regions, may be
 	// overridden by a region.

--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -61,7 +61,7 @@ func (s *cloudSuite) TestParseCloudsEndpointDenormalisation(c *gc.C) {
 func (s *cloudSuite) TestParseCloudsAuthTypes(c *gc.C) {
 	clouds := parsePublicClouds(c)
 	rackspace := clouds["rackspace"]
-	c.Assert(rackspace.AuthTypes, jc.SameContents, []cloud.AuthType{"access-key", "userpass"})
+	c.Assert(rackspace.AuthTypes, jc.SameContents, cloud.AuthTypes{"access-key", "userpass"})
 }
 
 func (s *cloudSuite) TestParseCloudsConfig(c *gc.C) {

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -5,6 +5,7 @@ package backups_test
 
 import (
 	"io"
+	"sort"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -260,9 +261,10 @@ func (s *restoreSuite) TestRestoreReboostrapBuiltInProvider(c *gc.C) {
 	boostrapped := false
 	s.PatchValue(&backups.BootstrapFunc, func(ctx environs.BootstrapContext, environ environs.Environ, args bootstrap.BootstrapParams) error {
 		boostrapped = true
+		sort.Sort(args.Cloud.AuthTypes)
 		c.Assert(args.Cloud, jc.DeepEquals, cloud.Cloud{
 			Type:      "lxd",
-			AuthTypes: []cloud.AuthType{"empty", "certificate"},
+			AuthTypes: []cloud.AuthType{"certificate", "empty"},
 			Regions:   []cloud.Region{{Name: "localhost"}},
 		})
 		return nil

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -976,7 +976,7 @@ func (s *BootstrapSuite) TestBootstrapProviderManyCredentialsCloudNoAuthTypes(c 
 		"many-credentials-no-auth-types",
 		"--credential", "one",
 	)
-	c.Assert(bootstrap.args.Cloud.AuthTypes, jc.SameContents, []cloud.AuthType{"one", "two"})
+	c.Assert(bootstrap.args.Cloud.AuthTypes, jc.SameContents, cloud.AuthTypes{"one", "two"})
 }
 
 func (s *BootstrapSuite) TestBootstrapProviderDetectRegions(c *gc.C) {

--- a/worker/logforwarder/logforwarder_test.go
+++ b/worker/logforwarder/logforwarder_test.go
@@ -205,7 +205,8 @@ func (s *LogForwarderSuite) TestConfigChange(c *gc.C) {
 	s.stream.waitBeforeNext(c)
 	s.stream.waitAfterNext(c)
 	s.sender.waitAfterSend(c)
-	s.stub.CheckCallNames(c, "Close", "Next", "Send")
+	// Check that the config change has been picked up and
+	// that the second record is sent.
 	rec2.Message = "send to 10.0.0.2"
 	s.stub.CheckCall(c, 2, "Send", []logfwd.Record{rec2})
 	s.stub.ResetCalls()


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1604408
Fixes: https://bugs.launchpad.net/juju-core/+bug/1604561

Fixes a map ordering related test failure in TestRestoreReboostrapBuiltInProvider
Also, a remove an assert that was racing in LogForwarderSuite.TestConfigChange. We don't care about what order the apis calls occurred, just that the expected record was sent.

(Review request: http://reviews.vapour.ws/r/5276/)