### PR TITLE
provider/joyent: Don't attempt to stop instances in parallel in test

### DIFF
--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -262,8 +262,11 @@ func (s *localServerSuite) TestInstancesGathering(c *gc.C) {
 	id1 := inst1.Id()
 	c.Logf("id0: %s, id1: %s", id0, id1)
 	defer func() {
-		err := env.StopInstances(inst0.Id(), inst1.Id())
-		c.Assert(err, jc.ErrorIsNil)
+		// StopInstances deletes machines in parallel but the Joyent
+		// API test double isn't goroutine-safe so stop them one at a
+		// time. See https://pad.lv/1604514
+		c.Check(env.StopInstances(inst0.Id()), jc.ErrorIsNil)
+		c.Check(env.StopInstances(inst1.Id()), jc.ErrorIsNil)
 	}()
 
 	for i, test := range instanceGathering {


### PR DESCRIPTION
StopInstances attempts to delete the instances its stopping in parallel but the Joyent API test double isn't goroutine-safe, occasionally tripping the race detector. Work around this by stopping the instances one at a time.

Fixes https://pad.lv/1604514

(Review request: http://reviews.vapour.ws/r/5277/)