### PR TITLE
Introduce new ModelConfig facade

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -26,7 +26,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/downloader"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/tools"
@@ -235,44 +234,6 @@ func (c *Client) WatchAll() (*AllWatcher, error) {
 // to its underlying state connection.
 func (c *Client) Close() error {
 	return c.st.Close()
-}
-
-// ModelGet returns all model settings.
-func (c *Client) ModelGet() (map[string]interface{}, error) {
-	result := params.ModelConfigResults{}
-	err := c.facade.FacadeCall("ModelGet", nil, &result)
-	values := make(map[string]interface{})
-	for name, val := range result.Config {
-		values[name] = val.Value
-	}
-	return values, err
-}
-
-// ModelGetWithMetadata returns all model settings along with extra
-// metadata like the source of the setting value.
-func (c *Client) ModelGetWithMetadata() (config.ConfigValues, error) {
-	result := params.ModelConfigResults{}
-	err := c.facade.FacadeCall("ModelGet", nil, &result)
-	values := make(config.ConfigValues)
-	for name, val := range result.Config {
-		values[name] = config.ConfigValue{
-			Value:  val.Value,
-			Source: val.Source,
-		}
-	}
-	return values, err
-}
-
-// ModelSet sets the given key-value pairs in the model.
-func (c *Client) ModelSet(config map[string]interface{}) error {
-	args := params.ModelSet{Config: config}
-	return c.facade.FacadeCall("ModelSet", args, nil)
-}
-
-// ModelUnset sets the given key-value pairs in the model.
-func (c *Client) ModelUnset(keys ...string) error {
-	args := params.ModelUnset{Keys: keys}
-	return c.facade.FacadeCall("ModelUnset", args, nil)
 }
 
 // SetModelAgentVersion sets the model agent-version setting

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -520,45 +520,6 @@ func (s *clientSuite) TestAbortCurrentUpgrade(c *gc.C) {
 	c.Assert(err, gc.Equals, someErr) // Confirms that the correct facade was called
 }
 
-func (s *clientSuite) TestEnvironmentGet(c *gc.C) {
-	client := s.APIState.Client()
-	env, err := client.ModelGet()
-	c.Assert(err, jc.ErrorIsNil)
-	// Check a known value, just checking that there is something there.
-	c.Assert(env["type"], gc.Equals, "dummy")
-}
-
-func (s *clientSuite) TestEnvironmentSet(c *gc.C) {
-	client := s.APIState.Client()
-	err := client.ModelSet(map[string]interface{}{
-		"some-name":  "value",
-		"other-name": true,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	// Check them using ModelGet.
-	env, err := client.ModelGet()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env["some-name"], gc.Equals, "value")
-	c.Assert(env["other-name"], gc.Equals, true)
-}
-
-func (s *clientSuite) TestEnvironmentUnset(c *gc.C) {
-	client := s.APIState.Client()
-	err := client.ModelSet(map[string]interface{}{
-		"some-name": "value",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Now unset it and make sure it isn't there.
-	err = client.ModelUnset("some-name")
-	c.Assert(err, jc.ErrorIsNil)
-
-	env, err := client.ModelGet()
-	c.Assert(err, jc.ErrorIsNil)
-	_, found := env["some-name"]
-	c.Assert(found, jc.IsFalse)
-}
-
 // badReader raises err when Read is called.
 type badReader struct {
 	err error

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -56,6 +56,7 @@ var facadeVersions = map[string]int{
 	"MigrationMinion":              1,
 	"MigrationStatusWatcher":       1,
 	"MigrationTarget":              1,
+	"ModelConfig":                  1,
 	"ModelManager":                 2,
 	"NotifyWatcher":                1,
 	"Payloads":                     1,

--- a/api/modelconfig/modelconfig.go
+++ b/api/modelconfig/modelconfig.go
@@ -1,0 +1,67 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelconfig
+
+import (
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/config"
+)
+
+// Client provides methods that the Juju client command uses to interact
+// with models stored in the Juju Server.
+type Client struct {
+	base.ClientFacade
+	facade base.FacadeCaller
+}
+
+// NewClient creates a new `Client` based on an existing authenticated API
+// connection.
+func NewClient(st base.APICallCloser) *Client {
+	frontend, backend := base.NewClientFacade(st, "ModelConfig")
+	return &Client{ClientFacade: frontend, facade: backend}
+}
+
+// Close closes the api connection.
+func (c *Client) Close() error {
+	return c.ClientFacade.Close()
+}
+
+// ModelGet returns all model settings.
+func (c *Client) ModelGet() (map[string]interface{}, error) {
+	result := params.ModelConfigResults{}
+	err := c.facade.FacadeCall("ModelGet", nil, &result)
+	values := make(map[string]interface{})
+	for name, val := range result.Config {
+		values[name] = val.Value
+	}
+	return values, err
+}
+
+// ModelGetWithMetadata returns all model settings along with extra
+// metadata like the source of the setting value.
+func (c *Client) ModelGetWithMetadata() (config.ConfigValues, error) {
+	result := params.ModelConfigResults{}
+	err := c.facade.FacadeCall("ModelGet", nil, &result)
+	values := make(config.ConfigValues)
+	for name, val := range result.Config {
+		values[name] = config.ConfigValue{
+			Value:  val.Value,
+			Source: val.Source,
+		}
+	}
+	return values, err
+}
+
+// ModelSet sets the given key-value pairs in the model.
+func (c *Client) ModelSet(config map[string]interface{}) error {
+	args := params.ModelSet{Config: config}
+	return c.facade.FacadeCall("ModelSet", args, nil)
+}
+
+// ModelUnset sets the given key-value pairs in the model.
+func (c *Client) ModelUnset(keys ...string) error {
+	args := params.ModelUnset{Keys: keys}
+	return c.facade.FacadeCall("ModelUnset", args, nil)
+}

--- a/api/modelconfig/modelconfig_test.go
+++ b/api/modelconfig/modelconfig_test.go
@@ -1,0 +1,129 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelconfig_test
+
+import (
+	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	basetesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/modelconfig"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/config"
+)
+
+type modelconfigrSuite struct {
+	gitjujutesting.IsolationSuite
+}
+
+var _ = gc.Suite(&modelconfigrSuite{})
+
+func (s *modelconfigrSuite) TestModelGet(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, result interface{},
+		) error {
+			c.Check(objType, gc.Equals, "ModelConfig")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "ModelGet")
+			c.Check(a, gc.IsNil)
+			c.Assert(result, gc.FitsTypeOf, &params.ModelConfigResults{})
+			results := result.(*params.ModelConfigResults)
+			results.Config = map[string]params.ConfigValue{
+				"foo": {"bar", "model"},
+			}
+			return nil
+		},
+	)
+	client := modelconfig.NewClient(apiCaller)
+	result, err := client.ModelGet()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, map[string]interface{}{
+		"foo": "bar",
+	})
+}
+
+func (s *modelconfigrSuite) TestModelGetWithMetadata(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, result interface{},
+		) error {
+			c.Check(objType, gc.Equals, "ModelConfig")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "ModelGet")
+			c.Check(a, gc.IsNil)
+			c.Assert(result, gc.FitsTypeOf, &params.ModelConfigResults{})
+			results := result.(*params.ModelConfigResults)
+			results.Config = map[string]params.ConfigValue{
+				"foo": {"bar", "model"},
+			}
+			return nil
+		},
+	)
+	client := modelconfig.NewClient(apiCaller)
+	result, err := client.ModelGetWithMetadata()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, config.ConfigValues{
+		"foo": {"bar", "model"},
+	})
+}
+
+func (s *modelconfigrSuite) TestModelSet(c *gc.C) {
+	called := false
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, result interface{},
+		) error {
+			c.Check(objType, gc.Equals, "ModelConfig")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "ModelSet")
+			c.Check(a, jc.DeepEquals, params.ModelSet{
+				Config: map[string]interface{}{
+					"some-name":  "value",
+					"other-name": true,
+				},
+			})
+			called = true
+			return nil
+		},
+	)
+	client := modelconfig.NewClient(apiCaller)
+	err := client.ModelSet(map[string]interface{}{
+		"some-name":  "value",
+		"other-name": true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *modelconfigrSuite) TestModelUnset(c *gc.C) {
+	called := false
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, result interface{},
+		) error {
+			c.Check(objType, gc.Equals, "ModelConfig")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "ModelUnset")
+			c.Check(a, jc.DeepEquals, params.ModelUnset{
+				Keys: []string{"foo", "bar"},
+			})
+			called = true
+			return nil
+		},
+	)
+	client := modelconfig.NewClient(apiCaller)
+	err := client.ModelUnset("foo", "bar")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+}

--- a/api/modelconfig/package_test.go
+++ b/api/modelconfig/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelconfig_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -50,6 +50,7 @@ import (
 	_ "github.com/juju/juju/apiserver/migrationmaster"
 	_ "github.com/juju/juju/apiserver/migrationminion"
 	_ "github.com/juju/juju/apiserver/migrationtarget"
+	_ "github.com/juju/juju/apiserver/modelconfig"
 	_ "github.com/juju/juju/apiserver/modelmanager"
 	_ "github.com/juju/juju/apiserver/provisioner"
 	_ "github.com/juju/juju/apiserver/proxyupdater"

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -217,7 +217,7 @@ func (s *serverSuite) TestCheckProviderAPISuccess(c *gc.C) {
 }
 
 func (s *serverSuite) TestCheckProviderAPIFail(c *gc.C) {
-	s.assertCheckProviderAPI(c, fmt.Errorf("instances error"), "cannot make API call to provider: instances error")
+	s.assertCheckProviderAPI(c, errors.New("instances error"), "cannot make API call to provider: instances error")
 }
 
 func (s *serverSuite) assertSetEnvironAgentVersion(c *gc.C) {
@@ -728,131 +728,6 @@ func (s *clientSuite) TestClientPrivateAddressUnit(c *gc.C) {
 	addr, err := s.APIState.Client().PrivateAddress("wordpress/0")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addr, gc.Equals, "private")
-}
-
-func (s *serverSuite) TestClientModelGet(c *gc.C) {
-	modelConfig, err := s.State.ModelConfig()
-	c.Assert(err, jc.ErrorIsNil)
-	result, err := s.client.ModelGet()
-	c.Assert(err, jc.ErrorIsNil)
-	cfg := make(map[string]params.ConfigValue)
-	for name, val := range modelConfig.AllAttrs() {
-		cfg[name] = params.ConfigValue{
-			Value:  val,
-			Source: "model",
-		}
-	}
-	delete(cfg, "authorized-keys")
-	c.Assert(result.Config, gc.DeepEquals, cfg)
-}
-
-func (s *serverSuite) assertEnvValue(c *gc.C, key string, expected interface{}) {
-	modelConfig, err := s.State.ModelConfig()
-	c.Assert(err, jc.ErrorIsNil)
-	value, found := modelConfig.AllAttrs()[key]
-	c.Assert(found, jc.IsTrue)
-	c.Assert(value, gc.Equals, expected)
-}
-
-func (s *serverSuite) assertEnvValueMissing(c *gc.C, key string) {
-	modelConfig, err := s.State.ModelConfig()
-	c.Assert(err, jc.ErrorIsNil)
-	_, found := modelConfig.AllAttrs()[key]
-	c.Assert(found, jc.IsFalse)
-}
-
-func (s *serverSuite) TestClientModelSet(c *gc.C) {
-	modelConfig, err := s.State.ModelConfig()
-	c.Assert(err, jc.ErrorIsNil)
-	_, found := modelConfig.AllAttrs()["some-key"]
-	c.Assert(found, jc.IsFalse)
-
-	params := params.ModelSet{
-		Config: map[string]interface{}{
-			"some-key":  "value",
-			"other-key": "other value"},
-	}
-	err = s.client.ModelSet(params)
-	c.Assert(err, jc.ErrorIsNil)
-	s.assertEnvValue(c, "some-key", "value")
-	s.assertEnvValue(c, "other-key", "other value")
-}
-
-func (s *serverSuite) TestClientModelSetImmutable(c *gc.C) {
-	// The various immutable config values are tested in
-	// environs/config/config_test.go, so just choosing one here.
-	params := params.ModelSet{
-		Config: map[string]interface{}{"firewall-mode": "global"},
-	}
-	err := s.client.ModelSet(params)
-	c.Check(err, gc.ErrorMatches, `cannot change firewall-mode from .* to "global"`)
-}
-
-func (s *serverSuite) assertModelSetBlocked(c *gc.C, args map[string]interface{}, msg string) {
-	err := s.client.ModelSet(params.ModelSet{args})
-	s.AssertBlocked(c, err, msg)
-}
-
-func (s *serverSuite) TestBlockChangesClientModelSet(c *gc.C) {
-	s.BlockAllChanges(c, "TestBlockChangesClientModelSet")
-	args := map[string]interface{}{"some-key": "value"}
-	s.assertModelSetBlocked(c, args, "TestBlockChangesClientModelSet")
-}
-
-func (s *serverSuite) TestClientModelSetCannotChangeAgentVersion(c *gc.C) {
-	args := params.ModelSet{
-		map[string]interface{}{"agent-version": "9.9.9"},
-	}
-	err := s.client.ModelSet(args)
-	c.Assert(err, gc.ErrorMatches, "agent-version cannot be changed")
-
-	// It's okay to pass env back with the same agent-version.
-	result, err := s.client.ModelGet()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Config["agent-version"], gc.NotNil)
-	args.Config["agent-version"] = result.Config["agent-version"].Value
-	err = s.client.ModelSet(args)
-	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *serverSuite) TestClientModelUnset(c *gc.C) {
-	err := s.State.UpdateModelConfig(map[string]interface{}{"abc": 123}, nil, nil)
-	c.Assert(err, jc.ErrorIsNil)
-
-	args := params.ModelUnset{[]string{"abc"}}
-	err = s.client.ModelUnset(args)
-	c.Assert(err, jc.ErrorIsNil)
-	s.assertEnvValueMissing(c, "abc")
-}
-
-func (s *serverSuite) TestBlockClientModelUnset(c *gc.C) {
-	err := s.State.UpdateModelConfig(map[string]interface{}{"abc": 123}, nil, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	s.BlockAllChanges(c, "TestBlockClientModelUnset")
-
-	args := params.ModelUnset{[]string{"abc"}}
-	err = s.client.ModelUnset(args)
-	s.AssertBlocked(c, err, "TestBlockClientModelUnset")
-}
-
-func (s *serverSuite) TestClientModelUnsetMissing(c *gc.C) {
-	// It's okay to unset a non-existent attribute.
-	args := params.ModelUnset{[]string{"not_there"}}
-	err := s.client.ModelUnset(args)
-	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *serverSuite) TestClientModelUnsetError(c *gc.C) {
-	err := s.State.UpdateModelConfig(map[string]interface{}{"abc": 123}, nil, nil)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// "type" may not be removed, and this will cause an error.
-	// If any one attribute's removal causes an error, there
-	// should be no change.
-	args := params.ModelUnset{[]string{"abc", "type"}}
-	err = s.client.ModelUnset(args)
-	c.Assert(err, gc.ErrorMatches, "type: expected string, got nothing")
-	s.assertEnvValue(c, "abc", 123)
 }
 
 func (s *clientSuite) TestClientFindTools(c *gc.C) {

--- a/apiserver/client/perm_test.go
+++ b/apiserver/client/perm_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/annotations"
 	"github.com/juju/juju/api/application"
+	"github.com/juju/juju/api/modelconfig"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/constraints"
@@ -138,15 +139,15 @@ func (s *permSuite) TestOperationPerm(c *gc.C) {
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
 		about: "Client.ModelGet",
-		op:    opClientEnvironmentGet,
+		op:    opClientModelGet,
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
 		about: "Client.ModelSet",
-		op:    opClientEnvironmentSet,
+		op:    opClientModelSet,
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
 		about: "Client.SetModelAgentVersion",
-		op:    opClientSetEnvironAgentVersion,
+		op:    opClientSetModelAgentVersion,
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
 		about: "Client.WatchAll",
@@ -379,28 +380,28 @@ func opClientSetEnvironmentConstraints(c *gc.C, st api.Connection, mst *state.St
 	return func() {}, nil
 }
 
-func opClientEnvironmentGet(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	_, err := st.Client().ModelGet()
+func opClientModelGet(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
+	_, err := modelconfig.NewClient(st).ModelGet()
 	if err != nil {
 		return func() {}, err
 	}
 	return func() {}, nil
 }
 
-func opClientEnvironmentSet(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
+func opClientModelSet(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
 	args := map[string]interface{}{"some-key": "some-value"}
-	err := st.Client().ModelSet(args)
+	err := modelconfig.NewClient(st).ModelSet(args)
 	if err != nil {
 		return func() {}, err
 	}
 	return func() {
 		args["some-key"] = nil
-		st.Client().ModelSet(args)
+		modelconfig.NewClient(st).ModelSet(args)
 	}, nil
 }
 
-func opClientSetEnvironAgentVersion(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	attrs, err := st.Client().ModelGet()
+func opClientSetModelAgentVersion(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
+	attrs, err := modelconfig.NewClient(st).ModelGet()
 	if err != nil {
 		return func() {}, err
 	}

--- a/apiserver/modelconfig/backend.go
+++ b/apiserver/modelconfig/backend.go
@@ -1,0 +1,27 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelconfig
+
+import (
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/state"
+)
+
+// Backend contains the state.State methods used in this package,
+// allowing stubs to be created for testing.
+type Backend interface {
+	common.BlockGetter
+	ModelConfigValues() (config.ConfigValues, error)
+	UpdateModelConfig(map[string]interface{}, []string, state.ValidateConfigFunc) error
+}
+
+type stateShim struct {
+	*state.State
+}
+
+// NewStateBackend creates a backend for the facade to use.
+func NewStateBackend(st *state.State) Backend {
+	return stateShim{st}
+}

--- a/apiserver/modelconfig/modelconfig.go
+++ b/apiserver/modelconfig/modelconfig.go
@@ -1,0 +1,130 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelconfig
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/state"
+)
+
+func init() {
+	common.RegisterStandardFacade("ModelConfig", 1, newFacade)
+}
+
+func newFacade(st *state.State, _ facade.Resources, auth facade.Authorizer) (*ModelConfigAPI, error) {
+	return NewModelConfigAPI(NewStateBackend(st), auth)
+}
+
+// ModelConfigAPI is the endpoint which implements the model config facade.
+type ModelConfigAPI struct {
+	backend Backend
+	auth    facade.Authorizer
+	check   *common.BlockChecker
+}
+
+// NewModelConfigAPI creates a new instance of the ModelConfig Facade.
+func NewModelConfigAPI(backend Backend, authorizer facade.Authorizer) (*ModelConfigAPI, error) {
+	if !authorizer.AuthClient() {
+		return nil, common.ErrPerm
+	}
+	client := &ModelConfigAPI{
+		backend: backend,
+		auth:    authorizer,
+		check:   common.NewBlockChecker(backend),
+	}
+	return client, nil
+}
+
+// ModelGet implements the server-side part of the
+// get-model-config CLI command.
+func (c *ModelConfigAPI) ModelGet() (params.ModelConfigResults, error) {
+	result := params.ModelConfigResults{}
+	values, err := c.backend.ModelConfigValues()
+	if err != nil {
+		return result, err
+	}
+
+	// TODO(wallyworld) - this can be removed once credentials are properly
+	// managed outside of model config.
+	// Strip out any model config attributes that are credential attributes.
+	provider, err := environs.Provider(values[config.TypeKey].Value.(string))
+	if err != nil {
+		return result, err
+	}
+	credSchemas := provider.CredentialSchemas()
+	var allCredentialAttributes []string
+	for _, schema := range credSchemas {
+		for _, attr := range schema {
+			allCredentialAttributes = append(allCredentialAttributes, attr.Name)
+		}
+	}
+	isCredentialAttribute := func(attr string) bool {
+		for _, a := range allCredentialAttributes {
+			if a == attr {
+				return true
+			}
+		}
+		return false
+	}
+
+	result.Config = make(map[string]params.ConfigValue)
+	for attr, val := range values {
+		if isCredentialAttribute(attr) {
+			continue
+		}
+		// Authorized keys are able to be listed using
+		// juju ssh-keys and including them here just
+		// clutters everything.
+		if attr == config.AuthorizedKeysKey {
+			continue
+		}
+		result.Config[attr] = params.ConfigValue{
+			Value:  val.Value,
+			Source: val.Source,
+		}
+	}
+	return result, nil
+}
+
+// ModelSet implements the server-side part of the
+// set-model-config CLI command.
+func (c *ModelConfigAPI) ModelSet(args params.ModelSet) error {
+	if err := c.check.ChangeAllowed(); err != nil {
+		return errors.Trace(err)
+	}
+	// Make sure we don't allow changing agent-version.
+	checkAgentVersion := func(updateAttrs map[string]interface{}, removeAttrs []string, oldConfig *config.Config) error {
+		if v, found := updateAttrs["agent-version"]; found {
+			oldVersion, _ := oldConfig.AgentVersion()
+			if v != oldVersion.String() {
+				return errors.New("agent-version cannot be changed")
+			}
+		}
+		return nil
+	}
+	// Replace any deprecated attributes with their new values.
+	attrs := config.ProcessDeprecatedAttributes(args.Config)
+	// TODO(waigani) 2014-3-11 #1167616
+	// Add a txn retry loop to ensure that the settings on disk have not
+	// changed underneath us.
+	return c.backend.UpdateModelConfig(attrs, nil, checkAgentVersion)
+}
+
+// ModelUnset implements the server-side part of the
+// set-model-config CLI command.
+func (c *ModelConfigAPI) ModelUnset(args params.ModelUnset) error {
+	if err := c.check.ChangeAllowed(); err != nil {
+		return errors.Trace(err)
+	}
+	// TODO(waigani) 2014-3-11 #1167616
+	// Add a txn retry loop to ensure that the settings on disk have not
+	// changed underneath us.
+	return c.backend.UpdateModelConfig(nil, args.Keys, nil)
+}

--- a/apiserver/modelconfig/modelconfig_test.go
+++ b/apiserver/modelconfig/modelconfig_test.go
@@ -1,0 +1,204 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelconfig_test
+
+import (
+	"github.com/juju/errors"
+	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/modelconfig"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/provider/dummy"
+	_ "github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
+)
+
+type modelconfigSuite struct {
+	gitjujutesting.IsolationSuite
+	backend    *mockBackend
+	authorizer apiservertesting.FakeAuthorizer
+	api        *modelconfig.ModelConfigAPI
+}
+
+var _ = gc.Suite(&modelconfigSuite{})
+
+func (s *modelconfigSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.authorizer = apiservertesting.FakeAuthorizer{
+		Tag: names.NewUserTag("bruce@local"),
+	}
+	s.backend = &mockBackend{
+		cfg: config.ConfigValues{
+			"type":            {"dummy", "model"},
+			"agent-version":   {"1.2.3.4", "model"},
+			"ftp-proxy":       {"http://proxy", "model"},
+			"authorized-keys": {testing.FakeAuthKeys, "model"},
+		},
+	}
+	var err error
+	s.api, err = modelconfig.NewModelConfigAPI(s.backend, &s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *modelconfigSuite) TestClientModelGet(c *gc.C) {
+	result, err := s.api.ModelGet()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Config, gc.DeepEquals, map[string]params.ConfigValue{
+		"type":          {"dummy", "model"},
+		"ftp-proxy":     {"http://proxy", "model"},
+		"agent-version": {Value: "1.2.3.4", Source: "model"},
+	})
+}
+
+func (s *modelconfigSuite) assertConfigValue(c *gc.C, key string, expected interface{}) {
+	value, found := s.backend.cfg[key]
+	c.Assert(found, jc.IsTrue)
+	c.Assert(value.Value, gc.Equals, expected)
+}
+
+func (s *modelconfigSuite) assertConfigValueMissing(c *gc.C, key string) {
+	_, found := s.backend.cfg[key]
+	c.Assert(found, jc.IsFalse)
+}
+
+func (s *modelconfigSuite) TestClientModelSet(c *gc.C) {
+	params := params.ModelSet{
+		Config: map[string]interface{}{
+			"some-key":  "value",
+			"other-key": "other value"},
+	}
+	err := s.api.ModelSet(params)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertConfigValue(c, "some-key", "value")
+	s.assertConfigValue(c, "other-key", "other value")
+}
+
+func (s *modelconfigSuite) blockAllChanges(c *gc.C, msg string) {
+	s.backend.msg = msg
+	s.backend.b = state.ChangeBlock
+}
+
+func (s *modelconfigSuite) assertBlocked(c *gc.C, err error, msg string) {
+	c.Assert(params.IsCodeOperationBlocked(err), jc.IsTrue, gc.Commentf("error: %#v", err))
+	c.Assert(errors.Cause(err), gc.DeepEquals, &params.Error{
+		Message: msg,
+		Code:    "operation is blocked",
+	})
+}
+
+func (s *modelconfigSuite) assertModelSetBlocked(c *gc.C, args map[string]interface{}, msg string) {
+	err := s.api.ModelSet(params.ModelSet{args})
+	s.assertBlocked(c, err, msg)
+}
+
+func (s *modelconfigSuite) TestBlockChangesClientModelSet(c *gc.C) {
+	s.blockAllChanges(c, "TestBlockChangesClientModelSet")
+	args := map[string]interface{}{"some-key": "value"}
+	s.assertModelSetBlocked(c, args, "TestBlockChangesClientModelSet")
+}
+
+func (s *modelconfigSuite) TestClientModelSetCannotChangeAgentVersion(c *gc.C) {
+	old, err := config.New(config.UseDefaults, dummy.SampleConfig().Merge(testing.Attrs{
+		"agent-version": "1.2.3.4",
+	}))
+	c.Assert(err, jc.ErrorIsNil)
+	s.backend.old = old
+	args := params.ModelSet{
+		map[string]interface{}{"agent-version": "9.9.9"},
+	}
+	err = s.api.ModelSet(args)
+	c.Assert(err, gc.ErrorMatches, "agent-version cannot be changed")
+
+	// It's okay to pass config back with the same agent-version.
+	result, err := s.api.ModelGet()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Config["agent-version"], gc.NotNil)
+	args.Config["agent-version"] = result.Config["agent-version"].Value
+	err = s.api.ModelSet(args)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *modelconfigSuite) TestClientModelUnset(c *gc.C) {
+	err := s.backend.UpdateModelConfig(map[string]interface{}{"abc": 123}, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	args := params.ModelUnset{[]string{"abc"}}
+	err = s.api.ModelUnset(args)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertConfigValueMissing(c, "abc")
+}
+
+func (s *modelconfigSuite) TestBlockClientModelUnset(c *gc.C) {
+	err := s.backend.UpdateModelConfig(map[string]interface{}{"abc": 123}, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.blockAllChanges(c, "TestBlockClientModelUnset")
+
+	args := params.ModelUnset{[]string{"abc"}}
+	err = s.api.ModelUnset(args)
+	s.assertBlocked(c, err, "TestBlockClientModelUnset")
+}
+
+func (s *modelconfigSuite) TestClientModelUnsetMissing(c *gc.C) {
+	// It's okay to unset a non-existent attribute.
+	args := params.ModelUnset{[]string{"not_there"}}
+	err := s.api.ModelUnset(args)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+type mockBackend struct {
+	cfg config.ConfigValues
+	old *config.Config
+	b   state.BlockType
+	msg string
+}
+
+func (m *mockBackend) ModelConfigValues() (config.ConfigValues, error) {
+	return m.cfg, nil
+}
+
+func (m *mockBackend) UpdateModelConfig(update map[string]interface{}, remove []string, validate state.ValidateConfigFunc) error {
+	if validate != nil {
+		err := validate(update, remove, m.old)
+		if err != nil {
+			return err
+		}
+	}
+	for k, v := range update {
+		m.cfg[k] = config.ConfigValue{v, "model"}
+	}
+	for _, n := range remove {
+		delete(m.cfg, n)
+	}
+	return nil
+}
+
+func (m *mockBackend) GetBlockForType(t state.BlockType) (state.Block, bool, error) {
+	if m.b == t {
+		return &mockBlock{t: t, m: m.msg}, true, nil
+	} else {
+		return nil, false, nil
+	}
+}
+
+type mockBlock struct {
+	state.Block
+	t state.BlockType
+	m string
+}
+
+func (m mockBlock) Id() string { return "" }
+
+func (m mockBlock) Tag() (names.Tag, error) { return names.NewModelTag("mocktesting"), nil }
+
+func (m mockBlock) Type() state.BlockType { return m.t }
+
+func (m mockBlock) Message() string { return m.m }
+
+func (m mockBlock) ModelUUID() string { return "" }

--- a/apiserver/modelconfig/package_test.go
+++ b/apiserver/modelconfig/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelconfig_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -473,6 +473,9 @@ func (s *UpgradeJujuSuite) TestFailUploadOnNonController(c *gc.C) {
 	s.PatchValue(&getUpgradeJujuAPI, func(*upgradeJujuCommand) (upgradeJujuAPI, error) {
 		return fakeAPI, nil
 	})
+	s.PatchValue(&getModelConfigAPI, func(*upgradeJujuCommand) (modelConfigAPI, error) {
+		return fakeAPI, nil
+	})
 	cmd := newUpgradeJujuCommand(nil)
 	_, err := coretesting.RunCommand(c, cmd, "--upload-tools", "-m", "dummy-model")
 	c.Assert(err, gc.ErrorMatches, "--upload-tools can only be used with the controller model")
@@ -876,6 +879,9 @@ func (a *fakeUpgradeJujuAPI) reset() {
 
 func (a *fakeUpgradeJujuAPI) patch(s *UpgradeJujuSuite) {
 	s.PatchValue(&getUpgradeJujuAPI, func(*upgradeJujuCommand) (upgradeJujuAPI, error) {
+		return a, nil
+	})
+	s.PatchValue(&getModelConfigAPI, func(*upgradeJujuCommand) (modelConfigAPI, error) {
 		return a, nil
 	})
 }

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -95,7 +95,7 @@ func (s *AddMachineSuite) TestInit(c *gc.C) {
 		},
 	} {
 		c.Logf("test %d", i)
-		wrappedCommand, addCmd := machine.NewAddCommandForTest(s.fakeAddMachine, s.fakeMachineManager)
+		wrappedCommand, addCmd := machine.NewAddCommandForTest(s.fakeAddMachine, s.fakeAddMachine, s.fakeMachineManager)
 		err := testing.InitCommand(wrappedCommand, test.args)
 		if test.errorString == "" {
 			c.Check(err, jc.ErrorIsNil)
@@ -114,7 +114,7 @@ func (s *AddMachineSuite) TestInit(c *gc.C) {
 }
 
 func (s *AddMachineSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
-	add, _ := machine.NewAddCommandForTest(s.fakeAddMachine, s.fakeMachineManager)
+	add, _ := machine.NewAddCommandForTest(s.fakeAddMachine, s.fakeAddMachine, s.fakeMachineManager)
 	return testing.RunCommand(c, add, args...)
 }
 

--- a/cmd/juju/machine/export_test.go
+++ b/cmd/juju/machine/export_test.go
@@ -19,10 +19,11 @@ type AddCommand struct {
 }
 
 // NewAddCommand returns an AddCommand with the api provided as specified.
-func NewAddCommandForTest(api AddMachineAPI, mmApi MachineManagerAPI) (cmd.Command, *AddCommand) {
+func NewAddCommandForTest(api AddMachineAPI, mcApi ModelConfigAPI, mmApi MachineManagerAPI) (cmd.Command, *AddCommand) {
 	cmd := &addCommand{
 		api:               api,
 		machineManagerAPI: mmApi,
+		modelConfigAPI:    mcApi,
 	}
 	return modelcmd.Wrap(cmd), &AddCommand{cmd}
 }

--- a/cmd/juju/model/get.go
+++ b/cmd/juju/model/get.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/errors"
 	"launchpad.net/gnuflag"
 
+	"github.com/juju/juju/api/modelconfig"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs/config"
 )
@@ -79,7 +80,11 @@ func (c *getCommand) getAPI() (GetModelAPI, error) {
 	if c.api != nil {
 		return c.api, nil
 	}
-	return c.NewAPIClient()
+	api, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, errors.Annotate(err, "opening API connection")
+	}
+	return modelconfig.NewClient(api), nil
 }
 
 func (c *getCommand) Run(ctx *cmd.Context) error {

--- a/cmd/juju/model/set.go
+++ b/cmd/juju/model/set.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/keyvalues"
 
+	"github.com/juju/juju/api/modelconfig"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 )
@@ -81,7 +82,11 @@ func (c *setCommand) getAPI() (SetModelAPI, error) {
 	if c.api != nil {
 		return c.api, nil
 	}
-	return c.NewAPIClient()
+	api, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, errors.Annotate(err, "opening API connection")
+	}
+	return modelconfig.NewClient(api), nil
 }
 
 func (c *setCommand) Run(ctx *cmd.Context) error {

--- a/cmd/juju/model/unset.go
+++ b/cmd/juju/model/unset.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/api/modelconfig"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 )
@@ -69,7 +70,11 @@ func (c *unsetCommand) getAPI() (UnsetModelAPI, error) {
 	if c.api != nil {
 		return c.api, nil
 	}
-	return c.NewAPIClient()
+	api, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, errors.Annotate(err, "opening API connection")
+	}
+	return modelconfig.NewClient(api), nil
 }
 
 func (c *unsetCommand) Run(ctx *cmd.Context) error {


### PR DESCRIPTION
A new facade - ModelConfig - is introduced. APIs used to get/set model config are moved off the client facade and re-homed on the new facade.

Much of this PR is simply moving code. A few commands - bundle, deploy, upgrade-juju, add machine - needed to be tweaked to use the new modelconfig client in addition to the old client.

To allow existing clients to continue to work, the client facade retains via an embedded ModelConfig apiserver the server side endpoints for callers using the client facade. This will be removed once the GUI and Python Juju client are updated.

(Review request: http://reviews.vapour.ws/r/5279/)