### PR TITLE
Adds ControllerUser

### DIFF
--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -136,14 +136,14 @@ func (c *Client) DestroyModel() error {
 
 // ParseModelAccess parses an access permission argument into
 // a type suitable for making an API facade call.
-func ParseModelAccess(access string) (params.ModelAccessPermission, error) {
-	var fail params.ModelAccessPermission
+func ParseModelAccess(access string) (params.UserAccessPermission, error) {
+	var fail params.UserAccessPermission
 
 	modelAccess, err := permission.ParseModelAccess(access)
 	if err != nil {
 		return fail, errors.Trace(err)
 	}
-	var accessPermission params.ModelAccessPermission
+	var accessPermission params.UserAccessPermission
 	switch modelAccess {
 	case permission.ModelReadAccess:
 		accessPermission = params.ModelReadAccess

--- a/api/usermanager/client.go
+++ b/api/usermanager/client.go
@@ -46,7 +46,7 @@ func (c *Client) AddUser(
 		modelTags[i] = names.NewModelTag(uuid).String()
 	}
 
-	var accessPermission params.ModelAccessPermission
+	var accessPermission params.UserAccessPermission
 	var err error
 	if len(modelTags) > 0 {
 		accessPermission, err = modelmanager.ParseModelAccess(access)

--- a/api/usermanager/client_test.go
+++ b/api/usermanager/client_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/api/usermanager"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/description"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
@@ -58,11 +59,11 @@ func (s *usermanagerSuite) TestAddUserWithModelAccess(c *gc.C) {
 	c.Assert(users, gc.HasLen, 3)
 	var modelUserTags = make([]names.UserTag, len(users))
 	for i, u := range users {
-		modelUserTags[i] = u.UserTag()
-		if u.UserTag().Name() == "foobar" {
-			c.Assert(u.IsReadOnly(), jc.IsTrue)
+		modelUserTags[i] = u.UserTag
+		if u.UserTag.Name() == "foobar" {
+			c.Assert(u.Access, gc.Equals, description.ReadAccess)
 		} else {
-			c.Assert(u.IsReadOnly(), jc.IsFalse)
+			c.Assert(u.Access, gc.Not(gc.Equals), description.ReadAccess)
 		}
 	}
 	c.Assert(modelUserTags, jc.SameContents, []names.UserTag{

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -809,9 +809,9 @@ func (s *loginSuite) TestLoginUpdatesLastLoginAndConnection(c *gc.C) {
 	c.Assert(lastLogin.After(startTime), jc.IsTrue)
 
 	// The env user is also updated.
-	modelUser, err := s.State.ModelUser(user.UserTag())
+	modelUser, err := s.State.UserAccess(user.UserTag(), s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
-	when, err := modelUser.LastConnection()
+	when, err := s.State.LastModelConnection(modelUser.UserTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(when, gc.NotNil)
 	c.Assert(when.After(startTime), jc.IsTrue)

--- a/apiserver/authhttp_test.go
+++ b/apiserver/authhttp_test.go
@@ -24,6 +24,7 @@ import (
 
 	apitesting "github.com/juju/juju/api/testing"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -234,9 +235,10 @@ func (s *authHttpSuite) setupOtherModel(c *gc.C) *state.State {
 	envState := s.Factory.MakeModel(c, nil)
 	s.AddCleanup(func(*gc.C) { envState.Close() })
 	user := s.Factory.MakeUser(c, nil)
-	_, err := envState.AddModelUser(state.ModelUserSpec{
+	_, err := envState.AddModelUser(state.UserAccessSpec{
 		User:      user.UserTag(),
-		CreatedBy: s.userTag})
+		CreatedBy: s.userTag,
+		Access:    description.ReadAccess})
 	c.Assert(err, jc.ErrorIsNil)
 	s.userTag = user.UserTag()
 	s.password = "password"

--- a/apiserver/client/backend.go
+++ b/apiserver/client/backend.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
@@ -58,8 +59,9 @@ type Backend interface {
 	Charm(*charm.URL) (*state.Charm, error)
 	LatestPlaceholderCharm(*charm.URL) (*state.Charm, error)
 	AddRelation(...state.Endpoint) (*state.Relation, error)
-	AddModelUser(state.ModelUserSpec) (*state.ModelUser, error)
-	RemoveModelUser(names.UserTag) error
+	AddModelUser(state.UserAccessSpec) (description.UserAccess, error)
+	AddControllerUser(state.UserAccessSpec) (description.UserAccess, error)
+	RemoveUserAccess(names.UserTag, names.Tag) error
 	Watch() *state.Multiwatcher
 	AbortCurrentUpgrade() error
 	APIHostPorts() ([][]network.HostPort, error)

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/modelconfig"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/manual"
@@ -380,6 +381,10 @@ func (c *Client) ModelInfo() (params.ModelInfo, error) {
 	return info, nil
 }
 
+func modelInfo(st *state.State, user description.UserAccess) (params.ModelUserInfo, error) {
+	return common.ModelUserInfo(user, st)
+}
+
 // ModelUserInfo returns information on all users in the model.
 func (c *Client) ModelUserInfo() (params.ModelUserInfoResults, error) {
 	var results params.ModelUserInfoResults
@@ -394,7 +399,7 @@ func (c *Client) ModelUserInfo() (params.ModelUserInfoResults, error) {
 
 	for _, user := range users {
 		var result params.ModelUserInfoResult
-		userInfo, err := common.ModelUserInfo(user)
+		userInfo, err := modelInfo(c.api.state(), user)
 		if err != nil {
 			result.Error = common.ServerError(err)
 		} else {

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/description"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
@@ -85,10 +86,11 @@ func (s *controllerSuite) TestAllModels(c *gc.C) {
 	st := s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "user", Owner: remoteUserTag})
 	defer st.Close()
-	st.AddModelUser(state.ModelUserSpec{
+	st.AddModelUser(state.UserAccessSpec{
 		User:        admin.UserTag(),
 		CreatedBy:   remoteUserTag,
-		DisplayName: "Foo Bar"})
+		DisplayName: "Foo Bar",
+		Access:      description.ReadAccess})
 
 	s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "no-access", Owner: remoteUserTag}).Close()
@@ -258,7 +260,7 @@ func (s *controllerSuite) TestModelStatus(c *gc.C) {
 	otherEnvOwner := s.Factory.MakeModelUser(c, nil)
 	otherSt := s.Factory.MakeModel(c, &factory.ModelParams{
 		Name:  "dummytoo",
-		Owner: otherEnvOwner.UserTag(),
+		Owner: otherEnvOwner.UserTag,
 		ConfigAttrs: testing.Attrs{
 			"controller": false,
 		},
@@ -296,7 +298,7 @@ func (s *controllerSuite) TestModelStatus(c *gc.C) {
 		ModelTag:           hostedEnvTag,
 		HostedMachineCount: 2,
 		ApplicationCount:   1,
-		OwnerTag:           otherEnvOwner.UserTag().String(),
+		OwnerTag:           otherEnvOwner.UserTag.String(),
 		Life:               params.Alive,
 	}})
 }

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 )
@@ -30,6 +31,7 @@ var (
 	BZMimeType                   = bzMimeType
 	JSMimeType                   = jsMimeType
 	SpritePath                   = spritePath
+	HasPermission                = hasPermission
 )
 
 func ServerMacaroon(srv *Server) (*macaroon.Macaroon, error) {
@@ -104,7 +106,7 @@ func TestingApiHandler(c *gc.C, srvSt, st *state.State) (*apiHandler, *common.Re
 	return h, h.getResources()
 }
 
-// TestingApiHandlerWithEntity gives you the sane kind of ApiHandler than
+// TestingApiHandlerWithEntity gives you the sane kind of ApiHandler as
 // TestingApiHandler but sets the passed entity as the apiHandler
 // entity.
 func TestingApiHandlerWithEntity(c *gc.C, srvSt, st *state.State, entity state.Entity) (*apiHandler, *common.Resources) {
@@ -222,4 +224,10 @@ func PatchGetControllerCACert(p Patcher, caCert string) {
 // CleanupSuite
 type Patcher interface {
 	PatchValue(ptr, value interface{})
+}
+
+func AssertHasPermission(c *gc.C, handler *apiHandler, access description.Access, tag names.Tag, expect bool) {
+	hasPermission, err := handler.HasPermission(access, tag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(hasPermission, gc.Equals, expect)
 }

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -104,6 +104,15 @@ func TestingApiHandler(c *gc.C, srvSt, st *state.State) (*apiHandler, *common.Re
 	return h, h.getResources()
 }
 
+// TestingApiHandlerWithEntity gives you the sane kind of ApiHandler than
+// TestingApiHandler but sets the passed entity as the apiHandler
+// entity.
+func TestingApiHandlerWithEntity(c *gc.C, srvSt, st *state.State, entity state.Entity) (*apiHandler, *common.Resources) {
+	h, hr := TestingApiHandler(c, srvSt, st)
+	h.entity = entity
+	return h, hr
+}
+
 // TestingUpgradingRoot returns a limited srvRoot
 // in an upgrade scenario.
 func TestingUpgradingRoot(st *state.State) rpc.MethodFinder {

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -94,8 +94,8 @@ type Authorizer interface {
 	AuthClient() bool
 
 	// HasPermission returns true if the given access is allowed for the given
-	// terget by the authenticated entity.
-	HasPermission(operation description.Access, target names.Tag) bool
+	// target by the authenticated entity.
+	HasPermission(operation description.Access, target names.Tag) (bool, error)
 }
 
 // Resources allows you to store and retrieve Resource implementations.

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -6,6 +6,7 @@ package facade
 import (
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/state"
 )
 
@@ -91,6 +92,10 @@ type Authorizer interface {
 	// Doesn't need to be on this interface, should be a utility
 	// func if anything.
 	AuthClient() bool
+
+	// HasPermission returns true if the given access is allowed for the given
+	// terget by the authenticated entity.
+	HasPermission(operation description.Access, target names.Tag) bool
 }
 
 // Resources allows you to store and retrieve Resource implementations.

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -4,6 +4,7 @@
 package modelmanager_test
 
 import (
+	"strings"
 	"time"
 
 	"github.com/juju/errors"
@@ -83,10 +84,6 @@ func (s *modelInfoSuite) setAPIUser(c *gc.C, user names.UserTag) {
 }
 
 func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
-	s.st.model.users[1].SetErrors(
-		state.NeverConnectedError("never connected"),
-		nil, nil, nil, nil,
-	)
 	info := s.getModelInfo(c)
 	c.Assert(info, jc.DeepEquals, params.ModelInfo{
 		Name:            "testenv",
@@ -110,7 +107,7 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		}, {
 			UserName:       "bob@local",
 			DisplayName:    "Bob",
-			LastConnection: nil, // never connected
+			LastConnection: &time.Time{},
 			Access:         params.ModelReadAccess,
 		}, {
 			UserName:       "charlotte@local",
@@ -125,11 +122,17 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		{"ForModel", []interface{}{names.NewModelTag(s.st.model.cfg.UUID())}},
 		{"Model", nil},
 		{"ControllerConfig", nil},
+		{"LastModelConnection", []interface{}{names.NewUserTag("admin")}},
+		{"LastModelConnection", []interface{}{names.NewLocalUserTag("bob")}},
+		{"LastModelConnection", []interface{}{names.NewLocalUserTag("charlotte")}},
 		{"Close", nil},
 	})
 	s.st.model.CheckCalls(c, []gitjujutesting.StubCall{
 		{"Config", nil},
 		{"Users", nil},
+		{"ModelTag", nil},
+		{"ModelTag", nil},
+		{"ModelTag", nil},
 		{"Status", nil},
 		{"Owner", nil},
 		{"Life", nil},
@@ -217,7 +220,7 @@ type mockState struct {
 	cloud           cloud.Cloud
 	model           *mockModel
 	controllerModel *mockModel
-	users           []*state.ModelUser
+	users           []description.UserAccess
 	creds           map[string]cloud.Credential
 }
 
@@ -251,7 +254,7 @@ func (st *mockState) IsControllerAdministrator(user names.UserTag) (bool, error)
 	}
 
 	for _, u := range st.controllerModel.users {
-		if user.Name() == u.UserName() && u.access == description.AdminAccess {
+		if user.Name() == u.userName && u.access == description.AdminAccess {
 			nextErr := st.NextErr()
 			if user.Name() != "admin" {
 				panic(user.Name())
@@ -325,9 +328,14 @@ func (st *mockState) Close() error {
 	return st.NextErr()
 }
 
-func (st *mockState) AddModelUser(spec state.ModelUserSpec) (*state.ModelUser, error) {
+func (st *mockState) AddModelUser(spec state.UserAccessSpec) (description.UserAccess, error) {
 	st.MethodCall(st, "AddModelUser", spec)
-	return nil, st.NextErr()
+	return description.UserAccess{}, st.NextErr()
+}
+
+func (st *mockState) AddControllerUser(spec state.UserAccessSpec) (description.UserAccess, error) {
+	st.MethodCall(st, "AddControllerUser", spec)
+	return description.UserAccess{}, st.NextErr()
 }
 
 func (st *mockState) RemoveModelUser(tag names.UserTag) error {
@@ -335,9 +343,24 @@ func (st *mockState) RemoveModelUser(tag names.UserTag) error {
 	return st.NextErr()
 }
 
-func (st *mockState) ModelUser(tag names.UserTag) (*state.ModelUser, error) {
-	st.MethodCall(st, "ModelUser", tag)
-	return nil, st.NextErr()
+func (st *mockState) UserAccess(tag names.UserTag, target names.Tag) (description.UserAccess, error) {
+	st.MethodCall(st, "ModelUser", tag, target)
+	return description.UserAccess{}, st.NextErr()
+}
+
+func (st *mockState) LastModelConnection(user names.UserTag) (time.Time, error) {
+	st.MethodCall(st, "LastModelConnection", user)
+	return time.Time{}, st.NextErr()
+}
+
+func (st *mockState) RemoveUserAccess(subject names.UserTag, target names.Tag) error {
+	st.MethodCall(st, "RemoveUserAccess", subject, target)
+	return st.NextErr()
+}
+
+func (st *mockState) SetUserAccess(subject names.UserTag, target names.Tag, access description.Access) (description.UserAccess, error) {
+	st.MethodCall(st, "SetUserAccess", subject, target, access)
+	return description.UserAccess{}, st.NextErr()
 }
 
 type mockModel struct {
@@ -396,14 +419,21 @@ func (m *mockModel) CloudCredential() string {
 	return "some-credential"
 }
 
-func (m *mockModel) Users() ([]common.ModelUser, error) {
+func (m *mockModel) Users() ([]description.UserAccess, error) {
 	m.MethodCall(m, "Users")
 	if err := m.NextErr(); err != nil {
 		return nil, err
 	}
-	users := make([]common.ModelUser, len(m.users))
+	users := make([]description.UserAccess, len(m.users))
 	for i, user := range m.users {
-		users[i] = user
+		users[i] = description.UserAccess{
+			UserID:      strings.ToLower(user.userName),
+			UserTag:     names.NewUserTag(user.userName),
+			Object:      m.ModelTag(),
+			Access:      user.access,
+			DisplayName: user.displayName,
+			UserName:    user.userName,
+		}
 	}
 	return users, nil
 }
@@ -424,45 +454,4 @@ type mockModelUser struct {
 	displayName    string
 	lastConnection time.Time
 	access         description.Access
-}
-
-func (u *mockModelUser) IsAdmin() bool {
-	u.MethodCall(u, "IsAdmin")
-	u.PopNoErr()
-	return u.access == description.AdminAccess
-}
-
-func (u *mockModelUser) IsReadOnly() bool {
-	u.MethodCall(u, "IsReadOnly")
-	u.PopNoErr()
-	return u.access == description.ReadAccess
-}
-
-func (u *mockModelUser) IsReadWrite() bool {
-	u.MethodCall(u, "IsReadWrite")
-	u.PopNoErr()
-	return u.access == description.WriteAccess
-}
-
-func (u *mockModelUser) DisplayName() string {
-	u.MethodCall(u, "DisplayName")
-	u.PopNoErr()
-	return u.displayName
-}
-
-func (u *mockModelUser) LastConnection() (time.Time, error) {
-	u.MethodCall(u, "LastConnection")
-	return u.lastConnection, u.NextErr()
-}
-
-func (u *mockModelUser) UserName() string {
-	u.MethodCall(u, "UserName")
-	u.PopNoErr()
-	return u.userName
-}
-
-func (u *mockModelUser) UserTag() names.UserTag {
-	u.MethodCall(u, "UserTag")
-	u.PopNoErr()
-	return names.NewUserTag(u.userName)
 }

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -621,6 +621,8 @@ func ChangeModelAccess(accessor common.ModelManagerBackend, modelTag names.Model
 	}
 
 	// Default to read access if not otherwise specified.
+	// TODO(perrito666) If the client does not know what it wants
+	// perhaps we should just err out.
 	if stateAccess == description.UndefinedAccess {
 		stateAccess = description.ReadAccess
 	}

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -102,10 +102,10 @@ type ModelInfoListResults struct {
 // model. Owners of a model can see this information for all users
 // who have access, so it should not include sensitive information.
 type ModelUserInfo struct {
-	UserName       string                `json:"user"`
-	DisplayName    string                `json:"display-name"`
-	LastConnection *time.Time            `json:"last-connection"`
-	Access         ModelAccessPermission `json:"access"`
+	UserName       string               `json:"user"`
+	DisplayName    string               `json:"display-name"`
+	LastConnection *time.Time           `json:"last-connection"`
+	Access         UserAccessPermission `json:"access"`
 }
 
 // ModelUserInfoResult holds the result of an ModelUserInfo call.
@@ -125,10 +125,10 @@ type ModifyModelAccessRequest struct {
 }
 
 type ModifyModelAccess struct {
-	UserTag  string                `json:"user-tag"`
-	Action   ModelAction           `json:"action"`
-	Access   ModelAccessPermission `json:"access"`
-	ModelTag string                `json:"model-tag"`
+	UserTag  string               `json:"user-tag"`
+	Action   ModelAction          `json:"action"`
+	Access   UserAccessPermission `json:"access"`
+	ModelTag string               `json:"model-tag"`
 }
 
 // ModelAction is an action that can be performed on a model.
@@ -140,13 +140,13 @@ const (
 	RevokeModelAccess ModelAction = "revoke"
 )
 
-// ModelAccessPermission is the type of permission that a user has to access a
+// UserAccessPermission is the type of permission that a user has to access a
 // model.
-type ModelAccessPermission string
+type UserAccessPermission string
 
 // Model access permissions that may be set on a user.
 const (
-	ModelAdminAccess ModelAccessPermission = "admin"
-	ModelReadAccess  ModelAccessPermission = "read"
-	ModelWriteAccess ModelAccessPermission = "write"
+	ModelAdminAccess UserAccessPermission = "admin"
+	ModelReadAccess  UserAccessPermission = "read"
+	ModelWriteAccess UserAccessPermission = "write"
 )

--- a/apiserver/params/usermanager.go
+++ b/apiserver/params/usermanager.go
@@ -54,7 +54,7 @@ type AddUser struct {
 	Password string `json:"password,omitempty"`
 
 	// ModelAccess is the permission that the user will have to access the models.
-	ModelAccess ModelAccessPermission `json:"model-access-permission,omitempty"`
+	ModelAccess UserAccessPermission `json:"model-access-permission,omitempty"`
 }
 
 // AddUserResults holds the results of the bulk AddUser API call.

--- a/apiserver/root_test.go
+++ b/apiserver/root_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -16,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/rpc/rpcreflect"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
@@ -399,4 +401,112 @@ func (r *rootSuite) TestAuthOwner(c *gc.C) {
 	authorized = apiHandler.AuthOwner(incorrectTag)
 
 	c.Check(authorized, jc.IsFalse)
+}
+
+type fakeUserAccess struct {
+	subjects []names.UserTag
+	objects  []names.Tag
+	user     description.UserAccess
+	err      error
+}
+
+func (f *fakeUserAccess) call(subject names.UserTag, object names.Tag) (description.UserAccess, error) {
+	f.subjects = append(f.subjects, subject)
+	f.objects = append(f.objects, object)
+	return f.user, f.err
+}
+
+func (r *rootSuite) TestNoUserTagLacksPermission(c *gc.C) {
+	nonUser := names.NewModelTag("beef1beef1-0000-0000-000011112222")
+	target := names.NewModelTag("beef1beef2-0000-0000-000011112222")
+	hasPermission, err := apiserver.HasPermission((&fakeUserAccess{}).call, nonUser, description.ReadAccess, target)
+	c.Assert(hasPermission, jc.IsFalse)
+	c.Assert(err, gc.ErrorMatches, "obtaining permission for subject kind \"model\" not valid")
+}
+
+func (r *rootSuite) TestHasPermission(c *gc.C) {
+	testCases := []struct {
+		title            string
+		userGetterAccess description.Access
+		user             names.UserTag
+		target           names.Tag
+		access           description.Access
+		expected         bool
+	}{
+		{
+			title:            "user has lesser permissions than required",
+			userGetterAccess: description.ReadAccess,
+			user:             names.NewUserTag("validuser"),
+			target:           names.NewModelTag("beef1beef2-0000-0000-000011112222"),
+			access:           description.WriteAccess,
+			expected:         false,
+		},
+		{
+			title:            "user has equal permission than required",
+			userGetterAccess: description.WriteAccess,
+			user:             names.NewUserTag("validuser"),
+			target:           names.NewModelTag("beef1beef2-0000-0000-000011112222"),
+			access:           description.WriteAccess,
+			expected:         true,
+		},
+		{
+			title:            "user has greater permission than required",
+			userGetterAccess: description.AdminAccess,
+			user:             names.NewUserTag("validuser"),
+			target:           names.NewModelTag("beef1beef2-0000-0000-000011112222"),
+			access:           description.WriteAccess,
+			expected:         true,
+		},
+		{
+			title:            "user requests model permission on controller",
+			userGetterAccess: description.AdminAccess,
+			user:             names.NewUserTag("validuser"),
+			target:           names.NewModelTag("beef1beef2-0000-0000-000011112222"),
+			access:           description.AddModelAccess,
+			expected:         false,
+		},
+		{
+			title:            "user requests controller permission on model",
+			userGetterAccess: description.AdminAccess,
+			user:             names.NewUserTag("validuser"),
+			target:           names.NewControllerTag("beef1beef2-0000-0000-000011112222"),
+			access:           description.AdminAccess, // notice user has this permission for model.
+			expected:         false,
+		},
+		{
+			title:            "controller permissions also work",
+			userGetterAccess: description.AddModelAccess,
+			user:             names.NewUserTag("validuser"),
+			target:           names.NewControllerTag("beef1beef2-0000-0000-000011112222"),
+			access:           description.AddModelAccess,
+			expected:         true,
+		},
+	}
+	for i, t := range testCases {
+		userGetter := &fakeUserAccess{
+			user: description.UserAccess{
+				Access: t.userGetterAccess,
+			}}
+		c.Logf("HasPermission test n %d: %s", i, t.title)
+		hasPermission, err := apiserver.HasPermission(userGetter.call, t.user, t.access, t.target)
+		c.Assert(hasPermission, gc.Equals, t.expected)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+}
+
+func (r *rootSuite) TestUserGetterErrorReturns(c *gc.C) {
+	user := names.NewUserTag("validuser")
+	target := names.NewModelTag("beef1beef2-0000-0000-000011112222")
+	userGetter := &fakeUserAccess{
+		user: description.UserAccess{},
+		err:  errors.NotFoundf("a user"),
+	}
+	hasPermission, err := apiserver.HasPermission(userGetter.call, user, description.ReadAccess, target)
+	c.Assert(hasPermission, jc.IsFalse)
+	c.Assert(err, gc.ErrorMatches, "while obtaining model user: a user not found")
+	c.Assert(userGetter.subjects, gc.HasLen, 1)
+	c.Assert(userGetter.subjects[0], gc.DeepEquals, user)
+	c.Assert(userGetter.objects, gc.HasLen, 1)
+	c.Assert(userGetter.objects[0], gc.DeepEquals, target)
 }

--- a/apiserver/testing/fakeauthorizer.go
+++ b/apiserver/testing/fakeauthorizer.go
@@ -4,8 +4,9 @@
 package testing
 
 import (
-	"github.com/juju/juju/core/description"
 	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/core/description"
 )
 
 // FakeAuthorizer implements the facade.Authorizer interface.
@@ -45,7 +46,7 @@ func (fa FakeAuthorizer) GetAuthTag() names.Tag {
 	return fa.Tag
 }
 
-func (fa FakeAuthorizer) HasPermission(operation description.Access, target names.Tag) bool {
+func (fa FakeAuthorizer) HasPermission(operation description.Access, target names.Tag) (bool, error) {
 	// TODO(perrito666) provide a way to pre-set the desired result here.
-	return fa.Tag == target
+	return fa.Tag == target, nil
 }

--- a/apiserver/testing/fakeauthorizer.go
+++ b/apiserver/testing/fakeauthorizer.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"github.com/juju/juju/core/description"
 	"gopkg.in/juju/names.v2"
 )
 
@@ -42,4 +43,9 @@ func (fa FakeAuthorizer) AuthClient() bool {
 
 func (fa FakeAuthorizer) GetAuthTag() names.Tag {
 	return fa.Tag
+}
+
+func (fa FakeAuthorizer) HasPermission(operation description.Access, target names.Tag) bool {
+	// TODO(perrito666) provide a way to pre-set the desired result here.
+	return fa.Tag == target
 }

--- a/core/description/access.go
+++ b/core/description/access.go
@@ -36,7 +36,7 @@ const (
 	// AddModelAccess allows user to add new models in subjects supporting it.
 	AddModelAccess Access = "addmodel"
 
-	// SuperUserAccess allows user unrestricted permissions in the subject.
+	// SuperuserAccess allows user unrestricted permissions in the subject.
 	SuperuserAccess Access = "superuser"
 )
 
@@ -50,9 +50,29 @@ func (a Access) Validate() error {
 	return errors.NotValidf("access level %s", a)
 }
 
+// ValidateModelAccess returns error if the passed access is not a valid
+// model access level.
+func ValidateModelAccess(access Access) error {
+	switch access {
+	case ReadAccess, WriteAccess, AdminAccess:
+		return nil
+	}
+	return errors.NotValidf("%q model access", access)
+}
+
+//ValidateControllerAccess returns error if the passed access is not a valid
+// controller access level.
+func ValidateControllerAccess(access Access) error {
+	switch access {
+	case LoginAccess, AddModelAccess, SuperuserAccess:
+		return nil
+	}
+	return errors.NotValidf("%q controller access", access)
+}
+
 // EqualOrGreaterAccessThan returns true if the provided access is equal or
 // less than the current.
-func (a Access) EqualOrGreaterAccessThan(access Access) bool {
+func (a Access) EqualOrGreaterModelAccessThan(access Access) bool {
 	if a == access {
 		return true
 	}
@@ -67,7 +87,17 @@ func (a Access) EqualOrGreaterAccessThan(access Access) bool {
 	case AdminAccess:
 		return access == ReadAccess ||
 			access == WriteAccess
-	// Controller permissions
+	}
+	return false
+}
+
+func (a Access) EqualOrGreaterControllerAccessThan(access Access) bool {
+	if a == access {
+		return true
+	}
+	switch a {
+	case UndefinedAccess:
+		return false
 	case LoginAccess:
 		return access == UndefinedAccess
 	case AddModelAccess:
@@ -77,32 +107,6 @@ func (a Access) EqualOrGreaterAccessThan(access Access) bool {
 		return access == UndefinedAccess ||
 			access == LoginAccess ||
 			access == AddModelAccess
-	}
-	return false
-}
-
-// LessAccessThan returns true if the provided access is greater than
-// the current.
-func (a Access) LessAccessThan(access Access) bool {
-	switch a {
-	case UndefinedAccess:
-		return access == ReadAccess ||
-			access == WriteAccess ||
-			access == AdminAccess ||
-			access == LoginAccess ||
-			access == AddModelAccess ||
-			access == SuperuserAccess
-	case ReadAccess:
-		return access == WriteAccess ||
-			access == AdminAccess
-	case WriteAccess:
-		return access == AdminAccess
-	// Controller permissions
-	case LoginAccess:
-		return access == AddModelAccess ||
-			access == SuperuserAccess
-	case AddModelAccess:
-		return access == SuperuserAccess
 	}
 	return false
 }

--- a/core/description/access.go
+++ b/core/description/access.go
@@ -16,6 +16,8 @@ const (
 	// used when access is not defined at all.
 	UndefinedAccess Access = ""
 
+	// Model Permissions
+
 	// ReadAccess allows a user to read information about a permission subject,
 	// without being able to make any changes.
 	ReadAccess Access = "read"
@@ -25,15 +27,58 @@ const (
 
 	// AdminAccess allows a user full control over the subject.
 	AdminAccess Access = "admin"
+
+	// Controller permissions
+
+	// LoginAccess allows a user to log-ing into the subject.
+	LoginAccess Access = "login"
+
+	// AddModelAccess allows user to add new models in subjects supporting it.
+	AddModelAccess Access = "addmodel"
+
+	// SuperUserAccess allows user unrestricted permissions in the subject.
+	SuperuserAccess Access = "superuser"
 )
 
 // Validate returns error if the current is not a valid access level.
 func (a Access) Validate() error {
 	switch a {
-	case UndefinedAccess, AdminAccess, ReadAccess, WriteAccess:
+	case UndefinedAccess, AdminAccess, ReadAccess, WriteAccess,
+		LoginAccess, AddModelAccess, SuperuserAccess:
 		return nil
 	}
 	return errors.NotValidf("access level %s", a)
+}
+
+// EqualOrGreaterAccessThan returns true if the provided access is equal or
+// less than the current.
+func (a Access) EqualOrGreaterAccessThan(access Access) bool {
+	if a == access {
+		return true
+	}
+	switch a {
+	case UndefinedAccess:
+		return false
+	case ReadAccess:
+		return access == UndefinedAccess
+	case WriteAccess:
+		return access == ReadAccess ||
+			access == UndefinedAccess
+	case AdminAccess:
+		return access == ReadAccess ||
+			access == WriteAccess
+	// Controller permissions
+	case LoginAccess:
+		return access == UndefinedAccess
+	case AddModelAccess:
+		return access == UndefinedAccess ||
+			access == LoginAccess
+	case SuperuserAccess:
+		return access == UndefinedAccess ||
+			access == LoginAccess ||
+			access == AddModelAccess
+	}
+	return false
 }
 
 // LessAccessThan returns true if the provided access is greater than
@@ -43,12 +88,21 @@ func (a Access) LessAccessThan(access Access) bool {
 	case UndefinedAccess:
 		return access == ReadAccess ||
 			access == WriteAccess ||
-			access == AdminAccess
+			access == AdminAccess ||
+			access == LoginAccess ||
+			access == AddModelAccess ||
+			access == SuperuserAccess
 	case ReadAccess:
 		return access == WriteAccess ||
 			access == AdminAccess
 	case WriteAccess:
 		return access == AdminAccess
+	// Controller permissions
+	case LoginAccess:
+		return access == AddModelAccess ||
+			access == SuperuserAccess
+	case AddModelAccess:
+		return access == SuperuserAccess
 	}
 	return false
 }

--- a/core/description/access.go
+++ b/core/description/access.go
@@ -36,9 +36,9 @@ func (a Access) Validate() error {
 	return errors.NotValidf("access level %s", a)
 }
 
-// IsGreaterAccess returns true if the provided access is greater than
+// LessAccessThan returns true if the provided access is greater than
 // the current.
-func (a Access) IsGreaterAccess(access Access) bool {
+func (a Access) LessAccessThan(access Access) bool {
 	switch a {
 	case UndefinedAccess:
 		return access == ReadAccess ||
@@ -53,8 +53,8 @@ func (a Access) IsGreaterAccess(access Access) bool {
 	return false
 }
 
-// accessField returns a Checker that accepts a string value only and returns
-// it unprocessed.
+// accessField returns a Checker that accepts a string value only
+// and returns a valid Access or an error.
 func accessField() schema.Checker {
 	return accessC{}
 }

--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -102,9 +102,7 @@ type User interface {
 	CreatedBy() names.UserTag
 	DateCreated() time.Time
 	LastConnection() time.Time
-	IsReadOnly() bool
-	IsReadWrite() bool
-	IsAdmin() bool
+	Access() Access
 }
 
 // Address represents an IP Address of some form.

--- a/core/description/user.go
+++ b/core/description/user.go
@@ -80,19 +80,9 @@ func (u *user) LastConnection() time.Time {
 	return *u.LastConnection_
 }
 
-// IsRead implements User.
-func (u *user) IsReadOnly() bool {
-	return u.Access_ == ReadAccess
-}
-
-// IsReadWrite implements User.
-func (u *user) IsReadWrite() bool {
-	return u.Access_ == WriteAccess
-}
-
-// IsAdmin implements User.
-func (u *user) IsAdmin() bool {
-	return u.Access_ == AdminAccess
+// Access implements User.
+func (u *user) Access() Access {
+	return u.Access_
 }
 
 func importUsers(source map[string]interface{}) ([]*user, error) {

--- a/core/description/user_test.go
+++ b/core/description/user_test.go
@@ -70,7 +70,8 @@ func (*UserSerializationSuite) TestParsingSerializedData(c *gc.C) {
 				DisplayName_: "A read only user",
 				CreatedBy_:   "admin@local",
 				DateCreated_: time.Date(2015, 10, 9, 12, 34, 56, 0, time.UTC),
-				Access_:      ReadAccess,
+				// We want to fail if someone breaks ReadAccess definition.
+				Access_: Access("read"),
 			},
 		},
 	}

--- a/core/description/useraccess.go
+++ b/core/description/useraccess.go
@@ -1,0 +1,35 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"time"
+
+	"gopkg.in/juju/names.v2"
+)
+
+// UserAccess represents a user access to a target whereas the user
+// could represent a remote user or a user across multiple models the
+// user access always represents a single user for a single target.
+// There should be no more than one UserAccess per target/user pair.
+// Many of these fields are storage artifacts but generate them from
+// other fields implies out of band knowledge of other packages.
+type UserAccess struct {
+	// UserID is the stored ID of the user.
+	UserID string
+	// UserTag is the tag for the user.
+	UserTag names.UserTag
+	// Object is the tag for the object of this access grant.
+	Object names.Tag
+	// Access represents the level of access subjec has over object.
+	Access Access
+	// CreatedBy is the tag of the user that granted the access.
+	CreatedBy names.UserTag
+	// DateCreated is the date the user was created in UTC.
+	DateCreated time.Time
+	// DisplayName is the name we are showing for this user.
+	DisplayName string
+	// UserName is the actual username for this access.
+	UserName string
+}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -63,7 +63,7 @@ gopkg.in/juju/charmrepo.v2-unstable	git	6e6733987fb03100f30e494cc1134351fe4a593b
 gopkg.in/juju/charmstore.v5-unstable	git	2cb9f80553dddaae8c5e2161ea45f4be5d9afc00	2016-05-27T11:46:22Z
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/juju/jujusvg.v1	git	cc128825adce31ea13020d24e7b3302bac86a8c3	2016-05-30T22:53:36Z
-gopkg.in/juju/names.v2	git	5426d66579afd36fc63d809dd58806806c2f161f	2016-06-23T03:33:52Z
+gopkg.in/juju/names.v2	git	3e0d33a444fec55aea7269b849eb22da41e73072	2016-07-18T22:31:20Z
 gopkg.in/macaroon-bakery.v1	git	b097c9d99b2537efaf54492e08f7e148f956ba51	2016-05-24T09:38:11Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	29cc868a5ca65f401ff318143f9408d02f4799cc	2016-06-09T18:00:28Z

--- a/featuretests/api_model_test.go
+++ b/featuretests/api_model_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/description"
 	jujunames "github.com/juju/juju/juju/names"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
@@ -46,10 +47,10 @@ func (s *apiEnvironmentSuite) TestGrantModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	user := names.NewUserTag(username)
-	modelUser, err := s.State.ModelUser(user)
+	modelUser, err := s.State.UserAccess(user, model.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modelUser.UserName(), gc.Equals, user.Canonical())
-	lastConn, err := modelUser.LastConnection()
+	c.Assert(modelUser.UserName, gc.Equals, user.Canonical())
+	lastConn, err := s.State.LastModelConnection(modelUser.UserTag)
 	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
 	c.Assert(lastConn.IsZero(), jc.IsTrue)
 }
@@ -61,45 +62,45 @@ func (s *apiEnvironmentSuite) TestRevokeModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	mm := modelmanager.NewClient(s.APIState)
 
-	modelUser, err := s.State.ModelUser(user.UserTag())
+	modelUser, err := s.State.UserAccess(user.UserTag, s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modelUser, gc.NotNil)
+	c.Assert(modelUser, gc.Not(gc.DeepEquals), description.UserAccess{})
 
 	// Then test unsharing the environment.
-	err = mm.RevokeModel(user.UserName(), "read", model.UUID())
+	err = mm.RevokeModel(user.UserName, "read", model.UUID())
 	c.Assert(err, jc.ErrorIsNil)
 
-	modelUser, err = s.State.ModelUser(user.UserTag())
+	modelUser, err = s.State.UserAccess(user.UserTag, s.State.ModelTag())
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
-	c.Assert(modelUser, gc.IsNil)
+	c.Assert(modelUser, gc.DeepEquals, description.UserAccess{})
 }
 
 func (s *apiEnvironmentSuite) TestEnvironmentUserInfo(c *gc.C) {
 	modelUser := s.Factory.MakeModelUser(c, &factory.ModelUserParams{User: "bobjohns@ubuntuone", DisplayName: "Bob Johns"})
-	env, err := s.State.Model()
+	mod, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	owner, err := s.State.ModelUser(env.Owner())
+	owner, err := s.State.UserAccess(mod.Owner(), mod.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	obtained, err := s.client.ModelUserInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained, gc.DeepEquals, []params.ModelUserInfo{
 		{
-			UserName:       owner.UserName(),
-			DisplayName:    owner.DisplayName(),
+			UserName:       owner.UserName,
+			DisplayName:    owner.DisplayName,
 			Access:         "admin",
-			LastConnection: lastConnPointer(c, owner),
+			LastConnection: lastConnPointer(c, s.State, owner),
 		}, {
 			UserName:       "bobjohns@ubuntuone",
 			DisplayName:    "Bob Johns",
 			Access:         "admin",
-			LastConnection: lastConnPointer(c, modelUser),
+			LastConnection: lastConnPointer(c, s.State, modelUser),
 		},
 	})
 }
 
-func lastConnPointer(c *gc.C, modelUser *state.ModelUser) *time.Time {
-	lastConn, err := modelUser.LastConnection()
+func lastConnPointer(c *gc.C, st *state.State, modelUser description.UserAccess) *time.Time {
+	lastConn, err := st.LastModelConnection(modelUser.UserTag)
 	if err != nil {
 		if state.IsNeverConnectedError(err) {
 			return nil

--- a/featuretests/cmd_juju_model_test.go
+++ b/featuretests/cmd_juju_model_test.go
@@ -47,11 +47,11 @@ func (s *cmdModelSuite) TestGrantModelCmdStack(c *gc.C) {
 	c.Assert(obtained, gc.Equals, expected)
 
 	user := names.NewUserTag(username)
-	modelUser, err := s.State.ModelUser(user)
+	modelUser, err := s.State.UserAccess(user, s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modelUser.UserName(), gc.Equals, user.Canonical())
-	c.Assert(modelUser.CreatedBy(), gc.Equals, s.AdminUserTag(c).Canonical())
-	lastConn, err := modelUser.LastConnection()
+	c.Assert(modelUser.UserName, gc.Equals, user.Canonical())
+	c.Assert(modelUser.CreatedBy.Canonical(), gc.Equals, s.AdminUserTag(c).Canonical())
+	lastConn, err := s.State.LastModelConnection(modelUser.UserTag)
 	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
 	c.Assert(lastConn.IsZero(), jc.IsTrue)
 }
@@ -74,9 +74,9 @@ func (s *cmdModelSuite) TestRevokeModelCmdStack(c *gc.C) {
 	c.Assert(obtained, gc.Equals, expected)
 
 	user := names.NewUserTag(username)
-	modelUser, err := s.State.ModelUser(user)
+	modelUser, err := s.State.UserAccess(user, s.State.ModelTag())
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
-	c.Assert(modelUser, gc.IsNil)
+	c.Assert(modelUser, gc.DeepEquals, description.UserAccess{})
 }
 
 func (s *cmdModelSuite) TestModelUsersCmd(c *gc.C) {
@@ -84,7 +84,7 @@ func (s *cmdModelSuite) TestModelUsersCmd(c *gc.C) {
 	username := "bar@ubuntuone"
 	context := s.run(c, "grant", username, "controller")
 	user := names.NewUserTag(username)
-	modelUser, err := s.State.ModelUser(user)
+	modelUser, err := s.State.UserAccess(user, s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelUser, gc.NotNil)
 

--- a/featuretests/cmd_juju_user_test.go
+++ b/featuretests/cmd_juju_user_test.go
@@ -69,7 +69,7 @@ func (s *UserSuite) TestUserAddGrantModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	var modelUserTags = make([]names.UserTag, len(users))
 	for i, u := range users {
-		modelUserTags[i] = u.UserTag()
+		modelUserTags[i] = u.UserTag
 	}
 	c.Assert(modelUserTags, jc.SameContents, []names.UserTag{
 		user.Tag().(names.UserTag),

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -134,6 +134,11 @@ func allCollections() collectionSchema {
 			global: true,
 		},
 
+		// This collection holds users that are relative to controllers.
+		controllerUsersC: {
+			global: true,
+		},
+
 		// This collection holds the last time the user connected to the API server.
 		userLastLoginC: {
 			global:    true,
@@ -400,6 +405,7 @@ const (
 	constraintsC             = "constraints"
 	containerRefsC           = "containerRefs"
 	controllersC             = "controllers"
+	controllerUsersC         = "controllerusers"
 	filesystemAttachmentsC   = "filesystemAttachments"
 	filesystemsC             = "filesystems"
 	globalSettingsC          = "globalSettings"

--- a/state/controller.go
+++ b/state/controller.go
@@ -12,6 +12,12 @@ import (
 const (
 	// controllerSettingsGlobalKey is the key for the controller and its settings.
 	controllerSettingsGlobalKey = "controllerSettings"
+
+	// controllerInheritedSettingsGlobalKey is the key for default settings shared across models.
+	controllerInheritedSettingsGlobalKey = "controllerInheritedSettings"
+
+	// controllerGlobalKey is the key for controller.
+	controllerGlobalKey = "c"
 )
 
 // ControllerConfig returns the config values for the controller.

--- a/state/controller.go
+++ b/state/controller.go
@@ -13,9 +13,6 @@ const (
 	// controllerSettingsGlobalKey is the key for the controller and its settings.
 	controllerSettingsGlobalKey = "controllerSettings"
 
-	// controllerInheritedSettingsGlobalKey is the key for default settings shared across models.
-	controllerInheritedSettingsGlobalKey = "controllerInheritedSettings"
-
 	// controllerGlobalKey is the key for controller.
 	controllerGlobalKey = "c"
 )

--- a/state/controlleruser.go
+++ b/state/controlleruser.go
@@ -17,150 +17,51 @@ import (
 
 const defaultControllerPermission = description.LoginAccess
 
-// ControllerUser represents a user access to an controller
-// controller user always represents a single user for a single controller.
-// There should be no more than one ControllerUser per controller.
-type ControllerUser struct {
-	st                   *State
-	doc                  controllerUserDoc
-	controllerPermission *permission
-}
-
-// NewControllerUser returns a ControllerUser with permissions.
-func NewControllerUser(st *State, doc controllerUserDoc) (*ControllerUser, error) {
-	mu := &ControllerUser{
-		st:  st,
-		doc: doc,
-	}
-	if err := mu.refreshPermission(); err != nil {
-		return nil, errors.Trace(err)
-	}
-	return mu, nil
-}
-
-type controllerUserDoc struct {
-	ID             string    `bson:"_id"`
-	ControllerUUID string    `bson:"controller-uuid"`
-	UserName       string    `bson:"user"`
-	DisplayName    string    `bson:"displayname"`
-	CreatedBy      string    `bson:"createdby"`
-	DateCreated    time.Time `bson:"datecreated"`
-}
-
-// Access returns the access level of this controller user.
-func (e *ControllerUser) Access() description.Access {
-	return e.controllerPermission.access()
-}
-
-// ID returns the ID of the controller user.
-func (e *ControllerUser) ID() string {
-	return e.doc.ID
-}
-
-// UserTag returns the tag for the controller user.
-func (e *ControllerUser) UserTag() names.UserTag {
-	return names.NewUserTag(e.doc.UserName)
-}
-
-// UserName returns the user name of the controller user.
-func (e *ControllerUser) UserName() string {
-	return e.doc.UserName
-}
-
-// DisplayName returns the display name of the controller user.
-func (e *ControllerUser) DisplayName() string {
-	return e.doc.DisplayName
-}
-
-// CreatedBy returns the user who created the controller user.
-func (e *ControllerUser) CreatedBy() string {
-	return e.doc.CreatedBy
-}
-
-// DateCreated returns the date the controller user was created in UTC.
-func (e *ControllerUser) DateCreated() time.Time {
-	return e.doc.DateCreated.UTC()
-}
-
-// refreshPermission reloads the permission for this controller user from persistence.
-func (e *ControllerUser) refreshPermission() error {
-	perm, err := e.st.userPermission(controllerGlobalKey, e.globalKey())
-	if err != nil {
-		return errors.Annotate(err, "updating permission")
-	}
-	e.controllerPermission = perm
-	return nil
-}
-
-// IsGreaterAccess returns true if provided access is higher than
-// the current one.
-func (e *ControllerUser) IsGreaterAccess(a description.Access) bool {
-	return e.controllerPermission.isGreaterAccess(a)
-}
-
-// SetAccess changes the user's access permissions on the controller.
-func (e *ControllerUser) SetAccess(access description.Access) error {
+// setAccess changes the user's access permissions on the controller.
+func (st *State) setControllerAccess(access description.Access, userGlobalKey string) error {
 	if err := access.Validate(); err != nil {
 		return errors.Trace(err)
 	}
-	op := updatePermissionOp(controllerGlobalKey, e.globalKey(), access)
-	err := e.st.runTransaction([]txn.Op{op})
+	op := updatePermissionOp(controllerGlobalKey, userGlobalKey, access)
+	err := st.runTransaction([]txn.Op{op})
 	if err == txn.ErrAborted {
 		return errors.NotFoundf("existing permissions")
 	}
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return e.refreshPermission()
+	return errors.Trace(err)
 }
 
-func (e *ControllerUser) globalKey() string {
-	// TODO(perrito666) this asumes out of band knowledge of how controllerUserID is crafted
-	username := strings.ToLower(e.UserName())
-	return userWithGlobalKey(username)
-}
-
-// ControllerUser returns the controller user.
-func (st *State) ControllerUser(user names.UserTag) (*ControllerUser, error) {
-	controllerUser := &ControllerUser{st: st}
+// controllerUser a model userAccessDoc.
+func (st *State) controllerUser(user names.UserTag) (userAccessDoc, error) {
+	controllerUser := userAccessDoc{}
 	controllerUsers, closer := st.getCollection(controllerUsersC)
 	defer closer()
 
 	username := strings.ToLower(user.Canonical())
-	err := controllerUsers.FindId(username).One(&controllerUser.doc)
+	err := controllerUsers.FindId(username).One(&controllerUser)
 	if err == mgo.ErrNotFound {
-		return nil, errors.NotFoundf("controller user %q", user.Canonical())
+		return userAccessDoc{}, errors.NotFoundf("controller user %q", user.Canonical())
 	}
 	// DateCreated is inserted as UTC, but read out as local time. So we
 	// convert it back to UTC here.
-	controllerUser.doc.DateCreated = controllerUser.doc.DateCreated.UTC()
-	if err := controllerUser.refreshPermission(); err != nil {
-		return nil, errors.Trace(err)
-	}
+	controllerUser.DateCreated = controllerUser.DateCreated.UTC()
 	return controllerUser, nil
-}
-
-// controllerUserID returns the document id of the controller user
-func controllerUserID(user names.UserTag) string {
-	username := user.Canonical()
-	return strings.ToLower(username)
 }
 
 func createControllerUserOps(controllerUUID string, user, createdBy names.UserTag, displayName string, dateCreated time.Time, access description.Access) []txn.Op {
 	creatorname := createdBy.Canonical()
-	doc := &controllerUserDoc{
-		ID:             controllerUserID(user),
-		ControllerUUID: controllerUUID,
-		UserName:       user.Canonical(),
-		DisplayName:    displayName,
-		CreatedBy:      creatorname,
-		DateCreated:    dateCreated,
+	doc := &userAccessDoc{
+		ID:          userAccessID(user),
+		ObjectUUID:  controllerUUID,
+		UserName:    user.Canonical(),
+		DisplayName: displayName,
+		CreatedBy:   creatorname,
+		DateCreated: dateCreated,
 	}
 	ops := []txn.Op{
-		createPermissionOp(controllerGlobalKey, userWithGlobalKey(controllerUserID(user)), access),
+		createPermissionOp(controllerGlobalKey, userGlobalKey(userAccessID(user)), access),
 		{
 			C:      controllerUsersC,
-			Id:     controllerUserID(user),
+			Id:     userAccessID(user),
 			Assert: txn.DocMissing,
 			Insert: doc,
 		},
@@ -169,12 +70,12 @@ func createControllerUserOps(controllerUUID string, user, createdBy names.UserTa
 }
 
 // RemoveControllerUser removes a user from the database.
-func (st *State) RemoveControllerUser(user names.UserTag) error {
+func (st *State) removeControllerUser(user names.UserTag) error {
 	ops := []txn.Op{
-		removePermissionOp(controllerGlobalKey, userWithGlobalKey(controllerUserID(user))),
+		removePermissionOp(controllerGlobalKey, userGlobalKey(userAccessID(user))),
 		{
 			C:      controllerUsersC,
-			Id:     controllerUserID(user),
+			Id:     userAccessID(user),
 			Assert: txn.DocExists,
 			Remove: true,
 		}}

--- a/state/controlleruser.go
+++ b/state/controlleruser.go
@@ -1,0 +1,190 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/core/description"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/txn"
+)
+
+const defaultControllerPermission = description.LoginAccess
+
+// ControllerUser represents a user access to an controller
+// controller user always represents a single user for a single controller.
+// There should be no more than one ControllerUser per controller.
+type ControllerUser struct {
+	st                   *State
+	doc                  controllerUserDoc
+	controllerPermission *permission
+}
+
+// NewControllerUser returns a ControllerUser with permissions.
+func NewControllerUser(st *State, doc controllerUserDoc) (*ControllerUser, error) {
+	mu := &ControllerUser{
+		st:  st,
+		doc: doc,
+	}
+	if err := mu.refreshPermission(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return mu, nil
+}
+
+type controllerUserDoc struct {
+	ID             string    `bson:"_id"`
+	ControllerUUID string    `bson:"controller-uuid"`
+	UserName       string    `bson:"user"`
+	DisplayName    string    `bson:"displayname"`
+	CreatedBy      string    `bson:"createdby"`
+	DateCreated    time.Time `bson:"datecreated"`
+}
+
+// Access returns the access level of this controller user.
+func (e *ControllerUser) Access() description.Access {
+	return e.controllerPermission.access()
+}
+
+// ID returns the ID of the controller user.
+func (e *ControllerUser) ID() string {
+	return e.doc.ID
+}
+
+// UserTag returns the tag for the controller user.
+func (e *ControllerUser) UserTag() names.UserTag {
+	return names.NewUserTag(e.doc.UserName)
+}
+
+// UserName returns the user name of the controller user.
+func (e *ControllerUser) UserName() string {
+	return e.doc.UserName
+}
+
+// DisplayName returns the display name of the controller user.
+func (e *ControllerUser) DisplayName() string {
+	return e.doc.DisplayName
+}
+
+// CreatedBy returns the user who created the controller user.
+func (e *ControllerUser) CreatedBy() string {
+	return e.doc.CreatedBy
+}
+
+// DateCreated returns the date the controller user was created in UTC.
+func (e *ControllerUser) DateCreated() time.Time {
+	return e.doc.DateCreated.UTC()
+}
+
+// refreshPermission reloads the permission for this controller user from persistence.
+func (e *ControllerUser) refreshPermission() error {
+	perm, err := e.st.userPermission(controllerGlobalKey, e.globalKey())
+	if err != nil {
+		return errors.Annotate(err, "updating permission")
+	}
+	e.controllerPermission = perm
+	return nil
+}
+
+// IsGreaterAccess returns true if provided access is higher than
+// the current one.
+func (e *ControllerUser) IsGreaterAccess(a description.Access) bool {
+	return e.controllerPermission.isGreaterAccess(a)
+}
+
+// SetAccess changes the user's access permissions on the controller.
+func (e *ControllerUser) SetAccess(access description.Access) error {
+	if err := access.Validate(); err != nil {
+		return errors.Trace(err)
+	}
+	op := updatePermissionOp(controllerGlobalKey, e.globalKey(), access)
+	err := e.st.runTransaction([]txn.Op{op})
+	if err == txn.ErrAborted {
+		return errors.NotFoundf("existing permissions")
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return e.refreshPermission()
+}
+
+func (e *ControllerUser) globalKey() string {
+	// TODO(perrito666) this asumes out of band knowledge of how controllerUserID is crafted
+	username := strings.ToLower(e.UserName())
+	return userWithGlobalKey(username)
+}
+
+// ControllerUser returns the controller user.
+func (st *State) ControllerUser(user names.UserTag) (*ControllerUser, error) {
+	controllerUser := &ControllerUser{st: st}
+	controllerUsers, closer := st.getCollection(controllerUsersC)
+	defer closer()
+
+	username := strings.ToLower(user.Canonical())
+	err := controllerUsers.FindId(username).One(&controllerUser.doc)
+	if err == mgo.ErrNotFound {
+		return nil, errors.NotFoundf("controller user %q", user.Canonical())
+	}
+	// DateCreated is inserted as UTC, but read out as local time. So we
+	// convert it back to UTC here.
+	controllerUser.doc.DateCreated = controllerUser.doc.DateCreated.UTC()
+	if err := controllerUser.refreshPermission(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return controllerUser, nil
+}
+
+// controllerUserID returns the document id of the controller user
+func controllerUserID(user names.UserTag) string {
+	username := user.Canonical()
+	return strings.ToLower(username)
+}
+
+func createControllerUserOps(controllerUUID string, user, createdBy names.UserTag, displayName string, dateCreated time.Time, access description.Access) []txn.Op {
+	creatorname := createdBy.Canonical()
+	doc := &controllerUserDoc{
+		ID:             controllerUserID(user),
+		ControllerUUID: controllerUUID,
+		UserName:       user.Canonical(),
+		DisplayName:    displayName,
+		CreatedBy:      creatorname,
+		DateCreated:    dateCreated,
+	}
+	ops := []txn.Op{
+		createPermissionOp(controllerGlobalKey, userWithGlobalKey(controllerUserID(user)), access),
+		{
+			C:      controllerUsersC,
+			Id:     controllerUserID(user),
+			Assert: txn.DocMissing,
+			Insert: doc,
+		},
+	}
+	return ops
+}
+
+// RemoveControllerUser removes a user from the database.
+func (st *State) RemoveControllerUser(user names.UserTag) error {
+	ops := []txn.Op{
+		removePermissionOp(controllerGlobalKey, userWithGlobalKey(controllerUserID(user))),
+		{
+			C:      controllerUsersC,
+			Id:     controllerUserID(user),
+			Assert: txn.DocExists,
+			Remove: true,
+		}}
+
+	err := st.runTransaction(ops)
+	if err == txn.ErrAborted {
+		err = errors.NewNotFound(nil, fmt.Sprintf("controller user %q does not exist", user.Canonical()))
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}

--- a/state/controlleruser_test.go
+++ b/state/controlleruser_test.go
@@ -1,0 +1,97 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/core/description"
+	"github.com/juju/juju/testing/factory"
+)
+
+type ControllerUserSuite struct {
+	ConnSuite
+}
+
+var _ = gc.Suite(&ControllerUserSuite{})
+
+type accessAwareUser interface {
+	Access() description.Access
+}
+
+func (s *ControllerUserSuite) TestDefaultAccessControllerUser(c *gc.C) {
+	user := s.Factory.MakeUser(c,
+		&factory.UserParams{
+			Name: "validusername",
+		})
+	_ = s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
+	t := user.Tag()
+	userTag := t.(names.UserTag)
+	controllerUser, err := s.State.ControllerUser(userTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(controllerUser.Access(), gc.Equals, description.LoginAccess)
+}
+
+func (s *ControllerUserSuite) TestSetAccessControllerUser(c *gc.C) {
+	user := s.Factory.MakeUser(c,
+		&factory.UserParams{
+			Name: "validusername",
+		})
+	_ = s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
+	t := user.Tag()
+	userTag := t.(names.UserTag)
+	controllerUser, err := s.State.ControllerUser(userTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(controllerUser.Access(), gc.Equals, description.LoginAccess)
+
+	controllerUser.SetAccess(description.AddModelAccess)
+
+	controllerUser, err = s.State.ControllerUser(user.UserTag())
+	c.Assert(controllerUser.Access(), gc.Equals, description.AddModelAccess)
+}
+
+//---------
+func (s *ControllerUserSuite) TestRemoveControllerUser(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "validUsername"})
+	_, err := s.State.ControllerUser(user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.RemoveControllerUser(user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.State.ControllerUser(user.UserTag())
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+// TestCaseSensitiveControllerUserErrors tests that the user id is not case sensitive
+// and adding two times the same username with different capitalization will
+// fail, even though it is actually testing the mechanism for AddUser (which fails
+// before controller user adding) the test is here in case anyone changes the
+// logic behind Adding regular users and forgets to do the same for ControllerUsers.
+func (s *ControllerUserSuite) TestCaseSensitiveControllerUserErrors(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "VALIDuSERNAME"})
+	_, err := s.State.ControllerUser(user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	user = s.Factory.MakeUser(c, &factory.UserParams{Name: "validUsername",
+		ExpectedCreateError: `user already exists`,
+		NoModelUser:         true})
+}
+
+func (s *ControllerUserSuite) TestRemoveControllerUserSucceeds(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{})
+	err := s.State.RemoveControllerUser(user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ControllerUserSuite) TestRemoveControllerUserFails(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{})
+	err := s.State.RemoveControllerUser(user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.RemoveControllerUser(user.UserTag())
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -21,6 +21,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
@@ -459,8 +460,8 @@ func IsManagerMachineError(err error) bool {
 
 var ActionNotificationIdToActionId = actionNotificationIdToActionId
 
-func UpdateModelUserLastConnection(e *ModelUser, when time.Time) error {
-	return e.updateLastConnection(when)
+func UpdateModelUserLastConnection(st *State, e description.UserAccess, when time.Time) error {
+	return st.updateLastModelConnection(e.UserTag, when)
 }
 
 func RemoveEndpointBindingsForService(c *gc.C, service *Application) {

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -135,10 +135,10 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(entity.Tag(), gc.Equals, owner)
 	// Check that the owner has an ModelUser created for the bootstrapped model.
-	modelUser, err := s.State.ModelUser(model.Owner())
+	modelUser, err := s.State.UserAccess(model.Owner(), model.Tag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modelUser.UserTag(), gc.Equals, owner)
-	c.Assert(modelUser.ModelTag(), gc.Equals, model.Tag())
+	c.Assert(modelUser.UserTag, gc.Equals, owner)
+	c.Assert(modelUser.Object, gc.Equals, model.Tag())
 
 	// Check that the model can be found through the tag.
 	entity, err = s.State.FindEntity(modelTag)

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -177,24 +177,14 @@ func (e *exporter) modelUsers() error {
 		return errors.Trace(err)
 	}
 	for _, user := range users {
-		var access description.Access
-		switch {
-		case user.IsAdmin():
-			access = description.AdminAccess
-		case user.IsReadWrite():
-			access = description.WriteAccess
-		default:
-			access = description.ReadAccess
-		}
-
-		lastConn := lastConnections[strings.ToLower(user.UserName())]
+		lastConn := lastConnections[strings.ToLower(user.UserName)]
 		arg := description.UserArgs{
-			Name:           user.UserTag(),
-			DisplayName:    user.DisplayName(),
-			CreatedBy:      names.NewUserTag(user.CreatedBy()),
-			DateCreated:    user.DateCreated(),
+			Name:           user.UserTag,
+			DisplayName:    user.DisplayName,
+			CreatedBy:      user.CreatedBy,
+			DateCreated:    user.DateCreated,
 			LastConnection: lastConn,
-			Access:         access,
+			Access:         user.Access,
 		}
 		e.model.AddUser(arg)
 	}

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -177,15 +177,14 @@ func (e *exporter) modelUsers() error {
 		return errors.Trace(err)
 	}
 	for _, user := range users {
-		var access string
+		var access description.Access
 		switch {
 		case user.IsAdmin():
-			access = string(description.AdminAccess)
+			access = description.AdminAccess
 		case user.IsReadWrite():
-			access = string(description.WriteAccess)
+			access = description.WriteAccess
 		default:
-			access = string(description.ReadAccess)
-
+			access = description.ReadAccess
 		}
 
 		lastConn := lastConnections[strings.ToLower(user.UserName())]
@@ -195,7 +194,7 @@ func (e *exporter) modelUsers() error {
 			CreatedBy:      names.NewUserTag(user.CreatedBy()),
 			DateCreated:    user.DateCreated(),
 			LastConnection: lastConn,
-			Access:         stringToAccess(access),
+			Access:         access,
 		}
 		e.model.AddUser(arg)
 	}

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -148,19 +148,19 @@ func (s *MigrationExportSuite) TestModelUsers(c *gc.C) {
 	// Make sure we have some last connection times for the admin user,
 	// and create a few other users.
 	lastConnection := state.NowToTheSecond()
-	owner, err := s.State.ModelUser(s.Owner)
+	owner, err := s.State.UserAccess(s.Owner, s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
-	err = state.UpdateModelUserLastConnection(owner, lastConnection)
+	err = state.UpdateModelUserLastConnection(s.State, owner, lastConnection)
 	c.Assert(err, jc.ErrorIsNil)
 
 	bobTag := names.NewUserTag("bob@external")
-	bob, err := s.State.AddModelUser(state.ModelUserSpec{
+	bob, err := s.State.AddModelUser(state.UserAccessSpec{
 		User:      bobTag,
 		CreatedBy: s.Owner,
 		Access:    description.ReadAccess,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = state.UpdateModelUserLastConnection(bob, lastConnection)
+	err = state.UpdateModelUserLastConnection(s.State, bob, lastConnection)
 	c.Assert(err, jc.ErrorIsNil)
 
 	model, err := s.State.Export()
@@ -174,18 +174,18 @@ func (s *MigrationExportSuite) TestModelUsers(c *gc.C) {
 	exportedAdmin := users[1]
 
 	c.Assert(exportedAdmin.Name(), gc.Equals, s.Owner)
-	c.Assert(exportedAdmin.DisplayName(), gc.Equals, owner.DisplayName())
+	c.Assert(exportedAdmin.DisplayName(), gc.Equals, owner.DisplayName)
 	c.Assert(exportedAdmin.CreatedBy(), gc.Equals, s.Owner)
-	c.Assert(exportedAdmin.DateCreated(), gc.Equals, owner.DateCreated())
+	c.Assert(exportedAdmin.DateCreated(), gc.Equals, owner.DateCreated)
 	c.Assert(exportedAdmin.LastConnection(), gc.Equals, lastConnection)
-	c.Assert(exportedAdmin.IsReadOnly(), jc.IsFalse)
+	c.Assert(exportedAdmin.Access(), gc.Equals, description.AdminAccess)
 
 	c.Assert(exportedBob.Name(), gc.Equals, bobTag)
 	c.Assert(exportedBob.DisplayName(), gc.Equals, "")
 	c.Assert(exportedBob.CreatedBy(), gc.Equals, s.Owner)
-	c.Assert(exportedBob.DateCreated(), gc.Equals, bob.DateCreated())
+	c.Assert(exportedBob.DateCreated(), gc.Equals, bob.DateCreated)
 	c.Assert(exportedBob.LastConnection(), gc.Equals, lastConnection)
-	c.Assert(exportedBob.IsReadOnly(), jc.IsTrue)
+	c.Assert(exportedBob.Access(), gc.Equals, description.ReadAccess)
 }
 
 func (s *MigrationExportSuite) TestMachines(c *gc.C) {

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -201,7 +201,7 @@ func (i *importer) modelUsers() error {
 	// the wrong DateCreated, so we remove it, and add in all the users we
 	// know about. It is also possible that the owner of the model no
 	// longer has access to the model due to changes over time.
-	if err := i.st.RemoveModelUser(i.dbModel.Owner()); err != nil {
+	if err := i.st.RemoveUserAccess(i.dbModel.Owner(), i.dbModel.ModelTag()); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -209,22 +209,13 @@ func (i *importer) modelUsers() error {
 	modelUUID := i.dbModel.UUID()
 	var ops []txn.Op
 	for _, user := range users {
-		var access description.Access
-		switch {
-		case user.IsReadOnly():
-			access = description.ReadAccess
-		case user.IsReadWrite():
-			access = description.WriteAccess
-		default:
-			access = description.AdminAccess
-		}
 		ops = append(ops, createModelUserOps(
 			modelUUID,
 			user.Name(),
 			user.CreatedBy(),
 			user.DisplayName(),
 			user.DateCreated(),
-			access)...,
+			user.Access())...,
 		)
 	}
 	if err := i.st.runTransaction(ops); err != nil {
@@ -237,11 +228,7 @@ func (i *importer) modelUsers() error {
 		if lastConnection.IsZero() {
 			continue
 		}
-		envUser, err := i.st.ModelUser(user.Name())
-		if err != nil {
-			return errors.Trace(err)
-		}
-		err = envUser.updateLastConnection(lastConnection)
+		err := i.st.updateLastModelConnection(user.Name(), lastConnection)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -79,6 +79,9 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// Users aren't migrated.
 		usersC,
 		userLastLoginC,
+		// Controller users contain extra data about users therefore
+		// are not migrated either.
+		controllerUsersC,
 		// userenvnameC is just to provide a unique key constraint.
 		usermodelnameC,
 		// Metrics aren't migrated.
@@ -176,6 +179,9 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 
 	// If this test fails, it means that a new collection has been added
 	// but migrations for it has not been done. This is a Bad Thing™.
+	// Beware, if your collection is something controller-related it might
+	// not need migration (such as Users or ControllerUsers) in that
+	// case they only need to be accounted for among the ignored collections.
 	c.Assert(remainder, gc.HasLen, 0)
 }
 

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -210,16 +210,16 @@ func (s *MigrationSuite) TestEnvUserDocFields(c *gc.C) {
 	fields := set.NewStrings(
 		// ID is the same as UserName (but lowercased)
 		"ID",
-		// ModelUUID shouldn't be exported, and is inherited
+		// ObjectUUID shouldn't be exported, and is inherited
 		// from the model definition.
-		"ModelUUID",
+		"ObjectUUID",
 		// Tracked fields:
 		"UserName",
 		"DisplayName",
 		"CreatedBy",
 		"DateCreated",
 	)
-	s.AssertExportedFields(c, modelUserDoc{}, fields)
+	s.AssertExportedFields(c, userAccessDoc{}, fields)
 }
 
 func (s *MigrationSuite) TestPermissionDocFields(c *gc.C) {

--- a/state/model.go
+++ b/state/model.go
@@ -17,6 +17,7 @@ import (
 
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/status"
@@ -577,22 +578,22 @@ func (m *Model) refresh(query mongo.Query) error {
 }
 
 // Users returns a slice of all users for this model.
-func (m *Model) Users() ([]*ModelUser, error) {
+func (m *Model) Users() ([]description.UserAccess, error) {
 	if m.st.ModelUUID() != m.UUID() {
 		return nil, errors.New("cannot lookup model users outside the current model")
 	}
 	coll, closer := m.st.getCollection(modelUsersC)
 	defer closer()
 
-	var userDocs []modelUserDoc
+	var userDocs []userAccessDoc
 	err := coll.Find(nil).All(&userDocs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	var modelUsers []*ModelUser
+	var modelUsers []description.UserAccess
 	for _, doc := range userDocs {
-		mu, err := NewModelUser(m.st, doc)
+		mu, err := NewModelUserAccess(m.st, doc)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/state"
@@ -693,14 +694,14 @@ func (s *ModelSuite) TestListUsersTwoModels(c *gc.C) {
 	assertObtainedUsersMatchExpectedUsers(c, obtainedUsersOtherEnv, expectedUsersOtherEnv)
 }
 
-func addModelUsers(c *gc.C, st *state.State) (expected []*state.ModelUser) {
+func addModelUsers(c *gc.C, st *state.State) (expected []description.UserAccess) {
 	// get the model owner
 	testAdmin := names.NewUserTag("test-admin")
-	owner, err := st.ModelUser(testAdmin)
+	owner, err := st.UserAccess(testAdmin, st.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	f := factory.NewFactory(st)
-	return []*state.ModelUser{
+	return []description.UserAccess{
 		// we expect the owner to be an existing model user
 		owner,
 		// add new users to the model
@@ -710,13 +711,13 @@ func addModelUsers(c *gc.C, st *state.State) (expected []*state.ModelUser) {
 	}
 }
 
-func assertObtainedUsersMatchExpectedUsers(c *gc.C, obtainedUsers, expectedUsers []*state.ModelUser) {
+func assertObtainedUsersMatchExpectedUsers(c *gc.C, obtainedUsers, expectedUsers []description.UserAccess) {
 	c.Assert(len(obtainedUsers), gc.Equals, len(expectedUsers))
 	for i, obtained := range obtainedUsers {
-		c.Assert(obtained.ModelTag().Id(), gc.Equals, expectedUsers[i].ModelTag().Id())
-		c.Assert(obtained.UserName(), gc.Equals, expectedUsers[i].UserName())
-		c.Assert(obtained.DisplayName(), gc.Equals, expectedUsers[i].DisplayName())
-		c.Assert(obtained.CreatedBy(), gc.Equals, expectedUsers[i].CreatedBy())
+		c.Assert(obtained.Object.Id(), gc.Equals, expectedUsers[i].Object.Id())
+		c.Assert(obtained.UserTag, gc.Equals, expectedUsers[i].UserTag)
+		c.Assert(obtained.DisplayName, gc.Equals, expectedUsers[i].DisplayName)
+		c.Assert(obtained.CreatedBy, gc.Equals, expectedUsers[i].CreatedBy)
 	}
 }
 

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -17,37 +17,6 @@ import (
 	"github.com/juju/juju/core/description"
 )
 
-// ModelUser represents a user access to an model whereas the user
-// could represent a remote user or a user across multiple models the
-// model user always represents a single user for a single model.
-// There should be no more than one ModelUser per model.
-type ModelUser struct {
-	st              *State
-	doc             modelUserDoc
-	modelPermission *permission
-}
-
-// NewModelUser returns a ModelUser with permissions.
-func NewModelUser(st *State, doc modelUserDoc) (*ModelUser, error) {
-	mu := &ModelUser{
-		st:  st,
-		doc: doc,
-	}
-	if err := mu.refreshPermission(); err != nil {
-		return nil, errors.Trace(err)
-	}
-	return mu, nil
-}
-
-type modelUserDoc struct {
-	ID          string    `bson:"_id"`
-	ModelUUID   string    `bson:"model-uuid"`
-	UserName    string    `bson:"user"`
-	DisplayName string    `bson:"displayname"`
-	CreatedBy   string    `bson:"createdby"`
-	DateCreated time.Time `bson:"datecreated"`
-}
-
 // modelUserLastConnectionDoc is updated by the apiserver whenever the user
 // connects over the API. This update is not done using mgo.txn so the values
 // could well change underneath a normal transaction and as such, it should
@@ -60,108 +29,28 @@ type modelUserLastConnectionDoc struct {
 	LastConnection time.Time `bson:"last-connection"`
 }
 
-// Access returns the access level of this model user.
-func (e *ModelUser) Access() description.Access {
-	return e.modelPermission.access()
-}
-
-// ID returns the ID of the model user.
-func (e *ModelUser) ID() string {
-	return e.doc.ID
-}
-
-// ModelTag returns the model tag of the model user.
-func (e *ModelUser) ModelTag() names.ModelTag {
-	return names.NewModelTag(e.doc.ModelUUID)
-}
-
-// UserTag returns the tag for the model user.
-func (e *ModelUser) UserTag() names.UserTag {
-	return names.NewUserTag(e.doc.UserName)
-}
-
-// UserName returns the user name of the model user.
-func (e *ModelUser) UserName() string {
-	return e.doc.UserName
-}
-
-// DisplayName returns the display name of the model user.
-func (e *ModelUser) DisplayName() string {
-	return e.doc.DisplayName
-}
-
-// CreatedBy returns the user who created the model user.
-func (e *ModelUser) CreatedBy() string {
-	return e.doc.CreatedBy
-}
-
-// DateCreated returns the date the model user was created in UTC.
-func (e *ModelUser) DateCreated() time.Time {
-	return e.doc.DateCreated.UTC()
-}
-
-// refreshPermission reloads the permission for this model user from persistence.
-func (e *ModelUser) refreshPermission() error {
-	perm, err := e.st.userPermission(modelGlobalKey, e.globalKey())
-	if err != nil {
-		return errors.Annotate(err, "updating permission")
-	}
-	e.modelPermission = perm
-	return nil
-}
-
-// IsReadOnly returns whether or not the user has write access or only
-// read access to the model.
-func (e *ModelUser) IsReadOnly() bool {
-	return e.modelPermission.isReadOnly()
-}
-
-// IsAdmin is a convenience method that
-// returns whether or not the user has description.AdminAccess.
-func (e *ModelUser) IsAdmin() bool {
-	return e.modelPermission.isAdmin()
-}
-
-// IsReadWrite is a convenience method that
-// returns whether or not the user has description.WriteAccess.
-func (e *ModelUser) IsReadWrite() bool {
-	return e.modelPermission.isReadWrite()
-}
-
-// IsGreaterAccess returns true if provided access is higher than
-// the current one.
-func (e *ModelUser) IsGreaterAccess(a description.Access) bool {
-	return e.modelPermission.isGreaterAccess(a)
-}
-
-// SetAccess changes the user's access permissions on the model.
-func (e *ModelUser) SetAccess(access description.Access) error {
-	if err := access.Validate(); err != nil {
-		return errors.Trace(err)
-	}
-	op := updatePermissionOp(modelGlobalKey, e.globalKey(), access)
-	err := e.st.runTransaction([]txn.Op{op})
+// setModelAccess changes the user's access permissions on the model.
+func (st *State) setModelAccess(access description.Access, userGlobalKey string) error {
+	op := updatePermissionOp(modelGlobalKey, userGlobalKey, access)
+	err := st.runTransaction([]txn.Op{op})
 	if err == txn.ErrAborted {
 		return errors.NotFoundf("existing permissions")
 	}
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return e.refreshPermission()
+	return errors.Trace(err)
 }
 
-// LastConnection returns when this ModelUser last connected through the API
+// LastModelConnection returns when this User last connected through the API
 // in UTC. The resulting time will be nil if the user has never logged in.
-func (e *ModelUser) LastConnection() (time.Time, error) {
-	lastConnections, closer := e.st.getRawCollection(modelUserLastConnectionC)
+func (st *State) LastModelConnection(user names.UserTag) (time.Time, error) {
+	lastConnections, closer := st.getRawCollection(modelUserLastConnectionC)
 	defer closer()
 
-	username := strings.ToLower(e.UserName())
+	username := user.Canonical()
 	var lastConn modelUserLastConnectionDoc
-	err := lastConnections.FindId(e.st.docID(username)).Select(bson.D{{"last-connection", 1}}).One(&lastConn)
+	err := lastConnections.FindId(st.docID(username)).Select(bson.D{{"last-connection", 1}}).One(&lastConn)
 	if err != nil {
 		if err == mgo.ErrNotFound {
-			err = errors.Wrap(err, NeverConnectedError(e.UserName()))
+			err = errors.Wrap(err, NeverConnectedError(username))
 		}
 		return time.Time{}, errors.Trace(err)
 	}
@@ -185,13 +74,13 @@ func IsNeverConnectedError(err error) bool {
 	return ok
 }
 
-// UpdateLastConnection updates the last connection time of the model user.
-func (e *ModelUser) UpdateLastConnection() error {
-	return e.updateLastConnection(nowToTheSecond())
+// UpdateLastModelConnection updates the last connection time of the model user.
+func (st *State) UpdateLastModelConnection(user names.UserTag) error {
+	return st.updateLastModelConnection(user, nowToTheSecond())
 }
 
-func (e *ModelUser) updateLastConnection(when time.Time) error {
-	lastConnections, closer := e.st.getCollection(modelUserLastConnectionC)
+func (st *State) updateLastModelConnection(user names.UserTag, when time.Time) error {
+	lastConnections, closer := st.getCollection(modelUserLastConnectionC)
 	defer closer()
 
 	lastConnectionsW := lastConnections.Writeable()
@@ -202,117 +91,62 @@ func (e *ModelUser) updateLastConnection(when time.Time) error {
 	session.SetSafe(&mgo.Safe{})
 
 	lastConn := modelUserLastConnectionDoc{
-		ID:             e.st.docID(strings.ToLower(e.UserName())),
-		ModelUUID:      e.ModelTag().Id(),
-		UserName:       e.UserName(),
+		ID:             st.docID(strings.ToLower(user.Canonical())),
+		ModelUUID:      st.ModelUUID(),
+		UserName:       user.Canonical(),
 		LastConnection: when,
 	}
 	_, err := lastConnectionsW.UpsertId(lastConn.ID, lastConn)
 	return errors.Trace(err)
 }
 
-func (e *ModelUser) globalKey() string {
-	// TODO(perrito666) this asumes out of band knowledge of how modelUserID is crafted
-	username := strings.ToLower(e.UserName())
-	return userWithGlobalKey(username)
-}
-
-// ModelUser returns the model user.
-func (st *State) ModelUser(user names.UserTag) (*ModelUser, error) {
-	modelUser := &ModelUser{st: st}
+// ModelUser a model userAccessDoc.
+func (st *State) modelUser(user names.UserTag) (userAccessDoc, error) {
+	modelUser := userAccessDoc{}
 	modelUsers, closer := st.getCollection(modelUsersC)
 	defer closer()
 
 	username := strings.ToLower(user.Canonical())
-	err := modelUsers.FindId(username).One(&modelUser.doc)
+	err := modelUsers.FindId(username).One(&modelUser)
 	if err == mgo.ErrNotFound {
-		return nil, errors.NotFoundf("model user %q", user.Canonical())
+		return userAccessDoc{}, errors.NotFoundf("model user %q", username)
 	}
 	// DateCreated is inserted as UTC, but read out as local time. So we
 	// convert it back to UTC here.
-	modelUser.doc.DateCreated = modelUser.doc.DateCreated.UTC()
-	if err := modelUser.refreshPermission(); err != nil {
-		return nil, errors.Trace(err)
-	}
+	modelUser.DateCreated = modelUser.DateCreated.UTC()
 	return modelUser, nil
-}
-
-// ModelUserSpec defines the attributes that can be set when adding a new
-// model user.
-type ModelUserSpec struct {
-	User        names.UserTag
-	CreatedBy   names.UserTag
-	DisplayName string
-	Access      description.Access
-}
-
-// AddModelUser adds a new user to the database.
-func (st *State) AddModelUser(spec ModelUserSpec) (*ModelUser, error) {
-	// Ensure local user exists in state before adding them as an model user.
-	if spec.User.IsLocal() {
-		localUser, err := st.User(spec.User)
-		if err != nil {
-			return nil, errors.Annotate(err, fmt.Sprintf("user %q does not exist locally", spec.User.Name()))
-		}
-		if spec.DisplayName == "" {
-			spec.DisplayName = localUser.DisplayName()
-		}
-	}
-
-	// Ensure local createdBy user exists.
-	if spec.CreatedBy.IsLocal() {
-		if _, err := st.User(spec.CreatedBy); err != nil {
-			return nil, errors.Annotatef(err, "createdBy user %q does not exist locally", spec.CreatedBy.Name())
-		}
-	}
-
-	modelUUID := st.ModelUUID()
-	ops := createModelUserOps(modelUUID, spec.User, spec.CreatedBy, spec.DisplayName, nowToTheSecond(), spec.Access)
-	err := st.runTransaction(ops)
-	if err == txn.ErrAborted {
-		err = errors.AlreadyExistsf("model user %q", spec.User.Canonical())
-	}
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return st.ModelUser(spec.User)
-}
-
-// modelUserID returns the document id of the model user
-func modelUserID(user names.UserTag) string {
-	username := user.Canonical()
-	return strings.ToLower(username)
 }
 
 func createModelUserOps(modelUUID string, user, createdBy names.UserTag, displayName string, dateCreated time.Time, access description.Access) []txn.Op {
 	creatorname := createdBy.Canonical()
-	doc := &modelUserDoc{
-		ID:          modelUserID(user),
-		ModelUUID:   modelUUID,
+	doc := &userAccessDoc{
+		ID:          userAccessID(user),
+		ObjectUUID:  modelUUID,
 		UserName:    user.Canonical(),
 		DisplayName: displayName,
 		CreatedBy:   creatorname,
 		DateCreated: dateCreated,
 	}
 	ops := []txn.Op{
-		createPermissionOp(modelGlobalKey, userWithGlobalKey(modelUserID(user)), access),
+		createPermissionOp(modelGlobalKey, userGlobalKey(userAccessID(user)), access),
 		{
 			C:      modelUsersC,
-			Id:     modelUserID(user),
+			Id:     userAccessID(user),
 			Assert: txn.DocMissing,
 			Insert: doc,
 		},
 	}
+
 	return ops
 }
 
-// RemoveModelUser removes a user from the database.
-func (st *State) RemoveModelUser(user names.UserTag) error {
+// removeModelUser removes a user from the database.
+func (st *State) removeModelUser(user names.UserTag) error {
 	ops := []txn.Op{
-		removePermissionOp(modelGlobalKey, userWithGlobalKey(modelUserID(user))),
+		removePermissionOp(modelGlobalKey, userGlobalKey(userAccessID(user))),
 		{
 			C:      modelUsersC,
-			Id:     modelUserID(user),
+			Id:     userAccessID(user),
 			Assert: txn.DocExists,
 			Remove: true,
 		}}
@@ -360,15 +194,15 @@ func (st *State) ModelsForUser(user names.UserTag) ([]*UserModel, error) {
 	modelUsers, userCloser := st.getRawCollection(modelUsersC)
 	defer userCloser()
 
-	var userSlice []modelUserDoc
-	err := modelUsers.Find(bson.D{{"user", user.Canonical()}}).Select(bson.D{{"model-uuid", 1}, {"_id", 1}}).All(&userSlice)
+	var userSlice []userAccessDoc
+	err := modelUsers.Find(bson.D{{"user", user.Canonical()}}).Select(bson.D{{"object-uuid", 1}, {"_id", 1}}).All(&userSlice)
 	if err != nil {
 		return nil, err
 	}
 
 	var result []*UserModel
 	for _, doc := range userSlice {
-		modelTag := names.NewModelTag(doc.ModelUUID)
+		modelTag := names.NewModelTag(doc.ObjectUUID)
 		env, err := st.GetModel(modelTag)
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -394,7 +228,7 @@ func (st *State) IsControllerAdministrator(user names.UserTag) (bool, error) {
 	defer closer()
 
 	username := strings.ToLower(user.Canonical())
-	subjectGlobalKey := userWithGlobalKey(username)
+	subjectGlobalKey := userGlobalKey(username)
 
 	// TODO(perrito666) 20160606 this is prone to errors, it will just
 	// yield ErrPerm and be hard to trace, use ModelUser and Permission.

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -137,7 +137,7 @@ func (e *ModelUser) SetAccess(access description.Access) error {
 	op := updatePermissionOp(modelGlobalKey, e.globalKey(), access)
 	err := e.st.runTransaction([]txn.Op{op})
 	if err == txn.ErrAborted {
-		return errors.Errorf("no existing permissions found for %q", e.UserName())
+		return errors.NotFoundf("existing permissions")
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/state/modeluser_test.go
+++ b/state/modeluser_test.go
@@ -25,31 +25,6 @@ type ModelUserSuite struct {
 
 var _ = gc.Suite(&ModelUserSuite{})
 
-type userWithPermissions interface {
-	IsReadOnly() bool
-	IsReadWrite() bool
-	IsAdmin() bool
-}
-
-func checkModelUserHasRightAccess(c *gc.C, expected description.Access, user userWithPermissions) {
-	switch expected {
-	case description.ReadAccess:
-		c.Assert(user.IsReadOnly(), jc.IsTrue)
-		c.Assert(user.IsReadWrite(), jc.IsFalse)
-		c.Assert(user.IsAdmin(), jc.IsFalse)
-	case description.WriteAccess:
-		c.Assert(user.IsReadOnly(), jc.IsFalse)
-		c.Assert(user.IsReadWrite(), jc.IsTrue)
-		c.Assert(user.IsAdmin(), jc.IsFalse)
-	case description.AdminAccess:
-		c.Assert(user.IsReadOnly(), jc.IsFalse)
-		c.Assert(user.IsReadWrite(), jc.IsFalse)
-		c.Assert(user.IsAdmin(), jc.IsTrue)
-	default:
-		c.FailNow()
-	}
-}
-
 func (s *ModelUserSuite) TestAddModelUser(c *gc.C) {
 	now := state.NowToTheSecond()
 	user := s.Factory.MakeUser(c,
@@ -59,34 +34,34 @@ func (s *ModelUserSuite) TestAddModelUser(c *gc.C) {
 		})
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
 	modelUser, err := s.State.AddModelUser(
-		state.ModelUserSpec{
+		state.UserAccessSpec{
 			User:      user.UserTag(),
 			CreatedBy: createdBy.UserTag(),
 			Access:    description.WriteAccess,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(modelUser.ID(), gc.Equals, fmt.Sprintf("%s:validusername@local", s.modelTag.Id()))
-	c.Assert(modelUser.ModelTag(), gc.Equals, s.modelTag)
-	c.Assert(modelUser.UserName(), gc.Equals, "validusername@local")
-	c.Assert(modelUser.DisplayName(), gc.Equals, user.DisplayName())
-	checkModelUserHasRightAccess(c, description.WriteAccess, modelUser)
-	c.Assert(modelUser.CreatedBy(), gc.Equals, "createdby@local")
-	c.Assert(modelUser.DateCreated().Equal(now) || modelUser.DateCreated().After(now), jc.IsTrue)
-	when, err := modelUser.LastConnection()
+	c.Assert(modelUser.UserID, gc.Equals, fmt.Sprintf("%s:validusername@local", s.modelTag.Id()))
+	c.Assert(modelUser.Object, gc.Equals, s.modelTag)
+	c.Assert(modelUser.UserName, gc.Equals, "validusername@local")
+	c.Assert(modelUser.DisplayName, gc.Equals, user.DisplayName())
+	c.Assert(modelUser.Access, gc.Equals, description.WriteAccess)
+	c.Assert(modelUser.CreatedBy.Id(), gc.Equals, "createdby@local")
+	c.Assert(modelUser.DateCreated.Equal(now) || modelUser.DateCreated.After(now), jc.IsTrue)
+	when, err := s.State.LastModelConnection(modelUser.UserTag)
 	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
 	c.Assert(when.IsZero(), jc.IsTrue)
 
-	modelUser, err = s.State.ModelUser(user.UserTag())
+	modelUser, err = s.State.UserAccess(user.UserTag(), s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modelUser.ID(), gc.Equals, fmt.Sprintf("%s:validusername@local", s.modelTag.Id()))
-	c.Assert(modelUser.ModelTag(), gc.Equals, s.modelTag)
-	c.Assert(modelUser.UserName(), gc.Equals, "validusername@local")
-	c.Assert(modelUser.DisplayName(), gc.Equals, user.DisplayName())
-	checkModelUserHasRightAccess(c, description.WriteAccess, modelUser)
-	c.Assert(modelUser.CreatedBy(), gc.Equals, "createdby@local")
-	c.Assert(modelUser.DateCreated().Equal(now) || modelUser.DateCreated().After(now), jc.IsTrue)
-	when, err = modelUser.LastConnection()
+	c.Assert(modelUser.UserID, gc.Equals, fmt.Sprintf("%s:validusername@local", s.modelTag.Id()))
+	c.Assert(modelUser.Object, gc.Equals, s.modelTag)
+	c.Assert(modelUser.UserName, gc.Equals, "validusername@local")
+	c.Assert(modelUser.DisplayName, gc.Equals, user.DisplayName())
+	c.Assert(modelUser.Access, gc.Equals, description.WriteAccess)
+	c.Assert(modelUser.CreatedBy.Id(), gc.Equals, "createdby@local")
+	c.Assert(modelUser.DateCreated.Equal(now) || modelUser.DateCreated.After(now), jc.IsTrue)
+	when, err = s.State.LastModelConnection(modelUser.UserTag)
 	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
 	c.Assert(when.IsZero(), jc.IsTrue)
 }
@@ -99,22 +74,22 @@ func (s *ModelUserSuite) TestAddReadOnlyModelUser(c *gc.C) {
 		})
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
 	modelUser, err := s.State.AddModelUser(
-		state.ModelUserSpec{
+		state.UserAccessSpec{
 			User:      user.UserTag(),
 			CreatedBy: createdBy.UserTag(),
 			Access:    description.ReadAccess,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(modelUser.UserName(), gc.Equals, "validusername@local")
-	c.Assert(modelUser.DisplayName(), gc.Equals, user.DisplayName())
-	checkModelUserHasRightAccess(c, description.ReadAccess, modelUser)
+	c.Assert(modelUser.UserName, gc.Equals, "validusername@local")
+	c.Assert(modelUser.DisplayName, gc.Equals, user.DisplayName())
+	c.Assert(modelUser.Access, gc.Equals, description.ReadAccess)
 
 	// Make sure that it is set when we read the user out.
-	modelUser, err = s.State.ModelUser(user.UserTag())
+	modelUser, err = s.State.UserAccess(user.UserTag(), s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modelUser.UserName(), gc.Equals, "validusername@local")
-	checkModelUserHasRightAccess(c, description.ReadAccess, modelUser)
+	c.Assert(modelUser.UserName, gc.Equals, "validusername@local")
+	c.Assert(modelUser.Access, gc.Equals, description.ReadAccess)
 }
 
 func (s *ModelUserSuite) TestAddReadWriteModelUser(c *gc.C) {
@@ -125,22 +100,22 @@ func (s *ModelUserSuite) TestAddReadWriteModelUser(c *gc.C) {
 		})
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
 	modelUser, err := s.State.AddModelUser(
-		state.ModelUserSpec{
+		state.UserAccessSpec{
 			User:      user.UserTag(),
 			CreatedBy: createdBy.UserTag(),
 			Access:    description.WriteAccess,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(modelUser.UserName(), gc.Equals, "validusername@local")
-	c.Assert(modelUser.DisplayName(), gc.Equals, user.DisplayName())
-	checkModelUserHasRightAccess(c, description.WriteAccess, modelUser)
+	c.Assert(modelUser.UserName, gc.Equals, "validusername@local")
+	c.Assert(modelUser.DisplayName, gc.Equals, user.DisplayName())
+	c.Assert(modelUser.Access, gc.Equals, description.WriteAccess)
 
 	// Make sure that it is set when we read the user out.
-	modelUser, err = s.State.ModelUser(user.UserTag())
+	modelUser, err = s.State.UserAccess(user.UserTag(), s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modelUser.UserName(), gc.Equals, "validusername@local")
-	checkModelUserHasRightAccess(c, description.WriteAccess, modelUser)
+	c.Assert(modelUser.UserName, gc.Equals, "validusername@local")
+	c.Assert(modelUser.Access, gc.Equals, description.WriteAccess)
 }
 
 func (s *ModelUserSuite) TestAddAdminModelUser(c *gc.C) {
@@ -151,22 +126,22 @@ func (s *ModelUserSuite) TestAddAdminModelUser(c *gc.C) {
 		})
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
 	modelUser, err := s.State.AddModelUser(
-		state.ModelUserSpec{
+		state.UserAccessSpec{
 			User:      user.UserTag(),
 			CreatedBy: createdBy.UserTag(),
 			Access:    description.AdminAccess,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(modelUser.UserName(), gc.Equals, "validusername@local")
-	c.Assert(modelUser.DisplayName(), gc.Equals, user.DisplayName())
-	checkModelUserHasRightAccess(c, description.AdminAccess, modelUser)
+	c.Assert(modelUser.UserName, gc.Equals, "validusername@local")
+	c.Assert(modelUser.DisplayName, gc.Equals, user.DisplayName())
+	c.Assert(modelUser.Access, gc.Equals, description.AdminAccess)
 
 	// Make sure that it is set when we read the user out.
-	modelUser, err = s.State.ModelUser(user.UserTag())
+	modelUser, err = s.State.UserAccess(user.UserTag(), s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modelUser.UserName(), gc.Equals, "validusername@local")
-	checkModelUserHasRightAccess(c, description.AdminAccess, modelUser)
+	c.Assert(modelUser.UserName, gc.Equals, "validusername@local")
+	c.Assert(modelUser.Access, gc.Equals, description.AdminAccess)
 }
 
 func (s *ModelUserSuite) TestDefaultAccessModelUser(c *gc.C) {
@@ -177,12 +152,13 @@ func (s *ModelUserSuite) TestDefaultAccessModelUser(c *gc.C) {
 		})
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
 	modelUser, err := s.State.AddModelUser(
-		state.ModelUserSpec{
+		state.UserAccessSpec{
 			User:      user.UserTag(),
 			CreatedBy: createdBy.UserTag(),
+			Access:    description.ReadAccess,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	checkModelUserHasRightAccess(c, description.ReadAccess, modelUser)
+	c.Assert(modelUser.Access, gc.Equals, description.ReadAccess)
 }
 
 func (s *ModelUserSuite) TestSetAccessModelUser(c *gc.C) {
@@ -193,30 +169,32 @@ func (s *ModelUserSuite) TestSetAccessModelUser(c *gc.C) {
 		})
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
 	modelUser, err := s.State.AddModelUser(
-		state.ModelUserSpec{
+		state.UserAccessSpec{
 			User:      user.UserTag(),
 			CreatedBy: createdBy.UserTag(),
 			Access:    description.AdminAccess,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	checkModelUserHasRightAccess(c, description.AdminAccess, modelUser)
+	c.Assert(modelUser.Access, gc.Equals, description.AdminAccess)
 
-	modelUser.SetAccess(description.ReadAccess)
+	s.State.SetUserAccess(modelUser.UserTag, s.State.ModelTag(), description.ReadAccess)
 
-	modelUser, err = s.State.ModelUser(user.UserTag())
-	checkModelUserHasRightAccess(c, description.ReadAccess, modelUser)
+	modelUser, err = s.State.UserAccess(user.UserTag(), s.State.ModelTag())
+	c.Assert(modelUser.Access, gc.Equals, description.ReadAccess)
 }
 
 func (s *ModelUserSuite) TestCaseUserNameVsId(c *gc.C) {
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
-	user, err := s.State.AddModelUser(state.ModelUserSpec{
+	user, err := s.State.AddModelUser(state.UserAccessSpec{
 		User:      names.NewUserTag("Bob@RandomProvider"),
-		CreatedBy: model.Owner()})
+		CreatedBy: model.Owner(),
+		Access:    description.ReadAccess,
+	})
 	c.Assert(err, gc.IsNil)
-	c.Assert(user.UserName(), gc.Equals, "Bob@RandomProvider")
-	c.Assert(user.ID(), gc.Equals, state.DocID(s.State, "bob@randomprovider"))
+	c.Assert(user.UserName, gc.Equals, "Bob@RandomProvider")
+	c.Assert(user.UserID, gc.Equals, state.DocID(s.State, "bob@randomprovider"))
 }
 
 func (s *ModelUserSuite) TestCaseSensitiveModelUserErrors(c *gc.C) {
@@ -224,10 +202,12 @@ func (s *ModelUserSuite) TestCaseSensitiveModelUserErrors(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.Factory.MakeModelUser(c, &factory.ModelUserParams{User: "Bob@ubuntuone"})
 
-	_, err = s.State.AddModelUser(state.ModelUserSpec{
+	_, err = s.State.AddModelUser(state.UserAccessSpec{
 		User:      names.NewUserTag("boB@ubuntuone"),
-		CreatedBy: model.Owner()})
-	c.Assert(err, gc.ErrorMatches, `model user "boB@ubuntuone" already exists`)
+		CreatedBy: model.Owner(),
+		Access:    description.ReadAccess,
+	})
+	c.Assert(err, gc.ErrorMatches, `user access "boB@ubuntuone" already exists`)
 	c.Assert(errors.IsAlreadyExists(err), jc.IsTrue)
 }
 
@@ -239,11 +219,11 @@ func (s *ModelUserSuite) TestCaseInsensitiveLookupInMultiEnvirons(c *gc.C) {
 		// assert case insensitive lookup for each username
 		for _, username := range usernames {
 			userTag := names.NewUserTag(username)
-			obtainedUser, err := st1.ModelUser(userTag)
+			obtainedUser, err := st1.UserAccess(userTag, st1.ModelTag())
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(obtainedUser, gc.DeepEquals, expectedUser)
 
-			_, err = st2.ModelUser(userTag)
+			_, err = st2.UserAccess(userTag, st2.ModelTag())
 			c.Assert(errors.IsNotFound(err), jc.IsTrue)
 		}
 	}
@@ -264,43 +244,45 @@ func (s *ModelUserSuite) TestCaseInsensitiveLookupInMultiEnvirons(c *gc.C) {
 
 func (s *ModelUserSuite) TestAddModelDisplayName(c *gc.C) {
 	modelUserDefault := s.Factory.MakeModelUser(c, nil)
-	c.Assert(modelUserDefault.DisplayName(), gc.Matches, "display name-[0-9]*")
+	c.Assert(modelUserDefault.DisplayName, gc.Matches, "display name-[0-9]*")
 
 	modelUser := s.Factory.MakeModelUser(c, &factory.ModelUserParams{DisplayName: "Override user display name"})
-	c.Assert(modelUser.DisplayName(), gc.Equals, "Override user display name")
+	c.Assert(modelUser.DisplayName, gc.Equals, "Override user display name")
 }
 
 func (s *ModelUserSuite) TestAddModelNoUserFails(c *gc.C) {
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
-	_, err := s.State.AddModelUser(state.ModelUserSpec{
+	_, err := s.State.AddModelUser(state.UserAccessSpec{
 		User:      names.NewLocalUserTag("validusername"),
-		CreatedBy: createdBy.UserTag()})
+		CreatedBy: createdBy.UserTag(),
+		Access:    description.ReadAccess})
 	c.Assert(err, gc.ErrorMatches, `user "validusername" does not exist locally: user "validusername" not found`)
 }
 
 func (s *ModelUserSuite) TestAddModelNoCreatedByUserFails(c *gc.C) {
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "validusername"})
-	_, err := s.State.AddModelUser(state.ModelUserSpec{
+	_, err := s.State.AddModelUser(state.UserAccessSpec{
 		User:      user.UserTag(),
-		CreatedBy: names.NewLocalUserTag("createdby")})
+		CreatedBy: names.NewLocalUserTag("createdby"),
+		Access:    description.ReadAccess})
 	c.Assert(err, gc.ErrorMatches, `createdBy user "createdby" does not exist locally: user "createdby" not found`)
 }
 
 func (s *ModelUserSuite) TestRemoveModelUser(c *gc.C) {
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "validUsername"})
-	_, err := s.State.ModelUser(user.UserTag())
+	_, err := s.State.UserAccess(user.UserTag(), s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.State.RemoveModelUser(user.UserTag())
+	err = s.State.RemoveUserAccess(user.UserTag(), s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.State.ModelUser(user.UserTag())
+	_, err = s.State.UserAccess(user.UserTag(), s.State.ModelTag())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *ModelUserSuite) TestRemoveModelUserFails(c *gc.C) {
 	user := s.Factory.MakeUser(c, &factory.UserParams{NoModelUser: true})
-	err := s.State.RemoveModelUser(user.UserTag())
+	err := s.State.RemoveUserAccess(user.UserTag(), s.State.ModelTag())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
@@ -308,11 +290,11 @@ func (s *ModelUserSuite) TestUpdateLastConnection(c *gc.C) {
 	now := state.NowToTheSecond()
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "validusername", Creator: createdBy.Tag()})
-	modelUser, err := s.State.ModelUser(user.UserTag())
+	modelUser, err := s.State.UserAccess(user.UserTag(), s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
-	err = modelUser.UpdateLastConnection()
+	err = s.State.UpdateLastModelConnection(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
-	when, err := modelUser.LastConnection()
+	when, err := s.State.LastModelConnection(modelUser.UserTag)
 	c.Assert(err, jc.ErrorIsNil)
 	// It is possible that the update is done over a second boundary, so we need
 	// to check for after now as well as equal.
@@ -325,36 +307,37 @@ func (s *ModelUserSuite) TestUpdateLastConnectionTwoModelUsers(c *gc.C) {
 	// Create a user and add them to the inital model.
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "validusername", Creator: createdBy.Tag()})
-	modelUser, err := s.State.ModelUser(user.UserTag())
+	modelUser, err := s.State.UserAccess(user.UserTag(), s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create a second model and add the same user to this.
 	st2 := s.Factory.MakeModel(c, nil)
 	defer st2.Close()
-	modelUser2, err := st2.AddModelUser(state.ModelUserSpec{
+	modelUser2, err := st2.AddModelUser(state.UserAccessSpec{
 		User:      user.UserTag(),
-		CreatedBy: createdBy.UserTag()})
+		CreatedBy: createdBy.UserTag(),
+		Access:    description.ReadAccess})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Now we have two model users with the same username. Ensure we get
 	// separate last connections.
 
 	// Connect modelUser and get last connection.
-	err = modelUser.UpdateLastConnection()
+	err = s.State.UpdateLastModelConnection(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
-	when, err := modelUser.LastConnection()
+	when, err := s.State.LastModelConnection(modelUser.UserTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(when.After(now) || when.Equal(now), jc.IsTrue)
 
 	// Try to get last connection for modelUser2. As they have never connected,
 	// we expect to get an error.
-	_, err = modelUser2.LastConnection()
+	_, err = st2.LastModelConnection(modelUser2.UserTag)
 	c.Assert(err, gc.ErrorMatches, `never connected: "validusername@local"`)
 
 	// Connect modelUser2 and get last connection.
-	err = modelUser2.UpdateLastConnection()
+	err = s.State.UpdateLastModelConnection(modelUser2.UserTag)
 	c.Assert(err, jc.ErrorIsNil)
-	when, err = modelUser2.LastConnection()
+	when, err = s.State.LastModelConnection(modelUser2.UserTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(when.After(now) || when.Equal(now), jc.IsTrue)
 }
@@ -379,9 +362,13 @@ func (s *ModelUserSuite) TestModelsForUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(models, gc.HasLen, 1)
 	c.Assert(models[0].UUID(), gc.Equals, s.State.ModelUUID())
-	when, err := models[0].LastConnection()
+	st, err := s.State.ForModel(models[0].ModelTag())
+	c.Assert(err, jc.ErrorIsNil)
+	modelUser, err := s.State.UserAccess(user.UserTag(), models[0].ModelTag())
+	when, err := st.LastModelConnection(modelUser.UserTag)
 	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
 	c.Assert(when.IsZero(), jc.IsTrue)
+	c.Assert(st.Close(), jc.ErrorIsNil)
 }
 
 func (s *ModelUserSuite) newEnvWithOwner(c *gc.C, name string, owner names.UserTag) *state.Model {
@@ -422,8 +409,9 @@ func (s *ModelUserSuite) newEnvWithUser(c *gc.C, name string, user names.UserTag
 	newEnv, err := envState.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = envState.AddModelUser(state.ModelUserSpec{
-		User: user, CreatedBy: newEnv.Owner()})
+	_, err = envState.AddModelUser(state.UserAccessSpec{
+		User: user, CreatedBy: newEnv.Owner(),
+		Access: description.ReadAccess})
 	c.Assert(err, jc.ErrorIsNil)
 	return newEnv
 }
@@ -474,7 +462,7 @@ func (s *ModelUserSuite) TestIsControllerAdministrator(c *gc.C) {
 	c.Assert(isAdmin, jc.IsTrue)
 
 	readonly := s.Factory.MakeModelUser(c, &factory.ModelUserParams{Access: description.ReadAccess})
-	isAdmin, err = s.State.IsControllerAdministrator(readonly.UserTag())
+	isAdmin, err = s.State.IsControllerAdministrator(readonly.UserTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(isAdmin, jc.IsFalse)
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -176,7 +176,7 @@ func (s *StateSuite) TestModelUUID(c *gc.C) {
 
 func (s *StateSuite) TestNoModelDocs(c *gc.C) {
 	c.Assert(s.State.EnsureModelRemoved(), gc.ErrorMatches,
-		fmt.Sprintf("found documents for model with uuid %s: 1 constraints doc, 2 leases doc, 1 modelusers doc, 1 permissions doc, 1 settings doc, 1 statuses doc", s.State.ModelUUID()))
+		fmt.Sprintf("found documents for model with uuid %s: 1 constraints doc, 2 leases doc, 1 modelusers doc, 2 permissions doc, 1 settings doc, 1 statuses doc", s.State.ModelUUID()))
 }
 
 func (s *StateSuite) TestMongoSession(c *gc.C) {

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage/provider"
@@ -460,10 +461,11 @@ func (s *upgradesSuite) setupAddDefaultEndpointBindingsToServices(c *gc.C) []*Ap
 	stateOwner, err := s.state.AddUser("bob", "notused", "notused", "bob")
 	c.Assert(err, jc.ErrorIsNil)
 	ownerTag := stateOwner.UserTag()
-	_, err = s.state.AddModelUser(ModelUserSpec{
+	_, err = s.state.AddModelUser(UserAccessSpec{
 		User:        ownerTag,
 		CreatedBy:   ownerTag,
 		DisplayName: "",
+		Access:      description.ReadAccess,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/user.go
+++ b/state/user.go
@@ -23,10 +23,10 @@ import (
 	"gopkg.in/mgo.v2/txn"
 )
 
-const userGlobalKey = "us"
+const userGlobalKeyPrefix = "us"
 
-func userWithGlobalKey(userID string) string {
-	return fmt.Sprintf("%s#%s", userGlobalKey, userID)
+func userGlobalKey(userID string) string {
+	return fmt.Sprintf("%s#%s", userGlobalKeyPrefix, userID)
 }
 
 func (st *State) checkUserExists(name string) (bool, error) {

--- a/state/user.go
+++ b/state/user.go
@@ -23,6 +23,12 @@ import (
 	"gopkg.in/mgo.v2/txn"
 )
 
+const userGlobalKey = "us"
+
+func userWithGlobalKey(userID string) string {
+	return fmt.Sprintf("%s#%s", userGlobalKey, userID)
+}
+
 func (st *State) checkUserExists(name string) (bool, error) {
 	users, closer := st.getCollection(usersC)
 	defer closer()
@@ -64,6 +70,7 @@ func (st *State) addUser(name, displayName, password, creator string, secretKey 
 	}
 	nameToLower := strings.ToLower(name)
 
+	dateCreated := nowToTheSecond()
 	user := &User{
 		st: st,
 		doc: userDoc{
@@ -72,7 +79,7 @@ func (st *State) addUser(name, displayName, password, creator string, secretKey 
 			DisplayName: displayName,
 			SecretKey:   secretKey,
 			CreatedBy:   creator,
-			DateCreated: nowToTheSecond(),
+			DateCreated: dateCreated,
 		},
 	}
 
@@ -91,6 +98,14 @@ func (st *State) addUser(name, displayName, password, creator string, secretKey 
 		Assert: txn.DocMissing,
 		Insert: &user.doc,
 	}}
+	controllerUserOps := createControllerUserOps(st.ControllerUUID(),
+		names.NewUserTag(name),
+		names.NewUserTag(creator),
+		displayName,
+		dateCreated,
+		defaultControllerPermission)
+	ops = append(ops, controllerUserOps...)
+
 	err := st.runTransaction(ops)
 	if err == txn.ErrAborted {
 		err = errors.AlreadyExistsf("user")
@@ -133,8 +148,9 @@ func (st *State) RemoveUser(tag names.UserTag) error {
 	return st.run(buildTxn)
 }
 
-func createInitialUserOp(st *State, user names.UserTag, password, salt string) txn.Op {
+func createInitialUserOps(controllerUUID string, user names.UserTag, password, salt string) []txn.Op {
 	nameToLower := strings.ToLower(user.Name())
+	dateCreated := nowToTheSecond()
 	doc := userDoc{
 		DocID:        nameToLower,
 		Name:         user.Name(),
@@ -142,14 +158,24 @@ func createInitialUserOp(st *State, user names.UserTag, password, salt string) t
 		PasswordHash: utils.UserPasswordHash(password, salt),
 		PasswordSalt: salt,
 		CreatedBy:    user.Name(),
-		DateCreated:  nowToTheSecond(),
+		DateCreated:  dateCreated,
 	}
-	return txn.Op{
+	ops := []txn.Op{{
 		C:      usersC,
 		Id:     nameToLower,
 		Assert: txn.DocMissing,
 		Insert: &doc,
-	}
+	}}
+	controllerUserOps := createControllerUserOps(controllerUUID,
+		names.NewUserTag(user.Name()),
+		names.NewUserTag(user.Name()),
+		user.Name(),
+		dateCreated,
+		defaultControllerPermission)
+
+	ops = append(ops, controllerUserOps...)
+	return ops
+
 }
 
 // getUser fetches information about the user with the

--- a/state/user_internal_test.go
+++ b/state/user_internal_test.go
@@ -6,9 +6,10 @@ package state
 import (
 	"strings"
 
-	"github.com/juju/juju/core/description"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/core/description"
 )
 
 type internalUserSuite struct {
@@ -33,15 +34,15 @@ func (s *internalUserSuite) TestCreateInitialUserOps(c *gc.C) {
 	op = ops[1]
 	permdoc := op.Insert.(*permissionDoc)
 	c.Assert(permdoc.Access, gc.Equals, string(description.LoginAccess))
-	c.Assert(permdoc.ID, gc.Equals, permissionID(controllerGlobalKey, userWithGlobalKey(strings.ToLower(tag.Canonical()))))
-	c.Assert(permdoc.SubjectGlobalKey, gc.Equals, userWithGlobalKey(strings.ToLower(tag.Canonical())))
+	c.Assert(permdoc.ID, gc.Equals, permissionID(controllerGlobalKey, userGlobalKey(strings.ToLower(tag.Canonical()))))
+	c.Assert(permdoc.SubjectGlobalKey, gc.Equals, userGlobalKey(strings.ToLower(tag.Canonical())))
 	c.Assert(permdoc.ObjectGlobalKey, gc.Equals, controllerGlobalKey)
 
 	// controller user
 	op = ops[2]
-	cudoc := op.Insert.(*controllerUserDoc)
+	cudoc := op.Insert.(*userAccessDoc)
 	c.Assert(cudoc.ID, gc.Equals, "admin@local")
-	c.Assert(cudoc.ControllerUUID, gc.Equals, s.state.ControllerUUID())
+	c.Assert(cudoc.ObjectUUID, gc.Equals, s.state.ControllerUUID())
 	c.Assert(cudoc.UserName, gc.Equals, "AdMiN@local")
 	c.Assert(cudoc.DisplayName, gc.Equals, "AdMiN")
 	c.Assert(cudoc.CreatedBy, gc.Equals, "AdMiN@local")

--- a/state/useraccess.go
+++ b/state/useraccess.go
@@ -1,0 +1,198 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/core/description"
+)
+
+type userAccessDoc struct {
+	ID          string    `bson:"_id"`
+	ObjectUUID  string    `bson:"object-uuid"`
+	UserName    string    `bson:"user"`
+	DisplayName string    `bson:"displayname"`
+	CreatedBy   string    `bson:"createdby"`
+	DateCreated time.Time `bson:"datecreated"`
+}
+
+// UserAccessSpec defines the attributes that can be set when adding a new
+// user access.
+type UserAccessSpec struct {
+	User        names.UserTag
+	CreatedBy   names.UserTag
+	DisplayName string
+	Access      description.Access
+}
+
+// AddModelUser adds a new user for the current model to the database.
+func (st *State) AddModelUser(spec UserAccessSpec) (description.UserAccess, error) {
+	if err := description.ValidateModelAccess(spec.Access); err != nil {
+		return description.UserAccess{}, errors.Annotate(err, "adding model user")
+	}
+	return st.addUserAccess(spec, modelGlobalKey)
+}
+
+// AddControllerUser adds a new user for the curent controller to the database.
+func (st *State) AddControllerUser(spec UserAccessSpec) (description.UserAccess, error) {
+	if err := description.ValidateControllerAccess(spec.Access); err != nil {
+		return description.UserAccess{}, errors.Annotate(err, "adding controller user")
+	}
+	return st.addUserAccess(spec, controllerGlobalKey)
+}
+
+func (st *State) addUserAccess(spec UserAccessSpec, targetGlobalKey string) (description.UserAccess, error) {
+	// Ensure local user exists in state before adding them as an model user.
+	if spec.User.IsLocal() {
+		localUser, err := st.User(spec.User)
+		if err != nil {
+			return description.UserAccess{}, errors.Annotate(err, fmt.Sprintf("user %q does not exist locally", spec.User.Name()))
+		}
+		if spec.DisplayName == "" {
+			spec.DisplayName = localUser.DisplayName()
+		}
+	}
+
+	// Ensure local createdBy user exists.
+	if spec.CreatedBy.IsLocal() {
+		if _, err := st.User(spec.CreatedBy); err != nil {
+			return description.UserAccess{}, errors.Annotatef(err, "createdBy user %q does not exist locally", spec.CreatedBy.Name())
+		}
+	}
+	var (
+		ops       []txn.Op
+		err       error
+		targetTag names.Tag
+	)
+	switch targetGlobalKey {
+	case modelGlobalKey:
+		ops = createModelUserOps(
+			st.ModelUUID(),
+			spec.User,
+			spec.CreatedBy,
+			spec.DisplayName,
+			nowToTheSecond(),
+			spec.Access)
+		targetTag = st.ModelTag()
+	case controllerGlobalKey:
+		ops = createControllerUserOps(
+			st.ControllerUUID(),
+			spec.User,
+			spec.CreatedBy,
+			spec.DisplayName,
+			nowToTheSecond(),
+			spec.Access)
+		targetTag = names.NewControllerTag(st.ControllerUUID())
+	default:
+		return description.UserAccess{}, errors.NotSupportedf("user access global key %q", targetGlobalKey)
+	}
+	err = st.runTransaction(ops)
+	if err == txn.ErrAborted {
+		err = errors.AlreadyExistsf("user access %q", spec.User.Canonical())
+	}
+	if err != nil {
+		return description.UserAccess{}, errors.Trace(err)
+	}
+	return st.UserAccess(spec.User, targetTag)
+}
+
+// userAccessID returns the document id of the user access.
+func userAccessID(user names.UserTag) string {
+	username := user.Canonical()
+	return strings.ToLower(username)
+}
+
+// NewModelUserAccess returns a new description.UserAccess for the given userDoc and
+// current Model.
+func NewModelUserAccess(st *State, userDoc userAccessDoc) (description.UserAccess, error) {
+	perm, err := st.userPermission(modelGlobalKey, userGlobalKey(strings.ToLower(userDoc.UserName)))
+	if err != nil {
+		return description.UserAccess{}, errors.Annotate(err, "obtaining model permission")
+	}
+	return newUserAccess(perm, userDoc, names.NewModelTag(userDoc.ObjectUUID)), nil
+}
+
+// NewControllerUserAccess returns a new description.UserAccess for the given userDoc and
+// current Controller.
+func NewControllerUserAccess(st *State, userDoc userAccessDoc) (description.UserAccess, error) {
+	perm, err := st.userPermission(controllerGlobalKey, userGlobalKey(strings.ToLower(userDoc.UserName)))
+	if err != nil {
+		return description.UserAccess{}, errors.Annotate(err, "obtaining controller permission")
+	}
+	return newUserAccess(perm, userDoc, names.NewControllerTag(userDoc.ObjectUUID)), nil
+}
+
+func newUserAccess(perm *permission, userDoc userAccessDoc, object names.Tag) description.UserAccess {
+	return description.UserAccess{
+		UserID:      userDoc.ID,
+		UserTag:     names.NewUserTag(userDoc.UserName),
+		Object:      object,
+		Access:      perm.access(),
+		CreatedBy:   names.NewUserTag(userDoc.CreatedBy),
+		DateCreated: userDoc.DateCreated.UTC(),
+		DisplayName: userDoc.DisplayName,
+		UserName:    userDoc.UserName,
+	}
+}
+
+// UserAccess returns a new description.UserAccess for the passed subject and target.
+func (st *State) UserAccess(subject names.UserTag, target names.Tag) (description.UserAccess, error) {
+	var (
+		userDoc userAccessDoc
+		err     error
+	)
+	switch target.Kind() {
+	case names.ModelTagKind:
+		userDoc, err = st.modelUser(subject)
+		if err == nil {
+			return NewModelUserAccess(st, userDoc)
+		}
+	case names.ControllerTagKind:
+		userDoc, err = st.controllerUser(subject)
+		if err == nil {
+			return NewControllerUserAccess(st, userDoc)
+		}
+	default:
+		return description.UserAccess{}, errors.NotValidf("%q as a target", target.Kind())
+	}
+	return description.UserAccess{}, errors.Trace(err)
+}
+
+// SetUserAccess sets <access> level on <target> to <subject>.
+func (st *State) SetUserAccess(subject names.UserTag, target names.Tag, access description.Access) (description.UserAccess, error) {
+	err := access.Validate()
+	if err != nil {
+		return description.UserAccess{}, errors.Trace(err)
+	}
+	switch target.Kind() {
+	case names.ModelTagKind:
+		err = st.setModelAccess(access, userGlobalKey(userAccessID(subject)))
+	case names.ControllerTagKind:
+		err = st.setControllerAccess(access, userGlobalKey(userAccessID(subject)))
+	default:
+		return description.UserAccess{}, errors.NotValidf("%q as a target", target.Kind())
+	}
+	if err != nil {
+		return description.UserAccess{}, errors.Trace(err)
+	}
+	return st.UserAccess(subject, target)
+}
+
+// RemoveUserAccess removes access for subject to the passed tag.
+func (st *State) RemoveUserAccess(subject names.UserTag, target names.Tag) error {
+	switch target.Kind() {
+	case names.ModelTagKind:
+		return errors.Trace(st.removeModelUser(subject))
+	case names.ControllerTagKind:
+		return errors.Trace(st.removeControllerUser(subject))
+	}
+	return errors.NotValidf("%q as a target", target.Kind())
+}

--- a/state/userpermission.go
+++ b/state/userpermission.go
@@ -76,7 +76,7 @@ func (p *permission) access() description.Access {
 }
 
 func (p *permission) isGreaterAccess(a description.Access) bool {
-	return stringToAccess(p.doc.Access).IsGreaterAccess(a)
+	return stringToAccess(p.doc.Access).LessAccessThan(a)
 }
 
 func permissionID(objectKey, subjectKey string) string {

--- a/state/userpermission.go
+++ b/state/userpermission.go
@@ -80,9 +80,9 @@ func (p *permission) isGreaterAccess(a description.Access) bool {
 }
 
 func permissionID(objectKey, subjectKey string) string {
-	// example: e#mo#jim
+	// example: e#us#jim
 	// e: model global key (its always e).
-	// mo: model user key prefix.
+	// us: user key prefix.
 	// jim: an arbitrary username.
 	return fmt.Sprintf("%s#%s", objectKey, subjectKey)
 }

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -46,14 +46,13 @@ func NewFactory(st *state.State) *Factory {
 
 // UserParams defines the parameters for creating a user with MakeUser.
 type UserParams struct {
-	Name                string
-	DisplayName         string
-	Password            string
-	Creator             names.Tag
-	NoModelUser         bool
-	Disabled            bool
-	Access              description.Access
-	ExpectedCreateError string
+	Name        string
+	DisplayName string
+	Password    string
+	Creator     names.Tag
+	NoModelUser bool
+	Disabled    bool
+	Access      description.Access
 }
 
 // ModelUserParams defines the parameters for creating an environment user.
@@ -185,13 +184,9 @@ func (factory *Factory) MakeUser(c *gc.C, params *UserParams) *state.User {
 	creatorUserTag := params.Creator.(names.UserTag)
 	user, err := factory.st.AddUser(
 		params.Name, params.DisplayName, params.Password, creatorUserTag.Name())
-	if params.ExpectedCreateError != "" {
-		c.Assert(err, gc.ErrorMatches, params.ExpectedCreateError)
-	} else {
-		c.Assert(err, jc.ErrorIsNil)
-	}
+	c.Assert(err, jc.ErrorIsNil)
 	if !params.NoModelUser {
-		_, err := factory.st.AddModelUser(state.ModelUserSpec{
+		_, err := factory.st.AddModelUser(state.UserAccessSpec{
 			User:        user.UserTag(),
 			CreatedBy:   names.NewUserTag(user.CreatedBy()),
 			DisplayName: params.DisplayName,
@@ -210,7 +205,7 @@ func (factory *Factory) MakeUser(c *gc.C, params *UserParams) *state.User {
 // attributes of ModelUserParams that are the default empty values, some
 // meaningful valid values are used instead. If params is not specified,
 // defaults are used.
-func (factory *Factory) MakeModelUser(c *gc.C, params *ModelUserParams) *state.ModelUser {
+func (factory *Factory) MakeModelUser(c *gc.C, params *ModelUserParams) description.UserAccess {
 	if params == nil {
 		params = &ModelUserParams{}
 	}
@@ -230,7 +225,7 @@ func (factory *Factory) MakeModelUser(c *gc.C, params *ModelUserParams) *state.M
 		params.CreatedBy = env.Owner()
 	}
 	createdByUserTag := params.CreatedBy.(names.UserTag)
-	modelUser, err := factory.st.AddModelUser(state.ModelUserSpec{
+	modelUser, err := factory.st.AddModelUser(state.UserAccessSpec{
 		User:        names.NewUserTag(params.User),
 		CreatedBy:   createdByUserTag,
 		DisplayName: params.DisplayName,

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -46,13 +46,14 @@ func NewFactory(st *state.State) *Factory {
 
 // UserParams defines the parameters for creating a user with MakeUser.
 type UserParams struct {
-	Name        string
-	DisplayName string
-	Password    string
-	Creator     names.Tag
-	NoModelUser bool
-	Disabled    bool
-	Access      description.Access
+	Name                string
+	DisplayName         string
+	Password            string
+	Creator             names.Tag
+	NoModelUser         bool
+	Disabled            bool
+	Access              description.Access
+	ExpectedCreateError string
 }
 
 // ModelUserParams defines the parameters for creating an environment user.
@@ -184,7 +185,11 @@ func (factory *Factory) MakeUser(c *gc.C, params *UserParams) *state.User {
 	creatorUserTag := params.Creator.(names.UserTag)
 	user, err := factory.st.AddUser(
 		params.Name, params.DisplayName, params.Password, creatorUserTag.Name())
-	c.Assert(err, jc.ErrorIsNil)
+	if params.ExpectedCreateError != "" {
+		c.Assert(err, gc.ErrorMatches, params.ExpectedCreateError)
+	} else {
+		c.Assert(err, jc.ErrorIsNil)
+	}
 	if !params.NoModelUser {
 		_, err := factory.st.AddModelUser(state.ModelUserSpec{
 			User:        user.UserTag(),

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
@@ -91,7 +92,7 @@ func (s *factorySuite) TestMakeUserParams(c *gc.C) {
 	c.Assert(err, jc.Satisfies, state.IsNeverLoggedInError)
 	c.Assert(savedLastLogin, gc.Equals, lastLogin)
 
-	_, err = s.State.ModelUser(user.UserTag())
+	_, err = s.State.UserAccess(user.UserTag(), s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -126,18 +127,18 @@ func (s *factorySuite) TestMakeUserNoModelUser(c *gc.C) {
 
 	_, err := s.State.User(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.ModelUser(user.UserTag())
+	_, err = s.State.UserAccess(user.UserTag(), s.State.ModelTag())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *factorySuite) TestMakeModelUserNil(c *gc.C) {
 	modelUser := s.Factory.MakeModelUser(c, nil)
-	saved, err := s.State.ModelUser(modelUser.UserTag())
+	saved, err := s.State.UserAccess(modelUser.UserTag, modelUser.Object)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(saved.ModelTag().Id(), gc.Equals, modelUser.ModelTag().Id())
-	c.Assert(saved.UserName(), gc.Equals, modelUser.UserName())
-	c.Assert(saved.DisplayName(), gc.Equals, modelUser.DisplayName())
-	c.Assert(saved.CreatedBy(), gc.Equals, modelUser.CreatedBy())
+	c.Assert(saved.Object.Id(), gc.Equals, modelUser.Object.Id())
+	c.Assert(saved.UserName, gc.Equals, modelUser.UserName)
+	c.Assert(saved.DisplayName, gc.Equals, modelUser.DisplayName)
+	c.Assert(saved.CreatedBy, gc.Equals, modelUser.CreatedBy)
 }
 
 func (s *factorySuite) TestMakeModelUserPartialParams(c *gc.C) {
@@ -145,12 +146,12 @@ func (s *factorySuite) TestMakeModelUserPartialParams(c *gc.C) {
 	modelUser := s.Factory.MakeModelUser(c, &factory.ModelUserParams{
 		User: "foobar123"})
 
-	saved, err := s.State.ModelUser(modelUser.UserTag())
+	saved, err := s.State.UserAccess(modelUser.UserTag, modelUser.Object)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(saved.ModelTag().Id(), gc.Equals, modelUser.ModelTag().Id())
-	c.Assert(saved.UserName(), gc.Equals, "foobar123@local")
-	c.Assert(saved.DisplayName(), gc.Equals, modelUser.DisplayName())
-	c.Assert(saved.CreatedBy(), gc.Equals, modelUser.CreatedBy())
+	c.Assert(saved.Object.Id(), gc.Equals, modelUser.Object.Id())
+	c.Assert(saved.UserName, gc.Equals, "foobar123@local")
+	c.Assert(saved.DisplayName, gc.Equals, modelUser.DisplayName)
+	c.Assert(saved.CreatedBy, gc.Equals, modelUser.CreatedBy)
 }
 
 func (s *factorySuite) TestMakeModelUserParams(c *gc.C) {
@@ -167,12 +168,12 @@ func (s *factorySuite) TestMakeModelUserParams(c *gc.C) {
 		DisplayName: "Foo Bar",
 	})
 
-	saved, err := s.State.ModelUser(modelUser.UserTag())
+	saved, err := s.State.UserAccess(modelUser.UserTag, s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(saved.ModelTag().Id(), gc.Equals, modelUser.ModelTag().Id())
-	c.Assert(saved.UserName(), gc.Equals, "foobar@local")
-	c.Assert(saved.CreatedBy(), gc.Equals, "createdby@local")
-	c.Assert(saved.DisplayName(), gc.Equals, "Foo Bar")
+	c.Assert(saved.Object.Id(), gc.Equals, modelUser.Object.Id())
+	c.Assert(saved.UserName, gc.Equals, "foobar@local")
+	c.Assert(saved.CreatedBy.Id(), gc.Equals, "createdby@local")
+	c.Assert(saved.DisplayName, gc.Equals, "Foo Bar")
 }
 
 func (s *factorySuite) TestMakeModelUserInvalidCreatedBy(c *gc.C) {
@@ -184,9 +185,9 @@ func (s *factorySuite) TestMakeModelUserInvalidCreatedBy(c *gc.C) {
 	}
 
 	c.Assert(invalidFunc, gc.PanicMatches, `interface conversion: .*`)
-	saved, err := s.State.ModelUser(names.NewLocalUserTag("bob"))
+	saved, err := s.State.UserAccess(names.NewLocalUserTag("bob"), s.State.ModelTag())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Assert(saved, gc.IsNil)
+	c.Assert(saved, gc.DeepEquals, description.UserAccess{})
 }
 
 func (s *factorySuite) TestMakeModelUserNonLocalUser(c *gc.C) {
@@ -197,12 +198,12 @@ func (s *factorySuite) TestMakeModelUserNonLocalUser(c *gc.C) {
 		CreatedBy:   creator.UserTag(),
 	})
 
-	saved, err := s.State.ModelUser(modelUser.UserTag())
+	saved, err := s.State.UserAccess(modelUser.UserTag, s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(saved.ModelTag().Id(), gc.Equals, modelUser.ModelTag().Id())
-	c.Assert(saved.UserName(), gc.Equals, "foobar@ubuntuone")
-	c.Assert(saved.DisplayName(), gc.Equals, "Foo Bar")
-	c.Assert(saved.CreatedBy(), gc.Equals, creator.UserTag().Canonical())
+	c.Assert(saved.Object.Id(), gc.Equals, modelUser.Object.Id())
+	c.Assert(saved.UserName, gc.Equals, "foobar@ubuntuone")
+	c.Assert(saved.DisplayName, gc.Equals, "Foo Bar")
+	c.Assert(saved.CreatedBy.Canonical(), gc.Equals, creator.UserTag().Canonical())
 }
 
 func (s *factorySuite) TestMakeMachineNil(c *gc.C) {


### PR DESCRIPTION
* There is now a layer to persist controller level permissions.
 * A ControllerUser is created with each new User.
 * Three new permission levels have been added for controllers (login, addmodel, superuser).
 * ControllerUsers get Login permission by default.

(Review request: http://reviews.vapour.ws/r/5282/)