### PR TITLE
Don't check close.

### DIFF
--- a/utils/ssh/ssh_gocrypto_test.go
+++ b/utils/ssh/ssh_gocrypto_test.go
@@ -49,10 +49,7 @@ func newServer(c *gc.C) *sshServer {
 func (s *sshServer) run(c *gc.C) {
 	netconn, err := s.listener.Accept()
 	c.Assert(err, jc.ErrorIsNil)
-	defer func() {
-		err := netconn.Close()
-		c.Assert(err, jc.ErrorIsNil)
-	}()
+	defer netconn.Close()
 	conn, chans, reqs, err := cryptossh.NewServerConn(netconn, s.cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	s.client = cryptossh.NewClient(conn, chans, reqs)


### PR DESCRIPTION
Fixes http://pad.lv/1458585 by doing the same fix that is now in github.com/juju/utils/ssh that master uses.

Effectively the goroutine outlives the test and there is currently no way for the test to stop the server. Simple fix is to not check the Close error. All it says is "oh, it's already closed".

(Review request: http://reviews.vapour.ws/r/5284/)