### PR TITLE
Don't try to remove all the records for an entire environment at once.

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -355,6 +355,7 @@ func allCollections() collectionSchema {
 		storageConstraintsC: {},
 		statusesC:           {},
 		statusesHistoryC: {
+			rawAccess: true,
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "globalkey", "updated"},
 			}},

--- a/state/unit.go
+++ b/state/unit.go
@@ -349,9 +349,6 @@ func (u *Unit) Destroy() (err error) {
 func (u *Unit) eraseHistory() error {
 	history, closer := u.st.getCollection(statusesHistoryC)
 	defer closer()
-	// XXX(fwereade): 2015-06-19 this is anything but safe: we must not mix
-	// txn and non-txn operations in the same collection without clear and
-	// detailed reasoning for so doing.
 	historyW := history.Writeable()
 
 	if _, err := historyW.RemoveAll(bson.D{{"statusid", u.globalKey()}}); err != nil {


### PR DESCRIPTION
Addresses http://pad.lv/1579010. Instead of building up a single transaction that tries to remove all of a models documents in one go, just address each collection in a transaction. Also uses juju/retry to catch any intermittent errors while iterating through all the collections.

(Review request: http://reviews.vapour.ws/r/5285/)