### PR TITLE
Better error message when a stale model uuid is used

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -126,9 +126,9 @@ func (s *apiclientSuite) TestOpenHonorsModelTag(c *gc.C) {
 	_, err := api.Open(info, api.DialOpts{})
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
 		Message: `unknown model: "bad-tag"`,
-		Code:    "not found",
+		Code:    "model not found",
 	})
-	c.Check(params.ErrCode(err), gc.Equals, params.CodeNotFound)
+	c.Check(params.ErrCode(err), gc.Equals, params.CodeModelNotFound)
 
 	// Now set it to the right tag, and we should succeed.
 	info.ModelTag = s.State.ModelTag()

--- a/api/base/caller.go
+++ b/api/base/caller.go
@@ -4,21 +4,12 @@
 package base
 
 import (
-	"fmt"
 	"io"
 	"net/url"
 
-	"github.com/juju/errors"
 	"github.com/juju/httprequest"
 	"gopkg.in/juju/names.v2"
 )
-
-// OldAgentError is returned when an api call is not supported
-// by the Juju agent.
-func OldAgentError(operation string, vers string) error {
-	return errors.NewNotSupported(
-		nil, fmt.Sprintf("%s not supported. Please upgrade API server to Juju %v or later", operation, vers))
-}
 
 // APICaller is implemented by the client-facing State object.
 // It defines the lowest level of API calls and is used by

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -456,7 +456,7 @@ func (s *clientSuite) TestConnectStreamAtUUIDPath(c *gc.C) {
 	c.Assert(connectURL.Path, gc.Matches, fmt.Sprintf("/model/%s/path", environ.UUID()))
 }
 
-func (s *clientSuite) TestOpenUsesEnvironUUIDPaths(c *gc.C) {
+func (s *clientSuite) TestOpenUsesModelUUIDPaths(c *gc.C) {
 	info := s.APIInfo(c)
 
 	// Passing in the correct model UUID should work
@@ -472,13 +472,13 @@ func (s *clientSuite) TestOpenUsesEnvironUUIDPaths(c *gc.C) {
 	apistate, err = api.Open(info, api.DialOpts{})
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
 		Message: `unknown model: "dead-beef-123456"`,
-		Code:    "not found",
+		Code:    "model not found",
 	})
-	c.Check(err, jc.Satisfies, params.IsCodeNotFound)
+	c.Check(err, jc.Satisfies, params.IsCodeModelNotFound)
 	c.Assert(apistate, gc.IsNil)
 }
 
-func (s *clientSuite) TestSetEnvironAgentVersionDuringUpgrade(c *gc.C) {
+func (s *clientSuite) TestSetModelAgentVersionDuringUpgrade(c *gc.C) {
 	// This is an integration test which ensure that a test with the
 	// correct error code is seen by the client from the
 	// SetModelAgentVersion call when an upgrade is in progress.

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -55,10 +55,10 @@ func (s *baseLoginSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *baseLoginSuite) setupServer(c *gc.C) (api.Connection, func()) {
-	return s.setupServerForEnvironment(c, s.State.ModelTag())
+	return s.setupServerForModel(c, s.State.ModelTag())
 }
 
-func (s *baseLoginSuite) setupServerForEnvironment(c *gc.C, modelTag names.ModelTag) (api.Connection, func()) {
+func (s *baseLoginSuite) setupServerForModel(c *gc.C, modelTag names.ModelTag) (api.Connection, func()) {
 	info, cleanup := s.setupServerForEnvironmentWithValidator(c, modelTag, nil)
 	st, err := api.Open(info, fastDialOpts)
 	c.Assert(err, jc.ErrorIsNil)
@@ -623,7 +623,7 @@ func (s *loginSuite) TestControllerModel(c *gc.C) {
 	err := st.Login(adminUser, "dummy-secret", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertRemoteEnvironment(c, st, s.State.ModelTag())
+	s.assertRemoteModel(c, st, s.State.ModelTag())
 }
 
 func (s *loginSuite) TestControllerModelBadCreds(c *gc.C) {
@@ -642,7 +642,7 @@ func (s *loginSuite) TestControllerModelBadCreds(c *gc.C) {
 	})
 }
 
-func (s *loginSuite) TestNonExistentEnvironment(c *gc.C) {
+func (s *loginSuite) TestNonExistentModel(c *gc.C) {
 	info, cleanup := s.setupServerWithValidator(c, nil)
 	defer cleanup()
 
@@ -656,11 +656,11 @@ func (s *loginSuite) TestNonExistentEnvironment(c *gc.C) {
 	err = st.Login(adminUser, "dummy-secret", "", nil)
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
 		Message: fmt.Sprintf("unknown model: %q", uuid),
-		Code:    "not found",
+		Code:    "model not found",
 	})
 }
 
-func (s *loginSuite) TestInvalidEnvironment(c *gc.C) {
+func (s *loginSuite) TestInvalidModel(c *gc.C) {
 	info, cleanup := s.setupServerWithValidator(c, nil)
 	defer cleanup()
 
@@ -672,11 +672,11 @@ func (s *loginSuite) TestInvalidEnvironment(c *gc.C) {
 	err := st.Login(adminUser, "dummy-secret", "", nil)
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
 		Message: `unknown model: "rubbish"`,
-		Code:    "not found",
+		Code:    "model not found",
 	})
 }
 
-func (s *loginSuite) TestOtherEnvironment(c *gc.C) {
+func (s *loginSuite) TestOtherModel(c *gc.C) {
 	info, cleanup := s.setupServerWithValidator(c, nil)
 	defer cleanup()
 
@@ -691,10 +691,10 @@ func (s *loginSuite) TestOtherEnvironment(c *gc.C) {
 
 	err := st.Login(envOwner.UserTag(), "password", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertRemoteEnvironment(c, st, envState.ModelTag())
+	s.assertRemoteModel(c, st, envState.ModelTag())
 }
 
-func (s *loginSuite) TestMachineLoginOtherEnvironment(c *gc.C) {
+func (s *loginSuite) TestMachineLoginOtherModel(c *gc.C) {
 	// User credentials are checked against a global user list.
 	// Machine credentials are checked against environment specific
 	// machines, so this makes sure that the credential checking is
@@ -761,7 +761,7 @@ func (s *loginSuite) TestOtherEnvironmentWhenNotController(c *gc.C) {
 	})
 }
 
-func (s *loginSuite) assertRemoteEnvironment(c *gc.C, st api.Connection, expected names.ModelTag) {
+func (s *loginSuite) assertRemoteModel(c *gc.C, st api.Connection, expected names.ModelTag) {
 	// Look at what the api thinks it has.
 	tag, err := st.ModelTag()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -33,7 +33,7 @@ func (e *noAddressSetError) Error() string {
 }
 
 func NoAddressSetError(unitTag names.UnitTag, addressName string) error {
-	return &noAddressSetError{unitTag, addressName}
+	return &noAddressSetError{unitTag: unitTag, addressName: addressName}
 }
 
 func isNoAddressSetError(err error) bool {
@@ -93,7 +93,6 @@ var (
 	ErrPerm               = errors.New("permission denied")
 	ErrNotLoggedIn        = errors.New("not logged in")
 	ErrUnknownWatcher     = errors.New("unknown watcher id")
-	ErrUnknownPinger      = errors.New("unknown pinger id")
 	ErrStoppedWatcher     = errors.New("watcher has been stopped")
 	ErrBadRequest         = errors.New("invalid request")
 	ErrTryAgain           = errors.New("try again")
@@ -165,7 +164,8 @@ func ServerErrorAndStatus(err error) (*params.Error, int) {
 	switch err1.Code {
 	case params.CodeUnauthorized:
 		status = http.StatusUnauthorized
-	case params.CodeNotFound:
+	case params.CodeNotFound,
+		params.CodeModelNotFound:
 		status = http.StatusNotFound
 	case params.CodeBadRequest:
 		status = http.StatusBadRequest
@@ -218,7 +218,7 @@ func ServerError(err error) *params.Error {
 	case state.IsHasAttachmentsError(err):
 		code = params.CodeMachineHasAttachedStorage
 	case isUnknownModelError(err):
-		code = params.CodeNotFound
+		code = params.CodeModelNotFound
 	case errors.IsNotSupported(err):
 		code = params.CodeNotSupported
 	case errors.IsBadRequest(err):

--- a/apiserver/common/errors_test.go
+++ b/apiserver/common/errors_test.go
@@ -182,9 +182,9 @@ var errorTransformTests = []struct {
 	code:   "",
 }, {
 	err:        common.UnknownModelError("dead-beef-123456"),
-	code:       params.CodeNotFound,
+	code:       params.CodeModelNotFound,
 	status:     http.StatusNotFound,
-	helperFunc: params.IsCodeNotFound,
+	helperFunc: params.IsCodeModelNotFound,
 }, {
 	err:    nil,
 	code:   "",
@@ -232,12 +232,9 @@ func (s *errorsSuite) TestErrorTransform(c *gc.C) {
 			params.CodeNoAddressSet,
 			params.CodeUpgradeInProgress,
 			params.CodeMachineHasAttachedStorage,
-			params.CodeDischargeRequired:
+			params.CodeDischargeRequired,
+			params.CodeModelNotFound:
 			continue
-		case params.CodeNotFound:
-			if common.IsUnknownModelError(t.err) {
-				continue
-			}
 		case params.CodeOperationBlocked:
 			// ServerError doesn't actually have a case for this code.
 			continue

--- a/apiserver/common/export_test.go
+++ b/apiserver/common/export_test.go
@@ -12,7 +12,6 @@ var (
 	EnvtoolsFindTools       = &envtoolsFindTools
 	SendMetrics             = &sendMetrics
 	MockableDestroyMachines = destroyMachines
-	IsUnknownModelError     = isUnknownModelError
 )
 
 type Patcher interface {

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -58,6 +58,7 @@ func (e Error) GoString() string {
 // The Code constants hold error codes for some kinds of error.
 const (
 	CodeNotFound                  = "not found"
+	CodeModelNotFound             = "model not found"
 	CodeUnauthorized              = "unauthorized access"
 	CodeLoginExpired              = "login expired"
 	CodeCannotEnterScope          = "cannot enter scope"
@@ -109,6 +110,10 @@ func IsCodeActionNotAvailable(err error) bool {
 
 func IsCodeNotFound(err error) bool {
 	return ErrCode(err) == CodeNotFound
+}
+
+func IsCodeModelNotFound(err error) bool {
+	return ErrCode(err) == CodeModelNotFound
 }
 
 func IsCodeUnauthorized(err error) bool {

--- a/apiserver/utils.go
+++ b/apiserver/utils.go
@@ -45,12 +45,10 @@ type validateArgs struct {
 func validateModelUUID(args validateArgs) (string, error) {
 	ssState := args.statePool.SystemState()
 	if args.modelUUID == "" {
-		// We allow the modelUUID to be empty for 2 cases
-		// 1) Compatibility with older clients
-		// 2) TODO: server a limited API at the root (empty modelUUID)
-		//    with just the user manager and model manager
-		//    if the connection comes over a sufficiently up to date
-		//    login command.
+		// We allow the modelUUID to be empty so that:
+		//    TODO: server a limited API at the root (empty modelUUID)
+		//    just the user manager and model manager are able to accept
+		//    requests that don't require a modelUUID, like add-model.
 		if args.strict {
 			return "", errors.Trace(common.UnknownModelError(args.modelUUID))
 		}

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -122,7 +122,7 @@ var newApiClientForStatus = func(c *statusCommand) (statusAPI, error) {
 func (c *statusCommand) Run(ctx *cmd.Context) error {
 	apiclient, err := newApiClientForStatus(c)
 	if err != nil {
-		return errors.Annotate(err, "connecting to API")
+		return errors.Trace(err)
 	}
 	defer apiclient.Close()
 

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -4,8 +4,12 @@
 package modelcmd_test
 
 import (
+	"fmt"
+	"strings"
+
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/errors"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -23,12 +27,18 @@ var _ = gc.Suite(&BaseCommandSuite{})
 
 func (s *BaseCommandSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	//s.PatchEnvironment("JUJU_CLI_VERSION", "")
 
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = "foo"
 	s.store.Controllers["foo"] = jujuclient.ControllerDetails{
 		APIEndpoints: []string{"testing.invalid:1234"},
+	}
+	s.store.Models["foo"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{
+			"admin@local/badmodel":  {"deadbeef"},
+			"admin@local/goodmodel": {"deadbeef2"},
+		},
+		CurrentModel: "admin@local/badmodel",
 	}
 	s.store.Accounts["foo"] = jujuclient.AccountDetails{
 		User: "bar@local", Password: "hunter2",
@@ -50,4 +60,29 @@ To log back in, run the following command:
 
     juju login bar
 `)
+}
+
+func (s *BaseCommandSuite) assertUnknownModel(c *gc.C, current, expectedCurrent string) {
+	s.store.Models["foo"].CurrentModel = current
+	apiOpen := func(*api.Info, api.DialOpts) (api.Connection, error) {
+		return nil, errors.Trace(&params.Error{Code: params.CodeModelNotFound, Message: "model deaddeaf not found"})
+	}
+	cmd := modelcmd.NewModelCommandBase(s.store, "foo", "admin@local/badmodel")
+	cmd.SetAPIOpen(apiOpen)
+	conn, err := cmd.NewAPIRoot()
+	c.Assert(conn, gc.IsNil)
+	msg := strings.Replace(err.Error(), "\n", "", -1)
+	c.Assert(msg, gc.Equals, `model "admin@local/badmodel" has been removed from the controller, run 'juju models' and switch to one of them.There are 1 accessible models on controller "foo".`)
+	c.Assert(s.store.Models["foo"].Models, gc.HasLen, 1)
+	fmt.Println(s.store.Models)
+	c.Assert(s.store.Models["foo"].Models["admin@local/goodmodel"], gc.DeepEquals, jujuclient.ModelDetails{"deadbeef2"})
+	c.Assert(s.store.Models["foo"].CurrentModel, gc.Equals, expectedCurrent)
+}
+
+func (s *BaseCommandSuite) TestUnknownModel(c *gc.C) {
+	s.assertUnknownModel(c, "admin@local/badmodel", "")
+}
+
+func (s *BaseCommandSuite) TestUnknownModelNotCurrent(c *gc.C) {
+	s.assertUnknownModel(c, "admin@local/goodmodel", "admin@local/goodmodel")
 }

--- a/juju/api.go
+++ b/juju/api.go
@@ -5,7 +5,6 @@ package juju
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/juju/errors"
@@ -32,8 +31,6 @@ type apiStateCachedInfo struct {
 	// newly retrieved, and should be cached in the config store.
 	cachedInfo *api.Info
 }
-
-var errAborted = fmt.Errorf("aborted")
 
 // NewAPIConnectionParams contains the parameters for creating a new Juju API
 // connection.


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1602034

When an api request is made, if the model uuid is not found, a new model not found error code is returned. On the client side, this is used to print a more user friendly error.

Also some drive by cleanup of unused code.

(Review request: http://reviews.vapour.ws/r/5287/)