### PR TITLE
environs: refactor PrepareForBootstrap

### DIFF
--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -135,6 +135,7 @@ func (c *restoreCommand) Init(args []string) error {
 
 type restoreBootstrapParams struct {
 	ControllerConfig controller.Config
+	CloudType        string
 	CloudName        string
 	CloudRegion      string
 	CredentialName   string
@@ -159,7 +160,7 @@ func (c *restoreCommand) getEnviron(
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	provider, err := environs.Provider(params.Config.Type())
+	provider, err := environs.Provider(config.CloudType)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
@@ -205,6 +206,7 @@ func (c *restoreCommand) getEnviron(
 	env, err := environs.New(cfg)
 	return env, &restoreBootstrapParams{
 		ControllerConfig: controllerCfg,
+		CloudType:        config.CloudType,
 		CloudName:        config.Cloud,
 		CloudRegion:      config.CloudRegion,
 		CredentialName:   config.Credential,

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -71,6 +71,7 @@ func (s *restoreSuite) SetUpTest(c *gc.C) {
 	}
 	s.store.BootstrapConfig["testing"] = jujuclient.BootstrapConfig{
 		Cloud:       "mycloud",
+		CloudType:   "dummy",
 		CloudRegion: "a-region",
 		Config: map[string]interface{}{
 			"type": "dummy",

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -749,7 +749,9 @@ func (s *BootstrapSuite) TestAutoSyncLocalSource(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := modelcmd.NewGetBootstrapConfigFunc(s.store)("devcontroller")
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := p.PrepareForBootstrap(envtesting.BootstrapContext(c), cfg)
+	env, err := p.Open(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	err = env.PrepareForBootstrap(envtesting.BootstrapContext(c))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Now check the available tools which are the 1.2.0 envtools.

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -340,25 +340,54 @@ func (c *destroyCommandBase) Init(args []string) error {
 // Environ by first checking the config store, then querying the
 // API if the information is not in the store.
 func (c *destroyCommandBase) getControllerEnviron(
-	store jujuclient.ClientStore, controllerName string, sysAPI destroyControllerAPI,
-) (_ environs.Environ, err error) {
-	cfg, err := modelcmd.NewGetBootstrapConfigFunc(store)(controllerName)
+	store jujuclient.ClientStore,
+	controllerName string,
+	sysAPI destroyControllerAPI,
+) (environs.Environ, error) {
+	env, err := c.getControllerEnvironFromStore(store, controllerName)
 	if errors.IsNotFound(err) {
-		if sysAPI == nil {
-			return nil, errors.New(
-				"unable to get bootstrap information from client store or API",
-			)
-		}
-		bootstrapConfig, err := sysAPI.ModelConfig()
-		if err != nil {
-			return nil, errors.Annotate(err, "getting bootstrap config from API")
-		}
-		cfg, err = config.New(config.NoDefaults, bootstrapConfig)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
+		return c.getControllerEnvironFromAPI(sysAPI, controllerName)
 	} else if err != nil {
-		return nil, errors.Annotate(err, "getting bootstrap config from client store")
+		return nil, errors.Annotate(err, "getting environ using bootstrap config from client store")
+	}
+	return env, nil
+}
+
+func (c *destroyCommandBase) getControllerEnvironFromStore(
+	store jujuclient.ClientStore,
+	controllerName string,
+) (environs.Environ, error) {
+	bootstrapConfig, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(store)(controllerName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	provider, err := environs.Provider(bootstrapConfig.CloudType)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	cfg, err := provider.BootstrapConfig(*params)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return environs.New(cfg)
+}
+
+func (c *destroyCommandBase) getControllerEnvironFromAPI(
+	api destroyControllerAPI,
+	controllerName string,
+) (environs.Environ, error) {
+	if api == nil {
+		return nil, errors.New(
+			"unable to get bootstrap information from client store or API",
+		)
+	}
+	attrs, err := api.ModelConfig()
+	if err != nil {
+		return nil, errors.Annotate(err, "getting model config from API")
+	}
+	cfg, err := config.New(config.NoDefaults, attrs)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 	return environs.New(cfg)
 }

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -184,7 +184,8 @@ func (s *baseDestroySuite) SetUpTest(c *gc.C) {
 		})
 		if model.bootstrapCfg != nil {
 			s.store.BootstrapConfig[controllerName] = jujuclient.BootstrapConfig{
-				Config: createBootstrapInfo(c, "admin"),
+				Config:    createBootstrapInfo(c, "admin"),
+				CloudType: "dummy",
 			}
 		}
 
@@ -285,7 +286,7 @@ func (s *DestroySuite) TestDestroyControllerGetFails(c *gc.C) {
 	s.api.SetErrors(errors.NotFoundf(`controller "test3"`))
 	_, err := s.runDestroyCommand(c, "test3", "-y")
 	c.Assert(err, gc.ErrorMatches,
-		"getting controller environ: getting bootstrap config from API: controller \"test3\" not found",
+		"getting controller environ: getting model config from API: controller \"test3\" not found",
 	)
 	checkControllerExistsInStore(c, "test3", s.store)
 }
@@ -351,7 +352,8 @@ func (s *DestroySuite) resetController(c *gc.C) {
 		User: "admin@local",
 	}
 	s.store.BootstrapConfig["test1"] = jujuclient.BootstrapConfig{
-		Config: createBootstrapInfo(c, "admin"),
+		Config:    createBootstrapInfo(c, "admin"),
+		CloudType: "dummy",
 	}
 }
 

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -91,7 +91,7 @@ func (s *KillSuite) TestKillEnvironmentGetFailsWithAPIConnection(c *gc.C) {
 	s.api.SetErrors(errors.NotFoundf(`controller "test3"`))
 	_, err := s.runKillCommand(c, "test3", "-y")
 	c.Assert(err, gc.ErrorMatches,
-		"getting controller environ: getting bootstrap config from API: controller \"test3\" not found",
+		"getting controller environ: getting model config from API: controller \"test3\" not found",
 	)
 	checkControllerExistsInStore(c, "test3", s.store)
 }

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -101,6 +101,7 @@ func (s *ShowControllerSuite) TestShowControllerWithBootstrapConfig(c *gc.C) {
 			"extra": "value",
 		},
 		Credential:    "my-credential",
+		CloudType:     "maas",
 		Cloud:         "mallards",
 		CloudRegion:   "mallards1",
 		CloudEndpoint: "http://mallards.local/MAAS",

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -803,7 +803,9 @@ func (s *BootstrapSuite) makeTestModel(c *gc.C) {
 		Config:         cfg,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := provider.PrepareForBootstrap(nullContext(), cfg)
+	env, err := provider.Open(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	err = env.PrepareForBootstrap(nullContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)

--- a/cmd/plugins/juju-metadata/validateimagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata_test.go
@@ -113,6 +113,7 @@ func cacheTestEnvConfig(c *gc.C, store *jujuclienttesting.MemStore) {
 	store.BootstrapConfig["ec2-controller"] = jujuclient.BootstrapConfig{
 		Config:      ec2Config.AllAttrs(),
 		Cloud:       "ec2",
+		CloudType:   "ec2",
 		CloudRegion: "us-east-1",
 	}
 
@@ -140,6 +141,7 @@ func cacheTestEnvConfig(c *gc.C, store *jujuclienttesting.MemStore) {
 	store.BootstrapConfig["azure-controller"] = jujuclient.BootstrapConfig{
 		Config:               azureConfig.AllAttrs(),
 		Cloud:                "azure",
+		CloudType:            "azure",
 		CloudRegion:          "West US",
 		CloudEndpoint:        "https://management.azure.com",
 		CloudStorageEndpoint: "https://core.windows.net",

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -167,8 +167,11 @@ func prepare(
 	if err != nil {
 		return nil, details, errors.Trace(err)
 	}
-	env, err := p.PrepareForBootstrap(ctx, cfg)
+	env, err := p.Open(cfg)
 	if err != nil {
+		return nil, details, errors.Trace(err)
+	}
+	if err := env.PrepareForBootstrap(ctx); err != nil {
 		return nil, details, errors.Trace(err)
 	}
 
@@ -207,6 +210,7 @@ func prepare(
 	details.ModelUUID = cfg.UUID()
 	details.ControllerDetails.Cloud = args.CloudName
 	details.ControllerDetails.CloudRegion = args.CloudRegion
+	details.BootstrapConfig.CloudType = cfg.Type()
 	details.BootstrapConfig.Cloud = args.CloudName
 	details.BootstrapConfig.CloudRegion = args.CloudRegion
 	details.CloudEndpoint = args.CloudEndpoint

--- a/environs/bootstrap/prepare_test.go
+++ b/environs/bootstrap/prepare_test.go
@@ -94,7 +94,8 @@ func (*PrepareSuite) TestPrepare(c *gc.C) {
 			"development":               false,
 			"test-mode":                 false,
 		},
-		Cloud: "dummy",
+		Cloud:     "dummy",
+		CloudType: "dummy",
 	})
 
 	// Check we cannot call Prepare again.

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -31,9 +31,6 @@ type EnvironProvider interface {
 	// local files, etc are not available.
 	PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error)
 
-	// PrepareForBootstrap prepares an environment for use.
-	PrepareForBootstrap(ctx BootstrapContext, cfg *config.Config) (Environ, error)
-
 	// BootstrapConfig produces the configuration for the initial controller
 	// model, based on the provided arguments. BootstrapConfig is expected
 	// to produce a deterministic output. Any unique values should be based
@@ -166,6 +163,13 @@ type ConfigGetter interface {
 // implementation.  The typical provider implementation needs locking to
 // avoid undefined behaviour when the configuration changes.
 type Environ interface {
+	// PrepareForBootstrap prepares an environment for bootstrapping.
+	//
+	// This will be called very early in the bootstrap procedure, to
+	// give an Environ a chance to perform interactive operations that
+	// are required for bootstrapping.
+	PrepareForBootstrap(ctx BootstrapContext) error
+
 	// Bootstrap creates a new instance with the series and architecture
 	// of its choice, constrained to those of the available tools, and
 	// returns the instance's architecture, series, and a function that

--- a/jujuclient/bootstrapconfigfile_test.go
+++ b/jujuclient/bootstrapconfigfile_test.go
@@ -32,6 +32,7 @@ controllers:
       type: ec2
     credential: default
     cloud: aws
+    type: ec2
     region: us-east-1
     endpoint: https://us-east-1.amazonaws.com
   mallards:
@@ -42,6 +43,7 @@ controllers:
       name: admin
       type: maas
     cloud: maas
+    type: maas
     region: 127.0.0.1
 `
 
@@ -57,6 +59,7 @@ var testBootstrapConfig = map[string]jujuclient.BootstrapConfig{
 		},
 		Credential:    "default",
 		Cloud:         "aws",
+		CloudType:     "ec2",
 		CloudRegion:   "us-east-1",
 		CloudEndpoint: "https://us-east-1.amazonaws.com",
 	},
@@ -70,6 +73,7 @@ var testBootstrapConfig = map[string]jujuclient.BootstrapConfig{
 			"name": "admin",
 		},
 		Cloud:       "maas",
+		CloudType:   "maas",
 		CloudRegion: "127.0.0.1",
 	},
 }

--- a/jujuclient/file.go
+++ b/jujuclient/file.go
@@ -636,5 +636,11 @@ func (s *store) BootstrapConfigForController(controllerName string) (*BootstrapC
 	if !ok {
 		return nil, errors.NotFoundf("bootstrap config for controller %s", controllerName)
 	}
+	if cfg.CloudType == "" {
+		// TODO(axw) 2016-07-25 #1603841
+		// Drop this when we get to 2.0. This exists only for
+		// compatibility with previous beta releases.
+		cfg.CloudType, _ = cfg.Config["type"].(string)
+	}
 	return &cfg, nil
 }

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -77,6 +77,9 @@ type BootstrapConfig struct {
 	// Cloud is the name of the cloud to create the Juju controller in.
 	Cloud string `yaml:"cloud"`
 
+	// CloudType is the type of the cloud to create the Juju controller in.
+	CloudType string `yaml:"type"`
+
 	// CloudRegion is the name of the region of the cloud to create
 	// the Juju controller in. This will be empty for clouds without
 	// regions.

--- a/jujuclient/validation.go
+++ b/jujuclient/validation.go
@@ -70,6 +70,9 @@ func ValidateBootstrapConfig(cfg BootstrapConfig) error {
 	if cfg.Cloud == "" {
 		return errors.NotValidf("empty cloud name")
 	}
+	if cfg.CloudType == "" {
+		return errors.NotValidf("empty cloud type")
+	}
 	if len(cfg.Config) == 0 {
 		return errors.NotValidf("empty config")
 	}

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -89,6 +89,16 @@ func newEnviron(provider *azureEnvironProvider, cfg *config.Config) (*azureEnvir
 	return &env, nil
 }
 
+// PrepareForBootstrap is specified in the Environ interface.
+func (env *azureEnviron) PrepareForBootstrap(ctx environs.BootstrapContext) error {
+	if ctx.ShouldVerifyCredentials() {
+		if err := verifyCredentials(env); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
 // Bootstrap is specified in the Environ interface.
 func (env *azureEnviron) Bootstrap(
 	ctx environs.BootstrapContext,

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -336,7 +336,9 @@ func prepareForBootstrap(
 		Credentials:          fakeUserPassCredential(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := provider.PrepareForBootstrap(ctx, cfg)
+	env, err := provider.Open(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	err = env.PrepareForBootstrap(ctx)
 	c.Assert(err, jc.ErrorIsNil)
 	return env
 }

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -126,20 +126,6 @@ func (prov *azureEnvironProvider) BootstrapConfig(args environs.BootstrapConfigP
 	return cfg, nil
 }
 
-// PrepareForBootstrap is specified in the EnvironProvider interface.
-func (prov *azureEnvironProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
-	env, err := prov.Open(cfg)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if ctx.ShouldVerifyCredentials() {
-		if err := verifyCredentials(env.(*azureEnviron)); err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
-	return env, nil
-}
-
 // SecretAttrs is specified in the EnvironProvider interface.
 func (prov *azureEnvironProvider) SecretAttrs(cfg *config.Config) (map[string]string, error) {
 	unknownAttrs := cfg.UnknownAttrs()

--- a/provider/cloudsigma/environ.go
+++ b/provider/cloudsigma/environ.go
@@ -78,6 +78,12 @@ func (env *environ) Config() *config.Config {
 	return env.ecfg.Config
 }
 
+// PrepareForBootstrap is defined by Environ.
+func (env *environ) PrepareForBootstrap(ctx environs.BootstrapContext) error {
+	logger.Infof("preparing model %q", env.name)
+	return nil
+}
+
 // Bootstrap initializes the state for the environment, possibly
 // starting one or more instances.  If the configuration's
 // AdminSecret is non-empty, the administrator password on the

--- a/provider/cloudsigma/provider.go
+++ b/provider/cloudsigma/provider.go
@@ -110,12 +110,6 @@ func (environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*co
 	return cfg, nil
 }
 
-// PrepareForBootstrap is defined by EnvironProvider.
-func (environProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
-	logger.Infof("preparing model %q", cfg.Name())
-	return providerInstance.Open(cfg)
-}
-
 // Validate ensures that config is a valid configuration for this
 // provider, applying changes to it if necessary, and returns the
 // validated configuration.

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -554,11 +554,6 @@ func (p *environProvider) PrepareForCreateEnvironment(controllerUUID string, cfg
 	return cfg, nil
 }
 
-// PrepareForBootstrap is specified in the EnvironProvider interface.
-func (p *environProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
-	return p.Open(cfg)
-}
-
 // BootstrapConfig is specified in the EnvironProvider interface.
 func (p *environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
 	ecfg, err := p.newConfig(args.Config)
@@ -635,6 +630,11 @@ func (*environ) PrecheckInstance(series string, cons constraints.Value, placemen
 	if placement != "" && placement != "valid" {
 		return fmt.Errorf("%s placement is invalid", placement)
 	}
+	return nil
+}
+
+// PrepareForBootstrap is specified in the Environ interface.
+func (p *environ) PrepareForBootstrap(ctx environs.BootstrapContext) error {
 	return nil
 }
 

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -92,32 +92,6 @@ func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*
 	return cfg, nil
 }
 
-// PrepareForBootstrap is specified in the EnvironProvider interface.
-func (p environProvider) PrepareForBootstrap(
-	ctx environs.BootstrapContext,
-	cfg *config.Config,
-) (environs.Environ, error) {
-	e, err := p.Open(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	env := e.(*environ)
-	if ctx.ShouldVerifyCredentials() {
-		if err := verifyCredentials(env); err != nil {
-			return nil, err
-		}
-	}
-
-	apiClient, ecfg := env.ec2(), env.ecfg()
-	region, vpcID, forceVPCID := ecfg.region(), ecfg.vpcID(), ecfg.forceVPCID()
-	if err := validateBootstrapVPC(apiClient, region, vpcID, forceVPCID, ctx); err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return e, nil
-}
-
 // Validate is specified in the EnvironProvider interface.
 func (environProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {
 	newEcfg, err := validateConfig(cfg, old)

--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -142,6 +142,16 @@ func (env *environ) Config() *config.Config {
 	return env.ecfg.config
 }
 
+// PrepareForBootstrap implements environs.Environ.
+func (env *environ) PrepareForBootstrap(ctx environs.BootstrapContext) error {
+	if ctx.ShouldVerifyCredentials() {
+		if err := env.gce.VerifyCredentials(); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
 // Bootstrap creates a new instance, chosing the series and arch out of
 // available tools. The series and arch are returned along with a func
 // that must be called to finalize the bootstrap process by transferring

--- a/provider/gce/provider.go
+++ b/provider/gce/provider.go
@@ -66,20 +66,6 @@ func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*
 	return p.PrepareForCreateEnvironment(args.ControllerUUID, cfg)
 }
 
-// PrepareForBootstrap implements environs.EnvironProvider.
-func (p environProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
-	env, err := newEnviron(cfg)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if ctx.ShouldVerifyCredentials() {
-		if err := env.gce.VerifyCredentials(); err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
-	return env, nil
-}
-
 // Schema returns the configuration schema for an environment.
 func (environProvider) Schema() environschema.Fields {
 	fields, err := config.Schema(configSchema)

--- a/provider/joyent/environ.go
+++ b/provider/joyent/environ.go
@@ -117,6 +117,15 @@ func (env *joyentEnviron) Config() *config.Config {
 	return env.Ecfg().Config
 }
 
+func (env *joyentEnviron) PrepareForBootstrap(ctx environs.BootstrapContext) error {
+	if ctx.ShouldVerifyCredentials() {
+		if err := verifyCredentials(env); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
 func (env *joyentEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	return common.Bootstrap(ctx, env, args)
 }

--- a/provider/joyent/provider.go
+++ b/provider/joyent/provider.go
@@ -79,20 +79,6 @@ func (p joyentProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*c
 	return p.PrepareForCreateEnvironment(args.ControllerUUID, cfg)
 }
 
-// PrepareForBootstrap is specified in the EnvironProvider interface.
-func (p joyentProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
-	e, err := p.Open(cfg)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if ctx.ShouldVerifyCredentials() {
-		if err := verifyCredentials(e.(*joyentEnviron)); err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
-	return e, nil
-}
-
 const unauthorisedMessage = `
 Please ensure the SSH access key you have specified is correct.
 You can create or import an SSH key via the "Account Summary"

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -136,6 +136,16 @@ func (env *environ) Config() *config.Config {
 	return cfg
 }
 
+// PrepareForBootstrap implements environs.Environ.
+func (env *environ) PrepareForBootstrap(ctx environs.BootstrapContext) error {
+	if ctx.ShouldVerifyCredentials() {
+		if err := env.verifyCredentials(); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
 // Bootstrap creates a new instance, chosing the series and arch out of
 // available tools. The series and arch are returned along with a func
 // that must be called to finalize the bootstrap process by transferring

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -161,3 +161,8 @@ func (s *environSuite) TestDestroyHostedModels(c *gc.C) {
 		{"RemoveInstances", []interface{}{prefix, []string{machine1.Name}}},
 	})
 }
+
+func (s *environSuite) TestPrepareForBootstrap(c *gc.C) {
+	err := s.Env.PrepareForBootstrap(envtesting.BootstrapContext(c))
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -35,24 +35,6 @@ func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*
 	return p.PrepareForCreateEnvironment(args.ControllerUUID, args.Config)
 }
 
-// PrepareForBootstrap implements environs.EnvironProvider.
-func (p environProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
-	// TODO(ericsnow) Do some of what happens in local provider's
-	// PrepareForBootstrap()? Only if "remote" is local host?
-
-	env, err := newEnviron(cfg, newRawProvider)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	if ctx.ShouldVerifyCredentials() {
-		if err := env.verifyCredentials(); err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
-	return env, nil
-}
-
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.
 func (environProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
 	return cfg, nil

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
-	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/provider/lxd"
 	"github.com/juju/juju/tools/lxdclient"
 )
@@ -117,10 +116,4 @@ func (s *ProviderFunctionalSuite) TestBootstrapConfig(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(cfg, gc.NotNil)
-}
-
-func (s *ProviderFunctionalSuite) TestPrepareForBootstrap(c *gc.C) {
-	env, err := s.provider.PrepareForBootstrap(envtesting.BootstrapContext(c), s.Config)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(env, gc.NotNil)
 }

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -123,6 +123,16 @@ func (env *maasEnviron) usingMAAS2() bool {
 	return env.apiVersion == apiVersion2
 }
 
+// PrepareForBootstrap is specified in the Environ interface.
+func (env *maasEnviron) PrepareForBootstrap(ctx environs.BootstrapContext) error {
+	if ctx.ShouldVerifyCredentials() {
+		if err := verifyCredentials(env); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Bootstrap is specified in the Environ interface.
 func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	result, series, finalizer, err := common.BootstrapInstance(ctx, env, args)

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -88,20 +88,6 @@ func (p maasEnvironProvider) BootstrapConfig(args environs.BootstrapConfigParams
 	return p.PrepareForCreateEnvironment(args.ControllerUUID, cfg)
 }
 
-// PrepareForBootstrap is specified in the EnvironProvider interface.
-func (p maasEnvironProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
-	env, err := p.Open(cfg)
-	if err != nil {
-		return nil, err
-	}
-	if ctx.ShouldVerifyCredentials() {
-		if err := verifyCredentials(env.(*maasEnviron)); err != nil {
-			return nil, err
-		}
-	}
-	return env, nil
-}
-
 func verifyCredentials(env *maasEnviron) error {
 	// Verify we can connect to the server and authenticate.
 	if env.usingMAAS2() {

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -81,6 +81,14 @@ func (e *manualEnviron) Config() *config.Config {
 	return e.envConfig().Config
 }
 
+// PrepareForBootstrap is specified in the Environ interface.
+func (e *manualEnviron) PrepareForBootstrap(ctx environs.BootstrapContext) error {
+	if err := ensureBootstrapUbuntuUser(ctx, e.envConfig()); err != nil {
+		return err
+	}
+	return nil
+}
+
 // Bootstrap is specified on the Environ interface.
 func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	envConfig := e.envConfig()

--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -71,18 +71,6 @@ func (p manualProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*c
 	return cfg.Apply(envConfig.attrs)
 }
 
-// PrepareForBootstrap is specified in the EnvironProvider interface.
-func (p manualProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
-	if _, err := p.validate(cfg, nil); err != nil {
-		return nil, err
-	}
-	envConfig := newModelConfig(cfg, cfg.UnknownAttrs())
-	if err := ensureBootstrapUbuntuUser(ctx, envConfig); err != nil {
-		return nil, err
-	}
-	return p.open(envConfig)
-}
-
 func (p manualProvider) Open(cfg *config.Config) (environs.Environ, error) {
 	_, err := p.validate(cfg, nil)
 	if err != nil {

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -65,9 +65,12 @@ func (s *providerSuite) testPrepareForBootstrap(c *gc.C, endpoint, region string
 	if err != nil {
 		return nil, err
 	}
+	env, err := manual.ProviderInstance.Open(testConfig)
+	if err != nil {
+		return nil, err
+	}
 	ctx := envtesting.BootstrapContext(c)
-	_, err = manual.ProviderInstance.PrepareForBootstrap(ctx, testConfig)
-	return ctx, err
+	return ctx, env.PrepareForBootstrap(ctx)
 }
 
 func (s *providerSuite) TestNullAlias(c *gc.C) {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -149,22 +149,6 @@ func (p EnvironProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*
 	return p.PrepareForCreateEnvironment(args.ControllerUUID, cfg)
 }
 
-// PrepareForBootstrap is specified in the EnvironProvider interface.
-func (p EnvironProvider) PrepareForBootstrap(
-	ctx environs.BootstrapContext,
-	cfg *config.Config,
-) (environs.Environ, error) {
-	e, err := p.Open(cfg)
-	if err != nil {
-		return nil, err
-	}
-	// Verify credentials.
-	if err := authenticateClient(e.(*Environ)); err != nil {
-		return nil, err
-	}
-	return e, nil
-}
-
 // MetadataLookupParams returns parameters which are used to query image metadata to
 // find matching image information.
 func (p EnvironProvider) MetadataLookupParams(region string) (*simplestreams.MetadataLookupParams, error) {
@@ -558,6 +542,15 @@ func (e *Environ) PrecheckInstance(series string, cons constraints.Value, placem
 		}
 	}
 	return errors.Errorf("invalid Openstack flavour %q specified", *cons.InstanceType)
+}
+
+// PrepareForBootstrap is specified in the Environ interface.
+func (e *Environ) PrepareForBootstrap(ctx environs.BootstrapContext) error {
+	// Verify credentials.
+	if err := authenticateClient(e); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (e *Environ) Bootstrap(ctx environs.BootstrapContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -107,6 +107,11 @@ func (p *fakeEnviron) Open(cfg *config.Config) (environs.Environ, error) {
 	return nil, nil
 }
 
+func (e *fakeEnviron) PrepareForBootstrap(ctx environs.BootstrapContext) error {
+	e.Push("PrepareForBootstrap", ctx)
+	return nil
+}
+
 func (e *fakeEnviron) Bootstrap(ctx environs.BootstrapContext, params environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	e.Push("Bootstrap", ctx, params)
 	return nil, nil

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -93,6 +93,11 @@ func (env *environ) Config() *config.Config {
 	return cfg
 }
 
+// PrepareForBootstrap implements environs.Environ.
+func (env *environ) PrepareForBootstrap(ctx environs.BootstrapContext) error {
+	return nil
+}
+
 //this variable is exported, because it has to be rewritten in external unit tests
 var Bootstrap = common.Bootstrap
 

--- a/provider/vsphere/environ_test.go
+++ b/provider/vsphere/environ_test.go
@@ -9,9 +9,11 @@ import (
 	"os"
 
 	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs"
+	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/provider/vsphere"
@@ -45,4 +47,9 @@ func (s *environSuite) TestDestroy(c *gc.C) {
 	})
 	err := s.Env.Destroy()
 	c.Assert(err, gc.ErrorMatches, "Destroy called")
+}
+
+func (s *environSuite) TestPrepareForBootstrap(c *gc.C) {
+	err := s.Env.PrepareForBootstrap(envtesting.BootstrapContext(c))
+	c.Check(err, jc.ErrorIsNil)
 }

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -49,16 +49,6 @@ func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*
 	return p.PrepareForCreateEnvironment(args.ControllerUUID, cfg)
 }
 
-// PrepareForBootstrap implements environs.EnvironProvider.
-func (p environProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
-	env, err := newEnviron(cfg)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return env, nil
-}
-
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.
 func (environProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
 	return cfg, nil

--- a/provider/vsphere/provider_test.go
+++ b/provider/vsphere/provider_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/provider/vsphere"
 )
 
@@ -53,12 +52,6 @@ func (s *providerSuite) TestBootstrapConfig(c *gc.C) {
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(cfg, gc.NotNil)
-}
-
-func (s *providerSuite) TestPrepareForBootstrap(c *gc.C) {
-	env, err := s.provider.PrepareForBootstrap(testing.BootstrapContext(c), s.Config)
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(env, gc.NotNil)
 }
 
 func (s *providerSuite) TestValidate(c *gc.C) {


### PR DESCRIPTION
We move PrepareForBootstrap off EnvironProvider,
onto Environ, and change its purpose. Once upon
a time it had a dual purpose: to add things to
the initial config, and to perform possibly-interactive
pre-bootstrap environment initialisation. We now
have the EnvironProvider.BootstrapConfig method
for initialising config; and the pre-bootstrap
init is best situated next to Bootstrap, on Environ.

Apart from clarifying the purpose of the method,
this change means that there is now exactly one
provider method for constructing an Environ, and that
is EnvironProvider.Open.

There is a small change to jujuclient related to
bootstrapping: to store the cloud type in bootstrap
config. This will become necessary when we remove
"type" from model config.

(Review request: http://reviews.vapour.ws/r/5289/)