### PR TITLE
Fixes lp#1600054 - generate image metadata for more than one virt type.

### DIFF
--- a/environs/imagemetadata/generate.go
+++ b/environs/imagemetadata/generate.go
@@ -71,6 +71,12 @@ func mergeMetadata(seriesVersion string, cloudSpec *simplestreams.CloudSpec, new
 
 	regions := make(map[string]bool)
 	var allCloudSpecs = []simplestreams.CloudSpec{}
+	// Each metadata item defines its own cloud specification.
+	// However, when we combine metadata items in the file, we do not want to
+	// repeat common cloud specifications in index definition.
+	// Since region name and endpoint have 1:1 correspondence,
+	// only one distinct cloud specification for each region
+	// is being collected.
 	addDistinctCloudSpec := func(im *ImageMetadata) {
 		if _, ok := regions[im.RegionName]; !ok {
 			regions[im.RegionName] = true

--- a/environs/imagemetadata/generate.go
+++ b/environs/imagemetadata/generate.go
@@ -55,13 +55,32 @@ func readMetadata(metadataStore storage.Storage) ([]*ImageMetadata, error) {
 	return existingMetadata, nil
 }
 
+// mapKey returns a key that uniquely identifies image metadata.
+// The metadata for different images may have similar values
+// for some parameters. This key ensures that truly distinct
+// metadata is not overwritten by closely related ones.
+// This key is similar to image metadata key built in state which combines
+// parameter values rather than using image id to ensure record uniqueness.
 func mapKey(im *ImageMetadata) string {
-	return fmt.Sprintf("%s-%s", im.productId(), im.RegionName)
+	return fmt.Sprintf("%s-%s-%s-%s", im.productId(), im.RegionName, im.VirtType, im.Storage)
 }
 
 // mergeMetadata merges the newMetadata into existingMetadata, overwriting existing matching image records.
 func mergeMetadata(seriesVersion string, cloudSpec *simplestreams.CloudSpec, newMetadata,
 	existingMetadata []*ImageMetadata) ([]*ImageMetadata, []simplestreams.CloudSpec) {
+
+	regions := make(map[string]bool)
+	var allCloudSpecs = []simplestreams.CloudSpec{}
+	addDistinctCloudSpec := func(im *ImageMetadata) {
+		if _, ok := regions[im.RegionName]; !ok {
+			regions[im.RegionName] = true
+			aCloudSpec := simplestreams.CloudSpec{
+				Region:   im.RegionName,
+				Endpoint: im.Endpoint,
+			}
+			allCloudSpecs = append(allCloudSpecs, aCloudSpec)
+		}
+	}
 
 	var toWrite = make([]*ImageMetadata, len(newMetadata))
 	imageIds := make(map[string]bool)
@@ -72,23 +91,13 @@ func mergeMetadata(seriesVersion string, cloudSpec *simplestreams.CloudSpec, new
 		newRecord.Endpoint = cloudSpec.Endpoint
 		toWrite[i] = &newRecord
 		imageIds[mapKey(&newRecord)] = true
+		addDistinctCloudSpec(&newRecord)
 	}
-	regions := make(map[string]bool)
-	var allCloudSpecs = []simplestreams.CloudSpec{*cloudSpec}
 	for _, im := range existingMetadata {
-		if _, ok := imageIds[mapKey(im)]; ok {
-			continue
+		if _, ok := imageIds[mapKey(im)]; !ok {
+			toWrite = append(toWrite, im)
+			addDistinctCloudSpec(im)
 		}
-		toWrite = append(toWrite, im)
-		if _, ok := regions[im.RegionName]; ok {
-			continue
-		}
-		regions[im.RegionName] = true
-		existingCloudSpec := simplestreams.CloudSpec{
-			Region:   im.RegionName,
-			Endpoint: im.Endpoint,
-		}
-		allCloudSpecs = append(allCloudSpecs, existingCloudSpec)
 	}
 	return toWrite, allCloudSpecs
 }

--- a/environs/imagemetadata/generate_test.go
+++ b/environs/imagemetadata/generate_test.go
@@ -21,7 +21,7 @@ type generateSuite struct {
 	coretesting.BaseSuite
 }
 
-func assertFetch(c *gc.C, stor storage.Storage, series, arch, region, endpoint, id string) {
+func assertFetch(c *gc.C, stor storage.Storage, series, arch, region, endpoint string, ids ...string) {
 	cons := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 		CloudSpec: simplestreams.CloudSpec{region, endpoint},
 		Series:    []string{series},
@@ -30,8 +30,10 @@ func assertFetch(c *gc.C, stor storage.Storage, series, arch, region, endpoint, 
 	dataSource := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "images", simplestreams.DEFAULT_CLOUD_DATA, false)
 	metadata, _, err := imagemetadata.Fetch([]simplestreams.DataSource{dataSource}, cons)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(metadata, gc.HasLen, 1)
-	c.Assert(metadata[0].Id, gc.Equals, id)
+	c.Assert(metadata, gc.HasLen, len(ids))
+	for i, id := range ids {
+		c.Assert(metadata[i].Id, gc.Equals, id)
+	}
 }
 
 func (s *generateSuite) TestWriteMetadata(c *gc.C) {
@@ -193,4 +195,122 @@ func (s *generateSuite) TestWriteMetadataMergeDifferentRegion(c *gc.C) {
 	c.Assert(metadata, gc.DeepEquals, newImageMetadata)
 	assertFetch(c, targetStorage, "raring", "amd64", "region", "endpoint", "1234")
 	assertFetch(c, targetStorage, "raring", "amd64", "region2", "endpoint2", "abcd")
+}
+
+// lp#1600054
+func (s *generateSuite) TestWriteMetadataMergeDifferentVirtType(c *gc.C) {
+	existingImageMetadata := []*imagemetadata.ImageMetadata{
+		{
+			Id:       "1234",
+			Arch:     "amd64",
+			Version:  "13.04",
+			VirtType: "kvm",
+		},
+	}
+	cloudSpec := &simplestreams.CloudSpec{
+		Region:   "region",
+		Endpoint: "endpoint",
+	}
+	dir := c.MkDir()
+	targetStorage, err := filestorage.NewFileStorageWriter(dir)
+	c.Assert(err, jc.ErrorIsNil)
+	err = imagemetadata.MergeAndWriteMetadata("raring", existingImageMetadata, cloudSpec, targetStorage)
+	c.Assert(err, jc.ErrorIsNil)
+	newImageMetadata := []*imagemetadata.ImageMetadata{
+		{
+			Id:       "abcd",
+			Arch:     "amd64",
+			Version:  "13.04",
+			VirtType: "lxd",
+		},
+	}
+	err = imagemetadata.MergeAndWriteMetadata("raring", newImageMetadata, cloudSpec, targetStorage)
+	c.Assert(err, jc.ErrorIsNil)
+
+	foundMetadata := testing.ParseMetadataFromDir(c, dir)
+
+	expectedMetadata := append(newImageMetadata, existingImageMetadata...)
+	c.Assert(len(foundMetadata), gc.Equals, len(expectedMetadata))
+	for _, im := range expectedMetadata {
+		im.RegionName = cloudSpec.Region
+		im.Endpoint = cloudSpec.Endpoint
+	}
+	imagemetadata.Sort(expectedMetadata)
+	c.Assert(foundMetadata, gc.DeepEquals, expectedMetadata)
+	assertFetch(c, targetStorage, "raring", "amd64", "region", "endpoint", "1234", "abcd")
+}
+
+func (s *generateSuite) TestWriteIndexRegionOnce(c *gc.C) {
+	existingImageMetadata := []*imagemetadata.ImageMetadata{
+		{
+			Id:       "1234",
+			Arch:     "amd64",
+			Version:  "13.04",
+			VirtType: "kvm",
+		},
+	}
+	cloudSpec := &simplestreams.CloudSpec{
+		Region:   "region",
+		Endpoint: "endpoint",
+	}
+	dir := c.MkDir()
+	targetStorage, err := filestorage.NewFileStorageWriter(dir)
+	c.Assert(err, jc.ErrorIsNil)
+	err = imagemetadata.MergeAndWriteMetadata("raring", existingImageMetadata, cloudSpec, targetStorage)
+	c.Assert(err, jc.ErrorIsNil)
+	newImageMetadata := []*imagemetadata.ImageMetadata{
+		{
+			Id:       "abcd",
+			Arch:     "amd64",
+			Version:  "13.04",
+			VirtType: "lxd",
+		},
+	}
+	err = imagemetadata.MergeAndWriteMetadata("raring", newImageMetadata, cloudSpec, targetStorage)
+	c.Assert(err, jc.ErrorIsNil)
+
+	foundIndex := testing.ParseIndexMetadataFromStorage(c, targetStorage)
+	expectedCloudSpecs := []simplestreams.CloudSpec{*cloudSpec}
+	c.Assert(foundIndex.Clouds, jc.SameContents, expectedCloudSpecs)
+}
+
+func (s *generateSuite) TestWriteDistinctIndexRegions(c *gc.C) {
+	existingImageMetadata := []*imagemetadata.ImageMetadata{
+		{
+			Id:       "1234",
+			Arch:     "amd64",
+			Version:  "13.04",
+			VirtType: "kvm",
+		},
+	}
+	cloudSpec := &simplestreams.CloudSpec{
+		Region:   "region",
+		Endpoint: "endpoint",
+	}
+	dir := c.MkDir()
+	targetStorage, err := filestorage.NewFileStorageWriter(dir)
+	c.Assert(err, jc.ErrorIsNil)
+	err = imagemetadata.MergeAndWriteMetadata("raring", existingImageMetadata, cloudSpec, targetStorage)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedCloudSpecs := []simplestreams.CloudSpec{*cloudSpec}
+
+	newImageMetadata := []*imagemetadata.ImageMetadata{
+		{
+			Id:       "abcd",
+			Arch:     "amd64",
+			Version:  "13.04",
+			VirtType: "lxd",
+		},
+	}
+	cloudSpec = &simplestreams.CloudSpec{
+		Region:   "region2",
+		Endpoint: "endpoint2",
+	}
+	err = imagemetadata.MergeAndWriteMetadata("raring", newImageMetadata, cloudSpec, targetStorage)
+	c.Assert(err, jc.ErrorIsNil)
+
+	foundIndex := testing.ParseIndexMetadataFromStorage(c, targetStorage)
+	expectedCloudSpecs = append(expectedCloudSpecs, *cloudSpec)
+	c.Assert(foundIndex.Clouds, jc.SameContents, expectedCloudSpecs)
 }

--- a/environs/imagemetadata/generate_test.go
+++ b/environs/imagemetadata/generate_test.go
@@ -269,7 +269,7 @@ func (s *generateSuite) TestWriteIndexRegionOnce(c *gc.C) {
 	err = imagemetadata.MergeAndWriteMetadata("raring", newImageMetadata, cloudSpec, targetStorage)
 	c.Assert(err, jc.ErrorIsNil)
 
-	foundIndex := testing.ParseIndexMetadataFromStorage(c, targetStorage)
+	foundIndex, _ := testing.ParseIndexMetadataFromStorage(c, targetStorage)
 	expectedCloudSpecs := []simplestreams.CloudSpec{*cloudSpec}
 	c.Assert(foundIndex.Clouds, jc.SameContents, expectedCloudSpecs)
 }
@@ -310,7 +310,7 @@ func (s *generateSuite) TestWriteDistinctIndexRegions(c *gc.C) {
 	err = imagemetadata.MergeAndWriteMetadata("raring", newImageMetadata, cloudSpec, targetStorage)
 	c.Assert(err, jc.ErrorIsNil)
 
-	foundIndex := testing.ParseIndexMetadataFromStorage(c, targetStorage)
+	foundIndex, _ := testing.ParseIndexMetadataFromStorage(c, targetStorage)
 	expectedCloudSpecs = append(expectedCloudSpecs, *cloudSpec)
 	c.Assert(foundIndex.Clouds, jc.SameContents, expectedCloudSpecs)
 }

--- a/environs/imagemetadata/testing/testing.go
+++ b/environs/imagemetadata/testing/testing.go
@@ -36,7 +36,7 @@ func ParseMetadataFromDir(c *gc.C, metadataDir string) []*imagemetadata.ImageMet
 }
 
 // ParseIndexMetadataFromStorage loads Indices from the specified storage reader.
-func ParseIndexMetadataFromStorage(c *gc.C, stor storage.StorageReader) *simplestreams.IndexMetadata {
+func ParseIndexMetadataFromStorage(c *gc.C, stor storage.StorageReader) (*simplestreams.IndexMetadata, simplestreams.DataSource) {
 	source := storage.NewStorageSimpleStreamsDataSource("test storage reader", stor, "images", simplestreams.DEFAULT_CLOUD_DATA, false)
 
 	// Find the simplestreams index file.
@@ -54,12 +54,12 @@ func ParseIndexMetadataFromStorage(c *gc.C, stor storage.StorageReader) *simples
 
 	imageIndexMetadata := indexRef.Indexes["com.ubuntu.cloud:custom"]
 	c.Assert(imageIndexMetadata, gc.NotNil)
-	return imageIndexMetadata
+	return imageIndexMetadata, source
 }
 
 // ParseMetadataFromStorage loads ImageMetadata from the specified storage reader.
 func ParseMetadataFromStorage(c *gc.C, stor storage.StorageReader) []*imagemetadata.ImageMetadata {
-	imageIndexMetadata := ParseIndexMetadataFromStorage(c, stor)
+	imageIndexMetadata, source := ParseIndexMetadataFromStorage(c, stor)
 	c.Assert(imageIndexMetadata, gc.NotNil)
 
 	// Read the products file contents.
@@ -70,7 +70,6 @@ func ParseMetadataFromStorage(c *gc.C, stor storage.StorageReader) []*imagemetad
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Parse the products file metadata.
-	source := storage.NewStorageSimpleStreamsDataSource("test storage reader", stor, "images", simplestreams.DEFAULT_CLOUD_DATA, false)
 	url, err := source.URL(imageIndexMetadata.ProductsFilePath)
 	c.Assert(err, jc.ErrorIsNil)
 	cloudMetadata, err := simplestreams.ParseCloudMetadata(data, "products:1.0", url, imagemetadata.ImageMetadata{})


### PR DESCRIPTION
Generating image metadata produces index and detailed items metadata file. If these files exist, they could be modified to contain additional metadata by re-run the command as many times as needed for each individual image.

Bug#1600054 identified that attempts to generate metadata for different virt-type values overwrote existing data in the files instead of adding to it. Further examination of the code also identified, that the same behavior could be observed if generate metadata command was run for different root storage types. This PR fixes that.

Once the fix was implemented, another problem beame obvious where several metadata for the same region could be successfully added to items files but index file would contain as many repetitive definitions of the same region/endpoint cloud specification as items added.

QA steps:
1. run 'juju metadata generate-image' with one virt type and image id
2. run 'juju metadata generate-image' with another virt type and image id 
3. ensure that metadata and index files contain metadata details for both items and repetitive details such as cloud specification is not duplicated.
4. repeat 1, 2, 3 for different values of root storage types

Example generate-image command:

juju metadata generate-image -r RegionOne -u http://10.244.241.80:5000/v2.0 -d ~/images -i aaa111 --virt-type=lxd
  

(Review request: http://reviews.vapour.ws/r/5291/)