### PR TITLE
Added logging for lock acquisition.

### DIFF
--- a/cmd/jujud/run.go
+++ b/cmd/jujud/run.go
@@ -181,10 +181,15 @@ func (c *RunCommand) executeNoContext() (*exec.ExecResponse, error) {
 		Clock: clock.WallClock,
 		Delay: 250 * time.Millisecond,
 	}
+	logger.Debugf("acquire lock %q for juju-run", c.MachineLockName)
 	releaser, err := mutex.Acquire(spec)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	logger.Debugf("lock %q acquired", c.MachineLockName)
+
+	// Defer the logging first so it is executed after the Release. LIFO.
+	defer logger.Debugf("release lock %q for juju-run", c.MachineLockName)
 	defer releaser.Release()
 
 	runCmd := c.appendProxyToCommands()

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -160,10 +160,13 @@ func (cs *ContainerSetup) runInitialiser(abort <-chan struct{}, containerType in
 		Delay:  time.Second,
 		Cancel: abort,
 	}
+	logger.Debugf("acquire lock %q for container initialisation", cs.initLockName)
 	releaser, err := mutex.Acquire(spec)
 	if err != nil {
 		return errors.Annotate(err, "failed to acquire initialization lock")
 	}
+	logger.Debugf("lock %q acquired", cs.initLockName)
+	defer logger.Debugf("release lock %q for container initialisation", cs.initLockName)
 	defer releaser.Release()
 
 	if err := initialiser.Initialise(); err != nil {

--- a/worker/reboot/reboot.go
+++ b/worker/reboot/reboot.go
@@ -78,12 +78,14 @@ func (r *Reboot) Handle(_ <-chan struct{}) error {
 		if _, err := mutex.Acquire(spec); err != nil {
 			return errors.Trace(err)
 		}
+		logger.Debugf("mutex %q acquired, won't release", r.machineLockName)
 		return worker.ErrRebootMachine
 	case params.ShouldShutdown:
 		logger.Debugf("acquiring mutex %q for shutdown", r.machineLockName)
 		if _, err := mutex.Acquire(spec); err != nil {
 			return errors.Trace(err)
 		}
+		logger.Debugf("mutex %q acquired, won't release", r.machineLockName)
 		return worker.ErrShutdownMachine
 	default:
 		return nil

--- a/worker/uniter/operation/executor.go
+++ b/worker/uniter/operation/executor.go
@@ -73,6 +73,7 @@ func (x *executor) Run(op Operation) (runErr error) {
 		if err != nil {
 			return errors.Annotate(err, "could not acquire lock")
 		}
+		defer logger.Debugf("lock released")
 		defer releaser.Release()
 	}
 

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -521,10 +521,12 @@ func (u *Uniter) acquireExecutionLock() (mutex.Releaser, error) {
 		Delay:  250 * time.Millisecond,
 		Cancel: u.catacomb.Dying(),
 	}
+	logger.Debugf("acquire lock %q for uniter hook execution", u.hookLockName)
 	releaser, err := mutex.Acquire(spec)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	logger.Debugf("lock %q acquired", u.hookLockName)
 	return releaser, nil
 }
 


### PR DESCRIPTION
For something as critical as the machine lock, it is useful to have logging for when it is acquired and released.

(Review request: http://reviews.vapour.ws/r/5294/)