### PR TITLE
state: allow unused optional storage to be removed

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -433,16 +433,91 @@ func (s *Application) checkRelationsOps(ch *Charm, relations []*Relation) ([]txn
 	return asserts, nil
 }
 
-func (s *Application) checkStorageUpgrade(newMeta *charm.Meta) (err error) {
+func (s *Application) checkStorageUpgrade(newMeta *charm.Meta) (_ []txn.Op, err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot upgrade application %q to charm %q", s, newMeta.Name)
 	ch, _, err := s.Charm()
 	if err != nil {
-		return errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	oldMeta := ch.Meta()
-	for name := range oldMeta.Storage {
-		if _, ok := newMeta.Storage[name]; !ok {
-			return errors.Errorf("storage %q removed", name)
+	var ops []txn.Op
+	var units []*Unit
+	for name, oldStorageMeta := range oldMeta.Storage {
+		if _, ok := newMeta.Storage[name]; ok {
+			continue
+		}
+		if oldStorageMeta.CountMin > 0 {
+			return nil, errors.Errorf("required storage %q removed", name)
+		}
+		// Optional storage has been removed. So long as there
+		// are no instances of the store, it can safely be
+		// removed.
+		if oldStorageMeta.Shared {
+			n, err := s.st.countEntityStorageInstancesForName(
+				s.Tag(), name,
+			)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if n > 0 {
+				return nil, errors.Errorf("in-use storage %q removed", name)
+			}
+			// TODO(axw) if/when it is possible to
+			// add shared storage instance to an
+			// application post-deployment, we must
+			// include a txn.Op here that asserts
+			// that the number of instances is zero.
+		} else {
+			if units == nil {
+				var err error
+				units, err = s.AllUnits()
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				ops = append(ops, txn.Op{
+					C:      applicationsC,
+					Id:     s.doc.DocID,
+					Assert: bson.D{{"unitcount", len(units)}},
+				})
+				for _, unit := range units {
+					// Here we check that the storage
+					// attachment count remains the same.
+					// To get around the ABA problem, we
+					// also add ops for the individual
+					// attachments below.
+					ops = append(ops, txn.Op{
+						C:  unitsC,
+						Id: unit.doc.DocID,
+						Assert: bson.D{{
+							"storageattachmentcount",
+							unit.doc.StorageAttachmentCount,
+						}},
+					})
+				}
+			}
+			for _, unit := range units {
+				attachments, err := s.st.UnitStorageAttachments(unit.UnitTag())
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				for _, attachment := range attachments {
+					storageTag := attachment.StorageInstance()
+					storageName, err := names.StorageName(storageTag.Id())
+					if err != nil {
+						return nil, errors.Trace(err)
+					}
+					if storageName == name {
+						return nil, errors.Errorf("in-use storage %q removed", name)
+					}
+					// We assert that other storage attachments still exist to
+					// avoid the ABA problem.
+					ops = append(ops, txn.Op{
+						C:      storageAttachmentsC,
+						Id:     storageAttachmentId(unit.Name(), storageTag.Id()),
+						Assert: txn.DocExists,
+					})
+				}
+			}
 		}
 	}
 	less := func(a, b int) bool {
@@ -452,7 +527,7 @@ func (s *Application) checkStorageUpgrade(newMeta *charm.Meta) (err error) {
 		oldStorageMeta, ok := oldMeta.Storage[name]
 		if !ok {
 			if newStorageMeta.CountMin > 0 {
-				return errors.Errorf("required storage %q added", name)
+				return nil, errors.Errorf("required storage %q added", name)
 			}
 			// New storage is fine as long as it is not required.
 			//
@@ -463,31 +538,31 @@ func (s *Application) checkStorageUpgrade(newMeta *charm.Meta) (err error) {
 			continue
 		}
 		if newStorageMeta.Type != oldStorageMeta.Type {
-			return errors.Errorf(
+			return nil, errors.Errorf(
 				"existing storage %q type changed from %q to %q",
 				name, oldStorageMeta.Type, newStorageMeta.Type,
 			)
 		}
 		if newStorageMeta.Shared != oldStorageMeta.Shared {
-			return errors.Errorf(
+			return nil, errors.Errorf(
 				"existing storage %q shared changed from %v to %v",
 				name, oldStorageMeta.Shared, newStorageMeta.Shared,
 			)
 		}
 		if newStorageMeta.ReadOnly != oldStorageMeta.ReadOnly {
-			return errors.Errorf(
+			return nil, errors.Errorf(
 				"existing storage %q read-only changed from %v to %v",
 				name, oldStorageMeta.ReadOnly, newStorageMeta.ReadOnly,
 			)
 		}
 		if newStorageMeta.Location != oldStorageMeta.Location {
-			return errors.Errorf(
+			return nil, errors.Errorf(
 				"existing storage %q location changed from %q to %q",
 				name, oldStorageMeta.Location, newStorageMeta.Location,
 			)
 		}
 		if newStorageMeta.CountMin > oldStorageMeta.CountMin {
-			return errors.Errorf(
+			return nil, errors.Errorf(
 				"existing storage %q range contracted: min increased from %d to %d",
 				name, oldStorageMeta.CountMin, newStorageMeta.CountMin,
 			)
@@ -497,7 +572,7 @@ func (s *Application) checkStorageUpgrade(newMeta *charm.Meta) (err error) {
 			if oldStorageMeta.CountMax == -1 {
 				oldCountMax = "<unbounded>"
 			}
-			return errors.Errorf(
+			return nil, errors.Errorf(
 				"existing storage %q range contracted: max decreased from %v to %d",
 				name, oldCountMax, newStorageMeta.CountMax,
 			)
@@ -506,13 +581,13 @@ func (s *Application) checkStorageUpgrade(newMeta *charm.Meta) (err error) {
 			// If a location is specified, the store may not go
 			// from being a singleton to multiple, since then the
 			// location has a different meaning.
-			return errors.Errorf(
+			return nil, errors.Errorf(
 				"existing storage %q with location changed from singleton to multiple",
 				name,
 			)
 		}
 	}
-	return nil
+	return ops, nil
 }
 
 // changeCharmOps returns the operations necessary to set a service's
@@ -643,9 +718,11 @@ func (s *Application) changeCharmOps(ch *Charm, channel string, forceUnits bool,
 
 	// Check storage to ensure no storage is removed, and no required
 	// storage is added for which there are no constraints.
-	if err := s.checkStorageUpgrade(ch.Meta()); err != nil {
+	storageOps, err := s.checkStorageUpgrade(ch.Meta())
+	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	ops = append(ops, storageOps...)
 
 	// And finally, decrement the old settings.
 	return append(ops, decOps...), nil

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/storage/provider/registry"
+	"github.com/juju/juju/testing/factory"
 )
 
 type ServiceSuite struct {
@@ -2161,6 +2162,16 @@ storage:
       range: 0-
 `
 
+const oneRequiredOneOptionalStorageMeta = `
+storage:
+  data0:
+    type: block
+  data1:
+    type: block
+    multiple:
+      range: 0-
+`
+
 const twoRequiredStorageMeta = `
 storage:
   data0:
@@ -2241,12 +2252,46 @@ func (s *ServiceSuite) setCharmFromMeta(c *gc.C, oldMeta, newMeta string) error 
 	return svc.SetCharm(cfg)
 }
 
-func (s *ServiceSuite) TestSetCharmStorageRemoved(c *gc.C) {
+func (s *ServiceSuite) TestSetCharmOptionalUnusedStorageRemoved(c *gc.C) {
 	err := s.setCharmFromMeta(c,
-		mysqlBaseMeta+twoOptionalStorageMeta,
-		mysqlBaseMeta+oneOptionalStorageMeta,
+		mysqlBaseMeta+oneRequiredOneOptionalStorageMeta,
+		mysqlBaseMeta+oneRequiredStorageMeta,
 	)
-	c.Assert(err, gc.ErrorMatches, `cannot upgrade application "test" to charm "mysql": storage "data1" removed`)
+	c.Assert(err, jc.ErrorIsNil)
+	// It's valid to remove optional storage so long
+	// as it is not in use.
+}
+
+func (s *ServiceSuite) TestSetCharmOptionalUsedStorageRemoved(c *gc.C) {
+	registry.RegisterEnvironStorageProviders("someprovider", provider.LoopProviderType)
+	oldMeta := mysqlBaseMeta + oneRequiredOneOptionalStorageMeta
+	newMeta := mysqlBaseMeta + oneRequiredStorageMeta
+	oldCh := s.AddMetaCharm(c, "mysql", oldMeta, 2)
+	newCh := s.AddMetaCharm(c, "mysql", newMeta, 3)
+	svc := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Name:  "test",
+		Charm: oldCh,
+		Storage: map[string]state.StorageConstraints{
+			"data0": {Count: 1},
+			"data1": {Count: 1},
+		},
+	})
+	defer state.SetBeforeHooks(c, s.State, func() {
+		// Adding a unit will cause the storage to be in-use.
+		_, err := svc.AddUnit()
+		c.Assert(err, jc.ErrorIsNil)
+	}).Check()
+	cfg := state.SetCharmConfig{Charm: newCh}
+	err := svc.SetCharm(cfg)
+	c.Assert(err, gc.ErrorMatches, `cannot upgrade application "test" to charm "mysql": in-use storage "data1" removed`)
+}
+
+func (s *ServiceSuite) TestSetCharmRequiredStorageRemoved(c *gc.C) {
+	err := s.setCharmFromMeta(c,
+		mysqlBaseMeta+oneRequiredStorageMeta,
+		mysqlBaseMeta,
+	)
+	c.Assert(err, gc.ErrorMatches, `cannot upgrade application "test" to charm "mysql": required storage "data0" removed`)
 }
 
 func (s *ServiceSuite) TestSetCharmRequiredStorageAdded(c *gc.C) {

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -91,6 +91,7 @@ type ApplicationParams struct {
 	Charm       *state.Charm
 	Status      *status.StatusInfo
 	Settings    map[string]interface{}
+	Storage     map[string]state.StorageConstraints
 	Constraints constraints.Value
 }
 
@@ -396,6 +397,7 @@ func (factory *Factory) MakeApplication(c *gc.C, params *ApplicationParams) *sta
 		Name:        params.Name,
 		Charm:       params.Charm,
 		Settings:    charm.Settings(params.Settings),
+		Storage:     params.Storage,
 		Constraints: params.Constraints,
 	})
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
When switching/upgrading the charm for an application,
we have been too strict when stores are removed from
the charm metadata. If a store is marked optional,
and is unused, its removal should not trigger failure.

QA:
 - juju deploy prometheus
 - fetch prometheus charm source, apply https://code.launchpad.net/~canonical-is-sa/charms/trusty/prometheus/layer-prometheus
   (which was reverted due to this bug)
 - upgrade-charm prometheus --path <path/to/source>

There should be no errors.

Fixes https://bugs.launchpad.net/juju-core/+bug/1599503

(Review request: http://reviews.vapour.ws/r/5299/)