### PR TITLE
migration: Return id instead of attempt

### DIFF
--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -50,7 +50,7 @@ func (c *Client) Watch() (watcher.NotifyWatcher, error) {
 // model migration.
 func (c *Client) GetMigrationStatus() (migration.MigrationStatus, error) {
 	var empty migration.MigrationStatus
-	var status params.FullMigrationStatus
+	var status params.MasterMigrationStatus
 	err := c.caller.FacadeCall("GetMigrationStatus", nil, &status)
 	if err != nil {
 		return empty, errors.Trace(err)
@@ -78,8 +78,8 @@ func (c *Client) GetMigrationStatus() (migration.MigrationStatus, error) {
 	}
 
 	return migration.MigrationStatus{
+		MigrationId:      status.MigrationId,
 		ModelUUID:        modelTag.Id(),
-		Attempt:          status.Attempt,
 		Phase:            phase,
 		PhaseChangedTime: status.PhaseChangedTime,
 		TargetInfo: migration.TargetInfo{

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -65,8 +65,8 @@ func (s *ClientSuite) TestGetMigrationStatus(c *gc.C) {
 	controllerUUID := utils.MustNewUUID().String()
 	timestamp := time.Date(2016, 6, 22, 16, 42, 44, 0, time.UTC)
 	apiCaller := apitesting.APICallerFunc(func(_ string, _ int, _, _ string, _, result interface{}) error {
-		out := result.(*params.FullMigrationStatus)
-		*out = params.FullMigrationStatus{
+		out := result.(*params.MasterMigrationStatus)
+		*out = params.MasterMigrationStatus{
 			Spec: params.ModelMigrationSpec{
 				ModelTag: names.NewModelTag(modelUUID).String(),
 				TargetInfo: params.ModelMigrationTargetInfo{
@@ -77,7 +77,7 @@ func (s *ClientSuite) TestGetMigrationStatus(c *gc.C) {
 					Password:      "secret",
 				},
 			},
-			Attempt:          3,
+			MigrationId:      "id",
 			Phase:            "READONLY",
 			PhaseChangedTime: timestamp,
 		}
@@ -88,8 +88,8 @@ func (s *ClientSuite) TestGetMigrationStatus(c *gc.C) {
 	status, err := client.GetMigrationStatus()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.DeepEquals, migration.MigrationStatus{
+		MigrationId:      "id",
 		ModelUUID:        modelUUID,
-		Attempt:          3,
 		Phase:            migration.READONLY,
 		PhaseChangedTime: timestamp,
 		TargetInfo: migration.TargetInfo{

--- a/apiserver/migrationmaster/facade.go
+++ b/apiserver/migrationmaster/facade.go
@@ -64,8 +64,8 @@ func (api *API) Watch() params.NotifyWatchResult {
 
 // GetMigrationStatus returns the details and progress of the latest
 // model migration.
-func (api *API) GetMigrationStatus() (params.FullMigrationStatus, error) {
-	empty := params.FullMigrationStatus{}
+func (api *API) GetMigrationStatus() (params.MasterMigrationStatus, error) {
+	empty := params.MasterMigrationStatus{}
 
 	mig, err := api.backend.LatestModelMigration()
 	if err != nil {
@@ -77,17 +77,12 @@ func (api *API) GetMigrationStatus() (params.FullMigrationStatus, error) {
 		return empty, errors.Annotate(err, "retrieving target info")
 	}
 
-	attempt, err := mig.Attempt()
-	if err != nil {
-		return empty, errors.Annotate(err, "retrieving attempt")
-	}
-
 	phase, err := mig.Phase()
 	if err != nil {
 		return empty, errors.Annotate(err, "retrieving phase")
 	}
 
-	return params.FullMigrationStatus{
+	return params.MasterMigrationStatus{
 		Spec: params.ModelMigrationSpec{
 			ModelTag: names.NewModelTag(mig.ModelUUID()).String(),
 			TargetInfo: params.ModelMigrationTargetInfo{
@@ -98,7 +93,7 @@ func (api *API) GetMigrationStatus() (params.FullMigrationStatus, error) {
 				Password:      target.Password,
 			},
 		},
-		Attempt:          attempt,
+		MigrationId:      mig.Id(),
 		Phase:            phase.String(),
 		PhaseChangedTime: mig.PhaseChangedTime(),
 	}, nil

--- a/apiserver/migrationmaster/facade_test.go
+++ b/apiserver/migrationmaster/facade_test.go
@@ -91,7 +91,7 @@ func (s *Suite) TestGetMigrationStatus(c *gc.C) {
 
 	status, err := api.GetMigrationStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.DeepEquals, params.FullMigrationStatus{
+	c.Assert(status, gc.DeepEquals, params.MasterMigrationStatus{
 		Spec: params.ModelMigrationSpec{
 			ModelTag: names.NewModelTag(modelUUID).String(),
 			TargetInfo: params.ModelMigrationTargetInfo{
@@ -102,7 +102,7 @@ func (s *Suite) TestGetMigrationStatus(c *gc.C) {
 				Password:      "secret",
 			},
 		},
-		Attempt:          1,
+		MigrationId:      "id",
 		Phase:            "READONLY",
 		PhaseChangedTime: s.backend.migration.PhaseChangedTime(),
 	})

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -73,6 +73,16 @@ type ModelArgs struct {
 	ModelTag string `json:"model-tag"`
 }
 
+// MasterMigrationStatus is used to report the current status of a
+// model migration for the migrationmaster. It includes authentication
+// details for the remote controller.
+type MasterMigrationStatus struct {
+	Spec             ModelMigrationSpec `json:"spec"`
+	MigrationId      string             `json:"migration-id"`
+	Phase            string             `json:"phase"`
+	PhaseChangedTime time.Time          `json:"phase-changed-time"`
+}
+
 // MigrationStatus reports the current status of a model migration.
 type MigrationStatus struct {
 	MigrationId string `json:"migration-id"`
@@ -85,16 +95,6 @@ type MigrationStatus struct {
 
 	TargetAPIAddrs []string `json:"target-api-addrs"`
 	TargetCACert   string   `json:"target-ca-cert"`
-}
-
-// FullMigrationStatus reports the current status of a model
-// migration, including authentication details for the remote
-// controller.
-type FullMigrationStatus struct {
-	Spec             ModelMigrationSpec `json:"spec"`
-	Attempt          int                `json:"attempt"`
-	Phase            string             `json:"phase"`
-	PhaseChangedTime time.Time          `json:"phase-changed-time"`
 }
 
 // PhasesResults holds the phase of one or more model migrations.

--- a/core/migration/migration.go
+++ b/core/migration/migration.go
@@ -10,14 +10,13 @@ import (
 )
 
 // MigrationStatus returns the details for a migration as needed by
-// the migration master worker.
+// the migrationmaster worker.
 type MigrationStatus struct {
+	// MigrationId hold the unique id for the migration.
+	MigrationId string
+
 	// ModelUUID holds the UUID of the model being migrated.
 	ModelUUID string
-
-	// Attempt specifies the migration attempt number. This is
-	// incremeted for each attempt to migrate a model.
-	Attempt int
 
 	// Phases indicates the current migration phase.
 	Phase Phase

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -471,11 +471,9 @@ func truncDuration(d time.Duration) time.Duration {
 }
 
 func validateMinionReports(reports coremigration.MinionReports, status coremigration.MigrationStatus) error {
-	// TODO(mjs) the migration id should be part of the status response.
-	migId := fmt.Sprintf("%s:%d", status.ModelUUID, status.Attempt)
-	if reports.MigrationId != migId {
+	if reports.MigrationId != status.MigrationId {
 		return errors.Errorf("unexpected migration id in minion reports, got %v, expected %v",
-			reports.MigrationId, migId)
+			reports.MigrationId, status.MigrationId)
 	}
 	if reports.Phase != status.Phase {
 		return errors.Errorf("minion reports phase (%s) does not match migration phase (%s)",

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -575,8 +575,8 @@ func newStubMasterFacade(stub *jujutesting.Stub, now time.Time) *stubMasterFacad
 		stub:           stub,
 		watcherChanges: make(chan struct{}, 999),
 		status: coremigration.MigrationStatus{
+			MigrationId:      "model-uuid:2",
 			ModelUUID:        "model-uuid",
-			Attempt:          2,
 			Phase:            coremigration.QUIESCE,
 			PhaseChangedTime: now,
 			TargetInfo: coremigration.TargetInfo{


### PR DESCRIPTION
... from MigrationMaster.GetMigrationStatus

It turns out that having the full id (which includes the attempt) is more useful than having the attempt number separately. The client api and migrationmaster worker have been updated to match.

This removes one of the migrationmaster's TODOs.

(Review request: http://reviews.vapour.ws/r/5303/)