### PR TITLE
environs: introduce OpenParams

### DIFF
--- a/apiserver/common/networkingcommon/spaces.go
+++ b/apiserver/common/networkingcommon/spaces.go
@@ -16,23 +16,11 @@ import (
 // SupportsSpaces checks if the environment implements NetworkingEnviron
 // and also if it supports spaces.
 func SupportsSpaces(backing environs.EnvironConfigGetter) error {
-	config, err := backing.ModelConfig()
+	env, err := environs.GetEnviron(backing, environs.New)
 	if err != nil {
-		return errors.Annotate(err, "getting model config")
+		return errors.Annotate(err, "getting environ")
 	}
-	env, err := environs.New(config)
-	if err != nil {
-		return errors.Annotate(err, "validating model config")
-	}
-	netEnv, ok := environs.SupportsNetworking(env)
-	if !ok {
-		return errors.NotSupportedf("networking")
-	}
-	ok, err = netEnv.SupportsSpaces()
-	if !ok {
-		if err != nil && !errors.IsNotSupported(err) {
-			logger.Errorf("checking model spaces support failed with: %v", err)
-		}
+	if !environs.SupportsSpaces(env) {
 		return errors.NotSupportedf("spaces")
 	}
 	return nil

--- a/apiserver/common/networkingcommon/spaces_test.go
+++ b/apiserver/common/networkingcommon/spaces_test.go
@@ -153,7 +153,7 @@ func (s *SpacesSuite) TestCreateSpacesModelConfigError(c *gc.C) {
 
 	spaces := params.CreateSpacesParams{}
 	_, err := networkingcommon.CreateSpaces(apiservertesting.BackingInstance, spaces)
-	c.Assert(err, gc.ErrorMatches, "getting model config: boom")
+	c.Assert(err, gc.ErrorMatches, "getting environ: boom")
 }
 
 func (s *SpacesSuite) TestCreateSpacesProviderOpenError(c *gc.C) {
@@ -164,7 +164,7 @@ func (s *SpacesSuite) TestCreateSpacesProviderOpenError(c *gc.C) {
 
 	spaces := params.CreateSpacesParams{}
 	_, err := networkingcommon.CreateSpaces(apiservertesting.BackingInstance, spaces)
-	c.Assert(err, gc.ErrorMatches, "validating model config: boom")
+	c.Assert(err, gc.ErrorMatches, "getting environ: boom")
 }
 
 func (s *SpacesSuite) TestCreateSpacesNotSupportedError(c *gc.C) {
@@ -185,7 +185,7 @@ func (s *SpacesSuite) TestSuppportsSpacesModelConfigError(c *gc.C) {
 	)
 
 	err := networkingcommon.SupportsSpaces(apiservertesting.BackingInstance)
-	c.Assert(err, gc.ErrorMatches, "getting model config: boom")
+	c.Assert(err, gc.ErrorMatches, "getting environ: boom")
 }
 
 func (s *SpacesSuite) TestSuppportsSpacesEnvironNewError(c *gc.C) {
@@ -195,7 +195,7 @@ func (s *SpacesSuite) TestSuppportsSpacesEnvironNewError(c *gc.C) {
 	)
 
 	err := networkingcommon.SupportsSpaces(apiservertesting.BackingInstance)
-	c.Assert(err, gc.ErrorMatches, "validating model config: boom")
+	c.Assert(err, gc.ErrorMatches, "getting environ: boom")
 }
 
 func (s *SpacesSuite) TestSuppportsSpacesWithoutNetworking(c *gc.C) {

--- a/apiserver/common/networkingcommon/subnets.go
+++ b/apiserver/common/networkingcommon/subnets.go
@@ -432,8 +432,8 @@ func ListSubnets(api NetworkBacking, args params.SubnetsFilters) (results params
 // current model config, if supported. If the model does not support
 // environs.Networking, an error satisfying errors.IsNotSupported() will be
 // returned.
-func networkingEnviron(api NetworkBacking) (environs.NetworkingEnviron, error) {
-	env, err := environs.GetEnviron(api, environs.New)
+func networkingEnviron(getter environs.EnvironConfigGetter) (environs.NetworkingEnviron, error) {
+	env, err := environs.GetEnviron(getter, environs.New)
 	if err != nil {
 		return nil, errors.Annotate(err, "opening environment")
 	}

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
 	providercommon "github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state"
@@ -106,8 +105,7 @@ type BackingSpace interface {
 // retrieve information from the underlying persistency layer (state
 // DB).
 type NetworkBacking interface {
-	// ModelConfig returns the current environment config.
-	ModelConfig() (*config.Config, error)
+	environs.EnvironConfigGetter
 
 	// AvailabilityZones returns all cached availability zones (i.e.
 	// not from the provider, but in state).

--- a/apiserver/spaces/spaces_test.go
+++ b/apiserver/spaces/spaces_test.go
@@ -263,7 +263,7 @@ func (s *SpacesSuite) TestListSpacesAllSpacesError(c *gc.C) {
 	boom := errors.New("backing boom")
 	apiservertesting.BackingInstance.SetErrors(boom)
 	_, err := s.facade.ListSpaces()
-	c.Assert(err, gc.ErrorMatches, "getting model config: backing boom")
+	c.Assert(err, gc.ErrorMatches, "getting environ: backing boom")
 }
 
 func (s *SpacesSuite) TestListSpacesSubnetsError(c *gc.C) {
@@ -314,7 +314,7 @@ func (s *SpacesSuite) TestCreateSpacesModelConfigError(c *gc.C) {
 
 	spaces := params.CreateSpacesParams{}
 	_, err := s.facade.CreateSpaces(spaces)
-	c.Assert(err, gc.ErrorMatches, "getting model config: boom")
+	c.Assert(err, gc.ErrorMatches, "getting environ: boom")
 }
 
 func (s *SpacesSuite) TestCreateSpacesProviderOpenError(c *gc.C) {
@@ -325,7 +325,7 @@ func (s *SpacesSuite) TestCreateSpacesProviderOpenError(c *gc.C) {
 
 	spaces := params.CreateSpacesParams{}
 	_, err := s.facade.CreateSpaces(spaces)
-	c.Assert(err, gc.ErrorMatches, "validating model config: boom")
+	c.Assert(err, gc.ErrorMatches, "getting environ: boom")
 }
 
 func (s *SpacesSuite) TestCreateSpacesNotSupportedError(c *gc.C) {

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -515,12 +515,12 @@ type StubProvider struct {
 
 var _ environs.EnvironProvider = (*StubProvider)(nil)
 
-func (sp *StubProvider) Open(cfg *config.Config) (environs.Environ, error) {
-	sp.MethodCall(sp, "Open", cfg)
+func (sp *StubProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+	sp.MethodCall(sp, "Open", args.Config)
 	if err := sp.NextErr(); err != nil {
 		return nil, err
 	}
-	switch cfg.Name() {
+	switch args.Config.Name() {
 	case StubEnvironName:
 		return EnvironInstance, nil
 	case StubZonedEnvironName:
@@ -530,7 +530,7 @@ func (sp *StubProvider) Open(cfg *config.Config) (environs.Environ, error) {
 	case StubZonedNetworkingEnvironName:
 		return ZonedNetworkingEnvironInstance, nil
 	}
-	panic("unexpected model name: " + cfg.Name())
+	panic("unexpected model name: " + args.Config.Name())
 }
 
 // GoString implements fmt.GoStringer.

--- a/apiserver/upgrader/upgrader.go
+++ b/apiserver/upgrader/upgrader.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/stateenvirons"
 	"github.com/juju/juju/state/watcher"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -83,8 +84,9 @@ func NewUpgraderAPI(
 		return nil, err
 	}
 	urlGetter := common.NewToolsURLGetter(env.UUID(), st)
+	configGetter := stateenvirons.EnvironConfigGetter{st}
 	return &UpgraderAPI{
-		ToolsGetter: common.NewToolsGetter(st, st, st, urlGetter, getCanReadWrite),
+		ToolsGetter: common.NewToolsGetter(st, configGetter, st, urlGetter, getCanReadWrite),
 		ToolsSetter: common.NewToolsSetter(st, getCanReadWrite),
 		st:          st,
 		resources:   resources,

--- a/cmd/juju/backups/export_test.go
+++ b/cmd/juju/backups/export_test.go
@@ -71,30 +71,40 @@ func NewRestoreCommandForTest(
 	store jujuclient.ClientStore,
 	api RestoreAPI,
 	getArchive func(string) (ArchiveReader, *params.BackupsMetadataResult, error),
-	getEnviron func(string, *params.BackupsMetadataResult) (environs.Environ, *restoreBootstrapParams, error),
+	newEnviron func(environs.OpenParams) (environs.Environ, error),
+	getRebootstrapParams func(string, *params.BackupsMetadataResult) (*restoreBootstrapParams, error),
 ) cmd.Command {
 	c := &restoreCommand{
-		getArchiveFunc: getArchive,
-		getEnvironFunc: getEnviron,
+		getArchiveFunc:           getArchive,
+		newEnvironFunc:           newEnviron,
+		getRebootstrapParamsFunc: getRebootstrapParams,
 		newAPIClientFunc: func() (RestoreAPI, error) {
 			return api, nil
 		},
 		waitForAgentFunc: func(ctx *cmd.Context, c *modelcmd.ModelCommandBase, controllerName string) error {
 			return nil
-		}}
-	if getEnviron == nil {
-		c.getEnvironFunc = func(controllerNme string, meta *params.BackupsMetadataResult) (environs.Environ, *restoreBootstrapParams, error) {
-			return c.getEnviron(controllerNme, meta)
-		}
+		},
+	}
+	if getRebootstrapParams == nil {
+		c.getRebootstrapParamsFunc = c.getRebootstrapParams
+	}
+	if newEnviron == nil {
+		c.newEnvironFunc = environs.New
 	}
 	c.Log = &cmd.Log{}
 	c.SetClientStore(store)
 	return modelcmd.Wrap(c)
 }
 
-func GetEnvironFunc(e environs.Environ, cloud string) func(string, *params.BackupsMetadataResult) (environs.Environ, *restoreBootstrapParams, error) {
-	return func(string, *params.BackupsMetadataResult) (environs.Environ, *restoreBootstrapParams, error) {
-		return e, &restoreBootstrapParams{
+func GetEnvironFunc(e environs.Environ) func(environs.OpenParams) (environs.Environ, error) {
+	return func(environs.OpenParams) (environs.Environ, error) {
+		return e, nil
+	}
+}
+
+func GetRebootstrapParamsFunc(cloud string) func(string, *params.BackupsMetadataResult) (*restoreBootstrapParams, error) {
+	return func(string, *params.BackupsMetadataResult) (*restoreBootstrapParams, error) {
+		return &restoreBootstrapParams{
 			ControllerConfig: testing.FakeControllerConfig(),
 			CloudName:        cloud,
 			CloudRegion:      "a-region",
@@ -102,8 +112,8 @@ func GetEnvironFunc(e environs.Environ, cloud string) func(string, *params.Backu
 	}
 }
 
-func GetEnvironFuncWithError() func(string, *params.BackupsMetadataResult) (environs.Environ, *restoreBootstrapParams, error) {
-	return func(string, *params.BackupsMetadataResult) (environs.Environ, *restoreBootstrapParams, error) {
-		return nil, nil, errors.New("failed")
+func GetRebootstrapParamsFuncWithError() func(string, *params.BackupsMetadataResult) (*restoreBootstrapParams, error) {
+	return func(string, *params.BackupsMetadataResult) (*restoreBootstrapParams, error) {
+		return nil, errors.New("failed")
 	}
 }

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -745,11 +745,9 @@ func (s *BootstrapSuite) TestAutoSyncLocalSource(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	p, err := environs.Provider("dummy")
-	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := modelcmd.NewGetBootstrapConfigFunc(s.store)("devcontroller")
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := p.Open(cfg)
+	env, err := environs.New(environs.OpenParams{cfg})
 	c.Assert(err, jc.ErrorIsNil)
 	err = env.PrepareForBootstrap(envtesting.BootstrapContext(c))
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -369,7 +369,7 @@ func (c *destroyCommandBase) getControllerEnvironFromStore(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return environs.New(cfg)
+	return environs.New(environs.OpenParams{cfg})
 }
 
 func (c *destroyCommandBase) getControllerEnvironFromAPI(
@@ -389,7 +389,7 @@ func (c *destroyCommandBase) getControllerEnvironFromAPI(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return environs.New(cfg)
+	return environs.New(environs.OpenParams{cfg})
 }
 
 func confirmDestruction(ctx *cmd.Context, controllerName string) error {

--- a/cmd/jujud/agent/imagemetadataworker_test.go
+++ b/cmd/jujud/agent/imagemetadataworker_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/juju/api/imagemetadata"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker"
@@ -31,7 +30,7 @@ func (s *MachineMockProviderSuite) TestMachineAgentRunsMetadataWorker(c *gc.C) {
 		return worker.NewNoOpWorker()
 	}
 	s.PatchValue(&newMetadataUpdater, newWorker)
-	s.PatchValue(&newEnvirons, func(config *config.Config) (environs.Environ, error) {
+	s.PatchValue(&newEnvirons, func(environs.OpenParams) (environs.Environ, error) {
 		return &dummyEnviron{}, nil
 	})
 

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -905,7 +905,12 @@ func (a *MachineAgent) startStateWorkers(st *state.State) (worker.Worker, error)
 				return w, nil
 			})
 			a.startWorkerAfterUpgrade(runner, "peergrouper", func() (worker.Worker, error) {
-				w, err := peergrouperNew(st)
+				env, err := stateenvirons.GetNewEnvironFunc(environs.New)(st)
+				if err != nil {
+					return nil, errors.Annotate(err, "getting environ from state")
+				}
+				supportsSpaces := environs.SupportsSpaces(env)
+				w, err := peergrouperNew(st, supportsSpaces)
 				if err != nil {
 					return nil, errors.Annotate(err, "cannot start peergrouper worker")
 				}

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -412,7 +412,7 @@ func (s *MachineSuite) TestManageModelRunsInstancePoller(c *gc.C) {
 
 func (s *MachineSuite) TestManageModelRunsPeergrouper(c *gc.C) {
 	started := newSignal()
-	s.AgentSuite.PatchValue(&peergrouperNew, func(st *state.State) (worker.Worker, error) {
+	s.AgentSuite.PatchValue(&peergrouperNew, func(st *state.State, _ bool) (worker.Worker, error) {
 		c.Check(st, gc.NotNil)
 		started.trigger()
 		return newDummyWorker(), nil

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -87,7 +87,7 @@ func (s *commonMachineSuite) SetUpTest(c *gc.C) {
 
 	s.singularRecord = newSingularRunnerRecord()
 	s.AgentSuite.PatchValue(&newSingularRunner, s.singularRecord.newSingularRunner)
-	s.AgentSuite.PatchValue(&peergrouperNew, func(st *state.State) (worker.Worker, error) {
+	s.AgentSuite.PatchValue(&peergrouperNew, func(*state.State, bool) (worker.Worker, error) {
 		return newDummyWorker(), nil
 	})
 

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -128,7 +128,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 	}
 
 	// Get the bootstrap machine's addresses from the provider.
-	env, err := environs.New(args.ControllerModelConfig)
+	env, err := environs.New(environs.OpenParams{args.ControllerModelConfig})
 	if err != nil {
 		return err
 	}

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -803,7 +803,7 @@ func (s *BootstrapSuite) makeTestModel(c *gc.C) {
 		Config:         cfg,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := provider.Open(cfg)
+	env, err := provider.Open(environs.OpenParams{cfg})
 	c.Assert(err, jc.ErrorIsNil)
 	err = env.PrepareForBootstrap(nullContext())
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -41,7 +41,7 @@ func (c *imageMetadataCommandBase) prepare(context *cmd.Context) (environs.Envir
 	// identify region and endpoint info that we need. Not sure what
 	// we'll do about simplestreams.MetadataValidator yet. Probably
 	// move it to the EnvironProvider interface.
-	return environs.New(cfg)
+	return environs.New(environs.OpenParams{cfg})
 }
 
 func newImageMetadataCommand() cmd.Command {

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -167,7 +167,7 @@ func prepare(
 	if err != nil {
 		return nil, details, errors.Trace(err)
 	}
-	env, err := p.Open(cfg)
+	env, err := p.Open(environs.OpenParams{cfg})
 	if err != nil {
 		return nil, details, errors.Trace(err)
 	}

--- a/environs/environ.go
+++ b/environs/environ.go
@@ -16,15 +16,18 @@ type EnvironConfigGetter interface {
 
 // NewEnvironFunc is the type of a function that, given a model config,
 // returns an Environ. This will typically be environs.New.
-type NewEnvironFunc func(*config.Config) (Environ, error)
+type NewEnvironFunc func(OpenParams) (Environ, error)
 
 // GetEnviron returns the environs.Environ ("provider") associated
 // with the model.
 func GetEnviron(st EnvironConfigGetter, newEnviron NewEnvironFunc) (Environ, error) {
-	envcfg, err := st.ModelConfig()
+	modelConfig, err := st.ModelConfig()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	env, err := newEnviron(envcfg)
-	return env, errors.Trace(err)
+	env, err := newEnviron(OpenParams{modelConfig})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return env, nil
 }

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -40,12 +40,18 @@ type EnvironProvider interface {
 	// Open opens the environment and returns it.
 	// The configuration must have come from a previously
 	// prepared environment.
-	Open(cfg *config.Config) (Environ, error)
+	Open(OpenParams) (Environ, error)
 
 	// SecretAttrs filters the supplied configuration returning only values
 	// which are considered sensitive. All of the values of these secret
 	// attributes need to be strings.
 	SecretAttrs(cfg *config.Config) (map[string]string, error)
+}
+
+// OpenParams contains the parameters for EnvironProvider.Open.
+type OpenParams struct {
+	// Config is the base configuration for the provider.
+	Config *config.Config
 }
 
 // ProviderSchema can be implemented by a provider to provide

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -49,7 +49,7 @@ type Tests struct {
 
 // Open opens an instance of the testing environment.
 func (t *Tests) Open(c *gc.C, cfg *config.Config) environs.Environ {
-	e, err := environs.New(cfg)
+	e, err := environs.New(environs.OpenParams{cfg})
 	c.Assert(err, gc.IsNil, gc.Commentf("opening environ %#v", cfg.AllAttrs()))
 	c.Assert(e, gc.NotNil)
 	return e

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -6,6 +6,7 @@ package environs
 import (
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/errors"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 )
@@ -60,4 +61,21 @@ type NetworkingEnviron interface {
 func supportsNetworking(environ Environ) (NetworkingEnviron, bool) {
 	ne, ok := environ.(NetworkingEnviron)
 	return ne, ok
+}
+
+// SupportsSpaces checks if the environment implements NetworkingEnviron
+// and also if it supports spaces.
+func SupportsSpaces(env Environ) bool {
+	netEnv, ok := supportsNetworking(env)
+	if !ok {
+		return false
+	}
+	ok, err := netEnv.SupportsSpaces()
+	if err != nil {
+		if !errors.IsNotSupported(err) {
+			logger.Errorf("checking model spaces support failed with: %v", err)
+		}
+		return false
+	}
+	return ok
 }

--- a/environs/open.go
+++ b/environs/open.go
@@ -6,7 +6,6 @@ package environs
 import (
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -14,12 +13,12 @@ import (
 const AdminUser = "admin@local"
 
 // New returns a new environment based on the provided configuration.
-func New(config *config.Config) (Environ, error) {
-	p, err := Provider(config.Type())
+func New(args OpenParams) (Environ, error) {
+	p, err := Provider(args.Config.Type())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return p.Open(config)
+	return p.Open(args)
 }
 
 // Destroy destroys the controller and, if successful,

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -117,7 +117,7 @@ func (*OpenSuite) TestNewUnknownEnviron(c *gc.C) {
 		},
 	))
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.New(cfg)
+	env, err := environs.New(environs.OpenParams{cfg})
 	c.Assert(err, gc.ErrorMatches, "no registered provider for.*")
 	c.Assert(env, gc.IsNil)
 }
@@ -130,7 +130,7 @@ func (*OpenSuite) TestNew(c *gc.C) {
 		},
 	))
 	c.Assert(err, jc.ErrorIsNil)
-	e, err := environs.New(cfg)
+	e, err := environs.New(environs.OpenParams{cfg})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = e.ControllerInstances("uuid")
 	c.Assert(err, gc.ErrorMatches, "model is not prepared")

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -306,7 +306,7 @@ func openEnviron(
 	// Opening the environment should not incur network communication,
 	// so we don't set s.sender until after opening.
 	cfg := makeTestModelConfig(c, attrs...)
-	env, err := provider.Open(cfg)
+	env, err := provider.Open(environs.OpenParams{cfg})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Force an explicit refresh of the access token, so it isn't done
@@ -336,7 +336,7 @@ func prepareForBootstrap(
 		Credentials:          fakeUserPassCredential(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := provider.Open(cfg)
+	env, err := provider.Open(environs.OpenParams{cfg})
 	c.Assert(err, jc.ErrorIsNil)
 	err = env.PrepareForBootstrap(ctx)
 	c.Assert(err, jc.ErrorIsNil)
@@ -484,9 +484,7 @@ func (c *mockClock) After(d time.Duration) <-chan time.Time {
 }
 
 func (s *environSuite) TestOpen(c *gc.C) {
-	cfg := makeTestModelConfig(c)
-	env, err := s.provider.Open(cfg)
-	c.Assert(err, jc.ErrorIsNil)
+	env := s.openEnviron(c)
 	c.Assert(env, gc.NotNil)
 }
 

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -70,9 +70,9 @@ func NewEnvironProvider(config ProviderConfig) (*azureEnvironProvider, error) {
 }
 
 // Open is specified in the EnvironProvider interface.
-func (prov *azureEnvironProvider) Open(cfg *config.Config) (environs.Environ, error) {
-	logger.Debugf("opening model %q", cfg.Name())
-	environ, err := newEnviron(prov, cfg)
+func (prov *azureEnvironProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+	logger.Debugf("opening model %q", args.Config.Name())
+	environ, err := newEnviron(prov, args.Config)
 	if err != nil {
 		return nil, errors.Annotate(err, "opening model")
 	}

--- a/provider/cloudsigma/config_test.go
+++ b/provider/cloudsigma/config_test.go
@@ -91,7 +91,7 @@ func (s *configSuite) TestNewModelConfig(c *gc.C) {
 		c.Logf("test %d: %s", i, test.info)
 		attrs := validAttrs().Merge(test.insert).Delete(test.remove...)
 		testConfig := newConfig(c, attrs)
-		environ, err := environs.New(testConfig)
+		environ, err := environs.New(environs.OpenParams{testConfig})
 		if test.err == "" {
 			c.Check(err, gc.IsNil)
 			attrs := environ.Config().AllAttrs()
@@ -177,7 +177,7 @@ func (s *configSuite) TestSetConfig(c *gc.C) {
 	baseConfig := newConfig(c, validAttrs())
 	for i, test := range changeConfigTests {
 		c.Logf("test %d: %s", i, test.info)
-		environ, err := environs.New(baseConfig)
+		environ, err := environs.New(environs.OpenParams{baseConfig})
 		c.Assert(err, gc.IsNil)
 		attrs := validAttrs().Merge(test.insert).Delete(test.remove...)
 		testConfig := newConfig(c, attrs)
@@ -195,13 +195,6 @@ func (s *configSuite) TestSetConfig(c *gc.C) {
 			}
 		}
 	}
-}
-
-func (s *configSuite) TestConfigName(c *gc.C) {
-	baseConfig := newConfig(c, validAttrs().Merge(testing.Attrs{"name": "testname"}))
-	environ, err := environs.New(baseConfig)
-	c.Assert(err, gc.IsNil)
-	c.Check(environ.Config().Name(), gc.Equals, "testname")
 }
 
 func (s *configSuite) TestModelConfig(c *gc.C) {

--- a/provider/cloudsigma/environ_test.go
+++ b/provider/cloudsigma/environ_test.go
@@ -46,7 +46,7 @@ func (s *environSuite) TestBase(c *gc.C) {
 	})
 
 	baseConfig := newConfig(c, validAttrs().Merge(testing.Attrs{"name": "testname"}))
-	env, err := environs.New(baseConfig)
+	env, err := environs.New(environs.OpenParams{baseConfig})
 	c.Assert(err, gc.IsNil)
 	env.(*environ).supportedArchitectures = []string{arch.AMD64}
 
@@ -89,7 +89,7 @@ func (s *environSuite) TestUnsupportedConstraints(c *gc.C) {
 	})
 
 	baseConfig := newConfig(c, validAttrs().Merge(testing.Attrs{"name": "testname"}))
-	env, err := environs.New(baseConfig)
+	env, err := environs.New(environs.OpenParams{baseConfig})
 	c.Assert(err, gc.IsNil)
 	env.(*environ).supportedArchitectures = []string{arch.AMD64}
 

--- a/provider/cloudsigma/environinstance_test.go
+++ b/provider/cloudsigma/environinstance_test.go
@@ -75,7 +75,7 @@ func (s *environInstanceSuite) createEnviron(c *gc.C, cfg *config.Config) enviro
 	if cfg == nil {
 		cfg = s.baseConfig
 	}
-	environ, err := environs.New(cfg)
+	environ, err := environs.New(environs.OpenParams{cfg})
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(environ, gc.NotNil)

--- a/provider/cloudsigma/provider.go
+++ b/provider/cloudsigma/provider.go
@@ -55,11 +55,11 @@ func init() {
 // Open opens the environment and returns it.
 // The configuration must have come from a previously
 // prepared environment.
-func (environProvider) Open(cfg *config.Config) (environs.Environ, error) {
-	logger.Infof("opening model %q", cfg.Name())
+func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+	logger.Infof("opening model %q", args.Config.Name())
 
-	env := &environ{name: cfg.Name()}
-	if err := env.SetConfig(cfg); err != nil {
+	env := &environ{name: args.Config.Name()}
+	if err := env.SetConfig(args.Config); err != nil {
 		return nil, err
 	}
 

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -515,17 +515,17 @@ func (e *environ) state() (*environState, error) {
 	return state, nil
 }
 
-func (p *environProvider) Open(cfg *config.Config) (environs.Environ, error) {
+func (p *environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	ecfg, err := p.newConfig(cfg)
+	ecfg, err := p.newConfig(args.Config)
 	if err != nil {
 		return nil, err
 	}
 	env := &environ{
 		name:         ecfg.Name(),
 		ecfgUnlocked: ecfg,
-		modelUUID:    cfg.UUID(),
+		modelUUID:    args.Config.UUID(),
 	}
 	if err := env.checkBroken("Open"); err != nil {
 		return nil, err

--- a/provider/ec2/config_test.go
+++ b/provider/ec2/config_test.go
@@ -68,7 +68,7 @@ func (t configTest) check(c *gc.C) {
 	}).Merge(t.config)
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	e, err := environs.New(cfg)
+	e, err := environs.New(environs.OpenParams{cfg})
 	if t.change != nil {
 		c.Assert(err, jc.ErrorIsNil)
 

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -617,7 +617,7 @@ func (t *localServerSuite) TestDestroyHostedModelDeleteSecurityGroupInsistentlyE
 
 	cfg, err := env.Config().Apply(map[string]interface{}{"controller-uuid": "7e386e08-cba7-44a4-a76e-7c1633584210"})
 	c.Assert(err, jc.ErrorIsNil)
-	env, err = environs.New(cfg)
+	env, err = environs.New(environs.OpenParams{cfg})
 	c.Assert(err, jc.ErrorIsNil)
 
 	msg := "destroy security group error"
@@ -640,7 +640,7 @@ func (t *localServerSuite) TestDestroyControllerDestroysHostedModelResources(c *
 		"firewall-mode": "global",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.New(cfg)
+	env, err := environs.New(environs.OpenParams{cfg})
 	c.Assert(err, jc.ErrorIsNil)
 	inst, _ := testing.AssertStartInstance(c, env, t.ControllerUUID, "0")
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -34,7 +34,7 @@ func (p environProvider) RestrictedConfigAttributes() []string {
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.
 func (p environProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
-	e, err := p.Open(cfg)
+	e, err := p.Open(environs.OpenParams{cfg})
 	if err != nil {
 		return nil, err
 	}
@@ -49,11 +49,11 @@ func (p environProvider) PrepareForCreateEnvironment(controllerUUID string, cfg 
 }
 
 // Open is specified in the EnvironProvider interface.
-func (p environProvider) Open(cfg *config.Config) (environs.Environ, error) {
-	logger.Infof("opening model %q", cfg.Name())
+func (p environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+	logger.Infof("opening model %q", args.Config.Name())
 	e := new(environ)
-	e.name = cfg.Name()
-	err := e.SetConfig(cfg)
+	e.name = args.Config.Name()
+	err := e.SetConfig(args.Config)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/gce/config_test.go
+++ b/provider/gce/config_test.go
@@ -160,7 +160,7 @@ func (s *ConfigSuite) TestNewModelConfig(c *gc.C) {
 		c.Logf("test %d: %s", i, test.info)
 
 		testConfig := test.newConfig(c)
-		environ, err := environs.New(testConfig)
+		environ, err := environs.New(environs.OpenParams{testConfig})
 
 		// Check the result
 		if test.err != "" {
@@ -280,7 +280,7 @@ func (s *ConfigSuite) TestSetConfig(c *gc.C) {
 	for i, test := range changeConfigTests {
 		c.Logf("test %d: %s", i, test.info)
 
-		environ, err := environs.New(s.config)
+		environ, err := environs.New(environs.OpenParams{s.config})
 		c.Assert(err, jc.ErrorIsNil)
 
 		testConfig := test.newConfig(c)

--- a/provider/gce/provider.go
+++ b/provider/gce/provider.go
@@ -19,8 +19,8 @@ type environProvider struct {
 var providerInstance environProvider
 
 // Open implements environs.EnvironProvider.
-func (environProvider) Open(cfg *config.Config) (environs.Environ, error) {
-	env, err := newEnviron(cfg)
+func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+	env, err := newEnviron(args.Config)
 	return env, errors.Trace(err)
 }
 

--- a/provider/gce/provider_test.go
+++ b/provider/gce/provider_test.go
@@ -33,7 +33,7 @@ func (s *providerSuite) TestRegistered(c *gc.C) {
 }
 
 func (s *providerSuite) TestOpen(c *gc.C) {
-	env, err := s.provider.Open(s.Config)
+	env, err := s.provider.Open(environs.OpenParams{s.Config})
 	c.Check(err, jc.ErrorIsNil)
 
 	envConfig := env.Config()

--- a/provider/joyent/config_test.go
+++ b/provider/joyent/config_test.go
@@ -166,7 +166,7 @@ func doTest(s *ConfigSuite, i int, test configtest, c *gc.C) {
 	attrs := validAttrs().Merge(test.insert).Delete(test.remove...)
 	attrs["private-key"] = s.privateKeyData
 	testConfig := newConfig(c, attrs)
-	environ, err := environs.New(testConfig)
+	environ, err := environs.New(environs.OpenParams{testConfig})
 	if test.err == "" {
 		c.Check(err, jc.ErrorIsNil)
 		if err != nil {
@@ -237,7 +237,7 @@ func (s *ConfigSuite) TestSetConfig(c *gc.C) {
 	baseConfig := newConfig(c, validAttrs())
 	for i, test := range changeConfigTests {
 		c.Logf("test %d: %s", i, test.info)
-		environ, err := environs.New(baseConfig)
+		environ, err := environs.New(environs.OpenParams{baseConfig})
 		c.Assert(err, jc.ErrorIsNil)
 		attrs := validAttrs().Merge(test.insert).Delete(test.remove...)
 		testConfig := newConfig(c, attrs)

--- a/provider/joyent/provider.go
+++ b/provider/joyent/provider.go
@@ -118,8 +118,8 @@ func credentials(cfg *environConfig) (*auth.Credentials, error) {
 	}, nil
 }
 
-func (joyentProvider) Open(cfg *config.Config) (environs.Environ, error) {
-	env, err := newEnviron(cfg)
+func (joyentProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+	env, err := newEnviron(args.Config)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/lxd/config_test.go
+++ b/provider/lxd/config_test.go
@@ -321,7 +321,7 @@ func (s *configSuite) TestNewModelConfig(c *gc.C) {
 		c.Logf("test %d: %s", i, test.info)
 
 		testConfig := test.newConfig(c)
-		environ, err := environs.New(testConfig)
+		environ, err := environs.New(environs.OpenParams{testConfig})
 
 		// Check the result
 		if test.err != "" {
@@ -421,7 +421,7 @@ func (s *configSuite) TestSetConfig(c *gc.C) {
 	for i, test := range changeConfigTests {
 		c.Logf("test %d: %s", i, test.info)
 
-		environ, err := environs.New(s.config)
+		environ, err := environs.New(environs.OpenParams{s.config})
 		c.Assert(err, jc.ErrorIsNil)
 
 		testConfig := test.newConfig(c)

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -21,12 +21,12 @@ type environProvider struct {
 var providerInstance environProvider
 
 // Open implements environs.EnvironProvider.
-func (environProvider) Open(cfg *config.Config) (environs.Environ, error) {
+func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
 	// TODO(ericsnow) verify prerequisites (see provider/local/prereq.go)?
 	// TODO(ericsnow) do something similar to correctLocalhostURLs()
 	// (in provider/local/environprovider.go)?
 
-	env, err := newEnviron(cfg, newRawProvider)
+	env, err := newEnviron(args.Config, newRawProvider)
 	return env, errors.Trace(err)
 }
 

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -103,7 +103,7 @@ func (s *ProviderFunctionalSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ProviderFunctionalSuite) TestOpen(c *gc.C) {
-	env, err := s.provider.Open(s.Config)
+	env, err := s.provider.Open(environs.OpenParams{s.Config})
 	c.Assert(err, jc.ErrorIsNil)
 	envConfig := env.Config()
 

--- a/provider/maas/config_test.go
+++ b/provider/maas/config_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/testing"
 )
@@ -40,11 +39,7 @@ func newConfig(values map[string]interface{}) (*maasModelConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	env, err := environs.New(cfg)
-	if err != nil {
-		return nil, err
-	}
-	return env.(*maasEnviron).ecfg(), nil
+	return providerInstance.newConfig(cfg)
 }
 
 func (s *configSuite) SetUpTest(c *gc.C) {

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -28,9 +28,9 @@ var _ environs.EnvironProvider = (*maasEnvironProvider)(nil)
 
 var providerInstance maasEnvironProvider
 
-func (maasEnvironProvider) Open(cfg *config.Config) (environs.Environ, error) {
-	logger.Debugf("opening model %q.", cfg.Name())
-	env, err := NewEnviron(cfg)
+func (maasEnvironProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+	logger.Debugf("opening model %q.", args.Config.Name())
+	env, err := NewEnviron(args.Config)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/maas/environprovider_test.go
+++ b/provider/maas/environprovider_test.go
@@ -190,7 +190,7 @@ func (suite *EnvironProviderSuite) TestOpenReturnsNilInterfaceUponFailure(c *gc.
 	})
 	config, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := providerInstance.Open(config)
+	env, err := providerInstance.Open(environs.OpenParams{config})
 	// When Open() fails (i.e. returns a non-nil error), it returns an
 	// environs.Environ interface object with a nil value and a nil
 	// type.

--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -17,19 +17,23 @@ import (
 	coretesting "github.com/juju/juju/testing"
 )
 
-type environSuite struct {
+type baseEnvironSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite
 	env *manualEnviron
 }
 
-var _ = gc.Suite(&environSuite{})
-
-func (s *environSuite) SetUpTest(c *gc.C) {
+func (s *baseEnvironSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	env, err := manualProvider{}.Open(MinimalConfig(c))
+	env, err := manualProvider{}.Open(environs.OpenParams{MinimalConfig(c)})
 	c.Assert(err, jc.ErrorIsNil)
 	s.env = env.(*manualEnviron)
 }
+
+type environSuite struct {
+	baseEnvironSuite
+}
+
+var _ = gc.Suite(&environSuite{})
 
 func (s *environSuite) TestSetConfig(c *gc.C) {
 	err := s.env.SetConfig(MinimalConfig(c))
@@ -131,33 +135,11 @@ func (s *environSuite) TestConstraintsValidator(c *gc.C) {
 	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "instance-type", "tags", "virt-type"})
 }
 
-type bootstrapSuite struct {
-	coretesting.FakeJujuXDGDataHomeSuite
-	env *manualEnviron
-}
-
-var _ = gc.Suite(&bootstrapSuite{})
-
-func (s *bootstrapSuite) SetUpTest(c *gc.C) {
-	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	env, err := manualProvider{}.Open(MinimalConfig(c))
-	c.Assert(err, jc.ErrorIsNil)
-	s.env = env.(*manualEnviron)
-}
-
 type controllerInstancesSuite struct {
-	coretesting.FakeJujuXDGDataHomeSuite
-	env *manualEnviron
+	baseEnvironSuite
 }
 
 var _ = gc.Suite(&controllerInstancesSuite{})
-
-func (s *controllerInstancesSuite) SetUpTest(c *gc.C) {
-	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	env, err := manualProvider{}.Open(MinimalConfig(c))
-	c.Assert(err, jc.ErrorIsNil)
-	s.env = env.(*manualEnviron)
-}
 
 func (s *controllerInstancesSuite) TestControllerInstances(c *gc.C) {
 	var outputResult string

--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -71,15 +71,15 @@ func (p manualProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*c
 	return cfg.Apply(envConfig.attrs)
 }
 
-func (p manualProvider) Open(cfg *config.Config) (environs.Environ, error) {
-	_, err := p.validate(cfg, nil)
+func (p manualProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+	_, err := p.validate(args.Config, nil)
 	if err != nil {
 		return nil, err
 	}
 	// validate adds missing manual-specific config attributes
 	// with their defaults in the result; we don't wnat that in
 	// Open.
-	envConfig := newModelConfig(cfg, cfg.UnknownAttrs())
+	envConfig := newModelConfig(args.Config, args.Config.UnknownAttrs())
 	return p.open(envConfig)
 }
 

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -65,7 +65,7 @@ func (s *providerSuite) testPrepareForBootstrap(c *gc.C, endpoint, region string
 	if err != nil {
 		return nil, err
 	}
-	env, err := manual.ProviderInstance.Open(testConfig)
+	env, err := manual.ProviderInstance.Open(environs.OpenParams{testConfig})
 	if err != nil {
 		return nil, err
 	}

--- a/provider/openstack/config_test.go
+++ b/provider/openstack/config_test.go
@@ -100,7 +100,7 @@ func (t configTest) check(c *gc.C) {
 	}
 	defer restoreEnvVars(savedVars)
 
-	e, err := environs.New(cfg)
+	e, err := environs.New(environs.OpenParams{cfg})
 	if t.change != nil {
 		c.Assert(err, jc.ErrorIsNil)
 

--- a/provider/openstack/live_test.go
+++ b/provider/openstack/live_test.go
@@ -15,9 +15,6 @@ import (
 	"gopkg.in/goose.v1/identity"
 	"gopkg.in/goose.v1/nova"
 
-	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/bootstrap"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/jujutest"
 	"github.com/juju/juju/environs/storage"
 	envtesting "github.com/juju/juju/environs/testing"
@@ -211,27 +208,15 @@ func (t *LiveTests) TestSetupGlobalGroupExposesCorrectPorts(c *gc.C) {
 }
 
 func (s *LiveTests) assertStartInstanceDefaultSecurityGroup(c *gc.C, useDefault bool) {
-	attrs := s.TestConfig.Merge(coretesting.Attrs{
-		"name":                 "sample-" + randomName(),
+	s.LiveTests.PatchValue(&s.TestConfig, s.TestConfig.Merge(coretesting.Attrs{
 		"use-default-secgroup": useDefault,
-	})
-	cfg, err := config.New(config.NoDefaults, attrs)
-	c.Assert(err, jc.ErrorIsNil)
-	// Set up a test environment.
-	env, err := environs.New(cfg)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env, gc.NotNil)
-	defer env.Destroy()
-	// Bootstrap and start an instance.
-	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      jujutesting.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	inst, _ := jujutesting.AssertStartInstance(c, env, s.ControllerUUID, "100")
+	}))
+	s.Destroy(c)
+	s.BootstrapOnce(c)
+
+	inst, _ := jujutesting.AssertStartInstance(c, s.Env, s.ControllerUUID, "100")
 	// Check whether the instance has the default security group assigned.
-	novaClient := openstack.GetNovaClient(env)
+	novaClient := openstack.GetNovaClient(s.Env)
 	groups, err := novaClient.GetServerSecurityGroups(string(inst.Id()))
 	c.Assert(err, jc.ErrorIsNil)
 	defaultGroupFound := false

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -281,7 +281,7 @@ func (s *localServerSuite) TearDownTest(c *gc.C) {
 func (s *localServerSuite) openEnviron(c *gc.C, attrs coretesting.Attrs) environs.Environ {
 	cfg, err := config.New(config.NoDefaults, s.TestConfig.Merge(attrs))
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.New(cfg)
+	env, err := environs.New(environs.OpenParams{cfg})
 	c.Assert(err, jc.ErrorIsNil)
 	return env
 }
@@ -1298,7 +1298,7 @@ func (s *localHTTPSServerSuite) TestMustDisableSSLVerify(c *gc.C) {
 	newattrs["ssl-hostname-verification"] = true
 	cfg, err := config.New(config.NoDefaults, newattrs)
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.New(cfg)
+	env, err := environs.New(environs.OpenParams{cfg})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = env.AllInstances()
 	c.Assert(err, gc.ErrorMatches, "(.|\n)*x509: certificate signed by unknown authority")

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -71,17 +71,17 @@ var shortAttempt = utils.AttemptStrategy{
 	Delay: 200 * time.Millisecond,
 }
 
-func (p EnvironProvider) Open(cfg *config.Config) (environs.Environ, error) {
-	logger.Infof("opening model %q", cfg.Name())
+func (p EnvironProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+	logger.Infof("opening model %q", args.Config.Name())
 	e := new(Environ)
 
 	e.firewaller = p.FirewallerFactory.GetFirewaller(e)
 	e.configurator = p.Configurator
-	err := e.SetConfig(cfg)
+	err := e.SetConfig(args.Config)
 	if err != nil {
 		return nil, err
 	}
-	e.name = cfg.Name()
+	e.name = args.Config.Name()
 	return e, nil
 }
 

--- a/provider/rackspace/provider_test.go
+++ b/provider/rackspace/provider_test.go
@@ -56,8 +56,8 @@ type fakeProvider struct {
 	testing.Stub
 }
 
-func (p *fakeProvider) Open(cfg *config.Config) (environs.Environ, error) {
-	p.MethodCall(p, "Open", cfg)
+func (p *fakeProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+	p.MethodCall(p, "Open", args)
 	return nil, nil
 }
 

--- a/provider/vsphere/config_test.go
+++ b/provider/vsphere/config_test.go
@@ -128,7 +128,7 @@ func (*ConfigSuite) TestNewModelConfig(c *gc.C) {
 		c.Logf("test %d: %s", i, test.info)
 
 		testConfig := test.newConfig(c)
-		environ, err := environs.New(testConfig)
+		environ, err := environs.New(environs.OpenParams{testConfig})
 
 		// Check the result
 		if test.err != "" {
@@ -232,7 +232,7 @@ func (s *ConfigSuite) TestSetConfig(c *gc.C) {
 	for i, test := range changeConfigTests {
 		c.Logf("test %d: %s", i, test.info)
 
-		environ, err := environs.New(s.config)
+		environ, err := environs.New(environs.OpenParams{s.config})
 		c.Assert(err, jc.ErrorIsNil)
 
 		testConfig := test.newConfig(c)

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -24,8 +24,8 @@ var _ environs.EnvironProvider = providerInstance
 var logger = loggo.GetLogger("juju.provider.vmware")
 
 // Open implements environs.EnvironProvider.
-func (environProvider) Open(cfg *config.Config) (environs.Environ, error) {
-	env, err := newEnviron(cfg)
+func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+	env, err := newEnviron(args.Config)
 	return env, errors.Trace(err)
 }
 

--- a/provider/vsphere/provider_test.go
+++ b/provider/vsphere/provider_test.go
@@ -35,7 +35,7 @@ func (s *providerSuite) TestRegistered(c *gc.C) {
 }
 
 func (s *providerSuite) TestOpen(c *gc.C) {
-	env, err := s.provider.Open(s.Config)
+	env, err := s.provider.Open(environs.OpenParams{s.Config})
 	c.Check(err, jc.ErrorIsNil)
 
 	envConfig := env.Config()

--- a/provider/vsphere/testing_test.go
+++ b/provider/vsphere/testing_test.go
@@ -65,7 +65,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 func (s *BaseSuite) initEnv(c *gc.C) {
 	cfg, err := testing.ModelConfig(c).Apply(ConfigAttrs)
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.New(cfg)
+	env, err := environs.New(environs.OpenParams{cfg})
 	c.Assert(err, jc.ErrorIsNil)
 	s.Env = env.(*environ)
 	s.setConfig(c, cfg)

--- a/worker/discoverspaces/worker_test.go
+++ b/worker/discoverspaces/worker_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/stateenvirons"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/discoverspaces"
@@ -188,9 +189,7 @@ func (s *WorkerSuite) TestWorkerIgnoresExistingSpacesAndSubnets(c *gc.C) {
 
 func (s *WorkerSuite) startWorker(c *gc.C) (worker.Worker, gate.Lock) {
 	// create fresh environ to see any injected broken-ness
-	config, err := s.State.ModelConfig()
-	c.Assert(err, jc.ErrorIsNil)
-	environ, err := environs.New(config)
+	environ, err := stateenvirons.GetNewEnvironFunc(environs.New)(s.State)
 	c.Assert(err, jc.ErrorIsNil)
 
 	lock := gate.NewLock()

--- a/worker/environ/environ_test.go
+++ b/worker/environ/environ_test.go
@@ -11,7 +11,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/config"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/environ"
 	"github.com/juju/juju/worker/workertest"
@@ -72,7 +71,7 @@ func (s *TrackerSuite) TestModelConfigInvalid(c *gc.C) {
 	fix.Run(c, func(context *runContext) {
 		tracker, err := environ.NewTracker(environ.Config{
 			Observer: context,
-			NewEnvironFunc: func(*config.Config) (environs.Environ, error) {
+			NewEnvironFunc: func(environs.OpenParams) (environs.Environ, error) {
 				return nil, errors.NotValidf("config")
 			},
 		})
@@ -165,7 +164,7 @@ func (s *TrackerSuite) TestWatchedModelConfigIncompatible(c *gc.C) {
 	fix.Run(c, func(context *runContext) {
 		tracker, err := environ.NewTracker(environ.Config{
 			Observer: context,
-			NewEnvironFunc: func(*config.Config) (environs.Environ, error) {
+			NewEnvironFunc: func(environs.OpenParams) (environs.Environ, error) {
 				env := &mockEnviron{}
 				env.SetErrors(errors.New("SetConfig is broken"))
 				return env, nil

--- a/worker/environ/fixture_test.go
+++ b/worker/environ/fixture_test.go
@@ -144,6 +144,6 @@ func (e *mockEnviron) SetConfig(cfg *config.Config) error {
 	return nil
 }
 
-func newMockEnviron(cfg *config.Config) (environs.Environ, error) {
-	return &mockEnviron{cfg: cfg}, nil
+func newMockEnviron(args environs.OpenParams) (environs.Environ, error) {
+	return &mockEnviron{cfg: args.Config}, nil
 }

--- a/worker/environ/wait_test.go
+++ b/worker/environ/wait_test.go
@@ -11,7 +11,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/config"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/environ"
 	"github.com/juju/juju/worker/workertest"
@@ -103,11 +102,11 @@ func (s *WaitSuite) TestIgnoresBadConfig(c *gc.C) {
 			"type": "unknown",
 		},
 	}
-	newEnvironFunc := func(cfg *config.Config) (environs.Environ, error) {
-		if cfg.Type() == "unknown" {
+	newEnvironFunc := func(args environs.OpenParams) (environs.Environ, error) {
+		if args.Config.Type() == "unknown" {
 			return nil, errors.NotValidf("config")
 		}
-		return &mockEnviron{cfg: cfg}, nil
+		return &mockEnviron{cfg: args.Config}, nil
 	}
 	fix.Run(c, func(context *runContext) {
 		abort := make(chan struct{})

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -11,8 +11,6 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/replicaset"
 
-	"github.com/juju/juju/apiserver/common/networkingcommon"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -32,7 +30,6 @@ type stateInterface interface {
 	Space(id string) (SpaceReader, error)
 	SetOrGetMongoSpaceName(spaceName network.SpaceName) (network.SpaceName, error)
 	SetMongoSpaceState(mongoSpaceState state.MongoSpaceStates) error
-	ModelConfig() (*config.Config, error)
 }
 
 type stateMachine interface {
@@ -108,7 +105,7 @@ type pgWorker struct {
 
 // New returns a new worker that maintains the mongo replica set
 // with respect to the given state.
-func New(st *state.State) (worker.Worker, error) {
+func New(st *state.State, supportsSpaces bool) (worker.Worker, error) {
 	cfg, err := st.ControllerConfig()
 	if err != nil {
 		return nil, err
@@ -118,7 +115,6 @@ func New(st *state.State) (worker.Worker, error) {
 		mongoPort: cfg.StatePort(),
 		apiPort:   cfg.APIPort(),
 	}
-	supportsSpaces := networkingcommon.SupportsSpaces(shim) == nil
 	return newWorker(shim, newPublisher(st), supportsSpaces)
 }
 


### PR DESCRIPTION
Modify the environs.EnvironProvider.Open method
and environs.New to take the new OpenParams
parameter struct instead of just *config.Config.
We will add cloud and credentials to this struct
later.

(Review request: http://reviews.vapour.ws/r/5304/)