### PR TITLE
lxd: Properly store the image source (auto-update)

### DIFF
--- a/tools/lxdclient/client_image.go
+++ b/tools/lxdclient/client_image.go
@@ -144,7 +144,7 @@ func (i *imageClient) EnsureImageExists(series string, sources []Remote, copyPro
 			context: fmt.Sprintf("copying image for %s from %s: %%s", name, source.URL()),
 			forward: forwarder.Forward,
 		}
-		err = source.CopyImage(target, i.raw, []string{name}, adapter.copyProgress)
+		err = source.CopyImage(series, i.raw, []string{name}, adapter.copyProgress)
 		return errors.Annotatef(err, "unable to get LXD image for %s", name)
 	}
 	return lastErr


### PR DESCRIPTION
In current code, Juju resolves the image alias prior to copying the
image into the local image store.

This means that the local LXD daemon won't know what the image alias was
and so can't auto-update the image in the future.

Fix this by just passing the alias straight to LXD, but still resolve it
in Juju before so the log messages and errors remain identical.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>