### PR TITLE
Move PORTS after ADDRESS in tabular status.

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -193,13 +193,13 @@ func FormatTabular(value interface{}) ([]byte, error) {
 			u.WorkloadStatusInfo.Current,
 			u.JujuStatusInfo.Current,
 			u.Machine,
-			strings.Join(u.OpenedPorts, ","),
 			u.PublicAddress,
+			strings.Join(u.OpenedPorts, ","),
 			message,
 		)
 	}
 
-	outputHeaders("UNIT", "WORKLOAD", "AGENT", "MACHINE", "PORTS", "PUBLIC-ADDRESS", "MESSAGE")
+	outputHeaders("UNIT", "WORKLOAD", "AGENT", "MACHINE", "PUBLIC-ADDRESS", "PORTS", "MESSAGE")
 	for _, name := range utils.SortStringsNaturally(stringKeysFromMap(units)) {
 		u := units[name]
 		pUnit(name, u, 0)

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3388,11 +3388,11 @@ info               mysql      logging    subordinate
 db                 mysql      wordpress  regular
 logging-directory  wordpress  logging    subordinate
 
-UNIT         WORKLOAD     AGENT  MACHINE  PORTS  PUBLIC-ADDRESS    MESSAGE
-mysql/0      maintenance  idle   2               controller-2.dns  installing all the things
-  logging/1  error        idle                   controller-2.dns  somehow lost in all those logs
-wordpress/0  active       idle   1               controller-1.dns  
-  logging/0  active       idle                   controller-1.dns  
+UNIT         WORKLOAD     AGENT  MACHINE  PUBLIC-ADDRESS    PORTS  MESSAGE
+mysql/0      maintenance  idle   2        controller-2.dns         installing all the things
+  logging/1  error        idle            controller-2.dns         somehow lost in all those logs
+wordpress/0  active       idle   1        controller-1.dns         
+  logging/0  active       idle            controller-1.dns         
 
 MACHINE  STATE    DNS               INS-ID        SERIES   AZ
 0        started  controller-0.dns  controller-0  quantal  us-east-1a
@@ -3445,7 +3445,7 @@ MODEL  CONTROLLER  CLOUD/REGION  VERSION
 APP  VERSION  STATUS  EXPOSED  ORIGIN  CHARM  REV  OS
 foo                   false                   0    
 
-UNIT   WORKLOAD     AGENT      MACHINE  PORTS  PUBLIC-ADDRESS  MESSAGE
+UNIT   WORKLOAD     AGENT      MACHINE  PUBLIC-ADDRESS  PORTS  MESSAGE
 foo/0  maintenance  executing                                  (config-changed) doing some work
 foo/1  maintenance  executing                                  (backup database) doing some work
 
@@ -3537,7 +3537,7 @@ MODEL  CONTROLLER  CLOUD/REGION  VERSION
 APP  VERSION  STATUS  EXPOSED  ORIGIN  CHARM  REV  OS
 foo                   false                   0    
 
-UNIT   WORKLOAD  AGENT  MACHINE  PORTS  PUBLIC-ADDRESS  MESSAGE
+UNIT   WORKLOAD  AGENT  MACHINE  PUBLIC-ADDRESS  PORTS  MESSAGE
 foo/0                                                   
 foo/1                                                   
 


### PR DESCRIPTION
The idea is that standard syntax is 'ip:port' so it makes more sense for PORTS
to come after ADDRESS instead of before.

Testing:
```
  $ juju bootstrap test-lxd lxd
  $ juju deploy mysql
  $ juju status
```

And see something like:
```
MODEL    CONTROLLER  CLOUD/REGION   VERSION
default  test-lxd    lxd/localhost  2.0-beta14.1

APP    VERSION  STATUS   EXPOSED  ORIGIN      CHARM  REV  OS
mysql           unknown  false    jujucharms  mysql  55   ubuntu

RELATION  PROVIDES  CONSUMES  TYPE
cluster   mysql     mysql     peer

UNIT     WORKLOAD  AGENT  MACHINE  PUBLIC-ADDRESS  PORTS     MESSAGE
mysql/0  unknown   idle   0        10.246.146.20   3306/tcp  

MACHINE  STATE    DNS            INS-ID         SERIES  AZ
0        started  10.246.146.20  juju-7c9629-0  trusty  
```

which shows that PORTS is coming after the PUBLIC-ADDRESS