### PR TITLE
Fixes lp:1575676: Detect LXD default profile's bridge name and use it

### DIFF
--- a/provider/lxd/config.go
+++ b/provider/lxd/config.go
@@ -215,11 +215,7 @@ func (c *environConfig) clientConfig() (lxdclient.Config, error) {
 	cfg := lxdclient.Config{
 		Remote: remote,
 	}
-	cfg, err := cfg.WithDefaults()
-	if err != nil {
-		return cfg, errors.Trace(err)
-	}
-	return cfg, nil
+	return cfg.WithDefaults()
 }
 
 // TODO(ericsnow) Switch to a DI testing approach and eliminiate this var.

--- a/provider/lxd/config.go
+++ b/provider/lxd/config.go
@@ -215,7 +215,11 @@ func (c *environConfig) clientConfig() (lxdclient.Config, error) {
 	cfg := lxdclient.Config{
 		Remote: remote,
 	}
-	return cfg.WithDefaults()
+	cfg, err := cfg.WithDefaults()
+	if err != nil {
+		return cfg, errors.Trace(err)
+	}
+	return cfg, nil
 }
 
 // TODO(ericsnow) Switch to a DI testing approach and eliminiate this var.

--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -185,7 +185,6 @@ func isSupportedLxdVersion(version string) bool {
 // newRawClient connects to the LXD host that is defined in Config.
 func newRawClient(remote Remote) (*lxd.Client, error) {
 	host := remote.Host
-	logger.Debugf("connecting to LXD remote %q: %q", remote.ID(), host)
 
 	if remote.ID() == remoteIDForLocal && host == "" {
 		host = "unix://" + lxdshared.VarPath("unix.socket")
@@ -196,6 +195,7 @@ func newRawClient(remote Remote) (*lxd.Client, error) {
 			host = net.JoinHostPort(host, lxdshared.DefaultPort)
 		}
 	}
+	logger.Debugf("connecting to LXD remote %q: %q", remote.ID(), host)
 
 	clientCert := ""
 	if remote.Cert != nil && remote.Cert.CertPEM != nil {

--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -16,12 +16,12 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/lxc/lxd"
 	lxdshared "github.com/lxc/lxd/shared"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/network"
-	"github.com/juju/loggo"
 )
 
 var logger = loggo.GetLogger("juju.tools.lxdclient")

--- a/tools/lxdclient/client_profile.go
+++ b/tools/lxdclient/client_profile.go
@@ -13,7 +13,8 @@ import (
 type rawProfileClient interface {
 	ProfileCreate(name string) error
 	ListProfiles() ([]string, error)
-	SetProfileConfigItem(name, key, value string) error
+	SetProfileConfigItem(profile, key, value string) error
+	GetProfileConfig(profile string) (map[string]string, error)
 	ProfileDelete(profile string) error
 	ProfileDeviceAdd(profile, devname, devtype string, props []string) (*lxd.Response, error)
 }
@@ -69,4 +70,22 @@ func (p profileClient) HasProfile(name string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// SetProfileConfigItem updates the given profile config key to the given value.
+func (p profileClient) SetProfileConfigItem(profile, key, value string) error {
+	if err := p.raw.SetProfileConfigItem(profile, key, value); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// GetProfileConfig returns a map with all keys and values for the given
+// profile.
+func (p profileClient) GetProfileConfig(profile string) (map[string]string, error) {
+	config, err := p.raw.GetProfileConfig(profile)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return config, nil
 }

--- a/tools/lxdclient/config.go
+++ b/tools/lxdclient/config.go
@@ -62,6 +62,8 @@ func (cfg Config) UsingTCPRemote() (Config, error) {
 		return cfg, errors.Trace(err)
 	}
 
+	// If the default profile's bridge was never used before, the next call with
+	// also activate it and get its address.
 	remote, err := cfg.Remote.UsingTCP(client.defaultProfileBridgeName)
 	if err != nil {
 		return cfg, errors.Trace(err)

--- a/tools/lxdclient/config.go
+++ b/tools/lxdclient/config.go
@@ -58,11 +58,6 @@ func (cfg Config) UsingTCPRemote() (Config, error) {
 		return cfg, errors.Trace(err)
 	}
 
-	// UsingTCP will try to figure out a usable IPv4 address for the default
-	// profile's bridge device name, otherwise set it up. If this lxd has never
-	// had anything done to it, it hasn't been socket activated yet, and the
-	// bridge won't exist. So, we rely on this poke to get the bridge started.
-
 	if _, err := client.ServerStatus(); err != nil {
 		return cfg, errors.Trace(err)
 	}

--- a/tools/lxdclient/config.go
+++ b/tools/lxdclient/config.go
@@ -58,16 +58,16 @@ func (cfg Config) UsingTCPRemote() (Config, error) {
 		return cfg, errors.Trace(err)
 	}
 
-	/* UsingTCP will try to figure out the network name of the lxdbr0,
-	 * which means that lxdbr0 needs to be up. If this lxd has never had
-	 * anything done to it, it hasn't been socket activated yet, and lxdbr0
-	 * won't exist. So, we rely on this poke to get lxdbr0 started.
-	 */
+	// UsingTCP will try to figure out a usable IPv4 address for the default
+	// profile's bridge device name, otherwise set it up. If this lxd has never
+	// had anything done to it, it hasn't been socket activated yet, and the
+	// bridge won't exist. So, we rely on this poke to get the bridge started.
+
 	if _, err := client.ServerStatus(); err != nil {
 		return cfg, errors.Trace(err)
 	}
 
-	remote, err := cfg.Remote.UsingTCP()
+	remote, err := cfg.Remote.UsingTCP(client.defaultProfileBridgeName)
 	if err != nil {
 		return cfg, errors.Trace(err)
 	}

--- a/tools/lxdclient/config.go
+++ b/tools/lxdclient/config.go
@@ -63,8 +63,7 @@ func (cfg Config) UsingTCPRemote() (Config, error) {
 	 * anything done to it, it hasn't been socket activated yet, and lxdbr0
 	 * won't exist. So, we rely on this poke to get lxdbr0 started.
 	 */
-	_, err = client.ServerStatus()
-	if err != nil {
+	if _, err := client.ServerStatus(); err != nil {
 		return cfg, errors.Trace(err)
 	}
 
@@ -74,7 +73,7 @@ func (cfg Config) UsingTCPRemote() (Config, error) {
 	}
 
 	// Update the server config and authorized certs.
-	serverCert, err := prepareRemote(client, *remote.Cert)
+	serverCert, err := prepareRemote(client, remote.Cert)
 	if err != nil {
 		return cfg, errors.Trace(err)
 	}
@@ -88,7 +87,7 @@ func (cfg Config) UsingTCPRemote() (Config, error) {
 	return cfg, nil
 }
 
-func prepareRemote(client *Client, newCert Cert) (string, error) {
+func prepareRemote(client *Client, newCert *Cert) (string, error) {
 	// Make sure the LXD service is configured to listen to local https
 	// requests, rather than only via the Unix socket.
 	// TODO: jam 2016-02-25 This tells LXD to listen on all addresses,
@@ -99,8 +98,12 @@ func prepareRemote(client *Client, newCert Cert) (string, error) {
 		return "", errors.Trace(err)
 	}
 
+	if newCert == nil {
+		return "", nil
+	}
+
 	// Make sure the LXD service will allow our certificate to connect
-	if err := client.AddCert(newCert); err != nil {
+	if err := client.AddCert(*newCert); err != nil {
 		return "", errors.Trace(err)
 	}
 

--- a/tools/lxdclient/remote.go
+++ b/tools/lxdclient/remote.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// remoteLocalName is a specific remote name in the default LXD config.
-	// See https://github.com/lxc/lxd/blob/master/config.go:defaultRemote.
+	// See https://github.com/lxc/lxd/blob/master/config.go:DefaultRemotes.
 	remoteLocalName  = "local"
 	remoteIDForLocal = remoteLocalName
 )
@@ -127,8 +127,6 @@ func (r Remote) withLocalDefaults() Remote {
 		r.Protocol = LXDProtocol
 	}
 
-	// TODO(ericsnow) Set r.Cert to nil?
-
 	return r
 }
 
@@ -173,12 +171,11 @@ func (r Remote) validateLocal() error {
 	return nil
 }
 
-// UsingTCP converts the remote into a non-local version. For
-// non-local remotes this is a no-op.
+// UsingTCP converts the remote into a non-local version. For non-local remotes
+// this is a no-op.
 //
-// For a "local" remote (see Local), the remote is changed to a one
-// with the host set to the IP address of the local lxcbr0 bridge
-// interface. The remote is also set up for remote access, setting
+// For a "local" remote (see Local), the remote is changed to a one with the
+// host set to "127.0.0.1". The remote is also set up for remote access, setting
 // the cert if not already set.
 func (r Remote) UsingTCP() (Remote, error) {
 	// Note that r is a value receiver, so it is an implicit copy.
@@ -187,7 +184,14 @@ func (r Remote) UsingTCP() (Remote, error) {
 		return r, nil
 	}
 
+	r.Host = "127.0.0.1"
+
 	// TODO(ericsnow) Change r.Name if "local"? Prepend "juju-"?
 
-	return r.WithDefaults()
+	r, err := r.WithDefaults()
+	if err != nil {
+		return r, errors.Trace(err)
+	}
+
+	return r, nil
 }

--- a/tools/lxdclient/remote.go
+++ b/tools/lxdclient/remote.go
@@ -7,10 +7,7 @@ package lxdclient
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/utils"
 	lxdshared "github.com/lxc/lxd/shared"
-
-	"github.com/juju/juju/network"
 )
 
 const (
@@ -190,21 +187,7 @@ func (r Remote) UsingTCP() (Remote, error) {
 		return r, nil
 	}
 
-	// TODO: jam 2016-02-25 This should be updated for systems that are
-	// 	 space aware, as we may not be just using the default LXC
-	// 	 bridge.
-	addr, err := utils.GetAddressForInterface(network.DefaultLXDBridge)
-	if err != nil {
-		return r, errors.Trace(err)
-	}
-	r.Host = addr
-
-	r, err = r.WithDefaults()
-	if err != nil {
-		return r, errors.Trace(err)
-	}
-
 	// TODO(ericsnow) Change r.Name if "local"? Prepend "juju-"?
 
-	return r, nil
+	return r.WithDefaults()
 }

--- a/tools/lxdclient/remote_test.go
+++ b/tools/lxdclient/remote_test.go
@@ -6,15 +6,12 @@
 package lxdclient_test
 
 import (
-	"fmt"
 	"net"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/tools/lxdclient"
 )
 
@@ -427,12 +424,6 @@ type remoteFunctionalSuite struct {
 }
 
 func (s *remoteFunctionalSuite) TestUsingTCP(c *gc.C) {
-	if _, err := net.InterfaceByName(network.DefaultLXDBridge); err != nil {
-		c.Skip("network bridge interface not found")
-	}
-	if _, err := utils.GetAddressForInterface(network.DefaultLXDBridge); err != nil {
-		c.Skip(fmt.Sprintf("no IPv4 address available for %s", network.DefaultLXDBridge))
-	}
 	lxdclient.PatchGenerateCertificate(&s.CleanupSuite, testingCert, testingKey)
 
 	remote := lxdclient.Remote{

--- a/tools/lxdclient/remote_test.go
+++ b/tools/lxdclient/remote_test.go
@@ -413,7 +413,7 @@ func (s *remoteSuite) TestUsingTCPNoop(c *gc.C) {
 		Protocol: lxdclient.LXDProtocol,
 		Cert:     s.Cert,
 	}
-	nonlocal, err := remote.UsingTCP()
+	nonlocal, err := remote.UsingTCP("")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(nonlocal, jc.DeepEquals, remote)
@@ -431,7 +431,7 @@ func (s *remoteFunctionalSuite) TestUsingTCP(c *gc.C) {
 		Host: "",
 		Cert: nil,
 	}
-	nonlocal, err := remote.UsingTCP()
+	nonlocal, err := remote.UsingTCP("lo")
 	c.Assert(err, jc.ErrorIsNil)
 
 	checkValidRemote(c, &nonlocal)


### PR DESCRIPTION
Changed tools/lxdclient code not to assume the default LXD bridge name
is always "lxdbr0". Instead, the "default" profile's bridge device name
is determined and used in Client.

See http://pad.lv/1575676 for details.

QA steps to verify the fix:

1. LXD provider (where it appears):
```
   $ sudo dpkg-reconfigure -p medium lxd
   # rename the lxdbr0 to something else, keep the rest the same.
   $ juju bootstrap --upload-tools lxd localhost
   # expect success, before this fix it failed to complete due to lxdbr0
   # not existing. 
   $ juju deploy ubuntu # also OK
```

2. Manual provider (for completeness):
```
   $ lxc launch ubuntu:xenial man-x1
   $ lxc info man-x1 | grep eth0    # find eth0's address, e.g. 10.0.1.2
   $ lxc file push ~/.ssh/<ssh-key.pub> man-x1/home/ubuntu/.ssh/authorized_keys
   # to allow the below to work
   $ ssh ubuntu@10.0.1.2            # should work now
   $ juju bootstrap --upload-tools man manual/10.0.1.2
```