### PR TITLE
Move PORTS after ADDRESS in tabular status.

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -69,8 +69,8 @@ func FormatTabular(value interface{}) ([]byte, error) {
 			u.AgentStatusInfo.Current,
 			u.AgentStatusInfo.Version,
 			u.Machine,
-			strings.Join(u.OpenedPorts, ","),
 			u.PublicAddress,
+			strings.Join(u.OpenedPorts, ","),
 			message,
 		)
 	}
@@ -85,9 +85,9 @@ func FormatTabular(value interface{}) ([]byte, error) {
 	}
 	var header []string
 	if newStatus {
-		header = []string{"ID", "WORKLOAD-STATE", "AGENT-STATE", "VERSION", "MACHINE", "PORTS", "PUBLIC-ADDRESS", "MESSAGE"}
+		header = []string{"ID", "WORKLOAD-STATE", "AGENT-STATE", "VERSION", "MACHINE", "PUBLIC-ADDRESS", "PORTS", "MESSAGE"}
 	} else {
-		header = []string{"ID", "STATE", "VERSION", "MACHINE", "PORTS", "PUBLIC-ADDRESS"}
+		header = []string{"ID", "STATE", "VERSION", "MACHINE", "PUBLIC-ADDRESS", "PORTS"}
 	}
 
 	p("\n[Units]")

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3213,11 +3213,11 @@ mysql      maintenance true    cs:quantal/mysql-1
 wordpress  active      true    cs:quantal/wordpress-3
 
 [Units]
-ID          WORKLOAD-STATE AGENT-STATE VERSION MACHINE PORTS PUBLIC-ADDRESS MESSAGE
-mysql/0     maintenance    idle        1.2.3   2             dummyenv-2.dns installing all the things
-  logging/1 error          idle                              dummyenv-2.dns somehow lost in all those logs
-wordpress/0 active         idle        1.2.3   1             dummyenv-1.dns
-  logging/0 active         idle                              dummyenv-1.dns
+ID          WORKLOAD-STATE AGENT-STATE VERSION MACHINE PUBLIC-ADDRESS PORTS MESSAGE
+mysql/0     maintenance    idle        1.2.3   2       dummyenv-2.dns       installing all the things
+  logging/1 error          idle                        dummyenv-2.dns       somehow lost in all those logs
+wordpress/0 active         idle        1.2.3   1       dummyenv-1.dns       
+  logging/0 active         idle                        dummyenv-1.dns       
 
 [Machines]
 ID         STATE   VERSION DNS            INS-ID     SERIES  HARDWARE
@@ -3282,7 +3282,7 @@ NAME       STATUS EXPOSED CHARM
 foo               false         
 
 [Units] 
-ID      WORKLOAD-STATE AGENT-STATE VERSION MACHINE PORTS PUBLIC-ADDRESS MESSAGE                           
+ID      WORKLOAD-STATE AGENT-STATE VERSION MACHINE PUBLIC-ADDRESS PORTS MESSAGE                           
 foo/0   maintenance    executing                                        (config-changed) doing some work  
 foo/1   maintenance    executing                                        (backup database) doing some work 
 


### PR DESCRIPTION
The idea is that standard syntax is 'ip:port' so it makes more sense for PORTS
to come after ADDRESS instead of before.

This is the same change that is has landed in Master, but I'm not sure if we want to do it or not. We haven't done several of the other changes to status (2 whitespaces, extra fields, etc).