### PR TITLE
state: fix unit/machine storage cleanup

### DIFF
--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -308,14 +308,26 @@ func (st *State) cleanupDyingUnit(name string) error {
 	}
 	// Mark storage attachments as dying, so that they are detached
 	// and removed from state, allowing the unit to terminate.
-	storageAttachments, err := st.UnitStorageAttachments(unit.UnitTag())
+	return st.cleanupUnitStorageAttachments(unit.UnitTag(), false)
+}
+
+func (st *State) cleanupUnitStorageAttachments(unitTag names.UnitTag, remove bool) error {
+	storageAttachments, err := st.UnitStorageAttachments(unitTag)
 	if err != nil {
 		return err
 	}
 	for _, storageAttachment := range storageAttachments {
-		err := st.DestroyStorageAttachment(
-			storageAttachment.StorageInstance(), unit.UnitTag(),
-		)
+		storageTag := storageAttachment.StorageInstance()
+		err := st.DestroyStorageAttachment(storageTag, unitTag)
+		if errors.IsNotFound(err) {
+			continue
+		} else if err != nil {
+			return err
+		}
+		if !remove {
+			continue
+		}
+		err = st.RemoveStorageAttachment(storageTag, unitTag)
 		if errors.IsNotFound(err) {
 			continue
 		} else if err != nil {
@@ -373,9 +385,6 @@ func (st *State) cleanupForceDestroyedMachine(machineId string) error {
 	} else if err != nil {
 		return err
 	}
-	if err := cleanupDyingMachineResources(machine); err != nil {
-		return err
-	}
 	// In an ideal world, we'd call machine.Destroy() here, and thus prevent
 	// new dependencies being added while we clean up the ones we know about.
 	// But machine destruction is unsophisticated, and doesn't allow for
@@ -388,6 +397,9 @@ func (st *State) cleanupForceDestroyedMachine(machineId string) error {
 		if err := st.obliterateUnit(unitName); err != nil {
 			return err
 		}
+	}
+	if err := cleanupDyingMachineResources(machine); err != nil {
+		return err
 	}
 	// We need to refresh the machine at this point, because the local copy
 	// of the document will not reflect changes caused by the unit cleanups
@@ -492,6 +504,10 @@ func (st *State) obliterateUnit(unitName string) error {
 		return nil
 	} else if err != nil {
 		return err
+	}
+	// Destroy and remove all storage attachments for the unit.
+	if err := st.cleanupUnitStorageAttachments(unit.UnitTag(), true); err != nil {
+		return errors.Annotatef(err, "cannot destroy storage for unit %q", unitName)
 	}
 	for _, subName := range unit.SubordinateNames() {
 		if err := st.obliterateUnit(subName); err != nil {

--- a/state/volume.go
+++ b/state/volume.go
@@ -459,16 +459,16 @@ func isVolumeInherentlyMachineBound(st *State, tag names.VolumeTag) (bool, error
 		if err != nil {
 			return false, errors.Trace(err)
 		}
+		if provider.Scope() == storage.ScopeMachine {
+			// Any storage created by a machine must be destroyed
+			// along with the machine.
+			return true, nil
+		}
 		if provider.Dynamic() {
-			// Even machine-scoped storage could be provisioned
-			// while the machine is Dying, and we don't know at
-			// this layer whether or not it will be Persistent.
-			//
-			// TODO(axw) extend storage provider interface to
-			// determine up-front whether or not a volume will
-			// be persistent. This will have to depend on the
-			// machine type, since, e.g., loop devices will
-			// outlive LXC containers.
+			// We don't know ahead of time whether the storage
+			// will be Persistent, so we assume it will be, and
+			// rely on the environment-level storage provisioner
+			// to clean up.
 			return false, nil
 		}
 		// Volume is static, so even if it is provisioned, it will

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -739,13 +739,12 @@ func (s *VolumeStateSuite) TestRemoveMachineRemovesVolumes(c *gc.C) {
 	c.Assert(machine.Destroy(), jc.ErrorIsNil)
 
 	// Cannot advance to Dead while there are persistent, or
-	// unprovisioned dynamic volumes (regardless of scope).
+	// unprovisioned environ-scoped dynamic volumes.
 	err = machine.EnsureDead()
 	c.Assert(err, jc.Satisfies, state.IsHasAttachmentsError)
-	c.Assert(err, gc.ErrorMatches, "machine 0 has attachments \\[volume-0 volume-0-1 volume-0-2\\]")
+	c.Assert(err, gc.ErrorMatches, "machine 0 has attachments \\[volume-0 volume-0-1\\]")
 	s.obliterateVolumeAttachment(c, machine.MachineTag(), names.NewVolumeTag("0"))
 	s.obliterateVolumeAttachment(c, machine.MachineTag(), names.NewVolumeTag("0/1"))
-	s.obliterateVolumeAttachment(c, machine.MachineTag(), names.NewVolumeTag("0/2"))
 	c.Assert(machine.EnsureDead(), jc.ErrorIsNil)
 	c.Assert(machine.Remove(), jc.ErrorIsNil)
 
@@ -758,9 +757,7 @@ func (s *VolumeStateSuite) TestRemoveMachineRemovesVolumes(c *gc.C) {
 	for _, v := range allVolumes {
 		remaining.Add(v.Tag().String())
 	}
-	c.Assert(remaining.SortedValues(), jc.DeepEquals, []string{
-		"volume-0", "volume-0-1", "volume-0-2",
-	})
+	c.Assert(remaining.SortedValues(), jc.DeepEquals, []string{"volume-0", "volume-0-1"})
 
 	attachments, err := s.State.MachineVolumeAttachments(machine.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
There was a problem with the way we were cleaning up
storage when force-destroying machines:
 - we were destroying machine storage (volumes) before
   unit storage; it should be the other way around
 - due to holdover logic, we were not allowing machine-scoped
   storage to be short-circuit removed if it wasn't yet
   provisioned

The latter issue is due to an old issue which no longer
affects us: at one point, we leaked loop devices from
LXC containers, and so we marked them as "persistent".
Thus, we could not safely destroy a machine if it had
unprovisioned machine-scoped storage, or we would risk
leaking loop devices. This is no longer an issue, and
so we now assume machine-scoped storage will be destroyed
along with the machine. Thus, a machine can be removed
even if it has unprovisioned machine-scoped storage
associated with it.

Fixes https://bugs.launchpad.net/juju-core/+bug/1604931

(Review request: http://reviews.vapour.ws/r/5309/)