### PR TITLE
Migrate volume and volume attachments.

### DIFF
--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -417,7 +417,7 @@ type Volume interface {
 // VolumeAttachment represents a volume attached to a machine.
 type VolumeAttachment interface {
 	Machine() names.MachineTag
-
+	Provisioned() bool
 	ReadOnly() bool
 	DeviceName() string
 	DeviceLink() string

--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -24,6 +24,13 @@ type HasConstraints interface {
 	SetConstraints(ConstraintsArgs)
 }
 
+// HasStatus defines the common methods for setting and getting  status
+// entries for the various entities.
+type HasStatus interface {
+	Status() Status
+	SetStatus(StatusArgs)
+}
+
 // HasStatusHistory defines the common methods for setting and
 // getting historical status entries for the various entities.
 type HasStatusHistory interface {
@@ -119,6 +126,7 @@ type AgentTools interface {
 type Machine interface {
 	HasAnnotations
 	HasConstraints
+	HasStatus
 	HasStatusHistory
 
 	Id() string
@@ -148,9 +156,6 @@ type Machine interface {
 
 	Containers() []Machine
 	AddContainer(MachineArgs) Machine
-
-	Status() Status
-	SetStatus(StatusArgs)
 
 	// TODO:
 	// Storage
@@ -230,6 +235,7 @@ type Status interface {
 type Application interface {
 	HasAnnotations
 	HasConstraints
+	HasStatus
 	HasStatusHistory
 
 	Tag() names.ApplicationTag
@@ -250,9 +256,6 @@ type Application interface {
 	LeadershipSettings() map[string]interface{}
 
 	MetricsCredentials() []byte
-
-	Status() Status
-	SetStatus(StatusArgs)
 
 	Units() []Unit
 	AddUnit(UnitArgs) Unit
@@ -383,4 +386,39 @@ type IPAddress interface {
 type SSHHostKey interface {
 	MachineID() string
 	Keys() []string
+}
+
+// Volume represents a volume (disk, logical volume, etc.) in the model.
+type Volume interface {
+	HasStatus
+	HasStatusHistory
+
+	Tag() names.VolumeTag
+	Name() string
+	// Link to Storage...
+
+	Binding() names.Tag
+
+	Provisioned() bool
+
+	Size() uint64
+	Pool() string
+
+	// These three attributes are only valid if the volume is provisioned.
+
+	HardwareID() string
+	VolumeID() string
+	Persistent() bool
+
+	Attachments() []VolumeAttachment
+}
+
+// VolumeAttachment represents a volume attached to a machine.
+type VolumeAttachment interface {
+	MachineID() string
+
+	ReadOnly() bool
+	DeviceName() string
+	DeviceLink() string
+	BusAddress() string
 }

--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -394,10 +394,9 @@ type Volume interface {
 	HasStatusHistory
 
 	Tag() names.VolumeTag
-	Name() string
 	// Link to Storage...
 
-	Binding() names.Tag
+	Binding() (names.Tag, error)
 
 	Provisioned() bool
 
@@ -411,11 +410,12 @@ type Volume interface {
 	Persistent() bool
 
 	Attachments() []VolumeAttachment
+	AddAttachment(VolumeAttachmentArgs) VolumeAttachment
 }
 
 // VolumeAttachment represents a volume attached to a machine.
 type VolumeAttachment interface {
-	MachineID() string
+	Machine() names.MachineTag
 
 	ReadOnly() bool
 	DeviceName() string

--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -88,6 +88,9 @@ type Model interface {
 	Sequences() map[string]int
 	SetSequence(name string, value int)
 
+	Volumes() []Volume
+	AddVolume(VolumeArgs) Volume
+
 	Validate() error
 }
 

--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -24,7 +24,7 @@ type HasConstraints interface {
 	SetConstraints(ConstraintsArgs)
 }
 
-// HasStatus defines the common methods for setting and getting  status
+// HasStatus defines the common methods for setting and getting status
 // entries for the various entities.
 type HasStatus interface {
 	Status() Status

--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -397,7 +397,7 @@ type Volume interface {
 	HasStatusHistory
 
 	Tag() names.VolumeTag
-	// Link to Storage...
+	// TODO: Link to Storage when we add storage
 
 	Binding() (names.Tag, error)
 
@@ -405,8 +405,6 @@ type Volume interface {
 
 	Size() uint64
 	Pool() string
-
-	// These three attributes are only valid if the volume is provisioned.
 
 	HardwareID() string
 	VolumeID() string

--- a/core/description/volume.go
+++ b/core/description/volume.go
@@ -1,0 +1,383 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+	"gopkg.in/juju/names.v2"
+)
+
+type volumes struct {
+	Version  int       `yaml:"version"`
+	Volumes_ []*volume `yaml:"volumes"`
+}
+
+type volume struct {
+	ID_          string `yaml:"id"`
+	Binding_     string `yaml:"binding"`
+	Provisioned_ bool   `yaml:"provisioned"`
+	Size_        uint64 `yaml:"size"`
+	Pool_        string `yaml:"pool,omitempty"`
+	HardwareID_  string `yaml:"hardware-id,omitempty"`
+	VolumeID_    string `yaml:"volume-id,omitempty"`
+	Persistent_  bool   `yaml:"persistent"`
+
+	Status_        *status `yaml:"status"`
+	StatusHistory_ `yaml:"status-history"`
+
+	Attachments_ volumeAttachments `yaml:"attachments"`
+}
+
+type volumeAttachments struct {
+	Version      int                 `yaml:"version"`
+	Attachments_ []*volumeAttachment `yaml:"attachments"`
+}
+
+type volumeAttachment struct {
+	MachineID_  string `yaml:"machine-id"`
+	ReadOnly_   bool   `yaml:"read-only"`
+	DeviceName_ string `yaml:"device-name"`
+	DeviceLink_ string `yaml:"device-link"`
+	BusAddress_ string `yaml:"bus-address"`
+}
+
+// VolumeArgs is an argument struct used to add a volume to the Model.
+type VolumeArgs struct {
+	Tag         names.VolumeTag
+	Binding     names.Tag
+	Provisioned bool
+	Size        uint64
+	Pool        string
+	HardwareID  string
+	VolumeID    string
+	Persistent  bool
+}
+
+func newVolume(args VolumeArgs) *volume {
+	v := &volume{
+		ID_:            args.Tag.Id(),
+		Provisioned_:   args.Provisioned,
+		Size_:          args.Size,
+		Pool_:          args.Pool,
+		HardwareID_:    args.HardwareID,
+		VolumeID_:      args.VolumeID,
+		Persistent_:    args.Persistent,
+		StatusHistory_: newStatusHistory(),
+	}
+	if args.Binding != nil {
+		v.Binding_ = args.Binding.String()
+	}
+	v.setAttachments(nil)
+	return v
+}
+
+// Tag implements Volume.
+func (v *volume) Tag() names.VolumeTag {
+	return names.NewVolumeTag(v.ID_)
+}
+
+// Binding implements Volume.
+func (v *volume) Binding() (names.Tag, error) {
+	if v.Binding_ == "" {
+		return nil, nil
+	}
+	tag, err := names.ParseTag(v.Binding_)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return tag, nil
+}
+
+// Provisioned implements Volume.
+func (v *volume) Provisioned() bool {
+	return v.Provisioned_
+}
+
+// Size implements Volume.
+func (v *volume) Size() uint64 {
+	return v.Size_
+}
+
+// Pool implements Volume.
+func (v *volume) Pool() string {
+	return v.Pool_
+}
+
+// HardwareID implements Volume.
+func (v *volume) HardwareID() string {
+	return v.HardwareID_
+}
+
+// VolumeID implements Volume.
+func (v *volume) VolumeID() string {
+	return v.VolumeID_
+}
+
+// Persistent implements Volume.
+func (v *volume) Persistent() bool {
+	return v.Persistent_
+}
+
+// Status implements Volume.
+func (v *volume) Status() Status {
+	// To avoid typed nils check nil here.
+	if v.Status_ == nil {
+		return nil
+	}
+	return v.Status_
+}
+
+// SetStatus implements Volume.
+func (v *volume) SetStatus(args StatusArgs) {
+	v.Status_ = newStatus(args)
+}
+
+func (v *volume) setAttachments(attachments []*volumeAttachment) {
+	v.Attachments_ = volumeAttachments{
+		Version:      1,
+		Attachments_: attachments,
+	}
+}
+
+// Attachments implements Volume.
+func (v *volume) Attachments() []VolumeAttachment {
+	var result []VolumeAttachment
+	for _, attachment := range v.Attachments_.Attachments_ {
+		result = append(result, attachment)
+	}
+	return result
+}
+
+// AddAttachment implements Volume.
+func (v *volume) AddAttachment(args VolumeAttachmentArgs) VolumeAttachment {
+	a := newVolumeAttachment(args)
+	v.Attachments_.Attachments_ = append(v.Attachments_.Attachments_, a)
+	return a
+}
+
+// Validate implements Volume.
+func (v *volume) Validate() error {
+	if v.ID_ == "" {
+		return errors.NotValidf("volume missing id")
+	}
+	if v.Size_ == 0 {
+		return errors.NotValidf("volume %q missing size", v.ID_)
+	}
+	if v.Status_ == nil {
+		return errors.NotValidf("volume %q missing status", v.ID_)
+	}
+	return nil
+}
+
+func importVolumes(source map[string]interface{}) ([]*volume, error) {
+	checker := versionedChecker("volumes")
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "volumes version schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+
+	version := int(valid["version"].(int64))
+	importFunc, ok := volumeDeserializationFuncs[version]
+	if !ok {
+		return nil, errors.NotValidf("version %d", version)
+	}
+	sourceList := valid["volumes"].([]interface{})
+	return importVolumeList(sourceList, importFunc)
+}
+
+func importVolumeList(sourceList []interface{}, importFunc volumeDeserializationFunc) ([]*volume, error) {
+	result := make([]*volume, 0, len(sourceList))
+	for i, value := range sourceList {
+		source, ok := value.(map[string]interface{})
+		if !ok {
+			return nil, errors.Errorf("unexpected value for volume %d, %T", i, value)
+		}
+		volume, err := importFunc(source)
+		if err != nil {
+			return nil, errors.Annotatef(err, "volume %d", i)
+		}
+		result = append(result, volume)
+	}
+	return result, nil
+}
+
+type volumeDeserializationFunc func(map[string]interface{}) (*volume, error)
+
+var volumeDeserializationFuncs = map[int]volumeDeserializationFunc{
+	1: importVolumeV1,
+}
+
+func importVolumeV1(source map[string]interface{}) (*volume, error) {
+	fields := schema.Fields{
+		"id":          schema.String(),
+		"binding":     schema.String(),
+		"provisioned": schema.Bool(),
+		"size":        schema.ForceUint(),
+		"pool":        schema.String(),
+		"hardware-id": schema.String(),
+		"volume-id":   schema.String(),
+		"persistent":  schema.Bool(),
+		"status":      schema.StringMap(schema.Any()),
+		"attachments": schema.StringMap(schema.Any()),
+	}
+
+	defaults := schema.Defaults{
+		"pool":        "",
+		"hardware-id": "",
+		"volume-id":   "",
+		"attachments": schema.Omit,
+	}
+	addStatusHistorySchema(fields)
+	checker := schema.FieldMap(fields, defaults)
+
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "volume v1 schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+	// From here we know that the map returned from the schema coercion
+	// contains fields of the right type.
+	result := &volume{
+		ID_:            valid["id"].(string),
+		Binding_:       valid["binding"].(string),
+		Provisioned_:   valid["provisioned"].(bool),
+		Size_:          valid["size"].(uint64),
+		Pool_:          valid["pool"].(string),
+		HardwareID_:    valid["hardware-id"].(string),
+		VolumeID_:      valid["volume-id"].(string),
+		Persistent_:    valid["persistent"].(bool),
+		StatusHistory_: newStatusHistory(),
+	}
+	if err := result.importStatusHistory(valid); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	status, err := importStatus(valid["status"].(map[string]interface{}))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	result.Status_ = status
+
+	attachments, err := importVolumeAttachments(valid["attachments"].(map[string]interface{}))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	result.setAttachments(attachments)
+
+	return result, nil
+}
+
+// VolumeAttachmentArgs is an argument struct used to add information about the
+// cloud instance to a Volume.
+type VolumeAttachmentArgs struct {
+	Machine    names.MachineTag
+	ReadOnly   bool
+	DeviceName string
+	DeviceLink string
+	BusAddress string
+}
+
+func newVolumeAttachment(args VolumeAttachmentArgs) *volumeAttachment {
+	return &volumeAttachment{
+		MachineID_:  args.Machine.Id(),
+		ReadOnly_:   args.ReadOnly,
+		DeviceName_: args.DeviceName,
+		DeviceLink_: args.DeviceLink,
+		BusAddress_: args.BusAddress,
+	}
+}
+
+// Machine implements VolumeAttachment
+func (a *volumeAttachment) Machine() names.MachineTag {
+	return names.NewMachineTag(a.MachineID_)
+}
+
+// ReadOnly implements VolumeAttachment
+func (a *volumeAttachment) ReadOnly() bool {
+	return a.ReadOnly_
+}
+
+// DeviceName implements VolumeAttachment
+func (a *volumeAttachment) DeviceName() string {
+	return a.DeviceName_
+}
+
+// DeviceLink implements VolumeAttachment
+func (a *volumeAttachment) DeviceLink() string {
+	return a.DeviceLink_
+}
+
+// BusAddress implements VolumeAttachment
+func (a *volumeAttachment) BusAddress() string {
+	return a.BusAddress_
+}
+
+func importVolumeAttachments(source map[string]interface{}) ([]*volumeAttachment, error) {
+	checker := versionedChecker("attachments")
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "volume attachments version schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+
+	version := int(valid["version"].(int64))
+	importFunc, ok := volumeAttachmentDeserializationFuncs[version]
+	if !ok {
+		return nil, errors.NotValidf("version %d", version)
+	}
+	sourceList := valid["attachments"].([]interface{})
+	return importVolumeAttachmentList(sourceList, importFunc)
+}
+
+func importVolumeAttachmentList(sourceList []interface{}, importFunc volumeAttachmentDeserializationFunc) ([]*volumeAttachment, error) {
+	result := make([]*volumeAttachment, 0, len(sourceList))
+	for i, value := range sourceList {
+		source, ok := value.(map[string]interface{})
+		if !ok {
+			return nil, errors.Errorf("unexpected value for volumeAttachment %d, %T", i, value)
+		}
+		volumeAttachment, err := importFunc(source)
+		if err != nil {
+			return nil, errors.Annotatef(err, "volumeAttachment %d", i)
+		}
+		result = append(result, volumeAttachment)
+	}
+	return result, nil
+}
+
+type volumeAttachmentDeserializationFunc func(map[string]interface{}) (*volumeAttachment, error)
+
+var volumeAttachmentDeserializationFuncs = map[int]volumeAttachmentDeserializationFunc{
+	1: importVolumeAttachmentV1,
+}
+
+func importVolumeAttachmentV1(source map[string]interface{}) (*volumeAttachment, error) {
+	fields := schema.Fields{
+		"machine-id":  schema.String(),
+		"read-only":   schema.Bool(),
+		"device-name": schema.String(),
+		"device-link": schema.String(),
+		"bus-address": schema.String(),
+	}
+	checker := schema.FieldMap(fields, nil) // no defaults
+
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "volumeAttachment v1 schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+	// From here we know that the map returned from the schema coercion
+	// contains fields of the right type.
+
+	result := &volumeAttachment{
+		MachineID_:  valid["machine-id"].(string),
+		ReadOnly_:   valid["read-only"].(bool),
+		DeviceName_: valid["device-name"].(string),
+		DeviceLink_: valid["device-link"].(string),
+		BusAddress_: valid["bus-address"].(string),
+	}
+	return result, nil
+}

--- a/core/description/volume.go
+++ b/core/description/volume.go
@@ -36,11 +36,12 @@ type volumeAttachments struct {
 }
 
 type volumeAttachment struct {
-	MachineID_  string `yaml:"machine-id"`
-	ReadOnly_   bool   `yaml:"read-only"`
-	DeviceName_ string `yaml:"device-name"`
-	DeviceLink_ string `yaml:"device-link"`
-	BusAddress_ string `yaml:"bus-address"`
+	MachineID_   string `yaml:"machine-id"`
+	Provisioned_ bool   `yaml:"provisioned"`
+	ReadOnly_    bool   `yaml:"read-only"`
+	DeviceName_  string `yaml:"device-name"`
+	DeviceLink_  string `yaml:"device-link"`
+	BusAddress_  string `yaml:"bus-address"`
 }
 
 // VolumeArgs is an argument struct used to add a volume to the Model.
@@ -273,26 +274,33 @@ func importVolumeV1(source map[string]interface{}) (*volume, error) {
 // VolumeAttachmentArgs is an argument struct used to add information about the
 // cloud instance to a Volume.
 type VolumeAttachmentArgs struct {
-	Machine    names.MachineTag
-	ReadOnly   bool
-	DeviceName string
-	DeviceLink string
-	BusAddress string
+	Machine     names.MachineTag
+	Provisioned bool
+	ReadOnly    bool
+	DeviceName  string
+	DeviceLink  string
+	BusAddress  string
 }
 
 func newVolumeAttachment(args VolumeAttachmentArgs) *volumeAttachment {
 	return &volumeAttachment{
-		MachineID_:  args.Machine.Id(),
-		ReadOnly_:   args.ReadOnly,
-		DeviceName_: args.DeviceName,
-		DeviceLink_: args.DeviceLink,
-		BusAddress_: args.BusAddress,
+		MachineID_:   args.Machine.Id(),
+		Provisioned_: args.Provisioned,
+		ReadOnly_:    args.ReadOnly,
+		DeviceName_:  args.DeviceName,
+		DeviceLink_:  args.DeviceLink,
+		BusAddress_:  args.BusAddress,
 	}
 }
 
 // Machine implements VolumeAttachment
 func (a *volumeAttachment) Machine() names.MachineTag {
 	return names.NewMachineTag(a.MachineID_)
+}
+
+// Provisioned implements VolumeAttachment
+func (a *volumeAttachment) Provisioned() bool {
+	return a.Provisioned_
 }
 
 // ReadOnly implements VolumeAttachment
@@ -357,6 +365,7 @@ var volumeAttachmentDeserializationFuncs = map[int]volumeAttachmentDeserializati
 func importVolumeAttachmentV1(source map[string]interface{}) (*volumeAttachment, error) {
 	fields := schema.Fields{
 		"machine-id":  schema.String(),
+		"provisioned": schema.Bool(),
 		"read-only":   schema.Bool(),
 		"device-name": schema.String(),
 		"device-link": schema.String(),
@@ -373,11 +382,12 @@ func importVolumeAttachmentV1(source map[string]interface{}) (*volumeAttachment,
 	// contains fields of the right type.
 
 	result := &volumeAttachment{
-		MachineID_:  valid["machine-id"].(string),
-		ReadOnly_:   valid["read-only"].(bool),
-		DeviceName_: valid["device-name"].(string),
-		DeviceLink_: valid["device-link"].(string),
-		BusAddress_: valid["bus-address"].(string),
+		MachineID_:   valid["machine-id"].(string),
+		Provisioned_: valid["provisioned"].(bool),
+		ReadOnly_:    valid["read-only"].(bool),
+		DeviceName_:  valid["device-name"].(string),
+		DeviceLink_:  valid["device-link"].(string),
+		BusAddress_:  valid["bus-address"].(string),
 	}
 	return result, nil
 }

--- a/core/description/volume_test.go
+++ b/core/description/volume_test.go
@@ -1,0 +1,256 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/yaml.v2"
+)
+
+type VolumeSerializationSuite struct {
+	SliceSerializationSuite
+	StatusHistoryMixinSuite
+}
+
+var _ = gc.Suite(&VolumeSerializationSuite{})
+
+func (s *VolumeSerializationSuite) SetUpTest(c *gc.C) {
+	s.SliceSerializationSuite.SetUpTest(c)
+	s.importName = "volumes"
+	s.sliceName = "volumes"
+	s.importFunc = func(m map[string]interface{}) (interface{}, error) {
+		return importVolumes(m)
+	}
+	s.testFields = func(m map[string]interface{}) {
+		m["volumes"] = []interface{}{}
+	}
+	s.StatusHistoryMixinSuite.creator = func() HasStatusHistory {
+		return testVolume()
+	}
+	s.StatusHistoryMixinSuite.serializer = func(c *gc.C, initial interface{}) HasStatusHistory {
+		return s.exportImport(c, initial.(*volume))
+	}
+}
+
+func testVolumeMap() map[interface{}]interface{} {
+	return map[interface{}]interface{}{
+		"id":             "1234",
+		"binding":        "machine-42",
+		"provisioned":    true,
+		"size":           int(20 * gig),
+		"pool":           "swimming",
+		"hardware-id":    "a hardware id",
+		"volume-id":      "some volume id",
+		"persistent":     true,
+		"status":         minimalStatusMap(),
+		"status-history": emptyStatusHistoryMap(),
+		"attachments": map[interface{}]interface{}{
+			"version":     1,
+			"attachments": []interface{}{},
+		},
+	}
+}
+
+func testVolume() *volume {
+	v := newVolume(testVolumeArgs())
+	v.SetStatus(minimalStatusArgs())
+	return v
+}
+
+func testVolumeArgs() VolumeArgs {
+	return VolumeArgs{
+		Tag:         names.NewVolumeTag("1234"),
+		Binding:     names.NewMachineTag("42"),
+		Provisioned: true,
+		Size:        20 * gig,
+		Pool:        "swimming",
+		HardwareID:  "a hardware id",
+		VolumeID:    "some volume id",
+		Persistent:  true,
+	}
+}
+
+func (s *VolumeSerializationSuite) TestNewVolume(c *gc.C) {
+	volume := testVolume()
+
+	c.Check(volume.Tag(), gc.Equals, names.NewVolumeTag("1234"))
+	binding, err := volume.Binding()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(binding, gc.Equals, names.NewMachineTag("42"))
+	c.Check(volume.Provisioned(), jc.IsTrue)
+	c.Check(volume.Size(), gc.Equals, 20*gig)
+	c.Check(volume.Pool(), gc.Equals, "swimming")
+	c.Check(volume.HardwareID(), gc.Equals, "a hardware id")
+	c.Check(volume.VolumeID(), gc.Equals, "some volume id")
+	c.Check(volume.Persistent(), jc.IsTrue)
+
+	c.Check(volume.Attachments(), gc.HasLen, 0)
+}
+
+func (s *VolumeSerializationSuite) TestVolumeValid(c *gc.C) {
+	volume := testVolume()
+	c.Assert(volume.Validate(), jc.ErrorIsNil)
+}
+
+func (s *VolumeSerializationSuite) TestVolumeValidMissingID(c *gc.C) {
+	v := newVolume(VolumeArgs{})
+	err := v.Validate()
+	c.Check(err, gc.ErrorMatches, `volume missing id not valid`)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *VolumeSerializationSuite) TestVolumeValidMissingSize(c *gc.C) {
+	v := newVolume(VolumeArgs{
+		Tag: names.NewVolumeTag("123"),
+	})
+	err := v.Validate()
+	c.Check(err, gc.ErrorMatches, `volume "123" missing size not valid`)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *VolumeSerializationSuite) TestVolumeValidMissingStatus(c *gc.C) {
+	v := newVolume(VolumeArgs{
+		Tag:  names.NewVolumeTag("123"),
+		Size: 5,
+	})
+	err := v.Validate()
+	c.Check(err, gc.ErrorMatches, `volume "123" missing status not valid`)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *VolumeSerializationSuite) TestVolumeValidMinimal(c *gc.C) {
+	v := newVolume(VolumeArgs{
+		Tag:  names.NewVolumeTag("123"),
+		Size: 5,
+	})
+	v.SetStatus(minimalStatusArgs())
+	err := v.Validate()
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *VolumeSerializationSuite) TestVolumeMatches(c *gc.C) {
+	bytes, err := yaml.Marshal(testVolume())
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[interface{}]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(source, jc.DeepEquals, testVolumeMap())
+}
+
+func (s *VolumeSerializationSuite) exportImport(c *gc.C, volume_ *volume) *volume {
+	initial := volumes{
+		Version:  1,
+		Volumes_: []*volume{volume_},
+	}
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	volumes, err := importVolumes(source)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(volumes, gc.HasLen, 1)
+	return volumes[0]
+}
+
+func (s *VolumeSerializationSuite) TestParsingSerializedData(c *gc.C) {
+	original := testVolume()
+	original.AddAttachment(testVolumeAttachmentArgs())
+	volume := s.exportImport(c, original)
+	c.Assert(volume, jc.DeepEquals, original)
+}
+
+type VolumeAttachmentSerializationSuite struct {
+	SliceSerializationSuite
+}
+
+var _ = gc.Suite(&VolumeAttachmentSerializationSuite{})
+
+func (s *VolumeAttachmentSerializationSuite) SetUpTest(c *gc.C) {
+	s.SliceSerializationSuite.SetUpTest(c)
+	s.importName = "volume attachments"
+	s.sliceName = "attachments"
+	s.importFunc = func(m map[string]interface{}) (interface{}, error) {
+		return importVolumeAttachments(m)
+	}
+	s.testFields = func(m map[string]interface{}) {
+		m["attachments"] = []interface{}{}
+	}
+}
+
+func testVolumeAttachmentMap() map[interface{}]interface{} {
+	return map[interface{}]interface{}{
+		"machine-id":  "42",
+		"read-only":   true,
+		"device-name": "sdd",
+		"device-link": "link?",
+		"bus-address": "nfi",
+	}
+}
+
+func testVolumeAttachment() *volumeAttachment {
+	return newVolumeAttachment(testVolumeAttachmentArgs())
+}
+
+func testVolumeAttachmentArgs() VolumeAttachmentArgs {
+	return VolumeAttachmentArgs{
+		Machine:    names.NewMachineTag("42"),
+		ReadOnly:   true,
+		DeviceName: "sdd",
+		DeviceLink: "link?",
+		BusAddress: "nfi",
+	}
+}
+
+func (s *VolumeAttachmentSerializationSuite) TestNewVolumeAttachment(c *gc.C) {
+	attachment := testVolumeAttachment()
+
+	c.Check(attachment.Machine(), gc.Equals, names.NewMachineTag("42"))
+	c.Check(attachment.ReadOnly(), jc.IsTrue)
+	c.Check(attachment.DeviceName(), gc.Equals, "sdd")
+	c.Check(attachment.DeviceLink(), gc.Equals, "link?")
+	c.Check(attachment.BusAddress(), gc.Equals, "nfi")
+}
+
+func (s *VolumeAttachmentSerializationSuite) TestVolumeAttachmentMatches(c *gc.C) {
+	bytes, err := yaml.Marshal(testVolumeAttachment())
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[interface{}]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(source, jc.DeepEquals, testVolumeAttachmentMap())
+}
+
+func (s *VolumeAttachmentSerializationSuite) exportImport(c *gc.C, attachment *volumeAttachment) *volumeAttachment {
+	initial := volumeAttachments{
+		Version:      1,
+		Attachments_: []*volumeAttachment{attachment},
+	}
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	attachments, err := importVolumeAttachments(source)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(attachments, gc.HasLen, 1)
+	return attachments[0]
+}
+
+func (s *VolumeAttachmentSerializationSuite) TestParsingSerializedData(c *gc.C) {
+	original := testVolumeAttachment()
+	attachment := s.exportImport(c, original)
+	c.Assert(attachment, jc.DeepEquals, original)
+}

--- a/core/description/volume_test.go
+++ b/core/description/volume_test.go
@@ -189,6 +189,7 @@ func (s *VolumeAttachmentSerializationSuite) SetUpTest(c *gc.C) {
 func testVolumeAttachmentMap() map[interface{}]interface{} {
 	return map[interface{}]interface{}{
 		"machine-id":  "42",
+		"provisioned": true,
 		"read-only":   true,
 		"device-name": "sdd",
 		"device-link": "link?",
@@ -202,11 +203,12 @@ func testVolumeAttachment() *volumeAttachment {
 
 func testVolumeAttachmentArgs() VolumeAttachmentArgs {
 	return VolumeAttachmentArgs{
-		Machine:    names.NewMachineTag("42"),
-		ReadOnly:   true,
-		DeviceName: "sdd",
-		DeviceLink: "link?",
-		BusAddress: "nfi",
+		Machine:     names.NewMachineTag("42"),
+		Provisioned: true,
+		ReadOnly:    true,
+		DeviceName:  "sdd",
+		DeviceLink:  "link?",
+		BusAddress:  "nfi",
 	}
 }
 
@@ -214,6 +216,7 @@ func (s *VolumeAttachmentSerializationSuite) TestNewVolumeAttachment(c *gc.C) {
 	attachment := testVolumeAttachment()
 
 	c.Check(attachment.Machine(), gc.Equals, names.NewMachineTag("42"))
+	c.Check(attachment.Provisioned(), jc.IsTrue)
 	c.Check(attachment.ReadOnly(), jc.IsTrue)
 	c.Check(attachment.DeviceName(), gc.Equals, "sdd")
 	c.Check(attachment.DeviceLink(), gc.Equals, "link?")

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -104,7 +104,7 @@ func (st *State) Export() (description.Model, error) {
 	if err := export.sshHostKeys(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := export.volumes(); err != nil {
+	if err := export.storage(); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -1118,6 +1118,13 @@ func (e *exporter) logExtras() {
 	}
 }
 
+func (e *exporter) storage() error {
+	if err := e.volumes(); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
 func (e *exporter) volumes() error {
 	coll, closer := e.st.getCollection(volumesC)
 	defer closer()
@@ -1207,11 +1214,13 @@ func (e *exporter) readVolumeAttachments() (map[string][]volumeAttachmentDoc, er
 
 	result := make(map[string][]volumeAttachmentDoc)
 	var doc volumeAttachmentDoc
-
+	var count int
 	iter := coll.Find(nil).Iter()
 	defer iter.Close()
 	for iter.Next(&doc) {
 		result[doc.Volume] = append(result[doc.Volume], doc)
+		count++
 	}
+	e.logger.Debugf("read %d volume attachment documents", count)
 	return result, nil
 }

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1186,6 +1186,7 @@ func (e *exporter) addVolume(vol *volume, volAttachments []volumeAttachmentDoc) 
 		}
 		if info, err := va.Info(); err == nil {
 			logger.Debugf("    info %#v", info)
+			args.Provisioned = true
 			args.ReadOnly = info.ReadOnly
 			args.DeviceName = info.DeviceName
 			args.DeviceLink = info.DeviceLink

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1143,6 +1143,9 @@ func (e *exporter) volumes() error {
 			return errors.Trace(err)
 		}
 	}
+	if err := iter.Err(); err != nil {
+		return errors.Annotate(err, "failed to read volumes")
+	}
 	return nil
 }
 
@@ -1166,10 +1169,6 @@ func (e *exporter) addVolume(vol *volume, volAttachments []volumeAttachmentDoc) 
 		logger.Debugf("  params %#v", params)
 		args.Size = params.Size
 		args.Pool = params.Pool
-		// Possibly set the binding and storage if they are unset.
-		if args.Binding == nil {
-			args.Binding = params.binding
-		}
 	}
 
 	globalKey := vol.globalKey()
@@ -1220,6 +1219,9 @@ func (e *exporter) readVolumeAttachments() (map[string][]volumeAttachmentDoc, er
 	for iter.Next(&doc) {
 		result[doc.Volume] = append(result[doc.Volume], doc)
 		count++
+	}
+	if err := iter.Err(); err != nil {
+		return nil, errors.Annotate(err, "failed to read volumes attachments")
 	}
 	e.logger.Debugf("read %d volume attachment documents", count)
 	return result, nil

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -685,6 +685,8 @@ func (s *MigrationExportSuite) TestVolumes(c *gc.C) {
 	c.Assert(volumes, gc.HasLen, 2)
 	provisioned, notProvisioned := volumes[0], volumes[1]
 
+	// TODO: check status
+
 	c.Check(provisioned.Tag(), gc.Equals, volTag)
 	binding, err := provisioned.Binding()
 	c.Check(err, jc.ErrorIsNil)

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -699,6 +699,7 @@ func (s *MigrationExportSuite) TestVolumes(c *gc.C) {
 	c.Assert(attachments, gc.HasLen, 1)
 	attachment := attachments[0]
 	c.Check(attachment.Machine(), gc.Equals, machineTag)
+	c.Check(attachment.Provisioned(), jc.IsTrue)
 	c.Check(attachment.ReadOnly(), jc.IsTrue)
 	c.Check(attachment.DeviceName(), gc.Equals, "device name")
 	c.Check(attachment.DeviceLink(), gc.Equals, "device link")
@@ -718,6 +719,7 @@ func (s *MigrationExportSuite) TestVolumes(c *gc.C) {
 	c.Assert(attachments, gc.HasLen, 1)
 	attachment = attachments[0]
 	c.Check(attachment.Machine(), gc.Equals, machineTag)
+	c.Check(attachment.Provisioned(), jc.IsFalse)
 	c.Check(attachment.ReadOnly(), jc.IsFalse)
 	c.Check(attachment.DeviceName(), gc.Equals, "")
 	c.Check(attachment.DeviceLink(), gc.Equals, "")

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
+	"github.com/juju/juju/storage/provider/registry"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -644,4 +645,81 @@ type goodToken struct{}
 // Check implements leadership.Token
 func (*goodToken) Check(interface{}) error {
 	return nil
+}
+
+func (s *MigrationExportSuite) TestVolumes(c *gc.C) {
+	registry.RegisterEnvironStorageProviders("someprovider", "loop")
+	defer registry.ResetEnvironStorageProviders("someprovider")
+
+	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
+		Volumes: []state.MachineVolumeParams{{
+			Volume:     state.VolumeParams{Size: 1234},
+			Attachment: state.VolumeAttachmentParams{ReadOnly: true},
+		}, {
+			Volume: state.VolumeParams{Size: 4000},
+		}},
+	})
+	machineTag := machine.MachineTag()
+
+	// We know that the first volume is called "0/0" - although I don't know why.
+	volTag := names.NewVolumeTag("0/0")
+	err := s.State.SetVolumeInfo(volTag, state.VolumeInfo{
+		HardwareId: "magic",
+		Size:       1500,
+		VolumeId:   "volume id",
+		Persistent: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.SetVolumeAttachmentInfo(machineTag, volTag, state.VolumeAttachmentInfo{
+		DeviceName: "device name",
+		DeviceLink: "device link",
+		BusAddress: "bus address",
+		ReadOnly:   true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := s.State.Export()
+	c.Assert(err, jc.ErrorIsNil)
+
+	volumes := model.Volumes()
+	c.Assert(volumes, gc.HasLen, 2)
+	provisioned, notProvisioned := volumes[0], volumes[1]
+
+	c.Check(provisioned.Tag(), gc.Equals, volTag)
+	binding, err := provisioned.Binding()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(binding, gc.Equals, machineTag)
+	c.Check(provisioned.Provisioned(), jc.IsTrue)
+	c.Check(provisioned.Size(), gc.Equals, uint64(1500))
+	c.Check(provisioned.Pool(), gc.Equals, "loop")
+	c.Check(provisioned.HardwareID(), gc.Equals, "magic")
+	c.Check(provisioned.VolumeID(), gc.Equals, "volume id")
+	c.Check(provisioned.Persistent(), jc.IsTrue)
+	attachments := provisioned.Attachments()
+	c.Assert(attachments, gc.HasLen, 1)
+	attachment := attachments[0]
+	c.Check(attachment.Machine(), gc.Equals, machineTag)
+	c.Check(attachment.ReadOnly(), jc.IsTrue)
+	c.Check(attachment.DeviceName(), gc.Equals, "device name")
+	c.Check(attachment.DeviceLink(), gc.Equals, "device link")
+	c.Check(attachment.BusAddress(), gc.Equals, "bus address")
+
+	c.Check(notProvisioned.Tag(), gc.Equals, names.NewVolumeTag("0/1"))
+	binding, err = notProvisioned.Binding()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(binding, gc.Equals, machineTag)
+	c.Check(notProvisioned.Provisioned(), jc.IsFalse)
+	c.Check(notProvisioned.Size(), gc.Equals, uint64(4000))
+	c.Check(notProvisioned.Pool(), gc.Equals, "loop")
+	c.Check(notProvisioned.HardwareID(), gc.Equals, "")
+	c.Check(notProvisioned.VolumeID(), gc.Equals, "")
+	c.Check(notProvisioned.Persistent(), jc.IsFalse)
+	attachments = notProvisioned.Attachments()
+	c.Assert(attachments, gc.HasLen, 1)
+	attachment = attachments[0]
+	c.Check(attachment.Machine(), gc.Equals, machineTag)
+	c.Check(attachment.ReadOnly(), jc.IsFalse)
+	c.Check(attachment.DeviceName(), gc.Equals, "")
+	c.Check(attachment.DeviceLink(), gc.Equals, "")
+	c.Check(attachment.BusAddress(), gc.Equals, "")
 }

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -661,7 +661,8 @@ func (s *MigrationExportSuite) TestVolumes(c *gc.C) {
 	})
 	machineTag := machine.MachineTag()
 
-	// We know that the first volume is called "0/0" - although I don't know why.
+	// We know that the first volume is called "0/0" as it is the first volume
+	// (volumes use sequences), and it is bound to machine 0.
 	volTag := names.NewVolumeTag("0/0")
 	err := s.State.SetVolumeInfo(volTag, state.VolumeInfo{
 		HardwareId: "magic",

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -56,6 +56,8 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 
 		// storage
 		blockDevicesC,
+		volumesC,
+		volumeAttachmentsC,
 	)
 
 	ignoredCollections := set.NewStrings(
@@ -152,8 +154,6 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		storageInstancesC,
 		storageAttachmentsC,
 		storageConstraintsC,
-		volumesC,
-		volumeAttachmentsC,
 
 		// actions
 		actionsC,
@@ -637,6 +637,48 @@ func (s *MigrationSuite) TestSSHHostKeyDocFields(c *gc.C) {
 		"Keys",
 	)
 	s.AssertExportedFields(c, sshHostKeysDoc{}, migrated.Union(ignored))
+}
+
+func (s *MigrationSuite) TestVolumeDocFields(c *gc.C) {
+	ignored := set.NewStrings(
+		"ModelUUID",
+		"DocID",
+		"Life",
+	)
+	migrated := set.NewStrings(
+		"Name",
+		"AttachmentCount", // through count of attachment instances
+		"Binding",
+		"Info",
+		"Params",
+	)
+	todo := set.NewStrings("StorageId")
+	s.AssertExportedFields(c, volumeDoc{}, migrated.Union(ignored).Union(todo))
+	// The info and params fields ar structs.
+	s.AssertExportedFields(c, VolumeInfo{}, set.NewStrings(
+		"HardwareId", "Size", "Pool", "VolumeId", "Persistent"))
+	s.AssertExportedFields(c, VolumeParams{}, set.NewStrings(
+		"Size", "Pool"))
+}
+
+func (s *MigrationSuite) TestVolumeAttachmentDocFields(c *gc.C) {
+	ignored := set.NewStrings(
+		"ModelUUID",
+		"DocID",
+		"Life",
+	)
+	migrated := set.NewStrings(
+		"Volume",
+		"Machine",
+		"Info",
+		"Params",
+	)
+	s.AssertExportedFields(c, volumeAttachmentDoc{}, migrated.Union(ignored))
+	// The info and params fields ar structs.
+	s.AssertExportedFields(c, VolumeAttachmentInfo{}, set.NewStrings(
+		"DeviceName", "DeviceLink", "BusAddress", "ReadOnly"))
+	s.AssertExportedFields(c, VolumeAttachmentParams{}, set.NewStrings(
+		"ReadOnly"))
 }
 
 func (s *MigrationSuite) AssertExportedFields(c *gc.C, doc interface{}, fields set.Strings) {


### PR DESCRIPTION
This change adds the concept of volumes and volume attachments to the database agnostic representation in core/description. It also exports and imports the model representation into the state package.

The volume structure makes reference to storage ids, but storage makes more sense to be done after volumes and filesystems, so we'll need to loop back and finish that off.

(Review request: http://reviews.vapour.ws/r/5310/)