### PR TITLE
Migrationmaster per model logging

### DIFF
--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -166,6 +166,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewWorker:     migrationflag.NewWorker,
 		})),
 		migrationMasterName: ifNotDead(migrationmaster.Manifold(migrationmaster.ManifoldConfig{
+			AgentName:     agentName,
 			APICallerName: apiCallerName,
 			FortressName:  migrationFortressName,
 			Clock:         config.Clock,

--- a/worker/migrationmaster/manifold.go
+++ b/worker/migrationmaster/manifold.go
@@ -26,8 +26,8 @@ type ManifoldConfig struct {
 	NewWorker func(Config) (worker.Worker, error)
 }
 
-// validate is called by start to check for bad configuration.
-func (config ManifoldConfig) validate() error {
+// Validate is called by start to check for bad configuration.
+func (config ManifoldConfig) Validate() error {
 	if config.APICallerName == "" {
 		return errors.NotValidf("empty APICallerName")
 	}
@@ -48,7 +48,7 @@ func (config ManifoldConfig) validate() error {
 
 // start is a StartFunc for a Worker manifold.
 func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
-	if err := config.validate(); err != nil {
+	if err := config.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
 	var apiConn api.Connection

--- a/worker/migrationmaster/manifoldconfig_test.go
+++ b/worker/migrationmaster/manifoldconfig_test.go
@@ -1,0 +1,79 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationmaster_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/migrationmaster"
+)
+
+type ManifoldConfigSuite struct {
+	testing.IsolationSuite
+	config migrationmaster.ManifoldConfig
+}
+
+var _ = gc.Suite(&ManifoldConfigSuite{})
+
+func (s *ManifoldConfigSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.config = s.validConfig()
+}
+
+func (s *ManifoldConfigSuite) validConfig() migrationmaster.ManifoldConfig {
+	return migrationmaster.ManifoldConfig{
+		AgentName:     "agent",
+		APICallerName: "api-caller",
+		FortressName:  "fortress",
+		Clock:         struct{ clock.Clock }{},
+		NewFacade:     func(base.APICaller) (migrationmaster.Facade, error) { return nil, nil },
+		NewWorker:     func(migrationmaster.Config) (worker.Worker, error) { return nil, nil },
+	}
+}
+
+func (s *ManifoldConfigSuite) TestValid(c *gc.C) {
+	c.Check(s.config.Validate(), jc.ErrorIsNil)
+}
+
+func (s *ManifoldConfigSuite) TestMissingAgentName(c *gc.C) {
+	s.config.AgentName = ""
+	s.checkNotValid(c, "empty AgentName not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingAPICallerName(c *gc.C) {
+	s.config.APICallerName = ""
+	s.checkNotValid(c, "empty APICallerName not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingFortressName(c *gc.C) {
+	s.config.FortressName = ""
+	s.checkNotValid(c, "empty FortressName not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingClock(c *gc.C) {
+	s.config.Clock = nil
+	s.checkNotValid(c, "nil Clock not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingNewFacade(c *gc.C) {
+	s.config.NewFacade = nil
+	s.checkNotValid(c, "nil NewFacade not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingNewWorker(c *gc.C) {
+	s.config.NewWorker = nil
+	s.checkNotValid(c, "nil NewWorker not valid")
+}
+
+func (s *ManifoldConfigSuite) checkNotValid(c *gc.C, expect string) {
+	err := s.config.Validate()
+	c.Check(err, gc.ErrorMatches, expect)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}

--- a/worker/migrationmaster/validate_test.go
+++ b/worker/migrationmaster/validate_test.go
@@ -27,6 +27,12 @@ func (*ValidateSuite) TestValid(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 }
 
+func (*ValidateSuite) TestMissingModelUUID(c *gc.C) {
+	config := validConfig()
+	config.ModelUUID = ""
+	checkNotValid(c, config, "empty ModelUUID not valid")
+}
+
 func (*ValidateSuite) TestMissingGuard(c *gc.C) {
 	config := validConfig()
 	config.Guard = nil
@@ -71,6 +77,7 @@ func (*ValidateSuite) TestMissingClock(c *gc.C) {
 
 func validConfig() migrationmaster.Config {
 	return migrationmaster.Config{
+		ModelUUID:       "uuid",
 		Guard:           struct{ fortress.Guard }{},
 		Facade:          struct{ migrationmaster.Facade }{},
 		APIOpen:         func(*api.Info, api.DialOpts) (api.Connection, error) { return nil, nil },

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -82,6 +82,7 @@ type Facade interface {
 
 // Config defines the operation of a Worker.
 type Config struct {
+	ModelUUID       string
 	Facade          Facade
 	Guard           fortress.Guard
 	APIOpen         func(*api.Info, api.DialOpts) (api.Connection, error)
@@ -93,6 +94,9 @@ type Config struct {
 
 // Validate returns an error if config cannot drive a Worker.
 func (config Config) Validate() error {
+	if config.ModelUUID == "" {
+		return errors.NotValidf("empty ModelUUID")
+	}
 	if config.Facade == nil {
 		return errors.NotValidf("nil Facade")
 	}

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -102,7 +103,7 @@ func (s *Suite) SetUpTest(c *gc.C) {
 	// The default worker Config used by most of the tests. Tests may
 	// tweak parts of this as needed.
 	s.config = migrationmaster.Config{
-		ModelUUID:       "uuid",
+		ModelUUID:       utils.MustNewUUID().String(),
 		Facade:          s.masterFacade,
 		Guard:           newStubGuard(s.stub),
 		APIOpen:         s.apiOpen,

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -102,6 +102,7 @@ func (s *Suite) SetUpTest(c *gc.C) {
 	// The default worker Config used by most of the tests. Tests may
 	// tweak parts of this as needed.
 	s.config = migrationmaster.Config{
+		ModelUUID:       "uuid",
 		Facade:          s.masterFacade,
 		Guard:           newStubGuard(s.stub),
 		APIOpen:         s.apiOpen,


### PR DESCRIPTION
worker/migraitonmaster: Add missing tests for ManifoldConfig.Validate

Note that Validate is now also exported.

---

worker/migrationmaster: Thread model UUID into worker

The model UUID pulled out of the agent's config and passed to the worker via its Config. This will be used to support logger setup.

---

worker/migrationmaster: Use a specific logger per migration

Each logger includes the model UUID suffix in the logger name. This makes it easier to distinguish the activity of different migrationmaster instances.

---

cmd/jujud/agent/model: Pass agent to migrationmaster

The agent is a new requirement for this worker.


(Review request: http://reviews.vapour.ws/r/5311/)