### PR TITLE
Revert "Merge pull request #5858 from bz2/revert_pr5758"

### DIFF
--- a/cmd/juju/application/cmd_test.go
+++ b/cmd/juju/application/cmd_test.go
@@ -54,7 +54,7 @@ func initExpectations(com *DeployCommand, store jujuclient.ClientStore) {
 	if com.NumUnits == 0 {
 		com.NumUnits = 1
 	}
-	com.SetClientStore(store)
+	com.SetClientStore(modelcmd.QualifyingClientStore{store})
 	com.SetModelName("controller")
 }
 

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -233,7 +233,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 	c.Assert(controller.APIEndpoints, gc.DeepEquals, addrConnectedTo)
 	c.Assert(utils.IsValidUUIDString(controller.ControllerUUID), jc.IsTrue)
 
-	controllerModel, err := s.store.ModelByName(controllerName, bootstrap.ControllerModelName)
+	controllerModel, err := s.store.ModelByName(controllerName, "admin@local/controller")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(controllerModel.ModelUUID, gc.Equals, controller.ControllerUUID)
 
@@ -398,7 +398,7 @@ func (s *BootstrapSuite) TestBootstrapSetsCurrentModel(c *gc.C) {
 	c.Assert(currentController, gc.Equals, "devcontroller")
 	modelName, err := s.store.CurrentModel(currentController)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modelName, gc.Equals, "default")
+	c.Assert(modelName, gc.Equals, "admin@local/default")
 }
 
 func (s *BootstrapSuite) TestBootstrapDefaultModel(c *gc.C) {
@@ -594,11 +594,11 @@ func (s *BootstrapSuite) TestBootstrapErrorRestoresOldMetadata(c *gc.C) {
 		jujuclient.ClientStore,
 		bootstrap.PrepareParams,
 	) (environs.Environ, error) {
-		s.writeControllerModelAccountInfo(c, "foo", "bar", "foobar@local")
+		s.writeControllerModelAccountInfo(c, "foo", "foobar@local/bar", "foobar@local")
 		return nil, fmt.Errorf("mock-prepare")
 	})
 
-	s.writeControllerModelAccountInfo(c, "olddevcontroller", "fredmodel", "fred@local")
+	s.writeControllerModelAccountInfo(c, "olddevcontroller", "fred@local/fredmodel", "fred@local")
 	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "devcontroller", "dummy", "--auto-upgrade")
 	c.Assert(err, gc.ErrorMatches, "mock-prepare")
 
@@ -609,14 +609,14 @@ func (s *BootstrapSuite) TestBootstrapErrorRestoresOldMetadata(c *gc.C) {
 	c.Assert(accountDetails.User, gc.Equals, "fred@local")
 	currentModel, err := s.store.CurrentModel(currentController)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(currentModel, gc.Equals, "fredmodel")
+	c.Assert(currentModel, gc.Equals, "fred@local/fredmodel")
 }
 
 func (s *BootstrapSuite) TestBootstrapAlreadyExists(c *gc.C) {
 	const controllerName = "devcontroller"
 	s.patchVersionAndSeries(c, "raring")
 
-	s.writeControllerModelAccountInfo(c, "devcontroller", "fredmodel", "fred@local")
+	s.writeControllerModelAccountInfo(c, "devcontroller", "fred@local/fredmodel", "fred@local")
 
 	ctx := coretesting.Context(c)
 	_, errc := cmdtesting.RunCommand(ctx, s.newBootstrapCommand(), controllerName, "dummy", "--auto-upgrade")
@@ -630,7 +630,7 @@ func (s *BootstrapSuite) TestBootstrapAlreadyExists(c *gc.C) {
 	c.Assert(accountDetails.User, gc.Equals, "fred@local")
 	currentModel, err := s.store.CurrentModel(currentController)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(currentModel, gc.Equals, "fredmodel")
+	c.Assert(currentModel, gc.Equals, "fred@local/fredmodel")
 }
 
 func (s *BootstrapSuite) TestInvalidLocalSource(c *gc.C) {

--- a/cmd/juju/commands/migrate_test.go
+++ b/cmd/juju/commands/migrate_test.go
@@ -158,7 +158,11 @@ func (m *fakeModelAPI) ListModels(user string) ([]base.UserModel, error) {
 	if m.model == "" {
 		return []base.UserModel{}, nil
 	}
-	return []base.UserModel{{Name: m.model, UUID: modelUUID}}, nil
+	return []base.UserModel{{
+		Name:  m.model,
+		UUID:  modelUUID,
+		Owner: "source@local",
+	}}, nil
 }
 
 func (m *fakeModelAPI) Close() error {

--- a/cmd/juju/commands/migrate_test.go
+++ b/cmd/juju/commands/migrate_test.go
@@ -50,7 +50,7 @@ func (s *MigrateSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Define the model to migrate in the config.
-	err = s.store.UpdateModel("source", "model", jujuclient.ModelDetails{
+	err = s.store.UpdateModel("source", "source@local/model", jujuclient.ModelDetails{
 		ModelUUID: modelUUID,
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/commands/switch.go
+++ b/cmd/juju/commands/switch.go
@@ -71,17 +71,18 @@ func (c *switchCommand) Init(args []string) error {
 }
 
 func (c *switchCommand) Run(ctx *cmd.Context) (resultErr error) {
+	store := modelcmd.QualifyingClientStore{c.Store}
 
 	// Get the current name for logging the transition or printing
 	// the current controller/model.
-	currentControllerName, err := c.Store.CurrentController()
+	currentControllerName, err := store.CurrentController()
 	if errors.IsNotFound(err) {
 		currentControllerName = ""
 	} else if err != nil {
 		return errors.Trace(err)
 	}
 	if c.Target == "" {
-		currentName, err := c.name(currentControllerName, true)
+		currentName, err := c.name(store, currentControllerName, true)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -91,7 +92,7 @@ func (c *switchCommand) Run(ctx *cmd.Context) (resultErr error) {
 		fmt.Fprintf(ctx.Stdout, "%s\n", currentName)
 		return nil
 	}
-	currentName, err := c.name(currentControllerName, false)
+	currentName, err := c.name(store, currentControllerName, false)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -114,16 +115,16 @@ func (c *switchCommand) Run(ctx *cmd.Context) (resultErr error) {
 
 	// If the target identifies a controller, then set that as the current controller.
 	var newControllerName = c.Target
-	if _, err = c.Store.ControllerByName(c.Target); err == nil {
+	if _, err = store.ControllerByName(c.Target); err == nil {
 		if newControllerName == currentControllerName {
 			newName = currentName
 			return nil
 		} else {
-			newName, err = c.name(newControllerName, false)
+			newName, err = c.name(store, newControllerName, false)
 			if err != nil {
 				return errors.Trace(err)
 			}
-			return errors.Trace(c.Store.SetCurrentController(newControllerName))
+			return errors.Trace(store.SetCurrentController(newControllerName))
 		}
 	} else if !errors.IsNotFound(err) {
 		return errors.Trace(err)
@@ -135,25 +136,28 @@ func (c *switchCommand) Run(ctx *cmd.Context) (resultErr error) {
 	// case, the model must exist in the current controller.
 	newControllerName, modelName := modelcmd.SplitModelName(c.Target)
 	if newControllerName != "" {
-		if _, err = c.Store.ControllerByName(newControllerName); err != nil {
+		if _, err = store.ControllerByName(newControllerName); err != nil {
 			return errors.Trace(err)
 		}
-		newName = modelcmd.JoinModelName(newControllerName, modelName)
 	} else {
 		if currentControllerName == "" {
 			return unknownSwitchTargetError(c.Target)
 		}
 		newControllerName = currentControllerName
-		newName = modelcmd.JoinModelName(newControllerName, modelName)
 	}
+	modelName, err = store.QualifiedModelName(newControllerName, modelName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	newName = modelcmd.JoinModelName(newControllerName, modelName)
 
-	err = c.Store.SetCurrentModel(newControllerName, modelName)
+	err = store.SetCurrentModel(newControllerName, modelName)
 	if errors.IsNotFound(err) {
 		// The model isn't known locally, so we must query the controller.
-		if err := c.RefreshModels(c.Store, newControllerName); err != nil {
+		if err := c.RefreshModels(store, newControllerName); err != nil {
 			return errors.Annotate(err, "refreshing models cache")
 		}
-		err := c.Store.SetCurrentModel(newControllerName, modelName)
+		err := store.SetCurrentModel(newControllerName, modelName)
 		if errors.IsNotFound(err) {
 			return unknownSwitchTargetError(c.Target)
 		} else if err != nil {
@@ -163,7 +167,7 @@ func (c *switchCommand) Run(ctx *cmd.Context) (resultErr error) {
 		return errors.Trace(err)
 	}
 	if currentControllerName != newControllerName {
-		if err := c.Store.SetCurrentController(newControllerName); err != nil {
+		if err := store.SetCurrentController(newControllerName); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -185,11 +189,11 @@ func logSwitch(ctx *cmd.Context, oldName string, newName *string) {
 // name returns the name of the current model for the specified controller
 // if one is set, otherwise the controller name with an indicator that it
 // is the name of a controller and not a model.
-func (c *switchCommand) name(controllerName string, machineReadable bool) (string, error) {
+func (c *switchCommand) name(store jujuclient.ModelGetter, controllerName string, machineReadable bool) (string, error) {
 	if controllerName == "" {
 		return "", nil
 	}
-	modelName, err := c.Store.CurrentModel(controllerName)
+	modelName, err := store.CurrentModel(controllerName)
 	if err == nil {
 		return modelcmd.JoinModelName(controllerName, modelName), nil
 	}

--- a/cmd/juju/commands/switch_test.go
+++ b/cmd/juju/commands/switch_test.go
@@ -77,12 +77,12 @@ func (s *SwitchSimpleSuite) TestNoArgsCurrentModel(c *gc.C) {
 	s.addController(c, "a-controller")
 	s.store.CurrentControllerName = "a-controller"
 	s.store.Models["a-controller"] = &jujuclient.ControllerModels{
-		Models:       map[string]jujuclient.ModelDetails{"mymodel": {}},
-		CurrentModel: "mymodel",
+		Models:       map[string]jujuclient.ModelDetails{"admin@local/mymodel": {}},
+		CurrentModel: "admin@local/mymodel",
 	}
 	ctx, err := s.run(c)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stdout(ctx), gc.Equals, "a-controller:mymodel\n")
+	c.Assert(coretesting.Stdout(ctx), gc.Equals, "a-controller:admin@local/mymodel\n")
 }
 
 func (s *SwitchSimpleSuite) TestSwitchWritesCurrentController(c *gc.C) {
@@ -131,78 +131,98 @@ func (s *SwitchSimpleSuite) TestSwitchControllerToModel(c *gc.C) {
 	s.store.CurrentControllerName = "ctrl"
 	s.addController(c, "ctrl")
 	s.store.Models["ctrl"] = &jujuclient.ControllerModels{
-		Models: map[string]jujuclient.ModelDetails{"mymodel": {}},
+		Models: map[string]jujuclient.ModelDetails{"admin@local/mymodel": {}},
 	}
 	context, err := s.run(c, "mymodel")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(context), gc.Equals, "ctrl (controller) -> ctrl:mymodel\n")
+	c.Assert(coretesting.Stderr(context), gc.Equals, "ctrl (controller) -> ctrl:admin@local/mymodel\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
 		{"CurrentModel", []interface{}{"ctrl"}},
 		{"ControllerByName", []interface{}{"mymodel"}},
-		{"SetCurrentModel", []interface{}{"ctrl", "mymodel"}},
+		{"AccountDetails", []interface{}{"ctrl"}},
+		{"SetCurrentModel", []interface{}{"ctrl", "admin@local/mymodel"}},
 	})
-	c.Assert(s.store.Models["ctrl"].CurrentModel, gc.Equals, "mymodel")
+	c.Assert(s.store.Models["ctrl"].CurrentModel, gc.Equals, "admin@local/mymodel")
 }
 
 func (s *SwitchSimpleSuite) TestSwitchControllerToModelDifferentController(c *gc.C) {
 	s.store.CurrentControllerName = "old"
 	s.addController(c, "new")
 	s.store.Models["new"] = &jujuclient.ControllerModels{
-		Models: map[string]jujuclient.ModelDetails{"mymodel": {}},
+		Models: map[string]jujuclient.ModelDetails{"admin@local/mymodel": {}},
 	}
 	context, err := s.run(c, "new:mymodel")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(context), gc.Equals, "old (controller) -> new:mymodel\n")
+	c.Assert(coretesting.Stderr(context), gc.Equals, "old (controller) -> new:admin@local/mymodel\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
 		{"CurrentModel", []interface{}{"old"}},
 		{"ControllerByName", []interface{}{"new:mymodel"}},
 		{"ControllerByName", []interface{}{"new"}},
-		{"SetCurrentModel", []interface{}{"new", "mymodel"}},
+		{"AccountDetails", []interface{}{"new"}},
+		{"SetCurrentModel", []interface{}{"new", "admin@local/mymodel"}},
 		{"SetCurrentController", []interface{}{"new"}},
 	})
-	c.Assert(s.store.Models["new"].CurrentModel, gc.Equals, "mymodel")
+	c.Assert(s.store.Models["new"].CurrentModel, gc.Equals, "admin@local/mymodel")
 }
 
 func (s *SwitchSimpleSuite) TestSwitchLocalControllerToModelDifferentController(c *gc.C) {
 	s.store.CurrentControllerName = "old"
 	s.addController(c, "new")
 	s.store.Models["new"] = &jujuclient.ControllerModels{
-		Models: map[string]jujuclient.ModelDetails{"mymodel": {}},
+		Models: map[string]jujuclient.ModelDetails{"admin@local/mymodel": {}},
 	}
 	context, err := s.run(c, "new:mymodel")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(context), gc.Equals, "old (controller) -> new:mymodel\n")
+	c.Assert(coretesting.Stderr(context), gc.Equals, "old (controller) -> new:admin@local/mymodel\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
 		{"CurrentModel", []interface{}{"old"}},
 		{"ControllerByName", []interface{}{"new:mymodel"}},
 		{"ControllerByName", []interface{}{"new"}},
-		{"SetCurrentModel", []interface{}{"new", "mymodel"}},
+		{"AccountDetails", []interface{}{"new"}},
+		{"SetCurrentModel", []interface{}{"new", "admin@local/mymodel"}},
 		{"SetCurrentController", []interface{}{"new"}},
 	})
-	c.Assert(s.store.Models["new"].CurrentModel, gc.Equals, "mymodel")
+	c.Assert(s.store.Models["new"].CurrentModel, gc.Equals, "admin@local/mymodel")
 }
 
 func (s *SwitchSimpleSuite) TestSwitchControllerToDifferentControllerCurrentModel(c *gc.C) {
 	s.store.CurrentControllerName = "old"
 	s.addController(c, "new")
 	s.store.Models["new"] = &jujuclient.ControllerModels{
-		Models:       map[string]jujuclient.ModelDetails{"mymodel": {}},
-		CurrentModel: "mymodel",
+		Models:       map[string]jujuclient.ModelDetails{"admin@local/mymodel": {}},
+		CurrentModel: "admin@local/mymodel",
 	}
 	context, err := s.run(c, "new:mymodel")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(context), gc.Equals, "old (controller) -> new:mymodel\n")
+	c.Assert(coretesting.Stderr(context), gc.Equals, "old (controller) -> new:admin@local/mymodel\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
 		{"CurrentModel", []interface{}{"old"}},
 		{"ControllerByName", []interface{}{"new:mymodel"}},
 		{"ControllerByName", []interface{}{"new"}},
-		{"SetCurrentModel", []interface{}{"new", "mymodel"}},
+		{"AccountDetails", []interface{}{"new"}},
+		{"SetCurrentModel", []interface{}{"new", "admin@local/mymodel"}},
 		{"SetCurrentController", []interface{}{"new"}},
 	})
+}
+
+func (s *SwitchSimpleSuite) TestSwitchToModelDifferentOwner(c *gc.C) {
+	s.store.CurrentControllerName = "same"
+	s.addController(c, "same")
+	s.store.Models["same"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{
+			"admin@local/mymodel":  {},
+			"bianca@local/mymodel": {},
+		},
+		CurrentModel: "admin@local/mymodel",
+	}
+	context, err := s.run(c, "bianca/mymodel")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(coretesting.Stderr(context), gc.Equals, "same:admin@local/mymodel -> same:bianca@local/mymodel\n")
+	c.Assert(s.store.Models["same"].CurrentModel, gc.Equals, "bianca@local/mymodel")
 }
 
 func (s *SwitchSimpleSuite) TestSwitchUnknownNoCurrentController(c *gc.C) {
@@ -219,15 +239,13 @@ func (s *SwitchSimpleSuite) TestSwitchUnknownCurrentControllerRefreshModels(c *g
 	s.addController(c, "ctrl")
 	s.onRefresh = func() {
 		s.store.Models["ctrl"] = &jujuclient.ControllerModels{
-			Models: map[string]jujuclient.ModelDetails{"unknown": {}},
+			Models: map[string]jujuclient.ModelDetails{"admin@local/unknown": {}},
 		}
 	}
 	ctx, err := s.run(c, "unknown")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(ctx), gc.Equals, "ctrl (controller) -> ctrl:unknown\n")
-	s.CheckCalls(c, []testing.StubCall{
-		{"RefreshModels", []interface{}{s.stubStore, "ctrl"}},
-	})
+	c.Assert(coretesting.Stderr(ctx), gc.Equals, "ctrl (controller) -> ctrl:admin@local/unknown\n")
+	s.CheckCallNames(c, "RefreshModels")
 }
 
 func (s *SwitchSimpleSuite) TestSwitchUnknownCurrentControllerRefreshModelsStillUnknown(c *gc.C) {
@@ -235,9 +253,7 @@ func (s *SwitchSimpleSuite) TestSwitchUnknownCurrentControllerRefreshModelsStill
 	s.addController(c, "ctrl")
 	_, err := s.run(c, "unknown")
 	c.Assert(err, gc.ErrorMatches, `"unknown" is not the name of a model or controller`)
-	s.CheckCalls(c, []testing.StubCall{
-		{"RefreshModels", []interface{}{s.stubStore, "ctrl"}},
-	})
+	s.CheckCallNames(c, "RefreshModels")
 }
 
 func (s *SwitchSimpleSuite) TestSwitchUnknownCurrentControllerRefreshModelsFails(c *gc.C) {
@@ -246,9 +262,7 @@ func (s *SwitchSimpleSuite) TestSwitchUnknownCurrentControllerRefreshModelsFails
 	s.SetErrors(errors.New("not very refreshing"))
 	_, err := s.run(c, "unknown")
 	c.Assert(err, gc.ErrorMatches, "refreshing models cache: not very refreshing")
-	s.CheckCalls(c, []testing.StubCall{
-		{"RefreshModels", []interface{}{s.stubStore, "ctrl"}},
-	})
+	s.CheckCallNames(c, "RefreshModels")
 }
 
 func (s *SwitchSimpleSuite) TestSettingWhenEnvVarSet(c *gc.C) {

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -148,7 +148,7 @@ func (s *addSuite) TestAddExistingName(c *gc.C) {
 	// controller will error out if the model already exists. Overwriting
 	// means we'll replace any stale details from an previously existing
 	// model with the same name.
-	err := s.store.UpdateModel("test-master", "test", jujuclient.ModelDetails{
+	err := s.store.UpdateModel("test-master", "bob@local/test", jujuclient.ModelDetails{
 		"stale-uuid",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -156,7 +156,7 @@ func (s *addSuite) TestAddExistingName(c *gc.C) {
 	_, err = s.run(c, "test")
 	c.Assert(err, jc.ErrorIsNil)
 
-	details, err := s.store.ModelByName("test-master", "test")
+	details, err := s.store.ModelByName("test-master", "bob@local/test")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(details, jc.DeepEquals, &jujuclient.ModelDetails{"fake-model-uuid"})
 }
@@ -278,7 +278,7 @@ func (s *addSuite) TestAddErrorRemoveConfigstoreInfo(c *gc.C) {
 	_, err := s.run(c, "test")
 	c.Assert(err, gc.ErrorMatches, "bah humbug")
 
-	_, err = s.store.ModelByName("test-master", "test")
+	_, err = s.store.ModelByName("test-master", "bob@local/test")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
@@ -286,7 +286,7 @@ func (s *addSuite) TestAddStoresValues(c *gc.C) {
 	_, err := s.run(c, "test")
 	c.Assert(err, jc.ErrorIsNil)
 
-	model, err := s.store.ModelByName("test-master", "test")
+	model, err := s.store.ModelByName("test-master", "bob@local/test")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(model, jc.DeepEquals, &jujuclient.ModelDetails{"fake-model-uuid"})
 }
@@ -296,7 +296,7 @@ func (s *addSuite) TestNoEnvCacheOtherUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Creating a model for another user does not update the model cache.
-	_, err = s.store.ModelByName("test-master", "test")
+	_, err = s.store.ModelByName("test-master", "bob@local/test")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -67,8 +67,8 @@ func NewListModelsCommandForTest(modelAPI ModelManagerAPI, sysAPI ModelsSysAPI, 
 
 // NewRegisterCommandForTest returns a RegisterCommand with the function used
 // to open the API connection mocked out.
-func NewRegisterCommandForTest(apiOpen api.OpenFunc, refreshModels func(jujuclient.ClientStore, string) error, store jujuclient.ClientStore) *registerCommand {
-	return &registerCommand{apiOpen: apiOpen, refreshModels: refreshModels, store: store}
+func NewRegisterCommandForTest(apiOpen api.OpenFunc, listModels func(jujuclient.ClientStore, string, string) ([]base.UserModel, error), store jujuclient.ClientStore) *registerCommand {
+	return &registerCommand{apiOpen: apiOpen, listModelsFunc: listModels, store: store}
 }
 
 // NewRemoveBlocksCommandForTest returns a RemoveBlocksCommand with the

--- a/cmd/juju/controller/listcontrollersconverters.go
+++ b/cmd/juju/controller/listcontrollersconverters.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/jujuclient"
 )
@@ -73,6 +74,14 @@ func (c *listControllersCommand) convertControllerDetails(storeControllers map[s
 			}
 		} else {
 			modelName = currentModel
+			if userName != "" {
+				// There's a user logged in, so display the
+				// model name relative to that user.
+				if unqualifiedModelName, owner, err := jujuclient.SplitModelName(modelName); err == nil {
+					user := names.NewUserTag(userName)
+					modelName = ownerQualifiedModelName(unqualifiedModelName, owner, user)
+				}
+			}
 		}
 
 		controllers[controllerName] = ControllerItem{

--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
 )
 
 // NewListModelsCommand returns a command to list models.
@@ -29,13 +30,14 @@ func NewListModelsCommand() cmd.Command {
 // current user can access on the current controller.
 type modelsCommand struct {
 	modelcmd.ControllerCommandBase
-	out       cmd.Output
-	all       bool
-	user      string
-	listUUID  bool
-	exactTime bool
-	modelAPI  ModelManagerAPI
-	sysAPI    ModelsSysAPI
+	out          cmd.Output
+	all          bool
+	loggedInUser string
+	user         string
+	listUUID     bool
+	exactTime    bool
+	modelAPI     ModelManagerAPI
+	sysAPI       ModelsSysAPI
 }
 
 var listModelsDoc = `
@@ -109,28 +111,35 @@ func (c *modelsCommand) SetFlags(f *gnuflag.FlagSet) {
 // ModelSet contains the set of models known to the client,
 // and UUID of the current model.
 type ModelSet struct {
-	Models       []common.ModelInfo `yaml:"models" json:"models"`
-	CurrentModel string             `yaml:"current-model,omitempty" json:"current-model,omitempty"`
+	Models []common.ModelInfo `yaml:"models" json:"models"`
+
+	// CurrentModel is the name of the current model, qualified for the
+	// user for which we're listing models. i.e. for the user admin@local,
+	// and the model admin@local/foo, this field will contain "foo"; for
+	// bob@local and the same model, the field will contain "admin/foo".
+	CurrentModel string `yaml:"current-model,omitempty" json:"current-model,omitempty"`
+
+	// CurrentModelQualified is the fully qualified name for the current
+	// model, i.e. having the format $owner/$model.
+	CurrentModelQualified string `yaml:"-" json:"-"`
 }
 
 // Run implements Command.Run
 func (c *modelsCommand) Run(ctx *cmd.Context) error {
-	if c.user == "" {
-		accountDetails, err := c.ClientStore().AccountDetails(
-			c.ControllerName(),
-		)
-		if err != nil {
-			return err
-		}
-		c.user = accountDetails.User
+	accountDetails, err := c.ClientStore().AccountDetails(c.ControllerName())
+	if err != nil {
+		return err
 	}
+	c.loggedInUser = accountDetails.User
 
 	// First get a list of the models.
 	var models []base.UserModel
-	var err error
 	if c.all {
 		models, err = c.getAllModels()
 	} else {
+		if c.user == "" {
+			c.user = accountDetails.User
+		}
 		models, err = c.getUserModels()
 	}
 	if err != nil {
@@ -159,11 +168,21 @@ func (c *modelsCommand) Run(ctx *cmd.Context) error {
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
+	modelSet.CurrentModelQualified = current
 	modelSet.CurrentModel = current
+	if c.user != "" {
+		userForListing := names.NewUserTag(c.user)
+		unqualifiedModelName, owner, err := jujuclient.SplitModelName(current)
+		if err == nil {
+			modelSet.CurrentModel = ownerQualifiedModelName(
+				unqualifiedModelName, owner, userForListing,
+			)
+		}
+	}
+
 	if err := c.out.Write(ctx, modelSet); err != nil {
 		return err
 	}
-
 	if len(models) == 0 && c.out.Name() == "tabular" {
 		// When the output is tabular, we inform the user when there
 		// are no models available, and tell them how to go about
@@ -232,6 +251,18 @@ func (c *modelsCommand) formatTabular(value interface{}) ([]byte, error) {
 	if !ok {
 		return nil, errors.Errorf("expected value of type %T, got %T", modelSet, value)
 	}
+
+	// We need the tag of the user for which we're listing models,
+	// and for the logged-in user. We use these below when formatting
+	// the model display names.
+	loggedInUser := names.NewUserTag(c.loggedInUser)
+	userForLastConn := loggedInUser
+	var userForListing names.UserTag
+	if c.user != "" {
+		userForListing = names.NewUserTag(c.user)
+		userForLastConn = userForListing
+	}
+
 	var out bytes.Buffer
 	const (
 		// To format things into columns.
@@ -248,16 +279,16 @@ func (c *modelsCommand) formatTabular(value interface{}) ([]byte, error) {
 	}
 	fmt.Fprintf(tw, "\tOWNER\tSTATUS\tLAST CONNECTION\n")
 	for _, model := range modelSet.Models {
-		name := model.Name
-		if name == modelSet.CurrentModel {
+		owner := names.NewUserTag(model.Owner)
+		name := ownerQualifiedModelName(model.Name, owner, userForListing)
+		if jujuclient.JoinOwnerModelName(owner, model.Name) == modelSet.CurrentModelQualified {
 			name += "*"
 		}
 		fmt.Fprintf(tw, "%s", name)
 		if c.listUUID {
 			fmt.Fprintf(tw, "\t%s", model.UUID)
 		}
-		user := names.NewUserTag(c.user).Canonical()
-		lastConnection := model.Users[user].LastConnection
+		lastConnection := model.Users[userForLastConn.Canonical()].LastConnection
 		if lastConnection == "" {
 			lastConnection = "never connected"
 		}
@@ -265,4 +296,20 @@ func (c *modelsCommand) formatTabular(value interface{}) ([]byte, error) {
 	}
 	tw.Flush()
 	return out.Bytes(), nil
+}
+
+// ownerQualifiedModelName returns the model name qualified with the
+// model owner if the owner is not the same as the given canonical
+// user name. If the owner is a local user, we omit the domain.
+func ownerQualifiedModelName(modelName string, owner, user names.UserTag) string {
+	if owner.Canonical() == user.Canonical() {
+		return modelName
+	}
+	var ownerName string
+	if owner.IsLocal() {
+		ownerName = owner.Name()
+	} else {
+		ownerName = owner.Canonical()
+	}
+	return fmt.Sprintf("%s/%s", ownerName, modelName)
 }

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -103,15 +103,15 @@ func (s *ModelsSuite) SetUpTest(c *gc.C) {
 	models := []base.UserModel{
 		{
 			Name:  "test-model1",
-			Owner: "user-admin@local",
+			Owner: "admin@local",
 			UUID:  "test-model1-UUID",
 		}, {
 			Name:  "test-model2",
-			Owner: "user-admin@local",
+			Owner: "carlotta@local",
 			UUID:  "test-model2-UUID",
 		}, {
 			Name:  "test-model3",
-			Owner: "user-admin@local",
+			Owner: "daiwik@external",
 			UUID:  "test-model3-UUID",
 		},
 	}
@@ -123,7 +123,7 @@ func (s *ModelsSuite) SetUpTest(c *gc.C) {
 	s.store.CurrentControllerName = "fake"
 	s.store.Controllers["fake"] = jujuclient.ControllerDetails{}
 	s.store.Models["fake"] = &jujuclient.ControllerModels{
-		CurrentModel: "test-model1",
+		CurrentModel: "admin@local/test-model1",
 	}
 	s.store.Accounts["fake"] = jujuclient.AccountDetails{
 		User:     "admin@local",
@@ -135,21 +135,28 @@ func (s *ModelsSuite) newCommand() cmd.Command {
 	return controller.NewListModelsCommandForTest(s.api, s.api, s.store)
 }
 
-func (s *ModelsSuite) checkSuccess(c *gc.C, user string, args ...string) {
-	context, err := testing.RunCommand(c, s.newCommand(), args...)
+func (s *ModelsSuite) TestModelsOwner(c *gc.C) {
+	context, err := testing.RunCommand(c, s.newCommand())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.api.user, gc.Equals, user)
+	c.Assert(s.api.user, gc.Equals, "admin@local")
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"MODEL         OWNER             STATUS      LAST CONNECTION\n"+
-		"test-model1*  user-admin@local  active      2015-03-20\n"+
-		"test-model2   user-admin@local  active      2015-03-01\n"+
-		"test-model3   user-admin@local  destroying  never connected\n"+
+		"MODEL                        OWNER            STATUS      LAST CONNECTION\n"+
+		"test-model1*                 admin@local      active      2015-03-20\n"+
+		"carlotta/test-model2         carlotta@local   active      2015-03-01\n"+
+		"daiwik@external/test-model3  daiwik@external  destroying  never connected\n"+
 		"\n")
 }
 
-func (s *ModelsSuite) TestModels(c *gc.C) {
-	s.checkSuccess(c, "admin@local")
-	s.checkSuccess(c, "bob", "--user", "bob")
+func (s *ModelsSuite) TestModelsNonOwner(c *gc.C) {
+	context, err := testing.RunCommand(c, s.newCommand(), "--user", "bob")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.api.user, gc.Equals, "bob")
+	c.Assert(testing.Stdout(context), gc.Equals, ""+
+		"MODEL                        OWNER            STATUS      LAST CONNECTION\n"+
+		"admin/test-model1*           admin@local      active      2015-03-20\n"+
+		"carlotta/test-model2         carlotta@local   active      2015-03-01\n"+
+		"daiwik@external/test-model3  daiwik@external  destroying  never connected\n"+
+		"\n")
 }
 
 func (s *ModelsSuite) TestAllModels(c *gc.C) {
@@ -157,10 +164,10 @@ func (s *ModelsSuite) TestAllModels(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.all, jc.IsTrue)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"MODEL         OWNER             STATUS      LAST CONNECTION\n"+
-		"test-model1*  user-admin@local  active      2015-03-20\n"+
-		"test-model2   user-admin@local  active      2015-03-01\n"+
-		"test-model3   user-admin@local  destroying  never connected\n"+
+		"MODEL                        OWNER            STATUS      LAST CONNECTION\n"+
+		"admin/test-model1*           admin@local      active      2015-03-20\n"+
+		"carlotta/test-model2         carlotta@local   active      2015-03-01\n"+
+		"daiwik@external/test-model3  daiwik@external  destroying  never connected\n"+
 		"\n")
 }
 
@@ -169,10 +176,10 @@ func (s *ModelsSuite) TestAllModelsNoneCurrent(c *gc.C) {
 	context, err := testing.RunCommand(c, s.newCommand())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"MODEL        OWNER             STATUS      LAST CONNECTION\n"+
-		"test-model1  user-admin@local  active      2015-03-20\n"+
-		"test-model2  user-admin@local  active      2015-03-01\n"+
-		"test-model3  user-admin@local  destroying  never connected\n"+
+		"MODEL                        OWNER            STATUS      LAST CONNECTION\n"+
+		"test-model1                  admin@local      active      2015-03-20\n"+
+		"carlotta/test-model2         carlotta@local   active      2015-03-01\n"+
+		"daiwik@external/test-model3  daiwik@external  destroying  never connected\n"+
 		"\n")
 }
 
@@ -181,10 +188,10 @@ func (s *ModelsSuite) TestModelsUUID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.user, gc.Equals, "admin@local")
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"MODEL         MODEL UUID        OWNER             STATUS      LAST CONNECTION\n"+
-		"test-model1*  test-model1-UUID  user-admin@local  active      2015-03-20\n"+
-		"test-model2   test-model2-UUID  user-admin@local  active      2015-03-01\n"+
-		"test-model3   test-model3-UUID  user-admin@local  destroying  never connected\n"+
+		"MODEL                        MODEL UUID        OWNER            STATUS      LAST CONNECTION\n"+
+		"test-model1*                 test-model1-UUID  admin@local      active      2015-03-20\n"+
+		"carlotta/test-model2         test-model2-UUID  carlotta@local   active      2015-03-01\n"+
+		"daiwik@external/test-model3  test-model3-UUID  daiwik@external  destroying  never connected\n"+
 		"\n")
 }
 

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -224,7 +224,9 @@ func (c *registerCommand) maybeSetCurrentModel(ctx *cmd.Context, store jujuclien
 	if len(models) == 1 {
 		// There is exactly one model shared,
 		// so set it as the current model.
-		modelName := models[0].Name
+		model := models[0]
+		owner := names.NewUserTag(model.Owner)
+		modelName := jujuclient.JoinOwnerModelName(owner, model.Name)
 		err := store.SetCurrentModel(controllerName, modelName)
 		if err != nil {
 			return errors.Trace(err)

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -25,6 +25,8 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
@@ -39,7 +41,7 @@ of a model to grant access to that model with "juju grant".`[1:])
 func NewRegisterCommand() cmd.Command {
 	cmd := &registerCommand{}
 	cmd.apiOpen = cmd.APIOpen
-	cmd.refreshModels = cmd.RefreshModels
+	cmd.listModelsFunc = cmd.listModels
 	cmd.store = jujuclient.NewFileClientStore()
 	return modelcmd.WrapBase(cmd)
 }
@@ -48,10 +50,10 @@ func NewRegisterCommand() cmd.Command {
 // information.
 type registerCommand struct {
 	modelcmd.JujuCommandBase
-	apiOpen       api.OpenFunc
-	refreshModels func(_ jujuclient.ClientStore, controller string) error
-	store         jujuclient.ClientStore
-	EncodedData   string
+	apiOpen        api.OpenFunc
+	listModelsFunc func(_ jujuclient.ClientStore, controller, user string) ([]base.UserModel, error)
+	store          jujuclient.ClientStore
+	EncodedData    string
 }
 
 var usageRegisterSummary = `
@@ -102,11 +104,12 @@ func (c *registerCommand) Init(args []string) error {
 
 func (c *registerCommand) Run(ctx *cmd.Context) error {
 
-	registrationParams, err := c.getParameters(ctx)
+	store := modelcmd.QualifyingClientStore{c.store}
+	registrationParams, err := c.getParameters(ctx, store)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	_, err = c.store.ControllerByName(registrationParams.controllerName)
+	_, err = store.ControllerByName(registrationParams.controllerName)
 	if err == nil {
 		return errors.AlreadyExistsf("controller %q", registrationParams.controllerName)
 	} else if !errors.IsNotFound(err) {
@@ -159,7 +162,7 @@ func (c *registerCommand) Run(ctx *cmd.Context) error {
 		ControllerUUID: responsePayload.ControllerUUID,
 		CACert:         responsePayload.CACert,
 	}
-	if err := c.store.UpdateController(registrationParams.controllerName, controllerDetails); err != nil {
+	if err := store.UpdateController(registrationParams.controllerName, controllerDetails); err != nil {
 		return errors.Trace(err)
 	}
 	macaroonJSON, err := responsePayload.Macaroon.MarshalJSON()
@@ -170,16 +173,27 @@ func (c *registerCommand) Run(ctx *cmd.Context) error {
 		User:     registrationParams.userTag.Canonical(),
 		Macaroon: string(macaroonJSON),
 	}
-	if err := c.store.UpdateAccount(registrationParams.controllerName, accountDetails); err != nil {
+	if err := store.UpdateAccount(registrationParams.controllerName, accountDetails); err != nil {
 		return errors.Trace(err)
 	}
 
 	// Log into the controller to verify the credentials, and
-	// refresh the connection information.
-	if err := c.refreshModels(c.store, registrationParams.controllerName); err != nil {
+	// list the models available.
+	models, err := c.listModelsFunc(store, registrationParams.controllerName, accountDetails.User)
+	if err != nil {
 		return errors.Trace(err)
 	}
-	if err := c.store.SetCurrentController(registrationParams.controllerName); err != nil {
+	for _, model := range models {
+		owner := names.NewUserTag(model.Owner)
+		if err := store.UpdateModel(
+			registrationParams.controllerName,
+			jujuclient.JoinOwnerModelName(owner, model.Name),
+			jujuclient.ModelDetails{model.UUID},
+		); err != nil {
+			return errors.Annotate(err, "storing model details")
+		}
+	}
+	if err := store.SetCurrentController(registrationParams.controllerName); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -187,27 +201,31 @@ func (c *registerCommand) Run(ctx *cmd.Context) error {
 		ctx.Stderr, "\nWelcome, %s. You are now logged into %q.\n",
 		registrationParams.userTag.Id(), registrationParams.controllerName,
 	)
-	return c.maybeSetCurrentModel(ctx, registrationParams.controllerName)
+	return c.maybeSetCurrentModel(ctx, store, registrationParams.controllerName, accountDetails.User, models)
 }
 
-func (c *registerCommand) maybeSetCurrentModel(ctx *cmd.Context, controllerName string) error {
-	models, err := c.store.AllModels(controllerName)
-	if errors.IsNotFound(err) {
+func (c *registerCommand) listModels(store jujuclient.ClientStore, controllerName, userName string) ([]base.UserModel, error) {
+	api, err := c.NewAPIRoot(store, controllerName, "")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer api.Close()
+	mm := modelmanager.NewClient(api)
+	return mm.ListModels(userName)
+}
+
+func (c *registerCommand) maybeSetCurrentModel(ctx *cmd.Context, store jujuclient.ClientStore, controllerName, userName string, models []base.UserModel) error {
+	if len(models) == 0 {
 		fmt.Fprintf(ctx.Stderr, "\n%s\n\n", errNoModels.Error())
 		return nil
-	} else if err != nil {
-		return errors.Trace(err)
 	}
 
 	// If we get to here, there is at least one model.
 	if len(models) == 1 {
 		// There is exactly one model shared,
 		// so set it as the current model.
-		var modelName string
-		for modelName = range models {
-			// Loop exists only to obtain one and only key.
-		}
-		err := c.store.SetCurrentModel(controllerName, modelName)
+		modelName := models[0].Name
+		err := store.SetCurrentModel(controllerName, modelName)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -217,11 +235,22 @@ func (c *registerCommand) maybeSetCurrentModel(ctx *cmd.Context, controllerName 
 There are %d models available. Use "juju switch" to select
 one of them:
 `, len(models))
-		modelNames := make(set.Strings)
-		for modelName := range models {
-			modelNames.Add(modelName)
+		user := names.NewUserTag(userName)
+		ownerModelNames := make(set.Strings)
+		otherModelNames := make(set.Strings)
+		for _, model := range models {
+			if model.Owner == userName {
+				ownerModelNames.Add(model.Name)
+				continue
+			}
+			owner := names.NewUserTag(model.Owner)
+			modelName := ownerQualifiedModelName(model.Name, owner, user)
+			otherModelNames.Add(modelName)
 		}
-		for _, modelName := range modelNames.SortedValues() {
+		for _, modelName := range ownerModelNames.SortedValues() {
+			fmt.Fprintf(ctx.Stderr, "  - juju switch %s\n", modelName)
+		}
+		for _, modelName := range otherModelNames.SortedValues() {
 			fmt.Fprintf(ctx.Stderr, "  - juju switch %s\n", modelName)
 		}
 		fmt.Fprintln(ctx.Stderr)
@@ -240,7 +269,7 @@ type registrationParams struct {
 
 // getParameters gets all of the parameters required for registering, prompting
 // the user as necessary.
-func (c *registerCommand) getParameters(ctx *cmd.Context) (*registrationParams, error) {
+func (c *registerCommand) getParameters(ctx *cmd.Context, store jujuclient.ClientStore) (*registrationParams, error) {
 
 	// Decode key, username, controller addresses from the string supplied
 	// on the command line.
@@ -263,7 +292,7 @@ func (c *registerCommand) getParameters(ctx *cmd.Context) (*registrationParams, 
 	copy(params.key[:], info.SecretKey)
 
 	// Prompt the user for the controller name.
-	controllerName, err := c.promptControllerName(info.ControllerName, ctx.Stderr, ctx.Stdin)
+	controllerName, err := c.promptControllerName(store, info.ControllerName, ctx.Stderr, ctx.Stdin)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -367,8 +396,8 @@ const errControllerConflicts = `WARNING: The controller proposed %q which clashe
 
 `
 
-func (c *registerCommand) promptControllerName(suggestedName string, stderr io.Writer, stdin io.Reader) (string, error) {
-	_, err := c.store.ControllerByName(suggestedName)
+func (c *registerCommand) promptControllerName(store jujuclient.ClientStore, suggestedName string, stderr io.Writer, stdin io.Reader) (string, error) {
+	_, err := store.ControllerByName(suggestedName)
 	if err == nil {
 		fmt.Fprintf(stderr, errControllerConflicts, suggestedName)
 		suggestedName = ""

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -23,6 +23,7 @@ import (
 	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/jujuclient"
@@ -32,13 +33,14 @@ import (
 
 type RegisterSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
-	apiConnection               *mockAPIConnection
-	store                       *jujuclienttesting.MemStore
-	apiOpenError                error
-	refreshModels               func(jujuclient.ClientStore, string) error
-	refreshModelsControllerName string
-	server                      *httptest.Server
-	httpHandler                 http.Handler
+	apiConnection            *mockAPIConnection
+	store                    *jujuclienttesting.MemStore
+	apiOpenError             error
+	listModels               func(jujuclient.ClientStore, string, string) ([]base.UserModel, error)
+	listModelsControllerName string
+	listModelsUserName       string
+	server                   *httptest.Server
+	httpHandler              http.Handler
 }
 
 var _ = gc.Suite(&RegisterSuite{})
@@ -58,10 +60,12 @@ func (s *RegisterSuite) SetUpTest(c *gc.C) {
 		controllerTag: testing.ModelTag,
 		addr:          serverURL.Host,
 	}
-	s.refreshModelsControllerName = ""
-	s.refreshModels = func(store jujuclient.ClientStore, controllerName string) error {
-		s.refreshModelsControllerName = controllerName
-		return nil
+	s.listModelsControllerName = ""
+	s.listModelsUserName = ""
+	s.listModels = func(_ jujuclient.ClientStore, controllerName, userName string) ([]base.UserModel, error) {
+		s.listModelsControllerName = controllerName
+		s.listModelsUserName = userName
+		return nil, nil
 	}
 
 	s.store = jujuclienttesting.NewMemStore()
@@ -82,7 +86,7 @@ func (s *RegisterSuite) apiOpen(info *api.Info, opts api.DialOpts) (api.Connecti
 }
 
 func (s *RegisterSuite) run(c *gc.C, stdin io.Reader, args ...string) (*cmd.Context, error) {
-	command := controller.NewRegisterCommandForTest(s.apiOpen, s.refreshModels, s.store)
+	command := controller.NewRegisterCommandForTest(s.apiOpen, s.listModels, s.store)
 	err := testing.InitCommand(command, args)
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := testing.Context(c)
@@ -143,7 +147,8 @@ func (s *RegisterSuite) TestInit(c *gc.C) {
 
 func (s *RegisterSuite) TestRegister(c *gc.C) {
 	ctx := s.testRegister(c, "")
-	c.Assert(s.refreshModelsControllerName, gc.Equals, "controller-name")
+	c.Assert(s.listModelsControllerName, gc.Equals, "controller-name")
+	c.Assert(s.listModelsUserName, gc.Equals, "bob@local")
 	stderr := testing.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `
 Enter a name for this controller [controller-name]: 
@@ -160,29 +165,31 @@ of a model to grant access to that model with "juju grant".
 }
 
 func (s *RegisterSuite) TestRegisterOneModel(c *gc.C) {
-	s.refreshModels = func(store jujuclient.ClientStore, controller string) error {
-		err := store.UpdateModel(controller, "theoneandonly", jujuclient.ModelDetails{
-			ModelUUID: "df136476-12e9-11e4-8a70-b2227cce2b54",
-		})
-		c.Assert(err, jc.ErrorIsNil)
-		return nil
+	s.listModels = func(_ jujuclient.ClientStore, controllerName, userName string) ([]base.UserModel, error) {
+		return []base.UserModel{{
+			Name:  "theoneandonly",
+			Owner: "bob@local",
+			UUID:  "df136476-12e9-11e4-8a70-b2227cce2b54",
+		}}, nil
 	}
 	s.testRegister(c, "")
 	c.Assert(
 		s.store.Models["controller-name"].CurrentModel,
-		gc.Equals, "theoneandonly",
+		gc.Equals, "bob@local/theoneandonly",
 	)
 }
 
 func (s *RegisterSuite) TestRegisterMultipleModels(c *gc.C) {
-	s.refreshModels = func(store jujuclient.ClientStore, controller string) error {
-		for _, name := range [...]string{"model1", "model2"} {
-			err := store.UpdateModel(controller, name, jujuclient.ModelDetails{
-				ModelUUID: "df136476-12e9-11e4-8a70-b2227cce2b54",
-			})
-			c.Assert(err, jc.ErrorIsNil)
-		}
-		return nil
+	s.listModels = func(_ jujuclient.ClientStore, controllerName, userName string) ([]base.UserModel, error) {
+		return []base.UserModel{{
+			Name:  "model1",
+			Owner: "bob@local",
+			UUID:  "df136476-12e9-11e4-8a70-b2227cce2b54",
+		}, {
+			Name:  "model2",
+			Owner: "bob@local",
+			UUID:  "df136476-12e9-11e4-8a70-b2227cce2b55",
+		}}, nil
 	}
 	ctx := s.testRegister(c, "")
 
@@ -320,12 +327,12 @@ func (s *RegisterSuite) TestProposedControllerNameExists(c *gc.C) {
 		CACert:         testing.CACert,
 	})
 
-	s.refreshModels = func(store jujuclient.ClientStore, controller string) error {
-		err := store.UpdateModel(controller, "controller-name", jujuclient.ModelDetails{
-			ModelUUID: "df136476-12e9-11e4-8a70-b2227cce2b54",
-		})
-		c.Assert(err, jc.ErrorIsNil)
-		return nil
+	s.listModels = func(_ jujuclient.ClientStore, controllerName, userName string) ([]base.UserModel, error) {
+		return []base.UserModel{{
+			Name:  "model-name",
+			Owner: "bob@local",
+			UUID:  "df136476-12e9-11e4-8a70-b2227cce2b54",
+		}}, nil
 	}
 
 	ctx := s.testRegister(c, "you must specify a non-empty controller name")

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -168,14 +168,14 @@ func (s *RegisterSuite) TestRegisterOneModel(c *gc.C) {
 	s.listModels = func(_ jujuclient.ClientStore, controllerName, userName string) ([]base.UserModel, error) {
 		return []base.UserModel{{
 			Name:  "theoneandonly",
-			Owner: "bob@local",
+			Owner: "carol@local",
 			UUID:  "df136476-12e9-11e4-8a70-b2227cce2b54",
 		}}, nil
 	}
 	s.testRegister(c, "")
 	c.Assert(
 		s.store.Models["controller-name"].CurrentModel,
-		gc.Equals, "bob@local/theoneandonly",
+		gc.Equals, "carol@local/theoneandonly",
 	)
 }
 

--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -52,8 +52,8 @@ func (s *DestroySuite) SetUpTest(c *gc.C) {
 	s.store.Controllers["test1"] = jujuclient.ControllerDetails{ControllerUUID: "test1-uuid"}
 	s.store.Models["test1"] = &jujuclient.ControllerModels{
 		Models: map[string]jujuclient.ModelDetails{
-			"test1": {"test1-uuid"},
-			"test2": {"test2-uuid"},
+			"admin@local/test1": {"test1-uuid"},
+			"admin@local/test2": {"test2-uuid"},
 		},
 	}
 	s.store.Accounts["test1"] = jujuclient.AccountDetails{
@@ -99,7 +99,7 @@ func (s *DestroySuite) TestDestroyUnknownArgument(c *gc.C) {
 
 func (s *DestroySuite) TestDestroyUnknownModel(c *gc.C) {
 	_, err := s.runDestroyCommand(c, "foo")
-	c.Assert(err, gc.ErrorMatches, `cannot read model info: model test1:foo not found`)
+	c.Assert(err, gc.ErrorMatches, `cannot read model info: model test1:admin@local/foo not found`)
 }
 
 func (s *DestroySuite) TestDestroyCannotConnectToAPI(c *gc.C) {
@@ -107,34 +107,34 @@ func (s *DestroySuite) TestDestroyCannotConnectToAPI(c *gc.C) {
 	_, err := s.runDestroyCommand(c, "test2", "-y")
 	c.Assert(err, gc.ErrorMatches, "cannot destroy model: connection refused")
 	c.Check(c.GetTestLog(), jc.Contains, "failed to destroy model \"test2\"")
-	checkModelExistsInStore(c, "test1:test2", s.store)
+	checkModelExistsInStore(c, "test1:admin@local/test2", s.store)
 }
 
 func (s *DestroySuite) TestSystemDestroyFails(c *gc.C) {
 	_, err := s.runDestroyCommand(c, "test1", "-y")
 	c.Assert(err, gc.ErrorMatches, `"test1" is a controller; use 'juju destroy-controller' to destroy it`)
-	checkModelExistsInStore(c, "test1:test1", s.store)
+	checkModelExistsInStore(c, "test1:admin@local/test1", s.store)
 }
 
 func (s *DestroySuite) TestDestroy(c *gc.C) {
-	checkModelExistsInStore(c, "test1:test2", s.store)
+	checkModelExistsInStore(c, "test1:admin@local/test2", s.store)
 	_, err := s.runDestroyCommand(c, "test2", "-y")
 	c.Assert(err, jc.ErrorIsNil)
-	checkModelRemovedFromStore(c, "test1:test2", s.store)
+	checkModelRemovedFromStore(c, "test1:admin@local/test2", s.store)
 }
 
 func (s *DestroySuite) TestFailedDestroyModel(c *gc.C) {
 	s.api.err = errors.New("permission denied")
 	_, err := s.runDestroyCommand(c, "test1:test2", "-y")
 	c.Assert(err, gc.ErrorMatches, "cannot destroy model: permission denied")
-	checkModelExistsInStore(c, "test1:test2", s.store)
+	checkModelExistsInStore(c, "test1:admin@local/test2", s.store)
 }
 
 func (s *DestroySuite) resetModel(c *gc.C) {
 	s.store.Models["test1"] = &jujuclient.ControllerModels{
 		Models: map[string]jujuclient.ModelDetails{
-			"test1": {"test1-uuid"},
-			"test2": {"test2-uuid"},
+			"admin@local/test1": {"test1-uuid"},
+			"admin@local/test2": {"test2-uuid"},
 		},
 	}
 }
@@ -156,7 +156,7 @@ func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 		c.Fatalf("command took too long")
 	}
 	c.Check(testing.Stdout(ctx), gc.Matches, "WARNING!.*test2(.|\n)*")
-	checkModelExistsInStore(c, "test1:test1", s.store)
+	checkModelExistsInStore(c, "test1:admin@local/test1", s.store)
 
 	// EOF on stdin: equivalent to answering no.
 	stdin.Reset()
@@ -169,7 +169,7 @@ func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 		c.Fatalf("command took too long")
 	}
 	c.Check(testing.Stdout(ctx), gc.Matches, "WARNING!.*test2(.|\n)*")
-	checkModelExistsInStore(c, "test1:test2", s.store)
+	checkModelExistsInStore(c, "test1:admin@local/test2", s.store)
 
 	for _, answer := range []string{"y", "Y", "yes", "YES"} {
 		stdin.Reset()
@@ -182,7 +182,7 @@ func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 		case <-time.After(testing.LongWait):
 			c.Fatalf("command took too long")
 		}
-		checkModelRemovedFromStore(c, "test1:test2", s.store)
+		checkModelRemovedFromStore(c, "test1:admin@local/test2", s.store)
 
 		// Add the test2 model back into the store for the next test
 		s.resetModel(c)

--- a/cmd/juju/model/dump_test.go
+++ b/cmd/juju/model/dump_test.go
@@ -52,11 +52,11 @@ func (s *DumpCommandSuite) SetUpTest(c *gc.C) {
 	s.store.Accounts["testing"] = jujuclient.AccountDetails{
 		User: "admin@local",
 	}
-	err := s.store.UpdateModel("testing", "mymodel", jujuclient.ModelDetails{
+	err := s.store.UpdateModel("testing", "admin@local/mymodel", jujuclient.ModelDetails{
 		testing.ModelTag.Id(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	s.store.Models["testing"].CurrentModel = "mymodel"
+	s.store.Models["testing"].CurrentModel = "admin@local/mymodel"
 }
 
 func (s *DumpCommandSuite) TestDump(c *gc.C) {

--- a/cmd/juju/model/grantrevoke_test.go
+++ b/cmd/juju/model/grantrevoke_test.go
@@ -47,11 +47,11 @@ func (s *grantRevokeSuite) SetUpTest(c *gc.C) {
 	s.store.Models = map[string]*jujuclient.ControllerModels{
 		controllerName: {
 			Models: map[string]jujuclient.ModelDetails{
-				"foo":    jujuclient.ModelDetails{fooModelUUID},
-				"bar":    jujuclient.ModelDetails{barModelUUID},
-				"baz":    jujuclient.ModelDetails{bazModelUUID},
-				"model1": jujuclient.ModelDetails{model1ModelUUID},
-				"model2": jujuclient.ModelDetails{model2ModelUUID},
+				"bob@local/foo":    jujuclient.ModelDetails{fooModelUUID},
+				"bob@local/bar":    jujuclient.ModelDetails{barModelUUID},
+				"bob@local/baz":    jujuclient.ModelDetails{bazModelUUID},
+				"bob@local/model1": jujuclient.ModelDetails{model1ModelUUID},
+				"bob@local/model2": jujuclient.ModelDetails{model2ModelUUID},
 			},
 		},
 	}

--- a/cmd/juju/model/show_test.go
+++ b/cmd/juju/model/show_test.go
@@ -120,11 +120,11 @@ func (s *ShowCommandSuite) SetUpTest(c *gc.C) {
 	s.store.Accounts["testing"] = jujuclient.AccountDetails{
 		User: "admin@local",
 	}
-	err := s.store.UpdateModel("testing", "mymodel", jujuclient.ModelDetails{
+	err := s.store.UpdateModel("testing", "admin@local/mymodel", jujuclient.ModelDetails{
 		testing.ModelTag.Id(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	s.store.Models["testing"].CurrentModel = "mymodel"
+	s.store.Models["testing"].CurrentModel = "admin@local/mymodel"
 }
 
 func (s *ShowCommandSuite) TestShow(c *gc.C) {

--- a/cmd/juju/user/add_test.go
+++ b/cmd/juju/user/add_test.go
@@ -146,7 +146,7 @@ Please send this command to foobar:
 type mockModelApi struct{}
 
 func (m *mockModelApi) ListModels(user string) ([]base.UserModel, error) {
-	return []base.UserModel{{Name: "model", UUID: "modeluuid"}}, nil
+	return []base.UserModel{{Name: "model", UUID: "modeluuid", Owner: "current-user@local"}}, nil
 }
 
 func (m *mockModelApi) Close() error {

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -212,7 +212,9 @@ func (c *JujuCommandBase) RefreshModels(store jujuclient.ClientStore, controller
 	}
 	for _, model := range models {
 		modelDetails := jujuclient.ModelDetails{model.UUID}
-		if err := store.UpdateModel(controllerName, model.Name, modelDetails); err != nil {
+		owner := names.NewUserTag(model.Owner)
+		modelName := jujuclient.JoinOwnerModelName(owner, model.Name)
+		if err := store.UpdateModel(controllerName, modelName, modelDetails); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/cmd/modelcmd/clientstore.go
+++ b/cmd/modelcmd/clientstore.go
@@ -1,0 +1,79 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelcmd
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/jujuclient"
+)
+
+// QualifyingClientStore wraps a jujuclient.ClientStore, modifying
+// model-related methods such that they accept unqualified model
+// names, and automatically qualify them with the logged-in user
+// name as necessary.
+type QualifyingClientStore struct {
+	jujuclient.ClientStore
+}
+
+// QualifiedModelName returns a Qualified model name, given either
+// an unqualified or qualified model name. If the input is a
+// fully qualified name, it is returned untouched; otherwise it is
+// return qualified with the logged-in user name.
+func (s QualifyingClientStore) QualifiedModelName(controllerName, modelName string) (string, error) {
+	if !jujuclient.IsQualifiedModelName(modelName) {
+		details, err := s.ClientStore.AccountDetails(controllerName)
+		if err != nil {
+			return "", errors.Annotate(err, "getting account details for qualifying model name")
+		}
+		owner := names.NewUserTag(details.User)
+		modelName = jujuclient.JoinOwnerModelName(owner, modelName)
+	} else {
+		unqualifiedModelName, owner, err := jujuclient.SplitModelName(modelName)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		// Make sure that the user name is canonical.
+		owner = names.NewUserTag(owner.Canonical())
+		modelName = jujuclient.JoinOwnerModelName(owner, unqualifiedModelName)
+	}
+	return modelName, nil
+}
+
+// Implements jujuclient.ModelGetter.
+func (s QualifyingClientStore) ModelByName(controllerName, modelName string) (*jujuclient.ModelDetails, error) {
+	modelName, err := s.QualifiedModelName(controllerName, modelName)
+	if err != nil {
+		return nil, errors.Annotatef(err, "getting model %q", modelName)
+	}
+	return s.ClientStore.ModelByName(controllerName, modelName)
+}
+
+// Implements jujuclient.ModelUpdater.
+func (s QualifyingClientStore) UpdateModel(controllerName, modelName string, details jujuclient.ModelDetails) error {
+	modelName, err := s.QualifiedModelName(controllerName, modelName)
+	if err != nil {
+		return errors.Annotatef(err, "updating model %q", modelName)
+	}
+	return s.ClientStore.UpdateModel(controllerName, modelName, details)
+}
+
+// Implements jujuclient.ModelUpdater.
+func (s QualifyingClientStore) SetCurrentModel(controllerName, modelName string) error {
+	modelName, err := s.QualifiedModelName(controllerName, modelName)
+	if err != nil {
+		return errors.Annotatef(err, "setting current model to %q", modelName)
+	}
+	return s.ClientStore.SetCurrentModel(controllerName, modelName)
+}
+
+// Implements jujuclient.ModelRemover.
+func (s QualifyingClientStore) RemoveModel(controllerName, modelName string) error {
+	modelName, err := s.QualifiedModelName(controllerName, modelName)
+	if err != nil {
+		return errors.Annotatef(err, "removing model %q", modelName)
+	}
+	return s.ClientStore.RemoveModel(controllerName, modelName)
+}

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -239,8 +239,9 @@ func (w *sysCommandWrapper) Init(args []string) error {
 	store := w.ClientStore()
 	if store == nil {
 		store = jujuclient.NewFileClientStore()
-		w.SetClientStore(store)
 	}
+	store = QualifyingClientStore{store}
+	w.SetClientStore(store)
 	if w.setFlags {
 		if w.controllerName == "" && w.useDefaultControllerName {
 			currentController, err := store.CurrentController()

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -275,8 +275,9 @@ func (w *modelCommandWrapper) Init(args []string) error {
 	store := w.ClientStore()
 	if store == nil {
 		store = jujuclient.NewFileClientStore()
-		w.SetClientStore(store)
 	}
+	store = QualifyingClientStore{store}
+	w.SetClientStore(store)
 	if !w.skipFlags {
 		if w.modelName == "" && w.useDefaultModel {
 			// Look for the default.

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -54,34 +54,34 @@ func (s *ModelCommandSuite) TestGetCurrentModelCurrentControllerNoCurrentModel(c
 }
 
 func (s *ModelCommandSuite) TestGetCurrentModelCurrentControllerModel(c *gc.C) {
-	err := s.store.UpdateModel("foo", "mymodel", jujuclient.ModelDetails{"uuid"})
+	err := s.store.UpdateModel("foo", "admin@local/mymodel", jujuclient.ModelDetails{"uuid"})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.store.SetCurrentModel("foo", "mymodel")
+	err = s.store.SetCurrentModel("foo", "admin@local/mymodel")
 	c.Assert(err, jc.ErrorIsNil)
 
 	env, err := modelcmd.GetCurrentModel(s.store)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env, gc.Equals, "foo:mymodel")
+	c.Assert(env, gc.Equals, "foo:admin@local/mymodel")
 }
 
 func (s *ModelCommandSuite) TestGetCurrentModelJujuEnvSet(c *gc.C) {
-	os.Setenv(osenv.JujuModelEnvKey, "magic")
+	os.Setenv(osenv.JujuModelEnvKey, "admin@local/magic")
 	env, err := modelcmd.GetCurrentModel(s.store)
-	c.Assert(env, gc.Equals, "magic")
+	c.Assert(env, gc.Equals, "admin@local/magic")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *ModelCommandSuite) TestGetCurrentModelBothSet(c *gc.C) {
-	os.Setenv(osenv.JujuModelEnvKey, "magic")
+	os.Setenv(osenv.JujuModelEnvKey, "admin@local/magic")
 
-	err := s.store.UpdateModel("foo", "mymodel", jujuclient.ModelDetails{"uuid"})
+	err := s.store.UpdateModel("foo", "admin@local/mymodel", jujuclient.ModelDetails{"uuid"})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.store.SetCurrentModel("foo", "mymodel")
+	err = s.store.SetCurrentModel("foo", "admin@local/mymodel")
 	c.Assert(err, jc.ErrorIsNil)
 
 	env, err := modelcmd.GetCurrentModel(s.store)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env, gc.Equals, "magic")
+	c.Assert(env, gc.Equals, "admin@local/magic")
 }
 
 func (s *ModelCommandSuite) TestModelCommandInitExplicit(c *gc.C) {
@@ -95,11 +95,11 @@ func (s *ModelCommandSuite) TestModelCommandInitExplicitLongForm(c *gc.C) {
 }
 
 func (s *ModelCommandSuite) TestModelCommandInitEnvFile(c *gc.C) {
-	err := s.store.UpdateModel("foo", "mymodel", jujuclient.ModelDetails{"uuid"})
+	err := s.store.UpdateModel("foo", "admin@local/mymodel", jujuclient.ModelDetails{"uuid"})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.store.SetCurrentModel("foo", "mymodel")
+	err = s.store.SetCurrentModel("foo", "admin@local/mymodel")
 	c.Assert(err, jc.ErrorIsNil)
-	s.testEnsureModelName(c, "mymodel")
+	s.testEnsureModelName(c, "admin@local/mymodel")
 }
 
 func (s *ModelCommandSuite) TestBootstrapContext(c *gc.C) {
@@ -191,7 +191,7 @@ func (s *macaroonLoginSuite) SetUpTest(c *gc.C) {
 	s.MacaroonSuite.AddModelUser(c, testUser)
 
 	s.controllerName = "my-controller"
-	s.modelName = "my-model"
+	s.modelName = testUser + "/my-model"
 	modelTag := names.NewModelTag(s.State.ModelUUID())
 	apiInfo := s.APIInfo(c)
 

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -5,6 +5,7 @@ package bootstrap
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs"
@@ -112,6 +113,10 @@ func decorateAndWriteInfo(
 	details prepareDetails,
 	controllerName, modelName string,
 ) error {
+	qualifiedModelName := jujuclient.JoinOwnerModelName(
+		names.NewUserTag(details.AccountDetails.User),
+		modelName,
+	)
 	if err := store.UpdateController(controllerName, details.ControllerDetails); err != nil {
 		return errors.Trace(err)
 	}
@@ -121,10 +126,10 @@ func decorateAndWriteInfo(
 	if err := store.UpdateAccount(controllerName, details.AccountDetails); err != nil {
 		return errors.Trace(err)
 	}
-	if err := store.UpdateModel(controllerName, modelName, details.ModelDetails); err != nil {
+	if err := store.UpdateModel(controllerName, qualifiedModelName, details.ModelDetails); err != nil {
 		return errors.Trace(err)
 	}
-	if err := store.SetCurrentModel(controllerName, modelName); err != nil {
+	if err := store.SetCurrentModel(controllerName, qualifiedModelName); err != nil {
 		return errors.Trace(err)
 	}
 	return nil

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -103,7 +103,7 @@ func (s *OpenSuite) TestUpdateEnvInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(foundController.ControllerUUID, gc.Not(gc.Equals), "")
 	c.Assert(foundController.CACert, gc.Not(gc.Equals), "")
-	foundModel, err := store.ModelByName("controller-name", "admin-model")
+	foundModel, err := store.ModelByName("controller-name", "admin@local/admin-model")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(foundModel, jc.DeepEquals, &jujuclient.ModelDetails{
 		ModelUUID: cfg.UUID(),

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -88,9 +88,9 @@ func (s *cmdControllerSuite) TestAddModelNormalUser(c *gc.C) {
 	s.createModelNormalUser(c, "new-model", false)
 	context := s.run(c, "list-models", "--all")
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"MODEL        OWNER        STATUS     LAST CONNECTION\n"+
-		"controller*  admin@local  available  just now\n"+
-		"new-model    test@local   available  never connected\n"+
+		"MODEL              OWNER        STATUS     LAST CONNECTION\n"+
+		"admin/controller*  admin@local  available  just now\n"+
+		"test/new-model     test@local   available  never connected\n"+
 		"\n")
 }
 
@@ -163,7 +163,7 @@ Added 'new-model' model with credential 'cred' for user 'admin'
 	// to the api server.
 	accountDetails, err := s.ControllerStore.AccountDetails("kontroll")
 	c.Assert(err, jc.ErrorIsNil)
-	modelDetails, err := s.ControllerStore.ModelByName("kontroll", "new-model")
+	modelDetails, err := s.ControllerStore.ModelByName("kontroll", "admin@local/new-model")
 	c.Assert(err, jc.ErrorIsNil)
 	api, err := juju.NewAPIConnection(juju.NewAPIConnectionParams{
 		Store:          s.ControllerStore,

--- a/featuretests/cmd_juju_login_test.go
+++ b/featuretests/cmd_juju_login_test.go
@@ -5,6 +5,7 @@ package featuretests
 
 import (
 	"io"
+	"os"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -13,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/commands"
+	"github.com/juju/juju/juju/osenv"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
@@ -20,6 +22,11 @@ import (
 
 type cmdLoginSuite struct {
 	jujutesting.JujuConnSuite
+}
+
+func (s *cmdLoginSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	os.Setenv(osenv.JujuModelEnvKey, "")
 }
 
 func (s *cmdLoginSuite) run(c *gc.C, stdin io.Reader, args ...string) *cmd.Context {

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -129,7 +129,7 @@ func (s *NewAPIClientSuite) TestWithBootstrapConfig(c *gc.C) {
 		return expectState, nil
 	}
 
-	st, err := newAPIConnectionFromNames(c, "noconfig", "admin", store, apiOpen)
+	st, err := newAPIConnectionFromNames(c, "noconfig", "admin@local/admin", store, apiOpen)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st, gc.Equals, expectState)
 	c.Assert(called, gc.Equals, 1)
@@ -145,7 +145,7 @@ func (s *NewAPIClientSuite) TestWithBootstrapConfig(c *gc.C) {
 
 	// If APIHostPorts haven't changed, then the store won't be updated.
 	stubStore := jujuclienttesting.WrapClientStore(store)
-	st, err = newAPIConnectionFromNames(c, "noconfig", "admin", stubStore, apiOpen)
+	st, err = newAPIConnectionFromNames(c, "noconfig", "admin@local/admin", stubStore, apiOpen)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st, gc.Equals, expectState)
 	c.Assert(called, gc.Equals, 2)
@@ -206,7 +206,7 @@ func (s *NewAPIClientSuite) TestWithRedirect(c *gc.C) {
 		return nil, fmt.Errorf("OpenAPI called too many times")
 	}
 
-	st0, err := newAPIConnectionFromNames(c, "ctl", "admin", store, redirOpen)
+	st0, err := newAPIConnectionFromNames(c, "ctl", "admin@local/admin", store, redirOpen)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(openCount, gc.Equals, 2)
 	st := st0.(*mockAPIState)
@@ -260,7 +260,7 @@ func newClientStore(c *gc.C, controllerName string) *jujuclienttesting.MemStore 
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = store.UpdateModel(controllerName, "admin", jujuclient.ModelDetails{
+	err = store.UpdateModel(controllerName, "admin@local/admin", jujuclient.ModelDetails{
 		fakeUUID,
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/jujuclient/accounts.go
+++ b/jujuclient/accounts.go
@@ -63,8 +63,8 @@ type accountsCollection struct {
 	ControllerAccounts map[string]AccountDetails `yaml:"controllers"`
 }
 
-// TODO(axw) 2016-07-14 #NNN
-// Drop this code once we get to 2.0-beta13.
+// TODO(axw) 2016-07-14 #1603841
+// Drop this code once we get to 2.0.
 func migrateLegacyAccounts(data []byte) error {
 	type legacyControllerAccounts struct {
 		Accounts       map[string]AccountDetails `yaml:"accounts"`

--- a/jujuclient/models.go
+++ b/jujuclient/models.go
@@ -4,11 +4,14 @@
 package jujuclient
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils"
+	"gopkg.in/juju/names.v2"
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/juju/osenv"
@@ -76,8 +79,8 @@ type ControllerModels struct {
 	CurrentModel string `yaml:"current-model,omitempty"`
 }
 
-// TODO(axw) 2016-07-14 #NNN
-// Drop this code once we get to 2.0-beta13.
+// TODO(axw) 2016-07-14 #1603841
+// Drop this code once we get to 2.0.
 func migrateLegacyModels(data []byte) error {
 	accounts, err := ReadAccountsFile(JujuAccountsPath())
 	if err != nil {
@@ -121,4 +124,31 @@ func migrateLegacyModels(data []byte) error {
 		return WriteModelsFile(result)
 	}
 	return nil
+}
+
+// JoinOwnerModelName returns a model name qualified with the model owner.
+func JoinOwnerModelName(owner names.UserTag, modelName string) string {
+	return fmt.Sprintf("%s/%s", owner.Canonical(), modelName)
+}
+
+// IsQualifiedModelName returns true if the provided model name is qualified
+// with an owner. The name is assumed to be either a valid qualified model
+// name, or a valid unqualified model name.
+func IsQualifiedModelName(name string) bool {
+	return strings.ContainsRune(name, '/')
+}
+
+// SplitModelName splits a qualified model name into the model and owner
+// name components.
+func SplitModelName(name string) (string, names.UserTag, error) {
+	i := strings.IndexRune(name, '/')
+	if i < 0 {
+		return "", names.UserTag{}, errors.NotValidf("unqualified model name %q", name)
+	}
+	owner := name[:i]
+	if !names.IsValidUser(owner) {
+		return "", names.UserTag{}, errors.NotValidf("user name %q", owner)
+	}
+	name = name[i+1:]
+	return name, names.NewUserTag(owner), nil
 }

--- a/jujuclient/models_test.go
+++ b/jujuclient/models_test.go
@@ -31,28 +31,28 @@ func (s *ModelsSuite) SetUpTest(c *gc.C) {
 func (s *ModelsSuite) TestModelByNameNoFile(c *gc.C) {
 	err := os.Remove(jujuclient.JujuModelsPath())
 	c.Assert(err, jc.ErrorIsNil)
-	details, err := s.store.ModelByName("not-found", "admin")
+	details, err := s.store.ModelByName("not-found", "admin@local/admin")
 	c.Assert(err, gc.ErrorMatches, "models for controller not-found not found")
 	c.Assert(details, gc.IsNil)
 }
 
 func (s *ModelsSuite) TestModelByNameControllerNotFound(c *gc.C) {
-	details, err := s.store.ModelByName("not-found", "admin")
+	details, err := s.store.ModelByName("not-found", "admin@local/admin")
 	c.Assert(err, gc.ErrorMatches, "models for controller not-found not found")
 	c.Assert(details, gc.IsNil)
 }
 
 func (s *ModelsSuite) TestModelByNameModelNotFound(c *gc.C) {
-	details, err := s.store.ModelByName("kontroll", "not-found")
-	c.Assert(err, gc.ErrorMatches, "model kontroll:not-found not found")
+	details, err := s.store.ModelByName("kontroll", "admin@local/not-found")
+	c.Assert(err, gc.ErrorMatches, "model kontroll:admin@local/not-found not found")
 	c.Assert(details, gc.IsNil)
 }
 
 func (s *ModelsSuite) TestModelByName(c *gc.C) {
-	details, err := s.store.ModelByName("kontroll", "admin")
+	details, err := s.store.ModelByName("kontroll", "admin@local/admin")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(details, gc.NotNil)
-	c.Assert(*details, jc.DeepEquals, testControllerModels["kontroll"].Models["admin"])
+	c.Assert(*details, jc.DeepEquals, testControllerModels["kontroll"].Models["admin@local/admin"])
 }
 
 func (s *ModelsSuite) TestAllModelsNoFile(c *gc.C) {
@@ -72,7 +72,7 @@ func (s *ModelsSuite) TestAllModels(c *gc.C) {
 func (s *ModelsSuite) TestCurrentModel(c *gc.C) {
 	current, err := s.store.CurrentModel("kontroll")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(current, gc.Equals, "my-model")
+	c.Assert(current, gc.Equals, "admin@local/my-model")
 }
 
 func (s *ModelsSuite) TestCurrentModelNotSet(c *gc.C) {
@@ -86,44 +86,44 @@ func (s *ModelsSuite) TestCurrentModelControllerNotFound(c *gc.C) {
 }
 
 func (s *ModelsSuite) TestSetCurrentModelControllerNotFound(c *gc.C) {
-	err := s.store.SetCurrentModel("not-found", "admin")
+	err := s.store.SetCurrentModel("not-found", "admin@local/admin")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *ModelsSuite) TestSetCurrentModelModelNotFound(c *gc.C) {
-	err := s.store.SetCurrentModel("kontroll", "not-found")
+	err := s.store.SetCurrentModel("kontroll", "admin@local/not-found")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *ModelsSuite) TestSetCurrentModel(c *gc.C) {
-	err := s.store.SetCurrentModel("kontroll", "admin")
+	err := s.store.SetCurrentModel("kontroll", "admin@local/admin")
 	c.Assert(err, jc.ErrorIsNil)
 	all, err := jujuclient.ReadModelsFile(jujuclient.JujuModelsPath())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(all["kontroll"].CurrentModel, gc.Equals, "admin")
+	c.Assert(all["kontroll"].CurrentModel, gc.Equals, "admin@local/admin")
 }
 
 func (s *ModelsSuite) TestUpdateModelNewController(c *gc.C) {
 	testModelDetails := jujuclient.ModelDetails{"test.uuid"}
-	err := s.store.UpdateModel("new-controller", "new-model", testModelDetails)
+	err := s.store.UpdateModel("new-controller", "admin@local/new-model", testModelDetails)
 	c.Assert(err, jc.ErrorIsNil)
 	models, err := s.store.AllModels("new-controller")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(models, jc.DeepEquals, map[string]jujuclient.ModelDetails{
-		"new-model": testModelDetails,
+		"admin@local/new-model": testModelDetails,
 	})
 }
 
 func (s *ModelsSuite) TestUpdateModelExistingControllerAndModelNewModel(c *gc.C) {
 	testModelDetails := jujuclient.ModelDetails{"test.uuid"}
-	err := s.store.UpdateModel("kontroll", "new-model", testModelDetails)
+	err := s.store.UpdateModel("kontroll", "admin@local/new-model", testModelDetails)
 	c.Assert(err, jc.ErrorIsNil)
 	models, err := s.store.AllModels("kontroll")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(models, jc.DeepEquals, map[string]jujuclient.ModelDetails{
-		"admin":     kontrollAdminModelDetails,
-		"my-model":  kontrollMyModelModelDetails,
-		"new-model": testModelDetails,
+		"admin@local/admin":     kontrollAdminModelDetails,
+		"admin@local/my-model":  kontrollMyModelModelDetails,
+		"admin@local/new-model": testModelDetails,
 	})
 }
 
@@ -132,9 +132,9 @@ func (s *ModelsSuite) TestUpdateModelOverwrites(c *gc.C) {
 	for i := 0; i < 2; i++ {
 		// Twice so we exercise the code path of updating with
 		// identical details.
-		err := s.store.UpdateModel("kontroll", "admin", testModelDetails)
+		err := s.store.UpdateModel("kontroll", "admin@local/admin", testModelDetails)
 		c.Assert(err, jc.ErrorIsNil)
-		details, err := s.store.ModelByName("kontroll", "admin")
+		details, err := s.store.ModelByName("kontroll", "admin@local/admin")
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(*details, jc.DeepEquals, testModelDetails)
 	}
@@ -152,36 +152,36 @@ controllers:
 	c.Assert(err, jc.ErrorIsNil)
 
 	testModelDetails := jujuclient.ModelDetails{"test.uuid"}
-	err = s.store.UpdateModel("ctrl", "admin", testModelDetails)
+	err = s.store.UpdateModel("ctrl", "admin@local/admin", testModelDetails)
 	c.Assert(err, jc.ErrorIsNil)
 	models, err := s.store.AllModels("ctrl")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(models, jc.DeepEquals, map[string]jujuclient.ModelDetails{
-		"admin": testModelDetails,
+		"admin@local/admin": testModelDetails,
 	})
 }
 
 func (s *ModelsSuite) TestRemoveModelNoFile(c *gc.C) {
 	err := os.Remove(jujuclient.JujuModelsPath())
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.store.RemoveModel("not-found", "admin")
+	err = s.store.RemoveModel("not-found", "admin@local/admin")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *ModelsSuite) TestRemoveModelControllerNotFound(c *gc.C) {
-	err := s.store.RemoveModel("not-found", "admin")
+	err := s.store.RemoveModel("not-found", "admin@local/admin")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *ModelsSuite) TestRemoveModelNotFound(c *gc.C) {
-	err := s.store.RemoveModel("kontroll", "not-found")
+	err := s.store.RemoveModel("kontroll", "admin@local/not-found")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *ModelsSuite) TestRemoveModel(c *gc.C) {
-	err := s.store.RemoveModel("kontroll", "admin")
+	err := s.store.RemoveModel("kontroll", "admin@local/admin")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.store.ModelByName("kontroll", "admin")
+	_, err = s.store.ModelByName("kontroll", "admin@local/admin")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
@@ -197,6 +197,6 @@ func (s *ModelsSuite) TestRemoveControllerRemovesModels(c *gc.C) {
 
 	models, err := jujuclient.ReadModelsFile(jujuclient.JujuModelsPath())
 	c.Assert(err, jc.ErrorIsNil)
-	_, ok := models["kontroll"]
+	_, ok := models["admin@local/kontroll"]
 	c.Assert(ok, jc.IsFalse) // kontroll models are removed
 }

--- a/jujuclient/modelsfile_test.go
+++ b/jujuclient/modelsfile_test.go
@@ -24,28 +24,28 @@ const testModelsYAML = `
 controllers:
   ctrl:
     models:
-      admin:
+      admin@local/admin:
         uuid: ghi
   kontroll:
     models:
-      admin:
+      admin@local/admin:
         uuid: abc
-      my-model:
+      admin@local/my-model:
         uuid: def
-    current-model: my-model
+    current-model: admin@local/my-model
 `
 
 var testControllerModels = map[string]*jujuclient.ControllerModels{
 	"kontroll": {
 		Models: map[string]jujuclient.ModelDetails{
-			"admin":    kontrollAdminModelDetails,
-			"my-model": kontrollMyModelModelDetails,
+			"admin@local/admin":    kontrollAdminModelDetails,
+			"admin@local/my-model": kontrollMyModelModelDetails,
 		},
-		CurrentModel: "my-model",
+		CurrentModel: "admin@local/my-model",
 	},
 	"ctrl": {
 		Models: map[string]jujuclient.ModelDetails{
-			"admin": ctrlAdminModelDetails,
+			"admin@local/admin": ctrlAdminModelDetails,
 		},
 	},
 }

--- a/jujuclient/modelvalidation_test.go
+++ b/jujuclient/modelvalidation_test.go
@@ -4,6 +4,7 @@
 package jujuclient_test
 
 import (
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/jujuclient"
@@ -25,7 +26,12 @@ func (s *ModelValidationSuite) SetUpTest(c *gc.C) {
 var _ = gc.Suite(&ModelValidationSuite{})
 
 func (s *ModelValidationSuite) TestValidateModelName(c *gc.C) {
-	c.Assert(jujuclient.ValidateModelName(""), gc.ErrorMatches, "empty model name not valid")
+	c.Assert(jujuclient.ValidateModelName("foo@bar/baz"), jc.ErrorIsNil)
+	c.Assert(jujuclient.ValidateModelName("foo/bar"), gc.ErrorMatches, `validating model name \"foo/bar\": validating model owner name: unqualified user name "foo" not valid`)
+	c.Assert(jujuclient.ValidateModelName("foo"), gc.ErrorMatches, `validating model name "foo": unqualified model name "foo" not valid`)
+	c.Assert(jujuclient.ValidateModelName(""), gc.ErrorMatches, `validating model name "": unqualified model name "" not valid`)
+	c.Assert(jujuclient.ValidateModelName("!"), gc.ErrorMatches, `validating model name "!": unqualified model name "!" not valid`)
+	c.Assert(jujuclient.ValidateModelName("!/foo"), gc.ErrorMatches, `validating model name "!/foo": user name "!" not valid`)
 }
 
 func (s *ModelValidationSuite) TestValidateModelDetailsNoModelUUID(c *gc.C) {

--- a/jujuclient/validation.go
+++ b/jujuclient/validation.go
@@ -52,9 +52,16 @@ func ValidateControllerName(name string) error {
 
 // ValidateModelName validates the given model name.
 func ValidateModelName(name string) error {
-	// TODO(axw) define a regex for valid model names.
-	if name == "" {
-		return errors.NotValidf("empty model name")
+	modelName, owner, err := SplitModelName(name)
+	if err != nil {
+		return errors.Annotatef(err, "validating model name %q", name)
+	}
+	if err := validateUserTag(owner); err != nil {
+		err = errors.Annotate(err, "validating model owner name")
+		return errors.Annotatef(err, "validating model name %q", name)
+	}
+	if !names.IsValidModelName(modelName) {
+		return errors.NotValidf("model name %q", name)
 	}
 	return nil
 }
@@ -81,10 +88,15 @@ func ValidateBootstrapConfig(cfg BootstrapConfig) error {
 
 func validateUser(name string) error {
 	if !names.IsValidUser(name) {
-		return errors.NotValidf("account name %q", name)
+		return errors.NotValidf("user name %q", name)
 	}
-	if tag := names.NewUserTag(name); tag.Id() != tag.Canonical() {
-		return errors.NotValidf("unqualified account name %q", name)
+	tag := names.NewUserTag(name)
+	return validateUserTag(tag)
+}
+
+func validateUserTag(tag names.UserTag) error {
+	if tag.Id() != tag.Canonical() {
+		return errors.NotValidf("unqualified user name %q", tag.Id())
 	}
 	return nil
 }

--- a/state/user.go
+++ b/state/user.go
@@ -231,19 +231,17 @@ func (st *State) AllUsers(includeDeactivated bool) ([]*User, error) {
 	// sure we cannot miss users that previously existed without the deleted
 	// attr. Since this will only be in 2.0 that should never happen, but...
 	// belt and suspenders.
-	query = append(query, bson.D{{"$or", []bson.D{
-		{{"deleted", bson.D{{"$exists", false}}}},
-		{{"deleted", false}},
-	}}}...)
+	query = append(query, bson.DocElem{
+		"deleted", bson.D{{"$ne", true}},
+	})
 
 	// As above, in the case that a user previously existed and doesn't have a
 	// deactivated attribute, we make sure the query checks for the existence
 	// of the attribute, and if it exists that it is not true.
 	if !includeDeactivated {
-		query = append(query, bson.D{{"$or", []bson.D{
-			{{"deactivated", bson.D{{"$exists", false}}}},
-			{{"deactivated", false}},
-		}}}...)
+		query = append(query, bson.DocElem{
+			"deactivated", bson.D{{"$ne", true}},
+		})
 	}
 	iter := users.Find(query).Iter()
 	defer iter.Close()

--- a/state/user.go
+++ b/state/user.go
@@ -231,17 +231,19 @@ func (st *State) AllUsers(includeDeactivated bool) ([]*User, error) {
 	// sure we cannot miss users that previously existed without the deleted
 	// attr. Since this will only be in 2.0 that should never happen, but...
 	// belt and suspenders.
-	query = append(query, bson.D{
-		{"deleted", bson.D{{"$ne", true}}},
-		{"deleted", bson.D{{"$exists", false}}}}...)
+	query = append(query, bson.D{{"$or", []bson.D{
+		{{"deleted", bson.D{{"$exists", false}}}},
+		{{"deleted", false}},
+	}}}...)
 
 	// As above, in the case that a user previously existed and doesn't have a
 	// deactivated attribute, we make sure the query checks for the existence
 	// of the attribute, and if it exists that it is not true.
 	if !includeDeactivated {
-		query = append(query, bson.D{
-			{"deactivated", bson.D{{"$ne", true}}},
-			{"deactivated", bson.D{{"$exists", false}}}}...)
+		query = append(query, bson.D{{"$or", []bson.D{
+			{{"deactivated", bson.D{{"$exists", false}}}},
+			{{"deactivated", false}},
+		}}}...)
 	}
 	iter := users.Find(query).Iter()
 	defer iter.Close()

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -229,16 +229,29 @@ func (s *UserSuite) TestRemoveUser(c *gc.C) {
 func (s *UserSuite) TestDisable(c *gc.C) {
 	user := s.Factory.MakeUser(c, &factory.UserParams{Password: "a-password"})
 	c.Assert(user.IsDisabled(), jc.IsFalse)
+	c.Assert(s.activeUsers(c), jc.DeepEquals, []string{"test-admin", user.Name()})
 
 	err := user.Disable()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(user.IsDisabled(), jc.IsTrue)
 	c.Assert(user.PasswordValid("a-password"), jc.IsFalse)
+	c.Assert(s.activeUsers(c), jc.DeepEquals, []string{"test-admin"})
 
 	err = user.Enable()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(user.IsDisabled(), jc.IsFalse)
 	c.Assert(user.PasswordValid("a-password"), jc.IsTrue)
+	c.Assert(s.activeUsers(c), jc.DeepEquals, []string{"test-admin", user.Name()})
+}
+
+func (s *UserSuite) activeUsers(c *gc.C) []string {
+	users, err := s.State.AllUsers(false)
+	c.Assert(err, jc.ErrorIsNil)
+	names := make([]string, len(users))
+	for i, u := range users {
+		names[i] = u.Name()
+	}
+	return names
 }
 
 func (s *UserSuite) TestSetPasswordHash(c *gc.C) {


### PR DESCRIPTION
This reverts commit 66555a8b93658974e541846f87baf9a574bf8e4f, reversing
changes made to 0c3cf8abfcb8f773255d5078a656e614f80120d8.

Also: cmd/juju/controller: fix model auto-switching

When you use "juju register" and you have access to only one model, you're
automatically switched to that model. We must qualify the model name if it
is not owned by you.