### PR TITLE
Implement methods needed for Networking interface

### DIFF
--- a/provider/vsphere/environ_network.go
+++ b/provider/vsphere/environ_network.go
@@ -18,12 +18,22 @@ func (env *environ) SupportsSpaces() (bool, error) {
 	return false, errors.NotSupportedf("spaces")
 }
 
-// Subnets implements environs.Environ.
+// SupportsSpaceDiscovery implements environs.Networking.
+func (env *environ) SupportsSpaceDiscovery() (bool, error) {
+	return false, errors.NotSupportedf("spaces")
+}
+
+// Spaces implements environs.Networking.
+func (env *environ) Spaces() ([]network.SpaceInfo, error) {
+	return nil, errors.NotSupportedf("spaces")
+}
+
+// Subnets implements environs.Networking.
 func (env *environ) Subnets(inst instance.Id, ids []network.Id) ([]network.SubnetInfo, error) {
 	return env.client.Subnets(inst, ids)
 }
 
-// NetworkInterfaces implements environs.Environ.
+// NetworkInterfaces implements environs.Networking.
 func (env *environ) NetworkInterfaces(inst instance.Id) ([]network.InterfaceInfo, error) {
 	return env.client.GetNetworkInterfaces(inst, env.ecfg)
 }
@@ -49,6 +59,7 @@ func (env *environ) Ports() ([]network.PortRange, error) {
 	return nil, errors.Trace(errors.NotSupportedf("Ports"))
 }
 
+// AllocateContainerAddresses implements environs.Networking.
 func (e *environ) AllocateContainerAddresses(hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo []network.InterfaceInfo) ([]network.InterfaceInfo, error) {
 	return nil, errors.NotSupportedf("container address allocation")
 }

--- a/provider/vsphere/environ_test.go
+++ b/provider/vsphere/environ_test.go
@@ -53,3 +53,9 @@ func (s *environSuite) TestPrepareForBootstrap(c *gc.C) {
 	err := s.Env.PrepareForBootstrap(envtesting.BootstrapContext(c))
 	c.Check(err, jc.ErrorIsNil)
 }
+
+func (s *environSuite) TestSupportsNetworking(c *gc.C) {
+	var _ environs.Networking = s.Env
+	_, ok := environs.SupportsNetworking(s.Env)
+	c.Assert(ok, jc.IsTrue)
+}


### PR DESCRIPTION
The vsphere provider was being treated as not supporting networking,
despite having some support (for Subnets and NetworkInterfaces). Add
stub implementations for Spaces and SupportsSpaceDiscovery - they are
needed for environs.SupportsNetworking, otherwise Subnets and
NetworkInterfaces wouldn't be used.

Also add a test that will fail if new methods are added to the
Networking interface but not added here.

Fixes lp:1606917.

(Review request: http://reviews.vapour.ws/r/5312/)