### PR TITLE
Fix bootstrap with upload-tools to set the right agent version

### DIFF
--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -321,6 +321,9 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	if err := instanceConfig.SetTools(selectedToolsList); err != nil {
 		return errors.Trace(err)
 	}
+	// Make sure we have the most recent environ config as the specified
+	// tools version has been updated there.
+	cfg = environ.Config()
 	if err := finalizeInstanceBootstrapConfig(ctx, instanceConfig, args, cfg, customImageMetadata); err != nil {
 		return errors.Annotate(err, "finalizing bootstrap instance config")
 	}


### PR DESCRIPTION
When upload tools was used the agent version was set in the environ config, but an older version was being passed to the finalize method that was writing out the bootstrap-config for jujud bootstrap-state to process, and writing out an incorrect agent-version.

(Review request: http://reviews.vapour.ws/r/5313/)