### PR TITLE
Patch out arch for the tests.

### DIFF
--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -281,6 +281,13 @@ func (s *bootstrapSuite) TestBootstrapUploadTools(c *gc.C) {
 		c.Skip("issue 1403084: Currently does not work because of jujud problems")
 	}
 
+	// Patch out HostArch and FindTools to allow the test to pass on other architectures,
+	// such as s390.
+	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
+	s.PatchValue(bootstrap.FindTools, func(environs.Environ, int, int, string, tools.Filter) (tools.List, error) {
+		return nil, errors.NotFoundf("tools")
+	})
+
 	env := newEnviron("foo", useDefaultKeys, nil)
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
 		UploadTools:      true,
@@ -305,6 +312,8 @@ func (s *bootstrapSuite) TestBootstrapNoToolsNonReleaseStream(c *gc.C) {
 		c.Skip("issue 1403084: Currently does not work because of jujud problems")
 	}
 
+	// Patch out HostArch and FindTools to allow the test to pass on other architectures,
+	// such as s390.
 	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
 	s.PatchValue(bootstrap.FindTools, func(environs.Environ, int, int, string, tools.Filter) (tools.List, error) {
 		return nil, errors.NotFoundf("tools")


### PR DESCRIPTION
These patches are needed for other architectures such as s390s in order for the tests to pass.

(Review request: http://reviews.vapour.ws/r/5314/)