### PR TITLE
apiserver/client: Include migration status in FullStatus output

### DIFF
--- a/apiserver/client/backend.go
+++ b/apiserver/client/backend.go
@@ -63,6 +63,7 @@ type Backend interface {
 	Watch() *state.Multiwatcher
 	AbortCurrentUpgrade() error
 	APIHostPorts() ([][]network.HostPort, error)
+	LatestModelMigration() (state.ModelMigration, error)
 }
 
 func NewStateBackend(st *state.State) Backend {

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -34,6 +34,7 @@ type ModelStatusInfo struct {
 	CloudRegion      string `json:"region,omitempty"`
 	Version          string `json:"version"`
 	AvailableVersion string `json:"available-version"`
+	Migration        string `json:"migration,omitempty"`
 }
 
 // MachineStatus holds status info about a machine.

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -603,6 +603,7 @@ func (st *State) CreateModelMigration(spec ModelMigrationSpec) (ModelMigration, 
 			StartTime:        now,
 			Phase:            migration.QUIESCE.String(),
 			PhaseChangedTime: now,
+			StatusMessage:    "starting",
 		}
 		return []txn.Op{{
 			C:      migrationsC,

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -70,7 +70,7 @@ func (s *ModelMigrationSuite) TestCreate(c *gc.C) {
 	c.Check(mig.StartTime(), gc.Equals, s.clock.Now())
 	c.Check(mig.SuccessTime().IsZero(), jc.IsTrue)
 	c.Check(mig.EndTime().IsZero(), jc.IsTrue)
-	c.Check(mig.StatusMessage(), gc.Equals, "")
+	c.Check(mig.StatusMessage(), gc.Equals, "starting")
 	c.Check(mig.InitiatedBy(), gc.Equals, "admin")
 
 	info, err := mig.TargetInfo()
@@ -425,8 +425,8 @@ func (s *ModelMigrationSuite) TestStatusMessage(c *gc.C) {
 	mig2, err := s.State2.LatestModelMigration()
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(mig.StatusMessage(), gc.Equals, "")
-	c.Check(mig2.StatusMessage(), gc.Equals, "")
+	c.Check(mig.StatusMessage(), gc.Equals, "starting")
+	c.Check(mig2.StatusMessage(), gc.Equals, "starting")
 
 	err = mig.SetStatusMessage("foo bar")
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
This takes care of the apiserver changes to include migration status in the FullStatus API response.

An initial status is now always set when a migration is created so that there is some sort status output before the migrationmaster worker sets one.

(Review request: http://reviews.vapour.ws/r/5315/)