### PR TITLE
environs: add CloudSpec

### DIFF
--- a/api/firewaller/firewaller_test.go
+++ b/api/firewaller/firewaller_test.go
@@ -69,6 +69,6 @@ func (s *firewallerSuite) SetUpTest(c *gc.C) {
 	}
 
 	// Create the firewaller API facade.
-	s.firewaller = s.st.Firewaller()
+	s.firewaller = firewaller.NewState(s.st)
 	c.Assert(s.firewaller, gc.NotNil)
 }

--- a/api/interface.go
+++ b/api/interface.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/api/charmrevisionupdater"
 	"github.com/juju/juju/api/cleaner"
 	"github.com/juju/juju/api/discoverspaces"
-	"github.com/juju/juju/api/firewaller"
 	"github.com/juju/juju/api/imagemetadata"
 	"github.com/juju/juju/api/instancepoller"
 	"github.com/juju/juju/api/reboot"
@@ -210,7 +209,6 @@ type Connection interface {
 	// prohibitively ugly to do so.
 	Client() *Client
 	Uniter() (*uniter.State, error)
-	Firewaller() *firewaller.State
 	Upgrader() *upgrader.State
 	Reboot() (reboot.State, error)
 	DiscoverSpaces() *discoverspaces.API

--- a/api/state.go
+++ b/api/state.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/api/charmrevisionupdater"
 	"github.com/juju/juju/api/cleaner"
 	"github.com/juju/juju/api/discoverspaces"
-	"github.com/juju/juju/api/firewaller"
 	"github.com/juju/juju/api/imagemetadata"
 	"github.com/juju/juju/api/instancepoller"
 	"github.com/juju/juju/api/keyupdater"
@@ -243,12 +242,6 @@ func (st *state) Uniter() (*uniter.State, error) {
 		return nil, errors.Errorf("expected UnitTag, got %T %v", st.authTag, st.authTag)
 	}
 	return uniter.NewState(st, unitTag), nil
-}
-
-// Firewaller returns a version of the state that provides functionality
-// required by the firewaller worker.
-func (st *state) Firewaller() *firewaller.State {
-	return firewaller.NewState(st)
 }
 
 // Upgrader returns access to the Upgrader API

--- a/apiserver/common/modelwatcher_test.go
+++ b/apiserver/common/modelwatcher_test.go
@@ -127,7 +127,7 @@ func testingEnvConfig(c *gc.C) *config.Config {
 			ControllerConfig: testing.FakeControllerConfig(),
 			ControllerName:   "dummycontroller",
 			BaseConfig:       dummy.SampleConfig(),
-			CloudName:        "dummy",
+			Cloud:            dummy.SampleCloudSpec(),
 			AdminSecret:      "admin-secret",
 		},
 	)

--- a/apiserver/imagemetadata/updatefrompublished_test.go
+++ b/apiserver/imagemetadata/updatefrompublished_test.go
@@ -12,16 +12,13 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/imagemetadata"
 	imagetesting "github.com/juju/juju/environs/imagemetadata/testing"
 	"github.com/juju/juju/environs/simplestreams"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/juju/keys"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state/cloudimagemetadata"
 	"github.com/juju/juju/testing"
@@ -165,19 +162,7 @@ func (s *imageMetadataUpdateSuite) TestUpdateFromPublishedImagesForProviderWithN
 	// testingEnvConfig prepares an environment configuration using
 	// the dummy provider since it doesn't implement simplestreams.HasRegion.
 	s.state.environConfig = func() (*config.Config, error) {
-		env, err := bootstrap.Prepare(
-			modelcmd.BootstrapContext(testing.Context(c)),
-			jujuclienttesting.NewMemStore(),
-			bootstrap.PrepareParams{
-				ControllerConfig: testing.FakeControllerConfig(),
-				ControllerName:   "dummycontroller",
-				BaseConfig:       dummy.SampleConfig(),
-				CloudName:        "dummy",
-				AdminSecret:      "admin-secret",
-			},
-		)
-		c.Assert(err, jc.ErrorIsNil)
-		return env.Config(), err
+		return config.New(config.UseDefaults, dummy.SampleConfig())
 	}
 
 	s.state.saveMetadata = func(m []cloudimagemetadata.Metadata) error {

--- a/apiserver/migrationtarget/migrationtarget_test.go
+++ b/apiserver/migrationtarget/migrationtarget_test.go
@@ -15,10 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/migrationtarget"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/description"
-	"github.com/juju/juju/environs/bootstrap"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
@@ -36,19 +33,7 @@ var _ = gc.Suite(&Suite{})
 func (s *Suite) SetUpTest(c *gc.C) {
 	// Set up InitialConfig with a dummy provider configuration. This
 	// is required to allow model import test to work.
-	env, err := bootstrap.Prepare(
-		modelcmd.BootstrapContext(testing.Context(c)),
-		jujuclienttesting.NewMemStore(),
-		bootstrap.PrepareParams{
-			ControllerConfig: testing.FakeControllerConfig(),
-			ControllerName:   "dummycontroller",
-			BaseConfig:       dummy.SampleConfig(),
-			CloudName:        "dummy",
-			AdminSecret:      "admin-secret",
-		},
-	)
-	c.Assert(err, jc.ErrorIsNil)
-	s.InitialConfig = testing.CustomModelConfig(c, env.Config().AllAttrs())
+	s.InitialConfig = testing.CustomModelConfig(c, dummy.SampleConfig())
 
 	// The call up to StateSuite's SetUpTest uses s.InitialConfig so
 	// it has to happen here.

--- a/cmd/juju/backups/export_test.go
+++ b/cmd/juju/backups/export_test.go
@@ -106,8 +106,11 @@ func GetRebootstrapParamsFunc(cloud string) func(string, *params.BackupsMetadata
 	return func(string, *params.BackupsMetadataResult) (*restoreBootstrapParams, error) {
 		return &restoreBootstrapParams{
 			ControllerConfig: testing.FakeControllerConfig(),
-			CloudName:        cloud,
-			CloudRegion:      "a-region",
+			Cloud: environs.CloudSpec{
+				Type:   "lxd",
+				Name:   cloud,
+				Region: "a-region",
+			},
 		}, nil
 	}
 }

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -531,16 +531,19 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	environ, err := bootstrapPrepare(
 		modelcmd.BootstrapContext(ctx), store,
 		bootstrap.PrepareParams{
-			BaseConfig:           modelConfigAttrs,
-			ControllerConfig:     controllerConfig,
-			ControllerName:       c.controllerName,
-			CloudName:            c.Cloud,
-			CloudRegion:          region.Name,
-			CloudEndpoint:        region.Endpoint,
-			CloudStorageEndpoint: region.StorageEndpoint,
-			Credential:           *credential,
-			CredentialName:       credentialName,
-			AdminSecret:          bootstrapConfig.AdminSecret,
+			BaseConfig:       modelConfigAttrs,
+			ControllerConfig: controllerConfig,
+			ControllerName:   c.controllerName,
+			Cloud: environs.CloudSpec{
+				Type:            cloud.Type,
+				Name:            c.Cloud,
+				Region:          region.Name,
+				Endpoint:        region.Endpoint,
+				StorageEndpoint: region.StorageEndpoint,
+				Credential:      credential,
+			},
+			CredentialName: credentialName,
+			AdminSecret:    bootstrapConfig.AdminSecret,
 		},
 	)
 	if err != nil {

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1059,7 +1059,7 @@ func (s *BootstrapSuite) TestBootstrapProviderCaseInsensitiveRegionCheck(c *gc.C
 
 	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "ctrl", "dummy/DUMMY")
 	c.Assert(err, gc.ErrorMatches, "mock-prepare")
-	c.Assert(prepareParams.CloudRegion, gc.Equals, "dummy")
+	c.Assert(prepareParams.Cloud.Region, gc.Equals, "dummy")
 }
 
 func (s *BootstrapSuite) TestBootstrapConfigFile(c *gc.C) {

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -412,9 +412,14 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 	}
 	return bootstrapConfig, &environs.BootstrapConfigParams{
 		controllerDetails.ControllerUUID,
-		cfg, *credential,
-		bootstrapConfig.CloudRegion,
-		bootstrapConfig.CloudEndpoint,
-		bootstrapConfig.CloudStorageEndpoint,
+		environs.CloudSpec{
+			bootstrapConfig.CloudType,
+			bootstrapConfig.Cloud,
+			bootstrapConfig.CloudRegion,
+			bootstrapConfig.CloudEndpoint,
+			bootstrapConfig.CloudStorageEndpoint,
+			credential,
+		},
+		cfg,
 	}, nil
 }

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -61,7 +61,7 @@ func (s *ToolsMetadataSuite) SetUpTest(c *gc.C) {
 			ControllerConfig: coretesting.FakeControllerConfig(),
 			ControllerName:   cfg.Name(),
 			BaseConfig:       cfg.AllAttrs(),
-			CloudName:        "dummy",
+			Cloud:            dummy.SampleCloudSpec(),
 			AdminSecret:      "admin-secret",
 		},
 	)

--- a/environs/bootstrap/prepare_test.go
+++ b/environs/bootstrap/prepare_test.go
@@ -61,7 +61,7 @@ func (*PrepareSuite) TestPrepare(c *gc.C) {
 		ControllerConfig: controllerCfg,
 		ControllerName:   cfg.Name(),
 		BaseConfig:       cfg.AllAttrs(),
-		CloudName:        "dummy",
+		Cloud:            dummy.SampleCloudSpec(),
 		AdminSecret:      "admin-secret",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -103,7 +103,7 @@ func (*PrepareSuite) TestPrepare(c *gc.C) {
 		ControllerConfig: controllerCfg,
 		ControllerName:   cfg.Name(),
 		BaseConfig:       cfg.AllAttrs(),
-		CloudName:        "dummy",
+		Cloud:            dummy.SampleCloudSpec(),
 		AdminSecret:      "admin-secret",
 	})
 	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)

--- a/environs/cloudspec.go
+++ b/environs/cloudspec.go
@@ -1,0 +1,31 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package environs
+
+import "github.com/juju/juju/cloud"
+
+// CloudSpec describes a specific cloud configuration, for the purpose
+// of opening an Environ to manage the cloud resources.
+type CloudSpec struct {
+	// Type is the type of cloud, eg aws, openstack etc.
+	Type string
+
+	// Name is the name of the cloud.
+	Name string
+
+	// Region is the name of the cloud region, if the cloud supports
+	// regions.
+	Region string
+
+	// Endpoint is the endpoint for the cloud (region).
+	Endpoint string
+
+	// StorageEndpoint is the storage endpoint for the cloud (region).
+	StorageEndpoint string
+
+	// Credential is the cloud credential to use to authenticate
+	// with the cloud, or nil if the cloud does not require any
+	// credentials.
+	Credential *cloud.Credential
+}

--- a/environs/imagemetadata_test.go
+++ b/environs/imagemetadata_test.go
@@ -52,7 +52,7 @@ func (s *ImageMetadataSuite) env(c *gc.C, imageMetadataURL, stream string) envir
 			ControllerConfig: testing.FakeControllerConfig(),
 			ControllerName:   attrs["name"].(string),
 			BaseConfig:       attrs,
-			CloudName:        "dummy",
+			Cloud:            dummy.SampleCloudSpec(),
 			AdminSecret:      "admin-secret",
 		},
 	)

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -70,28 +70,12 @@ type BootstrapConfigParams struct {
 	// ControllerUUID is the UUID of the controller to be bootstrapped.
 	ControllerUUID string
 
+	// Cloud is the cloud specification to use to connect to the cloud.
+	Cloud CloudSpec
+
 	// Config is the base configuration for the provider. This should
 	// be updated with the region, endpoint and credentials.
 	Config *config.Config
-
-	// Credentials is the set of credentials to use to bootstrap.
-	//
-	// TODO(axw) rename field to Credential.
-	Credentials cloud.Credential
-
-	// CloudRegion is the name of the region of the cloud to create
-	// the Juju controller in. This will be empty for clouds without
-	// regions.
-	CloudRegion string
-
-	// CloudEndpoint is the location of the primary API endpoint to
-	// use when communicating with the cloud.
-	CloudEndpoint string
-
-	// CloudStorageEndpoint is the location of the API endpoint to use
-	// when communicating with the cloud's storage service. This will
-	// be empty for clouds that have no cloud-specific API endpoint.
-	CloudStorageEndpoint string
 }
 
 // ProviderCredentials is an interface that an EnvironProvider implements

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -158,12 +158,15 @@ func (t *LiveTests) prepareForBootstrapParams(c *gc.C) bootstrap.PrepareParams {
 	return bootstrap.PrepareParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
 		BaseConfig:       t.TestConfig,
-		Credential:       credential,
-		CloudEndpoint:    t.CloudEndpoint,
-		CloudRegion:      t.CloudRegion,
-		ControllerName:   t.TestConfig["name"].(string),
-		CloudName:        t.TestConfig["type"].(string),
-		AdminSecret:      AdminSecret,
+		Cloud: environs.CloudSpec{
+			Type:       t.TestConfig["type"].(string),
+			Name:       t.TestConfig["type"].(string),
+			Region:     t.CloudRegion,
+			Endpoint:   t.CloudEndpoint,
+			Credential: &credential,
+		},
+		ControllerName: t.TestConfig["name"].(string),
+		AdminSecret:    AdminSecret,
 	}
 }
 

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -55,23 +55,30 @@ func (t *Tests) Open(c *gc.C, cfg *config.Config) environs.Environ {
 	return e
 }
 
+func (t *Tests) CloudSpec() environs.CloudSpec {
+	credential := t.Credential
+	if credential.AuthType() == "" {
+		credential = cloud.NewEmptyCredential()
+	}
+	return environs.CloudSpec{
+		Type:       t.TestConfig["type"].(string),
+		Name:       t.TestConfig["type"].(string),
+		Region:     t.CloudRegion,
+		Endpoint:   t.CloudEndpoint,
+		Credential: &credential,
+	}
+}
+
 // PrepareParams returns the environs.PrepareParams that will be used to call
 // environs.Prepare.
 func (t *Tests) PrepareParams(c *gc.C) bootstrap.PrepareParams {
 	testConfigCopy := t.TestConfig.Merge(nil)
 
-	credential := t.Credential
-	if credential.AuthType() == "" {
-		credential = cloud.NewEmptyCredential()
-	}
 	return bootstrap.PrepareParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
 		BaseConfig:       testConfigCopy,
-		Credential:       credential,
+		Cloud:            t.CloudSpec(),
 		ControllerName:   t.TestConfig["name"].(string),
-		CloudName:        t.TestConfig["type"].(string),
-		CloudEndpoint:    t.CloudEndpoint,
-		CloudRegion:      t.CloudRegion,
 		AdminSecret:      AdminSecret,
 	}
 }

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -55,7 +55,7 @@ func (s *OpenSuite) TestNewDummyEnviron(c *gc.C) {
 		ControllerConfig: controllerCfg,
 		ControllerName:   cfg.Name(),
 		BaseConfig:       cfg.AllAttrs(),
-		CloudName:        "dummy",
+		Cloud:            dummy.SampleCloudSpec(),
 		AdminSecret:      "admin-secret",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -94,7 +94,7 @@ func (s *OpenSuite) TestUpdateEnvInfo(c *gc.C) {
 		ControllerConfig: controllerCfg,
 		ControllerName:   "controller-name",
 		BaseConfig:       cfg.AllAttrs(),
-		CloudName:        "dummy",
+		Cloud:            dummy.SampleCloudSpec(),
 		AdminSecret:      "admin-secret",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -153,7 +153,7 @@ func (*OpenSuite) TestDestroy(c *gc.C) {
 		ControllerConfig: controllerCfg,
 		ControllerName:   "controller-name",
 		BaseConfig:       cfg.AllAttrs(),
-		CloudName:        "dummy",
+		Cloud:            dummy.SampleCloudSpec(),
 		AdminSecret:      "admin-secret",
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/tools/tools_test.go
+++ b/environs/tools/tools_test.go
@@ -104,7 +104,7 @@ func (s *SimpleStreamsToolsSuite) resetEnv(c *gc.C, attrs map[string]interface{}
 			ControllerConfig: coretesting.FakeControllerConfig(),
 			ControllerName:   attrs["name"].(string),
 			BaseConfig:       attrs,
-			CloudName:        "dummy",
+			Cloud:            dummy.SampleCloudSpec(),
 			AdminSecret:      "admin-secret",
 		},
 	)

--- a/environs/tools/urls_test.go
+++ b/environs/tools/urls_test.go
@@ -50,7 +50,7 @@ func (s *URLsSuite) env(c *gc.C, toolsMetadataURL string) environs.Environ {
 			ControllerConfig: coretesting.FakeControllerConfig(),
 			ControllerName:   attrs["name"].(string),
 			BaseConfig:       attrs,
-			CloudName:        "dummy",
+			Cloud:            dummy.SampleCloudSpec(),
 			AdminSecret:      "admin-secret",
 		},
 	)

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -91,7 +91,7 @@ func (s *NewAPIClientSuite) bootstrapModel(c *gc.C) (environs.Environ, jujuclien
 		ControllerConfig: coretesting.FakeControllerConfig(),
 		ControllerName:   controllerName,
 		BaseConfig:       dummy.SampleConfig(),
-		CloudName:        "dummy",
+		Cloud:            dummy.SampleCloudSpec(),
 		AdminSecret:      "admin-secret",
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -279,9 +279,8 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 		bootstrap.PrepareParams{
 			ControllerConfig: s.ControllerConfig,
 			BaseConfig:       cfg.AllAttrs(),
-			Credential:       cloud.NewEmptyCredential(),
+			Cloud:            dummy.SampleCloudSpec(),
 			ControllerName:   ControllerName,
-			CloudName:        "dummy",
 			AdminSecret:      AdminSecret,
 		},
 	)

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -17,12 +17,9 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 
-	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/description"
-	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/provider/dummy"
 	_ "github.com/juju/juju/provider/dummy"
@@ -45,20 +42,7 @@ func (s *ImportSuite) SetUpTest(c *gc.C) {
 	// is one that isn't registered as a valid provider. For our tests here we
 	// need a real registered provider, so we use the dummy provider.
 	// NOTE: make a better test provider.
-	env, err := bootstrap.Prepare(
-		modelcmd.BootstrapContext(testing.Context(c)),
-		jujuclienttesting.NewMemStore(),
-		bootstrap.PrepareParams{
-			ControllerConfig: testing.FakeControllerConfig(),
-			ControllerName:   "dummycontroller",
-			BaseConfig:       dummy.SampleConfig(),
-			CloudName:        "dummy",
-			AdminSecret:      "admin-secret",
-		},
-	)
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.InitialConfig = testing.CustomModelConfig(c, env.Config().AllAttrs())
+	s.InitialConfig = testing.CustomModelConfig(c, dummy.SampleConfig())
 	s.StateSuite.SetUpTest(c)
 }
 

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -329,11 +329,13 @@ func prepareForBootstrap(
 	cfg := makeTestModelConfig(c, attrs...)
 	*sender = azuretesting.Senders{tokenRefreshSender()}
 	cfg, err := provider.BootstrapConfig(environs.BootstrapConfigParams{
-		Config:               cfg,
-		CloudRegion:          "westus",
-		CloudEndpoint:        "https://management.azure.com",
-		CloudStorageEndpoint: "https://core.windows.net",
-		Credentials:          fakeUserPassCredential(),
+		Config: cfg,
+		Cloud: environs.CloudSpec{
+			Region:          "westus",
+			Endpoint:        "https://management.azure.com",
+			StorageEndpoint: "https://core.windows.net",
+			Credential:      fakeUserPassCredential(),
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := provider.Open(environs.OpenParams{cfg})

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -107,13 +107,13 @@ func (prov *azureEnvironProvider) PrepareForCreateEnvironment(controllerUUID str
 // BootstrapConfig is specified in the EnvironProvider interface.
 func (prov *azureEnvironProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
 	attrs := map[string]interface{}{
-		configAttrLocation:        args.CloudRegion,
-		configAttrEndpoint:        args.CloudEndpoint,
-		configAttrStorageEndpoint: args.CloudStorageEndpoint,
+		configAttrLocation:        args.Cloud.Region,
+		configAttrEndpoint:        args.Cloud.Endpoint,
+		configAttrStorageEndpoint: args.Cloud.StorageEndpoint,
 	}
-	switch authType := args.Credentials.AuthType(); authType {
+	switch authType := args.Cloud.Credential.AuthType(); authType {
 	case cloud.UserPassAuthType:
-		for k, v := range args.Credentials.Attributes() {
+		for k, v := range args.Cloud.Credential.Attributes() {
 			attrs[k] = v
 		}
 	default:

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -40,8 +40,8 @@ func (s *environProviderSuite) SetUpTest(c *gc.C) {
 	s.sender = nil
 }
 
-func fakeUserPassCredential() cloud.Credential {
-	return cloud.NewCredential(
+func fakeUserPassCredential() *cloud.Credential {
+	cred := cloud.NewCredential(
 		cloud.UserPassAuthType,
 		map[string]string{
 			"application-id":       "application-id",
@@ -50,17 +50,20 @@ func fakeUserPassCredential() cloud.Credential {
 			"application-password": "application-password",
 		},
 	)
+	return &cred
 }
 
 func (s *environProviderSuite) TestBootstrapConfig(c *gc.C) {
 	cfg := makeTestModelConfig(c)
 	s.sender = azuretesting.Senders{tokenRefreshSender()}
 	cfg, err := s.provider.BootstrapConfig(environs.BootstrapConfigParams{
-		Config:               cfg,
-		CloudRegion:          "westus",
-		CloudEndpoint:        "https://api.azurestack.local",
-		CloudStorageEndpoint: "https://storage.azurestack.local",
-		Credentials:          fakeUserPassCredential(),
+		Config: cfg,
+		Cloud: environs.CloudSpec{
+			Region:          "westus",
+			Endpoint:        "https://api.azurestack.local",
+			StorageEndpoint: "https://storage.azurestack.local",
+			Credential:      fakeUserPassCredential(),
+		},
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(cfg, gc.NotNil)

--- a/provider/cloudsigma/provider.go
+++ b/provider/cloudsigma/provider.go
@@ -85,10 +85,10 @@ func (environProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *c
 // BootstrapConfig is defined by EnvironProvider.
 func (environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
 	cfg := args.Config
-	switch authType := args.Credentials.AuthType(); authType {
+	switch authType := args.Cloud.Credential.AuthType(); authType {
 	case cloud.UserPassAuthType:
 		var err error
-		credentialAttributes := args.Credentials.Attributes()
+		credentialAttributes := args.Cloud.Credential.Attributes()
 		cfg, err = cfg.Apply(map[string]interface{}{
 			"username": credentialAttributes["username"],
 			"password": credentialAttributes["password"],
@@ -101,8 +101,8 @@ func (environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*co
 	}
 	// Ensure cloud info is in config.
 	cfg, err := cfg.Apply(map[string]interface{}{
-		"region":   args.CloudRegion,
-		"endpoint": args.CloudEndpoint,
+		"region":   args.Cloud.Region,
+		"endpoint": args.Cloud.Endpoint,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/provider/dummy/config_test.go
+++ b/provider/dummy/config_test.go
@@ -35,7 +35,7 @@ func (*ConfigSuite) TestSecretAttrs(c *gc.C) {
 			ControllerConfig: testing.FakeControllerConfig(),
 			BaseConfig:       attrs,
 			ControllerName:   attrs["name"].(string),
-			CloudName:        "dummy",
+			Cloud:            dummy.SampleCloudSpec(),
 			AdminSecret:      AdminSecret,
 		},
 	)
@@ -99,7 +99,7 @@ func (s *ConfigSuite) TestFirewallMode(c *gc.C) {
 				ControllerConfig: testing.FakeControllerConfig(),
 				ControllerName:   cfg.Name(),
 				BaseConfig:       cfg.AllAttrs(),
-				CloudName:        "dummy",
+				Cloud:            dummy.SampleCloudSpec(),
 				AdminSecret:      AdminSecret,
 			},
 		)

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -74,6 +74,15 @@ const BootstrapInstanceId = "localhost"
 
 var errNotPrepared = errors.New("model is not prepared")
 
+// SampleCloudSpec returns an environs.CloudSpec that can be used to
+// open a dummy Environ.
+func SampleCloudSpec() environs.CloudSpec {
+	return environs.CloudSpec{
+		Type: "dummy",
+		Name: "dummy",
+	}
+}
+
 // SampleConfig() returns an environment configuration with all required
 // attributes set.
 func SampleConfig() testing.Attrs {

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -121,7 +121,7 @@ func (s *suite) bootstrapTestEnviron(c *gc.C) environs.NetworkingEnviron {
 			ControllerConfig: testing.FakeControllerConfig(),
 			BaseConfig:       s.TestConfig,
 			ControllerName:   s.TestConfig["name"].(string),
-			CloudName:        "dummy",
+			Cloud:            dummy.SampleCloudSpec(),
 			AdminSecret:      AdminSecret,
 		},
 	)

--- a/provider/ec2/config_test.go
+++ b/provider/ec2/config_test.go
@@ -431,16 +431,20 @@ func (s *ConfigSuite) TestBootstrapConfigSetsDefaultBlockSource(c *gc.C) {
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 
+	credential := cloud.NewCredential(
+		cloud.AccessKeyAuthType,
+		map[string]string{
+			"access-key": "x",
+			"secret-key": "y",
+		},
+	)
 	cfg, err = providerInstance.BootstrapConfig(environs.BootstrapConfigParams{
 		Config: cfg,
-		Credentials: cloud.NewCredential(
-			cloud.AccessKeyAuthType,
-			map[string]string{
-				"access-key": "x",
-				"secret-key": "y",
-			},
-		),
-		CloudRegion: "test",
+		Cloud: environs.CloudSpec{
+			Type:       "ec2",
+			Region:     "test",
+			Credential: &credential,
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	source, ok := cfg.StorageDefaultBlockSource()
@@ -456,16 +460,20 @@ func (s *ConfigSuite) TestPrepareSetsDefaultBlockSource(c *gc.C) {
 	config, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 
+	credential := cloud.NewCredential(
+		cloud.AccessKeyAuthType,
+		map[string]string{
+			"access-key": "x",
+			"secret-key": "y",
+		},
+	)
 	cfg, err := providerInstance.BootstrapConfig(environs.BootstrapConfigParams{
-		Config:      config,
-		CloudRegion: "test",
-		Credentials: cloud.NewCredential(
-			cloud.AccessKeyAuthType,
-			map[string]string{
-				"access-key": "x",
-				"secret-key": "y",
-			},
-		),
+		Config: config,
+		Cloud: environs.CloudSpec{
+			Type:       "ec2",
+			Region:     "test",
+			Credential: &credential,
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1477,23 +1477,27 @@ func (t *localNonUSEastSuite) SetUpTest(c *gc.C) {
 	}
 	t.srv.startServer(c)
 
+	credential := cloud.NewCredential(
+		cloud.AccessKeyAuthType,
+		map[string]string{
+			"access-key": "x",
+			"secret-key": "x",
+		},
+	)
+
 	env, err := bootstrap.Prepare(
 		envtesting.BootstrapContext(c),
 		jujuclienttesting.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: coretesting.FakeControllerConfig(),
 			BaseConfig:       localConfigAttrs,
-			Credential: cloud.NewCredential(
-				cloud.AccessKeyAuthType,
-				map[string]string{
-					"access-key": "x",
-					"secret-key": "x",
-				},
-			),
-			ControllerName: localConfigAttrs["name"].(string),
-			CloudName:      "ec2",
-			CloudRegion:    "test",
-			AdminSecret:    testing.AdminSecret,
+			ControllerName:   localConfigAttrs["name"].(string),
+			Cloud: environs.CloudSpec{
+				Type:       "ec2",
+				Region:     "test",
+				Credential: &credential,
+			},
+			AdminSecret: testing.AdminSecret,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/gce/provider.go
+++ b/provider/gce/provider.go
@@ -28,17 +28,17 @@ func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) 
 func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
 	// Add credentials to the configuration.
 	cfg := args.Config
-	switch authType := args.Credentials.AuthType(); authType {
+	switch authType := args.Cloud.Credential.AuthType(); authType {
 	case cloud.JSONFileAuthType:
-		var err error
-		filename := args.Credentials.Attributes()["file"]
-		args.Credentials, err = ParseJSONAuthFile(filename)
+		filename := args.Cloud.Credential.Attributes()["file"]
+		credential, err := ParseJSONAuthFile(filename)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		args.Cloud.Credential = &credential
 		fallthrough
 	case cloud.OAuth2AuthType:
-		credentialAttrs := args.Credentials.Attributes()
+		credentialAttrs := args.Cloud.Credential.Attributes()
 		var err error
 		cfg, err = args.Config.Apply(map[string]interface{}{
 			cfgProjectID:   credentialAttrs[cfgProjectID],
@@ -55,7 +55,7 @@ func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*
 	// Ensure cloud info is in config.
 	var err error
 	cfg, err = cfg.Apply(map[string]interface{}{
-		cfgRegion: args.CloudRegion,
+		cfgRegion: args.Cloud.Region,
 		// TODO (anastasiamac 2016-06-09) at some stage will need to
 		//  also add endpoint and storage endpoint.
 	})

--- a/provider/gce/provider_test.go
+++ b/provider/gce/provider_test.go
@@ -41,17 +41,20 @@ func (s *providerSuite) TestOpen(c *gc.C) {
 }
 
 func (s *providerSuite) TestBootstrapConfig(c *gc.C) {
+	credential := cloud.NewCredential(
+		cloud.OAuth2AuthType,
+		map[string]string{
+			"project-id":   "x",
+			"client-id":    "y",
+			"client-email": "zz@example.com",
+			"private-key":  "why",
+		},
+	)
 	cfg, err := s.provider.BootstrapConfig(environs.BootstrapConfigParams{
 		Config: s.Config,
-		Credentials: cloud.NewCredential(
-			cloud.OAuth2AuthType,
-			map[string]string{
-				"project-id":   "x",
-				"client-id":    "y",
-				"client-email": "zz@example.com",
-				"private-key":  "why",
-			},
-		),
+		Cloud: environs.CloudSpec{
+			Credential: &credential,
+		},
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(cfg, gc.NotNil)

--- a/provider/joyent/config_test.go
+++ b/provider/joyent/config_test.go
@@ -278,12 +278,15 @@ func (s *ConfigSuite) TestBootstrapConfig(c *gc.C) {
 			credentialAttrs[k] = fmt.Sprintf("%v", v)
 		}
 		testConfig := newConfig(c, attrs)
+		credential := cloud.NewCredential(
+			cloud.UserPassAuthType,
+			credentialAttrs,
+		)
 		preparedConfig, err := jp.Provider.BootstrapConfig(environs.BootstrapConfigParams{
 			Config: testConfig,
-			Credentials: cloud.NewCredential(
-				cloud.UserPassAuthType,
-				credentialAttrs,
-			),
+			Cloud: environs.CloudSpec{
+				Credential: &credential,
+			},
 		})
 		if test.err == "" {
 			c.Check(err, jc.ErrorIsNil)

--- a/provider/joyent/export_test.go
+++ b/provider/joyent/export_test.go
@@ -211,6 +211,10 @@ func CredentialsAttributes(attrs testing.Attrs) map[string]string {
 
 // MakeConfig creates a functional environConfig for a test.
 func MakeConfig(c *gc.C, attrs testing.Attrs) *environConfig {
+	credential := cloud.NewCredential(
+		cloud.UserPassAuthType,
+		CredentialsAttributes(attrs),
+	)
 	env, err := bootstrap.Prepare(
 		envtesting.BootstrapContext(c),
 		jujuclienttesting.NewMemStore(),
@@ -218,11 +222,11 @@ func MakeConfig(c *gc.C, attrs testing.Attrs) *environConfig {
 			ControllerConfig: testing.FakeControllerConfig(),
 			BaseConfig:       attrs,
 			ControllerName:   attrs["name"].(string),
-			CloudName:        "joyent",
-			Credential: cloud.NewCredential(
-				cloud.UserPassAuthType,
-				CredentialsAttributes(attrs),
-			),
+			Cloud: environs.CloudSpec{
+				Type:       "joyent",
+				Name:       "joyent",
+				Credential: &credential,
+			},
 			AdminSecret: "sekrit",
 		},
 	)

--- a/provider/joyent/provider.go
+++ b/provider/joyent/provider.go
@@ -60,17 +60,17 @@ func (joyentProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *co
 func (p joyentProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
 	attrs := map[string]interface{}{}
 	// Add the credential attributes to config.
-	switch authType := args.Credentials.AuthType(); authType {
+	switch authType := args.Cloud.Credential.AuthType(); authType {
 	case cloud.UserPassAuthType:
-		credentialAttrs := args.Credentials.Attributes()
+		credentialAttrs := args.Cloud.Credential.Attributes()
 		for k, v := range credentialAttrs {
 			attrs[k] = v
 		}
 	default:
 		return nil, errors.NotSupportedf("%q auth-type", authType)
 	}
-	if args.CloudEndpoint != "" {
-		attrs[sdcUrl] = args.CloudEndpoint
+	if args.Cloud.Endpoint != "" {
+		attrs[sdcUrl] = args.Cloud.Endpoint
 	}
 	cfg, err := args.Config.Apply(attrs)
 	if err != nil {

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -60,21 +60,21 @@ func (p maasEnvironProvider) PrepareForCreateEnvironment(controllerUUID string, 
 func (p maasEnvironProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
 	// For MAAS, the cloud endpoint may be either a full URL
 	// for the MAAS server, or just the IP/host.
-	if args.CloudEndpoint == "" {
+	if args.Cloud.Endpoint == "" {
 		return nil, errors.New("MAAS server not specified")
 	}
-	server := args.CloudEndpoint
+	server := args.Cloud.Endpoint
 	if url, err := url.Parse(server); err != nil || url.Scheme == "" {
-		server = fmt.Sprintf("http://%s/MAAS", args.CloudEndpoint)
+		server = fmt.Sprintf("http://%s/MAAS", args.Cloud.Endpoint)
 	}
 
 	attrs := map[string]interface{}{
 		"maas-server": server,
 	}
 	// Add the credentials.
-	switch authType := args.Credentials.AuthType(); authType {
+	switch authType := args.Cloud.Credential.AuthType(); authType {
 	case cloud.OAuth1AuthType:
-		credentialAttrs := args.Credentials.Attributes()
+		credentialAttrs := args.Cloud.Credential.Attributes()
 		for k, v := range credentialAttrs {
 			attrs[k] = v
 		}

--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -52,14 +52,14 @@ func (p manualProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *
 
 // BootstrapConfig is specified in the EnvironProvider interface.
 func (p manualProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
-	if args.CloudEndpoint == "" {
+	if args.Cloud.Endpoint == "" {
 		return nil, errors.Errorf(
 			"missing address of host to bootstrap: " +
 				`please specify "juju bootstrap manual/<host>"`,
 		)
 	}
 	cfg, err := args.Config.Apply(map[string]interface{}{
-		"bootstrap-host": args.CloudEndpoint,
+		"bootstrap-host": args.Cloud.Endpoint,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -58,9 +58,11 @@ func (s *providerSuite) testPrepareForBootstrap(c *gc.C, endpoint, region string
 	testConfig, err := config.New(config.UseDefaults, minimal)
 	c.Assert(err, jc.ErrorIsNil)
 	testConfig, err = manual.ProviderInstance.BootstrapConfig(environs.BootstrapConfigParams{
-		Config:        testConfig,
-		CloudEndpoint: endpoint,
-		CloudRegion:   region,
+		Config: testConfig,
+		Cloud: environs.CloudSpec{
+			Endpoint: endpoint,
+			Region:   region,
+		},
 	})
 	if err != nil {
 		return nil, err

--- a/provider/openstack/config_test.go
+++ b/provider/openstack/config_test.go
@@ -459,15 +459,18 @@ func (s *ConfigSuite) TestBootstrapConfigSetsDefaultBlockSource(c *gc.C) {
 }
 
 func bootstrapConfigParams(cfg *config.Config) environs.BootstrapConfigParams {
+	credential := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+		"username":    "user",
+		"password":    "secret",
+		"tenant-name": "sometenant",
+	})
 	return environs.BootstrapConfigParams{
 		Config: cfg,
-		Credentials: cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
-			"username":    "user",
-			"password":    "secret",
-			"tenant-name": "sometenant",
-		}),
-		CloudRegion:   "region",
-		CloudEndpoint: "http://auth",
+		Cloud: environs.CloudSpec{
+			Region:     "region",
+			Endpoint:   "http://auth",
+			Credential: &credential,
+		},
 	}
 }
 

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1818,15 +1818,19 @@ func (t *localServerSuite) TestTagInstance(c *gc.C) {
 }
 
 func prepareParams(attrs map[string]interface{}, cred *identity.Credentials) bootstrap.PrepareParams {
+	credential := makeCredential(cred)
 	return bootstrap.PrepareParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
 		BaseConfig:       attrs,
 		ControllerName:   attrs["name"].(string),
-		Credential:       makeCredential(cred),
-		CloudName:        "openstack",
-		CloudEndpoint:    cred.URL,
-		CloudRegion:      cred.Region,
-		AdminSecret:      testing.AdminSecret,
+		Cloud: environs.CloudSpec{
+			Type:       "openstack",
+			Name:       "openstack",
+			Endpoint:   cred.URL,
+			Region:     cred.Region,
+			Credential: &credential,
+		},
+		AdminSecret: testing.AdminSecret,
 	}
 }
 

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -116,11 +116,11 @@ func (p EnvironProvider) PrepareForCreateEnvironment(controllerUUID string, cfg 
 func (p EnvironProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
 	// Add credentials to the configuration.
 	attrs := map[string]interface{}{
-		"region":   args.CloudRegion,
-		"auth-url": args.CloudEndpoint,
+		"region":   args.Cloud.Region,
+		"auth-url": args.Cloud.Endpoint,
 	}
-	credentialAttrs := args.Credentials.Attributes()
-	switch authType := args.Credentials.AuthType(); authType {
+	credentialAttrs := args.Cloud.Credential.Attributes()
+	switch authType := args.Cloud.Credential.AuthType(); authType {
 	case cloud.UserPassAuthType:
 		// TODO(axw) we need a way of saying to use legacy auth.
 		attrs["username"] = credentialAttrs["username"]

--- a/provider/rackspace/provider.go
+++ b/provider/rackspace/provider.go
@@ -21,6 +21,6 @@ func (p *environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (
 	// Rackspace regions are expected to be uppercase, but Juju
 	// stores and displays them in lowercase in the CLI. Ensure
 	// they're uppercase when they get to the Rackspace API.
-	args.CloudRegion = strings.ToUpper(args.CloudRegion)
+	args.Cloud.Region = strings.ToUpper(args.Cloud.Region)
 	return p.EnvironProvider.BootstrapConfig(args)
 }

--- a/provider/rackspace/provider_test.go
+++ b/provider/rackspace/provider_test.go
@@ -42,11 +42,15 @@ func (s *providerSuite) TestValidate(c *gc.C) {
 }
 
 func (s *providerSuite) TestBootstrapConfig(c *gc.C) {
-	args := environs.BootstrapConfigParams{CloudRegion: "dfw"}
+	args := environs.BootstrapConfigParams{
+		Cloud: environs.CloudSpec{
+			Region: "dfw",
+		},
+	}
 	s.provider.BootstrapConfig(args)
 
 	expect := args
-	expect.CloudRegion = "DFW"
+	expect.Cloud.Region = "DFW"
 	s.innerProvider.CheckCalls(c, []testing.StubCall{
 		{"BootstrapConfig", []interface{}{expect}},
 	})

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -32,9 +32,9 @@ func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) 
 // BootstrapConfig implements environs.EnvironProvider.
 func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
 	cfg := args.Config
-	switch authType := args.Credentials.AuthType(); authType {
+	switch authType := args.Cloud.Credential.AuthType(); authType {
 	case cloud.UserPassAuthType:
-		credentialAttrs := args.Credentials.Attributes()
+		credentialAttrs := args.Cloud.Credential.Attributes()
 		var err error
 		cfg, err = cfg.Apply(map[string]interface{}{
 			cfgUser:     credentialAttrs["user"],

--- a/provider/vsphere/provider_test.go
+++ b/provider/vsphere/provider_test.go
@@ -43,12 +43,15 @@ func (s *providerSuite) TestOpen(c *gc.C) {
 }
 
 func (s *providerSuite) TestBootstrapConfig(c *gc.C) {
+	credential := cloud.NewCredential(
+		cloud.UserPassAuthType,
+		map[string]string{"user": "u", "password": "p"},
+	)
 	cfg, err := s.provider.BootstrapConfig(environs.BootstrapConfigParams{
 		Config: s.Config,
-		Credentials: cloud.NewCredential(
-			cloud.UserPassAuthType,
-			map[string]string{"user": "u", "password": "p"},
-		),
+		Cloud: environs.CloudSpec{
+			Credential: &credential,
+		},
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(cfg, gc.NotNil)

--- a/state/stateenvirons/config_test.go
+++ b/state/stateenvirons/config_test.go
@@ -1,0 +1,63 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package stateenvirons_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/state/stateenvirons"
+	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/testing/factory"
+)
+
+type environSuite struct {
+	statetesting.StateSuite
+}
+
+var _ = gc.Suite(&environSuite{})
+
+func (s *environSuite) TestGetNewEnvironFunc(c *gc.C) {
+	var calls int
+	var callArgs environs.OpenParams
+	newEnviron := func(args environs.OpenParams) (environs.Environ, error) {
+		calls++
+		callArgs = args
+		return nil, nil
+	}
+	stateenvirons.GetNewEnvironFunc(newEnviron)(s.State)
+	c.Assert(calls, gc.Equals, 1)
+
+	cfg, err := s.State.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(callArgs.Config, jc.DeepEquals, cfg)
+}
+
+func (s *environSuite) TestCloudSpec(c *gc.C) {
+	owner := s.Factory.MakeUser(c, nil).UserTag()
+	emptyCredential := cloud.NewEmptyCredential()
+	err := s.State.UpdateCloudCredentials(owner, "dummy", map[string]cloud.Credential{
+		"empty-credential": emptyCredential,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	st := s.Factory.MakeModel(c, &factory.ModelParams{
+		Name:            "foo",
+		CloudName:       "dummy",
+		CloudCredential: "empty-credential",
+		Owner:           owner,
+	})
+	defer st.Close()
+
+	emptyCredential.Label = "empty-credential"
+	cloudSpec, err := stateenvirons.EnvironConfigGetter{st}.CloudSpec()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloudSpec, jc.DeepEquals, environs.CloudSpec{
+		Type:       "dummy",
+		Name:       "dummy",
+		Credential: &emptyCredential,
+	})
+}

--- a/state/stateenvirons/package_test.go
+++ b/state/stateenvirons/package_test.go
@@ -1,0 +1,22 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package stateenvirons_test
+
+import (
+	"testing"
+
+	"github.com/juju/utils/os"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+func TestPackage(t *testing.T) {
+	// At this stage, Juju only supports running the apiservers and database
+	// on Ubuntu. If we end up officially supporting CentOS, then we should
+	// make sure we run the tests there.
+	if os.HostOS() != os.Ubuntu {
+		t.Skipf("skipping tests on %v", os.HostOS())
+	}
+	coretesting.MgoTestPackage(t)
+}

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -60,7 +60,7 @@ func (s *firewallerBaseSuite) setUpTest(c *gc.C, firewallMode string) {
 	c.Assert(s.st, gc.NotNil)
 
 	// Create the firewaller API facade.
-	s.firewaller = s.st.Firewaller()
+	s.firewaller = apifirewaller.NewState(s.st)
 	c.Assert(s.firewaller, gc.NotNil)
 }
 


### PR DESCRIPTION
Add the environs.CloudSpec type, which contains
the information required to connect to the cloud
provider. This includes the cloud type and name;
region name; endpoints; and credentials. This
will later be added to OpenParams, and also
PrepareForCreateEnvironment (or we may refactor
EnvironProvider.BootstrapConfig so that it is
used for both bootstrap and hosted models).

environs.BootstrapConfigParams and
environs/bootstrap.PrepareParams are both updated
to use the new struct instead of spreading the
contents out like they used to. The providers are
of course updated to match.

The state/stateenvirons package has been updated
with a method of producing a CloudSpec from a
*state.State. This will be used in a follow-up
PR that introduces a CloudSpec method to several
apiserver facades.

(Review request: http://reviews.vapour.ws/r/5316/)