### PR TITLE
{apiserver,api}/common/cloudspec: cloudspec API

### DIFF
--- a/api/agent/state.go
+++ b/api/agent/state.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/common"
+	"github.com/juju/juju/api/common/cloudspec"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state/multiwatcher"
@@ -19,6 +20,7 @@ import (
 type State struct {
 	facade base.FacadeCaller
 	*common.ModelWatcher
+	*cloudspec.CloudSpecAPI
 	*common.ControllerConfigAPI
 }
 
@@ -29,6 +31,7 @@ func NewState(caller base.APICaller) *State {
 	return &State{
 		facade:              facadeCaller,
 		ModelWatcher:        common.NewModelWatcher(facadeCaller),
+		CloudSpecAPI:        cloudspec.NewCloudSpecAPI(facadeCaller),
 		ControllerConfigAPI: common.NewControllerConfig(facadeCaller),
 	}
 }

--- a/api/common/cloudspec/cloudspec.go
+++ b/api/common/cloudspec/cloudspec.go
@@ -1,0 +1,64 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudspec
+
+import (
+	"github.com/juju/errors"
+	names "gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
+)
+
+// CloudSpecAPI provides common client-side API functions
+// to call into apiserver/common/cloudspec.CloudSpec.
+type CloudSpecAPI struct {
+	facade base.FacadeCaller
+}
+
+// NewCloudSpecAPI creates a CloudSpecAPI using the provided
+// FacadeCaller.
+func NewCloudSpecAPI(facade base.FacadeCaller) *CloudSpecAPI {
+	return &CloudSpecAPI{facade}
+}
+
+// CloudSpec returns the cloud specification for the model
+// with the given tag.
+func (api *CloudSpecAPI) CloudSpec(tag names.ModelTag) (environs.CloudSpec, error) {
+	var results params.CloudSpecResults
+	args := params.Entities{Entities: []params.Entity{{tag.String()}}}
+	err := api.facade.FacadeCall("CloudSpec", args, &results)
+	if err != nil {
+		return environs.CloudSpec{}, err
+	}
+	if n := len(results.Results); n != 1 {
+		return environs.CloudSpec{}, errors.Errorf("expected 1 result, got %d", n)
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return environs.CloudSpec{}, errors.Annotate(result.Error, "API request failed")
+	}
+	var credential *cloud.Credential
+	if result.Result.Credential != nil {
+		credentialValue := cloud.NewCredential(
+			cloud.AuthType(result.Result.Credential.AuthType),
+			result.Result.Credential.Attributes,
+		)
+		credential = &credentialValue
+	}
+	spec := environs.CloudSpec{
+		Type:            result.Result.Type,
+		Name:            result.Result.Name,
+		Region:          result.Result.Region,
+		Endpoint:        result.Result.Endpoint,
+		StorageEndpoint: result.Result.StorageEndpoint,
+		Credential:      credential,
+	}
+	if err := spec.Validate(); err != nil {
+		return environs.CloudSpec{}, errors.Annotate(err, "validating CloudSpec")
+	}
+	return spec, nil
+}

--- a/api/common/cloudspec/cloudspec_test.go
+++ b/api/common/cloudspec/cloudspec_test.go
@@ -1,0 +1,127 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudspec_test
+
+import (
+	"errors"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	apitesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/common/cloudspec"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&CloudSpecSuite{})
+
+type CloudSpecSuite struct {
+	testing.IsolationSuite
+}
+
+func (s *CloudSpecSuite) TestNewCloudSpecAPI(c *gc.C) {
+	api := cloudspec.NewCloudSpecAPI(nil)
+	c.Check(api, gc.NotNil)
+}
+
+func (s *CloudSpecSuite) TestCloudSpec(c *gc.C) {
+	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
+	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
+		c.Assert(name, gc.Equals, "CloudSpec")
+		c.Assert(args, jc.DeepEquals, params.Entities{[]params.Entity{
+			{coretesting.ModelTag.String()},
+		}})
+		*(response.(*params.CloudSpecResults)) = params.CloudSpecResults{
+			[]params.CloudSpecResult{{
+				Result: &params.CloudSpec{
+					Type:            "type",
+					Name:            "name",
+					Region:          "region",
+					Endpoint:        "endpoint",
+					StorageEndpoint: "storage-endpoint",
+					Credential: &params.CloudCredential{
+						AuthType:   "auth-type",
+						Attributes: map[string]string{"k": "v"},
+					},
+				},
+			}},
+		}
+		return nil
+	}
+	api := cloudspec.NewCloudSpecAPI(&facadeCaller)
+	cloudSpec, err := api.CloudSpec(coretesting.ModelTag)
+	c.Assert(err, jc.ErrorIsNil)
+
+	credential := cloud.NewCredential(
+		"auth-type",
+		map[string]string{"k": "v"},
+	)
+	c.Assert(cloudSpec, jc.DeepEquals, environs.CloudSpec{
+		Type:            "type",
+		Name:            "name",
+		Region:          "region",
+		Endpoint:        "endpoint",
+		StorageEndpoint: "storage-endpoint",
+		Credential:      &credential,
+	})
+}
+
+func (s *CloudSpecSuite) TestCloudSpecOverallError(c *gc.C) {
+	expect := errors.New("bewm")
+	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
+	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
+		return expect
+	}
+	api := cloudspec.NewCloudSpecAPI(&facadeCaller)
+	_, err := api.CloudSpec(coretesting.ModelTag)
+	c.Assert(err, gc.Equals, expect)
+}
+
+func (s *CloudSpecSuite) TestCloudSpecResultCountMismatch(c *gc.C) {
+	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
+	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
+		return nil
+	}
+	api := cloudspec.NewCloudSpecAPI(&facadeCaller)
+	_, err := api.CloudSpec(coretesting.ModelTag)
+	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 0")
+}
+
+func (s *CloudSpecSuite) TestCloudSpecResultError(c *gc.C) {
+	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
+	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
+		*(response.(*params.CloudSpecResults)) = params.CloudSpecResults{
+			[]params.CloudSpecResult{{
+				Error: &params.Error{
+					Code:    params.CodeUnauthorized,
+					Message: "dang",
+				},
+			}},
+		}
+		return nil
+	}
+	api := cloudspec.NewCloudSpecAPI(&facadeCaller)
+	_, err := api.CloudSpec(coretesting.ModelTag)
+	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
+	c.Assert(err, gc.ErrorMatches, "API request failed: dang")
+}
+
+func (s *CloudSpecSuite) TestCloudSpecInvalidCloudSpec(c *gc.C) {
+	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
+	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
+		*(response.(*params.CloudSpecResults)) = params.CloudSpecResults{[]params.CloudSpecResult{{
+			Result: &params.CloudSpec{
+				Type: "",
+			},
+		}}}
+		return nil
+	}
+	api := cloudspec.NewCloudSpecAPI(&facadeCaller)
+	_, err := api.CloudSpec(coretesting.ModelTag)
+	c.Assert(err, gc.ErrorMatches, "validating CloudSpec: empty Type not valid")
+}

--- a/api/common/cloudspec/package_test.go
+++ b/api/common/cloudspec/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudspec_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/common"
+	"github.com/juju/juju/api/common/cloudspec"
 	"github.com/juju/juju/apiserver/params"
 )
 
@@ -19,6 +20,7 @@ type Client struct {
 	base.ClientFacade
 	facade base.FacadeCaller
 	*common.ControllerConfigAPI
+	*cloudspec.CloudSpecAPI
 }
 
 // NewClient creates a new `Client` based on an existing authenticated API
@@ -29,6 +31,7 @@ func NewClient(st base.APICallCloser) *Client {
 		ClientFacade:        frontend,
 		facade:              backend,
 		ControllerConfigAPI: common.NewControllerConfig(backend),
+		CloudSpecAPI:        cloudspec.NewCloudSpecAPI(backend),
 	}
 }
 

--- a/api/firewaller/firewaller.go
+++ b/api/firewaller/firewaller.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/common"
+	"github.com/juju/juju/api/common/cloudspec"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/watcher"
@@ -20,6 +21,7 @@ const firewallerFacade = "Firewaller"
 type State struct {
 	facade base.FacadeCaller
 	*common.ModelWatcher
+	*cloudspec.CloudSpecAPI
 }
 
 // NewState creates a new client-side Firewaller API facade.
@@ -28,6 +30,7 @@ func NewState(caller base.APICaller) *State {
 	return &State{
 		facade:       facadeCaller,
 		ModelWatcher: common.NewModelWatcher(facadeCaller),
+		CloudSpecAPI: cloudspec.NewCloudSpecAPI(facadeCaller),
 	}
 }
 

--- a/api/provisioner/provisioner.go
+++ b/api/provisioner/provisioner.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/common"
+	"github.com/juju/juju/api/common/cloudspec"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
@@ -22,6 +23,7 @@ type State struct {
 	*common.ModelWatcher
 	*common.APIAddresser
 	*common.ControllerConfigAPI
+	*cloudspec.CloudSpecAPI
 
 	facade base.FacadeCaller
 }
@@ -35,6 +37,7 @@ func NewState(caller base.APICaller) *State {
 		ModelWatcher:        common.NewModelWatcher(facadeCaller),
 		APIAddresser:        common.NewAPIAddresser(facadeCaller),
 		ControllerConfigAPI: common.NewControllerConfig(facadeCaller),
+		CloudSpecAPI:        cloudspec.NewCloudSpecAPI(facadeCaller),
 		facade:              facadeCaller}
 }
 

--- a/apiserver/agent/agent.go
+++ b/apiserver/agent/agent.go
@@ -11,11 +11,13 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/common/cloudspec"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/state/stateenvirons"
 )
 
 func init() {
@@ -28,6 +30,7 @@ type AgentAPIV2 struct {
 	*common.RebootFlagClearer
 	*common.ModelWatcher
 	*common.ControllerConfigAPI
+	cloudspec.CloudSpecAPI
 
 	st   *state.State
 	auth facade.Authorizer
@@ -43,11 +46,13 @@ func NewAgentAPIV2(st *state.State, resources facade.Resources, auth facade.Auth
 	getCanChange := func() (common.AuthFunc, error) {
 		return auth.AuthOwner, nil
 	}
+	environConfigGetter := stateenvirons.EnvironConfigGetter{st}
 	return &AgentAPIV2{
 		PasswordChanger:     common.NewPasswordChanger(st, getCanChange),
 		RebootFlagClearer:   common.NewRebootFlagClearer(st, getCanChange),
 		ModelWatcher:        common.NewModelWatcher(st, resources, auth),
 		ControllerConfigAPI: common.NewControllerConfig(st),
+		CloudSpecAPI:        cloudspec.NewCloudSpecForModel(st.ModelTag(), environConfigGetter.CloudSpec),
 		st:                  st,
 		auth:                auth,
 	}, nil

--- a/apiserver/common/cloudspec/cloudspec.go
+++ b/apiserver/common/cloudspec/cloudspec.go
@@ -1,0 +1,91 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudspec
+
+import (
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs"
+)
+
+// CloudSpecAPI implements common methods for use by various
+// facades for querying the cloud spec of models.
+type CloudSpecAPI struct {
+	getCloudSpec func(names.ModelTag) (environs.CloudSpec, error)
+	getAuthFunc  common.GetAuthFunc
+}
+
+// NewCloudSpec returns a new CloudSpecAPI.
+func NewCloudSpec(
+	getCloudSpec func(names.ModelTag) (environs.CloudSpec, error),
+	getAuthFunc common.GetAuthFunc,
+) CloudSpecAPI {
+	return CloudSpecAPI{getCloudSpec, getAuthFunc}
+}
+
+// NewCloudSpecForModel returns a new CloudSpecAPI that permits access to only
+// one model.
+func NewCloudSpecForModel(
+	modelTag names.ModelTag,
+	getCloudSpec func() (environs.CloudSpec, error),
+) CloudSpecAPI {
+	return CloudSpecAPI{
+		func(names.ModelTag) (environs.CloudSpec, error) {
+			// The tag passed in is guaranteed to be the
+			// same as "modelTag", as the authorizer below
+			// would have failed otherwise.
+			return getCloudSpec()
+		},
+		func() (common.AuthFunc, error) {
+			return func(tag names.Tag) bool {
+				return tag == modelTag
+			}, nil
+		},
+	}
+}
+
+// CloudSpec returns the model's cloud spec.
+func (s CloudSpecAPI) CloudSpec(args params.Entities) (params.CloudSpecResults, error) {
+	authFunc, err := s.getAuthFunc()
+	if err != nil {
+		return params.CloudSpecResults{}, err
+	}
+	results := params.CloudSpecResults{
+		Results: make([]params.CloudSpecResult, len(args.Entities)),
+	}
+	for i, arg := range args.Entities {
+		tag, err := names.ParseModelTag(arg.Tag)
+		if err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		if !authFunc(tag) {
+			results.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+		spec, err := s.getCloudSpec(tag)
+		if err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		var paramsCloudCredential *params.CloudCredential
+		if spec.Credential != nil && spec.Credential.AuthType() != "" {
+			paramsCloudCredential = &params.CloudCredential{
+				string(spec.Credential.AuthType()),
+				spec.Credential.Attributes(),
+			}
+		}
+		results.Results[i].Result = &params.CloudSpec{
+			spec.Type,
+			spec.Name,
+			spec.Region,
+			spec.Endpoint,
+			spec.StorageEndpoint,
+			paramsCloudCredential,
+		}
+	}
+	return results, nil
+}

--- a/apiserver/common/cloudspec/cloudspec_test.go
+++ b/apiserver/common/cloudspec/cloudspec_test.go
@@ -1,0 +1,139 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudspec_test
+
+import (
+	"errors"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+	names "gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/common/cloudspec"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type CloudSpecSuite struct {
+	testing.IsolationSuite
+	testing.Stub
+	result   environs.CloudSpec
+	authFunc common.AuthFunc
+	api      cloudspec.CloudSpecAPI
+}
+
+var _ = gc.Suite(&CloudSpecSuite{})
+
+func (s *CloudSpecSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.Stub.ResetCalls()
+
+	s.authFunc = func(tag names.Tag) bool {
+		s.AddCall("Auth", tag)
+		return tag == coretesting.ModelTag
+	}
+	s.api = cloudspec.NewCloudSpec(func(tag names.ModelTag) (environs.CloudSpec, error) {
+		s.AddCall("CloudSpec", tag)
+		return s.result, s.NextErr()
+	}, func() (common.AuthFunc, error) {
+		s.AddCall("GetAuthFunc")
+		return s.authFunc, s.NextErr()
+	})
+
+	credential := cloud.NewCredential(
+		"auth-type",
+		map[string]string{"k": "v"},
+	)
+	s.result = environs.CloudSpec{
+		"type",
+		"name",
+		"region",
+		"endpoint",
+		"storage-endpoint",
+		&credential,
+	}
+}
+
+func (s *CloudSpecSuite) TestCloudSpec(c *gc.C) {
+	otherModelTag := names.NewModelTag(utils.MustNewUUID().String())
+	machineTag := names.NewMachineTag("42")
+	result, err := s.api.CloudSpec(params.Entities{Entities: []params.Entity{
+		{coretesting.ModelTag.String()},
+		{otherModelTag.String()},
+		{machineTag.String()},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, jc.DeepEquals, []params.CloudSpecResult{{
+		Result: &params.CloudSpec{
+			"type",
+			"name",
+			"region",
+			"endpoint",
+			"storage-endpoint",
+			&params.CloudCredential{
+				"auth-type",
+				map[string]string{"k": "v"},
+			},
+		},
+	}, {
+		Error: &params.Error{
+			Code:    params.CodeUnauthorized,
+			Message: "permission denied",
+		},
+	}, {
+		Error: &params.Error{
+			Message: `"machine-42" is not a valid model tag`,
+		},
+	}})
+	s.CheckCalls(c, []testing.StubCall{
+		{"GetAuthFunc", nil},
+		{"Auth", []interface{}{coretesting.ModelTag}},
+		{"CloudSpec", []interface{}{coretesting.ModelTag}},
+		{"Auth", []interface{}{otherModelTag}},
+	})
+}
+
+func (s *CloudSpecSuite) TestCloudSpecNilCredential(c *gc.C) {
+	s.result.Credential = nil
+	result, err := s.api.CloudSpec(params.Entities{
+		Entities: []params.Entity{{coretesting.ModelTag.String()}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, jc.DeepEquals, []params.CloudSpecResult{{
+		Result: &params.CloudSpec{
+			"type",
+			"name",
+			"region",
+			"endpoint",
+			"storage-endpoint",
+			nil,
+		},
+	}})
+}
+
+func (s *CloudSpecSuite) TestCloudSpecGetAuthFuncError(c *gc.C) {
+	expect := errors.New("bewm")
+	s.SetErrors(expect)
+	result, err := s.api.CloudSpec(params.Entities{
+		Entities: []params.Entity{{coretesting.ModelTag.String()}},
+	})
+	c.Assert(err, gc.Equals, expect)
+	c.Assert(result, jc.DeepEquals, params.CloudSpecResults{})
+}
+
+func (s *CloudSpecSuite) TestCloudSpecCloudSpecError(c *gc.C) {
+	s.SetErrors(nil, errors.New("bewm"))
+	result, err := s.api.CloudSpec(params.Entities{
+		Entities: []params.Entity{{coretesting.ModelTag.String()}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.CloudSpecResults{Results: []params.CloudSpecResult{{
+		Error: &params.Error{Message: "bewm"},
+	}}})
+}

--- a/apiserver/common/cloudspec/package_test.go
+++ b/apiserver/common/cloudspec/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudspec_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/firewaller/firewaller.go
+++ b/apiserver/firewaller/firewaller.go
@@ -8,10 +8,12 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/common/cloudspec"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/stateenvirons"
 	"github.com/juju/juju/state/watcher"
 )
 
@@ -28,6 +30,7 @@ type FirewallerAPI struct {
 	*common.UnitsWatcher
 	*common.ModelMachinesWatcher
 	*common.InstanceIdGetter
+	cloudspec.CloudSpecAPI
 
 	st            *state.State
 	resources     facade.Resources
@@ -91,6 +94,9 @@ func NewFirewallerAPI(
 		accessMachine,
 	)
 
+	environConfigGetter := stateenvirons.EnvironConfigGetter{st}
+	cloudSpecAPI := cloudspec.NewCloudSpecForModel(st.ModelTag(), environConfigGetter.CloudSpec)
+
 	return &FirewallerAPI{
 		LifeGetter:           lifeGetter,
 		ModelWatcher:         modelWatcher,
@@ -98,6 +104,7 @@ func NewFirewallerAPI(
 		UnitsWatcher:         unitsWatcher,
 		ModelMachinesWatcher: machinesWatcher,
 		InstanceIdGetter:     instanceIdGetter,
+		CloudSpecAPI:         cloudSpecAPI,
 		st:                   st,
 		resources:            resources,
 		authorizer:           authorizer,

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -83,10 +83,31 @@ type CloudDefaults struct {
 // CloudDefaultsResult contains a CloudDefaults or an error.
 type CloudDefaultsResult struct {
 	Result *CloudDefaults `json:"result,omitempty"`
-	Error  *Error         `json:"error"`
+	Error  *Error         `json:"error,omitempty"`
 }
 
 // CloudDefaultsResults contains a set of CloudDefaultsResults.
 type CloudDefaultsResults struct {
 	Results []CloudDefaultsResult `json:"results,omitempty"`
+}
+
+// CloudSpec holds a cloud specification.
+type CloudSpec struct {
+	Type            string           `json:"type"`
+	Name            string           `json:"name"`
+	Region          string           `json:"region,omitempty"`
+	Endpoint        string           `json:"endpoint,omitempty"`
+	StorageEndpoint string           `json:"storage-endpoint,omitempty"`
+	Credential      *CloudCredential `json:"credential,omitempty"`
+}
+
+// CloudSpecResult contains a CloudSpec or an error.
+type CloudSpecResult struct {
+	Result *CloudSpec `json:"result,omitempty"`
+	Error  *Error     `json:"error,omitempty"`
+}
+
+// CloudSpecResults contains a set of CloudSpecResults.
+type CloudSpecResults struct {
+	Results []CloudSpecResult `json:"results,omitempty"`
 }

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/common/cloudspec"
 	"github.com/juju/juju/apiserver/common/networkingcommon"
 	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/apiserver/facade"
@@ -49,6 +50,7 @@ type ProvisionerAPI struct {
 	*common.InstanceIdGetter
 	*common.ToolsFinder
 	*common.ToolsGetter
+	cloudspec.CloudSpecAPI
 
 	st           *state.State
 	resources    facade.Resources
@@ -115,6 +117,7 @@ func NewProvisionerAPI(st *state.State, resources facade.Resources, authorizer f
 		InstanceIdGetter:     common.NewInstanceIdGetter(st, getAuthFunc),
 		ToolsFinder:          common.NewToolsFinder(configGetter, st, urlGetter),
 		ToolsGetter:          common.NewToolsGetter(st, configGetter, st, urlGetter, getAuthOwner),
+		CloudSpecAPI:         cloudspec.NewCloudSpecForModel(st.ModelTag(), configGetter.CloudSpec),
 		st:                   st,
 		resources:            resources,
 		authorizer:           authorizer,

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -336,6 +336,7 @@ type StubBacking struct {
 	*testing.Stub
 
 	EnvConfig *config.Config
+	Cloud     environs.CloudSpec
 
 	Zones   []providercommon.AvailabilityZone
 	Spaces  []networkingcommon.BackingSpace
@@ -368,6 +369,12 @@ func (sb *StubBacking) SetUp(c *gc.C, envName string, withZones, withSpaces, wit
 		"name": envName,
 	}
 	sb.EnvConfig = coretesting.CustomModelConfig(c, extraAttrs)
+	sb.Cloud = environs.CloudSpec{
+		Type:            StubProviderType,
+		Name:            "cloud-name",
+		Endpoint:        "endpoint",
+		StorageEndpoint: "storage-endpoint",
+	}
 	sb.Zones = []providercommon.AvailabilityZone{}
 	if withZones {
 		sb.Zones = make([]providercommon.AvailabilityZone, len(ProviderInstance.Zones))
@@ -424,6 +431,14 @@ func (sb *StubBacking) ModelConfig() (*config.Config, error) {
 		return nil, err
 	}
 	return sb.EnvConfig, nil
+}
+
+func (sb *StubBacking) CloudSpec() (environs.CloudSpec, error) {
+	sb.MethodCall(sb, "CloudSpec")
+	if err := sb.NextErr(); err != nil {
+		return environs.CloudSpec{}, err
+	}
+	return sb.Cloud, nil
 }
 
 func (sb *StubBacking) AvailabilityZones() ([]providercommon.AvailabilityZone, error) {

--- a/environs/cloudspec.go
+++ b/environs/cloudspec.go
@@ -3,7 +3,11 @@
 
 package environs
 
-import "github.com/juju/juju/cloud"
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/cloud"
+	names "gopkg.in/juju/names.v2"
+)
 
 // CloudSpec describes a specific cloud configuration, for the purpose
 // of opening an Environ to manage the cloud resources.
@@ -28,4 +32,16 @@ type CloudSpec struct {
 	// with the cloud, or nil if the cloud does not require any
 	// credentials.
 	Credential *cloud.Credential
+}
+
+// Validate validates that the CloudSpec is well-formed. It does
+// not ensure that the cloud type and credentials are valid.
+func (cs CloudSpec) Validate() error {
+	if cs.Type == "" {
+		return errors.NotValidf("empty Type")
+	}
+	if !names.IsValidCloud(cs.Name) {
+		return errors.NotValidf("cloud name %q", cs.Name)
+	}
+	return nil
 }


### PR DESCRIPTION
Add a common CloudSpec API to various facades,
for workers and other clients that need to
construct an Environ. The controller facade
needs to embed this API for "destroy-controller"
to work without access to bootstrap config.

The API method is non-bulk, like ModelConfig,
as it doesn't make sense to specify model tags
in the facades that the API is included in.
In all cases, all methods in the facade are
scoped to a single model. In the case of the
controller, we only want to be able to query
the CloudSpec of the controller model.

These will be used in a following PR, where we
add CloudSpec to environs.OpenParams.

**QA**

Bootstrapped lxd.

(Review request: http://reviews.vapour.ws/r/5320/)