### PR TITLE
When adding a model, fork and store default config attributes

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -222,7 +222,9 @@ LXC_BRIDGE="ignored"`[1:])
 	newModelCfg, err := st.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	// Add in the cloud attributes.
-	expectedAttrs := modelCfg.AllAttrs()
+	expectedCfg, err := config.New(config.UseDefaults, modelAttrs)
+	c.Assert(err, jc.ErrorIsNil)
+	expectedAttrs := expectedCfg.AllAttrs()
 	expectedAttrs["apt-mirror"] = "http://mirror"
 	c.Assert(newModelCfg.AllAttrs(), jc.DeepEquals, expectedAttrs)
 

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -32,6 +32,7 @@ type ModelManagerBackend interface {
 	IsControllerAdministrator(user names.UserTag) (bool, error)
 	NewModel(state.ModelArgs) (Model, ModelManagerBackend, error)
 
+	ComposeNewModelConfig(modelAttr map[string]interface{}) (map[string]interface{}, error)
 	ControllerModel() (Model, error)
 	ControllerConfig() (controller.Config, error)
 	ForModel(tag names.ModelTag) (ModelManagerBackend, error)

--- a/apiserver/common/modelwatcher_test.go
+++ b/apiserver/common/modelwatcher_test.go
@@ -126,7 +126,7 @@ func testingEnvConfig(c *gc.C) *config.Config {
 		bootstrap.PrepareParams{
 			ControllerConfig: testing.FakeControllerConfig(),
 			ControllerName:   "dummycontroller",
-			BaseConfig:       dummy.SampleConfig(),
+			ModelConfig:      dummy.SampleConfig(),
 			Cloud:            dummy.SampleCloudSpec(),
 			AdminSecret:      "admin-secret",
 		},

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -273,6 +273,16 @@ func (st *mockState) ControllerModel() (common.Model, error) {
 	return st.controllerModel, st.NextErr()
 }
 
+func (st *mockState) ComposeNewModelConfig(modelAttr map[string]interface{}) (map[string]interface{}, error) {
+	st.MethodCall(st, "ComposeNewModelConfig")
+	attr := make(map[string]interface{})
+	for attrName, val := range modelAttr {
+		attr[attrName] = val
+	}
+	attr["something"] = "value"
+	return attr, st.NextErr()
+}
+
 func (st *mockState) ControllerConfig() (controller.Config, error) {
 	st.MethodCall(st, "ControllerConfig")
 	return controller.Config{

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -150,6 +150,9 @@ func (mm *ModelManagerAPI) newModelConfig(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	if joint, err = mm.state.ComposeNewModelConfig(joint); err != nil {
+		return nil, errors.Trace(err)
+	}
 	creator := modelmanager.ModelConfigCreator{
 		FindTools: func(n version.Number) (tools.List, error) {
 			result, err := mm.toolsFinder.FindTools(params.FindToolsParams{

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -28,7 +28,6 @@ import (
 	jujuversion "github.com/juju/juju/version"
 	// Register the providers for the field check test
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/controller"
 	_ "github.com/juju/juju/provider/azure"
 	"github.com/juju/juju/provider/dummy"
 	_ "github.com/juju/juju/provider/ec2"
@@ -129,6 +128,7 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 		"ControllerModel",
 		"CloudCredentials",
 		"ControllerConfig",
+		"ComposeNewModelConfig",
 		"NewModel",
 		"ForModel",
 		"Model",
@@ -140,7 +140,7 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 	// We cannot predict the UUID, because it's generated,
 	// so we just extract it and ensure that it's not the
 	// same as the controller UUID.
-	newModelArgs := s.st.Calls()[5].Args[0].(state.ModelArgs)
+	newModelArgs := s.st.Calls()[6].Args[0].(state.ModelArgs)
 	uuid := newModelArgs.Config.UUID()
 	c.Assert(uuid, gc.Not(gc.Equals), s.st.controllerModel.cfg.UUID())
 
@@ -153,13 +153,9 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 		"controller":    false,
 		"broken":        "",
 		"secret":        "pork",
+		"something":     "value",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	// TODO(wallyworld) - we need to separate controller and model schemas
-	// Remove any remaining controller attributes from the env config.
-	cfg, err = cfg.Remove(controller.ControllerOnlyConfigAttributes)
-	c.Assert(err, jc.ErrorIsNil)
-
 	c.Assert(newModelArgs, jc.DeepEquals, state.ModelArgs{
 		Owner:           names.NewUserTag("admin@local"),
 		CloudName:       "some-cloud",
@@ -177,7 +173,7 @@ func (s *modelManagerSuite) TestCreateModelDefaultRegion(c *gc.C) {
 	_, err := s.api.CreateModel(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newModelArgs := s.st.Calls()[5].Args[0].(state.ModelArgs)
+	newModelArgs := s.st.Calls()[6].Args[0].(state.ModelArgs)
 	c.Assert(newModelArgs.CloudRegion, gc.Equals, "some-region")
 }
 
@@ -198,7 +194,7 @@ func (s *modelManagerSuite) testCreateModelDefaultCredentialAdmin(c *gc.C, owner
 	_, err := s.api.CreateModel(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newModelArgs := s.st.Calls()[5].Args[0].(state.ModelArgs)
+	newModelArgs := s.st.Calls()[6].Args[0].(state.ModelArgs)
 	c.Assert(newModelArgs.CloudCredential, gc.Equals, "some-credential")
 }
 
@@ -210,7 +206,7 @@ func (s *modelManagerSuite) TestCreateModelEmptyCredentialNonAdmin(c *gc.C) {
 	_, err := s.api.CreateModel(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newModelArgs := s.st.Calls()[5].Args[0].(state.ModelArgs)
+	newModelArgs := s.st.Calls()[6].Args[0].(state.ModelArgs)
 	c.Assert(newModelArgs.CloudCredential, gc.Equals, "")
 }
 

--- a/cmd/juju/model/get.go
+++ b/cmd/juju/model/get.go
@@ -88,6 +88,14 @@ func (c *getCommand) getAPI() (GetModelAPI, error) {
 	return modelconfig.NewClient(api), nil
 }
 
+func (c *getCommand) isModelAttrbute(attr string) bool {
+	switch attr {
+	case config.NameKey, config.TypeKey, config.UUIDKey:
+		return true
+	}
+	return false
+}
+
 func (c *getCommand) Run(ctx *cmd.Context) error {
 	client, err := c.getAPI()
 	if err != nil {
@@ -98,6 +106,14 @@ func (c *getCommand) Run(ctx *cmd.Context) error {
 	attrs, err := client.ModelGetWithMetadata()
 	if err != nil {
 		return err
+	}
+
+	for attrName := range attrs {
+		// We don't want model attributes included, these are available
+		// via show-model.
+		if c.isModelAttrbute(attrName) {
+			delete(attrs, attrName)
+		}
 	}
 
 	if c.key != "" {

--- a/cmd/juju/model/get_test.go
+++ b/cmd/juju/model/get_test.go
@@ -37,19 +37,19 @@ func (s *GetSuite) TestInit(c *gc.C) {
 }
 
 func (s *GetSuite) TestSingleValue(c *gc.C) {
-	context, err := s.run(c, "name")
+	context, err := s.run(c, "special")
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := strings.TrimSpace(testing.Stdout(context))
-	c.Assert(output, gc.Equals, "test-model")
+	c.Assert(output, gc.Equals, "special value")
 }
 
 func (s *GetSuite) TestSingleValueJSON(c *gc.C) {
-	context, err := s.run(c, "--format=json", "name")
+	context, err := s.run(c, "--format=json", "special")
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := strings.TrimSpace(testing.Stdout(context))
-	c.Assert(output, gc.Equals, "test-model")
+	c.Assert(output, gc.Equals, "special value")
 }
 
 func (s *GetSuite) TestAllValuesYAML(c *gc.C) {
@@ -58,9 +58,6 @@ func (s *GetSuite) TestAllValuesYAML(c *gc.C) {
 
 	output := strings.TrimSpace(testing.Stdout(context))
 	expected := "" +
-		"name:\n" +
-		"  value: test-model\n" +
-		"  source: model\n" +
 		"running:\n" +
 		"  value: true\n" +
 		"  source: model\n" +
@@ -75,7 +72,7 @@ func (s *GetSuite) TestAllValuesJSON(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := strings.TrimSpace(testing.Stdout(context))
-	expected := `{"name":{"Value":"test-model","Source":"model"},"running":{"Value":true,"Source":"model"},"special":{"Value":"special value","Source":"model"}}`
+	expected := `{"running":{"Value":true,"Source":"model"},"special":{"Value":"special value","Source":"model"}}`
 	c.Assert(output, gc.Equals, expected)
 }
 
@@ -86,7 +83,6 @@ func (s *GetSuite) TestAllValuesTabular(c *gc.C) {
 	output := strings.TrimSpace(testing.Stdout(context))
 	expected := "" +
 		"ATTRIBUTE  FROM   VALUE\n" +
-		"name       model  test-model\n" +
 		"running    model  True\n" +
 		"special    model  special value"
 	c.Assert(output, gc.Equals, expected)

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -406,7 +406,7 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 	}
 	bootstrapConfig.Config[config.UUIDKey] = controllerDetails.ControllerUUID
 
-	cfg, err := config.New(config.UseDefaults, bootstrapConfig.Config)
+	cfg, err := config.New(config.NoDefaults, bootstrapConfig.Config)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -57,7 +57,7 @@ func (s *ToolsMetadataSuite) SetUpTest(c *gc.C) {
 		bootstrap.PrepareParams{
 			ControllerConfig: coretesting.FakeControllerConfig(),
 			ControllerName:   cfg.Name(),
-			BaseConfig:       cfg.AllAttrs(),
+			ModelConfig:      cfg.AllAttrs(),
 			Cloud:            dummy.SampleCloudSpec(),
 			AdminSecret:      "admin-secret",
 		},

--- a/controller/modelmanager/createmodel.go
+++ b/controller/modelmanager/createmodel.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/version"
 
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/tools"
@@ -94,17 +93,11 @@ func (c ModelConfigCreator) NewModelConfig(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	attrs = cfg.AllAttrs()
 
-	// TODO(wallyworld) - we need to separate controller and model schemas
-	for _, attr := range controller.ControllerOnlyConfigAttributes {
-		if _, ok := attrs[attr]; ok {
-			return nil, errors.Errorf("unexpected controller attribute %q in model config", attr)
-		}
-	}
 	// Any values that would normally be copied from the controller
 	// config can also be defined, but if they differ from the controller
 	// values, an error is returned.
+	attrs = cfg.AllAttrs()
 	for _, field := range restrictedFields {
 		if value, ok := attrs[field]; ok {
 			if serverValue := baseAttrs[field]; value != serverValue {
@@ -203,13 +196,6 @@ func finalizeConfig(isAdmin bool, controllerUUID string, controllerModelCfg *con
 	cfg, err := config.New(config.UseDefaults, attrs)
 	if err != nil {
 		return nil, errors.Annotate(err, "creating config from values failed")
-	}
-
-	// TODO(wallyworld) - we need to separate controller and model schemas
-	// Remove any remaining controller attributes from the env config.
-	cfg, err = cfg.Remove(controller.ControllerOnlyConfigAttributes)
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot remove controller attributes")
 	}
 
 	cfg, err = provider.PrepareForCreateEnvironment(controllerUUID, cfg)

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -93,7 +93,7 @@ type BootstrapParams struct {
 	ControllerConfig controller.Config
 
 	// ControllerInheritedConfig is the set of config attributes to be shared
-	// across all models in the same controller on the bootstrap cloud.
+	// across all models in the same controller.
 	ControllerInheritedConfig map[string]interface{}
 
 	// HostedModelConfig is the set of config attributes to be overlaid

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -712,9 +712,10 @@ func (s *bootstrapSuite) TestFinishBootstrapConfig(c *gc.C) {
 
 	env := newEnviron("foo", useDefaultKeys, nil)
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      password,
-		CAPrivateKey:     coretesting.CAKey,
+		ControllerConfig:          coretesting.FakeControllerConfig(),
+		ControllerInheritedConfig: map[string]interface{}{"ftp-proxy": "http://proxy"},
+		AdminSecret:               password,
+		CAPrivateKey:              coretesting.CAKey,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	icfg := env.instanceConfig
@@ -727,6 +728,7 @@ func (s *bootstrapSuite) TestFinishBootstrapConfig(c *gc.C) {
 	c.Check(icfg.Controller.MongoInfo, jc.DeepEquals, &mongo.MongoInfo{
 		Password: password, Info: mongo.Info{CACert: coretesting.CACert},
 	})
+	c.Check(icfg.Bootstrap.ControllerInheritedConfig, gc.DeepEquals, map[string]interface{}{"ftp-proxy": "http://proxy"})
 	controllerCfg := icfg.Controller.Config
 	c.Check(controllerCfg["ca-private-key"], gc.IsNil)
 	c.Check(icfg.Bootstrap.StateServingInfo.StatePort, gc.Equals, controllerCfg.StatePort())

--- a/environs/bootstrap/prepare_test.go
+++ b/environs/bootstrap/prepare_test.go
@@ -43,6 +43,7 @@ func (*PrepareSuite) TestPrepare(c *gc.C) {
 	baselineAttrs := dummy.SampleConfig().Merge(testing.Attrs{
 		"controller": false,
 		"name":       "erewhemos",
+		"test-mode":  true,
 	}).Delete(
 		"admin-secret",
 	)
@@ -60,7 +61,7 @@ func (*PrepareSuite) TestPrepare(c *gc.C) {
 	_, err = bootstrap.Prepare(ctx, controllerStore, bootstrap.PrepareParams{
 		ControllerConfig: controllerCfg,
 		ControllerName:   cfg.Name(),
-		BaseConfig:       cfg.AllAttrs(),
+		ModelConfig:      cfg.AllAttrs(),
 		Cloud:            dummy.SampleCloudSpec(),
 		AdminSecret:      "admin-secret",
 	})
@@ -92,7 +93,7 @@ func (*PrepareSuite) TestPrepare(c *gc.C) {
 			"name":                      "erewhemos",
 			"controller":                false,
 			"development":               false,
-			"test-mode":                 false,
+			"test-mode":                 true,
 		},
 		Cloud:     "dummy",
 		CloudType: "dummy",
@@ -102,7 +103,7 @@ func (*PrepareSuite) TestPrepare(c *gc.C) {
 	_, err = bootstrap.Prepare(ctx, controllerStore, bootstrap.PrepareParams{
 		ControllerConfig: controllerCfg,
 		ControllerName:   cfg.Name(),
-		BaseConfig:       cfg.AllAttrs(),
+		ModelConfig:      cfg.AllAttrs(),
 		Cloud:            dummy.SampleCloudSpec(),
 		AdminSecret:      "admin-secret",
 	})

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -5,8 +5,6 @@ package config_test
 
 import (
 	"fmt"
-	"os"
-	"regexp"
 	"strings"
 	stdtesting "testing"
 	"time"
@@ -48,15 +46,20 @@ func (s *ConfigSuite) SetUpTest(c *gc.C) {
 // sampleConfig holds a configuration with all required
 // attributes set.
 var sampleConfig = testing.Attrs{
-	"type":                      "my-type",
-	"name":                      "my-name",
-	"uuid":                      testing.ModelTag.Id(),
-	"authorized-keys":           testing.FakeAuthKeys,
-	"firewall-mode":             config.FwInstance,
-	"unknown":                   "my-unknown",
-	"ssl-hostname-verification": true,
-	"development":               false,
-	"default-series":            series.LatestLts(),
+	"type":                       "my-type",
+	"name":                       "my-name",
+	"uuid":                       testing.ModelTag.Id(),
+	"authorized-keys":            testing.FakeAuthKeys,
+	"firewall-mode":              config.FwInstance,
+	"unknown":                    "my-unknown",
+	"ssl-hostname-verification":  true,
+	"development":                false,
+	"default-series":             series.LatestLts(),
+	"disable-network-management": false,
+	"ignore-machine-addresses":   false,
+	"automatically-retry-hooks":  true,
+	"proxy-ssh":                  false,
+	"resource-tags":              []string{},
 }
 
 type configTest struct {
@@ -71,8 +74,6 @@ var testResourceTags = []string{"a=b", "c=", "d=e"}
 var testResourceTagsMap = map[string]string{
 	"a": "b", "c": "", "d": "e",
 }
-
-var quotedPathSeparator = regexp.QuoteMeta(string(os.PathSeparator))
 
 var minimalConfigAttrs = testing.Attrs{
 	"type": "my-type",
@@ -106,12 +107,6 @@ var configTests = []configTest{
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"default-series": "my-series",
-		}),
-	}, {
-		about:       "Implicit series with empty value",
-		useDefaults: config.UseDefaults,
-		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"default-series": "",
 		}),
 	}, {
 		about:       "Explicit logging",
@@ -385,18 +380,23 @@ var configTests = []configTest{
 		about:       "Config settings from juju actual installation",
 		useDefaults: config.NoDefaults,
 		attrs: map[string]interface{}{
-			"name":                      "sample",
-			"development":               false,
-			"ssl-hostname-verification": true,
-			"authorized-keys":           "ssh-rsa mykeys rog@rog-x220\n",
-			"region":                    "us-east-1",
-			"default-series":            "precise",
-			"secret-key":                "a-secret-key",
-			"access-key":                "an-access-key",
-			"agent-version":             "1.13.2",
-			"firewall-mode":             "instance",
-			"type":                      "ec2",
-			"uuid":                      testing.ModelTag.Id(),
+			"name":                       "sample",
+			"development":                false,
+			"ssl-hostname-verification":  true,
+			"authorized-keys":            "ssh-rsa mykeys rog@rog-x220\n",
+			"region":                     "us-east-1",
+			"default-series":             "precise",
+			"secret-key":                 "a-secret-key",
+			"access-key":                 "an-access-key",
+			"agent-version":              "1.13.2",
+			"firewall-mode":              "instance",
+			"disable-network-management": false,
+			"ignore-machine-addresses":   false,
+			"automatically-retry-hooks":  true,
+			"proxy-ssh":                  false,
+			"resource-tags":              []string{},
+			"type":                       "ec2",
+			"uuid":                       testing.ModelTag.Id(),
 		},
 	}, {
 		about:       "TestMode flag specified",
@@ -432,8 +432,6 @@ var configTests = []configTest{
 		}),
 		err: `empty uuid in model configuration`,
 	},
-	missingAttributeNoDefault("development"),
-	missingAttributeNoDefault("ssl-hostname-verification"),
 	{
 		about:       "Explicit apt-mirror",
 		useDefaults: config.UseDefaults,
@@ -536,15 +534,6 @@ var configTests = []configTest{
 	},
 }
 
-func missingAttributeNoDefault(attrName string) configTest {
-	return configTest{
-		about:       fmt.Sprintf("No default: missing %s", attrName),
-		useDefaults: config.NoDefaults,
-		attrs:       sampleConfig.Delete(attrName),
-		err:         fmt.Sprintf("%s: expected [a-z]+, got nothing", attrName),
-	}
-}
-
 type testFile struct {
 	name, data string
 }
@@ -601,12 +590,13 @@ func (test configTest) check(c *gc.C, home *gitjujutesting.FakeHome) {
 	testmode, _ := test.attrs["test-mode"].(bool)
 	c.Assert(cfg.TestMode(), gc.Equals, testmode)
 
-	series, _ := test.attrs["default-series"].(string)
-	if defaultSeries, ok := cfg.DefaultSeries(); ok {
-		c.Assert(defaultSeries, gc.Equals, series)
+	seriesAttr, _ := test.attrs["default-series"].(string)
+	defaultSeries, ok := cfg.DefaultSeries()
+	c.Assert(ok, jc.IsTrue)
+	if seriesAttr != "" {
+		c.Assert(defaultSeries, gc.Equals, seriesAttr)
 	} else {
-		c.Assert(series, gc.Equals, "")
-		c.Assert(defaultSeries, gc.Equals, "")
+		c.Assert(defaultSeries, gc.Equals, series.LatestLts())
 	}
 
 	if m, _ := test.attrs["firewall-mode"].(string); m != "" {
@@ -694,11 +684,20 @@ func (test configTest) check(c *gc.C, home *gitjujutesting.FakeHome) {
 	c.Assert(agentStreamValue, gc.Equals, expectedAgentStreamAttr)
 
 	resourceTags, cfgHasResourceTags := cfg.ResourceTags()
-	if _, ok := test.attrs["resource-tags"]; ok {
-		c.Assert(cfgHasResourceTags, jc.IsTrue)
-		c.Assert(resourceTags, jc.DeepEquals, testResourceTagsMap)
+	c.Assert(cfgHasResourceTags, jc.IsTrue)
+	if tags, ok := test.attrs["resource-tags"]; ok {
+		switch tags := tags.(type) {
+		case []string:
+			if len(tags) > 0 {
+				c.Assert(resourceTags, jc.DeepEquals, testResourceTagsMap)
+			}
+		case string:
+			if tags != "" {
+				c.Assert(resourceTags, jc.DeepEquals, testResourceTagsMap)
+			}
+		}
 	} else {
-		c.Assert(cfgHasResourceTags, jc.IsFalse)
+		c.Assert(resourceTags, gc.HasLen, 0)
 	}
 }
 
@@ -715,16 +714,20 @@ func (s *ConfigSuite) TestConfigAttrs(c *gc.C) {
 	// Normally this is handled by gitjujutesting.FakeHome
 	s.PatchEnvironment(osenv.JujuLoggingConfigEnvKey, "")
 	attrs := map[string]interface{}{
-		"type":                      "my-type",
-		"name":                      "my-name",
-		"uuid":                      "90168e4c-2f10-4e9c-83c2-1fb55a58e5a9",
-		"authorized-keys":           testing.FakeAuthKeys,
-		"firewall-mode":             config.FwInstance,
-		"unknown":                   "my-unknown",
-		"ssl-hostname-verification": true,
-		"development":               false,
-		"default-series":            series.LatestLts(),
-		"test-mode":                 false,
+		"type":                       "my-type",
+		"name":                       "my-name",
+		"uuid":                       "90168e4c-2f10-4e9c-83c2-1fb55a58e5a9",
+		"authorized-keys":            testing.FakeAuthKeys,
+		"firewall-mode":              config.FwInstance,
+		"unknown":                    "my-unknown",
+		"ssl-hostname-verification":  true,
+		"default-series":             series.LatestLts(),
+		"disable-network-management": false,
+		"ignore-machine-addresses":   false,
+		"automatically-retry-hooks":  true,
+		"proxy-ssh":                  false,
+		"development":                false,
+		"test-mode":                  false,
 	}
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
@@ -964,19 +967,6 @@ func (s *ConfigSuite) TestAutoHookRetryTrueEnv(c *gc.C) {
 	c.Assert(config.AutomaticallyRetryHooks(), gc.Equals, true)
 }
 
-func (s *ConfigSuite) TestCloudImageBaseURL(c *gc.C) {
-	s.addJujuFiles(c)
-	config := newTestConfig(c, testing.Attrs{})
-	c.Assert(config.CloudImageBaseURL(), gc.Equals, "")
-}
-
-func (s *ConfigSuite) TestCloudImageBaseURLSet(c *gc.C) {
-	s.addJujuFiles(c)
-	config := newTestConfig(c, testing.Attrs{
-		"cloudimg-base-url": "http://local.foo/query"})
-	c.Assert(config.CloudImageBaseURL(), gc.Equals, "http://local.foo/query")
-}
-
 func (s *ConfigSuite) TestProxyValuesWithFallback(c *gc.C) {
 	s.addJujuFiles(c)
 
@@ -1121,6 +1111,23 @@ func (s *ConfigSuite) TestSchemaWithExtraOverlap(c *gc.C) {
 	})
 	c.Assert(err, gc.ErrorMatches, `config field "type" clashes with global config`)
 	c.Assert(schema, gc.IsNil)
+}
+
+func (s *ConfigSuite) TestCoerceForStorage(c *gc.C) {
+	cfg := newTestConfig(c, testing.Attrs{
+		"resource-tags": "a=b c=d"})
+	tags, ok := cfg.ResourceTags()
+	c.Assert(ok, jc.IsTrue)
+	expectedTags := map[string]string{"a": "b", "c": "d"}
+	c.Assert(tags, gc.DeepEquals, expectedTags)
+	tagsStr := config.CoerceForStorage(cfg.AllAttrs())["resource-tags"].(string)
+	tagItems := strings.Split(tagsStr, " ")
+	tagsMap := make(map[string]string)
+	for _, kv := range tagItems {
+		parts := strings.Split(kv, "=")
+		tagsMap[parts[0]] = parts[1]
+	}
+	c.Assert(tagsMap, gc.DeepEquals, expectedTags)
 }
 
 var specializeCharmRepoTests = []struct {

--- a/environs/config/source.go
+++ b/environs/config/source.go
@@ -7,6 +7,10 @@ package config
 // After a call to UpdateModelConfig, any attributes added/removed
 // will have a source of JujuModelConfigSource.
 const (
+	// JujuDefaultSource is used to label model config attributes that
+	// come from hard coded defaults.
+	JujuDefaultSource = "default"
+
 	// JujuControllerSource is used to label model config attributes that
 	// come from those associated with the controller.
 	JujuControllerSource = "controller"

--- a/environs/imagemetadata_test.go
+++ b/environs/imagemetadata_test.go
@@ -51,7 +51,7 @@ func (s *ImageMetadataSuite) env(c *gc.C, imageMetadataURL, stream string) envir
 		bootstrap.PrepareParams{
 			ControllerConfig: testing.FakeControllerConfig(),
 			ControllerName:   attrs["name"].(string),
-			BaseConfig:       attrs,
+			ModelConfig:      attrs,
 			Cloud:            dummy.SampleCloudSpec(),
 			AdminSecret:      "admin-secret",
 		},

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -157,7 +157,7 @@ func (t *LiveTests) prepareForBootstrapParams(c *gc.C) bootstrap.PrepareParams {
 	}
 	return bootstrap.PrepareParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
-		BaseConfig:       t.TestConfig,
+		ModelConfig:      t.TestConfig,
 		Cloud: environs.CloudSpec{
 			Type:       t.TestConfig["type"].(string),
 			Name:       t.TestConfig["type"].(string),
@@ -808,7 +808,7 @@ func (t *LiveTests) TestBootstrapWithDefaultSeries(c *gc.C) {
 		"name":       "dummy storage",
 	})
 	args := t.prepareForBootstrapParams(c)
-	args.BaseConfig = dummyCfg
+	args.ModelConfig = dummyCfg
 	dummyenv, err := bootstrap.Prepare(envtesting.BootstrapContext(c),
 		jujuclienttesting.NewMemStore(),
 		args,
@@ -822,7 +822,7 @@ func (t *LiveTests) TestBootstrapWithDefaultSeries(c *gc.C) {
 		"name":           "livetests",
 		"default-series": other.Series,
 	})
-	args.BaseConfig = attrs
+	args.ModelConfig = attrs
 	env, err := bootstrap.Prepare(envtesting.BootstrapContext(c),
 		t.ControllerStore,
 		args)

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -76,7 +76,7 @@ func (t *Tests) PrepareParams(c *gc.C) bootstrap.PrepareParams {
 
 	return bootstrap.PrepareParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
-		BaseConfig:       testConfigCopy,
+		ModelConfig:      testConfigCopy,
 		Cloud:            t.CloudSpec(),
 		ControllerName:   t.TestConfig["name"].(string),
 		AdminSecret:      AdminSecret,
@@ -91,14 +91,14 @@ func (t *Tests) Prepare(c *gc.C) environs.Environ {
 // PrepareWithParams prepares an instance of the testing environment.
 func (t *Tests) PrepareWithParams(c *gc.C, params bootstrap.PrepareParams) environs.Environ {
 	e, err := bootstrap.Prepare(envtesting.BootstrapContext(c), t.ControllerStore, params)
-	c.Assert(err, gc.IsNil, gc.Commentf("preparing environ %#v", params.BaseConfig))
+	c.Assert(err, gc.IsNil, gc.Commentf("preparing environ %#v", params.ModelConfig))
 	c.Assert(e, gc.NotNil)
 	return e
 }
 
 func (t *Tests) AssertPrepareFailsWithConfig(c *gc.C, badConfig coretesting.Attrs, errorMatches string) error {
 	args := t.PrepareParams(c)
-	args.BaseConfig = coretesting.Attrs(args.BaseConfig).Merge(badConfig)
+	args.ModelConfig = coretesting.Attrs(args.ModelConfig).Merge(badConfig)
 
 	e, err := bootstrap.Prepare(envtesting.BootstrapContext(c), t.ControllerStore, args)
 	c.Assert(err, gc.ErrorMatches, errorMatches)

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -54,7 +54,7 @@ func (s *OpenSuite) TestNewDummyEnviron(c *gc.C) {
 	env, err := bootstrap.Prepare(ctx, cache, bootstrap.PrepareParams{
 		ControllerConfig: controllerCfg,
 		ControllerName:   cfg.Name(),
-		BaseConfig:       cfg.AllAttrs(),
+		ModelConfig:      cfg.AllAttrs(),
 		Cloud:            dummy.SampleCloudSpec(),
 		AdminSecret:      "admin-secret",
 	})
@@ -93,7 +93,7 @@ func (s *OpenSuite) TestUpdateEnvInfo(c *gc.C) {
 	_, err = bootstrap.Prepare(ctx, store, bootstrap.PrepareParams{
 		ControllerConfig: controllerCfg,
 		ControllerName:   "controller-name",
-		BaseConfig:       cfg.AllAttrs(),
+		ModelConfig:      cfg.AllAttrs(),
 		Cloud:            dummy.SampleCloudSpec(),
 		AdminSecret:      "admin-secret",
 	})
@@ -152,7 +152,7 @@ func (*OpenSuite) TestDestroy(c *gc.C) {
 	e, err := bootstrap.Prepare(ctx, store, bootstrap.PrepareParams{
 		ControllerConfig: controllerCfg,
 		ControllerName:   "controller-name",
-		BaseConfig:       cfg.AllAttrs(),
+		ModelConfig:      cfg.AllAttrs(),
 		Cloud:            dummy.SampleCloudSpec(),
 		AdminSecret:      "admin-secret",
 	})

--- a/environs/tools/tools_test.go
+++ b/environs/tools/tools_test.go
@@ -103,7 +103,7 @@ func (s *SimpleStreamsToolsSuite) resetEnv(c *gc.C, attrs map[string]interface{}
 		bootstrap.PrepareParams{
 			ControllerConfig: coretesting.FakeControllerConfig(),
 			ControllerName:   attrs["name"].(string),
-			BaseConfig:       attrs,
+			ModelConfig:      attrs,
 			Cloud:            dummy.SampleCloudSpec(),
 			AdminSecret:      "admin-secret",
 		},

--- a/environs/tools/urls_test.go
+++ b/environs/tools/urls_test.go
@@ -49,7 +49,7 @@ func (s *URLsSuite) env(c *gc.C, toolsMetadataURL string) environs.Environ {
 		bootstrap.PrepareParams{
 			ControllerConfig: coretesting.FakeControllerConfig(),
 			ControllerName:   attrs["name"].(string),
-			BaseConfig:       attrs,
+			ModelConfig:      attrs,
 			Cloud:            dummy.SampleCloudSpec(),
 			AdminSecret:      "admin-secret",
 		},

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -90,7 +90,7 @@ func (s *NewAPIClientSuite) bootstrapModel(c *gc.C) (environs.Environ, jujuclien
 	env, err := bootstrap.Prepare(ctx, store, bootstrap.PrepareParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
 		ControllerName:   controllerName,
-		BaseConfig:       dummy.SampleConfig(),
+		ModelConfig:      dummy.SampleConfig(),
 		Cloud:            dummy.SampleCloudSpec(),
 		AdminSecret:      "admin-secret",
 	})

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -278,7 +278,7 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 		s.ControllerStore,
 		bootstrap.PrepareParams{
 			ControllerConfig: s.ControllerConfig,
-			BaseConfig:       cfg.AllAttrs(),
+			ModelConfig:      cfg.AllAttrs(),
 			Cloud:            dummy.SampleCloudSpec(),
 			ControllerName:   ControllerName,
 			AdminSecret:      AdminSecret,

--- a/jujuclient/bootstrapconfig.go
+++ b/jujuclient/bootstrapconfig.go
@@ -55,6 +55,14 @@ func ParseBootstrapConfig(data []byte) (map[string]BootstrapConfig, error) {
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot unmarshal bootstrap config")
 	}
+	// TODO(wallyworld) - drop when we get to beta 15.
+	// This is for backwards compatibility with beta 13.
+	for controllerName, cfg := range result.ControllerBootstrapConfig {
+		if cfg.Config == nil {
+			cfg.Config = cfg.OldConfig
+			result.ControllerBootstrapConfig[controllerName] = cfg
+		}
+	}
 	return result.ControllerBootstrapConfig, nil
 }
 

--- a/jujuclient/bootstrapconfigfile_test.go
+++ b/jujuclient/bootstrapconfigfile_test.go
@@ -27,7 +27,7 @@ controllers:
     controller-config:
       api-port: 17070
       state-port: 37017
-    base-model-config:
+    model-config:
       name: admin
       type: ec2
     credential: default
@@ -39,7 +39,7 @@ controllers:
     controller-config:
       api-port: 17070
       state-port: 37017
-    base-model-config:
+    model-config:
       name: admin
       type: maas
     cloud: maas

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -65,9 +65,13 @@ type BootstrapConfig struct {
 	// ControllerConfig is the controller configuration.
 	ControllerConfig controller.Config `yaml:"controller-config"`
 
-	// ModelConfig is the base configuration for the provider. This should
-	// be updated with the region, endpoint and credentials.
-	Config map[string]interface{} `yaml:"base-model-config"`
+	// Config is the complete configuration for the provider.
+	// This should be updated with the region, endpoint and credentials.
+	Config map[string]interface{} `yaml:"model-config"`
+
+	// TODO(wallyworld) - drop when we get to beta 15.
+	// This is for backwards compatibility with beta 13.
+	OldConfig map[string]interface{} `yaml:"base-model-config,omitempty"`
 
 	// Credential is the name of the credential used to bootstrap.
 	//

--- a/logfwd/syslog/config.go
+++ b/logfwd/syslog/config.go
@@ -45,10 +45,11 @@ func (cfg RawConfig) Validate() error {
 		return errors.Trace(err)
 	}
 
-	if _, err := cfg.tlsConfig(); err != nil {
-		return errors.Annotate(err, "validating TLS config")
+	if cfg.Enabled || cfg.ClientKey != "" || cfg.ClientCert != "" || cfg.CACert != "" {
+		if _, err := cfg.tlsConfig(); err != nil {
+			return errors.Annotate(err, "validating TLS config")
+		}
 	}
-
 	return nil
 }
 
@@ -57,7 +58,7 @@ func (cfg RawConfig) validateHost() error {
 	if err != nil {
 		host = cfg.Host
 	}
-	if host == "" {
+	if host == "" && cfg.Enabled {
 		return errors.NotValidf("Host %q", cfg.Host)
 	}
 	return nil

--- a/logfwd/syslog/config_test.go
+++ b/logfwd/syslog/config_test.go
@@ -4,7 +4,6 @@
 package syslog_test
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -47,14 +46,13 @@ func (s *ConfigSuite) TestRawValidateWithoutPort(c *gc.C) {
 
 func (s *ConfigSuite) TestRawValidateZeroValue(c *gc.C) {
 	var cfg syslog.RawConfig
-
 	err := cfg.Validate()
-
-	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *ConfigSuite) TestRawValidateMissingHost(c *gc.C) {
 	cfg := syslog.RawConfig{
+		Enabled:    true,
 		Host:       "",
 		CACert:     validCACert,
 		ClientCert: validCert,
@@ -66,8 +64,21 @@ func (s *ConfigSuite) TestRawValidateMissingHost(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `Host "" not valid`)
 }
 
+func (s *ConfigSuite) TestRawValidateMissingHostNotEnabled(c *gc.C) {
+	cfg := syslog.RawConfig{
+		Host:       "",
+		CACert:     validCACert,
+		ClientCert: validCert,
+		ClientKey:  validKey,
+	}
+
+	err := cfg.Validate()
+	c.Check(err, jc.ErrorIsNil)
+}
+
 func (s *ConfigSuite) TestRawValidateMissingHostname(c *gc.C) {
 	cfg := syslog.RawConfig{
+		Enabled:    true,
 		Host:       ":9876",
 		CACert:     validCACert,
 		ClientCert: validCert,

--- a/provider/dummy/config_test.go
+++ b/provider/dummy/config_test.go
@@ -33,7 +33,7 @@ func (*ConfigSuite) TestSecretAttrs(c *gc.C) {
 		ctx, jujuclienttesting.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: testing.FakeControllerConfig(),
-			BaseConfig:       attrs,
+			ModelConfig:      attrs,
 			ControllerName:   attrs["name"].(string),
 			Cloud:            dummy.SampleCloudSpec(),
 			AdminSecret:      AdminSecret,
@@ -98,7 +98,7 @@ func (s *ConfigSuite) TestFirewallMode(c *gc.C) {
 			bootstrap.PrepareParams{
 				ControllerConfig: testing.FakeControllerConfig(),
 				ControllerName:   cfg.Name(),
-				BaseConfig:       cfg.AllAttrs(),
+				ModelConfig:      cfg.AllAttrs(),
 				Cloud:            dummy.SampleCloudSpec(),
 				AdminSecret:      AdminSecret,
 			},

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -119,7 +119,7 @@ func (s *suite) bootstrapTestEnviron(c *gc.C) environs.NetworkingEnviron {
 		s.ControllerStore,
 		bootstrap.PrepareParams{
 			ControllerConfig: testing.FakeControllerConfig(),
-			BaseConfig:       s.TestConfig,
+			ModelConfig:      s.TestConfig,
 			ControllerName:   s.TestConfig["name"].(string),
 			Cloud:            dummy.SampleCloudSpec(),
 			AdminSecret:      AdminSecret,

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -301,8 +301,8 @@ func (t *localServerSuite) makeTestingDefaultVPCUnavailable(c *gc.C) {
 func (t *localServerSuite) TestPrepareForBootstrapWithNotRecommendedButForcedVPCID(c *gc.C) {
 	t.makeTestingDefaultVPCUnavailable(c)
 	params := t.PrepareParams(c)
-	params.BaseConfig["vpc-id"] = t.srv.defaultVPC.Id
-	params.BaseConfig["vpc-id-force"] = true
+	params.ModelConfig["vpc-id"] = t.srv.defaultVPC.Id
+	params.ModelConfig["vpc-id-force"] = true
 
 	t.prepareWithParamsAndBootstrapWithVPCID(c, params, t.srv.defaultVPC.Id)
 }
@@ -311,7 +311,7 @@ func (t *localServerSuite) TestPrepareForBootstrapWithEmptyVPCID(c *gc.C) {
 	const emptyVPCID = ""
 
 	params := t.PrepareParams(c)
-	params.BaseConfig["vpc-id"] = emptyVPCID
+	params.ModelConfig["vpc-id"] = emptyVPCID
 
 	t.prepareWithParamsAndBootstrapWithVPCID(c, params, emptyVPCID)
 }
@@ -333,14 +333,14 @@ func (t *localServerSuite) prepareWithParamsAndBootstrapWithVPCID(c *gc.C, param
 
 func (t *localServerSuite) TestPrepareForBootstrapWithVPCIDNone(c *gc.C) {
 	params := t.PrepareParams(c)
-	params.BaseConfig["vpc-id"] = "none"
+	params.ModelConfig["vpc-id"] = "none"
 
 	t.prepareWithParamsAndBootstrapWithVPCID(c, params, ec2.VPCIDNone)
 }
 
 func (t *localServerSuite) TestPrepareForBootstrapWithDefaultVPCID(c *gc.C) {
 	params := t.PrepareParams(c)
-	params.BaseConfig["vpc-id"] = t.srv.defaultVPC.Id
+	params.ModelConfig["vpc-id"] = t.srv.defaultVPC.Id
 
 	t.prepareWithParamsAndBootstrapWithVPCID(c, params, t.srv.defaultVPC.Id)
 }
@@ -1490,7 +1490,7 @@ func (t *localNonUSEastSuite) SetUpTest(c *gc.C) {
 		jujuclienttesting.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: coretesting.FakeControllerConfig(),
-			BaseConfig:       localConfigAttrs,
+			ModelConfig:      localConfigAttrs,
 			ControllerName:   localConfigAttrs["name"].(string),
 			Cloud: environs.CloudSpec{
 				Type:       "ec2",

--- a/provider/joyent/export_test.go
+++ b/provider/joyent/export_test.go
@@ -220,7 +220,7 @@ func MakeConfig(c *gc.C, attrs testing.Attrs) *environConfig {
 		jujuclienttesting.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: testing.FakeControllerConfig(),
-			BaseConfig:       attrs,
+			ModelConfig:      attrs,
 			ControllerName:   attrs["name"].(string),
 			Cloud: environs.CloudSpec{
 				Type:       "joyent",

--- a/provider/manual/config_test.go
+++ b/provider/manual/config_test.go
@@ -26,6 +26,7 @@ func MinimalConfigValues() map[string]interface{} {
 		"type":            "manual",
 		"uuid":            coretesting.ModelTag.Id(),
 		"controller-uuid": coretesting.ModelTag.Id(),
+		"firewall-mode":   "instance",
 		"bootstrap-host":  "hostname",
 		"bootstrap-user":  "",
 		// While the ca-cert bits aren't entirely minimal, they avoid the need

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -89,7 +89,7 @@ func (s *providerSuite) TestDisablesUpdatesByDefault(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	attrs := manual.MinimalConfigValues()
-	testConfig, err := config.New(config.UseDefaults, attrs)
+	testConfig, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(testConfig.EnableOSRefreshUpdate(), jc.IsTrue)
 	c.Check(testConfig.EnableOSUpgrade(), jc.IsTrue)

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1821,7 +1821,7 @@ func prepareParams(attrs map[string]interface{}, cred *identity.Credentials) boo
 	credential := makeCredential(cred)
 	return bootstrap.PrepareParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
-		BaseConfig:       attrs,
+		ModelConfig:      attrs,
 		ControllerName:   attrs["name"].(string),
 		Cloud: environs.CloudSpec{
 			Type:       "openstack",

--- a/state/controller.go
+++ b/state/controller.go
@@ -12,9 +12,6 @@ import (
 const (
 	// controllerSettingsGlobalKey is the key for the controller and its settings.
 	controllerSettingsGlobalKey = "controllerSettings"
-
-	// controllerInheritedSettingsGlobalKey is the key for default settings shared across models.
-	controllerInheritedSettingsGlobalKey = "controllerInheritedSettings"
 )
 
 // ControllerConfig returns the config values for the controller.

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -38,6 +38,7 @@ const (
 	StorageInstancesC = storageInstancesC
 	GUISettingsC      = guisettingsC
 	GlobalSettingsC   = globalSettingsC
+	SettingsC         = settingsC
 )
 
 var (
@@ -53,6 +54,7 @@ var (
 	ApplicationGlobalKey                 = applicationGlobalKey
 	ReadSettings                         = readSettings
 	ControllerInheritedSettingsGlobalKey = controllerInheritedSettingsGlobalKey
+	ModelGlobalKey                       = modelGlobalKey
 	MergeBindings                        = mergeBindings
 	UpgradeInProgressError               = errUpgradeInProgress
 )

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -123,7 +123,10 @@ func (s *MigrationExportSuite) TestModelInfo(c *gc.C) {
 	dbModelCfg, err := dbModel.Config()
 	c.Assert(err, jc.ErrorIsNil)
 	modelAttrs := dbModelCfg.AllAttrs()
-	c.Assert(model.Config(), jc.DeepEquals, modelAttrs)
+	modelCfg := model.Config()
+	// Config as read from state has resources tags coerced to a map.
+	modelCfg["resource-tags"] = map[string]string{}
+	c.Assert(modelCfg, jc.DeepEquals, modelAttrs)
 	c.Assert(model.LatestToolsVersion(), gc.Equals, latestTools)
 	c.Assert(model.Annotations(), jc.DeepEquals, testAnnotations)
 	constraints := model.Constraints()

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -4,9 +4,12 @@
 package state_test
 
 import (
+	"strings"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
@@ -38,18 +41,18 @@ func (s *ModelConfigSuite) SetUpTest(c *gc.C) {
 func (s *ModelConfigSuite) TestAdditionalValidation(c *gc.C) {
 	updateAttrs := map[string]interface{}{"logging-config": "juju=ERROR"}
 	configValidator1 := func(updateAttrs map[string]interface{}, removeAttrs []string, oldConfig *config.Config) error {
-		c.Assert(updateAttrs, gc.DeepEquals, map[string]interface{}{"logging-config": "juju=ERROR"})
-		if _, found := updateAttrs["logging-config"]; found {
+		c.Assert(updateAttrs, jc.DeepEquals, map[string]interface{}{"logging-config": "juju=ERROR"})
+		if lc, found := updateAttrs["logging-config"]; found && lc != "" {
 			return errors.New("cannot change logging-config")
 		}
 		return nil
 	}
-	removeAttrs := []string{"logging-config"}
+	removeAttrs := []string{"some-attr"}
 	configValidator2 := func(updateAttrs map[string]interface{}, removeAttrs []string, oldConfig *config.Config) error {
-		c.Assert(removeAttrs, gc.DeepEquals, []string{"logging-config"})
+		c.Assert(removeAttrs, jc.DeepEquals, []string{"some-attr"})
 		for _, i := range removeAttrs {
-			if i == "logging-config" {
-				return errors.New("cannot remove logging-config")
+			if i == "some-attr" {
+				return errors.New("cannot remove some-attr")
 			}
 		}
 		return nil
@@ -61,7 +64,7 @@ func (s *ModelConfigSuite) TestAdditionalValidation(c *gc.C) {
 	err := s.State.UpdateModelConfig(updateAttrs, nil, configValidator1)
 	c.Assert(err, gc.ErrorMatches, "cannot change logging-config")
 	err = s.State.UpdateModelConfig(nil, removeAttrs, configValidator2)
-	c.Assert(err, gc.ErrorMatches, "cannot remove logging-config")
+	c.Assert(err, gc.ErrorMatches, "cannot remove some-attr")
 	err = s.State.UpdateModelConfig(updateAttrs, nil, configValidator3)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -80,7 +83,27 @@ func (s *ModelConfigSuite) TestModelConfig(c *gc.C) {
 	oldCfg, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(oldCfg, gc.DeepEquals, cfg)
+	c.Assert(oldCfg, jc.DeepEquals, cfg)
+}
+
+func (s *ModelConfigSuite) TestComposeNewModelConfig(c *gc.C) {
+	attrs := map[string]interface{}{
+		"authorized-keys": "different-keys",
+		"arbitrary-key":   "shazam!",
+		"uuid":            testing.ModelTag.Id(),
+		"type":            "dummy",
+		"name":            "test",
+		"resource-tags":   map[string]string{"a": "b", "c": "d"},
+	}
+	cfgAttrs, err := s.State.ComposeNewModelConfig(attrs)
+	c.Assert(err, jc.ErrorIsNil)
+	expectedCfg, err := config.New(config.UseDefaults, attrs)
+	c.Assert(err, jc.ErrorIsNil)
+	expected := expectedCfg.AllAttrs()
+	expected["apt-mirror"] = "http://cloud-mirror"
+	// config.New() adds logging-config so remove it.
+	expected["logging-config"] = ""
+	c.Assert(cfgAttrs, jc.DeepEquals, expected)
 }
 
 func (s *ModelConfigSuite) TestUpdateModelConfigRejectsControllerConfig(c *gc.C) {
@@ -105,6 +128,30 @@ func (s *ModelConfigSuite) TestUpdateModelConfigRemoveInherited(c *gc.C) {
 	c.Assert(allAttrs["apt-mirror"], gc.Equals, "http://cloud-mirror")
 	_, ok := allAttrs["arbitrary-key"]
 	c.Assert(ok, jc.IsFalse)
+}
+
+func (s *ModelConfigSuite) TestUpdateModelConfigCoerce(c *gc.C) {
+	attrs := map[string]interface{}{
+		"resource-tags": map[string]string{"a": "b", "c": "d"},
+	}
+	err := s.State.UpdateModelConfig(attrs, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	modelSettings, err := s.State.ReadSettings(state.SettingsC, state.ModelGlobalKey)
+	c.Assert(err, jc.ErrorIsNil)
+	expectedTags := map[string]string{"a": "b", "c": "d"}
+	tagsStr := config.CoerceForStorage(modelSettings.Map())["resource-tags"].(string)
+	tagItems := strings.Split(tagsStr, " ")
+	tagsMap := make(map[string]string)
+	for _, kv := range tagItems {
+		parts := strings.Split(kv, "=")
+		tagsMap[parts[0]] = parts[1]
+	}
+	c.Assert(tagsMap, gc.DeepEquals, expectedTags)
+
+	cfg, err := s.State.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.AllAttrs()["resource-tags"], gc.DeepEquals, expectedTags)
 }
 
 func (s *ModelConfigSuite) TestUpdateModelConfigPreferredOverRemove(c *gc.C) {
@@ -147,7 +194,7 @@ func (s *ModelConfigSourceSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *ModelConfigSourceSuite) TestModelConfigWhenSetOverridesCloudValue(c *gc.C) {
+func (s *ModelConfigSourceSuite) TestModelConfigWhenSetOverridesControllerValue(c *gc.C) {
 	attrs := map[string]interface{}{
 		"authorized-keys": "different-keys",
 		"apt-mirror":      "http://anothermirror",
@@ -207,13 +254,21 @@ func (s *ModelConfigSourceSuite) TestNewModelConfigForksControllerValue(c *gc.C)
 	c.Assert(modelCfg.AllAttrs()["apt-mirror"], gc.Equals, "http://mirror")
 }
 
-func (s *ModelConfigSourceSuite) TestModelConfigValues(c *gc.C) {
-	modelCfg, err := s.State.ModelConfig()
-	c.Assert(err, jc.ErrorIsNil)
+func (s *ModelConfigSourceSuite) assertModelConfigValues(c *gc.C, modelCfg *config.Config, modelAttributes, controllerAttributes set.Strings) {
 	expectedValues := make(config.ConfigValues)
+	defaultAttributes := set.NewStrings()
+	for defaultAttr := range config.ConfigDefaults() {
+		defaultAttributes.Add(defaultAttr)
+	}
 	for attr, val := range modelCfg.AllAttrs() {
 		source := "model"
-		if attr == "http-proxy" {
+		if defaultAttributes.Contains(attr) {
+			source = "default"
+		}
+		if modelAttributes.Contains(attr) {
+			source = "model"
+		}
+		if controllerAttributes.Contains(attr) {
 			source = "controller"
 		}
 		expectedValues[attr] = config.ConfigValue{
@@ -226,6 +281,13 @@ func (s *ModelConfigSourceSuite) TestModelConfigValues(c *gc.C) {
 	c.Assert(sources, jc.DeepEquals, expectedValues)
 }
 
+func (s *ModelConfigSourceSuite) TestModelConfigValues(c *gc.C) {
+	modelCfg, err := s.State.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	modelAttributes := set.NewStrings("name", "apt-mirror", "logging-config", "authorized-keys", "resource-tags")
+	s.assertModelConfigValues(c, modelCfg, modelAttributes, set.NewStrings("http-proxy"))
+}
+
 func (s *ModelConfigSourceSuite) TestModelConfigUpdateSource(c *gc.C) {
 	attrs := map[string]interface{}{
 		"http-proxy": "http://anotherproxy",
@@ -233,21 +295,8 @@ func (s *ModelConfigSourceSuite) TestModelConfigUpdateSource(c *gc.C) {
 	}
 	err := s.State.UpdateModelConfig(attrs, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
-
 	modelCfg, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	expectedValues := make(config.ConfigValues)
-	for attr, val := range modelCfg.AllAttrs() {
-		source := "model"
-		if attr == "apt-mirror" {
-			source = "controller"
-		}
-		expectedValues[attr] = config.ConfigValue{
-			Value:  val,
-			Source: source,
-		}
-	}
-	sources, err := s.State.ModelConfigValues()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sources, jc.DeepEquals, expectedValues)
+	modelAttributes := set.NewStrings("name", "http-proxy", "logging-config", "authorized-keys", "resource-tags")
+	s.assertModelConfigValues(c, modelCfg, modelAttributes, set.NewStrings("apt-mirror"))
 }

--- a/state/settings.go
+++ b/state/settings.go
@@ -226,7 +226,6 @@ func (s *Settings) Write() ([]ItemChange, error) {
 	if err != nil {
 		return nil, err
 	}
-	s.disk = copyMap(s.core, nil)
 	return changes, nil
 }
 
@@ -317,7 +316,7 @@ func readSettings(st *State, collection, key string) (*Settings, error) {
 	return s, nil
 }
 
-var errSettingsExist = fmt.Errorf("cannot overwrite existing settings")
+var errSettingsExist = errors.New("cannot overwrite existing settings")
 
 func createSettingsOp(collection, key string, values map[string]interface{}) txn.Op {
 	newValues := copyMap(values, escapeReplacer.Replace)

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -92,10 +92,6 @@ func CustomModelConfig(c *gc.C, extra Attrs) *config.Config {
 	return cfg
 }
 
-const (
-	SampleModelName = "erewhemos"
-)
-
 const DefaultMongoPassword = "conn-from-name-secret"
 
 // FakeJujuXDGDataHomeSuite isolates the user's home directory and


### PR DESCRIPTION
environs.Config is refactored so that default values are available for all relevant configuration attributes, not just select values. This means that when creating a model, all config attributes, even the default ones are forked and stored. This means that:
* juju model-config correctly shows where config originates from 
* models migrate and retain all their config and are not subject to new Juju versions setting different defaults
* set-model-config does not print a bogus error


(Review request: http://reviews.vapour.ws/r/5321/)