### PR TITLE
Add support for setting migration status message on migrationmaster facade

### DIFF
--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -100,6 +100,15 @@ func (c *Client) SetPhase(phase migration.Phase) error {
 	return c.caller.FacadeCall("SetPhase", args, nil)
 }
 
+// SetStatusMessage sets a human readable message regarding the
+// progress of a migration.
+func (c *Client) SetStatusMessage(message string) error {
+	args := params.SetMigrationStatusMessageArgs{
+		Message: message,
+	}
+	return c.caller.FacadeCall("SetStatusMessage", args, nil)
+}
+
 // Export returns a serialized representation of the model associated
 // with the API connection. The charms used by the model are also
 // returned.

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -126,6 +126,30 @@ func (s *ClientSuite) TestSetPhaseError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
+func (s *ClientSuite) TestSetStatusMessage(c *gc.C) {
+	var stub jujutesting.Stub
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		stub.AddCall(objType+"."+request, id, arg)
+		return nil
+	})
+	client := migrationmaster.NewClient(apiCaller, nil)
+	err := client.SetStatusMessage("foo")
+	c.Assert(err, jc.ErrorIsNil)
+	expectedArg := params.SetMigrationStatusMessageArgs{Message: "foo"}
+	stub.CheckCalls(c, []jujutesting.StubCall{
+		{"MigrationMaster.SetStatusMessage", []interface{}{"", expectedArg}},
+	})
+}
+
+func (s *ClientSuite) TestSetStatusMessageError(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(string, int, string, string, interface{}, interface{}) error {
+		return errors.New("boom")
+	})
+	client := migrationmaster.NewClient(apiCaller, nil)
+	err := client.SetStatusMessage("foo")
+	c.Assert(err, gc.ErrorMatches, "boom")
+}
+
 func (s *ClientSuite) TestExport(c *gc.C) {
 	var stub jujutesting.Stub
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {

--- a/apiserver/migrationmaster/facade.go
+++ b/apiserver/migrationmaster/facade.go
@@ -117,6 +117,18 @@ func (api *API) SetPhase(args params.SetMigrationPhaseArgs) error {
 	return errors.Annotate(err, "failed to set phase")
 }
 
+// SetStatusMessage sets a human readable status message containing
+// information about the migration's progress. This will be shown in
+// status output shown to the end user.
+func (api *API) SetStatusMessage(args params.SetMigrationStatusMessageArgs) error {
+	mig, err := api.backend.LatestModelMigration()
+	if err != nil {
+		return errors.Annotate(err, "could not get migration")
+	}
+	err = mig.SetStatusMessage(args.Message)
+	return errors.Annotate(err, "failed to set status message")
+}
+
 // Export serializes the model associated with the API connection.
 func (api *API) Export() (params.SerializedModel, error) {
 	var serialized params.SerializedModel

--- a/apiserver/migrationmaster/facade_test.go
+++ b/apiserver/migrationmaster/facade_test.go
@@ -140,6 +140,30 @@ func (s *Suite) TestSetPhaseError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "failed to set phase: blam")
 }
 
+func (s *Suite) TestSetStatusMessage(c *gc.C) {
+	api := s.mustMakeAPI(c)
+
+	err := api.SetStatusMessage(params.SetMigrationStatusMessageArgs{Message: "foo"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(s.backend.migration.messageSet, gc.Equals, "foo")
+}
+
+func (s *Suite) TestSetStatusMessageNoMigration(c *gc.C) {
+	s.backend.getErr = errors.New("boom")
+	api := s.mustMakeAPI(c)
+
+	err := api.SetStatusMessage(params.SetMigrationStatusMessageArgs{Message: "foo"})
+	c.Check(err, gc.ErrorMatches, "could not get migration: boom")
+}
+
+func (s *Suite) TestSetStatusMessageError(c *gc.C) {
+	s.backend.migration.setMessageErr = errors.New("blam")
+	api := s.mustMakeAPI(c)
+
+	err := api.SetStatusMessage(params.SetMigrationStatusMessageArgs{Message: "foo"})
+	c.Assert(err, gc.ErrorMatches, "failed to set status message: blam")
+}
+
 func (s *Suite) TestExport(c *gc.C) {
 	s.model.AddApplication(description.ApplicationArgs{
 		Tag:      names.NewApplicationTag("foo"),
@@ -300,6 +324,8 @@ type stubMigration struct {
 	stub          *testing.Stub
 	setPhaseErr   error
 	phaseSet      coremigration.Phase
+	setMessageErr error
+	messageSet    string
 	minionReports *state.MinionReports
 }
 
@@ -338,6 +364,14 @@ func (m *stubMigration) SetPhase(phase coremigration.Phase) error {
 		return m.setPhaseErr
 	}
 	m.phaseSet = phase
+	return nil
+}
+
+func (m *stubMigration) SetStatusMessage(message string) error {
+	if m.setMessageErr != nil {
+		return m.setMessageErr
+	}
+	m.messageSet = message
 	return nil
 }
 

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -48,6 +48,12 @@ type SetMigrationPhaseArgs struct {
 	Phase string `json:"phase"`
 }
 
+// SetMigrationStatusMessageArgs provides a migration status message
+// to the migrationmaster.SetStatusMessage API method.
+type SetMigrationStatusMessageArgs struct {
+	Message string `json:"message"`
+}
+
 // SerializedModel wraps a buffer contain a serialised Juju model. It
 // also contains lists of the charms and tools used in the model.
 type SerializedModel struct {


### PR DESCRIPTION
This change adds a SetStatusMessage API method so that the migrationmaster worker can report migration progress in a human readable way.

(Review request: http://reviews.vapour.ws/r/5324/)