### PR TITLE
worker/migrationmaster: Report migration status

### DIFF
--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -672,6 +672,10 @@ func (c *stubMasterFacade) SetPhase(phase coremigration.Phase) error {
 	return nil
 }
 
+func (c *stubMasterFacade) SetStatusMessage(message string) error {
+	return nil
+}
+
 func (c *stubMasterFacade) Reap() error {
 	c.stub.AddCall("masterFacade.Reap")
 	return nil


### PR DESCRIPTION
Human consumable migration status is now set by the migrationmaster as the migration progresses. Status setting is combined with logging to keep the call sites clean.



(Review request: http://reviews.vapour.ws/r/5326/)