### PR TITLE
environs: add CloudSpec to OpenParams

### DIFF
--- a/apiserver/agent/agent.go
+++ b/apiserver/agent/agent.go
@@ -52,7 +52,7 @@ func NewAgentAPIV2(st *state.State, resources facade.Resources, auth facade.Auth
 		RebootFlagClearer:   common.NewRebootFlagClearer(st, getCanChange),
 		ModelWatcher:        common.NewModelWatcher(st, resources, auth),
 		ControllerConfigAPI: common.NewControllerConfig(st),
-		CloudSpecAPI:        cloudspec.NewCloudSpecForModel(st.ModelTag(), environConfigGetter.CloudSpec),
+		CloudSpecAPI:        cloudspec.NewCloudSpec(environConfigGetter.CloudSpec, common.AuthFuncForTag(st.ModelTag())),
 		st:                  st,
 		auth:                auth,
 	}, nil

--- a/apiserver/common/interfaces.go
+++ b/apiserver/common/interfaces.go
@@ -50,6 +50,15 @@ func AuthNever() GetAuthFunc {
 	}
 }
 
+// AuthFuncForTag returns an authentication function that always returns true iff it is passed a specific tag.
+func AuthFuncForTag(valid names.Tag) GetAuthFunc {
+	return func() (AuthFunc, error) {
+		return func(tag names.Tag) bool {
+			return tag == valid
+		}, nil
+	}
+}
+
 // AuthFuncForTagKind returns a GetAuthFunc which creates an AuthFunc
 // allowing only the given tag kind and denies all others. Passing an
 // empty kind is an error.

--- a/apiserver/common/networkingcommon/shims.go
+++ b/apiserver/common/networkingcommon/shims.go
@@ -7,10 +7,10 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
 	providercommon "github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/stateenvirons"
 )
 
 // NOTE: All of the following code is only tested with a feature test.
@@ -81,18 +81,14 @@ func (s *spaceShim) Subnets() ([]BackingSubnet, error) {
 }
 
 func NewStateShim(st *state.State) *stateShim {
-	return &stateShim{st: st}
+	return &stateShim{stateenvirons.EnvironConfigGetter{st}, st}
 }
 
 // stateShim forwards and adapts state.State methods to Backing
 // method.
 type stateShim struct {
-	NetworkBacking
+	stateenvirons.EnvironConfigGetter
 	st *state.State
-}
-
-func (s *stateShim) ModelConfig() (*config.Config, error) {
-	return s.st.ModelConfig()
 }
 
 func (s *stateShim) AddSpace(name string, providerId network.Id, subnetIds []string, public bool) error {

--- a/apiserver/common/networkingcommon/spaces_test.go
+++ b/apiserver/common/networkingcommon/spaces_test.go
@@ -81,6 +81,7 @@ func (s *SpacesSuite) checkCreateSpaces(c *gc.C, p checkCreateSpacesParams) {
 
 	baseCalls := []apiservertesting.StubMethodCall{
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.ZonedNetworkingEnvironCall("SupportsSpaces"),
 	}
@@ -159,6 +160,7 @@ func (s *SpacesSuite) TestCreateSpacesModelConfigError(c *gc.C) {
 func (s *SpacesSuite) TestCreateSpacesProviderOpenError(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil,                // Backing.ModelConfig()
+		nil,                // Backing.CloudSpec()
 		errors.New("boom"), // Provider.Open()
 	)
 
@@ -170,6 +172,7 @@ func (s *SpacesSuite) TestCreateSpacesProviderOpenError(c *gc.C) {
 func (s *SpacesSuite) TestCreateSpacesNotSupportedError(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.ModelConfig()
+		nil, // Backing.CloudSpec()
 		nil, // Provider.Open()
 		errors.NotSupportedf("spaces"), // ZonedNetworkingEnviron.SupportsSpaces()
 	)
@@ -191,6 +194,7 @@ func (s *SpacesSuite) TestSuppportsSpacesModelConfigError(c *gc.C) {
 func (s *SpacesSuite) TestSuppportsSpacesEnvironNewError(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil,                // Backing.ModelConfig()
+		nil,                // Backing.CloudSpec()
 		errors.New("boom"), // environs.New()
 	)
 
@@ -220,6 +224,7 @@ func (s *SpacesSuite) TestSuppportsSpacesWithoutSpaces(c *gc.C) {
 
 	apiservertesting.SharedStub.SetErrors(
 		nil,                // Backing.ModelConfig()
+		nil,                // Backing.CloudSpec()
 		nil,                // environs.New()
 		errors.New("boom"), // Backing.SupportsSpaces()
 	)

--- a/apiserver/common/networkingcommon/subnets_test.go
+++ b/apiserver/common/networkingcommon/subnets_test.go
@@ -96,6 +96,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesUpdates(c *gc.C) {
 	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
 		apiservertesting.BackingCall("AvailabilityZones"),
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.ZonedEnvironCall("AvailabilityZones"),
 		apiservertesting.BackingCall("SetAvailabilityZones", apiservertesting.ProviderInstance.Zones),
@@ -113,6 +114,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndSetFails(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.AvailabilityZones
 		nil, // Backing.ModelConfig
+		nil, // Backing.CloudSpec
 		nil, // Provider.Open
 		nil, // ZonedEnviron.AvailabilityZones
 		errors.NotSupportedf("setting"), // Backing.SetAvailabilityZones
@@ -129,6 +131,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndSetFails(c *gc.C) {
 	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
 		apiservertesting.BackingCall("AvailabilityZones"),
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.ZonedEnvironCall("AvailabilityZones"),
 		apiservertesting.BackingCall("SetAvailabilityZones", apiservertesting.ProviderInstance.Zones),
@@ -146,6 +149,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndFetchingZonesFails(c *gc
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.AvailabilityZones
 		nil, // Backing.ModelConfig
+		nil, // Backing.CloudSpec
 		nil, // Provider.Open
 		errors.NotValidf("foo"), // ZonedEnviron.AvailabilityZones
 	)
@@ -161,6 +165,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndFetchingZonesFails(c *gc
 	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
 		apiservertesting.BackingCall("AvailabilityZones"),
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.ZonedEnvironCall("AvailabilityZones"),
 	)
@@ -204,6 +209,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndOpenFails(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.AvailabilityZones
 		nil, // Backing.ModelConfig
+		nil, // Backing.CloudSpec
 		errors.NotValidf("config"), // Provider.Open
 	)
 
@@ -218,6 +224,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndOpenFails(c *gc.C) {
 	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
 		apiservertesting.BackingCall("AvailabilityZones"),
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 	)
 }
@@ -242,6 +249,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndZonesNotSupported(c *gc.
 	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
 		apiservertesting.BackingCall("AvailabilityZones"),
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 	)
 }
@@ -401,15 +409,18 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 
 		// caching subnets (2nd attepmt): fails
 		nil, // BackingInstance.ModelConfig (2nd call)
+		nil, // BackingInstance.CloudSpec (1st call)
 		errors.NotFoundf("provider"), // ProviderInstance.Open (1st call)
 
 		// caching subnets (3rd attempt): fails
 		nil, // BackingInstance.ModelConfig (3rd call)
+		nil, // BackingInstance.CloudSpec (2nd call)
 		nil, // ProviderInstance.Open (2nd call)
 		errors.NotFoundf("subnets"), // NetworkingEnvironInstance.Subnets (1st call)
 
 		// caching subnets (4th attempt): succeeds
 		nil, // BackingInstance.ModelConfig (4th call)
+		nil, // BackingInstance.CloudSpec (3rd call)
 		nil, // ProviderInstance.Open (3rd call)
 		nil, // NetworkingEnvironInstance.Subnets (2nd call)
 
@@ -519,15 +530,18 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 
 		// caching subnets (2nd attepmt): fails
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 
 		// caching subnets (3rd attempt): fails
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.NetworkingEnvironCall("Subnets", instance.UnknownId, []network.Id(nil)),
 
 		// caching subnets (4th attempt): succeeds
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.NetworkingEnvironCall("Subnets", instance.UnknownId, []network.Id(nil)),
 
@@ -567,6 +581,7 @@ func (s *SubnetsSuite) CheckAddSubnetsFails(
 	// These calls always happen.
 	expectedCalls := []apiservertesting.StubMethodCall{
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 	}
 
@@ -625,6 +640,7 @@ func (s *SubnetsSuite) CheckAddSubnetsFails(
 		// updateZones tries to constructs a ZonedEnviron with these calls.
 		zoneCalls := append([]apiservertesting.StubMethodCall{},
 			apiservertesting.BackingCall("ModelConfig"),
+			apiservertesting.BackingCall("CloudSpec"),
 			apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		)
 		// Receiver can differ according to envName, but

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -81,13 +81,11 @@ func NewControllerAPI(
 	environConfigGetter := stateenvirons.EnvironConfigGetter{st}
 	return &ControllerAPI{
 		ControllerConfigAPI: common.NewControllerConfig(st),
-		CloudSpecAPI: cloudspec.NewCloudSpecForModel(
-			st.ModelTag(), environConfigGetter.CloudSpec,
-		),
-		state:      st,
-		authorizer: authorizer,
-		apiUser:    apiUser,
-		resources:  resources,
+		CloudSpecAPI:        cloudspec.NewCloudSpec(environConfigGetter.CloudSpec, common.AuthFuncForTag(st.ModelTag())),
+		state:               st,
+		authorizer:          authorizer,
+		apiUser:             apiUser,
+		resources:           resources,
 	}, nil
 }
 

--- a/apiserver/firewaller/firewaller.go
+++ b/apiserver/firewaller/firewaller.go
@@ -95,7 +95,7 @@ func NewFirewallerAPI(
 	)
 
 	environConfigGetter := stateenvirons.EnvironConfigGetter{st}
-	cloudSpecAPI := cloudspec.NewCloudSpecForModel(st.ModelTag(), environConfigGetter.CloudSpec)
+	cloudSpecAPI := cloudspec.NewCloudSpec(environConfigGetter.CloudSpec, common.AuthFuncForTag(st.ModelTag()))
 
 	return &FirewallerAPI{
 		LifeGetter:           lifeGetter,

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -117,7 +117,7 @@ func NewProvisionerAPI(st *state.State, resources facade.Resources, authorizer f
 		InstanceIdGetter:     common.NewInstanceIdGetter(st, getAuthFunc),
 		ToolsFinder:          common.NewToolsFinder(configGetter, st, urlGetter),
 		ToolsGetter:          common.NewToolsGetter(st, configGetter, st, urlGetter, getAuthOwner),
-		CloudSpecAPI:         cloudspec.NewCloudSpecForModel(st.ModelTag(), configGetter.CloudSpec),
+		CloudSpecAPI:         cloudspec.NewCloudSpec(configGetter.CloudSpec, common.AuthFuncForTag(st.ModelTag())),
 		st:                   st,
 		resources:            resources,
 		authorizer:           authorizer,

--- a/apiserver/spaces/spaces_test.go
+++ b/apiserver/spaces/spaces_test.go
@@ -121,6 +121,7 @@ func (s *SpacesSuite) checkAddSpaces(c *gc.C, p checkAddSpacesParams) {
 
 	baseCalls := []apiservertesting.StubMethodCall{
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.ZonedNetworkingEnvironCall("SupportsSpaces"),
 	}
@@ -163,6 +164,7 @@ func (s *SpacesSuite) TestAddSpacesManySubnets(c *gc.C) {
 func (s *SpacesSuite) TestAddSpacesAPIError(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.ModelConfig()
+		nil, // Backing.CloudSpec()
 		nil, // Provider.Open()
 		nil, // ZonedNetworkingEnviron.SupportsSpaces()
 		errors.AlreadyExistsf("space-foo"), // Backing.AddSpace()
@@ -269,6 +271,7 @@ func (s *SpacesSuite) TestListSpacesAllSpacesError(c *gc.C) {
 func (s *SpacesSuite) TestListSpacesSubnetsError(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.ModelConfig()
+		nil, // Backing.CloudSpec()
 		nil, // Provider.Open()
 		nil, // ZonedNetworkingEnviron.SupportsSpaces()
 		nil, // Backing.AllSpaces()
@@ -289,6 +292,7 @@ func (s *SpacesSuite) TestListSpacesSubnetsSingleSubnetError(c *gc.C) {
 	boom := errors.New("boom")
 	apiservertesting.SharedStub.SetErrors(
 		nil,  // Backing.ModelConfig()
+		nil,  // Backing.CloudSpec()
 		nil,  // Provider.Open()
 		nil,  // ZonedNetworkingEnviron.SupportsSpaces()
 		nil,  // Backing.AllSpaces()
@@ -320,6 +324,7 @@ func (s *SpacesSuite) TestCreateSpacesModelConfigError(c *gc.C) {
 func (s *SpacesSuite) TestCreateSpacesProviderOpenError(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil,                // Backing.ModelConfig()
+		nil,                // Backing.CloudSpec()
 		errors.New("boom"), // Provider.Open()
 	)
 
@@ -331,6 +336,7 @@ func (s *SpacesSuite) TestCreateSpacesProviderOpenError(c *gc.C) {
 func (s *SpacesSuite) TestCreateSpacesNotSupportedError(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.ModelConfig()
+		nil, // Backing.CloudSpec()
 		nil, // Provider.Open()
 		errors.NotSupportedf("spaces"), // ZonedNetworkingEnviron.SupportsSpaces()
 	)
@@ -343,6 +349,7 @@ func (s *SpacesSuite) TestCreateSpacesNotSupportedError(c *gc.C) {
 func (s *SpacesSuite) TestListSpacesNotSupportedError(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.ModelConfig()
+		nil, // Backing.CloudSpec()
 		nil, // Provider.Open
 		errors.NotSupportedf("spaces"), // ZonedNetworkingEnviron.SupportsSpaces()
 	)

--- a/apiserver/subnets/subnets_test.go
+++ b/apiserver/subnets/subnets_test.go
@@ -148,6 +148,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesUpdates(c *gc.C) {
 	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
 		apiservertesting.BackingCall("AvailabilityZones"),
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.ZonedEnvironCall("AvailabilityZones"),
 		apiservertesting.BackingCall("SetAvailabilityZones", apiservertesting.ProviderInstance.Zones),
@@ -159,6 +160,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndSetFails(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.AvailabilityZones
 		nil, // Backing.ModelConfig
+		nil, // Backing.CloudSpec
 		nil, // Provider.Open
 		nil, // ZonedEnviron.AvailabilityZones
 		errors.NotSupportedf("setting"), // Backing.SetAvailabilityZones
@@ -175,6 +177,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndSetFails(c *gc.C) {
 	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
 		apiservertesting.BackingCall("AvailabilityZones"),
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.ZonedEnvironCall("AvailabilityZones"),
 		apiservertesting.BackingCall("SetAvailabilityZones", apiservertesting.ProviderInstance.Zones),
@@ -186,6 +189,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndFetchingZonesFails(c *gc
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.AvailabilityZones
 		nil, // Backing.ModelConfig
+		nil, // Backing.CloudSpec
 		nil, // Provider.Open
 		errors.NotValidf("foo"), // ZonedEnviron.AvailabilityZones
 	)
@@ -201,6 +205,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndFetchingZonesFails(c *gc
 	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
 		apiservertesting.BackingCall("AvailabilityZones"),
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.ZonedEnvironCall("AvailabilityZones"),
 	)
@@ -232,6 +237,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndOpenFails(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.AvailabilityZones
 		nil, // Backing.ModelConfig
+		nil, // Backing.CloudSpec
 		errors.NotValidf("config"), // Provider.Open
 	)
 
@@ -246,6 +252,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndOpenFails(c *gc.C) {
 	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
 		apiservertesting.BackingCall("AvailabilityZones"),
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 	)
 }
@@ -265,6 +272,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndZonesNotSupported(c *gc.
 	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
 		apiservertesting.BackingCall("AvailabilityZones"),
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 	)
 }
@@ -453,15 +461,18 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 
 		// caching subnets (2nd attepmt): fails
 		nil, // BackingInstance.ModelConfig (2nd call)
+		nil, // BackingInstance.CloudSpec (1st call)
 		errors.NotFoundf("provider"), // ProviderInstance.Open (1st call)
 
 		// caching subnets (3rd attempt): fails
 		nil, // BackingInstance.ModelConfig (3rd call)
+		nil, // BackingInstance.CloudSpec (2nd call)
 		nil, // ProviderInstance.Open (2nd call)
 		errors.NotFoundf("subnets"), // NetworkingEnvironInstance.Subnets (1st call)
 
 		// caching subnets (4th attempt): succeeds
 		nil, // BackingInstance.ModelConfig (4th call)
+		nil, // BackingInstance.CloudSpec (3rd call)
 		nil, // ProviderInstance.Open (3rd call)
 		nil, // NetworkingEnvironInstance.Subnets (2nd call)
 
@@ -571,15 +582,18 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 
 		// caching subnets (2nd attepmt): fails
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 
 		// caching subnets (3rd attempt): fails
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.NetworkingEnvironCall("Subnets", instance.UnknownId, []network.Id(nil)),
 
 		// caching subnets (4th attempt): succeeds
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.NetworkingEnvironCall("Subnets", instance.UnknownId, []network.Id(nil)),
 
@@ -619,6 +633,7 @@ func (s *SubnetsSuite) CheckAddSubnetsFails(
 	// These calls always happen.
 	expectedCalls := []apiservertesting.StubMethodCall{
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 	}
 
@@ -677,6 +692,7 @@ func (s *SubnetsSuite) CheckAddSubnetsFails(
 		// updateZones tries to constructs a ZonedEnviron with these calls.
 		zoneCalls := append([]apiservertesting.StubMethodCall{},
 			apiservertesting.BackingCall("ModelConfig"),
+			apiservertesting.BackingCall("CloudSpec"),
 			apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		)
 		// Receiver can differ according to envName, but

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
+	names "gopkg.in/juju/names.v2"
 )
 
 type StubNetwork struct {
@@ -433,7 +434,7 @@ func (sb *StubBacking) ModelConfig() (*config.Config, error) {
 	return sb.EnvConfig, nil
 }
 
-func (sb *StubBacking) CloudSpec() (environs.CloudSpec, error) {
+func (sb *StubBacking) CloudSpec(names.ModelTag) (environs.CloudSpec, error) {
 	sb.MethodCall(sb, "CloudSpec")
 	if err := sb.NextErr(); err != nil {
 		return environs.CloudSpec{}, err

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -260,7 +260,10 @@ func (c *restoreCommand) rebootstrap(ctx *cmd.Context, meta *params.BackupsMetad
 		return errors.Trace(err)
 	}
 
-	env, err := c.newEnvironFunc(environs.OpenParams{params.ModelConfig})
+	env, err := c.newEnvironFunc(environs.OpenParams{
+		Cloud:  params.Cloud,
+		Config: params.ModelConfig,
+	})
 	if err != nil {
 		return errors.Annotate(err, "opening environ for rebootstrapping")
 	}

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -748,9 +748,17 @@ func (s *BootstrapSuite) TestAutoSyncLocalSource(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	cfg, err := modelcmd.NewGetBootstrapConfigFunc(s.store)("devcontroller")
+	bootstrapConfig, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(s.store)("devcontroller")
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.New(environs.OpenParams{cfg})
+	provider, err := environs.Provider(bootstrapConfig.CloudType)
+	c.Assert(err, jc.ErrorIsNil)
+	cfg, err := provider.BootstrapConfig(*params)
+	c.Assert(err, jc.ErrorIsNil)
+
+	env, err := environs.New(environs.OpenParams{
+		Cloud:  params.Cloud,
+		Config: cfg,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = env.PrepareForBootstrap(envtesting.BootstrapContext(c))
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -19,10 +19,11 @@ import (
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/cmd/modelcmd"
 	cmdtesting "github.com/juju/juju/cmd/testing"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
-	_ "github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
 )
 
@@ -49,6 +50,7 @@ type baseDestroySuite struct {
 // fakeDestroyAPI mocks out the controller API
 type fakeDestroyAPI struct {
 	gitjujutesting.Stub
+	cloud      environs.CloudSpec
 	env        map[string]interface{}
 	destroyAll bool
 	blocks     []params.ModelBlockInfo
@@ -59,6 +61,14 @@ type fakeDestroyAPI struct {
 func (f *fakeDestroyAPI) Close() error {
 	f.MethodCall(f, "Close")
 	return f.NextErr()
+}
+
+func (f *fakeDestroyAPI) CloudSpec(tag names.ModelTag) (environs.CloudSpec, error) {
+	f.MethodCall(f, "CloudSpec", tag)
+	if err := f.NextErr(); err != nil {
+		return environs.CloudSpec{}, err
+	}
+	return f.cloud, nil
 }
 
 func (f *fakeDestroyAPI) ModelConfig() (map[string]interface{}, error) {
@@ -132,6 +142,7 @@ func (s *baseDestroySuite) SetUpTest(c *gc.C) {
 	s.clientapi = &fakeDestroyAPIClient{}
 	owner := names.NewUserTag("owner")
 	s.api = &fakeDestroyAPI{
+		cloud:     dummy.SampleCloudSpec(),
 		envStatus: map[string]base.ModelStatus{},
 	}
 	s.apierror = nil

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/agentbootstrap"
 	agenttools "github.com/juju/juju/agent/tools"
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	agentcmd "github.com/juju/juju/cmd/jujud/agent"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
@@ -128,7 +129,30 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 	}
 
 	// Get the bootstrap machine's addresses from the provider.
-	env, err := environs.New(environs.OpenParams{args.ControllerModelConfig})
+	cloudEndpoint := args.ControllerCloud.Endpoint
+	cloudStorageEndpoint := args.ControllerCloud.StorageEndpoint
+	if args.ControllerCloudRegion != "" {
+		region, err := cloud.RegionByName(
+			args.ControllerCloud.Regions,
+			args.ControllerCloudRegion,
+		)
+		if err != nil {
+			return errors.Annotate(err, "getting cloud region")
+		}
+		cloudEndpoint = region.Endpoint
+		cloudStorageEndpoint = region.StorageEndpoint
+	}
+	env, err := environs.New(environs.OpenParams{
+		Cloud: environs.CloudSpec{
+			Type:            args.ControllerCloud.Type,
+			Name:            args.ControllerCloudName,
+			Region:          args.ControllerCloudRegion,
+			Endpoint:        cloudEndpoint,
+			StorageEndpoint: cloudStorageEndpoint,
+			Credential:      args.ControllerCloudCredential,
+		},
+		Config: args.ControllerModelConfig,
+	})
 	if err != nil {
 		return err
 	}

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -803,7 +803,10 @@ func (s *BootstrapSuite) makeTestModel(c *gc.C) {
 		Config:         cfg,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := provider.Open(environs.OpenParams{cfg})
+	env, err := provider.Open(environs.OpenParams{
+		Cloud:  dummy.SampleCloudSpec(),
+		Config: cfg,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = env.PrepareForBootstrap(nullContext())
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -148,7 +148,10 @@ func prepare(
 	if err != nil {
 		return nil, details, errors.Trace(err)
 	}
-	env, err := p.Open(environs.OpenParams{cfg})
+	env, err := p.Open(environs.OpenParams{
+		Cloud:  args.Cloud,
+		Config: cfg,
+	})
 	if err != nil {
 		return nil, details, errors.Trace(err)
 	}

--- a/environs/environ.go
+++ b/environs/environ.go
@@ -5,6 +5,7 @@ package environs
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/environs/config"
 )
@@ -12,6 +13,7 @@ import (
 // EnvironConfigGetter exposes a model configuration to its clients.
 type EnvironConfigGetter interface {
 	ModelConfig() (*config.Config, error)
+	CloudSpec(names.ModelTag) (CloudSpec, error)
 }
 
 // NewEnvironFunc is the type of a function that, given a model config,
@@ -25,7 +27,14 @@ func GetEnviron(st EnvironConfigGetter, newEnviron NewEnvironFunc) (Environ, err
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	env, err := newEnviron(OpenParams{modelConfig})
+	cloudSpec, err := st.CloudSpec(names.NewModelTag(modelConfig.UUID()))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	env, err := newEnviron(OpenParams{
+		Cloud:  cloudSpec,
+		Config: modelConfig,
+	})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/environs/environ_test.go
+++ b/environs/environ_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state/stateenvirons"
 )
 
 type environSuite struct {
@@ -18,7 +19,7 @@ type environSuite struct {
 var _ = gc.Suite(&environSuite{})
 
 func (s *environSuite) TestGetEnvironment(c *gc.C) {
-	env, err := environs.GetEnviron(s.State, environs.New)
+	env, err := stateenvirons.GetNewEnvironFunc(environs.New)(s.State)
 	c.Assert(err, jc.ErrorIsNil)
 	config, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -50,6 +50,9 @@ type EnvironProvider interface {
 
 // OpenParams contains the parameters for EnvironProvider.Open.
 type OpenParams struct {
+	// Cloud is the cloud specification to use to connect to the cloud.
+	Cloud CloudSpec
+
 	// Config is the base configuration for the provider.
 	Config *config.Config
 }

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -49,7 +49,10 @@ type Tests struct {
 
 // Open opens an instance of the testing environment.
 func (t *Tests) Open(c *gc.C, cfg *config.Config) environs.Environ {
-	e, err := environs.New(environs.OpenParams{cfg})
+	e, err := environs.New(environs.OpenParams{
+		Cloud:  t.CloudSpec(),
+		Config: cfg,
+	})
 	c.Assert(err, gc.IsNil, gc.Commentf("opening environ %#v", cfg.AllAttrs()))
 	c.Assert(e, gc.NotNil)
 	return e

--- a/environs/open.go
+++ b/environs/open.go
@@ -14,7 +14,7 @@ const AdminUser = "admin@local"
 
 // New returns a new environment based on the provided configuration.
 func New(args OpenParams) (Environ, error) {
-	p, err := Provider(args.Config.Type())
+	p, err := Provider(args.Cloud.Type)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -111,13 +111,11 @@ func (s *OpenSuite) TestUpdateEnvInfo(c *gc.C) {
 }
 
 func (*OpenSuite) TestNewUnknownEnviron(c *gc.C) {
-	cfg, err := config.New(config.NoDefaults, dummy.SampleConfig().Merge(
-		testing.Attrs{
-			"type": "wondercloud",
+	env, err := environs.New(environs.OpenParams{
+		Cloud: environs.CloudSpec{
+			Type: "wondercloud",
 		},
-	))
-	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.New(environs.OpenParams{cfg})
+	})
 	c.Assert(err, gc.ErrorMatches, "no registered provider for.*")
 	c.Assert(env, gc.IsNil)
 }
@@ -130,7 +128,10 @@ func (*OpenSuite) TestNew(c *gc.C) {
 		},
 	))
 	c.Assert(err, jc.ErrorIsNil)
-	e, err := environs.New(environs.OpenParams{cfg})
+	e, err := environs.New(environs.OpenParams{
+		Cloud:  dummy.SampleCloudSpec(),
+		Config: cfg,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = e.ControllerInstances("uuid")
 	c.Assert(err, gc.ErrorMatches, "model is not prepared")

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -318,8 +318,10 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 			Endpoint:        cloudSpec.Endpoint,
 			StorageEndpoint: cloudSpec.StorageEndpoint,
 		},
-		AdminSecret:  AdminSecret,
-		CAPrivateKey: testing.CAKey,
+		CloudCredential:     cloudSpec.Credential,
+		CloudCredentialName: "cred",
+		AdminSecret:         AdminSecret,
+		CAPrivateKey:        testing.CAKey,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -306,7 +306,10 @@ func openEnviron(
 	// Opening the environment should not incur network communication,
 	// so we don't set s.sender until after opening.
 	cfg := makeTestModelConfig(c, attrs...)
-	env, err := provider.Open(environs.OpenParams{cfg})
+	env, err := provider.Open(environs.OpenParams{
+		Cloud:  fakeCloudSpec(),
+		Config: cfg,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Force an explicit refresh of the access token, so it isn't done
@@ -330,19 +333,26 @@ func prepareForBootstrap(
 	*sender = azuretesting.Senders{tokenRefreshSender()}
 	cfg, err := provider.BootstrapConfig(environs.BootstrapConfigParams{
 		Config: cfg,
-		Cloud: environs.CloudSpec{
-			Region:          "westus",
-			Endpoint:        "https://management.azure.com",
-			StorageEndpoint: "https://core.windows.net",
-			Credential:      fakeUserPassCredential(),
-		},
+		Cloud:  fakeCloudSpec(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := provider.Open(environs.OpenParams{cfg})
+	env, err := provider.Open(environs.OpenParams{
+		Cloud:  fakeCloudSpec(),
+		Config: cfg,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = env.PrepareForBootstrap(ctx)
 	c.Assert(err, jc.ErrorIsNil)
 	return env
+}
+
+func fakeCloudSpec() environs.CloudSpec {
+	return environs.CloudSpec{
+		Region:          "westus",
+		Endpoint:        "https://management.azure.com",
+		StorageEndpoint: "https://core.windows.net",
+		Credential:      fakeUserPassCredential(),
+	}
 }
 
 func tokenRefreshSender() *azuretesting.MockSender {

--- a/provider/cloudsigma/config_test.go
+++ b/provider/cloudsigma/config_test.go
@@ -30,6 +30,15 @@ func validAttrs() testing.Attrs {
 	})
 }
 
+func fakeCloudSpec() environs.CloudSpec {
+	return environs.CloudSpec{
+		Type:     "cloudsigma",
+		Name:     "cloudsigma",
+		Region:   "zrh",
+		Endpoint: "https://0.1.2.3:2000/api/2.0/",
+	}
+}
+
 type configSuite struct {
 	testing.BaseSuite
 }
@@ -91,7 +100,7 @@ func (s *configSuite) TestNewModelConfig(c *gc.C) {
 		c.Logf("test %d: %s", i, test.info)
 		attrs := validAttrs().Merge(test.insert).Delete(test.remove...)
 		testConfig := newConfig(c, attrs)
-		environ, err := environs.New(environs.OpenParams{testConfig})
+		environ, err := environs.New(environs.OpenParams{fakeCloudSpec(), testConfig})
 		if test.err == "" {
 			c.Check(err, gc.IsNil)
 			attrs := environ.Config().AllAttrs()
@@ -177,7 +186,7 @@ func (s *configSuite) TestSetConfig(c *gc.C) {
 	baseConfig := newConfig(c, validAttrs())
 	for i, test := range changeConfigTests {
 		c.Logf("test %d: %s", i, test.info)
-		environ, err := environs.New(environs.OpenParams{baseConfig})
+		environ, err := environs.New(environs.OpenParams{fakeCloudSpec(), baseConfig})
 		c.Assert(err, gc.IsNil)
 		attrs := validAttrs().Merge(test.insert).Delete(test.remove...)
 		testConfig := newConfig(c, attrs)

--- a/provider/cloudsigma/environ_test.go
+++ b/provider/cloudsigma/environ_test.go
@@ -46,7 +46,10 @@ func (s *environSuite) TestBase(c *gc.C) {
 	})
 
 	baseConfig := newConfig(c, validAttrs().Merge(testing.Attrs{"name": "testname"}))
-	env, err := environs.New(environs.OpenParams{baseConfig})
+	env, err := environs.New(environs.OpenParams{
+		Cloud:  fakeCloudSpec(),
+		Config: baseConfig,
+	})
 	c.Assert(err, gc.IsNil)
 	env.(*environ).supportedArchitectures = []string{arch.AMD64}
 
@@ -89,7 +92,10 @@ func (s *environSuite) TestUnsupportedConstraints(c *gc.C) {
 	})
 
 	baseConfig := newConfig(c, validAttrs().Merge(testing.Attrs{"name": "testname"}))
-	env, err := environs.New(environs.OpenParams{baseConfig})
+	env, err := environs.New(environs.OpenParams{
+		Cloud:  fakeCloudSpec(),
+		Config: baseConfig,
+	})
 	c.Assert(err, gc.IsNil)
 	env.(*environ).supportedArchitectures = []string{arch.AMD64}
 

--- a/provider/cloudsigma/environinstance_test.go
+++ b/provider/cloudsigma/environinstance_test.go
@@ -75,7 +75,10 @@ func (s *environInstanceSuite) createEnviron(c *gc.C, cfg *config.Config) enviro
 	if cfg == nil {
 		cfg = s.baseConfig
 	}
-	environ, err := environs.New(environs.OpenParams{cfg})
+	environ, err := environs.New(environs.OpenParams{
+		Cloud:  fakeCloudSpec(),
+		Config: cfg,
+	})
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(environ, gc.NotNil)

--- a/provider/ec2/config_test.go
+++ b/provider/ec2/config_test.go
@@ -62,13 +62,21 @@ type configTest struct {
 type attrs map[string]interface{}
 
 func (t configTest) check(c *gc.C) {
+	cloudSpec := environs.CloudSpec{
+		Type:   "ec2",
+		Name:   "ec2test",
+		Region: "us-east-1",
+	}
 	attrs := testing.FakeConfig().Merge(testing.Attrs{
 		"type":   "ec2",
 		"region": "us-east-1",
 	}).Merge(t.config)
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	e, err := environs.New(environs.OpenParams{cfg})
+	e, err := environs.New(environs.OpenParams{
+		Cloud:  cloudSpec,
+		Config: cfg,
+	})
 	if t.change != nil {
 		c.Assert(err, jc.ErrorIsNil)
 

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -617,7 +617,10 @@ func (t *localServerSuite) TestDestroyHostedModelDeleteSecurityGroupInsistentlyE
 
 	cfg, err := env.Config().Apply(map[string]interface{}{"controller-uuid": "7e386e08-cba7-44a4-a76e-7c1633584210"})
 	c.Assert(err, jc.ErrorIsNil)
-	env, err = environs.New(environs.OpenParams{cfg})
+	env, err = environs.New(environs.OpenParams{
+		Cloud:  t.CloudSpec(),
+		Config: cfg,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	msg := "destroy security group error"
@@ -640,7 +643,7 @@ func (t *localServerSuite) TestDestroyControllerDestroysHostedModelResources(c *
 		"firewall-mode": "global",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.New(environs.OpenParams{cfg})
+	env, err := environs.New(environs.OpenParams{t.CloudSpec(), cfg})
 	c.Assert(err, jc.ErrorIsNil)
 	inst, _ := testing.AssertStartInstance(c, env, t.ControllerUUID, "0")
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/gce/provider_test.go
+++ b/provider/gce/provider_test.go
@@ -7,7 +7,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/gce"
 )
@@ -33,7 +32,10 @@ func (s *providerSuite) TestRegistered(c *gc.C) {
 }
 
 func (s *providerSuite) TestOpen(c *gc.C) {
-	env, err := s.provider.Open(environs.OpenParams{s.Config})
+	env, err := s.provider.Open(environs.OpenParams{
+		Cloud:  makeTestCloudSpec(),
+		Config: s.Config,
+	})
 	c.Check(err, jc.ErrorIsNil)
 
 	envConfig := env.Config()
@@ -41,20 +43,9 @@ func (s *providerSuite) TestOpen(c *gc.C) {
 }
 
 func (s *providerSuite) TestBootstrapConfig(c *gc.C) {
-	credential := cloud.NewCredential(
-		cloud.OAuth2AuthType,
-		map[string]string{
-			"project-id":   "x",
-			"client-id":    "y",
-			"client-email": "zz@example.com",
-			"private-key":  "why",
-		},
-	)
 	cfg, err := s.provider.BootstrapConfig(environs.BootstrapConfigParams{
 		Config: s.Config,
-		Cloud: environs.CloudSpec{
-			Credential: &credential,
-		},
+		Cloud:  makeTestCloudSpec(),
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(cfg, gc.NotNil)

--- a/provider/lxd/config_test.go
+++ b/provider/lxd/config_test.go
@@ -321,7 +321,7 @@ func (s *configSuite) TestNewModelConfig(c *gc.C) {
 		c.Logf("test %d: %s", i, test.info)
 
 		testConfig := test.newConfig(c)
-		environ, err := environs.New(environs.OpenParams{testConfig})
+		environ, err := environs.New(environs.OpenParams{lxdCloudSpec(), testConfig})
 
 		// Check the result
 		if test.err != "" {
@@ -421,7 +421,7 @@ func (s *configSuite) TestSetConfig(c *gc.C) {
 	for i, test := range changeConfigTests {
 		c.Logf("test %d: %s", i, test.info)
 
-		environ, err := environs.New(environs.OpenParams{s.config})
+		environ, err := environs.New(environs.OpenParams{lxdCloudSpec(), s.config})
 		c.Assert(err, jc.ErrorIsNil)
 
 		testConfig := test.newConfig(c)
@@ -449,5 +449,12 @@ func (*configSuite) TestSchema(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	for name, field := range globalFields {
 		c.Check(fields[name], jc.DeepEquals, field)
+	}
+}
+
+func lxdCloudSpec() environs.CloudSpec {
+	return environs.CloudSpec{
+		Type: "lxd",
+		Name: "localhost",
 	}
 }

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -104,7 +104,10 @@ func (s *ProviderFunctionalSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ProviderFunctionalSuite) TestOpen(c *gc.C) {
-	env, err := s.provider.Open(environs.OpenParams{s.Config})
+	env, err := s.provider.Open(environs.OpenParams{
+		Cloud:  lxdCloudSpec(),
+		Config: s.Config,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	envConfig := env.Config()
 

--- a/provider/maas/environprovider_test.go
+++ b/provider/maas/environprovider_test.go
@@ -183,7 +183,10 @@ func (suite *EnvironProviderSuite) TestOpenReturnsNilInterfaceUponFailure(c *gc.
 	})
 	config, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := providerInstance.Open(environs.OpenParams{config})
+	env, err := providerInstance.Open(environs.OpenParams{
+		Cloud:  suite.cloudSpec(),
+		Config: config,
+	})
 	// When Open() fails (i.e. returns a non-nil error), it returns an
 	// environs.Environ interface object with a nil value and a nil
 	// type.

--- a/provider/manual/config.go
+++ b/provider/manual/config.go
@@ -11,7 +11,6 @@ import (
 
 var (
 	configFields = schema.Fields{
-		"bootstrap-host": schema.String(),
 		"bootstrap-user": schema.String(),
 	}
 	configDefaults = schema.Defaults{
@@ -26,10 +25,6 @@ type environConfig struct {
 
 func newModelConfig(config *config.Config, attrs map[string]interface{}) *environConfig {
 	return &environConfig{Config: config, attrs: attrs}
-}
-
-func (c *environConfig) bootstrapHost() string {
-	return c.attrs["bootstrap-host"].(string)
 }
 
 func (c *environConfig) bootstrapUser() string {

--- a/provider/manual/config_test.go
+++ b/provider/manual/config_test.go
@@ -10,6 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -20,6 +21,14 @@ type configSuite struct {
 
 var _ = gc.Suite(&configSuite{})
 
+func CloudSpec() environs.CloudSpec {
+	return environs.CloudSpec{
+		Name:     "manual",
+		Type:     "manual",
+		Endpoint: "hostname",
+	}
+}
+
 func MinimalConfigValues() map[string]interface{} {
 	return map[string]interface{}{
 		"name":            "test",
@@ -27,7 +36,6 @@ func MinimalConfigValues() map[string]interface{} {
 		"uuid":            coretesting.ModelTag.Id(),
 		"controller-uuid": coretesting.ModelTag.Id(),
 		"firewall-mode":   "instance",
-		"bootstrap-host":  "hostname",
 		"bootstrap-user":  "",
 		// While the ca-cert bits aren't entirely minimal, they avoid the need
 		// to set up a fake home.
@@ -51,25 +59,6 @@ func getModelConfig(c *gc.C, attrs map[string]interface{}) *environConfig {
 	return envConfig
 }
 
-func (s *configSuite) TestValidateConfig(c *gc.C) {
-	testConfig := MinimalConfig(c)
-	testConfig, err := testConfig.Apply(map[string]interface{}{"bootstrap-host": ""})
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = manualProvider{}.Validate(testConfig, nil)
-	c.Assert(err, gc.ErrorMatches, "bootstrap-host must be specified")
-
-	values := MinimalConfigValues()
-	delete(values, "bootstrap-user")
-	testConfig, err = config.New(config.UseDefaults, values)
-	c.Assert(err, jc.ErrorIsNil)
-
-	valid, err := manualProvider{}.Validate(testConfig, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	unknownAttrs := valid.UnknownAttrs()
-	c.Assert(unknownAttrs["bootstrap-host"], gc.Equals, "hostname")
-	c.Assert(unknownAttrs["bootstrap-user"], gc.Equals, "")
-}
-
 func (s *configSuite) TestConfigMutability(c *gc.C) {
 	testConfig := MinimalConfig(c)
 	valid, err := manualProvider{}.Validate(testConfig, nil)
@@ -81,7 +70,6 @@ func (s *configSuite) TestConfigMutability(c *gc.C) {
 	// machine agent's config/upstart config.
 	oldConfig := testConfig
 	for k, v := range map[string]interface{}{
-		"bootstrap-host": "new-hostname",
 		"bootstrap-user": "new-username",
 	} {
 		testConfig = MinimalConfig(c)
@@ -94,14 +82,11 @@ func (s *configSuite) TestConfigMutability(c *gc.C) {
 	}
 }
 
-func (s *configSuite) TestBootstrapHostUser(c *gc.C) {
+func (s *configSuite) TestBootstrapUser(c *gc.C) {
 	values := MinimalConfigValues()
 	testConfig := getModelConfig(c, values)
-	c.Assert(testConfig.bootstrapHost(), gc.Equals, "hostname")
 	c.Assert(testConfig.bootstrapUser(), gc.Equals, "")
-	values["bootstrap-host"] = "127.0.0.1"
 	values["bootstrap-user"] = "ubuntu"
 	testConfig = getModelConfig(c, values)
-	c.Assert(testConfig.bootstrapHost(), gc.Equals, "127.0.0.1")
 	c.Assert(testConfig.bootstrapUser(), gc.Equals, "ubuntu")
 }

--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -24,7 +24,10 @@ type baseEnvironSuite struct {
 
 func (s *baseEnvironSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	env, err := manualProvider{}.Open(environs.OpenParams{MinimalConfig(c)})
+	env, err := manualProvider{}.Open(environs.OpenParams{
+		Cloud:  CloudSpec(),
+		Config: MinimalConfig(c),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.env = env.(*manualEnviron)
 }
@@ -34,17 +37,6 @@ type environSuite struct {
 }
 
 var _ = gc.Suite(&environSuite{})
-
-func (s *environSuite) TestSetConfig(c *gc.C) {
-	err := s.env.SetConfig(MinimalConfig(c))
-	c.Assert(err, jc.ErrorIsNil)
-
-	testConfig := MinimalConfig(c)
-	testConfig, err = testConfig.Apply(map[string]interface{}{"bootstrap-host": ""})
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.env.SetConfig(testConfig)
-	c.Assert(err, gc.ErrorMatches, "bootstrap-host must be specified")
-}
 
 func (s *environSuite) TestInstances(c *gc.C) {
 	var ids []instance.Id

--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -21,12 +21,10 @@ type manualProvider struct {
 // Verify that we conform to the interface.
 var _ environs.EnvironProvider = (*manualProvider)(nil)
 
-var errNoBootstrapHost = errors.New("bootstrap-host must be specified")
-
 var initUbuntuUser = manual.InitUbuntuUser
 
-func ensureBootstrapUbuntuUser(ctx environs.BootstrapContext, cfg *environConfig) error {
-	err := initUbuntuUser(cfg.bootstrapHost(), cfg.bootstrapUser(), cfg.AuthorizedKeys(), ctx.GetStdin(), ctx.GetStdout())
+func ensureBootstrapUbuntuUser(ctx environs.BootstrapContext, host string, cfg *environConfig) error {
+	err := initUbuntuUser(host, cfg.bootstrapUser(), cfg.AuthorizedKeys(), ctx.GetStdin(), ctx.GetStdout())
 	if err != nil {
 		logger.Errorf("initializing ubuntu user: %v", err)
 		return err
@@ -37,7 +35,7 @@ func ensureBootstrapUbuntuUser(ctx environs.BootstrapContext, cfg *environConfig
 
 // RestrictedConfigAttributes is specified in the EnvironProvider interface.
 func (p manualProvider) RestrictedConfigAttributes() []string {
-	return []string{"bootstrap-host", "bootstrap-user"}
+	return []string{"bootstrap-user"}
 }
 
 // DetectRegions is specified in the environs.CloudRegionDetector interface.
@@ -52,26 +50,20 @@ func (p manualProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *
 
 // BootstrapConfig is specified in the EnvironProvider interface.
 func (p manualProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
-	if args.Cloud.Endpoint == "" {
-		return nil, errors.Errorf(
-			"missing address of host to bootstrap: " +
-				`please specify "juju bootstrap manual/<host>"`,
-		)
-	}
-	cfg, err := args.Config.Apply(map[string]interface{}{
-		"bootstrap-host": args.Cloud.Endpoint,
-	})
-	if err != nil {
+	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Trace(err)
 	}
-	envConfig, err := p.validate(cfg, nil)
+	envConfig, err := p.validate(args.Config, nil)
 	if err != nil {
 		return nil, err
 	}
-	return cfg.Apply(envConfig.attrs)
+	return args.Config.Apply(envConfig.attrs)
 }
 
 func (p manualProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+	if err := validateCloudSpec(args.Cloud); err != nil {
+		return nil, errors.Trace(err)
+	}
 	_, err := p.validate(args.Config, nil)
 	if err != nil {
 		return nil, err
@@ -80,11 +72,21 @@ func (p manualProvider) Open(args environs.OpenParams) (environs.Environ, error)
 	// with their defaults in the result; we don't wnat that in
 	// Open.
 	envConfig := newModelConfig(args.Config, args.Config.UnknownAttrs())
-	return p.open(envConfig)
+	return p.open(args.Cloud.Endpoint, envConfig)
 }
 
-func (p manualProvider) open(cfg *environConfig) (environs.Environ, error) {
-	env := &manualEnviron{cfg: cfg}
+func validateCloudSpec(spec environs.CloudSpec) error {
+	if spec.Endpoint == "" {
+		return errors.Errorf(
+			"missing address of host to bootstrap: " +
+				`please specify "juju bootstrap manual/<host>"`,
+		)
+	}
+	return nil
+}
+
+func (p manualProvider) open(host string, cfg *environConfig) (environs.Environ, error) {
+	env := &manualEnviron{host: host, cfg: cfg}
 	// Need to call SetConfig to initialise storage.
 	if err := env.SetConfig(cfg.Config); err != nil {
 		return nil, err
@@ -109,9 +111,6 @@ func (p manualProvider) validate(cfg, old *config.Config) (*environConfig, error
 		return nil, err
 	}
 	envConfig := newModelConfig(cfg, validated)
-	if envConfig.bootstrapHost() == "" {
-		return nil, errNoBootstrapHost
-	}
 	// Check various immutable attributes.
 	if old != nil {
 		oldEnvConfig, err := p.validate(old, nil)
@@ -120,7 +119,6 @@ func (p manualProvider) validate(cfg, old *config.Config) (*environConfig, error
 		}
 		for _, key := range [...]string{
 			"bootstrap-user",
-			"bootstrap-host",
 		} {
 			if err = checkImmutableString(envConfig, oldEnvConfig, key); err != nil {
 				return nil, err

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -57,17 +57,21 @@ func (s *providerSuite) testPrepareForBootstrap(c *gc.C, endpoint, region string
 	minimal := manual.MinimalConfigValues()
 	testConfig, err := config.New(config.UseDefaults, minimal)
 	c.Assert(err, jc.ErrorIsNil)
+	cloudSpec := environs.CloudSpec{
+		Endpoint: endpoint,
+		Region:   region,
+	}
 	testConfig, err = manual.ProviderInstance.BootstrapConfig(environs.BootstrapConfigParams{
 		Config: testConfig,
-		Cloud: environs.CloudSpec{
-			Endpoint: endpoint,
-			Region:   region,
-		},
+		Cloud:  cloudSpec,
 	})
 	if err != nil {
 		return nil, err
 	}
-	env, err := manual.ProviderInstance.Open(environs.OpenParams{testConfig})
+	env, err := manual.ProviderInstance.Open(environs.OpenParams{
+		Cloud:  cloudSpec,
+		Config: testConfig,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/provider/openstack/config_test.go
+++ b/provider/openstack/config_test.go
@@ -100,7 +100,17 @@ func (t configTest) check(c *gc.C) {
 	}
 	defer restoreEnvVars(savedVars)
 
-	e, err := environs.New(environs.OpenParams{cfg})
+	cloudSpec := environs.CloudSpec{
+		Type:     "openstack",
+		Name:     "openstack",
+		Endpoint: "http://auth",
+		Region:   "Configtest",
+	}
+
+	e, err := environs.New(environs.OpenParams{
+		Cloud:  cloudSpec,
+		Config: cfg,
+	})
 	if t.change != nil {
 		c.Assert(err, jc.ErrorIsNil)
 

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -30,6 +30,10 @@ func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) 
 }
 
 // BootstrapConfig implements environs.EnvironProvider.
+//
+// TODO(axw) 2016-07-29 #1607620
+// We should be extracting the endpoint and region
+// in this method, and using them as host/datacenter.
 func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
 	cfg := args.Config
 	switch authType := args.Cloud.Credential.AuthType(); authType {

--- a/provider/vsphere/provider_test.go
+++ b/provider/vsphere/provider_test.go
@@ -35,7 +35,10 @@ func (s *providerSuite) TestRegistered(c *gc.C) {
 }
 
 func (s *providerSuite) TestOpen(c *gc.C) {
-	env, err := s.provider.Open(environs.OpenParams{s.Config})
+	env, err := s.provider.Open(environs.OpenParams{
+		Cloud:  vsphere.FakeCloudSpec(),
+		Config: s.Config,
+	})
 	c.Check(err, jc.ErrorIsNil)
 
 	envConfig := env.Config()

--- a/provider/vsphere/testing_test.go
+++ b/provider/vsphere/testing_test.go
@@ -29,8 +29,8 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-var (
-	ConfigAttrs = testing.FakeConfig().Merge(testing.Attrs{
+func ConfigAttrs() testing.Attrs {
+	return testing.FakeConfig().Merge(testing.Attrs{
 		"type":             "vsphere",
 		"uuid":             "2d02eeac-9dbb-11e4-89d3-123b93f75cba",
 		"datacenter":       "/datacenter1",
@@ -39,7 +39,14 @@ var (
 		"password":         "password1",
 		"external-network": "",
 	})
-)
+}
+
+func FakeCloudSpec() environs.CloudSpec {
+	return environs.CloudSpec{
+		Type: "vsphere",
+		Name: "vsphere",
+	}
+}
 
 type BaseSuite struct {
 	gitjujutesting.IsolationSuite
@@ -63,9 +70,12 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *BaseSuite) initEnv(c *gc.C) {
-	cfg, err := testing.ModelConfig(c).Apply(ConfigAttrs)
+	cfg, err := testing.ModelConfig(c).Apply(ConfigAttrs())
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.New(environs.OpenParams{cfg})
+	env, err := environs.New(environs.OpenParams{
+		Cloud:  FakeCloudSpec(),
+		Config: cfg,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.Env = env.(*environ)
 	s.setConfig(c, cfg)

--- a/state/interface.go
+++ b/state/interface.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
@@ -96,6 +97,13 @@ type AgentEntity interface {
 	EnsureDeader
 	Remover
 	NotifyWatcherFactory
+}
+
+// CloudAccessor defines the methods needed to
+// access cloud information.
+type CloudAccessor interface {
+	Cloud(string) (cloud.Cloud, error)
+	CloudCredentials(user names.UserTag, cloud string) (map[string]cloud.Credential, error)
 }
 
 // ModelAccessor defines the methods needed to watch for model

--- a/state/stateenvirons/config.go
+++ b/state/stateenvirons/config.go
@@ -5,6 +5,7 @@ package stateenvirons
 
 import (
 	"github.com/juju/errors"
+	names "gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
@@ -18,8 +19,8 @@ type EnvironConfigGetter struct {
 }
 
 // CloudSpec implements environs.EnvironConfigGetter.
-func (g EnvironConfigGetter) CloudSpec() (environs.CloudSpec, error) {
-	model, err := g.Model()
+func (g EnvironConfigGetter) CloudSpec(tag names.ModelTag) (environs.CloudSpec, error) {
+	model, err := g.GetModel(tag)
 	if err != nil {
 		return environs.CloudSpec{}, errors.Trace(err)
 	}

--- a/state/stateenvirons/config_test.go
+++ b/state/stateenvirons/config_test.go
@@ -53,7 +53,7 @@ func (s *environSuite) TestCloudSpec(c *gc.C) {
 	defer st.Close()
 
 	emptyCredential.Label = "empty-credential"
-	cloudSpec, err := stateenvirons.EnvironConfigGetter{st}.CloudSpec()
+	cloudSpec, err := stateenvirons.EnvironConfigGetter{st}.CloudSpec(st.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudSpec, jc.DeepEquals, environs.CloudSpec{
 		Type:       "dummy",


### PR DESCRIPTION
Add the CloudSpec to OpenParams. We do not currently refer
to OpenParams.Cloud in any of the providers except the manual
provider.

Requires https://github.com/juju/juju/pull/5886

**QA**

- Bootstrapped AWS in ap-southeast-2
- Created another model in us-east-1

- Bootstrapped manual, confirmed that bootstrap-host
  is not present in model config.

(Review request: http://reviews.vapour.ws/r/5329/)