### PR TITLE
containerinit: replace network interfaces file on first boot

### DIFF
--- a/cloudconfig/containerinit/export_test.go
+++ b/cloudconfig/containerinit/export_test.go
@@ -6,5 +6,6 @@ package containerinit
 
 var (
 	NetworkInterfacesFile          = &networkInterfacesFile
+	SystemNetworkInterfacesFile    = &systemNetworkInterfacesFile
 	NewCloudInitConfigWithNetworks = newCloudInitConfigWithNetworks
 )


### PR DESCRIPTION
On first boot we replace the data-source's /etc/network/interfaces with
a file that has been prepared by Juju to contain the correct mapping of
container interfaces to parent devices on the host machine.

We take down all the currently running interfaces, rewrite
/etc/network/interfaces with Juju's version, then bring all of those up.
This is a one-time affair.

Fixes [LP:#1566801](https://bugs.launchpad.net/juju-core/+bug/1566801)

(Review request: http://reviews.vapour.ws/r/5330/)