### PR TITLE
Generate /etc/network/interfaces for a container with the gateway staying on the correct card

### DIFF
--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -7,6 +7,7 @@ package containerinit
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
@@ -62,6 +63,18 @@ var (
 	networkInterfacesFile       = systemNetworkInterfacesFile + "-juju"
 )
 
+func writeList(w io.Writer, prefix string, list []string) {
+	if len(list) > 0 {
+		fmt.Fprintf(w, "%s %s\n", prefix, strings.Join(list, " "))
+	}
+}
+
+func writeString(w io.Writer, prefix, value string) {
+	if value != "" {
+		fmt.Fprintf(w, "%s %s\n", prefix, value)
+	}
+}
+
 // GenerateNetworkConfig renders a network config for one or more network
 // interfaces, using the given non-nil networkConfig containing a non-empty
 // Interfaces field.
@@ -71,64 +84,34 @@ func GenerateNetworkConfig(networkConfig *container.NetworkConfig) (string, erro
 	}
 	logger.Debugf("generating network config from %#v", *networkConfig)
 
+	w := &bytes.Buffer{}
 	prepared := PrepareNetworkConfigFromInterfaces(networkConfig.Interfaces)
 
-	var output bytes.Buffer
-	gatewayWritten := false
-	for _, name := range prepared.InterfaceNames {
-		output.WriteString("\n")
-		if name == "lo" {
-			output.WriteString("auto ")
-			autoStarted := strings.Join(prepared.AutoStarted, " ")
-			output.WriteString(autoStarted + "\n\n")
-			output.WriteString("iface lo inet loopback\n")
+	w.WriteString("\n")
+	writeList(w, "auto", prepared.AutoStarted)
+	w.WriteString("\niface lo inet loopback\n")
+	writeList(w, "  dns-nameservers", prepared.DNSServers)
+	writeList(w, "  dns-search", prepared.DNSSearchDomains)
 
-			dnsServers := strings.Join(prepared.DNSServers, " ")
-			if dnsServers != "" {
-				output.WriteString("  dns-nameservers ")
-				output.WriteString(dnsServers + "\n")
-			}
-
-			dnsSearchDomains := strings.Join(prepared.DNSSearchDomains, " ")
-			if dnsSearchDomains != "" {
-				output.WriteString("  dns-search ")
-				output.WriteString(dnsSearchDomains + "\n")
-			}
-			continue
-		}
-
-		address, hasAddress := prepared.NameToAddress[name]
-		if !hasAddress {
-			output.WriteString("iface " + name + " inet manual\n")
-			continue
-		} else if address == string(network.ConfigDHCP) {
-			output.WriteString("iface " + name + " inet dhcp\n")
-			continue
-		}
-
-		output.WriteString("iface " + name + " inet static\n")
-		output.WriteString("  address " + address + "\n")
-		if !gatewayWritten && prepared.GatewayAddress != "" {
-			output.WriteString("  gateway " + prepared.GatewayAddress + "\n")
-			gatewayWritten = true // write it only once
-		}
+	for _, iface := range networkConfig.Interfaces {
+		w.WriteString("\n")
+		fmt.Fprintf(w, "iface %v inet %v\n", iface.InterfaceName, iface.ConfigType)
+		writeString(w, "  address", iface.CIDRAddress())
+		writeString(w, "  gateway", iface.GatewayAddress.Value)
 	}
 
-	generatedConfig := output.String()
-	logger.Debugf("generated network config:\n%s", generatedConfig)
-
+	generatedConfig := w.String()
+	logger.Debugf("generated network config from %#v\nusing%#v:\n%s",
+		networkConfig.Interfaces, prepared, generatedConfig)
 	return generatedConfig, nil
 }
 
 // PreparedConfig holds all the necessary information to render a persistent
 // network config to a file.
 type PreparedConfig struct {
-	InterfaceNames   []string
 	AutoStarted      []string
 	DNSServers       []string
 	DNSSearchDomains []string
-	NameToAddress    map[string]string
-	GatewayAddress   string
 }
 
 // PrepareNetworkConfigFromInterfaces collects the necessary information to
@@ -137,12 +120,8 @@ type PreparedConfig struct {
 func PrepareNetworkConfigFromInterfaces(interfaces []network.InterfaceInfo) *PreparedConfig {
 	dnsServers := set.NewStrings()
 	dnsSearchDomains := set.NewStrings()
-	gatewayAddress := ""
-	namesInOrder := make([]string, 1, len(interfaces)+1)
-	nameToAddress := make(map[string]string)
 
 	// Always include the loopback.
-	namesInOrder[0] = "lo"
 	autoStarted := set.NewStrings("lo")
 
 	for _, info := range interfaces {
@@ -150,33 +129,17 @@ func PrepareNetworkConfigFromInterfaces(interfaces []network.InterfaceInfo) *Pre
 			autoStarted.Add(info.InterfaceName)
 		}
 
-		if cidr := info.CIDRAddress(); cidr != "" {
-			nameToAddress[info.InterfaceName] = cidr
-		} else if info.ConfigType == network.ConfigDHCP {
-			nameToAddress[info.InterfaceName] = string(network.ConfigDHCP)
-		}
-
 		for _, dns := range info.DNSServers {
 			dnsServers.Add(dns.Value)
 		}
 
 		dnsSearchDomains = dnsSearchDomains.Union(set.NewStrings(info.DNSSearchDomains...))
-
-		if info.InterfaceName == "eth0" && gatewayAddress == "" {
-			// Only set gateway once for the primary NIC.
-			gatewayAddress = info.GatewayAddress.Value
-		}
-
-		namesInOrder = append(namesInOrder, info.InterfaceName)
 	}
 
 	prepared := &PreparedConfig{
-		InterfaceNames:   namesInOrder,
-		NameToAddress:    nameToAddress,
 		AutoStarted:      autoStarted.SortedValues(),
 		DNSServers:       dnsServers.SortedValues(),
 		DNSSearchDomains: dnsSearchDomains.SortedValues(),
-		GatewayAddress:   gatewayAddress,
 	}
 
 	logger.Debugf("prepared network config for rendering: %+v", prepared)

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -42,6 +42,38 @@ type UserDataSuite struct {
 
 var _ = gc.Suite(&UserDataSuite{})
 
+func configToUserData(config string) string {
+	userData := `#cloud-config
+bootcmd:
+- install -D -m 644 /dev/null '%[1]s'
+- |-
+  printf '%%s\n' '`
+
+	for _, line := range strings.Split(strings.TrimSuffix(config, "\n"), "\n") {
+		if line != "" {
+			userData += "  " + line + "\n"
+		} else {
+			userData += "\n"
+		}
+	}
+
+	userData += `  ' > '%[1]s'
+runcmd:
+- |-
+  if [ -f %[1]s ]; then
+      ifdown -a
+      sleep 1.5
+      if ifup -a --interfaces=%[1]s; then
+          cp %[2]s %[2]s-orig
+          cp %[1]s %[2]s
+      else
+          ifup -a
+      fi
+  fi
+`
+	return userData
+}
+
 func (s *UserDataSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.networkInterfacesFile = filepath.Join(c.MkDir(), "juju-interfaces")
@@ -57,15 +89,12 @@ func (s *UserDataSuite) SetUpTest(c *gc.C) {
 		GatewayAddress:   network.NewAddress("0.1.2.1"),
 		MACAddress:       "aa:bb:cc:dd:ee:f0",
 	}, {
-		InterfaceName:    "eth1",
-		CIDR:             "0.1.2.0/24",
-		ConfigType:       network.ConfigStatic,
-		NoAutoStart:      false,
-		Address:          network.NewAddress("0.1.2.4"),
-		DNSServers:       network.NewAddresses("ns1.invalid", "ns2.invalid"),
-		DNSSearchDomains: []string{"foo", "bar"},
-		GatewayAddress:   network.NewAddress("0.1.2.1"),
-		MACAddress:       "aa:bb:cc:dd:ee:f0",
+		InterfaceName: "eth1",
+		CIDR:          "0.1.2.0/24",
+		ConfigType:    network.ConfigStatic,
+		NoAutoStart:   false,
+		Address:       network.NewAddress("0.1.2.4"),
+		MACAddress:    "aa:bb:cc:dd:ee:f0",
 	}, {
 		InterfaceName: "eth2",
 		ConfigType:    network.ConfigDHCP,
@@ -99,44 +128,7 @@ iface eth3 inet dhcp
 
 iface eth4 inet manual
 `
-	s.expectedSampleUserData = `
-#cloud-config
-bootcmd:
-- install -D -m 644 /dev/null '%[1]s'
-- |-
-  printf '%%s\n' '
-  auto eth0 eth1 eth3 lo
-
-  iface lo inet loopback
-    dns-nameservers ns1.invalid ns2.invalid
-    dns-search bar foo
-
-  iface eth0 inet static
-    address 0.1.2.3/24
-    gateway 0.1.2.1
-
-  iface eth1 inet static
-    address 0.1.2.4/24
-
-  iface eth2 inet dhcp
-
-  iface eth3 inet dhcp
-
-  iface eth4 inet manual
-  ' > '%[1]s'
-runcmd:
-- |-
-  if [ -f %[1]s ]; then
-      ifdown -a
-      sleep 1.5
-      if ifup -a --interfaces=%[1]s; then
-          cp %[2]s %[2]s-orig
-          cp %[1]s %[2]s
-      else
-          ifup -a
-      fi
-  fi
-`[1:]
+	s.expectedSampleUserData = configToUserData(s.expectedSampleConfig)
 
 	s.expectedFallbackConfig = `
 auto eth0 lo
@@ -145,31 +137,7 @@ iface lo inet loopback
 
 iface eth0 inet dhcp
 `
-	s.expectedFallbackUserData = `
-#cloud-config
-bootcmd:
-- install -D -m 644 /dev/null '%[1]s'
-- |-
-  printf '%%s\n' '
-  auto eth0 lo
-
-  iface lo inet loopback
-
-  iface eth0 inet dhcp
-  ' > '%[1]s'
-runcmd:
-- |-
-  if [ -f %[1]s ]; then
-      ifdown -a
-      sleep 1.5
-      if ifup -a --interfaces=%[1]s; then
-          cp %[2]s %[2]s-orig
-          cp %[1]s %[2]s
-      else
-          ifup -a
-      fi
-  fi
-`[1:]
+	s.expectedFallbackUserData = configToUserData(s.expectedFallbackConfig)
 
 	s.PatchValue(containerinit.NetworkInterfacesFile, s.networkInterfacesFile)
 	s.PatchValue(containerinit.SystemNetworkInterfacesFile, s.systemNetworkInterfacesFile)
@@ -282,4 +250,79 @@ func assertUserData(c *gc.C, cloudConf cloudinit.CloudConfig, expected string) {
 	} else {
 		c.Assert(out["bootcmd"], gc.IsNil)
 	}
+}
+
+func (s *UserDataSuite) TestDualNicBug1602054(c *gc.C) {
+	networkConfig := container.NetworkConfig{
+		NetworkType: "bridge",
+		Device:      "lxdbr0", MTU: 0,
+		Interfaces: []network.InterfaceInfo{
+			{
+				DeviceIndex:         0,
+				MACAddress:          "00:16:3e:29:de:c5",
+				CIDR:                "192.168.200.0/24",
+				ProviderId:          "33",
+				ProviderSubnetId:    "3",
+				ProviderSpaceId:     "",
+				ProviderVLANId:      "5001",
+				ProviderAddressId:   "216",
+				AvailabilityZones:   []string(nil),
+				VLANTag:             0,
+				InterfaceName:       "eth0",
+				ParentInterfaceName: "br-eth0",
+				InterfaceType:       "ethernet",
+				Disabled:            false,
+				NoAutoStart:         false,
+				ConfigType:          "static",
+				Address:             network.NewScopedAddress("192.168.200.1", network.ScopeCloudLocal),
+				DNSServers: []network.Address{
+					network.NewScopedAddress("192.168.1.2", network.ScopeCloudLocal),
+				},
+				MTU:              1500,
+				DNSSearchDomains: []string{"maas"},
+				GatewayAddress:   network.Address{},
+			}, {
+				DeviceIndex:         0,
+				MACAddress:          "00:16:3e:43:10:2b",
+				CIDR:                "192.168.1.0/24",
+				ProviderId:          "34",
+				ProviderSubnetId:    "1",
+				ProviderSpaceId:     "",
+				ProviderVLANId:      "0",
+				ProviderAddressId:   "218",
+				AvailabilityZones:   []string(nil),
+				VLANTag:             0,
+				InterfaceName:       "eth1",
+				ParentInterfaceName: "br-eth1",
+				InterfaceType:       "ethernet",
+				Disabled:            false,
+				NoAutoStart:         false,
+				ConfigType:          "static",
+				Address:             network.NewScopedAddress("192.168.200.102", network.ScopeCloudLocal),
+				DNSServers:          []network.Address{},
+				MTU:                 1500,
+				DNSSearchDomains:    []string(nil),
+				GatewayAddress:      network.NewScopedAddress("192.168.1.1", network.ScopeCloudLocal),
+			}},
+	}
+
+	data, err := containerinit.GenerateNetworkConfig(&networkConfig)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, gc.NotNil)
+
+	expected := `
+auto eth0 eth1 lo
+
+iface lo inet loopback
+  dns-nameservers 192.168.1.2
+  dns-search maas
+
+iface eth0 inet static
+  address 192.168.200.1/24
+
+iface eth1 inet static
+  address 192.168.200.102/24
+  gateway 192.168.1.1
+`
+	c.Assert(data, gc.Equals, expected)
 }


### PR DESCRIPTION
The old logic for generating /etc/network/interfaces for a container involved looking for a gateway on eth0 but not any other interface. It then wrote that interface to eth0, even if eth0 didn't route to the same subnet that contained the gateway address. This is very broken and has been fixed.

Simplified and fixed the generation of /etc/network/interfaces for containers. I retained the logic that puts DNS configuration on the loopback interface because I didn't want to make unnecessary changes to functionality. A further update that keeps DNS settings attached to the interface they were associated with would be trivial.

Simplified test logic by generating cloud-init user data from the expected /etc/network/interfaces content so there is no chance for copy/paste errors.

Added a unit test for this bug fix (bug https://bugs.launchpad.net/juju-core/+bug/1602054) based on live test data that previously failed.

Live tested by deploying a LXD to a machine with two NICs and the default gateway on eth1 rather than eth0. Checked that the LXD had a gateway on eth1.

(Review request: http://reviews.vapour.ws/r/5333/)