### PR TITLE
Remove series as an argument to enableha

### DIFF
--- a/api/highavailability/client.go
+++ b/api/highavailability/client.go
@@ -36,7 +36,7 @@ func NewClient(caller base.APICallCloser) *Client {
 
 // EnableHA ensures the availability of Juju controllers.
 func (c *Client) EnableHA(
-	numControllers int, cons constraints.Value, series string, placement []string,
+	numControllers int, cons constraints.Value, placement []string,
 ) (params.ControllersChanges, error) {
 
 	var results params.ControllersChangeResults
@@ -45,7 +45,6 @@ func (c *Client) EnableHA(
 			ModelTag:       c.modelTag.String(),
 			NumControllers: numControllers,
 			Constraints:    cons,
-			Series:         series,
 			Placement:      placement,
 		}}}
 

--- a/api/highavailability/client_test.go
+++ b/api/highavailability/client_test.go
@@ -56,7 +56,7 @@ func assertEnableHA(c *gc.C, s *jujutesting.JujuConnSuite) {
 
 	emptyCons := constraints.Value{}
 	client := highavailability.NewClient(s.APIState)
-	result, err := client.EnableHA(3, emptyCons, "", nil)
+	result, err := client.EnableHA(3, emptyCons, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(result.Maintained, gc.DeepEquals, []string{"machine-0"})

--- a/cmd/juju/commands/enableha.go
+++ b/cmd/juju/commands/enableha.go
@@ -45,17 +45,17 @@ type enableHACommand struct {
 
 	// NumControllers specifies the number of controllers to make available.
 	NumControllers int
-	// Series is used for newly created machines, if specified.
-	// Otherwise,  the environment's default-series is used.
-	Series string
+
 	// Constraints, if specified, will be merged with those already
 	// in the environment when creating new machines.
 	Constraints constraints.Value
+
 	// Placement specifies specific machine(s) which will be used to host
 	// new controllers. If there are more controllers required than
 	// machines specified, new machines will be created.
 	// Placement is passed verbatim to the API, to be evaluated and used server-side.
 	Placement []string
+
 	// PlacementSpec holds the unparsed placement directives argument (--to).
 	PlacementSpec string
 }
@@ -74,18 +74,16 @@ Examples:
     # then that number will be ensured.
     juju enable-ha
 
-    # Ensure that 5 controllers are available, with newly created
-    # controller machines having the "trusty" series.
-    juju enable-ha -n 5 --series=trusty
+    # Ensure that 5 controllers are available.
+    juju enable-ha -n 5 
 
     # Ensure that 7 controllers are available, with newly created
-    # controller machines having the default series, and at least
-    # 8GB RAM.
+    # controller machines having at least 8GB RAM.
     juju enable-ha -n 7 --constraints mem=8G
 
     # Ensure that 7 controllers are available, with machines server1 and
     # server2 used first, and if necessary, newly created controller
-    # machines having the default series, and at least 8GB RAM.
+    # machines having at least 8GB RAM.
     juju enable-ha -n 7 --to server1,server2 --constraints mem=8G
 `
 
@@ -149,7 +147,6 @@ func (c *enableHACommand) Info() *cmd.Info {
 
 func (c *enableHACommand) SetFlags(f *gnuflag.FlagSet) {
 	f.IntVar(&c.NumControllers, "n", 0, "Number of controllers to make available")
-	f.StringVar(&c.Series, "series", "", "The charm series")
 	f.StringVar(&c.PlacementSpec, "to", "", "The machine(s) to become controllers, bypasses constraints")
 	f.Var(constraints.ConstraintsValue{&c.Constraints}, "constraints", "Additional machine constraints")
 	c.out.AddFlags(f, "simple", map[string]cmd.Formatter{
@@ -201,7 +198,7 @@ type availabilityInfo struct {
 type MakeHAClient interface {
 	Close() error
 	EnableHA(
-		numControllers int, cons constraints.Value, series string,
+		numControllers int, cons constraints.Value,
 		placement []string) (params.ControllersChanges, error)
 }
 
@@ -217,7 +214,6 @@ func (c *enableHACommand) Run(ctx *cmd.Context) error {
 	enableHAResult, err := haClient.EnableHA(
 		c.NumControllers,
 		c.Constraints,
-		c.Series,
 		c.Placement,
 	)
 	if err != nil {

--- a/cmd/juju/commands/enableha_test.go
+++ b/cmd/juju/commands/enableha_test.go
@@ -263,3 +263,11 @@ converting machines: 1, 2
 	c.Check(&s.fake.cons, jc.Satisfies, constraints.IsEmpty)
 	c.Check(len(s.fake.placement), gc.Equals, 2)
 }
+
+func (s *EnableHASuite) TestEnableHADisallowsSeries(c *gc.C) {
+	// We don't allow --series as an argument. This test ensures it is not
+	// inadvertantly added back.
+	ctx, err := s.runEnableHA(c, "-n", "0", "--series", "xenian")
+	c.Assert(err, gc.ErrorMatches, "flag provided but not defined: --series")
+	c.Assert(coretesting.Stdout(ctx), gc.Equals, "")
+}

--- a/cmd/juju/commands/enableha_test.go
+++ b/cmd/juju/commands/enableha_test.go
@@ -50,7 +50,6 @@ type fakeHAClient struct {
 	numControllers int
 	cons           constraints.Value
 	err            error
-	series         string
 	placement      []string
 	result         params.ControllersChanges
 }
@@ -59,12 +58,10 @@ func (f *fakeHAClient) Close() error {
 	return nil
 }
 
-func (f *fakeHAClient) EnableHA(numControllers int, cons constraints.Value,
-	series string, placement []string) (params.ControllersChanges, error) {
+func (f *fakeHAClient) EnableHA(numControllers int, cons constraints.Value, placement []string) (params.ControllersChanges, error) {
 
 	f.numControllers = numControllers
 	f.cons = cons
-	f.series = series
 	f.placement = placement
 
 	if f.err != nil {
@@ -112,7 +109,6 @@ func (s *EnableHASuite) TestEnableHA(c *gc.C) {
 
 	c.Assert(s.fake.numControllers, gc.Equals, 1)
 	c.Assert(&s.fake.cons, jc.Satisfies, constraints.IsEmpty)
-	c.Assert(s.fake.series, gc.Equals, "")
 	c.Assert(len(s.fake.placement), gc.Equals, 0)
 }
 
@@ -137,7 +133,6 @@ func (s *EnableHASuite) TestEnableHAFormatYaml(c *gc.C) {
 
 	c.Assert(s.fake.numControllers, gc.Equals, 3)
 	c.Assert(&s.fake.cons, jc.Satisfies, constraints.IsEmpty)
-	c.Assert(s.fake.series, gc.Equals, "")
 	c.Assert(len(s.fake.placement), gc.Equals, 0)
 
 	var result map[string][]string
@@ -157,7 +152,6 @@ func (s *EnableHASuite) TestEnableHAFormatJson(c *gc.C) {
 
 	c.Assert(s.fake.numControllers, gc.Equals, 3)
 	c.Assert(&s.fake.cons, jc.Satisfies, constraints.IsEmpty)
-	c.Assert(s.fake.series, gc.Equals, "")
 	c.Assert(len(s.fake.placement), gc.Equals, 0)
 
 	var result map[string][]string
@@ -166,9 +160,9 @@ func (s *EnableHASuite) TestEnableHAFormatJson(c *gc.C) {
 	c.Assert(result, gc.DeepEquals, expected)
 }
 
-func (s *EnableHASuite) TestEnableHAWithSeries(c *gc.C) {
+func (s *EnableHASuite) TestEnableHAWithFive(c *gc.C) {
 	// Also test with -n 5 to validate numbers other than 1 and 3
-	ctx, err := s.runEnableHA(c, "--series", "series", "-n", "5")
+	ctx, err := s.runEnableHA(c, "-n", "5")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(coretesting.Stdout(ctx), gc.Equals,
 		"maintaining machines: 0\n"+
@@ -176,7 +170,6 @@ func (s *EnableHASuite) TestEnableHAWithSeries(c *gc.C) {
 
 	c.Assert(s.fake.numControllers, gc.Equals, 5)
 	c.Assert(&s.fake.cons, jc.Satisfies, constraints.IsEmpty)
-	c.Assert(s.fake.series, gc.Equals, "series")
 	c.Assert(len(s.fake.placement), gc.Equals, 0)
 }
 
@@ -190,7 +183,6 @@ func (s *EnableHASuite) TestEnableHAWithConstraints(c *gc.C) {
 	c.Assert(s.fake.numControllers, gc.Equals, 3)
 	expectedCons := constraints.MustParse("mem=4G")
 	c.Assert(s.fake.cons, gc.DeepEquals, expectedCons)
-	c.Assert(s.fake.series, gc.Equals, "")
 	c.Assert(len(s.fake.placement), gc.Equals, 0)
 }
 
@@ -203,7 +195,6 @@ func (s *EnableHASuite) TestEnableHAWithPlacement(c *gc.C) {
 
 	c.Assert(s.fake.numControllers, gc.Equals, 3)
 	c.Assert(&s.fake.cons, jc.Satisfies, constraints.IsEmpty)
-	c.Assert(s.fake.series, gc.Equals, "")
 	expectedPlacement := []string{"valid"}
 	c.Assert(s.fake.placement, gc.DeepEquals, expectedPlacement)
 }
@@ -229,7 +220,6 @@ func (s *EnableHASuite) TestEnableHAAllows0(c *gc.C) {
 
 	c.Assert(s.fake.numControllers, gc.Equals, 0)
 	c.Assert(&s.fake.cons, jc.Satisfies, constraints.IsEmpty)
-	c.Assert(s.fake.series, gc.Equals, "")
 	c.Assert(len(s.fake.placement), gc.Equals, 0)
 }
 
@@ -244,7 +234,6 @@ func (s *EnableHASuite) TestEnableHADefaultsTo0(c *gc.C) {
 
 	c.Assert(s.fake.numControllers, gc.Equals, 0)
 	c.Assert(&s.fake.cons, jc.Satisfies, constraints.IsEmpty)
-	c.Assert(s.fake.series, gc.Equals, "")
 	c.Assert(len(s.fake.placement), gc.Equals, 0)
 }
 
@@ -272,6 +261,5 @@ converting machines: 1, 2
 
 	c.Check(s.fake.numControllers, gc.Equals, 0)
 	c.Check(&s.fake.cons, jc.Satisfies, constraints.IsEmpty)
-	c.Check(s.fake.series, gc.Equals, "")
 	c.Check(len(s.fake.placement), gc.Equals, 2)
 }


### PR DESCRIPTION
One should not be able to add HA nodes in Xenial when the primary
controller is Trusty. Mongo is unlikely to have compatible versions on
different series. So this commit removes that specific footshooter from
the user arsenal.

Refs: https://bugs.launchpad.net/juju-core/+bug/1587653

(Review request: http://reviews.vapour.ws/r/5340/)