### PR TITLE
Fixes lp#1591488 and others: metadata-source not working and supported architectures are not complete.

### DIFF
--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -488,8 +488,8 @@ func bootstrapImageMetadata(
 	}
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 		CloudSpec: region,
-		Series:    arches,
-		Arches:    allSeries,
+		Series:    allSeries,
+		Arches:    arches,
 		Stream:    environ.Config().ImageStream(),
 	})
 	logger.Debugf("constraints for image metadata lookup %v", imageConstraint)

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -214,6 +214,21 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	logger.Debugf("model %q supports service/machine networks: %v", cfg.Name(), supportsNetworking)
 	disableNetworkManagement, _ := cfg.DisableNetworkManagement()
 	logger.Debugf("network management by juju enabled: %v", !disableNetworkManagement)
+
+	// This call needs to be made before finding tools:
+	// we register image metadata data sources
+	// which, in turn, enables us to know what architectures
+	// we can support when we discover tools.
+	imageMetadata, err := bootstrapImageMetadata(
+		environ, bootstrapConstraints.Arch,
+		bootstrapSeries,
+		args.BootstrapImage,
+		&customImageMetadata,
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	availableTools, err := findAvailableTools(
 		environ, args.AgentVersion, bootstrapConstraints.Arch,
 		bootstrapSeries, args.UploadTools, args.BuildToolsTarball != nil,
@@ -222,15 +237,6 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 		return errors.New(noToolsMessage)
 	} else if err != nil {
 		return err
-	}
-
-	imageMetadata, err := bootstrapImageMetadata(
-		environ, availableTools,
-		args.BootstrapImage,
-		&customImageMetadata,
-	)
-	if err != nil {
-		return errors.Trace(err)
 	}
 
 	// If we're uploading, we must override agent-version;
@@ -422,7 +428,7 @@ func userPublicSigningKey() (string, error) {
 // state database will have the synthesised image metadata added to it.
 func bootstrapImageMetadata(
 	environ environs.Environ,
-	availableTools coretools.List,
+	arch, aseries *string,
 	bootstrapImageId string,
 	customImageMetadata *[]*imagemetadata.ImageMetadata,
 ) ([]*imagemetadata.ImageMetadata, error) {
@@ -445,15 +451,15 @@ func bootstrapImageMetadata(
 		return nil, errors.Trace(err)
 	}
 
+	arches := []string{}
+	if arch != nil {
+		arches = []string{*arch}
+	}
+	allSeries := []string{}
+	if aseries != nil {
+		allSeries = []string{*aseries}
+	}
 	if bootstrapImageId != "" {
-		arches := availableTools.Arches()
-		if len(arches) != 1 {
-			return nil, errors.NotValidf("multiple architectures with bootstrap image")
-		}
-		allSeries := availableTools.AllSeries()
-		if len(allSeries) != 1 {
-			return nil, errors.NotValidf("multiple series with bootstrap image")
-		}
 		seriesVersion, err := series.SeriesVersion(allSeries[0])
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -482,8 +488,8 @@ func bootstrapImageMetadata(
 	}
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 		CloudSpec: region,
-		Series:    availableTools.AllSeries(),
-		Arches:    availableTools.Arches(),
+		Series:    arches,
+		Arches:    allSeries,
 		Stream:    environ.Config().ImageStream(),
 	})
 	logger.Debugf("constraints for image metadata lookup %v", imageConstraint)

--- a/environs/imagemetadata/simplestreams.go
+++ b/environs/imagemetadata/simplestreams.go
@@ -11,11 +11,12 @@ import (
 	"sort"
 
 	"github.com/juju/utils"
+	"github.com/juju/utils/arch"
+	"github.com/juju/utils/series"
+	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/juju/keys"
-	"github.com/juju/utils/arch"
-	"github.com/juju/utils/series"
 )
 
 func init() {
@@ -225,6 +226,17 @@ func (im *ImageMetadata) String() string {
 func (im *ImageMetadata) productId() string {
 	stream := idStream(im.Stream)
 	return fmt.Sprintf("com.ubuntu.cloud%s:server:%s:%s", stream, im.Version, im.Arch)
+}
+
+func DistictArchitectures(metadata []*ImageMetadata) []string {
+	if metadata == nil {
+		return nil
+	}
+	archesSet := set.NewStrings()
+	for _, one := range metadata {
+		archesSet.Add(one.Arch)
+	}
+	return archesSet.SortedValues()
 }
 
 // Fetch returns a list of images for the specified cloud matching the constraint.

--- a/provider/cloudsigma/environ.go
+++ b/provider/cloudsigma/environ.go
@@ -29,9 +29,12 @@ type environ struct {
 	lock      sync.Mutex
 	archMutex sync.Mutex
 
-	ecfg                   *environConfig
-	client                 *environClient
-	supportedArchitectures []string
+	ecfg   *environConfig
+	client *environClient
+
+	// initialArchitectures hold architectures that were used during bootstrap
+	// as they may not yet have made neither to the database nor data sources.
+	initialArchitectures []string
 }
 
 // Name returns the Environ's name.

--- a/provider/cloudsigma/environ_test.go
+++ b/provider/cloudsigma/environ_test.go
@@ -48,7 +48,7 @@ func (s *environSuite) TestBase(c *gc.C) {
 	baseConfig := newConfig(c, validAttrs().Merge(testing.Attrs{"name": "testname"}))
 	env, err := environs.New(environs.OpenParams{baseConfig})
 	c.Assert(err, gc.IsNil)
-	env.(*environ).supportedArchitectures = []string{arch.AMD64}
+	env.(*environ).initialArchitectures = []string{arch.AMD64}
 
 	cfg := env.Config()
 	c.Assert(cfg, gc.NotNil)
@@ -91,7 +91,7 @@ func (s *environSuite) TestUnsupportedConstraints(c *gc.C) {
 	baseConfig := newConfig(c, validAttrs().Merge(testing.Attrs{"name": "testname"}))
 	env, err := environs.New(environs.OpenParams{baseConfig})
 	c.Assert(err, gc.IsNil)
-	env.(*environ).supportedArchitectures = []string{arch.AMD64}
+	env.(*environ).initialArchitectures = []string{arch.AMD64}
 
 	validator, err := env.ConstraintsValidator()
 	c.Check(validator, gc.NotNil)

--- a/provider/cloudsigma/environinstance.go
+++ b/provider/cloudsigma/environinstance.go
@@ -41,6 +41,12 @@ func (*environ) MaintainInstance(args environs.StartInstanceParams) error {
 func (env *environ) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	logger.Infof("sigmaEnviron.StartInstance...")
 
+	// This is especially important for bootstrap instance.
+	// There is a window where image metadata may not be available
+	// through traditional search path - database, data sources.
+	// In these cases, the only point of truth is the image
+	// metadata passed in.
+	env.initialArchitectures = imagemetadata.DistictArchitectures(args.ImageMetadata)
 	if args.InstanceConfig == nil {
 		return nil, errors.New("instance configuration is nil")
 	}

--- a/provider/common/provider.go
+++ b/provider/common/provider.go
@@ -37,8 +37,8 @@ func (dp DefaultProvider) DestroyEnv() error {
 
 // SupportedArchitectures returns all the image architectures for env
 // matching the constraints.
-func (dp DefaultProvider) SupportedArchitectures(imageConstraint *imagemetadata.ImageConstraint) ([]string, error) {
-	arches, err := SupportedArchitectures(dp.Env, imageConstraint)
+func (dp DefaultProvider) SupportedArchitectures(imageConstraint *imagemetadata.ImageConstraint, knownArchitectures []string) ([]string, error) {
+	arches, err := SupportedArchitectures(dp.Env, imageConstraint, knownArchitectures)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -60,14 +60,16 @@ type environ struct {
 	uuid string
 	gce  gceConnection
 
-	lock sync.Mutex // lock protects access to ecfg
+	// lock protects access to ecfg
+	lock sync.Mutex
 	ecfg *environConfig
 
 	// namespace is used to create the machine and device hostnames.
 	namespace instance.Namespace
 
-	archLock               sync.Mutex // protects supportedArchitectures
-	supportedArchitectures []string
+	// initialArchitectures hold architectures that were used during bootstrap
+	// as they may not yet have made neither to the database nor data sources.
+	initialArchitectures []string
 }
 
 // Function entry points defined as variables so they can be overridden

--- a/provider/gce/environ_broker.go
+++ b/provider/gce/environ_broker.go
@@ -35,8 +35,14 @@ func (*environ) MaintainInstance(args environs.StartInstanceParams) error {
 
 // StartInstance implements environs.InstanceBroker.
 func (env *environ) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
-	// Start a new instance.
+	// This is especially important for bootstrap instance.
+	// There is a window where image metadata may not be available
+	// through traditional search path - database, data sources.
+	// In these cases, the only point of truth is the image
+	// metadata passed in.
+	env.initialArchitectures = imagemetadata.DistictArchitectures(args.ImageMetadata)
 
+	// Start a new instance.
 	spec, err := buildInstanceSpec(env, args)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -25,8 +25,9 @@ type environ struct {
 	name   string
 	client *client
 
-	archLock               sync.Mutex // archLock protects access to the following fields.
-	supportedArchitectures []string
+	// initialArchitectures hold architectures that were used during bootstrap
+	// as they may not yet have made neither to the database nor data sources.
+	initialArchitectures []string
 
 	// namespace is used to create the machine and device hostnames.
 	namespace instance.Namespace

--- a/provider/vsphere/environ_policy.go
+++ b/provider/vsphere/environ_policy.go
@@ -27,18 +27,10 @@ func (env *environ) PrecheckInstance(series string, cons constraints.Value, plac
 }
 
 func (env *environ) getSupportedArchitectures() ([]string, error) {
-	env.archLock.Lock()
-	defer env.archLock.Unlock()
-
-	if env.supportedArchitectures != nil {
-		return env.supportedArchitectures, nil
-	}
-
 	archList, err := env.lookupArchitectures()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	env.supportedArchitectures = archList
 	return archList, nil
 }
 


### PR DESCRIPTION
This PR addresses several bugs that reported symptoms with the underlying problem coming from supported architectures. This P currently contains code changes only for early preview with unit tests still to come.

1. Discover available images and metadata before tools, to ensure that we have data sources registered and subsequent calls to supporting architectures yield correct results.

2. Some provides were caching the list of supported architectures which meant that after bootstrap, we would never update architecture list even when new architectures
become available, i.e. if images/tools for new architectures come in, they will not be picked up.
 
3. What is important for providers that make call to supported architectures, is to remember what architectures were available at bootstrap.
This is especially important for bootstrap instance, but is also valuable for deployments that are done using local metadata source or on environments with limited/no internet connection. There is a window where image metadata may not be available through traditional search path - database, data sources.
In these cases, the only point of truth is the image metadata passed in at bootstrap time.

*QA steps*
On an environment with limited/no internet or on private cloud:
1. Generate local images using `juju metadata generate-image`
2. Bootstrap with the location of the generate metadata using`--metadata-source` for `juju bootstrap` command
3. Check bootstrapped successfully using desired metadata/image


(Review request: http://reviews.vapour.ws/r/5341/)