### PR TITLE
cmd/juju/status: Include migration message in status output

### DIFF
--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -32,6 +32,7 @@ type modelStatus struct {
 	CloudRegion      string `json:"region,omitempty" yaml:"region,omitempty"`
 	Version          string `json:"version" yaml:"version"`
 	AvailableVersion string `json:"upgrade-available,omitempty" yaml:"upgrade-available,omitempty"`
+	Migration        string `json:"migration,omitempty" yaml:"migration,omitempty"`
 }
 
 type machineStatus struct {

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -53,6 +53,7 @@ func (sf *statusFormatter) format() formattedStatus {
 			CloudRegion:      sf.status.Model.CloudRegion,
 			Version:          sf.status.Model.Version,
 			AvailableVersion: sf.status.Model.AvailableVersion,
+			Migration:        sf.status.Model.Migration,
 		},
 		Machines:     make(map[string]machineStatus),
 		Applications: make(map[string]applicationStatus),


### PR DESCRIPTION
The human readable status text reported by the migrationmaster worker while a model migration is in progress is now included as part of the yaml and json status output.

(Review request: http://reviews.vapour.ws/r/5342/)