### PR TITLE
cmd/jujud/agent: Reenable test is not affected by LP 1600301

### DIFF
--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1341,12 +1341,11 @@ func (s *MachineSuite) TestMigratingModelWorkers(c *gc.C) {
 }
 
 func (s *MachineSuite) TestDyingModelCleanedUp(c *gc.C) {
-	c.Skip("issue 1600301: this test only passes by luck")
 	st, closer := s.setUpNewModel(c)
 	defer closer()
 	timeout := time.After(ReallyLongWait)
 
-	s.assertJobWithState(c, state.JobManageModel, func(_ agent.Config, _ *state.State) {
+	s.assertJobWithState(c, state.JobManageModel, func(agent.Config, *state.State) {
 		model, err := st.Model()
 		c.Assert(err, jc.ErrorIsNil)
 		watch := model.Watch()
@@ -1366,7 +1365,7 @@ func (s *MachineSuite) TestDyingModelCleanedUp(c *gc.C) {
 				}
 				c.Assert(err, jc.ErrorIsNil) // guaranteed fail
 			case <-time.After(coretesting.ShortWait):
-				s.BackingState.StartSync()
+				st.StartSync()
 			case <-timeout:
 				c.Fatalf("timed out waiting for workers")
 			}


### PR DESCRIPTION
As part of sorting out LP 1600301, TestDyingModelCleanedUp was disabled but because it doesn't use TrackModels it is unlikely to have the problem which the bug relates to.

Also, StartSync was being called on the wrong State. Calling StartSync on a State for the correct model makes the test somewhat faster (although I'm still not sure exactly how this works as it's not the same State instance used by the apiserver).

(Review request: http://reviews.vapour.ws/r/5343/)