### PR TITLE
Local charm revision metadata is once again saved

### DIFF
--- a/state/application_test.go
+++ b/state/application_test.go
@@ -1703,11 +1703,9 @@ func (s *ServiceSuite) TestRemoveQueuesLocalCharmCleanup(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dirty, jc.IsTrue)
 
-	// Run the cleanup and check the charm.
+	// Run the cleanup
 	err = s.State.Cleanup()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.Charm(s.charm.URL())
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	// Check we're now clean.
 	dirty, err = s.State.NeedsCleanup()

--- a/state/charm.go
+++ b/state/charm.go
@@ -392,12 +392,8 @@ func (c *Charm) UpdateMacaroon(m macaroon.Slice) error {
 	return nil
 }
 
-// deleteCharmArchive deletes a charm archive from blob storage
-// and removes the corresponding charm record from state.
+// deleteCharmArchive deletes a charm archive from blob storage.
 func (st *State) deleteCharmArchive(curl *charm.URL, storagePath string) error {
-	if err := st.deleteCharm(curl); err != nil {
-		return errors.Annotate(err, "cannot delete charm record from state")
-	}
 	stor := storage.NewStorage(st.ModelUUID(), st.MongoSession())
 	if err := stor.Remove(storagePath); err != nil {
 		return errors.Annotate(err, "cannot delete charm from storage")
@@ -435,20 +431,6 @@ func (st *State) AddCharm(info CharmInfo) (stch *Charm, err error) {
 		return st.Charm(info.ID)
 	}
 	return nil, errors.Trace(err)
-}
-
-// deleteCharm removes the charm record with curl from state.
-func (st *State) deleteCharm(curl *charm.URL) error {
-	op := []txn.Op{{
-		C:      charmsC,
-		Id:     curl.String(),
-		Remove: true,
-	}}
-	err := st.runTransaction(op)
-	if err == mgo.ErrNotFound {
-		return nil
-	}
-	return errors.Trace(err)
 }
 
 type hasMeta interface {

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -499,22 +499,6 @@ func (s *CharmSuite) TestAllCharms(c *gc.C) {
 	c.Assert(charms[2].URL(), gc.DeepEquals, curl2)
 }
 
-func (s *CharmSuite) TestDeleteCharm(c *gc.C) {
-	info := s.dummyCharm(c, "cs:quantal/dummy-1")
-	sch, err := s.State.AddCharm(info)
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = state.DeleteCharm(s.State, sch.URL())
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, err = s.State.Charm(sch.URL())
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-
-	// Deleting again is a no-op.
-	err = state.DeleteCharm(s.State, sch.URL())
-	c.Assert(err, jc.ErrorIsNil)
-}
-
 type CharmTestHelperSuite struct {
 	ConnSuite
 }

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -94,8 +94,6 @@ func (s *CleanupSuite) TestCleanupDyingServiceCharm(c *gc.C) {
 	s.assertCleanupRuns(c)
 	_, _, err = stor.Get(storagePath)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	_, err = s.State.Charm(ch.URL())
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *CleanupSuite) TestCleanupControllerModels(c *gc.C) {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -489,7 +489,3 @@ func LeadershipLeases(st *State) (map[string]lease.Info, error) {
 	}
 	return client.Leases(), nil
 }
-
-func DeleteCharm(st *State, curl *charm.URL) error {
-	return st.deleteCharm(curl)
-}


### PR DESCRIPTION
One of the things the fix for lp:1580418 did is remove obsolete charm documents from mongo. This had the side-effect of resetting a local charm's revision number when the charm was completely removed from the environment. There is another bug where the filesystem cache is not cleared out when a charm is removed, and fixing this bug would also fix this bug, but after discussing with William Reade, it was apparent that the more holistic approach was to bring local charms back into the fold with regards to a charm URL representing a specific revision of a charm archive. Breaking this concept can have many unintended consequences.

Fixes: https://bugs.launchpad.net/juju-core/+bug/1605096

(Review request: http://reviews.vapour.ws/r/5344/)