### PR TITLE
Pass proxy information to lxd

### DIFF
--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -179,6 +179,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		proxyConfigUpdaterName: ifNotMigrating(proxyupdater.Manifold(proxyupdater.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
+			WorkerFunc:    proxyupdater.NewWorker,
 		})),
 
 		// The charmdir resource coordinates whether the charm directory is

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -153,7 +153,7 @@ func (cs *ContainerSetup) runInitialiser(abort <-chan struct{}, containerType in
 		Name:  cs.initLockName,
 		Clock: clock.WallClock,
 		// If we don't get the lock straigh away, there is no point trying multiple
-		// times per second for an operation that is likelty to ake multiple seconds.
+		// times per second for an operation that is likelty to take multiple seconds.
 		Delay:  time.Second,
 		Cancel: abort,
 	}

--- a/worker/proxyupdater/manifold.go
+++ b/worker/proxyupdater/manifold.go
@@ -5,44 +5,60 @@ package proxyupdater
 
 import (
 	"github.com/juju/errors"
-	"gopkg.in/juju/names.v2"
+	"github.com/juju/utils/proxy"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/proxyupdater"
-	"github.com/juju/juju/cmd/jujud/agent/engine"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
 )
 
 // ManifoldConfig defines the names of the manifolds on which a Manifold will depend.
-type ManifoldConfig engine.AgentApiManifoldConfig
+type ManifoldConfig struct {
+	AgentName      string
+	APICallerName  string
+	WorkerFunc     func(Config) (worker.Worker, error)
+	ExternalUpdate func(proxy.Settings) error
+}
 
 // Manifold returns a dependency manifold that runs a proxy updater worker,
 // using the api connection resource named in the supplied config.
 func Manifold(config ManifoldConfig) dependency.Manifold {
-	typedConfig := engine.AgentApiManifoldConfig(config)
-	return engine.AgentApiManifold(typedConfig, newWorker)
-}
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.APICallerName,
+		},
+		Start: func(context dependency.Context) (worker.Worker, error) {
+			if config.WorkerFunc == nil {
+				return nil, errors.NotValidf("missing WorkerFunc")
+			}
+			var agent agent.Agent
+			if err := context.Get(config.AgentName, &agent); err != nil {
+				return nil, err
+			}
+			var apiCaller base.APICaller
+			if err := context.Get(config.APICallerName, &apiCaller); err != nil {
+				return nil, err
+			}
 
-// newWorker is not currently tested; it should eventually replace New as the
-// package's exposed factory func, and then all tests should pass through it.
-func newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
-	agentConfig := a.CurrentConfig()
-	switch tag := agentConfig.Tag().(type) {
-	case names.MachineTag, names.UnitTag:
-	default:
-		return nil, errors.Errorf("unknown agent type: %T", tag)
+			agentConfig := agent.CurrentConfig()
+			proxyAPI, err := proxyupdater.NewAPI(apiCaller, agentConfig.Tag())
+			if err != nil {
+				return nil, err
+			}
+			w, err := config.WorkerFunc(Config{
+				Directory:      "/home/ubuntu",
+				RegistryPath:   `HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings`,
+				Filename:       ".juju-proxy",
+				API:            proxyAPI,
+				ExternalUpdate: config.ExternalUpdate,
+			})
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return w, nil
+		},
 	}
-
-	proxyAPI, err := proxyupdater.NewAPI(apiCaller, agentConfig.Tag())
-	if err != nil {
-		return nil, err
-	}
-	return NewWorker(Config{
-		Directory:    "/home/ubuntu",
-		RegistryPath: `HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings`,
-		Filename:     ".juju-proxy",
-		API:          proxyAPI,
-	})
 }

--- a/worker/proxyupdater/manifold_test.go
+++ b/worker/proxyupdater/manifold_test.go
@@ -4,89 +4,142 @@
 package proxyupdater_test
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/proxy"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/cmd/jujud/agent/engine/enginetest"
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
 	"github.com/juju/juju/worker/proxyupdater"
-	proxyup "github.com/juju/juju/worker/proxyupdater"
 )
 
 type ManifoldSuite struct {
 	testing.IsolationSuite
-	newCalled bool
+	config   proxyupdater.ManifoldConfig
+	startErr error
 }
 
 var _ = gc.Suite(&ManifoldSuite{})
 
+func OtherUpdate(proxy.Settings) error {
+	return nil
+}
+
 func (s *ManifoldSuite) SetUpTest(c *gc.C) {
-	s.newCalled = false
-	s.PatchValue(&proxyupdater.NewWorker,
-		func(_ proxyupdater.Config) (worker.Worker, error) {
-			s.newCalled = true
-			return nil, nil
+	s.IsolationSuite.SetUpTest(c)
+	s.startErr = nil
+	s.config = proxyupdater.ManifoldConfig{
+		AgentName:     "agent-name",
+		APICallerName: "api-caller-name",
+		WorkerFunc: func(cfg proxyupdater.Config) (worker.Worker, error) {
+			if s.startErr != nil {
+				return nil, s.startErr
+			}
+			return &dummyWorker{config: cfg}, nil
 		},
-	)
+		ExternalUpdate: OtherUpdate,
+	}
 }
 
-func (s *ManifoldSuite) TestMachineShouldWrite(c *gc.C) {
-	config := proxyup.ManifoldConfig(enginetest.AgentApiManifoldTestConfig())
-	_, err := enginetest.RunAgentApiManifold(
-		proxyup.Manifold(config),
-		&fakeAgent{tag: names.NewMachineTag("42")},
-		nil)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.newCalled, jc.IsTrue)
+func (s *ManifoldSuite) manifold() dependency.Manifold {
+	return proxyupdater.Manifold(s.config)
 }
 
-func (s *ManifoldSuite) TestMachineShouldntWrite(c *gc.C) {
-	config := proxyup.ManifoldConfig(enginetest.AgentApiManifoldTestConfig())
-	_, err := enginetest.RunAgentApiManifold(
-		proxyup.Manifold(config),
-		&fakeAgent{tag: names.NewMachineTag("42")},
-		nil)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.newCalled, jc.IsTrue)
+func (s *ManifoldSuite) TestInputs(c *gc.C) {
+	c.Check(s.manifold().Inputs, jc.DeepEquals, []string{"agent-name", "api-caller-name"})
 }
 
-func (s *ManifoldSuite) TestUnit(c *gc.C) {
-	config := proxyup.ManifoldConfig(enginetest.AgentApiManifoldTestConfig())
-	_, err := enginetest.RunAgentApiManifold(
-		proxyup.Manifold(config),
-		&fakeAgent{tag: names.NewUnitTag("foo/0")},
-		nil)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.newCalled, jc.IsTrue)
+func (s *ManifoldSuite) TestWorkerFuncMissing(c *gc.C) {
+	s.config.WorkerFunc = nil
+	context := dt.StubContext(nil, nil)
+	worker, err := s.manifold().Start(context)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "missing WorkerFunc not valid")
 }
 
-func (s *ManifoldSuite) TestNonAgent(c *gc.C) {
-	config := proxyup.ManifoldConfig(enginetest.AgentApiManifoldTestConfig())
-	_, err := enginetest.RunAgentApiManifold(
-		proxyup.Manifold(config),
-		&fakeAgent{tag: names.NewUserTag("foo")},
-		nil)
-	c.Assert(err, gc.ErrorMatches, "unknown agent type:.+")
-	c.Assert(s.newCalled, jc.IsFalse)
+func (s *ManifoldSuite) TestStartAgentMissing(c *gc.C) {
+	context := dt.StubContext(nil, map[string]interface{}{
+		"agent-name": dependency.ErrMissing,
+	})
+
+	worker, err := s.manifold().Start(context)
+	c.Check(worker, gc.IsNil)
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
 }
 
-type fakeAgent struct {
+func (s *ManifoldSuite) TestStartAPICallerMissing(c *gc.C) {
+	context := dt.StubContext(nil, map[string]interface{}{
+		"agent-name":      &dummyAgent{},
+		"api-caller-name": dependency.ErrMissing,
+	})
+
+	worker, err := s.manifold().Start(context)
+	c.Check(worker, gc.IsNil)
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+}
+
+func (s *ManifoldSuite) TestStartError(c *gc.C) {
+	s.startErr = errors.New("boom")
+	context := dt.StubContext(nil, map[string]interface{}{
+		"agent-name":      &dummyAgent{},
+		"api-caller-name": &dummyApiCaller{},
+	})
+
+	worker, err := s.manifold().Start(context)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "boom")
+}
+
+func (s *ManifoldSuite) TestStartSuccess(c *gc.C) {
+	context := dt.StubContext(nil, map[string]interface{}{
+		"agent-name":      &dummyAgent{},
+		"api-caller-name": &dummyApiCaller{},
+	})
+
+	worker, err := s.manifold().Start(context)
+	c.Check(err, jc.ErrorIsNil)
+	dummy, ok := worker.(*dummyWorker)
+	c.Assert(ok, jc.IsTrue)
+	c.Check(dummy.config.Directory, gc.Equals, "/home/ubuntu")
+	c.Check(dummy.config.RegistryPath, gc.Equals, `HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings`)
+	c.Check(dummy.config.Filename, gc.Equals, ".juju-proxy")
+	c.Check(dummy.config.API, gc.NotNil)
+	// Checking function equality is problematic.
+	c.Check(dummy.config.ExternalUpdate, gc.NotNil)
+}
+
+type dummyAgent struct {
 	agent.Agent
-	tag names.Tag
 }
 
-func (a *fakeAgent) CurrentConfig() agent.Config {
-	return &fakeConfig{tag: a.tag}
+func (*dummyAgent) CurrentConfig() agent.Config {
+	return &dummyConfig{}
 }
 
-type fakeConfig struct {
+type dummyConfig struct {
 	agent.Config
-	tag names.Tag
 }
 
-func (c *fakeConfig) Tag() names.Tag {
-	return c.tag
+func (*dummyConfig) Tag() names.Tag {
+	return names.NewMachineTag("42")
+}
+
+type dummyApiCaller struct {
+	base.APICaller
+}
+
+func (*dummyApiCaller) BestFacadeVersion(_ string) int {
+	return 42
+}
+
+type dummyWorker struct {
+	worker.Worker
+
+	config proxyupdater.Config
 }


### PR DESCRIPTION
Since lxd runs as a service, it doesn't have access to the environment variables for the proxies that jujud sets. This branch updates the proxy updater worker so it will also configure the lxd proxies.

(Review request: http://reviews.vapour.ws/r/5345/)