### PR TITLE
cmd/jujud/agent: Ensure workers are stable in tests

### DIFF
--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -409,9 +409,7 @@ func (s *UnitSuite) TestWorkers(c *gc.C) {
 	go func() { c.Check(a.Run(nil), gc.IsNil) }()
 	defer func() { c.Check(a.Stop(), gc.IsNil) }()
 
-	id := a.Tag().String()
-	checkNotMigrating := EngineMatchFunc(c, tracker, append(
-		alwaysUnitWorkers, notMigratingUnitWorkers...,
-	))
-	WaitMatch(c, checkNotMigrating, id, s.BackingState.StartSync)
+	matcher := NewWorkerMatcher(c, tracker, a.Tag().String(),
+		append(alwaysUnitWorkers, notMigratingUnitWorkers...))
+	WaitMatch(c, matcher.Check, coretesting.LongWait, s.BackingState.StartSync)
 }


### PR DESCRIPTION
EngineMatchFunc has been replaced with NewWorkerMatcher. NewWorkerMatcher uses the same approach as EngineMatchFunc but will only report a match if the required workers have been running for at least 1s. This means that TestHostedModelWorkers - which is known to have problems - now fails reliably (it is still being skipped - fix coming).

All tests which used EngineMatchFunc now use NewWorkerMatcher.

TestMigratingModelWorkers was been reenabled. It doesn't suffer from the same issue as TestHostedModelWorkers, is actually passing reliably and shouldn't have been skipped.

The WaitMatch helper is now used in all places where it can be - reducing a significant amount of test boilerplate.

(Review request: http://reviews.vapour.ws/r/5346/)