### PR TITLE
apiserver/params: fix Cloud(Region) serialization

### DIFF
--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -8,7 +8,7 @@ type Cloud struct {
 	Type            string        `json:"type"`
 	AuthTypes       []string      `json:"auth-types,omitempty"`
 	Endpoint        string        `json:"endpoint,omitempty"`
-	StorageEndpoint string        `json:"endpoint,omitempty"`
+	StorageEndpoint string        `json:"storage-endpoint,omitempty"`
 	Regions         []CloudRegion `json:"regions,omitempty"`
 }
 
@@ -16,7 +16,7 @@ type Cloud struct {
 type CloudRegion struct {
 	Name            string `json:"name"`
 	Endpoint        string `json:"endpoint,omitempty"`
-	StorageEndpoint string `json:"endpoint,omitempty"`
+	StorageEndpoint string `json:"storage-endpoint,omitempty"`
 }
 
 // CloudResult contains a cloud definition or an error.

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -99,7 +99,7 @@ func (c *addModelCommand) Init(args []string) error {
 		return errors.Errorf("%q is not a valid user", c.Owner)
 	}
 
-	return nil
+	return cmd.CheckEmpty(args)
 }
 
 type AddModelAPI interface {

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -117,6 +117,9 @@ func (s *addSuite) TestInit(c *gc.C) {
 			args:   []string{"new-model", "--config", "key=value", "--config", "key2=value2"},
 			name:   "new-model",
 			values: map[string]interface{}{"key": "value", "key2": "value2"},
+		}, {
+			args: []string{"new-model", "extra", "args"},
+			err:  `unrecognized args: \["extra" "args"\]`,
 		},
 	} {
 		c.Logf("test %d", i)

--- a/environs/bootstrap/prepare_test.go
+++ b/environs/bootstrap/prepare_test.go
@@ -95,8 +95,10 @@ func (*PrepareSuite) TestPrepare(c *gc.C) {
 			"development":               false,
 			"test-mode":                 true,
 		},
-		Cloud:     "dummy",
-		CloudType: "dummy",
+		Cloud:                "dummy",
+		CloudType:            "dummy",
+		CloudEndpoint:        "dummy-endpoint",
+		CloudStorageEndpoint: "dummy-storage-endpoint",
 	})
 
 	// Check we cannot call Prepare again.

--- a/featuretests/api_cloud_test.go
+++ b/featuretests/api_cloud_test.go
@@ -1,0 +1,41 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	apicloud "github.com/juju/juju/api/cloud"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/juju/testing"
+)
+
+// NOTE(axw) this suite only exists because nothing exercises
+// the cloud API enough to expose serialisation bugs such as
+// lp:1607557. If/when we have commands that would expose that
+// bug, we should drop this suite and write a new command-based
+// one.
+
+type CloudAPISuite struct {
+	testing.JujuConnSuite
+	client *apicloud.Client
+}
+
+func (s *CloudAPISuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	s.client = apicloud.NewClient(s.APIState)
+}
+
+func (s *CloudAPISuite) TestCloudAPI(c *gc.C) {
+	result, err := s.client.Cloud(names.NewCloudTag("dummy"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, cloud.Cloud{
+		Type:            "dummy",
+		AuthTypes:       []cloud.AuthType{cloud.EmptyAuthType},
+		Endpoint:        "dummy-endpoint",
+		StorageEndpoint: "dummy-storage-endpoint",
+	})
+}

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -148,13 +148,14 @@ func (s *cmdControllerSuite) TestAddModel(c *gc.C) {
 	// The JujuConnSuite doesn't set up an ssh key in the fake home dir,
 	// so fake one on the command line.  The dummy provider also expects
 	// a config value for 'controller'.
-	context := s.run(c, "add-model", "new-model", "authorized-keys=fake-key", "controller=false")
+	context := s.run(
+		c, "add-model", "new-model",
+		"--config", "authorized-keys=fake-key",
+		"--config", "controller=false",
+	)
 	c.Check(testing.Stdout(context), gc.Equals, "")
 	c.Check(testing.Stderr(context), gc.Equals, `
 Added 'new-model' model for user 'admin'
-
-No SSH authorized-keys were found. You must use "juju add-ssh-key"
-before "juju ssh", "juju scp", or "juju debug-hooks" will work.
 `[1:])
 
 	// Make sure that the saved server details are sufficient to connect

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -24,6 +24,7 @@ func init() {
 	}
 	// Initialize all suites here.
 	gc.Suite(&annotationsSuite{})
+	gc.Suite(&CloudAPISuite{})
 	gc.Suite(&apiEnvironmentSuite{})
 	gc.Suite(&BakeryStorageSuite{})
 	gc.Suite(&blockSuite{})

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -273,13 +273,14 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	for key, value := range s.ControllerConfigAttrs {
 		s.ControllerConfig[key] = value
 	}
+	cloudSpec := dummy.SampleCloudSpec()
 	environ, err := bootstrap.Prepare(
 		modelcmd.BootstrapContext(ctx),
 		s.ControllerStore,
 		bootstrap.PrepareParams{
 			ControllerConfig: s.ControllerConfig,
 			ModelConfig:      cfg.AllAttrs(),
-			Cloud:            dummy.SampleCloudSpec(),
+			Cloud:            cloudSpec,
 			ControllerName:   ControllerName,
 			AdminSecret:      AdminSecret,
 		},
@@ -310,10 +311,12 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	s.ControllerConfig["api-port"] = apiPort
 	err = bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), environ, bootstrap.BootstrapParams{
 		ControllerConfig: s.ControllerConfig,
-		CloudName:        "dummy",
+		CloudName:        cloudSpec.Name,
 		Cloud: cloud.Cloud{
-			Type:      "dummy",
-			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
+			Type:            cloudSpec.Type,
+			AuthTypes:       []cloud.AuthType{cloud.EmptyAuthType},
+			Endpoint:        cloudSpec.Endpoint,
+			StorageEndpoint: cloudSpec.StorageEndpoint,
 		},
 		AdminSecret:  AdminSecret,
 		CAPrivateKey: testing.CAKey,

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -78,8 +78,10 @@ var errNotPrepared = errors.New("model is not prepared")
 // open a dummy Environ.
 func SampleCloudSpec() environs.CloudSpec {
 	return environs.CloudSpec{
-		Type: "dummy",
-		Name: "dummy",
+		Type:            "dummy",
+		Name:            "dummy",
+		Endpoint:        "dummy-endpoint",
+		StorageEndpoint: "dummy-storage-endpoint",
 	}
 }
 


### PR DESCRIPTION
Duplicate json tag for endpoint.
One should be storage-endpoint.

Added a "feature test" to call
the API, since we don't have any
commands that would validate the
endpoints. The test only exercises
Cloud serialization, and not
CloudRegion, because adding regions
to the dummy provider has further
ramifications; and we can't easily
inject an alternative cloud into
state right now.

Also found and fixed an issue with
argument parsing in add-model,
while investigating options for
adding a feature test.

Fixes https://bugs.launchpad.net/juju-core/+bug/1607557

(Review request: http://reviews.vapour.ws/r/5347/)