### PR TITLE
worker/provisioner: Get Environ from environ-tracker

### DIFF
--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -223,9 +223,10 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewWorker: discoverspaces.NewWorker,
 		})),
 		computeProvisionerName: ifNotMigrating(provisioner.Manifold(provisioner.ManifoldConfig{
-			AgentName:     agentName,
-			APICallerName: apiCallerName,
-			EnvironName:   environTrackerName,
+			AgentName:          agentName,
+			APICallerName:      apiCallerName,
+			EnvironName:        environTrackerName,
+			NewProvisionerFunc: provisioner.NewEnvironProvisioner,
 		})),
 		storageProvisionerName: ifNotMigrating(storageprovisioner.ModelManifold(storageprovisioner.ModelManifoldConfig{
 			APICallerName: apiCallerName,

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -225,6 +225,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		computeProvisionerName: ifNotMigrating(provisioner.Manifold(provisioner.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
+			EnvironName:   environTrackerName,
 		})),
 		storageProvisionerName: ifNotMigrating(storageprovisioner.ModelManifold(storageprovisioner.ModelManifoldConfig{
 			APICallerName: apiCallerName,

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -77,7 +77,7 @@ func (s *ContainerSetupSuite) SetUpTest(c *gc.C) {
 	// Set up provisioner for the state machine.
 	s.agentConfig = s.AgentConfigForTag(c, names.NewMachineTag("0"))
 	var err error
-	s.p, err = provisioner.NewEnvironProvisioner(s.provisioner, s.agentConfig)
+	s.p, err = provisioner.NewEnvironProvisioner(s.provisioner, s.agentConfig, s.Environ)
 	c.Assert(err, jc.ErrorIsNil)
 	s.lockName = "provisioner-test"
 }

--- a/worker/provisioner/manifold.go
+++ b/worker/provisioner/manifold.go
@@ -23,6 +23,8 @@ type ManifoldConfig struct {
 	AgentName     string
 	APICallerName string
 	EnvironName   string
+
+	NewProvisionerFunc func(*apiprovisioner.State, agent.Config, environs.Environ) (Provisioner, error)
 }
 
 // Manifold creates a manifold that runs an environemnt provisioner. See the
@@ -51,8 +53,8 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			}
 
 			api := apiprovisioner.NewState(apiCaller)
-			config := agent.CurrentConfig()
-			w, err := NewEnvironProvisioner(api, config, environ)
+			agentConfig := agent.CurrentConfig()
+			w, err := config.NewProvisionerFunc(api, agentConfig, environ)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/worker/provisioner/manifold.go
+++ b/worker/provisioner/manifold.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	apiprovisioner "github.com/juju/juju/api/provisioner"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
 )
@@ -21,25 +22,37 @@ import (
 type ManifoldConfig struct {
 	AgentName     string
 	APICallerName string
+	EnvironName   string
 }
 
 // Manifold creates a manifold that runs an environemnt provisioner. See the
 // ManifoldConfig type for discussion about how this can/should evolve.
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
-		Inputs: []string{config.AgentName, config.APICallerName},
+		Inputs: []string{
+			config.AgentName,
+			config.APICallerName,
+			config.EnvironName,
+		},
 		Start: func(context dependency.Context) (worker.Worker, error) {
 			var agent agent.Agent
 			if err := context.Get(config.AgentName, &agent); err != nil {
 				return nil, errors.Trace(err)
 			}
+
 			var apiCaller base.APICaller
 			if err := context.Get(config.APICallerName, &apiCaller); err != nil {
 				return nil, errors.Trace(err)
 			}
+
+			var environ environs.Environ
+			if err := context.Get(config.EnvironName, &environ); err != nil {
+				return nil, errors.Trace(err)
+			}
+
 			api := apiprovisioner.NewState(apiCaller)
 			config := agent.CurrentConfig()
-			w, err := NewEnvironProvisioner(api, config)
+			w, err := NewEnvironProvisioner(api, config, environ)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/catacomb"
-	"github.com/juju/juju/worker/environ"
 )
 
 var logger = loggo.GetLogger("juju.provisioner")
@@ -175,15 +174,17 @@ func (p *provisioner) getStartTask(harvestMode config.HarvestMode) (ProvisionerT
 // NewEnvironProvisioner returns a new Provisioner for an environment.
 // When new machines are added to the state, it allocates instances
 // from the environment and allocates them to the new machines.
-func NewEnvironProvisioner(st *apiprovisioner.State, agentConfig agent.Config) (Provisioner, error) {
+func NewEnvironProvisioner(st *apiprovisioner.State, agentConfig agent.Config, environ environs.Environ) (Provisioner, error) {
 	p := &environProvisioner{
 		provisioner: provisioner{
 			st:          st,
 			agentConfig: agentConfig,
 			toolsFinder: getToolsFinder(st),
 		},
+		environ: environ,
 	}
 	p.Provisioner = p
+	p.broker = environ
 	logger.Tracef("Starting environ provisioner for %q", p.agentConfig.Tag())
 
 	err := catacomb.Invoke(catacomb.Plan{
@@ -197,6 +198,10 @@ func NewEnvironProvisioner(st *apiprovisioner.State, agentConfig agent.Config) (
 }
 
 func (p *environProvisioner) loop() error {
+	// TODO(mjs channeling axw) - It would be better if there were
+	// APIs to watch and fetch provisioner specific config instead of
+	// watcher for all changes to model config. This would avoid the
+	// need for a full model config.
 	var modelConfigChanges <-chan struct{}
 	modelWatcher, err := p.st.WatchForModelConfigChanges()
 	if err != nil {
@@ -206,15 +211,6 @@ func (p *environProvisioner) loop() error {
 		return errors.Trace(err)
 	}
 	modelConfigChanges = modelWatcher.Changes()
-
-	p.environ, err = environ.WaitForEnviron(modelWatcher, p.st, environs.New, p.catacomb.Dying())
-	if err != nil {
-		if err == environ.ErrWaitAborted {
-			return p.catacomb.ErrDying()
-		}
-		return loggedErrorStack(errors.Trace(err))
-	}
-	p.broker = p.environ
 
 	modelConfig := p.environ.Config()
 	p.configObserver.notify(modelConfig)
@@ -328,7 +324,7 @@ func (p *containerProvisioner) loop() error {
 			return p.catacomb.ErrDying()
 		case _, ok := <-modelWatcher.Changes():
 			if !ok {
-				return errors.New("model configuratioon watch closed")
+				return errors.New("model configuration watch closed")
 			}
 			modelConfig, err := p.st.ModelConfig()
 			if err != nil {

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -429,10 +429,12 @@ func (s *CommonProvisionerSuite) newEnvironProvisioner(c *gc.C) provisioner.Prov
 	context := dt.StubContext(nil, map[string]interface{}{
 		"agent":      mockAgent{config: agentConfig},
 		"api-caller": s.st,
+		"environ":    s.Environ,
 	})
 	manifold := provisioner.Manifold(provisioner.ManifoldConfig{
 		AgentName:     "agent",
 		APICallerName: "api-caller",
+		EnvironName:   "environ",
 	})
 	untyped, err := manifold.Start(context)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
The provisioner now gets an Environ instance as an external resource (from the environ-tracker) instead of obtaining one itself using WaitForEnviron.

This opens up the possibility of more flexibility in testing and for removing the use of JujuConnSuite for the unit tests.

Part of the fix for LP 1600301.

(Review request: http://reviews.vapour.ws/r/5351/)