### PR TITLE
cmd/jujud/agent: Re-enable TestHostedModelWorkers

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -987,6 +987,7 @@ func (a *MachineAgent) startModelWorkers(uuid string) (worker.Worker, error) {
 		StatusHistoryPrunerMaxHistoryMB:   5120,            // 5G
 		StatusHistoryPrunerInterval:       5 * time.Minute,
 		SpacesImportedGate:                a.discoverSpacesComplete,
+		NewEnvironFunc:                    newEnvirons,
 	})
 	if err := dependency.Install(engine, manifolds); err != nil {
 		if err := worker.Stop(engine); err != nil {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cert"
 	"github.com/juju/juju/core/migration"
+	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju"
@@ -1256,7 +1257,13 @@ func (s *MachineSuite) TestControllerModelWorkers(c *gc.C) {
 }
 
 func (s *MachineSuite) TestHostedModelWorkers(c *gc.C) {
-	c.Skip("issue 1600301")
+	// The dummy provider blows up in the face of multi-model
+	// scenarios so patch in a minimal environs.Environ that's good
+	// enough to allow the model workers to run.
+	s.PatchValue(&newEnvirons, func(environs.OpenParams) (environs.Environ, error) {
+		return &minModelWorkersEnviron{}, nil
+	})
+
 	st, closer := s.setUpNewModel(c)
 	defer closer()
 	uuid := st.ModelUUID()

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -84,6 +84,10 @@ type ManifoldsConfig struct {
 	// SpacesImportedGate will be unlocked when spaces are known to
 	// have been imported.
 	SpacesImportedGate gate.Lock
+
+	// NewEnvironFunc is a function opens a provider "environment"
+	// (typically environs.New).
+	NewEnvironFunc environs.NewEnvironFunc
 }
 
 // Manifolds returns a set of interdependent dependency manifolds that will
@@ -201,7 +205,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// workers (firewaller, provisioners, address-cleaner?).
 		environTrackerName: ifResponsible(environ.Manifold(environ.ManifoldConfig{
 			APICallerName:  apiCallerName,
-			NewEnvironFunc: environs.New,
+			NewEnvironFunc: config.NewEnvironFunc,
 		})),
 
 		// The undertaker is currently the only ifNotAlive worker.

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -26,6 +26,8 @@ import (
 	apideployer "github.com/juju/juju/api/deployer"
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo/mongotest"
@@ -533,3 +535,26 @@ func (FakeAgentConfig) ChangeConfig(mutate agent.ConfigMutator) error {
 }
 
 func (FakeAgentConfig) CheckArgs([]string) error { return nil }
+
+// minModelWorkersEnviron implements just enough of environs.Environ
+// to allow model workers to run.
+type minModelWorkersEnviron struct {
+	environs.Environ
+}
+
+func (e *minModelWorkersEnviron) Config() *config.Config {
+	attrs := coretesting.FakeConfig()
+	cfg, err := config.New(config.NoDefaults, attrs)
+	if err != nil {
+		panic(err)
+	}
+	return cfg
+}
+
+func (e *minModelWorkersEnviron) SetConfig(*config.Config) error {
+	return nil
+}
+
+func (e *minModelWorkersEnviron) AllInstances() ([]instance.Instance, error) {
+	return nil, nil
+}


### PR DESCRIPTION
The dummy provider blows up in the face of multi-model scenarios causing TestHostedModelWorkers to fail.

The environ-tracker worker now takes a func to create a new Environ to support injecting of an alternate Envrion in tests. A new minimal Environ is now injected in TestHostedModelWorkers which is just enough to allow the various model workers to run.

TestHostedModelWorkers is now works again and has been re-enabled.

This is the final PR for LP 1600301.

(Review request: http://reviews.vapour.ws/r/5354/)