### PR TITLE
Fixed lp:1602054: juju deployed lxd containers are missing a default gateway when configured with multiple interfaces

### DIFF
--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -114,9 +114,8 @@ func GenerateNetworkConfig(networkConfig *container.NetworkConfig) (string, erro
 		output.WriteString("  address " + address + "\n")
 		if !gatewayWritten && prepared.GatewayAddress != "" {
 			_, network, err := net.ParseCIDR(address)
-
 			if err != nil {
-				return "", errors.Trace(err)
+				return "", errors.Annotatef(err, "invalid gateway for interface %q with address %q", name, address)
 			}
 
 			gatewayIP := net.ParseIP(prepared.GatewayAddress)

--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"path/filepath"
 	"strings"
 
@@ -103,19 +104,35 @@ func GenerateNetworkConfig(networkConfig *container.NetworkConfig) (string, erro
 			continue
 		} else if address == string(network.ConfigDHCP) {
 			output.WriteString("iface " + name + " inet dhcp\n")
+			// We're expecting to get a default gateway
+			// from the DHCP lease.
+			gatewayWritten = true
 			continue
 		}
 
 		output.WriteString("iface " + name + " inet static\n")
 		output.WriteString("  address " + address + "\n")
 		if !gatewayWritten && prepared.GatewayAddress != "" {
-			output.WriteString("  gateway " + prepared.GatewayAddress + "\n")
-			gatewayWritten = true // write it only once
+			_, network, err := net.ParseCIDR(address)
+
+			if err != nil {
+				return "", errors.Trace(err)
+			}
+
+			gatewayIP := net.ParseIP(prepared.GatewayAddress)
+			if network.Contains(gatewayIP) {
+				output.WriteString("  gateway " + prepared.GatewayAddress + "\n")
+				gatewayWritten = true // write it only once
+			}
 		}
 	}
 
 	generatedConfig := output.String()
 	logger.Debugf("generated network config:\n%s", generatedConfig)
+
+	if !gatewayWritten {
+		logger.Infof("generated network config has no gateway")
+	}
 
 	return generatedConfig, nil
 }
@@ -162,8 +179,7 @@ func PrepareNetworkConfigFromInterfaces(interfaces []network.InterfaceInfo) *Pre
 
 		dnsSearchDomains = dnsSearchDomains.Union(set.NewStrings(info.DNSSearchDomains...))
 
-		if info.InterfaceName == "eth0" && gatewayAddress == "" {
-			// Only set gateway once for the primary NIC.
+		if gatewayAddress == "" && info.GatewayAddress.Value != "" {
 			gatewayAddress = info.GatewayAddress.Value
 		}
 

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -47,7 +47,7 @@ func (s *UserDataSuite) SetUpTest(c *gc.C) {
 	s.networkInterfacesFile = filepath.Join(c.MkDir(), "juju-interfaces")
 	s.systemNetworkInterfacesFile = filepath.Join(c.MkDir(), "system-interfaces")
 	s.fakeInterfaces = []network.InterfaceInfo{{
-		InterfaceName:    "eth0",
+		InterfaceName:    "any0",
 		CIDR:             "0.1.2.0/24",
 		ConfigType:       network.ConfigStatic,
 		NoAutoStart:      false,
@@ -57,47 +57,47 @@ func (s *UserDataSuite) SetUpTest(c *gc.C) {
 		GatewayAddress:   network.NewAddress("0.1.2.1"),
 		MACAddress:       "aa:bb:cc:dd:ee:f0",
 	}, {
-		InterfaceName:    "eth1",
-		CIDR:             "0.1.2.0/24",
+		InterfaceName:    "any1",
+		CIDR:             "0.2.2.0/24",
 		ConfigType:       network.ConfigStatic,
 		NoAutoStart:      false,
-		Address:          network.NewAddress("0.1.2.4"),
+		Address:          network.NewAddress("0.2.2.4"),
 		DNSServers:       network.NewAddresses("ns1.invalid", "ns2.invalid"),
 		DNSSearchDomains: []string{"foo", "bar"},
-		GatewayAddress:   network.NewAddress("0.1.2.1"),
-		MACAddress:       "aa:bb:cc:dd:ee:f0",
+		GatewayAddress:   network.NewAddress("0.2.2.1"),
+		MACAddress:       "aa:bb:cc:dd:ee:f1",
 	}, {
-		InterfaceName: "eth2",
+		InterfaceName: "any2",
 		ConfigType:    network.ConfigDHCP,
 		NoAutoStart:   true,
 	}, {
-		InterfaceName: "eth3",
+		InterfaceName: "any3",
 		ConfigType:    network.ConfigDHCP,
 		NoAutoStart:   false,
 	}, {
-		InterfaceName: "eth4",
+		InterfaceName: "any4",
 		ConfigType:    network.ConfigManual,
 		NoAutoStart:   true,
 	}}
 	s.expectedSampleConfig = `
-auto eth0 eth1 eth3 lo
+auto any0 any1 any3 lo
 
 iface lo inet loopback
   dns-nameservers ns1.invalid ns2.invalid
   dns-search bar foo
 
-iface eth0 inet static
+iface any0 inet static
   address 0.1.2.3/24
   gateway 0.1.2.1
 
-iface eth1 inet static
-  address 0.1.2.4/24
+iface any1 inet static
+  address 0.2.2.4/24
 
-iface eth2 inet dhcp
+iface any2 inet dhcp
 
-iface eth3 inet dhcp
+iface any3 inet dhcp
 
-iface eth4 inet manual
+iface any4 inet manual
 `
 	s.expectedSampleUserData = `
 #cloud-config
@@ -105,24 +105,24 @@ bootcmd:
 - install -D -m 644 /dev/null '%[1]s'
 - |-
   printf '%%s\n' '
-  auto eth0 eth1 eth3 lo
+  auto any0 any1 any3 lo
 
   iface lo inet loopback
     dns-nameservers ns1.invalid ns2.invalid
     dns-search bar foo
 
-  iface eth0 inet static
+  iface any0 inet static
     address 0.1.2.3/24
     gateway 0.1.2.1
 
-  iface eth1 inet static
-    address 0.1.2.4/24
+  iface any1 inet static
+    address 0.2.2.4/24
 
-  iface eth2 inet dhcp
+  iface any2 inet dhcp
 
-  iface eth3 inet dhcp
+  iface any3 inet dhcp
 
-  iface eth4 inet manual
+  iface any4 inet manual
   ' > '%[1]s'
 runcmd:
 - |-


### PR DESCRIPTION
Remove the assumption that eth0 must be the default gateway. When
rendering /etc/network/interfaces validate whether any default gateway
information that is present is appropriate for the iface stanza that is
currently being rendered.

Only one 'gateway <addr>' can be present in /etc/network/interfaces,
additional entries must have 'metric' options to disambiguate them. As
we don't want to make up arbitrary metrics we write an entry for the
first case of:

ifaceNetworkAddress.Contains(gatewayIPAddress)

or where we see an interface configured as DHCP and we assume we'll get
a default route with the lease.

NOTE: Took over frobware's fix proposed as http://reviews.vapour.ws/r/5331/,
applied a few minor tweaks and tested on MAAS 2.0rc3 (see below). For
more details, see http://pad.lv/1602054.

QA steps:

   1. Bootstrap on MAAS with series xenial to a dual-NIC node with VLANs
   2. Switch to controller model
   3. Add LXD container to the controller machine.
   4. Verify the generated /etc/network/interfaces inside the container
   to ensure it looks correct (one 'gateway' stanza only).
   5. Ping bbc.co.uk from both the host and the container to ensure both
   DNS resolution works and there is a default route via the gateway.
   6. Add another machine (series trusty) with manual placement to a
   node preconfigured to have 2 NICs, but only the second one is up and
   configured.
   7. Add LXD to the new machine, wait for it to come up, repeat checks
   in steps 4 and 5.

(Review request: http://reviews.vapour.ws/r/5356/)