### PR TITLE
state: fix UpdateCloudCredentials for existing creds

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -60,7 +60,9 @@ const (
 
 // Cloud is a cloud definition.
 type Cloud struct {
-	// Type is the type of cloud, eg aws, openstack etc.
+	// Type is the type of cloud, eg ec2, openstack etc.
+	// This is one of the provider names registered with
+	// environs.RegisterProvider.
 	Type string
 
 	// AuthTypes are the authentication modes supported by the cloud.

--- a/state/cloud_test.go
+++ b/state/cloud_test.go
@@ -1,0 +1,76 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cloud"
+)
+
+type CloudSuite struct {
+	ConnSuite
+}
+
+var _ = gc.Suite(&CloudSuite{})
+
+func (s *CloudSuite) TestCloudNotFound(c *gc.C) {
+	cld, err := s.State.Cloud("unknown")
+	c.Assert(err, gc.ErrorMatches, `cloud "unknown" not found`)
+	c.Assert(cld, jc.DeepEquals, cloud.Cloud{})
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *CloudSuite) TestAddCloud(c *gc.C) {
+	cld := cloud.Cloud{
+		Type:            "low",
+		AuthTypes:       cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
+		Endpoint:        "global-endpoint",
+		StorageEndpoint: "global-storage",
+		Regions: []cloud.Region{{
+			Name:            "region1",
+			Endpoint:        "region1-endpoint",
+			StorageEndpoint: "region1-storage",
+		}, {
+			Name:            "region2",
+			Endpoint:        "region2-endpoint",
+			StorageEndpoint: "region2-storage",
+		}},
+	}
+	err := s.State.AddCloud("stratus", cld)
+	c.Assert(err, jc.ErrorIsNil)
+	cld1, err := s.State.Cloud("stratus")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cld1, jc.DeepEquals, cld)
+}
+
+func (s *CloudSuite) TestAddCloudDuplicate(c *gc.C) {
+	err := s.State.AddCloud("stratus", cloud.Cloud{
+		Type:      "low",
+		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.AddCloud("stratus", cloud.Cloud{
+		Type:      "low",
+		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
+	})
+	c.Assert(err, gc.ErrorMatches, `cloud "stratus" already exists`)
+	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
+}
+
+func (s *CloudSuite) TestAddCloudNoType(c *gc.C) {
+	err := s.State.AddCloud("stratus", cloud.Cloud{
+		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
+	})
+	c.Assert(err, gc.ErrorMatches, `invalid cloud: empty Type not valid`)
+}
+
+func (s *CloudSuite) TestAddCloudNoAuthTypes(c *gc.C) {
+	err := s.State.AddCloud("stratus", cloud.Cloud{
+		Type: "foo",
+	})
+	c.Assert(err, gc.ErrorMatches, `invalid cloud: empty auth-types not valid`)
+}

--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -40,7 +40,7 @@ func (st *State) CloudCredentials(user names.UserTag, cloudName string) (map[str
 	for iter.Next(&doc) {
 		credentials[doc.Name] = doc.toCredential()
 	}
-	if err := iter.Close(); err != nil {
+	if err := iter.Err(); err != nil {
 		return nil, errors.Annotatef(
 			err, "cannot get cloud credentials for user %q, cloud %q",
 			user.Canonical(), cloudName,
@@ -62,7 +62,17 @@ func (st *State) UpdateCloudCredentials(user names.UserTag, cloudName string, cr
 		if err != nil {
 			return nil, errors.Annotate(err, "validating cloud credentials")
 		}
-		ops = append(ops, updateCloudCredentialsOps(user, cloudName, credentials)...)
+		existingCreds, err := st.CloudCredentials(user, cloudName)
+		if err != nil {
+			return nil, errors.Maskf(err, "fetching cloud credentials")
+		}
+		for credName, cred := range credentials {
+			if _, ok := existingCreds[credName]; ok {
+				ops = append(ops, updateCloudCredentialOp(user, cloudName, credName, cred))
+			} else {
+				ops = append(ops, createCloudCredentialOp(user, cloudName, credName, cred))
+			}
+		}
 		return ops, nil
 	}
 	if err := st.run(buildTxn); err != nil {
@@ -74,26 +84,35 @@ func (st *State) UpdateCloudCredentials(user names.UserTag, cloudName string, cr
 	return nil
 }
 
-// updateCloudCredentialsOps returns a list of txn.Ops that will create
-// or update a set of cloud credentials for a user.
-func updateCloudCredentialsOps(user names.UserTag, cloudName string, credentials map[string]cloud.Credential) []txn.Op {
-	owner := user.Canonical()
-	ops := make([]txn.Op, 0, len(credentials))
-	for name, credential := range credentials {
-		ops = append(ops, txn.Op{
-			C:      cloudCredentialsC,
-			Id:     cloudCredentialDocID(user, cloudName, name),
-			Assert: txn.DocMissing,
-			Insert: &cloudCredentialDoc{
-				Owner:      owner,
-				Cloud:      cloudName,
-				Name:       name,
-				AuthType:   string(credential.AuthType()),
-				Attributes: credential.Attributes(),
-			},
-		})
+// createCloudCredentialOp returns a txn.Op that will create
+// a cloud credential.
+func createCloudCredentialOp(user names.UserTag, cloudName, credName string, cred cloud.Credential) txn.Op {
+	return txn.Op{
+		C:      cloudCredentialsC,
+		Id:     cloudCredentialDocID(user, cloudName, credName),
+		Assert: txn.DocMissing,
+		Insert: &cloudCredentialDoc{
+			Owner:      user.Canonical(),
+			Cloud:      cloudName,
+			Name:       credName,
+			AuthType:   string(cred.AuthType()),
+			Attributes: cred.Attributes(),
+		},
 	}
-	return ops
+}
+
+// updateCloudCredentialOp returns a txn.Op that will update
+// a cloud credential.
+func updateCloudCredentialOp(user names.UserTag, cloudName, credName string, cred cloud.Credential) txn.Op {
+	return txn.Op{
+		C:      cloudCredentialsC,
+		Id:     cloudCredentialDocID(user, cloudName, credName),
+		Assert: txn.DocExists,
+		Update: bson.D{{"$set", bson.D{
+			{"auth-type", string(cred.AuthType())},
+			{"attributes", cred.Attributes()},
+		}}},
+	}
 }
 
 func cloudCredentialDocID(user names.UserTag, cloudName, credentialName string) string {
@@ -109,6 +128,14 @@ func (c cloudCredentialDoc) toCredential() cloud.Credential {
 // validateCloudCredentials checks that the supplied cloud credentials are
 // valid for use with the controller's cloud, and returns a set of txn.Ops
 // to assert the same in a transaction.
+//
+// TODO(rogpeppe) We're going to a lot of effort here to assert that a
+// cloud's auth types haven't changed since we looked at them a moment
+// ago, but we don't support changing a cloud's definition currently and
+// it's not clear that doing so would be a good idea, as changing a
+// cloud's auth type would invalidate all existing credentials and would
+// usually involve a new provider version and juju binary too, so
+// perhaps all this code is unnecessary.
 func validateCloudCredentials(cloud cloud.Cloud, cloudName string, credentials map[string]cloud.Credential) ([]txn.Op, error) {
 	requiredAuthTypes := make(set.Strings)
 	for name, credential := range credentials {

--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -1,0 +1,139 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/cloud"
+)
+
+type CloudCredentialsSuite struct {
+	ConnSuite
+}
+
+var _ = gc.Suite(&CloudCredentialsSuite{})
+
+func (s *CloudCredentialsSuite) TestUpdateCloudCredentialsNew(c *gc.C) {
+	err := s.State.AddCloud("stratus", cloud.Cloud{
+		Type:      "low",
+		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	creds := map[string]cloud.Credential{
+		"cred1": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+			"foo": "foo val",
+			"bar": "bar val",
+		}),
+		"cred2": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+			"a": "a val",
+			"b": "b val",
+		}),
+		"cred3": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+			"user":     "bob",
+			"password": "bob's password",
+		}),
+	}
+	addCredLabels(creds)
+
+	err = s.State.UpdateCloudCredentials(names.NewUserTag("bob"), "stratus", creds)
+	c.Assert(err, jc.ErrorIsNil)
+	// The retrieved credentials have labels although cloud.NewCredential
+	// doesn't have them, so add them.
+	for name, cred := range creds {
+		cred.Label = name
+		creds[name] = cred
+	}
+	creds1, err := s.State.CloudCredentials(names.NewUserTag("bob"), "stratus")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(creds1, jc.DeepEquals, creds)
+}
+
+func (s *CloudCredentialsSuite) TestCloudCredentialsEmpty(c *gc.C) {
+	creds, err := s.State.CloudCredentials(names.NewUserTag("bob"), "dummy")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(creds, gc.HasLen, 0)
+}
+
+func (s *CloudCredentialsSuite) TestUpdateCloudCredentialsExisting(c *gc.C) {
+	err := s.State.AddCloud("stratus", cloud.Cloud{
+		Type:      "low",
+		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.UpdateCloudCredentials(names.NewUserTag("bob"), "stratus", map[string]cloud.Credential{
+		"cred1": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+			"foo": "foo val",
+			"bar": "bar val",
+		}),
+		"cred2": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+			"a": "a val",
+			"b": "b val",
+		}),
+		"cred3": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+			"user":     "bob",
+			"password": "bob's password",
+		}),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.UpdateCloudCredentials(names.NewUserTag("bob"), "stratus", map[string]cloud.Credential{
+		"cred1": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+			"user":     "bob's nephew",
+			"password": "simple",
+		}),
+		"cred2": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+			"b": "new b val",
+		}),
+		"cred4": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+			"d": "d val",
+		}),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expect := map[string]cloud.Credential{
+		"cred1": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+			"user":     "bob's nephew",
+			"password": "simple",
+		}),
+		"cred2": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+			"b": "new b val",
+		}),
+		"cred3": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+			"user":     "bob",
+			"password": "bob's password",
+		}),
+		"cred4": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+			"d": "d val",
+		}),
+	}
+	addCredLabels(expect)
+
+	creds1, err := s.State.CloudCredentials(names.NewUserTag("bob"), "stratus")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(creds1, jc.DeepEquals, expect)
+}
+
+func (s *CloudCredentialsSuite) TestUpdateCloudCredentialsInvalidAuthType(c *gc.C) {
+	err := s.State.AddCloud("stratus", cloud.Cloud{
+		Type:      "low",
+		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType},
+	})
+	err = s.State.UpdateCloudCredentials(names.NewUserTag("bob"), "stratus", map[string]cloud.Credential{
+		"cred1": cloud.NewCredential(cloud.UserPassAuthType, nil),
+	})
+	c.Assert(err, gc.ErrorMatches, `updating cloud credentials for user "user-bob", cloud "stratus": validating cloud credentials: credential "cred1" with auth-type "userpass" is not supported \(expected one of \["access-key"\]\)`)
+}
+
+// addCredLabels adds labels to all the given credentials, because
+// the labels are present when the credentials are returned from the
+// state but not when created with NewCredential.
+func addCredLabels(creds map[string]cloud.Credential) {
+	for name, cred := range creds {
+		cred.Label = name
+		creds[name] = cred
+	}
+}

--- a/state/collection.go
+++ b/state/collection.go
@@ -4,10 +4,10 @@
 package state
 
 import (
+	"github.com/juju/errors"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/mongo"
 )
 

--- a/state/model.go
+++ b/state/model.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
+	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -19,7 +20,6 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/status"
-	"github.com/juju/version"
 )
 
 // modelGlobalKey is the key for the model, its

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -9,11 +9,12 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/description"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/core/description"
 )
 
 // ModelUser represents a user access to an model whereas the user

--- a/state/open.go
+++ b/state/open.go
@@ -263,13 +263,13 @@ func Initialize(args InitializeParams) (_ *State, err error) {
 		createSettingsOp(controllersC, controllerSettingsGlobalKey, args.ControllerConfig),
 		createSettingsOp(globalSettingsC, controllerInheritedSettingsGlobalKey, args.ControllerInheritedConfig),
 	}
-	if len(args.CloudCredentials) > 0 {
-		credentialsOps := updateCloudCredentialsOps(
+	for credName, cred := range args.CloudCredentials {
+		ops = append(ops, createCloudCredentialOp(
 			args.ControllerModelArgs.Owner,
 			args.CloudName,
-			args.CloudCredentials,
-		)
-		ops = append(ops, credentialsOps...)
+			credName,
+			cred,
+		))
 	}
 	ops = append(ops, modelOps...)
 

--- a/state/package_test.go
+++ b/state/package_test.go
@@ -6,8 +6,9 @@ package state_test
 import (
 	"testing"
 
-	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/utils/os"
+
+	coretesting "github.com/juju/juju/testing"
 )
 
 func TestPackage(t *testing.T) {

--- a/state/undertaker.go
+++ b/state/undertaker.go
@@ -4,10 +4,8 @@
 package state
 
 import (
-	"gopkg.in/mgo.v2/bson"
-
 	"github.com/juju/errors"
-
+	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 )
 

--- a/state/unitagent.go
+++ b/state/unitagent.go
@@ -5,8 +5,9 @@ package state
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/status"
 	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/status"
 )
 
 // UnitAgent represents the state of a service's unit agent.

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -7,11 +7,12 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/status"
 	"github.com/juju/loggo"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/status"
 )
 
 var upgradesLogger = loggo.GetLogger("juju.state.upgrade")

--- a/state/userpermission.go
+++ b/state/userpermission.go
@@ -7,10 +7,11 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/description"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/core/description"
 )
 
 // permission represents the permission a user has


### PR DESCRIPTION
state: fix UpdateCloudCredentials for existing creds

UpdateCloudCredentials didn't work when there were existing
credentials with the same name.

To test this properly, we required different clouds with different
credentials, so we implement a CreateCloud method too.

Fixes https://bugs.launchpad.net/juju-core/+bug/1608421.

Partially addresses https://bugs.launchpad.net/juju-core/+bug/1608494.

(Review request: http://reviews.vapour.ws/r/5357/)