### PR TITLE
worker/dependency: annotate ErrMissing

### DIFF
--- a/cmd/jujud/agent/engine/housing.go
+++ b/cmd/jujud/agent/engine/housing.go
@@ -103,7 +103,7 @@ func flagStart(inner dependency.StartFunc, name string) dependency.StartFunc {
 			return nil, errors.Trace(err)
 		}
 		if !flag.Check() {
-			return nil, dependency.ErrMissing
+			return nil, errors.Annotatef(dependency.ErrMissing, "%q not set", name)
 		}
 		return inner(context)
 	}

--- a/worker/dependency/context.go
+++ b/worker/dependency/context.go
@@ -63,19 +63,19 @@ func (ctx *context) expire() {
 
 // rawAccess is a GetResourceFunc that neither checks enpiry nor records access.
 func (ctx *context) rawAccess(resourceName string, out interface{}) error {
-	input := ctx.workers[resourceName]
-	if input == nil {
-		// No worker running (or not declared).
-		return ErrMissing
+	input, found := ctx.workers[resourceName]
+	if !found {
+		return errors.Annotatef(ErrMissing, "%q not declared", resourceName)
+	} else if input == nil {
+		return errors.Annotatef(ErrMissing, "%q not running", resourceName)
 	}
 	if out == nil {
-		// No conversion necessary.
+		// No conversion necessary, just an exist check.
 		return nil
 	}
 	convert := ctx.outputs[resourceName]
 	if convert == nil {
-		// Conversion required, no func available.
-		return ErrMissing
+		return errors.Annotatef(ErrMissing, "%q not exposed", resourceName)
 	}
 	return convert(input, out)
 }

--- a/worker/dependency/engine_test.go
+++ b/worker/dependency/engine_test.go
@@ -165,7 +165,8 @@ func (s *EngineSuite) TestStartGetUndeclaredName(c *gc.C) {
 		err = engine.Install("other-task", dependency.Manifold{
 			Start: func(context dependency.Context) (worker.Worker, error) {
 				err := context.Get("some-task", nil)
-				c.Check(err, gc.Equals, dependency.ErrMissing)
+				c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+				c.Check(err, gc.ErrorMatches, `"some-task" not declared: dependency not available`)
 				close(done)
 				// Return a real worker so we don't keep restarting and potentially double-closing.
 				return startMinimalWorker(context)

--- a/worker/dependency/reporter_test.go
+++ b/worker/dependency/reporter_test.go
@@ -158,12 +158,12 @@ func (s *ReportSuite) TestReportError(c *gc.C) {
 			"manifolds": map[string]interface{}{
 				"task": map[string]interface{}{
 					"state":  "stopped",
-					"error":  dependency.ErrMissing.Error(),
+					"error":  `"missing" not running: dependency not available`,
 					"inputs": []string{"missing"},
 					"resource-log": []map[string]interface{}{{
 						"name":  "missing",
 						"type":  "<nil>",
-						"error": dependency.ErrMissing.Error(),
+						"error": `"missing" not running: dependency not available`,
 					}},
 				},
 			},


### PR DESCRIPTION
Various sources of dependency.ErrMissing now annotate the error to
clarify its cause. This should turn the inscrutable:

    failed to start "uniter" manifold worker: dependency not available

log lines to look more like:

    failed to start "uniter" manifold worker: "api-caller" not running: dependency not available

and allow clearer and more immediate diagnosis of root causes.

(Review request: http://reviews.vapour.ws/r/5362/)