### PR TITLE
Fixed lp:1609343: When spaces constraints are set, pick subnets in the correct VPC

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -508,9 +508,9 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 
 		var subnetIDsForZone []string
 		var subnetErr error
-		if haveVPCID && !args.Constraints.HaveSpaces() {
-			subnetIDsForZone, subnetErr = getVPCSubnetIDsForAvailabilityZone(e.ec2(), e.ecfg().vpcID(), zone)
-		} else if !haveVPCID && args.Constraints.HaveSpaces() {
+		if haveVPCID {
+			subnetIDsForZone, subnetErr = getVPCSubnetIDsForAvailabilityZone(e.ec2(), e.ecfg().vpcID(), zone, args.SubnetsToZones)
+		} else if args.Constraints.HaveSpaces() {
 			subnetIDsForZone, subnetErr = findSubnetIDsForAvailabilityZone(zone, args.SubnetsToZones)
 		}
 

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -509,7 +509,11 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 		var subnetIDsForZone []string
 		var subnetErr error
 		if haveVPCID {
-			subnetIDsForZone, subnetErr = getVPCSubnetIDsForAvailabilityZone(e.ec2(), e.ecfg().vpcID(), zone, args.SubnetsToZones)
+			var allowedSubnetIDs []string
+			for subnetID, _ := range args.SubnetsToZones {
+				allowedSubnetIDs = append(allowedSubnetIDs, string(subnetID))
+			}
+			subnetIDsForZone, subnetErr = getVPCSubnetIDsForAvailabilityZone(e.ec2(), e.ecfg().vpcID(), zone, allowedSubnetIDs)
 		} else if args.Constraints.HaveSpaces() {
 			subnetIDsForZone, subnetErr = findSubnetIDsForAvailabilityZone(zone, args.SubnetsToZones)
 		}

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -465,9 +465,11 @@ func getVPCSubnetIDsForAvailabilityZone(
 	matchingSubnetIDs := set.NewStrings()
 	for _, subnet := range subnets {
 		if subnet.AvailZone != zoneName {
+			logger.Infof("skipping subnet %q (in VPC %q): not in the chosen AZ %q", subnet.Id, vpcID, zoneName)
 			continue
 		}
 		if !allowedSubnetIDs.IsEmpty() && !allowedSubnetIDs.Contains(subnet.Id) {
+			logger.Infof("skipping subnet %q (in VPC %q, AZ %q): not matching spaces constraints", subnet.Id, vpcID, zoneName)
 			continue
 		}
 		matchingSubnetIDs.Add(subnet.Id)
@@ -478,7 +480,9 @@ func getVPCSubnetIDsForAvailabilityZone(
 		return nil, errors.NewNotFound(nil, message)
 	}
 
-	return matchingSubnetIDs.SortedValues(), nil
+	sortedIDs := matchingSubnetIDs.SortedValues()
+	logger.Infof("found %d subnets in VPC %q matching AZ %q and constraints: %v", len(sortedIDs), vpcID, zoneName, sortedIDs)
+	return sortedIDs, nil
 }
 
 func findSubnetIDsForAvailabilityZone(zoneName string, subnetsToZones map[network.Id][]string) ([]string, error) {

--- a/provider/ec2/environ_vpc_test.go
+++ b/provider/ec2/environ_vpc_test.go
@@ -620,15 +620,11 @@ func (s *vpcSuite) TestGetVPCSubnetIDsForAvailabilityZoneWithSubnetsToZones(c *g
 	s.stubAPI.SetSubnetsResponse(4, "my-zone", noPublicIPOnLaunch)
 	// Simulate we used --constraints spaces=foo, which contains subnet-1 and
 	// subnet-3 out of the 4 subnets in AZ my-zone (see the related bug
-	// http://pad.lv/1609343). The provisioner will have populated
-	// SubnetsToZones like this:
-	subnetsToZones := map[network.Id][]string{
-		"subnet-1": []string{"my-zone"},
-		"subnet-3": []string{"my-zone"},
-	}
+	// http://pad.lv/1609343).
+	allowedSubnetIDs := []string{"subnet-1", "subnet-3"}
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, "my-zone", subnetsToZones)
+	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, "my-zone", allowedSubnetIDs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(subnetIDs, jc.DeepEquals, []string{"subnet-1", "subnet-3"})
 

--- a/provider/ec2/environ_vpc_test.go
+++ b/provider/ec2/environ_vpc_test.go
@@ -585,7 +585,7 @@ func (s *vpcSuite) TestGetVPCSubnetIDsForAvailabilityZoneWithSubnetsError(c *gc.
 	s.stubAPI.SetErrors(errors.New("too cloudy"))
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, anyZone)
+	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, anyZone, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot get VPC "vpc-anything" subnets: unexpected AWS .*: too cloudy`)
 	c.Check(subnetIDs, gc.IsNil)
 
@@ -596,7 +596,7 @@ func (s *vpcSuite) TestGetVPCSubnetIDsForAvailabilityZoneNoSubnetsAtAll(c *gc.C)
 	s.stubAPI.SetSubnetsResponse(noResults, anyZone, noPublicIPOnLaunch)
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, anyZone)
+	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, anyZone, nil)
 	c.Assert(err, gc.ErrorMatches, `VPC "vpc-anything" has no subnets in AZ "any-zone": no subnets found for VPC.*`)
 	c.Check(err, jc.Satisfies, errors.IsNotFound)
 	c.Check(subnetIDs, gc.IsNil)
@@ -608,10 +608,29 @@ func (s *vpcSuite) TestGetVPCSubnetIDsForAvailabilityZoneNoSubnetsInAZ(c *gc.C) 
 	s.stubAPI.SetSubnetsResponse(3, "other-zone", noPublicIPOnLaunch)
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, "given-zone")
+	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, "given-zone", nil)
 	c.Assert(err, gc.ErrorMatches, `VPC "vpc-anything" has no subnets in AZ "given-zone"`)
 	c.Check(err, jc.Satisfies, errors.IsNotFound)
 	c.Check(subnetIDs, gc.IsNil)
+
+	s.stubAPI.CheckSingleSubnetsCall(c, anyVPC)
+}
+
+func (s *vpcSuite) TestGetVPCSubnetIDsForAvailabilityZoneWithSubnetsToZones(c *gc.C) {
+	s.stubAPI.SetSubnetsResponse(4, "my-zone", noPublicIPOnLaunch)
+	// Simulate we used --constraints spaces=foo, which contains subnet-1 and
+	// subnet-3 out of the 4 subnets in AZ my-zone (see the related bug
+	// http://pad.lv/1609343). The provisioner will have populated
+	// SubnetsToZones like this:
+	subnetsToZones := map[network.Id][]string{
+		"subnet-1": []string{"my-zone"},
+		"subnet-3": []string{"my-zone"},
+	}
+
+	anyVPC := makeEC2VPC(anyVPCID, anyState)
+	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, "my-zone", subnetsToZones)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(subnetIDs, jc.DeepEquals, []string{"subnet-1", "subnet-3"})
 
 	s.stubAPI.CheckSingleSubnetsCall(c, anyVPC)
 }
@@ -620,7 +639,7 @@ func (s *vpcSuite) TestGetVPCSubnetIDsForAvailabilityZoneSuccess(c *gc.C) {
 	s.stubAPI.SetSubnetsResponse(2, "my-zone", noPublicIPOnLaunch)
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, "my-zone")
+	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, "my-zone", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// Result slice of IDs is always sorted.
 	c.Check(subnetIDs, jc.DeepEquals, []string{"subnet-0", "subnet-1"})


### PR DESCRIPTION
When multiple subnets from different VPCs are available in any given AWS
AZ, the controller is provisioned in one of these VPCs, we added a
hosted model using the same VPC, added a space with some of the subnets
in that VPC, and we're deploying with spaces constraints specified, Juju
does not filter the subnets by VPC and can pick subnets in a different
VPC while doing automatic instance distribution per AZs. This leads to a
provisioning error like the one below:

cannot run instances: Security group sg-7d3cd107 and subnet
subnet-bf1a3cc8 belong to different networks. (InvalidParameter)

This fix introduces a second filtering stage when deciding which subnets
to pick when both spaces constraints and an explicit VPC ID for the
model is provided.

Reported on the Juju mailing list. See http://pad.lv/1609343 for
details.

QA steps (assuming the AWS shared team account is used)

   1. juju bootstrap aws aws/eu-central-1 --upload-tools --config vpc-id=vpc-3299c65b
   2. juju add-model -c aws hosted --config vpc-id=vpc-3299c65b
   3. juju add-space test
   4. juju add-subnet subnet-096b3f72 test
   5. juju add-subnet subnet-0c9eaf65 test
   6. juju deploy ubuntu -n 3 --constraints spaces=test
   7. Verify there are 3 machines provisioned OK (check juju status),
   apart from the controller. There should be no errors.
   8. Verify via the AWS Web UI Console (EC2 section; or the AWS CLI) that all those 4 instances are: (1) NOT running in subnet-00e0f57b (public-extra-1a), subnet-df7882b7  (public-extra-1b) (i.e. not part of the space "test" we added); and (2) distributed evenly across eu-central-1a and eu-central-1b AZs.

(Review request: http://reviews.vapour.ws/r/5363/)