### PR TITLE
environs: update API for hosted models

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -142,7 +142,7 @@ LXC_BRIDGE="ignored"`[1:])
 	modelCfg, err := config.New(config.NoDefaults, modelAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 	controllerCfg := testing.FakeControllerConfig()
-	modelCfg, err = provider.BootstrapConfig(environs.BootstrapConfigParams{
+	modelCfg, err = provider.PrepareConfig(environs.PrepareConfigParams{
 		ControllerUUID: controllerCfg.ControllerUUID(),
 		Config:         modelCfg,
 	})

--- a/apiserver/agent/agent.go
+++ b/apiserver/agent/agent.go
@@ -52,7 +52,7 @@ func NewAgentAPIV2(st *state.State, resources facade.Resources, auth facade.Auth
 		RebootFlagClearer:   common.NewRebootFlagClearer(st, getCanChange),
 		ModelWatcher:        common.NewModelWatcher(st, resources, auth),
 		ControllerConfigAPI: common.NewControllerConfig(st),
-		CloudSpecAPI:        cloudspec.NewCloudSpecForModel(st.ModelTag(), environConfigGetter.CloudSpec),
+		CloudSpecAPI:        cloudspec.NewCloudSpec(environConfigGetter.CloudSpec, common.AuthFuncForTag(st.ModelTag())),
 		st:                  st,
 		auth:                auth,
 	}, nil

--- a/apiserver/common/interfaces.go
+++ b/apiserver/common/interfaces.go
@@ -50,6 +50,15 @@ func AuthNever() GetAuthFunc {
 	}
 }
 
+// AuthFuncForTag returns an authentication function that always returns true iff it is passed a specific tag.
+func AuthFuncForTag(valid names.Tag) GetAuthFunc {
+	return func() (AuthFunc, error) {
+		return func(tag names.Tag) bool {
+			return tag == valid
+		}, nil
+	}
+}
+
 // AuthFuncForTagKind returns a GetAuthFunc which creates an AuthFunc
 // allowing only the given tag kind and denies all others. Passing an
 // empty kind is an error.

--- a/apiserver/common/networkingcommon/shims.go
+++ b/apiserver/common/networkingcommon/shims.go
@@ -7,10 +7,10 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
 	providercommon "github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/stateenvirons"
 )
 
 // NOTE: All of the following code is only tested with a feature test.
@@ -81,18 +81,14 @@ func (s *spaceShim) Subnets() ([]BackingSubnet, error) {
 }
 
 func NewStateShim(st *state.State) *stateShim {
-	return &stateShim{st: st}
+	return &stateShim{stateenvirons.EnvironConfigGetter{st}, st}
 }
 
 // stateShim forwards and adapts state.State methods to Backing
 // method.
 type stateShim struct {
-	NetworkBacking
+	stateenvirons.EnvironConfigGetter
 	st *state.State
-}
-
-func (s *stateShim) ModelConfig() (*config.Config, error) {
-	return s.st.ModelConfig()
 }
 
 func (s *stateShim) AddSpace(name string, providerId network.Id, subnetIds []string, public bool) error {

--- a/apiserver/common/networkingcommon/spaces_test.go
+++ b/apiserver/common/networkingcommon/spaces_test.go
@@ -81,6 +81,7 @@ func (s *SpacesSuite) checkCreateSpaces(c *gc.C, p checkCreateSpacesParams) {
 
 	baseCalls := []apiservertesting.StubMethodCall{
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.ZonedNetworkingEnvironCall("SupportsSpaces"),
 	}
@@ -159,6 +160,7 @@ func (s *SpacesSuite) TestCreateSpacesModelConfigError(c *gc.C) {
 func (s *SpacesSuite) TestCreateSpacesProviderOpenError(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil,                // Backing.ModelConfig()
+		nil,                // Backing.CloudSpec()
 		errors.New("boom"), // Provider.Open()
 	)
 
@@ -170,6 +172,7 @@ func (s *SpacesSuite) TestCreateSpacesProviderOpenError(c *gc.C) {
 func (s *SpacesSuite) TestCreateSpacesNotSupportedError(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.ModelConfig()
+		nil, // Backing.CloudSpec()
 		nil, // Provider.Open()
 		errors.NotSupportedf("spaces"), // ZonedNetworkingEnviron.SupportsSpaces()
 	)
@@ -191,6 +194,7 @@ func (s *SpacesSuite) TestSuppportsSpacesModelConfigError(c *gc.C) {
 func (s *SpacesSuite) TestSuppportsSpacesEnvironNewError(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil,                // Backing.ModelConfig()
+		nil,                // Backing.CloudSpec()
 		errors.New("boom"), // environs.New()
 	)
 
@@ -220,6 +224,7 @@ func (s *SpacesSuite) TestSuppportsSpacesWithoutSpaces(c *gc.C) {
 
 	apiservertesting.SharedStub.SetErrors(
 		nil,                // Backing.ModelConfig()
+		nil,                // Backing.CloudSpec()
 		nil,                // environs.New()
 		errors.New("boom"), // Backing.SupportsSpaces()
 	)

--- a/apiserver/common/networkingcommon/subnets_test.go
+++ b/apiserver/common/networkingcommon/subnets_test.go
@@ -96,6 +96,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesUpdates(c *gc.C) {
 	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
 		apiservertesting.BackingCall("AvailabilityZones"),
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.ZonedEnvironCall("AvailabilityZones"),
 		apiservertesting.BackingCall("SetAvailabilityZones", apiservertesting.ProviderInstance.Zones),
@@ -113,6 +114,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndSetFails(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.AvailabilityZones
 		nil, // Backing.ModelConfig
+		nil, // Backing.CloudSpec
 		nil, // Provider.Open
 		nil, // ZonedEnviron.AvailabilityZones
 		errors.NotSupportedf("setting"), // Backing.SetAvailabilityZones
@@ -129,6 +131,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndSetFails(c *gc.C) {
 	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
 		apiservertesting.BackingCall("AvailabilityZones"),
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.ZonedEnvironCall("AvailabilityZones"),
 		apiservertesting.BackingCall("SetAvailabilityZones", apiservertesting.ProviderInstance.Zones),
@@ -146,6 +149,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndFetchingZonesFails(c *gc
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.AvailabilityZones
 		nil, // Backing.ModelConfig
+		nil, // Backing.CloudSpec
 		nil, // Provider.Open
 		errors.NotValidf("foo"), // ZonedEnviron.AvailabilityZones
 	)
@@ -161,6 +165,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndFetchingZonesFails(c *gc
 	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
 		apiservertesting.BackingCall("AvailabilityZones"),
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.ZonedEnvironCall("AvailabilityZones"),
 	)
@@ -204,6 +209,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndOpenFails(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.AvailabilityZones
 		nil, // Backing.ModelConfig
+		nil, // Backing.CloudSpec
 		errors.NotValidf("config"), // Provider.Open
 	)
 
@@ -218,6 +224,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndOpenFails(c *gc.C) {
 	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
 		apiservertesting.BackingCall("AvailabilityZones"),
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 	)
 }
@@ -242,6 +249,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndZonesNotSupported(c *gc.
 	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
 		apiservertesting.BackingCall("AvailabilityZones"),
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 	)
 }
@@ -401,15 +409,18 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 
 		// caching subnets (2nd attepmt): fails
 		nil, // BackingInstance.ModelConfig (2nd call)
+		nil, // BackingInstance.CloudSpec (1st call)
 		errors.NotFoundf("provider"), // ProviderInstance.Open (1st call)
 
 		// caching subnets (3rd attempt): fails
 		nil, // BackingInstance.ModelConfig (3rd call)
+		nil, // BackingInstance.CloudSpec (2nd call)
 		nil, // ProviderInstance.Open (2nd call)
 		errors.NotFoundf("subnets"), // NetworkingEnvironInstance.Subnets (1st call)
 
 		// caching subnets (4th attempt): succeeds
 		nil, // BackingInstance.ModelConfig (4th call)
+		nil, // BackingInstance.CloudSpec (3rd call)
 		nil, // ProviderInstance.Open (3rd call)
 		nil, // NetworkingEnvironInstance.Subnets (2nd call)
 
@@ -519,15 +530,18 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 
 		// caching subnets (2nd attepmt): fails
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 
 		// caching subnets (3rd attempt): fails
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.NetworkingEnvironCall("Subnets", instance.UnknownId, []network.Id(nil)),
 
 		// caching subnets (4th attempt): succeeds
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.NetworkingEnvironCall("Subnets", instance.UnknownId, []network.Id(nil)),
 
@@ -567,6 +581,7 @@ func (s *SubnetsSuite) CheckAddSubnetsFails(
 	// These calls always happen.
 	expectedCalls := []apiservertesting.StubMethodCall{
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 	}
 
@@ -625,6 +640,7 @@ func (s *SubnetsSuite) CheckAddSubnetsFails(
 		// updateZones tries to constructs a ZonedEnviron with these calls.
 		zoneCalls := append([]apiservertesting.StubMethodCall{},
 			apiservertesting.BackingCall("ModelConfig"),
+			apiservertesting.BackingCall("CloudSpec"),
 			apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		)
 		// Receiver can differ according to envName, but

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -81,13 +81,11 @@ func NewControllerAPI(
 	environConfigGetter := stateenvirons.EnvironConfigGetter{st}
 	return &ControllerAPI{
 		ControllerConfigAPI: common.NewControllerConfig(st),
-		CloudSpecAPI: cloudspec.NewCloudSpecForModel(
-			st.ModelTag(), environConfigGetter.CloudSpec,
-		),
-		state:      st,
-		authorizer: authorizer,
-		apiUser:    apiUser,
-		resources:  resources,
+		CloudSpecAPI:        cloudspec.NewCloudSpec(environConfigGetter.CloudSpec, common.AuthFuncForTag(st.ModelTag())),
+		state:               st,
+		authorizer:          authorizer,
+		apiUser:             apiUser,
+		resources:           resources,
 	}, nil
 }
 

--- a/apiserver/firewaller/firewaller.go
+++ b/apiserver/firewaller/firewaller.go
@@ -95,7 +95,7 @@ func NewFirewallerAPI(
 	)
 
 	environConfigGetter := stateenvirons.EnvironConfigGetter{st}
-	cloudSpecAPI := cloudspec.NewCloudSpecForModel(st.ModelTag(), environConfigGetter.CloudSpec)
+	cloudSpecAPI := cloudspec.NewCloudSpec(environConfigGetter.CloudSpec, common.AuthFuncForTag(st.ModelTag()))
 
 	return &FirewallerAPI{
 		LifeGetter:           lifeGetter,

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -64,6 +64,10 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 		cloud: cloud.Cloud{
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
+			Regions: []cloud.Region{
+				{Name: "some-region"},
+				{Name: "qux"},
+			},
 		},
 		controllerModel: &mockModel{
 			owner: names.NewUserTag("admin@local"),
@@ -126,6 +130,7 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 		"IsControllerAdministrator",
 		"ModelUUID",
 		"ControllerModel",
+		"Cloud",
 		"CloudCredentials",
 		"ControllerConfig",
 		"ComposeNewModelConfig",
@@ -140,7 +145,7 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 	// We cannot predict the UUID, because it's generated,
 	// so we just extract it and ensure that it's not the
 	// same as the controller UUID.
-	newModelArgs := s.st.Calls()[6].Args[0].(state.ModelArgs)
+	newModelArgs := s.st.Calls()[7].Args[0].(state.ModelArgs)
 	uuid := newModelArgs.Config.UUID()
 	c.Assert(uuid, gc.Not(gc.Equals), s.st.controllerModel.cfg.UUID())
 
@@ -173,7 +178,7 @@ func (s *modelManagerSuite) TestCreateModelDefaultRegion(c *gc.C) {
 	_, err := s.api.CreateModel(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newModelArgs := s.st.Calls()[6].Args[0].(state.ModelArgs)
+	newModelArgs := s.st.Calls()[7].Args[0].(state.ModelArgs)
 	c.Assert(newModelArgs.CloudRegion, gc.Equals, "some-region")
 }
 
@@ -194,7 +199,7 @@ func (s *modelManagerSuite) testCreateModelDefaultCredentialAdmin(c *gc.C, owner
 	_, err := s.api.CreateModel(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newModelArgs := s.st.Calls()[6].Args[0].(state.ModelArgs)
+	newModelArgs := s.st.Calls()[7].Args[0].(state.ModelArgs)
 	c.Assert(newModelArgs.CloudCredential, gc.Equals, "some-credential")
 }
 
@@ -419,7 +424,7 @@ func (s *modelManagerStateSuite) TestCreateModelValidatesConfig(c *gc.C) {
 	args.Config["controller"] = "maybe"
 	_, err := s.modelmanager.CreateModel(args)
 	c.Assert(err, gc.ErrorMatches,
-		"failed to create config: provider validation failed: controller: expected bool, got string\\(\"maybe\"\\)",
+		"failed to create config: provider config preparation failed: controller: expected bool, got string\\(\"maybe\"\\)",
 	)
 }
 

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -117,7 +117,7 @@ func NewProvisionerAPI(st *state.State, resources facade.Resources, authorizer f
 		InstanceIdGetter:     common.NewInstanceIdGetter(st, getAuthFunc),
 		ToolsFinder:          common.NewToolsFinder(configGetter, st, urlGetter),
 		ToolsGetter:          common.NewToolsGetter(st, configGetter, st, urlGetter, getAuthOwner),
-		CloudSpecAPI:         cloudspec.NewCloudSpecForModel(st.ModelTag(), configGetter.CloudSpec),
+		CloudSpecAPI:         cloudspec.NewCloudSpec(configGetter.CloudSpec, common.AuthFuncForTag(st.ModelTag())),
 		st:                   st,
 		resources:            resources,
 		authorizer:           authorizer,

--- a/apiserver/spaces/spaces_test.go
+++ b/apiserver/spaces/spaces_test.go
@@ -121,6 +121,7 @@ func (s *SpacesSuite) checkAddSpaces(c *gc.C, p checkAddSpacesParams) {
 
 	baseCalls := []apiservertesting.StubMethodCall{
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.ZonedNetworkingEnvironCall("SupportsSpaces"),
 	}
@@ -163,6 +164,7 @@ func (s *SpacesSuite) TestAddSpacesManySubnets(c *gc.C) {
 func (s *SpacesSuite) TestAddSpacesAPIError(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.ModelConfig()
+		nil, // Backing.CloudSpec()
 		nil, // Provider.Open()
 		nil, // ZonedNetworkingEnviron.SupportsSpaces()
 		errors.AlreadyExistsf("space-foo"), // Backing.AddSpace()
@@ -269,6 +271,7 @@ func (s *SpacesSuite) TestListSpacesAllSpacesError(c *gc.C) {
 func (s *SpacesSuite) TestListSpacesSubnetsError(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.ModelConfig()
+		nil, // Backing.CloudSpec()
 		nil, // Provider.Open()
 		nil, // ZonedNetworkingEnviron.SupportsSpaces()
 		nil, // Backing.AllSpaces()
@@ -289,6 +292,7 @@ func (s *SpacesSuite) TestListSpacesSubnetsSingleSubnetError(c *gc.C) {
 	boom := errors.New("boom")
 	apiservertesting.SharedStub.SetErrors(
 		nil,  // Backing.ModelConfig()
+		nil,  // Backing.CloudSpec()
 		nil,  // Provider.Open()
 		nil,  // ZonedNetworkingEnviron.SupportsSpaces()
 		nil,  // Backing.AllSpaces()
@@ -320,6 +324,7 @@ func (s *SpacesSuite) TestCreateSpacesModelConfigError(c *gc.C) {
 func (s *SpacesSuite) TestCreateSpacesProviderOpenError(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil,                // Backing.ModelConfig()
+		nil,                // Backing.CloudSpec()
 		errors.New("boom"), // Provider.Open()
 	)
 
@@ -331,6 +336,7 @@ func (s *SpacesSuite) TestCreateSpacesProviderOpenError(c *gc.C) {
 func (s *SpacesSuite) TestCreateSpacesNotSupportedError(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.ModelConfig()
+		nil, // Backing.CloudSpec()
 		nil, // Provider.Open()
 		errors.NotSupportedf("spaces"), // ZonedNetworkingEnviron.SupportsSpaces()
 	)
@@ -343,6 +349,7 @@ func (s *SpacesSuite) TestCreateSpacesNotSupportedError(c *gc.C) {
 func (s *SpacesSuite) TestListSpacesNotSupportedError(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.ModelConfig()
+		nil, // Backing.CloudSpec()
 		nil, // Provider.Open
 		errors.NotSupportedf("spaces"), // ZonedNetworkingEnviron.SupportsSpaces()
 	)

--- a/apiserver/subnets/subnets_test.go
+++ b/apiserver/subnets/subnets_test.go
@@ -148,6 +148,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesUpdates(c *gc.C) {
 	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
 		apiservertesting.BackingCall("AvailabilityZones"),
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.ZonedEnvironCall("AvailabilityZones"),
 		apiservertesting.BackingCall("SetAvailabilityZones", apiservertesting.ProviderInstance.Zones),
@@ -159,6 +160,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndSetFails(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.AvailabilityZones
 		nil, // Backing.ModelConfig
+		nil, // Backing.CloudSpec
 		nil, // Provider.Open
 		nil, // ZonedEnviron.AvailabilityZones
 		errors.NotSupportedf("setting"), // Backing.SetAvailabilityZones
@@ -175,6 +177,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndSetFails(c *gc.C) {
 	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
 		apiservertesting.BackingCall("AvailabilityZones"),
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.ZonedEnvironCall("AvailabilityZones"),
 		apiservertesting.BackingCall("SetAvailabilityZones", apiservertesting.ProviderInstance.Zones),
@@ -186,6 +189,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndFetchingZonesFails(c *gc
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.AvailabilityZones
 		nil, // Backing.ModelConfig
+		nil, // Backing.CloudSpec
 		nil, // Provider.Open
 		errors.NotValidf("foo"), // ZonedEnviron.AvailabilityZones
 	)
@@ -201,6 +205,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndFetchingZonesFails(c *gc
 	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
 		apiservertesting.BackingCall("AvailabilityZones"),
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.ZonedEnvironCall("AvailabilityZones"),
 	)
@@ -232,6 +237,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndOpenFails(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil, // Backing.AvailabilityZones
 		nil, // Backing.ModelConfig
+		nil, // Backing.CloudSpec
 		errors.NotValidf("config"), // Provider.Open
 	)
 
@@ -246,6 +252,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndOpenFails(c *gc.C) {
 	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
 		apiservertesting.BackingCall("AvailabilityZones"),
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 	)
 }
@@ -265,6 +272,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndZonesNotSupported(c *gc.
 	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
 		apiservertesting.BackingCall("AvailabilityZones"),
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 	)
 }
@@ -453,15 +461,18 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 
 		// caching subnets (2nd attepmt): fails
 		nil, // BackingInstance.ModelConfig (2nd call)
+		nil, // BackingInstance.CloudSpec (1st call)
 		errors.NotFoundf("provider"), // ProviderInstance.Open (1st call)
 
 		// caching subnets (3rd attempt): fails
 		nil, // BackingInstance.ModelConfig (3rd call)
+		nil, // BackingInstance.CloudSpec (2nd call)
 		nil, // ProviderInstance.Open (2nd call)
 		errors.NotFoundf("subnets"), // NetworkingEnvironInstance.Subnets (1st call)
 
 		// caching subnets (4th attempt): succeeds
 		nil, // BackingInstance.ModelConfig (4th call)
+		nil, // BackingInstance.CloudSpec (3rd call)
 		nil, // ProviderInstance.Open (3rd call)
 		nil, // NetworkingEnvironInstance.Subnets (2nd call)
 
@@ -571,15 +582,18 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 
 		// caching subnets (2nd attepmt): fails
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 
 		// caching subnets (3rd attempt): fails
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.NetworkingEnvironCall("Subnets", instance.UnknownId, []network.Id(nil)),
 
 		// caching subnets (4th attempt): succeeds
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		apiservertesting.NetworkingEnvironCall("Subnets", instance.UnknownId, []network.Id(nil)),
 
@@ -619,6 +633,7 @@ func (s *SubnetsSuite) CheckAddSubnetsFails(
 	// These calls always happen.
 	expectedCalls := []apiservertesting.StubMethodCall{
 		apiservertesting.BackingCall("ModelConfig"),
+		apiservertesting.BackingCall("CloudSpec"),
 		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 	}
 
@@ -677,6 +692,7 @@ func (s *SubnetsSuite) CheckAddSubnetsFails(
 		// updateZones tries to constructs a ZonedEnviron with these calls.
 		zoneCalls := append([]apiservertesting.StubMethodCall{},
 			apiservertesting.BackingCall("ModelConfig"),
+			apiservertesting.BackingCall("CloudSpec"),
 			apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
 		)
 		// Receiver can differ according to envName, but

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
+	names "gopkg.in/juju/names.v2"
 )
 
 type StubNetwork struct {
@@ -433,7 +434,7 @@ func (sb *StubBacking) ModelConfig() (*config.Config, error) {
 	return sb.EnvConfig, nil
 }
 
-func (sb *StubBacking) CloudSpec() (environs.CloudSpec, error) {
+func (sb *StubBacking) CloudSpec(names.ModelTag) (environs.CloudSpec, error) {
 	sb.MethodCall(sb, "CloudSpec")
 	if err := sb.NextErr(); err != nil {
 		return environs.CloudSpec{}, err

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -260,7 +260,10 @@ func (c *restoreCommand) rebootstrap(ctx *cmd.Context, meta *params.BackupsMetad
 		return errors.Trace(err)
 	}
 
-	env, err := c.newEnvironFunc(environs.OpenParams{params.ModelConfig})
+	env, err := c.newEnvironFunc(environs.OpenParams{
+		Cloud:  params.Cloud,
+		Config: params.ModelConfig,
+	})
 	if err != nil {
 		return errors.Annotate(err, "opening environ for rebootstrapping")
 	}

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -163,7 +163,7 @@ func (c *restoreCommand) getRebootstrapParams(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	cfg, err := provider.BootstrapConfig(*params)
+	cfg, err := provider.PrepareConfig(*params)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -748,9 +748,17 @@ func (s *BootstrapSuite) TestAutoSyncLocalSource(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	cfg, err := modelcmd.NewGetBootstrapConfigFunc(s.store)("devcontroller")
+	bootstrapConfig, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(s.store)("devcontroller")
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.New(environs.OpenParams{cfg})
+	provider, err := environs.Provider(bootstrapConfig.CloudType)
+	c.Assert(err, jc.ErrorIsNil)
+	cfg, err := provider.BootstrapConfig(*params)
+	c.Assert(err, jc.ErrorIsNil)
+
+	env, err := environs.New(environs.OpenParams{
+		Cloud:  params.Cloud,
+		Config: cfg,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = env.PrepareForBootstrap(envtesting.BootstrapContext(c))
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -752,7 +752,7 @@ func (s *BootstrapSuite) TestAutoSyncLocalSource(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	provider, err := environs.Provider(bootstrapConfig.CloudType)
 	c.Assert(err, jc.ErrorIsNil)
-	cfg, err := provider.BootstrapConfig(*params)
+	cfg, err := provider.PrepareConfig(*params)
 	c.Assert(err, jc.ErrorIsNil)
 
 	env, err := environs.New(environs.OpenParams{

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -366,7 +366,7 @@ func (c *destroyCommandBase) getControllerEnvironFromStore(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	cfg, err := provider.BootstrapConfig(*params)
+	cfg, err := provider.PrepareConfig(*params)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -19,10 +19,11 @@ import (
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/cmd/modelcmd"
 	cmdtesting "github.com/juju/juju/cmd/testing"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
-	_ "github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
 )
 
@@ -49,6 +50,7 @@ type baseDestroySuite struct {
 // fakeDestroyAPI mocks out the controller API
 type fakeDestroyAPI struct {
 	gitjujutesting.Stub
+	cloud      environs.CloudSpec
 	env        map[string]interface{}
 	destroyAll bool
 	blocks     []params.ModelBlockInfo
@@ -59,6 +61,14 @@ type fakeDestroyAPI struct {
 func (f *fakeDestroyAPI) Close() error {
 	f.MethodCall(f, "Close")
 	return f.NextErr()
+}
+
+func (f *fakeDestroyAPI) CloudSpec(tag names.ModelTag) (environs.CloudSpec, error) {
+	f.MethodCall(f, "CloudSpec", tag)
+	if err := f.NextErr(); err != nil {
+		return environs.CloudSpec{}, err
+	}
+	return f.cloud, nil
 }
 
 func (f *fakeDestroyAPI) ModelConfig() (map[string]interface{}, error) {
@@ -132,6 +142,7 @@ func (s *baseDestroySuite) SetUpTest(c *gc.C) {
 	s.clientapi = &fakeDestroyAPIClient{}
 	owner := names.NewUserTag("owner")
 	s.api = &fakeDestroyAPI{
+		cloud:     dummy.SampleCloudSpec(),
 		envStatus: map[string]base.ModelStatus{},
 	}
 	s.apierror = nil

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/agentbootstrap"
 	agenttools "github.com/juju/juju/agent/tools"
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	agentcmd "github.com/juju/juju/cmd/jujud/agent"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
@@ -128,7 +129,30 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 	}
 
 	// Get the bootstrap machine's addresses from the provider.
-	env, err := environs.New(environs.OpenParams{args.ControllerModelConfig})
+	cloudEndpoint := args.ControllerCloud.Endpoint
+	cloudStorageEndpoint := args.ControllerCloud.StorageEndpoint
+	if args.ControllerCloudRegion != "" {
+		region, err := cloud.RegionByName(
+			args.ControllerCloud.Regions,
+			args.ControllerCloudRegion,
+		)
+		if err != nil {
+			return errors.Annotate(err, "getting cloud region")
+		}
+		cloudEndpoint = region.Endpoint
+		cloudStorageEndpoint = region.StorageEndpoint
+	}
+	env, err := environs.New(environs.OpenParams{
+		Cloud: environs.CloudSpec{
+			Type:            args.ControllerCloud.Type,
+			Name:            args.ControllerCloudName,
+			Region:          args.ControllerCloudRegion,
+			Endpoint:        cloudEndpoint,
+			StorageEndpoint: cloudStorageEndpoint,
+			Credential:      args.ControllerCloudCredential,
+		},
+		Config: args.ControllerModelConfig,
+	})
 	if err != nil {
 		return err
 	}

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -798,7 +798,7 @@ func (s *BootstrapSuite) makeTestModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	controllerCfg := testing.FakeControllerConfig()
 	controllerCfg["controller-uuid"] = cfg.UUID()
-	cfg, err = provider.BootstrapConfig(environs.BootstrapConfigParams{
+	cfg, err = provider.PrepareConfig(environs.PrepareConfigParams{
 		ControllerUUID: controllerCfg.ControllerUUID(),
 		Config:         cfg,
 	})

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -803,7 +803,10 @@ func (s *BootstrapSuite) makeTestModel(c *gc.C) {
 		Config:         cfg,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := provider.Open(environs.OpenParams{cfg})
+	env, err := provider.Open(environs.OpenParams{
+		Cloud:  dummy.SampleCloudSpec(),
+		Config: cfg,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = env.PrepareForBootstrap(nullContext())
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -342,7 +342,7 @@ func NewGetBootstrapConfigFunc(store jujuclient.ClientStore) func(string) (*conf
 
 // NewGetBootstrapConfigParamsFunc returns a function that, given a controller name,
 // returns the params needed to bootstrap a fresh copy of that controller in the given client store.
-func NewGetBootstrapConfigParamsFunc(store jujuclient.ClientStore) func(string) (*jujuclient.BootstrapConfig, *environs.BootstrapConfigParams, error) {
+func NewGetBootstrapConfigParamsFunc(store jujuclient.ClientStore) func(string) (*jujuclient.BootstrapConfig, *environs.PrepareConfigParams, error) {
 	return bootstrapConfigGetter{store}.getBootstrapConfigParams
 }
 
@@ -359,10 +359,10 @@ func (g bootstrapConfigGetter) getBootstrapConfig(controllerName string) (*confi
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return provider.BootstrapConfig(*params)
+	return provider.PrepareConfig(*params)
 }
 
-func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (*jujuclient.BootstrapConfig, *environs.BootstrapConfigParams, error) {
+func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (*jujuclient.BootstrapConfig, *environs.PrepareConfigParams, error) {
 	if _, err := g.ClientStore.ControllerByName(controllerName); err != nil {
 		return nil, nil, errors.Annotate(err, "resolving controller name")
 	}
@@ -410,7 +410,7 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	return bootstrapConfig, &environs.BootstrapConfigParams{
+	return bootstrapConfig, &environs.PrepareConfigParams{
 		controllerDetails.ControllerUUID,
 		environs.CloudSpec{
 			bootstrapConfig.CloudType,

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -39,7 +39,7 @@ func (c *imageMetadataCommandBase) prepare(context *cmd.Context) (environs.Envir
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	cfg, err := provider.BootstrapConfig(*params)
+	cfg, err := provider.PrepareConfig(*params)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/controller/modelmanager/createmodel.go
+++ b/controller/modelmanager/createmodel.go
@@ -20,19 +20,15 @@ var (
 	logger = loggo.GetLogger("juju.controller.modelmanager")
 )
 
-const (
-	// IsAdmin is used when generating a model config for an admin user.
-	IsAdmin = true
-
-	// IsNotAdmin is used when generating a model config for a non admin user.
-	IsNotAdmin = false
-)
-
 // ModelConfigCreator provides a method of creating a new model config.
 //
 // The zero value of ModelConfigCreator is usable with the limitations
 // noted on each struct field.
 type ModelConfigCreator struct {
+	// Provider will be used to obtain EnvironProviders for preparing
+	// and validating configuration.
+	Provider func(string) (environs.EnvironProvider, error)
+
 	// FindTools, if non-nil, will be used to validate the agent-version
 	// value in NewModelConfig if it differs from the base configuration.
 	//
@@ -51,13 +47,17 @@ type ModelConfigCreator struct {
 //
 // The config will be validated with the provider before being returned.
 func (c ModelConfigCreator) NewModelConfig(
-	isAdmin bool,
+	cloud environs.CloudSpec,
 	controllerUUID string,
 	base *config.Config,
 	attrs map[string]interface{},
 ) (*config.Config, error) {
 
 	if err := c.checkVersion(base, attrs); err != nil {
+		return nil, errors.Trace(err)
+	}
+	provider, err := c.Provider(cloud.Type)
+	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -68,7 +68,7 @@ func (c ModelConfigCreator) NewModelConfig(
 	// However, before we can create a valid config, we need to make sure
 	// we copy across fields from the main config that aren't there.
 	baseAttrs := base.AllAttrs()
-	restrictedFields, err := RestrictedProviderFields(base.Type())
+	restrictedFields, err := RestrictedProviderFields(provider)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -89,7 +89,7 @@ func (c ModelConfigCreator) NewModelConfig(
 		}
 		attrs[config.UUIDKey] = uuid.String()
 	}
-	cfg, err := finalizeConfig(isAdmin, controllerUUID, base, attrs)
+	cfg, err := finalizeConfig(provider, cloud, controllerUUID, attrs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -172,11 +172,7 @@ func (c *ModelConfigCreator) checkVersion(base *config.Config, attrs map[string]
 // specific config, since models should be independent of each other; and
 // anything that should not change across models should be in the controller
 // config.
-func RestrictedProviderFields(providerType string) ([]string, error) {
-	provider, err := environs.Provider(providerType)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+func RestrictedProviderFields(provider environs.EnvironProvider) ([]string, error) {
 	var fields []string
 	// For now, all models in a controller must be of the same type.
 	fields = append(fields, config.TypeKey)
@@ -184,27 +180,29 @@ func RestrictedProviderFields(providerType string) ([]string, error) {
 	return fields, nil
 }
 
-// finalizeConfig creates the config object from attributes, calls
-// PrepareForCreateEnvironment, and then finally validates the config
-// before returning it.
-func finalizeConfig(isAdmin bool, controllerUUID string, controllerModelCfg *config.Config, attrs map[string]interface{}) (*config.Config, error) {
-	provider, err := environs.Provider(controllerModelCfg.Type())
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
+// finalizeConfig creates the config object from attributes,
+// and calls EnvironProvider.PrepareConfig.
+func finalizeConfig(
+	provider environs.EnvironProvider,
+	cloud environs.CloudSpec,
+	controllerUUID string,
+	attrs map[string]interface{},
+) (*config.Config, error) {
 	cfg, err := config.New(config.UseDefaults, attrs)
 	if err != nil {
 		return nil, errors.Annotate(err, "creating config from values failed")
 	}
-
-	cfg, err = provider.PrepareForCreateEnvironment(controllerUUID, cfg)
+	cfg, err = provider.PrepareConfig(environs.PrepareConfigParams{
+		ControllerUUID: controllerUUID,
+		Cloud:          cloud,
+		Config:         cfg,
+	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotate(err, "provider config preparation failed")
 	}
 	cfg, err = provider.Validate(cfg, nil)
 	if err != nil {
-		return nil, errors.Annotate(err, "provider validation failed")
+		return nil, errors.Annotate(err, "provider config validation failed")
 	}
 	return cfg, nil
 }

--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -29,6 +29,7 @@ import (
 
 type ModelConfigCreatorSuite struct {
 	coretesting.BaseSuite
+	fake       fakeProvider
 	creator    modelmanager.ModelConfigCreator
 	baseConfig *config.Config
 }
@@ -37,7 +38,17 @@ var _ = gc.Suite(&ModelConfigCreatorSuite{})
 
 func (s *ModelConfigCreatorSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.creator = modelmanager.ModelConfigCreator{}
+	s.fake = fakeProvider{
+		restrictedConfigAttributes: []string{"restricted"},
+	}
+	s.creator = modelmanager.ModelConfigCreator{
+		Provider: func(provider string) (environs.EnvironProvider, error) {
+			if provider != "fake" {
+				return nil, errors.Errorf("expected fake, got %s", provider)
+			}
+			return &s.fake, nil
+		},
+	}
 	baseConfig, err := config.New(
 		config.UseDefaults,
 		coretesting.FakeConfig().Merge(coretesting.Attrs{
@@ -53,15 +64,11 @@ func (s *ModelConfigCreatorSuite) SetUpTest(c *gc.C) {
 	baseConfig, err = baseConfig.Remove(controller.ControllerOnlyConfigAttributes)
 	c.Assert(err, jc.ErrorIsNil)
 	s.baseConfig = baseConfig
-	fake.Reset()
 }
 
 func (s *ModelConfigCreatorSuite) newModelConfig(attrs map[string]interface{}) (*config.Config, error) {
-	return s.creator.NewModelConfig(modelmanager.IsNotAdmin, coretesting.ModelTag.Id(), s.baseConfig, attrs)
-}
-
-func (s *ModelConfigCreatorSuite) newModelConfigAdmin(attrs map[string]interface{}) (*config.Config, error) {
-	return s.creator.NewModelConfig(modelmanager.IsAdmin, coretesting.ModelTag.Id(), s.baseConfig, attrs)
+	cloudSpec := environs.CloudSpec{Type: "fake"}
+	return s.creator.NewModelConfig(cloudSpec, coretesting.ModelTag.Id(), s.baseConfig, attrs)
 }
 
 func (s *ModelConfigCreatorSuite) TestCreateModelValidatesConfig(c *gc.C) {
@@ -80,53 +87,12 @@ func (s *ModelConfigCreatorSuite) TestCreateModelValidatesConfig(c *gc.C) {
 	expected["uuid"] = newModelUUID
 	c.Assert(cfg.AllAttrs(), jc.DeepEquals, expected)
 
-	fake.Stub.CheckCallNames(c,
+	s.fake.Stub.CheckCallNames(c,
 		"RestrictedConfigAttributes",
-		"PrepareForCreateEnvironment",
+		"PrepareConfig",
 		"Validate",
 	)
-	validateCall := fake.Stub.Calls()[2]
-	c.Assert(validateCall.Args, gc.HasLen, 2)
-	c.Assert(validateCall.Args[0], gc.Equals, cfg)
-	c.Assert(validateCall.Args[1], gc.IsNil)
-}
-
-func (s *ModelConfigCreatorSuite) TestCreateModelForAdminUserPrefersUserSecrets(c *gc.C) {
-	var err error
-	s.baseConfig, err = s.baseConfig.Apply(coretesting.Attrs{
-		"username": "user",
-		"password": "password",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	newModelUUID := utils.MustNewUUID().String()
-	newAttrs := coretesting.Attrs{
-		"name":       "new-model",
-		"additional": "value",
-		"uuid":       newModelUUID,
-		"username":   "anotheruser",
-		"password":   "anotherpassword",
-	}
-	cfg, err := s.newModelConfigAdmin(newAttrs)
-	c.Assert(err, jc.ErrorIsNil)
-	expectedCfg, err := config.New(config.UseDefaults, newAttrs)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// TODO(wallyworld) - we need to separate controller and model schemas
-	// Remove any remaining controller attributes from the env config.
-	expectedCfg, err = expectedCfg.Remove(controller.ControllerOnlyConfigAttributes)
-	c.Assert(err, jc.ErrorIsNil)
-
-	expected := expectedCfg.AllAttrs()
-	c.Assert(expected["username"], gc.Equals, "anotheruser")
-	c.Assert(expected["password"], gc.Equals, "anotherpassword")
-	c.Assert(cfg.AllAttrs(), jc.DeepEquals, expected)
-
-	fake.Stub.CheckCallNames(c,
-		"RestrictedConfigAttributes",
-		"PrepareForCreateEnvironment",
-		"Validate",
-	)
-	validateCall := fake.Stub.Calls()[2]
+	validateCall := s.fake.Stub.Calls()[2]
 	c.Assert(validateCall.Args, gc.HasLen, 2)
 	c.Assert(validateCall.Args[0], gc.Equals, cfg)
 	c.Assert(validateCall.Args[1], gc.IsNil)
@@ -275,7 +241,9 @@ func (*RestrictedProviderFieldsSuite) TestRestrictedProviderFields(c *gc.C) {
 		},
 	}} {
 		c.Logf("%d: %s provider", i, test.provider)
-		fields, err := modelmanager.RestrictedProviderFields(test.provider)
+		provider, err := environs.Provider(test.provider)
+		c.Check(err, jc.ErrorIsNil)
+		fields, err := modelmanager.RestrictedProviderFields(provider)
 		c.Check(err, jc.ErrorIsNil)
 		c.Check(fields, jc.SameContents, test.expected)
 	}
@@ -285,11 +253,6 @@ type fakeProvider struct {
 	testing.Stub
 	environs.EnvironProvider
 	restrictedConfigAttributes []string
-}
-
-func (p *fakeProvider) Reset() {
-	p.Stub.ResetCalls()
-	p.restrictedConfigAttributes = []string{"restricted"}
 }
 
 func (p *fakeProvider) RestrictedConfigAttributes() []string {
@@ -302,9 +265,9 @@ func (p *fakeProvider) Validate(cfg, old *config.Config) (*config.Config, error)
 	return cfg, p.NextErr()
 }
 
-func (p *fakeProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
-	p.MethodCall(p, "PrepareForCreateEnvironment", controllerUUID, cfg)
-	return cfg, p.NextErr()
+func (p *fakeProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
+	p.MethodCall(p, "PrepareConfig", args)
+	return args.Config, p.NextErr()
 }
 
 func (p *fakeProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
@@ -324,11 +287,4 @@ func (p *fakeProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSc
 
 func (p *fakeProvider) DetectCredentials() (*cloud.CloudCredential, error) {
 	return nil, errors.NotFoundf("credentials")
-}
-
-var fake fakeProvider
-
-func init() {
-	fake.Reset()
-	environs.RegisterProvider("fake", &fake)
 }

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -148,7 +148,10 @@ func prepare(
 	if err != nil {
 		return nil, details, errors.Trace(err)
 	}
-	env, err := p.Open(environs.OpenParams{cfg})
+	env, err := p.Open(environs.OpenParams{
+		Cloud:  args.Cloud,
+		Config: cfg,
+	})
 	if err != nil {
 		return nil, details, errors.Trace(err)
 	}

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -142,7 +142,7 @@ func prepare(
 		return nil, details, errors.Trace(err)
 	}
 
-	cfg, err = p.BootstrapConfig(environs.BootstrapConfigParams{
+	cfg, err = p.PrepareConfig(environs.PrepareConfigParams{
 		args.ControllerConfig.ControllerUUID(), args.Cloud, cfg,
 	})
 	if err != nil {

--- a/environs/environ.go
+++ b/environs/environ.go
@@ -5,6 +5,7 @@ package environs
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/environs/config"
 )
@@ -12,6 +13,7 @@ import (
 // EnvironConfigGetter exposes a model configuration to its clients.
 type EnvironConfigGetter interface {
 	ModelConfig() (*config.Config, error)
+	CloudSpec(names.ModelTag) (CloudSpec, error)
 }
 
 // NewEnvironFunc is the type of a function that, given a model config,
@@ -25,7 +27,14 @@ func GetEnviron(st EnvironConfigGetter, newEnviron NewEnvironFunc) (Environ, err
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	env, err := newEnviron(OpenParams{modelConfig})
+	cloudSpec, err := st.CloudSpec(names.NewModelTag(modelConfig.UUID()))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	env, err := newEnviron(OpenParams{
+		Cloud:  cloudSpec,
+		Config: modelConfig,
+	})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/environs/environ_test.go
+++ b/environs/environ_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state/stateenvirons"
 )
 
 type environSuite struct {
@@ -18,7 +19,7 @@ type environSuite struct {
 var _ = gc.Suite(&environSuite{})
 
 func (s *environSuite) TestGetEnvironment(c *gc.C) {
-	env, err := environs.GetEnviron(s.State, environs.New)
+	env, err := stateenvirons.GetNewEnvironFunc(environs.New)(s.State)
 	c.Assert(err, jc.ErrorIsNil)
 	config, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -50,6 +50,9 @@ type EnvironProvider interface {
 
 // OpenParams contains the parameters for EnvironProvider.Open.
 type OpenParams struct {
+	// Cloud is the cloud specification to use to connect to the cloud.
+	Cloud CloudSpec
+
 	// Config is the base configuration for the provider.
 	Config *config.Config
 }

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -49,7 +49,10 @@ type Tests struct {
 
 // Open opens an instance of the testing environment.
 func (t *Tests) Open(c *gc.C, cfg *config.Config) environs.Environ {
-	e, err := environs.New(environs.OpenParams{cfg})
+	e, err := environs.New(environs.OpenParams{
+		Cloud:  t.CloudSpec(),
+		Config: cfg,
+	})
 	c.Assert(err, gc.IsNil, gc.Commentf("opening environ %#v", cfg.AllAttrs()))
 	c.Assert(e, gc.NotNil)
 	return e

--- a/environs/open.go
+++ b/environs/open.go
@@ -14,7 +14,7 @@ const AdminUser = "admin@local"
 
 // New returns a new environment based on the provided configuration.
 func New(args OpenParams) (Environ, error) {
-	p, err := Provider(args.Config.Type())
+	p, err := Provider(args.Cloud.Type)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -111,13 +111,11 @@ func (s *OpenSuite) TestUpdateEnvInfo(c *gc.C) {
 }
 
 func (*OpenSuite) TestNewUnknownEnviron(c *gc.C) {
-	cfg, err := config.New(config.NoDefaults, dummy.SampleConfig().Merge(
-		testing.Attrs{
-			"type": "wondercloud",
+	env, err := environs.New(environs.OpenParams{
+		Cloud: environs.CloudSpec{
+			Type: "wondercloud",
 		},
-	))
-	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.New(environs.OpenParams{cfg})
+	})
 	c.Assert(err, gc.ErrorMatches, "no registered provider for.*")
 	c.Assert(env, gc.IsNil)
 }
@@ -130,7 +128,10 @@ func (*OpenSuite) TestNew(c *gc.C) {
 		},
 	))
 	c.Assert(err, jc.ErrorIsNil)
-	e, err := environs.New(environs.OpenParams{cfg})
+	e, err := environs.New(environs.OpenParams{
+		Cloud:  dummy.SampleCloudSpec(),
+		Config: cfg,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = e.ControllerInstances("uuid")
 	c.Assert(err, gc.ErrorMatches, "model is not prepared")

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -318,8 +318,10 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 			Endpoint:        cloudSpec.Endpoint,
 			StorageEndpoint: cloudSpec.StorageEndpoint,
 		},
-		AdminSecret:  AdminSecret,
-		CAPrivateKey: testing.CAKey,
+		CloudCredential:     cloudSpec.Credential,
+		CloudCredentialName: "cred",
+		AdminSecret:         AdminSecret,
+		CAPrivateKey:        testing.CAKey,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -306,7 +306,10 @@ func openEnviron(
 	// Opening the environment should not incur network communication,
 	// so we don't set s.sender until after opening.
 	cfg := makeTestModelConfig(c, attrs...)
-	env, err := provider.Open(environs.OpenParams{cfg})
+	env, err := provider.Open(environs.OpenParams{
+		Cloud:  fakeCloudSpec(),
+		Config: cfg,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Force an explicit refresh of the access token, so it isn't done
@@ -330,19 +333,26 @@ func prepareForBootstrap(
 	*sender = azuretesting.Senders{tokenRefreshSender()}
 	cfg, err := provider.BootstrapConfig(environs.BootstrapConfigParams{
 		Config: cfg,
-		Cloud: environs.CloudSpec{
-			Region:          "westus",
-			Endpoint:        "https://management.azure.com",
-			StorageEndpoint: "https://core.windows.net",
-			Credential:      fakeUserPassCredential(),
-		},
+		Cloud:  fakeCloudSpec(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := provider.Open(environs.OpenParams{cfg})
+	env, err := provider.Open(environs.OpenParams{
+		Cloud:  fakeCloudSpec(),
+		Config: cfg,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = env.PrepareForBootstrap(ctx)
 	c.Assert(err, jc.ErrorIsNil)
 	return env
+}
+
+func fakeCloudSpec() environs.CloudSpec {
+	return environs.CloudSpec{
+		Region:          "westus",
+		Endpoint:        "https://management.azure.com",
+		StorageEndpoint: "https://core.windows.net",
+		Credential:      fakeUserPassCredential(),
+	}
 }
 
 func tokenRefreshSender() *azuretesting.MockSender {

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -331,7 +331,7 @@ func prepareForBootstrap(
 	// so we don't set s.sender until after opening.
 	cfg := makeTestModelConfig(c, attrs...)
 	*sender = azuretesting.Senders{tokenRefreshSender()}
-	cfg, err := provider.BootstrapConfig(environs.BootstrapConfigParams{
+	cfg, err := provider.PrepareConfig(environs.PrepareConfigParams{
 		Config: cfg,
 		Cloud:  fakeCloudSpec(),
 	})

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -92,20 +92,8 @@ func (prov *azureEnvironProvider) RestrictedConfigAttributes() []string {
 	}
 }
 
-// PrepareForCreateEnvironment is specified in the EnvironProvider interface.
-func (prov *azureEnvironProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
-	env, err := newEnviron(prov, cfg)
-	if err != nil {
-		return nil, errors.Annotate(err, "opening model")
-	}
-	if err := env.initResourceGroup(controllerUUID); err != nil {
-		return nil, errors.Annotate(err, "initializing resource group")
-	}
-	return env.Config(), nil
-}
-
-// BootstrapConfig is specified in the EnvironProvider interface.
-func (prov *azureEnvironProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
+// PrepareConfig is specified in the EnvironProvider interface.
+func (prov *azureEnvironProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	attrs := map[string]interface{}{
 		configAttrLocation:        args.Cloud.Region,
 		configAttrEndpoint:        args.Cloud.Endpoint,

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -53,10 +53,10 @@ func fakeUserPassCredential() *cloud.Credential {
 	return &cred
 }
 
-func (s *environProviderSuite) TestBootstrapConfig(c *gc.C) {
+func (s *environProviderSuite) TestPrepareConfig(c *gc.C) {
 	cfg := makeTestModelConfig(c)
 	s.sender = azuretesting.Senders{tokenRefreshSender()}
-	cfg, err := s.provider.BootstrapConfig(environs.BootstrapConfigParams{
+	cfg, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
 		Config: cfg,
 		Cloud: environs.CloudSpec{
 			Region:          "westus",

--- a/provider/cloudsigma/config_test.go
+++ b/provider/cloudsigma/config_test.go
@@ -30,6 +30,15 @@ func validAttrs() testing.Attrs {
 	})
 }
 
+func fakeCloudSpec() environs.CloudSpec {
+	return environs.CloudSpec{
+		Type:     "cloudsigma",
+		Name:     "cloudsigma",
+		Region:   "zrh",
+		Endpoint: "https://0.1.2.3:2000/api/2.0/",
+	}
+}
+
 type configSuite struct {
 	testing.BaseSuite
 }
@@ -91,7 +100,7 @@ func (s *configSuite) TestNewModelConfig(c *gc.C) {
 		c.Logf("test %d: %s", i, test.info)
 		attrs := validAttrs().Merge(test.insert).Delete(test.remove...)
 		testConfig := newConfig(c, attrs)
-		environ, err := environs.New(environs.OpenParams{testConfig})
+		environ, err := environs.New(environs.OpenParams{fakeCloudSpec(), testConfig})
 		if test.err == "" {
 			c.Check(err, gc.IsNil)
 			attrs := environ.Config().AllAttrs()
@@ -177,7 +186,7 @@ func (s *configSuite) TestSetConfig(c *gc.C) {
 	baseConfig := newConfig(c, validAttrs())
 	for i, test := range changeConfigTests {
 		c.Logf("test %d: %s", i, test.info)
-		environ, err := environs.New(environs.OpenParams{baseConfig})
+		environ, err := environs.New(environs.OpenParams{fakeCloudSpec(), baseConfig})
 		c.Assert(err, gc.IsNil)
 		attrs := validAttrs().Merge(test.insert).Delete(test.remove...)
 		testConfig := newConfig(c, attrs)

--- a/provider/cloudsigma/environ.go
+++ b/provider/cloudsigma/environ.go
@@ -78,9 +78,14 @@ func (env *environ) Config() *config.Config {
 	return env.ecfg.Config
 }
 
-// PrepareForBootstrap is defined by Environ.
+// PrepareForBootstrap is part of the Environ interface.
 func (env *environ) PrepareForBootstrap(ctx environs.BootstrapContext) error {
 	logger.Infof("preparing model %q", env.name)
+	return nil
+}
+
+// Create is part of the Environ interface.
+func (env *environ) Create(environs.CreateParams) error {
 	return nil
 }
 

--- a/provider/cloudsigma/environ_test.go
+++ b/provider/cloudsigma/environ_test.go
@@ -46,7 +46,10 @@ func (s *environSuite) TestBase(c *gc.C) {
 	})
 
 	baseConfig := newConfig(c, validAttrs().Merge(testing.Attrs{"name": "testname"}))
-	env, err := environs.New(environs.OpenParams{baseConfig})
+	env, err := environs.New(environs.OpenParams{
+		Cloud:  fakeCloudSpec(),
+		Config: baseConfig,
+	})
 	c.Assert(err, gc.IsNil)
 	env.(*environ).supportedArchitectures = []string{arch.AMD64}
 
@@ -89,7 +92,10 @@ func (s *environSuite) TestUnsupportedConstraints(c *gc.C) {
 	})
 
 	baseConfig := newConfig(c, validAttrs().Merge(testing.Attrs{"name": "testname"}))
-	env, err := environs.New(environs.OpenParams{baseConfig})
+	env, err := environs.New(environs.OpenParams{
+		Cloud:  fakeCloudSpec(),
+		Config: baseConfig,
+	})
 	c.Assert(err, gc.IsNil)
 	env.(*environ).supportedArchitectures = []string{arch.AMD64}
 

--- a/provider/cloudsigma/environinstance_test.go
+++ b/provider/cloudsigma/environinstance_test.go
@@ -75,7 +75,10 @@ func (s *environInstanceSuite) createEnviron(c *gc.C, cfg *config.Config) enviro
 	if cfg == nil {
 		cfg = s.baseConfig
 	}
-	environ, err := environs.New(environs.OpenParams{cfg})
+	environ, err := environs.New(environs.OpenParams{
+		Cloud:  fakeCloudSpec(),
+		Config: cfg,
+	})
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(environ, gc.NotNil)

--- a/provider/cloudsigma/provider.go
+++ b/provider/cloudsigma/provider.go
@@ -73,17 +73,8 @@ func (environProvider) RestrictedConfigAttributes() []string {
 	return []string{"region"}
 }
 
-// PrepareForCreateEnvironment prepares an environment for creation. Any
-// additional configuration attributes are added to the config passed in
-// and returned.  This allows providers to add additional required config
-// for new environments that may be created in an existing juju server.
-func (environProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
-	// Not even sure if this will ever make sense.
-	return nil, errors.NotImplementedf("PrepareForCreateEnvironment")
-}
-
-// BootstrapConfig is defined by EnvironProvider.
-func (environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
+// PrepareConfig is defined by EnvironProvider.
+func (environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	cfg := args.Config
 	switch authType := args.Cloud.Credential.AuthType(); authType {
 	case cloud.UserPassAuthType:

--- a/provider/ec2/config_test.go
+++ b/provider/ec2/config_test.go
@@ -62,13 +62,21 @@ type configTest struct {
 type attrs map[string]interface{}
 
 func (t configTest) check(c *gc.C) {
+	cloudSpec := environs.CloudSpec{
+		Type:   "ec2",
+		Name:   "ec2test",
+		Region: "us-east-1",
+	}
 	attrs := testing.FakeConfig().Merge(testing.Attrs{
 		"type":   "ec2",
 		"region": "us-east-1",
 	}).Merge(t.config)
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	e, err := environs.New(environs.OpenParams{cfg})
+	e, err := environs.New(environs.OpenParams{
+		Cloud:  cloudSpec,
+		Config: cfg,
+	})
 	if t.change != nil {
 		c.Assert(err, jc.ErrorIsNil)
 

--- a/provider/ec2/config_test.go
+++ b/provider/ec2/config_test.go
@@ -431,7 +431,7 @@ func (s *ConfigSuite) TestMissingAuth(c *gc.C) {
 	test.check(c)
 }
 
-func (s *ConfigSuite) TestBootstrapConfigSetsDefaultBlockSource(c *gc.C) {
+func (s *ConfigSuite) TestPrepareConfigSetsDefaultBlockSource(c *gc.C) {
 	s.PatchValue(&verifyCredentials, func(*environ) error { return nil })
 	attrs := testing.FakeConfig().Merge(testing.Attrs{
 		"type": "ec2",
@@ -446,7 +446,7 @@ func (s *ConfigSuite) TestBootstrapConfigSetsDefaultBlockSource(c *gc.C) {
 			"secret-key": "y",
 		},
 	)
-	cfg, err = providerInstance.BootstrapConfig(environs.BootstrapConfigParams{
+	cfg, err = providerInstance.PrepareConfig(environs.PrepareConfigParams{
 		Config: cfg,
 		Cloud: environs.CloudSpec{
 			Type:       "ec2",
@@ -475,7 +475,7 @@ func (s *ConfigSuite) TestPrepareSetsDefaultBlockSource(c *gc.C) {
 			"secret-key": "y",
 		},
 	)
-	cfg, err := providerInstance.BootstrapConfig(environs.BootstrapConfigParams{
+	cfg, err := providerInstance.PrepareConfig(environs.PrepareConfigParams{
 		Config: config,
 		Cloud: environs.CloudSpec{
 			Type:       "ec2",

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -617,7 +617,10 @@ func (t *localServerSuite) TestDestroyHostedModelDeleteSecurityGroupInsistentlyE
 
 	cfg, err := env.Config().Apply(map[string]interface{}{"controller-uuid": "7e386e08-cba7-44a4-a76e-7c1633584210"})
 	c.Assert(err, jc.ErrorIsNil)
-	env, err = environs.New(environs.OpenParams{cfg})
+	env, err = environs.New(environs.OpenParams{
+		Cloud:  t.CloudSpec(),
+		Config: cfg,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	msg := "destroy security group error"
@@ -640,7 +643,7 @@ func (t *localServerSuite) TestDestroyControllerDestroysHostedModelResources(c *
 		"firewall-mode": "global",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.New(environs.OpenParams{cfg})
+	env, err := environs.New(environs.OpenParams{t.CloudSpec(), cfg})
 	c.Assert(err, jc.ErrorIsNil)
 	inst, _ := testing.AssertStartInstance(c, env, t.ControllerUUID, "0")
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -32,20 +32,6 @@ func (p environProvider) RestrictedConfigAttributes() []string {
 	return []string{"region", "vpc-id-force"}
 }
 
-// PrepareForCreateEnvironment is specified in the EnvironProvider interface.
-func (p environProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
-	apiClient, _, ecfg, err := awsClients(cfg)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	modelName := cfg.Name()
-	vpcID := ecfg.vpcID()
-	if err := validateModelVPC(apiClient, modelName, vpcID); err != nil {
-		return nil, errors.Trace(err)
-	}
-	return cfg, nil
-}
-
 // Open is specified in the EnvironProvider interface.
 func (p environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
 	logger.Infof("opening model %q", args.Config.Name())
@@ -58,8 +44,8 @@ func (p environProvider) Open(args environs.OpenParams) (environs.Environ, error
 	return e, nil
 }
 
-// BootstrapConfig is specified in the EnvironProvider interface.
-func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
+// PrepareConfig is specified in the EnvironProvider interface.
+func (p environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	// Add credentials to the configuration.
 	attrs := map[string]interface{}{
 		"region": args.Cloud.Region,
@@ -86,7 +72,6 @@ func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
 	return cfg, nil
 }
 

--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -152,6 +152,14 @@ func (env *environ) PrepareForBootstrap(ctx environs.BootstrapContext) error {
 	return nil
 }
 
+// Create implements environs.Environ.
+func (env *environ) Create(environs.CreateParams) error {
+	if err := env.gce.VerifyCredentials(); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
 // Bootstrap creates a new instance, chosing the series and arch out of
 // available tools. The series and arch are returned along with a func
 // that must be called to finalize the bootstrap process by transferring

--- a/provider/gce/provider.go
+++ b/provider/gce/provider.go
@@ -24,8 +24,8 @@ func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) 
 	return env, errors.Trace(err)
 }
 
-// BootstrapConfig implements environs.EnvironProvider.
-func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
+// PrepareConfig implements environs.EnvironProvider.
+func (p environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	// Add credentials to the configuration.
 	cfg := args.Config
 	switch authType := args.Cloud.Credential.AuthType(); authType {
@@ -62,8 +62,7 @@ func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
-	return p.PrepareForCreateEnvironment(args.ControllerUUID, cfg)
+	return configWithDefaults(cfg)
 }
 
 // Schema returns the configuration schema for an environment.
@@ -73,11 +72,6 @@ func (environProvider) Schema() environschema.Fields {
 		panic(err)
 	}
 	return fields
-}
-
-// PrepareForCreateEnvironment is specified in the EnvironProvider interface.
-func (p environProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
-	return configWithDefaults(cfg)
 }
 
 // UpgradeModelConfig is specified in the ModelConfigUpgrader interface.

--- a/provider/gce/provider_test.go
+++ b/provider/gce/provider_test.go
@@ -42,8 +42,8 @@ func (s *providerSuite) TestOpen(c *gc.C) {
 	c.Assert(envConfig.Name(), gc.Equals, "testenv")
 }
 
-func (s *providerSuite) TestBootstrapConfig(c *gc.C) {
-	cfg, err := s.provider.BootstrapConfig(environs.BootstrapConfigParams{
+func (s *providerSuite) TestPrepareConfig(c *gc.C) {
+	cfg, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
 		Config: s.Config,
 		Cloud:  makeTestCloudSpec(),
 	})

--- a/provider/gce/provider_test.go
+++ b/provider/gce/provider_test.go
@@ -7,7 +7,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/gce"
 )
@@ -33,7 +32,10 @@ func (s *providerSuite) TestRegistered(c *gc.C) {
 }
 
 func (s *providerSuite) TestOpen(c *gc.C) {
-	env, err := s.provider.Open(environs.OpenParams{s.Config})
+	env, err := s.provider.Open(environs.OpenParams{
+		Cloud:  makeTestCloudSpec(),
+		Config: s.Config,
+	})
 	c.Check(err, jc.ErrorIsNil)
 
 	envConfig := env.Config()
@@ -41,20 +43,9 @@ func (s *providerSuite) TestOpen(c *gc.C) {
 }
 
 func (s *providerSuite) TestBootstrapConfig(c *gc.C) {
-	credential := cloud.NewCredential(
-		cloud.OAuth2AuthType,
-		map[string]string{
-			"project-id":   "x",
-			"client-id":    "y",
-			"client-email": "zz@example.com",
-			"private-key":  "why",
-		},
-	)
 	cfg, err := s.provider.BootstrapConfig(environs.BootstrapConfigParams{
 		Config: s.Config,
-		Cloud: environs.CloudSpec{
-			Credential: &credential,
-		},
+		Cloud:  makeTestCloudSpec(),
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(cfg, gc.NotNil)

--- a/provider/joyent/config_test.go
+++ b/provider/joyent/config_test.go
@@ -274,12 +274,12 @@ var bootstrapConfigTests = []struct {
 	expect: validAttrs(),
 }}
 
-func (s *ConfigSuite) TestBootstrapConfig(c *gc.C) {
+func (s *ConfigSuite) TestPrepareConfig(c *gc.C) {
 	for i, test := range bootstrapConfigTests {
 		c.Logf("test %d: %s", i, test.info)
 		attrs := validAttrs().Merge(test.insert).Delete(test.remove...)
 		testConfig := newConfig(c, attrs)
-		preparedConfig, err := jp.Provider.BootstrapConfig(environs.BootstrapConfigParams{
+		preparedConfig, err := jp.Provider.PrepareConfig(environs.PrepareConfigParams{
 			Config: testConfig,
 			Cloud:  s.cloudSpec(),
 		})

--- a/provider/joyent/environ.go
+++ b/provider/joyent/environ.go
@@ -117,6 +117,14 @@ func (env *joyentEnviron) Config() *config.Config {
 	return env.Ecfg().Config
 }
 
+// Create is part of the Environ interface.
+func (env *joyentEnviron) Create(environs.CreateParams) error {
+	if err := verifyCredentials(env); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
 func (env *joyentEnviron) PrepareForBootstrap(ctx environs.BootstrapContext) error {
 	if ctx.ShouldVerifyCredentials() {
 		if err := verifyCredentials(env); err != nil {

--- a/provider/joyent/provider.go
+++ b/provider/joyent/provider.go
@@ -46,18 +46,13 @@ var _ environs.EnvironProvider = providerInstance
 
 var _ simplestreams.HasRegion = (*joyentEnviron)(nil)
 
-// RestrictedConfigAttributes is specified in the EnvironProvider interface.
+// RestrictedConfigAttributes is part of the EnvironProvider interface.
 func (joyentProvider) RestrictedConfigAttributes() []string {
 	return []string{sdcUrl}
 }
 
-// PrepareForCreateEnvironment is specified in the EnvironProvider interface.
-func (joyentProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
-	return cfg, nil
-}
-
-// BootstrapConfig is specified in the EnvironProvider interface.
-func (p joyentProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
+// PrepareConfig is part of the EnvironProvider interface.
+func (p joyentProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	attrs := map[string]interface{}{}
 	// Add the credential attributes to config.
 	switch authType := args.Cloud.Credential.AuthType(); authType {
@@ -76,7 +71,7 @@ func (p joyentProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*c
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return p.PrepareForCreateEnvironment(args.ControllerUUID, cfg)
+	return cfg, nil
 }
 
 const unauthorisedMessage = `

--- a/provider/lxd/config_test.go
+++ b/provider/lxd/config_test.go
@@ -321,7 +321,7 @@ func (s *configSuite) TestNewModelConfig(c *gc.C) {
 		c.Logf("test %d: %s", i, test.info)
 
 		testConfig := test.newConfig(c)
-		environ, err := environs.New(environs.OpenParams{testConfig})
+		environ, err := environs.New(environs.OpenParams{lxdCloudSpec(), testConfig})
 
 		// Check the result
 		if test.err != "" {
@@ -421,7 +421,7 @@ func (s *configSuite) TestSetConfig(c *gc.C) {
 	for i, test := range changeConfigTests {
 		c.Logf("test %d: %s", i, test.info)
 
-		environ, err := environs.New(environs.OpenParams{s.config})
+		environ, err := environs.New(environs.OpenParams{lxdCloudSpec(), s.config})
 		c.Assert(err, jc.ErrorIsNil)
 
 		testConfig := test.newConfig(c)
@@ -449,5 +449,12 @@ func (*configSuite) TestSchema(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	for name, field := range globalFields {
 		c.Check(fields[name], jc.DeepEquals, field)
+	}
+}
+
+func lxdCloudSpec() environs.CloudSpec {
+	return environs.CloudSpec{
+		Type: "lxd",
+		Name: "localhost",
 	}
 }

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -146,6 +146,14 @@ func (env *environ) PrepareForBootstrap(ctx environs.BootstrapContext) error {
 	return nil
 }
 
+// Create implements environs.Environ.
+func (env *environ) Create(environs.CreateParams) error {
+	if err := env.verifyCredentials(); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
 // Bootstrap creates a new instance, chosing the series and arch out of
 // available tools. The series and arch are returned along with a func
 // that must be called to finalize the bootstrap process by transferring

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -31,14 +31,9 @@ func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) 
 	return env, errors.Trace(err)
 }
 
-// BootstrapConfig implements environs.EnvironProvider.
-func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
-	return p.PrepareForCreateEnvironment(args.ControllerUUID, args.Config)
-}
-
-// PrepareForCreateEnvironment is specified in the EnvironProvider interface.
-func (environProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
-	return cfg, nil
+// PrepareConfig implements environs.EnvironProvider.
+func (p environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
+	return args.Config, nil
 }
 
 // RestrictedConfigAttributes is specified in the EnvironProvider interface.

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -114,8 +114,8 @@ func (s *ProviderFunctionalSuite) TestOpen(c *gc.C) {
 	c.Check(envConfig.Name(), gc.Equals, "testenv")
 }
 
-func (s *ProviderFunctionalSuite) TestBootstrapConfig(c *gc.C) {
-	cfg, err := s.provider.BootstrapConfig(environs.BootstrapConfigParams{
+func (s *ProviderFunctionalSuite) TestPrepareConfig(c *gc.C) {
+	cfg, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
 		Config: s.Config,
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -104,7 +104,10 @@ func (s *ProviderFunctionalSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ProviderFunctionalSuite) TestOpen(c *gc.C) {
-	env, err := s.provider.Open(environs.OpenParams{s.Config})
+	env, err := s.provider.Open(environs.OpenParams{
+		Cloud:  lxdCloudSpec(),
+		Config: s.Config,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	envConfig := env.Config()
 

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -123,7 +123,7 @@ func (env *maasEnviron) usingMAAS2() bool {
 	return env.apiVersion == apiVersion2
 }
 
-// PrepareForBootstrap is specified in the Environ interface.
+// PrepareForBootstrap is part of the Environ interface.
 func (env *maasEnviron) PrepareForBootstrap(ctx environs.BootstrapContext) error {
 	if ctx.ShouldVerifyCredentials() {
 		if err := verifyCredentials(env); err != nil {
@@ -133,7 +133,15 @@ func (env *maasEnviron) PrepareForBootstrap(ctx environs.BootstrapContext) error
 	return nil
 }
 
-// Bootstrap is specified in the Environ interface.
+// Create is part of the Environ interface.
+func (env *maasEnviron) Create(environs.CreateParams) error {
+	if err := verifyCredentials(env); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Bootstrap is part of the Environ interface.
 func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	result, series, finalizer, err := common.BootstrapInstance(ctx, env, args)
 	if err != nil {

--- a/provider/maas/environprovider_test.go
+++ b/provider/maas/environprovider_test.go
@@ -183,7 +183,10 @@ func (suite *EnvironProviderSuite) TestOpenReturnsNilInterfaceUponFailure(c *gc.
 	})
 	config, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := providerInstance.Open(environs.OpenParams{config})
+	env, err := providerInstance.Open(environs.OpenParams{
+		Cloud:  suite.cloudSpec(),
+		Config: config,
+	})
 	// When Open() fails (i.e. returns a non-nil error), it returns an
 	// environs.Environ interface object with a nil value and a nil
 	// type.

--- a/provider/maas/environprovider_test.go
+++ b/provider/maas/environprovider_test.go
@@ -60,7 +60,7 @@ func (suite *EnvironProviderSuite) TestCredentialsSetup(c *gc.C) {
 	config, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 
-	cfg, err := providerInstance.BootstrapConfig(environs.BootstrapConfigParams{
+	cfg, err := providerInstance.PrepareConfig(environs.PrepareConfigParams{
 		Config: config,
 		Cloud:  suite.cloudSpec(),
 	})
@@ -82,7 +82,7 @@ func (suite *EnvironProviderSuite) TestUnknownAttrsContainAgentName(c *gc.C) {
 	config, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 
-	cfg, err := providerInstance.BootstrapConfig(environs.BootstrapConfigParams{
+	cfg, err := providerInstance.PrepareConfig(environs.PrepareConfigParams{
 		Config: config,
 		Cloud:  suite.cloudSpec(),
 	})
@@ -107,7 +107,7 @@ func (suite *EnvironProviderSuite) TestMAASServerFromEndpoint(c *gc.C) {
 	cloudSpec := suite.cloudSpec()
 	cloudSpec.Endpoint = "maas.testing"
 
-	cfg, err := providerInstance.BootstrapConfig(environs.BootstrapConfigParams{
+	cfg, err := providerInstance.PrepareConfig(environs.PrepareConfigParams{
 		Config: config,
 		Cloud:  cloudSpec,
 	})
@@ -119,33 +119,20 @@ func (suite *EnvironProviderSuite) TestMAASServerFromEndpoint(c *gc.C) {
 
 func (suite *EnvironProviderSuite) TestPrepareSetsAgentName(c *gc.C) {
 	attrs := testing.FakeConfig().Merge(testing.Attrs{
-		"type":        "maas",
-		"maas-oauth":  "aa:bb:cc",
-		"maas-server": "http://maas.testing.invalid/maas/",
+		"type": "maas",
 	})
 	config, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 
-	config, err = providerInstance.PrepareForCreateEnvironment(suite.controllerUUID, config)
+	cfg, err := providerInstance.PrepareConfig(environs.PrepareConfigParams{
+		Config: config,
+		Cloud:  suite.cloudSpec(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	uuid, ok := config.UnknownAttrs()["maas-agent-name"]
+	uuid, ok := cfg.UnknownAttrs()["maas-agent-name"]
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(uuid, jc.Satisfies, utils.IsValidUUIDString)
-}
-
-func (suite *EnvironProviderSuite) TestPrepareExistingAgentName(c *gc.C) {
-	attrs := testing.FakeConfig().Merge(testing.Attrs{
-		"type":            "maas",
-		"maas-oauth":      "aa:bb:cc",
-		"maas-server":     "http://maas.testing.invalid/maas/",
-		"maas-agent-name": "foobar",
-	})
-	config, err := config.New(config.NoDefaults, attrs)
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, err = providerInstance.PrepareForCreateEnvironment(suite.controllerUUID, config)
-	c.Assert(err, gc.Equals, errAgentNameAlreadySet)
 }
 
 func (suite *EnvironProviderSuite) TestAgentNameShouldNotBeSetByHand(c *gc.C) {
@@ -156,7 +143,7 @@ func (suite *EnvironProviderSuite) TestAgentNameShouldNotBeSetByHand(c *gc.C) {
 	config, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = providerInstance.BootstrapConfig(environs.BootstrapConfigParams{
+	_, err = providerInstance.PrepareConfig(environs.PrepareConfigParams{
 		Config: config,
 		Cloud:  suite.cloudSpec(),
 	})

--- a/provider/manual/config.go
+++ b/provider/manual/config.go
@@ -11,7 +11,6 @@ import (
 
 var (
 	configFields = schema.Fields{
-		"bootstrap-host": schema.String(),
 		"bootstrap-user": schema.String(),
 	}
 	configDefaults = schema.Defaults{
@@ -26,10 +25,6 @@ type environConfig struct {
 
 func newModelConfig(config *config.Config, attrs map[string]interface{}) *environConfig {
 	return &environConfig{Config: config, attrs: attrs}
-}
-
-func (c *environConfig) bootstrapHost() string {
-	return c.attrs["bootstrap-host"].(string)
 }
 
 func (c *environConfig) bootstrapUser() string {

--- a/provider/manual/config_test.go
+++ b/provider/manual/config_test.go
@@ -10,6 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -20,6 +21,14 @@ type configSuite struct {
 
 var _ = gc.Suite(&configSuite{})
 
+func CloudSpec() environs.CloudSpec {
+	return environs.CloudSpec{
+		Name:     "manual",
+		Type:     "manual",
+		Endpoint: "hostname",
+	}
+}
+
 func MinimalConfigValues() map[string]interface{} {
 	return map[string]interface{}{
 		"name":            "test",
@@ -27,7 +36,6 @@ func MinimalConfigValues() map[string]interface{} {
 		"uuid":            coretesting.ModelTag.Id(),
 		"controller-uuid": coretesting.ModelTag.Id(),
 		"firewall-mode":   "instance",
-		"bootstrap-host":  "hostname",
 		"bootstrap-user":  "",
 		// While the ca-cert bits aren't entirely minimal, they avoid the need
 		// to set up a fake home.
@@ -51,25 +59,6 @@ func getModelConfig(c *gc.C, attrs map[string]interface{}) *environConfig {
 	return envConfig
 }
 
-func (s *configSuite) TestValidateConfig(c *gc.C) {
-	testConfig := MinimalConfig(c)
-	testConfig, err := testConfig.Apply(map[string]interface{}{"bootstrap-host": ""})
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = manualProvider{}.Validate(testConfig, nil)
-	c.Assert(err, gc.ErrorMatches, "bootstrap-host must be specified")
-
-	values := MinimalConfigValues()
-	delete(values, "bootstrap-user")
-	testConfig, err = config.New(config.UseDefaults, values)
-	c.Assert(err, jc.ErrorIsNil)
-
-	valid, err := manualProvider{}.Validate(testConfig, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	unknownAttrs := valid.UnknownAttrs()
-	c.Assert(unknownAttrs["bootstrap-host"], gc.Equals, "hostname")
-	c.Assert(unknownAttrs["bootstrap-user"], gc.Equals, "")
-}
-
 func (s *configSuite) TestConfigMutability(c *gc.C) {
 	testConfig := MinimalConfig(c)
 	valid, err := manualProvider{}.Validate(testConfig, nil)
@@ -81,7 +70,6 @@ func (s *configSuite) TestConfigMutability(c *gc.C) {
 	// machine agent's config/upstart config.
 	oldConfig := testConfig
 	for k, v := range map[string]interface{}{
-		"bootstrap-host": "new-hostname",
 		"bootstrap-user": "new-username",
 	} {
 		testConfig = MinimalConfig(c)
@@ -94,14 +82,11 @@ func (s *configSuite) TestConfigMutability(c *gc.C) {
 	}
 }
 
-func (s *configSuite) TestBootstrapHostUser(c *gc.C) {
+func (s *configSuite) TestBootstrapUser(c *gc.C) {
 	values := MinimalConfigValues()
 	testConfig := getModelConfig(c, values)
-	c.Assert(testConfig.bootstrapHost(), gc.Equals, "hostname")
 	c.Assert(testConfig.bootstrapUser(), gc.Equals, "")
-	values["bootstrap-host"] = "127.0.0.1"
 	values["bootstrap-user"] = "ubuntu"
 	testConfig = getModelConfig(c, values)
-	c.Assert(testConfig.bootstrapHost(), gc.Equals, "127.0.0.1")
 	c.Assert(testConfig.bootstrapUser(), gc.Equals, "ubuntu")
 }

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -80,7 +80,7 @@ func (e *manualEnviron) Config() *config.Config {
 	return e.envConfig().Config
 }
 
-// PrepareForBootstrap is specified in the Environ interface.
+// PrepareForBootstrap is part of the Environ interface.
 func (e *manualEnviron) PrepareForBootstrap(ctx environs.BootstrapContext) error {
 	if err := ensureBootstrapUbuntuUser(ctx, e.host, e.envConfig()); err != nil {
 		return err
@@ -88,7 +88,12 @@ func (e *manualEnviron) PrepareForBootstrap(ctx environs.BootstrapContext) error
 	return nil
 }
 
-// Bootstrap is specified on the Environ interface.
+// Create is part of the Environ interface.
+func (e *manualEnviron) Create(environs.CreateParams) error {
+	return nil
+}
+
+// Bootstrap is part of the Environ interface.
 func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	provisioned, err := manualCheckProvisioned(e.host)
 	if err != nil {

--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -24,7 +24,10 @@ type baseEnvironSuite struct {
 
 func (s *baseEnvironSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	env, err := manualProvider{}.Open(environs.OpenParams{MinimalConfig(c)})
+	env, err := manualProvider{}.Open(environs.OpenParams{
+		Cloud:  CloudSpec(),
+		Config: MinimalConfig(c),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.env = env.(*manualEnviron)
 }
@@ -34,17 +37,6 @@ type environSuite struct {
 }
 
 var _ = gc.Suite(&environSuite{})
-
-func (s *environSuite) TestSetConfig(c *gc.C) {
-	err := s.env.SetConfig(MinimalConfig(c))
-	c.Assert(err, jc.ErrorIsNil)
-
-	testConfig := MinimalConfig(c)
-	testConfig, err = testConfig.Apply(map[string]interface{}{"bootstrap-host": ""})
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.env.SetConfig(testConfig)
-	c.Assert(err, gc.ErrorMatches, "bootstrap-host must be specified")
-}
 
 func (s *environSuite) TestInstances(c *gc.C) {
 	var ids []instance.Id

--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -43,15 +43,13 @@ func (p manualProvider) DetectRegions() ([]cloud.Region, error) {
 	return nil, errors.NotFoundf("regions")
 }
 
-// PrepareForCreateEnvironment is specified in the EnvironProvider interface.
-func (p manualProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
-	return cfg, nil
-}
-
-// BootstrapConfig is specified in the EnvironProvider interface.
-func (p manualProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
-	if err := validateCloudSpec(args.Cloud); err != nil {
-		return nil, errors.Trace(err)
+// PrepareConfig is specified in the EnvironProvider interface.
+func (p manualProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
+	if args.Cloud.Endpoint == "" {
+		return nil, errors.Errorf(
+			"missing address of host to bootstrap: " +
+				`please specify "juju bootstrap manual/<host>"`,
+		)
 	}
 	envConfig, err := p.validate(args.Config, nil)
 	if err != nil {

--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -21,12 +21,10 @@ type manualProvider struct {
 // Verify that we conform to the interface.
 var _ environs.EnvironProvider = (*manualProvider)(nil)
 
-var errNoBootstrapHost = errors.New("bootstrap-host must be specified")
-
 var initUbuntuUser = manual.InitUbuntuUser
 
-func ensureBootstrapUbuntuUser(ctx environs.BootstrapContext, cfg *environConfig) error {
-	err := initUbuntuUser(cfg.bootstrapHost(), cfg.bootstrapUser(), cfg.AuthorizedKeys(), ctx.GetStdin(), ctx.GetStdout())
+func ensureBootstrapUbuntuUser(ctx environs.BootstrapContext, host string, cfg *environConfig) error {
+	err := initUbuntuUser(host, cfg.bootstrapUser(), cfg.AuthorizedKeys(), ctx.GetStdin(), ctx.GetStdout())
 	if err != nil {
 		logger.Errorf("initializing ubuntu user: %v", err)
 		return err
@@ -37,7 +35,7 @@ func ensureBootstrapUbuntuUser(ctx environs.BootstrapContext, cfg *environConfig
 
 // RestrictedConfigAttributes is specified in the EnvironProvider interface.
 func (p manualProvider) RestrictedConfigAttributes() []string {
-	return []string{"bootstrap-host", "bootstrap-user"}
+	return []string{"bootstrap-user"}
 }
 
 // DetectRegions is specified in the environs.CloudRegionDetector interface.
@@ -52,26 +50,20 @@ func (p manualProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *
 
 // BootstrapConfig is specified in the EnvironProvider interface.
 func (p manualProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
-	if args.Cloud.Endpoint == "" {
-		return nil, errors.Errorf(
-			"missing address of host to bootstrap: " +
-				`please specify "juju bootstrap manual/<host>"`,
-		)
-	}
-	cfg, err := args.Config.Apply(map[string]interface{}{
-		"bootstrap-host": args.Cloud.Endpoint,
-	})
-	if err != nil {
+	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Trace(err)
 	}
-	envConfig, err := p.validate(cfg, nil)
+	envConfig, err := p.validate(args.Config, nil)
 	if err != nil {
 		return nil, err
 	}
-	return cfg.Apply(envConfig.attrs)
+	return args.Config.Apply(envConfig.attrs)
 }
 
 func (p manualProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+	if err := validateCloudSpec(args.Cloud); err != nil {
+		return nil, errors.Trace(err)
+	}
 	_, err := p.validate(args.Config, nil)
 	if err != nil {
 		return nil, err
@@ -80,11 +72,21 @@ func (p manualProvider) Open(args environs.OpenParams) (environs.Environ, error)
 	// with their defaults in the result; we don't wnat that in
 	// Open.
 	envConfig := newModelConfig(args.Config, args.Config.UnknownAttrs())
-	return p.open(envConfig)
+	return p.open(args.Cloud.Endpoint, envConfig)
 }
 
-func (p manualProvider) open(cfg *environConfig) (environs.Environ, error) {
-	env := &manualEnviron{cfg: cfg}
+func validateCloudSpec(spec environs.CloudSpec) error {
+	if spec.Endpoint == "" {
+		return errors.Errorf(
+			"missing address of host to bootstrap: " +
+				`please specify "juju bootstrap manual/<host>"`,
+		)
+	}
+	return nil
+}
+
+func (p manualProvider) open(host string, cfg *environConfig) (environs.Environ, error) {
+	env := &manualEnviron{host: host, cfg: cfg}
 	// Need to call SetConfig to initialise storage.
 	if err := env.SetConfig(cfg.Config); err != nil {
 		return nil, err
@@ -109,9 +111,6 @@ func (p manualProvider) validate(cfg, old *config.Config) (*environConfig, error
 		return nil, err
 	}
 	envConfig := newModelConfig(cfg, validated)
-	if envConfig.bootstrapHost() == "" {
-		return nil, errNoBootstrapHost
-	}
 	// Check various immutable attributes.
 	if old != nil {
 		oldEnvConfig, err := p.validate(old, nil)
@@ -120,7 +119,6 @@ func (p manualProvider) validate(cfg, old *config.Config) (*environConfig, error
 		}
 		for _, key := range [...]string{
 			"bootstrap-user",
-			"bootstrap-host",
 		} {
 			if err = checkImmutableString(envConfig, oldEnvConfig, key); err != nil {
 				return nil, err

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -33,14 +33,6 @@ func (s *providerSuite) SetUpTest(c *gc.C) {
 	})
 }
 
-func (s *providerSuite) TestPrepareForCreateEnvironment(c *gc.C) {
-	testConfig, err := config.New(config.UseDefaults, manual.MinimalConfigValues())
-	c.Assert(err, jc.ErrorIsNil)
-	cfg, err := manual.ProviderInstance.PrepareForCreateEnvironment(coretesting.ModelTag.Id(), testConfig)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg, gc.Equals, testConfig)
-}
-
 func (s *providerSuite) TestPrepareForBootstrapCloudEndpointAndRegion(c *gc.C) {
 	ctx, err := s.testPrepareForBootstrap(c, "endpoint", "region")
 	c.Assert(err, jc.ErrorIsNil)
@@ -61,7 +53,7 @@ func (s *providerSuite) testPrepareForBootstrap(c *gc.C, endpoint, region string
 		Endpoint: endpoint,
 		Region:   region,
 	}
-	testConfig, err = manual.ProviderInstance.BootstrapConfig(environs.BootstrapConfigParams{
+	testConfig, err = manual.ProviderInstance.PrepareConfig(environs.PrepareConfigParams{
 		Config: testConfig,
 		Cloud:  cloudSpec,
 	})

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -57,17 +57,21 @@ func (s *providerSuite) testPrepareForBootstrap(c *gc.C, endpoint, region string
 	minimal := manual.MinimalConfigValues()
 	testConfig, err := config.New(config.UseDefaults, minimal)
 	c.Assert(err, jc.ErrorIsNil)
+	cloudSpec := environs.CloudSpec{
+		Endpoint: endpoint,
+		Region:   region,
+	}
 	testConfig, err = manual.ProviderInstance.BootstrapConfig(environs.BootstrapConfigParams{
 		Config: testConfig,
-		Cloud: environs.CloudSpec{
-			Endpoint: endpoint,
-			Region:   region,
-		},
+		Cloud:  cloudSpec,
 	})
 	if err != nil {
 		return nil, err
 	}
-	env, err := manual.ProviderInstance.Open(environs.OpenParams{testConfig})
+	env, err := manual.ProviderInstance.Open(environs.OpenParams{
+		Cloud:  cloudSpec,
+		Config: testConfig,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/provider/openstack/config_test.go
+++ b/provider/openstack/config_test.go
@@ -452,7 +452,7 @@ func (s *ConfigSuite) TestDeprecatedAttributesRemoved(c *gc.C) {
 	}
 }
 
-func (s *ConfigSuite) TestBootstrapConfigSetsDefaultBlockSource(c *gc.C) {
+func (s *ConfigSuite) TestPrepareConfigSetsDefaultBlockSource(c *gc.C) {
 	attrs := testing.FakeConfig().Merge(testing.Attrs{
 		"type": "openstack",
 	})
@@ -461,20 +461,20 @@ func (s *ConfigSuite) TestBootstrapConfigSetsDefaultBlockSource(c *gc.C) {
 	_, ok := cfg.StorageDefaultBlockSource()
 	c.Assert(ok, jc.IsFalse)
 
-	cfg, err = providerInstance.BootstrapConfig(bootstrapConfigParams(cfg))
+	cfg, err = providerInstance.PrepareConfig(prepareConfigParams(cfg))
 	c.Assert(err, jc.ErrorIsNil)
 	source, ok := cfg.StorageDefaultBlockSource()
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(source, gc.Equals, "cinder")
 }
 
-func bootstrapConfigParams(cfg *config.Config) environs.BootstrapConfigParams {
+func prepareConfigParams(cfg *config.Config) environs.PrepareConfigParams {
 	credential := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
 		"username":    "user",
 		"password":    "secret",
 		"tenant-name": "sometenant",
 	})
-	return environs.BootstrapConfigParams{
+	return environs.PrepareConfigParams{
 		Config: cfg,
 		Cloud: environs.CloudSpec{
 			Region:     "region",

--- a/provider/openstack/config_test.go
+++ b/provider/openstack/config_test.go
@@ -100,7 +100,17 @@ func (t configTest) check(c *gc.C) {
 	}
 	defer restoreEnvVars(savedVars)
 
-	e, err := environs.New(environs.OpenParams{cfg})
+	cloudSpec := environs.CloudSpec{
+		Type:     "openstack",
+		Name:     "openstack",
+		Endpoint: "http://auth",
+		Region:   "Configtest",
+	}
+
+	e, err := environs.New(environs.OpenParams{
+		Cloud:  cloudSpec,
+		Config: cfg,
+	})
 	if t.change != nil {
 		c.Assert(err, jc.ErrorIsNil)
 

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -107,13 +107,8 @@ func (EnvironProvider) DetectRegions() ([]cloud.Region, error) {
 	}}, nil
 }
 
-// PrepareForCreateEnvironment is specified in the EnvironProvider interface.
-func (p EnvironProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
-	return cfg, nil
-}
-
-// BootstrapConfig is specified in the EnvironProvider interface.
-func (p EnvironProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
+// PrepareConfig is specified in the EnvironProvider interface.
+func (p EnvironProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	// Add credentials to the configuration.
 	attrs := map[string]interface{}{
 		"region":   args.Cloud.Region,
@@ -146,7 +141,7 @@ func (p EnvironProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return p.PrepareForCreateEnvironment(args.ControllerUUID, cfg)
+	return cfg, nil
 }
 
 // MetadataLookupParams returns parameters which are used to query image metadata to
@@ -544,12 +539,23 @@ func (e *Environ) PrecheckInstance(series string, cons constraints.Value, placem
 	return errors.Errorf("invalid Openstack flavour %q specified", *cons.InstanceType)
 }
 
-// PrepareForBootstrap is specified in the Environ interface.
+// PrepareForBootstrap is part of the Environ interface.
 func (e *Environ) PrepareForBootstrap(ctx environs.BootstrapContext) error {
 	// Verify credentials.
 	if err := authenticateClient(e); err != nil {
 		return err
 	}
+	return nil
+}
+
+// Create is part of the Environ interface.
+func (e *Environ) Create(environs.CreateParams) error {
+	// Verify credentials.
+	if err := authenticateClient(e); err != nil {
+		return err
+	}
+	// TODO(axw) 2016-08-04 #1609643
+	// Create global security group(s) here.
 	return nil
 }
 

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -107,6 +107,11 @@ func (p *fakeEnviron) Open(cfg *config.Config) (environs.Environ, error) {
 	return nil, nil
 }
 
+func (e *fakeEnviron) Create(args environs.CreateParams) error {
+	e.Push("Create", args)
+	return nil
+}
+
 func (e *fakeEnviron) PrepareForBootstrap(ctx environs.BootstrapContext) error {
 	e.Push("PrepareForBootstrap", ctx)
 	return nil

--- a/provider/rackspace/provider.go
+++ b/provider/rackspace/provider.go
@@ -16,11 +16,11 @@ type environProvider struct {
 
 var providerInstance *environProvider
 
-// BootstrapConfig is specified in the EnvironProvider interface.
-func (p *environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
+// PrepareConfig is specified in the EnvironProvider interface.
+func (p *environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	// Rackspace regions are expected to be uppercase, but Juju
 	// stores and displays them in lowercase in the CLI. Ensure
 	// they're uppercase when they get to the Rackspace API.
 	args.Cloud.Region = strings.ToUpper(args.Cloud.Region)
-	return p.EnvironProvider.BootstrapConfig(args)
+	return p.EnvironProvider.PrepareConfig(args)
 }

--- a/provider/rackspace/provider_test.go
+++ b/provider/rackspace/provider_test.go
@@ -41,18 +41,18 @@ func (s *providerSuite) TestValidate(c *gc.C) {
 	s.innerProvider.CheckCallNames(c, "Validate")
 }
 
-func (s *providerSuite) TestBootstrapConfig(c *gc.C) {
-	args := environs.BootstrapConfigParams{
+func (s *providerSuite) TestPrepareConfig(c *gc.C) {
+	args := environs.PrepareConfigParams{
 		Cloud: environs.CloudSpec{
 			Region: "dfw",
 		},
 	}
-	s.provider.BootstrapConfig(args)
+	s.provider.PrepareConfig(args)
 
 	expect := args
 	expect.Cloud.Region = "DFW"
 	s.innerProvider.CheckCalls(c, []testing.StubCall{
-		{"BootstrapConfig", []interface{}{expect}},
+		{"PrepareConfig", []interface{}{expect}},
 	})
 }
 
@@ -75,8 +75,8 @@ func (p *fakeProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *c
 	return nil, nil
 }
 
-func (p *fakeProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
-	p.MethodCall(p, "BootstrapConfig", args)
+func (p *fakeProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
+	p.MethodCall(p, "PrepareConfig", args)
 	return nil, nil
 }
 

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -98,6 +98,11 @@ func (env *environ) PrepareForBootstrap(ctx environs.BootstrapContext) error {
 	return nil
 }
 
+// Create implements environs.Environ.
+func (env *environ) Create(environs.CreateParams) error {
+	return nil
+}
+
 //this variable is exported, because it has to be rewritten in external unit tests
 var Bootstrap = common.Bootstrap
 

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -29,12 +29,12 @@ func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) 
 	return env, errors.Trace(err)
 }
 
-// BootstrapConfig implements environs.EnvironProvider.
+// PrepareConfig implements environs.EnvironProvider.
 //
 // TODO(axw) 2016-07-29 #1607620
 // We should be extracting the endpoint and region
 // in this method, and using them as host/datacenter.
-func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
+func (p environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	cfg := args.Config
 	switch authType := args.Cloud.Credential.AuthType(); authType {
 	case cloud.UserPassAuthType:
@@ -50,11 +50,6 @@ func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*
 	default:
 		return nil, errors.NotSupportedf("%q auth-type", authType)
 	}
-	return p.PrepareForCreateEnvironment(args.ControllerUUID, cfg)
-}
-
-// PrepareForCreateEnvironment is specified in the EnvironProvider interface.
-func (environProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
 	return cfg, nil
 }
 

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -30,6 +30,10 @@ func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) 
 }
 
 // BootstrapConfig implements environs.EnvironProvider.
+//
+// TODO(axw) 2016-07-29 #1607620
+// We should be extracting the endpoint and region
+// in this method, and using them as host/datacenter.
 func (p environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
 	cfg := args.Config
 	switch authType := args.Cloud.Credential.AuthType(); authType {

--- a/provider/vsphere/provider_test.go
+++ b/provider/vsphere/provider_test.go
@@ -35,7 +35,10 @@ func (s *providerSuite) TestRegistered(c *gc.C) {
 }
 
 func (s *providerSuite) TestOpen(c *gc.C) {
-	env, err := s.provider.Open(environs.OpenParams{s.Config})
+	env, err := s.provider.Open(environs.OpenParams{
+		Cloud:  vsphere.FakeCloudSpec(),
+		Config: s.Config,
+	})
 	c.Check(err, jc.ErrorIsNil)
 
 	envConfig := env.Config()

--- a/provider/vsphere/provider_test.go
+++ b/provider/vsphere/provider_test.go
@@ -45,12 +45,12 @@ func (s *providerSuite) TestOpen(c *gc.C) {
 	c.Assert(envConfig.Name(), gc.Equals, "testenv")
 }
 
-func (s *providerSuite) TestBootstrapConfig(c *gc.C) {
+func (s *providerSuite) TestPrepareConfig(c *gc.C) {
 	credential := cloud.NewCredential(
 		cloud.UserPassAuthType,
 		map[string]string{"user": "u", "password": "p"},
 	)
-	cfg, err := s.provider.BootstrapConfig(environs.BootstrapConfigParams{
+	cfg, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
 		Config: s.Config,
 		Cloud: environs.CloudSpec{
 			Credential: &credential,

--- a/provider/vsphere/testing_test.go
+++ b/provider/vsphere/testing_test.go
@@ -29,8 +29,8 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-var (
-	ConfigAttrs = testing.FakeConfig().Merge(testing.Attrs{
+func ConfigAttrs() testing.Attrs {
+	return testing.FakeConfig().Merge(testing.Attrs{
 		"type":             "vsphere",
 		"uuid":             "2d02eeac-9dbb-11e4-89d3-123b93f75cba",
 		"datacenter":       "/datacenter1",
@@ -39,7 +39,14 @@ var (
 		"password":         "password1",
 		"external-network": "",
 	})
-)
+}
+
+func FakeCloudSpec() environs.CloudSpec {
+	return environs.CloudSpec{
+		Type: "vsphere",
+		Name: "vsphere",
+	}
+}
 
 type BaseSuite struct {
 	gitjujutesting.IsolationSuite
@@ -63,9 +70,12 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *BaseSuite) initEnv(c *gc.C) {
-	cfg, err := testing.ModelConfig(c).Apply(ConfigAttrs)
+	cfg, err := testing.ModelConfig(c).Apply(ConfigAttrs())
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.New(environs.OpenParams{cfg})
+	env, err := environs.New(environs.OpenParams{
+		Cloud:  FakeCloudSpec(),
+		Config: cfg,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.Env = env.(*environ)
 	s.setConfig(c, cfg)

--- a/state/interface.go
+++ b/state/interface.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
@@ -96,6 +97,13 @@ type AgentEntity interface {
 	EnsureDeader
 	Remover
 	NotifyWatcherFactory
+}
+
+// CloudAccessor defines the methods needed to
+// access cloud information.
+type CloudAccessor interface {
+	Cloud(string) (cloud.Cloud, error)
+	CloudCredentials(user names.UserTag, cloud string) (map[string]cloud.Credential, error)
 }
 
 // ModelAccessor defines the methods needed to watch for model

--- a/state/stateenvirons/config.go
+++ b/state/stateenvirons/config.go
@@ -34,14 +34,6 @@ func (g EnvironConfigGetter) CloudSpec(tag names.ModelTag) (environs.CloudSpec, 
 	if err != nil {
 		return environs.CloudSpec{}, errors.Trace(err)
 	}
-	if regionName != "" {
-		region, err := cloud.RegionByName(modelCloud.Regions, regionName)
-		if err != nil {
-			return environs.CloudSpec{}, errors.Trace(err)
-		}
-		modelCloud.Endpoint = region.Endpoint
-		modelCloud.StorageEndpoint = region.StorageEndpoint
-	}
 
 	var credential *cloud.Credential
 	if credentialName != "" {
@@ -57,14 +49,7 @@ func (g EnvironConfigGetter) CloudSpec(tag names.ModelTag) (environs.CloudSpec, 
 		credential = &credentialValue
 	}
 
-	return environs.CloudSpec{
-		modelCloud.Type,
-		cloudName,
-		regionName,
-		modelCloud.Endpoint,
-		modelCloud.StorageEndpoint,
-		credential,
-	}, nil
+	return environs.MakeCloudSpec(modelCloud, cloudName, regionName, credential)
 }
 
 // NewEnvironFunc defines the type of a function that, given a state.State,

--- a/state/stateenvirons/config.go
+++ b/state/stateenvirons/config.go
@@ -5,6 +5,7 @@ package stateenvirons
 
 import (
 	"github.com/juju/errors"
+	names "gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
@@ -18,8 +19,8 @@ type EnvironConfigGetter struct {
 }
 
 // CloudSpec implements environs.EnvironConfigGetter.
-func (g EnvironConfigGetter) CloudSpec() (environs.CloudSpec, error) {
-	model, err := g.Model()
+func (g EnvironConfigGetter) CloudSpec(tag names.ModelTag) (environs.CloudSpec, error) {
+	model, err := g.GetModel(tag)
 	if err != nil {
 		return environs.CloudSpec{}, errors.Trace(err)
 	}

--- a/state/stateenvirons/config_test.go
+++ b/state/stateenvirons/config_test.go
@@ -53,7 +53,7 @@ func (s *environSuite) TestCloudSpec(c *gc.C) {
 	defer st.Close()
 
 	emptyCredential.Label = "empty-credential"
-	cloudSpec, err := stateenvirons.EnvironConfigGetter{st}.CloudSpec()
+	cloudSpec, err := stateenvirons.EnvironConfigGetter{st}.CloudSpec(st.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudSpec, jc.DeepEquals, environs.CloudSpec{
 		Type:       "dummy",


### PR DESCRIPTION
Requires https://github.com/juju/juju/pull/5893

This change drops the PrepareForCreateEnvironment method from
EnvironProvider, and renames BootstrapConfig to PrepareConfig.
PrepareConfig is now called for both bootstrap and hosted-model creation.

Several implementations of PrepareForCreateEnvironment were doing things
other than config preparation. These are now handled in a new
Environ.Create method, which is called just after a hosted model is
created, but before it is added to the state database.

(Review request: http://reviews.vapour.ws/r/5367/)