### PR TITLE
Skip lxd tests on Windows

### DIFF
--- a/tools/lxdclient/testing_test.go
+++ b/tools/lxdclient/testing_test.go
@@ -7,6 +7,7 @@ package lxdclient
 
 import (
 	"crypto/x509"
+	"runtime"
 
 	"github.com/juju/errors"
 	"github.com/juju/testing"
@@ -21,6 +22,13 @@ type BaseSuite struct {
 	Stub   *testing.Stub
 	Client *stubClient
 	Cert   *Cert
+}
+
+func (s *BaseSuite) SetUpSuite(c *gc.C) {
+	s.IsolationSuite.SetUpSuite(c)
+	if runtime.GOOS == "windows" {
+		c.Skip("LXD is not supported on Windows")
+	}
 }
 
 func (s *BaseSuite) SetUpTest(c *gc.C) {


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1609407

LXD test was failing on Windows. We don't need to run such tests there.

(Review request: http://reviews.vapour.ws/r/5368/)