### PR TITLE
Retry apiserver errors that match "i/o timeout"

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -608,11 +608,9 @@ func (s *state) APICall(facade string, version int, id, method string, args, res
 			}
 			return ec.ErrorCode() != params.CodeRetry
 		},
-		// The combination of five attempts and the double delay
-		// means that we get 100, 200, 400, 800 millisecond backoffs.
-		// The maximum elapsed delay will be 1500ms or 1.5 seconds.
-		Attempts:    5,
 		Delay:       100 * time.Millisecond,
+		MaxDelay:    3 * time.Second,
+		MaxDuration: 10 * time.Second,
 		BackoffFunc: retry.DoubleDelay,
 		Clock:       s.clock,
 	}

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -609,7 +609,7 @@ func (s *state) APICall(facade string, version int, id, method string, args, res
 			return ec.ErrorCode() != params.CodeRetry
 		},
 		Delay:       100 * time.Millisecond,
-		MaxDelay:    3 * time.Second,
+		MaxDelay:    1500 * time.Millisecond,
 		MaxDuration: 10 * time.Second,
 		BackoffFunc: retry.DoubleDelay,
 		Clock:       s.clock,

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -256,9 +256,11 @@ func (s *apiclientSuite) TestAPICallRetriesLimit(c *gc.C) {
 		200 * time.Millisecond,
 		400 * time.Millisecond,
 		800 * time.Millisecond,
-		1600 * time.Millisecond,
-		3 * time.Second,
-		3 * time.Second,
+		1500 * time.Millisecond,
+		1500 * time.Millisecond,
+		1500 * time.Millisecond,
+		1500 * time.Millisecond,
+		1500 * time.Millisecond,
 	})
 }
 

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/network"
+	"github.com/juju/utils/clock"
 )
 
 var (
@@ -19,6 +20,9 @@ var (
 	FacadeVersions        = &facadeVersions
 	ConnectWebsocket      = connectWebsocket
 )
+
+// RPCConnection defines the methods that are called on the rpc.Conn instance.
+type RPCConnection rpcConnection
 
 // SetServerAddress allows changing the URL to the internal API server
 // that AddLocalCharm uses in order to test NotImplementedError.
@@ -41,13 +45,17 @@ type TestingStateParams struct {
 	FacadeVersions map[string][]int
 	ServerScheme   string
 	ServerRoot     string
+	RPCConnection  RPCConnection
+	Clock          clock.Clock
 }
 
 // NewTestingState creates an api.State object that can be used for testing. It
 // isn't backed onto an actual API server, so actual RPC methods can't be
-// called on it. But it can be used for testing general behavior.
+// called on it. But it can be used for testing general behaviour.
 func NewTestingState(params TestingStateParams) Connection {
 	st := &state{
+		client:            params.RPCConnection,
+		clock:             params.Clock,
 		addr:              params.Address,
 		modelTag:          params.ModelTag,
 		hostPorts:         params.APIHostPorts,

--- a/api/interface.go
+++ b/api/interface.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/api/upgrader"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/rpc"
 	"github.com/juju/utils/set"
 )
 
@@ -185,10 +184,6 @@ type Connection interface {
 	// inside it as well. We should figure this out sometime -- we should
 	// either expose Ping() or Broken() but not both.
 	Ping() error
-
-	// RPCClient is apparently exported for testing purposes only, but this
-	// seems to indicate *some* sort of layering confusion.
-	RPCClient() *rpc.Conn
 
 	// I think this is actually dead code. It's tested, at least, so I'm
 	// keeping it for now, but it's not apparently used anywhere else.

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -180,6 +180,8 @@ func ServerErrorAndStatus(err error) (*params.Error, int) {
 		status = http.StatusForbidden
 	case params.CodeDischargeRequired:
 		status = http.StatusUnauthorized
+	case params.CodeRetry:
+		status = http.StatusServiceUnavailable
 	}
 	return err1, status
 }
@@ -198,6 +200,8 @@ func ServerError(err error) *params.Error {
 	var info *params.ErrorInfo
 	switch {
 	case ok:
+	case isIOTimeout(err):
+		code = params.CodeRetry
 	case errors.IsUnauthorized(err):
 		code = params.CodeUnauthorized
 	case errors.IsNotFound(err):
@@ -245,6 +249,17 @@ func ServerError(err error) *params.Error {
 		Code:    code,
 		Info:    info,
 	}
+}
+
+// Unfortunately there is no specific type of error for i/o timeout,
+// and the error that bubbles up from mgo is annotated and a string type,
+// so all we can do is look at the error suffix and see if it matches.
+func isIOTimeout(err error) bool {
+	// Perhaps sometime in the future, we'll have additional ways to tell if
+	// the error is an i/o timeout type error, but for now this is all we
+	// have.
+	msg := err.Error()
+	return strings.HasSuffix(msg, "i/o timeout")
 }
 
 func DestroyErr(desc string, ids, errs []string) error {

--- a/apiserver/common/errors_test.go
+++ b/apiserver/common/errors_test.go
@@ -191,6 +191,10 @@ var errorTransformTests = []struct {
 	status:     http.StatusNotFound,
 	helperFunc: params.IsCodeModelNotFound,
 }, {
+	err:    errors.Annotate(errors.New("i/o timeout"), "annotated"),
+	code:   params.CodeRetry,
+	status: http.StatusServiceUnavailable,
+}, {
 	err:    nil,
 	code:   "",
 	status: http.StatusOK,
@@ -238,7 +242,8 @@ func (s *errorsSuite) TestErrorTransform(c *gc.C) {
 			params.CodeUpgradeInProgress,
 			params.CodeMachineHasAttachedStorage,
 			params.CodeDischargeRequired,
-			params.CodeModelNotFound:
+			params.CodeModelNotFound,
+			params.CodeRetry:
 			continue
 		case params.CodeOperationBlocked:
 			// ServerError doesn't actually have a case for this code.

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -88,6 +88,7 @@ const (
 	CodeForbidden                 = "forbidden"
 	CodeDischargeRequired         = "macaroon discharge required"
 	CodeRedirect                  = "redirection required"
+	CodeRetry                     = "retry"
 )
 
 // ErrCode returns the error code associated with


### PR DESCRIPTION
This change is in two parts. The apiserver part uses the common ServerError function that translates errors to catch errors whose suffix matches the "i/o timeout" string. This unfortunately is the only way to catch them because mgo annotates the error and returns an error string type. 503 is used as the http return code as "Service Unavailable" is considered temporary, and it is a server side error.

On the client side, the retry is caught in the base APICaller function "APICall". Currently it just uses five attempts as a maximum, but since the "i/o timeout" only occurs when a database session is closed from under us, it should be ok.

(Review request: http://reviews.vapour.ws/r/5369/)