### PR TITLE
ModelDefaults set and unset api

### DIFF
--- a/api/modelconfig/modelconfig.go
+++ b/api/modelconfig/modelconfig.go
@@ -4,6 +4,8 @@
 package modelconfig
 
 import (
+	"github.com/juju/errors"
+
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs/config"
@@ -32,11 +34,14 @@ func (c *Client) Close() error {
 func (c *Client) ModelGet() (map[string]interface{}, error) {
 	result := params.ModelConfigResults{}
 	err := c.facade.FacadeCall("ModelGet", nil, &result)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	values := make(map[string]interface{})
 	for name, val := range result.Config {
 		values[name] = val.Value
 	}
-	return values, err
+	return values, nil
 }
 
 // ModelGetWithMetadata returns all model settings along with extra
@@ -44,6 +49,9 @@ func (c *Client) ModelGet() (map[string]interface{}, error) {
 func (c *Client) ModelGetWithMetadata() (config.ConfigValues, error) {
 	result := params.ModelConfigResults{}
 	err := c.facade.FacadeCall("ModelGet", nil, &result)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	values := make(config.ConfigValues)
 	for name, val := range result.Config {
 		values[name] = config.ConfigValue{
@@ -51,7 +59,7 @@ func (c *Client) ModelGetWithMetadata() (config.ConfigValues, error) {
 			Source: val.Source,
 		}
 	}
-	return values, err
+	return values, nil
 }
 
 // ModelSet sets the given key-value pairs in the model.
@@ -64,4 +72,21 @@ func (c *Client) ModelSet(config map[string]interface{}) error {
 func (c *Client) ModelUnset(keys ...string) error {
 	args := params.ModelUnset{Keys: keys}
 	return c.facade.FacadeCall("ModelUnset", args, nil)
+}
+
+// ModelDefaults returns the default config values used when creating a new model.
+func (c *Client) ModelDefaults() (config.ConfigValues, error) {
+	result := params.ModelConfigResults{}
+	err := c.facade.FacadeCall("ModelDefaults", nil, &result)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	values := make(config.ConfigValues)
+	for name, val := range result.Config {
+		values[name] = config.ConfigValue{
+			Value:  val.Value,
+			Source: val.Source,
+		}
+	}
+	return values, nil
 }

--- a/api/modelconfig/modelconfig.go
+++ b/api/modelconfig/modelconfig.go
@@ -90,3 +90,15 @@ func (c *Client) ModelDefaults() (config.ConfigValues, error) {
 	}
 	return values, nil
 }
+
+// SetModelDefaults updates the specified default model config values.
+func (c *Client) SetModelDefaults(config map[string]interface{}) error {
+	args := params.ModelSet{Config: config}
+	return c.facade.FacadeCall("SetModelDefaults", args, nil)
+}
+
+// UnsetModelDefaults removes the specified default model config values.
+func (c *Client) UnsetModelDefaults(keys ...string) error {
+	args := params.ModelUnset{Keys: keys}
+	return c.facade.FacadeCall("UnsetModelDefaults", args, nil)
+}

--- a/api/modelconfig/modelconfig_test.go
+++ b/api/modelconfig/modelconfig_test.go
@@ -127,3 +127,30 @@ func (s *modelconfigrSuite) TestModelUnset(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 }
+
+func (s *modelconfigrSuite) TestModelDefaults(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, result interface{},
+		) error {
+			c.Check(objType, gc.Equals, "ModelConfig")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "ModelDefaults")
+			c.Check(a, gc.IsNil)
+			c.Assert(result, gc.FitsTypeOf, &params.ModelConfigResults{})
+			results := result.(*params.ModelConfigResults)
+			results.Config = map[string]params.ConfigValue{
+				"foo": {"bar", "model"},
+			}
+			return nil
+		},
+	)
+	client := modelconfig.NewClient(apiCaller)
+	result, err := client.ModelDefaults()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, config.ConfigValues{
+		"foo": {"bar", "model"},
+	})
+}

--- a/apiserver/modelconfig/backend.go
+++ b/apiserver/modelconfig/backend.go
@@ -15,6 +15,7 @@ type Backend interface {
 	common.BlockGetter
 	ModelConfigValues() (config.ConfigValues, error)
 	ModelConfigDefaultValues() (config.ConfigValues, error)
+	UpdateModelConfigDefaultValues(map[string]interface{}, []string) error
 	UpdateModelConfig(map[string]interface{}, []string, state.ValidateConfigFunc) error
 }
 

--- a/apiserver/modelconfig/backend.go
+++ b/apiserver/modelconfig/backend.go
@@ -14,6 +14,7 @@ import (
 type Backend interface {
 	common.BlockGetter
 	ModelConfigValues() (config.ConfigValues, error)
+	ModelConfigDefaultValues() (config.ConfigValues, error)
 	UpdateModelConfig(map[string]interface{}, []string, state.ValidateConfigFunc) error
 }
 

--- a/apiserver/modelconfig/modelconfig.go
+++ b/apiserver/modelconfig/modelconfig.go
@@ -128,3 +128,20 @@ func (c *ModelConfigAPI) ModelUnset(args params.ModelUnset) error {
 	// changed underneath us.
 	return c.backend.UpdateModelConfig(nil, args.Keys, nil)
 }
+
+// ModelDefaults returns the default config values used when creating a new model.
+func (c *ModelConfigAPI) ModelDefaults() (params.ModelConfigResults, error) {
+	result := params.ModelConfigResults{}
+	values, err := c.backend.ModelConfigDefaultValues()
+	if err != nil {
+		return result, err
+	}
+	result.Config = make(map[string]params.ConfigValue)
+	for attr, val := range values {
+		result.Config[attr] = params.ConfigValue{
+			Value:  val.Value,
+			Source: val.Source,
+		}
+	}
+	return result, nil
+}

--- a/apiserver/modelconfig/modelconfig.go
+++ b/apiserver/modelconfig/modelconfig.go
@@ -111,9 +111,6 @@ func (c *ModelConfigAPI) ModelSet(args params.ModelSet) error {
 	}
 	// Replace any deprecated attributes with their new values.
 	attrs := config.ProcessDeprecatedAttributes(args.Config)
-	// TODO(waigani) 2014-3-11 #1167616
-	// Add a txn retry loop to ensure that the settings on disk have not
-	// changed underneath us.
 	return c.backend.UpdateModelConfig(attrs, nil, checkAgentVersion)
 }
 
@@ -123,9 +120,6 @@ func (c *ModelConfigAPI) ModelUnset(args params.ModelUnset) error {
 	if err := c.check.ChangeAllowed(); err != nil {
 		return errors.Trace(err)
 	}
-	// TODO(waigani) 2014-3-11 #1167616
-	// Add a txn retry loop to ensure that the settings on disk have not
-	// changed underneath us.
 	return c.backend.UpdateModelConfig(nil, args.Keys, nil)
 }
 
@@ -144,4 +138,24 @@ func (c *ModelConfigAPI) ModelDefaults() (params.ModelConfigResults, error) {
 		}
 	}
 	return result, nil
+}
+
+// SetModelDefaults writes new values for the specified default model settings.
+func (c *ModelConfigAPI) SetModelDefaults(args params.ModelSet) error {
+	if err := c.check.ChangeAllowed(); err != nil {
+		return errors.Trace(err)
+	}
+	// Make sure we don't allow changing agent-version.
+	if _, found := args.Config["agent-version"]; found {
+		return errors.New("agent-version cannot have a default value")
+	}
+	return c.backend.UpdateModelConfigDefaultValues(args.Config, nil)
+}
+
+// UnsetModelDefaults removes the specified default model settings.
+func (c *ModelConfigAPI) UnsetModelDefaults(args params.ModelUnset) error {
+	if err := c.check.ChangeAllowed(); err != nil {
+		return errors.Trace(err)
+	}
+	return c.backend.UpdateModelConfigDefaultValues(nil, args.Keys)
 }

--- a/apiserver/modelconfig/modelconfig_test.go
+++ b/apiserver/modelconfig/modelconfig_test.go
@@ -41,6 +41,10 @@ func (s *modelconfigSuite) SetUpTest(c *gc.C) {
 			"ftp-proxy":       {"http://proxy", "model"},
 			"authorized-keys": {testing.FakeAuthKeys, "model"},
 		},
+		cfgDefaults: config.ConfigValues{
+			"attr":  {Value: "val", Source: "controller"},
+			"attr2": {Value: "val2", Source: "controller"},
+		},
 	}
 	var err error
 	s.api, err = modelconfig.NewModelConfigAPI(s.backend, &s.authorizer)
@@ -98,10 +102,10 @@ func (s *modelconfigSuite) assertModelSetBlocked(c *gc.C, args map[string]interf
 	s.assertBlocked(c, err, msg)
 }
 
-func (s *modelconfigSuite) TestBlockChangesClientModelSet(c *gc.C) {
-	s.blockAllChanges(c, "TestBlockChangesClientModelSet")
+func (s *modelconfigSuite) TestBlockChangesModelSet(c *gc.C) {
+	s.blockAllChanges(c, "TestBlockChangesModelSet")
 	args := map[string]interface{}{"some-key": "value"}
-	s.assertModelSetBlocked(c, args, "TestBlockChangesClientModelSet")
+	s.assertModelSetBlocked(c, args, "TestBlockChangesModelSet")
 }
 
 func (s *modelconfigSuite) TestModelSetCannotChangeAgentVersion(c *gc.C) {
@@ -135,14 +139,14 @@ func (s *modelconfigSuite) TestModelUnset(c *gc.C) {
 	s.assertConfigValueMissing(c, "abc")
 }
 
-func (s *modelconfigSuite) TestBlockClientModelUnset(c *gc.C) {
+func (s *modelconfigSuite) TestBlockModelUnset(c *gc.C) {
 	err := s.backend.UpdateModelConfig(map[string]interface{}{"abc": 123}, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.blockAllChanges(c, "TestBlockClientModelUnset")
+	s.blockAllChanges(c, "TestBlockModelUnset")
 
 	args := params.ModelUnset{[]string{"abc"}}
 	err = s.api.ModelUnset(args)
-	s.assertBlocked(c, err, "TestBlockClientModelUnset")
+	s.assertBlocked(c, err, "TestBlockModelUnset")
 }
 
 func (s *modelconfigSuite) TestModelUnsetMissing(c *gc.C) {
@@ -156,17 +160,63 @@ func (s *modelconfigSuite) TestModelDefaults(c *gc.C) {
 	result, err := s.api.ModelDefaults()
 	c.Assert(err, jc.ErrorIsNil)
 	expectedValues := map[string]params.ConfigValue{
-		"attr":  {Value: "val", Source: "default"},
+		"attr":  {Value: "val", Source: "controller"},
 		"attr2": {Value: "val2", Source: "controller"},
 	}
 	c.Assert(result.Config, jc.DeepEquals, expectedValues)
 }
 
+func (s *modelconfigSuite) TestSetModelDefaults(c *gc.C) {
+	params := params.ModelSet{
+		Config: map[string]interface{}{
+			"attr3": "val3",
+			"attr4": "val4"},
+	}
+	err := s.api.SetModelDefaults(params)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.backend.cfgDefaults, jc.DeepEquals, config.ConfigValues{
+		"attr":  {Value: "val", Source: "controller"},
+		"attr2": {Value: "val2", Source: "controller"},
+		"attr3": {Value: "val3", Source: "controller"},
+		"attr4": {Value: "val4", Source: "controller"},
+	})
+}
+
+func (s *modelconfigSuite) TestBlockChangesSetModelDefaults(c *gc.C) {
+	s.blockAllChanges(c, "TestBlockChangesSetModelDefaults")
+	err := s.api.SetModelDefaults(params.ModelSet{})
+	s.assertBlocked(c, err, "TestBlockChangesSetModelDefaults")
+}
+
+func (s *modelconfigSuite) TestUnsetModelDefaults(c *gc.C) {
+	args := params.ModelUnset{[]string{"attr"}}
+	err := s.api.UnsetModelDefaults(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.backend.cfgDefaults, jc.DeepEquals, config.ConfigValues{
+		"attr2": {Value: "val2", Source: "controller"},
+	})
+}
+
+func (s *modelconfigSuite) TestBlockUnsetModelDefaults(c *gc.C) {
+	s.blockAllChanges(c, "TestBlockUnsetModelDefaults")
+	args := params.ModelUnset{[]string{"abc"}}
+	err := s.api.UnsetModelDefaults(args)
+	s.assertBlocked(c, err, "TestBlockUnsetModelDefaults")
+}
+
+func (s *modelconfigSuite) TestUnsetModelDefaultsMissing(c *gc.C) {
+	// It's okay to unset a non-existent attribute.
+	args := params.ModelUnset{[]string{"not_there"}}
+	err := s.api.UnsetModelDefaults(args)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 type mockBackend struct {
-	cfg config.ConfigValues
-	old *config.Config
-	b   state.BlockType
-	msg string
+	cfg         config.ConfigValues
+	cfgDefaults config.ConfigValues
+	old         *config.Config
+	b           state.BlockType
+	msg         string
 }
 
 func (m *mockBackend) ModelConfigValues() (config.ConfigValues, error) {
@@ -174,10 +224,7 @@ func (m *mockBackend) ModelConfigValues() (config.ConfigValues, error) {
 }
 
 func (m *mockBackend) ModelConfigDefaultValues() (config.ConfigValues, error) {
-	return config.ConfigValues{
-		"attr":  {Value: "val", Source: "default"},
-		"attr2": {Value: "val2", Source: "controller"},
-	}, nil
+	return m.cfgDefaults, nil
 }
 
 func (m *mockBackend) UpdateModelConfig(update map[string]interface{}, remove []string, validate state.ValidateConfigFunc) error {
@@ -192,6 +239,16 @@ func (m *mockBackend) UpdateModelConfig(update map[string]interface{}, remove []
 	}
 	for _, n := range remove {
 		delete(m.cfg, n)
+	}
+	return nil
+}
+
+func (m *mockBackend) UpdateModelConfigDefaultValues(update map[string]interface{}, remove []string) error {
+	for k, v := range update {
+		m.cfgDefaults[k] = config.ConfigValue{v, "controller"}
+	}
+	for _, n := range remove {
+		delete(m.cfgDefaults, n)
 	}
 	return nil
 }

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -290,6 +290,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 
 	// Manage model
 	r.Register(model.NewGetCommand())
+	r.Register(model.NewModelDefaultsCommand())
 	r.Register(model.NewSetCommand())
 	r.Register(model.NewUnsetCommand())
 	r.Register(model.NewRetryProvisioningCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -441,6 +441,7 @@ var commandNames = []string{
 	"machine",
 	"machines",
 	"model-config",
+	"model-defaults",
 	"models",
 	"plans",
 	"register",

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -34,6 +34,14 @@ func NewUnsetCommandForTest(api UnsetModelAPI) cmd.Command {
 	return modelcmd.Wrap(cmd)
 }
 
+// NewGetDefaultsCommandForTest returns a GetDefaultsCommand with the api provided as specified.
+func NewGetDefaultsCommandForTest(api modelDefaultsAPI) cmd.Command {
+	cmd := &getDefaultsCommand{
+		newAPIFunc: func() (modelDefaultsAPI, error) { return api, nil },
+	}
+	return modelcmd.Wrap(cmd)
+}
+
 // NewRetryProvisioningCommandForTest returns a RetryProvisioningCommand with the api provided as specified.
 func NewRetryProvisioningCommandForTest(api RetryProvisioningAPI) cmd.Command {
 	cmd := &retryProvisioningCommand{

--- a/cmd/juju/model/fakeenv_test.go
+++ b/cmd/juju/model/fakeenv_test.go
@@ -48,6 +48,13 @@ func (f *fakeEnvAPI) ModelGetWithMetadata() (config.ConfigValues, error) {
 	return result, nil
 }
 
+func (f *fakeEnvAPI) ModelDefaults() (config.ConfigValues, error) {
+	return config.ConfigValues{
+		"attr":  {Value: "foo", Source: "default"},
+		"attr2": {Value: "bar", Source: "controller"},
+	}, nil
+}
+
 func (f *fakeEnvAPI) ModelSet(config map[string]interface{}) error {
 	f.values = config
 	return f.err

--- a/cmd/juju/model/getdefaults.go
+++ b/cmd/juju/model/getdefaults.go
@@ -1,0 +1,165 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package model
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/api/modelconfig"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/environs/config"
+)
+
+// NewModelDefaultsCommand returns a command used to print the
+// default model config attributes.
+func NewModelDefaultsCommand() cmd.Command {
+	c := &getDefaultsCommand{}
+	c.newAPIFunc = func() (modelDefaultsAPI, error) {
+		api, err := c.NewAPIRoot()
+		if err != nil {
+			return nil, errors.Annotate(err, "opening API connection")
+		}
+		return modelconfig.NewClient(api), nil
+	}
+	return modelcmd.Wrap(c)
+}
+
+type getDefaultsCommand struct {
+	modelcmd.ModelCommandBase
+	newAPIFunc func() (modelDefaultsAPI, error)
+	key        string
+	out        cmd.Output
+}
+
+const modelDefaultsHelpDoc = `
+By default, all default configuration (keys and values) are
+displayed if a key is not specified.
+By default, the model is the current model.
+
+Examples:
+
+    juju model-defaults
+    juju model-defaults http-proxy
+    juju model-defaults -m mymodel type
+
+See also:
+    models
+    set-model-defaults
+    unset-model-defaults
+    set-model-config
+    get-model-config
+    unset-model-config
+`
+
+func (c *getDefaultsCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "model-defaults",
+		Args:    "[<model key>]",
+		Purpose: "Displays default configuration settings for a model.",
+		Doc:     strings.TrimSpace(modelDefaultsHelpDoc),
+	}
+}
+
+func (c *getDefaultsCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
+		"yaml":    cmd.FormatYaml,
+		"json":    cmd.FormatJson,
+		"tabular": formatDefaultConfigTabular,
+	})
+}
+
+func (c *getDefaultsCommand) Init(args []string) (err error) {
+	c.key, err = cmd.ZeroOrOneArgs(args)
+	return
+}
+
+// modelDefaultsAPI defines the api methods used by this command.
+type modelDefaultsAPI interface {
+	// Close closes the api connection.
+	Close() error
+
+	// ModelDefaults returns the default config values used when creating a new model.
+	ModelDefaults() (config.ConfigValues, error)
+}
+
+func (c *getDefaultsCommand) Run(ctx *cmd.Context) error {
+	client, err := c.newAPIFunc()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	attrs, err := client.ModelDefaults()
+	if err != nil {
+		return err
+	}
+
+	if c.key != "" {
+		if value, ok := attrs[c.key]; ok {
+			attrs = config.ConfigValues{
+				c.key: value,
+			}
+		} else {
+			return errors.Errorf("key %q not found in %q model defaults.", c.key, attrs["name"])
+		}
+	}
+	// If key is empty, write out the whole lot.
+	return c.out.Write(ctx, attrs)
+}
+
+// formatConfigTabular returns a tabular summary of default config information.
+func formatDefaultConfigTabular(value interface{}) ([]byte, error) {
+	configValues, ok := value.(config.ConfigValues)
+	if !ok {
+		return nil, errors.Errorf("expected value of type %T, got %T", configValues, value)
+	}
+
+	var out bytes.Buffer
+	const (
+		// To format things into columns.
+		minwidth = 0
+		tabwidth = 1
+		padding  = 2
+		padchar  = ' '
+		flags    = 0
+	)
+	tw := tabwriter.NewWriter(&out, minwidth, tabwidth, padding, padchar, flags)
+	p := func(values ...string) {
+		text := strings.Join(values, "\t")
+		fmt.Fprintln(tw, text)
+	}
+	var valueNames []string
+	for name := range configValues {
+		valueNames = append(valueNames, name)
+	}
+	sort.Strings(valueNames)
+	p("ATTRIBUTE\tDEFAULT\tCONTROLLER")
+
+	for _, name := range valueNames {
+		info := configValues[name]
+		val, err := cmd.FormatSmart(info.Value)
+		if err != nil {
+			return nil, errors.Annotatef(err, "formatting value for %q", name)
+		}
+		d := "-"
+		c := "-"
+		if info.Source == "default" {
+			d = string(val)
+		} else {
+			c = string(val)
+		}
+		p(name, d, c)
+	}
+
+	tw.Flush()
+	return out.Bytes(), nil
+}

--- a/cmd/juju/model/getdefaults_test.go
+++ b/cmd/juju/model/getdefaults_test.go
@@ -1,0 +1,92 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package model_test
+
+import (
+	"strings"
+
+	"github.com/juju/cmd"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/model"
+	"github.com/juju/juju/testing"
+)
+
+type getDefaultsSuite struct {
+	fakeEnvSuite
+}
+
+var _ = gc.Suite(&getDefaultsSuite{})
+
+func (s *getDefaultsSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
+	command := model.NewGetDefaultsCommandForTest(s.fake)
+	return testing.RunCommand(c, command, args...)
+}
+
+func (s *getDefaultsSuite) TestInitArgCount(c *gc.C) {
+	// zero or one args is fine.
+	err := testing.InitCommand(model.NewGetDefaultsCommandForTest(s.fake), nil)
+	c.Check(err, jc.ErrorIsNil)
+	err = testing.InitCommand(model.NewGetDefaultsCommandForTest(s.fake), []string{"one"})
+	c.Check(err, jc.ErrorIsNil)
+	// More than one is not allowed.
+	err = testing.InitCommand(model.NewGetDefaultsCommandForTest(s.fake), []string{"one", "two"})
+	c.Check(err, gc.ErrorMatches, `unrecognized args: \["two"\]`)
+}
+
+func (s *getDefaultsSuite) TestSingleValue(c *gc.C) {
+	context, err := s.run(c, "attr")
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(testing.Stdout(context))
+	expected := "" +
+		"ATTRIBUTE  DEFAULT  CONTROLLER\n" +
+		"attr       foo      -"
+	c.Assert(output, gc.Equals, expected)
+}
+
+func (s *getDefaultsSuite) TestSingleValueJSON(c *gc.C) {
+	context, err := s.run(c, "--format=json", "attr")
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(testing.Stdout(context))
+	c.Assert(output, gc.Equals, `{"attr":{"Value":"foo","Source":"default"}}`)
+}
+
+func (s *getDefaultsSuite) TestAllValuesYAML(c *gc.C) {
+	context, err := s.run(c, "--format=yaml")
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(testing.Stdout(context))
+	expected := "" +
+		"attr:\n" +
+		"  value: foo\n" +
+		"  source: default\n" +
+		"attr2:\n" +
+		"  value: bar\n" +
+		"  source: controller"
+	c.Assert(output, gc.Equals, expected)
+}
+
+func (s *getDefaultsSuite) TestAllValuesJSON(c *gc.C) {
+	context, err := s.run(c, "--format=json")
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(testing.Stdout(context))
+	expected := `{"attr":{"Value":"foo","Source":"default"},"attr2":{"Value":"bar","Source":"controller"}}`
+	c.Assert(output, gc.Equals, expected)
+}
+
+func (s *getDefaultsSuite) TestAllValuesTabular(c *gc.C) {
+	context, err := s.run(c)
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(testing.Stdout(context))
+	expected := "" +
+		"ATTRIBUTE  DEFAULT  CONTROLLER\n" +
+		"attr       foo      -\n" +
+		"attr2      -        bar"
+	c.Assert(output, gc.Equals, expected)
+}

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -300,3 +300,25 @@ func (s *ModelConfigSourceSuite) TestModelConfigUpdateSource(c *gc.C) {
 	modelAttributes := set.NewStrings("name", "http-proxy", "logging-config", "authorized-keys", "resource-tags")
 	s.assertModelConfigValues(c, modelCfg, modelAttributes, set.NewStrings("apt-mirror"))
 }
+
+func (s *ModelConfigSourceSuite) TestModelConfigDefaults(c *gc.C) {
+	expectedValues := make(config.ConfigValues)
+	for attr, val := range config.ConfigDefaults() {
+		source := "default"
+		expectedValues[attr] = config.ConfigValue{
+			Value:  val,
+			Source: source,
+		}
+	}
+	expectedValues["http-proxy"] = config.ConfigValue{
+		Value:  "http://proxy",
+		Source: "controller",
+	}
+	expectedValues["apt-mirror"] = config.ConfigValue{
+		Value:  "http://mirror",
+		Source: "controller",
+	}
+	sources, err := s.State.ModelConfigDefaultValues()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sources, jc.DeepEquals, expectedValues)
+}


### PR DESCRIPTION
Depends on https://github.com/juju/juju/pull/5919

Add the api and apiserver and state implementations to allow the set-model-defaults and unset-model-defaults commands to work.

(Review request: http://reviews.vapour.ws/r/5370/)