### PR TITLE
api: allow empty CA cert

### DIFF
--- a/api/interface.go
+++ b/api/interface.go
@@ -37,6 +37,8 @@ type Info struct {
 
 	// CACert holds the CA certificate that will be used
 	// to validate the controller's certificate, in PEM format.
+	// If this is empty, the standard system root certificates
+	// will be used.
 	CACert string
 
 	// ModelTag holds the model tag for the model we are
@@ -88,9 +90,6 @@ func (info *Info) Validate() error {
 	}
 	if _, err := network.ParseHostPorts(info.Addrs...); err != nil {
 		return errors.NotValidf("host addresses: %v", err)
-	}
-	if info.CACert == "" {
-		return errors.NotValidf("missing CA certificate")
 	}
 	if info.SkipLogin {
 		if info.Tag != nil {


### PR DESCRIPTION
This will allow the client to connect to a controller that uses
a certificate in the standard HTTPS chain of trust.

(Review request: http://reviews.vapour.ws/r/5374/)