### PR TITLE
state: separate refcounts from migrations

### DIFF
--- a/core/description/application.go
+++ b/core/description/application.go
@@ -35,8 +35,7 @@ type application struct {
 	Status_        *status `yaml:"status"`
 	StatusHistory_ `yaml:"status-history"`
 
-	Settings_         map[string]interface{} `yaml:"settings"`
-	SettingsRefCount_ int                    `yaml:"settings-refcount"`
+	Settings_ map[string]interface{} `yaml:"settings"`
 
 	Leader_             string                 `yaml:"leader,omitempty"`
 	LeadershipSettings_ map[string]interface{} `yaml:"leadership-settings"`
@@ -65,7 +64,6 @@ type ApplicationArgs struct {
 	Exposed              bool
 	MinUnits             int
 	Settings             map[string]interface{}
-	SettingsRefCount     int
 	Leader               string
 	LeadershipSettings   map[string]interface{}
 	MetricsCredentials   []byte
@@ -84,7 +82,6 @@ func newApplication(args ApplicationArgs) *application {
 		Exposed_:              args.Exposed,
 		MinUnits_:             args.MinUnits,
 		Settings_:             args.Settings,
-		SettingsRefCount_:     args.SettingsRefCount,
 		Leader_:               args.Leader,
 		LeadershipSettings_:   args.LeadershipSettings,
 		MetricsCredentials_:   creds,
@@ -147,11 +144,6 @@ func (s *application) MinUnits() int {
 // Settings implements Application.
 func (s *application) Settings() map[string]interface{} {
 	return s.Settings_
-}
-
-// SettingsRefCount implements Application.
-func (s *application) SettingsRefCount() int {
-	return s.SettingsRefCount_
 }
 
 // Leader implements Application.
@@ -310,7 +302,6 @@ func importApplicationV1(source map[string]interface{}) (*application, error) {
 		"min-units":           schema.Int(),
 		"status":              schema.StringMap(schema.Any()),
 		"settings":            schema.StringMap(schema.Any()),
-		"settings-refcount":   schema.Int(),
 		"leader":              schema.String(),
 		"leadership-settings": schema.StringMap(schema.Any()),
 		"metrics-creds":       schema.String(),
@@ -348,7 +339,6 @@ func importApplicationV1(source map[string]interface{}) (*application, error) {
 		Exposed_:              valid["exposed"].(bool),
 		MinUnits_:             int(valid["min-units"].(int64)),
 		Settings_:             valid["settings"].(map[string]interface{}),
-		SettingsRefCount_:     int(valid["settings-refcount"].(int64)),
 		Leader_:               valid["leader"].(string),
 		LeadershipSettings_:   valid["leadership-settings"].(map[string]interface{}),
 		StatusHistory_:        newStatusHistory(),

--- a/core/description/application_test.go
+++ b/core/description/application_test.go
@@ -47,8 +47,7 @@ func minimalApplicationMap() map[interface{}]interface{} {
 		"settings": map[interface{}]interface{}{
 			"key": "value",
 		},
-		"settings-refcount": 1,
-		"leader":            "ubuntu/0",
+		"leader": "ubuntu/0",
 		"leadership-settings": map[interface{}]interface{}{
 			"leader": true,
 		},
@@ -91,8 +90,7 @@ func minimalApplicationArgs() ApplicationArgs {
 		Settings: map[string]interface{}{
 			"key": "value",
 		},
-		SettingsRefCount: 1,
-		Leader:           "ubuntu/0",
+		Leader: "ubuntu/0",
 		LeadershipSettings: map[string]interface{}{
 			"leader": true,
 		},
@@ -114,8 +112,7 @@ func (s *ApplicationSerializationSuite) TestNewApplication(c *gc.C) {
 		Settings: map[string]interface{}{
 			"key": "value",
 		},
-		SettingsRefCount: 1,
-		Leader:           "magic/1",
+		Leader: "magic/1",
 		LeadershipSettings: map[string]interface{}{
 			"leader": true,
 		},
@@ -134,7 +131,6 @@ func (s *ApplicationSerializationSuite) TestNewApplication(c *gc.C) {
 	c.Assert(application.Exposed(), jc.IsTrue)
 	c.Assert(application.MinUnits(), gc.Equals, 42)
 	c.Assert(application.Settings(), jc.DeepEquals, args.Settings)
-	c.Assert(application.SettingsRefCount(), gc.Equals, 1)
 	c.Assert(application.Leader(), gc.Equals, "magic/1")
 	c.Assert(application.LeadershipSettings(), jc.DeepEquals, args.LeadershipSettings)
 	c.Assert(application.MetricsCredentials(), jc.DeepEquals, []byte("sekrit"))

--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -253,7 +253,6 @@ type Application interface {
 	MinUnits() int
 
 	Settings() map[string]interface{}
-	SettingsRefCount() int
 
 	Leader() string
 	LeadershipSettings() map[string]interface{}

--- a/state/application.go
+++ b/state/application.go
@@ -90,8 +90,8 @@ func (s *Application) globalKey() string {
 	return applicationGlobalKey(s.doc.Name)
 }
 
-func applicationSettingsKey(applicationname string, curl *charm.URL) string {
-	return fmt.Sprintf("a#%s#%s", applicationname, curl)
+func applicationSettingsKey(appName string, curl *charm.URL) string {
+	return fmt.Sprintf("a#%s#%s", appName, curl)
 }
 
 // settingsKey returns the charm-version-specific settings collection
@@ -246,7 +246,6 @@ func removeResourcesOps(st *State, serviceID string) ([]txn.Op, error) {
 // removeOps returns the operations required to remove the service. Supplied
 // asserts will be included in the operation on the application document.
 func (s *Application) removeOps(asserts bson.D) []txn.Op {
-	settingsDocID := s.st.docID(s.settingsKey())
 	ops := []txn.Op{
 		{
 			C:      applicationsC,
@@ -254,14 +253,11 @@ func (s *Application) removeOps(asserts bson.D) []txn.Op {
 			Assert: asserts,
 			Remove: true,
 		}, {
-			C:      settingsrefsC,
-			Id:     settingsDocID,
-			Remove: true,
-		}, {
 			C:      settingsC,
-			Id:     settingsDocID,
+			Id:     s.settingsKey(),
 			Remove: true,
 		},
+		nsRefcounts.JustRemoveOp(settingsrefsC, s.settingsKey()),
 		removeEndpointBindingsOp(s.globalKey()),
 		removeStorageConstraintsOp(s.globalKey()),
 		removeConstraintsOp(s.st, s.globalKey()),
@@ -1507,91 +1503,49 @@ func (s *Application) StorageConstraints() (map[string]StorageConstraints, error
 }
 
 // settingsIncRefOp returns an operation that increments the ref count
-// of the application settings identified by applicationname and curl. If
+// of the application settings identified by appName and curl. If
 // canCreate is false, a missing document will be treated as an error;
 // otherwise, it will be created with a ref count of 1.
-func settingsIncRefOp(st *State, applicationname string, curl *charm.URL, canCreate bool) (txn.Op, error) {
+func settingsIncRefOp(st *State, appName string, curl *charm.URL, canCreate bool) (txn.Op, error) {
 	settingsrefs, closer := st.getCollection(settingsrefsC)
 	defer closer()
 
-	key := applicationSettingsKey(applicationname, curl)
-	if count, err := settingsrefs.FindId(key).Count(); err != nil {
-		return txn.Op{}, err
-	} else if count == 0 {
-		if !canCreate {
-			return txn.Op{}, errors.NotFoundf("application %q settings for charm %q", applicationname, curl)
-		}
-		return txn.Op{
-			C:      settingsrefsC,
-			Id:     st.docID(key),
-			Assert: txn.DocMissing,
-			Insert: settingsRefsDoc{
-				RefCount:  1,
-				ModelUUID: st.ModelUUID()},
-		}, nil
+	getOp := nsRefcounts.CreateIncRefOp
+	if !canCreate {
+		getOp = nsRefcounts.StrictIncRefOp
 	}
-	return txn.Op{
-		C:      settingsrefsC,
-		Id:     st.docID(key),
-		Assert: txn.DocExists,
-		Update: bson.D{{"$inc", bson.D{{"refcount", 1}}}},
-	}, nil
+
+	key := applicationSettingsKey(appName, curl)
+	op, err := getOp(settingsrefs, key)
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
+	return op, nil
 }
 
 // settingsDecRefOps returns a list of operations that decrement the
-// ref count of the application settings identified by applicationname and
+// ref count of the application settings identified by appName and
 // curl. If the ref count is set to zero, the appropriate setting and
 // ref count documents will both be deleted.
-func settingsDecRefOps(st *State, applicationname string, curl *charm.URL) ([]txn.Op, error) {
+func settingsDecRefOps(st *State, appName string, curl *charm.URL) ([]txn.Op, error) {
 	settingsrefs, closer := st.getCollection(settingsrefsC)
 	defer closer()
 
-	key := applicationSettingsKey(applicationname, curl)
-	var doc settingsRefsDoc
-	if err := settingsrefs.FindId(key).One(&doc); err == mgo.ErrNotFound {
-		return nil, errors.NotFoundf("application %q settings for charm %q", applicationname, curl)
-	} else if err != nil {
-		return nil, err
+	key := applicationSettingsKey(appName, curl)
+	op, isFinal, err := nsRefcounts.DyingDecRefOp(settingsrefs, key)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	docID := st.docID(key)
-	if doc.RefCount == 1 {
-		return []txn.Op{{
-			C:      settingsrefsC,
-			Id:     docID,
-			Assert: bson.D{{"refcount", 1}},
-			Remove: true,
-		}, {
-			C:      settingsC,
-			Id:     docID,
-			Remove: true,
-		}}, nil
-	}
-	return []txn.Op{{
-		C:      settingsrefsC,
-		Id:     docID,
-		Assert: bson.D{{"refcount", bson.D{{"$gt", 1}}}},
-		Update: bson.D{{"$inc", bson.D{{"refcount", -1}}}},
-	}}, nil
-}
 
-// settingsRefsDoc holds the number of units and services using the
-// settings document identified by the document's id. Every time a
-// application upgrades its charm the settings doc ref count for the new
-// charm url is incremented, and the old settings is ref count is
-// decremented. When a unit upgrades to the new charm, the old service
-// settings ref count is decremented and the ref count of the new
-// charm settings is incremented. The last unit upgrading to the new
-// charm is responsible for deleting the old charm's settings doc.
-//
-// Note: We're not using the settingsDoc for this because changing
-// just the ref count is not considered a change worth reporting
-// to watchers and firing config-changed hooks.
-//
-// There is an implicit _id field here, which mongo creates, which is
-// always the same as the settingsDoc's id.
-type settingsRefsDoc struct {
-	RefCount  int
-	ModelUUID string `bson:"model-uuid"`
+	ops := []txn.Op{op}
+	if isFinal {
+		ops = append(ops, txn.Op{
+			C:      settingsC,
+			Id:     key,
+			Remove: true,
+		})
+	}
+	return ops, nil
 }
 
 // Status returns the status of the service.
@@ -1708,12 +1662,11 @@ var statusServerities = map[status.Status]int{
 }
 
 type addApplicationOpsArgs struct {
-	applicationDoc   *applicationDoc
-	statusDoc        statusDoc
-	constraints      constraints.Value
-	storage          map[string]StorageConstraints
-	settings         map[string]interface{}
-	settingsRefCount int
+	applicationDoc *applicationDoc
+	statusDoc      statusDoc
+	constraints    constraints.Value
+	storage        map[string]StorageConstraints
+	settings       map[string]interface{}
 	// These are nil when adding a new service, and most likely
 	// non-nil when migrating.
 	leadershipSettings map[string]interface{}
@@ -1737,14 +1690,8 @@ func addApplicationOps(st *State, args addApplicationOpsArgs) []txn.Op {
 		createSettingsOp(settingsC, leadershipKey, args.leadershipSettings),
 		createStatusOp(st, globalKey, args.statusDoc),
 		addModelServiceRefOp(st, svc.Name()),
+		nsRefcounts.JustCreateOp(settingsrefsC, settingsKey, 1),
 		{
-			C:      settingsrefsC,
-			Id:     settingsKey,
-			Assert: txn.DocMissing,
-			Insert: settingsRefsDoc{
-				RefCount: args.settingsRefCount,
-			},
-		}, {
 			C:      applicationsC,
 			Id:     svc.Name(),
 			Assert: txn.DocMissing,

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
-	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
@@ -948,7 +947,7 @@ func (s *ServiceSuite) TestUpdateConfigSettings(c *gc.C) {
 
 func assertNoSettingsRef(c *gc.C, st *state.State, svcName string, sch *state.Charm) {
 	_, err := state.ServiceSettingsRefCount(st, svcName, sch.URL())
-	c.Assert(err, gc.Equals, mgo.ErrNotFound)
+	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsNotFound)
 }
 
 func assertSettingsRef(c *gc.C, st *state.State, svcName string, sch *state.Charm, refcount int) {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -104,16 +104,12 @@ func (doc *MachineDoc) String() string {
 	return m.String()
 }
 
-func ServiceSettingsRefCount(st *State, applicationname string, curl *charm.URL) (int, error) {
+func ServiceSettingsRefCount(st *State, appName string, curl *charm.URL) (int, error) {
 	settingsRefsCollection, closer := st.getCollection(settingsrefsC)
 	defer closer()
 
-	key := applicationSettingsKey(applicationname, curl)
-	var doc settingsRefsDoc
-	if err := settingsRefsCollection.FindId(key).One(&doc); err == nil {
-		return doc.RefCount, nil
-	}
-	return 0, mgo.ErrNotFound
+	key := applicationSettingsKey(appName, curl)
+	return nsRefcounts.read(settingsRefsCollection, key)
 }
 
 func AddTestingCharm(c *gc.C, st *State, name string) *Charm {

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -459,11 +459,6 @@ func (e *exporter) applications() error {
 	}
 	e.logger.Debugf("found %d applications", len(applications))
 
-	refcounts, err := e.readAllSettingsRefCounts()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
 	e.units, err = e.readAllUnits()
 	if err != nil {
 		return errors.Trace(err)
@@ -482,7 +477,7 @@ func (e *exporter) applications() error {
 	for _, application := range applications {
 		applicationUnits := e.units[application.Name()]
 		leader := leaders[application.Name()]
-		if err := e.addApplication(application, refcounts, applicationUnits, meterStatus, leader); err != nil {
+		if err := e.addApplication(application, applicationUnits, meterStatus, leader); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -502,17 +497,13 @@ func (e *exporter) readApplicationLeaders() (map[string]string, error) {
 	return result, nil
 }
 
-func (e *exporter) addApplication(application *Application, refcounts map[string]int, units []*Unit, meterStatus map[string]*meterStatusDoc, leader string) error {
+func (e *exporter) addApplication(application *Application, units []*Unit, meterStatus map[string]*meterStatusDoc, leader string) error {
 	settingsKey := application.settingsKey()
 	leadershipKey := leadershipSettingsKey(application.Name())
 
 	applicationSettingsDoc, found := e.modelSettings[settingsKey]
 	if !found {
 		return errors.Errorf("missing settings for application %q", application.Name())
-	}
-	refCount, found := refcounts[settingsKey]
-	if !found {
-		return errors.Errorf("missing settings refcount for application %q", application.Name())
 	}
 	leadershipSettingsDoc, found := e.modelSettings[leadershipKey]
 	if !found {
@@ -530,7 +521,6 @@ func (e *exporter) addApplication(application *Application, refcounts map[string
 		Exposed:              application.doc.Exposed,
 		MinUnits:             application.doc.MinUnits,
 		Settings:             applicationSettingsDoc.Settings,
-		SettingsRefCount:     refCount,
 		Leader:               leader,
 		LeadershipSettings:   leadershipSettingsDoc.Settings,
 		MetricsCredentials:   application.doc.MetricCredentials,
@@ -1076,34 +1066,6 @@ func (e *exporter) constraintsArgs(globalKey string) (description.ConstraintsArg
 	if optionalErr != nil {
 		return description.ConstraintsArgs{}, errors.Trace(optionalErr)
 	}
-	return result, nil
-}
-
-func (e *exporter) readAllSettingsRefCounts() (map[string]int, error) {
-	refCounts, closer := e.st.getCollection(settingsrefsC)
-	defer closer()
-
-	var docs []bson.M
-	err := refCounts.Find(nil).All(&docs)
-	if err != nil {
-		return nil, errors.Annotate(err, "failed to read settings refcount collection")
-	}
-
-	e.logger.Debugf("read %d settings refcount documents", len(docs))
-	result := make(map[string]int)
-	for _, doc := range docs {
-		docId, ok := doc["_id"].(string)
-		if !ok {
-			return nil, errors.Errorf("expected string, got %s (%T)", doc["_id"], doc["_id"])
-		}
-		id := e.st.localID(docId)
-		count, ok := doc["refcount"].(int)
-		if !ok {
-			return nil, errors.Errorf("expected int, got %s (%T)", doc["refcount"], doc["refcount"])
-		}
-		result[id] = count
-	}
-
 	return result, nil
 }
 

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -325,7 +325,6 @@ func (s *MigrationExportSuite) assertMigrateApplications(c *gc.C, cons constrain
 	c.Assert(exported.Settings(), jc.DeepEquals, map[string]interface{}{
 		"foo": "bar",
 	})
-	c.Assert(exported.SettingsRefCount(), gc.Equals, 1)
 	c.Assert(exported.LeadershipSettings(), jc.DeepEquals, map[string]interface{}{
 		"leader": "true",
 	})

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -596,7 +596,6 @@ func (i *importer) application(s description.Application) error {
 		constraints:    i.constraints(s.Constraints()),
 		// storage          TODO,
 		settings:           s.Settings(),
-		settingsRefCount:   s.SettingsRefCount(),
 		leadershipSettings: s.LeadershipSettings(),
 	})
 

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -41,9 +41,6 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		unitsC,
 		meterStatusC, // red / green status for metrics of units
 
-		// settings reference counts are only used for applications
-		settingsrefsC,
-
 		// relation
 		relationsC,
 		relationScopesC,
@@ -85,6 +82,9 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		metricsC,
 		// Backup and restore information is not migrated.
 		restoreInfoC,
+		// reference counts are implementation details that should be
+		// reconstructed on the other side.
+		settingsrefsC,
 		// upgradeInfoC is used to coordinate upgrades and schema migrations,
 		// and aren't needed for model migrations.
 		upgradeInfoC,
@@ -333,17 +333,6 @@ func (s *MigrationSuite) TestServiceDocFields(c *gc.C) {
 		"MetricCredentials",
 	)
 	s.AssertExportedFields(c, applicationDoc{}, migrated.Union(ignored))
-}
-
-func (s *MigrationSuite) TestSettingsRefsDocFields(c *gc.C) {
-	fields := set.NewStrings(
-		// ModelUUID shouldn't be exported, and is inherited
-		// from the model definition.
-		"ModelUUID",
-
-		"RefCount",
-	)
-	s.AssertExportedFields(c, settingsRefsDoc{}, fields)
 }
 
 func (s *MigrationSuite) TestUnitDocFields(c *gc.C) {

--- a/state/refcounts_ns.go
+++ b/state/refcounts_ns.go
@@ -1,0 +1,155 @@
+package state
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/mongo"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+)
+
+// refcountDoc holds reference counts.
+type refcountDoc struct {
+	// _id is some globalKey.
+	RefCount int `bson:"refcount"`
+}
+
+// nsRefcounts_ backs nsRefcounts.
+type nsRefcounts_ struct{}
+
+// nsRefcounts exposes methods for safely manipulating reference count
+// documents.
+var nsRefcounts = nsRefcounts_{}
+
+// JustCreateOp returns a txn.Op that creates a refcount document as
+// configured, *without* checking database state for sanity first.
+// You should prefer to avoid using this method in most cases.
+func (nsRefcounts_) JustCreateOp(collName, key string, value int) txn.Op {
+	return txn.Op{
+		C:      collName,
+		Id:     key,
+		Assert: txn.DocMissing,
+		Insert: bson.D{{"refcount", value}},
+	}
+}
+
+// JustIncRefOp returns a txn.Op that increments a refcount document as
+// configured, *without* checking database state for sanity first. You
+// should prefer to avoid using this method in most cases.
+func (nsRefcounts_) JustIncRefOp(collName, key string) txn.Op {
+	return txn.Op{
+		C:      collName,
+		Id:     key,
+		Assert: txn.DocExists,
+		Update: bson.D{{"$inc", bson.D{{"refcount", 1}}}},
+	}
+}
+
+// JustRemoveOp returns a txn.Op that deletes a refcount doc without
+// *any validation at all*. You should *strongly* prefer to avoid using
+// this method in most cases.
+func (ns nsRefcounts_) JustRemoveOp(collName, key string) txn.Op {
+	return txn.Op{
+		C:      collName,
+		Id:     key,
+		Remove: true,
+	}
+}
+
+// StrictCreateOp returns a txn.Op that creates a refcount document as
+// configured, or an error if the document already exists.
+func (ns nsRefcounts_) StrictCreateOp(refcounts mongo.Collection, key string, value int) (txn.Op, error) {
+	if exists, err := ns.exists(refcounts, key); err != nil {
+		return txn.Op{}, errors.Trace(err)
+	} else if exists {
+		return txn.Op{}, errors.New("refcount already exists")
+	}
+	return ns.JustCreateOp(refcounts.Name(), key, value), nil
+}
+
+// CreateIncrefOp returns a txn.Op that creates a refcount document as
+// configured with a value of 1; or increments any such refcount doc
+// that already exists.
+func (ns nsRefcounts_) CreateIncRefOp(refcounts mongo.Collection, key string) (txn.Op, error) {
+	if exists, err := ns.exists(refcounts, key); err != nil {
+		return txn.Op{}, errors.Trace(err)
+	} else if !exists {
+		return ns.JustCreateOp(refcounts.Name(), key, 1), nil
+	}
+	return ns.JustIncRefOp(refcounts.Name(), key), nil
+}
+
+// StrictIncRefOp returns a txn.Op that increments the value of a
+// refcount doc, or returns an error if it does not exist.
+func (ns nsRefcounts_) StrictIncRefOp(refcounts mongo.Collection, key string) (txn.Op, error) {
+	if exists, err := ns.exists(refcounts, key); err != nil {
+		return txn.Op{}, errors.Trace(err)
+	} else if !exists {
+		return txn.Op{}, errors.New("refcount does not exist")
+	}
+	return ns.JustIncRefOp(refcounts.Name(), key), nil
+}
+
+// AliveDecRefOp returns a txn.Op that decrements the value of a
+// refcount doc, or an error if the doc does not exist or the count
+// would go below 0.
+func (ns nsRefcounts_) AliveDecRefOp(refcounts mongo.Collection, key string) (txn.Op, error) {
+	if refcount, err := ns.read(refcounts, key); err != nil {
+		return txn.Op{}, errors.Trace(err)
+	} else if refcount < 1 {
+		return txn.Op{}, errors.New("cannot decRef below 0")
+	}
+	return txn.Op{
+		C:      refcounts.Name(),
+		Id:     key,
+		Assert: bson.D{{"refcount", bson.D{{"$gt", 0}}}},
+		Update: bson.D{{"$inc", bson.D{{"refcount", -1}}}},
+	}, nil
+}
+
+// DyingDecRefOp returns a txn.Op that decrements the value of a
+// refcount doc and deletes it if the count reaches 0; if the Op will
+// cause a delete, the bool result will be true. It will return an error
+// if the doc does not exist or the count would go below 0.
+func (ns nsRefcounts_) DyingDecRefOp(refcounts mongo.Collection, key string) (txn.Op, bool, error) {
+	refcount, err := ns.read(refcounts, key)
+	if err != nil {
+		return txn.Op{}, false, errors.Trace(err)
+	}
+	if refcount < 1 {
+		return txn.Op{}, false, errors.New("cannot decRef below 0")
+	} else if refcount > 1 {
+		return txn.Op{
+			C:      refcounts.Name(),
+			Id:     key,
+			Assert: bson.D{{"refcount", bson.D{{"$gt", 1}}}},
+			Update: bson.D{{"$inc", bson.D{{"refcount", -1}}}},
+		}, false, nil
+	}
+	return txn.Op{
+		C:      refcounts.Name(),
+		Id:     key,
+		Assert: bson.D{{"refcount", 1}},
+		Remove: true,
+	}, true, nil
+}
+
+// exists returns whether the identified refcount doc exists.
+func (nsRefcounts_) exists(refcounts mongo.Collection, key string) (bool, error) {
+	count, err := refcounts.FindId(key).Count()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	return count != 0, nil
+}
+
+// read returns the value stored in the identified refcount doc.
+func (nsRefcounts_) read(refcounts mongo.Collection, key string) (int, error) {
+	var doc refcountDoc
+	if err := refcounts.FindId(key).One(&doc); err == mgo.ErrNotFound {
+		return 0, errors.NotFoundf("refcount")
+	} else if err != nil {
+		return 0, errors.Trace(err)
+	}
+	return doc.RefCount, nil
+}

--- a/state/state.go
+++ b/state/state.go
@@ -1069,12 +1069,11 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 			endpointBindingsOp,
 		},
 		addApplicationOps(st, addApplicationOpsArgs{
-			applicationDoc:   svcDoc,
-			statusDoc:        statusDoc,
-			constraints:      args.Constraints,
-			storage:          args.Storage,
-			settings:         map[string]interface{}(args.Settings),
-			settingsRefCount: 1,
+			applicationDoc: svcDoc,
+			statusDoc:      statusDoc,
+			constraints:    args.Constraints,
+			storage:        args.Storage,
+			settings:       map[string]interface{}(args.Settings),
 		})...)
 
 	// Collect peer relation addition operations.

--- a/state/unit.go
+++ b/state/unit.go
@@ -2299,20 +2299,35 @@ type addUnitOpsArgs struct {
 func addUnitOps(st *State, args addUnitOpsArgs) []txn.Op {
 	name := args.unitDoc.Name
 	agentGlobalKey := unitAgentGlobalKey(name)
+
 	// TODO: consider the constraints op
 	// TODO: consider storageOps
-	return []txn.Op{
+	prereqOps := []txn.Op{
 		createStatusOp(st, unitGlobalKey(name), args.workloadStatusDoc),
 		createStatusOp(st, agentGlobalKey, args.agentStatusDoc),
 		createStatusOp(st, globalWorkloadVersionKey(name), args.workloadVersionDoc),
 		createMeterStatusOp(st, agentGlobalKey, args.meterStatusDoc),
-		{
-			C:      unitsC,
-			Id:     name,
-			Assert: txn.DocMissing,
-			Insert: args.unitDoc,
-		},
 	}
+
+	// Freshly-created units will not have a charm URL set; migrated
+	// ones will, and they need to maintain their refcounts. If we
+	// relax the restrictions on migrating apps mid-upgrade, this
+	// will need to be more sophisticated, because it might need to
+	// create the settings doc; and will likely have to look in the
+	// DB to find out which.
+	if curl := args.unitDoc.CharmURL; curl != nil {
+		appName := args.unitDoc.Application
+		settingsKey := applicationSettingsKey(appName, curl)
+		incRefSettingsOp := nsRefcounts.JustIncRefOp(settingsrefsC, settingsKey)
+		prereqOps = append(prereqOps, incRefSettingsOp)
+	}
+
+	return append(prereqOps, txn.Op{
+		C:      unitsC,
+		Id:     name,
+		Assert: txn.DocMissing,
+		Insert: args.unitDoc,
+	})
 }
 
 // HistoryGetter allows getting the status history based on some identifying key.


### PR DESCRIPTION
Refcount values are (1) implied by the rest of a model description and
(2) pure implementation details necessitated by mgo/txn. They've been
dropped from description.Application; refcount sanity is now maintained
implicitly during import by the add*Ops-level funcs.

Refcount operations themselves have been extracted to refcounts_ns.go;
not all of them are used, but there's a forthcoming CL that will use
them for *charm* refcounts, thus helping us to safely delete
unreferenced charms in the near future.

(Review request: http://reviews.vapour.ws/r/5375/)