### PR TITLE
cmd/juju/commands: Have migrate command refresh models

### DIFF
--- a/cmd/juju/commands/migrate.go
+++ b/cmd/juju/commands/migrate.go
@@ -62,7 +62,7 @@ func (c *migrateCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "migrate",
 		Args:    "<model-name> <target-controller-name>",
-		Purpose: "migrate a hosted model to another controller",
+		Purpose: "Migrate a hosted model to another controller.",
 		Doc:     migrateDoc,
 	}
 }

--- a/cmd/juju/commands/migrate.go
+++ b/cmd/juju/commands/migrate.go
@@ -87,10 +87,11 @@ func (c *migrateCommand) Init(args []string) error {
 func (c *migrateCommand) getMigrationSpec() (*controller.ModelMigrationSpec, error) {
 	store := c.ClientStore()
 
-	modelInfo, err := store.ModelByName(c.ControllerName(), c.model)
+	modelUUIDs, err := c.ModelUUIDs([]string{c.model})
 	if err != nil {
 		return nil, err
 	}
+	modelUUID := modelUUIDs[0]
 
 	controllerInfo, err := store.ControllerByName(c.targetController)
 	if err != nil {
@@ -103,7 +104,7 @@ func (c *migrateCommand) getMigrationSpec() (*controller.ModelMigrationSpec, err
 	}
 
 	return &controller.ModelMigrationSpec{
-		ModelUUID:            modelInfo.ModelUUID,
+		ModelUUID:            modelUUID,
 		TargetControllerUUID: controllerInfo.ControllerUUID,
 		TargetAddrs:          controllerInfo.APIEndpoints,
 		TargetCACert:         controllerInfo.CACert,

--- a/cmd/juju/commands/migrate_test.go
+++ b/cmd/juju/commands/migrate_test.go
@@ -8,6 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/controller"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/feature"
@@ -73,22 +74,22 @@ func (s *MigrateSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *MigrateSuite) TestMissingModel(c *gc.C) {
-	_, err := s.runCommand(c)
+	_, err := s.makeAndRun(c)
 	c.Assert(err, gc.ErrorMatches, "model not specified")
 }
 
 func (s *MigrateSuite) TestMissingTargetController(c *gc.C) {
-	_, err := s.runCommand(c, "mymodel")
+	_, err := s.makeAndRun(c, "mymodel")
 	c.Assert(err, gc.ErrorMatches, "target controller not specified")
 }
 
 func (s *MigrateSuite) TestTooManyArgs(c *gc.C) {
-	_, err := s.runCommand(c, "one", "too", "many")
+	_, err := s.makeAndRun(c, "one", "too", "many")
 	c.Assert(err, gc.ErrorMatches, "too many arguments specified")
 }
 
 func (s *MigrateSuite) TestSuccess(c *gc.C) {
-	ctx, err := s.runCommand(c, "model", "target")
+	ctx, err := s.makeAndRun(c, "model", "target")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(testing.Stderr(ctx), gc.Matches, "Migration started with ID \"uuid:0\"\n")
@@ -103,22 +104,40 @@ func (s *MigrateSuite) TestSuccess(c *gc.C) {
 }
 
 func (s *MigrateSuite) TestModelDoesntExist(c *gc.C) {
-	_, err := s.runCommand(c, "wat", "target")
+	cmd := s.makeCommand()
+	cmd.SetModelApi(&fakeModelAPI{})
+	_, err := s.run(c, cmd, "wat", "target")
 	c.Check(err, gc.ErrorMatches, "model .+ not found")
 	c.Check(s.api.specSeen, gc.IsNil) // API shouldn't have been called
 }
 
+func (s *MigrateSuite) TestModelDoesntExistBeforeRefresh(c *gc.C) {
+	cmd := s.makeCommand()
+	cmd.SetModelApi(&fakeModelAPI{model: "wat"}) // Model is available after refresh
+	_, err := s.run(c, cmd, "wat", "target")
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(s.api.specSeen, gc.NotNil)
+}
+
 func (s *MigrateSuite) TestControllerDoesntExist(c *gc.C) {
-	_, err := s.runCommand(c, "model", "wat")
+	_, err := s.makeAndRun(c, "model", "wat")
 	c.Check(err, gc.ErrorMatches, "controller wat not found")
 	c.Check(s.api.specSeen, gc.IsNil) // API shouldn't have been called
 }
 
-func (s *MigrateSuite) runCommand(c *gc.C, args ...string) (*cmd.Context, error) {
+func (s *MigrateSuite) makeAndRun(c *gc.C, args ...string) (*cmd.Context, error) {
+	return s.run(c, s.makeCommand(), args...)
+}
+
+func (s *MigrateSuite) makeCommand() *migrateCommand {
 	cmd := &migrateCommand{
 		api: s.api,
 	}
 	cmd.SetClientStore(s.store)
+	return cmd
+}
+
+func (s *MigrateSuite) run(c *gc.C, cmd *migrateCommand, args ...string) (*cmd.Context, error) {
 	return testing.RunCommand(c, modelcmd.WrapController(cmd), args...)
 }
 
@@ -129,4 +148,19 @@ type fakeMigrateAPI struct {
 func (a *fakeMigrateAPI) InitiateModelMigration(spec controller.ModelMigrationSpec) (string, error) {
 	a.specSeen = &spec
 	return "uuid:0", nil
+}
+
+type fakeModelAPI struct {
+	model string
+}
+
+func (m *fakeModelAPI) ListModels(user string) ([]base.UserModel, error) {
+	if m.model == "" {
+		return []base.UserModel{}, nil
+	}
+	return []base.UserModel{{Name: m.model, UUID: modelUUID}}, nil
+}
+
+func (m *fakeModelAPI) Close() error {
+	return nil
 }


### PR DESCRIPTION
The "juju migrate" command now refreshes models from the selected controller if the model to be migrated can't be found in the local config. The ModelUUIDs helper is now used to look up the model UUID as this already has the required refresh logic.

Fixes LP 1607457

Also a drive-by to fix the help summary.

(Review request: http://reviews.vapour.ws/r/5378/)