### PR TITLE
worker/modelworkermanager: Allow workers for a given model to be started again

### DIFF
--- a/worker/modelworkermanager/modelworkermanager_test.go
+++ b/worker/modelworkermanager/modelworkermanager_test.go
@@ -87,16 +87,20 @@ func (s *suite) TestRestartsErrorWorker(c *gc.C) {
 	})
 }
 
-func (s *suite) TestNeverRestartsFinishedWorker(c *gc.C) {
+func (s *suite) TestRestartsFinishedWorker(c *gc.C) {
+	// It must be possible to restart the workers for a model due to
+	// model migrations: a model can be migrated away from a
+	// controller and then migrated back later.
 	s.runTest(c, func(w worker.Worker, backend *mockBackend) {
 		backend.sendModelChange("uuid")
 		workers := s.waitWorkers(c, 1)
-		workers[0].tomb.Kill(nil)
+		workertest.CleanKill(c, workers[0])
 
-		// even when we get a change for it
+		s.assertNoWorkers(c)
+
 		backend.sendModelChange("uuid")
 		workertest.CheckAlive(c, w)
-		s.assertNoWorkers(c)
+		s.waitWorkers(c, 1)
 	})
 }
 


### PR DESCRIPTION
This is required to support model migrations where a model may be migrated away and then migrated back again later. The Runner already prevents more than one set workers for a given model at a time.

Fixes LP 1610012

(Review request: http://reviews.vapour.ws/r/5380/)