### PR TITLE
Provisioning machines now automatically retries

### DIFF
--- a/instance/instance.go
+++ b/instance/instance.go
@@ -67,27 +67,6 @@ type HardwareCharacteristics struct {
 	AvailabilityZone *string `json:"availability-zone,omitempty" yaml:"availabilityzone,omitempty"`
 }
 
-// An error reporting that an error has occurred during instance creation
-// (e.g. due to a failed container from on of previous deploys) and
-// that it is safe to restart instance creation
-type RetryableCreationError struct {
-	message string
-}
-
-// Returns the error message
-func (e RetryableCreationError) Error() string { return e.message }
-
-func NewRetryableCreationError(errorMessage string) *RetryableCreationError {
-	return &RetryableCreationError{errorMessage}
-}
-
-// IsRetryableCreationError returns true if the given error is
-// RetryableCreationError
-func IsRetryableCreationError(err error) bool {
-	_, ok := err.(*RetryableCreationError)
-	return ok
-}
-
 func (hc HardwareCharacteristics) String() string {
 	var strs []string
 	if hc.Arch != nil {

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -649,8 +649,13 @@ func tagRootDisk(e *ec2.EC2, tags map[string]string, inst *ec2.Instance) error {
 	}
 	for a := waitRootDiskAttempt.Start(); volumeId == "" && a.Next(); {
 		resp, err := e.Instances([]string{inst.InstanceId}, nil)
-		if err != nil {
-			return err
+		if err = errors.Annotate(err, "cannot fetch instance information"); err != nil {
+			logger.Warningf("%v", err)
+			if a.HasNext() == false {
+				return err
+			}
+			logger.Infof("retrying fetch of instances")
+			continue
 		}
 		if len(resp.Reservations) > 0 && len(resp.Reservations[0].Instances) > 0 {
 			inst = &resp.Reservations[0].Instances[0]

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -587,7 +587,7 @@ func (s *ProvisionerSuite) TestProvisionerFailedStartInstanceWithInjectedCreatio
 	cleanup := dummy.PatchTransientErrorInjectionChannel(errorInjectionChannel)
 	defer cleanup()
 
-	retryableError := instance.NewRetryableCreationError("container failed to start and was destroyed")
+	retryableError := errors.New("container failed to start and was destroyed")
 	destroyError := errors.New("container failed to start and failed to destroy: manual cleanup of containers needed")
 	// send the error message three times, because the provisioner will retry twice as patched above.
 	errorInjectionChannel <- retryableError
@@ -633,75 +633,12 @@ func (s *ProvisionerSuite) TestProvisionerSucceedStartInstanceWithInjectedRetrya
 
 	// send the error message once
 	// - instance creation should succeed
-	retryableError := instance.NewRetryableCreationError("container failed to start and was destroyed")
+	retryableError := errors.New("container failed to start and was destroyed")
 	errorInjectionChannel <- retryableError
 
 	m, err := s.addMachine()
 	c.Assert(err, jc.ErrorIsNil)
 	s.checkStartInstance(c, m)
-}
-
-func (s *ProvisionerSuite) TestProvisionerSucceedStartInstanceWithInjectedWrappedRetryableCreationError(c *gc.C) {
-	// Set the retry delay to 0, and retry count to 1 to keep tests short
-	s.PatchValue(provisioner.RetryStrategyDelay, 0*time.Second)
-	s.PatchValue(provisioner.RetryStrategyCount, 1)
-
-	// create the error injection channel
-	errorInjectionChannel := make(chan error, 1)
-	c.Assert(errorInjectionChannel, gc.NotNil)
-
-	p := s.newEnvironProvisioner(c)
-	defer stop(c, p)
-
-	// patch the dummy provider error injection channel
-	cleanup := dummy.PatchTransientErrorInjectionChannel(errorInjectionChannel)
-	defer cleanup()
-
-	// send the error message once
-	// - instance creation should succeed
-	retryableError := errors.Wrap(errors.New(""), instance.NewRetryableCreationError("container failed to start and was destroyed"))
-	errorInjectionChannel <- retryableError
-
-	m, err := s.addMachine()
-	c.Assert(err, jc.ErrorIsNil)
-	s.checkStartInstance(c, m)
-}
-
-func (s *ProvisionerSuite) TestProvisionerFailStartInstanceWithInjectedNonRetryableCreationError(c *gc.C) {
-	// create the error injection channel
-	errorInjectionChannel := make(chan error, 1)
-	c.Assert(errorInjectionChannel, gc.NotNil)
-
-	p := s.newEnvironProvisioner(c)
-	defer stop(c, p)
-
-	// patch the dummy provider error injection channel
-	cleanup := dummy.PatchTransientErrorInjectionChannel(errorInjectionChannel)
-	defer cleanup()
-
-	// send the error message once
-	nonRetryableError := errors.New("some nonretryable error")
-	errorInjectionChannel <- nonRetryableError
-
-	m, err := s.addMachine()
-	c.Assert(err, jc.ErrorIsNil)
-	s.checkNoOperations(c)
-
-	t0 := time.Now()
-	for time.Since(t0) < coretesting.LongWait {
-		// And check the machine status is set to error.
-		statusInfo, err := m.Status()
-		c.Assert(err, jc.ErrorIsNil)
-		if statusInfo.Status == status.StatusPending {
-			time.Sleep(coretesting.ShortWait)
-			continue
-		}
-		c.Assert(statusInfo.Status, gc.Equals, status.StatusError)
-		// check that the status matches the error message
-		c.Assert(statusInfo.Message, gc.Equals, nonRetryableError.Error())
-		return
-	}
-	c.Fatal("Test took too long to complete")
 }
 
 func (s *ProvisionerSuite) TestProvisionerStopRetryingIfDying(c *gc.C) {
@@ -716,7 +653,7 @@ func (s *ProvisionerSuite) TestProvisionerStopRetryingIfDying(c *gc.C) {
 	cleanup := dummy.PatchTransientErrorInjectionChannel(errorInjectionChannel)
 	defer cleanup()
 
-	retryableError := instance.NewRetryableCreationError("container failed to start and was destroyed")
+	retryableError := errors.New("container failed to start and was destroyed")
 	errorInjectionChannel <- retryableError
 
 	m, err := s.addMachine()


### PR DESCRIPTION
While investigating this bug, I discovered that our retry logic for provisioning machines was never actually invoked. We only retried on errors if the error returned was of a type that isn't used anywhere in Juju's codebase. This change re-enables the existing retry mechanism by relying on the retry strategy already passed in.

I removed the dead code that caused this issue.

I also allowed the AWS provider to retry waiting for root disks if it couldn't fetch instance information.

Fixes https://bugs.launchpad.net/juju-core/+bug/1597170

(Review request: http://reviews.vapour.ws/r/5384/)