### PR TITLE
agent/agentbootstrap: call Environ.Create

### DIFF
--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -259,7 +259,11 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 			adminTag,
 			agentConfig,
 			agentbootstrap.InitializeStateParams{
-				args, addrs, jobs, sharedSecret,
+				StateInitializationParams: args,
+				BootstrapMachineAddresses: addrs,
+				BootstrapMachineJobs:      jobs,
+				SharedSecret:              sharedSecret,
+				Provider:                  environs.Provider,
 			},
 			dialOpts,
 			stateenvirons.GetNewPolicyFunc(

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -645,8 +645,8 @@ func (*environ) PrecheckInstance(series string, cons constraints.Value, placemen
 	return nil
 }
 
-// Create is part of the EnvironProvider interface.
-func (e *environ) Create(environs.CreateParams) error {
+// Create is part of the Environ interface.
+func (e *environ) Create(args environs.CreateParams) error {
 	return nil
 }
 


### PR DESCRIPTION
We were missing a call to Environ.Create for the
hosted model. On Azure, this means the "default"
model was lacking a resource group, rendering it
unusable.

Fixes https://bugs.launchpad.net/juju-core/+bug/1610243

(Review request: http://reviews.vapour.ws/r/5385/)