### PR TITLE
Implemented API/CLI for grant/revoke

### DIFF
--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -473,9 +473,12 @@ func (s *loginSuite) TestNonEnvironUserLoginFails(c *gc.C) {
 	info, cleanup := s.setupServerWithValidator(c, nil)
 	defer cleanup()
 	user := s.Factory.MakeUser(c, &factory.UserParams{Password: "dummy-password", NoModelUser: true})
+	ctag := names.NewControllerTag(s.State.ControllerUUID())
+	err := s.State.RemoveUserAccess(user.UserTag(), ctag)
+	c.Assert(err, jc.ErrorIsNil)
 	info.Password = "dummy-password"
 	info.Tag = user.UserTag()
-	_, err := api.Open(info, fastDialOpts)
+	_, err = api.Open(info, fastDialOpts)
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
 		Message: "invalid entity name or password",
 		Code:    "unauthorized access",

--- a/apiserver/client_auth_root_test.go
+++ b/apiserver/client_auth_root_test.go
@@ -44,31 +44,16 @@ func (s *clientAuthRootSuite) AssertCallErrPerm(c *gc.C, client *clientAuthRoot,
 
 func (s *clientAuthRootSuite) TestNormalUser(c *gc.C) {
 	modelUser := s.Factory.MakeModelUser(c, nil)
-	client := newClientAuthRoot(&fakeFinder{}, modelUser)
+	client := newClientAuthRoot(&fakeFinder{}, modelUser, description.UserAccess{})
 	s.AssertCallGood(c, client, "Application", 1, "Deploy")
 	s.AssertCallGood(c, client, "UserManager", 1, "UserInfo")
 	s.AssertCallNotImplemented(c, client, "Client", 1, "Unknown")
 	s.AssertCallNotImplemented(c, client, "Unknown", 1, "Method")
 }
 
-func (s *clientAuthRootSuite) TestAdminUser(c *gc.C) {
-	modelUser := s.Factory.MakeModelUser(c, &factory.ModelUserParams{Access: description.WriteAccess})
-	client := newClientAuthRoot(&fakeFinder{}, modelUser)
-	s.AssertCallGood(c, client, "Client", 1, "FullStatus")
-	s.AssertCallErrPerm(c, client, "ModelManager", 2, "ModifyModelAccess")
-	s.AssertCallErrPerm(c, client, "ModelManager", 2, "CreateModel")
-	s.AssertCallErrPerm(c, client, "Controller", 3, "DestroyController")
-
-	modelUser = s.Factory.MakeModelUser(c, &factory.ModelUserParams{Access: description.AdminAccess})
-	client = newClientAuthRoot(&fakeFinder{}, modelUser)
-	s.AssertCallGood(c, client, "ModelManager", 2, "ModifyModelAccess")
-	s.AssertCallGood(c, client, "ModelManager", 2, "CreateModel")
-	s.AssertCallGood(c, client, "Controller", 3, "DestroyController")
-}
-
 func (s *clientAuthRootSuite) TestReadOnlyUser(c *gc.C) {
 	modelUser := s.Factory.MakeModelUser(c, &factory.ModelUserParams{Access: description.ReadAccess})
-	client := newClientAuthRoot(&fakeFinder{}, modelUser)
+	client := newClientAuthRoot(&fakeFinder{}, modelUser, description.UserAccess{})
 	// deploys are bad
 	s.AssertCallErrPerm(c, client, "Application", 1, "Deploy")
 	// read only commands are fine

--- a/apiserver/cloud/backend.go
+++ b/apiserver/cloud/backend.go
@@ -16,7 +16,7 @@ type Backend interface {
 	ControllerModel() (Model, error)
 	UpdateCloudCredentials(user names.UserTag, cloudName string, credentials map[string]cloud.Credential) error
 
-	IsControllerAdministrator(names.UserTag) (bool, error)
+	IsControllerAdmin(names.UserTag) (bool, error)
 
 	Close() error
 }

--- a/apiserver/cloud/cloud.go
+++ b/apiserver/cloud/cloud.go
@@ -44,7 +44,7 @@ func NewCloudAPI(backend Backend, authorizer facade.Authorizer) (*CloudAPI, erro
 	}
 	getUserAuthFunc := func() (common.AuthFunc, error) {
 		authUser, _ := authorizer.GetAuthTag().(names.UserTag)
-		isAdmin, err := backend.IsControllerAdministrator(authUser)
+		isAdmin, err := backend.IsControllerAdmin(authUser)
 		if err != nil {
 			return nil, err
 		}
@@ -132,7 +132,7 @@ func (mm *CloudAPI) CloudDefaults(args params.Entities) (params.CloudDefaultsRes
 			results.Results[i].Error = common.ServerError(common.ErrPerm)
 			continue
 		}
-		isAdmin, err := mm.backend.IsControllerAdministrator(userTag)
+		isAdmin, err := mm.backend.IsControllerAdmin(userTag)
 		if err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue

--- a/apiserver/cloud/cloud_test.go
+++ b/apiserver/cloud/cloud_test.go
@@ -76,9 +76,9 @@ func (s *cloudSuite) TestCloudDefaults(c *gc.C) {
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.CheckCallNames(c,
-		"IsControllerAdministrator", // for auth-checking
+		"IsControllerAdmin", // for auth-checking
 		"ControllerModel",
-		"IsControllerAdministrator", // to get default credential
+		"IsControllerAdmin", // to get default credential
 	)
 	c.Assert(results.Results, gc.HasLen, 3)
 	c.Assert(results.Results[0].Error, jc.DeepEquals, &params.Error{
@@ -102,9 +102,9 @@ func (s *cloudSuite) TestCloudDefaultsAdminAccess(c *gc.C) {
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.CheckCallNames(c,
-		"IsControllerAdministrator", // for auth-checking
+		"IsControllerAdmin", // for auth-checking
 		"ControllerModel",
-		"IsControllerAdministrator", // to get default credential
+		"IsControllerAdmin", // to get default credential
 	)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -127,7 +127,7 @@ func (s *cloudSuite) TestCredentials(c *gc.C) {
 		CloudTag: "cloud-meep",
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
-	s.backend.CheckCallNames(c, "IsControllerAdministrator", "CloudCredentials")
+	s.backend.CheckCallNames(c, "IsControllerAdmin", "CloudCredentials")
 	s.backend.CheckCall(c, 1, "CloudCredentials", names.NewUserTag("bruce"), "meep")
 
 	c.Assert(results.Results, gc.HasLen, 3)
@@ -159,7 +159,7 @@ func (s *cloudSuite) TestCredentialsAdminAccess(c *gc.C) {
 		CloudTag: "cloud-meep",
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
-	s.backend.CheckCallNames(c, "IsControllerAdministrator", "CloudCredentials")
+	s.backend.CheckCallNames(c, "IsControllerAdmin", "CloudCredentials")
 	c.Assert(results.Results, gc.HasLen, 1)
 	// admin can access others' credentials
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -190,7 +190,7 @@ func (s *cloudSuite) TestUpdateCredentials(c *gc.C) {
 		},
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
-	s.backend.CheckCallNames(c, "IsControllerAdministrator", "UpdateCloudCredentials")
+	s.backend.CheckCallNames(c, "IsControllerAdmin", "UpdateCloudCredentials")
 	c.Assert(results.Results, gc.HasLen, 3)
 	c.Assert(results.Results[0].Error, jc.DeepEquals, &params.Error{
 		Message: `"machine-0" is not a valid user tag`,
@@ -230,7 +230,7 @@ func (s *cloudSuite) TestUpdateCredentialsAdminAccess(c *gc.C) {
 		},
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
-	s.backend.CheckCallNames(c, "IsControllerAdministrator", "UpdateCloudCredentials")
+	s.backend.CheckCallNames(c, "IsControllerAdmin", "UpdateCloudCredentials")
 	c.Assert(results.Results, gc.HasLen, 1)
 	// admin can update others' credentials
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -242,8 +242,8 @@ type mockBackend struct {
 	creds map[string]cloud.Credential
 }
 
-func (st *mockBackend) IsControllerAdministrator(user names.UserTag) (bool, error) {
-	st.MethodCall(st, "IsControllerAdministrator", user)
+func (st *mockBackend) IsControllerAdmin(user names.UserTag) (bool, error) {
+	st.MethodCall(st, "IsControllerAdmin", user)
 	return user.Canonical() == "admin@local", st.NextErr()
 }
 

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -29,7 +29,7 @@ type ModelManagerBackend interface {
 
 	ModelUUID() string
 	ModelsForUser(names.UserTag) ([]*state.UserModel, error)
-	IsControllerAdministrator(user names.UserTag) (bool, error)
+	IsControllerAdmin(user names.UserTag) (bool, error)
 	NewModel(state.ModelArgs) (Model, ModelManagerBackend, error)
 
 	ComposeNewModelConfig(modelAttr map[string]interface{}) (map[string]interface{}, error)
@@ -42,6 +42,8 @@ type ModelManagerBackend interface {
 	AddControllerUser(state.UserAccessSpec) (description.UserAccess, error)
 	RemoveUserAccess(names.UserTag, names.Tag) error
 	UserAccess(names.UserTag, names.Tag) (description.UserAccess, error)
+	ControllerUUID() string
+	ControllerTag() names.ControllerTag
 	ModelTag() names.ModelTag
 	Export() (description.Model, error)
 	SetUserAccess(subject names.UserTag, target names.Tag, access description.Access) (description.UserAccess, error)

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/txn"
 	"github.com/juju/utils/set"
 	"gopkg.in/juju/names.v2"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/juju/juju/apiserver/common/cloudspec"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
@@ -37,8 +39,9 @@ type Controller interface {
 	ListBlockedModels() (params.ModelBlockInfoList, error)
 	RemoveBlocks(args params.RemoveBlocksArgs) error
 	WatchAllModels() (params.AllWatcherId, error)
-	ModelStatus(req params.Entities) (params.ModelStatusResults, error)
+	ModelStatus(params.Entities) (params.ModelStatusResults, error)
 	InitiateModelMigration(params.InitiateModelMigrationArgs) (params.InitiateModelMigrationResults, error)
+	ModifyControllerAccess(params.ModifyControllerAccessRequest) (params.ErrorResults, error)
 }
 
 // ControllerAPI implements the environment manager interface and is
@@ -69,7 +72,7 @@ func NewControllerAPI(
 	// Since we know this is a user tag (because AuthClient is true),
 	// we just do the type assertion to the UserTag.
 	apiUser, _ := authorizer.GetAuthTag().(names.UserTag)
-	isAdmin, err := st.IsControllerAdministrator(apiUser)
+	isAdmin, err := authorizer.HasPermission(description.SuperuserAccess, st.ControllerTag())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -386,6 +389,121 @@ func (c *ControllerAPI) environStatus(tag string) (params.ModelStatus, error) {
 		HostedMachineCount: len(hostedMachines),
 		ApplicationCount:   len(services),
 	}, nil
+}
+
+// ModifyControllerAccess changes the model access granted to users.
+func (c *ControllerAPI) ModifyControllerAccess(args params.ModifyControllerAccessRequest) (params.ErrorResults, error) {
+	result := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(args.Changes)),
+	}
+	if len(args.Changes) == 0 {
+		return result, nil
+	}
+
+	hasPermission, err := c.authorizer.HasPermission(description.SuperuserAccess, c.state.ControllerTag())
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	for i, arg := range args.Changes {
+		if !hasPermission {
+			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+
+		controllerAccess := description.Access(arg.Access)
+		if err := description.ValidateControllerAccess(controllerAccess); err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+
+		targetUserTag, err := names.ParseUserTag(arg.UserTag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(errors.Annotate(err, "could not modify controller access"))
+			continue
+		}
+
+		result.Results[i].Error = common.ServerError(
+			ChangeControllerAccess(c.state, c.apiUser, targetUserTag, arg.Action, controllerAccess))
+	}
+	return result, nil
+}
+
+func grantControllerAccess(accessor *state.State, targetUserTag, apiUser names.UserTag, access description.Access) error {
+	_, err := accessor.AddControllerUser(state.UserAccessSpec{User: targetUserTag, CreatedBy: apiUser, Access: access})
+	if errors.IsAlreadyExists(err) {
+		controllerTag := accessor.ControllerTag()
+		controllerUser, err := accessor.UserAccess(targetUserTag, controllerTag)
+		if errors.IsNotFound(err) {
+			// Conflicts with prior check, must be inconsistent state.
+			err = txn.ErrExcessiveContention
+		}
+		if err != nil {
+			return errors.Annotate(err, "could not look up controller access for user")
+		}
+
+		// Only set access if greater access is being granted.
+		if controllerUser.Access.EqualOrGreaterControllerAccessThan(access) {
+			return errors.Errorf("user already has %q access or greater", access)
+		}
+		if _, err = accessor.SetUserAccess(controllerUser.UserTag, controllerUser.Object, access); err != nil {
+			return errors.Annotate(err, "could not set controller access for user")
+		}
+		return nil
+
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func revokeControllerAccess(accessor *state.State, targetUserTag, apiUser names.UserTag, access description.Access) error {
+	controllerTag := accessor.ControllerTag()
+	switch access {
+	case description.LoginAccess:
+		// Revoking login access removes all access.
+		err := accessor.RemoveUserAccess(targetUserTag, controllerTag)
+		return errors.Annotate(err, "could not revoke controller access")
+	case description.AddModelAccess:
+		// Revoking add-model access sets login.
+		controllerUser, err := accessor.UserAccess(targetUserTag, controllerTag)
+		if err != nil {
+			return errors.Annotate(err, "could not look up controller access for user")
+		}
+		_, err = accessor.SetUserAccess(controllerUser.UserTag, controllerUser.Object, description.LoginAccess)
+		return errors.Annotate(err, "could not set controller access to read-only")
+	case description.SuperuserAccess:
+		// Revoking superuser sets add-model.
+		controllerUser, err := accessor.UserAccess(targetUserTag, controllerTag)
+		if err != nil {
+			return errors.Annotate(err, "could not look up controller access for user")
+		}
+		_, err = accessor.SetUserAccess(controllerUser.UserTag, controllerUser.Object, description.AddModelAccess)
+		return errors.Annotate(err, "could not set controller access to add-model")
+
+	default:
+		return errors.Errorf("don't know how to revoke %q access", access)
+	}
+
+}
+
+// ChangeControllerAccess performs the requested access grant or revoke action for the
+// specified user on the controller.
+func ChangeControllerAccess(accessor *state.State, apiUser, targetUserTag names.UserTag, action params.ControllerAction, access description.Access) error {
+
+	switch action {
+	case params.GrantControllerAccess:
+		err := grantControllerAccess(accessor, targetUserTag, apiUser, access)
+		if err != nil {
+			return errors.Annotate(err, "could not grant controller access")
+		}
+		return nil
+	case params.RevokeControllerAccess:
+		return revokeControllerAccess(accessor, targetUserTag, apiUser, access)
+	default:
+		return errors.Errorf("unknown action %q", action)
+	}
 }
 
 func (o orderedBlockInfo) Swap(i, j int) {

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -4,8 +4,10 @@
 package controller_test
 
 import (
+	"regexp"
 	"time"
 
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -420,4 +422,203 @@ func (s *controllerSuite) TestInitiateModelMigrationPartialFailure(c *gc.C) {
 func randomModelTag() string {
 	uuid := utils.MustNewUUID().String()
 	return names.NewModelTag(uuid).String()
+}
+
+func (s *controllerSuite) modifyControllerAccess(c *gc.C, user names.UserTag, action params.ControllerAction, access string) error {
+	args := params.ModifyControllerAccessRequest{
+		Changes: []params.ModifyControllerAccess{{
+			UserTag: user.String(),
+			Action:  action,
+			Access:  access,
+		}}}
+	result, err := s.controller.ModifyControllerAccess(args)
+	c.Assert(err, jc.ErrorIsNil)
+	return result.OneError()
+}
+
+func (s *controllerSuite) controllerGrant(c *gc.C, user names.UserTag, access string) error {
+	return s.modifyControllerAccess(c, user, params.GrantControllerAccess, access)
+}
+
+func (s *controllerSuite) controllerRevoke(c *gc.C, user names.UserTag, access string) error {
+	return s.modifyControllerAccess(c, user, params.RevokeControllerAccess, access)
+}
+
+func (s *controllerSuite) TestGrantMissingUserFails(c *gc.C) {
+	user := names.NewLocalUserTag("foobar")
+	err := s.controllerGrant(c, user, string(description.AddModelAccess))
+	expectedErr := `could not grant controller access: user "foobar" does not exist locally: user "foobar" not found`
+	c.Assert(err, gc.ErrorMatches, expectedErr)
+}
+
+func (s *controllerSuite) TestRevokeSuperuserLeavesAddModelAccess(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{NoModelUser: true})
+
+	err := s.controllerGrant(c, user.UserTag(), string(description.SuperuserAccess))
+	c.Assert(err, gc.IsNil)
+	ctag := names.NewControllerTag(s.State.ControllerUUID())
+	controllerUser, err := s.State.UserAccess(user.UserTag(), ctag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(controllerUser.Access, gc.Equals, description.SuperuserAccess)
+
+	err = s.controllerRevoke(c, user.UserTag(), string(description.SuperuserAccess))
+	c.Assert(err, gc.IsNil)
+
+	controllerUser, err = s.State.UserAccess(user.UserTag(), controllerUser.Object)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(controllerUser.Access, gc.Equals, description.AddModelAccess)
+}
+
+func (s *controllerSuite) TestRevokeAddModelLeavesLoginAccess(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{NoModelUser: true})
+
+	err := s.controllerGrant(c, user.UserTag(), string(description.AddModelAccess))
+	c.Assert(err, gc.IsNil)
+	ctag := names.NewControllerTag(s.State.ControllerUUID())
+	controllerUser, err := s.State.UserAccess(user.UserTag(), ctag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(controllerUser.Access, gc.Equals, description.AddModelAccess)
+
+	err = s.controllerRevoke(c, user.UserTag(), string(description.AddModelAccess))
+	c.Assert(err, gc.IsNil)
+
+	controllerUser, err = s.State.UserAccess(user.UserTag(), controllerUser.Object)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(controllerUser.Access, gc.Equals, description.LoginAccess)
+}
+
+func (s *controllerSuite) TestRevokeLoginRemovesControllerUser(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{NoModelUser: true})
+	err := s.controllerRevoke(c, user.UserTag(), string(description.LoginAccess))
+	c.Assert(err, gc.IsNil)
+
+	ctag := names.NewControllerTag(s.State.ControllerUUID())
+	_, err = s.State.UserAccess(user.UserTag(), ctag)
+
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+}
+
+func (s *controllerSuite) TestRevokeControllerMissingUser(c *gc.C) {
+	user := names.NewLocalUserTag("foobar")
+	err := s.controllerRevoke(c, user, string(description.AddModelAccess))
+	expectedErr := `could not look up controller access for user: controller user "foobar@local" not found`
+	c.Assert(err, gc.ErrorMatches, expectedErr)
+}
+
+func (s *controllerSuite) TestGrantOnlyGreaterAccess(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{NoModelUser: true})
+
+	err := s.controllerGrant(c, user.UserTag(), string(description.AddModelAccess))
+	c.Assert(err, gc.IsNil)
+	ctag := names.NewControllerTag(s.State.ControllerUUID())
+	controllerUser, err := s.State.UserAccess(user.UserTag(), ctag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(controllerUser.Access, gc.Equals, description.AddModelAccess)
+
+	err = s.controllerGrant(c, user.UserTag(), string(description.AddModelAccess))
+	expectedErr := `could not grant controller access: user already has "addmodel" access or greater`
+	c.Assert(err, gc.ErrorMatches, expectedErr)
+}
+
+func (s *controllerSuite) TestGrantControllerAddRemoteUser(c *gc.C) {
+	userTag := names.NewUserTag("foobar@ubuntuone")
+
+	err := s.controllerGrant(c, userTag, string(description.AddModelAccess))
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctag := names.NewControllerTag(s.State.ControllerUUID())
+	controllerUser, err := s.State.UserAccess(userTag, ctag)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(controllerUser.Access, gc.Equals, description.AddModelAccess)
+}
+
+func (s *controllerSuite) TestGrantControllerInvalidUserTag(c *gc.C) {
+	for _, testParam := range []struct {
+		tag      string
+		validTag bool
+	}{{
+		tag:      "unit-foo/0",
+		validTag: true,
+	}, {
+		tag:      "application-foo",
+		validTag: true,
+	}, {
+		tag:      "relation-wordpress:db mysql:db",
+		validTag: true,
+	}, {
+		tag:      "machine-0",
+		validTag: true,
+	}, {
+		tag:      "user@local",
+		validTag: false,
+	}, {
+		tag:      "user-Mua^h^h^h^arh",
+		validTag: true,
+	}, {
+		tag:      "user@",
+		validTag: false,
+	}, {
+		tag:      "user@ubuntuone",
+		validTag: false,
+	}, {
+		tag:      "user@ubuntuone",
+		validTag: false,
+	}, {
+		tag:      "@ubuntuone",
+		validTag: false,
+	}, {
+		tag:      "in^valid.",
+		validTag: false,
+	}, {
+		tag:      "",
+		validTag: false,
+	},
+	} {
+		var expectedErr string
+		errPart := `could not modify controller access: "` + regexp.QuoteMeta(testParam.tag) + `" is not a valid `
+
+		if testParam.validTag {
+			// The string is a valid tag, but not a user tag.
+			expectedErr = errPart + `user tag`
+		} else {
+			// The string is not a valid tag of any kind.
+			expectedErr = errPart + `tag`
+		}
+
+		args := params.ModifyControllerAccessRequest{
+			Changes: []params.ModifyControllerAccess{{
+				UserTag: testParam.tag,
+				Action:  params.GrantControllerAccess,
+				Access:  string(description.SuperuserAccess),
+			}}}
+
+		result, err := s.controller.ModifyControllerAccess(args)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)
+	}
+}
+
+func (s *controllerSuite) TestModifyControllerAccessEmptyArgs(c *gc.C) {
+	args := params.ModifyControllerAccessRequest{Changes: []params.ModifyControllerAccess{{}}}
+
+	result, err := s.controller.ModifyControllerAccess(args)
+	c.Assert(err, jc.ErrorIsNil)
+	expectedErr := `"" controller access not valid`
+	c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)
+}
+
+func (s *controllerSuite) TestModifyControllerAccessInvalidAction(c *gc.C) {
+	var dance params.ControllerAction = "dance"
+	args := params.ModifyControllerAccessRequest{
+		Changes: []params.ModifyControllerAccess{{
+			UserTag: "user-user@local",
+			Action:  dance,
+			Access:  string(description.LoginAccess),
+		}}}
+
+	result, err := s.controller.ModifyControllerAccess(args)
+	c.Assert(err, jc.ErrorIsNil)
+	expectedErr := `unknown action "dance"`
+	c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)
 }

--- a/apiserver/controller/destroy.go
+++ b/apiserver/controller/destroy.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/description"
 )
 
 // DestroyController will attempt to destroy the controller. If the args
@@ -20,6 +21,18 @@ import (
 // that it should wait for hosted models to be completely cleaned up
 // before proceeding.
 func (s *ControllerAPI) DestroyController(args params.DestroyControllerArgs) error {
+	hasPermission, err := s.authorizer.HasPermission(description.SuperuserAccess, s.state.ControllerTag())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	isCAdmin, err := s.state.IsControllerAdmin(s.apiUser)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if !hasPermission && !isCAdmin {
+		return errors.Trace(common.ErrPerm)
+	}
+
 	st := common.NewModelManagerBackend(s.state)
 	controllerModel, err := st.ControllerModel()
 	if err != nil {

--- a/apiserver/migrationtarget/migrationtarget.go
+++ b/apiserver/migrationtarget/migrationtarget.go
@@ -49,7 +49,7 @@ func checkAuth(authorizer facade.Authorizer, st *state.State) error {
 
 	// Type assertion is fine because AuthClient is true.
 	apiUser := authorizer.GetAuthTag().(names.UserTag)
-	if isAdmin, err := st.IsControllerAdministrator(apiUser); err != nil {
+	if isAdmin, err := st.IsControllerAdmin(apiUser); err != nil {
 		return errors.Trace(err)
 	} else if !isAdmin {
 		// The entire facade is only accessible to controller administrators.

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -117,7 +117,7 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		}},
 	})
 	s.st.CheckCalls(c, []gitjujutesting.StubCall{
-		{"IsControllerAdministrator", []interface{}{names.NewUserTag("admin@local")}},
+		{"IsControllerAdmin", []interface{}{names.NewUserTag("admin@local")}},
 		{"ModelUUID", nil},
 		{"ForModel", []interface{}{names.NewModelTag(s.st.model.cfg.UUID())}},
 		{"Model", nil},
@@ -244,8 +244,8 @@ func (st *mockState) ModelsForUser(user names.UserTag) ([]*state.UserModel, erro
 	return nil, st.NextErr()
 }
 
-func (st *mockState) IsControllerAdministrator(user names.UserTag) (bool, error) {
-	st.MethodCall(st, "IsControllerAdministrator", user)
+func (st *mockState) IsControllerAdmin(user names.UserTag) (bool, error) {
+	st.MethodCall(st, "IsControllerAdmin", user)
 	if st.controllerModel == nil {
 		return user.Canonical() == "admin@local", st.NextErr()
 	}
@@ -276,6 +276,11 @@ func (st *mockState) ControllerModel() (common.Model, error) {
 	return st.controllerModel, st.NextErr()
 }
 
+func (st *mockState) ControllerTag() names.ControllerTag {
+	st.MethodCall(st, "ControllerTag")
+	return names.NewControllerTag(st.controllerModel.tag.Id())
+}
+
 func (st *mockState) ComposeNewModelConfig(modelAttr map[string]interface{}) (map[string]interface{}, error) {
 	st.MethodCall(st, "ComposeNewModelConfig")
 	attr := make(map[string]interface{})
@@ -284,6 +289,11 @@ func (st *mockState) ComposeNewModelConfig(modelAttr map[string]interface{}) (ma
 	}
 	attr["something"] = "value"
 	return attr, st.NextErr()
+}
+
+func (st *mockState) ControllerUUID() string {
+	st.MethodCall(st, "ControllerUUID")
+	return st.uuid
 }
 
 func (st *mockState) ControllerConfig() (controller.Config, error) {

--- a/apiserver/params/controller.go
+++ b/apiserver/params/controller.go
@@ -46,3 +46,23 @@ type ModelStatus struct {
 type ModelStatusResults struct {
 	Results []ModelStatus `json:"models"`
 }
+
+// ModifyControllerAccessRequest holds the parameters for making grant and revoke controller calls.
+type ModifyControllerAccessRequest struct {
+	Changes []ModifyControllerAccess `json:"changes"`
+}
+
+type ModifyControllerAccess struct {
+	UserTag string           `json:"user-tag"`
+	Action  ControllerAction `json:"action"`
+	Access  string           `json:"access"`
+}
+
+// ControllerAction is an action that can be performed on a model.
+type ControllerAction string
+
+// Actions that can be preformed on a model.
+const (
+	GrantControllerAccess  ControllerAction = "grant"
+	RevokeControllerAccess ControllerAction = "revoke"
+)

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -366,6 +366,7 @@ func hasPermission(userGetter userAccessFunc, entity names.Tag,
 	case description.ReadAccess, description.WriteAccess, description.AdminAccess:
 		validForKind = target.Kind() == names.ModelTagKind
 	}
+
 	if !validForKind {
 		return false, nil
 	}

--- a/apiserver/testing/fakeauthorizer.go
+++ b/apiserver/testing/fakeauthorizer.go
@@ -47,6 +47,12 @@ func (fa FakeAuthorizer) GetAuthTag() names.Tag {
 }
 
 func (fa FakeAuthorizer) HasPermission(operation description.Access, target names.Tag) (bool, error) {
-	// TODO(perrito666) provide a way to pre-set the desired result here.
-	return fa.Tag == target, nil
+	if fa.Tag.Kind() == names.UserTagKind {
+		ut := fa.Tag.(names.UserTag)
+		if ut.Name() == "admin" {
+			return true, nil
+		}
+		return false, nil
+	}
+	return true, nil
 }

--- a/apiserver/usermanager/usermanager.go
+++ b/apiserver/usermanager/usermanager.go
@@ -50,7 +50,7 @@ func NewUserManagerAPI(
 	apiUser, _ := authorizer.GetAuthTag().(names.UserTag)
 	// Pretty much all of the user manager methods have special casing for admin
 	// users, so look once when we start and remember if the user is an admin.
-	isAdmin, err := st.IsControllerAdministrator(apiUser)
+	isAdmin, err := st.IsControllerAdmin(apiUser)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/model/grantrevoke_test.go
+++ b/cmd/juju/model/grantrevoke_test.go
@@ -65,7 +65,7 @@ func (s *grantRevokeSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
 func (s *grantRevokeSuite) TestPassesValues(c *gc.C) {
 	user := "sam"
 	models := []string{fooModelUUID, barModelUUID, bazModelUUID}
-	_, err := s.run(c, "sam", "foo", "bar", "baz")
+	_, err := s.run(c, "sam", "read", "foo", "bar", "baz")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.fake.user, jc.DeepEquals, user)
 	c.Assert(s.fake.modelUUIDs, jc.DeepEquals, models)
@@ -74,7 +74,7 @@ func (s *grantRevokeSuite) TestPassesValues(c *gc.C) {
 
 func (s *grantRevokeSuite) TestAccess(c *gc.C) {
 	sam := "sam"
-	_, err := s.run(c, "--acl", "write", "sam", "model1", "model2")
+	_, err := s.run(c, "sam", "write", "model1", "model2")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.fake.user, jc.DeepEquals, sam)
 	c.Assert(s.fake.modelUUIDs, jc.DeepEquals, []string{model1ModelUUID, model2ModelUUID})
@@ -83,7 +83,7 @@ func (s *grantRevokeSuite) TestAccess(c *gc.C) {
 
 func (s *grantRevokeSuite) TestBlockGrant(c *gc.C) {
 	s.fake.err = &params.Error{Code: params.CodeOperationBlocked}
-	_, err := s.run(c, "sam", "foo")
+	_, err := s.run(c, "sam", "read", "foo")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	c.Check(c.GetTestLog(), jc.Contains, "To unblock changes")
 }
@@ -107,7 +107,7 @@ func (s *grantSuite) TestInit(c *gc.C) {
 	err := testing.InitCommand(wrappedCmd, []string{})
 	c.Assert(err, gc.ErrorMatches, "no user specified")
 
-	err = testing.InitCommand(wrappedCmd, []string{"bob", "model1", "model2"})
+	err = testing.InitCommand(wrappedCmd, []string{"bob", "read", "model1", "model2"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(grantCmd.User, gc.Equals, "bob")
@@ -115,9 +115,6 @@ func (s *grantSuite) TestInit(c *gc.C) {
 
 	err = testing.InitCommand(wrappedCmd, []string{})
 	c.Assert(err, gc.ErrorMatches, `no user specified`)
-
-	err = testing.InitCommand(wrappedCmd, []string{"nomodel"})
-	c.Assert(err, gc.ErrorMatches, `no model specified`)
 }
 
 type revokeSuite struct {
@@ -139,7 +136,7 @@ func (s *revokeSuite) TestInit(c *gc.C) {
 	err := testing.InitCommand(wrappedCmd, []string{})
 	c.Assert(err, gc.ErrorMatches, "no user specified")
 
-	err = testing.InitCommand(wrappedCmd, []string{"bob", "model1", "model2"})
+	err = testing.InitCommand(wrappedCmd, []string{"bob", "read", "model1", "model2"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(revokeCmd.User, gc.Equals, "bob")
@@ -148,8 +145,6 @@ func (s *revokeSuite) TestInit(c *gc.C) {
 	err = testing.InitCommand(wrappedCmd, []string{})
 	c.Assert(err, gc.ErrorMatches, `no user specified`)
 
-	err = testing.InitCommand(wrappedCmd, []string{"nomodel"})
-	c.Assert(err, gc.ErrorMatches, `no model specified`)
 }
 
 type fakeGrantRevokeAPI struct {

--- a/core/description/access.go
+++ b/core/description/access.go
@@ -70,7 +70,7 @@ func ValidateControllerAccess(access Access) error {
 	return errors.NotValidf("%q controller access", access)
 }
 
-// EqualOrGreaterAccessThan returns true if the provided access is equal or
+// EqualOrGreaterModelAccessThan returns true if the provided access is equal or
 // less than the current.
 func (a Access) EqualOrGreaterModelAccessThan(access Access) bool {
 	if a == access {
@@ -91,6 +91,8 @@ func (a Access) EqualOrGreaterModelAccessThan(access Access) bool {
 	return false
 }
 
+// EqualOrGreaterControllerAccessThan returns true if the provided access is equal or
+// less than the current.
 func (a Access) EqualOrGreaterControllerAccessThan(access Access) bool {
 	if a == access {
 		return true

--- a/core/description/useraccess.go
+++ b/core/description/useraccess.go
@@ -33,3 +33,10 @@ type UserAccess struct {
 	// UserName is the actual username for this access.
 	UserName string
 }
+
+// IsEmptyUserAccess returns true if the passed UserAccess instance
+// is empty.
+func IsEmptyUserAccess(a UserAccess) bool {
+	empty := UserAccess{}
+	return a == empty
+}

--- a/featuretests/cmd_juju_model_test.go
+++ b/featuretests/cmd_juju_model_test.go
@@ -41,7 +41,7 @@ func (s *cmdModelSuite) run(c *gc.C, args ...string) *cmd.Context {
 
 func (s *cmdModelSuite) TestGrantModelCmdStack(c *gc.C) {
 	username := "bar@ubuntuone"
-	context := s.run(c, "grant", username, "controller")
+	context := s.run(c, "grant", username, "read", "controller")
 	obtained := strings.Replace(testing.Stdout(context), "\n", "", -1)
 	expected := ""
 	c.Assert(obtained, gc.Equals, expected)
@@ -68,7 +68,7 @@ func (s *cmdModelSuite) TestRevokeModelCmdStack(c *gc.C) {
 	loggo.RemoveWriter("warning")
 
 	// Then test that the unshare command stack is hooked up
-	context := s.run(c, "revoke", username, "controller")
+	context := s.run(c, "revoke", username, "read", "controller")
 	obtained := strings.Replace(testing.Stdout(context), "\n", "", -1)
 	expected := ""
 	c.Assert(obtained, gc.Equals, expected)
@@ -82,7 +82,7 @@ func (s *cmdModelSuite) TestRevokeModelCmdStack(c *gc.C) {
 func (s *cmdModelSuite) TestModelUsersCmd(c *gc.C) {
 	// Firstly share an model with a user
 	username := "bar@ubuntuone"
-	context := s.run(c, "grant", username, "controller")
+	context := s.run(c, "grant", username, "read", "controller")
 	user := names.NewUserTag(username)
 	modelUser, err := s.State.UserAccess(user, s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/binarystorage.go
+++ b/state/binarystorage.go
@@ -24,7 +24,7 @@ func (st *State) ToolsStorage() (binarystorage.StorageCloser, error) {
 	// This is a hosted model. Hosted models have their own tools
 	// catalogue, which we combine with the controller's.
 
-	controllerSt, err := st.ForModel(st.controllerTag)
+	controllerSt, err := st.ForModel(st.controllerModelTag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -50,7 +50,7 @@ func (st *State) ToolsStorage() (binarystorage.StorageCloser, error) {
 // GUIStorage returns a new binarystorage.StorageCloser that stores GUI archive
 // metadata in the "juju" database "guimetadata" collection.
 func (st *State) GUIStorage() (binarystorage.StorageCloser, error) {
-	return st.newBinaryStorageCloser(guimetadataC, st.controllerTag.Id()), nil
+	return st.newBinaryStorageCloser(guimetadataC, st.controllerModelTag.Id()), nil
 }
 
 func (st *State) newBinaryStorageCloser(collectionName, uuid string) binarystorage.StorageCloser {

--- a/state/model.go
+++ b/state/model.go
@@ -270,7 +270,7 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 			newSt.Close()
 		}
 	}()
-	newSt.controllerTag = st.controllerTag
+	newSt.controllerModelTag = st.controllerModelTag
 
 	modelOps, err := newSt.modelSetupOps(args, nil)
 	if err != nil {
@@ -308,7 +308,7 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 		return nil, nil, errors.Trace(err)
 	}
 
-	err = newSt.start(st.controllerTag)
+	err = newSt.start(st.controllerModelTag)
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "could not start state for new model")
 	}

--- a/state/modeluser_test.go
+++ b/state/modeluser_test.go
@@ -450,38 +450,38 @@ func (s *ModelUserSuite) TestModelsForUserMultiple(c *gc.C) {
 	}
 }
 
-func (s *ModelUserSuite) TestIsControllerAdministrator(c *gc.C) {
-	isAdmin, err := s.State.IsControllerAdministrator(s.Owner)
+func (s *ModelUserSuite) TestIsControllerAdmin(c *gc.C) {
+	isAdmin, err := s.State.IsControllerAdmin(s.Owner)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(isAdmin, jc.IsTrue)
 
 	user := s.Factory.MakeUser(c, &factory.UserParams{NoModelUser: true})
-	isAdmin, err = s.State.IsControllerAdministrator(user.UserTag())
+	isAdmin, err = s.State.IsControllerAdmin(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(isAdmin, jc.IsFalse)
 
-	s.Factory.MakeModelUser(c, &factory.ModelUserParams{User: user.UserTag().Canonical()})
-	isAdmin, err = s.State.IsControllerAdministrator(user.UserTag())
+	s.State.SetUserAccess(user.UserTag(), s.State.ControllerTag(), description.SuperuserAccess)
+	isAdmin, err = s.State.IsControllerAdmin(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(isAdmin, jc.IsTrue)
 
 	readonly := s.Factory.MakeModelUser(c, &factory.ModelUserParams{Access: description.ReadAccess})
-	isAdmin, err = s.State.IsControllerAdministrator(readonly.UserTag)
+	isAdmin, err = s.State.IsControllerAdmin(readonly.UserTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(isAdmin, jc.IsFalse)
 }
 
-func (s *ModelUserSuite) TestIsControllerAdministratorFromOtherState(c *gc.C) {
+func (s *ModelUserSuite) TestIsControllerAdminFromOtherState(c *gc.C) {
 	user := s.Factory.MakeUser(c, &factory.UserParams{NoModelUser: true})
 
 	otherState := s.Factory.MakeModel(c, &factory.ModelParams{Owner: user.UserTag()})
 	defer otherState.Close()
 
-	isAdmin, err := otherState.IsControllerAdministrator(user.UserTag())
+	isAdmin, err := otherState.IsControllerAdmin(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(isAdmin, jc.IsFalse)
 
-	isAdmin, err = otherState.IsControllerAdministrator(s.Owner)
+	isAdmin, err = otherState.IsControllerAdmin(s.Owner)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(isAdmin, jc.IsTrue)
 }

--- a/state/open.go
+++ b/state/open.go
@@ -210,7 +210,7 @@ func Initialize(args InitializeParams) (_ *State, err error) {
 			}
 		}
 	}()
-	st.controllerTag = modelTag
+	st.controllerModelTag = modelTag
 
 	// A valid model is used as a signal that the
 	// state has already been initalized. If this is the case
@@ -294,7 +294,7 @@ func (st *State) modelSetupOps(args ModelArgs, controllerInheritedConfig map[str
 		return nil, errors.Trace(err)
 	}
 
-	controllerUUID := st.controllerTag.Id()
+	controllerUUID := st.controllerModelTag.Id()
 	modelUUID := args.Config.UUID()
 	modelStatusDoc := statusDoc{
 		ModelUUID: modelUUID,

--- a/state/state.go
+++ b/state/state.go
@@ -33,6 +33,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/audit"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
@@ -74,13 +75,13 @@ type providerIdDoc struct {
 // State represents the state of an model
 // managed by juju.
 type State struct {
-	modelTag      names.ModelTag
-	controllerTag names.ModelTag
-	mongoInfo     *mongo.MongoInfo
-	session       *mgo.Session
-	database      Database
-	policy        Policy
-	newPolicy     NewPolicyFunc
+	modelTag           names.ModelTag
+	controllerModelTag names.ModelTag
+	mongoInfo          *mongo.MongoInfo
+	session            *mgo.Session
+	database           Database
+	policy             Policy
+	newPolicy          NewPolicyFunc
 
 	// cloudName is the name of the cloud on which the model
 	// represented by this state runs.
@@ -133,13 +134,21 @@ type StateServingInfo struct {
 // IsController returns true if this state instance has the bootstrap
 // model UUID.
 func (st *State) IsController() bool {
-	return st.modelTag == st.controllerTag
+	return st.modelTag == st.controllerModelTag
 }
 
 // ControllerUUID returns the model UUID for the controller model
 // of this state instance.
 func (st *State) ControllerUUID() string {
-	return st.controllerTag.Id()
+	return st.controllerModelTag.Id()
+}
+func (st *State) ControllerTag() names.ControllerTag {
+	return names.NewControllerTag(st.controllerModelTag.Id())
+}
+
+func ControllerAccess(st *State, tag names.Tag) (description.UserAccess, error) {
+	ctag := names.NewControllerTag(st.ControllerUUID())
+	return st.UserAccess(tag.(names.UserTag), ctag)
 }
 
 // RemoveAllModelDocs removes all documents from multi-model
@@ -279,7 +288,7 @@ func (st *State) ForModel(model names.ModelTag) (*State, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := newSt.start(st.controllerTag); err != nil {
+	if err := newSt.start(st.controllerModelTag); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return newSt, nil
@@ -301,7 +310,7 @@ func (st *State) start(controllerTag names.ModelTag) (err error) {
 		}
 	}()
 
-	st.controllerTag = controllerTag
+	st.controllerModelTag = controllerTag
 
 	if identity := st.mongoInfo.Tag; identity != nil {
 		// TODO(fwereade): it feels a bit wrong to take this from MongoInfo -- I

--- a/state/user.go
+++ b/state/user.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/utils"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
@@ -171,7 +172,8 @@ func createInitialUserOps(controllerUUID string, user names.UserTag, password, s
 		names.NewUserTag(user.Name()),
 		user.Name(),
 		dateCreated,
-		defaultControllerPermission)
+		// first user is controller admin.
+		description.SuperuserAccess)
 
 	ops = append(ops, controllerUserOps...)
 	return ops

--- a/state/user_internal_test.go
+++ b/state/user_internal_test.go
@@ -33,7 +33,7 @@ func (s *internalUserSuite) TestCreateInitialUserOps(c *gc.C) {
 	// controller user permissions
 	op = ops[1]
 	permdoc := op.Insert.(*permissionDoc)
-	c.Assert(permdoc.Access, gc.Equals, string(description.LoginAccess))
+	c.Assert(permdoc.Access, gc.Equals, string(description.SuperuserAccess))
 	c.Assert(permdoc.ID, gc.Equals, permissionID(controllerGlobalKey, userGlobalKey(strings.ToLower(tag.Canonical()))))
 	c.Assert(permdoc.SubjectGlobalKey, gc.Equals, userGlobalKey(strings.ToLower(tag.Canonical())))
 	c.Assert(permdoc.ObjectGlobalKey, gc.Equals, controllerGlobalKey)

--- a/state/useraccess.go
+++ b/state/useraccess.go
@@ -123,7 +123,7 @@ func NewModelUserAccess(st *State, userDoc userAccessDoc) (description.UserAcces
 // NewControllerUserAccess returns a new description.UserAccess for the given userDoc and
 // current Controller.
 func NewControllerUserAccess(st *State, userDoc userAccessDoc) (description.UserAccess, error) {
-	perm, err := st.userPermission(controllerGlobalKey, userGlobalKey(strings.ToLower(userDoc.UserName)))
+	perm, err := st.controllerUserPermission(controllerGlobalKey, userGlobalKey(strings.ToLower(userDoc.UserName)))
 	if err != nil {
 		return description.UserAccess{}, errors.Annotate(err, "obtaining controller permission")
 	}

--- a/state/userpermission.go
+++ b/state/userpermission.go
@@ -51,22 +51,26 @@ func (st *State) userPermission(objectKey, subjectKey string) (*permission, erro
 		return nil, errors.NotFoundf("user permissions for user %q", id)
 	}
 	return userPermission, nil
-
 }
 
-// globalUserPermission returns a Permission for the given Subject and User.
-func (st *State) globalUserPermission(objectKey, subjectKey string) (*permission, error) {
+// controllerUserPermission returns a Permission for the given Subject and User.
+func (st *State) controllerUserPermission(objectKey, subjectKey string) (*permission, error) {
 	userPermission := &permission{}
-	permissions, closer := st.getRawCollection(permissionsC)
+	controllerSt, err := st.ForModel(st.controllerModelTag)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer controllerSt.Close()
+
+	permissions, closer := controllerSt.getCollection(permissionsC)
 	defer closer()
 
 	id := permissionID(objectKey, subjectKey)
-	err := permissions.FindId(st.docID(id)).One(&userPermission.doc)
+	err = permissions.FindId(controllerSt.docID(id)).One(&userPermission.doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("user permissions for user %q", id)
 	}
 	return userPermission, nil
-
 }
 
 // isReadOnly returns whether or not the user has write access or only

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -89,6 +89,13 @@ func (s *UniterSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *UniterSuite) SetUpTest(c *gc.C) {
+	zone, err := time.LoadLocation("")
+	c.Assert(err, jc.ErrorIsNil)
+	now := time.Date(2030, 11, 11, 11, 11, 11, 11, zone)
+	leaseClock = coretesting.NewClock(now)
+	state.GetClock = func() clock.Clock {
+		return leaseClock
+	}
 	s.updateStatusHookTicker = newManualTicker()
 	s.GitSuite.SetUpTest(c)
 	s.JujuConnSuite.SetUpTest(c)


### PR DESCRIPTION
* New style of syntax for grant/revoke for models
* Grant/Revoke now support controllers.
* Bug fixes in controller permission checking.
* Permission gating now happens in common.Authorizer for some facade calls.

(Review request: http://reviews.vapour.ws/r/5386/)