### PR TITLE
provider/{ec2,azure}: remove cloud/creds from config

### DIFF
--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -207,15 +207,10 @@ func (*RestrictedProviderFieldsSuite) TestRestrictedProviderFields(c *gc.C) {
 		expected []string
 	}{{
 		provider: "azure",
-		expected: []string{
-			"type",
-			"location", "endpoint", "storage-endpoint",
-		},
+		expected: []string{"type"},
 	}, {
 		provider: "dummy",
-		expected: []string{
-			"type",
-		},
+		expected: []string{"type"},
 	}, {
 		provider: "joyent",
 		expected: []string{
@@ -237,7 +232,7 @@ func (*RestrictedProviderFieldsSuite) TestRestrictedProviderFields(c *gc.C) {
 		provider: "ec2",
 		expected: []string{
 			"type",
-			"region", "vpc-id-force",
+			"vpc-id-force",
 		},
 	}} {
 		c.Logf("%d: %s provider", i, test.provider)

--- a/provider/azure/config.go
+++ b/provider/azure/config.go
@@ -4,10 +4,8 @@
 package azure
 
 import (
-	"net/url"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/Godeps/_workspace/src/github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/azure-sdk-for-go/arm/storage"
 	"github.com/juju/errors"
 	"github.com/juju/schema"
@@ -17,13 +15,6 @@ import (
 )
 
 const (
-	configAttrAppId              = "application-id"
-	configAttrSubscriptionId     = "subscription-id"
-	configAttrTenantId           = "tenant-id"
-	configAttrAppPassword        = "application-password"
-	configAttrLocation           = "location"
-	configAttrEndpoint           = "endpoint"
-	configAttrStorageEndpoint    = "storage-endpoint"
 	configAttrStorageAccountType = "storage-account-type"
 
 	// The below bits are internal book-keeping things, rather than
@@ -35,13 +26,6 @@ const (
 )
 
 var configFields = schema.Fields{
-	configAttrLocation:           schema.String(),
-	configAttrEndpoint:           schema.String(),
-	configAttrStorageEndpoint:    schema.String(),
-	configAttrAppId:              schema.String(),
-	configAttrSubscriptionId:     schema.String(),
-	configAttrTenantId:           schema.String(),
-	configAttrAppPassword:        schema.String(),
 	configAttrStorageAccountType: schema.String(),
 }
 
@@ -49,29 +33,12 @@ var configDefaults = schema.Defaults{
 	configAttrStorageAccountType: string(storage.StandardLRS),
 }
 
-var requiredConfigAttributes = []string{
-	configAttrAppId,
-	configAttrAppPassword,
-	configAttrSubscriptionId,
-	configAttrTenantId,
-	configAttrLocation,
-	configAttrEndpoint,
-	configAttrStorageEndpoint,
-}
-
 var immutableConfigAttributes = []string{
-	configAttrSubscriptionId,
-	configAttrTenantId,
 	configAttrStorageAccountType,
 }
 
 type azureModelConfig struct {
 	*config.Config
-	token              *azure.ServicePrincipalToken
-	subscriptionId     string
-	location           string // canonicalized
-	endpoint           string
-	storageEndpoint    string
 	storageAccountType storage.AccountType
 }
 
@@ -101,12 +68,6 @@ func validateConfig(newCfg, oldCfg *config.Config) (*azureModelConfig, error) {
 		return nil, err
 	}
 
-	// Ensure required configuration is provided.
-	for _, key := range requiredConfigAttributes {
-		if value, ok := validated[key].(string); !ok || value == "" {
-			return nil, errors.Errorf("%q config not specified", key)
-		}
-	}
 	if oldCfg != nil {
 		// Ensure immutable configuration isn't changed.
 		oldUnknownAttrs := oldCfg.UnknownAttrs()
@@ -128,8 +89,6 @@ func validateConfig(newCfg, oldCfg *config.Config) (*azureModelConfig, error) {
 			}
 			// It's valid to go from not having to having.
 		}
-		// TODO(axw) figure out how we intend to handle changing
-		// secrets, such as application key
 	}
 
 	// Resource group names must not exceed 80 characters. Resource group
@@ -147,20 +106,12 @@ Please choose a model name of no more than %d characters.`,
 		)
 	}
 
-	location := canonicalLocation(validated[configAttrLocation].(string))
-	endpoint := validated[configAttrEndpoint].(string)
-	storageEndpoint := validated[configAttrStorageEndpoint].(string)
-	appId := validated[configAttrAppId].(string)
-	subscriptionId := validated[configAttrSubscriptionId].(string)
-	tenantId := validated[configAttrTenantId].(string)
-	appPassword := validated[configAttrAppPassword].(string)
-	storageAccountType := validated[configAttrStorageAccountType].(string)
-
 	if newCfg.FirewallMode() == config.FwGlobal {
 		// We do not currently support the "global" firewall mode.
 		return nil, errNoFwGlobal
 	}
 
+	storageAccountType := validated[configAttrStorageAccountType].(string)
 	if !isKnownStorageAccountType(storageAccountType) {
 		return nil, errors.Errorf(
 			"invalid storage account type %q, expected one of: %q",
@@ -168,30 +119,10 @@ Please choose a model name of no more than %d characters.`,
 		)
 	}
 
-	// The Azure storage code wants the endpoint host only, not the URL.
-	storageEndpointURL, err := url.Parse(storageEndpoint)
-	if err != nil {
-		return nil, errors.Annotate(err, "parsing storage endpoint URL")
-	}
-
-	token, err := azure.NewServicePrincipalToken(
-		appId, appPassword, tenantId,
-		azure.AzureResourceManagerScope,
-	)
-	if err != nil {
-		return nil, errors.Annotate(err, "constructing service principal token")
-	}
-
 	azureConfig := &azureModelConfig{
 		newCfg,
-		token,
-		subscriptionId,
-		location,
-		endpoint,
-		storageEndpointURL.Host,
 		storage.AccountType(storageAccountType),
 	}
-
 	return azureConfig, nil
 }
 

--- a/provider/azure/config_test.go
+++ b/provider/azure/config_test.go
@@ -55,26 +55,12 @@ func (s *configSuite) TestValidateInvalidFirewallMode(c *gc.C) {
 	)
 }
 
-func (s *configSuite) TestValidateLocation(c *gc.C) {
-	s.assertConfigInvalid(c, testing.Attrs{"location": ""}, `"location" config not specified`)
-	// We don't validate locations, because new locations may be added.
-	// Azure will complain if the location is invalid anyway.
-	s.assertConfigValid(c, testing.Attrs{"location": "eurasia"})
-}
-
 func (s *configSuite) TestValidateModelNameLength(c *gc.C) {
 	s.assertConfigInvalid(
 		c, testing.Attrs{"name": "someextremelyoverlylongishmodelname"},
 		`resource group name "juju-someextremelyoverlylongishmodelname-model-deadbeef-0bad-400d-8000-4b1d0d06f00d" is too long
 
 Please choose a model name of no more than 32 characters.`)
-}
-
-func (s *configSuite) TestValidateInvalidCredentials(c *gc.C) {
-	s.assertConfigInvalid(c, testing.Attrs{"application-id": ""}, `"application-id" config not specified`)
-	s.assertConfigInvalid(c, testing.Attrs{"application-password": ""}, `"application-password" config not specified`)
-	s.assertConfigInvalid(c, testing.Attrs{"tenant-id": ""}, `"tenant-id" config not specified`)
-	s.assertConfigInvalid(c, testing.Attrs{"subscription-id": ""}, `"subscription-id" config not specified`)
 }
 
 func (s *configSuite) TestValidateStorageAccountTypeCantChange(c *gc.C) {
@@ -101,15 +87,8 @@ func (s *configSuite) assertConfigInvalid(c *gc.C, attrs testing.Attrs, expect s
 
 func makeTestModelConfig(c *gc.C, extra ...testing.Attrs) *config.Config {
 	attrs := testing.Attrs{
-		"type":                 "azure",
-		"application-id":       fakeApplicationId,
-		"tenant-id":            fakeTenantId,
-		"application-password": "opensezme",
-		"subscription-id":      fakeSubscriptionId,
-		"location":             "westus",
-		"endpoint":             "https://api.azurestack.local",
-		"storage-endpoint":     "https://storage.azurestack.local",
-		"agent-version":        "1.2.3",
+		"type":          "azure",
+		"agent-version": "1.2.3",
 	}
 	for _, extra := range extra {
 		attrs = attrs.Merge(extra)

--- a/provider/azure/credentials.go
+++ b/provider/azure/credentials.go
@@ -9,6 +9,13 @@ import (
 	"github.com/juju/juju/cloud"
 )
 
+const (
+	credAttrAppId          = "application-id"
+	credAttrSubscriptionId = "subscription-id"
+	credAttrTenantId       = "tenant-id"
+	credAttrAppPassword    = "application-password"
+)
+
 // environPoviderCredentials is an implementation of
 // environs.ProviderCredentials for the Azure Resource
 // Manager cloud provider.
@@ -19,13 +26,13 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 	return map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.UserPassAuthType: {
 			{
-				configAttrAppId, cloud.CredentialAttr{Description: "Azure Active Directory application ID"},
+				credAttrAppId, cloud.CredentialAttr{Description: "Azure Active Directory application ID"},
 			}, {
-				configAttrSubscriptionId, cloud.CredentialAttr{Description: "Azure subscription ID"},
+				credAttrSubscriptionId, cloud.CredentialAttr{Description: "Azure subscription ID"},
 			}, {
-				configAttrTenantId, cloud.CredentialAttr{Description: "Azure Active Directory tenant ID"},
+				credAttrTenantId, cloud.CredentialAttr{Description: "Azure Active Directory tenant ID"},
 			}, {
-				configAttrAppPassword, cloud.CredentialAttr{
+				credAttrAppPassword, cloud.CredentialAttr{
 					Description: "Azure Active Directory application password",
 					Hidden:      true,
 				},

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -348,9 +348,11 @@ func prepareForBootstrap(
 
 func fakeCloudSpec() environs.CloudSpec {
 	return environs.CloudSpec{
+		Type:            "azure",
+		Name:            "azure",
 		Region:          "westus",
-		Endpoint:        "https://management.azure.com",
-		StorageEndpoint: "https://core.windows.net",
+		Endpoint:        "https://api.azurestack.local",
+		StorageEndpoint: "https://storage.azurestack.local",
 		Credential:      fakeUserPassCredential(),
 	}
 }

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -24,6 +24,7 @@ import (
 type environProviderSuite struct {
 	testing.BaseSuite
 	provider environs.EnvironProvider
+	spec     environs.CloudSpec
 	requests []*http.Request
 	sender   azuretesting.Senders
 }
@@ -36,6 +37,14 @@ func (s *environProviderSuite) SetUpTest(c *gc.C) {
 		Sender:           &s.sender,
 		RequestInspector: requestRecorder(&s.requests),
 	})
+	s.spec = environs.CloudSpec{
+		Type:            "azure",
+		Name:            "azure",
+		Region:          "westus",
+		Endpoint:        "https://api.azurestack.local",
+		StorageEndpoint: "https://storage.azurestack.local",
+		Credential:      fakeUserPassCredential(),
+	}
 	s.sender = nil
 }
 
@@ -43,10 +52,10 @@ func fakeUserPassCredential() *cloud.Credential {
 	cred := cloud.NewCredential(
 		cloud.UserPassAuthType,
 		map[string]string{
-			"application-id":       "application-id",
-			"subscription-id":      "subscription-id",
-			"tenant-id":            "tenant-id",
-			"application-password": "application-password",
+			"application-id":       fakeApplicationId,
+			"subscription-id":      fakeSubscriptionId,
+			"tenant-id":            fakeTenantId,
+			"application-password": "opensezme",
 		},
 	)
 	return &cred
@@ -56,21 +65,39 @@ func (s *environProviderSuite) TestPrepareConfig(c *gc.C) {
 	cfg := makeTestModelConfig(c)
 	s.sender = azuretesting.Senders{tokenRefreshSender()}
 	cfg, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
+		Cloud:  s.spec,
 		Config: cfg,
-		Cloud: environs.CloudSpec{
-			Region:          "westus",
-			Endpoint:        "https://api.azurestack.local",
-			StorageEndpoint: "https://storage.azurestack.local",
-			Credential:      fakeUserPassCredential(),
-		},
 	})
-	c.Check(err, jc.ErrorIsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Check(cfg, gc.NotNil)
+}
 
-	attrs := cfg.UnknownAttrs()
-	c.Assert(attrs["location"], gc.Equals, "westus")
-	c.Assert(attrs["endpoint"], gc.Equals, "https://api.azurestack.local")
-	c.Assert(attrs["storage-endpoint"], gc.Equals, "https://storage.azurestack.local")
+func (s *environProviderSuite) TestOpen(c *gc.C) {
+	env, err := s.provider.Open(environs.OpenParams{
+		Cloud:  s.spec,
+		Config: makeTestModelConfig(c),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env, gc.NotNil)
+}
+
+func (s *environProviderSuite) TestOpenMissingCredential(c *gc.C) {
+	s.spec.Credential = nil
+	s.testOpenError(c, s.spec, `validating cloud spec: missing credential not valid`)
+}
+
+func (s *environProviderSuite) TestOpenUnsupportedCredential(c *gc.C) {
+	credential := cloud.NewCredential(cloud.OAuth1AuthType, map[string]string{})
+	s.spec.Credential = &credential
+	s.testOpenError(c, s.spec, `validating cloud spec: "oauth1" auth-type not supported`)
+}
+
+func (s *environProviderSuite) testOpenError(c *gc.C, spec environs.CloudSpec, expect string) {
+	_, err := s.provider.Open(environs.OpenParams{
+		Cloud:  spec,
+		Config: makeTestModelConfig(c),
+	})
+	c.Assert(err, gc.ErrorMatches, expect)
 }
 
 func newProvider(c *gc.C, config azure.ProviderConfig) environs.EnvironProvider {

--- a/provider/azure/export_test.go
+++ b/provider/azure/export_test.go
@@ -13,5 +13,5 @@ func ForceVolumeSourceTokenRefresh(vs storage.VolumeSource) error {
 }
 
 func ForceTokenRefresh(env environs.Environ) error {
-	return env.(*azureEnviron).config.token.Refresh()
+	return env.(*azureEnviron).token.Refresh()
 }

--- a/provider/azure/instance.go
+++ b/provider/azure/instance.go
@@ -153,10 +153,8 @@ func (inst *azureInstance) Addresses() ([]jujunetwork.Address, error) {
 // internal virtual network. This address is used to identify the machine in
 // network security rules.
 func (inst *azureInstance) internalNetworkAddress() (jujunetwork.Address, error) {
-	inst.env.mu.Lock()
-	subscriptionId := inst.env.config.subscriptionId
+	subscriptionId := inst.env.subscriptionId
 	resourceGroup := inst.env.resourceGroup
-	inst.env.mu.Unlock()
 	internalSubnetId := internalSubnetId(resourceGroup, subscriptionId)
 
 	for _, nic := range inst.networkInterfaces {
@@ -185,10 +183,8 @@ func (inst *azureInstance) internalNetworkAddress() (jujunetwork.Address, error)
 
 // OpenPorts is specified in the Instance interface.
 func (inst *azureInstance) OpenPorts(machineId string, ports []jujunetwork.PortRange) error {
-	inst.env.mu.Lock()
 	nsgClient := network.SecurityGroupsClient{inst.env.network}
 	securityRuleClient := network.SecurityRulesClient{inst.env.network}
-	inst.env.mu.Unlock()
 	internalNetworkAddress, err := inst.internalNetworkAddress()
 	if err != nil {
 		return errors.Trace(err)
@@ -283,9 +279,7 @@ func (inst *azureInstance) OpenPorts(machineId string, ports []jujunetwork.PortR
 
 // ClosePorts is specified in the Instance interface.
 func (inst *azureInstance) ClosePorts(machineId string, ports []jujunetwork.PortRange) error {
-	inst.env.mu.Lock()
 	securityRuleClient := network.SecurityRulesClient{inst.env.network}
-	inst.env.mu.Unlock()
 	securityGroupName := internalSecurityGroupName
 
 	// Delete rules one at a time; this is necessary to avoid trampling
@@ -313,10 +307,7 @@ func (inst *azureInstance) ClosePorts(machineId string, ports []jujunetwork.Port
 
 // Ports is specified in the Instance interface.
 func (inst *azureInstance) Ports(machineId string) (ports []jujunetwork.PortRange, err error) {
-	inst.env.mu.Lock()
 	nsgClient := network.SecurityGroupsClient{inst.env.network}
-	inst.env.mu.Unlock()
-
 	securityGroupName := internalSecurityGroupName
 	var nsg network.SecurityGroup
 	if err := inst.env.callAPI(func() (autorest.Response, error) {

--- a/provider/ec2/config.go
+++ b/provider/ec2/config.go
@@ -7,32 +7,12 @@ import (
 	"fmt"
 
 	"github.com/juju/schema"
-	"gopkg.in/amz.v3/aws"
 	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/environs/config"
 )
 
 var configSchema = environschema.Fields{
-	"access-key": {
-		Description: "The EC2 access key",
-		EnvVar:      "AWS_ACCESS_KEY_ID",
-		Type:        environschema.Tstring,
-		Mandatory:   true,
-		Group:       environschema.AccountGroup,
-	},
-	"secret-key": {
-		Description: "The EC2 secret key",
-		EnvVar:      "AWS_SECRET_ACCESS_KEY",
-		Type:        environschema.Tstring,
-		Mandatory:   true,
-		Secret:      true,
-		Group:       environschema.AccountGroup,
-	},
-	"region": {
-		Description: "The EC2 region to use",
-		Type:        environschema.Tstring,
-	},
 	"vpc-id": {
 		Description: "Use a specific AWS VPC ID (optional). When not specified, Juju requires a default VPC or EC2-Classic features to be available for the account/region.",
 		Example:     "vpc-a1b2c3d4",
@@ -57,8 +37,6 @@ var configFields = func() schema.Fields {
 }()
 
 var configDefaults = schema.Defaults{
-	"access-key":   "",
-	"secret-key":   "",
 	"vpc-id":       "",
 	"vpc-id-force": false,
 }
@@ -66,18 +44,6 @@ var configDefaults = schema.Defaults{
 type environConfig struct {
 	*config.Config
 	attrs map[string]interface{}
-}
-
-func (c *environConfig) region() string {
-	return c.attrs["region"].(string)
-}
-
-func (c *environConfig) accessKey() string {
-	return c.attrs["access-key"].(string)
-}
-
-func (c *environConfig) secretKey() string {
-	return c.attrs["secret-key"].(string)
 }
 
 func (c *environConfig) vpcID() string {
@@ -116,19 +82,6 @@ func validateConfig(cfg, old *config.Config) (*environConfig, error) {
 	}
 	ecfg := &environConfig{cfg, validated}
 
-	if ecfg.accessKey() == "" || ecfg.secretKey() == "" {
-		auth, err := aws.EnvAuth()
-		if err != nil || ecfg.accessKey() != "" || ecfg.secretKey() != "" {
-			return nil, fmt.Errorf("model has no access-key or secret-key")
-		}
-		ecfg.attrs["access-key"] = auth.AccessKey
-		ecfg.attrs["secret-key"] = auth.SecretKey
-	}
-
-	if _, ok := aws.Regions[ecfg.region()]; !ok {
-		return nil, fmt.Errorf("invalid region name %q", ecfg.region())
-	}
-
 	if vpcID := ecfg.vpcID(); isVPCIDSetButInvalid(vpcID) {
 		return nil, fmt.Errorf("vpc-id: %q is not a valid AWS VPC ID", vpcID)
 	} else if !isVPCIDSet(vpcID) && ecfg.forceVPCID() {
@@ -137,9 +90,6 @@ func validateConfig(cfg, old *config.Config) (*environConfig, error) {
 
 	if old != nil {
 		attrs := old.UnknownAttrs()
-		if region, _ := attrs["region"].(string); ecfg.region() != region {
-			return nil, fmt.Errorf("cannot change region from %q to %q", region, ecfg.region())
-		}
 
 		if vpcID, _ := attrs["vpc-id"].(string); vpcID != ecfg.vpcID() {
 			return nil, fmt.Errorf("cannot change vpc-id from %q to %q", vpcID, ecfg.vpcID())

--- a/provider/ec2/config_test.go
+++ b/provider/ec2/config_test.go
@@ -49,11 +49,8 @@ type configTest struct {
 	config             map[string]interface{}
 	change             map[string]interface{}
 	expect             map[string]interface{}
-	region             string
 	vpcID              string
 	forceVPCID         bool
-	accessKey          string
-	secretKey          string
 	firewallMode       string
 	blockStorageSource string
 	err                string
@@ -62,14 +59,21 @@ type configTest struct {
 type attrs map[string]interface{}
 
 func (t configTest) check(c *gc.C) {
+	credential := cloud.NewCredential(
+		cloud.AccessKeyAuthType,
+		map[string]string{
+			"access-key": "x",
+			"secret-key": "y",
+		},
+	)
 	cloudSpec := environs.CloudSpec{
-		Type:   "ec2",
-		Name:   "ec2test",
-		Region: "us-east-1",
+		Type:       "ec2",
+		Name:       "ec2test",
+		Region:     "us-east-1",
+		Credential: &credential,
 	}
 	attrs := testing.FakeConfig().Merge(testing.Attrs{
-		"type":   "ec2",
-		"region": "us-east-1",
+		"type": "ec2",
 	}).Merge(t.config)
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
@@ -101,28 +105,9 @@ func (t configTest) check(c *gc.C) {
 
 	ecfg := e.(*environ).ecfg()
 	c.Assert(ecfg.Name(), gc.Equals, "testenv")
-	if t.region != "" {
-		c.Assert(ecfg.region(), gc.Equals, t.region)
-	}
-
 	c.Assert(ecfg.vpcID(), gc.Equals, t.vpcID)
 	c.Assert(ecfg.forceVPCID(), gc.Equals, t.forceVPCID)
 
-	if t.accessKey != "" {
-		c.Assert(ecfg.accessKey(), gc.Equals, t.accessKey)
-		c.Assert(ecfg.secretKey(), gc.Equals, t.secretKey)
-		expected := map[string]string{
-			"access-key": t.accessKey,
-			"secret-key": t.secretKey,
-		}
-		c.Assert(err, jc.ErrorIsNil)
-		actual, err := e.Provider().SecretAttrs(ecfg.Config)
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(expected, gc.DeepEquals, actual)
-	} else {
-		c.Assert(ecfg.accessKey(), gc.DeepEquals, testAuth.AccessKey)
-		c.Assert(ecfg.secretKey(), gc.DeepEquals, testAuth.SecretKey)
-	}
 	if t.firewallMode != "" {
 		c.Assert(ecfg.FirewallMode(), gc.Equals, t.firewallMode)
 	}
@@ -136,34 +121,6 @@ func (t configTest) check(c *gc.C) {
 var configTests = []configTest{
 	{
 		config: attrs{},
-	}, {
-		config: attrs{
-			"region": "eu-west-1",
-		},
-		region: "eu-west-1",
-	}, {
-		config: attrs{
-			"region": "unknown",
-		},
-		err: ".*invalid region name.*",
-	}, {
-		config: attrs{
-			"region": "configtest",
-		},
-		region: "configtest",
-	}, {
-		config: attrs{
-			"region": "configtest",
-		},
-		change: attrs{
-			"region": "us-east-1",
-		},
-		err: `.*cannot change region from "configtest" to "us-east-1"`,
-	}, {
-		config: attrs{
-			"region": 666,
-		},
-		err: `.*expected string, got int\(666\)`,
 	}, {
 		config:     attrs{},
 		vpcID:      "",
@@ -292,37 +249,6 @@ var configTests = []configTest{
 		vpcID:      "vpc-foo",
 		forceVPCID: true,
 	}, {
-		config: attrs{
-			"access-key": 666,
-		},
-		err: `.*expected string, got int\(666\)`,
-	}, {
-		config: attrs{
-			"secret-key": 666,
-		},
-		err: `.*expected string, got int\(666\)`,
-	}, {
-		config: attrs{
-			"access-key": "jujuer",
-			"secret-key": "open sesame",
-		},
-		accessKey: "jujuer",
-		secretKey: "open sesame",
-	}, {
-		config: attrs{
-			"access-key": "jujuer",
-		},
-		err: ".*model has no access-key or secret-key",
-	}, {
-		config: attrs{
-			"secret-key": "badness",
-		},
-		err: ".*model has no access-key or secret-key",
-	}, {
-		config: attrs{
-			"admin-secret": "Futumpsh",
-		},
-	}, {
 		config:       attrs{},
 		firewallMode: config.FwInstance,
 	}, {
@@ -382,8 +308,6 @@ func indent(s string, with string) string {
 func (s *ConfigSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.savedHome = utils.Home()
-	s.savedAccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
-	s.savedSecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
 
 	home := c.MkDir()
 	sshDir := filepath.Join(home, ".ssh")
@@ -394,16 +318,12 @@ func (s *ConfigSuite) SetUpTest(c *gc.C) {
 
 	err = utils.SetHome(home)
 	c.Assert(err, jc.ErrorIsNil)
-	os.Setenv("AWS_ACCESS_KEY_ID", testAuth.AccessKey)
-	os.Setenv("AWS_SECRET_ACCESS_KEY", testAuth.SecretKey)
 	aws.Regions["configtest"] = configTestRegion
 }
 
 func (s *ConfigSuite) TearDownTest(c *gc.C) {
 	err := utils.SetHome(s.savedHome)
 	c.Assert(err, jc.ErrorIsNil)
-	os.Setenv("AWS_ACCESS_KEY_ID", s.savedAccessKey)
-	os.Setenv("AWS_SECRET_ACCESS_KEY", s.savedSecretKey)
 	delete(aws.Regions, "configtest")
 	s.BaseSuite.TearDownTest(c)
 }
@@ -413,22 +333,6 @@ func (s *ConfigSuite) TestConfig(c *gc.C) {
 		c.Logf("test %d: %v", i, t.config)
 		t.check(c)
 	}
-}
-
-func (s *ConfigSuite) TestMissingAuth(c *gc.C) {
-	os.Setenv("AWS_ACCESS_KEY_ID", "")
-	os.Setenv("AWS_SECRET_ACCESS_KEY", "")
-
-	// Since PR #52 amz.v3 uses these AWS_ vars as fallbacks, if set.
-	os.Setenv("AWS_ACCESS_KEY", "")
-	os.Setenv("AWS_SECRET_KEY", "")
-
-	// Since LP r37 goamz uses also these EC2_ as fallbacks, so unset them too.
-	os.Setenv("EC2_ACCESS_KEY", "")
-	os.Setenv("EC2_SECRET_KEY", "")
-	test := configTests[0]
-	test.err = ".*model has no access-key or secret-key"
-	test.check(c)
 }
 
 func (s *ConfigSuite) TestPrepareConfigSetsDefaultBlockSource(c *gc.C) {
@@ -450,6 +354,7 @@ func (s *ConfigSuite) TestPrepareConfigSetsDefaultBlockSource(c *gc.C) {
 		Config: cfg,
 		Cloud: environs.CloudSpec{
 			Type:       "ec2",
+			Name:       "aws",
 			Region:     "test",
 			Credential: &credential,
 		},
@@ -479,6 +384,7 @@ func (s *ConfigSuite) TestPrepareSetsDefaultBlockSource(c *gc.C) {
 		Config: config,
 		Cloud: environs.CloudSpec{
 			Type:       "ec2",
+			Name:       "aws",
 			Region:     "test",
 			Credential: &credential,
 		},

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -288,7 +288,7 @@ func (v *ebsVolumeSource) CreateVolumes(params []storage.VolumeParams) (_ []stor
 
 	instances := make(instanceCache)
 	if instanceIds.Size() > 1 {
-		if err := instances.update(v.env.ec2(), instanceIds.Values()...); err != nil {
+		if err := instances.update(v.env.ec2, instanceIds.Values()...); err != nil {
 			logger.Debugf("querying running instances: %v", err)
 			// We ignore the error, because we don't want an invalid
 			// InstanceId reference from one VolumeParams to prevent
@@ -317,7 +317,7 @@ func (v *ebsVolumeSource) createVolume(p storage.VolumeParams, instances instanc
 		if err == nil || volumeId == "" {
 			return
 		}
-		if _, err := v.env.ec2().DeleteVolume(volumeId); err != nil {
+		if _, err := v.env.ec2.DeleteVolume(volumeId); err != nil {
 			logger.Errorf("error cleaning up volume %v: %v", volumeId, err)
 		}
 	}()
@@ -329,7 +329,7 @@ func (v *ebsVolumeSource) createVolume(p storage.VolumeParams, instances instanc
 
 	// Create.
 	instId := string(p.Attachment.InstanceId)
-	if err := instances.update(v.env.ec2(), instId); err != nil {
+	if err := instances.update(v.env.ec2, instId); err != nil {
 		return nil, nil, errors.Trace(err)
 	}
 	inst, err := instances.get(instId)
@@ -340,7 +340,7 @@ func (v *ebsVolumeSource) createVolume(p storage.VolumeParams, instances instanc
 	}
 	vol, _ := parseVolumeOptions(p.Size, p.Attributes)
 	vol.AvailZone = inst.AvailZone
-	resp, err := v.env.ec2().CreateVolume(vol)
+	resp, err := v.env.ec2.CreateVolume(vol)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
@@ -352,7 +352,7 @@ func (v *ebsVolumeSource) createVolume(p storage.VolumeParams, instances instanc
 		resourceTags[k] = v
 	}
 	resourceTags[tagName] = resourceName(p.Tag, v.envName)
-	if err := tagResources(v.env.ec2(), resourceTags, volumeId); err != nil {
+	if err := tagResources(v.env.ec2, resourceTags, volumeId); err != nil {
 		return nil, nil, errors.Annotate(err, "tagging volume")
 	}
 
@@ -371,7 +371,7 @@ func (v *ebsVolumeSource) createVolume(p storage.VolumeParams, instances instanc
 func (v *ebsVolumeSource) ListVolumes() ([]string, error) {
 	filter := ec2.NewFilter()
 	filter.Add("tag:"+tags.JujuModel, v.modelUUID)
-	return listVolumes(v.env.ec2(), filter)
+	return listVolumes(v.env.ec2, filter)
 }
 
 func listVolumes(client *ec2.EC2, filter *ec2.Filter) ([]string, error) {
@@ -406,7 +406,7 @@ func (v *ebsVolumeSource) DescribeVolumes(volIds []string) ([]storage.DescribeVo
 	// operation to fail. If we get an invalid volume ID response,
 	// fall back to querying each volume individually. That should
 	// be rare.
-	resp, err := v.env.ec2().Volumes(volIds, nil)
+	resp, err := v.env.ec2.Volumes(volIds, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -438,7 +438,7 @@ func (v *ebsVolumeSource) DescribeVolumes(volIds []string) ([]storage.DescribeVo
 
 // DestroyVolumes is specified on the storage.VolumeSource interface.
 func (v *ebsVolumeSource) DestroyVolumes(volIds []string) ([]error, error) {
-	return destroyVolumes(v.env.ec2(), volIds), nil
+	return destroyVolumes(v.env.ec2, volIds), nil
 }
 
 func destroyVolumes(client *ec2.EC2, volIds []string) []error {
@@ -611,7 +611,7 @@ func (v *ebsVolumeSource) AttachVolumes(attachParams []storage.VolumeAttachmentP
 	}
 	instances := make(instanceCache)
 	if instIds.Size() > 1 {
-		if err := instances.update(v.env.ec2(), instIds.Values()...); err != nil {
+		if err := instances.update(v.env.ec2, instIds.Values()...); err != nil {
 			logger.Debugf("querying running instances: %v", err)
 			// We ignore the error, because we don't want an invalid
 			// InstanceId reference from one VolumeParams to prevent
@@ -689,7 +689,7 @@ func (v *ebsVolumeSource) attachOneVolume(
 			// Can't attach any more volumes.
 			return "", "", err
 		}
-		_, err = v.env.ec2().AttachVolume(volumeId, instId, requestDeviceName)
+		_, err = v.env.ec2.AttachVolume(volumeId, instId, requestDeviceName)
 		if ec2Err, ok := err.(*ec2.Error); ok {
 			switch ec2Err.Code {
 			case invalidParameterValue:
@@ -720,7 +720,7 @@ func (v *ebsVolumeSource) waitVolumeCreated(volumeId string) (*ec2.Volume, error
 		Delay: 200 * time.Millisecond,
 	}
 	var lastStatus string
-	volume, err := waitVolume(v.env.ec2(), volumeId, attempt, func(volume *ec2.Volume) (bool, error) {
+	volume, err := waitVolume(v.env.ec2, volumeId, attempt, func(volume *ec2.Volume) (bool, error) {
 		lastStatus = volume.Status
 		return volume.Status != volumeStatusCreating, nil
 	})
@@ -805,7 +805,7 @@ func (c instanceCache) get(id string) (ec2.Instance, error) {
 
 // DetachVolumes is specified on the storage.VolumeSource interface.
 func (v *ebsVolumeSource) DetachVolumes(attachParams []storage.VolumeAttachmentParams) ([]error, error) {
-	return detachVolumes(v.env.ec2(), attachParams)
+	return detachVolumes(v.env.ec2, attachParams)
 }
 
 func detachVolumes(client *ec2.EC2, attachParams []storage.VolumeAttachmentParams) ([]error, error) {

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/clock"
-	"gopkg.in/amz.v3/aws"
 	"gopkg.in/amz.v3/ec2"
 	"gopkg.in/amz.v3/s3"
 	"gopkg.in/juju/names.v2"
@@ -57,7 +56,10 @@ var (
 )
 
 type environ struct {
-	name string
+	name  string
+	cloud environs.CloudSpec
+	ec2   *ec2.EC2
+	s3    *s3.S3
 
 	// archMutex gates access to supportedArchitectures
 	archMutex sync.Mutex
@@ -68,8 +70,6 @@ type environ struct {
 	// ecfgMutex protects the *Unlocked fields below.
 	ecfgMutex    sync.Mutex
 	ecfgUnlocked *environConfig
-	ec2Unlocked  *ec2.EC2
-	s3Unlocked   *s3.S3
 
 	availabilityZonesMutex sync.Mutex
 	availabilityZones      []common.AvailabilityZone
@@ -79,33 +79,14 @@ func (e *environ) Config() *config.Config {
 	return e.ecfg().Config
 }
 
-func awsClients(cfg *config.Config) (*ec2.EC2, *s3.S3, *environConfig, error) {
+func (e *environ) SetConfig(cfg *config.Config) error {
 	ecfg, err := providerInstance.newConfig(cfg)
 	if err != nil {
-		return nil, nil, nil, err
+		return errors.Trace(err)
 	}
-
-	auth := aws.Auth{
-		AccessKey: ecfg.accessKey(),
-		SecretKey: ecfg.secretKey(),
-	}
-	region := aws.Regions[ecfg.region()]
-	signer := aws.SignV4Factory(region.Name, "ec2")
-	return ec2.New(auth, region, signer), s3.New(auth, region), ecfg, nil
-}
-
-func (e *environ) SetConfig(cfg *config.Config) error {
-	ec2Client, s3Client, ecfg, err := awsClients(cfg)
-	if err != nil {
-		return err
-	}
-
 	e.ecfgMutex.Lock()
-	defer e.ecfgMutex.Unlock()
 	e.ecfgUnlocked = ecfg
-	e.ec2Unlocked = ec2Client
-	e.s3Unlocked = s3Client
-
+	e.ecfgMutex.Unlock()
 	return nil
 }
 
@@ -114,13 +95,6 @@ func (e *environ) ecfg() *environConfig {
 	ecfg := e.ecfgUnlocked
 	e.ecfgMutex.Unlock()
 	return ecfg
-}
-
-func (e *environ) ec2() *ec2.EC2 {
-	e.ecfgMutex.Lock()
-	ec2 := e.ec2Unlocked
-	e.ecfgMutex.Unlock()
-	return ec2
 }
 
 func (e *environ) Name() string {
@@ -134,9 +108,9 @@ func (env *environ) PrepareForBootstrap(ctx environs.BootstrapContext) error {
 			return err
 		}
 	}
-	apiClient, ecfg := env.ec2(), env.ecfg()
-	region, vpcID, forceVPCID := ecfg.region(), ecfg.vpcID(), ecfg.forceVPCID()
-	if err := validateBootstrapVPC(apiClient, region, vpcID, forceVPCID, ctx); err != nil {
+	ecfg := env.ecfg()
+	vpcID, forceVPCID := ecfg.vpcID(), ecfg.forceVPCID()
+	if err := validateBootstrapVPC(env.ec2, env.cloud.Region, vpcID, forceVPCID, ctx); err != nil {
 		return errors.Trace(err)
 	}
 	return nil
@@ -147,9 +121,8 @@ func (env *environ) Create(args environs.CreateParams) error {
 	if err := verifyCredentials(env); err != nil {
 		return err
 	}
-	apiClient := env.ec2()
 	vpcID := env.ecfg().vpcID()
-	if err := validateModelVPC(apiClient, env.name, vpcID); err != nil {
+	if err := validateModelVPC(env.ec2, env.name, vpcID); err != nil {
 		return errors.Trace(err)
 	}
 	// TODO(axw) 2016-08-04 #1609643
@@ -255,8 +228,8 @@ func (e *environ) AvailabilityZones() ([]common.AvailabilityZone, error) {
 	defer e.availabilityZonesMutex.Unlock()
 	if e.availabilityZones == nil {
 		filter := ec2.NewFilter()
-		filter.Add("region-name", e.ecfg().region())
-		resp, err := ec2AvailabilityZones(e.ec2(), filter)
+		filter.Add("region-name", e.cloud.Region)
+		resp, err := ec2AvailabilityZones(e.ec2, filter)
 		if err != nil {
 			return nil, err
 		}
@@ -342,7 +315,7 @@ func (e *environ) PrecheckInstance(series string, cons constraints.Value, placem
 // MetadataLookupParams returns parameters which are used to query simplestreams metadata.
 func (e *environ) MetadataLookupParams(region string) (*simplestreams.MetadataLookupParams, error) {
 	if region == "" {
-		region = e.ecfg().region()
+		region = e.cloud.Region
 	}
 	cloudSpec, err := e.cloudSpec(region)
 	if err != nil {
@@ -358,7 +331,7 @@ func (e *environ) MetadataLookupParams(region string) (*simplestreams.MetadataLo
 
 // Region is specified in the HasRegion interface.
 func (e *environ) Region() (simplestreams.CloudSpec, error) {
-	return e.cloudSpec(e.ecfg().region())
+	return e.cloudSpec(e.cloud.Region)
 }
 
 func (e *environ) cloudSpec(region string) (simplestreams.CloudSpec, error) {
@@ -450,7 +423,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 	arches := args.Tools.Arches()
 
 	spec, err := findInstanceSpec(args.ImageMetadata, &instances.InstanceConstraint{
-		Region:      e.ecfg().region(),
+		Region:      e.cloud.Region,
 		Series:      args.InstanceConfig.Series,
 		Arches:      arches,
 		Constraints: args.Constraints,
@@ -531,7 +504,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 			for subnetID, _ := range args.SubnetsToZones {
 				allowedSubnetIDs = append(allowedSubnetIDs, string(subnetID))
 			}
-			subnetIDsForZone, subnetErr = getVPCSubnetIDsForAvailabilityZone(e.ec2(), e.ecfg().vpcID(), zone, allowedSubnetIDs)
+			subnetIDsForZone, subnetErr = getVPCSubnetIDsForAvailabilityZone(e.ec2, e.ecfg().vpcID(), zone, allowedSubnetIDs)
 		} else if args.Constraints.HaveSpaces() {
 			subnetIDsForZone, subnetErr = findSubnetIDsForAvailabilityZone(zone, args.SubnetsToZones)
 		}
@@ -558,7 +531,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 			logger.Infof("selected subnet %q in zone %q", runArgs.SubnetId, zone)
 		}
 
-		instResp, err = runInstances(e.ec2(), runArgs)
+		instResp, err = runInstances(e.ec2, runArgs)
 		if err == nil || !isZoneOrSubnetConstrainedError(err) {
 			break
 		}
@@ -591,7 +564,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 		names.NewMachineTag(args.InstanceConfig.MachineId), e.Config().Name(),
 	)
 	args.InstanceConfig.Tags[tagName] = instanceName
-	if err := tagResources(e.ec2(), args.InstanceConfig.Tags, string(inst.Id())); err != nil {
+	if err := tagResources(e.ec2, args.InstanceConfig.Tags, string(inst.Id())); err != nil {
 		return nil, errors.Annotate(err, "tagging instance")
 	}
 
@@ -604,7 +577,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 			cfg,
 		)
 		tags[tagName] = instanceName + "-root"
-		if err := tagRootDisk(e.ec2(), tags, inst.Instance); err != nil {
+		if err := tagRootDisk(e.ec2, tags, inst.Instance); err != nil {
 			return nil, errors.Annotate(err, "tagging root disk")
 		}
 	}
@@ -780,7 +753,7 @@ func (e *environ) gatherInstances(
 	insts []instance.Instance,
 	filter *ec2.Filter,
 ) error {
-	resp, err := e.ec2().Instances(nil, filter)
+	resp, err := e.ec2.Instances(nil, filter)
 	if err != nil {
 		return err
 	}
@@ -813,14 +786,13 @@ func (e *environ) gatherInstances(
 
 // NetworkInterfaces implements NetworkingEnviron.NetworkInterfaces.
 func (e *environ) NetworkInterfaces(instId instance.Id) ([]network.InterfaceInfo, error) {
-	ec2Client := e.ec2()
 	var err error
 	var networkInterfacesResp *ec2.NetworkInterfacesResp
 	for a := shortAttempt.Start(); a.Next(); {
 		logger.Tracef("retrieving NICs for instance %q", instId)
 		filter := ec2.NewFilter()
 		filter.Add("attachment.instance-id", string(instId))
-		networkInterfacesResp, err = ec2Client.NetworkInterfaces(nil, filter)
+		networkInterfacesResp, err = e.ec2.NetworkInterfaces(nil, filter)
 		logger.Tracef("instance %q NICs: %#v (err: %v)", instId, networkInterfacesResp, err)
 		if err != nil {
 			logger.Errorf("failed to get instance %q interfaces: %v (retrying)", instId, err)
@@ -841,7 +813,7 @@ func (e *environ) NetworkInterfaces(instId instance.Id) ([]network.InterfaceInfo
 	ec2Interfaces := networkInterfacesResp.Interfaces
 	result := make([]network.InterfaceInfo, len(ec2Interfaces))
 	for i, iface := range ec2Interfaces {
-		resp, err := ec2Client.Subnets([]string{iface.SubnetId}, nil)
+		resp, err := e.ec2.Subnets([]string{iface.SubnetId}, nil)
 		if err != nil {
 			return nil, errors.Annotatef(err, "failed to retrieve subnet %q info", iface.SubnetId)
 		}
@@ -930,8 +902,7 @@ func (e *environ) Subnets(instId instance.Id, subnetIds []network.Id) ([]network
 			results = append(results, info)
 		}
 	} else {
-		ec2Inst := e.ec2()
-		resp, err := ec2Inst.Subnets(nil, nil)
+		resp, err := e.ec2.Subnets(nil, nil)
 		if err != nil {
 			return nil, errors.Annotatef(err, "failed to retrieve subnets")
 		}
@@ -1055,7 +1026,7 @@ func (e *environ) allInstanceIDs(filter *ec2.Filter) ([]instance.Id, error) {
 }
 
 func (e *environ) allInstances(filter *ec2.Filter) ([]instance.Instance, error) {
-	resp, err := e.ec2().Instances(nil, filter)
+	resp, err := e.ec2.Instances(nil, filter)
 	if err != nil {
 		return nil, errors.Annotate(err, "listing instances")
 	}
@@ -1110,7 +1081,7 @@ func (e *environ) destroyControllerManagedEnvirons(controllerUUID string) error 
 	if err != nil {
 		return errors.Annotate(err, "listing volumes")
 	}
-	errs := destroyVolumes(e.ec2(), volIds)
+	errs := destroyVolumes(e.ec2, volIds)
 	for i, err := range errs {
 		if err == nil {
 			continue
@@ -1124,7 +1095,7 @@ func (e *environ) destroyControllerManagedEnvirons(controllerUUID string) error 
 		return errors.Trace(err)
 	}
 	for _, g := range groups {
-		if err := deleteSecurityGroupInsistently(e.ec2(), g, clock.WallClock); err != nil {
+		if err := deleteSecurityGroupInsistently(e.ec2, g, clock.WallClock); err != nil {
 			return errors.Annotatef(
 				err, "cannot delete security group %q (%q)",
 				g.Name, g.Id,
@@ -1137,7 +1108,7 @@ func (e *environ) destroyControllerManagedEnvirons(controllerUUID string) error 
 func (e *environ) allControllerManagedVolumes(controllerUUID string) ([]string, error) {
 	filter := ec2.NewFilter()
 	e.addControllerFilter(filter, controllerUUID)
-	return listVolumes(e.ec2(), filter)
+	return listVolumes(e.ec2, filter)
 }
 
 func portsToIPPerms(ports []network.PortRange) []ec2.IPPerm {
@@ -1163,7 +1134,7 @@ func (e *environ) openPortsInGroup(name string, ports []network.PortRange) error
 		return err
 	}
 	ipPerms := portsToIPPerms(ports)
-	_, err = e.ec2().AuthorizeSecurityGroup(g, ipPerms)
+	_, err = e.ec2.AuthorizeSecurityGroup(g, ipPerms)
 	if err != nil && ec2ErrCode(err) == "InvalidPermission.Duplicate" {
 		if len(ports) == 1 {
 			return nil
@@ -1173,7 +1144,7 @@ func (e *environ) openPortsInGroup(name string, ports []network.PortRange) error
 		// otherwise the ports that were *not* duplicates will have
 		// been ignored
 		for i := range ipPerms {
-			_, err := e.ec2().AuthorizeSecurityGroup(g, ipPerms[i:i+1])
+			_, err := e.ec2.AuthorizeSecurityGroup(g, ipPerms[i:i+1])
 			if err != nil && ec2ErrCode(err) != "InvalidPermission.Duplicate" {
 				return fmt.Errorf("cannot open port %v: %v", ipPerms[i], err)
 			}
@@ -1197,7 +1168,7 @@ func (e *environ) closePortsInGroup(name string, ports []network.PortRange) erro
 	if err != nil {
 		return err
 	}
-	_, err = e.ec2().RevokeSecurityGroup(g, portsToIPPerms(ports))
+	_, err = e.ec2.RevokeSecurityGroup(g, portsToIPPerms(ports))
 	if err != nil {
 		return fmt.Errorf("cannot close ports: %v", err)
 	}
@@ -1258,7 +1229,6 @@ func (*environ) Provider() environs.EnvironProvider {
 }
 
 func (e *environ) instanceSecurityGroups(instIDs []instance.Id, states ...string) ([]ec2.SecurityGroup, error) {
-	ec2inst := e.ec2()
 	strInstID := make([]string, len(instIDs))
 	for i := range instIDs {
 		strInstID[i] = string(instIDs[i])
@@ -1269,7 +1239,7 @@ func (e *environ) instanceSecurityGroups(instIDs []instance.Id, states ...string
 		filter.Add("instance-state-name", states...)
 	}
 
-	resp, err := ec2inst.Instances(strInstID, filter)
+	resp, err := e.ec2.Instances(strInstID, filter)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot retrieve instance information from aws to delete security groups")
 	}
@@ -1289,7 +1259,7 @@ func (e *environ) instanceSecurityGroups(instIDs []instance.Id, states ...string
 func (e *environ) controllerSecurityGroups(controllerUUID string) ([]ec2.SecurityGroup, error) {
 	filter := ec2.NewFilter()
 	e.addControllerFilter(filter, controllerUUID)
-	resp, err := e.ec2().SecurityGroups(nil, filter)
+	resp, err := e.ec2.SecurityGroups(nil, filter)
 	if err != nil {
 		return nil, errors.Annotate(err, "listing security groups")
 	}
@@ -1311,7 +1281,7 @@ func (e *environ) cleanEnvironmentSecurityGroups() error {
 	if err != nil {
 		return errors.Annotatef(err, "cannot retrieve default security group: %q", jujuGroup)
 	}
-	if err := deleteSecurityGroupInsistently(e.ec2(), g, clock.WallClock); err != nil {
+	if err := deleteSecurityGroupInsistently(e.ec2, g, clock.WallClock); err != nil {
 		return errors.Annotate(err, "cannot delete default security group")
 	}
 	return nil
@@ -1321,7 +1291,6 @@ func (e *environ) terminateInstances(ids []instance.Id) error {
 	if len(ids) == 0 {
 		return nil
 	}
-	ec2inst := e.ec2()
 
 	// TODO (anastasiamac 2016-04-11) Err if instances still have resources hanging around.
 	// LP#1568654
@@ -1334,7 +1303,7 @@ func (e *environ) terminateInstances(ids []instance.Id) error {
 	// in defer. Bug#1567179.
 	var err error
 	for a := shortAttempt.Start(); a.Next(); {
-		_, err = terminateInstancesById(ec2inst, ids...)
+		_, err = terminateInstancesById(e.ec2, ids...)
 		if err == nil || ec2ErrCode(err) != "InvalidInstanceID.NotFound" {
 			// This will return either success at terminating all instances (1st condition) or
 			// encountered error as long as it's not NotFound (2nd condition).
@@ -1353,7 +1322,7 @@ func (e *environ) terminateInstances(ids []instance.Id) error {
 	// So try each instance individually, ignoring a NotFound error this time.
 	deletedIDs := []instance.Id{}
 	for _, id := range ids {
-		_, err = terminateInstancesById(ec2inst, id)
+		_, err = terminateInstancesById(e.ec2, id)
 		if err == nil {
 			deletedIDs = append(deletedIDs, id)
 		}
@@ -1396,12 +1365,11 @@ func (e *environ) deleteSecurityGroupsForInstances(ids []instance.Id) {
 	// https://bugs.launchpad.net/juju-core/+bug/1534289
 	jujuGroup := e.jujuGroupName()
 
-	ec2inst := e.ec2()
 	for _, deletable := range securityGroups {
 		if deletable.Name == jujuGroup {
 			continue
 		}
-		if err := deleteSecurityGroupInsistently(ec2inst, deletable, clock.WallClock); err != nil {
+		if err := deleteSecurityGroupInsistently(e.ec2, deletable, clock.WallClock); err != nil {
 			// In ideal world, we would err out here.
 			// However:
 			// 1. We do not know if all instances have been terminated.
@@ -1537,13 +1505,13 @@ func (e *environ) securityGroupsByNameOrID(groupName string) (*ec2.SecurityGroup
 		filter := ec2.NewFilter()
 		filter.Add("vpc-id", chosenVPCID)
 		filter.Add("group-name", groupName)
-		return e.ec2().SecurityGroups(nil, filter)
+		return e.ec2.SecurityGroups(nil, filter)
 	}
 
 	// EC2-Classic or EC2-VPC with implicit default VPC need to use the
 	// GroupName.X arguments instead of the filters.
 	groups := ec2.SecurityGroupNames(groupName)
-	return e.ec2().SecurityGroups(groups, nil)
+	return e.ec2.SecurityGroups(groups, nil)
 }
 
 // ensureGroup returns the security group with name and perms.
@@ -1560,8 +1528,7 @@ func (e *environ) ensureGroup(controllerUUID, name string, perms []ec2.IPPerm) (
 		inVPCLogSuffix = ""
 	}
 
-	ec2inst := e.ec2()
-	resp, err := ec2inst.CreateSecurityGroup(chosenVPCID, name, "juju group")
+	resp, err := e.ec2.CreateSecurityGroup(chosenVPCID, name, "juju group")
 	if err != nil && ec2ErrCode(err) != "InvalidGroup.Duplicate" {
 		err = errors.Annotatef(err, "creating security group %q%s", name, inVPCLogSuffix)
 		return zeroGroup, err
@@ -1577,7 +1544,7 @@ func (e *environ) ensureGroup(controllerUUID, name string, perms []ec2.IPPerm) (
 			names.NewModelTag(controllerUUID),
 			cfg,
 		)
-		if err := tagResources(ec2inst, tags, g.Id); err != nil {
+		if err := tagResources(e.ec2, tags, g.Id); err != nil {
 			return g, errors.Annotate(err, "tagging security group")
 		}
 		logger.Debugf("created security group %q with ID %q%s", name, g.Id, inVPCLogSuffix)
@@ -1607,7 +1574,7 @@ func (e *environ) ensureGroup(controllerUUID, name string, perms []ec2.IPPerm) (
 		}
 	}
 	if len(revoke) > 0 {
-		_, err := ec2inst.RevokeSecurityGroup(g, revoke.ipPerms())
+		_, err := e.ec2.RevokeSecurityGroup(g, revoke.ipPerms())
 		if err != nil {
 			err = errors.Annotatef(err, "revoking security group %q%s", g.Id, inVPCLogSuffix)
 			return zeroGroup, err
@@ -1621,7 +1588,7 @@ func (e *environ) ensureGroup(controllerUUID, name string, perms []ec2.IPPerm) (
 		}
 	}
 	if len(add) > 0 {
-		_, err := ec2inst.AuthorizeSecurityGroup(g, add.ipPerms())
+		_, err := e.ec2.AuthorizeSecurityGroup(g, add.ipPerms())
 		if err != nil {
 			err = errors.Annotatef(err, "authorizing security group %q%s", g.Id, inVPCLogSuffix)
 			return zeroGroup, err

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func StorageEC2(vs jujustorage.VolumeSource) *ec2.EC2 {
-	return vs.(*ebsVolumeSource).env.ec2()
+	return vs.(*ebsVolumeSource).env.ec2
 }
 
 func JujuGroupName(e environs.Environ) string {
@@ -32,7 +32,7 @@ func MachineGroupName(e environs.Environ, machineId string) string {
 }
 
 func EnvironEC2(e environs.Environ) *ec2.EC2 {
-	return e.(*environ).ec2()
+	return e.(*environ).ec2
 }
 
 func InstanceEC2(inst instance.Instance) *ec2.Instance {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -50,12 +50,6 @@ import (
 	jujuversion "github.com/juju/juju/version"
 )
 
-type ProviderSuite struct {
-	coretesting.BaseSuite
-}
-
-var _ = gc.Suite(&ProviderSuite{})
-
 var localConfigAttrs = coretesting.FakeConfig().Merge(coretesting.Attrs{
 	"name":          "sample",
 	"type":          "ec2",

--- a/provider/ec2/provider_test.go
+++ b/provider/ec2/provider_test.go
@@ -1,0 +1,77 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ec2_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type ProviderSuite struct {
+	testing.IsolationSuite
+	spec     environs.CloudSpec
+	provider environs.EnvironProvider
+}
+
+var _ = gc.Suite(&ProviderSuite{})
+
+func (s *ProviderSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	credential := cloud.NewCredential(
+		cloud.AccessKeyAuthType,
+		map[string]string{
+			"access-key": "foo",
+			"secret-key": "bar",
+		},
+	)
+	s.spec = environs.CloudSpec{
+		Type:       "ec2",
+		Name:       "aws",
+		Region:     "us-east-1",
+		Credential: &credential,
+	}
+
+	provider, err := environs.Provider("ec2")
+	c.Assert(err, jc.ErrorIsNil)
+	s.provider = provider
+}
+
+func (s *ProviderSuite) TestOpen(c *gc.C) {
+	env, err := s.provider.Open(environs.OpenParams{
+		Cloud:  s.spec,
+		Config: coretesting.ModelConfig(c),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env, gc.NotNil)
+}
+
+func (s *ProviderSuite) TestOpenInvalidRegion(c *gc.C) {
+	s.spec.Region = "foobar"
+	s.testOpenError(c, s.spec, `validating cloud spec: region name "foobar" not valid`)
+}
+
+func (s *ProviderSuite) TestOpenMissingCredential(c *gc.C) {
+	s.spec.Credential = nil
+	s.testOpenError(c, s.spec, `validating cloud spec: missing credential not valid`)
+}
+
+func (s *ProviderSuite) TestOpenUnsupportedCredential(c *gc.C) {
+	credential := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{})
+	s.spec.Credential = &credential
+	s.testOpenError(c, s.spec, `validating cloud spec: "userpass" auth-type not supported`)
+}
+
+func (s *ProviderSuite) testOpenError(c *gc.C, spec environs.CloudSpec, expect string) {
+	_, err := s.provider.Open(environs.OpenParams{
+		Cloud:  spec,
+		Config: coretesting.ModelConfig(c),
+	})
+	c.Assert(err, gc.ErrorMatches, expect)
+}


### PR DESCRIPTION
**azure**

Drop location, application-id, subscription-id, tenant-id,
application-password, endpoint, and storage-endpoint from azure model
ocnfig. Instead, pull those values out of the cloud spec. With this change,
we now properly support adding machines to separate Azure locations.

**ec2**

Drop region, access-key and secret-key from ec2 model config. Instead, pull
those values out of the cloud spec. With this change, we now properly
support adding machines to separate regions.

(Review request: http://reviews.vapour.ws/r/5387/)