### PR TITLE
provider/gce: remove region/endpoints/creds config

### DIFF
--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -180,12 +180,19 @@ func (s CredentialSchema) Finalize(
 		if field.FilePath {
 			pathValue, ok := resultMap[name]
 			if ok && pathValue != "" {
-				if absPath, err := ValidateFileAttrValue(pathValue.(string)); err != nil {
+				absPath, err := ValidateFileAttrValue(pathValue.(string))
+				if err != nil {
 					return nil, errors.Trace(err)
-				} else {
-					newAttrs[name] = absPath
-					continue
 				}
+				data, err := readFile(absPath)
+				if err != nil {
+					return nil, errors.Annotatef(err, "reading file for %q", name)
+				}
+				if len(data) == 0 {
+					return nil, errors.NotValidf("empty file for %q", name)
+				}
+				newAttrs[name] = string(data)
+				continue
 			}
 		}
 		if val, ok := resultMap[name]; ok {
@@ -301,7 +308,9 @@ type CredentialAttr struct {
 	// value used for this attribute.
 	FileAttr string
 
-	// FilePath is true is the value of this attribute is a file path.
+	// FilePath is true is the value of this attribute is a file path. If
+	// this is true, then the attribute value will be set to the contents
+	// of the file when the credential is "finalized".
 	FilePath bool
 
 	// Optional controls whether the attribute is required to have a non-empty

--- a/cloud/credentials_test.go
+++ b/cloud/credentials_test.go
@@ -318,15 +318,13 @@ func (s *credentialsSuite) TestFinalizeCredential(c *gc.C) {
 			"key": "value",
 		},
 	)
-	schema := cloud.CredentialSchema{
-		{
-			"key",
-			cloud.CredentialAttr{
-				Description: "key credential",
-				Hidden:      true,
-			},
+	schema := cloud.CredentialSchema{{
+		"key",
+		cloud.CredentialAttr{
+			Description: "key credential",
+			Hidden:      true,
 		},
-	}
+	}}
 	_, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.UserPassAuthType: schema,
 	}, readFileNotSupported)
@@ -341,18 +339,16 @@ func (s *credentialsSuite) TestFinalizeCredentialFileAttr(c *gc.C) {
 			"quay":     "value",
 		},
 	)
-	schema := cloud.CredentialSchema{
-		{
-			"key",
-			cloud.CredentialAttr{
-				Description: "key credential",
-				Hidden:      true,
-				FileAttr:    "key-file",
-			},
-		}, {
-			"quay", cloud.CredentialAttr{FileAttr: "quay-file"},
+	schema := cloud.CredentialSchema{{
+		"key",
+		cloud.CredentialAttr{
+			Description: "key credential",
+			Hidden:      true,
+			FileAttr:    "key-file",
 		},
-	}
+	}, {
+		"quay", cloud.CredentialAttr{FileAttr: "quay-file"},
+	}}
 	readFile := func(s string) ([]byte, error) {
 		c.Assert(s, gc.Equals, "path")
 		return []byte("file-value"), nil
@@ -374,16 +370,14 @@ func (s *credentialsSuite) TestFinalizeCredentialFileEmpty(c *gc.C) {
 			"key-file": "path",
 		},
 	)
-	schema := cloud.CredentialSchema{
-		{
-			"key",
-			cloud.CredentialAttr{
-				Description: "key credential",
-				Hidden:      true,
-				FileAttr:    "key-file",
-			},
+	schema := cloud.CredentialSchema{{
+		"key",
+		cloud.CredentialAttr{
+			Description: "key credential",
+			Hidden:      true,
+			FileAttr:    "key-file",
 		},
-	}
+	}}
 	readFile := func(string) ([]byte, error) {
 		return nil, nil
 	}
@@ -398,16 +392,14 @@ func (s *credentialsSuite) TestFinalizeCredentialFileAttrNeither(c *gc.C) {
 		cloud.UserPassAuthType,
 		map[string]string{},
 	)
-	schema := cloud.CredentialSchema{
-		{
-			"key",
-			cloud.CredentialAttr{
-				Description: "key credential",
-				Hidden:      true,
-				FileAttr:    "key-file",
-			},
+	schema := cloud.CredentialSchema{{
+		"key",
+		cloud.CredentialAttr{
+			Description: "key credential",
+			Hidden:      true,
+			FileAttr:    "key-file",
 		},
-	}
+	}}
 	_, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.UserPassAuthType: schema,
 	}, readFileNotSupported)
@@ -422,16 +414,14 @@ func (s *credentialsSuite) TestFinalizeCredentialFileAttrBoth(c *gc.C) {
 			"key-file": "path",
 		},
 	)
-	schema := cloud.CredentialSchema{
-		{
-			"key",
-			cloud.CredentialAttr{
-				Description: "key credential",
-				Hidden:      true,
-				FileAttr:    "key-file",
-			},
+	schema := cloud.CredentialSchema{{
+		"key",
+		cloud.CredentialAttr{
+			Description: "key credential",
+			Hidden:      true,
+			FileAttr:    "key-file",
 		},
-	}
+	}}
 	_, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.UserPassAuthType: schema,
 	}, readFileNotSupported)
@@ -443,15 +433,13 @@ func (s *credentialsSuite) TestFinalizeCredentialInvalid(c *gc.C) {
 		cloud.UserPassAuthType,
 		map[string]string{},
 	)
-	schema := cloud.CredentialSchema{
-		{
-			"key",
-			cloud.CredentialAttr{
-				Description: "key credential",
-				Hidden:      true,
-			},
+	schema := cloud.CredentialSchema{{
+		"key",
+		cloud.CredentialAttr{
+			Description: "key credential",
+			Hidden:      true,
 		},
-	}
+	}}
 	_, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.UserPassAuthType: schema,
 	}, readFileNotSupported)
@@ -483,13 +471,9 @@ func (s *credentialsSuite) TestFinalizeCredentialMandatoryFieldMissing(c *gc.C) 
 		},
 	)
 	schema := cloud.CredentialSchema{
-		{
-			"username", cloud.CredentialAttr{Optional: false},
-		}, {
-			"password", cloud.CredentialAttr{Hidden: true},
-		}, {
-			"domain", cloud.CredentialAttr{},
-		},
+		{"username", cloud.CredentialAttr{Optional: false}},
+		{"password", cloud.CredentialAttr{Hidden: true}},
+		{"domain", cloud.CredentialAttr{}},
 	}
 	_, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.UserPassAuthType: schema,
@@ -504,16 +488,14 @@ func (s *credentialsSuite) TestFinalizeCredentialMandatoryFieldFromFile(c *gc.C)
 			"key-file": "path",
 		},
 	)
-	schema := cloud.CredentialSchema{
-		{
-			"key",
-			cloud.CredentialAttr{
-				Description: "key credential",
-				Optional:    false,
-				FileAttr:    "key-file",
-			},
+	schema := cloud.CredentialSchema{{
+		"key",
+		cloud.CredentialAttr{
+			Description: "key credential",
+			Optional:    false,
+			FileAttr:    "key-file",
 		},
-	}
+	}}
 	readFile := func(s string) ([]byte, error) {
 		c.Assert(s, gc.Equals, "path")
 		return []byte("file-value"), nil
@@ -538,13 +520,9 @@ func (s *credentialsSuite) TestFinalizeCredentialExtraField(c *gc.C) {
 		},
 	)
 	schema := cloud.CredentialSchema{
-		{
-			"username", cloud.CredentialAttr{Optional: false},
-		}, {
-			"password", cloud.CredentialAttr{Hidden: true},
-		}, {
-			"domain", cloud.CredentialAttr{},
-		},
+		{"username", cloud.CredentialAttr{Optional: false}},
+		{"password", cloud.CredentialAttr{Hidden: true}},
+		{"domain", cloud.CredentialAttr{}},
 	}
 	_, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.UserPassAuthType: schema,
@@ -562,13 +540,9 @@ func (s *credentialsSuite) TestFinalizeCredentialInvalidChoice(c *gc.C) {
 		},
 	)
 	schema := cloud.CredentialSchema{
-		{
-			"username", cloud.CredentialAttr{Optional: false},
-		}, {
-			"password", cloud.CredentialAttr{Hidden: true},
-		}, {
-			"algorithm", cloud.CredentialAttr{Options: []interface{}{"bar", "foobar"}},
-		},
+		{"username", cloud.CredentialAttr{Optional: false}},
+		{"password", cloud.CredentialAttr{Hidden: true}},
+		{"algorithm", cloud.CredentialAttr{Options: []interface{}{"bar", "foobar"}}},
 	}
 	_, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.UserPassAuthType: schema,
@@ -588,17 +562,21 @@ func (s *credentialsSuite) TestFinalizeCredentialFilePath(c *gc.C) {
 			"file": filename,
 		},
 	)
-	schema := cloud.CredentialSchema{
-		{
-			"file", cloud.CredentialAttr{FilePath: true},
-		},
+	schema := cloud.CredentialSchema{{
+		"file", cloud.CredentialAttr{FilePath: true},
+	}}
+
+	readFile := func(path string) ([]byte, error) {
+		c.Assert(path, gc.Equals, filename)
+		return []byte("file-contents"), nil
 	}
+
 	newCred, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.JSONFileAuthType: schema,
-	}, nil)
+	}, readFile)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newCred.Attributes(), jc.DeepEquals, map[string]string{
-		"file": filename,
+		"file": "file-contents",
 	})
 }
 
@@ -609,11 +587,9 @@ func (s *credentialsSuite) TestFinalizeCredentialInvalidFilePath(c *gc.C) {
 			"file": filepath.Join(c.MkDir(), "somefile"),
 		},
 	)
-	schema := cloud.CredentialSchema{
-		{
-			"file", cloud.CredentialAttr{FilePath: true},
-		},
-	}
+	schema := cloud.CredentialSchema{{
+		"file", cloud.CredentialAttr{FilePath: true},
+	}}
 	_, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.JSONFileAuthType: schema,
 	}, nil)
@@ -627,11 +603,9 @@ func (s *credentialsSuite) TestFinalizeCredentialRelativeFilePath(c *gc.C) {
 			"file": "file",
 		},
 	)
-	schema := cloud.CredentialSchema{
-		{
-			"file", cloud.CredentialAttr{FilePath: true},
-		},
-	}
+	schema := cloud.CredentialSchema{{
+		"file", cloud.CredentialAttr{FilePath: true},
+	}}
 	_, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.JSONFileAuthType: schema,
 	}, nil)
@@ -646,13 +620,11 @@ func (s *credentialsSuite) TestRemoveSecrets(c *gc.C) {
 			"password": "secret",
 		},
 	)
-	schema := cloud.CredentialSchema{
-		{
-			"username", cloud.CredentialAttr{},
-		}, {
-			"password", cloud.CredentialAttr{Hidden: true},
-		},
-	}
+	schema := cloud.CredentialSchema{{
+		"username", cloud.CredentialAttr{},
+	}, {
+		"password", cloud.CredentialAttr{Hidden: true},
+	}}
 	sanitisedCred, err := cloud.RemoveSecrets(cred, map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.UserPassAuthType: schema,
 	})

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -31,7 +31,6 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/provider/gce"
 	jujuversion "github.com/juju/juju/version"
 )
 
@@ -442,17 +441,6 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	controllerUUID, err := utils.NewUUID()
 	if err != nil {
 		return errors.Trace(err)
-	}
-
-	// TODO(axw) this is a dirty hack to get 2.0-beta10 over the line.
-	// We need to pull this out immediately after, and then update
-	// everything to remove credentials from model config.
-	if cloud.Type == "gce" && credential.AuthType() == jujucloud.JSONFileAuthType {
-		cred, err := gce.ParseJSONAuthFile(credential.Attributes()["file"])
-		if err != nil {
-			return errors.Trace(err)
-		}
-		*credential = cred
 	}
 
 	// Create a model config, and split out any controller

--- a/environs/testing/credentials.go
+++ b/environs/testing/credentials.go
@@ -6,7 +6,6 @@ package testing
 import (
 	"fmt"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -32,8 +31,8 @@ func AssertProviderCredentialsValid(c *gc.C, p environs.EnvironProvider, authTyp
 	schema, ok := p.CredentialSchemas()[authType]
 	c.Assert(ok, jc.IsTrue, gc.Commentf("missing schema for %q auth-type", authType))
 	validate := func(attrs map[string]string) error {
-		_, err := schema.Finalize(attrs, func(string) ([]byte, error) {
-			return nil, errors.NotSupportedf("reading files")
+		_, err := schema.Finalize(attrs, func(path string) ([]byte, error) {
+			return []byte("contentsOf(" + path + ")"), nil
 		})
 		return err
 	}

--- a/provider/gce/config.go
+++ b/provider/gce/config.go
@@ -9,7 +9,6 @@ import (
 	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/provider/gce/google"
 )
 
 // TODO(ericsnow) While not strictly config-related, we could use some
@@ -22,68 +21,7 @@ import (
 // that we can use to validate this provider's potentially out-of-date
 // data.
 
-// The GCE-specific config keys.
-const (
-	cfgPrivateKey    = "private-key"
-	cfgClientID      = "client-id"
-	cfgClientEmail   = "client-email"
-	cfgRegion        = "region"
-	cfgProjectID     = "project-id"
-	cfgImageEndpoint = "image-endpoint"
-)
-
-var configSchema = environschema.Fields{
-	cfgPrivateKey: {
-		Type: environschema.Tstring,
-		Description: cfgPrivateKey + ` is the private key that matches the public key
-associated with the GCE account.`,
-		EnvVar:    google.OSEnvPrivateKey,
-		Group:     environschema.AccountGroup,
-		Secret:    true,
-		Mandatory: true,
-	},
-	cfgClientID: {
-		Type:        environschema.Tstring,
-		Description: cfgClientID + ` is the GCE account's OAuth ID.`,
-		EnvVar:      google.OSEnvClientID,
-		Group:       environschema.AccountGroup,
-		Mandatory:   true,
-	},
-	cfgClientEmail: {
-		Type:        environschema.Tstring,
-		Description: cfgClientEmail + ` is the email address associated with the GCE account.`,
-		EnvVar:      google.OSEnvClientEmail,
-		Group:       environschema.AccountGroup,
-		Mandatory:   true,
-	},
-	cfgProjectID: {
-		Type:        environschema.Tstring,
-		Description: cfgProjectID + ` is the project ID to use in all GCE API requests`,
-		EnvVar:      google.OSEnvProjectID,
-		Group:       environschema.AccountGroup,
-		Mandatory:   true,
-	},
-	cfgRegion: {
-		Type:        environschema.Tstring,
-		Description: cfgRegion + ` is the GCE region in which to operate`,
-		EnvVar:      google.OSEnvRegion,
-	},
-	cfgImageEndpoint: {
-		Type:        environschema.Tstring,
-		Description: cfgImageEndpoint + ` identifies where the provider should look for cloud images (i.e. for simplestreams)`,
-		EnvVar:      google.OSEnvImageEndpoint,
-	},
-}
-
-var osEnvFields = func() map[string]string {
-	m := make(map[string]string)
-	for name, f := range configSchema {
-		if f.EnvVar != "" {
-			m[f.EnvVar] = name
-		}
-	}
-	return m
-}()
+var configSchema = environschema.Fields{}
 
 // configFields is the spec for each GCE config value's type.
 var configFields = func() schema.Fields {
@@ -94,28 +32,13 @@ var configFields = func() schema.Fields {
 	return fs
 }()
 
-// TODO(ericsnow) Do we need custom defaults for "image-metadata-url" or
-// "agent-metadata-url"? The defaults are the official ones (e.g.
-// cloud-images).
-var configDefaults = schema.Defaults{
-	// See http://cloud-images.ubuntu.com/releases/streams/v1/com.ubuntu.cloud:released:gce.json
-	cfgImageEndpoint: "https://www.googleapis.com",
-}
+var configImmutableFields = []string{}
 
-var configImmutableFields = []string{
-	cfgPrivateKey,
-	cfgClientID,
-	cfgClientEmail,
-	cfgRegion,
-	cfgProjectID,
-	cfgImageEndpoint,
-}
+var configDefaults = schema.Defaults{}
 
 type environConfig struct {
-	config      *config.Config
-	attrs       map[string]interface{}
-	credentials google.Credentials
-	conn        google.ConnectionConfig
+	config *config.Config
+	attrs  map[string]interface{}
 }
 
 // newConfig builds a new environConfig from the provided Config
@@ -130,101 +53,29 @@ func newConfig(cfg, old *config.Config) (*environConfig, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	// We don't allow an empty string for any attribute.
-	for attr, value := range attrs {
-		if value == "" {
-			return nil, errors.Errorf("%s: must not be empty", attr)
+
+	if old != nil {
+		// There's an old configuration. Validate it so that any
+		// default values are correctly coerced for when we check
+		// the old values later.
+		oldEcfg, err := newConfig(old, nil)
+		if err != nil {
+			return nil, errors.Annotatef(err, "invalid base config")
+		}
+		for _, attr := range configImmutableFields {
+			oldv, newv := oldEcfg.attrs[attr], attrs[attr]
+			if oldv != newv {
+				return nil, errors.Errorf(
+					"%s: cannot change from %v to %v",
+					attr, oldv, newv,
+				)
+			}
 		}
 	}
-	newCfg, err := cfg.Apply(attrs)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	credentials, err := parseCredentials(attrs)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+
 	ecfg := &environConfig{
-		config:      newCfg,
-		attrs:       attrs,
-		credentials: *credentials,
-		conn: google.ConnectionConfig{
-			Region:    attrs[cfgRegion].(string),
-			ProjectID: attrs[cfgProjectID].(string),
-		},
-	}
-	// Verify that the connection object is valid.
-	if err := ecfg.conn.Validate(); err != nil {
-		return nil, errors.Trace(handleInvalidFieldError(err))
-	}
-	if old == nil {
-		return ecfg, nil
-	}
-	// There's an old configuration. Validate it so that any
-	// default values are correctly coerced for when we
-	// check the old values later.
-	oldEcfg, err := newConfig(old, nil)
-	if err != nil {
-		return nil, errors.Annotatef(err, "invalid base config")
-	}
-	for _, attr := range configImmutableFields {
-		oldv, newv := oldEcfg.attrs[attr], ecfg.attrs[attr]
-		if oldv != newv {
-			return nil, errors.Errorf("%s: cannot change from %v to %v", attr, oldv, newv)
-		}
+		config: cfg,
+		attrs:  attrs,
 	}
 	return ecfg, nil
-}
-
-func (c *environConfig) region() string {
-	return c.conn.Region
-}
-
-// imageEndpoint identifies where the provider should look for
-// cloud images (i.e. for simplestreams).
-func (c *environConfig) imageEndpoint() string {
-	return c.attrs[cfgImageEndpoint].(string)
-}
-
-// secret returns the secret configuration values.
-func (c *environConfig) secret() map[string]string {
-	secretAttrs := make(map[string]string)
-	for attr, val := range c.attrs {
-		if configSchema[attr].Secret {
-			secretAttrs[attr] = val.(string)
-		}
-	}
-	return secretAttrs
-}
-
-// parseCredentials extracts the OAuth2 info from the config from the
-// individual fields (falling back on the JSON file).
-func parseCredentials(attrs map[string]interface{}) (*google.Credentials, error) {
-	values := make(map[string]string)
-	for attr, val := range attrs {
-		f := configSchema[attr]
-		if f.Group == environschema.AccountGroup && f.EnvVar != "" {
-			values[f.EnvVar] = val.(string)
-		}
-	}
-	creds, err := google.NewCredentials(values)
-	if err != nil {
-		return nil, handleInvalidFieldError(err)
-	}
-	return creds, nil
-}
-
-// handleInvalidFieldError converts a google.InvalidConfigValue into a new
-// error, translating a {provider/gce/google}.OSEnvVar* value into a
-// GCE config key in the new error.
-func handleInvalidFieldError(err error) error {
-	vErr, ok := errors.Cause(err).(*google.InvalidConfigValueError)
-	if !ok {
-		return err
-	}
-	vErr.Key = osEnvFields[vErr.Key]
-	if vErr.Value == "" {
-		return errors.Errorf("%s: must not be empty", vErr.Key)
-	}
-	return err
 }

--- a/provider/gce/config_test.go
+++ b/provider/gce/config_test.go
@@ -7,7 +7,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/provider/gce"
@@ -107,76 +106,10 @@ func updateAttrs(attrs, updates testing.Attrs) testing.Attrs {
 }
 
 var newConfigTests = []configTestSpec{{
-	info:   "client-id is required",
-	remove: []string{"client-id"},
-	err:    "client-id: expected string, got nothing",
-}, {
-	info:   "client-id cannot be empty",
-	insert: testing.Attrs{"client-id": ""},
-	err:    "client-id: must not be empty",
-}, {
-	info:   "private-key is required",
-	remove: []string{"private-key"},
-	err:    "private-key: expected string, got nothing",
-}, {
-	info:   "private-key cannot be empty",
-	insert: testing.Attrs{"private-key": ""},
-	err:    "private-key: must not be empty",
-}, {
-	info:   "client-email is required",
-	remove: []string{"client-email"},
-	err:    "client-email: expected string, got nothing",
-}, {
-	info:   "client-email cannot be empty",
-	insert: testing.Attrs{"client-email": ""},
-	err:    "client-email: must not be empty",
-}, {
-	info:   "region cannot be empty",
-	insert: testing.Attrs{"region": ""},
-	err:    "region: must not be empty",
-}, {
-	info:   "project-id is required",
-	remove: []string{"project-id"},
-	err:    "project-id: expected string, got nothing",
-}, {
-	info:   "project-id cannot be empty",
-	insert: testing.Attrs{"project-id": ""},
-	err:    "project-id: must not be empty",
-}, {
-	info:   "image-endpoint is inserted if missing",
-	remove: []string{"image-endpoint"},
-	expect: testing.Attrs{"image-endpoint": "https://www.googleapis.com"},
-}, {
-	info:   "image-endpoint cannot be empty",
-	insert: testing.Attrs{"image-endpoint": ""},
-	err:    "image-endpoint: must not be empty",
-}, {
 	info:   "unknown field is not touched",
 	insert: testing.Attrs{"unknown-field": 12345},
 	expect: testing.Attrs{"unknown-field": 12345},
 }}
-
-func makeTestCloudSpec() environs.CloudSpec {
-	cred := makeTestCredential()
-	return environs.CloudSpec{
-		Type:       "gce",
-		Name:       "google",
-		Region:     "us-east1",
-		Credential: &cred,
-	}
-}
-
-func makeTestCredential() cloud.Credential {
-	return cloud.NewCredential(
-		cloud.OAuth2AuthType,
-		map[string]string{
-			"project-id":   "x",
-			"client-id":    "y",
-			"client-email": "zz@example.com",
-			"private-key":  "why",
-		},
-	)
-}
 
 func (s *ConfigSuite) TestNewModelConfig(c *gc.C) {
 	for i, test := range newConfigTests {
@@ -184,7 +117,7 @@ func (s *ConfigSuite) TestNewModelConfig(c *gc.C) {
 
 		testConfig := test.newConfig(c)
 		environ, err := environs.New(environs.OpenParams{
-			Cloud:  makeTestCloudSpec(),
+			Cloud:  gce.MakeTestCloudSpec(),
 			Config: testConfig,
 		})
 
@@ -235,26 +168,6 @@ var changeConfigTests = []configTestSpec{{
 	info:   "no change, no error",
 	expect: gce.ConfigAttrs,
 }, {
-	info:   "cannot change private-key",
-	insert: testing.Attrs{"private-key": "okkult"},
-	err:    "private-key: cannot change from " + gce.PrivateKey + " to okkult",
-}, {
-	info:   "cannot change client-id",
-	insert: testing.Attrs{"client-id": "mutant"},
-	err:    "client-id: cannot change from " + gce.ClientID + " to mutant",
-}, {
-	info:   "cannot change client-email",
-	insert: testing.Attrs{"client-email": "spam@eggs.com"},
-	err:    "client-email: cannot change from " + gce.ClientEmail + " to spam@eggs.com",
-}, {
-	info:   "cannot change region",
-	insert: testing.Attrs{"region": "not home"},
-	err:    "region: cannot change from home to not home",
-}, {
-	info:   "cannot change project-id",
-	insert: testing.Attrs{"project-id": "your-juju"},
-	err:    "project-id: cannot change from my-juju to your-juju",
-}, {
 	info:   "can insert unknown field",
 	insert: testing.Attrs{"unknown": "ignoti"},
 	expect: testing.Attrs{"unknown": "ignoti"},
@@ -277,37 +190,12 @@ func (s *ConfigSuite) TestValidateChange(c *gc.C) {
 	}
 }
 
-func (s *ConfigSuite) TestValidateChangeFromOldConfigWithMissingAttributeWithDefault(c *gc.C) {
-	// If the provider implementation is changed to add a new configuration attribute
-	// that has a default value, and the controller is upgraded to the new implementation,
-	// the validated configuration in the state will have no value for that attribute,
-	// even though newly validated configurations will.
-	//
-	// This test ensures that we can deal with that scenario by removing
-	// an attribute which currently has a default, and checking that we can
-	// still validate OK.
-
-	oldCfg := configTestSpec{
-		remove: []string{"image-endpoint"},
-	}.newConfig(c)
-
-	newCfg, err := testing.ModelConfig(c).Apply(gce.ConfigAttrs.Merge(testing.Attrs{
-		"image-endpoint": "https://www.googleapis.com",
-	}))
-	c.Assert(err, jc.ErrorIsNil)
-
-	validatedConfig, err := gce.Provider.Validate(newCfg, oldCfg)
-
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(validatedConfig.AllAttrs()["image-endpoint"], gc.Equals, "https://www.googleapis.com")
-}
-
 func (s *ConfigSuite) TestSetConfig(c *gc.C) {
 	for i, test := range changeConfigTests {
 		c.Logf("test %d: %s", i, test.info)
 
 		environ, err := environs.New(environs.OpenParams{
-			Cloud:  makeTestCloudSpec(),
+			Cloud:  gce.MakeTestCloudSpec(),
 			Config: s.config,
 		})
 		c.Assert(err, jc.ErrorIsNil)

--- a/provider/gce/credentials_test.go
+++ b/provider/gce/credentials_test.go
@@ -62,7 +62,7 @@ func (s *credentialsSuite) TestOAuth2HiddenAttributes(c *gc.C) {
 func (s *credentialsSuite) TestJSONFileCredentialsValid(c *gc.C) {
 	dir := c.MkDir()
 	filename := filepath.Join(dir, "somefile")
-	err := ioutil.WriteFile(filename, []byte{}, 0600)
+	err := ioutil.WriteFile(filename, []byte("contents"), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 	envtesting.AssertProviderCredentialsValid(c, s.provider, "jsonfile", map[string]string{
 		// For now at least, the contents of the file are not validated

--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -4,10 +4,12 @@
 package gce
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/juju/errors"
 
+	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/simplestreams"
@@ -56,9 +58,10 @@ type gceConnection interface {
 }
 
 type environ struct {
-	name string
-	uuid string
-	gce  gceConnection
+	name  string
+	uuid  string
+	cloud environs.CloudSpec
+	gce   gceConnection
 
 	lock sync.Mutex // lock protects access to ecfg
 	ecfg *environConfig
@@ -73,20 +76,42 @@ type environ struct {
 // Function entry points defined as variables so they can be overridden
 // for testing purposes.
 var (
-	newConnection = func(ecfg *environConfig) (gceConnection, error) {
-		return google.Connect(ecfg.conn, &ecfg.credentials)
+	newConnection = func(conn google.ConnectionConfig, creds *google.Credentials) (gceConnection, error) {
+		return google.Connect(conn, creds)
 	}
 	destroyEnv = common.Destroy
 	bootstrap  = common.Bootstrap
 )
 
-func newEnviron(cfg *config.Config) (*environ, error) {
+func newEnviron(cloud environs.CloudSpec, cfg *config.Config) (*environ, error) {
 	ecfg, err := newConfig(cfg, nil)
 	if err != nil {
 		return nil, errors.Annotate(err, "invalid config")
 	}
+
+	credAttrs := cloud.Credential.Attributes()
+	if cloud.Credential.AuthType() == jujucloud.JSONFileAuthType {
+		contents := credAttrs[credAttrFile]
+		credential, err := parseJSONAuthFile(strings.NewReader(contents))
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		credAttrs = credential.Attributes()
+	}
+
+	credential := &google.Credentials{
+		ClientID:    credAttrs[credAttrClientID],
+		ProjectID:   credAttrs[credAttrProjectID],
+		ClientEmail: credAttrs[credAttrClientEmail],
+		PrivateKey:  []byte(credAttrs[credAttrPrivateKey]),
+	}
+	connectionConfig := google.ConnectionConfig{
+		Region:    cloud.Region,
+		ProjectID: credential.ProjectID,
+	}
+
 	// Connect and authenticate.
-	conn, err := newConnection(ecfg)
+	conn, err := newConnection(connectionConfig, credential)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -98,6 +123,7 @@ func newEnviron(cfg *config.Config) (*environ, error) {
 	return &environ{
 		name:      ecfg.config.Name(),
 		uuid:      ecfg.config.UUID(),
+		cloud:     cloud,
 		ecfg:      ecfg,
 		gce:       conn,
 		namespace: namespace,
@@ -117,8 +143,8 @@ func (*environ) Provider() environs.EnvironProvider {
 // Region returns the CloudSpec to use for the provider, as configured.
 func (env *environ) Region() (simplestreams.CloudSpec, error) {
 	return simplestreams.CloudSpec{
-		Region:   env.ecfg.region(),
-		Endpoint: env.ecfg.imageEndpoint(),
+		Region:   env.cloud.Region,
+		Endpoint: env.cloud.Endpoint,
 	}, nil
 }
 

--- a/provider/gce/environ_availzones.go
+++ b/provider/gce/environ_availzones.go
@@ -14,7 +14,7 @@ import (
 
 // AvailabilityZones returns all availability zones in the environment.
 func (env *environ) AvailabilityZones() ([]common.AvailabilityZone, error) {
-	zones, err := env.gce.AvailabilityZones(env.ecfg.region())
+	zones, err := env.gce.AvailabilityZones(env.cloud.Region)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -54,7 +54,7 @@ func (env *environ) InstanceAvailabilityZoneNames(ids []instance.Id) ([]string, 
 }
 
 func (env *environ) availZone(name string) (*google.AvailabilityZone, error) {
-	zones, err := env.gce.AvailabilityZones(env.ecfg.region())
+	zones, err := env.gce.AvailabilityZones(env.cloud.Region)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/gce/environ_availzones_test.go
+++ b/provider/gce/environ_availzones_test.go
@@ -51,7 +51,7 @@ func (s *environAZSuite) TestAvailabilityZonesAPI(c *gc.C) {
 
 	c.Check(s.FakeConn.Calls, gc.HasLen, 1)
 	c.Check(s.FakeConn.Calls[0].FuncName, gc.Equals, "AvailabilityZones")
-	c.Check(s.FakeConn.Calls[0].Region, gc.Equals, "home")
+	c.Check(s.FakeConn.Calls[0].Region, gc.Equals, "us-east1")
 }
 
 func (s *environAZSuite) TestInstanceAvailabilityZoneNames(c *gc.C) {
@@ -137,7 +137,7 @@ func (s *environAZSuite) TestParseAvailabilityZonesPlacementAPI(c *gc.C) {
 	s.FakeCommon.CheckCalls(c, []gce.FakeCall{})
 	c.Check(s.FakeConn.Calls, gc.HasLen, 1)
 	c.Check(s.FakeConn.Calls[0].FuncName, gc.Equals, "AvailabilityZones")
-	c.Check(s.FakeConn.Calls[0].Region, gc.Equals, "home")
+	c.Check(s.FakeConn.Calls[0].Region, gc.Equals, "us-east1")
 }
 
 func (s *environAZSuite) TestParseAvailabilityZonesPlacementUnavailable(c *gc.C) {

--- a/provider/gce/environ_broker.go
+++ b/provider/gce/environ_broker.go
@@ -96,7 +96,7 @@ func (env *environ) buildInstanceSpec(args environs.StartInstanceParams) (*insta
 	series := args.Tools.OneSeries()
 	spec, err := findInstanceSpec(
 		env, &instances.InstanceConstraint{
-			Region:      env.ecfg.region(),
+			Region:      env.cloud.Region,
 			Series:      series,
 			Arches:      arches,
 			Constraints: args.Constraints,

--- a/provider/gce/environ_policy_test.go
+++ b/provider/gce/environ_policy_test.go
@@ -54,7 +54,7 @@ func (s *environPolSuite) TestPrecheckInstanceFullAPI(c *gc.C) {
 
 	c.Check(s.FakeConn.Calls, gc.HasLen, 1)
 	c.Check(s.FakeConn.Calls[0].FuncName, gc.Equals, "AvailabilityZones")
-	c.Check(s.FakeConn.Calls[0].Region, gc.Equals, "home")
+	c.Check(s.FakeConn.Calls[0].Region, gc.Equals, "us-east1")
 }
 
 func (s *environPolSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {

--- a/provider/gce/environ_test.go
+++ b/provider/gce/environ_test.go
@@ -38,7 +38,7 @@ func (s *environSuite) TestRegion(c *gc.C) {
 	cloudSpec, err := s.Env.Region()
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(cloudSpec.Region, gc.Equals, "home")
+	c.Check(cloudSpec.Region, gc.Equals, "us-east1")
 	c.Check(cloudSpec.Endpoint, gc.Equals, "https://www.googleapis.com")
 }
 

--- a/provider/gce/provider.go
+++ b/provider/gce/provider.go
@@ -20,49 +20,34 @@ var providerInstance environProvider
 
 // Open implements environs.EnvironProvider.
 func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
-	env, err := newEnviron(args.Config)
+	if err := validateCloudSpec(args.Cloud); err != nil {
+		return nil, errors.Annotate(err, "validating cloud spec")
+	}
+	env, err := newEnviron(args.Cloud, args.Config)
 	return env, errors.Trace(err)
 }
 
 // PrepareConfig implements environs.EnvironProvider.
 func (p environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
-	// Add credentials to the configuration.
-	cfg := args.Config
-	switch authType := args.Cloud.Credential.AuthType(); authType {
-	case cloud.JSONFileAuthType:
-		filename := args.Cloud.Credential.Attributes()["file"]
-		credential, err := ParseJSONAuthFile(filename)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		args.Cloud.Credential = &credential
-		fallthrough
-	case cloud.OAuth2AuthType:
-		credentialAttrs := args.Cloud.Credential.Attributes()
-		var err error
-		cfg, err = args.Config.Apply(map[string]interface{}{
-			cfgProjectID:   credentialAttrs[cfgProjectID],
-			cfgClientID:    credentialAttrs[cfgClientID],
-			cfgClientEmail: credentialAttrs[cfgClientEmail],
-			cfgPrivateKey:  credentialAttrs[cfgPrivateKey],
-		})
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
+	if err := validateCloudSpec(args.Cloud); err != nil {
+		return nil, errors.Annotate(err, "validating cloud spec")
+	}
+	return configWithDefaults(args.Config)
+}
+
+func validateCloudSpec(spec environs.CloudSpec) error {
+	if err := spec.Validate(); err != nil {
+		return errors.Trace(err)
+	}
+	if spec.Credential == nil {
+		return errors.NotValidf("missing credential")
+	}
+	switch authType := spec.Credential.AuthType(); authType {
+	case cloud.OAuth2AuthType, cloud.JSONFileAuthType:
 	default:
-		return nil, errors.NotSupportedf("%q auth-type", authType)
+		return errors.NotSupportedf("%q auth-type", authType)
 	}
-	// Ensure cloud info is in config.
-	var err error
-	cfg, err = cfg.Apply(map[string]interface{}{
-		cfgRegion: args.Cloud.Region,
-		// TODO (anastasiamac 2016-06-09) at some stage will need to
-		//  also add endpoint and storage endpoint.
-	})
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return configWithDefaults(cfg)
+	return nil
 }
 
 // Schema returns the configuration schema for an environment.
@@ -93,10 +78,7 @@ func configWithDefaults(cfg *config.Config) (*config.Config, error) {
 
 // RestrictedConfigAttributes is specified in the EnvironProvider interface.
 func (environProvider) RestrictedConfigAttributes() []string {
-	return []string{
-		cfgRegion,
-		cfgImageEndpoint,
-	}
+	return []string{}
 }
 
 // Validate implements environs.EnvironProvider.Validate.
@@ -110,10 +92,5 @@ func (environProvider) Validate(cfg, old *config.Config) (*config.Config, error)
 
 // SecretAttrs implements environs.EnvironProvider.SecretAttrs.
 func (environProvider) SecretAttrs(cfg *config.Config) (map[string]string, error) {
-	// The defaults should be set already, so we pass nil.
-	ecfg, err := newConfig(cfg, nil)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return ecfg.secret(), nil
+	return map[string]string{}, nil
 }


### PR DESCRIPTION
Drop region, image-endpoint, project-id, client-id,
client-email, and private-key from gce model config.
Instead, pull those values from out of the cloud spec.
With this change, we now properly support adding
machines to separate GCE regions.

There is a minor change to credential parsing, to
read file attributes into the credential map when
finalizing.

(Review request: http://reviews.vapour.ws/r/5389/)