### PR TITLE
provider/maas: remove server/cred config

### DIFF
--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -216,10 +216,7 @@ func (*RestrictedProviderFieldsSuite) TestRestrictedProviderFields(c *gc.C) {
 		expected: []string{"type"},
 	}, {
 		provider: "maas",
-		expected: []string{
-			"type",
-			"maas-server",
-		},
+		expected: []string{"type"},
 	}, {
 		provider: "openstack",
 		expected: []string{

--- a/provider/maas/config.go
+++ b/provider/maas/config.go
@@ -4,32 +4,13 @@
 package maas
 
 import (
-	"fmt"
-	"net/url"
-	"strings"
-
-	"github.com/juju/errors"
 	"github.com/juju/schema"
 	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/environs/config"
 )
 
-var configSchema = environschema.Fields{
-	"maas-server": {
-		Description: "maas-server specifies the location of the MAAS server. It must specify the base path.",
-		Type:        environschema.Tstring,
-		Example:     "http://192.168.1.1/MAAS/",
-	},
-	"maas-oauth": {
-		Description: "maas-oauth holds the OAuth credentials from MAAS.",
-		Type:        environschema.Tstring,
-	},
-	"maas-agent-name": {
-		Description: "maas-agent-name is an optional UUID to group the instances acquired from MAAS, to support multiple models per MAAS user.",
-		Type:        environschema.Tstring,
-	},
-}
+var configSchema = environschema.Fields{}
 
 var configFields = func() schema.Fields {
 	fs, _, err := configSchema.ValidationSchema()
@@ -39,34 +20,11 @@ var configFields = func() schema.Fields {
 	return fs
 }()
 
-var configDefaults = schema.Defaults{
-	// For backward-compatibility, maas-agent-name is the empty string
-	// by default. However, new environments should all use a UUID.
-	"maas-agent-name": "",
-}
+var configDefaults = schema.Defaults{}
 
 type maasModelConfig struct {
 	*config.Config
 	attrs map[string]interface{}
-}
-
-func (cfg *maasModelConfig) updateMaasServer(newServer string) {
-	cfg.attrs["maas-server"] = newServer
-}
-
-func (cfg *maasModelConfig) maasServer() string {
-	return cfg.attrs["maas-server"].(string)
-}
-
-func (cfg *maasModelConfig) maasOAuth() string {
-	return cfg.attrs["maas-oauth"].(string)
-}
-
-func (cfg *maasModelConfig) maasAgentName() string {
-	if uuid, ok := cfg.attrs["maas-agent-name"].(string); ok {
-		return uuid
-	}
-	return ""
 }
 
 func (prov maasEnvironProvider) newConfig(cfg *config.Config) (*maasModelConfig, error) {
@@ -89,78 +47,19 @@ func (maasEnvironProvider) Schema() environschema.Fields {
 	return fields
 }
 
-var errMalformedMaasOAuth = errors.New("malformed maas-oauth (3 items separated by colons)")
-
 func (prov maasEnvironProvider) Validate(cfg, oldCfg *config.Config) (*config.Config, error) {
 	// Validate base configuration change before validating MAAS specifics.
 	err := config.Validate(cfg, oldCfg)
 	if err != nil {
 		return nil, err
 	}
-
 	validated, err := cfg.ValidateUnknownAttrs(configFields, configDefaults)
 	if err != nil {
 		return nil, err
 	}
-
-	// Add MAAS specific defaults.
-	providerDefaults := make(map[string]interface{})
-
-	// Storage.
-	if _, ok := cfg.StorageDefaultBlockSource(); !ok {
-		providerDefaults[config.StorageDefaultBlockSourceKey] = maasStorageProviderType
+	envCfg := &maasModelConfig{
+		Config: cfg,
+		attrs:  validated,
 	}
-
-	if len(providerDefaults) > 0 {
-		if cfg, err = cfg.Apply(providerDefaults); err != nil {
-			return nil, err
-		}
-	}
-
-	if oldCfg != nil {
-		oldAttrs := oldCfg.UnknownAttrs()
-		validMaasAgentName := false
-		if oldName, ok := oldAttrs["maas-agent-name"]; !ok || oldName == nil {
-			// If maas-agent-name was nil (because the config was
-			// generated pre-1.16.2 the only correct value for it is ""
-			// See bug #1256179
-			validMaasAgentName = (validated["maas-agent-name"] == "")
-		} else {
-			validMaasAgentName = (validated["maas-agent-name"] == oldName)
-		}
-		if !validMaasAgentName {
-			return nil, fmt.Errorf("cannot change maas-agent-name")
-		}
-	}
-	envCfg := new(maasModelConfig)
-	envCfg.Config = cfg
-	envCfg.attrs = validated
-	err = validateServerURL(envCfg)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	oauth := envCfg.maasOAuth()
-	if strings.Count(oauth, ":") != 2 {
-		return nil, errMalformedMaasOAuth
-	}
-
 	return cfg.Apply(envCfg.attrs)
-}
-
-func validateServerURL(envCfg *maasModelConfig) error {
-	server := envCfg.maasServer()
-	serverURL, firstErr := url.Parse(server)
-	if firstErr != nil || serverURL.Scheme == "" || serverURL.Host == "" {
-		serverURL, err := url.Parse("http://" + server)
-		if err != nil || serverURL.Scheme == "" || serverURL.Host == "" {
-			msg := fmt.Sprintf("malformed maas-server URL '%v'", server)
-			if firstErr != nil {
-				return errors.Annotate(firstErr, msg)
-			}
-
-			return errors.Errorf(msg)
-		}
-		envCfg.updateMaasServer("http://" + server)
-	}
-	return nil
 }

--- a/provider/maas/config_test.go
+++ b/provider/maas/config_test.go
@@ -6,7 +6,6 @@ package maas
 import (
 	"github.com/juju/gomaasapi"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
@@ -54,101 +53,11 @@ func (s *configSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&GetMAAS2Controller, mockGetController)
 }
 
-func (*configSuite) TestParsesMAASSettings(c *gc.C) {
-	server := "http://maas.testing.invalid/maas/"
-	oauth := "consumer-key:resource-token:resource-secret"
-	future := "futurama"
-
-	uuid, err := utils.NewUUID()
-	c.Assert(err, jc.ErrorIsNil)
-	ecfg, err := newConfig(map[string]interface{}{
-		"maas-server":     server,
-		"maas-oauth":      oauth,
-		"maas-agent-name": uuid.String(),
-		"future-key":      future,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(ecfg.maasServer(), gc.Equals, server)
-	c.Check(ecfg.maasOAuth(), gc.DeepEquals, oauth)
-	c.Check(ecfg.maasAgentName(), gc.Equals, uuid.String())
-	c.Check(ecfg.UnknownAttrs()["future-key"], gc.DeepEquals, future)
-}
-
-func (*configSuite) TestValidateUpdatesServer(c *gc.C) {
-	server := "maas.testing.invalid/maas/"
-	attrs := map[string]interface{}{
-		"maas-server": server,
-		"maas-oauth":  "consumer-key:resource-token:resource-secret",
-	}
-	oldCfg, err := newConfig(attrs)
-	c.Assert(err, jc.ErrorIsNil)
-	newCfg, err := oldCfg.Apply(nil)
-	c.Assert(err, jc.ErrorIsNil)
-
-	result, err := maasEnvironProvider{}.Validate(newCfg, oldCfg.Config)
-	c.Assert(err, jc.ErrorIsNil)
-	newAttrs := result.AllAttrs()
-	c.Assert(newAttrs["maas-server"].(string), gc.Equals, "http://"+server)
-}
-
-func (*configSuite) TestInvalidServerURL(c *gc.C) {
-	// Note that as we add http:// as a prefix to invalid urls, the only
-	// thing we can now detect as invalid is an empty string.
-	server := ""
-	attrs := map[string]interface{}{
-		"maas-server": server,
-		"maas-oauth":  "consumer-key:resource-token:resource-secret",
-	}
-	_, err := newConfig(attrs)
-	c.Assert(err, gc.ErrorMatches, "malformed maas-server URL ''")
-}
-
-func (*configSuite) TestMaasAgentNameDefault(c *gc.C) {
-	ecfg, err := newConfig(map[string]interface{}{
-		"maas-server": "http://maas.testing.invalid/maas/",
-		"maas-oauth":  "consumer-key:resource-token:resource-secret",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(ecfg.maasAgentName(), gc.Equals, "")
-}
-
-func (*configSuite) TestChecksWellFormedMaasServer(c *gc.C) {
-	_, err := newConfig(map[string]interface{}{
-		"maas-server": "This should have been a URL.",
-		"maas-oauth":  "consumer-key:resource-token:resource-secret",
-	})
-	c.Assert(err, gc.NotNil)
-	c.Check(err, gc.ErrorMatches, ".*malformed maas-server.*")
-}
-
-func (*configSuite) TestChecksWellFormedMaasOAuth(c *gc.C) {
-	_, err := newConfig(map[string]interface{}{
-		"maas-server": "http://maas.testing.invalid/maas/",
-		"maas-oauth":  "This should have been a 3-part token.",
-	})
-	c.Assert(err, gc.NotNil)
-	c.Check(err, gc.ErrorMatches, ".*malformed maas-oauth.*")
-}
-
-func (*configSuite) TestBlockStorageProviderDefault(c *gc.C) {
-	ecfg, err := newConfig(map[string]interface{}{
-		"maas-server": "http://maas.testing.invalid/maas/",
-		"maas-oauth":  "consumer-key:resource-token:resource-secret",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	src, _ := ecfg.StorageDefaultBlockSource()
-	c.Assert(src, gc.Equals, "maas")
-}
-
 func (*configSuite) TestValidateUpcallsEnvironsConfigValidate(c *gc.C) {
 	// The base Validate() function will not allow an environment to
 	// change its name.  Trigger that error so as to prove that the
 	// environment provider's Validate() calls the base Validate().
-	baseAttrs := map[string]interface{}{
-		"maas-server": "http://maas.testing.invalid/maas/",
-		"maas-oauth":  "consumer-key:resource-token:resource-secret",
-	}
-	oldCfg, err := newConfig(baseAttrs)
+	oldCfg, err := newConfig(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	newName := oldCfg.Name() + "-but-different"
 	newCfg, err := oldCfg.Apply(map[string]interface{}{"name": newName})
@@ -158,22 +67,6 @@ func (*configSuite) TestValidateUpcallsEnvironsConfigValidate(c *gc.C) {
 
 	c.Assert(err, gc.NotNil)
 	c.Check(err, gc.ErrorMatches, ".*cannot change name.*")
-}
-
-func (*configSuite) TestValidateCannotChangeAgentName(c *gc.C) {
-	baseAttrs := map[string]interface{}{
-		"maas-server":     "http://maas.testing.invalid/maas/",
-		"maas-oauth":      "consumer-key:resource-token:resource-secret",
-		"maas-agent-name": "1234-5678",
-	}
-	oldCfg, err := newConfig(baseAttrs)
-	c.Assert(err, jc.ErrorIsNil)
-	newCfg, err := oldCfg.Apply(map[string]interface{}{
-		"maas-agent-name": "9876-5432",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = maasEnvironProvider{}.Validate(newCfg, oldCfg.Config)
-	c.Assert(err, gc.ErrorMatches, "cannot change maas-agent-name")
 }
 
 func (*configSuite) TestSchema(c *gc.C) {

--- a/provider/maas/constraints_test.go
+++ b/provider/maas/constraints_test.go
@@ -350,7 +350,7 @@ func (suite *environSuite) TestAcquireNodePassedAgentName(c *gc.C) {
 	requestValues := suite.testMAASObject.TestServer.NodeOperationRequestValues()
 	nodeRequestValues, found := requestValues["node0"]
 	c.Assert(found, jc.IsTrue)
-	c.Assert(nodeRequestValues[0].Get("agent_name"), gc.Equals, exampleAgentName)
+	c.Assert(nodeRequestValues[0].Get("agent_name"), gc.Equals, env.Config().UUID())
 }
 
 func (suite *environSuite) TestAcquireNodePassesPositiveAndNegativeTags(c *gc.C) {

--- a/provider/maas/credentials.go
+++ b/provider/maas/credentials.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils"
@@ -15,19 +16,21 @@ import (
 	"github.com/juju/juju/cloud"
 )
 
+const (
+	credAttrMAASOAuth = "maas-oauth"
+)
+
 type environProviderCredentials struct{}
 
 // CredentialSchemas is part of the environs.ProviderCredentials interface.
 func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
 	return map[cloud.AuthType]cloud.CredentialSchema{
-		cloud.OAuth1AuthType: {
-			{
-				"maas-oauth", cloud.CredentialAttr{
-					Description: "OAuth/API-key credentials for MAAS",
-					Hidden:      true,
-				},
+		cloud.OAuth1AuthType: {{
+			credAttrMAASOAuth, cloud.CredentialAttr{
+				Description: "OAuth/API-key credentials for MAAS",
+				Hidden:      true,
 			},
-		},
+		}},
 	}
 }
 
@@ -51,7 +54,7 @@ func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, e
 		return nil, errors.New("MAAS credentials require a value for OAuth token")
 	}
 	cred := cloud.NewCredential(cloud.OAuth1AuthType, map[string]string{
-		"maas-oauth": fmt.Sprintf("%v", oauthKey),
+		credAttrMAASOAuth: fmt.Sprintf("%v", oauthKey),
 	})
 	server, ok := details["Server"]
 	if server == "" || !ok {
@@ -62,5 +65,16 @@ func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, e
 	return &cloud.CloudCredential{
 		AuthCredentials: map[string]cloud.Credential{
 			"default": cred,
-		}}, nil
+		},
+	}, nil
 }
+
+func parseOAuthToken(cred cloud.Credential) (string, error) {
+	oauth := cred.Attributes()[credAttrMAASOAuth]
+	if strings.Count(oauth, ":") != 2 {
+		return "", errMalformedMaasOAuth
+	}
+	return oauth, nil
+}
+
+var errMalformedMaasOAuth = errors.New("malformed maas-oauth (3 items separated by colons)")

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1062,16 +1062,16 @@ func (s *environSuite) TestStartInstanceDistributionFailover(c *gc.C) {
 	})
 	c.Assert(s.testMAASObject.TestServer.NodesOperationRequestValues(), gc.DeepEquals, []url.Values{{
 		"name":       []string{"bootstrap-host"},
-		"agent_name": []string{exampleAgentName},
+		"agent_name": []string{env.Config().UUID()},
 	}, {
 		"zone":       []string{"zone1"},
-		"agent_name": []string{exampleAgentName},
+		"agent_name": []string{env.Config().UUID()},
 	}, {
 		"zone":       []string{"zonelord"},
-		"agent_name": []string{exampleAgentName},
+		"agent_name": []string{env.Config().UUID()},
 	}, {
 		"zone":       []string{"zone2"},
-		"agent_name": []string{exampleAgentName},
+		"agent_name": []string{env.Config().UUID()},
 	}})
 }
 

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -30,7 +30,10 @@ var providerInstance maasEnvironProvider
 
 func (maasEnvironProvider) Open(args environs.OpenParams) (environs.Environ, error) {
 	logger.Debugf("opening model %q.", args.Config.Name())
-	env, err := NewEnviron(args.Config)
+	if err := validateCloudSpec(args.Cloud); err != nil {
+		return nil, errors.Annotate(err, "validating cloud spec")
+	}
+	env, err := NewEnviron(args.Cloud, args.Config)
 	if err != nil {
 		return nil, err
 	}
@@ -42,41 +45,23 @@ var errAgentNameAlreadySet = errors.New(
 
 // RestrictedConfigAttributes is specified in the EnvironProvider interface.
 func (p maasEnvironProvider) RestrictedConfigAttributes() []string {
-	return []string{"maas-server"}
+	return []string{}
 }
 
 // PrepareConfig is specified in the EnvironProvider interface.
 func (p maasEnvironProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
-	// For MAAS, the cloud endpoint may be either a full URL
-	// for the MAAS server, or just the IP/host.
-	if args.Cloud.Endpoint == "" {
-		return nil, errors.New("MAAS server not specified")
+	if err := validateCloudSpec(args.Cloud); err != nil {
+		return nil, errors.Annotate(err, "validating cloud spec")
 	}
-	server := args.Cloud.Endpoint
-	if url, err := url.Parse(server); err != nil || url.Scheme == "" {
-		server = fmt.Sprintf("http://%s/MAAS", args.Cloud.Endpoint)
-	}
-
-	attrs := map[string]interface{}{
-		"maas-server": server,
-	}
-	// Add the credentials.
-	switch authType := args.Cloud.Credential.AuthType(); authType {
-	case cloud.OAuth1AuthType:
-		credentialAttrs := args.Cloud.Credential.Attributes()
-		for k, v := range credentialAttrs {
-			attrs[k] = v
+	var attrs map[string]interface{}
+	if _, ok := args.Config.StorageDefaultBlockSource(); !ok {
+		attrs = map[string]interface{}{
+			config.StorageDefaultBlockSourceKey: maasStorageProviderType,
 		}
-	default:
-		return nil, errors.NotSupportedf("%q auth-type", authType)
 	}
-
-	// Set maas-agent-name; make sure it's not set by the user.
-	if _, ok := args.Config.UnknownAttrs()["maas-agent-name"]; ok {
-		return nil, errAgentNameAlreadySet
+	if len(attrs) == 0 {
+		return args.Config, nil
 	}
-	attrs["maas-agent-name"] = args.Config.UUID()
-
 	return args.Config.Apply(attrs)
 }
 
@@ -98,16 +83,45 @@ Please ensure the credentials are correct.`)
 
 // SecretAttrs is specified in the EnvironProvider interface.
 func (prov maasEnvironProvider) SecretAttrs(cfg *config.Config) (map[string]string, error) {
-	secretAttrs := make(map[string]string)
-	maasCfg, err := prov.newConfig(cfg)
-	if err != nil {
-		return nil, err
-	}
-	secretAttrs["maas-oauth"] = maasCfg.maasOAuth()
-	return secretAttrs, nil
+	return map[string]string{}, nil
 }
 
 // DetectRegions is specified in the environs.CloudRegionDetector interface.
 func (p maasEnvironProvider) DetectRegions() ([]cloud.Region, error) {
 	return nil, errors.NotFoundf("regions")
+}
+
+func validateCloudSpec(spec environs.CloudSpec) error {
+	if err := spec.Validate(); err != nil {
+		return errors.Trace(err)
+	}
+	if _, err := parseCloudEndpoint(spec.Endpoint); err != nil {
+		return errors.Annotate(err, "validating endpoint")
+	}
+	if spec.Credential == nil {
+		return errors.NotValidf("missing credential")
+	}
+	if authType := spec.Credential.AuthType(); authType != cloud.OAuth1AuthType {
+		return errors.NotSupportedf("%q auth-type", authType)
+	}
+	if _, err := parseOAuthToken(*spec.Credential); err != nil {
+		return errors.Annotate(err, "validating MAAS OAuth token")
+	}
+	return nil
+}
+
+func parseCloudEndpoint(endpoint string) (server string, _ error) {
+	// For MAAS, the cloud endpoint may be either a full URL
+	// for the MAAS server, or just the IP/host.
+	if endpoint == "" {
+		return "", errors.New("MAAS server not specified")
+	}
+	server = endpoint
+	if url, err := url.Parse(server); err != nil || url.Scheme == "" {
+		server = fmt.Sprintf("http://%s/MAAS", endpoint)
+		if _, err := url.Parse(server); err != nil {
+			return "", errors.NotValidf("endpoint %q", endpoint)
+		}
+	}
+	return server, nil
 }

--- a/provider/maas/environprovider_test.go
+++ b/provider/maas/environprovider_test.go
@@ -5,9 +5,13 @@ package maas
 
 import (
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"strings"
 
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
@@ -23,131 +27,117 @@ type EnvironProviderSuite struct {
 var _ = gc.Suite(&EnvironProviderSuite{})
 
 func (s *EnvironProviderSuite) cloudSpec() environs.CloudSpec {
-	credential := cloud.NewCredential(
-		cloud.OAuth1AuthType,
-		map[string]string{
-			"maas-oauth": "aa:bb:cc",
-		},
-	)
+	credential := oauthCredential("aa:bb:cc")
 	return environs.CloudSpec{
 		Type:       "maas",
+		Name:       "maas",
 		Endpoint:   "http://maas.testing.invalid/maas/",
 		Credential: &credential,
 	}
 }
 
-func (suite *EnvironProviderSuite) TestSecretAttrsReturnsSensitiveMAASAttributes(c *gc.C) {
-	const oauth = "aa:bb:cc"
-	attrs := testing.FakeConfig().Merge(testing.Attrs{
-		"type":        "maas",
-		"maas-oauth":  oauth,
-		"maas-server": "http://maas.testing.invalid/maas/",
-	})
-	config, err := config.New(config.NoDefaults, attrs)
-	c.Assert(err, jc.ErrorIsNil)
-
-	secretAttrs, err := providerInstance.SecretAttrs(config)
-	c.Assert(err, jc.ErrorIsNil)
-
-	expectedAttrs := map[string]string{"maas-oauth": oauth}
-	c.Check(secretAttrs, gc.DeepEquals, expectedAttrs)
+func oauthCredential(token string) cloud.Credential {
+	return cloud.NewCredential(
+		cloud.OAuth1AuthType,
+		map[string]string{
+			"maas-oauth": token,
+		},
+	)
 }
 
-func (suite *EnvironProviderSuite) TestCredentialsSetup(c *gc.C) {
-	attrs := testing.FakeConfig().Merge(testing.Attrs{
-		"type": "maas",
-	})
+func (suite *EnvironProviderSuite) TestPrepareConfig(c *gc.C) {
+	attrs := testing.FakeConfig().Merge(testing.Attrs{"type": "maas"})
 	config, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
+	_, err = providerInstance.PrepareConfig(environs.PrepareConfigParams{
+		Config: config,
+		Cloud:  suite.cloudSpec(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
 
+func (suite *EnvironProviderSuite) TestPrepareConfigInvalidOAuth(c *gc.C) {
+	attrs := testing.FakeConfig().Merge(testing.Attrs{"type": "maas"})
+	config, err := config.New(config.NoDefaults, attrs)
+	c.Assert(err, jc.ErrorIsNil)
+	spec := suite.cloudSpec()
+	cred := oauthCredential("wrongly-formatted-oauth-string")
+	spec.Credential = &cred
+	_, err = providerInstance.PrepareConfig(environs.PrepareConfigParams{
+		Config: config,
+		Cloud:  spec,
+	})
+	c.Assert(err, gc.ErrorMatches, ".*malformed maas-oauth.*")
+}
+
+func (suite *EnvironProviderSuite) TestPrepareConfigInvalidEndpoint(c *gc.C) {
+	attrs := testing.FakeConfig().Merge(testing.Attrs{"type": "maas"})
+	config, err := config.New(config.NoDefaults, attrs)
+	c.Assert(err, jc.ErrorIsNil)
+	spec := suite.cloudSpec()
+	spec.Endpoint = "This should have been a URL or host."
+	_, err = providerInstance.PrepareConfig(environs.PrepareConfigParams{
+		Config: config,
+		Cloud:  spec,
+	})
+	c.Assert(err, gc.ErrorMatches,
+		`validating cloud spec: validating endpoint: endpoint "This should have been a URL or host." not valid`,
+	)
+}
+
+func (suite *EnvironProviderSuite) TestPrepareConfigSetsDefaults(c *gc.C) {
+	attrs := testing.FakeConfig().Merge(testing.Attrs{"type": "maas"})
+	config, err := config.New(config.NoDefaults, attrs)
+	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := providerInstance.PrepareConfig(environs.PrepareConfigParams{
 		Config: config,
 		Cloud:  suite.cloudSpec(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-
-	attrs = cfg.UnknownAttrs()
-	server, ok := attrs["maas-server"]
-	c.Assert(ok, jc.IsTrue)
-	c.Assert(server, gc.Equals, "http://maas.testing.invalid/maas/")
-	oauth, ok := attrs["maas-oauth"]
-	c.Assert(ok, jc.IsTrue)
-	c.Assert(oauth, gc.Equals, "aa:bb:cc")
+	src, _ := cfg.StorageDefaultBlockSource()
+	c.Assert(src, gc.Equals, "maas")
 }
 
-func (suite *EnvironProviderSuite) TestUnknownAttrsContainAgentName(c *gc.C) {
-	attrs := testing.FakeConfig().Merge(testing.Attrs{
-		"type": "maas",
-	})
-	config, err := config.New(config.NoDefaults, attrs)
-	c.Assert(err, jc.ErrorIsNil)
-
-	cfg, err := providerInstance.PrepareConfig(environs.PrepareConfigParams{
-		Config: config,
-		Cloud:  suite.cloudSpec(),
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	unknownAttrs := cfg.UnknownAttrs()
-	c.Assert(unknownAttrs["maas-server"], gc.Equals, "http://maas.testing.invalid/maas/")
-
-	uuid, ok := unknownAttrs["maas-agent-name"]
-
-	c.Assert(ok, jc.IsTrue)
-	c.Assert(uuid, jc.Satisfies, utils.IsValidUUIDString)
+func (suite *EnvironProviderSuite) TestMAASServerFromEndpointURL(c *gc.C) {
+	suite.testMAASServerFromEndpoint(c, suite.testMAASObject.TestServer.URL)
 }
 
-func (suite *EnvironProviderSuite) TestMAASServerFromEndpoint(c *gc.C) {
-	attrs := testing.FakeConfig().Merge(testing.Attrs{
-		"type": "maas",
-	})
+func (suite *EnvironProviderSuite) TestMAASServerFromEndpointHost(c *gc.C) {
+	targetURL, err := url.Parse(suite.testMAASObject.TestServer.URL)
+	c.Assert(err, jc.ErrorIsNil)
+
+	rp := httputil.NewSingleHostReverseProxy(targetURL)
+	rp.Director = func(req *http.Request) {
+		req.URL.Path = strings.TrimPrefix(req.URL.Path, "/MAAS")
+		req.URL.Scheme = targetURL.Scheme
+		req.URL.Host = targetURL.Host
+	}
+	proxy := httptest.NewServer(rp)
+	defer proxy.Close()
+
+	// The proxy's host:port will be formatted into a URL, with a
+	// fixed root path of "/MAAS".
+	proxyURL, err := url.Parse(proxy.URL)
+	c.Assert(err, jc.ErrorIsNil)
+	suite.testMAASServerFromEndpoint(c, proxyURL.Host)
+}
+
+func (suite *EnvironProviderSuite) testMAASServerFromEndpoint(c *gc.C, endpoint string) {
+	attrs := testing.FakeConfig().Merge(testing.Attrs{"type": "maas"})
 	config, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cloudSpec := suite.cloudSpec()
-	cloudSpec.Endpoint = "maas.testing"
-
-	cfg, err := providerInstance.PrepareConfig(environs.PrepareConfigParams{
+	cloudSpec.Endpoint = endpoint
+	env, err := providerInstance.Open(environs.OpenParams{
 		Config: config,
 		Cloud:  cloudSpec,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	unknownAttrs := cfg.UnknownAttrs()
-	c.Assert(unknownAttrs["maas-server"], gc.Equals, "http://maas.testing/MAAS")
-}
-
-func (suite *EnvironProviderSuite) TestPrepareSetsAgentName(c *gc.C) {
-	attrs := testing.FakeConfig().Merge(testing.Attrs{
-		"type": "maas",
-	})
-	config, err := config.New(config.NoDefaults, attrs)
+	suite.addNode(`{"system_id":"test-allocated"}`)
+	_, err = env.AllInstances()
 	c.Assert(err, jc.ErrorIsNil)
-
-	cfg, err := providerInstance.PrepareConfig(environs.PrepareConfigParams{
-		Config: config,
-		Cloud:  suite.cloudSpec(),
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	uuid, ok := cfg.UnknownAttrs()["maas-agent-name"]
-	c.Assert(ok, jc.IsTrue)
-	c.Assert(uuid, jc.Satisfies, utils.IsValidUUIDString)
-}
-
-func (suite *EnvironProviderSuite) TestAgentNameShouldNotBeSetByHand(c *gc.C) {
-	attrs := testing.FakeConfig().Merge(testing.Attrs{
-		"type":            "maas",
-		"maas-agent-name": "foobar",
-	})
-	config, err := config.New(config.NoDefaults, attrs)
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, err = providerInstance.PrepareConfig(environs.PrepareConfigParams{
-		Config: config,
-		Cloud:  suite.cloudSpec(),
-	})
-	c.Assert(err, gc.Equals, errAgentNameAlreadySet)
 }
 
 // create a temporary file with the given content.  The file will be cleaned
@@ -162,16 +152,14 @@ func createTempFile(c *gc.C, content []byte) string {
 }
 
 func (suite *EnvironProviderSuite) TestOpenReturnsNilInterfaceUponFailure(c *gc.C) {
-	const oauth = "wrongly-formatted-oauth-string"
-	attrs := testing.FakeConfig().Merge(testing.Attrs{
-		"type":        "maas",
-		"maas-oauth":  oauth,
-		"maas-server": "http://maas.testing.invalid/maas/",
-	})
+	attrs := testing.FakeConfig().Merge(testing.Attrs{"type": "maas"})
 	config, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
+	spec := suite.cloudSpec()
+	cred := oauthCredential("wrongly-formatted-oauth-string")
+	spec.Credential = &cred
 	env, err := providerInstance.Open(environs.OpenParams{
-		Cloud:  suite.cloudSpec(),
+		Cloud:  spec,
 		Config: config,
 	})
 	// When Open() fails (i.e. returns a non-nil error), it returns an

--- a/provider/maas/export_test.go
+++ b/provider/maas/export_test.go
@@ -14,10 +14,6 @@ var (
 	ShortAttempt = &shortAttempt
 )
 
-func MAASAgentName(env environs.Environ) string {
-	return env.(*maasEnviron).ecfg().maasAgentName()
-}
-
 func GetMAASClient(env environs.Environ) *gomaasapi.MAASObject {
 	return env.(*maasEnviron).getMAASClient()
 }

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
@@ -35,15 +37,23 @@ func (suite *maas2Suite) makeEnviron(c *gc.C, controller gomaasapi.Controller) *
 	for k, v := range maasEnvAttrs {
 		testAttrs[k] = v
 	}
-	testAttrs["maas-server"] = "http://any-old-junk.invalid/"
 	testAttrs["agent-version"] = version.Current.String()
-	testAttrs["maas-agent-name"] = "agent-prefix"
+
+	cred := cloud.NewCredential(cloud.OAuth1AuthType, map[string]string{
+		"maas-oauth": "a:b:c",
+	})
+	cloud := environs.CloudSpec{
+		Type:       "maas",
+		Name:       "maas",
+		Endpoint:   "http://any-old-junk.invalid/",
+		Credential: &cred,
+	}
 
 	attrs := coretesting.FakeConfig().Merge(testAttrs)
 	suite.controllerUUID = coretesting.FakeControllerConfig().ControllerUUID()
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := NewEnviron(cfg)
+	env, err := NewEnviron(cloud, cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env, gc.NotNil)
 	return env

--- a/provider/maas/maas2storage_test.go
+++ b/provider/maas/maas2storage_test.go
@@ -29,10 +29,10 @@ func checkCalls(c *gc.C, stub *testing.Stub, calls ...testing.StubCall) {
 }
 
 func (s *maas2StorageSuite) makeStorage(c *gc.C, controller gomaasapi.Controller) *maas2Storage {
-	storage, ok := NewStorage(s.makeEnviron(c, controller)).(*maas2Storage)
+	env := s.makeEnviron(c, controller)
+	env.uuid = "prefix"
+	storage, ok := NewStorage(env).(*maas2Storage)
 	c.Assert(ok, jc.IsTrue)
-	ecfg := storage.environ.ecfg()
-	ecfg.attrs["maas-agent-name"] = "prefix"
 	return storage
 }
 

--- a/provider/maas/storage.go
+++ b/provider/maas/storage.go
@@ -55,11 +55,7 @@ func (stor *maas1Storage) addressFileObject(name string) gomaasapi.MAASObject {
 // This prevents different environments from interfering with each other.
 // We're using the agent name UUID here.
 func prefixWithPrivateNamespace(env *maasEnviron, name string) string {
-	prefix := env.ecfg().maasAgentName()
-	if prefix != "" {
-		return prefix + "-" + name
-	}
-	return name
+	return env.uuid + "-" + name
 }
 
 func (stor *maas1Storage) prefixWithPrivateNamespace(name string) string {

--- a/provider/maas/storage_test.go
+++ b/provider/maas/storage_test.go
@@ -388,22 +388,11 @@ func (s *storageSuite) TestRemoveAllDeletesAllFiles(c *gc.C) {
 }
 
 func (s *storageSuite) TestprefixWithPrivateNamespacePrefixesWithAgentName(c *gc.C) {
-	sstor := NewStorage(s.makeEnviron())
+	env := s.makeEnviron()
+	sstor := NewStorage(env)
 	stor := sstor.(*maas1Storage)
-	agentName := stor.environ.ecfg().maasAgentName()
-	c.Assert(agentName, gc.Not(gc.Equals), "")
-	expectedPrefix := agentName + "-"
+	expectedPrefix := env.Config().UUID() + "-"
 	const name = "myname"
 	expectedResult := expectedPrefix + name
 	c.Assert(stor.prefixWithPrivateNamespace(name), gc.Equals, expectedResult)
-}
-
-func (s *storageSuite) TesttprefixWithPrivateNamespaceIgnoresAgentName(c *gc.C) {
-	sstor := NewStorage(s.makeEnviron())
-	stor := sstor.(*maas1Storage)
-	ecfg := stor.environ.ecfg()
-	ecfg.attrs["maas-agent-name"] = ""
-
-	const name = "myname"
-	c.Assert(stor.prefixWithPrivateNamespace(name), gc.Equals, name)
 }


### PR DESCRIPTION
Drop maas-server, maas-oauth, and maas-agent-name
from maas model config. Instead, maas-server and
maas-oauth are pulled from the cloud spec. We no
longer need to cater for old deployments of Juju
on MAAS, so we can get rid of maas-agent-name and
use the model UUID directly.

(Review request: http://reviews.vapour.ws/r/5391/)