### PR TITLE
provider/{openstack,vsphere}: remove cloud/creds from config

### DIFF
--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -219,10 +219,7 @@ func (*RestrictedProviderFieldsSuite) TestRestrictedProviderFields(c *gc.C) {
 		expected: []string{"type"},
 	}, {
 		provider: "openstack",
-		expected: []string{
-			"type",
-			"region", "auth-url", "auth-mode",
-		},
+		expected: []string{"type"},
 	}, {
 		provider: "ec2",
 		expected: []string{

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -62,10 +62,9 @@ var newOpenstackStorage = func(env *Environ) (OpenstackStorage, error) {
 	env.ecfgMutex.Lock()
 	authClient := env.client
 	envNovaClient := env.novaUnlocked
-	region := env.ecfgUnlocked.region()
 	env.ecfgMutex.Unlock()
 
-	endpointUrl, err := getVolumeEndpointURL(authClient, region)
+	endpointUrl, err := getVolumeEndpointURL(authClient, env.cloud.Region)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, errors.NewNotSupported(err, "volumes not supported")

--- a/provider/openstack/config.go
+++ b/provider/openstack/config.go
@@ -5,68 +5,14 @@ package openstack
 
 import (
 	"fmt"
-	"net/url"
 
-	"github.com/juju/errors"
 	"github.com/juju/schema"
-	"gopkg.in/goose.v1/identity"
 	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/environs/config"
 )
 
 var configSchema = environschema.Fields{
-	"username": {
-		Description: "The user name  to use when auth-mode is userpass.",
-		Type:        environschema.Tstring,
-		EnvVars:     identity.CredEnvUser,
-		Group:       environschema.AccountGroup,
-	},
-	"password": {
-		Description: "The password to use when auth-mode is userpass.",
-		Type:        environschema.Tstring,
-		EnvVars:     identity.CredEnvSecrets,
-		Group:       environschema.AccountGroup,
-		Secret:      true,
-	},
-	"tenant-name": {
-		Description: "The openstack tenant name.",
-		Type:        environschema.Tstring,
-		EnvVars:     identity.CredEnvTenantName,
-		Group:       environschema.AccountGroup,
-	},
-	"auth-url": {
-		Description: "The keystone URL for authentication.",
-		Type:        environschema.Tstring,
-		EnvVars:     identity.CredEnvAuthURL,
-		Example:     "https://yourkeystoneurl:443/v2.0/",
-		Group:       environschema.AccountGroup,
-	},
-	"auth-mode": {
-		Description: "The authentication mode to use. When set to keypair, the access-key and secret-key parameters should be set; when set to userpass or legacy, the username and password parameters should be set.",
-		Type:        environschema.Tstring,
-		Values:      []interface{}{AuthKeyPair, AuthLegacy, AuthUserPass},
-		Group:       environschema.AccountGroup,
-	},
-	"access-key": {
-		Description: "The access key to use when auth-mode is set to keypair.",
-		Type:        environschema.Tstring,
-		EnvVars:     identity.CredEnvUser,
-		Group:       environschema.AccountGroup,
-		Secret:      true,
-	},
-	"secret-key": {
-		Description: "The secret key to use when auth-mode is set to keypair.",
-		EnvVars:     identity.CredEnvSecrets,
-		Group:       environschema.AccountGroup,
-		Type:        environschema.Tstring,
-		Secret:      true,
-	},
-	"region": {
-		Description: "The openstack region.",
-		Type:        environschema.Tstring,
-		EnvVars:     identity.CredEnvRegion,
-	},
 	"use-floating-ip": {
 		Description: "Whether a floating IP address is required to give the nodes a public IP address. Some installations assign public IP addresses by default without requiring a floating IP address.",
 		Type:        environschema.Tbool,
@@ -92,46 +38,6 @@ var configFields = func() schema.Fields {
 type environConfig struct {
 	*config.Config
 	attrs map[string]interface{}
-}
-
-func (c *environConfig) region() string {
-	return c.attrs["region"].(string)
-}
-
-func (c *environConfig) username() string {
-	return c.attrs["username"].(string)
-}
-
-func (c *environConfig) password() string {
-	return c.attrs["password"].(string)
-}
-
-func (c *environConfig) tenantName() string {
-	return c.attrs["tenant-name"].(string)
-}
-
-func (c *environConfig) domainName() string {
-	dname, ok := c.attrs["domain-name"]
-	if ok {
-		return dname.(string)
-	}
-	return ""
-}
-
-func (c *environConfig) authURL() string {
-	return c.attrs["auth-url"].(string)
-}
-
-func (c *environConfig) authMode() AuthMode {
-	return AuthMode(c.attrs["auth-mode"].(string))
-}
-
-func (c *environConfig) accessKey() string {
-	return c.attrs["access-key"].(string)
-}
-
-func (c *environConfig) secretKey() string {
-	return c.attrs["secret-key"].(string)
 }
 
 func (c *environConfig) useFloatingIP() bool {
@@ -174,47 +80,6 @@ func (p EnvironProvider) Validate(cfg, old *config.Config) (valid *config.Config
 		return nil, err
 	}
 	ecfg := &environConfig{cfg, validated}
-
-	switch ecfg.authMode() {
-	case AuthUserPass, AuthLegacy:
-		if ecfg.username() == "" {
-			return nil, errors.NotValidf("missing username")
-		}
-		if ecfg.password() == "" {
-			return nil, errors.NotValidf("missing password")
-		}
-	case AuthKeyPair:
-		if ecfg.accessKey() == "" {
-			return nil, errors.NotValidf("missing access-key")
-		}
-		if ecfg.secretKey() == "" {
-			return nil, errors.NotValidf("missing secret-key")
-		}
-	default:
-		return nil, fmt.Errorf("unexpected authentication mode %q", ecfg.authMode())
-	}
-
-	if ecfg.authURL() == "" {
-		return nil, errors.NotValidf("missing auth-url")
-	}
-	if ecfg.tenantName() == "" {
-		return nil, errors.NotValidf("missing tenant-name")
-	}
-	if ecfg.region() == "" {
-		return nil, errors.NotValidf("missing region")
-	}
-
-	parts, err := url.Parse(ecfg.authURL())
-	if err != nil || parts.Host == "" || parts.Scheme == "" {
-		return nil, fmt.Errorf("invalid auth-url value %q", ecfg.authURL())
-	}
-
-	if old != nil {
-		attrs := old.UnknownAttrs()
-		if region, _ := attrs["region"].(string); ecfg.region() != region {
-			return nil, fmt.Errorf("cannot change region from %q to %q", region, ecfg.region())
-		}
-	}
 
 	// Check for deprecated fields and log a warning. We also print to stderr to ensure the user sees the message
 	// even if they are not running with --debug.

--- a/provider/openstack/credentials.go
+++ b/provider/openstack/credentials.go
@@ -17,6 +17,15 @@ import (
 	"github.com/juju/juju/cloud"
 )
 
+const (
+	credAttrTenantName = "tenant-name"
+	credAttrUserName   = "username"
+	credAttrPassword   = "password"
+	credAttrDomainName = "domain-name"
+	credAttrAccessKey  = "access-key"
+	credAttrSecretKey  = "secret-key"
+)
+
 type OpenstackCredentials struct{}
 
 // CredentialSchemas is part of the environs.ProviderCredentials interface.
@@ -24,16 +33,16 @@ func (OpenstackCredentials) CredentialSchemas() map[cloud.AuthType]cloud.Credent
 	return map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.UserPassAuthType: {
 			{
-				"username", cloud.CredentialAttr{Description: "The username to authenticate with."},
+				credAttrUserName, cloud.CredentialAttr{Description: "The username to authenticate with."},
 			}, {
-				"password", cloud.CredentialAttr{
+				credAttrPassword, cloud.CredentialAttr{
 					Description: "The password for the specified username.",
 					Hidden:      true,
 				},
 			}, {
-				"tenant-name", cloud.CredentialAttr{Description: "The OpenStack tenant name."},
+				credAttrTenantName, cloud.CredentialAttr{Description: "The OpenStack tenant name."},
 			}, {
-				"domain-name", cloud.CredentialAttr{
+				credAttrDomainName, cloud.CredentialAttr{
 					Description: "The OpenStack domain name.",
 					Optional:    true,
 				},
@@ -41,14 +50,14 @@ func (OpenstackCredentials) CredentialSchemas() map[cloud.AuthType]cloud.Credent
 		},
 		cloud.AccessKeyAuthType: {
 			{
-				"access-key", cloud.CredentialAttr{Description: "The access key to authenticate with."},
+				credAttrAccessKey, cloud.CredentialAttr{Description: "The access key to authenticate with."},
 			}, {
-				"secret-key", cloud.CredentialAttr{
+				credAttrSecretKey, cloud.CredentialAttr{
 					Description: "The secret key to authenticate with.",
 					Hidden:      true,
 				},
 			}, {
-				"tenant-name", cloud.CredentialAttr{Description: "The OpenStack tenant name."},
+				credAttrTenantName, cloud.CredentialAttr{Description: "The OpenStack tenant name."},
 			},
 		},
 	}
@@ -116,19 +125,19 @@ func (c OpenstackCredentials) detectCredential() (*cloud.Credential, string, str
 		credential = cloud.NewCredential(
 			cloud.UserPassAuthType,
 			map[string]string{
-				"username":    creds.User,
-				"password":    creds.Secrets,
-				"tenant-name": creds.TenantName,
-				"domain-name": creds.DomainName,
+				credAttrUserName:   creds.User,
+				credAttrPassword:   creds.Secrets,
+				credAttrTenantName: creds.TenantName,
+				credAttrDomainName: creds.DomainName,
 			},
 		)
 	} else {
 		credential = cloud.NewCredential(
 			cloud.AccessKeyAuthType,
 			map[string]string{
-				"access-key":  creds.User,
-				"secret-key":  creds.Secrets,
-				"tenant-name": creds.TenantName,
+				credAttrAccessKey:  creds.User,
+				credAttrSecretKey:  creds.Secrets,
+				credAttrTenantName: creds.TenantName,
 			},
 		)
 	}

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -35,9 +35,10 @@ var (
 
 // MetadataStorage returns a Storage instance which is used to store simplestreams metadata for tests.
 func MetadataStorage(e environs.Environ) envstorage.Storage {
-	ecfg := e.(*Environ).ecfg()
+	env := e.(*Environ)
+	ecfg := env.ecfg()
 	container := "juju-dist-test"
-	client, err := authClient(ecfg)
+	client, err := authClient(env.cloud, ecfg)
 	if err != nil {
 		panic(fmt.Errorf("cannot create %s container: %v", container, err))
 	}
@@ -423,7 +424,7 @@ func FindInstanceSpec(
 	return findInstanceSpec(env, &instances.InstanceConstraint{
 		Series:      series,
 		Arches:      []string{arch},
-		Region:      env.ecfg().region(),
+		Region:      env.cloud.Region,
 		Constraints: constraints.MustParse(cons),
 	}, imageMetadata)
 }

--- a/provider/openstack/provider_configurator.go
+++ b/provider/openstack/provider_configurator.go
@@ -40,14 +40,6 @@ func (c *defaultConfigurator) GetCloudConfig(args environs.StartInstanceParams) 
 // GetConfigDefaults implements ProviderConfigurator interface.
 func (c *defaultConfigurator) GetConfigDefaults() schema.Defaults {
 	return schema.Defaults{
-		"username":             "",
-		"password":             "",
-		"tenant-name":          "",
-		"auth-url":             "",
-		"auth-mode":            string(AuthUserPass),
-		"access-key":           "",
-		"secret-key":           "",
-		"region":               "",
 		"use-floating-ip":      false,
 		"use-default-secgroup": false,
 		"network":              "",

--- a/provider/rackspace/provider.go
+++ b/provider/rackspace/provider.go
@@ -16,11 +16,22 @@ type environProvider struct {
 
 var providerInstance *environProvider
 
-// PrepareConfig is specified in the EnvironProvider interface.
+// PrepareConfig is part of the EnvironProvider interface.
 func (p *environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
+	args.Cloud = transformCloudSpec(args.Cloud)
+	return p.EnvironProvider.PrepareConfig(args)
+}
+
+// Open is part of the EnvironProvider interface.
+func (p *environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+	args.Cloud = transformCloudSpec(args.Cloud)
+	return p.EnvironProvider.Open(args)
+}
+
+func transformCloudSpec(spec environs.CloudSpec) environs.CloudSpec {
 	// Rackspace regions are expected to be uppercase, but Juju
 	// stores and displays them in lowercase in the CLI. Ensure
 	// they're uppercase when they get to the Rackspace API.
-	args.Cloud.Region = strings.ToUpper(args.Cloud.Region)
-	return p.EnvironProvider.PrepareConfig(args)
+	spec.Region = strings.ToUpper(spec.Region)
+	return spec
 }

--- a/provider/rackspace/provider_configurator.go
+++ b/provider/rackspace/provider_configurator.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/provider/openstack"
 )
 
 type rackspaceConfigurator struct {
@@ -38,14 +37,6 @@ func (c *rackspaceConfigurator) GetCloudConfig(args environs.StartInstanceParams
 // GetConfigDefaults implements ProviderConfigurator interface.
 func (c *rackspaceConfigurator) GetConfigDefaults() schema.Defaults {
 	return schema.Defaults{
-		"username":             "",
-		"password":             "",
-		"tenant-name":          "",
-		"auth-url":             "https://identity.api.rackspacecloud.com/v2.0",
-		"auth-mode":            string(openstack.AuthUserPass),
-		"access-key":           "",
-		"secret-key":           "",
-		"region":               "",
 		"use-floating-ip":      false,
 		"use-default-secgroup": false,
 		"network":              "",

--- a/provider/vsphere/config.go
+++ b/provider/vsphere/config.go
@@ -6,9 +6,6 @@
 package vsphere
 
 import (
-	"fmt"
-	"net/url"
-
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 
@@ -17,41 +14,23 @@ import (
 
 // The vmware-specific config keys.
 const (
-	cfgDatacenter      = "datacenter"
-	cfgHost            = "host"
-	cfgUser            = "user"
-	cfgPassword        = "password"
 	cfgExternalNetwork = "external-network"
 )
 
 // configFields is the spec for each vmware config value's type.
-var configFields = schema.Fields{
-	cfgHost:            schema.String(),
-	cfgUser:            schema.String(),
-	cfgPassword:        schema.String(),
-	cfgDatacenter:      schema.String(),
-	cfgExternalNetwork: schema.String(),
-}
+var (
+	configFields = schema.Fields{
+		cfgExternalNetwork: schema.String(),
+	}
 
-var requiredFields = []string{
-	cfgHost,
-	cfgUser,
-	cfgPassword,
-	cfgDatacenter,
-}
+	requiredFields = []string{}
 
-var configDefaults = schema.Defaults{
-	cfgExternalNetwork: "",
-}
+	configDefaults = schema.Defaults{
+		cfgExternalNetwork: "",
+	}
 
-var configSecretFields = []string{
-	cfgPassword,
-}
-
-var configImmutableFields = []string{
-	cfgHost,
-	cfgDatacenter,
-}
+	configImmutableFields = []string{}
+)
 
 type environConfig struct {
 	*config.Config
@@ -96,37 +75,8 @@ func newValidConfig(cfg *config.Config, defaults map[string]interface{}) (*envir
 	return ecfg, nil
 }
 
-func (c *environConfig) datacenter() string {
-	return c.attrs[cfgDatacenter].(string)
-}
-
-func (c *environConfig) host() string {
-	return c.attrs[cfgHost].(string)
-}
-
-func (c *environConfig) user() string {
-	return c.attrs[cfgUser].(string)
-}
-
-func (c *environConfig) password() string {
-	return c.attrs[cfgPassword].(string)
-}
-
 func (c *environConfig) externalNetwork() string {
 	return c.attrs[cfgExternalNetwork].(string)
-}
-
-func (c *environConfig) url() (*url.URL, error) {
-	return url.Parse(fmt.Sprintf("https://%s:%s@%s/sdk", c.user(), c.password(), c.host()))
-}
-
-// secret gathers the "secret" config values and returns them.
-func (c *environConfig) secret() map[string]string {
-	secretAttrs := make(map[string]string, len(configSecretFields))
-	for _, key := range configSecretFields {
-		secretAttrs[key] = c.attrs[key].(string)
-	}
-	return secretAttrs
 }
 
 // validate checks vmware-specific config values.
@@ -137,10 +87,6 @@ func (c environConfig) validate() error {
 			return errors.Errorf("%s: must not be empty", field)
 		}
 	}
-	if _, err := c.url(); err != nil {
-		return errors.Trace(err)
-	}
-
 	return nil
 }
 

--- a/provider/vsphere/config_test.go
+++ b/provider/vsphere/config_test.go
@@ -86,38 +86,6 @@ func (ts configTestSpec) newConfig(c *gc.C) *config.Config {
 }
 
 var newConfigTests = []configTestSpec{{
-	info:   "datacenter is required",
-	remove: []string{"datacenter"},
-	err:    "datacenter: expected string, got nothing",
-}, {
-	info:   "datacenter cannot be empty",
-	insert: testing.Attrs{"datacenter": ""},
-	err:    "datacenter: must not be empty",
-}, {
-	info:   "host is required",
-	remove: []string{"host"},
-	err:    "host: expected string, got nothing",
-}, {
-	info:   "host cannot be empty",
-	insert: testing.Attrs{"host": ""},
-	err:    "host: must not be empty",
-}, {
-	info:   "user is required",
-	remove: []string{"user"},
-	err:    "user: expected string, got nothing",
-}, {
-	info:   "user cannot be empty",
-	insert: testing.Attrs{"user": ""},
-	err:    "user: must not be empty",
-}, {
-	info:   "password is required",
-	remove: []string{"password"},
-	err:    "password: expected string, got nothing",
-}, {
-	info:   "password cannot be empty",
-	insert: testing.Attrs{"password": ""},
-	err:    "password: must not be empty",
-}, {
 	info:   "unknown field is not touched",
 	insert: testing.Attrs{"unknown-field": "12345"},
 	expect: testing.Attrs{"unknown-field": "12345"},
@@ -193,22 +161,6 @@ func (s *ConfigSuite) TestValidateOldConfig(c *gc.C) {
 var changeConfigTests = []configTestSpec{{
 	info:   "no change, no error",
 	expect: vsphere.ConfigAttrs(),
-}, {
-	info:   "cannot change datacenter",
-	insert: testing.Attrs{"datacenter": "/datacenter2"},
-	err:    "datacenter: cannot change from /datacenter1 to /datacenter2",
-}, {
-	info:   "cannot change host",
-	insert: testing.Attrs{"host": "host2"},
-	err:    "host: cannot change from host1 to host2",
-}, {
-	info:   "cannot change user",
-	insert: testing.Attrs{"user": "user2"},
-	expect: testing.Attrs{"user": "user2"},
-}, {
-	info:   "cannot change password",
-	insert: testing.Attrs{"password": "password2"},
-	expect: testing.Attrs{"password": "password2"},
 }, {
 	info:   "can insert unknown field",
 	insert: testing.Attrs{"unknown": "ignoti"},

--- a/provider/vsphere/credentials.go
+++ b/provider/vsphere/credentials.go
@@ -11,6 +11,11 @@ import (
 	"github.com/juju/juju/cloud"
 )
 
+const (
+	credAttrUser     = "user"
+	credAttrPassword = "password"
+)
+
 type environProviderCredentials struct{}
 
 // CredentialSchemas is part of the environs.ProviderCredentials interface.
@@ -18,9 +23,9 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 	return map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.UserPassAuthType: {
 			{
-				"user", cloud.CredentialAttr{Description: "The username to authenticate with."},
+				credAttrUser, cloud.CredentialAttr{Description: "The username to authenticate with."},
 			}, {
-				"password", cloud.CredentialAttr{
+				credAttrPassword, cloud.CredentialAttr{
 					Description: "The password to authenticate with.",
 					Hidden:      true,
 				},

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -23,6 +23,7 @@ import (
 
 type environ struct {
 	name   string
+	cloud  environs.CloudSpec
 	client *client
 
 	archLock               sync.Mutex // archLock protects access to the following fields.
@@ -35,13 +36,13 @@ type environ struct {
 	ecfg *environConfig
 }
 
-func newEnviron(cfg *config.Config) (*environ, error) {
+func newEnviron(cloud environs.CloudSpec, cfg *config.Config) (*environ, error) {
 	ecfg, err := newValidConfig(cfg, configDefaults)
 	if err != nil {
 		return nil, errors.Annotate(err, "invalid config")
 	}
 
-	client, err := newClient(ecfg)
+	client, err := newClient(cloud)
 	if err != nil {
 		return nil, errors.Annotatef(err, "failed to create new client")
 	}
@@ -53,6 +54,7 @@ func newEnviron(cfg *config.Config) (*environ, error) {
 
 	env := &environ{
 		name:      ecfg.Name(),
+		cloud:     cloud,
 		ecfg:      ecfg,
 		client:    client,
 		namespace: namespace,

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -25,42 +25,24 @@ var logger = loggo.GetLogger("juju.provider.vmware")
 
 // Open implements environs.EnvironProvider.
 func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
-	env, err := newEnviron(args.Config)
+	if err := validateCloudSpec(args.Cloud); err != nil {
+		return nil, errors.Annotate(err, "validating cloud spec")
+	}
+	env, err := newEnviron(args.Cloud, args.Config)
 	return env, errors.Trace(err)
 }
 
 // PrepareConfig implements environs.EnvironProvider.
-//
-// TODO(axw) 2016-07-29 #1607620
-// We should be extracting the endpoint and region
-// in this method, and using them as host/datacenter.
 func (p environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
-	cfg := args.Config
-	switch authType := args.Cloud.Credential.AuthType(); authType {
-	case cloud.UserPassAuthType:
-		credentialAttrs := args.Cloud.Credential.Attributes()
-		var err error
-		cfg, err = cfg.Apply(map[string]interface{}{
-			cfgUser:     credentialAttrs["user"],
-			cfgPassword: credentialAttrs["password"],
-		})
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-	default:
-		return nil, errors.NotSupportedf("%q auth-type", authType)
+	if err := validateCloudSpec(args.Cloud); err != nil {
+		return nil, errors.Annotate(err, "validating cloud spec")
 	}
-	return cfg, nil
+	return args.Config, nil
 }
 
 // RestrictedConfigAttributes is specified in the EnvironProvider interface.
 func (environProvider) RestrictedConfigAttributes() []string {
-	return []string{
-		cfgDatacenter,
-		cfgHost,
-		cfgUser,
-		cfgPassword,
-	}
+	return []string{}
 }
 
 // Validate implements environs.EnvironProvider.
@@ -88,10 +70,18 @@ func (environProvider) Validate(cfg, old *config.Config) (valid *config.Config, 
 
 // SecretAttrs implements environs.EnvironProvider.
 func (environProvider) SecretAttrs(cfg *config.Config) (map[string]string, error) {
-	// The defaults should be set already, so we pass nil.
-	ecfg, err := newValidConfig(cfg, nil)
-	if err != nil {
-		return nil, errors.Trace(err)
+	return map[string]string{}, nil
+}
+
+func validateCloudSpec(spec environs.CloudSpec) error {
+	if err := spec.Validate(); err != nil {
+		return errors.Trace(err)
 	}
-	return ecfg.secret(), nil
+	if spec.Credential == nil {
+		return errors.NotValidf("missing credential")
+	}
+	if authType := spec.Credential.AuthType(); authType != cloud.UserPassAuthType {
+		return errors.NotSupportedf("%q auth-type", authType)
+	}
+	return nil
 }

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -77,6 +77,7 @@ func validateCloudSpec(spec environs.CloudSpec) error {
 	if err := spec.Validate(); err != nil {
 		return errors.Trace(err)
 	}
+	// TODO(axw) add validation of endpoint/region.
 	if spec.Credential == nil {
 		return errors.NotValidf("missing credential")
 	}

--- a/provider/vsphere/provider_test.go
+++ b/provider/vsphere/provider_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/vsphere"
 )
@@ -17,6 +18,7 @@ type providerSuite struct {
 	vsphere.BaseSuite
 
 	provider environs.EnvironProvider
+	spec     environs.CloudSpec
 }
 
 var _ = gc.Suite(&providerSuite{})
@@ -27,6 +29,7 @@ func (s *providerSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.provider, err = environs.Provider("vsphere")
 	c.Check(err, jc.ErrorIsNil)
+	s.spec = vsphere.FakeCloudSpec()
 }
 
 func (s *providerSuite) TestRegistered(c *gc.C) {
@@ -35,7 +38,7 @@ func (s *providerSuite) TestRegistered(c *gc.C) {
 
 func (s *providerSuite) TestOpen(c *gc.C) {
 	env, err := s.provider.Open(environs.OpenParams{
-		Cloud:  vsphere.FakeCloudSpec(),
+		Cloud:  s.spec,
 		Config: s.Config,
 	})
 	c.Check(err, jc.ErrorIsNil)
@@ -44,10 +47,34 @@ func (s *providerSuite) TestOpen(c *gc.C) {
 	c.Assert(envConfig.Name(), gc.Equals, "testenv")
 }
 
+func (s *providerSuite) TestOpenInvalidCloudSpec(c *gc.C) {
+	s.spec.Name = ""
+	s.testOpenError(c, s.spec, `validating cloud spec: cloud name "" not valid`)
+}
+
+func (s *providerSuite) TestOpenMissingCredential(c *gc.C) {
+	s.spec.Credential = nil
+	s.testOpenError(c, s.spec, `validating cloud spec: missing credential not valid`)
+}
+
+func (s *providerSuite) TestOpenUnsupportedCredential(c *gc.C) {
+	credential := cloud.NewCredential(cloud.OAuth1AuthType, map[string]string{})
+	s.spec.Credential = &credential
+	s.testOpenError(c, s.spec, `validating cloud spec: "oauth1" auth-type not supported`)
+}
+
+func (s *providerSuite) testOpenError(c *gc.C, spec environs.CloudSpec, expect string) {
+	_, err := s.provider.Open(environs.OpenParams{
+		Cloud:  spec,
+		Config: s.Config,
+	})
+	c.Assert(err, gc.ErrorMatches, expect)
+}
+
 func (s *providerSuite) TestPrepareConfig(c *gc.C) {
 	cfg, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
 		Config: s.Config,
-		Cloud:  vsphere.FakeCloudSpec(),
+		Cloud:  s.spec,
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(cfg, gc.NotNil)

--- a/provider/vsphere/provider_test.go
+++ b/provider/vsphere/provider_test.go
@@ -9,7 +9,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/vsphere"
 )
@@ -46,15 +45,9 @@ func (s *providerSuite) TestOpen(c *gc.C) {
 }
 
 func (s *providerSuite) TestPrepareConfig(c *gc.C) {
-	credential := cloud.NewCredential(
-		cloud.UserPassAuthType,
-		map[string]string{"user": "u", "password": "p"},
-	)
 	cfg, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
 		Config: s.Config,
-		Cloud: environs.CloudSpec{
-			Credential: &credential,
-		},
+		Cloud:  vsphere.FakeCloudSpec(),
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(cfg, gc.NotNil)
@@ -66,13 +59,4 @@ func (s *providerSuite) TestValidate(c *gc.C) {
 
 	validAttrs := validCfg.AllAttrs()
 	c.Assert(s.Config.AllAttrs(), gc.DeepEquals, validAttrs)
-}
-
-func (s *providerSuite) TestSecretAttrs(c *gc.C) {
-	obtainedAttrs, err := s.provider.SecretAttrs(s.Config)
-	c.Check(err, jc.ErrorIsNil)
-
-	expectedAttrs := map[string]string{"password": "password1"}
-	c.Assert(obtainedAttrs, gc.DeepEquals, expectedAttrs)
-
 }

--- a/provider/vsphere/testing_test.go
+++ b/provider/vsphere/testing_test.go
@@ -43,7 +43,7 @@ func FakeCloudSpec() environs.CloudSpec {
 	return environs.CloudSpec{
 		Type:       "vsphere",
 		Name:       "vsphere",
-		Region:     "/datacenter1", // TODO(axw) leading "/"?
+		Region:     "/datacenter1",
 		Endpoint:   "host1",
 		Credential: &cred,
 	}

--- a/provider/vsphere/testing_test.go
+++ b/provider/vsphere/testing_test.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/juju/osenv"
@@ -33,19 +34,26 @@ func ConfigAttrs() testing.Attrs {
 	return testing.FakeConfig().Merge(testing.Attrs{
 		"type":             "vsphere",
 		"uuid":             "2d02eeac-9dbb-11e4-89d3-123b93f75cba",
-		"datacenter":       "/datacenter1",
-		"host":             "host1",
-		"user":             "user1",
-		"password":         "password1",
 		"external-network": "",
 	})
 }
 
 func FakeCloudSpec() environs.CloudSpec {
+	cred := FakeCredential()
 	return environs.CloudSpec{
-		Type: "vsphere",
-		Name: "vsphere",
+		Type:       "vsphere",
+		Name:       "vsphere",
+		Region:     "/datacenter1", // TODO(axw) leading "/"?
+		Endpoint:   "host1",
+		Credential: &cred,
 	}
+}
+
+func FakeCredential() cloud.Credential {
+	return cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+		"user":     "user1",
+		"password": "password1",
+	})
 }
 
 type BaseSuite struct {


### PR DESCRIPTION
**vsphere**

Drop host, datacenter, user and password from vsphere model config.
Instead, pull those values out of the cloud spec; cloud endpoint is
taken as the host, and region as the datacenter.

Fixes https://bugs.launchpad.net/juju-core/+bug/1607620

**openstack/rackspace**

Drop region, auth-mode, auth-url, username, password, tenant-name,
access-key, and secret-key from openstack model config. Instead, pull
those values out of the cloud spec.

With this change, we now properly support adding machines to separate
OpenStack regions, and vSphere datacenters.

(Review request: http://reviews.vapour.ws/r/5392/)