### PR TITLE
cmd/juju/controller: don't show bootstrap-config

### DIFF
--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -4,14 +4,11 @@
 package controller
 
 import (
-	"fmt"
-
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -100,10 +97,6 @@ type ShowControllerDetails struct {
 	// Account is the account details for the user logged into this controller.
 	Account *AccountDetails `yaml:"account,omitempty" json:"account,omitempty"`
 
-	// BootstrapConfig contains the bootstrap configuration for this controller.
-	// This is only available on the client that bootstrapped the controller.
-	BootstrapConfig *BootstrapConfig `yaml:"bootstrap-config,omitempty" json:"bootstrap-config,omitempty"`
-
 	// Errors is a collection of errors related to accessing this controller details.
 	Errors []string `yaml:"errors,omitempty" json:"errors,omitempty"`
 }
@@ -141,17 +134,6 @@ type AccountDetails struct {
 	Password string `yaml:"password,omitempty" json:"password,omitempty"`
 }
 
-// BootstrapConfig holds the configuration used to bootstrap a controller.
-type BootstrapConfig struct {
-	Config               map[string]interface{} `yaml:"config,omitempty" json:"config,omitempty"`
-	Cloud                string                 `yaml:"cloud" json:"cloud"`
-	CloudType            string                 `yaml:"cloud-type" json:"cloud-type"`
-	CloudRegion          string                 `yaml:"region,omitempty" json:"region,omitempty"`
-	CloudEndpoint        string                 `yaml:"endpoint,omitempty" json:"endpoint,omitempty"`
-	CloudStorageEndpoint string                 `yaml:"storage-endpoint,omitempty" json:"storage-endpoint,omitempty"`
-	Credential           string                 `yaml:"credential,omitempty" json:"credential,omitempty"`
-}
-
 func (c *showControllerCommand) convertControllerForShow(controllerName string, details *jujuclient.ControllerDetails) ShowControllerDetails {
 	controller := ShowControllerDetails{
 		Details: ControllerDetails{
@@ -164,7 +146,6 @@ func (c *showControllerCommand) convertControllerForShow(controllerName string, 
 	}
 	c.convertModelsForShow(controllerName, &controller)
 	c.convertAccountsForShow(controllerName, &controller)
-	c.convertBootstrapConfigForShow(controllerName, &controller)
 	return controller
 }
 
@@ -203,39 +184,6 @@ func (c *showControllerCommand) convertModelsForShow(controllerName string, cont
 	if err != nil && !errors.IsNotFound(err) {
 		controller.Errors = append(controller.Errors, err.Error())
 		return
-	}
-}
-
-func (c *showControllerCommand) convertBootstrapConfigForShow(controllerName string, controller *ShowControllerDetails) {
-	bootstrapConfig, err := c.store.BootstrapConfigForController(controllerName)
-	if errors.IsNotFound(err) {
-		return
-	} else if err != nil {
-		controller.Errors = append(controller.Errors, err.Error())
-		return
-	}
-	cfg := make(map[string]interface{})
-	var cloudType string
-	for k, v := range bootstrapConfig.Config {
-		switch k {
-		case config.NameKey:
-			// Name is always "admin" for the admin model,
-			// which is not interesting to us here.
-		case config.TypeKey:
-			// Pull Type up to the top level.
-			cloudType = fmt.Sprint(v)
-		default:
-			cfg[k] = v
-		}
-	}
-	controller.BootstrapConfig = &BootstrapConfig{
-		Config:               cfg,
-		Cloud:                bootstrapConfig.Cloud,
-		CloudType:            cloudType,
-		CloudRegion:          bootstrapConfig.CloudRegion,
-		CloudEndpoint:        bootstrapConfig.CloudEndpoint,
-		CloudStorageEndpoint: bootstrapConfig.CloudStorageEndpoint,
-		Credential:           bootstrapConfig.Credential,
 	}
 }
 

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -123,14 +123,6 @@ mallards:
   current-model: my-model
   account:
     user: admin@local
-  bootstrap-config:
-    config:
-      extra: value
-    cloud: mallards
-    cloud-type: maas
-    region: mallards1
-    endpoint: http://mallards.local/MAAS
-    credential: my-credential
 `[1:]
 
 	s.assertShowController(c, "mallards")


### PR DESCRIPTION
Remove bootstrap config from show-controller output.
It's noisy and distracting from the useful details.

(Review request: http://reviews.vapour.ws/r/5393/)