### PR TITLE
Improve controller removal help text

### DIFF
--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -59,7 +59,8 @@ Examples:
     juju destroy-controller --destroy-all-models mycontroller
 
 See also: 
-    kill-controller`
+    kill-controller
+    unregister`
 
 var usageSummary = `
 Destroys a controller.`[1:]

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -18,14 +18,17 @@ import (
 
 const killDoc = `
 Forcibly destroy the specified controller.  If the API server is accessible,
-this command will attempt to destroy the controller model and all
-hosted models and their resources.
+this command will attempt to destroy the controller model and all hosted models
+and their resources.
 
-If the API server is unreachable, the machines of the controller model
-will be destroyed through the cloud provisioner.  If there are additional
-machines, including machines within hosted models, these machines will
-not be destroyed and will never be reconnected to the Juju controller being
-destroyed. 
+If the API server is unreachable, the machines of the controller model will be
+destroyed through the cloud provisioner.  If there are additional machines,
+including machines within hosted models, these machines will not be destroyed
+and will never be reconnected to the Juju controller being destroyed.
+
+See also:
+    destroy-controller
+    unregister
 `
 
 // NewKillCommand returns a command to kill a controller. Killing is a forceful

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -58,23 +58,24 @@ var usageRegisterSummary = `
 Registers a Juju user to a controller.`[1:]
 
 var usageRegisterDetails = `
-Connects to a controller and completes the user registration process that
-began with the `[1:] + "`juju add-user`" + ` command. The latter prints out the 'string'
-that is referred to in Usage.
-The user will be prompted for a password, which, once set, causes the 
-registration string to be voided. In order to start using Juju the user 
-can now either add a model or wait for a model to be shared with them.
-Some machine providers will require the user to be in possession of 
-certain credentials in order to add a model.
+Connects to a controller and completes the user registration process that began
+with the `[1:] + "`juju add-user`" + ` command. The latter prints out the 'string' that is
+referred to in Usage.
+
+The user will be prompted for a password, which, once set, causes the
+registration string to be voided. In order to start using Juju the user can now
+either add a model or wait for a model to be shared with them.  Some machine
+providers will require the user to be in possession of certain credentials in
+order to add a model.
 
 Examples:
 
-    juju register MFATA3JvZDAnExMxMDQuMTU0LjQyLjQ0OjE3MDcwExAxMC4xMjguMC4yOjE3MDcw
-    BCBEFCaXerhNImkKKabuX5ULWf2Bp4AzPNJEbXVWgraLrAA=
+    juju register MFATA3JvZDAnExMxMDQuMTU0LjQyLjQ0OjE3MDcwExAxMC4xMjguMC4yOjE3MDcwBCBEFCaXerhNImkKKabuX5ULWf2Bp4AzPNJEbXVWgraLrAA=
 
 See also: 
     add-user
-    change-user-password`
+    change-user-password
+    unregister`
 
 // Info implements Command.Info
 // `register` may seem generic, but is seen as simple and without potential

--- a/cmd/juju/controller/unregister.go
+++ b/cmd/juju/controller/unregister.go
@@ -33,16 +33,18 @@ type unregisterCommand struct {
 }
 
 var usageUnregisterDetails = `
-Removes local connection information for the specified controller.
-This command does not destroy the controller.  In order to regain
-access to an unregistered controller, it will need to be added
-again using the juju register command.
+Removes local connection information for the specified controller.  This
+command does not destroy the controller.  In order to regain access to an
+unregistered controller, it will need to be added again using the juju register
+command.
 
 Examples:
 
     juju unregister my-controller
 
-See Also:
+See also:
+    juju destroy-controller
+    juju kill-controller
     juju register`
 
 // Info implements Command.Info


### PR DESCRIPTION
Add 'See also' lines to mention destroy-controller, kill-controller and
unregister in the others' help text, as well as unregister in register's.

Fixes lp:1607303


Review Notes:

 * The bug suggests linking each command's help text to the other. This seems reasonable in that each has a related use
 * `register` is a slight exception in that it now refers to `unregister` but neither of the controller removal commands, to which it seems less related
 * Help text line lengths were also updated if they were not wrapped at 80 characters

QA steps:

 * Confirm the help text output

 ```
for c in destroy-controller kill-controller register unregister; do
    echo $c
    juju help $c | sed -n '/See also/,/^$/p'
    echo
done
```

(Review request: http://reviews.vapour.ws/r/5395/)