### PR TITLE
API server prep work for pubsub.

### DIFF
--- a/apiserver/authhttp_test.go
+++ b/apiserver/authhttp_test.go
@@ -94,15 +94,15 @@ func (s *authHttpSuite) baseURL(c *gc.C) *url.URL {
 	}
 }
 
-func (s *authHttpSuite) dialWebsocketFromURL(c *gc.C, server string, header http.Header) *websocket.Conn {
-	config := s.makeWebsocketConfigFromURL(c, server, header)
+func dialWebsocketFromURL(c *gc.C, server string, header http.Header) *websocket.Conn {
+	config := makeWebsocketConfigFromURL(c, server, header)
 	c.Logf("dialing %v", server)
 	conn, err := websocket.DialConfig(config)
 	c.Assert(err, jc.ErrorIsNil)
 	return conn
 }
 
-func (s *authHttpSuite) makeWebsocketConfigFromURL(c *gc.C, server string, header http.Header) *websocket.Config {
+func makeWebsocketConfigFromURL(c *gc.C, server string, header http.Header) *websocket.Config {
 	config, err := websocket.NewConfig(server, "http://localhost/")
 	c.Assert(err, jc.ErrorIsNil)
 	config.Header = header
@@ -114,7 +114,7 @@ func (s *authHttpSuite) makeWebsocketConfigFromURL(c *gc.C, server string, heade
 	return config
 }
 
-func (s *authHttpSuite) assertWebsocketClosed(c *gc.C, reader *bufio.Reader) {
+func assertWebsocketClosed(c *gc.C, reader *bufio.Reader) {
 	_, err := reader.ReadByte()
 	c.Assert(err, gc.Equals, io.EOF)
 }

--- a/apiserver/debuglog_test.go
+++ b/apiserver/debuglog_test.go
@@ -25,7 +25,7 @@ type debugLogBaseSuite struct {
 func (s *debugLogBaseSuite) TestBadParams(c *gc.C) {
 	reader := s.openWebsocket(c, url.Values{"maxLines": {"foo"}})
 	assertJSONError(c, reader, `maxLines value "foo" is not a valid unsigned number`)
-	s.assertWebsocketClosed(c, reader)
+	assertWebsocketClosed(c, reader)
 }
 
 func (s *debugLogBaseSuite) TestWithHTTP(c *gc.C) {
@@ -49,7 +49,7 @@ func (s *debugLogBaseSuite) TestNoAuth(c *gc.C) {
 	reader := bufio.NewReader(conn)
 
 	assertJSONError(c, reader, "no credentials provided")
-	s.assertWebsocketClosed(c, reader)
+	assertWebsocketClosed(c, reader)
 }
 
 func (s *debugLogBaseSuite) TestAgentLoginsRejected(c *gc.C) {
@@ -63,7 +63,7 @@ func (s *debugLogBaseSuite) TestAgentLoginsRejected(c *gc.C) {
 	reader := bufio.NewReader(conn)
 
 	assertJSONError(c, reader, "tag kind machine not valid")
-	s.assertWebsocketClosed(c, reader)
+	assertWebsocketClosed(c, reader)
 }
 
 func (s *debugLogBaseSuite) openWebsocket(c *gc.C, values url.Values) *bufio.Reader {
@@ -76,7 +76,7 @@ func (s *debugLogBaseSuite) openWebsocketCustomPath(c *gc.C, path string) *bufio
 	server := s.logURL(c, "wss", nil)
 	server.Path = path
 	header := utils.BasicAuthHeader(s.userTag.String(), s.password)
-	conn := s.dialWebsocketFromURL(c, server.String(), header)
+	conn := dialWebsocketFromURL(c, server.String(), header)
 	s.AddCleanup(func(_ *gc.C) { conn.Close() })
 	return bufio.NewReader(conn)
 }
@@ -92,5 +92,5 @@ func (s *debugLogBaseSuite) dialWebsocket(c *gc.C, queryParams url.Values) *webs
 
 func (s *debugLogBaseSuite) dialWebsocketInternal(c *gc.C, queryParams url.Values, header http.Header) *websocket.Conn {
 	server := s.logURL(c, "wss", queryParams).String()
-	return s.dialWebsocketFromURL(c, server, header)
+	return dialWebsocketFromURL(c, server, header)
 }

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -116,8 +116,8 @@ func (ctxt *httpContext) stateForRequestAuthenticatedUser(r *http.Request) (*sta
 	return st, entity, nil
 }
 
-// stateForRequestAuthenticatedUser is like stateForRequestAuthenticated
-// except that it also verifies that the authenticated entity is a user.
+// stateForRequestAuthenticatedAgent is like stateForRequestAuthenticated
+// except that it also verifies that the authenticated entity is an agent.
 func (ctxt *httpContext) stateForRequestAuthenticatedAgent(r *http.Request) (*state.State, state.Entity, error) {
 	authFunc := common.AuthEither(
 		common.AuthFuncForTagKind(names.MachineTagKind),

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -67,7 +67,7 @@ func (s *logsinkSuite) SetUpTest(c *gc.C) {
 func (s *logsinkSuite) TestRejectsBadEnvironUUID(c *gc.C) {
 	reader := s.openWebsocketCustomPath(c, "/model/does-not-exist/logsink")
 	assertJSONError(c, reader, `unknown model: "does-not-exist"`)
-	s.assertWebsocketClosed(c, reader)
+	assertWebsocketClosed(c, reader)
 }
 
 func (s *logsinkSuite) TestNoAuth(c *gc.C) {
@@ -101,7 +101,7 @@ func (s *logsinkSuite) checkAuthFails(c *gc.C, header http.Header, message strin
 	defer conn.Close()
 	reader := bufio.NewReader(conn)
 	assertJSONError(c, reader, message)
-	s.assertWebsocketClosed(c, reader)
+	assertWebsocketClosed(c, reader)
 }
 
 func (s *logsinkSuite) TestLogging(c *gc.C) {
@@ -208,13 +208,13 @@ func (s *logsinkSuite) dialWebsocket(c *gc.C) *websocket.Conn {
 
 func (s *logsinkSuite) dialWebsocketInternal(c *gc.C, header http.Header) *websocket.Conn {
 	server := s.logsinkURL(c, "wss").String()
-	return s.dialWebsocketFromURL(c, server, header)
+	return dialWebsocketFromURL(c, server, header)
 }
 
 func (s *logsinkSuite) openWebsocketCustomPath(c *gc.C, path string) *bufio.Reader {
 	server := s.logsinkURL(c, "wss")
 	server.Path = path
-	conn := s.dialWebsocketFromURL(c, server.String(), s.makeAuthHeader())
+	conn := dialWebsocketFromURL(c, server.String(), s.makeAuthHeader())
 	s.AddCleanup(func(_ *gc.C) { conn.Close() })
 	return bufio.NewReader(conn)
 }

--- a/apiserver/observer/audit.go
+++ b/apiserver/observer/audit.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/version"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/audit"
 	"github.com/juju/juju/rpc"
@@ -58,12 +59,12 @@ type Audit struct {
 }
 
 // Login implements Observer.
-func (a *Audit) Login(tag string) {
-	a.state.authenticatedTag = tag
+func (a *Audit) Login(entity names.Tag, _ names.ModelTag, _ bool, _ string) {
+	a.state.authenticatedTag = entity.String()
 }
 
 // Join implements Observer.
-func (a *Audit) Join(req *http.Request) {
+func (a *Audit) Join(req *http.Request, _ uint64) {
 	a.state.remoteAddress = req.RemoteAddr
 }
 

--- a/apiserver/observer/fakeobserver/instance.go
+++ b/apiserver/observer/fakeobserver/instance.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"runtime"
 
+	"gopkg.in/juju/names.v2"
+
 	"strings"
 
 	"github.com/juju/juju/rpc"
@@ -19,8 +21,8 @@ type Instance struct {
 }
 
 // Join implements Observer.
-func (f *Instance) Join(req *http.Request) {
-	f.AddCall(funcName(), req)
+func (f *Instance) Join(req *http.Request, connectionID uint64) {
+	f.AddCall(funcName(), req, connectionID)
 }
 
 // Leave implements Observer.
@@ -29,8 +31,8 @@ func (f *Instance) Leave() {
 }
 
 // Login implements Observer.
-func (f *Instance) Login(entityName string) {
-	f.AddCall(funcName(), entityName)
+func (f *Instance) Login(entity names.Tag, model names.ModelTag, fromController bool, userData string) {
+	f.AddCall(funcName(), entity, model, fromController, userData)
 }
 
 // RPCObserver implements Observer.

--- a/apiserver/observer/observer.go
+++ b/apiserver/observer/observer.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/juju/juju/rpc"
+	"gopkg.in/juju/names.v2"
 )
 
 // Observer defines a type which will observe API server events as
@@ -16,11 +17,11 @@ type Observer interface {
 	rpc.ObserverFactory
 
 	// Login informs an Observer that an entity has logged in.
-	Login(string)
+	Login(entity names.Tag, model names.ModelTag, fromController bool, userData string)
 
 	// Join is called when the connection to the API server's
 	// WebSocket is opened.
-	Join(req *http.Request)
+	Join(req *http.Request, connectionID uint64)
 
 	// Leave is called when the connection to the API server's
 	// WebSocket is closed.
@@ -75,8 +76,8 @@ type Multiplexer struct {
 
 // Join is called when the connection to the API server's WebSocket is
 // opened.
-func (m *Multiplexer) Join(req *http.Request) {
-	mapConcurrent(func(o Observer) { o.Join(req) }, m.observers)
+func (m *Multiplexer) Join(req *http.Request, connectionID uint64) {
+	mapConcurrent(func(o Observer) { o.Join(req, connectionID) }, m.observers)
 }
 
 // Leave implements Observer.
@@ -85,8 +86,8 @@ func (m *Multiplexer) Leave() {
 }
 
 // Login implements Observer.
-func (m *Multiplexer) Login(entityName string) {
-	mapConcurrent(func(o Observer) { o.Login(entityName) }, m.observers)
+func (m *Multiplexer) Login(entity names.Tag, model names.ModelTag, fromController bool, userData string) {
+	mapConcurrent(func(o Observer) { o.Login(entity, model, fromController, userData) }, m.observers)
 }
 
 // RPCObserver implements Observer. It will create an

--- a/apiserver/observer/observer_test.go
+++ b/apiserver/observer/observer_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/observer/fakeobserver"
@@ -42,10 +43,10 @@ func (*multiplexerSuite) TestJoin_CallsAllObservers(c *gc.C) {
 
 	o := observer.NewMultiplexer(observers[0], observers[1])
 	var req http.Request
-	o.Join(&req)
+	o.Join(&req, 1234)
 
 	for _, f := range observers {
-		f.CheckCall(c, 0, "Join", &req)
+		f.CheckCall(c, 0, "Join", &req, uint64(1234))
 	}
 }
 
@@ -84,10 +85,13 @@ func (*multiplexerSuite) TestLogin_CallsAllObservers(c *gc.C) {
 	}
 
 	o := observer.NewMultiplexer(observers[0], observers[1])
-	tag := "foo"
-	o.Login(tag)
+	entity := names.NewMachineTag("42")
+	model := names.NewModelTag("fake-uuid")
+	fromController := false
+	userData := "foo"
+	o.Login(entity, model, fromController, userData)
 
 	for _, f := range observers {
-		f.CheckCall(c, 0, "Login", tag)
+		f.CheckCall(c, 0, "Login", entity, model, fromController, userData)
 	}
 }

--- a/apiserver/package_test.go
+++ b/apiserver/package_test.go
@@ -4,11 +4,11 @@
 package apiserver_test
 
 import (
-	stdtesting "testing"
+	"testing"
 
 	coretesting "github.com/juju/juju/testing"
 )
 
-func TestPackage(t *stdtesting.T) {
+func TestPackage(t *testing.T) {
 	coretesting.MgoTestPackage(t)
 }

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -381,6 +381,7 @@ type LoginRequest struct {
 	Credentials string           `json:"credentials"`
 	Nonce       string           `json:"nonce"`
 	Macaroons   []macaroon.Slice `json:"macaroons"`
+	UserData    string           `json:"user-data"`
 }
 
 // LoginRequestCompat holds credentials for identifying an entity to the Login v1

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/juju/cmd"
@@ -1115,14 +1114,13 @@ func newObserverFn(
 	var observerFactories []observer.ObserverFactory
 
 	// Common logging of RPC requests
-	var connectionID int64
 	observerFactories = append(observerFactories, func() observer.Observer {
 		logger := loggo.GetLogger("juju.apiserver")
 		ctx := observer.RequestObserverContext{
 			Clock:  clock,
 			Logger: logger,
 		}
-		return observer.NewRequestObserver(ctx, atomic.AddInt64(&connectionID, 1))
+		return observer.NewRequestObserver(ctx)
 	})
 
 	// Auditing observer


### PR DESCRIPTION
Extends the methods on the request observers. Since a pubsub observer will also send the connection ID, it makes sense to have one source of truth as to the connection ID rather than the log output using one and pubsub using another. Also for login, the pubsub system needs the extra data to track presence.

Makes some test methods stand-alone functions, these are used in a follow-up branch.

(Review request: http://reviews.vapour.ws/r/5397/)