### PR TITLE
juju get-config supports getting single key value

### DIFF
--- a/cmd/juju/application/get.go
+++ b/cmd/juju/application/get.go
@@ -4,6 +4,8 @@
 package application
 
 import (
+	"fmt"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"launchpad.net/gnuflag"
@@ -17,6 +19,8 @@ var usageGetConfigSummary = `
 Displays configuration settings for a deployed application.`[1:]
 
 var usageGetConfigDetails = `
+By default, all configuration (keys, values, metadata) for the application are
+displayed if a key is not specified.
 Output includes the name of the charm used to deploy the application and a
 listing of the application-specific configuration settings.
 See `[1:] + "`juju status`" + ` for application names.
@@ -24,6 +28,7 @@ See `[1:] + "`juju status`" + ` for application names.
 Examples:
     juju get-config mysql
     juju get-config mysql-testing
+    juju get-config mysql wait-timeout
 
 See also: 
     set-config
@@ -38,7 +43,8 @@ func NewGetCommand() cmd.Command {
 // getCommand retrieves the configuration of an application.
 type getCommand struct {
 	modelcmd.ModelCommandBase
-	ApplicationName string
+	applicationName string
+	key             string
 	out             cmd.Output
 	api             getServiceAPI
 }
@@ -46,7 +52,7 @@ type getCommand struct {
 func (c *getCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "get-config",
-		Args:    "<application name>",
+		Args:    "<application name> [attribute-key]",
 		Purpose: usageGetConfigSummary,
 		Doc:     usageGetConfigDetails,
 		Aliases: []string{"get-configs"},
@@ -65,8 +71,12 @@ func (c *getCommand) Init(args []string) error {
 	if len(args) == 0 {
 		return errors.New("no application name specified")
 	}
-	c.ApplicationName = args[0]
-	return cmd.CheckEmpty(args[1:])
+	c.applicationName = args[0]
+	if len(args) == 1 {
+		return nil
+	}
+	c.key = args[1]
+	return cmd.CheckEmpty(args[2:])
 }
 
 // getServiceAPI defines the methods on the client API
@@ -96,9 +106,21 @@ func (c *getCommand) Run(ctx *cmd.Context) error {
 	}
 	defer apiclient.Close()
 
-	results, err := apiclient.Get(c.ApplicationName)
+	results, err := apiclient.Get(c.applicationName)
 	if err != nil {
 		return err
+	}
+	if c.key != "" {
+		info, found := results.Config[c.key].(map[string]interface{})
+		if !found {
+			return fmt.Errorf("key %q not found in %q application settings.", c.key, c.applicationName)
+		}
+		out, err := cmd.FormatSmart(info["value"])
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(ctx.Stdout, "%v\n", string(out))
+		return nil
 	}
 
 	resultsMap := map[string]interface{}{

--- a/cmd/juju/application/get_test.go
+++ b/cmd/juju/application/get_test.go
@@ -77,6 +77,23 @@ func (s *GetSuite) TestGetCommandInit(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "no application name specified")
 }
 
+func (s *GetSuite) TestGetCommandInitWithApplication(c *gc.C) {
+	err := coretesting.InitCommand(application.NewGetCommandForTest(s.fake), []string{"app"})
+	// everything ok
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *GetSuite) TestGetCommandInitWithKey(c *gc.C) {
+	err := coretesting.InitCommand(application.NewGetCommandForTest(s.fake), []string{"app", "key"})
+	// everything ok
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *GetSuite) TestGetCommandInitTooManyArgs(c *gc.C) {
+	err := coretesting.InitCommand(application.NewGetCommandForTest(s.fake), []string{"app", "key", "another"})
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["another"\]`)
+}
+
 func (s *GetSuite) TestGetConfig(c *gc.C) {
 	for _, t := range getTests {
 		ctx := coretesting.Context(c)
@@ -97,4 +114,20 @@ func (s *GetSuite) TestGetConfig(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(actual, gc.DeepEquals, expected)
 	}
+}
+
+func (s *GetSuite) TestGetConfigKey(c *gc.C) {
+	ctx := coretesting.Context(c)
+	code := cmd.Main(application.NewGetCommandForTest(s.fake), ctx, []string{"dummy-application", "title"})
+	c.Check(code, gc.Equals, 0)
+	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
+	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, "Nearly There\n")
+}
+
+func (s *GetSuite) TestGetConfigKeyNotFound(c *gc.C) {
+	ctx := coretesting.Context(c)
+	code := cmd.Main(application.NewGetCommandForTest(s.fake), ctx, []string{"dummy-application", "invalid"})
+	c.Check(code, gc.Equals, 1)
+	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "error: key \"invalid\" not found in \"dummy-application\" application settings.\n")
+	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, "")
 }


### PR DESCRIPTION
Stakeholders want to be able to get and print the value of a single application setting key. Just the value, no metadata.

(Review request: http://reviews.vapour.ws/r/5399/)