### PR TITLE
Flagged non-standard retry methods as deprecated

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -522,6 +522,7 @@ func dialWebsocket(addr, path string, opts DialOpts, tlsConfig *tls.Config, try 
 var newWebsocketDialer = createWebsocketDialer
 
 func createWebsocketDialer(cfg *websocket.Config, opts DialOpts) func(<-chan struct{}) (io.Closer, error) {
+	// TODO(katco): 2016-08-09: lp:1611427
 	openAttempt := utils.AttemptStrategy{
 		Total: opts.Timeout,
 		Delay: opts.RetryDelay,

--- a/api/backups/restore.go
+++ b/api/backups/restore.go
@@ -20,6 +20,8 @@ import (
 var (
 	// restoreStrategy is the attempt strategy for api server calls re-attempts in case
 	// the server is upgrading.
+	//
+	// TODO(katco): 2016-08-09: lp:1611427
 	restoreStrategy = utils.AttemptStrategy{
 		Delay: 10 * time.Second,
 		Min:   1,

--- a/cmd/juju/commands/ssh_common.go
+++ b/cmd/juju/commands/ssh_common.go
@@ -65,6 +65,8 @@ func (t *resolvedTarget) isAgent() bool {
 }
 
 // attemptStarter is an interface corresponding to utils.AttemptStrategy
+//
+// TODO(katco): 2016-08-09: lp:1611427
 type attemptStarter interface {
 	Start() attempt
 }
@@ -73,9 +75,11 @@ type attempt interface {
 	Next() bool
 }
 
+// TODO(katco): 2016-08-09: lp:1611427
 type attemptStrategy utils.AttemptStrategy
 
 func (s attemptStrategy) Start() attempt {
+	// TODO(katco): 2016-08-09: lp:1611427
 	return utils.AttemptStrategy(s).Start()
 }
 

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -88,6 +88,7 @@ func tryAPI(c *modelcmd.ModelCommandBase) error {
 // command which will fail until the controller is fully initialised.
 // TODO(wallyworld) - add a bespoke command to maybe the admin facade for this purpose.
 func WaitForAgentInitialisation(ctx *cmd.Context, c *modelcmd.ModelCommandBase, controllerName string) error {
+	// TODO(katco): 2016-08-09: lp:1611427
 	attempts := utils.AttemptStrategy{
 		Min:   bootstrapReadyPollCount,
 		Delay: bootstrapReadyPollDelay,

--- a/environs/filestorage/filestorage.go
+++ b/environs/filestorage/filestorage.go
@@ -114,6 +114,7 @@ func (f *fileStorageReader) URL(name string) (string, error) {
 
 // DefaultConsistencyStrategy implements storage.StorageReader.ConsistencyStrategy.
 func (f *fileStorageReader) DefaultConsistencyStrategy() utils.AttemptStrategy {
+	// TODO(katco): 2016-08-09: lp:1611427
 	return utils.AttemptStrategy{}
 }
 

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -76,6 +76,8 @@ type LiveTests struct {
 
 	// Attempt holds a strategy for waiting until the environment
 	// becomes logically consistent.
+	//
+	// TODO(katco): 2016-08-09: lp:1611427
 	Attempt utils.AttemptStrategy
 
 	// CanOpenState should be true if the testing environment allows
@@ -734,6 +736,7 @@ func (t *LiveTests) checkUpgrade(c *gc.C, st *state.State, newVersion version.Bi
 	}
 }
 
+// TODO(katco): 2016-08-09: lp:1611427
 var waitAgent = utils.AttemptStrategy{
 	Total: 30 * time.Second,
 	Delay: 1 * time.Second,

--- a/environs/storage/interfaces.go
+++ b/environs/storage/interfaces.go
@@ -32,6 +32,8 @@ type StorageReader interface {
 	// If the storage implementation has immediate consistency, the
 	// strategy won't need to wait at all.  But for eventually-consistent
 	// storage backends a few seconds of polling may be needed.
+	//
+	// TODO(katco): 2016-08-09: lp:1611427
 	DefaultConsistencyStrategy() utils.AttemptStrategy
 
 	// ShouldRetry returns true is the specified error is such that an

--- a/environs/storage/storage.go
+++ b/environs/storage/storage.go
@@ -39,6 +39,8 @@ func Get(stor StorageReader, name string) (io.ReadCloser, error) {
 }
 
 // GetWithRetry gets the named file from stor using the specified attempt strategy.
+//
+// TODO(katco): 2016-08-09: lp:1611427
 func GetWithRetry(stor StorageReader, name string, attempt utils.AttemptStrategy) (r io.ReadCloser, err error) {
 	for a := attempt.Start(); a.Next(); {
 		r, err = stor.Get(name)
@@ -55,6 +57,8 @@ func List(stor StorageReader, prefix string) ([]string, error) {
 }
 
 // ListWithRetry lists the files matching prefix from stor using the specified attempt strategy.
+//
+// TODO(katco): 2016-08-09: lp:1611427
 func ListWithRetry(stor StorageReader, prefix string, attempt utils.AttemptStrategy) (list []string, err error) {
 	for a := attempt.Start(); a.Next(); {
 		list, err = stor.List(prefix)
@@ -116,6 +120,7 @@ func (s *storageSimpleStreamsDataSource) Fetch(path string) (io.ReadCloser, stri
 	if err == nil {
 		dataURL = fullURL
 	}
+	// TODO(katco): 2016-08-09: lp:1611427
 	var attempt utils.AttemptStrategy
 	if s.allowRetry {
 		attempt = s.storage.DefaultConsistencyStrategy()

--- a/environs/storage/storage_test.go
+++ b/environs/storage/storage_test.go
@@ -136,6 +136,7 @@ func (s *fakeStorage) URL(name string) (string, error) {
 }
 
 func (s *fakeStorage) DefaultConsistencyStrategy() utils.AttemptStrategy {
+	// TODO(katco): 2016-08-09: lp:1611427
 	return utils.AttemptStrategy{Min: 10}
 }
 
@@ -145,6 +146,7 @@ func (s *fakeStorage) ShouldRetry(error) bool {
 
 func (s *storageSuite) TestGetWithRetry(c *gc.C) {
 	stor := &fakeStorage{shouldRetry: true}
+	// TODO(katco): 2016-08-09: lp:1611427
 	attempt := utils.AttemptStrategy{Min: 5}
 	storage.GetWithRetry(stor, "foo", attempt)
 	c.Assert(stor.getName, gc.Equals, "foo")
@@ -167,6 +169,7 @@ func (s *storageSuite) TestGetNoRetryAllowed(c *gc.C) {
 
 func (s *storageSuite) TestListWithRetry(c *gc.C) {
 	stor := &fakeStorage{shouldRetry: true}
+	// TODO(katco): 2016-08-09: lp:1611427
 	attempt := utils.AttemptStrategy{Min: 5}
 	storage.ListWithRetry(stor, "foo", attempt)
 	c.Assert(stor.listPrefix, gc.Equals, "foo")

--- a/environs/testing/polling.go
+++ b/environs/testing/polling.go
@@ -12,10 +12,14 @@ import (
 
 // impatientAttempt is an extremely short polling time suitable for tests.
 // It polls at least once, never delays, and times out very quickly.
+//
+// TODO(katco): 2016-08-09: lp:1611427
 var impatientAttempt = utils.AttemptStrategy{}
 
 // savedAttemptStrategy holds the state needed to restore an AttemptStrategy's
 // original setting.
+//
+// TODO(katco): 2016-08-09: lp:1611427
 type savedAttemptStrategy struct {
 	address  *utils.AttemptStrategy
 	original utils.AttemptStrategy
@@ -23,6 +27,8 @@ type savedAttemptStrategy struct {
 
 // saveAttemptStrategies captures the information required to restore the
 // given AttemptStrategy objects.
+//
+// TODO(katco): 2016-08-09: lp:1611427
 func saveAttemptStrategies(strategies []*utils.AttemptStrategy) []savedAttemptStrategy {
 	savedStrategies := make([]savedAttemptStrategy, len(strategies))
 	for index, strategy := range strategies {
@@ -49,6 +55,8 @@ func restoreAttemptStrategies(strategies []savedAttemptStrategy) {
 // internalPatchAttemptStrategies sets the given AttemptStrategy objects
 // to the impatientAttempt configuration, and returns a function that restores
 // the original configurations.
+//
+// TODO(katco): 2016-08-09: lp:1611427
 func internalPatchAttemptStrategies(strategies []*utils.AttemptStrategy) func() {
 	snapshot := saveAttemptStrategies(strategies)
 	for _, strategy := range strategies {
@@ -64,6 +72,8 @@ func internalPatchAttemptStrategies(strategies []*utils.AttemptStrategy) func() 
 // polling and timeout times so that tests can run fast.
 // It returns a cleanup function that restores the original settings.  You must
 // call this afterwards.
+//
+// TODO(katco): 2016-08-09: lp:1611427
 func PatchAttemptStrategies(strategies ...*utils.AttemptStrategy) func() {
 	// The one irregularity here is that LongAttempt goes on the list of
 	// strategies that need patching.  To keep testing simple, we treat

--- a/environs/testing/polling_test.go
+++ b/environs/testing/polling_test.go
@@ -23,6 +23,7 @@ type testingSuite struct{}
 var _ = gc.Suite(&testingSuite{})
 
 func (*testingSuite) TestSaveAttemptStrategiesSaves(c *gc.C) {
+	// TODO(katco): 2016-08-09: lp:1611427
 	attempt := utils.AttemptStrategy{
 		Total: time.Second,
 		Delay: time.Millisecond,
@@ -36,6 +37,7 @@ func (*testingSuite) TestSaveAttemptStrategiesSaves(c *gc.C) {
 }
 
 func (*testingSuite) TestSaveAttemptStrategiesLeavesOriginalsIntact(c *gc.C) {
+	// TODO(katco): 2016-08-09: lp:1611427
 	original := utils.AttemptStrategy{
 		Total: time.Second,
 		Delay: time.Millisecond,
@@ -48,6 +50,7 @@ func (*testingSuite) TestSaveAttemptStrategiesLeavesOriginalsIntact(c *gc.C) {
 }
 
 func (*testingSuite) TestInternalPatchAttemptStrategiesPatches(c *gc.C) {
+	// TODO(katco): 2016-08-09: lp:1611427
 	attempt := utils.AttemptStrategy{
 		Total: 33 * time.Millisecond,
 		Delay: 99 * time.Microsecond,
@@ -64,6 +67,7 @@ func (*testingSuite) TestInternalPatchAttemptStrategiesPatches(c *gc.C) {
 // these tests take this as sufficient proof that any strategy that gets
 // patched, also gets restored by the cleanup function.
 func (*testingSuite) TestInternalPatchAttemptStrategiesReturnsCleanup(c *gc.C) {
+	// TODO(katco): 2016-08-09: lp:1611427
 	original := utils.AttemptStrategy{
 		Total: 22 * time.Millisecond,
 		Delay: 77 * time.Microsecond,
@@ -91,6 +95,7 @@ func (*testingSuite) TestPatchAttemptStrategiesPatchesEnvironsStrategies(c *gc.C
 }
 
 func (*testingSuite) TestPatchAttemptStrategiesPatchesGivenAttempts(c *gc.C) {
+	// TODO(katco): 2016-08-09: lp:1611427
 	attempt1 := utils.AttemptStrategy{
 		Total: 33 * time.Millisecond,
 		Delay: 99 * time.Microsecond,

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -45,6 +45,7 @@ const (
 	RestrictedAPIExposed = false
 )
 
+// TODO(katco): 2016-08-09: lp:1611427
 var ShortAttempt = &utils.AttemptStrategy{
 	Total: time.Second * 10,
 	Delay: time.Millisecond * 200,

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -389,6 +389,7 @@ func (s *JujuConnSuite) AddDefaultToolsToState(c *gc.C) {
 	s.AddToolsToState(c, versions...)
 }
 
+// TODO(katco): 2016-08-09: lp:1611427
 var redialStrategy = utils.AttemptStrategy{
 	Total: 60 * time.Second,
 	Delay: 250 * time.Millisecond,

--- a/provider/common/polling.go
+++ b/provider/common/polling.go
@@ -11,6 +11,8 @@ import (
 
 // Use ShortAttempt to poll for short-term events.
 // TODO: This may need tuning for different providers (or even environments).
+//
+// TODO(katco): 2016-08-09: lp:1611427
 var ShortAttempt = utils.AttemptStrategy{
 	Total: 5 * time.Second,
 	Delay: 200 * time.Millisecond,
@@ -22,6 +24,8 @@ var ShortAttempt = utils.AttemptStrategy{
 // Other requests fail due to a slow state transition (e.g. an instance taking
 // a while to release a security group after termination).  If you need to
 // poll for the latter kind, use LongAttempt.
+//
+// TODO(katco): 2016-08-09: lp:1611427
 var LongAttempt = utils.AttemptStrategy{
 	Total: 3 * time.Minute,
 	Delay: 1 * time.Second,

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -45,6 +45,7 @@ const (
 
 var (
 	// Use shortAttempt to poll for short-term events or for retrying API calls.
+	// TODO(katco): 2016-08-09: lp:1611427
 	shortAttempt = utils.AttemptStrategy{
 		Total: 5 * time.Second,
 		Delay: 200 * time.Millisecond,
@@ -634,6 +635,7 @@ func tagRootDisk(e *ec2.EC2, tags map[string]string, inst *ec2.Instance) error {
 	// Wait until the instance has an associated EBS volume in the
 	// block-device-mapping.
 	volumeId := findVolumeId(inst)
+	// TODO(katco): 2016-08-09: lp:1611427
 	waitRootDiskAttempt := utils.AttemptStrategy{
 		Total: 5 * time.Minute,
 		Delay: 5 * time.Second,

--- a/provider/ec2/storage.go
+++ b/provider/ec2/storage.go
@@ -79,12 +79,15 @@ func (s *ec2storage) URL(name string) (string, error) {
 	return s.bucket.SignedURL(name, maxExpiratoryPeriod)
 }
 
+// TODO(katco): 2016-08-09: lp:1611427
 var storageAttempt = utils.AttemptStrategy{
 	Total: 5 * time.Second,
 	Delay: 200 * time.Millisecond,
 }
 
 // DefaultConsistencyStrategy is specified in the StorageReader interface.
+//
+// TODO(katco): 2016-08-09: lp:1611427
 func (s *ec2storage) DefaultConsistencyStrategy() utils.AttemptStrategy {
 	return storageAttempt
 }

--- a/provider/gce/google/raw.go
+++ b/provider/gce/google/raw.go
@@ -21,7 +21,7 @@ const diskTypesBase = "https://www.googleapis.com/compute/v1/projects/%s/zones/%
 // These are attempt strategies used in waitOperation.
 var (
 	// TODO(ericsnow) Tune the timeouts and delays.
-
+	// TODO(katco): 2016-08-09: lp:1611427
 	attemptsLong = utils.AttemptStrategy{
 		Total: 5 * time.Minute,
 		Delay: 2 * time.Second,
@@ -325,6 +325,8 @@ var doOpCall = func(call opDoer) (*compute.Operation, error) {
 // waitOperation waits for the provided operation to reach the "done"
 // status. It follows the given attempt strategy (e.g. wait time between
 // attempts) and may time out.
+//
+// TODO(katco): 2016-08-09: lp:1611427
 func (rc *rawConn) waitOperation(projectID string, op *compute.Operation, attempts utils.AttemptStrategy) error {
 	// TODO(perrito666) 2016-05-02 lp:1558657
 	started := time.Now()

--- a/provider/gce/google/raw_test.go
+++ b/provider/gce/google/raw_test.go
@@ -14,8 +14,9 @@ import (
 type rawConnSuite struct {
 	BaseSuite
 
-	op       *compute.Operation
-	rawConn  *rawConn
+	op      *compute.Operation
+	rawConn *rawConn
+	// TODO(katco): 2016-08-09: lp:1611427
 	strategy utils.AttemptStrategy
 
 	callCount int

--- a/provider/joyent/export_test.go
+++ b/provider/joyent/export_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 // Use ShortAttempt to poll for short-term events.
+//
+// TODO(katco): 2016-08-09: lp:1611427
 var ShortAttempt = utils.AttemptStrategy{
 	Total: 5 * time.Second,
 	Delay: 200 * time.Millisecond,

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1051,6 +1051,7 @@ func (environ *maasEnviron) waitForNodeDeployment(id instance.Id, timeout time.D
 }
 
 func (environ *maasEnviron) waitForNodeDeployment2(id instance.Id, timeout time.Duration) error {
+	// TODO(katco): 2016-08-09: lp:1611427
 	longAttempt := utils.AttemptStrategy{
 		Delay: 10 * time.Second,
 		Total: timeout,

--- a/provider/maas/maas2storage.go
+++ b/provider/maas/maas2storage.go
@@ -76,6 +76,8 @@ func (stor *maas2Storage) URL(name string) (string, error) {
 }
 
 // DefaultConsistencyStrategy implements storage.StorageReader
+//
+// TODO(katco): 2016-08-09: lp:1611427
 func (stor *maas2Storage) DefaultConsistencyStrategy() utils.AttemptStrategy {
 	return utils.AttemptStrategy{}
 }

--- a/service/service.go
+++ b/service/service.go
@@ -195,6 +195,8 @@ func listServicesCommand(initSystem string) (string, bool) {
 
 // installStartRetryAttempts defines how much InstallAndStart retries
 // upon Start failures.
+//
+// TODO(katco): 2016-08-09: lp:1611427
 var installStartRetryAttempts = utils.AttemptStrategy{
 	Total: 1 * time.Second,
 	Delay: 250 * time.Millisecond,

--- a/service/windows/password_windows.go
+++ b/service/windows/password_windows.go
@@ -67,6 +67,7 @@ func ensureJujudPasswordHelper(username, newPassword string, mgr ServiceManager,
 	return nil
 }
 
+// TODO(katco): 2016-08-09: lp:1611427
 var changeServicePasswordAttempts = utils.AttemptStrategy{
 	Total: 5 * time.Second,
 	Delay: 6 * time.Second,

--- a/state/backups/restore.go
+++ b/state/backups/restore.go
@@ -153,6 +153,7 @@ func newStateConnection(modelTag names.ModelTag, info *mongo.MongoInfo) (*state.
 		newStateConnDelay       = 15 * time.Second
 		newStateConnMinAttempts = 8
 	)
+	// TODO(katco): 2016-08-09: lp:1611427
 	attempt := utils.AttemptStrategy{Delay: newStateConnDelay, Min: newStateConnMinAttempts}
 	getEnviron := stateenvirons.GetNewEnvironFunc(environs.New)
 	for a := attempt.Start(); a.Next(); {

--- a/testing/constants.go
+++ b/testing/constants.go
@@ -21,6 +21,7 @@ const ShortWait = 50 * time.Millisecond
 // test suite
 const LongWait = 10 * time.Second
 
+// TODO(katco): 2016-08-09: lp:1611427
 var LongAttempt = &utils.AttemptStrategy{
 	Total: LongWait,
 	Delay: ShortWait,

--- a/worker/apicaller/connect.go
+++ b/worker/apicaller/connect.go
@@ -21,6 +21,8 @@ var (
 	// retry strategy for "handling" ErrNotProvisioned. It exists
 	// in the name of stability; as the code evolves, it would be
 	// great to see its function moved up a level or two.
+	//
+	// TODO(katco): 2016-08-09: lp:1611427
 	checkProvisionedStrategy = utils.AttemptStrategy{
 		Total: 1 * time.Minute,
 		Delay: 5 * time.Second,

--- a/worker/apicaller/retry_test.go
+++ b/worker/apicaller/retry_test.go
@@ -39,6 +39,7 @@ func (s *RetryStrategySuite) TestOnlyConnectSuccess(c *gc.C) {
 		errNotProvisioned, // first strategy attempt
 		nil,               // success on second strategy attempt
 	)
+	// TODO(katco): 2016-08-09: lp:1611427
 	strategy := utils.AttemptStrategy{Min: 3}
 	conn, err := strategyTest(stub, strategy, func(apiOpen api.OpenFunc) (api.Connection, error) {
 		return apicaller.OnlyConnect(&mockAgent{stub: stub}, apiOpen)
@@ -56,6 +57,7 @@ func (s *RetryStrategySuite) TestOnlyConnectOldPasswordSuccess(c *gc.C) {
 		errNotProvisioned, // first strategy attempt
 		nil,               // second strategy attempt
 	)
+	// TODO(katco): 2016-08-09: lp:1611427
 	strategy := utils.AttemptStrategy{Min: 3}
 	conn, err := strategyTest(stub, strategy, func(apiOpen api.OpenFunc) (api.Connection, error) {
 		return apicaller.OnlyConnect(&mockAgent{stub: stub}, apiOpen)
@@ -85,6 +87,7 @@ func checkWaitProvisionedError(c *gc.C, connect apicaller.ConnectFunc) (api.Conn
 		errNotProvisioned,       // second strategy attempt
 		errors.New("splat pow"), // third strategy attempt
 	)
+	// TODO(katco): 2016-08-09: lp:1611427
 	strategy := utils.AttemptStrategy{Min: 3}
 	conn, err := strategyTest(stub, strategy, func(apiOpen api.OpenFunc) (api.Connection, error) {
 		return connect(&mockAgent{stub: stub}, apiOpen)
@@ -113,6 +116,7 @@ func checkWaitNeverProvisioned(c *gc.C, connect apicaller.ConnectFunc) (api.Conn
 		errNotProvisioned, // second strategy attempt
 		errNotProvisioned, // third strategy attempt
 	)
+	// TODO(katco): 2016-08-09: lp:1611427
 	strategy := utils.AttemptStrategy{Min: 3}
 	conn, err := strategyTest(stub, strategy, func(apiOpen api.OpenFunc) (api.Connection, error) {
 		return connect(&mockAgent{stub: stub}, apiOpen)

--- a/worker/apicaller/util_test.go
+++ b/worker/apicaller/util_test.go
@@ -162,6 +162,7 @@ func lifeTest(c *gc.C, stub *testing.Stub, life apiagent.Life, test func() (api.
 	return test()
 }
 
+// TODO(katco): 2016-08-09: lp:1611427
 func strategyTest(stub *testing.Stub, strategy utils.AttemptStrategy, test func(api.OpenFunc) (api.Connection, error)) (api.Connection, error) {
 	unpatch := testing.PatchValue(apicaller.Strategy, strategy)
 	defer unpatch()

--- a/worker/peergrouper/initiate.go
+++ b/worker/peergrouper/initiate.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/mongo"
 )
 
+// TODO(katco): 2016-08-09: lp:1611427
 var initiateAttemptStrategy = utils.AttemptStrategy{
 	Total: 60 * time.Second,
 	Delay: 5 * time.Second,

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -69,6 +69,8 @@ type provisioner struct {
 
 // RetryStrategy defines the retry behavior when encountering a retryable
 // error during provisioning.
+//
+// TODO(katco): 2016-08-09: lp:1611427
 type RetryStrategy struct {
 	retryDelay time.Duration
 	retryCount int

--- a/worker/singular/mongo_test.go
+++ b/worker/singular/mongo_test.go
@@ -524,6 +524,7 @@ func startReplicaSet(n int) (_ []*gitjujutesting.MgoInstance, err error) {
 			Id:       i + 1,
 		})
 	}
+	// TODO(katco): 2016-08-09: lp:1611427
 	attempt := utils.AttemptStrategy{
 		Total: 60 * time.Second,
 		Delay: 1 * time.Second,

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -198,6 +198,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 
 	logger.Infof("hooks are retried %v", u.hookRetryStrategy.ShouldRetry)
 	retryHookChan := make(chan struct{}, 1)
+	// TODO(katco): 2016-08-09: This type is deprecated: lp:1611427
 	retryHookTimer := utils.NewBackoffTimer(utils.BackoffTimerConfig{
 		Min:    u.hookRetryStrategy.MinRetryTime,
 		Max:    u.hookRetryStrategy.MaxRetryTime,

--- a/worker/upgradesteps/worker.go
+++ b/worker/upgradesteps/worker.go
@@ -439,6 +439,7 @@ var IsMachineMaster = func(st *state.State, machineId string) (bool, error) {
 	return isMaster, nil
 }
 
+// TODO(katco): 2016-08-09: lp:1611427
 var getUpgradeRetryStrategy = func() utils.AttemptStrategy {
 	return utils.AttemptStrategy{
 		Delay: 2 * time.Minute,

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -490,6 +490,7 @@ func makeBumpedCurrentVersion() version.Binary {
 const maxUpgradeRetries = 3
 
 func (s *UpgradeSuite) setInstantRetryStrategy(c *gc.C) {
+	// TODO(katco): 2016-08-09: lp:1611427
 	s.PatchValue(&getUpgradeRetryStrategy, func() utils.AttemptStrategy {
 		c.Logf("setting instant retry strategy for upgrade: retries=%d", maxUpgradeRetries)
 		return utils.AttemptStrategy{


### PR DESCRIPTION
This helps address https://bugs.launchpad.net/juju-core/+bug/1611427

(Review request: http://reviews.vapour.ws/r/5402/)