### PR TITLE
Fix behaviour when more than one credential is available and maasrc is missing

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -292,9 +292,14 @@ var (
 	waitForAgentInitialisation = common.WaitForAgentInitialisation
 )
 
-var ambiguousCredentialError = errors.New(`
+var ambiguousDetectedCredentialError = errors.New(`
 more than one credential detected
 run juju autoload-credentials and specify a credential using the --credential argument`[1:],
+)
+
+var ambiguousCredentialError = errors.New(`
+more than one credential is available
+specify a credential using the --credential argument`[1:],
 )
 
 // Run connects to the environment specified on the command line and bootstraps
@@ -396,6 +401,9 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	credential, credentialName, regionName, err := modelcmd.GetCredentials(
 		store, c.Region, c.CredentialName, c.Cloud, cloud.Type,
 	)
+	if errors.Cause(err) == modelcmd.ErrMultipleCredentials {
+		return ambiguousCredentialError
+	}
 	if errors.IsNotFound(err) && c.CredentialName == "" {
 		// No credential was explicitly specified, and no credential
 		// was found in credentials.yaml; have the provider detect
@@ -403,7 +411,7 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		ctx.Verbosef("no credentials found, checking environment")
 		detected, err := modelcmd.DetectCredential(c.Cloud, cloud.Type)
 		if errors.Cause(err) == modelcmd.ErrMultipleCredentials {
-			return ambiguousCredentialError
+			return ambiguousDetectedCredentialError
 		} else if err != nil {
 			return errors.Trace(err)
 		}

--- a/cmd/modelcmd/credentials.go
+++ b/cmd/modelcmd/credentials.go
@@ -84,9 +84,13 @@ func credentialByName(
 		return nil, "", "", errors.Annotate(err, "loading credentials")
 	}
 	if credentialName == "" {
-		// No credential specified, so use the default for the cloud.
 		credentialName = cloudCredentials.DefaultCredential
-		if credentialName == "" && len(cloudCredentials.AuthCredentials) == 1 {
+		if credentialName == "" {
+			// No credential specified, but there's more than one.
+			if len(cloudCredentials.AuthCredentials) > 1 {
+				return nil, "", "", ErrMultipleCredentials
+			}
+			// No credential specified, so use the default for the cloud.
 			for credentialName = range cloudCredentials.AuthCredentials {
 			}
 		}

--- a/provider/maas/credentials.go
+++ b/provider/maas/credentials.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/juju/errors"
@@ -37,6 +38,9 @@ func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, e
 	// {"Server": "http://<ip>/MAAS", "OAuth": "<key>"}
 	maasrc := filepath.Join(utils.Home(), ".maasrc")
 	fileBytes, err := ioutil.ReadFile(maasrc)
+	if os.IsNotExist(err) {
+		return nil, errors.NotFoundf("maas credentials")
+	}
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/maas/credentials_test.go
+++ b/provider/maas/credentials_test.go
@@ -4,6 +4,7 @@
 package maas_test
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -74,4 +75,9 @@ func (s *credentialsSuite) TestDetectCredentialsNoServer(c *gc.C) {
 	)
 	expected.Label = "MAAS credential for unspecified server"
 	c.Assert(creds.AuthCredentials["default"], jc.DeepEquals, expected)
+}
+
+func (s *credentialsSuite) TestDetectCredentialsNoFile(c *gc.C) {
+	_, err := s.provider.DetectCredentials()
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }


### PR DESCRIPTION
There were two issues:
1. missing .maasrc file caused bootstrap to fail
2. credential handling at bootstrap did not handle having more than one available credential very well

What happens now is that if there's more than one credential available in credentials.yaml and none is specified, a better error is printed.

(Review request: http://reviews.vapour.ws/r/5403/)