### PR TITLE
Fix workers not restarting after aborted migration

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -291,7 +291,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		migrationFortressName: ifFullyUpgraded(fortress.Manifold()),
 		migrationInactiveFlagName: migrationflag.Manifold(migrationflag.ManifoldConfig{
 			APICallerName: apiCallerName,
-			Check:         migrationflag.IsNone,
+			Check:         migrationflag.IsTerminal,
 			NewFacade:     migrationflag.NewFacade,
 			NewWorker:     migrationflag.NewWorker,
 		}),

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -165,7 +165,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		migrationFortressName: ifNotDead(fortress.Manifold()),
 		migrationInactiveFlagName: ifNotDead(migrationflag.Manifold(migrationflag.ManifoldConfig{
 			APICallerName: apiCallerName,
-			Check:         migrationflag.IsNone,
+			Check:         migrationflag.IsTerminal,
 			NewFacade:     migrationflag.NewFacade,
 			NewWorker:     migrationflag.NewWorker,
 		})),

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -141,7 +141,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		migrationFortressName: fortress.Manifold(),
 		migrationInactiveFlagName: migrationflag.Manifold(migrationflag.ManifoldConfig{
 			APICallerName: apiCallerName,
-			Check:         migrationflag.IsNone,
+			Check:         migrationflag.IsTerminal,
 			NewFacade:     migrationflag.NewFacade,
 			NewWorker:     migrationflag.NewWorker,
 		}),

--- a/worker/migrationflag/worker.go
+++ b/worker/migrationflag/worker.go
@@ -25,9 +25,10 @@ type Facade interface {
 // Predicate defines a predicate.
 type Predicate func(migration.Phase) bool
 
-// IsNone is a predicate.
-func IsNone(phase migration.Phase) bool {
-	return phase == migration.NONE
+// IsTerminal returns true when the given phase means a migration has
+// finished (successfully or otherwise).
+func IsTerminal(phase migration.Phase) bool {
+	return phase.IsTerminal()
 }
 
 // Config holds the dependencies and configuration for a Worker.

--- a/worker/migrationflag/worker_test.go
+++ b/worker/migrationflag/worker_test.go
@@ -130,3 +130,22 @@ func (*WorkerSuite) TestNoRelevantPhaseChange(c *gc.C) {
 	workertest.CleanKill(c, worker)
 	checkCalls(c, stub, "Phase", "Watch", "Phase", "Phase", "Phase")
 }
+
+func (*WorkerSuite) TestIsTerminal(c *gc.C) {
+	tests := []struct {
+		phase    migration.Phase
+		expected bool
+	}{
+		{migration.QUIESCE, false},
+		{migration.SUCCESS, false},
+		{migration.ABORT, false},
+		{migration.NONE, true},
+		{migration.UNKNOWN, true},
+		{migration.ABORTDONE, true},
+		{migration.DONE, true},
+	}
+	for _, t := range tests {
+		c.Check(migrationflag.IsTerminal(t.phase), gc.Equals, t.expected,
+			gc.Commentf("for %s", t.phase))
+	}
+}

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -427,21 +427,26 @@ func (w *Worker) waitForActiveMigration() (coremigration.MigrationStatus, error)
 			return empty, w.catacomb.ErrDying()
 		case <-watcher.Changes():
 		}
+
 		status, err := w.config.Facade.GetMigrationStatus()
 		switch {
 		case params.IsCodeNotFound(err):
-			if err := w.config.Guard.Unlock(); err != nil {
-				return empty, errors.Trace(err)
+			// There's never been a migration.
+		case err == nil && status.Phase.IsTerminal():
+			// No migration in progress.
+			if modelHasMigrated(status.Phase) {
+				return empty, ErrMigrated
 			}
-			continue
 		case err != nil:
 			return empty, errors.Annotate(err, "retrieving migration status")
-		}
-		if modelHasMigrated(status.Phase) {
-			return empty, ErrMigrated
-		}
-		if !status.Phase.IsTerminal() {
+		default:
+			// Migration is in progress.
 			return status, nil
+		}
+
+		// While waiting for a migration, ensure the fortress is open.
+		if err := w.config.Guard.Unlock(); err != nil {
+			return empty, errors.Trace(err)
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes 2 problems:

1. The migrationflag manifold was only treating the NONE phase as "no migration in progress". Now, terminal phases are treated this way.
2.  The migrationmaster worker was only opening the fortress when there had never been a migration before, but not in the case of a previously aborted migration.

(Review request: http://reviews.vapour.ws/r/5404/)

```
$ juju bootstrap B lxd --upload-tools
$ juju bootstrap A lxd --upload-tools
$ JUJU_DEV_FEATURE_FLAGS=migration juju migrate default B
# migration aborts because a model named "default" already exists on B
```

Ensure the model workers restart:
```
$ juju debug-log -m A:controller --replay -T | grep -e dependency -e migrationmaster | tail -30
machine-0: 2016-08-10 01:33:31 INFO juju.worker.migrationmaster:1ca4c8 worker.go:223 setting migration phase to ABORT
machine-0: 2016-08-10 01:33:31 INFO juju.worker.migrationmaster:1ca4c8 worker.go:249 aborted: removing model from target controller
machine-0: 2016-08-10 01:33:31 ERROR juju.worker.migrationmaster:1ca4c8 worker.go:253 failed to remove model from target controller: model not found (not found)
machine-0: 2016-08-10 01:33:31 INFO juju.worker.migrationmaster:1ca4c8 worker.go:223 setting migration phase to ABORTDONE
machine-0: 2016-08-10 01:33:31 DEBUG juju.worker.dependency engine.go:492 "migration-master" manifold worker stopped: migration is no longer active
machine-0: 2016-08-10 01:33:31 DEBUG juju.worker.dependency engine.go:478 "migration-master" manifold worker started
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:492 "migration-inactive-flag" manifold worker stopped: migration flag value changed
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:492 "instance-poller" manifold worker stopped: "migration-inactive-flag" not running: dependency not available
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:492 "firewaller" manifold worker stopped: "migration-inactive-flag" not running: dependency not available
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:492 "application-scaler" manifold worker stopped: "migration-inactive-flag" not running: dependency not available
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:492 "charm-revision-updater" manifold worker stopped: "migration-inactive-flag" not running: dependency not available
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:492 "storage-provisioner" manifold worker stopped: "migration-inactive-flag" not running: dependency not available
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:492 "status-history-pruner" manifold worker stopped: "migration-inactive-flag" not running: dependency not available
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:492 "metric-worker" manifold worker stopped: "migration-inactive-flag" not running: dependency not available
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:492 "compute-provisioner" manifold worker stopped: "migration-inactive-flag" not running: dependency not available
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:492 "unit-assigner" manifold worker stopped: "migration-inactive-flag" not running: dependency not available
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:492 "space-importer" manifold worker stopped: "migration-inactive-flag" not running: dependency not available
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:492 "state-cleaner" manifold worker stopped: "migration-inactive-flag" not running: dependency not available
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:478 "migration-inactive-flag" manifold worker started
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:478 "state-cleaner" manifold worker started
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:478 "metric-worker" manifold worker started
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:478 "status-history-pruner" manifold worker started
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:478 "compute-provisioner" manifold worker started
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:478 "space-importer" manifold worker started
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:478 "instance-poller" manifold worker started
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:478 "charm-revision-updater" manifold worker started
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:478 "application-scaler" manifold worker started
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:478 "storage-provisioner" manifold worker started
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:478 "unit-assigner" manifold worker started
machine-0: 2016-08-10 01:33:36 DEBUG juju.worker.dependency engine.go:478 "firewaller" manifold worker started
```

