### PR TITLE
Remove the READONLY migration phase

### DIFF
--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -78,7 +78,7 @@ func (s *ClientSuite) TestGetMigrationStatus(c *gc.C) {
 				},
 			},
 			MigrationId:      "id",
-			Phase:            "READONLY",
+			Phase:            "PRECHECK",
 			PhaseChangedTime: timestamp,
 		}
 		return nil
@@ -90,7 +90,7 @@ func (s *ClientSuite) TestGetMigrationStatus(c *gc.C) {
 	c.Assert(status, gc.DeepEquals, migration.MigrationStatus{
 		MigrationId:      "id",
 		ModelUUID:        modelUUID,
-		Phase:            migration.READONLY,
+		Phase:            migration.PRECHECK,
 		PhaseChangedTime: timestamp,
 		TargetInfo: migration.TargetInfo{
 			ControllerTag: names.NewModelTag(controllerUUID),
@@ -252,7 +252,7 @@ func (s *ClientSuite) TestGetMinionReports(c *gc.C) {
 		out := result.(*params.MinionReports)
 		*out = params.MinionReports{
 			MigrationId:  "id",
-			Phase:        "READONLY",
+			Phase:        "PRECHECK",
 			SuccessCount: 4,
 			UnknownCount: 3,
 			UnknownSample: []string{
@@ -276,7 +276,7 @@ func (s *ClientSuite) TestGetMinionReports(c *gc.C) {
 	})
 	c.Assert(out, gc.DeepEquals, migration.MinionReports{
 		MigrationId:         "id",
-		Phase:               migration.READONLY,
+		Phase:               migration.PRECHECK,
 		SuccessCount:        4,
 		UnknownCount:        3,
 		SomeUnknownMachines: []string{"3", "4"},
@@ -312,7 +312,7 @@ func (s *ClientSuite) TestGetMinionReportsBadUnknownTag(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(_ string, _ int, _ string, _ string, _ interface{}, result interface{}) error {
 		out := result.(*params.MinionReports)
 		*out = params.MinionReports{
-			Phase:         "READONLY",
+			Phase:         "PRECHECK",
 			UnknownSample: []string{"carl"},
 		}
 		return nil
@@ -326,7 +326,7 @@ func (s *ClientSuite) TestGetMinionReportsBadFailedTag(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(_ string, _ int, _ string, _ string, _ interface{}, result interface{}) error {
 		out := result.(*params.MinionReports)
 		*out = params.MinionReports{
-			Phase:  "READONLY",
+			Phase:  "PRECHECK",
 			Failed: []string{"dave"},
 		}
 		return nil

--- a/apiserver/migrationmaster/facade_test.go
+++ b/apiserver/migrationmaster/facade_test.go
@@ -103,7 +103,7 @@ func (s *Suite) TestGetMigrationStatus(c *gc.C) {
 			},
 		},
 		MigrationId:      "id",
-		Phase:            "READONLY",
+		Phase:            "PRECHECK",
 		PhaseChangedTime: s.backend.migration.PhaseChangedTime(),
 	})
 }
@@ -261,7 +261,7 @@ func (s *Suite) TestGetMinionReports(c *gc.C) {
 	}
 	c.Assert(reports, gc.DeepEquals, params.MinionReports{
 		MigrationId:   "id",
-		Phase:         "READONLY",
+		Phase:         "PRECHECK",
 		SuccessCount:  3,
 		UnknownCount:  len(unknown),
 		UnknownSample: expectedSample,
@@ -334,7 +334,7 @@ func (m *stubMigration) Id() string {
 }
 
 func (m *stubMigration) Phase() (coremigration.Phase, error) {
-	return coremigration.READONLY, nil
+	return coremigration.PRECHECK, nil
 }
 
 func (m *stubMigration) PhaseChangedTime() time.Time {

--- a/apiserver/migrationminion/migrationminion_test.go
+++ b/apiserver/migrationminion/migrationminion_test.go
@@ -74,13 +74,13 @@ func (s *Suite) TestReport(c *gc.C) {
 	api := s.mustMakeAPI(c)
 	err := api.Report(params.MinionReport{
 		MigrationId: "id",
-		Phase:       "READONLY",
+		Phase:       "PRECHECK",
 		Success:     true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.stub.CheckCalls(c, []testing.StubCall{
 		{"ModelMigration", []interface{}{"id"}},
-		{"Report", []interface{}{s.authorizer.Tag, migration.READONLY, true}},
+		{"Report", []interface{}{s.authorizer.Tag, migration.PRECHECK, true}},
 	})
 }
 

--- a/apiserver/watcher_test.go
+++ b/apiserver/watcher_test.go
@@ -100,7 +100,7 @@ func (s *watcherSuite) TestMigrationStatusWatcher(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, params.MigrationStatus{
 		MigrationId:    "id",
 		Attempt:        2,
-		Phase:          "READONLY",
+		Phase:          "PRECHECK",
 		SourceAPIAddrs: []string{"1.2.3.4:5", "2.3.4.5:6", "3.4.5.6:7"},
 		SourceCACert:   "no worries",
 		TargetAPIAddrs: []string{"1.2.3.4:5555"},
@@ -201,7 +201,7 @@ func (m *fakeModelMigration) Attempt() (int, error) {
 }
 
 func (m *fakeModelMigration) Phase() (migration.Phase, error) {
-	return migration.READONLY, nil
+	return migration.PRECHECK, nil
 }
 
 func (m *fakeModelMigration) TargetInfo() (*migration.TargetInfo, error) {

--- a/core/migration/phase.go
+++ b/core/migration/phase.go
@@ -11,7 +11,6 @@ const (
 	UNKNOWN Phase = iota
 	NONE
 	QUIESCE
-	READONLY
 	PRECHECK
 	IMPORT
 	VALIDATION
@@ -28,7 +27,6 @@ var phaseNames = []string{
 	"UNKNOWN", // To catch uninitialised fields.
 	"NONE",    // For watchers to indicate there's never been a migration attempt.
 	"QUIESCE",
-	"READONLY",
 	"PRECHECK",
 	"IMPORT",
 	"VALIDATION",
@@ -85,7 +83,7 @@ func (p Phase) IsRunning() bool {
 		return false
 	}
 	switch p {
-	case QUIESCE, READONLY, PRECHECK, IMPORT, VALIDATION, SUCCESS:
+	case QUIESCE, PRECHECK, IMPORT, VALIDATION, SUCCESS:
 		return true
 	default:
 		return false
@@ -97,8 +95,7 @@ func (p Phase) IsRunning() bool {
 // The keys are the "from" states and the values enumerate the
 // possible "to" states.
 var validTransitions = map[Phase][]Phase{
-	QUIESCE:     {READONLY, ABORT},
-	READONLY:    {PRECHECK, ABORT},
+	QUIESCE:     {PRECHECK, ABORT},
 	PRECHECK:    {IMPORT, ABORT},
 	IMPORT:      {VALIDATION, ABORT},
 	VALIDATION:  {SUCCESS, ABORT},

--- a/core/migration/phase_test.go
+++ b/core/migration/phase_test.go
@@ -74,7 +74,7 @@ func (s *PhaseSuite) TestIsRunning(c *gc.C) {
 func (s *PhaseSuite) TestCanTransitionTo(c *gc.C) {
 	c.Check(migration.QUIESCE.CanTransitionTo(migration.SUCCESS), jc.IsFalse)
 	c.Check(migration.QUIESCE.CanTransitionTo(migration.ABORT), jc.IsTrue)
-	c.Check(migration.QUIESCE.CanTransitionTo(migration.READONLY), jc.IsTrue)
+	c.Check(migration.QUIESCE.CanTransitionTo(migration.PRECHECK), jc.IsTrue)
 	c.Check(migration.QUIESCE.CanTransitionTo(migration.Phase(-1)), jc.IsFalse)
 
 	c.Check(migration.ABORT.CanTransitionTo(migration.QUIESCE), jc.IsFalse)

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -275,13 +275,13 @@ func (s *ModelMigrationSuite) TestRefresh(c *gc.C) {
 	mig2, err := s.State2.LatestModelMigration()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = mig1.SetPhase(migration.READONLY)
+	err = mig1.SetPhase(migration.PRECHECK)
 	c.Assert(err, jc.ErrorIsNil)
 
 	assertPhase(c, mig2, migration.QUIESCE)
 	err = mig2.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	assertPhase(c, mig2, migration.READONLY)
+	assertPhase(c, mig2, migration.PRECHECK)
 }
 
 func (s *ModelMigrationSuite) TestSuccessfulPhaseTransitions(c *gc.C) {
@@ -295,7 +295,6 @@ func (s *ModelMigrationSuite) TestSuccessfulPhaseTransitions(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	phases := []migration.Phase{
-		migration.READONLY,
 		migration.PRECHECK,
 		migration.IMPORT,
 		migration.VALIDATION,
@@ -366,7 +365,6 @@ func (s *ModelMigrationSuite) TestREAPFAILEDCleanup(c *gc.C) {
 
 	// Advance the migration to REAPFAILED.
 	phases := []migration.Phase{
-		migration.READONLY,
 		migration.PRECHECK,
 		migration.IMPORT,
 		migration.VALIDATION,
@@ -404,18 +402,18 @@ func (s *ModelMigrationSuite) TestPhaseChangeRace(c *gc.C) {
 	defer state.SetBeforeHooks(c, s.State2, func() {
 		mig, err := s.State2.LatestModelMigration()
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(mig.SetPhase(migration.READONLY), jc.ErrorIsNil)
+		c.Assert(mig.SetPhase(migration.PRECHECK), jc.ErrorIsNil)
 	}).Check()
 
-	err = mig.SetPhase(migration.READONLY)
+	err = mig.SetPhase(migration.PRECHECK)
 	c.Assert(err, gc.ErrorMatches, "phase already changed")
 	assertPhase(c, mig, migration.QUIESCE)
 
 	// After a refresh it the phase change should be ok.
 	c.Assert(mig.Refresh(), jc.ErrorIsNil)
-	err = mig.SetPhase(migration.READONLY)
+	err = mig.SetPhase(migration.PRECHECK)
 	c.Assert(err, jc.ErrorIsNil)
-	assertPhase(c, mig, migration.READONLY)
+	assertPhase(c, mig, migration.PRECHECK)
 }
 
 func (s *ModelMigrationSuite) TestStatusMessage(c *gc.C) {
@@ -522,7 +520,7 @@ func (s *ModelMigrationSuite) TestWatchMigrationStatus(c *gc.C) {
 	wc.AssertOneChange()
 
 	// Change phase.
-	c.Assert(mig2.SetPhase(migration.READONLY), jc.ErrorIsNil)
+	c.Assert(mig2.SetPhase(migration.PRECHECK), jc.ErrorIsNil)
 	wc.AssertOneChange()
 
 	// End it.
@@ -636,7 +634,7 @@ func (s *ModelMigrationSuite) TestMinionReportWithOldPhase(c *gc.C) {
 	c.Check(reports.Succeeded, gc.HasLen, 0)
 
 	// Advance the migration
-	c.Assert(mig.SetPhase(migration.READONLY), jc.ErrorIsNil)
+	c.Assert(mig.SetPhase(migration.PRECHECK), jc.ErrorIsNil)
 
 	// Submit minion report for the old phase.
 	tag := names.NewMachineTag("42")

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -187,8 +187,6 @@ func (w *Worker) run() error {
 		switch phase {
 		case coremigration.QUIESCE:
 			phase, err = w.doQUIESCE()
-		case coremigration.READONLY:
-			phase, err = w.doREADONLY()
 		case coremigration.PRECHECK:
 			phase, err = w.doPRECHECK()
 		case coremigration.IMPORT:
@@ -272,12 +270,6 @@ func (w *Worker) setStatus(message string) error {
 func (w *Worker) doQUIESCE() (coremigration.Phase, error) {
 	// TODO(mjs) - Wait for all agents to report back.
 	// w.setInfoStatus("model quiescing to readonly mode")
-	return coremigration.READONLY, nil
-}
-
-func (w *Worker) doREADONLY() (coremigration.Phase, error) {
-	// TODO(mjs) - To be implemented.
-	// w.setInfoStatus("model in readonly mode")
 	return coremigration.PRECHECK, nil
 }
 

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -158,7 +158,6 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 		{"masterFacade.Watch", nil},
 		{"masterFacade.GetMigrationStatus", nil},
 		{"guard.Lockdown", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.READONLY}},
 		{"masterFacade.SetPhase", []interface{}{coremigration.PRECHECK}},
 		{"masterFacade.SetPhase", []interface{}{coremigration.IMPORT}},
 		{"masterFacade.Export", nil},
@@ -337,7 +336,6 @@ func (s *Suite) TestExportFailure(c *gc.C) {
 		{"masterFacade.Watch", nil},
 		{"masterFacade.GetMigrationStatus", nil},
 		{"guard.Lockdown", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.READONLY}},
 		{"masterFacade.SetPhase", []interface{}{coremigration.PRECHECK}},
 		{"masterFacade.SetPhase", []interface{}{coremigration.IMPORT}},
 		{"masterFacade.Export", nil},
@@ -363,7 +361,6 @@ func (s *Suite) TestAPIOpenFailure(c *gc.C) {
 		{"masterFacade.Watch", nil},
 		{"masterFacade.GetMigrationStatus", nil},
 		{"guard.Lockdown", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.READONLY}},
 		{"masterFacade.SetPhase", []interface{}{coremigration.PRECHECK}},
 		{"masterFacade.SetPhase", []interface{}{coremigration.IMPORT}},
 		{"masterFacade.Export", nil},
@@ -388,7 +385,6 @@ func (s *Suite) TestImportFailure(c *gc.C) {
 		{"masterFacade.Watch", nil},
 		{"masterFacade.GetMigrationStatus", nil},
 		{"guard.Lockdown", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.READONLY}},
 		{"masterFacade.SetPhase", []interface{}{coremigration.PRECHECK}},
 		{"masterFacade.SetPhase", []interface{}{coremigration.IMPORT}},
 		{"masterFacade.Export", nil},
@@ -528,11 +524,11 @@ func (s *Suite) TestMinionWaitWrongPhase(c *gc.C) {
 	// Have the phase in the minion reports be different from the
 	// migration status. This shouldn't happen but the migrationmaster
 	// should handle it.
-	s.masterFacade.minionReports.Phase = coremigration.READONLY
+	s.masterFacade.minionReports.Phase = coremigration.PRECHECK
 	s.triggerMinionReports()
 
 	err = workertest.CheckKilled(c, worker)
-	c.Assert(err, gc.ErrorMatches, `minion reports phase \(READONLY\) does not match migration phase \(SUCCESS\)`)
+	c.Assert(err, gc.ErrorMatches, `minion reports phase \(PRECHECK\) does not match migration phase \(SUCCESS\)`)
 }
 
 func (s *Suite) TestMinionWaitMigrationIdChanged(c *gc.C) {


### PR DESCRIPTION
It turns out there was no need to distinguish between QUIESCE and READONLY so READONLY has been removed.

# QA steps

To help verify that migrations still work:

```shell
$ juju bootstrap B lxd --upload-tools
$ juju bootstrap A lxd --upload-tools
$ juju add-model foo
$ juju deploy ubuntu
# wait...
$ JUJU_DEV_FEATURE_FLAGS=migration juju migrate foo B
# wait...
$ juju switch B:foo
$ juju status
# ensure that agents are happy
```

(Review request: http://reviews.vapour.ws/r/5405/)