### PR TITLE
Send structured data over the streaming log api.

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -4,7 +4,6 @@
 package api_test
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -357,10 +356,9 @@ func (s *clientSuite) TestWatchDebugLogConnected(c *gc.C) {
 	// Use the no tail option so we don't try to start a tailing cursor
 	// on the oplog when there is no oplog configured in mongo as the tests
 	// don't set up mongo in replicaset mode.
-	reader, err := client.WatchDebugLog(api.DebugLogParams{NoTail: true})
+	messages, err := client.WatchDebugLog(api.DebugLogParams{NoTail: true})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(reader, gc.NotNil)
-	reader.Close()
+	c.Assert(messages, gc.NotNil)
 }
 
 func (s *clientSuite) TestConnectStreamRequiresSlashPathPrefix(c *gc.C) {
@@ -407,7 +405,8 @@ func (s *clientSuite) TestConnectStreamErrorReadError(c *gc.C) {
 }
 
 func (s *clientSuite) TestWatchDebugLogParamsEncoded(c *gc.C) {
-	s.PatchValue(api.WebsocketDialConfig, echoURL(c))
+	catcher := urlCatcher{}
+	s.PatchValue(api.WebsocketDialConfig, catcher.recordLocation)
 
 	params := api.DebugLogParams{
 		IncludeEntity: []string{"a", "b"},
@@ -422,10 +421,10 @@ func (s *clientSuite) TestWatchDebugLogParamsEncoded(c *gc.C) {
 	}
 
 	client := s.APIState.Client()
-	reader, err := client.WatchDebugLog(params)
+	_, err := client.WatchDebugLog(params)
 	c.Assert(err, jc.ErrorIsNil)
 
-	connectURL := connectURLFromReader(c, reader)
+	connectURL := catcher.location
 	values := connectURL.Query()
 	c.Assert(values, jc.DeepEquals, url.Values{
 		"includeEntity": params.IncludeEntity,
@@ -441,8 +440,8 @@ func (s *clientSuite) TestWatchDebugLogParamsEncoded(c *gc.C) {
 }
 
 func (s *clientSuite) TestConnectStreamAtUUIDPath(c *gc.C) {
-	s.PatchValue(api.WebsocketDialConfig, echoURL(c))
-	// If the server supports it, we should log at "/model/UUID/log"
+	catcher := urlCatcher{}
+	s.PatchValue(api.WebsocketDialConfig, catcher.recordLocation)
 	environ, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	info := s.APIInfo(c)
@@ -450,9 +449,9 @@ func (s *clientSuite) TestConnectStreamAtUUIDPath(c *gc.C) {
 	apistate, err := api.Open(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	defer apistate.Close()
-	reader, err := apistate.ConnectStream("/path", nil)
+	_, err = apistate.ConnectStream("/path", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	connectURL := connectURLFromReader(c, reader)
+	connectURL := catcher.location
 	c.Assert(connectURL.Path, gc.Matches, fmt.Sprintf("/model/%s/path", environ.UUID()))
 }
 
@@ -529,25 +528,17 @@ func (r *badReader) Read(p []byte) (n int, err error) {
 	return 0, r.err
 }
 
-func echoURL(c *gc.C) func(*websocket.Config) (base.Stream, error) {
-	return func(config *websocket.Config) (base.Stream, error) {
-		pr, pw := io.Pipe()
-		go func() {
-			fmt.Fprintf(pw, "null\n")
-			fmt.Fprintf(pw, "%s\n", config.Location)
-		}()
-		return fakeStreamReader{pr}, nil
-	}
+type urlCatcher struct {
+	location *url.URL
 }
 
-func connectURLFromReader(c *gc.C, rc io.ReadCloser) *url.URL {
-	bufReader := bufio.NewReader(rc)
-	location, err := bufReader.ReadString('\n')
-	c.Assert(err, jc.ErrorIsNil)
-	connectURL, err := url.Parse(strings.TrimSpace(location))
-	c.Assert(err, jc.ErrorIsNil)
-	rc.Close()
-	return connectURL
+func (u *urlCatcher) recordLocation(config *websocket.Config) (base.Stream, error) {
+	u.location = config.Location
+	pr, pw := io.Pipe()
+	go func() {
+		fmt.Fprintf(pw, "null\n")
+	}()
+	return fakeStreamReader{pr}, nil
 }
 
 type fakeStreamReader struct {
@@ -562,13 +553,13 @@ func (s fakeStreamReader) Close() error {
 }
 
 func (s fakeStreamReader) Write([]byte) (int, error) {
-	panic("not implemented")
+	return 0, errors.NotImplementedf("Write")
 }
 
 func (s fakeStreamReader) ReadJSON(v interface{}) error {
-	panic("not implemented")
+	return errors.NotImplementedf("ReadJSON")
 }
 
 func (s fakeStreamReader) WriteJSON(v interface{}) error {
-	panic("not implemented")
+	return errors.NotImplementedf("WriteJSON")
 }

--- a/api/state_macaroon_test.go
+++ b/api/state_macaroon_test.go
@@ -60,7 +60,8 @@ func (s *macaroonLoginSuite) TestUnknownUserLogin(c *gc.C) {
 }
 
 func (s *macaroonLoginSuite) TestConnectStream(c *gc.C) {
-	s.PatchValue(api.WebsocketDialConfig, echoURL(c))
+	catcher := urlCatcher{}
+	s.PatchValue(api.WebsocketDialConfig, catcher.recordLocation)
 
 	dischargeCount := 0
 	s.DischargerLogin = func() string {
@@ -77,13 +78,14 @@ func (s *macaroonLoginSuite) TestConnectStream(c *gc.C) {
 	conn, err := s.client.ConnectStream("/path", nil)
 	c.Assert(err, gc.IsNil)
 	defer conn.Close()
-	connectURL := connectURLFromReader(c, conn)
+	connectURL := catcher.location
 	c.Assert(connectURL.Path, gc.Equals, "/model/"+s.State.ModelTag().Id()+"/path")
 	c.Assert(dischargeCount, gc.Equals, 1)
 }
 
 func (s *macaroonLoginSuite) TestConnectStreamWithoutLogin(c *gc.C) {
-	s.PatchValue(api.WebsocketDialConfig, echoURL(c))
+	catcher := urlCatcher{}
+	s.PatchValue(api.WebsocketDialConfig, catcher.recordLocation)
 
 	conn, err := s.client.ConnectStream("/path", nil)
 	c.Assert(err, gc.ErrorMatches, `cannot use ConnectStream without logging in`)

--- a/apiserver/debuglog_db_internal_test.go
+++ b/apiserver/debuglog_db_internal_test.go
@@ -12,6 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -244,7 +245,17 @@ func (s *fakeDebugLogSocket) sendError(err error) {
 	s.writes <- fmt.Sprintf("err: %v", err)
 }
 
-func (s *fakeDebugLogSocket) Write(buf []byte) (int, error) {
-	s.writes <- string(buf)
-	return len(buf), nil
+func (s *fakeDebugLogSocket) sendLogRecord(r *params.LogMessage) error {
+	s.writes <- fmt.Sprintf("%s: %s %s %s %s %s\n",
+		r.Entity,
+		s.formatTime(r.Timestamp),
+		r.Severity,
+		r.Module,
+		r.Location,
+		r.Message)
+	return nil
+}
+
+func (c *fakeDebugLogSocket) formatTime(t time.Time) string {
+	return t.In(time.UTC).Format("2006-01-02 15:04:05")
 }

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -180,14 +180,15 @@ func (ctxt *httpContext) stop() <-chan struct{} {
 
 // sendJSON writes a JSON-encoded response value
 // to the given writer along with a trailing newline.
-func sendJSON(w io.Writer, response interface{}) {
+func sendJSON(w io.Writer, response interface{}) error {
 	body, err := json.Marshal(response)
 	if err != nil {
 		logger.Errorf("cannot marshal JSON result %#v: %v", response, err)
-		return
+		return err
 	}
 	body = append(body, '\n')
-	w.Write(body)
+	_, err = w.Write(body)
+	return err
 }
 
 // sendStatusAndJSON sends an HTTP status code and

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -707,3 +707,13 @@ type GUIVersionRequest struct {
 	// Version holds the Juju GUI version number.
 	Version version.Number `json:"version"`
 }
+
+// LogMessage is a structured logging entry.
+type LogMessage struct {
+	Entity    string    `json:"tag"`
+	Timestamp time.Time `json:"ts"`
+	Severity  string    `json:"sev"`
+	Module    string    `json:"mod"`
+	Location  string    `json:"loc"`
+	Message   string    `json:"msg"`
+}

--- a/cmd/juju/commands/debuglog.go
+++ b/cmd/juju/commands/debuglog.go
@@ -5,7 +5,7 @@ package commands
 
 import (
 	"fmt"
-	"io"
+	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/loggo"
@@ -143,7 +143,7 @@ func (c *debugLogCommand) Init(args []string) error {
 }
 
 type DebugLogAPI interface {
-	WatchDebugLog(params api.DebugLogParams) (io.ReadCloser, error)
+	WatchDebugLog(params api.DebugLogParams) (<-chan api.LogMessage, error)
 	Close() error
 }
 
@@ -158,11 +158,32 @@ func (c *debugLogCommand) Run(ctx *cmd.Context) (err error) {
 		return err
 	}
 	defer client.Close()
-	debugLog, err := client.WatchDebugLog(c.params)
+	messages, err := client.WatchDebugLog(c.params)
 	if err != nil {
 		return err
 	}
-	defer debugLog.Close()
-	_, err = io.Copy(ctx.Stdout, debugLog)
-	return err
+	for {
+		msg, ok := <-messages
+		if !ok {
+			break
+		}
+		fmt.Fprint(ctx.Stdout, c.formatLogRecord(msg))
+	}
+
+	return nil
+}
+
+func (c *debugLogCommand) formatLogRecord(r api.LogMessage) string {
+	return fmt.Sprintf("%s: %s %s %s %s %s\n",
+		r.Entity,
+		c.formatTime(r.Timestamp),
+		r.Severity,
+		r.Module,
+		r.Location,
+		r.Message,
+	)
+}
+
+func (c *debugLogCommand) formatTime(t time.Time) string {
+	return t.In(time.UTC).Format("2006-01-02 15:04:05")
 }


### PR DESCRIPTION
In order to have debug-log do intelligent things with the logging, it needs to have structured data.

This change makes the streaming api send structured JSON messages rather than lines of text.

(Review request: http://reviews.vapour.ws/r/5406/)