### PR TITLE
Migration master/minion synchronisation in QUIESCE phase

### DIFF
--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -268,17 +268,14 @@ func (w *Worker) setStatus(message string) error {
 }
 
 func (w *Worker) doQUIESCE(status coremigration.MigrationStatus) (coremigration.Phase, error) {
-	w.setInfoStatus("model quiescing to readonly mode")
-	err := w.waitForMinions(status, failFast, "quiescing")
-	switch errors.Cause(err) {
-	case nil:
-		return coremigration.PRECHECK, nil
-	case errMinionReportFailed, errMinionReportTimeout:
-		w.setErrorStatus("quiescing to read-only mode failed: %v", err)
-		return coremigration.ABORT, nil
-	default:
+	ok, err := w.waitForMinions(status, failFast, "quiescing")
+	if err != nil {
 		return coremigration.UNKNOWN, errors.Trace(err)
 	}
+	if !ok {
+		return coremigration.ABORT, nil
+	}
+	return coremigration.PRECHECK, nil
 }
 
 func (w *Worker) doPRECHECK() (coremigration.Phase, error) {
@@ -359,17 +356,14 @@ func (w *Worker) activateModel(targetInfo coremigration.TargetInfo, modelUUID st
 }
 
 func (w *Worker) doSUCCESS(status coremigration.MigrationStatus) (coremigration.Phase, error) {
-	err := w.waitForMinions(status, waitForAll, "successful")
-	switch errors.Cause(err) {
-	case nil, errMinionReportFailed, errMinionReportTimeout:
-		// There's no turning back from SUCCESS - any problems should
-		// have been picked up in VALIDATION. After the minion wait in
-		// the SUCCESS phase, the migration can only proceed to
-		// LOGTRANSFER.
-		return coremigration.LOGTRANSFER, nil
-	default:
+	_, err := w.waitForMinions(status, waitForAll, "successful")
+	if err != nil {
 		return coremigration.UNKNOWN, errors.Trace(err)
 	}
+	// There's no turning back from SUCCESS - any problems should have
+	// been picked up in VALIDATION. After the minion wait in the
+	// SUCCESS phase, the migration can only proceed to LOGTRANSFER.
+	return coremigration.LOGTRANSFER, nil
 }
 
 func (w *Worker) doLOGTRANSFER() (coremigration.Phase, error) {
@@ -455,10 +449,11 @@ func (w *Worker) waitForActiveMigration() (coremigration.MigrationStatus, error)
 const failFast = false  // Stop waiting at first minion failure report
 const waitForAll = true // Wait for all minion reports to arrive (or timeout)
 
-var errMinionReportTimeout = errors.New("timed out waiting for all agents to report")
-var errMinionReportFailed = errors.New("one or more agents failed a migration phase")
-
-func (w *Worker) waitForMinions(status coremigration.MigrationStatus, waitPolicy bool, infoPrefix string) error {
+func (w *Worker) waitForMinions(
+	status coremigration.MigrationStatus,
+	waitPolicy bool,
+	infoPrefix string,
+) (success bool, err error) {
 	clk := w.config.Clock
 	maxWait := maxMinionWait - clk.Now().Sub(status.PhaseChangedTime)
 	timeout := clk.After(maxWait)
@@ -469,10 +464,10 @@ func (w *Worker) waitForMinions(status coremigration.MigrationStatus, waitPolicy
 
 	watch, err := w.config.Facade.WatchMinionReports()
 	if err != nil {
-		return errors.Trace(err)
+		return false, errors.Trace(err)
 	}
 	if err := w.catacomb.Add(watch); err != nil {
-		return errors.Trace(err)
+		return false, errors.Trace(err)
 	}
 
 	logProgress := clk.After(minionWaitLogInterval)
@@ -481,34 +476,37 @@ func (w *Worker) waitForMinions(status coremigration.MigrationStatus, waitPolicy
 	for {
 		select {
 		case <-w.catacomb.Dying():
-			return w.catacomb.ErrDying()
+			return false, w.catacomb.ErrDying()
 
 		case <-timeout:
 			w.logger.Errorf(formatMinionTimeout(reports, status))
-			return errors.Trace(errMinionReportTimeout)
+			w.setErrorStatus("%s: timed out waiting for all agents to report", infoPrefix)
+			return false, nil
 
 		case <-watch.Changes():
 			var err error
 			reports, err = w.config.Facade.GetMinionReports()
 			if err != nil {
-				return errors.Trace(err)
+				return false, errors.Trace(err)
 			}
 			if err := validateMinionReports(reports, status); err != nil {
-				return errors.Trace(err)
+				return false, errors.Trace(err)
 			}
 			failures := len(reports.FailedMachines) + len(reports.FailedUnits)
 			if failures > 0 {
 				w.logger.Errorf(formatMinionFailure(reports))
+				w.setErrorStatus("%s: some agents reported failure", infoPrefix)
 				if waitPolicy == failFast {
-					return errors.Trace(errMinionReportFailed)
+					return false, nil
 				}
 			}
 			if reports.UnknownCount == 0 {
 				w.logger.Infof(formatMinionWaitDone(reports))
 				if failures > 0 {
-					return errors.Trace(errMinionReportFailed)
+					w.setErrorStatus("%s: some agents reported failure", infoPrefix)
+					return false, nil
 				}
-				return nil
+				return true, nil
 			}
 
 		case <-logProgress:

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -140,13 +140,28 @@ func (s *Suite) triggerMinionReports() {
 	}
 }
 
+func (s *Suite) queueMinionReports(r coremigration.MinionReports) {
+	s.masterFacade.minionReports = append(s.masterFacade.minionReports, r)
+	s.triggerMinionReports()
+}
+
+func (s *Suite) queuePassingMinionReports(p coremigration.Phase) {
+	s.queueMinionReports(coremigration.MinionReports{
+		MigrationId:  "model-uuid:2",
+		Phase:        p,
+		SuccessCount: 5,
+		UnknownCount: 0,
+	})
+}
+
 func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 	s.config.UploadBinaries = makeStubUploadBinaries(s.stub)
 	worker, err := migrationmaster.New(s.config)
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.DirtyKill(c, worker)
 	s.triggerMigration()
-	s.triggerMinionReports()
+	s.queuePassingMinionReports(coremigration.QUIESCE)
+	s.queuePassingMinionReports(coremigration.SUCCESS)
 
 	err = workertest.CheckKilled(c, worker)
 	c.Assert(errors.Cause(err), gc.Equals, migrationmaster.ErrMigrated)
@@ -155,10 +170,20 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 	// connection to the target controller was made, the model was
 	// imported and then the migration completed.
 	s.stub.CheckCalls(c, []jujutesting.StubCall{
+		// Wait for migration to start.
 		{"masterFacade.Watch", nil},
 		{"masterFacade.GetMigrationStatus", nil},
 		{"guard.Lockdown", nil},
+
+		// QUIESCE
+		{"masterFacade.WatchMinionReports", nil},
+		{"masterFacade.GetMinionReports", nil},
 		{"masterFacade.SetPhase", []interface{}{coremigration.PRECHECK}},
+
+		// PRECHECK
+		// Nothing yet.
+
+		//IMPORT
 		{"masterFacade.SetPhase", []interface{}{coremigration.IMPORT}},
 		{"masterFacade.Export", nil},
 		apiOpenCallController,
@@ -179,10 +204,16 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 		activateCall,
 		connCloseCall,
 		{"masterFacade.SetPhase", []interface{}{coremigration.SUCCESS}},
+
+		// SUCCESS
 		{"masterFacade.WatchMinionReports", nil},
 		{"masterFacade.GetMinionReports", nil},
 		{"masterFacade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
+
+		// LOGTRANSFER
 		{"masterFacade.SetPhase", []interface{}{coremigration.REAP}},
+
+		// REAP
 		{"masterFacade.Reap", nil},
 		{"masterFacade.SetPhase", []interface{}{coremigration.DONE}},
 	})
@@ -195,7 +226,7 @@ func (s *Suite) TestMigrationResume(c *gc.C) {
 	defer workertest.DirtyKill(c, worker)
 	s.masterFacade.status.Phase = coremigration.SUCCESS
 	s.triggerMigration()
-	s.triggerMinionReports()
+	s.queuePassingMinionReports(coremigration.SUCCESS)
 
 	err = workertest.CheckKilled(c, worker)
 	c.Assert(errors.Cause(err), gc.Equals, migrationmaster.ErrMigrated)
@@ -322,7 +353,46 @@ func (s *Suite) TestLockdownError(c *gc.C) {
 	})
 }
 
+func (s *Suite) TestQUIESCEMinionWaitWatchError(c *gc.C) {
+	s.checkMinionWaitWatchError(c, coremigration.QUIESCE)
+}
+
+func (s *Suite) TestQUIESCEMinionWaitGetError(c *gc.C) {
+	s.checkMinionWaitGetError(c, coremigration.QUIESCE)
+}
+
+func (s *Suite) TestQUIESCEFailedAgent(c *gc.C) {
+	s.masterFacade.status.Phase = coremigration.QUIESCE
+
+	worker, err := migrationmaster.New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.DirtyKill(c, worker)
+	s.triggerMigration()
+	s.queueMinionReports(coremigration.MinionReports{
+		MigrationId:    "model-uuid:2",
+		Phase:          coremigration.QUIESCE,
+		FailedMachines: []string{"42"},
+	})
+
+	err = workertest.CheckKilled(c, worker)
+	c.Assert(err, gc.Equals, migrationmaster.ErrInactive)
+
+	s.stub.CheckCalls(c, []jujutesting.StubCall{
+		{"masterFacade.Watch", nil},
+		{"masterFacade.GetMigrationStatus", nil},
+		{"guard.Lockdown", nil},
+		{"masterFacade.WatchMinionReports", nil},
+		{"masterFacade.GetMinionReports", nil},
+		{"masterFacade.SetPhase", []interface{}{coremigration.ABORT}},
+		apiOpenCallController,
+		abortCall,
+		connCloseCall,
+		{"masterFacade.SetPhase", []interface{}{coremigration.ABORTDONE}},
+	})
+}
+
 func (s *Suite) TestExportFailure(c *gc.C) {
+	s.masterFacade.status.Phase = coremigration.IMPORT
 	s.masterFacade.exportErr = errors.New("boom")
 	worker, err := migrationmaster.New(s.config)
 	c.Assert(err, jc.ErrorIsNil)
@@ -336,8 +406,6 @@ func (s *Suite) TestExportFailure(c *gc.C) {
 		{"masterFacade.Watch", nil},
 		{"masterFacade.GetMigrationStatus", nil},
 		{"guard.Lockdown", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.PRECHECK}},
-		{"masterFacade.SetPhase", []interface{}{coremigration.IMPORT}},
 		{"masterFacade.Export", nil},
 		{"masterFacade.SetPhase", []interface{}{coremigration.ABORT}},
 		apiOpenCallController,
@@ -348,6 +416,7 @@ func (s *Suite) TestExportFailure(c *gc.C) {
 }
 
 func (s *Suite) TestAPIOpenFailure(c *gc.C) {
+	s.masterFacade.status.Phase = coremigration.IMPORT
 	worker, err := migrationmaster.New(s.config)
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.DirtyKill(c, worker)
@@ -361,8 +430,6 @@ func (s *Suite) TestAPIOpenFailure(c *gc.C) {
 		{"masterFacade.Watch", nil},
 		{"masterFacade.GetMigrationStatus", nil},
 		{"guard.Lockdown", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.PRECHECK}},
-		{"masterFacade.SetPhase", []interface{}{coremigration.IMPORT}},
 		{"masterFacade.Export", nil},
 		apiOpenCallController,
 		{"masterFacade.SetPhase", []interface{}{coremigration.ABORT}},
@@ -372,6 +439,7 @@ func (s *Suite) TestAPIOpenFailure(c *gc.C) {
 }
 
 func (s *Suite) TestImportFailure(c *gc.C) {
+	s.masterFacade.status.Phase = coremigration.IMPORT
 	worker, err := migrationmaster.New(s.config)
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.DirtyKill(c, worker)
@@ -385,8 +453,6 @@ func (s *Suite) TestImportFailure(c *gc.C) {
 		{"masterFacade.Watch", nil},
 		{"masterFacade.GetMigrationStatus", nil},
 		{"guard.Lockdown", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.PRECHECK}},
-		{"masterFacade.SetPhase", []interface{}{coremigration.IMPORT}},
 		{"masterFacade.Export", nil},
 		apiOpenCallController,
 		importCall,
@@ -399,42 +465,28 @@ func (s *Suite) TestImportFailure(c *gc.C) {
 	})
 }
 
-func (s *Suite) TestMinionWaitWatchError(c *gc.C) {
-	worker, err := migrationmaster.New(s.config)
-	c.Assert(err, jc.ErrorIsNil)
-	defer workertest.DirtyKill(c, worker)
-	s.masterFacade.minionReportsWatchErr = errors.New("boom")
-	s.masterFacade.status.Phase = coremigration.SUCCESS
-	s.triggerMigration()
-
-	err = workertest.CheckKilled(c, worker)
-	c.Assert(err, gc.ErrorMatches, "boom")
+func (s *Suite) TestSUCCESSMinionWaitWatchError(c *gc.C) {
+	s.checkMinionWaitWatchError(c, coremigration.SUCCESS)
 }
 
-func (s *Suite) TestMinionWaitGetError(c *gc.C) {
-	worker, err := migrationmaster.New(s.config)
-	c.Assert(err, jc.ErrorIsNil)
-	defer workertest.DirtyKill(c, worker)
-	s.masterFacade.minionReportsErr = errors.New("boom")
-	s.masterFacade.status.Phase = coremigration.SUCCESS
-	s.triggerMigration()
-	s.triggerMinionReports()
-
-	err = workertest.CheckKilled(c, worker)
-	c.Assert(err, gc.ErrorMatches, "boom")
+func (s *Suite) TestSUCCESSMinionWaitGetError(c *gc.C) {
+	s.checkMinionWaitGetError(c, coremigration.SUCCESS)
 }
 
-func (s *Suite) TestMinionWaitSUCCESSFailedMachine(c *gc.C) {
+func (s *Suite) TestSUCCESSMinionWaitFailedMachine(c *gc.C) {
 	// With the SUCCESS phase the master should wait for all reports,
 	// continuing even if some minions report failure.
 
-	s.masterFacade.minionReports.FailedMachines = []string{"42"}
 	worker, err := migrationmaster.New(s.config)
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.DirtyKill(c, worker)
 	s.masterFacade.status.Phase = coremigration.SUCCESS
 	s.triggerMigration()
-	s.triggerMinionReports()
+	s.queueMinionReports(coremigration.MinionReports{
+		MigrationId:    "model-uuid:2",
+		Phase:          coremigration.SUCCESS,
+		FailedMachines: []string{"42"},
+	})
 
 	err = workertest.CheckKilled(c, worker)
 	c.Assert(err, gc.Equals, migrationmaster.ErrMigrated)
@@ -452,16 +504,19 @@ func (s *Suite) TestMinionWaitSUCCESSFailedMachine(c *gc.C) {
 	})
 }
 
-func (s *Suite) TestMinionWaitSUCCESSFailedUnit(c *gc.C) {
-	// See note for TestMinionWaitSUCCESSFailedMachine above.
+func (s *Suite) TestSUCCESSMinionWaitFailedUnit(c *gc.C) {
+	// See note for TestMinionWaitFailedMachine above.
 
-	s.masterFacade.minionReports.FailedUnits = []string{"foo/2"}
 	worker, err := migrationmaster.New(s.config)
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.DirtyKill(c, worker)
 	s.masterFacade.status.Phase = coremigration.SUCCESS
 	s.triggerMigration()
-	s.triggerMinionReports()
+	s.queueMinionReports(coremigration.MinionReports{
+		MigrationId: "model-uuid:2",
+		Phase:       coremigration.SUCCESS,
+		FailedUnits: []string{"foo/2"},
+	})
 
 	err = workertest.CheckKilled(c, worker)
 	c.Assert(err, gc.Equals, migrationmaster.ErrMigrated)
@@ -479,7 +534,7 @@ func (s *Suite) TestMinionWaitSUCCESSFailedUnit(c *gc.C) {
 	})
 }
 
-func (s *Suite) TestMinionWaitSUCCESSTimeout(c *gc.C) {
+func (s *Suite) TestSUCCESSMinionWaitTimeout(c *gc.C) {
 	// The SUCCESS phase is special in that even if some minions fail
 	// to report the migration should continue. There's no turning
 	// back from SUCCESS.
@@ -524,8 +579,7 @@ func (s *Suite) TestMinionWaitWrongPhase(c *gc.C) {
 	// Have the phase in the minion reports be different from the
 	// migration status. This shouldn't happen but the migrationmaster
 	// should handle it.
-	s.masterFacade.minionReports.Phase = coremigration.PRECHECK
-	s.triggerMinionReports()
+	s.queuePassingMinionReports(coremigration.PRECHECK)
 
 	err = workertest.CheckKilled(c, worker)
 	c.Assert(err, gc.ErrorMatches, `minion reports phase \(PRECHECK\) does not match migration phase \(SUCCESS\)`)
@@ -541,8 +595,10 @@ func (s *Suite) TestMinionWaitMigrationIdChanged(c *gc.C) {
 	// Have the migration id in the minion reports be different from
 	// the migration status. This shouldn't happen but the
 	// migrationmaster should handle it.
-	s.masterFacade.minionReports.MigrationId = "blah"
-	s.triggerMinionReports()
+	s.queueMinionReports(coremigration.MinionReports{
+		MigrationId: "blah",
+		Phase:       coremigration.SUCCESS,
+	})
 
 	err = workertest.CheckKilled(c, worker)
 	c.Assert(err, gc.ErrorMatches,
@@ -557,7 +613,35 @@ func (s *Suite) waitForStubCalls(c *gc.C, expectedCallNames []string) {
 			return
 		}
 	}
-	c.Fatalf("failed to see expected calls. saw: %v", callNames)
+	c.Fatalf("failed to see expected calls\nobtained: %v\nexpected: %v",
+		callNames, expectedCallNames)
+}
+
+func (s *Suite) checkMinionWaitWatchError(c *gc.C, phase coremigration.Phase) {
+	s.masterFacade.minionReportsWatchErr = errors.New("boom")
+	s.masterFacade.status.Phase = phase
+
+	worker, err := migrationmaster.New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.DirtyKill(c, worker)
+	s.triggerMigration()
+
+	err = workertest.CheckKilled(c, worker)
+	c.Assert(err, gc.ErrorMatches, "boom")
+}
+
+func (s *Suite) checkMinionWaitGetError(c *gc.C, phase coremigration.Phase) {
+	s.masterFacade.minionReportsErr = errors.New("boom")
+	s.masterFacade.status.Phase = phase
+
+	worker, err := migrationmaster.New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.DirtyKill(c, worker)
+	s.triggerMigration()
+	s.triggerMinionReports()
+
+	err = workertest.CheckKilled(c, worker)
+	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
 func stubCallNames(stub *jujutesting.Stub) []string {
@@ -609,14 +693,6 @@ func newStubMasterFacade(stub *jujutesting.Stub, now time.Time) *stubMasterFacad
 		// Give minionReportsChanges a larger-than-required buffer to
 		// support waits at a number of phases.
 		minionReportsChanges: make(chan struct{}, 999),
-
-		// Default to happy state. Test may wish to tweak.
-		minionReports: coremigration.MinionReports{
-			MigrationId:  "model-uuid:2",
-			Phase:        coremigration.SUCCESS,
-			SuccessCount: 5,
-			UnknownCount: 0,
-		},
 	}
 }
 
@@ -634,7 +710,7 @@ type stubMasterFacade struct {
 
 	minionReportsChanges  chan struct{}
 	minionReportsWatchErr error
-	minionReports         coremigration.MinionReports
+	minionReports         []coremigration.MinionReports
 	minionReportsErr      error
 }
 
@@ -667,7 +743,13 @@ func (c *stubMasterFacade) GetMinionReports() (coremigration.MinionReports, erro
 	if c.minionReportsErr != nil {
 		return coremigration.MinionReports{}, c.minionReportsErr
 	}
-	return c.minionReports, nil
+	if len(c.minionReports) == 0 {
+		return coremigration.MinionReports{}, errors.NotFoundf("reports")
+
+	}
+	r := c.minionReports[0]
+	c.minionReports = c.minionReports[1:]
+	return r, nil
 }
 
 func (c *stubMasterFacade) Export() (coremigration.SerializedModel, error) {


### PR DESCRIPTION
Each migrationminion now reports it is ready in the QUIESCE phase and the migrationmaster now waits for minions to report before proceeding.

This change required quite of bit of churn in the migrationmaster's test infrastructure.

Also included is a refactoring of minion waiting in migrationmaster. Handling the possible responses from waitForMinions was unwieldy.

## QA Steps

```shell
$ juju bootstrap B lxd --upload-tools
$ juju bootstrap A lxd --upload-tools
$ juju add-model foo
$ juju deploy ubuntu
# wait...
$ JUJU_DEV_FEATURE_FLAGS=migration juju migrate foo B
# wait...
$ juju switch B:foo
$ juju status
# ensure that agents are happy

# Check the logs to confirm the wait in QUIESCE happened

$ juju debug-log -m A:controller --replay -T | grep migrationmaster | grep -i quies
machine-0: 2016-08-11 00:26:49 INFO juju.worker.migrationmaster:85669c worker.go:247 quiescing: waiting for agents to report back
machine-0: 2016-08-11 00:26:49 INFO juju.worker.migrationmaster:85669c worker.go:459 waiting for agents to report back for migration phase QUIESCE (will wait up to 14m55s)
machine-0: 2016-08-11 00:26:54 INFO juju.worker.migrationmaster:85669c worker.go:500 completed waiting for agents to report for QUIESCE: 2 succeeded, 0 failed
```

(Review request: http://reviews.vapour.ws/r/5408/)