### PR TITLE
Made controlleruser and permissions global.

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -195,7 +195,9 @@ func allCollections() collectionSchema {
 		// This collection is basically a standard SQL intersection table; it
 		// references the global records of the users allowed access to a
 		// given operation.
-		permissionsC: {},
+		permissionsC: {
+			global: true,
+		},
 
 		// This collection holds the last time the model user connected
 		// to the model.

--- a/state/controller.go
+++ b/state/controller.go
@@ -4,6 +4,8 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
 
 	jujucontroller "github.com/juju/juju/controller"
@@ -16,6 +18,12 @@ const (
 	// controllerGlobalKey is the key for controller.
 	controllerGlobalKey = "c"
 )
+
+// controllerKey will return the key for a given controller using the
+// controller uuid and the controllerGlobalKey.
+func controllerKey(controllerUUID string) string {
+	return fmt.Sprintf("%s#%s", controllerGlobalKey, controllerUUID)
+}
 
 // ControllerConfig returns the config values for the controller.
 func (st *State) ControllerConfig() (jujucontroller.Config, error) {

--- a/state/model.go
+++ b/state/model.go
@@ -28,6 +28,11 @@ import (
 // settings and constraints.
 const modelGlobalKey = "e"
 
+// modelKey will create the kei for a given model using the modelGlobalKey.
+func modelKey(modelUUID string) string {
+	return fmt.Sprintf("%s#%s", modelGlobalKey, modelUUID)
+}
+
 // MigrationMode specifies where the Model is with respect to migration.
 type MigrationMode string
 

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -34,7 +34,7 @@ func (st *State) setModelAccess(access description.Access, userGlobalKey string)
 	if err := description.ValidateModelAccess(access); err != nil {
 		return errors.Trace(err)
 	}
-	op := updatePermissionOp(modelGlobalKey, userGlobalKey, access)
+	op := updatePermissionOp(modelKey(st.ModelUUID()), userGlobalKey, access)
 	err := st.runTransaction([]txn.Op{op})
 	if err == txn.ErrAborted {
 		return errors.NotFoundf("existing permissions")
@@ -131,7 +131,7 @@ func createModelUserOps(modelUUID string, user, createdBy names.UserTag, display
 		DateCreated: dateCreated,
 	}
 	ops := []txn.Op{
-		createPermissionOp(modelGlobalKey, userGlobalKey(userAccessID(user)), access),
+		createPermissionOp(modelKey(modelUUID), userGlobalKey(userAccessID(user)), access),
 		{
 			C:      modelUsersC,
 			Id:     userAccessID(user),
@@ -146,7 +146,7 @@ func createModelUserOps(modelUUID string, user, createdBy names.UserTag, display
 // removeModelUser removes a user from the database.
 func (st *State) removeModelUser(user names.UserTag) error {
 	ops := []txn.Op{
-		removePermissionOp(modelGlobalKey, userGlobalKey(userAccessID(user))),
+		removePermissionOp(modelKey(st.ModelUUID()), userGlobalKey(userAccessID(user))),
 		{
 			C:      modelUsersC,
 			Id:     userAccessID(user),

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -176,7 +176,7 @@ func (s *StateSuite) TestModelUUID(c *gc.C) {
 
 func (s *StateSuite) TestNoModelDocs(c *gc.C) {
 	c.Assert(s.State.EnsureModelRemoved(), gc.ErrorMatches,
-		fmt.Sprintf("found documents for model with uuid %s: 1 constraints doc, 2 leases doc, 1 modelusers doc, 2 permissions doc, 1 settings doc, 1 statuses doc", s.State.ModelUUID()))
+		fmt.Sprintf("found documents for model with uuid %s: 1 constraints doc, 2 leases doc, 1 modelusers doc, 1 settings doc, 1 statuses doc", s.State.ModelUUID()))
 }
 
 func (s *StateSuite) TestMongoSession(c *gc.C) {

--- a/state/user_internal_test.go
+++ b/state/user_internal_test.go
@@ -34,9 +34,9 @@ func (s *internalUserSuite) TestCreateInitialUserOps(c *gc.C) {
 	op = ops[1]
 	permdoc := op.Insert.(*permissionDoc)
 	c.Assert(permdoc.Access, gc.Equals, string(description.SuperuserAccess))
-	c.Assert(permdoc.ID, gc.Equals, permissionID(controllerGlobalKey, userGlobalKey(strings.ToLower(tag.Canonical()))))
+	c.Assert(permdoc.ID, gc.Equals, permissionID(controllerKey(s.state.ControllerUUID()), userGlobalKey(strings.ToLower(tag.Canonical()))))
 	c.Assert(permdoc.SubjectGlobalKey, gc.Equals, userGlobalKey(strings.ToLower(tag.Canonical())))
-	c.Assert(permdoc.ObjectGlobalKey, gc.Equals, controllerGlobalKey)
+	c.Assert(permdoc.ObjectGlobalKey, gc.Equals, controllerKey(s.state.ControllerUUID()))
 
 	// controller user
 	op = ops[2]

--- a/state/useraccess.go
+++ b/state/useraccess.go
@@ -113,7 +113,7 @@ func userAccessID(user names.UserTag) string {
 // NewModelUserAccess returns a new description.UserAccess for the given userDoc and
 // current Model.
 func NewModelUserAccess(st *State, userDoc userAccessDoc) (description.UserAccess, error) {
-	perm, err := st.userPermission(modelGlobalKey, userGlobalKey(strings.ToLower(userDoc.UserName)))
+	perm, err := st.userPermission(modelKey(st.ModelUUID()), userGlobalKey(strings.ToLower(userDoc.UserName)))
 	if err != nil {
 		return description.UserAccess{}, errors.Annotate(err, "obtaining model permission")
 	}
@@ -123,7 +123,7 @@ func NewModelUserAccess(st *State, userDoc userAccessDoc) (description.UserAcces
 // NewControllerUserAccess returns a new description.UserAccess for the given userDoc and
 // current Controller.
 func NewControllerUserAccess(st *State, userDoc userAccessDoc) (description.UserAccess, error) {
-	perm, err := st.controllerUserPermission(controllerGlobalKey, userGlobalKey(strings.ToLower(userDoc.UserName)))
+	perm, err := st.controllerUserPermission(controllerKey(st.ControllerUUID()), userGlobalKey(strings.ToLower(userDoc.UserName)))
 	if err != nil {
 		return description.UserAccess{}, errors.Annotate(err, "obtaining controller permission")
 	}

--- a/state/userpermission.go
+++ b/state/userpermission.go
@@ -40,13 +40,13 @@ func accessToString(a description.Access) string {
 }
 
 // userPermission returns a Permission for the given Subject and User.
-func (st *State) userPermission(objectKey, subjectKey string) (*permission, error) {
+func (st *State) userPermission(objectGlobalKey, subjectGlobalKey string) (*permission, error) {
 	userPermission := &permission{}
 	permissions, closer := st.getCollection(permissionsC)
 	defer closer()
 
-	id := permissionID(objectKey, subjectKey)
-	err := permissions.FindId(st.docID(id)).One(&userPermission.doc)
+	id := permissionID(objectGlobalKey, subjectGlobalKey)
+	err := permissions.FindId(id).One(&userPermission.doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("user permissions for user %q", id)
 	}
@@ -54,19 +54,14 @@ func (st *State) userPermission(objectKey, subjectKey string) (*permission, erro
 }
 
 // controllerUserPermission returns a Permission for the given Subject and User.
-func (st *State) controllerUserPermission(objectKey, subjectKey string) (*permission, error) {
+func (st *State) controllerUserPermission(objectGlobalKey, subjectGlobalKey string) (*permission, error) {
 	userPermission := &permission{}
-	controllerSt, err := st.ForModel(st.controllerModelTag)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	defer controllerSt.Close()
 
-	permissions, closer := controllerSt.getCollection(permissionsC)
+	permissions, closer := st.getCollection(permissionsC)
 	defer closer()
 
-	id := permissionID(objectKey, subjectKey)
-	err = permissions.FindId(controllerSt.docID(id)).One(&userPermission.doc)
+	id := permissionID(objectGlobalKey, subjectGlobalKey)
+	err := permissions.FindId(id).One(&userPermission.doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("user permissions for user %q", id)
 	}
@@ -95,12 +90,23 @@ func (p *permission) access() description.Access {
 	return stringToAccess(p.doc.Access)
 }
 
-func permissionID(objectKey, subjectKey string) string {
-	// example: e#us#jim
-	// e: model global key (its always e).
-	// us: user key prefix.
-	// jim: an arbitrary username.
-	return fmt.Sprintf("%s#%s", objectKey, subjectKey)
+func permissionID(objectGlobalKey, subjectGlobalKey string) string {
+	// example: e#:deadbeef#us#jim
+	// e: object global key
+	// deadbeef: object uuid
+	// us#jim: subject global key
+	// the first element (e in this example) is the global key for the object
+	// (model in this example)
+	// the second, is the : prefixed model uuid
+	// the third, in this example is a user with name jim, hence the globalKey
+	// ( a user global key) being us#jim.
+	// another example, now with controller and user maria:
+	// c#:deadbeef#us#maria
+	// c: object global key, in this case controller.
+	// :deadbeef controller uuid
+	// us#maria: its the user global key for maria.
+	// if this where for model, it would be e#us#maria
+	return fmt.Sprintf("%s#%s", objectGlobalKey, subjectGlobalKey)
 }
 
 func updatePermissionOp(objectGlobalKey, subjectGlobalKey string, access description.Access) txn.Op {


### PR DESCRIPTION
ControllerUser and Permissions collections where being used
in an incorrect manner, by user ForModel, I instead changed them
to be global and started adding the modelID where required.

(Review request: http://reviews.vapour.ws/r/5409/)