### PR TITLE
Don't cache supported architectures on provider environ.

### DIFF
--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -68,9 +68,6 @@ type environ struct {
 
 	// namespace is used to create the machine and device hostnames.
 	namespace instance.Namespace
-
-	archLock               sync.Mutex // protects supportedArchitectures
-	supportedArchitectures []string
 }
 
 // Function entry points defined as variables so they can be overridden

--- a/provider/gce/environ_policy.go
+++ b/provider/gce/environ_policy.go
@@ -28,25 +28,9 @@ func (env *environ) PrecheckInstance(series string, cons constraints.Value, plac
 	return nil
 }
 
-func (env *environ) getSupportedArchitectures() ([]string, error) {
-	env.archLock.Lock()
-	defer env.archLock.Unlock()
-
-	if env.supportedArchitectures != nil {
-		return env.supportedArchitectures, nil
-	}
-
-	archList, err := env.lookupArchitectures()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	env.supportedArchitectures = archList
-	return archList, nil
-}
-
 var supportedArchitectures = common.SupportedArchitectures
 
-func (env *environ) lookupArchitectures() ([]string, error) {
+func (env *environ) getSupportedArchitectures() ([]string, error) {
 	// Create a filter to get all images from our region and for the
 	// correct stream.
 	cloudSpec, err := env.Region()

--- a/provider/joyent/environ.go
+++ b/provider/joyent/environ.go
@@ -28,11 +28,6 @@ type joyentEnviron struct {
 	cloud   environs.CloudSpec
 	compute *joyentCompute
 
-	// supportedArchitectures caches the architectures
-	// for which images can be instantiated.
-	archLock               sync.Mutex
-	supportedArchitectures []string
-
 	lock sync.Mutex // protects ecfg
 	ecfg *environConfig
 }
@@ -84,11 +79,6 @@ func (env *joyentEnviron) PrecheckInstance(series string, cons constraints.Value
 }
 
 func (env *joyentEnviron) getSupportedArchitectures() ([]string, error) {
-	env.archLock.Lock()
-	defer env.archLock.Unlock()
-	if env.supportedArchitectures != nil {
-		return env.supportedArchitectures, nil
-	}
 	cfg := env.Ecfg()
 	// Create a filter to get all images from our region and for the correct stream.
 	cloudSpec := simplestreams.CloudSpec{
@@ -99,9 +89,7 @@ func (env *joyentEnviron) getSupportedArchitectures() ([]string, error) {
 		CloudSpec: cloudSpec,
 		Stream:    cfg.ImageStream(),
 	})
-	var err error
-	env.supportedArchitectures, err = common.SupportedArchitectures(env, imageConstraint)
-	return env.supportedArchitectures, err
+	return common.SupportedArchitectures(env, imageConstraint)
 }
 
 func (env *joyentEnviron) SetConfig(cfg *config.Config) error {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -79,9 +79,6 @@ type maasEnviron struct {
 
 	// archMutex gates access to supportedArchitectures
 	archMutex sync.Mutex
-	// supportedArchitectures caches the architectures
-	// for which images can be instantiated.
-	supportedArchitectures []string
 
 	// ecfgMutex protects the *Unlocked fields below.
 	ecfgMutex sync.Mutex
@@ -266,20 +263,11 @@ func (env *maasEnviron) SetConfig(cfg *config.Config) error {
 func (env *maasEnviron) getSupportedArchitectures() ([]string, error) {
 	env.archMutex.Lock()
 	defer env.archMutex.Unlock()
-	if env.supportedArchitectures != nil {
-		return env.supportedArchitectures, nil
-	}
-
 	fetchArchitectures := env.allArchitecturesWithFallback
 	if env.usingMAAS2() {
 		fetchArchitectures = env.allArchitectures2
 	}
-	architectures, err := fetchArchitectures()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	env.supportedArchitectures = architectures
-	return env.supportedArchitectures, nil
+	return fetchArchitectures()
 }
 
 // SupportsSpaces is specified on environs.Networking.

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -159,12 +159,6 @@ type Environ struct {
 	name  string
 	cloud environs.CloudSpec
 
-	// archMutex gates access to cachedSupportedArchitectures
-	archMutex sync.Mutex
-	// cachedSupportedArchitectures caches the architectures
-	// for which images can be instantiated.
-	cachedSupportedArchitectures []string
-
 	ecfgMutex    sync.Mutex
 	ecfgUnlocked *environConfig
 	client       client.AuthenticatingClient
@@ -398,12 +392,6 @@ func (e *Environ) ConstraintsValidator() (constraints.Validator, error) {
 }
 
 func (e *Environ) supportedArchitectures() ([]string, error) {
-	e.archMutex.Lock()
-	defer e.archMutex.Unlock()
-	if e.cachedSupportedArchitectures != nil {
-		return e.cachedSupportedArchitectures, nil
-	}
-	// Create a filter to get all images from our region and for the correct stream.
 	cloudSpec, err := e.Region()
 	if err != nil {
 		return nil, err
@@ -412,8 +400,7 @@ func (e *Environ) supportedArchitectures() ([]string, error) {
 		CloudSpec: cloudSpec,
 		Stream:    e.Config().ImageStream(),
 	})
-	e.cachedSupportedArchitectures, err = common.SupportedArchitectures(e, imageConstraint)
-	return e.cachedSupportedArchitectures, err
+	return common.SupportedArchitectures(e, imageConstraint)
 }
 
 var novaListAvailabilityZones = (*nova.Client).ListAvailabilityZones

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -26,9 +26,6 @@ type environ struct {
 	cloud  environs.CloudSpec
 	client *client
 
-	archLock               sync.Mutex // archLock protects access to the following fields.
-	supportedArchitectures []string
-
 	// namespace is used to create the machine and device hostnames.
 	namespace instance.Namespace
 


### PR DESCRIPTION
Some provides are caching the list of supported architectures. This means that after bootstrap, we can never update architecture list even when new architectures become available. The implication is that when new images/tools supporting additional architectures come in, they will not be picked up.

Note: 
This PR deals with all such provider but one - cloudsigma has different test setup and is going to be tackled in a separate PR.
Providers addressed here:
* ec2
* gce
* joyent
* maas
* openstack
* vsphere

This work is a pre-cursor to supported architecture fix.

QA steps:
1. bootstrap on the desired provider
2. deploy an application with constraint that specified obviously unsupported architecture [expect failure]
3. add image with metadata for the failed architecture
4. re-deploy from 2 [expect success]




(Review request: http://reviews.vapour.ws/r/5411/)