### PR TITLE
provider/manual: remove systemd conf on destroy

### DIFF
--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -222,6 +222,7 @@ touch %s
 pkill -%d jujud && exit
 stop %s
 rm -f /etc/init/juju*
+rm -f /etc/systemd/system/juju*
 rm -fr %s %s
 exit 0
 `

--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -85,6 +85,7 @@ touch '/var/lib/juju/uninstall-agent'
 pkill -6 jujud && exit
 stop juju-db
 rm -f /etc/init/juju*
+rm -f /etc/systemd/system/juju*
 rm -fr '/var/lib/juju' '/var/log/juju'
 exit 0
 `)


### PR DESCRIPTION
When destroying a manual environment, remove the
systemd conf files.

Fixes https://bugs.launchpad.net/juju-core/+bug/1611453

(Review request: http://reviews.vapour.ws/r/5414/)