### PR TITLE
Pass ReleaseContainerAddresses much less info

### DIFF
--- a/environs/networking.go
+++ b/environs/networking.go
@@ -48,8 +48,8 @@ type Networking interface {
 	AllocateContainerAddresses(hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo []network.InterfaceInfo) ([]network.InterfaceInfo, error)
 
 	// ReleaseContainerAddresses releases the previously allocated
-	// addresses matching the interface infos passed in.
-	ReleaseContainerAddresses(interfaces []network.InterfaceInfo) error
+	// addresses matching the interface details passed in.
+	ReleaseContainerAddresses(interfaces []network.ProviderInterfaceInfo) error
 }
 
 // NetworkingEnviron combines the standard Environ interface with the

--- a/network/network.go
+++ b/network/network.go
@@ -303,6 +303,23 @@ func (i *InterfaceInfo) CIDRAddress() string {
 	return ipNet.String()
 }
 
+// ProviderInterfaceInfo holds enough information to identify an
+// interface or link layer device to a provider so that it can be
+// queried or manipulated. Its initial purpose is to pass to
+// provider.ReleaseContainerAddresses.
+type ProviderInterfaceInfo struct {
+	// InterfaceName is the raw OS-specific network device name (e.g.
+	// "eth1", even for a VLAN eth1.42 virtual interface).
+	InterfaceName string
+
+	// ProviderId is a provider-specific NIC id.
+	ProviderId Id
+
+	// MACAddress is the network interface's hardware MAC address
+	// (e.g. "aa:bb:cc:dd:ee:ff").
+	MACAddress string
+}
+
 // LXCNetDefaultConfig is the location of the default network config
 // of the lxc package. It's exported to allow cross-package testing.
 var LXCNetDefaultConfig = "/etc/default/lxc-net"

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1569,6 +1569,6 @@ func (e *environ) AllocateContainerAddresses(hostInstanceID instance.Id, contain
 	return nil, errors.NotSupportedf("container address allocation")
 }
 
-func (e *environ) ReleaseContainerAddresses(interfaces []network.InterfaceInfo) error {
+func (e *environ) ReleaseContainerAddresses(interfaces []network.ProviderInterfaceInfo) error {
 	return errors.NotSupportedf("container address allocation")
 }

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1726,6 +1726,6 @@ func (e *environ) AllocateContainerAddresses(hostInstanceID instance.Id, contain
 	return nil, errors.NotSupportedf("container address allocation")
 }
 
-func (e *environ) ReleaseContainerAddresses(interfaces []network.InterfaceInfo) error {
+func (e *environ) ReleaseContainerAddresses(interfaces []network.ProviderInterfaceInfo) error {
 	return errors.NotSupportedf("container address allocation")
 }

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -2216,7 +2216,7 @@ func (env *maasEnviron) allocateContainerAddresses2(hostInstanceID instance.Id, 
 	return finalInterfaces, nil
 }
 
-func (env *maasEnviron) ReleaseContainerAddresses(interfaces []network.InterfaceInfo) error {
+func (env *maasEnviron) ReleaseContainerAddresses(interfaces []network.ProviderInterfaceInfo) error {
 	macAddresses := make([]string, len(interfaces))
 	for i, info := range interfaces {
 		macAddresses[i] = info.MACAddress

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1114,7 +1114,7 @@ func (s *environSuite) TestReleaseContainerAddresses(c *gc.C) {
 	})
 
 	env := s.makeEnviron()
-	err := env.ReleaseContainerAddresses([]network.InterfaceInfo{
+	err := env.ReleaseContainerAddresses([]network.ProviderInterfaceInfo{
 		{MACAddress: "mac1"},
 		{MACAddress: "mac3"},
 		{MACAddress: "mac4"},

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -1682,7 +1682,7 @@ func (suite *maas2EnvironSuite) TestReleaseContainerAddresses(c *gc.C) {
 	controller.devices = []gomaasapi.Device{dev1, dev2}
 
 	env := suite.makeEnviron(c, controller)
-	err := env.ReleaseContainerAddresses([]network.InterfaceInfo{
+	err := env.ReleaseContainerAddresses([]network.ProviderInterfaceInfo{
 		{MACAddress: "will"},
 		{MACAddress: "dustin"},
 		{MACAddress: "eleven"},
@@ -1701,7 +1701,7 @@ func (suite *maas2EnvironSuite) TestReleaseContainerAddresses(c *gc.C) {
 func (suite *maas2EnvironSuite) TestReleaseContainerAddressesErrorGettingDevices(c *gc.C) {
 	controller := newFakeControllerWithErrors(errors.New("Everything done broke"))
 	env := suite.makeEnviron(c, controller)
-	err := env.ReleaseContainerAddresses([]network.InterfaceInfo{{MACAddress: "anything"}})
+	err := env.ReleaseContainerAddresses([]network.ProviderInterfaceInfo{{MACAddress: "anything"}})
 	c.Assert(err, gc.ErrorMatches, "Everything done broke")
 }
 
@@ -1713,7 +1713,7 @@ func (suite *maas2EnvironSuite) TestReleaseContainerAddressesErrorDeletingDevice
 	controller.devices = []gomaasapi.Device{dev1}
 
 	env := suite.makeEnviron(c, controller)
-	err := env.ReleaseContainerAddresses([]network.InterfaceInfo{
+	err := env.ReleaseContainerAddresses([]network.ProviderInterfaceInfo{
 		{MACAddress: "eleven"},
 	})
 	c.Assert(err, gc.ErrorMatches, "deleting device hopper: don't delete me")

--- a/provider/vsphere/environ_network.go
+++ b/provider/vsphere/environ_network.go
@@ -65,6 +65,6 @@ func (e *environ) AllocateContainerAddresses(hostInstanceID instance.Id, contain
 }
 
 // ReleaseContainerAddresses implements environs.Networking.
-func (e *environ) ReleaseContainerAddresses(interfaces []network.InterfaceInfo) error {
+func (e *environ) ReleaseContainerAddresses(interfaces []network.ProviderInterfaceInfo) error {
 	return errors.NotSupportedf("container address allocation")
 }


### PR DESCRIPTION
Fully constructing a network.InterfaceInfo is far more than we actually
need to release the container addresses, and it's a hassle to build it
in state and pass through the API, especially with testing. But it seems
wrong/potentially confusing to construct a partial one, for example only 
setting the MAC address and leave the rest blank because we know the 
MAAS provider (the only implementation of ReleaseContainerAddresses 
at the moment) only needs the MAC.

Instead of that, create a struct that is designed to hold information
for identifying an interface/L2 device to a provider (which is a much
smaller set of fields) and always fully populate that information. When
we need other fields for other providers we can add it.

Part of lp:1585878.

Only unit testing done - the worker that will call ReleaseContainerAddresses
is still under construction.