### PR TITLE
state: Log at Info level when preferred private/public addresses change

### DIFF
--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -436,6 +436,10 @@ func (st *State) machineDocForTemplate(template MachineTemplate, id string) *mac
 	// thing to do when none is available.
 	privateAddr, _ := network.SelectInternalAddress(template.Addresses, false)
 	publicAddr, _ := network.SelectPublicAddress(template.Addresses)
+	logger.Infof(
+		"new machine %q has preferred addresses: private %q, public %q",
+		id, privateAddr, publicAddr,
+	)
 	return &machineDoc{
 		DocID:                   st.docID(id),
 		Id:                      id,

--- a/state/machine.go
+++ b/state/machine.go
@@ -1430,10 +1430,20 @@ func (m *Machine) setAddresses(addresses []network.Address, field *[]address, fi
 
 	*field = stateAddresses
 	if changedPrivate {
+		oldPrivate := m.doc.PreferredPrivateAddress.networkAddress()
 		m.doc.PreferredPrivateAddress = newPrivate
+		logger.Infof(
+			"machine %q preferred private address changed from %q to %q",
+			m.Id(), oldPrivate, newPrivate.networkAddress(),
+		)
 	}
 	if changedPublic {
+		oldPublic := m.doc.PreferredPublicAddress.networkAddress()
 		m.doc.PreferredPublicAddress = newPublic
+		logger.Infof(
+			"machine %q preferred public address changed from %q to %q",
+			m.Id(), oldPublic, newPublic.networkAddress(),
+		)
 	}
 	return nil
 }


### PR DESCRIPTION
Whenever we create a new machine and select preferred private and publc
addresses for it, or when new addresses appear on the machine, more
suitable as preferred public or private, before changing the current
ones we log the change at Info level.

Related bug http://pad.lv/1516150 - this is not a fix, but to help
debugging.

Live tested on LXD and MAAS:
1. juju bootstrap ...  --upload-tools --config logging-config='<root>=INFO'
2. juju switch controller
3. juju ssh 0
4. sudo egrep 'new machine ".*" has preferred' /var/log/cloud-init-output.log
5. sudo ip addr add 9.9.9.9 dev eth0    # br-eth0 for MAAS
6. sudo systemctl restart jujud-machine-0
7. sudo egrep 'machine ".*" preferred public address changed from ".*" to "9.9.9.9"' /var/log/juju/machine-0.log

(Review request: http://reviews.vapour.ws/r/5421/)