### PR TITLE
apiserver: make the ModelManager API require controller-only login

### DIFF
--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -192,6 +192,7 @@ func (s *controllerSuite) TestAPIServerCanShutdownWithOutstandingNext(c *gc.C) {
 	// Connect to the API server we've just started.
 	apiInfo := s.APIInfo(c)
 	apiInfo.Addrs = []string{lis.Addr().String()}
+	apiInfo.ModelTag = names.ModelTag{}
 	apiState, err := api.Open(apiInfo, api.DialOpts{})
 	sysManager := controller.NewClient(apiState)
 	defer sysManager.Close()

--- a/api/interface.go
+++ b/api/interface.go
@@ -42,7 +42,8 @@ type Info struct {
 	CACert string
 
 	// ModelTag holds the model tag for the model we are
-	// trying to connect to.
+	// trying to connect to. If this is empty, a controller-only
+	// login will be made.
 	ModelTag names.ModelTag
 
 	// ...but this block of fields is all about the authentication mechanism

--- a/api/usermanager/client_test.go
+++ b/api/usermanager/client_test.go
@@ -26,8 +26,13 @@ var _ = gc.Suite(&usermanagerSuite{})
 
 func (s *usermanagerSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
-	s.usermanager = usermanager.NewClient(s.APIState)
+	s.usermanager = usermanager.NewClient(s.OpenControllerAPI(c))
 	c.Assert(s.usermanager, gc.NotNil)
+}
+
+func (s *usermanagerSuite) TearDownTest(c *gc.C) {
+	s.usermanager.Close()
+	s.JujuConnSuite.TearDownTest(c)
 }
 
 func (s *usermanagerSuite) TestAddUser(c *gc.C) {

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -24,7 +24,7 @@ import (
 	jujuversion "github.com/juju/juju/version"
 )
 
-type adminApiFactory func(*Server, *apiHandler, observer.Observer) interface{}
+type adminAPIFactory func(*Server, *apiHandler, observer.Observer) interface{}
 
 // admin is the only object that unlogged-in clients can access. It holds any
 // methods that are needed to log in.
@@ -52,19 +52,19 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 		return fail, errAlreadyLoggedIn
 	}
 
-	// authedApi is the API method finder we'll use after getting logged in.
-	var authedApi rpc.Root = newApiRoot(a.root.state, a.root.resources, a.root)
+	// authedAPI is the API root we'll use after getting logged in.
+	var authedAPI rpc.Root = newAPIRoot(a.root.state, a.root.resources, a.root)
 
 	// Use the login validation function, if one was specified.
 	if a.srv.validator != nil {
 		err := a.srv.validator(req)
 		switch err {
 		case params.UpgradeInProgressError:
-			authedApi = newUpgradingRoot(authedApi)
+			authedAPI = newUpgradingRoot(authedAPI)
 		case AboutToRestoreError:
-			authedApi = newAboutToRestoreRoot(authedApi)
+			authedAPI = newAboutToRestoreRoot(authedAPI)
 		case RestoreInProgressError:
-			authedApi = newRestoreInProgressRoot(authedApi)
+			authedAPI = newRestoreInProgressRoot(authedAPI)
 		case nil:
 			// in this case no need to wrap authed api so we do nothing
 		default:
@@ -88,7 +88,7 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 		}
 	}
 
-	serverOnlyLogin := a.root.modelUUID == ""
+	controllerOnlyLogin := a.root.modelUUID == ""
 	controllerMachineLogin := false
 
 	entity, lastConnection, err := doCheckCreds(a.root.state, req, isUser, a.srv.authCtxt)
@@ -193,28 +193,28 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 		ServerVersion: jujuversion.Current.String(),
 	}
 
-	// For sufficiently modern login versions, stop serving the
-	// controller model at the root of the API.
-	if serverOnlyLogin {
-		authedApi = newRestrictedRoot(authedApi)
+	allowFacade := isModelFacade
+	if controllerOnlyLogin {
+		allowFacade = isControllerFacade
 		// Remove the ModelTag from the response as there is no
 		// model here.
 		loginResult.ModelTag = ""
-		// Strip out the facades that are not supported from the result.
-		var facades []params.FacadeVersions
-		for _, facade := range loginResult.Facades {
-			if restrictedRootNames.Contains(facade.Name) {
-				facades = append(facades, facade)
-			}
-		}
-		loginResult.Facades = facades
 	}
+	authedAPI = newRestrictedRoot(authedAPI, allowFacade)
+	// Strip out the facades that are not supported from the result.
+	facades := make([]params.FacadeVersions, 0, len(loginResult.Facades))
+	for _, facade := range loginResult.Facades {
+		if allowFacade(facade.Name) {
+			facades = append(facades, facade)
+		}
+	}
+	loginResult.Facades = facades
 
 	if !description.IsEmptyUserAccess(modelUser) || !description.IsEmptyUserAccess(controllerUser) {
-		authedApi = newClientAuthRoot(authedApi, modelUser, controllerUser)
+		authedAPI = newClientAuthRoot(authedAPI, modelUser, controllerUser)
 	}
 
-	a.root.rpcConn.ServeRoot(authedApi, serverError)
+	a.root.rpcConn.ServeRoot(authedAPI, serverError)
 
 	return loginResult, nil
 }
@@ -246,7 +246,7 @@ var doCheckCreds = checkCreds
 
 // checkCreds validates the entities credentials in the current model.
 // If the entity is a user, and lookForModelUser is true, a model user must exist
-// for the model.  In the case of a user logging in to the server, but
+// for the model.  In the case of a user logging in to the controller, but
 // not a model, there is no env user needed.  While we have the env
 // user, if we do have it, update the last login time.
 //

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -35,7 +35,7 @@ import (
 
 type baseLoginSuite struct {
 	jujutesting.JujuConnSuite
-	setAdminApi func(*apiserver.Server)
+	setAdminAPI func(*apiserver.Server)
 }
 
 type loginSuite struct {
@@ -44,8 +44,8 @@ type loginSuite struct {
 
 var _ = gc.Suite(&loginSuite{
 	baseLoginSuite{
-		setAdminApi: func(srv *apiserver.Server) {
-			apiserver.SetAdminApiVersions(srv, 3)
+		setAdminAPI: func(srv *apiserver.Server) {
+			apiserver.SetAdminAPIVersions(srv, 3)
 		},
 	},
 })
@@ -591,8 +591,8 @@ func (s *baseLoginSuite) setupServerForEnvironmentWithValidator(c *gc.C, modelTa
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.setAdminApi, gc.NotNil)
-	s.setAdminApi(srv)
+	c.Assert(s.setAdminAPI, gc.NotNil)
+	s.setAdminAPI(srv)
 	info := &api.Info{
 		Tag:      nil,
 		Password: "",

--- a/apiserver/adminv3.go
+++ b/apiserver/adminv3.go
@@ -11,12 +11,12 @@ import (
 	"github.com/juju/juju/apiserver/params"
 )
 
-type adminApiV3 struct {
+type adminAPIV3 struct {
 	*admin
 }
 
-func newAdminApiV3(srv *Server, root *apiHandler, apiObserver observer.Observer) interface{} {
-	return &adminApiV3{
+func newAdminAPIV3(srv *Server, root *apiHandler, apiObserver observer.Observer) interface{} {
+	return &adminAPIV3{
 		&admin{
 			srv:         srv,
 			root:        root,
@@ -27,7 +27,7 @@ func newAdminApiV3(srv *Server, root *apiHandler, apiObserver observer.Observer)
 
 // Admin returns an object that provides API access to methods that can be
 // called even when not authenticated.
-func (r *adminApiV3) Admin(id string) (*adminApiV3, error) {
+func (r *adminAPIV3) Admin(id string) (*adminAPIV3, error) {
 	if id != "" {
 		// Safeguard id for possible future use.
 		return nil, common.ErrBadId
@@ -37,13 +37,13 @@ func (r *adminApiV3) Admin(id string) (*adminApiV3, error) {
 
 // Login logs in with the provided credentials.  All subsequent requests on the
 // connection will act as the authenticated user.
-func (a *adminApiV3) Login(req params.LoginRequest) (params.LoginResultV1, error) {
+func (a *adminAPIV3) Login(req params.LoginRequest) (params.LoginResultV1, error) {
 	return a.doLogin(req, 3)
 }
 
 // RedirectInfo returns redirected host information for the model.
 // In Juju it always returns an error because the Juju controller
 // does not multiplex controllers.
-func (a *adminApiV3) RedirectInfo() (params.RedirectInfoResult, error) {
+func (a *adminAPIV3) RedirectInfo() (params.RedirectInfoResult, error) {
 	return params.RedirectInfoResult{}, fmt.Errorf("not redirected")
 }

--- a/apiserver/adminv3_test.go
+++ b/apiserver/adminv3_test.go
@@ -22,8 +22,8 @@ type loginV3Suite struct {
 var _ = gc.Suite(&loginV3Suite{
 	loginSuite{
 		baseLoginSuite{
-			setAdminApi: func(srv *apiserver.Server) {
-				apiserver.SetAdminApiVersions(srv, 3)
+			setAdminAPI: func(srv *apiserver.Server) {
+				apiserver.SetAdminAPIVersions(srv, 3)
 			},
 		},
 	},
@@ -56,7 +56,7 @@ func (s *loginV3Suite) TestClientLoginToServer(c *gc.C) {
 	client := apiState.Client()
 	_, err = client.GetModelConstraints()
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
-		Message: `logged in to server, no model, "Client" not supported`,
+		Message: `facade "Client" not supported for API connection type`,
 		Code:    "not supported",
 	})
 }

--- a/apiserver/annotations/client_test.go
+++ b/apiserver/annotations/client_test.go
@@ -22,7 +22,7 @@ type annotationSuite struct {
 	// TODO(anastasiamac) mock to remove JujuConnSuite
 	jujutesting.JujuConnSuite
 
-	annotationsApi *annotations.API
+	annotationsAPI *annotations.API
 	authorizer     apiservertesting.FakeAuthorizer
 }
 
@@ -34,7 +34,7 @@ func (s *annotationSuite) SetUpTest(c *gc.C) {
 		Tag: s.AdminUserTag(c),
 	}
 	var err error
-	s.annotationsApi, err = annotations.NewAPI(s.State, nil, s.authorizer)
+	s.annotationsAPI, err = annotations.NewAPI(s.State, nil, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -79,7 +79,7 @@ func (s *annotationSuite) TestServiceAnnotations(c *gc.C) {
 func (s *annotationSuite) assertAnnotationsRemoval(c *gc.C, tag names.Tag) {
 	entity := tag.String()
 	entities := params.Entities{[]params.Entity{{entity}}}
-	ann := s.annotationsApi.Get(entities)
+	ann := s.annotationsAPI.Get(entities)
 	c.Assert(ann.Results, gc.HasLen, 1)
 
 	aResult := ann.Results[0]
@@ -92,11 +92,11 @@ func (s *annotationSuite) TestInvalidEntityAnnotations(c *gc.C) {
 	entities := params.Entities{[]params.Entity{{entity}}}
 	annotations := map[string]string{"mykey": "myvalue"}
 
-	setResult := s.annotationsApi.Set(
+	setResult := s.annotationsAPI.Set(
 		params.AnnotationsSet{Annotations: constructSetParameters([]string{entity}, annotations)})
 	c.Assert(setResult.OneError().Error(), gc.Matches, ".*permission denied.*")
 
-	got := s.annotationsApi.Get(entities)
+	got := s.annotationsAPI.Get(entities)
 	c.Assert(got.Results, gc.HasLen, 1)
 
 	aResult := got.Results[0]
@@ -161,11 +161,11 @@ func (s *annotationSuite) TestRelationAnnotations(c *gc.C) {
 	entities := params.Entities{[]params.Entity{entity}}
 	annotations := map[string]string{"mykey": "myvalue"}
 
-	setResult := s.annotationsApi.Set(
+	setResult := s.annotationsAPI.Set(
 		params.AnnotationsSet{Annotations: constructSetParameters([]string{tag}, annotations)})
 	c.Assert(setResult.OneError().Error(), gc.Matches, ".*does not support annotations.*")
 
-	got := s.annotationsApi.Get(entities)
+	got := s.annotationsAPI.Get(entities)
 	c.Assert(got.Results, gc.HasLen, 1)
 
 	aResult := got.Results[0]
@@ -201,7 +201,7 @@ func (s *annotationSuite) TestMultipleEntitiesAnnotations(c *gc.C) {
 	}
 	annotations := map[string]string{"mykey": "myvalue"}
 
-	setResult := s.annotationsApi.Set(
+	setResult := s.annotationsAPI.Set(
 		params.AnnotationsSet{Annotations: constructSetParameters(entities, annotations)})
 	c.Assert(setResult.Results, gc.HasLen, 1)
 
@@ -210,7 +210,7 @@ func (s *annotationSuite) TestMultipleEntitiesAnnotations(c *gc.C) {
 	c.Assert(oneError, gc.Matches, fmt.Sprintf(".*%q.*", rTag))
 	c.Assert(oneError, gc.Matches, ".*does not support annotations.*")
 
-	got := s.annotationsApi.Get(params.Entities{[]params.Entity{
+	got := s.annotationsAPI.Get(params.Entities{[]params.Entity{
 		{rEntity},
 		{sEntity}}})
 	c.Assert(got.Results, gc.HasLen, 2)
@@ -251,7 +251,7 @@ func (s *annotationSuite) setupEntity(
 	entities []string,
 	initialAnnotations map[string]string) {
 	if initialAnnotations != nil {
-		initialResult := s.annotationsApi.Set(
+		initialResult := s.annotationsAPI.Set(
 			params.AnnotationsSet{
 				Annotations: constructSetParameters(entities, initialAnnotations)})
 		c.Assert(initialResult.Combine(), jc.ErrorIsNil)
@@ -262,7 +262,7 @@ func (s *annotationSuite) assertSetEntityAnnotations(c *gc.C,
 	entities []string,
 	annotations map[string]string,
 	expectedError string) {
-	setResult := s.annotationsApi.Set(
+	setResult := s.annotationsAPI.Set(
 		params.AnnotationsSet{Annotations: constructSetParameters(entities, annotations)})
 	if expectedError != "" {
 		c.Assert(setResult.OneError().Error(), gc.Matches, expectedError)
@@ -275,7 +275,7 @@ func (s *annotationSuite) assertGetEntityAnnotations(c *gc.C,
 	entities params.Entities,
 	entity string,
 	expected map[string]string) params.AnnotationsGetResult {
-	got := s.annotationsApi.Get(entities)
+	got := s.annotationsAPI.Get(entities)
 	c.Assert(got.Results, gc.HasLen, 1)
 
 	aResult := got.Results[0]
@@ -291,7 +291,7 @@ func (s *annotationSuite) cleanupEntityAnnotations(c *gc.C,
 	for key := range aResult.Annotations {
 		cleanup[key] = ""
 	}
-	cleanupResult := s.annotationsApi.Set(
+	cleanupResult := s.annotationsAPI.Set(
 		params.AnnotationsSet{Annotations: constructSetParameters(entities, cleanup)})
 	c.Assert(cleanupResult.Combine(), jc.ErrorIsNil)
 }

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -48,7 +48,7 @@ type Server struct {
 	logDir            string
 	limiter           utils.Limiter
 	validator         LoginValidator
-	adminApiFactories map[int]adminApiFactory
+	adminAPIFactories map[int]adminAPIFactory
 	modelUUID         string
 	authCtxt          *authContext
 	lastConnectionID  uint64
@@ -228,8 +228,8 @@ func newServer(s *state.State, lis *net.TCPListener, cfg ServerConfig) (_ *Serve
 		logDir:      cfg.LogDir,
 		limiter:     utils.NewLimiter(loginRateLimit),
 		validator:   cfg.Validator,
-		adminApiFactories: map[int]adminApiFactory{
-			3: newAdminApiV3,
+		adminAPIFactories: map[int]adminAPIFactory{
+			3: newAdminAPIV3,
 		},
 	}
 	srv.authCtxt, err = newAuthContext(s)
@@ -513,11 +513,11 @@ func (srv *Server) serveConn(wsConn *websocket.Conn, modelUUID string, apiObserv
 	if err != nil {
 		conn.ServeRoot(&errRoot{err}, serverError)
 	} else {
-		adminApis := make(map[int]interface{})
-		for apiVersion, factory := range srv.adminApiFactories {
-			adminApis[apiVersion] = factory(srv, h, apiObserver)
+		adminAPIs := make(map[int]interface{})
+		for apiVersion, factory := range srv.adminAPIFactories {
+			adminAPIs[apiVersion] = factory(srv, h, apiObserver)
 		}
-		conn.ServeRoot(newAnonRoot(h, adminApis), serverError)
+		conn.ServeRoot(newAnonRoot(h, adminAPIs), serverError)
 	}
 	conn.Start()
 	select {
@@ -542,7 +542,7 @@ func (srv *Server) newAPIHandler(conn *rpc.Conn, modelUUID string) (*apiHandler,
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return newApiHandler(srv, st, conn, modelUUID)
+	return newAPIHandler(srv, st, conn, modelUUID)
 }
 
 func (srv *Server) mongoPinger() error {

--- a/apiserver/application/application_test.go
+++ b/apiserver/application/application_test.go
@@ -44,7 +44,7 @@ type serviceSuite struct {
 	apiservertesting.CharmStoreSuite
 	commontesting.BlockHelper
 
-	applicationApi *application.API
+	applicationAPI *application.API
 	application    *state.Application
 	authorizer     apiservertesting.FakeAuthorizer
 }
@@ -76,7 +76,7 @@ func (s *serviceSuite) SetUpTest(c *gc.C) {
 		Tag: s.AdminUserTag(c),
 	}
 	var err error
-	s.applicationApi, err = application.NewAPI(s.State, nil, s.authorizer)
+	s.applicationAPI, err = application.NewAPI(s.State, nil, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -140,7 +140,7 @@ func (s *serviceSuite) TestSetMetricCredentials(c *gc.C) {
 	}
 	for i, t := range tests {
 		c.Logf("Running test %d %v", i, t.about)
-		results, err := s.applicationApi.SetMetricCredentials(t.args)
+		results, err := s.applicationAPI.SetMetricCredentials(t.args)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(results.Results, gc.HasLen, len(t.results.Results))
 		c.Assert(results, gc.DeepEquals, t.results)
@@ -207,7 +207,7 @@ func (s *serviceSuite) TestServiceDeployWithStorage(c *gc.C) {
 		Constraints:     cons,
 		Storage:         storageConstraints,
 	}
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{args}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -262,7 +262,7 @@ func (s *serviceSuite) TestServiceDeployWithInvalidStoragePool(c *gc.C) {
 		Constraints:     cons,
 		Storage:         storageConstraints,
 	}
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{args}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -283,7 +283,7 @@ func (s *serviceSuite) TestServiceDeployDefaultFilesystemStorage(c *gc.C) {
 		NumUnits:        1,
 		Constraints:     cons,
 	}
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{args}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -318,7 +318,7 @@ func (s *serviceSuite) TestServiceDeploy(c *gc.C) {
 			{"deadbeef-0bad-400d-8000-4b1d0d06f00d", "valid"},
 		},
 	}
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{args}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -347,7 +347,7 @@ func (s *serviceSuite) TestServiceDeployWithInvalidPlacement(c *gc.C) {
 			{"deadbeef-0bad-400d-8000-4b1d0d06f00d", "invalid"},
 		},
 	}
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{args}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -372,7 +372,7 @@ func (s *serviceSuite) testClientServicesDeployWithBindings(c *gc.C, endpointBin
 		EndpointBindings: endpointBindings,
 	}
 
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{args}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -592,7 +592,7 @@ func (s *serviceSuite) TestAddCharmOverwritesPlaceholders(c *gc.C) {
 
 func (s *serviceSuite) TestServiceGetCharmURL(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	result, err := s.applicationApi.GetCharmURL(params.ApplicationGet{"wordpress"})
+	result, err := s.applicationAPI.GetCharmURL(params.ApplicationGet{"wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.Result, gc.Equals, "local:quantal/wordpress-3")
@@ -604,7 +604,7 @@ func (s *serviceSuite) TestServiceSetCharm(c *gc.C) {
 		URL: curl.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmUrl:        curl.String(),
 			ApplicationName: "application",
@@ -618,7 +618,7 @@ func (s *serviceSuite) TestServiceSetCharm(c *gc.C) {
 		URL: curl.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.applicationApi.SetCharm(params.ApplicationSetCharm{
+	err = s.applicationAPI.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "application",
 		CharmUrl:        curl.String(),
 	})
@@ -639,7 +639,7 @@ func (s *serviceSuite) setupServiceSetCharm(c *gc.C) {
 		URL: curl.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmUrl:        curl.String(),
 			ApplicationName: "application",
@@ -656,7 +656,7 @@ func (s *serviceSuite) setupServiceSetCharm(c *gc.C) {
 }
 
 func (s *serviceSuite) assertServiceSetCharm(c *gc.C, forceUnits bool) {
-	err := s.applicationApi.SetCharm(params.ApplicationSetCharm{
+	err := s.applicationAPI.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "application",
 		CharmUrl:        "cs:~who/precise/wordpress-3",
 		ForceUnits:      forceUnits,
@@ -671,7 +671,7 @@ func (s *serviceSuite) assertServiceSetCharm(c *gc.C, forceUnits bool) {
 }
 
 func (s *serviceSuite) assertServiceSetCharmBlocked(c *gc.C, msg string) {
-	err := s.applicationApi.SetCharm(params.ApplicationSetCharm{
+	err := s.applicationAPI.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "application",
 		CharmUrl:        "cs:~who/precise/wordpress-3",
 	})
@@ -702,7 +702,7 @@ func (s *serviceSuite) TestServiceSetCharmForceUnits(c *gc.C) {
 		URL: curl.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmUrl:        curl.String(),
 			ApplicationName: "application",
@@ -716,7 +716,7 @@ func (s *serviceSuite) TestServiceSetCharmForceUnits(c *gc.C) {
 		URL: curl.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.applicationApi.SetCharm(params.ApplicationSetCharm{
+	err = s.applicationAPI.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "application",
 		CharmUrl:        curl.String(),
 		ForceUnits:      true,
@@ -744,7 +744,7 @@ func (s *serviceSuite) TestBlockServiceSetCharmForce(c *gc.C) {
 }
 
 func (s *serviceSuite) TestServiceSetCharmInvalidService(c *gc.C) {
-	err := s.applicationApi.SetCharm(params.ApplicationSetCharm{
+	err := s.applicationAPI.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "badservice",
 		CharmUrl:        "cs:precise/wordpress-3",
 		ForceSeries:     true,
@@ -774,7 +774,7 @@ func (s *serviceSuite) TestServiceSetCharmLegacy(c *gc.C) {
 		URL: curl.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmUrl:        curl.String(),
 			ApplicationName: "application",
@@ -790,7 +790,7 @@ func (s *serviceSuite) TestServiceSetCharmLegacy(c *gc.C) {
 
 	// Even with forceSeries = true, we can't change a charm where
 	// the series is sepcified in the URL.
-	err = s.applicationApi.SetCharm(params.ApplicationSetCharm{
+	err = s.applicationAPI.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "application",
 		CharmUrl:        curl.String(),
 		ForceSeries:     true,
@@ -804,7 +804,7 @@ func (s *serviceSuite) TestServiceSetCharmUnsupportedSeries(c *gc.C) {
 		URL: curl.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmUrl:        curl.String(),
 			ApplicationName: "application",
@@ -819,7 +819,7 @@ func (s *serviceSuite) TestServiceSetCharmUnsupportedSeries(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.applicationApi.SetCharm(params.ApplicationSetCharm{
+	err = s.applicationAPI.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "application",
 		CharmUrl:        curl.String(),
 	})
@@ -832,7 +832,7 @@ func (s *serviceSuite) assertServiceSetCharmSeries(c *gc.C, upgradeCharm, series
 		URL: curl.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmUrl:        curl.String(),
 			ApplicationName: "application",
@@ -852,7 +852,7 @@ func (s *serviceSuite) assertServiceSetCharmSeries(c *gc.C, upgradeCharm, series
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.applicationApi.SetCharm(params.ApplicationSetCharm{
+	err = s.applicationAPI.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "application",
 		CharmUrl:        curl.String(),
 		ForceSeries:     true,
@@ -879,7 +879,7 @@ func (s *serviceSuite) TestServiceSetCharmWrongOS(c *gc.C) {
 		URL: curl.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmUrl:        curl.String(),
 			ApplicationName: "application",
@@ -894,7 +894,7 @@ func (s *serviceSuite) TestServiceSetCharmWrongOS(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.applicationApi.SetCharm(params.ApplicationSetCharm{
+	err = s.applicationAPI.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "application",
 		CharmUrl:        curl.String(),
 		ForceSeries:     true,
@@ -931,7 +931,7 @@ func (s *serviceSuite) TestSpecializeStoreOnDeployServiceSetCharmAndAddCharm(c *
 		URL: curl.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmUrl:        curl.String(),
 			ApplicationName: "application",
@@ -944,7 +944,7 @@ func (s *serviceSuite) TestSpecializeStoreOnDeployServiceSetCharmAndAddCharm(c *
 
 	// Check that the store's test mode is enabled when calling SetCharm.
 	curl, _ = s.UploadCharm(c, "trusty/wordpress-2", "wordpress")
-	err = s.applicationApi.SetCharm(params.ApplicationSetCharm{
+	err = s.applicationAPI.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "application",
 		CharmUrl:        curl.String(),
 	})
@@ -968,7 +968,7 @@ func (s *serviceSuite) setupServiceDeploy(c *gc.C, args string) (*charm.URL, cha
 }
 
 func (s *serviceSuite) assertServiceDeployPrincipal(c *gc.C, curl *charm.URL, ch charm.Charm, mem4g constraints.Value) {
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmUrl:        curl.String(),
 			ApplicationName: "application",
@@ -982,7 +982,7 @@ func (s *serviceSuite) assertServiceDeployPrincipal(c *gc.C, curl *charm.URL, ch
 }
 
 func (s *serviceSuite) assertServiceDeployPrincipalBlocked(c *gc.C, msg string, curl *charm.URL, mem4g constraints.Value) {
-	_, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	_, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmUrl:        curl.String(),
 			ApplicationName: "application",
@@ -1016,7 +1016,7 @@ func (s *serviceSuite) TestServiceDeploySubordinate(c *gc.C) {
 		URL: curl.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmUrl:        curl.String(),
 			ApplicationName: "application-name",
@@ -1045,7 +1045,7 @@ func (s *serviceSuite) TestServiceDeployConfig(c *gc.C) {
 		URL: curl.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmUrl:        curl.String(),
 			ApplicationName: "application-name",
@@ -1071,7 +1071,7 @@ func (s *serviceSuite) TestServiceDeployConfigError(c *gc.C) {
 		URL: curl.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmUrl:        curl.String(),
 			ApplicationName: "application-name",
@@ -1094,7 +1094,7 @@ func (s *serviceSuite) TestServiceDeployToMachine(c *gc.C) {
 
 	machine, err := s.State.AddMachine("precise", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmUrl:        curl.String(),
 			ApplicationName: "application-name",
@@ -1128,7 +1128,7 @@ func (s *serviceSuite) TestServiceDeployToMachine(c *gc.C) {
 }
 
 func (s *serviceSuite) TestServiceDeployToMachineNotFound(c *gc.C) {
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmUrl:        "cs:precise/application-name-1",
 			ApplicationName: "application-name",
@@ -1149,7 +1149,7 @@ func (s *serviceSuite) deployServiceForUpdateTests(c *gc.C) {
 		URL: curl.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.applicationApi.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmUrl:        curl.String(),
 			ApplicationName: "application",
@@ -1174,7 +1174,7 @@ func (s *serviceSuite) checkClientServiceUpdateSetCharm(c *gc.C, forceCharmUrl b
 		CharmUrl:        curl.String(),
 		ForceCharmUrl:   forceCharmUrl,
 	}
-	err = s.applicationApi.Update(args)
+	err = s.applicationAPI.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the charm has been updated and and the force flag correctly set.
@@ -1219,7 +1219,7 @@ func (s *serviceSuite) TestBlockChangeServiceUpdate(c *gc.C) {
 		CharmUrl:        curl,
 		ForceCharmUrl:   false,
 	}
-	err := s.applicationApi.Update(args)
+	err := s.applicationAPI.Update(args)
 	s.AssertBlocked(c, err, "TestBlockChangeServiceUpdate")
 }
 
@@ -1241,7 +1241,7 @@ func (s *serviceSuite) TestBlockServiceUpdateForced(c *gc.C) {
 		CharmUrl:        curl,
 		ForceCharmUrl:   true,
 	}
-	err := s.applicationApi.Update(args)
+	err := s.applicationAPI.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the charm has been updated and and the force flag correctly set.
@@ -1259,7 +1259,7 @@ func (s *serviceSuite) TestServiceUpdateSetCharmNotFound(c *gc.C) {
 		ApplicationName: "wordpress",
 		CharmUrl:        "cs:precise/wordpress-999999",
 	}
-	err := s.applicationApi.Update(args)
+	err := s.applicationAPI.Update(args)
 	c.Check(err, gc.ErrorMatches, `charm "cs:precise/wordpress-999999" not found`)
 }
 
@@ -1272,7 +1272,7 @@ func (s *serviceSuite) TestServiceUpdateSetMinUnits(c *gc.C) {
 		ApplicationName: "dummy",
 		MinUnits:        &minUnits,
 	}
-	err := s.applicationApi.Update(args)
+	err := s.applicationAPI.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the minimum number of units has been set.
@@ -1289,7 +1289,7 @@ func (s *serviceSuite) TestServiceUpdateSetMinUnitsError(c *gc.C) {
 		ApplicationName: "dummy",
 		MinUnits:        &minUnits,
 	}
-	err := s.applicationApi.Update(args)
+	err := s.applicationAPI.Update(args)
 	c.Assert(err, gc.ErrorMatches,
 		`cannot set minimum units for application "dummy": cannot set a negative minimum number of units`)
 
@@ -1306,7 +1306,7 @@ func (s *serviceSuite) TestServiceUpdateSetSettingsStrings(c *gc.C) {
 		ApplicationName: "dummy",
 		SettingsStrings: map[string]string{"title": "s-title", "username": "s-user"},
 	}
-	err := s.applicationApi.Update(args)
+	err := s.applicationAPI.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the settings have been correctly updated.
@@ -1324,7 +1324,7 @@ func (s *serviceSuite) TestServiceUpdateSetSettingsYAML(c *gc.C) {
 		ApplicationName: "dummy",
 		SettingsYAML:    "dummy:\n  title: y-title\n  username: y-user",
 	}
-	err := s.applicationApi.Update(args)
+	err := s.applicationAPI.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the settings have been correctly updated.
@@ -1342,7 +1342,7 @@ func (s *serviceSuite) TestClientServiceUpdateSetSettingsGetYAML(c *gc.C) {
 		ApplicationName: "dummy",
 		SettingsYAML:    "charm: dummy\napplication: dummy\nsettings:\n  title:\n    value: y-title\n    type: string\n  username:\n    value: y-user\n  ignore:\n    blah: true",
 	}
-	err := s.applicationApi.Update(args)
+	err := s.applicationAPI.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the settings have been correctly updated.
@@ -1362,7 +1362,7 @@ func (s *serviceSuite) TestServiceUpdateSetConstraints(c *gc.C) {
 		ApplicationName: "dummy",
 		Constraints:     &cons,
 	}
-	err = s.applicationApi.Update(args)
+	err = s.applicationAPI.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the constraints have been correctly updated.
@@ -1392,7 +1392,7 @@ func (s *serviceSuite) TestServiceUpdateAllParams(c *gc.C) {
 		SettingsYAML:    "application:\n  blog-title: yaml-title\n",
 		Constraints:     &cons,
 	}
-	err = s.applicationApi.Update(args)
+	err = s.applicationAPI.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the service has been correctly updated.
@@ -1426,18 +1426,18 @@ func (s *serviceSuite) TestServiceUpdateNoParams(c *gc.C) {
 
 	// Calling Update with no parameters set is a no-op.
 	args := params.ApplicationUpdate{ApplicationName: "wordpress"}
-	err := s.applicationApi.Update(args)
+	err := s.applicationAPI.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *serviceSuite) TestServiceUpdateNoService(c *gc.C) {
-	err := s.applicationApi.Update(params.ApplicationUpdate{})
+	err := s.applicationAPI.Update(params.ApplicationUpdate{})
 	c.Assert(err, gc.ErrorMatches, `"" is not a valid application name`)
 }
 
 func (s *serviceSuite) TestServiceUpdateInvalidService(c *gc.C) {
 	args := params.ApplicationUpdate{ApplicationName: "no-such-service"}
-	err := s.applicationApi.Update(args)
+	err := s.applicationAPI.Update(args)
 	c.Assert(err, gc.ErrorMatches, `application "no-such-service" not found`)
 }
 
@@ -1448,7 +1448,7 @@ var (
 func (s *serviceSuite) TestServiceSet(c *gc.C) {
 	dummy := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
-	err := s.applicationApi.Set(params.ApplicationSet{ApplicationName: "dummy", Options: map[string]string{
+	err := s.applicationAPI.Set(params.ApplicationSet{ApplicationName: "dummy", Options: map[string]string{
 		"title":    "foobar",
 		"username": validSetTestValue,
 	}})
@@ -1460,7 +1460,7 @@ func (s *serviceSuite) TestServiceSet(c *gc.C) {
 		"username": validSetTestValue,
 	})
 
-	err = s.applicationApi.Set(params.ApplicationSet{ApplicationName: "dummy", Options: map[string]string{
+	err = s.applicationAPI.Set(params.ApplicationSet{ApplicationName: "dummy", Options: map[string]string{
 		"title":    "barfoo",
 		"username": "",
 	}})
@@ -1474,7 +1474,7 @@ func (s *serviceSuite) TestServiceSet(c *gc.C) {
 }
 
 func (s *serviceSuite) assertServiceSetBlocked(c *gc.C, dummy *state.Application, msg string) {
-	err := s.applicationApi.Set(params.ApplicationSet{
+	err := s.applicationAPI.Set(params.ApplicationSet{
 		ApplicationName: "dummy",
 		Options: map[string]string{
 			"title":    "foobar",
@@ -1483,7 +1483,7 @@ func (s *serviceSuite) assertServiceSetBlocked(c *gc.C, dummy *state.Application
 }
 
 func (s *serviceSuite) assertServiceSet(c *gc.C, dummy *state.Application) {
-	err := s.applicationApi.Set(params.ApplicationSet{
+	err := s.applicationAPI.Set(params.ApplicationSet{
 		ApplicationName: "dummy",
 		Options: map[string]string{
 			"title":    "foobar",
@@ -1518,7 +1518,7 @@ func (s *serviceSuite) TestBlockChangesServiceSet(c *gc.C) {
 func (s *serviceSuite) TestServerUnset(c *gc.C) {
 	dummy := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
-	err := s.applicationApi.Set(params.ApplicationSet{ApplicationName: "dummy", Options: map[string]string{
+	err := s.applicationAPI.Set(params.ApplicationSet{ApplicationName: "dummy", Options: map[string]string{
 		"title":    "foobar",
 		"username": "user name",
 	}})
@@ -1530,7 +1530,7 @@ func (s *serviceSuite) TestServerUnset(c *gc.C) {
 		"username": "user name",
 	})
 
-	err = s.applicationApi.Unset(params.ApplicationUnset{ApplicationName: "dummy", Options: []string{"username"}})
+	err = s.applicationAPI.Unset(params.ApplicationUnset{ApplicationName: "dummy", Options: []string{"username"}})
 	c.Assert(err, jc.ErrorIsNil)
 	settings, err = dummy.ConfigSettings()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1542,7 +1542,7 @@ func (s *serviceSuite) TestServerUnset(c *gc.C) {
 func (s *serviceSuite) setupServerUnsetBlocked(c *gc.C) *state.Application {
 	dummy := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
-	err := s.applicationApi.Set(params.ApplicationSet{
+	err := s.applicationAPI.Set(params.ApplicationSet{
 		ApplicationName: "dummy",
 		Options: map[string]string{
 			"title":    "foobar",
@@ -1559,7 +1559,7 @@ func (s *serviceSuite) setupServerUnsetBlocked(c *gc.C) *state.Application {
 }
 
 func (s *serviceSuite) assertServerUnset(c *gc.C, dummy *state.Application) {
-	err := s.applicationApi.Unset(params.ApplicationUnset{
+	err := s.applicationAPI.Unset(params.ApplicationUnset{
 		ApplicationName: "dummy",
 		Options:         []string{"username"},
 	})
@@ -1572,7 +1572,7 @@ func (s *serviceSuite) assertServerUnset(c *gc.C, dummy *state.Application) {
 }
 
 func (s *serviceSuite) assertServerUnsetBlocked(c *gc.C, dummy *state.Application, msg string) {
-	err := s.applicationApi.Unset(params.ApplicationUnset{
+	err := s.applicationAPI.Unset(params.ApplicationUnset{
 		ApplicationName: "dummy",
 		Options:         []string{"username"},
 	})
@@ -1641,7 +1641,7 @@ func (s *serviceSuite) TestClientAddServiceUnits(c *gc.C) {
 		if t.to != "" {
 			args.Placement = []*instance.Placement{instance.MustParsePlacement(t.to)}
 		}
-		result, err := s.applicationApi.AddUnits(args)
+		result, err := s.applicationAPI.AddUnits(args)
 		if t.err != "" {
 			c.Assert(err, gc.ErrorMatches, t.err)
 			continue
@@ -1662,7 +1662,7 @@ func (s *serviceSuite) TestAddServiceUnitsToNewContainer(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.applicationApi.AddUnits(params.AddApplicationUnits{
+	_, err = s.applicationAPI.AddUnits(params.AddApplicationUnits{
 		ApplicationName: "dummy",
 		NumUnits:        1,
 		Placement:       []*instance.Placement{instance.MustParsePlacement("lxd:" + machine.Id())},
@@ -1713,7 +1713,7 @@ func (s *serviceSuite) TestAddServiceUnits(c *gc.C) {
 		if serviceName == "" {
 			serviceName = "dummy"
 		}
-		result, err := s.applicationApi.AddUnits(params.AddApplicationUnits{
+		result, err := s.applicationAPI.AddUnits(params.AddApplicationUnits{
 			ApplicationName: serviceName,
 			NumUnits:        len(t.expected),
 			Placement:       t.placement,
@@ -1735,7 +1735,7 @@ func (s *serviceSuite) TestAddServiceUnits(c *gc.C) {
 }
 
 func (s *serviceSuite) assertAddServiceUnits(c *gc.C) {
-	result, err := s.applicationApi.AddUnits(params.AddApplicationUnits{
+	result, err := s.applicationAPI.AddUnits(params.AddApplicationUnits{
 		ApplicationName: "dummy",
 		NumUnits:        3,
 	})
@@ -1758,10 +1758,10 @@ func (s *serviceSuite) TestServiceCharmRelations(c *gc.C) {
 	_, err = s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.applicationApi.CharmRelations(params.ApplicationCharmRelations{"blah"})
+	_, err = s.applicationAPI.CharmRelations(params.ApplicationCharmRelations{"blah"})
 	c.Assert(err, gc.ErrorMatches, `application "blah" not found`)
 
-	result, err := s.applicationApi.CharmRelations(params.ApplicationCharmRelations{"wordpress"})
+	result, err := s.applicationAPI.CharmRelations(params.ApplicationCharmRelations{"wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.CharmRelations, gc.DeepEquals, []string{
 		"cache", "db", "juju-info", "logging-dir", "monitoring-port", "url",
@@ -1769,7 +1769,7 @@ func (s *serviceSuite) TestServiceCharmRelations(c *gc.C) {
 }
 
 func (s *serviceSuite) assertAddServiceUnitsBlocked(c *gc.C, msg string) {
-	_, err := s.applicationApi.AddUnits(params.AddApplicationUnits{
+	_, err := s.applicationAPI.AddUnits(params.AddApplicationUnits{
 		ApplicationName: "dummy",
 		NumUnits:        3,
 	})
@@ -1796,7 +1796,7 @@ func (s *serviceSuite) TestBlockChangeAddServiceUnits(c *gc.C) {
 
 func (s *serviceSuite) TestAddUnitToMachineNotFound(c *gc.C) {
 	s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
-	_, err := s.applicationApi.AddUnits(params.AddApplicationUnits{
+	_, err := s.applicationAPI.AddUnits(params.AddApplicationUnits{
 		ApplicationName: "dummy",
 		NumUnits:        3,
 		Placement:       []*instance.Placement{instance.MustParsePlacement("42")},
@@ -1818,7 +1818,7 @@ func (s *serviceSuite) TestServiceExpose(c *gc.C) {
 	c.Assert(svcs[1].IsExposed(), jc.IsTrue)
 	for i, t := range serviceExposeTests {
 		c.Logf("test %d. %s", i, t.about)
-		err = s.applicationApi.Expose(params.ApplicationExpose{t.service})
+		err = s.applicationAPI.Expose(params.ApplicationExpose{t.service})
 		if t.err != "" {
 			c.Assert(err, gc.ErrorMatches, t.err)
 		} else {
@@ -1870,7 +1870,7 @@ var serviceExposeTests = []struct {
 func (s *serviceSuite) assertServiceExpose(c *gc.C) {
 	for i, t := range serviceExposeTests {
 		c.Logf("test %d. %s", i, t.about)
-		err := s.applicationApi.Expose(params.ApplicationExpose{t.service})
+		err := s.applicationAPI.Expose(params.ApplicationExpose{t.service})
 		if t.err != "" {
 			c.Assert(err, gc.ErrorMatches, t.err)
 		} else {
@@ -1885,7 +1885,7 @@ func (s *serviceSuite) assertServiceExpose(c *gc.C) {
 func (s *serviceSuite) assertServiceExposeBlocked(c *gc.C, msg string) {
 	for i, t := range serviceExposeTests {
 		c.Logf("test %d. %s", i, t.about)
-		err := s.applicationApi.Expose(params.ApplicationExpose{t.service})
+		err := s.applicationAPI.Expose(params.ApplicationExpose{t.service})
 		s.AssertBlocked(c, err, msg)
 	}
 }
@@ -1943,7 +1943,7 @@ func (s *serviceSuite) TestServiceUnexpose(c *gc.C) {
 			svc.SetExposed()
 		}
 		c.Assert(svc.IsExposed(), gc.Equals, t.initial)
-		err := s.applicationApi.Unexpose(params.ApplicationUnexpose{t.service})
+		err := s.applicationAPI.Unexpose(params.ApplicationUnexpose{t.service})
 		if t.err == "" {
 			c.Assert(err, jc.ErrorIsNil)
 			svc.Refresh()
@@ -1965,7 +1965,7 @@ func (s *serviceSuite) setupServiceUnexpose(c *gc.C) *state.Application {
 }
 
 func (s *serviceSuite) assertServiceUnexpose(c *gc.C, svc *state.Application) {
-	err := s.applicationApi.Unexpose(params.ApplicationUnexpose{"dummy-service"})
+	err := s.applicationAPI.Unexpose(params.ApplicationUnexpose{"dummy-service"})
 	c.Assert(err, jc.ErrorIsNil)
 	svc.Refresh()
 	c.Assert(svc.IsExposed(), gc.Equals, false)
@@ -1974,7 +1974,7 @@ func (s *serviceSuite) assertServiceUnexpose(c *gc.C, svc *state.Application) {
 }
 
 func (s *serviceSuite) assertServiceUnexposeBlocked(c *gc.C, svc *state.Application, msg string) {
-	err := s.applicationApi.Unexpose(params.ApplicationUnexpose{"dummy-service"})
+	err := s.applicationAPI.Unexpose(params.ApplicationUnexpose{"dummy-service"})
 	s.AssertBlocked(c, err, msg)
 	err = svc.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -2023,7 +2023,7 @@ func (s *serviceSuite) TestServiceDestroy(c *gc.C) {
 	s.AddTestingService(c, "dummy-service", s.AddTestingCharm(c, "dummy"))
 	for i, t := range serviceDestroyTests {
 		c.Logf("test %d. %s", i, t.about)
-		err := s.applicationApi.Destroy(params.ApplicationDestroy{t.service})
+		err := s.applicationAPI.Destroy(params.ApplicationDestroy{t.service})
 		if t.err != "" {
 			c.Assert(err, gc.ErrorMatches, t.err)
 		} else {
@@ -2038,7 +2038,7 @@ func (s *serviceSuite) TestServiceDestroy(c *gc.C) {
 	serviceName := "wordpress"
 	application, err := s.State.Application(serviceName)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.applicationApi.Destroy(params.ApplicationDestroy{serviceName})
+	err = s.applicationAPI.Destroy(params.ApplicationDestroy{serviceName})
 	c.Assert(err, jc.ErrorIsNil)
 	err = application.Refresh()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
@@ -2055,7 +2055,7 @@ func (s *serviceSuite) TestBlockServiceDestroy(c *gc.C) {
 
 	// block remove-objects
 	s.BlockRemoveObject(c, "TestBlockServiceDestroy")
-	err := s.applicationApi.Destroy(params.ApplicationDestroy{"dummy-service"})
+	err := s.applicationAPI.Destroy(params.ApplicationDestroy{"dummy-service"})
 	s.AssertBlocked(c, err, "TestBlockServiceDestroy")
 	// Tests may have invalid service names.
 	application, err := s.State.Application("dummy-service")
@@ -2101,7 +2101,7 @@ func (s *serviceSuite) TestDestroySubordinateUnits(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Try to destroy the subordinate alone; check it fails.
-	err = s.applicationApi.DestroyUnits(params.DestroyApplicationUnits{
+	err = s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
 		UnitNames: []string{"logging/0"},
 	})
 	c.Assert(err, gc.ErrorMatches, `no units were destroyed: unit "logging/0" is a subordinate`)
@@ -2112,7 +2112,7 @@ func (s *serviceSuite) TestDestroySubordinateUnits(c *gc.C) {
 
 func (s *serviceSuite) assertDestroyPrincipalUnits(c *gc.C, units []*state.Unit) {
 	// Destroy 2 of them; check they become Dying.
-	err := s.applicationApi.DestroyUnits(params.DestroyApplicationUnits{
+	err := s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
 		UnitNames: []string{"wordpress/0", "wordpress/1"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2121,7 +2121,7 @@ func (s *serviceSuite) assertDestroyPrincipalUnits(c *gc.C, units []*state.Unit)
 
 	// Try to destroy an Alive one and a Dying one; check
 	// it destroys the Alive one and ignores the Dying one.
-	err = s.applicationApi.DestroyUnits(params.DestroyApplicationUnits{
+	err = s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
 		UnitNames: []string{"wordpress/2", "wordpress/0"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2129,7 +2129,7 @@ func (s *serviceSuite) assertDestroyPrincipalUnits(c *gc.C, units []*state.Unit)
 
 	// Try to destroy an Alive one along with a nonexistent one; check that
 	// the valid instruction is followed but the invalid one is warned about.
-	err = s.applicationApi.DestroyUnits(params.DestroyApplicationUnits{
+	err = s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
 		UnitNames: []string{"boojum/123", "wordpress/3"},
 	})
 	c.Assert(err, gc.ErrorMatches, `some units were not destroyed: unit "boojum/123" does not exist`)
@@ -2140,7 +2140,7 @@ func (s *serviceSuite) assertDestroyPrincipalUnits(c *gc.C, units []*state.Unit)
 	c.Assert(err, jc.ErrorIsNil)
 	err = wp0.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.applicationApi.DestroyUnits(params.DestroyApplicationUnits{
+	err = s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
 		UnitNames: []string{"wordpress/0", "wordpress/4"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2186,7 +2186,7 @@ func (s *serviceSuite) assertBlockedErrorAndLiveliness(
 func (s *serviceSuite) TestBlockChangesDestroyPrincipalUnits(c *gc.C) {
 	units := s.setupDestroyPrincipalUnits(c)
 	s.BlockAllChanges(c, "TestBlockChangesDestroyPrincipalUnits")
-	err := s.applicationApi.DestroyUnits(params.DestroyApplicationUnits{
+	err := s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
 		UnitNames: []string{"wordpress/0", "wordpress/1"},
 	})
 	s.assertBlockedErrorAndLiveliness(c, err, "TestBlockChangesDestroyPrincipalUnits", units[0], units[1], units[2], units[3])
@@ -2195,7 +2195,7 @@ func (s *serviceSuite) TestBlockChangesDestroyPrincipalUnits(c *gc.C) {
 func (s *serviceSuite) TestBlockRemoveDestroyPrincipalUnits(c *gc.C) {
 	units := s.setupDestroyPrincipalUnits(c)
 	s.BlockRemoveObject(c, "TestBlockRemoveDestroyPrincipalUnits")
-	err := s.applicationApi.DestroyUnits(params.DestroyApplicationUnits{
+	err := s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
 		UnitNames: []string{"wordpress/0", "wordpress/1"},
 	})
 	s.assertBlockedErrorAndLiveliness(c, err, "TestBlockRemoveDestroyPrincipalUnits", units[0], units[1], units[2], units[3])
@@ -2204,7 +2204,7 @@ func (s *serviceSuite) TestBlockRemoveDestroyPrincipalUnits(c *gc.C) {
 func (s *serviceSuite) TestBlockDestroyDestroyPrincipalUnits(c *gc.C) {
 	units := s.setupDestroyPrincipalUnits(c)
 	s.BlockDestroyModel(c, "TestBlockDestroyDestroyPrincipalUnits")
-	err := s.applicationApi.DestroyUnits(params.DestroyApplicationUnits{
+	err := s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
 		UnitNames: []string{"wordpress/0", "wordpress/1"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2216,7 +2216,7 @@ func (s *serviceSuite) assertDestroySubordinateUnits(c *gc.C, wordpress0, loggin
 	// Try to destroy the principal and the subordinate together; check it warns
 	// about the subordinate, but destroys the one it can. (The principal unit
 	// agent will be responsible for destroying the subordinate.)
-	err := s.applicationApi.DestroyUnits(params.DestroyApplicationUnits{
+	err := s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
 		UnitNames: []string{"wordpress/0", "logging/0"},
 	})
 	c.Assert(err, gc.ErrorMatches, `some units were not destroyed: unit "logging/0" is a subordinate`)
@@ -2242,7 +2242,7 @@ func (s *serviceSuite) TestBlockRemoveDestroySubordinateUnits(c *gc.C) {
 
 	s.BlockRemoveObject(c, "TestBlockRemoveDestroySubordinateUnits")
 	// Try to destroy the subordinate alone; check it fails.
-	err = s.applicationApi.DestroyUnits(params.DestroyApplicationUnits{
+	err = s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
 		UnitNames: []string{"logging/0"},
 	})
 	s.AssertBlocked(c, err, "TestBlockRemoveDestroySubordinateUnits")
@@ -2250,7 +2250,7 @@ func (s *serviceSuite) TestBlockRemoveDestroySubordinateUnits(c *gc.C) {
 	assertLife(c, wordpress0, state.Alive)
 	assertLife(c, logging0, state.Alive)
 
-	err = s.applicationApi.DestroyUnits(params.DestroyApplicationUnits{
+	err = s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
 		UnitNames: []string{"wordpress/0", "logging/0"},
 	})
 	s.AssertBlocked(c, err, "TestBlockRemoveDestroySubordinateUnits")
@@ -2277,7 +2277,7 @@ func (s *serviceSuite) TestBlockChangesDestroySubordinateUnits(c *gc.C) {
 
 	s.BlockAllChanges(c, "TestBlockChangesDestroySubordinateUnits")
 	// Try to destroy the subordinate alone; check it fails.
-	err = s.applicationApi.DestroyUnits(params.DestroyApplicationUnits{
+	err = s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
 		UnitNames: []string{"logging/0"},
 	})
 	s.AssertBlocked(c, err, "TestBlockChangesDestroySubordinateUnits")
@@ -2285,7 +2285,7 @@ func (s *serviceSuite) TestBlockChangesDestroySubordinateUnits(c *gc.C) {
 	assertLife(c, wordpress0, state.Alive)
 	assertLife(c, logging0, state.Alive)
 
-	err = s.applicationApi.DestroyUnits(params.DestroyApplicationUnits{
+	err = s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
 		UnitNames: []string{"wordpress/0", "logging/0"},
 	})
 	s.AssertBlocked(c, err, "TestBlockChangesDestroySubordinateUnits")
@@ -2312,7 +2312,7 @@ func (s *serviceSuite) TestBlockDestroyDestroySubordinateUnits(c *gc.C) {
 
 	s.BlockDestroyModel(c, "TestBlockDestroyDestroySubordinateUnits")
 	// Try to destroy the subordinate alone; check it fails.
-	err = s.applicationApi.DestroyUnits(params.DestroyApplicationUnits{
+	err = s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
 		UnitNames: []string{"logging/0"},
 	})
 	c.Assert(err, gc.ErrorMatches, `no units were destroyed: unit "logging/0" is a subordinate`)
@@ -2327,7 +2327,7 @@ func (s *serviceSuite) TestClientSetServiceConstraints(c *gc.C) {
 	// Update constraints for the application.
 	cons, err := constraints.Parse("mem=4096", "cpu-cores=2")
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.applicationApi.SetConstraints(params.SetConstraints{ApplicationName: "dummy", Constraints: cons})
+	err = s.applicationAPI.SetConstraints(params.SetConstraints{ApplicationName: "dummy", Constraints: cons})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the constraints have been correctly updated.
@@ -2345,7 +2345,7 @@ func (s *serviceSuite) setupSetServiceConstraints(c *gc.C) (*state.Application, 
 }
 
 func (s *serviceSuite) assertSetServiceConstraints(c *gc.C, application *state.Application, cons constraints.Value) {
-	err := s.applicationApi.SetConstraints(params.SetConstraints{ApplicationName: "dummy", Constraints: cons})
+	err := s.applicationAPI.SetConstraints(params.SetConstraints{ApplicationName: "dummy", Constraints: cons})
 	c.Assert(err, jc.ErrorIsNil)
 	// Ensure the constraints have been correctly updated.
 	obtained, err := application.Constraints()
@@ -2354,7 +2354,7 @@ func (s *serviceSuite) assertSetServiceConstraints(c *gc.C, application *state.A
 }
 
 func (s *serviceSuite) assertSetServiceConstraintsBlocked(c *gc.C, msg string, service *state.Application, cons constraints.Value) {
-	err := s.applicationApi.SetConstraints(params.SetConstraints{ApplicationName: "dummy", Constraints: cons})
+	err := s.applicationAPI.SetConstraints(params.SetConstraints{ApplicationName: "dummy", Constraints: cons})
 	s.AssertBlocked(c, err, msg)
 }
 
@@ -2386,7 +2386,7 @@ func (s *serviceSuite) TestClientGetServiceConstraints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check we can get the constraints.
-	result, err := s.applicationApi.GetConstraints(params.GetApplicationConstraints{"dummy"})
+	result, err := s.applicationAPI.GetConstraints(params.GetApplicationConstraints{"dummy"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Constraints, gc.DeepEquals, cons)
 }
@@ -2421,7 +2421,7 @@ func (s *serviceSuite) setupRelationScenario(c *gc.C) {
 
 func (s *serviceSuite) assertAddRelation(c *gc.C, endpoints []string) {
 	s.setupRelationScenario(c)
-	res, err := s.applicationApi.AddRelation(params.AddRelation{Endpoints: endpoints})
+	res, err := s.applicationAPI.AddRelation(params.AddRelation{Endpoints: endpoints})
 	c.Assert(err, jc.ErrorIsNil)
 	s.checkEndpoints(c, res.Endpoints)
 	// Show that the relation was added.
@@ -2455,7 +2455,7 @@ func (s *serviceSuite) TestBlockRemoveAddRelation(c *gc.C) {
 func (s *serviceSuite) TestBlockChangesAddRelation(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	s.BlockAllChanges(c, "TestBlockChangesAddRelation")
-	_, err := s.applicationApi.AddRelation(params.AddRelation{Endpoints: []string{"wordpress", "mysql"}})
+	_, err := s.applicationAPI.AddRelation(params.AddRelation{Endpoints: []string{"wordpress", "mysql"}})
 	s.AssertBlocked(c, err, "TestBlockChangesAddRelation")
 }
 
@@ -2470,7 +2470,7 @@ func (s *serviceSuite) TestSuccessfullyAddRelationSwapped(c *gc.C) {
 func (s *serviceSuite) TestCallWithOnlyOneEndpoint(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	endpoints := []string{"wordpress"}
-	_, err := s.applicationApi.AddRelation(params.AddRelation{Endpoints: endpoints})
+	_, err := s.applicationAPI.AddRelation(params.AddRelation{Endpoints: endpoints})
 	c.Assert(err, gc.ErrorMatches, "no relations found")
 }
 
@@ -2478,7 +2478,7 @@ func (s *serviceSuite) TestCallWithOneEndpointTooMany(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	s.AddTestingService(c, "logging", s.AddTestingCharm(c, "logging"))
 	endpoints := []string{"wordpress", "mysql", "logging"}
-	_, err := s.applicationApi.AddRelation(params.AddRelation{Endpoints: endpoints})
+	_, err := s.applicationAPI.AddRelation(params.AddRelation{Endpoints: endpoints})
 	c.Assert(err, gc.ErrorMatches, "cannot relate 3 endpoints")
 }
 
@@ -2491,7 +2491,7 @@ func (s *serviceSuite) TestAddAlreadyAddedRelation(c *gc.C) {
 	_, err = s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
 	// And try to add it again.
-	_, err = s.applicationApi.AddRelation(params.AddRelation{Endpoints: endpoints})
+	_, err = s.applicationAPI.AddRelation(params.AddRelation{Endpoints: endpoints})
 	c.Assert(err, gc.ErrorMatches, `cannot add relation "wordpress:db mysql:server": relation already exists`)
 }
 
@@ -2513,7 +2513,7 @@ func (s *serviceSuite) assertDestroyRelation(c *gc.C, endpoints []string) {
 }
 
 func (s *serviceSuite) assertDestroyRelationSuccess(c *gc.C, relation *state.Relation, endpoints []string) {
-	err := s.applicationApi.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
+	err := s.applicationAPI.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
 	c.Assert(err, jc.ErrorIsNil)
 	// Show that the relation was removed.
 	c.Assert(relation.Refresh(), jc.Satisfies, errors.IsNotFound)
@@ -2535,7 +2535,7 @@ func (s *serviceSuite) TestSuccessfullyDestroyRelationSwapped(c *gc.C) {
 func (s *serviceSuite) TestNoRelation(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	endpoints := []string{"wordpress", "mysql"}
-	err := s.applicationApi.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
+	err := s.applicationAPI.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
 	c.Assert(err, gc.ErrorMatches, `relation "wordpress:db mysql:server" not found`)
 }
 
@@ -2543,14 +2543,14 @@ func (s *serviceSuite) TestAttemptDestroyingNonExistentRelation(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	s.AddTestingService(c, "riak", s.AddTestingCharm(c, "riak"))
 	endpoints := []string{"riak", "wordpress"}
-	err := s.applicationApi.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
+	err := s.applicationAPI.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
 	c.Assert(err, gc.ErrorMatches, "no relations found")
 }
 
 func (s *serviceSuite) TestAttemptDestroyingWithOnlyOneEndpoint(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	endpoints := []string{"wordpress"}
-	err := s.applicationApi.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
+	err := s.applicationAPI.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
 	c.Assert(err, gc.ErrorMatches, "no relations found")
 }
 
@@ -2559,7 +2559,7 @@ func (s *serviceSuite) TestAttemptDestroyingPeerRelation(c *gc.C) {
 	s.AddTestingService(c, "riak", s.AddTestingCharm(c, "riak"))
 
 	endpoints := []string{"riak:ring"}
-	err := s.applicationApi.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
+	err := s.applicationAPI.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
 	c.Assert(err, gc.ErrorMatches, `cannot destroy relation "riak:ring": is a peer relation`)
 }
 
@@ -2573,12 +2573,12 @@ func (s *serviceSuite) TestAttemptDestroyingAlreadyDestroyedRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	endpoints := []string{"wordpress", "mysql"}
-	err = s.applicationApi.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
+	err = s.applicationAPI.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
 	// Show that the relation was removed.
 	c.Assert(rel.Refresh(), jc.Satisfies, errors.IsNotFound)
 
 	// And try to destroy it again.
-	err = s.applicationApi.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
+	err = s.applicationAPI.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
 	c.Assert(err, gc.ErrorMatches, `relation "wordpress:db mysql:server" not found`)
 }
 
@@ -2587,7 +2587,7 @@ func (s *serviceSuite) TestBlockRemoveDestroyRelation(c *gc.C) {
 	relation := s.setupDestroyRelationScenario(c, endpoints)
 	// block remove-objects
 	s.BlockRemoveObject(c, "TestBlockRemoveDestroyRelation")
-	err := s.applicationApi.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
+	err := s.applicationAPI.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
 	s.AssertBlocked(c, err, "TestBlockRemoveDestroyRelation")
 	assertLife(c, relation, state.Alive)
 }
@@ -2596,7 +2596,7 @@ func (s *serviceSuite) TestBlockChangeDestroyRelation(c *gc.C) {
 	endpoints := []string{"wordpress", "mysql"}
 	relation := s.setupDestroyRelationScenario(c, endpoints)
 	s.BlockAllChanges(c, "TestBlockChangeDestroyRelation")
-	err := s.applicationApi.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
+	err := s.applicationAPI.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
 	s.AssertBlocked(c, err, "TestBlockChangeDestroyRelation")
 	assertLife(c, relation, state.Alive)
 }

--- a/apiserver/application/get_test.go
+++ b/apiserver/application/get_test.go
@@ -21,7 +21,7 @@ import (
 type getSuite struct {
 	jujutesting.JujuConnSuite
 
-	serviceApi *application.API
+	serviceAPI *application.API
 	authorizer apiservertesting.FakeAuthorizer
 }
 
@@ -34,13 +34,13 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 		Tag: s.AdminUserTag(c),
 	}
 	var err error
-	s.serviceApi, err = application.NewAPI(s.State, nil, s.authorizer)
+	s.serviceAPI, err = application.NewAPI(s.State, nil, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *getSuite) TestClientServiceGetSmoketest(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	results, err := s.serviceApi.Get(params.ApplicationGet{"wordpress"})
+	results, err := s.serviceAPI.Get(params.ApplicationGet{"wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
 		Application: "wordpress",
@@ -58,7 +58,7 @@ func (s *getSuite) TestClientServiceGetSmoketest(c *gc.C) {
 }
 
 func (s *getSuite) TestServiceGetUnknownService(c *gc.C) {
-	_, err := s.serviceApi.Get(params.ApplicationGet{"unknown"})
+	_, err := s.serviceAPI.Get(params.ApplicationGet{"unknown"})
 	c.Assert(err, gc.ErrorMatches, `application "unknown" not found`)
 }
 

--- a/apiserver/client_auth_root_test.go
+++ b/apiserver/client_auth_root_test.go
@@ -32,7 +32,7 @@ func (*clientAuthRootSuite) AssertCallGood(c *gc.C, client *clientAuthRoot, root
 
 func (*clientAuthRootSuite) AssertCallNotImplemented(c *gc.C, client *clientAuthRoot, rootName string, version int, methodName string) {
 	caller, err := client.FindMethod(rootName, version, methodName)
-	c.Check(errors.Cause(err), jc.Satisfies, isCallNotImplementedError)
+	c.Check(err, jc.Satisfies, isCallNotImplementedError)
 	c.Assert(caller, gc.IsNil)
 }
 
@@ -58,14 +58,12 @@ func (s *clientAuthRootSuite) TestReadOnlyUser(c *gc.C) {
 	s.AssertCallErrPerm(c, client, "Application", 1, "Deploy")
 	// read only commands are fine
 	s.AssertCallGood(c, client, "Client", 1, "FullStatus")
-	// calls on the restricted root is also fine
-	s.AssertCallGood(c, client, "UserManager", 1, "AddUser")
 	s.AssertCallNotImplemented(c, client, "Client", 1, "Unknown")
 	s.AssertCallNotImplemented(c, client, "Unknown", 1, "Method")
 }
 
 func isCallNotImplementedError(err error) bool {
-	_, ok := err.(*rpcreflect.CallNotImplementedError)
+	_, ok := errors.Cause(err).(*rpcreflect.CallNotImplementedError)
 	return ok
 }
 

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -193,6 +193,7 @@ func ServerError(err error) *params.Error {
 	if err == nil {
 		return nil
 	}
+	logger.Infof("server RPC error %v", errors.Details(err))
 	msg := err.Error()
 	// Skip past annotations when looking for the code.
 	err = errors.Cause(err)

--- a/apiserver/common/testing/block.go
+++ b/apiserver/common/testing/block.go
@@ -20,7 +20,7 @@ import (
 // It provides easy access to switch blocks on
 // as well as test whether operations are blocked or not.
 type BlockHelper struct {
-	ApiState api.Connection
+	apiState api.Connection
 	client   *block.Client
 }
 
@@ -28,7 +28,7 @@ type BlockHelper struct {
 // to manage desired juju blocks.
 func NewBlockHelper(st api.Connection) BlockHelper {
 	return BlockHelper{
-		ApiState: st,
+		apiState: st,
 		client:   block.NewClient(st),
 	}
 }
@@ -52,7 +52,7 @@ func (s BlockHelper) BlockRemoveObject(c *gc.C, msg string) {
 
 func (s BlockHelper) Close() {
 	s.client.Close()
-	s.ApiState.Close()
+	s.apiState.Close()
 }
 
 // BlockDestroyModel blocks destroy-model.

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -56,7 +56,7 @@ func ServerAuthenticatorForTag(srv *Server, tag names.Tag) (authentication.Entit
 	return srv.authCtxt.authenticatorForTag(tag)
 }
 
-func ApiHandlerWithEntity(entity state.Entity) *apiHandler {
+func APIHandlerWithEntity(entity state.Entity) *apiHandler {
 	return &apiHandler{entity: entity}
 }
 
@@ -84,16 +84,16 @@ func NewErrRoot(err error) *errRoot {
 	return &errRoot{err}
 }
 
-// TestingApiRoot gives you an ApiRoot as a rpc.Methodfinder that is
+// TestingAPIRoot gives you an APIRoot as a rpc.Methodfinder that is
 // *barely* connected to anything.  Just enough to let you probe some
 // of the interfaces, but not enough to actually do any RPC calls.
-func TestingApiRoot(st *state.State) rpc.Root {
-	return newApiRoot(st, common.NewResources(), nil)
+func TestingAPIRoot(st *state.State) rpc.Root {
+	return newAPIRoot(st, common.NewResources(), nil)
 }
 
-// TestingApiHandler gives you an ApiHandler that isn't connected to
+// TestingAPIHandler gives you an APIHandler that isn't connected to
 // anything real. It's enough to let test some basic functionality though.
-func TestingApiHandler(c *gc.C, srvSt, st *state.State) (*apiHandler, *common.Resources) {
+func TestingAPIHandler(c *gc.C, srvSt, st *state.State) (*apiHandler, *common.Resources) {
 	authCtxt, err := newAuthContext(srvSt)
 	c.Assert(err, jc.ErrorIsNil)
 	srv := &Server{
@@ -101,16 +101,16 @@ func TestingApiHandler(c *gc.C, srvSt, st *state.State) (*apiHandler, *common.Re
 		state:    srvSt,
 		tag:      names.NewMachineTag("0"),
 	}
-	h, err := newApiHandler(srv, st, nil, st.ModelUUID())
+	h, err := newAPIHandler(srv, st, nil, st.ModelUUID())
 	c.Assert(err, jc.ErrorIsNil)
 	return h, h.getResources()
 }
 
-// TestingApiHandlerWithEntity gives you the sane kind of ApiHandler as
-// TestingApiHandler but sets the passed entity as the apiHandler
+// TestingAPIHandlerWithEntity gives you the sane kind of APIHandler as
+// TestingAPIHandler but sets the passed entity as the apiHandler
 // entity.
-func TestingApiHandlerWithEntity(c *gc.C, srvSt, st *state.State, entity state.Entity) (*apiHandler, *common.Resources) {
-	h, hr := TestingApiHandler(c, srvSt, st)
+func TestingAPIHandlerWithEntity(c *gc.C, srvSt, st *state.State, entity state.Entity) (*apiHandler, *common.Resources) {
+	h, hr := TestingAPIHandler(c, srvSt, st)
 	h.entity = entity
 	return h, hr
 }
@@ -118,84 +118,84 @@ func TestingApiHandlerWithEntity(c *gc.C, srvSt, st *state.State, entity state.E
 // TestingUpgradingRoot returns a limited srvRoot
 // in an upgrade scenario.
 func TestingUpgradingRoot(st *state.State) rpc.Root {
-	r := TestingApiRoot(st)
+	r := TestingAPIRoot(st)
 	return newUpgradingRoot(r)
 }
 
-// TestingRestrictedApiHandler returns a restricted srvRoot as if accessed
+// TestingRestrictedAPIHandler returns a restricted srvRoot as if accessed
 // from the root of the API path.
-func TestingRestrictedApiHandler(st *state.State) rpc.Root {
-	r := TestingApiRoot(st)
-	return newRestrictedRoot(r)
+func TestingRestrictedAPIHandler(st *state.State) rpc.Root {
+	r := TestingAPIRoot(st)
+	return newRestrictedRoot(r, isControllerFacade)
 }
 
-type preFacadeAdminApi struct{}
+type preFacadeAdminAPI struct{}
 
-func newPreFacadeAdminApi(srv *Server, root *apiHandler, observer observer.Observer) interface{} {
-	return &preFacadeAdminApi{}
+func newPreFacadeAdminAPI(srv *Server, root *apiHandler, observer observer.Observer) interface{} {
+	return &preFacadeAdminAPI{}
 }
 
-func (r *preFacadeAdminApi) Admin(id string) (*preFacadeAdminApi, error) {
+func (r *preFacadeAdminAPI) Admin(id string) (*preFacadeAdminAPI, error) {
 	return r, nil
 }
 
 var PreFacadeModelTag = names.NewModelTag("383c49f3-526d-4f9e-b50a-1e6fa4e9b3d9")
 
-func (r *preFacadeAdminApi) Login(c params.Creds) (params.LoginResult, error) {
+func (r *preFacadeAdminAPI) Login(c params.Creds) (params.LoginResult, error) {
 	return params.LoginResult{
 		ModelTag: PreFacadeModelTag.String(),
 	}, nil
 }
 
-type failAdminApi struct{}
+type failAdminAPI struct{}
 
-func newFailAdminApi(srv *Server, root *apiHandler, observer observer.Observer) interface{} {
-	return &failAdminApi{}
+func newFailAdminAPI(srv *Server, root *apiHandler, observer observer.Observer) interface{} {
+	return &failAdminAPI{}
 }
 
-func (r *failAdminApi) Admin(id string) (*failAdminApi, error) {
+func (r *failAdminAPI) Admin(id string) (*failAdminAPI, error) {
 	return r, nil
 }
 
-func (r *failAdminApi) Login(c params.Creds) (params.LoginResult, error) {
+func (r *failAdminAPI) Login(c params.Creds) (params.LoginResult, error) {
 	return params.LoginResult{}, fmt.Errorf("fail")
 }
 
-// SetPreFacadeAdminApi is used to create a test scenario where the API server
+// SetPreFacadeAdminAPI is used to create a test scenario where the API server
 // does not know about API facade versioning. In this case, the client should
 // login to the v1 facade, which sends backwards-compatible login fields.
 // The v0 facade will fail on a pre-defined error.
-func SetPreFacadeAdminApi(srv *Server) {
-	srv.adminApiFactories = map[int]adminApiFactory{
-		0: newFailAdminApi,
-		1: newPreFacadeAdminApi,
+func SetPreFacadeAdminAPI(srv *Server) {
+	srv.adminAPIFactories = map[int]adminAPIFactory{
+		0: newFailAdminAPI,
+		1: newPreFacadeAdminAPI,
 	}
 }
 
-func SetAdminApiVersions(srv *Server, versions ...int) {
-	factories := make(map[int]adminApiFactory)
+func SetAdminAPIVersions(srv *Server, versions ...int) {
+	factories := make(map[int]adminAPIFactory)
 	for _, n := range versions {
 		switch n {
 		case 3:
-			factories[n] = newAdminApiV3
+			factories[n] = newAdminAPIV3
 		default:
 			panic(fmt.Errorf("unknown admin API version %d", n))
 		}
 	}
-	srv.adminApiFactories = factories
+	srv.adminAPIFactories = factories
 }
 
 // TestingRestoreInProgressRoot returns a limited restoreInProgressRoot
 // containing a srvRoot as returned by TestingSrvRoot.
 func TestingRestoreInProgressRoot(st *state.State) *restoreInProgressRoot {
-	r := TestingApiRoot(st)
+	r := TestingAPIRoot(st)
 	return newRestoreInProgressRoot(r)
 }
 
 // TestingAboutToRestoreRoot returns a limited aboutToRestoreRoot
 // containing a srvRoot as returned by TestingSrvRoot.
 func TestingAboutToRestoreRoot(st *state.State) *aboutToRestoreRoot {
-	r := TestingApiRoot(st)
+	r := TestingAPIRoot(st)
 	return newAboutToRestoreRoot(r)
 }
 

--- a/apiserver/read_only_calls.go
+++ b/apiserver/read_only_calls.go
@@ -61,6 +61,7 @@ var readOnlyCalls = set.NewStrings(
 	"Subnets.AllZones",
 	"Subnets.ListSubnets",
 	"UserManager.UserInfo",
+	"UserManager.CreateLocalLoginMacaroon",
 )
 
 // isCallReadOnly returns whether or not the method on the facade

--- a/apiserver/restricted_root_test.go
+++ b/apiserver/restricted_root_test.go
@@ -23,7 +23,7 @@ var _ = gc.Suite(&restrictedRootSuite{})
 
 func (r *restrictedRootSuite) SetUpTest(c *gc.C) {
 	r.BaseSuite.SetUpTest(c)
-	r.root = apiserver.TestingRestrictedApiHandler(nil)
+	r.root = apiserver.TestingRestrictedAPIHandler(nil)
 }
 
 func (r *restrictedRootSuite) assertMethodAllowed(c *gc.C, rootName string, version int, method string) {
@@ -52,7 +52,7 @@ func (r *restrictedRootSuite) TestFindAllowedMethod(c *gc.C) {
 func (r *restrictedRootSuite) TestFindDisallowedMethod(c *gc.C) {
 	caller, err := r.root.FindMethod("Client", 1, "FullStatus")
 
-	c.Assert(err, gc.ErrorMatches, `logged in to server, no model, "Client" not supported`)
+	c.Assert(err, gc.ErrorMatches, `facade "Client" not supported for API connection type`)
 	c.Assert(errors.IsNotSupported(err), jc.IsTrue)
 	c.Assert(caller, gc.IsNil)
 }
@@ -60,7 +60,7 @@ func (r *restrictedRootSuite) TestFindDisallowedMethod(c *gc.C) {
 func (r *restrictedRootSuite) TestNonExistentFacade(c *gc.C) {
 	caller, err := r.root.FindMethod("SomeFacade", 0, "Method")
 
-	c.Assert(err, gc.ErrorMatches, `logged in to server, no model, "SomeFacade" not supported`)
+	c.Assert(err, gc.ErrorMatches, `facade "SomeFacade" not supported for API connection type`)
 	c.Assert(caller, gc.IsNil)
 }
 

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -42,7 +42,7 @@ type objectKey struct {
 
 // apiHandler represents a single client's connection to the state
 // after it has logged in. It contains an rpc.Root which it
-// uses to dispatch Api calls appropriately.
+// uses to dispatch API calls appropriately.
 type apiHandler struct {
 	state     *state.State
 	rpcConn   *rpc.Conn
@@ -57,8 +57,8 @@ type apiHandler struct {
 
 var _ = (*apiHandler)(nil)
 
-// newApiHandler returns a new apiHandler.
-func newApiHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID string) (*apiHandler, error) {
+// newAPIHandler returns a new apiHandler.
+func newAPIHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID string) (*apiHandler, error) {
 	r := &apiHandler{
 		state:     st,
 		resources: common.NewResources(),
@@ -137,8 +137,8 @@ type apiRoot struct {
 	objectCache map[objectKey]reflect.Value
 }
 
-// newApiRoot returns a new apiRoot.
-func newApiRoot(st *state.State, resources *common.Resources, authorizer facade.Authorizer) *apiRoot {
+// newAPIRoot returns a new apiRoot.
+func newAPIRoot(st *state.State, resources *common.Resources, authorizer facade.Authorizer) *apiRoot {
 	r := &apiRoot{
 		state:       st,
 		resources:   resources,
@@ -280,14 +280,14 @@ func lookupMethod(rootName string, version int, methodName string) (reflect.Type
 // which has not logged in.
 type anonRoot struct {
 	*apiHandler
-	adminApis map[int]interface{}
+	adminAPIs map[int]interface{}
 }
 
 // NewAnonRoot creates a new AnonRoot which dispatches to the given Admin API implementation.
-func newAnonRoot(h *apiHandler, adminApis map[int]interface{}) *anonRoot {
+func newAnonRoot(h *apiHandler, adminAPIs map[int]interface{}) *anonRoot {
 	r := &anonRoot{
 		apiHandler: h,
-		adminApis:  adminApis,
+		adminAPIs:  adminAPIs,
 	}
 	return r
 }
@@ -299,7 +299,7 @@ func (r *anonRoot) FindMethod(rootName string, version int, methodName string) (
 			Version:    version,
 		}
 	}
-	if api, ok := r.adminApis[version]; ok {
+	if api, ok := r.adminAPIs[version]; ok {
 		return rpcreflect.ValueOf(reflect.ValueOf(api)).FindMethod(rootName, 0, methodName)
 	}
 	return nil, &rpc.RequestError{

--- a/apiserver/root_test.go
+++ b/apiserver/root_test.go
@@ -119,7 +119,7 @@ type rootSuite struct {
 var _ = gc.Suite(&rootSuite{})
 
 func (r *rootSuite) TestFindMethodUnknownFacade(c *gc.C) {
-	root := apiserver.TestingApiRoot(nil)
+	root := apiserver.TestingAPIRoot(nil)
 	caller, err := root.FindMethod("unknown-testing-facade", 0, "Method")
 	c.Check(caller, gc.IsNil)
 	c.Check(err, gc.FitsTypeOf, (*rpcreflect.CallNotImplementedError)(nil))
@@ -127,7 +127,7 @@ func (r *rootSuite) TestFindMethodUnknownFacade(c *gc.C) {
 }
 
 func (r *rootSuite) TestFindMethodUnknownVersion(c *gc.C) {
-	srvRoot := apiserver.TestingApiRoot(nil)
+	srvRoot := apiserver.TestingAPIRoot(nil)
 	defer common.Facades.Discard("my-testing-facade", 0)
 	myGoodFacade := func(
 		*state.State, facade.Resources, facade.Authorizer,
@@ -144,7 +144,7 @@ func (r *rootSuite) TestFindMethodUnknownVersion(c *gc.C) {
 }
 
 func (r *rootSuite) TestFindMethodEnsuresTypeMatch(c *gc.C) {
-	srvRoot := apiserver.TestingApiRoot(nil)
+	srvRoot := apiserver.TestingAPIRoot(nil)
 	defer common.Facades.Discard("my-testing-facade", 0)
 	defer common.Facades.Discard("my-testing-facade", 1)
 	defer common.Facades.Discard("my-testing-facade", 2)
@@ -207,7 +207,7 @@ func assertCallResult(c *gc.C, caller rpcreflect.MethodCaller, id string, expect
 }
 
 func (r *rootSuite) TestFindMethodCachesFacades(c *gc.C) {
-	srvRoot := apiserver.TestingApiRoot(nil)
+	srvRoot := apiserver.TestingAPIRoot(nil)
 	defer common.Facades.Discard("my-counting-facade", 0)
 	defer common.Facades.Discard("my-counting-facade", 1)
 	var count int64
@@ -243,7 +243,7 @@ func (r *rootSuite) TestFindMethodCachesFacades(c *gc.C) {
 }
 
 func (r *rootSuite) TestFindMethodCachesFacadesWithId(c *gc.C) {
-	srvRoot := apiserver.TestingApiRoot(nil)
+	srvRoot := apiserver.TestingAPIRoot(nil)
 	defer common.Facades.Discard("my-counting-facade", 0)
 	var count int64
 	// like newCounter, but also tracks the "id" that was requested for
@@ -275,7 +275,7 @@ func (r *rootSuite) TestFindMethodCachesFacadesWithId(c *gc.C) {
 }
 
 func (r *rootSuite) TestFindMethodCacheRaceSafe(c *gc.C) {
-	srvRoot := apiserver.TestingApiRoot(nil)
+	srvRoot := apiserver.TestingAPIRoot(nil)
 	defer common.Facades.Discard("my-counting-facade", 0)
 	var count int64
 	newIdCounter := func(context facade.Context) (facade.Facade, error) {
@@ -326,7 +326,7 @@ func (*secondImpl) OneMethod() stringVar {
 }
 
 func (r *rootSuite) TestFindMethodHandlesInterfaceTypes(c *gc.C) {
-	srvRoot := apiserver.TestingApiRoot(nil)
+	srvRoot := apiserver.TestingAPIRoot(nil)
 	defer common.Facades.Discard("my-interface-facade", 0)
 	defer common.Facades.Discard("my-interface-facade", 1)
 	common.RegisterStandardFacade("my-interface-facade", 0, func(
@@ -388,7 +388,7 @@ func (r *rootSuite) TestAuthOwner(c *gc.C) {
 
 	entity := &stubStateEntity{tag}
 
-	apiHandler := apiserver.ApiHandlerWithEntity(entity)
+	apiHandler := apiserver.APIHandlerWithEntity(entity)
 	authorized := apiHandler.AuthOwner(tag)
 
 	c.Check(authorized, jc.IsTrue)

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -451,10 +451,10 @@ func (s *serverSuite) bootstrapHasPermissionTest(c *gc.C) (*state.User, names.Co
 	return u, ctag
 }
 
-func (s *serverSuite) TestApiHandlerHasPermissionLogin(c *gc.C) {
+func (s *serverSuite) TestAPIHandlerHasPermissionLogin(c *gc.C) {
 	u, ctag := s.bootstrapHasPermissionTest(c)
 
-	handler, _ := apiserver.TestingApiHandlerWithEntity(c, s.State, s.State, u)
+	handler, _ := apiserver.TestingAPIHandlerWithEntity(c, s.State, s.State, u)
 	defer handler.Kill()
 
 	apiserver.AssertHasPermission(c, handler, description.LoginAccess, ctag, true)
@@ -462,11 +462,11 @@ func (s *serverSuite) TestApiHandlerHasPermissionLogin(c *gc.C) {
 	apiserver.AssertHasPermission(c, handler, description.SuperuserAccess, ctag, false)
 }
 
-func (s *serverSuite) TestApiHandlerHasPermissionAdmodel(c *gc.C) {
+func (s *serverSuite) TestAPIHandlerHasPermissionAdmodel(c *gc.C) {
 	u, ctag := s.bootstrapHasPermissionTest(c)
 	user := u.UserTag()
 
-	handler, _ := apiserver.TestingApiHandlerWithEntity(c, s.State, s.State, u)
+	handler, _ := apiserver.TestingAPIHandlerWithEntity(c, s.State, s.State, u)
 	defer handler.Kill()
 
 	ua, err := s.State.SetUserAccess(user, ctag, description.AddModelAccess)
@@ -478,11 +478,11 @@ func (s *serverSuite) TestApiHandlerHasPermissionAdmodel(c *gc.C) {
 	apiserver.AssertHasPermission(c, handler, description.SuperuserAccess, ctag, false)
 }
 
-func (s *serverSuite) TestApiHandlerHasPermissionSuperUser(c *gc.C) {
+func (s *serverSuite) TestAPIHandlerHasPermissionSuperUser(c *gc.C) {
 	u, ctag := s.bootstrapHasPermissionTest(c)
 	user := u.UserTag()
 
-	handler, _ := apiserver.TestingApiHandlerWithEntity(c, s.State, s.State, u)
+	handler, _ := apiserver.TestingAPIHandlerWithEntity(c, s.State, s.State, u)
 	defer handler.Kill()
 
 	ua, err := s.State.SetUserAccess(user, ctag, description.SuperuserAccess)
@@ -494,25 +494,25 @@ func (s *serverSuite) TestApiHandlerHasPermissionSuperUser(c *gc.C) {
 	apiserver.AssertHasPermission(c, handler, description.SuperuserAccess, ctag, true)
 }
 
-func (s *serverSuite) TestApiHandlerTeardownInitialEnviron(c *gc.C) {
-	s.checkApiHandlerTeardown(c, s.State, s.State)
+func (s *serverSuite) TestAPIHandlerTeardownInitialEnviron(c *gc.C) {
+	s.checkAPIHandlerTeardown(c, s.State, s.State)
 }
 
-func (s *serverSuite) TestApiHandlerTeardownOtherEnviron(c *gc.C) {
+func (s *serverSuite) TestAPIHandlerTeardownOtherEnviron(c *gc.C) {
 	otherState := s.Factory.MakeModel(c, nil)
 	defer otherState.Close()
-	s.checkApiHandlerTeardown(c, s.State, otherState)
+	s.checkAPIHandlerTeardown(c, s.State, otherState)
 }
 
-func (s *serverSuite) TestApiHandlerConnectedModel(c *gc.C) {
+func (s *serverSuite) TestAPIHandlerConnectedModel(c *gc.C) {
 	otherState := s.Factory.MakeModel(c, nil)
 	defer otherState.Close()
-	handler, _ := apiserver.TestingApiHandler(c, s.State, otherState)
+	handler, _ := apiserver.TestingAPIHandler(c, s.State, otherState)
 	c.Check(handler.ConnectedModel(), gc.Equals, otherState.ModelUUID())
 }
 
-func (s *serverSuite) checkApiHandlerTeardown(c *gc.C, srvSt, st *state.State) {
-	handler, resources := apiserver.TestingApiHandler(c, srvSt, st)
+func (s *serverSuite) checkAPIHandlerTeardown(c *gc.C, srvSt, st *state.State) {
+	handler, resources := apiserver.TestingAPIHandler(c, srvSt, st)
 	resource := new(fakeResource)
 	resources.Register(resource)
 

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -507,7 +507,7 @@ func (s *toolsWithMacaroonsSuite) TestCanPostWithDischargedMacaroon(c *gc.C) {
 func (s *toolsWithMacaroonsSuite) TestCanPostWithLocalLogin(c *gc.C) {
 	// Create a new user, and a local login macaroon for it.
 	user := s.Factory.MakeUser(c, &factory.UserParams{Password: "hunter2"})
-	conn := s.OpenAPIAs(c, user.Tag(), "hunter2")
+	conn := s.OpenControllerAPIAs(c, user.Tag(), "hunter2")
 	defer conn.Close()
 	mac, err := usermanager.NewClient(conn).CreateLocalLoginMacaroon(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -97,7 +97,7 @@ func (c *destroyCommand) getAPI() (DestroyModelAPI, error) {
 	if c.api != nil {
 		return c.api, nil
 	}
-	root, err := c.NewAPIRoot()
+	root, err := c.NewControllerAPIRoot()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/model/show.go
+++ b/cmd/juju/model/show.go
@@ -41,7 +41,7 @@ func (c *showModelCommand) getAPI() (ShowModelAPI, error) {
 	if c.api != nil {
 		return c.api, nil
 	}
-	api, err := c.NewAPIRoot()
+	api, err := c.NewControllerAPIRoot()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/core/description/useraccess.go
+++ b/core/description/useraccess.go
@@ -22,7 +22,7 @@ type UserAccess struct {
 	UserTag names.UserTag
 	// Object is the tag for the object of this access grant.
 	Object names.Tag
-	// Access represents the level of access subjec has over object.
+	// Access represents the level of access subject has over object.
 	Access Access
 	// CreatedBy is the tag of the user that granted the access.
 	CreatedBy names.UserTag
@@ -37,6 +37,5 @@ type UserAccess struct {
 // IsEmptyUserAccess returns true if the passed UserAccess instance
 // is empty.
 func IsEmptyUserAccess(a UserAccess) bool {
-	empty := UserAccess{}
-	return a == empty
+	return a == UserAccess{}
 }

--- a/featuretests/api_cloud_test.go
+++ b/featuretests/api_cloud_test.go
@@ -26,7 +26,12 @@ type CloudAPISuite struct {
 
 func (s *CloudAPISuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
-	s.client = apicloud.NewClient(s.APIState)
+	s.client = apicloud.NewClient(s.OpenControllerAPI(c))
+}
+
+func (s *CloudAPISuite) TearDownTest(c *gc.C) {
+	s.client.Close()
+	s.JujuConnSuite.TearDownTest(c)
 }
 
 func (s *CloudAPISuite) TestCloudAPI(c *gc.C) {

--- a/featuretests/api_model_test.go
+++ b/featuretests/api_model_test.go
@@ -42,7 +42,8 @@ func (s *apiEnvironmentSuite) TestGrantModel(c *gc.C) {
 	username := "foo@ubuntuone"
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	mm := modelmanager.NewClient(s.APIState)
+	mm := modelmanager.NewClient(s.OpenControllerAPI(c))
+	defer mm.Close()
 	err = mm.GrantModel(username, "read", model.UUID())
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -60,7 +61,8 @@ func (s *apiEnvironmentSuite) TestRevokeModel(c *gc.C) {
 	user := s.Factory.MakeModelUser(c, &factory.ModelUserParams{User: "foo@ubuntuone"})
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	mm := modelmanager.NewClient(s.APIState)
+	mm := modelmanager.NewClient(s.OpenControllerAPI(c))
+	defer mm.Close()
 
 	modelUser, err := s.State.UserAccess(user.UserTag, s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -46,7 +46,8 @@ func (s *cmdControllerSuite) run(c *gc.C, args ...string) *cmd.Context {
 }
 
 func (s *cmdControllerSuite) createModelAdminUser(c *gc.C, modelname string, isServer bool) params.ModelInfo {
-	modelManager := modelmanager.NewClient(s.APIState)
+	modelManager := modelmanager.NewClient(s.OpenControllerAPI(c))
+	defer modelManager.Close()
 	model, err := modelManager.CreateModel(modelname, s.AdminUserTag(c).Id(), "", "", map[string]interface{}{
 		"controller": isServer,
 	})
@@ -56,7 +57,8 @@ func (s *cmdControllerSuite) createModelAdminUser(c *gc.C, modelname string, isS
 
 func (s *cmdControllerSuite) createModelNormalUser(c *gc.C, modelname string, isServer bool) {
 	s.run(c, "add-user", "test")
-	modelManager := modelmanager.NewClient(s.APIState)
+	modelManager := modelmanager.NewClient(s.OpenControllerAPI(c))
+	defer modelManager.Close()
 	_, err := modelManager.CreateModel(modelname, names.NewLocalUserTag("test").Id(), "", "", map[string]interface{}{
 		"authorized-keys": "ssh-key",
 		"controller":      isServer,

--- a/featuretests/cmd_juju_login_test.go
+++ b/featuretests/cmd_juju_login_test.go
@@ -36,7 +36,8 @@ func (s *cmdLoginSuite) run(c *gc.C, stdin io.Reader, args ...string) *cmd.Conte
 	}
 	command := commands.NewJujuCommand(context)
 	c.Assert(testing.InitCommand(command, args), jc.ErrorIsNil)
-	c.Assert(command.Run(context), jc.ErrorIsNil)
+	err := command.Run(context)
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf("stdout: %q; stderr: %q", context.Stdout, context.Stderr))
 	loggo.RemoveWriter("warning") // remove logger added by main command
 	return context
 }


### PR DESCRIPTION
This change splits the controller and model APIs so that no controller
calls may be made on a model API connection and vice versa.
This paves the way for having all model traffic go directly to
the API server responsible for that model.

We also start to standardise on the Go standard "API" rather than "Api".

This is a backwardly incompatible API change, because it will no longer
be possible to call controller calls on a model connection.


(Review request: http://reviews.vapour.ws/r/5426/)