### PR TITLE
apiserver: serve controller-only endpoint from /api

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -106,8 +106,8 @@ func (s *apiclientSuite) TestOpen(c *gc.C) {
 	defer st.Close()
 
 	c.Assert(st.Addr(), gc.Equals, info.Addrs[0])
-	modelTag, err := st.ModelTag()
-	c.Assert(err, jc.ErrorIsNil)
+	modelTag, ok := st.ModelTag()
+	c.Assert(ok, jc.IsTrue)
 	c.Assert(modelTag, gc.Equals, s.State.ModelTag())
 
 	remoteVersion, versionSet := st.ServerVersion()
@@ -369,5 +369,5 @@ func assertConnAddrForEnv(c *gc.C, conn *websocket.Conn, addr, modelUUID, tail s
 }
 
 func assertConnAddrForRoot(c *gc.C, conn *websocket.Conn, addr string) {
-	c.Assert(conn.RemoteAddr(), gc.Matches, "^wss://"+addr+"/$")
+	c.Assert(conn.RemoteAddr(), gc.Matches, "^wss://"+addr+"/api$")
 }

--- a/api/application/client.go
+++ b/api/application/client.go
@@ -52,10 +52,9 @@ func (c *Client) SetMetricCredentials(service string, credentials []byte) error 
 
 // ModelUUID returns the model UUID from the client connection.
 func (c *Client) ModelUUID() string {
-	tag, err := c.st.ModelTag()
-	if err != nil {
-		logger.Warningf("model tag not an model: %v", err)
-		return ""
+	tag, ok := c.st.ModelTag()
+	if !ok {
+		logger.Warningf("controller-only API connection has no model tag")
 	}
 	return tag.Id()
 }

--- a/api/base/caller.go
+++ b/api/base/caller.go
@@ -26,9 +26,9 @@ type APICaller interface {
 	// client can use with the current API server.
 	BestFacadeVersion(facade string) int
 
-	// ModelTag returns the tag of the model the client is
-	// connected to.
-	ModelTag() (names.ModelTag, error)
+	// ModelTag returns the tag of the model the client is connected
+	// to if there is one. It returns false for a controller-only connection.
+	ModelTag() (names.ModelTag, bool)
 
 	// HTTPClient returns an httprequest.Client that can be used
 	// to make HTTP requests to the API. URLs passed to the client

--- a/api/base/testing/apicaller.go
+++ b/api/base/testing/apicaller.go
@@ -32,8 +32,8 @@ func (APICallerFunc) BestFacadeVersion(facade string) int {
 	return 0
 }
 
-func (APICallerFunc) ModelTag() (names.ModelTag, error) {
-	return coretesting.ModelTag, nil
+func (APICallerFunc) ModelTag() (names.ModelTag, bool) {
+	return coretesting.ModelTag, true
 }
 
 func (APICallerFunc) Close() error {

--- a/api/client.go
+++ b/api/client.go
@@ -185,13 +185,21 @@ func (c *Client) SetModelConstraints(constraints constraints.Value) error {
 	return c.facade.FacadeCall("SetModelConstraints", params, nil)
 }
 
-// ModelUUID returns the model UUID from the client connection.
-func (c *Client) ModelUUID() (string, error) {
-	tag, err := c.st.ModelTag()
-	if err != nil {
-		return "", errors.Annotate(err, "model tag not an model")
+// ModelUUID returns the model UUID from the client connection
+// and reports whether it is valud.
+func (c *Client) ModelUUID() (string, bool) {
+	tag, ok := c.st.ModelTag()
+	if !ok {
+		return "", false
 	}
-	return tag.Id(), nil
+	return tag.Id(), true
+}
+
+// ModelInfo returns details about the Juju model.
+func (c *Client) ModelInfo() (params.ModelInfo, error) {
+	var info params.ModelInfo
+	err := c.facade.FacadeCall("ModelInfo", nil, &info)
+	return info, err
 }
 
 // ModelUserInfo returns information on all users in the model.

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -306,8 +306,8 @@ func fakeAPIEndpoint(c *gc.C, client *api.Client, address, method string, handle
 
 // envEndpoint returns "/model/<model-uuid>/<destination>"
 func envEndpoint(c *gc.C, apiState api.Connection, destination string) string {
-	modelTag, err := apiState.ModelTag()
-	c.Assert(err, jc.ErrorIsNil)
+	modelTag, ok := apiState.ModelTag()
+	c.Assert(ok, jc.IsTrue)
 	return path.Join("/model", modelTag.Id(), destination)
 }
 
@@ -316,8 +316,8 @@ func (s *clientSuite) TestClientEnvironmentUUID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	client := s.APIState.Client()
-	uuid, err := client.ModelUUID()
-	c.Assert(err, jc.ErrorIsNil)
+	uuid, ok := client.ModelUUID()
+	c.Assert(ok, jc.IsTrue)
 	c.Assert(uuid, gc.Equals, environ.Tag().Id())
 }
 
@@ -363,7 +363,7 @@ func (s *clientSuite) TestWatchDebugLogConnected(c *gc.C) {
 
 func (s *clientSuite) TestConnectStreamRequiresSlashPathPrefix(c *gc.C) {
 	reader, err := s.APIState.ConnectStream("foo", nil)
-	c.Assert(err, gc.ErrorMatches, `path must start with "/"`)
+	c.Assert(err, gc.ErrorMatches, `cannot make API path from non-slash-prefixed path "foo"`)
 	c.Assert(reader, gc.Equals, nil)
 }
 

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/network"
 	"github.com/juju/utils/clock"
+	"gopkg.in/juju/names.v2"
 )
 
 var (
@@ -53,11 +54,19 @@ type TestingStateParams struct {
 // isn't backed onto an actual API server, so actual RPC methods can't be
 // called on it. But it can be used for testing general behaviour.
 func NewTestingState(params TestingStateParams) Connection {
+	var modelTag names.ModelTag
+	if params.ModelTag != "" {
+		t, err := names.ParseModelTag(params.ModelTag)
+		if err != nil {
+			panic("invalid model tag")
+		}
+		modelTag = t
+	}
 	st := &state{
 		client:            params.RPCConnection,
 		clock:             params.Clock,
 		addr:              params.Address,
-		modelTag:          params.ModelTag,
+		modelTag:          modelTag,
 		hostPorts:         params.APIHostPorts,
 		facadeVersions:    params.FacadeVersions,
 		serverScheme:      params.ServerScheme,

--- a/api/highavailability/client.go
+++ b/api/highavailability/client.go
@@ -26,10 +26,7 @@ type Client struct {
 
 // NewClient returns a new HighAvailability client.
 func NewClient(caller base.APICallCloser) *Client {
-	modelTag, err := caller.ModelTag()
-	if err != nil {
-		logger.Errorf("ignoring invalid model tag: %v", err)
-	}
+	modelTag, _ := caller.ModelTag()
 	frontend, backend := base.NewClientFacade(caller, "HighAvailability")
 	return &Client{ClientFacade: frontend, facade: backend, modelTag: modelTag}
 }

--- a/api/interface.go
+++ b/api/interface.go
@@ -173,7 +173,7 @@ type Connection interface {
 	// (as opposed to the model tag of the currently connected
 	// model inside that controller).
 	// This could be defined on base.APICaller.
-	ControllerTag() (names.ModelTag, error)
+	ControllerTag() names.ModelTag
 
 	// All the rest are strange and questionable and deserve extra attention
 	// and/or discussion.

--- a/api/metricsmanager/client.go
+++ b/api/metricsmanager/client.go
@@ -29,9 +29,10 @@ var _ MetricsManagerClient = (*Client)(nil)
 
 // NewClient creates a new client for accessing the metricsmanager api
 func NewClient(apiCaller base.APICaller) (*Client, error) {
-	modelTag, err := apiCaller.ModelTag()
-	if err != nil {
-		return nil, errors.Trace(err)
+	modelTag, ok := apiCaller.ModelTag()
+	if !ok {
+		return nil, errors.New("metricsmanager client is not appropriate for controller-only API")
+
 	}
 	facade := base.NewFacadeCaller(apiCaller, "MetricsManager")
 	return &Client{

--- a/api/singular/api.go
+++ b/api/singular/api.go
@@ -22,9 +22,9 @@ func NewAPI(apiCaller base.APICaller, controllerTag names.MachineTag) (*API, err
 	if !names.IsValidMachine(controllerId) {
 		return nil, errors.NotValidf("controller tag")
 	}
-	modelTag, err := apiCaller.ModelTag()
-	if err != nil {
-		return nil, errors.Trace(err)
+	modelTag, ok := apiCaller.ModelTag()
+	if !ok {
+		return nil, errors.New("cannot use singular API on controller-only connection")
 	}
 	facadeCaller := base.NewFacadeCaller(apiCaller, "Singular")
 	return &API{

--- a/api/singular/api_test.go
+++ b/api/singular/api_test.go
@@ -37,10 +37,10 @@ func (s *APISuite) TestBadControllerTag(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, "controller tag not valid")
 }
 
-func (s *APISuite) TestBadModelTag(c *gc.C) {
+func (s *APISuite) TestControllerOnlyAPI(c *gc.C) {
 	api, err := singular.NewAPI(mockAPICaller{}, machine123)
 	c.Check(api, gc.IsNil)
-	c.Check(err, gc.ErrorMatches, "no tags for you")
+	c.Check(err, gc.ErrorMatches, `cannot use singular API on controller-only connection`)
 }
 
 func (s *APISuite) TestNoCalls(c *gc.C) {
@@ -181,6 +181,6 @@ type mockAPICaller struct {
 	base.APICaller
 }
 
-func (mockAPICaller) ModelTag() (names.ModelTag, error) {
-	return names.ModelTag{}, errors.New("no tags for you")
+func (mockAPICaller) ModelTag() (names.ModelTag, bool) {
+	return names.ModelTag{}, false
 }

--- a/api/state.go
+++ b/api/state.go
@@ -146,8 +146,22 @@ type loginResultParams struct {
 
 func (st *state) setLoginResult(p loginResultParams) error {
 	st.authTag = p.tag
-	st.modelTag = p.modelTag
-	st.controllerTag = p.controllerTag
+	var modelTag names.ModelTag
+	if p.modelTag != "" {
+		var err error
+		modelTag, err = names.ParseModelTag(p.modelTag)
+		if err != nil {
+			return errors.Annotatef(err, "invalid model tag in login result")
+		}
+	}
+	if modelTag.Id() != st.modelTag.Id() {
+		return errors.Errorf("mismatched model tag in login result (got %q want %q)", modelTag.Id(), st.modelTag.Id())
+	}
+	ctag, err := names.ParseModelTag(p.controllerTag)
+	if err != nil {
+		return errors.Annotatef(err, "invalid controller tag %q returned from login", p.modelTag)
+	}
+	st.controllerTag = ctag
 	st.readOnly = p.readOnly
 
 	hostPorts, err := addAddress(p.servers, st.addr)

--- a/api/undertaker/undertaker.go
+++ b/api/undertaker/undertaker.go
@@ -25,9 +25,9 @@ type Client struct {
 
 // NewClient creates a new client for accessing the undertaker API.
 func NewClient(caller base.APICaller, newWatcher NewWatcherFunc) (*Client, error) {
-	modelTag, err := caller.ModelTag()
-	if err != nil {
-		return nil, errors.Trace(err)
+	modelTag, ok := caller.ModelTag()
+	if !ok {
+		return nil, errors.New("undertaker client is not appropriate for controller-only API")
 	}
 	return &Client{
 		modelTag:   modelTag,

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -767,15 +767,15 @@ func (s *loginSuite) TestOtherEnvironmentWhenNotController(c *gc.C) {
 
 func (s *loginSuite) assertRemoteModel(c *gc.C, api api.Connection, expected names.ModelTag) {
 	// Look at what the api thinks it has.
-	tag, err := api.ModelTag()
-	c.Assert(err, jc.ErrorIsNil)
+	tag, ok := api.ModelTag()
+	c.Assert(ok, jc.IsTrue)
 	c.Assert(tag, gc.Equals, expected)
 	// Look at what the api Client thinks it has.
 	client := api.Client()
 
 	// ModelUUID looks at the env tag on the api state connection.
-	uuid, err := client.ModelUUID()
-	c.Assert(err, jc.ErrorIsNil)
+	uuid, ok := client.ModelUUID()
+	c.Assert(ok, jc.IsTrue)
 	c.Assert(uuid, gc.Equals, expected.Id())
 
 	// The code below is to verify that the API connection is operating on

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -398,6 +398,10 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 			srv.authCtxt.userAuth.CreateLocalLoginMacaroon,
 		},
 	)
+	add("/api", mainAPIHandler)
+	// Serve the API at / (only) for backward compatiblity. Note that the
+	// pat muxer special-cases / so that it does not serve all
+	// possible endpoints, but only / itself.
 	add("/", mainAPIHandler)
 
 	return endpoints

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -291,18 +291,25 @@ func (s *serverSuite) TestMinTLSVersion(c *gc.C) {
 }
 
 func (s *serverSuite) TestNonCompatiblePathsAre404(c *gc.C) {
-	// we expose the API at '/' for compatibility, and at '/ModelUUID/api'
-	// for the correct location, but other Paths should fail.
+	// We expose the API at '/api', '/' (controller-only), and at '/ModelUUID/api'
+	// for the correct location, but other paths should fail.
 	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
 	srv := newServer(c, s.State)
 	defer srv.Stop()
 
 	// We have to use 'localhost' because that is what the TLS cert says.
 	addr := fmt.Sprintf("localhost:%d", srv.Addr().Port)
-	// '/' should be fine
-	conn, err := dialWebsocket(c, addr, "/", 0)
+
+	// '/api' should be fine
+	conn, err := dialWebsocket(c, addr, "/api", 0)
 	c.Assert(err, jc.ErrorIsNil)
 	conn.Close()
+
+	// '/`' should be fine
+	conn, err = dialWebsocket(c, addr, "/", 0)
+	c.Assert(err, jc.ErrorIsNil)
+	conn.Close()
+
 	// '/model/MODELUUID/api' should be fine
 	conn, err = dialWebsocket(c, addr, "/model/dead-beef-123456/api", 0)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/testing/fakeapi_test.go
+++ b/apiserver/testing/fakeapi_test.go
@@ -18,9 +18,10 @@ type fakeAPISuite struct {
 	testing.IsolationSuite
 }
 
+const fakeUUID = "f47ac10b-58cc-dead-beef-0e02b2c3d479"
+
 func (*fakeAPISuite) TestFakeAPI(c *gc.C) {
 	var r root
-	fakeUUID := "dead-beef"
 	srv := apiservertesting.NewAPIServer(func(modelUUID string) interface{} {
 		c.Check(modelUUID, gc.Equals, fakeUUID)
 		return &r
@@ -29,7 +30,7 @@ func (*fakeAPISuite) TestFakeAPI(c *gc.C) {
 	info := &api.Info{
 		Addrs:    srv.Addrs,
 		CACert:   jtesting.CACert,
-		ModelTag: names.NewModelTag("dead-beef"),
+		ModelTag: names.NewModelTag(fakeUUID),
 	}
 	_, err := api.Open(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -52,8 +53,8 @@ func (r *root) Admin(id string) (facade, error) {
 func (f facade) Login(req params.LoginRequest) (params.LoginResultV1, error) {
 	f.r.calledMethods = append(f.r.calledMethods, "Login")
 	return params.LoginResultV1{
-		ModelTag:      names.NewModelTag("dead-beef").String(),
-		ControllerTag: names.NewModelTag("dead-beef").String(),
+		ModelTag:      names.NewModelTag(fakeUUID).String(),
+		ControllerTag: names.NewModelTag(fakeUUID).String(),
 		UserInfo: &params.AuthUserInfo{
 			DisplayName: "foo",
 			Identity:    "user-bar",

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -529,9 +529,9 @@ func (c *DeployCommand) deployCharm(args deployCharmArgs) (rErr error) {
 		return errors.Trace(err)
 	}
 
-	uuid, err := args.client.ModelUUID()
-	if err != nil {
-		return errors.Trace(err)
+	uuid, ok := args.client.ModelUUID()
+	if !ok {
+		return errors.New("API connection is controller-only (should never happen)")
 	}
 
 	deployInfo := DeploymentInfo{

--- a/cmd/juju/controller/mock_test.go
+++ b/cmd/juju/controller/mock_test.go
@@ -4,8 +4,6 @@
 package controller_test
 
 import (
-	"errors"
-
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/network"
 	"gopkg.in/juju/names.v2"
@@ -34,11 +32,8 @@ func (m *mockAPIConnection) APIHostPorts() [][]network.HostPort {
 	return m.apiHostPorts
 }
 
-func (m *mockAPIConnection) ControllerTag() (names.ModelTag, error) {
-	if m.controllerTag.Id() == "" {
-		return m.controllerTag, errors.New("no server tag")
-	}
-	return m.controllerTag, nil
+func (m *mockAPIConnection) ControllerTag() names.ModelTag {
+	return m.controllerTag
 }
 
 func (m *mockAPIConnection) SetPassword(username, password string) error {

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -151,7 +151,7 @@ type AddMachineAPI interface {
 	AddMachines([]params.AddMachineParams) ([]params.AddMachinesResult, error)
 	Close() error
 	ForceDestroyMachines(machines ...string) error
-	ModelUUID() (string, error)
+	ModelUUID() (string, bool)
 	ProvisioningScript(params.ProvisioningScriptParams) (script string, err error)
 }
 
@@ -263,9 +263,9 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 
 	logger.Infof("model provisioning")
 	if c.Placement != nil && c.Placement.Scope == "model-uuid" {
-		uuid, err := client.ModelUUID()
-		if err != nil {
-			return errors.Trace(err)
+		uuid, ok := client.ModelUUID()
+		if !ok {
+			return errors.New("API connection is controller-only (should never happen)")
 		}
 		c.Placement.Scope = uuid
 	}

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -218,8 +218,8 @@ func (f *fakeAddMachineAPI) Close() error {
 	return nil
 }
 
-func (f *fakeAddMachineAPI) ModelUUID() (string, error) {
-	return "fake-uuid", nil
+func (f *fakeAddMachineAPI) ModelUUID() (string, bool) {
+	return "fake-uuid", true
 }
 
 func (f *fakeAddMachineAPI) AddMachines(args []params.AddMachineParams) ([]params.AddMachinesResult, error) {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-2
 github.com/juju/bundlechanges	git	6791af0ab78efe88ff99c2a0095208b3b7a32055	2016-07-20T09:32:50Z
 github.com/juju/cmd	git	7c57a7d5a20602e4563a83f2d530283ca0e6f481	2016-08-10T12:53:08Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
-github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T17:52:03Z
+github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:32:58Z
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
@@ -44,7 +44,7 @@ github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-0
 github.com/juju/testing	git	d325c22badd4ba3a5fde01d479b188c7a06df755	2016-08-02T03:47:59Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils	git	1e842599b703a2e335fa67879f2f2c3687482a11	2016-08-11T18:13:00Z
+github.com/juju/utils	git	bdb77b07e7e3f77463d10d2b554cd1b7a78009a2	2016-08-15T11:38:39Z
 github.com/juju/version	git	4ae6172c00626779a5a462c3e3d22fc0e889431a	2016-06-03T19:49:58Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
@@ -80,6 +80,6 @@ gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:
 gopkg.in/mgo.v2	git	29cc868a5ca65f401ff318143f9408d02f4799cc	2016-06-09T18:00:28Z
 gopkg.in/natefinch/lumberjack.v2	git	514cbda263a734ae8caac038dadf05f8f3f9f738	2016-01-25T11:17:49Z
 gopkg.in/natefinch/npipe.v2	git	c1b8fa8bdccecb0b8db834ee0b92fdbcfa606dd6	2016-06-21T03:49:01Z
-gopkg.in/tomb.v1	git	dd632973f1e7218eb1089048e0798ec9ae7dceb8	2014-10-24T11:56:13Z
+gopkg.in/tomb.v1	git	dd632973f1e7218eb1089048e0798ec9ae7dceb8	2014-10-24T13:56:13Z
 gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:07Z
 gopkg.in/yaml.v2	git	a83829b6f1293c91addabc89d0571c246397bbf4	2016-03-01T20:40:22Z

--- a/juju/mock_test.go
+++ b/juju/mock_test.go
@@ -79,12 +79,23 @@ func (s *mockAPIState) APIHostPorts() [][]network.HostPort {
 	return s.apiHostPorts
 }
 
-func (s *mockAPIState) ModelTag() (names.ModelTag, error) {
-	return names.ParseModelTag(s.modelTag)
+func (s *mockAPIState) ModelTag() (names.ModelTag, bool) {
+	if s.modelTag == "" {
+		return names.ModelTag{}, false
+	}
+	t, err := names.ParseModelTag(s.modelTag)
+	if err != nil {
+		panic("bad model tag")
+	}
+	return t, true
 }
 
-func (s *mockAPIState) ControllerTag() (names.ModelTag, error) {
-	return names.ParseModelTag(s.controllerTag)
+func (s *mockAPIState) ControllerTag() names.ModelTag {
+	t, err := names.ParseModelTag(s.controllerTag)
+	if err != nil {
+		panic("bad controller tag")
+	}
+	return t
 }
 
 func panicAPIOpen(apiInfo *api.Info, opts api.DialOpts) (api.Connection, error) {

--- a/worker/apicaller/connect.go
+++ b/worker/apicaller/connect.go
@@ -274,9 +274,9 @@ func ScaryConnect(a agent.Agent, apiOpen api.OpenFunc) (_ api.Connection, err er
 func maybeSetAgentModelTag(a agent.Agent, conn api.Connection) error {
 	if a.CurrentConfig().Model().Id() == "" {
 		err := a.ChangeConfig(func(setter agent.ConfigSetter) error {
-			modelTag, err := conn.ModelTag()
-			if err != nil {
-				return errors.Annotate(err, "no model uuid set on api")
+			modelTag, ok := conn.ModelTag()
+			if !ok {
+				return errors.New("API connection is controller-only (should never happen)")
 			}
 			return setter.Migrate(agent.MigrateParams{
 				Model: modelTag,

--- a/worker/apicaller/connect_test.go
+++ b/worker/apicaller/connect_test.go
@@ -72,7 +72,7 @@ func testEntityFine(c *gc.C, life apiagent.Life) {
 }
 
 func (*ScaryConnectSuite) TestModelTagCannotChangeConfig(c *gc.C) {
-	stub := checkModelTagUpdate(c, errors.New("oh noes"))
+	stub := checkModelTagUpdate(c, false, errors.New("oh noes"))
 	stub.CheckCallNames(c,
 		"ChangeConfig",
 		"Life", "SetPassword",
@@ -80,7 +80,7 @@ func (*ScaryConnectSuite) TestModelTagCannotChangeConfig(c *gc.C) {
 }
 
 func (*ScaryConnectSuite) TestModelTagCannotGetTag(c *gc.C) {
-	stub := checkModelTagUpdate(c, nil, errors.New("oh noes"))
+	stub := checkModelTagUpdate(c, true)
 	stub.CheckCallNames(c,
 		"ChangeConfig", "ModelTag",
 		"Life", "SetPassword",
@@ -88,7 +88,7 @@ func (*ScaryConnectSuite) TestModelTagCannotGetTag(c *gc.C) {
 }
 
 func (*ScaryConnectSuite) TestModelTagCannotMigrate(c *gc.C) {
-	stub := checkModelTagUpdate(c, nil, nil, errors.New("oh noes"))
+	stub := checkModelTagUpdate(c, false, nil, errors.New("oh noes"))
 	stub.CheckCallNames(c,
 		"ChangeConfig", "ModelTag", "Migrate",
 		"Life", "SetPassword",
@@ -99,7 +99,7 @@ func (*ScaryConnectSuite) TestModelTagCannotMigrate(c *gc.C) {
 }
 
 func (*ScaryConnectSuite) TestModelTagSuccess(c *gc.C) {
-	stub := checkModelTagUpdate(c)
+	stub := checkModelTagUpdate(c, false)
 	stub.CheckCallNames(c,
 		"ChangeConfig", "ModelTag", "Migrate",
 		"Life", "SetPassword",
@@ -109,12 +109,15 @@ func (*ScaryConnectSuite) TestModelTagSuccess(c *gc.C) {
 	})
 }
 
-func checkModelTagUpdate(c *gc.C, errs ...error) *testing.Stub {
+func checkModelTagUpdate(c *gc.C, controllerOnly bool, errs ...error) *testing.Stub {
 	// success case; just a little failure we don't mind, otherwise
 	// equivalent to testEntityFine.
 	stub := &testing.Stub{}
 	stub.SetErrors(errs...) // from ChangeConfig
-	expectConn := &mockConn{stub: stub}
+	expectConn := &mockConn{
+		controllerOnly: controllerOnly,
+		stub:           stub,
+	}
 	apiOpen := func(info *api.Info, opts api.DialOpts) (api.Connection, error) {
 		return expectConn, nil
 	}

--- a/worker/metrics/sender/manifold_test.go
+++ b/worker/metrics/sender/manifold_test.go
@@ -121,9 +121,9 @@ func (s *stubAPICaller) BestFacadeVersion(facade string) int {
 	return 42
 }
 
-func (s *stubAPICaller) ModelTag() (names.ModelTag, error) {
+func (s *stubAPICaller) ModelTag() (names.ModelTag, bool) {
 	s.MethodCall(s, "ModelTag")
-	return names.NewModelTag("foobar"), nil
+	return names.NewModelTag("foobar"), true
 }
 
 func (s *stubAPICaller) ConnectStream(string, url.Values) (base.Stream, error) {

--- a/worker/migrationflag/manifold.go
+++ b/worker/migrationflag/manifold.go
@@ -52,9 +52,9 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	modelTag, err := apiCaller.ModelTag()
-	if err != nil {
-		return nil, errors.Trace(err)
+	modelTag, ok := apiCaller.ModelTag()
+	if !ok {
+		return nil, errors.New("API connection is controller-only (should never happen)")
 	}
 	worker, err := config.NewWorker(Config{
 		Facade: facade,

--- a/worker/migrationflag/util_test.go
+++ b/worker/migrationflag/util_test.go
@@ -171,6 +171,6 @@ type stubCaller struct {
 }
 
 // ModelTag is part of the base.APICaller interface.
-func (*stubCaller) ModelTag() (names.ModelTag, error) {
-	return names.NewModelTag(validUUID), nil
+func (*stubCaller) ModelTag() (names.ModelTag, bool) {
+	return names.NewModelTag(validUUID), true
 }


### PR DESCRIPTION
This makes the websocket API endpoints more consistent
between controller-only and model. We continue to
server to old endpoint at / for backward compatibility.

We also change the API server so that it checks that
the login result is consistent with the model UUID
being asked for, and store the model UUID in parsed
form so we don't parse it each time it's asked for.

This means we can return a boolean rather than an error
from the ModelTag entry point, which prepares the way for
all facades to check whether they're being layered onto
the right kind of API connection.

We also clear up some backward-compatibility cruft
from the apiserver implementation.

(Review request: http://reviews.vapour.ws/r/5428/)