### PR TITLE
Add proper permission gating to facades.

### DIFF
--- a/apiserver/action/run.go
+++ b/apiserver/action/run.go
@@ -44,6 +44,9 @@ func getAllUnitNames(st *state.State, units, services []string) (result []names.
 // Run the commands specified on the machines identified through the
 // list of machines, units and services.
 func (a *ActionAPI) Run(run params.RunParams) (results params.ActionResults, err error) {
+	if err := a.checkCanWrite(); err != nil {
+		return results, err
+	}
 	if err := a.check.ChangeAllowed(); err != nil {
 		return results, errors.Trace(err)
 	}
@@ -68,6 +71,10 @@ func (a *ActionAPI) Run(run params.RunParams) (results params.ActionResults, err
 
 // RunOnAllMachines attempts to run the specified command on all the machines.
 func (a *ActionAPI) RunOnAllMachines(run params.RunParams) (results params.ActionResults, err error) {
+	if err := a.checkCanWrite(); err != nil {
+		return results, err
+	}
+
 	if err := a.check.ChangeAllowed(); err != nil {
 		return results, errors.Trace(err)
 	}

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -335,12 +335,12 @@ func (f modelUserEntityFinder) FindEntity(tag names.Tag) (state.Entity, error) {
 	}
 	modelUser, err := f.st.UserAccess(utag, f.st.ModelTag())
 	if err != nil && !errors.IsNotFound(err) {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	controllerUser, err := state.ControllerAccess(f.st, utag)
 	if err != nil && !errors.IsNotFound(err) {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	if description.IsEmptyUserAccess(modelUser) && description.IsEmptyUserAccess(controllerUser) {
 		return nil, errors.NotFoundf("model or controller user")
@@ -354,7 +354,7 @@ func (f modelUserEntityFinder) FindEntity(tag names.Tag) (state.Entity, error) {
 	if utag.IsLocal() {
 		user, err := f.st.User(utag)
 		if err != nil {
-			return nil, err
+			return nil, errors.Trace(err)
 		}
 		u.user = user
 	}
@@ -433,7 +433,7 @@ func (u *modelUserEntity) LastLogin() (time.Time, error) {
 		// to implement LastLogin error semantics too.
 		err = state.NeverLoggedInError(err.Error())
 	}
-	return t, err
+	return t, errors.Trace(err)
 }
 
 // UpdateLastLogin implements loginEntity.UpdateLastLogin.

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -10,30 +10,30 @@ package apiserver
 // TODO(fwereade): this is silly. We should be declaring our full API in *one*
 // place, not scattering it across packages and depending on magic import lists.
 import (
-	_ "github.com/juju/juju/apiserver/action"
+	_ "github.com/juju/juju/apiserver/action" // ModelUser Write
 	_ "github.com/juju/juju/apiserver/agent"
 	_ "github.com/juju/juju/apiserver/agenttools"
-	_ "github.com/juju/juju/apiserver/annotations"
-	_ "github.com/juju/juju/apiserver/application"
+	_ "github.com/juju/juju/apiserver/annotations" // ModelUser Write
+	_ "github.com/juju/juju/apiserver/application" // ModelUser Write
 	_ "github.com/juju/juju/apiserver/applicationscaler"
-	_ "github.com/juju/juju/apiserver/backups"
-	_ "github.com/juju/juju/apiserver/block"
+	_ "github.com/juju/juju/apiserver/backups" // ModelUser Write
+	_ "github.com/juju/juju/apiserver/block"   // ModelUser Write
 	_ "github.com/juju/juju/apiserver/charmrevisionupdater"
-	_ "github.com/juju/juju/apiserver/charms"
+	_ "github.com/juju/juju/apiserver/charms" // ModelUser Write
 	_ "github.com/juju/juju/apiserver/cleaner"
-	_ "github.com/juju/juju/apiserver/client"
-	_ "github.com/juju/juju/apiserver/cloud"
-	_ "github.com/juju/juju/apiserver/controller"
+	_ "github.com/juju/juju/apiserver/client"     // ModelUser Write
+	_ "github.com/juju/juju/apiserver/cloud"      // ModelUser Read
+	_ "github.com/juju/juju/apiserver/controller" // ModelUser Admin (although some methods check for read only)
 	_ "github.com/juju/juju/apiserver/deployer"
 	_ "github.com/juju/juju/apiserver/discoverspaces"
 	_ "github.com/juju/juju/apiserver/diskmanager"
 	_ "github.com/juju/juju/apiserver/firewaller"
-	_ "github.com/juju/juju/apiserver/highavailability"
+	_ "github.com/juju/juju/apiserver/highavailability" // ModelUser Write
 	_ "github.com/juju/juju/apiserver/hostkeyreporter"
-	_ "github.com/juju/juju/apiserver/imagemanager"
+	_ "github.com/juju/juju/apiserver/imagemanager" // ModelUser Write
 	_ "github.com/juju/juju/apiserver/imagemetadata"
 	_ "github.com/juju/juju/apiserver/instancepoller"
-	_ "github.com/juju/juju/apiserver/keymanager"
+	_ "github.com/juju/juju/apiserver/keymanager" // ModelUser Write
 	_ "github.com/juju/juju/apiserver/keyupdater"
 	_ "github.com/juju/juju/apiserver/leadership"
 	_ "github.com/juju/juju/apiserver/lifeflag"
@@ -41,27 +41,27 @@ import (
 	_ "github.com/juju/juju/apiserver/logger"
 	_ "github.com/juju/juju/apiserver/machine"
 	_ "github.com/juju/juju/apiserver/machineactions"
-	_ "github.com/juju/juju/apiserver/machinemanager"
+	_ "github.com/juju/juju/apiserver/machinemanager" // ModelUser Write
 	_ "github.com/juju/juju/apiserver/meterstatus"
 	_ "github.com/juju/juju/apiserver/metricsadder"
-	_ "github.com/juju/juju/apiserver/metricsdebug"
+	_ "github.com/juju/juju/apiserver/metricsdebug" // ModelUser Write
 	_ "github.com/juju/juju/apiserver/metricsmanager"
 	_ "github.com/juju/juju/apiserver/migrationflag"
 	_ "github.com/juju/juju/apiserver/migrationmaster"
 	_ "github.com/juju/juju/apiserver/migrationminion"
-	_ "github.com/juju/juju/apiserver/migrationtarget"
-	_ "github.com/juju/juju/apiserver/modelconfig"
-	_ "github.com/juju/juju/apiserver/modelmanager"
+	_ "github.com/juju/juju/apiserver/migrationtarget" // ModelUser Write
+	_ "github.com/juju/juju/apiserver/modelconfig"     // ModelUser Write
+	_ "github.com/juju/juju/apiserver/modelmanager"    // ModelUser Write
 	_ "github.com/juju/juju/apiserver/provisioner"
 	_ "github.com/juju/juju/apiserver/proxyupdater"
 	_ "github.com/juju/juju/apiserver/reboot"
 	_ "github.com/juju/juju/apiserver/resumer"
 	_ "github.com/juju/juju/apiserver/retrystrategy"
 	_ "github.com/juju/juju/apiserver/singular"
-	_ "github.com/juju/juju/apiserver/spaces"
-	_ "github.com/juju/juju/apiserver/sshclient"
+	_ "github.com/juju/juju/apiserver/spaces"    // ModelUser Write
+	_ "github.com/juju/juju/apiserver/sshclient" // ModelUser Write
 	_ "github.com/juju/juju/apiserver/statushistory"
-	_ "github.com/juju/juju/apiserver/storage"
+	_ "github.com/juju/juju/apiserver/storage" // ModelUser Write
 	_ "github.com/juju/juju/apiserver/storageprovisioner"
 	_ "github.com/juju/juju/apiserver/subnets"
 	_ "github.com/juju/juju/apiserver/undertaker"

--- a/apiserver/annotations/client.go
+++ b/apiserver/annotations/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/state"
 )
 
@@ -40,6 +41,7 @@ func NewAPI(
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*API, error) {
+
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}
@@ -50,10 +52,40 @@ func NewAPI(
 	}, nil
 }
 
+func (api *API) checkCanRead() error {
+	canRead, err := api.authorizer.HasPermission(description.ReadAccess, api.access.ModelTag())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if !canRead {
+		return common.ErrPerm
+	}
+	return nil
+}
+
+func (api *API) checkCanWrite() error {
+	canWrite, err := api.authorizer.HasPermission(description.WriteAccess, api.access.ModelTag())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if !canWrite {
+		return common.ErrPerm
+	}
+	return nil
+}
+
 // Get returns annotations for given entities.
 // If annotations cannot be retrieved for a given entity, an error is returned.
 // Each entity is treated independently and, hence, will fail or succeed independently.
 func (api *API) Get(args params.Entities) params.AnnotationsGetResults {
+	if err := api.checkCanRead(); err != nil {
+		result := make([]params.AnnotationsGetResult, len(args.Entities))
+		for i := range result {
+			result[i].Error = params.ErrorResult{Error: common.ServerError(err)}
+		}
+		return params.AnnotationsGetResults{Results: result}
+	}
+
 	entityResults := []params.AnnotationsGetResult{}
 	for _, entity := range args.Entities {
 		anEntityResult := params.AnnotationsGetResult{EntityTag: entity.Tag}
@@ -69,6 +101,13 @@ func (api *API) Get(args params.Entities) params.AnnotationsGetResults {
 
 // Set stores annotations for given entities
 func (api *API) Set(args params.AnnotationsSet) params.ErrorResults {
+	if err := api.checkCanWrite(); err != nil {
+		errorResults := make([]params.ErrorResult, len(args.Annotations))
+		for i := range errorResults {
+			errorResults[i].Error = common.ServerError(err)
+		}
+		return params.ErrorResults{Results: errorResults}
+	}
 	setErrors := []params.ErrorResult{}
 	for _, entityAnnotation := range args.Annotations {
 		err := api.setEntityAnnotations(entityAnnotation.EntityTag, entityAnnotation.Annotations)

--- a/apiserver/annotations/state.go
+++ b/apiserver/annotations/state.go
@@ -13,6 +13,7 @@ type annotationAccess interface {
 	FindEntity(tag names.Tag) (state.Entity, error)
 	GetAnnotations(entity state.GlobalEntity) (map[string]string, error)
 	SetAnnotations(entity state.GlobalEntity, annotations map[string]string) error
+	ModelTag() names.ModelTag
 }
 
 type stateShim struct {
@@ -29,4 +30,8 @@ func (s stateShim) GetAnnotations(entity state.GlobalEntity) (map[string]string,
 
 func (s stateShim) SetAnnotations(entity state.GlobalEntity, annotations map[string]string) error {
 	return s.state.SetAnnotations(entity, annotations)
+}
+
+func (s stateShim) ModelTag() names.ModelTag {
+	return s.state.ModelTag()
 }

--- a/apiserver/application/get.go
+++ b/apiserver/application/get.go
@@ -12,6 +12,9 @@ import (
 
 // Get returns the configuration for a service.
 func (api *API) Get(args params.ApplicationGet) (params.ApplicationGetResults, error) {
+	if err := api.checkCanRead(); err != nil {
+		return params.ApplicationGetResults{}, err
+	}
 	app, err := api.state.Application(args.ApplicationName)
 	if err != nil {
 		return params.ApplicationGetResults{}, err

--- a/apiserver/authentication/user.go
+++ b/apiserver/authentication/user.go
@@ -116,6 +116,7 @@ func (u *UserAuthenticator) authenticateMacaroons(
 	}
 	entity, err := entityFinder.FindEntity(tag)
 	if errors.IsNotFound(err) {
+		logger.Debugf("entity %s not found", tag.String())
 		return nil, errors.Trace(common.ErrBadCreds)
 	} else if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/backups/backups.go
+++ b/apiserver/backups/backups.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
@@ -31,6 +32,7 @@ type Backend interface {
 	MongoConnectionInfo() *mongo.MongoInfo
 	MongoSession() *mgo.Session
 	ModelTag() names.ModelTag
+	ControllerTag() names.ControllerTag
 	ModelConfig() (*config.Config, error)
 	ControllerConfig() (controller.Config, error)
 	StateServingInfo() (state.StateServingInfo, error)
@@ -48,8 +50,13 @@ type API struct {
 
 // NewAPI creates a new instance of the Backups API facade.
 func NewAPI(backend Backend, resources facade.Resources, authorizer facade.Authorizer) (*API, error) {
-	if !authorizer.AuthClient() {
-		return nil, errors.Trace(common.ErrPerm)
+	isControllerAdmin, err := authorizer.HasPermission(description.SuperuserAccess, backend.ControllerTag())
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, errors.Trace(err)
+	}
+
+	if !authorizer.AuthClient() || !isControllerAdmin {
+		return nil, common.ErrPerm
 	}
 
 	// For now, backup operations are only permitted on the controller environment.

--- a/apiserver/backups/backups_test.go
+++ b/apiserver/backups/backups_test.go
@@ -35,7 +35,7 @@ func (s *backupsSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.resources = common.NewResources()
 	s.resources.RegisterNamed("dataDir", common.StringResource("/var/lib/juju"))
-	tag := names.NewLocalUserTag("spam")
+	tag := names.NewLocalUserTag("admin")
 	s.authorizer = &apiservertesting.FakeAuthorizer{Tag: tag}
 	var err error
 	s.api, err = backupsAPI.NewAPI(&stateShim{s.State}, s.resources, s.authorizer)

--- a/apiserver/block/state.go
+++ b/apiserver/block/state.go
@@ -3,12 +3,16 @@
 
 package block
 
-import "github.com/juju/juju/state"
+import (
+	"github.com/juju/juju/state"
+	names "gopkg.in/juju/names.v2"
+)
 
 type blockAccess interface {
 	AllBlocks() ([]state.Block, error)
 	SwitchBlockOn(t state.BlockType, msg string) error
 	SwitchBlockOff(t state.BlockType) error
+	ModelTag() names.ModelTag
 }
 
 type stateShim struct {

--- a/apiserver/charms/client.go
+++ b/apiserver/charms/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/state"
 )
 
@@ -37,12 +38,24 @@ type API struct {
 	authorizer facade.Authorizer
 }
 
+func (a *API) checkCanRead() error {
+	canRead, err := a.authorizer.HasPermission(description.ReadAccess, a.access.ModelTag())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if !canRead {
+		return common.ErrPerm
+	}
+	return nil
+}
+
 // NewAPI returns a new charms API facade.
 func NewAPI(
 	st *state.State,
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*API, error) {
+
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}
@@ -56,13 +69,17 @@ func NewAPI(
 // CharmInfo returns information about the requested charm.
 // NOTE: thumper 2016-06-29, this is not a bulk call and probably should be.
 func (a *API) CharmInfo(args params.CharmURL) (params.CharmInfo, error) {
+	if err := a.checkCanRead(); err != nil {
+		return params.CharmInfo{}, errors.Trace(err)
+	}
+
 	curl, err := charm.ParseURL(args.URL)
 	if err != nil {
-		return params.CharmInfo{}, err
+		return params.CharmInfo{}, errors.Trace(err)
 	}
 	aCharm, err := a.access.Charm(curl)
 	if err != nil {
-		return params.CharmInfo{}, err
+		return params.CharmInfo{}, errors.Trace(err)
 	}
 	info := params.CharmInfo{
 		Revision: aCharm.Revision(),
@@ -79,6 +96,10 @@ func (a *API) CharmInfo(args params.CharmURL) (params.CharmInfo, error) {
 // If supplied parameter contains any names, the result will be filtered
 // to return only the charms with supplied names.
 func (a *API) List(args params.CharmsList) (params.CharmsListResult, error) {
+	if err := a.checkCanRead(); err != nil {
+		return params.CharmsListResult{}, errors.Trace(err)
+	}
+
 	charms, err := a.access.AllCharms()
 	if err != nil {
 		return params.CharmsListResult{}, errors.Annotatef(err, " listing charms ")
@@ -101,13 +122,17 @@ func (a *API) List(args params.CharmsList) (params.CharmsListResult, error) {
 
 // IsMetered returns whether or not the charm is metered.
 func (a *API) IsMetered(args params.CharmURL) (params.IsMeteredResult, error) {
+	if err := a.checkCanRead(); err != nil {
+		return params.IsMeteredResult{}, errors.Trace(err)
+	}
+
 	curl, err := charm.ParseURL(args.URL)
 	if err != nil {
-		return params.IsMeteredResult{false}, err
+		return params.IsMeteredResult{false}, errors.Trace(err)
 	}
 	aCharm, err := a.access.Charm(curl)
 	if err != nil {
-		return params.IsMeteredResult{false}, err
+		return params.IsMeteredResult{false}, errors.Trace(err)
 	}
 	if aCharm.Metrics() != nil && len(aCharm.Metrics().Metrics) > 0 {
 		return params.IsMeteredResult{true}, nil

--- a/apiserver/charms/state.go
+++ b/apiserver/charms/state.go
@@ -5,6 +5,7 @@ package charms
 
 import (
 	"gopkg.in/juju/charm.v6-unstable"
+	names "gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/state"
 )
@@ -12,6 +13,7 @@ import (
 type charmsAccess interface {
 	Charm(curl *charm.URL) (*state.Charm, error)
 	AllCharms() ([]*state.Charm, error)
+	ModelTag() names.ModelTag
 }
 
 type stateShim struct {
@@ -24,4 +26,8 @@ func (s stateShim) Charm(curl *charm.URL) (*state.Charm, error) {
 
 func (s stateShim) AllCharms() ([]*state.Charm, error) {
 	return s.state.AllCharms()
+}
+
+func (s stateShim) ModelTag() names.ModelTag {
+	return s.state.ModelTag()
 }

--- a/apiserver/client/bundles.go
+++ b/apiserver/client/bundles.go
@@ -19,6 +19,10 @@ import (
 // bundle data. The changes are sorted by requirements, so that they can be
 // applied in order.
 func (c *Client) GetBundleChanges(args params.GetBundleChangesParams) (params.GetBundleChangesResults, error) {
+	if err := c.checkCanRead(); err != nil {
+		return params.GetBundleChangesResults{}, err
+	}
+
 	var results params.GetBundleChangesResults
 	data, err := charm.ReadBundleData(strings.NewReader(args.BundleDataYAML))
 	if err != nil {

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -61,6 +61,28 @@ type Client struct {
 	check      *common.BlockChecker
 }
 
+func (c *Client) checkCanRead() error {
+	canRead, err := c.api.auth.HasPermission(description.ReadAccess, c.api.stateAccessor.ModelTag())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if !canRead {
+		return common.ErrPerm
+	}
+	return nil
+}
+
+func (c *Client) checkCanWrite() error {
+	canWrite, err := c.api.auth.HasPermission(description.WriteAccess, c.api.stateAccessor.ModelTag())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if !canWrite {
+		return common.ErrPerm
+	}
+	return nil
+}
+
 func newClient(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*Client, error) {
 	urlGetter := common.NewToolsURLGetter(st.ModelUUID(), st)
 	configGetter := stateenvirons.EnvironConfigGetter{st}
@@ -116,6 +138,9 @@ func NewClient(
 }
 
 func (c *Client) WatchAll() (params.AllWatcherId, error) {
+	if err := c.checkCanRead(); err != nil {
+		return params.AllWatcherId{}, err
+	}
 	w := c.api.stateAccessor.Watch()
 	return params.AllWatcherId{
 		AllWatcherId: c.api.resources.Register(w),
@@ -124,6 +149,9 @@ func (c *Client) WatchAll() (params.AllWatcherId, error) {
 
 // Resolved implements the server side of Client.Resolved.
 func (c *Client) Resolved(p params.Resolved) error {
+	if err := c.checkCanWrite(); err != nil {
+		return err
+	}
 	if err := c.check.ChangeAllowed(); err != nil {
 		return errors.Trace(err)
 	}
@@ -136,6 +164,10 @@ func (c *Client) Resolved(p params.Resolved) error {
 
 // PublicAddress implements the server side of Client.PublicAddress.
 func (c *Client) PublicAddress(p params.PublicAddress) (results params.PublicAddressResults, err error) {
+	if err := c.checkCanRead(); err != nil {
+		return params.PublicAddressResults{}, err
+	}
+
 	switch {
 	case names.IsValidMachine(p.Target):
 		machine, err := c.api.stateAccessor.Machine(p.Target)
@@ -164,6 +196,10 @@ func (c *Client) PublicAddress(p params.PublicAddress) (results params.PublicAdd
 
 // PrivateAddress implements the server side of Client.PrivateAddress.
 func (c *Client) PrivateAddress(p params.PrivateAddress) (results params.PrivateAddressResults, err error) {
+	if err := c.checkCanRead(); err != nil {
+		return params.PrivateAddressResults{}, err
+	}
+
 	switch {
 	case names.IsValidMachine(p.Target):
 		machine, err := c.api.stateAccessor.Machine(p.Target)
@@ -193,6 +229,10 @@ func (c *Client) PrivateAddress(p params.PrivateAddress) (results params.Private
 
 // GetModelConstraints returns the constraints for the model.
 func (c *Client) GetModelConstraints() (params.GetConstraintsResults, error) {
+	if err := c.checkCanRead(); err != nil {
+		return params.GetConstraintsResults{}, err
+	}
+
 	cons, err := c.api.stateAccessor.ModelConstraints()
 	if err != nil {
 		return params.GetConstraintsResults{}, err
@@ -202,6 +242,10 @@ func (c *Client) GetModelConstraints() (params.GetConstraintsResults, error) {
 
 // SetModelConstraints sets the constraints for the model.
 func (c *Client) SetModelConstraints(args params.SetConstraints) error {
+	if err := c.checkCanWrite(); err != nil {
+		return err
+	}
+
 	if err := c.check.ChangeAllowed(); err != nil {
 		return errors.Trace(err)
 	}
@@ -210,6 +254,10 @@ func (c *Client) SetModelConstraints(args params.SetConstraints) error {
 
 // AddMachines adds new machines with the supplied parameters.
 func (c *Client) AddMachines(args params.AddMachines) (params.AddMachinesResults, error) {
+	if err := c.checkCanWrite(); err != nil {
+		return params.AddMachinesResults{}, err
+	}
+
 	return c.AddMachinesV2(args)
 }
 
@@ -233,6 +281,10 @@ func (c *Client) AddMachinesV2(args params.AddMachines) (params.AddMachinesResul
 
 // InjectMachines injects a machine into state with provisioned status.
 func (c *Client) InjectMachines(args params.AddMachines) (params.AddMachinesResults, error) {
+	if err := c.checkCanWrite(); err != nil {
+		return params.AddMachinesResults{}, err
+	}
+
 	return c.AddMachines(args)
 }
 
@@ -311,6 +363,10 @@ func (c *Client) addOneMachine(p params.AddMachineParams) (*state.Machine, error
 // ProvisioningScript returns a shell script that, when run,
 // provisions a machine agent on the machine executing the script.
 func (c *Client) ProvisioningScript(args params.ProvisioningScriptParams) (params.ProvisioningScriptResult, error) {
+	if err := c.checkCanWrite(); err != nil {
+		return params.ProvisioningScriptResult{}, err
+	}
+
 	var result params.ProvisioningScriptResult
 	icfg, err := InstanceConfig(c.api.state(), args.MachineId, args.Nonce, args.DataDir)
 	if err != nil {
@@ -348,6 +404,10 @@ func (c *Client) ProvisioningScript(args params.ProvisioningScriptParams) (param
 
 // DestroyMachines removes a given set of machines.
 func (c *Client) DestroyMachines(args params.DestroyMachines) error {
+	if err := c.checkCanWrite(); err != nil {
+		return err
+	}
+
 	if err := c.check.RemoveAllowed(); !args.Force && err != nil {
 		return errors.Trace(err)
 	}
@@ -360,6 +420,10 @@ func (c *Client) DestroyMachines(args params.DestroyMachines) error {
 //
 // TODO(axw) drop this method after 2.0-beta16 is out.
 func (c *Client) ModelInfo() (params.ModelInfo, error) {
+	if err := c.checkCanWrite(); err != nil {
+		return params.ModelInfo{}, err
+	}
+
 	state := c.api.stateAccessor
 	conf, err := state.ModelConfig()
 	if err != nil {
@@ -390,6 +454,10 @@ func modelInfo(st *state.State, user description.UserAccess) (params.ModelUserIn
 // ModelUserInfo returns information on all users in the model.
 func (c *Client) ModelUserInfo() (params.ModelUserInfoResults, error) {
 	var results params.ModelUserInfoResults
+	if err := c.checkCanRead(); err != nil {
+		return results, err
+	}
+
 	env, err := c.api.stateAccessor.Model()
 	if err != nil {
 		return results, errors.Trace(err)
@@ -414,11 +482,19 @@ func (c *Client) ModelUserInfo() (params.ModelUserInfoResults, error) {
 
 // AgentVersion returns the current version that the API server is running.
 func (c *Client) AgentVersion() (params.AgentVersionResult, error) {
+	if err := c.checkCanRead(); err != nil {
+		return params.AgentVersionResult{}, err
+	}
+
 	return params.AgentVersionResult{Version: jujuversion.Current}, nil
 }
 
 // SetModelAgentVersion sets the model agent version.
 func (c *Client) SetModelAgentVersion(args params.SetModelAgentVersion) error {
+	if err := c.checkCanWrite(); err != nil {
+		return err
+	}
+
 	if err := c.check.ChangeAllowed(); err != nil {
 		return errors.Trace(err)
 	}
@@ -437,6 +513,10 @@ func (c *Client) SetModelAgentVersion(args params.SetModelAgentVersion) error {
 // AbortCurrentUpgrade aborts and archives the current upgrade
 // synchronisation record, if any.
 func (c *Client) AbortCurrentUpgrade() error {
+	if err := c.checkCanWrite(); err != nil {
+		return err
+	}
+
 	if err := c.check.ChangeAllowed(); err != nil {
 		return errors.Trace(err)
 	}
@@ -445,10 +525,18 @@ func (c *Client) AbortCurrentUpgrade() error {
 
 // FindTools returns a List containing all tools matching the given parameters.
 func (c *Client) FindTools(args params.FindToolsParams) (params.FindToolsResult, error) {
+	if err := c.checkCanWrite(); err != nil {
+		return params.FindToolsResult{}, err
+	}
+
 	return c.api.toolsFinder.FindTools(args)
 }
 
 func (c *Client) AddCharm(args params.AddCharm) error {
+	if err := c.checkCanWrite(); err != nil {
+		return err
+	}
+
 	return application.AddCharmWithAuthorization(c.api.state(), params.AddCharmWithAuthorization{
 		URL:     args.URL,
 		Channel: args.Channel,
@@ -462,17 +550,29 @@ func (c *Client) AddCharm(args params.AddCharm) error {
 // The authorization macaroon, args.CharmStoreMacaroon, may be
 // omitted, in which case this call is equivalent to AddCharm.
 func (c *Client) AddCharmWithAuthorization(args params.AddCharmWithAuthorization) error {
+	if err := c.checkCanWrite(); err != nil {
+		return err
+	}
+
 	return application.AddCharmWithAuthorization(c.api.state(), args)
 }
 
 // ResolveCharm resolves the best available charm URLs with series, for charm
 // locations without a series specified.
 func (c *Client) ResolveCharms(args params.ResolveCharms) (params.ResolveCharmResults, error) {
+	if err := c.checkCanWrite(); err != nil {
+		return params.ResolveCharmResults{}, err
+	}
+
 	return application.ResolveCharms(c.api.state(), args)
 }
 
 // RetryProvisioning marks a provisioning error as transient on the machines.
 func (c *Client) RetryProvisioning(p params.Entities) (params.ErrorResults, error) {
+	if err := c.checkCanWrite(); err != nil {
+		return params.ErrorResults{}, err
+	}
+
 	if err := c.check.ChangeAllowed(); err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
@@ -487,6 +587,10 @@ func (c *Client) RetryProvisioning(p params.Entities) (params.ErrorResults, erro
 
 // APIHostPorts returns the API host/port addresses stored in state.
 func (c *Client) APIHostPorts() (result params.APIHostPortsResult, err error) {
+	if err := c.checkCanWrite(); err != nil {
+		return result, err
+	}
+
 	var servers [][]network.HostPort
 	if servers, err = c.api.stateAccessor.APIHostPorts(); err != nil {
 		return params.APIHostPortsResult{}, err

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -103,6 +103,7 @@ func (c *Client) machineStatusHistory(machineTag names.MachineTag, filter status
 
 // StatusHistory returns a slice of past statuses for several entities.
 func (c *Client) StatusHistory(request params.StatusHistoryRequests) params.StatusHistoryResults {
+
 	results := params.StatusHistoryResults{}
 	// TODO(perrito666) the contents of the loop could be split into
 	// a oneHistory method for clarity.
@@ -112,6 +113,15 @@ func (c *Client) StatusHistory(request params.StatusHistoryRequests) params.Stat
 			Date:  request.Filter.Date,
 			Delta: request.Filter.Delta,
 		}
+		if err := c.checkCanRead(); err != nil {
+			history := params.StatusHistoryResult{
+				Error: common.ServerError(err),
+			}
+			results.Results = append(results.Results, history)
+			continue
+
+		}
+
 		if err := filter.Validate(); err != nil {
 			history := params.StatusHistoryResult{
 				Error: common.ServerError(errors.Annotate(err, "cannot validate status history filter")),
@@ -154,6 +164,10 @@ func (c *Client) StatusHistory(request params.StatusHistoryRequests) params.Stat
 
 // FullStatus gives the information needed for juju status over the api
 func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error) {
+	if err := c.checkCanRead(); err != nil {
+		return params.FullStatus{}, err
+	}
+
 	var noStatus params.FullStatus
 	var context statusContext
 	var err error

--- a/apiserver/client/statushistory_test.go
+++ b/apiserver/client/statushistory_test.go
@@ -28,7 +28,7 @@ type statusHistoryTestSuite struct {
 
 func (s *statusHistoryTestSuite) SetUpTest(c *gc.C) {
 	s.st = &mockState{}
-	tag := names.NewUserTag("user")
+	tag := names.NewUserTag("admin")
 	authorizer := &apiservertesting.FakeAuthorizer{Tag: tag}
 	var err error
 	s.api, err = client.NewClient(
@@ -226,6 +226,10 @@ type mockState struct {
 
 func (m *mockState) ModelUUID() string {
 	return "uuid"
+}
+
+func (m *mockState) ModelTag() names.ModelTag {
+	return names.NewModelTag("deadbeef-0bad-400d-8000-4b1d0d06f00d")
 }
 
 func (m *mockState) Unit(name string) (client.Unit, error) {

--- a/apiserver/cloud/backend.go
+++ b/apiserver/cloud/backend.go
@@ -14,6 +14,8 @@ type Backend interface {
 	Cloud(cloudName string) (cloud.Cloud, error)
 	CloudCredentials(user names.UserTag, cloudName string) (map[string]cloud.Credential, error)
 	ControllerModel() (Model, error)
+	ControllerTag() names.ControllerTag
+	ModelTag() names.ModelTag
 	UpdateCloudCredentials(user names.UserTag, cloudName string, credentials map[string]cloud.Credential) error
 
 	IsControllerAdmin(names.UserTag) (bool, error)

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -126,6 +126,9 @@ type NetworkBacking interface {
 
 	// AllSubnets returns all backing subnets.
 	AllSubnets() ([]BackingSubnet, error)
+
+	// ModelTag returns the tag of the model this state is associated to.
+	ModelTag() names.ModelTag
 }
 
 func BackingSubnetToParamsSubnet(subnet BackingSubnet) params.Subnet {

--- a/apiserver/controller/destroy.go
+++ b/apiserver/controller/destroy.go
@@ -25,11 +25,7 @@ func (s *ControllerAPI) DestroyController(args params.DestroyControllerArgs) err
 	if err != nil {
 		return errors.Trace(err)
 	}
-	isCAdmin, err := s.state.IsControllerAdmin(s.apiUser)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if !hasPermission && !isCAdmin {
+	if !hasPermission {
 		return errors.Trace(common.ErrPerm)
 	}
 

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -93,9 +93,13 @@ type Authorizer interface {
 	// func if anything.
 	AuthClient() bool
 
-	// HasPermission returns true if the given access is allowed for the given
+	// HasPermission reports whether the given access is allowed for the given
 	// target by the authenticated entity.
 	HasPermission(operation description.Access, target names.Tag) (bool, error)
+
+	// UserHasPermission reports whether the given access is allowed for the given
+	// target by the given user.
+	UserHasPermission(user names.UserTag, operation description.Access, target names.Tag) (bool, error)
 
 	// ConnectedModel returns the UUID of the model to which the API
 	// connection was made.

--- a/apiserver/highavailability/highavailability.go
+++ b/apiserver/highavailability/highavailability.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/state"
 )
 
@@ -55,6 +56,16 @@ func NewHighAvailabilityAPI(st *state.State, resources facade.Resources, authori
 func (api *HighAvailabilityAPI) EnableHA(args params.ControllersSpecs) (params.ControllersChangeResults, error) {
 	results := params.ControllersChangeResults{Results: make([]params.ControllersChangeResult, len(args.Specs))}
 	for i, controllersServersSpec := range args.Specs {
+		if api.authorizer.AuthClient() {
+			admin, err := api.authorizer.HasPermission(description.SuperuserAccess, api.state.ControllerTag())
+			if err != nil && !errors.IsNotFound(err) {
+				return results, errors.Trace(err)
+			}
+			if !admin {
+				return results, common.ServerError(common.ErrPerm)
+			}
+
+		}
 		result, err := EnableHASingle(api.state, controllersServersSpec)
 		results.Results[i].Result = result
 		results.Results[i].Error = common.ServerError(err)

--- a/apiserver/imagemanager/state.go
+++ b/apiserver/imagemanager/state.go
@@ -6,10 +6,12 @@ package imagemanager
 import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/imagestorage"
+	names "gopkg.in/juju/names.v2"
 )
 
 type stateInterface interface {
 	ImageStorage() imagestorage.Storage
+	ControllerTag() names.ControllerTag
 }
 
 type stateShim struct {

--- a/apiserver/imagemetadata/metadata_test.go
+++ b/apiserver/imagemetadata/metadata_test.go
@@ -22,7 +22,7 @@ func (s *metadataSuite) TestFindNil(c *gc.C) {
 	found, err := s.api.List(params.ImageMetadataFilter{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Result, gc.HasLen, 0)
-	s.assertCalls(c, findMetadata)
+	s.assertCalls(c, "ControllerTag", findMetadata)
 }
 
 func (s *metadataSuite) TestFindEmpty(c *gc.C) {
@@ -33,7 +33,7 @@ func (s *metadataSuite) TestFindEmpty(c *gc.C) {
 	found, err := s.api.List(params.ImageMetadataFilter{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Result, gc.HasLen, 0)
-	s.assertCalls(c, findMetadata)
+	s.assertCalls(c, "ControllerTag", findMetadata)
 }
 
 func (s *metadataSuite) TestFindEmptyGroups(c *gc.C) {
@@ -47,7 +47,7 @@ func (s *metadataSuite) TestFindEmptyGroups(c *gc.C) {
 	found, err := s.api.List(params.ImageMetadataFilter{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Result, gc.HasLen, 0)
-	s.assertCalls(c, findMetadata)
+	s.assertCalls(c, "ControllerTag", findMetadata)
 }
 
 func (s *metadataSuite) TestFindError(c *gc.C) {
@@ -59,7 +59,7 @@ func (s *metadataSuite) TestFindError(c *gc.C) {
 	found, err := s.api.List(params.ImageMetadataFilter{})
 	c.Assert(err, gc.ErrorMatches, msg)
 	c.Assert(found.Result, gc.HasLen, 0)
-	s.assertCalls(c, findMetadata)
+	s.assertCalls(c, "ControllerTag", findMetadata)
 }
 
 func (s *metadataSuite) TestFindOrder(c *gc.C) {
@@ -92,14 +92,14 @@ func (s *metadataSuite) TestFindOrder(c *gc.C) {
 		params.CloudImageMetadata{ImageId: customImageId2, Priority: 20},
 		params.CloudImageMetadata{ImageId: publicImageId, Priority: 15},
 	})
-	s.assertCalls(c, findMetadata)
+	s.assertCalls(c, "ControllerTag", findMetadata)
 }
 
 func (s *metadataSuite) TestSaveEmpty(c *gc.C) {
 	errs, err := s.api.Save(params.MetadataSaveParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs.Results, gc.HasLen, 0)
-	s.assertCalls(c)
+	s.assertCalls(c, "ControllerTag")
 }
 
 func (s *metadataSuite) TestSave(c *gc.C) {
@@ -130,14 +130,14 @@ func (s *metadataSuite) TestSave(c *gc.C) {
 	c.Assert(errs.Results, gc.HasLen, 2)
 	c.Assert(errs.Results[0].Error, gc.IsNil)
 	c.Assert(errs.Results[1].Error, gc.ErrorMatches, msg)
-	s.assertCalls(c, environConfig, "Model", saveMetadata, saveMetadata)
+	s.assertCalls(c, "ControllerTag", environConfig, "Model", saveMetadata, saveMetadata)
 }
 
 func (s *metadataSuite) TestDeleteEmpty(c *gc.C) {
 	errs, err := s.api.Delete(params.MetadataImageIds{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs.Results, gc.HasLen, 0)
-	s.assertCalls(c)
+	s.assertCalls(c, "ControllerTag")
 }
 
 func (s *metadataSuite) TestDelete(c *gc.C) {
@@ -157,5 +157,5 @@ func (s *metadataSuite) TestDelete(c *gc.C) {
 	c.Assert(errs.Results, gc.HasLen, 2)
 	c.Assert(errs.Results[0].Error, gc.IsNil)
 	c.Assert(errs.Results[1].Error, gc.ErrorMatches, msg)
-	s.assertCalls(c, deleteMetadata, deleteMetadata)
+	s.assertCalls(c, "ControllerTag", deleteMetadata, deleteMetadata)
 }

--- a/apiserver/imagemetadata/package_test.go
+++ b/apiserver/imagemetadata/package_test.go
@@ -43,7 +43,7 @@ func (s *baseImageMetadataSuite) SetUpSuite(c *gc.C) {
 func (s *baseImageMetadataSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.resources = common.NewResources()
-	s.authorizer = testing.FakeAuthorizer{names.NewUserTag("testuser"), true, ""}
+	s.authorizer = testing.FakeAuthorizer{Tag: names.NewUserTag("testuser"), EnvironManager: true, AdminTag: names.NewUserTag("testuser")}
 
 	s.state = s.constructState(testConfig(c), &mockModel{"meep"})
 
@@ -83,6 +83,9 @@ func (s *baseImageMetadataSuite) constructState(cfg *config.Config, model imagem
 		model: func() (imagemetadata.Model, error) {
 			return model, nil
 		},
+		controllerTag: func() names.ControllerTag {
+			return names.NewControllerTag("deadbeef-2f18-4fd2-967d-db9663db7bea")
+		},
 	}
 }
 
@@ -94,6 +97,7 @@ type mockState struct {
 	deleteMetadata func(imageId string) error
 	environConfig  func() (*config.Config, error)
 	model          func() (imagemetadata.Model, error)
+	controllerTag  func() names.ControllerTag
 }
 
 func (st *mockState) FindMetadata(f cloudimagemetadata.MetadataFilter) (map[string][]cloudimagemetadata.Metadata, error) {
@@ -119,6 +123,11 @@ func (st *mockState) ModelConfig() (*config.Config, error) {
 func (st *mockState) Model() (imagemetadata.Model, error) {
 	st.Stub.MethodCall(st, "Model")
 	return st.model()
+}
+
+func (st *mockState) ControllerTag() names.ControllerTag {
+	st.Stub.MethodCall(st, "ControllerTag")
+	return st.controllerTag()
 }
 
 type mockModel struct {

--- a/apiserver/imagemetadata/state.go
+++ b/apiserver/imagemetadata/state.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/cloudimagemetadata"
+	names "gopkg.in/juju/names.v2"
 )
 
 type metadataAcess interface {
@@ -15,6 +16,7 @@ type metadataAcess interface {
 	DeleteMetadata(imageId string) error
 	Model() (Model, error)
 	ModelConfig() (*config.Config, error)
+	ControllerTag() names.ControllerTag
 }
 
 type Model interface {

--- a/apiserver/imagemetadata/updatefrompublished_test.go
+++ b/apiserver/imagemetadata/updatefrompublished_test.go
@@ -282,7 +282,7 @@ func (s *regionMetadataSuite) setExpectations(c *gc.C) {
 func (s *regionMetadataSuite) checkStoredPublished(c *gc.C) {
 	err := s.api.UpdateFromPublishedImages()
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertCalls(c, environConfig, "Model", saveMetadata)
+	s.assertCalls(c, "ControllerTag", "ControllerTag", environConfig, "Model", saveMetadata)
 	c.Assert(s.saved, jc.SameContents, s.expected)
 }
 
@@ -397,7 +397,7 @@ func (s *regionMetadataSuite) TestUpdateFromPublishedImagesMultipleDS(c *gc.C) {
 
 	err = s.api.UpdateFromPublishedImages()
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertCalls(c, environConfig, "Model", saveMetadata, environConfig, "Model", saveMetadata)
+	s.assertCalls(c, "ControllerTag", "ControllerTag", environConfig, "Model", saveMetadata, "ControllerTag", environConfig, "Model", saveMetadata)
 	c.Assert(s.saved, jc.SameContents, s.expected)
 }
 

--- a/apiserver/machinemanager/machinemanager_test.go
+++ b/apiserver/machinemanager/machinemanager_test.go
@@ -135,6 +135,10 @@ func (st *mockState) GetBlockForType(t state.BlockType) (state.Block, bool, erro
 	return &mockBlock{}, false, nil
 }
 
+func (st *mockState) ModelTag() names.ModelTag {
+	return names.NewModelTag("deadbeef-2f18-4fd2-967d-db9663db7bea")
+}
+
 func (st *mockState) ModelConfig() (*config.Config, error) {
 	panic("not implemented")
 }

--- a/apiserver/machinemanager/state.go
+++ b/apiserver/machinemanager/state.go
@@ -7,11 +7,13 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
+	names "gopkg.in/juju/names.v2"
 )
 
 type stateInterface interface {
 	ModelConfig() (*config.Config, error)
 	Model() (*state.Model, error)
+	ModelTag() names.ModelTag
 	GetBlockForType(t state.BlockType) (state.Block, bool, error)
 	AddOneMachine(template state.MachineTemplate) (*state.Machine, error)
 	AddMachineInsideNewMachine(template, parentTemplate state.MachineTemplate, containerType instance.ContainerType) (*state.Machine, error)
@@ -28,6 +30,9 @@ func (s stateShim) ModelConfig() (*config.Config, error) {
 
 func (s stateShim) Model() (*state.Model, error) {
 	return s.State.Model()
+}
+func (s stateShim) ModelTag() names.ModelTag {
+	return s.State.ModelTag()
 }
 
 func (s stateShim) GetBlockForType(t state.BlockType) (state.Block, bool, error) {

--- a/apiserver/migrationtarget/migrationtarget.go
+++ b/apiserver/migrationtarget/migrationtarget.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/state"
 )
@@ -47,9 +48,7 @@ func checkAuth(authorizer facade.Authorizer, st *state.State) error {
 		return errors.Trace(common.ErrPerm)
 	}
 
-	// Type assertion is fine because AuthClient is true.
-	apiUser := authorizer.GetAuthTag().(names.UserTag)
-	if isAdmin, err := st.IsControllerAdmin(apiUser); err != nil {
+	if isAdmin, err := authorizer.HasPermission(description.SuperuserAccess, st.ControllerTag()); err != nil {
 		return errors.Trace(err)
 	} else if !isAdmin {
 		// The entire facade is only accessible to controller administrators.

--- a/apiserver/migrationtarget/migrationtarget_test.go
+++ b/apiserver/migrationtarget/migrationtarget_test.go
@@ -43,7 +43,8 @@ func (s *Suite) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(*gc.C) { s.resources.StopAll() })
 
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		Tag: s.Owner,
+		Tag:      s.Owner,
+		AdminTag: s.Owner,
 	}
 }
 

--- a/apiserver/modelconfig/backend.go
+++ b/apiserver/modelconfig/backend.go
@@ -7,12 +7,14 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
+	names "gopkg.in/juju/names.v2"
 )
 
 // Backend contains the state.State methods used in this package,
 // allowing stubs to be created for testing.
 type Backend interface {
 	common.BlockGetter
+	ModelTag() names.ModelTag
 	ModelConfigValues() (config.ConfigValues, error)
 	ModelConfigDefaultValues() (config.ConfigValues, error)
 	UpdateModelConfigDefaultValues(map[string]interface{}, []string) error

--- a/apiserver/modelconfig/modelconfig.go
+++ b/apiserver/modelconfig/modelconfig.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
@@ -42,13 +43,28 @@ func NewModelConfigAPI(backend Backend, authorizer facade.Authorizer) (*ModelCon
 	return client, nil
 }
 
+func (c *ModelConfigAPI) checkCanWrite() error {
+	canWrite, err := c.auth.HasPermission(description.WriteAccess, c.backend.ModelTag())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if !canWrite {
+		return common.ErrPerm
+	}
+	return nil
+}
+
 // ModelGet implements the server-side part of the
 // get-model-config CLI command.
 func (c *ModelConfigAPI) ModelGet() (params.ModelConfigResults, error) {
 	result := params.ModelConfigResults{}
+	if err := c.checkCanWrite(); err != nil {
+		return result, errors.Trace(err)
+	}
+
 	values, err := c.backend.ModelConfigValues()
 	if err != nil {
-		return result, err
+		return result, errors.Trace(err)
 	}
 
 	// TODO(wallyworld) - this can be removed once credentials are properly
@@ -56,7 +72,7 @@ func (c *ModelConfigAPI) ModelGet() (params.ModelConfigResults, error) {
 	// Strip out any model config attributes that are credential attributes.
 	provider, err := environs.Provider(values[config.TypeKey].Value.(string))
 	if err != nil {
-		return result, err
+		return result, errors.Trace(err)
 	}
 	credSchemas := provider.CredentialSchemas()
 	var allCredentialAttributes []string
@@ -96,6 +112,10 @@ func (c *ModelConfigAPI) ModelGet() (params.ModelConfigResults, error) {
 // ModelSet implements the server-side part of the
 // set-model-config CLI command.
 func (c *ModelConfigAPI) ModelSet(args params.ModelSet) error {
+	if err := c.checkCanWrite(); err != nil {
+		return err
+	}
+
 	if err := c.check.ChangeAllowed(); err != nil {
 		return errors.Trace(err)
 	}
@@ -117,6 +137,9 @@ func (c *ModelConfigAPI) ModelSet(args params.ModelSet) error {
 // ModelUnset implements the server-side part of the
 // set-model-config CLI command.
 func (c *ModelConfigAPI) ModelUnset(args params.ModelUnset) error {
+	if err := c.checkCanWrite(); err != nil {
+		return err
+	}
 	if err := c.check.ChangeAllowed(); err != nil {
 		return errors.Trace(err)
 	}
@@ -126,9 +149,13 @@ func (c *ModelConfigAPI) ModelUnset(args params.ModelUnset) error {
 // ModelDefaults returns the default config values used when creating a new model.
 func (c *ModelConfigAPI) ModelDefaults() (params.ModelConfigResults, error) {
 	result := params.ModelConfigResults{}
+	if err := c.checkCanWrite(); err != nil {
+		return result, errors.Trace(err)
+	}
+
 	values, err := c.backend.ModelConfigDefaultValues()
 	if err != nil {
-		return result, err
+		return result, errors.Trace(err)
 	}
 	result.Config = make(map[string]params.ConfigValue)
 	for attr, val := range values {
@@ -156,6 +183,10 @@ func (c *ModelConfigAPI) SetModelDefaults(args params.SetModelDefaults) (params.
 }
 
 func (c *ModelConfigAPI) setModelDefaults(args params.ModelDefaultValues) error {
+	if err := c.checkCanWrite(); err != nil {
+		return errors.Trace(err)
+	}
+
 	if err := c.check.ChangeAllowed(); err != nil {
 		return errors.Trace(err)
 	}
@@ -169,6 +200,10 @@ func (c *ModelConfigAPI) setModelDefaults(args params.ModelDefaultValues) error 
 // UnsetModelDefaults removes the specified default model settings.
 func (c *ModelConfigAPI) UnsetModelDefaults(args params.UnsetModelDefaults) (params.ErrorResults, error) {
 	results := params.ErrorResults{Results: make([]params.ErrorResult, len(args.Keys))}
+	if err := c.checkCanWrite(); err != nil {
+		return results, err
+	}
+
 	if err := c.check.ChangeAllowed(); err != nil {
 		return results, errors.Trace(err)
 	}

--- a/apiserver/modelconfig/modelconfig_test.go
+++ b/apiserver/modelconfig/modelconfig_test.go
@@ -32,7 +32,8 @@ var _ = gc.Suite(&modelconfigSuite{})
 func (s *modelconfigSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		Tag: names.NewUserTag("bruce@local"),
+		Tag:      names.NewUserTag("bruce@local"),
+		AdminTag: names.NewUserTag("bruce@local"),
 	}
 	s.backend = &mockBackend{
 		cfg: config.ConfigValues{
@@ -272,6 +273,10 @@ func (m *mockBackend) GetBlockForType(t state.BlockType) (state.Block, bool, err
 	} else {
 		return nil, false, nil
 	}
+}
+
+func (m *mockBackend) ModelTag() names.ModelTag {
+	return names.NewModelTag("deadbeef-2f18-4fd2-967d-db9663db7bea")
 }
 
 type mockBlock struct {

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -50,6 +50,23 @@ func (s *modelInfoSuite) SetUpTest(c *gc.C) {
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 		},
 	}
+	s.st.controllerModel = &mockModel{
+		owner: names.NewUserTag("admin@local"),
+		life:  state.Alive,
+		cfg:   coretesting.ModelConfig(c),
+		status: status.StatusInfo{
+			Status: status.StatusAvailable,
+			Since:  &time.Time{},
+		},
+		users: []*mockModelUser{{
+			userName: "admin",
+			access:   description.AdminAccess,
+		}, {
+			userName: "otheruser",
+			access:   description.AdminAccess,
+		}},
+	}
+
 	s.st.model = &mockModel{
 		owner: names.NewUserTag("bob@local"),
 		cfg:   coretesting.ModelConfig(c),
@@ -58,6 +75,7 @@ func (s *modelInfoSuite) SetUpTest(c *gc.C) {
 			Status: status.StatusDestroying,
 			Since:  &time.Time{},
 		},
+
 		users: []*mockModelUser{{
 			userName: "admin",
 			access:   description.AdminAccess,
@@ -117,7 +135,7 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		}},
 	})
 	s.st.CheckCalls(c, []gitjujutesting.StubCall{
-		{"IsControllerAdmin", []interface{}{names.NewUserTag("admin@local")}},
+		{"ControllerTag", nil},
 		{"ModelUUID", nil},
 		{"ForModel", []interface{}{names.NewModelTag(s.st.model.cfg.UUID())}},
 		{"Model", nil},

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -82,7 +82,7 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 				access:   description.AdminAccess,
 			}, {
 				userName: "otheruser",
-				access:   description.AdminAccess,
+				access:   description.WriteAccess,
 			}},
 		},
 		model: &mockModel{
@@ -99,7 +99,7 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 				access:   description.AdminAccess,
 			}, {
 				userName: "otheruser",
-				access:   description.AdminAccess,
+				access:   description.WriteAccess,
 			}},
 		},
 		creds: map[string]cloud.Credential{
@@ -127,10 +127,9 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 	_, err := s.api.CreateModel(args)
 	c.Assert(err, jc.ErrorIsNil)
 	s.st.CheckCallNames(c,
-		"IsControllerAdmin",
+		"ControllerTag",
 		"ModelUUID",
 		"ControllerTag",
-		"IsControllerAdmin",
 		"ControllerModel",
 		"Cloud",
 		"CloudCredentials",
@@ -142,8 +141,8 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 		"ControllerConfig",
 		"LastModelConnection",
 		"LastModelConnection",
-		"Close", // close new model's state
-		"Close", // close controller model's state
+		"Close",
+		"Close",
 	)
 
 	// We cannot predict the UUID, because it's generated,
@@ -324,8 +323,6 @@ func (s *modelManagerSuite) TestDumpModelMissingModel(c *gc.C) {
 }
 
 func (s *modelManagerSuite) TestDumpModelMissingUser(c *gc.C) {
-	s.st.SetErrors(nil, errors.New("boom"))
-
 	authoriser := apiservertesting.FakeAuthorizer{
 		Tag: names.NewUserTag("other@local"),
 	}
@@ -337,12 +334,12 @@ func (s *modelManagerSuite) TestDumpModelMissingUser(c *gc.C) {
 
 	calls := s.st.Calls()
 	lastCall := calls[len(calls)-1]
-	c.Check(lastCall.FuncName, gc.Equals, "ModelUser")
+	c.Check(lastCall.FuncName, gc.Equals, "ModelTag")
 
 	result := results.Results[0]
 	c.Assert(result.Result, gc.IsNil)
 	c.Assert(result.Error, gc.NotNil)
-	c.Check(result.Error.Message, gc.Equals, `boom`)
+	c.Check(result.Error.Message, gc.Equals, `permission denied`)
 }
 
 // modelManagerStateSuite contains end-to-end tests.

--- a/apiserver/pinger.go
+++ b/apiserver/pinger.go
@@ -4,9 +4,9 @@
 package apiserver
 
 import (
-	"errors"
 	"time"
 
+	"github.com/juju/errors"
 	"gopkg.in/tomb.v1"
 
 	"github.com/juju/juju/apiserver/common"

--- a/apiserver/provisioner/provisioninginfo.go
+++ b/apiserver/provisioner/provisioninginfo.go
@@ -34,7 +34,7 @@ func (p *ProvisionerAPI) ProvisioningInfo(args params.Entities) (params.Provisio
 	}
 	canAccess, err := p.getAuthFunc()
 	if err != nil {
-		return result, err
+		return result, errors.Trace(err)
 	}
 	for i, entity := range args.Entities {
 		tag, err := names.ParseMachineTag(entity.Tag)
@@ -54,7 +54,7 @@ func (p *ProvisionerAPI) ProvisioningInfo(args params.Entities) (params.Provisio
 func (p *ProvisionerAPI) getProvisioningInfo(m *state.Machine) (*params.ProvisioningInfo, error) {
 	cons, err := m.Constraints()
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	volumes, err := p.machineVolumeParams(m)
@@ -110,18 +110,18 @@ func (p *ProvisionerAPI) getProvisioningInfo(m *state.Machine) (*params.Provisio
 func (p *ProvisionerAPI) machineVolumeParams(m *state.Machine) ([]params.VolumeParams, error) {
 	volumeAttachments, err := m.VolumeAttachments()
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	if len(volumeAttachments) == 0 {
 		return nil, nil
 	}
 	modelConfig, err := p.st.ModelConfig()
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	controllerCfg, err := p.st.ControllerConfig()
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	allVolumeParams := make([]params.VolumeParams, 0, len(volumeAttachments))
 	for _, volumeAttachment := range volumeAttachments {
@@ -290,7 +290,7 @@ func (p *ProvisionerAPI) machineEndpointBindings(m *state.Machine) (map[string]s
 		}
 		service, err := unit.Application()
 		if err != nil {
-			return nil, err
+			return nil, errors.Trace(err)
 		}
 		if processedServicesSet.Contains(service.Name()) {
 			// Already processed, skip it.
@@ -298,7 +298,7 @@ func (p *ProvisionerAPI) machineEndpointBindings(m *state.Machine) (map[string]s
 		}
 		bindings, err := service.EndpointBindings()
 		if err != nil {
-			return nil, err
+			return nil, errors.Trace(err)
 		}
 		processedServicesSet.Add(service.Name())
 
@@ -363,7 +363,7 @@ func (p *ProvisionerAPI) availableImageMetadata(m *state.Machine) ([]params.Clou
 	// Look for image metadata in state.
 	data, err := p.findImageMetadata(imageConstraint, env)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	sort.Sort(metadataList(data))
 	logger.Debugf("available image metadata for provisioning: %v", data)
@@ -494,7 +494,7 @@ func (p *ProvisionerAPI) imageMetadataFromState(constraint *imagemetadata.ImageC
 func (p *ProvisionerAPI) imageMetadataFromDataSources(env environs.Environ, constraint *imagemetadata.ImageConstraint) ([]params.CloudImageMetadata, error) {
 	sources, err := environs.ImageMetadataSources(env)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	getStream := func(current string) string {

--- a/apiserver/root_test.go
+++ b/apiserver/root_test.go
@@ -421,7 +421,7 @@ func (r *rootSuite) TestNoUserTagLacksPermission(c *gc.C) {
 	target := names.NewModelTag("beef1beef2-0000-0000-000011112222")
 	hasPermission, err := apiserver.HasPermission((&fakeUserAccess{}).call, nonUser, description.ReadAccess, target)
 	c.Assert(hasPermission, jc.IsFalse)
-	c.Assert(err, gc.ErrorMatches, "obtaining permission for subject kind \"model\" not valid")
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (r *rootSuite) TestHasPermission(c *gc.C) {
@@ -503,8 +503,8 @@ func (r *rootSuite) TestUserGetterErrorReturns(c *gc.C) {
 		err:  errors.NotFoundf("a user"),
 	}
 	hasPermission, err := apiserver.HasPermission(userGetter.call, user, description.ReadAccess, target)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hasPermission, jc.IsFalse)
-	c.Assert(err, gc.ErrorMatches, "while obtaining model user: a user not found")
 	c.Assert(userGetter.subjects, gc.HasLen, 1)
 	c.Assert(userGetter.subjects[0], gc.DeepEquals, user)
 	c.Assert(userGetter.objects, gc.HasLen, 1)

--- a/apiserver/sshclient/facade_test.go
+++ b/apiserver/sshclient/facade_test.go
@@ -43,6 +43,7 @@ func (s *facadeSuite) SetUpTest(c *gc.C) {
 	s.backend = new(mockBackend)
 	s.authorizer = new(apiservertesting.FakeAuthorizer)
 	s.authorizer.Tag = names.NewUserTag("igor")
+	s.authorizer.AdminTag = names.NewUserTag("igor")
 	facade, err := sshclient.New(s.backend, nil, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 	s.facade = facade
@@ -148,6 +149,10 @@ func (s *facadeSuite) TestProxyFalse(c *gc.C) {
 type mockBackend struct {
 	stub     jujutesting.Stub
 	proxySSH bool
+}
+
+func (backend *mockBackend) ModelTag() names.ModelTag {
+	return names.NewModelTag("deadbeef-2f18-4fd2-967d-db9663db7bea")
 }
 
 func (backend *mockBackend) ModelConfig() (*config.Config, error) {

--- a/apiserver/sshclient/shim.go
+++ b/apiserver/sshclient/shim.go
@@ -18,6 +18,7 @@ type Backend interface {
 	ModelConfig() (*config.Config, error)
 	GetMachineForEntity(tag string) (SSHMachine, error)
 	GetSSHHostKeys(names.MachineTag) (state.SSHHostKeys, error)
+	ModelTag() names.ModelTag
 }
 
 // SSHMachine specifies the methods on State.Machine of interest to

--- a/apiserver/storage/base_test.go
+++ b/apiserver/storage/base_test.go
@@ -50,7 +50,7 @@ type baseStorageSuite struct {
 func (s *baseStorageSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.resources = common.NewResources()
-	s.authorizer = testing.FakeAuthorizer{names.NewUserTag("testuser"), true, ""}
+	s.authorizer = testing.FakeAuthorizer{Tag: names.NewUserTag("admin"), EnvironManager: true}
 	s.calls = []string{}
 	s.state = s.constructState()
 

--- a/apiserver/storage/mock_test.go
+++ b/apiserver/storage/mock_test.go
@@ -50,6 +50,7 @@ type mockState struct {
 	watchVolumeAttachment               func(names.MachineTag, names.VolumeTag) state.NotifyWatcher
 	watchBlockDevices                   func(names.MachineTag) state.NotifyWatcher
 	modelName                           string
+	modelTag                            names.ModelTag
 	volume                              func(tag names.VolumeTag) (state.Volume, error)
 	machineVolumeAttachments            func(machine names.MachineTag) ([]state.VolumeAttachment, error)
 	volumeAttachments                   func(volume names.VolumeTag) ([]state.VolumeAttachment, error)
@@ -113,6 +114,10 @@ func (st *mockState) WatchBlockDevices(mtag names.MachineTag) state.NotifyWatche
 
 func (st *mockState) ModelName() (string, error) {
 	return st.modelName, nil
+}
+
+func (st *mockState) ModelTag() names.ModelTag {
+	return st.modelTag
 }
 
 func (st *mockState) AllVolumes() ([]state.Volume, error) {

--- a/apiserver/storage/shim.go
+++ b/apiserver/storage/shim.go
@@ -81,6 +81,9 @@ type storageAccess interface {
 	// ModelName is required for pool functionality.
 	ModelName() (string, error)
 
+	// ModelTag is required for model permission checking.
+	ModelTag() names.ModelTag
+
 	// AllVolumes is required for volume functionality.
 	AllVolumes() ([]state.Volume, error)
 

--- a/apiserver/testing/fakeauthorizer.go
+++ b/apiserver/testing/fakeauthorizer.go
@@ -14,6 +14,7 @@ type FakeAuthorizer struct {
 	Tag            names.Tag
 	EnvironManager bool
 	ModelUUID      string
+	AdminTag       names.UserTag
 }
 
 func (fa FakeAuthorizer) AuthOwner(tag names.Tag) bool {
@@ -47,10 +48,16 @@ func (fa FakeAuthorizer) GetAuthTag() names.Tag {
 	return fa.Tag
 }
 
+// HasPermission returns true if the logged in user is admin or has a name equal to
+// the pre-set admin tag.
 func (fa FakeAuthorizer) HasPermission(operation description.Access, target names.Tag) (bool, error) {
 	if fa.Tag.Kind() == names.UserTagKind {
 		ut := fa.Tag.(names.UserTag)
 		if ut.Name() == "admin" {
+			return true, nil
+		}
+		emptyTag := names.UserTag{}
+		if fa.AdminTag != emptyTag && ut == fa.AdminTag {
 			return true, nil
 		}
 		return false, nil
@@ -62,4 +69,21 @@ func (fa FakeAuthorizer) HasPermission(operation description.Access, target name
 // connected to.
 func (fa FakeAuthorizer) ConnectedModel() string {
 	return fa.ModelUUID
+}
+
+// HasPermission returns true if the passed user is admin or has a name equal to
+// the pre-set admin tag.
+func (fa FakeAuthorizer) UserHasPermission(user names.UserTag, operation description.Access, target names.Tag) (bool, error) {
+	if user.Name() == "admin" {
+		return true, nil
+	}
+	emptyTag := names.UserTag{}
+	if fa.AdminTag != emptyTag && user == fa.AdminTag {
+		return true, nil
+	}
+	ut := fa.Tag.(names.UserTag)
+	if ut == user {
+		return true, nil
+	}
+	return false, nil
 }

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -435,6 +435,10 @@ func (sb *StubBacking) ModelConfig() (*config.Config, error) {
 	return sb.EnvConfig, nil
 }
 
+func (sb *StubBacking) ModelTag() names.ModelTag {
+	return names.NewModelTag("dbeef-2f18-4fd2-967d-db9663db7bea")
+}
+
 func (sb *StubBacking) CloudSpec(names.ModelTag) (environs.CloudSpec, error) {
 	sb.MethodCall(sb, "CloudSpec")
 	if err := sb.NextErr(); err != nil {

--- a/apiserver/usermanager/usermanager_test.go
+++ b/apiserver/usermanager/usermanager_test.go
@@ -203,14 +203,8 @@ func (s *userManagerSuite) TestAddUserAsNormalUser(c *gc.C) {
 			Password:    "password",
 		}}}
 
-	got, err := usermanager.AddUser(args)
-
-	for _, result := range got.Results {
-		c.Check(errors.Cause(result.Error), jc.DeepEquals,
-			&params.Error{Message: "permission denied", Code: "unauthorized access"})
-	}
-	c.Assert(got.Results, gc.HasLen, 1)
-	c.Assert(err, jc.ErrorIsNil)
+	_, err = usermanager.AddUser(args)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
 
 	_, err = s.State.User(names.NewLocalUserTag("foobar"))
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
@@ -359,12 +353,8 @@ func (s *userManagerSuite) TestDisableUserAsNormalUser(c *gc.C) {
 	args := params.Entities{
 		[]params.Entity{{barb.Tag().String()}},
 	}
-	got, err := usermanager.DisableUser(args)
-	for _, result := range got.Results {
-		c.Check(errors.Cause(result.Error), jc.DeepEquals, &params.Error{Message: "permission denied", Code: "unauthorized access"})
-	}
-	c.Assert(got.Results, gc.HasLen, 1)
-	c.Assert(err, jc.ErrorIsNil)
+	_, err = usermanager.DisableUser(args)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
 
 	err = barb.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
@@ -382,12 +372,8 @@ func (s *userManagerSuite) TestEnableUserAsNormalUser(c *gc.C) {
 	args := params.Entities{
 		[]params.Entity{{barb.Tag().String()}},
 	}
-	got, err := usermanager.EnableUser(args)
-	for _, result := range got.Results {
-		c.Check(errors.Cause(result.Error), jc.DeepEquals, &params.Error{Message: "permission denied", Code: "unauthorized access"})
-	}
-	c.Assert(got.Results, gc.HasLen, 1)
-	c.Assert(err, jc.ErrorIsNil)
+	_, err = usermanager.EnableUser(args)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
 
 	err = barb.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
@@ -685,12 +671,9 @@ func (s *userManagerSuite) TestRemoveUserAsNormalUser(c *gc.C) {
 	c.Assert(ui.Results[0].Result.Username, gc.DeepEquals, jjam.Name())
 
 	// Remove jjam as chuck and fail.
-	got, err := usermanager.RemoveUser(params.Entities{
+	_, err = usermanager.RemoveUser(params.Entities{
 		Entities: []params.Entity{{Tag: jjam.Tag().String()}}})
-	c.Check(got.Results, gc.HasLen, 1)
-	c.Check(errors.Cause(got.Results[0].Error), jc.DeepEquals,
-		&params.Error{Message: "permission denied", Code: "unauthorized access"})
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
 
 	// Make sure jjam is still around.
 	err = jjam.Refresh()
@@ -718,12 +701,9 @@ func (s *userManagerSuite) TestRemoveUserSelfAsNormalUser(c *gc.C) {
 	c.Assert(ui.Results[0].Result.Username, gc.DeepEquals, jjam.Name())
 
 	// Remove the user as the user
-	got, err := usermanager.RemoveUser(params.Entities{
+	_, err = usermanager.RemoveUser(params.Entities{
 		Entities: []params.Entity{{Tag: jjam.Tag().String()}}})
-	c.Assert(got.Results, gc.HasLen, 1)
-	c.Check(errors.Cause(got.Results[0].Error), jc.DeepEquals,
-		&params.Error{Message: "permission denied", Code: "unauthorized access"})
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
 
 	// Check if deleted.
 	err = jjam.Refresh()

--- a/core/description/access.go
+++ b/core/description/access.go
@@ -84,7 +84,7 @@ func (a Access) EqualOrGreaterModelAccessThan(access Access) bool {
 	case WriteAccess:
 		return access == ReadAccess ||
 			access == UndefinedAccess
-	case AdminAccess:
+	case AdminAccess, SuperuserAccess:
 		return access == ReadAccess ||
 			access == WriteAccess
 	}


### PR DESCRIPTION
Facades that serve Users have been modified to
do permission checking per facade call in most cases
(some will check per facade) these checks provide a much
more atomic permission schema.

(Review request: http://reviews.vapour.ws/r/5430/)