### PR TITLE
api/modelmanager: introduce DestroyModels

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -185,13 +185,6 @@ func (c *Client) SetModelConstraints(constraints constraints.Value) error {
 	return c.facade.FacadeCall("SetModelConstraints", params, nil)
 }
 
-// ModelInfo returns details about the Juju model.
-func (c *Client) ModelInfo() (params.ModelInfo, error) {
-	var info params.ModelInfo
-	err := c.facade.FacadeCall("ModelInfo", nil, &info)
-	return info, err
-}
-
 // ModelUUID returns the model UUID from the client connection.
 func (c *Client) ModelUUID() (string, error) {
 	tag, err := c.st.ModelTag()

--- a/api/modelmanager/modelmanager_test.go
+++ b/api/modelmanager/modelmanager_test.go
@@ -77,17 +77,24 @@ func (s *modelmanagerSuite) TestListModels(c *gc.C) {
 	c.Assert(ownerNames, jc.DeepEquals, []string{"user@remote", "user@remote"})
 }
 
-func (s *modelmanagerSuite) TestDestroyEnvironment(c *gc.C) {
+func (s *modelmanagerSuite) TestDestroyModel(c *gc.C) {
 	modelManagerClient := s.OpenAPI(c)
 	var called bool
 	modelmanager.PatchFacadeCall(&s.CleanupSuite, modelManagerClient,
 		func(req string, args interface{}, resp interface{}) error {
-			c.Assert(req, gc.Equals, "DestroyModel")
+			c.Assert(req, gc.Equals, "DestroyModels")
+			c.Assert(args, jc.DeepEquals, params.Entities{
+				Entities: []params.Entity{{testing.ModelTag.String()}},
+			})
+			results := resp.(*params.ErrorResults)
+			*results = params.ErrorResults{
+				Results: []params.ErrorResult{{}},
+			}
 			called = true
 			return nil
 		})
 
-	err := modelManagerClient.DestroyModel()
+	err := modelManagerClient.DestroyModel(testing.ModelTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 }

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -357,6 +357,8 @@ func (c *Client) DestroyMachines(args params.DestroyMachines) error {
 
 // ModelInfo returns information about the current model (default
 // series and type).
+//
+// TODO(axw) drop this method after 2.0-beta16 is out.
 func (c *Client) ModelInfo() (params.ModelInfo, error) {
 	state := c.api.stateAccessor
 	conf, err := state.ModelConfig()

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -104,6 +104,20 @@ func (s *serverSuite) setAgentPresence(c *gc.C, machineId string) *presence.Ping
 	return pinger
 }
 
+func (s *serverSuite) TestModelInfo(c *gc.C) {
+	model, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	conf, _ := s.State.ModelConfig()
+	info, err := s.client.ModelInfo()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info.DefaultSeries, gc.Equals, config.PreferredSeries(conf))
+	c.Assert(info.CloudRegion, gc.Equals, model.CloudRegion())
+	c.Assert(info.ProviderType, gc.Equals, conf.Type())
+	c.Assert(info.Name, gc.Equals, conf.Name())
+	c.Assert(info.UUID, gc.Equals, model.UUID())
+	c.Assert(info.ControllerUUID, gc.Equals, model.ControllerUUID())
+}
+
 func (s *serverSuite) TestModelUsersInfo(c *gc.C) {
 	testAdmin := s.AdminUserTag(c)
 	owner, err := s.State.UserAccess(testAdmin, s.State.ModelTag())
@@ -395,20 +409,6 @@ func (s *clientSuite) TestClientStatus(c *gc.C) {
 	clearSinceTimes(status)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, jc.DeepEquals, scenarioStatus)
-}
-
-func (s *clientSuite) TestClientModelInfo(c *gc.C) {
-	model, err := s.State.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	conf, _ := s.State.ModelConfig()
-	info, err := s.APIState.Client().ModelInfo()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(info.DefaultSeries, gc.Equals, config.PreferredSeries(conf))
-	c.Assert(info.CloudRegion, gc.Equals, model.CloudRegion())
-	c.Assert(info.ProviderType, gc.Equals, conf.Type())
-	c.Assert(info.Name, gc.Equals, conf.Name())
-	c.Assert(info.UUID, gc.Equals, model.UUID())
-	c.Assert(info.ControllerUUID, gc.Equals, model.ControllerUUID())
 }
 
 func assertLife(c *gc.C, entity state.Living, life state.Life) {

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -36,6 +36,7 @@ type ModelManagerBackend interface {
 	ControllerModel() (Model, error)
 	ControllerConfig() (controller.Config, error)
 	ForModel(tag names.ModelTag) (ModelManagerBackend, error)
+	GetModel(names.ModelTag) (Model, error)
 	Model() (Model, error)
 	AllModels() ([]Model, error)
 	AddModelUser(state.UserAccessSpec) (description.UserAccess, error)
@@ -105,6 +106,15 @@ func (st modelManagerStateShim) ForModel(tag names.ModelTag) (ModelManagerBacken
 		return nil, err
 	}
 	return modelManagerStateShim{otherState}, nil
+}
+
+// GetModel implements ModelManagerBackend.
+func (st modelManagerStateShim) GetModel(tag names.ModelTag) (Model, error) {
+	m, err := st.State.GetModel(tag)
+	if err != nil {
+		return nil, err
+	}
+	return modelShim{m}, nil
 }
 
 // Model implements ModelManagerBackend.

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -308,6 +308,11 @@ func (st *mockState) ForModel(tag names.ModelTag) (common.ModelManagerBackend, e
 	return st, st.NextErr()
 }
 
+func (st *mockState) GetModel(tag names.ModelTag) (common.Model, error) {
+	st.MethodCall(st, "GetModel", tag)
+	return st.model, st.NextErr()
+}
+
 func (st *mockState) Model() (common.Model, error) {
 	st.MethodCall(st, "Model")
 	return st.model, st.NextErr()

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/loggo"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/apiserver/params"
@@ -61,7 +62,7 @@ Continue [y/N]? `[1:]
 // API that the destroy command calls. It is exported for mocking in tests.
 type DestroyModelAPI interface {
 	Close() error
-	DestroyModel() error
+	DestroyModel(names.ModelTag) error
 }
 
 // Info implements Command.Info.
@@ -137,7 +138,7 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	defer api.Close()
 
 	// Attempt to destroy the model.
-	err = api.DestroyModel()
+	err = api.DestroyModel(names.NewModelTag(modelDetails.ModelUUID))
 	if err != nil {
 		return c.handleError(errors.Annotate(err, "cannot destroy model"), modelName)
 	}

--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/model"
@@ -38,7 +39,7 @@ type fakeDestroyAPI struct {
 
 func (f *fakeDestroyAPI) Close() error { return nil }
 
-func (f *fakeDestroyAPI) DestroyModel() error {
+func (f *fakeDestroyAPI) DestroyModel(names.ModelTag) error {
 	return f.err
 }
 


### PR DESCRIPTION
Introduce a new API method, DestroyModels, which
supersedes DestroyModel. The new method takes a
set of model tags, and returns a set of error
results. The old method will be dropped once the
GUI and other clients are updated.

(Review request: http://reviews.vapour.ws/r/5431/)