### PR TITLE
state: Remove user permissions when removing model docs

### DIFF
--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -287,7 +287,7 @@ func (w *Worker) doPRECHECK() (coremigration.Phase, error) {
 func (w *Worker) doIMPORT(targetInfo coremigration.TargetInfo, modelUUID string) (coremigration.Phase, error) {
 	err := w.transferModel(targetInfo, modelUUID)
 	if err != nil {
-		w.setErrorStatus("model export failed: %v", err)
+		w.setErrorStatus("model data transfer failed: %v", err)
 		return coremigration.ABORT, nil
 	}
 	return coremigration.VALIDATION, nil


### PR DESCRIPTION
Documents in the permissions collection were being left behind after a model was removed. This was preventing models from being migrated away from a controller and then back again.

Fixes LP 1612500.

### QA Steps

```
$ juju bootstrap B lxd --upload-tools &
$ juju bootstrap A lxd --upload-tools &
$ juju wait
$ juju switch A
$ juju add-model foo
$ juju deploy ubuntu
# wait...
$ JUJU_DEV_FEATURE_FLAGS=migration juju migrate foo B
# wait...
$ juju switch B:foo
$ JUJU_DEV_FEATURE_FLAGS=migration juju migrate foo A
# wait...
$ juju switch A:foo
$ juju status
# ensure that agents are happy
```

Previously, the second migration would fail.


(Review request: http://reviews.vapour.ws/r/5432/)