### PR TITLE
state: Hide previously successful migrations

### DIFF
--- a/state/export_test.go
+++ b/state/export_test.go
@@ -492,3 +492,16 @@ func LeadershipLeases(st *State) (map[string]lease.Info, error) {
 	}
 	return client.Leases(), nil
 }
+
+func ResetMigrationMode(c *gc.C, st *State) {
+	ops := []txn.Op{{
+		C:      modelsC,
+		Id:     st.ModelUUID(),
+		Assert: txn.DocExists,
+		Update: bson.M{
+			"$set": bson.M{"migration-mode": MigrationModeActive},
+		},
+	}}
+	err := st.runTransaction(ops)
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -663,6 +663,23 @@ func (st *State) LatestModelMigration() (ModelMigration, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	// Hide previous migrations for models which have been migrated
+	// away from a model and then migrated back.
+	phase, err := mig.Phase()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if phase == migration.DONE {
+		model, err := st.Model()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if model.MigrationMode() == MigrationModeActive {
+			return nil, errors.NotFoundf("migration")
+		}
+	}
+
 	return mig, nil
 }
 


### PR DESCRIPTION
LatestModelMigration no longer reports a previous migration in the case of a model having migrated away from a controller and later back again. This avoids confusing the migrationmaster worker in this case.

Fixes LP 1613150.

### QA

Migrate a model from controller A, to B and then back to A again. Observe that after this the migrationmaster worker stays up (no "model has migrated" errors) at this point.

(Review request: http://reviews.vapour.ws/r/5434/)