### PR TITLE
apiserver: remove support for old login API versions

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -340,12 +340,12 @@ type redirectAPIAdmin struct {
 	r *redirectAPI
 }
 
-func (a *redirectAPIAdmin) Login(req params.LoginRequest) (params.LoginResultV1, error) {
+func (a *redirectAPIAdmin) Login(req params.LoginRequest) (params.LoginResult, error) {
 	if a.r.modelUUID != "beef1beef1-0000-0000-000011112222" {
-		return params.LoginResultV1{}, errors.New("logged into unexpected model")
+		return params.LoginResult{}, errors.New("logged into unexpected model")
 	}
 	a.r.redirected = true
-	return params.LoginResultV1{}, params.Error{
+	return params.LoginResult{}, params.Error{
 		Message: "redirect",
 		Code:    params.CodeRedirect,
 	}

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -42,8 +42,9 @@ var RestoreInProgressError = errors.New("restore in progress")
 var MaintenanceNoLoginError = errors.New("login failed - maintenance in progress")
 var errAlreadyLoggedIn = errors.New("already logged in")
 
-func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.LoginResultV1, error) {
-	var fail params.LoginResultV1
+// login is the internal version of the Login API call.
+func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginResult, error) {
+	var fail params.LoginResult
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -94,7 +95,7 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 	entity, lastConnection, err := doCheckCreds(a.root.state, req, isUser, a.srv.authCtxt)
 	if err != nil {
 		if err, ok := errors.Cause(err).(*common.DischargeRequiredError); ok {
-			loginResult := params.LoginResultV1{
+			loginResult := params.LoginResult{
 				DischargeRequired:       err.Macaroon,
 				DischargeRequiredReason: err.Error(),
 			}
@@ -208,7 +209,7 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 		apiRoot = restrictAll(apiRoot, errors.New("migration in progress, model is importing"))
 	}
 
-	loginResult := params.LoginResultV1{
+	loginResult := params.LoginResult{
 		Servers:       params.FromNetworkHostsPorts(hostPorts),
 		ControllerTag: model.ControllerTag().String(),
 		UserInfo:      maybeUserInfo,

--- a/apiserver/adminv3.go
+++ b/apiserver/adminv3.go
@@ -37,8 +37,8 @@ func (r *adminAPIV3) Admin(id string) (*adminAPIV3, error) {
 
 // Login logs in with the provided credentials.  All subsequent requests on the
 // connection will act as the authenticated user.
-func (a *adminAPIV3) Login(req params.LoginRequest) (params.LoginResultV1, error) {
-	return a.doLogin(req, 3)
+func (a *adminAPIV3) Login(req params.LoginRequest) (params.LoginResult, error) {
+	return a.login(req, 3)
 }
 
 // RedirectInfo returns redirected host information for the model.

--- a/apiserver/adminv3_test.go
+++ b/apiserver/adminv3_test.go
@@ -91,7 +91,13 @@ func (s *loginV3Suite) TestClientLoginToRootOldClient(c *gc.C) {
 	defer cleanup()
 
 	info := s.APIInfo(c)
+	info.Tag = nil
+	info.Password = ""
 	info.ModelTag = names.ModelTag{}
-	_, err := api.OpenWithVersion(info, api.DialOpts{}, 2)
+	info.SkipLogin = true
+	apiState, err := api.Open(info, api.DialOpts{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = apiState.APICall("Admin", 2, "", "Login", struct{}{}, nil)
 	c.Assert(err, gc.ErrorMatches, ".*this version of Juju does not support login from old clients.*")
 }

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -590,14 +590,6 @@ type FacadeVersions struct {
 	Versions []int  `json:"versions"`
 }
 
-// LoginResult holds the result of a Login call.
-type LoginResult struct {
-	Servers        [][]HostPort     `json:"servers"`
-	ModelTag       string           `json:"model-tag"`
-	LastConnection *time.Time       `json:"last-connection"`
-	Facades        []FacadeVersions `json:"facades"`
-}
-
 // RedirectInfoResult holds the result of a RedirectInfo call.
 type RedirectInfoResult struct {
 	// Servers holds an entry for each server that holds the
@@ -632,8 +624,8 @@ type AuthUserInfo struct {
 	ReadOnly bool `json:"read-only"`
 }
 
-// LoginResultV1 holds the result of an Admin v1 Login call.
-type LoginResultV1 struct {
+// LoginResult holds the result of an Admin Login call.
+type LoginResult struct {
 	// DischargeRequired implies that the login request has failed, and none of
 	// the other fields are populated. It contains a macaroon which, when
 	// discharged, will grant access on a subsequent call to Login.

--- a/apiserver/testing/fakeapi_test.go
+++ b/apiserver/testing/fakeapi_test.go
@@ -50,9 +50,9 @@ func (r *root) Admin(id string) (facade, error) {
 	return facade{r}, nil
 }
 
-func (f facade) Login(req params.LoginRequest) (params.LoginResultV1, error) {
+func (f facade) Login(req params.LoginRequest) (params.LoginResult, error) {
 	f.r.calledMethods = append(f.r.calledMethods, "Login")
-	return params.LoginResultV1{
+	return params.LoginResult{
 		ModelTag:      names.NewModelTag(fakeUUID).String(),
 		ControllerTag: names.NewModelTag(fakeUUID).String(),
 		UserInfo: &params.AuthUserInfo{

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/juju/api"
 	apiagent "github.com/juju/juju/api/agent"
 	"github.com/juju/juju/api/base"
 	apimachiner "github.com/juju/juju/api/machiner"
@@ -39,7 +40,6 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/tools"
-	"github.com/juju/juju/api"
 	apideployer "github.com/juju/juju/api/deployer"
 	"github.com/juju/juju/api/metricsmanager"
 	apiprovisioner "github.com/juju/juju/api/provisioner"
@@ -494,7 +494,7 @@ func (a *MachineAgent) executeRebootOrShutdown(action params.RebootAction) error
 	// We need to reopen the API to clear the reboot flag after
 	// scheduling the reboot. It may be cleaner to do this in the reboot
 	// worker, before returning the ErrRebootMachine.
-	conn, err := apicaller.OnlyConnect(a, apicaller.APIOpen)
+	conn, err := apicaller.OnlyConnect(a, api.Open)
 	if err != nil {
 		logger.Infof("Reboot: Error connecting to state")
 		return errors.Trace(err)

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -219,7 +219,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		apiCallerName: apicaller.Manifold(apicaller.ManifoldConfig{
 			AgentName:            agentName,
 			APIConfigWatcherName: apiConfigWatcherName,
-			APIOpen:              apicaller.APIOpen,
+			APIOpen:              api.Open,
 			NewConnection:        apicaller.ScaryConnect,
 			Filter:               connectFilter,
 		}),
@@ -298,7 +298,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:         agentName,
 			APICallerName:     apiCallerName,
 			FortressName:      migrationFortressName,
-			APIOpen:           apicaller.APIOpen,
+			APIOpen:           api.Open,
 			ValidateMigration: config.ValidateMigration,
 			NewFacade:         migrationminion.NewFacade,
 			NewWorker:         migrationminion.NewWorker,

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -6,6 +6,7 @@ package model
 import (
 	"time"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/utils/clock"
 	"github.com/juju/utils/voyeur"
 
@@ -114,7 +115,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		}),
 		apiCallerName: apicaller.Manifold(apicaller.ManifoldConfig{
 			AgentName:     agentName,
-			APIOpen:       apicaller.APIOpen,
+			APIOpen:       api.Open,
 			NewConnection: apicaller.OnlyConnect,
 			Filter:        apiConnectFilter,
 		}),

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/utils/voyeur"
 
 	coreagent "github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	msapi "github.com/juju/juju/api/meterstatus"
 	"github.com/juju/juju/cmd/jujud/agent/engine"
@@ -103,7 +104,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		apiCallerName: apicaller.Manifold(apicaller.ManifoldConfig{
 			AgentName:            agentName,
 			APIConfigWatcherName: apiConfigWatcherName,
-			APIOpen:              apicaller.APIOpen,
+			APIOpen:              api.Open,
 			NewConnection:        apicaller.ScaryConnect,
 			Filter:               connectFilter,
 		}),
@@ -147,7 +148,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:         agentName,
 			APICallerName:     apiCallerName,
 			FortressName:      migrationFortressName,
-			APIOpen:           apicaller.APIOpen,
+			APIOpen:           api.Open,
 			ValidateMigration: config.ValidateMigration,
 			NewFacade:         migrationminion.NewFacade,
 			NewWorker:         migrationminion.NewWorker,

--- a/worker/apicaller/connect.go
+++ b/worker/apicaller/connect.go
@@ -44,21 +44,6 @@ var (
 	ErrChangedPassword = errors.New("insecure password replaced; retry")
 )
 
-// APIOpen is an api.OpenFunc that wraps api.Open, and handles the edge
-// case where a model has jumping several versions and doesn't yet have
-// the model UUID cached in the agent config; in which case we fall back
-// to login version 1.
-//
-// You probably want to use this in ManifoldConfig; *we* probably want to
-// put this particular hack inside api.Open, but I seem to recall there
-// being some complication last time I thought that was a good idea.
-func APIOpen(info *api.Info, opts api.DialOpts) (api.Connection, error) {
-	if info.ModelTag.Id() == "" {
-		return api.OpenWithVersion(info, opts, 1)
-	}
-	return api.Open(info, opts)
-}
-
 // OnlyConnect logs into the API using the supplied agent's credentials.
 func OnlyConnect(a agent.Agent, apiOpen api.OpenFunc) (api.Connection, error) {
 	agentConfig := a.CurrentConfig()


### PR DESCRIPTION
And remove some other redundant code relating
to API compatibility too.

To QA, bootstrap a controller and check that you can log into it.

(Review request: http://reviews.vapour.ws/r/5439/)