### PR TITLE
Filter on host arch when looking for tools, if no arch is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,21 +118,6 @@ provider because it uses LXC, which requires root privileges)
     juju switch local
     sudo juju bootstrap
 
---upload-tools
---------------
-
-The `juju` client program, and the juju 'tools' are deployed in lockstep. When a
-release of `juju` is made, the compiled tools matching that version of juju
-are extracted and uploaded to a known location. This consumes a release version
-number, and implies that no tools are available for the next, development, version
-of juju. Therefore, when using the development version of juju you will need to
-pass an additional flag, `--upload-tools` to instruct the `juju` client to build
-a set of tools from source and upload them to the model as part of the
-bootstrap process.
-
-    juju bootstrap -m your-model --upload-tools {--debug}
-
-
 Installing bash completion for juju
 ===================================
 

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -48,12 +48,11 @@ func NewRestoreCommand() cmd.Command {
 // it is invoked with "juju restore-backup".
 type restoreCommand struct {
 	CommandBase
-	constraints           constraints.Value
-	filename              string
-	backupId              string
-	bootstrap             bool
-	buildAgent            bool
-	uploadToolsDeprecated bool
+	constraints constraints.Value
+	filename    string
+	backupId    string
+	bootstrap   bool
+	buildAgent  bool
 
 	newAPIClientFunc         func() (RestoreAPI, error)
 	newEnvironFunc           func(environs.OpenParams) (environs.Environ, error)
@@ -113,7 +112,6 @@ func (c *restoreCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.filename, "file", "", "Provide a file to be used as the backup.")
 	f.StringVar(&c.backupId, "id", "", "Provide the name of the backup to be restored")
 	f.BoolVar(&c.buildAgent, "build-agent", false, "Build binary agent if bootstraping a new machine")
-	f.BoolVar(&c.uploadToolsDeprecated, "upload-tools", false, "DEPRECATED: see build-agent")
 }
 
 // Init is where the preconditions for this commands can be checked.
@@ -126,11 +124,6 @@ func (c *restoreCommand) Init(args []string) error {
 	}
 	if c.backupId != "" && c.bootstrap {
 		return errors.Errorf("it is not possible to rebootstrap and restore from an id.")
-	}
-
-	// TODO(wallyworld) - remove me when CI scripts updated
-	if c.uploadToolsDeprecated {
-		c.buildAgent = c.uploadToolsDeprecated
 	}
 
 	var err error

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -126,7 +126,6 @@ type bootstrapCommand struct {
 	BootstrapSeries       string
 	BootstrapImage        string
 	BuildAgent            bool
-	UploadToolsDeprecated bool
 	MetadataSource        string
 	Placement             string
 	KeepBrokenEnvironment bool
@@ -168,7 +167,6 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 		f.StringVar(&c.BootstrapImage, "bootstrap-image", "", "Specify the image of the bootstrap machine")
 	}
 	f.BoolVar(&c.BuildAgent, "build-agent", false, "Build local version of agent binary before bootstrapping")
-	f.BoolVar(&c.UploadToolsDeprecated, "upload-tools", false, "DEPRECATED: see build-agent")
 	f.StringVar(&c.MetadataSource, "metadata-source", "", "Local path to use as tools and/or metadata source")
 	f.StringVar(&c.Placement, "to", "", "Placement directive indicating an instance to bootstrap")
 	f.BoolVar(&c.KeepBrokenEnvironment, "keep-broken", false, "Do not destroy the model if bootstrap fails")
@@ -198,10 +196,6 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 			}
 			// some other flag was set, which means non-interactive.
 		}
-	}
-	// TODO(wallyworld) - remove me when CI scripts updated
-	if c.UploadToolsDeprecated {
-		c.BuildAgent = c.UploadToolsDeprecated
 	}
 	if c.showClouds && c.showRegionsForCloud != "" {
 		return errors.New("--clouds and --regions can't be used together")
@@ -312,9 +306,6 @@ specify a credential using the --credential argument`[1:],
 // a juju in that environment if none already exists. If there is as yet no environments.yaml file,
 // the user is informed how to create one.
 func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
-	if c.UploadToolsDeprecated {
-		fmt.Fprintln(ctx.Stderr, "WARNING: --upload-tools is deprecated, please use --build-agent instead")
-	}
 	if c.interactive {
 		if err := c.runInteractive(ctx); err != nil {
 			return errors.Trace(err)

--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -70,13 +70,12 @@ func newUpgradeJujuCommand(minUpgradeVers map[int]version.Number, options ...mod
 // upgradeJujuCommand upgrades the agents in a juju installation.
 type upgradeJujuCommand struct {
 	modelcmd.ModelCommandBase
-	vers                  string
-	Version               version.Number
-	BuildAgent            bool
-	UploadToolsDeprecated bool
-	DryRun                bool
-	ResetPrevious         bool
-	AssumeYes             bool
+	vers          string
+	Version       version.Number
+	BuildAgent    bool
+	DryRun        bool
+	ResetPrevious bool
+	AssumeYes     bool
 
 	// minMajorUpgradeVersion maps known major numbers to
 	// the minimum version that can be upgraded to that
@@ -96,7 +95,6 @@ func (c *upgradeJujuCommand) Info() *cmd.Info {
 func (c *upgradeJujuCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.vers, "version", "", "Upgrade to specific version")
 	f.BoolVar(&c.BuildAgent, "build-agent", false, "Build a local version of the agent binary; for development use only")
-	f.BoolVar(&c.UploadToolsDeprecated, "upload-tools", false, "DEPRECATED: see build-agent")
 	f.BoolVar(&c.DryRun, "dry-run", false, "Don't change anything, just report what would be changed")
 	f.BoolVar(&c.ResetPrevious, "reset-previous-upgrade", false, "Clear the previous (incomplete) upgrade status (use with care)")
 	f.BoolVar(&c.AssumeYes, "y", false, "Answer 'yes' to confirmation prompts")
@@ -104,9 +102,6 @@ func (c *upgradeJujuCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *upgradeJujuCommand) Init(args []string) error {
-	if c.UploadToolsDeprecated {
-		c.BuildAgent = c.UploadToolsDeprecated
-	}
 	if c.vers != "" {
 		vers, err := version.Parse(c.vers)
 		if err != nil {

--- a/environs/tools/build.go
+++ b/environs/tools/build.go
@@ -208,13 +208,12 @@ func buildJujud(dir string) error {
 }
 
 func packageLocalTools(toolsDir string, buildAgent bool) error {
-	// TODO(wallyworld) - when upload-tools compatibility is removed, either build or copy, not both
-	//if !buildAgent {
-	if err := copyExistingJujud(toolsDir); err == nil {
+	if !buildAgent {
+		if err := copyExistingJujud(toolsDir); err != nil {
+			return errors.New("no prepackaged agent available and no jujud binary can be found")
+		}
 		return nil
 	}
-	logger.Warningf("no prepackaged agent available and no jujud binary found")
-
 	logger.Infof("Building agent binary to upload (%s)", jujuversion.Current.String())
 	if err := buildJujud(toolsDir); err != nil {
 		return errors.Annotate(err, "cannot build jujud agent binary from source")


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1613487

When bootstrapping, and no arch is specified, we were not filtering on arch when looking for tools. This allowed a list of tools to be returned (but than that match the necessary arch). This prevented a local binary from being uploaded, and on non amd64 architectures, bootstrap failed.

Also remove any last upload-tools compatibility.

And fix an issue with sync_test being flakey.

(Review request: http://reviews.vapour.ws/r/5442/)