### PR TITLE
Show migration status in tabular output

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -122,10 +122,12 @@ func FormatTabular(value interface{}) ([]byte, error) {
 
 	header := []interface{}{"MODEL", "CONTROLLER", "CLOUD/REGION", "VERSION"}
 	values := []interface{}{fs.Model.Name, fs.Model.Controller, cloudRegion, fs.Model.Version}
-	if fs.Model.AvailableVersion != "" {
-		header = append(header, "UPGRADE-AVAILABLE")
-		values = append(values, fs.Model.AvailableVersion)
+	message := getModelMessage(fs.Model)
+	if message != "" {
+		header = append(header, "MESSAGE")
+		values = append(values, message)
 	}
+
 	// The first set of headers don't use outputHeaders because it adds the blank line.
 	p(header...)
 	p(values...)
@@ -238,6 +240,18 @@ func FormatTabular(value interface{}) ([]byte, error) {
 	printMachines(tw, fs.Machines)
 	tw.Flush()
 	return out.Bytes(), nil
+}
+
+func getModelMessage(model modelStatus) string {
+	// Select the most important message about the model (if any).
+	switch {
+	case model.Migration != "":
+		return "migrating: " + model.Migration
+	case model.AvailableVersion != "":
+		return "upgrade available: " + model.AvailableVersion
+	default:
+		return ""
+	}
 }
 
 func printMachines(tw *tabwriter.Writer, machines map[string]machineStatus) {

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -40,37 +40,45 @@ type statusCommand struct {
 }
 
 var usageSummary = `
-Displays the current status of Juju, applications, and units.`[1:]
+Reports the current status of the model, machines, applications and units.`[1:]
 
 var usageDetails = `
-By default (without argument), the status of Juju and all applications and all
-units will be displayed. 
-Application or unit names may be used as output filters (the '*' can be used
-as a wildcard character).  
-In addition to matched applications and units, related machines, applications, and
-units will also be displayed. If a subordinate unit is matched, then its
-principal unit will be displayed. If a principal unit is matched, then all
-of its subordinates will be displayed. 
-Explanation of the different formats:
-- {short|line|oneline}: List units and their subordinates. For each
-           unit, the IP address and agent status are listed.
-- summary: Displays the subnet(s) and port(s) the model utilises.
-           Also displays aggregate information about:
-           - MACHINES: total #, and # in each state.
-           - UNITS: total #, and # in each state.
-           - APPLICATIONS: total #, and # exposed of each application.
-- tabular (default): Displays information in a tabular format in these sections:
-           - Machines: ID, STATE, DNS, INS-ID, SERIES, AZ
-           - Applications: NAME, EXPOSED, CHARM
-           - Units: ID, STATE, VERSION, MACHINE, PORTS, PUBLIC-ADDRESS
-             - Also displays subordinate units.
-- yaml: Displays information on machines, applications, and units in yaml format.
-Note: AZ above is the cloud region's availability zone.
+By default (without argument), the status of the model, including all
+applications and units will be output.
+
+Application or unit names may be used as output filters (the '*' can be used as
+a wildcard character). In addition to matched applications and units, related
+machines, applications, and units will also be displayed. If a subordinate unit
+is matched, then its principal unit will be displayed. If a principal unit is
+matched, then all of its subordinates will be displayed.
+
+The available output formats are:
+
+- tabular (default): Displays status in a tabular format with a separate table
+      for the model, machines, applications, relations (if any) and units.
+      Note: in this format, the AZ column refers to the cloud region's
+      availability zone.
+- {short|line|oneline}: List units and their subordinates. For each unit, the IP
+      address and agent status are listed.
+- summary: Displays the subnet(s) and port(s) the model utilises. Also displays
+      aggregate information about:
+      - MACHINES: total #, and # in each state.
+      - UNITS: total #, and # in each state.
+      - APPLICATIONS: total #, and # exposed of each application.
+- yaml: Displays information about the model, machines, applications, and units
+      in structured YAML format.
+- json: Displays information about the model, machines, applications, and units
+      in structured JSON format.
 
 Examples:
     juju status
     juju status mysql
     juju status nova-*
+
+See Also:
+    juju show-model
+    juju machines
+    juju storage
 `
 
 func (c *statusCommand) Info() *cmd.Info {


### PR DESCRIPTION
A new MESSAGE column has been introduced which will show migration status if there's a migration in progress, or the availability of an upgrade if available. This replaces the previous UPGRADE-AVAILABLE
column.

Also, cleaned up the help for the status command. Wrap lines correctly, tidy up formatting, covered missed areas, describe the json format and added See Also.

Also, cleaned up the migration status messages generated by the migrationmaster worker.

### QA

Bootstrapped controllers A and B. Created a model "foo" on controller A and deployed the "ubuntu" charm to it. Ran `watch -n0.3 juju status` and started the migration of foo to B, watching the migration status in the tabular format output.

(Review request: http://reviews.vapour.ws/r/5444/)