### PR TITLE
Rework model set/unset api to accommodate cloud/region

### DIFF
--- a/api/modelconfig/modelconfig.go
+++ b/api/modelconfig/modelconfig.go
@@ -5,6 +5,7 @@ package modelconfig
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
@@ -92,13 +93,43 @@ func (c *Client) ModelDefaults() (config.ConfigValues, error) {
 }
 
 // SetModelDefaults updates the specified default model config values.
-func (c *Client) SetModelDefaults(config map[string]interface{}) error {
-	args := params.ModelSet{Config: config}
-	return c.facade.FacadeCall("SetModelDefaults", args, nil)
+func (c *Client) SetModelDefaults(cloud, region string, config map[string]interface{}) error {
+	var cloudTag string
+	if cloud != "" {
+		cloudTag = names.NewCloudTag(cloud).String()
+	}
+	args := params.SetModelDefaults{
+		Config: []params.ModelDefaultValues{{
+			Config:      config,
+			CloudTag:    cloudTag,
+			CloudRegion: region,
+		}},
+	}
+	var result params.ErrorResults
+	err := c.facade.FacadeCall("SetModelDefaults", args, &result)
+	if err != nil {
+		return err
+	}
+	return result.OneError()
 }
 
 // UnsetModelDefaults removes the specified default model config values.
-func (c *Client) UnsetModelDefaults(keys ...string) error {
-	args := params.ModelUnset{Keys: keys}
-	return c.facade.FacadeCall("UnsetModelDefaults", args, nil)
+func (c *Client) UnsetModelDefaults(cloud, region string, keys ...string) error {
+	var cloudTag string
+	if cloud != "" {
+		cloudTag = names.NewCloudTag(cloud).String()
+	}
+	args := params.UnsetModelDefaults{
+		Keys: []params.ModelUnsetKeys{{
+			Keys:        keys,
+			CloudTag:    cloudTag,
+			CloudRegion: region,
+		}},
+	}
+	var result params.ErrorResults
+	err := c.facade.FacadeCall("UnsetModelDefaults", args, &result)
+	if err != nil {
+		return err
+	}
+	return result.OneError()
 }

--- a/api/modelconfig/modelconfig_test.go
+++ b/api/modelconfig/modelconfig_test.go
@@ -166,18 +166,25 @@ func (s *modelconfigSuite) TestSetModelDefaults(c *gc.C) {
 			c.Check(objType, gc.Equals, "ModelConfig")
 			c.Check(id, gc.Equals, "")
 			c.Check(request, gc.Equals, "SetModelDefaults")
-			c.Check(a, jc.DeepEquals, params.ModelSet{
-				Config: map[string]interface{}{
-					"some-name":  "value",
-					"other-name": true,
-				},
-			})
+			c.Check(a, jc.DeepEquals, params.SetModelDefaults{
+				Config: []params.ModelDefaultValues{{
+					CloudTag:    "cloud-mycloud",
+					CloudRegion: "region",
+					Config: map[string]interface{}{
+						"some-name":  "value",
+						"other-name": true,
+					},
+				}}})
+			c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+			*(result.(*params.ErrorResults)) = params.ErrorResults{
+				Results: []params.ErrorResult{{Error: nil}},
+			}
 			called = true
 			return nil
 		},
 	)
 	client := modelconfig.NewClient(apiCaller)
-	err := client.SetModelDefaults(map[string]interface{}{
+	err := client.SetModelDefaults("mycloud", "region", map[string]interface{}{
 		"some-name":  "value",
 		"other-name": true,
 	})
@@ -196,15 +203,22 @@ func (s *modelconfigSuite) TestUnsetModelDefaults(c *gc.C) {
 			c.Check(objType, gc.Equals, "ModelConfig")
 			c.Check(id, gc.Equals, "")
 			c.Check(request, gc.Equals, "UnsetModelDefaults")
-			c.Check(a, jc.DeepEquals, params.ModelUnset{
-				Keys: []string{"foo", "bar"},
-			})
+			c.Check(a, jc.DeepEquals, params.UnsetModelDefaults{
+				Keys: []params.ModelUnsetKeys{{
+					CloudTag:    "cloud-mycloud",
+					CloudRegion: "region",
+					Keys:        []string{"foo", "bar"},
+				}}})
+			c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+			*(result.(*params.ErrorResults)) = params.ErrorResults{
+				Results: []params.ErrorResult{{Error: nil}},
+			}
 			called = true
 			return nil
 		},
 	)
 	client := modelconfig.NewClient(apiCaller)
-	err := client.UnsetModelDefaults("foo", "bar")
+	err := client.UnsetModelDefaults("mycloud", "region", "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 }

--- a/apiserver/modelconfig/modelconfig_test.go
+++ b/apiserver/modelconfig/modelconfig_test.go
@@ -167,13 +167,15 @@ func (s *modelconfigSuite) TestModelDefaults(c *gc.C) {
 }
 
 func (s *modelconfigSuite) TestSetModelDefaults(c *gc.C) {
-	params := params.ModelSet{
-		Config: map[string]interface{}{
-			"attr3": "val3",
-			"attr4": "val4"},
-	}
-	err := s.api.SetModelDefaults(params)
+	params := params.SetModelDefaults{
+		Config: []params.ModelDefaultValues{{
+			Config: map[string]interface{}{
+				"attr3": "val3",
+				"attr4": "val4"},
+		}}}
+	result, err := s.api.SetModelDefaults(params)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.OneError(), jc.ErrorIsNil)
 	c.Assert(s.backend.cfgDefaults, jc.DeepEquals, config.ConfigValues{
 		"attr":  {Value: "val", Source: "controller"},
 		"attr2": {Value: "val2", Source: "controller"},
@@ -184,14 +186,18 @@ func (s *modelconfigSuite) TestSetModelDefaults(c *gc.C) {
 
 func (s *modelconfigSuite) TestBlockChangesSetModelDefaults(c *gc.C) {
 	s.blockAllChanges(c, "TestBlockChangesSetModelDefaults")
-	err := s.api.SetModelDefaults(params.ModelSet{})
+	_, err := s.api.SetModelDefaults(params.SetModelDefaults{})
 	s.assertBlocked(c, err, "TestBlockChangesSetModelDefaults")
 }
 
 func (s *modelconfigSuite) TestUnsetModelDefaults(c *gc.C) {
-	args := params.ModelUnset{[]string{"attr"}}
-	err := s.api.UnsetModelDefaults(args)
+	args := params.UnsetModelDefaults{
+		Keys: []params.ModelUnsetKeys{{
+			Keys: []string{"attr"},
+		}}}
+	result, err := s.api.UnsetModelDefaults(args)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.OneError(), jc.ErrorIsNil)
 	c.Assert(s.backend.cfgDefaults, jc.DeepEquals, config.ConfigValues{
 		"attr2": {Value: "val2", Source: "controller"},
 	})
@@ -199,16 +205,23 @@ func (s *modelconfigSuite) TestUnsetModelDefaults(c *gc.C) {
 
 func (s *modelconfigSuite) TestBlockUnsetModelDefaults(c *gc.C) {
 	s.blockAllChanges(c, "TestBlockUnsetModelDefaults")
-	args := params.ModelUnset{[]string{"abc"}}
-	err := s.api.UnsetModelDefaults(args)
+	args := params.UnsetModelDefaults{
+		Keys: []params.ModelUnsetKeys{{
+			Keys: []string{"abc"},
+		}}}
+	_, err := s.api.UnsetModelDefaults(args)
 	s.assertBlocked(c, err, "TestBlockUnsetModelDefaults")
 }
 
 func (s *modelconfigSuite) TestUnsetModelDefaultsMissing(c *gc.C) {
 	// It's okay to unset a non-existent attribute.
-	args := params.ModelUnset{[]string{"not_there"}}
-	err := s.api.UnsetModelDefaults(args)
+	args := params.UnsetModelDefaults{
+		Keys: []params.ModelUnsetKeys{{
+			Keys: []string{"not there"},
+		}}}
+	result, err := s.api.UnsetModelDefaults(args)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.OneError(), jc.ErrorIsNil)
 }
 
 type mockBackend struct {

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -34,6 +34,34 @@ type ModelUnset struct {
 	Keys []string `json:"keys"`
 }
 
+// SetModelDefaults contains the arguments for SetModelDefaults
+// client API call.
+type SetModelDefaults struct {
+	Config []ModelDefaultValues `json:"config"`
+}
+
+// ModelDefaultValues contains the default model values for
+// a cloud/region.
+type ModelDefaultValues struct {
+	CloudTag    string                 `json:"cloud-tag,omitempty"`
+	CloudRegion string                 `json:"cloud-region,omitempty"`
+	Config      map[string]interface{} `json:"config"`
+}
+
+// ModelUnsetKeys contains the config keys to unset for
+// a cloud/region.
+type ModelUnsetKeys struct {
+	CloudTag    string   `json:"cloud-tag,omitempty"`
+	CloudRegion string   `json:"cloud-region,omitempty"`
+	Keys        []string `json:"keys"`
+}
+
+// UnsetModelDefaults contains the arguments for UnsetModelDefaults
+// client API call.
+type UnsetModelDefaults struct {
+	Keys []ModelUnsetKeys `json:"keys"`
+}
+
 // SetModelAgentVersion contains the arguments for
 // SetModelAgentVersion client API call.
 type SetModelAgentVersion struct {

--- a/cmd/juju/model/fakeenv_test.go
+++ b/cmd/juju/model/fakeenv_test.go
@@ -31,10 +31,11 @@ func (s *fakeEnvSuite) SetUpTest(c *gc.C) {
 }
 
 type fakeEnvAPI struct {
-	values   map[string]interface{}
-	defaults config.ConfigValues
-	err      error
-	keys     []string
+	values        map[string]interface{}
+	cloud, region string
+	defaults      config.ConfigValues
+	err           error
+	keys          []string
 }
 
 func (f *fakeEnvAPI) Close() error {
@@ -57,20 +58,24 @@ func (f *fakeEnvAPI) ModelDefaults() (config.ConfigValues, error) {
 	return f.defaults, nil
 }
 
-func (f *fakeEnvAPI) SetModelDefaults(cfg map[string]interface{}) error {
+func (f *fakeEnvAPI) SetModelDefaults(cloud, region string, cfg map[string]interface{}) error {
 	if f.err != nil {
 		return f.err
 	}
+	f.cloud = cloud
+	f.region = region
 	for name, val := range cfg {
 		f.defaults[name] = config.ConfigValue{Value: val, Source: "controller"}
 	}
 	return nil
 }
 
-func (f *fakeEnvAPI) UnsetModelDefaults(keys ...string) error {
+func (f *fakeEnvAPI) UnsetModelDefaults(cloud, region string, keys ...string) error {
 	if f.err != nil {
 		return f.err
 	}
+	f.cloud = cloud
+	f.region = region
 	for _, key := range keys {
 		delete(f.defaults, key)
 	}

--- a/cmd/juju/model/setdefaults.go
+++ b/cmd/juju/model/setdefaults.go
@@ -93,7 +93,7 @@ type setModelDefaultsAPI interface {
 
 	// SetModelDefaults sets the default config values to use
 	// when creating new models.
-	SetModelDefaults(config map[string]interface{}) error
+	SetModelDefaults(cloud, region string, config map[string]interface{}) error
 }
 
 func (c *setDefaultsCommand) Run(ctx *cmd.Context) error {
@@ -103,5 +103,6 @@ func (c *setDefaultsCommand) Run(ctx *cmd.Context) error {
 	}
 	defer client.Close()
 
-	return block.ProcessBlockedError(client.SetModelDefaults(c.values), block.BlockChange)
+	// TODO(wallyworld) - call with cloud and region when that bit is done
+	return block.ProcessBlockedError(client.SetModelDefaults("", "", c.values), block.BlockChange)
 }

--- a/cmd/juju/model/unsetdefaults.go
+++ b/cmd/juju/model/unsetdefaults.go
@@ -82,7 +82,7 @@ type unsetModelDefaultsAPI interface {
 
 	// UnsetModelDefaults clears the default model
 	// configuration values.
-	UnsetModelDefaults(keys ...string) error
+	UnsetModelDefaults(cloud, region string, keys ...string) error
 }
 
 func (c *unsetDefaultsCommand) Run(ctx *cmd.Context) error {
@@ -92,5 +92,6 @@ func (c *unsetDefaultsCommand) Run(ctx *cmd.Context) error {
 	}
 	defer client.Close()
 
-	return block.ProcessBlockedError(client.UnsetModelDefaults(c.keys...), block.BlockChange)
+	// TODO(wallyworld) - call with cloud and region when that bit is done
+	return block.ProcessBlockedError(client.UnsetModelDefaults("", "", c.keys...), block.BlockChange)
 }


### PR DESCRIPTION
A largely mechanical change to add in cloud and region to the model set/unset default value api. The api is made bulk to allow the values for several cloud regions to be set/unset in the one call.

(Review request: http://reviews.vapour.ws/r/5445/)