### PR TITLE
Use CloudCredentialTag

### DIFF
--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -37,18 +37,24 @@ func (c *Client) Close() error {
 // CreateModel creates a new model using the model config,
 // cloud region and credential specified in the args.
 func (c *Client) CreateModel(
-	name, owner, cloudRegion, cloudCredential string, config map[string]interface{},
+	name, owner, cloudRegion string,
+	cloudCredential names.CloudCredentialTag,
+	config map[string]interface{},
 ) (params.ModelInfo, error) {
 	var result params.ModelInfo
 	if !names.IsValidUser(owner) {
 		return result, errors.Errorf("invalid owner name %q", owner)
 	}
+	var cloudCredentialTag string
+	if cloudCredential != (names.CloudCredentialTag{}) {
+		cloudCredentialTag = cloudCredential.String()
+	}
 	createArgs := params.ModelCreateArgs{
-		Name:            name,
-		OwnerTag:        names.NewUserTag(owner).String(),
-		Config:          config,
-		CloudRegion:     cloudRegion,
-		CloudCredential: cloudCredential,
+		Name:               name,
+		OwnerTag:           names.NewUserTag(owner).String(),
+		Config:             config,
+		CloudRegion:        cloudRegion,
+		CloudCredentialTag: cloudCredentialTag,
 	}
 	err := c.facade.FacadeCall("CreateModel", createArgs, &result)
 	if err != nil {

--- a/api/modelmanager/modelmanager_test.go
+++ b/api/modelmanager/modelmanager_test.go
@@ -34,7 +34,7 @@ func (s *modelmanagerSuite) OpenAPI(c *gc.C) *modelmanager.Client {
 func (s *modelmanagerSuite) TestCreateModelBadUser(c *gc.C) {
 	modelManager := s.OpenAPI(c)
 	defer modelManager.Close()
-	_, err := modelManager.CreateModel("mymodel", "not a user", "", "", nil)
+	_, err := modelManager.CreateModel("mymodel", "not a user", "", names.CloudCredentialTag{}, nil)
 	c.Assert(err, gc.ErrorMatches, `invalid owner name "not a user"`)
 }
 
@@ -43,7 +43,7 @@ func (s *modelmanagerSuite) TestCreateModel(c *gc.C) {
 	defer modelManager.Close()
 	user := s.Factory.MakeUser(c, nil)
 	owner := user.UserTag().Canonical()
-	newModel, err := modelManager.CreateModel("new-model", owner, "", "", map[string]interface{}{
+	newModel, err := modelManager.CreateModel("new-model", owner, "", names.CloudCredentialTag{}, map[string]interface{}{
 		"authorized-keys": "ssh-key",
 		// dummy needs controller
 		"controller": false,

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -435,15 +435,18 @@ func (c *Client) ModelInfo() (params.ModelInfo, error) {
 	}
 
 	info := params.ModelInfo{
-		DefaultSeries:   config.PreferredSeries(conf),
-		Cloud:           model.Cloud(),
-		CloudRegion:     model.CloudRegion(),
-		CloudCredential: model.CloudCredential(),
-		ProviderType:    conf.Type(),
-		Name:            conf.Name(),
-		UUID:            model.UUID(),
-		ControllerUUID:  model.ControllerUUID(),
+		DefaultSeries:  config.PreferredSeries(conf),
+		Cloud:          model.Cloud(),
+		CloudRegion:    model.CloudRegion(),
+		ProviderType:   conf.Type(),
+		Name:           conf.Name(),
+		UUID:           model.UUID(),
+		ControllerUUID: model.ControllerUUID(),
 	}
+	if tag, ok := model.CloudCredential(); ok {
+		info.CloudCredentialTag = tag.String()
+	}
+
 	return info, nil
 }
 

--- a/apiserver/cloud/backend.go
+++ b/apiserver/cloud/backend.go
@@ -12,11 +12,11 @@ import (
 
 type Backend interface {
 	Cloud(cloudName string) (cloud.Cloud, error)
-	CloudCredentials(user names.UserTag, cloudName string) (map[string]cloud.Credential, error)
+	CloudCredentials(user names.UserTag, cloudName string) (map[names.CloudCredentialTag]cloud.Credential, error)
 	ControllerModel() (Model, error)
 	ControllerTag() names.ControllerTag
 	ModelTag() names.ModelTag
-	UpdateCloudCredentials(user names.UserTag, cloudName string, credentials map[string]cloud.Credential) error
+	UpdateCloudCredential(names.CloudCredentialTag, cloud.Credential) error
 
 	IsControllerAdmin(names.UserTag) (bool, error)
 
@@ -41,6 +41,6 @@ func (s stateShim) ControllerModel() (Model, error) {
 
 type Model interface {
 	Cloud() string
-	CloudCredential() string
+	CloudCredential() (names.CloudCredentialTag, bool)
 	CloudRegion() string
 }

--- a/apiserver/cloud/cloud_test.go
+++ b/apiserver/cloud/cloud_test.go
@@ -35,9 +35,9 @@ func (s *cloudSuite) SetUpTest(c *gc.C) {
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
 			Regions:   []cloud.Region{{Name: "nether", Endpoint: "endpoint"}},
 		},
-		creds: map[string]cloud.Credential{
-			"one": cloud.NewEmptyCredential(),
-			"two": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+		creds: map[names.CloudCredentialTag]cloud.Credential{
+			names.NewCloudCredentialTag("meep/bruce@local/one"): cloud.NewEmptyCredential(),
+			names.NewCloudCredentialTag("meep/bruce@local/two"): cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
 				"username": "admin",
 				"password": "adm1n",
 			}),
@@ -101,17 +101,9 @@ func (s *cloudSuite) TestCredentials(c *gc.C) {
 		Message: "permission denied", Code: params.CodeUnauthorized,
 	})
 	c.Assert(results.Results[2].Error, gc.IsNil)
-	c.Assert(results.Results[2].Credentials, jc.DeepEquals, map[string]params.CloudCredential{
-		"one": {
-			AuthType: "empty",
-		},
-		"two": {
-			AuthType: "userpass",
-			Attributes: map[string]string{
-				"username": "admin",
-				"password": "adm1n",
-			},
-		},
+	c.Assert(results.Results[2].Result, jc.SameContents, []string{
+		"cloudcred-meep_bruce@local_one",
+		"cloudcred-meep_bruce@local_two",
 	})
 }
 
@@ -130,34 +122,22 @@ func (s *cloudSuite) TestCredentialsAdminAccess(c *gc.C) {
 
 func (s *cloudSuite) TestUpdateCredentials(c *gc.C) {
 	s.authorizer.Tag = names.NewUserTag("bruce@local")
-	results, err := s.api.UpdateCredentials(params.UsersCloudCredentials{[]params.UserCloudCredentials{{
-		UserTag:  "machine-0",
-		CloudTag: "cloud-meep",
+	results, err := s.api.UpdateCredentials(params.UpdateCloudCredentials{[]params.UpdateCloudCredential{{
+		Tag: "machine-0",
 	}, {
-		UserTag:  "user-admin",
-		CloudTag: "cloud-meep",
+		Tag: "cloudcred-meep_admin_whatever",
 	}, {
-		UserTag:  "user-bruce",
-		CloudTag: "cloud-meep",
-		Credentials: map[string]params.CloudCredential{
-			"three": {
-				AuthType:   "oauth1",
-				Attributes: map[string]string{"token": "foo:bar:baz"},
-			},
-			"four": {
-				AuthType: "access-key",
-				Attributes: map[string]string{
-					"access-key": "foo",
-					"secret-key": "bar",
-				},
-			},
+		Tag: "cloudcred-meep_bruce_three",
+		Credential: params.CloudCredential{
+			AuthType:   "oauth1",
+			Attributes: map[string]string{"token": "foo:bar:baz"},
 		},
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
-	s.backend.CheckCallNames(c, "ControllerTag", "UpdateCloudCredentials")
+	s.backend.CheckCallNames(c, "ControllerTag", "UpdateCloudCredential")
 	c.Assert(results.Results, gc.HasLen, 3)
 	c.Assert(results.Results[0].Error, jc.DeepEquals, &params.Error{
-		Message: `"machine-0" is not a valid user tag`,
+		Message: `"machine-0" is not a valid cloudcred tag`,
 	})
 	c.Assert(results.Results[1].Error, jc.DeepEquals, &params.Error{
 		Message: "permission denied", Code: params.CodeUnauthorized,
@@ -165,36 +145,26 @@ func (s *cloudSuite) TestUpdateCredentials(c *gc.C) {
 	c.Assert(results.Results[2].Error, gc.IsNil)
 
 	s.backend.CheckCall(
-		c, 1, "UpdateCloudCredentials",
-		names.NewUserTag("bruce"),
-		"meep",
-		map[string]cloud.Credential{
-			"three": cloud.NewCredential(
-				cloud.OAuth1AuthType,
-				map[string]string{"token": "foo:bar:baz"},
-			),
-			"four": cloud.NewCredential(
-				cloud.AccessKeyAuthType,
-				map[string]string{"access-key": "foo", "secret-key": "bar"},
-			),
-		},
+		c, 1, "UpdateCloudCredential",
+		names.NewCloudCredentialTag("meep/bruce/three"),
+		cloud.NewCredential(
+			cloud.OAuth1AuthType,
+			map[string]string{"token": "foo:bar:baz"},
+		),
 	)
 }
 
 func (s *cloudSuite) TestUpdateCredentialsAdminAccess(c *gc.C) {
 	s.authorizer.Tag = names.NewUserTag("admin@local")
-	results, err := s.api.UpdateCredentials(params.UsersCloudCredentials{[]params.UserCloudCredentials{{
-		UserTag:  "user-julia",
-		CloudTag: "cloud-meep",
-		Credentials: map[string]params.CloudCredential{
-			"three": {
-				AuthType:   "oauth1",
-				Attributes: map[string]string{"token": "foo:bar:baz"},
-			},
+	results, err := s.api.UpdateCredentials(params.UpdateCloudCredentials{[]params.UpdateCloudCredential{{
+		Tag: "cloudcred-meep_julia_three",
+		Credential: params.CloudCredential{
+			AuthType:   "oauth1",
+			Attributes: map[string]string{"token": "foo:bar:baz"},
 		},
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
-	s.backend.CheckCallNames(c, "ControllerTag", "UpdateCloudCredentials")
+	s.backend.CheckCallNames(c, "ControllerTag", "UpdateCloudCredential")
 	c.Assert(results.Results, gc.HasLen, 1)
 	// admin can update others' credentials
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -203,7 +173,7 @@ func (s *cloudSuite) TestUpdateCredentialsAdminAccess(c *gc.C) {
 type mockBackend struct {
 	gitjujutesting.Stub
 	cloud cloud.Cloud
-	creds map[string]cloud.Credential
+	creds map[names.CloudCredentialTag]cloud.Credential
 }
 
 func (st *mockBackend) IsControllerAdmin(user names.UserTag) (bool, error) {
@@ -213,7 +183,8 @@ func (st *mockBackend) IsControllerAdmin(user names.UserTag) (bool, error) {
 
 func (st *mockBackend) ControllerModel() (cloudfacade.Model, error) {
 	st.MethodCall(st, "ControllerModel")
-	return &mockModel{"some-cloud", "some-region", "some-credential"}, st.NextErr()
+	credentialTag := names.NewCloudCredentialTag("some-cloud/admin@local/some-credential")
+	return &mockModel{"some-cloud", "some-region", credentialTag}, st.NextErr()
 }
 
 func (st *mockBackend) ControllerTag() names.ControllerTag {
@@ -231,13 +202,13 @@ func (st *mockBackend) Cloud(name string) (cloud.Cloud, error) {
 	return st.cloud, st.NextErr()
 }
 
-func (st *mockBackend) CloudCredentials(user names.UserTag, cloudName string) (map[string]cloud.Credential, error) {
+func (st *mockBackend) CloudCredentials(user names.UserTag, cloudName string) (map[names.CloudCredentialTag]cloud.Credential, error) {
 	st.MethodCall(st, "CloudCredentials", user, cloudName)
 	return st.creds, st.NextErr()
 }
 
-func (st *mockBackend) UpdateCloudCredentials(user names.UserTag, cloudName string, creds map[string]cloud.Credential) error {
-	st.MethodCall(st, "UpdateCloudCredentials", user, cloudName, creds)
+func (st *mockBackend) UpdateCloudCredential(tag names.CloudCredentialTag, cred cloud.Credential) error {
+	st.MethodCall(st, "UpdateCloudCredential", tag, cred)
 	return st.NextErr()
 }
 
@@ -247,9 +218,9 @@ func (st *mockBackend) Close() error {
 }
 
 type mockModel struct {
-	cloud           string
-	cloudRegion     string
-	cloudCredential string
+	cloud              string
+	cloudRegion        string
+	cloudCredentialTag names.CloudCredentialTag
 }
 
 func (m *mockModel) Cloud() string {
@@ -260,6 +231,6 @@ func (m *mockModel) CloudRegion() string {
 	return m.cloudRegion
 }
 
-func (m *mockModel) CloudCredential() string {
-	return m.cloudCredential
+func (m *mockModel) CloudCredential() (names.CloudCredentialTag, bool) {
+	return m.cloudCredentialTag, true
 }

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -62,7 +62,7 @@ type Model interface {
 	Owner() names.UserTag
 	Status() (status.StatusInfo, error)
 	Cloud() string
-	CloudCredential() string
+	CloudCredential() (names.CloudCredentialTag, bool)
 	CloudRegion() string
 	Users() ([]description.UserAccess, error)
 	Destroy() error

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -104,16 +104,16 @@ func (s *modelInfoSuite) setAPIUser(c *gc.C, user names.UserTag) {
 func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 	info := s.getModelInfo(c)
 	c.Assert(info, jc.DeepEquals, params.ModelInfo{
-		Name:            "testenv",
-		UUID:            s.st.model.cfg.UUID(),
-		ControllerUUID:  "deadbeef-0bad-400d-8000-4b1d0d06f00d",
-		OwnerTag:        "user-bob@local",
-		ProviderType:    "someprovider",
-		Cloud:           "some-cloud",
-		CloudRegion:     "some-region",
-		CloudCredential: "some-credential",
-		DefaultSeries:   series.LatestLts(),
-		Life:            params.Dying,
+		Name:               "testenv",
+		UUID:               s.st.model.cfg.UUID(),
+		ControllerUUID:     "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		OwnerTag:           "user-bob@local",
+		ProviderType:       "someprovider",
+		Cloud:              "some-cloud",
+		CloudRegion:        "some-region",
+		CloudCredentialTag: "cloudcred-some-cloud_bob@local_some-credential",
+		DefaultSeries:      series.LatestLts(),
+		Life:               params.Dying,
 		Status: params.EntityStatus{
 			Status: status.StatusDestroying,
 			Since:  &time.Time{},
@@ -239,7 +239,7 @@ type mockState struct {
 	model           *mockModel
 	controllerModel *mockModel
 	users           []description.UserAccess
-	creds           map[string]cloud.Credential
+	cred            cloud.Credential
 }
 
 type fakeModelDescription struct {
@@ -351,9 +351,9 @@ func (st *mockState) Cloud(name string) (cloud.Cloud, error) {
 	return st.cloud, st.NextErr()
 }
 
-func (st *mockState) CloudCredentials(user names.UserTag, cloudName string) (map[string]cloud.Credential, error) {
-	st.MethodCall(st, "CloudCredentials", user, cloudName)
-	return st.creds, st.NextErr()
+func (st *mockState) CloudCredential(tag names.CloudCredentialTag) (cloud.Credential, error) {
+	st.MethodCall(st, "CloudCredential", tag)
+	return st.cred, st.NextErr()
 }
 
 func (st *mockState) Close() error {
@@ -446,10 +446,10 @@ func (m *mockModel) CloudRegion() string {
 	return "some-region"
 }
 
-func (m *mockModel) CloudCredential() string {
+func (m *mockModel) CloudCredential() (names.CloudCredentialTag, bool) {
 	m.MethodCall(m, "CloudCredential")
 	m.PopNoErr()
-	return "some-credential"
+	return names.NewCloudCredentialTag("some-cloud/bob@local/some-credential"), true
 }
 
 func (m *mockModel) Users() ([]description.UserAccess, error) {

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -38,18 +38,6 @@ type CloudCredential struct {
 	Attributes map[string]string `json:"attrs,omitempty"`
 }
 
-// CloudCredentialsResult contains a set of credentials for a user and cloud,
-// or an error.
-type CloudCredentialsResult struct {
-	Error       *Error                     `json:"error,omitempty"`
-	Credentials map[string]CloudCredential `json:"credentials,omitempty"`
-}
-
-// CloudCredentialsResults contains a set of CloudCredentialsResults.
-type CloudCredentialsResults struct {
-	Results []CloudCredentialsResult `json:"results,omitempty"`
-}
-
 // UserCloud contains a user/cloud tag pair, typically used for identifying
 // a user's credentials for a cloud.
 type UserCloud struct {
@@ -62,16 +50,16 @@ type UserClouds struct {
 	UserClouds []UserCloud `json:"user-clouds,omitempty"`
 }
 
-// UserCloudCredentials contains a user's credentials for a cloud.
-type UserCloudCredentials struct {
-	UserTag     string                     `json:"user-tag"`
-	CloudTag    string                     `json:"cloud-tag"`
-	Credentials map[string]CloudCredential `json:"credentials"`
+// UpdateCloudCredentials contains a set of tagged cloud credentials.
+type UpdateCloudCredentials struct {
+	Credentials []UpdateCloudCredential `json:"credentials,omitempty"`
 }
 
-// UsersCloudCredentials contains a set of UserCloudCredentials.
-type UsersCloudCredentials struct {
-	Users []UserCloudCredentials `json:"users"`
+// UpdateCloudCredential contains a cloud credential and its tag,
+// for updating in state.
+type UpdateCloudCredential struct {
+	Tag        string          `json:"tag"`
+	Credential CloudCredential `json:"credential"`
 }
 
 // CloudSpec holds a cloud specification.

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -117,12 +117,12 @@ type ModelCreateArgs struct {
 	// the same region as the controller model.
 	CloudRegion string `json:"region,omitempty"`
 
-	// CloudCredential is the name of the cloud credential to use
+	// CloudCredentialTag is the tag of the cloud credential to use
 	// for managing the model's resources. If the cloud does not
 	// require credentials, this may be empty. If this is empty,
 	// and the owner is the controller owner, the same credential
 	// used for the controller model will be used.
-	CloudCredential string `json:"credential,omitempty"`
+	CloudCredentialTag string `json:"credential,omitempty"`
 }
 
 // Model holds the result of an API call returning a name and UUID

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -73,14 +73,14 @@ type ModelInfo struct {
 	// The json names for the fields below are as per the older
 	// field names for backward compatibility. New fields are
 	// camel-cased for consistency within this type only.
-	Name            string `json:"name"`
-	UUID            string `json:"uuid"`
-	ControllerUUID  string `json:"controller-uuid"`
-	ProviderType    string `json:"provider-type"`
-	DefaultSeries   string `json:"default-series"`
-	Cloud           string `json:"cloud"`
-	CloudRegion     string `json:"cloud-region,omitempty"`
-	CloudCredential string `json:"cloud-credential,omitempty"`
+	Name               string `json:"name"`
+	UUID               string `json:"uuid"`
+	ControllerUUID     string `json:"controller-uuid"`
+	ProviderType       string `json:"provider-type"`
+	DefaultSeries      string `json:"default-series"`
+	Cloud              string `json:"cloud"`
+	CloudRegion        string `json:"cloud-region,omitempty"`
+	CloudCredentialTag string `json:"cloud-credential-tag,omitempty"`
 
 	// OwnerTag is the tag of the user that owns the model.
 	OwnerTag string `json:"owner-tag"`

--- a/cmd/juju/common/cloudcredential.go
+++ b/cmd/juju/common/cloudcredential.go
@@ -1,0 +1,27 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+
+	"gopkg.in/juju/names.v2"
+)
+
+// ResolveCloudCredentialTag takes a string which is of either the format
+// "<credential>" or "<user>/<credential>". If the string does not include
+// a user, then the supplied user tag is implied.
+func ResolveCloudCredentialTag(user names.UserTag, cloud names.CloudTag, credentialName string) (names.CloudCredentialTag, error) {
+	if i := strings.IndexRune(credentialName, '/'); i == -1 {
+		credentialName = fmt.Sprintf("%s/%s", user.Id(), credentialName)
+	}
+	s := fmt.Sprintf("%s/%s", cloud.Id(), credentialName)
+	if !names.IsValidCloudCredential(s) {
+		return names.CloudCredentialTag{}, errors.NotValidf("cloud credential name %q", s)
+	}
+	return names.NewCloudCredentialTag(s), nil
+}

--- a/cmd/juju/common/cloudcredential_test.go
+++ b/cmd/juju/common/cloudcredential_test.go
@@ -1,0 +1,49 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/cmd/juju/common"
+)
+
+var _ = gc.Suite(&cloudCredentialSuite{})
+
+type cloudCredentialSuite struct {
+	testing.IsolationSuite
+}
+
+func (*cloudCredentialSuite) TestResolveCloudCredentialTag(c *gc.C) {
+	testResolveCloudCredentialTag(c,
+		names.NewUserTag("admin@local"),
+		names.NewCloudTag("aws"),
+		"foo",
+		"aws/admin@local/foo",
+	)
+}
+
+func (*cloudCredentialSuite) TestResolveCloudCredentialTagOtherUser(c *gc.C) {
+	testResolveCloudCredentialTag(c,
+		names.NewUserTag("admin@local"),
+		names.NewCloudTag("aws"),
+		"brenda@local/foo",
+		"aws/brenda@local/foo",
+	)
+}
+
+func testResolveCloudCredentialTag(
+	c *gc.C,
+	user names.UserTag,
+	cloud names.CloudTag,
+	credentialName string,
+	expect string,
+) {
+	tag, err := common.ResolveCloudCredentialTag(user, cloud, credentialName)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tag.Id(), gc.Equals, expect)
+}

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -305,7 +305,7 @@ func (s *addSuite) TestNoEnvCacheOtherUser(c *gc.C) {
 type fakeAddClient struct {
 	owner           string
 	cloudRegion     string
-	cloudCredential string
+	cloudCredential names.CloudCredentialTag
 	config          map[string]interface{}
 	err             error
 	model           params.ModelInfo
@@ -317,7 +317,7 @@ func (*fakeAddClient) Close() error {
 	return nil
 }
 
-func (f *fakeAddClient) CreateModel(name, owner, cloudRegion, cloudCredential string, config map[string]interface{}) (params.ModelInfo, error) {
+func (f *fakeAddClient) CreateModel(name, owner, cloudRegion string, cloudCredential names.CloudCredentialTag, config map[string]interface{}) (params.ModelInfo, error) {
 	if f.err != nil {
 		return params.ModelInfo{}, f.err
 	}
@@ -333,12 +333,12 @@ type fakeCloudAPI struct {
 	controller.CloudAPI
 }
 
-func (c *fakeCloudAPI) Credentials(names.UserTag, names.CloudTag) (map[string]cloud.Credential, error) {
-	return map[string]cloud.Credential{
-		"default": cloud.NewEmptyCredential(),
+func (c *fakeCloudAPI) Credentials(names.UserTag, names.CloudTag) ([]names.CloudCredentialTag, error) {
+	return []names.CloudCredentialTag{
+		names.NewCloudCredentialTag("cloud/admin@local/default"),
 	}, nil
 }
 
-func (c *fakeCloudAPI) UpdateCredentials(names.UserTag, names.CloudTag, map[string]cloud.Credential) error {
+func (c *fakeCloudAPI) UpdateCredential(names.CloudCredentialTag, cloud.Credential) error {
 	return nil
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -74,7 +74,7 @@ gopkg.in/juju/charmrepo.v2-unstable	git	73c1113f7ddee0306f4b3c19773d35a3f153c04a
 gopkg.in/juju/charmstore.v5-unstable	git	714c25cd43dbb8eb51f57a55d76d521fc2126455	2016-08-09T13:45:06Z
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/juju/jujusvg.v2	git	d82160011935ef79fc7aca84aba2c6f74700fe75	2016-06-09T10:52:15Z
-gopkg.in/juju/names.v2	git	3e0d33a444fec55aea7269b849eb22da41e73072	2016-07-18T22:31:20Z
+gopkg.in/juju/names.v2	git	fa4c1959bef64b8f18569dc83a85b25d15204503	2016-08-16T07:05:44Z
 gopkg.in/macaroon-bakery.v1	git	469b44e6f1f9479e115c8ae879ef80695be624d5	2016-06-22T12:14:21Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	29cc868a5ca65f401ff318143f9408d02f4799cc	2016-06-09T18:00:28Z

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -48,7 +48,7 @@ func (s *cmdControllerSuite) run(c *gc.C, args ...string) *cmd.Context {
 func (s *cmdControllerSuite) createModelAdminUser(c *gc.C, modelname string, isServer bool) params.ModelInfo {
 	modelManager := modelmanager.NewClient(s.OpenControllerAPI(c))
 	defer modelManager.Close()
-	model, err := modelManager.CreateModel(modelname, s.AdminUserTag(c).Id(), "", "", map[string]interface{}{
+	model, err := modelManager.CreateModel(modelname, s.AdminUserTag(c).Id(), "", names.CloudCredentialTag{}, map[string]interface{}{
 		"controller": isServer,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -59,7 +59,7 @@ func (s *cmdControllerSuite) createModelNormalUser(c *gc.C, modelname string, is
 	s.run(c, "add-user", "test")
 	modelManager := modelmanager.NewClient(s.OpenControllerAPI(c))
 	defer modelManager.Close()
-	_, err := modelManager.CreateModel(modelname, names.NewLocalUserTag("test").Id(), "", "", map[string]interface{}{
+	_, err := modelManager.CreateModel(modelname, names.NewLocalUserTag("test").Id(), "", names.CloudCredentialTag{}, map[string]interface{}{
 		"authorized-keys": "ssh-key",
 		"controller":      isServer,
 	})

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -724,10 +724,20 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 				return err
 			}
 
-			cloudCredentials := make(map[string]cloud.Credential)
-			if icfg.Bootstrap.ControllerCloudCredential != nil {
-				cloudCredentials[icfg.Bootstrap.ControllerCloudCredentialName] =
-					*icfg.Bootstrap.ControllerCloudCredential
+			adminUser := names.NewUserTag("admin@local")
+			var cloudCredentialTag names.CloudCredentialTag
+			if icfg.Bootstrap.ControllerCloudCredentialName != "" {
+				cloudCredentialTag = names.NewCloudCredentialTag(fmt.Sprintf(
+					"%s/%s/%s",
+					icfg.Bootstrap.ControllerCloudName,
+					adminUser.Canonical(),
+					icfg.Bootstrap.ControllerCloudCredentialName,
+				))
+			}
+
+			cloudCredentials := make(map[names.CloudCredentialTag]cloud.Credential)
+			if icfg.Bootstrap.ControllerCloudCredential != nil && icfg.Bootstrap.ControllerCloudCredentialName != "" {
+				cloudCredentials[cloudCredentialTag] = *icfg.Bootstrap.ControllerCloudCredential
 			}
 
 			info := stateInfo()
@@ -738,12 +748,12 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 			st, err := state.Initialize(state.InitializeParams{
 				ControllerConfig: icfg.Controller.Config,
 				ControllerModelArgs: state.ModelArgs{
-					Owner:                   names.NewUserTag("admin@local"),
+					Owner:                   adminUser,
 					Config:                  icfg.Bootstrap.ControllerModelConfig,
 					Constraints:             icfg.Bootstrap.BootstrapMachineConstraints,
 					CloudName:               icfg.Bootstrap.ControllerCloudName,
 					CloudRegion:             icfg.Bootstrap.ControllerCloudRegion,
-					CloudCredential:         icfg.Bootstrap.ControllerCloudCredentialName,
+					CloudCredential:         cloudCredentialTag,
 					StorageProviderRegistry: e,
 				},
 				Cloud:            icfg.Bootstrap.ControllerCloud,

--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/set"
 	"gopkg.in/juju/names.v2"
+	mgo "gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
@@ -25,20 +26,45 @@ type cloudCredentialDoc struct {
 	Attributes map[string]string `bson:"attributes,omitempty"`
 }
 
-// CloudCredentials returns the user's cloud credentials for a given cloud,
-// keyed by credential name.
-func (st *State) CloudCredentials(user names.UserTag, cloudName string) (map[string]cloud.Credential, error) {
+// CloudCredential returns the cloud credential for the given tag.
+func (st *State) CloudCredential(tag names.CloudCredentialTag) (cloud.Credential, error) {
 	coll, cleanup := st.getCollection(cloudCredentialsC)
 	defer cleanup()
 
 	var doc cloudCredentialDoc
-	credentials := make(map[string]cloud.Credential)
+	err := coll.FindId(cloudCredentialDocID(tag)).One(&doc)
+	if err == mgo.ErrNotFound {
+		return cloud.Credential{}, errors.NotFoundf(
+			"cloud credential %q", tag.Id(),
+		)
+	} else if err != nil {
+		return cloud.Credential{}, errors.Annotatef(
+			err, "getting cloud credential %q", tag.Id(),
+		)
+	}
+	return doc.toCredential(), nil
+}
+
+// CloudCredentials returns the user's cloud credentials for a given cloud,
+// keyed by credential name.
+func (st *State) CloudCredentials(user names.UserTag, cloudName string) (
+	map[names.CloudCredentialTag]cloud.Credential, error,
+) {
+	coll, cleanup := st.getCollection(cloudCredentialsC)
+	defer cleanup()
+
+	var doc cloudCredentialDoc
+	credentials := make(map[names.CloudCredentialTag]cloud.Credential)
 	iter := coll.Find(bson.D{
 		{"owner", user.Canonical()},
 		{"cloud", cloudName},
 	}).Iter()
 	for iter.Next(&doc) {
-		credentials[doc.Name] = doc.toCredential()
+		tag, err := doc.cloudCredentialTag()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		credentials[tag] = doc.toCredential()
 	}
 	if err := iter.Err(); err != nil {
 		return nil, errors.Annotatef(
@@ -49,11 +75,11 @@ func (st *State) CloudCredentials(user names.UserTag, cloudName string) (map[str
 	return credentials, nil
 }
 
-// UpdateCloudCredentials updates the user's cloud credentials. Any existing
-// credentials with the same names will be replaced, and any other credentials
-// not in the updated set will be untouched.
-func (st *State) UpdateCloudCredentials(user names.UserTag, cloudName string, credentials map[string]cloud.Credential) error {
+// UpdateCloudCredential adds or updates a cloud credential with the given tag.
+func (st *State) UpdateCloudCredential(tag names.CloudCredentialTag, credential cloud.Credential) error {
+	credentials := map[names.CloudCredentialTag]cloud.Credential{tag: credential}
 	buildTxn := func(attempt int) ([]txn.Op, error) {
+		cloudName := tag.Cloud().Id()
 		cloud, err := st.Cloud(cloudName)
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -62,39 +88,34 @@ func (st *State) UpdateCloudCredentials(user names.UserTag, cloudName string, cr
 		if err != nil {
 			return nil, errors.Annotate(err, "validating cloud credentials")
 		}
-		existingCreds, err := st.CloudCredentials(user, cloudName)
+		existingCreds, err := st.CloudCredentials(tag.Owner(), cloudName)
 		if err != nil {
 			return nil, errors.Maskf(err, "fetching cloud credentials")
 		}
-		for credName, cred := range credentials {
-			if _, ok := existingCreds[credName]; ok {
-				ops = append(ops, updateCloudCredentialOp(user, cloudName, credName, cred))
-			} else {
-				ops = append(ops, createCloudCredentialOp(user, cloudName, credName, cred))
-			}
+		if _, ok := existingCreds[tag]; ok {
+			ops = append(ops, updateCloudCredentialOp(tag, credential))
+		} else {
+			ops = append(ops, createCloudCredentialOp(tag, credential))
 		}
 		return ops, nil
 	}
 	if err := st.run(buildTxn); err != nil {
-		return errors.Annotatef(
-			err, "updating cloud credentials for user %q, cloud %q",
-			user.String(), cloudName,
-		)
+		return errors.Annotate(err, "updating cloud credentials")
 	}
 	return nil
 }
 
 // createCloudCredentialOp returns a txn.Op that will create
 // a cloud credential.
-func createCloudCredentialOp(user names.UserTag, cloudName, credName string, cred cloud.Credential) txn.Op {
+func createCloudCredentialOp(tag names.CloudCredentialTag, cred cloud.Credential) txn.Op {
 	return txn.Op{
 		C:      cloudCredentialsC,
-		Id:     cloudCredentialDocID(user, cloudName, credName),
+		Id:     cloudCredentialDocID(tag),
 		Assert: txn.DocMissing,
 		Insert: &cloudCredentialDoc{
-			Owner:      user.Canonical(),
-			Cloud:      cloudName,
-			Name:       credName,
+			Owner:      tag.Owner().Canonical(),
+			Cloud:      tag.Cloud().Id(),
+			Name:       tag.Name(),
 			AuthType:   string(cred.AuthType()),
 			Attributes: cred.Attributes(),
 		},
@@ -103,10 +124,10 @@ func createCloudCredentialOp(user names.UserTag, cloudName, credName string, cre
 
 // updateCloudCredentialOp returns a txn.Op that will update
 // a cloud credential.
-func updateCloudCredentialOp(user names.UserTag, cloudName, credName string, cred cloud.Credential) txn.Op {
+func updateCloudCredentialOp(tag names.CloudCredentialTag, cred cloud.Credential) txn.Op {
 	return txn.Op{
 		C:      cloudCredentialsC,
-		Id:     cloudCredentialDocID(user, cloudName, credName),
+		Id:     cloudCredentialDocID(tag),
 		Assert: txn.DocExists,
 		Update: bson.D{{"$set", bson.D{
 			{"auth-type", string(cred.AuthType())},
@@ -115,8 +136,16 @@ func updateCloudCredentialOp(user names.UserTag, cloudName, credName string, cre
 	}
 }
 
-func cloudCredentialDocID(user names.UserTag, cloudName, credentialName string) string {
-	return fmt.Sprintf("%s#%s#%s", user.Canonical(), cloudName, credentialName)
+func cloudCredentialDocID(tag names.CloudCredentialTag) string {
+	return fmt.Sprintf("%s#%s#%s", tag.Cloud().Id(), tag.Owner().Canonical(), tag.Name())
+}
+
+func (c cloudCredentialDoc) cloudCredentialTag() (names.CloudCredentialTag, error) {
+	id := fmt.Sprintf("%s/%s/%s", c.Cloud, c.Owner, c.Name)
+	if !names.IsValidCloudCredential(id) {
+		return names.CloudCredentialTag{}, errors.NotValidf("cloud credential ID")
+	}
+	return names.NewCloudCredentialTag(id), nil
 }
 
 func (c cloudCredentialDoc) toCredential() cloud.Credential {
@@ -127,7 +156,8 @@ func (c cloudCredentialDoc) toCredential() cloud.Credential {
 
 // validateCloudCredentials checks that the supplied cloud credentials are
 // valid for use with the controller's cloud, and returns a set of txn.Ops
-// to assert the same in a transaction.
+// to assert the same in a transaction. The map keys are the cloud credential
+// IDs.
 //
 // TODO(rogpeppe) We're going to a lot of effort here to assert that a
 // cloud's auth types haven't changed since we looked at them a moment
@@ -136,9 +166,19 @@ func (c cloudCredentialDoc) toCredential() cloud.Credential {
 // cloud's auth type would invalidate all existing credentials and would
 // usually involve a new provider version and juju binary too, so
 // perhaps all this code is unnecessary.
-func validateCloudCredentials(cloud cloud.Cloud, cloudName string, credentials map[string]cloud.Credential) ([]txn.Op, error) {
+func validateCloudCredentials(
+	cloud cloud.Cloud,
+	cloudName string,
+	credentials map[names.CloudCredentialTag]cloud.Credential,
+) ([]txn.Op, error) {
 	requiredAuthTypes := make(set.Strings)
-	for name, credential := range credentials {
+	for tag, credential := range credentials {
+		if tag.Cloud().Id() != cloudName {
+			return nil, errors.NewNotValid(nil, fmt.Sprintf(
+				"credential %q for non-matching cloud is not valid (expected %q)",
+				tag.Id(), cloudName,
+			))
+		}
 		var found bool
 		for _, authType := range cloud.AuthTypes {
 			if credential.AuthType() == authType {
@@ -149,7 +189,7 @@ func validateCloudCredentials(cloud cloud.Cloud, cloudName string, credentials m
 		if !found {
 			return nil, errors.NewNotValid(nil, fmt.Sprintf(
 				"credential %q with auth-type %q is not supported (expected one of %q)",
-				name, credential.AuthType(), cloud.AuthTypes,
+				tag.Id(), credential.AuthType(), cloud.AuthTypes,
 			))
 		}
 		requiredAuthTypes.Add(string(credential.AuthType()))

--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -17,46 +17,28 @@ type CloudCredentialsSuite struct {
 
 var _ = gc.Suite(&CloudCredentialsSuite{})
 
-func (s *CloudCredentialsSuite) TestUpdateCloudCredentialsNew(c *gc.C) {
+func (s *CloudCredentialsSuite) TestUpdateCloudCredentialNew(c *gc.C) {
 	err := s.State.AddCloud("stratus", cloud.Cloud{
 		Type:      "low",
 		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	creds := map[string]cloud.Credential{
-		"cred1": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
-			"foo": "foo val",
-			"bar": "bar val",
-		}),
-		"cred2": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
-			"a": "a val",
-			"b": "b val",
-		}),
-		"cred3": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
-			"user":     "bob",
-			"password": "bob's password",
-		}),
-	}
-	addCredLabels(creds)
-
-	err = s.State.UpdateCloudCredentials(names.NewUserTag("bob"), "stratus", creds)
+	cred := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+		"foo": "foo val",
+		"bar": "bar val",
+	})
+	tag := names.NewCloudCredentialTag("stratus/bob@local/foobar")
+	err = s.State.UpdateCloudCredential(tag, cred)
 	c.Assert(err, jc.ErrorIsNil)
+
 	// The retrieved credentials have labels although cloud.NewCredential
-	// doesn't have them, so add them.
-	for name, cred := range creds {
-		cred.Label = name
-		creds[name] = cred
-	}
-	creds1, err := s.State.CloudCredentials(names.NewUserTag("bob"), "stratus")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(creds1, jc.DeepEquals, creds)
-}
+	// doesn't have them, so add it to the expected value.
+	cred.Label = "foobar"
 
-func (s *CloudCredentialsSuite) TestCloudCredentialsEmpty(c *gc.C) {
-	creds, err := s.State.CloudCredentials(names.NewUserTag("bob"), "dummy")
+	out, err := s.State.CloudCredential(tag)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(creds, gc.HasLen, 0)
+	c.Assert(out, jc.DeepEquals, cred)
 }
 
 func (s *CloudCredentialsSuite) TestUpdateCloudCredentialsExisting(c *gc.C) {
@@ -65,75 +47,82 @@ func (s *CloudCredentialsSuite) TestUpdateCloudCredentialsExisting(c *gc.C) {
 		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.UpdateCloudCredentials(names.NewUserTag("bob"), "stratus", map[string]cloud.Credential{
-		"cred1": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
-			"foo": "foo val",
-			"bar": "bar val",
-		}),
-		"cred2": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
-			"a": "a val",
-			"b": "b val",
-		}),
-		"cred3": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
-			"user":     "bob",
-			"password": "bob's password",
-		}),
+
+	cred := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+		"foo": "foo val",
+		"bar": "bar val",
 	})
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.UpdateCloudCredentials(names.NewUserTag("bob"), "stratus", map[string]cloud.Credential{
-		"cred1": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
-			"user":     "bob's nephew",
-			"password": "simple",
-		}),
-		"cred2": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
-			"b": "new b val",
-		}),
-		"cred4": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
-			"d": "d val",
-		}),
-	})
+	tag := names.NewCloudCredentialTag("stratus/bob@local/foobar")
+	err = s.State.UpdateCloudCredential(tag, cred)
 	c.Assert(err, jc.ErrorIsNil)
 
-	expect := map[string]cloud.Credential{
-		"cred1": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
-			"user":     "bob's nephew",
-			"password": "simple",
-		}),
-		"cred2": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
-			"b": "new b val",
-		}),
-		"cred3": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
-			"user":     "bob",
-			"password": "bob's password",
-		}),
-		"cred4": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
-			"d": "d val",
-		}),
-	}
-	addCredLabels(expect)
-
-	creds1, err := s.State.CloudCredentials(names.NewUserTag("bob"), "stratus")
+	cred = cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+		"user":     "bob's nephew",
+		"password": "simple",
+	})
+	err = s.State.UpdateCloudCredential(tag, cred)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(creds1, jc.DeepEquals, expect)
+
+	// The retrieved credentials have labels although cloud.NewCredential
+	// doesn't have them, so add it to the expected value.
+	cred.Label = "foobar"
+
+	out, err := s.State.CloudCredential(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out, jc.DeepEquals, cred)
 }
 
-func (s *CloudCredentialsSuite) TestUpdateCloudCredentialsInvalidAuthType(c *gc.C) {
+func (s *CloudCredentialsSuite) TestUpdateCloudCredentialInvalidAuthType(c *gc.C) {
 	err := s.State.AddCloud("stratus", cloud.Cloud{
 		Type:      "low",
 		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType},
 	})
-	err = s.State.UpdateCloudCredentials(names.NewUserTag("bob"), "stratus", map[string]cloud.Credential{
-		"cred1": cloud.NewCredential(cloud.UserPassAuthType, nil),
-	})
-	c.Assert(err, gc.ErrorMatches, `updating cloud credentials for user "user-bob", cloud "stratus": validating cloud credentials: credential "cred1" with auth-type "userpass" is not supported \(expected one of \["access-key"\]\)`)
+	tag := names.NewCloudCredentialTag("stratus/bob@local/foobar")
+	cred := cloud.NewCredential(cloud.UserPassAuthType, nil)
+	err = s.State.UpdateCloudCredential(tag, cred)
+	c.Assert(err, gc.ErrorMatches, `updating cloud credentials: validating cloud credentials: credential "stratus/bob@local/foobar" with auth-type "userpass" is not supported \(expected one of \["access-key"\]\)`)
 }
 
-// addCredLabels adds labels to all the given credentials, because
-// the labels are present when the credentials are returned from the
-// state but not when created with NewCredential.
-func addCredLabels(creds map[string]cloud.Credential) {
-	for name, cred := range creds {
-		cred.Label = name
-		creds[name] = cred
-	}
+func (s *CloudCredentialsSuite) TestCloudCredentialsEmpty(c *gc.C) {
+	creds, err := s.State.CloudCredentials(names.NewUserTag("bob"), "dummy")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(creds, gc.HasLen, 0)
+}
+
+func (s *CloudCredentialsSuite) TestCloudCredentials(c *gc.C) {
+	err := s.State.AddCloud("stratus", cloud.Cloud{
+		Type:      "low",
+		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	otherUser := s.Factory.MakeUser(c, nil).UserTag()
+
+	tag1 := names.NewCloudCredentialTag("stratus/bob@local/bobcred1")
+	cred1 := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+		"foo": "foo val",
+		"bar": "bar val",
+	})
+	err = s.State.UpdateCloudCredential(tag1, cred1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	tag2 := names.NewCloudCredentialTag("stratus/" + otherUser.Canonical() + "/foobar")
+	tag3 := names.NewCloudCredentialTag("stratus/bob@local/bobcred2")
+	cred2 := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+		"baz": "baz val",
+		"qux": "qux val",
+	})
+	err = s.State.UpdateCloudCredential(tag2, cred2)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.UpdateCloudCredential(tag3, cred2)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cred1.Label = "bobcred1"
+	cred2.Label = "bobcred2"
+
+	creds, err := s.State.CloudCredentials(names.NewUserTag("bob"), "stratus")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(creds, jc.DeepEquals, map[names.CloudCredentialTag]cloud.Credential{
+		tag1: cred1,
+		tag3: cred2,
+	})
 }

--- a/state/interface.go
+++ b/state/interface.go
@@ -103,7 +103,7 @@ type AgentEntity interface {
 // about clouds and credentials.
 type CloudAccessor interface {
 	Cloud(cloud string) (cloud.Cloud, error)
-	CloudCredentials(user names.UserTag, cloud string) (map[string]cloud.Credential, error)
+	CloudCredential(tag names.CloudCredentialTag) (cloud.Credential, error)
 }
 
 // ModelAccessor defines the methods needed to watch for model

--- a/state/model.go
+++ b/state/model.go
@@ -75,7 +75,7 @@ type modelDoc struct {
 	// deployed. This will be empty for clouds that do not support regions.
 	CloudRegion string `bson:"cloud-region,omitempty"`
 
-	// CloudCredential is the name of the cloud credential that is used
+	// CloudCredential is the ID of the cloud credential that is used
 	// for managing cloud resources for this model. This will be empty
 	// for clouds that do not require credentials.
 	CloudCredential string `bson:"cloud-credential,omitempty"`
@@ -164,10 +164,10 @@ type ModelArgs struct {
 	// deployed. This will be empty for clouds that do not support regions.
 	CloudRegion string
 
-	// CloudCredential is the name of the cloud credential that will be
-	// used for managing cloud resources for this model. This will be empty
-	// for clouds that do not require credentials.
-	CloudCredential string
+	// CloudCredential is the tag of the cloud credential that will be
+	// used for managing cloud resources for this model. This will be
+	// empty for clouds that do not require credentials.
+	CloudCredential names.CloudCredentialTag
 
 	// Config is the model config.
 	Config *config.Config
@@ -191,8 +191,8 @@ func (m ModelArgs) Validate() error {
 	if m.Config == nil {
 		return errors.NotValidf("nil Config")
 	}
-	if m.CloudName == "" {
-		return errors.NotValidf("empty Cloud Name")
+	if !names.IsValidCloud(m.CloudName) {
+		return errors.NotValidf("Cloud Name %q", m.CloudName)
 	}
 	if m.Owner == (names.UserTag{}) {
 		return errors.NotValidf("empty Owner")
@@ -251,7 +251,7 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 		return nil, nil, errors.Trace(err)
 	}
 	assertCloudCredentialOp, err := validateCloudCredential(
-		controllerCloud, args.CloudName, cloudCredentials, args.CloudCredential, owner,
+		controllerCloud, args.CloudName, cloudCredentials, args.CloudCredential,
 	)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
@@ -357,21 +357,35 @@ func validateCloudRegion(cloud jujucloud.Cloud, cloudName, regionName string) (t
 // validateCloudCredential validates the given cloud credential
 // name against the provided cloud definition and credentials,
 // and returns a txn.Op to include in a transaction to assert the
-// same.
+// same. A user is supplied, for which access to the credential
+// will be asserted.
 func validateCloudCredential(
 	cloud jujucloud.Cloud,
 	cloudName string,
-	cloudCredentials map[string]jujucloud.Credential,
-	cloudCredentialName string,
-	cloudCredentialOwner names.UserTag,
+	cloudCredentials map[names.CloudCredentialTag]jujucloud.Credential,
+	cloudCredential names.CloudCredentialTag,
 ) (txn.Op, error) {
-	if cloudCredentialName != "" {
-		if _, ok := cloudCredentials[cloudCredentialName]; !ok {
-			return txn.Op{}, errors.NotFoundf("credential %q", cloudCredentialName)
+	if cloudCredential != (names.CloudCredentialTag{}) {
+		if cloudCredential.Cloud().Id() != cloudName {
+			return txn.Op{}, errors.NotValidf("credential %q", cloudCredential.Id())
 		}
+		var found bool
+		for tag := range cloudCredentials {
+			if tag.Canonical() == cloudCredential.Canonical() {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return txn.Op{}, errors.NotFoundf("credential %q", cloudCredential.Id())
+		}
+		// NOTE(axw) if we add ACLs for credentials,
+		// we'll need to check access here. The map
+		// we check above contains only the credentials
+		// that the model owner has access to.
 		return txn.Op{
 			C:      cloudCredentialsC,
-			Id:     cloudCredentialDocID(cloudCredentialOwner, cloudName, cloudCredentialName),
+			Id:     cloudCredentialDocID(cloudCredential),
 			Assert: txn.DocExists,
 		}, nil
 	}
@@ -437,10 +451,13 @@ func (m *Model) CloudRegion() string {
 	return m.doc.CloudRegion
 }
 
-// CloudCredential returns the name of the cloud credential used for managing the
-// model's cloud resources.
-func (m *Model) CloudCredential() string {
-	return m.doc.CloudCredential
+// CloudCredential returns the tag of the cloud credential used for managing the
+// model's cloud resources, and a boolean indicating whether a credential is set.
+func (m *Model) CloudCredential() (names.CloudCredentialTag, bool) {
+	if names.IsValidCloudCredential(m.doc.CloudCredential) {
+		return names.NewCloudCredentialTag(m.doc.CloudCredential), true
+	}
+	return names.CloudCredentialTag{}, false
 }
 
 // MigrationMode returns whether the model is active or being migrated.
@@ -893,7 +910,8 @@ func removeModelServiceRefOp(st *State, applicationname string) txn.Op {
 // an model document with the given name and UUID.
 func createModelOp(
 	owner names.UserTag,
-	name, uuid, server, cloudName, cloudRegion, cloudCredential string,
+	name, uuid, server, cloudName, cloudRegion string,
+	cloudCredential names.CloudCredentialTag,
 	migrationMode MigrationMode,
 ) txn.Op {
 	doc := &modelDoc{
@@ -905,7 +923,7 @@ func createModelOp(
 		MigrationMode:   migrationMode,
 		Cloud:           cloudName,
 		CloudRegion:     cloudRegion,
-		CloudCredential: cloudCredential,
+		CloudCredential: cloudCredential.Canonical(),
 	}
 	return txn.Op{
 		C:      modelsC,

--- a/state/open.go
+++ b/state/open.go
@@ -122,7 +122,7 @@ type InitializeParams struct {
 
 	// CloudCredentials contains the credentials for the owner of
 	// the controller model to store in the controller.
-	CloudCredentials map[string]cloud.Credential
+	CloudCredentials map[names.CloudCredentialTag]cloud.Credential
 
 	// ControllerConfig contains config attributes for
 	// the controller.
@@ -185,7 +185,6 @@ func (p InitializeParams) Validate() error {
 		p.CloudName,
 		p.CloudCredentials,
 		p.ControllerModelArgs.CloudCredential,
-		p.ControllerModelArgs.Owner,
 	); err != nil {
 		return errors.Annotate(err, "validating controller model cloud credential")
 	}
@@ -277,13 +276,8 @@ func Initialize(args InitializeParams) (_ *State, err error) {
 		ops = append(ops, createSettingsOp(globalSettingsC, regionSettingsGlobalKey(args.CloudName, k), v))
 	}
 
-	for credName, cred := range args.CloudCredentials {
-		ops = append(ops, createCloudCredentialOp(
-			args.ControllerModelArgs.Owner,
-			args.CloudName,
-			credName,
-			cred,
-		))
+	for tag, cred := range args.CloudCredentials {
+		ops = append(ops, createCloudCredentialOp(tag, cred))
 	}
 	ops = append(ops, modelOps...)
 

--- a/state/stateenvirons/config.go
+++ b/state/stateenvirons/config.go
@@ -26,17 +26,16 @@ func (g EnvironConfigGetter) CloudSpec(tag names.ModelTag) (environs.CloudSpec, 
 	}
 	cloudName := model.Cloud()
 	regionName := model.CloudRegion()
-	credentialName := model.CloudCredential()
-	modelOwner := model.Owner()
-	return CloudSpec(g.State, cloudName, regionName, credentialName, modelOwner)
+	credentialTag, _ := model.CloudCredential()
+	return CloudSpec(g.State, cloudName, regionName, credentialTag)
 }
 
 // CloudSpec returns an environs.CloudSpec from a *state.State,
 // given the cloud, region and credential names.
 func CloudSpec(
 	accessor state.CloudAccessor,
-	cloudName, regionName, credentialName string,
-	credentialOwner names.UserTag,
+	cloudName, regionName string,
+	credentialTag names.CloudCredentialTag,
 ) (environs.CloudSpec, error) {
 	modelCloud, err := accessor.Cloud(cloudName)
 	if err != nil {
@@ -44,15 +43,10 @@ func CloudSpec(
 	}
 
 	var credential *cloud.Credential
-	if credentialName != "" {
-		credentials, err := accessor.CloudCredentials(credentialOwner, cloudName)
+	if credentialTag != (names.CloudCredentialTag{}) {
+		credentialValue, err := accessor.CloudCredential(credentialTag)
 		if err != nil {
 			return environs.CloudSpec{}, errors.Trace(err)
-		}
-		var ok bool
-		credentialValue, ok := credentials[credentialName]
-		if !ok {
-			return environs.CloudSpec{}, errors.NotFoundf("credential %q", credentialName)
 		}
 		credential = &credentialValue
 	}

--- a/state/stateenvirons/config_test.go
+++ b/state/stateenvirons/config_test.go
@@ -6,6 +6,7 @@ package stateenvirons_test
 import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
@@ -39,15 +40,14 @@ func (s *environSuite) TestGetNewEnvironFunc(c *gc.C) {
 func (s *environSuite) TestCloudSpec(c *gc.C) {
 	owner := s.Factory.MakeUser(c, nil).UserTag()
 	emptyCredential := cloud.NewEmptyCredential()
-	err := s.State.UpdateCloudCredentials(owner, "dummy", map[string]cloud.Credential{
-		"empty-credential": emptyCredential,
-	})
+	tag := names.NewCloudCredentialTag("dummy/" + owner.Canonical() + "/empty-credential")
+	err := s.State.UpdateCloudCredential(tag, emptyCredential)
 	c.Assert(err, jc.ErrorIsNil)
 
 	st := s.Factory.MakeModel(c, &factory.ModelParams{
 		Name:            "foo",
 		CloudName:       "dummy",
-		CloudCredential: "empty-credential",
+		CloudCredential: tag,
 		Owner:           owner,
 	})
 	defer st.Close()

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -126,7 +126,7 @@ type ModelParams struct {
 	ConfigAttrs             testing.Attrs
 	CloudName               string
 	CloudRegion             string
-	CloudCredential         string
+	CloudCredential         names.CloudCredentialTag
 	StorageProviderRegistry storage.ProviderRegistry
 }
 


### PR DESCRIPTION
We update the Cloud and ModelManager APIs to
make use of the new names.CloudCredentialTag
type. This decouples credentials from model
owner in the CreateModel API call, such that
we can later add ACLs on, and share, credentials.

The Cloud.CloudCredentials API now returns
only the *tags* of cloud credentials that a
user has access to, rather than the contents
of those credentials. This will make it possible
to share cloud credentials with another user
without exposing the credential contents to them.

Note that ACLs and sharing are *not* implemented.
When you update credentials, you're still limited
to updating your own. For now, you can still only
refer to your own, even if the tag syntax allows
for referring to another user's.

(Review request: http://reviews.vapour.ws/r/5447/)