### PR TITLE
Fixed lp:1612624: Bootstrap fail on MAAS if ipv6 is disabled

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -449,7 +449,17 @@ func EnsureServer(args EnsureServerParams) error {
 		}
 	}
 
-	svcConf := newConf(args.DataDir, dbDir, mongoPath, args.StatePort, oplogSizeMB, args.SetNumaControlPolicy, mgoVersion, true)
+	svcConf := newConf(ConfigArgs{
+		DataDir:     args.DataDir,
+		DBDir:       dbDir,
+		MongoPath:   mongoPath,
+		Port:        args.StatePort,
+		OplogSizeMB: oplogSizeMB,
+		WantNumaCtl: args.SetNumaControlPolicy,
+		Version:     mgoVersion,
+		Auth:        true,
+		IPv6:        network.SupportsIPv6(),
+	})
 	svc, err := newService(ServiceName, svcConf)
 	if err != nil {
 		return err

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -108,6 +108,20 @@ func makeEnsureServerParams(dataDir string) mongo.EnsureServerParams {
 	}
 }
 
+func (s *MongoSuite) makeConfigArgs(dataDir string) mongo.ConfigArgs {
+	return mongo.ConfigArgs{
+		DataDir:     dataDir,
+		DBDir:       dataDir,
+		MongoPath:   mongo.JujuMongod24Path,
+		Port:        1234,
+		OplogSizeMB: 1024,
+		WantNumaCtl: false,
+		Version:     s.mongodVersion,
+		Auth:        true,
+		IPv6:        true,
+	}
+}
+
 func (s *MongoSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
@@ -579,30 +593,34 @@ func (s *MongoSuite) TestInstallMongodServiceExists(c *gc.C) {
 }
 
 func (s *MongoSuite) TestNewServiceWithReplSet(c *gc.C) {
-	dataDir := c.MkDir()
-
-	conf := mongo.NewConf(dataDir, dataDir, mongo.JujuMongod24Path, 1234, 1024, false, s.mongodVersion, true)
+	conf := mongo.NewConf(s.makeConfigArgs(c.MkDir()))
 	c.Assert(strings.Contains(conf.ExecStart, "--replSet"), jc.IsTrue)
 }
 
 func (s *MongoSuite) TestNewServiceWithNumCtl(c *gc.C) {
-	dataDir := c.MkDir()
-
-	conf := mongo.NewConf(dataDir, dataDir, mongo.JujuMongod24Path, 1234, 1024, true, s.mongodVersion, true)
+	args := s.makeConfigArgs(c.MkDir())
+	args.WantNumaCtl = true
+	conf := mongo.NewConf(args)
 	c.Assert(conf.ExtraScript, gc.Not(gc.Matches), "")
 }
 
-func (s *MongoSuite) TestNewServiceIPv6(c *gc.C) {
-	dataDir := c.MkDir()
-
-	conf := mongo.NewConf(dataDir, dataDir, mongo.JujuMongod24Path, 1234, 1024, false, s.mongodVersion, true)
+func (s *MongoSuite) TestNewServiceWithIPv6(c *gc.C) {
+	args := s.makeConfigArgs(c.MkDir())
+	args.IPv6 = true
+	conf := mongo.NewConf(args)
 	c.Assert(strings.Contains(conf.ExecStart, "--ipv6"), jc.IsTrue)
 }
 
-func (s *MongoSuite) TestNewServiceWithJournal(c *gc.C) {
-	dataDir := c.MkDir()
+func (s *MongoSuite) TestNewServiceWithoutIPv6(c *gc.C) {
+	args := s.makeConfigArgs(c.MkDir())
+	args.IPv6 = false
+	conf := mongo.NewConf(args)
+	c.Assert(strings.Contains(conf.ExecStart, "--ipv6"), jc.IsFalse)
+}
 
-	conf := mongo.NewConf(dataDir, dataDir, mongo.JujuMongod24Path, 1234, 1024, false, s.mongodVersion, true)
+func (s *MongoSuite) TestNewServiceWithJournal(c *gc.C) {
+	args := s.makeConfigArgs(c.MkDir())
+	conf := mongo.NewConf(args)
 	c.Assert(conf.ExecStart, gc.Matches, `.* --journal.*`)
 }
 

--- a/mongo/service_test.go
+++ b/mongo/service_test.go
@@ -28,7 +28,17 @@ func (s *serviceSuite) TestNewConf(c *gc.C) {
 	mongodVersion := mongo.Mongo24
 	port := 12345
 	oplogSizeMB := 10
-	conf := mongo.NewConf(dataDir, dbDir, mongodPath, port, oplogSizeMB, false, mongodVersion, true)
+	conf := mongo.NewConf(mongo.ConfigArgs{
+		DataDir:     dataDir,
+		DBDir:       dbDir,
+		MongoPath:   mongodPath,
+		Port:        port,
+		OplogSizeMB: oplogSizeMB,
+		WantNumaCtl: false,
+		Version:     mongodVersion,
+		Auth:        true,
+		IPv6:        true,
+	})
 
 	expected := common.Conf{
 		Desc: "juju state database",
@@ -46,9 +56,9 @@ func (s *serviceSuite) TestNewConf(c *gc.C) {
 			" --syslog" +
 			" --journal" +
 			" --replSet juju" +
-			" --ipv6" +
 			" --quiet" +
 			" --oplogSize 10" +
+			" --ipv6" +
 			" --auth" +
 			" --keyFile '/var/lib/juju/shared-secret'" +
 			" --noprealloc" +

--- a/network/export_test.go
+++ b/network/export_test.go
@@ -3,4 +3,7 @@
 
 package network
 
-var NetLookupIP = &netLookupIP
+var (
+	NetLookupIP = &netLookupIP
+	NetListen   = &netListen
+)

--- a/network/utils.go
+++ b/network/utils.go
@@ -5,6 +5,7 @@ package network
 
 import (
 	"bufio"
+	"net"
 	"os"
 	"strings"
 
@@ -160,4 +161,19 @@ func parseResolvStanza(line, stanza string) ([]string, error) {
 	}
 
 	return parsedValues, nil
+}
+
+var netListen = net.Listen
+
+// SupportsIPv6 reports whether the platform supports IPv6 networking
+// functionality.
+//
+// Source: https://github.com/golang/net/blob/master/internal/nettest/stack.go
+func SupportsIPv6() bool {
+	ln, err := netListen("tcp6", "[::1]:0")
+	if err != nil {
+		return false
+	}
+	ln.Close()
+	return true
 }


### PR DESCRIPTION
When IPv6 is disabled (e.g. in the kernel), mongod refuses to
start when the --ipv6 argument is given to it. This PR fixes
this by only passing --ipv6 to mongod if IPv6 is usable (i.e.
::1 can be listened to) on host system.

Added network.SupportsIPv6() helper, used to determine whether
to pass --ipv6 argument to mongod inside the init job (service)
ExecStart command.

QA steps:
 1. With the MAAS UI, go to the Settings page
 2. Put "ipv6.disable=1" in the "Global Kernel Parameters".
 3. juju bootstrap on that MAAS (any node)
 4. Expected success (before this PR it fails to complete).

See http://pad.lv/1612624 for more details.

(Review request: http://reviews.vapour.ws/r/5449/)