### PR TITLE
Add transmit-vendor-metrics environ config.

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -125,6 +125,10 @@ const (
 	// automatically retry a hook that has failed
 	AutomaticallyRetryHooks = "automatically-retry-hooks"
 
+	// TransmitVendorMetricsKey is the key for whether the controller sends
+	// metrics collected in this model for anonymized aggregate analytics.
+	TransmitVendorMetricsKey = "transmit-vendor-metrics"
+
 	//
 	// Deprecated Settings Attributes
 	//
@@ -290,6 +294,7 @@ var defaultConfigValues = map[string]interface{}{
 	"enable-os-upgrade":        true,
 	"development":              false,
 	"test-mode":                false,
+	TransmitVendorMetricsKey:   true,
 
 	// Image and agent streams and URLs.
 	"image-stream":       "released",
@@ -763,6 +768,16 @@ func (c *Config) AutomaticallyRetryHooks() bool {
 	}
 }
 
+// TransmitVendorMetrics returns whether the controller sends charm-collected metrics
+// in this model for anonymized aggregate analytics. By default this should be true.
+func (c *Config) TransmitVendorMetrics() bool {
+	if val, ok := c.defined[TransmitVendorMetricsKey].(bool); !ok {
+		return true
+	} else {
+		return val
+	}
+}
+
 // ProvisionerHarvestMode reports the harvesting methodology the
 // provisioner should take.
 func (c *Config) ProvisionerHarvestMode() HarvestMode {
@@ -956,6 +971,7 @@ var alwaysOptional = schema.Defaults{
 	IgnoreMachineAddresses:       schema.Omit,
 	AutomaticallyRetryHooks:      schema.Omit,
 	"test-mode":                  schema.Omit,
+	TransmitVendorMetricsKey:     schema.Omit,
 }
 
 func allowEmpty(attr string) bool {
@@ -1303,6 +1319,11 @@ data of the store. (default false)`,
 	},
 	AutomaticallyRetryHooks: {
 		Description: "Determines whether the uniter should automatically retry failed hooks",
+		Type:        environschema.Tbool,
+		Group:       environschema.EnvironGroup,
+	},
+	TransmitVendorMetricsKey: {
+		Description: "Determines whether metrics declared by charms deployed into this model are sent for anonymized aggregate analytics",
 		Type:        environschema.Tbool,
 		Group:       environschema.EnvironGroup,
 	},

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -520,6 +520,18 @@ var configTests = []configTest{
 		}),
 		err: `invalid syslog forwarding config: validating TLS config: parsing client key pair: (crypto/)?tls: private key does not match public key`,
 	}, {
+		about:       "transmit-vendor-metrics asserted with default value",
+		useDefaults: config.UseDefaults,
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
+			"transmit-vendor-metrics": true,
+		}),
+	}, {
+		about:       "transmit-vendor-metrics asserted false",
+		useDefaults: config.UseDefaults,
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
+			"transmit-vendor-metrics": false,
+		}),
+	}, {
 		about:       "Valid syslog config values",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
@@ -698,6 +710,14 @@ func (test configTest) check(c *gc.C, home *gitjujutesting.FakeHome) {
 		}
 	} else {
 		c.Assert(resourceTags, gc.HasLen, 0)
+	}
+
+	xmit := cfg.TransmitVendorMetrics()
+	expectedXmit, xmitAsserted := test.attrs["transmit-vendor-metrics"]
+	if xmitAsserted {
+		c.Check(xmit, gc.Equals, expectedXmit)
+	} else {
+		c.Check(xmit, jc.IsTrue)
 	}
 }
 


### PR DESCRIPTION
Add model config setting which allows operators to opt-out of sending the metrics declared & collected by a charm. These metrics are anonymized and aggregated into analytics that may be shared with charm authors.

For some background on this stuff -- the only metrics collected by Juju are those declared in a charm's `metrics.yaml` and added in the charm's collect-metrics hook.

(Review request: http://reviews.vapour.ws/r/5450/)