### PR TITLE
Remove obsolete ACLs option from add user.

### DIFF
--- a/api/state_test.go
+++ b/api/state_test.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/api/usermanager"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
@@ -117,11 +118,15 @@ func (s *stateSuite) TestLoginReadOnly(c *gc.C) {
 	c.Assert(s.APIState.ReadOnly(), jc.IsFalse)
 
 	// Check with an user in read-only mode.
-	modeltag, ok := s.APIState.ModelTag()
-	c.Assert(ok, jc.IsTrue)
 	manager := usermanager.NewClient(s.OpenControllerAPI(c))
 	defer manager.Close()
-	usertag, _, err := manager.AddUser("ro", "ro", "ro-password", "read", modeltag.Id())
+	usertag, _, err := manager.AddUser("ro", "ro", "ro-password")
+	c.Assert(err, jc.ErrorIsNil)
+	mmanager := modelmanager.NewClient(s.OpenControllerAPI(c))
+	defer mmanager.Close()
+	modeltag, ok := s.APIState.ModelTag()
+	c.Assert(ok, jc.IsTrue)
+	err = mmanager.GrantModel(usertag.Canonical(), "read", modeltag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	conn := s.OpenAPIAs(c, usertag, "ro-password")
 	c.Assert(conn.ReadOnly(), jc.IsTrue)

--- a/api/usermanager/client.go
+++ b/api/usermanager/client.go
@@ -14,7 +14,6 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/apiserver/params"
 )
 
@@ -36,35 +35,21 @@ func NewClient(st base.APICallCloser) *Client {
 
 // AddUser creates a new local user in the controller, sharing with that user any specified models.
 func (c *Client) AddUser(
-	username, displayName, password, access string, modelUUIDs ...string,
+	username, displayName, password string,
 ) (_ names.UserTag, secretKey []byte, _ error) {
 	if !names.IsValidUser(username) {
 		return names.UserTag{}, nil, fmt.Errorf("invalid user name %q", username)
 	}
-	modelTags := make([]string, len(modelUUIDs))
-	for i, uuid := range modelUUIDs {
-		modelTags[i] = names.NewModelTag(uuid).String()
-	}
-
-	var accessPermission params.UserAccessPermission
-	var err error
-	if len(modelTags) > 0 {
-		accessPermission, err = modelmanager.ParseModelAccess(access)
-		if err != nil {
-			return names.UserTag{}, nil, errors.Trace(err)
-		}
-	}
 
 	userArgs := params.AddUsers{
 		Users: []params.AddUser{{
-			Username:        username,
-			DisplayName:     displayName,
-			Password:        password,
-			SharedModelTags: modelTags,
-			ModelAccess:     accessPermission}},
+			Username:    username,
+			DisplayName: displayName,
+			Password:    password,
+		}},
 	}
 	var results params.AddUserResults
-	err = c.facade.FacadeCall("AddUser", userArgs, &results)
+	err := c.facade.FacadeCall("AddUser", userArgs, &results)
 	if err != nil {
 		return names.UserTag{}, nil, errors.Trace(err)
 	}

--- a/api/usermanager/client_test.go
+++ b/api/usermanager/client_test.go
@@ -7,11 +7,9 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/usermanager"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/core/description"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
@@ -36,7 +34,7 @@ func (s *usermanagerSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *usermanagerSuite) TestAddUser(c *gc.C) {
-	tag, _, err := s.usermanager.AddUser("foobar", "Foo Bar", "password", "")
+	tag, _, err := s.usermanager.AddUser("foobar", "Foo Bar", "password")
 	c.Assert(err, jc.ErrorIsNil)
 
 	user, err := s.State.User(tag)
@@ -46,42 +44,10 @@ func (s *usermanagerSuite) TestAddUser(c *gc.C) {
 	c.Assert(user.PasswordValid("password"), jc.IsTrue)
 }
 
-func (s *usermanagerSuite) TestAddUserWithModelAccess(c *gc.C) {
-	sharedModelState := s.Factory.MakeModel(c, nil)
-	defer sharedModelState.Close()
-
-	foobarTag, _, err := s.usermanager.AddUser("foobar", "Foo Bar", "password", "read", sharedModelState.ModelUUID())
-	c.Assert(err, jc.ErrorIsNil)
-
-	altAdminTag, _, err := s.usermanager.AddUser("altadmin", "Alt Admin", "password", "write", sharedModelState.ModelUUID())
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Check model is shared with expected users.
-	sharedModel, err := sharedModelState.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	users, err := sharedModel.Users()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(users, gc.HasLen, 3)
-	var modelUserTags = make([]names.UserTag, len(users))
-	for i, u := range users {
-		modelUserTags[i] = u.UserTag
-		if u.UserTag.Name() == "foobar" {
-			c.Assert(u.Access, gc.Equals, description.ReadAccess)
-		} else {
-			c.Assert(u.Access, gc.Not(gc.Equals), description.ReadAccess)
-		}
-	}
-	c.Assert(modelUserTags, jc.SameContents, []names.UserTag{
-		foobarTag,
-		altAdminTag,
-		names.NewLocalUserTag("admin"),
-	})
-}
-
 func (s *usermanagerSuite) TestAddExistingUser(c *gc.C) {
 	s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar"})
 
-	_, _, err := s.usermanager.AddUser("foobar", "Foo Bar", "password", "read")
+	_, _, err := s.usermanager.AddUser("foobar", "Foo Bar", "password")
 	c.Assert(err, gc.ErrorMatches, "failed to create user: user already exists")
 }
 
@@ -91,7 +57,7 @@ func (s *usermanagerSuite) TestAddUserResponseError(c *gc.C) {
 			return errors.New("call error")
 		},
 	)
-	_, _, err := s.usermanager.AddUser("foobar", "Foo Bar", "password", "write")
+	_, _, err := s.usermanager.AddUser("foobar", "Foo Bar", "password")
 	c.Assert(err, gc.ErrorMatches, "call error")
 }
 
@@ -105,12 +71,12 @@ func (s *usermanagerSuite) TestAddUserResultCount(c *gc.C) {
 			return errors.New("wrong result type")
 		},
 	)
-	_, _, err := s.usermanager.AddUser("foobar", "Foo Bar", "password", "read")
+	_, _, err := s.usermanager.AddUser("foobar", "Foo Bar", "password")
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
 }
 
 func (s *usermanagerSuite) TestRemoveUser(c *gc.C) {
-	tag, _, err := s.usermanager.AddUser("jjam", "Jimmy Jam", "password", "")
+	tag, _, err := s.usermanager.AddUser("jjam", "Jimmy Jam", "password")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the user exists.

--- a/apiserver/params/usermanager.go
+++ b/apiserver/params/usermanager.go
@@ -42,9 +42,8 @@ type AddUsers struct {
 
 // AddUser stores the parameters to add one user.
 type AddUser struct {
-	Username        string   `json:"username"`
-	DisplayName     string   `json:"display-name"`
-	SharedModelTags []string `json:"shared-model-tags"`
+	Username    string `json:"username"`
+	DisplayName string `json:"display-name"`
 
 	// Password is optional. If it is empty, then
 	// a secret key will be generated for the user
@@ -52,9 +51,6 @@ type AddUser struct {
 	// be possible to login with a password until
 	// registration with the secret key is completed.
 	Password string `json:"password,omitempty"`
-
-	// ModelAccess is the permission that the user will have to access the models.
-	ModelAccess UserAccessPermission `json:"model-access-permission,omitempty"`
 }
 
 // AddUserResults holds the results of the bulk AddUser API call.

--- a/apiserver/usermanager/usermanager.go
+++ b/apiserver/usermanager/usermanager.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
-	"github.com/juju/juju/apiserver/modelmanager"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
@@ -117,31 +116,6 @@ func (api *UserManagerAPI) AddUser(args params.AddUsers) (params.AddUserResults,
 			}
 		}
 
-		if len(arg.SharedModelTags) > 0 {
-			modelAccess, err := modelmanager.FromModelAccessParam(arg.ModelAccess)
-			if err != nil {
-				err = errors.Annotatef(err, "user %q created but models not shared", arg.Username)
-				result.Results[i].Error = common.ServerError(err)
-				continue
-			}
-			userTag := user.Tag().(names.UserTag)
-			for _, modelTagStr := range arg.SharedModelTags {
-				modelTag, err := names.ParseModelTag(modelTagStr)
-				if err != nil {
-					err = errors.Annotatef(err, "user %q created but model %q not shared", arg.Username, modelTagStr)
-					result.Results[i].Error = common.ServerError(err)
-					break
-				}
-				err = modelmanager.ChangeModelAccess(
-					common.NewModelManagerBackend(api.state), modelTag, api.apiUser,
-					userTag, params.GrantModelAccess, modelAccess, api.isAdmin)
-				if err != nil {
-					err = errors.Annotatef(err, "user %q created but model %q not shared", arg.Username, modelTagStr)
-					result.Results[i].Error = common.ServerError(err)
-					break
-				}
-			}
-		}
 	}
 	return result, nil
 }

--- a/cmd/juju/user/add.go
+++ b/cmd/juju/user/add.go
@@ -7,16 +7,13 @@ import (
 	"encoding/asn1"
 	"encoding/base64"
 	"fmt"
-	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/gnuflag"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/juju/permission"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -34,7 +31,6 @@ credentials in order to create a model.
 Examples:
     juju add-user bob
     juju add-user --controller mycontroller bob
-    juju add-user --models=mymodel --acl=read bob
 
 See also: 
     register
@@ -48,7 +44,7 @@ See also:
 
 // AddUserAPI defines the usermanager API methods that the add command uses.
 type AddUserAPI interface {
-	AddUser(username, displayName, password, access string, modelUUIDs ...string) (names.UserTag, []byte, error)
+	AddUser(username, displayName, password string) (names.UserTag, []byte, error)
 	Close() error
 }
 
@@ -62,13 +58,6 @@ type addCommand struct {
 	api         AddUserAPI
 	User        string
 	DisplayName string
-	ModelNames  string
-	ModelAccess string
-}
-
-func (c *addCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.StringVar(&c.ModelNames, "models", "", "Models the new user is granted access to")
-	f.StringVar(&c.ModelAccess, "acl", "read", "Access controls")
 }
 
 // Info implements Command.Info.
@@ -85,11 +74,6 @@ func (c *addCommand) Info() *cmd.Info {
 func (c *addCommand) Init(args []string) error {
 	if len(args) == 0 {
 		return fmt.Errorf("no username supplied")
-	}
-
-	_, err := permission.ParseModelAccess(c.ModelAccess)
-	if err != nil {
-		return err
 	}
 
 	c.User, args = args[0], args[1:]
@@ -111,24 +95,10 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 		defer api.Close()
 	}
 
-	var modelNames []string
-	for _, modelArg := range strings.Split(c.ModelNames, ",") {
-		modelArg = strings.TrimSpace(modelArg)
-		if len(modelArg) > 0 {
-			modelNames = append(modelNames, modelArg)
-		}
-	}
-
-	// If we need to share a model, look up the model UUIDs from the supplied names.
-	modelUUIDs, err := c.ModelUUIDs(modelNames)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
 	// Add a user without a password. This will generate a temporary
 	// secret key, which we'll print out for the user to supply to
 	// "juju register".
-	_, secretKey, err := api.AddUser(c.User, c.DisplayName, "", c.ModelAccess, modelUUIDs...)
+	_, secretKey, err := api.AddUser(c.User, c.DisplayName, "")
 	if err != nil {
 		return block.ProcessBlockedError(err, block.BlockChange)
 	}
@@ -172,18 +142,13 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 	)
 
 	fmt.Fprintf(ctx.Stdout, "User %q added\n", displayName)
-	for _, modelName := range modelNames {
-		fmt.Fprintf(ctx.Stdout, "User %q granted %s access to model %q\n", displayName, c.ModelAccess, modelName)
-	}
 	fmt.Fprintf(ctx.Stdout, "Please send this command to %v:\n", c.User)
 	fmt.Fprintf(ctx.Stdout, "    juju register %s\n",
 		base64RegistrationData,
 	)
-	if len(modelNames) == 0 {
-		fmt.Fprintf(ctx.Stdout, `
+	fmt.Fprintf(ctx.Stdout, `
 %q has not been granted access to any models. You can use "juju grant" to grant access.
 `, displayName)
-	}
 
 	return nil
 }

--- a/cmd/juju/user/add_test.go
+++ b/cmd/juju/user/add_test.go
@@ -60,15 +60,11 @@ func (s *UserAddCommandSuite) TestInit(c *gc.C) {
 		args:        []string{"foobar", "Foo Bar", "extra"},
 		errorString: `unrecognized args: \["extra"\]`,
 	}, {
-		args:   []string{"foobar", "--models", "foo,bar", "--acl=read"},
-		user:   "foobar",
-		models: "foo,bar",
-		acl:    "read",
+		args: []string{"foobar"},
+		user: "foobar",
 	}, {
-		args:   []string{"foobar", "--models", "baz", "--acl=write"},
-		user:   "foobar",
-		models: "baz",
-		acl:    "write",
+		args: []string{"foobar"},
+		user: "foobar",
 	}} {
 		c.Logf("test %d (%q)", i, test.args)
 		wrappedCommand, command := user.NewAddCommandForTest(s.mockAPI, s.store, &mockModelApi{})
@@ -77,12 +73,6 @@ func (s *UserAddCommandSuite) TestInit(c *gc.C) {
 			c.Check(err, jc.ErrorIsNil)
 			c.Check(command.User, gc.Equals, test.user)
 			c.Check(command.DisplayName, gc.Equals, test.displayname)
-			if len(test.models) > 0 {
-				c.Check(command.ModelNames, gc.Equals, test.models)
-			}
-			if test.acl != "" {
-				c.Check(command.ModelAccess, gc.Equals, test.acl)
-			}
 		} else {
 			c.Check(err, gc.ErrorMatches, test.errorString)
 		}
@@ -94,26 +84,6 @@ func (s *UserAddCommandSuite) TestAddUserWithUsername(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.mockAPI.username, gc.Equals, "foobar")
 	c.Assert(s.mockAPI.displayname, gc.Equals, "")
-	c.Assert(s.mockAPI.access, gc.Equals, "read")
-	c.Assert(s.mockAPI.models, gc.HasLen, 0)
-	expected := `
-User "foobar" added
-Please send this command to foobar:
-    juju register MEYTBmZvb2JhcjAREw8xMjcuMC4wLjE6MTIzNDUEIFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYEwd0ZXN0aW5n
-
-"foobar" has not been granted access to any models. You can use "juju grant" to grant access.
-`[1:]
-	c.Assert(testing.Stdout(context), gc.Equals, expected)
-	c.Assert(testing.Stderr(context), gc.Equals, "")
-}
-
-func (s *UserAddCommandSuite) TestAddUserWithUsernameAndACL(c *gc.C) {
-	context, err := s.run(c, "--acl", "write", "foobar")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.mockAPI.username, gc.Equals, "foobar")
-	c.Assert(s.mockAPI.displayname, gc.Equals, "")
-	c.Assert(s.mockAPI.access, gc.Equals, "write")
-	c.Assert(s.mockAPI.models, gc.HasLen, 0)
 	expected := `
 User "foobar" added
 Please send this command to foobar:
@@ -130,8 +100,6 @@ func (s *UserAddCommandSuite) TestAddUserWithUsernameAndDisplayname(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.mockAPI.username, gc.Equals, "foobar")
 	c.Assert(s.mockAPI.displayname, gc.Equals, "Foo Bar")
-	c.Assert(s.mockAPI.access, gc.Equals, "read")
-	c.Assert(s.mockAPI.models, gc.HasLen, 0)
 	expected := `
 User "Foo Bar (foobar)" added
 Please send this command to foobar:
@@ -151,23 +119,6 @@ func (m *mockModelApi) ListModels(user string) ([]base.UserModel, error) {
 
 func (m *mockModelApi) Close() error {
 	return nil
-}
-
-func (s *UserAddCommandSuite) TestAddUserWithModelAccess(c *gc.C) {
-	context, err := s.run(c, "foobar", "--models", "model")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.mockAPI.username, gc.Equals, "foobar")
-	c.Assert(s.mockAPI.displayname, gc.Equals, "")
-	c.Assert(s.mockAPI.access, gc.Equals, "read")
-	c.Assert(s.mockAPI.models, gc.DeepEquals, []string{"modeluuid"})
-	expected := `
-User "foobar" added
-User "foobar" granted read access to model "model"
-Please send this command to foobar:
-    juju register MEYTBmZvb2JhcjAREw8xMjcuMC4wLjE6MTIzNDUEIFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYEwd0ZXN0aW5n
-`[1:]
-	c.Assert(testing.Stdout(context), gc.Equals, expected)
-	c.Assert(testing.Stderr(context), gc.Equals, "")
 }
 
 func (s *UserAddCommandSuite) TestBlockAddUser(c *gc.C) {
@@ -194,19 +145,15 @@ type mockAddUserAPI struct {
 	username    string
 	displayname string
 	password    string
-	access      string
-	models      []string
 }
 
-func (m *mockAddUserAPI) AddUser(username, displayname, password, access string, models ...string) (names.UserTag, []byte, error) {
+func (m *mockAddUserAPI) AddUser(username, displayname, password string) (names.UserTag, []byte, error) {
 	if m.blocked {
 		return names.UserTag{}, nil, common.OperationBlockedError("the operation has been blocked")
 	}
 	m.username = username
 	m.displayname = displayname
 	m.password = password
-	m.access = access
-	m.models = models
 	if m.failMessage != "" {
 		return names.UserTag{}, nil, errors.New(m.failMessage)
 	}

--- a/featuretests/cmd_juju_login_test.go
+++ b/featuretests/cmd_juju_login_test.go
@@ -43,7 +43,8 @@ func (s *cmdLoginSuite) run(c *gc.C, stdin io.Reader, args ...string) *cmd.Conte
 }
 
 func (s *cmdLoginSuite) createTestUser(c *gc.C) {
-	s.run(c, nil, "add-user", "test", "--models", "controller")
+	s.run(c, nil, "add-user", "test")
+	s.run(c, nil, "grant", "test", "read", "controller")
 	s.changeUserPassword(c, "test", "hunter2")
 }
 

--- a/featuretests/cmd_juju_user_test.go
+++ b/featuretests/cmd_juju_user_test.go
@@ -49,34 +49,6 @@ func (s *UserSuite) TestUserAdd(c *gc.C) {
 	c.Assert(user.IsDisabled(), jc.IsFalse)
 }
 
-func (s *UserSuite) TestUserAddGrantModel(c *gc.C) {
-	sharedModelState := s.Factory.MakeModel(c, &factory.ModelParams{
-		Name: "amodel",
-	})
-	defer sharedModelState.Close()
-
-	ctx, err := s.RunUserCommand(c, "", "add-user", "test", "--models", "amodel")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(ctx), jc.HasPrefix, `User "test" added`)
-	user, err := s.State.User(names.NewLocalUserTag("test"))
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(user.IsDisabled(), jc.IsFalse)
-
-	// Check model is shared with expected users.
-	sharedModel, err := sharedModelState.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	users, err := sharedModel.Users()
-	c.Assert(err, jc.ErrorIsNil)
-	var modelUserTags = make([]names.UserTag, len(users))
-	for i, u := range users {
-		modelUserTags[i] = u.UserTag
-	}
-	c.Assert(modelUserTags, jc.SameContents, []names.UserTag{
-		user.Tag().(names.UserTag),
-		names.NewLocalUserTag("admin"),
-	})
-}
-
 func (s *UserSuite) TestUserChangePassword(c *gc.C) {
 	user, err := s.State.User(s.AdminUserTag(c))
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Removed references to acls and model sharing from
add user.

(Review request: http://reviews.vapour.ws/r/5451/)