### PR TITLE
Migrate the storage instances and attachments.

### DIFF
--- a/core/description/filesystem.go
+++ b/core/description/filesystem.go
@@ -174,6 +174,9 @@ func (f *filesystem) Validate() error {
 	if f.Status_ == nil {
 		return errors.NotValidf("filesystem %q missing status", f.ID_)
 	}
+	if _, err := f.Binding(); err != nil {
+		return errors.Wrap(err, errors.NotValidf("filesystem %q binding", f.ID_))
+	}
 	return nil
 }
 

--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -97,6 +97,9 @@ type Model interface {
 	Filesystems() []Filesystem
 	AddFilesystem(FilesystemArgs) Filesystem
 
+	Storages() []Storage
+	AddStorage(StorageArgs) Storage
+
 	Validate() error
 }
 
@@ -469,4 +472,19 @@ type FilesystemAttachment interface {
 	Provisioned() bool
 	MountPoint() string
 	ReadOnly() bool
+}
+
+// Storage represents the state of a unit or application-wide storage instance
+// in the model.
+type Storage interface {
+	Tag() names.StorageTag
+	Kind() string
+	// Owner returns the tag of the application or unit that owns this storage
+	// instance.
+	Owner() (names.Tag, error)
+	Name() string
+
+	Attachments() []names.UnitTag
+
+	Validate() error
 }

--- a/core/description/model.go
+++ b/core/description/model.go
@@ -53,6 +53,7 @@ func NewModel(args ModelArgs) Model {
 	m.setActions(nil)
 	m.setVolumes(nil)
 	m.setFilesystems(nil)
+	m.setStorages(nil)
 	return m
 }
 
@@ -137,10 +138,9 @@ type model struct {
 	CloudRegion_     string `yaml:"cloud-region,omitempty"`
 	CloudCredential_ string `yaml:"cloud-credential,omitempty"`
 
-	// TODO:
-	// Storage...
 	Volumes_     volumes     `yaml:"volumes"`
 	Filesystems_ filesystems `yaml:"filesystems"`
+	Storages_    storages    `yaml:"storages"`
 }
 
 func (m *model) Tag() names.ModelTag {
@@ -511,29 +511,49 @@ func (m *model) setFilesystems(filesystemList []*filesystem) {
 	}
 }
 
+// Storages implements Model.
+func (m *model) Storages() []Storage {
+	var result []Storage
+	for _, storage := range m.Storages_.Storages_ {
+		result = append(result, storage)
+	}
+	return result
+}
+
+// AddStorage implemets Model.
+func (m *model) AddStorage(args StorageArgs) Storage {
+	storage := newStorage(args)
+	m.Storages_.Storages_ = append(m.Storages_.Storages_, storage)
+	return storage
+}
+
+func (m *model) setStorages(storageList []*storage) {
+	m.Storages_ = storages{
+		Version:   1,
+		Storages_: storageList,
+	}
+}
+
 // Validate implements Model.
 func (m *model) Validate() error {
 	// A model needs an owner.
 	if m.Owner_ == "" {
 		return errors.NotValidf("missing model owner")
 	}
-
+	allMachines := set.NewStrings()
 	unitsWithOpenPorts := set.NewStrings()
 	for _, machine := range m.Machines_.Machines_ {
-		if err := machine.Validate(); err != nil {
+		if err := m.validateMachine(machine, allMachines, unitsWithOpenPorts); err != nil {
 			return errors.Trace(err)
 		}
-		for _, op := range machine.OpenedPorts() {
-			for _, pr := range op.OpenPorts() {
-				unitsWithOpenPorts.Add(pr.UnitName())
-			}
-		}
 	}
+	allApplications := set.NewStrings()
 	allUnits := set.NewStrings()
 	for _, application := range m.Applications_.Applications_ {
 		if err := application.Validate(); err != nil {
 			return errors.Trace(err)
 		}
+		allApplications.Add(application.Name())
 		allUnits = allUnits.Union(application.unitNames())
 	}
 	// Make sure that all the unit names specified in machine opened ports
@@ -561,11 +581,8 @@ func (m *model) Validate() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	err = m.validateVolumes()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	err = m.validateFilesystems()
+
+	err = m.validateStorage(allMachines, allApplications, allUnits)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -573,21 +590,79 @@ func (m *model) Validate() error {
 	return nil
 }
 
-func (m *model) validateVolumes() error {
+func (m *model) validateMachine(machine Machine, allMachineIDs, unitsWithOpenPorts set.Strings) error {
+	if err := machine.Validate(); err != nil {
+		return errors.Trace(err)
+	}
+	allMachineIDs.Add(machine.Id())
+	for _, op := range machine.OpenedPorts() {
+		for _, pr := range op.OpenPorts() {
+			unitsWithOpenPorts.Add(pr.UnitName())
+		}
+	}
+	for _, container := range machine.Containers() {
+		err := m.validateMachine(container, allMachineIDs, unitsWithOpenPorts)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+func (m *model) validateStorage(allMachineIDs, allApplications, allUnits set.Strings) error {
+	appsAndUnits := allApplications.Union(allUnits)
+	allStorage := set.NewStrings()
+	for i, storage := range m.Storages_.Storages_ {
+		if err := storage.Validate(); err != nil {
+			return errors.Annotatef(err, "storage[%d]", i)
+		}
+		allStorage.Add(storage.Tag().Id())
+		owner, err := storage.Owner()
+		if err != nil {
+			return errors.Wrap(err, errors.NotValidf("storage[%d] owner (%s)", i, owner))
+		}
+		ownerID := owner.Id()
+		if !appsAndUnits.Contains(ownerID) {
+			return errors.NotValidf("storage[%d] owner (%s)", i, ownerID)
+		}
+		for _, unit := range storage.Attachments() {
+			if !allUnits.Contains(unit.Id()) {
+				return errors.NotValidf("storage[%d] attachment referencing unknown unit %q", i, unit)
+			}
+		}
+	}
+	allVolumes := set.NewStrings()
 	for i, volume := range m.Volumes_.Volumes_ {
 		if err := volume.Validate(); err != nil {
 			return errors.Annotatef(err, "volume[%d]", i)
 		}
+		allVolumes.Add(volume.Tag().Id())
+		if storeID := volume.Storage().Id(); storeID != "" && !allStorage.Contains(storeID) {
+			return errors.NotValidf("volume[%d] referencing unknown storage %q", i, storeID)
+		}
+		for j, attachment := range volume.Attachments() {
+			if machineID := attachment.Machine().Id(); !allMachineIDs.Contains(machineID) {
+				return errors.NotValidf("volume[%d].attachment[%d] referencing unknown machine %q", i, j, machineID)
+			}
+		}
 	}
-	return nil
-}
-
-func (m *model) validateFilesystems() error {
 	for i, filesystem := range m.Filesystems_.Filesystems_ {
 		if err := filesystem.Validate(); err != nil {
 			return errors.Annotatef(err, "filesystem[%d]", i)
 		}
+		if storeID := filesystem.Storage().Id(); storeID != "" && !allStorage.Contains(storeID) {
+			return errors.NotValidf("filesystem[%d] referencing unknown storage %q", i, storeID)
+		}
+		if volID := filesystem.Volume().Id(); volID != "" && !allVolumes.Contains(volID) {
+			return errors.NotValidf("filesystem[%d] referencing unknown volume %q", i, volID)
+		}
+		for j, attachment := range filesystem.Attachments() {
+			if machineID := attachment.Machine().Id(); !allMachineIDs.Contains(machineID) {
+				return errors.NotValidf("filesystem[%d].attachment[%d] referencing unknown machine %q", i, j, machineID)
+			}
+		}
 	}
+
 	return nil
 }
 
@@ -784,6 +859,7 @@ func importModelV1(source map[string]interface{}) (*model, error) {
 		"linklayerdevices": schema.StringMap(schema.Any()),
 		"volumes":          schema.StringMap(schema.Any()),
 		"filesystems":      schema.StringMap(schema.Any()),
+		"storages":         schema.StringMap(schema.Any()),
 		"sequences":        schema.StringMap(schema.Int()),
 	}
 	// Some values don't have to be there.
@@ -923,6 +999,12 @@ func importModelV1(source map[string]interface{}) (*model, error) {
 		return nil, errors.Annotate(err, "filesystems")
 	}
 	result.setFilesystems(filesystems)
+
+	storages, err := importStorages(valid["storages"].(map[string]interface{}))
+	if err != nil {
+		return nil, errors.Annotate(err, "storages")
+	}
+	result.setStorages(storages)
 
 	return result, nil
 }

--- a/core/description/model_test.go
+++ b/core/description/model_test.go
@@ -704,3 +704,18 @@ func (s *ModelSerializationSuite) TestFilesystems(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(model.Filesystems(), jc.DeepEquals, filesystems)
 }
+
+func (s *ModelSerializationSuite) TestStorage(c *gc.C) {
+	initial := NewModel(ModelArgs{Owner: names.NewUserTag("owner")})
+	storage := initial.AddStorage(testStorageArgs())
+	storages := initial.Storages()
+	c.Assert(storages, gc.HasLen, 1)
+	c.Assert(storages[0], jc.DeepEquals, storage)
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := Deserialize(bytes)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(model.Storages(), jc.DeepEquals, storages)
+}

--- a/core/description/storage.go
+++ b/core/description/storage.go
@@ -1,0 +1,169 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+	"gopkg.in/juju/names.v2"
+)
+
+type storages struct {
+	Version   int        `yaml:"version"`
+	Storages_ []*storage `yaml:"storages"`
+}
+
+type storage struct {
+	ID_    string `yaml:"id"`
+	Kind_  string `yaml:"kind"`
+	Owner_ string `yaml:"owner"`
+	Name_  string `yaml:"name"`
+
+	Attachments_ []string `yaml:"attachments"`
+}
+
+// StorageArgs is an argument struct used to add a storage to the Model.
+type StorageArgs struct {
+	Tag         names.StorageTag
+	Kind        string
+	Owner       names.Tag
+	Name        string
+	Attachments []names.UnitTag
+}
+
+func newStorage(args StorageArgs) *storage {
+	s := &storage{
+		ID_:   args.Tag.Id(),
+		Kind_: args.Kind,
+		Name_: args.Name,
+	}
+	if args.Owner != nil {
+		s.Owner_ = args.Owner.String()
+	}
+	for _, unit := range args.Attachments {
+		s.Attachments_ = append(s.Attachments_, unit.Id())
+	}
+	return s
+}
+
+// Tag implements Storage.
+func (s *storage) Tag() names.StorageTag {
+	return names.NewStorageTag(s.ID_)
+}
+
+// Kind implements Storage.
+func (s *storage) Kind() string {
+	return s.Kind_
+}
+
+// Owner implements Storage.
+func (s *storage) Owner() (names.Tag, error) {
+	if s.Owner_ == "" {
+		return nil, nil
+	}
+	tag, err := names.ParseTag(s.Owner_)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return tag, nil
+}
+
+// Name implements Storage.
+func (s *storage) Name() string {
+	return s.Name_
+}
+
+// Attachments implements Storage.
+func (s *storage) Attachments() []names.UnitTag {
+	var result []names.UnitTag
+	for _, unit := range s.Attachments_ {
+		result = append(result, names.NewUnitTag(unit))
+	}
+	return result
+}
+
+// Validate implements Storage.
+func (s *storage) Validate() error {
+	if s.ID_ == "" {
+		return errors.NotValidf("storage missing id")
+	}
+	if s.Owner_ == "" {
+		return errors.NotValidf("storage %q missing owner", s.ID_)
+	}
+	// Also check that the owner and attachments are valid.
+	if _, err := s.Owner(); err != nil {
+		return errors.Wrap(err, errors.NotValidf("storage %q invalid owner", s.ID_))
+	}
+	return nil
+}
+
+func importStorages(source map[string]interface{}) ([]*storage, error) {
+	checker := versionedChecker("storages")
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "storages version schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+
+	version := int(valid["version"].(int64))
+	importFunc, ok := storageDeserializationFuncs[version]
+	if !ok {
+		return nil, errors.NotValidf("version %d", version)
+	}
+	sourceList := valid["storages"].([]interface{})
+	return importStorageList(sourceList, importFunc)
+}
+
+func importStorageList(sourceList []interface{}, importFunc storageDeserializationFunc) ([]*storage, error) {
+	result := make([]*storage, 0, len(sourceList))
+	for i, value := range sourceList {
+		source, ok := value.(map[string]interface{})
+		if !ok {
+			return nil, errors.Errorf("unexpected value for storage %d, %T", i, value)
+		}
+		storage, err := importFunc(source)
+		if err != nil {
+			return nil, errors.Annotatef(err, "storage %d", i)
+		}
+		result = append(result, storage)
+	}
+	return result, nil
+}
+
+type storageDeserializationFunc func(map[string]interface{}) (*storage, error)
+
+var storageDeserializationFuncs = map[int]storageDeserializationFunc{
+	1: importStorageV1,
+}
+
+func importStorageV1(source map[string]interface{}) (*storage, error) {
+	fields := schema.Fields{
+		"id":          schema.String(),
+		"kind":        schema.String(),
+		"owner":       schema.String(),
+		"name":        schema.String(),
+		"attachments": schema.List(schema.String()),
+	}
+
+	// Normally a list would have defaults, but in this case storage
+	// should always have at least one attachment.
+	checker := schema.FieldMap(fields, nil) // no defaults
+
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "storage v1 schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+	// From here we know that the map returned from the schema coercion
+	// contains fields of the right type.
+	result := &storage{
+		ID_:          valid["id"].(string),
+		Kind_:        valid["kind"].(string),
+		Owner_:       valid["owner"].(string),
+		Name_:        valid["name"].(string),
+		Attachments_: convertToStringSlice(valid["attachments"]),
+	}
+
+	return result, nil
+}

--- a/core/description/storage_test.go
+++ b/core/description/storage_test.go
@@ -1,0 +1,123 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/yaml.v2"
+)
+
+type StorageSerializationSuite struct {
+	SliceSerializationSuite
+}
+
+var _ = gc.Suite(&StorageSerializationSuite{})
+
+func (s *StorageSerializationSuite) SetUpTest(c *gc.C) {
+	s.SliceSerializationSuite.SetUpTest(c)
+	s.importName = "storages"
+	s.sliceName = "storages"
+	s.importFunc = func(m map[string]interface{}) (interface{}, error) {
+		return importStorages(m)
+	}
+	s.testFields = func(m map[string]interface{}) {
+		m["storages"] = []interface{}{}
+	}
+}
+
+func testStorageMap() map[interface{}]interface{} {
+	return map[interface{}]interface{}{
+		"id":    "db/0",
+		"kind":  "magic",
+		"owner": "application-postgresql",
+		"name":  "db",
+		"attachments": []interface{}{
+			"postgresql/0",
+			"postgresql/1",
+		},
+	}
+}
+
+func testStorage() *storage {
+	v := newStorage(testStorageArgs())
+	return v
+}
+
+func testStorageArgs() StorageArgs {
+	return StorageArgs{
+		Tag:   names.NewStorageTag("db/0"),
+		Kind:  "magic",
+		Owner: names.NewApplicationTag("postgresql"),
+		Name:  "db",
+		Attachments: []names.UnitTag{
+			names.NewUnitTag("postgresql/0"),
+			names.NewUnitTag("postgresql/1"),
+		},
+	}
+}
+
+func (s *StorageSerializationSuite) TestNewStorage(c *gc.C) {
+	storage := testStorage()
+
+	c.Check(storage.Tag(), gc.Equals, names.NewStorageTag("db/0"))
+	c.Check(storage.Kind(), gc.Equals, "magic")
+	owner, err := storage.Owner()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(owner, gc.Equals, names.NewApplicationTag("postgresql"))
+	c.Check(storage.Name(), gc.Equals, "db")
+	c.Check(storage.Attachments(), jc.DeepEquals, []names.UnitTag{
+		names.NewUnitTag("postgresql/0"),
+		names.NewUnitTag("postgresql/1"),
+	})
+}
+
+func (s *StorageSerializationSuite) TestStorageValid(c *gc.C) {
+	storage := testStorage()
+	c.Assert(storage.Validate(), jc.ErrorIsNil)
+}
+
+func (s *StorageSerializationSuite) TestStorageValidMissingID(c *gc.C) {
+	v := newStorage(StorageArgs{})
+	err := v.Validate()
+	c.Check(err, gc.ErrorMatches, `storage missing id not valid`)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *StorageSerializationSuite) TestStorageMatches(c *gc.C) {
+	bytes, err := yaml.Marshal(testStorage())
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[interface{}]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(source, jc.DeepEquals, testStorageMap())
+}
+
+func (s *StorageSerializationSuite) exportImport(c *gc.C, storage_ *storage) *storage {
+	initial := storages{
+		Version:   1,
+		Storages_: []*storage{storage_},
+	}
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	storages, err := importStorages(source)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(storages, gc.HasLen, 1)
+	return storages[0]
+}
+
+func (s *StorageSerializationSuite) TestParsingSerializedData(c *gc.C) {
+	original := testStorage()
+	storage := s.exportImport(c, original)
+	c.Assert(storage, jc.DeepEquals, original)
+}

--- a/core/description/volume.go
+++ b/core/description/volume.go
@@ -180,6 +180,9 @@ func (v *volume) Validate() error {
 	if v.Status_ == nil {
 		return errors.NotValidf("volume %q missing status", v.ID_)
 	}
+	if _, err := v.Binding(); err != nil {
+		return errors.Wrap(err, errors.NotValidf("volume %q binding", v.ID_))
+	}
 	return nil
 }
 

--- a/state/application.go
+++ b/state/application.go
@@ -1102,11 +1102,10 @@ func (s *Application) unitStorageOps(unitName string, cons map[string]StorageCon
 		return nil, -1, err
 	}
 	meta := charm.Meta()
-	url := charm.URL()
 	tag := names.NewUnitTag(unitName)
 	// TODO(wallyworld) - record constraints info in data model - size and pool name
 	ops, numStorageAttachments, err = createStorageOps(
-		s.st, tag, meta, url, cons,
+		s.st, tag, meta, cons,
 		s.doc.Series,
 		false, // unit is not assigned yet; don't create machine storage
 	)

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -493,6 +493,14 @@ func LeadershipLeases(st *State) (map[string]lease.Info, error) {
 	return client.Leases(), nil
 }
 
+func StorageAttachmentCount(instance StorageInstance) int {
+	internal, ok := instance.(*storageInstance)
+	if !ok {
+		return -1
+	}
+	return internal.doc.AttachmentCount
+}
+
 func ResetMigrationMode(c *gc.C, st *State) {
 	ops := []txn.Op{{
 		C:      modelsC,

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -62,6 +62,8 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 
 		filesystemsC,
 		filesystemAttachmentsC,
+		storageInstancesC,
+		storageAttachmentsC,
 		volumesC,
 		volumeAttachmentsC,
 	)
@@ -163,8 +165,6 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		endpointBindingsC,
 
 		// storage
-		storageInstancesC,
-		storageAttachmentsC,
 		storageConstraintsC,
 
 		// uncategorised
@@ -752,6 +752,35 @@ func (s *MigrationSuite) TestFilesystemAttachmentDocFields(c *gc.C) {
 		"MountPoint", "ReadOnly"))
 	s.AssertExportedFields(c, FilesystemAttachmentParams{}, set.NewStrings(
 		"Location", "ReadOnly"))
+}
+
+func (s *MigrationSuite) TestStorageInstanceDocFields(c *gc.C) {
+	ignored := set.NewStrings(
+		"ModelUUID",
+		"DocID",
+		"Life",
+	)
+	migrated := set.NewStrings(
+		"Id",
+		"Kind",
+		"Owner",
+		"StorageName",
+		"AttachmentCount", // through count of attachment instances
+	)
+	s.AssertExportedFields(c, storageInstanceDoc{}, migrated.Union(ignored))
+}
+
+func (s *MigrationSuite) TestStorageAttachmentDocFields(c *gc.C) {
+	ignored := set.NewStrings(
+		"ModelUUID",
+		"DocID",
+		"Life",
+	)
+	migrated := set.NewStrings(
+		"Unit",
+		"StorageInstance",
+	)
+	s.AssertExportedFields(c, storageAttachmentDoc{}, migrated.Union(ignored))
 }
 
 func (s *MigrationSuite) AssertExportedFields(c *gc.C, doc interface{}, fields set.Strings) {

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -524,7 +524,6 @@ func (s *StorageStateSuite) assertStorageUnitsAdded(c *gc.C) {
 			c.Assert(err, jc.ErrorIsNil)
 			count[storageInstance.StorageName()]++
 			c.Assert(storageInstance.Kind(), gc.Equals, state.StorageKindBlock)
-			c.Assert(storageInstance.CharmURL(), gc.DeepEquals, ch.URL())
 		}
 		c.Assert(count, gc.DeepEquals, map[string]int{
 			"multi1to10": 1,


### PR DESCRIPTION
There is follow up work needed to go through the machine and unit docs to record the new
storage information that is available.

Still no CI available until we migrate storage pools, storage constraints, and update the machines and units with the volume, filesystems and storage values.

(Review request: http://reviews.vapour.ws/r/5452/)