### PR TITLE
add dummy region to tests

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -143,18 +143,20 @@ LXC_BRIDGE="ignored"`[1:])
 
 	hostedModelUUID := utils.MustNewUUID().String()
 	hostedModelConfigAttrs := map[string]interface{}{
-		"name": "hosted",
-		"uuid": hostedModelUUID,
+		"name":   "hosted",
+		"uuid":   hostedModelUUID,
+		"region": "some-region",
 	}
 	controllerInheritedConfig := map[string]interface{}{
 		"apt-mirror": "http://mirror",
+		"a-key":      "value",
 	}
 	regionConfig := cloud.RegionConfig{
-		"a-region": cloud.Attrs{
+		"some-region": cloud.Attrs{
 			"a-key": "a-value",
 		},
-		"b-region": cloud.Attrs{
-			"b-key": "b-value",
+		"another-region": cloud.Attrs{
+			"a-key": "b-value",
 		},
 	}
 	var envProvider fakeProvider
@@ -166,11 +168,11 @@ LXC_BRIDGE="ignored"`[1:])
 			ControllerCloud: cloud.Cloud{
 				Type:         "dummy",
 				AuthTypes:    []cloud.AuthType{cloud.EmptyAuthType},
-				Regions:      []cloud.Region{{Name: "a-region"}},
+				Regions:      []cloud.Region{{Name: "some-region"}},
 				RegionConfig: regionConfig,
 			},
 			ControllerCloudName:       "dummy",
-			ControllerCloudRegion:     "a-region",
+			ControllerCloudRegion:     "some-region",
 			ControllerConfig:          controllerCfg,
 			ControllerModelConfig:     modelCfg,
 			ModelConstraints:          expectModelConstraints,
@@ -229,6 +231,7 @@ LXC_BRIDGE="ignored"`[1:])
 	c.Assert(err, jc.ErrorIsNil)
 	expectedAttrs := expectedCfg.AllAttrs()
 	expectedAttrs["apt-mirror"] = "http://mirror"
+	expectedAttrs["a-key"] = "value"
 	c.Assert(newModelCfg.AllAttrs(), jc.DeepEquals, expectedAttrs)
 
 	gotModelConstraints, err := st.ModelConstraints()
@@ -247,7 +250,7 @@ LXC_BRIDGE="ignored"`[1:])
 	hostedModel, err := hostedModelSt.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hostedModel.Name(), gc.Equals, "hosted")
-	c.Assert(hostedModel.CloudRegion(), gc.Equals, "a-region")
+	c.Assert(hostedModel.CloudRegion(), gc.Equals, "some-region")
 	hostedCfg, err := hostedModelSt.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	_, hasUnexpected := hostedCfg.AllAttrs()["not-for-hosted"]
@@ -313,7 +316,8 @@ LXC_BRIDGE="ignored"`[1:])
 		Cloud: environs.CloudSpec{
 			Type:   "dummy",
 			Name:   "dummy",
-			Region: "a-region",
+			Region: "some-region",
+			// XXX Something here.
 		},
 		Config: hostedCfg,
 	})

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -149,14 +149,11 @@ LXC_BRIDGE="ignored"`[1:])
 	}
 	controllerInheritedConfig := map[string]interface{}{
 		"apt-mirror": "http://mirror",
-		"a-key":      "value",
+		"no-proxy":   "value",
 	}
 	regionConfig := cloud.RegionConfig{
 		"some-region": cloud.Attrs{
-			"a-key": "a-value",
-		},
-		"another-region": cloud.Attrs{
-			"a-key": "b-value",
+			"no-proxy": "a-value",
 		},
 	}
 	var envProvider fakeProvider
@@ -231,7 +228,7 @@ LXC_BRIDGE="ignored"`[1:])
 	c.Assert(err, jc.ErrorIsNil)
 	expectedAttrs := expectedCfg.AllAttrs()
 	expectedAttrs["apt-mirror"] = "http://mirror"
-	expectedAttrs["a-key"] = "value"
+	expectedAttrs["no-proxy"] = "value"
 	c.Assert(newModelCfg.AllAttrs(), jc.DeepEquals, expectedAttrs)
 
 	gotModelConstraints, err := st.ModelConstraints()
@@ -317,7 +314,6 @@ LXC_BRIDGE="ignored"`[1:])
 			Type:   "dummy",
 			Name:   "dummy",
 			Region: "some-region",
-			// XXX Something here.
 		},
 		Config: hostedCfg,
 	})

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -165,11 +165,11 @@ LXC_BRIDGE="ignored"`[1:])
 			ControllerCloud: cloud.Cloud{
 				Type:         "dummy",
 				AuthTypes:    []cloud.AuthType{cloud.EmptyAuthType},
-				Regions:      []cloud.Region{{Name: "some-region"}},
+				Regions:      []cloud.Region{{Name: "dummy-region"}},
 				RegionConfig: regionConfig,
 			},
 			ControllerCloudName:       "dummy",
-			ControllerCloudRegion:     "some-region",
+			ControllerCloudRegion:     "dummy-region",
 			ControllerConfig:          controllerCfg,
 			ControllerModelConfig:     modelCfg,
 			ModelConstraints:          expectModelConstraints,
@@ -247,7 +247,7 @@ LXC_BRIDGE="ignored"`[1:])
 	hostedModel, err := hostedModelSt.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hostedModel.Name(), gc.Equals, "hosted")
-	c.Assert(hostedModel.CloudRegion(), gc.Equals, "some-region")
+	c.Assert(hostedModel.CloudRegion(), gc.Equals, "dummy-region")
 	hostedCfg, err := hostedModelSt.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	_, hasUnexpected := hostedCfg.AllAttrs()["not-for-hosted"]
@@ -313,7 +313,7 @@ LXC_BRIDGE="ignored"`[1:])
 		Cloud: environs.CloudSpec{
 			Type:   "dummy",
 			Name:   "dummy",
-			Region: "some-region",
+			Region: "dummy-region",
 		},
 		Config: hostedCfg,
 	})

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -143,9 +143,8 @@ LXC_BRIDGE="ignored"`[1:])
 
 	hostedModelUUID := utils.MustNewUUID().String()
 	hostedModelConfigAttrs := map[string]interface{}{
-		"name":   "hosted",
-		"uuid":   hostedModelUUID,
-		"region": "some-region",
+		"name": "hosted",
+		"uuid": hostedModelUUID,
 	}
 	controllerInheritedConfig := map[string]interface{}{
 		"apt-mirror": "http://mirror",

--- a/api/modelmanager/modelmanager_test.go
+++ b/api/modelmanager/modelmanager_test.go
@@ -49,7 +49,7 @@ func (s *modelmanagerSuite) TestCreateModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newModel.Name, gc.Equals, "new-model")
 	c.Assert(newModel.OwnerTag, gc.Equals, user.Tag().String())
-	c.Assert(newModel.CloudRegion, gc.Equals, "")
+	c.Assert(newModel.CloudRegion, gc.Equals, "dummy-region")
 	c.Assert(utils.IsValidUUIDString(newModel.UUID), jc.IsTrue)
 }
 

--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -159,9 +159,10 @@ func (s *baseSuite) openAs(c *gc.C, tag names.Tag) api.Connection {
 // also tested live and it works.
 var scenarioStatus = &params.FullStatus{
 	Model: params.ModelStatusInfo{
-		Name:    "controller",
-		Cloud:   "dummy",
-		Version: "1.2.3",
+		Name:        "controller",
+		Cloud:       "dummy",
+		CloudRegion: "dummy-region",
+		Version:     "1.2.3",
 	},
 	Machines: map[string]params.MachineStatus{
 		"0": {

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3490,7 +3490,7 @@ func (s *StatusSuite) testStatusWithFormatTabular(c *gc.C, useFeatureFlag bool) 
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	expected := `
-MODEL       CONTROLLER  CLOUD/REGION        VERSION  UPGRADE-AVAILABLE
+MODEL       CONTROLLER  CLOUD/REGION        VERSION  MESSAGE
 controller  kontroll    dummy/dummy-region  1.2.3    1.2.4
 
 APP        VERSION  STATUS       EXPOSED  ORIGIN      CHARM      REV  OS

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -162,6 +162,7 @@ var (
 		"name":       "controller",
 		"controller": "kontroll",
 		"cloud":      "dummy",
+		"region":     "dummy-region",
 		"version":    "1.2.3",
 	}
 
@@ -2380,6 +2381,7 @@ var statusTests = []testCase{
 					"name":              "controller",
 					"controller":        "kontroll",
 					"cloud":             "dummy",
+					"region":            "dummy-region",
 					"version":           "1.2.3",
 					"upgrade-available": "1.2.4",
 				},
@@ -3185,6 +3187,7 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 			"name":       hostedModelName,
 			"controller": "kontroll",
 			"cloud":      "dummy",
+			"region":     "dummy-region",
 			"version":    "1.2.3",
 			"migration":  statusText,
 		},
@@ -3434,8 +3437,8 @@ func (s *StatusSuite) testStatusWithFormatTabular(c *gc.C, useFeatureFlag bool) 
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	expected := `
-MODEL       CONTROLLER  CLOUD/REGION  VERSION  UPGRADE-AVAILABLE
-controller  kontroll    dummy         1.2.3    1.2.4
+MODEL       CONTROLLER  CLOUD/REGION        VERSION  UPGRADE-AVAILABLE
+controller  kontroll    dummy/dummy-region  1.2.3    1.2.4
 
 APP        VERSION  STATUS       EXPOSED  ORIGIN      CHARM      REV  OS
 logging    a bi...               true     jujucharms  logging    1    ubuntu
@@ -3756,6 +3759,7 @@ func (s *StatusSuite) TestFilterToContainer(c *gc.C) {
 		"  name: controller\n" +
 		"  controller: kontroll\n" +
 		"  cloud: dummy\n" +
+		"  region: dummy-region\n" +
 		"  version: 1.2.3\n" +
 		"machines:\n" +
 		"  \"0\":\n" +
@@ -4048,6 +4052,7 @@ var statusTimeTest = test(
 				"name":       "controller",
 				"controller": "kontroll",
 				"cloud":      "dummy",
+				"region":     "dummy-region",
 				"version":    "1.2.3",
 			},
 			"machines": M{

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3194,8 +3194,8 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 
 func (s *StatusSuite) TestMigrationInProgressTabular(c *gc.C) {
 	expected := `
-MODEL   CONTROLLER  CLOUD/REGION  VERSION  MESSAGE
-hosted  kontroll    dummy         1.2.3    migrating: foo bar
+MODEL   CONTROLLER  CLOUD/REGION        VERSION  MESSAGE
+hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar
 
 APP  VERSION  STATUS  EXPOSED  ORIGIN  CHARM  REV  OS
 
@@ -3215,8 +3215,8 @@ MACHINE  STATE  DNS  INS-ID  SERIES  AZ
 
 func (s *StatusSuite) TestMigrationInProgressAndUpgradeAvailable(c *gc.C) {
 	expected := `
-MODEL   CONTROLLER  CLOUD/REGION  VERSION  MESSAGE
-hosted  kontroll    dummy         1.2.3    migrating: foo bar
+MODEL   CONTROLLER  CLOUD/REGION        VERSION  MESSAGE
+hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar
 
 APP  VERSION  STATUS  EXPOSED  ORIGIN  CHARM  REV  OS
 
@@ -3491,7 +3491,7 @@ func (s *StatusSuite) testStatusWithFormatTabular(c *gc.C, useFeatureFlag bool) 
 	c.Check(string(stderr), gc.Equals, "")
 	expected := `
 MODEL       CONTROLLER  CLOUD/REGION        VERSION  MESSAGE
-controller  kontroll    dummy/dummy-region  1.2.3    1.2.4
+controller  kontroll    dummy/dummy-region  1.2.3    upgrade available: 1.2.4
 
 APP        VERSION  STATUS       EXPOSED  ORIGIN      CHARM      REV  OS
 logging    a bi...               true     jujucharms  logging    1    ubuntu

--- a/environs/bootstrap/prepare_test.go
+++ b/environs/bootstrap/prepare_test.go
@@ -96,6 +96,7 @@ func (*PrepareSuite) TestPrepare(c *gc.C) {
 			"test-mode":                 true,
 		},
 		Cloud:                 "dummy",
+		CloudRegion:           "dummy-region",
 		CloudType:             "dummy",
 		CloudEndpoint:         "dummy-endpoint",
 		CloudIdentityEndpoint: "dummy-identity-endpoint",

--- a/featuretests/api_cloud_test.go
+++ b/featuretests/api_cloud_test.go
@@ -33,8 +33,16 @@ func (s *CloudAPISuite) TestCloudAPI(c *gc.C) {
 	result, err := s.client.Cloud(names.NewCloudTag("dummy"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, cloud.Cloud{
-		Type:             "dummy",
-		AuthTypes:        []cloud.AuthType{cloud.EmptyAuthType},
+		Type:      "dummy",
+		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
+		Regions: []cloud.Region{
+			cloud.Region{
+				Name:             "dummy-region",
+				Endpoint:         "dummy-endpoint",
+				IdentityEndpoint: "dummy-identity-endpoint",
+				StorageEndpoint:  "dummy-storage-endpoint",
+			},
+		},
 		Endpoint:         "dummy-endpoint",
 		IdentityEndpoint: "dummy-identity-endpoint",
 		StorageEndpoint:  "dummy-storage-endpoint",

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -68,7 +68,7 @@ func (s *cmdControllerSuite) TestControllerListCommand(c *gc.C) {
 	context := s.run(c, "list-controllers")
 	expectedOutput := `
 CONTROLLER  MODEL       USER         CLOUD/REGION
-kontroll*   controller  admin@local  dummy
+kontroll*   controller  admin@local  dummy/dummy-region
 
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expectedOutput)
@@ -103,6 +103,7 @@ models:
   controller-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
   owner: admin@local
   cloud: dummy
+  region: dummy-region
   type: dummy
   life: alive
   status:
@@ -156,7 +157,7 @@ func (s *cmdControllerSuite) TestAddModel(c *gc.C) {
 	)
 	c.Check(testing.Stdout(context), gc.Equals, "")
 	c.Check(testing.Stderr(context), gc.Equals, `
-Added 'new-model' model with credential 'cred' for user 'admin'
+Added 'new-model' model on dummy/dummy-region with credential 'cred' for user 'admin'
 `[1:])
 
 	// Make sure that the saved server details are sufficient to connect
@@ -189,6 +190,7 @@ func (s *cmdControllerSuite) testControllerDestroy(c *gc.C, forceAPI bool) {
 	st := s.Factory.MakeModel(c, &factory.ModelParams{
 		Name:        "just-a-controller",
 		ConfigAttrs: testing.Attrs{"controller": true},
+		CloudRegion: "dummy-region",
 	})
 	defer st.Close()
 	factory.NewFactory(st).MakeApplication(c, nil)
@@ -260,7 +262,8 @@ func (s *cmdControllerSuite) TestRemoveBlocks(c *gc.C) {
 
 func (s *cmdControllerSuite) TestControllerKill(c *gc.C) {
 	st := s.Factory.MakeModel(c, &factory.ModelParams{
-		Name: "foo",
+		Name:        "foo",
+		CloudRegion: "dummy-region",
 	})
 
 	st.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyModel")

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -322,12 +322,21 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	err = bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), environ, bootstrap.BootstrapParams{
 		ControllerConfig: s.ControllerConfig,
 		CloudName:        cloudSpec.Name,
+		CloudRegion:      "dummy-region",
 		Cloud: cloud.Cloud{
 			Type:             cloudSpec.Type,
 			AuthTypes:        []cloud.AuthType{cloud.EmptyAuthType},
 			Endpoint:         cloudSpec.Endpoint,
 			IdentityEndpoint: cloudSpec.IdentityEndpoint,
 			StorageEndpoint:  cloudSpec.StorageEndpoint,
+			Regions: []cloud.Region{
+				cloud.Region{
+					Name:             "dummy-region",
+					Endpoint:         "dummy-endpoint",
+					IdentityEndpoint: "dummy-identity-endpoint",
+					StorageEndpoint:  "dummy-storage-endpoint",
+				},
+			},
 		},
 		CloudCredential:     cloudSpec.Credential,
 		CloudCredentialName: "cred",

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -83,6 +83,7 @@ func SampleCloudSpec() environs.CloudSpec {
 		Name:             "dummy",
 		Endpoint:         "dummy-endpoint",
 		IdentityEndpoint: "dummy-identity-endpoint",
+		Region:           "dummy-region",
 		StorageEndpoint:  "dummy-storage-endpoint",
 		Credential:       &cred,
 	}

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -57,7 +57,7 @@ func (s *allWatcherBaseSuite) newState(c *gc.C) *State {
 		"uuid": utils.MustNewUUID().String(),
 	})
 	_, st, err := s.state.NewModel(ModelArgs{
-		CloudName: "dummy", Config: cfg, Owner: s.owner,
+		CloudName: "dummy", CloudRegion: "dummy-region", Config: cfg, Owner: s.owner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/annotations_test.go
+++ b/state/annotations_test.go
@@ -181,7 +181,7 @@ func (s *AnnotationsEnvSuite) createTestEnv(c *gc.C) (*state.Model, *state.State
 	})
 	owner := names.NewUserTag("test@remote")
 	env, st, err := s.State.NewModel(state.ModelArgs{
-		CloudName: "dummy", Config: cfg, Owner: owner,
+		CloudName: "dummy", CloudRegion: "dummy-region", Config: cfg, Owner: owner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/binarystorage_test.go
+++ b/state/binarystorage_test.go
@@ -84,9 +84,10 @@ func (s *binaryStorageSuite) SetUpTest(c *gc.C) {
 		"uuid": s.modelUUID,
 	})
 	_, s.st, err = s.State.NewModel(state.ModelArgs{
-		CloudName: "dummy",
-		Config:    cfg,
-		Owner:     names.NewLocalUserTag("test-admin"),
+		CloudName:   "dummy",
+		CloudRegion: "dummy-region",
+		Config:      cfg,
+		Owner:       names.NewLocalUserTag("test-admin"),
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/block_test.go
+++ b/state/block_test.go
@@ -196,7 +196,7 @@ func (s *blockSuite) createTestModel(c *gc.C) (*state.Model, *state.State) {
 	})
 	owner := names.NewUserTag("test@remote")
 	env, st, err := s.State.NewModel(state.ModelArgs{
-		CloudName: "dummy", Config: cfg, Owner: owner,
+		CloudName: "dummy", CloudRegion: "dummy-region", Config: cfg, Owner: owner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -116,7 +116,7 @@ func (s *ConnSuite) NewStateForModelNamed(c *gc.C, modelName string) *state.Stat
 	})
 	otherOwner := names.NewLocalUserTag("test-admin")
 	_, otherState, err := s.State.NewModel(state.ModelArgs{
-		CloudName: "dummy", Config: cfg, Owner: otherOwner,
+		CloudName: "dummy", CloudRegion: "dummy-region", Config: cfg, Owner: otherOwner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -62,6 +62,7 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: ModelArgs{
 			CloudName:               "dummy",
+			CloudRegion:             "dummy-region",
 			Owner:                   s.owner,
 			Config:                  modelCfg,
 			StorageProviderRegistry: provider.CommonStorageProviders(),
@@ -70,6 +71,11 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 		Cloud: cloud.Cloud{
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
+			Regions: []cloud.Region{
+				cloud.Region{
+					Name: "dummy-region",
+				},
+			},
 		},
 		MongoInfo:     info,
 		MongoDialOpts: mongotest.DialOpts(),

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -65,9 +65,10 @@ func (s *ModelSuite) TestNewModelNonExistentLocalUser(c *gc.C) {
 	owner := names.NewUserTag("non-existent@local")
 
 	_, _, err := s.State.NewModel(state.ModelArgs{
-		CloudName: "dummy",
-		Config:    cfg,
-		Owner:     owner,
+		CloudName:   "dummy",
+		CloudRegion: "dummy-region",
+		Config:      cfg,
+		Owner:       owner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	c.Assert(err, gc.ErrorMatches, `cannot create model: user "non-existent" not found`)
@@ -79,9 +80,10 @@ func (s *ModelSuite) TestNewModelSameUserSameNameFails(c *gc.C) {
 
 	// Create the first model.
 	_, st1, err := s.State.NewModel(state.ModelArgs{
-		CloudName: "dummy",
-		Config:    cfg,
-		Owner:     owner,
+		CloudName:   "dummy",
+		CloudRegion: "dummy-region",
+		Config:      cfg,
+		Owner:       owner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -96,9 +98,10 @@ func (s *ModelSuite) TestNewModelSameUserSameNameFails(c *gc.C) {
 		"uuid": newUUID.String(),
 	})
 	_, _, err = s.State.NewModel(state.ModelArgs{
-		CloudName: "dummy",
-		Config:    cfg2,
-		Owner:     owner,
+		CloudName:   "dummy",
+		CloudRegion: "dummy-region",
+		Config:      cfg2,
+		Owner:       owner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	errMsg := fmt.Sprintf("model %q for %s already exists", cfg2.Name(), owner.Canonical())
@@ -120,9 +123,10 @@ func (s *ModelSuite) TestNewModelSameUserSameNameFails(c *gc.C) {
 
 	// We should now be able to create the other model.
 	env2, st2, err := s.State.NewModel(state.ModelArgs{
-		CloudName: "dummy",
-		Config:    cfg2,
-		Owner:     owner,
+		CloudName:   "dummy",
+		CloudRegion: "dummy-region",
+		Config:      cfg2,
+		Owner:       owner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -136,9 +140,10 @@ func (s *ModelSuite) TestNewModel(c *gc.C) {
 	owner := names.NewUserTag("test@remote")
 
 	model, st, err := s.State.NewModel(state.ModelArgs{
-		CloudName: "dummy",
-		Config:    cfg,
-		Owner:     owner,
+		CloudName:   "dummy",
+		CloudRegion: "dummy-region",
+		Config:      cfg,
+		Owner:       owner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -183,6 +188,7 @@ func (s *ModelSuite) TestNewModelImportingMode(c *gc.C) {
 
 	env, st, err := s.State.NewModel(state.ModelArgs{
 		CloudName:               "dummy",
+		CloudRegion:             "dummy-region",
 		Config:                  cfg,
 		Owner:                   owner,
 		MigrationMode:           state.MigrationModeImporting,
@@ -199,9 +205,10 @@ func (s *ModelSuite) TestSetMigrationMode(c *gc.C) {
 	owner := names.NewUserTag("test@remote")
 
 	env, st, err := s.State.NewModel(state.ModelArgs{
-		CloudName: "dummy",
-		Config:    cfg,
-		Owner:     owner,
+		CloudName:   "dummy",
+		CloudRegion: "dummy-region",
+		Config:      cfg,
+		Owner:       owner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -227,9 +234,10 @@ func (s *ModelSuite) TestControllerModel(c *gc.C) {
 func (s *ModelSuite) TestControllerModelAccessibleFromOtherModels(c *gc.C) {
 	cfg, _ := s.createTestModelConfig(c)
 	_, st, err := s.State.NewModel(state.ModelArgs{
-		CloudName: "dummy",
-		Config:    cfg,
-		Owner:     names.NewUserTag("test@remote"),
+		CloudName:   "dummy",
+		CloudRegion: "dummy-region",
+		Config:      cfg,
+		Owner:       names.NewUserTag("test@remote"),
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -825,17 +833,17 @@ func (s *ModelCloudValidationSuite) TestNewModelUnknownCloudRegion(c *gc.C) {
 	defer st.Close()
 	cfg, _ := createTestModelConfig(c, st.ModelUUID())
 	_, _, err := st.NewModel(state.ModelArgs{
-		CloudName:               "dummy",
-		Config:                  cfg,
-		Owner:                   owner,
-		CloudRegion:             "missing-region",
+		CloudName:   "dummy",
+		CloudRegion: "dummy-region",
+		Config:      cfg,
+		Owner:       owner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
-	c.Assert(err, gc.ErrorMatches, `region "missing-region" not found \(expected one of \["some-region"\]\)`)
+	c.Assert(err, gc.ErrorMatches, `region "dummy-region" not found \(expected one of \["some-region"\]\)`)
 }
 
 func (s *ModelCloudValidationSuite) TestNewModelMissingCloudRegion(c *gc.C) {
-	st, owner := s.initializeState(c, []cloud.Region{{Name: "some-region"}}, []cloud.AuthType{cloud.EmptyAuthType}, nil)
+	st, owner := s.initializeState(c, []cloud.Region{{Name: "dummy-region"}}, []cloud.AuthType{cloud.EmptyAuthType}, nil)
 	defer st.Close()
 	cfg, _ := createTestModelConfig(c, st.ModelUUID())
 	_, _, err := st.NewModel(state.ModelArgs{
@@ -848,8 +856,9 @@ func (s *ModelCloudValidationSuite) TestNewModelMissingCloudRegion(c *gc.C) {
 }
 
 func (s *ModelCloudValidationSuite) TestNewModelUnknownCloudCredential(c *gc.C) {
+	regions := []cloud.Region{cloud.Region{Name: "dummy-region"}}
 	st, owner := s.initializeState(
-		c, nil, []cloud.AuthType{cloud.UserPassAuthType}, map[string]cloud.Credential{
+		c, regions, []cloud.AuthType{cloud.UserPassAuthType}, map[string]cloud.Credential{
 			"controller-credentials": cloud.NewCredential(cloud.UserPassAuthType, nil),
 		},
 	)
@@ -857,6 +866,7 @@ func (s *ModelCloudValidationSuite) TestNewModelUnknownCloudCredential(c *gc.C) 
 	cfg, _ := createTestModelConfig(c, st.ModelUUID())
 	_, _, err := st.NewModel(state.ModelArgs{
 		CloudName:               "dummy",
+		CloudRegion:             "dummy-region",
 		Config:                  cfg,
 		Owner:                   owner,
 		CloudCredential:         "unknown-credential",
@@ -866,30 +876,40 @@ func (s *ModelCloudValidationSuite) TestNewModelUnknownCloudCredential(c *gc.C) 
 }
 
 func (s *ModelCloudValidationSuite) TestNewModelMissingCloudCredential(c *gc.C) {
+	regions := []cloud.Region{cloud.Region{Name: "dummy-region"}}
 	st, owner := s.initializeState(
-		c, nil, []cloud.AuthType{cloud.UserPassAuthType}, map[string]cloud.Credential{
+		c, regions, []cloud.AuthType{cloud.UserPassAuthType}, map[string]cloud.Credential{
 			"controller-credentials": cloud.NewCredential(cloud.UserPassAuthType, nil),
 		},
 	)
 	defer st.Close()
 	cfg, _ := createTestModelConfig(c, st.ModelUUID())
 	_, _, err := st.NewModel(state.ModelArgs{
-		CloudName: "dummy",
-		Config:    cfg,
-		Owner:     owner,
+		CloudName:   "dummy",
+		CloudRegion: "dummy-region",
+		Config:      cfg,
+		Owner:       owner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	c.Assert(err, gc.ErrorMatches, "missing CloudCredential not valid")
 }
 
 func (s *ModelCloudValidationSuite) TestNewModelMissingCloudCredentialSupportsEmptyAuth(c *gc.C) {
-	st, owner := s.initializeState(c, nil, []cloud.AuthType{cloud.EmptyAuthType}, nil)
+	regions := []cloud.Region{
+		cloud.Region{
+			Name:             "dummy-region",
+			Endpoint:         "dummy-endpoint",
+			IdentityEndpoint: "dummy-identity-endpoint",
+			StorageEndpoint:  "dummy-storage-endpoint",
+		},
+	}
+	st, owner := s.initializeState(c, regions, []cloud.AuthType{cloud.EmptyAuthType}, nil)
 	defer st.Close()
 	cfg, _ := createTestModelConfig(c, st.ModelUUID())
 	cfg, err := cfg.Apply(map[string]interface{}{"name": "whatever"})
 	c.Assert(err, jc.ErrorIsNil)
 	_, newSt, err := st.NewModel(state.ModelArgs{
-		CloudName: "dummy", Config: cfg, Owner: owner,
+		CloudName: "dummy", CloudRegion: "dummy-region", Config: cfg, Owner: owner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -286,7 +286,6 @@ func modelConfigSources(st *State) []modelConfigSource {
 		{config.JujuDefaultSource, func() (attrValues, error) { return config.ConfigDefaults(), nil }},
 		{config.JujuControllerSource, st.controllerInheritedConfig},
 		{config.JujuControllerSource, st.regionInheritedConfig},
-		// We will also support tenant, user etc
 	}
 
 }
@@ -322,6 +321,10 @@ func (st *State) regionInheritedConfig() (attrValues, error) {
 	if err != nil {
 		// Some clouds have no region so we need to handle an empty region by
 		// returning and handling an error or returning nil.
+		// TODO(ro): http://reviews.vapour.ws/r/5454/#comment29388 check for
+		// model.CloudRegion() == "" above and return a NotFound error there,
+		// saving searching for non-existent settings with a partially
+		// constructed key
 		return nil, errors.Trace(err)
 	}
 	return settings.Map(), nil

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -309,8 +309,6 @@ func (st *State) controllerInheritedConfig() (attrValues, error) {
 // regionInheritedConfig returns the configuration attributes for the region in
 // the cloud where the model is targeted.
 func (st *State) regionInheritedConfig() (attrValues, error) {
-	// XXX Some cloud's have no region so we need to handle an empty region by
-	// returning and handling an error or returning nil.
 	model, err := st.Model()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -322,6 +320,8 @@ func (st *State) regionInheritedConfig() (attrValues, error) {
 			model.CloudRegion()),
 	)
 	if err != nil {
+		// Some clouds have no region so we need to handle an empty region by
+		// returning and handling an error or returning nil.
 		return nil, errors.Trace(err)
 	}
 	return settings.Map(), nil

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -236,7 +236,7 @@ func (s *ModelConfigSourceSuite) TestNewModelConfigForksControllerValue(c *gc.C)
 	})
 	owner := names.NewUserTag("test@remote")
 	_, st, err := s.State.NewModel(state.ModelArgs{
-		Config: cfg, Owner: owner, CloudName: "dummy",
+		Config: cfg, Owner: owner, CloudName: "dummy", CloudRegion: "dummy-region",
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/modeluser_test.go
+++ b/state/modeluser_test.go
@@ -384,7 +384,7 @@ func (s *ModelUserSuite) newEnvWithOwner(c *gc.C, name string, owner names.UserT
 		"uuid": uuid.String(),
 	})
 	model, st, err := s.State.NewModel(state.ModelArgs{
-		CloudName: "dummy", Config: cfg, Owner: owner,
+		CloudName: "dummy", CloudRegion: "dummy-region", Config: cfg, Owner: owner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/open.go
+++ b/state/open.go
@@ -230,6 +230,8 @@ func Initialize(args InitializeParams) (_ *State, err error) {
 	modelOps, err := st.modelSetupOps(
 		args.ControllerModelArgs,
 		&lineage{
+			// TODO(ro): http://reviews.vapour.ws/r/5454/#comment29390 add
+			// regiond config here too.
 			ControllerConfig: args.ControllerInheritedConfig,
 		})
 	if err != nil {
@@ -305,7 +307,6 @@ func Initialize(args InitializeParams) (_ *State, err error) {
 type lineage struct {
 	ControllerConfig map[string]interface{}
 	RegionConfig     cloud.RegionConfig
-	// Tenant and User config coming soon?
 }
 
 // modelSetupOps returns the transactions necessary to set up a model.
@@ -370,6 +371,8 @@ func (st *State) modelSetupOps(args ModelArgs, inherited *lineage) ([]txn.Op, er
 				sourceFunc: modelConfigSourceFunc(func() (attrValues, error) {
 					return inherited.ControllerConfig, nil
 				})},
+			// TODO(ro): http://reviews.vapour.ws/r/5454/#comment29392 need
+			// to add region config to modelConfigSources here too.
 		}
 	} else {
 		configSources = modelConfigSources(st)

--- a/state/stateenvirons/config_test.go
+++ b/state/stateenvirons/config_test.go
@@ -56,8 +56,12 @@ func (s *environSuite) TestCloudSpec(c *gc.C) {
 	cloudSpec, err := stateenvirons.EnvironConfigGetter{st}.CloudSpec(st.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudSpec, jc.DeepEquals, environs.CloudSpec{
-		Type:       "dummy",
-		Name:       "dummy",
-		Credential: &emptyCredential,
+		Type:             "dummy",
+		Name:             "dummy",
+		Region:           "dummy-region",
+		Endpoint:         "dummy-endpoint",
+		IdentityEndpoint: "dummy-identity-endpoint",
+		StorageEndpoint:  "dummy-storage-endpoint",
+		Credential:       &emptyCredential,
 	})
 }

--- a/state/testing/conn.go
+++ b/state/testing/conn.go
@@ -35,9 +35,10 @@ func Initialize(c *gc.C, owner names.UserTag, cfg *config.Config, controllerInhe
 	st, err := state.Initialize(state.InitializeParams{
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
-			CloudName: "dummy",
-			Config:    cfg,
-			Owner:     owner,
+			CloudName:   "dummy",
+			CloudRegion: "dummy-region",
+			Config:      cfg,
+			Owner:       owner,
 			StorageProviderRegistry: StorageProviders(),
 		},
 		ControllerInheritedConfig: controllerInheritedConfig,
@@ -45,6 +46,14 @@ func Initialize(c *gc.C, owner names.UserTag, cfg *config.Config, controllerInhe
 		Cloud: cloud.Cloud{
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
+			Regions: []cloud.Region{
+				cloud.Region{
+					Name:             "dummy-region",
+					Endpoint:         "dummy-endpoint",
+					IdentityEndpoint: "dummy-identity-endpoint",
+					StorageEndpoint:  "dummy-storage-endpoint",
+				},
+			},
 		},
 		MongoInfo:     mgoInfo,
 		MongoDialOpts: dialOpts,

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -575,6 +575,9 @@ func (factory *Factory) MakeModel(c *gc.C, params *ModelParams) *state.State {
 	if params.CloudName == "" {
 		params.CloudName = "dummy"
 	}
+	if params.CloudRegion == "" {
+		params.CloudRegion = "dummy-region"
+	}
 	if params.Owner == nil {
 		origEnv, err := factory.st.Model()
 		c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Add region to dummy provider and update tests

This predominantly adds a region to the dummy cloud provider and updates juju connsuite and friends. It does have a couple region-config bits, but this is all part of the model-config-tree WIP.

QA: 
I've run the full test suite and everything passes.

(Review request: http://reviews.vapour.ws/r/5454/)