### PR TITLE
Fixes for tools handing on non-amd64

### DIFF
--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -222,6 +222,12 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 		bootstrapArch = *bootstrapConstraints.Arch
 	} else {
 		bootstrapArch = arch.HostArch()
+		// We no longer support controllers on i386.
+		// If we are bootstrapping from an i386 client,
+		// we'll look for amd64 tools.
+		if bootstrapArch == arch.I386 {
+			bootstrapArch = arch.AMD64
+		}
 	}
 
 	ctx.Infof("Bootstrapping model %q", cfg.Name())

--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -80,7 +80,7 @@ func (s *localLiveSuite) SetUpSuite(c *gc.C) {
 	s.TestConfig = GetFakeConfig().Merge(coretesting.Attrs{
 		"image-metadata-url": "test://host",
 	})
-	s.LiveTests.UploadArches = []string{arch.AMD64}
+	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 	s.AddCleanup(func(*gc.C) { envtesting.PatchAttemptStrategies(&joyent.ShortAttempt) })
 }
 
@@ -131,8 +131,7 @@ func (s *localServerSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	s.cSrv.setupServer(c)
 	s.AddCleanup(s.cSrv.destroyServer)
-
-	s.Tests.ToolsFixture.UploadArches = []string{arch.AMD64}
+	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 	s.Tests.SetUpTest(c)
 
 	s.Credential = cloud.NewCredential(cloud.UserPassAuthType, map[string]string{


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1613782
Fixes: https://bugs.launchpad.net/juju-core/+bug/1613838

The joyent test unit failures are because joyent only supports amd64 and when run on non amd64 arches we were passing by fluke before because the tests were faulty. So the tests are fixed.

The issue with windows bootstrap is because the client is being run on i386 and so we need to look for amd64 tools. Previously we were being less strict about filtering on matching arch.

(Review request: http://reviews.vapour.ws/r/5456/)