### PR TITLE
Migrate missing machine and unit fields.

### DIFF
--- a/state/machine.go
+++ b/state/machine.go
@@ -116,10 +116,6 @@ type machineDoc struct {
 	PasswordHash  string
 	Clean         bool
 
-	// TODO(axw) 2015-06-22 #1467379
-	// We need an upgrade step to populate "volumes" and "filesystems"
-	// for entities created in 1.24.
-	//
 	// Volumes contains the names of volumes attached to the machine.
 	Volumes []string `bson:"volumes,omitempty"`
 	// Filesystems contains the names of filesystems attached to the machine.

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1176,7 +1176,15 @@ func (e *exporter) addVolume(vol *volume, volAttachments []volumeAttachmentDoc) 
 	args := description.VolumeArgs{
 		Tag:     vol.VolumeTag(),
 		Binding: vol.LifeBinding(),
-		// TODO: add storage link
+	}
+	if tag, err := vol.StorageInstance(); err == nil {
+		// only returns an error when no storage tag.
+		args.Storage = tag
+	} else {
+		if !errors.IsNotAssigned(err) {
+			// This is an unexpected error.
+			return errors.Trace(err)
+		}
 	}
 	logger.Debugf("addVolume: %#v", vol.doc)
 	if info, err := vol.Info(); err == nil {


### PR DESCRIPTION
Add the storage attachment counts to units.
Add the clean, volumes and filesystems fields for machines.

(Review request: http://reviews.vapour.ws/r/5457/)