### PR TITLE
apiserver: allow Pinger on controller-only connection

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -193,14 +193,16 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 		ServerVersion: jujuversion.Current.String(),
 	}
 
+	connType := "model"
 	allowFacade := isModelFacade
 	if controllerOnlyLogin {
+		connType = "controller"
 		allowFacade = isControllerFacade
 		// Remove the ModelTag from the response as there is no
 		// model here.
 		loginResult.ModelTag = ""
 	}
-	authedAPI = newRestrictedRoot(authedAPI, allowFacade)
+	authedAPI = newRestrictedRoot(authedAPI, connType, allowFacade)
 	// Strip out the facades that are not supported from the result.
 	facades := make([]params.FacadeVersions, 0, len(loginResult.Facades))
 	for _, facade := range loginResult.Facades {

--- a/apiserver/adminv3_test.go
+++ b/apiserver/adminv3_test.go
@@ -56,7 +56,7 @@ func (s *loginV3Suite) TestClientLoginToServer(c *gc.C) {
 	client := apiState.Client()
 	_, err = client.GetModelConstraints()
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
-		Message: `facade "Client" not supported for API connection type`,
+		Message: `facade "Client" not supported for controller API connection`,
 		Code:    "not supported",
 	})
 }

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -126,7 +126,7 @@ func TestingUpgradingRoot(st *state.State) rpc.Root {
 // from the root of the API path.
 func TestingRestrictedAPIHandler(st *state.State) rpc.Root {
 	r := TestingAPIRoot(st)
-	return newRestrictedRoot(r, isControllerFacade)
+	return newRestrictedRoot(r, "controller", isControllerFacade)
 }
 
 type preFacadeAdminAPI struct{}

--- a/apiserver/restricted_root_test.go
+++ b/apiserver/restricted_root_test.go
@@ -47,12 +47,14 @@ func (r *restrictedRootSuite) TestFindAllowedMethod(c *gc.C) {
 	r.assertMethodAllowed(c, "Controller", 3, "DestroyController")
 	r.assertMethodAllowed(c, "Controller", 3, "ModelConfig")
 	r.assertMethodAllowed(c, "Controller", 3, "ListBlockedModels")
+
+	r.assertMethodAllowed(c, "Pinger", 1, "Ping")
 }
 
 func (r *restrictedRootSuite) TestFindDisallowedMethod(c *gc.C) {
 	caller, err := r.root.FindMethod("Client", 1, "FullStatus")
 
-	c.Assert(err, gc.ErrorMatches, `facade "Client" not supported for API connection type`)
+	c.Assert(err, gc.ErrorMatches, `facade "Client" not supported for controller API connection`)
 	c.Assert(errors.IsNotSupported(err), jc.IsTrue)
 	c.Assert(caller, gc.IsNil)
 }
@@ -60,7 +62,7 @@ func (r *restrictedRootSuite) TestFindDisallowedMethod(c *gc.C) {
 func (r *restrictedRootSuite) TestNonExistentFacade(c *gc.C) {
 	caller, err := r.root.FindMethod("SomeFacade", 0, "Method")
 
-	c.Assert(err, gc.ErrorMatches, `facade "SomeFacade" not supported for API connection type`)
+	c.Assert(err, gc.ErrorMatches, `facade "SomeFacade" not supported for controller API connection`)
 	c.Assert(caller, gc.IsNil)
 }
 


### PR DESCRIPTION
For long-lived connections, it's important to have the pinger available.

To QA, make a controller-only API connection and Ping on it.
It should not return an error.


(Review request: http://reviews.vapour.ws/r/5458/)