### PR TITLE
Fixed lp:1587345: Parse correctly loop devices without inode reported.

### DIFF
--- a/storage/looputil/loop_test.go
+++ b/storage/looputil/loop_test.go
@@ -187,6 +187,15 @@ func (s *LoopUtilSuite) TestDetachLoopDevicesAlternativeRootWithPrefix(c *gc.C) 
 	})
 }
 
+func (s *LoopUtilSuite) TestDetachLoopDevicesListEmptyInodeOK(c *gc.C) {
+	commands := &mockRunCommand{c: c}
+	defer commands.assertDrained()
+	commands.expect("losetup", "-a").respond("/dev/loop0: []: (/var/lib/lxc-btrfs.img)", nil)
+	m := looputil.NewTestLoopDeviceManager(commands.run, nil, nil)
+	err := m.DetachLoopDevices("", "")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 type mockFileInfo struct {
 	os.FileInfo
 	inode uint64


### PR DESCRIPTION
Originally the bug was easier to reproduce just by adding a loop device,
as described in http://pad.lv/1587345. That changed, so now the same
error can be triggered by explicitly adding a failing test (first commit).

When parsing the output of `losetup -a` to get all attached loop devices,
the used regular expression required an inode to be present on each line.

It looks like showing the inodes is a privileged information, because:

```
$ losetup -a
/dev/loop0: []: (/var/lib/snapd/snaps/ubuntu-core_122.snap)
$ sudo losetup -a
[sudo] password for dimitern: 
/dev/loop0: [2049]:2360184 (/var/lib/snapd/snaps/ubuntu-core_122.snap)
```
That `[]:` caused the parse error. With this fix (second commit), the
added test LoopUtilSuite.TestDetachLoopDevicesListEmptyInodeOK now
passes OK.

So QA steps:
1. fetch and switch to this PR's branch.
2. git checkout HEAD~       # move to the first commit
3. cd $GOPATH/src/github.com/juju/juju/storage/looputil
4. go test -check.v
5. expect failure with error like  "listing loop devices: cannot parse.."
6. git checkout dimitern/lp-1587345-provisioner-storage-loopdev       # move to the second commit with the fix
7. go test -check.v
8. expect all tests to pass

(Review request: http://reviews.vapour.ws/r/5459/)