### PR TITLE
 provider/maas: remove MTU option from the bridge (backport)

### DIFF
--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -15,6 +15,11 @@ import shutil
 import subprocess
 import sys
 
+# These options are to be removed from a sub-interface and applied to
+# the new bridged interface.
+
+BRIDGE_ONLY_OPTIONS = {'address', 'gateway', 'netmask', 'dns-nameservers', 'dns-search', 'dns-sortlist'}
+
 
 class SeekableIterator(object):
     """An iterator that supports relative seeking."""
@@ -69,72 +74,93 @@ class LogicalInterface(object):
         self.is_vlan = [x for x in self.options if x.startswith("vlan-raw-device")]
         self.is_active = self.method == "dhcp" or self.method == "static"
         self.is_bridged = [x for x in self.options if x.startswith("bridge_ports ")]
+        self.has_auto_stanza = None
+        self.parent = None
 
     def __str__(self):
         return self.name
 
+    @classmethod
+    def prune_options(cls, options, invalid_options):
+        result = []
+        for o in options:
+            words = o.split()
+            if words[0] not in invalid_options:
+                result.append(o)
+        return result
+
     # Returns an ordered set of stanzas to bridge this interface.
-    def bridge(self, prefix, bridge_name, add_auto_stanza):
+    def bridge(self, prefix, bridge_name):
         if bridge_name is None:
             bridge_name = prefix + self.name
         # Note: the testing order here is significant.
         if not self.is_active or self.is_bridged:
-            return self._bridge_unchanged(add_auto_stanza)
+            return self._bridge_unchanged()
         elif self.is_alias:
-            return self._bridge_alias(add_auto_stanza)
+            if self.parent and self.parent.iface and (not self.parent.iface.is_active or self.parent.iface.is_bridged):
+                # if we didn't change the parent interface
+                # then we don't change the aliases neither.
+                return self._bridge_unchanged()
+            else:
+                return self._bridge_alias(bridge_name)
         elif self.is_vlan:
-            return self._bridge_vlan(prefix, bridge_name, add_auto_stanza)
+            return self._bridge_vlan(bridge_name)
         elif self.is_bonded:
-            return self._bridge_bond(prefix, bridge_name, add_auto_stanza)
+            return self._bridge_bond(bridge_name)
         else:
-            return self._bridge_device(prefix, bridge_name)
+            return self._bridge_device(bridge_name)
 
-    def _bridge_device(self, prefix, bridge_name):
-        s1 = IfaceStanza(self.name, self.family, "manual", [])
-        s2 = AutoStanza(bridge_name)
+    def _bridge_device(self, bridge_name):
+        stanzas = []
+        if self.has_auto_stanza:
+            stanzas.append(AutoStanza(self.name))
+        options = self.prune_options(self.options, BRIDGE_ONLY_OPTIONS)
+        stanzas.append(IfaceStanza(self.name, self.family, "manual", options))
+        stanzas.append(AutoStanza(bridge_name))
         options = list(self.options)
         options.append("bridge_ports {}".format(self.name))
-        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
-        return [s1, s2, s3]
+        options = self.prune_options(options, ['mtu'])
+        stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
+        return stanzas
 
-    def _bridge_vlan(self, prefix, bridge_name, add_auto_stanza):
+    def _bridge_vlan(self, bridge_name):
         stanzas = []
-        s1 = IfaceStanza(self.name, self.family, "manual", self.options)
-        stanzas.append(s1)
-        if add_auto_stanza:
+        if self.has_auto_stanza:
+            stanzas.append(AutoStanza(self.name))
+        options = self.prune_options(self.options, BRIDGE_ONLY_OPTIONS)
+        stanzas.append(IfaceStanza(self.name, self.family, "manual", options))
+        stanzas.append(AutoStanza(bridge_name))
+        options = list(self.options)
+        options.append("bridge_ports {}".format(self.name))
+        options = self.prune_options(options, ['mtu', 'vlan_id', 'vlan-raw-device'])
+        stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
+        return stanzas
+
+    def _bridge_alias(self, bridge_name):
+        stanzas = []
+        if self.has_auto_stanza:
             stanzas.append(AutoStanza(bridge_name))
-        options = [x for x in self.options if not x.startswith("vlan")]
-        options.append("bridge_ports {}".format(self.name))
-        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
-        stanzas.append(s3)
+        stanzas.append(IfaceStanza(bridge_name, self.family, self.method, list(self.options)))
         return stanzas
 
-    def _bridge_alias(self, add_auto_stanza):
+    def _bridge_bond(self, bridge_name):
         stanzas = []
-        if add_auto_stanza:
+        if self.has_auto_stanza:
             stanzas.append(AutoStanza(self.name))
-        s1 = IfaceStanza(self.name, self.family, self.method, list(self.options))
-        stanzas.append(s1)
-        return stanzas
-
-    def _bridge_bond(self, prefix, bridge_name, add_auto_stanza):
-        stanzas = []
-        if add_auto_stanza:
-            stanzas.append(AutoStanza(self.name))
-        s1 = IfaceStanza(self.name, self.family, "manual", list(self.options))
-        s2 = AutoStanza(bridge_name)
+        options = self.prune_options(self.options, BRIDGE_ONLY_OPTIONS)
+        stanzas.append(IfaceStanza(self.name, self.family, "manual", options))
+        stanzas.append(AutoStanza(bridge_name))
         options = [x for x in self.options if not x.startswith("bond")]
+        options = self.prune_options(options, ['mtu'])
         options.append("bridge_ports {}".format(self.name))
-        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
-        stanzas.extend([s1, s2, s3])
+        stanzas.append(IfaceStanza(bridge_name, self.family, self.method, options))
         return stanzas
 
-    def _bridge_unchanged(self, add_auto_stanza):
+    def _bridge_unchanged(self):
         stanzas = []
-        if add_auto_stanza:
+        if self.has_auto_stanza:
             stanzas.append(AutoStanza(self.name))
-        s1 = IfaceStanza(self.name, self.family, self.method, list(self.options))
-        stanzas.append(s1)
+        stanzas.append(IfaceStanza(self.name, self.family, self.method, list(self.options)))
         return stanzas
 
 
@@ -175,6 +201,13 @@ class NetworkInterfaceParser(object):
             if self.is_stanza(line):
                 stanza = self._parse_stanza(line, line_iterator)
                 self._stanzas.append(stanza)
+        physical_interfaces = self._physical_interfaces()
+        for s in self._stanzas:
+            if not s.is_logical_interface:
+                continue
+            s.iface.has_auto_stanza = s.iface.name in physical_interfaces
+
+        self._connect_aliases()
 
     def _parse_stanza(self, stanza_line, iterable):
         stanza_options = []
@@ -191,7 +224,25 @@ class NetworkInterfaceParser(object):
     def stanzas(self):
         return [x for x in self._stanzas]
 
-    def physical_interfaces(self):
+    def _connect_aliases(self):
+        """Set a reference in the alias interfaces to its related interface"""
+        ifaces = {}
+        aliases = []
+        for stanza in self._stanzas:
+            if stanza.iface is None:
+                continue
+
+            if stanza.iface.is_alias:
+                aliases.append(stanza)
+            else:
+                ifaces[stanza.iface.name] = stanza
+
+        for alias in aliases:
+            parent_name = alias.iface.name.split(':')[0]
+            if parent_name in ifaces:
+                alias.iface.parent = ifaces[parent_name]
+
+    def _physical_interfaces(self):
         return {x.phy.name: x.phy for x in [y for y in self._stanzas if y.is_physical_interface]}
 
     def __iter__(self):  # class iter
@@ -315,7 +366,6 @@ def main(args):
 
     stanzas = []
     config_parser = NetworkInterfaceParser(args.filename)
-    physical_interfaces = config_parser.physical_interfaces()
 
     # Bridging requires modifying 'auto' and 'iface' stanzas only.
     # Calling <iface>.bridge() will return a set of stanzas that cover
@@ -327,13 +377,12 @@ def main(args):
 
     for s in config_parser.stanzas():
         if s.is_logical_interface:
-            add_auto_stanza = s.iface.name in physical_interfaces
             if args.interface_to_bridge and args.interface_to_bridge != s.iface.name:
-                if add_auto_stanza:
+                if s.iface.has_auto_stanza:
                     stanzas.append(AutoStanza(s.iface.name))
                 stanzas.append(s)
             else:
-                stanzas.extend(s.iface.bridge(args.bridge_prefix, args.bridge_name, add_auto_stanza))
+                stanzas.extend(s.iface.bridge(args.bridge_prefix, args.bridge_name))
         elif not s.is_physical_interface:
             stanzas.append(s)
 

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -101,7 +101,7 @@ func (s *bridgeConfigSuite) TestBridgeScriptWithPrefixTransformation(c *gc.C) {
 		prefix   string
 	}{
 		{networkDHCPInitial, networkDHCPExpected, "test-br-"},
-		{networkDHCPWithAliasInitial, networkDHCPWithAliasExpected, "test-br-"},
+		{networkStaticWithAliasInitial, networkStaticWithAliasExpected, "test-br-"},
 		{networkDHCPWithBondInitial, networkDHCPWithBondExpected, "test-br-"},
 		{networkDualNICInitial, networkDualNICExpected, "test-br-"},
 		{networkMultipleAliasesInitial, networkMultipleAliasesExpected, "test-br-"},
@@ -210,6 +210,7 @@ iface eth0 inet static
 const networkStaticExpected = `auto lo
 iface lo inet loopback
 
+auto eth0
 iface eth0 inet manual
 
 auto test-br-eth0
@@ -228,6 +229,7 @@ iface eth0 inet dhcp`
 const networkDHCPExpected = `auto lo
 iface lo inet loopback
 
+auto eth0
 iface eth0 inet manual
 
 auto test-br-eth0
@@ -252,6 +254,7 @@ iface eth1 inet static
 const networkDualNICExpected = `auto lo
 iface lo inet loopback
 
+auto eth0
 iface eth0 inet manual
 
 auto test-br-eth0
@@ -261,6 +264,7 @@ iface test-br-eth0 inet static
     gateway 4.3.2.1
     bridge_ports eth0
 
+auto eth1
 iface eth1 inet manual
 
 auto test-br-eth1
@@ -286,6 +290,7 @@ iface eth0:1 inet static
 const networkWithAliasExpected = `auto lo
 iface lo inet loopback
 
+auto eth0
 iface eth0 inet manual
 
 auto test-br-eth0
@@ -295,11 +300,11 @@ iface test-br-eth0 inet static
     gateway 4.3.2.1
     bridge_ports eth0
 
-auto eth0:1
-iface eth0:1 inet static
+auto test-br-eth0:1
+iface test-br-eth0:1 inet static
     address 1.2.3.5`
 
-const networkDHCPWithAliasInitial = `auto lo
+const networkStaticWithAliasInitial = `auto lo
 iface lo inet loopback
 
 auto eth0
@@ -317,9 +322,10 @@ iface eth0:2 inet static
 
 dns-nameserver 192.168.1.142`
 
-const networkDHCPWithAliasExpected = `auto lo
+const networkStaticWithAliasExpected = `auto lo
 iface lo inet loopback
 
+auto eth0
 iface eth0 inet manual
 
 auto test-br-eth0
@@ -328,12 +334,12 @@ iface test-br-eth0 inet static
     address 10.14.0.102/24
     bridge_ports eth0
 
-auto eth0:1
-iface eth0:1 inet static
+auto test-br-eth0:1
+iface test-br-eth0:1 inet static
     address 10.14.0.103/24
 
-auto eth0:2
-iface eth0:2 inet static
+auto test-br-eth0:2
+iface test-br-eth0:2 inet static
     address 10.14.0.100/24
     dns-nameserver 192.168.1.142`
 
@@ -356,17 +362,18 @@ iface eth1 inet manual
 dns-nameservers 10.17.20.200
 dns-search maas`
 
-const networkMultipleStaticWithAliasesExpected = `iface eth0 inet manual
+const networkMultipleStaticWithAliasesExpected = `auto eth0
+iface eth0 inet manual
+    mtu 1500
 
 auto test-br-eth0
 iface test-br-eth0 inet static
     gateway 10.17.20.1
     address 10.17.20.201/24
-    mtu 1500
     bridge_ports eth0
 
-auto eth0:1
-iface eth0:1 inet static
+auto test-br-eth0:1
+iface test-br-eth0:1 inet static
     address 10.17.20.202/24
     mtu 1500
 
@@ -434,12 +441,9 @@ iface bond0 inet manual
     bond-mode active-backup
     hwaddress 52:54:00:1c:f1:5b
     bond-slaves none
-    dns-nameservers 10.17.20.200
-    dns-search maas19
 
 auto test-br-bond0
 iface test-br-bond0 inet dhcp
-    mtu 1500
     hwaddress 52:54:00:1c:f1:5b
     bridge_ports bond0
     dns-nameservers 10.17.20.200
@@ -470,34 +474,37 @@ iface eth10:2 inet static
 dns-nameservers 10.17.20.200
 dns-search maas19`
 
-const networkMultipleAliasesExpected = `iface eth0 inet manual
+const networkMultipleAliasesExpected = `auto eth0
+iface eth0 inet manual
 
 auto test-br-eth0
 iface test-br-eth0 inet dhcp
     bridge_ports eth0
 
+auto eth1
 iface eth1 inet manual
 
 auto test-br-eth1
 iface test-br-eth1 inet dhcp
     bridge_ports eth1
 
+auto eth10
 iface eth10 inet manual
+    mtu 1500
 
 auto test-br-eth10
 iface test-br-eth10 inet static
     gateway 10.17.20.1
     address 10.17.20.201/24
-    mtu 1500
     bridge_ports eth10
 
-auto eth10:1
-iface eth10:1 inet static
+auto test-br-eth10:1
+iface test-br-eth10:1 inet static
     address 10.17.20.202/24
     mtu 1500
 
-auto eth10:2
-iface eth10:2 inet static
+auto test-br-eth10:2
+iface test-br-eth10:2 inet static
     address 10.17.20.203/24
     mtu 1500
     dns-nameservers 10.17.20.200
@@ -634,53 +641,54 @@ iface eth3 inet manual
     mtu 1500
     bond-mode active-backup
 
+auto eth4
 iface eth4 inet manual
+    mtu 1500
 
 auto juju-br-eth4
 iface juju-br-eth4 inet static
     address 10.17.20.202/24
-    mtu 1500
     bridge_ports eth4
 
+auto eth5
 iface eth5 inet manual
+    mtu 1500
 
 auto juju-br-eth5
 iface juju-br-eth5 inet dhcp
-    mtu 1500
     bridge_ports eth5
 
+auto eth6
 iface eth6 inet manual
+    mtu 1500
 
 auto juju-br-eth6
 iface juju-br-eth6 inet static
     address 10.17.20.203/24
-    mtu 1500
     bridge_ports eth6
 
-auto eth6:1
-iface eth6:1 inet static
+auto juju-br-eth6:1
+iface juju-br-eth6:1 inet static
     address 10.17.20.205/24
     mtu 1500
 
-auto eth6:2
-iface eth6:2 inet static
+auto juju-br-eth6:2
+iface juju-br-eth6:2 inet static
     address 10.17.20.204/24
     mtu 1500
 
-auto eth6:3
-iface eth6:3 inet static
+auto juju-br-eth6:3
+iface juju-br-eth6:3 inet static
     address 10.17.20.206/24
     mtu 1500
 
-auto eth6:4
-iface eth6:4 inet static
+auto juju-br-eth6:4
+iface juju-br-eth6:4 inet static
     address 10.17.20.207/24
     mtu 1500
 
 auto bond0
 iface bond0 inet manual
-    gateway 10.17.20.1
-    address 10.17.20.201/24
     bond-lacp_rate slow
     bond-xmit_hash_policy layer2
     bond-miimon 100
@@ -693,7 +701,6 @@ auto juju-br-bond0
 iface juju-br-bond0 inet static
     gateway 10.17.20.1
     address 10.17.20.201/24
-    mtu 1500
     hwaddress 52:54:00:6a:4f:fd
     bridge_ports bond0
 
@@ -706,12 +713,9 @@ iface bond1 inet manual
     bond-mode active-backup
     hwaddress 52:54:00:8e:6e:b0
     bond-slaves none
-    dns-nameservers 10.17.20.200
-    dns-search maas19
 
 auto juju-br-bond1
 iface juju-br-bond1 inet dhcp
-    mtu 1500
     hwaddress 52:54:00:8e:6e:b0
     bridge_ports bond1
     dns-nameservers 10.17.20.200
@@ -744,21 +748,22 @@ iface eth1.3 inet static
 dns-nameservers 10.17.20.200
 dns-search maas19`
 
-const networkVLANExpected = `iface eth0 inet manual
+const networkVLANExpected = `auto eth0
+iface eth0 inet manual
+    mtu 1500
 
 auto vlan-br-eth0
 iface vlan-br-eth0 inet static
     gateway 10.17.20.1
     address 10.17.20.212/24
-    mtu 1500
     bridge_ports eth0
 
 auto eth1
 iface eth1 inet manual
     mtu 1500
 
+auto eth0.2
 iface eth0.2 inet manual
-    address 192.168.2.3/24
     vlan-raw-device eth0
     mtu 1500
     vlan_id 2
@@ -766,21 +771,17 @@ iface eth0.2 inet manual
 auto vlan-br-eth0.2
 iface vlan-br-eth0.2 inet static
     address 192.168.2.3/24
-    mtu 1500
     bridge_ports eth0.2
 
+auto eth1.3
 iface eth1.3 inet manual
-    address 192.168.3.3/24
     vlan-raw-device eth1
     mtu 1500
     vlan_id 3
-    dns-nameservers 10.17.20.200
-    dns-search maas19
 
 auto vlan-br-eth1.3
 iface vlan-br-eth1.3 inet static
     address 192.168.3.3/24
-    mtu 1500
     bridge_ports eth1.3
     dns-nameservers 10.17.20.200
     dns-search maas19`
@@ -839,13 +840,14 @@ iface eth1.2670 inet static
 dns-nameservers 10.245.168.2
 dns-search dellstack`
 
-const networkVLANWithMultipleNameserversExpected = `iface eth0 inet manual
+const networkVLANWithMultipleNameserversExpected = `auto eth0
+iface eth0 inet manual
+    mtu 1500
 
 auto br-eth0
 iface br-eth0 inet static
     gateway 10.245.168.1
     address 10.245.168.11/21
-    mtu 1500
     bridge_ports eth0
     dns-nameservers 10.245.168.2
 
@@ -861,60 +863,51 @@ auto eth3
 iface eth3 inet manual
     mtu 1500
 
+auto eth1.2667
 iface eth1.2667 inet manual
-    address 10.245.184.2/24
     vlan-raw-device eth1
     mtu 1500
     vlan_id 2667
-    dns-nameservers 10.245.168.2
 
 auto br-eth1.2667
 iface br-eth1.2667 inet static
     address 10.245.184.2/24
-    mtu 1500
     bridge_ports eth1.2667
     dns-nameservers 10.245.168.2
 
+auto eth1.2668
 iface eth1.2668 inet manual
-    address 10.245.185.1/24
     vlan-raw-device eth1
     mtu 1500
     vlan_id 2668
-    dns-nameservers 10.245.168.2
 
 auto br-eth1.2668
 iface br-eth1.2668 inet static
     address 10.245.185.1/24
-    mtu 1500
     bridge_ports eth1.2668
     dns-nameservers 10.245.168.2
 
+auto eth1.2669
 iface eth1.2669 inet manual
-    address 10.245.186.1/24
     vlan-raw-device eth1
     mtu 1500
     vlan_id 2669
-    dns-nameservers 10.245.168.2
 
 auto br-eth1.2669
 iface br-eth1.2669 inet static
     address 10.245.186.1/24
-    mtu 1500
     bridge_ports eth1.2669
     dns-nameservers 10.245.168.2
 
+auto eth1.2670
 iface eth1.2670 inet manual
-    address 10.245.187.2/24
     vlan-raw-device eth1
     mtu 1500
     vlan_id 2670
-    dns-nameservers 10.245.168.2
-    dns-search dellstack
 
 auto br-eth1.2670
 iface br-eth1.2670 inet static
     address 10.245.187.2/24
-    mtu 1500
     bridge_ports eth1.2670
     dns-nameservers 10.245.168.2
     dns-search dellstack`
@@ -993,8 +986,6 @@ iface eth1 inet manual
 
 auto bond0
 iface bond0 inet manual
-    address 10.17.20.211/24
-    gateway 10.17.20.1
     bond-slaves none
     bond-mode active-backup
     bond-xmit_hash_policy layer2
@@ -1002,19 +993,17 @@ iface bond0 inet manual
     mtu 1500
     hwaddress 52:54:00:1c:f1:5b
     bond-lacp_rate slow
-    dns-nameservers 10.17.20.200
 
 auto br-bond0
 iface br-bond0 inet static
     address 10.17.20.211/24
     gateway 10.17.20.1
-    mtu 1500
     hwaddress 52:54:00:1c:f1:5b
     bridge_ports bond0
     dns-nameservers 10.17.20.200
 
+auto bond0.2
 iface bond0.2 inet manual
-    address 192.168.2.102/24
     vlan-raw-device bond0
     mtu 1500
     vlan_id 2
@@ -1022,21 +1011,17 @@ iface bond0.2 inet manual
 auto br-bond0.2
 iface br-bond0.2 inet static
     address 192.168.2.102/24
-    mtu 1500
     bridge_ports bond0.2
 
+auto bond0.3
 iface bond0.3 inet manual
-    address 192.168.3.101/24
     vlan-raw-device bond0
     mtu 1500
     vlan_id 3
-    dns-nameservers 10.17.20.200
-    dns-search maas19
 
 auto br-bond0.3
 iface br-bond0.3 inet static
     address 192.168.3.101/24
-    mtu 1500
     bridge_ports bond0.3
     dns-nameservers 10.17.20.200
     dns-search maas19`
@@ -1062,13 +1047,14 @@ dns-nameservers 10.17.20.200
 dns-search maas19
 `
 
-const networkVLANWithInactiveDeviceExpected = `iface eth0 inet manual
+const networkVLANWithInactiveDeviceExpected = `auto eth0
+iface eth0 inet manual
+    mtu 1500
 
 auto br-eth0
 iface br-eth0 inet static
     gateway 10.17.20.1
     address 10.17.20.211/24
-    mtu 1500
     bridge_ports eth0
     dns-nameservers 10.17.20.200
 
@@ -1076,16 +1062,14 @@ auto eth1
 iface eth1 inet manual
     mtu 1500
 
+auto eth1.2
 iface eth1.2 inet manual
     vlan-raw-device eth1
     mtu 1500
     vlan_id 2
-    dns-nameservers 10.17.20.200
-    dns-search maas19
 
 auto br-eth1.2
 iface br-eth1.2 inet dhcp
-    mtu 1500
     bridge_ports eth1.2
     dns-nameservers 10.17.20.200
     dns-search maas19`
@@ -1111,33 +1095,33 @@ dns-nameservers 10.17.20.200
 dns-search maas19
 `
 
-const networkVLANWithActiveDHCPDeviceExpected = `iface eth0 inet manual
+const networkVLANWithActiveDHCPDeviceExpected = `auto eth0
+iface eth0 inet manual
+    mtu 1500
 
 auto br-eth0
 iface br-eth0 inet static
     gateway 10.17.20.1
     address 10.17.20.211/24
-    mtu 1500
     bridge_ports eth0
     dns-nameservers 10.17.20.200
 
+auto eth1
 iface eth1 inet manual
+    mtu 1500
 
 auto br-eth1
 iface br-eth1 inet dhcp
-    mtu 1500
     bridge_ports eth1
 
+auto eth1.2
 iface eth1.2 inet manual
     vlan-raw-device eth1
     mtu 1500
     vlan_id 2
-    dns-nameservers 10.17.20.200
-    dns-search maas19
 
 auto br-eth1.2
 iface br-eth1.2 inet dhcp
-    mtu 1500
     bridge_ports eth1.2
     dns-nameservers 10.17.20.200
     dns-search maas19`
@@ -1182,43 +1166,47 @@ iface eth3 inet static
 dns-search ubuntu juju
 dns-search dellstack ubuntu dellstack`
 
-const networkWithMultipleDNSValuesExpected = `iface eth0 inet manual
+const networkWithMultipleDNSValuesExpected = `auto eth0
+iface eth0 inet manual
+    mtu 1500
 
 auto br-eth0
 iface br-eth0 inet static
     gateway 10.245.168.1
     address 10.245.168.11/21
-    mtu 1500
     bridge_ports eth0
     dns-nameservers 10.245.168.2 192.168.1.1
 
+auto eth1
 iface eth1 inet manual
+    mtu 1500
 
 auto br-eth1
 iface br-eth1 inet static
     gateway 10.245.168.1
     address 10.245.168.12/21
-    mtu 1500
     bridge_ports eth1
     dns-sortlist 192.168.1.0/24 10.245.168.0/21
 
+auto eth2
 iface eth2 inet manual
+    mtu 1500
 
 auto br-eth2
 iface br-eth2 inet static
     gateway 10.245.168.1
     address 10.245.168.13/21
-    mtu 1500
     bridge_ports eth2
     dns-search juju ubuntu dellstack
 
+auto eth3
 iface eth3 inet manual
+    mtu 1500
 
 auto br-eth3
 iface br-eth3 inet static
     gateway 10.245.168.1
     address 10.245.168.14/21
-    mtu 1500
     bridge_ports eth3
     dns-nameservers 192.168.1.1 10.245.168.2
     dns-search juju ubuntu dellstack
@@ -1246,22 +1234,24 @@ dns-nameservers
 dns-search
 dns-sortlist`
 
-const networkWithEmptyDNSValuesExpected = `iface eth0 inet manual
+const networkWithEmptyDNSValuesExpected = `auto eth0
+iface eth0 inet manual
+    mtu 1500
 
 auto br-eth0
 iface br-eth0 inet static
     gateway 10.245.168.1
     address 10.245.168.11/21
-    mtu 1500
     bridge_ports eth0
 
+auto eth1
 iface eth1 inet manual
+    mtu 1500
 
 auto br-eth1
 iface br-eth1 inet static
     gateway 10.245.168.1
     address 10.245.168.12/21
-    mtu 1500
     bridge_ports eth1`
 
 const networkLP1532167Initial = `auto eth0
@@ -1412,8 +1402,6 @@ iface eth3 inet manual
 
 auto bond0
 iface bond0 inet manual
-    gateway 10.38.160.1
-    address 10.38.160.24/24
     bond-lacp_rate fast
     bond-xmit_hash_policy layer2+3
     bond-miimon 100
@@ -1426,7 +1414,6 @@ auto juju-br0
 iface juju-br0 inet static
     gateway 10.38.160.1
     address 10.38.160.24/24
-    mtu 1500
     hwaddress 44:a8:42:41:ab:37
     bridge_ports bond0
 
@@ -1552,6 +1539,7 @@ iface br-eth0 inet static
     gateway 4.3.2.1
     bridge_ports eth0
 
+auto eth1
 iface eth1 inet manual
 
 auto br-eth1


### PR DESCRIPTION
Backport of PR #5791.

The MTU statement must be on the interface to work and not on the bridge
itself; bridges inherit the lowest MTU of all sub-interfaces. Further to
this, ifupdown seems to bug out and always fails to add the default
route when an MTU is set on the bridge. Leaving the MTU option on the
bridge completely breaks the network on reboot.

This commit also removes:

address
gateway
netmask
dns-nameservers
dns-search
dns-sortlist

from the sub-interfaces, leaving them on the bridge interface only.

(Review request: http://reviews.vapour.ws/r/5460/)