### PR TITLE
Expose max-log-size and max-log-age as controller configuration.

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -939,8 +939,13 @@ func (a *MachineAgent) startStateWorkers(st *state.State) (worker.Worker, error)
 				return newCertificateUpdater(m, agentConfig, st, st, stateServingSetter), nil
 			})
 
+			controllerCfg, err := st.ControllerConfig()
+			if err != nil {
+				return nil, errors.Annotate(err, "could not retrieve the controller config.")
+			}
+
 			a.startWorkerAfterUpgrade(singularRunner, "dblogpruner", func() (worker.Worker, error) {
-				return dblogpruner.New(st, dblogpruner.NewLogPruneParams()), nil
+				return dblogpruner.New(st, dblogpruner.NewLogPruneParams(controllerCfg)), nil
 			})
 
 			a.startWorkerAfterUpgrade(singularRunner, "txnpruner", func() (worker.Worker, error) {

--- a/controller/config.go
+++ b/controller/config.go
@@ -58,6 +58,21 @@ const (
 
 	// DefaultApiPort is the default port the API server is listening on.
 	DefaultAPIPort int = 17070
+
+	// DefaultMaxLogSize is the default max size in GB of the logs collections
+	DefaultMaxLogSize int = 4
+
+	// DefaultMaxLogAge is the default max retention period in days for
+	// the logs collection.
+	DefaultMaxLogAge int = 3
+
+	// MaxLogAgeKey defines the maximum amount of days for log retention
+	// this value is considered by the dblogpruner worker.
+	MaxLogAgeKey = "max-log-age"
+
+	// MaxLogSizeKey defines the maximun size of the logs collection
+	// in GB, this value is considered by the dblogpruner worker.
+	MaxLogSizeKey = "max-log-size"
 )
 
 // ControllerOnlyConfigAttributes are attributes which are only relevant
@@ -70,6 +85,8 @@ var ControllerOnlyConfigAttributes = []string{
 	IdentityURL,
 	IdentityPublicKey,
 	SetNumaControlPolicyKey,
+	MaxLogAgeKey,
+	MaxLogSizeKey,
 }
 
 // ControllerOnlyAttribute returns true if the specified attribute name
@@ -195,6 +212,24 @@ func (c Config) IdentityPublicKey() *bakery.PublicKey {
 	return &pubKey
 }
 
+// MaxLogSize returns the maximun size of the logs collection
+// in GB, this value is considered by the dblogpruner worker.
+func (c Config) MaxLogSize() int {
+	if logSize, ok := c[MaxLogSizeKey]; ok {
+		return logSize.(int)
+	}
+	return DefaultMaxLogSize
+}
+
+// MaxLogAge returns the maximum retention period of time in days
+// for the logs collection, this value is considered by the dblogpruner.
+func (c Config) MaxLogAge() int {
+	if logAge, ok := c[MaxLogAgeKey]; ok {
+		return logAge.(int)
+	}
+	return DefaultMaxLogAge
+}
+
 // NumaCtlPreference returns if numactl is preferred.
 func (c Config) NumaCtlPreference() bool {
 	if numa, ok := c[SetNumaControlPolicyKey]; ok {
@@ -251,6 +286,8 @@ var configChecker = schema.FieldMap(schema.Fields{
 	IdentityURL:             schema.String(),
 	IdentityPublicKey:       schema.String(),
 	SetNumaControlPolicyKey: schema.Bool(),
+	MaxLogAgeKey:            schema.ForceInt(),
+	MaxLogSizeKey:           schema.ForceInt(),
 }, schema.Defaults{
 	ApiPort:                 DefaultAPIPort,
 	AuditingEnabled:         DefaultAuditingEnabled,
@@ -258,4 +295,6 @@ var configChecker = schema.FieldMap(schema.Fields{
 	IdentityURL:             schema.Omit,
 	IdentityPublicKey:       schema.Omit,
 	SetNumaControlPolicyKey: DefaultNumaControlPolicy,
+	MaxLogAgeKey:            DefaultMaxLogAge,
+	MaxLogSizeKey:           DefaultMaxLogSize,
 })

--- a/state/logs.go
+++ b/state/logs.go
@@ -665,6 +665,8 @@ func PruneLogs(st MongoSessioner, minLogTime time.Time, maxLogsMB int) error {
 
 	pruneCounts := make(map[string]int)
 
+	logger.Tracef("prunning logs with min-log-time=%s, max-log-size=%d MB", minLogTime.String(), maxLogsMB)
+
 	// Remove old log entries (per model UUID to take advantage
 	// of indexes on the logs collection).
 	for _, modelUUID := range modelUUIDs {

--- a/worker/dblogpruner/worker.go
+++ b/worker/dblogpruner/worker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/tomb.v1"
 
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker"
 )
@@ -20,16 +21,14 @@ type LogPruneParams struct {
 	PruneInterval   time.Duration
 }
 
-const DefaultMaxLogAge = 3 * 24 * time.Hour // 3 days
-const DefaultMaxCollectionMB = 4 * 1024     // 4 GB
 const DefaultPruneInterval = 5 * time.Minute
 
 // NewLogPruneParams returns a LogPruneParams initialised with default
 // values.
-func NewLogPruneParams() *LogPruneParams {
+func NewLogPruneParams(cfg controller.Config) *LogPruneParams {
 	return &LogPruneParams{
-		MaxLogAge:       DefaultMaxLogAge,
-		MaxCollectionMB: DefaultMaxCollectionMB,
+		MaxLogAge:       time.Duration(cfg.MaxLogAge()*24) * time.Hour, // Max log age in hours
+		MaxCollectionMB: cfg.MaxLogSize() * 1024,                       // Max log size in MB
 		PruneInterval:   DefaultPruneInterval,
 	}
 }

--- a/worker/dblogpruner/worker_test.go
+++ b/worker/dblogpruner/worker_test.go
@@ -52,6 +52,30 @@ func (s *suite) StartWorker(c *gc.C, maxLogAge time.Duration, maxCollectionMB in
 	})
 }
 
+func (s *suite) TestDefaultLogPruneParams(c *gc.C) {
+	cfg, _ := s.State.ControllerConfig()
+	c.Assert(dblogpruner.NewLogPruneParams(cfg), gc.DeepEquals, &dblogpruner.LogPruneParams{
+		time.Duration(3*24) * time.Hour,
+		4 * 1024,
+		time.Duration(dblogpruner.DefaultPruneInterval),
+	})
+}
+
+func (s *suite) TestUserDefinedLogPruneParams(c *gc.C) {
+	maxLogAge := 8    // 8 days
+	maxLogSize := 100 // 100 GB
+
+	cfg := testing.FakeControllerConfig()
+	cfg["max-log-size"] = maxLogSize
+	cfg["max-log-age"] = maxLogAge
+
+	c.Assert(dblogpruner.NewLogPruneParams(cfg), gc.DeepEquals, &dblogpruner.LogPruneParams{
+		time.Duration(maxLogAge*24) * time.Hour,
+		maxLogSize * 1024,
+		time.Duration(dblogpruner.DefaultPruneInterval),
+	})
+}
+
 func (s *suite) TestPrunesOldLogs(c *gc.C) {
 	maxLogAge := 24 * time.Hour
 	noPruneMB := int(1e9)


### PR DESCRIPTION
This commit adds the max-log-size and max-log-age config
directives in the controller level.

Both config directives were previously declared as constant
variables defined on github.com/juju/juju/workers/dblogpruner.go.

The rationale for exposing those configuration options comes
by the fact that some users needs to adjust the logs retention time
to a value that is better suitable for the environment.

This commit fixes LP: #1566545

Signed-off-by: Jorge Niedbalski jnr@metaklass.org

(Review request: http://reviews.vapour.ws/r/5463/)
