### PR TITLE
Tighten up model migration API, struct and field names

### DIFF
--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -179,9 +179,9 @@ func (c *Client) modifyControllerUser(action params.ControllerAction, user, acce
 	return result.Combine()
 }
 
-// ModelMigrationSpec holds the details required to start the
-// migration of a single model.
-type ModelMigrationSpec struct {
+// MigrationSpec holds the details required to start the migration of
+// a single model.
+type MigrationSpec struct {
 	ModelUUID            string
 	TargetControllerUUID string
 	TargetAddrs          []string
@@ -192,7 +192,7 @@ type ModelMigrationSpec struct {
 
 // Validate performs sanity checks on the migration configuration it
 // holds.
-func (s *ModelMigrationSpec) Validate() error {
+func (s *MigrationSpec) Validate() error {
 	if !names.IsValidModel(s.ModelUUID) {
 		return errors.NotValidf("model UUID")
 	}
@@ -214,20 +214,20 @@ func (s *ModelMigrationSpec) Validate() error {
 	return nil
 }
 
-// InitiateModelMigration attempts to start a migration for the
-// specified model, returning the migration's ID.
+// InitiateMigration attempts to start a migration for the specified
+// model, returning the migration's ID.
 //
 // The API server supports starting multiple migrations in one request
 // but we don't need that at the client side yet (and may never) so
 // this call just supports starting one migration at a time.
-func (c *Client) InitiateModelMigration(spec ModelMigrationSpec) (string, error) {
+func (c *Client) InitiateMigration(spec MigrationSpec) (string, error) {
 	if err := spec.Validate(); err != nil {
 		return "", errors.Trace(err)
 	}
-	args := params.InitiateModelMigrationArgs{
-		Specs: []params.ModelMigrationSpec{{
+	args := params.InitiateMigrationArgs{
+		Specs: []params.MigrationSpec{{
 			ModelTag: names.NewModelTag(spec.ModelUUID).String(),
-			TargetInfo: params.ModelMigrationTargetInfo{
+			TargetInfo: params.MigrationTargetInfo{
 				ControllerTag: names.NewModelTag(spec.TargetControllerUUID).String(),
 				Addrs:         spec.TargetAddrs,
 				CACert:        spec.TargetCACert,
@@ -236,8 +236,8 @@ func (c *Client) InitiateModelMigration(spec ModelMigrationSpec) (string, error)
 			},
 		}},
 	}
-	response := params.InitiateModelMigrationResults{}
-	if err := c.facade.FacadeCall("InitiateModelMigration", args, &response); err != nil {
+	response := params.InitiateMigrationResults{}
+	if err := c.facade.FacadeCall("InitiateMigration", args, &response); err != nil {
 		return "", errors.Trace(err)
 	}
 	if len(response.Results) != 1 {

--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -261,14 +261,14 @@ func (s *controllerSuite) TestModelStatus(c *gc.C) {
 	}})
 }
 
-func (s *controllerSuite) TestInitiateModelMigration(c *gc.C) {
+func (s *controllerSuite) TestInitiateMigration(c *gc.C) {
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
 
-	_, err := st.LatestModelMigration()
+	_, err := st.LatestMigration()
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 
-	spec := controller.ModelMigrationSpec{
+	spec := controller.MigrationSpec{
 		ModelUUID:            st.ModelUUID(),
 		TargetControllerUUID: randomUUID(),
 		TargetAddrs:          []string{"1.2.3.4:5"},
@@ -279,19 +279,19 @@ func (s *controllerSuite) TestInitiateModelMigration(c *gc.C) {
 
 	sysManager := s.OpenAPI(c)
 	defer sysManager.Close()
-	id, err := sysManager.InitiateModelMigration(spec)
+	id, err := sysManager.InitiateMigration(spec)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedId := st.ModelUUID() + ":0"
 	c.Check(id, gc.Equals, expectedId)
 
 	// Check database.
-	mig, err := st.LatestModelMigration()
+	mig, err := st.LatestMigration()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(mig.Id(), gc.Equals, expectedId)
 }
 
-func (s *controllerSuite) TestInitiateModelMigrationError(c *gc.C) {
-	spec := controller.ModelMigrationSpec{
+func (s *controllerSuite) TestInitiateMigrationError(c *gc.C) {
+	spec := controller.MigrationSpec{
 		ModelUUID:            randomUUID(), // Model doesn't exist.
 		TargetControllerUUID: randomUUID(),
 		TargetAddrs:          []string{"1.2.3.4:5"},
@@ -302,7 +302,7 @@ func (s *controllerSuite) TestInitiateModelMigrationError(c *gc.C) {
 
 	sysManager := s.OpenAPI(c)
 	defer sysManager.Close()
-	id, err := sysManager.InitiateModelMigration(spec)
+	id, err := sysManager.InitiateMigration(spec)
 	c.Check(id, gc.Equals, "")
 	c.Check(err, gc.ErrorMatches, "unable to read model: .+")
 }

--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -156,13 +156,13 @@ func (c *Client) WatchMinionReports() (watcher.NotifyWatcher, error) {
 	return c.newWatcher(c.caller.RawAPICaller(), result), nil
 }
 
-// GetMinionReports returns details of the reports made by migration
+// MinionReports returns details of the reports made by migration
 // minions to the controller for the current migration phase.
-func (c *Client) GetMinionReports() (migration.MinionReports, error) {
+func (c *Client) MinionReports() (migration.MinionReports, error) {
 	var in params.MinionReports
 	var out migration.MinionReports
 
-	err := c.caller.FacadeCall("GetMinionReports", nil, &in)
+	err := c.caller.FacadeCall("MinionReports", nil, &in)
 	if err != nil {
 		return out, errors.Trace(err)
 	}

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -67,9 +67,9 @@ func (s *ClientSuite) TestGetMigrationStatus(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(_ string, _ int, _, _ string, _, result interface{}) error {
 		out := result.(*params.MasterMigrationStatus)
 		*out = params.MasterMigrationStatus{
-			Spec: params.ModelMigrationSpec{
+			Spec: params.MigrationSpec{
 				ModelTag: names.NewModelTag(modelUUID).String(),
-				TargetInfo: params.ModelMigrationTargetInfo{
+				TargetInfo: params.MigrationTargetInfo{
 					ControllerTag: names.NewModelTag(controllerUUID).String(),
 					Addrs:         []string{"2.2.2.2:2"},
 					CACert:        "cert",
@@ -245,7 +245,7 @@ func (s *ClientSuite) TestWatchMinionReportsError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
-func (s *ClientSuite) TestGetMinionReports(c *gc.C) {
+func (s *ClientSuite) TestMinionReports(c *gc.C) {
 	var stub jujutesting.Stub
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		stub.AddCall(objType+"."+request, id, arg)
@@ -269,10 +269,10 @@ func (s *ClientSuite) TestGetMinionReports(c *gc.C) {
 		return nil
 	})
 	client := migrationmaster.NewClient(apiCaller, nil)
-	out, err := client.GetMinionReports()
+	out, err := client.MinionReports()
 	c.Assert(err, jc.ErrorIsNil)
 	stub.CheckCalls(c, []jujutesting.StubCall{
-		{"MigrationMaster.GetMinionReports", []interface{}{"", nil}},
+		{"MigrationMaster.MinionReports", []interface{}{"", nil}},
 	})
 	c.Assert(out, gc.DeepEquals, migration.MinionReports{
 		MigrationId:         "id",
@@ -286,16 +286,16 @@ func (s *ClientSuite) TestGetMinionReports(c *gc.C) {
 	})
 }
 
-func (s *ClientSuite) TestGetMinionReportsFailedCall(c *gc.C) {
+func (s *ClientSuite) TestMinionReportsFailedCall(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(string, int, string, string, interface{}, interface{}) error {
 		return errors.New("blam")
 	})
 	client := migrationmaster.NewClient(apiCaller, nil)
-	_, err := client.GetMinionReports()
+	_, err := client.MinionReports()
 	c.Assert(err, gc.ErrorMatches, "blam")
 }
 
-func (s *ClientSuite) TestGetMinionReportsInvalidPhase(c *gc.C) {
+func (s *ClientSuite) TestMinionReportsInvalidPhase(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(_ string, _ int, _ string, _ string, _ interface{}, result interface{}) error {
 		out := result.(*params.MinionReports)
 		*out = params.MinionReports{
@@ -304,11 +304,11 @@ func (s *ClientSuite) TestGetMinionReportsInvalidPhase(c *gc.C) {
 		return nil
 	})
 	client := migrationmaster.NewClient(apiCaller, nil)
-	_, err := client.GetMinionReports()
+	_, err := client.MinionReports()
 	c.Assert(err, gc.ErrorMatches, `invalid phase: "BLARGH"`)
 }
 
-func (s *ClientSuite) TestGetMinionReportsBadUnknownTag(c *gc.C) {
+func (s *ClientSuite) TestMinionReportsBadUnknownTag(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(_ string, _ int, _ string, _ string, _ interface{}, result interface{}) error {
 		out := result.(*params.MinionReports)
 		*out = params.MinionReports{
@@ -318,11 +318,11 @@ func (s *ClientSuite) TestGetMinionReportsBadUnknownTag(c *gc.C) {
 		return nil
 	})
 	client := migrationmaster.NewClient(apiCaller, nil)
-	_, err := client.GetMinionReports()
+	_, err := client.MinionReports()
 	c.Assert(err, gc.ErrorMatches, `processing unknown agents: "carl" is not a valid tag`)
 }
 
-func (s *ClientSuite) TestGetMinionReportsBadFailedTag(c *gc.C) {
+func (s *ClientSuite) TestMinionReportsBadFailedTag(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(_ string, _ int, _ string, _ string, _ interface{}, result interface{}) error {
 		out := result.(*params.MinionReports)
 		*out = params.MinionReports{
@@ -332,6 +332,6 @@ func (s *ClientSuite) TestGetMinionReportsBadFailedTag(c *gc.C) {
 		return nil
 	})
 	client := migrationmaster.NewClient(apiCaller, nil)
-	_, err := client.GetMinionReports()
+	_, err := client.MinionReports()
 	c.Assert(err, gc.ErrorMatches, `processing failed agents: "dave" is not a valid tag`)
 }

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -320,7 +320,7 @@ func (s *migrationSuite) TestMigrationStatusWatcher(c *gc.C) {
 	assertChange("", migration.NONE)
 
 	// Now create a migration, should trigger watcher.
-	spec := state.ModelMigrationSpec{
+	spec := state.MigrationSpec{
 		InitiatedBy: names.NewUserTag("someone"),
 		TargetInfo: migration.TargetInfo{
 			ControllerTag: names.NewModelTag(utils.MustNewUUID().String()),
@@ -330,7 +330,7 @@ func (s *migrationSuite) TestMigrationStatusWatcher(c *gc.C) {
 			Password:      "sekret",
 		},
 	}
-	mig, err := hostedState.CreateModelMigration(spec)
+	mig, err := hostedState.CreateMigration(spec)
 	c.Assert(err, jc.ErrorIsNil)
 	assertChange(mig.Id(), migration.QUIESCE)
 
@@ -341,7 +341,7 @@ func (s *migrationSuite) TestMigrationStatusWatcher(c *gc.C) {
 	assertChange(mig.Id(), migration.ABORTDONE)
 
 	// Start a new migration, this should also trigger.
-	mig2, err := hostedState.CreateModelMigration(spec)
+	mig2, err := hostedState.CreateMigration(spec)
 	c.Assert(err, jc.ErrorIsNil)
 	assertChange(mig2.Id(), migration.QUIESCE)
 }

--- a/apiserver/client/backend.go
+++ b/apiserver/client/backend.go
@@ -65,7 +65,7 @@ type Backend interface {
 	Watch() *state.Multiwatcher
 	AbortCurrentUpgrade() error
 	APIHostPorts() ([][]network.HostPort, error)
-	LatestModelMigration() (state.ModelMigration, error)
+	LatestMigration() (state.ModelMigration, error)
 }
 
 func NewStateBackend(st *state.State) Backend {

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -321,7 +321,7 @@ func (c *Client) modelStatus() (params.ModelStatusInfo, error) {
 }
 
 func (c *Client) getMigrationStatus() (string, error) {
-	mig, err := c.api.stateAccessor.LatestModelMigration()
+	mig, err := c.api.stateAccessor.LatestMigration()
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return "", nil

--- a/apiserver/client/status_test.go
+++ b/apiserver/client/status_test.go
@@ -255,7 +255,7 @@ func (s *statusUnitTestSuite) TestMigrationInProgress(c *gc.C) {
 	checkMigStatus("")
 
 	// Start it migrating.
-	mig, err := state2.CreateModelMigration(state.ModelMigrationSpec{
+	mig, err := state2.CreateMigration(state.MigrationSpec{
 		InitiatedBy: names.NewUserTag("admin"),
 		TargetInfo: migration.TargetInfo{
 			ControllerTag: names.NewModelTag(utils.MustNewUUID().String()),

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -305,7 +305,7 @@ func (s *controllerSuite) TestModelStatus(c *gc.C) {
 	}})
 }
 
-func (s *controllerSuite) TestInitiateModelMigration(c *gc.C) {
+func (s *controllerSuite) TestInitiateMigration(c *gc.C) {
 	// Create two hosted models to migrate.
 	st1 := s.Factory.MakeModel(c, nil)
 	defer st1.Close()
@@ -314,11 +314,11 @@ func (s *controllerSuite) TestInitiateModelMigration(c *gc.C) {
 	defer st2.Close()
 
 	// Kick off the migration.
-	args := params.InitiateModelMigrationArgs{
-		Specs: []params.ModelMigrationSpec{
+	args := params.InitiateMigrationArgs{
+		Specs: []params.MigrationSpec{
 			{
 				ModelTag: st1.ModelTag().String(),
-				TargetInfo: params.ModelMigrationTargetInfo{
+				TargetInfo: params.MigrationTargetInfo{
 					ControllerTag: randomModelTag(),
 					Addrs:         []string{"1.1.1.1:1111", "2.2.2.2:2222"},
 					CACert:        "cert1",
@@ -327,7 +327,7 @@ func (s *controllerSuite) TestInitiateModelMigration(c *gc.C) {
 				},
 			}, {
 				ModelTag: st2.ModelTag().String(),
-				TargetInfo: params.ModelMigrationTargetInfo{
+				TargetInfo: params.MigrationTargetInfo{
 					ControllerTag: randomModelTag(),
 					Addrs:         []string{"3.3.3.3:3333"},
 					CACert:        "cert2",
@@ -337,7 +337,7 @@ func (s *controllerSuite) TestInitiateModelMigration(c *gc.C) {
 			},
 		},
 	}
-	out, err := s.controller.InitiateModelMigration(args)
+	out, err := s.controller.InitiateMigration(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out.Results, gc.HasLen, 2)
 
@@ -352,7 +352,7 @@ func (s *controllerSuite) TestInitiateModelMigration(c *gc.C) {
 		c.Check(result.MigrationId, gc.Equals, expectedId)
 
 		// Ensure the migration made it into the DB correctly.
-		mig, err := st.LatestModelMigration()
+		mig, err := st.LatestMigration()
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(mig.Id(), gc.Equals, expectedId)
 		c.Check(mig.ModelUUID(), gc.Equals, st.ModelUUID())
@@ -367,19 +367,19 @@ func (s *controllerSuite) TestInitiateModelMigration(c *gc.C) {
 	}
 }
 
-func (s *controllerSuite) TestInitiateModelMigrationValidationError(c *gc.C) {
+func (s *controllerSuite) TestInitiateMigrationValidationError(c *gc.C) {
 	// Create a hosted model to migrate.
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
 
 	// Kick off the migration with missing details.
-	args := params.InitiateModelMigrationArgs{
-		Specs: []params.ModelMigrationSpec{{
+	args := params.InitiateMigrationArgs{
+		Specs: []params.MigrationSpec{{
 			ModelTag: st.ModelTag().String(),
 			// TargetInfo missing
 		}},
 	}
-	out, err := s.controller.InitiateModelMigration(args)
+	out, err := s.controller.InitiateMigration(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out.Results, gc.HasLen, 1)
 	result := out.Results[0]
@@ -388,15 +388,15 @@ func (s *controllerSuite) TestInitiateModelMigrationValidationError(c *gc.C) {
 	c.Check(result.Error, gc.ErrorMatches, "controller tag: .+ is not a valid tag")
 }
 
-func (s *controllerSuite) TestInitiateModelMigrationPartialFailure(c *gc.C) {
+func (s *controllerSuite) TestInitiateMigrationPartialFailure(c *gc.C) {
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
 
-	args := params.InitiateModelMigrationArgs{
-		Specs: []params.ModelMigrationSpec{
+	args := params.InitiateMigrationArgs{
+		Specs: []params.MigrationSpec{
 			{
 				ModelTag: st.ModelTag().String(),
-				TargetInfo: params.ModelMigrationTargetInfo{
+				TargetInfo: params.MigrationTargetInfo{
 					ControllerTag: randomModelTag(),
 					Addrs:         []string{"1.1.1.1:1111", "2.2.2.2:2222"},
 					CACert:        "cert",
@@ -408,7 +408,7 @@ func (s *controllerSuite) TestInitiateModelMigrationPartialFailure(c *gc.C) {
 			},
 		},
 	}
-	out, err := s.controller.InitiateModelMigration(args)
+	out, err := s.controller.InitiateMigration(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out.Results, gc.HasLen, 2)
 

--- a/apiserver/migrationflag/shim.go
+++ b/apiserver/migrationflag/shim.go
@@ -42,7 +42,7 @@ func (shim *backend) WatchMigrationPhase() state.NotifyWatcher {
 
 // MigrationPhase is part of the Backend interface.
 func (shim *backend) MigrationPhase() (migration.Phase, error) {
-	mig, err := shim.st.LatestModelMigration()
+	mig, err := shim.st.LatestMigration()
 	if errors.IsNotFound(err) {
 		return migration.NONE, nil
 	} else if err != nil {

--- a/apiserver/migrationmaster/backend.go
+++ b/apiserver/migrationmaster/backend.go
@@ -13,7 +13,7 @@ import (
 type Backend interface {
 	migration.StateExporter
 
-	WatchForModelMigration() state.NotifyWatcher
-	LatestModelMigration() (state.ModelMigration, error)
+	WatchForMigration() state.NotifyWatcher
+	LatestMigration() (state.ModelMigration, error)
 	RemoveExportingModelDocs() error
 }

--- a/apiserver/migrationmaster/facade.go
+++ b/apiserver/migrationmaster/facade.go
@@ -51,7 +51,7 @@ func NewAPI(
 // associated with the API connection. The returned id should be used
 // with the NotifyWatcher facade to receive events.
 func (api *API) Watch() params.NotifyWatchResult {
-	watch := api.backend.WatchForModelMigration()
+	watch := api.backend.WatchForMigration()
 	if _, ok := <-watch.Changes(); ok {
 		return params.NotifyWatchResult{
 			NotifyWatcherId: api.resources.Register(watch),
@@ -67,7 +67,7 @@ func (api *API) Watch() params.NotifyWatchResult {
 func (api *API) GetMigrationStatus() (params.MasterMigrationStatus, error) {
 	empty := params.MasterMigrationStatus{}
 
-	mig, err := api.backend.LatestModelMigration()
+	mig, err := api.backend.LatestMigration()
 	if err != nil {
 		return empty, errors.Annotate(err, "retrieving model migration")
 	}
@@ -83,9 +83,9 @@ func (api *API) GetMigrationStatus() (params.MasterMigrationStatus, error) {
 	}
 
 	return params.MasterMigrationStatus{
-		Spec: params.ModelMigrationSpec{
+		Spec: params.MigrationSpec{
 			ModelTag: names.NewModelTag(mig.ModelUUID()).String(),
-			TargetInfo: params.ModelMigrationTargetInfo{
+			TargetInfo: params.MigrationTargetInfo{
 				ControllerTag: target.ControllerTag.String(),
 				Addrs:         target.Addrs,
 				CACert:        target.CACert,
@@ -103,7 +103,7 @@ func (api *API) GetMigrationStatus() (params.MasterMigrationStatus, error) {
 // phase must be a valid phase value, for example QUIESCE" or
 // "ABORT". See the core/migration package for the complete list.
 func (api *API) SetPhase(args params.SetMigrationPhaseArgs) error {
-	mig, err := api.backend.LatestModelMigration()
+	mig, err := api.backend.LatestMigration()
 	if err != nil {
 		return errors.Annotate(err, "could not get migration")
 	}
@@ -121,7 +121,7 @@ func (api *API) SetPhase(args params.SetMigrationPhaseArgs) error {
 // information about the migration's progress. This will be shown in
 // status output shown to the end user.
 func (api *API) SetStatusMessage(args params.SetMigrationStatusMessageArgs) error {
-	mig, err := api.backend.LatestModelMigration()
+	mig, err := api.backend.LatestMigration()
 	if err != nil {
 		return errors.Annotate(err, "could not get migration")
 	}
@@ -157,7 +157,7 @@ func (api *API) Reap() error {
 // WatchMinionReports sets up a watcher which reports when a report
 // for a migration minion has arrived.
 func (api *API) WatchMinionReports() params.NotifyWatchResult {
-	mig, err := api.backend.LatestModelMigration()
+	mig, err := api.backend.LatestMigration()
 	if err != nil {
 		return params.NotifyWatchResult{Error: common.ServerError(err)}
 	}
@@ -177,17 +177,17 @@ func (api *API) WatchMinionReports() params.NotifyWatchResult {
 	}
 }
 
-// GetMinionReports returns details of the reports made by migration
+// MinionReports returns details of the reports made by migration
 // minions to the controller for the current migration phase.
-func (api *API) GetMinionReports() (params.MinionReports, error) {
+func (api *API) MinionReports() (params.MinionReports, error) {
 	var out params.MinionReports
 
-	mig, err := api.backend.LatestModelMigration()
+	mig, err := api.backend.LatestMigration()
 	if err != nil {
 		return out, errors.Trace(err)
 	}
 
-	reports, err := mig.GetMinionReports()
+	reports, err := mig.MinionReports()
 	if err != nil {
 		return out, errors.Trace(err)
 	}

--- a/apiserver/migrationmaster/facade_test.go
+++ b/apiserver/migrationmaster/facade_test.go
@@ -92,9 +92,9 @@ func (s *Suite) TestGetMigrationStatus(c *gc.C) {
 	status, err := api.GetMigrationStatus()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.DeepEquals, params.MasterMigrationStatus{
-		Spec: params.ModelMigrationSpec{
+		Spec: params.MigrationSpec{
 			ModelTag: names.NewModelTag(modelUUID).String(),
-			TargetInfo: params.ModelMigrationTargetInfo{
+			TargetInfo: params.MigrationTargetInfo{
 				ControllerTag: names.NewModelTag(controllerUUID).String(),
 				Addrs:         []string{"1.1.1.1:1", "2.2.2.2:2"},
 				CACert:        "trust me",
@@ -214,7 +214,7 @@ func (s *Suite) TestWatchMinionReports(c *gc.C) {
 	c.Assert(result.Error, gc.IsNil)
 
 	s.stub.CheckCallNames(c,
-		"LatestModelMigration",
+		"LatestMigration",
 		"ModelMigration.WatchMinionReports",
 	)
 
@@ -229,7 +229,7 @@ func (s *Suite) TestWatchMinionReports(c *gc.C) {
 	}
 }
 
-func (s *Suite) TestGetMinionReports(c *gc.C) {
+func (s *Suite) TestMinionReports(c *gc.C) {
 	// Report 16 unknowns. These are in reverse order in order to test
 	// sorting.
 	unknown := make([]names.Tag, 0, 16)
@@ -250,7 +250,7 @@ func (s *Suite) TestGetMinionReports(c *gc.C) {
 	}
 
 	api := s.mustMakeAPI(c)
-	reports, err := api.GetMinionReports()
+	reports, err := api.MinionReports()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Expect the sample of unknowns to be in order and be limited to
@@ -295,13 +295,13 @@ type stubBackend struct {
 	model     description.Model
 }
 
-func (b *stubBackend) WatchForModelMigration() state.NotifyWatcher {
-	b.stub.AddCall("WatchForModelMigration")
+func (b *stubBackend) WatchForMigration() state.NotifyWatcher {
+	b.stub.AddCall("WatchForMigration")
 	return apiservertesting.NewFakeNotifyWatcher()
 }
 
-func (b *stubBackend) LatestModelMigration() (state.ModelMigration, error) {
-	b.stub.AddCall("LatestModelMigration")
+func (b *stubBackend) LatestMigration() (state.ModelMigration, error) {
+	b.stub.AddCall("LatestMigration")
 	if b.getErr != nil {
 		return nil, b.getErr
 	}
@@ -380,7 +380,7 @@ func (m *stubMigration) WatchMinionReports() (state.NotifyWatcher, error) {
 	return apiservertesting.NewFakeNotifyWatcher(), nil
 }
 
-func (m *stubMigration) GetMinionReports() (*state.MinionReports, error) {
+func (m *stubMigration) MinionReports() (*state.MinionReports, error) {
 	return m.minionReports, nil
 }
 

--- a/apiserver/migrationminion/backend.go
+++ b/apiserver/migrationminion/backend.go
@@ -9,5 +9,5 @@ import "github.com/juju/juju/state"
 // MigrationMinion facade.
 type Backend interface {
 	WatchMigrationStatus() state.NotifyWatcher
-	ModelMigration(string) (state.ModelMigration, error)
+	Migration(string) (state.ModelMigration, error)
 }

--- a/apiserver/migrationminion/migrationminion.go
+++ b/apiserver/migrationminion/migrationminion.go
@@ -59,11 +59,11 @@ func (api *API) Report(info params.MinionReport) error {
 		return errors.New("unable to parse phase")
 	}
 
-	mig, err := api.backend.ModelMigration(info.MigrationId)
+	mig, err := api.backend.Migration(info.MigrationId)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	err = mig.MinionReport(api.authorizer.GetAuthTag(), phase, info.Success)
+	err = mig.SubmitMinionReport(api.authorizer.GetAuthTag(), phase, info.Success)
 	return errors.Trace(err)
 }

--- a/apiserver/migrationminion/migrationminion_test.go
+++ b/apiserver/migrationminion/migrationminion_test.go
@@ -79,7 +79,7 @@ func (s *Suite) TestReport(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.stub.CheckCalls(c, []testing.StubCall{
-		{"ModelMigration", []interface{}{"id"}},
+		{"Migration", []interface{}{"id"}},
 		{"Report", []interface{}{s.authorizer.Tag, migration.PRECHECK, true}},
 	})
 }
@@ -127,8 +127,8 @@ func (b *stubBackend) WatchMigrationStatus() state.NotifyWatcher {
 	return apiservertesting.NewFakeNotifyWatcher()
 }
 
-func (b *stubBackend) ModelMigration(id string) (state.ModelMigration, error) {
-	b.stub.AddCall("ModelMigration", id)
+func (b *stubBackend) Migration(id string) (state.ModelMigration, error) {
+	b.stub.AddCall("Migration", id)
 	if b.modelLookupErr != nil {
 		return nil, b.modelLookupErr
 	}
@@ -140,7 +140,7 @@ type stubModelMigration struct {
 	stub *testing.Stub
 }
 
-func (m *stubModelMigration) MinionReport(tag names.Tag, phase migration.Phase, success bool) error {
+func (m *stubModelMigration) SubmitMinionReport(tag names.Tag, phase migration.Phase, success bool) error {
 	m.stub.AddCall("Report", tag, phase, success)
 	return nil
 }

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -5,22 +5,22 @@ package params
 
 import "time"
 
-// InitiateModelMigrationArgs holds the details required to start one
-// or more model migrations.
-type InitiateModelMigrationArgs struct {
-	Specs []ModelMigrationSpec `json:"specs"`
+// InitiateMigrationArgs holds the details required to start one or
+// more model migrations.
+type InitiateMigrationArgs struct {
+	Specs []MigrationSpec `json:"specs"`
 }
 
-// ModelMigrationSpec holds the details required to start the
-// migration of a single model.
-type ModelMigrationSpec struct {
-	ModelTag   string                   `json:"model-tag"`
-	TargetInfo ModelMigrationTargetInfo `json:"target-info"`
+// MigrationSpec holds the details required to start the migration of
+// a single model.
+type MigrationSpec struct {
+	ModelTag   string              `json:"model-tag"`
+	TargetInfo MigrationTargetInfo `json:"target-info"`
 }
 
-// ModelMigrationTargetInfo holds the details required to connect to
-// and authenticate with a remote controller for model migration.
-type ModelMigrationTargetInfo struct {
+// MigrationTargetInfo holds the details required to connect to and
+// authenticate with a remote controller for model migration.
+type MigrationTargetInfo struct {
 	ControllerTag string   `json:"controller-tag"`
 	Addrs         []string `json:"addrs"`
 	CACert        string   `json:"ca-cert"`
@@ -28,15 +28,15 @@ type ModelMigrationTargetInfo struct {
 	Password      string   `json:"password"`
 }
 
-// InitiateModelMigrationResults is used to return the result of one
-// or more attempts to start model migrations.
-type InitiateModelMigrationResults struct {
-	Results []InitiateModelMigrationResult `json:"results"`
+// InitiateMigrationResults is used to return the result of one or
+// more attempts to start model migrations.
+type InitiateMigrationResults struct {
+	Results []InitiateMigrationResult `json:"results"`
 }
 
-// InitiateModelMigrationResult is used to return the result of one
-// model migration initiation attempt.
-type InitiateModelMigrationResult struct {
+// InitiateMigrationResult is used to return the result of one model
+// migration initiation attempt.
+type InitiateMigrationResult struct {
 	ModelTag    string `json:"model-tag"`
 	Error       *Error `json:"error,omitempty"`
 	MigrationId string `json:"migration-id"`
@@ -83,10 +83,10 @@ type ModelArgs struct {
 // model migration for the migrationmaster. It includes authentication
 // details for the remote controller.
 type MasterMigrationStatus struct {
-	Spec             ModelMigrationSpec `json:"spec"`
-	MigrationId      string             `json:"migration-id"`
-	Phase            string             `json:"phase"`
-	PhaseChangedTime time.Time          `json:"phase-changed-time"`
+	Spec             MigrationSpec `json:"spec"`
+	MigrationId      string        `json:"migration-id"`
+	Phase            string        `json:"phase"`
+	PhaseChangedTime time.Time     `json:"phase-changed-time"`
 }
 
 // MigrationStatus reports the current status of a model migration.

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -411,7 +411,7 @@ var getMigrationBackend = func(st *state.State) migrationBackend {
 // migrationBackend defines State functionality required by the
 // migration watchers.
 type migrationBackend interface {
-	LatestModelMigration() (state.ModelMigration, error)
+	LatestMigration() (state.ModelMigration, error)
 	APIHostPorts() ([][]network.HostPort, error)
 	ControllerConfig() (controller.Config, error)
 }
@@ -458,7 +458,7 @@ func (w *srvMigrationStatusWatcher) Next() (params.MigrationStatus, error) {
 		return empty, err
 	}
 
-	mig, err := w.st.LatestModelMigration()
+	mig, err := w.st.LatestMigration()
 	if errors.IsNotFound(err) {
 		return params.MigrationStatus{
 			Phase: migration.NONE.String(),

--- a/apiserver/watcher_test.go
+++ b/apiserver/watcher_test.go
@@ -158,7 +158,7 @@ type fakeMigrationBackend struct {
 	noMigration bool
 }
 
-func (b *fakeMigrationBackend) LatestModelMigration() (state.ModelMigration, error) {
+func (b *fakeMigrationBackend) LatestMigration() (state.ModelMigration, error) {
 	if b.noMigration {
 		return nil, errors.NotFoundf("migration")
 	}

--- a/cmd/juju/commands/migrate.go
+++ b/cmd/juju/commands/migrate.go
@@ -25,7 +25,7 @@ type migrateCommand struct {
 }
 
 type migrateAPI interface {
-	InitiateModelMigration(spec controller.ModelMigrationSpec) (string, error)
+	InitiateMigration(spec controller.MigrationSpec) (string, error)
 }
 
 const migrateDoc = `
@@ -84,7 +84,7 @@ func (c *migrateCommand) Init(args []string) error {
 	return nil
 }
 
-func (c *migrateCommand) getMigrationSpec() (*controller.ModelMigrationSpec, error) {
+func (c *migrateCommand) getMigrationSpec() (*controller.MigrationSpec, error) {
 	store := c.ClientStore()
 
 	modelUUIDs, err := c.ModelUUIDs([]string{c.model})
@@ -103,7 +103,7 @@ func (c *migrateCommand) getMigrationSpec() (*controller.ModelMigrationSpec, err
 		return nil, err
 	}
 
-	return &controller.ModelMigrationSpec{
+	return &controller.MigrationSpec{
 		ModelUUID:            modelUUID,
 		TargetControllerUUID: controllerInfo.ControllerUUID,
 		TargetAddrs:          controllerInfo.APIEndpoints,
@@ -123,7 +123,7 @@ func (c *migrateCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return err
 	}
-	id, err := api.InitiateModelMigration(*spec)
+	id, err := api.InitiateMigration(*spec)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/commands/migrate_test.go
+++ b/cmd/juju/commands/migrate_test.go
@@ -93,7 +93,7 @@ func (s *MigrateSuite) TestSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(testing.Stderr(ctx), gc.Matches, "Migration started with ID \"uuid:0\"\n")
-	c.Check(s.api.specSeen, jc.DeepEquals, &controller.ModelMigrationSpec{
+	c.Check(s.api.specSeen, jc.DeepEquals, &controller.MigrationSpec{
 		ModelUUID:            modelUUID,
 		TargetControllerUUID: targetControllerUUID,
 		TargetAddrs:          []string{"1.2.3.4:5"},
@@ -142,10 +142,10 @@ func (s *MigrateSuite) run(c *gc.C, cmd *migrateCommand, args ...string) (*cmd.C
 }
 
 type fakeMigrateAPI struct {
-	specSeen *controller.ModelMigrationSpec
+	specSeen *controller.MigrationSpec
 }
 
-func (a *fakeMigrateAPI) InitiateModelMigration(spec controller.ModelMigrationSpec) (string, error) {
+func (a *fakeMigrateAPI) InitiateMigration(spec controller.MigrationSpec) (string, error) {
 	a.specSeen = &spec
 	return "uuid:0", nil
 }

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3249,7 +3249,7 @@ func (s *StatusSuite) setupMigrationTest(c *gc.C) *state.State {
 		Name: hostedModelName,
 	})
 
-	mig, err := hostedSt.CreateModelMigration(state.ModelMigrationSpec{
+	mig, err := hostedSt.CreateMigration(state.MigrationSpec{
 		InitiatedBy: names.NewUserTag("admin"),
 		TargetInfo: migration.TargetInfo{
 			ControllerTag: names.NewModelTag(utils.MustNewUUID().String()),

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1289,7 +1289,7 @@ func (s *MachineSuite) TestMigratingModelWorkers(c *gc.C) {
 	s.PatchValue(&modelManifolds, instrumented)
 
 	targetControllerTag := names.NewModelTag(utils.MustNewUUID().String())
-	_, err := st.CreateModelMigration(state.ModelMigrationSpec{
+	_, err := st.CreateMigration(state.MigrationSpec{
 		InitiatedBy: names.NewUserTag("admin"),
 		TargetInfo: migration.TargetInfo{
 			ControllerTag: targetControllerTag,

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -37,18 +37,18 @@ var testAnnotations = map[string]string{
 	"another": "one",
 }
 
-type MigrationSuite struct {
+type MigrationBaseSuite struct {
 	ConnSuite
 }
 
-func (s *MigrationSuite) setLatestTools(c *gc.C, latestTools version.Number) {
+func (s *MigrationBaseSuite) setLatestTools(c *gc.C, latestTools version.Number) {
 	dbModel, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	err = dbModel.UpdateLatestToolsVersion(latestTools)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *MigrationSuite) setRandSequenceValue(c *gc.C, name string) int {
+func (s *MigrationBaseSuite) setRandSequenceValue(c *gc.C, name string) int {
 	var value int
 	var err error
 	count := rand.Intn(5) + 1
@@ -60,13 +60,13 @@ func (s *MigrationSuite) setRandSequenceValue(c *gc.C, name string) int {
 	return value + 1
 }
 
-func (s *MigrationSuite) primeStatusHistory(c *gc.C, entity statusSetter, statusVal status.Status, count int) {
+func (s *MigrationBaseSuite) primeStatusHistory(c *gc.C, entity statusSetter, statusVal status.Status, count int) {
 	primeStatusHistory(c, entity, statusVal, count, func(i int) map[string]interface{} {
 		return map[string]interface{}{"index": count - i}
 	}, 0)
 }
 
-func (s *MigrationSuite) makeApplicationWithLeader(c *gc.C, applicationname string, count int, leader int) {
+func (s *MigrationBaseSuite) makeApplicationWithLeader(c *gc.C, applicationname string, count int, leader int) {
 	c.Assert(leader < count, jc.IsTrue)
 	units := make([]*state.Unit, count)
 	application := s.Factory.MakeApplication(c, &factory.ApplicationParams{
@@ -87,7 +87,7 @@ func (s *MigrationSuite) makeApplicationWithLeader(c *gc.C, applicationname stri
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *MigrationSuite) makeUnitWithStorage(c *gc.C) (*state.Application, *state.Unit, names.StorageTag) {
+func (s *MigrationBaseSuite) makeUnitWithStorage(c *gc.C) (*state.Application, *state.Unit, names.StorageTag) {
 	pool := "loop-pool"
 	kind := "block"
 	// Create a default pool for block devices.
@@ -117,7 +117,7 @@ func (s *MigrationSuite) makeUnitWithStorage(c *gc.C) (*state.Application, *stat
 }
 
 type MigrationExportSuite struct {
-	MigrationSuite
+	MigrationBaseSuite
 }
 
 var _ = gc.Suite(&MigrationExportSuite{})

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 type MigrationImportSuite struct {
-	MigrationSuite
+	MigrationBaseSuite
 }
 
 var _ = gc.Suite(&MigrationImportSuite{})

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -21,16 +21,16 @@ import (
 	"github.com/juju/juju/testing/factory"
 )
 
-type ModelMigrationSuite struct {
+type MigrationSuite struct {
 	ConnSuite
 	State2  *state.State
 	clock   *coretesting.Clock
-	stdSpec state.ModelMigrationSpec
+	stdSpec state.MigrationSpec
 }
 
-var _ = gc.Suite(new(ModelMigrationSuite))
+var _ = gc.Suite(new(MigrationSuite))
 
-func (s *ModelMigrationSuite) SetUpTest(c *gc.C) {
+func (s *MigrationSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
 	s.clock = coretesting.NewClock(time.Now().Truncate(time.Second))
 	s.PatchValue(&state.GetClock, func() clock.Clock {
@@ -44,7 +44,7 @@ func (s *ModelMigrationSuite) SetUpTest(c *gc.C) {
 	targetControllerTag := names.NewModelTag(utils.MustNewUUID().String())
 
 	// Plausible migration arguments to test with.
-	s.stdSpec = state.ModelMigrationSpec{
+	s.stdSpec = state.MigrationSpec{
 		InitiatedBy: names.NewUserTag("admin"),
 		TargetInfo: migration.TargetInfo{
 			ControllerTag: targetControllerTag,
@@ -56,12 +56,12 @@ func (s *ModelMigrationSuite) SetUpTest(c *gc.C) {
 	}
 }
 
-func (s *ModelMigrationSuite) TestCreate(c *gc.C) {
+func (s *MigrationSuite) TestCreate(c *gc.C) {
 	model, err := s.State2.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(model.MigrationMode(), gc.Equals, state.MigrationModeActive)
 
-	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(mig.ModelUUID(), gc.Equals, s.State2.ModelUUID())
@@ -86,23 +86,23 @@ func (s *ModelMigrationSuite) TestCreate(c *gc.C) {
 	c.Check(model.MigrationMode(), gc.Equals, state.MigrationModeExporting)
 }
 
-func (s *ModelMigrationSuite) TestIdSequencesAreIndependent(c *gc.C) {
+func (s *MigrationSuite) TestIdSequencesAreIndependent(c *gc.C) {
 	st2 := s.State2
 	st3 := s.Factory.MakeModel(c, nil)
 	s.AddCleanup(func(*gc.C) { st3.Close() })
 
-	mig2, err := st2.CreateModelMigration(s.stdSpec)
+	mig2, err := st2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	checkIdAndAttempt(c, mig2, 0)
 
-	mig3, err := st3.CreateModelMigration(s.stdSpec)
+	mig3, err := st3.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	checkIdAndAttempt(c, mig3, 0)
 }
 
-func (s *ModelMigrationSuite) TestIdSequencesIncrement(c *gc.C) {
+func (s *MigrationSuite) TestIdSequencesIncrement(c *gc.C) {
 	for attempt := 0; attempt < 3; attempt++ {
-		mig, err := s.State2.CreateModelMigration(s.stdSpec)
+		mig, err := s.State2.CreateMigration(s.stdSpec)
 		c.Assert(err, jc.ErrorIsNil)
 		checkIdAndAttempt(c, mig, attempt)
 		c.Check(mig.SetPhase(migration.ABORT), jc.ErrorIsNil)
@@ -110,17 +110,17 @@ func (s *ModelMigrationSuite) TestIdSequencesIncrement(c *gc.C) {
 	}
 }
 
-func (s *ModelMigrationSuite) TestIdSequencesIncrementOnlyWhenNecessary(c *gc.C) {
+func (s *MigrationSuite) TestIdSequencesIncrementOnlyWhenNecessary(c *gc.C) {
 	// Ensure that sequence numbers aren't "used up" unnecessarily
 	// when the create txn is going to fail.
 
-	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	checkIdAndAttempt(c, mig, 0)
 
 	// This attempt will fail because a migration is already in
 	// progress.
-	_, err = s.State2.CreateModelMigration(s.stdSpec)
+	_, err = s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, gc.ErrorMatches, ".+already in progress")
 
 	// Now abort the migration and create another. The Id sequence
@@ -128,25 +128,25 @@ func (s *ModelMigrationSuite) TestIdSequencesIncrementOnlyWhenNecessary(c *gc.C)
 	c.Assert(mig.SetPhase(migration.ABORT), jc.ErrorIsNil)
 	c.Assert(mig.SetPhase(migration.ABORTDONE), jc.ErrorIsNil)
 
-	mig, err = s.State2.CreateModelMigration(s.stdSpec)
+	mig, err = s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	checkIdAndAttempt(c, mig, 1)
 }
 
-func (s *ModelMigrationSuite) TestSpecValidation(c *gc.C) {
+func (s *MigrationSuite) TestSpecValidation(c *gc.C) {
 	tests := []struct {
 		label        string
-		tweakSpec    func(*state.ModelMigrationSpec)
+		tweakSpec    func(*state.MigrationSpec)
 		errorPattern string
 	}{{
 		"invalid InitiatedBy",
-		func(spec *state.ModelMigrationSpec) {
+		func(spec *state.MigrationSpec) {
 			spec.InitiatedBy = names.UserTag{}
 		},
 		"InitiatedBy not valid",
 	}, {
 		"TargetInfo is validated",
-		func(spec *state.ModelMigrationSpec) {
+		func(spec *state.MigrationSpec) {
 			spec.TargetInfo.Password = ""
 		},
 		"empty Password not valid",
@@ -163,88 +163,88 @@ func (s *ModelMigrationSuite) TestSpecValidation(c *gc.C) {
 		c.Check(errors.IsNotValid(err), jc.IsTrue)
 		c.Check(err, gc.ErrorMatches, test.errorPattern)
 
-		// Ensure that CreateModelMigration rejects the bad spec too.
-		mig, err := s.State2.CreateModelMigration(spec)
+		// Ensure that CreateMigration rejects the bad spec too.
+		mig, err := s.State2.CreateMigration(spec)
 		c.Check(mig, gc.IsNil)
 		c.Check(errors.IsNotValid(err), jc.IsTrue)
 		c.Check(err, gc.ErrorMatches, test.errorPattern)
 	}
 }
 
-func (s *ModelMigrationSuite) TestCreateWithControllerModel(c *gc.C) {
+func (s *MigrationSuite) TestCreateWithControllerModel(c *gc.C) {
 	// This is the State for the controller
-	mig, err := s.State.CreateModelMigration(s.stdSpec)
+	mig, err := s.State.CreateMigration(s.stdSpec)
 	c.Check(mig, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "controllers can't be migrated")
 }
 
-func (s *ModelMigrationSuite) TestCreateMigrationInProgress(c *gc.C) {
-	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+func (s *MigrationSuite) TestCreateMigrationInProgress(c *gc.C) {
+	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(mig, gc.Not(gc.IsNil))
 	c.Assert(err, jc.ErrorIsNil)
 
-	mig2, err := s.State2.CreateModelMigration(s.stdSpec)
+	mig2, err := s.State2.CreateMigration(s.stdSpec)
 	c.Check(mig2, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "failed to create migration: already in progress")
 }
 
-func (s *ModelMigrationSuite) TestCreateMigrationRace(c *gc.C) {
+func (s *MigrationSuite) TestCreateMigrationRace(c *gc.C) {
 	defer state.SetBeforeHooks(c, s.State2, func() {
-		mig, err := s.State2.CreateModelMigration(s.stdSpec)
+		mig, err := s.State2.CreateMigration(s.stdSpec)
 		c.Assert(mig, gc.Not(gc.IsNil))
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
 
-	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Check(mig, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "failed to create migration: already in progress")
 }
 
-func (s *ModelMigrationSuite) TestCreateMigrationWhenModelNotAlive(c *gc.C) {
+func (s *MigrationSuite) TestCreateMigrationWhenModelNotAlive(c *gc.C) {
 	// Set the hosted model to Dying.
 	model, err := s.State2.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(model.Destroy(), jc.ErrorIsNil)
 
-	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Check(mig, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "failed to create migration: model is not alive")
 }
 
-func (s *ModelMigrationSuite) TestMigrationToSameController(c *gc.C) {
+func (s *MigrationSuite) TestMigrationToSameController(c *gc.C) {
 	spec := s.stdSpec
 	spec.TargetInfo.ControllerTag = s.State.ModelTag()
 
-	mig, err := s.State2.CreateModelMigration(spec)
+	mig, err := s.State2.CreateMigration(spec)
 	c.Check(mig, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "model already attached to target controller")
 }
 
-func (s *ModelMigrationSuite) TestLatestModelMigration(c *gc.C) {
-	mig1, err := s.State2.CreateModelMigration(s.stdSpec)
+func (s *MigrationSuite) TestLatestMigration(c *gc.C) {
+	mig1, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 
-	mig2, err := s.State2.LatestModelMigration()
+	mig2, err := s.State2.LatestMigration()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(mig1.Id(), gc.Equals, mig2.Id())
 }
 
-func (s *ModelMigrationSuite) TestLatestModelMigrationNotExist(c *gc.C) {
-	mig, err := s.State.LatestModelMigration()
+func (s *MigrationSuite) TestLatestMigrationNotExist(c *gc.C) {
+	mig, err := s.State.LatestMigration()
 	c.Check(mig, gc.IsNil)
 	c.Check(errors.IsNotFound(err), jc.IsTrue)
 }
 
-func (s *ModelMigrationSuite) TestGetsLatestAttempt(c *gc.C) {
+func (s *MigrationSuite) TestGetsLatestAttempt(c *gc.C) {
 	modelUUID := s.State2.ModelUUID()
 
 	for i := 0; i < 10; i++ {
 		c.Logf("loop %d", i)
-		_, err := s.State2.CreateModelMigration(s.stdSpec)
+		_, err := s.State2.CreateMigration(s.stdSpec)
 		c.Assert(err, jc.ErrorIsNil)
 
-		mig, err := s.State2.LatestModelMigration()
+		mig, err := s.State2.LatestMigration()
 		c.Check(mig.Id(), gc.Equals, fmt.Sprintf("%s:%d", modelUUID, i))
 
 		c.Assert(mig.SetPhase(migration.ABORT), jc.ErrorIsNil)
@@ -252,10 +252,10 @@ func (s *ModelMigrationSuite) TestGetsLatestAttempt(c *gc.C) {
 	}
 }
 
-func (s *ModelMigrationSuite) TestLatestModelMigrationPreviousMigration(c *gc.C) {
+func (s *MigrationSuite) TestLatestMigrationPreviousMigration(c *gc.C) {
 	// Check the scenario of a model having been migrated away and
 	// then migrated back. The previous migration shouldn't be
-	// reported by LatestModelMigration.
+	// reported by LatestMigration.
 
 	// Make it appear as if the model has been successfully
 	// migrated. Don't actually remove model documents to simulate it
@@ -269,7 +269,7 @@ func (s *ModelMigrationSuite) TestLatestModelMigrationPreviousMigration(c *gc.C)
 		migration.REAP,
 		migration.DONE,
 	}
-	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	for _, phase := range phases {
 		c.Assert(mig.SetPhase(phase), jc.ErrorIsNil)
@@ -277,39 +277,39 @@ func (s *ModelMigrationSuite) TestLatestModelMigrationPreviousMigration(c *gc.C)
 	state.ResetMigrationMode(c, s.State2)
 
 	// Previous migration shouldn't be reported.
-	_, err = s.State2.LatestModelMigration()
+	_, err = s.State2.LatestMigration()
 	c.Check(errors.IsNotFound(err), jc.IsTrue)
 
 	// Start a new migration attempt, which should be reported.
-	mig2, err := s.State2.CreateModelMigration(s.stdSpec)
+	mig2, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 
-	mig2b, err := s.State2.LatestModelMigration()
+	mig2b, err := s.State2.LatestMigration()
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(mig2b.Id(), gc.Equals, mig2.Id())
 }
 
-func (s *ModelMigrationSuite) TestModelMigration(c *gc.C) {
-	mig1, err := s.State2.CreateModelMigration(s.stdSpec)
+func (s *MigrationSuite) TestMigration(c *gc.C) {
+	mig1, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 
-	mig2, err := s.State2.ModelMigration(mig1.Id())
+	mig2, err := s.State2.Migration(mig1.Id())
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(mig1.Id(), gc.Equals, mig2.Id())
 	c.Check(mig2.StartTime(), gc.Equals, s.clock.Now())
 }
 
-func (s *ModelMigrationSuite) TestModelMigrationNotFound(c *gc.C) {
-	_, err := s.State2.ModelMigration("does not exist")
+func (s *MigrationSuite) TestMigrationNotFound(c *gc.C) {
+	_, err := s.State2.Migration("does not exist")
 	c.Check(err, jc.Satisfies, errors.IsNotFound)
 	c.Check(err, gc.ErrorMatches, "migration not found")
 }
 
-func (s *ModelMigrationSuite) TestRefresh(c *gc.C) {
-	mig1, err := s.State2.CreateModelMigration(s.stdSpec)
+func (s *MigrationSuite) TestRefresh(c *gc.C) {
+	mig1, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 
-	mig2, err := s.State2.LatestModelMigration()
+	mig2, err := s.State2.LatestMigration()
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = mig1.SetPhase(migration.PRECHECK)
@@ -321,14 +321,14 @@ func (s *ModelMigrationSuite) TestRefresh(c *gc.C) {
 	assertPhase(c, mig2, migration.PRECHECK)
 }
 
-func (s *ModelMigrationSuite) TestSuccessfulPhaseTransitions(c *gc.C) {
+func (s *MigrationSuite) TestSuccessfulPhaseTransitions(c *gc.C) {
 	st := s.State2
 
-	mig, err := st.CreateModelMigration(s.stdSpec)
+	mig, err := st.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mig, gc.NotNil)
 
-	mig2, err := st.LatestModelMigration()
+	mig2, err := st.LatestMigration()
 	c.Assert(err, jc.ErrorIsNil)
 
 	phases := []migration.Phase{
@@ -379,8 +379,8 @@ func (s *ModelMigrationSuite) TestSuccessfulPhaseTransitions(c *gc.C) {
 	s.assertMigrationCleanedUp(c, mig)
 }
 
-func (s *ModelMigrationSuite) TestABORTCleanup(c *gc.C) {
-	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+func (s *MigrationSuite) TestABORTCleanup(c *gc.C) {
+	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.clock.Advance(time.Millisecond)
@@ -396,8 +396,8 @@ func (s *ModelMigrationSuite) TestABORTCleanup(c *gc.C) {
 	c.Assert(model.MigrationMode(), gc.Equals, state.MigrationModeActive)
 }
 
-func (s *ModelMigrationSuite) TestREAPFAILEDCleanup(c *gc.C) {
-	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+func (s *MigrationSuite) TestREAPFAILEDCleanup(c *gc.C) {
+	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Advance the migration to REAPFAILED.
@@ -418,26 +418,26 @@ func (s *ModelMigrationSuite) TestREAPFAILEDCleanup(c *gc.C) {
 	s.assertMigrationCleanedUp(c, mig)
 }
 
-func (s *ModelMigrationSuite) assertMigrationCleanedUp(c *gc.C, mig state.ModelMigration) {
+func (s *MigrationSuite) assertMigrationCleanedUp(c *gc.C, mig state.ModelMigration) {
 	c.Assert(mig.PhaseChangedTime(), gc.Equals, s.clock.Now())
 	c.Assert(mig.EndTime(), gc.Equals, s.clock.Now())
 	assertMigrationNotActive(c, s.State2)
 }
 
-func (s *ModelMigrationSuite) TestIllegalPhaseTransition(c *gc.C) {
-	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+func (s *MigrationSuite) TestIllegalPhaseTransition(c *gc.C) {
+	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = mig.SetPhase(migration.SUCCESS)
 	c.Check(err, gc.ErrorMatches, "illegal phase change: QUIESCE -> SUCCESS")
 }
 
-func (s *ModelMigrationSuite) TestPhaseChangeRace(c *gc.C) {
-	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+func (s *MigrationSuite) TestPhaseChangeRace(c *gc.C) {
+	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(mig, gc.Not(gc.IsNil))
 
 	defer state.SetBeforeHooks(c, s.State2, func() {
-		mig, err := s.State2.LatestModelMigration()
+		mig, err := s.State2.LatestMigration()
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(mig.SetPhase(migration.PRECHECK), jc.ErrorIsNil)
 	}).Check()
@@ -453,11 +453,11 @@ func (s *ModelMigrationSuite) TestPhaseChangeRace(c *gc.C) {
 	assertPhase(c, mig, migration.PRECHECK)
 }
 
-func (s *ModelMigrationSuite) TestStatusMessage(c *gc.C) {
-	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+func (s *MigrationSuite) TestStatusMessage(c *gc.C) {
+	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(mig, gc.Not(gc.IsNil))
 
-	mig2, err := s.State2.LatestModelMigration()
+	mig2, err := s.State2.LatestMigration()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(mig.StatusMessage(), gc.Equals, "starting")
@@ -472,13 +472,13 @@ func (s *ModelMigrationSuite) TestStatusMessage(c *gc.C) {
 	c.Check(mig2.StatusMessage(), gc.Equals, "foo bar")
 }
 
-func (s *ModelMigrationSuite) TestWatchForModelMigration(c *gc.C) {
+func (s *MigrationSuite) TestWatchForMigration(c *gc.C) {
 	// Start watching for migration.
 	w, wc := s.createMigrationWatcher(c, s.State2)
 	wc.AssertOneChange()
 
 	// Create the migration - should be reported.
-	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
@@ -494,9 +494,9 @@ func (s *ModelMigrationSuite) TestWatchForModelMigration(c *gc.C) {
 	wc.AssertClosed()
 }
 
-func (s *ModelMigrationSuite) TestWatchForModelMigrationInProgress(c *gc.C) {
+func (s *MigrationSuite) TestWatchForMigrationInProgress(c *gc.C) {
 	// Create a migration.
-	_, err := s.State2.CreateModelMigration(s.stdSpec)
+	_, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Start watching for a migration - the in progress one should be reported.
@@ -504,7 +504,7 @@ func (s *ModelMigrationSuite) TestWatchForModelMigrationInProgress(c *gc.C) {
 	wc.AssertOneChange()
 }
 
-func (s *ModelMigrationSuite) TestWatchForModelMigrationMultiModel(c *gc.C) {
+func (s *MigrationSuite) TestWatchForMigrationMultiModel(c *gc.C) {
 	_, wc2 := s.createMigrationWatcher(c, s.State2)
 	wc2.AssertOneChange()
 
@@ -516,32 +516,32 @@ func (s *ModelMigrationSuite) TestWatchForModelMigrationMultiModel(c *gc.C) {
 	wc3.AssertOneChange()
 
 	// Create a migration for 2.
-	_, err := s.State2.CreateModelMigration(s.stdSpec)
+	_, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	wc2.AssertOneChange()
 	wc3.AssertNoChange()
 
 	// Create a migration for 3.
-	_, err = State3.CreateModelMigration(s.stdSpec)
+	_, err = State3.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	wc2.AssertNoChange()
 	wc3.AssertOneChange()
 }
 
-func (s *ModelMigrationSuite) createMigrationWatcher(c *gc.C, st *state.State) (
+func (s *MigrationSuite) createMigrationWatcher(c *gc.C, st *state.State) (
 	state.NotifyWatcher, statetesting.NotifyWatcherC,
 ) {
-	w := st.WatchForModelMigration()
+	w := st.WatchForMigration()
 	s.AddCleanup(func(c *gc.C) { statetesting.AssertStop(c, w) })
 	return w, statetesting.NewNotifyWatcherC(c, st, w)
 }
 
-func (s *ModelMigrationSuite) TestWatchMigrationStatus(c *gc.C) {
+func (s *MigrationSuite) TestWatchMigrationStatus(c *gc.C) {
 	w, wc := s.createStatusWatcher(c, s.State2)
 	wc.AssertOneChange() // Initial event.
 
 	// Create a migration.
-	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
@@ -552,7 +552,7 @@ func (s *ModelMigrationSuite) TestWatchMigrationStatus(c *gc.C) {
 	wc.AssertOneChange()
 
 	// Start another.
-	mig2, err := s.State2.CreateModelMigration(s.stdSpec)
+	mig2, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
@@ -568,9 +568,9 @@ func (s *ModelMigrationSuite) TestWatchMigrationStatus(c *gc.C) {
 	wc.AssertClosed()
 }
 
-func (s *ModelMigrationSuite) TestWatchMigrationStatusPreexisting(c *gc.C) {
+func (s *MigrationSuite) TestWatchMigrationStatusPreexisting(c *gc.C) {
 	// Create an aborted migration.
-	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mig.SetPhase(migration.ABORT), jc.ErrorIsNil)
 
@@ -578,7 +578,7 @@ func (s *ModelMigrationSuite) TestWatchMigrationStatusPreexisting(c *gc.C) {
 	wc.AssertOneChange()
 }
 
-func (s *ModelMigrationSuite) TestWatchMigrationStatusMultiModel(c *gc.C) {
+func (s *MigrationSuite) TestWatchMigrationStatusMultiModel(c *gc.C) {
 	_, wc2 := s.createStatusWatcher(c, s.State2)
 	wc2.AssertOneChange() // initial event
 
@@ -590,13 +590,13 @@ func (s *ModelMigrationSuite) TestWatchMigrationStatusMultiModel(c *gc.C) {
 	wc3.AssertOneChange() // initial event
 
 	// Create a migration for 2.
-	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	wc2.AssertOneChange()
 	wc3.AssertNoChange()
 
 	// Create a migration for 3.
-	_, err = State3.CreateModelMigration(s.stdSpec)
+	_, err = State3.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	wc2.AssertNoChange()
 	wc3.AssertOneChange()
@@ -608,7 +608,7 @@ func (s *ModelMigrationSuite) TestWatchMigrationStatusMultiModel(c *gc.C) {
 	wc3.AssertNoChange()
 }
 
-func (s *ModelMigrationSuite) TestMinionReports(c *gc.C) {
+func (s *MigrationSuite) TestMinionReports(c *gc.C) {
 	// Create some machines and units to report with.
 	factory2 := factory.NewFactory(s.State2)
 	m0 := factory2.MakeMachine(c, nil)
@@ -616,57 +616,57 @@ func (s *ModelMigrationSuite) TestMinionReports(c *gc.C) {
 	m1 := factory2.MakeMachine(c, nil)
 	m2 := factory2.MakeMachine(c, nil)
 
-	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 
 	const phase = migration.QUIESCE
-	c.Assert(mig.MinionReport(m0.Tag(), phase, true), jc.ErrorIsNil)
-	c.Assert(mig.MinionReport(m1.Tag(), phase, false), jc.ErrorIsNil)
-	c.Assert(mig.MinionReport(u0.Tag(), phase, true), jc.ErrorIsNil)
+	c.Assert(mig.SubmitMinionReport(m0.Tag(), phase, true), jc.ErrorIsNil)
+	c.Assert(mig.SubmitMinionReport(m1.Tag(), phase, false), jc.ErrorIsNil)
+	c.Assert(mig.SubmitMinionReport(u0.Tag(), phase, true), jc.ErrorIsNil)
 
-	reports, err := mig.GetMinionReports()
+	reports, err := mig.MinionReports()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(reports.Succeeded, jc.SameContents, []names.Tag{m0.Tag(), u0.Tag()})
 	c.Check(reports.Failed, jc.SameContents, []names.Tag{m1.Tag()})
 	c.Check(reports.Unknown, jc.SameContents, []names.Tag{m2.Tag()})
 }
 
-func (s *ModelMigrationSuite) TestDuplicateMinionReportsSameSuccess(c *gc.C) {
+func (s *MigrationSuite) TestDuplicateMinionReportsSameSuccess(c *gc.C) {
 	// It should be OK for a minion report to arrive more than once
 	// for the same migration, agent and phase as long as the value of
 	// "success" is the same.
-	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	tag := names.NewMachineTag("42")
-	c.Check(mig.MinionReport(tag, migration.QUIESCE, true), jc.ErrorIsNil)
-	c.Check(mig.MinionReport(tag, migration.QUIESCE, true), jc.ErrorIsNil)
+	c.Check(mig.SubmitMinionReport(tag, migration.QUIESCE, true), jc.ErrorIsNil)
+	c.Check(mig.SubmitMinionReport(tag, migration.QUIESCE, true), jc.ErrorIsNil)
 }
 
-func (s *ModelMigrationSuite) TestDuplicateMinionReportsDifferingSuccess(c *gc.C) {
+func (s *MigrationSuite) TestDuplicateMinionReportsDifferingSuccess(c *gc.C) {
 	// It is not OK for a minion report to arrive more than once for
 	// the same migration, agent and phase when the "success" value
 	// changes.
-	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	tag := names.NewMachineTag("42")
-	c.Check(mig.MinionReport(tag, migration.QUIESCE, true), jc.ErrorIsNil)
-	err = mig.MinionReport(tag, migration.QUIESCE, false)
+	c.Check(mig.SubmitMinionReport(tag, migration.QUIESCE, true), jc.ErrorIsNil)
+	err = mig.SubmitMinionReport(tag, migration.QUIESCE, false)
 	c.Check(err, gc.ErrorMatches,
 		fmt.Sprintf("conflicting reports received for %s/QUIESCE/machine-42", mig.Id()))
 }
 
-func (s *ModelMigrationSuite) TestMinionReportWithOldPhase(c *gc.C) {
+func (s *MigrationSuite) TestMinionReportWithOldPhase(c *gc.C) {
 	// It is OK for a report to arrive for even a migration has moved
 	// on.
-	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Get another reference to the same migration.
-	migalt, err := s.State2.LatestModelMigration()
+	migalt, err := s.State2.LatestMigration()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Confirm that there's no reports when starting.
-	reports, err := mig.GetMinionReports()
+	reports, err := mig.MinionReports()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(reports.Succeeded, gc.HasLen, 0)
 
@@ -675,21 +675,21 @@ func (s *ModelMigrationSuite) TestMinionReportWithOldPhase(c *gc.C) {
 
 	// Submit minion report for the old phase.
 	tag := names.NewMachineTag("42")
-	c.Assert(mig.MinionReport(tag, migration.QUIESCE, true), jc.ErrorIsNil)
+	c.Assert(mig.SubmitMinionReport(tag, migration.QUIESCE, true), jc.ErrorIsNil)
 
 	// The report should still have been recorded.
-	reports, err = migalt.GetMinionReports()
+	reports, err = migalt.MinionReports()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(reports.Succeeded, jc.SameContents, []names.Tag{tag})
 }
 
-func (s *ModelMigrationSuite) TestMinionReportWithInactiveMigration(c *gc.C) {
+func (s *MigrationSuite) TestMinionReportWithInactiveMigration(c *gc.C) {
 	// Create a migration.
-	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Get another reference to the same migration.
-	migalt, err := s.State2.LatestModelMigration()
+	migalt, err := s.State2.LatestMigration()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Abort the migration.
@@ -697,34 +697,34 @@ func (s *ModelMigrationSuite) TestMinionReportWithInactiveMigration(c *gc.C) {
 	c.Assert(mig.SetPhase(migration.ABORTDONE), jc.ErrorIsNil)
 
 	// Confirm that there's no reports when starting.
-	reports, err := mig.GetMinionReports()
+	reports, err := mig.MinionReports()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(reports.Succeeded, gc.HasLen, 0)
 
 	// Submit a minion report for it.
 	tag := names.NewMachineTag("42")
-	c.Assert(mig.MinionReport(tag, migration.QUIESCE, true), jc.ErrorIsNil)
+	c.Assert(mig.SubmitMinionReport(tag, migration.QUIESCE, true), jc.ErrorIsNil)
 
 	// The report should still have been recorded.
-	reports, err = migalt.GetMinionReports()
+	reports, err = migalt.MinionReports()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(reports.Succeeded, jc.SameContents, []names.Tag{tag})
 }
 
-func (s *ModelMigrationSuite) TestWatchMinionReports(c *gc.C) {
+func (s *MigrationSuite) TestWatchMinionReports(c *gc.C) {
 	mig, wc := s.createMigAndWatchReports(c, s.State2)
 	wc.AssertOneChange() // initial event
 
 	// A report should trigger the watcher.
-	c.Assert(mig.MinionReport(names.NewMachineTag("0"), migration.QUIESCE, true), jc.ErrorIsNil)
+	c.Assert(mig.SubmitMinionReport(names.NewMachineTag("0"), migration.QUIESCE, true), jc.ErrorIsNil)
 	wc.AssertOneChange()
 
 	// A report for a different phase shouldn't trigger the watcher.
-	c.Assert(mig.MinionReport(names.NewMachineTag("1"), migration.IMPORT, true), jc.ErrorIsNil)
+	c.Assert(mig.SubmitMinionReport(names.NewMachineTag("1"), migration.IMPORT, true), jc.ErrorIsNil)
 	wc.AssertNoChange()
 }
 
-func (s *ModelMigrationSuite) TestWatchMinionReportsMultiModel(c *gc.C) {
+func (s *MigrationSuite) TestWatchMinionReportsMultiModel(c *gc.C) {
 	mig, wc := s.createMigAndWatchReports(c, s.State2)
 	wc.AssertOneChange() // initial event
 
@@ -734,16 +734,16 @@ func (s *ModelMigrationSuite) TestWatchMinionReportsMultiModel(c *gc.C) {
 	wc3.AssertOneChange() // initial event
 
 	// Ensure the correct watchers are triggered.
-	c.Assert(mig.MinionReport(names.NewMachineTag("0"), migration.QUIESCE, true), jc.ErrorIsNil)
+	c.Assert(mig.SubmitMinionReport(names.NewMachineTag("0"), migration.QUIESCE, true), jc.ErrorIsNil)
 	wc.AssertOneChange()
 	wc3.AssertNoChange()
 
-	c.Assert(mig3.MinionReport(names.NewMachineTag("0"), migration.QUIESCE, true), jc.ErrorIsNil)
+	c.Assert(mig3.SubmitMinionReport(names.NewMachineTag("0"), migration.QUIESCE, true), jc.ErrorIsNil)
 	wc.AssertNoChange()
 	wc3.AssertOneChange()
 }
 
-func (s *ModelMigrationSuite) createStatusWatcher(c *gc.C, st *state.State) (
+func (s *MigrationSuite) createStatusWatcher(c *gc.C, st *state.State) (
 	state.NotifyWatcher, statetesting.NotifyWatcherC,
 ) {
 	w := st.WatchMigrationStatus()
@@ -751,10 +751,10 @@ func (s *ModelMigrationSuite) createStatusWatcher(c *gc.C, st *state.State) (
 	return w, statetesting.NewNotifyWatcherC(c, st, w)
 }
 
-func (s *ModelMigrationSuite) createMigAndWatchReports(c *gc.C, st *state.State) (
+func (s *MigrationSuite) createMigAndWatchReports(c *gc.C, st *state.State) (
 	state.ModelMigration, statetesting.NotifyWatcherC,
 ) {
-	mig, err := st.CreateModelMigration(s.stdSpec)
+	mig, err := st.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 
 	w, err := mig.WatchMinionReports()
@@ -780,7 +780,7 @@ func assertMigrationNotActive(c *gc.C, st *state.State) {
 }
 
 func isMigrationActive(c *gc.C, st *state.State) bool {
-	isActive, err := st.IsModelMigrationActive()
+	isActive, err := st.IsMigrationActive()
 	c.Assert(err, jc.ErrorIsNil)
 	return isActive
 }

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2399,10 +2399,10 @@ func (w *blockDevicesWatcher) loop() error {
 	}
 }
 
-// WatchForModelMigration returns a notify watcher which reports when
+// WatchForMigration returns a notify watcher which reports when
 // a migration is in progress for the model associated with the
 // State.
-func (st *State) WatchForModelMigration() NotifyWatcher {
+func (st *State) WatchForMigration() NotifyWatcher {
 	return newMigrationActiveWatcher(st)
 }
 

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -77,9 +77,9 @@ type Facade interface {
 	// minion has made a report for the current migration phase.
 	WatchMinionReports() (watcher.NotifyWatcher, error)
 
-	// GetMinionReports returns details of the reports made by migration
+	// MinionReports returns details of the reports made by migration
 	// minions to the controller for the current migration phase.
-	GetMinionReports() (coremigration.MinionReports, error)
+	MinionReports() (coremigration.MinionReports, error)
 }
 
 // Config defines the operation of a Worker.
@@ -485,7 +485,7 @@ func (w *Worker) waitForMinions(
 
 		case <-watch.Changes():
 			var err error
-			reports, err = w.config.Facade.GetMinionReports()
+			reports, err = w.config.Facade.MinionReports()
 			if err != nil {
 				return false, errors.Trace(err)
 			}

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -177,7 +177,7 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 
 		// QUIESCE
 		{"masterFacade.WatchMinionReports", nil},
-		{"masterFacade.GetMinionReports", nil},
+		{"masterFacade.MinionReports", nil},
 		{"masterFacade.SetPhase", []interface{}{coremigration.PRECHECK}},
 
 		// PRECHECK
@@ -207,7 +207,7 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 
 		// SUCCESS
 		{"masterFacade.WatchMinionReports", nil},
-		{"masterFacade.GetMinionReports", nil},
+		{"masterFacade.MinionReports", nil},
 		{"masterFacade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
 
 		// LOGTRANSFER
@@ -236,7 +236,7 @@ func (s *Suite) TestMigrationResume(c *gc.C) {
 		{"masterFacade.GetMigrationStatus", nil},
 		{"guard.Lockdown", nil},
 		{"masterFacade.WatchMinionReports", nil},
-		{"masterFacade.GetMinionReports", nil},
+		{"masterFacade.MinionReports", nil},
 		{"masterFacade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
 		{"masterFacade.SetPhase", []interface{}{coremigration.REAP}},
 		{"masterFacade.Reap", nil},
@@ -382,7 +382,7 @@ func (s *Suite) TestQUIESCEFailedAgent(c *gc.C) {
 		{"masterFacade.GetMigrationStatus", nil},
 		{"guard.Lockdown", nil},
 		{"masterFacade.WatchMinionReports", nil},
-		{"masterFacade.GetMinionReports", nil},
+		{"masterFacade.MinionReports", nil},
 		{"masterFacade.SetPhase", []interface{}{coremigration.ABORT}},
 		apiOpenCallController,
 		abortCall,
@@ -496,7 +496,7 @@ func (s *Suite) TestSUCCESSMinionWaitFailedMachine(c *gc.C) {
 		{"masterFacade.GetMigrationStatus", nil},
 		{"guard.Lockdown", nil},
 		{"masterFacade.WatchMinionReports", nil},
-		{"masterFacade.GetMinionReports", nil},
+		{"masterFacade.MinionReports", nil},
 		{"masterFacade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
 		{"masterFacade.SetPhase", []interface{}{coremigration.REAP}},
 		{"masterFacade.Reap", nil},
@@ -526,7 +526,7 @@ func (s *Suite) TestSUCCESSMinionWaitFailedUnit(c *gc.C) {
 		{"masterFacade.GetMigrationStatus", nil},
 		{"guard.Lockdown", nil},
 		{"masterFacade.WatchMinionReports", nil},
-		{"masterFacade.GetMinionReports", nil},
+		{"masterFacade.MinionReports", nil},
 		{"masterFacade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
 		{"masterFacade.SetPhase", []interface{}{coremigration.REAP}},
 		{"masterFacade.Reap", nil},
@@ -738,8 +738,8 @@ func (c *stubMasterFacade) WatchMinionReports() (watcher.NotifyWatcher, error) {
 	return newMockWatcher(c.minionReportsChanges), nil
 }
 
-func (c *stubMasterFacade) GetMinionReports() (coremigration.MinionReports, error) {
-	c.stub.AddCall("masterFacade.GetMinionReports")
+func (c *stubMasterFacade) MinionReports() (coremigration.MinionReports, error) {
+	c.stub.AddCall("masterFacade.MinionReports")
 	if c.minionReportsErr != nil {
 		return coremigration.MinionReports{}, c.minionReportsErr
 	}


### PR DESCRIPTION
The goal of this PR is to tidy up wieldy API names relating to model
migrations.

Main changes:
- "ModelMigration" replaced with with "Migration" in most places
- "GetMinionReports" is now "MinionReports"
- "MinionReport" is now "SubmitMinionReport" (longer but clearer)

### QA

Ensured that migrations still work.

```
$ juju bootstrap B lxd &
$ juju bootstrap A lxd &
$ juju wait
$ juju switch A
$ juju add-model foo
$ juju deploy ubuntu
# wait...
$ JUJU_DEV_FEATURE_FLAGS=migration juju migrate foo B
# wait... (checking "juju status")
$ juju switch B:foo
# ensure that agents are happy, then check logs
$ juju status
$ juju debug-log -m A:controller --replay -T -l ERROR
```

(Review request: http://reviews.vapour.ws/r/5465/)