### PR TITLE
state: Set silly unit ERROR logs to TRACE

### DIFF
--- a/state/unit.go
+++ b/state/unit.go
@@ -448,7 +448,7 @@ func (u *Unit) destroyHostOps(s *Application) (ops []txn.Op, err error) {
 			Update: bson.D{{"$pull", bson.D{{"subordinates", u.doc.Name}}}},
 		}}, nil
 	} else if u.doc.MachineId == "" {
-		unitLogger.Errorf("unit %v unassigned", u)
+		unitLogger.Tracef("unit %v unassigned", u)
 		return nil, nil
 	}
 
@@ -753,7 +753,7 @@ func (u *Unit) machine() (*Machine, error) {
 func (u *Unit) PublicAddress() (network.Address, error) {
 	m, err := u.machine()
 	if err != nil {
-		unitLogger.Errorf("%v", err)
+		unitLogger.Tracef("%v", err)
 		return network.Address{}, errors.Trace(err)
 	}
 	return m.PublicAddress()
@@ -763,7 +763,7 @@ func (u *Unit) PublicAddress() (network.Address, error) {
 func (u *Unit) PrivateAddress() (network.Address, error) {
 	m, err := u.machine()
 	if err != nil {
-		unitLogger.Errorf("%v", err)
+		unitLogger.Tracef("%v", err)
 		return network.Address{}, errors.Trace(err)
 	}
 	return m.PrivateAddress()

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -503,11 +503,11 @@ func (w *Worker) waitForMinions(
 			if reports.UnknownCount == 0 {
 				msg := formatMinionWaitDone(reports, infoPrefix)
 				if failures > 0 {
-					w.logger.Infof(msg)
+					w.logger.Errorf(msg)
 					w.setErrorStatus("%s, some agents reported failure", infoPrefix)
 					return false, nil
 				}
-				w.logger.Errorf(msg)
+				w.logger.Infof(msg)
 				w.setInfoStatus("%s, all agents reported success", infoPrefix)
 				return true, nil
 			}


### PR DESCRIPTION
These were being logged whenever `juju status` was issued and a unit was being provisioned.

Trivial so no QA steps.

Also fixed incorrect log levels in migrationmaster worker.

(Review request: http://reviews.vapour.ws/r/5467/)