### PR TITLE
debug-log defaults to local time, no date, no location

### DIFF
--- a/cmd/juju/commands/debuglog_test.go
+++ b/cmd/juju/commands/debuglog_test.go
@@ -4,6 +4,8 @@
 package commands
 
 import (
+	"time"
+
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -125,13 +127,45 @@ func (s *DebugLogSuite) TestParamsPassed(c *gc.C) {
 }
 
 func (s *DebugLogSuite) TestLogOutput(c *gc.C) {
+	// test timezone is 6 hours east of UTC
+	s.PatchValue(&time.Local, time.FixedZone("test", 6*60*60))
 	s.PatchValue(&getDebugLogAPI, func(_ *debugLogCommand) (DebugLogAPI, error) {
 		return &fakeDebugLogAPI{log: []api.LogMessage{
-			{Message: "this is the log output"}}}, nil
+			{
+				Entity:    "machine-0",
+				Timestamp: time.Date(2016, 10, 9, 8, 15, 23, 345000000, time.UTC),
+				Severity:  "INFO",
+				Module:    "test.module",
+				Location:  "somefile.go:123",
+				Message:   "this is the log output",
+			},
+		}}, nil
 	})
-	ctx, err := testing.RunCommand(c, newDebugLogCommand())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(ctx), gc.Matches, ".*this is the log output\n")
+	checkOutput := func(args ...string) {
+		count := len(args)
+		args, expected := args[:count-1], args[count-1]
+		ctx, err := testing.RunCommand(c, newDebugLogCommand(), args...)
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(testing.Stdout(ctx), gc.Equals, expected)
+
+	}
+	checkOutput(
+		"machine-0: 14:15:23 INFO test.module this is the log output\n")
+	checkOutput(
+		"--ms",
+		"machine-0: 14:15:23.345 INFO test.module this is the log output\n")
+	checkOutput(
+		"--utc",
+		"machine-0: 08:15:23 INFO test.module this is the log output\n")
+	checkOutput(
+		"--date",
+		"machine-0: 2016-10-09 14:15:23 INFO test.module this is the log output\n")
+	checkOutput(
+		"--utc", "--date",
+		"machine-0: 2016-10-09 08:15:23 INFO test.module this is the log output\n")
+	checkOutput(
+		"--location",
+		"machine-0: 14:15:23 INFO test.module somefile.go:123 this is the log output\n")
 }
 
 type fakeDebugLogAPI struct {


### PR DESCRIPTION
Adds flags:
  --utc, show timestamps in UTC
  --location, show the location of the log message (useful generally only for devs)
  --date, also show the date
  --ms, show millisecond precision

(Review request: http://reviews.vapour.ws/r/5468/)