### PR TITLE
Fix provisioning race

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -121,6 +121,9 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 		if kind != names.MachineTagKind {
 			return fail, errors.Trace(err)
 		}
+		if errors.Cause(err) != common.ErrBadCreds {
+			return fail, err
+		}
 		entity, err = a.checkControllerMachineCreds(req)
 		if err != nil {
 			return fail, errors.Trace(err)

--- a/apiserver/authentication/agent.go
+++ b/apiserver/authentication/agent.go
@@ -43,6 +43,12 @@ func (*AgentAuthenticator) Authenticate(entityFinder EntityFinder, tag names.Tag
 	// If this is a machine agent connecting, we need to check the
 	// nonce matches, otherwise the wrong agent might be trying to
 	// connect.
+	//
+	// NOTE(axw) with the current implementation of Login, it is
+	// important that we check the password before checking the
+	// nonce, or an unprovisioned machine in a hosted model will
+	// prevent a controller machine from logging into the hosted
+	// model.
 	if machine, ok := authenticator.(*state.Machine); ok {
 		if !machine.CheckProvisioned(req.Nonce) {
 			return nil, errors.NotProvisionedf("machine %v", machine.Id())

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -316,6 +316,28 @@ func (factory *Factory) MakeMachine(c *gc.C, params *MachineParams) *state.Machi
 // The machine and its password are returned.
 func (factory *Factory) MakeMachineReturningPassword(c *gc.C, params *MachineParams) (*state.Machine, string) {
 	params = factory.paramsFillDefaults(c, params)
+	return factory.makeMachineReturningPassword(c, params, true)
+}
+
+// MakeUnprovisionedMachineReturningPassword will add a machine with values
+// defined in params. For some values in params, if they are missing, some
+// meaningful empty values will be set. If params is not specified, defaults
+// are used. The machine and its password are returned; the machine will not
+// be provisioned.
+func (factory *Factory) MakeUnprovisionedMachineReturningPassword(c *gc.C, params *MachineParams) (*state.Machine, string) {
+	if params != nil {
+		c.Assert(params.Nonce, gc.Equals, "")
+		c.Assert(params.InstanceId, gc.Equals, instance.Id(""))
+		c.Assert(params.Characteristics, gc.IsNil)
+	}
+	params = factory.paramsFillDefaults(c, params)
+	params.Nonce = ""
+	params.InstanceId = ""
+	params.Characteristics = nil
+	return factory.makeMachineReturningPassword(c, params, false)
+}
+
+func (factory *Factory) makeMachineReturningPassword(c *gc.C, params *MachineParams, setProvisioned bool) (*state.Machine, string) {
 	machineTemplate := state.MachineTemplate{
 		Series:      params.Series,
 		Jobs:        params.Jobs,
@@ -325,8 +347,10 @@ func (factory *Factory) MakeMachineReturningPassword(c *gc.C, params *MachinePar
 	}
 	machine, err := factory.st.AddOneMachine(machineTemplate)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned(params.InstanceId, params.Nonce, params.Characteristics)
-	c.Assert(err, jc.ErrorIsNil)
+	if setProvisioned {
+		err = machine.SetProvisioned(params.InstanceId, params.Nonce, params.Characteristics)
+		c.Assert(err, jc.ErrorIsNil)
+	}
 	err = machine.SetPassword(params.Password)
 	c.Assert(err, jc.ErrorIsNil)
 	if len(params.Addresses) > 0 {

--- a/worker/apicaller/connect.go
+++ b/worker/apicaller/connect.go
@@ -24,7 +24,7 @@ var (
 	//
 	// TODO(katco): 2016-08-09: lp:1611427
 	checkProvisionedStrategy = utils.AttemptStrategy{
-		Total: 1 * time.Minute,
+		Total: 10 * time.Minute,
 		Delay: 5 * time.Second,
 	}
 


### PR DESCRIPTION
There was a bug in Login that caused machine
agents to fail login if attempted before the
provisioner has a chance to record the nonce
in state. We should return "not provisioned"
error codes in favour of "unauthorized".

Also, increase the grace period for agent
logins to 10 minutes from 1 minute. Azure
machine provisioning takes a while for the
instances to be fully provisioned, which
the SDK blocks on.

(Review request: http://reviews.vapour.ws/r/5469/)