### PR TITLE
Include a controllerSocket configuration variable for the GUI.

### DIFF
--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -415,15 +415,11 @@ func (c *Client) DestroyMachines(args params.DestroyMachines) error {
 	return common.DestroyMachines(c.api.stateAccessor, args.Force, args.MachineNames...)
 }
 
-// ModelInfo returns information about the current model (default
-// series and type).
-//
-// TODO(axw) drop this method after 2.0-beta16 is out.
+// ModelInfo returns information about the current model.
 func (c *Client) ModelInfo() (params.ModelInfo, error) {
 	if err := c.checkCanWrite(); err != nil {
 		return params.ModelInfo{}, err
 	}
-
 	state := c.api.stateAccessor
 	conf, err := state.ModelConfig()
 	if err != nil {
@@ -433,20 +429,19 @@ func (c *Client) ModelInfo() (params.ModelInfo, error) {
 	if err != nil {
 		return params.ModelInfo{}, err
 	}
-
 	info := params.ModelInfo{
-		DefaultSeries:  config.PreferredSeries(conf),
-		Cloud:          model.Cloud(),
-		CloudRegion:    model.CloudRegion(),
-		ProviderType:   conf.Type(),
-		Name:           conf.Name(),
-		UUID:           model.UUID(),
-		ControllerUUID: model.ControllerUUID(),
+		DefaultSeries: config.PreferredSeries(conf),
+		Cloud:         model.Cloud(),
+		CloudRegion:   model.CloudRegion(),
+		ProviderType:  conf.Type(),
+		Name:          conf.Name(),
+		UUID:          model.UUID(),
+		OwnerTag:      model.Owner().String(),
+		Life:          params.Life(model.Life().String()),
 	}
 	if tag, ok := model.CloudCredential(); ok {
 		info.CloudCredentialTag = tag.String()
 	}
-
 	return info, nil
 }
 

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -115,7 +115,11 @@ func (s *serverSuite) TestModelInfo(c *gc.C) {
 	c.Assert(info.ProviderType, gc.Equals, conf.Type())
 	c.Assert(info.Name, gc.Equals, conf.Name())
 	c.Assert(info.UUID, gc.Equals, model.UUID())
-	c.Assert(info.ControllerUUID, gc.Equals, model.ControllerUUID())
+	c.Assert(info.OwnerTag, gc.Equals, model.Owner().String())
+	c.Assert(info.Life, gc.Equals, params.Alive)
+	// The controller UUID is not returned by the ModelInfo endpoint on the
+	// Client facade.
+	c.Assert(info.ControllerUUID, gc.Equals, "")
 }
 
 func (s *serverSuite) TestModelUsersInfo(c *gc.C) {

--- a/apiserver/gui.go
+++ b/apiserver/gui.go
@@ -60,8 +60,8 @@ var (
 // - the "jujugui" directory includes a "templates/config.js.go" file which is
 //   used to render the Juju GUI configuration file. The template receives at
 //   least the following variables in its context: "base", "host", "socket",
-//   "staticURL", "uuid" and "version". It might receive more variables but
-//   cannot assume them to be always provided.
+//   "controllerSocket", "staticURL", "uuid" and "version". It might receive
+//   more variables but cannot assume them to be always provided.
 type guiRouter struct {
 	dataDir string
 	ctxt    httpContext
@@ -341,9 +341,10 @@ func (h *guiHandler) serveConfig(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Content-Type", jsMimeType)
 	tmpl := filepath.Join(h.rootDir, "templates", "config.js.go")
 	renderGUITemplate(w, tmpl, map[string]interface{}{
-		"base":   h.baseURLPath,
-		"host":   req.Host,
-		"socket": "/model/$uuid/api",
+		"base":             h.baseURLPath,
+		"host":             req.Host,
+		"controllerSocket": "/api",
+		"socket":           "/model/$uuid/api",
 		// staticURL holds the root of the static hierarchy, hence why the
 		// empty string is used here.
 		"staticURL": h.hashedPath(""),

--- a/apiserver/gui_test.go
+++ b/apiserver/gui_test.go
@@ -496,6 +496,7 @@ var config = {
     // This is just an example and does not reflect the real Juju GUI config.
     base: '{{.base}}',
     host: '{{.host}}',
+    controllerSocket: '{{.controllerSocket}}',
     socket: '{{.socket}}',
     staticURL: '{{.staticURL}}',
     uuid: '{{.uuid}}',
@@ -513,6 +514,7 @@ var config = {
     // This is just an example and does not reflect the real Juju GUI config.
     base: '/gui/%[1]s/',
     host: '%[2]s',
+    controllerSocket: '/api',
     socket: '/model/$uuid/api',
     staticURL: '/gui/%[1]s/%[3]s',
     uuid: '%[1]s',


### PR DESCRIPTION
Also slightly change the Client.ModelInfo API call for the GUI needs.

The goal of these two changes is to allow the GUI to properly establish both the controller connection (using the path specified in the config.js context) and model one (with the ability to retrieve model information from the model connection, ability that we want to preserve as mentioned yesterday, rather than deprecate).

To QA this, you can:
- bootstrap a controller with this branch;
- use the branch at https://github.com/frankban/juju-gui/tree/controller-template to build a GUI release bz2 archive (with `make dist`);
- run `juju upgrade-gui path/to/juju-gui/dist/jujugui-2.1.10.tar.bz2` in order to upgrade the GUI in Juju with the customized one;
- run `juju gui --show-credentials`: the GUI will be opened in your default browser;
- log into the GUI with the credentials included in the output of the previous command;
- check that you can see the GUI canvas;
- finally, open the JavaScript console, run `window.juju_config.controllerSocketTemplate` and check that it equals "/api".

(Review request: http://reviews.vapour.ws/r/5475/)