### PR TITLE
Implement VALIDATION model migration phase

### DIFF
--- a/worker/migrationminion/manifold.go
+++ b/worker/migrationminion/manifold.go
@@ -6,6 +6,7 @@ package migrationminion
 import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
@@ -15,9 +16,11 @@ import (
 // ManifoldConfig defines the names of the manifolds on which a
 // Worker manifold will depend.
 type ManifoldConfig struct {
-	AgentName     string
-	APICallerName string
-	FortressName  string
+	AgentName       string
+	APICallerName   string
+	FortressName    string
+	APIOpen         func(*api.Info, api.DialOpts) (api.Connection, error)
+	ValidationCheck func(base.APICaller) error
 
 	NewFacade func(base.APICaller) (Facade, error)
 	NewWorker func(Config) (worker.Worker, error)
@@ -33,6 +36,12 @@ func (config ManifoldConfig) validate() error {
 	}
 	if config.FortressName == "" {
 		return errors.NotValidf("empty FortressName")
+	}
+	if config.APIOpen == nil {
+		return errors.NotValidf("nil APIOpen")
+	}
+	if config.ValidationCheck == nil {
+		return errors.NotValidf("nil ValidationCheck")
 	}
 	if config.NewFacade == nil {
 		return errors.NotValidf("nil NewFacade")
@@ -66,9 +75,11 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		return nil, errors.Trace(err)
 	}
 	worker, err := config.NewWorker(Config{
-		Agent:  agent,
-		Facade: facade,
-		Guard:  guard,
+		Agent:           agent,
+		Facade:          facade,
+		Guard:           guard,
+		APIOpen:         config.APIOpen,
+		ValidationCheck: config.ValidationCheck,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/migrationminion/manifold.go
+++ b/worker/migrationminion/manifold.go
@@ -16,11 +16,11 @@ import (
 // ManifoldConfig defines the names of the manifolds on which a
 // Worker manifold will depend.
 type ManifoldConfig struct {
-	AgentName       string
-	APICallerName   string
-	FortressName    string
-	APIOpen         func(*api.Info, api.DialOpts) (api.Connection, error)
-	ValidationCheck func(base.APICaller) error
+	AgentName         string
+	APICallerName     string
+	FortressName      string
+	APIOpen           func(*api.Info, api.DialOpts) (api.Connection, error)
+	ValidateMigration func(base.APICaller) error
 
 	NewFacade func(base.APICaller) (Facade, error)
 	NewWorker func(Config) (worker.Worker, error)
@@ -40,8 +40,8 @@ func (config ManifoldConfig) validate() error {
 	if config.APIOpen == nil {
 		return errors.NotValidf("nil APIOpen")
 	}
-	if config.ValidationCheck == nil {
-		return errors.NotValidf("nil ValidationCheck")
+	if config.ValidateMigration == nil {
+		return errors.NotValidf("nil ValidateMigration")
 	}
 	if config.NewFacade == nil {
 		return errors.NotValidf("nil NewFacade")
@@ -75,11 +75,11 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		return nil, errors.Trace(err)
 	}
 	worker, err := config.NewWorker(Config{
-		Agent:           agent,
-		Facade:          facade,
-		Guard:           guard,
-		APIOpen:         config.APIOpen,
-		ValidationCheck: config.ValidationCheck,
+		Agent:             agent,
+		Facade:            facade,
+		Guard:             guard,
+		APIOpen:           config.APIOpen,
+		ValidateMigration: config.ValidateMigration,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/migrationminion/validate_test.go
+++ b/worker/migrationminion/validate_test.go
@@ -6,6 +6,8 @@ package migrationminion_test
 import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/migrationminion"
 	"github.com/juju/testing"
@@ -30,23 +32,37 @@ func (*ValidateSuite) TestMissingAgent(c *gc.C) {
 	checkNotValid(c, config, "nil Agent not valid")
 }
 
-func (*ValidateSuite) TestMissingGuard(c *gc.C) {
-	config := validConfig()
-	config.Guard = nil
-	checkNotValid(c, config, "nil Guard not valid")
-}
-
 func (*ValidateSuite) TestMissingFacade(c *gc.C) {
 	config := validConfig()
 	config.Facade = nil
 	checkNotValid(c, config, "nil Facade not valid")
 }
 
+func (*ValidateSuite) TestMissingGuard(c *gc.C) {
+	config := validConfig()
+	config.Guard = nil
+	checkNotValid(c, config, "nil Guard not valid")
+}
+
+func (*ValidateSuite) TestMissingAPIOpen(c *gc.C) {
+	config := validConfig()
+	config.APIOpen = nil
+	checkNotValid(c, config, "nil APIOpen not valid")
+}
+
+func (*ValidateSuite) TestMissingValidateCheck(c *gc.C) {
+	config := validConfig()
+	config.ValidationCheck = nil
+	checkNotValid(c, config, "nil ValidationCheck not valid")
+}
+
 func validConfig() migrationminion.Config {
 	return migrationminion.Config{
-		Agent:  struct{ agent.Agent }{},
-		Guard:  struct{ fortress.Guard }{},
-		Facade: struct{ migrationminion.Facade }{},
+		Agent:           struct{ agent.Agent }{},
+		Guard:           struct{ fortress.Guard }{},
+		Facade:          struct{ migrationminion.Facade }{},
+		APIOpen:         func(*api.Info, api.DialOpts) (api.Connection, error) { return nil, nil },
+		ValidationCheck: func(base.APICaller) error { return nil },
 	}
 }
 

--- a/worker/migrationminion/validate_test.go
+++ b/worker/migrationminion/validate_test.go
@@ -50,19 +50,19 @@ func (*ValidateSuite) TestMissingAPIOpen(c *gc.C) {
 	checkNotValid(c, config, "nil APIOpen not valid")
 }
 
-func (*ValidateSuite) TestMissingValidateCheck(c *gc.C) {
+func (*ValidateSuite) TestMissingValidateMigration(c *gc.C) {
 	config := validConfig()
-	config.ValidationCheck = nil
-	checkNotValid(c, config, "nil ValidationCheck not valid")
+	config.ValidateMigration = nil
+	checkNotValid(c, config, "nil ValidateMigration not valid")
 }
 
 func validConfig() migrationminion.Config {
 	return migrationminion.Config{
-		Agent:           struct{ agent.Agent }{},
-		Guard:           struct{ fortress.Guard }{},
-		Facade:          struct{ migrationminion.Facade }{},
-		APIOpen:         func(*api.Info, api.DialOpts) (api.Connection, error) { return nil, nil },
-		ValidationCheck: func(base.APICaller) error { return nil },
+		Agent:             struct{ agent.Agent }{},
+		Guard:             struct{ fortress.Guard }{},
+		Facade:            struct{ migrationminion.Facade }{},
+		APIOpen:           func(*api.Info, api.DialOpts) (api.Connection, error) { return nil, nil },
+		ValidateMigration: func(base.APICaller) error { return nil },
 	}
 }
 

--- a/worker/migrationminion/worker.go
+++ b/worker/migrationminion/worker.go
@@ -28,11 +28,11 @@ type Facade interface {
 
 // Config defines the operation of a Worker.
 type Config struct {
-	Agent           agent.Agent
-	Facade          Facade
-	Guard           fortress.Guard
-	APIOpen         func(*api.Info, api.DialOpts) (api.Connection, error)
-	ValidationCheck func(base.APICaller) error
+	Agent             agent.Agent
+	Facade            Facade
+	Guard             fortress.Guard
+	APIOpen           func(*api.Info, api.DialOpts) (api.Connection, error)
+	ValidateMigration func(base.APICaller) error
 }
 
 // Validate returns an error if config cannot drive a Worker.
@@ -49,8 +49,8 @@ func (config Config) Validate() error {
 	if config.APIOpen == nil {
 		return errors.NotValidf("nil APIOpen")
 	}
-	if config.ValidationCheck == nil {
-		return errors.NotValidf("nil ValidationCheck")
+	if config.ValidateMigration == nil {
+		return errors.NotValidf("nil ValidateMigration")
 	}
 	return nil
 }
@@ -179,7 +179,7 @@ func (w *Worker) validate(status watcher.MigrationStatus) error {
 	defer conn.Close()
 
 	// Ask the agent to confirm that things look ok.
-	err = w.config.ValidationCheck(conn)
+	err = w.config.ValidateMigration(conn)
 	return errors.Trace(err)
 }
 

--- a/worker/migrationminion/worker.go
+++ b/worker/migrationminion/worker.go
@@ -8,6 +8,8 @@ import (
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/watcher"
@@ -26,9 +28,11 @@ type Facade interface {
 
 // Config defines the operation of a Worker.
 type Config struct {
-	Agent  agent.Agent
-	Facade Facade
-	Guard  fortress.Guard
+	Agent           agent.Agent
+	Facade          Facade
+	Guard           fortress.Guard
+	APIOpen         func(*api.Info, api.DialOpts) (api.Connection, error)
+	ValidationCheck func(base.APICaller) error
 }
 
 // Validate returns an error if config cannot drive a Worker.
@@ -41,6 +45,12 @@ func (config Config) Validate() error {
 	}
 	if config.Guard == nil {
 		return errors.NotValidf("nil Guard")
+	}
+	if config.APIOpen == nil {
+		return errors.NotValidf("nil APIOpen")
+	}
+	if config.ValidationCheck == nil {
+		return errors.NotValidf("nil ValidationCheck")
 	}
 	return nil
 }
@@ -120,25 +130,56 @@ func (w *Worker) handle(status watcher.MigrationStatus) error {
 
 	switch status.Phase {
 	case migration.QUIESCE:
-		// Report that the minion is ready and that all workers that
-		// should be shut down have done so.
-		if err := w.report(status, true); err != nil {
-			return errors.Trace(err)
-		}
+		err = w.doQUIESCE(status)
+	case migration.VALIDATION:
+		err = w.doVALIDATION(status)
 	case migration.SUCCESS:
-		// Report first because the config update in doSUCCESS will
-		// cause the API connection to drop. The SUCCESS phase is the
-		// point of no return anyway.
-		if err := w.report(status, true); err != nil {
-			return errors.Trace(err)
-		}
-		if err = w.doSUCCESS(status); err != nil {
-			return errors.Trace(err)
-		}
+		err = w.doSUCCESS(status)
 	default:
 		// The minion doesn't need to do anything for other
 		// migration phases.
 	}
+	return errors.Trace(err)
+}
+
+func (w *Worker) doQUIESCE(status watcher.MigrationStatus) error {
+	// Report that the minion is ready and that all workers that
+	// should be shut down have done so.
+	return w.report(status, true)
+}
+
+func (w *Worker) doVALIDATION(status watcher.MigrationStatus) error {
+	err := w.validate(status)
+	if err != nil {
+		// Don't return this error just log it and report to the
+		// migrationmaster that things didn't work out.
+		logger.Errorf("validation failed: %v", err)
+	}
+	return w.report(status, err == nil)
+}
+
+func (w *Worker) validate(status watcher.MigrationStatus) error {
+	agentConf := w.config.Agent.CurrentConfig()
+	apiInfo, ok := agentConf.APIInfo()
+	if !ok {
+		return errors.New("no API connection details")
+	}
+	apiInfo.Addrs = status.TargetAPIAddrs
+	apiInfo.CACert = status.TargetCACert
+
+	// Use zero DialOpts (no retries) because the worker must stay
+	// responsive to Kill requests. We don't want it to be blocked by
+	// a long set of retry attempts.
+	conn, err := w.config.APIOpen(apiInfo, api.DialOpts{})
+	if err != nil {
+		// Don't return this error just log it and report to the
+		// migrationmaster that things didn't work out.
+		return errors.Annotate(err, "failed to open API to target controller")
+	}
+	defer conn.Close()
+
+	// Ask the agent to confirm that things look ok.
+	err = w.config.ValidationCheck(conn)
 	return errors.Trace(err)
 }
 
@@ -147,6 +188,14 @@ func (w *Worker) doSUCCESS(status watcher.MigrationStatus) error {
 	if err != nil {
 		return errors.Annotate(err, "converting API addresses")
 	}
+
+	// Report first because the config update that's about to happen
+	// will cause the API connection to drop. The SUCCESS phase is the
+	// point of no return anyway.
+	if err := w.report(status, true); err != nil {
+		return errors.Trace(err)
+	}
+
 	err = w.config.Agent.ChangeConfig(func(conf agent.ConfigSetter) error {
 		conf.SetAPIHostPorts(hps)
 		conf.SetCACert(status.TargetCACert)

--- a/worker/migrationminion/worker_test.go
+++ b/worker/migrationminion/worker_test.go
@@ -57,8 +57,8 @@ func (s *Suite) SetUpTest(c *gc.C) {
 		Guard:   s.guard,
 		Agent:   s.agent,
 		APIOpen: s.apiOpen,
-		ValidationCheck: func(base.APICaller) error {
-			s.stub.AddCall("ValidationCheck")
+		ValidateMigration: func(base.APICaller) error {
+			s.stub.AddCall("ValidateMigration")
 			return nil
 		},
 	}
@@ -177,7 +177,7 @@ func (s *Suite) TestVALIDATION(c *gc.C) {
 		"Watch",
 		"Lockdown",
 		"API open",
-		"ValidationCheck",
+		"ValidateMigration",
 		"API close",
 		"Report",
 	})
@@ -218,8 +218,8 @@ func (s *Suite) TestVALIDATIONFail(c *gc.C) {
 		MigrationId: "id",
 		Phase:       migration.VALIDATION,
 	}
-	s.config.ValidationCheck = func(base.APICaller) error {
-		s.stub.AddCall("ValidationCheck")
+	s.config.ValidateMigration = func(base.APICaller) error {
+		s.stub.AddCall("ValidateMigration")
 		return errors.New("boom")
 	}
 	w, err := migrationminion.New(s.config)
@@ -230,7 +230,7 @@ func (s *Suite) TestVALIDATIONFail(c *gc.C) {
 		"Watch",
 		"Lockdown",
 		"API open",
-		"ValidationCheck",
+		"ValidateMigration",
 		"API close",
 		"Report",
 	})

--- a/worker/migrationminion/worker_test.go
+++ b/worker/migrationminion/worker_test.go
@@ -12,8 +12,11 @@ import (
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/network"
 	coretesting "github.com/juju/juju/testing"
@@ -24,8 +27,17 @@ import (
 	"github.com/juju/juju/worker/workertest"
 )
 
+var (
+	modelTag      = names.NewModelTag("model-uuid")
+	addrs         = []string{"1.1.1.1:1111", "2.2.2.2:2222"}
+	agentTag      = names.NewMachineTag("42")
+	agentPassword = "sekret"
+	caCert        = "cert"
+)
+
 type Suite struct {
 	coretesting.BaseSuite
+	config migrationminion.Config
 	stub   *jujutesting.Stub
 	client *stubMinionClient
 	guard  *stubGuard
@@ -40,14 +52,25 @@ func (s *Suite) SetUpTest(c *gc.C) {
 	s.client = newStubMinionClient(s.stub)
 	s.guard = newStubGuard(s.stub)
 	s.agent = newStubAgent()
+	s.config = migrationminion.Config{
+		Facade:  s.client,
+		Guard:   s.guard,
+		Agent:   s.agent,
+		APIOpen: s.apiOpen,
+		ValidationCheck: func(base.APICaller) error {
+			s.stub.AddCall("ValidationCheck")
+			return nil
+		},
+	}
+}
+
+func (s *Suite) apiOpen(info *api.Info, dialOpts api.DialOpts) (api.Connection, error) {
+	s.stub.AddCall("API open", info)
+	return &stubConnection{stub: s.stub}, nil
 }
 
 func (s *Suite) TestStartAndStop(c *gc.C) {
-	w, err := migrationminion.New(migrationminion.Config{
-		Facade: s.client,
-		Guard:  s.guard,
-		Agent:  s.agent,
-	})
+	w, err := migrationminion.New(s.config)
 	c.Assert(err, jc.ErrorIsNil)
 	workertest.CleanKill(c, w)
 	s.stub.CheckCallNames(c, "Watch")
@@ -55,11 +78,7 @@ func (s *Suite) TestStartAndStop(c *gc.C) {
 
 func (s *Suite) TestWatchFailure(c *gc.C) {
 	s.client.watchErr = errors.New("boom")
-	w, err := migrationminion.New(migrationminion.Config{
-		Facade: s.client,
-		Guard:  s.guard,
-		Agent:  s.agent,
-	})
+	w, err := migrationminion.New(s.config)
 	c.Assert(err, jc.ErrorIsNil)
 	err = workertest.CheckKilled(c, w)
 	c.Check(err, gc.ErrorMatches, "setting up watcher: boom")
@@ -67,11 +86,7 @@ func (s *Suite) TestWatchFailure(c *gc.C) {
 
 func (s *Suite) TestClosedWatcherChannel(c *gc.C) {
 	close(s.client.watcher.changes)
-	w, err := migrationminion.New(migrationminion.Config{
-		Facade: s.client,
-		Guard:  s.guard,
-		Agent:  s.agent,
-	})
+	w, err := migrationminion.New(s.config)
 	c.Assert(err, jc.ErrorIsNil)
 	err = workertest.CheckKilled(c, w)
 	c.Check(err, gc.ErrorMatches, "watcher channel closed")
@@ -82,11 +97,7 @@ func (s *Suite) TestUnlockError(c *gc.C) {
 		Phase: migration.NONE,
 	}
 	s.guard.unlockErr = errors.New("squish")
-	w, err := migrationminion.New(migrationminion.Config{
-		Facade: s.client,
-		Guard:  s.guard,
-		Agent:  s.agent,
-	})
+	w, err := migrationminion.New(s.config)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = workertest.CheckKilled(c, w)
@@ -99,11 +110,7 @@ func (s *Suite) TestLockdownError(c *gc.C) {
 		Phase: migration.QUIESCE,
 	}
 	s.guard.lockdownErr = errors.New("squash")
-	w, err := migrationminion.New(migrationminion.Config{
-		Facade: s.client,
-		Guard:  s.guard,
-		Agent:  s.agent,
-	})
+	w, err := migrationminion.New(s.config)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = workertest.CheckKilled(c, w)
@@ -131,11 +138,7 @@ func (s *Suite) checkNonRunningPhase(c *gc.C, phase migration.Phase) {
 	c.Logf("checking %s", phase)
 	s.stub.ResetCalls()
 	s.client.watcher.changes <- watcher.MigrationStatus{Phase: phase}
-	w, err := migrationminion.New(migrationminion.Config{
-		Facade: s.client,
-		Guard:  s.guard,
-		Agent:  s.agent,
-	})
+	w, err := migrationminion.New(s.config)
 	c.Assert(err, jc.ErrorIsNil)
 	workertest.CheckAlive(c, w)
 	workertest.CleanKill(c, w)
@@ -147,11 +150,7 @@ func (s *Suite) TestQUIESCE(c *gc.C) {
 		MigrationId: "id",
 		Phase:       migration.QUIESCE,
 	}
-	w, err := migrationminion.New(migrationminion.Config{
-		Facade: s.client,
-		Guard:  s.guard,
-		Agent:  s.agent,
-	})
+	w, err := migrationminion.New(s.config)
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
 
@@ -163,19 +162,89 @@ func (s *Suite) TestQUIESCE(c *gc.C) {
 	s.stub.CheckCall(c, 2, "Report", "id", migration.QUIESCE, true)
 }
 
+func (s *Suite) TestVALIDATION(c *gc.C) {
+	s.client.watcher.changes <- watcher.MigrationStatus{
+		MigrationId:    "id",
+		Phase:          migration.VALIDATION,
+		TargetAPIAddrs: addrs,
+		TargetCACert:   caCert,
+	}
+	w, err := migrationminion.New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	s.waitForStubCalls(c, []string{
+		"Watch",
+		"Lockdown",
+		"API open",
+		"ValidationCheck",
+		"API close",
+		"Report",
+	})
+	s.stub.CheckCall(c, 2, "API open", &api.Info{
+		ModelTag: modelTag,
+		Tag:      agentTag,
+		Password: agentPassword,
+		Addrs:    addrs,
+		CACert:   caCert,
+	})
+	s.stub.CheckCall(c, 5, "Report", "id", migration.VALIDATION, true)
+}
+
+func (s *Suite) TestVALIDATIONCantConnect(c *gc.C) {
+	s.client.watcher.changes <- watcher.MigrationStatus{
+		MigrationId: "id",
+		Phase:       migration.VALIDATION,
+	}
+	s.config.APIOpen = func(*api.Info, api.DialOpts) (api.Connection, error) {
+		s.stub.AddCall("API open")
+		return nil, errors.New("boom")
+	}
+	w, err := migrationminion.New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	s.waitForStubCalls(c, []string{
+		"Watch",
+		"Lockdown",
+		"API open",
+		"Report",
+	})
+	s.stub.CheckCall(c, 3, "Report", "id", migration.VALIDATION, false)
+}
+
+func (s *Suite) TestVALIDATIONFail(c *gc.C) {
+	s.client.watcher.changes <- watcher.MigrationStatus{
+		MigrationId: "id",
+		Phase:       migration.VALIDATION,
+	}
+	s.config.ValidationCheck = func(base.APICaller) error {
+		s.stub.AddCall("ValidationCheck")
+		return errors.New("boom")
+	}
+	w, err := migrationminion.New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	s.waitForStubCalls(c, []string{
+		"Watch",
+		"Lockdown",
+		"API open",
+		"ValidationCheck",
+		"API close",
+		"Report",
+	})
+	s.stub.CheckCall(c, 5, "Report", "id", migration.VALIDATION, false)
+}
+
 func (s *Suite) TestSUCCESS(c *gc.C) {
-	addrs := []string{"1.1.1.1:1", "9.9.9.9:9"}
 	s.client.watcher.changes <- watcher.MigrationStatus{
 		MigrationId:    "id",
 		Phase:          migration.SUCCESS,
 		TargetAPIAddrs: addrs,
-		TargetCACert:   "top secret",
+		TargetCACert:   caCert,
 	}
-	w, err := migrationminion.New(migrationminion.Config{
-		Facade: s.client,
-		Guard:  s.guard,
-		Agent:  s.agent,
-	})
+	w, err := migrationminion.New(s.config)
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {
@@ -185,7 +254,7 @@ func (s *Suite) TestSUCCESS(c *gc.C) {
 	}
 	workertest.CleanKill(c, w)
 	c.Assert(s.agent.conf.addrs, gc.DeepEquals, addrs)
-	c.Assert(s.agent.conf.caCert, gc.DeepEquals, "top secret")
+	c.Assert(s.agent.conf.caCert, gc.DeepEquals, caCert)
 	s.stub.CheckCallNames(c, "Watch", "Lockdown", "Report")
 	s.stub.CheckCall(c, 2, "Report", "id", migration.SUCCESS, true)
 }
@@ -281,7 +350,7 @@ func newStubAgent() *stubAgent {
 type stubAgent struct {
 	agent.Agent
 	configChanged chan bool
-	conf          stubConfig
+	conf          stubAgentConfig
 }
 
 func (ma *stubAgent) CurrentConfig() agent.Config {
@@ -293,7 +362,7 @@ func (ma *stubAgent) ChangeConfig(f agent.ConfigMutator) error {
 	return f(&ma.conf)
 }
 
-type stubConfig struct {
+type stubAgentConfig struct {
 	agent.ConfigSetter
 
 	mu     sync.Mutex
@@ -301,13 +370,13 @@ type stubConfig struct {
 	caCert string
 }
 
-func (mc *stubConfig) setAddresses(addrs ...string) {
+func (mc *stubAgentConfig) setAddresses(addrs ...string) {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 	mc.addrs = append([]string(nil), addrs...)
 }
 
-func (mc *stubConfig) SetAPIHostPorts(servers [][]network.HostPort) {
+func (mc *stubAgentConfig) SetAPIHostPorts(servers [][]network.HostPort) {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 	mc.addrs = nil
@@ -318,8 +387,30 @@ func (mc *stubConfig) SetAPIHostPorts(servers [][]network.HostPort) {
 	}
 }
 
-func (mc *stubConfig) SetCACert(cert string) {
+func (mc *stubAgentConfig) SetCACert(cert string) {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 	mc.caCert = cert
+}
+
+func (mc *stubAgentConfig) APIInfo() (*api.Info, bool) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	return &api.Info{
+		Addrs:    mc.addrs,
+		CACert:   mc.caCert,
+		ModelTag: modelTag,
+		Tag:      agentTag,
+		Password: agentPassword,
+	}, true
+}
+
+type stubConnection struct {
+	api.Connection
+	stub *jujutesting.Stub
+}
+
+func (c *stubConnection) Close() error {
+	c.stub.AddCall("API close")
+	return nil
 }


### PR DESCRIPTION
Before the migration is declared successful, the migration minions in each agent responds to the VALIDATION phase by checking that it can connect to the target controller's API server and making API requests to ensure things look ok. The minion then reports the success or failure of these checks back to the migration master.

The migration master now waits for successful responses from all minions before activating the model in the target controller and moving the migration forward to the SUCCESS phase. If any minion reports a  failure or fails to report within 15 mins, the migration is aborted.





(Review request: http://reviews.vapour.ws/r/5476/)