### PR TITLE
Clean up stderr after provider status messages

### DIFF
--- a/environs/broker.go
+++ b/environs/broker.go
@@ -70,8 +70,14 @@ type StartInstanceParams struct {
 	// that may be used to start this instance.
 	ImageMetadata []*imagemetadata.ImageMetadata
 
-	// StatusCallback is a callback to be used by the instance to report changes in status.
+	// StatusCallback is a callback to be used by the instance to report
+	// changes in status. Its signature is consistent with other
+	// status-related functions to allow them to be used as callbacks.
 	StatusCallback func(settableStatus status.Status, info string, data map[string]interface{}) error
+
+	// CleanupCallback is a callback to be used to clean up any residual
+	// status-reporting output from StatusCallback.
+	CleanupCallback func(info string) error
 }
 
 // StartInstanceResult holds the result of an

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -133,18 +133,35 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 	maybeSetBridge(instanceConfig)
 
 	fmt.Fprintln(ctx.GetStderr(), "Launching instance")
+	// Print instance status reports status changes during provisioning.
+	// Note the carriage returns, meaning subsequent prints are to the same
+	// line of stderr, not a new line.
 	instanceStatus := func(settableStatus status.Status, info string, data map[string]interface{}) error {
-		fmt.Fprintf(ctx.GetStderr(), "%s      \r", info)
+		// The data arg is not expected to be used in this case, but
+		// print it, rather than ignore it, if we get something.
+		dataString := ""
+		if len(data) > 0 {
+			dataString = fmt.Sprintf(" %v", data)
+		}
+		fmt.Fprintf(ctx.GetStderr(), "%s%s\r", info, dataString)
+		return nil
+	}
+	// Likely used after the final instanceStatus call to white-out the
+	// current stderr line before the next use, removing any residual status
+	// reporting output.
+	statusCleanup := func(info string) error {
+		fmt.Fprintf(ctx.GetStderr(), "%s\r", info)
 		return nil
 	}
 	result, err := env.StartInstance(environs.StartInstanceParams{
-		ControllerUUID: args.ControllerConfig.ControllerUUID(),
-		Constraints:    args.BootstrapConstraints,
-		Tools:          availableTools,
-		InstanceConfig: instanceConfig,
-		Placement:      args.Placement,
-		ImageMetadata:  imageMetadata,
-		StatusCallback: instanceStatus,
+		ControllerUUID:  args.ControllerConfig.ControllerUUID(),
+		Constraints:     args.BootstrapConstraints,
+		Tools:           availableTools,
+		InstanceConfig:  instanceConfig,
+		Placement:       args.Placement,
+		ImageMetadata:   imageMetadata,
+		StatusCallback:  instanceStatus,
+		CleanupCallback: statusCleanup,
 	})
 	if err != nil {
 		return nil, "", nil, errors.Annotate(err, "cannot start bootstrap instance")


### PR DESCRIPTION
provider/common/bootstrap.go instanceStatus (StatusCallback) prints to stderr
with carriage returns, overwriting the previous line, to show transient status.

The CleanupCallback field has been added to allow an implementation of
StartInstance the ability to tidy up after itself. This is now used in
provider/common/bootstrap.go and provider/lxd/environ_broker.go to clean up
stderr after the last status message, rather than leaving the next print to
stderr with residual output to overwrite.

This is the only current bootstrap case of StatusCallback. Later use cases may
need to equally clean up after themselves, depending on how they use
StatusCallback.

Fixes lp:1608529

QA steps:

 * Bootstrapping a lxd cloud should no longer show a spurious 'd' after the instance name (see the bug) in the output. This must be tested without the --debug option, the use of which masks the bug

 * If you delete your lxc image before bootstrap, you should see the download status of a new image. This status message should completely disappear from stderr after the instance starts

(Review request: http://reviews.vapour.ws/r/5478/)