### PR TITLE
backport use of utils.SecureTLSConfig

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -4,7 +4,6 @@
 package api
 
 import (
-	"crypto/tls"
 	"crypto/x509"
 	"io"
 	"net/http"
@@ -235,10 +234,9 @@ func setUpWebsocket(addr, path string, header http.Header, rootCAs *x509.CertPoo
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	cfg.TlsConfig = &tls.Config{
-		RootCAs:    rootCAs,
-		ServerName: "juju-apiserver",
-	}
+	cfg.TlsConfig = utils.SecureTLSConfig()
+	cfg.TlsConfig.RootCAs = rootCAs
+	cfg.TlsConfig.ServerName = "juju-apiserver"
 	cfg.Header = header
 	return cfg, nil
 }

--- a/api/http.go
+++ b/api/http.go
@@ -4,7 +4,6 @@
 package api
 
 import (
-	"crypto/tls"
 	"io"
 	"net/http"
 	"net/url"
@@ -23,13 +22,13 @@ var newHTTPClient = func(s Connection) apihttp.HTTPClient {
 // NewHTTPClient returns an HTTP client initialized based on State.
 func (s *State) NewHTTPClient() *http.Client {
 	httpclient := utils.GetValidatingHTTPClient()
-	tlsconfig := tls.Config{
-		RootCAs: s.certPool,
-		// We want to be specific here (rather than just using "anything".
-		// See commit 7fc118f015d8480dfad7831788e4b8c0432205e8 (PR 899).
-		ServerName: "juju-apiserver",
-	}
-	httpclient.Transport = utils.NewHttpTLSTransport(&tlsconfig)
+	tlsconfig := utils.SecureTLSConfig()
+	tlsconfig.RootCAs = s.certPool
+	// We want to be specific here (rather than just using "anything".
+	// See commit 7fc118f015d8480dfad7831788e4b8c0432205e8 (PR 899).
+	tlsconfig.ServerName = "juju-apiserver"
+
+	httpclient.Transport = utils.NewHttpTLSTransport(tlsconfig)
 	return httpclient
 }
 

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -185,13 +185,11 @@ func newServer(s *state.State, lis *net.TCPListener, cfg ServerConfig) (*Server,
 	if err != nil {
 		return nil, err
 	}
-	// TODO(rog) check that *srvRoot is a valid type for using
-	// as an RPC server.
-	tlsConfig := tls.Config{
-		Certificates: []tls.Certificate{tlsCert},
-		MinVersion:   tls.VersionTLS10,
-	}
-	changeCertListener := newChangeCertListener(lis, cfg.CertChanged, tlsConfig)
+
+	tlsConfig := utils.SecureTLSConfig()
+	tlsConfig.Certificates = []tls.Certificate{tlsCert}
+
+	changeCertListener := newChangeCertListener(lis, cfg.CertChanged, *tlsConfig)
 	go srv.run(changeCertListener)
 	return srv, nil
 }

--- a/apiserver/authhttp_test.go
+++ b/apiserver/authhttp_test.go
@@ -5,7 +5,6 @@ package apiserver_test
 
 import (
 	"bufio"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"io"
@@ -66,7 +65,9 @@ func (s *authHttpSuite) makeWebsocketConfigFromURL(c *gc.C, server string, heade
 	config.Header = header
 	caCerts := x509.NewCertPool()
 	c.Assert(caCerts.AppendCertsFromPEM([]byte(testing.CACert)), jc.IsTrue)
-	config.TlsConfig = &tls.Config{RootCAs: caCerts, ServerName: "anything"}
+	config.TlsConfig = utils.SecureTLSConfig()
+	config.TlsConfig.RootCAs = caCerts
+	config.TlsConfig.ServerName = "anything"
 	return config
 }
 

--- a/apiserver/metricsender/sender.go
+++ b/apiserver/metricsender/sender.go
@@ -5,7 +5,6 @@ package metricsender
 
 import (
 	"bytes"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"net/http"
@@ -33,7 +32,9 @@ func (s *HttpSender) Send(metrics []*wireformat.MetricBatch) (*wireformat.Respon
 		return nil, errors.Trace(err)
 	}
 	r := bytes.NewBuffer(b)
-	t := utils.NewHttpTLSTransport(&tls.Config{RootCAs: metricsCertsPool})
+	cfg := utils.SecureTLSConfig()
+	cfg.RootCAs = metricsCertsPool
+	t := utils.NewHttpTLSTransport(cfg)
 	client := &http.Client{Transport: t}
 	resp, err := client.Post(metricsHost, "application/json", r)
 	if err != nil {

--- a/apiserver/metricsender/sender_test.go
+++ b/apiserver/metricsender/sender_test.go
@@ -55,9 +55,9 @@ func (s *SenderSuite) SetUpTest(c *gc.C) {
 func (s *SenderSuite) startServer(c *gc.C, handler http.Handler) func() {
 	ts := httptest.NewUnstartedServer(handler)
 	certPool, cert := createCerts(c, "127.0.0.1")
-	ts.TLS = &tls.Config{
-		Certificates: []tls.Certificate{cert},
-	}
+	ts.TLS = utils.SecureTLSConfig()
+	ts.TLS.Certificates = []tls.Certificate{cert}
+
 	ts.StartTLS()
 	cleanup := metricsender.PatchHostAndCertPool(ts.URL, certPool)
 	return func() {

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	"golang.org/x/net/websocket"
 	gc "gopkg.in/check.v1"
 
@@ -259,10 +260,14 @@ func dialWebsocket(c *gc.C, addr, path string, tlsVersion uint16) (*websocket.Co
 	xcert, err := cert.ParseCert(coretesting.CACert)
 	c.Assert(err, jc.ErrorIsNil)
 	pool.AddCert(xcert)
-	config.TlsConfig = &tls.Config{
-		RootCAs:    pool,
-		MaxVersion: tlsVersion,
+	config.TlsConfig = utils.SecureTLSConfig()
+	if tlsVersion > 0 {
+		// This is for testing only. Please don't muck with the maxtlsversion in
+		// production.
+		config.TlsConfig.MaxVersion = tlsVersion
 	}
+	config.TlsConfig.RootCAs = pool
+
 	return websocket.DialConfig(config)
 }
 

--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cert"
@@ -237,14 +238,14 @@ func checkTLSConnection(c *gc.C, caCert, srvCert *x509.Certificate, srvKey *rsa.
 	var clientState tls.ConnectionState
 	done := make(chan error)
 	go func() {
-		config := tls.Config{
-			Certificates: []tls.Certificate{{
-				Certificate: [][]byte{srvCert.Raw},
-				PrivateKey:  srvKey,
-			}},
-		}
+		config := utils.SecureTLSConfig()
 
-		conn := tls.Server(p1, &config)
+		config.Certificates = []tls.Certificate{{
+			Certificate: [][]byte{srvCert.Raw},
+			PrivateKey:  srvKey,
+		}}
+
+		conn := tls.Server(p1, config)
 		defer conn.Close()
 		data, err := ioutil.ReadAll(conn)
 		c.Assert(err, jc.ErrorIsNil)
@@ -252,10 +253,10 @@ func checkTLSConnection(c *gc.C, caCert, srvCert *x509.Certificate, srvKey *rsa.
 		close(done)
 	}()
 
-	clientConn := tls.Client(p0, &tls.Config{
-		ServerName: "anyServer",
-		RootCAs:    clientCertPool,
-	})
+	cfg := utils.SecureTLSConfig()
+	cfg.ServerName = "anyServer"
+	cfg.RootCAs = clientCertPool
+	clientConn := tls.Client(p0, cfg)
 	defer clientConn.Close()
 
 	_, err := clientConn.Write([]byte(msg))

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -29,7 +29,7 @@ github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T0
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
 github.com/juju/testing	git	162fafccebf20a4207ab93d63b986c230e3f4d2e	2015-05-29T04:40:43Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	9e19645362dc6932f4b395ea1c11649f953d2e93	2016-07-29T19:51:26Z
+github.com/juju/utils	git	70bf09197df816ad8cdf2ed5a6db59c0424cfb9a	2016-08-18T18:26:56Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 golang.org/x/crypto	git	c57d4a71915a248dbad846d60825145062b4c18e	2015-03-27T05:11:19Z
 golang.org/x/net	git	bb64f4dc73d4ab97978d5e1cb34515dcc570361b	2015-05-18T01:39:50Z

--- a/environs/httpstorage/backend_test.go
+++ b/environs/httpstorage/backend_test.go
@@ -5,7 +5,6 @@ package httpstorage_test
 
 import (
 	"bytes"
-	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
@@ -429,8 +428,10 @@ func (b *backendSuite) tlsServerAndClient(c *gc.C) (client *http.Client, url, da
 	b.AddCleanup(func(*gc.C) { listener.Close() })
 	caCerts := x509.NewCertPool()
 	c.Assert(caCerts.AppendCertsFromPEM([]byte(coretesting.CACert)), jc.IsTrue)
+	cfg := utils.SecureTLSConfig()
+	cfg.RootCAs = caCerts
 	client = &http.Client{
-		Transport: utils.NewHttpTLSTransport(&tls.Config{RootCAs: caCerts}),
+		Transport: utils.NewHttpTLSTransport(cfg),
 	}
 	return client, url, dataDir
 }

--- a/environs/httpstorage/storage.go
+++ b/environs/httpstorage/storage.go
@@ -4,7 +4,6 @@
 package httpstorage
 
 import (
-	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"io"
@@ -54,11 +53,13 @@ func ClientTLS(addr string, caCertPEM string, authkey string) (storage.Storage, 
 	if !caCerts.AppendCertsFromPEM([]byte(caCertPEM)) {
 		return nil, errors.New("error adding CA certificate to pool")
 	}
+	cfg := utils.SecureTLSConfig()
+	cfg.RootCAs = caCerts
 	return &localStorage{
 		addr:    addr,
 		authkey: authkey,
 		client: &http.Client{
-			Transport: utils.NewHttpTLSTransport(&tls.Config{RootCAs: caCerts}),
+			Transport: utils.NewHttpTLSTransport(cfg),
 		},
 	}, nil
 }

--- a/mongo/open.go
+++ b/mongo/open.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
+	"github.com/juju/utils"
 	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/cert"
@@ -107,10 +108,18 @@ func DialInfo(info Info, opts DialOpts) (*mgo.DialInfo, error) {
 	}
 	pool := x509.NewCertPool()
 	pool.AddCert(xcert)
-	tlsConfig := &tls.Config{
-		RootCAs:    pool,
-		ServerName: "juju-mongodb",
+	tlsConfig := utils.SecureTLSConfig()
+
+	// TODO(natefinch): revisit this when are full-time on mongo 3.
+	// We have to add non-ECDHE suites because mongo doesn't support ECDHE.
+	moreSuites := []uint16{
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
 	}
+	tlsConfig.CipherSuites = append(tlsConfig.CipherSuites, moreSuites...)
+	tlsConfig.RootCAs = pool
+	tlsConfig.ServerName = "juju-mongodb"
+
 	dial := func(addr net.Addr) (net.Conn, error) {
 		c, err := net.Dial("tcp", addr.String())
 		if err != nil {

--- a/worker/rsyslog/worker.go
+++ b/worker/rsyslog/worker.go
@@ -196,10 +196,10 @@ func (h *RsyslogConfigHandler) composeTLS(caCert string) (*tls.Config, error) {
 	if !ok {
 		return nil, errors.Errorf("Failed to parse rsyslog root certificate")
 	}
-	return &tls.Config{
-		RootCAs:    cert,
-		ServerName: "juju-rsyslog",
-	}, nil
+	cfg := utils.SecureTLSConfig()
+	cfg.RootCAs = cert
+	cfg.ServerName = "juju-rsyslog"
+	return cfg, nil
 }
 
 func (h *RsyslogConfigHandler) replaceRemoteLogger(caCert string) error {


### PR DESCRIPTION
This was a manual backport, which luckily was just a matter of find and replace, more or less.
We should use utils.SecureTLSConfig everywhere we need a tls.Config.

Compare to https://github.com/juju/juju/pull/5310/files

(Review request: http://reviews.vapour.ws/r/5480/)