### PR TITLE
juju/provider/vsphere: do not build storage.go on gccgo

### DIFF
--- a/provider/vsphere/storage.go
+++ b/provider/vsphere/storage.go
@@ -1,6 +1,8 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+
 package vsphere
 
 import (


### PR DESCRIPTION
Or maybe the package actually builds with gccgo now?