### PR TITLE
Cmd formatter update

### DIFF
--- a/cmd/juju/action/list.go
+++ b/cmd/juju/action/list.go
@@ -4,10 +4,9 @@
 package action
 
 import (
-	"bytes"
 	"fmt"
+	"io"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/juju/cmd"
 	errors "github.com/juju/errors"
@@ -17,6 +16,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 )
 
 func NewListCommand() cmd.Command {
@@ -40,7 +40,11 @@ For more information, see also the 'run-action' command, which executes actions.
 
 // Set up the output.
 func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
+		"yaml":    cmd.FormatYaml,
+		"json":    cmd.FormatJson,
+		"tabular": c.printTabular,
+	})
 	f.BoolVar(&c.fullSchema, "schema", false, "Display the full action schema")
 }
 
@@ -56,6 +60,9 @@ func (c *listCommand) Info() *cmd.Info {
 
 // Init validates the service name and any other options.
 func (c *listCommand) Init(args []string) error {
+	if c.out.Name() == "tabular" && c.fullSchema {
+		return errors.New("full schema not compatible with tabular output")
+	}
 	switch len(args) {
 	case 0:
 		return errors.New("no application name specified")
@@ -85,10 +92,6 @@ func (c *listCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 
-	if len(actions) == 0 {
-		return c.out.Write(ctx, "No actions defined for "+c.applicationTag.Id())
-	}
-
 	if c.fullSchema {
 		verboseSpecs := make(map[string]interface{})
 		for k, v := range actions {
@@ -108,25 +111,44 @@ func (c *listCommand) Run(ctx *cmd.Context) error {
 		sortedNames = append(sortedNames, name)
 	}
 	utils.SortStringsNaturally(sortedNames)
-	return c.printTabular(ctx, shortOutput, sortedNames)
+
+	var output interface{}
+	switch c.out.Name() {
+	case "yaml", "json":
+		output = shortOutput
+	default:
+		var list []listOutput
+		for _, name := range sortedNames {
+			list = append(list, listOutput{name, shortOutput[name]})
+		}
+		output = list
+	}
+
+	return c.out.Write(ctx, output)
+}
+
+type listOutput struct {
+	action      string
+	description string
 }
 
 // printTabular prints the list of actions in tabular format
-func (c *listCommand) printTabular(ctx *cmd.Context, actions map[string]string, sortedNames []string) error {
-	var out bytes.Buffer
-	const (
-		// To format things into columns.
-		minwidth = 0
-		tabwidth = 2
-		padding  = 2
-		padchar  = ' '
-		flags    = 0
-	)
-	tw := tabwriter.NewWriter(&out, minwidth, tabwidth, padding, padchar, flags)
+func (c *listCommand) printTabular(writer io.Writer, value interface{}) error {
+	list, ok := value.([]listOutput)
+	if !ok {
+		return errors.New("unexpected value")
+	}
+
+	if len(list) == 0 {
+		fmt.Fprintf(writer, "No actions defined for %s", c.applicationTag.Id())
+		return nil
+	}
+
+	tw := output.TabWriter(writer)
 	fmt.Fprintf(tw, "%s\t%s\n", "ACTION", "DESCRIPTION")
-	for _, name := range sortedNames {
-		fmt.Fprintf(tw, "%s\t%s\n", name, strings.TrimSpace(actions[name]))
+	for _, value := range list {
+		fmt.Fprintf(tw, "%s\t%s\n", value.action, strings.TrimSpace(value.description))
 	}
 	tw.Flush()
-	return c.out.Write(ctx, string(out.Bytes()))
+	return nil
 }

--- a/cmd/juju/action/list_test.go
+++ b/cmd/juju/action/list_test.go
@@ -57,8 +57,12 @@ func (s *ListSuite) TestInit(c *gc.C) {
 		args:        []string{validServiceId},
 		expectedSvc: names.NewApplicationTag(validServiceId),
 	}, {
+		should:      "schema with tabular output",
+		args:        []string{"--schema", validServiceId},
+		expectedErr: "full schema not compatible with tabular output",
+	}, {
 		should:               "init properly with valid application name and --schema",
-		args:                 []string{"--schema", validServiceId},
+		args:                 []string{"--format=yaml", "--schema", validServiceId},
 		expectedOutputSchema: true,
 		expectedSvc:          names.NewApplicationTag(validServiceId),
 	}}
@@ -71,6 +75,7 @@ func (s *ListSuite) TestInit(c *gc.C) {
 			args := append([]string{modelFlag, "admin"}, t.args...)
 			err := testing.InitCommand(s.wrappedCommand, args)
 			if t.expectedErr == "" {
+				c.Check(err, jc.ErrorIsNil)
 				c.Check(s.command.ApplicationTag(), gc.Equals, t.expectedSvc)
 				c.Check(s.command.FullSchema(), gc.Equals, t.expectedOutputSchema)
 			} else {
@@ -110,7 +115,7 @@ snapshot        Take a snapshot of the database.
 		withCharmActions: someCharmActions,
 	}, {
 		should:           "get full schema results properly",
-		withArgs:         []string{"--schema", validServiceId},
+		withArgs:         []string{"--format=yaml", "--schema", validServiceId},
 		expectFullSchema: true,
 		withCharmActions: someCharmActions,
 	}, {

--- a/cmd/juju/action/list_test.go
+++ b/cmd/juju/action/list_test.go
@@ -58,7 +58,7 @@ func (s *ListSuite) TestInit(c *gc.C) {
 		expectedSvc: names.NewApplicationTag(validServiceId),
 	}, {
 		should:      "schema with tabular output",
-		args:        []string{"--schema", validServiceId},
+		args:        []string{"--format=tabular", "--schema", validServiceId},
 		expectedErr: "full schema not compatible with tabular output",
 	}, {
 		should:               "init properly with valid application name and --schema",

--- a/cmd/juju/action/run.go
+++ b/cmd/juju/action/run.go
@@ -4,7 +4,6 @@
 package action
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -141,7 +140,7 @@ func (c *runCommand) Init(args []string) error {
 		}
 		ActionName := args[1]
 		if valid := ActionNameRule.MatchString(ActionName); !valid {
-			return fmt.Errorf("invalid action name %q", ActionName)
+			return errors.Errorf("invalid action name %q", ActionName)
 		}
 		c.unitTag = names.NewUnitTag(unitName)
 		c.actionName = ActionName
@@ -153,13 +152,13 @@ func (c *runCommand) Init(args []string) error {
 		for _, arg := range args[2:] {
 			thisArg := strings.SplitN(arg, "=", 2)
 			if len(thisArg) != 2 {
-				return fmt.Errorf("argument %q must be of the form key...=value", arg)
+				return errors.Errorf("argument %q must be of the form key...=value", arg)
 			}
 			keySlice := strings.Split(thisArg[0], ".")
 			// check each key for validity
 			for _, key := range keySlice {
 				if valid := keyRule.MatchString(key); !valid {
-					return fmt.Errorf("key %q must start and end with lowercase alphanumeric, and contain only lowercase alphanumeric and hyphens", key)
+					return errors.Errorf("key %q must start and end with lowercase alphanumeric, and contain only lowercase alphanumeric and hyphens", key)
 				}
 			}
 			// c.args={..., [key, key, key, key, value]}

--- a/cmd/juju/action/run.go
+++ b/cmd/juju/action/run.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 )
 
 var keyRule = regexp.MustCompile("^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
@@ -111,7 +112,7 @@ var ActionNameRule = regexp.MustCompile("^[a-z](?:[a-z-]*[a-z])?$")
 
 // SetFlags offers an option for YAML output.
 func (c *runCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
 	f.Var(&c.paramsYAML, "params", "Path to yaml-formatted params file")
 	f.BoolVar(&c.parseStrings, "string-args", false, "Use raw string values of CLI args")
 }

--- a/cmd/juju/action/showoutput.go
+++ b/cmd/juju/action/showoutput.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 )
 
 func NewShowOutputCommand() cmd.Command {
@@ -41,7 +42,7 @@ displayed.  This is also the behavior when any negative time is given.
 
 // Set up the output.
 func (c *showOutputCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
 	f.StringVar(&c.wait, "wait", "-1s", "Wait for results")
 }
 

--- a/cmd/juju/action/status.go
+++ b/cmd/juju/action/status.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 )
 
 func NewStatusCommand() cmd.Command {
@@ -32,7 +33,7 @@ If --name <name> is provided the search will be done by name rather than by ID.
 
 // Set up the output.
 func (c *statusCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
 	f.StringVar(&c.name, "name", "", "Action name")
 }
 

--- a/cmd/juju/action/status_test.go
+++ b/cmd/juju/action/status_test.go
@@ -113,9 +113,10 @@ func (s *StatusSuite) runTestCase(c *gc.C, tc statusTestCase) {
 			c.Assert(err, gc.ErrorMatches, tc.expectError)
 		}
 		if len(tc.results) > 0 {
-			buf, err := cmd.DefaultFormatters["yaml"](action.ActionResultsToMap(tc.results))
+			out := &bytes.Buffer{}
+			err := cmd.DefaultFormatters["yaml"](out, action.ActionResultsToMap(tc.results))
 			c.Check(err, jc.ErrorIsNil)
-			c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, string(buf)+"\n")
+			c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, out.String()+"\n")
 			c.Check(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
 		}
 	}

--- a/cmd/juju/application/addrelation.go
+++ b/cmd/juju/application/addrelation.go
@@ -4,8 +4,6 @@
 package application
 
 import (
-	"fmt"
-
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 
@@ -37,7 +35,7 @@ func (c *addRelationCommand) Info() *cmd.Info {
 
 func (c *addRelationCommand) Init(args []string) error {
 	if len(args) != 2 {
-		return fmt.Errorf("a relation must involve two applications")
+		return errors.Errorf("a relation must involve two applications")
 	}
 	c.Endpoints = args
 	return nil

--- a/cmd/juju/application/constraints.go
+++ b/cmd/juju/application/constraints.go
@@ -5,6 +5,7 @@ package application
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -108,8 +109,9 @@ func (c *serviceGetConstraintsCommand) Info() *cmd.Info {
 	}
 }
 
-func formatConstraints(value interface{}) ([]byte, error) {
-	return []byte(value.(constraints.Value).String()), nil
+func formatConstraints(writer io.Writer, value interface{}) error {
+	fmt.Fprint(writer, value.(constraints.Value).String())
+	return nil
 }
 
 func (c *serviceGetConstraintsCommand) SetFlags(f *gnuflag.FlagSet) {

--- a/cmd/juju/application/constraints.go
+++ b/cmd/juju/application/constraints.go
@@ -124,10 +124,10 @@ func (c *serviceGetConstraintsCommand) SetFlags(f *gnuflag.FlagSet) {
 
 func (c *serviceGetConstraintsCommand) Init(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("no application name specified")
+		return errors.Errorf("no application name specified")
 	}
 	if !names.IsValidApplication(args[0]) {
-		return fmt.Errorf("invalid application name %q", args[0])
+		return errors.Errorf("invalid application name %q", args[0])
 	}
 
 	c.ApplicationName, args = args[0], args[1:]
@@ -169,10 +169,10 @@ func (c *serviceSetConstraintsCommand) Info() *cmd.Info {
 
 func (c *serviceSetConstraintsCommand) Init(args []string) (err error) {
 	if len(args) == 0 {
-		return fmt.Errorf("no application name specified")
+		return errors.Errorf("no application name specified")
 	}
 	if !names.IsValidApplication(args[0]) {
-		return fmt.Errorf("invalid application name %q", args[0])
+		return errors.Errorf("invalid application name %q", args[0])
 	}
 
 	c.ApplicationName, args = args[0], args[1:]

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -258,7 +258,7 @@ func (c *DeployCommand) Init(args []string) error {
 	switch len(args) {
 	case 2:
 		if !names.IsValidApplication(args[1]) {
-			return fmt.Errorf("invalid application name %q", args[1])
+			return errors.Errorf("invalid application name %q", args[1])
 		}
 		c.ApplicationName = args[1]
 		fallthrough

--- a/cmd/juju/application/fakeapplication_test.go
+++ b/cmd/juju/application/fakeapplication_test.go
@@ -90,7 +90,7 @@ func (f *fakeServiceAPI) Unset(application string, options []string) error {
 	// Verify all options before unsetting any of them.
 	for _, name := range options {
 		if _, ok := f.values[name]; !ok {
-			return fmt.Errorf("unknown option %q", name)
+			return errors.Errorf("unknown option %q", name)
 		}
 	}
 

--- a/cmd/juju/application/get.go
+++ b/cmd/juju/application/get.go
@@ -4,6 +4,7 @@
 package application
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/juju/cmd"
@@ -13,6 +14,7 @@ import (
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 )
 
 var usageGetConfigSummary = `
@@ -60,10 +62,7 @@ func (c *getCommand) Info() *cmd.Info {
 }
 
 func (c *getCommand) SetFlags(f *gnuflag.FlagSet) {
-	// TODO(dfc) add json formatting ?
-	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
-		"yaml": cmd.FormatYaml,
-	})
+	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
 }
 
 func (c *getCommand) Init(args []string) error {
@@ -115,11 +114,12 @@ func (c *getCommand) Run(ctx *cmd.Context) error {
 		if !found {
 			return fmt.Errorf("key %q not found in %q application settings.", c.key, c.applicationName)
 		}
-		out, err := cmd.FormatSmart(info["value"])
+		out := &bytes.Buffer{}
+		err := cmd.FormatYaml(out, info["value"])
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(ctx.Stdout, "%v\n", string(out))
+		fmt.Fprintln(ctx.Stdout, out.String())
 		return nil
 	}
 

--- a/cmd/juju/application/get.go
+++ b/cmd/juju/application/get.go
@@ -66,7 +66,6 @@ func (c *getCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *getCommand) Init(args []string) error {
-	// TODO(dfc) add --schema-only
 	if len(args) == 0 {
 		return errors.New("no application name specified")
 	}
@@ -112,7 +111,7 @@ func (c *getCommand) Run(ctx *cmd.Context) error {
 	if c.key != "" {
 		info, found := results.Config[c.key].(map[string]interface{})
 		if !found {
-			return fmt.Errorf("key %q not found in %q application settings.", c.key, c.applicationName)
+			return errors.Errorf("key %q not found in %q application settings.", c.key, c.applicationName)
 		}
 		out := &bytes.Buffer{}
 		err := cmd.FormatYaml(out, info["value"])

--- a/cmd/juju/application/register_test.go
+++ b/cmd/juju/application/register_test.go
@@ -4,7 +4,6 @@ package application
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 
@@ -354,7 +353,7 @@ func (s *registrationSuite) TestUnmeteredCharm(c *gc.C) {
 }
 
 func (s *registrationSuite) TestFailedAuth(c *gc.C) {
-	s.stub.SetErrors(nil, fmt.Errorf("could not authorize"))
+	s.stub.SetErrors(nil, errors.Errorf("could not authorize"))
 	client := httpbakery.NewClient()
 	d := DeploymentInfo{
 		CharmID: charmstore.CharmID{

--- a/cmd/juju/application/removeapplication.go
+++ b/cmd/juju/application/removeapplication.go
@@ -59,10 +59,10 @@ func (c *removeServiceCommand) Info() *cmd.Info {
 
 func (c *removeServiceCommand) Init(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("no application specified")
+		return errors.Errorf("no application specified")
 	}
 	if !names.IsValidApplication(args[0]) {
-		return fmt.Errorf("invalid application name %q", args[0])
+		return errors.Errorf("invalid application name %q", args[0])
 	}
 	c.ApplicationName, args = args[0], args[1:]
 	return cmd.CheckEmpty(args)

--- a/cmd/juju/application/removerelation.go
+++ b/cmd/juju/application/removerelation.go
@@ -4,8 +4,6 @@
 package application
 
 import (
-	"fmt"
-
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 
@@ -62,7 +60,7 @@ func (c *removeRelationCommand) Info() *cmd.Info {
 
 func (c *removeRelationCommand) Init(args []string) error {
 	if len(args) != 2 {
-		return fmt.Errorf("a relation must involve two applications")
+		return errors.Errorf("a relation must involve two applications")
 	}
 	c.Endpoints = args
 	return nil

--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -4,8 +4,6 @@
 package application
 
 import (
-	"fmt"
-
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
@@ -60,11 +58,11 @@ func (c *removeUnitCommand) Info() *cmd.Info {
 func (c *removeUnitCommand) Init(args []string) error {
 	c.UnitNames = args
 	if len(c.UnitNames) == 0 {
-		return fmt.Errorf("no units specified")
+		return errors.Errorf("no units specified")
 	}
 	for _, name := range c.UnitNames {
 		if !names.IsValidUnit(name) {
-			return fmt.Errorf("invalid unit name %q", name)
+			return errors.Errorf("invalid unit name %q", name)
 		}
 	}
 	return nil

--- a/cmd/juju/application/set.go
+++ b/cmd/juju/application/set.go
@@ -158,7 +158,7 @@ func (c *setCommand) Run(ctx *cmd.Context) error {
 
 		if v[0] != '@' {
 			if !utf8.ValidString(v) {
-				return fmt.Errorf("value for option %q contains non-UTF-8 sequences", k)
+				return errors.Errorf("value for option %q contains non-UTF-8 sequences", k)
 			}
 			settings[k] = v
 			continue
@@ -168,7 +168,7 @@ func (c *setCommand) Run(ctx *cmd.Context) error {
 			return err
 		}
 		if !utf8.ValidString(nv) {
-			return fmt.Errorf("value for option %q contains non-UTF-8 sequences", k)
+			return errors.Errorf("value for option %q contains non-UTF-8 sequences", k)
 		}
 		settings[k] = nv
 	}
@@ -200,14 +200,14 @@ func readValue(ctx *cmd.Context, filename string) (string, error) {
 	absFilename := ctx.AbsPath(filename)
 	fi, err := os.Stat(absFilename)
 	if err != nil {
-		return "", fmt.Errorf("cannot read option from file %q: %v", filename, err)
+		return "", errors.Errorf("cannot read option from file %q: %v", filename, err)
 	}
 	if fi.Size() > maxValueSize {
-		return "", fmt.Errorf("size of option file is larger than 5M")
+		return "", errors.Errorf("size of option file is larger than 5M")
 	}
 	content, err := ioutil.ReadFile(ctx.AbsPath(filename))
 	if err != nil {
-		return "", fmt.Errorf("cannot read option from file %q: %v", filename, err)
+		return "", errors.Errorf("cannot read option from file %q: %v", filename, err)
 	}
 	return string(content), nil
 }

--- a/cmd/juju/application/upgradecharm.go
+++ b/cmd/juju/application/upgradecharm.go
@@ -4,7 +4,6 @@
 package application
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -136,22 +135,22 @@ func (c *upgradeCharmCommand) Init(args []string) error {
 	switch len(args) {
 	case 1:
 		if !names.IsValidApplication(args[0]) {
-			return fmt.Errorf("invalid application name %q", args[0])
+			return errors.Errorf("invalid application name %q", args[0])
 		}
 		c.ApplicationName = args[0]
 	case 0:
-		return fmt.Errorf("no application specified")
+		return errors.Errorf("no application specified")
 	default:
 		return cmd.CheckEmpty(args[1:])
 	}
 	if c.SwitchURL != "" && c.Revision != -1 {
-		return fmt.Errorf("--switch and --revision are mutually exclusive")
+		return errors.Errorf("--switch and --revision are mutually exclusive")
 	}
 	if c.CharmPath != "" && c.Revision != -1 {
-		return fmt.Errorf("--path and --revision are mutually exclusive")
+		return errors.Errorf("--path and --revision are mutually exclusive")
 	}
 	if c.SwitchURL != "" && c.CharmPath != "" {
-		return fmt.Errorf("--switch and --path are mutually exclusive")
+		return errors.Errorf("--switch and --path are mutually exclusive")
 	}
 	return nil
 }
@@ -362,7 +361,7 @@ func (c *upgradeCharmCommand) addCharm(
 	if err == nil {
 		_, newName := filepath.Split(charmRef)
 		if newName != oldURL.Name {
-			return id, nil, fmt.Errorf("cannot upgrade %q to %q", oldURL.Name, newName)
+			return id, nil, errors.Errorf("cannot upgrade %q to %q", oldURL.Name, newName)
 		}
 		addedURL, err := client.AddLocalCharm(newURL, ch)
 		id.URL = addedURL
@@ -402,12 +401,12 @@ func (c *upgradeCharmCommand) addCharm(
 	// or Revision flags, discover the latest.
 	if *newURL == *oldURL {
 		if refURL.Revision != -1 {
-			return id, nil, fmt.Errorf("already running specified charm %q", newURL)
+			return id, nil, errors.Errorf("already running specified charm %q", newURL)
 		}
 		// No point in trying to upgrade a charm store charm when
 		// we just determined that's the latest revision
 		// available.
-		return id, nil, fmt.Errorf("already running latest charm %q", newURL)
+		return id, nil, errors.Errorf("already running latest charm %q", newURL)
 	}
 
 	curl, csMac, err := addCharmFromURL(client, newURL, channel, store.Client())

--- a/cmd/juju/block/list.go
+++ b/cmd/juju/block/list.go
@@ -4,9 +4,8 @@
 package block
 
 import (
-	"bytes"
 	"fmt"
-	"text/tabwriter"
+	"io"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 )
 
 func newListCommand() cmd.Command {
@@ -117,15 +117,14 @@ func formatBlockInfo(all []params.Block) []BlockInfo {
 	return output
 }
 
-// formatBlocks returns block list representation.
-func formatBlocks(value interface{}) ([]byte, error) {
+// formatBlocks writes block list representation.
+func formatBlocks(writer io.Writer, value interface{}) error {
 	blocks, ok := value.([]BlockInfo)
 	if !ok {
-		return nil, errors.Errorf("expected value of type %T, got %T", blocks, value)
+		return errors.Errorf("expected value of type %T, got %T", blocks, value)
 	}
-	var out bytes.Buffer
 	// To format things as desired.
-	tw := tabwriter.NewWriter(&out, 0, 1, 1, ' ', 0)
+	tw := output.TabWriter(writer)
 
 	for _, ablock := range blocks {
 		fmt.Fprintln(tw)
@@ -135,13 +134,13 @@ func formatBlocks(value interface{}) ([]byte, error) {
 		}
 		fmt.Fprintf(tw, "%v\t", ablock.Operation)
 		if ablock.Message != nil {
-			fmt.Fprintf(tw, "\t=%v, %v", switched, *ablock.Message)
+			fmt.Fprintf(tw, "=%v, %v", switched, *ablock.Message)
 			continue
 		}
-		fmt.Fprintf(tw, "\t=%v", switched)
+		fmt.Fprintf(tw, "=%v", switched)
 	}
 
 	tw.Flush()
 
-	return out.Bytes(), nil
+	return nil
 }

--- a/cmd/juju/cachedimages/list.go
+++ b/cmd/juju/cachedimages/list.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 )
 
 const listCommandDoc = `
@@ -62,10 +63,7 @@ func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.Kind, "kind", "", "The image kind to list eg lxd")
 	f.StringVar(&c.Series, "series", "", "The series of the image to list eg xenial")
 	f.StringVar(&c.Arch, "arch", "", "The architecture of the image to list eg amd64")
-	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
-		"yaml": cmd.FormatYaml,
-		"json": cmd.FormatJson,
-	})
+	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
 }
 
 // Init implements Command.Init.

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -4,11 +4,10 @@
 package cloud
 
 import (
-	"bytes"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -17,6 +16,7 @@ import (
 
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/cmd/output"
 )
 
 var logger = loggo.GetLogger("juju.cmd.juju.cloud")
@@ -154,23 +154,14 @@ func listCloudDetails() (*cloudList, error) {
 	return details, nil
 }
 
-// formatCloudsTabular returns a tabular summary of cloud information.
-func formatCloudsTabular(value interface{}) ([]byte, error) {
+// formatCloudsTabular writes a tabular summary of cloud information.
+func formatCloudsTabular(writer io.Writer, value interface{}) error {
 	clouds, ok := value.(*cloudList)
 	if !ok {
-		return nil, errors.Errorf("expected value of type %T, got %T", clouds, value)
+		return errors.Errorf("expected value of type %T, got %T", clouds, value)
 	}
 
-	var out bytes.Buffer
-	const (
-		// To format things into columns.
-		minwidth = 0
-		tabwidth = 1
-		padding  = 2
-		padchar  = ' '
-		flags    = 0
-	)
-	tw := tabwriter.NewWriter(&out, minwidth, tabwidth, padding, padchar, flags)
+	tw := output.TabWriter(writer)
 	p := func(values ...string) {
 		text := strings.Join(values, "\t")
 		fmt.Fprintln(tw, text)
@@ -216,5 +207,5 @@ func formatCloudsTabular(value interface{}) ([]byte, error) {
 	printClouds(clouds.personal)
 
 	tw.Flush()
-	return out.Bytes(), nil
+	return nil
 }

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -4,11 +4,10 @@
 package cloud
 
 import (
-	"bytes"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -16,6 +15,7 @@ import (
 
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/cmd/output"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
 )
@@ -175,11 +175,11 @@ func (c *listCredentialsCommand) removeSecrets(cloudName string, cloudCred *juju
 	return nil
 }
 
-// formatCredentialsTabular returns a tabular summary of cloud information.
-func formatCredentialsTabular(value interface{}) ([]byte, error) {
+// formatCredentialsTabular writes a tabular summary of cloud information.
+func formatCredentialsTabular(writer io.Writer, value interface{}) error {
 	credentials, ok := value.(credentialsMap)
 	if !ok {
-		return nil, errors.Errorf("expected value of type %T, got %T", credentials, value)
+		return errors.Errorf("expected value of type %T, got %T", credentials, value)
 	}
 
 	// For tabular we'll sort alphabetically by cloud, and then by credential name.
@@ -189,16 +189,7 @@ func formatCredentialsTabular(value interface{}) ([]byte, error) {
 	}
 	sort.Strings(cloudNames)
 
-	var out bytes.Buffer
-	const (
-		// To format things into columns.
-		minwidth = 0
-		tabwidth = 1
-		padding  = 2
-		padchar  = ' '
-		flags    = 0
-	)
-	tw := tabwriter.NewWriter(&out, minwidth, tabwidth, padding, padchar, flags)
+	tw := output.TabWriter(writer)
 	p := func(values ...string) {
 		text := strings.Join(values, "\t")
 		fmt.Fprintln(tw, text)
@@ -225,5 +216,5 @@ func formatCredentialsTabular(value interface{}) ([]byte, error) {
 	}
 	tw.Flush()
 
-	return out.Bytes(), nil
+	return nil
 }

--- a/cmd/juju/cloud/updateclouds.go
+++ b/cmd/juju/cloud/updateclouds.go
@@ -79,7 +79,7 @@ func (c *updateCloudsCommand) Run(ctxt *cmd.Context) error {
 		case http.StatusUnauthorized:
 			return errors.Unauthorizedf("unauthorised access to URL %q", c.publicCloudURL)
 		}
-		return fmt.Errorf("cannot read public cloud information at URL %q, %q", c.publicCloudURL, resp.Status)
+		return errors.Errorf("cannot read public cloud information at URL %q, %q", c.publicCloudURL, resp.Status)
 	}
 
 	cloudData, err := decodeCheckSignature(resp.Body, c.publicSigningKey)
@@ -122,7 +122,7 @@ func decodeCheckSignature(r io.Reader, publicKey string) ([]byte, error) {
 	}
 	keyring, err := openpgp.ReadArmoredKeyRing(bytes.NewBufferString(publicKey))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse public key: %v", err)
+		return nil, errors.Errorf("failed to parse public key: %v", err)
 	}
 
 	_, err = openpgp.CheckDetachedSignature(keyring, bytes.NewBuffer(b.Bytes), b.ArmoredSignature.Body)

--- a/cmd/juju/commands/debughooks.go
+++ b/cmd/juju/commands/debughooks.go
@@ -46,11 +46,11 @@ func (c *debugHooksCommand) Info() *cmd.Info {
 
 func (c *debugHooksCommand) Init(args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("no unit name specified")
+		return errors.Errorf("no unit name specified")
 	}
 	c.Target = args[0]
 	if !names.IsValidUnit(c.Target) {
-		return fmt.Errorf("%q is not a valid unit name", c.Target)
+		return errors.Errorf("%q is not a valid unit name", c.Target)
 	}
 
 	// If any of the hooks is "*", then debug all hooks.
@@ -111,7 +111,7 @@ func (c *debugHooksCommand) validateHooks() error {
 			}
 			sort.Strings(names)
 			logger.Infof("unknown hook %s, valid hook names: %v", hook, names)
-			return fmt.Errorf("unit %q does not contain hook %q", c.Target, hook)
+			return errors.Errorf("unit %q does not contain hook %q", c.Target, hook)
 		}
 	}
 	return nil

--- a/cmd/juju/commands/debuglog.go
+++ b/cmd/juju/commands/debuglog.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/ansiterm"
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/loggo"
 
@@ -148,7 +149,7 @@ func (c *debugLogCommand) Init(args []string) error {
 	if c.level != "" {
 		level, ok := loggo.ParseLevel(c.level)
 		if !ok || level < loggo.TRACE || level > loggo.ERROR {
-			return fmt.Errorf("level value %q is not one of %q, %q, %q, %q, %q",
+			return errors.Errorf("level value %q is not one of %q, %q, %q, %q, %q",
 				c.level, loggo.TRACE, loggo.DEBUG, loggo.INFO, loggo.WARNING, loggo.ERROR)
 		}
 		c.params.Level = level

--- a/cmd/juju/commands/enableha.go
+++ b/cmd/juju/commands/enableha.go
@@ -4,8 +4,8 @@
 package commands
 
 import (
-	"bytes"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -88,13 +88,11 @@ Examples:
 `
 
 // formatSimple marshals value to a yaml-formatted []byte, unless value is nil.
-func formatSimple(value interface{}) ([]byte, error) {
+func formatSimple(writer io.Writer, value interface{}) error {
 	enableHAResult, ok := value.(availabilityInfo)
 	if !ok {
-		return nil, fmt.Errorf("unexpected result type for enable-ha call: %T", value)
+		return fmt.Errorf("unexpected result type for enable-ha call: %T", value)
 	}
-
-	var buf bytes.Buffer
 
 	for _, machineList := range []struct {
 		message string
@@ -128,13 +126,13 @@ func formatSimple(value interface{}) ([]byte, error) {
 		if len(machineList.list) == 0 {
 			continue
 		}
-		_, err := fmt.Fprintf(&buf, machineList.message, strings.Join(machineList.list, ", "))
+		_, err := fmt.Fprintf(writer, machineList.message, strings.Join(machineList.list, ", "))
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return buf.Bytes(), nil
+	return nil
 }
 
 func (c *enableHACommand) Info() *cmd.Info {

--- a/cmd/juju/commands/enableha.go
+++ b/cmd/juju/commands/enableha.go
@@ -91,7 +91,7 @@ Examples:
 func formatSimple(writer io.Writer, value interface{}) error {
 	enableHAResult, ok := value.(availabilityInfo)
 	if !ok {
-		return fmt.Errorf("unexpected result type for enable-ha call: %T", value)
+		return errors.Errorf("unexpected result type for enable-ha call: %T", value)
 	}
 
 	for _, machineList := range []struct {
@@ -157,7 +157,7 @@ func (c *enableHACommand) SetFlags(f *gnuflag.FlagSet) {
 
 func (c *enableHACommand) Init(args []string) error {
 	if c.NumControllers < 0 || (c.NumControllers%2 != 1 && c.NumControllers != 0) {
-		return fmt.Errorf("must specify a number of controllers odd and non-negative")
+		return errors.Errorf("must specify a number of controllers odd and non-negative")
 	}
 	if c.PlacementSpec != "" {
 		placementSpecs := strings.Split(c.PlacementSpec, ",")
@@ -173,7 +173,7 @@ func (c *enableHACommand) Init(args []string) error {
 				continue
 			}
 			if err != instance.ErrPlacementScopeMissing {
-				return fmt.Errorf("unsupported enable-ha placement directive %q", spec)
+				return errors.Errorf("unsupported enable-ha placement directive %q", spec)
 			}
 			c.Placement[i] = spec
 		}

--- a/cmd/juju/commands/enableha_test.go
+++ b/cmd/juju/commands/enableha_test.go
@@ -105,7 +105,7 @@ func (s *EnableHASuite) runEnableHA(c *gc.C, args ...string) (*cmd.Context, erro
 func (s *EnableHASuite) TestEnableHA(c *gc.C) {
 	ctx, err := s.runEnableHA(c, "-n", "1")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stdout(ctx), gc.Equals, "")
+	c.Assert(coretesting.Stdout(ctx), gc.Equals, "\n")
 
 	c.Assert(s.fake.numControllers, gc.Equals, 1)
 	c.Assert(&s.fake.cons, jc.Satisfies, constraints.IsEmpty)

--- a/cmd/juju/commands/resolved.go
+++ b/cmd/juju/commands/resolved.go
@@ -4,9 +4,8 @@
 package commands
 
 import (
-	"fmt"
-
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"gopkg.in/juju/names.v2"
 
@@ -42,11 +41,11 @@ func (c *resolvedCommand) Init(args []string) error {
 	if len(args) > 0 {
 		c.UnitName = args[0]
 		if !names.IsValidUnit(c.UnitName) {
-			return fmt.Errorf("invalid unit name %q", c.UnitName)
+			return errors.Errorf("invalid unit name %q", c.UnitName)
 		}
 		args = args[1:]
 	} else {
-		return fmt.Errorf("no unit specified")
+		return errors.Errorf("no unit specified")
 	}
 	return cmd.CheckEmpty(args)
 }

--- a/cmd/juju/commands/run.go
+++ b/cmd/juju/commands/run.go
@@ -93,23 +93,23 @@ func (c *runCommand) SetFlags(f *gnuflag.FlagSet) {
 
 func (c *runCommand) Init(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("no commands specified")
+		return errors.Errorf("no commands specified")
 	}
 	c.commands, args = args[0], args[1:]
 
 	if c.all {
 		if len(c.machines) != 0 {
-			return fmt.Errorf("You cannot specify --all and individual machines")
+			return errors.Errorf("You cannot specify --all and individual machines")
 		}
 		if len(c.services) != 0 {
-			return fmt.Errorf("You cannot specify --all and individual applications")
+			return errors.Errorf("You cannot specify --all and individual applications")
 		}
 		if len(c.units) != 0 {
-			return fmt.Errorf("You cannot specify --all and individual units")
+			return errors.Errorf("You cannot specify --all and individual units")
 		}
 	} else {
 		if len(c.machines) == 0 && len(c.services) == 0 && len(c.units) == 0 {
-			return fmt.Errorf("You must specify a target, either through --all, --machine, --application or --unit")
+			return errors.Errorf("You must specify a target, either through --all, --machine, --application or --unit")
 		}
 	}
 
@@ -130,7 +130,7 @@ func (c *runCommand) Init(args []string) error {
 		}
 	}
 	if len(nameErrors) > 0 {
-		return fmt.Errorf("The following run targets are not valid:\n%s",
+		return errors.Errorf("The following run targets are not valid:\n%s",
 			strings.Join(nameErrors, "\n"))
 	}
 

--- a/cmd/juju/commands/run.go
+++ b/cmd/juju/commands/run.go
@@ -78,7 +78,12 @@ func (c *runCommand) Info() *cmd.Info {
 }
 
 func (c *runCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	c.out.AddFlags(f, "default", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+		// default is used to format a single result specially.
+		"default": cmd.FormatYaml,
+	})
 	f.BoolVar(&c.all, "all", false, "Run the commands on all the machines")
 	f.DurationVar(&c.timeout, "timeout", 5*time.Minute, "How long to wait before the remote command is considered to have failed")
 	f.Var(cmd.NewStringsValue(nil, &c.machines), "machine", "One or more machine ids")
@@ -270,9 +275,9 @@ func (c *runCommand) Run(ctx *cmd.Context) error {
 		<-afterFunc(1 * time.Second)
 	}
 
-	// If we are just dealing with one result, AND we are using the smart
+	// If we are just dealing with one result, AND we are using the default
 	// format, then pretend we were running it locally.
-	if len(values) == 1 && c.out.Name() == "smart" {
+	if len(values) == 1 && c.out.Name() == "default" {
 		result, ok := values[0].(map[string]interface{})
 		if !ok {
 			return errors.New("couldn't read action output")

--- a/cmd/juju/commands/run_test.go
+++ b/cmd/juju/commands/run_test.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 	"strings"
@@ -254,7 +255,8 @@ func (s *RunSuite) TestRunForMachineAndUnit(c *gc.C) {
 		ConvertActionResults(unitResult, unitQuery),
 	}
 
-	jsonFormatted, err := cmd.FormatJson(unformatted)
+	buff := &bytes.Buffer{}
+	err := cmd.FormatJson(buff, unformatted)
 	c.Assert(err, jc.ErrorIsNil)
 
 	context, err := testing.RunCommand(c, newRunCommand(),
@@ -262,7 +264,7 @@ func (s *RunSuite) TestRunForMachineAndUnit(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(testing.Stdout(context), gc.Equals, string(jsonFormatted)+"\n")
+	c.Check(testing.Stdout(context), gc.Equals, buff.String()+"\n")
 }
 
 func (s *RunSuite) TestBlockRunForMachineAndUnit(c *gc.C) {
@@ -316,13 +318,14 @@ func (s *RunSuite) TestAllMachines(c *gc.C) {
 		},
 	}
 
-	jsonFormatted, err := cmd.FormatJson(unformatted)
+	buff := &bytes.Buffer{}
+	err := cmd.FormatJson(buff, unformatted)
 	c.Assert(err, jc.ErrorIsNil)
 
 	context, err := testing.RunCommand(c, newRunCommand(), "--format=json", "--all", "hostname")
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(testing.Stdout(context), gc.Equals, string(jsonFormatted)+"\n")
+	c.Check(testing.Stdout(context), gc.Equals, buff.String()+"\n")
 	c.Check(testing.Stderr(context), gc.Equals, "")
 }
 
@@ -358,10 +361,12 @@ func (s *RunSuite) TestSingleResponse(c *gc.C) {
 		ConvertActionResults(machineResult, query),
 	}
 
-	jsonFormatted, err := cmd.FormatJson(unformatted)
+	jsonFormatted := &bytes.Buffer{}
+	err := cmd.FormatJson(jsonFormatted, unformatted)
 	c.Assert(err, jc.ErrorIsNil)
 
-	yamlFormatted, err := cmd.FormatYaml(unformatted)
+	yamlFormatted := &bytes.Buffer{}
+	err = cmd.FormatYaml(yamlFormatted, unformatted)
 	c.Assert(err, jc.ErrorIsNil)
 
 	for i, test := range []struct {
@@ -378,11 +383,11 @@ func (s *RunSuite) TestSingleResponse(c *gc.C) {
 	}, {
 		message: "yaml output",
 		format:  "yaml",
-		stdout:  string(yamlFormatted) + "\n",
+		stdout:  yamlFormatted.String() + "\n",
 	}, {
 		message: "json output",
 		format:  "json",
-		stdout:  string(jsonFormatted) + "\n",
+		stdout:  jsonFormatted.String() + "\n",
 	}} {
 		c.Log(fmt.Sprintf("%v: %s", i, test.message))
 		args := []string{}

--- a/cmd/juju/commands/scp.go
+++ b/cmd/juju/commands/scp.go
@@ -4,7 +4,6 @@
 package commands
 
 import (
-	"fmt"
 	"net"
 	"strings"
 
@@ -93,7 +92,7 @@ func (c *scpCommand) Info() *cmd.Info {
 
 func (c *scpCommand) Init(args []string) error {
 	if len(args) < 2 {
-		return fmt.Errorf("at least two arguments required")
+		return errors.Errorf("at least two arguments required")
 	}
 	c.Args = args
 	return nil

--- a/cmd/juju/commands/ssh.go
+++ b/cmd/juju/commands/ssh.go
@@ -4,8 +4,6 @@
 package commands
 
 import (
-	"fmt"
-
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/utils/ssh"
@@ -69,7 +67,7 @@ func (c *sshCommand) Info() *cmd.Info {
 
 func (c *sshCommand) Init(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("no target name specified")
+		return errors.Errorf("no target name specified")
 	}
 	c.Target, c.Args = args[0], args[1:]
 	return nil

--- a/cmd/juju/commands/ssh_common.go
+++ b/cmd/juju/commands/ssh_common.go
@@ -5,7 +5,6 @@ package commands
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -231,11 +230,11 @@ func (c *SSHCommon) proxySSH() (bool, error) {
 func (c *SSHCommon) setProxyCommand(options *ssh.Options) error {
 	apiServerHost, _, err := net.SplitHostPort(c.apiAddr)
 	if err != nil {
-		return fmt.Errorf("failed to get proxy address: %v", err)
+		return errors.Errorf("failed to get proxy address: %v", err)
 	}
 	juju, err := getJujuExecutable()
 	if err != nil {
-		return fmt.Errorf("failed to get juju executable path: %v", err)
+		return errors.Errorf("failed to get juju executable path: %v", err)
 	}
 
 	// TODO(mjs) 2016-05-09 LP #1579592 - It would be good to check the

--- a/cmd/juju/controller/getconfig.go
+++ b/cmd/juju/controller/getconfig.go
@@ -4,13 +4,12 @@
 package controller
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 
-	"github.com/juju/errors"
 	apicontroller "github.com/juju/juju/api/controller"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
@@ -93,7 +92,7 @@ func (c *getConfigCommand) Run(ctx *cmd.Context) error {
 		if value, found := attrs[c.key]; found {
 			return c.out.Write(ctx, value)
 		}
-		return fmt.Errorf("key %q not found in %q controller.", c.key, c.ControllerName())
+		return errors.Errorf("key %q not found in %q controller.", c.key, c.ControllerName())
 	}
 	// If key is empty, write out the whole lot.
 	return c.out.Write(ctx, attrs)

--- a/cmd/juju/controller/getconfig.go
+++ b/cmd/juju/controller/getconfig.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 	apicontroller "github.com/juju/juju/api/controller"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 	"github.com/juju/juju/controller"
 )
 
@@ -52,7 +53,7 @@ func (c *getConfigCommand) Info() *cmd.Info {
 }
 
 func (c *getConfigCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
 }
 
 func (c *getConfigCommand) Init(args []string) (err error) {

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -127,7 +127,7 @@ func (c *addCommand) SetFlags(f *gnuflag.FlagSet) {
 
 func (c *addCommand) Init(args []string) error {
 	if c.Constraints.Container != nil {
-		return fmt.Errorf("container constraint %q not allowed when adding a machine", *c.Constraints.Container)
+		return errors.Errorf("container constraint %q not allowed when adding a machine", *c.Constraints.Container)
 	}
 	placement, err := cmd.ZeroOrOneArgs(args)
 	if err != nil {

--- a/cmd/juju/machine/remove.go
+++ b/cmd/juju/machine/remove.go
@@ -4,9 +4,8 @@
 package machine
 
 import (
-	"fmt"
-
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"gopkg.in/juju/names.v2"
 
@@ -67,11 +66,11 @@ func (c *removeCommand) SetFlags(f *gnuflag.FlagSet) {
 
 func (c *removeCommand) Init(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("no machines specified")
+		return errors.Errorf("no machines specified")
 	}
 	for _, id := range args {
 		if !names.IsValidMachine(id) {
-			return fmt.Errorf("invalid machine id %q", id)
+			return errors.Errorf("invalid machine id %q", id)
 		}
 	}
 	c.MachineIds = args

--- a/cmd/juju/model/constraints.go
+++ b/cmd/juju/model/constraints.go
@@ -4,6 +4,9 @@
 package model
 
 import (
+	"fmt"
+	"io"
+
 	"github.com/juju/cmd"
 	"github.com/juju/gnuflag"
 
@@ -100,8 +103,9 @@ func (c *modelGetConstraintsCommand) getAPI() (ConstraintsAPI, error) {
 	return c.NewAPIClient()
 }
 
-func formatConstraints(value interface{}) ([]byte, error) {
-	return []byte(value.(constraints.Value).String()), nil
+func formatConstraints(writer io.Writer, value interface{}) error {
+	fmt.Fprint(writer, value.(constraints.Value).String())
+	return nil
 }
 
 func (c *modelGetConstraintsCommand) SetFlags(f *gnuflag.FlagSet) {

--- a/cmd/juju/model/dump.go
+++ b/cmd/juju/model/dump.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 )
 
 // NewDumpCommand returns a fully constructed dump-model command.
@@ -48,10 +49,7 @@ func (c *dumpCommand) Info() *cmd.Info {
 
 // SetFlags implements Command.
 func (c *dumpCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
-		"yaml": cmd.FormatYaml,
-		"json": cmd.FormatJson,
-	})
+	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
 }
 
 // Init implements Command.

--- a/cmd/juju/model/get.go
+++ b/cmd/juju/model/get.go
@@ -6,9 +6,9 @@ package model
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/juju/api/modelconfig"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 	"github.com/juju/juju/environs/config"
 )
 
@@ -118,11 +119,11 @@ func (c *getCommand) Run(ctx *cmd.Context) error {
 
 	if c.key != "" {
 		if value, found := attrs[c.key]; found {
-			out, err := cmd.FormatSmart(value.Value)
+			err := cmd.FormatYaml(ctx.Stdout, value.Value)
+			fmt.Fprintln(ctx.Stdout)
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(ctx.Stdout, "%v\n", string(out))
 			return nil
 		}
 		return fmt.Errorf("key %q not found in %q model.", c.key, attrs["name"])
@@ -131,23 +132,14 @@ func (c *getCommand) Run(ctx *cmd.Context) error {
 	return c.out.Write(ctx, attrs)
 }
 
-// formatConfigTabular returns a tabular summary of config information.
-func formatConfigTabular(value interface{}) ([]byte, error) {
+// formatConfigTabular writes a tabular summary of config information.
+func formatConfigTabular(writer io.Writer, value interface{}) error {
 	configValues, ok := value.(config.ConfigValues)
 	if !ok {
-		return nil, errors.Errorf("expected value of type %T, got %T", configValues, value)
+		return errors.Errorf("expected value of type %T, got %T", configValues, value)
 	}
 
-	var out bytes.Buffer
-	const (
-		// To format things into columns.
-		minwidth = 0
-		tabwidth = 1
-		padding  = 2
-		padchar  = ' '
-		flags    = 0
-	)
-	tw := tabwriter.NewWriter(&out, minwidth, tabwidth, padding, padchar, flags)
+	tw := output.TabWriter(writer)
 	p := func(values ...string) {
 		text := strings.Join(values, "\t")
 		fmt.Fprintln(tw, text)
@@ -161,16 +153,17 @@ func formatConfigTabular(value interface{}) ([]byte, error) {
 
 	for _, name := range valueNames {
 		info := configValues[name]
-		val, err := cmd.FormatSmart(info.Value)
+		out := &bytes.Buffer{}
+		err := cmd.FormatYaml(out, info.Value)
 		if err != nil {
-			return nil, errors.Annotatef(err, "formatting value for %q", name)
+			return errors.Annotatef(err, "formatting value for %q", name)
 		}
 		// Some attribute values have a newline appended
 		// which makes the output messy.
-		valString := strings.TrimSuffix(string(val), "\n")
+		valString := strings.TrimSuffix(out.String(), "\n")
 		p(name, info.Source, valString)
 	}
 
 	tw.Flush()
-	return out.Bytes(), nil
+	return nil
 }

--- a/cmd/juju/model/get.go
+++ b/cmd/juju/model/get.go
@@ -126,7 +126,7 @@ func (c *getCommand) Run(ctx *cmd.Context) error {
 			}
 			return nil
 		}
-		return fmt.Errorf("key %q not found in %q model.", c.key, attrs["name"])
+		return errors.Errorf("key %q not found in %q model.", c.key, attrs["name"])
 	}
 	// If key is empty, write out the whole lot.
 	return c.out.Write(ctx, attrs)

--- a/cmd/juju/model/get_test.go
+++ b/cmd/juju/model/get_test.go
@@ -4,8 +4,6 @@
 package model_test
 
 import (
-	"strings"
-
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -40,30 +38,30 @@ func (s *GetSuite) TestSingleValue(c *gc.C) {
 	context, err := s.run(c, "special")
 	c.Assert(err, jc.ErrorIsNil)
 
-	output := strings.TrimSpace(testing.Stdout(context))
-	c.Assert(output, gc.Equals, "special value")
+	output := testing.Stdout(context)
+	c.Assert(output, gc.Equals, "special value\n")
 }
 
 func (s *GetSuite) TestSingleValueJSON(c *gc.C) {
 	context, err := s.run(c, "--format=json", "special")
 	c.Assert(err, jc.ErrorIsNil)
 
-	output := strings.TrimSpace(testing.Stdout(context))
-	c.Assert(output, gc.Equals, "special value")
+	output := testing.Stdout(context)
+	c.Assert(output, gc.Equals, "special value\n")
 }
 
 func (s *GetSuite) TestAllValuesYAML(c *gc.C) {
 	context, err := s.run(c, "--format=yaml")
 	c.Assert(err, jc.ErrorIsNil)
 
-	output := strings.TrimSpace(testing.Stdout(context))
+	output := testing.Stdout(context)
 	expected := "" +
 		"running:\n" +
 		"  value: true\n" +
 		"  source: model\n" +
 		"special:\n" +
 		"  value: special value\n" +
-		"  source: model"
+		"  source: model\n"
 	c.Assert(output, gc.Equals, expected)
 }
 
@@ -71,8 +69,8 @@ func (s *GetSuite) TestAllValuesJSON(c *gc.C) {
 	context, err := s.run(c, "--format=json")
 	c.Assert(err, jc.ErrorIsNil)
 
-	output := strings.TrimSpace(testing.Stdout(context))
-	expected := `{"running":{"Value":true,"Source":"model"},"special":{"Value":"special value","Source":"model"}}`
+	output := testing.Stdout(context)
+	expected := `{"running":{"Value":true,"Source":"model"},"special":{"Value":"special value","Source":"model"}}` + "\n"
 	c.Assert(output, gc.Equals, expected)
 }
 
@@ -80,10 +78,11 @@ func (s *GetSuite) TestAllValuesTabular(c *gc.C) {
 	context, err := s.run(c)
 	c.Assert(err, jc.ErrorIsNil)
 
-	output := strings.TrimSpace(testing.Stdout(context))
+	output := testing.Stdout(context)
 	expected := "" +
 		"ATTRIBUTE  FROM   VALUE\n" +
-		"running    model  True\n" +
-		"special    model  special value"
+		"running    model  true\n" +
+		"special    model  special value\n" +
+		"\n"
 	c.Assert(output, gc.Equals, expected)
 }

--- a/cmd/juju/model/retryprovisioning_test.go
+++ b/cmd/juju/model/retryprovisioning_test.go
@@ -4,7 +4,6 @@
 package model_test
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -63,7 +62,7 @@ func (f *fakeRetryProvisioningClient) RetryProvisioning(machines ...names.Machin
 				m.data["transient"] = true
 			} else {
 				results[i].Error = common.ServerError(
-					fmt.Errorf("%s is not in an error state",
+					errors.Errorf("%s is not in an error state",
 						names.ReadableString(machine)))
 			}
 		} else {

--- a/cmd/juju/model/show.go
+++ b/cmd/juju/model/show.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 )
 
 const showModelCommandDoc = `Show information about the current or specified model`
@@ -60,10 +61,7 @@ func (c *showModelCommand) Info() *cmd.Info {
 
 // SetFlags implements Command.SetFlags.
 func (c *showModelCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
-		"yaml": cmd.FormatYaml,
-		"json": cmd.FormatJson,
-	})
+	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
 }
 
 // Init implements Command.Init.

--- a/cmd/juju/romulus/agree/agree.go
+++ b/cmd/juju/romulus/agree/agree.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 	"github.com/juju/terms-client/api"
 	"github.com/juju/terms-client/api/wireformat"
 	"gopkg.in/juju/charm.v6-unstable"
@@ -69,7 +70,7 @@ type agreeCommand struct {
 // SetFlags implements Command.SetFlags.
 func (c *agreeCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.SkipTermContent, "yes", false, "Agree to terms non interactively")
-	c.out.AddFlags(f, "json", cmd.DefaultFormatters)
+	c.out.AddFlags(f, "json", output.DefaultFormatters)
 }
 
 // Info implements Command.Info.

--- a/cmd/juju/romulus/listagreements/listagreements.go
+++ b/cmd/juju/romulus/listagreements/listagreements.go
@@ -5,6 +5,7 @@ package listagreements
 
 import (
 	"encoding/json"
+	"io"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -95,6 +96,11 @@ func (c *listAgreementsCommand) Run(ctx *cmd.Context) error {
 	return nil
 }
 
-func formatJSON(value interface{}) ([]byte, error) {
-	return json.MarshalIndent(value, "", "    ")
+func formatJSON(writer io.Writer, value interface{}) error {
+	bytes, err := json.MarshalIndent(value, "", "    ")
+	if err != nil {
+		return err
+	}
+	_, err = writer.Write(bytes)
+	return err
 }

--- a/cmd/juju/romulus/listbudgets/list-budgets.go
+++ b/cmd/juju/romulus/listbudgets/list-budgets.go
@@ -4,6 +4,8 @@
 package listbudgets
 
 import (
+	"fmt"
+	"io"
 	"sort"
 
 	"github.com/gosuri/uitable"
@@ -78,10 +80,10 @@ func (c *listBudgetsCommand) Run(ctx *cmd.Context) error {
 }
 
 // formatTabular returns a tabular view of available budgets.
-func formatTabular(value interface{}) ([]byte, error) {
+func formatTabular(writer io.Writer, value interface{}) error {
 	b, ok := value.(*wireformat.ListBudgetsResponse)
 	if !ok {
-		return nil, errors.Errorf("expected value of type %T, got %T", b, value)
+		return errors.Errorf("expected value of type %T, got %T", b, value)
 	}
 	sort.Sort(b.Budgets)
 
@@ -99,7 +101,8 @@ func formatTabular(value interface{}) ([]byte, error) {
 	table.AddRow("TOTAL", b.Total.Limit, b.Total.Allocated, b.Total.Available, b.Total.Consumed)
 	table.AddRow("", "", "", "", "")
 	table.AddRow("Credit limit:", b.Credit, "", "", "")
-	return []byte(table.String()), nil
+	fmt.Fprint(writer, table)
+	return nil
 }
 
 var newAPIClient = newAPIClientImpl

--- a/cmd/juju/romulus/showbudget/show_budget.go
+++ b/cmd/juju/romulus/showbudget/show_budget.go
@@ -4,6 +4,8 @@
 package showbudget
 
 import (
+	"fmt"
+	"io"
 	"sort"
 
 	"github.com/gosuri/uitable"
@@ -120,10 +122,10 @@ func (c *showBudgetCommand) resolveModelNames(budget *wireformat.BudgetWithAlloc
 }
 
 // formatTabular returns a tabular view of available budgets.
-func formatTabular(value interface{}) ([]byte, error) {
+func formatTabular(writer io.Writer, value interface{}) error {
 	b, ok := value.(*wireformat.BudgetWithAllocations)
 	if !ok {
-		return nil, errors.Errorf("expected value of type %T, got %T", b, value)
+		return errors.Errorf("expected value of type %T, got %T", b, value)
 	}
 
 	table := uitable.New()
@@ -158,7 +160,8 @@ func formatTabular(value interface{}) ([]byte, error) {
 	table.AddRow("TOTAL", "", b.Total.Consumed, b.Total.Allocated, "", b.Total.Usage)
 	table.AddRow("BUDGET", "", "", b.Limit, "")
 	table.AddRow("UNALLOCATED", "", "", b.Total.Unallocated, "")
-	return []byte(table.String()), nil
+	fmt.Fprint(writer, table)
+	return nil
 }
 
 var newAPIClient = newAPIClientImpl

--- a/cmd/juju/space/list.go
+++ b/cmd/juju/space/list.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 )
 
 // NewListCommand returns a command used to list spaces.
@@ -49,11 +50,7 @@ func (c *listCommand) Info() *cmd.Info {
 // SetFlags is defined on the cmd.Command interface.
 func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.SpaceCommandBase.SetFlags(f)
-	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
-		"yaml": cmd.FormatYaml,
-		"json": cmd.FormatJson,
-	})
-
+	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
 	f.BoolVar(&c.Short, "short", false, "only display spaces.")
 }
 

--- a/cmd/juju/space/list_test.go
+++ b/cmd/juju/space/list_test.go
@@ -256,7 +256,7 @@ func (s *ListSuite) TestRunWhenNoSpacesExistSucceeds(c *gc.C) {
 
 	s.AssertRunSucceeds(c,
 		`no spaces to display\n`,
-		"", // empty stdout.
+		"\n", // empty stdout.
 	)
 
 	s.api.CheckCallNames(c, "ListSpaces", "Close")

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3330,19 +3330,19 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	c.Assert(string(stdout), gc.Equals, `
-Running on subnets: 127.0.0.1/8, 10.0.0.1/8 
-Utilizing ports:                            
-     # MACHINES: (3)
-        started:  3 
-                
-        # UNITS: (4)
-         active:  3 
-          error:  1 
-                
- # APPLICATIONS:  (3)
-         logging  1/1 exposed
-           mysql  1/1 exposed
-       wordpress  1/1 exposed
+Running on subnets:  127.0.0.1/8, 10.0.0.1/8  
+ Utilizing ports:                             
+      # MACHINES:  (3)
+         started:   3 
+                 
+         # UNITS:  (4)
+          active:   3 
+           error:   1 
+                 
+  # APPLICATIONS:  (3)
+          logging  1/1  exposed
+            mysql  1/1  exposed
+        wordpress  1/1  exposed
 
 `[1:])
 }
@@ -3553,9 +3553,10 @@ func (s *StatusSuite) TestFormatTabularHookActionName(c *gc.C) {
 			},
 		},
 	}
-	out, err := FormatTabular(status)
+	out := &bytes.Buffer{}
+	err := FormatTabular(out, status)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(out), gc.Equals, `
+	c.Assert(out.String(), gc.Equals, `
 MODEL  CONTROLLER  CLOUD/REGION  VERSION
                                  
 
@@ -3586,9 +3587,10 @@ func (s *StatusSuite) TestFormatTabularConsistentPeerRelationName(c *gc.C) {
 			},
 		},
 	}
-	out, err := FormatTabular(status)
+	out := &bytes.Buffer{}
+	err := FormatTabular(out, status)
 	c.Assert(err, jc.ErrorIsNil)
-	sections, err := splitTableSections(out)
+	sections, err := splitTableSections(out.Bytes())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sections["RELATION"], gc.DeepEquals, []string{
 		"RELATION    PROVIDES  CONSUMES  TYPE",
@@ -3645,9 +3647,10 @@ func (s *StatusSuite) TestFormatTabularMetering(c *gc.C) {
 			},
 		},
 	}
-	out, err := FormatTabular(status)
+	out := &bytes.Buffer{}
+	err := FormatTabular(out, status)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(out), gc.Equals, `
+	c.Assert(out.String(), gc.Equals, `
 MODEL  CONTROLLER  CLOUD/REGION  VERSION
                                  
 

--- a/cmd/juju/storage/add_test.go
+++ b/cmd/juju/storage/add_test.go
@@ -35,7 +35,7 @@ func (s *addSuite) SetUpTest(c *gc.C) {
 			result := make([]params.ErrorResult, len(storages))
 			for i, one := range storages {
 				if strings.HasPrefix(one.StorageName, "err") {
-					result[i].Error = common.ServerError(fmt.Errorf("test failure"))
+					result[i].Error = common.ServerError(errors.Errorf("test failure"))
 				}
 			}
 			return result, nil
@@ -149,10 +149,10 @@ failed to add "storage42": storage "storage42" not found
 		result := make([]params.ErrorResult, len(storages))
 		for i, one := range storages {
 			if one.StorageName == "storage2" {
-				result[i].Error = common.ServerError(fmt.Errorf(`storage pool "barf" not found`))
+				result[i].Error = common.ServerError(errors.Errorf(`storage pool "barf" not found`))
 			}
 			if one.StorageName == "storage42" {
-				result[i].Error = common.ServerError(fmt.Errorf(`storage "storage42" not found`))
+				result[i].Error = common.ServerError(errors.Errorf(`storage "storage42" not found`))
 			}
 		}
 		return result, nil
@@ -175,7 +175,7 @@ failed to add "storage42": storage "storage42" not found
 		result := make([]params.ErrorResult, len(storages))
 		for i, one := range storages {
 			if one.StorageName == "storage42" || one.StorageName == "storage2" {
-				result[i].Error = common.ServerError(fmt.Errorf(`storage "%v" not found`, one.StorageName))
+				result[i].Error = common.ServerError(errors.Errorf(`storage "%v" not found`, one.StorageName))
 			}
 		}
 		return result, nil
@@ -199,7 +199,7 @@ storage "storage0" not found
 			if one.StorageName == "storage42" || one.StorageName == "storage2" {
 				result[i].Error = common.ServerError(errors.New(unitErr))
 			} else {
-				result[i].Error = common.ServerError(fmt.Errorf(`storage "%v" not found`, one.StorageName))
+				result[i].Error = common.ServerError(errors.Errorf(`storage "%v" not found`, one.StorageName))
 			}
 		}
 		return result, nil

--- a/cmd/juju/storage/filesystemlistformatters.go
+++ b/cmd/juju/storage/filesystemlistformatters.go
@@ -4,36 +4,28 @@
 package storage
 
 import (
-	"bytes"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/dustin/go-humanize"
 	"github.com/juju/errors"
+	"github.com/juju/juju/cmd/output"
 )
 
-// formatFilesystemListTabular returns a tabular summary of filesystem instances.
-func formatFilesystemListTabular(value interface{}) ([]byte, error) {
+// formatFilesystemListTabular writes a tabular summary of filesystem instances.
+func formatFilesystemListTabular(writer io.Writer, value interface{}) error {
 	infos, ok := value.(map[string]FilesystemInfo)
 	if !ok {
-		return nil, errors.Errorf("expected value of type %T, got %T", infos, value)
+		return errors.Errorf("expected value of type %T, got %T", infos, value)
 	}
-	return formatFilesystemListTabularTyped(infos), nil
+	formatFilesystemListTabularTyped(writer, infos)
+	return nil
 }
 
-func formatFilesystemListTabularTyped(infos map[string]FilesystemInfo) []byte {
-	var out bytes.Buffer
-	const (
-		// To format things into columns.
-		minwidth = 0
-		tabwidth = 1
-		padding  = 2
-		padchar  = ' '
-		flags    = 0
-	)
-	tw := tabwriter.NewWriter(&out, minwidth, tabwidth, padding, padchar, flags)
+func formatFilesystemListTabularTyped(writer io.Writer, infos map[string]FilesystemInfo) {
+	tw := output.TabWriter(writer)
 
 	print := func(values ...string) {
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
@@ -85,7 +77,6 @@ func formatFilesystemListTabularTyped(infos map[string]FilesystemInfo) []byte {
 	}
 
 	tw.Flush()
-	return out.Bytes()
 }
 
 type filesystemAttachmentInfo struct {

--- a/cmd/juju/storage/list.go
+++ b/cmd/juju/storage/list.go
@@ -4,6 +4,8 @@
 package storage
 
 import (
+	"io"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -120,22 +122,19 @@ func (c *listCommand) generateListOutput(ctx *cmd.Context, api StorageListAPI) (
 	return output, nil
 }
 
-func formatListTabular(value interface{}) ([]byte, error) {
+func formatListTabular(writer io.Writer, value interface{}) error {
 
 	switch value.(type) {
 	case map[string]StorageInfo:
-		output, err := formatStorageListTabular(value)
-		return output, err
+		return formatStorageListTabular(writer, value)
 
 	case map[string]FilesystemInfo:
-		output, err := formatFilesystemListTabular(value)
-		return output, err
+		return formatFilesystemListTabular(writer, value)
 
 	case map[string]VolumeInfo:
-		output, err := formatVolumeListTabular(value)
-		return output, err
+		return formatVolumeListTabular(writer, value)
 
 	default:
-		return nil, errors.Errorf("unexpected value of type %T", value)
+		return errors.Errorf("unexpected value of type %T", value)
 	}
 }

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -40,12 +40,12 @@ func (s *ListSuite) TestList(c *gc.C) {
 		nil,
 		// Default format is tabular
 		`
-\[Storage\]    
-UNIT         ID          LOCATION STATUS   MESSAGE 
-postgresql/0 db-dir/1100 hither   attached         
-transcode/0  db-dir/1000 thither  pending          
-transcode/0  shared-fs/0 there    attached         
-transcode/1  shared-fs/0 here     attached         
+\[Storage\]     
+UNIT          ID           LOCATION  STATUS    MESSAGE  
+postgresql/0  db-dir/1100  hither    attached           
+transcode/0   db-dir/1000  thither   pending            
+transcode/0   shared-fs/0  there     attached           
+transcode/1   shared-fs/0  here      attached           
 
 `[1:])
 }
@@ -97,12 +97,12 @@ func (s *ListSuite) TestListOwnerStorageIdSort(c *gc.C) {
 		nil,
 		// Default format is tabular
 		`
-\[Storage\]    
-UNIT         ID          LOCATION STATUS   MESSAGE 
-postgresql/0 db-dir/1100 hither   attached         
-transcode/0  db-dir/1000 thither  pending          
-transcode/0  shared-fs/0 there    attached         
-transcode/1  shared-fs/0 here     attached         
+\[Storage\]     
+UNIT          ID           LOCATION  STATUS    MESSAGE  
+postgresql/0  db-dir/1100  hither    attached           
+transcode/0   db-dir/1000  thither   pending            
+transcode/0   shared-fs/0  there     attached           
+transcode/1   shared-fs/0  here      attached           
 
 `[1:])
 }

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -4,25 +4,24 @@
 package storage
 
 import (
-	"bytes"
 	"fmt"
+	"io"
 	"sort"
 	"strconv"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/cmd/output"
 )
 
-// formatListTabular returns a tabular summary of storage instances.
-func formatStorageListTabular(value interface{}) ([]byte, error) {
+// formatListTabular writes a tabular summary of storage instances.
+func formatStorageListTabular(writer io.Writer, value interface{}) error {
 	storageInfo, ok := value.(map[string]StorageInfo)
 	if !ok {
-		return nil, errors.Errorf("expected value of type %T, got %T", storageInfo, value)
+		return errors.Errorf("expected value of type %T, got %T", storageInfo, value)
 	}
-	var out bytes.Buffer
-	// To format things into columns.
-	tw := tabwriter.NewWriter(&out, 0, 1, 1, ' ', 0)
+
+	tw := output.TabWriter(writer)
 	p := func(values ...interface{}) {
 		for _, v := range values {
 			fmt.Fprintf(tw, "%v\t", v)
@@ -88,7 +87,7 @@ func formatStorageListTabular(value interface{}) ([]byte, error) {
 	}
 	tw.Flush()
 
-	return out.Bytes(), nil
+	return nil
 }
 
 type storageAttachmentInfo struct {

--- a/cmd/juju/storage/poollistformatters.go
+++ b/cmd/juju/storage/poollistformatters.go
@@ -4,37 +4,29 @@
 package storage
 
 import (
-	"bytes"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/cmd/output"
 )
 
 // formatPoolListTabular returns a tabular summary of pool instances or
 // errors out if parameter is not a map of PoolInfo.
-func formatPoolListTabular(value interface{}) ([]byte, error) {
+func formatPoolListTabular(writer io.Writer, value interface{}) error {
 	pools, ok := value.(map[string]PoolInfo)
 	if !ok {
-		return nil, errors.Errorf("expected value of type %T, got %T", pools, value)
+		return errors.Errorf("expected value of type %T, got %T", pools, value)
 	}
-	return formatPoolsTabular(pools)
+	formatPoolsTabular(writer, pools)
+	return nil
 }
 
 // formatPoolsTabular returns a tabular summary of pool instances.
-func formatPoolsTabular(pools map[string]PoolInfo) ([]byte, error) {
-	var out bytes.Buffer
-	const (
-		// To format things into columns.
-		minwidth = 0
-		tabwidth = 1
-		padding  = 2
-		padchar  = ' '
-		flags    = 0
-	)
-	tw := tabwriter.NewWriter(&out, minwidth, tabwidth, padding, padchar, flags)
+func formatPoolsTabular(writer io.Writer, pools map[string]PoolInfo) {
+	tw := output.TabWriter(writer)
 	print := func(values ...string) {
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
 	}
@@ -61,6 +53,4 @@ func formatPoolsTabular(pools map[string]PoolInfo) ([]byte, error) {
 		print(name, pool.Provider, strings.Join(attrs, " "))
 	}
 	tw.Flush()
-
-	return out.Bytes(), nil
 }

--- a/cmd/juju/storage/show.go
+++ b/cmd/juju/storage/show.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 )
 
 // NewShowCommand returns a command that shows storage details
@@ -60,7 +61,7 @@ func (c *showCommand) Info() *cmd.Info {
 // SetFlags implements Command.SetFlags.
 func (c *showCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.StorageCommandBase.SetFlags(f)
-	c.out.AddFlags(f, "yaml", cmd.DefaultFormatters)
+	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
 }
 
 // Run implements Command.Run.

--- a/cmd/juju/storage/volumelistformatters.go
+++ b/cmd/juju/storage/volumelistformatters.go
@@ -4,36 +4,28 @@
 package storage
 
 import (
-	"bytes"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/dustin/go-humanize"
 	"github.com/juju/errors"
+	"github.com/juju/juju/cmd/output"
 )
 
 // formatVolumeListTabular returns a tabular summary of volume instances.
-func formatVolumeListTabular(value interface{}) ([]byte, error) {
+func formatVolumeListTabular(writer io.Writer, value interface{}) error {
 	infos, ok := value.(map[string]VolumeInfo)
 	if !ok {
-		return nil, errors.Errorf("expected value of type %T, got %T", infos, value)
+		return errors.Errorf("expected value of type %T, got %T", infos, value)
 	}
-	return formatVolumeListTabularTyped(infos), nil
+	formatVolumeListTabularTyped(writer, infos)
+	return nil
 }
 
-func formatVolumeListTabularTyped(infos map[string]VolumeInfo) []byte {
-	var out bytes.Buffer
-	const (
-		// To format things into columns.
-		minwidth = 0
-		tabwidth = 1
-		padding  = 2
-		padchar  = ' '
-		flags    = 0
-	)
-	tw := tabwriter.NewWriter(&out, minwidth, tabwidth, padding, padchar, flags)
+func formatVolumeListTabularTyped(writer io.Writer, infos map[string]VolumeInfo) {
+	tw := output.TabWriter(writer)
 
 	print := func(values ...string) {
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
@@ -85,7 +77,7 @@ func formatVolumeListTabularTyped(infos map[string]VolumeInfo) []byte {
 	}
 
 	tw.Flush()
-	return out.Bytes()
+	return
 }
 
 type volumeAttachmentInfo struct {

--- a/cmd/juju/subnet/list.go
+++ b/cmd/juju/subnet/list.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 )
 
 // NewListCommand returns a cammin used to list all subnets
@@ -60,10 +61,7 @@ func (c *listCommand) Info() *cmd.Info {
 // SetFlags is defined on the cmd.Command interface.
 func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.SubnetCommandBase.SetFlags(f)
-	c.Out.AddFlags(f, "yaml", map[string]cmd.Formatter{
-		"yaml": cmd.FormatYaml,
-		"json": cmd.FormatJson,
-	})
+	c.Out.AddFlags(f, "yaml", output.DefaultFormatters)
 
 	f.StringVar(&c.SpaceName, "space", "", "Filter results by space name")
 	f.StringVar(&c.ZoneName, "zone", "", "Filter results by zone name")

--- a/cmd/juju/user/add.go
+++ b/cmd/juju/user/add.go
@@ -73,7 +73,7 @@ func (c *addCommand) Info() *cmd.Info {
 // Init implements Command.Init.
 func (c *addCommand) Init(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("no username supplied")
+		return errors.Errorf("no username supplied")
 	}
 
 	c.User, args = args[0], args[1:]

--- a/cmd/juju/user/info.go
+++ b/cmd/juju/user/info.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 )
 
 var helpSummary = `
@@ -85,7 +86,7 @@ func (c *infoCommand) Info() *cmd.Info {
 // SetFlags implements Command.SetFlags.
 func (c *infoCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.infoCommandBase.SetFlags(f)
-	c.out.AddFlags(f, "yaml", cmd.DefaultFormatters)
+	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
 }
 
 // Init implements Command.Init.

--- a/cmd/juju/user/remove.go
+++ b/cmd/juju/user/remove.go
@@ -84,7 +84,7 @@ func (c *removeCommand) Info() *cmd.Info {
 // Init implements Command.Init.
 func (c *removeCommand) Init(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("no username supplied")
+		return errors.Errorf("no username supplied")
 	}
 	c.UserName = args[0]
 	return cmd.CheckEmpty(args[1:])

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -1,0 +1,31 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package output
+
+import (
+	"io"
+	"text/tabwriter"
+
+	"github.com/juju/cmd"
+)
+
+// DefaultFormatters holds the formatters that can be
+// specified with the --format flag.
+var DefaultFormatters = map[string]cmd.Formatter{
+	"yaml": cmd.FormatYaml,
+	"json": cmd.FormatJson,
+}
+
+// TabWriter returns a new tab writer with common layout definition.
+func TabWriter(writer io.Writer) *tabwriter.Writer {
+	const (
+		// To format things into columns.
+		minwidth = 0
+		tabwidth = 1
+		padding  = 2
+		padchar  = ' '
+		flags    = 0
+	)
+	return tabwriter.NewWriter(writer, minwidth, tabwidth, padding, padchar, flags)
+}

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -203,7 +203,7 @@ func (c *imageMetadataCommand) Run(context *cmd.Context) error {
 	}
 	err = imagemetadata.MergeAndWriteMetadata(c.Series, []*imagemetadata.ImageMetadata{im}, &cloudSpec, targetStorage)
 	if err != nil {
-		return fmt.Errorf("image metadata files could not be created: %v", err)
+		return errors.Errorf("image metadata files could not be created: %v", err)
 	}
 	dir := context.AbsPath(c.Dir)
 	dest := filepath.Join(dir, storage.BaseImagesPath, "streams", "v1")

--- a/cmd/plugins/juju-metadata/listformatter.go
+++ b/cmd/plugins/juju-metadata/listformatter.go
@@ -4,35 +4,26 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
+	"io"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/cmd/output"
 )
 
-func formatMetadataListTabular(value interface{}) ([]byte, error) {
+func formatMetadataListTabular(writer io.Writer, value interface{}) error {
 	metadata, ok := value.([]MetadataInfo)
 	if !ok {
-		return nil, errors.Errorf("expected value of type %T, got %T", metadata, value)
+		return errors.Errorf("expected value of type %T, got %T", metadata, value)
 	}
-	return formatMetadataTabular(metadata)
+	formatMetadataTabular(writer, metadata)
+	return nil
 }
 
 // formatMetadataTabular returns a tabular summary of cloud image metadata.
-func formatMetadataTabular(metadata []MetadataInfo) ([]byte, error) {
-	var out bytes.Buffer
-
-	const (
-		// To format things into columns.
-		minwidth = 0
-		tabwidth = 1
-		padding  = 2
-		padchar  = ' '
-		flags    = 0
-	)
-	tw := tabwriter.NewWriter(&out, minwidth, tabwidth, padding, padchar, flags)
+func formatMetadataTabular(writer io.Writer, metadata []MetadataInfo) {
+	tw := output.TabWriter(writer)
 	print := func(values ...string) {
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
 	}
@@ -42,6 +33,4 @@ func formatMetadataTabular(metadata []MetadataInfo) ([]byte, error) {
 		print(m.Source, m.Series, m.Arch, m.Region, m.ImageId, m.Stream, m.VirtType, m.RootStorageType)
 	}
 	tw.Flush()
-
-	return out.Bytes(), nil
 }

--- a/cmd/plugins/juju-metadata/listformatter.go
+++ b/cmd/plugins/juju-metadata/listformatter.go
@@ -21,7 +21,7 @@ func formatMetadataListTabular(writer io.Writer, value interface{}) error {
 	return nil
 }
 
-// formatMetadataTabular returns a tabular summary of cloud image metadata.
+// formatMetadataTabular writes a tabular summary of cloud image metadata.
 func formatMetadataTabular(writer io.Writer, metadata []MetadataInfo) {
 	tw := output.TabWriter(writer)
 	print := func(values ...string) {

--- a/cmd/plugins/juju-metadata/signmetadata.go
+++ b/cmd/plugins/juju-metadata/signmetadata.go
@@ -4,13 +4,13 @@
 package main
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/loggo"
 
@@ -55,10 +55,10 @@ func (c *signMetadataCommand) SetFlags(f *gnuflag.FlagSet) {
 
 func (c *signMetadataCommand) Init(args []string) error {
 	if c.dir == "" {
-		return fmt.Errorf("directory must be specified")
+		return errors.Errorf("directory must be specified")
 	}
 	if c.keyFile == "" {
-		return fmt.Errorf("keyfile must be specified")
+		return errors.Errorf("keyfile must be specified")
 	}
 	return cmd.CheckEmpty(args)
 }
@@ -88,15 +88,15 @@ func process(dir, key, passphrase string) error {
 		logger.Infof("signing file %q", filename)
 		f, err := os.Open(filename)
 		if err != nil {
-			return fmt.Errorf("opening file %q: %v", filename, err)
+			return errors.Errorf("opening file %q: %v", filename, err)
 		}
 		encoded, err := simplestreams.Encode(f, key, passphrase)
 		if err != nil {
-			return fmt.Errorf("encoding file %q: %v", filename, err)
+			return errors.Errorf("encoding file %q: %v", filename, err)
 		}
 		signedFilename := strings.Replace(filename, simplestreams.UnsignedSuffix, simplestreams.SignedSuffix, -1)
 		if err = ioutil.WriteFile(signedFilename, encoded, 0644); err != nil {
-			return fmt.Errorf("writing signed file %q: %v", signedFilename, err)
+			return errors.Errorf("writing signed file %q: %v", signedFilename, err)
 		}
 	}
 	// Now process any directories in dir.

--- a/cmd/plugins/juju-metadata/validateimagemetadata.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/utils"
 
@@ -98,13 +99,13 @@ func (c *validateImageMetadataCommand) SetFlags(f *gnuflag.FlagSet) {
 func (c *validateImageMetadataCommand) Init(args []string) error {
 	if c.providerType != "" {
 		if c.series == "" {
-			return fmt.Errorf("series required if provider type is specified")
+			return errors.Errorf("series required if provider type is specified")
 		}
 		if c.region == "" {
-			return fmt.Errorf("region required if provider type is specified")
+			return errors.Errorf("region required if provider type is specified")
 		}
 		if c.metadataDir == "" {
-			return fmt.Errorf("metadata directory required if provider type is specified")
+			return errors.Errorf("metadata directory required if provider type is specified")
 		}
 	}
 	return cmd.CheckEmpty(args)
@@ -129,7 +130,7 @@ func (oes *overrideEnvStream) Config() *config.Config {
 	newCfg, err := cfg.Apply(map[string]interface{}{"image-stream": oes.stream})
 	if err != nil {
 		// This should never happen.
-		panic(fmt.Errorf("unexpected error making override config: %v", err))
+		panic(errors.Errorf("unexpected error making override config: %v", err))
 	}
 	return newCfg
 }
@@ -148,7 +149,7 @@ func (c *validateImageMetadataCommand) Run(context *cmd.Context) error {
 			}
 			buff := &bytes.Buffer{}
 			if yamlErr := cmd.FormatYaml(buff, metadata); yamlErr == nil {
-				err = fmt.Errorf("%v\n%v", err, buff.String())
+				err = errors.Errorf("%v\n%v", err, buff.String())
 			}
 		}
 		return err
@@ -168,7 +169,7 @@ func (c *validateImageMetadataCommand) Run(context *cmd.Context) error {
 				sources = append(sources, fmt.Sprintf("- %s (%s)", s.Description(), url))
 			}
 		}
-		return fmt.Errorf(
+		return errors.Errorf(
 			"no matching image ids for region %s using sources:\n%s",
 			params.Region, strings.Join(sources, "\n"))
 	}
@@ -185,7 +186,7 @@ func (c *validateImageMetadataCommand) createLookupParams(context *cmd.Context) 
 		}
 		mdLookup, ok := environ.(simplestreams.MetadataValidator)
 		if !ok {
-			return nil, fmt.Errorf("%s provider does not support image metadata validation", environ.Config().Type())
+			return nil, errors.Errorf("%s provider does not support image metadata validation", environ.Config().Type())
 		}
 		params, err = mdLookup.MetadataLookupParams(c.region)
 		if err != nil {
@@ -203,7 +204,7 @@ func (c *validateImageMetadataCommand) createLookupParams(context *cmd.Context) 
 		}
 		mdLookup, ok := prov.(simplestreams.MetadataValidator)
 		if !ok {
-			return nil, fmt.Errorf("%s provider does not support image metadata validation", c.providerType)
+			return nil, errors.Errorf("%s provider does not support image metadata validation", c.providerType)
 		}
 		params, err = mdLookup.MetadataLookupParams(c.region)
 		if err != nil {

--- a/cmd/plugins/juju-metadata/validateimagemetadata.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 	"github.com/juju/utils"
 
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/imagemetadata"
@@ -84,7 +86,7 @@ func (c *validateImageMetadataCommand) Info() *cmd.Info {
 }
 
 func (c *validateImageMetadataCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
 	f.StringVar(&c.providerType, "p", "", "the provider type eg ec2, openstack")
 	f.StringVar(&c.metadataDir, "d", "", "directory where metadata files are found")
 	f.StringVar(&c.series, "s", "", "the series for which to validate (overrides env config series)")
@@ -144,8 +146,9 @@ func (c *validateImageMetadataCommand) Run(context *cmd.Context) error {
 			metadata := map[string]interface{}{
 				"Resolve Metadata": *resolveInfo,
 			}
-			if metadataYaml, yamlErr := cmd.FormatYaml(metadata); yamlErr == nil {
-				err = fmt.Errorf("%v\n%v", err, string(metadataYaml))
+			buff := &bytes.Buffer{}
+			if yamlErr := cmd.FormatYaml(buff, metadata); yamlErr == nil {
+				err = fmt.Errorf("%v\n%v", err, buff.String())
 			}
 		}
 		return err

--- a/cmd/plugins/juju-metadata/validatetoolsmetadata.go
+++ b/cmd/plugins/juju-metadata/validatetoolsmetadata.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"github.com/juju/version"
 
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/tools"
@@ -111,7 +113,7 @@ func (c *validateToolsMetadataCommand) Info() *cmd.Info {
 }
 
 func (c *validateToolsMetadataCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
 	f.StringVar(&c.providerType, "p", "", "the provider type eg ec2, openstack")
 	f.StringVar(&c.metadataDir, "d", "", "directory where metadata files are found")
 	f.StringVar(&c.series, "s", "", "the series for which to validate (overrides env config series)")
@@ -218,8 +220,9 @@ func (c *validateToolsMetadataCommand) Run(context *cmd.Context) error {
 			metadata := map[string]interface{}{
 				"Resolve Metadata": *resolveInfo,
 			}
-			if metadataYaml, yamlErr := cmd.FormatYaml(metadata); yamlErr == nil {
-				err = fmt.Errorf("%v\n%v", err, string(metadataYaml))
+			buff := &bytes.Buffer{}
+			if yamlErr := cmd.FormatYaml(buff, metadata); yamlErr == nil {
+				err = fmt.Errorf("%v\n%v", err, buff.String())
 			}
 		}
 		return err

--- a/cmd/plugins/juju-metadata/validatetoolsmetadata.go
+++ b/cmd/plugins/juju-metadata/validatetoolsmetadata.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/utils/arch"
 	"github.com/juju/version"
@@ -129,10 +130,10 @@ func (c *validateToolsMetadataCommand) SetFlags(f *gnuflag.FlagSet) {
 func (c *validateToolsMetadataCommand) Init(args []string) error {
 	if c.providerType != "" {
 		if c.region == "" {
-			return fmt.Errorf("region required if provider type is specified")
+			return errors.Errorf("region required if provider type is specified")
 		}
 		if c.metadataDir == "" {
-			return fmt.Errorf("metadata directory required if provider type is specified")
+			return errors.Errorf("metadata directory required if provider type is specified")
 		}
 	}
 	if c.exactVersion == "current" {
@@ -155,7 +156,7 @@ func (c *validateToolsMetadataCommand) Run(context *cmd.Context) error {
 		if err == nil {
 			mdLookup, ok := environ.(simplestreams.MetadataValidator)
 			if !ok {
-				return fmt.Errorf("%s provider does not support tools metadata validation", environ.Config().Type())
+				return errors.Errorf("%s provider does not support tools metadata validation", environ.Config().Type())
 			}
 			params, err = mdLookup.MetadataLookupParams(c.region)
 			if err != nil {
@@ -180,7 +181,7 @@ func (c *validateToolsMetadataCommand) Run(context *cmd.Context) error {
 		}
 		mdLookup, ok := prov.(simplestreams.MetadataValidator)
 		if !ok {
-			return fmt.Errorf("%s provider does not support tools metadata validation", c.providerType)
+			return errors.Errorf("%s provider does not support tools metadata validation", c.providerType)
 		}
 		params, err = mdLookup.MetadataLookupParams(c.region)
 		if err != nil {
@@ -222,7 +223,7 @@ func (c *validateToolsMetadataCommand) Run(context *cmd.Context) error {
 			}
 			buff := &bytes.Buffer{}
 			if yamlErr := cmd.FormatYaml(buff, metadata); yamlErr == nil {
-				err = fmt.Errorf("%v\n%v", err, buff.String())
+				err = errors.Errorf("%v\n%v", err, buff.String())
 			}
 		}
 		return err
@@ -242,7 +243,7 @@ func (c *validateToolsMetadataCommand) Run(context *cmd.Context) error {
 				sources = append(sources, fmt.Sprintf("- %s (%s)", s.Description(), url))
 			}
 		}
-		return fmt.Errorf("no matching tools using sources:\n%s", strings.Join(sources, "\n"))
+		return errors.Errorf("no matching tools using sources:\n%s", strings.Join(sources, "\n"))
 	}
 	return nil
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -20,7 +20,7 @@ github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24
 github.com/juju/ansiterm	git	e2a7a542a5eb387f493298469a8a3de37dcbc043	2016-08-17T02:52:43Z
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	6791af0ab78efe88ff99c2a0095208b3b7a32055	2016-07-20T09:32:50Z
-github.com/juju/cmd	git	84f14c0b731048db5756bc01a0c7a2323c87483c	2016-08-18T05:41:16Z
+github.com/juju/cmd	git	3764bbd1cd74c91a5fc019440bf812881f566481	2016-08-18T23:27:15Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:32:58Z

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -39,3 +39,7 @@ const Migration = "migration"
 
 // DeveloperMode allows access to developer specific commands and behaviour.
 const DeveloperMode = "developer-mode"
+
+// SmartFormatter enables the deprecated "smart" formatter for the uniter
+// hook tools.
+const SmartFormatter = "smart-formatter"

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -125,9 +125,9 @@ func (s *cmdStorageSuite) TestStorageList(c *gc.C) {
 	createUnitWithStorage(c, &s.JujuConnSuite, testPool)
 
 	expected := `
-[Storage]       
-UNIT            ID     LOCATION STATUS  MESSAGE 
-storage-block/0 data/0          pending         
+[Storage]        
+UNIT             ID      LOCATION  STATUS   MESSAGE  
+storage-block/0  data/0            pending           
 
 `[1:]
 	runList(c, expected)
@@ -139,9 +139,9 @@ func (s *cmdStorageSuite) TestStorageListPersistent(c *gc.C) {
 	// There are currently no guarantees about whether storage
 	// will be persistent until it has been provisioned.
 	expected := `
-[Storage]       
-UNIT            ID     LOCATION STATUS  MESSAGE 
-storage-block/0 data/0          pending         
+[Storage]        
+UNIT             ID      LOCATION  STATUS   MESSAGE  
+storage-block/0  data/0            pending           
 
 `[1:]
 	runList(c, expected)
@@ -545,9 +545,9 @@ func (s *cmdStorageSuite) TestStorageAddToUnitHasVolumes(c *gc.C) {
 	context, err := runJujuCommand(c, "storage", "list")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, `
-[Storage]            
-UNIT                 ID     LOCATION STATUS  MESSAGE 
-storage-filesystem/0 data/0          pending         
+[Storage]             
+UNIT                  ID      LOCATION  STATUS   MESSAGE  
+storage-filesystem/0  data/0            pending           
 
 `[1:])
 	c.Assert(testing.Stderr(context), gc.Equals, "")
@@ -568,10 +568,10 @@ storage-filesystem/0 data/0          pending
 	context, err = runJujuCommand(c, "list-storage")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, `
-[Storage]            
-UNIT                 ID     LOCATION STATUS  MESSAGE 
-storage-filesystem/0 data/0          pending         
-storage-filesystem/0 data/1          pending         
+[Storage]             
+UNIT                  ID      LOCATION  STATUS   MESSAGE  
+storage-filesystem/0  data/0            pending           
+storage-filesystem/0  data/1            pending           
 
 `[1:])
 	c.Assert(testing.Stderr(context), gc.Equals, "")

--- a/payload/status/list_test.go
+++ b/payload/status/list_test.go
@@ -82,9 +82,9 @@ func (s *listSuite) TestOkay(c *gc.C) {
 
 	c.Check(stdout, gc.Equals, `
 [Unit Payloads]
-UNIT                  MACHINE PAYLOAD-CLASS STATUS  TYPE   ID     TAGS  
-a-application/0       1       spam          running docker idspam a-tag 
-another-application/1 2       eggs          running docker ideggs       
+UNIT                   MACHINE  PAYLOAD-CLASS  STATUS   TYPE    ID      TAGS   
+a-application/0        1        spam           running  docker  idspam  a-tag  
+another-application/1  2        eggs           running  docker  ideggs         
 
 `[1:])
 	c.Check(stderr, gc.Equals, "")
@@ -97,7 +97,7 @@ func (s *listSuite) TestNoPayloads(c *gc.C) {
 
 	c.Check(stdout, gc.Equals, `
 [Unit Payloads]
-UNIT MACHINE PAYLOAD-CLASS STATUS TYPE ID TAGS 
+UNIT  MACHINE  PAYLOAD-CLASS  STATUS  TYPE  ID  TAGS  
 
 `[1:])
 	c.Check(stderr, gc.Equals, "")
@@ -121,9 +121,9 @@ func (s *listSuite) TestPatternsOkay(c *gc.C) {
 
 	c.Check(stdout, gc.Equals, `
 [Unit Payloads]
-UNIT                  MACHINE PAYLOAD-CLASS STATUS  TYPE   ID     TAGS  
-a-application/0       1       spam          running docker idspam a-tag 
-another-application/1 2       eggs          running docker ideggs a-tag 
+UNIT                   MACHINE  PAYLOAD-CLASS  STATUS   TYPE    ID      TAGS   
+a-application/0        1        spam           running  docker  idspam  a-tag  
+another-application/1  2        eggs           running  docker  ideggs  a-tag  
 
 `[1:])
 	c.Check(stderr, gc.Equals, "")
@@ -158,9 +158,9 @@ func (s *listSuite) TestOutputFormats(c *gc.C) {
 	formats := map[string]string{
 		"tabular": `
 [Unit Payloads]
-UNIT                  MACHINE PAYLOAD-CLASS STATUS  TYPE   ID     TAGS  
-a-application/0       1       spam          running docker idspam a-tag 
-another-application/1 2       eggs          running docker ideggs       
+UNIT                   MACHINE  PAYLOAD-CLASS  STATUS   TYPE    ID      TAGS   
+a-application/0        1        spam           running  docker  idspam  a-tag  
+another-application/1  2        eggs           running  docker  ideggs         
 
 `[1:],
 		"yaml": `

--- a/payload/status/output_tabular.go
+++ b/payload/status/output_tabular.go
@@ -4,12 +4,12 @@
 package status
 
 import (
-	"bytes"
 	"fmt"
+	"io"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/cmd/output"
 )
 
 const tabularSection = "[Unit Payloads]"
@@ -29,18 +29,16 @@ var (
 	tabularRow    = strings.Repeat("%s\t", len(tabularColumns))
 )
 
-// FormatTabular returns a tabular summary of payloads.
-func FormatTabular(value interface{}) ([]byte, error) {
+// FormatTabular writes a tabular summary of payloads.
+func FormatTabular(writer io.Writer, value interface{}) error {
 	payloads, valueConverted := value.([]FormattedPayload)
 	if !valueConverted {
-		return nil, errors.Errorf("expected value of type %T, got %T", payloads, value)
+		return errors.Errorf("expected value of type %T, got %T", payloads, value)
 	}
 
 	// TODO(ericsnow) sort the rows first?
 
-	var out bytes.Buffer
-	// To format things into columns.
-	tw := tabwriter.NewWriter(&out, 0, 1, 1, ' ', 0)
+	tw := output.TabWriter(writer)
 
 	// Write the header.
 	fmt.Fprintln(tw, tabularSection)
@@ -61,5 +59,5 @@ func FormatTabular(value interface{}) ([]byte, error) {
 	}
 	tw.Flush()
 
-	return out.Bytes(), nil
+	return nil
 }

--- a/resource/cmd/list_charm_resources_test.go
+++ b/resource/cmd/list_charm_resources_test.go
@@ -82,9 +82,9 @@ func (s *ListCharmSuite) TestOkay(c *gc.C) {
 	c.Check(code, gc.Equals, 0)
 
 	c.Check(stdout, gc.Equals, `
-RESOURCE REVISION
-website  2
-music    1
+RESOURCE  REVISION
+website   2
+music     1
 
 `[1:])
 	c.Check(stderr, gc.Equals, "")
@@ -116,7 +116,7 @@ func (s *ListCharmSuite) TestNoResources(c *gc.C) {
 	c.Check(code, gc.Equals, 0)
 
 	c.Check(stdout, gc.Equals, `
-RESOURCE REVISION
+RESOURCE  REVISION
 
 `[1:])
 	c.Check(stderr, gc.Equals, "")
@@ -136,9 +136,9 @@ func (s *ListCharmSuite) TestOutputFormats(c *gc.C) {
 
 	formats := map[string]string{
 		"tabular": `
-RESOURCE REVISION
-website  1
-music    1
+RESOURCE  REVISION
+website   1
+music     1
 
 `[1:],
 		"yaml": `

--- a/resource/cmd/output_tabular.go
+++ b/resource/cmd/output_tabular.go
@@ -4,27 +4,26 @@
 package cmd
 
 import (
-	"bytes"
 	"fmt"
+	"io"
 	"sort"
 	"text/tabwriter"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/cmd/output"
 )
 
 // FormatCharmTabular returns a tabular summary of charm resources.
-func FormatCharmTabular(value interface{}) ([]byte, error) {
+func FormatCharmTabular(writer io.Writer, value interface{}) error {
 	resources, valueConverted := value.([]FormattedCharmResource)
 	if !valueConverted {
-		return nil, errors.Errorf("expected value of type %T, got %T", resources, value)
+		return errors.Errorf("expected value of type %T, got %T", resources, value)
 	}
 
 	// TODO(ericsnow) sort the rows first?
 
-	var out bytes.Buffer
-
 	// To format things into columns.
-	tw := tabwriter.NewWriter(&out, 0, 1, 1, ' ', 0)
+	tw := output.TabWriter(writer)
 
 	// Write the header.
 	// We do not print a section label.
@@ -40,32 +39,34 @@ func FormatCharmTabular(value interface{}) ([]byte, error) {
 	}
 	tw.Flush()
 
-	return out.Bytes(), nil
+	return nil
 }
 
 // FormatSvcTabular returns a tabular summary of resources.
-func FormatSvcTabular(value interface{}) ([]byte, error) {
+func FormatSvcTabular(writer io.Writer, value interface{}) error {
 	switch resources := value.(type) {
 	case FormattedServiceInfo:
-		return formatServiceTabular(resources), nil
+		formatServiceTabular(writer, resources)
+		return nil
 	case []FormattedUnitResource:
-		return formatUnitTabular(resources), nil
+		formatUnitTabular(writer, resources)
+		return nil
 	case FormattedServiceDetails:
-		return formatServiceDetailTabular(resources), nil
+		formatServiceDetailTabular(writer, resources)
+		return nil
 	case FormattedUnitDetails:
-		return formatUnitDetailTabular(resources), nil
+		formatUnitDetailTabular(writer, resources)
+		return nil
 	default:
-		return nil, errors.Errorf("unexpected type for data: %T", resources)
+		return errors.Errorf("unexpected type for data: %T", resources)
 	}
 }
 
-func formatServiceTabular(info FormattedServiceInfo) []byte {
+func formatServiceTabular(writer io.Writer, info FormattedServiceInfo) {
 	// TODO(ericsnow) sort the rows first?
 
-	var out bytes.Buffer
-
-	fmt.Fprintln(&out, "[Service]")
-	tw := tabwriter.NewWriter(&out, 0, 1, 1, ' ', 0)
+	fmt.Fprintln(writer, "[Service]")
+	tw := output.TabWriter(writer)
 	fmt.Fprintln(tw, "RESOURCE\tSUPPLIED BY\tREVISION")
 
 	// Print each info to its own row.
@@ -83,12 +84,10 @@ func formatServiceTabular(info FormattedServiceInfo) []byte {
 	// with the below fmt.Fprintlns.
 	tw.Flush()
 
-	writeUpdates(info.Updates, &out, tw)
-
-	return out.Bytes()
+	writeUpdates(info.Updates, writer, tw)
 }
 
-func writeUpdates(updates []FormattedCharmResource, out *bytes.Buffer, tw *tabwriter.Writer) {
+func writeUpdates(updates []FormattedCharmResource, out io.Writer, tw *tabwriter.Writer) {
 	if len(updates) > 0 {
 		fmt.Fprintln(out, "")
 		fmt.Fprintln(out, "[Updates Available]")
@@ -104,15 +103,13 @@ func writeUpdates(updates []FormattedCharmResource, out *bytes.Buffer, tw *tabwr
 	tw.Flush()
 }
 
-func formatUnitTabular(resources []FormattedUnitResource) []byte {
+func formatUnitTabular(writer io.Writer, resources []FormattedUnitResource) {
 	// TODO(ericsnow) sort the rows first?
 
-	var out bytes.Buffer
-
-	fmt.Fprintln(&out, "[Unit]")
+	fmt.Fprintln(writer, "[Unit]")
 
 	// To format things into columns.
-	tw := tabwriter.NewWriter(&out, 0, 1, 1, ' ', 0)
+	tw := output.TabWriter(writer)
 
 	// Write the header.
 	// We do not print a section label.
@@ -127,20 +124,17 @@ func formatUnitTabular(resources []FormattedUnitResource) []byte {
 		)
 	}
 	tw.Flush()
-
-	return out.Bytes()
 }
 
-func formatServiceDetailTabular(resources FormattedServiceDetails) []byte {
+func formatServiceDetailTabular(writer io.Writer, resources FormattedServiceDetails) {
 	// note that the unit resource can be a zero value here, to indicate that
 	// the unit has not downloaded that resource yet.
 
-	var out bytes.Buffer
-	fmt.Fprintln(&out, "[Units]")
+	fmt.Fprintln(writer, "[Units]")
 
 	sort.Sort(byUnitID(resources.Resources))
 	// To format things into columns.
-	tw := tabwriter.NewWriter(&out, 0, 1, 1, ' ', 0)
+	tw := output.TabWriter(writer)
 
 	// Write the header.
 	fmt.Fprintln(tw, "UNIT\tRESOURCE\tREVISION\tEXPECTED")
@@ -155,21 +149,18 @@ func formatServiceDetailTabular(resources FormattedServiceDetails) []byte {
 	}
 	tw.Flush()
 
-	writeUpdates(resources.Updates, &out, tw)
-
-	return out.Bytes()
+	writeUpdates(resources.Updates, writer, tw)
 }
 
-func formatUnitDetailTabular(resources FormattedUnitDetails) []byte {
+func formatUnitDetailTabular(writer io.Writer, resources FormattedUnitDetails) {
 	// note that the unit resource can be a zero value here, to indicate that
 	// the unit has not downloaded that resource yet.
 
-	var out bytes.Buffer
-	fmt.Fprintln(&out, "[Unit]")
+	fmt.Fprintln(writer, "[Unit]")
 
 	sort.Sort(byUnitID(resources))
 	// To format things into columns.
-	tw := tabwriter.NewWriter(&out, 0, 1, 1, ' ', 0)
+	tw := output.TabWriter(writer)
 
 	// Write the header.
 	fmt.Fprintln(tw, "RESOURCE\tREVISION\tEXPECTED")
@@ -182,7 +173,6 @@ func formatUnitDetailTabular(resources FormattedUnitDetails) []byte {
 		)
 	}
 	tw.Flush()
-	return out.Bytes()
 }
 
 type byUnitID []FormattedDetailResource

--- a/resource/cmd/show_service_test.go
+++ b/resource/cmd/show_service_test.go
@@ -175,15 +175,15 @@ func (s *ShowServiceSuite) TestRun(c *gc.C) {
 
 	c.Check(stdout, gc.Equals, `
 [Service]
-RESOURCE SUPPLIED BY REVISION
-openjdk  charmstore  7
-website  upload      -
-rsc1234  charmstore  15
-website2 Bill User   2012-12-12T12:12
+RESOURCE  SUPPLIED BY  REVISION
+openjdk   charmstore   7
+website   upload       -
+rsc1234   charmstore   15
+website2  Bill User    2012-12-12T12:12
 
 [Updates Available]
-RESOURCE REVISION
-openjdk  10
+RESOURCE  REVISION
+openjdk   10
 
 `[1:])
 
@@ -238,9 +238,9 @@ func (s *ShowServiceSuite) TestRunUnit(c *gc.C) {
 
 	c.Check(stdout, gc.Equals, `
 [Unit]
-RESOURCE REVISION
-rsc1234  15
-website2 2012-12-12T12:12
+RESOURCE  REVISION
+rsc1234   15
+website2  2012-12-12T12:12
 
 `[1:])
 
@@ -402,13 +402,13 @@ func (s *ShowServiceSuite) TestRunDetails(c *gc.C) {
 
 	c.Check(stdout, gc.Equals, `
 [Units]
-UNIT RESOURCE REVISION         EXPECTED
-5    alpha    10               15
-5    beta     2012-12-12T12:12 2012-12-12T12:12
-5    charlie  2011-11-11T11:11 2012-12-12T12:12 (fetching: 2%)
-10   alpha    10               15 (fetching: 15%)
-10   beta     -                2012-12-12T12:12
-10   charlie  2011-11-11T11:11 2012-12-12T12:12 (fetching: 9%)
+UNIT  RESOURCE  REVISION          EXPECTED
+5     alpha     10                15
+5     beta      2012-12-12T12:12  2012-12-12T12:12
+5     charlie   2011-11-11T11:11  2012-12-12T12:12 (fetching: 2%)
+10    alpha     10                15 (fetching: 15%)
+10    beta      -                 2012-12-12T12:12
+10    charlie   2011-11-11T11:11  2012-12-12T12:12 (fetching: 9%)
 
 `[1:])
 
@@ -542,10 +542,10 @@ func (s *ShowServiceSuite) TestRunUnitDetails(c *gc.C) {
 
 	c.Check(stdout, gc.Equals, `
 [Unit]
-RESOURCE REVISION         EXPECTED
-alpha    10               15
-beta     -                2012-12-12T12:12
-charlie  2011-11-11T11:11 2012-12-12T12:12 (fetching: 0%)
+RESOURCE  REVISION          EXPECTED
+alpha     10                15
+beta      -                 2012-12-12T12:12
+charlie   2011-11-11T11:11  2012-12-12T12:12 (fetching: 0%)
 
 `[1:])
 

--- a/worker/uniter/runner/jujuc/action-get.go
+++ b/worker/uniter/runner/jujuc/action-get.go
@@ -8,6 +8,10 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils/featureflag"
+
+	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/feature"
 )
 
 // ActionGetCommand implements the action-get command.
@@ -43,7 +47,11 @@ map as needed.
 // SetFlags handles known option flags; in this case, [--output={json|yaml}]
 // and --help.
 func (c *ActionGetCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	if featureflag.Enabled(feature.SmartFormatter) {
+		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	} else {
+		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
+	}
 }
 
 // Init makes sure there are no additional unknown arguments to action-get.

--- a/worker/uniter/runner/jujuc/action-get_test.go
+++ b/worker/uniter/runner/jujuc/action-get_test.go
@@ -11,6 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -51,6 +52,7 @@ func (s *ActionGetSuite) TestNonActionRunFail(c *gc.C) {
 }
 
 func (s *ActionGetSuite) TestActionGet(c *gc.C) {
+	s.SetFeatureFlags(feature.SmartFormatter)
 	var actionGetTestMaps = []map[string]interface{}{
 		{
 			"outfile": "foo.bz2",
@@ -107,15 +109,15 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 	}{{
 		summary: "a simple empty map with nil key",
 		args:    []string{},
-		out:     "{}\n",
+		out:     "{}",
 	}, {
 		summary: "a simple empty map with nil key",
 		args:    []string{"--format", "yaml"},
-		out:     "{}\n",
+		out:     "{}",
 	}, {
 		summary: "a simple empty map with nil key",
 		args:    []string{"--format", "json"},
-		out:     "null\n",
+		out:     "null",
 	}, {
 		summary: "a nonexistent key",
 		args:    []string{"foo"},
@@ -125,7 +127,7 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 	}, {
 		summary: "a nonexistent key",
 		args:    []string{"--format", "json", "foo"},
-		out:     "null\n",
+		out:     "null",
 	}, {
 		summary:      "a nonexistent inner key",
 		args:         []string{"outfile.type"},
@@ -138,7 +140,7 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 		summary:      "a nonexistent inner key",
 		args:         []string{"--format", "json", "outfile.type"},
 		actionParams: actionGetTestMaps[1],
-		out:          "null\n",
+		out:          "null",
 	}, {
 		summary:      "a nonexistent inner key",
 		args:         []string{"outfile.type.1"},
@@ -151,7 +153,7 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 		summary:      "a nonexistent inner key",
 		args:         []string{"--format", "json", "outfile.type.1"},
 		actionParams: actionGetTestMaps[1],
-		out:          "null\n",
+		out:          "null",
 	}, {
 		summary:      "a map with a non-string key",
 		args:         []string{"outfile.type"},
@@ -164,22 +166,22 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 		summary:      "a map with a non-string key",
 		args:         []string{"--format", "json", "outfile.type"},
 		actionParams: actionGetTestMaps[3],
-		out:          "null\n",
+		out:          "null",
 	}, {
 		summary:      "a simple map of one value to one key",
 		args:         []string{},
 		actionParams: actionGetTestMaps[0],
-		out:          "outfile: foo.bz2\n",
+		out:          "outfile: foo.bz2",
 	}, {
 		summary:      "a simple map of one value to one key",
 		args:         []string{"--format", "yaml"},
 		actionParams: actionGetTestMaps[0],
-		out:          "outfile: foo.bz2\n",
+		out:          "outfile: foo.bz2",
 	}, {
 		summary:      "a simple map of one value to one key",
 		args:         []string{"--format", "json"},
 		actionParams: actionGetTestMaps[0],
-		out:          "{\"outfile\":\"foo.bz2\"}\n",
+		out:          `{"outfile":"foo.bz2"}`,
 	}, {
 		summary:      "an entire map",
 		args:         []string{},
@@ -188,7 +190,7 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 			"  type:\n" +
 			"    \"1\": raw\n" +
 			"    \"2\": gzip\n" +
-			"    \"3\": bzip\n",
+			"    \"3\": bzip",
 	}, {
 		summary:      "an entire map",
 		args:         []string{"--format", "yaml"},
@@ -197,50 +199,50 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 			"  type:\n" +
 			"    \"1\": raw\n" +
 			"    \"2\": gzip\n" +
-			"    \"3\": bzip\n",
+			"    \"3\": bzip",
 	}, {
 		summary:      "an entire map",
 		args:         []string{"--format", "json"},
 		actionParams: actionGetTestMaps[2],
-		out:          `{"outfile":{"type":{"1":"raw","2":"gzip","3":"bzip"}}}` + "\n",
+		out:          `{"outfile":{"type":{"1":"raw","2":"gzip","3":"bzip"}}}`,
 	}, {
 		summary:      "an inner map value which is itself a map",
 		args:         []string{"outfile.type"},
 		actionParams: actionGetTestMaps[2],
 		out: "\"1\": raw\n" +
 			"\"2\": gzip\n" +
-			"\"3\": bzip\n",
+			"\"3\": bzip",
 	}, {
 		summary:      "an inner map value which is itself a map",
 		args:         []string{"--format", "yaml", "outfile.type"},
 		actionParams: actionGetTestMaps[2],
 		out: "\"1\": raw\n" +
 			"\"2\": gzip\n" +
-			"\"3\": bzip\n",
+			"\"3\": bzip",
 	}, {
 		summary:      "an inner map value which is itself a map",
 		args:         []string{"--format", "json", "outfile.type"},
 		actionParams: actionGetTestMaps[2],
-		out:          `{"1":"raw","2":"gzip","3":"bzip"}` + "\n",
+		out:          `{"1":"raw","2":"gzip","3":"bzip"}`,
 	}, {
 		summary:      "a map with an inner map keyed by interface{}",
 		args:         []string{"outfile.type"},
 		actionParams: actionGetTestMaps[4],
 		out: "\"1\": raw\n" +
 			"\"2\": gzip\n" +
-			"\"3\": bzip\n",
+			"\"3\": bzip",
 	}, {
 		summary:      "a map with an inner map keyed by interface{}",
 		args:         []string{"--format", "yaml", "outfile.type"},
 		actionParams: actionGetTestMaps[4],
 		out: "\"1\": raw\n" +
 			"\"2\": gzip\n" +
-			"\"3\": bzip\n",
+			"\"3\": bzip",
 	}, {
 		summary:      "a map with an inner map keyed by interface{}",
 		args:         []string{"--format", "json", "outfile.type"},
 		actionParams: actionGetTestMaps[4],
-		out:          `{"1":"raw","2":"gzip","3":"bzip"}` + "\n",
+		out:          `{"1":"raw","2":"gzip","3":"bzip"}`,
 	}, {
 		summary: "too many arguments",
 		args:    []string{"multiple", "keys"},
@@ -257,10 +259,11 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 		ctx := testing.Context(c)
 		code := cmd.Main(com, ctx, t.args)
 		c.Check(code, gc.Equals, t.code)
-		c.Check(bufferString(ctx.Stdout), gc.Equals, t.out)
 		if code == 0 {
+			c.Check(bufferString(ctx.Stdout), gc.Equals, t.out+"\n")
 			c.Check(bufferString(ctx.Stderr), gc.Equals, "")
 		} else {
+			c.Check(bufferString(ctx.Stdout), gc.Equals, "")
 			expect := fmt.Sprintf(`(\n)*error: %s\n`, t.errMsg)
 			c.Check(bufferString(ctx.Stderr), gc.Matches, expect)
 		}
@@ -280,8 +283,8 @@ Summary:
 get action parameters
 
 Options:
---format  (= smart)
-    Specify output format (json|smart|yaml)
+--format  (= yaml)
+    Specify output format (json|yaml)
 -o, --output (= "")
     Specify an output file
 

--- a/worker/uniter/runner/jujuc/config-get.go
+++ b/worker/uniter/runner/jujuc/config-get.go
@@ -8,6 +8,10 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils/featureflag"
+
+	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/feature"
 )
 
 // ConfigGetCommand implements the config-get command.
@@ -38,7 +42,11 @@ reported as null. <key> and --all are mutually exclusive.
 }
 
 func (c *ConfigGetCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	if featureflag.Enabled(feature.SmartFormatter) {
+		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	} else {
+		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
+	}
 	f.BoolVar(&c.All, "a", false, "print all keys")
 	f.BoolVar(&c.All, "all", false, "")
 }

--- a/worker/uniter/runner/jujuc/config-get_test.go
+++ b/worker/uniter/runner/jujuc/config-get_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v2"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -34,12 +35,13 @@ var configGetKeyTests = []struct {
 	{[]string{"spline-reticulation"}, "45\n"},
 	{[]string{"--format", "yaml", "spline-reticulation"}, "45\n"},
 	{[]string{"--format", "json", "spline-reticulation"}, "45\n"},
-	{[]string{"missing"}, ""},
-	{[]string{"--format", "yaml", "missing"}, ""},
+	{[]string{"missing"}, "\n"},
+	{[]string{"--format", "yaml", "missing"}, "\n"},
 	{[]string{"--format", "json", "missing"}, "null\n"},
 }
 
 func (s *ConfigGetSuite) TestOutputFormatKey(c *gc.C) {
+	s.SetFeatureFlags(feature.SmartFormatter)
 	for i, t := range configGetKeyTests {
 		c.Logf("test %d: %#v", i, t.args)
 		hctx := s.GetHookContext(c, -1, "")
@@ -47,9 +49,9 @@ func (s *ConfigGetSuite) TestOutputFormatKey(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := testing.Context(c)
 		code := cmd.Main(com, ctx, t.args)
-		c.Assert(code, gc.Equals, 0)
-		c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
-		c.Assert(bufferString(ctx.Stdout), gc.Matches, t.out)
+		c.Check(code, gc.Equals, 0)
+		c.Check(bufferString(ctx.Stderr), gc.Equals, "")
+		c.Check(bufferString(ctx.Stdout), gc.Matches, t.out)
 	}
 }
 
@@ -138,8 +140,8 @@ print service configuration
 Options:
 -a, --all  (= false)
     print all keys
---format  (= smart)
-    Specify output format (json|smart|yaml)
+--format  (= yaml)
+    Specify output format (json|yaml)
 -o, --output (= "")
     Specify an output file
 
@@ -162,7 +164,7 @@ func (s *ConfigGetSuite) TestOutputPath(c *gc.C) {
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
 	content, err := ioutil.ReadFile(filepath.Join(ctx.Dir, "some-file"))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(content), gc.Equals, "False\n")
+	c.Assert(string(content), gc.Equals, "false\n")
 }
 
 func (s *ConfigGetSuite) TestUnknownArg(c *gc.C) {

--- a/worker/uniter/runner/jujuc/is-leader.go
+++ b/worker/uniter/runner/jujuc/is-leader.go
@@ -7,6 +7,10 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils/featureflag"
+
+	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/feature"
 )
 
 // isLeaderCommand implements the is-leader command.
@@ -37,7 +41,11 @@ there is no such guarantee.
 
 // SetFlags is part of the cmd.Command interface.
 func (c *isLeaderCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	if featureflag.Enabled(feature.SmartFormatter) {
+		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	} else {
+		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
+	}
 }
 
 // Run is part of the cmd.Command interface.

--- a/worker/uniter/runner/jujuc/is-leader_test.go
+++ b/worker/uniter/runner/jujuc/is-leader_test.go
@@ -6,16 +6,16 @@ package jujuc_test
 import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
 type isLeaderSuite struct {
-	jujutesting.IsolationSuite
+	testing.BaseSuite
 }
 
 var _ = gc.Suite(&isLeaderSuite{})
@@ -57,18 +57,22 @@ func (s *isLeaderSuite) TestIsLeaderError(c *gc.C) {
 }
 
 func (s *isLeaderSuite) TestFormatDefaultYes(c *gc.C) {
+	s.SetFeatureFlags(feature.SmartFormatter)
 	s.testOutput(c, true, nil, "True\n")
 }
 
 func (s *isLeaderSuite) TestFormatDefaultNo(c *gc.C) {
+	s.SetFeatureFlags(feature.SmartFormatter)
 	s.testOutput(c, false, nil, "False\n")
 }
 
 func (s *isLeaderSuite) TestFormatSmartYes(c *gc.C) {
+	s.SetFeatureFlags(feature.SmartFormatter)
 	s.testOutput(c, true, []string{"--format", "smart"}, "True\n")
 }
 
 func (s *isLeaderSuite) TestFormatSmartNo(c *gc.C) {
+	s.SetFeatureFlags(feature.SmartFormatter)
 	s.testOutput(c, false, []string{"--format", "smart"}, "False\n")
 }
 

--- a/worker/uniter/runner/jujuc/leader-get.go
+++ b/worker/uniter/runner/jujuc/leader-get.go
@@ -9,6 +9,10 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils/featureflag"
+
+	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/feature"
 )
 
 // leaderGetCommand implements the leader-get command.
@@ -40,7 +44,11 @@ is given, or if the key is "-", all keys and values will be printed.
 
 // SetFlags is part of the cmd.Command interface.
 func (c *leaderGetCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	if featureflag.Enabled(feature.SmartFormatter) {
+		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	} else {
+		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
+	}
 }
 
 // Init is part of the cmd.Command interface.

--- a/worker/uniter/runner/jujuc/leader-get_test.go
+++ b/worker/uniter/runner/jujuc/leader-get_test.go
@@ -6,25 +6,27 @@ package jujuc_test
 import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
 type leaderGetSuite struct {
-	jujutesting.IsolationSuite
+	testing.BaseSuite
 	command cmd.Command
 }
 
 var _ = gc.Suite(&leaderGetSuite{})
 
 func (s *leaderGetSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
 	var err error
 	s.command, err = jujuc.NewLeaderGetCommand(nil)
 	c.Assert(err, jc.ErrorIsNil)
+	s.SetFeatureFlags(feature.SmartFormatter)
 }
 
 func (s *leaderGetSuite) TestInitError(c *gc.C) {
@@ -68,7 +70,7 @@ func (s *leaderGetSuite) TestSettingsError(c *gc.C) {
 }
 
 func (s *leaderGetSuite) TestSettingsFormatDefaultMissingKey(c *gc.C) {
-	s.testOutput(c, []string{"unknown"}, "")
+	s.testOutput(c, []string{"unknown"}, "\n")
 }
 
 func (s *leaderGetSuite) TestSettingsFormatDefaultKey(c *gc.C) {
@@ -84,7 +86,7 @@ func (s *leaderGetSuite) TestSettingsFormatDefaultEmpty(c *gc.C) {
 }
 
 func (s *leaderGetSuite) TestSettingsFormatSmartMissingKey(c *gc.C) {
-	s.testOutput(c, []string{"--format", "smart", "unknown"}, "")
+	s.testOutput(c, []string{"--format", "smart", "unknown"}, "\n")
 }
 
 func (s *leaderGetSuite) TestSettingsFormatSmartKey(c *gc.C) {

--- a/worker/uniter/runner/jujuc/network-get.go
+++ b/worker/uniter/runner/jujuc/network-get.go
@@ -9,6 +9,10 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils/featureflag"
+
+	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/feature"
 )
 
 // NetworkGetCommand implements the network-get command.
@@ -45,7 +49,11 @@ the IP address the local unit should advertise as its endpoint to its peers.
 
 // SetFlags is part of the cmd.Command interface.
 func (c *NetworkGetCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	if featureflag.Enabled(feature.SmartFormatter) {
+		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	} else {
+		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
+	}
 	f.BoolVar(&c.primaryAddress, "primary-address", false, "get the primary address for the binding")
 }
 

--- a/worker/uniter/runner/jujuc/network-get_test.go
+++ b/worker/uniter/runner/jujuc/network-get_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -46,6 +47,7 @@ func (s *NetworkGetSuite) createCommand(c *gc.C) cmd.Command {
 }
 
 func (s *NetworkGetSuite) TestNetworkGet(c *gc.C) {
+	s.SetFeatureFlags(feature.SmartFormatter)
 	for i, t := range []struct {
 		summary  string
 		args     []string
@@ -118,8 +120,8 @@ Summary:
 get network config
 
 Options:
---format  (= smart)
-    Specify output format (json|smart|yaml)
+--format  (= yaml)
+    Specify output format (json|yaml)
 -o, --output (= "")
     Specify an output file
 --primary-address  (= false)

--- a/worker/uniter/runner/jujuc/opened-ports.go
+++ b/worker/uniter/runner/jujuc/opened-ports.go
@@ -6,6 +6,10 @@ package jujuc
 import (
 	"github.com/juju/cmd"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils/featureflag"
+
+	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/feature"
 )
 
 // OpenedPortsCommand implements the opened-ports command.
@@ -30,7 +34,11 @@ func (c *OpenedPortsCommand) Info() *cmd.Info {
 }
 
 func (c *OpenedPortsCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	if featureflag.Enabled(feature.SmartFormatter) {
+		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	} else {
+		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
+	}
 }
 
 func (c *OpenedPortsCommand) Init(args []string) error {

--- a/worker/uniter/runner/jujuc/opened-ports_test.go
+++ b/worker/uniter/runner/jujuc/opened-ports_test.go
@@ -10,6 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
@@ -22,6 +23,7 @@ type OpenedPortsSuite struct {
 var _ = gc.Suite(&OpenedPortsSuite{})
 
 func (s *OpenedPortsSuite) TestRunAllFormats(c *gc.C) {
+	s.SetFeatureFlags(feature.SmartFormatter)
 	expectedPorts := []network.PortRange{
 		{10, 20, "tcp"},
 		{80, 80, "tcp"},

--- a/worker/uniter/runner/jujuc/relation-get.go
+++ b/worker/uniter/runner/jujuc/relation-get.go
@@ -9,8 +9,11 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils/featureflag"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/feature"
 )
 
 // RelationGetCommand implements the relation-get command.
@@ -61,7 +64,11 @@ If no key is given, or if the key is "-", all keys and values will be printed.
 
 // SetFlags is part of the cmd.Command interface.
 func (c *RelationGetCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	if featureflag.Enabled(feature.SmartFormatter) {
+		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	} else {
+		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
+	}
 	f.Var(c.relationIdProxy, "r", "specify a relation by id")
 	f.Var(c.relationIdProxy, "relation", "")
 }

--- a/worker/uniter/runner/jujuc/relation-get_test.go
+++ b/worker/uniter/runner/jujuc/relation-get_test.go
@@ -13,6 +13,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 	jujuctesting "github.com/juju/juju/worker/uniter/runner/jujuc/testing"
@@ -141,6 +142,7 @@ var relationGetTests = []struct {
 }
 
 func (s *RelationGetSuite) TestRelationGet(c *gc.C) {
+	s.SetFeatureFlags(feature.SmartFormatter)
 	for i, t := range relationGetTests {
 		c.Logf("test %d: %s", i, t.summary)
 		hctx, _ := s.newHookContext(t.relid, t.unit)
@@ -151,10 +153,7 @@ func (s *RelationGetSuite) TestRelationGet(c *gc.C) {
 		c.Check(code, gc.Equals, t.code)
 		if code == 0 {
 			c.Check(bufferString(ctx.Stderr), gc.Equals, "")
-			expect := t.out
-			if expect != "" {
-				expect = expect + "\n"
-			}
+			expect := t.out + "\n"
 			c.Check(bufferString(ctx.Stdout), gc.Equals, expect)
 		} else {
 			c.Check(bufferString(ctx.Stdout), gc.Equals, "")
@@ -222,8 +221,8 @@ Summary:
 get relation settings
 
 Options:
---format  (= smart)
-    Specify output format (json|smart|yaml)
+--format  (= yaml)
+    Specify output format (json|yaml)
 -o, --output (= "")
     Specify an output file
 -r, --relation  (= %s)
@@ -279,6 +278,7 @@ func (s *RelationGetSuite) TestHelp(c *gc.C) {
 }
 
 func (s *RelationGetSuite) TestOutputPath(c *gc.C) {
+	s.SetFeatureFlags(feature.SmartFormatter)
 	hctx, _ := s.newHookContext(1, "m/0")
 	com, err := jujuc.NewCommand(hctx, cmdString("relation-get"))
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/jujuc/relation-ids.go
+++ b/worker/uniter/runner/jujuc/relation-ids.go
@@ -10,6 +10,10 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils/featureflag"
+
+	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/feature"
 )
 
 // RelationIdsCommand implements the relation-ids command.
@@ -50,7 +54,11 @@ func (c *RelationIdsCommand) Info() *cmd.Info {
 }
 
 func (c *RelationIdsCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	if featureflag.Enabled(feature.SmartFormatter) {
+		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	} else {
+		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
+	}
 }
 
 func (c *RelationIdsCommand) Init(args []string) error {

--- a/worker/uniter/runner/jujuc/relation-ids_test.go
+++ b/worker/uniter/runner/jujuc/relation-ids_test.go
@@ -11,6 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -101,6 +102,7 @@ var relationIdsTests = []struct {
 }
 
 func (s *RelationIdsSuite) TestRelationIds(c *gc.C) {
+	s.SetFeatureFlags(feature.SmartFormatter)
 	for i, t := range relationIdsTests {
 		c.Logf("test %d: %s", i, t.summary)
 		hctx, _ := s.newHookContext(t.relid, "")
@@ -111,10 +113,7 @@ func (s *RelationIdsSuite) TestRelationIds(c *gc.C) {
 		c.Assert(code, gc.Equals, t.code)
 		if code == 0 {
 			c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
-			expect := t.out
-			if expect != "" {
-				expect += "\n"
-			}
+			expect := t.out + "\n"
 			c.Assert(bufferString(ctx.Stdout), gc.Equals, expect)
 		} else {
 			c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
@@ -131,8 +130,8 @@ Summary:
 list all relation ids with the given relation name
 
 Options:
---format  (= smart)
-    Specify output format (json|smart|yaml)
+--format  (= yaml)
+    Specify output format (json|yaml)
 -o, --output (= "")
     Specify an output file
 %s`[1:]

--- a/worker/uniter/runner/jujuc/relation-list.go
+++ b/worker/uniter/runner/jujuc/relation-list.go
@@ -9,6 +9,10 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils/featureflag"
+
+	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/feature"
 )
 
 // RelationListCommand implements the relation-list command.
@@ -46,7 +50,11 @@ func (c *RelationListCommand) Info() *cmd.Info {
 }
 
 func (c *RelationListCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	if featureflag.Enabled(feature.SmartFormatter) {
+		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	} else {
+		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
+	}
 	f.Var(c.relationIdProxy, "r", "specify a relation by id")
 	f.Var(c.relationIdProxy, "relation", "")
 }

--- a/worker/uniter/runner/jujuc/relation-list_test.go
+++ b/worker/uniter/runner/jujuc/relation-list_test.go
@@ -11,6 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -108,6 +109,7 @@ var relationListTests = []struct {
 }
 
 func (s *RelationListSuite) TestRelationList(c *gc.C) {
+	s.SetFeatureFlags(feature.SmartFormatter)
 	for i, t := range relationListTests {
 		c.Logf("test %d: %s", i, t.summary)
 		hctx, info := s.newHookContext(t.relid, "")
@@ -122,10 +124,7 @@ func (s *RelationListSuite) TestRelationList(c *gc.C) {
 		c.Assert(code, gc.Equals, t.code)
 		if code == 0 {
 			c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
-			expect := t.out
-			if expect != "" {
-				expect = expect + "\n"
-			}
+			expect := t.out + "\n"
 			c.Assert(bufferString(ctx.Stdout), gc.Equals, expect)
 		} else {
 			c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
@@ -143,8 +142,8 @@ Summary:
 list relation units
 
 Options:
---format  (= smart)
-    Specify output format (json|smart|yaml)
+--format  (= yaml)
+    Specify output format (json|yaml)
 -o, --output (= "")
     Specify an output file
 -r, --relation  (= %s)

--- a/worker/uniter/runner/jujuc/status-get.go
+++ b/worker/uniter/runner/jujuc/status-get.go
@@ -7,7 +7,10 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils/featureflag"
 
+	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/status"
 )
 
@@ -38,7 +41,11 @@ If the --include-data flag is passed, the associated data are printed also.
 }
 
 func (c *StatusGetCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	if featureflag.Enabled(feature.SmartFormatter) {
+		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	} else {
+		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
+	}
 	f.BoolVar(&c.includeData, "include-data", false, "print all status data")
 	f.BoolVar(&c.serviceWide, "application", false, "print status for all units of this application if this unit is the leader")
 }

--- a/worker/uniter/runner/jujuc/status-get_test.go
+++ b/worker/uniter/runner/jujuc/status-get_test.go
@@ -42,7 +42,6 @@ var statusGetTests = []struct {
 }{
 	{[]string{"--format", "json", "--include-data"}, formatJson, statusAttributes},
 	{[]string{"--format", "yaml"}, formatYaml, map[string]interface{}{"status": "error"}},
-	{[]string{}, -1, "error\n"},
 }
 
 func setFakeStatus(ctx *Context) {
@@ -112,8 +111,8 @@ func (s *statusGetSuite) TestHelp(c *gc.C) {
 		"Options:\n" +
 		"--application  (= false)\n" +
 		"    print status for all units of this application if this unit is the leader\n" +
-		"--format  (= smart)\n" +
-		"    Specify output format (json|smart|yaml)\n" +
+		"--format  (= yaml)\n" +
+		"    Specify output format (json|yaml)\n" +
 		"--include-data  (= false)\n" +
 		"    print all status data\n" +
 		"-o, --output (= \"\")\n" +

--- a/worker/uniter/runner/jujuc/storage-get.go
+++ b/worker/uniter/runner/jujuc/storage-get.go
@@ -7,7 +7,11 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/feature"
 )
 
 // StorageGetCommand implements the storage-get command.
@@ -43,7 +47,11 @@ When no <key> is supplied, all keys values are printed.
 }
 
 func (c *StorageGetCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	if featureflag.Enabled(feature.SmartFormatter) {
+		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	} else {
+		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
+	}
 	f.Var(c.storageTagProxy, "s", "specify a storage instance by id")
 }
 

--- a/worker/uniter/runner/jujuc/storage-get_test.go
+++ b/worker/uniter/runner/jujuc/storage-get_test.go
@@ -74,8 +74,8 @@ Summary:
 print information for storage instance with specified id
 
 Options:
---format  (= smart)
-    Specify output format (json|smart|yaml)
+--format  (= yaml)
+    Specify output format (json|yaml)
 -o, --output (= "")
     Specify an output file
 -s  (= data/0)

--- a/worker/uniter/runner/jujuc/storage-list.go
+++ b/worker/uniter/runner/jujuc/storage-list.go
@@ -7,7 +7,11 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/feature"
 )
 
 // StorageListCommand implements the storage-list command.
@@ -42,7 +46,11 @@ instances for that named storage will be returned.
 }
 
 func (c *StorageListCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	if featureflag.Enabled(feature.SmartFormatter) {
+		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	} else {
+		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
+	}
 }
 
 func (c *StorageListCommand) Init(args []string) (err error) {

--- a/worker/uniter/runner/jujuc/storage-list_test.go
+++ b/worker/uniter/runner/jujuc/storage-list_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v2"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 	jujuctesting "github.com/juju/juju/worker/uniter/runner/jujuc/testing"
@@ -49,6 +50,7 @@ func (s *storageListSuite) TestOutputFormatJSON(c *gc.C) {
 }
 
 func (s *storageListSuite) TestOutputFormatDefault(c *gc.C) {
+	s.SetFeatureFlags(feature.SmartFormatter)
 	// The default output format is "smart", which is
 	// a newline-separated list of strings.
 	s.testOutputFormat(c,
@@ -111,8 +113,8 @@ Summary:
 list storage attached to the unit
 
 Options:
---format  (= smart)
-    Specify output format (json|smart|yaml)
+--format  (= yaml)
+    Specify output format (json|yaml)
 -o, --output (= "")
     Specify an output file
 

--- a/worker/uniter/runner/jujuc/unit-get.go
+++ b/worker/uniter/runner/jujuc/unit-get.go
@@ -9,6 +9,10 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils/featureflag"
+
+	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/feature"
 )
 
 // UnitGetCommand implements the unit-get command.
@@ -32,7 +36,11 @@ func (c *UnitGetCommand) Info() *cmd.Info {
 }
 
 func (c *UnitGetCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	if featureflag.Enabled(feature.SmartFormatter) {
+		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	} else {
+		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
+	}
 }
 
 func (c *UnitGetCommand) Init(args []string) error {

--- a/worker/uniter/runner/jujuc/unit-get_test.go
+++ b/worker/uniter/runner/jujuc/unit-get_test.go
@@ -63,8 +63,8 @@ Summary:
 print public-address or private-address
 
 Options:
---format  (= smart)
-    Specify output format (json|smart|yaml)
+--format  (= yaml)
+    Specify output format (json|yaml)
 -o, --output (= "")
     Specify an output file
 `)

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1322,7 +1322,7 @@ func (s *UniterSuite) TestUniterRelations(c *gc.C) {
 
 				// Check that config-changed didn't record any relations, because
 				// they shouldn't been available until after the start hook.
-				ft.File{"charm/relations.out", "", 0644}.Check(c, ctx.path)
+				ft.File{"charm/relations.out", "[]\n", 0644}.Check(c, ctx.path)
 			}},
 			startUniter{},
 			waitHooks{"config-changed"},
@@ -1332,7 +1332,7 @@ func (s *UniterSuite) TestUniterRelations(c *gc.C) {
 				ft.Dir{path, 0755}.Check(c, ctx.path)
 
 				// Check that config-changed did record the joined relations.
-				data := fmt.Sprintf("db:%d\n", ctx.relation.Id())
+				data := fmt.Sprintf("- db:%d\n", ctx.relation.Id())
 				ft.File{"charm/relations.out", data, 0644}.Check(c, ctx.path)
 			}},
 		),

--- a/worker/uniter/util_unix_test.go
+++ b/worker/uniter/util_unix_test.go
@@ -27,7 +27,7 @@ var (
 var (
 	// Used in TestLeadership
 	leadershipScript = `
-if [ $(is-leader) != "False" ]; then exit -1; fi
+if [ $(is-leader) != "false" ]; then exit -1; fi
 `[1:]
 
 	// Different hook file contents. These are used in util_test

--- a/worker/uniter/util_windows_test.go
+++ b/worker/uniter/util_windows_test.go
@@ -31,7 +31,7 @@ var (
 var (
 	// Used in TestLeadership
 	leadershipScript = `
-If ($(is-leader) -ne "False") {exit -1}
+If ($(is-leader) -ne "false") {exit -1}
 `[1:]
 
 	// Different hook file contents. These are used in util_test


### PR DESCRIPTION
All command formatters now take io.Writer. There is a pending cmd branch that needs to land as a pre-requisite, which will then have an updated hash in dependencies.tsv.

This work is needed in order to be able to get colored formatted output.

As an aside in this branch, I created a common function for creating a TabWriter so we have consistent formatting across commands.

Also the smart formatter has been removed. It is still available in jujuc hook tools as long as a feature flag is used.

(Review request: http://reviews.vapour.ws/r/5481/)