### PR TITLE
Rename MigrationModeActive to MigrationModeNone

### DIFF
--- a/apiserver/migrationtarget/migrationtarget.go
+++ b/apiserver/migrationtarget/migrationtarget.go
@@ -109,5 +109,5 @@ func (api *API) Activate(args params.ModelArgs) error {
 		return errors.Trace(err)
 	}
 
-	return model.SetMigrationMode(state.MigrationModeActive)
+	return model.SetMigrationMode(state.MigrationModeNone)
 }

--- a/apiserver/migrationtarget/migrationtarget_test.go
+++ b/apiserver/migrationtarget/migrationtarget_test.go
@@ -136,7 +136,7 @@ func (s *Suite) TestActivate(c *gc.C) {
 	// The model should no longer exist.
 	model, err := s.State.GetModel(tag)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(model.MigrationMode(), gc.Equals, state.MigrationModeActive)
+	c.Assert(model.MigrationMode(), gc.Equals, state.MigrationModeNone)
 }
 
 func (s *Suite) TestActivateNotATag(c *gc.C) {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -507,7 +507,7 @@ func ResetMigrationMode(c *gc.C, st *State) {
 		Id:     st.ModelUUID(),
 		Assert: txn.DocExists,
 		Update: bson.M{
-			"$set": bson.M{"migration-mode": MigrationModeActive},
+			"$set": bson.M{"migration-mode": MigrationModeNone},
 		},
 	}}
 	err := st.runTransaction(ops)

--- a/state/model.go
+++ b/state/model.go
@@ -36,9 +36,9 @@ func modelKey(modelUUID string) string {
 type MigrationMode string
 
 const (
-	// MigrationModeActive is the default mode for a model and reflects
-	// a model that is active within its controller.
-	MigrationModeActive MigrationMode = ""
+	// MigrationModeNone is the default mode for a model and reflects
+	// that it isn't involved with a model migration.
+	MigrationModeNone MigrationMode = ""
 
 	// MigrationModeExporting reflects a model that is in the process of being
 	// exported from one controller to another.
@@ -201,7 +201,7 @@ func (m ModelArgs) Validate() error {
 		return errors.NotValidf("nil StorageProviderRegistry")
 	}
 	switch m.MigrationMode {
-	case MigrationModeActive, MigrationModeImporting:
+	case MigrationModeNone, MigrationModeImporting:
 	default:
 		return errors.NotValidf("initial migration mode %q", m.MigrationMode)
 	}
@@ -1033,7 +1033,7 @@ func assertModelActiveOp(modelUUID string) txn.Op {
 	return txn.Op{
 		C:      modelsC,
 		Id:     modelUUID,
-		Assert: append(isAliveDoc, bson.DocElem{"migration-mode", MigrationModeActive}),
+		Assert: append(isAliveDoc, bson.DocElem{"migration-mode", MigrationModeNone}),
 	}
 }
 
@@ -1043,7 +1043,7 @@ func checkModelActive(st *State) error {
 		return errors.Errorf("model %q is no longer alive", model.Name())
 	} else if err != nil {
 		return errors.Annotate(err, "unable to read model")
-	} else if mode := model.MigrationMode(); mode != MigrationModeActive {
+	} else if mode := model.MigrationMode(); mode != MigrationModeNone {
 		return errors.Errorf("model %q is being migrated", model.Name())
 	}
 	return nil

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -41,7 +41,7 @@ func (s *ModelSuite) TestModel(c *gc.C) {
 	c.Assert(model.Name(), gc.Equals, "testenv")
 	c.Assert(model.Owner(), gc.Equals, s.Owner)
 	c.Assert(model.Life(), gc.Equals, state.Alive)
-	c.Assert(model.MigrationMode(), gc.Equals, state.MigrationModeActive)
+	c.Assert(model.MigrationMode(), gc.Equals, state.MigrationModeNone)
 }
 
 func (s *ModelSuite) TestModelDestroy(c *gc.C) {

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -302,7 +302,7 @@ func (mig *modelMigration) SetPhase(nextPhase migration.Phase) error {
 			Id:     mig.doc.ModelUUID,
 			Assert: txn.DocExists,
 			Update: bson.M{
-				"$set": bson.M{"migration-mode": MigrationModeActive},
+				"$set": bson.M{"migration-mode": MigrationModeNone},
 			},
 		})
 	}
@@ -675,7 +675,7 @@ func (st *State) LatestMigration() (ModelMigration, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		if model.MigrationMode() == MigrationModeActive {
+		if model.MigrationMode() == MigrationModeNone {
 			return nil, errors.NotFoundf("migration")
 		}
 	}

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -59,7 +59,7 @@ func (s *MigrationSuite) SetUpTest(c *gc.C) {
 func (s *MigrationSuite) TestCreate(c *gc.C) {
 	model, err := s.State2.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(model.MigrationMode(), gc.Equals, state.MigrationModeActive)
+	c.Assert(model.MigrationMode(), gc.Equals, state.MigrationModeNone)
 
 	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
@@ -393,7 +393,7 @@ func (s *MigrationSuite) TestABORTCleanup(c *gc.C) {
 	// Model should be set back to active.
 	model, err := s.State2.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(model.MigrationMode(), gc.Equals, state.MigrationModeActive)
+	c.Assert(model.MigrationMode(), gc.Equals, state.MigrationModeNone)
 }
 
 func (s *MigrationSuite) TestREAPFAILEDCleanup(c *gc.C) {

--- a/state/open.go
+++ b/state/open.go
@@ -154,7 +154,7 @@ func (p InitializeParams) Validate() error {
 	if err := p.ControllerModelArgs.Validate(); err != nil {
 		return errors.Trace(err)
 	}
-	if p.ControllerModelArgs.MigrationMode != MigrationModeActive {
+	if p.ControllerModelArgs.MigrationMode != MigrationModeNone {
 		return errors.NotValidf("migration mode %q", p.ControllerModelArgs.MigrationMode)
 	}
 	uuid := p.ControllerModelArgs.Config.UUID()


### PR DESCRIPTION
"Active" was confusing because this mode actually means no migration is in progress.

(Review request: http://reviews.vapour.ws/r/5482/)