### PR TITLE
state: don't force-destroy manual machines

### DIFF
--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -185,9 +185,9 @@ func (st *State) cleanupModelsForDyingController() (err error) {
 	return nil
 }
 
-// cleanupMachinesForDyingModel sets all non-manager, non-manual
-// machines to Dying, if they are not already Dying or Dead. It's expected to
-// be used when a model is destroyed.
+// cleanupMachinesForDyingModel sets all non-manager machines to Dying,
+// if they are not already Dying or Dead. It's expected to be used when
+// a model is destroyed.
 func (st *State) cleanupMachinesForDyingModel() (err error) {
 	// This won't miss machines, because a Dying model cannot have
 	// machines added to it. But we do have to remove the machines themselves
@@ -203,7 +203,21 @@ func (st *State) cleanupMachinesForDyingModel() (err error) {
 		if _, isContainer := m.ParentId(); isContainer {
 			continue
 		}
-		if err := m.ForceDestroy(); err != nil {
+		manual, err := m.IsManual()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		destroy := m.ForceDestroy
+		if manual {
+			// Manually added machines should never be force-
+			// destroyed automatically. That should be a user-
+			// driven decision, since it may leak applications
+			// and resources on the machine. If something is
+			// stuck, then the user can still force-destroy
+			// the manual machines.
+			destroy = m.Destroy
+		}
+		if err := destroy(); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -119,10 +119,18 @@ func (s *CleanupSuite) TestCleanupControllerModels(c *gc.C) {
 }
 
 func (s *CleanupSuite) TestCleanupModelMachines(c *gc.C) {
-	// Create a state and hosted machine.
+	// Create a controller machine, and manual and non-manual
+	// workload machine.
 	stateMachine, err := s.State.AddMachine("quantal", state.JobManageModel)
 	c.Assert(err, jc.ErrorIsNil)
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	manualMachine, err := s.State.AddOneMachine(state.MachineTemplate{
+		Series:     "quantal",
+		Jobs:       []state.MachineJob{state.JobHostUnits},
+		InstanceId: "inst-ance",
+		Nonce:      "manual:foo",
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create a relation with a unit in scope and assigned to the hosted machine.
@@ -150,6 +158,7 @@ func (s *CleanupSuite) TestCleanupModelMachines(c *gc.C) {
 	// ...but that the machine remains, and is Dead, ready for removal by the
 	// provisioner.
 	assertLife(c, machine, state.Dead)
+	assertLife(c, manualMachine, state.Dying)
 	assertLife(c, stateMachine, state.Alive)
 }
 


### PR DESCRIPTION
When destroying a model, we were force-destroying
all non-manager machines. We should not force-destroy
manual machines, as doing so may lead to applications
being left running on the machine. Instead, just
issue a non-force destroy. If the machine is in a
bad state, the user will have to force-destroy
via "juju remove-machine --force".

Fixes https://bugs.launchpad.net/juju-core/+bug/1475212