### PR TITLE
apiserver/modelmanager: CreateModel CloudTag arg

### DIFF
--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -194,8 +194,22 @@ func (mm *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Mode
 		return result, errors.Trace(err)
 	}
 
-	cloudName := controllerModel.Cloud()
-	cloud, err := mm.state.Cloud(cloudName)
+	var cloudTag names.CloudTag
+	cloudRegionName := args.CloudRegion
+	if args.CloudTag != "" {
+		var err error
+		cloudTag, err = names.ParseCloudTag(args.CloudTag)
+		if err != nil {
+			return result, errors.Trace(err)
+		}
+	} else {
+		cloudTag = names.NewCloudTag(controllerModel.Cloud())
+		if cloudRegionName == "" {
+			cloudRegionName = controllerModel.CloudRegion()
+		}
+	}
+
+	cloud, err := mm.state.Cloud(cloudTag.Id())
 	if err != nil {
 		return result, errors.Annotate(err, "getting cloud definition")
 	}
@@ -229,11 +243,6 @@ func (mm *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Mode
 		}
 	}
 
-	cloudRegionName := args.CloudRegion
-	if cloudRegionName == "" {
-		cloudRegionName = controllerModel.CloudRegion()
-	}
-
 	var credential *jujucloud.Credential
 	if cloudCredentialTag != (names.CloudCredentialTag{}) {
 		credentialValue, err := mm.state.CloudCredential(cloudCredentialTag)
@@ -243,7 +252,7 @@ func (mm *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Mode
 		credential = &credentialValue
 	}
 
-	cloudSpec, err := environs.MakeCloudSpec(cloud, cloudName, cloudRegionName, credential)
+	cloudSpec, err := environs.MakeCloudSpec(cloud, cloudTag.Id(), cloudRegionName, credential)
 	if err != nil {
 		return result, errors.Trace(err)
 	}
@@ -277,7 +286,7 @@ func (mm *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Mode
 	// version, it is not supported, also check existing tools, and if we don't
 	// have tools for that version, also die.
 	model, st, err := mm.state.NewModel(state.ModelArgs{
-		CloudName:       cloudName,
+		CloudName:       cloudTag.Id(),
 		CloudRegion:     cloudRegionName,
 		CloudCredential: cloudCredentialTag,
 		Config:          newConfig,

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -112,6 +112,19 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 	s.api = api
 }
 
+func (s *modelManagerSuite) getModelArgs(c *gc.C) state.ModelArgs {
+	for _, v := range s.st.Calls() {
+		if v.Args == nil {
+			continue
+		}
+		if newModelArgs, ok := v.Args[0].(state.ModelArgs); ok {
+			return newModelArgs
+		}
+	}
+	c.Fatal("failed to find state.ModelArgs")
+	panic("unreachable")
+}
+
 func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 	args := params.ModelCreateArgs{
 		Name:     "foo",
@@ -146,16 +159,7 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 	// We cannot predict the UUID, because it's generated,
 	// so we just extract it and ensure that it's not the
 	// same as the controller UUID.
-	var newModelArgs state.ModelArgs
-	for _, v := range s.st.Calls() {
-		if v.Args == nil {
-			continue
-		}
-		var ok bool
-		if newModelArgs, ok = v.Args[0].(state.ModelArgs); ok {
-			break
-		}
-	}
+	newModelArgs := s.getModelArgs(c)
 	uuid := newModelArgs.Config.UUID()
 	c.Assert(uuid, gc.Not(gc.Equals), s.st.controllerModel.cfg.UUID())
 
@@ -186,6 +190,24 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 	})
 }
 
+func (s *modelManagerSuite) TestCreateModelArgsWithCloud(c *gc.C) {
+	args := params.ModelCreateArgs{
+		Name:     "foo",
+		OwnerTag: "user-admin@local",
+		Config: map[string]interface{}{
+			"bar": "baz",
+		},
+		CloudTag:           "cloud-some-cloud",
+		CloudRegion:        "qux",
+		CloudCredentialTag: "cloudcred-some-cloud_admin@local_some-credential",
+	}
+	_, err := s.api.CreateModel(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	newModelArgs := s.getModelArgs(c)
+	c.Assert(newModelArgs.CloudName, gc.Equals, "some-cloud")
+}
+
 func (s *modelManagerSuite) TestCreateModelDefaultRegion(c *gc.C) {
 	args := params.ModelCreateArgs{
 		Name:     "foo",
@@ -194,17 +216,7 @@ func (s *modelManagerSuite) TestCreateModelDefaultRegion(c *gc.C) {
 	_, err := s.api.CreateModel(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	var newModelArgs state.ModelArgs
-	for _, v := range s.st.Calls() {
-		if v.Args == nil {
-			continue
-		}
-		var ok bool
-		if newModelArgs, ok = v.Args[0].(state.ModelArgs); ok {
-			break
-		}
-	}
-
+	newModelArgs := s.getModelArgs(c)
 	c.Assert(newModelArgs.CloudRegion, gc.Equals, "some-region")
 }
 
@@ -225,17 +237,7 @@ func (s *modelManagerSuite) testCreateModelDefaultCredentialAdmin(c *gc.C, owner
 	_, err := s.api.CreateModel(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	var newModelArgs state.ModelArgs
-	for _, v := range s.st.Calls() {
-		if v.Args == nil {
-			continue
-		}
-		var ok bool
-		if newModelArgs, ok = v.Args[0].(state.ModelArgs); ok {
-			break
-		}
-	}
-
+	newModelArgs := s.getModelArgs(c)
 	c.Assert(newModelArgs.CloudCredential, gc.Equals, names.NewCloudCredentialTag(
 		"some-cloud/bob@local/some-credential",
 	))
@@ -249,16 +251,7 @@ func (s *modelManagerSuite) TestCreateModelEmptyCredentialNonAdmin(c *gc.C) {
 	_, err := s.api.CreateModel(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	var newModelArgs state.ModelArgs
-	for _, v := range s.st.Calls() {
-		if v.Args == nil {
-			continue
-		}
-		var ok bool
-		if newModelArgs, ok = v.Args[0].(state.ModelArgs); ok {
-			break
-		}
-	}
+	newModelArgs := s.getModelArgs(c)
 	c.Assert(newModelArgs.CloudCredential, gc.Equals, names.CloudCredentialTag{})
 }
 

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -111,10 +111,15 @@ type ModelCreateArgs struct {
 	// creation of the model.
 	Config map[string]interface{} `json:"config,omitempty"`
 
+	// CloudTag is the tag of the cloud to create the model in.
+	// If this is empty, the model will be created in the same
+	// cloud as the controller model.
+	CloudTag string `json:"cloud-tag,omitempty"`
+
 	// CloudRegion is the name of the cloud region to create the
 	// model in. If the cloud does not support regions, this must
-	// be empty. If this is empty, the model will be created in
-	// the same region as the controller model.
+	// be empty. If this is empty, and CloudTag is empty, the model
+	// will be created in the same region as the controller model.
 	CloudRegion string `json:"region,omitempty"`
 
 	// CloudCredentialTag is the tag of the cloud credential to use


### PR DESCRIPTION
Add a CloudTag field to the CreateModel args.
It's still only possible to create models of
the same cloud as the controller, but this
will make it possible to change on the backend
later.

**QA**

1. bootstrap azure/southeastasia
2. add-model foo (check there's a new resource group in southeastasia)
3. add-model bar --region=westus (check there's a new resource group in westus)
4. destroy-controller