### PR TITLE
state: isolate/generalise refcounting

### DIFF
--- a/core/description/application.go
+++ b/core/description/application.go
@@ -35,8 +35,7 @@ type application struct {
 	Status_        *status `yaml:"status"`
 	StatusHistory_ `yaml:"status-history"`
 
-	Settings_         map[string]interface{} `yaml:"settings"`
-	SettingsRefCount_ int                    `yaml:"settings-refcount"`
+	Settings_ map[string]interface{} `yaml:"settings"`
 
 	Leader_             string                 `yaml:"leader,omitempty"`
 	LeadershipSettings_ map[string]interface{} `yaml:"leadership-settings"`
@@ -64,7 +63,6 @@ type ApplicationArgs struct {
 	Exposed              bool
 	MinUnits             int
 	Settings             map[string]interface{}
-	SettingsRefCount     int
 	Leader               string
 	LeadershipSettings   map[string]interface{}
 	StorageConstraints   map[string]StorageConstraintArgs
@@ -84,7 +82,6 @@ func newApplication(args ApplicationArgs) *application {
 		Exposed_:              args.Exposed,
 		MinUnits_:             args.MinUnits,
 		Settings_:             args.Settings,
-		SettingsRefCount_:     args.SettingsRefCount,
 		Leader_:               args.Leader,
 		LeadershipSettings_:   args.LeadershipSettings,
 		MetricsCredentials_:   creds,
@@ -153,11 +150,6 @@ func (s *application) MinUnits() int {
 // Settings implements Application.
 func (s *application) Settings() map[string]interface{} {
 	return s.Settings_
-}
-
-// SettingsRefCount implements Application.
-func (s *application) SettingsRefCount() int {
-	return s.SettingsRefCount_
 }
 
 // Leader implements Application.
@@ -325,7 +317,6 @@ func importApplicationV1(source map[string]interface{}) (*application, error) {
 		"min-units":           schema.Int(),
 		"status":              schema.StringMap(schema.Any()),
 		"settings":            schema.StringMap(schema.Any()),
-		"settings-refcount":   schema.Int(),
 		"leader":              schema.String(),
 		"leadership-settings": schema.StringMap(schema.Any()),
 		"storage-constraints": schema.StringMap(schema.StringMap(schema.Any())),
@@ -365,7 +356,6 @@ func importApplicationV1(source map[string]interface{}) (*application, error) {
 		Exposed_:              valid["exposed"].(bool),
 		MinUnits_:             int(valid["min-units"].(int64)),
 		Settings_:             valid["settings"].(map[string]interface{}),
-		SettingsRefCount_:     int(valid["settings-refcount"].(int64)),
 		Leader_:               valid["leader"].(string),
 		LeadershipSettings_:   valid["leadership-settings"].(map[string]interface{}),
 		StatusHistory_:        newStatusHistory(),

--- a/core/description/application_test.go
+++ b/core/description/application_test.go
@@ -47,8 +47,7 @@ func minimalApplicationMap() map[interface{}]interface{} {
 		"settings": map[interface{}]interface{}{
 			"key": "value",
 		},
-		"settings-refcount": 1,
-		"leader":            "ubuntu/0",
+		"leader": "ubuntu/0",
 		"leadership-settings": map[interface{}]interface{}{
 			"leader": true,
 		},
@@ -94,8 +93,7 @@ func minimalApplicationArgs() ApplicationArgs {
 		Settings: map[string]interface{}{
 			"key": "value",
 		},
-		SettingsRefCount: 1,
-		Leader:           "ubuntu/0",
+		Leader: "ubuntu/0",
 		LeadershipSettings: map[string]interface{}{
 			"leader": true,
 		},
@@ -117,8 +115,7 @@ func (s *ApplicationSerializationSuite) TestNewApplication(c *gc.C) {
 		Settings: map[string]interface{}{
 			"key": "value",
 		},
-		SettingsRefCount: 1,
-		Leader:           "magic/1",
+		Leader: "magic/1",
 		LeadershipSettings: map[string]interface{}{
 			"leader": true,
 		},
@@ -137,7 +134,6 @@ func (s *ApplicationSerializationSuite) TestNewApplication(c *gc.C) {
 	c.Assert(application.Exposed(), jc.IsTrue)
 	c.Assert(application.MinUnits(), gc.Equals, 42)
 	c.Assert(application.Settings(), jc.DeepEquals, args.Settings)
-	c.Assert(application.SettingsRefCount(), gc.Equals, 1)
 	c.Assert(application.Leader(), gc.Equals, "magic/1")
 	c.Assert(application.LeadershipSettings(), jc.DeepEquals, args.LeadershipSettings)
 	c.Assert(application.MetricsCredentials(), jc.DeepEquals, []byte("sekrit"))

--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -257,7 +257,6 @@ type Application interface {
 	MinUnits() int
 
 	Settings() map[string]interface{}
-	SettingsRefCount() int
 
 	Leader() string
 	LeadershipSettings() map[string]interface{}

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -251,8 +251,8 @@ func allCollections() collectionSchema {
 		assignUnitC: {},
 
 		// meterStatusC is the collection used to store meter status information.
-		meterStatusC:  {},
-		settingsrefsC: {},
+		meterStatusC: {},
+		refcountsC:   {},
 		relationsC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "endpoints.relationname"},
@@ -445,7 +445,7 @@ const (
 	applicationsC            = "applications"
 	endpointBindingsC        = "endpointbindings"
 	settingsC                = "settings"
-	settingsrefsC            = "settingsrefs"
+	refcountsC               = "refcounts"
 	sshHostKeysC             = "sshhostkeys"
 	spacesC                  = "spaces"
 	statusesC                = "statuses"

--- a/state/application.go
+++ b/state/application.go
@@ -90,8 +90,8 @@ func (s *Application) globalKey() string {
 	return applicationGlobalKey(s.doc.Name)
 }
 
-func applicationSettingsKey(applicationname string, curl *charm.URL) string {
-	return fmt.Sprintf("a#%s#%s", applicationname, curl)
+func applicationSettingsKey(appName string, curl *charm.URL) string {
+	return fmt.Sprintf("a#%s#%s", appName, curl)
 }
 
 // settingsKey returns the charm-version-specific settings collection
@@ -246,7 +246,6 @@ func removeResourcesOps(st *State, serviceID string) ([]txn.Op, error) {
 // removeOps returns the operations required to remove the service. Supplied
 // asserts will be included in the operation on the application document.
 func (s *Application) removeOps(asserts bson.D) []txn.Op {
-	settingsDocID := s.st.docID(s.settingsKey())
 	ops := []txn.Op{
 		{
 			C:      applicationsC,
@@ -254,14 +253,11 @@ func (s *Application) removeOps(asserts bson.D) []txn.Op {
 			Assert: asserts,
 			Remove: true,
 		}, {
-			C:      settingsrefsC,
-			Id:     settingsDocID,
-			Remove: true,
-		}, {
 			C:      settingsC,
-			Id:     settingsDocID,
+			Id:     s.settingsKey(),
 			Remove: true,
 		},
+		nsRefcounts.JustRemoveOp(refcountsC, s.settingsKey(), -1),
 		removeEndpointBindingsOp(s.globalKey()),
 		removeStorageConstraintsOp(s.globalKey()),
 		removeConstraintsOp(s.st, s.globalKey()),
@@ -1506,91 +1502,49 @@ func (s *Application) StorageConstraints() (map[string]StorageConstraints, error
 }
 
 // settingsIncRefOp returns an operation that increments the ref count
-// of the application settings identified by applicationname and curl. If
+// of the application settings identified by appName and curl. If
 // canCreate is false, a missing document will be treated as an error;
 // otherwise, it will be created with a ref count of 1.
-func settingsIncRefOp(st *State, applicationname string, curl *charm.URL, canCreate bool) (txn.Op, error) {
-	settingsrefs, closer := st.getCollection(settingsrefsC)
+func settingsIncRefOp(st *State, appName string, curl *charm.URL, canCreate bool) (txn.Op, error) {
+	refcounts, closer := st.getCollection(refcountsC)
 	defer closer()
 
-	key := applicationSettingsKey(applicationname, curl)
-	if count, err := settingsrefs.FindId(key).Count(); err != nil {
-		return txn.Op{}, err
-	} else if count == 0 {
-		if !canCreate {
-			return txn.Op{}, errors.NotFoundf("application %q settings for charm %q", applicationname, curl)
-		}
-		return txn.Op{
-			C:      settingsrefsC,
-			Id:     st.docID(key),
-			Assert: txn.DocMissing,
-			Insert: settingsRefsDoc{
-				RefCount:  1,
-				ModelUUID: st.ModelUUID()},
-		}, nil
+	getOp := nsRefcounts.CreateOrIncRefOp
+	if !canCreate {
+		getOp = nsRefcounts.StrictIncRefOp
 	}
-	return txn.Op{
-		C:      settingsrefsC,
-		Id:     st.docID(key),
-		Assert: txn.DocExists,
-		Update: bson.D{{"$inc", bson.D{{"refcount", 1}}}},
-	}, nil
+
+	key := applicationSettingsKey(appName, curl)
+	op, err := getOp(refcounts, key)
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
+	return op, nil
 }
 
 // settingsDecRefOps returns a list of operations that decrement the
-// ref count of the application settings identified by applicationname and
+// ref count of the application settings identified by appName and
 // curl. If the ref count is set to zero, the appropriate setting and
 // ref count documents will both be deleted.
-func settingsDecRefOps(st *State, applicationname string, curl *charm.URL) ([]txn.Op, error) {
-	settingsrefs, closer := st.getCollection(settingsrefsC)
+func settingsDecRefOps(st *State, appName string, curl *charm.URL) ([]txn.Op, error) {
+	refcounts, closer := st.getCollection(refcountsC)
 	defer closer()
 
-	key := applicationSettingsKey(applicationname, curl)
-	var doc settingsRefsDoc
-	if err := settingsrefs.FindId(key).One(&doc); err == mgo.ErrNotFound {
-		return nil, errors.NotFoundf("application %q settings for charm %q", applicationname, curl)
-	} else if err != nil {
-		return nil, err
+	key := applicationSettingsKey(appName, curl)
+	op, isFinal, err := nsRefcounts.DyingDecRefOp(refcounts, key)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	docID := st.docID(key)
-	if doc.RefCount == 1 {
-		return []txn.Op{{
-			C:      settingsrefsC,
-			Id:     docID,
-			Assert: bson.D{{"refcount", 1}},
-			Remove: true,
-		}, {
-			C:      settingsC,
-			Id:     docID,
-			Remove: true,
-		}}, nil
-	}
-	return []txn.Op{{
-		C:      settingsrefsC,
-		Id:     docID,
-		Assert: bson.D{{"refcount", bson.D{{"$gt", 1}}}},
-		Update: bson.D{{"$inc", bson.D{{"refcount", -1}}}},
-	}}, nil
-}
 
-// settingsRefsDoc holds the number of units and services using the
-// settings document identified by the document's id. Every time a
-// application upgrades its charm the settings doc ref count for the new
-// charm url is incremented, and the old settings is ref count is
-// decremented. When a unit upgrades to the new charm, the old service
-// settings ref count is decremented and the ref count of the new
-// charm settings is incremented. The last unit upgrading to the new
-// charm is responsible for deleting the old charm's settings doc.
-//
-// Note: We're not using the settingsDoc for this because changing
-// just the ref count is not considered a change worth reporting
-// to watchers and firing config-changed hooks.
-//
-// There is an implicit _id field here, which mongo creates, which is
-// always the same as the settingsDoc's id.
-type settingsRefsDoc struct {
-	RefCount  int
-	ModelUUID string `bson:"model-uuid"`
+	ops := []txn.Op{op}
+	if isFinal {
+		ops = append(ops, txn.Op{
+			C:      settingsC,
+			Id:     key,
+			Remove: true,
+		})
+	}
+	return ops, nil
 }
 
 // Status returns the status of the service.
@@ -1707,12 +1661,11 @@ var statusServerities = map[status.Status]int{
 }
 
 type addApplicationOpsArgs struct {
-	applicationDoc   *applicationDoc
-	statusDoc        statusDoc
-	constraints      constraints.Value
-	storage          map[string]StorageConstraints
-	settings         map[string]interface{}
-	settingsRefCount int
+	applicationDoc *applicationDoc
+	statusDoc      statusDoc
+	constraints    constraints.Value
+	storage        map[string]StorageConstraints
+	settings       map[string]interface{}
 	// These are nil when adding a new service, and most likely
 	// non-nil when migrating.
 	leadershipSettings map[string]interface{}
@@ -1736,14 +1689,8 @@ func addApplicationOps(st *State, args addApplicationOpsArgs) []txn.Op {
 		createSettingsOp(settingsC, leadershipKey, args.leadershipSettings),
 		createStatusOp(st, globalKey, args.statusDoc),
 		addModelServiceRefOp(st, svc.Name()),
+		nsRefcounts.JustCreateOp(refcountsC, settingsKey, 1),
 		{
-			C:      settingsrefsC,
-			Id:     settingsKey,
-			Assert: txn.DocMissing,
-			Insert: settingsRefsDoc{
-				RefCount: args.settingsRefCount,
-			},
-		}, {
 			C:      applicationsC,
 			Id:     svc.Name(),
 			Assert: txn.DocMissing,

--- a/state/charm.go
+++ b/state/charm.go
@@ -146,12 +146,15 @@ func insertPendingCharmOps(st *State, curl *charm.URL) ([]txn.Op, error) {
 // insertAnyCharmOps returns the txn operations necessary to insert the supplied
 // charm document.
 func insertAnyCharmOps(cdoc *charmDoc) ([]txn.Op, error) {
-	return []txn.Op{{
+	key := charmGlobalKey(cdoc.URL)
+	refOp := nsRefcounts.JustCreateOp(refcountsC, key, 0)
+	charmOp := txn.Op{
 		C:      charmsC,
 		Id:     cdoc.DocID,
 		Assert: txn.DocMissing,
 		Insert: cdoc,
-	}}, nil
+	}
+	return []txn.Op{refOp, charmOp}, nil
 }
 
 // updateCharmOps returns the txn operations necessary to update the charm
@@ -222,13 +225,22 @@ func deleteOldPlaceholderCharmsOps(st *State, charms mongo.Collection, curl *cha
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	refcounts, closer := st.getCollection(refcountsC)
+	defer closer()
+
 	var ops []txn.Op
 	for _, doc := range docs {
 		if doc.URL.Revision >= curl.Revision {
 			continue
 		}
-		ops = append(ops, txn.Op{
-			C:      charmsC,
+		key := charmGlobalKey(doc.URL)
+		refOp, err := nsRefcounts.RemoveOp(refcounts, key, 0)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		ops = append(ops, refOp, txn.Op{
+			C:      charms.Name(),
 			Id:     doc.DocID,
 			Assert: stillPlaceholder,
 			Remove: true,
@@ -331,15 +343,6 @@ func (c *Charm) Actions() *charm.Actions {
 // StoragePath returns the storage path of the charm bundle.
 func (c *Charm) StoragePath() string {
 	return c.doc.StoragePath
-}
-
-// BundleURL returns the url to the charm bundle in
-// the provider storage.
-//
-// DEPRECATED: this is only to be used for migrating
-// charm archives to model storage.
-func (c *Charm) BundleURL() *url.URL {
-	return c.doc.BundleURL
 }
 
 // BundleSha256 returns the SHA256 digest of the charm bundle bytes.

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -105,16 +105,12 @@ func (doc *MachineDoc) String() string {
 	return m.String()
 }
 
-func ServiceSettingsRefCount(st *State, applicationname string, curl *charm.URL) (int, error) {
-	settingsRefsCollection, closer := st.getCollection(settingsrefsC)
+func ServiceSettingsRefCount(st *State, appName string, curl *charm.URL) (int, error) {
+	refcounts, closer := st.getCollection(refcountsC)
 	defer closer()
 
-	key := applicationSettingsKey(applicationname, curl)
-	var doc settingsRefsDoc
-	if err := settingsRefsCollection.FindId(key).One(&doc); err == nil {
-		return doc.RefCount, nil
-	}
-	return 0, mgo.ErrNotFound
+	key := applicationSettingsKey(appName, curl)
+	return nsRefcounts.read(refcounts, key)
 }
 
 func AddTestingCharm(c *gc.C, st *State, name string) *Charm {

--- a/state/life_ns.go
+++ b/state/life_ns.go
@@ -1,3 +1,6 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package state
 
 import (

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -356,7 +356,6 @@ func (s *MigrationExportSuite) assertMigrateApplications(c *gc.C, cons constrain
 	c.Assert(exported.Settings(), jc.DeepEquals, map[string]interface{}{
 		"foo": "bar",
 	})
-	c.Assert(exported.SettingsRefCount(), gc.Equals, 1)
 	c.Assert(exported.LeadershipSettings(), jc.DeepEquals, map[string]interface{}{
 		"leader": "true",
 	})

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -631,7 +631,6 @@ func (i *importer) application(s description.Application) error {
 		constraints:        i.constraints(s.Constraints()),
 		storage:            i.storageConstraints(s.StorageConstraints()),
 		settings:           s.Settings(),
-		settingsRefCount:   s.SettingsRefCount(),
 		leadershipSettings: s.LeadershipSettings(),
 	})
 

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -41,9 +41,6 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		unitsC,
 		meterStatusC, // red / green status for metrics of units
 
-		// settings reference counts are only used for applications
-		settingsrefsC,
-
 		// relation
 		relationsC,
 		relationScopesC,
@@ -100,6 +97,9 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		metricsC,
 		// Backup and restore information is not migrated.
 		restoreInfoC,
+		// reference counts are implementation details that should be
+		// reconstructed on the other side.
+		refcountsC,
 		// upgradeInfoC is used to coordinate upgrades and schema migrations,
 		// and aren't needed for model migrations.
 		upgradeInfoC,
@@ -343,17 +343,6 @@ func (s *MigrationSuite) TestApplicationDocFields(c *gc.C) {
 		"MetricCredentials",
 	)
 	s.AssertExportedFields(c, applicationDoc{}, migrated.Union(ignored))
-}
-
-func (s *MigrationSuite) TestSettingsRefsDocFields(c *gc.C) {
-	fields := set.NewStrings(
-		// ModelUUID shouldn't be exported, and is inherited
-		// from the model definition.
-		"ModelUUID",
-
-		"RefCount",
-	)
-	s.AssertExportedFields(c, settingsRefsDoc{}, fields)
 }
 
 func (s *MigrationSuite) TestUnitDocFields(c *gc.C) {

--- a/state/payloads_ns.go
+++ b/state/payloads_ns.go
@@ -1,3 +1,6 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package state
 
 import (

--- a/state/refcounts_ns.go
+++ b/state/refcounts_ns.go
@@ -1,0 +1,191 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/mongo"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+)
+
+// refcountDoc holds a reference count. Refcounts are important to juju
+// because mgo/txn offers no other mechanisms for safely coordinating
+// deletion of unreferenced documents.
+//
+// TODO(fwereade) 2016-08-11 lp:1612163
+//
+// There are several places that use ad-hoc refcounts (application
+// UnitCount and RelationCount; and model refs; and many many more)
+// which should (1) be using separate refcount docs instead of dumping
+// them in entity docs and (2) be using *this* refcount functionality
+// rather than building their own ad-hoc variants.
+type refcountDoc struct {
+
+	// The _id field should hold some globalKey to identify what's
+	// being referenced, but there's no reason to express it in this
+	// document directly.
+
+	// RefCount holds the reference count for whatever this doc is
+	// referencing.
+	RefCount int `bson:"refcount"`
+}
+
+// nsRefcounts exposes methods for safely manipulating reference count
+// documents. (You can also manipulate them unsafely via the Just*
+// methods that don't keep track of DB state.)
+var nsRefcounts = nsRefcounts_{}
+
+// nsRefcounts_ backs nsRefcounts.
+type nsRefcounts_ struct{}
+
+// StrictCreateOp returns a txn.Op that creates a refcount document as
+// configured, or an error if the document already exists.
+func (ns nsRefcounts_) StrictCreateOp(coll mongo.Collection, key string, value int) (txn.Op, error) {
+	if exists, err := ns.exists(coll, key); err != nil {
+		return txn.Op{}, errors.Trace(err)
+	} else if exists {
+		return txn.Op{}, errors.New("refcount already exists")
+	}
+	return ns.JustCreateOp(coll.Name(), key, value), nil
+}
+
+// CreateOrIncrefOp returns a txn.Op that creates a refcount document as
+// configured with a value of 1; or increments any such refcount doc
+// that already exists.
+func (ns nsRefcounts_) CreateOrIncRefOp(coll mongo.Collection, key string) (txn.Op, error) {
+	if exists, err := ns.exists(coll, key); err != nil {
+		return txn.Op{}, errors.Trace(err)
+	} else if !exists {
+		return ns.JustCreateOp(coll.Name(), key, 1), nil
+	}
+	return ns.JustIncRefOp(coll.Name(), key), nil
+}
+
+// StrictIncRefOp returns a txn.Op that increments the value of a
+// refcount doc, or returns an error if it does not exist.
+func (ns nsRefcounts_) StrictIncRefOp(coll mongo.Collection, key string) (txn.Op, error) {
+	if exists, err := ns.exists(coll, key); err != nil {
+		return txn.Op{}, errors.Trace(err)
+	} else if !exists {
+		return txn.Op{}, errors.New("refcount does not exist")
+	}
+	return ns.JustIncRefOp(coll.Name(), key), nil
+}
+
+// AliveDecRefOp returns a txn.Op that decrements the value of a
+// refcount doc, or an error if the doc does not exist or the count
+// would go below 0.
+func (ns nsRefcounts_) AliveDecRefOp(coll mongo.Collection, key string) (txn.Op, error) {
+	if refcount, err := ns.read(coll, key); err != nil {
+		return txn.Op{}, errors.Trace(err)
+	} else if refcount < 1 {
+		return txn.Op{}, errors.New("cannot decRef below 0")
+	}
+	return ns.justDecRefOp(coll.Name(), key, 0), nil
+}
+
+// DyingDecRefOp returns a txn.Op that decrements the value of a
+// refcount doc and deletes it if the count reaches 0; if the Op will
+// cause a delete, the bool result will be true. It will return an error
+// if the doc does not exist or the count would go below 0.
+func (ns nsRefcounts_) DyingDecRefOp(coll mongo.Collection, key string) (txn.Op, bool, error) {
+	refcount, err := ns.read(coll, key)
+	if err != nil {
+		return txn.Op{}, false, errors.Trace(err)
+	}
+	if refcount < 1 {
+		return txn.Op{}, false, errors.New("cannot decRef below 0")
+	} else if refcount > 1 {
+		return ns.justDecRefOp(coll.Name(), key, 1), false, nil
+	}
+	return ns.JustRemoveOp(coll.Name(), key, 1), true, nil
+}
+
+// RemoveOp returns a txn.Op that removes a refcount doc so long as its
+// refcount is the supplied value, or an error.
+func (ns nsRefcounts_) RemoveOp(coll mongo.Collection, key string, value int) (txn.Op, error) {
+	refcount, err := ns.read(coll, key)
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
+	if refcount != value {
+		return txn.Op{}, errors.New("refcount changed")
+	}
+	return ns.JustRemoveOp(coll.Name(), key, value), nil
+}
+
+// JustCreateOp returns a txn.Op that creates a refcount document as
+// configured, *without* checking database state for sanity first.
+// You should avoid using this method in most cases.
+func (nsRefcounts_) JustCreateOp(collName, key string, value int) txn.Op {
+	return txn.Op{
+		C:      collName,
+		Id:     key,
+		Assert: txn.DocMissing,
+		Insert: bson.D{{"refcount", value}},
+	}
+}
+
+// JustIncRefOp returns a txn.Op that increments a refcount document by
+// 1, as configured, *without* checking database state for sanity first.
+// You should avoid using this method in most cases.
+func (nsRefcounts_) JustIncRefOp(collName, key string) txn.Op {
+	return txn.Op{
+		C:      collName,
+		Id:     key,
+		Assert: txn.DocExists,
+		Update: bson.D{{"$inc", bson.D{{"refcount", 1}}}},
+	}
+}
+
+// JustRemoveOp returns a txn.Op that deletes a refcount doc so long as
+// the refcount matches count. You should avoid using this method in
+// most cases.
+func (ns nsRefcounts_) JustRemoveOp(collName, key string, count int) txn.Op {
+	op := txn.Op{
+		C:      collName,
+		Id:     key,
+		Remove: true,
+	}
+	if count >= 0 {
+		op.Assert = bson.D{{"refcount", count}}
+	}
+	return op
+}
+
+// justDecRefOp returns a txn.Op that decrements a refcount document by
+// 1, as configured, allowing it to drop no lower than limit; which must
+// not be less than zero. It's unexported, meaningless though that may
+// be, to encourage clients to *really* not use it: too many ways to
+// mess it up if you're not precisely aware of the context.
+func (nsRefcounts_) justDecRefOp(collName, key string, limit int) txn.Op {
+	return txn.Op{
+		C:      collName,
+		Id:     key,
+		Assert: bson.D{{"refcount", bson.D{{"$gt", limit}}}},
+		Update: bson.D{{"$inc", bson.D{{"refcount", -1}}}},
+	}
+}
+
+// exists returns whether the identified refcount doc exists.
+func (nsRefcounts_) exists(coll mongo.Collection, key string) (bool, error) {
+	count, err := coll.FindId(key).Count()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	return count != 0, nil
+}
+
+// read returns the value stored in the identified refcount doc.
+func (nsRefcounts_) read(coll mongo.Collection, key string) (int, error) {
+	var doc refcountDoc
+	if err := coll.FindId(key).One(&doc); err == mgo.ErrNotFound {
+		return 0, errors.NotFoundf("refcount")
+	} else if err != nil {
+		return 0, errors.Trace(err)
+	}
+	return doc.RefCount, nil
+}

--- a/state/state.go
+++ b/state/state.go
@@ -1096,12 +1096,11 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 			endpointBindingsOp,
 		},
 		addApplicationOps(st, addApplicationOpsArgs{
-			applicationDoc:   svcDoc,
-			statusDoc:        statusDoc,
-			constraints:      args.Constraints,
-			storage:          args.Storage,
-			settings:         map[string]interface{}(args.Settings),
-			settingsRefCount: 1,
+			applicationDoc: svcDoc,
+			statusDoc:      statusDoc,
+			constraints:    args.Constraints,
+			storage:        args.Storage,
+			settings:       map[string]interface{}(args.Settings),
 		})...)
 
 	// Collect peer relation addition operations.

--- a/state/unit.go
+++ b/state/unit.go
@@ -2299,20 +2299,35 @@ type addUnitOpsArgs struct {
 func addUnitOps(st *State, args addUnitOpsArgs) []txn.Op {
 	name := args.unitDoc.Name
 	agentGlobalKey := unitAgentGlobalKey(name)
+
 	// TODO: consider the constraints op
 	// TODO: consider storageOps
-	return []txn.Op{
+	prereqOps := []txn.Op{
 		createStatusOp(st, unitGlobalKey(name), args.workloadStatusDoc),
 		createStatusOp(st, agentGlobalKey, args.agentStatusDoc),
 		createStatusOp(st, globalWorkloadVersionKey(name), args.workloadVersionDoc),
 		createMeterStatusOp(st, agentGlobalKey, args.meterStatusDoc),
-		{
-			C:      unitsC,
-			Id:     name,
-			Assert: txn.DocMissing,
-			Insert: args.unitDoc,
-		},
 	}
+
+	// Freshly-created units will not have a charm URL set; migrated
+	// ones will, and they need to maintain their refcounts. If we
+	// relax the restrictions on migrating apps mid-upgrade, this
+	// will need to be more sophisticated, because it might need to
+	// create the settings doc; and will likely have to look in the
+	// DB to find out which.
+	if curl := args.unitDoc.CharmURL; curl != nil {
+		appName := args.unitDoc.Application
+		settingsKey := applicationSettingsKey(appName, curl)
+		incRefSettingsOp := nsRefcounts.JustIncRefOp(refcountsC, settingsKey)
+		prereqOps = append(prereqOps, incRefSettingsOp)
+	}
+
+	return append(prereqOps, txn.Op{
+		C:      unitsC,
+		Id:     name,
+		Assert: txn.DocMissing,
+		Insert: args.unitDoc,
+	})
 }
 
 // HistoryGetter allows getting the status history based on some identifying key.


### PR DESCRIPTION
Refcount values are (1) implied by the rest of a model description and
(2) pure implementation details necessitated by mgo/txn. They've been
dropped from description.Application; refcount sanity is now maintained
implicitly during import by the add*Ops-level funcs.

Refcount operations themselves have been extracted to refcounts_ns.go
...and the "settingsrefs" collection has been renamed to "refcounts",
reflecting its broader purpose.

Charm refcounts have been added, but nothing currently holds references
to them.

This is identical to PR5939, except that nsRefcounts.JustRemoveOp now accepts a negative value to indicate "don't assert anything, just kill it". To QA, deploy ~/containers/bundle/elk-stack and wait for all machines to be started; then destroy-controller --destroy-all-models, and check that everything gets cleaned up.