### PR TITLE
Expose machine.MarkForRemoval in provisioner API

### DIFF
--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -168,6 +168,20 @@ func (m *Machine) Remove() error {
 	return result.OneError()
 }
 
+// MarkForRemoval indicates that the machine is ready to have any
+// provider-level resources cleaned up and be removed.
+func (m *Machine) MarkForRemoval() error {
+	var result params.ErrorResults
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: m.tag.String()}},
+	}
+	err := m.st.facade.FacadeCall("MarkMachinesForRemoval", args, &result)
+	if err != nil {
+		return err
+	}
+	return result.OneError()
+}
+
 // Series returns the operating system series running on the machine.
 //
 // NOTE: Unlike state.Machine.Series(), this method returns an error

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -1258,6 +1258,7 @@ func (s *withoutControllerSuite) TestMarkMachinesForRemoval(c *gc.C) {
 	c.Check(results[0].Error, gc.IsNil)
 	c.Check(*results[1].Error, gc.Equals,
 		*common.ServerError(errors.NotFoundf("machine 100")))
+	c.Check(*results[1].Error, jc.Satisfies, params.IsCodeNotFound)
 	c.Check(results[2].Error, gc.IsNil)
 	c.Check(*results[3].Error, gc.Equals,
 		*common.ServerError(errors.New("cannot remove machine 1: machine is not dead")))


### PR DESCRIPTION
Part of [lp:1585878](https://bugs.launchpad.net/juju-core/+bug/1585878)

Once the machine undertaker is ready the provisioner task will mark machines for removal instead of removing them directly.

From talking to thumper, there's no need to bump the version of the provisioner facade as long as this gets into the beta.