### PR TITLE
Fixes lp:1596853 & refactoring deploy cmd for UT

### DIFF
--- a/api/interface.go
+++ b/api/interface.go
@@ -149,7 +149,7 @@ func DefaultDialOpts() DialOpts {
 type OpenFunc func(*Info, DialOpts) (Connection, error)
 
 // Connection exists purely to make api-opening funcs mockable. It's just a
-// dumb copy of all the methods on api.Connection; we can and should be extracting
+// dumb copy of all the methods on api.state; we can and should be extracting
 // smaller and more relevant interfaces (and dropping some of them too).
 
 // Connection represents a connection to a Juju API server.

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -57,8 +57,7 @@ func deployBundle(
 	bundleFilePath string,
 	data *charm.BundleData,
 	channel csparams.Channel,
-	client *api.Client,
-	serviceDeployer *applicationDeployer,
+	apiRoot DeployAPI,
 	resolver *charmURLResolver,
 	log deploymentLogger,
 	bundleStorage map[string]map[string]storage.Constraints,
@@ -93,7 +92,7 @@ func deployBundle(
 	numChanges := len(changes)
 
 	// Initialize the unit status.
-	status, err := client.Status(nil)
+	status, err := apiRoot.Client().Status(nil)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get model status")
 	}
@@ -105,43 +104,23 @@ func deployBundle(
 	}
 
 	// Instantiate a watcher used to follow the deployment progress.
-	watcher, err := watchAll(client)
+	watcher, err := watchAll(apiRoot.Client())
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot watch model")
 	}
 	defer watcher.Stop()
 
-	applicationClient, err := serviceDeployer.newApplicationAPIClient()
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot get application client")
-	}
-
-	modelConfigClient, err := serviceDeployer.newModelConfigAPIClient()
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot get model config client")
-	}
-
-	annotationsClient, err := serviceDeployer.newAnnotationsAPIClient()
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot get annotations client")
-	}
-
-	charmsClient, err := serviceDeployer.newCharmsAPIClient()
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot get charms client")
-	}
 	// Instantiate the bundle handler.
 	h := &bundleHandler{
 		bundleDir:         bundleFilePath,
 		changes:           changes,
 		results:           make(map[string]string, numChanges),
 		channel:           channel,
-		client:            client,
-		modelConfigClient: modelConfigClient,
-		applicationClient: applicationClient,
-		annotationsClient: annotationsClient,
-		charmsClient:      charmsClient,
-		serviceDeployer:   serviceDeployer,
+		api:               apiRoot,
+		modelConfigClient: modelconfig.NewClient(apiRoot),
+		applicationClient: application.NewClient(apiRoot),
+		annotationsClient: apiannotations.NewClient(apiRoot),
+		charmsClient:      charms.NewClient(apiRoot),
 		bundleStorage:     bundleStorage,
 		resolver:          resolver,
 		log:               log,
@@ -177,7 +156,7 @@ func deployBundle(
 					Channel: channels[cURL],
 				}
 				csMac := csMacs[cURL]
-				err = h.addService(change.Id(), change.Params, chID, csMac)
+				err = h.addService(apiRoot, change.Id(), change.Params, chID, csMac)
 			}
 		case *bundlechanges.AddUnitChange:
 			err = h.addUnit(change.Id(), change.Params)
@@ -218,8 +197,8 @@ type bundleHandler struct {
 	// channel identifies the default channel to use for the bundle.
 	channel csparams.Channel
 
-	// client is used to interact with the environment.
-	client *api.Client
+	// api is used to interact with the environment.
+	api DeployAPI
 
 	// modelConfigClient is used to get model config information.
 	modelConfigClient *modelconfig.Client
@@ -232,9 +211,6 @@ type bundleHandler struct {
 
 	// annotationsClient is used to interact with annotations.
 	annotationsClient *apiannotations.Client
-
-	// serviceDeployer is used to deploy services.
-	serviceDeployer *applicationDeployer
 
 	// bundleStorage contains a mapping of application-specific storage
 	// constraints. For each application, the storage constraints in the
@@ -293,7 +269,7 @@ func (h *bundleHandler) addCharm(id string, p bundlechanges.AddCharmParams) (*ch
 			return nil, noChannel, nil, errors.Annotatef(err, "cannot deploy local charm at %q", charmPath)
 		}
 		if err == nil {
-			if curl, err = h.client.AddLocalCharm(curl, ch); err != nil {
+			if curl, err = h.api.AddLocalCharm(curl, ch); err != nil {
 				return nil, noChannel, nil, err
 			}
 			h.log.Infof("added charm %s", curl)
@@ -315,7 +291,7 @@ func (h *bundleHandler) addCharm(id string, p bundlechanges.AddCharmParams) (*ch
 		return nil, channel, nil, errors.Errorf("expected charm URL, got bundle URL %q", p.Charm)
 	}
 	var csMac *macaroon.Macaroon
-	url, csMac, err = addCharmFromURL(h.client, url, channel, store.Client())
+	url, csMac, err = addCharmFromURL(h.api, url, channel, store.Client())
 	if err != nil {
 		return nil, channel, nil, errors.Annotatef(err, "cannot add charm %q", p.Charm)
 	}
@@ -326,7 +302,13 @@ func (h *bundleHandler) addCharm(id string, p bundlechanges.AddCharmParams) (*ch
 
 // addService deploys or update an application with no units. Service options are
 // also set or updated.
-func (h *bundleHandler) addService(id string, p bundlechanges.AddApplicationParams, chID charmstore.CharmID, csMac *macaroon.Macaroon) error {
+func (h *bundleHandler) addService(
+	api DeployAPI,
+	id string,
+	p bundlechanges.AddApplicationParams,
+	chID charmstore.CharmID,
+	csMac *macaroon.Macaroon,
+) error {
 	h.results[id] = p.Application
 	ch := chID.URL.String()
 	// Handle application configuration.
@@ -370,7 +352,7 @@ func (h *bundleHandler) addService(id string, p bundlechanges.AddApplicationPara
 	if err != nil {
 		return err
 	}
-	resNames2IDs, err := handleResources(h.serviceDeployer.api, resources, p.Application, chID, csMac, charmInfo.Meta.Resources)
+	resNames2IDs, err := handleResources(api, resources, p.Application, chID, csMac, charmInfo.Meta.Resources)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -391,23 +373,25 @@ func (h *bundleHandler) addService(id string, p bundlechanges.AddApplicationPara
 		conf:            conf,
 		fromBundle:      true,
 	}
-	series, message, err := selector.charmSeries()
+	series, err := selector.charmSeries()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	// Deploy the application.
-	if err := h.serviceDeployer.applicationDeploy(applicationDeployParams{
-		charmID:         chID,
-		applicationName: p.Application,
-		series:          series,
-		configYAML:      configYAML,
-		constraints:     cons,
-		storage:         storageConstraints,
-		spaceBindings:   p.EndpointBindings,
-		resources:       resNames2IDs,
-	}); err == nil {
-		h.log.Infof("application %s deployed (charm %s %v)", p.Application, ch, fmt.Sprintf(message, series))
+	if err := deployApp(
+		api,
+		application.DeployArgs{
+			CharmID:          chID,
+			Cons:             cons,
+			ApplicationName:  p.Application,
+			Series:           series,
+			ConfigYAML:       configYAML,
+			Storage:          storageConstraints,
+			Resources:        resNames2IDs,
+			EndpointBindings: p.EndpointBindings,
+		}); err == nil {
+		h.log.Infof("application %s deployed (charm %s)", p.Application, ch)
 		for resName := range resNames2IDs {
 			h.log.Infof("added resource %s", resName)
 		}
@@ -419,7 +403,7 @@ func (h *bundleHandler) addService(id string, p bundlechanges.AddApplicationPara
 	// charm is compatible with the one declared in the bundle. If it is,
 	// reuse the existing application or upgrade to a specified revision.
 	// Exit with an error otherwise.
-	if err := h.upgradeCharm(p.Application, chID, csMac, resources); err != nil {
+	if err := h.upgradeCharm(api, p.Application, chID, csMac, resources); err != nil {
 		return errors.Annotatef(err, "cannot upgrade application %q", p.Application)
 	}
 	// Update application configuration.
@@ -512,7 +496,7 @@ func (h *bundleHandler) addMachine(id string, p bundlechanges.AddMachineParams) 
 			}
 		}
 	}
-	r, err := h.client.AddMachines([]params.AddMachineParams{machineParams})
+	r, err := h.api.Client().AddMachines([]params.AddMachineParams{machineParams})
 	if err != nil {
 		return errors.Annotatef(err, "cannot create machine for holding %s", msg)
 	}
@@ -828,7 +812,13 @@ func resolve(placeholder string, results map[string]string) string {
 // If the application is already deployed using the given charm id, do nothing.
 // This function returns an error if the existing charm and the target one are
 // incompatible, meaning an upgrade from one to the other is not allowed.
-func (h *bundleHandler) upgradeCharm(applicationName string, chID charmstore.CharmID, csMac *macaroon.Macaroon, resources map[string]string) error {
+func (h *bundleHandler) upgradeCharm(
+	api DeployAPI,
+	applicationName string,
+	chID charmstore.CharmID,
+	csMac *macaroon.Macaroon,
+	resources map[string]string,
+) error {
 	id := chID.URL.String()
 	existing, err := h.applicationClient.GetCharmURL(applicationName)
 	if err != nil {
@@ -846,13 +836,13 @@ func (h *bundleHandler) upgradeCharm(applicationName string, chID charmstore.Cha
 	if url.WithRevision(-1).Path() != existing.WithRevision(-1).Path() {
 		return errors.Errorf("bundle charm %q is incompatible with existing charm %q", id, existing)
 	}
-	filtered, err := getUpgradeResources(h.serviceDeployer.api, applicationName, url, h.client, resources)
+	filtered, err := getUpgradeResources(api, applicationName, url, resources)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	var resNames2IDs map[string]string
 	if len(filtered) != 0 {
-		resNames2IDs, err = handleResources(h.serviceDeployer.api, resources, applicationName, chID, csMac, filtered)
+		resNames2IDs, err = handleResources(api, resources, applicationName, chID, csMac, filtered)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/cmd/juju/application/bundle_resources_test.go
+++ b/cmd/juju/application/bundle_resources_test.go
@@ -47,7 +47,7 @@ func (s *ResourcesBundleSuite) TestDeployBundleResources(c *gc.C) {
 	lines := strings.Split(output, "\n")
 	expectedLines := strings.Split(strings.TrimSpace(`
 added charm cs:trusty/starsay-42
-application starsay deployed (charm cs:trusty/starsay-42 with the series "trusty" defined by the bundle)
+application starsay deployed (charm cs:trusty/starsay-42)
 added resource install-resource
 added resource store-resource
 added resource upload-resource

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -63,9 +63,9 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:xenial/mysql-42
-application mysql deployed (charm cs:xenial/mysql-42 with the series "xenial" defined by the bundle)
+application mysql deployed (charm cs:xenial/mysql-42)
 added charm cs:xenial/wordpress-47
-application wordpress deployed (charm cs:xenial/wordpress-47 with the series "xenial" defined by the bundle)
+application wordpress deployed (charm cs:xenial/wordpress-47)
 related wordpress:db and mysql:server
 added mysql/0 unit to new machine
 added wordpress/0 unit to new machine
@@ -91,9 +91,9 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleWithTermsSuccess(c *gc.C) 
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:xenial/terms1-17
-application terms1 deployed (charm cs:xenial/terms1-17 with the series "xenial" defined by the bundle)
+application terms1 deployed (charm cs:xenial/terms1-17)
 added charm cs:xenial/terms2-42
-application terms2 deployed (charm cs:xenial/terms2-42 with the series "xenial" defined by the bundle)
+application terms2 deployed (charm cs:xenial/terms2-42)
 added terms1/0 unit to new machine
 added terms2/0 unit to new machine
 deployment of bundle "cs:bundle/terms-simple-1" completed`
@@ -121,9 +121,9 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleStorage(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:xenial/mysql-42
-application mysql deployed (charm cs:xenial/mysql-42 with the series "xenial" defined by the bundle)
+application mysql deployed (charm cs:xenial/mysql-42)
 added charm cs:xenial/wordpress-47
-application wordpress deployed (charm cs:xenial/wordpress-47 with the series "xenial" defined by the bundle)
+application wordpress deployed (charm cs:xenial/wordpress-47)
 related wordpress:db and mysql:server
 added mysql/0 unit to new machine
 added wordpress/0 unit to new machine
@@ -174,9 +174,9 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleEndpointBindingsSuccess(c 
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:xenial/mysql-42
-application mysql deployed (charm cs:xenial/mysql-42 with the series "xenial" defined by the bundle)
+application mysql deployed (charm cs:xenial/mysql-42)
 added charm cs:xenial/wordpress-extra-bindings-47
-application wordpress-extra-bindings deployed (charm cs:xenial/wordpress-extra-bindings-47 with the series "xenial" defined by the bundle)
+application wordpress-extra-bindings deployed (charm cs:xenial/wordpress-extra-bindings-47)
 related wordpress-extra-bindings:db and mysql:server
 added mysql/0 unit to new machine
 added wordpress-extra-bindings/0 unit to new machine
@@ -275,7 +275,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalPath(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := fmt.Sprintf(`
 added charm local:xenial/dummy-1
-application dummy deployed (charm local:xenial/dummy-1 with the series "xenial" defined by the bundle)
+application dummy deployed (charm local:xenial/dummy-1)
 added dummy/0 unit to new machine
 deployment of bundle %q completed`, path)
 	c.Assert(output, gc.Equals, strings.TrimSpace(expectedOutput))
@@ -302,7 +302,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleNoSeriesInCharmURL(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := fmt.Sprintf(`
 added charm cs:~who/multi-series-0
-application dummy deployed (charm cs:~who/multi-series-0 with the series "trusty" defined by the bundle)
+application dummy deployed (charm cs:~who/multi-series-0)
 deployment of bundle %q completed`, path)
 	c.Assert(output, gc.Equals, strings.TrimSpace(expectedOutput))
 	s.assertCharmsUploaded(c, "cs:~who/multi-series-0")
@@ -520,9 +520,9 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeployment(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm local:xenial/mysql-1
-application mysql deployed (charm local:xenial/mysql-1 with the series "xenial" defined by the bundle)
+application mysql deployed (charm local:xenial/mysql-1)
 added charm local:xenial/wordpress-3
-application wordpress deployed (charm local:xenial/wordpress-3 with the series "xenial" defined by the bundle)
+application wordpress deployed (charm local:xenial/wordpress-3)
 related wordpress:db and mysql:server
 added mysql/0 unit to new machine
 added mysql/1 unit to new machine
@@ -562,9 +562,9 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalAndCharmStoreCharms(c
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm local:xenial/mysql-1
-application mysql deployed (charm local:xenial/mysql-1 with the series "xenial" defined by the bundle)
+application mysql deployed (charm local:xenial/mysql-1)
 added charm cs:xenial/wordpress-42
-application wordpress deployed (charm cs:xenial/wordpress-42 with the series "xenial" defined by the bundle)
+application wordpress deployed (charm cs:xenial/wordpress-42)
 related wordpress:db and mysql:server
 added mysql/0 unit to new machine
 added wordpress/0 unit to new machine
@@ -602,9 +602,9 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationOptions(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:precise/dummy-0
-application customized deployed (charm cs:precise/dummy-0 with the series "precise" defined by the bundle)
+application customized deployed (charm cs:precise/dummy-0)
 added charm cs:xenial/wordpress-42
-application wordpress deployed (charm cs:xenial/wordpress-42 with the series "xenial" defined by the bundle)
+application wordpress deployed (charm cs:xenial/wordpress-42)
 added customized/0 unit to new machine
 added wordpress/0 unit to new machine
 deployment of bundle "local:bundle/example-0" completed`
@@ -642,9 +642,9 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationConstrants(c *g
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:precise/dummy-0
-application customized deployed (charm cs:precise/dummy-0 with the series "precise" defined by the bundle)
+application customized deployed (charm cs:precise/dummy-0)
 added charm cs:xenial/wordpress-42
-application wordpress deployed (charm cs:xenial/wordpress-42 with the series "xenial" defined by the bundle)
+application wordpress deployed (charm cs:xenial/wordpress-42)
 added customized/0 unit to new machine
 deployment of bundle "local:bundle/example-0" completed`
 	c.Assert(output, gc.Equals, strings.TrimSpace(expectedOutput))
@@ -685,9 +685,9 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationUpgrade(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:vivid/upgrade-1
-application up deployed (charm cs:vivid/upgrade-1 with the series "vivid" defined by the bundle)
+application up deployed (charm cs:vivid/upgrade-1)
 added charm cs:xenial/wordpress-42
-application wordpress deployed (charm cs:xenial/wordpress-42 with the series "xenial" defined by the bundle)
+application wordpress deployed (charm cs:xenial/wordpress-42)
 added up/0 unit to new machine
 added wordpress/0 unit to new machine
 deployment of bundle "local:bundle/example-0" completed`
@@ -755,7 +755,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleExpose(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:xenial/wordpress-42
-application wordpress deployed (charm cs:xenial/wordpress-42 with the series "xenial" defined by the bundle)
+application wordpress deployed (charm cs:xenial/wordpress-42)
 application wordpress exposed
 added wordpress/0 unit to new machine
 deployment of bundle "local:bundle/example-0" completed`
@@ -859,13 +859,13 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMultipleRelations(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:xenial/mysql-1
-application mysql deployed (charm cs:xenial/mysql-1 with the series "xenial" defined by the bundle)
+application mysql deployed (charm cs:xenial/mysql-1)
 added charm cs:xenial/postgres-2
-application pgres deployed (charm cs:xenial/postgres-2 with the series "xenial" defined by the bundle)
+application pgres deployed (charm cs:xenial/postgres-2)
 added charm cs:xenial/varnish-3
-application varnish deployed (charm cs:xenial/varnish-3 with the series "xenial" defined by the bundle)
+application varnish deployed (charm cs:xenial/varnish-3)
 added charm cs:xenial/wordpress-0
-application wp deployed (charm cs:xenial/wordpress-0 with the series "xenial" defined by the bundle)
+application wp deployed (charm cs:xenial/wordpress-0)
 related wp:db and mysql:server
 related wp:db and pgres:server
 related varnish:webcache and wp:cache
@@ -971,9 +971,9 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMachinesUnitsPlacement(c *
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:xenial/mysql-2
-application sql deployed (charm cs:xenial/mysql-2 with the series "xenial" defined by the bundle)
+application sql deployed (charm cs:xenial/mysql-2)
 added charm cs:xenial/wordpress-0
-application wp deployed (charm cs:xenial/wordpress-0 with the series "xenial" defined by the bundle)
+application wp deployed (charm cs:xenial/wordpress-0)
 created new machine 0 for holding wp unit
 created new machine 1 for holding wp unit
 added wp/0 unit to machine 0
@@ -1099,7 +1099,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMachineAttributes(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:xenial/django-42
-application django deployed (charm cs:xenial/django-42 with the series "xenial" defined by the bundle)
+application django deployed (charm cs:xenial/django-42)
 created new machine 0 for holding django unit
 annotations set for machine 0
 added django/0 unit to machine 0
@@ -1178,9 +1178,9 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleUnitPlacedInApplication(c 
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:xenial/django-42
-application django deployed (charm cs:xenial/django-42 with the series "xenial" defined by the bundle)
+application django deployed (charm cs:xenial/django-42)
 added charm cs:xenial/wordpress-0
-application wordpress deployed (charm cs:xenial/wordpress-0 with the series "xenial" defined by the bundle)
+application wordpress deployed (charm cs:xenial/wordpress-0)
 added wordpress/0 unit to new machine
 added wordpress/1 unit to new machine
 added wordpress/2 unit to new machine
@@ -1228,11 +1228,11 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleUnitColocationWithUnit(c *
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:xenial/django-42
-application django deployed (charm cs:xenial/django-42 with the series "xenial" defined by the bundle)
+application django deployed (charm cs:xenial/django-42)
 added charm cs:xenial/mem-47
-application memcached deployed (charm cs:xenial/mem-47 with the series "xenial" defined by the bundle)
+application memcached deployed (charm cs:xenial/mem-47)
 added charm cs:xenial/rails-0
-application ror deployed (charm cs:xenial/rails-0 with the series "xenial" defined by the bundle)
+application ror deployed (charm cs:xenial/rails-0)
 created new machine 0 for holding memcached and ror units
 added memcached/0 unit to machine 0
 added ror/0 unit to machine 0
@@ -1288,7 +1288,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleUnitPlacedToMachines(c *gc
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:xenial/django-42
-application django deployed (charm cs:xenial/django-42 with the series "xenial" defined by the bundle)
+application django deployed (charm cs:xenial/django-42)
 created new machine 0 for holding django unit
 created new machine 1 for holding django unit
 added django/0 unit to machine 0
@@ -1347,11 +1347,11 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMassiveUnitColocation(c *g
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:xenial/django-42
-application django deployed (charm cs:xenial/django-42 with the series "xenial" defined by the bundle)
+application django deployed (charm cs:xenial/django-42)
 added charm cs:xenial/mem-47
-application memcached deployed (charm cs:xenial/mem-47 with the series "xenial" defined by the bundle)
+application memcached deployed (charm cs:xenial/mem-47)
 added charm cs:xenial/rails-0
-application ror deployed (charm cs:xenial/rails-0 with the series "xenial" defined by the bundle)
+application ror deployed (charm cs:xenial/rails-0)
 created new machine 0 for holding django, memcached and ror units
 created new machine 1 for holding memcached unit
 created new machine 2 for holding memcached and ror units
@@ -1416,7 +1416,7 @@ added charm cs:xenial/django-42
 reusing application django (charm: cs:xenial/django-42)
 added charm cs:xenial/mem-47
 reusing application memcached (charm: cs:xenial/mem-47)
-application node deployed (charm cs:xenial/django-42 with the series "xenial" defined by the bundle)
+application node deployed (charm cs:xenial/django-42)
 avoid creating other machines to host django and memcached units
 avoid adding new units to application django: 4 units already present
 avoid adding new units to application memcached: 3 units already present
@@ -1478,10 +1478,10 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleAnnotations(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:xenial/django-42
-application django deployed (charm cs:xenial/django-42 with the series "xenial" defined by the bundle)
+application django deployed (charm cs:xenial/django-42)
 annotations set for application django
 added charm cs:xenial/mem-47
-application memcached deployed (charm cs:xenial/mem-47 with the series "xenial" defined by the bundle)
+application memcached deployed (charm cs:xenial/mem-47)
 created new machine 0 for holding django unit
 annotations set for machine 0
 added django/0 unit to machine 0

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
+	"github.com/juju/juju/api/charms"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -63,8 +64,8 @@ func (s *RemoveServiceSuite) TestSuccess(c *gc.C) {
 
 func (s *RemoveServiceSuite) TestRemoveLocalMetered(c *gc.C) {
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "metered")
-	deploy := &DeployCommand{}
-	_, err := testing.RunCommand(c, modelcmd.Wrap(deploy), ch, "--series", "quantal")
+	deploy := NewDeployCommand()
+	_, err := testing.RunCommand(c, deploy, ch, "--series", "quantal")
 	c.Assert(err, jc.ErrorIsNil)
 	err = runRemoveService(c, "metered")
 	c.Assert(err, jc.ErrorIsNil)
@@ -125,8 +126,21 @@ func (s *RemoveCharmStoreCharmsSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&getBudgetAPIClient, func(*httpbakery.Client) budgetAPIClient { return s.budgetAPIClient })
 
 	testcharms.UploadCharm(c, s.client, "cs:quantal/metered-1", "metered")
-	deploy := &DeployCommand{}
-	_, err := testing.RunCommand(c, modelcmd.Wrap(deploy), "cs:quantal/metered-1")
+	deployCmd := &DeployCommand{}
+	cmd := modelcmd.Wrap(deployCmd)
+	deployCmd.NewAPIRoot = func() (DeployAPI, error) {
+		apiRoot, err := deployCmd.ModelCommandBase.NewAPIRoot()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return &deployAPIAdapter{
+			Connection:   apiRoot,
+			apiClient:    &apiClient{Client: apiRoot.Client()},
+			charmsClient: &charmsClient{Client: charms.NewClient(apiRoot)},
+		}, nil
+	}
+
+	_, err := testing.RunCommand(c, cmd, "cs:quantal/metered-1")
 	c.Assert(err, jc.ErrorIsNil)
 
 }

--- a/cmd/juju/application/series_selector_test.go
+++ b/cmd/juju/application/series_selector_test.go
@@ -150,14 +150,13 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				previous := series.SetLatestLtsForTesting(test.ltsSeries)
 				defer series.SetLatestLtsForTesting(previous)
 			}
-			series, msg, err := test.seriesSelector.charmSeries()
+			series, err := test.seriesSelector.charmSeries()
 			if test.err != "" {
 				c.Check(err, gc.ErrorMatches, test.err)
 				return
 			}
 			c.Check(err, jc.ErrorIsNil)
 			c.Check(series, gc.Equals, test.expectedSeries)
-			c.Check(msg, gc.Matches, test.message)
 		}()
 	}
 }

--- a/cmd/juju/application/store.go
+++ b/cmd/juju/application/store.go
@@ -16,7 +16,6 @@ import (
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/macaroon.v1"
 
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs/config"
 )
@@ -124,7 +123,7 @@ func (r *charmURLResolver) resolve(url *charm.URL) (*charm.URL, csparams.Channel
 // given charm URL to state. For non-public charm URLs, this function also
 // handles the macaroon authorization process using the given csClient.
 // The resulting charm URL of the added charm is displayed on stdout.
-func addCharmFromURL(client *api.Client, curl *charm.URL, channel csparams.Channel, csClient *csclient.Client) (*charm.URL, *macaroon.Macaroon, error) {
+func addCharmFromURL(client CharmAdder, curl *charm.URL, channel csparams.Channel, csClient *csclient.Client) (*charm.URL, *macaroon.Macaroon, error) {
 	var csMac *macaroon.Macaroon
 	if err := client.AddCharm(curl, channel); err != nil {
 		if !params.IsCodeUnauthorized(err) {

--- a/cmd/juju/application/upgradecharm_resources_test.go
+++ b/cmd/juju/application/upgradecharm_resources_test.go
@@ -197,8 +197,8 @@ func (s *UpgradeCharmStoreResourceSuite) TestDeployStarsaySuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	output := testing.Stderr(ctx)
 
-	expectedOutput := `Added charm "cs:trusty/starsay-1" to the model.
-Deploying charm "cs:trusty/starsay-1" with the user specified series "trusty".
+	expectedOutput := `Located charm "cs:trusty/starsay-1".
+Deploying charm "cs:trusty/starsay-1".
 `
 	c.Assert(output, gc.Equals, expectedOutput)
 	s.assertCharmsUploaded(c, "cs:trusty/starsay-1")

--- a/component/all/resource.go
+++ b/component/all/resource.go
@@ -127,7 +127,11 @@ func (r resources) registerPublicCommands() {
 	commands.RegisterEnvCommand(func() modelcmd.ModelCommand {
 		return cmd.NewUploadCommand(cmd.UploadDeps{
 			NewClient: func(c *cmd.UploadCommand) (cmd.UploadClient, error) {
-				return resourceadapters.NewAPIClient(c.NewAPIRoot)
+				apiRoot, err := c.NewAPIRoot()
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				return resourceadapters.NewAPIClient(apiRoot)
 			},
 			OpenResource: func(s string) (cmd.ReadSeekCloser, error) {
 				return os.Open(s)
@@ -139,7 +143,11 @@ func (r resources) registerPublicCommands() {
 	commands.RegisterEnvCommand(func() modelcmd.ModelCommand {
 		return cmd.NewShowServiceCommand(cmd.ShowServiceDeps{
 			NewClient: func(c *cmd.ShowServiceCommand) (cmd.ShowServiceClient, error) {
-				return resourceadapters.NewAPIClient(c.NewAPIRoot)
+				apiRoot, err := c.NewAPIRoot()
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				return resourceadapters.NewAPIClient(apiRoot)
 			},
 		})
 	})

--- a/resource/resourceadapters/apiclient.go
+++ b/resource/resourceadapters/apiclient.go
@@ -6,7 +6,6 @@ package resourceadapters
 import (
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/api/client"
@@ -16,16 +15,7 @@ import (
 // NewAPIClient is mostly a copy of the newClient code in
 // component/all/resources.go.  It lives here because it simplifies this code
 // immensely.
-func NewAPIClient(newAPICaller func() (api.Connection, error)) (*client.Client, error) {
-	apiCaller, err := newAPICaller()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return newAPIClient(apiCaller)
-}
-
-func newAPIClient(apiCaller api.Connection) (*client.Client, error) {
+func NewAPIClient(apiCaller base.APICallCloser) (*client.Client, error) {
 	caller := base.NewFacadeCallerForVersion(apiCaller, resource.FacadeName, server.Version)
 
 	httpClient, err := apiCaller.HTTPClient()

--- a/resource/resourceadapters/deploy.go
+++ b/resource/resourceadapters/deploy.go
@@ -10,7 +10,7 @@ import (
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 	"gopkg.in/macaroon.v1"
 
-	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/resource/api/client"
 	"github.com/juju/juju/resource/cmd"
@@ -19,8 +19,8 @@ import (
 // DeployResources uploads the bytes for the given files to the server and
 // creates pending resource metadata for the all resource mentioned in the
 // metadata. It returns a map of resource name to pending resource IDs.
-func DeployResources(applicationID string, chID charmstore.CharmID, csMac *macaroon.Macaroon, filesAndRevisions map[string]string, resources map[string]charmresource.Meta, conn api.Connection) (ids map[string]string, err error) {
-	client, err := newAPIClient(conn)
+func DeployResources(applicationID string, chID charmstore.CharmID, csMac *macaroon.Macaroon, filesAndRevisions map[string]string, resources map[string]charmresource.Meta, conn base.APICallCloser) (ids map[string]string, err error) {
+	client, err := NewAPIClient(conn)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
This patch accomplishes a few things:

* Reduce the number of connections to the API server
  During deploy, we were opening several clients and repeatedly opening/closing new API connections. We now open one connection at the root of the command in `Run(...)` and pass it through as needed. In my tests, the connections a deploy of a local charm requires to work has been reduced from 4 to 1, and as a result, deploys will be fater -- especially in scenarios where the connection to the controller is slow.

* The deploy command now takes in an API
  This allows for unit tests to be written against this command.

* The API passed in has begun to be pared down from api.Connection.
  This work is not complete, but it provides a strong start to build on.

Some tests required touch-ups to work with the new API being passed in. Some code could be deleted as it was providing obviated abstraction around opening new API connections.

Please note that this only represents the start of a larger body of work. Currently, the way of mocking out some of the tests relies too much on knowledge of implementation. As the API interface being passed in shrinks, this problem will shrink as well.

(Review request: http://reviews.vapour.ws/r/5485/)