### PR TITLE
Add access value to list users output

### DIFF
--- a/api/usermanager/client_test.go
+++ b/api/usermanager/client_test.go
@@ -145,6 +145,7 @@ func (s *usermanagerSuite) TestUserInfo(c *gc.C) {
 		{
 			Username:    "foobar",
 			DisplayName: "Foo Bar",
+			Access:      "login",
 			CreatedBy:   s.AdminUserTag(c).Name(),
 			DateCreated: user.DateCreated(),
 		},

--- a/apiserver/params/usermanager.go
+++ b/apiserver/params/usermanager.go
@@ -11,6 +11,7 @@ import (
 type UserInfo struct {
 	Username       string     `json:"username"`
 	DisplayName    string     `json:"display-name"`
+	Access         string     `json:"access"`
 	CreatedBy      string     `json:"created-by"`
 	DateCreated    time.Time  `json:"date-created"`
 	LastConnection *time.Time `json:"last-connection,omitempty"`

--- a/cmd/juju/user/info.go
+++ b/cmd/juju/user/info.go
@@ -68,6 +68,7 @@ type infoCommand struct {
 type UserInfo struct {
 	Username       string `yaml:"user-name" json:"user-name"`
 	DisplayName    string `yaml:"display-name" json:"display-name"`
+	Access         string `yaml:"access" json:"access"`
 	DateCreated    string `yaml:"date-created" json:"date-created"`
 	LastConnection string `yaml:"last-connection" json:"last-connection"`
 	Disabled       bool   `yaml:"disabled,omitempty" json:"disabled,omitempty"`
@@ -139,6 +140,7 @@ func (c *infoCommandBase) apiUsersToUserInfoSlice(users []params.UserInfo) []Use
 		outInfo := UserInfo{
 			Username:       info.Username,
 			DisplayName:    info.DisplayName,
+			Access:         info.Access,
 			Disabled:       info.Disabled,
 			LastConnection: common.LastConnection(info.LastConnection, now, c.exactTime),
 		}

--- a/cmd/juju/user/info_test.go
+++ b/cmd/juju/user/info_test.go
@@ -53,9 +53,11 @@ func (*fakeUserInfoAPI) UserInfo(usernames []string, all usermanager.IncludeDisa
 	switch usernames[0] {
 	case "current-user@local":
 		info.Username = "current-user"
+		info.Access = "addmodel"
 	case "foobar":
 		info.Username = "foobar"
 		info.DisplayName = "Foo Bar"
+		info.Access = "login"
 	default:
 		return nil, common.ErrPerm
 	}
@@ -67,6 +69,7 @@ func (s *UserInfoCommandSuite) TestUserInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, `user-name: current-user
 display-name: ""
+access: addmodel
 date-created: 1981-02-27
 last-connection: 2014-01-01
 `)
@@ -77,6 +80,7 @@ func (s *UserInfoCommandSuite) TestUserInfoExactTime(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, `user-name: current-user
 display-name: ""
+access: addmodel
 date-created: 1981-02-27 16:10:05 +0000 UTC
 last-connection: 2014-01-01 00:00:00 +0000 UTC
 `)
@@ -87,6 +91,7 @@ func (s *UserInfoCommandSuite) TestUserInfoWithUsername(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, `user-name: foobar
 display-name: Foo Bar
+access: login
 date-created: 1981-02-27
 last-connection: 2014-01-01
 `)
@@ -101,7 +106,7 @@ func (s *UserInfoCommandSuite) TestUserInfoFormatJson(c *gc.C) {
 	context, err := testing.RunCommand(c, s.NewShowUserCommand(), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, `
-{"user-name":"current-user","display-name":"","date-created":"1981-02-27","last-connection":"2014-01-01"}
+{"user-name":"current-user","display-name":"","access":"addmodel","date-created":"1981-02-27","last-connection":"2014-01-01"}
 `[1:])
 }
 
@@ -109,7 +114,7 @@ func (s *UserInfoCommandSuite) TestUserInfoFormatJsonWithUsername(c *gc.C) {
 	context, err := testing.RunCommand(c, s.NewShowUserCommand(), "foobar", "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, `
-{"user-name":"foobar","display-name":"Foo Bar","date-created":"1981-02-27","last-connection":"2014-01-01"}
+{"user-name":"foobar","display-name":"Foo Bar","access":"login","date-created":"1981-02-27","last-connection":"2014-01-01"}
 `[1:])
 }
 
@@ -118,6 +123,7 @@ func (s *UserInfoCommandSuite) TestUserInfoFormatYaml(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, `user-name: current-user
 display-name: ""
+access: addmodel
 date-created: 1981-02-27
 last-connection: 2014-01-01
 `)

--- a/featuretests/cmd_juju_user_test.go
+++ b/featuretests/cmd_juju_user_test.go
@@ -121,8 +121,10 @@ func (s *UserSuite) TestUserList(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	periodPattern := `(just now|\d+ \S+ ago)`
 	expected := fmt.Sprintf(`
-NAME\s+DISPLAY NAME\s+DATE CREATED\s+LAST CONNECTION
-admin\s+admin\s+%s\s+%s
+CONTROLLER: kontroll
+
+NAME\s+DISPLAY NAME\s+ACCESS\s+DATE CREATED\s+LAST CONNECTION
+admin.*\s+admin\s+superuser\s+%s\s+%s
 
 `[1:], periodPattern, periodPattern)
 	c.Assert(testing.Stdout(ctx), gc.Matches, expected)


### PR DESCRIPTION
juju list-users will now show the access level each user has on the controller, as well as the name of the controller. It will also have a * next to the current logged in user. And the current user will be highlighted in green.

An issue was also fixed where the permission checking was wrong. Users who run list-users will only see their own user name, unless they have superuser rights on the controller, in which case they can see everyone.

(Review request: http://reviews.vapour.ws/r/5490/)