### PR TITLE
Migrate storage constraints

### DIFF
--- a/core/description/application.go
+++ b/core/description/application.go
@@ -164,6 +164,11 @@ func (s *application) LeadershipSettings() map[string]interface{} {
 	return s.LeadershipSettings_
 }
 
+// StorageConstraints implements Application.
+func (s *application) StorageConstraints() map[string]StorageConstraint {
+	return nil
+}
+
 // MetricsCredentials implements Application.
 func (s *application) MetricsCredentials() []byte {
 	// Here we are explicitly throwing away any decode error. We check that

--- a/core/description/application_test.go
+++ b/core/description/application_test.go
@@ -62,8 +62,11 @@ func minimalApplicationMap() map[interface{}]interface{} {
 	}
 }
 
-func minimalApplication() *application {
-	s := newApplication(minimalApplicationArgs())
+func minimalApplication(args ...ApplicationArgs) *application {
+	if len(args) == 0 {
+		args = []ApplicationArgs{minimalApplicationArgs()}
+	}
+	s := newApplication(args[0])
 	s.SetStatus(minimalStatusArgs())
 	u := s.AddUnit(minimalUnitArgs())
 	u.SetAgentStatus(minimalStatusArgs())
@@ -203,6 +206,31 @@ func (s *ApplicationSerializationSuite) TestConstraints(c *gc.C) {
 
 	application := s.exportImport(c, initial)
 	c.Assert(application.Constraints(), jc.DeepEquals, newConstraints(args))
+}
+
+func (s *ApplicationSerializationSuite) TestStorageConstraints(c *gc.C) {
+	args := minimalApplicationArgs()
+	args.StorageConstraints = map[string]StorageConstraintArgs{
+		"first":  {Pool: "first", Size: 1234, Count: 1},
+		"second": {Pool: "second", Size: 4321, Count: 7},
+	}
+	initial := minimalApplication(args)
+
+	application := s.exportImport(c, initial)
+
+	constraints := application.StorageConstraints()
+	c.Assert(constraints, gc.HasLen, 2)
+	first, found := constraints["first"]
+	c.Assert(found, jc.IsTrue)
+	c.Check(first.Pool(), gc.Equals, "first")
+	c.Check(first.Size(), gc.Equals, uint64(1234))
+	c.Check(first.Count(), gc.Equals, uint64(1))
+
+	second, found := constraints["second"]
+	c.Assert(found, jc.IsTrue)
+	c.Check(second.Pool(), gc.Equals, "second")
+	c.Check(second.Size(), gc.Equals, uint64(4321))
+	c.Check(second.Count(), gc.Equals, uint64(7))
 }
 
 func (s *ApplicationSerializationSuite) TestLeaderValid(c *gc.C) {

--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -170,9 +170,6 @@ type Machine interface {
 	Containers() []Machine
 	AddContainer(MachineArgs) Machine
 
-	// TODO:
-	// Storage
-
 	BlockDevices() []BlockDevice
 	AddBlockDevice(BlockDeviceArgs) BlockDevice
 
@@ -183,10 +180,7 @@ type Machine interface {
 	// enough stuff set, like tools, and addresses etc.
 	Validate() error
 
-	// reboot doc
-	// block devices
 	// port docs
-	// machine filesystems
 }
 
 // OpenedPorts represents a collection of port ranges that are open on a
@@ -269,6 +263,7 @@ type Application interface {
 	LeadershipSettings() map[string]interface{}
 
 	MetricsCredentials() []byte
+	StorageConstraints() map[string]StorageConstraint
 
 	Units() []Unit
 	AddUnit(UnitArgs) Unit
@@ -497,4 +492,16 @@ type StoragePool interface {
 	Name() string
 	Provider() string
 	Attributes() map[string]interface{}
+}
+
+// StorageConstraint repressents the user-specified constraints for
+// provisioning storage instances for an application unit.
+type StorageConstraint interface {
+	// Pool is the name of the storage pool from which to provision the
+	// storage instances.
+	Pool() string
+	// Size is the required size of the storage instances, in MiB.
+	Size() uint64
+	// Count is the required number of storage instances.
+	Count() uint64
 }

--- a/core/description/storageconstraint.go
+++ b/core/description/storageconstraint.go
@@ -1,0 +1,111 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+)
+
+// StorageConstraintArgs is an argument struct used to create a new internal
+// storageconstraint type that supports the StorageConstraint interface.
+type StorageConstraintArgs struct {
+	Pool  string
+	Size  uint64
+	Count uint64
+}
+
+func newStorageConstraint(args StorageConstraintArgs) *storageconstraint {
+	return &storageconstraint{
+		Version: 1,
+		Pool_:   args.Pool,
+		Size_:   args.Size,
+		Count_:  args.Count,
+	}
+}
+
+type storageconstraint struct {
+	Version int `yaml:"version"`
+
+	Pool_  string `yaml:"pool"`
+	Size_  uint64 `yaml:"size"`
+	Count_ uint64 `yaml:"count"`
+}
+
+// Pool implements StorageConstraint.
+func (s *storageconstraint) Pool() string {
+	return s.Pool_
+}
+
+// Size implements StorageConstraint.
+func (s *storageconstraint) Size() uint64 {
+	return s.Size_
+}
+
+// Count implements StorageConstraint.
+func (s *storageconstraint) Count() uint64 {
+	return s.Count_
+}
+
+func importStorageConstraintes(sourceMap map[string]interface{}) (map[string]*storageconstraint, error) {
+	result := make(map[string]*storageconstraint)
+	for key, value := range sourceMap {
+		source, ok := value.(map[string]interface{})
+		if !ok {
+			return nil, errors.Errorf("unexpected value for storageconstraint %q, %T", key, value)
+		}
+		constraint, err := importStorageConstraint(source)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		result[key] = constraint
+	}
+	return result, nil
+}
+
+// importStorageConstraint constructs a new StorageConstraint from a map representing a serialised
+// StorageConstraint instance.
+func importStorageConstraint(source map[string]interface{}) (*storageconstraint, error) {
+	version, err := getVersion(source)
+	if err != nil {
+		return nil, errors.Annotate(err, "storageconstraint version schema check failed")
+	}
+
+	importFunc, ok := storageconstraintDeserializationFuncs[version]
+	if !ok {
+		return nil, errors.NotValidf("version %d", version)
+	}
+
+	return importFunc(source)
+}
+
+type storageconstraintDeserializationFunc func(map[string]interface{}) (*storageconstraint, error)
+
+var storageconstraintDeserializationFuncs = map[int]storageconstraintDeserializationFunc{
+	1: importStorageConstraintV1,
+}
+
+func importStorageConstraintV1(source map[string]interface{}) (*storageconstraint, error) {
+	fields := schema.Fields{
+		"pool":  schema.String(),
+		"size":  schema.Uint(),
+		"count": schema.Uint(),
+	}
+	checker := schema.FieldMap(fields, nil)
+
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "storageconstraint v1 schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+	// From here we know that the map returned from the schema coercion
+	// contains fields of the right type.
+
+	return &storageconstraint{
+		Version: 1,
+		Pool_:   valid["pool"].(string),
+		Size_:   valid["size"].(uint64),
+		Count_:  valid["count"].(uint64),
+	}, nil
+}

--- a/core/description/storageconstraint.go
+++ b/core/description/storageconstraint.go
@@ -48,7 +48,7 @@ func (s *storageconstraint) Count() uint64 {
 	return s.Count_
 }
 
-func importStorageConstraintes(sourceMap map[string]interface{}) (map[string]*storageconstraint, error) {
+func importStorageConstraints(sourceMap map[string]interface{}) (map[string]*storageconstraint, error) {
 	result := make(map[string]*storageconstraint)
 	for key, value := range sourceMap {
 		source, ok := value.(map[string]interface{})

--- a/core/description/storageconstraint_test.go
+++ b/core/description/storageconstraint_test.go
@@ -1,0 +1,74 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+)
+
+type StorageConstraintSerializationSuite struct {
+	SerializationSuite
+}
+
+var _ = gc.Suite(&StorageConstraintSerializationSuite{})
+
+func (s *StorageConstraintSerializationSuite) SetUpTest(c *gc.C) {
+	s.SerializationSuite.SetUpTest(c)
+	s.importName = "storageconstraint"
+	s.importFunc = func(m map[string]interface{}) (interface{}, error) {
+		return importStorageConstraint(m)
+	}
+	s.testFields = func(m map[string]interface{}) {
+		m["pool"] = ""
+		m["size"] = 0
+		m["count"] = 0
+	}
+}
+
+func (s *StorageConstraintSerializationSuite) TestMissingValue(c *gc.C) {
+	testMap := s.makeMap(1)
+	delete(testMap, "pool")
+	_, err := importStorageConstraint(testMap)
+	c.Check(err.Error(), gc.Equals, "storageconstraint v1 schema check failed: pool: expected string, got nothing")
+}
+
+func (*StorageConstraintSerializationSuite) TestParsing(c *gc.C) {
+	addr, err := importStorageConstraint(map[string]interface{}{
+		"version": 1,
+		"pool":    "olympic",
+		"size":    50,
+		"count":   2,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	expected := &storageconstraint{
+		Version: 1,
+		Pool_:   "olympic",
+		Size_:   50,
+		Count_:  2,
+	}
+	c.Assert(addr, jc.DeepEquals, expected)
+}
+
+func (*StorageConstraintSerializationSuite) TestParsingSerializedData(c *gc.C) {
+	initial := &storageconstraint{
+		Version: 1,
+		Pool_:   "olympic",
+		Size_:   50,
+		Count_:  2,
+	}
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	storageconstraints, err := importStorageConstraint(source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(storageconstraints, jc.DeepEquals, initial)
+}

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -862,6 +862,21 @@ func (s *MigrationExportSuite) TestStorage(c *gc.C) {
 	model, err := s.State.Export()
 	c.Assert(err, jc.ErrorIsNil)
 
+	apps := model.Applications()
+	c.Assert(apps, gc.HasLen, 1)
+	constraints := apps[0].StorageConstraints()
+	c.Assert(constraints, gc.HasLen, 2)
+	cons, found := constraints["data"]
+	c.Assert(found, jc.IsTrue)
+	c.Check(cons.Pool(), gc.Equals, "loop-pool")
+	c.Check(cons.Size(), gc.Equals, uint64(0x400))
+	c.Check(cons.Count(), gc.Equals, uint64(1))
+	cons, found = constraints["allecto"]
+	c.Assert(found, jc.IsTrue)
+	c.Check(cons.Pool(), gc.Equals, "loop")
+	c.Check(cons.Size(), gc.Equals, uint64(0x400))
+	c.Check(cons.Count(), gc.Equals, uint64(0))
+
 	storages := model.Storages()
 	c.Assert(storages, gc.HasLen, 1)
 

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -626,10 +626,10 @@ func (i *importer) application(s description.Application) error {
 	// TODO: update never set malarky... maybe...
 
 	ops := addApplicationOps(i.st, addApplicationOpsArgs{
-		applicationDoc: sdoc,
-		statusDoc:      statusDoc,
-		constraints:    i.constraints(s.Constraints()),
-		// storage          TODO,
+		applicationDoc:     sdoc,
+		statusDoc:          statusDoc,
+		constraints:        i.constraints(s.Constraints()),
+		storage:            i.storageConstraints(s.StorageConstraints()),
 		settings:           s.Settings(),
 		settingsRefCount:   s.SettingsRefCount(),
 		leadershipSettings: s.LeadershipSettings(),
@@ -665,6 +665,21 @@ func (i *importer) application(s description.Application) error {
 	}
 
 	return nil
+}
+
+func (i *importer) storageConstraints(cons map[string]description.StorageConstraint) map[string]StorageConstraints {
+	if len(cons) == 0 {
+		return nil
+	}
+	result := make(map[string]StorageConstraints)
+	for key, value := range cons {
+		result[key] = StorageConstraints{
+			Pool:  value.Pool(),
+			Size:  value.Size(),
+			Count: value.Count(),
+		}
+	}
+	return result
 }
 
 func (i *importer) unit(s description.Application, u description.Unit) error {

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -853,7 +853,7 @@ func (s *MigrationImportSuite) TestFilesystems(c *gc.C) {
 }
 
 func (s *MigrationImportSuite) TestStorage(c *gc.C) {
-	_, u, storageTag := s.makeUnitWithStorage(c)
+	app, u, storageTag := s.makeUnitWithStorage(c)
 	original, err := s.State.StorageInstance(storageTag)
 	c.Assert(err, jc.ErrorIsNil)
 	originalCount := state.StorageAttachmentCount(original)
@@ -862,8 +862,18 @@ func (s *MigrationImportSuite) TestStorage(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(originalAttachments, gc.HasLen, 1)
 	c.Assert(originalAttachments[0].Unit(), gc.Equals, u.UnitTag())
+	appName := app.Name()
 
 	_, newSt := s.importModel(c)
+
+	app, err = newSt.Application(appName)
+	c.Assert(err, jc.ErrorIsNil)
+	cons, err := app.StorageConstraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(cons, jc.DeepEquals, map[string]state.StorageConstraints{
+		"data":    {Pool: "loop-pool", Size: 0x400, Count: 1},
+		"allecto": {Pool: "loop", Size: 0x400},
+	})
 
 	instance, err := newSt.StorageInstance(storageTag)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -60,10 +60,12 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// actions
 		actionsC,
 
+		// storage
 		filesystemsC,
 		filesystemAttachmentsC,
-		storageInstancesC,
 		storageAttachmentsC,
+		storageConstraintsC,
+		storageInstancesC,
 		volumesC,
 		volumeAttachmentsC,
 	)
@@ -163,9 +165,6 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		"payloads",
 		"resources",
 		endpointBindingsC,
-
-		// storage
-		storageConstraintsC,
 
 		// uncategorised
 		metricsManagerC, // should really be copied across
@@ -775,6 +774,17 @@ func (s *MigrationSuite) TestStorageAttachmentDocFields(c *gc.C) {
 		"StorageInstance",
 	)
 	s.AssertExportedFields(c, storageAttachmentDoc{}, migrated.Union(ignored))
+}
+
+func (s *MigrationSuite) TestStorageConstraintsDocFields(c *gc.C) {
+	ignored := set.NewStrings(
+		"ModelUUID",
+		"DocID",
+	)
+	migrated := set.NewStrings(
+		"Constraints",
+	)
+	s.AssertExportedFields(c, storageConstraintsDoc{}, migrated.Union(ignored))
 }
 
 func (s *MigrationSuite) AssertExportedFields(c *gc.C, doc interface{}, fields set.Strings) {


### PR DESCRIPTION
Applications can have storage constraints. We should be able to set up a CI test that checks a model with storage once this lands.

(Review request: http://reviews.vapour.ws/r/5491/)