### PR TITLE
provider/azure: speed up instance registration

### DIFF
--- a/provider/azure/async.go
+++ b/provider/azure/async.go
@@ -1,0 +1,70 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azure
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+)
+
+// asyncCreationRespondDecorator returns an autorest.RespondDecorator
+// that replaces non-failure provisioning states with "Succeeded", to
+// prevent the autorest code from blocking until the resource is completely
+// provisioned.
+func asyncCreationRespondDecorator(original autorest.RespondDecorator) autorest.RespondDecorator {
+	return func(r autorest.Responder) autorest.Responder {
+		return autorest.ResponderFunc(func(resp *http.Response) error {
+			if resp.Body != nil {
+				if err := overrideProvisioningState(resp); err != nil {
+					return err
+				}
+			}
+			return original(r).Respond(resp)
+		})
+	}
+}
+
+func overrideProvisioningState(resp *http.Response) error {
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(resp.Body); err != nil {
+		return err
+	}
+	if err := resp.Body.Close(); err != nil {
+		return err
+	}
+	resp.Body = ioutil.NopCloser(&buf)
+
+	body := make(map[string]interface{})
+	if err := json.Unmarshal(buf.Bytes(), &body); err != nil {
+		// Don't treat failure to decode the body as an error,
+		// or we may get in the way of response handling.
+		return nil
+	}
+	properties, ok := body["properties"].(map[string]interface{})
+	if !ok {
+		// No properties, nothing to do.
+		return nil
+	}
+	provisioningState, ok := properties["provisioningState"]
+	if !ok {
+		// No provisioningState, nothing to do.
+		return nil
+	}
+
+	switch provisioningState {
+	case "Canceled", "Failed", "Succeeded":
+		// In any of these cases, pass on the body untouched.
+	default:
+		properties["provisioningState"] = "Succeeded"
+		buf.Reset()
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/provider/azure/instance.go
+++ b/provider/azure/instance.go
@@ -42,6 +42,10 @@ func (inst *azureInstance) Status() instance.InstanceStatus {
 	// delivered when explicitly requested, and you can only request it
 	// when querying a single VM. This means the results of AllInstances
 	// or Instances would have the instance view missing.
+	//
+	// TODO(axw) if the provisioning state is "Failed", then
+	// we should query the operation status and report the error
+	// here.
 	return instance.InstanceStatus{
 		Status:  status.StatusEmpty,
 		Message: to.String(inst.Properties.ProvisioningState),


### PR DESCRIPTION
Don't wait for VM or VM extensions to be be
fully provisioned before returning from StartInstances.
We intercept the responses and rewrite the provisioning
state from "Creating" (for example) to "Succeeded".
This stops the Azure SDK from synchronising the
request.

There is a regression in functionality introduced by
this: if VM provisioning fails asynchronously, then
it will not be possible to identify the cause of the
failure without looking in the Azure console. This
will be rectified in a follow-up.

Fixes https://bugs.launchpad.net/juju-core/+bug/1614689

(Review request: http://reviews.vapour.ws/r/5492/)