### PR TITLE
New juju whoami command

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -288,6 +288,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(user.NewLoginCommand())
 	r.Register(user.NewLogoutCommand())
 	r.Register(user.NewRemoveCommand())
+	r.Register(user.NewWhoAmICommand())
 
 	// Manage cached images
 	r.Register(cachedimages.NewRemoveCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -563,6 +563,7 @@ var commandNames = []string{
 	"upgrade-juju",
 	"users",
 	"version",
+	"whoami",
 }
 
 // devFeatures are feature flags that impact registration of commands.

--- a/cmd/juju/common/model.go
+++ b/cmd/juju/common/model.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/juju/errors"
@@ -86,4 +87,20 @@ func ModelUserInfoFromParams(users []params.ModelUserInfo, now time.Time) map[st
 		output[names.NewUserTag(info.UserName).Canonical()] = outInfo
 	}
 	return output
+}
+
+// OwnerQualifiedModelName returns the model name qualified with the
+// model owner if the owner is not the same as the given canonical
+// user name. If the owner is a local user, we omit the domain.
+func OwnerQualifiedModelName(modelName string, owner, user names.UserTag) string {
+	if owner.Canonical() == user.Canonical() {
+		return modelName
+	}
+	var ownerName string
+	if owner.IsLocal() {
+		ownerName = owner.Name()
+	} else {
+		ownerName = owner.Canonical()
+	}
+	return fmt.Sprintf("%s/%s", ownerName, modelName)
 }

--- a/cmd/juju/controller/listcontrollersconverters.go
+++ b/cmd/juju/controller/listcontrollersconverters.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -80,7 +81,7 @@ func (c *listControllersCommand) convertControllerDetails(storeControllers map[s
 				// model name relative to that user.
 				if unqualifiedModelName, owner, err := jujuclient.SplitModelName(modelName); err == nil {
 					user := names.NewUserTag(userName)
-					modelName = ownerQualifiedModelName(unqualifiedModelName, owner, user)
+					modelName = common.OwnerQualifiedModelName(unqualifiedModelName, owner, user)
 				}
 			}
 		}

--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -175,7 +175,7 @@ func (c *modelsCommand) Run(ctx *cmd.Context) error {
 		userForListing := names.NewUserTag(c.user)
 		unqualifiedModelName, owner, err := jujuclient.SplitModelName(current)
 		if err == nil {
-			modelSet.CurrentModel = ownerQualifiedModelName(
+			modelSet.CurrentModel = common.OwnerQualifiedModelName(
 				unqualifiedModelName, owner, userForListing,
 			)
 		}
@@ -274,7 +274,7 @@ func (c *modelsCommand) formatTabular(writer io.Writer, value interface{}) error
 	fmt.Fprint(tw, "\tOWNER\tSTATUS\tACCESS\tLAST CONNECTION\n")
 	for _, model := range modelSet.Models {
 		owner := names.NewUserTag(model.Owner)
-		name := ownerQualifiedModelName(model.Name, owner, userForListing)
+		name := common.OwnerQualifiedModelName(model.Name, owner, userForListing)
 		if jujuclient.JoinOwnerModelName(owner, model.Name) == modelSet.CurrentModelQualified {
 			name += "*"
 			output.CurrentHighlight.Fprintf(tw, "%s", name)
@@ -297,20 +297,4 @@ func (c *modelsCommand) formatTabular(writer io.Writer, value interface{}) error
 	}
 	tw.Flush()
 	return nil
-}
-
-// ownerQualifiedModelName returns the model name qualified with the
-// model owner if the owner is not the same as the given canonical
-// user name. If the owner is a local user, we omit the domain.
-func ownerQualifiedModelName(modelName string, owner, user names.UserTag) string {
-	if owner.Canonical() == user.Canonical() {
-		return modelName
-	}
-	var ownerName string
-	if owner.IsLocal() {
-		ownerName = owner.Name()
-	} else {
-		ownerName = owner.Canonical()
-	}
-	return fmt.Sprintf("%s/%s", ownerName, modelName)
 }

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 )
@@ -247,7 +248,7 @@ one of them:
 				continue
 			}
 			owner := names.NewUserTag(model.Owner)
-			modelName := ownerQualifiedModelName(model.Name, owner, user)
+			modelName := common.OwnerQualifiedModelName(model.Name, owner, user)
 			otherModelNames.Add(modelName)
 		}
 		for _, modelName := range ownerModelNames.SortedValues() {

--- a/cmd/juju/user/export_test.go
+++ b/cmd/juju/user/export_test.go
@@ -103,3 +103,9 @@ func NewListCommandForTest(api UserInfoAPI, store jujuclient.ClientStore) cmd.Co
 	c.SetClientStore(store)
 	return modelcmd.WrapController(c)
 }
+
+// NewWhoAmICommandForTest returns a whoAMI command with a mock store.
+func NewWhoAmICommandForTest(store jujuclient.ClientStore) cmd.Command {
+	c := &whoAmICommand{store: store}
+	return c
+}

--- a/cmd/juju/user/whoami.go
+++ b/cmd/juju/user/whoami.go
@@ -1,0 +1,126 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package user
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/jujuclient"
+)
+
+var whoAmIDetails = `
+Display the current controller, model and logged in user name. 
+
+Examples:
+    juju whoami
+
+See also:
+    juju login
+    juju logout
+    juju list-controllers
+    juju list-models
+    juju list-users`[1:]
+
+// NewWhoAmICommand returns a command to print login details.
+func NewWhoAmICommand() cmd.Command {
+	cmd := &whoAmICommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+	return modelcmd.WrapBase(cmd)
+}
+
+// Info implements Command.Info
+func (c *whoAmICommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "whoami",
+		Purpose: "Print current login details",
+		Doc:     whoAmIDetails,
+	}
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *whoAmICommand) SetFlags(f *gnuflag.FlagSet) {
+	c.JujuCommandBase.SetFlags(f)
+	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
+		"yaml":    cmd.FormatYaml,
+		"json":    cmd.FormatJson,
+		"tabular": formatWhoAmITabular,
+	})
+}
+
+type whoAmI struct {
+	ControllerName string `yaml:"controller" json:"controller"`
+	ModelName      string `yaml:"model,omitempty" json:"model,omitempty"`
+	UserName       string `yaml:"user" json:"user"`
+}
+
+func formatWhoAmITabular(writer io.Writer, value interface{}) error {
+	details, ok := value.(whoAmI)
+	if !ok {
+		return errors.Errorf("expected value of type %T, got %T", details, value)
+	}
+	tw := output.TabWriter(writer)
+	fmt.Fprintf(tw, "Controller:\t%s\n", details.ControllerName)
+	modelName := details.ModelName
+	if modelName == "" {
+		modelName = "<no-current-model>"
+	}
+	fmt.Fprintf(tw, "Model:\t%s\n", modelName)
+	fmt.Fprintf(tw, "User:\t%s", details.UserName)
+	return tw.Flush()
+}
+
+// Run implements Command.Run
+func (c *whoAmICommand) Run(ctx *cmd.Context) error {
+	controllerName, err := c.store.CurrentController()
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	if err != nil {
+		fmt.Fprintln(ctx.Stderr, "There is no current controller.\nRun juju list-controllers to see available controllers.")
+		return nil
+	}
+	modelName, err := c.store.CurrentModel(controllerName)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	userDetails, err := c.store.AccountDetails(controllerName)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	if err != nil {
+		fmt.Fprintf(ctx.Stderr, "You are not logged in to controller %q and model %q.\nRun juju login if you want to login.\n", controllerName, modelName)
+		return nil
+	}
+	// Only qualify model name if there is a current model.
+	if modelName != "" {
+		if unqualifiedModelName, owner, err := jujuclient.SplitModelName(modelName); err == nil {
+			user := names.NewUserTag(userDetails.User)
+			modelName = common.OwnerQualifiedModelName(unqualifiedModelName, owner, user)
+		}
+	}
+
+	result := whoAmI{
+		ControllerName: controllerName,
+		ModelName:      modelName,
+		UserName:       userDetails.User,
+	}
+	return c.out.Write(ctx, result)
+}
+
+type whoAmICommand struct {
+	modelcmd.JujuCommandBase
+
+	out   cmd.Output
+	store jujuclient.ClientStore
+}

--- a/cmd/juju/user/whoami_test.go
+++ b/cmd/juju/user/whoami_test.go
@@ -1,0 +1,189 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package user_test
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/user"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/testing"
+)
+
+type WhoAmITestSuite struct {
+	testing.BaseSuite
+	store          jujuclient.ClientStore
+	expectedOutput string
+	expectedErr    string
+}
+
+var _ = gc.Suite(&WhoAmITestSuite{})
+
+func (s *WhoAmITestSuite) TestEmptyStore(c *gc.C) {
+	s.expectedOutput = `
+There is no current controller.
+Run juju list-controllers to see available controllers.
+`[1:]
+
+	s.store = jujuclienttesting.NewMemStore()
+	s.assertWhoAmI(c)
+}
+
+func (s *WhoAmITestSuite) TestNoCurrentController(c *gc.C) {
+	s.expectedOutput = `
+There is no current controller.
+Run juju list-controllers to see available controllers.
+`[1:]
+
+	s.store = &jujuclienttesting.MemStore{
+		Controllers: map[string]jujuclient.ControllerDetails{
+			"controller": {},
+		},
+	}
+	s.assertWhoAmI(c)
+}
+
+func (s *WhoAmITestSuite) TestNoCurrentModel(c *gc.C) {
+	s.expectedOutput = `
+Controller:  controller
+Model:       <no-current-model>
+User:        admin@local
+`[1:]
+
+	s.store = &jujuclienttesting.MemStore{
+		CurrentControllerName: "controller",
+		Controllers: map[string]jujuclient.ControllerDetails{
+			"controller": {},
+		},
+		Models: map[string]*jujuclient.ControllerModels{
+			"controller": {
+				Models: map[string]jujuclient.ModelDetails{
+					"admin@local/model": {"model-uuid"},
+				},
+			},
+		},
+		Accounts: map[string]jujuclient.AccountDetails{
+			"controller": {
+				User: "admin@local",
+			},
+		},
+	}
+	s.assertWhoAmI(c)
+}
+
+func (s *WhoAmITestSuite) TestNoCurrentUser(c *gc.C) {
+	s.expectedOutput = `
+You are not logged in to controller "controller" and model "admin@local/model".
+Run juju login if you want to login.
+`[1:]
+
+	s.store = &jujuclienttesting.MemStore{
+		CurrentControllerName: "controller",
+		Controllers: map[string]jujuclient.ControllerDetails{
+			"controller": {},
+		},
+		Models: map[string]*jujuclient.ControllerModels{
+			"controller": {
+				Models: map[string]jujuclient.ModelDetails{
+					"admin@local/model": {"model-uuid"},
+				},
+				CurrentModel: "admin@local/model",
+			},
+		},
+	}
+	s.assertWhoAmI(c)
+}
+
+func (s *WhoAmITestSuite) assertWhoAmIForUser(c *gc.C, user, format string) {
+	s.store = &jujuclienttesting.MemStore{
+		CurrentControllerName: "controller",
+		Controllers: map[string]jujuclient.ControllerDetails{
+			"controller": {},
+		},
+		Models: map[string]*jujuclient.ControllerModels{
+			"controller": {
+				Models: map[string]jujuclient.ModelDetails{
+					"admin@local/model": {"model-uuid"},
+				},
+				CurrentModel: "admin@local/model",
+			},
+		},
+		Accounts: map[string]jujuclient.AccountDetails{
+			"controller": {
+				User: user,
+			},
+		},
+	}
+	s.assertWhoAmI(c, "--format", format)
+}
+
+func (s *WhoAmITestSuite) TestWhoAmISameUser(c *gc.C) {
+	s.expectedOutput = `
+Controller:  controller
+Model:       model
+User:        admin@local
+`[1:]
+	s.assertWhoAmIForUser(c, "admin@local", "tabular")
+}
+
+func (s *WhoAmITestSuite) TestWhoAmIYaml(c *gc.C) {
+	s.expectedOutput = `
+controller: controller
+model: model
+user: admin@local
+`[1:]
+	s.assertWhoAmIForUser(c, "admin@local", "yaml")
+}
+
+func (s *WhoAmITestSuite) TestWhoAmIJson(c *gc.C) {
+	s.expectedOutput = `
+{"controller":"controller","model":"model","user":"admin@local"}
+`[1:]
+	s.assertWhoAmIForUser(c, "admin@local", "json")
+}
+
+func (s *WhoAmITestSuite) TestWhoAmIDifferentUsersModel(c *gc.C) {
+	s.expectedOutput = `
+Controller:  controller
+Model:       admin/model
+User:        bob@local
+`[1:]
+	s.assertWhoAmIForUser(c, "bob@local", "tabular")
+}
+
+func (s *WhoAmITestSuite) TestFromStoreErr(c *gc.C) {
+	msg := "fail getting current controller"
+	errStore := jujuclienttesting.NewStubStore()
+	errStore.SetErrors(errors.New(msg))
+	s.store = errStore
+	s.expectedErr = msg
+	s.assertWhoAmIFailed(c)
+	errStore.CheckCallNames(c, "CurrentController")
+}
+
+func (s *WhoAmITestSuite) runWhoAmI(c *gc.C, args ...string) (*cmd.Context, error) {
+	return testing.RunCommand(c, user.NewWhoAmICommandForTest(s.store), args...)
+}
+
+func (s *WhoAmITestSuite) assertWhoAmIFailed(c *gc.C, args ...string) {
+	_, err := s.runWhoAmI(c, args...)
+	c.Assert(err, gc.ErrorMatches, s.expectedErr)
+}
+
+func (s *WhoAmITestSuite) assertWhoAmI(c *gc.C, args ...string) string {
+	context, err := s.runWhoAmI(c, args...)
+	c.Assert(err, jc.ErrorIsNil)
+	output := testing.Stdout(context)
+	if output == "" {
+		output = testing.Stderr(context)
+	}
+	if s.expectedOutput != "" {
+		c.Assert(output, gc.Equals, s.expectedOutput)
+	}
+	return output
+}


### PR DESCRIPTION
juju whoami prints the current logged in controller, model, user (if any).
Part of the implementation moved OwnerQualifiedModelName() to a common package so it can be reused.

(Review request: http://reviews.vapour.ws/r/5493/)