### PR TITLE
Add some extra CLI output when bootstrapping and upgrading

### DIFF
--- a/cloudconfig/cloudinit/cloudinit_centos.go
+++ b/cloudconfig/cloudinit/cloudinit_centos.go
@@ -178,8 +178,10 @@ func (cfg *centOSCloudConfig) getCommandsForAddingPackages() ([]string, error) {
 
 	pkgs := cfg.Packages()
 	for _, pkg := range pkgs {
-		cmds = append(cmds, LogProgressCmd("Installing package: %s", pkg))
 		cmds = append(cmds, "package_manager_loop "+cfg.paccmder.InstallCmd(pkg))
+	}
+	if len(cmds) > 0 {
+		cmds = append([]string{LogProgressCmd(fmt.Sprintf("Installing %s", strings.Join(pkgs, ", ")))}, cmds...)
 	}
 	return cmds, nil
 }

--- a/cloudconfig/cloudinit/cloudinit_ubuntu.go
+++ b/cloudconfig/cloudinit/cloudinit_ubuntu.go
@@ -198,6 +198,7 @@ func (cfg *ubuntuCloudConfig) getCommandsForAddingPackages() ([]string, error) {
 
 	var pkgsWithTargetRelease []string
 	pkgs := cfg.Packages()
+	var pkgNames []string = make([]string, len(pkgs))
 	for i, _ := range pkgs {
 		pack := pkgs[i]
 		if pack == "--target-release" || len(pkgsWithTargetRelease) > 0 {
@@ -223,12 +224,13 @@ func (cfg *ubuntuCloudConfig) getCommandsForAddingPackages() ([]string, error) {
 			pkgsWithTargetRelease = []string{}
 		}
 
-		cmds = append(cmds, LogProgressCmd("Installing package: %s", packageName))
+		pkgNames[i] = packageName
 		cmd := looper + cfg.paccmder.InstallCmd(installArgs...)
 		cmds = append(cmds, cmd)
 	}
 
 	if len(cmds) > 0 {
+		cmds = append([]string{LogProgressCmd(fmt.Sprintf("Installing %s", strings.Join(pkgNames, ", ")))}, cmds...)
 		// setting DEBIAN_FRONTEND=noninteractive prevents debconf
 		// from prompting, always taking default values instead.
 		cmds = append([]string{"export DEBIAN_FRONTEND=noninteractive"}, cmds...)

--- a/cloudconfig/userdatacfg.go
+++ b/cloudconfig/userdatacfg.go
@@ -127,7 +127,7 @@ func (c *baseConfigure) addMachineAgentToBoot() error {
 		return err
 	}
 	if targetOS != os.Windows {
-		c.conf.AddRunCmd(cloudinit.LogProgressCmd("Starting Juju machine agent (%s)", svcName))
+		c.conf.AddRunCmd(cloudinit.LogProgressCmd("Starting Juju machine agent (service %s)", svcName))
 	}
 	c.conf.AddScripts(cmds...)
 	return nil

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -338,7 +338,7 @@ mkdir -p /var/log/juju
 chown syslog:adm /var/log/juju
 bin='/var/lib/juju/tools/1\.2\.3-precise-amd64'
 mkdir -p \$bin
-echo 'Fetching tools.*
+echo 'Fetching agent.*
 curl .* '.*' --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/juju1\.2\.3-precise-amd64\.tgz'
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-precise-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-precise-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
@@ -349,10 +349,10 @@ cat > '/var/lib/juju/agents/machine-0/agent\.conf' << 'EOF'\\n.*\\nEOF
 chmod 0600 '/var/lib/juju/agents/machine-0/agent\.conf'
 install -D -m 600 /dev/null '/var/lib/juju/bootstrap-params'
 printf '%s\\n' '.*' > '/var/lib/juju/bootstrap-params'
-echo 'Bootstrapping Juju machine agent'.*
+echo 'Installing Juju machine agent'.*
 /var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --timeout 10m0s --data-dir '/var/lib/juju' --debug '/var/lib/juju/bootstrap-params'
 ln -s 1\.2\.3-precise-amd64 '/var/lib/juju/tools/machine-0'
-echo 'Starting Juju machine agent \(jujud-machine-0\)'.*
+echo 'Starting Juju machine agent \(service jujud-machine-0\)'.*
 cat > /etc/init/jujud-machine-0\.conf << 'EOF'\\ndescription "juju agent for machine-0"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-0\.log\\n  chown syslog:syslog /var/log/juju/machine-0\.log\\n  chmod 0600 /var/log/juju/machine-0\.log\\n\\n  exec '/var/lib/juju/tools/machine-0/jujud' machine --data-dir '/var/lib/juju' --machine-id 0 --debug >> /var/log/juju/machine-0\.log 2>&1\\nend script\\nEOF\\n
 start jujud-machine-0
 rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-precise-amd64\.sha256
@@ -397,7 +397,7 @@ mkdir -p /var/log/juju
 chown syslog:adm /var/log/juju
 bin='/var/lib/juju/tools/1\.2\.3-quantal-amd64'
 mkdir -p \$bin
-echo 'Fetching tools.*
+echo 'Fetching agent.*
 curl .* --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-quantal-amd64'
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-quantal-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-quantal-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
@@ -407,7 +407,7 @@ mkdir -p '/var/lib/juju/agents/machine-99'
 cat > '/var/lib/juju/agents/machine-99/agent\.conf' << 'EOF'\\n.*\\nEOF
 chmod 0600 '/var/lib/juju/agents/machine-99/agent\.conf'
 ln -s 1\.2\.3-quantal-amd64 '/var/lib/juju/tools/machine-99'
-echo 'Starting Juju machine agent \(jujud-machine-99\)'.*
+echo 'Starting Juju machine agent \(service jujud-machine-99\)'.*
 cat > /etc/init/jujud-machine-99\.conf << 'EOF'\\ndescription "juju agent for machine-99"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-99\.log\\n  chown syslog:syslog /var/log/juju/machine-99\.log\\n  chmod 0600 /var/log/juju/machine-99\.log\\n\\n  exec '/var/lib/juju/tools/machine-99/jujud' machine --data-dir '/var/lib/juju' --machine-id 99 --debug >> /var/log/juju/machine-99\.log 2>&1\\nend script\\nEOF\\n
 start jujud-machine-99
 rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-quantal-amd64\.sha256

--- a/cmd/juju/backups/export_test.go
+++ b/cmd/juju/backups/export_test.go
@@ -81,7 +81,7 @@ func NewRestoreCommandForTest(
 		newAPIClientFunc: func() (RestoreAPI, error) {
 			return api, nil
 		},
-		waitForAgentFunc: func(ctx *cmd.Context, c *modelcmd.ModelCommandBase, controllerName string) error {
+		waitForAgentFunc: func(ctx *cmd.Context, c *modelcmd.ModelCommandBase, controllerName, hostedModelName string) error {
 			return nil
 		},
 	}

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -58,7 +58,7 @@ type restoreCommand struct {
 	newEnvironFunc           func(environs.OpenParams) (environs.Environ, error)
 	getRebootstrapParamsFunc func(string, *params.BackupsMetadataResult) (*restoreBootstrapParams, error)
 	getArchiveFunc           func(string) (ArchiveReader, *params.BackupsMetadataResult, error)
-	waitForAgentFunc         func(ctx *cmd.Context, c *modelcmd.ModelCommandBase, controllerName string) error
+	waitForAgentFunc         func(ctx *cmd.Context, c *modelcmd.ModelCommandBase, controllerName, hostedModelName string) error
 }
 
 // RestoreAPI is used to invoke various API calls.
@@ -346,7 +346,7 @@ func (c *restoreCommand) rebootstrap(ctx *cmd.Context, meta *params.BackupsMetad
 	// To avoid race conditions when running scripted bootstraps, wait
 	// for the controller's machine agent to be ready to accept commands
 	// before exiting this bootstrap command.
-	return c.waitForAgentFunc(ctx, &c.ModelCommandBase, c.ControllerName())
+	return c.waitForAgentFunc(ctx, &c.ModelCommandBase, c.ControllerName(), "default")
 }
 
 func (c *restoreCommand) newClient() (*backups.Client, error) {

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -746,7 +746,7 @@ See `[1:] + "`juju kill-controller`" + `.`)
 	// To avoid race conditions when running scripted bootstraps, wait
 	// for the controller's machine agent to be ready to accept commands
 	// before exiting this bootstrap command.
-	return waitForAgentInitialisation(ctx, &c.ModelCommandBase, c.controllerName)
+	return waitForAgentInitialisation(ctx, &c.ModelCommandBase, c.controllerName, c.hostedModelName)
 }
 
 // runInteractive queries the user about bootstrap config interactively at the

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -99,7 +99,7 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 	expectedNumber.Build = 1235
 	s.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(c, &expectedNumber))
 
-	s.PatchValue(&waitForAgentInitialisation, func(*cmd.Context, *modelcmd.ModelCommandBase, string) error {
+	s.PatchValue(&waitForAgentInitialisation, func(*cmd.Context, *modelcmd.ModelCommandBase, string, string) error {
 		return nil
 	})
 
@@ -911,10 +911,11 @@ func (s *BootstrapSuite) TestMissingToolsUploadFailedError(c *gc.C) {
 		"--auto-upgrade", "--agent-version=1.7.3",
 	)
 
-	c.Check(coretesting.Stderr(ctx), gc.Equals, fmt.Sprintf(`
+	c.Check(coretesting.Stderr(ctx), gc.Equals, `
 Creating Juju controller "devcontroller" on dummy-cloud/region-1
-Bootstrapping model %q
-`[1:], bootstrap.ControllerModelName))
+Looking for packaged Juju agent binaries
+Preparing local Juju agent binary
+`[1:])
 	c.Check(err, gc.ErrorMatches, "failed to bootstrap model: cannot package bootstrap agent binary: an error")
 }
 
@@ -1305,7 +1306,7 @@ func (s *BootstrapSuite) TestBootstrapSetsControllerOnBase(c *gc.C) {
 
 	// Record the controller name seen by ModelCommandBase at the end of bootstrap.
 	var seenControllerName string
-	s.PatchValue(&waitForAgentInitialisation, func(_ *cmd.Context, base *modelcmd.ModelCommandBase, _ string) error {
+	s.PatchValue(&waitForAgentInitialisation, func(_ *cmd.Context, base *modelcmd.ModelCommandBase, _, _ string) error {
 		seenControllerName = base.ControllerName()
 		return nil
 	})

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -565,11 +565,7 @@ func (s *UpgradeJujuSuite) TestUpgradeDryRun(c *gc.C) {
 			tools:          []string{"2.1.0-quantal-amd64", "2.1.2-quantal-i386", "2.1.3-quantal-amd64", "2.1-dev1-quantal-amd64", "2.2.3-quantal-amd64"},
 			currentVersion: "2.1.3-quantal-amd64",
 			agentVersion:   "2.0.0",
-			expectedCmdOutput: `available tools:
-    2.1.3-quantal-amd64
-best version:
-    2.1.3
-upgrade to this version by running
+			expectedCmdOutput: `upgrade to this version by running
     juju upgrade-juju --version="2.1.3"
 `,
 		},
@@ -579,15 +575,7 @@ upgrade to this version by running
 			tools:          []string{"2.1.0-quantal-amd64", "2.1.2-quantal-i386", "2.1.3-quantal-amd64", "2.1-dev1-quantal-amd64", "2.2.3-quantal-amd64"},
 			currentVersion: "2.0.0-quantal-amd64",
 			agentVersion:   "2.0.0",
-			expectedCmdOutput: `available tools:
-    2.1-dev1-quantal-amd64
-    2.1.0-quantal-amd64
-    2.1.2-quantal-i386
-    2.1.3-quantal-amd64
-    2.2.3-quantal-amd64
-best version:
-    2.1.3
-upgrade to this version by running
+			expectedCmdOutput: `upgrade to this version by running
     juju upgrade-juju --version="2.1.3"
 `,
 		},
@@ -597,13 +585,7 @@ upgrade to this version by running
 			tools:          []string{"2.1.0-quantal-amd64", "2.1.2-quantal-i386", "2.1.3-quantal-amd64", "1.2.3-myawesomeseries-amd64"},
 			currentVersion: "2.0.0-quantal-amd64",
 			agentVersion:   "2.0.0",
-			expectedCmdOutput: `available tools:
-    2.1.0-quantal-amd64
-    2.1.2-quantal-i386
-    2.1.3-quantal-amd64
-best version:
-    2.1.3
-upgrade to this version by running
+			expectedCmdOutput: `upgrade to this version by running
     juju upgrade-juju --version="2.1.3"
 `,
 		},
@@ -664,11 +646,6 @@ func (s *UpgradeJujuSuite) setUpEnvAndTools(c *gc.C, currentVersion string, agen
 }
 
 func (s *UpgradeJujuSuite) TestUpgradesDifferentMajor(c *gc.C) {
-	toolsList49Only := `available tools:
-    4.9.0-trusty-amd64
-best version:
-    4.9.0
-`
 	tests := []struct {
 		about             string
 		cmdArgs           []string
@@ -682,30 +659,24 @@ best version:
 		expectedErr       string
 		upgradeMap        map[int]version.Number
 	}{{
-		about:             "upgrade previous major to latest previous major",
-		tools:             []string{"5.0.1-trusty-amd64", "4.9.0-trusty-amd64"},
-		currentVersion:    "5.0.0-trusty-amd64",
-		agentVersion:      "4.8.5",
-		expectedVersion:   "4.9.0",
-		expectedCmdOutput: toolsList49Only,
-		expectedLogOutput: `.*version 4.9.0 incompatible with this client \(5.0.0\).*started upgrade to 4.9.0.*`,
+		about:           "upgrade previous major to latest previous major",
+		tools:           []string{"5.0.1-trusty-amd64", "4.9.0-trusty-amd64"},
+		currentVersion:  "5.0.0-trusty-amd64",
+		agentVersion:    "4.8.5",
+		expectedVersion: "4.9.0",
 	}, {
-		about:             "upgrade previous major to latest previous major --dry-run still warns",
-		tools:             []string{"5.0.1-trusty-amd64", "4.9.0-trusty-amd64"},
-		currentVersion:    "5.0.1-trusty-amd64",
-		agentVersion:      "4.8.5",
-		expectedVersion:   "4.9.0",
-		expectedCmdOutput: toolsList49Only,
-		expectedLogOutput: `.*version 4.9.0 incompatible with this client \(5.0.1\).*started upgrade to 4.9.0.*`,
+		about:           "upgrade previous major to latest previous major --dry-run still warns",
+		tools:           []string{"5.0.1-trusty-amd64", "4.9.0-trusty-amd64"},
+		currentVersion:  "5.0.1-trusty-amd64",
+		agentVersion:    "4.8.5",
+		expectedVersion: "4.9.0",
 	}, {
-		about:             "upgrade previous major to latest previous major with --version",
-		cmdArgs:           []string{"--version=4.9.0"},
-		tools:             []string{"5.0.2-trusty-amd64", "4.9.0-trusty-amd64", "4.8.0-trusty-amd64"},
-		currentVersion:    "5.0.2-trusty-amd64",
-		agentVersion:      "4.7.5",
-		expectedVersion:   "4.9.0",
-		expectedCmdOutput: toolsList49Only,
-		expectedLogOutput: `.*version 4.9.0 incompatible with this client \(5.0.2\).*started upgrade to 4.9.0.*`,
+		about:           "upgrade previous major to latest previous major with --version",
+		cmdArgs:         []string{"--version=4.9.0"},
+		tools:           []string{"5.0.2-trusty-amd64", "4.9.0-trusty-amd64", "4.8.0-trusty-amd64"},
+		currentVersion:  "5.0.2-trusty-amd64",
+		agentVersion:    "4.7.5",
+		expectedVersion: "4.9.0",
 	}, {
 		about:             "can upgrade lower major version to current major version at minimum level",
 		cmdArgs:           []string{"--version=6.0.5"},

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"fmt"
 	"io"
 	"strings"
 	"time"
@@ -17,6 +18,7 @@ import (
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/jujuclient"
@@ -87,7 +89,7 @@ func tryAPI(c *modelcmd.ModelCommandBase) error {
 // WaitForAgentInitialisation polls the bootstrapped controller with a read-only
 // command which will fail until the controller is fully initialised.
 // TODO(wallyworld) - add a bespoke command to maybe the admin facade for this purpose.
-func WaitForAgentInitialisation(ctx *cmd.Context, c *modelcmd.ModelCommandBase, controllerName string) error {
+func WaitForAgentInitialisation(ctx *cmd.Context, c *modelcmd.ModelCommandBase, controllerName, hostedModelName string) error {
 	// TODO(katco): 2016-08-09: lp:1611427
 	attempts := utils.AttemptStrategy{
 		Min:   bootstrapReadyPollCount,
@@ -98,11 +100,24 @@ func WaitForAgentInitialisation(ctx *cmd.Context, c *modelcmd.ModelCommandBase, 
 		err         error
 	)
 
+	// Make a best effort to find the new controller address so we can print it.
+	addressInfo := ""
+	controller, err := c.ClientStore().ControllerByName(controllerName)
+	if err == nil && len(controller.APIEndpoints) > 0 {
+		addr, err := network.ParseHostPort(controller.APIEndpoints[0])
+		if err == nil {
+			addressInfo = fmt.Sprintf(" at %s", addr.Address.Value)
+		}
+	}
+
+	ctx.Infof("Contacting Juju controller%s to verify accessibility...", addressInfo)
 	apiAttempts = 1
 	for attempt := attempts.Start(); attempt.Next(); apiAttempts++ {
 		err = tryAPI(c)
 		if err == nil {
-			ctx.Infof("Bootstrap complete, %s now available.", controllerName)
+			ctx.Infof("Bootstrap complete, %q controller now available.", controllerName)
+			ctx.Infof("Controller machines are in the %q model.", bootstrap.ControllerModelName)
+			ctx.Infof("Initial model %q added.", hostedModelName)
 			break
 		}
 		// As the API server is coming up, it goes through a number of steps.
@@ -120,10 +135,10 @@ func WaitForAgentInitialisation(ctx *cmd.Context, c *modelcmd.ModelCommandBase, 
 			strings.HasSuffix(errorMessage, "connection is shut down"),
 			strings.HasSuffix(errorMessage, "no api connection available"),
 			strings.Contains(errorMessage, "spaces are still being discovered"):
-			ctx.Infof("Waiting for API to become available")
+			ctx.Verbosef("Still waiting for API to become available")
 			continue
 		case params.ErrCode(err) == params.CodeUpgradeInProgress:
-			ctx.Infof("Waiting for API to become available: %v", err)
+			ctx.Verbosef("Still waiting for API to become available: %v", err)
 			continue
 		}
 		break

--- a/cmd/juju/common/controller_test.go
+++ b/cmd/juju/common/controller_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 	cmdtesting "github.com/juju/juju/cmd/testing"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
@@ -93,7 +94,9 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyRetries(c *gc.C) {
 	} {
 		s.mockBlockClient.numRetries = t.numRetries
 		s.mockBlockClient.retryCount = 0
-		err := WaitForAgentInitialisation(cmdtesting.NullContext(c), nil, "controller")
+		cmd := &modelcmd.ModelCommandBase{}
+		cmd.SetClientStore(jujuclienttesting.NewMemStore())
+		err := WaitForAgentInitialisation(cmdtesting.NullContext(c), cmd, "controller", "default")
 		c.Check(errors.Cause(err), gc.DeepEquals, t.err)
 		expectedRetries := t.numRetries
 		if t.numRetries <= 0 {
@@ -109,7 +112,9 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyRetries(c *gc.C) {
 
 func (s *controllerSuite) TestWaitForAgentAPIReadyWaitsForSpaceDiscovery(c *gc.C) {
 	s.mockBlockClient.discoveringSpacesError = 2
-	err := WaitForAgentInitialisation(cmdtesting.NullContext(c), nil, "controller")
+	cmd := &modelcmd.ModelCommandBase{}
+	cmd.SetClientStore(jujuclienttesting.NewMemStore())
+	err := WaitForAgentInitialisation(cmdtesting.NullContext(c), cmd, "controller", "default")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.mockBlockClient.discoveringSpacesError, gc.Equals, 0)
 }
@@ -118,7 +123,9 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyRetriesWithOpenEOFErr(c *gc.C)
 	s.mockBlockClient.numRetries = 0
 	s.mockBlockClient.retryCount = 0
 	s.mockBlockClient.loginError = io.EOF
-	err := WaitForAgentInitialisation(cmdtesting.NullContext(c), nil, "controller")
+	cmd := &modelcmd.ModelCommandBase{}
+	cmd.SetClientStore(jujuclienttesting.NewMemStore())
+	err := WaitForAgentInitialisation(cmdtesting.NullContext(c), cmd, "controller", "default")
 	c.Check(err, jc.ErrorIsNil)
 
 	c.Check(s.mockBlockClient.retryCount, gc.Equals, 1)
@@ -128,7 +135,9 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyStopsRetriesWithOpenErr(c *gc.
 	s.mockBlockClient.numRetries = 0
 	s.mockBlockClient.retryCount = 0
 	s.mockBlockClient.loginError = errors.NewUnauthorized(nil, "")
-	err := WaitForAgentInitialisation(cmdtesting.NullContext(c), nil, "controller")
+	cmd := &modelcmd.ModelCommandBase{}
+	cmd.SetClientStore(jujuclienttesting.NewMemStore())
+	err := WaitForAgentInitialisation(cmdtesting.NullContext(c), cmd, "controller", "default")
 	c.Check(err, jc.Satisfies, errors.IsUnauthorized)
 
 	c.Check(s.mockBlockClient.retryCount, gc.Equals, 0)

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -484,7 +484,7 @@ func (s *bootstrapSuite) TestBootstrapGUISuccessRemote(c *gc.C) {
 		GUIDataSourceBaseURL: "https://1.2.3.4/gui/sources",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(ctx), jc.Contains, "Preparing for Juju GUI 2.0.42 release installation\n")
+	c.Assert(coretesting.Stderr(ctx), jc.Contains, "Fetching Juju GUI 2.0.42\n")
 
 	// The most recent GUI release info has been stored.
 	c.Assert(env.instanceConfig.Bootstrap.GUI.URL, gc.Equals, "https://1.2.3.4/juju-gui-2.0.42.tar.bz2")
@@ -504,7 +504,7 @@ func (s *bootstrapSuite) TestBootstrapGUISuccessLocal(c *gc.C) {
 		CAPrivateKey:     coretesting.CAKey,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(ctx), jc.Contains, "Preparing for Juju GUI 2.2.0 installation from local archive\n")
+	c.Assert(coretesting.Stderr(ctx), jc.Contains, "Fetching Juju GUI 2.2.0 from local archive\n")
 
 	// Check GUI URL and version.
 	c.Assert(env.instanceConfig.Bootstrap.GUI.URL, gc.Equals, "file://"+path)


### PR DESCRIPTION
juju bootstrap and upgrade has had some extra CLI output added to make things clearer for the user. For bootstrap, some long running setup ops are prefaced by CLI output explaining what is happening. For upgrade, some log messages are converted to stdout text, and some info logs are changed to debug (end users don't need to know such detail and it gets in the way).

(Review request: http://reviews.vapour.ws/r/5494/)