### PR TITLE
Client-side facade for the machine undertaker API

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -46,6 +46,7 @@ var facadeVersions = map[string]int{
 	"Logger":                       1,
 	"MachineActions":               1,
 	"MachineManager":               2,
+	"MachineUndertaker":            1,
 	"Machiner":                     1,
 	"MeterStatus":                  1,
 	"MetricsAdder":                 2,

--- a/api/machineundertaker/package_test.go
+++ b/api/machineundertaker/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machineundertaker_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/api/machineundertaker/undertaker.go
+++ b/api/machineundertaker/undertaker.go
@@ -45,9 +45,12 @@ func (api *API) AllMachineRemovals() ([]names.MachineTag, error) {
 	if len(results.Results) != 1 {
 		return nil, errors.Errorf("expected one result, got %d", len(results.Results))
 	}
-	entities := results.Results[0].Entities
-	machines := make([]names.MachineTag, len(entities))
-	for i, entity := range entities {
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, errors.Trace(result.Error)
+	}
+	machines := make([]names.MachineTag, len(result.Entities))
+	for i, entity := range result.Entities {
 		tag, err := names.ParseMachineTag(entity.Tag)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/api/machineundertaker/undertaker.go
+++ b/api/machineundertaker/undertaker.go
@@ -1,0 +1,106 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machineundertaker
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api/base"
+	apiwatcher "github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/watcher"
+)
+
+// API provides access to the machine undertaker API facade.
+type API struct {
+	facade   base.FacadeCaller
+	modelTag names.ModelTag
+}
+
+// NewAPI creates a new client-side machine undertaker facade.
+func NewAPI(caller base.APICaller) (*API, error) {
+	modelTag, ok := caller.ModelTag()
+	if !ok {
+		return nil, errors.New("machine undertaker client requires a model API connection")
+	}
+	api := API{
+		facade:   base.NewFacadeCaller(caller, "MachineUndertaker"),
+		modelTag: modelTag,
+	}
+	return &api, nil
+}
+
+// AllMachineRemovals returns all the machines that have been marked
+// ready to clean up.
+func (api *API) AllMachineRemovals() ([]names.MachineTag, error) {
+	var results params.Entities
+	args := wrapEntities(api.modelTag)
+	err := api.facade.FacadeCall("AllMachineRemovals", &args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	machines := make([]names.MachineTag, len(results.Entities))
+	for i, entity := range results.Entities {
+		tag, err := names.ParseMachineTag(entity.Tag)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		machines[i] = tag
+	}
+	return machines, nil
+}
+
+// GetProviderInterfaceInfo gets the provider details for all of the
+// interfaces for one machine.
+func (api *API) GetProviderInterfaceInfo(machine names.MachineTag) ([]network.ProviderInterfaceInfo, error) {
+	var result params.ProviderInterfaceInfoResults
+	args := wrapEntities(machine)
+	err := api.facade.FacadeCall("GetMachineProviderInterfaceInfo", &args, &result)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(result.Results) != 1 {
+		return nil, errors.Errorf("expected one result, got %d", len(result.Results))
+	}
+	item := result.Results[0]
+	if item.MachineTag != machine.String() {
+		return nil, errors.Errorf("expected interface info for %s but got %s", machine, item.MachineTag)
+	}
+	infos := make([]network.ProviderInterfaceInfo, len(item.Interfaces))
+	for i, info := range item.Interfaces {
+		infos[i].InterfaceName = info.InterfaceName
+		infos[i].MACAddress = info.MACAddress
+		infos[i].ProviderId = network.Id(info.ProviderId)
+	}
+	return infos, nil
+}
+
+// CompleteRemoval finishes the removal of the machine in the database
+// after any provider resources are cleaned up.
+func (api *API) CompleteRemoval(machine names.MachineTag) error {
+	args := wrapEntities(machine)
+	return api.facade.FacadeCall("CompleteMachineRemovals", &args, nil)
+}
+
+// WatchMachineRemovals registers to be notified when a machine
+// removal is requested.
+func (api *API) WatchMachineRemovals() (watcher.NotifyWatcher, error) {
+	var result params.NotifyWatchResult
+	args := wrapEntities(api.modelTag)
+	err := api.facade.FacadeCall("WatchMachineRemovals", &args, &result)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := result.Error; err != nil {
+		return nil, errors.Trace(result.Error)
+	}
+	w := apiwatcher.NewNotifyWatcher(api.facade.RawAPICaller(), result)
+	return w, nil
+}
+
+func wrapEntities(tag names.Tag) params.Entities {
+	return params.Entities{Entities: []params.Entity{{Tag: tag.String()}}}
+}

--- a/api/machineundertaker/undertaker_test.go
+++ b/api/machineundertaker/undertaker_test.go
@@ -1,0 +1,336 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machineundertaker_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/machineundertaker"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/network"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker/workertest"
+)
+
+type undertakerSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&undertakerSuite{})
+
+func (s *undertakerSuite) TestRequiresModelConnection(c *gc.C) {
+	api, err := machineundertaker.NewAPI(&fakeAPICaller{hasModelTag: false})
+	c.Assert(err, gc.ErrorMatches, "machine undertaker client requires a model API connection")
+	c.Assert(api, gc.IsNil)
+	api, err = machineundertaker.NewAPI(&fakeAPICaller{hasModelTag: true})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(api, gc.NotNil)
+}
+
+func (s *undertakerSuite) TestAllMachineRemovals(c *gc.C) {
+	caller := func(facade string, version int, id, request string, arg, result interface{}) error {
+		c.Check(facade, gc.Equals, "MachineUndertaker")
+		c.Check(request, gc.Equals, "AllMachineRemovals")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(arg, gc.DeepEquals, wrapEntities(coretesting.ModelTag.String()))
+		c.Assert(result, gc.FitsTypeOf, &params.Entities{})
+		*result.(*params.Entities) = *wrapEntities("machine-23", "machine-42")
+		return nil
+	}
+	api := makeAPI(c, caller)
+	results, err := api.AllMachineRemovals()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, []names.MachineTag{
+		names.NewMachineTag("23"),
+		names.NewMachineTag("42"),
+	})
+}
+
+func (s *undertakerSuite) TestAllMachineRemovals_Error(c *gc.C) {
+	caller := func(facade string, version int, id, request string, arg, result interface{}) error {
+		return errors.New("restless year")
+	}
+	api := makeAPI(c, caller)
+	results, err := api.AllMachineRemovals()
+	c.Assert(err, gc.ErrorMatches, "restless year")
+	c.Assert(results, gc.IsNil)
+}
+
+func (s *undertakerSuite) TestAllMachineRemovals_BadTag(c *gc.C) {
+	caller := func(facade string, version int, id, request string, arg, result interface{}) error {
+		c.Assert(result, gc.FitsTypeOf, &params.Entities{})
+		*result.(*params.Entities) = *wrapEntities("machine-23", "application-burp")
+		return nil
+	}
+	api := makeAPI(c, caller)
+	results, err := api.AllMachineRemovals()
+	c.Assert(err, gc.ErrorMatches, `"application-burp" is not a valid machine tag`)
+	c.Assert(results, gc.IsNil)
+}
+
+func (*undertakerSuite) TestGetInfo(c *gc.C) {
+	caller := func(facade string, version int, id, request string, arg, result interface{}) error {
+		c.Check(facade, gc.Equals, "MachineUndertaker")
+		c.Check(request, gc.Equals, "GetMachineProviderInterfaceInfo")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(arg, gc.DeepEquals, wrapEntities("machine-100"))
+		c.Assert(result, gc.FitsTypeOf, &params.ProviderInterfaceInfoResults{})
+		*result.(*params.ProviderInterfaceInfoResults) = params.ProviderInterfaceInfoResults{
+			Results: []params.ProviderInterfaceInfoResult{{
+				MachineTag: "machine-100",
+				Interfaces: []params.ProviderInterfaceInfo{{
+					InterfaceName: "hamster huey",
+					MACAddress:    "calvin",
+					ProviderId:    "1234",
+				}, {
+					InterfaceName: "happy hamster hop",
+					MACAddress:    "hobbes",
+					ProviderId:    "1235",
+				}},
+			}},
+		}
+		return nil
+	}
+	api := makeAPI(c, caller)
+	results, err := api.GetProviderInterfaceInfo(names.NewMachineTag("100"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, []network.ProviderInterfaceInfo{{
+		InterfaceName: "hamster huey",
+		MACAddress:    "calvin",
+		ProviderId:    "1234",
+	}, {
+		InterfaceName: "happy hamster hop",
+		MACAddress:    "hobbes",
+		ProviderId:    "1235",
+	}})
+}
+
+func (*undertakerSuite) TestGetInfo_GenericError(c *gc.C) {
+	caller := func(facade string, version int, id, request string, arg, result interface{}) error {
+		return errors.New("gooey kablooey")
+	}
+	api := makeAPI(c, caller)
+	results, err := api.GetProviderInterfaceInfo(names.NewMachineTag("100"))
+	c.Assert(err, gc.ErrorMatches, "gooey kablooey")
+	c.Assert(results, gc.IsNil)
+}
+
+func (*undertakerSuite) TestGetInfo_TooMany(c *gc.C) {
+	caller := func(facade string, version int, id, request string, arg, result interface{}) error {
+		c.Assert(result, gc.FitsTypeOf, &params.ProviderInterfaceInfoResults{})
+		*result.(*params.ProviderInterfaceInfoResults) = params.ProviderInterfaceInfoResults{
+			Results: []params.ProviderInterfaceInfoResult{{
+				MachineTag: "machine-100",
+				Interfaces: []params.ProviderInterfaceInfo{{
+					InterfaceName: "hamster huey",
+					MACAddress:    "calvin",
+					ProviderId:    "1234",
+				}},
+			}, {
+				MachineTag: "machine-101",
+				Interfaces: []params.ProviderInterfaceInfo{{
+					InterfaceName: "hamster huey",
+					MACAddress:    "calvin",
+					ProviderId:    "1234",
+				}},
+			}},
+		}
+		return nil
+	}
+	api := makeAPI(c, caller)
+	results, err := api.GetProviderInterfaceInfo(names.NewMachineTag("100"))
+	c.Assert(err, gc.ErrorMatches, "expected one result, got 2")
+	c.Assert(results, gc.IsNil)
+}
+
+func (*undertakerSuite) TestGetInfo_BadMachine(c *gc.C) {
+	caller := func(facade string, version int, id, request string, arg, result interface{}) error {
+		c.Assert(result, gc.FitsTypeOf, &params.ProviderInterfaceInfoResults{})
+		*result.(*params.ProviderInterfaceInfoResults) = params.ProviderInterfaceInfoResults{
+			Results: []params.ProviderInterfaceInfoResult{{
+				MachineTag: "machine-101",
+				Interfaces: []params.ProviderInterfaceInfo{{
+					InterfaceName: "hamster huey",
+					MACAddress:    "calvin",
+					ProviderId:    "1234",
+				}},
+			}},
+		}
+		return nil
+	}
+	api := makeAPI(c, caller)
+	results, err := api.GetProviderInterfaceInfo(names.NewMachineTag("100"))
+	c.Assert(err, gc.ErrorMatches, "expected interface info for machine-100 but got machine-101")
+	c.Assert(results, gc.IsNil)
+}
+
+func (*undertakerSuite) TestCompleteRemoval(c *gc.C) {
+	caller := func(facade string, version int, id, request string, arg, result interface{}) error {
+		c.Check(facade, gc.Equals, "MachineUndertaker")
+		c.Check(request, gc.Equals, "CompleteMachineRemovals")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(arg, gc.DeepEquals, wrapEntities("machine-100"))
+		c.Check(result, gc.DeepEquals, nil)
+		return errors.New("gooey kablooey")
+	}
+	api := makeAPI(c, caller)
+	err := api.CompleteRemoval(names.NewMachineTag("100"))
+	c.Assert(err, gc.ErrorMatches, "gooey kablooey")
+}
+
+func (*undertakerSuite) TestWatchMachineRemovals_CallFailed(c *gc.C) {
+	caller := func(facade string, version int, id, request string, arg, result interface{}) error {
+		c.Check(facade, gc.Equals, "MachineUndertaker")
+		c.Check(request, gc.Equals, "WatchMachineRemovals")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(arg, gc.DeepEquals, wrapEntities(coretesting.ModelTag.String()))
+		return errors.New("oopsy")
+	}
+	api := makeAPI(c, caller)
+	w, err := api.WatchMachineRemovals()
+	c.Check(w, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "oopsy")
+}
+
+func (*undertakerSuite) TestWatchMachineRemovals_ErrorInWatcher(c *gc.C) {
+	caller := func(facade string, version int, id, request string, arg, result interface{}) error {
+		c.Assert(result, gc.FitsTypeOf, &params.NotifyWatchResult{})
+		*result.(*params.NotifyWatchResult) = params.NotifyWatchResult{
+			Error: &params.Error{Message: "blammo"},
+		}
+		return nil
+	}
+	api := makeAPI(c, caller)
+	w, err := api.WatchMachineRemovals()
+	c.Check(w, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "blammo")
+}
+
+func (*undertakerSuite) TestWatchMachineRemovals(c *gc.C) {
+	var watcherCalls int
+	notifyChan := make(chan struct{})
+	stopChan := make(chan struct{})
+	nextCountChan := make(chan int, 1000)
+
+	watcherCreate := func(id string, arg, result interface{}) error {
+		c.Check(id, gc.Equals, "")
+		c.Check(arg, gc.DeepEquals, wrapEntities(coretesting.ModelTag.String()))
+		c.Assert(result, gc.FitsTypeOf, &params.NotifyWatchResult{})
+		*result.(*params.NotifyWatchResult) = params.NotifyWatchResult{
+			NotifyWatcherId: "1001",
+		}
+		watcherCalls++
+		return nil
+	}
+
+	watcherNext := func(id string, arg, result interface{}) error {
+		c.Check(id, gc.Equals, "1001")
+		c.Check(arg, gc.IsNil)
+		select {
+		case <-time.After(coretesting.LongWait):
+			return errors.New("timed out trying to count next call")
+		case nextCountChan <- 1:
+		}
+
+		select {
+		case <-notifyChan:
+			return nil
+		case <-stopChan:
+			close(nextCountChan)
+			return &params.Error{Code: params.CodeStopped}
+		case <-time.After(coretesting.LongWait):
+			return errors.New("timed out waiting for notify")
+		}
+	}
+
+	watcherStop := func(id string, arg, result interface{}) error {
+		c.Check(id, gc.Equals, "1001")
+		c.Check(arg, gc.IsNil)
+		close(stopChan)
+		return nil
+	}
+
+	caller := func(facade string, version int, id, request string, arg, result interface{}) error {
+		c.Check(version, gc.Equals, 0)
+		switch {
+		case facade == "MachineUndertaker" && request == "WatchMachineRemovals":
+			return watcherCreate(id, arg, result)
+		case facade == "NotifyWatcher" && request == "Next":
+			return watcherNext(id, arg, result)
+		case facade == "NotifyWatcher" && request == "Stop":
+			return watcherStop(id, arg, result)
+		default:
+			c.Fatalf("unknown request - facade %s, request %s", facade, request)
+			return nil
+		}
+	}
+
+	api := makeAPI(c, caller)
+	w, err := api.WatchMachineRemovals()
+	c.Assert(err, jc.ErrorIsNil)
+	waitForOneSignal(c, w)
+
+	// Trigger another notify.
+	select {
+	case notifyChan <- struct{}{}:
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out sending notify")
+	}
+
+	waitForOneSignal(c, w)
+	workertest.CleanKill(c, w)
+
+	nextCount := 0
+	for i := range nextCountChan {
+		nextCount += i
+	}
+	c.Assert(nextCount, gc.Equals, 2)
+}
+
+func waitForOneSignal(c *gc.C, w watcher.NotifyWatcher) {
+	select {
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("expected notify didn't happen")
+	case <-w.Changes():
+	}
+}
+
+func makeAPI(c *gc.C, caller testing.APICallerFunc) *machineundertaker.API {
+	api, err := machineundertaker.NewAPI(caller)
+	c.Assert(err, jc.ErrorIsNil)
+	return api
+}
+
+func wrapEntities(tags ...string) *params.Entities {
+	results := make([]params.Entity, len(tags))
+	for i := range tags {
+		results[i].Tag = tags[i]
+	}
+	return &params.Entities{Entities: results}
+}
+
+type fakeAPICaller struct {
+	base.APICaller
+	hasModelTag bool
+}
+
+func (c *fakeAPICaller) ModelTag() (names.ModelTag, bool) {
+	return names.ModelTag{}, c.hasModelTag
+}
+
+func (c *fakeAPICaller) BestFacadeVersion(string) int {
+	return 0
+}

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -42,6 +42,7 @@ import (
 	_ "github.com/juju/juju/apiserver/machine"
 	_ "github.com/juju/juju/apiserver/machineactions"
 	_ "github.com/juju/juju/apiserver/machinemanager" // ModelUser Write
+	_ "github.com/juju/juju/apiserver/machineundertaker"
 	_ "github.com/juju/juju/apiserver/meterstatus"
 	_ "github.com/juju/juju/apiserver/metricsadder"
 	_ "github.com/juju/juju/apiserver/metricsdebug" // ModelUser Write

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -46,10 +46,17 @@ type Entities struct {
 	Entities []Entity `json:"entities"`
 }
 
-// EntitiesResults contains multiple Entitieses (where each Entities
-// is the result of a query).
+// EntitiesResults contains multiple Entities results (where each
+// Entities is the result of a query).
 type EntitiesResults struct {
-	Results []Entities `json:"results"`
+	Results []EntitiesResult `json:"results"`
+}
+
+// EntitiesResult is the result of one query that either yields some
+// set of entities or an error.
+type EntitiesResult struct {
+	Entities []Entity `json:"entities"`
+	Error    *Error   `json:"error,omitempty"`
 }
 
 // EntityPasswords holds the parameters for making a SetPasswords call.

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -46,6 +46,12 @@ type Entities struct {
 	Entities []Entity `json:"entities"`
 }
 
+// EntitiesResults contains multiple Entitieses (where each Entities
+// is the result of a query).
+type EntitiesResults struct {
+	Results []Entities `json:"results"`
+}
+
 // EntityPasswords holds the parameters for making a SetPasswords call.
 type EntityPasswords struct {
 	Changes []EntityPassword `json:"changes"`


### PR DESCRIPTION
This is part of http://pad.lv/1585878.

This will be used by the machine undertaker worker to clean up provider-level machine resources and then finally remove the machines from the database.

Testing done: only unit tests, the worker will exercise this once it's completed.

(Review request: http://reviews.vapour.ws/r/5495/)