### PR TITLE
Fixed lp:1614559: Check LXD API is 1.X, not LXD server binary version

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -52,7 +52,7 @@ github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:1
 github.com/juju/zip	git	f6b1e93fa2e29a1d7d49b566b2b51efb060c982a	2016-02-05T10:52:21Z
 github.com/julienschmidt/httprouter	git	77a895ad01ebc98a4dc95d8355bc825ce80a56f6	2015-10-13T22:55:20Z
 github.com/lunixbochs/vtclean	git	4fbf7632a2c6d3fbdb9931439bdbbeded02cbe36	2016-01-25T03:51:06Z
-github.com/lxc/lxd	git	ab7fdf1296dee6ef352261d320cc85f5f45b78a9	2016-08-20T03:01:12Z
+github.com/lxc/lxd	git	0d172e3080f768fd419f0c97f5246983797db243	2016-08-12T05:08:18Z
 github.com/mattn/go-colorable	git	ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8	2016-07-31T23:54:17Z
 github.com/mattn/go-isatty	git	66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8	2016-08-06T12:27:52Z
 github.com/mattn/go-runewidth	git	d96d1bd051f2bd9e7e43d602782b37b93b1b5666	2015-11-18T07:21:59Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -52,7 +52,7 @@ github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:1
 github.com/juju/zip	git	f6b1e93fa2e29a1d7d49b566b2b51efb060c982a	2016-02-05T10:52:21Z
 github.com/julienschmidt/httprouter	git	77a895ad01ebc98a4dc95d8355bc825ce80a56f6	2015-10-13T22:55:20Z
 github.com/lunixbochs/vtclean	git	4fbf7632a2c6d3fbdb9931439bdbbeded02cbe36	2016-01-25T03:51:06Z
-github.com/lxc/lxd	git	62f62e9d6e0da14947023f99764eac29c26cef8d	2016-03-28T00:14:48Z
+github.com/lxc/lxd	git	ab7fdf1296dee6ef352261d320cc85f5f45b78a9	2016-08-20T03:01:12Z
 github.com/mattn/go-colorable	git	ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8	2016-07-31T23:54:17Z
 github.com/mattn/go-isatty	git	66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8	2016-08-06T12:27:52Z
 github.com/mattn/go-runewidth	git	d96d1bd051f2bd9e7e43d602782b37b93b1b5666	2015-11-18T07:21:59Z

--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -151,16 +151,18 @@ var lxdNewClientFromInfo = lxd.NewClientFromInfo
 func isSupportedAPIVersion(version string) bool {
 	versionParts := strings.Split(version, ".")
 	if len(versionParts) < 2 {
+		logger.Warningf("LXD API version %q: expected format <major>.<minor>", version)
 		return false
 	}
 
 	major, err := strconv.Atoi(versionParts[0])
 	if err != nil {
+		logger.Warningf("LXD API version %q: unexpected major number: %v", version, err)
 		return false
 	}
 
-	// Allow API version 1.X+ only
-	if major != 1 {
+	if major < 1 {
+		logger.Warningf("LXD API version %q: expected major version 1 or later", version)
 		return false
 	}
 
@@ -226,7 +228,9 @@ func newRawClient(remote Remote) (*lxd.Client, error) {
 		}
 
 		if !isSupportedAPIVersion(status.APIVersion) {
-			return nil, errors.Errorf("lxd API version %s, juju needs at least 1.0", status.APIVersion)
+			logger.Warningf("trying to use unsupported LXD API version %q", status.APIVersion)
+		} else {
+			logger.Infof("using LXD API version %q", status.APIVersion)
 		}
 	}
 

--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -148,36 +148,19 @@ func Connect(cfg Config) (*Client, error) {
 
 var lxdNewClientFromInfo = lxd.NewClientFromInfo
 
-func isSupportedLxdVersion(version string) bool {
-	var major, minor, micro int
-	var err error
-
+func isSupportedAPIVersion(version string) bool {
 	versionParts := strings.Split(version, ".")
-	if len(versionParts) < 3 {
+	if len(versionParts) < 2 {
 		return false
 	}
 
-	major, err = strconv.Atoi(versionParts[0])
+	major, err := strconv.Atoi(versionParts[0])
 	if err != nil {
 		return false
 	}
 
-	minor, err = strconv.Atoi(versionParts[1])
-	if err != nil {
-		return false
-	}
-
-	micro, err = strconv.Atoi(versionParts[2])
-	if err != nil {
-		return false
-	}
-
-	if major < 2 {
-		return false
-	}
-
-	/* disallow 2.0.0.rc4 and friends */
-	if major == 2 && minor == 0 && micro == 0 && len(versionParts) > 3 {
+	// Allow API version 1.X+ only
+	if major != 1 {
 		return false
 	}
 
@@ -242,8 +225,8 @@ func newRawClient(remote Remote) (*lxd.Client, error) {
 			return nil, errors.Trace(err)
 		}
 
-		if !isSupportedLxdVersion(status.Environment.ServerVersion) {
-			return nil, errors.Errorf("lxd version %s, juju needs at least 2.0.0", status.Environment.ServerVersion)
+		if !isSupportedAPIVersion(status.APIVersion) {
+			return nil, errors.Errorf("lxd API version %s, juju needs at least 1.0", status.APIVersion)
 		}
 	}
 

--- a/tools/lxdclient/client_test.go
+++ b/tools/lxdclient/client_test.go
@@ -196,12 +196,29 @@ func (cs *ConnectSuite) TestRemoteConnectError(c *gc.C) {
 	c.Assert(errors.Cause(err), gc.Equals, testerr)
 }
 
-func (cs *ConnectSuite) TestVersionCheck(c *gc.C) {
-	c.Assert(isSupportedAPIVersion("1.0"), jc.IsTrue)
-	c.Assert(isSupportedAPIVersion("0.9"), jc.IsFalse)
-	c.Assert(isSupportedAPIVersion("1.1"), jc.IsTrue)
-	c.Assert(isSupportedAPIVersion("2.1"), jc.IsFalse)
-	c.Assert(isSupportedAPIVersion("a.b.c"), jc.IsFalse)
+func (*ConnectSuite) CheckLogContains(c *gc.C, suffix string) {
+	c.Check(c.GetTestLog(), jc.Contains, "WARNING juju.tools.lxdclient "+suffix)
+}
+
+func (*ConnectSuite) CheckVersionSupported(c *gc.C, version string, supported bool) {
+	c.Check(isSupportedAPIVersion(version), gc.Equals, supported)
+}
+
+func (cs *ConnectSuite) TestBadVersionChecks(c *gc.C) {
+	cs.CheckVersionSupported(c, "foo", false)
+	cs.CheckLogContains(c, `LXD API version "foo": expected format <major>.<minor>`)
+
+	cs.CheckVersionSupported(c, "a.b", false)
+	cs.CheckLogContains(c, `LXD API version "a.b": unexpected major number: strconv.ParseInt: parsing "a": invalid syntax`)
+
+	cs.CheckVersionSupported(c, "0.9", false)
+	cs.CheckLogContains(c, `LXD API version "0.9": expected major version 1 or later`)
+}
+
+func (cs *ConnectSuite) TestGoodVersionChecks(c *gc.C) {
+	cs.CheckVersionSupported(c, "1.0", true)
+	cs.CheckVersionSupported(c, "2.0", true)
+	cs.CheckVersionSupported(c, "2.1", true)
 }
 
 var testerr = errors.Errorf("boo!")

--- a/tools/lxdclient/client_test.go
+++ b/tools/lxdclient/client_test.go
@@ -197,10 +197,11 @@ func (cs *ConnectSuite) TestRemoteConnectError(c *gc.C) {
 }
 
 func (cs *ConnectSuite) TestVersionCheck(c *gc.C) {
-	c.Assert(isSupportedLxdVersion("2.0.0"), jc.IsTrue)
-	c.Assert(isSupportedLxdVersion("2.0.0.rc4"), jc.IsFalse)
-	c.Assert(isSupportedLxdVersion("0.19"), jc.IsFalse)
-	c.Assert(isSupportedLxdVersion("2.0.1"), jc.IsTrue)
+	c.Assert(isSupportedAPIVersion("1.0"), jc.IsTrue)
+	c.Assert(isSupportedAPIVersion("0.9"), jc.IsFalse)
+	c.Assert(isSupportedAPIVersion("1.1"), jc.IsTrue)
+	c.Assert(isSupportedAPIVersion("2.1"), jc.IsFalse)
+	c.Assert(isSupportedAPIVersion("a.b.c"), jc.IsFalse)
 }
 
 var testerr = errors.Errorf("boo!")


### PR DESCRIPTION
We were checking the LXD server's binary version was 2.0.0, which is not
the right thing to check for compatibility. This PR updates the lxc/lxd
dependencies to the latest version, so we can use server.APIVersion
field and actually perform the correct check - whether the LXD API
version is 1.X at least. When it isn't Juju we still try to use it, but clearly
warn the user about it being unsupported. This is to allow future LXD
API versions to work with older Juju releases, assuming the API itself
does not break backwards-compatibility.

See bug http://pad.lv/1614559 for details.

QA steps:
    1. `sudo add-apt-repository ppa:ubuntu-lxc/lxd-stable`
    2. `sudo apt update && sudo apt full-upgrade -y`
    3. `lxc version`    # ensure it reports 2.1
    4. `cd $GOPATH/src/github.com/juju/juju/`
    5. `git checkout origin/master`
    6. `juju bootstrap lxd localhost`   # expect failure
    7. `git checkout dimitern/lp-1614559-lxd-api-version`
    8. `godeps -u dependencies.tsv`
    9. `go install -v github.com/juju/juju/...`
    10. `juju bootstrap lxd localhost`   # expect success

(Review request: http://reviews.vapour.ws/r/5496/)