### PR TITLE
Support macaroons for migration authentication

### DIFF
--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -209,6 +209,7 @@ type MigrationSpec struct {
 	TargetCACert         string
 	TargetUser           string
 	TargetPassword       string
+	TargetMacaroon       string
 }
 
 // Validate performs sanity checks on the migration configuration it
@@ -229,8 +230,8 @@ func (s *MigrationSpec) Validate() error {
 	if !names.IsValidUser(s.TargetUser) {
 		return errors.NotValidf("target user")
 	}
-	if s.TargetPassword == "" {
-		return errors.NotValidf("empty target password")
+	if s.TargetPassword == "" && s.TargetMacaroon == "" {
+		return errors.NotValidf("missing authentication secrets")
 	}
 	return nil
 }
@@ -254,6 +255,7 @@ func (c *Client) InitiateMigration(spec MigrationSpec) (string, error) {
 				CACert:        spec.TargetCACert,
 				AuthTag:       names.NewUserTag(spec.TargetUser).String(),
 				Password:      spec.TargetPassword,
+				Macaroon:      spec.TargetMacaroon,
 			},
 		}},
 	}

--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -46,12 +46,12 @@ func (c *Client) Watch() (watcher.NotifyWatcher, error) {
 	return c.newWatcher(c.caller.RawAPICaller(), result), nil
 }
 
-// GetMigrationStatus returns the details and progress of the latest
+// MigrationStatus returns the details and progress of the latest
 // model migration.
-func (c *Client) GetMigrationStatus() (migration.MigrationStatus, error) {
+func (c *Client) MigrationStatus() (migration.MigrationStatus, error) {
 	var empty migration.MigrationStatus
 	var status params.MasterMigrationStatus
-	err := c.caller.FacadeCall("GetMigrationStatus", nil, &status)
+	err := c.caller.FacadeCall("MigrationStatus", nil, &status)
 	if err != nil {
 		return empty, errors.Trace(err)
 	}

--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
@@ -77,6 +78,14 @@ func (c *Client) MigrationStatus() (migration.MigrationStatus, error) {
 		return empty, errors.Annotatef(err, "unable to parse auth tag")
 	}
 
+	var mac *macaroon.Macaroon
+	if target.Macaroon != "" {
+		mac = new(macaroon.Macaroon)
+		if err := mac.UnmarshalJSON([]byte(target.Macaroon)); err != nil {
+			return empty, errors.Annotatef(err, "unmarshalling macaroon")
+		}
+	}
+
 	return migration.MigrationStatus{
 		MigrationId:      status.MigrationId,
 		ModelUUID:        modelTag.Id(),
@@ -88,6 +97,7 @@ func (c *Client) MigrationStatus() (migration.MigrationStatus, error) {
 			CACert:        target.CACert,
 			AuthTag:       authTag,
 			Password:      target.Password,
+			Macaroon:      mac,
 		},
 	}, nil
 }

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -60,7 +60,7 @@ func (s *ClientSuite) TestWatchCallError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
-func (s *ClientSuite) TestGetMigrationStatus(c *gc.C) {
+func (s *ClientSuite) TestMigrationStatus(c *gc.C) {
 	modelUUID := utils.MustNewUUID().String()
 	controllerUUID := utils.MustNewUUID().String()
 	timestamp := time.Date(2016, 6, 22, 16, 42, 44, 0, time.UTC)
@@ -85,7 +85,7 @@ func (s *ClientSuite) TestGetMigrationStatus(c *gc.C) {
 	})
 	client := migrationmaster.NewClient(apiCaller, nil)
 
-	status, err := client.GetMigrationStatus()
+	status, err := client.MigrationStatus()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.DeepEquals, migration.MigrationStatus{
 		MigrationId:      "id",

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api/base"
 	apitesting "github.com/juju/juju/api/base/testing"
@@ -61,6 +62,11 @@ func (s *ClientSuite) TestWatchCallError(c *gc.C) {
 }
 
 func (s *ClientSuite) TestMigrationStatus(c *gc.C) {
+	mac, err := macaroon.New([]byte("secret"), "id", "location")
+	c.Assert(err, jc.ErrorIsNil)
+	macJSON, err := mac.MarshalJSON()
+	c.Assert(err, jc.ErrorIsNil)
+
 	modelUUID := utils.MustNewUUID().String()
 	controllerUUID := utils.MustNewUUID().String()
 	timestamp := time.Date(2016, 6, 22, 16, 42, 44, 0, time.UTC)
@@ -75,6 +81,7 @@ func (s *ClientSuite) TestMigrationStatus(c *gc.C) {
 					CACert:        "cert",
 					AuthTag:       names.NewUserTag("admin").String(),
 					Password:      "secret",
+					Macaroon:      string(macJSON),
 				},
 			},
 			MigrationId:      "id",
@@ -98,6 +105,7 @@ func (s *ClientSuite) TestMigrationStatus(c *gc.C) {
 			CACert:        "cert",
 			AuthTag:       names.NewUserTag("admin"),
 			Password:      "secret",
+			Macaroon:      mac,
 		},
 	})
 }

--- a/apiserver/migrationmaster/facade.go
+++ b/apiserver/migrationmaster/facade.go
@@ -62,9 +62,9 @@ func (api *API) Watch() params.NotifyWatchResult {
 	}
 }
 
-// GetMigrationStatus returns the details and progress of the latest
+// MigrationStatus returns the details and progress of the latest
 // model migration.
-func (api *API) GetMigrationStatus() (params.MasterMigrationStatus, error) {
+func (api *API) MigrationStatus() (params.MasterMigrationStatus, error) {
 	empty := params.MasterMigrationStatus{}
 
 	mig, err := api.backend.LatestMigration()

--- a/apiserver/migrationmaster/facade.go
+++ b/apiserver/migrationmaster/facade.go
@@ -82,6 +82,14 @@ func (api *API) MigrationStatus() (params.MasterMigrationStatus, error) {
 		return empty, errors.Annotate(err, "retrieving phase")
 	}
 
+	var macJSON []byte
+	if target.Macaroon != nil {
+		macJSON, err = target.Macaroon.MarshalJSON()
+		if err != nil {
+			return empty, errors.Annotate(err, "marshalling macaroon")
+		}
+	}
+
 	return params.MasterMigrationStatus{
 		Spec: params.MigrationSpec{
 			ModelTag: names.NewModelTag(mig.ModelUUID()).String(),
@@ -91,6 +99,7 @@ func (api *API) MigrationStatus() (params.MasterMigrationStatus, error) {
 				CACert:        target.CACert,
 				AuthTag:       target.AuthTag.String(),
 				Password:      target.Password,
+				Macaroon:      string(macJSON),
 			},
 		},
 		MigrationId:      mig.Id(),

--- a/apiserver/migrationmaster/facade_test.go
+++ b/apiserver/migrationmaster/facade_test.go
@@ -86,10 +86,10 @@ func (s *Suite) TestWatch(c *gc.C) {
 	}
 }
 
-func (s *Suite) TestGetMigrationStatus(c *gc.C) {
+func (s *Suite) TestMigrationStatus(c *gc.C) {
 	api := s.mustMakeAPI(c)
 
-	status, err := api.GetMigrationStatus()
+	status, err := api.MigrationStatus()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.DeepEquals, params.MasterMigrationStatus{
 		Spec: params.MigrationSpec{

--- a/apiserver/migrationmaster/facade_test.go
+++ b/apiserver/migrationmaster/facade_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/migrationmaster"
@@ -87,11 +88,14 @@ func (s *Suite) TestWatch(c *gc.C) {
 }
 
 func (s *Suite) TestMigrationStatus(c *gc.C) {
-	api := s.mustMakeAPI(c)
+	var expectedMacaroon = `
+{"caveats":[],"location":"location","identifier":"id","signature":"a9802bf274262733d6283a69c62805b5668dbf475bcd7edc25a962833f7c2cba"}`[1:]
 
+	api := s.mustMakeAPI(c)
 	status, err := api.MigrationStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.DeepEquals, params.MasterMigrationStatus{
+
+	c.Check(status, gc.DeepEquals, params.MasterMigrationStatus{
 		Spec: params.MigrationSpec{
 			ModelTag: names.NewModelTag(modelUUID).String(),
 			TargetInfo: params.MigrationTargetInfo{
@@ -100,6 +104,7 @@ func (s *Suite) TestMigrationStatus(c *gc.C) {
 				CACert:        "trust me",
 				AuthTag:       names.NewUserTag("admin").String(),
 				Password:      "secret",
+				Macaroon:      expectedMacaroon,
 			},
 		},
 		MigrationId:      "id",
@@ -350,12 +355,17 @@ func (m *stubMigration) ModelUUID() string {
 }
 
 func (m *stubMigration) TargetInfo() (*coremigration.TargetInfo, error) {
+	mac, err := macaroon.New([]byte("secret"), "id", "location")
+	if err != nil {
+		panic(err)
+	}
 	return &coremigration.TargetInfo{
 		ControllerTag: names.NewModelTag(controllerUUID),
 		Addrs:         []string{"1.1.1.1:1", "2.2.2.2:2"},
 		CACert:        "trust me",
 		AuthTag:       names.NewUserTag("admin"),
 		Password:      "secret",
+		Macaroon:      mac,
 	}, nil
 }
 

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -25,7 +25,8 @@ type MigrationTargetInfo struct {
 	Addrs         []string `json:"addrs"`
 	CACert        string   `json:"ca-cert"`
 	AuthTag       string   `json:"auth-tag"`
-	Password      string   `json:"password"`
+	Password      string   `json:"password,omitempty"`
+	Macaroon      string   `json:"macaroon,omitempty"`
 }
 
 // InitiateMigrationResults is used to return the result of one or

--- a/cmd/juju/commands/migrate.go
+++ b/cmd/juju/commands/migrate.go
@@ -110,6 +110,7 @@ func (c *migrateCommand) getMigrationSpec() (*controller.MigrationSpec, error) {
 		TargetCACert:         controllerInfo.CACert,
 		TargetUser:           accountInfo.User,
 		TargetPassword:       accountInfo.Password,
+		TargetMacaroon:       accountInfo.Macaroon,
 	}, nil
 }
 

--- a/cmd/juju/commands/migrate_test.go
+++ b/cmd/juju/commands/migrate_test.go
@@ -57,8 +57,11 @@ func (s *MigrateSuite) SetUpTest(c *gc.C) {
 
 	// Define the account for the target controller.
 	err = s.store.UpdateAccount("target", jujuclient.AccountDetails{
-		User:     "target@local",
+		User: "target@local",
+		// It's unlikely that both will actually be set for a single
+		// account but it's fine for the tests.
 		Password: "secret",
+		Macaroon: "macaroon",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -100,6 +103,7 @@ func (s *MigrateSuite) TestSuccess(c *gc.C) {
 		TargetCACert:         "cert",
 		TargetUser:           "target@local",
 		TargetPassword:       "secret",
+		TargetMacaroon:       "macaroon",
 	})
 }
 

--- a/core/migration/targetinfo.go
+++ b/core/migration/targetinfo.go
@@ -5,8 +5,10 @@ package migration
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/network"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon.v1"
+
+	"github.com/juju/juju/network"
 )
 
 // TargetInfo holds the details required to connect to a
@@ -34,6 +36,10 @@ type TargetInfo struct {
 
 	// Password holds the password to use with AuthTag.
 	Password string
+
+	// Macroon holds the macaroon to use with AuthTag. At least one of
+	// Password or Macaroon must be set.
+	Macaroon *macaroon.Macaroon
 }
 
 // Validate returns an error if the TargetInfo contains bad data. Nil
@@ -61,8 +67,8 @@ func (info *TargetInfo) Validate() error {
 		return errors.NotValidf("empty AuthTag")
 	}
 
-	if info.Password == "" {
-		return errors.NotValidf("empty Password")
+	if info.Password == "" && info.Macaroon == nil {
+		return errors.NotValidf("missing Password & Macaroon")
 	}
 
 	return nil

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/state"
@@ -43,6 +44,9 @@ func (s *MigrationSuite) SetUpTest(c *gc.C) {
 
 	targetControllerTag := names.NewModelTag(utils.MustNewUUID().String())
 
+	mac, err := macaroon.New([]byte("secret"), "id", "location")
+	c.Assert(err, jc.ErrorIsNil)
+
 	// Plausible migration arguments to test with.
 	s.stdSpec = state.MigrationSpec{
 		InitiatedBy: names.NewUserTag("admin"),
@@ -52,6 +56,7 @@ func (s *MigrationSuite) SetUpTest(c *gc.C) {
 			CACert:        "cert",
 			AuthTag:       names.NewUserTag("user"),
 			Password:      "password",
+			Macaroon:      mac,
 		},
 	}
 }
@@ -147,9 +152,9 @@ func (s *MigrationSuite) TestSpecValidation(c *gc.C) {
 	}, {
 		"TargetInfo is validated",
 		func(spec *state.MigrationSpec) {
-			spec.TargetInfo.Password = ""
+			spec.TargetInfo.CACert = ""
 		},
-		"empty Password not valid",
+		"empty CACert not valid",
 	}}
 	for _, test := range tests {
 		c.Logf("---- %s -----------", test.label)

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils/clock"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/migrationtarget"
@@ -182,6 +183,7 @@ func (w *Worker) run() error {
 	}
 
 	phase := status.Phase
+
 	for {
 		var err error
 		switch phase {
@@ -605,6 +607,10 @@ func (w *Worker) openAPIConnForModel(targetInfo coremigration.TargetInfo, modelU
 		Password: targetInfo.Password,
 		ModelTag: names.NewModelTag(modelUUID),
 	}
+	if targetInfo.Macaroon != nil {
+		apiInfo.Macaroons = []macaroon.Slice{{targetInfo.Macaroon}}
+	}
+
 	// Use zero DialOpts (no retries) because the worker must stay
 	// responsive to Kill requests. We don't want it to be blocked by
 	// a long set of retry attempts.

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -53,9 +53,9 @@ type Facade interface {
 	// active for the model associated with the API connection.
 	Watch() (watcher.NotifyWatcher, error)
 
-	// GetMigrationStatus returns the details and progress of the
-	// latest model migration.
-	GetMigrationStatus() (coremigration.MigrationStatus, error)
+	// MigrationStatus returns the details and progress of the latest
+	// model migration.
+	MigrationStatus() (coremigration.MigrationStatus, error)
 
 	// SetPhase updates the phase of the currently active model
 	// migration.
@@ -430,7 +430,7 @@ func (w *Worker) waitForActiveMigration() (coremigration.MigrationStatus, error)
 		case <-watcher.Changes():
 		}
 
-		status, err := w.config.Facade.GetMigrationStatus()
+		status, err := w.config.Facade.MigrationStatus()
 		switch {
 		case params.IsCodeNotFound(err):
 			// There's never been a migration.

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -173,7 +173,7 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 	s.stub.CheckCalls(c, []jujutesting.StubCall{
 		// Wait for migration to start.
 		{"masterFacade.Watch", nil},
-		{"masterFacade.GetMigrationStatus", nil},
+		{"masterFacade.MigrationStatus", nil},
 		{"guard.Lockdown", nil},
 
 		// QUIESCE
@@ -238,7 +238,7 @@ func (s *Suite) TestMigrationResume(c *gc.C) {
 
 	s.stub.CheckCalls(c, []jujutesting.StubCall{
 		{"masterFacade.Watch", nil},
-		{"masterFacade.GetMigrationStatus", nil},
+		{"masterFacade.MigrationStatus", nil},
 		{"guard.Lockdown", nil},
 		{"masterFacade.WatchMinionReports", nil},
 		{"masterFacade.MinionReports", nil},
@@ -259,7 +259,7 @@ func (s *Suite) TestPreviouslyAbortedMigration(c *gc.C) {
 
 	s.waitForStubCalls(c, []string{
 		"masterFacade.Watch",
-		"masterFacade.GetMigrationStatus",
+		"masterFacade.MigrationStatus",
 		"guard.Unlock",
 	})
 }
@@ -276,7 +276,7 @@ func (s *Suite) TestPreviouslyCompletedMigration(c *gc.C) {
 
 	s.stub.CheckCalls(c, []jujutesting.StubCall{
 		{"masterFacade.Watch", nil},
-		{"masterFacade.GetMigrationStatus", nil},
+		{"masterFacade.MigrationStatus", nil},
 	})
 }
 
@@ -300,7 +300,7 @@ func (s *Suite) TestStatusError(c *gc.C) {
 
 	s.stub.CheckCalls(c, []jujutesting.StubCall{
 		{"masterFacade.Watch", nil},
-		{"masterFacade.GetMigrationStatus", nil},
+		{"masterFacade.MigrationStatus", nil},
 	})
 }
 
@@ -314,7 +314,7 @@ func (s *Suite) TestStatusNotFound(c *gc.C) {
 
 	s.waitForStubCalls(c, []string{
 		"masterFacade.Watch",
-		"masterFacade.GetMigrationStatus",
+		"masterFacade.MigrationStatus",
 		"guard.Unlock",
 	})
 }
@@ -334,7 +334,7 @@ func (s *Suite) TestUnlockError(c *gc.C) {
 
 	s.stub.CheckCalls(c, []jujutesting.StubCall{
 		{"masterFacade.Watch", nil},
-		{"masterFacade.GetMigrationStatus", nil},
+		{"masterFacade.MigrationStatus", nil},
 		{"guard.Unlock", nil},
 	})
 }
@@ -353,7 +353,7 @@ func (s *Suite) TestLockdownError(c *gc.C) {
 
 	s.stub.CheckCalls(c, []jujutesting.StubCall{
 		{"masterFacade.Watch", nil},
-		{"masterFacade.GetMigrationStatus", nil},
+		{"masterFacade.MigrationStatus", nil},
 		{"guard.Lockdown", nil},
 	})
 }
@@ -395,7 +395,7 @@ func (s *Suite) TestExportFailure(c *gc.C) {
 
 	s.stub.CheckCalls(c, []jujutesting.StubCall{
 		{"masterFacade.Watch", nil},
-		{"masterFacade.GetMigrationStatus", nil},
+		{"masterFacade.MigrationStatus", nil},
 		{"guard.Lockdown", nil},
 		{"masterFacade.Export", nil},
 		{"masterFacade.SetPhase", []interface{}{coremigration.ABORT}},
@@ -419,7 +419,7 @@ func (s *Suite) TestAPIOpenFailure(c *gc.C) {
 
 	s.stub.CheckCalls(c, []jujutesting.StubCall{
 		{"masterFacade.Watch", nil},
-		{"masterFacade.GetMigrationStatus", nil},
+		{"masterFacade.MigrationStatus", nil},
 		{"guard.Lockdown", nil},
 		{"masterFacade.Export", nil},
 		apiOpenCallController,
@@ -442,7 +442,7 @@ func (s *Suite) TestImportFailure(c *gc.C) {
 
 	s.stub.CheckCalls(c, []jujutesting.StubCall{
 		{"masterFacade.Watch", nil},
-		{"masterFacade.GetMigrationStatus", nil},
+		{"masterFacade.MigrationStatus", nil},
 		{"guard.Lockdown", nil},
 		{"masterFacade.Export", nil},
 		apiOpenCallController,
@@ -484,7 +484,7 @@ func (s *Suite) TestSUCCESSMinionWaitFailedMachine(c *gc.C) {
 
 	s.stub.CheckCalls(c, []jujutesting.StubCall{
 		{"masterFacade.Watch", nil},
-		{"masterFacade.GetMigrationStatus", nil},
+		{"masterFacade.MigrationStatus", nil},
 		{"guard.Lockdown", nil},
 		{"masterFacade.WatchMinionReports", nil},
 		{"masterFacade.MinionReports", nil},
@@ -514,7 +514,7 @@ func (s *Suite) TestSUCCESSMinionWaitFailedUnit(c *gc.C) {
 
 	s.stub.CheckCalls(c, []jujutesting.StubCall{
 		{"masterFacade.Watch", nil},
-		{"masterFacade.GetMigrationStatus", nil},
+		{"masterFacade.MigrationStatus", nil},
 		{"guard.Lockdown", nil},
 		{"masterFacade.WatchMinionReports", nil},
 		{"masterFacade.MinionReports", nil},
@@ -550,7 +550,7 @@ func (s *Suite) TestSUCCESSMinionWaitTimeout(c *gc.C) {
 
 	s.stub.CheckCalls(c, []jujutesting.StubCall{
 		{"masterFacade.Watch", nil},
-		{"masterFacade.GetMigrationStatus", nil},
+		{"masterFacade.MigrationStatus", nil},
 		{"guard.Lockdown", nil},
 		{"masterFacade.WatchMinionReports", nil},
 		{"masterFacade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
@@ -653,7 +653,7 @@ func (s *Suite) checkMinionWaitFailedAgent(c *gc.C, phase coremigration.Phase) {
 
 	s.stub.CheckCalls(c, []jujutesting.StubCall{
 		{"masterFacade.Watch", nil},
-		{"masterFacade.GetMigrationStatus", nil},
+		{"masterFacade.MigrationStatus", nil},
 		{"guard.Lockdown", nil},
 		{"masterFacade.WatchMinionReports", nil},
 		{"masterFacade.MinionReports", nil},
@@ -743,8 +743,8 @@ func (c *stubMasterFacade) Watch() (watcher.NotifyWatcher, error) {
 	return newMockWatcher(c.watcherChanges), nil
 }
 
-func (c *stubMasterFacade) GetMigrationStatus() (coremigration.MigrationStatus, error) {
-	c.stub.AddCall("masterFacade.GetMigrationStatus")
+func (c *stubMasterFacade) MigrationStatus() (coremigration.MigrationStatus, error) {
+	c.stub.AddCall("masterFacade.MigrationStatus")
 	if c.statusErr != nil {
 		return coremigration.MigrationStatus{}, c.statusErr
 	}


### PR DESCRIPTION
Up until now migrations have only supported password authentication to the target controller but with modern Juju most users will have a macaroon in their local account store and not a password. This PR threads support for macaroon authentication through the migration infrastructure so that users with macaroons can initiate migrations.

By reusing the user's macaroon directly, this implementation is a little naive. A upcoming change will have the client request a macaroon from the target controller, attenuate it and have that used for all future migration activities. Password authentication support for the migration infrastructure will be removed at that point - simplifying the code and improving security by not having long lived credentials being stored and passed around.

Drive-by: rename the GetMigrationStatus API on the MigrationMaster facade to MigrationStatus.

(Review request: http://reviews.vapour.ws/r/5498/)