### PR TITLE
add version canary files

### DIFF
--- a/cmd/juju/version_canary.go
+++ b/cmd/juju/version_canary.go
@@ -1,0 +1,10 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build !go1.6
+
+package main
+
+// This line intentionally does not compile.  This file will only be compiled if
+// you are compiling with a version of Go that is lower than the one we support.
+var requiredGoVersion = This_project_requires_Go_1_6

--- a/cmd/jujud/version_canary.go
+++ b/cmd/jujud/version_canary.go
@@ -1,0 +1,10 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build !go1.6
+
+package main
+
+// This line intentionally does not compile.  This file will only be compiled if
+// you are compiling with a version of Go that is lower than the one we support.
+var requiredGoVersion = This_project_requires_Go_1_6


### PR DESCRIPTION
These files will fail compilation on versions of go we don't support,
and they'll do it with a more obvious error message than you'd get
from random pieces of the stdlib being missing or language features
being missing.

(Review request: http://reviews.vapour.ws/r/5499/)