### PR TITLE
Fixes lp#1591488: deploy with custom image metadata.

### DIFF
--- a/apiserver/imagemetadata/export_test.go
+++ b/apiserver/imagemetadata/export_test.go
@@ -3,17 +3,7 @@
 
 package imagemetadata
 
-import (
-	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/state/cloudimagemetadata"
-)
-
 var (
 	CreateAPI     = createAPI
 	ProcessErrors = processErrors
 )
-
-func ParseMetadataFromParams(api *API, p params.CloudImageMetadata, cfg *config.Config, cloudRegion string) (cloudimagemetadata.Metadata, error) {
-	return api.parseMetadataFromParams(p, cfg, cloudRegion)
-}

--- a/apiserver/imagemetadata/functions_test.go
+++ b/apiserver/imagemetadata/functions_test.go
@@ -7,82 +7,12 @@ import (
 	"fmt"
 
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/imagemetadata"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/state/cloudimagemetadata"
 	"github.com/juju/juju/testing"
 )
-
-type funcSuite struct {
-	baseImageMetadataSuite
-
-	cfg      *config.Config
-	expected cloudimagemetadata.Metadata
-}
-
-var _ = gc.Suite(&funcSuite{})
-
-func (s *funcSuite) SetUpTest(c *gc.C) {
-	s.baseImageMetadataSuite.SetUpTest(c)
-
-	cfg, err := config.New(config.NoDefaults, mockConfig())
-	c.Assert(err, jc.ErrorIsNil)
-	s.cfg = cfg
-	s.state = s.constructState(s.cfg, nil)
-
-	s.expected = cloudimagemetadata.Metadata{
-		cloudimagemetadata.MetadataAttributes{
-			Stream: "released",
-			Source: "custom",
-			Series: series.LatestLts(),
-			Arch:   "amd64",
-			Region: "dummy_region",
-		},
-		0,
-		"",
-	}
-}
-
-func (s *funcSuite) TestParseMetadataNoSource(c *gc.C) {
-	m, err := imagemetadata.ParseMetadataFromParams(s.api, params.CloudImageMetadata{}, s.cfg, "dummy_region")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m, gc.DeepEquals, s.expected)
-}
-
-func (s *funcSuite) TestParseMetadataAnySource(c *gc.C) {
-	s.expected.Source = "any"
-	m, err := imagemetadata.ParseMetadataFromParams(s.api, params.CloudImageMetadata{Source: "any"}, s.cfg, "dummy_region")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m, gc.DeepEquals, s.expected)
-}
-
-func (s *funcSuite) TestParseMetadataAnyStream(c *gc.C) {
-	stream := "happy stream"
-	s.expected.Stream = stream
-
-	m, err := imagemetadata.ParseMetadataFromParams(s.api, params.CloudImageMetadata{Stream: stream}, s.cfg, "dummy_region")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m, gc.DeepEquals, s.expected)
-}
-
-func (s *funcSuite) TestParseMetadataDefaultStream(c *gc.C) {
-	m, err := imagemetadata.ParseMetadataFromParams(s.api, params.CloudImageMetadata{}, s.cfg, "dummy_region")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m, gc.DeepEquals, s.expected)
-}
-
-func (s *funcSuite) TestParseMetadataAnyRegion(c *gc.C) {
-	region := "region"
-	s.expected.Region = region
-
-	m, err := imagemetadata.ParseMetadataFromParams(s.api, params.CloudImageMetadata{Region: region}, s.cfg, "dummy_region")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m, gc.DeepEquals, s.expected)
-}
 
 type funcMetadataSuite struct {
 	testing.BaseSuite

--- a/apiserver/imagemetadata/metadata.go
+++ b/apiserver/imagemetadata/metadata.go
@@ -192,11 +192,11 @@ func (api *API) parseMetadataListFromParams(p params.CloudImageMetadataList, cfg
 			metadata.Priority,
 			metadata.ImageId,
 		}
+		// TODO (anastasiamac 2016-08-24) This is a band-aid solution.
+		// Once correct value is read from simplestreams, this needs to go.
+		// Bug# 1616295
 		if results[i].Stream == "" {
 			results[i].Stream = cfg.ImageStream()
-		}
-		if results[i].Source == "" {
-			results[i].Source = "custom"
 		}
 	}
 	return results

--- a/apiserver/imagemetadata/metadata.go
+++ b/apiserver/imagemetadata/metadata.go
@@ -212,24 +212,30 @@ func (api *API) parseMetadataFromParams(p params.CloudImageMetadata, cfg *config
 		p.Priority,
 		p.ImageId,
 	}
+	SupplyWithDefaults(&result, cfg, cloudRegion)
+	return result, nil
+}
 
+// SupplyWithDefaults pre-populates cloud image metadata parameter with known defaults
+// for properties that have missing values.
+func SupplyWithDefaults(p *cloudimagemetadata.Metadata, cfg *config.Config, cloudRegion string) {
 	// Fill in any required default values.
 	if p.Stream == "" {
-		result.Stream = cfg.ImageStream()
+		p.Stream = cfg.ImageStream()
 	}
 	if p.Source == "" {
-		result.Source = "custom"
+		p.Source = "custom"
 	}
-	if result.Arch == "" {
-		result.Arch = "amd64"
+	if p.Arch == "" {
+		// TODO (anastasiamac 2016-08-23) is this correct? Should it not be host arch?
+		p.Arch = "amd64"
 	}
-	if result.Series == "" {
-		result.Series = config.PreferredSeries(cfg)
+	if p.Series == "" {
+		p.Series = config.PreferredSeries(cfg)
 	}
-	if result.Region == "" {
-		result.Region = cloudRegion
+	if p.Region == "" {
+		p.Region = cloudRegion
 	}
-	return result, nil
 }
 
 // UpdateFromPublishedImages retrieves currently published image metadata and

--- a/apiserver/imagemetadata/metadata_test.go
+++ b/apiserver/imagemetadata/metadata_test.go
@@ -116,7 +116,7 @@ func (s *metadataSuite) TestSave(c *gc.C) {
 		// Once correct value is read from simplestreams, this needs to go.
 		// Bug# 1616295
 		// Ensure empty stream is changed to release
-		c.Assert("released", gc.DeepEquals, m[0].Stream)
+		c.Assert(m[0].Stream, gc.DeepEquals, "released")
 		if saveCalls == 1 {
 			// don't err on first call
 			return nil

--- a/apiserver/imagemetadata/metadata_test.go
+++ b/apiserver/imagemetadata/metadata_test.go
@@ -112,6 +112,9 @@ func (s *metadataSuite) TestSave(c *gc.C) {
 	s.state.saveMetadata = func(m []cloudimagemetadata.Metadata) error {
 		saveCalls += 1
 		c.Assert(m, gc.HasLen, saveCalls)
+		// TODO (anastasiamac 2016-08-24) This is a check for a band-aid solution.
+		// Once correct value is read from simplestreams, this needs to go.
+		// Bug# 1616295
 		// Ensure empty stream is changed to release
 		c.Assert("released", gc.DeepEquals, m[0].Stream)
 		if saveCalls == 1 {

--- a/apiserver/imagemetadata/metadata_test.go
+++ b/apiserver/imagemetadata/metadata_test.go
@@ -112,6 +112,8 @@ func (s *metadataSuite) TestSave(c *gc.C) {
 	s.state.saveMetadata = func(m []cloudimagemetadata.Metadata) error {
 		saveCalls += 1
 		c.Assert(m, gc.HasLen, saveCalls)
+		// Ensure empty stream is changed to release
+		c.Assert("released", gc.DeepEquals, m[0].Stream)
 		if saveCalls == 1 {
 			// don't err on first call
 			return nil

--- a/apiserver/imagemetadata/metadata_test.go
+++ b/apiserver/imagemetadata/metadata_test.go
@@ -132,7 +132,7 @@ func (s *metadataSuite) TestSave(c *gc.C) {
 	c.Assert(errs.Results, gc.HasLen, 2)
 	c.Assert(errs.Results[0].Error, gc.IsNil)
 	c.Assert(errs.Results[1].Error, gc.ErrorMatches, msg)
-	s.assertCalls(c, "ControllerTag", environConfig, "Model", saveMetadata, saveMetadata)
+	s.assertCalls(c, "ControllerTag", environConfig, saveMetadata, saveMetadata)
 }
 
 func (s *metadataSuite) TestDeleteEmpty(c *gc.C) {

--- a/apiserver/imagemetadata/updatefrompublished_test.go
+++ b/apiserver/imagemetadata/updatefrompublished_test.go
@@ -282,7 +282,7 @@ func (s *regionMetadataSuite) setExpectations(c *gc.C) {
 func (s *regionMetadataSuite) checkStoredPublished(c *gc.C) {
 	err := s.api.UpdateFromPublishedImages()
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertCalls(c, "ControllerTag", "ControllerTag", environConfig, "Model", saveMetadata)
+	s.assertCalls(c, "ControllerTag", "ControllerTag", environConfig, saveMetadata)
 	c.Assert(s.saved, jc.SameContents, s.expected)
 }
 
@@ -392,12 +392,13 @@ func (s *regionMetadataSuite) TestUpdateFromPublishedImagesMultipleDS(c *gc.C) {
 	priority := s.setupMetadata(c, anotherDS, cloudSpec, m1)
 	m1.Source = anotherDS
 	m1.Priority = priority
+	m1.Stream = "released"
 
 	s.expected = append(s.expected, m1)
 
 	err = s.api.UpdateFromPublishedImages()
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertCalls(c, "ControllerTag", "ControllerTag", environConfig, "Model", saveMetadata, "ControllerTag", environConfig, "Model", saveMetadata)
+	s.assertCalls(c, "ControllerTag", "ControllerTag", environConfig, saveMetadata, "ControllerTag", environConfig, saveMetadata)
 	c.Assert(s.saved, jc.SameContents, s.expected)
 }
 

--- a/apiserver/provisioner/provisioninginfo.go
+++ b/apiserver/provisioner/provisioninginfo.go
@@ -513,14 +513,14 @@ func (p *ProvisionerAPI) imageMetadataFromDataSources(env environs.Environ, cons
 			priority,
 			m.Id,
 		}
+		// TODO (anastasiamac 2016-08-24) This is a band-aid solution.
+		// Once correct value is read from simplestreams, this needs to go.
+		// Bug# 1616295
 		if result.Stream == "" {
 			result.Stream = constraint.Stream
 		}
 		if result.Stream == "" {
 			result.Stream = cfg.ImageStream()
-		}
-		if result.Source == "" {
-			result.Source = "custom"
 		}
 		return result
 	}

--- a/apiserver/provisioner/provisioninginfo.go
+++ b/apiserver/provisioner/provisioninginfo.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/storagecommon"
-	apiserverimagemetadata "github.com/juju/juju/apiserver/imagemetadata"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/environs"
@@ -498,6 +497,7 @@ func (p *ProvisionerAPI) imageMetadataFromDataSources(env environs.Environ, cons
 		return nil, errors.Trace(err)
 	}
 
+	cfg := env.Config()
 	toModel := func(m *imagemetadata.ImageMetadata, mSeries string, source string, priority int) cloudimagemetadata.Metadata {
 		result := cloudimagemetadata.Metadata{
 			cloudimagemetadata.MetadataAttributes{
@@ -516,7 +516,12 @@ func (p *ProvisionerAPI) imageMetadataFromDataSources(env environs.Environ, cons
 		if result.Stream == "" {
 			result.Stream = constraint.Stream
 		}
-		apiserverimagemetadata.SupplyWithDefaults(&result, env.Config(), constraint.Region)
+		if result.Stream == "" {
+			result.Stream = cfg.ImageStream()
+		}
+		if result.Source == "" {
+			result.Source = "custom"
+		}
 		return result
 	}
 

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -292,9 +292,6 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 
 	// Add custom image metadata to environment storage.
 	if len(args.CustomImageMetadata) > 0 {
-		// TODO (anastasiamac) Is this right? this will mean that custom image metadtaa will be available
-		// only in controller region, i.e. if there is potential to have machines in other regions,
-		// they will not be able to get these image metadata.
 		if err := c.saveCustomImageMetadata(st, env, args.CustomImageMetadata); err != nil {
 			return err
 		}

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -744,6 +744,10 @@ func assertWrittenToState(c *gc.C, metadata cloudimagemetadata.Metadata) {
 	// find all image metadata in state
 	all, err := st.CloudImageMetadataStorage.FindMetadata(cloudimagemetadata.MetadataFilter{})
 	c.Assert(err, jc.ErrorIsNil)
+	// if there was no stream, it should have defaulted to "released"
+	if metadata.Stream == "" {
+		metadata.Stream = "released"
+	}
 	c.Assert(all, gc.DeepEquals, map[string][]cloudimagemetadata.Metadata{
 		metadata.Source: []cloudimagemetadata.Metadata{metadata},
 	})

--- a/state/cloudimagemetadata/image.go
+++ b/state/cloudimagemetadata/image.go
@@ -269,13 +269,24 @@ func validateMetadata(m *imagesMetadataDoc) error {
 	if m.Series == "" {
 		return errors.NotValidf("missing series: metadata for image %v", m.ImageId)
 	}
-
 	v, err := series.SeriesVersion(m.Series)
 	if err != nil {
 		return err
 	}
-
 	m.Version = v
+
+	if m.Stream == "" {
+		return errors.NotValidf("missing stream: metadata for image %v", m.ImageId)
+	}
+	if m.Source == "" {
+		return errors.NotValidf("missing source: metadata for image %v", m.ImageId)
+	}
+	if m.Arch == "" {
+		return errors.NotValidf("missing architecture: metadata for image %v", m.ImageId)
+	}
+	if m.Region == "" {
+		return errors.NotValidf("missing region: metadata for image %v", m.ImageId)
+	}
 	return nil
 }
 

--- a/state/cloudimagemetadata/image_test.go
+++ b/state/cloudimagemetadata/image_test.go
@@ -50,6 +50,7 @@ func (s *cloudImageMetadataSuite) TestSaveMetadata(c *gc.C) {
 		Arch:            "arch",
 		VirtType:        "virtType-test",
 		RootStorageType: "rootStorageType-test",
+		Source:          "test",
 	}
 	attrs2 := cloudimagemetadata.MetadataAttributes{
 		Stream:  "chalk",
@@ -57,6 +58,7 @@ func (s *cloudImageMetadataSuite) TestSaveMetadata(c *gc.C) {
 		Version: "12.04",
 		Series:  "precise",
 		Arch:    "amd64",
+		Source:  "test",
 	}
 	added := []cloudimagemetadata.Metadata{
 		{attrs1, 0, "1"},
@@ -78,6 +80,7 @@ func (s *cloudImageMetadataSuite) TestFindMetadataNotFound(c *gc.C) {
 		Series:          "trusty",
 		Arch:            "arch",
 		VirtType:        "virtType",
+		Source:          "test",
 		RootStorageType: "rootStorageType"}
 	m := cloudimagemetadata.Metadata{attrs, 0, "1"}
 	s.assertRecordMetadata(c, m)
@@ -115,6 +118,7 @@ func (s *cloudImageMetadataSuite) TestFindMetadata(c *gc.C) {
 		Series:          "trusty",
 		Arch:            "arch",
 		VirtType:        "virtType",
+		Source:          "test",
 		RootStorageType: "rootStorageType"}
 
 	m := cloudimagemetadata.Metadata{attrs, 0, "1"}
@@ -141,6 +145,8 @@ func (s *cloudImageMetadataSuite) TestSaveMetadataUpdateSameAttrsAndImages(c *gc
 		Version: "14.04",
 		Series:  "trusty",
 		Arch:    "arch",
+		Source:  "test",
+		Region:  "wonder",
 	}
 	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "1"}
 	metadata1 := cloudimagemetadata.Metadata{attrs, 0, "1"}
@@ -156,6 +162,8 @@ func (s *cloudImageMetadataSuite) TestSaveMetadataUpdateSameAttrsDiffImages(c *g
 		Version: "14.04",
 		Series:  "trusty",
 		Arch:    "arch",
+		Source:  "test",
+		Region:  "wonder",
 	}
 	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "1"}
 	metadata1 := cloudimagemetadata.Metadata{attrs, 0, "12"}
@@ -173,6 +181,8 @@ func (s *cloudImageMetadataSuite) TestSaveDiffMetadataConcurrentlyAndOrderByDate
 		Version: "14.04",
 		Series:  "trusty",
 		Arch:    "arch",
+		Region:  "wonder",
+		Source:  "test",
 	}
 	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "0"}
 	metadata1 := cloudimagemetadata.Metadata{attrs, 0, "1"}
@@ -193,6 +203,8 @@ func (s *cloudImageMetadataSuite) TestSaveSameMetadataDiffImageConcurrently(c *g
 		Version: "14.04",
 		Series:  "trusty",
 		Arch:    "arch",
+		Source:  "test",
+		Region:  "wonder",
 	}
 	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "0"}
 	metadata1 := cloudimagemetadata.Metadata{attrs, 0, "1"}
@@ -210,6 +222,8 @@ func (s *cloudImageMetadataSuite) TestSaveSameMetadataSameImageConcurrently(c *g
 		Version: "14.04",
 		Series:  "trusty",
 		Arch:    "arch",
+		Source:  "test",
+		Region:  "wonder",
 	}
 	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "0"}
 
@@ -227,6 +241,7 @@ func (s *cloudImageMetadataSuite) TestSaveSameMetadataSameImageDiffSourceConcurr
 		Series:  "trusty",
 		Arch:    "arch",
 		Source:  "public",
+		Region:  "wonder",
 	}
 	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "0"}
 
@@ -246,6 +261,8 @@ func (s *cloudImageMetadataSuite) TestSaveMetadataNoVersionPassed(c *gc.C) {
 		Stream: "stream",
 		Series: "trusty",
 		Arch:   "arch",
+		Source: "test",
+		Region: "wonder",
 	}
 	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "1"}
 	s.assertRecordMetadata(c, metadata0)
@@ -255,6 +272,8 @@ func (s *cloudImageMetadataSuite) TestSaveMetadataNoSeriesPassed(c *gc.C) {
 	attrs := cloudimagemetadata.MetadataAttributes{
 		Stream: "stream",
 		Arch:   "arch",
+		Source: "test",
+		Region: "wonder",
 	}
 	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "1"}
 	err := s.storage.SaveMetadata([]cloudimagemetadata.Metadata{metadata0})
@@ -266,10 +285,59 @@ func (s *cloudImageMetadataSuite) TestSaveMetadataUnsupportedSeriesPassed(c *gc.
 		Stream: "stream",
 		Series: "blah",
 		Arch:   "arch",
+		Source: "test",
 	}
 	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "1"}
 	err := s.storage.SaveMetadata([]cloudimagemetadata.Metadata{metadata0})
 	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`unknown version for series: "blah"`))
+}
+
+func (s *cloudImageMetadataSuite) TestSaveMetadataNoStreamPassed(c *gc.C) {
+	attrs := cloudimagemetadata.MetadataAttributes{
+		Arch:   "arch",
+		Source: "test",
+		Series: "trusty",
+		Region: "wonder",
+	}
+	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "1"}
+	err := s.storage.SaveMetadata([]cloudimagemetadata.Metadata{metadata0})
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`missing stream: metadata for image 1 not valid`))
+}
+
+func (s *cloudImageMetadataSuite) TestSaveMetadataNoSourcePassed(c *gc.C) {
+	attrs := cloudimagemetadata.MetadataAttributes{
+		Stream: "stream",
+		Arch:   "arch",
+		Series: "trusty",
+		Region: "wonder",
+	}
+	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "1"}
+	err := s.storage.SaveMetadata([]cloudimagemetadata.Metadata{metadata0})
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`missing source: metadata for image 1 not valid`))
+}
+
+func (s *cloudImageMetadataSuite) TestSaveMetadataNoArchitecturePassed(c *gc.C) {
+	attrs := cloudimagemetadata.MetadataAttributes{
+		Stream: "stream",
+		Source: "test",
+		Series: "trusty",
+		Region: "wonder",
+	}
+	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "1"}
+	err := s.storage.SaveMetadata([]cloudimagemetadata.Metadata{metadata0})
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`missing architecture: metadata for image 1 not valid`))
+}
+
+func (s *cloudImageMetadataSuite) TestSaveMetadataNoRegionPassed(c *gc.C) {
+	attrs := cloudimagemetadata.MetadataAttributes{
+		Stream: "stream",
+		Arch:   "arch",
+		Source: "test",
+		Series: "trusty",
+	}
+	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "1"}
+	err := s.storage.SaveMetadata([]cloudimagemetadata.Metadata{metadata0})
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`missing region: metadata for image 1 not valid`))
 }
 
 func (s *cloudImageMetadataSuite) assertConcurrentSave(c *gc.C, metadata0, metadata1 cloudimagemetadata.Metadata, expected ...cloudimagemetadata.Metadata) {
@@ -319,6 +387,7 @@ func (s *cloudImageMetadataSuite) TestSupportedArchitectures(c *gc.C) {
 		Series:          "trusty",
 		Arch:            arch1,
 		VirtType:        "virtType-test",
+		Source:          "test",
 		RootStorageType: "rootStorageType-test"}
 
 	added := cloudimagemetadata.Metadata{attrs, 0, "1"}
@@ -353,6 +422,7 @@ func (s *cloudImageMetadataSuite) TestSupportedArchitecturesUnmatchedStreams(c *
 		Series:          "trusty",
 		Arch:            "arch",
 		VirtType:        "virtType-test",
+		Source:          "test",
 		RootStorageType: "rootStorageType-test"}
 
 	added := cloudimagemetadata.Metadata{attrs, 0, "1"}
@@ -376,6 +446,7 @@ func (s *cloudImageMetadataSuite) TestSupportedArchitecturesUnmatchedRegions(c *
 		Series:          "trusty",
 		Arch:            "arch",
 		VirtType:        "virtType-test",
+		Source:          "test",
 		RootStorageType: "rootStorageType-test"}
 
 	added := cloudimagemetadata.Metadata{attrs, 0, "1"}
@@ -399,6 +470,7 @@ func (s *cloudImageMetadataSuite) TestSupportedArchitecturesUnmatchedStreamsAndR
 		Series:          "trusty",
 		Arch:            "arch",
 		VirtType:        "virtType-test",
+		Source:          "test",
 		RootStorageType: "rootStorageType-test"}
 
 	added := cloudimagemetadata.Metadata{attrs, 0, "1"}
@@ -457,6 +529,7 @@ func (s *cloudImageMetadataSuite) addTestImageMetadata(c *gc.C, imageId string) 
 		Series:          "trusty",
 		Arch:            "arch",
 		VirtType:        "virtType-test",
+		Source:          "test",
 		RootStorageType: "rootStorageType-test"}
 
 	added := cloudimagemetadata.Metadata{attrs, 0, imageId}

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -124,6 +124,7 @@ func (s *CommonProvisionerSuite) SetUpTest(c *gc.C) {
 			VirtType:        "",
 			RootStorageType: "",
 			Source:          "test",
+			Stream:          "released",
 		},
 		10,
 		"-999",


### PR DESCRIPTION
The problem was that on some occasions, we'd save metadata without going through apiserver layer but by calling persistence (state layer) directly. The apiserver layer, however, populated some defaults if values are missing, for example, empty "stream" will contain "released".

In other words, we'd end up with some data in database that we couldn't easily retrieve using our filters. Our filters are pre-populated with sensible defaults when we look for available image metadata.

Related pieces of code in both provisioner and bootstrap now ensure that data contains our standard defaults before persisting.

Implementation bikeshed :D
1. Is apiserverimagemetadata an ok import alias?
2. Is it ok that custom image metadata default region is that of controller when it is not specified explicitly?
3. Should image metadata architecture default be amd64 or should it be host architecture? 
4. Should SupplyWithDefault call be located on apiserver or should it be refactored to a different common location?

QA steps:
1. Bootstrap private cloud using --metadata-source (locally, I have disabled official data sources to ensure my metadata is picked up)
2. Deploy an application (I used ubuntu)
3. Make sure that unit machine comes up with the right image

(Review request: http://reviews.vapour.ws/r/5502/)