### PR TITLE
api, apiserver: Added support for GetMetricsForModel

### DIFF
--- a/api/metricsdebug/client.go
+++ b/api/metricsdebug/client.go
@@ -23,6 +23,9 @@ type Client struct {
 // MetricsDebugClient defines the methods on the metricsdebug API end point.
 type MetricsDebugClient interface {
 	// GetMetrics will receive metrics collected by the given entity tags
+	// The tags act as a filter over what is to be returned. If tags are
+	// supplied GetMetrics will return all the metrics recorded in the
+	// current model.
 	GetMetrics(tags ...string) ([]params.MetricResult, error)
 }
 

--- a/api/metricsdebug/client.go
+++ b/api/metricsdebug/client.go
@@ -23,9 +23,7 @@ type Client struct {
 // MetricsDebugClient defines the methods on the metricsdebug API end point.
 type MetricsDebugClient interface {
 	// GetMetrics will receive metrics collected by the given entity tags
-	GetMetrics(tags []string) ([]params.MetricResult, error)
-	// GetMetricsForModel will receive metrics collected in the given model.
-	GetMetricsForModel(model string) ([]params.MetricResult, error)
+	GetMetrics(tags ...string) ([]params.MetricResult, error)
 }
 
 // MeterStatusClient defines methods on the metricsdebug API end point.
@@ -44,7 +42,7 @@ func NewClient(st base.APICallCloser) *Client {
 }
 
 // GetMetrics will receive metrics collected by the given entity
-func (c *Client) GetMetrics(tags []string) ([]params.MetricResult, error) {
+func (c *Client) GetMetrics(tags ...string) ([]params.MetricResult, error) {
 	entities := make([]params.Entity, len(tags))
 	for i, tag := range tags {
 		entities[i] = params.Entity{Tag: tag}
@@ -52,24 +50,6 @@ func (c *Client) GetMetrics(tags []string) ([]params.MetricResult, error) {
 	p := params.Entities{Entities: entities}
 	results := new(params.MetricResults)
 	if err := c.facade.FacadeCall("GetMetrics", p, results); err != nil {
-		return nil, errors.Trace(err)
-	}
-	if err := results.OneError(); err != nil {
-		return nil, errors.Trace(err)
-	}
-	metrics := []params.MetricResult{}
-	for _, r := range results.Results {
-		metrics = append(metrics, r.Metrics...)
-	}
-	return metrics, nil
-}
-
-func (c *Client) GetMetricsForModel(model string) ([]params.MetricResult, error) {
-	p := params.Entities{Entities: []params.Entity{
-		{Tag: model},
-	}}
-	results := new(params.MetricResults)
-	if err := c.facade.FacadeCall("GetMetricsForModel", p, results); err != nil {
 		return nil, errors.Trace(err)
 	}
 	if err := results.OneError(); err != nil {

--- a/api/metricsdebug/client.go
+++ b/api/metricsdebug/client.go
@@ -23,7 +23,7 @@ type Client struct {
 // MetricsDebugClient defines the methods on the metricsdebug API end point.
 type MetricsDebugClient interface {
 	// GetMetrics will receive metrics collected by the given entity tags
-	// The tags act as a filter over what is to be returned. If tags are
+	// The tags act as a filter over what is to be returned. If no tags are
 	// supplied GetMetrics will return all the metrics recorded in the
 	// current model.
 	GetMetrics(tags ...string) ([]params.MetricResult, error)

--- a/api/metricsdebug/client_test.go
+++ b/api/metricsdebug/client_test.go
@@ -134,6 +134,24 @@ func (s *metricsdebugSuiteMock) TestGetMetricsForModel(c *gc.C) {
 	c.Assert(metrics[0].Time, gc.Equals, now)
 }
 
+func (s *metricsdebugSuiteMock) TestGetMetricsForModelFails(c *gc.C) {
+	var called bool
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			requestParam, response interface{},
+		) error {
+			called = true
+			return errors.New("an error")
+		})
+	client := metricsdebug.NewClient(apiCaller)
+	metrics, err := client.GetMetrics()
+	c.Assert(called, jc.IsTrue)
+	c.Assert(metrics, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "an error")
+}
+
 func (s *metricsdebugSuiteMock) TestSetMeterStatus(c *gc.C) {
 	var called bool
 	apiCaller := basetesting.APICallerFunc(

--- a/api/metricsdebug/client_test.go
+++ b/api/metricsdebug/client_test.go
@@ -50,7 +50,7 @@ func (s *metricsdebugSuiteMock) TestGetMetrics(c *gc.C) {
 			return nil
 		})
 	client := metricsdebug.NewClient(apiCaller)
-	metrics, err := client.GetMetrics("unit-wordpress/0")
+	metrics, err := client.GetMetrics([]string{"unit-wordpress/0"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 	c.Assert(metrics, gc.HasLen, 1)
@@ -76,7 +76,7 @@ func (s *metricsdebugSuiteMock) TestGetMetricsFails(c *gc.C) {
 			return nil
 		})
 	client := metricsdebug.NewClient(apiCaller)
-	metrics, err := client.GetMetrics("unit-wordpress/0")
+	metrics, err := client.GetMetrics([]string{"unit-wordpress/0"})
 	c.Assert(err, gc.ErrorMatches, "an error")
 	c.Assert(metrics, gc.IsNil)
 	c.Assert(called, jc.IsTrue)
@@ -94,10 +94,44 @@ func (s *metricsdebugSuiteMock) TestGetMetricsFacadeCallError(c *gc.C) {
 			return errors.New("an error")
 		})
 	client := metricsdebug.NewClient(apiCaller)
-	metrics, err := client.GetMetrics("unit-wordpress/0")
+	metrics, err := client.GetMetrics([]string{"unit-wordpress/0"})
 	c.Assert(err, gc.ErrorMatches, "an error")
 	c.Assert(metrics, gc.IsNil)
 	c.Assert(called, jc.IsTrue)
+}
+
+func (s *metricsdebugSuiteMock) TestGetMetricsForModel(c *gc.C) {
+	var called bool
+	now := time.Now()
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			requestParam, response interface{},
+		) error {
+			c.Assert(request, gc.Equals, "GetMetricsForModel")
+			entities := requestParam.(params.Entities)
+			c.Assert(entities.Entities[0].Tag, gc.Equals, "model")
+			result := response.(*params.MetricResults)
+			result.Results = []params.EntityMetrics{{
+				Metrics: []params.MetricResult{{
+					Key:   "pings",
+					Value: "5",
+					Time:  now,
+				}},
+				Error: nil,
+			}}
+			called = true
+			return nil
+		})
+	client := metricsdebug.NewClient(apiCaller)
+	metrics, err := client.GetMetricsForModel("model")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+	c.Assert(metrics, gc.HasLen, 1)
+	c.Assert(metrics[0].Key, gc.Equals, "pings")
+	c.Assert(metrics[0].Value, gc.Equals, "5")
+	c.Assert(metrics[0].Time, gc.Equals, now)
 }
 
 func (s *metricsdebugSuiteMock) TestSetMeterStatus(c *gc.C) {
@@ -199,7 +233,7 @@ func (s *metricsdebugSuite) TestFeatureGetMetrics(c *gc.C) {
 	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	metric := s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit})
-	metrics, err := s.manager.GetMetrics("unit-metered/0")
+	metrics, err := s.manager.GetMetrics([]string{"unit-metered/0"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metrics, gc.HasLen, 1)
 	assertSameMetric(c, metrics[0], metric)
@@ -220,15 +254,41 @@ func (s *metricsdebugSuite) TestFeatureGetMultipleMetrics(c *gc.C) {
 		Unit: unit1,
 	})
 
-	metrics0, err := s.manager.GetMetrics("unit-metered/0")
+	metrics0, err := s.manager.GetMetrics([]string{"unit-metered/0"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metrics0, gc.HasLen, 1)
 	assertSameMetric(c, metrics0[0], metricUnit0)
 
-	metrics1, err := s.manager.GetMetrics("unit-metered/1")
+	metrics1, err := s.manager.GetMetrics([]string{"unit-metered/1"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metrics1, gc.HasLen, 1)
 	assertSameMetric(c, metrics1[0], metricUnit1)
+
+	metrics2, err := s.manager.GetMetrics([]string{"unit-metered/0", "unit-metered/1"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metrics2, gc.HasLen, 2)
+}
+
+func (s *metricsdebugSuite) TestFeatureGetMetricsForModel(c *gc.C) {
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Charm: meteredCharm,
+	})
+	unit0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+
+	metricUnit0 := s.Factory.MakeMetric(c, &factory.MetricParams{
+		Unit: unit0,
+	})
+	metricUnit1 := s.Factory.MakeMetric(c, &factory.MetricParams{
+		Unit: unit1,
+	})
+
+	metrics, err := s.manager.GetMetricsForModel(s.State.ModelTag().String())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metrics, gc.HasLen, 2)
+	assertSameMetric(c, metrics[0], metricUnit0)
+	assertSameMetric(c, metrics[1], metricUnit1)
 }
 
 func (s *metricsdebugSuite) TestFeatureGetMultipleMetricsWithService(c *gc.C) {
@@ -246,7 +306,7 @@ func (s *metricsdebugSuite) TestFeatureGetMultipleMetricsWithService(c *gc.C) {
 		Unit: unit1,
 	})
 
-	metrics, err := s.manager.GetMetrics("application-metered")
+	metrics, err := s.manager.GetMetrics([]string{"application-metered"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metrics, gc.HasLen, 2)
 	assertSameMetric(c, metrics[0], metricUnit0)

--- a/apiserver/metricsdebug/metricsdebug.go
+++ b/apiserver/metricsdebug/metricsdebug.go
@@ -99,25 +99,29 @@ func (api *MetricsDebugAPI) GetMetrics(args params.Entities) (params.MetricResul
 			err := errors.Errorf("invalid tag %v", arg.Tag)
 			results.Results[i].Error = common.ServerError(err)
 		}
-		metricCount := 0
-		for _, b := range batches {
-			metricCount += len(b.Metrics())
-		}
-		metrics := make([]params.MetricResult, metricCount)
-		ix := 0
-		for _, mb := range batches {
-			for _, m := range mb.Metrics() {
-				metrics[ix] = params.MetricResult{
-					Key:   m.Key,
-					Value: m.Value,
-					Time:  m.Time,
-				}
-				ix++
-			}
-			results.Results[i].Metrics = metrics
-		}
+		results.Results[i].Metrics = api.metricBatchesToMetricResult(batches)
 	}
 	return results, nil
+}
+
+func (api *MetricsDebugAPI) metricBatchesToMetricResult(batches []state.MetricBatch) []params.MetricResult {
+	metricCount := 0
+	for _, b := range batches {
+		metricCount += len(b.Metrics())
+	}
+	metrics := make([]params.MetricResult, metricCount)
+	ix := 0
+	for _, mb := range batches {
+		for _, m := range mb.Metrics() {
+			metrics[ix] = params.MetricResult{
+				Key:   m.Key,
+				Value: m.Value,
+				Time:  m.Time,
+			}
+			ix++
+		}
+	}
+	return metrics
 }
 
 // SetMeterStatus sets meter statuses for entities.

--- a/apiserver/metricsdebug/metricsdebug.go
+++ b/apiserver/metricsdebug/metricsdebug.go
@@ -26,7 +26,7 @@ type metricsDebug interface {
 	// MetricBatchesForApplication returns metric batches for the given application.
 	MetricBatchesForApplication(application string) ([]state.MetricBatch, error)
 
-	//MetricBatchesForModel returns metrics batches for all applications in the model.
+	//MetricBatchesForModel returns all metrics batches in the model.
 	MetricBatchesForModel() ([]state.MetricBatch, error)
 
 	// Unit returns the unit based on its name.
@@ -76,11 +76,7 @@ func (api *MetricsDebugAPI) GetMetrics(args params.Entities) (params.MetricResul
 	if len(args.Entities) == 0 {
 		batches, err := api.state.MetricBatchesForModel()
 		if err != nil {
-			return params.MetricResults{
-				Results: []params.EntityMetrics{{
-					Error: common.ServerError(err),
-				}},
-			}, errors.Annotate(err, "failed to get metrics")
+			return results, errors.Annotate(err, "failed to get metrics")
 		}
 		return params.MetricResults{
 			Results: []params.EntityMetrics{{

--- a/apiserver/metricsdebug/metricsdebug_test.go
+++ b/apiserver/metricsdebug/metricsdebug_test.go
@@ -298,12 +298,16 @@ func (s *metricsDebugSuite) TestGetModelNoMocks(c *gc.C) {
 	metrics, err := s.metricsdebug.GetMetrics(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metrics.Results, gc.HasLen, 1)
-	c.Assert(metrics.Results[0].Metrics[0].Key, gc.Equals, metricUnit0.Metrics()[0].Key)
-	c.Assert(metrics.Results[0].Metrics[0].Value, gc.Equals, metricUnit0.Metrics()[0].Value)
-	c.Assert(metrics.Results[0].Metrics[0].Time, jc.TimeBetween(metricUnit0.Metrics()[0].Time, metricUnit0.Metrics()[0].Time))
-	c.Assert(metrics.Results[0].Metrics[0].Unit, gc.Equals, metricUnit0.Unit())
-	c.Assert(metrics.Results[0].Metrics[1].Key, gc.Equals, metricUnit1.Metrics()[0].Key)
-	c.Assert(metrics.Results[0].Metrics[1].Value, gc.Equals, metricUnit1.Metrics()[0].Value)
-	c.Assert(metrics.Results[0].Metrics[1].Time, jc.TimeBetween(metricUnit1.Metrics()[0].Time, metricUnit1.Metrics()[0].Time))
-	c.Assert(metrics.Results[0].Metrics[1].Unit, gc.Equals, metricUnit1.Unit())
+	metric0 := metrics.Results[0].Metrics[0]
+	metric1 := metrics.Results[0].Metrics[1]
+	expected0 := metricUnit0.Metrics()[0]
+	expected1 := metricUnit1.Metrics()[0]
+	c.Assert(metric0.Key, gc.Equals, expected0.Key)
+	c.Assert(metric0.Value, gc.Equals, expected0.Value)
+	c.Assert(metric0.Time, jc.TimeBetween(expected0.Time, expected0.Time))
+	c.Assert(metric0.Unit, gc.Equals, metricUnit0.Unit())
+	c.Assert(metric1.Key, gc.Equals, expected1.Key)
+	c.Assert(metric1.Value, gc.Equals, expected1.Value)
+	c.Assert(metric1.Time, jc.TimeBetween(expected1.Time, expected1.Time))
+	c.Assert(metric1.Unit, gc.Equals, metricUnit1.Unit())
 }

--- a/apiserver/metricsdebug/metricsdebug_test.go
+++ b/apiserver/metricsdebug/metricsdebug_test.go
@@ -173,9 +173,10 @@ func (s *metricsDebugSuite) TestGetMetrics(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
 	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
-	newTime := time.Now().Round(time.Second)
-	metricA := state.Metric{"pings", "5", newTime}
-	metricB := state.Metric{"pings", "10.5", newTime}
+	t0 := time.Now().Round(time.Second)
+	t1 := t0.Add(time.Second)
+	metricA := state.Metric{"pings", "5", t0}
+	metricB := state.Metric{"pings", "10.5", t1}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit, Metrics: []state.Metric{metricA}})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit, Metrics: []state.Metric{metricA, metricB}})
 	args := params.Entities{Entities: []params.Entity{
@@ -184,30 +185,132 @@ func (s *metricsDebugSuite) TestGetMetrics(c *gc.C) {
 	result, err := s.metricsdebug.GetMetrics(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Metrics, gc.HasLen, 3)
+	c.Assert(result.Results[0].Metrics, gc.HasLen, 1)
 	c.Assert(result.Results[0], jc.DeepEquals, params.EntityMetrics{
 		Metrics: []params.MetricResult{
 			{
 				Key:   "pings",
-				Value: "5",
-				Time:  newTime,
-				Unit:  "metered/0",
-			},
-			{
-				Key:   "pings",
-				Value: "5",
-				Time:  newTime,
-				Unit:  "metered/0",
-			},
-			{
-				Key:   "pings",
 				Value: "10.5",
-				Time:  newTime,
+				Time:  t1,
 				Unit:  "metered/0",
 			},
 		},
 		Error: nil,
 	})
+}
+
+func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectly(c *gc.C) {
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
+	unit0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	t0 := time.Now().Round(time.Second)
+	t1 := t0.Add(time.Second)
+	metricA := state.Metric{"pings", "5", t1}
+	metricB := state.Metric{"pings", "10.5", t0}
+	metricC := state.Metric{"juju-units", "8", t1}
+	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit0, Metrics: []state.Metric{metricA, metricB, metricC}})
+	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit1, Metrics: []state.Metric{metricA, metricB, metricC}})
+	args := params.Entities{}
+	result, err := s.metricsdebug.GetMetrics(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Metrics, gc.HasLen, 4)
+	c.Assert(result.Results[0].Metrics, jc.SameContents, []params.MetricResult{{
+		Key:   "pings",
+		Value: "5",
+		Time:  t1,
+		Unit:  "metered/0",
+	}, {
+		Key:   "juju-units",
+		Value: "8",
+		Time:  t1,
+		Unit:  "metered/0",
+	}, {
+		Key:   "pings",
+		Value: "5",
+		Time:  t1,
+		Unit:  "metered/1",
+	}, {
+		Key:   "juju-units",
+		Value: "8",
+		Time:  t1,
+		Unit:  "metered/1",
+	}},
+	)
+}
+
+func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectlyWhenNotAllMetricsInEachBatch(c *gc.C) {
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
+	unit0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	t0 := time.Now().Round(time.Second)
+	t1 := t0.Add(time.Second)
+	metricA := state.Metric{"pings", "5", t1}
+	metricB := state.Metric{"pings", "10.5", t0}
+	metricC := state.Metric{"juju-units", "8", t1}
+	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit0, Metrics: []state.Metric{metricA, metricB, metricC}})
+	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit1, Metrics: []state.Metric{metricA, metricB}})
+	args := params.Entities{}
+	result, err := s.metricsdebug.GetMetrics(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Metrics, gc.HasLen, 3)
+	c.Assert(result.Results[0].Metrics, jc.SameContents, []params.MetricResult{{
+		Key:   "pings",
+		Value: "5",
+		Time:  t1,
+		Unit:  "metered/0",
+	}, {
+		Key:   "juju-units",
+		Value: "8",
+		Time:  t1,
+		Unit:  "metered/0",
+	}, {
+		Key:   "pings",
+		Value: "5",
+		Time:  t1,
+		Unit:  "metered/1",
+	}},
+	)
+}
+
+func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectlyWithMultipleBatchesPerUnit(c *gc.C) {
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
+	unit0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	t0 := time.Now().Round(time.Second)
+	t1 := t0.Add(time.Second)
+	metricA := state.Metric{"pings", "5", t1}
+	metricB := state.Metric{"pings", "10.5", t0}
+	metricC := state.Metric{"juju-units", "8", t1}
+	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit0, Metrics: []state.Metric{metricA, metricB}})
+	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit0, Metrics: []state.Metric{metricC}})
+	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit1, Metrics: []state.Metric{metricA, metricB}})
+	args := params.Entities{}
+	result, err := s.metricsdebug.GetMetrics(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Metrics, gc.HasLen, 3)
+	c.Assert(result.Results[0].Metrics, jc.SameContents, []params.MetricResult{{
+		Key:   "pings",
+		Value: "5",
+		Time:  t1,
+		Unit:  "metered/0",
+	}, {
+		Key:   "juju-units",
+		Value: "8",
+		Time:  t1,
+		Unit:  "metered/0",
+	}, {
+		Key:   "pings",
+		Value: "5",
+		Time:  t1,
+		Unit:  "metered/1",
+	}},
+	)
 }
 
 func (s *metricsDebugSuite) TestGetMultipleMetricsNoMocks(c *gc.C) {

--- a/apiserver/params/metrics.go
+++ b/apiserver/params/metrics.go
@@ -32,8 +32,8 @@ type EntityMetrics struct {
 
 // MetricResult contains a single metric.
 type MetricResult struct {
+	Time  time.Time `json:"time"`
 	Key   string    `json:"key"`
 	Value string    `json:"value"`
-	Time  time.Time `json:"time"`
 	Unit  string    `json:"unit"`
 }

--- a/apiserver/params/metrics.go
+++ b/apiserver/params/metrics.go
@@ -32,8 +32,8 @@ type EntityMetrics struct {
 
 // MetricResult contains a single metric.
 type MetricResult struct {
-	Time  time.Time `json:"time"`
 	Key   string    `json:"key"`
 	Value string    `json:"value"`
+	Time  time.Time `json:"time"`
 	Unit  string    `json:"unit"`
 }

--- a/apiserver/params/metrics.go
+++ b/apiserver/params/metrics.go
@@ -30,7 +30,7 @@ type EntityMetrics struct {
 	Error   *Error         `json:"error,omitempty"`
 }
 
-// MetricResults contains a single metric.
+// MetricResult contains a single metric.
 type MetricResult struct {
 	Time  time.Time `json:"time"`
 	Key   string    `json:"key"`

--- a/apiserver/params/metrics.go
+++ b/apiserver/params/metrics.go
@@ -35,4 +35,5 @@ type MetricResult struct {
 	Time  time.Time `json:"time"`
 	Key   string    `json:"key"`
 	Value string    `json:"value"`
+	Unit  string    `json:"unit"`
 }

--- a/cmd/juju/metricsdebug/metricsdebug.go
+++ b/cmd/juju/metricsdebug/metricsdebug.go
@@ -73,7 +73,7 @@ func (c *DebugMetricsCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 type GetMetricsClient interface {
-	GetMetrics(tag string) ([]params.MetricResult, error)
+	GetMetrics(tag ...string) ([]params.MetricResult, error)
 	Close() error
 }
 

--- a/cmd/juju/metricsdebug/metricsdebug_test.go
+++ b/cmd/juju/metricsdebug/metricsdebug_test.go
@@ -32,7 +32,7 @@ type MockGetMetricsClient struct {
 	testing.Stub
 }
 
-func (m *MockGetMetricsClient) GetMetrics(tag string) ([]params.MetricResult, error) {
+func (m *MockGetMetricsClient) GetMetrics(tag ...string) ([]params.MetricResult, error) {
 	m.Stub.MethodCall(m, "GetMetrics", tag)
 	return nil, nil
 }

--- a/cmd/juju/metricsdebug/metricsdebug_test.go
+++ b/cmd/juju/metricsdebug/metricsdebug_test.go
@@ -54,7 +54,7 @@ func (s *DebugMetricsMockSuite) TestUnit(c *gc.C) {
 	})
 	_, err := coretesting.RunCommand(c, metricsdebug.New(), "metered/0")
 	c.Assert(err, jc.ErrorIsNil)
-	client.CheckCall(c, 0, "GetMetrics", "unit-metered-0")
+	client.CheckCall(c, 0, "GetMetrics", []string{"unit-metered-0"})
 }
 
 func (s *DebugMetricsMockSuite) TestService(c *gc.C) {
@@ -64,7 +64,7 @@ func (s *DebugMetricsMockSuite) TestService(c *gc.C) {
 	})
 	_, err := coretesting.RunCommand(c, metricsdebug.New(), "metered")
 	c.Assert(err, jc.ErrorIsNil)
-	client.CheckCall(c, 0, "GetMetrics", "application-metered")
+	client.CheckCall(c, 0, "GetMetrics", []string{"application-metered"})
 }
 
 func (s *DebugMetricsMockSuite) TestNotValidServiceOrUnit(c *gc.C) {
@@ -101,7 +101,6 @@ func (s *DebugMetricsCommandSuite) TestUnits(c *gc.C) {
 	expectedOutput := bytes.Buffer{}
 	tw := tabwriter.NewWriter(&expectedOutput, 0, 1, 1, ' ', 0)
 	fmt.Fprintf(tw, "TIME\tMETRIC\tVALUE\n")
-	fmt.Fprintf(tw, "%v\tpings\t5\n", outputTime)
 	fmt.Fprintf(tw, "%v\tpings\t10.5\n", outputTime)
 	tw.Flush()
 	ctx, err := coretesting.RunCommand(c, metricsdebug.New(), "metered/1")
@@ -124,7 +123,7 @@ func (s *DebugMetricsCommandSuite) TestServiceWithNoption(c *gc.C) {
 	tw := tabwriter.NewWriter(&expectedOutput, 0, 1, 1, ' ', 0)
 	fmt.Fprintf(tw, "TIME\tMETRIC\tVALUE\n")
 	fmt.Fprintf(tw, "%v\tpings\t5\n", outputTime)
-	fmt.Fprintf(tw, "%v\tpings\t5\n", outputTime)
+	fmt.Fprintf(tw, "%v\tpings\t10.5\n", outputTime)
 	tw.Flush()
 	ctx, err := coretesting.RunCommand(c, metricsdebug.New(), "metered", "-n", "2")
 	c.Assert(err, jc.ErrorIsNil)
@@ -145,7 +144,6 @@ func (s *DebugMetricsCommandSuite) TestServiceWithNoptionGreaterThanMetricCount(
 	expectedOutput := bytes.Buffer{}
 	tw := tabwriter.NewWriter(&expectedOutput, 0, 1, 1, ' ', 0)
 	fmt.Fprintf(tw, "TIME\tMETRIC\tVALUE\n")
-	fmt.Fprintf(tw, "%v\tpings\t5\n", outputTime)
 	fmt.Fprintf(tw, "%v\tpings\t5\n", outputTime)
 	fmt.Fprintf(tw, "%v\tpings\t10.5\n", outputTime)
 	tw.Flush()
@@ -177,19 +175,10 @@ func (s *DebugMetricsCommandSuite) TestUnitJsonOutput(c *gc.C) {
     {
         "time": "%v",
         "key": "pings",
-        "value": "5"
-    },
-    {
-        "time": "%v",
-        "key": "pings",
-        "value": "5"
-    },
-    {
-        "time": "%v",
-        "key": "pings",
-        "value": "10.5"
+        "value": "10.5",
+        "unit": "metered/0"
     }
-]`, outputTime, outputTime, outputTime)
+]`, outputTime)
 	ctx, err := coretesting.RunCommand(c, metricsdebug.New(), "metered/0", "--json")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, expectedOutput)

--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -868,17 +868,17 @@ func (s *MetricLocalCharmSuite) TestUnitMetricBatchesReturnsAllCharms(c *gc.C) {
 }
 
 func (s *MetricLocalCharmSuite) TestUnique(c *gc.C) {
-	now := state.NowToTheSecond()
-	t1 := now.Add(time.Second)
+	t0 := state.NowToTheSecond()
+	t1 := t0.Add(time.Second)
 	batch, err := s.State.AddMetrics(
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
-			Created:  now,
+			Created:  t0,
 			CharmURL: s.meteredCharm.URL().String(),
 			Metrics: []state.Metric{{
 				Key:   "pings",
 				Value: "1",
-				Time:  now,
+				Time:  t0,
 			}, {
 				Key:   "pings",
 				Value: "2",
@@ -890,7 +890,7 @@ func (s *MetricLocalCharmSuite) TestUnique(c *gc.C) {
 			}, {
 				Key:   "juju-units",
 				Value: "2",
-				Time:  now,
+				Time:  t0,
 			}},
 			Unit: s.unit.UnitTag(),
 		},

--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -867,6 +867,48 @@ func (s *MetricLocalCharmSuite) TestUnitMetricBatchesReturnsAllCharms(c *gc.C) {
 	c.Assert(metricBatches, gc.HasLen, 1)
 }
 
+func (s *MetricLocalCharmSuite) TestUnique(c *gc.C) {
+	now := state.NowToTheSecond()
+	t1 := now.Add(time.Second)
+	batch, err := s.State.AddMetrics(
+		state.BatchParam{
+			UUID:     utils.MustNewUUID().String(),
+			Created:  now,
+			CharmURL: s.meteredCharm.URL().String(),
+			Metrics: []state.Metric{{
+				Key:   "pings",
+				Value: "1",
+				Time:  now,
+			}, {
+				Key:   "pings",
+				Value: "2",
+				Time:  t1,
+			}, {
+				Key:   "juju-units",
+				Value: "1",
+				Time:  t1,
+			}, {
+				Key:   "juju-units",
+				Value: "2",
+				Time:  now,
+			}},
+			Unit: s.unit.UnitTag(),
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	metrics := batch.UniqueMetrics()
+	c.Assert(metrics, gc.HasLen, 2)
+	c.Assert(metrics, jc.SameContents, []state.Metric{{
+		Key:   "pings",
+		Value: "2",
+		Time:  t1,
+	}, {
+		Key:   "juju-units",
+		Value: "1",
+		Time:  t1,
+	}})
+}
+
 type modelData struct {
 	state        *state.State
 	application  *state.Application


### PR DESCRIPTION
This change is to support a follow up change to the juju metrics command. The apiserver now supports querying all metrics in a given model.

In addition the response includes the Unit for each metric

(Review request: http://reviews.vapour.ws/r/5504/)