### PR TITLE
Fix interactive bootstrap with upload tools

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -182,21 +182,6 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *bootstrapCommand) Init(args []string) (err error) {
-	if len(args) == 0 {
-		switch c.flagset.NFlag() {
-		case 0:
-			// no args or flags, go interactive.
-			c.interactive = true
-			return nil
-		case 1:
-			if c.BuildAgent {
-				// juju bootstrap --build-agent is ok for interactive, too.
-				c.interactive = true
-				return nil
-			}
-			// some other flag was set, which means non-interactive.
-		}
-	}
 	if c.showClouds && c.showRegionsForCloud != "" {
 		return errors.New("--clouds and --regions can't be used together")
 	}
@@ -252,9 +237,14 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 		return errors.New("requested agent version major.minor mismatch")
 	}
 
-	// The user must specify two positional arguments: the controller name,
-	// and the cloud name (optionally with region specified).
-	if len(args) < 2 {
+	switch len(args) {
+	case 0:
+		// no args or flags, go interactive.
+		c.interactive = true
+		return nil
+	case 1:
+		// The user must specify both positional arguments: the controller name,
+		// and the cloud name (optionally with region specified).
 		return errors.New("controller name and cloud name are required")
 	}
 	c.controllerName = args[0]

--- a/cmd/juju/commands/bootstrap_interactive_test.go
+++ b/cmd/juju/commands/bootstrap_interactive_test.go
@@ -15,6 +15,7 @@ import (
 
 	jujucloud "github.com/juju/juju/cloud"
 	jujutesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 type BSInteractSuite struct {
@@ -52,11 +53,18 @@ func (BSInteractSuite) TestInitTwoArgs(c *gc.C) {
 	c.Assert(cmd.interactive, jc.IsFalse)
 }
 
-func (BSInteractSuite) TestInitOtherFlag(c *gc.C) {
+func (BSInteractSuite) TestInitInfoOnlyFlag(c *gc.C) {
 	cmd := &bootstrapCommand{}
 	err := jujutesting.InitCommand(cmd, []string{"--clouds"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmd.interactive, jc.IsFalse)
+}
+
+func (BSInteractSuite) TestInitVariousFlags(c *gc.C) {
+	cmd := &bootstrapCommand{}
+	err := jujutesting.InitCommand(cmd, []string{"--keep-broken", "--agent-version", version.Current.String()})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmd.interactive, jc.IsTrue)
 }
 
 func (BSInteractSuite) TestQueryCloud(c *gc.C) {


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1615868

Juju was too strict on deciding to run interactive bootstrap, and consequently important arg parsing was not being run. Besides that, interactive is about prompting for missing cloud and controller name - there's no reason why other args such as --keep-broken or --debug should no be able to be used with interactive mode.

(Review request: http://reviews.vapour.ws/r/5506/)