### PR TITLE
provider/azure: reduce API calls in provisioning

### DIFF
--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -210,7 +210,7 @@ func (env *azureEnviron) Create(args environs.CreateParams) error {
 	if err := verifyCredentials(env); err != nil {
 		return errors.Trace(err)
 	}
-	return errors.Trace(env.initResourceGroup(args.ControllerUUID))
+	return errors.Trace(env.initResourceGroup(args.ControllerUUID, nil))
 }
 
 // Bootstrap is part of the Environ interface.
@@ -219,7 +219,8 @@ func (env *azureEnviron) Bootstrap(
 	args environs.BootstrapParams,
 ) (*environs.BootstrapResult, error) {
 
-	if err := env.initResourceGroup(args.ControllerConfig.ControllerUUID()); err != nil {
+	apiPort := args.ControllerConfig.APIPort()
+	if err := env.initResourceGroup(args.ControllerConfig.ControllerUUID(), &apiPort); err != nil {
 		return nil, errors.Annotate(err, "creating controller resource group")
 	}
 	result, err := common.Bootstrap(ctx, env, args)
@@ -236,7 +237,7 @@ func (env *azureEnviron) Bootstrap(
 // initResourceGroup creates and initialises a resource group for this
 // environment. The resource group will have a storage account, and
 // internal network and subnet.
-func (env *azureEnviron) initResourceGroup(controllerUUID string) error {
+func (env *azureEnviron) initResourceGroup(controllerUUID string, apiPort *int) error {
 	location := env.location
 	resourceGroupsClient := resources.GroupsClient{env.resources}
 	networkClient := env.network
@@ -264,29 +265,45 @@ func (env *azureEnviron) initResourceGroup(controllerUUID string) error {
 
 	// Create an internal network for all VMs in the
 	// resource group to connect to.
-	vnet, err := createInternalVirtualNetwork(
-		env.callAPI, networkClient, env.resourceGroup, location, tags,
-	)
-	if err != nil {
+	if _, err := createInternalVirtualNetwork(
+		env.callAPI, networkClient,
+		env.subscriptionId, env.resourceGroup,
+		location, tags,
+	); err != nil {
 		return errors.Annotate(err, "creating virtual network")
 	}
 
 	// Create an network security group which will be
 	// associated with all machines.
-	nsg, err := createInternalNetworkSecurityGroup(
-		env.callAPI, networkClient, env.resourceGroup, location, tags,
-	)
-	if err != nil {
+	if _, err := createInternalNetworkSecurityGroup(
+		env.callAPI, networkClient,
+		env.subscriptionId, env.resourceGroup,
+		location, tags, apiPort,
+	); err != nil {
 		return errors.Annotate(err, "creating security group")
 	}
 
-	_, err = createInternalNetworkSubnet(
-		env.callAPI, networkClient, env.resourceGroup,
+	// Create a subnet to which all machines will be attached.
+	if _, err := createInternalNetworkSubnet(
+		env.callAPI, networkClient,
+		env.subscriptionId, env.resourceGroup,
 		internalSubnetName, internalSubnetPrefix,
-		vnet, nsg, location, tags,
-	)
-	if err != nil {
+		location, tags,
+	); err != nil {
 		return errors.Annotate(err, "creating subnet")
+	}
+
+	if apiPort != nil {
+		// apiPort is non-nil only for the controller model. Create
+		// a subnet to which controller machines will be attached.
+		if _, err := createInternalNetworkSubnet(
+			env.callAPI, networkClient,
+			env.subscriptionId, env.resourceGroup,
+			controllerSubnetName, controllerSubnetPrefix,
+			location, tags,
+		); err != nil {
+			return errors.Annotate(err, "creating subnet")
+		}
 	}
 
 	// Create a storage account for the resource group.
@@ -500,11 +517,6 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 		env.mu.Unlock()
 		return nil, errors.Annotate(err, "getting storage account")
 	}
-	internalNetworkSubnet, err := env.getInternalSubnetLocked()
-	if err != nil {
-		env.mu.Unlock()
-		return nil, errors.Trace(err)
-	}
 	env.mu.Unlock()
 
 	// If the user has not specified a root-disk size, then
@@ -583,21 +595,12 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 	// machine with this.
 	vmTags[jujuMachineNameTag] = vmName
 
-	// If the machine will run a controller, then we need to open the
-	// API port for it.
-	var apiPortPtr *int
-	if args.InstanceConfig.Controller != nil {
-		apiPort := args.InstanceConfig.Controller.Config.APIPort()
-		apiPortPtr = &apiPort
-	}
-
 	vm, err := createVirtualMachine(
-		env.resourceGroup, location, vmName,
-		vmTags, envTags,
+		env.subscriptionId, env.resourceGroup,
+		location, vmName, vmTags, envTags,
 		instanceSpec, args.InstanceConfig,
 		args.DistributionGroup,
 		env.Instances,
-		apiPortPtr, internalNetworkSubnet,
 		storageAccount,
 		networkClient, vmClient,
 		availabilitySetClient, vmExtensionClient,
@@ -633,14 +636,12 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 // All resources created are tagged with the specified "vmTags", so if
 // this function fails then all resources can be deleted by tag.
 func createVirtualMachine(
-	resourceGroup, location, vmName string,
+	subscriptionId, resourceGroup, location, vmName string,
 	vmTags, envTags map[string]string,
 	instanceSpec *instances.InstanceSpec,
 	instanceConfig *instancecfg.InstanceConfig,
 	distributionGroupFunc func() ([]instance.Id, error),
 	instancesFunc func([]instance.Id) ([]instance.Instance, error),
-	apiPort *int,
-	internalNetworkSubnet *network.Subnet,
 	storageAccount *storage.Account,
 	networkClient network.ManagementClient,
 	vmClient compute.VirtualMachinesClient,
@@ -663,8 +664,12 @@ func createVirtualMachine(
 
 	networkProfile, err := newNetworkProfile(
 		callAPI, networkClient,
-		vmName, apiPort, internalNetworkSubnet,
-		resourceGroup, location, vmTags,
+		vmName,
+		instanceConfig.Controller != nil,
+		subscriptionId,
+		resourceGroup,
+		location,
+		vmTags,
 	)
 	if err != nil {
 		return compute.VirtualMachine{}, errors.Annotate(err, "creating network profile")
@@ -1387,13 +1392,6 @@ func (env *azureEnviron) getInstanceTypesLocked() (map[string]instances.Instance
 	}
 	env.instanceTypes = instanceTypes
 	return instanceTypes, nil
-}
-
-// getInternalSubnetLocked queries the internal subnet for the environment.
-func (env *azureEnviron) getInternalSubnetLocked() (*network.Subnet, error) {
-	return getInternalNetworkSubnet(
-		env.callAPI, env.network, env.resourceGroup, internalSubnetName,
-	)
 }
 
 // getStorageClient queries the storage account key, and uses it to construct

--- a/provider/azure/instance_test.go
+++ b/provider/azure/instance_test.go
@@ -376,6 +376,7 @@ func (s *instanceSuite) TestInstanceOpenPorts(c *gc.C) {
 	)
 	ipConfiguration := network.InterfaceIPConfiguration{
 		Properties: &network.InterfaceIPConfigurationPropertiesFormat{
+			Primary:          to.BoolPtr(true),
 			PrivateIPAddress: to.StringPtr("10.0.0.4"),
 			Subnet: &network.Subnet{
 				ID: to.StringPtr(internalSubnetId),
@@ -446,6 +447,7 @@ func (s *instanceSuite) TestInstanceOpenPortsAlreadyOpen(c *gc.C) {
 	)
 	ipConfiguration := network.InterfaceIPConfiguration{
 		Properties: &network.InterfaceIPConfigurationPropertiesFormat{
+			Primary:          to.BoolPtr(true),
 			PrivateIPAddress: to.StringPtr("10.0.0.4"),
 			Subnet: &network.Subnet{
 				ID: to.StringPtr(internalSubnetId),


### PR DESCRIPTION
Reduce the number of Azure API requests we make
when provisioning an instance. Instead of creating
and then fetching resources, we craft the resource
IDs ourselves and use them when constructing cross-
resource references.

A significant change here is that controller machines
and non-controller machines are now allocated to
separate subnets. This means that we can create a
single network security group rule to allow API
access for all controller machines. The subnets are
on the same virtual network, and the machines can
still communicate with each other across them.

(Review request: http://reviews.vapour.ws/r/5507/)