### PR TITLE
Reinstate the smart formatters for hook tools.

### DIFF
--- a/cmd/juju/action/status_test.go
+++ b/cmd/juju/action/status_test.go
@@ -114,9 +114,9 @@ func (s *StatusSuite) runTestCase(c *gc.C, tc statusTestCase) {
 		}
 		if len(tc.results) > 0 {
 			out := &bytes.Buffer{}
-			err := cmd.DefaultFormatters["yaml"](out, action.ActionResultsToMap(tc.results))
+			err := cmd.FormatYaml(out, action.ActionResultsToMap(tc.results))
 			c.Check(err, jc.ErrorIsNil)
-			c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, out.String()+"\n")
+			c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, out.String())
 			c.Check(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
 		}
 	}

--- a/cmd/juju/application/get.go
+++ b/cmd/juju/application/get.go
@@ -118,7 +118,7 @@ func (c *getCommand) Run(ctx *cmd.Context) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintln(ctx.Stdout, out.String())
+		fmt.Fprint(ctx.Stdout, out.String())
 		return nil
 	}
 

--- a/cmd/juju/commands/run_test.go
+++ b/cmd/juju/commands/run_test.go
@@ -264,7 +264,7 @@ func (s *RunSuite) TestRunForMachineAndUnit(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(testing.Stdout(context), gc.Equals, buff.String()+"\n")
+	c.Check(testing.Stdout(context), gc.Equals, buff.String())
 }
 
 func (s *RunSuite) TestBlockRunForMachineAndUnit(c *gc.C) {
@@ -325,7 +325,7 @@ func (s *RunSuite) TestAllMachines(c *gc.C) {
 	context, err := testing.RunCommand(c, newRunCommand(), "--format=json", "--all", "hostname")
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(testing.Stdout(context), gc.Equals, buff.String()+"\n")
+	c.Check(testing.Stdout(context), gc.Equals, buff.String())
 	c.Check(testing.Stderr(context), gc.Equals, "")
 }
 
@@ -383,11 +383,11 @@ func (s *RunSuite) TestSingleResponse(c *gc.C) {
 	}, {
 		message: "yaml output",
 		format:  "yaml",
-		stdout:  yamlFormatted.String() + "\n",
+		stdout:  yamlFormatted.String(),
 	}, {
 		message: "json output",
 		format:  "json",
-		stdout:  jsonFormatted.String() + "\n",
+		stdout:  jsonFormatted.String(),
 	}} {
 		c.Log(fmt.Sprintf("%v: %s", i, test.message))
 		args := []string{}

--- a/cmd/juju/model/get.go
+++ b/cmd/juju/model/get.go
@@ -120,7 +120,6 @@ func (c *getCommand) Run(ctx *cmd.Context) error {
 	if c.key != "" {
 		if value, found := attrs[c.key]; found {
 			err := cmd.FormatYaml(ctx.Stdout, value.Value)
-			fmt.Fprintln(ctx.Stdout)
 			if err != nil {
 				return err
 			}

--- a/cmd/juju/romulus/listagreements/listagreements.go
+++ b/cmd/juju/romulus/listagreements/listagreements.go
@@ -101,6 +101,7 @@ func formatJSON(writer io.Writer, value interface{}) error {
 	if err != nil {
 		return err
 	}
+	bytes = append(bytes, '\n')
 	_, err = writer.Write(bytes)
 	return err
 }

--- a/cmd/juju/romulus/listagreements/listagreements_test.go
+++ b/cmd/juju/romulus/listagreements/listagreements_test.go
@@ -61,8 +61,7 @@ const (
 func (s *listAgreementsSuite) TestGetUsersAgreements(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, listagreements.NewListAgreementsCommand())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `[]
-`)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "[]\n")
 	c.Assert(s.client.called, jc.IsTrue)
 
 	s.client.setError("well, this is embarassing")
@@ -94,8 +93,7 @@ func (s *listAgreementsSuite) TestGetUsersAgreements(c *gc.C) {
 func (s *listAgreementsSuite) TestGetUsersAgreementsWithTermOwner(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, listagreements.NewListAgreementsCommand())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `[]
-`)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "[]\n")
 	c.Assert(s.client.called, jc.IsTrue)
 
 	s.client.setError("well, this is embarassing")

--- a/cmd/juju/space/list_test.go
+++ b/cmd/juju/space/list_test.go
@@ -256,7 +256,7 @@ func (s *ListSuite) TestRunWhenNoSpacesExistSucceeds(c *gc.C) {
 
 	s.AssertRunSucceeds(c,
 		`no spaces to display\n`,
-		"\n", // empty stdout.
+		"", // empty stdout.
 	)
 
 	s.api.CheckCallNames(c, "ListSpaces", "Close")

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -20,7 +20,7 @@ github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24
 github.com/juju/ansiterm	git	f2548f919a28b707811b612420169a871a816b8c	2016-08-19T03:04:17Z
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	6791af0ab78efe88ff99c2a0095208b3b7a32055	2016-07-20T09:32:50Z
-github.com/juju/cmd	git	3764bbd1cd74c91a5fc019440bf812881f566481	2016-08-18T23:27:15Z
+github.com/juju/cmd	git	3d2841a2d279880e1ff93f09362025b5a91e9397	2016-08-23T09:39:17Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:32:58Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -20,7 +20,7 @@ github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24
 github.com/juju/ansiterm	git	f2548f919a28b707811b612420169a871a816b8c	2016-08-19T03:04:17Z
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	6791af0ab78efe88ff99c2a0095208b3b7a32055	2016-07-20T09:32:50Z
-github.com/juju/cmd	git	3d2841a2d279880e1ff93f09362025b5a91e9397	2016-08-23T09:39:17Z
+github.com/juju/cmd	git	1c6973d59b804e4d3c293fbf240f067e73436bc9	2016-08-23T10:31:14Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:32:58Z

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -39,7 +39,3 @@ const Migration = "migration"
 
 // DeveloperMode allows access to developer specific commands and behaviour.
 const DeveloperMode = "developer-mode"
-
-// SmartFormatter enables the deprecated "smart" formatter for the uniter
-// hook tools.
-const SmartFormatter = "smart-formatter"

--- a/worker/uniter/runner/jujuc/action-get.go
+++ b/worker/uniter/runner/jujuc/action-get.go
@@ -8,10 +8,6 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/gnuflag"
-	"github.com/juju/utils/featureflag"
-
-	"github.com/juju/juju/cmd/output"
-	"github.com/juju/juju/feature"
 )
 
 // ActionGetCommand implements the action-get command.
@@ -47,11 +43,7 @@ map as needed.
 // SetFlags handles known option flags; in this case, [--output={json|yaml}]
 // and --help.
 func (c *ActionGetCommand) SetFlags(f *gnuflag.FlagSet) {
-	if featureflag.Enabled(feature.SmartFormatter) {
-		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
-	} else {
-		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
-	}
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
 }
 
 // Init makes sure there are no additional unknown arguments to action-get.

--- a/worker/uniter/runner/jujuc/action-get_test.go
+++ b/worker/uniter/runner/jujuc/action-get_test.go
@@ -11,7 +11,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -52,7 +51,6 @@ func (s *ActionGetSuite) TestNonActionRunFail(c *gc.C) {
 }
 
 func (s *ActionGetSuite) TestActionGet(c *gc.C) {
-	s.SetFeatureFlags(feature.SmartFormatter)
 	var actionGetTestMaps = []map[string]interface{}{
 		{
 			"outfile": "foo.bz2",

--- a/worker/uniter/runner/jujuc/action-get_test.go
+++ b/worker/uniter/runner/jujuc/action-get_test.go
@@ -109,15 +109,15 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 	}{{
 		summary: "a simple empty map with nil key",
 		args:    []string{},
-		out:     "{}",
+		out:     "{}\n",
 	}, {
 		summary: "a simple empty map with nil key",
 		args:    []string{"--format", "yaml"},
-		out:     "{}",
+		out:     "{}\n",
 	}, {
 		summary: "a simple empty map with nil key",
 		args:    []string{"--format", "json"},
-		out:     "null",
+		out:     "null\n",
 	}, {
 		summary: "a nonexistent key",
 		args:    []string{"foo"},
@@ -127,7 +127,7 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 	}, {
 		summary: "a nonexistent key",
 		args:    []string{"--format", "json", "foo"},
-		out:     "null",
+		out:     "null\n",
 	}, {
 		summary:      "a nonexistent inner key",
 		args:         []string{"outfile.type"},
@@ -140,7 +140,7 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 		summary:      "a nonexistent inner key",
 		args:         []string{"--format", "json", "outfile.type"},
 		actionParams: actionGetTestMaps[1],
-		out:          "null",
+		out:          "null\n",
 	}, {
 		summary:      "a nonexistent inner key",
 		args:         []string{"outfile.type.1"},
@@ -153,7 +153,7 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 		summary:      "a nonexistent inner key",
 		args:         []string{"--format", "json", "outfile.type.1"},
 		actionParams: actionGetTestMaps[1],
-		out:          "null",
+		out:          "null\n",
 	}, {
 		summary:      "a map with a non-string key",
 		args:         []string{"outfile.type"},
@@ -166,22 +166,22 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 		summary:      "a map with a non-string key",
 		args:         []string{"--format", "json", "outfile.type"},
 		actionParams: actionGetTestMaps[3],
-		out:          "null",
+		out:          "null\n",
 	}, {
 		summary:      "a simple map of one value to one key",
 		args:         []string{},
 		actionParams: actionGetTestMaps[0],
-		out:          "outfile: foo.bz2",
+		out:          "outfile: foo.bz2\n",
 	}, {
 		summary:      "a simple map of one value to one key",
 		args:         []string{"--format", "yaml"},
 		actionParams: actionGetTestMaps[0],
-		out:          "outfile: foo.bz2",
+		out:          "outfile: foo.bz2\n",
 	}, {
 		summary:      "a simple map of one value to one key",
 		args:         []string{"--format", "json"},
 		actionParams: actionGetTestMaps[0],
-		out:          `{"outfile":"foo.bz2"}`,
+		out:          `{"outfile":"foo.bz2"}` + "\n",
 	}, {
 		summary:      "an entire map",
 		args:         []string{},
@@ -190,7 +190,7 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 			"  type:\n" +
 			"    \"1\": raw\n" +
 			"    \"2\": gzip\n" +
-			"    \"3\": bzip",
+			"    \"3\": bzip\n",
 	}, {
 		summary:      "an entire map",
 		args:         []string{"--format", "yaml"},
@@ -199,50 +199,50 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 			"  type:\n" +
 			"    \"1\": raw\n" +
 			"    \"2\": gzip\n" +
-			"    \"3\": bzip",
+			"    \"3\": bzip\n",
 	}, {
 		summary:      "an entire map",
 		args:         []string{"--format", "json"},
 		actionParams: actionGetTestMaps[2],
-		out:          `{"outfile":{"type":{"1":"raw","2":"gzip","3":"bzip"}}}`,
+		out:          `{"outfile":{"type":{"1":"raw","2":"gzip","3":"bzip"}}}` + "\n",
 	}, {
 		summary:      "an inner map value which is itself a map",
 		args:         []string{"outfile.type"},
 		actionParams: actionGetTestMaps[2],
 		out: "\"1\": raw\n" +
 			"\"2\": gzip\n" +
-			"\"3\": bzip",
+			"\"3\": bzip\n",
 	}, {
 		summary:      "an inner map value which is itself a map",
 		args:         []string{"--format", "yaml", "outfile.type"},
 		actionParams: actionGetTestMaps[2],
 		out: "\"1\": raw\n" +
 			"\"2\": gzip\n" +
-			"\"3\": bzip",
+			"\"3\": bzip\n",
 	}, {
 		summary:      "an inner map value which is itself a map",
 		args:         []string{"--format", "json", "outfile.type"},
 		actionParams: actionGetTestMaps[2],
-		out:          `{"1":"raw","2":"gzip","3":"bzip"}`,
+		out:          `{"1":"raw","2":"gzip","3":"bzip"}` + "\n",
 	}, {
 		summary:      "a map with an inner map keyed by interface{}",
 		args:         []string{"outfile.type"},
 		actionParams: actionGetTestMaps[4],
 		out: "\"1\": raw\n" +
 			"\"2\": gzip\n" +
-			"\"3\": bzip",
+			"\"3\": bzip\n",
 	}, {
 		summary:      "a map with an inner map keyed by interface{}",
 		args:         []string{"--format", "yaml", "outfile.type"},
 		actionParams: actionGetTestMaps[4],
 		out: "\"1\": raw\n" +
 			"\"2\": gzip\n" +
-			"\"3\": bzip",
+			"\"3\": bzip\n",
 	}, {
 		summary:      "a map with an inner map keyed by interface{}",
 		args:         []string{"--format", "json", "outfile.type"},
 		actionParams: actionGetTestMaps[4],
-		out:          `{"1":"raw","2":"gzip","3":"bzip"}`,
+		out:          `{"1":"raw","2":"gzip","3":"bzip"}` + "\n",
 	}, {
 		summary: "too many arguments",
 		args:    []string{"multiple", "keys"},
@@ -260,7 +260,7 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 		code := cmd.Main(com, ctx, t.args)
 		c.Check(code, gc.Equals, t.code)
 		if code == 0 {
-			c.Check(bufferString(ctx.Stdout), gc.Equals, t.out+"\n")
+			c.Check(bufferString(ctx.Stdout), gc.Equals, t.out)
 			c.Check(bufferString(ctx.Stderr), gc.Equals, "")
 		} else {
 			c.Check(bufferString(ctx.Stdout), gc.Equals, "")
@@ -283,8 +283,8 @@ Summary:
 get action parameters
 
 Options:
---format  (= yaml)
-    Specify output format (json|yaml)
+--format  (= smart)
+    Specify output format (json|smart|yaml)
 -o, --output (= "")
     Specify an output file
 

--- a/worker/uniter/runner/jujuc/config-get.go
+++ b/worker/uniter/runner/jujuc/config-get.go
@@ -8,10 +8,6 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/gnuflag"
-	"github.com/juju/utils/featureflag"
-
-	"github.com/juju/juju/cmd/output"
-	"github.com/juju/juju/feature"
 )
 
 // ConfigGetCommand implements the config-get command.
@@ -42,11 +38,7 @@ reported as null. <key> and --all are mutually exclusive.
 }
 
 func (c *ConfigGetCommand) SetFlags(f *gnuflag.FlagSet) {
-	if featureflag.Enabled(feature.SmartFormatter) {
-		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
-	} else {
-		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
-	}
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
 	f.BoolVar(&c.All, "a", false, "print all keys")
 	f.BoolVar(&c.All, "all", false, "")
 }

--- a/worker/uniter/runner/jujuc/config-get_test.go
+++ b/worker/uniter/runner/jujuc/config-get_test.go
@@ -35,8 +35,8 @@ var configGetKeyTests = []struct {
 	{[]string{"spline-reticulation"}, "45\n"},
 	{[]string{"--format", "yaml", "spline-reticulation"}, "45\n"},
 	{[]string{"--format", "json", "spline-reticulation"}, "45\n"},
-	{[]string{"missing"}, "\n"},
-	{[]string{"--format", "yaml", "missing"}, "\n"},
+	{[]string{"missing"}, ""},
+	{[]string{"--format", "yaml", "missing"}, ""},
 	{[]string{"--format", "json", "missing"}, "null\n"},
 }
 
@@ -140,8 +140,8 @@ print service configuration
 Options:
 -a, --all  (= false)
     print all keys
---format  (= yaml)
-    Specify output format (json|yaml)
+--format  (= smart)
+    Specify output format (json|smart|yaml)
 -o, --output (= "")
     Specify an output file
 
@@ -164,7 +164,7 @@ func (s *ConfigGetSuite) TestOutputPath(c *gc.C) {
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
 	content, err := ioutil.ReadFile(filepath.Join(ctx.Dir, "some-file"))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(content), gc.Equals, "false\n")
+	c.Assert(string(content), gc.Equals, "False\n")
 }
 
 func (s *ConfigGetSuite) TestUnknownArg(c *gc.C) {

--- a/worker/uniter/runner/jujuc/config-get_test.go
+++ b/worker/uniter/runner/jujuc/config-get_test.go
@@ -14,7 +14,6 @@ import (
 	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v2"
 
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -41,7 +40,6 @@ var configGetKeyTests = []struct {
 }
 
 func (s *ConfigGetSuite) TestOutputFormatKey(c *gc.C) {
-	s.SetFeatureFlags(feature.SmartFormatter)
 	for i, t := range configGetKeyTests {
 		c.Logf("test %d: %#v", i, t.args)
 		hctx := s.GetHookContext(c, -1, "")

--- a/worker/uniter/runner/jujuc/is-leader.go
+++ b/worker/uniter/runner/jujuc/is-leader.go
@@ -7,10 +7,6 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/utils/featureflag"
-
-	"github.com/juju/juju/cmd/output"
-	"github.com/juju/juju/feature"
 )
 
 // isLeaderCommand implements the is-leader command.
@@ -41,11 +37,7 @@ there is no such guarantee.
 
 // SetFlags is part of the cmd.Command interface.
 func (c *isLeaderCommand) SetFlags(f *gnuflag.FlagSet) {
-	if featureflag.Enabled(feature.SmartFormatter) {
-		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
-	} else {
-		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
-	}
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
 }
 
 // Run is part of the cmd.Command interface.

--- a/worker/uniter/runner/jujuc/is-leader_test.go
+++ b/worker/uniter/runner/jujuc/is-leader_test.go
@@ -9,7 +9,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -57,22 +56,18 @@ func (s *isLeaderSuite) TestIsLeaderError(c *gc.C) {
 }
 
 func (s *isLeaderSuite) TestFormatDefaultYes(c *gc.C) {
-	s.SetFeatureFlags(feature.SmartFormatter)
 	s.testOutput(c, true, nil, "True\n")
 }
 
 func (s *isLeaderSuite) TestFormatDefaultNo(c *gc.C) {
-	s.SetFeatureFlags(feature.SmartFormatter)
 	s.testOutput(c, false, nil, "False\n")
 }
 
 func (s *isLeaderSuite) TestFormatSmartYes(c *gc.C) {
-	s.SetFeatureFlags(feature.SmartFormatter)
 	s.testOutput(c, true, []string{"--format", "smart"}, "True\n")
 }
 
 func (s *isLeaderSuite) TestFormatSmartNo(c *gc.C) {
-	s.SetFeatureFlags(feature.SmartFormatter)
 	s.testOutput(c, false, []string{"--format", "smart"}, "False\n")
 }
 

--- a/worker/uniter/runner/jujuc/leader-get.go
+++ b/worker/uniter/runner/jujuc/leader-get.go
@@ -9,10 +9,6 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/utils/featureflag"
-
-	"github.com/juju/juju/cmd/output"
-	"github.com/juju/juju/feature"
 )
 
 // leaderGetCommand implements the leader-get command.
@@ -44,11 +40,7 @@ is given, or if the key is "-", all keys and values will be printed.
 
 // SetFlags is part of the cmd.Command interface.
 func (c *leaderGetCommand) SetFlags(f *gnuflag.FlagSet) {
-	if featureflag.Enabled(feature.SmartFormatter) {
-		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
-	} else {
-		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
-	}
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
 }
 
 // Init is part of the cmd.Command interface.

--- a/worker/uniter/runner/jujuc/leader-get_test.go
+++ b/worker/uniter/runner/jujuc/leader-get_test.go
@@ -70,7 +70,7 @@ func (s *leaderGetSuite) TestSettingsError(c *gc.C) {
 }
 
 func (s *leaderGetSuite) TestSettingsFormatDefaultMissingKey(c *gc.C) {
-	s.testOutput(c, []string{"unknown"}, "\n")
+	s.testOutput(c, []string{"unknown"}, "")
 }
 
 func (s *leaderGetSuite) TestSettingsFormatDefaultKey(c *gc.C) {
@@ -86,7 +86,7 @@ func (s *leaderGetSuite) TestSettingsFormatDefaultEmpty(c *gc.C) {
 }
 
 func (s *leaderGetSuite) TestSettingsFormatSmartMissingKey(c *gc.C) {
-	s.testOutput(c, []string{"--format", "smart", "unknown"}, "\n")
+	s.testOutput(c, []string{"--format", "smart", "unknown"}, "")
 }
 
 func (s *leaderGetSuite) TestSettingsFormatSmartKey(c *gc.C) {

--- a/worker/uniter/runner/jujuc/leader-get_test.go
+++ b/worker/uniter/runner/jujuc/leader-get_test.go
@@ -9,7 +9,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -26,7 +25,6 @@ func (s *leaderGetSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.command, err = jujuc.NewLeaderGetCommand(nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.SetFeatureFlags(feature.SmartFormatter)
 }
 
 func (s *leaderGetSuite) TestInitError(c *gc.C) {

--- a/worker/uniter/runner/jujuc/network-get.go
+++ b/worker/uniter/runner/jujuc/network-get.go
@@ -9,10 +9,6 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/utils/featureflag"
-
-	"github.com/juju/juju/cmd/output"
-	"github.com/juju/juju/feature"
 )
 
 // NetworkGetCommand implements the network-get command.
@@ -49,11 +45,7 @@ the IP address the local unit should advertise as its endpoint to its peers.
 
 // SetFlags is part of the cmd.Command interface.
 func (c *NetworkGetCommand) SetFlags(f *gnuflag.FlagSet) {
-	if featureflag.Enabled(feature.SmartFormatter) {
-		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
-	} else {
-		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
-	}
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
 	f.BoolVar(&c.primaryAddress, "primary-address", false, "get the primary address for the binding")
 }
 

--- a/worker/uniter/runner/jujuc/network-get_test.go
+++ b/worker/uniter/runner/jujuc/network-get_test.go
@@ -11,7 +11,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -47,7 +46,6 @@ func (s *NetworkGetSuite) createCommand(c *gc.C) cmd.Command {
 }
 
 func (s *NetworkGetSuite) TestNetworkGet(c *gc.C) {
-	s.SetFeatureFlags(feature.SmartFormatter)
 	for i, t := range []struct {
 		summary  string
 		args     []string

--- a/worker/uniter/runner/jujuc/network-get_test.go
+++ b/worker/uniter/runner/jujuc/network-get_test.go
@@ -120,8 +120,8 @@ Summary:
 get network config
 
 Options:
---format  (= yaml)
-    Specify output format (json|yaml)
+--format  (= smart)
+    Specify output format (json|smart|yaml)
 -o, --output (= "")
     Specify an output file
 --primary-address  (= false)

--- a/worker/uniter/runner/jujuc/opened-ports.go
+++ b/worker/uniter/runner/jujuc/opened-ports.go
@@ -6,10 +6,6 @@ package jujuc
 import (
 	"github.com/juju/cmd"
 	"github.com/juju/gnuflag"
-	"github.com/juju/utils/featureflag"
-
-	"github.com/juju/juju/cmd/output"
-	"github.com/juju/juju/feature"
 )
 
 // OpenedPortsCommand implements the opened-ports command.
@@ -34,11 +30,7 @@ func (c *OpenedPortsCommand) Info() *cmd.Info {
 }
 
 func (c *OpenedPortsCommand) SetFlags(f *gnuflag.FlagSet) {
-	if featureflag.Enabled(feature.SmartFormatter) {
-		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
-	} else {
-		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
-	}
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
 }
 
 func (c *OpenedPortsCommand) Init(args []string) error {

--- a/worker/uniter/runner/jujuc/opened-ports_test.go
+++ b/worker/uniter/runner/jujuc/opened-ports_test.go
@@ -10,7 +10,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
@@ -23,7 +22,6 @@ type OpenedPortsSuite struct {
 var _ = gc.Suite(&OpenedPortsSuite{})
 
 func (s *OpenedPortsSuite) TestRunAllFormats(c *gc.C) {
-	s.SetFeatureFlags(feature.SmartFormatter)
 	expectedPorts := []network.PortRange{
 		{10, 20, "tcp"},
 		{80, 80, "tcp"},

--- a/worker/uniter/runner/jujuc/relation-get.go
+++ b/worker/uniter/runner/jujuc/relation-get.go
@@ -9,11 +9,8 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/utils/featureflag"
 
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/cmd/output"
-	"github.com/juju/juju/feature"
 )
 
 // RelationGetCommand implements the relation-get command.
@@ -64,11 +61,7 @@ If no key is given, or if the key is "-", all keys and values will be printed.
 
 // SetFlags is part of the cmd.Command interface.
 func (c *RelationGetCommand) SetFlags(f *gnuflag.FlagSet) {
-	if featureflag.Enabled(feature.SmartFormatter) {
-		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
-	} else {
-		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
-	}
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
 	f.Var(c.relationIdProxy, "r", "specify a relation by id")
 	f.Var(c.relationIdProxy, "relation", "")
 }

--- a/worker/uniter/runner/jujuc/relation-get_test.go
+++ b/worker/uniter/runner/jujuc/relation-get_test.go
@@ -13,7 +13,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 	jujuctesting "github.com/juju/juju/worker/uniter/runner/jujuc/testing"
@@ -142,7 +141,6 @@ var relationGetTests = []struct {
 }
 
 func (s *RelationGetSuite) TestRelationGet(c *gc.C) {
-	s.SetFeatureFlags(feature.SmartFormatter)
 	for i, t := range relationGetTests {
 		c.Logf("test %d: %s", i, t.summary)
 		hctx, _ := s.newHookContext(t.relid, t.unit)
@@ -281,7 +279,6 @@ func (s *RelationGetSuite) TestHelp(c *gc.C) {
 }
 
 func (s *RelationGetSuite) TestOutputPath(c *gc.C) {
-	s.SetFeatureFlags(feature.SmartFormatter)
 	hctx, _ := s.newHookContext(1, "m/0")
 	com, err := jujuc.NewCommand(hctx, cmdString("relation-get"))
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/jujuc/relation-get_test.go
+++ b/worker/uniter/runner/jujuc/relation-get_test.go
@@ -153,7 +153,10 @@ func (s *RelationGetSuite) TestRelationGet(c *gc.C) {
 		c.Check(code, gc.Equals, t.code)
 		if code == 0 {
 			c.Check(bufferString(ctx.Stderr), gc.Equals, "")
-			expect := t.out + "\n"
+			expect := t.out
+			if len(expect) > 0 {
+				expect += "\n"
+			}
 			c.Check(bufferString(ctx.Stdout), gc.Equals, expect)
 		} else {
 			c.Check(bufferString(ctx.Stdout), gc.Equals, "")
@@ -221,8 +224,8 @@ Summary:
 get relation settings
 
 Options:
---format  (= yaml)
-    Specify output format (json|yaml)
+--format  (= smart)
+    Specify output format (json|smart|yaml)
 -o, --output (= "")
     Specify an output file
 -r, --relation  (= %s)

--- a/worker/uniter/runner/jujuc/relation-ids.go
+++ b/worker/uniter/runner/jujuc/relation-ids.go
@@ -10,10 +10,6 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/utils/featureflag"
-
-	"github.com/juju/juju/cmd/output"
-	"github.com/juju/juju/feature"
 )
 
 // RelationIdsCommand implements the relation-ids command.
@@ -54,11 +50,7 @@ func (c *RelationIdsCommand) Info() *cmd.Info {
 }
 
 func (c *RelationIdsCommand) SetFlags(f *gnuflag.FlagSet) {
-	if featureflag.Enabled(feature.SmartFormatter) {
-		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
-	} else {
-		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
-	}
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
 }
 
 func (c *RelationIdsCommand) Init(args []string) error {

--- a/worker/uniter/runner/jujuc/relation-ids_test.go
+++ b/worker/uniter/runner/jujuc/relation-ids_test.go
@@ -11,7 +11,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -102,7 +101,6 @@ var relationIdsTests = []struct {
 }
 
 func (s *RelationIdsSuite) TestRelationIds(c *gc.C) {
-	s.SetFeatureFlags(feature.SmartFormatter)
 	for i, t := range relationIdsTests {
 		c.Logf("test %d: %s", i, t.summary)
 		hctx, _ := s.newHookContext(t.relid, "")
@@ -113,7 +111,10 @@ func (s *RelationIdsSuite) TestRelationIds(c *gc.C) {
 		c.Assert(code, gc.Equals, t.code)
 		if code == 0 {
 			c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
-			expect := t.out + "\n"
+			expect := t.out
+			if expect != "" {
+				expect += "\n"
+			}
 			c.Assert(bufferString(ctx.Stdout), gc.Equals, expect)
 		} else {
 			c.Assert(bufferString(ctx.Stdout), gc.Equals, "")

--- a/worker/uniter/runner/jujuc/relation-ids_test.go
+++ b/worker/uniter/runner/jujuc/relation-ids_test.go
@@ -130,8 +130,8 @@ Summary:
 list all relation ids with the given relation name
 
 Options:
---format  (= yaml)
-    Specify output format (json|yaml)
+--format  (= smart)
+    Specify output format (json|smart|yaml)
 -o, --output (= "")
     Specify an output file
 %s`[1:]

--- a/worker/uniter/runner/jujuc/relation-list.go
+++ b/worker/uniter/runner/jujuc/relation-list.go
@@ -9,10 +9,6 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/utils/featureflag"
-
-	"github.com/juju/juju/cmd/output"
-	"github.com/juju/juju/feature"
 )
 
 // RelationListCommand implements the relation-list command.
@@ -50,11 +46,7 @@ func (c *RelationListCommand) Info() *cmd.Info {
 }
 
 func (c *RelationListCommand) SetFlags(f *gnuflag.FlagSet) {
-	if featureflag.Enabled(feature.SmartFormatter) {
-		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
-	} else {
-		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
-	}
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
 	f.Var(c.relationIdProxy, "r", "specify a relation by id")
 	f.Var(c.relationIdProxy, "relation", "")
 }

--- a/worker/uniter/runner/jujuc/relation-list_test.go
+++ b/worker/uniter/runner/jujuc/relation-list_test.go
@@ -11,7 +11,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -109,7 +108,6 @@ var relationListTests = []struct {
 }
 
 func (s *RelationListSuite) TestRelationList(c *gc.C) {
-	s.SetFeatureFlags(feature.SmartFormatter)
 	for i, t := range relationListTests {
 		c.Logf("test %d: %s", i, t.summary)
 		hctx, info := s.newHookContext(t.relid, "")
@@ -123,13 +121,16 @@ func (s *RelationListSuite) TestRelationList(c *gc.C) {
 		c.Logf(bufferString(ctx.Stderr))
 		c.Assert(code, gc.Equals, t.code)
 		if code == 0 {
-			c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
-			expect := t.out + "\n"
-			c.Assert(bufferString(ctx.Stdout), gc.Equals, expect)
+			c.Check(bufferString(ctx.Stderr), gc.Equals, "")
+			expect := t.out
+			if expect != "" {
+				expect += "\n"
+			}
+			c.Check(bufferString(ctx.Stdout), gc.Equals, expect)
 		} else {
-			c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
+			c.Check(bufferString(ctx.Stdout), gc.Equals, "")
 			expect := fmt.Sprintf(`(.|\n)*error: %s\n`, t.out)
-			c.Assert(bufferString(ctx.Stderr), gc.Matches, expect)
+			c.Check(bufferString(ctx.Stderr), gc.Matches, expect)
 		}
 	}
 }

--- a/worker/uniter/runner/jujuc/relation-list_test.go
+++ b/worker/uniter/runner/jujuc/relation-list_test.go
@@ -142,8 +142,8 @@ Summary:
 list relation units
 
 Options:
---format  (= yaml)
-    Specify output format (json|yaml)
+--format  (= smart)
+    Specify output format (json|smart|yaml)
 -o, --output (= "")
     Specify an output file
 -r, --relation  (= %s)

--- a/worker/uniter/runner/jujuc/status-get.go
+++ b/worker/uniter/runner/jujuc/status-get.go
@@ -7,10 +7,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/utils/featureflag"
 
-	"github.com/juju/juju/cmd/output"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/status"
 )
 
@@ -41,11 +38,7 @@ If the --include-data flag is passed, the associated data are printed also.
 }
 
 func (c *StatusGetCommand) SetFlags(f *gnuflag.FlagSet) {
-	if featureflag.Enabled(feature.SmartFormatter) {
-		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
-	} else {
-		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
-	}
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
 	f.BoolVar(&c.includeData, "include-data", false, "print all status data")
 	f.BoolVar(&c.serviceWide, "application", false, "print status for all units of this application if this unit is the leader")
 }

--- a/worker/uniter/runner/jujuc/status-get_test.go
+++ b/worker/uniter/runner/jujuc/status-get_test.go
@@ -111,8 +111,8 @@ func (s *statusGetSuite) TestHelp(c *gc.C) {
 		"Options:\n" +
 		"--application  (= false)\n" +
 		"    print status for all units of this application if this unit is the leader\n" +
-		"--format  (= yaml)\n" +
-		"    Specify output format (json|yaml)\n" +
+		"--format  (= smart)\n" +
+		"    Specify output format (json|smart|yaml)\n" +
 		"--include-data  (= false)\n" +
 		"    print all status data\n" +
 		"-o, --output (= \"\")\n" +

--- a/worker/uniter/runner/jujuc/storage-get.go
+++ b/worker/uniter/runner/jujuc/storage-get.go
@@ -7,11 +7,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/names.v2"
-
-	"github.com/juju/juju/cmd/output"
-	"github.com/juju/juju/feature"
 )
 
 // StorageGetCommand implements the storage-get command.
@@ -47,11 +43,7 @@ When no <key> is supplied, all keys values are printed.
 }
 
 func (c *StorageGetCommand) SetFlags(f *gnuflag.FlagSet) {
-	if featureflag.Enabled(feature.SmartFormatter) {
-		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
-	} else {
-		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
-	}
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
 	f.Var(c.storageTagProxy, "s", "specify a storage instance by id")
 }
 

--- a/worker/uniter/runner/jujuc/storage-get_test.go
+++ b/worker/uniter/runner/jujuc/storage-get_test.go
@@ -74,8 +74,8 @@ Summary:
 print information for storage instance with specified id
 
 Options:
---format  (= yaml)
-    Specify output format (json|yaml)
+--format  (= smart)
+    Specify output format (json|smart|yaml)
 -o, --output (= "")
     Specify an output file
 -s  (= data/0)

--- a/worker/uniter/runner/jujuc/storage-list.go
+++ b/worker/uniter/runner/jujuc/storage-list.go
@@ -7,11 +7,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/names.v2"
-
-	"github.com/juju/juju/cmd/output"
-	"github.com/juju/juju/feature"
 )
 
 // StorageListCommand implements the storage-list command.
@@ -46,11 +42,7 @@ instances for that named storage will be returned.
 }
 
 func (c *StorageListCommand) SetFlags(f *gnuflag.FlagSet) {
-	if featureflag.Enabled(feature.SmartFormatter) {
-		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
-	} else {
-		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
-	}
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
 }
 
 func (c *StorageListCommand) Init(args []string) (err error) {

--- a/worker/uniter/runner/jujuc/storage-list_test.go
+++ b/worker/uniter/runner/jujuc/storage-list_test.go
@@ -113,8 +113,8 @@ Summary:
 list storage attached to the unit
 
 Options:
---format  (= yaml)
-    Specify output format (json|yaml)
+--format  (= smart)
+    Specify output format (json|smart|yaml)
 -o, --output (= "")
     Specify an output file
 

--- a/worker/uniter/runner/jujuc/storage-list_test.go
+++ b/worker/uniter/runner/jujuc/storage-list_test.go
@@ -11,7 +11,6 @@ import (
 	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v2"
 
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 	jujuctesting "github.com/juju/juju/worker/uniter/runner/jujuc/testing"
@@ -50,7 +49,6 @@ func (s *storageListSuite) TestOutputFormatJSON(c *gc.C) {
 }
 
 func (s *storageListSuite) TestOutputFormatDefault(c *gc.C) {
-	s.SetFeatureFlags(feature.SmartFormatter)
 	// The default output format is "smart", which is
 	// a newline-separated list of strings.
 	s.testOutputFormat(c,

--- a/worker/uniter/runner/jujuc/unit-get.go
+++ b/worker/uniter/runner/jujuc/unit-get.go
@@ -9,10 +9,6 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/utils/featureflag"
-
-	"github.com/juju/juju/cmd/output"
-	"github.com/juju/juju/feature"
 )
 
 // UnitGetCommand implements the unit-get command.
@@ -36,11 +32,7 @@ func (c *UnitGetCommand) Info() *cmd.Info {
 }
 
 func (c *UnitGetCommand) SetFlags(f *gnuflag.FlagSet) {
-	if featureflag.Enabled(feature.SmartFormatter) {
-		c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
-	} else {
-		c.out.AddFlags(f, "yaml", output.DefaultFormatters)
-	}
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
 }
 
 func (c *UnitGetCommand) Init(args []string) error {

--- a/worker/uniter/runner/jujuc/unit-get_test.go
+++ b/worker/uniter/runner/jujuc/unit-get_test.go
@@ -63,8 +63,8 @@ Summary:
 print public-address or private-address
 
 Options:
---format  (= yaml)
-    Specify output format (json|yaml)
+--format  (= smart)
+    Specify output format (json|smart|yaml)
 -o, --output (= "")
     Specify an output file
 `)

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1322,7 +1322,7 @@ func (s *UniterSuite) TestUniterRelations(c *gc.C) {
 
 				// Check that config-changed didn't record any relations, because
 				// they shouldn't been available until after the start hook.
-				ft.File{"charm/relations.out", "[]\n", 0644}.Check(c, ctx.path)
+				ft.File{"charm/relations.out", "", 0644}.Check(c, ctx.path)
 			}},
 			startUniter{},
 			waitHooks{"config-changed"},
@@ -1332,7 +1332,7 @@ func (s *UniterSuite) TestUniterRelations(c *gc.C) {
 				ft.Dir{path, 0755}.Check(c, ctx.path)
 
 				// Check that config-changed did record the joined relations.
-				data := fmt.Sprintf("- db:%d\n", ctx.relation.Id())
+				data := fmt.Sprintf("db:%d\n", ctx.relation.Id())
 				ft.File{"charm/relations.out", data, 0644}.Check(c, ctx.path)
 			}},
 		),

--- a/worker/uniter/util_unix_test.go
+++ b/worker/uniter/util_unix_test.go
@@ -27,7 +27,7 @@ var (
 var (
 	// Used in TestLeadership
 	leadershipScript = `
-if [ $(is-leader) != "false" ]; then exit -1; fi
+if [ $(is-leader) != "False" ]; then exit -1; fi
 `[1:]
 
 	// Different hook file contents. These are used in util_test

--- a/worker/uniter/util_windows_test.go
+++ b/worker/uniter/util_windows_test.go
@@ -31,7 +31,7 @@ var (
 var (
 	// Used in TestLeadership
 	leadershipScript = `
-If ($(is-leader) -ne "false") {exit -1}
+If ($(is-leader) -ne "False") {exit -1}
 `[1:]
 
 	// Different hook file contents. These are used in util_test


### PR DESCRIPTION
Addresses http://pad.lv/1615051 where we were getting hook failures due to bash failing to parse the now yaml output. This branch reinstates the smart formatters to allow bash hooks to be written with ease again.

Many of the changes here take the expected output back to what it was before the massive branch that landed on Friday had.

(Review request: http://reviews.vapour.ws/r/5512/)