### PR TITLE
Replace everybody@external with everyone

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -24,9 +24,9 @@ import (
 	jujuversion "github.com/juju/juju/version"
 )
 
-// EverybodyTagName represents a special group that encompasses
+// EveryoneTagName represents a special group that encompasses
 // all external users.
-const EverybodyTagName = "everybody@external"
+const EveryoneTagName = "everyone@external"
 
 type adminAPIFactory func(*Server, *apiHandler, observer.Observer) interface{}
 
@@ -154,7 +154,7 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 	var maybeUserInfo *params.AuthUserInfo
 	var modelUser description.UserAccess
 	var controllerUser description.UserAccess
-	var everybodyGroupUser description.UserAccess
+	var everyoneGroupUser description.UserAccess
 	// Send back user info if user
 	if isUser {
 		maybeUserInfo = &params.AuthUserInfo{
@@ -167,16 +167,16 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 			return fail, errors.Annotatef(err, "obtaining ControllerUser for logged in user %s", entity.Tag())
 		}
 
-		// TODO(perrito666) remove the following section about everybody group
+		// TODO(perrito666) remove the following section about everyone group
 		// when groups are implemented, this accounts only for the lack of a local
 		// ControllerUser when logging in from an external user that has not been granted
 		// permissions on the controller but there are permissions for the special
-		// everybody group.
+		// everyone group.
 		if !userTag.IsLocal() {
-			everybodyTag := names.NewUserTag(EverybodyTagName)
-			everybodyGroupUser, err = state.ControllerAccess(a.root.state, everybodyTag)
+			everyoneTag := names.NewUserTag(EveryoneTagName)
+			everyoneGroupUser, err = state.ControllerAccess(a.root.state, everyoneTag)
 			if err != nil && !errors.IsNotFound(err) {
-				return fail, errors.Annotatef(err, "obtaining ControllerUser for everybody group")
+				return fail, errors.Annotatef(err, "obtaining ControllerUser for everyone group")
 			}
 		}
 
@@ -187,7 +187,7 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 
 		if description.IsEmptyUserAccess(modelUser) &&
 			description.IsEmptyUserAccess(controllerUser) &&
-			description.IsEmptyUserAccess(everybodyGroupUser) {
+			description.IsEmptyUserAccess(everyoneGroupUser) {
 			return fail, errors.NotFoundf("model or controller access for logged in user %q", userTag.Canonical())
 		}
 		maybeUserInfo.ReadOnly = modelUser.Access == description.ReadAccess
@@ -238,7 +238,7 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 
 	if !description.IsEmptyUserAccess(modelUser) ||
 		!description.IsEmptyUserAccess(controllerUser) ||
-		!description.IsEmptyUserAccess(everybodyGroupUser) {
+		!description.IsEmptyUserAccess(everyoneGroupUser) {
 		authedAPI = newClientAuthRoot(authedAPI, modelUser, controllerUser)
 	}
 
@@ -371,15 +371,15 @@ func (f modelUserEntityFinder) FindEntity(tag names.Tag) (state.Entity, error) {
 		return nil, errors.Trace(err)
 	}
 
-	// TODO(perrito666) remove the following section about everybody group
+	// TODO(perrito666) remove the following section about everyone group
 	// when groups are implemented, this accounts only for the lack of a local
 	// ControllerUser when logging in from an external user that has not been granted
 	// permissions on the controller but there are permissions for the special
-	// everybody group.
+	// everyone group.
 	if !utag.IsLocal() {
 		controllerUser, err = maybeUseGroupPermission(f.st.UserAccess, controllerUser, f.st.ControllerTag(), utag)
 		if err != nil {
-			return nil, errors.Annotatef(err, "obtaining ControllerUser for everybody group")
+			return nil, errors.Annotatef(err, "obtaining ControllerUser for everyone group")
 		}
 	}
 

--- a/apiserver/root_test.go
+++ b/apiserver/root_test.go
@@ -511,41 +511,41 @@ func (r *rootSuite) TestUserGetterErrorReturns(c *gc.C) {
 	c.Assert(userGetter.objects[0], gc.DeepEquals, target)
 }
 
-type fakeEverybodyUserAccess struct {
-	user      description.UserAccess
-	everybody description.UserAccess
+type fakeEveryoneUserAccess struct {
+	user     description.UserAccess
+	everyone description.UserAccess
 }
 
-func (f *fakeEverybodyUserAccess) call(subject names.UserTag, object names.Tag) (description.UserAccess, error) {
-	if subject.Canonical() == apiserver.EverybodyTagName {
-		return f.everybody, nil
+func (f *fakeEveryoneUserAccess) call(subject names.UserTag, object names.Tag) (description.UserAccess, error) {
+	if subject.Canonical() == apiserver.EveryoneTagName {
+		return f.everyone, nil
 	}
 	return f.user, nil
 }
 
-func (r *rootSuite) TestEverybodyAtExternal(c *gc.C) {
+func (r *rootSuite) TestEveryoneAtExternal(c *gc.C) {
 	testCases := []struct {
 		title            string
 		userGetterAccess description.Access
-		everybodyAccess  description.Access
+		everyoneAccess   description.Access
 		user             names.UserTag
 		target           names.Tag
 		access           description.Access
 		expected         bool
 	}{
 		{
-			title:            "user has lesser permissions than everybody",
+			title:            "user has lesser permissions than everyone",
 			userGetterAccess: description.LoginAccess,
-			everybodyAccess:  description.AddModelAccess,
+			everyoneAccess:   description.AddModelAccess,
 			user:             names.NewUserTag("validuser@external"),
 			target:           names.NewControllerTag("beef1beef2-0000-0000-000011112222"),
 			access:           description.AddModelAccess,
 			expected:         true,
 		},
 		{
-			title:            "user has greater permissions than everybody",
+			title:            "user has greater permissions than everyone",
 			userGetterAccess: description.AddModelAccess,
-			everybodyAccess:  description.LoginAccess,
+			everyoneAccess:   description.LoginAccess,
 			user:             names.NewUserTag("validuser@external"),
 			target:           names.NewControllerTag("beef1beef2-0000-0000-000011112222"),
 			access:           description.AddModelAccess,
@@ -554,7 +554,7 @@ func (r *rootSuite) TestEverybodyAtExternal(c *gc.C) {
 		{
 			title:            "everibody not considered if user is local",
 			userGetterAccess: description.LoginAccess,
-			everybodyAccess:  description.AddModelAccess,
+			everyoneAccess:   description.AddModelAccess,
 			user:             names.NewUserTag("validuser"),
 			target:           names.NewControllerTag("beef1beef2-0000-0000-000011112222"),
 			access:           description.AddModelAccess,
@@ -563,15 +563,15 @@ func (r *rootSuite) TestEverybodyAtExternal(c *gc.C) {
 	}
 
 	for i, t := range testCases {
-		userGetter := &fakeEverybodyUserAccess{
+		userGetter := &fakeEveryoneUserAccess{
 			user: description.UserAccess{
 				Access: t.userGetterAccess,
 			},
-			everybody: description.UserAccess{
-				Access: t.everybodyAccess,
+			everyone: description.UserAccess{
+				Access: t.everyoneAccess,
 			},
 		}
-		c.Logf(`HasPermission "everybody" test n %d: %s`, i, t.title)
+		c.Logf(`HasPermission "everyone" test n %d: %s`, i, t.title)
 		hasPermission, err := apiserver.HasPermission(userGetter.call, t.user, t.access, t.target)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(hasPermission, gc.Equals, t.expected)


### PR DESCRIPTION
everybody@external was used as the wildcard to grant controller permissions to all external users, the name must change to everyone@external

(Review request: http://reviews.vapour.ws/r/5515/)