### PR TITLE
Fixes lp#1616305: image metadata collection must be global.

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -373,7 +373,9 @@ func allCollections() collectionSchema {
 		},
 
 		// This collection holds information about cloud image metadata.
-		cloudimagemetadataC: {},
+		cloudimagemetadataC: {
+			global: true,
+		},
 
 		// ----------------------
 

--- a/state/cloudimagemetadata/image.go
+++ b/state/cloudimagemetadata/image.go
@@ -19,7 +19,6 @@ import (
 var logger = loggo.GetLogger("juju.state.cloudimagemetadata")
 
 type storage struct {
-	modelUUID  string
 	collection string
 	store      DataStore
 }
@@ -28,8 +27,8 @@ var _ Storage = (*storage)(nil)
 
 // NewStorage constructs a new Storage that stores image metadata
 // in the provided data store.
-func NewStorage(modelUUID, collectionName string, store DataStore) Storage {
-	return &storage{modelUUID, collectionName, store}
+func NewStorage(collectionName string, store DataStore) Storage {
+	return &storage{collectionName, store}
 }
 
 var emptyMetadata = Metadata{}
@@ -161,9 +160,6 @@ func (s *storage) getMetadata(id string) (Metadata, error) {
 // imagesMetadataDoc results in immutable records. Updates are effectively
 // a delate and an insert.
 type imagesMetadataDoc struct {
-	// ModelUUID is the model identifier.
-	ModelUUID string `bson:"model-uuid"`
-
 	// Id contains unique key for cloud image metadata.
 	// This is an amalgamation of all deterministic metadata attributes to ensure
 	// that there can be a public and custom image for the same attributes set.
@@ -232,7 +228,6 @@ func (m imagesMetadataDoc) metadata() Metadata {
 
 func (s *storage) mongoDoc(m Metadata) imagesMetadataDoc {
 	r := imagesMetadataDoc{
-		ModelUUID:       s.modelUUID,
 		Id:              buildKey(m),
 		Stream:          m.Stream,
 		Region:          m.Region,

--- a/state/cloudimagemetadata/image_test.go
+++ b/state/cloudimagemetadata/image_test.go
@@ -28,7 +28,6 @@ type cloudImageMetadataSuite struct {
 var _ = gc.Suite(&cloudImageMetadataSuite{})
 
 const (
-	envName        = "test-model"
 	collectionName = "test-collection"
 )
 
@@ -38,7 +37,7 @@ func (s *cloudImageMetadataSuite) SetUpTest(c *gc.C) {
 	db := s.MgoSuite.Session.DB("juju")
 
 	s.access = NewTestMongo(db)
-	s.storage = cloudimagemetadata.NewStorage(envName, collectionName, s.access)
+	s.storage = cloudimagemetadata.NewStorage(collectionName, s.access)
 }
 
 func (s *cloudImageMetadataSuite) TestSaveMetadata(c *gc.C) {

--- a/state/state.go
+++ b/state/state.go
@@ -368,7 +368,6 @@ func (st *State) start(controllerTag names.ModelTag) (err error) {
 
 	logger.Infof("creating cloud image metadata storage")
 	st.CloudImageMetadataStorage = cloudimagemetadata.NewStorage(
-		st.ModelUUID(),
 		cloudimagemetadataC,
 		&environMongo{st},
 	)


### PR DESCRIPTION
Currently, image metadata collection is model-bound which means that we can only deploy to a "controller" model using custom images. 
This collection needs to be controller-wide to ensure that any model can find this metadata. 

QA steps:
1. Bootstrap private cloud using --metadata-source
2. Deploy an application to a non-controller model either the "default" or add new one)
3. Watch status - the machine should come up using an image from metadata-source

QA for multi-region cloud:
1. Bootstrap cloud using --metadata-source that has images metadata for all regions under test
2. Deploy an application to "default" model
3. Add a new model to a different region (add-model --region=xxxx)
4. Deploy an application to this new model
5. Observe all machines come up