### PR TITLE
Take account of provider specific config when creating models and bootstrapping

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -261,6 +261,10 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 		"type":            "dummy",
 		"default-series":  "raring",
 		"authorized-keys": "public auth key\n",
+		// Dummy provider defaults
+		"broken":     "",
+		"secret":     "pork",
+		"controller": false,
 	}
 	for k, v := range config.ConfigDefaults() {
 		if _, ok := expected[k]; !ok {
@@ -1157,7 +1161,7 @@ func (s *BootstrapSuite) TestBootstrapConfigFile(c *gc.C) {
 		c, s.newBootstrapCommand(), "ctrl", "dummy",
 		"--config", configFile,
 	)
-	c.Assert(err, gc.ErrorMatches, `controller: expected bool, got string.*`)
+	c.Assert(err, gc.ErrorMatches, `invalid attribute value\(s\) for dummy cloud: controller: expected bool, got string.*`)
 }
 
 func (s *BootstrapSuite) TestBootstrapMultipleConfigFiles(c *gc.C) {
@@ -1210,9 +1214,9 @@ func (s *BootstrapSuite) TestBootstrapCloudConfigAndAdHoc(c *gc.C) {
 		"--auto-upgrade",
 		// Configuration specified on the command line overrides
 		// anything specified in files, no matter what the order.
-		"--config", "controller=false",
+		"--config", "controller=not-a-bool",
 	)
-	c.Assert(err, gc.ErrorMatches, "failed to bootstrap model: dummy.Bootstrap is broken")
+	c.Assert(err, gc.ErrorMatches, `invalid attribute value\(s\) for dummy cloud: controller: expected bool, got .*`)
 }
 
 func (s *BootstrapSuite) TestBootstrapPrintClouds(c *gc.C) {

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1017,7 +1017,7 @@ func (cfg *Config) ValidateUnknownAttrs(fields schema.Fields, defaults schema.De
 		if fields[name] == nil {
 			if val, isString := value.(string); isString && val != "" {
 				// only warn about attributes with non-empty string values
-				logger.Errorf("unknown config field %q", name)
+				logger.Warningf("unknown config field %q", name)
 			}
 			result[name] = value
 		}

--- a/environs/config/source.go
+++ b/environs/config/source.go
@@ -3,6 +3,10 @@
 
 package config
 
+import (
+	"github.com/juju/schema"
+)
+
 // These constants define named sources of model config attributes.
 // After a call to UpdateModelConfig, any attributes added/removed
 // will have a source of JujuModelConfigSource.
@@ -41,4 +45,16 @@ func (c ConfigValues) AllAttrs() map[string]interface{} {
 		result[attr] = val
 	}
 	return result
+}
+
+// ConfigSchemaSource instances provide information on config attributes
+// and the default attribute values.
+type ConfigSchemaSource interface {
+	// ConfigSchema returns extra config attributes specific
+	// to this provider only.
+	ConfigSchema() schema.Fields
+
+	// ConfigDefaults returns the default values for the
+	// provider specific config attributes.
+	ConfigDefaults() schema.Defaults
 }

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -19,6 +19,8 @@ type EnvironProvider interface {
 	config.Validator
 	ProviderCredentials
 
+	// TODO(wallyworld) - embed config.ConfigSchemaSource and make all providers implement it
+
 	// RestrictedConfigAttributes are provider specific attributes stored in
 	// the config that really cannot or should not be changed across
 	// environments running inside a single juju server.

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -509,6 +509,20 @@ func (p *environProvider) Schema() environschema.Fields {
 	return fields
 }
 
+var _ config.ConfigSchemaSource = (*environProvider)(nil)
+
+// ConfigSchema returns extra config attributes specific
+// to this provider only.
+func (p environProvider) ConfigSchema() schema.Fields {
+	return configFields
+}
+
+// ConfigDefaults returns the default values for the
+// provider specific config attributes.
+func (p environProvider) ConfigDefaults() schema.Defaults {
+	return configDefaults
+}
+
 func (p *environProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
 	return map[cloud.AuthType]cloud.CredentialSchema{cloud.EmptyAuthType: {}}
 }

--- a/provider/ec2/config.go
+++ b/provider/ec2/config.go
@@ -71,6 +71,18 @@ func (environProvider) Schema() environschema.Fields {
 	return fields
 }
 
+// ConfigSchema returns extra config attributes specific
+// to this provider only.
+func (p environProvider) ConfigSchema() schema.Fields {
+	return configFields
+}
+
+// ConfigDefaults returns the default values for the
+// provider specific config attributes.
+func (p environProvider) ConfigDefaults() schema.Defaults {
+	return configDefaults
+}
+
 func validateConfig(cfg, old *config.Config) (*environConfig, error) {
 	// Check for valid changes for the base config values.
 	if err := config.Validate(cfg, old); err != nil {

--- a/provider/ec2/environ_test.go
+++ b/provider/ec2/environ_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
@@ -18,6 +19,7 @@ import (
 // Ensure EC2 provider supports the expected interfaces,
 var (
 	_ environs.NetworkingEnviron = (*environ)(nil)
+	_ config.ConfigSchemaSource  = (*environProvider)(nil)
 	_ simplestreams.HasRegion    = (*environ)(nil)
 	_ state.Prechecker           = (*environ)(nil)
 	_ instance.Distributor       = (*environ)(nil)

--- a/provider/gce/provider.go
+++ b/provider/gce/provider.go
@@ -5,6 +5,7 @@ package gce
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/schema"
 	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/cloud"
@@ -57,6 +58,18 @@ func (environProvider) Schema() environschema.Fields {
 		panic(err)
 	}
 	return fields
+}
+
+// ConfigSchema returns extra config attributes specific
+// to this provider only.
+func (p environProvider) ConfigSchema() schema.Fields {
+	return configFields
+}
+
+// ConfigDefaults returns the default values for the
+// provider specific config attributes.
+func (p environProvider) ConfigDefaults() schema.Defaults {
+	return configDefaults
 }
 
 // UpgradeModelConfig is specified in the ModelConfigUpgrader interface.

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -31,6 +31,11 @@ import (
 	coretools "github.com/juju/juju/tools"
 )
 
+// Ensure GCE provider supports the expected interfaces.
+var (
+	_ config.ConfigSchemaSource = (*environProvider)(nil)
+)
+
 // These values are fake GCE auth credentials for use in tests.
 const (
 	ClientName  = "ba9876543210-0123456789abcdefghijklmnopqrstuv"

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -7,6 +7,7 @@ package lxd
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/schema"
 	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/cloud"
@@ -87,4 +88,16 @@ func validateCloudSpec(spec environs.CloudSpec) error {
 		}
 	}
 	return nil
+}
+
+// ConfigSchema returns extra config attributes specific
+// to this provider only.
+func (p environProvider) ConfigSchema() schema.Fields {
+	return configFields
+}
+
+// ConfigDefaults returns the default values for the
+// provider specific config attributes.
+func (p environProvider) ConfigDefaults() schema.Defaults {
+	return configDefaults
 }

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -29,6 +29,11 @@ import (
 	"github.com/juju/version"
 )
 
+// Ensure LXD provider supports the expected interfaces.
+var (
+	_ config.ConfigSchemaSource = (*environProvider)(nil)
+)
+
 // These values are stub LXD client credentials for use in tests.
 const (
 	PublicKey = `-----BEGIN CERTIFICATE-----

--- a/provider/maas/config.go
+++ b/provider/maas/config.go
@@ -47,6 +47,18 @@ func (maasEnvironProvider) Schema() environschema.Fields {
 	return fields
 }
 
+// ConfigSchema returns extra config attributes specific
+// to this provider only.
+func (p maasEnvironProvider) ConfigSchema() schema.Fields {
+	return configFields
+}
+
+// ConfigDefaults returns the default values for the
+// provider specific config attributes.
+func (p maasEnvironProvider) ConfigDefaults() schema.Defaults {
+	return configDefaults
+}
+
 func (prov maasEnvironProvider) Validate(cfg, oldCfg *config.Config) (*config.Config, error) {
 	// Validate base configuration change before validating MAAS specifics.
 	err := config.Validate(cfg, oldCfg)

--- a/provider/maas/config_test.go
+++ b/provider/maas/config_test.go
@@ -13,6 +13,11 @@ import (
 	"github.com/juju/juju/testing"
 )
 
+// Ensure MAAS provider supports the expected interfaces.
+var (
+	_ config.ConfigSchemaSource = (*maasEnvironProvider)(nil)
+)
+
 type configSuite struct {
 	testing.BaseSuite
 }

--- a/provider/openstack/config.go
+++ b/provider/openstack/config.go
@@ -27,6 +27,8 @@ var configSchema = environschema.Fields{
 	},
 }
 
+var configDefaults = schema.Defaults{}
+
 var configFields = func() schema.Fields {
 	fs, _, err := configSchema.ValidationSchema()
 	if err != nil {
@@ -67,6 +69,18 @@ func (EnvironProvider) Schema() environschema.Fields {
 		panic(err)
 	}
 	return fields
+}
+
+// ConfigSchema returns extra config attributes specific
+// to this provider only.
+func (p EnvironProvider) ConfigSchema() schema.Fields {
+	return configFields
+}
+
+// ConfigDefaults returns the default values for the
+// provider specific config attributes.
+func (p EnvironProvider) ConfigDefaults() schema.Defaults {
+	return configDefaults
 }
 
 func (p EnvironProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -49,7 +49,10 @@ type EnvironProvider struct {
 	FirewallerFactory FirewallerFactory
 }
 
-var _ environs.EnvironProvider = (*EnvironProvider)(nil)
+var (
+	_ environs.EnvironProvider = (*EnvironProvider)(nil)
+	_ environs.ProviderSchema  = (*EnvironProvider)(nil)
+)
 
 var providerInstance *EnvironProvider = &EnvironProvider{
 	OpenstackCredentials{},

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -114,3 +114,7 @@ func (internalStatePolicy) InstanceDistributor() (instance.Distributor, error) {
 func (internalStatePolicy) StorageProviderRegistry() (storage.ProviderRegistry, error) {
 	return provider.CommonStorageProviders(), nil
 }
+
+func (internalStatePolicy) ProviderConfigSchemaSource() (config.ConfigSchemaSource, error) {
+	return nil, errors.NotImplementedf("ConfigSchemaSource")
+}

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -39,6 +39,9 @@ func (s *ModelConfigSuite) SetUpTest(c *gc.C) {
 		validator.RegisterUnsupported([]string{constraints.CpuPower})
 		return validator, nil
 	}
+	s.policy.GetProviderConfigSchemaSource = func() (config.ConfigSchemaSource, error) {
+		return &statetesting.MockConfigSchemaSource{}, nil
+	}
 }
 
 func (s *ModelConfigSuite) TestAdditionalValidation(c *gc.C) {
@@ -104,6 +107,7 @@ func (s *ModelConfigSuite) TestComposeNewModelConfig(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expected := expectedCfg.AllAttrs()
 	expected["apt-mirror"] = "http://cloud-mirror"
+	expected["providerAttr"] = "vulch"
 	// config.New() adds logging-config so remove it.
 	expected["logging-config"] = ""
 	c.Assert(cfgAttrs, jc.DeepEquals, expected)
@@ -117,18 +121,20 @@ func (s *ModelConfigSuite) TestUpdateModelConfigRejectsControllerConfig(c *gc.C)
 
 func (s *ModelConfigSuite) TestUpdateModelConfigRemoveInherited(c *gc.C) {
 	attrs := map[string]interface{}{
-		"apt-mirror":    "http://different-mirror",
+		"apt-mirror":    "http://different-mirror", // controller
 		"arbitrary-key": "shazam!",
+		"providerAttr":  "beef", // provider
 	}
 	err := s.State.UpdateModelConfig(attrs, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.State.UpdateModelConfig(nil, []string{"apt-mirror", "arbitrary-key"}, nil)
+	err = s.State.UpdateModelConfig(nil, []string{"apt-mirror", "arbitrary-key", "providerAttr"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	allAttrs := cfg.AllAttrs()
 	c.Assert(allAttrs["apt-mirror"], gc.Equals, "http://cloud-mirror")
+	c.Assert(allAttrs["providerAttr"], gc.Equals, "vulch")
 	_, ok := allAttrs["arbitrary-key"]
 	c.Assert(ok, jc.IsFalse)
 }
@@ -159,20 +165,23 @@ func (s *ModelConfigSuite) TestUpdateModelConfigCoerce(c *gc.C) {
 
 func (s *ModelConfigSuite) TestUpdateModelConfigPreferredOverRemove(c *gc.C) {
 	attrs := map[string]interface{}{
-		"apt-mirror":    "http://different-mirror",
+		"apt-mirror":    "http://different-mirror", // controller
 		"arbitrary-key": "shazam!",
+		"providerAttr":  "beef", // provider
 	}
 	err := s.State.UpdateModelConfig(attrs, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.State.UpdateModelConfig(map[string]interface{}{
-		"apt-mirror": "http://another-mirror",
+		"apt-mirror":   "http://another-mirror",
+		"providerAttr": "pork",
 	}, []string{"apt-mirror", "arbitrary-key"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	allAttrs := cfg.AllAttrs()
 	c.Assert(allAttrs["apt-mirror"], gc.Equals, "http://another-mirror")
+	c.Assert(allAttrs["providerAttr"], gc.Equals, "pork")
 	_, ok := allAttrs["arbitrary-key"]
 	c.Assert(ok, jc.IsFalse)
 }

--- a/state/testing/policy.go
+++ b/state/testing/policy.go
@@ -5,6 +5,8 @@ package testing
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/schema"
+	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
@@ -14,11 +16,12 @@ import (
 )
 
 type MockPolicy struct {
-	GetPrechecker              func() (state.Prechecker, error)
-	GetConfigValidator         func() (config.Validator, error)
-	GetConstraintsValidator    func() (constraints.Validator, error)
-	GetInstanceDistributor     func() (instance.Distributor, error)
-	GetStorageProviderRegistry func() (storage.ProviderRegistry, error)
+	GetPrechecker                 func() (state.Prechecker, error)
+	GetConfigValidator            func() (config.Validator, error)
+	GetProviderConfigSchemaSource func() (config.ConfigSchemaSource, error)
+	GetConstraintsValidator       func() (constraints.Validator, error)
+	GetInstanceDistributor        func() (instance.Distributor, error)
+	GetStorageProviderRegistry    func() (storage.ProviderRegistry, error)
 }
 
 func (p *MockPolicy) Prechecker() (state.Prechecker, error) {
@@ -54,4 +57,32 @@ func (p *MockPolicy) StorageProviderRegistry() (storage.ProviderRegistry, error)
 		return p.GetStorageProviderRegistry()
 	}
 	return nil, errors.NotImplementedf("StorageProviderRegistry")
+}
+
+func (p *MockPolicy) ProviderConfigSchemaSource() (config.ConfigSchemaSource, error) {
+	if p.GetProviderConfigSchemaSource != nil {
+		return p.GetProviderConfigSchemaSource()
+	}
+	return nil, errors.NotImplementedf("ProviderConfigSchemaSource")
+}
+
+type MockConfigSchemaSource struct{}
+
+func (m *MockConfigSchemaSource) ConfigSchema() schema.Fields {
+	configSchema := environschema.Fields{
+		"providerAttr": {
+			Type: environschema.Tstring,
+		},
+	}
+	fs, _, err := configSchema.ValidationSchema()
+	if err != nil {
+		panic(err)
+	}
+	return fs
+}
+
+func (m *MockConfigSchemaSource) ConfigDefaults() schema.Defaults {
+	return schema.Defaults{
+		"providerAttr": "vulch",
+	}
 }


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1615552

Providers can define their own bespoke config in the environprovider. This is separate to the generic environs/config applicable to all providers. We need to account for this config when bootstrapping (apply the config to the model) and also when figuring out model config source ("default", "controller" etc).

Add code to bootstrap and also model config handling in state. A new state policy method is required to allow state to access the provider.

QA
Hack LXD provider to have config that doesn't do anything.
Bootstrap LXD, using --config to set one of the hacked values
$ juju model-config
$ juju model-defaults show the expected values

$ juju set-model-config foo=bar
(where foo is one of the provider attrs, no warning printed like we used to see)

$ juju model-config
shows the correct values

$ juju unset-model-config foo
resets the value to the provider value
