### PR TITLE
Handle duplicate devices in ReleaseContainerAddresses

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -27,7 +27,7 @@ github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:3
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
-github.com/juju/gomaasapi	git	c4008a71e7212cb6a99a9c17bb218034927d82b7	2016-07-28T00:29:23Z
+github.com/juju/gomaasapi	git	0d72ac79f9a32e98262ac529fa5184e18213f447	2016-08-23T23:45:13Z
 github.com/juju/govmomi	git	4354a88d4b34abe467215f77c2fc1cb9f78b66f7	2015-04-24T01:54:48Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	796aaafaf712f666df58d31a482c51233038bf9f	2016-05-03T15:03:27Z


### PR DESCRIPTION
If a device has multiple MAC addresses that match arguments to
ReleaseContainerAddresses it will be returned multiple times, once for
each matching MAC. Make sure we only try to delete it once.

This is part of http://pad.lv/1585878

Testing done: I found this by removing a multi-nic container with the machine 
undertaker running  - without this change it fails to release the container 
addresses in both MAAS 1.9 and 2 (because the first delete succeeds and
subsequent ones fail with not found errors).

(Review request: http://reviews.vapour.ws/r/5521/)