### PR TITLE
Add machine undertaker worker

### DIFF
--- a/cmd/jujud/agent/engine_test.go
+++ b/cmd/jujud/agent/engine_test.go
@@ -43,6 +43,7 @@ var (
 		"environ-tracker",
 		"firewaller",
 		"instance-poller",
+		"machine-undertaker",
 		"metric-worker",
 		"migration-fortress",
 		"migration-inactive-flag",

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/juju/worker/gate"
 	"github.com/juju/juju/worker/instancepoller"
 	"github.com/juju/juju/worker/lifeflag"
+	"github.com/juju/juju/worker/machineundertaker"
 	"github.com/juju/juju/worker/metricworker"
 	"github.com/juju/juju/worker/migrationflag"
 	"github.com/juju/juju/worker/migrationmaster"
@@ -279,6 +280,11 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			// TODO(fwereade): 2016-03-17 lp:1558657
 			NewTimer: worker.NewTimer,
 		})),
+		machineUndertakerName: ifNotMigrating(machineundertaker.Manifold(machineundertaker.ManifoldConfig{
+			APICallerName: apiCallerName,
+			EnvironName:   environTrackerName,
+			NewWorker:     machineundertaker.NewWorker,
+		})),
 	}
 }
 
@@ -371,4 +377,5 @@ const (
 	metricWorkerName         = "metric-worker"
 	stateCleanerName         = "state-cleaner"
 	statusHistoryPrunerName  = "status-history-pruner"
+	machineUndertakerName    = "machine-undertaker"
 )

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -42,6 +42,7 @@ func (s *ManifoldsSuite) TestNames(c *gc.C) {
 		"firewaller",
 		"instance-poller",
 		"is-responsible-flag",
+		"machine-undertaker",
 		"metric-worker",
 		"migration-fortress",
 		"migration-inactive-flag",

--- a/worker/machineundertaker/manifold.go
+++ b/worker/machineundertaker/manifold.go
@@ -1,0 +1,50 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machineundertaker
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/machineundertaker"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// ManifoldConfig defines the machine undertaker's configuration and
+// dependencies.
+type ManifoldConfig struct {
+	APICallerName string
+	EnvironName   string
+
+	NewWorker func(Facade, environs.Environ) (worker.Worker, error)
+}
+
+// Manifold returns a dependency.Manifold that runs a machine
+// undertaker.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{config.APICallerName, config.EnvironName},
+		Start: func(context dependency.Context) (worker.Worker, error) {
+			var apiCaller base.APICaller
+			if err := context.Get(config.APICallerName, &apiCaller); err != nil {
+				return nil, errors.Trace(err)
+			}
+			var environ environs.Environ
+			if err := context.Get(config.EnvironName, &environ); err != nil {
+				return nil, errors.Trace(err)
+			}
+			api, err := machineundertaker.NewAPI(apiCaller)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			w, err := config.NewWorker(api, environ)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return w, nil
+		},
+	}
+}

--- a/worker/machineundertaker/manifold.go
+++ b/worker/machineundertaker/manifold.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/machineundertaker"
+	"github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
@@ -36,7 +37,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			if err := context.Get(config.EnvironName, &environ); err != nil {
 				return nil, errors.Trace(err)
 			}
-			api, err := machineundertaker.NewAPI(apiCaller)
+			api, err := machineundertaker.NewAPI(apiCaller, watcher.NewNotifyWatcher)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/worker/machineundertaker/manifold_test.go
+++ b/worker/machineundertaker/manifold_test.go
@@ -1,0 +1,103 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machineundertaker_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api/base"
+	apitesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	"github.com/juju/juju/worker/machineundertaker"
+)
+
+type manifoldSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&manifoldSuite{})
+
+func (*manifoldSuite) TestMissingCaller(c *gc.C) {
+	manifold := makeManifold(nil, nil)
+	result, err := manifold.Start(dt.StubContext(nil, map[string]interface{}{
+		"the-caller": dependency.ErrMissing,
+	}))
+	c.Assert(result, gc.IsNil)
+	c.Assert(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+}
+
+func (*manifoldSuite) TestMissingEnviron(c *gc.C) {
+	manifold := makeManifold(nil, nil)
+	result, err := manifold.Start(dt.StubContext(nil, map[string]interface{}{
+		"the-caller":  &fakeAPICaller{},
+		"the-environ": dependency.ErrMissing,
+	}))
+	c.Assert(result, gc.IsNil)
+	c.Assert(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+}
+
+func (*manifoldSuite) TestAPIError(c *gc.C) {
+	manifold := makeManifold(nil, nil)
+	result, err := manifold.Start(dt.StubContext(nil, map[string]interface{}{
+		"the-caller":  &fakeAPICaller{},
+		"the-environ": &fakeEnviron{},
+	}))
+	c.Assert(result, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "machine undertaker client requires a model API connection")
+}
+
+func (*manifoldSuite) TestWorkerError(c *gc.C) {
+	manifold := makeManifold(nil, errors.New("boglodite"))
+	result, err := manifold.Start(dt.StubContext(nil, map[string]interface{}{
+		"the-caller":  apitesting.APICallerFunc(nil),
+		"the-environ": &fakeEnviron{},
+	}))
+	c.Assert(result, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "boglodite")
+}
+
+func (*manifoldSuite) TestSuccess(c *gc.C) {
+	w := fakeWorker{name: "Boris"}
+	manifold := makeManifold(&w, nil)
+	result, err := manifold.Start(dt.StubContext(nil, map[string]interface{}{
+		"the-caller":  apitesting.APICallerFunc(nil),
+		"the-environ": &fakeEnviron{},
+	}))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, &w)
+}
+
+func makeManifold(workerResult worker.Worker, workerError error) dependency.Manifold {
+	return machineundertaker.Manifold(machineundertaker.ManifoldConfig{
+		APICallerName: "the-caller",
+		EnvironName:   "the-environ",
+		NewWorker: func(machineundertaker.Facade, environs.Environ) (worker.Worker, error) {
+			return workerResult, workerError
+		},
+	})
+}
+
+type fakeAPICaller struct {
+	base.APICaller
+}
+
+func (c *fakeAPICaller) ModelTag() (names.ModelTag, bool) {
+	return names.ModelTag{}, false
+}
+
+type fakeEnviron struct {
+	environs.Environ
+}
+
+type fakeWorker struct {
+	worker.Worker
+	name string
+}

--- a/worker/machineundertaker/package_test.go
+++ b/worker/machineundertaker/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machineundertaker_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/worker/machineundertaker/undertaker.go
+++ b/worker/machineundertaker/undertaker.go
@@ -1,0 +1,59 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machineundertaker
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker"
+)
+
+var logger = loggo.GetLogger("juju.worker.machineundertaker")
+
+// Facade defines the interface we require from the machine undertaker
+// facade.
+type Facade interface {
+	WatchMachineRemovals() (watcher.NotifyWatcher, error)
+	AllMachineRemovals() ([]names.MachineTag, error)
+	GetProviderInterfaceInfo(names.MachineTag) ([]network.ProviderInterfaceInfo, error)
+	CompleteRemoval(names.MachineTag) error
+}
+
+// MachineUndertaker is responsible for doing any provider-level
+// cleanup needed and then removing the machine.
+type Undertaker struct {
+	api Facade
+	env environs.Environ
+}
+
+func NewWorker(api Facade, env environs.Environ) (worker.Worker, error) {
+	w, err := watcher.NewNotifyWorker(watcher.NotifyConfig{
+		Handler: &Undertaker{api: api, env: env},
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+func (u *Undertaker) SetUp() (watcher.NotifyWatcher, error) {
+	logger.Infof("setting up machine undertaker")
+	return u.api.WatchMachineRemovals()
+}
+
+func (u *Undertaker) Handle(<-chan struct{}) error {
+	removals, err := u.api.AllMachineRemovals()
+	logger.Infof("handling removals of %v, %v", removals, err)
+	return nil
+}
+
+func (u *Undertaker) TearDown() error {
+	logger.Infof("tearing down machine undertaker")
+	return nil
+}

--- a/worker/machineundertaker/undertaker.go
+++ b/worker/machineundertaker/undertaker.go
@@ -28,13 +28,14 @@ type Facade interface {
 // MachineUndertaker is responsible for doing any provider-level
 // cleanup needed and then removing the machine.
 type Undertaker struct {
-	api Facade
-	env environs.Environ
+	api           Facade
+	envNetworking environs.Networking
 }
 
 func NewWorker(api Facade, env environs.Environ) (worker.Worker, error) {
+	envNetworking, _ := environs.SupportsNetworking(env)
 	w, err := watcher.NewNotifyWorker(watcher.NotifyConfig{
-		Handler: &Undertaker{api: api, env: env},
+		Handler: &Undertaker{api: api, envNetworking: envNetworking},
 	})
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -49,7 +50,54 @@ func (u *Undertaker) SetUp() (watcher.NotifyWatcher, error) {
 
 func (u *Undertaker) Handle(<-chan struct{}) error {
 	removals, err := u.api.AllMachineRemovals()
-	logger.Infof("handling removals of %v, %v", removals, err)
+	if err != nil {
+		// Should this be a fatal error instead?
+		logger.Errorf("couldn't get machine removals, %s", err)
+		return nil
+	}
+	logger.Debugf("handling removals: %v", removals)
+	// TODO(babbageclunk): shuffle the removals so if there's a
+	// problem with one others can still get past.
+	for _, machine := range removals {
+		err := u.maybeReleaseAddresses(machine)
+		if err != nil {
+			logger.Errorf("couldn't release addresses for %s: %s", machine, err)
+			continue
+		}
+		err = u.api.CompleteRemoval(machine)
+		if err != nil {
+			logger.Errorf("couldn't complete removal for %s: %s", machine, err)
+		} else {
+			logger.Debugf("completed removal: %s", machine)
+		}
+	}
+	return nil
+}
+
+func (u *Undertaker) maybeReleaseAddresses(machine names.MachineTag) error {
+	if u.envNetworking == nil {
+		// This environ doesn't support releasing addresses.
+		return nil
+	}
+	if !names.IsContainerMachine(machine.Id()) {
+		// Only containers need their addresses releasing.
+		return nil
+	}
+	interfaceInfos, err := u.api.GetProviderInterfaceInfo(machine)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(interfaceInfos) == 0 {
+		logger.Debugf("%s has no addresses to release", machine)
+		return nil
+	}
+	err = u.envNetworking.ReleaseContainerAddresses(interfaceInfos)
+	// Some providers say they support networking but don't
+	// actually support container addressing; don't freak out
+	// about those.
+	if err != nil && !errors.IsNotSupported(err) {
+		return errors.Trace(err)
+	}
 	return nil
 }
 

--- a/worker/machineundertaker/undertaker_test.go
+++ b/worker/machineundertaker/undertaker_test.go
@@ -1,0 +1,4 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machineundertaker_test

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -134,7 +134,7 @@ func (s *ContainerSetupSuite) createContainer(c *gc.C, host *state.Machine, ctyp
 	c.Assert(container.Remove(), gc.IsNil)
 	c.Assert(host.EnsureDead(), gc.IsNil)
 	s.checkStopInstances(c, inst)
-	s.waitRemoved(c, host)
+	s.waitForRemovalMark(c, host)
 }
 
 func (s *ContainerSetupSuite) assertContainerProvisionerStarted(
@@ -365,27 +365,11 @@ func (t toolsFinderFunc) FindTools(v version.Number, series string, arch string)
 }
 
 func getContainerInstance() (cont []ContainerInstance, err error) {
-	current_os, err := series.GetOSFromSeries(series.HostSeries())
-	if err != nil {
-		return nil, err
+	cont = []ContainerInstance{
+		{instance.KVM, [][]string{
+			{"uvtool-libvirt"},
+			{"uvtool"},
+		}},
 	}
-
-	switch current_os {
-	case jujuos.CentOS:
-		cont = []ContainerInstance{
-			{instance.KVM, [][]string{
-				{"uvtool-libvirt"},
-				{"uvtool"},
-			}},
-		}
-	default:
-		cont = []ContainerInstance{
-			{instance.KVM, [][]string{
-				{"uvtool-libvirt"},
-				{"uvtool"},
-			}},
-		}
-	}
-
 	return cont, nil
 }

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -339,7 +339,7 @@ func (s *kvmProvisionerSuite) TestContainerStartedAndStopped(c *gc.C) {
 	// ...and removed, along with the machine, when the machine is Dead.
 	c.Assert(container.EnsureDead(), gc.IsNil)
 	s.expectStopped(c, instId)
-	s.waitRemoved(c, container)
+	s.waitForRemovalMark(c, container)
 }
 
 func (s *kvmProvisionerSuite) TestKVMProvisionerObservesConfigChanges(c *gc.C) {

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -273,7 +273,7 @@ func (task *provisionerTask) processMachines(ids []string) error {
 	// Remove any dead machines from state.
 	for _, machine := range dead {
 		logger.Infof("removing dead machine %q", machine)
-		if err := machine.Remove(); err != nil {
+		if err := machine.MarkForRemoval(); err != nil {
 			logger.Errorf("failed to remove dead machine %q", machine)
 		}
 		delete(task.machines, machine.Id())

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -335,12 +335,11 @@ func (s *CommonProvisionerSuite) checkStopSomeInstances(c *gc.C,
 	}
 }
 
-func (s *CommonProvisionerSuite) waitMachine(c *gc.C, m *state.Machine, check func() bool) {
+func (s *CommonProvisionerSuite) waitForWatcher(c *gc.C, w state.NotifyWatcher, name string, check func() bool) {
 	// TODO(jam): We need to grow a new method on NotifyWatcherC
 	// that calls StartSync while waiting for changes, then
 	// waitMachine and waitHardwareCharacteristics can use that
 	// instead
-	w := m.Watch()
 	defer stop(c, w)
 	timeout := time.After(coretesting.LongWait)
 	resync := time.After(0)
@@ -354,40 +353,29 @@ func (s *CommonProvisionerSuite) waitMachine(c *gc.C, m *state.Machine, check fu
 			resync = time.After(coretesting.ShortWait)
 			s.BackingState.StartSync()
 		case <-timeout:
-			c.Fatalf("machine %v wait timed out", m)
+			c.Fatalf("%v wait timed out", name)
 		}
 	}
 }
 
 func (s *CommonProvisionerSuite) waitHardwareCharacteristics(c *gc.C, m *state.Machine, check func() bool) {
 	w := m.WatchHardwareCharacteristics()
-	defer stop(c, w)
-	timeout := time.After(coretesting.LongWait)
-	resync := time.After(0)
-	for {
-		select {
-		case <-w.Changes():
-			if check() {
-				return
-			}
-		case <-resync:
-			resync = time.After(coretesting.ShortWait)
-			s.BackingState.StartSync()
-		case <-timeout:
-			c.Fatalf("hardware characteristics for machine %v wait timed out", m)
-		}
-	}
+	name := fmt.Sprintf("hardware characteristics for machine %v", m)
+	s.waitForWatcher(c, w, name, check)
 }
 
-// waitRemoved waits for the supplied machine to be removed from state.
-func (s *CommonProvisionerSuite) waitRemoved(c *gc.C, m *state.Machine) {
-	s.waitMachine(c, m, func() bool {
-		err := m.Refresh()
-		if errors.IsNotFound(err) {
-			return true
-		}
+// waitForRemovalMark waits for the supplied machine to be marked for removal.
+func (s *CommonProvisionerSuite) waitForRemovalMark(c *gc.C, m *state.Machine) {
+	w := s.BackingState.WatchMachineRemovals()
+	name := fmt.Sprintf("machine %v marked for removal", m)
+	s.waitForWatcher(c, w, name, func() bool {
+		removals, err := s.BackingState.AllMachineRemovals()
 		c.Assert(err, jc.ErrorIsNil)
-		c.Logf("machine %v is still %s", m, m.Life())
+		for _, removal := range removals {
+			if removal == m.Id() {
+				return true
+			}
+		}
 		return false
 	})
 }
@@ -458,7 +446,7 @@ func (s *ProvisionerSuite) TestSimple(c *gc.C) {
 	// ...and removed, along with the machine, when the machine is Dead.
 	c.Assert(m.EnsureDead(), gc.IsNil)
 	s.checkStopInstances(c, instance)
-	s.waitRemoved(c, m)
+	s.waitForRemovalMark(c, m)
 }
 
 func (s *ProvisionerSuite) TestConstraints(c *gc.C) {
@@ -676,7 +664,7 @@ func (s *ProvisionerSuite) TestProvisioningDoesNotOccurForLXD(c *gc.C) {
 	c.Assert(container.Remove(), gc.IsNil)
 	c.Assert(m.EnsureDead(), gc.IsNil)
 	s.checkStopInstances(c, inst)
-	s.waitRemoved(c, m)
+	s.waitForRemovalMark(c, m)
 }
 
 func (s *ProvisionerSuite) TestProvisioningDoesNotOccurForKVM(c *gc.C) {
@@ -704,7 +692,7 @@ func (s *ProvisionerSuite) TestProvisioningDoesNotOccurForKVM(c *gc.C) {
 	c.Assert(container.Remove(), gc.IsNil)
 	c.Assert(m.EnsureDead(), gc.IsNil)
 	s.checkStopInstances(c, inst)
-	s.waitRemoved(c, m)
+	s.waitForRemovalMark(c, m)
 }
 
 type MachineClassifySuite struct {
@@ -900,7 +888,7 @@ func (s *ProvisionerSuite) TestProvisioningMachinesWithSpacesSuccess(c *gc.C) {
 	// Cleanup.
 	c.Assert(m.EnsureDead(), gc.IsNil)
 	s.checkStopInstances(c, inst)
-	s.waitRemoved(c, m)
+	s.waitForRemovalMark(c, m)
 }
 
 func (s *ProvisionerSuite) testProvisioningFailsAndSetsErrorStatusForConstraints(
@@ -1020,7 +1008,7 @@ func (s *ProvisionerSuite) TestProvisioningMachinesWithRequestedVolumes(c *gc.C)
 	// Cleanup.
 	c.Assert(m.EnsureDead(), gc.IsNil)
 	s.checkStopInstances(c, inst)
-	s.waitRemoved(c, m)
+	s.waitForRemovalMark(c, m)
 }
 
 func (s *ProvisionerSuite) TestProvisioningDoesNotProvisionTheSameMachineAfterRestart(c *gc.C) {
@@ -1072,7 +1060,7 @@ func (s *ProvisionerSuite) TestDyingMachines(c *gc.C) {
 	p = s.newEnvironProvisioner(c)
 	defer stop(c, p)
 	s.checkNoOperations(c)
-	s.waitRemoved(c, m1)
+	s.waitForRemovalMark(c, m1)
 
 	// verify the other one's still fine
 	err = m0.Refresh()
@@ -1200,7 +1188,7 @@ func (s *ProvisionerSuite) TestHarvestUnknownReapsOnlyUnknown(c *gc.C) {
 	// When only harvesting unknown machines, only one of the machines
 	// is stopped.
 	s.checkStopSomeInstances(c, []instance.Instance{i1}, []instance.Instance{i0})
-	s.waitRemoved(c, m0)
+	s.waitForRemovalMark(c, m0)
 }
 
 func (s *ProvisionerSuite) TestHarvestDestroyedReapsOnlyDestroyed(c *gc.C) {
@@ -1226,7 +1214,7 @@ func (s *ProvisionerSuite) TestHarvestDestroyedReapsOnlyDestroyed(c *gc.C) {
 	// When only harvesting destroyed machines, only one of the
 	// machines is stopped.
 	s.checkStopSomeInstances(c, []instance.Instance{i0}, []instance.Instance{i1})
-	s.waitRemoved(c, m0)
+	s.waitForRemovalMark(c, m0)
 }
 
 func (s *ProvisionerSuite) TestHarvestAllReapsAllTheThings(c *gc.C) {
@@ -1251,7 +1239,7 @@ func (s *ProvisionerSuite) TestHarvestAllReapsAllTheThings(c *gc.C) {
 
 	// Everything must die!
 	s.checkStopSomeInstances(c, []instance.Instance{i0, i1}, []instance.Instance{})
-	s.waitRemoved(c, m0)
+	s.waitForRemovalMark(c, m0)
 }
 
 func (s *ProvisionerSuite) TestProvisionerRetriesTransientErrors(c *gc.C) {


### PR DESCRIPTION
This ensures any necessary provider-level cleanup is done before the machine is fully removed.

In particular, for containers in MAAS we need to release allocated addresses - the container provisioner can't do this because it has no way to talk to the provider directly. So now the provisioner task will mark the machine as ready for removal when its work is completed. This worker watches for the removal request, releases addresses for containers (where the provider supports it), and then removes the machine and associated records. It's expected that other provider-level cleanup like IP address management will be added here.

Fixes http://pad.lv/1585878.

This is a work in progress - the worker is finished and I've tested it manually on lxd, maas 1.9 and maas 2 (with multi-nic containers), but I'm writing unit tests for the worker now.