### PR TITLE
Drop EnvironProvider methods

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -173,12 +173,6 @@ func InitializeState(
 		return nil, nil, errors.Trace(err)
 	}
 
-	// TODO(axw) we shouldn't be adding credentials to model config.
-	if args.ControllerCloudCredential != nil {
-		for k, v := range args.ControllerCloudCredential.Attributes() {
-			attrs[k] = v
-		}
-	}
 	controllerUUID := args.ControllerConfig.ControllerUUID()
 	creator := modelmanager.ModelConfigCreator{Provider: args.Provider}
 	hostedModelConfig, err := creator.NewModelConfig(

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -302,13 +302,12 @@ LXC_BRIDGE="ignored"`[1:])
 
 	// Make sure that the hosted model Environ's Create method is called.
 	envProvider.CheckCallNames(c,
-		"RestrictedConfigAttributes",
 		"PrepareConfig",
 		"Validate",
 		"Open",
 		"Create",
 	)
-	envProvider.CheckCall(c, 3, "Open", environs.OpenParams{
+	envProvider.CheckCall(c, 2, "Open", environs.OpenParams{
 		Cloud: environs.CloudSpec{
 			Type:   "dummy",
 			Name:   "dummy",
@@ -316,7 +315,7 @@ LXC_BRIDGE="ignored"`[1:])
 		},
 		Config: hostedCfg,
 	})
-	envProvider.CheckCall(c, 4, "Create", environs.CreateParams{
+	envProvider.CheckCall(c, 3, "Create", environs.CreateParams{
 		ControllerUUID: controllerCfg.ControllerUUID(),
 	})
 }
@@ -458,11 +457,6 @@ func (s *bootstrapSuite) assertCanLogInAsAdmin(c *gc.C, modelTag names.ModelTag,
 type fakeProvider struct {
 	environs.EnvironProvider
 	gitjujutesting.Stub
-}
-
-func (p *fakeProvider) RestrictedConfigAttributes() []string {
-	p.MethodCall(p, "RestrictedConfigAttributes")
-	return []string{}
 }
 
 func (p *fakeProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {

--- a/api/agent/model_test.go
+++ b/api/agent/model_test.go
@@ -27,5 +27,6 @@ func (s *modelSuite) SetUpTest(c *gc.C) {
 	c.Assert(agentAPI, gc.NotNil)
 
 	s.ModelWatcherTests = apitesting.NewModelWatcherTests(
-		agentAPI, s.BackingState, apitesting.NoSecrets)
+		agentAPI, s.BackingState,
+	)
 }

--- a/api/firewaller/state_test.go
+++ b/api/firewaller/state_test.go
@@ -22,7 +22,7 @@ var _ = gc.Suite(&stateSuite{})
 
 func (s *stateSuite) SetUpTest(c *gc.C) {
 	s.firewallerSuite.SetUpTest(c)
-	s.ModelWatcherTests = apitesting.NewModelWatcherTests(s.firewaller, s.BackingState, true)
+	s.ModelWatcherTests = apitesting.NewModelWatcherTests(s.firewaller, s.BackingState)
 }
 
 func (s *stateSuite) TearDownTest(c *gc.C) {

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -74,7 +74,7 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 	s.provisioner = provisioner.NewState(s.st)
 	c.Assert(s.provisioner, gc.NotNil)
 
-	s.ModelWatcherTests = apitesting.NewModelWatcherTests(s.provisioner, s.BackingState, apitesting.HasSecrets)
+	s.ModelWatcherTests = apitesting.NewModelWatcherTests(s.provisioner, s.BackingState)
 	s.APIAddresserTests = apitesting.NewAPIAddresserTests(s.provisioner, s.BackingState)
 }
 

--- a/api/uniter/state_test.go
+++ b/api/uniter/state_test.go
@@ -24,7 +24,7 @@ var _ = gc.Suite(&stateSuite{})
 func (s *stateSuite) SetUpTest(c *gc.C) {
 	s.uniterSuite.SetUpTest(c)
 	s.APIAddresserTests = apitesting.NewAPIAddresserTests(s.uniter, s.BackingState)
-	s.ModelWatcherTests = apitesting.NewModelWatcherTests(s.uniter, s.BackingState, apitesting.NoSecrets)
+	s.ModelWatcherTests = apitesting.NewModelWatcherTests(s.uniter, s.BackingState)
 }
 
 func (s *stateSuite) TestProviderType(c *gc.C) {

--- a/apiserver/agent/model_test.go
+++ b/apiserver/agent/model_test.go
@@ -48,5 +48,6 @@ func (s *modelSuite) SetUpTest(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.ModelWatcherTest = commontesting.NewModelWatcherTest(
-		s.api, s.State, s.resources, commontesting.NoSecrets)
+		s.api, s.State, s.resources,
+	)
 }

--- a/apiserver/common/modelwatcher.go
+++ b/apiserver/common/modelwatcher.go
@@ -6,7 +6,6 @@ package common
 import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/environs"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
 )
@@ -56,30 +55,10 @@ func (m *ModelWatcher) WatchForModelConfigChanges() (params.NotifyWatchResult, e
 // ModelConfig returns the current environment's configuration.
 func (m *ModelWatcher) ModelConfig() (params.ModelConfigResult, error) {
 	result := params.ModelConfigResult{}
-
 	config, err := m.st.ModelConfig()
 	if err != nil {
 		return result, err
 	}
-	allAttrs := config.AllAttrs()
-
-	if !m.authorizer.AuthModelManager() {
-		// Mask out any secrets in the environment configuration
-		// with values of the same type, so it'll pass validation.
-		//
-		// TODO(dimitern) 201309-26 bug #1231384
-		// Delete the code below and mark the bug as fixed,
-		// once it's live tested on MAAS and 1.16 compatibility
-		// is dropped.
-		provider, err := environs.Provider(config.Type())
-		if err != nil {
-			return result, err
-		}
-		secretAttrs, err := provider.SecretAttrs(config)
-		for k := range secretAttrs {
-			allAttrs[k] = "not available"
-		}
-	}
-	result.Config = allAttrs
+	result.Config = config.AllAttrs()
 	return result, nil
 }

--- a/apiserver/common/modelwatcher_test.go
+++ b/apiserver/common/modelwatcher_test.go
@@ -99,26 +99,6 @@ func (*environWatcherSuite) TestModelConfigFetchError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "pow")
 }
 
-func (*environWatcherSuite) TestModelConfigMaskedSecrets(c *gc.C) {
-	authorizer := apiservertesting.FakeAuthorizer{
-		Tag:            names.NewMachineTag("0"),
-		EnvironManager: false,
-	}
-	testingEnvConfig := testingEnvConfig(c)
-	e := common.NewModelWatcher(
-		&fakeModelAccessor{modelConfig: testingEnvConfig},
-		nil,
-		authorizer,
-	)
-	result, err := e.ModelConfig()
-	c.Assert(err, jc.ErrorIsNil)
-	// Make sure the secret attribute is masked.
-	c.Check(result.Config["secret"], gc.Equals, "not available")
-	// And only that is masked.
-	result.Config["secret"] = "pork"
-	c.Check(map[string]interface{}(result.Config), jc.DeepEquals, testingEnvConfig.AllAttrs())
-}
-
 func testingEnvConfig(c *gc.C) *config.Config {
 	env, err := bootstrap.Prepare(
 		modelcmd.BootstrapContext(testing.Context(c)),

--- a/apiserver/firewaller/firewaller_test.go
+++ b/apiserver/firewaller/firewaller_test.go
@@ -42,7 +42,7 @@ func (s *firewallerSuite) SetUpTest(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.firewaller = firewallerAPI
-	s.ModelWatcherTest = commontesting.NewModelWatcherTest(s.firewaller, s.State, s.resources, commontesting.HasSecrets)
+	s.ModelWatcherTest = commontesting.NewModelWatcherTest(s.firewaller, s.State, s.resources)
 }
 
 func (s *firewallerSuite) TestFirewallerFailsWithNonEnvironManagerUser(c *gc.C) {

--- a/apiserver/modelconfig/modelconfig.go
+++ b/apiserver/modelconfig/modelconfig.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/description"
-	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 )
@@ -67,34 +66,8 @@ func (c *ModelConfigAPI) ModelGet() (params.ModelConfigResults, error) {
 		return result, errors.Trace(err)
 	}
 
-	// TODO(wallyworld) - this can be removed once credentials are properly
-	// managed outside of model config.
-	// Strip out any model config attributes that are credential attributes.
-	provider, err := environs.Provider(values[config.TypeKey].Value.(string))
-	if err != nil {
-		return result, errors.Trace(err)
-	}
-	credSchemas := provider.CredentialSchemas()
-	var allCredentialAttributes []string
-	for _, schema := range credSchemas {
-		for _, attr := range schema {
-			allCredentialAttributes = append(allCredentialAttributes, attr.Name)
-		}
-	}
-	isCredentialAttribute := func(attr string) bool {
-		for _, a := range allCredentialAttributes {
-			if a == attr {
-				return true
-			}
-		}
-		return false
-	}
-
 	result.Config = make(map[string]params.ConfigValue)
 	for attr, val := range values {
-		if isCredentialAttribute(attr) {
-			continue
-		}
 		// Authorized keys are able to be listed using
 		// juju ssh-keys and including them here just
 		// clutters everything.

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -141,14 +141,6 @@ func (mm *ModelManagerAPI) newModelConfig(
 	}
 	joint[config.NameKey] = args.Name
 
-	// Copy credential attributes across to model config.
-	// TODO(axw) credentials should not be going into model config.
-	if cloudSpec.Credential != nil {
-		for key, value := range cloudSpec.Credential.Attributes() {
-			joint[key] = value
-		}
-	}
-
 	baseConfig, err := source.Config()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -101,7 +101,7 @@ var _ = gc.Suite(&withoutControllerSuite{})
 
 func (s *withoutControllerSuite) SetUpTest(c *gc.C) {
 	s.setUpTest(c, false)
-	s.ModelWatcherTest = commontesting.NewModelWatcherTest(s.provisioner, s.State, s.resources, commontesting.HasSecrets)
+	s.ModelWatcherTest = commontesting.NewModelWatcherTest(s.provisioner, s.State, s.resources)
 }
 
 func (s *withoutControllerSuite) TestProvisionerFailsWithNonMachineAgentNonManagerUser(c *gc.C) {
@@ -608,7 +608,7 @@ func (s *withoutControllerSuite) TestModelConfigNonManager(c *gc.C) {
 	aProvisioner, err := provisioner.NewProvisionerAPI(s.State, s.resources,
 		anAuthorizer)
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertModelConfig(c, aProvisioner, commontesting.NoSecrets)
+	s.AssertModelConfig(c, aProvisioner)
 }
 
 func (s *withoutControllerSuite) TestStatus(c *gc.C) {

--- a/apiserver/uniter/uniter_test.go
+++ b/apiserver/uniter/uniter_test.go
@@ -2293,7 +2293,6 @@ func (s *unitMetricBatchesSuite) SetUpTest(c *gc.C) {
 		s.uniter,
 		s.State,
 		s.resources,
-		commontesting.NoSecrets,
 	)
 }
 

--- a/cloudconfig/cloudinit/renderscript_test.go
+++ b/cloudconfig/cloudinit/renderscript_test.go
@@ -36,10 +36,6 @@ type testProvider struct {
 	environs.EnvironProvider
 }
 
-func (p *testProvider) SecretAttrs(cfg *config.Config) (map[string]string, error) {
-	return map[string]string{}, nil
-}
-
 func init() {
 	environs.RegisterProvider("sshinit_test", &testProvider{})
 }

--- a/controller/modelmanager/createmodel.go
+++ b/controller/modelmanager/createmodel.go
@@ -176,7 +176,6 @@ func RestrictedProviderFields(provider environs.EnvironProvider) ([]string, erro
 	var fields []string
 	// For now, all models in a controller must be of the same type.
 	fields = append(fields, config.TypeKey)
-	fields = append(fields, provider.RestrictedConfigAttributes()...)
 	return fields, nil
 }
 

--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -12,7 +12,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/controller/modelmanager"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -58,11 +57,6 @@ func (s *ModelConfigCreatorSuite) SetUpTest(c *gc.C) {
 		}),
 	)
 	c.Assert(err, jc.ErrorIsNil)
-
-	// TODO(wallyworld) - we need to separate controller and model schemas
-	// Remove any remaining controller attributes from the env config.
-	baseConfig, err = baseConfig.Remove(controller.ControllerOnlyConfigAttributes)
-	c.Assert(err, jc.ErrorIsNil)
 	s.baseConfig = baseConfig
 }
 
@@ -88,11 +82,10 @@ func (s *ModelConfigCreatorSuite) TestCreateModelValidatesConfig(c *gc.C) {
 	c.Assert(cfg.AllAttrs(), jc.DeepEquals, expected)
 
 	s.fake.Stub.CheckCallNames(c,
-		"RestrictedConfigAttributes",
 		"PrepareConfig",
 		"Validate",
 	)
-	validateCall := s.fake.Stub.Calls()[2]
+	validateCall := s.fake.Stub.Calls()[1]
 	c.Assert(validateCall.Args, gc.HasLen, 2)
 	c.Assert(validateCall.Args[0], gc.Equals, cfg)
 	c.Assert(validateCall.Args[1], gc.IsNil)
@@ -107,10 +100,6 @@ func (s *ModelConfigCreatorSuite) TestCreateModelBadConfig(c *gc.C) {
 		key:      "type",
 		value:    "dummy",
 		errMatch: `specified type "dummy" does not match controller "fake"`,
-	}, {
-		key:      "restricted",
-		value:    51,
-		errMatch: `specified restricted "51" does not match controller "area51"`,
 	}} {
 		c.Logf("%d: %s", i, test.key)
 		_, err := s.newModelConfig(coretesting.Attrs(
@@ -222,10 +211,7 @@ func (*RestrictedProviderFieldsSuite) TestRestrictedProviderFields(c *gc.C) {
 		expected: []string{"type"},
 	}, {
 		provider: "ec2",
-		expected: []string{
-			"type",
-			"vpc-id-force",
-		},
+		expected: []string{"type"},
 	}} {
 		c.Logf("%d: %s provider", i, test.provider)
 		provider, err := environs.Provider(test.provider)
@@ -240,11 +226,6 @@ type fakeProvider struct {
 	testing.Stub
 	environs.EnvironProvider
 	restrictedConfigAttributes []string
-}
-
-func (p *fakeProvider) RestrictedConfigAttributes() []string {
-	p.MethodCall(p, "RestrictedConfigAttributes")
-	return p.restrictedConfigAttributes
 }
 
 func (p *fakeProvider) Validate(cfg, old *config.Config) (*config.Config, error) {

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -21,11 +21,6 @@ type EnvironProvider interface {
 
 	// TODO(wallyworld) - embed config.ConfigSchemaSource and make all providers implement it
 
-	// RestrictedConfigAttributes are provider specific attributes stored in
-	// the config that really cannot or should not be changed across
-	// environments running inside a single juju server.
-	RestrictedConfigAttributes() []string
-
 	// PrepareConfig prepares the configuration for a new model, based on
 	// the provided arguments. PrepareConfig is expected to produce a
 	// deterministic output. Any unique values should be based on the
@@ -39,11 +34,6 @@ type EnvironProvider interface {
 	// Open should not perform any expensive operations, such as querying
 	// the cloud API, as it will be called frequently.
 	Open(OpenParams) (Environ, error)
-
-	// SecretAttrs filters the supplied configuration returning only values
-	// which are considered sensitive. All of the values of these secret
-	// attributes need to be strings.
-	SecretAttrs(cfg *config.Config) (map[string]string, error)
 }
 
 // OpenParams contains the parameters for EnvironProvider.Open.

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -486,33 +486,7 @@ func newState(environ environs.Environ, mongoInfo *mongo.MongoInfo) (*state.Stat
 	} else if err != nil {
 		return nil, err
 	}
-	if err := updateSecrets(environ, st); err != nil {
-		st.Close()
-		return nil, fmt.Errorf("unable to push secrets: %v", err)
-	}
 	return st, nil
-}
-
-func updateSecrets(env environs.Environ, st *state.State) error {
-	secrets, err := env.Provider().SecretAttrs(env.Config())
-	if err != nil {
-		return err
-	}
-	cfg, err := st.ModelConfig()
-	if err != nil {
-		return err
-	}
-	secretAttrs := make(map[string]interface{})
-	attrs := cfg.AllAttrs()
-	for k, v := range secrets {
-		if _, exists := attrs[k]; exists {
-			// Environment already has secrets. Won't send again.
-			return nil
-		} else {
-			secretAttrs[k] = v
-		}
-	}
-	return st.UpdateModelConfig(secretAttrs, nil, nil)
 }
 
 // PutCharm uploads the given charm to provider storage, and adds a

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -82,22 +82,12 @@ func (prov *azureEnvironProvider) Open(args environs.OpenParams) (environs.Envir
 	return environ, nil
 }
 
-// RestrictedConfigAttributes is part of the EnvironProvider interface.
-func (prov *azureEnvironProvider) RestrictedConfigAttributes() []string {
-	return []string{}
-}
-
 // PrepareConfig is part of the EnvironProvider interface.
 func (prov *azureEnvironProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}
 	return args.Config, nil
-}
-
-// SecretAttrs is part of the EnvironProvider interface.
-func (prov *azureEnvironProvider) SecretAttrs(cfg *config.Config) (map[string]string, error) {
-	return map[string]string{}, nil
 }
 
 func validateCloudSpec(spec environs.CloudSpec) error {

--- a/provider/cloudsigma/provider.go
+++ b/provider/cloudsigma/provider.go
@@ -81,13 +81,6 @@ func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) 
 	return env, nil
 }
 
-// RestrictedConfigAttributes are provider specific attributes stored in
-// the config that really cannot or should not be changed across
-// environments running inside a single juju server.
-func (environProvider) RestrictedConfigAttributes() []string {
-	return []string{}
-}
-
 // PrepareConfig is defined by EnvironProvider.
 func (environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
@@ -122,13 +115,6 @@ func (environProvider) Validate(cfg, old *config.Config) (*config.Config, error)
 	}
 
 	return newEcfg.Config, nil
-}
-
-// SecretAttrs filters the supplied configuration returning only values
-// which are considered sensitive. All of the values of these secret
-// attributes need to be strings.
-func (environProvider) SecretAttrs(cfg *config.Config) (map[string]string, error) {
-	return map[string]string{}, nil
 }
 
 func validateCloudSpec(spec environs.CloudSpec) error {

--- a/provider/dummy/config_test.go
+++ b/provider/dummy/config_test.go
@@ -26,31 +26,6 @@ func (s *ConfigSuite) TearDownTest(c *gc.C) {
 	dummy.Reset(c)
 }
 
-func (*ConfigSuite) TestSecretAttrs(c *gc.C) {
-	attrs := dummy.SampleConfig().Delete("secret")
-	ctx := envtesting.BootstrapContext(c)
-	env, err := bootstrap.Prepare(
-		ctx, jujuclienttesting.NewMemStore(),
-		bootstrap.PrepareParams{
-			ControllerConfig: testing.FakeControllerConfig(),
-			ModelConfig:      attrs,
-			ControllerName:   attrs["name"].(string),
-			Cloud:            dummy.SampleCloudSpec(),
-			AdminSecret:      AdminSecret,
-		},
-	)
-	c.Assert(err, jc.ErrorIsNil)
-	defer env.Destroy()
-	expected := map[string]string{
-		"secret": "pork",
-	}
-	cfg, err := config.New(config.NoDefaults, attrs)
-	c.Assert(err, jc.ErrorIsNil)
-	actual, err := env.Provider().SecretAttrs(cfg)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actual, gc.DeepEquals, expected)
-}
-
 var firewallModeTests = []struct {
 	configFirewallMode string
 	firewallMode       string

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -578,11 +578,6 @@ func (p *environProvider) Open(args environs.OpenParams) (environs.Environ, erro
 	return env, nil
 }
 
-// RestrictedConfigAttributes is specified in the EnvironProvider interface.
-func (p *environProvider) RestrictedConfigAttributes() []string {
-	return nil
-}
-
 // PrepareConfig is specified in the EnvironProvider interface.
 func (p *environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	ecfg, err := p.newConfig(args.Config)
@@ -634,16 +629,6 @@ func (p *environProvider) PrepareConfig(args environs.PrepareConfigParams) (*con
 	envState.bootstrapConfig = cfg
 	p.state[controllerUUID] = envState
 	return cfg, nil
-}
-
-func (*environProvider) SecretAttrs(cfg *config.Config) (map[string]string, error) {
-	ecfg, err := dummy.newConfig(cfg)
-	if err != nil {
-		return nil, err
-	}
-	return map[string]string{
-		"secret": ecfg.secret(),
-	}, nil
 }
 
 // Override for testing - the data directory with which the state api server is initialised.

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -26,13 +26,6 @@ type environProvider struct {
 
 var providerInstance environProvider
 
-// RestrictedConfigAttributes is specified in the EnvironProvider interface.
-func (p environProvider) RestrictedConfigAttributes() []string {
-	// TODO(dimitern): Both of these shouldn't be restricted for hosted models.
-	// See bug http://pad.lv/1580417 for more information.
-	return []string{"vpc-id-force"}
-}
-
 // Open is specified in the EnvironProvider interface.
 func (p environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
 	logger.Infof("opening model %q", args.Config.Name())
@@ -127,11 +120,6 @@ func (p environProvider) MetadataLookupParams(region string) (*simplestreams.Met
 		Region:   region,
 		Endpoint: ec2Region.EC2Endpoint,
 	}, nil
-}
-
-// SecretAttrs is specified in the EnvironProvider interface.
-func (environProvider) SecretAttrs(cfg *config.Config) (map[string]string, error) {
-	return make(map[string]string), nil
 }
 
 const badAccessKey = `

--- a/provider/gce/provider.go
+++ b/provider/gce/provider.go
@@ -89,11 +89,6 @@ func configWithDefaults(cfg *config.Config) (*config.Config, error) {
 	return cfg.Apply(defaults)
 }
 
-// RestrictedConfigAttributes is specified in the EnvironProvider interface.
-func (environProvider) RestrictedConfigAttributes() []string {
-	return []string{}
-}
-
 // Validate implements environs.EnvironProvider.Validate.
 func (environProvider) Validate(cfg, old *config.Config) (*config.Config, error) {
 	newCfg, err := newConfig(cfg, old)
@@ -101,9 +96,4 @@ func (environProvider) Validate(cfg, old *config.Config) (*config.Config, error)
 		return nil, errors.Annotate(err, "invalid config")
 	}
 	return newCfg.config, nil
-}
-
-// SecretAttrs implements environs.EnvironProvider.SecretAttrs.
-func (environProvider) SecretAttrs(cfg *config.Config) (map[string]string, error) {
-	return map[string]string{}, nil
 }

--- a/provider/joyent/provider.go
+++ b/provider/joyent/provider.go
@@ -46,11 +46,6 @@ var _ environs.EnvironProvider = providerInstance
 
 var _ simplestreams.HasRegion = (*joyentEnviron)(nil)
 
-// RestrictedConfigAttributes is part of the EnvironProvider interface.
-func (joyentProvider) RestrictedConfigAttributes() []string {
-	return []string{}
-}
-
 // PrepareConfig is part of the EnvironProvider interface.
 func (p joyentProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
@@ -124,10 +119,6 @@ func (joyentProvider) Validate(cfg, old *config.Config) (valid *config.Config, e
 		return nil, errors.Errorf("invalid Joyent provider config: %v", err)
 	}
 	return cfg.Apply(newEcfg.attrs)
-}
-
-func (joyentProvider) SecretAttrs(cfg *config.Config) (map[string]string, error) {
-	return map[string]string{}, nil
 }
 
 func GetProviderInstance() environs.EnvironProvider {

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -40,22 +40,12 @@ func (p environProvider) PrepareConfig(args environs.PrepareConfigParams) (*conf
 	return args.Config, nil
 }
 
-// RestrictedConfigAttributes is specified in the EnvironProvider interface.
-func (environProvider) RestrictedConfigAttributes() []string {
-	return []string{}
-}
-
 // Validate implements environs.EnvironProvider.
 func (environProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {
 	if _, err := newValidConfig(cfg); err != nil {
 		return nil, errors.Annotate(err, "invalid base config")
 	}
 	return cfg, nil
-}
-
-// SecretAttrs implements environs.EnvironProvider.
-func (environProvider) SecretAttrs(cfg *config.Config) (map[string]string, error) {
-	return map[string]string{}, nil
 }
 
 // DetectRegions implements environs.CloudRegionDetector.

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -74,12 +74,6 @@ func (s *providerSuite) TestValidate(c *gc.C) {
 	c.Check(s.Config.AllAttrs(), gc.DeepEquals, validAttrs)
 }
 
-func (s *providerSuite) TestSecretAttrs(c *gc.C) {
-	obtainedAttrs, err := s.provider.SecretAttrs(s.Config)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(obtainedAttrs, gc.HasLen, 0)
-}
-
 type ProviderFunctionalSuite struct {
 	lxd.BaseSuite
 

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -43,11 +43,6 @@ func (maasEnvironProvider) Open(args environs.OpenParams) (environs.Environ, err
 var errAgentNameAlreadySet = errors.New(
 	"maas-agent-name is already set; this should not be set by hand")
 
-// RestrictedConfigAttributes is specified in the EnvironProvider interface.
-func (p maasEnvironProvider) RestrictedConfigAttributes() []string {
-	return []string{}
-}
-
 // PrepareConfig is specified in the EnvironProvider interface.
 func (p maasEnvironProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
@@ -79,11 +74,6 @@ func verifyCredentials(env *maasEnviron) error {
 Please ensure the credentials are correct.`)
 	}
 	return nil
-}
-
-// SecretAttrs is specified in the EnvironProvider interface.
-func (prov maasEnvironProvider) SecretAttrs(cfg *config.Config) (map[string]string, error) {
-	return map[string]string{}, nil
 }
 
 // DetectRegions is specified in the environs.CloudRegionDetector interface.

--- a/provider/manual/config.go
+++ b/provider/manual/config.go
@@ -10,12 +10,8 @@ import (
 )
 
 var (
-	configFields = schema.Fields{
-		"bootstrap-user": schema.String(),
-	}
-	configDefaults = schema.Defaults{
-		"bootstrap-user": "",
-	}
+	configFields   = schema.Fields{}
+	configDefaults = schema.Defaults{}
 )
 
 type environConfig struct {
@@ -25,8 +21,4 @@ type environConfig struct {
 
 func newModelConfig(config *config.Config, attrs map[string]interface{}) *environConfig {
 	return &environConfig{Config: config, attrs: attrs}
-}
-
-func (c *environConfig) bootstrapUser() string {
-	return c.attrs["bootstrap-user"].(string)
 }

--- a/provider/manual/config_test.go
+++ b/provider/manual/config_test.go
@@ -4,9 +4,6 @@
 package manual
 
 import (
-	"fmt"
-	"regexp"
-
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -36,7 +33,6 @@ func MinimalConfigValues() map[string]interface{} {
 		"uuid":            coretesting.ModelTag.Id(),
 		"controller-uuid": coretesting.ModelTag.Id(),
 		"firewall-mode":   "instance",
-		"bootstrap-user":  "",
 		// While the ca-cert bits aren't entirely minimal, they avoid the need
 		// to set up a fake home.
 		"ca-cert":        coretesting.CACert,
@@ -57,36 +53,4 @@ func getModelConfig(c *gc.C, attrs map[string]interface{}) *environConfig {
 	envConfig, err := manualProvider{}.validate(testConfig, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return envConfig
-}
-
-func (s *configSuite) TestConfigMutability(c *gc.C) {
-	testConfig := MinimalConfig(c)
-	valid, err := manualProvider{}.Validate(testConfig, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	unknownAttrs := valid.UnknownAttrs()
-
-	// Make sure the immutable values can't be changed. It'd be nice to be
-	// able to change these, but that would involve somehow updating the
-	// machine agent's config/upstart config.
-	oldConfig := testConfig
-	for k, v := range map[string]interface{}{
-		"bootstrap-user": "new-username",
-	} {
-		testConfig = MinimalConfig(c)
-		testConfig, err = testConfig.Apply(map[string]interface{}{k: v})
-		c.Assert(err, jc.ErrorIsNil)
-		_, err := manualProvider{}.Validate(testConfig, oldConfig)
-		oldv := unknownAttrs[k]
-		errmsg := fmt.Sprintf("cannot change %s from %q to %q", k, oldv, v)
-		c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(errmsg))
-	}
-}
-
-func (s *configSuite) TestBootstrapUser(c *gc.C) {
-	values := MinimalConfigValues()
-	testConfig := getModelConfig(c, values)
-	c.Assert(testConfig.bootstrapUser(), gc.Equals, "")
-	values["bootstrap-user"] = "ubuntu"
-	testConfig = getModelConfig(c, values)
-	c.Assert(testConfig.bootstrapUser(), gc.Equals, "ubuntu")
 }

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -45,6 +45,7 @@ var (
 
 type manualEnviron struct {
 	host     string
+	user     string
 	cfgmutex sync.Mutex
 	cfg      *environConfig
 }
@@ -82,7 +83,7 @@ func (e *manualEnviron) Config() *config.Config {
 
 // PrepareForBootstrap is part of the Environ interface.
 func (e *manualEnviron) PrepareForBootstrap(ctx environs.BootstrapContext) error {
-	if err := ensureBootstrapUbuntuUser(ctx, e.host, e.envConfig()); err != nil {
+	if err := ensureBootstrapUbuntuUser(ctx, e.host, e.user, e.envConfig()); err != nil {
 		return err
 	}
 	return nil

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
+	"github.com/juju/utils/arch"
 	"github.com/juju/utils/ssh"
 
 	"github.com/juju/juju/agent"
@@ -38,16 +39,19 @@ const (
 )
 
 var (
-	logger                                       = loggo.GetLogger("juju.provider.manual")
-	manualCheckProvisioned                       = manual.CheckProvisioned
-	manualDetectSeriesAndHardwareCharacteristics = manual.DetectSeriesAndHardwareCharacteristics
+	logger                 = loggo.GetLogger("juju.provider.manual")
+	manualCheckProvisioned = manual.CheckProvisioned
 )
 
 type manualEnviron struct {
-	host     string
-	user     string
-	cfgmutex sync.Mutex
-	cfg      *environConfig
+	host string
+	user string
+	mu   sync.Mutex
+	cfg  *environConfig
+	// hw and series are detected by running a script on the
+	// target machine. We cache these, as they should not change.
+	hw     *instance.HardwareCharacteristics
+	series string
 }
 
 var errNoStartInstance = errors.New("manual provider cannot start instances")
@@ -71,9 +75,9 @@ func (e *manualEnviron) AllInstances() ([]instance.Instance, error) {
 }
 
 func (e *manualEnviron) envConfig() (cfg *environConfig) {
-	e.cfgmutex.Lock()
+	e.mu.Lock()
 	cfg = e.cfg
-	e.cfgmutex.Unlock()
+	e.mu.Unlock()
 	return cfg
 }
 
@@ -103,13 +107,13 @@ func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 	if provisioned {
 		return nil, manual.ErrProvisioned
 	}
-	hc, series, err := manualDetectSeriesAndHardwareCharacteristics(e.host)
+	hw, series, err := e.seriesAndHardwareCharacteristics()
 	if err != nil {
 		return nil, err
 	}
 	finalize := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig, _ environs.BootstrapDialOpts) error {
 		icfg.Bootstrap.BootstrapMachineInstanceId = BootstrapInstanceId
-		icfg.Bootstrap.BootstrapMachineHardwareCharacteristics = &hc
+		icfg.Bootstrap.BootstrapMachineHardwareCharacteristics = hw
 		if err := instancecfg.FinishInstanceConfig(icfg, e.Config()); err != nil {
 			return err
 		}
@@ -117,7 +121,7 @@ func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 	}
 
 	result := &environs.BootstrapResult{
-		Arch:     *hc.Arch,
+		Arch:     *hw.Arch,
 		Series:   series,
 		Finalize: finalize,
 	}
@@ -126,8 +130,7 @@ func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 
 // ControllerInstances is specified in the Environ interface.
 func (e *manualEnviron) ControllerInstances(controllerUUID string) ([]instance.Id, error) {
-	arg0 := filepath.Base(os.Args[0])
-	if arg0 != names.Jujud {
+	if !isRunningController() {
 		// Not running inside the controller, so we must
 		// verify the host.
 		if err := e.verifyBootstrapHost(); err != nil {
@@ -169,8 +172,8 @@ func (e *manualEnviron) verifyBootstrapHost() error {
 }
 
 func (e *manualEnviron) SetConfig(cfg *config.Config) error {
-	e.cfgmutex.Lock()
-	defer e.cfgmutex.Unlock()
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	_, err := manualProvider{}.validate(cfg, e.cfg.Config)
 	if err != nil {
 		return err
@@ -272,7 +275,32 @@ var unsupportedConstraints = []string{
 func (e *manualEnviron) ConstraintsValidator() (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 	validator.RegisterUnsupported(unsupportedConstraints)
+	if isRunningController() {
+		validator.UpdateVocabulary(constraints.Arch, []string{arch.HostArch()})
+	} else {
+		// We're running outside of the Juju controller, so we must
+		// SSH to the machine and detect its architecture.
+		hw, _, err := e.seriesAndHardwareCharacteristics()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		validator.UpdateVocabulary(constraints.Arch, []string{*hw.Arch})
+	}
 	return validator, nil
+}
+
+func (e *manualEnviron) seriesAndHardwareCharacteristics() (_ *instance.HardwareCharacteristics, series string, _ error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.hw != nil {
+		return e.hw, e.series, nil
+	}
+	hw, series, err := manual.DetectSeriesAndHardwareCharacteristics(e.host)
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+	e.hw, e.series = &hw, series
+	return e.hw, e.series, nil
 }
 
 func (e *manualEnviron) OpenPorts(ports []network.PortRange) error {
@@ -289,4 +317,8 @@ func (e *manualEnviron) Ports() ([]network.PortRange, error) {
 
 func (*manualEnviron) Provider() environs.EnvironProvider {
 	return manualProvider{}
+}
+
+func isRunningController() bool {
+	return filepath.Base(os.Args[0]) == names.Jujud
 }

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -39,10 +39,16 @@ func (s *providerSuite) TestPrepareForBootstrapCloudEndpointAndRegion(c *gc.C) {
 	s.CheckCall(c, 0, "InitUbuntuUser", "endpoint", "", "", ctx.GetStdin(), ctx.GetStdout())
 }
 
+func (s *providerSuite) TestPrepareForBootstrapUserHost(c *gc.C) {
+	ctx, err := s.testPrepareForBootstrap(c, "user@host", "")
+	c.Assert(err, jc.ErrorIsNil)
+	s.CheckCall(c, 0, "InitUbuntuUser", "host", "user", "", ctx.GetStdin(), ctx.GetStdout())
+}
+
 func (s *providerSuite) TestPrepareForBootstrapNoCloudEndpoint(c *gc.C) {
 	_, err := s.testPrepareForBootstrap(c, "", "region")
 	c.Assert(err, gc.ErrorMatches,
-		`missing address of host to bootstrap: please specify "juju bootstrap manual/<host>"`)
+		`missing address of host to bootstrap: please specify "juju bootstrap manual/\[user@\]<host>"`)
 }
 
 func (s *providerSuite) testPrepareForBootstrap(c *gc.C, endpoint, region string) (environs.BootstrapContext, error) {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -91,11 +91,6 @@ func (p EnvironProvider) Open(args environs.OpenParams) (environs.Environ, error
 	return e, nil
 }
 
-// RestrictedConfigAttributes is specified in the EnvironProvider interface.
-func (p EnvironProvider) RestrictedConfigAttributes() []string {
-	return []string{}
-}
-
 // DetectRegions implements environs.CloudRegionDetector.
 func (EnvironProvider) DetectRegions() ([]cloud.Region, error) {
 	// If OS_REGION_NAME and OS_AUTH_URL are both set,
@@ -141,10 +136,6 @@ func (p EnvironProvider) MetadataLookupParams(region string) (*simplestreams.Met
 	return &simplestreams.MetadataLookupParams{
 		Region: region,
 	}, nil
-}
-
-func (p EnvironProvider) SecretAttrs(cfg *config.Config) (map[string]string, error) {
-	return make(map[string]string), nil
 }
 
 func (p EnvironProvider) newConfig(cfg *config.Config) (*environConfig, error) {

--- a/provider/rackspace/provider_test.go
+++ b/provider/rackspace/provider_test.go
@@ -65,11 +65,6 @@ func (p *fakeProvider) Open(args environs.OpenParams) (environs.Environ, error) 
 	return nil, nil
 }
 
-func (p *fakeProvider) RestrictedConfigAttributes() []string {
-	p.MethodCall(p, "RestrictedConfigAttributes")
-	return nil
-}
-
 func (p *fakeProvider) PrepareForCreateEnvironment(controllerUUID string, cfg *config.Config) (*config.Config, error) {
 	p.MethodCall(p, "PrepareForCreateEnvironment", controllerUUID, cfg)
 	return nil, nil
@@ -88,11 +83,6 @@ func (p *fakeProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *c
 func (p *fakeProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {
 	p.MethodCall(p, "Validate", cfg, old)
 	return cfg, nil
-}
-
-func (p *fakeProvider) SecretAttrs(cfg *config.Config) (map[string]string, error) {
-	p.MethodCall(p, "SecretAttrs", cfg)
-	return nil, nil
 }
 
 func (p *fakeProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -40,11 +40,6 @@ func (p environProvider) PrepareConfig(args environs.PrepareConfigParams) (*conf
 	return args.Config, nil
 }
 
-// RestrictedConfigAttributes is specified in the EnvironProvider interface.
-func (environProvider) RestrictedConfigAttributes() []string {
-	return []string{}
-}
-
 // Validate implements environs.EnvironProvider.
 func (environProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {
 	if old == nil {
@@ -66,11 +61,6 @@ func (environProvider) Validate(cfg, old *config.Config) (valid *config.Config, 
 	}
 
 	return ecfg.Config, nil
-}
-
-// SecretAttrs implements environs.EnvironProvider.
-func (environProvider) SecretAttrs(cfg *config.Config) (map[string]string, error) {
-	return map[string]string{}, nil
 }
 
 func validateCloudSpec(spec environs.CloudSpec) error {


### PR DESCRIPTION
Drop EnvironProvider.RestrictedConfigAttributes
and EnvironProvider.SecretAttrs methods, and
stop adding credential attributes to and removing
them from model config.

To enable this, there are two functional changes:
 - in the ec2 provider, vpc-id-force is no longer
   restricted. This attribute is only used at
   bootstrap time, so it doesn't need to be the
   same in each model. Preferably it wouldn't be
   in model config at all, but we don't have a
   way of describing provider-specific bootstrap
   config.
 - in the manual provider, we drop the bootstrap-user
   config attribute and extend the endpoint syntax
   to permit user@host as well as host.