### PR TITLE
Add openstack default config values

### DIFF
--- a/provider/lxd/config.go
+++ b/provider/lxd/config.go
@@ -15,7 +15,6 @@ import (
 
 var (
 	configSchema                 = environschema.Fields{}
-	configBaseDefaults           = schema.Defaults{}
 	configFields, configDefaults = func() (schema.Fields, schema.Defaults) {
 		fields, defaults, err := configSchema.ValidationSchema()
 		if err != nil {

--- a/provider/openstack/config.go
+++ b/provider/openstack/config.go
@@ -27,7 +27,11 @@ var configSchema = environschema.Fields{
 	},
 }
 
-var configDefaults = schema.Defaults{}
+var configDefaults = schema.Defaults{
+	"use-floating-ip":      false,
+	"use-default-secgroup": false,
+	"network":              "",
+}
 
 var configFields = func() schema.Fields {
 	fs, _, err := configSchema.ValidationSchema()


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju/+bug/1616584

Trivial fix to openstack provider. The rackspace provider was ok, but the openstack provider didn't have any default values for its config. Also removed unused var in LXD provider.

(Review request: http://reviews.vapour.ws/r/5524/)