### PR TITLE
Enabled deployment of local charms from controller

### DIFF
--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -379,18 +379,16 @@ func (h *bundleHandler) addService(
 	}
 
 	// Deploy the application.
-	if err := deployApp(
-		api,
-		application.DeployArgs{
-			CharmID:          chID,
-			Cons:             cons,
-			ApplicationName:  p.Application,
-			Series:           series,
-			ConfigYAML:       configYAML,
-			Storage:          storageConstraints,
-			Resources:        resNames2IDs,
-			EndpointBindings: p.EndpointBindings,
-		}); err == nil {
+	if err := api.Deploy(application.DeployArgs{
+		CharmID:          chID,
+		Cons:             cons,
+		ApplicationName:  p.Application,
+		Series:           series,
+		ConfigYAML:       configYAML,
+		Storage:          storageConstraints,
+		Resources:        resNames2IDs,
+		EndpointBindings: p.EndpointBindings,
+	}); err == nil {
 		h.log.Infof("application %s deployed (charm %s)", p.Application, ch)
 		for resName := range resNames2IDs {
 			h.log.Infof("added resource %s", resName)

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
+	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/api/charms"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -134,9 +135,10 @@ func (s *RemoveCharmStoreCharmsSuite) SetUpTest(c *gc.C) {
 			return nil, errors.Trace(err)
 		}
 		return &deployAPIAdapter{
-			Connection:   apiRoot,
-			apiClient:    &apiClient{Client: apiRoot.Client()},
-			charmsClient: &charmsClient{Client: charms.NewClient(apiRoot)},
+			Connection:        apiRoot,
+			apiClient:         &apiClient{Client: apiRoot.Client()},
+			charmsClient:      &charmsClient{Client: charms.NewClient(apiRoot)},
+			applicationClient: &applicationClient{application.NewClient(apiRoot)},
 		}, nil
 	}
 


### PR DESCRIPTION
Fixes lp:1611514.

The use-case is the following:
1. A user deploys a local charm, e.g.: `juju deploy ./foo`
2. A user deploys a local charm from the controller, e.g.: `juju deploy local:trusty/foo-0 bar`

This patch also pulls in the `Deploy(application.DeployArgs)` method into `DeployAPI` which simplifies a bunch of tests.

(Review request: http://reviews.vapour.ws/r/5526/)