### PR TITLE
Source migration prechecks infrastructure

### DIFF
--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -119,6 +119,12 @@ func (c *Client) SetStatusMessage(message string) error {
 	return c.caller.FacadeCall("SetStatusMessage", args, nil)
 }
 
+// Prechecks verifies that the source controller and model are healthy
+// and able to participate in a migration.
+func (c *Client) Prechecks() error {
+	return c.caller.FacadeCall("Prechecks", nil, nil)
+}
+
 // Export returns a serialized representation of the model associated
 // with the API connection. The charms used by the model are also
 // returned.

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -158,6 +158,20 @@ func (s *ClientSuite) TestSetStatusMessageError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
+func (s *ClientSuite) TestPrechecks(c *gc.C) {
+	var stub jujutesting.Stub
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		stub.AddCall(objType+"."+request, id, arg)
+		return errors.New("blam")
+	})
+	client := migrationmaster.NewClient(apiCaller, nil)
+	err := client.Prechecks()
+	c.Check(err, gc.ErrorMatches, "blam")
+	stub.CheckCalls(c, []jujutesting.StubCall{
+		{"MigrationMaster.Prechecks", []interface{}{"", nil}},
+	})
+}
+
 func (s *ClientSuite) TestExport(c *gc.C) {
 	var stub jujutesting.Stub
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {

--- a/apiserver/migrationmaster/backend.go
+++ b/apiserver/migrationmaster/backend.go
@@ -11,9 +11,9 @@ import (
 // Backend defines the state functionality required by the
 // migrationmaster facade.
 type Backend interface {
-	migration.StateExporter
-
 	WatchForMigration() state.NotifyWatcher
 	LatestMigration() (state.ModelMigration, error)
 	RemoveExportingModelDocs() error
+
+	migration.StateExporter
 }

--- a/apiserver/migrationmaster/shim.go
+++ b/apiserver/migrationmaster/shim.go
@@ -5,6 +5,7 @@ package migrationmaster
 
 import (
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/migration"
 	"github.com/juju/juju/state"
 )
 
@@ -15,5 +16,5 @@ func newAPIForRegistration(
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*API, error) {
-	return NewAPI(st, resources, authorizer)
+	return NewAPI(st, migration.PrecheckShim(st), resources, authorizer)
 }

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -215,22 +215,3 @@ func uploadTools(config UploadBinariesConfig) error {
 	}
 	return nil
 }
-
-// PrecheckBackend is implemented by *state.State but defined as an interface
-// for easier testing.
-type PrecheckBackend interface {
-	NeedsCleanup() (bool, error)
-}
-
-// Precheck checks the database state to make sure that the preconditions
-// for model migration are met.
-func Precheck(backend PrecheckBackend) error {
-	cleanupNeeded, err := backend.NeedsCleanup()
-	if err != nil {
-		return errors.Annotate(err, "precheck cleanups")
-	}
-	if cleanupNeeded {
-		return errors.New("precheck failed: cleanup needed")
-	}
-	return nil
-}

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -197,46 +197,6 @@ func (s *ExportSuite) TestExportModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-type PrecheckSuite struct {
-	testing.BaseSuite
-}
-
-var _ = gc.Suite(&PrecheckSuite{})
-
-// Assert that *state.State implements the PrecheckBackend
-var _ migration.PrecheckBackend = (*state.State)(nil)
-
-func (*PrecheckSuite) TestPrecheckCleanups(c *gc.C) {
-	backend := &fakePrecheckBackend{}
-	err := migration.Precheck(backend)
-	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (*PrecheckSuite) TestPrecheckCleanupsError(c *gc.C) {
-	backend := &fakePrecheckBackend{
-		cleanupError: errors.New("boom"),
-	}
-	err := migration.Precheck(backend)
-	c.Assert(err, gc.ErrorMatches, "precheck cleanups: boom")
-}
-
-func (*PrecheckSuite) TestPrecheckCleanupsNeeded(c *gc.C) {
-	backend := &fakePrecheckBackend{
-		cleanupNeeded: true,
-	}
-	err := migration.Precheck(backend)
-	c.Assert(err, gc.ErrorMatches, "precheck failed: cleanup needed")
-}
-
-type fakePrecheckBackend struct {
-	cleanupNeeded bool
-	cleanupError  error
-}
-
-func (f *fakePrecheckBackend) NeedsCleanup() (bool, error) {
-	return f.cleanupNeeded, f.cleanupError
-}
-
 type InternalSuite struct {
 	testing.BaseSuite
 }

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -17,13 +17,10 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/description"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/provider/dummy"
 	_ "github.com/juju/juju/provider/dummy"
-	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
@@ -195,30 +192,4 @@ func (s *ExportSuite) TestExportModel(c *gc.C) {
 	// The bytes must be a valid model.
 	_, err = description.Deserialize(bytes)
 	c.Assert(err, jc.ErrorIsNil)
-}
-
-type InternalSuite struct {
-	testing.BaseSuite
-}
-
-var _ = gc.Suite(&InternalSuite{})
-
-type stateGetter struct {
-	cfg *config.Config
-}
-
-func (e *stateGetter) Model() (*state.Model, error) {
-	return &state.Model{}, nil
-}
-
-func (s *stateGetter) ModelConfig() (*config.Config, error) {
-	return s.cfg, nil
-}
-
-func (s *stateGetter) ControllerConfig() (controller.Config, error) {
-	return map[string]interface{}{
-		controller.ControllerUUIDKey: testing.ModelTag.Id(),
-		controller.CACertKey:         testing.CACert,
-		controller.ApiPort:           4321,
-	}, nil
 }

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -10,6 +10,45 @@ import (
 	"github.com/juju/juju/tools"
 )
 
+/*
+# TODO - remaining prechecks
+
+## Source model
+
+- model machines have errors
+- machines that are dying or dead
+- pending reboots
+- machine or unit is being provisioned
+- application is being provisioned?
+- units that are dying or dead
+- model is being imported as part of another migration
+
+## Source controller
+
+- controller is upgrading
+  * all machine versions must match agent version
+
+- source controller has upgrade info doc (IsUpgrading)
+- controller machines have errors
+- controller machines that are dying or dead
+- pending reboots
+
+## Target controller
+
+- target controller tools are less than source model tools
+
+- target controller is upgrading
+  * all machine versions must match agent version
+
+- source controller has upgrade info doc (IsUpgrading)
+
+- target controller machines have errors
+- target controller already has a model with the same owner:name
+- target controller already has a model with the same UUID
+  - what about if left over from previous failed attempt?
+
+*/
+
 // PrecheckBackend defines the interface to query Juju's state
 // for migration prechecks.
 type PrecheckBackend interface {

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -1,0 +1,27 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migration
+
+import (
+	"github.com/juju/errors"
+)
+
+// PrecheckBackend is implemented by *state.State but defined as an interface
+// for easier testing.
+type PrecheckBackend interface {
+	NeedsCleanup() (bool, error)
+}
+
+// Precheck checks the database state to make sure that the preconditions
+// for model migration are met.
+func Precheck(backend PrecheckBackend) error {
+	cleanupNeeded, err := backend.NeedsCleanup()
+	if err != nil {
+		return errors.Annotate(err, "precheck cleanups")
+	}
+	if cleanupNeeded {
+		return errors.New("precheck failed: cleanup needed")
+	}
+	return nil
+}

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -10,9 +10,9 @@ import (
 	"github.com/juju/juju/tools"
 )
 
-// SourcePrecheckBackend defines the interface to query Juju's state
+// PrecheckBackend defines the interface to query Juju's state
 // for migration prechecks.
-type SourcePrecheckBackend interface {
+type PrecheckBackend interface {
 	NeedsCleanup() (bool, error)
 	AgentVersion() (version.Number, error)
 	AllMachines() ([]PrecheckMachine, error)
@@ -28,7 +28,7 @@ type PrecheckMachine interface {
 // SourcePrecheck checks the state of the source controller to make
 // sure that the preconditions for model migration are met. The
 // backend provided must be for the model to be migrated.
-func SourcePrecheck(backend SourcePrecheckBackend) error {
+func SourcePrecheck(backend PrecheckBackend) error {
 	cleanupNeeded, err := backend.NeedsCleanup()
 	if err != nil {
 		return errors.Annotate(err, "checking cleanups")

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -7,18 +7,17 @@ import (
 	"github.com/juju/errors"
 )
 
-// PrecheckBackend is implemented by *state.State but defined as an interface
-// for easier testing.
-type PrecheckBackend interface {
+// SourcePrecheckBackend defines the things required to
+type SourcePrecheckBackend interface {
 	NeedsCleanup() (bool, error)
 }
 
-// Precheck checks the database state to make sure that the preconditions
-// for model migration are met.
-func Precheck(backend PrecheckBackend) error {
+// SourcePrecheck checks the state of the source controller to make
+// sure that the preconditions for model migration are met.
+func SourcePrecheck(backend SourcePrecheckBackend) error {
 	cleanupNeeded, err := backend.NeedsCleanup()
 	if err != nil {
-		return errors.Annotate(err, "precheck cleanups")
+		return errors.Annotate(err, "checking cleanups")
 	}
 	if cleanupNeeded {
 		return errors.New("precheck failed: cleanup needed")

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -5,22 +5,58 @@ package migration
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/version"
+
+	"github.com/juju/juju/tools"
 )
 
-// SourcePrecheckBackend defines the things required to
+// SourcePrecheckBackend defines the interface to query Juju's state
+// for migration prechecks.
 type SourcePrecheckBackend interface {
 	NeedsCleanup() (bool, error)
+	AgentVersion() (version.Number, error)
+	AllMachines() ([]PrecheckMachine, error)
+}
+
+// PrecheckMachine describes state interface for a machine needed by
+// migration prechecks.
+type PrecheckMachine interface {
+	Id() string
+	AgentTools() (*tools.Tools, error)
 }
 
 // SourcePrecheck checks the state of the source controller to make
-// sure that the preconditions for model migration are met.
+// sure that the preconditions for model migration are met. The
+// backend provided must be for the model to be migrated.
 func SourcePrecheck(backend SourcePrecheckBackend) error {
 	cleanupNeeded, err := backend.NeedsCleanup()
 	if err != nil {
 		return errors.Annotate(err, "checking cleanups")
 	}
 	if cleanupNeeded {
-		return errors.New("precheck failed: cleanup needed")
+		return errors.New("cleanup needed")
 	}
+
+	modelVersion, err := backend.AgentVersion()
+	if err != nil {
+		return errors.Annotate(err, "retrieving model version")
+	}
+
+	machines, err := backend.AllMachines()
+	if err != nil {
+		return errors.Annotate(err, "retrieving machines")
+	}
+	for _, machine := range machines {
+		tools, err := machine.AgentTools()
+		if err != nil {
+			return errors.Annotatef(err, "retrieving tools for machine %s", machine.Id())
+		}
+		machineVersion := tools.Version.Number
+		if machineVersion != modelVersion {
+			return errors.Errorf("machine %s tools don't match model (%s != %s)",
+				machine.Id(), machineVersion, modelVersion)
+		}
+	}
+
 	return nil
 }

--- a/migration/precheck_shim.go
+++ b/migration/precheck_shim.go
@@ -1,0 +1,53 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migration
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/version"
+
+	"github.com/juju/juju/state"
+)
+
+// PrecheckShim wraps a *state.State to implement PrecheckBackend.
+func PrecheckShim(st *state.State) PrecheckBackend {
+	return &precheckShim{st}
+}
+
+// precheckShim is untested, but is small and simple enough to be
+// verified by inspection.
+type precheckShim struct {
+	st *state.State
+}
+
+// NeedsCleanup implements PrecheckBackend.
+func (s *precheckShim) NeedsCleanup() (bool, error) {
+	return s.st.NeedsCleanup()
+}
+
+// AgentVersion implements PrecheckBackend.
+func (s *precheckShim) AgentVersion() (version.Number, error) {
+	cfg, err := s.st.ModelConfig()
+	if err != nil {
+		return version.Zero, errors.Trace(err)
+	}
+	vers, ok := cfg.AgentVersion()
+	if !ok {
+		return version.Zero, errors.New("no model agent version")
+	}
+	return vers, nil
+}
+
+// AllMachines implements PrecheckBackend.
+func (s *precheckShim) AllMachines() ([]PrecheckMachine, error) {
+	machines, err := s.st.AllMachines()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	out := make([]PrecheckMachine, 0, len(machines))
+	for _, machine := range machines {
+		out = append(out, machine)
+	}
+	return out, nil
+}

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -14,9 +14,6 @@ import (
 	"github.com/juju/juju/tools"
 )
 
-// Ensure PrecheckShim matches the required interface.
-var _ migration.PrecheckBackend = new(migration.PrecheckShim)
-
 type SourcePrecheckSuite struct {
 	testing.BaseSuite
 }

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -12,31 +12,31 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-type PrecheckSuite struct {
+type SourcePrecheckSuite struct {
 	testing.BaseSuite
 }
 
-var _ = gc.Suite(&PrecheckSuite{})
+var _ = gc.Suite(&SourcePrecheckSuite{})
 
-func (*PrecheckSuite) TestPrecheckCleanups(c *gc.C) {
+func (*SourcePrecheckSuite) TestCleanups(c *gc.C) {
 	backend := &fakePrecheckBackend{}
-	err := migration.Precheck(backend)
+	err := migration.SourcePrecheck(backend)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (*PrecheckSuite) TestPrecheckCleanupsError(c *gc.C) {
+func (*SourcePrecheckSuite) TestCleanupsError(c *gc.C) {
 	backend := &fakePrecheckBackend{
 		cleanupError: errors.New("boom"),
 	}
-	err := migration.Precheck(backend)
-	c.Assert(err, gc.ErrorMatches, "precheck cleanups: boom")
+	err := migration.SourcePrecheck(backend)
+	c.Assert(err, gc.ErrorMatches, "checking cleanups: boom")
 }
 
-func (*PrecheckSuite) TestPrecheckCleanupsNeeded(c *gc.C) {
+func (*SourcePrecheckSuite) TestCleanupsNeeded(c *gc.C) {
 	backend := &fakePrecheckBackend{
 		cleanupNeeded: true,
 	}
-	err := migration.Precheck(backend)
+	err := migration.SourcePrecheck(backend)
 	c.Assert(err, gc.ErrorMatches, "precheck failed: cleanup needed")
 }
 
@@ -45,6 +45,6 @@ type fakePrecheckBackend struct {
 	cleanupError  error
 }
 
-func (f *fakePrecheckBackend) NeedsCleanup() (bool, error) {
-	return f.cleanupNeeded, f.cleanupError
+func (b *fakePrecheckBackend) NeedsCleanup() (bool, error) {
+	return b.cleanupNeeded, b.cleanupError
 }

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -1,0 +1,50 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migration_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/migration"
+	"github.com/juju/juju/testing"
+)
+
+type PrecheckSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&PrecheckSuite{})
+
+func (*PrecheckSuite) TestPrecheckCleanups(c *gc.C) {
+	backend := &fakePrecheckBackend{}
+	err := migration.Precheck(backend)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (*PrecheckSuite) TestPrecheckCleanupsError(c *gc.C) {
+	backend := &fakePrecheckBackend{
+		cleanupError: errors.New("boom"),
+	}
+	err := migration.Precheck(backend)
+	c.Assert(err, gc.ErrorMatches, "precheck cleanups: boom")
+}
+
+func (*PrecheckSuite) TestPrecheckCleanupsNeeded(c *gc.C) {
+	backend := &fakePrecheckBackend{
+		cleanupNeeded: true,
+	}
+	err := migration.Precheck(backend)
+	c.Assert(err, gc.ErrorMatches, "precheck failed: cleanup needed")
+}
+
+type fakePrecheckBackend struct {
+	cleanupNeeded bool
+	cleanupError  error
+}
+
+func (f *fakePrecheckBackend) NeedsCleanup() (bool, error) {
+	return f.cleanupNeeded, f.cleanupError
+}

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -14,6 +14,9 @@ import (
 	"github.com/juju/juju/tools"
 )
 
+// Ensure PrecheckShim matches the required interface.
+var _ migration.PrecheckBackend = new(migration.PrecheckShim)
+
 type SourcePrecheckSuite struct {
 	testing.BaseSuite
 }

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -6,10 +6,12 @@ package migration_test
 import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/tools"
 )
 
 type SourcePrecheckSuite struct {
@@ -19,32 +21,90 @@ type SourcePrecheckSuite struct {
 var _ = gc.Suite(&SourcePrecheckSuite{})
 
 func (*SourcePrecheckSuite) TestCleanups(c *gc.C) {
-	backend := &fakePrecheckBackend{}
+	backend := &fakeBackend{}
 	err := migration.SourcePrecheck(backend)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (*SourcePrecheckSuite) TestCleanupsError(c *gc.C) {
-	backend := &fakePrecheckBackend{
-		cleanupError: errors.New("boom"),
+	backend := &fakeBackend{
+		cleanupErr: errors.New("boom"),
 	}
 	err := migration.SourcePrecheck(backend)
 	c.Assert(err, gc.ErrorMatches, "checking cleanups: boom")
 }
 
 func (*SourcePrecheckSuite) TestCleanupsNeeded(c *gc.C) {
-	backend := &fakePrecheckBackend{
+	backend := &fakeBackend{
 		cleanupNeeded: true,
 	}
 	err := migration.SourcePrecheck(backend)
-	c.Assert(err, gc.ErrorMatches, "precheck failed: cleanup needed")
+	c.Assert(err, gc.ErrorMatches, "cleanup needed")
 }
 
-type fakePrecheckBackend struct {
+func (*SourcePrecheckSuite) TestAgentVersionError(c *gc.C) {
+	backend := &fakeBackend{
+		agentVersionErr: errors.New("boom"),
+	}
+	err := migration.SourcePrecheck(backend)
+	c.Assert(err, gc.ErrorMatches, "retrieving model version: boom")
+}
+
+func (*SourcePrecheckSuite) TestMachineVersionsMatch(c *gc.C) {
+	backend := &fakeBackend{
+		machines: []migration.PrecheckMachine{
+			&machine{"0", version.MustParseBinary("1.2.3-trusty-amd64")},
+			&machine{"1", version.MustParseBinary("1.2.3-xenial-amd64")},
+		},
+	}
+	err := migration.SourcePrecheck(backend)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (*SourcePrecheckSuite) TestMachineVersionsDontMatch(c *gc.C) {
+	backend := &fakeBackend{
+		machines: []migration.PrecheckMachine{
+			&machine{"0", version.MustParseBinary("1.2.3-trusty-amd64")},
+			&machine{"1", version.MustParseBinary("1.3.1-xenial-amd64")},
+		},
+	}
+	err := migration.SourcePrecheck(backend)
+	c.Assert(err, gc.ErrorMatches, `machine 1 tools don't match model \(1.3.1 != 1.2.3\)`)
+}
+
+type fakeBackend struct {
 	cleanupNeeded bool
-	cleanupError  error
+	cleanupErr    error
+
+	agentVersionErr error
+
+	machines       []migration.PrecheckMachine
+	allMachinesErr error
 }
 
-func (b *fakePrecheckBackend) NeedsCleanup() (bool, error) {
-	return b.cleanupNeeded, b.cleanupError
+func (b *fakeBackend) NeedsCleanup() (bool, error) {
+	return b.cleanupNeeded, b.cleanupErr
+}
+
+func (b *fakeBackend) AgentVersion() (version.Number, error) {
+	return version.MustParse("1.2.3"), b.agentVersionErr
+}
+
+func (b *fakeBackend) AllMachines() ([]migration.PrecheckMachine, error) {
+	return b.machines, b.allMachinesErr
+}
+
+type machine struct {
+	id      string
+	version version.Binary
+}
+
+func (m *machine) Id() string {
+	return m.id
+}
+
+func (m *machine) AgentTools() (*tools.Tools, error) {
+	return &tools.Tools{
+		Version: m.version,
+	}, nil
 }

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -66,6 +66,10 @@ type Facade interface {
 	// progress of a migration.
 	SetStatusMessage(string) error
 
+	// Prechecks performs pre-migration checks on the model and
+	// (source) controller.
+	Prechecks() error
+
 	// Export returns a serialized representation of the model
 	// associated with the API connection.
 	Export() (coremigration.SerializedModel, error)
@@ -281,8 +285,13 @@ func (w *Worker) doQUIESCE(status coremigration.MigrationStatus) (coremigration.
 }
 
 func (w *Worker) doPRECHECK() (coremigration.Phase, error) {
-	// TODO(mjs) - To be implemented.
-	// w.setInfoStatus("performing prechecks")
+	w.setInfoStatus("performing prechecks")
+	err := w.config.Facade.Prechecks()
+	if err != nil {
+		w.setErrorStatus("prechecks failed, %v", err)
+		return coremigration.ABORT, nil
+	}
+	// TODO(mjs) - perform prechecks on target controller
 	return coremigration.IMPORT, nil
 }
 


### PR DESCRIPTION
This PR is mainly about adding the plumbing to support prechecks for the source controller and model. The infrastructure of target controller prechecks, as well as more precheck implementations, are coming.

Here we have:

* Cleaned up existing precheck code and tests
* Added a check to ensure that all machines in the source model have the same tools version as the version set on the model
* Added precheck support to the MigrationMaster facade (apiserver and api)
* migrationmaster worker now calls precheck API in PRECHECK phase

