### PR TITLE
Pass tz in rather than patch.

### DIFF
--- a/cmd/juju/commands/debuglog.go
+++ b/cmd/juju/commands/debuglog.go
@@ -106,7 +106,11 @@ func (c *debugLogCommand) Info() *cmd.Info {
 }
 
 func newDebugLogCommand() cmd.Command {
-	return modelcmd.Wrap(&debugLogCommand{})
+	return newDebugLogCommandTZ(time.Local)
+}
+
+func newDebugLogCommandTZ(tz *time.Location) cmd.Command {
+	return modelcmd.Wrap(&debugLogCommand{tz: tz})
 }
 
 type debugLogCommand struct {
@@ -168,8 +172,6 @@ func (c *debugLogCommand) Init(args []string) error {
 	}
 	if c.utc {
 		c.tz = time.UTC
-	} else {
-		c.tz = time.Local
 	}
 	if c.date {
 		c.format = "2006-01-02 15:04:05"

--- a/cmd/juju/commands/debuglog_test.go
+++ b/cmd/juju/commands/debuglog_test.go
@@ -125,7 +125,7 @@ func (s *DebugLogSuite) TestParamsPassed(c *gc.C) {
 
 func (s *DebugLogSuite) TestLogOutput(c *gc.C) {
 	// test timezone is 6 hours east of UTC
-	s.PatchValue(&time.Local, time.FixedZone("test", 6*60*60))
+	tz := time.FixedZone("test", 6*60*60)
 	s.PatchValue(&getDebugLogAPI, func(_ *debugLogCommand) (DebugLogAPI, error) {
 		return &fakeDebugLogAPI{log: []api.LogMessage{
 			{
@@ -141,7 +141,7 @@ func (s *DebugLogSuite) TestLogOutput(c *gc.C) {
 	checkOutput := func(args ...string) {
 		count := len(args)
 		args, expected := args[:count-1], args[count-1]
-		ctx, err := testing.RunCommand(c, newDebugLogCommand(), args...)
+		ctx, err := testing.RunCommand(c, newDebugLogCommandTZ(tz), args...)
 		c.Check(err, jc.ErrorIsNil)
 		c.Check(testing.Stdout(ctx), gc.Equals, expected)
 


### PR DESCRIPTION
Fixes http://pad.lv/1614571 - Data race: TestLogOutput

(Review request: http://reviews.vapour.ws/r/5528/)