### PR TITLE
Use the correct lxd image alias

### DIFF
--- a/tools/lxdclient/client_image.go
+++ b/tools/lxdclient/client_image.go
@@ -98,17 +98,6 @@ func (i *imageClient) EnsureImageExists(series string, sources []Remote, copyPro
 	// at private methods so we can't easily tweak it.
 	name := i.ImageNameForSeries(series)
 
-	// TODO(jam) Add a flag to not trust local aliases, which would allow
-	// non-state machines to only trust the alias that is set on the state
-	// machines.
-	// if IgnoreLocalAliases {}
-	target := i.raw.GetAlias(name)
-	if target != "" {
-		// GetAlias returns "" if the alias is not found, else it
-		// returns the Target of the alias (the hash)
-		return nil
-	}
-
 	var lastErr error
 	for _, remote := range sources {
 		source, err := i.connectToSource(remote)
@@ -144,7 +133,7 @@ func (i *imageClient) EnsureImageExists(series string, sources []Remote, copyPro
 			context: fmt.Sprintf("copying image for %s from %s: %%s", name, source.URL()),
 			forward: forwarder.Forward,
 		}
-		err = source.CopyImage(target, i.raw, []string{name}, adapter.copyProgress)
+		err = source.CopyImage(series, i.raw, []string{name}, adapter.copyProgress)
 		return errors.Annotatef(err, "unable to get LXD image for %s", name)
 	}
 	return lastErr

--- a/tools/lxdclient/client_image_test.go
+++ b/tools/lxdclient/client_image_test.go
@@ -33,7 +33,7 @@ func (s *imageSuite) SetUpTest(c *gc.C) {
 		stub: s.Stub,
 		url:  "https://match",
 		aliases: map[string]string{
-			"trusty": "deadbeef",
+			"trusty": "trusty-alias",
 		},
 	}
 	s.remoteWithNothing = &stubRemoteClient{
@@ -138,7 +138,6 @@ func (s *imageSuite) TestEnsureImageExistsAlreadyPresent(c *gc.C) {
 	}
 	err := client.EnsureImageExists("trusty", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.Stub.CheckCall(c, 0, "GetAlias", "ubuntu-trusty")
 }
 
 func (s *imageSuite) TestEnsureImageExistsFirstRemote(c *gc.C) {
@@ -158,10 +157,6 @@ func (s *imageSuite) TestEnsureImageExistsFirstRemote(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	// We didn't find it locally
 	s.Stub.CheckCalls(c, []testing.StubCall{
-		{ // Check if we already have 'ubuntu-trusty' locally
-			FuncName: "GetAlias",
-			Args:     []interface{}{"ubuntu-trusty"},
-		},
 		{ // We didn't so connect to the first remote
 			FuncName: "connectToSource",
 			Args:     []interface{}{"https://match"},
@@ -172,12 +167,12 @@ func (s *imageSuite) TestEnsureImageExistsFirstRemote(c *gc.C) {
 		},
 		{ // So Copy the Image
 			FuncName: "CopyImage",
-			Args:     []interface{}{"deadbeef", []string{"ubuntu-trusty"}},
+			Args:     []interface{}{"trusty", []string{"ubuntu-trusty"}},
 		},
 	})
 	// We've updated the aliases
 	c.Assert(raw.Aliases, gc.DeepEquals, map[string]string{
-		"ubuntu-trusty": "deadbeef",
+		"ubuntu-trusty": "trusty",
 	})
 }
 
@@ -197,16 +192,12 @@ func (s *imageSuite) TestEnsureImageExistsUnableToConnect(c *gc.C) {
 		Protocol: SimplestreamsProtocol,
 	}
 	s.Stub.ResetCalls()
-	s.Stub.SetErrors(nil, errors.Errorf("unable-to-connect"))
+	s.Stub.SetErrors(errors.Errorf("unable-to-connect"))
 	remotes := []Remote{badRemote, s.remoteWithTrusty.AsRemote()}
 	err := client.EnsureImageExists("trusty", remotes, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// We didn't find it locally
 	s.Stub.CheckCalls(c, []testing.StubCall{
-		{ // Check if we already have 'ubuntu-trusty' locally
-			FuncName: "GetAlias",
-			Args:     []interface{}{"ubuntu-trusty"},
-		},
 		{ // We didn't so connect to the first remote
 			FuncName: "connectToSource",
 			Args:     []interface{}{"https://nosuch-remote.invalid"},
@@ -221,12 +212,12 @@ func (s *imageSuite) TestEnsureImageExistsUnableToConnect(c *gc.C) {
 		},
 		{ // So Copy the Image
 			FuncName: "CopyImage",
-			Args:     []interface{}{"deadbeef", []string{"ubuntu-trusty"}},
+			Args:     []interface{}{"trusty", []string{"ubuntu-trusty"}},
 		},
 	})
 	// We've updated the aliases
 	c.Assert(raw.Aliases, gc.DeepEquals, map[string]string{
-		"ubuntu-trusty": "deadbeef",
+		"ubuntu-trusty": "trusty",
 	})
 }
 
@@ -247,10 +238,6 @@ func (s *imageSuite) TestEnsureImageExistsNotPresentInFirstRemote(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	// We didn't find it locally
 	s.Stub.CheckCalls(c, []testing.StubCall{
-		{ // Check if we already have 'ubuntu-trusty' locally
-			FuncName: "GetAlias",
-			Args:     []interface{}{"ubuntu-trusty"},
-		},
 		{ // We didn't so connect to the first remote
 			FuncName: "connectToSource",
 			Args:     []interface{}{s.remoteWithNothing.URL()},
@@ -269,12 +256,12 @@ func (s *imageSuite) TestEnsureImageExistsNotPresentInFirstRemote(c *gc.C) {
 		},
 		{ // So Copy the Image
 			FuncName: "CopyImage",
-			Args:     []interface{}{"deadbeef", []string{"ubuntu-trusty"}},
+			Args:     []interface{}{"trusty", []string{"ubuntu-trusty"}},
 		},
 	})
 	// We've updated the aliases
 	c.Assert(raw.Aliases, gc.DeepEquals, map[string]string{
-		"ubuntu-trusty": "deadbeef",
+		"ubuntu-trusty": "trusty",
 	})
 }
 


### PR DESCRIPTION
Originally submitted by Stéphane as https://github.com/juju/juju/pull/5869 
"In current code, Juju resolves the image alias prior to copying the
image into the local image store.

This means that the local LXD daemon won't know what the image alias was
and so can't auto-update the image in the future.

Fix this by just passing the alias straight to LXD, but still resolve it
in Juju before so the log messages and errors remain identical."

I did the test changes.


(Review request: http://reviews.vapour.ws/r/5529/)