### PR TITLE
Improve error message for invalid bundles paths

### DIFF
--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -158,7 +158,10 @@ func (s *DeploySuite) TestDeployFromPathRelativeDir(c *gc.C) {
 	err = os.Chdir(s.CharmsPath)
 	c.Assert(err, jc.ErrorIsNil)
 	err = runDeploy(c, "multi-series")
-	c.Assert(err, gc.ErrorMatches, `.*path "multi-series" can not be a relative path`)
+	c.Assert(err, gc.ErrorMatches, ""+
+		"The charm or bundle \"multi-series\" is ambiguous.\n"+
+		"To deploy a local charm or bundle, run `juju deploy ./multi-series`.\n"+
+		"To deploy a charm or bundle from the store, run `juju deploy cs:multi-series`.")
 }
 
 func (s *DeploySuite) TestDeployFromPathOldCharm(c *gc.C) {


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju/+bug/1606282

When the user tries to deploy a charm or bundle using a relative path, the error message is improved:

$ juju deploy mysql
ERROR The charm/bundle "mysql" is ambiguous.
If you want to deploy a local charm or bundle, don't use a relative path, try juju deploy ./mysql
If you want to deploy a charm or bundle from the store, try juju deploy cs:mysql


(Review request: http://reviews.vapour.ws/r/5531/)