### PR TITLE
Wait for 30s for jujud to stop, then kill it.

### DIFF
--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -228,7 +228,19 @@ func (e *manualEnviron) DestroyController(controllerUUID string) error {
 	script := `
 set -x
 touch %s
-pkill -%d jujud && exit
+# If jujud is running, we then wait for a while for it to stop.
+if pkill -%d jujud; then
+   for i in ` + "`seq 1 30`" + `; do
+	 if pgrep jujud > /dev/null ; then
+	   sleep 1
+	 else
+	   echo "jujud stopped"
+	   break
+	 fi
+   done
+fi
+# If jujud didn't stop nicely, we kill it hard here.
+pkill -9 jujud
 stop %s
 rm -f /etc/init/juju*
 rm -f /etc/systemd/system/juju*
@@ -249,10 +261,12 @@ exit 0
 		utils.ShQuote(agent.DefaultPaths.DataDir),
 		utils.ShQuote(agent.DefaultPaths.LogDir),
 	)
-	_, err := runSSHCommand(
+	logger.Tracef("destroy controller script: %s", script)
+	stdout, err := runSSHCommand(
 		"ubuntu@"+e.host,
 		[]string{"sudo", "/bin/bash"}, script,
 	)
+	logger.Debugf("script output: %q", stdout)
 	return err
 }
 


### PR DESCRIPTION
The manual provider was just telling jujud to stop and hoping that it would.

This change addresses http://pad.lv/1475212 by having the script that tells the agent to stop, actually wait a while for it to stop.


(Review request: http://reviews.vapour.ws/r/5532/)