### PR TITLE
add-model to take cloud/region positional arg

### DIFF
--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -37,13 +37,20 @@ func (c *Client) Close() error {
 // CreateModel creates a new model using the model config,
 // cloud region and credential specified in the args.
 func (c *Client) CreateModel(
-	name, owner, cloudRegion string,
+	name, owner, cloud, cloudRegion string,
 	cloudCredential names.CloudCredentialTag,
 	config map[string]interface{},
 ) (params.ModelInfo, error) {
 	var result params.ModelInfo
 	if !names.IsValidUser(owner) {
 		return result, errors.Errorf("invalid owner name %q", owner)
+	}
+	var cloudTag string
+	if cloud != "" {
+		if !names.IsValidCloud(cloud) {
+			return result, errors.Errorf("invalid cloud name %q", cloud)
+		}
+		cloudTag = names.NewCloudTag(cloud).String()
 	}
 	var cloudCredentialTag string
 	if cloudCredential != (names.CloudCredentialTag{}) {
@@ -53,6 +60,7 @@ func (c *Client) CreateModel(
 		Name:               name,
 		OwnerTag:           names.NewUserTag(owner).String(),
 		Config:             config,
+		CloudTag:           cloudTag,
 		CloudRegion:        cloudRegion,
 		CloudCredentialTag: cloudCredentialTag,
 	}

--- a/api/modelmanager/modelmanager_test.go
+++ b/api/modelmanager/modelmanager_test.go
@@ -34,16 +34,28 @@ func (s *modelmanagerSuite) OpenAPI(c *gc.C) *modelmanager.Client {
 func (s *modelmanagerSuite) TestCreateModelBadUser(c *gc.C) {
 	modelManager := s.OpenAPI(c)
 	defer modelManager.Close()
-	_, err := modelManager.CreateModel("mymodel", "not a user", "", names.CloudCredentialTag{}, nil)
+	_, err := modelManager.CreateModel("mymodel", "not a user", "", "", names.CloudCredentialTag{}, nil)
 	c.Assert(err, gc.ErrorMatches, `invalid owner name "not a user"`)
 }
 
 func (s *modelmanagerSuite) TestCreateModel(c *gc.C) {
+	s.testCreateModel(c, "dummy", "dummy-region")
+}
+
+func (s *modelmanagerSuite) TestCreateModelCloudDefaultRegion(c *gc.C) {
+	s.testCreateModel(c, "dummy", "")
+}
+
+func (s *modelmanagerSuite) TestCreateModelDefaultCloudAndRegion(c *gc.C) {
+	s.testCreateModel(c, "", "")
+}
+
+func (s *modelmanagerSuite) testCreateModel(c *gc.C, cloud, region string) {
 	modelManager := s.OpenAPI(c)
 	defer modelManager.Close()
 	user := s.Factory.MakeUser(c, nil)
 	owner := user.UserTag().Canonical()
-	newModel, err := modelManager.CreateModel("new-model", owner, "", names.CloudCredentialTag{}, map[string]interface{}{
+	newModel, err := modelManager.CreateModel("new-model", owner, cloud, region, names.CloudCredentialTag{}, map[string]interface{}{
 		"authorized-keys": "ssh-key",
 		// dummy needs controller
 		"controller": false,

--- a/apiserver/cloud/backend.go
+++ b/apiserver/cloud/backend.go
@@ -11,6 +11,7 @@ import (
 )
 
 type Backend interface {
+	Clouds() (map[names.CloudTag]cloud.Cloud, error)
 	Cloud(cloudName string) (cloud.Cloud, error)
 	CloudCredentials(user names.UserTag, cloudName string) (map[names.CloudCredentialTag]cloud.Credential, error)
 	ControllerModel() (Model, error)

--- a/apiserver/cloud/cloud_test.go
+++ b/apiserver/cloud/cloud_test.go
@@ -68,6 +68,19 @@ func (s *cloudSuite) TestCloud(c *gc.C) {
 	})
 }
 
+func (s *cloudSuite) TestClouds(c *gc.C) {
+	result, err := s.api.Clouds()
+	c.Assert(err, jc.ErrorIsNil)
+	s.backend.CheckCallNames(c, "Clouds")
+	c.Assert(result.Clouds, jc.DeepEquals, map[string]params.Cloud{
+		"cloud-my-cloud": {
+			Type:      "dummy",
+			AuthTypes: []string{"empty", "userpass"},
+			Regions:   []params.CloudRegion{{Name: "nether", Endpoint: "endpoint"}},
+		},
+	})
+}
+
 func (s *cloudSuite) TestDefaultCloud(c *gc.C) {
 	result, err := s.api.DefaultCloud()
 	c.Assert(err, jc.ErrorIsNil)
@@ -200,6 +213,13 @@ func (st *mockBackend) ModelTag() names.ModelTag {
 func (st *mockBackend) Cloud(name string) (cloud.Cloud, error) {
 	st.MethodCall(st, "Cloud", name)
 	return st.cloud, st.NextErr()
+}
+
+func (st *mockBackend) Clouds() (map[names.CloudTag]cloud.Cloud, error) {
+	st.MethodCall(st, "Clouds")
+	return map[names.CloudTag]cloud.Cloud{
+		names.NewCloudTag("my-cloud"): st.cloud,
+	}, st.NextErr()
 }
 
 func (st *mockBackend) CloudCredentials(user names.UserTag, cloudName string) (map[names.CloudCredentialTag]cloud.Credential, error) {

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -236,6 +236,7 @@ type mockState struct {
 
 	uuid            string
 	cloud           cloud.Cloud
+	clouds          map[names.CloudTag]cloud.Cloud
 	model           *mockModel
 	controllerModel *mockModel
 	users           []description.UserAccess
@@ -344,6 +345,11 @@ func (st *mockState) ModelTag() names.ModelTag {
 func (st *mockState) AllModels() ([]common.Model, error) {
 	st.MethodCall(st, "AllModels")
 	return []common.Model{st.model}, st.NextErr()
+}
+
+func (st *mockState) Clouds() (map[names.CloudTag]cloud.Cloud, error) {
+	st.MethodCall(st, "Clouds")
+	return st.clouds, st.NextErr()
 }
 
 func (st *mockState) Cloud(name string) (cloud.Cloud, error) {

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -59,15 +59,20 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 	cfg, err := config.New(config.UseDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 
+	dummyCloud := cloud.Cloud{
+		Type:      "dummy",
+		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
+		Regions: []cloud.Region{
+			{Name: "some-region"},
+			{Name: "qux"},
+		},
+	}
+
 	s.st = mockState{
-		uuid: coretesting.ModelTag.Id(),
-		cloud: cloud.Cloud{
-			Type:      "dummy",
-			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
-			Regions: []cloud.Region{
-				{Name: "some-region"},
-				{Name: "qux"},
-			},
+		uuid:  coretesting.ModelTag.Id(),
+		cloud: dummyCloud,
+		clouds: map[names.CloudTag]cloud.Cloud{
+			names.NewCloudTag("some-cloud"): dummyCloud,
 		},
 		controllerModel: &mockModel{
 			owner: names.NewUserTag("admin@local"),
@@ -213,6 +218,17 @@ func (s *modelManagerSuite) TestCreateModelArgsWithCloud(c *gc.C) {
 
 	newModelArgs := s.getModelArgs(c)
 	c.Assert(newModelArgs.CloudName, gc.Equals, "some-cloud")
+}
+
+func (s *modelManagerSuite) TestCreateModelArgsWithCloudNotFound(c *gc.C) {
+	s.st.SetErrors(nil, errors.NotFoundf("cloud"))
+	args := params.ModelCreateArgs{
+		Name:     "foo",
+		OwnerTag: "user-admin@local",
+		CloudTag: "cloud-some-unknown-cloud",
+	}
+	_, err := s.api.CreateModel(args)
+	c.Assert(err, gc.ErrorMatches, `cloud "some-unknown-cloud" not found, expected one of \["some-cloud"\]`)
 }
 
 func (s *modelManagerSuite) TestCreateModelDefaultRegion(c *gc.C) {

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -32,6 +32,12 @@ type CloudResults struct {
 	Results []CloudResult `json:"results,omitempty"`
 }
 
+// CloudsResult contains a set of Clouds.
+type CloudsResult struct {
+	// Clouds is a map of clouds, keyed by cloud tag.
+	Clouds map[string]Cloud `json:"clouds,omitempty"`
+}
+
 // CloudCredential contains a cloud credential.
 type CloudCredential struct {
 	AuthType   string            `json:"auth-type"`

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -4,7 +4,9 @@
 package controller
 
 import (
+	"bytes"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -17,9 +19,10 @@ import (
 	cloudapi "github.com/juju/juju/api/cloud"
 	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/cloud"
+	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/jujuclient"
 )
@@ -51,11 +54,11 @@ type addModelCommand struct {
 }
 
 const addModelHelpDoc = `
-Adding a model is typically done in order to run a specific workload. The
-model is of the same cloud type as the controller and is managed by that
-controller. By default, the controller is the current controller. The
-credentials used to add the model are the ones used to create any future
-resources within the model (` + "`juju deploy`, `juju add-unit`" + `).
+Adding a model is typically done in order to run a specific workload.
+To add a model, you must at a minimum specify a model name. You may
+also supply model-specific configuration, a credential, and which
+cloud/region to deploy the model to. The cloud/region and credentials
+are the ones used to create any future resources within the model.
 
 Model names can be duplicated across controllers but must be unique for
 any given controller. Model names may only contain lowercase letters,
@@ -64,20 +67,30 @@ digits and hyphens, and may not start with a hyphen.
 Credential names are specified either in the form "credential-name", or
 "credential-owner/credential-name". There is currently no way to acquire
 access to another user's credentials, so the only valid value for
-credential-owner is your own user name.
+credential-owner is your own user name. This may change in a future
+release.
+
+If no cloud/region is specified, then the model will be deployed to
+the same cloud/region as the controller model. If a region is specified
+without a cloud qualifier, then it is assumed to be in the same cloud
+as the controller model. It is not currently possible for a controller
+to manage multiple clouds, so the only valid cloud is the same cloud
+as the controller model is deployed to. This may change in a future
+release.
 
 Examples:
 
     juju add-model mymodel
+    juju add-model mymodel us-east-1
+    juju add-model mymodel aws/us-east-1
     juju add-model mymodel --config my-config.yaml --config image-stream=daily
     juju add-model mymodel --credential credential_name --config authorized-keys="ssh-rsa ..."
-    juju add-model mymodel --region us-east-1
 `
 
 func (c *addModelCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "add-model",
-		Args:    "<model name>",
+		Args:    "<model name> [cloud|region|(cloud/region)]",
 		Purpose: "Adds a hosted model.",
 		Doc:     strings.TrimSpace(addModelHelpDoc),
 	}
@@ -86,7 +99,6 @@ func (c *addModelCommand) Info() *cmd.Info {
 func (c *addModelCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.Owner, "owner", "", "The owner of the new model if not the current user")
 	f.StringVar(&c.CredentialName, "credential", "", "Credential used to add the model")
-	f.StringVar(&c.CloudRegion, "region", "", "Cloud region to add the model to")
 	f.Var(&c.Config, "config", "Path to YAML model configuration file or individual options (--config config.yaml [--config key=value ...])")
 }
 
@@ -95,6 +107,10 @@ func (c *addModelCommand) Init(args []string) error {
 		return errors.New("model name is required")
 	}
 	c.Name, args = args[0], args[1:]
+
+	if len(args) > 0 {
+		c.CloudRegion, args = args[0], args[1:]
+	}
 
 	if !names.IsValidModelName(c.Name) {
 		return errors.Errorf("%q is not a valid name: model names may only contain lowercase letters, digits and hyphens", c.Name)
@@ -109,7 +125,7 @@ func (c *addModelCommand) Init(args []string) error {
 
 type AddModelAPI interface {
 	CreateModel(
-		name, owner, cloudRegion string,
+		name, owner, cloudName, cloudRegion string,
 		cloudCredential names.CloudCredentialTag,
 		config map[string]interface{},
 	) (params.ModelInfo, error)
@@ -117,9 +133,10 @@ type AddModelAPI interface {
 
 type CloudAPI interface {
 	DefaultCloud() (names.CloudTag, error)
-	Cloud(names.CloudTag) (cloud.Cloud, error)
+	Clouds() (map[names.CloudTag]jujucloud.Cloud, error)
+	Cloud(names.CloudTag) (jujucloud.Cloud, error)
 	Credentials(names.UserTag, names.CloudTag) ([]names.CloudCredentialTag, error)
-	UpdateCredential(names.CloudCredentialTag, cloud.Credential) error
+	UpdateCredential(names.CloudCredentialTag, jujucloud.Credential) error
 }
 
 func (c *addModelCommand) newApiRoot() (api.Connection, error) {
@@ -138,10 +155,6 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 
 	store := c.ClientStore()
 	controllerName := c.ControllerName()
-	controllerDetails, err := store.ControllerByName(controllerName)
-	if err != nil {
-		return errors.Trace(err)
-	}
 	accountDetails, err := store.AccountDetails(controllerName)
 	if err != nil {
 		return errors.Trace(err)
@@ -161,20 +174,35 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
+	cloudClient := c.newCloudAPI(api)
+	var cloudTag names.CloudTag
+	var cloud jujucloud.Cloud
+	var cloudRegion string
+	if c.CloudRegion != "" {
+		cloudTag, cloud, cloudRegion, err = c.getCloudRegion(cloudClient)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
 	// If the user has specified a credential, then we will upload it if
 	// it doesn't already exist in the controller, and it exists locally.
 	var credentialTag names.CloudCredentialTag
 	if c.CredentialName != "" {
 		var err error
-		cloudClient := c.newCloudAPI(api)
-		credentialTag, err = c.maybeUploadCredential(ctx, cloudClient, modelOwner)
+		if c.CloudRegion == "" {
+			if cloudTag, cloud, err = defaultCloud(cloudClient); err != nil {
+				return errors.Trace(err)
+			}
+		}
+		credentialTag, err = c.maybeUploadCredential(ctx, cloudClient, cloudTag, cloud, modelOwner)
 		if err != nil {
 			return errors.Trace(err)
 		}
 	}
 
 	addModelClient := c.newAddModelAPI(api)
-	model, err := addModelClient.CreateModel(c.Name, modelOwner, c.CloudRegion, credentialTag, attrs)
+	model, err := addModelClient.CreateModel(c.Name, modelOwner, cloudTag.Id(), cloudRegion, credentialTag, attrs)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -194,9 +222,17 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 		}
 	}
 
-	if model.CloudRegion != "" {
-		messageFormat += " on %s/%s"
-		messageArgs = append(messageArgs, controllerDetails.Cloud, model.CloudRegion)
+	if c.CloudRegion != "" || model.CloudRegion != "" {
+		// The user explicitly requested a cloud/region,
+		// or the cloud supports multiple regions. Whichever
+		// the case, tell the user which cloud/region the
+		// model was deployed to.
+		cloudRegion := model.Cloud
+		if model.CloudRegion != "" {
+			cloudRegion += "/" + model.CloudRegion
+		}
+		messageFormat += " on %s"
+		messageArgs = append(messageArgs, cloudRegion)
 	}
 	if model.CloudCredentialTag != "" {
 		tag, err := names.ParseCloudCredentialTag(model.CloudCredentialTag)
@@ -213,7 +249,6 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 
 	messageFormat += forUserSuffix
 
-	// lp#1594335
 	// "Added '<model>' model [on <cloud>/<region>] [with credential '<credential>'] for user '<user namePart>'"
 	ctx.Infof(messageFormat, messageArgs...)
 
@@ -229,16 +264,134 @@ before "juju ssh", "juju scp", or "juju debug-hooks" will work.`)
 	return nil
 }
 
+func (c *addModelCommand) getCloudRegion(cloudClient CloudAPI) (cloudTag names.CloudTag, cloud jujucloud.Cloud, cloudRegion string, err error) {
+	var cloudName string
+	sep := strings.IndexRune(c.CloudRegion, '/')
+	if sep >= 0 {
+		// User specified "cloud/region".
+		cloudName, cloudRegion = c.CloudRegion[:sep], c.CloudRegion[sep+1:]
+		if !names.IsValidCloud(cloudName) {
+			return names.CloudTag{}, jujucloud.Cloud{}, "", errors.NotValidf("cloud name %q", cloudName)
+		}
+		cloudTag = names.NewCloudTag(cloudName)
+		if cloud, err = cloudClient.Cloud(cloudTag); err != nil {
+			return names.CloudTag{}, jujucloud.Cloud{}, "", errors.Trace(err)
+		}
+	} else {
+		// User specified "cloud" or "region". We'll try first
+		// for cloud (check if it's a valid cloud name, and
+		// whether there is a cloud by that name), and then
+		// as a region within the default cloud.
+		if names.IsValidCloud(c.CloudRegion) {
+			cloudName = c.CloudRegion
+		} else {
+			cloudRegion = c.CloudRegion
+		}
+		if cloudName != "" {
+			cloudTag = names.NewCloudTag(cloudName)
+			cloud, err = cloudClient.Cloud(cloudTag)
+			if params.IsCodeNotFound(err) {
+				// No such cloud with the specified name,
+				// so we'll try the name as a region in
+				// the default cloud.
+				cloudRegion, cloudName = cloudName, ""
+			} else if err != nil {
+				return names.CloudTag{}, jujucloud.Cloud{}, "", errors.Trace(err)
+			}
+		}
+		if cloudName == "" {
+			cloudTag, cloud, err = defaultCloud(cloudClient)
+			if err != nil && !errors.IsNotFound(err) {
+				return names.CloudTag{}, jujucloud.Cloud{}, "", errors.Trace(err)
+			}
+		}
+	}
+	if cloudRegion != "" {
+		// A region has been specified, make sure it exists.
+		if _, err := jujucloud.RegionByName(cloud.Regions, cloudRegion); err != nil {
+			if cloudRegion == c.CloudRegion {
+				// The string is not in the format cloud/region,
+				// so we should tell that the user that it is
+				// neither a cloud nor a region in the default
+				// cloud (or that there is no default cloud).
+				err := c.unsupportedCloudOrRegionError(cloudClient, cloudTag)
+				return names.CloudTag{}, jujucloud.Cloud{}, "", errors.Trace(err)
+			}
+			return names.CloudTag{}, jujucloud.Cloud{}, "", errors.Trace(err)
+		}
+	} else if len(cloud.Regions) > 0 {
+		// The first region in the list is the default.
+		cloudRegion = cloud.Regions[0].Name
+	}
+	return cloudTag, cloud, cloudRegion, nil
+}
+
+func (c *addModelCommand) unsupportedCloudOrRegionError(cloudClient CloudAPI, defaultCloudTag names.CloudTag) (err error) {
+	clouds, err := cloudClient.Clouds()
+	if err != nil {
+		return errors.Annotate(err, "querying supported clouds")
+	}
+	cloudNames := make([]string, 0, len(clouds))
+	for tag := range clouds {
+		cloudNames = append(cloudNames, tag.Id())
+	}
+	sort.Strings(cloudNames)
+
+	var buf bytes.Buffer
+	tw := output.TabWriter(&buf)
+	fmt.Fprintln(tw, "CLOUD\tREGIONS")
+	for _, cloudName := range cloudNames {
+		cloud := clouds[names.NewCloudTag(cloudName)]
+		regionNames := make([]string, len(cloud.Regions))
+		for i, region := range cloud.Regions {
+			regionNames[i] = region.Name
+		}
+		fmt.Fprintf(tw, "%s\t%s\n", cloudName, strings.Join(regionNames, ", "))
+	}
+	tw.Flush()
+
+	var prefix string
+	if defaultCloudTag != (names.CloudTag{}) {
+		prefix = fmt.Sprintf(`
+%q is neither a cloud supported by this controller,
+nor a region in the controller's default cloud %q.
+The clouds/regions supported by this controller are:`[1:],
+			c.CloudRegion, defaultCloudTag.Id())
+	} else {
+		prefix = fmt.Sprintf(`
+%q is not a cloud supported by this controller,
+and there is no default cloud. The clouds/regions supported
+by this controller are:`[1:], c.CloudRegion)
+	}
+	return errors.Errorf("%s\n\n%s", prefix, buf.String())
+}
+
+func defaultCloud(cloudClient CloudAPI) (names.CloudTag, jujucloud.Cloud, error) {
+	cloudTag, err := cloudClient.DefaultCloud()
+	if err != nil {
+		if params.IsCodeNotFound(err) {
+			return names.CloudTag{}, jujucloud.Cloud{}, errors.NewNotFound(nil, `
+there is no default cloud defined, please specify one using:
+
+    juju add-model [flags] <model-name> cloud[/region]`[1:])
+		}
+		return names.CloudTag{}, jujucloud.Cloud{}, errors.Trace(err)
+	}
+	cloud, err := cloudClient.Cloud(cloudTag)
+	if err != nil {
+		return names.CloudTag{}, jujucloud.Cloud{}, errors.Trace(err)
+	}
+	return cloudTag, cloud, nil
+}
+
 func (c *addModelCommand) maybeUploadCredential(
 	ctx *cmd.Context,
 	cloudClient CloudAPI,
+	cloudTag names.CloudTag,
+	cloud jujucloud.Cloud,
 	modelOwner string,
 ) (names.CloudCredentialTag, error) {
 
-	cloudTag, err := cloudClient.DefaultCloud()
-	if err != nil {
-		return names.CloudCredentialTag{}, errors.Trace(err)
-	}
 	modelOwnerTag := names.NewUserTag(modelOwner)
 	credentialTag, err := common.ResolveCloudCredentialTag(
 		modelOwnerTag, cloudTag, c.CredentialName,
@@ -261,7 +414,7 @@ func (c *addModelCommand) maybeUploadCredential(
 		if tag.Canonical() != credentialId {
 			continue
 		}
-		ctx.Infof("using credential '%s' cached in controller", c.CredentialName)
+		ctx.Infof("Using credential '%s' cached in controller", c.CredentialName)
 		return credentialTag, nil
 	}
 
@@ -274,18 +427,14 @@ func (c *addModelCommand) maybeUploadCredential(
 	}
 
 	// Upload the credential from the client, if it exists locally.
-	cloudDetails, err := cloudClient.Cloud(cloudTag)
-	if err != nil {
-		return names.CloudCredentialTag{}, errors.Trace(err)
-	}
 	credential, _, _, err := modelcmd.GetCredentials(
 		c.ClientStore(), c.CloudRegion, credentialTag.Name(),
-		cloudTag.Id(), cloudDetails.Type,
+		cloudTag.Id(), cloud.Type,
 	)
 	if err != nil {
 		return names.CloudCredentialTag{}, errors.Trace(err)
 	}
-	ctx.Infof("uploading credential '%s' to controller", credentialTag.Id())
+	ctx.Infof("Uploading credential '%s' to controller", credentialTag.Id())
 	if err := cloudClient.UpdateCredential(credentialTag, *credential); err != nil {
 		return names.CloudCredentialTag{}, errors.Trace(err)
 	}

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -25,16 +26,16 @@ import (
 	"gopkg.in/juju/names.v2"
 )
 
-type addSuite struct {
+type AddModelSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
 	fakeAddModelAPI *fakeAddClient
-	fakeCloundAPI   *fakeCloudAPI
+	fakeCloudAPI    *fakeCloudAPI
 	store           *jujuclienttesting.MemStore
 }
 
-var _ = gc.Suite(&addSuite{})
+var _ = gc.Suite(&AddModelSuite{})
 
-func (s *addSuite) SetUpTest(c *gc.C) {
+func (s *AddModelSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.fakeAddModelAPI = &fakeAddClient{
 		model: params.ModelInfo{
@@ -43,7 +44,7 @@ func (s *addSuite) SetUpTest(c *gc.C) {
 			OwnerTag: "ignored-for-now",
 		},
 	}
-	s.fakeCloundAPI = &fakeCloudAPI{}
+	s.fakeCloudAPI = &fakeCloudAPI{}
 
 	// Set up the current controller, and write just enough info
 	// so we don't try to refresh
@@ -72,19 +73,20 @@ func (*fakeAPIConnection) Close() error {
 	return nil
 }
 
-func (s *addSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
-	command, _ := controller.NewAddModelCommandForTest(&fakeAPIConnection{}, s.fakeAddModelAPI, s.fakeCloundAPI, s.store)
+func (s *AddModelSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
+	command, _ := controller.NewAddModelCommandForTest(&fakeAPIConnection{}, s.fakeAddModelAPI, s.fakeCloudAPI, s.store)
 	return testing.RunCommand(c, command, args...)
 }
 
-func (s *addSuite) TestInit(c *gc.C) {
+func (s *AddModelSuite) TestInit(c *gc.C) {
 	modelNameErr := "%q is not a valid name: model names may only contain lowercase letters, digits and hyphens"
 	for i, test := range []struct {
-		args   []string
-		err    string
-		name   string
-		owner  string
-		values map[string]interface{}
+		args        []string
+		err         string
+		name        string
+		owner       string
+		cloudRegion string
+		values      map[string]interface{}
 	}{
 		{
 			err: "model name is required",
@@ -118,7 +120,11 @@ func (s *addSuite) TestInit(c *gc.C) {
 			name:   "new-model",
 			values: map[string]interface{}{"key": "value", "key2": "value2"},
 		}, {
-			args: []string{"new-model", "extra", "args"},
+			args:        []string{"new-model", "cloud/region"},
+			name:        "new-model",
+			cloudRegion: "cloud/region",
+		}, {
+			args: []string{"new-model", "cloud/region", "extra", "args"},
 			err:  `unrecognized args: \["extra" "args"\]`,
 		},
 	} {
@@ -133,6 +139,7 @@ func (s *addSuite) TestInit(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(command.Name, gc.Equals, test.name)
 		c.Assert(command.Owner, gc.Equals, test.owner)
+		c.Assert(command.CloudRegion, gc.Equals, test.cloudRegion)
 		attrs, err := command.Config.ReadAttrs(nil)
 		c.Assert(err, jc.ErrorIsNil)
 		if len(test.values) == 0 {
@@ -143,7 +150,7 @@ func (s *addSuite) TestInit(c *gc.C) {
 	}
 }
 
-func (s *addSuite) TestAddExistingName(c *gc.C) {
+func (s *AddModelSuite) TestAddExistingName(c *gc.C) {
 	// If there's any model details existing, we just overwrite them. The
 	// controller will error out if the model already exists. Overwriting
 	// means we'll replace any stale details from an previously existing
@@ -161,16 +168,101 @@ func (s *addSuite) TestAddExistingName(c *gc.C) {
 	c.Assert(details, jc.DeepEquals, &jujuclient.ModelDetails{"fake-model-uuid"})
 }
 
-func (s *addSuite) TestCredentialsPassedThrough(c *gc.C) {
-	c.Skip("TODO(wallyworld) - port to using new credential management")
+func (s *AddModelSuite) TestCredentialsPassedThrough(c *gc.C) {
 	_, err := s.run(c, "test", "--credential", "secrets")
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(s.fakeAddModelAPI.cloudCredential, gc.Equals, "secrets")
-	c.Assert(s.fakeAddModelAPI.config["type"], gc.Equals, "ec2")
+	c.Assert(s.fakeAddModelAPI.cloudCredential, gc.Equals, names.NewCloudCredentialTag("aws/bob@local/secrets"))
 }
 
-func (s *addSuite) TestComandLineConfigPassedThrough(c *gc.C) {
+func (s *AddModelSuite) TestCredentialsOtherUserPassedThrough(c *gc.C) {
+	_, err := s.run(c, "test", "--credential", "other/secrets")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.fakeAddModelAPI.cloudCredential, gc.Equals, names.NewCloudCredentialTag("aws/other/secrets"))
+}
+
+func (s *AddModelSuite) TestCredentialsNoDefaultCloud(c *gc.C) {
+	s.fakeCloudAPI.SetErrors(&params.Error{Code: params.CodeNotFound})
+	_, err := s.run(c, "test", "--credential", "secrets")
+	c.Assert(err, gc.ErrorMatches, `there is no default cloud defined, please specify one using:
+
+    juju add-model \[flags\] \<model-name\> cloud\[/region\]`)
+}
+
+func (s *AddModelSuite) TestCloudRegionPassedThrough(c *gc.C) {
+	_, err := s.run(c, "test", "aws/us-west-1")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.fakeAddModelAPI.cloudName, gc.Equals, "aws")
+	c.Assert(s.fakeAddModelAPI.cloudRegion, gc.Equals, "us-west-1")
+}
+
+func (s *AddModelSuite) TestDefaultCloudPassedThrough(c *gc.C) {
+	_, err := s.run(c, "test")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.fakeCloudAPI.CheckCallNames(c /*none*/)
+	c.Assert(s.fakeAddModelAPI.cloudName, gc.Equals, "")
+	c.Assert(s.fakeAddModelAPI.cloudRegion, gc.Equals, "")
+}
+
+func (s *AddModelSuite) TestDefaultCloudRegionPassedThrough(c *gc.C) {
+	_, err := s.run(c, "test", "us-west-1")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.fakeCloudAPI.CheckCalls(c, []gitjujutesting.StubCall{
+		{"Cloud", []interface{}{names.NewCloudTag("us-west-1")}},
+		{"DefaultCloud", nil},
+		{"Cloud", []interface{}{names.NewCloudTag("aws")}},
+	})
+	c.Assert(s.fakeAddModelAPI.cloudName, gc.Equals, "aws")
+	c.Assert(s.fakeAddModelAPI.cloudRegion, gc.Equals, "us-west-1")
+}
+
+func (s *AddModelSuite) TestNoDefaultCloudRegion(c *gc.C) {
+	s.fakeCloudAPI.SetErrors(
+		&params.Error{Code: params.CodeNotFound}, // no default region
+	)
+	_, err := s.run(c, "test", "us-west-1")
+	c.Assert(err, gc.ErrorMatches, `
+"us-west-1" is not a cloud supported by this controller,
+and there is no default cloud. The clouds/regions supported
+by this controller are:
+
+CLOUD  REGIONS
+aws    us-east-1, us-west-1
+lxd    
+`[1:])
+	s.fakeCloudAPI.CheckCalls(c, []gitjujutesting.StubCall{
+		{"Cloud", []interface{}{names.NewCloudTag("us-west-1")}},
+		{"DefaultCloud", nil},
+		{"Clouds", nil},
+	})
+}
+
+func (s *AddModelSuite) TestCloudDefaultRegionPassedThrough(c *gc.C) {
+	_, err := s.run(c, "test", "aws")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.fakeAddModelAPI.cloudName, gc.Equals, "aws")
+	c.Assert(s.fakeAddModelAPI.cloudRegion, gc.Equals, "us-east-1")
+}
+
+func (s *AddModelSuite) TestInvalidCloudOrRegionName(c *gc.C) {
+	_, err := s.run(c, "test", "oro")
+	c.Assert(err, gc.ErrorMatches, `
+"oro" is neither a cloud supported by this controller,
+nor a region in the controller's default cloud "aws".
+The clouds/regions supported by this controller are:
+
+CLOUD  REGIONS
+aws    us-east-1, us-west-1
+lxd    
+`[1:])
+}
+
+func (s *AddModelSuite) TestComandLineConfigPassedThrough(c *gc.C) {
 	_, err := s.run(c, "test", "--config", "account=magic", "--config", "cloud=special")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -178,7 +270,7 @@ func (s *addSuite) TestComandLineConfigPassedThrough(c *gc.C) {
 	c.Assert(s.fakeAddModelAPI.config["cloud"], gc.Equals, "special")
 }
 
-func (s *addSuite) TestConfigFileValuesPassedThrough(c *gc.C) {
+func (s *AddModelSuite) TestConfigFileValuesPassedThrough(c *gc.C) {
 	config := map[string]string{
 		"account": "magic",
 		"cloud":   "9",
@@ -196,7 +288,7 @@ func (s *addSuite) TestConfigFileValuesPassedThrough(c *gc.C) {
 	c.Assert(s.fakeAddModelAPI.config["cloud"], gc.Equals, "9")
 }
 
-func (s *addSuite) TestConfigFileWithNestedMaps(c *gc.C) {
+func (s *AddModelSuite) TestConfigFileWithNestedMaps(c *gc.C) {
 	nestedConfig := map[string]interface{}{
 		"account": "magic",
 		"cloud":   "9",
@@ -219,7 +311,7 @@ func (s *addSuite) TestConfigFileWithNestedMaps(c *gc.C) {
 	c.Assert(s.fakeAddModelAPI.config["nested"], jc.DeepEquals, nestedConfig)
 }
 
-func (s *addSuite) TestConfigFileFailsToConform(c *gc.C) {
+func (s *AddModelSuite) TestConfigFileFailsToConform(c *gc.C) {
 	nestedConfig := map[int]interface{}{
 		9: "9",
 	}
@@ -238,7 +330,7 @@ func (s *addSuite) TestConfigFileFailsToConform(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `unable to parse config: map keyed with non-string value`)
 }
 
-func (s *addSuite) TestConfigFileFormatError(c *gc.C) {
+func (s *AddModelSuite) TestConfigFileFormatError(c *gc.C) {
 	file, err := ioutil.TempFile(c.MkDir(), "")
 	c.Assert(err, jc.ErrorIsNil)
 	file.Write(([]byte)("not: valid: yaml"))
@@ -248,13 +340,13 @@ func (s *addSuite) TestConfigFileFormatError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `unable to parse config: yaml: .*`)
 }
 
-func (s *addSuite) TestConfigFileDoesntExist(c *gc.C) {
+func (s *AddModelSuite) TestConfigFileDoesntExist(c *gc.C) {
 	_, err := s.run(c, "test", "--config", "missing-file")
 	errMsg := ".*" + utils.NoSuchFileErrRegexp
 	c.Assert(err, gc.ErrorMatches, errMsg)
 }
 
-func (s *addSuite) TestConfigValuePrecedence(c *gc.C) {
+func (s *AddModelSuite) TestConfigValuePrecedence(c *gc.C) {
 	config := map[string]string{
 		"account": "magic",
 		"cloud":   "9",
@@ -272,7 +364,7 @@ func (s *addSuite) TestConfigValuePrecedence(c *gc.C) {
 	c.Assert(s.fakeAddModelAPI.config["cloud"], gc.Equals, "special")
 }
 
-func (s *addSuite) TestAddErrorRemoveConfigstoreInfo(c *gc.C) {
+func (s *AddModelSuite) TestAddErrorRemoveConfigstoreInfo(c *gc.C) {
 	s.fakeAddModelAPI.err = errors.New("bah humbug")
 
 	_, err := s.run(c, "test")
@@ -282,7 +374,7 @@ func (s *addSuite) TestAddErrorRemoveConfigstoreInfo(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
-func (s *addSuite) TestAddStoresValues(c *gc.C) {
+func (s *AddModelSuite) TestAddStoresValues(c *gc.C) {
 	_, err := s.run(c, "test")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -291,7 +383,7 @@ func (s *addSuite) TestAddStoresValues(c *gc.C) {
 	c.Assert(model, jc.DeepEquals, &jujuclient.ModelDetails{"fake-model-uuid"})
 }
 
-func (s *addSuite) TestNoEnvCacheOtherUser(c *gc.C) {
+func (s *AddModelSuite) TestNoEnvCacheOtherUser(c *gc.C) {
 	_, err := s.run(c, "test", "--owner", "zeus")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -304,6 +396,7 @@ func (s *addSuite) TestNoEnvCacheOtherUser(c *gc.C) {
 // AddModel command.
 type fakeAddClient struct {
 	owner           string
+	cloudName       string
 	cloudRegion     string
 	cloudCredential names.CloudCredentialTag
 	config          map[string]interface{}
@@ -317,12 +410,13 @@ func (*fakeAddClient) Close() error {
 	return nil
 }
 
-func (f *fakeAddClient) CreateModel(name, owner, cloudRegion string, cloudCredential names.CloudCredentialTag, config map[string]interface{}) (params.ModelInfo, error) {
+func (f *fakeAddClient) CreateModel(name, owner, cloudName, cloudRegion string, cloudCredential names.CloudCredentialTag, config map[string]interface{}) (params.ModelInfo, error) {
 	if f.err != nil {
 		return params.ModelInfo{}, f.err
 	}
 	f.owner = owner
 	f.cloudCredential = cloudCredential
+	f.cloudName = cloudName
 	f.cloudRegion = cloudRegion
 	f.config = config
 	return f.model, nil
@@ -331,14 +425,51 @@ func (f *fakeAddClient) CreateModel(name, owner, cloudRegion string, cloudCreden
 // TODO(wallyworld) - improve this stub and add test asserts
 type fakeCloudAPI struct {
 	controller.CloudAPI
+	gitjujutesting.Stub
 }
 
-func (c *fakeCloudAPI) Credentials(names.UserTag, names.CloudTag) ([]names.CloudCredentialTag, error) {
+func (c *fakeCloudAPI) DefaultCloud() (names.CloudTag, error) {
+	c.MethodCall(c, "DefaultCloud")
+	return names.NewCloudTag("aws"), c.NextErr()
+}
+
+func (c *fakeCloudAPI) Clouds() (map[names.CloudTag]cloud.Cloud, error) {
+	c.MethodCall(c, "Clouds")
+	return map[names.CloudTag]cloud.Cloud{
+		names.NewCloudTag("aws"): {
+			Regions: []cloud.Region{
+				{Name: "us-east-1"},
+				{Name: "us-west-1"},
+			},
+		},
+		names.NewCloudTag("lxd"): {},
+	}, c.NextErr()
+}
+
+func (c *fakeCloudAPI) Cloud(tag names.CloudTag) (cloud.Cloud, error) {
+	c.MethodCall(c, "Cloud", tag)
+	if tag.Id() != "aws" {
+		return cloud.Cloud{}, &params.Error{Code: params.CodeNotFound}
+	}
+	return cloud.Cloud{
+		Type:      "ec2",
+		AuthTypes: []cloud.AuthType{cloud.AccessKeyAuthType},
+		Regions: []cloud.Region{
+			{Name: "us-east-1"},
+			{Name: "us-west-1"},
+		},
+	}, c.NextErr()
+}
+
+func (c *fakeCloudAPI) Credentials(user names.UserTag, cloud names.CloudTag) ([]names.CloudCredentialTag, error) {
+	c.MethodCall(c, "Credentials", user, cloud)
 	return []names.CloudCredentialTag{
 		names.NewCloudCredentialTag("cloud/admin@local/default"),
-	}, nil
+		names.NewCloudCredentialTag("aws/other@local/secrets"),
+	}, c.NextErr()
 }
 
-func (c *fakeCloudAPI) UpdateCredential(names.CloudCredentialTag, cloud.Credential) error {
-	return nil
+func (c *fakeCloudAPI) UpdateCredential(credentialTag names.CloudCredentialTag, credential cloud.Credential) error {
+	c.MethodCall(c, "UpdateCredential", credentialTag, credential)
+	return c.NextErr()
 }

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -48,9 +48,11 @@ func (s *cmdControllerSuite) run(c *gc.C, args ...string) *cmd.Context {
 func (s *cmdControllerSuite) createModelAdminUser(c *gc.C, modelname string, isServer bool) params.ModelInfo {
 	modelManager := modelmanager.NewClient(s.OpenControllerAPI(c))
 	defer modelManager.Close()
-	model, err := modelManager.CreateModel(modelname, s.AdminUserTag(c).Id(), "", names.CloudCredentialTag{}, map[string]interface{}{
-		"controller": isServer,
-	})
+	model, err := modelManager.CreateModel(
+		modelname, s.AdminUserTag(c).Id(), "", "", names.CloudCredentialTag{}, map[string]interface{}{
+			"controller": isServer,
+		},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	return model
 }
@@ -59,10 +61,12 @@ func (s *cmdControllerSuite) createModelNormalUser(c *gc.C, modelname string, is
 	s.run(c, "add-user", "test")
 	modelManager := modelmanager.NewClient(s.OpenControllerAPI(c))
 	defer modelManager.Close()
-	_, err := modelManager.CreateModel(modelname, names.NewLocalUserTag("test").Id(), "", names.CloudCredentialTag{}, map[string]interface{}{
-		"authorized-keys": "ssh-key",
-		"controller":      isServer,
-	})
+	_, err := modelManager.CreateModel(
+		modelname, names.NewLocalUserTag("test").Id(), "", "", names.CloudCredentialTag{}, map[string]interface{}{
+			"authorized-keys": "ssh-key",
+			"controller":      isServer,
+		},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -156,14 +160,23 @@ func (s *cmdControllerSuite) TestListDeadModels(c *gc.C) {
 }
 
 func (s *cmdControllerSuite) TestAddModel(c *gc.C) {
+	s.testAddModel(c)
+}
+
+func (s *cmdControllerSuite) TestAddModelWithCloudAndRegion(c *gc.C) {
+	s.testAddModel(c, "dummy/dummy-region")
+}
+
+func (s *cmdControllerSuite) testAddModel(c *gc.C, args ...string) {
 	// The JujuConnSuite doesn't set up an ssh key in the fake home dir,
 	// so fake one on the command line.  The dummy provider also expects
 	// a config value for 'controller'.
-	context := s.run(
-		c, "add-model", "new-model",
+	args = append([]string{"add-model", "new-model"}, args...)
+	args = append(args,
 		"--config", "authorized-keys=fake-key",
 		"--config", "controller=false",
 	)
+	context := s.run(c, args...)
 	c.Check(testing.Stdout(context), gc.Equals, "")
 	c.Check(testing.Stderr(context), gc.Equals, `
 Added 'new-model' model on dummy/dummy-region with credential 'cred' for user 'admin'

--- a/state/cloud_test.go
+++ b/state/cloud_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/cloud"
 )
@@ -17,6 +18,25 @@ type CloudSuite struct {
 
 var _ = gc.Suite(&CloudSuite{})
 
+var lowCloud = cloud.Cloud{
+	Type:             "low",
+	AuthTypes:        cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
+	Endpoint:         "global-endpoint",
+	IdentityEndpoint: "identity-endpoint",
+	StorageEndpoint:  "storage-endpoint",
+	Regions: []cloud.Region{{
+		Name:             "region1",
+		Endpoint:         "region1-endpoint",
+		IdentityEndpoint: "region1-identity",
+		StorageEndpoint:  "region1-storage",
+	}, {
+		Name:             "region2",
+		Endpoint:         "region2-endpoint",
+		IdentityEndpoint: "region2-identity",
+		StorageEndpoint:  "region2-storage",
+	}},
+}
+
 func (s *CloudSuite) TestCloudNotFound(c *gc.C) {
 	cld, err := s.State.Cloud("unknown")
 	c.Assert(err, gc.ErrorMatches, `cloud "unknown" not found`)
@@ -24,30 +44,26 @@ func (s *CloudSuite) TestCloudNotFound(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
+func (s *CloudSuite) TestClouds(c *gc.C) {
+	dummyCloud, err := s.State.Cloud("dummy")
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.AddCloud("stratus", lowCloud)
+	c.Assert(err, jc.ErrorIsNil)
+
+	clouds, err := s.State.Clouds()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(clouds, jc.DeepEquals, map[names.CloudTag]cloud.Cloud{
+		names.NewCloudTag("dummy"):   dummyCloud,
+		names.NewCloudTag("stratus"): lowCloud,
+	})
+}
+
 func (s *CloudSuite) TestAddCloud(c *gc.C) {
-	cld := cloud.Cloud{
-		Type:             "low",
-		AuthTypes:        cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
-		Endpoint:         "global-endpoint",
-		IdentityEndpoint: "identity-endpoint",
-		StorageEndpoint:  "storage-endpoint",
-		Regions: []cloud.Region{{
-			Name:             "region1",
-			Endpoint:         "region1-endpoint",
-			IdentityEndpoint: "region1-identity",
-			StorageEndpoint:  "region1-storage",
-		}, {
-			Name:             "region2",
-			Endpoint:         "region2-endpoint",
-			IdentityEndpoint: "region2-identity",
-			StorageEndpoint:  "region2-storage",
-		}},
-	}
-	err := s.State.AddCloud("stratus", cld)
+	err := s.State.AddCloud("stratus", lowCloud)
 	c.Assert(err, jc.ErrorIsNil)
-	cld1, err := s.State.Cloud("stratus")
+	cloud, err := s.State.Cloud("stratus")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cld1, jc.DeepEquals, cld)
+	c.Assert(cloud, jc.DeepEquals, lowCloud)
 }
 
 func (s *CloudSuite) TestAddCloudDuplicate(c *gc.C) {

--- a/state/interface.go
+++ b/state/interface.go
@@ -103,6 +103,7 @@ type AgentEntity interface {
 // about clouds and credentials.
 type CloudAccessor interface {
 	Cloud(cloud string) (cloud.Cloud, error)
+	Clouds() (map[names.CloudTag]cloud.Cloud, error)
 	CloudCredential(tag names.CloudCredentialTag) (cloud.Credential, error)
 }
 


### PR DESCRIPTION
The add-model command now has an optional positional
argument, which can be the name of a cloud, a region,
or both (cloud/region). If it is a cloud, then the
cloud's default region will be used, if there are
any regions. If it is not a cloud, we check if it is
a region in the default cloud.

(Review request: http://reviews.vapour.ws/r/5534/)