### PR TITLE
deploy, apiserver: Added support for not registering metered charms whose plan is optional

### DIFF
--- a/api/charms/client.go
+++ b/api/charms/client.go
@@ -249,6 +249,7 @@ func convertCharmMetrics(metrics *params.CharmMetrics) *charm.Metrics {
 	}
 	return &charm.Metrics{
 		Metrics: convertCharmMetricMap(metrics.Metrics),
+		Plan:    metrics.Plan,
 	}
 }
 

--- a/api/charms/client.go
+++ b/api/charms/client.go
@@ -249,8 +249,12 @@ func convertCharmMetrics(metrics *params.CharmMetrics) *charm.Metrics {
 	}
 	return &charm.Metrics{
 		Metrics: convertCharmMetricMap(metrics.Metrics),
-		Plan:    metrics.Plan,
+		Plan:    convertCharmPlan(metrics.Plan),
 	}
+}
+
+func convertCharmPlan(plan params.CharmPlan) *charm.Plan {
+	return &charm.Plan{Required: plan.Required}
 }
 
 func convertCharmMetricMap(metrics map[string]params.CharmMetric) map[string]charm.Metric {

--- a/apiserver/charms/client.go
+++ b/apiserver/charms/client.go
@@ -306,6 +306,7 @@ func convertCharmMetrics(metrics *charm.Metrics) *params.CharmMetrics {
 	}
 	return &params.CharmMetrics{
 		Metrics: convertCharmMetricMap(metrics.Metrics),
+		Plan:    metrics.Plan,
 	}
 }
 

--- a/apiserver/charms/client.go
+++ b/apiserver/charms/client.go
@@ -306,8 +306,15 @@ func convertCharmMetrics(metrics *charm.Metrics) *params.CharmMetrics {
 	}
 	return &params.CharmMetrics{
 		Metrics: convertCharmMetricMap(metrics.Metrics),
-		Plan:    metrics.Plan,
+		Plan:    convertCharmPlan(metrics.Plan),
 	}
+}
+
+func convertCharmPlan(plan *charm.Plan) params.CharmPlan {
+	if plan == nil {
+		return params.CharmPlan{Required: false}
+	}
+	return params.CharmPlan{Required: plan.Required}
 }
 
 func convertCharmMetricMap(metrics map[string]charm.Metric) map[string]params.CharmMetric {

--- a/apiserver/charms/client_test.go
+++ b/apiserver/charms/client_test.go
@@ -208,6 +208,9 @@ func (s *charmsSuite) TestMeteredCharmInfo(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	expected := &params.CharmMetrics{
+		Plan: params.CharmPlan{
+			Required: true,
+		},
 		Metrics: map[string]params.CharmMetric{
 			"pings": params.CharmMetric{
 				Type:        "gauge",

--- a/apiserver/params/charms.go
+++ b/apiserver/params/charms.go
@@ -114,4 +114,5 @@ type CharmMetric struct {
 // CharmMetrics mirrors charm.Metrics.
 type CharmMetrics struct {
 	Metrics map[string]CharmMetric `json:"metrics"`
+	Plan    string                 `json:"plan"`
 }

--- a/apiserver/params/charms.go
+++ b/apiserver/params/charms.go
@@ -111,8 +111,13 @@ type CharmMetric struct {
 	Description string `json:"description"`
 }
 
+// CharmPlan mirrors charm.Plan
+type CharmPlan struct {
+	Required bool `json:"required"`
+}
+
 // CharmMetrics mirrors charm.Metrics.
 type CharmMetrics struct {
 	Metrics map[string]CharmMetric `json:"metrics"`
-	Plan    string                 `json:"plan"`
+	Plan    CharmPlan              `json:"plan"`
 }

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -310,6 +310,7 @@ type DeploymentInfo struct {
 	CharmID         charmstore.CharmID
 	ApplicationName string
 	ModelUUID       string
+	CharmInfo       *apicharms.CharmInfo
 }
 
 func (c *DeployCommand) Info() *cmd.Info {
@@ -463,6 +464,7 @@ func (c *DeployCommand) deployCharm(
 		CharmID:         id,
 		ApplicationName: serviceName,
 		ModelUUID:       uuid,
+		CharmInfo:       charmInfo,
 	}
 
 	for _, step := range c.Steps {

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -49,16 +49,22 @@ type DeployAPI interface {
 	// TODO(katco): Pair DeployAPI down to only the methods required
 	// by the deploy command.
 	api.Connection
+	MeteredDeployAPI
 	CharmAdder
 
 	ModelUUID() (string, bool)
 	CharmInfo(string) (*apicharms.CharmInfo, error)
 	Deploy(application.DeployArgs) error
 
-	// IsMetered(charmURL string) (bool, error)
-	// SetMetricCredentials(service string, credentials []byte) error
 	// AddPendingResources(client.AddPendingResourcesArgs) (ids []string, _ error)
 	// DeployResources(cmd.DeployResourcesArgs) (ids []string, _ error)
+}
+
+// MeteredDeployAPI represents the methods of the API the deploy
+// command needs for metered charms.
+type MeteredDeployAPI interface {
+	IsMetered(charmURL string) (bool, error)
+	SetMetricCredentials(service string, credentials []byte) error
 }
 
 // The following structs exist purely because Go cannot create a
@@ -298,10 +304,10 @@ type DeployStep interface {
 	// Set flags necessary for the deploy step.
 	SetFlags(*gnuflag.FlagSet)
 	// RunPre runs before the call is made to add the charm to the environment.
-	RunPre(api.Connection, *httpbakery.Client, *cmd.Context, DeploymentInfo) error
+	RunPre(MeteredDeployAPI, *httpbakery.Client, *cmd.Context, DeploymentInfo) error
 	// RunPost runs after the call is made to add the charm to the environment.
 	// The error parameter is used to notify the step of a previously occurred error.
-	RunPost(api.Connection, *httpbakery.Client, *cmd.Context, DeploymentInfo, error) error
+	RunPost(MeteredDeployAPI, *httpbakery.Client, *cmd.Context, DeploymentInfo, error) error
 }
 
 // DeploymentInfo is used to maintain all deployment information for
@@ -325,14 +331,16 @@ func (c *DeployCommand) Info() *cmd.Info {
 var (
 	// charmOnlyFlags and bundleOnlyFlags are used to validate flags based on
 	// whether we are deploying a charm or a bundle.
-	charmOnlyFlags  = []string{"bind", "config", "constraints", "force", "n", "num-units", "series", "to", "resource"}
-	bundleOnlyFlags = []string{}
+	charmOnlyFlags        = []string{"bind", "config", "constraints", "force", "n", "num-units", "series", "to", "resource"}
+	bundleOnlyFlags       = []string{}
+	modelCommandBaseFlags = []string{"B", "no-browser-login"}
 )
 
 func (c *DeployCommand) SetFlags(f *gnuflag.FlagSet) {
 	// Keep above charmOnlyFlags and bundleOnlyFlags lists updated when adding
 	// new flags.
 	c.UnitCommandBase.SetFlags(f)
+	c.ModelCommandBase.SetFlags(f)
 	f.IntVar(&c.NumUnits, "n", 1, "Number of application units to deploy for principal charms")
 	f.StringVar((*string)(&c.Channel), "channel", "", "Channel to use when getting the charm or bundle from the charm store")
 	f.Var(&c.Config, "config", "Path to yaml-formatted application config")

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1096,6 +1096,137 @@ func (s *DeployCharmStoreSuite) TestAddMetricCredentialsDefaultPlan(c *gc.C) {
 	}})
 }
 
+func (s *DeploySuite) TestAddMetricCredentialsDefaultForUnmeteredCharm(c *gc.C) {
+	var called bool
+	setter := &testMetricCredentialsSetter{
+		assert: func(serviceName string, data []byte) {
+			called = true
+			c.Assert(serviceName, gc.DeepEquals, "dummy")
+			c.Assert(data, gc.DeepEquals, []byte{})
+		},
+	}
+
+	cleanup := jujutesting.PatchValue(&getMetricCredentialsAPI, func(_ api.Connection) (metricCredentialsAPI, error) {
+		return setter, nil
+	})
+	defer cleanup()
+
+	ch := testcharms.Repo.ClonedDirPath(s.CharmsPath, "dummy")
+
+	deploy := &DeployCommand{Steps: []DeployStep{&RegisterMeteredCharm{}}}
+	_, err := coretesting.RunCommand(c, modelcmd.Wrap(deploy), ch, "--series", "trusty")
+	c.Assert(err, jc.ErrorIsNil)
+	curl := charm.MustParseURL("local:trusty/dummy-1")
+	s.AssertService(c, "dummy", curl, 1, 0)
+	c.Assert(called, jc.IsFalse)
+}
+
+func (s *DeployCharmStoreSuite) TestAddMetricCredentialsNotNeededForOptionalPlan(c *gc.C) {
+	var called bool
+	setter := &testMetricCredentialsSetter{
+		assert: func(serviceName string, data []byte) {
+			called = true
+		},
+	}
+
+	cleanup := jujutesting.PatchValue(&getMetricCredentialsAPI, func(_ api.Connection) (metricCredentialsAPI, error) {
+		return setter, nil
+	})
+	defer cleanup()
+
+	stub := &jujutesting.Stub{}
+	handler := &testMetricsRegistrationHandler{Stub: stub}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	metricsYAML := `
+plan:
+  required: false
+metrics:
+  pings:
+    type: gauge
+    description: ping pongs
+`
+	meteredMetaYAML := `
+name: metered
+description: metered charm
+summary: summary
+`
+
+	url, _ := testcharms.UploadCharmWithMeta(c, s.client, "cs:~user/quantal/metered", meteredMetaYAML, metricsYAML, 1)
+
+	deploy := &DeployCommand{Steps: []DeployStep{&RegisterMeteredCharm{RegisterURL: server.URL, QueryURL: server.URL}}}
+	_, err := coretesting.RunCommand(c, modelcmd.Wrap(deploy), url.String())
+	c.Assert(err, jc.ErrorIsNil)
+	curl := charm.MustParseURL(url.String())
+	svc, err := s.State.Application("metered")
+	c.Assert(err, jc.ErrorIsNil)
+	ch, _, err := svc.Charm()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ch.URL(), gc.DeepEquals, curl)
+	c.Assert(called, jc.IsFalse)
+	stub.CheckNoCalls(c)
+}
+
+func (s *DeployCharmStoreSuite) TestAddMetricCredentialsCalledWhenPlanSpecifiedWhenOptional(c *gc.C) {
+	var called bool
+	setter := &testMetricCredentialsSetter{
+		assert: func(serviceName string, data []byte) {
+			called = true
+			c.Assert(serviceName, gc.DeepEquals, "metered")
+			var b []byte
+			err := json.Unmarshal(data, &b)
+			c.Assert(err, gc.IsNil)
+			c.Assert(string(b), gc.Equals, "hello registration")
+		},
+	}
+
+	cleanup := jujutesting.PatchValue(&getMetricCredentialsAPI, func(_ api.Connection) (metricCredentialsAPI, error) {
+		return setter, nil
+	})
+	defer cleanup()
+
+	stub := &jujutesting.Stub{}
+	handler := &testMetricsRegistrationHandler{Stub: stub}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	metricsYAML := `
+plan:
+  required: false
+metrics:
+  pings:
+    type: gauge
+    description: ping pongs
+`
+	meteredMetaYAML := `
+name: metered
+description: metered charm
+summary: summary
+`
+
+	url, _ := testcharms.UploadCharmWithMeta(c, s.client, "cs:~user/quantal/metered", meteredMetaYAML, metricsYAML, 1)
+
+	deploy := &DeployCommand{Steps: []DeployStep{&RegisterMeteredCharm{RegisterURL: server.URL, QueryURL: server.URL}}}
+	_, err := coretesting.RunCommand(c, modelcmd.Wrap(deploy), url.String(), "--plan", "someplan")
+	c.Assert(err, jc.ErrorIsNil)
+	curl := charm.MustParseURL(url.String())
+	svc, err := s.State.Application("metered")
+	c.Assert(err, jc.ErrorIsNil)
+	ch, _, err := svc.Charm()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ch.URL(), gc.DeepEquals, curl)
+	c.Assert(called, jc.IsTrue)
+	stub.CheckCalls(c, []jujutesting.StubCall{{
+		"Authorize", []interface{}{metricRegistrationPost{
+			ModelUUID:       "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+			CharmURL:        "cs:~user/quantal/metered-0",
+			ApplicationName: "metered",
+			PlanURL:         "someplan",
+			Budget:          "personal",
+			Limit:           "0",
+		}},
+	}})
+}
+
 // FAILING
 func (s *DeployCharmStoreSuite) TestDeployCharmWithSomeEndpointBindingsSpecifiedSuccess(c *gc.C) {
 	_, err := s.State.AddSpace("db", "", nil, false)

--- a/cmd/juju/application/register.go
+++ b/cmd/juju/application/register.go
@@ -68,7 +68,7 @@ func (r *RegisterMeteredCharm) RunPre(state api.Connection, bakeryClient *httpba
 		return nil
 	}
 	info := deployInfo.CharmInfo
-	if info.Metrics != nil && !info.Metrics.PlanRequired() {
+	if r.Plan == "" && info.Metrics != nil && !info.Metrics.PlanRequired() {
 		return nil
 	}
 

--- a/cmd/juju/application/register.go
+++ b/cmd/juju/application/register.go
@@ -62,9 +62,13 @@ func (r *RegisterMeteredCharm) RunPre(state api.Connection, bakeryClient *httpba
 	charmsClient := charms.NewClient(state)
 	metered, err := charmsClient.IsMetered(deployInfo.CharmID.URL.String())
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	if !metered {
+		return nil
+	}
+	info := deployInfo.CharmInfo
+	if info.Metrics != nil && !info.Metrics.PlanRequired() {
 		return nil
 	}
 

--- a/cmd/juju/application/register.go
+++ b/cmd/juju/application/register.go
@@ -16,10 +16,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
-
-	"github.com/juju/juju/api"
-	"github.com/juju/juju/api/application"
-	"github.com/juju/juju/api/charms"
 )
 
 var budgetWithLimitRe = regexp.MustCompile(`^[a-zA-Z0-9\-]+:[0-9]+$`)
@@ -51,7 +47,7 @@ func (r *RegisterMeteredCharm) SetFlags(f *gnuflag.FlagSet) {
 
 // RunPre obtains authorization to deploy this charm. The authorization, if received is not
 // sent to the controller, rather it is kept as an attribute on RegisterMeteredCharm.
-func (r *RegisterMeteredCharm) RunPre(state api.Connection, bakeryClient *httpbakery.Client, ctx *cmd.Context, deployInfo DeploymentInfo) error {
+func (r *RegisterMeteredCharm) RunPre(api MeteredDeployAPI, bakeryClient *httpbakery.Client, ctx *cmd.Context, deployInfo DeploymentInfo) error {
 	if allocBudget, allocLimit, err := parseBudgetWithLimit(r.AllocationSpec); err == nil {
 		// Make these available to registration if valid.
 		r.budget, r.limit = allocBudget, allocLimit
@@ -59,8 +55,7 @@ func (r *RegisterMeteredCharm) RunPre(state api.Connection, bakeryClient *httpba
 		return errors.Trace(err)
 	}
 
-	charmsClient := charms.NewClient(state)
-	metered, err := charmsClient.IsMetered(deployInfo.CharmID.URL.String())
+	metered, err := api.IsMetered(deployInfo.CharmID.URL.String())
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -106,15 +101,14 @@ func (r *RegisterMeteredCharm) RunPre(state api.Connection, bakeryClient *httpba
 }
 
 // RunPost sends credentials obtained during the call to RunPre to the controller.
-func (r *RegisterMeteredCharm) RunPost(state api.Connection, bakeryClient *httpbakery.Client, ctx *cmd.Context, deployInfo DeploymentInfo, prevErr error) error {
+func (r *RegisterMeteredCharm) RunPost(api MeteredDeployAPI, bakeryClient *httpbakery.Client, ctx *cmd.Context, deployInfo DeploymentInfo, prevErr error) error {
 	if prevErr != nil {
 		return nil
 	}
 	if r.credentials == nil {
 		return nil
 	}
-	appClient := application.NewClient(state)
-	err := appClient.SetMetricCredentials(deployInfo.ApplicationName, r.credentials)
+	err := api.SetMetricCredentials(deployInfo.ApplicationName, r.credentials)
 	if err != nil {
 		logger.Warningf("failed to set metric credentials: %v", err)
 		return errors.Trace(err)

--- a/cmd/juju/application/register_test.go
+++ b/cmd/juju/application/register_test.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
 	"github.com/juju/juju/api"
+	apicharms "github.com/juju/juju/api/charms"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmstore"
 	coretesting "github.com/juju/juju/testing"
@@ -58,6 +59,11 @@ func (s *registrationSuite) TestMeteredCharm(c *gc.C) {
 		},
 		ApplicationName: "application name",
 		ModelUUID:       "model uuid",
+		CharmInfo: &apicharms.CharmInfo{
+			Metrics: &charm.Metrics{
+				Plan: charm.PlanRequired,
+			},
+		},
 	}
 	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, jc.ErrorIsNil)
@@ -96,6 +102,11 @@ func (s *registrationSuite) TestMeteredCharmAPIError(c *gc.C) {
 		},
 		ApplicationName: "application name",
 		ModelUUID:       "model uuid",
+		CharmInfo: &apicharms.CharmInfo{
+			Metrics: &charm.Metrics{
+				Plan: charm.PlanRequired,
+			},
+		},
 	}
 	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, gc.ErrorMatches, `authorization failed: something failed`)
@@ -121,6 +132,11 @@ func (s *registrationSuite) TestMeteredCharmInvalidAllocation(c *gc.C) {
 		},
 		ApplicationName: "application name",
 		ModelUUID:       "model uuid",
+		CharmInfo: &apicharms.CharmInfo{
+			Metrics: &charm.Metrics{
+				Plan: charm.PlanRequired,
+			},
+		},
 	}
 	s.register = &RegisterMeteredCharm{
 		Plan:           "someplan",
@@ -141,6 +157,11 @@ func (s *registrationSuite) TestMeteredCharmDeployError(c *gc.C) {
 		},
 		ApplicationName: "application name",
 		ModelUUID:       "model uuid",
+		CharmInfo: &apicharms.CharmInfo{
+			Metrics: &charm.Metrics{
+				Plan: charm.PlanRequired,
+			},
+		},
 	}
 	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, jc.ErrorIsNil)
@@ -172,6 +193,11 @@ func (s *registrationSuite) TestMeteredLocalCharmWithPlan(c *gc.C) {
 		},
 		ApplicationName: "application name",
 		ModelUUID:       "model uuid",
+		CharmInfo: &apicharms.CharmInfo{
+			Metrics: &charm.Metrics{
+				Plan: charm.PlanRequired,
+			},
+		},
 	}
 	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, jc.ErrorIsNil)
@@ -213,6 +239,11 @@ func (s *registrationSuite) TestMeteredLocalCharmNoPlan(c *gc.C) {
 		},
 		ApplicationName: "application name",
 		ModelUUID:       "model uuid",
+		CharmInfo: &apicharms.CharmInfo{
+			Metrics: &charm.Metrics{
+				Plan: charm.PlanRequired,
+			},
+		},
 	}
 	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, jc.ErrorIsNil)
@@ -253,6 +284,11 @@ func (s *registrationSuite) TestMeteredCharmNoPlanSet(c *gc.C) {
 		},
 		ApplicationName: "application name",
 		ModelUUID:       "model uuid",
+		CharmInfo: &apicharms.CharmInfo{
+			Metrics: &charm.Metrics{
+				Plan: charm.PlanRequired,
+			},
+		},
 	}
 	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, jc.ErrorIsNil)
@@ -297,6 +333,11 @@ func (s *registrationSuite) TestMeteredCharmNoDefaultPlan(c *gc.C) {
 		},
 		ApplicationName: "application name",
 		ModelUUID:       "model uuid",
+		CharmInfo: &apicharms.CharmInfo{
+			Metrics: &charm.Metrics{
+				Plan: charm.PlanRequired,
+			},
+		},
 	}
 	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, gc.ErrorMatches, `cs:quantal/metered-1 has no default plan. Try "juju deploy --plan <plan-name> with one of thisplan, thisotherplan"`)
@@ -322,6 +363,11 @@ func (s *registrationSuite) TestMeteredCharmFailToQueryDefaultCharm(c *gc.C) {
 		},
 		ApplicationName: "application name",
 		ModelUUID:       "model uuid",
+		CharmInfo: &apicharms.CharmInfo{
+			Metrics: &charm.Metrics{
+				Plan: charm.PlanRequired,
+			},
+		},
 	}
 	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, gc.ErrorMatches, `failed to query default plan:.*`)
@@ -340,6 +386,11 @@ func (s *registrationSuite) TestUnmeteredCharm(c *gc.C) {
 		},
 		ApplicationName: "application name",
 		ModelUUID:       "model uuid",
+		CharmInfo: &apicharms.CharmInfo{
+			Metrics: &charm.Metrics{
+				Plan: charm.PlanRequired,
+			},
+		},
 	}
 	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, jc.ErrorIsNil)
@@ -361,6 +412,11 @@ func (s *registrationSuite) TestFailedAuth(c *gc.C) {
 		},
 		ApplicationName: "application name",
 		ModelUUID:       "model uuid",
+		CharmInfo: &apicharms.CharmInfo{
+			Metrics: &charm.Metrics{
+				Plan: charm.PlanRequired,
+			},
+		},
 	}
 	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, gc.ErrorMatches, `authorization failed:.*`)

--- a/cmd/juju/application/register_test.go
+++ b/cmd/juju/application/register_test.go
@@ -15,9 +15,7 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
-	"github.com/juju/juju/api"
 	apicharms "github.com/juju/juju/api/charms"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmstore"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -65,14 +63,14 @@ func (s *registrationSuite) TestMeteredCharm(c *gc.C) {
 			},
 		},
 	}
-	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
+	err := s.register.RunPre(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.register.RunPost(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d, nil)
+	err = s.register.RunPost(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	authorization, err := json.Marshal([]byte("hello registration"))
 	authorization = append(authorization, byte(0xa))
 	s.stub.CheckCalls(c, []testing.StubCall{{
-		"APICall", []interface{}{"Charms", "IsMetered", params.CharmURL{URL: "cs:quantal/metered-1"}},
+		"IsMetered", []interface{}{"cs:quantal/metered-1"},
 	}, {
 		"Authorize", []interface{}{metricRegistrationPost{
 			ModelUUID:       "model uuid",
@@ -83,13 +81,11 @@ func (s *registrationSuite) TestMeteredCharm(c *gc.C) {
 			Limit:           "100",
 		}},
 	}, {
-		"APICall", []interface{}{"Application", "SetMetricCredentials", params.ApplicationMetricCredentials{
-			Creds: []params.ApplicationMetricCredential{params.ApplicationMetricCredential{
-				ApplicationName:   "application name",
-				MetricCredentials: authorization,
-			}},
+		"SetMetricCredentials", []interface{}{
+			"application name",
+			authorization,
 		}},
-	}})
+	})
 }
 
 func (s *registrationSuite) TestOptionalPlanMeteredCharm(c *gc.C) {
@@ -106,14 +102,14 @@ func (s *registrationSuite) TestOptionalPlanMeteredCharm(c *gc.C) {
 			},
 		},
 	}
-	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
+	err := s.register.RunPre(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.register.RunPost(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d, nil)
+	err = s.register.RunPost(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	authorization, err := json.Marshal([]byte("hello registration"))
 	authorization = append(authorization, byte(0xa))
 	s.stub.CheckCalls(c, []testing.StubCall{{
-		"APICall", []interface{}{"Charms", "IsMetered", params.CharmURL{URL: "cs:quantal/metered-1"}},
+		"IsMetered", []interface{}{"cs:quantal/metered-1"},
 	}, {
 		"Authorize", []interface{}{metricRegistrationPost{
 			ModelUUID:       "model uuid",
@@ -124,13 +120,11 @@ func (s *registrationSuite) TestOptionalPlanMeteredCharm(c *gc.C) {
 			Limit:           "100",
 		}},
 	}, {
-		"APICall", []interface{}{"Application", "SetMetricCredentials", params.ApplicationMetricCredentials{
-			Creds: []params.ApplicationMetricCredential{params.ApplicationMetricCredential{
-				ApplicationName:   "application name",
-				MetricCredentials: authorization,
-			}},
+		"SetMetricCredentials", []interface{}{
+			"application name",
+			authorization,
 		}},
-	}})
+	})
 }
 
 func (s *registrationSuite) TestPlanNotSpecifiedCharm(c *gc.C) {
@@ -147,14 +141,14 @@ func (s *registrationSuite) TestPlanNotSpecifiedCharm(c *gc.C) {
 			},
 		},
 	}
-	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
+	err := s.register.RunPre(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.register.RunPost(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d, nil)
+	err = s.register.RunPost(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	authorization, err := json.Marshal([]byte("hello registration"))
 	authorization = append(authorization, byte(0xa))
 	s.stub.CheckCalls(c, []testing.StubCall{{
-		"APICall", []interface{}{"Charms", "IsMetered", params.CharmURL{URL: "cs:quantal/metered-1"}},
+		"IsMetered", []interface{}{"cs:quantal/metered-1"},
 	}, {
 		"Authorize", []interface{}{metricRegistrationPost{
 			ModelUUID:       "model uuid",
@@ -165,13 +159,11 @@ func (s *registrationSuite) TestPlanNotSpecifiedCharm(c *gc.C) {
 			Limit:           "100",
 		}},
 	}, {
-		"APICall", []interface{}{"Application", "SetMetricCredentials", params.ApplicationMetricCredentials{
-			Creds: []params.ApplicationMetricCredential{params.ApplicationMetricCredential{
-				ApplicationName:   "application name",
-				MetricCredentials: authorization,
-			}},
+		"SetMetricCredentials", []interface{}{
+			"application name",
+			authorization,
 		}},
-	}})
+	})
 }
 
 func (s *registrationSuite) TestMeteredCharmAPIError(c *gc.C) {
@@ -189,10 +181,10 @@ func (s *registrationSuite) TestMeteredCharmAPIError(c *gc.C) {
 			},
 		},
 	}
-	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
+	err := s.register.RunPre(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, gc.ErrorMatches, `authorization failed: something failed`)
 	s.stub.CheckCalls(c, []testing.StubCall{{
-		"APICall", []interface{}{"Charms", "IsMetered", params.CharmURL{URL: "cs:quantal/metered-1"}},
+		"IsMetered", []interface{}{"cs:quantal/metered-1"},
 	}, {
 		"Authorize", []interface{}{metricRegistrationPost{
 			ModelUUID:       "model uuid",
@@ -225,7 +217,7 @@ func (s *registrationSuite) TestMeteredCharmInvalidAllocation(c *gc.C) {
 		AllocationSpec: "invalid allocation",
 	}
 
-	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
+	err := s.register.RunPre(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, gc.ErrorMatches, `invalid allocation, expecting <budget>:<limit>`)
 	s.stub.CheckNoCalls(c)
 }
@@ -244,16 +236,16 @@ func (s *registrationSuite) TestMeteredCharmDeployError(c *gc.C) {
 			},
 		},
 	}
-	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
+	err := s.register.RunPre(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, jc.ErrorIsNil)
 	deployError := errors.New("deployment failed")
-	err = s.register.RunPost(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d, deployError)
+	err = s.register.RunPost(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d, deployError)
 	c.Assert(err, jc.ErrorIsNil)
 	authorization, err := json.Marshal([]byte("hello registration"))
 	authorization = append(authorization, byte(0xa))
 	c.Assert(err, jc.ErrorIsNil)
 	s.stub.CheckCalls(c, []testing.StubCall{{
-		"APICall", []interface{}{"Charms", "IsMetered", params.CharmURL{URL: "cs:quantal/metered-1"}},
+		"IsMetered", []interface{}{"cs:quantal/metered-1"},
 	}, {
 		"Authorize", []interface{}{metricRegistrationPost{
 			ModelUUID:       "model uuid",
@@ -280,14 +272,14 @@ func (s *registrationSuite) TestMeteredLocalCharmWithPlan(c *gc.C) {
 			},
 		},
 	}
-	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
+	err := s.register.RunPre(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.register.RunPost(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d, nil)
+	err = s.register.RunPost(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	authorization, err := json.Marshal([]byte("hello registration"))
 	authorization = append(authorization, byte(0xa))
 	s.stub.CheckCalls(c, []testing.StubCall{{
-		"APICall", []interface{}{"Charms", "IsMetered", params.CharmURL{URL: "local:quantal/metered-1"}},
+		"IsMetered", []interface{}{"local:quantal/metered-1"},
 	}, {
 		"Authorize", []interface{}{metricRegistrationPost{
 			ModelUUID:       "model uuid",
@@ -298,12 +290,10 @@ func (s *registrationSuite) TestMeteredLocalCharmWithPlan(c *gc.C) {
 			Limit:           "100",
 		}},
 	}, {
-		"APICall", []interface{}{"Application", "SetMetricCredentials", params.ApplicationMetricCredentials{
-			Creds: []params.ApplicationMetricCredential{params.ApplicationMetricCredential{
-				ApplicationName:   "application name",
-				MetricCredentials: authorization,
-			}},
-		}},
+		"SetMetricCredentials", []interface{}{
+			"application name",
+			authorization,
+		},
 	}})
 }
 
@@ -326,14 +316,14 @@ func (s *registrationSuite) TestMeteredLocalCharmNoPlan(c *gc.C) {
 			},
 		},
 	}
-	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
+	err := s.register.RunPre(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.register.RunPost(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d, nil)
+	err = s.register.RunPost(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	authorization, err := json.Marshal([]byte("hello registration"))
 	authorization = append(authorization, byte(0xa))
 	s.stub.CheckCalls(c, []testing.StubCall{{
-		"APICall", []interface{}{"Charms", "IsMetered", params.CharmURL{URL: "local:quantal/metered-1"}},
+		"IsMetered", []interface{}{"local:quantal/metered-1"},
 	}, {
 		"Authorize", []interface{}{metricRegistrationPost{
 			ModelUUID:       "model uuid",
@@ -344,13 +334,11 @@ func (s *registrationSuite) TestMeteredLocalCharmNoPlan(c *gc.C) {
 			Limit:           "100",
 		}},
 	}, {
-		"APICall", []interface{}{"Application", "SetMetricCredentials", params.ApplicationMetricCredentials{
-			Creds: []params.ApplicationMetricCredential{params.ApplicationMetricCredential{
-				ApplicationName:   "application name",
-				MetricCredentials: authorization,
-			}},
+		"SetMetricCredentials", []interface{}{
+			"application name",
+			authorization,
 		}},
-	}})
+	})
 }
 
 func (s *registrationSuite) TestMeteredCharmNoPlanSet(c *gc.C) {
@@ -371,15 +359,15 @@ func (s *registrationSuite) TestMeteredCharmNoPlanSet(c *gc.C) {
 			},
 		},
 	}
-	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
+	err := s.register.RunPre(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.register.RunPost(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d, nil)
+	err = s.register.RunPost(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	authorization, err := json.Marshal([]byte("hello registration"))
 	authorization = append(authorization, byte(0xa))
 	c.Assert(err, jc.ErrorIsNil)
 	s.stub.CheckCalls(c, []testing.StubCall{{
-		"APICall", []interface{}{"Charms", "IsMetered", params.CharmURL{URL: "cs:quantal/metered-1"}},
+		"IsMetered", []interface{}{"cs:quantal/metered-1"},
 	}, {
 		"DefaultPlan", []interface{}{"cs:quantal/metered-1"},
 	}, {
@@ -392,12 +380,10 @@ func (s *registrationSuite) TestMeteredCharmNoPlanSet(c *gc.C) {
 			Limit:           "100",
 		}},
 	}, {
-		"APICall", []interface{}{"Application", "SetMetricCredentials", params.ApplicationMetricCredentials{
-			Creds: []params.ApplicationMetricCredential{params.ApplicationMetricCredential{
-				ApplicationName:   "application name",
-				MetricCredentials: authorization,
-			}},
-		}},
+		"SetMetricCredentials", []interface{}{
+			"application name",
+			authorization,
+		},
 	}})
 }
 
@@ -420,10 +406,10 @@ func (s *registrationSuite) TestMeteredCharmNoDefaultPlan(c *gc.C) {
 			},
 		},
 	}
-	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
+	err := s.register.RunPre(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, gc.ErrorMatches, `cs:quantal/metered-1 has no default plan. Try "juju deploy --plan <plan-name> with one of thisplan, thisotherplan"`)
 	s.stub.CheckCalls(c, []testing.StubCall{{
-		"APICall", []interface{}{"Charms", "IsMetered", params.CharmURL{URL: "cs:quantal/metered-1"}},
+		"IsMetered", []interface{}{"cs:quantal/metered-1"},
 	}, {
 		"DefaultPlan", []interface{}{"cs:quantal/metered-1"},
 	}, {
@@ -450,10 +436,10 @@ func (s *registrationSuite) TestMeteredCharmFailToQueryDefaultCharm(c *gc.C) {
 			},
 		},
 	}
-	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
+	err := s.register.RunPre(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, gc.ErrorMatches, `failed to query default plan:.*`)
 	s.stub.CheckCalls(c, []testing.StubCall{{
-		"APICall", []interface{}{"Charms", "IsMetered", params.CharmURL{URL: "cs:quantal/metered-1"}},
+		"IsMetered", []interface{}{"cs:quantal/metered-1"},
 	}, {
 		"DefaultPlan", []interface{}{"cs:quantal/metered-1"},
 	}})
@@ -473,13 +459,13 @@ func (s *registrationSuite) TestUnmeteredCharm(c *gc.C) {
 			},
 		},
 	}
-	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
+	err := s.register.RunPre(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, jc.ErrorIsNil)
 	s.stub.CheckCalls(c, []testing.StubCall{{
-		"APICall", []interface{}{"Charms", "IsMetered", params.CharmURL{URL: "cs:quantal/unmetered-1"}},
+		"IsMetered", []interface{}{"cs:quantal/unmetered-1"},
 	}})
 	s.stub.ResetCalls()
-	err = s.register.RunPost(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d, nil)
+	err = s.register.RunPost(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.stub.CheckCalls(c, []testing.StubCall{})
 }
@@ -499,13 +485,13 @@ func (s *registrationSuite) TestFailedAuth(c *gc.C) {
 			},
 		},
 	}
-	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
+	err := s.register.RunPre(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, gc.ErrorMatches, `authorization failed:.*`)
 	authorization, err := json.Marshal([]byte("hello registration"))
 	authorization = append(authorization, byte(0xa))
 	c.Assert(err, jc.ErrorIsNil)
 	s.stub.CheckCalls(c, []testing.StubCall{{
-		"APICall", []interface{}{"Charms", "IsMetered", params.CharmURL{URL: "cs:quantal/metered-1"}},
+		"IsMetered", []interface{}{"cs:quantal/metered-1"},
 	}, {
 		"Authorize", []interface{}{metricRegistrationPost{
 			ModelUUID:       "model uuid",
@@ -530,35 +516,35 @@ func (s *registrationSuite) TestPlanArgumentPlanRequiredInteraction(c *gc.C) {
 		about:        "deploy with --plan, required false",
 		planArgument: "plan",
 		planRequired: false,
-		apiCalls:     []string{"APICall", "Authorize"},
+		apiCalls:     []string{"IsMetered", "Authorize"},
 		err:          "",
 	}, {
 		about:        "deploy with --plan, required true",
 		planArgument: "plan",
 		planRequired: true,
-		apiCalls:     []string{"APICall", "Authorize"},
+		apiCalls:     []string{"IsMetered", "Authorize"},
 		err:          "",
 	}, {
 		about:        "deploy without --plan, required false with default plan",
 		planRequired: false,
-		apiCalls:     []string{"APICall"},
+		apiCalls:     []string{"IsMetered"},
 		err:          "",
 	}, {
 		about:        "deploy without --plan, required true with default plan",
 		planRequired: true,
-		apiCalls:     []string{"APICall", "DefaultPlan", "Authorize"},
+		apiCalls:     []string{"IsMetered", "DefaultPlan", "Authorize"},
 		err:          "",
 	}, {
 		about:         "deploy without --plan, required false with no default plan",
 		planRequired:  false,
 		noDefaultPlan: true,
-		apiCalls:      []string{"APICall"},
+		apiCalls:      []string{"IsMetered"},
 		err:           "",
 	}, {
 		about:         "deploy without --plan, required true with no default plan",
 		planRequired:  true,
 		noDefaultPlan: true,
-		apiCalls:      []string{"APICall", "DefaultPlan", "ListPlans"},
+		apiCalls:      []string{"IsMetered", "DefaultPlan", "ListPlans"},
 		err:           `cs:quantal/metered-1 has no default plan. Try "juju deploy --plan <plan-name> with one of thisplan, thisotherplan"`,
 	},
 	}
@@ -590,7 +576,7 @@ func (s *registrationSuite) TestPlanArgumentPlanRequiredInteraction(c *gc.C) {
 			},
 		}
 
-		err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
+		err := s.register.RunPre(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d)
 		if test.err != "" {
 			c.Assert(err, gc.ErrorMatches, test.err)
 		} else {
@@ -720,12 +706,12 @@ func (s *noPlanRegistrationSuite) TestOptionalPlanMeteredCharm(c *gc.C) {
 			},
 		},
 	}
-	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
+	err := s.register.RunPre(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.register.RunPost(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d, nil)
+	err = s.register.RunPost(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.stub.CheckCalls(c, []testing.StubCall{{
-		"APICall", []interface{}{"Charms", "IsMetered", params.CharmURL{URL: "cs:quantal/metered-1"}},
+		"IsMetered", []interface{}{"cs:quantal/metered-1"},
 	}})
 }
 
@@ -743,41 +729,29 @@ func (s *noPlanRegistrationSuite) TestPlanNotSpecifiedCharm(c *gc.C) {
 			},
 		},
 	}
-	err := s.register.RunPre(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d)
+	err := s.register.RunPre(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.register.RunPost(&mockAPIConnection{Stub: s.stub}, client, s.ctx, d, nil)
+	err = s.register.RunPost(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.stub.CheckCalls(c, []testing.StubCall{{
-		"APICall", []interface{}{"Charms", "IsMetered", params.CharmURL{URL: "cs:quantal/metered-1"}},
+		"IsMetered", []interface{}{"cs:quantal/metered-1"},
 	}})
 }
 
-type mockAPIConnection struct {
-	api.Connection
+type mockMeteredDeployAPI struct {
+	MeteredDeployAPI
 	*testing.Stub
 }
 
-func (*mockAPIConnection) BestFacadeVersion(facade string) int {
-	return 42
-}
-
-func (*mockAPIConnection) Close() error {
-	return nil
-}
-
-func (m *mockAPIConnection) APICall(objType string, version int, id, request string, parameters, response interface{}) error {
-	m.MethodCall(m, "APICall", objType, request, parameters)
-
-	switch request {
-	case "IsMetered":
-		parameters := parameters.(params.CharmURL)
-		response := response.(*params.IsMeteredResult)
-		if parameters.URL == "cs:quantal/metered-1" || parameters.URL == "local:quantal/metered-1" {
-			response.Metered = true
-		}
-	case "SetMetricCredentials":
-		response := response.(*params.ErrorResults)
-		response.Results = append(response.Results, params.ErrorResult{Error: nil})
+func (m *mockMeteredDeployAPI) IsMetered(charmURL string) (bool, error) {
+	m.AddCall("IsMetered", charmURL)
+	if charmURL == "cs:quantal/metered-1" || charmURL == "local:quantal/metered-1" {
+		return true, m.NextErr()
 	}
+	return false, m.NextErr()
+
+}
+func (m *mockMeteredDeployAPI) SetMetricCredentials(service string, credentials []byte) error {
+	m.AddCall("SetMetricCredentials", service, credentials)
 	return m.NextErr()
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -73,7 +73,7 @@ gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:
 gopkg.in/goose.v1	git	495e6fa2ab89bc5ed2c8e1bbcbc4c9e4a3c97d37	2016-03-17T17:25:46Z
 gopkg.in/ini.v1	git	776aa739ce9373377cd16f526cdf06cb4c89b40f	2016-02-22T23:24:41Z
 gopkg.in/juju/blobstore.v2	git	51fa6e26128d74e445c72d3a91af555151cc3654	2016-01-25T02:37:03Z
-gopkg.in/juju/charm.v6-unstable	git	a3bb92d047b0892452b6a39ece59b4d3a2ac35b9	2016-07-22T08:34:31Z
+gopkg.in/juju/charm.v6-unstable	git	70121953601b8bbdd8bb66e29e1bfddecd1005cc	2016-08-25T10:09:43Z
 gopkg.in/juju/charmrepo.v2-unstable	git	73c1113f7ddee0306f4b3c19773d35a3f153c04a	2016-08-11T14:04:21Z
 gopkg.in/juju/charmstore.v5-unstable	git	714c25cd43dbb8eb51f57a55d76d521fc2126455	2016-08-09T13:45:06Z
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z

--- a/testcharms/charm-repo/quantal/metered/metrics.yaml
+++ b/testcharms/charm-repo/quantal/metered/metrics.yaml
@@ -1,3 +1,4 @@
+plan: required
 metrics:
   pings:
     type: gauge

--- a/testcharms/charm-repo/quantal/metered/metrics.yaml
+++ b/testcharms/charm-repo/quantal/metered/metrics.yaml
@@ -1,4 +1,5 @@
-plan: required
+plan:
+  required: true
 metrics:
   pings:
     type: gauge

--- a/testcharms/charm.go
+++ b/testcharms/charm.go
@@ -19,6 +19,25 @@ import (
 // Repo provides access to the test charm repository.
 var Repo = testing.NewRepo("charm-repo", "quantal")
 
+// UploadCharmWithMeta pushes a new charm to the charmstore.
+// The uploaded charm takes the supplied charmURL with metadata.yaml and metrics.yaml
+// to define the charm, rather than relying on the charm to exist on disk.
+// This allows you to create charm definitions directly in yaml and have them uploaded
+// here for us in tests.
+//
+// For convenience the charm is also made public
+func UploadCharmWithMeta(c *gc.C, client *csclient.Client, charmURL, meta, metrics string, revision int) (*charm.URL, charm.Charm) {
+	ch := testing.NewCharm(c, testing.CharmSpec{
+		Meta:     meta,
+		Metrics:  metrics,
+		Revision: revision,
+	})
+	chURL, err := client.UploadCharm(charm.MustParseURL(charmURL), ch)
+	c.Assert(err, jc.ErrorIsNil)
+	SetPublic(c, client, chURL)
+	return chURL, ch
+}
+
 // UploadCharm uploads a charm using the given charm store client, and returns
 // the resulting charm URL and charm.
 //


### PR DESCRIPTION
(Review request: http://reviews.vapour.ws/r/5535/)