### PR TITLE
Refactor metricsmanager facade to send metrics for specified model.

### DIFF
--- a/apiserver/common/modeldestroy.go
+++ b/apiserver/common/modeldestroy.go
@@ -65,6 +65,11 @@ func destroyModel(st ModelManagerBackend, modelTag names.ModelTag, destroyHosted
 			if err = check.DestroyAllowed(); err != nil {
 				return errors.Trace(err)
 			}
+			err = sendMetrics(modelSt)
+			if err != nil {
+				logger.Errorf("failed to send leftover metrics: %v", err)
+			}
+
 		}
 	} else {
 		check := NewBlockChecker(st)
@@ -87,7 +92,6 @@ func destroyModel(st ModelManagerBackend, modelTag names.ModelTag, destroyHosted
 			return errors.Trace(err)
 		}
 	}
-
 	err = sendMetrics(st)
 	if err != nil {
 		logger.Errorf("failed to send leftover metrics: %v", err)

--- a/apiserver/common/modeldestroy_test.go
+++ b/apiserver/common/modeldestroy_test.go
@@ -93,7 +93,9 @@ func (s *destroyModelSuite) TestMetrics(c *gc.C) {
 	err := common.DestroyModel(s.modelManager, s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 
-	metricSender.CheckCalls(c, []jtesting.StubCall{{FuncName: "SendMetrics"}})
+	metricSender.CheckCalls(c, []jtesting.StubCall{{
+		FuncName: "SendMetrics",
+	}})
 }
 
 func (s *destroyModelSuite) TestDestroyModel(c *gc.C) {

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -45,7 +45,6 @@ type ModelManagerBackend interface {
 	UserAccess(names.UserTag, names.Tag) (description.UserAccess, error)
 	ControllerUUID() string
 	ControllerTag() names.ControllerTag
-	ModelTag() names.ModelTag
 	Export() (description.Model, error)
 	SetUserAccess(subject names.UserTag, target names.Tag, access description.Access) (description.UserAccess, error)
 	LastModelConnection(user names.UserTag) (time.Time, error)

--- a/apiserver/metricsender/metricsender.go
+++ b/apiserver/metricsender/metricsender.go
@@ -111,7 +111,7 @@ func SendMetrics(st MetricsSenderBackend, sender MetricSender, batchSize int) er
 	if err != nil {
 		return errors.Trace(err)
 	}
-	logger.Infof("metrics collection summary: sent:%d unsent:%d (%d sent metrics stored)", sent, unsent, sentStored)
+	logger.Infof("metrics collection summary for %s: sent:%d unsent:%d (%d sent metrics stored)", st.ModelTag(), sent, unsent, sentStored)
 
 	return nil
 }

--- a/apiserver/metricsender/stateinterface.go
+++ b/apiserver/metricsender/stateinterface.go
@@ -6,6 +6,8 @@
 package metricsender
 
 import (
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/state"
 )
 
@@ -20,4 +22,5 @@ type MetricsSenderBackend interface {
 	CountOfUnsentMetrics() (int, error)
 	CountOfSentMetrics() (int, error)
 	Unit(name string) (*state.Unit, error)
+	ModelTag() names.ModelTag
 }

--- a/apiserver/metricsmanager/metricsmanager.go
+++ b/apiserver/metricsmanager/metricsmanager.go
@@ -95,9 +95,19 @@ func (api *MetricsManagerAPI) CleanupOldMetrics(args params.Entities) (params.Er
 			result.Results[i].Error = common.ServerError(common.ErrPerm)
 			continue
 		}
-		err = api.state.CleanupOldMetrics()
+		modelState := api.state
+		if tag != api.state.ModelTag() {
+			modelState, err = api.state.ForModel(tag)
+			if err != nil {
+				err = errors.Annotatef(err, "failed to access state for %s", tag)
+				result.Results[i].Error = common.ServerError(err)
+				continue
+			}
+		}
+
+		err = modelState.CleanupOldMetrics()
 		if err != nil {
-			err = errors.Annotate(err, "failed to cleanup old metrics")
+			err = errors.Annotatef(err, "failed to cleanup old metrics for %s", tag)
 			result.Results[i].Error = common.ServerError(err)
 		}
 	}
@@ -126,9 +136,19 @@ func (api *MetricsManagerAPI) SendMetrics(args params.Entities) (params.ErrorRes
 			result.Results[i].Error = common.ServerError(common.ErrPerm)
 			continue
 		}
-		err = metricsender.SendMetrics(api.state, sender, maxBatchesPerSend)
+		modelState := api.state
+		if tag != api.state.ModelTag() {
+			modelState, err = api.state.ForModel(tag)
+			if err != nil {
+				err = errors.Annotatef(err, "failed to access state for %s", tag)
+				result.Results[i].Error = common.ServerError(err)
+				continue
+			}
+		}
+
+		err = metricsender.SendMetrics(modelState, sender, maxBatchesPerSend)
 		if err != nil {
-			err = errors.Annotate(err, "failed to send metrics")
+			err = errors.Annotatef(err, "failed to send metrics for %s", tag)
 			logger.Warningf("%v", err)
 			result.Results[i].Error = common.ServerError(err)
 			continue

--- a/apiserver/metricsmanager/metricsmanager_test.go
+++ b/apiserver/metricsmanager/metricsmanager_test.go
@@ -4,6 +4,7 @@
 package metricsmanager_test
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/juju/errors"
@@ -172,7 +173,9 @@ func (s *metricsManagerSuite) TestMeterStatusOnConsecutiveErrors(c *gc.C) {
 	}}
 	result, err := s.metricsmanager.SendMetrics(args)
 	c.Assert(err, jc.ErrorIsNil)
-	expectedError := params.ErrorResult{Error: apiservertesting.PrefixedError("failed to send metrics: ", "an error")}
+	expectedError := params.ErrorResult{Error: apiservertesting.PrefixedError(
+		fmt.Sprintf("failed to send metrics for %s: ", s.State.ModelTag()),
+		"an error")}
 	c.Assert(result.Results[0], jc.DeepEquals, expectedError)
 	mm, err := s.State.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/metrics.go
+++ b/state/metrics.go
@@ -241,6 +241,7 @@ func (st *State) CleanupOldMetrics() error {
 	metricsW := metrics.Writeable()
 	// TODO (mattyw) iter over this.
 	info, err := metricsW.RemoveAll(bson.M{
+		"model-uuid":  st.ModelUUID(),
 		"sent":        true,
 		"delete-time": bson.M{"$lte": now},
 	})
@@ -257,7 +258,8 @@ func (st *State) MetricsToSend(batchSize int) ([]*MetricBatch, error) {
 	c, closer := st.getCollection(metricsC)
 	defer closer()
 	err := c.Find(bson.M{
-		"sent": false,
+		"model-uuid": st.ModelUUID(),
+		"sent":       false,
 	}).Limit(batchSize).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -278,7 +280,8 @@ func (st *State) CountOfUnsentMetrics() (int, error) {
 	c, closer := st.getCollection(metricsC)
 	defer closer()
 	return c.Find(bson.M{
-		"sent": false,
+		"model-uuid": st.ModelUUID(),
+		"sent":       false,
 	}).Count()
 }
 
@@ -289,7 +292,8 @@ func (st *State) CountOfSentMetrics() (int, error) {
 	c, closer := st.getCollection(metricsC)
 	defer closer()
 	return c.Find(bson.M{
-		"sent": true,
+		"model-uuid": st.ModelUUID(),
+		"sent":       true,
 	}).Count()
 }
 


### PR DESCRIPTION
This pull request enables more fine grained control over which metrics are sent.

(Review request: http://reviews.vapour.ws/r/5536/)