### PR TITLE
state: refcount charms

### DIFF
--- a/apiserver/migrationtarget/migrationtarget.go
+++ b/apiserver/migrationtarget/migrationtarget.go
@@ -66,6 +66,8 @@ func (api *API) Import(serialized params.SerializedModel) error {
 	}
 	defer st.Close()
 	// TODO(mjs) - post import checks
+	// NOTE(fwereade) - checks here would be sensible, but we will
+	// also need to check after the binaries are imported too.
 	return err
 }
 
@@ -109,5 +111,6 @@ func (api *API) Activate(args params.ModelArgs) error {
 		return errors.Trace(err)
 	}
 
+	// TODO(fwereade) - need to validate binaries here.
 	return model.SetMigrationMode(state.MigrationModeNone)
 }

--- a/state/charmref.go
+++ b/state/charmref.go
@@ -1,0 +1,60 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/mgo.v2/txn"
+)
+
+func charmIncRefOps(st modelBackend, appName string, curl *charm.URL, canCreate bool) ([]txn.Op, error) {
+	refcounts, closer := st.getCollection(refcountsC)
+	defer closer()
+
+	getIncRefOp := nsRefcounts.CreateOrIncRefOp
+	if !canCreate {
+		getIncRefOp = nsRefcounts.StrictIncRefOp
+	}
+
+	settingsKey := applicationSettingsKey(appName, curl)
+	settingsOp, err := getIncRefOp(refcounts, settingsKey)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	charmKey := charmGlobalKey(curl)
+	charmOp, err := getIncRefOp(refcounts, charmKey)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return []txn.Op{
+		settingsOp,
+		charmOp,
+	}, nil
+}
+
+func charmDecRefOps(st modelBackend, appName string, curl *charm.URL) ([]txn.Op, error) {
+	refcounts, closer := st.getCollection(refcountsC)
+	defer closer()
+
+	charmKey := charmGlobalKey(curl)
+	charmOp, err := nsRefcounts.AliveDecRefOp(refcounts, charmKey)
+
+	settingsKey := applicationSettingsKey(appName, curl)
+	settingsOp, isFinal, err := nsRefcounts.DyingDecRefOp(refcounts, settingsKey)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	ops := []txn.Op{settingsOp, charmOp}
+	if isFinal {
+		ops = append(ops, txn.Op{
+			C:      settingsC,
+			Id:     settingsKey,
+			Remove: true,
+		})
+	}
+	return ops, nil
+}

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -625,7 +625,7 @@ func (i *importer) application(s description.Application) error {
 	statusDoc := i.makeStatusDoc(status)
 	// TODO: update never set malarky... maybe...
 
-	ops := addApplicationOps(i.st, addApplicationOpsArgs{
+	ops, err := addApplicationOps(i.st, addApplicationOpsArgs{
 		applicationDoc:     sdoc,
 		statusDoc:          statusDoc,
 		constraints:        i.constraints(s.Constraints()),
@@ -633,6 +633,9 @@ func (i *importer) application(s description.Application) error {
 		settings:           s.Settings(),
 		leadershipSettings: s.LeadershipSettings(),
 	})
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	if err := i.st.runTransaction(ops); err != nil {
 		return errors.Trace(err)
@@ -713,7 +716,7 @@ func (i *importer) unit(s description.Application, u description.Unit) error {
 		StatusInfo: workloadVersion,
 	}
 
-	ops := addUnitOps(i.st, addUnitOpsArgs{
+	ops, err := addUnitOps(i.st, addUnitOpsArgs{
 		unitDoc:            udoc,
 		agentStatusDoc:     agentStatusDoc,
 		workloadStatusDoc:  workloadStatusDoc,
@@ -723,6 +726,9 @@ func (i *importer) unit(s description.Application, u description.Unit) error {
 			Info: u.MeterStatusInfo(),
 		},
 	})
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	// If the unit is a principal, add it to its machine.
 	if u.Principal().Id() == "" {

--- a/state/refcounts_ns.go
+++ b/state/refcounts_ns.go
@@ -41,6 +41,17 @@ var nsRefcounts = nsRefcounts_{}
 // nsRefcounts_ backs nsRefcounts.
 type nsRefcounts_ struct{}
 
+// LazyCreateOp returns a txn.Op that creates a refcount document; or
+// false if the document already exists.
+func (ns nsRefcounts_) LazyCreateOp(coll mongo.Collection, key string) (txn.Op, bool, error) {
+	if exists, err := ns.exists(coll, key); err != nil {
+		return txn.Op{}, false, errors.Trace(err)
+	} else if exists {
+		return txn.Op{}, false, nil
+	}
+	return ns.JustCreateOp(coll.Name(), key, 0), true, nil
+}
+
 // StrictCreateOp returns a txn.Op that creates a refcount document as
 // configured, or an error if the document already exists.
 func (ns nsRefcounts_) StrictCreateOp(coll mongo.Collection, key string, value int) (txn.Op, error) {

--- a/state/state.go
+++ b/state/state.go
@@ -1090,18 +1090,21 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 
 	// The addServiceOps does not include the environment alive assertion,
 	// so we add it here.
-	ops := append(
-		[]txn.Op{
-			assertModelActiveOp(st.ModelUUID()),
-			endpointBindingsOp,
-		},
-		addApplicationOps(st, addApplicationOpsArgs{
-			applicationDoc: svcDoc,
-			statusDoc:      statusDoc,
-			constraints:    args.Constraints,
-			storage:        args.Storage,
-			settings:       map[string]interface{}(args.Settings),
-		})...)
+	ops := []txn.Op{
+		assertModelActiveOp(st.ModelUUID()),
+		endpointBindingsOp,
+	}
+	addOps, err := addApplicationOps(st, addApplicationOpsArgs{
+		applicationDoc: svcDoc,
+		statusDoc:      statusDoc,
+		constraints:    args.Constraints,
+		storage:        args.Storage,
+		settings:       map[string]interface{}(args.Settings),
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	ops = append(ops, addOps...)
 
 	// Collect peer relation addition operations.
 	//


### PR DESCRIPTION
We now reference count charms, and create the refcounts lazily to avoid
issues when migrating (in which the charms themselves are not
transferred until after the rest of the data that technically depends on
them.)

(Review request: http://reviews.vapour.ws/r/5539/)