### PR TITLE
Fix model permissions not always working.

### DIFF
--- a/apiserver/authhttp_test.go
+++ b/apiserver/authhttp_test.go
@@ -235,10 +235,11 @@ func (s *authHttpSuite) setupOtherModel(c *gc.C) *state.State {
 	envState := s.Factory.MakeModel(c, nil)
 	s.AddCleanup(func(*gc.C) { envState.Close() })
 	user := s.Factory.MakeUser(c, nil)
-	_, err := envState.AddModelUser(state.UserAccessSpec{
-		User:      user.UserTag(),
-		CreatedBy: s.userTag,
-		Access:    description.ReadAccess})
+	_, err := envState.AddModelUser(envState.ModelUUID(),
+		state.UserAccessSpec{
+			User:      user.UserTag(),
+			CreatedBy: s.userTag,
+			Access:    description.ReadAccess})
 	c.Assert(err, jc.ErrorIsNil)
 	s.userTag = user.UserTag()
 	s.password = "password"

--- a/apiserver/client/backend.go
+++ b/apiserver/client/backend.go
@@ -59,7 +59,7 @@ type Backend interface {
 	Charm(*charm.URL) (*state.Charm, error)
 	LatestPlaceholderCharm(*charm.URL) (*state.Charm, error)
 	AddRelation(...state.Endpoint) (*state.Relation, error)
-	AddModelUser(state.UserAccessSpec) (description.UserAccess, error)
+	AddModelUser(string, state.UserAccessSpec) (description.UserAccess, error)
 	AddControllerUser(state.UserAccessSpec) (description.UserAccess, error)
 	RemoveUserAccess(names.UserTag, names.Tag) error
 	Watch() *state.Multiwatcher

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -40,7 +40,7 @@ type ModelManagerBackend interface {
 	GetModel(names.ModelTag) (Model, error)
 	Model() (Model, error)
 	AllModels() ([]Model, error)
-	AddModelUser(state.UserAccessSpec) (description.UserAccess, error)
+	AddModelUser(string, state.UserAccessSpec) (description.UserAccess, error)
 	AddControllerUser(state.UserAccessSpec) (description.UserAccess, error)
 	RemoveUserAccess(names.UserTag, names.Tag) error
 	UserAccess(names.UserTag, names.Tag) (description.UserAccess, error)

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -79,11 +79,12 @@ func (s *controllerSuite) TestAllModels(c *gc.C) {
 	st := s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "user", Owner: remoteUserTag})
 	defer st.Close()
-	st.AddModelUser(state.UserAccessSpec{
-		User:        admin.UserTag(),
-		CreatedBy:   remoteUserTag,
-		DisplayName: "Foo Bar",
-		Access:      description.ReadAccess})
+	st.AddModelUser(st.ModelUUID(),
+		state.UserAccessSpec{
+			User:        admin.UserTag(),
+			CreatedBy:   remoteUserTag,
+			DisplayName: "Foo Bar",
+			Access:      description.ReadAccess})
 
 	s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "no-access", Owner: remoteUserTag}).Close()

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -367,8 +367,8 @@ func (st *mockState) Close() error {
 	return st.NextErr()
 }
 
-func (st *mockState) AddModelUser(spec state.UserAccessSpec) (description.UserAccess, error) {
-	st.MethodCall(st, "AddModelUser", spec)
+func (st *mockState) AddModelUser(modelUUID string, spec state.UserAccessSpec) (description.UserAccess, error) {
+	st.MethodCall(st, "AddModelUser", modelUUID, spec)
 	return description.UserAccess{}, st.NextErr()
 }
 

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -1073,9 +1073,10 @@ func (s *modelManagerStateSuite) TestGrantModelInvalidUserTag(c *gc.C) {
 
 		args := params.ModifyModelAccessRequest{
 			Changes: []params.ModifyModelAccess{{
-				UserTag: testParam.tag,
-				Action:  params.GrantModelAccess,
-				Access:  params.ModelReadAccess,
+				ModelTag: "model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
+				UserTag:  testParam.tag,
+				Action:   params.GrantModelAccess,
+				Access:   params.ModelReadAccess,
 			}}}
 
 		result, err := s.modelmanager.ModifyModelAccess(args)

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -183,15 +183,6 @@ func allCollections() collectionSchema {
 			indexes: bakerystorage.MongoIndexes(),
 		},
 
-		// -----------------
-
-		// Local collections
-		// =================
-
-		// This collection holds users related to a model and will be usde as one
-		// of the intersection axis of permissionsC
-		modelUsersC: {},
-
 		// This collection is basically a standard SQL intersection table; it
 		// references the global records of the users allowed access to a
 		// given operation.
@@ -204,6 +195,15 @@ func allCollections() collectionSchema {
 		modelUserLastConnectionC: {
 			rawAccess: true,
 		},
+
+		// -----------------
+
+		// Local collections
+		// =================
+
+		// This collection holds users related to a model and will be used as one
+		// of the intersection axis of permissionsC
+		modelUsersC: {},
 
 		// This collection contains governors that prevent certain kinds of
 		// changes from being accepted.

--- a/state/binarystorage.go
+++ b/state/binarystorage.go
@@ -54,7 +54,7 @@ func (st *State) GUIStorage() (binarystorage.StorageCloser, error) {
 }
 
 func (st *State) newBinaryStorageCloser(collectionName, uuid string) binarystorage.StorageCloser {
-	db, closer1 := st.database.CopySession()
+	db, closer1 := st.database.Copy()
 	metadataCollection, closer2 := db.GetCollection(collectionName)
 	txnRunner, closer3 := db.TransactionRunner()
 	closer := func() {

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -187,7 +187,7 @@ func (s *MigrationExportSuite) TestModelUsers(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	bobTag := names.NewUserTag("bob@external")
-	bob, err := s.State.AddModelUser(state.UserAccessSpec{
+	bob, err := s.State.AddModelUser(s.State.ModelUUID(), state.UserAccessSpec{
 		User:      bobTag,
 		CreatedBy: s.Owner,
 		Access:    description.ReadAccess,

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -147,7 +147,7 @@ func (s *MigrationImportSuite) newModelUser(c *gc.C, name string, readOnly bool,
 	if readOnly {
 		access = description.ReadAccess
 	}
-	user, err := s.State.AddModelUser(state.UserAccessSpec{
+	user, err := s.State.AddModelUser(s.State.ModelUUID(), state.UserAccessSpec{
 		User:      names.NewUserTag(name),
 		CreatedBy: s.Owner,
 		Access:    access,

--- a/state/model.go
+++ b/state/model.go
@@ -321,6 +321,10 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
+	_, err = newSt.SetUserAccess(newModel.Owner(), newModel.ModelTag(), description.AdminAccess)
+	if err != nil {
+		return nil, nil, errors.Annotate(err, "granting admin permission to the owner")
+	}
 
 	return newModel, newSt, nil
 }

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -30,12 +30,12 @@ type modelUserLastConnectionDoc struct {
 }
 
 // setModelAccess changes the user's access permissions on the model.
-func (st *State) setModelAccess(access description.Access, userGlobalKey string) error {
+func (st *State) setModelAccess(access description.Access, userGlobalKey, modelUUID string) error {
 	if err := description.ValidateModelAccess(access); err != nil {
 		return errors.Trace(err)
 	}
-	op := updatePermissionOp(modelKey(st.ModelUUID()), userGlobalKey, access)
-	err := st.runTransaction([]txn.Op{op})
+	op := updatePermissionOp(modelKey(modelUUID), userGlobalKey, access)
+	err := st.runTransactionFor(modelUUID, []txn.Op{op})
 	if err == txn.ErrAborted {
 		return errors.NotFoundf("existing permissions")
 	}
@@ -104,15 +104,18 @@ func (st *State) updateLastModelConnection(user names.UserTag, when time.Time) e
 }
 
 // ModelUser a model userAccessDoc.
-func (st *State) modelUser(user names.UserTag) (userAccessDoc, error) {
+func (st *State) modelUser(modelUUID string, user names.UserTag) (userAccessDoc, error) {
 	modelUser := userAccessDoc{}
-	modelUsers, closer := st.getCollection(modelUsersC)
+	modelUsers, closer := st.getCollectionFor(modelUUID, modelUsersC)
 	defer closer()
 
 	username := strings.ToLower(user.Canonical())
 	err := modelUsers.FindId(username).One(&modelUser)
 	if err == mgo.ErrNotFound {
 		return userAccessDoc{}, errors.NotFoundf("model user %q", username)
+	}
+	if err != nil {
+		return userAccessDoc{}, errors.Trace(err)
 	}
 	// DateCreated is inserted as UTC, but read out as local time. So we
 	// convert it back to UTC here.
@@ -130,6 +133,7 @@ func createModelUserOps(modelUUID string, user, createdBy names.UserTag, display
 		CreatedBy:   creatorname,
 		DateCreated: dateCreated,
 	}
+
 	ops := []txn.Op{
 		createPermissionOp(modelKey(modelUUID), userGlobalKey(userAccessID(user)), access),
 		{
@@ -139,7 +143,6 @@ func createModelUserOps(modelUUID string, user, createdBy names.UserTag, display
 			Insert: doc,
 		},
 	}
-
 	return ops
 }
 

--- a/state/state.go
+++ b/state/state.go
@@ -474,7 +474,7 @@ func (st *State) getTxnLogCollection() *mgo.Collection {
 // with various collections in a single session, so don't want to call
 // getCollection multiple times.
 func (st *State) newDB() (Database, func()) {
-	return st.database.CopySession()
+	return st.database.Copy()
 }
 
 // Ping probes the state's database connection to ensure

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2396,11 +2396,13 @@ func (s *StateSuite) insertFakeModelDocs(c *gc.C, st *state.State) string {
 
 	// Add a model user whose permissions should get removed
 	// when the model is.
-	_, err = s.State.AddModelUser(state.UserAccessSpec{
-		User:      names.NewUserTag("amelia@external"),
-		CreatedBy: s.Owner,
-		Access:    description.ReadAccess,
-	})
+	_, err = s.State.AddModelUser(
+		s.State.ModelUUID(),
+		state.UserAccessSpec{
+			User:      names.NewUserTag("amelia@external"),
+			CreatedBy: s.Owner,
+			Access:    description.ReadAccess,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 
 	return state.UserModelNameIndex(model.Owner().Canonical(), model.Name())

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -458,7 +458,7 @@ func (s *upgradesSuite) setupAddDefaultEndpointBindingsToServices(c *gc.C) []*Ap
 	stateOwner, err := s.state.AddUser("bob", "notused", "notused", "bob")
 	c.Assert(err, jc.ErrorIsNil)
 	ownerTag := stateOwner.UserTag()
-	_, err = s.state.AddModelUser(UserAccessSpec{
+	_, err = s.state.AddModelUser(s.state.ModelUUID(), UserAccessSpec{
 		User:        ownerTag,
 		CreatedBy:   ownerTag,
 		DisplayName: "",

--- a/state/useraccess.go
+++ b/state/useraccess.go
@@ -33,12 +33,22 @@ type UserAccessSpec struct {
 	Access      description.Access
 }
 
-// AddModelUser adds a new user for the current model to the database.
-func (st *State) AddModelUser(spec UserAccessSpec) (description.UserAccess, error) {
+// userAccessTarget defines the target of a user access granting.
+type userAccessTarget struct {
+	uuid      string
+	globalKey string
+}
+
+// AddModelUser adds a new user for the model identified by modelUUID to the database.
+func (st *State) AddModelUser(modelUUID string, spec UserAccessSpec) (description.UserAccess, error) {
 	if err := description.ValidateModelAccess(spec.Access); err != nil {
 		return description.UserAccess{}, errors.Annotate(err, "adding model user")
 	}
-	return st.addUserAccess(spec, modelGlobalKey)
+	target := userAccessTarget{
+		uuid:      modelUUID,
+		globalKey: modelGlobalKey,
+	}
+	return st.addUserAccess(spec, target)
 }
 
 // AddControllerUser adds a new user for the curent controller to the database.
@@ -46,10 +56,10 @@ func (st *State) AddControllerUser(spec UserAccessSpec) (description.UserAccess,
 	if err := description.ValidateControllerAccess(spec.Access); err != nil {
 		return description.UserAccess{}, errors.Annotate(err, "adding controller user")
 	}
-	return st.addUserAccess(spec, controllerGlobalKey)
+	return st.addUserAccess(spec, userAccessTarget{globalKey: controllerGlobalKey})
 }
 
-func (st *State) addUserAccess(spec UserAccessSpec, targetGlobalKey string) (description.UserAccess, error) {
+func (st *State) addUserAccess(spec UserAccessSpec, target userAccessTarget) (description.UserAccess, error) {
 	// Ensure local user exists in state before adding them as an model user.
 	if spec.User.IsLocal() {
 		localUser, err := st.User(spec.User)
@@ -72,16 +82,16 @@ func (st *State) addUserAccess(spec UserAccessSpec, targetGlobalKey string) (des
 		err       error
 		targetTag names.Tag
 	)
-	switch targetGlobalKey {
+	switch target.globalKey {
 	case modelGlobalKey:
 		ops = createModelUserOps(
-			st.ModelUUID(),
+			target.uuid,
 			spec.User,
 			spec.CreatedBy,
 			spec.DisplayName,
 			nowToTheSecond(),
 			spec.Access)
-		targetTag = st.ModelTag()
+		targetTag = names.NewModelTag(target.uuid)
 	case controllerGlobalKey:
 		ops = createControllerUserOps(
 			st.ControllerUUID(),
@@ -90,11 +100,11 @@ func (st *State) addUserAccess(spec UserAccessSpec, targetGlobalKey string) (des
 			spec.DisplayName,
 			nowToTheSecond(),
 			spec.Access)
-		targetTag = names.NewControllerTag(st.ControllerUUID())
+		targetTag = st.ControllerTag()
 	default:
-		return description.UserAccess{}, errors.NotSupportedf("user access global key %q", targetGlobalKey)
+		return description.UserAccess{}, errors.NotSupportedf("user access global key %q", target.globalKey)
 	}
-	err = st.runTransaction(ops)
+	err = st.runTransactionFor(target.uuid, ops)
 	if err == txn.ErrAborted {
 		err = errors.AlreadyExistsf("user access %q", spec.User.Canonical())
 	}
@@ -113,7 +123,7 @@ func userAccessID(user names.UserTag) string {
 // NewModelUserAccess returns a new description.UserAccess for the given userDoc and
 // current Model.
 func NewModelUserAccess(st *State, userDoc userAccessDoc) (description.UserAccess, error) {
-	perm, err := st.userPermission(modelKey(st.ModelUUID()), userGlobalKey(strings.ToLower(userDoc.UserName)))
+	perm, err := st.userPermission(modelKey(userDoc.ObjectUUID), userGlobalKey(strings.ToLower(userDoc.UserName)))
 	if err != nil {
 		return description.UserAccess{}, errors.Annotate(err, "obtaining model permission")
 	}
@@ -158,7 +168,7 @@ func (st *State) UserAccess(subject names.UserTag, target names.Tag) (descriptio
 	)
 	switch target.Kind() {
 	case names.ModelTagKind:
-		userDoc, err = st.modelUser(subject)
+		userDoc, err = st.modelUser(target.Id(), subject)
 		if err == nil {
 			return NewModelUserAccess(st, userDoc)
 		}
@@ -181,7 +191,7 @@ func (st *State) SetUserAccess(subject names.UserTag, target names.Tag, access d
 	}
 	switch target.Kind() {
 	case names.ModelTagKind:
-		err = st.setModelAccess(access, userGlobalKey(userAccessID(subject)))
+		err = st.setModelAccess(access, userGlobalKey(userAccessID(subject)), target.Id())
 	case names.ControllerTagKind:
 		err = st.setControllerAccess(access, userGlobalKey(userAccessID(subject)))
 	default:

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -189,7 +189,7 @@ func (factory *Factory) MakeUser(c *gc.C, params *UserParams) *state.User {
 		params.Name, params.DisplayName, params.Password, creatorUserTag.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	if !params.NoModelUser {
-		_, err := factory.st.AddModelUser(state.UserAccessSpec{
+		_, err := factory.st.AddModelUser(factory.st.ModelUUID(), state.UserAccessSpec{
 			User:        user.UserTag(),
 			CreatedBy:   names.NewUserTag(user.CreatedBy()),
 			DisplayName: params.DisplayName,
@@ -228,7 +228,7 @@ func (factory *Factory) MakeModelUser(c *gc.C, params *ModelUserParams) descript
 		params.CreatedBy = env.Owner()
 	}
 	createdByUserTag := params.CreatedBy.(names.UserTag)
-	modelUser, err := factory.st.AddModelUser(state.UserAccessSpec{
+	modelUser, err := factory.st.AddModelUser(factory.st.ModelUUID(), state.UserAccessSpec{
 		User:        names.NewUserTag(params.User),
 		CreatedBy:   createdByUserTag,
 		DisplayName: params.DisplayName,


### PR DESCRIPTION
modelUserC collection, being a local collection had the ids
sometimes wrongly marked for the controller model instead
of the model of the permission and subsequently the permissions
where not always taken in account.
modelUserC now became a global collection and the correct modelUUID
is ensured by hand upon insertion/retrieval.

(Review request: http://reviews.vapour.ws/r/5542/)