### PR TITLE
Add migration prechecks for the target controller

### DIFF
--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -119,6 +119,20 @@ func (c *Client) SetStatusMessage(message string) error {
 	return c.caller.FacadeCall("SetStatusMessage", args, nil)
 }
 
+// ModelInfo return basic information about the model to migrated.
+func (c *Client) ModelInfo() (migration.ModelInfo, error) {
+	var info params.MigrationModelInfo
+	err := c.caller.FacadeCall("ModelInfo", nil, &info)
+	if err != nil {
+		return migration.ModelInfo{}, errors.Trace(err)
+	}
+	return migration.ModelInfo{
+		UUID:         info.UUID,
+		Name:         info.Name,
+		AgentVersion: info.AgentVersion,
+	}, nil
+}
+
 // Prechecks verifies that the source controller and model are healthy
 // and able to participate in a migration.
 func (c *Client) Prechecks() error {

--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -10,46 +10,33 @@ import (
 	"github.com/juju/juju/apiserver/params"
 )
 
-// Client describes the client side API for the MigrationTarget
-// facade. It is called by the migration master worker to talk to the
-// target controller during a migration.
-type Client interface {
-	// Import takes a serialized model and imports it into the target
-	// controller.
-	Import([]byte) error
-
-	// Abort removes all data relating to a previously imported
-	// model.
-	Abort(string) error
-
-	// Activate marks a migrated model as being ready to use.
-	Activate(string) error
-}
-
 // NewClient returns a new Client based on an existing API connection.
-func NewClient(caller base.APICaller) Client {
-	return &client{base.NewFacadeCaller(caller, "MigrationTarget")}
+func NewClient(caller base.APICaller) *Client {
+	return &Client{base.NewFacadeCaller(caller, "MigrationTarget")}
 }
 
-// client implements Client.
-type client struct {
+// Client is the client-side API for the MigrationTarget facade. It is
+// used by the migrationmaster worker when talking to the target
+// controller during a migration.
+type Client struct {
 	caller base.FacadeCaller
 }
 
-// Import implements Client.
-func (c *client) Import(bytes []byte) error {
+// Import takes a serialized model and imports it into the target
+// controller.
+func (c *Client) Import(bytes []byte) error {
 	serialized := params.SerializedModel{Bytes: bytes}
 	return c.caller.FacadeCall("Import", serialized, nil)
 }
 
-// Abort implements Client.
-func (c *client) Abort(modelUUID string) error {
+// Abort removes all data relating to a previously imported model.
+func (c *Client) Abort(modelUUID string) error {
 	args := params.ModelArgs{ModelTag: names.NewModelTag(modelUUID).String()}
 	return c.caller.FacadeCall("Abort", args, nil)
 }
 
-// Activate implements Client.
-func (c *client) Activate(modelUUID string) error {
+// Activate marks a migrated model as being ready to use.
+func (c *Client) Activate(modelUUID string) error {
 	args := params.ModelArgs{ModelTag: names.NewModelTag(modelUUID).String()}
 	return c.caller.FacadeCall("Activate", args, nil)
 }

--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/version"
 )
 
 // NewClient returns a new Client based on an existing API connection.
@@ -20,6 +21,13 @@ func NewClient(caller base.APICaller) *Client {
 // controller during a migration.
 type Client struct {
 	caller base.FacadeCaller
+}
+
+func (c *Client) Prechecks(modelVersion version.Number) error {
+	args := params.TargetPrechecksArgs{
+		ModelVersion: modelVersion,
+	}
+	return c.caller.FacadeCall("Prechecks", args, nil)
 }
 
 // Import takes a serialized model and imports it into the target

--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -25,7 +25,7 @@ type Client struct {
 
 func (c *Client) Prechecks(modelVersion version.Number) error {
 	args := params.TargetPrechecksArgs{
-		ModelVersion: modelVersion,
+		AgentVersion: modelVersion,
 	}
 	return c.caller.FacadeCall("Prechecks", args, nil)
 }

--- a/api/migrationtarget/client_test.go
+++ b/api/migrationtarget/client_test.go
@@ -6,6 +6,7 @@ package migrationtarget_test
 import (
 	"github.com/juju/errors"
 	jujutesting "github.com/juju/testing"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
@@ -28,6 +29,21 @@ func (s *ClientSuite) getClientAndStub(c *gc.C) (*migrationtarget.Client, *jujut
 	})
 	client := migrationtarget.NewClient(apiCaller)
 	return client, &stub
+}
+
+func (s *ClientSuite) TestPrechecks(c *gc.C) {
+	client, stub := s.getClientAndStub(c)
+
+	vers := version.MustParse("1.2.3")
+	err := client.Prechecks(vers)
+
+	expectedArg := params.TargetPrechecksArgs{
+		ModelVersion: vers,
+	}
+	stub.CheckCalls(c, []jujutesting.StubCall{
+		{"MigrationTarget.Prechecks", []interface{}{"", expectedArg}},
+	})
+	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
 func (s *ClientSuite) TestImport(c *gc.C) {

--- a/api/migrationtarget/client_test.go
+++ b/api/migrationtarget/client_test.go
@@ -38,7 +38,7 @@ func (s *ClientSuite) TestPrechecks(c *gc.C) {
 	err := client.Prechecks(vers)
 
 	expectedArg := params.TargetPrechecksArgs{
-		ModelVersion: vers,
+		AgentVersion: vers,
 	}
 	stub.CheckCalls(c, []jujutesting.StubCall{
 		{"MigrationTarget.Prechecks", []interface{}{"", expectedArg}},

--- a/api/migrationtarget/client_test.go
+++ b/api/migrationtarget/client_test.go
@@ -20,7 +20,7 @@ type ClientSuite struct {
 
 var _ = gc.Suite(&ClientSuite{})
 
-func (s *ClientSuite) getClientAndStub(c *gc.C) (migrationtarget.Client, *jujutesting.Stub) {
+func (s *ClientSuite) getClientAndStub(c *gc.C) (*migrationtarget.Client, *jujutesting.Stub) {
 	var stub jujutesting.Stub
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		stub.AddCall(objType+"."+request, id, arg)

--- a/apiserver/migrationmaster/backend.go
+++ b/apiserver/migrationmaster/backend.go
@@ -6,6 +6,7 @@ package migrationmaster
 import (
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/state"
+	"github.com/juju/version"
 )
 
 // Backend defines the state functionality required by the
@@ -13,6 +14,9 @@ import (
 type Backend interface {
 	WatchForMigration() state.NotifyWatcher
 	LatestMigration() (state.ModelMigration, error)
+	ModelUUID() string
+	ModelName() (string, error)
+	AgentVersion() (version.Number, error)
 	RemoveExportingModelDocs() error
 
 	migration.StateExporter

--- a/apiserver/migrationmaster/facade.go
+++ b/apiserver/migrationmaster/facade.go
@@ -112,6 +112,28 @@ func (api *API) MigrationStatus() (params.MasterMigrationStatus, error) {
 	}, nil
 }
 
+// ModelInfo returns essential information about the model to be
+// migrated.
+func (api *API) ModelInfo() (params.MigrationModelInfo, error) {
+	empty := params.MigrationModelInfo{}
+
+	name, err := api.backend.ModelName()
+	if err != nil {
+		return empty, errors.Annotate(err, "retrieving model name")
+	}
+
+	vers, err := api.backend.AgentVersion()
+	if err != nil {
+		return empty, errors.Annotate(err, "retrieving agent version")
+	}
+
+	return params.MigrationModelInfo{
+		UUID:         api.backend.ModelUUID(),
+		Name:         name,
+		AgentVersion: vers,
+	}, nil
+}
+
 // SetPhase sets the phase of the active model migration. The provided
 // phase must be a valid phase value, for example QUIESCE" or
 // "ABORT". See the core/migration package for the complete list.

--- a/apiserver/migrationmaster/facade_test.go
+++ b/apiserver/migrationmaster/facade_test.go
@@ -114,6 +114,15 @@ func (s *Suite) TestMigrationStatus(c *gc.C) {
 	})
 }
 
+func (s *Suite) TestModelInfo(c *gc.C) {
+	api := s.mustMakeAPI(c)
+	model, err := api.ModelInfo()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(model.UUID, gc.Equals, "model-uuid")
+	c.Assert(model.Name, gc.Equals, "model-name")
+	c.Assert(model.AgentVersion, gc.Equals, version.MustParse("1.2.3"))
+}
+
 func (s *Suite) TestSetPhase(c *gc.C) {
 	api := s.mustMakeAPI(c)
 
@@ -319,6 +328,18 @@ func (b *stubBackend) LatestMigration() (state.ModelMigration, error) {
 		return nil, b.getErr
 	}
 	return b.migration, nil
+}
+
+func (b *stubBackend) ModelUUID() string {
+	return "model-uuid"
+}
+
+func (b *stubBackend) ModelName() (string, error) {
+	return "model-name", nil
+}
+
+func (b *stubBackend) AgentVersion() (version.Number, error) {
+	return version.MustParse("1.2.3"), nil
 }
 
 func (b *stubBackend) RemoveExportingModelDocs() error {

--- a/apiserver/migrationmaster/shim.go
+++ b/apiserver/migrationmaster/shim.go
@@ -4,9 +4,11 @@
 package migrationmaster
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/state"
+	"github.com/juju/version"
 )
 
 // newAPIForRegistration exists to provide the required signature for
@@ -16,5 +18,31 @@ func newAPIForRegistration(
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*API, error) {
-	return NewAPI(st, migration.PrecheckShim(st), resources, authorizer)
+	return NewAPI(&backendShim{st}, migration.PrecheckShim(st), resources, authorizer)
+}
+
+// backendShim wraps a *state.State to implement Backend. It is
+// untested, but is simple enough to be verified by inspection.
+type backendShim struct {
+	*state.State
+}
+
+func (s *backendShim) ModelName() (string, error) {
+	model, err := s.Model()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return model.Name(), nil
+}
+
+func (s *backendShim) AgentVersion() (version.Number, error) {
+	cfg, err := s.ModelConfig()
+	if err != nil {
+		return version.Zero, errors.Trace(err)
+	}
+	vers, ok := cfg.AgentVersion()
+	if !ok {
+		return version.Zero, errors.New("no agent version")
+	}
+	return vers, nil
 }

--- a/apiserver/migrationtarget/migrationtarget.go
+++ b/apiserver/migrationtarget/migrationtarget.go
@@ -62,7 +62,7 @@ func checkAuth(authorizer facade.Authorizer, st *state.State) error {
 func (api *API) Prechecks(args params.TargetPrechecksArgs) error {
 	return migration.TargetPrecheck(
 		migration.PrecheckShim(api.state),
-		args.ModelVersion,
+		args.AgentVersion,
 	)
 }
 

--- a/apiserver/migrationtarget/migrationtarget.go
+++ b/apiserver/migrationtarget/migrationtarget.go
@@ -57,6 +57,15 @@ func checkAuth(authorizer facade.Authorizer, st *state.State) error {
 	return nil
 }
 
+// Prechecks ensure that the target controller is ready to accept a
+// model migration.
+func (api *API) Prechecks(args params.TargetPrechecksArgs) error {
+	return migration.TargetPrecheck(
+		migration.PrecheckShim(api.state),
+		args.ModelVersion,
+	)
+}
+
 // Import takes a serialized Juju model, deserializes it, and
 // recreates it in the receiving controller.
 func (api *API) Import(serialized params.SerializedModel) error {

--- a/apiserver/migrationtarget/migrationtarget_test.go
+++ b/apiserver/migrationtarget/migrationtarget_test.go
@@ -84,7 +84,7 @@ func (s *Suite) importModel(c *gc.C, api *migrationtarget.API) names.ModelTag {
 func (s *Suite) TestPrechecks(c *gc.C) {
 	api := s.mustNewAPI(c)
 	args := params.TargetPrechecksArgs{
-		ModelVersion: s.controllerVersion(c),
+		AgentVersion: s.controllerVersion(c),
 	}
 	err := api.Prechecks(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -99,7 +99,7 @@ func (s *Suite) TestPrechecksFail(c *gc.C) {
 
 	api := s.mustNewAPI(c)
 	args := params.TargetPrechecksArgs{
-		ModelVersion: modelVersion,
+		AgentVersion: modelVersion,
 	}
 	err := api.Prechecks(args)
 	c.Assert(err, gc.NotNil)

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -174,6 +174,6 @@ type MinionReports struct {
 // TargetPrechecksArgs details regarding pre-migration checks to
 // MigrationTarget.Prechecks.
 type TargetPrechecksArgs struct {
-	// ModelVersion is the version of the model to be migrated
-	ModelVersion version.Number `json:"model-version"`
+	// AgentVersion is the tools version of the model to be migrated.
+	AgentVersion version.Number `json:"agent-version"`
 }

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -3,7 +3,11 @@
 
 package params
 
-import "time"
+import (
+	"time"
+
+	"github.com/juju/version"
+)
 
 // InitiateMigrationArgs holds the details required to start one or
 // more model migrations.
@@ -157,4 +161,11 @@ type MinionReports struct {
 	// Failed contains the tags of all agents which have reported a
 	// failed to complete a given migration phase.
 	Failed []string `json:"failed"`
+}
+
+// TargetPrechecksArgs details regarding pre-migration checks to
+// MigrationTarget.Prechecks.
+type TargetPrechecksArgs struct {
+	// ModelVersion is the version of the model to be migrated
+	ModelVersion version.Number `json:"model-version"`
 }

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -94,6 +94,14 @@ type MasterMigrationStatus struct {
 	PhaseChangedTime time.Time     `json:"phase-changed-time"`
 }
 
+// MigrationModelInfo is used to report basic model information to the
+// migrationmaster worker.
+type MigrationModelInfo struct {
+	UUID         string         `json:"uuid"`
+	Name         string         `json:"name"`
+	AgentVersion version.Number `json:"agent-version"`
+}
+
 // MigrationStatus reports the current status of a model migration.
 type MigrationStatus struct {
 	MigrationId string `json:"migration-id"`

--- a/core/migration/migration.go
+++ b/core/migration/migration.go
@@ -45,3 +45,10 @@ type SerializedModel struct {
 	// source controller.
 	Tools map[version.Binary]string // version -> tools URI
 }
+
+// ModelInfo is used to report basic details about a model.
+type ModelInfo struct {
+	UUID         string
+	Name         string
+	AgentVersion version.Number
+}

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -27,7 +27,6 @@ import (
 
 - controller is upgrading
   * all machine versions must match agent version
-
 - source controller has upgrade info doc (IsUpgrading)
 - controller machines have errors
 - controller machines that are dying or dead
@@ -36,16 +35,11 @@ import (
 ## Target controller
 
 - target controller tools are less than source model tools
-
-- target controller is upgrading
-  * all machine versions must match agent version
-
-- source controller has upgrade info doc (IsUpgrading)
-
 - target controller machines have errors
 - target controller already has a model with the same owner:name
 - target controller already has a model with the same UUID
   - what about if left over from previous failed attempt?
+- source controller has upgrade info doc (IsUpgrading)
 
 */
 
@@ -81,6 +75,23 @@ func SourcePrecheck(backend PrecheckBackend) error {
 		return errors.Annotate(err, "retrieving model version")
 	}
 
+	err = checkMachines(backend, modelVersion)
+	return errors.Trace(err)
+}
+
+// TargetPrecheck checks the state of the target controller to make
+// sure that the preconditions for model migration are met. The
+// backend provided must be for the target controller.
+func TargetPrecheck(backend PrecheckBackend) error {
+	modelVersion, err := backend.AgentVersion()
+	if err != nil {
+		return errors.Annotate(err, "retrieving model version")
+	}
+	err = checkMachines(backend, modelVersion)
+	return errors.Trace(err)
+}
+
+func checkMachines(backend PrecheckBackend, modelVersion version.Number) error {
 	machines, err := backend.AllMachines()
 	if err != nil {
 		return errors.Annotate(err, "retrieving machines")
@@ -96,6 +107,5 @@ func SourcePrecheck(backend PrecheckBackend) error {
 				machine.Id(), machineVersion, modelVersion)
 		}
 	}
-
 	return nil
 }

--- a/migration/precheck_shim.go
+++ b/migration/precheck_shim.go
@@ -15,20 +15,15 @@ func PrecheckShim(st *state.State) PrecheckBackend {
 	return &precheckShim{st}
 }
 
-// precheckShim is untested, but is small and simple enough to be
-// verified by inspection.
+// precheckShim is untested, but is simple enough to be verified by
+// inspection.
 type precheckShim struct {
-	st *state.State
-}
-
-// NeedsCleanup implements PrecheckBackend.
-func (s *precheckShim) NeedsCleanup() (bool, error) {
-	return s.st.NeedsCleanup()
+	*state.State
 }
 
 // AgentVersion implements PrecheckBackend.
 func (s *precheckShim) AgentVersion() (version.Number, error) {
-	cfg, err := s.st.ModelConfig()
+	cfg, err := s.ModelConfig()
 	if err != nil {
 		return version.Zero, errors.Trace(err)
 	}
@@ -41,7 +36,7 @@ func (s *precheckShim) AgentVersion() (version.Number, error) {
 
 // AllMachines implements PrecheckBackend.
 func (s *precheckShim) AllMachines() ([]PrecheckMachine, error) {
-	machines, err := s.st.AllMachines()
+	machines, err := s.State.AllMachines()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -14,11 +14,53 @@ import (
 	"github.com/juju/juju/tools"
 )
 
-type SourcePrecheckSuite struct {
+type precheckBaseSuite struct {
 	testing.BaseSuite
 }
 
+var _ = gc.Suite(&precheckBaseSuite{})
+
+type precheckRunner func(migration.PrecheckBackend) error
+
+func (*precheckBaseSuite) checkAgentVersionError(c *gc.C, runPrecheck precheckRunner) {
+	backend := &fakeBackend{
+		agentVersionErr: errors.New("boom"),
+	}
+	err := runPrecheck(backend)
+	c.Assert(err, gc.ErrorMatches, "retrieving model version: boom")
+}
+
+func (*precheckBaseSuite) checkMachineVersionsMatch(c *gc.C, runPrecheck precheckRunner) {
+	backend := &fakeBackend{
+		machines: []migration.PrecheckMachine{
+			&machine{"0", version.MustParseBinary("1.2.3-trusty-amd64")},
+			&machine{"1", version.MustParseBinary("1.2.3-xenial-amd64")},
+		},
+	}
+	err := runPrecheck(backend)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (*precheckBaseSuite) checkMachineVersionsDontMatch(c *gc.C, runPrecheck precheckRunner) {
+	backend := &fakeBackend{
+		machines: []migration.PrecheckMachine{
+			&machine{"0", version.MustParseBinary("1.2.3-trusty-amd64")},
+			&machine{"1", version.MustParseBinary("1.3.1-xenial-amd64")},
+		},
+	}
+	err := runPrecheck(backend)
+	c.Assert(err, gc.ErrorMatches, `machine 1 tools don't match model \(1.3.1 != 1.2.3\)`)
+}
+
+type SourcePrecheckSuite struct {
+	precheckBaseSuite
+}
+
 var _ = gc.Suite(&SourcePrecheckSuite{})
+
+func sourcePrecheck(backend migration.PrecheckBackend) error {
+	return migration.SourcePrecheck(backend)
+}
 
 func (*SourcePrecheckSuite) TestCleanups(c *gc.C) {
 	backend := &fakeBackend{}
@@ -42,34 +84,38 @@ func (*SourcePrecheckSuite) TestCleanupsNeeded(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "cleanup needed")
 }
 
-func (*SourcePrecheckSuite) TestAgentVersionError(c *gc.C) {
-	backend := &fakeBackend{
-		agentVersionErr: errors.New("boom"),
-	}
-	err := migration.SourcePrecheck(backend)
-	c.Assert(err, gc.ErrorMatches, "retrieving model version: boom")
+func (s *SourcePrecheckSuite) TestAgentVersionError(c *gc.C) {
+	s.checkAgentVersionError(c, sourcePrecheck)
 }
 
-func (*SourcePrecheckSuite) TestMachineVersionsMatch(c *gc.C) {
-	backend := &fakeBackend{
-		machines: []migration.PrecheckMachine{
-			&machine{"0", version.MustParseBinary("1.2.3-trusty-amd64")},
-			&machine{"1", version.MustParseBinary("1.2.3-xenial-amd64")},
-		},
-	}
-	err := migration.SourcePrecheck(backend)
-	c.Assert(err, jc.ErrorIsNil)
+func (s *SourcePrecheckSuite) TestMachineVersionsMatch(c *gc.C) {
+	s.checkMachineVersionsDontMatch(c, sourcePrecheck)
 }
 
-func (*SourcePrecheckSuite) TestMachineVersionsDontMatch(c *gc.C) {
-	backend := &fakeBackend{
-		machines: []migration.PrecheckMachine{
-			&machine{"0", version.MustParseBinary("1.2.3-trusty-amd64")},
-			&machine{"1", version.MustParseBinary("1.3.1-xenial-amd64")},
-		},
-	}
-	err := migration.SourcePrecheck(backend)
-	c.Assert(err, gc.ErrorMatches, `machine 1 tools don't match model \(1.3.1 != 1.2.3\)`)
+func (s *SourcePrecheckSuite) TestMachineVersionsDontMatch(c *gc.C) {
+	s.checkMachineVersionsDontMatch(c, sourcePrecheck)
+}
+
+type TargetPrecheckSuite struct {
+	precheckBaseSuite
+}
+
+var _ = gc.Suite(&TargetPrecheckSuite{})
+
+func targetPrecheck(backend migration.PrecheckBackend) error {
+	return migration.TargetPrecheck(backend)
+}
+
+func (s *TargetPrecheckSuite) TestAgentVersionError(c *gc.C) {
+	s.checkAgentVersionError(c, targetPrecheck)
+}
+
+func (s *TargetPrecheckSuite) TestMachineVersionsMatch(c *gc.C) {
+	s.checkMachineVersionsDontMatch(c, targetPrecheck)
+}
+
+func (s *TargetPrecheckSuite) TestMachineVersionsDontMatch(c *gc.C) {
+	s.checkMachineVersionsDontMatch(c, targetPrecheck)
 }
 
 type fakeBackend struct {

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -256,6 +256,10 @@ func (w *Worker) setInfoStatus(s string, a ...interface{}) {
 	w.setStatusAndLog(w.logger.Infof, s, a...)
 }
 
+func (w *Worker) setWarningStatus(s string, a ...interface{}) {
+	w.setStatusAndLog(w.logger.Warningf, s, a...)
+}
+
 func (w *Worker) setErrorStatus(s string, a ...interface{}) {
 	w.setStatusAndLog(w.logger.Errorf, s, a...)
 }
@@ -428,7 +432,7 @@ func (w *Worker) doABORT(targetInfo coremigration.TargetInfo, modelUUID string) 
 	if err := w.removeImportedModel(targetInfo, modelUUID); err != nil {
 		// This isn't fatal. Removing the imported model is a best
 		// efforts attempt so just report the error and proceed.
-		w.setErrorStatus("failed to remove model from target controller, %v", err)
+		w.setWarningStatus("failed to remove model from target controller, %v", err)
 	}
 	return coremigration.ABORTDONE, nil
 }

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -187,7 +187,7 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 		{"masterFacade.ModelInfo", nil},
 		apiOpenCallController,
 		{"MigrationTarget.Prechecks", []interface{}{params.TargetPrechecksArgs{
-			ModelVersion: version.MustParse("1.2.4"),
+			AgentVersion: version.MustParse("1.2.4"),
 		}}},
 		connCloseCall,
 		{"masterFacade.SetPhase", []interface{}{coremigration.IMPORT}},
@@ -445,7 +445,7 @@ func (s *Suite) TestPRECHECKTargetFail(c *gc.C) {
 		{"masterFacade.ModelInfo", nil},
 		apiOpenCallController,
 		{"MigrationTarget.Prechecks", []interface{}{params.TargetPrechecksArgs{
-			ModelVersion: version.MustParse("1.2.4"),
+			AgentVersion: version.MustParse("1.2.4"),
 		}}},
 		connCloseCall,
 		{"masterFacade.SetPhase", []interface{}{coremigration.ABORT}},


### PR DESCRIPTION
This PR is mainly about adding the plumbing to support prechecks of the target controller before a migration begins. 

Here we have:

- The core target prechecks scaffolding (migration.TargetPrechecks)
- A check to ensure that the target controller machines have tools matching the controller model's agent version (i.e. it isn't upgrading)
- A check to ensure the target controller tools version is the same or higher than the model to be migrated.
- A new ModelInfo API method on the MigrationMaster facade to retrieve basic information about the model to be migrated.
- A new Prechecks API method on the MigrationTarget facade to trigger target controller prechecks over the API.
- Updates to the migrationmaster worker to run prechecks on the target controller.


(Review request: http://reviews.vapour.ws/r/5543/)