### PR TITLE
Fence ssh keys for internal use from api commands

### DIFF
--- a/api/keymanager/client_test.go
+++ b/api/keymanager/client_test.go
@@ -139,7 +139,7 @@ func (s *keymanagerSuite) TestDeleteKeys(c *gc.C) {
 		{Error: nil},
 		{Error: clientError("invalid ssh key: missing")},
 	})
-	s.assertModelKeys(c, []string{"invalid", key3})
+	s.assertModelKeys(c, []string{key3, "invalid"})
 }
 
 func (s *keymanagerSuite) TestImportKeys(c *gc.C) {

--- a/apiserver/keymanager/keymanager.go
+++ b/apiserver/keymanager/keymanager.go
@@ -28,7 +28,7 @@ func init() {
 }
 
 // The comment values used by juju internal ssh keys.
-var internalKeyComments = []string{"juju-client-key", "juju-system-key"}
+var internalComments = set.NewStrings([]string{"juju-client-key", "juju-system-key"}...)
 
 // KeyManager defines the methods on the keymanager API end point.
 type KeyManager interface {
@@ -127,7 +127,6 @@ func (api *KeyManagerAPI) ListKeys(arg params.ListSSHKeys) (params.StringsResult
 }
 
 func parseKeys(keys []string, mode ssh.ListMode) (keyInfo []string) {
-	internalComments := set.NewStrings(internalKeyComments...)
 	for _, key := range keys {
 		fingerprint, comment, err := ssh.KeyFingerprint(key)
 		if err != nil {
@@ -326,33 +325,31 @@ func (api *KeyManagerAPI) ImportKeys(arg params.ModifyUserSSHKeys) (params.Error
 
 // currentKeyDataForDelete gathers data used when deleting ssh keys.
 func (api *KeyManagerAPI) currentKeyDataForDelete() (
-	keys map[string]string, invalidKeys []string, comments map[string]string, err error) {
+	currentKeys []string, byFingerprint map[string]string, byComment map[string]string, err error) {
 
 	cfg, err := api.state.ModelConfig()
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("reading current key data: %v", err)
 	}
 	// For now, authorised keys are global, common to all users.
-	existingSSHKeys := ssh.SplitAuthorisedKeys(cfg.AuthorizedKeys())
+	currentKeys = ssh.SplitAuthorisedKeys(cfg.AuthorizedKeys())
 
-	// Build up a map of keys indexed by fingerprint, and fingerprints indexed by comment
-	// so we can easily get the key represented by each keyId, which may be either a fingerprint
-	// or comment.
-	keys = make(map[string]string)
-	comments = make(map[string]string)
-	for _, key := range existingSSHKeys {
+	// Make two maps that index keys by fingerprint and by comment for fast
+	// lookup of keys to delete which may be given as either.
+	byFingerprint = make(map[string]string)
+	byComment = make(map[string]string)
+	for _, key := range currentKeys {
 		fingerprint, comment, err := ssh.KeyFingerprint(key)
 		if err != nil {
 			logger.Debugf("keeping unrecognised existing ssh key %q: %v", key, err)
-			invalidKeys = append(invalidKeys, key)
 			continue
 		}
-		keys[fingerprint] = key
+		byFingerprint[fingerprint] = key
 		if comment != "" {
-			comments[comment] = fingerprint
+			byComment[comment] = key
 		}
 	}
-	return keys, invalidKeys, comments, nil
+	return currentKeys, byFingerprint, byComment, nil
 }
 
 // DeleteKeys deletes the authorised ssh keys for the specified user.
@@ -371,38 +368,44 @@ func (api *KeyManagerAPI) DeleteKeys(arg params.ModifyUserSSHKeys) (params.Error
 		return params.ErrorResults{}, common.ServerError(common.ErrPerm)
 	}
 
-	sshKeys, invalidKeys, keyComments, err := api.currentKeyDataForDelete()
+	allKeys, byFingerprint, byComment, err := api.currentKeyDataForDelete()
 	if err != nil {
 		return params.ErrorResults{}, common.ServerError(fmt.Errorf("reading current key data: %v", err))
 	}
 
-	// We keep all existing invalid keys.
-	keysToWrite := invalidKeys
-
-	internalComments := set.NewStrings(internalKeyComments...)
+	// Record the keys to be deleted in the second pass.
+	keysToDelete := make(set.Strings)
 
 	// Find the keys corresponding to the specified key fingerprints or comments.
 	for i, keyId := range arg.Keys {
-		// assume keyId may be a fingerprint
-		fingerprint := keyId
-		_, ok := sshKeys[keyId]
-		if !ok {
-			// keyId is a comment
-			fingerprint, ok = keyComments[keyId]
-		}
-		if !ok {
-			result.Results[i].Error = common.ServerError(fmt.Errorf("invalid ssh key: %s", keyId))
-		}
-		if internalComments.Contains(keyId) {
-			result.Results[i].Error = common.ServerError(fmt.Errorf("may not delete internal key: %s", keyId))
+		// Is given keyId a fingerprint?
+		key, ok := byFingerprint[keyId]
+		if ok {
+			keysToDelete.Add(key)
 			continue
 		}
-		// We found the key to delete so remove it from those we wish to keep.
-		delete(sshKeys, fingerprint)
+		// Not a fingerprint, is it a comment?
+		key, ok = byComment[keyId]
+		if ok {
+			if internalComments.Contains(keyId) {
+				result.Results[i].Error = common.ServerError(fmt.Errorf("may not delete internal key: %s", keyId))
+				continue
+			}
+			keysToDelete.Add(key)
+			continue
+		}
+		result.Results[i].Error = common.ServerError(fmt.Errorf("invalid ssh key: %s", keyId))
 	}
-	for _, key := range sshKeys {
-		keysToWrite = append(keysToWrite, key)
+
+	var keysToWrite []string
+
+	// Add back only the keys that are not deleted, preserving the order.
+	for _, key := range allKeys {
+		if !keysToDelete.Contains(key) {
+			keysToWrite = append(keysToWrite, key)
+		}
 	}
+
 	if len(keysToWrite) == 0 {
 		return params.ErrorResults{}, common.ServerError(fmt.Errorf("cannot delete all keys"))
 	}

--- a/apiserver/keymanager/keymanager_test.go
+++ b/apiserver/keymanager/keymanager_test.go
@@ -248,7 +248,7 @@ func (s *keyManagerSuite) TestDeleteKeys(c *gc.C) {
 			{Error: apiservertesting.ServerError("invalid ssh key: invalid-key")},
 		},
 	})
-	s.assertEnvironKeys(c, []string{"bad key", key1})
+	s.assertEnvironKeys(c, []string{key1, "bad key"})
 }
 
 func (s *keyManagerSuite) TestDeleteKeysNotJujuInternal(c *gc.C) {

--- a/apiserver/keymanager/keymanager_test.go
+++ b/apiserver/keymanager/keymanager_test.go
@@ -112,6 +112,26 @@ func (s *keyManagerSuite) TestListKeys(c *gc.C) {
 	})
 }
 
+func (s *keyManagerSuite) TestListKeysHidesJujuInternal(c *gc.C) {
+	key1 := sshtesting.ValidKeyOne.Key + " juju-client-key"
+	key2 := sshtesting.ValidKeyTwo.Key + " juju-system-key"
+	s.setAuthorisedKeys(c, strings.Join([]string{key1, key2}, "\n"))
+
+	args := params.ListSSHKeys{
+		Entities: params.Entities{[]params.Entity{
+			{Tag: s.AdminUserTag(c).Name()},
+		}},
+		Mode: ssh.FullKeys,
+	}
+	results, err := s.keymanager.ListKeys(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.StringsResults{
+		Results: []params.StringsResult{
+			{Result: nil},
+		},
+	})
+}
+
 func (s *keyManagerSuite) assertEnvironKeys(c *gc.C, expected []string) {
 	envConfig, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
@@ -229,6 +249,28 @@ func (s *keyManagerSuite) TestDeleteKeys(c *gc.C) {
 		},
 	})
 	s.assertEnvironKeys(c, []string{"bad key", key1})
+}
+
+func (s *keyManagerSuite) TestDeleteKeysNotJujuInternal(c *gc.C) {
+	key1 := sshtesting.ValidKeyOne.Key + " juju-client-key"
+	key2 := sshtesting.ValidKeyTwo.Key + " juju-system-key"
+	key3 := sshtesting.ValidKeyThree.Key + " a user key"
+	initialKeys := []string{key1, key2, key3}
+	s.setAuthorisedKeys(c, strings.Join(initialKeys, "\n"))
+
+	args := params.ModifyUserSSHKeys{
+		User: s.AdminUserTag(c).Name(),
+		Keys: []string{"juju-client-key", "juju-system-key"},
+	}
+	results, err := s.keymanager.DeleteKeys(args)
+	c.Check(results, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{Error: apiservertesting.ServerError("may not delete internal key: juju-client-key")},
+			{Error: apiservertesting.ServerError("may not delete internal key: juju-system-key")},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertEnvironKeys(c, initialKeys)
 }
 
 func (s *keyManagerSuite) TestBlockDeleteKeys(c *gc.C) {


### PR DESCRIPTION
Fixes lp:1555727.

Change contains two elements. Firstly, keys automatically created
by juju for internal use are not included when listing ssh keys.
Secondly, attempting to delete an internal key from its comment
over the api from is prevented.

The change is not intended to make juju robust against all key
modifications, notably it is still possible to delete an internal
key from its full fingerprint, but should make the use experience
less confusing.

(Review request: http://reviews.vapour.ws/r/5545/)