### PR TITLE
Remove deleted users from model.Users

### DIFF
--- a/state/model.go
+++ b/state/model.go
@@ -622,6 +622,18 @@ func (m *Model) Users() ([]description.UserAccess, error) {
 
 	var modelUsers []description.UserAccess
 	for _, doc := range userDocs {
+		// check if the User belonging to this model user has
+		// been deleted, in this case we should not return it.
+		userTag := names.NewUserTag(doc.UserName)
+		if userTag.IsLocal() {
+			_, err := m.st.User(userTag)
+			if errors.IsUserNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
 		mu, err := NewModelUserAccess(m.st, doc)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -712,6 +712,26 @@ func (s *ModelSuite) TestMisMatchedEnvs(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "cannot lookup model users outside the current model")
 }
 
+func (s *ModelSuite) TestListUsersIgnoredDeletedUsers(c *gc.C) {
+	model, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedUsers := addModelUsers(c, s.State)
+
+	obtainedUsers, err := model.Users()
+	c.Assert(err, jc.ErrorIsNil)
+	assertObtainedUsersMatchExpectedUsers(c, obtainedUsers, expectedUsers)
+
+	lastUser := obtainedUsers[len(obtainedUsers)-1]
+	err = s.State.RemoveUser(lastUser.UserTag)
+	c.Assert(err, jc.ErrorIsNil)
+	expectedAfterDeletion := obtainedUsers[:len(obtainedUsers)-1]
+
+	obtainedUsers, err = model.Users()
+	c.Assert(err, jc.ErrorIsNil)
+	assertObtainedUsersMatchExpectedUsers(c, obtainedUsers, expectedAfterDeletion)
+}
+
 func (s *ModelSuite) TestListUsersTwoModels(c *gc.C) {
 	env, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Ignore deleted local users when listing modelUsers.
This fixes https://bugs.launchpad.net/juju/+bug/1613444

(Review request: http://reviews.vapour.ws/r/5546/)