### PR TITLE
Add the CLI bits for model defaults 

### DIFF
--- a/api/modelconfig/modelconfig_test.go
+++ b/api/modelconfig/modelconfig_test.go
@@ -139,10 +139,10 @@ func (s *modelconfigSuite) TestModelDefaults(c *gc.C) {
 			c.Check(id, gc.Equals, "")
 			c.Check(request, gc.Equals, "ModelDefaults")
 			c.Check(a, gc.IsNil)
-			c.Assert(result, gc.FitsTypeOf, &params.ModelConfigResults{})
-			results := result.(*params.ModelConfigResults)
-			results.Config = map[string]params.ConfigValue{
-				"foo": {"bar", "model"},
+			c.Assert(result, gc.FitsTypeOf, &params.ModelDefaultResults{})
+			results := result.(*params.ModelDefaultResults)
+			results.Config = map[string]params.ConfigSetting{
+				"foo": {"bar", "model", nil},
 			}
 			return nil
 		},
@@ -150,8 +150,8 @@ func (s *modelconfigSuite) TestModelDefaults(c *gc.C) {
 	client := modelconfig.NewClient(apiCaller)
 	result, err := client.ModelDefaults()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, config.ConfigValues{
-		"foo": {"bar", "model"},
+	c.Assert(result, jc.DeepEquals, config.DefaultValues{
+		"foo": {"bar", "model", nil},
 	})
 }
 

--- a/api/modelconfig/modelconfig_test.go
+++ b/api/modelconfig/modelconfig_test.go
@@ -139,10 +139,12 @@ func (s *modelconfigSuite) TestModelDefaults(c *gc.C) {
 			c.Check(id, gc.Equals, "")
 			c.Check(request, gc.Equals, "ModelDefaults")
 			c.Check(a, gc.IsNil)
-			c.Assert(result, gc.FitsTypeOf, &params.ModelDefaultResults{})
-			results := result.(*params.ModelDefaultResults)
-			results.Config = map[string]params.ConfigSetting{
-				"foo": {"bar", "model", nil},
+			c.Assert(result, gc.FitsTypeOf, &params.ModelDefaultsResult{})
+			results := result.(*params.ModelDefaultsResult)
+			results.Config = map[string]params.ModelDefaults{
+				"foo": {"bar", "model", []params.RegionDefaults{{
+					"dummy-region",
+					"dummy-value"}}},
 			}
 			return nil
 		},
@@ -150,8 +152,11 @@ func (s *modelconfigSuite) TestModelDefaults(c *gc.C) {
 	client := modelconfig.NewClient(apiCaller)
 	result, err := client.ModelDefaults()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, config.DefaultValues{
-		"foo": {"bar", "model", nil},
+
+	c.Assert(result, jc.DeepEquals, config.ModelDefaultAttributes{
+		"foo": {"bar", "model", []config.RegionDefaultValue{{
+			"dummy-region",
+			"dummy-value"}}},
 	})
 }
 

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -31,9 +31,9 @@ type ModelDefaultsResult struct {
 // ModelDefaults holds the settings for a given ModelDefaultsResult config
 // attribute.
 type ModelDefaults struct {
-	Default    interface{}      `json:"default"`
-	Controller interface{}      `json:"controller"`
-	Regions    []RegionDefaults `json:"regions"`
+	Default    interface{}      `json:"default,omitempty"`
+	Controller interface{}      `json:"controller,omitempty"`
+	Regions    []RegionDefaults `json:"regions,omitempty"`
 }
 
 // RegionDefaults contains the settings for regions in a ModelDefaults.

--- a/cmd/juju/model/fakeenv_test.go
+++ b/cmd/juju/model/fakeenv_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/juju/juju/testing"
 )
 
+// ModelConfig
+
 type fakeEnvSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
 	fake *fakeEnvAPI
@@ -23,9 +25,10 @@ func (s *fakeEnvSuite) SetUpTest(c *gc.C) {
 			"special": "special value",
 			"running": true,
 		},
-		defaults: config.DefaultValues{
-			"attr":  {Default: "foo"},
-			"attr2": {Controller: "bar"},
+		defaults: config.ConfigValues{
+			"attr":  {Value: "foo", Source: "default"},
+			"attr2": {Value: "bar", Source: "controller"},
+			"attr3": {Value: "baz", Source: "region"},
 		},
 	}
 }
@@ -33,7 +36,7 @@ func (s *fakeEnvSuite) SetUpTest(c *gc.C) {
 type fakeEnvAPI struct {
 	values        map[string]interface{}
 	cloud, region string
-	defaults      config.DefaultValues
+	defaults      config.ConfigValues
 	err           error
 	keys          []string
 }
@@ -54,23 +57,73 @@ func (f *fakeEnvAPI) ModelGetWithMetadata() (config.ConfigValues, error) {
 	return result, nil
 }
 
-func (f *fakeEnvAPI) ModelDefaults() (config.DefaultValues, error) {
+// ModelDefaults
+
+type fakeModelDefaultEnvSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
+	fake *fakeModelDefaultsAPI
+}
+
+func (s *fakeModelDefaultEnvSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	s.fake = &fakeModelDefaultsAPI{
+		values: map[string]interface{}{
+			"name":    "test-model",
+			"special": "special value",
+			"running": true,
+		},
+		defaults: config.ModelDefaultAttributes{
+			"attr": {Default: "foo"},
+			"attr2": {
+				Controller: "bar",
+				Regions: []config.RegionDefaultValue{{
+					"dummy-region",
+					"dummy-value"}}},
+		},
+	}
+}
+
+type fakeModelDefaultsAPI struct {
+	values        map[string]interface{}
+	cloud, region string
+	defaults      config.ModelDefaultAttributes
+	err           error
+	keys          []string
+}
+
+func (f *fakeModelDefaultsAPI) Close() error {
+	return nil
+}
+
+func (f *fakeModelDefaultsAPI) ModelGet() (map[string]interface{}, error) {
+	return f.values, nil
+}
+
+func (f *fakeModelDefaultsAPI) ModelGetWithMetadata() (config.ModelDefaultAttributes, error) {
+	result := make(config.ModelDefaultAttributes)
+	for name, val := range f.values {
+		result[name] = config.AttributeDefaultValues{Default: val}
+	}
+	return result, nil
+}
+
+func (f *fakeModelDefaultsAPI) ModelDefaults() (config.ModelDefaultAttributes, error) {
 	return f.defaults, nil
 }
 
-func (f *fakeEnvAPI) SetModelDefaults(cloud, region string, cfg map[string]interface{}) error {
+func (f *fakeModelDefaultsAPI) SetModelDefaults(cloud, region string, cfg map[string]interface{}) error {
 	if f.err != nil {
 		return f.err
 	}
 	f.cloud = cloud
 	f.region = region
 	for name, val := range cfg {
-		f.defaults[name] = config.DefaultSetting{Controller: val}
+		f.defaults[name] = config.AttributeDefaultValues{Controller: val}
 	}
 	return nil
 }
 
-func (f *fakeEnvAPI) UnsetModelDefaults(cloud, region string, keys ...string) error {
+func (f *fakeModelDefaultsAPI) UnsetModelDefaults(cloud, region string, keys ...string) error {
 	if f.err != nil {
 		return f.err
 	}
@@ -82,12 +135,12 @@ func (f *fakeEnvAPI) UnsetModelDefaults(cloud, region string, keys ...string) er
 	return nil
 }
 
-func (f *fakeEnvAPI) ModelSet(config map[string]interface{}) error {
+func (f *fakeModelDefaultsAPI) ModelSet(config map[string]interface{}) error {
 	f.values = config
 	return f.err
 }
 
-func (f *fakeEnvAPI) ModelUnset(keys ...string) error {
+func (f *fakeModelDefaultsAPI) ModelUnset(keys ...string) error {
 	f.keys = keys
 	return f.err
 }

--- a/cmd/juju/model/fakeenv_test.go
+++ b/cmd/juju/model/fakeenv_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-// ModelConfig
+// ModelConfig related fake environment for testing.
 
 type fakeEnvSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
@@ -57,7 +57,7 @@ func (f *fakeEnvAPI) ModelGetWithMetadata() (config.ConfigValues, error) {
 	return result, nil
 }
 
-// ModelDefaults
+// ModelDefaults related fake environment for testing.
 
 type fakeModelDefaultEnvSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
@@ -97,14 +97,6 @@ func (f *fakeModelDefaultsAPI) Close() error {
 
 func (f *fakeModelDefaultsAPI) ModelGet() (map[string]interface{}, error) {
 	return f.values, nil
-}
-
-func (f *fakeModelDefaultsAPI) ModelGetWithMetadata() (config.ModelDefaultAttributes, error) {
-	result := make(config.ModelDefaultAttributes)
-	for name, val := range f.values {
-		result[name] = config.AttributeDefaultValues{Default: val}
-	}
-	return result, nil
 }
 
 func (f *fakeModelDefaultsAPI) ModelDefaults() (config.ModelDefaultAttributes, error) {

--- a/cmd/juju/model/fakeenv_test.go
+++ b/cmd/juju/model/fakeenv_test.go
@@ -23,9 +23,9 @@ func (s *fakeEnvSuite) SetUpTest(c *gc.C) {
 			"special": "special value",
 			"running": true,
 		},
-		defaults: config.ConfigValues{
-			"attr":  {Value: "foo", Source: "default"},
-			"attr2": {Value: "bar", Source: "controller"},
+		defaults: config.DefaultValues{
+			"attr":  {Default: "foo"},
+			"attr2": {Controller: "bar"},
 		},
 	}
 }
@@ -33,7 +33,7 @@ func (s *fakeEnvSuite) SetUpTest(c *gc.C) {
 type fakeEnvAPI struct {
 	values        map[string]interface{}
 	cloud, region string
-	defaults      config.ConfigValues
+	defaults      config.DefaultValues
 	err           error
 	keys          []string
 }
@@ -54,7 +54,7 @@ func (f *fakeEnvAPI) ModelGetWithMetadata() (config.ConfigValues, error) {
 	return result, nil
 }
 
-func (f *fakeEnvAPI) ModelDefaults() (config.ConfigValues, error) {
+func (f *fakeEnvAPI) ModelDefaults() (config.DefaultValues, error) {
 	return f.defaults, nil
 }
 
@@ -65,7 +65,7 @@ func (f *fakeEnvAPI) SetModelDefaults(cloud, region string, cfg map[string]inter
 	f.cloud = cloud
 	f.region = region
 	for name, val := range cfg {
-		f.defaults[name] = config.ConfigValue{Value: val, Source: "controller"}
+		f.defaults[name] = config.DefaultSetting{Controller: val}
 	}
 	return nil
 }

--- a/cmd/juju/model/getdefaults.go
+++ b/cmd/juju/model/getdefaults.go
@@ -170,12 +170,6 @@ func formatDefaultConfigTabular(writer io.Writer, value interface{}) error {
 		if err != nil {
 			return errors.Annotatef(err, "formatting value for %q", name)
 		}
-		// valString := strings.TrimSuffix(out.String(), "\n")
-		// if info.Source == "default" {
-		// 	d = valString
-		// } else {
-		// 	c = valString
-		// }
 		p(name, info)
 	}
 

--- a/cmd/juju/model/getdefaults.go
+++ b/cmd/juju/model/getdefaults.go
@@ -89,7 +89,7 @@ type modelDefaultsAPI interface {
 	Close() error
 
 	// ModelDefaults returns the default config values used when creating a new model.
-	ModelDefaults() (config.ConfigValues, error)
+	ModelDefaults() (config.ModelDefaultAttributes, error)
 }
 
 func (c *getDefaultsCommand) Run(ctx *cmd.Context) error {
@@ -106,7 +106,7 @@ func (c *getDefaultsCommand) Run(ctx *cmd.Context) error {
 
 	if c.key != "" {
 		if value, ok := attrs[c.key]; ok {
-			attrs = config.ConfigValues{
+			attrs = config.ModelDefaultAttributes{
 				c.key: value,
 			}
 		} else {
@@ -119,39 +119,64 @@ func (c *getDefaultsCommand) Run(ctx *cmd.Context) error {
 
 // formatConfigTabular writes a tabular summary of default config information.
 func formatDefaultConfigTabular(writer io.Writer, value interface{}) error {
-	configValues, ok := value.(config.ConfigValues)
+	defaultValues, ok := value.(config.ModelDefaultAttributes)
 	if !ok {
-		return errors.Errorf("expected value of type %T, got %T", configValues, value)
+		return errors.Errorf("expected value of type %T, got %T", defaultValues, value)
 	}
 
 	tw := output.TabWriter(writer)
-	p := func(values ...string) {
+
+	ph := func(values ...string) {
 		text := strings.Join(values, "\t")
 		fmt.Fprintln(tw, text)
 	}
+
+	p := func(name string, value config.AttributeDefaultValues) {
+		var c, d interface{}
+		switch value.Default {
+		case nil:
+			d = "-"
+		case "":
+			d = `""`
+		default:
+			d = value.Default
+		}
+		switch value.Controller {
+		case nil:
+			c = "-"
+		case "":
+			c = `""`
+		default:
+			c = value.Controller
+		}
+		row := fmt.Sprintf("%s\t%v\t%v", name, d, c)
+		fmt.Fprintln(tw, row)
+		for _, region := range value.Regions {
+			row := fmt.Sprintf("  %s\t%v\t-", region.Name, region.Value)
+			fmt.Fprintln(tw, row)
+		}
+	}
 	var valueNames []string
-	for name := range configValues {
+	for name := range defaultValues {
 		valueNames = append(valueNames, name)
 	}
 	sort.Strings(valueNames)
-	p("ATTRIBUTE\tDEFAULT\tCONTROLLER")
+	ph("ATTRIBUTE\tDEFAULT\tCONTROLLER")
 
 	for _, name := range valueNames {
-		info := configValues[name]
+		info := defaultValues[name]
 		out := &bytes.Buffer{}
-		err := cmd.FormatYaml(out, info.Value)
+		err := cmd.FormatYaml(out, info)
 		if err != nil {
 			return errors.Annotatef(err, "formatting value for %q", name)
 		}
-		d := "-"
-		c := "-"
-		valString := strings.TrimSuffix(out.String(), "\n")
-		if info.Source == "default" {
-			d = valString
-		} else {
-			c = valString
-		}
-		p(name, d, c)
+		// valString := strings.TrimSuffix(out.String(), "\n")
+		// if info.Source == "default" {
+		// 	d = valString
+		// } else {
+		// 	c = valString
+		// }
+		p(name, info)
 	}
 
 	tw.Flush()

--- a/cmd/juju/model/getdefaults_test.go
+++ b/cmd/juju/model/getdefaults_test.go
@@ -52,7 +52,7 @@ func (s *getDefaultsSuite) TestSingleValueJSON(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := strings.TrimSpace(testing.Stdout(context))
-	c.Assert(output, gc.Equals, `{"attr":{"Value":"foo","Source":"default"}}`)
+	c.Assert(output, gc.Equals, `{"attr":{"Default":"foo","Controller":null,"Regions":null}}`)
 }
 
 func (s *getDefaultsSuite) TestAllValuesYAML(c *gc.C) {
@@ -62,11 +62,13 @@ func (s *getDefaultsSuite) TestAllValuesYAML(c *gc.C) {
 	output := strings.TrimSpace(testing.Stdout(context))
 	expected := "" +
 		"attr:\n" +
-		"  value: foo\n" +
-		"  source: default\n" +
+		"  default: foo\n" +
+		"  controller: null\n" +
+		"  regions: []\n" +
 		"attr2:\n" +
-		"  value: bar\n" +
-		"  source: controller"
+		"  default: null\n" +
+		"  controller: bar\n" +
+		"  regions: []"
 	c.Assert(output, gc.Equals, expected)
 }
 
@@ -75,7 +77,7 @@ func (s *getDefaultsSuite) TestAllValuesJSON(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := strings.TrimSpace(testing.Stdout(context))
-	expected := `{"attr":{"Value":"foo","Source":"default"},"attr2":{"Value":"bar","Source":"controller"}}`
+	expected := `{"attr":{"Default":"foo","Controller":null,"Regions":null},"attr2":{"Default":null,"Controller":"bar","Regions":null}}`
 	c.Assert(output, gc.Equals, expected)
 }
 

--- a/cmd/juju/model/getdefaults_test.go
+++ b/cmd/juju/model/getdefaults_test.go
@@ -52,7 +52,7 @@ func (s *getDefaultsSuite) TestSingleValueJSON(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := strings.TrimSpace(testing.Stdout(context))
-	c.Assert(output, gc.Equals, `{"attr":{"Default":"foo","Controller":null,"Regions":null}}`)
+	c.Assert(output, gc.Equals, `{"attr":{"default":"foo"}}`)
 }
 
 func (s *getDefaultsSuite) TestAllValuesYAML(c *gc.C) {
@@ -63,10 +63,7 @@ func (s *getDefaultsSuite) TestAllValuesYAML(c *gc.C) {
 	expected := "" +
 		"attr:\n" +
 		"  default: foo\n" +
-		"  controller: null\n" +
-		"  regions: []\n" +
 		"attr2:\n" +
-		"  default: null\n" +
 		"  controller: bar\n" +
 		"  regions:\n" +
 		"  - name: dummy-region\n" +
@@ -79,7 +76,7 @@ func (s *getDefaultsSuite) TestAllValuesJSON(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := strings.TrimSpace(testing.Stdout(context))
-	expected := `{"attr":{"Default":"foo","Controller":null,"Regions":null},"attr2":{"Default":null,"Controller":"bar","Regions":[{"Name":"dummy-region","Value":"dummy-value"}]}}`
+	expected := `{"attr":{"default":"foo"},"attr2":{"controller":"bar","regions":[{"name":"dummy-region","value":"dummy-value"}]}}`
 	c.Assert(output, gc.Equals, expected)
 }
 

--- a/cmd/juju/model/getdefaults_test.go
+++ b/cmd/juju/model/getdefaults_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 type getDefaultsSuite struct {
-	fakeEnvSuite
+	fakeModelDefaultEnvSuite
 }
 
 var _ = gc.Suite(&getDefaultsSuite{})
@@ -68,7 +68,9 @@ func (s *getDefaultsSuite) TestAllValuesYAML(c *gc.C) {
 		"attr2:\n" +
 		"  default: null\n" +
 		"  controller: bar\n" +
-		"  regions: []"
+		"  regions:\n" +
+		"  - name: dummy-region\n" +
+		"    value: dummy-value"
 	c.Assert(output, gc.Equals, expected)
 }
 
@@ -77,7 +79,7 @@ func (s *getDefaultsSuite) TestAllValuesJSON(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := strings.TrimSpace(testing.Stdout(context))
-	expected := `{"attr":{"Default":"foo","Controller":null,"Regions":null},"attr2":{"Default":null,"Controller":"bar","Regions":null}}`
+	expected := `{"attr":{"Default":"foo","Controller":null,"Regions":null},"attr2":{"Default":null,"Controller":"bar","Regions":[{"Name":"dummy-region","Value":"dummy-value"}]}}`
 	c.Assert(output, gc.Equals, expected)
 }
 
@@ -87,8 +89,9 @@ func (s *getDefaultsSuite) TestAllValuesTabular(c *gc.C) {
 
 	output := strings.TrimSpace(testing.Stdout(context))
 	expected := "" +
-		"ATTRIBUTE  DEFAULT  CONTROLLER\n" +
-		"attr       foo      -\n" +
-		"attr2      -        bar"
+		"ATTRIBUTE       DEFAULT      CONTROLLER\n" +
+		"attr            foo          -\n" +
+		"attr2           -            bar\n" +
+		"  dummy-region  dummy-value  -"
 	c.Assert(output, gc.Equals, expected)
 }

--- a/cmd/juju/model/set_test.go
+++ b/cmd/juju/model/set_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 type SetSuite struct {
-	fakeEnvSuite
+	fakeModelDefaultEnvSuite
 }
 
 var _ = gc.Suite(&SetSuite{})

--- a/cmd/juju/model/setdefaults_test.go
+++ b/cmd/juju/model/setdefaults_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 type SetDefaultsSuite struct {
-	fakeEnvSuite
+	fakeModelDefaultEnvSuite
 }
 
 var _ = gc.Suite(&SetDefaultsSuite{})
@@ -61,9 +61,12 @@ func (s *SetDefaultsSuite) TestInitUnknownValue(c *gc.C) {
 func (s *SetDefaultsSuite) TestSet(c *gc.C) {
 	_, err := s.run(c, "special=extra", "attr=baz")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.fake.defaults, jc.DeepEquals, config.DefaultValues{
-		"attr":    {Controller: "baz", Default: nil, Regions: nil},
-		"attr2":   {Controller: "bar", Default: nil, Regions: nil},
+	c.Assert(s.fake.defaults, jc.DeepEquals, config.ModelDefaultAttributes{
+		"attr": {Controller: "baz", Default: nil, Regions: nil},
+		"attr2": {Controller: "bar", Default: nil, Regions: []config.RegionDefaultValue{{
+			Name:  "dummy-region",
+			Value: "dummy-value",
+		}}},
 		"special": {Controller: "extra", Default: nil, Regions: nil},
 	})
 }

--- a/cmd/juju/model/setdefaults_test.go
+++ b/cmd/juju/model/setdefaults_test.go
@@ -61,10 +61,10 @@ func (s *SetDefaultsSuite) TestInitUnknownValue(c *gc.C) {
 func (s *SetDefaultsSuite) TestSet(c *gc.C) {
 	_, err := s.run(c, "special=extra", "attr=baz")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.fake.defaults, jc.DeepEquals, config.ConfigValues{
-		"attr":    {Value: "baz", Source: "controller"},
-		"attr2":   {Value: "bar", Source: "controller"},
-		"special": {Value: "extra", Source: "controller"},
+	c.Assert(s.fake.defaults, jc.DeepEquals, config.DefaultValues{
+		"attr":    {Controller: "baz", Default: nil, Regions: nil},
+		"attr2":   {Controller: "bar", Default: nil, Regions: nil},
+		"special": {Controller: "extra", Default: nil, Regions: nil},
 	})
 }
 

--- a/cmd/juju/model/unset_test.go
+++ b/cmd/juju/model/unset_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 type UnsetSuite struct {
-	fakeEnvSuite
+	fakeModelDefaultEnvSuite
 }
 
 var _ = gc.Suite(&UnsetSuite{})

--- a/cmd/juju/model/unsetdefaults_test.go
+++ b/cmd/juju/model/unsetdefaults_test.go
@@ -46,8 +46,8 @@ func (s *UnsetDefaultsSuite) TestInitUnknownValue(c *gc.C) {
 func (s *UnsetDefaultsSuite) TestUnset(c *gc.C) {
 	_, err := s.run(c, "attr", "unknown")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.fake.defaults, jc.DeepEquals, config.ConfigValues{
-		"attr2": {Value: "bar", Source: "controller"},
+	c.Assert(s.fake.defaults, jc.DeepEquals, config.DefaultValues{
+		"attr2": {Controller: "bar", Default: nil, Regions: nil},
 	})
 }
 

--- a/cmd/juju/model/unsetdefaults_test.go
+++ b/cmd/juju/model/unsetdefaults_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 type UnsetDefaultsSuite struct {
-	fakeEnvSuite
+	fakeModelDefaultEnvSuite
 }
 
 var _ = gc.Suite(&UnsetDefaultsSuite{})
@@ -46,8 +46,11 @@ func (s *UnsetDefaultsSuite) TestInitUnknownValue(c *gc.C) {
 func (s *UnsetDefaultsSuite) TestUnset(c *gc.C) {
 	_, err := s.run(c, "attr", "unknown")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.fake.defaults, jc.DeepEquals, config.DefaultValues{
-		"attr2": {Controller: "bar", Default: nil, Regions: nil},
+	c.Assert(s.fake.defaults, jc.DeepEquals, config.ModelDefaultAttributes{
+		"attr2": {Controller: "bar", Default: nil, Regions: []config.RegionDefaultValue{{
+			Name:  "dummy-region",
+			Value: "dummy-value",
+		}}},
 	})
 }
 

--- a/environs/config/source.go
+++ b/environs/config/source.go
@@ -72,16 +72,17 @@ type ModelDefaultAttributes map[string]AttributeDefaultValues
 // setting.
 type AttributeDefaultValues struct {
 	// Default and Controller represent the values as set at those levels.
-	Default, Controller interface{}
+	Default    interface{} `json:"default,omitempty" yaml:"default,omitempty"`
+	Controller interface{} `json:"controller,omitempty" yaml:"controller,omitempty"`
 	// Regions is a slice of Region representing the values as set in each
 	// region.
-	Regions []RegionDefaultValue
+	Regions []RegionDefaultValue `json:"regions,omitempty" yaml:"regions,omitempty"`
 }
 
 // RegionDefaultValue holds the region information for each region in DefaultSetting.
 type RegionDefaultValue struct {
 	// Name represents the region name for this specific setting.
-	Name string
+	Name string `json:"name" yaml:"name"`
 	// Value is the value of the setting this represents in the named region.
-	Value interface{}
+	Value interface{} `json:"value" yaml:"value"`
 }


### PR DESCRIPTION
Update CLI to parse new model-defaults shape

This is part of the model-config-tree work: 

QA: 
1. Full test suite passes.
2. Create a cloud with settings like: 
```
juju show-cloud local:awstest 
defined: local
type: ec2
regions:
  us-west-1:
    endpoint: https://us-west-1.aws.amazon.com/v1.2/
  us-east-1:
    endpoint: https://us-east-1.aws.amazon.com/v1.2/
  us-west-2:
    endpoint: https://us-west-2.aws.amazon.com/v1.2/
  eu-west-1:
    endpoint: https://eu-west-1.aws.amazon.com/v1.2/
  eu-central-1:
    endpoint: https://eu-central-1.aws.amazon.com/v1.2/
  ap-southeast-1:
    endpoint: https://ap-southeast-1.aws.amazon.com/v1.2/
  ap-southeast-2:
    endpoint: https://ap-southeast-2.aws.amazon.com/v1.2/
  ap-northeast-1:
    endpoint: https://ap-northeast-1.aws.amazon.com/v1.2/
  ap-northeast-2:
    endpoint: https://ap-northeast-2.aws.amazon.com/v1.2/
  sa-east-1:
    endpoint: https://sa-east-1.aws.amazon.com/v1.2/
config:
  bootstrap-timeout: 900
  default-series: xenial
  enable-os-refresh-update: true
  enable-os-upgrade: false
  logging-config: <root>=DEBUG
  no-proxy: https://local
  set-numa-control-policy: true
region-config:
  us-east-1:
    no-proxy: https://foo-east
  us-west-1:
    no-proxy: https://foo-west
```
3. Bootstrap that `juju bootstrap reed awstest`
4. Check the model defaults `juju model-defaults` includes regions something like:
```
ATTRIBUTE                   DEFAULT           CONTROLLER
agent-metadata-url          -                 -
agent-stream                released          -
apt-ftp-proxy               -                 -
apt-http-proxy              -                 -
apt-https-proxy             -                 -
apt-mirror                  -                 -
automatically-retry-hooks   true              -
default-series              xenial            xenial
development                 false             -
disable-network-management  false             -
enable-os-refresh-update    true              true
enable-os-upgrade           true              false
firewall-mode               instance          -
ftp-proxy                   -                 -
http-proxy                  -                 -
https-proxy                 -                 -
ignore-machine-addresses    false             -
image-metadata-url          -                 -
image-stream                released          -
logforward-enabled          false             -
logging-config              -                 <root>=DEBUG
no-proxy                    -                 https://local
  us-east-1                 https://foo-east  -
  us-west-1                 https://foo-west  -
provisioner-harvest-mode    destroyed         -
proxy-ssh                   false             -
resource-tags               -                 -
ssl-hostname-verification   true              -
test-mode                   false             -
vpc-id                      -                 -
vpc-id-force                false             -
```
5: verify yaml and json output as well.

(Review request: http://reviews.vapour.ws/r/5547/)