### PR TITLE
migration: Implement more prechecks

### DIFF
--- a/apiserver/migrationmaster/facade_test.go
+++ b/apiserver/migrationmaster/facade_test.go
@@ -182,7 +182,7 @@ func (s *Suite) TestSetStatusMessageError(c *gc.C) {
 func (s *Suite) TestPrechecks(c *gc.C) {
 	api := s.mustMakeAPI(c)
 	err := api.Prechecks()
-	c.Assert(err, gc.ErrorMatches, "checking cleanups: boom")
+	c.Assert(err, gc.ErrorMatches, "retrieving model version: boom")
 }
 
 func (s *Suite) TestExport(c *gc.C) {
@@ -435,6 +435,6 @@ type failingPrecheckBackend struct {
 	migration.PrecheckBackend
 }
 
-func (b *failingPrecheckBackend) NeedsCleanup() (bool, error) {
-	return false, errors.New("boom")
+func (b *failingPrecheckBackend) AgentVersion() (version.Number, error) {
+	return version.Number{}, errors.New("boom")
 }

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -79,6 +79,7 @@ import (
 	"github.com/juju/juju/worker/gate"
 	"github.com/juju/juju/worker/imagemetadataworker"
 	"github.com/juju/juju/worker/logsender"
+	"github.com/juju/juju/worker/migrationmaster"
 	"github.com/juju/juju/worker/modelworkermanager"
 	"github.com/juju/juju/worker/mongoupgrader"
 	"github.com/juju/juju/worker/peergrouper"
@@ -998,6 +999,7 @@ func (a *MachineAgent) startModelWorkers(uuid string) (worker.Worker, error) {
 		StatusHistoryPrunerInterval:       5 * time.Minute,
 		SpacesImportedGate:                a.discoverSpacesComplete,
 		NewEnvironFunc:                    newEnvirons,
+		NewMigrationMaster:                migrationmaster.NewWorker,
 	})
 	if err := dependency.Install(engine, manifolds); err != nil {
 		if err := worker.Stop(engine); err != nil {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -28,6 +28,7 @@ import (
 	"gopkg.in/juju/charmrepo.v2-unstable"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/natefinch/lumberjack.v2"
+	"gopkg.in/tomb.v1"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
@@ -35,6 +36,7 @@ import (
 	apimachiner "github.com/juju/juju/api/machiner"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cert"
+	"github.com/juju/juju/cmd/jujud/agent/model"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
@@ -52,9 +54,11 @@ import (
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/authenticationworker"
 	"github.com/juju/juju/worker/certupdater"
+	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/diskmanager"
 	"github.com/juju/juju/worker/instancepoller"
 	"github.com/juju/juju/worker/machiner"
+	"github.com/juju/juju/worker/migrationmaster"
 	"github.com/juju/juju/worker/mongoupgrader"
 	"github.com/juju/juju/worker/storageprovisioner"
 	"github.com/juju/juju/worker/upgrader"
@@ -1285,7 +1289,23 @@ func (s *MachineSuite) TestMigratingModelWorkers(c *gc.C) {
 	uuid := st.ModelUUID()
 
 	tracker := NewEngineTracker()
-	instrumented := TrackModels(c, tracker, modelManifolds)
+
+	// Replace the real migrationmaster worker with a fake one which
+	// does nothing. This is required to make this test be reliable as
+	// the environment required for the migrationmaster to operate
+	// correctly is too involved to set up from here.
+	//
+	// TODO(mjs) - an alternative might be to provide a fake Facade
+	// and api.Open to the real migrationmaster but this test is
+	// awfully far away from the low level details of the worker.
+	origModelManifolds := modelManifolds
+	modelManifoldsDisablingMigrationMaster := func(config model.ManifoldsConfig) dependency.Manifolds {
+		config.NewMigrationMaster = func(config migrationmaster.Config) (worker.Worker, error) {
+			return &nullWorker{}, nil
+		}
+		return origModelManifolds(config)
+	}
+	instrumented := TrackModels(c, tracker, modelManifoldsDisablingMigrationMaster)
 	s.PatchValue(&modelManifolds, instrumented)
 
 	targetControllerTag := names.NewModelTag(utils.MustNewUUID().String())
@@ -1293,7 +1313,7 @@ func (s *MachineSuite) TestMigratingModelWorkers(c *gc.C) {
 		InitiatedBy: names.NewUserTag("admin"),
 		TargetInfo: migration.TargetInfo{
 			ControllerTag: targetControllerTag,
-			Addrs:         []string{"1.2.3.4:5555", "4.3.2.1:6666"},
+			Addrs:         []string{"1.2.3.4:5555"},
 			CACert:        "cert",
 			AuthTag:       names.NewUserTag("user"),
 			Password:      "password",
@@ -1386,4 +1406,17 @@ func (s *MachineSuite) TestReplicasetInitForNewController(c *gc.C) {
 
 	c.Assert(s.fakeEnsureMongo.EnsureCount, gc.Equals, 1)
 	c.Assert(s.fakeEnsureMongo.InitiateCount, gc.Equals, 0)
+}
+
+type nullWorker struct {
+	tomb tomb.Tomb
+}
+
+func (w *nullWorker) Kill() {
+	w.tomb.Kill(nil)
+	w.tomb.Done()
+}
+
+func (w *nullWorker) Wait() error {
+	return w.tomb.Wait()
 }

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -89,6 +89,10 @@ type ManifoldsConfig struct {
 	// NewEnvironFunc is a function opens a provider "environment"
 	// (typically environs.New).
 	NewEnvironFunc environs.NewEnvironFunc
+
+	// NewMigrationMaster is called to create a new migrationmaster
+	// worker.
+	NewMigrationMaster func(migrationmaster.Config) (worker.Worker, error)
 }
 
 // Manifolds returns a set of interdependent dependency manifolds that will
@@ -177,7 +181,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			FortressName:  migrationFortressName,
 			Clock:         config.Clock,
 			NewFacade:     migrationmaster.NewFacade,
-			NewWorker:     migrationmaster.NewWorker,
+			NewWorker:     config.NewMigrationMaster,
 		})),
 
 		// Everything else should be wrapped in ifResponsible,

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -17,27 +17,28 @@ import (
 
 ## Source model
 
-- machines have errors
-  * Status() must be StatusStarted
 - machine being provisioned
   * InstanceStatus() must be StatusRunning
 
+- model is dying/dead
 - unit is being provisioned
 - application is being provisioned?
-- model is dying/dead
+  * check unit count? possibly can't have unit count > 0 without a unit existing - check this
+  * unit count of 0 is ok
+
 - pending reboots
 - units that are dying or dead
 - model is being imported as part of another migration
 
 ## Source controller
 
-- machines have errors, or are being provisioned (as above)
+- machines are being provisioned (as above)
 - controller model is dying/dead
 - pending reboots
 
 ## Target controller
 
-- machines have errors, or are being provisioned (as above)
+- machines are being provisioned (as above)
 - controller model is dying/dead
 - target controller already has a model with the same owner:name
 - target controller already has a model with the same UUID
@@ -133,6 +134,12 @@ func checkMachines(backend PrecheckBackend) error {
 	for _, machine := range machines {
 		if machine.Life() != state.Alive {
 			return errors.Errorf("machine %s is %s", machine.Id(), machine.Life())
+		}
+
+		if statusInfo, err := machine.Status(); err != nil {
+			return errors.Annotatef(err, "retrieving machine %s status", machine.Id())
+		} else if statusInfo.Status != status.StatusStarted {
+			return errors.Errorf("machine %s is %s", machine.Id(), statusInfo.Status)
 		}
 
 		tools, err := machine.AgentTools()

--- a/migration/precheck_shim.go
+++ b/migration/precheck_shim.go
@@ -46,3 +46,16 @@ func (s *precheckShim) AllMachines() ([]PrecheckMachine, error) {
 	}
 	return out, nil
 }
+
+// ControllerBackend implements PrecheckBackend.
+func (s *precheckShim) ControllerBackend() (PrecheckBackend, error) {
+	model, err := s.State.ControllerModel()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	st, err := s.State.ForModel(model.ModelTag())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return PrecheckShim(st), nil
+}


### PR DESCRIPTION
In the model, source controller and target controller, ensure that:
* all machines are Alive
* all machines are provisioned
* all machine agents are started

Also:
* ensure there is no controller upgrade document in the source or target controller (indicates an upgrade in progress)
* ensure the source controller machines have consistent tools version (i.e. aren't upgrading)

(Review request: http://reviews.vapour.ws/r/5550/)