### PR TITLE
Remove PRECHECK migration phase

### DIFF
--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -85,7 +85,7 @@ func (s *ClientSuite) TestMigrationStatus(c *gc.C) {
 				},
 			},
 			MigrationId:      "id",
-			Phase:            "PRECHECK",
+			Phase:            "IMPORT",
 			PhaseChangedTime: timestamp,
 		}
 		return nil
@@ -97,7 +97,7 @@ func (s *ClientSuite) TestMigrationStatus(c *gc.C) {
 	c.Assert(status, gc.DeepEquals, migration.MigrationStatus{
 		MigrationId:      "id",
 		ModelUUID:        modelUUID,
-		Phase:            migration.PRECHECK,
+		Phase:            migration.IMPORT,
 		PhaseChangedTime: timestamp,
 		TargetInfo: migration.TargetInfo{
 			ControllerTag: names.NewModelTag(controllerUUID),
@@ -298,7 +298,7 @@ func (s *ClientSuite) TestMinionReports(c *gc.C) {
 		out := result.(*params.MinionReports)
 		*out = params.MinionReports{
 			MigrationId:  "id",
-			Phase:        "PRECHECK",
+			Phase:        "IMPORT",
 			SuccessCount: 4,
 			UnknownCount: 3,
 			UnknownSample: []string{
@@ -322,7 +322,7 @@ func (s *ClientSuite) TestMinionReports(c *gc.C) {
 	})
 	c.Assert(out, gc.DeepEquals, migration.MinionReports{
 		MigrationId:         "id",
-		Phase:               migration.PRECHECK,
+		Phase:               migration.IMPORT,
 		SuccessCount:        4,
 		UnknownCount:        3,
 		SomeUnknownMachines: []string{"3", "4"},
@@ -358,7 +358,7 @@ func (s *ClientSuite) TestMinionReportsBadUnknownTag(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(_ string, _ int, _ string, _ string, _ interface{}, result interface{}) error {
 		out := result.(*params.MinionReports)
 		*out = params.MinionReports{
-			Phase:         "PRECHECK",
+			Phase:         "IMPORT",
 			UnknownSample: []string{"carl"},
 		}
 		return nil
@@ -372,7 +372,7 @@ func (s *ClientSuite) TestMinionReportsBadFailedTag(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(_ string, _ int, _ string, _ string, _ interface{}, result interface{}) error {
 		out := result.(*params.MinionReports)
 		*out = params.MinionReports{
-			Phase:  "PRECHECK",
+			Phase:  "IMPORT",
 			Failed: []string{"dave"},
 		}
 		return nil

--- a/apiserver/migrationmaster/facade_test.go
+++ b/apiserver/migrationmaster/facade_test.go
@@ -109,7 +109,7 @@ func (s *Suite) TestMigrationStatus(c *gc.C) {
 			},
 		},
 		MigrationId:      "id",
-		Phase:            "PRECHECK",
+		Phase:            "IMPORT",
 		PhaseChangedTime: s.backend.migration.PhaseChangedTime(),
 	})
 }
@@ -282,7 +282,7 @@ func (s *Suite) TestMinionReports(c *gc.C) {
 	}
 	c.Assert(reports, gc.DeepEquals, params.MinionReports{
 		MigrationId:   "id",
-		Phase:         "PRECHECK",
+		Phase:         "IMPORT",
 		SuccessCount:  3,
 		UnknownCount:  len(unknown),
 		UnknownSample: expectedSample,
@@ -368,7 +368,7 @@ func (m *stubMigration) Id() string {
 }
 
 func (m *stubMigration) Phase() (coremigration.Phase, error) {
-	return coremigration.PRECHECK, nil
+	return coremigration.IMPORT, nil
 }
 
 func (m *stubMigration) PhaseChangedTime() time.Time {

--- a/apiserver/migrationminion/migrationminion_test.go
+++ b/apiserver/migrationminion/migrationminion_test.go
@@ -74,13 +74,13 @@ func (s *Suite) TestReport(c *gc.C) {
 	api := s.mustMakeAPI(c)
 	err := api.Report(params.MinionReport{
 		MigrationId: "id",
-		Phase:       "PRECHECK",
+		Phase:       "IMPORT",
 		Success:     true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.stub.CheckCalls(c, []testing.StubCall{
 		{"Migration", []interface{}{"id"}},
-		{"Report", []interface{}{s.authorizer.Tag, migration.PRECHECK, true}},
+		{"Report", []interface{}{s.authorizer.Tag, migration.IMPORT, true}},
 	})
 }
 

--- a/apiserver/watcher_test.go
+++ b/apiserver/watcher_test.go
@@ -100,7 +100,7 @@ func (s *watcherSuite) TestMigrationStatusWatcher(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, params.MigrationStatus{
 		MigrationId:    "id",
 		Attempt:        2,
-		Phase:          "PRECHECK",
+		Phase:          "IMPORT",
 		SourceAPIAddrs: []string{"1.2.3.4:5", "2.3.4.5:6", "3.4.5.6:7"},
 		SourceCACert:   "no worries",
 		TargetAPIAddrs: []string{"1.2.3.4:5555"},
@@ -201,7 +201,7 @@ func (m *fakeModelMigration) Attempt() (int, error) {
 }
 
 func (m *fakeModelMigration) Phase() (migration.Phase, error) {
-	return migration.PRECHECK, nil
+	return migration.IMPORT, nil
 }
 
 func (m *fakeModelMigration) TargetInfo() (*migration.TargetInfo, error) {

--- a/core/migration/phase.go
+++ b/core/migration/phase.go
@@ -11,7 +11,6 @@ const (
 	UNKNOWN Phase = iota
 	NONE
 	QUIESCE
-	PRECHECK
 	IMPORT
 	VALIDATION
 	SUCCESS
@@ -27,7 +26,6 @@ var phaseNames = []string{
 	"UNKNOWN", // To catch uninitialised fields.
 	"NONE",    // For watchers to indicate there's never been a migration attempt.
 	"QUIESCE",
-	"PRECHECK",
 	"IMPORT",
 	"VALIDATION",
 	"SUCCESS",
@@ -83,7 +81,7 @@ func (p Phase) IsRunning() bool {
 		return false
 	}
 	switch p {
-	case QUIESCE, PRECHECK, IMPORT, VALIDATION, SUCCESS:
+	case QUIESCE, IMPORT, VALIDATION, SUCCESS:
 		return true
 	default:
 		return false
@@ -95,8 +93,7 @@ func (p Phase) IsRunning() bool {
 // The keys are the "from" states and the values enumerate the
 // possible "to" states.
 var validTransitions = map[Phase][]Phase{
-	QUIESCE:     {PRECHECK, ABORT},
-	PRECHECK:    {IMPORT, ABORT},
+	QUIESCE:     {IMPORT, ABORT},
 	IMPORT:      {VALIDATION, ABORT},
 	VALIDATION:  {SUCCESS, ABORT},
 	SUCCESS:     {LOGTRANSFER},

--- a/core/migration/phase_test.go
+++ b/core/migration/phase_test.go
@@ -24,7 +24,7 @@ func (s *PhaseSuite) TestUNKNOWN(c *gc.C) {
 }
 
 func (s *PhaseSuite) TestStringValid(c *gc.C) {
-	c.Check(migration.PRECHECK.String(), gc.Equals, "PRECHECK")
+	c.Check(migration.IMPORT.String(), gc.Equals, "IMPORT")
 	c.Check(migration.UNKNOWN.String(), gc.Equals, "UNKNOWN")
 	c.Check(migration.ABORT.String(), gc.Equals, "ABORT")
 }
@@ -74,8 +74,7 @@ func (s *PhaseSuite) TestIsRunning(c *gc.C) {
 func (s *PhaseSuite) TestCanTransitionTo(c *gc.C) {
 	c.Check(migration.QUIESCE.CanTransitionTo(migration.SUCCESS), jc.IsFalse)
 	c.Check(migration.QUIESCE.CanTransitionTo(migration.ABORT), jc.IsTrue)
-	c.Check(migration.QUIESCE.CanTransitionTo(migration.PRECHECK), jc.IsTrue)
+	c.Check(migration.QUIESCE.CanTransitionTo(migration.IMPORT), jc.IsTrue)
 	c.Check(migration.QUIESCE.CanTransitionTo(migration.Phase(-1)), jc.IsFalse)
-
 	c.Check(migration.ABORT.CanTransitionTo(migration.QUIESCE), jc.IsFalse)
 }

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -266,7 +266,6 @@ func (s *MigrationSuite) TestLatestMigrationPreviousMigration(c *gc.C) {
 	// migrated. Don't actually remove model documents to simulate it
 	// having been migrated back to the controller.
 	phases := []migration.Phase{
-		migration.PRECHECK,
 		migration.IMPORT,
 		migration.VALIDATION,
 		migration.SUCCESS,
@@ -317,13 +316,13 @@ func (s *MigrationSuite) TestRefresh(c *gc.C) {
 	mig2, err := s.State2.LatestMigration()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = mig1.SetPhase(migration.PRECHECK)
+	err = mig1.SetPhase(migration.IMPORT)
 	c.Assert(err, jc.ErrorIsNil)
 
 	assertPhase(c, mig2, migration.QUIESCE)
 	err = mig2.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	assertPhase(c, mig2, migration.PRECHECK)
+	assertPhase(c, mig2, migration.IMPORT)
 }
 
 func (s *MigrationSuite) TestSuccessfulPhaseTransitions(c *gc.C) {
@@ -337,7 +336,6 @@ func (s *MigrationSuite) TestSuccessfulPhaseTransitions(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	phases := []migration.Phase{
-		migration.PRECHECK,
 		migration.IMPORT,
 		migration.VALIDATION,
 		migration.SUCCESS,
@@ -407,7 +405,6 @@ func (s *MigrationSuite) TestREAPFAILEDCleanup(c *gc.C) {
 
 	// Advance the migration to REAPFAILED.
 	phases := []migration.Phase{
-		migration.PRECHECK,
 		migration.IMPORT,
 		migration.VALIDATION,
 		migration.SUCCESS,
@@ -444,18 +441,18 @@ func (s *MigrationSuite) TestPhaseChangeRace(c *gc.C) {
 	defer state.SetBeforeHooks(c, s.State2, func() {
 		mig, err := s.State2.LatestMigration()
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(mig.SetPhase(migration.PRECHECK), jc.ErrorIsNil)
+		c.Assert(mig.SetPhase(migration.IMPORT), jc.ErrorIsNil)
 	}).Check()
 
-	err = mig.SetPhase(migration.PRECHECK)
+	err = mig.SetPhase(migration.IMPORT)
 	c.Assert(err, gc.ErrorMatches, "phase already changed")
 	assertPhase(c, mig, migration.QUIESCE)
 
 	// After a refresh it the phase change should be ok.
 	c.Assert(mig.Refresh(), jc.ErrorIsNil)
-	err = mig.SetPhase(migration.PRECHECK)
+	err = mig.SetPhase(migration.IMPORT)
 	c.Assert(err, jc.ErrorIsNil)
-	assertPhase(c, mig, migration.PRECHECK)
+	assertPhase(c, mig, migration.IMPORT)
 }
 
 func (s *MigrationSuite) TestStatusMessage(c *gc.C) {
@@ -562,7 +559,7 @@ func (s *MigrationSuite) TestWatchMigrationStatus(c *gc.C) {
 	wc.AssertOneChange()
 
 	// Change phase.
-	c.Assert(mig2.SetPhase(migration.PRECHECK), jc.ErrorIsNil)
+	c.Assert(mig2.SetPhase(migration.IMPORT), jc.ErrorIsNil)
 	wc.AssertOneChange()
 
 	// End it.
@@ -676,7 +673,7 @@ func (s *MigrationSuite) TestMinionReportWithOldPhase(c *gc.C) {
 	c.Check(reports.Succeeded, gc.HasLen, 0)
 
 	// Advance the migration
-	c.Assert(mig.SetPhase(migration.PRECHECK), jc.ErrorIsNil)
+	c.Assert(mig.SetPhase(migration.IMPORT), jc.ErrorIsNil)
 
 	// Submit minion report for the old phase.
 	tag := names.NewMachineTag("42")


### PR DESCRIPTION
PRECHECK has now been merged with QUIESCE. Migration prechecks are now performed before waiting for agents to report that they are in read-only mode. This prevents long waits for the 15 min minion wait timeout to occur when an agent or machine is down and won't be able to report back.

(Review request: http://reviews.vapour.ws/r/5551/)