### PR TITLE
Add 2 new cloud facade apis - revoke and list credentials

### DIFF
--- a/apiserver/cloud/backend.go
+++ b/apiserver/cloud/backend.go
@@ -18,6 +18,7 @@ type Backend interface {
 	ControllerTag() names.ControllerTag
 	ModelTag() names.ModelTag
 	UpdateCloudCredential(names.CloudCredentialTag, cloud.Credential) error
+	RemoveCloudCredential(names.CloudCredentialTag) error
 
 	IsControllerAdmin(names.UserTag) (bool, error)
 

--- a/apiserver/common/cloudspec/cloudspec.go
+++ b/apiserver/common/cloudspec/cloudspec.go
@@ -74,8 +74,8 @@ func (s CloudSpecAPI) CloudSpec(args params.Entities) (params.CloudSpecResults, 
 		var paramsCloudCredential *params.CloudCredential
 		if spec.Credential != nil && spec.Credential.AuthType() != "" {
 			paramsCloudCredential = &params.CloudCredential{
-				string(spec.Credential.AuthType()),
-				spec.Credential.Attributes(),
+				AuthType:   string(spec.Credential.AuthType()),
+				Attributes: spec.Credential.Attributes(),
 			}
 		}
 		results.Results[i].Result = &params.CloudSpec{

--- a/apiserver/common/cloudspec/cloudspec_test.go
+++ b/apiserver/common/cloudspec/cloudspec_test.go
@@ -79,8 +79,8 @@ func (s *CloudSpecSuite) TestCloudSpec(c *gc.C) {
 			"identity-endpoint",
 			"storage-endpoint",
 			&params.CloudCredential{
-				"auth-type",
-				map[string]string{"k": "v"},
+				AuthType:   "auth-type",
+				Attributes: map[string]string{"k": "v"},
 			},
 		},
 	}, {

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -38,10 +38,28 @@ type CloudsResult struct {
 	Clouds map[string]Cloud `json:"clouds,omitempty"`
 }
 
-// CloudCredential contains a cloud credential.
+// CloudCredential contains a cloud credential
+// possibly with secrets redacted.
 type CloudCredential struct {
-	AuthType   string            `json:"auth-type"`
+	// AuthType is the authentication type.
+	AuthType string `json:"auth-type"`
+
+	// Attributes contains non-secret credential values.
 	Attributes map[string]string `json:"attrs,omitempty"`
+
+	// Redacted is a list of redacted attributes
+	Redacted []string `json:"redacted,omitempty"`
+}
+
+// CloudCredentialResult contains a CloudCredential or an error.
+type CloudCredentialResult struct {
+	Result *CloudCredential `json:"result,omitempty"`
+	Error  *Error           `json:"error,omitempty"`
+}
+
+// CloudCredentialResults contains a set of CloudCredentialResults.
+type CloudCredentialResults struct {
+	Results []CloudCredentialResult `json:"results,omitempty"`
 }
 
 // UserCloud contains a user/cloud tag pair, typically used for identifying
@@ -51,7 +69,7 @@ type UserCloud struct {
 	CloudTag string `json:"cloud-tag"`
 }
 
-// UserClouds contains a set of USerClouds.
+// UserClouds contains a set of UserClouds.
 type UserClouds struct {
 	UserClouds []UserCloud `json:"user-clouds,omitempty"`
 }

--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -33,6 +33,9 @@ type Credential struct {
 	authType   AuthType
 	attributes map[string]string
 
+	// Revoked is true if the credential has been revoked.
+	Revoked bool
+
 	// Label is optionally set to describe the credentials to a user.
 	Label string
 }

--- a/cloud/credentials_test.go
+++ b/cloud/credentials_test.go
@@ -620,6 +620,7 @@ func (s *credentialsSuite) TestRemoveSecrets(c *gc.C) {
 			"password": "secret",
 		},
 	)
+	c.Assert(cred.Revoked, jc.IsFalse)
 	schema := cloud.CredentialSchema{{
 		"username", cloud.CredentialAttr{},
 	}, {

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1108,7 +1108,7 @@ func (s *BootstrapSuite) TestBootstrapProviderDetectRegions(c *gc.C) {
 	c.Assert(bootstrap.args.CloudCredentialName, gc.Equals, "default")
 	c.Assert(bootstrap.args.Cloud, jc.DeepEquals, cloud.Cloud{
 		Type:      "dummy",
-		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
+		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
 		Regions:   []cloud.Region{{Name: "bruce", Endpoint: "endpoint"}},
 	})
 }
@@ -1129,7 +1129,7 @@ func (s *BootstrapSuite) TestBootstrapProviderDetectNoRegions(c *gc.C) {
 	c.Assert(bootstrap.args.CloudRegion, gc.Equals, "")
 	c.Assert(bootstrap.args.Cloud, jc.DeepEquals, cloud.Cloud{
 		Type:      "dummy",
-		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
+		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
 	})
 }
 

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -135,7 +135,7 @@ type CloudAPI interface {
 	DefaultCloud() (names.CloudTag, error)
 	Clouds() (map[names.CloudTag]jujucloud.Cloud, error)
 	Cloud(names.CloudTag) (jujucloud.Cloud, error)
-	Credentials(names.UserTag, names.CloudTag) ([]names.CloudCredentialTag, error)
+	UserCredentials(names.UserTag, names.CloudTag) ([]names.CloudCredentialTag, error)
 	UpdateCredential(names.CloudCredentialTag, jujucloud.Credential) error
 }
 
@@ -405,7 +405,7 @@ func (c *addModelCommand) maybeUploadCredential(
 	// TODO(axw) consider implementing a call that can check
 	// that the credential exists without fetching all of the
 	// names.
-	credentialTags, err := cloudClient.Credentials(modelOwnerTag, cloudTag)
+	credentialTags, err := cloudClient.UserCredentials(modelOwnerTag, cloudTag)
 	if err != nil {
 		return names.CloudCredentialTag{}, errors.Trace(err)
 	}

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -461,8 +461,8 @@ func (c *fakeCloudAPI) Cloud(tag names.CloudTag) (cloud.Cloud, error) {
 	}, c.NextErr()
 }
 
-func (c *fakeCloudAPI) Credentials(user names.UserTag, cloud names.CloudTag) ([]names.CloudCredentialTag, error) {
-	c.MethodCall(c, "Credentials", user, cloud)
+func (c *fakeCloudAPI) UserCredentials(user names.UserTag, cloud names.CloudTag) ([]names.CloudCredentialTag, error) {
+	c.MethodCall(c, "UserCredentials", user, cloud)
 	return []names.CloudCredentialTag{
 		names.NewCloudCredentialTag("cloud/admin@local/default"),
 		names.NewCloudCredentialTag("aws/other@local/secrets"),

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -264,7 +264,8 @@ func (s *cmdControllerSuite) testControllerDestroy(c *gc.C, forceAPI bool) {
 
 	destroyOp := (<-ops).(dummy.OpDestroy)
 	c.Assert(destroyOp.Env, gc.Equals, "controller")
-	c.Assert(destroyOp.Cloud, jc.DeepEquals, dummy.SampleCloudSpec())
+	c.Assert(destroyOp.Cloud, gc.Equals, "dummy")
+	c.Assert(destroyOp.CloudRegion, gc.Equals, "dummy-region")
 
 	store := jujuclient.NewFileClientStore()
 	_, err := store.ControllerByName("kontroll")

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -364,12 +364,12 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 		CloudRegion:      "dummy-region",
 		Cloud: cloud.Cloud{
 			Type:             cloudSpec.Type,
-			AuthTypes:        []cloud.AuthType{cloud.EmptyAuthType},
+			AuthTypes:        []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
 			Endpoint:         cloudSpec.Endpoint,
 			IdentityEndpoint: cloudSpec.IdentityEndpoint,
 			StorageEndpoint:  cloudSpec.StorageEndpoint,
 			Regions: []cloud.Region{
-				cloud.Region{
+				{
 					Name:             "dummy-region",
 					Endpoint:         "dummy-endpoint",
 					IdentityEndpoint: "dummy-identity-endpoint",

--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -125,4 +126,31 @@ func (s *CloudCredentialsSuite) TestCloudCredentials(c *gc.C) {
 		tag1: cred1,
 		tag3: cred2,
 	})
+}
+
+func (s *CloudCredentialsSuite) TestRemoveCredentials(c *gc.C) {
+	// Create it.
+	err := s.State.AddCloud("stratus", cloud.Cloud{
+		Type:      "low",
+		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	tag := names.NewCloudCredentialTag("stratus/bob@local/bobcred1")
+	cred := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+		"foo": "foo val",
+		"bar": "bar val",
+	})
+	err = s.State.UpdateCloudCredential(tag, cred)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.CloudCredential(tag)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Remove it.
+	err = s.State.RemoveCloudCredential(tag)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check it.
+	_, err = s.State.CloudCredential(tag)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }


### PR DESCRIPTION
The cloud facade gains 2 new apis:
- revoke a credential
- list credentials for the specified tags

(Review request: http://reviews.vapour.ws/r/5554/)