### PR TITLE
rework juju status output

### DIFF
--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -877,7 +877,7 @@ func processUnitLost(unit *state.Unit, unitStatus *params.UnitStatus) {
 
 		if wlStatus != status.StatusError {
 			unitStatus.WorkloadStatus.Status = status.StatusUnknown.String()
-			unitStatus.WorkloadStatus.Info = fmt.Sprintf("agent is lost, sorry! See 'juju status-history %s'", unit.Name())
+			unitStatus.WorkloadStatus.Info = fmt.Sprintf("Agent lost, see 'juju status-history %s'", unit.Name())
 		}
 		unitStatus.AgentStatus.Status = status.StatusLost.String()
 		unitStatus.AgentStatus.Info = "agent is not communicating with the server"

--- a/cmd/juju/machine/base.go
+++ b/cmd/juju/machine/base.go
@@ -5,6 +5,7 @@ package machine
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -29,15 +30,17 @@ type baselistMachinesCommand struct {
 	api           statusAPI
 	machineIds    []string
 	defaultFormat string
+	color         bool
 }
 
 // SetFlags sets utc and format flags based on user specified options.
 func (c *baselistMachinesCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.isoTime, "utc", false, "Display time as UTC in RFC3339 format")
+	f.BoolVar(&c.color, "color", false, "Force use of ANSI color codes")
 	c.out.AddFlags(f, c.defaultFormat, map[string]cmd.Formatter{
 		"yaml":    cmd.FormatYaml,
 		"json":    cmd.FormatJson,
-		"tabular": status.FormatMachineTabular,
+		"tabular": c.tabular,
 	})
 }
 
@@ -71,4 +74,8 @@ func (c *baselistMachinesCommand) Run(ctx *cmd.Context) error {
 	formatter := status.NewStatusFormatter(fullStatus, c.isoTime)
 	formatted := formatter.MachineFormat(c.machineIds)
 	return c.out.Write(ctx, formatted)
+}
+
+func (c *baselistMachinesCommand) tabular(writer io.Writer, value interface{}) error {
+	return status.FormatMachineTabular(writer, c.color, value)
 }

--- a/cmd/juju/machine/list_test.go
+++ b/cmd/juju/machine/list_test.go
@@ -79,10 +79,10 @@ func (s *MachineListCommandSuite) TestMachine(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineListCommand())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"MACHINE    STATE    DNS       INS-ID               SERIES  AZ\n"+
-		"0          started  10.0.0.1  juju-badd06-0        trusty  us-east-1\n"+
-		"1          started  10.0.0.2  juju-badd06-1        trusty  \n"+
-		"  1/lxd/0  pending  10.0.0.3  juju-badd06-1-lxd-0  trusty  \n"+
+		"MACHINE  STATE    DNS       INS-ID               SERIES  AZ\n"+
+		"0        started  10.0.0.1  juju-badd06-0        trusty  us-east-1\n"+
+		"1        started  10.0.0.2  juju-badd06-1        trusty  \n"+
+		"1/lxd/0  pending  10.0.0.3  juju-badd06-1-lxd-0  trusty  \n"+
 		"\n")
 }
 

--- a/cmd/juju/machine/show_test.go
+++ b/cmd/juju/machine/show_test.go
@@ -72,10 +72,10 @@ func (s *MachineShowCommandSuite) TestShowTabularMachine(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineShowCommand(), "--format", "tabular", "0", "1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"MACHINE    STATE    DNS       INS-ID               SERIES  AZ\n"+
-		"0          started  10.0.0.1  juju-badd06-0        trusty  us-east-1\n"+
-		"1          started  10.0.0.2  juju-badd06-1        trusty  \n"+
-		"  1/lxd/0  pending  10.0.0.3  juju-badd06-1-lxd-0  trusty  \n"+
+		"MACHINE  STATE    DNS       INS-ID               SERIES  AZ\n"+
+		"0        started  10.0.0.1  juju-badd06-0        trusty  us-east-1\n"+
+		"1        started  10.0.0.2  juju-badd06-1        trusty  \n"+
+		"1/lxd/0  pending  10.0.0.3  juju-badd06-1-lxd-0  trusty  \n"+
 		"\n")
 }
 

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -5,6 +5,7 @@ package status
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 
@@ -37,6 +38,8 @@ type statusCommand struct {
 	patterns []string
 	isoTime  bool
 	api      statusAPI
+
+	color bool
 }
 
 var usageSummary = `
@@ -93,6 +96,7 @@ func (c *statusCommand) Info() *cmd.Info {
 
 func (c *statusCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.isoTime, "utc", false, "Display time as UTC in RFC3339 format")
+	f.BoolVar(&c.color, "color", false, "Force use of ANSI color codes")
 
 	defaultFormat := "tabular"
 
@@ -102,7 +106,7 @@ func (c *statusCommand) SetFlags(f *gnuflag.FlagSet) {
 		"short":   FormatOneline,
 		"oneline": FormatOneline,
 		"line":    FormatOneline,
-		"tabular": FormatTabular,
+		"tabular": c.FormatTabular,
 		"summary": FormatSummary,
 	})
 }
@@ -149,4 +153,8 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 	formatter := newStatusFormatter(status, c.ControllerName(), c.isoTime)
 	formatted := formatter.format()
 	return c.out.Write(ctx, formatted)
+}
+
+func (c *statusCommand) FormatTabular(writer io.Writer, value interface{}) error {
+	return FormatTabular(writer, c.color, value)
 }

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -1284,7 +1284,7 @@ var statusTests = []testCase{
 								"machine": "0",
 								"workload-status": M{
 									"current": "unknown",
-									"message": "agent is lost, sorry! See 'juju status-history dummy-application/0'",
+									"message": "Agent lost, see 'juju status-history dummy-application/0'",
 									"since":   "01 Apr 15 01:23+10:00",
 								},
 								"juju-status": M{
@@ -3194,10 +3194,10 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 
 func (s *StatusSuite) TestMigrationInProgressTabular(c *gc.C) {
 	expected := `
-MODEL   CONTROLLER  CLOUD/REGION        VERSION  MESSAGE
+MODEL   CONTROLLER  CLOUD/REGION        VERSION  NOTES
 hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar
 
-APP  VERSION  STATUS  EXPOSED  ORIGIN  CHARM  REV  OS
+APP  VERSION  STATUS  SCALE  CHARM  STORE  REV  OS  NOTES
 
 UNIT  WORKLOAD  AGENT  MACHINE  PUBLIC-ADDRESS  PORTS  MESSAGE
 
@@ -3215,10 +3215,10 @@ MACHINE  STATE  DNS  INS-ID  SERIES  AZ
 
 func (s *StatusSuite) TestMigrationInProgressAndUpgradeAvailable(c *gc.C) {
 	expected := `
-MODEL   CONTROLLER  CLOUD/REGION        VERSION  MESSAGE
+MODEL   CONTROLLER  CLOUD/REGION        VERSION  NOTES
 hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar
 
-APP  VERSION  STATUS  EXPOSED  ORIGIN  CHARM  REV  OS
+APP  VERSION  STATUS  SCALE  CHARM  STORE  REV  OS  NOTES
 
 UNIT  WORKLOAD  AGENT  MACHINE  PUBLIC-ADDRESS  PORTS  MESSAGE
 
@@ -3490,13 +3490,13 @@ func (s *StatusSuite) testStatusWithFormatTabular(c *gc.C, useFeatureFlag bool) 
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	expected := `
-MODEL       CONTROLLER  CLOUD/REGION        VERSION  MESSAGE
+MODEL       CONTROLLER  CLOUD/REGION        VERSION  NOTES
 controller  kontroll    dummy/dummy-region  1.2.3    upgrade available: 1.2.4
 
-APP        VERSION  STATUS       EXPOSED  ORIGIN      CHARM      REV  OS
-logging    a bi...               true     jujucharms  logging    1    ubuntu
-mysql      5.7.13   maintenance  true     jujucharms  mysql      1    ubuntu
-wordpress  4.5.3    active       true     jujucharms  wordpress  3    ubuntu
+APP        VERSION  STATUS       SCALE  CHARM      STORE       REV  OS      NOTES
+logging    a bi...               2/2    logging    jujucharms  1    ubuntu  exposed
+mysql      5.7.13   maintenance  1/1    mysql      jujucharms  1    ubuntu  exposed
+wordpress  4.5.3    active       1/1    wordpress  jujucharms  3    ubuntu  exposed
 
 RELATION           PROVIDES   CONSUMES   TYPE
 juju-info          logging    mysql      regular
@@ -3554,14 +3554,14 @@ func (s *StatusSuite) TestFormatTabularHookActionName(c *gc.C) {
 		},
 	}
 	out := &bytes.Buffer{}
-	err := FormatTabular(out, status)
+	err := FormatTabular(out, false, status)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out.String(), gc.Equals, `
 MODEL  CONTROLLER  CLOUD/REGION  VERSION
                                  
 
-APP  VERSION  STATUS  EXPOSED  ORIGIN  CHARM  REV  OS
-foo                   false                   0    
+APP  VERSION  STATUS  SCALE  CHARM  STORE  REV  OS  NOTES
+foo                   2/2                  0        
 
 UNIT   WORKLOAD     AGENT      MACHINE  PUBLIC-ADDRESS  PORTS  MESSAGE
 foo/0  maintenance  executing                                  (config-changed) doing some work
@@ -3588,7 +3588,7 @@ func (s *StatusSuite) TestFormatTabularConsistentPeerRelationName(c *gc.C) {
 		},
 	}
 	out := &bytes.Buffer{}
-	err := FormatTabular(out, status)
+	err := FormatTabular(out, false, status)
 	c.Assert(err, jc.ErrorIsNil)
 	sections, err := splitTableSections(out.Bytes())
 	c.Assert(err, jc.ErrorIsNil)
@@ -3648,14 +3648,14 @@ func (s *StatusSuite) TestFormatTabularMetering(c *gc.C) {
 		},
 	}
 	out := &bytes.Buffer{}
-	err := FormatTabular(out, status)
+	err := FormatTabular(out, false, status)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out.String(), gc.Equals, `
 MODEL  CONTROLLER  CLOUD/REGION  VERSION
                                  
 
-APP  VERSION  STATUS  EXPOSED  ORIGIN  CHARM  REV  OS
-foo                   false                   0    
+APP  VERSION  STATUS  SCALE  CHARM  STORE  REV  OS  NOTES
+foo                   0/2                  0        
 
 UNIT   WORKLOAD  AGENT  MACHINE  PUBLIC-ADDRESS  PORTS  MESSAGE
 foo/0                                                   

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -4,10 +4,12 @@
 package output
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/juju/ansiterm"
 	"github.com/juju/cmd"
+	"github.com/juju/juju/status"
 )
 
 // DefaultFormatters holds the formatters that can be
@@ -30,6 +32,97 @@ func TabWriter(writer io.Writer) *ansiterm.TabWriter {
 	return ansiterm.NewTabWriter(writer, minwidth, tabwidth, padding, padchar, flags)
 }
 
+// TabWriterPrint returns a function that is used to help print many
+// elements to a tab writer.
+func TabWriterPrint(tw *ansiterm.TabWriter) func(...interface{}) {
+	w := Wrapper{tw}
+	return w.Print
+}
+
+// TabWriterPrintln returns a function that is used to help print many
+// elements to a tab writer, and finishes with a new line.
+func TabWriterPrintln(tw *ansiterm.TabWriter) func(...interface{}) {
+	w := Wrapper{tw}
+	return w.Println
+}
+
+// TabWriterPrintColor returns a function that will print out a single value
+// followed by a tab in the color context specified.
+func TabWriterPrintColor(tw *ansiterm.TabWriter) func(*ansiterm.Context, interface{}) {
+	w := Wrapper{tw}
+	return w.PrintColor
+}
+
+// Wrapper provides some helper functions for writing values out tab separated.
+type Wrapper struct {
+	*ansiterm.TabWriter
+}
+
+// Print writes each value followed by a tab.
+func (w *Wrapper) Print(values ...interface{}) {
+	for _, v := range values {
+		fmt.Fprintf(w, "%v\t", v)
+	}
+}
+
+// Println writes many tab separated values finished with a new line.
+func (w *Wrapper) Println(values ...interface{}) {
+	for i, v := range values {
+		if i != len(values)-1 {
+			fmt.Fprintf(w, "%v\t", v)
+		} else {
+			fmt.Fprintf(w, "%v", v)
+		}
+	}
+	fmt.Fprintln(w)
+}
+
+// PrintColor writes the value out in the color context specified.
+func (w *Wrapper) PrintColor(ctx *ansiterm.Context, value interface{}) {
+	if ctx != nil {
+		ctx.Fprintf(w.TabWriter, "%v\t", value)
+	} else {
+		fmt.Fprintf(w, "%v\t", value)
+	}
+}
+
+// PrintStatus writes out the status value in the standard color.
+func (w *Wrapper) PrintStatus(status status.Status) {
+	w.PrintColor(statusColors[status], status)
+}
+
 // CurrentHighlight is the color used to show the current
-// controller, user or model in tabular output.
-var CurrentHighlight = ansiterm.Foreground(ansiterm.Green)
+// controller, user or model in tabular
+var CurrentHighlight = ansiterm.Foreground(ansiterm.Blue)
+
+// ErrorHighlight is the color used to show error conditions.
+var ErrorHighlight = ansiterm.Foreground(ansiterm.Red)
+
+// WarningHighlight is the color used to show warning conditions.
+// Generally things that the user should be aware of, but not necessarily
+// requiring any user action.
+var WarningHighlight = ansiterm.Foreground(ansiterm.Yellow)
+
+// GoodHighlight is used to indicate good or success conditions.
+var GoodHighlight = ansiterm.Foreground(ansiterm.Blue)
+
+var statusColors = map[status.Status]*ansiterm.Context{
+	// good
+	status.StatusActive:  GoodHighlight,
+	status.StatusIdle:    GoodHighlight,
+	status.StatusStarted: GoodHighlight,
+	// busy
+	status.StatusAllocating:  WarningHighlight,
+	status.StatusExecuting:   WarningHighlight,
+	status.StatusLost:        WarningHighlight,
+	status.StatusMaintenance: WarningHighlight,
+	status.StatusPending:     WarningHighlight,
+	status.StatusRebooting:   WarningHighlight,
+	status.StatusStopped:     WarningHighlight,
+	status.StatusUnknown:     WarningHighlight,
+	// bad
+	status.StatusBlocked: ErrorHighlight,
+	status.StatusDown:    ErrorHighlight,
+	status.StatusError:   ErrorHighlight,
+	status.StatusFailed:  ErrorHighlight,
+}


### PR DESCRIPTION
Adds a touch of color for the status.
Adds current/desired scale for applications.
Changes app heading origin to store.
App exposure now shown in notes column.

(Review request: http://reviews.vapour.ws/r/5555/)