### PR TITLE
migration: Finalise source prechecks

### DIFF
--- a/apiserver/migrationmaster/facade_test.go
+++ b/apiserver/migrationmaster/facade_test.go
@@ -182,7 +182,7 @@ func (s *Suite) TestSetStatusMessageError(c *gc.C) {
 func (s *Suite) TestPrechecks(c *gc.C) {
 	api := s.mustMakeAPI(c)
 	err := api.Prechecks()
-	c.Assert(err, gc.ErrorMatches, "retrieving model version: boom")
+	c.Assert(err, gc.ErrorMatches, "retrieving model life: boom")
 }
 
 func (s *Suite) TestExport(c *gc.C) {
@@ -435,6 +435,6 @@ type failingPrecheckBackend struct {
 	migration.PrecheckBackend
 }
 
-func (b *failingPrecheckBackend) AgentVersion() (version.Number, error) {
-	return version.Number{}, errors.New("boom")
+func (b *failingPrecheckBackend) ModelLife() (state.Life, error) {
+	return state.Alive, errors.New("boom")
 }

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -18,6 +18,10 @@ import (
 /*
 # TODO - remaining prechecks
 
+## Model
+
+- what about if a charm upgrade is in progress? (i.e. charm URL != unit charm URL)
+
 ## Target controller
 
 - target controller already has a model with the same owner:name

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -19,7 +19,6 @@ import (
 
 ## Source model
 
-- application minunits vs units
 - model is dying/dead
 - pending reboots
 - model is being imported as part of another migration
@@ -66,6 +65,7 @@ type PrecheckApplication interface {
 	Name() string
 	Life() state.Life
 	AllUnits() ([]PrecheckUnit, error)
+	MinUnits() int
 }
 
 // PrecheckUnit describes state interface for a unit needed by
@@ -202,6 +202,10 @@ func checkUnits(app PrecheckApplication, modelVersion version.Number) error {
 	if err != nil {
 		return errors.Annotatef(err, "retrieving units for %s", app.Name())
 	}
+	if len(units) < app.MinUnits() {
+		return errors.Errorf("application %s is below its minimum units threshold", app.Name())
+	}
+
 	for _, unit := range units {
 		if unit.Life() != state.Alive {
 			return errors.Errorf("unit %s is %s", unit.Name(), unit.Life())

--- a/migration/precheck_shim.go
+++ b/migration/precheck_shim.go
@@ -47,22 +47,17 @@ func (s *precheckShim) AllMachines() ([]PrecheckMachine, error) {
 	return out, nil
 }
 
-// AllUnits implements PrecheckBackend.
-func (s *precheckShim) AllUnits() (out []PrecheckUnit, _ error) {
+// AllApplications implements PrecheckBackend.
+func (s *precheckShim) AllApplications() ([]PrecheckApplication, error) {
 	apps, err := s.State.AllApplications()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	out := make([]PrecheckApplication, 0, len(apps))
 	for _, app := range apps {
-		units, err := app.AllUnits()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		for _, unit := range units {
-			out = append(out, unit)
-		}
+		out = append(out, &precheckAppShim{app})
 	}
-	return
+	return out, nil
 }
 
 // ControllerBackend implements PrecheckBackend.
@@ -76,4 +71,22 @@ func (s *precheckShim) ControllerBackend() (PrecheckBackend, error) {
 		return nil, errors.Trace(err)
 	}
 	return PrecheckShim(st), nil
+}
+
+// precheckAppShim implements PrecheckApplication.
+type precheckAppShim struct {
+	*state.Application
+}
+
+// AllUnits implements PrecheckApplication.
+func (s *precheckAppShim) AllUnits() ([]PrecheckUnit, error) {
+	units, err := s.Application.AllUnits()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	out := make([]PrecheckUnit, 0, len(units))
+	for _, unit := range units {
+		out = append(out, unit)
+	}
+	return out, nil
 }

--- a/migration/precheck_shim.go
+++ b/migration/precheck_shim.go
@@ -30,6 +30,15 @@ func (s *precheckShim) ModelLife() (state.Life, error) {
 	return model.Life(), nil
 }
 
+// MigrationStatus implements PrecheckBackend.
+func (s *precheckShim) MigrationMode() (state.MigrationMode, error) {
+	model, err := s.Model()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return model.MigrationMode(), nil
+}
+
 // AgentVersion implements PrecheckBackend.
 func (s *precheckShim) AgentVersion() (version.Number, error) {
 	cfg, err := s.ModelConfig()

--- a/migration/precheck_shim.go
+++ b/migration/precheck_shim.go
@@ -21,6 +21,15 @@ type precheckShim struct {
 	*state.State
 }
 
+// ModelLife implements PrecheckBackend.
+func (s *precheckShim) ModelLife() (state.Life, error) {
+	model, err := s.Model()
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	return model.Life(), nil
+}
+
 // AgentVersion implements PrecheckBackend.
 func (s *precheckShim) AgentVersion() (version.Number, error) {
 	cfg, err := s.ModelConfig()

--- a/migration/precheck_shim.go
+++ b/migration/precheck_shim.go
@@ -47,6 +47,24 @@ func (s *precheckShim) AllMachines() ([]PrecheckMachine, error) {
 	return out, nil
 }
 
+// AllUnits implements PrecheckBackend.
+func (s *precheckShim) AllUnits() (out []PrecheckUnit, _ error) {
+	apps, err := s.State.AllApplications()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for _, app := range apps {
+		units, err := app.AllUnits()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		for _, unit := range units {
+			out = append(out, unit)
+		}
+	}
+	return
+}
+
 // ControllerBackend implements PrecheckBackend.
 func (s *precheckShim) ControllerBackend() (PrecheckBackend, error) {
 	model, err := s.State.ControllerModel()

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -44,6 +44,14 @@ func (*SourcePrecheckSuite) TestDyingModel(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "model is dying")
 }
 
+func (*SourcePrecheckSuite) TestImportingModel(c *gc.C) {
+	backend := &fakeBackend{
+		migrationMode: state.MigrationModeImporting,
+	}
+	err := migration.SourcePrecheck(backend)
+	c.Assert(err, gc.ErrorMatches, "model is being imported as part of another migration")
+}
+
 func (*SourcePrecheckSuite) TestCleanupsError(c *gc.C) {
 	backend := &fakeBackend{
 		cleanupErr: errors.New("boom"),
@@ -416,7 +424,8 @@ func newBackendWithProvisioningMachine() *fakeBackend {
 type fakeBackend struct {
 	agentVersionErr error
 
-	modelLife state.Life
+	modelLife     state.Life
+	migrationMode state.MigrationMode
 
 	cleanupNeeded bool
 	cleanupErr    error
@@ -435,6 +444,10 @@ type fakeBackend struct {
 
 func (b *fakeBackend) ModelLife() (state.Life, error) {
 	return b.modelLife, nil
+}
+
+func (b *fakeBackend) MigrationMode() (state.MigrationMode, error) {
+	return b.migrationMode, nil
 }
 
 func (b *fakeBackend) NeedsCleanup() (bool, error) {

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -97,6 +97,19 @@ func (s *SourcePrecheckSuite) TestProvisioningMachine(c *gc.C) {
 	c.Assert(err.Error(), gc.Equals, "machine 0 not running (allocating)")
 }
 
+func (s *SourcePrecheckSuite) TestDyingApplication(c *gc.C) {
+	backend := &fakeBackend{
+		apps: []migration.PrecheckApplication{
+			&fakeApp{
+				name: "foo",
+				life: state.Dying,
+			},
+		},
+	}
+	err := migration.SourcePrecheck(backend)
+	c.Assert(err.Error(), gc.Equals, "application foo is dying")
+}
+
 func (s *SourcePrecheckSuite) TestUnitVersionsDontMatch(c *gc.C) {
 	backend := &fakeBackend{
 		apps: []migration.PrecheckApplication{


### PR DESCRIPTION
This PR completes the migration prechecks for the model and source controller. Specifically, the following are now checked:

* Unit life
* Unit status
* Unit tools version consistency
* Application life
* Application min units vs actual unit count
* Model and controller model life (source and target)
* Scheduled reboots or shutdowns
* Model migration status (to ensure the model isn't part of another migration)



(Review request: http://reviews.vapour.ws/r/5556/)