### PR TITLE
Ensure ordering of auth types.

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"sort"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -354,6 +355,9 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		for authType := range schemas {
 			authTypes = append(authTypes, authType)
 		}
+		// Since we are iterating over a map, lets sort the authTypes so
+		// they are always in a consistent order.
+		sort.Sort(jujucloud.AuthTypes(authTypes))
 		cloud = &jujucloud.Cloud{
 			Type:      c.Cloud,
 			AuthTypes: authTypes,


### PR DESCRIPTION
Iterating over a map and inserting into a slice is guaranteed to not have a defined order, so sort the result.

(Review request: http://reviews.vapour.ws/r/5561/)