### PR TITLE
Ensure only superuser can access model-defaults

### DIFF
--- a/apiserver/modelconfig/backend.go
+++ b/apiserver/modelconfig/backend.go
@@ -14,6 +14,7 @@ import (
 // allowing stubs to be created for testing.
 type Backend interface {
 	common.BlockGetter
+	ControllerTag() names.ControllerTag
 	ModelTag() names.ModelTag
 	ModelConfigValues() (config.ConfigValues, error)
 	ModelConfigDefaultValues() (config.ModelDefaultAttributes, error)

--- a/apiserver/modelconfig/modelconfig.go
+++ b/apiserver/modelconfig/modelconfig.go
@@ -54,7 +54,7 @@ func (c *ModelConfigAPI) checkCanWrite() error {
 }
 
 func (c *ModelConfigAPI) isAdmin() error {
-	hasAccess, err := c.auth.HasPermission(description.SuperuserAccess, c.backend.ModelTag())
+	hasAccess, err := c.auth.HasPermission(description.SuperuserAccess, c.backend.ControllerTag())
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/modelconfig/modelconfig.go
+++ b/apiserver/modelconfig/modelconfig.go
@@ -53,6 +53,17 @@ func (c *ModelConfigAPI) checkCanWrite() error {
 	return nil
 }
 
+func (c *ModelConfigAPI) isAdmin() error {
+	hasAccess, err := c.auth.HasPermission(description.SuperuserAccess, c.backend.ModelTag())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if !hasAccess {
+		return common.ErrPerm
+	}
+	return nil
+}
+
 // ModelGet implements the server-side part of the
 // get-model-config CLI command.
 func (c *ModelConfigAPI) ModelGet() (params.ModelConfigResults, error) {
@@ -122,7 +133,7 @@ func (c *ModelConfigAPI) ModelUnset(args params.ModelUnset) error {
 // ModelDefaults returns the default config values used when creating a new model.
 func (c *ModelConfigAPI) ModelDefaults() (params.ModelDefaultsResult, error) {
 	result := params.ModelDefaultsResult{}
-	if err := c.checkCanWrite(); err != nil {
+	if err := c.isAdmin(); err != nil {
 		return result, errors.Trace(err)
 	}
 
@@ -163,7 +174,7 @@ func (c *ModelConfigAPI) SetModelDefaults(args params.SetModelDefaults) (params.
 }
 
 func (c *ModelConfigAPI) setModelDefaults(args params.ModelDefaultValues) error {
-	if err := c.checkCanWrite(); err != nil {
+	if err := c.isAdmin(); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -180,7 +191,7 @@ func (c *ModelConfigAPI) setModelDefaults(args params.ModelDefaultValues) error 
 // UnsetModelDefaults removes the specified default model settings.
 func (c *ModelConfigAPI) UnsetModelDefaults(args params.UnsetModelDefaults) (params.ErrorResults, error) {
 	results := params.ErrorResults{Results: make([]params.ErrorResult, len(args.Keys))}
-	if err := c.checkCanWrite(); err != nil {
+	if err := c.isAdmin(); err != nil {
 		return results, err
 	}
 

--- a/apiserver/modelconfig/modelconfig_test.go
+++ b/apiserver/modelconfig/modelconfig_test.go
@@ -365,6 +365,10 @@ func (m *mockBackend) ModelTag() names.ModelTag {
 	return names.NewModelTag("deadbeef-2f18-4fd2-967d-db9663db7bea")
 }
 
+func (m *mockBackend) ControllerTag() names.ControllerTag {
+	return names.NewControllerTag("deadbeef-babe-4fd2-967d-db9663db7bea")
+}
+
 type mockBlock struct {
 	state.Block
 	t state.BlockType

--- a/apiserver/modelconfig/modelconfig_test.go
+++ b/apiserver/modelconfig/modelconfig_test.go
@@ -260,6 +260,57 @@ func (s *modelconfigSuite) TestUnsetModelDefaultsMissing(c *gc.C) {
 	c.Assert(result.OneError(), jc.ErrorIsNil)
 }
 
+func (s *modelconfigSuite) TestModelDefaultsAsNormalUser(c *gc.C) {
+	mc, err := modelconfig.NewModelConfigAPI(s.backend, apiservertesting.FakeAuthorizer{
+		Tag: names.NewUserTag("charlie@local")})
+	c.Assert(err, jc.ErrorIsNil)
+	got, err := mc.ModelDefaults()
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+	c.Assert(got, gc.DeepEquals, params.ModelDefaultsResult{})
+}
+
+func (s *modelconfigSuite) TestSetModelDefaultsAsNormalUser(c *gc.C) {
+	mc, err := modelconfig.NewModelConfigAPI(s.backend, apiservertesting.FakeAuthorizer{
+		Tag: names.NewUserTag("charlie@local")})
+	c.Assert(err, jc.ErrorIsNil)
+	got, err := mc.SetModelDefaults(params.SetModelDefaults{
+		Config: []params.ModelDefaultValues{{
+			Config: map[string]interface{}{
+				"ftp-proxy": "http://charlie",
+			}}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, jc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			params.ErrorResult{
+				Error: &params.Error{
+					Message: "permission denied",
+					Code:    "unauthorized access"}}}})
+
+	// Make sure it didn't change.
+	cfg, err := s.api.ModelGet()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.Config["ftp-proxy"].Value.(string), jc.DeepEquals, "http://proxy")
+}
+
+func (s *modelconfigSuite) TestUnsetModelDefaultsAsNormalUser(c *gc.C) {
+	mc, err := modelconfig.NewModelConfigAPI(s.backend, apiservertesting.FakeAuthorizer{
+		Tag: names.NewUserTag("charlie@local")})
+	c.Assert(err, jc.ErrorIsNil)
+	got, err := mc.UnsetModelDefaults(params.UnsetModelDefaults{
+		Keys: []params.ModelUnsetKeys{{
+			Keys: []string{"ftp-proxy"}}}})
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+	c.Assert(got, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			params.ErrorResult{
+				Error: nil}}})
+
+	// Make sure it didn't change.
+	cfg, err := s.api.ModelGet()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.Config["ftp-proxy"].Value.(string), jc.DeepEquals, "http://proxy")
+}
+
 type mockBackend struct {
 	cfg         config.ConfigValues
 	cfgDefaults config.ModelDefaultAttributes


### PR DESCRIPTION
Only superuser can read, set, or unset model-defaults.

Refs: model-config-tree

(Review request: http://reviews.vapour.ws/r/5563/)