### PR TITLE
retry i/o timeouts from the apiserver

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -618,6 +618,7 @@ func (s *state) APICall(facade string, version int, id, method string, args, res
 			}, args, response)
 		},
 		IsFatalError: func(err error) bool {
+			err = errors.Cause(err)
 			ec, ok := err.(hasErrorCode)
 			if !ok {
 				return true

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -242,10 +242,11 @@ func (s *apiclientSuite) TestAPICallRetries(c *gc.C) {
 	conn := api.NewTestingState(api.TestingStateParams{
 		RPCConnection: &fakeRPCConnection{
 			errors: []error{
-				&rpc.RequestError{
-					Message: "hmm...",
-					Code:    params.CodeRetry,
-				},
+				errors.Trace(
+					&rpc.RequestError{
+						Message: "hmm...",
+						Code:    params.CodeRetry,
+					}),
 			},
 		},
 		Clock: clock,
@@ -258,7 +259,7 @@ func (s *apiclientSuite) TestAPICallRetries(c *gc.C) {
 
 func (s *apiclientSuite) TestAPICallRetriesLimit(c *gc.C) {
 	clock := &fakeClock{}
-	retryError := &rpc.RequestError{Message: "hmm...", Code: params.CodeRetry}
+	retryError := errors.Trace(&rpc.RequestError{Message: "hmm...", Code: params.CodeRetry})
 	var errors []error
 	for i := 0; i < 10; i++ {
 		errors = append(errors, retryError)

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -193,7 +193,7 @@ func ServerError(err error) *params.Error {
 	if err == nil {
 		return nil
 	}
-	logger.Infof("server RPC error %v", errors.Details(err))
+	logger.Tracef("server RPC error %v", errors.Details(err))
 	msg := err.Error()
 	// Skip past annotations when looking for the code.
 	err = errors.Cause(err)


### PR DESCRIPTION
Thought this was fixed, but it wasn't.

The rpc layer wraps the error, so the ErrorCode method wasn't available.

(Review request: http://reviews.vapour.ws/r/5565/)