### PR TITLE
cmd/application: Allocation reporting is now done through the logger rather than stdout

### DIFF
--- a/cmd/juju/application/removeapplication.go
+++ b/cmd/juju/application/removeapplication.go
@@ -4,8 +4,6 @@
 package application
 
 import (
-	"fmt"
-
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/romulus/api/budget"
@@ -132,12 +130,12 @@ func (c *removeServiceCommand) removeAllocation(ctx *cmd.Context) error {
 
 	resp, err := budgetClient.DeleteAllocation(modelUUID, c.ApplicationName)
 	if wireformat.IsNotAvail(err) {
-		fmt.Fprintf(ctx.Stdout, "WARNING: Allocation not removed - %s.\n", err.Error())
+		logger.Warningf("allocation not removed: %v", err)
 	} else if err != nil {
 		return err
 	}
 	if resp != "" {
-		fmt.Fprintf(ctx.Stdout, "%s\n", resp)
+		logger.Infof(resp)
 	}
 	return nil
 }


### PR DESCRIPTION


(Review request: http://reviews.vapour.ws/r/5567/)