### PR TITLE
Prevent removal of admin DB when mongo is v2.4

### DIFF
--- a/apiserver/backups/backups.go
+++ b/apiserver/backups/backups.go
@@ -31,6 +31,7 @@ type Backend interface {
 	MachineSeries(id string) (string, error)
 	MongoConnectionInfo() *mongo.MongoInfo
 	MongoSession() *mgo.Session
+	MongoVersion() (string, error)
 	ModelTag() names.ModelTag
 	ControllerTag() names.ControllerTag
 	ModelConfig() (*config.Config, error)

--- a/apiserver/backups/create.go
+++ b/apiserver/backups/create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/replicaset"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state/backups"
 )
 
@@ -29,7 +30,15 @@ func (a *API) Create(args params.BackupsCreateArgs) (p params.BackupsMetadataRes
 	}
 
 	mgoInfo := a.backend.MongoConnectionInfo()
-	dbInfo, err := backups.NewDBInfo(mgoInfo, session)
+	v, err := a.backend.MongoVersion()
+	if err != nil {
+		return p, errors.Annotatef(err, "discovering mongo version")
+	}
+	mongoVersion, err := mongo.NewVersion(v)
+	if err != nil {
+		return p, errors.Trace(err)
+	}
+	dbInfo, err := backups.NewDBInfo(mgoInfo, session, mongoVersion)
 	if err != nil {
 		return p, errors.Trace(err)
 	}

--- a/apiserver/backups/restore.go
+++ b/apiserver/backups/restore.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/common"
 	"github.com/juju/juju/state"
@@ -81,7 +82,16 @@ func (a *API) Restore(p params.RestoreArgs) error {
 
 	mgoInfo := a.backend.MongoConnectionInfo()
 	logger.Debugf("mongo info from state %+v", mgoInfo)
-	dbInfo, err := backups.NewDBInfo(mgoInfo, session)
+	v, err := a.backend.MongoVersion()
+	if err != nil {
+		return errors.Annotatef(err, "discovering mongo version")
+	}
+	mongoVersion, err := mongo.NewVersion(v)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	dbInfo, err := backups.NewDBInfo(mgoInfo, session, mongoVersion)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/state/backups/backups_test.go
+++ b/state/backups/backups_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state/backups"
 	backupstesting "github.com/juju/juju/state/backups/testing"
 )
@@ -53,7 +54,7 @@ func (s *backupsSuite) checkFailure(c *gc.C, expected string) {
 
 	paths := backups.Paths{DataDir: "/var/lib/juju"}
 	targets := set.NewStrings("juju", "admin")
-	dbInfo := backups.DBInfo{"a", "b", "c", targets}
+	dbInfo := backups.DBInfo{"a", "b", "c", targets, mongo.Mongo32wt}
 	meta := backupstesting.NewMetadataStarted()
 	meta.Notes = "some notes"
 	err := s.api.Create(meta, &paths, &dbInfo)
@@ -92,7 +93,7 @@ func (s *backupsSuite) TestCreateOkay(c *gc.C) {
 	// Run the backup.
 	paths := backups.Paths{DataDir: "/var/lib/juju"}
 	targets := set.NewStrings("juju", "admin")
-	dbInfo := backups.DBInfo{"a", "b", "c", targets}
+	dbInfo := backups.DBInfo{"a", "b", "c", targets, mongo.Mongo32wt}
 	meta := backupstesting.NewMetadataStarted()
 	backupstesting.SetOrigin(meta, "<model ID>", "<machine ID>", "<hostname>")
 	meta.Notes = "some notes"

--- a/state/backups/db_info_test.go
+++ b/state/backups/db_info_test.go
@@ -39,7 +39,7 @@ func (s *dbInfoSuite) TestNewDBInfoOkay(c *gc.C) {
 		Tag:      tag,
 		Password: "eggs",
 	}
-	dbInfo, err := backups.NewDBInfo(mgoInfo, &session)
+	dbInfo, err := backups.NewDBInfo(mgoInfo, &session, mongo.Mongo32wt)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(dbInfo.Address, gc.Equals, "localhost:8080")
@@ -56,7 +56,7 @@ func (s *dbInfoSuite) TestNewDBInfoMissingTag(c *gc.C) {
 		},
 		Password: "eggs",
 	}
-	dbInfo, err := backups.NewDBInfo(mgoInfo, &session)
+	dbInfo, err := backups.NewDBInfo(mgoInfo, &session, mongo.Mongo32wt)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(dbInfo.Username, gc.Equals, "")


### PR DESCRIPTION
Mongo 2.4 cannot properly come back after a restore if
admin database is not present.
Admin database causes an issue on 3.2 backups.
A selective removal of admin database has been put in place.

(Review request: http://reviews.vapour.ws/r/5568/)