### PR TITLE
Update show-controllers to show agent version.

### DIFF
--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -534,7 +534,6 @@ var commandNames = []string{
 	"show-budget",
 	"show-cloud",
 	"show-controller",
-	"show-controllers",
 	"show-machine",
 	"show-machines",
 	"show-model",

--- a/cmd/juju/controller/listcontrollersconverters.go
+++ b/cmd/juju/controller/listcontrollersconverters.go
@@ -31,6 +31,7 @@ type ControllerItem struct {
 	CACert         string   `yaml:"ca-cert" json:"ca-cert"`
 	Cloud          string   `yaml:"cloud" json:"cloud"`
 	CloudRegion    string   `yaml:"region,omitempty" json:"region,omitempty"`
+	AgentVersion   string   `yaml:"agent-version,omitempty" json:"agent-version,omitempty"`
 }
 
 // convertControllerDetails takes a map of Controllers and

--- a/cmd/juju/controller/listcontrollersformatters.go
+++ b/cmd/juju/controller/listcontrollersformatters.go
@@ -48,6 +48,7 @@ func formatShowControllersTabular(writer io.Writer, value interface{}) error {
 			CACert:         details.Details.CACert,
 			User:           details.Account.User,
 			Access:         details.Account.Access,
+			AgentVersion:   details.Details.AgentVersion,
 		}
 	}
 	return formatControllersTabular(writer, controllerSet, true)
@@ -62,7 +63,7 @@ func formatControllersTabular(writer io.Writer, set ControllerSet, withAccess bo
 	}
 
 	if withAccess {
-		print("CONTROLLER", "MODEL", "USER", "ACCESS", "CLOUD/REGION")
+		print("CONTROLLER", "MODEL", "USER", "ACCESS", "CLOUD/REGION", "VERSION")
 	} else {
 		print("CONTROLLER", "MODEL", "USER", "CLOUD/REGION")
 	}
@@ -98,7 +99,7 @@ func formatControllersTabular(writer io.Writer, set ControllerSet, withAccess bo
 			cloudRegion += "/" + c.CloudRegion
 		}
 		if withAccess {
-			print(modelName, userName, access, cloudRegion)
+			print(modelName, userName, access, cloudRegion, c.AgentVersion)
 		} else {
 			print(modelName, userName, cloudRegion)
 		}

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -63,7 +63,6 @@ func (c *showControllerCommand) Info() *cmd.Info {
 		Args:    "[<controller name> ...]",
 		Purpose: usageShowControllerSummary,
 		Doc:     usageShowControllerDetails,
-		Aliases: []string{"show-controllers"},
 	}
 }
 
@@ -202,8 +201,8 @@ type ControllerDetails struct {
 
 	// AgentVersion is the version of the agent running on this controller.
 	// AgentVersion need not always exist so we omitempty here. This struct is
-	// used in both list-controllers and show-controllers. show-controllers
-	// displays the agent version where list-controllers does not.
+	// used in both list-controller and show-controller. show-controller
+	// displays the agent version where list-controller does not.
 	AgentVersion string `yaml:"agent-version,omitempty" json:"agent-version,omitempty"`
 }
 

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -37,6 +37,7 @@ func (s *ShowControllerSuite) TestShowOneControllerOneInStore(c *gc.C) {
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
     cloud: mallards
+    agent-version: 999.99.99
 `
 	s.createTestClientStore(c)
 
@@ -47,6 +48,7 @@ mallards:
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
     cloud: mallards
+    agent-version: 999.99.99
   models:
     admin:
       uuid: abc
@@ -68,6 +70,7 @@ func (s *ShowControllerSuite) TestShowControllerWithPasswords(c *gc.C) {
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
     cloud: mallards
+    agent-version: 999.99.99
 `
 	s.createTestClientStore(c)
 
@@ -78,6 +81,7 @@ mallards:
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
     cloud: mallards
+    agent-version: 999.99.99
   models:
     admin:
       uuid: abc
@@ -101,6 +105,7 @@ func (s *ShowControllerSuite) TestShowControllerWithBootstrapConfig(c *gc.C) {
     ca-cert: this-is-another-ca-cert
     cloud: mallards
     region: mallards1
+    agent-version: 999.99.99
 `
 	store := s.createTestClientStore(c)
 	store.BootstrapConfig["mallards"] = jujuclient.BootstrapConfig{
@@ -124,6 +129,7 @@ mallards:
     ca-cert: this-is-another-ca-cert
     cloud: mallards
     region: mallards1
+    agent-version: 999.99.99
   models:
     admin:
       uuid: abc
@@ -149,6 +155,7 @@ aws-test:
     ca-cert: this-is-aws-test-ca-cert
     cloud: aws
     region: us-east-1
+    agent-version: 999.99.99
   models:
     admin:
       uuid: ghi
@@ -170,6 +177,7 @@ aws-test:
     ca-cert: this-is-aws-test-ca-cert
     cloud: aws
     region: us-east-1
+    agent-version: 999.99.99
   models:
     admin:
       uuid: ghi
@@ -183,6 +191,7 @@ mark-test-prodstack:
     api-endpoints: [this-is-one-of-many-api-endpoints]
     ca-cert: this-is-a-ca-cert
     cloud: prodstack
+    agent-version: 999.99.99
   account:
     user: admin@local
     access: superuser
@@ -194,9 +203,9 @@ mark-test-prodstack:
 func (s *ShowControllerSuite) TestShowSomeControllerTabular(c *gc.C) {
 	s.createTestClientStore(c)
 	s.expectedOutput = `
-CONTROLLER           MODEL  USER         ACCESS     CLOUD/REGION
-aws-test             admin  admin@local  superuser  aws/us-east-1
-mark-test-prodstack  -      admin@local  superuser  prodstack
+CONTROLLER           MODEL  USER         ACCESS     CLOUD/REGION   VERSION
+aws-test             admin  admin@local  superuser  aws/us-east-1  999.99.99
+mark-test-prodstack  -      admin@local  superuser  prodstack      999.99.99
 
 `[1:]
 
@@ -207,7 +216,7 @@ func (s *ShowControllerSuite) TestShowControllerJsonOne(c *gc.C) {
 	s.createTestClientStore(c)
 
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1"},"models":{"admin":{"uuid":"ghi"}},"current-model":"admin","account":{"user":"admin@local","access":"superuser"}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"models":{"admin":{"uuid":"ghi"}},"current-model":"admin","account":{"user":"admin@local","access":"superuser"}}}
 `[1:]
 
 	s.assertShowController(c, "--format", "json", "aws-test")
@@ -216,7 +225,7 @@ func (s *ShowControllerSuite) TestShowControllerJsonOne(c *gc.C) {
 func (s *ShowControllerSuite) TestShowControllerJsonMany(c *gc.C) {
 	s.createTestClientStore(c)
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1"},"models":{"admin":{"uuid":"ghi"}},"current-model":"admin","account":{"user":"admin@local","access":"superuser"}},"mark-test-prodstack":{"details":{"uuid":"this-is-a-uuid","api-endpoints":["this-is-one-of-many-api-endpoints"],"ca-cert":"this-is-a-ca-cert","cloud":"prodstack"},"account":{"user":"admin@local","access":"superuser"}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"models":{"admin":{"uuid":"ghi"}},"current-model":"admin","account":{"user":"admin@local","access":"superuser"}},"mark-test-prodstack":{"details":{"uuid":"this-is-a-uuid","api-endpoints":["this-is-one-of-many-api-endpoints"],"ca-cert":"this-is-a-ca-cert","cloud":"prodstack","agent-version":"999.99.99"},"account":{"user":"admin@local","access":"superuser"}}}
 `[1:]
 	s.assertShowController(c, "--format", "json", "aws-test", "mark-test-prodstack")
 }
@@ -238,7 +247,7 @@ func (s *ShowControllerSuite) TestShowControllerNoArgs(c *gc.C) {
 	store := s.createTestClientStore(c)
 
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1"},"models":{"admin":{"uuid":"ghi"}},"current-model":"admin","account":{"user":"admin@local","access":"superuser"}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"models":{"admin":{"uuid":"ghi"}},"current-model":"admin","account":{"user":"admin@local","access":"superuser"}}}
 `[1:]
 	store.CurrentControllerName = "aws-test"
 	s.assertShowController(c, "--format", "json")
@@ -287,6 +296,10 @@ type fakeController struct{}
 
 func (*fakeController) GetControllerAccess(user string) (description.Access, error) {
 	return "superuser", nil
+}
+
+func (*fakeController) ModelConfig() (map[string]interface{}, error) {
+	return map[string]interface{}{"agent-version": "999.99.99"}, nil
 }
 
 func (*fakeController) Close() error {

--- a/jujuclient/controllers_test.go
+++ b/jujuclient/controllers_test.go
@@ -34,6 +34,7 @@ func (s *ControllersSuite) SetUpTest(c *gc.C) {
 		"test.ca.cert",
 		"aws",
 		"southeastasia",
+		"",
 	}
 }
 

--- a/jujuclient/controllervalidation_test.go
+++ b/jujuclient/controllervalidation_test.go
@@ -24,6 +24,7 @@ func (s *ControllerValidationSuite) SetUpTest(c *gc.C) {
 		"test.ca.cert",
 		"aws",
 		"southeastasia",
+		"",
 	}
 }
 

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -34,6 +34,11 @@ type ControllerDetails struct {
 	// CloudRegion is the name of the cloud region that this controller
 	// runs in. This will be empty for clouds without regions.
 	CloudRegion string `yaml:"region,omitempty"`
+
+	// AgentVersion is the version of the agent running on this controller.
+	// While this isn't strictly needed to connect to a controller, it is used
+	// in formatting show-controller output where this struct is also used.
+	AgentVersion string `yaml:"agent-version,omitempty"`
 }
 
 // ModelDetails holds details of a model.


### PR DESCRIPTION
Refs: http://pad.lv/1603640

QA: 
1. Full unit test suite passes
2. Create a controller or two `juju bootstrap lxdtest lxd` && `juju bootstrap awstest aws`
3. Verify version is in the output of each format:
```
juju show-controllers --format=tabular
juju show-controllers --format=yaml
juju show-controllers --format=json
```

(Review request: http://reviews.vapour.ws/r/5569/)