### PR TITLE
apiserver: Extract unit status logic

### DIFF
--- a/apiserver/common/unitstatus.go
+++ b/apiserver/common/unitstatus.go
@@ -1,0 +1,80 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"fmt"
+
+	"gopkg.in/juju/charm.v6-unstable/hooks"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
+	"github.com/juju/juju/worker/uniter/operation"
+)
+
+// StatusAndErr pairs a StatusInfo with an error associated with
+// retrieving it.
+type StatusAndErr struct {
+	Status status.StatusInfo
+	Err    error
+}
+
+// UnitStatusGetter defines the unit functionality required to
+// determine unit agent and workload status.
+type UnitStatusGetter interface {
+	AgentStatus() (status.StatusInfo, error)
+	Status() (status.StatusInfo, error)
+	AgentPresence() (bool, error)
+	Name() string
+	Life() state.Life
+}
+
+// UnitStatus returns the unit agent and workload status for a given
+// unit, with special handling for agent presence.
+func UnitStatus(unit UnitStatusGetter) (agent StatusAndErr, workload StatusAndErr) {
+	agent.Status, agent.Err = unit.AgentStatus()
+	workload.Status, workload.Err = unit.Status()
+
+	if !canBeLost(agent.Status, workload.Status) {
+		// The unit is allocating or installing - there's no point in
+		// enquiring about the agent liveness.
+		return
+	}
+
+	agentAlive, err := unit.AgentPresence()
+	if err != nil {
+		return
+	}
+	if unit.Life() != state.Dead && !agentAlive {
+		// If the unit is in error, it would be bad to throw away
+		// the error information as when the agent reconnects, that
+		// error information would then be lost.
+		if workload.Status.Status != status.StatusError {
+			workload.Status.Status = status.StatusUnknown
+			workload.Status.Message = fmt.Sprintf("agent lost, see 'juju status-history %s'", unit.Name())
+		}
+		agent.Status.Status = status.StatusLost
+		agent.Status.Message = "agent is not communicating with the server"
+	}
+	return
+}
+
+func canBeLost(agent, workload status.StatusInfo) bool {
+	switch agent.Status {
+	case status.StatusAllocating:
+		return false
+	case status.StatusExecuting:
+		return agent.Message != operation.RunningHookMessage(string(hooks.Install))
+	}
+
+	// TODO(fwereade/wallyworld): we should have an explicit place in the model
+	// to tell us when we've hit this point, instead of piggybacking on top of
+	// status and/or status history.
+
+	return isWorkloadInstalled(workload)
+}
+
+func isWorkloadInstalled(workload status.StatusInfo) bool {
+	return workload.Status != status.StatusMaintenance || workload.Message != status.MessageInstalling
+}

--- a/apiserver/common/unitstatus_test.go
+++ b/apiserver/common/unitstatus_test.go
@@ -1,0 +1,137 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common_test
+
+import (
+	"errors"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
+)
+
+type UnitStatusSuite struct {
+	testing.IsolationSuite
+	unit *fakeStatusUnit
+}
+
+var _ = gc.Suite(&UnitStatusSuite{})
+
+func (s *UnitStatusSuite) SetUpTest(c *gc.C) {
+	s.unit = &fakeStatusUnit{
+		agentStatus: status.StatusInfo{
+			Status:  status.StatusStarted,
+			Message: "agent ok",
+		},
+		status: status.StatusInfo{
+			Status:  status.StatusIdle,
+			Message: "unit ok",
+		},
+		presence: true,
+	}
+}
+
+func (s *UnitStatusSuite) checkUntouched(c *gc.C) {
+	agent, workload := common.UnitStatus(s.unit)
+	c.Check(agent.Status, jc.DeepEquals, s.unit.agentStatus)
+	c.Check(agent.Err, jc.ErrorIsNil)
+	c.Check(workload.Status, jc.DeepEquals, s.unit.status)
+	c.Check(workload.Err, jc.ErrorIsNil)
+}
+
+func (s *UnitStatusSuite) TestNormal(c *gc.C) {
+	s.checkUntouched(c)
+}
+
+func (s *UnitStatusSuite) TestErrors(c *gc.C) {
+	s.unit.agentStatusErr = errors.New("agent status error")
+	s.unit.statusErr = errors.New("status error")
+
+	agent, workload := common.UnitStatus(s.unit)
+	c.Check(agent.Err, gc.ErrorMatches, "agent status error")
+	c.Check(workload.Err, gc.ErrorMatches, "status error")
+}
+
+func (s *UnitStatusSuite) TestLost(c *gc.C) {
+	s.unit.presence = false
+	agent, workload := common.UnitStatus(s.unit)
+	c.Check(agent.Status, jc.DeepEquals, status.StatusInfo{
+		Status:  status.StatusLost,
+		Message: "agent is not communicating with the server",
+	})
+	c.Check(agent.Err, jc.ErrorIsNil)
+	c.Check(workload.Status, jc.DeepEquals, status.StatusInfo{
+		Status:  status.StatusUnknown,
+		Message: "agent lost, see 'juju status-history foo/2'",
+	})
+	c.Check(workload.Err, jc.ErrorIsNil)
+}
+
+func (s *UnitStatusSuite) TestLostAndDead(c *gc.C) {
+	s.unit.presence = false
+	s.unit.life = state.Dead
+	// Status is untouched if unit is Dead.
+	s.checkUntouched(c)
+}
+
+func (s *UnitStatusSuite) TestPresenceError(c *gc.C) {
+	s.unit.presence = false
+	s.unit.presenceErr = errors.New("boom")
+	// Presence error gets ignored, so no output is unchanged.
+	s.checkUntouched(c)
+}
+
+func (s *UnitStatusSuite) TestNotLostIfAllocating(c *gc.C) {
+	s.unit.presence = false
+	s.unit.agentStatus.Status = status.StatusAllocating
+	s.checkUntouched(c)
+}
+
+func (s *UnitStatusSuite) TestCantBeLostDuringInstall(c *gc.C) {
+	s.unit.presence = false
+	s.unit.agentStatus.Status = status.StatusExecuting
+	s.unit.agentStatus.Message = "running install hook"
+	s.checkUntouched(c)
+}
+
+func (s *UnitStatusSuite) TestCantBeLostDuringWorkloadInstall(c *gc.C) {
+	s.unit.presence = false
+	s.unit.status.Status = status.StatusMaintenance
+	s.unit.status.Message = "installing charm software"
+	s.checkUntouched(c)
+}
+
+type fakeStatusUnit struct {
+	agentStatus    status.StatusInfo
+	agentStatusErr error
+	status         status.StatusInfo
+	statusErr      error
+	presence       bool
+	presenceErr    error
+	life           state.Life
+}
+
+func (u *fakeStatusUnit) Name() string {
+	return "foo/2"
+}
+
+func (u *fakeStatusUnit) AgentStatus() (status.StatusInfo, error) {
+	return u.agentStatus, u.agentStatusErr
+}
+
+func (u *fakeStatusUnit) Status() (status.StatusInfo, error) {
+	return u.status, u.statusErr
+}
+
+func (u *fakeStatusUnit) AgentPresence() (bool, error) {
+	return u.presence, u.presenceErr
+}
+
+func (u *fakeStatusUnit) Life() state.Life {
+	return u.life
+}

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -1284,7 +1284,7 @@ var statusTests = []testCase{
 								"machine": "0",
 								"workload-status": M{
 									"current": "unknown",
-									"message": "Agent lost, see 'juju status-history dummy-application/0'",
+									"message": "agent lost, see 'juju status-history dummy-application/0'",
 									"since":   "01 Apr 15 01:23+10:00",
 								},
 								"juju-status": M{


### PR DESCRIPTION
The FullStatus API handling code had special logic for handling of down/lost unit agents. This logic is also required for migration prechecks so it's been extracted to the common subpackage, with significant cleanups to improve clarity.

There were also no preexisting tests for this logic so these have been added.

(Review request: http://reviews.vapour.ws/r/5571/)