### PR TITLE
Don't fail engine creation on the introspection worker failing to start.

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -483,7 +483,11 @@ func (a *MachineAgent) makeEngineCreator(previousAgentVersion version.Number) fu
 			Engine:     engine,
 			WorkerFunc: introspection.NewWorker,
 		}); err != nil {
-			return nil, errors.Trace(err)
+			// If the introspection worker failed to start, we just log error
+			// but continue. It is very unlikely to happen in the real world
+			// as the only issue is connecting to the abstract domain socket
+			// and the agent is controlled by by the OS to only have one.
+			logger.Errorf("failed to start introspection worker: %v", err)
 		}
 		return engine, nil
 	}

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -167,7 +167,11 @@ func (a *UnitAgent) APIWorkers() (worker.Worker, error) {
 		Engine:     engine,
 		WorkerFunc: introspection.NewWorker,
 	}); err != nil {
-		return nil, errors.Trace(err)
+		// If the introspection worker failed to start, we just log error
+		// but continue. It is very unlikely to happen in the real world
+		// as the only issue is connecting to the abstract domain socket
+		// and the agent is controlled by by the OS to only have one.
+		logger.Errorf("failed to start introspection worker: %v", err)
 	}
 	return engine, nil
 }


### PR DESCRIPTION
When the featuretests were run, they start up full agents. When the package tests are run in parallel with other tests that started agents would cause the creating of the agent main dependency engine to kinda fail. 

(Review request: http://reviews.vapour.ws/r/5579/)