### PR TITLE
Fix server panic with missing history.

### DIFF
--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -656,7 +656,13 @@ func (context *statusContext) processApplication(service *state.Application) par
 			processedStatus.Err = err
 			return processedStatus
 		}
-		versions = append(versions, statuses[0])
+		// Even though we fully expect there to be historical values there,
+		// even the first should be the empty string, the status history
+		// collection is not added to in a transactional manner, so it may be
+		// not there even though we'd really like it to be. Such is mongo.
+		if len(statuses) > 0 {
+			versions = append(versions, statuses[0])
+		}
 	}
 	if len(versions) > 0 {
 		sort.Sort(bySinceDescending(versions))

--- a/apiserver/client/status_test.go
+++ b/apiserver/client/status_test.go
@@ -61,18 +61,11 @@ var _ = gc.Suite(&statusUnitTestSuite{})
 
 type statusUnitTestSuite struct {
 	baseSuite
-	*factory.Factory
-}
-
-func (s *statusUnitTestSuite) SetUpTest(c *gc.C) {
-	s.baseSuite.SetUpTest(c)
-	// State gets reset per test, so must the factory.
-	s.Factory = factory.NewFactory(s.State)
 }
 
 func (s *statusUnitTestSuite) TestProcessMachinesWithOneMachineAndOneContainer(c *gc.C) {
-	host := s.MakeMachine(c, &factory.MachineParams{InstanceId: instance.Id("0")})
-	container := s.MakeMachineNested(c, host.Id(), nil)
+	host := s.Factory.MakeMachine(c, &factory.MachineParams{InstanceId: instance.Id("0")})
+	container := s.Factory.MakeMachineNested(c, host.Id(), nil)
 	machines := map[string][]*state.Machine{
 		host.Id(): {host, container},
 	}
@@ -85,14 +78,14 @@ func (s *statusUnitTestSuite) TestProcessMachinesWithOneMachineAndOneContainer(c
 }
 
 func (s *statusUnitTestSuite) TestProcessMachinesWithEmbeddedContainers(c *gc.C) {
-	host := s.MakeMachine(c, &factory.MachineParams{InstanceId: instance.Id("1")})
-	lxdHost := s.MakeMachineNested(c, host.Id(), nil)
+	host := s.Factory.MakeMachine(c, &factory.MachineParams{InstanceId: instance.Id("1")})
+	lxdHost := s.Factory.MakeMachineNested(c, host.Id(), nil)
 	machines := map[string][]*state.Machine{
 		host.Id(): {
 			host,
 			lxdHost,
-			s.MakeMachineNested(c, lxdHost.Id(), nil),
-			s.MakeMachineNested(c, host.Id(), nil),
+			s.Factory.MakeMachineNested(c, lxdHost.Id(), nil),
+			s.Factory.MakeMachineNested(c, host.Id(), nil),
 		},
 	}
 
@@ -124,7 +117,7 @@ var testUnits = []struct {
 }
 
 func (s *statusUnitTestSuite) TestMeterStatus(c *gc.C) {
-	service := s.MakeApplication(c, nil)
+	service := s.Factory.MakeApplication(c, nil)
 
 	units, err := service.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
@@ -190,7 +183,7 @@ func checkUnitVersion(c *gc.C, appStatus params.ApplicationStatus, unit *state.U
 }
 
 func (s *statusUnitTestSuite) TestWorkloadVersionLastWins(c *gc.C) {
-	application := s.MakeApplication(c, nil)
+	application := s.Factory.MakeApplication(c, nil)
 	unit1 := addUnitWithVersion(c, application, "voltron")
 	unit2 := addUnitWithVersion(c, application, "voltron")
 	unit3 := addUnitWithVersion(c, application, "zarkon")
@@ -202,7 +195,7 @@ func (s *statusUnitTestSuite) TestWorkloadVersionLastWins(c *gc.C) {
 }
 
 func (s *statusUnitTestSuite) TestWorkloadVersionSimple(c *gc.C) {
-	application := s.MakeApplication(c, nil)
+	application := s.Factory.MakeApplication(c, nil)
 	unit1 := addUnitWithVersion(c, application, "voltron")
 
 	appStatus := s.checkAppVersion(c, application, "voltron")
@@ -210,7 +203,7 @@ func (s *statusUnitTestSuite) TestWorkloadVersionSimple(c *gc.C) {
 }
 
 func (s *statusUnitTestSuite) TestWorkloadVersionBlanksCanWin(c *gc.C) {
-	application := s.MakeApplication(c, nil)
+	application := s.Factory.MakeApplication(c, nil)
 	unit1 := addUnitWithVersion(c, application, "voltron")
 	unit2 := addUnitWithVersion(c, application, "")
 
@@ -220,12 +213,12 @@ func (s *statusUnitTestSuite) TestWorkloadVersionBlanksCanWin(c *gc.C) {
 }
 
 func (s *statusUnitTestSuite) TestWorkloadVersionNoUnits(c *gc.C) {
-	application := s.MakeApplication(c, nil)
+	application := s.Factory.MakeApplication(c, nil)
 	s.checkAppVersion(c, application, "")
 }
 
 func (s *statusUnitTestSuite) TestWorkloadVersionOkWithUnset(c *gc.C) {
-	application := s.MakeApplication(c, nil)
+	application := s.Factory.MakeApplication(c, nil)
 	unit, err := application.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 	appStatus := s.checkAppVersion(c, application, "")


### PR DESCRIPTION
Fixes http://pad.lv/1613866. The code was always expecting there to be at least one history value returned, which in a perfect world would be fine, but since the status history values are inserted outside transactions, it isn't guaranteed that they will be there.

(Review request: http://reviews.vapour.ws/r/5580/)