### PR TITLE
Cache user access level and agent version in controller.yaml

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -96,9 +96,11 @@ type state struct {
 	// authTag holds the authenticated entity's tag after login.
 	authTag names.Tag
 
-	// readOnly holds whether the user has read-only access for the
-	// connected model.
-	readOnly bool
+	// mpdelAccess holds the access level of the user to the connected model.
+	modelAccess string
+
+	// controllerAccess holds the access level of the user to the connected controller.
+	controllerAccess string
 
 	// broken is a channel that gets closed when the connection is
 	// broken.

--- a/api/interface.go
+++ b/api/interface.go
@@ -191,9 +191,11 @@ type Connection interface {
 	// connection.
 	AuthTag() names.Tag
 
-	// ReadOnly returns whether the authorized user is connected to the model
-	// in read-only mode.
-	ReadOnly() bool
+	// ModelAccess returns the access level of authorized user to the model.
+	ModelAccess() string
+
+	// ControllerAccess returns the access level of authorized user to the controller.
+	ControllerAccess() string
 
 	// These methods expose a bunch of worker-specific facades, and basically
 	// just should not exist; but removing them is too noisy for a single CL.

--- a/api/state.go
+++ b/api/state.go
@@ -95,22 +95,25 @@ func (st *state) Login(tag names.Tag, password, nonce string, macaroons []macaro
 		}
 	}
 
-	var readOnly bool
+	var controllerAccess string
+	var modelAccess string
 	if result.UserInfo != nil {
 		tag, err = names.ParseTag(result.UserInfo.Identity)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		readOnly = result.UserInfo.ReadOnly
+		controllerAccess = result.UserInfo.ControllerAccess
+		modelAccess = result.UserInfo.ModelAccess
 	}
 	servers := params.NetworkHostsPorts(result.Servers)
 	if err = st.setLoginResult(loginResultParams{
-		tag:           tag,
-		modelTag:      result.ModelTag,
-		controllerTag: result.ControllerTag,
-		servers:       servers,
-		facades:       result.Facades,
-		readOnly:      readOnly,
+		tag:              tag,
+		modelTag:         result.ModelTag,
+		controllerTag:    result.ControllerTag,
+		servers:          servers,
+		facades:          result.Facades,
+		modelAccess:      modelAccess,
+		controllerAccess: controllerAccess,
 	}); err != nil {
 		return errors.Trace(err)
 	}
@@ -122,12 +125,13 @@ func (st *state) Login(tag names.Tag, password, nonce string, macaroons []macaro
 }
 
 type loginResultParams struct {
-	tag           names.Tag
-	modelTag      string
-	controllerTag string
-	readOnly      bool
-	servers       [][]network.HostPort
-	facades       []params.FacadeVersions
+	tag              names.Tag
+	modelTag         string
+	controllerTag    string
+	modelAccess      string
+	controllerAccess string
+	servers          [][]network.HostPort
+	facades          []params.FacadeVersions
 }
 
 func (st *state) setLoginResult(p loginResultParams) error {
@@ -148,7 +152,8 @@ func (st *state) setLoginResult(p loginResultParams) error {
 		return errors.Annotatef(err, "invalid controller tag %q returned from login", p.controllerTag)
 	}
 	st.controllerTag = ctag
-	st.readOnly = p.readOnly
+	st.controllerAccess = p.controllerAccess
+	st.modelAccess = p.modelAccess
 
 	hostPorts, err := addAddress(p.servers, st.addr)
 	if err != nil {
@@ -173,10 +178,14 @@ func (st *state) AuthTag() names.Tag {
 	return st.authTag
 }
 
-// ReadOnly returns whether the authorized user is connected to the model in
-// read-only mode.
-func (st *state) ReadOnly() bool {
-	return st.readOnly
+// ModelAccess returns the access level of authorized user to the model.
+func (st *state) ModelAccess() string {
+	return st.modelAccess
+}
+
+// ControllerAccess returns the access level of authorized user to the model.
+func (st *state) ControllerAccess() string {
+	return st.controllerAccess
 }
 
 // slideAddressToFront moves the address at the location (serverIndex, addrIndex) to be

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -111,11 +111,10 @@ func (s *stateSuite) TestLoginMacaroon(c *gc.C) {
 	c.Assert(apistate.AuthTag(), gc.Equals, tag)
 }
 
-func (s *stateSuite) TestLoginReadOnly(c *gc.C) {
-	// The default user has read and write access.
-	c.Assert(s.APIState.ReadOnly(), jc.IsFalse)
+func (s *stateSuite) TestLoginSetsModelAccess(c *gc.C) {
+	// The default user has admin access.
+	c.Assert(s.APIState.ModelAccess(), gc.Equals, "admin")
 
-	// Check with an user in read-only mode.
 	manager := usermanager.NewClient(s.OpenControllerAPI(c))
 	defer manager.Close()
 	usertag, _, err := manager.AddUser("ro", "ro", "ro-password")
@@ -127,7 +126,25 @@ func (s *stateSuite) TestLoginReadOnly(c *gc.C) {
 	err = mmanager.GrantModel(usertag.Canonical(), "read", modeltag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	conn := s.OpenAPIAs(c, usertag, "ro-password")
-	c.Assert(conn.ReadOnly(), jc.IsTrue)
+	c.Assert(conn.ModelAccess(), gc.Equals, "read")
+}
+
+func (s *stateSuite) TestLoginSetsControllerAccess(c *gc.C) {
+	// The default user has admin access.
+	c.Assert(s.APIState.ControllerAccess(), gc.Equals, "superuser")
+
+	manager := usermanager.NewClient(s.OpenControllerAPI(c))
+	defer manager.Close()
+	usertag, _, err := manager.AddUser("ro", "ro", "ro-password")
+	c.Assert(err, jc.ErrorIsNil)
+	mmanager := modelmanager.NewClient(s.OpenControllerAPI(c))
+	defer mmanager.Close()
+	modeltag, ok := s.APIState.ModelTag()
+	c.Assert(ok, jc.IsTrue)
+	err = mmanager.GrantModel(usertag.Canonical(), "read", modeltag.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	conn := s.OpenAPIAs(c, usertag, "ro-password")
+	c.Assert(conn.ControllerAccess(), gc.Equals, "login")
 }
 
 func (s *stateSuite) TestLoginMacaroonInvalidId(c *gc.C) {

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -187,10 +187,10 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 			description.IsEmptyUserAccess(everyoneGroupUser) {
 			return fail, errors.NotFoundf("model or controller access for logged in user %q", userTag.Canonical())
 		}
-		maybeUserInfo.ReadOnly = modelUser.Access == description.ReadAccess
-		if maybeUserInfo.ReadOnly {
-			logger.Debugf("model user %s is READ ONLY", entity.Tag())
-		}
+		maybeUserInfo.ControllerAccess = string(controllerUser.Access)
+		maybeUserInfo.ModelAccess = string(modelUser.Access)
+		logger.Tracef("controller user %s has %v", entity.Tag(), controllerUser.Access)
+		logger.Tracef("model user %s has %s", entity.Tag(), modelUser.Access)
 	}
 
 	// Fetch the API server addresses from state.

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -619,9 +619,10 @@ type AuthUserInfo struct {
 	// the client, if any.
 	Credentials *string `json:"credentials,omitempty"`
 
-	// ReadOnly holds whether the user has read-only access for the
-	// connected model.
-	ReadOnly bool `json:"read-only"`
+	// ControllerAccess holds the access the user has to the connected controller.
+	ControllerAccess string `json:"controller-access"`
+	// ModelAccess holds the access the user has to the connected model.
+	ModelAccess string `json:"model-access"`
 }
 
 // LoginResult holds the result of an Admin Login call.

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -342,7 +342,7 @@ func (c *restoreCommand) rebootstrap(ctx *cmd.Context, meta *params.BackupsMetad
 	// New controller is bootstrapped, so now record the API address so
 	// we can connect.
 	apiPort := params.ControllerConfig.APIPort()
-	err = common.SetBootstrapEndpointAddress(store, c.ControllerName(), apiPort, env)
+	err = common.SetBootstrapEndpointAddress(store, c.ControllerName(), bootVers, apiPort, env)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/juju/juju/provider/dummy"
 	_ "github.com/juju/juju/provider/lxd"
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 type restoreSuite struct {
@@ -250,6 +251,7 @@ func (s *restoreSuite) TestRestoreReboostrapWritesUpdatedControllerInfo(c *gc.C)
 		ControllerUUID:         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
 		APIEndpoints:           []string{"10.0.0.1:17777"},
 		UnresolvedAPIEndpoints: []string{"10.0.0.1:17777"},
+		AgentVersion:           version.Current.String(),
 	})
 }
 

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -742,7 +742,11 @@ See `[1:] + "`juju kill-controller`" + `.`)
 		return errors.Trace(err)
 	}
 
-	err = common.SetBootstrapEndpointAddress(c.ClientStore(), c.controllerName, controllerConfig.APIPort(), environ)
+	agentVersion := jujuversion.Current
+	if c.AgentVersion != nil {
+		agentVersion = *c.AgentVersion
+	}
+	err = common.SetBootstrapEndpointAddress(c.ClientStore(), c.controllerName, agentVersion, controllerConfig.APIPort(), environ)
 	if err != nil {
 		return errors.Annotate(err, "saving bootstrap endpoint address")
 	}

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/network"
+	"github.com/juju/version"
 )
 
 var allInstances = func(environ environs.Environ) ([]instance.Instance, error) {
@@ -30,10 +31,14 @@ var allInstances = func(environ environs.Environ) ([]instance.Instance, error) {
 }
 
 // SetBootstrapEndpointAddress writes the API endpoint address of the
-// bootstrap server into the connection information. This should only be run
-// once directly after Bootstrap. It assumes that there is just one instance
-// in the environment - the bootstrap instance.
-func SetBootstrapEndpointAddress(store jujuclient.ControllerStore, controllerName string, apiPort int, environ environs.Environ) error {
+// bootstrap server, plus the agent version, into the connection information.
+// This should only be run once directly after Bootstrap. It assumes that
+// there is just one instance in the environment - the bootstrap instance.
+func SetBootstrapEndpointAddress(
+	store jujuclient.ControllerStore,
+	controllerName string, agentVersion version.Number,
+	apiPort int, environ environs.Environ,
+) error {
 	instances, err := allInstances(environ)
 	if err != nil {
 		return errors.Trace(err)
@@ -54,7 +59,7 @@ func SetBootstrapEndpointAddress(store jujuclient.ControllerStore, controllerNam
 		return errors.Annotate(err, "failed to get bootstrap instance addresses")
 	}
 	apiHostPorts := network.AddressesWithPort(netAddrs, apiPort)
-	return juju.UpdateControllerAddresses(store, controllerName, nil, apiHostPorts...)
+	return juju.UpdateControllerDetailsFromLogin(store, controllerName, agentVersion.String(), nil, apiHostPorts...)
 }
 
 var (

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -15,9 +15,10 @@ import (
 
 // NewListControllersCommandForTest returns a listControllersCommand with the clientstore provided
 // as specified.
-func NewListControllersCommandForTest(testStore jujuclient.ClientStore) *listControllersCommand {
+func NewListControllersCommandForTest(testStore jujuclient.ClientStore, api api.Connection) *listControllersCommand {
 	return &listControllersCommand{
 		store: testStore,
+		api:   api,
 	}
 }
 

--- a/cmd/juju/controller/listcontrollers.go
+++ b/cmd/juju/controller/listcontrollers.go
@@ -6,11 +6,13 @@ package controller
 import (
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 )
@@ -51,11 +53,19 @@ func (c *listControllersCommand) Info() *cmd.Info {
 // SetFlags implements Command.SetFlags.
 func (c *listControllersCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.JujuCommandBase.SetFlags(f)
+	f.BoolVar(&c.refresh, "refresh", false, "Connect to each controller to download the latest details")
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"yaml":    cmd.FormatYaml,
 		"json":    cmd.FormatJson,
-		"tabular": formatControllersListTabular,
+		"tabular": c.formatControllersListTabular,
 	})
+}
+
+func (c *listControllersCommand) getAPI(controllerName string) (api.Connection, error) {
+	if c.api != nil {
+		return c.api, nil
+	}
+	return c.NewAPIRoot(c.store, controllerName, "")
 }
 
 // Run implements Command.Run
@@ -63,6 +73,30 @@ func (c *listControllersCommand) Run(ctx *cmd.Context) error {
 	controllers, err := c.store.AllControllers()
 	if err != nil {
 		return errors.Annotate(err, "failed to list controllers")
+	}
+	if c.refresh && len(controllers) > 0 {
+		// For each controller, simply opening an API
+		// connection is enough to login and refresh the
+		// cached data.
+		var wg sync.WaitGroup
+		wg.Add(len(controllers))
+		for controllerName := range controllers {
+			go func() {
+				defer wg.Done()
+				client, err := c.getAPI(controllerName)
+				if err != nil {
+					fmt.Fprintf(ctx.GetStderr(), "error updating cached details for %q: %v", controllerName, err)
+					return
+				}
+				client.Close()
+			}()
+		}
+		wg.Wait()
+		// Reload controller details
+		controllers, err = c.store.AllControllers()
+		if err != nil {
+			return errors.Annotate(err, "failed to list controllers")
+		}
 	}
 	details, errs := c.convertControllerDetails(controllers)
 	if len(errs) > 0 {
@@ -84,6 +118,8 @@ func (c *listControllersCommand) Run(ctx *cmd.Context) error {
 type listControllersCommand struct {
 	modelcmd.JujuCommandBase
 
-	out   cmd.Output
-	store jujuclient.ClientStore
+	out     cmd.Output
+	store   jujuclient.ClientStore
+	api     api.Connection
+	refresh bool
 }

--- a/cmd/juju/controller/listcontrollers.go
+++ b/cmd/juju/controller/listcontrollers.go
@@ -81,11 +81,12 @@ func (c *listControllersCommand) Run(ctx *cmd.Context) error {
 		var wg sync.WaitGroup
 		wg.Add(len(controllers))
 		for controllerName := range controllers {
+			name := controllerName
 			go func() {
 				defer wg.Done()
-				client, err := c.getAPI(controllerName)
+				client, err := c.getAPI(name)
 				if err != nil {
-					fmt.Fprintf(ctx.GetStderr(), "error updating cached details for %q: %v", controllerName, err)
+					fmt.Fprintf(ctx.GetStderr(), "error updating cached details for %q: %v", name, err)
 					return
 				}
 				client.Close()

--- a/cmd/juju/controller/listcontrollersconverters.go
+++ b/cmd/juju/controller/listcontrollersconverters.go
@@ -57,7 +57,7 @@ func (c *listControllersCommand) convertControllerDetails(storeControllers map[s
 			serverName = details.APIEndpoints[0]
 		}
 
-		var userName string
+		var userName, access string
 		accountDetails, err := c.store.AccountDetails(controllerName)
 		if err != nil {
 			if !errors.IsNotFound(err) {
@@ -66,6 +66,7 @@ func (c *listControllersCommand) convertControllerDetails(storeControllers map[s
 			}
 		} else {
 			userName = accountDetails.User
+			access = accountDetails.LastKnownAccess
 		}
 
 		var modelName string
@@ -90,12 +91,14 @@ func (c *listControllersCommand) convertControllerDetails(storeControllers map[s
 		controllers[controllerName] = ControllerItem{
 			ModelName:      modelName,
 			User:           userName,
+			Access:         access,
 			Server:         serverName,
 			APIEndpoints:   details.APIEndpoints,
 			ControllerUUID: details.ControllerUUID,
 			CACert:         details.CACert,
 			Cloud:          details.Cloud,
 			CloudRegion:    details.CloudRegion,
+			AgentVersion:   details.AgentVersion,
 		}
 	}
 	return controllers, errs

--- a/cmd/juju/controller/package_test.go
+++ b/cmd/juju/controller/package_test.go
@@ -60,6 +60,7 @@ controllers:
     ca-cert: this-is-aws-test-ca-cert
     cloud: aws
     region: us-east-1
+    agent-version: 2.0.1
   mallards:
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
@@ -101,4 +102,5 @@ controllers:
   mallards:
     user: admin@local
     password: hunter2
+    last-known-access: superuser
 `

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -172,8 +173,9 @@ func (c *registerCommand) Run(ctx *cmd.Context) error {
 		return errors.Annotate(err, "marshalling temporary credential to JSON")
 	}
 	accountDetails := jujuclient.AccountDetails{
-		User:     registrationParams.userTag.Canonical(),
-		Macaroon: string(macaroonJSON),
+		User:            registrationParams.userTag.Canonical(),
+		Macaroon:        string(macaroonJSON),
+		LastKnownAccess: string(description.LoginAccess),
 	}
 	if err := store.UpdateAccount(registrationParams.controllerName, accountDetails); err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -286,8 +286,9 @@ func (s *RegisterSuite) testRegister(c *gc.C, expectedError string) *cmd.Context
 	account, err := s.store.AccountDetails("controller-name")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(account, jc.DeepEquals, &jujuclient.AccountDetails{
-		User:     "bob@local",
-		Macaroon: string(macaroonJSON),
+		User:            "bob@local",
+		Macaroon:        string(macaroonJSON),
+		LastKnownAccess: "login",
 	})
 	return ctx
 }

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -71,9 +71,8 @@ func (c *showControllerCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.JujuCommandBase.SetFlags(f)
 	f.BoolVar(&c.showPasswords, "show-password", false, "Show password for logged in user")
 	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
-		"yaml":    cmd.FormatYaml,
-		"json":    cmd.FormatJson,
-		"tabular": formatShowControllersTabular,
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
 	})
 }
 

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -200,18 +200,6 @@ mark-test-prodstack:
 	s.assertShowController(c, "aws-test", "mark-test-prodstack")
 }
 
-func (s *ShowControllerSuite) TestShowSomeControllerTabular(c *gc.C) {
-	s.createTestClientStore(c)
-	s.expectedOutput = `
-CONTROLLER           MODEL  USER         ACCESS     CLOUD/REGION   VERSION
-aws-test             admin  admin@local  superuser  aws/us-east-1  999.99.99
-mark-test-prodstack  -      admin@local  superuser  prodstack      999.99.99
-
-`[1:]
-
-	s.assertShowController(c, "--format", "tabular", "aws-test", "mark-test-prodstack")
-}
-
 func (s *ShowControllerSuite) TestShowControllerJsonOne(c *gc.C) {
 	s.createTestClientStore(c)
 

--- a/cmd/juju/user/change_password_test.go
+++ b/cmd/juju/user/change_password_test.go
@@ -108,7 +108,7 @@ func (s *ChangePasswordCommandSuite) TestChangePasswordFail(c *gc.C) {
 func (s *ChangePasswordCommandSuite) TestNoSetPasswordAfterFailedWrite(c *gc.C) {
 	store := jujuclienttesting.NewStubStore()
 	store.AccountDetailsFunc = func(string) (*jujuclient.AccountDetails, error) {
-		return &jujuclient.AccountDetails{"user", "old-password", ""}, nil
+		return &jujuclient.AccountDetails{"user", "old-password", "", ""}, nil
 	}
 	store.ControllerByNameFunc = func(string) (*jujuclient.ControllerDetails, error) {
 		return &jujuclient.ControllerDetails{}, nil

--- a/cmd/juju/user/export_test.go
+++ b/cmd/juju/user/export_test.go
@@ -65,7 +65,7 @@ func NewChangePasswordCommandForTest(api ChangePasswordAPI, store jujuclient.Cli
 // NewLoginCommand returns a LoginCommand with the api
 // and writer provided as specified.
 func NewLoginCommandForTest(
-	newLoginAPI func(juju.NewAPIConnectionParams) (LoginAPI, error),
+	newLoginAPI func(juju.NewAPIConnectionParams) (LoginAPI, ConnectionAPI, error),
 	store jujuclient.ClientStore,
 ) (cmd.Command, *LoginCommand) {
 	c := &loginCommand{newLoginAPI: newLoginAPI}

--- a/cmd/juju/user/logout_test.go
+++ b/cmd/juju/user/logout_test.go
@@ -96,7 +96,7 @@ func (s *LogoutCommandSuite) TestLogoutCount(c *gc.C) {
 }
 
 func (s *LogoutCommandSuite) TestLogoutWithoutMacaroon(c *gc.C) {
-	s.assertStorePassword(c, "current-user@local", "old-password")
+	s.assertStorePassword(c, "current-user@local", "old-password", "")
 	s.assertStoreMacaroon(c, "current-user@local", nil)
 	_, err := s.run(c)
 	c.Assert(err, gc.NotNil)
@@ -115,7 +115,7 @@ this command again with the "--force" flag.
 }
 
 func (s *LogoutCommandSuite) TestLogoutWithoutMacaroonForced(c *gc.C) {
-	s.assertStorePassword(c, "current-user@local", "old-password")
+	s.assertStorePassword(c, "current-user@local", "old-password", "")
 	s.assertStoreMacaroon(c, "current-user@local", nil)
 	_, err := s.run(c, "--force")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/user/user_test.go
+++ b/cmd/juju/user/user_test.go
@@ -34,11 +34,12 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	}
 }
 
-func (s *BaseSuite) assertStorePassword(c *gc.C, user, pass string) {
+func (s *BaseSuite) assertStorePassword(c *gc.C, user, pass, access string) {
 	details, err := s.store.AccountDetails("testing")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(details.User, gc.Equals, user)
 	c.Assert(details.Password, gc.Equals, pass)
+	c.Assert(details.LastKnownAccess, gc.Equals, access)
 }
 
 func (s *BaseSuite) assertStoreMacaroon(c *gc.C, user string, mac *macaroon.Macaroon) {

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/jujuclient"
@@ -201,6 +202,7 @@ func prepare(
 	details.ControllerModelUUID = args.ModelConfig[config.UUIDKey].(string)
 	details.User = environs.AdminUser
 	details.Password = args.AdminSecret
+	details.LastKnownAccess = string(description.SuperuserAccess)
 	details.ModelUUID = cfg.UUID()
 	details.ControllerDetails.Cloud = args.Cloud.Name
 	details.ControllerDetails.CloudRegion = args.Cloud.Region

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -73,8 +73,10 @@ func (s *cmdControllerSuite) createModelNormalUser(c *gc.C, modelname string, is
 func (s *cmdControllerSuite) TestControllerListCommand(c *gc.C) {
 	context := s.run(c, "list-controllers")
 	expectedOutput := `
-CONTROLLER  MODEL       USER         CLOUD/REGION
-kontroll*   controller  admin@local  dummy/dummy-region
+CONTROLLER  MODEL       USER         ACCESS      CLOUD/REGION        VERSION
+kontroll*   controller  admin@local  superuser+  dummy/dummy-region  (unknown)+
+
++ these are the last known values, run with --refresh to see the latest information.
 
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expectedOutput)

--- a/juju/api.go
+++ b/juju/api.go
@@ -124,7 +124,9 @@ func NewAPIConnection(args NewAPIConnectionParams) (api.Connection, error) {
 	if !apiInfo.SkipLogin {
 		if ok {
 			if accountDetails, err = args.Store.AccountDetails(args.ControllerName); err != nil {
-				logger.Errorf("cannot find local account information: %v", err)
+				if !errors.IsNotFound(err) {
+					logger.Errorf("cannot load local account information: %v", err)
+				}
 			} else {
 				accountDetails.LastKnownAccess = st.ControllerAccess()
 			}

--- a/juju/api.go
+++ b/juju/api.go
@@ -109,22 +109,40 @@ func NewAPIConnection(args NewAPIConnectionParams) (api.Connection, error) {
 	// controllers that redirect involves them having well known
 	// public addresses that won't change over time.
 	hostPorts := st.APIHostPorts()
-	err = updateControllerAddresses(args.Store, args.ControllerName, controller, hostPorts, addrConnectedTo)
+	agentVersion := ""
+	if v, ok := st.ServerVersion(); ok {
+		agentVersion = v.String()
+	}
+	err = updateControllerDetailsFromLogin(args.Store, args.ControllerName, controller, agentVersion, hostPorts, addrConnectedTo)
 	if err != nil {
 		logger.Errorf("cannot cache API addresses: %v", err)
 	}
-	if apiInfo.Tag == nil && !apiInfo.SkipLogin {
-		// We used macaroon auth to login; save the username
-		// that we've logged in as.
-		user, ok := st.AuthTag().(names.UserTag)
-		if ok && !user.IsLocal() {
-			if err := args.Store.UpdateAccount(args.ControllerName, jujuclient.AccountDetails{
-				User: user.Canonical(),
-			}); err != nil {
-				logger.Errorf("cannot update account information: %v", err)
+
+	// Process the account details obtained from login.
+	var accountDetails *jujuclient.AccountDetails
+	user, ok := st.AuthTag().(names.UserTag)
+	if !apiInfo.SkipLogin {
+		if ok {
+			if accountDetails, err = args.Store.AccountDetails(args.ControllerName); err != nil {
+				logger.Errorf("cannot find local account information: %v", err)
+			} else {
+				accountDetails.LastKnownAccess = st.ControllerAccess()
 			}
-		} else {
+		}
+		if ok && !user.IsLocal() && apiInfo.Tag == nil {
+			// We used macaroon auth to login; save the username
+			// that we've logged in as.
+			accountDetails = &jujuclient.AccountDetails{
+				User:            user.Canonical(),
+				LastKnownAccess: st.ControllerAccess(),
+			}
+		} else if apiInfo.Tag == nil {
 			logger.Errorf("unexpected logged-in username %v", st.AuthTag())
+		}
+	}
+	if accountDetails != nil {
+		if err := args.Store.UpdateAccount(args.ControllerName, *accountDetails); err != nil {
+			logger.Errorf("cannot update account information: %v", err)
 		}
 	}
 	return st, nil
@@ -293,36 +311,45 @@ func addrsChanged(a, b []string) bool {
 	return false
 }
 
-// UpdateControllerAddresses writes any new api addresses to the client controller file.
+// UpdateControllerDetailsFromLogin writes any new api addresses and other relevant details
+// to the client controller file.
 // Controller may be specified by a UUID or name, and must already exist.
-func UpdateControllerAddresses(
-	store jujuclient.ControllerStore, controllerName string,
+func UpdateControllerDetailsFromLogin(
+	store jujuclient.ControllerStore, controllerName, agentVersion string,
 	currentHostPorts [][]network.HostPort, addrConnectedTo ...network.HostPort,
 ) error {
 	controllerDetails, err := store.ControllerByName(controllerName)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return updateControllerAddresses(
+	return updateControllerDetailsFromLogin(
 		store, controllerName, controllerDetails,
+		agentVersion,
 		currentHostPorts, addrConnectedTo...,
 	)
 }
 
-func updateControllerAddresses(
+func updateControllerDetailsFromLogin(
 	store jujuclient.ControllerStore,
 	controllerName string, controllerDetails *jujuclient.ControllerDetails,
+	agentVersion string,
 	currentHostPorts [][]network.HostPort, addrConnectedTo ...network.HostPort,
 ) error {
 	// Get the new endpoint addresses.
 	addrs, unresolvedAddrs, addrsChanged := PrepareEndpointsForCaching(*controllerDetails, currentHostPorts, addrConnectedTo...)
-	if !addrsChanged {
+	otherDataChanged := agentVersion != controllerDetails.AgentVersion
+	if !addrsChanged && !otherDataChanged {
 		return nil
 	}
 
 	// Write the new controller data.
-	controllerDetails.APIEndpoints = addrs
-	controllerDetails.UnresolvedAPIEndpoints = unresolvedAddrs
+	if addrsChanged {
+		controllerDetails.APIEndpoints = addrs
+		controllerDetails.UnresolvedAPIEndpoints = unresolvedAddrs
+	}
+	if otherDataChanged {
+		controllerDetails.AgentVersion = agentVersion
+	}
 	err := store.UpdateController(controllerName, *controllerDetails)
 	return errors.Trace(err)
 }

--- a/juju/mock_test.go
+++ b/juju/mock_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/testing"
+	"github.com/juju/version"
 )
 
 type mockAPIState struct {
@@ -72,6 +73,10 @@ func (s *mockAPIState) Close() error {
 	return nil
 }
 
+func (s *mockAPIState) ServerVersion() (version.Number, bool) {
+	return version.MustParse("1.2.3"), true
+}
+
 func (s *mockAPIState) Addr() string {
 	return s.addr
 }
@@ -97,6 +102,14 @@ func (s *mockAPIState) ControllerTag() names.ControllerTag {
 		panic("bad controller tag")
 	}
 	return t
+}
+
+func (s *mockAPIState) AuthTag() names.Tag {
+	return names.NewUserTag("admin")
+}
+
+func (s *mockAPIState) ControllerAccess() string {
+	return "superuser"
 }
 
 func panicAPIOpen(apiInfo *api.Info, opts api.DialOpts) (api.Connection, error) {

--- a/jujuclient/accounts_test.go
+++ b/jujuclient/accounts_test.go
@@ -73,8 +73,8 @@ func (s *AccountsSuite) TestUpdateAccountNewController(c *gc.C) {
 
 func (s *AccountsSuite) TestUpdateAccountOverwrites(c *gc.C) {
 	testAccountDetails := jujuclient.AccountDetails{
-		User:     "admin@local",
-		Password: "fnord",
+		User:            "admin@local",
+		Password:        "fnord",
 		LastKnownAccess: "addmodel",
 	}
 	for i := 0; i < 2; i++ {

--- a/jujuclient/accounts_test.go
+++ b/jujuclient/accounts_test.go
@@ -48,6 +48,20 @@ func (s *AccountsSuite) TestAccountDetails(c *gc.C) {
 	c.Assert(*details, jc.DeepEquals, kontrollBobRemoteAccountDetails)
 }
 
+func (s *AccountsSuite) TestUpdateAccountIgnoresEmptyAccess(c *gc.C) {
+	testAccountDetails := jujuclient.AccountDetails{
+		User:     "admin@local",
+		Password: "fnord",
+	}
+	err := s.store.UpdateAccount("ctrl", testAccountDetails)
+	c.Assert(err, jc.ErrorIsNil)
+	details, err := s.store.AccountDetails("ctrl")
+	c.Assert(err, jc.ErrorIsNil)
+	testAccountDetails.LastKnownAccess = ctrlAdminAccountDetails.LastKnownAccess
+	c.Assert(testAccountDetails.LastKnownAccess, gc.Equals, "superuser")
+	c.Assert(*details, jc.DeepEquals, testAccountDetails)
+}
+
 func (s *AccountsSuite) TestUpdateAccountNewController(c *gc.C) {
 	testAccountDetails := jujuclient.AccountDetails{User: "admin@local"}
 	err := s.store.UpdateAccount("new-controller", testAccountDetails)
@@ -61,6 +75,7 @@ func (s *AccountsSuite) TestUpdateAccountOverwrites(c *gc.C) {
 	testAccountDetails := jujuclient.AccountDetails{
 		User:     "admin@local",
 		Password: "fnord",
+		LastKnownAccess: "addmodel",
 	}
 	for i := 0; i < 2; i++ {
 		// Twice so we exercise the code path of updating with

--- a/jujuclient/accountsfile_test.go
+++ b/jujuclient/accountsfile_test.go
@@ -37,8 +37,8 @@ var testControllerAccounts = map[string]jujuclient.AccountDetails{
 
 var (
 	ctrlAdminAccountDetails = jujuclient.AccountDetails{
-		User:     "admin@local",
-		Password: "hunter2",
+		User:            "admin@local",
+		Password:        "hunter2",
 		LastKnownAccess: "superuser",
 	}
 	kontrollBobRemoteAccountDetails = jujuclient.AccountDetails{

--- a/jujuclient/accountsfile_test.go
+++ b/jujuclient/accountsfile_test.go
@@ -25,6 +25,7 @@ controllers:
   ctrl:
     user: admin@local
     password: hunter2
+    last-known-access: superuser
   kontroll:
     user: bob@remote
 `
@@ -38,6 +39,7 @@ var (
 	ctrlAdminAccountDetails = jujuclient.AccountDetails{
 		User:     "admin@local",
 		Password: "hunter2",
+		LastKnownAccess: "superuser",
 	}
 	kontrollBobRemoteAccountDetails = jujuclient.AccountDetails{
 		User: "bob@remote",

--- a/jujuclient/file.go
+++ b/jujuclient/file.go
@@ -539,6 +539,11 @@ func (s *store) UpdateAccount(controllerName string, details AccountDetails) err
 	}
 	if oldDetails, ok := accounts[controllerName]; ok && details == oldDetails {
 		return nil
+	} else {
+		// Only update last known access if it has a value.
+		if details.LastKnownAccess == "" {
+			details.LastKnownAccess = oldDetails.LastKnownAccess
+		}
 	}
 
 	accounts[controllerName] = details

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -59,6 +59,9 @@ type AccountDetails struct {
 	// used to log in. This string is the JSON-encoding
 	// of a gopkg.in/macaroon.v1.Macaroon.
 	Macaroon string `yaml:"macaroon,omitempty"`
+
+	// LastKnownAccess is the last known access level for the account.
+	LastKnownAccess string `yaml:"last-known-access,omitempty"`
 }
 
 // BootstrapConfig holds the configuration used to bootstrap a controller.

--- a/jujuclient/jujuclienttesting/mem.go
+++ b/jujuclient/jujuclienttesting/mem.go
@@ -261,6 +261,11 @@ func (c *MemStore) UpdateAccount(controllerName string, details jujuclient.Accou
 	if err := jujuclient.ValidateAccountDetails(details); err != nil {
 		return err
 	}
+	oldDetails := c.Accounts[controllerName]
+	// Only update last known access if it has a value.
+	if details.LastKnownAccess == "" {
+		details.LastKnownAccess = oldDetails.LastKnownAccess
+	}
 	c.Accounts[controllerName] = details
 	return nil
 }


### PR DESCRIPTION
For each user in accounts.yaml, we cache their access level on the controller. We also cache the agent version of the controller in comtrollers.yaml. This information is displayed in list-controllers.

At bootstrap, the agent version and access level are set, to the bootstrap agent version and "superuser" respectively. Thereafter, each time the user logs in, or a connection is made to the controller via running a command, the information is also updated.

(Review request: http://reviews.vapour.ws/r/5585/)