### PR TITLE
network: Added ParseInterfaceType() and tests

### DIFF
--- a/network/utils.go
+++ b/network/utils.go
@@ -5,8 +5,10 @@ package network
 
 import (
 	"bufio"
+	"io/ioutil"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/juju/errors"
@@ -176,4 +178,49 @@ func SupportsIPv6() bool {
 	}
 	ln.Close()
 	return true
+}
+
+// SysClassNetRoot is the full Linux SYSFS path containing information about
+// each network interface on the system. Used as argument to
+// ParseInterfaceType().
+const SysClassNetPath = "/sys/class/net"
+
+// ParseInterfaceType parses the DEVTYPE attribute from the Linux kernel
+// userspace SYSFS location "<sysPath/<interfaceName>/uevent" and returns it as
+// InterfaceType. SysClassNetPath should be passed as sysPath. Returns
+// UnknownInterface if the type cannot be reliably determined for any reason.
+//
+// Example call: network.ParseInterfaceType(network.SysClassNetPath, "br-eth1")
+func ParseInterfaceType(sysPath, interfaceName string) InterfaceType {
+	const deviceType = "DEVTYPE="
+	location := filepath.Join(sysPath, interfaceName, "uevent")
+
+	data, err := ioutil.ReadFile(location)
+	if err != nil {
+		return UnknownInterface
+	}
+
+	devtype := ""
+	lines := strings.Fields(string(data))
+	for _, line := range lines {
+		if !strings.HasPrefix(line, deviceType) {
+			continue
+		}
+
+		devtype = strings.TrimPrefix(line, deviceType)
+		switch devtype {
+		case "bridge":
+			return BridgeInterface
+		case "vlan":
+			return VLAN_8021QInterface
+		case "bond":
+			return BondInterface
+		case "":
+			// DEVTYPE is not present for some types, like Ethernet and loopback
+			// interfaces, so if missing do not try to guess.
+			break
+		}
+	}
+
+	return UnknownInterface
 }

--- a/network/utils.go
+++ b/network/utils.go
@@ -197,6 +197,7 @@ func ParseInterfaceType(sysPath, interfaceName string) InterfaceType {
 
 	data, err := ioutil.ReadFile(location)
 	if err != nil {
+		logger.Debugf("ignoring error reading %q: %v", location, err)
 		return UnknownInterface
 	}
 


### PR DESCRIPTION
Using Linux SYSFS userspace location /sys/class/net/<iface>/uevent, we
can reliably determine a few of the network interface types on the host
system, most importantly bridges, bonds, and VLAN interfaces.

If we can't reliably determine the type or when running on an OS other
than Linux, ParseInterfaceType() returns UnknownInterface. Any errors
are ignored as irrelevant.

This is a prerequisite to fix http://pad.lv/1566791.

(Review request: http://reviews.vapour.ws/r/5586/)