### PR TITLE
Complete migration target controller prechecks

### DIFF
--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -126,9 +126,14 @@ func (c *Client) ModelInfo() (migration.ModelInfo, error) {
 	if err != nil {
 		return migration.ModelInfo{}, errors.Trace(err)
 	}
+	owner, err := names.ParseUserTag(info.OwnerTag)
+	if err != nil {
+		return migration.ModelInfo{}, errors.Trace(err)
+	}
 	return migration.ModelInfo{
 		UUID:         info.UUID,
 		Name:         info.Name,
+		Owner:        owner,
 		AgentVersion: info.AgentVersion,
 	}, nil
 }

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -160,11 +160,13 @@ func (s *ClientSuite) TestSetStatusMessageError(c *gc.C) {
 
 func (s *ClientSuite) TestModelInfo(c *gc.C) {
 	var stub jujutesting.Stub
+	owner := names.NewUserTag("owner")
 	apiCaller := apitesting.APICallerFunc(func(objType string, v int, id, request string, arg, result interface{}) error {
 		stub.AddCall(objType+"."+request, id, arg)
 		*(result.(*params.MigrationModelInfo)) = params.MigrationModelInfo{
 			UUID:         "uuid",
 			Name:         "name",
+			OwnerTag:     owner.String(),
 			AgentVersion: version.MustParse("1.2.3"),
 		}
 		return nil
@@ -178,6 +180,7 @@ func (s *ClientSuite) TestModelInfo(c *gc.C) {
 	c.Check(model, jc.DeepEquals, migration.ModelInfo{
 		UUID:         "uuid",
 		Name:         "name",
+		Owner:        owner,
 		AgentVersion: version.MustParse("1.2.3"),
 	})
 }

--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/version"
+	"github.com/juju/juju/migration"
 )
 
 // NewClient returns a new Client based on an existing API connection.
@@ -23,9 +23,12 @@ type Client struct {
 	caller base.FacadeCaller
 }
 
-func (c *Client) Prechecks(modelVersion version.Number) error {
+func (c *Client) Prechecks(model migration.PrecheckModelInfo) error {
 	args := params.TargetPrechecksArgs{
-		AgentVersion: modelVersion,
+		ModelTag:     names.NewModelTag(model.UUID).String(),
+		OwnerTag:     model.Owner.String(),
+		ModelName:    model.Name,
+		AgentVersion: model.Version,
 	}
 	return c.caller.FacadeCall("Prechecks", args, nil)
 }

--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -24,10 +24,10 @@ type Client struct {
 }
 
 func (c *Client) Prechecks(model coremigration.ModelInfo) error {
-	args := params.TargetPrechecksArgs{
-		ModelTag:     names.NewModelTag(model.UUID).String(),
+	args := params.MigrationModelInfo{
+		UUID:         model.UUID,
+		Name:         model.Name,
 		OwnerTag:     model.Owner.String(),
-		ModelName:    model.Name,
 		AgentVersion: model.AgentVersion,
 	}
 	return c.caller.FacadeCall("Prechecks", args, nil)

--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/migration"
+	coremigration "github.com/juju/juju/core/migration"
 )
 
 // NewClient returns a new Client based on an existing API connection.
@@ -23,12 +23,12 @@ type Client struct {
 	caller base.FacadeCaller
 }
 
-func (c *Client) Prechecks(model migration.PrecheckModelInfo) error {
+func (c *Client) Prechecks(model coremigration.ModelInfo) error {
 	args := params.TargetPrechecksArgs{
 		ModelTag:     names.NewModelTag(model.UUID).String(),
 		OwnerTag:     model.Owner.String(),
 		ModelName:    model.Name,
-		AgentVersion: model.Version,
+		AgentVersion: model.AgentVersion,
 	}
 	return c.caller.FacadeCall("Prechecks", args, nil)
 }

--- a/api/migrationtarget/client_test.go
+++ b/api/migrationtarget/client_test.go
@@ -46,10 +46,10 @@ func (s *ClientSuite) TestPrechecks(c *gc.C) {
 	})
 	c.Assert(err, gc.ErrorMatches, "boom")
 
-	expectedArg := params.TargetPrechecksArgs{
-		ModelTag:     names.NewModelTag("uuid").String(),
+	expectedArg := params.MigrationModelInfo{
+		UUID:         "uuid",
+		Name:         "name",
 		OwnerTag:     ownerTag.String(),
-		ModelName:    "name",
 		AgentVersion: vers,
 	}
 	stub.CheckCalls(c, []jujutesting.StubCall{

--- a/api/migrationtarget/client_test.go
+++ b/api/migrationtarget/client_test.go
@@ -13,7 +13,7 @@ import (
 	apitesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/migrationtarget"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/migration"
+	coremigration "github.com/juju/juju/core/migration"
 )
 
 type ClientSuite struct {
@@ -38,11 +38,11 @@ func (s *ClientSuite) TestPrechecks(c *gc.C) {
 	ownerTag := names.NewUserTag("owner")
 	vers := version.MustParse("1.2.3")
 
-	err := client.Prechecks(migration.PrecheckModelInfo{
-		UUID:    "uuid",
-		Owner:   ownerTag,
-		Name:    "name",
-		Version: vers,
+	err := client.Prechecks(coremigration.ModelInfo{
+		UUID:         "uuid",
+		Owner:        ownerTag,
+		Name:         "name",
+		AgentVersion: vers,
 	})
 	c.Assert(err, gc.ErrorMatches, "boom")
 

--- a/apiserver/migrationmaster/backend.go
+++ b/apiserver/migrationmaster/backend.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/state"
 	"github.com/juju/version"
+	"gopkg.in/juju/names.v2"
 )
 
 // Backend defines the state functionality required by the
@@ -16,6 +17,7 @@ type Backend interface {
 	LatestMigration() (state.ModelMigration, error)
 	ModelUUID() string
 	ModelName() (string, error)
+	ModelOwner() (names.UserTag, error)
 	AgentVersion() (version.Number, error)
 	RemoveExportingModelDocs() error
 

--- a/apiserver/migrationmaster/backend.go
+++ b/apiserver/migrationmaster/backend.go
@@ -4,10 +4,11 @@
 package migrationmaster
 
 import (
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/state"
 	"github.com/juju/version"
-	"gopkg.in/juju/names.v2"
 )
 
 // Backend defines the state functionality required by the

--- a/apiserver/migrationmaster/facade.go
+++ b/apiserver/migrationmaster/facade.go
@@ -122,6 +122,11 @@ func (api *API) ModelInfo() (params.MigrationModelInfo, error) {
 		return empty, errors.Annotate(err, "retrieving model name")
 	}
 
+	owner, err := api.backend.ModelOwner()
+	if err != nil {
+		return empty, errors.Annotate(err, "retrieving model owner")
+	}
+
 	vers, err := api.backend.AgentVersion()
 	if err != nil {
 		return empty, errors.Annotate(err, "retrieving agent version")
@@ -130,6 +135,7 @@ func (api *API) ModelInfo() (params.MigrationModelInfo, error) {
 	return params.MigrationModelInfo{
 		UUID:         api.backend.ModelUUID(),
 		Name:         name,
+		OwnerTag:     owner.String(),
 		AgentVersion: vers,
 	}, nil
 }

--- a/apiserver/migrationmaster/facade_test.go
+++ b/apiserver/migrationmaster/facade_test.go
@@ -120,6 +120,7 @@ func (s *Suite) TestModelInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(model.UUID, gc.Equals, "model-uuid")
 	c.Assert(model.Name, gc.Equals, "model-name")
+	c.Assert(model.OwnerTag, gc.Equals, names.NewUserTag("owner").String())
 	c.Assert(model.AgentVersion, gc.Equals, version.MustParse("1.2.3"))
 }
 
@@ -182,7 +183,7 @@ func (s *Suite) TestSetStatusMessageError(c *gc.C) {
 func (s *Suite) TestPrechecks(c *gc.C) {
 	api := s.mustMakeAPI(c)
 	err := api.Prechecks()
-	c.Assert(err, gc.ErrorMatches, "retrieving model life: boom")
+	c.Assert(err, gc.ErrorMatches, "retrieving model: boom")
 }
 
 func (s *Suite) TestExport(c *gc.C) {
@@ -338,6 +339,10 @@ func (b *stubBackend) ModelName() (string, error) {
 	return "model-name", nil
 }
 
+func (b *stubBackend) ModelOwner() (names.UserTag, error) {
+	return names.NewUserTag("owner"), nil
+}
+
 func (b *stubBackend) AgentVersion() (version.Number, error) {
 	return version.MustParse("1.2.3"), nil
 }
@@ -435,6 +440,6 @@ type failingPrecheckBackend struct {
 	migration.PrecheckBackend
 }
 
-func (b *failingPrecheckBackend) ModelLife() (state.Life, error) {
-	return state.Alive, errors.New("boom")
+func (b *failingPrecheckBackend) Model() (migration.PrecheckModel, error) {
+	return nil, errors.New("boom")
 }

--- a/apiserver/migrationmaster/shim.go
+++ b/apiserver/migrationmaster/shim.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/state"
 	"github.com/juju/version"
+	"gopkg.in/juju/names.v2"
 )
 
 // newAPIForRegistration exists to provide the required signature for
@@ -27,6 +28,7 @@ type backendShim struct {
 	*state.State
 }
 
+// ModelName implements Backend.
 func (s *backendShim) ModelName() (string, error) {
 	model, err := s.Model()
 	if err != nil {
@@ -35,6 +37,16 @@ func (s *backendShim) ModelName() (string, error) {
 	return model.Name(), nil
 }
 
+// ModelOwner implements Backend.
+func (s *backendShim) ModelOwner() (names.UserTag, error) {
+	model, err := s.Model()
+	if err != nil {
+		return names.UserTag{}, errors.Trace(err)
+	}
+	return model.Owner(), nil
+}
+
+// AgentVersion implements Backend.
 func (s *backendShim) AgentVersion() (version.Number, error) {
 	cfg, err := s.ModelConfig()
 	if err != nil {

--- a/apiserver/migrationtarget/migrationtarget.go
+++ b/apiserver/migrationtarget/migrationtarget.go
@@ -60,22 +60,18 @@ func checkAuth(authorizer facade.Authorizer, st *state.State) error {
 
 // Prechecks ensure that the target controller is ready to accept a
 // model migration.
-func (api *API) Prechecks(args params.TargetPrechecksArgs) error {
-	modelTag, err := names.ParseModelTag(args.ModelTag)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	ownerTag, err := names.ParseUserTag(args.OwnerTag)
+func (api *API) Prechecks(model params.MigrationModelInfo) error {
+	ownerTag, err := names.ParseUserTag(model.OwnerTag)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	return migration.TargetPrecheck(
 		migration.PrecheckShim(api.state),
 		coremigration.ModelInfo{
-			UUID:         modelTag.Id(),
+			UUID:         model.UUID,
+			Name:         model.Name,
 			Owner:        ownerTag,
-			Name:         args.ModelName,
-			AgentVersion: args.AgentVersion,
+			AgentVersion: model.AgentVersion,
 		},
 	)
 }

--- a/apiserver/migrationtarget/migrationtarget.go
+++ b/apiserver/migrationtarget/migrationtarget.go
@@ -60,9 +60,22 @@ func checkAuth(authorizer facade.Authorizer, st *state.State) error {
 // Prechecks ensure that the target controller is ready to accept a
 // model migration.
 func (api *API) Prechecks(args params.TargetPrechecksArgs) error {
+	modelTag, err := names.ParseModelTag(args.ModelTag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	ownerTag, err := names.ParseUserTag(args.OwnerTag)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	return migration.TargetPrecheck(
 		migration.PrecheckShim(api.state),
-		args.AgentVersion,
+		migration.PrecheckModelInfo{
+			UUID:    modelTag.Id(),
+			Owner:   ownerTag,
+			Name:    args.ModelName,
+			Version: args.AgentVersion,
+		},
 	)
 }
 

--- a/apiserver/migrationtarget/migrationtarget.go
+++ b/apiserver/migrationtarget/migrationtarget.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/description"
+	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/state"
 )
@@ -70,11 +71,11 @@ func (api *API) Prechecks(args params.TargetPrechecksArgs) error {
 	}
 	return migration.TargetPrecheck(
 		migration.PrecheckShim(api.state),
-		migration.PrecheckModelInfo{
-			UUID:    modelTag.Id(),
-			Owner:   ownerTag,
-			Name:    args.ModelName,
-			Version: args.AgentVersion,
+		coremigration.ModelInfo{
+			UUID:         modelTag.Id(),
+			Owner:        ownerTag,
+			Name:         args.ModelName,
+			AgentVersion: args.AgentVersion,
 		},
 	)
 }

--- a/apiserver/migrationtarget/migrationtarget_test.go
+++ b/apiserver/migrationtarget/migrationtarget_test.go
@@ -82,12 +82,11 @@ func (s *Suite) importModel(c *gc.C, api *migrationtarget.API) names.ModelTag {
 }
 
 func (s *Suite) TestPrechecks(c *gc.C) {
-	uuid := utils.MustNewUUID().String()
 	api := s.mustNewAPI(c)
-	args := params.TargetPrechecksArgs{
-		ModelTag:     names.NewModelTag(uuid).String(),
+	args := params.MigrationModelInfo{
+		UUID:         "uuid",
+		Name:         "some-model",
 		OwnerTag:     names.NewUserTag("someone").String(),
-		ModelName:    "some-model",
 		AgentVersion: s.controllerVersion(c),
 	}
 	err := api.Prechecks(args)
@@ -102,7 +101,7 @@ func (s *Suite) TestPrechecksFail(c *gc.C) {
 	modelVersion.Minor++
 
 	api := s.mustNewAPI(c)
-	args := params.TargetPrechecksArgs{
+	args := params.MigrationModelInfo{
 		AgentVersion: modelVersion,
 	}
 	err := api.Prechecks(args)

--- a/apiserver/migrationtarget/migrationtarget_test.go
+++ b/apiserver/migrationtarget/migrationtarget_test.go
@@ -82,8 +82,12 @@ func (s *Suite) importModel(c *gc.C, api *migrationtarget.API) names.ModelTag {
 }
 
 func (s *Suite) TestPrechecks(c *gc.C) {
+	uuid := utils.MustNewUUID().String()
 	api := s.mustNewAPI(c)
 	args := params.TargetPrechecksArgs{
+		ModelTag:     names.NewModelTag(uuid).String(),
+		OwnerTag:     names.NewUserTag("someone").String(),
+		ModelName:    "some-model",
 		AgentVersion: s.controllerVersion(c),
 	}
 	err := api.Prechecks(args)

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -171,19 +171,3 @@ type MinionReports struct {
 	// failed to complete a given migration phase.
 	Failed []string `json:"failed"`
 }
-
-// TargetPrechecksArgs details regarding pre-migration checks to
-// MigrationTarget.Prechecks.
-type TargetPrechecksArgs struct {
-	// ModelName is the name of the model to be migrated.
-	ModelName string `json:"model-name"`
-
-	// ModelTag is tag of the model to be migrated.
-	ModelTag string `json:"model-tag"`
-
-	// OwnerTag is the owner of the model to be migrated.
-	OwnerTag string `json:"owner-tag"`
-
-	// AgentVersion is the tools version of the model to be migrated.
-	AgentVersion version.Number `json:"agent-version"`
-}

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -174,6 +174,15 @@ type MinionReports struct {
 // TargetPrechecksArgs details regarding pre-migration checks to
 // MigrationTarget.Prechecks.
 type TargetPrechecksArgs struct {
+	// ModelName is the name of the model to be migrated.
+	ModelName string `json:"model-name"`
+
+	// ModelTag is tag of the model to be migrated.
+	ModelTag string `json:"model-tag"`
+
+	// OwnerTag is the owner of the model to be migrated.
+	OwnerTag string `json:"model-owner-tag"`
+
 	// AgentVersion is the tools version of the model to be migrated.
 	AgentVersion version.Number `json:"agent-version"`
 }

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -181,7 +181,7 @@ type TargetPrechecksArgs struct {
 	ModelTag string `json:"model-tag"`
 
 	// OwnerTag is the owner of the model to be migrated.
-	OwnerTag string `json:"model-owner-tag"`
+	OwnerTag string `json:"owner-tag"`
 
 	// AgentVersion is the tools version of the model to be migrated.
 	AgentVersion version.Number `json:"agent-version"`

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -99,6 +99,7 @@ type MasterMigrationStatus struct {
 type MigrationModelInfo struct {
 	UUID         string         `json:"uuid"`
 	Name         string         `json:"name"`
+	OwnerTag     string         `json:"owner-tag"`
 	AgentVersion version.Number `json:"agent-version"`
 }
 

--- a/core/migration/migration.go
+++ b/core/migration/migration.go
@@ -6,10 +6,9 @@ package migration
 import (
 	"time"
 
-	"gopkg.in/juju/names.v2"
-
 	"github.com/juju/errors"
 	"github.com/juju/version"
+	"gopkg.in/juju/names.v2"
 )
 
 // MigrationStatus returns the details for a migration as needed by

--- a/core/migration/migration.go
+++ b/core/migration/migration.go
@@ -8,6 +8,7 @@ import (
 
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/errors"
 	"github.com/juju/version"
 )
 
@@ -51,7 +52,23 @@ type SerializedModel struct {
 // ModelInfo is used to report basic details about a model.
 type ModelInfo struct {
 	UUID         string
-	Name         string
 	Owner        names.UserTag
+	Name         string
 	AgentVersion version.Number
+}
+
+func (i *ModelInfo) Validate() error {
+	if i.UUID == "" {
+		return errors.NotValidf("empty UUID")
+	}
+	if i.Owner.Name() == "" {
+		return errors.NotValidf("empty Owner")
+	}
+	if i.Name == "" {
+		return errors.NotValidf("empty Name")
+	}
+	if i.AgentVersion.Compare(version.Number{}) == 0 {
+		return errors.NotValidf("empty Version")
+	}
+	return nil
 }

--- a/core/migration/migration.go
+++ b/core/migration/migration.go
@@ -6,6 +6,8 @@ package migration
 import (
 	"time"
 
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/version"
 )
 
@@ -50,5 +52,6 @@ type SerializedModel struct {
 type ModelInfo struct {
 	UUID         string
 	Name         string
+	Owner        names.UserTag
 	AgentVersion version.Number
 }

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -150,6 +150,9 @@ func TargetPrecheck(backend PrecheckBackend, modelInfo coremigration.ModelInfo) 
 	}
 	canonicalOwner := modelInfo.Owner.Canonical()
 	for _, model := range models {
+		// If the model is importing then it's probably left behind
+		// from a previous migration attempt. It will be removed
+		// before the next import.
 		if model.UUID() == modelInfo.UUID && model.MigrationMode() != state.MigrationModeImporting {
 			return errors.Errorf("model with same UUID already exists (%s)", modelInfo.UUID)
 		}

--- a/migration/precheck_shim.go
+++ b/migration/precheck_shim.go
@@ -6,6 +6,7 @@ package migration
 import (
 	"github.com/juju/errors"
 	"github.com/juju/version"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/state"
 )
@@ -21,22 +22,22 @@ type precheckShim struct {
 	*state.State
 }
 
-// ModelLife implements PrecheckBackend.
-func (s *precheckShim) ModelLife() (state.Life, error) {
+// Model implements PrecheckBackend.
+func (s *precheckShim) Model() (PrecheckModel, error) {
 	model, err := s.Model()
 	if err != nil {
-		return 0, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
-	return model.Life(), nil
+	return model, nil
 }
 
-// MigrationStatus implements PrecheckBackend.
-func (s *precheckShim) MigrationMode() (state.MigrationMode, error) {
-	model, err := s.Model()
+// GetModel implements PrecheckBackend.
+func (s *precheckShim) GetModel(tag names.ModelTag) (PrecheckModel, error) {
+	model, err := s.GetModel(tag)
 	if err != nil {
-		return "", errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
-	return model.MigrationMode(), nil
+	return model, nil
 }
 
 // AgentVersion implements PrecheckBackend.

--- a/migration/precheck_shim.go
+++ b/migration/precheck_shim.go
@@ -6,7 +6,6 @@ package migration
 import (
 	"github.com/juju/errors"
 	"github.com/juju/version"
-	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/state"
 )
@@ -24,25 +23,29 @@ type precheckShim struct {
 
 // Model implements PrecheckBackend.
 func (s *precheckShim) Model() (PrecheckModel, error) {
-	model, err := s.Model()
+	model, err := s.State.Model()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return model, nil
 }
 
-// GetModel implements PrecheckBackend.
-func (s *precheckShim) GetModel(tag names.ModelTag) (PrecheckModel, error) {
-	model, err := s.GetModel(tag)
+// AllModels implements PrecheckBackend.
+func (s *precheckShim) AllModels() ([]PrecheckModel, error) {
+	models, err := s.State.AllModels()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return model, nil
+	out := make([]PrecheckModel, 0, len(models))
+	for _, model := range models {
+		out = append(out, model)
+	}
+	return out, nil
 }
 
 // AgentVersion implements PrecheckBackend.
 func (s *precheckShim) AgentVersion() (version.Number, error) {
-	cfg, err := s.ModelConfig()
+	cfg, err := s.State.ModelConfig()
 	if err != nil {
 		return version.Zero, errors.Trace(err)
 	}

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 
+	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
@@ -278,17 +279,17 @@ func (s *SourcePrecheckSuite) TestProvisioningControllerMachine(c *gc.C) {
 
 type TargetPrecheckSuite struct {
 	precheckBaseSuite
-	modelInfo migration.PrecheckModelInfo
+	modelInfo coremigration.ModelInfo
 }
 
 var _ = gc.Suite(&TargetPrecheckSuite{})
 
 func (s *TargetPrecheckSuite) SetUpTest(c *gc.C) {
-	s.modelInfo = migration.PrecheckModelInfo{
-		UUID:    modelUUID,
-		Owner:   modelOwner,
-		Name:    modelName,
-		Version: backendVersion,
+	s.modelInfo = coremigration.ModelInfo{
+		UUID:         modelUUID,
+		Owner:        modelOwner,
+		Name:         modelName,
+		AgentVersion: backendVersion,
 	}
 }
 
@@ -303,7 +304,7 @@ func (s *TargetPrecheckSuite) TestSuccess(c *gc.C) {
 
 func (s *TargetPrecheckSuite) TestVersionLessThanSource(c *gc.C) {
 	backend := newFakeBackend()
-	s.modelInfo.Version = version.MustParse("1.2.4")
+	s.modelInfo.AgentVersion = version.MustParse("1.2.4")
 	err := migration.TargetPrecheck(backend, s.modelInfo)
 	c.Assert(err.Error(), gc.Equals,
 		`model has higher version than target controller (1.2.4 > 1.2.3)`)

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -314,7 +314,12 @@ func (w *Worker) prechecks(status coremigration.MigrationStatus) error {
 	}
 	defer conn.Close()
 	targetClient := migrationtarget.NewClient(conn)
-	err = targetClient.Prechecks(model.AgentVersion)
+	err = targetClient.Prechecks(migration.PrecheckModelInfo{
+		UUID:    model.UUID,
+		Owner:   model.Owner,
+		Name:    model.Name,
+		Version: model.AgentVersion,
+	})
 	return errors.Annotate(err, "target prechecks failed")
 }
 

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -314,12 +314,7 @@ func (w *Worker) prechecks(status coremigration.MigrationStatus) error {
 	}
 	defer conn.Close()
 	targetClient := migrationtarget.NewClient(conn)
-	err = targetClient.Prechecks(migration.PrecheckModelInfo{
-		UUID:    model.UUID,
-		Owner:   model.Owner,
-		Name:    model.Name,
-		Version: model.AgentVersion,
-	})
+	err = targetClient.Prechecks(model)
 	return errors.Annotate(err, "target prechecks failed")
 }
 

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -94,6 +94,11 @@ var (
 			params.ModelArgs{ModelTag: modelTagString},
 		},
 	}
+	watchStatusLockdownCalls = []jujutesting.StubCall{
+		{"masterFacade.Watch", nil},
+		{"masterFacade.MigrationStatus", nil},
+		{"guard.Lockdown", nil},
+	}
 	prechecksCalls = []jujutesting.StubCall{
 		{"masterFacade.Prechecks", nil},
 		{"masterFacade.ModelInfo", nil},
@@ -105,6 +110,13 @@ var (
 			AgentVersion: modelVersion,
 		}}},
 		connCloseCall,
+	}
+	abortCalls = []jujutesting.StubCall{
+		{"masterFacade.SetPhase", []interface{}{coremigration.ABORT}},
+		apiOpenCallController,
+		abortCall,
+		connCloseCall,
+		{"masterFacade.SetPhase", []interface{}{coremigration.ABORTDONE}},
 	}
 )
 
@@ -187,64 +199,55 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 	// Observe that the migration was seen, the model exported, an API
 	// connection to the target controller was made, the model was
 	// imported and then the migration completed.
-	s.stub.CheckCalls(c, []jujutesting.StubCall{
+	s.stub.CheckCalls(c, joinCalls(
 		// Wait for migration to start.
-		{"masterFacade.Watch", nil},
-		{"masterFacade.MigrationStatus", nil},
-		{"guard.Lockdown", nil},
+		watchStatusLockdownCalls,
 
 		// QUIESCE
-		{"masterFacade.Prechecks", nil},
-		{"masterFacade.ModelInfo", nil},
-		apiOpenCallController,
-		{"MigrationTarget.Prechecks", []interface{}{params.TargetPrechecksArgs{
-			ModelName:    modelName,
-			ModelTag:     modelTag.String(),
-			OwnerTag:     ownerTag.String(),
-			AgentVersion: modelVersion,
-		}}},
-		connCloseCall,
-		{"masterFacade.WatchMinionReports", nil},
-		{"masterFacade.MinionReports", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.IMPORT}},
+		prechecksCalls,
+		[]jujutesting.StubCall{
+			{"masterFacade.WatchMinionReports", nil},
+			{"masterFacade.MinionReports", nil},
+			{"masterFacade.SetPhase", []interface{}{coremigration.IMPORT}},
 
-		//IMPORT
-		{"masterFacade.Export", nil},
-		apiOpenCallController,
-		importCall,
-		apiOpenCallModel,
-		{"UploadBinaries", []interface{}{
-			[]string{"charm0", "charm1"},
-			fakeCharmDownloader,
-			map[version.Binary]string{
-				version.MustParseBinary("2.1.0-trusty-amd64"): "/tools/0",
-			},
-			fakeToolsDownloader,
-		}},
-		connCloseCall, // for target model
-		connCloseCall, // for target controller
-		{"masterFacade.SetPhase", []interface{}{coremigration.VALIDATION}},
+			//IMPORT
+			{"masterFacade.Export", nil},
+			apiOpenCallController,
+			importCall,
+			apiOpenCallModel,
+			{"UploadBinaries", []interface{}{
+				[]string{"charm0", "charm1"},
+				fakeCharmDownloader,
+				map[version.Binary]string{
+					version.MustParseBinary("2.1.0-trusty-amd64"): "/tools/0",
+				},
+				fakeToolsDownloader,
+			}},
+			connCloseCall, // for target model
+			connCloseCall, // for target controller
+			{"masterFacade.SetPhase", []interface{}{coremigration.VALIDATION}},
 
-		// VALIDATION
-		{"masterFacade.WatchMinionReports", nil},
-		{"masterFacade.MinionReports", nil},
-		apiOpenCallController,
-		activateCall,
-		connCloseCall,
-		{"masterFacade.SetPhase", []interface{}{coremigration.SUCCESS}},
+			// VALIDATION
+			{"masterFacade.WatchMinionReports", nil},
+			{"masterFacade.MinionReports", nil},
+			apiOpenCallController,
+			activateCall,
+			connCloseCall,
+			{"masterFacade.SetPhase", []interface{}{coremigration.SUCCESS}},
 
-		// SUCCESS
-		{"masterFacade.WatchMinionReports", nil},
-		{"masterFacade.MinionReports", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
+			// SUCCESS
+			{"masterFacade.WatchMinionReports", nil},
+			{"masterFacade.MinionReports", nil},
+			{"masterFacade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
 
-		// LOGTRANSFER
-		{"masterFacade.SetPhase", []interface{}{coremigration.REAP}},
+			// LOGTRANSFER
+			{"masterFacade.SetPhase", []interface{}{coremigration.REAP}},
 
-		// REAP
-		{"masterFacade.Reap", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.DONE}},
-	})
+			// REAP
+			{"masterFacade.Reap", nil},
+			{"masterFacade.SetPhase", []interface{}{coremigration.DONE}},
+		}),
+	)
 }
 
 func (s *Suite) TestMigrationResume(c *gc.C) {
@@ -259,17 +262,17 @@ func (s *Suite) TestMigrationResume(c *gc.C) {
 	err = workertest.CheckKilled(c, worker)
 	c.Assert(errors.Cause(err), gc.Equals, migrationmaster.ErrMigrated)
 
-	s.stub.CheckCalls(c, []jujutesting.StubCall{
-		{"masterFacade.Watch", nil},
-		{"masterFacade.MigrationStatus", nil},
-		{"guard.Lockdown", nil},
-		{"masterFacade.WatchMinionReports", nil},
-		{"masterFacade.MinionReports", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
-		{"masterFacade.SetPhase", []interface{}{coremigration.REAP}},
-		{"masterFacade.Reap", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.DONE}},
-	})
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{
+			{"masterFacade.WatchMinionReports", nil},
+			{"masterFacade.MinionReports", nil},
+			{"masterFacade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
+			{"masterFacade.SetPhase", []interface{}{coremigration.REAP}},
+			{"masterFacade.Reap", nil},
+			{"masterFacade.SetPhase", []interface{}{coremigration.DONE}},
+		},
+	))
 }
 
 func (s *Suite) TestPreviouslyAbortedMigration(c *gc.C) {
@@ -296,7 +299,6 @@ func (s *Suite) TestPreviouslyCompletedMigration(c *gc.C) {
 
 	err = workertest.CheckKilled(c, worker)
 	c.Assert(errors.Cause(err), gc.Equals, migrationmaster.ErrMigrated)
-
 	s.stub.CheckCalls(c, []jujutesting.StubCall{
 		{"masterFacade.Watch", nil},
 		{"masterFacade.MigrationStatus", nil},
@@ -320,7 +322,6 @@ func (s *Suite) TestStatusError(c *gc.C) {
 	s.triggerMigration()
 
 	err = workertest.CheckKilled(c, worker)
-
 	s.stub.CheckCalls(c, []jujutesting.StubCall{
 		{"masterFacade.Watch", nil},
 		{"masterFacade.MigrationStatus", nil},
@@ -373,12 +374,7 @@ func (s *Suite) TestLockdownError(c *gc.C) {
 
 	err = workertest.CheckKilled(c, worker)
 	c.Check(err, gc.ErrorMatches, "biff")
-
-	s.stub.CheckCalls(c, []jujutesting.StubCall{
-		{"masterFacade.Watch", nil},
-		{"masterFacade.MigrationStatus", nil},
-		{"guard.Lockdown", nil},
-	})
+	s.stub.CheckCalls(c, watchStatusLockdownCalls)
 }
 
 func (s *Suite) TestQUIESCEMinionWaitWatchError(c *gc.C) {
@@ -405,28 +401,15 @@ func (s *Suite) TestQUIESCEFailedAgent(c *gc.C) {
 	err = workertest.CheckKilled(c, worker)
 	c.Assert(err, gc.Equals, migrationmaster.ErrInactive)
 
-	s.stub.CheckCalls(c, []jujutesting.StubCall{
-		{"masterFacade.Watch", nil},
-		{"masterFacade.MigrationStatus", nil},
-		{"guard.Lockdown", nil},
-		{"masterFacade.Prechecks", nil},
-		{"masterFacade.ModelInfo", nil},
-		apiOpenCallController,
-		{"MigrationTarget.Prechecks", []interface{}{params.TargetPrechecksArgs{
-			ModelName:    modelName,
-			ModelTag:     modelTag.String(),
-			OwnerTag:     ownerTag.String(),
-			AgentVersion: version.MustParse("1.2.4"),
-		}}},
-		connCloseCall,
-		{"masterFacade.WatchMinionReports", nil},
-		{"masterFacade.MinionReports", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.ABORT}},
-		apiOpenCallController,
-		abortCall,
-		connCloseCall,
-		{"masterFacade.SetPhase", []interface{}{coremigration.ABORTDONE}},
-	})
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		prechecksCalls,
+		[]jujutesting.StubCall{
+			{"masterFacade.WatchMinionReports", nil},
+			{"masterFacade.MinionReports", nil},
+		},
+		abortCalls,
+	))
 }
 
 func (s *Suite) TestQUIESCESourceChecksFail(c *gc.C) {
@@ -439,18 +422,11 @@ func (s *Suite) TestQUIESCESourceChecksFail(c *gc.C) {
 
 	err = workertest.CheckKilled(c, worker)
 	c.Assert(err, gc.Equals, migrationmaster.ErrInactive)
-
-	s.stub.CheckCalls(c, []jujutesting.StubCall{
-		{"masterFacade.Watch", nil},
-		{"masterFacade.MigrationStatus", nil},
-		{"guard.Lockdown", nil},
-		{"masterFacade.Prechecks", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.ABORT}},
-		apiOpenCallController,
-		abortCall,
-		connCloseCall,
-		{"masterFacade.SetPhase", []interface{}{coremigration.ABORTDONE}},
-	})
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{{"masterFacade.Prechecks", nil}},
+		abortCalls,
+	))
 }
 
 func (s *Suite) TestQUIESCEModelInfoFail(c *gc.C) {
@@ -464,18 +440,14 @@ func (s *Suite) TestQUIESCEModelInfoFail(c *gc.C) {
 	err = workertest.CheckKilled(c, worker)
 	c.Assert(err, gc.Equals, migrationmaster.ErrInactive)
 
-	s.stub.CheckCalls(c, []jujutesting.StubCall{
-		{"masterFacade.Watch", nil},
-		{"masterFacade.MigrationStatus", nil},
-		{"guard.Lockdown", nil},
-		{"masterFacade.Prechecks", nil},
-		{"masterFacade.ModelInfo", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.ABORT}},
-		apiOpenCallController,
-		abortCall,
-		connCloseCall,
-		{"masterFacade.SetPhase", []interface{}{coremigration.ABORTDONE}},
-	})
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{
+			{"masterFacade.Prechecks", nil},
+			{"masterFacade.ModelInfo", nil},
+		},
+		abortCalls,
+	))
 }
 
 func (s *Suite) TestQUIESCETargetChecksFail(c *gc.C) {
@@ -489,26 +461,11 @@ func (s *Suite) TestQUIESCETargetChecksFail(c *gc.C) {
 	err = workertest.CheckKilled(c, worker)
 	c.Assert(err, gc.Equals, migrationmaster.ErrInactive)
 
-	s.stub.CheckCalls(c, []jujutesting.StubCall{
-		{"masterFacade.Watch", nil},
-		{"masterFacade.MigrationStatus", nil},
-		{"guard.Lockdown", nil},
-		{"masterFacade.Prechecks", nil},
-		{"masterFacade.ModelInfo", nil},
-		apiOpenCallController,
-		{"MigrationTarget.Prechecks", []interface{}{params.TargetPrechecksArgs{
-			ModelName:    modelName,
-			ModelTag:     modelTag.String(),
-			OwnerTag:     ownerTag.String(),
-			AgentVersion: version.MustParse("1.2.4"),
-		}}},
-		connCloseCall,
-		{"masterFacade.SetPhase", []interface{}{coremigration.ABORT}},
-		apiOpenCallController,
-		abortCall,
-		connCloseCall,
-		{"masterFacade.SetPhase", []interface{}{coremigration.ABORTDONE}},
-	})
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		prechecksCalls,
+		abortCalls,
+	))
 }
 
 func (s *Suite) TestExportFailure(c *gc.C) {
@@ -522,17 +479,13 @@ func (s *Suite) TestExportFailure(c *gc.C) {
 	err = workertest.CheckKilled(c, worker)
 	c.Assert(err, gc.Equals, migrationmaster.ErrInactive)
 
-	s.stub.CheckCalls(c, []jujutesting.StubCall{
-		{"masterFacade.Watch", nil},
-		{"masterFacade.MigrationStatus", nil},
-		{"guard.Lockdown", nil},
-		{"masterFacade.Export", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.ABORT}},
-		apiOpenCallController,
-		abortCall,
-		connCloseCall,
-		{"masterFacade.SetPhase", []interface{}{coremigration.ABORTDONE}},
-	})
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{
+			{"masterFacade.Export", nil},
+		},
+		abortCalls,
+	))
 }
 
 func (s *Suite) TestAPIOpenFailure(c *gc.C) {
@@ -546,16 +499,16 @@ func (s *Suite) TestAPIOpenFailure(c *gc.C) {
 	err = workertest.CheckKilled(c, worker)
 	c.Assert(err, gc.Equals, migrationmaster.ErrInactive)
 
-	s.stub.CheckCalls(c, []jujutesting.StubCall{
-		{"masterFacade.Watch", nil},
-		{"masterFacade.MigrationStatus", nil},
-		{"guard.Lockdown", nil},
-		{"masterFacade.Export", nil},
-		apiOpenCallController,
-		{"masterFacade.SetPhase", []interface{}{coremigration.ABORT}},
-		apiOpenCallController,
-		{"masterFacade.SetPhase", []interface{}{coremigration.ABORTDONE}},
-	})
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{
+			{"masterFacade.Export", nil},
+			apiOpenCallController,
+			{"masterFacade.SetPhase", []interface{}{coremigration.ABORT}},
+			apiOpenCallController,
+			{"masterFacade.SetPhase", []interface{}{coremigration.ABORTDONE}},
+		},
+	))
 }
 
 func (s *Suite) TestImportFailure(c *gc.C) {
@@ -569,20 +522,16 @@ func (s *Suite) TestImportFailure(c *gc.C) {
 	err = workertest.CheckKilled(c, worker)
 	c.Assert(err, gc.Equals, migrationmaster.ErrInactive)
 
-	s.stub.CheckCalls(c, []jujutesting.StubCall{
-		{"masterFacade.Watch", nil},
-		{"masterFacade.MigrationStatus", nil},
-		{"guard.Lockdown", nil},
-		{"masterFacade.Export", nil},
-		apiOpenCallController,
-		importCall,
-		connCloseCall,
-		{"masterFacade.SetPhase", []interface{}{coremigration.ABORT}},
-		apiOpenCallController,
-		abortCall,
-		connCloseCall,
-		{"masterFacade.SetPhase", []interface{}{coremigration.ABORTDONE}},
-	})
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{
+			{"masterFacade.Export", nil},
+			apiOpenCallController,
+			importCall,
+			connCloseCall,
+		},
+		abortCalls,
+	))
 }
 
 func (s *Suite) TestVALIDATIONMinionWaitWatchError(c *gc.C) {
@@ -609,18 +558,14 @@ func (s *Suite) TestVALIDATIONFailedAgent(c *gc.C) {
 	err = workertest.CheckKilled(c, worker)
 	c.Assert(err, gc.Equals, migrationmaster.ErrInactive)
 
-	s.stub.CheckCalls(c, []jujutesting.StubCall{
-		{"masterFacade.Watch", nil},
-		{"masterFacade.MigrationStatus", nil},
-		{"guard.Lockdown", nil},
-		{"masterFacade.WatchMinionReports", nil},
-		{"masterFacade.MinionReports", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.ABORT}},
-		apiOpenCallController,
-		abortCall,
-		connCloseCall,
-		{"masterFacade.SetPhase", []interface{}{coremigration.ABORTDONE}},
-	})
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{
+			{"masterFacade.WatchMinionReports", nil},
+			{"masterFacade.MinionReports", nil},
+		},
+		abortCalls,
+	))
 }
 
 func (s *Suite) TestSUCCESSMinionWaitWatchError(c *gc.C) {
@@ -649,17 +594,17 @@ func (s *Suite) TestSUCCESSMinionWaitFailedMachine(c *gc.C) {
 	err = workertest.CheckKilled(c, worker)
 	c.Assert(err, gc.Equals, migrationmaster.ErrMigrated)
 
-	s.stub.CheckCalls(c, []jujutesting.StubCall{
-		{"masterFacade.Watch", nil},
-		{"masterFacade.MigrationStatus", nil},
-		{"guard.Lockdown", nil},
-		{"masterFacade.WatchMinionReports", nil},
-		{"masterFacade.MinionReports", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
-		{"masterFacade.SetPhase", []interface{}{coremigration.REAP}},
-		{"masterFacade.Reap", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.DONE}},
-	})
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{
+			{"masterFacade.WatchMinionReports", nil},
+			{"masterFacade.MinionReports", nil},
+			{"masterFacade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
+			{"masterFacade.SetPhase", []interface{}{coremigration.REAP}},
+			{"masterFacade.Reap", nil},
+			{"masterFacade.SetPhase", []interface{}{coremigration.DONE}},
+		},
+	))
 }
 
 func (s *Suite) TestSUCCESSMinionWaitFailedUnit(c *gc.C) {
@@ -678,18 +623,17 @@ func (s *Suite) TestSUCCESSMinionWaitFailedUnit(c *gc.C) {
 
 	err = workertest.CheckKilled(c, worker)
 	c.Assert(err, gc.Equals, migrationmaster.ErrMigrated)
-
-	s.stub.CheckCalls(c, []jujutesting.StubCall{
-		{"masterFacade.Watch", nil},
-		{"masterFacade.MigrationStatus", nil},
-		{"guard.Lockdown", nil},
-		{"masterFacade.WatchMinionReports", nil},
-		{"masterFacade.MinionReports", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
-		{"masterFacade.SetPhase", []interface{}{coremigration.REAP}},
-		{"masterFacade.Reap", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.DONE}},
-	})
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{
+			{"masterFacade.WatchMinionReports", nil},
+			{"masterFacade.MinionReports", nil},
+			{"masterFacade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
+			{"masterFacade.SetPhase", []interface{}{coremigration.REAP}},
+			{"masterFacade.Reap", nil},
+			{"masterFacade.SetPhase", []interface{}{coremigration.DONE}},
+		},
+	))
 }
 
 func (s *Suite) TestSUCCESSMinionWaitTimeout(c *gc.C) {
@@ -715,16 +659,16 @@ func (s *Suite) TestSUCCESSMinionWaitTimeout(c *gc.C) {
 	err = workertest.CheckKilled(c, worker)
 	c.Assert(err, gc.Equals, migrationmaster.ErrMigrated)
 
-	s.stub.CheckCalls(c, []jujutesting.StubCall{
-		{"masterFacade.Watch", nil},
-		{"masterFacade.MigrationStatus", nil},
-		{"guard.Lockdown", nil},
-		{"masterFacade.WatchMinionReports", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
-		{"masterFacade.SetPhase", []interface{}{coremigration.REAP}},
-		{"masterFacade.Reap", nil},
-		{"masterFacade.SetPhase", []interface{}{coremigration.DONE}},
-	})
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{
+			{"masterFacade.WatchMinionReports", nil},
+			{"masterFacade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
+			{"masterFacade.SetPhase", []interface{}{coremigration.REAP}},
+			{"masterFacade.Reap", nil},
+			{"masterFacade.SetPhase", []interface{}{coremigration.DONE}},
+		},
+	))
 }
 
 func (s *Suite) TestMinionWaitWrongPhase(c *gc.C) {
@@ -781,26 +725,26 @@ func (s *Suite) TestAPIConnectWithMacaroon(c *gc.C) {
 	err = workertest.CheckKilled(c, worker)
 	c.Assert(err, gc.Equals, migrationmaster.ErrInactive)
 
-	s.stub.CheckCalls(c, []jujutesting.StubCall{
-		{"masterFacade.Watch", nil},
-		{"masterFacade.MigrationStatus", nil},
-		{"guard.Lockdown", nil},
-		jujutesting.StubCall{
-			"apiOpen",
-			[]interface{}{
-				&api.Info{
-					Addrs:     []string{"1.2.3.4:5"},
-					CACert:    "cert",
-					Tag:       names.NewUserTag("admin"),
-					Macaroons: []macaroon.Slice{{mac}}, // <----
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{
+			{
+				"apiOpen",
+				[]interface{}{
+					&api.Info{
+						Addrs:     []string{"1.2.3.4:5"},
+						CACert:    "cert",
+						Tag:       names.NewUserTag("admin"),
+						Macaroons: []macaroon.Slice{{mac}}, // <----
+					},
+					api.DialOpts{},
 				},
-				api.DialOpts{},
 			},
+			abortCall,
+			connCloseCall,
+			{"masterFacade.SetPhase", []interface{}{coremigration.ABORTDONE}},
 		},
-		abortCall,
-		connCloseCall,
-		{"masterFacade.SetPhase", []interface{}{coremigration.ABORTDONE}},
-	})
+	))
 }
 
 func (s *Suite) waitForStubCalls(c *gc.C, expectedCallNames []string) {

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -103,9 +103,9 @@ var (
 		{"masterFacade.Prechecks", nil},
 		{"masterFacade.ModelInfo", nil},
 		apiOpenCallController,
-		{"MigrationTarget.Prechecks", []interface{}{params.TargetPrechecksArgs{
-			ModelName:    modelName,
-			ModelTag:     modelTag.String(),
+		{"MigrationTarget.Prechecks", []interface{}{params.MigrationModelInfo{
+			UUID:         modelUUID,
+			Name:         modelName,
 			OwnerTag:     ownerTag.String(),
 			AgentVersion: modelVersion,
 		}}},


### PR DESCRIPTION
This PR is all about checking for migration related conflicts with existing models in the target controller. Specifically:

* a migration can't start if there's already a model with the same owner:name on the target
* a migration can't start if there's already a model with the same UUID on the target

As part of this, a lot of API changes were required. Opportunities to remove unnecessary test boilerplate and remove unnecessary duplicated types were also taken.



(Review request: http://reviews.vapour.ws/r/5587/)