### PR TITLE
Allow patching of periodic worker delays for metrics.

### DIFF
--- a/worker/metrics/collect/manifold.go
+++ b/worker/metrics/collect/manifold.go
@@ -32,12 +32,12 @@ import (
 )
 
 const (
-	defaultPeriod     = 5 * time.Minute
 	defaultSocketName = "metrics-collect.socket"
 )
 
 var (
-	logger = loggo.GetLogger("juju.worker.metrics.collect")
+	logger        = loggo.GetLogger("juju.worker.metrics.collect")
+	defaultPeriod = 5 * time.Minute
 
 	// errMetricsNotDefined is returned when the charm the uniter is running does
 	// not declared any metrics.

--- a/worker/metrics/sender/manifold.go
+++ b/worker/metrics/sender/manifold.go
@@ -24,9 +24,6 @@ var (
 	newMetricAdderClient = func(apiCaller base.APICaller) metricsadder.MetricsAdderClient {
 		return metricsadder.NewClient(apiCaller)
 	}
-)
-
-const (
 	period = time.Minute * 5
 )
 


### PR DESCRIPTION
This patch allows modification of periodic worker delays for metric
collection in the unit agent as well as sending in the controller agent
at link time, for the specific and limited purpose of end-to-end testing
with metering infrastructure.

Removed the manifold config option for setting the collect worker delay
as it wasn't being used.

QA steps:
- Should be able to modify periodic worker delays with linker flags
  passed to `make install` and observe a change in periodic worker rate.
- Other than that, no change in features or functionality wrt metrics
  or in general.

(Review request: http://reviews.vapour.ws/r/5588/)