### PR TITLE
Update juju/utils dependency to pickup licence change.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -45,7 +45,7 @@ github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-0
 github.com/juju/testing	git	d325c22badd4ba3a5fde01d479b188c7a06df755	2016-08-02T03:47:59Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils	git	dbc08fbee4c1bcf60d65f5a523149310ece56a08	2016-09-05T10:44:24Z
+github.com/juju/utils   git     dbc08fbee4c1bcf60d65f5a523149310ece56a08        2016-09-05T01:56:06Z
 github.com/juju/version	git	4ae6172c00626779a5a462c3e3d22fc0e889431a	2016-06-03T19:49:58Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -45,7 +45,7 @@ github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-0
 github.com/juju/testing	git	d325c22badd4ba3a5fde01d479b188c7a06df755	2016-08-02T03:47:59Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils   git     dbc08fbee4c1bcf60d65f5a523149310ece56a08        2016-09-05T01:56:06Z
+github.com/juju/utils	git	dbc08fbee4c1bcf60d65f5a523149310ece56a08	2016-09-05T01:56:06Z
 github.com/juju/version	git	4ae6172c00626779a5a462c3e3d22fc0e889431a	2016-06-03T19:49:58Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -45,7 +45,7 @@ github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-0
 github.com/juju/testing	git	d325c22badd4ba3a5fde01d479b188c7a06df755	2016-08-02T03:47:59Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils	git	bdb77b07e7e3f77463d10d2b554cd1b7a78009a2	2016-08-15T11:38:39Z
+github.com/juju/utils	git	dbc08fbee4c1bcf60d65f5a523149310ece56a08	2016-09-05T10:44:24Z
 github.com/juju/version	git	4ae6172c00626779a5a462c3e3d22fc0e889431a	2016-06-03T19:49:58Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z


### PR DESCRIPTION
Fix for a bug#1604988 updated licence on juju/utils. This proposal ensures newer utils version is used in Juju.

(Review request: http://reviews.vapour.ws/r/5591/)