### PR TITLE
Update juju/utils dependency for 1.25 to pickup licence change.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -29,7 +29,7 @@ github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T0
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
 github.com/juju/testing	git	162fafccebf20a4207ab93d63b986c230e3f4d2e	2015-05-29T04:40:43Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	70bf09197df816ad8cdf2ed5a6db59c0424cfb9a	2016-08-18T18:26:56Z
+github.com/juju/utils	git	3b23c7348d5b56ac89911a2c953ff1f3f65b005f	2016-09-05T03:29:40Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 golang.org/x/crypto	git	c57d4a71915a248dbad846d60825145062b4c18e	2015-03-27T05:11:19Z
 golang.org/x/net	git	bb64f4dc73d4ab97978d5e1cb34515dcc570361b	2015-05-18T01:39:50Z


### PR DESCRIPTION
Fix for a bug#1604988 updated licence on juju/utils. This proposal ensures newer utils version is used in Juju.

(Review request: http://reviews.vapour.ws/r/5593/)