### PR TITLE
List models machineinfo

### DIFF
--- a/api/base/types.go
+++ b/api/base/types.go
@@ -24,6 +24,8 @@ type ModelStatus struct {
 	UUID               string
 	Life               params.Life
 	Owner              string
+	TotalMachineCount  int
+	CoreCount          int
 	HostedMachineCount int
 	ServiceCount       int
 }

--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -138,8 +138,14 @@ func (c *Client) ModelStatus(tags ...names.ModelTag) ([]base.ModelStatus, error)
 			Owner:              owner.Canonical(),
 			HostedMachineCount: r.HostedMachineCount,
 			ServiceCount:       r.ApplicationCount,
+			TotalMachineCount:  len(r.Machines),
 		}
-
+		// For now, we just care about core count.
+		for _, mm := range r.Machines {
+			if mm.Hardware != nil && mm.Hardware.Cores != nil {
+				results[i].CoreCount += int(*mm.Hardware.Cores)
+			}
+		}
 	}
 	return results, nil
 }

--- a/apiserver/common/machine.go
+++ b/apiserver/common/machine.go
@@ -6,6 +6,7 @@ package common
 import (
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 )
@@ -52,6 +53,9 @@ func (st *stateShim) Machine(id string) (Machine, error) {
 }
 
 type Machine interface {
+	Id() string
+	ContainerType() instance.ContainerType
+	HardwareCharacteristics() (*instance.HardwareCharacteristics, error)
 	Life() state.Life
 	ForceDestroy() error
 	Destroy() error

--- a/apiserver/common/machine.go
+++ b/apiserver/common/machine.go
@@ -88,9 +88,9 @@ func destroyMachines(st stateInterface, force bool, ids ...string) error {
 	return DestroyErr("machines", ids, errs)
 }
 
-// MachineHardwareInfo returns information about machine hardware for
-// alive physical machines (not containers).
-func MachineHardwareInfo(st ModelManagerBackend) (machineInfo []params.ModelMachineInfo, _ error) {
+// ModelMachineInfo returns information about machine hardware for
+// alive top level machines (not containers).
+func ModelMachineInfo(st ModelManagerBackend) (machineInfo []params.ModelMachineInfo, _ error) {
 	machines, err := st.AllMachines()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -109,14 +109,17 @@ func MachineHardwareInfo(st ModelManagerBackend) (machineInfo []params.ModelMach
 		if err != nil && !errors.IsNotFound(err) {
 			return nil, errors.Trace(err)
 		}
-		if hw != nil && hw.CpuCores != nil {
-			mInfo.Cores = hw.CpuCores
-			mInfo.Arch = hw.Arch
-			mInfo.Mem = hw.Mem
-			mInfo.RootDisk = hw.RootDisk
-			mInfo.CpuPower = hw.CpuPower
-			mInfo.Tags = hw.Tags
-			mInfo.AvailabilityZone = hw.AvailabilityZone
+		if hw != nil && hw.String() != "" {
+			hwParams := &params.MachineHardware{
+				Cores:            hw.CpuCores,
+				Arch:             hw.Arch,
+				Mem:              hw.Mem,
+				RootDisk:         hw.RootDisk,
+				CpuPower:         hw.CpuPower,
+				Tags:             hw.Tags,
+				AvailabilityZone: hw.AvailabilityZone,
+			}
+			mInfo.Hardware = hwParams
 		}
 		machineInfo = append(machineInfo, mInfo)
 	}

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -47,6 +47,7 @@ type ModelManagerBackend interface {
 	AddControllerUser(state.UserAccessSpec) (description.UserAccess, error)
 	RemoveUserAccess(names.UserTag, names.Tag) error
 	UserAccess(names.UserTag, names.Tag) (description.UserAccess, error)
+	AllMachines() (machines []Machine, err error)
 	ControllerUUID() string
 	ControllerTag() names.ControllerTag
 	Export() (description.Model, error)
@@ -158,4 +159,20 @@ func (m modelShim) Users() ([]description.UserAccess, error) {
 		users[i] = user
 	}
 	return users, nil
+}
+
+type machineShim struct {
+	*state.Machine
+}
+
+func (st modelManagerStateShim) AllMachines() ([]Machine, error) {
+	allStateMachines, err := st.State.AllMachines()
+	if err != nil {
+		return nil, err
+	}
+	all := make([]Machine, len(allStateMachines))
+	for i, m := range allStateMachines {
+		all[i] = machineShim{m}
+	}
+	return all, nil
 }

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -89,23 +89,6 @@ func NewControllerAPI(
 	}, nil
 }
 
-func (s *ControllerAPI) hasReadAccess() (bool, error) {
-	canRead, err := s.authorizer.HasPermission(description.ReadAccess, s.state.ModelTag())
-	if errors.IsNotFound(err) {
-		return false, nil
-	}
-	return canRead, err
-
-}
-
-func (s *ControllerAPI) hasWriteAccess() (bool, error) {
-	canWrite, err := s.authorizer.HasPermission(description.WriteAccess, s.state.ModelTag())
-	if errors.IsNotFound(err) {
-		return false, nil
-	}
-	return canWrite, err
-}
-
 func (s *ControllerAPI) checkHasAdmin() error {
 	isAdmin, err := s.authorizer.HasPermission(description.SuperuserAccess, s.state.ControllerTag())
 	if err != nil {

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -446,25 +446,31 @@ func (c *ControllerAPI) modelStatus(tag string) (params.ModelStatus, error) {
 		}
 	}
 
-	services, err := st.AllApplications()
+	applications, err := st.AllApplications()
 	if err != nil {
 		return status, errors.Trace(err)
 	}
 
-	env, err := st.Model()
+	model, err := st.Model()
 	if err != nil {
 		return status, errors.Trace(err)
 	}
+	if err != nil {
+		return status, errors.Trace(err)
+	}
+
+	modelMachines, err := common.ModelMachineInfo(common.NewModelManagerBackend(st))
 	if err != nil {
 		return status, errors.Trace(err)
 	}
 
 	return params.ModelStatus{
 		ModelTag:           tag,
-		OwnerTag:           env.Owner().String(),
-		Life:               params.Life(env.Life().String()),
+		OwnerTag:           model.Owner().String(),
+		Life:               params.Life(model.Life().String()),
 		HostedMachineCount: len(hostedMachines),
-		ApplicationCount:   len(services),
+		ApplicationCount:   len(applications),
+		Machines:           modelMachines,
 	}, nil
 }
 

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -37,6 +37,10 @@ type modelInfoSuite struct {
 	modelmanager *modelmanager.ModelManagerAPI
 }
 
+func pUint64(v uint64) *uint64 {
+	return &v
+}
+
 var _ = gc.Suite(&modelInfoSuite{})
 
 func (s *modelInfoSuite) SetUpTest(c *gc.C) {
@@ -69,7 +73,6 @@ func (s *modelInfoSuite) SetUpTest(c *gc.C) {
 		}},
 	}
 
-	one := uint64(1)
 	s.st.model = &mockModel{
 		owner: names.NewUserTag("bob@local"),
 		cfg:   coretesting.ModelConfig(c),
@@ -101,7 +104,7 @@ func (s *modelInfoSuite) SetUpTest(c *gc.C) {
 			id:            "1",
 			containerType: "none",
 			life:          state.Alive,
-			hw:            &instance.HardwareCharacteristics{CpuCores: &one},
+			hw:            &instance.HardwareCharacteristics{CpuCores: pUint64(1)},
 		},
 		&mockMachine{
 			id:            "2",
@@ -121,14 +124,13 @@ func (s *modelInfoSuite) SetUpTest(c *gc.C) {
 
 func (s *modelInfoSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	s.authorizer.Tag = user
-	modelmanager, err := modelmanager.NewModelManagerAPI(s.st, nil, s.authorizer)
+	var err error
+	s.modelmanager, err = modelmanager.NewModelManagerAPI(s.st, nil, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
-	s.modelmanager = modelmanager
 }
 
 func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 	info := s.getModelInfo(c)
-	one := uint64(1)
 	c.Assert(info, jc.DeepEquals, params.ModelInfo{
 		Name:               "testenv",
 		UUID:               s.st.model.cfg.UUID(),
@@ -165,8 +167,8 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 			Access:         params.ModelWriteAccess,
 		}},
 		Machines: []params.ModelMachineInfo{{
-			Id:    "1",
-			Cores: &one,
+			Id:       "1",
+			Hardware: &params.MachineHardware{Cores: pUint64(1)},
 		}, {
 			Id: "2",
 		}},

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -100,11 +100,17 @@ func (s *modelInfoSuite) SetUpTest(c *gc.C) {
 		&mockMachine{
 			id:            "1",
 			containerType: "none",
+			life:          state.Alive,
 			hw:            &instance.HardwareCharacteristics{CpuCores: &one},
 		},
 		&mockMachine{
 			id:            "2",
+			life:          state.Alive,
 			containerType: "lxc",
+		},
+		&mockMachine{
+			id:   "3",
+			life: state.Dead,
 		},
 	}
 
@@ -470,12 +476,17 @@ func (st *mockState) DumpAll() (map[string]interface{}, error) {
 type mockMachine struct {
 	common.Machine
 	id            string
+	life          state.Life
 	containerType instance.ContainerType
 	hw            *instance.HardwareCharacteristics
 }
 
 func (m *mockMachine) Id() string {
 	return m.id
+}
+
+func (m *mockMachine) Life() state.Life {
+	return m.life
 }
 
 func (m *mockMachine) ContainerType() instance.ContainerType {

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
@@ -68,6 +69,7 @@ func (s *modelInfoSuite) SetUpTest(c *gc.C) {
 		}},
 	}
 
+	one := uint64(1)
 	s.st.model = &mockModel{
 		owner: names.NewUserTag("bob@local"),
 		cfg:   coretesting.ModelConfig(c),
@@ -88,8 +90,24 @@ func (s *modelInfoSuite) SetUpTest(c *gc.C) {
 			userName:    "charlotte@local",
 			displayName: "Charlotte",
 			access:      description.ReadAccess,
+		}, {
+			userName:    "mary@local",
+			displayName: "Mary",
+			access:      description.WriteAccess,
 		}},
 	}
+	s.st.machines = []common.Machine{
+		&mockMachine{
+			id:            "1",
+			containerType: "none",
+			hw:            &instance.HardwareCharacteristics{CpuCores: &one},
+		},
+		&mockMachine{
+			id:            "2",
+			containerType: "lxc",
+		},
+	}
+
 	var err error
 	s.modelmanager, err = modelmanager.NewModelManagerAPI(s.st, nil, &s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
@@ -104,6 +122,7 @@ func (s *modelInfoSuite) setAPIUser(c *gc.C, user names.UserTag) {
 
 func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 	info := s.getModelInfo(c)
+	one := uint64(1)
 	c.Assert(info, jc.DeepEquals, params.ModelInfo{
 		Name:               "testenv",
 		UUID:               s.st.model.cfg.UUID(),
@@ -133,6 +152,17 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 			DisplayName:    "Charlotte",
 			LastConnection: &time.Time{},
 			Access:         params.ModelReadAccess,
+		}, {
+			UserName:       "mary@local",
+			DisplayName:    "Mary",
+			LastConnection: &time.Time{},
+			Access:         params.ModelWriteAccess,
+		}},
+		Machines: []params.ModelMachineInfo{{
+			Id:    "1",
+			Cores: &one,
+		}, {
+			Id: "2",
 		}},
 	})
 	s.st.CheckCalls(c, []gitjujutesting.StubCall{
@@ -144,11 +174,14 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		{"LastModelConnection", []interface{}{names.NewUserTag("admin")}},
 		{"LastModelConnection", []interface{}{names.NewLocalUserTag("bob")}},
 		{"LastModelConnection", []interface{}{names.NewLocalUserTag("charlotte")}},
+		{"LastModelConnection", []interface{}{names.NewLocalUserTag("mary")}},
+		{"AllMachines", nil},
 		{"Close", nil},
 	})
 	s.st.model.CheckCalls(c, []gitjujutesting.StubCall{
 		{"Config", nil},
 		{"Users", nil},
+		{"ModelTag", nil},
 		{"ModelTag", nil},
 		{"ModelTag", nil},
 		{"ModelTag", nil},
@@ -164,7 +197,18 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 func (s *modelInfoSuite) TestModelInfoOwner(c *gc.C) {
 	s.setAPIUser(c, names.NewUserTag("bob@local"))
 	info := s.getModelInfo(c)
-	c.Assert(info.Users, gc.HasLen, 3)
+	c.Assert(info.Users, gc.HasLen, 4)
+	c.Assert(info.Machines, gc.HasLen, 2)
+}
+
+func (s *modelInfoSuite) TestModelInfoWriteAccess(c *gc.C) {
+	mary := names.NewUserTag("mary@local")
+	s.authorizer.HasWriteTag = mary
+	s.setAPIUser(c, mary)
+	info := s.getModelInfo(c)
+	c.Assert(info.Users, gc.HasLen, 1)
+	c.Assert(info.Users[0].UserName, gc.Equals, "mary@local")
+	c.Assert(info.Machines, gc.HasLen, 2)
 }
 
 func (s *modelInfoSuite) TestModelInfoNonOwner(c *gc.C) {
@@ -172,6 +216,7 @@ func (s *modelInfoSuite) TestModelInfoNonOwner(c *gc.C) {
 	info := s.getModelInfo(c)
 	c.Assert(info.Users, gc.HasLen, 1)
 	c.Assert(info.Users[0].UserName, gc.Equals, "charlotte@local")
+	c.Assert(info.Machines, gc.HasLen, 0)
 }
 
 func (s *modelInfoSuite) getModelInfo(c *gc.C) params.ModelInfo {
@@ -248,6 +293,7 @@ type mockState struct {
 	controllerModel *mockModel
 	users           []description.UserAccess
 	cred            cloud.Credential
+	machines        []common.Machine
 }
 
 type fakeModelDescription struct {
@@ -354,6 +400,11 @@ func (st *mockState) AllModels() ([]common.Model, error) {
 	return []common.Model{st.model}, st.NextErr()
 }
 
+func (st *mockState) AllMachines() ([]common.Machine, error) {
+	st.MethodCall(st, "AllMachines")
+	return st.machines, st.NextErr()
+}
+
 func (st *mockState) Clouds() (map[names.CloudTag]cloud.Cloud, error) {
 	st.MethodCall(st, "Clouds")
 	return st.clouds, st.NextErr()
@@ -414,6 +465,25 @@ func (st *mockState) DumpAll() (map[string]interface{}, error) {
 	return map[string]interface{}{
 		"models": "lots of data",
 	}, st.NextErr()
+}
+
+type mockMachine struct {
+	common.Machine
+	id            string
+	containerType instance.ContainerType
+	hw            *instance.HardwareCharacteristics
+}
+
+func (m *mockMachine) Id() string {
+	return m.id
+}
+
+func (m *mockMachine) ContainerType() instance.ContainerType {
+	return m.containerType
+}
+
+func (m *mockMachine) HardwareCharacteristics() (*instance.HardwareCharacteristics, error) {
+	return m.hw, nil
 }
 
 type mockModel struct {

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -648,10 +648,14 @@ func fillMachineHardwareInfo(info *params.ModelInfo, st common.ModelManagerBacke
 	if err != nil {
 		return errors.Trace(err)
 	}
-	info.Machines = make([]params.ModelMachineInfo, len(machines))
-	for i, m := range machines {
-		info.Machines[i].Id = m.Id()
+	info.Machines = make([]params.ModelMachineInfo, 0, len(machines))
+	for _, m := range machines {
+		if m.Life() != state.Alive {
+			continue
+		}
+		mInfo := params.ModelMachineInfo{Id: m.Id()}
 		if m.ContainerType() != "" && m.ContainerType() != instance.NONE {
+			info.Machines = append(info.Machines, mInfo)
 			continue
 		}
 		// Only include cores for physical machines.
@@ -660,14 +664,15 @@ func fillMachineHardwareInfo(info *params.ModelInfo, st common.ModelManagerBacke
 			return errors.Trace(err)
 		}
 		if hw != nil && hw.CpuCores != nil {
-			info.Machines[i].Cores = hw.CpuCores
-			info.Machines[i].Arch = hw.Arch
-			info.Machines[i].Mem = hw.Mem
-			info.Machines[i].RootDisk = hw.RootDisk
-			info.Machines[i].CpuPower = hw.CpuPower
-			info.Machines[i].Tags = hw.Tags
-			info.Machines[i].AvailabilityZone = hw.AvailabilityZone
+			mInfo.Cores = hw.CpuCores
+			mInfo.Arch = hw.Arch
+			mInfo.Mem = hw.Mem
+			mInfo.RootDisk = hw.RootDisk
+			mInfo.CpuPower = hw.CpuPower
+			mInfo.Tags = hw.Tags
+			mInfo.AvailabilityZone = hw.AvailabilityZone
 		}
+		info.Machines = append(info.Machines, mInfo)
 	}
 	return nil
 }

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -635,7 +635,7 @@ func (m *ModelManagerAPI) getModelInfo(tag names.ModelTag) (params.ModelInfo, er
 		}
 	}
 	if canSeeMachines {
-		if info.Machines, err = common.MachineHardwareInfo(st); err != nil {
+		if info.Machines, err = common.ModelMachineInfo(st); err != nil {
 			return params.ModelInfo{}, err
 		}
 	}

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -164,6 +164,7 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 		"ControllerConfig",
 		"LastModelConnection",
 		"LastModelConnection",
+		"AllMachines",
 		"Close",
 		"Close",
 	)
@@ -635,10 +636,10 @@ func (s *modelManagerStateSuite) TestListModelsForSelfLocalUser(c *gc.C) {
 	c.Assert(result.UserModels, gc.HasLen, 0)
 }
 
-func (s *modelManagerStateSuite) checkModelMatches(c *gc.C, env params.Model, expected *state.Model) {
-	c.Check(env.Name, gc.Equals, expected.Name())
-	c.Check(env.UUID, gc.Equals, expected.UUID())
-	c.Check(env.OwnerTag, gc.Equals, expected.Owner().String())
+func (s *modelManagerStateSuite) checkModelMatches(c *gc.C, model params.Model, expected *state.Model) {
+	c.Check(model.Name, gc.Equals, expected.Name())
+	c.Check(model.UUID, gc.Equals, expected.UUID())
+	c.Check(model.OwnerTag, gc.Equals, expected.Owner().String())
 }
 
 func (s *modelManagerStateSuite) TestListModelsAdminSelf(c *gc.C) {

--- a/apiserver/params/controller.go
+++ b/apiserver/params/controller.go
@@ -35,11 +35,12 @@ type RemoveBlocksArgs struct {
 
 // ModelStatus holds information about the status of a juju model.
 type ModelStatus struct {
-	ModelTag           string `json:"model-tag"`
-	Life               Life   `json:"life"`
-	HostedMachineCount int    `json:"hosted-machine-count"`
-	ApplicationCount   int    `json:"application-count"`
-	OwnerTag           string `json:"owner-tag"`
+	ModelTag           string             `json:"model-tag"`
+	Life               Life               `json:"life"`
+	HostedMachineCount int                `json:"hosted-machine-count"`
+	ApplicationCount   int                `json:"application-count"`
+	OwnerTag           string             `json:"owner-tag"`
+	Machines           []ModelMachineInfo `json:"machines,omitempty"`
 }
 
 // ModelStatusResults holds status information about a group of models.

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -150,7 +150,12 @@ type ModelInfoListResults struct {
 
 // ModelMachineInfo holds information about a machine in a model.
 type ModelMachineInfo struct {
-	Id               string    `json:"id"`
+	Id       string           `json:"id"`
+	Hardware *MachineHardware `json:"hardware,omitempty"`
+}
+
+// MachineHardware holds information about a machine's hardware characteristics.
+type MachineHardware struct {
 	Arch             *string   `json:"arch,omitempty"`
 	Mem              *uint64   `json:"mem,omitempty"`
 	RootDisk         *uint64   `json:"root-disk,omitempty"`

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -112,6 +112,11 @@ type ModelInfo struct {
 	// to the model. Owners and administrators can see all users
 	// that have access; other users can only see their own details.
 	Users []ModelUserInfo `json:"users"`
+
+	// Machines contains information about the machines in the model.
+	// This information is available to owners and users with write
+	// access or greater.
+	Machines []ModelMachineInfo `json:"machines"`
 }
 
 // ModelInfoResult holds the result of a ModelInfo call.
@@ -141,6 +146,18 @@ type ModelInfoListResult struct {
 // multiple lists of ModelInfo structures.
 type ModelInfoListResults struct {
 	Results []ModelInfoListResult `json:"results"`
+}
+
+// ModelMachineInfo holds information about a machine in a model.
+type ModelMachineInfo struct {
+	Id               string    `json:"id"`
+	Arch             *string   `json:"arch,omitempty"`
+	Mem              *uint64   `json:"mem,omitempty"`
+	RootDisk         *uint64   `json:"root-disk,omitempty"`
+	Cores            *uint64   `json:"cores,omitempty"`
+	CpuPower         *uint64   `json:"cpu-power,omitempty"`
+	Tags             *[]string `json:"tags,omitempty"`
+	AvailabilityZone *string   `json:"availability-zone,omitempty"`
 }
 
 // ModelUserInfo holds information on a user who has access to a

--- a/apiserver/testing/fakeauthorizer.go
+++ b/apiserver/testing/fakeauthorizer.go
@@ -15,6 +15,7 @@ type FakeAuthorizer struct {
 	EnvironManager bool
 	ModelUUID      string
 	AdminTag       names.UserTag
+	HasWriteTag    names.UserTag
 }
 
 func (fa FakeAuthorizer) AuthOwner(tag names.Tag) bool {
@@ -58,6 +59,9 @@ func (fa FakeAuthorizer) HasPermission(operation description.Access, target name
 		}
 		emptyTag := names.UserTag{}
 		if fa.AdminTag != emptyTag && ut == fa.AdminTag {
+			return true, nil
+		}
+		if operation == description.WriteAccess && ut == fa.HasWriteTag {
 			return true, nil
 		}
 		return false, nil

--- a/cmd/juju/common/model.go
+++ b/cmd/juju/common/model.go
@@ -85,8 +85,8 @@ func ModelMachineInfoFromParams(machines []params.ModelMachineInfo) map[string]M
 	output := make(map[string]ModelMachineInfo, len(machines))
 	for _, info := range machines {
 		mInfo := ModelMachineInfo{}
-		if info.Cores != nil {
-			mInfo.Cores = *info.Cores
+		if info.Hardware != nil && info.Hardware.Cores != nil {
+			mInfo.Cores = *info.Hardware.Cores
 		}
 		output[info.Id] = mInfo
 	}

--- a/cmd/juju/common/model.go
+++ b/cmd/juju/common/model.go
@@ -15,17 +15,25 @@ import (
 
 // ModelInfo contains information about a model.
 type ModelInfo struct {
-	Name           string                   `json:"name" yaml:"name"`
-	UUID           string                   `json:"model-uuid" yaml:"model-uuid"`
-	ControllerUUID string                   `json:"controller-uuid" yaml:"controller-uuid"`
-	ControllerName string                   `json:"controller-name" yaml:"controller-name"`
-	Owner          string                   `json:"owner" yaml:"owner"`
-	Cloud          string                   `json:"cloud" yaml:"cloud"`
-	CloudRegion    string                   `json:"region,omitempty" yaml:"region,omitempty"`
-	ProviderType   string                   `json:"type" yaml:"type"`
-	Life           string                   `json:"life" yaml:"life"`
-	Status         ModelStatus              `json:"status" yaml:"status"`
-	Users          map[string]ModelUserInfo `json:"users" yaml:"users"`
+	Name           string                      `json:"name" yaml:"name"`
+	UUID           string                      `json:"model-uuid" yaml:"model-uuid"`
+	ControllerUUID string                      `json:"controller-uuid" yaml:"controller-uuid"`
+	ControllerName string                      `json:"controller-name" yaml:"controller-name"`
+	Owner          string                      `json:"owner" yaml:"owner"`
+	Cloud          string                      `json:"cloud" yaml:"cloud"`
+	CloudRegion    string                      `json:"region,omitempty" yaml:"region,omitempty"`
+	ProviderType   string                      `json:"type" yaml:"type"`
+	Life           string                      `json:"life" yaml:"life"`
+	Status         ModelStatus                 `json:"status" yaml:"status"`
+	Users          map[string]ModelUserInfo    `json:"users" yaml:"users"`
+	Machines       map[string]ModelMachineInfo `json:"machines,omitempty" yaml:"machines,omitempty"`
+}
+
+// ModelMachineInfo contains information about a machine in a model.
+// We currently only care about showing core count, but might
+// in the future care about memory, disks, containers etc.
+type ModelMachineInfo struct {
+	Cores uint64 `json:"cores" yaml:"cores"`
 }
 
 // ModelStatus contains the current status of a model.
@@ -67,10 +75,25 @@ func ModelInfoFromParams(info params.ModelInfo, now time.Time) (ModelInfo, error
 		CloudRegion:    info.CloudRegion,
 		ProviderType:   info.ProviderType,
 		Users:          ModelUserInfoFromParams(info.Users, now),
+		Machines:       ModelMachineInfoFromParams(info.Machines),
 	}, nil
 }
 
-// ModelUserInfoFromParams translates []params.ModelInfo to a map of
+// ModelMachineInfoFromParams translates []params.ModelMachineInfo to a map of
+// machine ids to ModelMachineInfo.
+func ModelMachineInfoFromParams(machines []params.ModelMachineInfo) map[string]ModelMachineInfo {
+	output := make(map[string]ModelMachineInfo, len(machines))
+	for _, info := range machines {
+		mInfo := ModelMachineInfo{}
+		if info.Cores != nil {
+			mInfo.Cores = *info.Cores
+		}
+		output[info.Id] = mInfo
+	}
+	return output
+}
+
+// ModelUserInfoFromParams translates []params.ModelUserInfo to a map of
 // user names to ModelUserInfo.
 func ModelUserInfoFromParams(users []params.ModelUserInfo, now time.Time) map[string]ModelUserInfo {
 	output := make(map[string]ModelUserInfo)

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -24,7 +24,7 @@ func NewListControllersCommandForTest(testStore jujuclient.ClientStore, api api.
 
 // NewShowControllerCommandForTest returns a showControllerCommand with the clientstore provided
 // as specified.
-func NewShowControllerCommandForTest(testStore jujuclient.ClientStore, api controllerAccessAPI) *showControllerCommand {
+func NewShowControllerCommandForTest(testStore jujuclient.ClientStore, api func(string) ControllerAccessAPI) *showControllerCommand {
 	return &showControllerCommand{
 		store: testStore,
 		api:   api,

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -84,7 +84,7 @@ func (f *fakeModelMgrAPIClient) ModelInfo(tags []names.ModelTag) ([]params.Model
 				if f.inclMachines {
 					one := uint64(1)
 					result.Machines = []params.ModelMachineInfo{
-						{Id: "0", Cores: &one}, {Id: "1"},
+						{Id: "0", Hardware: &params.MachineHardware{Cores: &one}}, {Id: "1"},
 					}
 				}
 			case "test-model2":

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/jujuclient"
@@ -20,14 +22,25 @@ import (
 
 type ShowControllerSuite struct {
 	baseControllerSuite
-	api *fakeController
+	fakeController *fakeController
+	api            func(string) controller.ControllerAccessAPI
 }
 
 var _ = gc.Suite(&ShowControllerSuite{})
 
 func (s *ShowControllerSuite) SetUpTest(c *gc.C) {
 	s.baseControllerSuite.SetUpTest(c)
-	s.api = &fakeController{}
+	s.fakeController = &fakeController{
+		modelNames: map[string]string{
+			"abc": "admin",
+			"def": "my-model",
+			"ghi": "admin",
+		},
+	}
+	s.api = func(controllerNamee string) controller.ControllerAccessAPI {
+		s.fakeController.controllerName = controllerNamee
+		return s.fakeController
+	}
 }
 
 func (s *ShowControllerSuite) TestShowOneControllerOneInStore(c *gc.C) {
@@ -39,7 +52,7 @@ func (s *ShowControllerSuite) TestShowOneControllerOneInStore(c *gc.C) {
     cloud: mallards
     agent-version: 999.99.99
 `
-	s.createTestClientStore(c)
+	s.fakeController.store = s.createTestClientStore(c)
 
 	s.expectedOutput = `
 mallards:
@@ -52,8 +65,12 @@ mallards:
   models:
     admin:
       uuid: abc
+      machine-count: 2
+      core-count: 4
     my-model:
       uuid: def
+      machine-count: 2
+      core-count: 4
   current-model: my-model
   account:
     user: admin@local
@@ -72,7 +89,7 @@ func (s *ShowControllerSuite) TestShowControllerWithPasswords(c *gc.C) {
     cloud: mallards
     agent-version: 999.99.99
 `
-	s.createTestClientStore(c)
+	s.fakeController.store = s.createTestClientStore(c)
 
 	s.expectedOutput = `
 mallards:
@@ -85,8 +102,12 @@ mallards:
   models:
     admin:
       uuid: abc
+      machine-count: 2
+      core-count: 4
     my-model:
       uuid: def
+      machine-count: 2
+      core-count: 4
   current-model: my-model
   account:
     user: admin@local
@@ -120,6 +141,7 @@ func (s *ShowControllerSuite) TestShowControllerWithBootstrapConfig(c *gc.C) {
 		CloudRegion:   "mallards1",
 		CloudEndpoint: "http://mallards.local/MAAS",
 	}
+	s.fakeController.store = store
 
 	s.expectedOutput = `
 mallards:
@@ -133,8 +155,12 @@ mallards:
   models:
     admin:
       uuid: abc
+      machine-count: 2
+      core-count: 4
     my-model:
       uuid: def
+      machine-count: 2
+      core-count: 4
   current-model: my-model
   account:
     user: admin@local
@@ -145,7 +171,7 @@ mallards:
 }
 
 func (s *ShowControllerSuite) TestShowOneControllerManyInStore(c *gc.C) {
-	s.createTestClientStore(c)
+	s.fakeController.store = s.createTestClientStore(c)
 
 	s.expectedOutput = `
 aws-test:
@@ -159,6 +185,8 @@ aws-test:
   models:
     admin:
       uuid: ghi
+      machine-count: 2
+      core-count: 4
   current-model: admin
   account:
     user: admin@local
@@ -168,7 +196,7 @@ aws-test:
 }
 
 func (s *ShowControllerSuite) TestShowSomeControllerMoreInStore(c *gc.C) {
-	s.createTestClientStore(c)
+	s.fakeController.store = s.createTestClientStore(c)
 	s.expectedOutput = `
 aws-test:
   details:
@@ -181,6 +209,8 @@ aws-test:
   models:
     admin:
       uuid: ghi
+      machine-count: 2
+      core-count: 4
   current-model: admin
   account:
     user: admin@local
@@ -201,25 +231,25 @@ mark-test-prodstack:
 }
 
 func (s *ShowControllerSuite) TestShowControllerJsonOne(c *gc.C) {
-	s.createTestClientStore(c)
+	s.fakeController.store = s.createTestClientStore(c)
 
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"models":{"admin":{"uuid":"ghi"}},"current-model":"admin","account":{"user":"admin@local","access":"superuser"}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"models":{"admin":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin","account":{"user":"admin@local","access":"superuser"}}}
 `[1:]
 
 	s.assertShowController(c, "--format", "json", "aws-test")
 }
 
 func (s *ShowControllerSuite) TestShowControllerJsonMany(c *gc.C) {
-	s.createTestClientStore(c)
+	s.fakeController.store = s.createTestClientStore(c)
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"models":{"admin":{"uuid":"ghi"}},"current-model":"admin","account":{"user":"admin@local","access":"superuser"}},"mark-test-prodstack":{"details":{"uuid":"this-is-a-uuid","api-endpoints":["this-is-one-of-many-api-endpoints"],"ca-cert":"this-is-a-ca-cert","cloud":"prodstack","agent-version":"999.99.99"},"account":{"user":"admin@local","access":"superuser"}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"models":{"admin":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin","account":{"user":"admin@local","access":"superuser"}},"mark-test-prodstack":{"details":{"uuid":"this-is-a-uuid","api-endpoints":["this-is-one-of-many-api-endpoints"],"ca-cert":"this-is-a-ca-cert","cloud":"prodstack","agent-version":"999.99.99"},"account":{"user":"admin@local","access":"superuser"}}}
 `[1:]
 	s.assertShowController(c, "--format", "json", "aws-test", "mark-test-prodstack")
 }
 
 func (s *ShowControllerSuite) TestShowControllerReadFromStoreErr(c *gc.C) {
-	s.createTestClientStore(c)
+	s.fakeController.store = s.createTestClientStore(c)
 
 	msg := "fail getting controller"
 	errStore := jujuclienttesting.NewStubStore()
@@ -233,9 +263,10 @@ func (s *ShowControllerSuite) TestShowControllerReadFromStoreErr(c *gc.C) {
 
 func (s *ShowControllerSuite) TestShowControllerNoArgs(c *gc.C) {
 	store := s.createTestClientStore(c)
+	s.fakeController.store = store
 
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"models":{"admin":{"uuid":"ghi"}},"current-model":"admin","account":{"user":"admin@local","access":"superuser"}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"models":{"admin":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin","account":{"user":"admin@local","access":"superuser"}}}
 `[1:]
 	store.CurrentControllerName = "aws-test"
 	s.assertShowController(c, "--format", "json")
@@ -280,7 +311,11 @@ func (s *ShowControllerSuite) assertShowController(c *gc.C, args ...string) {
 	c.Assert(testing.Stdout(context), gc.Equals, s.expectedOutput)
 }
 
-type fakeController struct{}
+type fakeController struct {
+	controllerName string
+	store          jujuclient.ClientStore
+	modelNames     map[string]string
+}
 
 func (*fakeController) GetControllerAccess(user string) (description.Access, error) {
 	return "superuser", nil
@@ -288,6 +323,34 @@ func (*fakeController) GetControllerAccess(user string) (description.Access, err
 
 func (*fakeController) ModelConfig() (map[string]interface{}, error) {
 	return map[string]interface{}{"agent-version": "999.99.99"}, nil
+}
+
+func (c *fakeController) ModelStatus(models ...names.ModelTag) (result []base.ModelStatus, _ error) {
+	for _, mtag := range models {
+		result = append(result, base.ModelStatus{
+			UUID:              mtag.Id(),
+			TotalMachineCount: 2,
+			CoreCount:         4,
+		})
+	}
+	return result, nil
+}
+
+func (c *fakeController) AllModels() (result []base.UserModel, _ error) {
+	all, err := c.store.AllModels(c.controllerName)
+	if errors.IsNotFound(err) {
+		return result, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	for _, m := range all {
+		result = append(result, base.UserModel{
+			UUID: m.ModelUUID,
+			Name: c.modelNames[m.ModelUUID],
+		})
+	}
+	return result, nil
 }
 
 func (*fakeController) Close() error {

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/commands"
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient"
@@ -105,6 +106,9 @@ func (s *cmdControllerSuite) TestAddModelNormalUser(c *gc.C) {
 }
 
 func (s *cmdControllerSuite) TestListModelsYAML(c *gc.C) {
+	s.Factory.MakeMachine(c, nil)
+	two := uint64(2)
+	s.Factory.MakeMachine(c, &factory.MachineParams{Characteristics: &instance.HardwareCharacteristics{CpuCores: &two}})
 	context := s.run(c, "list-models", "--format=yaml")
 	c.Assert(testing.Stdout(context), gc.Matches, `
 models:
@@ -125,6 +129,11 @@ models:
       display-name: admin
       access: admin
       last-connection: just now
+  machines:
+    "0":
+      cores: 0
+    "1":
+      cores: 2
 current-model: controller
 `[1:])
 }


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju/+bug/1602032

When listing models, the number of machines and cores is shown. Only model owners and admins, as well as those with write access to the model can see this information.

(Review request: http://reviews.vapour.ws/r/5594/)