### PR TITLE
Migration prechecks at migration creation time

### DIFF
--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -1,0 +1,130 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller_test
+
+import (
+	"errors"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	apitesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/controller"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	jujutesting "github.com/juju/testing"
+	"github.com/juju/utils"
+)
+
+type Suite struct {
+	jujutesting.IsolationSuite
+}
+
+var _ = gc.Suite(&Suite{})
+
+func (s *Suite) TestInitiateMigration(c *gc.C) {
+	client, stub := makeClient(params.InitiateMigrationResults{
+		Results: []params.InitiateMigrationResult{{
+			MigrationId: "id",
+		}},
+	})
+	spec := makeSpec()
+	id, err := client.InitiateMigration(spec)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(id, gc.Equals, "id")
+	stub.CheckCalls(c, []jujutesting.StubCall{{
+		"Controller.InitiateMigration",
+		[]interface{}{
+			params.InitiateMigrationArgs{
+				Specs: []params.MigrationSpec{{
+					ModelTag: names.NewModelTag(spec.ModelUUID).String(),
+					TargetInfo: params.MigrationTargetInfo{
+						ControllerTag: names.NewModelTag(spec.TargetControllerUUID).String(),
+						Addrs:         spec.TargetAddrs,
+						CACert:        spec.TargetCACert,
+						AuthTag:       names.NewUserTag(spec.TargetUser).String(),
+						Password:      spec.TargetPassword,
+						Macaroon:      spec.TargetMacaroon,
+					},
+				}},
+			},
+		},
+	}})
+}
+
+func (s *Suite) TestInitiateMigrationError(c *gc.C) {
+	client, _ := makeClient(params.InitiateMigrationResults{
+		Results: []params.InitiateMigrationResult{{
+			Error: common.ServerError(errors.New("boom")),
+		}},
+	})
+	id, err := client.InitiateMigration(makeSpec())
+	c.Check(id, gc.Equals, "")
+	c.Check(err, gc.ErrorMatches, "boom")
+}
+
+func (s *Suite) TestInitiateMigrationResultMismatch(c *gc.C) {
+	client, _ := makeClient(params.InitiateMigrationResults{
+		Results: []params.InitiateMigrationResult{
+			{MigrationId: "id"},
+			{MigrationId: "wtf"},
+		},
+	})
+	id, err := client.InitiateMigration(makeSpec())
+	c.Check(id, gc.Equals, "")
+	c.Check(err, gc.ErrorMatches, "unexpected number of results returned")
+}
+
+func (s *Suite) TestInitiateMigrationCallError(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(string, int, string, string, interface{}, interface{}) error {
+		return errors.New("boom")
+	})
+	client := controller.NewClient(apiCaller)
+	id, err := client.InitiateMigration(makeSpec())
+	c.Check(id, gc.Equals, "")
+	c.Check(err, gc.ErrorMatches, "boom")
+}
+
+func (s *Suite) TestInitiateMigrationValidationError(c *gc.C) {
+	client, stub := makeClient(params.InitiateMigrationResults{})
+	spec := makeSpec()
+	spec.ModelUUID = "not-a-uuid"
+	id, err := client.InitiateMigration(spec)
+	c.Check(id, gc.Equals, "")
+	c.Check(err, gc.ErrorMatches, "model UUID not valid")
+	c.Check(stub.Calls(), gc.HasLen, 0) // API call shouldn't have happened
+}
+
+func makeClient(results params.InitiateMigrationResults) (
+	*controller.Client, *jujutesting.Stub,
+) {
+	var stub jujutesting.Stub
+	apiCaller := apitesting.APICallerFunc(
+		func(objType string, version int, id, request string, arg, result interface{}) error {
+			stub.AddCall(objType+"."+request, arg)
+			out := result.(*params.InitiateMigrationResults)
+			*out = results
+			return nil
+		},
+	)
+	client := controller.NewClient(apiCaller)
+	return client, &stub
+}
+
+func makeSpec() controller.MigrationSpec {
+	return controller.MigrationSpec{
+		ModelUUID:            randomUUID(),
+		TargetControllerUUID: randomUUID(),
+		TargetAddrs:          []string{"1.2.3.4:5"},
+		TargetCACert:         "cert",
+		TargetUser:           "someone",
+		TargetPassword:       "secret",
+		TargetMacaroon:       "mac",
+	}
+}
+
+func randomUUID() string {
+	return utils.MustNewUUID().String()
+}

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -372,7 +372,7 @@ func (s *controllerSuite) TestInitiateMigration(c *gc.C) {
 	}
 }
 
-func (s *controllerSuite) TestInitiateMigrationValidationError(c *gc.C) {
+func (s *controllerSuite) TestInitiateMigrationSpecError(c *gc.C) {
 	// Create a hosted model to migrate.
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()

--- a/apiserver/controller/export_test.go
+++ b/apiserver/controller/export_test.go
@@ -1,0 +1,19 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller
+
+import (
+	"github.com/juju/juju/core/migration"
+	"github.com/juju/juju/state"
+)
+
+type patcher interface {
+	PatchValue(destination, source interface{})
+}
+
+func SetPrecheckResult(p patcher, err error) {
+	p.PatchValue(&runMigrationPrechecks, func(*state.State, migration.TargetInfo) error {
+		return err
+	})
+}

--- a/core/migration/targetinfo_test.go
+++ b/core/migration/targetinfo_test.go
@@ -87,29 +87,30 @@ func (s *TargetInfoSuite) TestValidation(c *gc.C) {
 		"",
 	}}
 
-	modelTag := names.NewModelTag(utils.MustNewUUID().String())
 	for _, test := range tests {
 		c.Logf("---- %s -----------", test.label)
-
-		mac, err := macaroon.New([]byte("secret"), "id", "location")
-		c.Assert(err, jc.ErrorIsNil)
-
-		info := migration.TargetInfo{
-			ControllerTag: modelTag,
-			Addrs:         []string{"1.2.3.4:5555", "4.3.2.1:6666"},
-			CACert:        "cert",
-			AuthTag:       names.NewUserTag("user"),
-			Password:      "password",
-			Macaroon:      mac,
-		}
+		info := makeValidTargetInfo(c)
 		test.tweakInfo(&info)
-
-		err = info.Validate()
+		err := info.Validate()
 		if test.errorPattern == "" {
 			c.Check(err, jc.ErrorIsNil)
 		} else {
 			c.Check(errors.IsNotValid(err), jc.IsTrue)
 			c.Check(err, gc.ErrorMatches, test.errorPattern)
 		}
+	}
+}
+
+func makeValidTargetInfo(c *gc.C) migration.TargetInfo {
+	modelTag := names.NewModelTag(utils.MustNewUUID().String())
+	mac, err := macaroon.New([]byte("secret"), "id", "location")
+	c.Assert(err, jc.ErrorIsNil)
+	return migration.TargetInfo{
+		ControllerTag: modelTag,
+		Addrs:         []string{"1.2.3.4:5555"},
+		CACert:        "cert",
+		AuthTag:       names.NewUserTag("user"),
+		Password:      "password",
+		Macaroon:      mac,
 	}
 }


### PR DESCRIPTION
The migration prechecks of the model, source controller and target controller are now also run inside the InitiateMigration API handler. This provides the earliest possible feedback to the user that a migration attempt isn't going to work.

(Review request: http://reviews.vapour.ws/r/5595/)