### PR TITLE
network: Added GetBridgePorts() and tests

### DIFF
--- a/network/utils.go
+++ b/network/utils.go
@@ -225,3 +225,32 @@ func ParseInterfaceType(sysPath, interfaceName string) InterfaceType {
 
 	return UnknownInterface
 }
+
+// GetBridgePorts extracts and returns the names of all interfaces configured as
+// ports of the given bridgeName from the Linux kernel userspace SYSFS location
+// "<sysPath/<bridgeName>/brif/*". SysClassNetPath should be passed as sysPath.
+// Returns an empty result if the ports cannot be determined reliably for any
+// reason, or if there are no configured ports for the bridge.
+//
+// Example call: network.GetBridgePorts(network.SysClassNetPath, "br-eth1")
+func GetBridgePorts(sysPath, bridgeName string) []string {
+	portsGlobPath := filepath.Join(sysPath, bridgeName, "brif", "*")
+	// Glob ignores I/O errors and can only return ErrBadPattern, which we treat
+	// as no results, but for debugging we're still logging the error.
+	paths, err := filepath.Glob(portsGlobPath)
+	if err != nil {
+		logger.Debugf("ignoring error traversing path %q: %v", portsGlobPath, err)
+	}
+
+	if len(paths) == 0 {
+		return nil
+	}
+
+	// We need to convert full paths like /sys/class/net/br-eth0/brif/eth0 to
+	// just names.
+	names := make([]string, len(paths))
+	for i := range paths {
+		names[i] = filepath.Base(paths[i])
+	}
+	return names
+}

--- a/network/utils_test.go
+++ b/network/utils_test.go
@@ -189,6 +189,39 @@ func (*UtilsSuite) TestParseInterfaceType(c *gc.C) {
 	c.Check(result, gc.Equals, network.UnknownInterface)
 }
 
+func (*UtilsSuite) TestGetBridgePorts(c *gc.C) {
+	fakeSysPath := filepath.Join(c.MkDir(), network.SysClassNetPath)
+	err := os.MkdirAll(fakeSysPath, 0700)
+	c.Check(err, jc.ErrorIsNil)
+
+	writeFakePorts := func(bridgeName string, portNames ...string) {
+		fakePortsPath := filepath.Join(fakeSysPath, bridgeName, "brif")
+		err := os.MkdirAll(fakePortsPath, 0700)
+		c.Check(err, jc.ErrorIsNil)
+
+		for _, portName := range portNames {
+			portPath := filepath.Join(fakePortsPath, portName)
+			err = ioutil.WriteFile(portPath, []byte(""), 0644)
+			c.Check(err, jc.ErrorIsNil)
+		}
+	}
+
+	result := network.GetBridgePorts(fakeSysPath, "missing")
+	c.Check(result, gc.IsNil)
+
+	writeFakePorts("br-eth0")
+	result = network.GetBridgePorts(fakeSysPath, "br-eth0")
+	c.Check(result, gc.IsNil)
+
+	writeFakePorts("br-eth0", "eth0")
+	result = network.GetBridgePorts(fakeSysPath, "br-eth0")
+	c.Check(result, jc.DeepEquals, []string{"eth0"})
+
+	writeFakePorts("br-ovs", "eth0", "eth1", "eth2")
+	result = network.GetBridgePorts(fakeSysPath, "br-ovs")
+	c.Check(result, jc.DeepEquals, []string{"eth0", "eth1", "eth2"})
+}
+
 type mockListener struct {
 	net.Listener
 }


### PR DESCRIPTION
Using Linux SYSFS userspace location /sys/class/net/<bridge>/brif/*, we
can reliably determine the names of the interfaces configured as ports
of a given bridge interface.

If we can't reliably determine the ports, like when running on an OS
other than Linux, or there are no ports configured, GetBridgePorts()
returns empty results.

This is another prerequisite to fix http://pad.lv/1566791.

(Review request: http://reviews.vapour.ws/r/5597/)