### PR TITLE
Refactor, simplify, and improve tests coverage of GetObservedNetworkConfig()

### DIFF
--- a/apiserver/common/networkingcommon/export_test.go
+++ b/apiserver/common/networkingcommon/export_test.go
@@ -1,9 +1,0 @@
-// Copyright 2016 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
-
-package networkingcommon
-
-var (
-	NetInterfaces  = &netInterfaces
-	InterfaceAddrs = &interfaceAddrs
-)

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -780,7 +780,8 @@ func (s *linkLayerDevicesStateSuite) addContainerMachine(c *gc.C) {
 }
 
 func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesAllowsParentBridgeDeviceForContainerDevice(c *gc.C) {
-	// Add default bridges per container type to ensure they will be ignored.
+	// Add default bridges per container type to ensure they will not be skipped
+	// when deciding which host bridges to use for the container NICs.
 	s.addParentBridgeDeviceWithContainerDevicesAsChildren(c, container.DefaultLxdBridge, "vethX", 1)
 	s.addParentBridgeDeviceWithContainerDevicesAsChildren(c, container.DefaultKvmBridge, "vethY", 1)
 	parentDevice, _ := s.addParentBridgeDeviceWithContainerDevicesAsChildren(c, "br-eth1.250", "eth", 1)

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -12,6 +12,7 @@ import (
 	jujutxn "github.com/juju/txn"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/container"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -779,6 +780,9 @@ func (s *linkLayerDevicesStateSuite) addContainerMachine(c *gc.C) {
 }
 
 func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesAllowsParentBridgeDeviceForContainerDevice(c *gc.C) {
+	// Add default bridges per container type to ensure they will be ignored.
+	s.addParentBridgeDeviceWithContainerDevicesAsChildren(c, container.DefaultLxdBridge, "vethX", 1)
+	s.addParentBridgeDeviceWithContainerDevicesAsChildren(c, container.DefaultKvmBridge, "vethY", 1)
 	parentDevice, _ := s.addParentBridgeDeviceWithContainerDevicesAsChildren(c, "br-eth1.250", "eth", 1)
 	childDevice, err := s.containerMachine.LinkLayerDevice("eth0")
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -924,8 +924,10 @@ func (m *Machine) SetContainerLinkLayerDevices(containerMachine *Machine) error 
 
 	for _, hostDevice := range allDevices {
 		deviceType, name := hostDevice.Type(), hostDevice.Name()
-		// Only use bridges, but not the default bridges per container type,
-		// which should only be used for fallback config.
+		// Since the default bridges (for each container type) are
+		// machine-local, and there's neither a way (at least not yet) nor any
+		// point in allocating addresses from the (machine-local) subnets
+		// configured on those bridges, we need to ignore them below.
 		if deviceType == BridgeDevice {
 			switch name {
 			case container.DefaultLxdBridge, container.DefaultKvmBridge:

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -157,7 +157,7 @@ func (mr *Machiner) Handle(_ <-chan struct{}) error {
 
 	life := mr.machine.Life()
 	if life == params.Alive {
-		observedConfig, err := getObservedNetworkConfig()
+		observedConfig, err := getObservedNetworkConfig(networkingcommon.DefaultNetworkConfigSource())
 		if err != nil {
 			return errors.Annotate(err, "cannot discover observed network config")
 		} else if len(observedConfig) == 0 {

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/juju/juju/api"
 	apimachiner "github.com/juju/juju/api/machiner"
+	"github.com/juju/juju/apiserver/common/networkingcommon"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
@@ -54,7 +55,7 @@ func (s *MachinerSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(machiner.InterfaceAddrs, func() ([]net.Addr, error) {
 		return s.addresses, nil
 	})
-	s.PatchValue(machiner.GetObservedNetworkConfig, func() ([]params.NetworkConfig, error) {
+	s.PatchValue(machiner.GetObservedNetworkConfig, func(_ networkingcommon.NetworkConfigSource) ([]params.NetworkConfig, error) {
 		return nil, nil
 	})
 }
@@ -291,7 +292,7 @@ func (s *MachinerStateSuite) SetUpTest(c *gc.C) {
 		return nil, nil
 	})
 	s.PatchValue(&network.LXCNetDefaultConfig, "")
-	s.PatchValue(machiner.GetObservedNetworkConfig, func() ([]params.NetworkConfig, error) {
+	s.PatchValue(machiner.GetObservedNetworkConfig, func(_ networkingcommon.NetworkConfigSource) ([]params.NetworkConfig, error) {
 		return nil, nil
 	})
 }


### PR DESCRIPTION
Using the new network.ParseInterfaceType() allows us to determine which
of the observed interfaces are bridges, simplifying the later step which
merges observed and provider network configs. Also, for bridges specifically,
using network.GetBridgePorts() we populate ParentInterfaceName on each
port interface to the parent bridge. There will be a follow-up that refactors and
further simplifies that merging.

Prerequisite to fixing http://pad.lv/1566791.

Live tested on MAAS 1.9.4 and 2.0.0 to ensure no regressions:
1. juju boostrap
2. juju switch controller
3. juju add-machine lxd:0
4. Expect no change in behavior with and without the fix
(e.g. if 0/lxd/0 came up allocated with multiple NICs without the fix,
expect the same, if it came up with fallback single-NIC eth0->lxdbr0,
expect the same).

(Review request: http://reviews.vapour.ws/r/5598/)