### PR TITLE
migration: Check for active migration in target

### DIFF
--- a/migration/precheck_shim.go
+++ b/migration/precheck_shim.go
@@ -43,6 +43,11 @@ func (s *precheckShim) AllModels() ([]PrecheckModel, error) {
 	return out, nil
 }
 
+// IsMigrationActive implements PrecheckBackend.
+func (s *precheckShim) IsMigrationActive(modelUUID string) (bool, error) {
+	return state.IsMigrationActive(s.State, modelUUID)
+}
+
 // AgentVersion implements PrecheckBackend.
 func (s *precheckShim) AgentVersion() (version.Number, error) {
 	cfg, err := s.State.ModelConfig()

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -753,12 +753,19 @@ func (st *State) migrationFromQuery(query mongo.Query) (ModelMigration, error) {
 	}, nil
 }
 
-// IsMigrationActive return true if a migration is in progress for
+// IsMigrationActive returns true if a migration is in progress for
 // the model associated with the State.
 func (st *State) IsMigrationActive() (bool, error) {
+	return IsMigrationActive(st, st.ModelUUID())
+}
+
+// IsMigrationActive returns true if a migration is in progress for
+// the model with the given UUID. The State provided need not be for
+// the model in question.
+func IsMigrationActive(st *State, modelUUID string) (bool, error) {
 	active, closer := st.getCollection(migrationsActiveC)
 	defer closer()
-	n, err := active.FindId(st.ModelUUID()).Count()
+	n, err := active.FindId(modelUUID).Count()
 	if err != nil {
 		return false, errors.Trace(err)
 	}

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -91,6 +91,25 @@ func (s *MigrationSuite) TestCreate(c *gc.C) {
 	c.Check(model.MigrationMode(), gc.Equals, state.MigrationModeExporting)
 }
 
+func (s *MigrationSuite) TestIsMigrationActive(c *gc.C) {
+	check := func(expected bool) {
+		isActive, err := s.State2.IsMigrationActive()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(isActive, gc.Equals, expected)
+
+		isActive2, err := state.IsMigrationActive(s.State, s.State2.ModelUUID())
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(isActive2, gc.Equals, expected)
+	}
+
+	check(false)
+
+	_, err := s.State2.CreateMigration(s.stdSpec)
+	c.Assert(err, jc.ErrorIsNil)
+
+	check(true)
+}
+
 func (s *MigrationSuite) TestIdSequencesAreIndependent(c *gc.C) {
 	st2 := s.State2
 	st3 := s.Factory.MakeModel(c, nil)


### PR DESCRIPTION
This check is necessary because there is a window between the REAP phase and then end of the DONE phase where a model's documents have been deleted but the migration isn't quite done yet. Migrating a model back into the controller during this window can cause the migrationmaster worker to be stopped and other workers to be incorrectly restarted.

This fixes https://lpad.tv/1611391

(Review request: http://reviews.vapour.ws/r/5599/)