### PR TITLE
Ensure the added metrics have different created times.

### DIFF
--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -714,7 +714,7 @@ func (s *MetricLocalCharmSuite) TestModelMetricBatches(c *gc.C) {
 	_, err = s.State.AddMetrics(
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
-			Created:  now,
+			Created:  now.Add(time.Second),
 			CharmURL: s.meteredCharm.URL().String(),
 			Metrics:  []state.Metric{m2},
 			Unit:     newUnit.UnitTag(),


### PR DESCRIPTION
The test was failing when the machine was under load. I guess sometimes the results came back in different orders.

(Review request: http://reviews.vapour.ws/r/5601/)