### PR TITLE
Add support for a flag for external migration control

### DIFF
--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -204,6 +204,7 @@ func (c *Client) GetControllerAccess(user string) (description.Access, error) {
 // a single model.
 type MigrationSpec struct {
 	ModelUUID            string
+	ExternalControl      bool
 	TargetControllerUUID string
 	TargetAddrs          []string
 	TargetCACert         string
@@ -257,6 +258,7 @@ func (c *Client) InitiateMigration(spec MigrationSpec) (string, error) {
 				Password:      spec.TargetPassword,
 				Macaroon:      spec.TargetMacaroon,
 			},
+			ExternalControl: spec.ExternalControl,
 		}},
 	}
 	response := params.InitiateMigrationResults{}

--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -34,24 +34,41 @@ func (s *Suite) TestInitiateMigration(c *gc.C) {
 	id, err := client.InitiateMigration(spec)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(id, gc.Equals, "id")
-	stub.CheckCalls(c, []jujutesting.StubCall{{
-		"Controller.InitiateMigration",
-		[]interface{}{
-			params.InitiateMigrationArgs{
-				Specs: []params.MigrationSpec{{
-					ModelTag: names.NewModelTag(spec.ModelUUID).String(),
-					TargetInfo: params.MigrationTargetInfo{
-						ControllerTag: names.NewModelTag(spec.TargetControllerUUID).String(),
-						Addrs:         spec.TargetAddrs,
-						CACert:        spec.TargetCACert,
-						AuthTag:       names.NewUserTag(spec.TargetUser).String(),
-						Password:      spec.TargetPassword,
-						Macaroon:      spec.TargetMacaroon,
-					},
-				}},
+	stub.CheckCalls(c, []jujutesting.StubCall{
+		{"Controller.InitiateMigration", []interface{}{specToArgs(spec)}},
+	})
+}
+
+func (s *Suite) TestInitiateMigrationExternalControl(c *gc.C) {
+	client, stub := makeClient(params.InitiateMigrationResults{
+		Results: []params.InitiateMigrationResult{{
+			MigrationId: "id",
+		}},
+	})
+	spec := makeSpec()
+	spec.ExternalControl = true
+	_, err := client.InitiateMigration(spec)
+	c.Assert(err, jc.ErrorIsNil)
+	stub.CheckCalls(c, []jujutesting.StubCall{
+		{"Controller.InitiateMigration", []interface{}{specToArgs(spec)}},
+	})
+}
+
+func specToArgs(spec controller.MigrationSpec) params.InitiateMigrationArgs {
+	return params.InitiateMigrationArgs{
+		Specs: []params.MigrationSpec{{
+			ModelTag: names.NewModelTag(spec.ModelUUID).String(),
+			TargetInfo: params.MigrationTargetInfo{
+				ControllerTag: names.NewModelTag(spec.TargetControllerUUID).String(),
+				Addrs:         spec.TargetAddrs,
+				CACert:        spec.TargetCACert,
+				AuthTag:       names.NewUserTag(spec.TargetUser).String(),
+				Password:      spec.TargetPassword,
+				Macaroon:      spec.TargetMacaroon,
 			},
-		},
-	}})
+			ExternalControl: spec.ExternalControl,
+		}},
+	}
 }
 
 func (s *Suite) TestInitiateMigrationError(c *gc.C) {

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -430,8 +430,9 @@ func (c *ControllerAPI) initiateOneMigration(spec params.MigrationSpec) (string,
 
 	// Trigger the migration.
 	mig, err := hostedState.CreateMigration(state.MigrationSpec{
-		InitiatedBy: c.apiUser,
-		TargetInfo:  targetInfo,
+		InitiatedBy:     c.apiUser,
+		TargetInfo:      targetInfo,
+		ExternalControl: spec.ExternalControl,
 	})
 	if err != nil {
 		return "", errors.Trace(err)

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -333,6 +333,7 @@ func (s *controllerSuite) TestInitiateMigration(c *gc.C) {
 					AuthTag:       names.NewUserTag("admin2").String(),
 					Macaroon:      string(macJSON),
 				},
+				ExternalControl: true,
 			},
 		},
 	}
@@ -356,6 +357,7 @@ func (s *controllerSuite) TestInitiateMigration(c *gc.C) {
 		c.Check(mig.Id(), gc.Equals, expectedId)
 		c.Check(mig.ModelUUID(), gc.Equals, st.ModelUUID())
 		c.Check(mig.InitiatedBy(), gc.Equals, s.AdminUserTag(c).Id())
+		c.Check(mig.ExternalControl(), gc.Equals, args.Specs[i].ExternalControl)
 
 		targetInfo, err := mig.TargetInfo()
 		c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -18,8 +18,9 @@ type InitiateMigrationArgs struct {
 // MigrationSpec holds the details required to start the migration of
 // a single model.
 type MigrationSpec struct {
-	ModelTag   string              `json:"model-tag"`
-	TargetInfo MigrationTargetInfo `json:"target-info"`
+	ModelTag        string              `json:"model-tag"`
+	TargetInfo      MigrationTargetInfo `json:"target-info"`
+	ExternalControl bool                `json:"external-control"`
 }
 
 // MigrationTargetInfo holds the details required to connect to and

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -77,6 +77,7 @@ func (s *MigrationSuite) TestCreate(c *gc.C) {
 	c.Check(mig.EndTime().IsZero(), jc.IsTrue)
 	c.Check(mig.StatusMessage(), gc.Equals, "starting")
 	c.Check(mig.InitiatedBy(), gc.Equals, "admin")
+	c.Check(mig.ExternalControl(), jc.IsFalse)
 
 	info, err := mig.TargetInfo()
 	c.Assert(err, jc.ErrorIsNil)
@@ -89,6 +90,15 @@ func (s *MigrationSuite) TestCreate(c *gc.C) {
 
 	c.Assert(model.Refresh(), jc.ErrorIsNil)
 	c.Check(model.MigrationMode(), gc.Equals, state.MigrationModeExporting)
+}
+
+func (s *MigrationSuite) TestCreateExternalControl(c *gc.C) {
+	spec := s.stdSpec
+	spec.ExternalControl = true
+	mig, err := s.State2.CreateMigration(spec)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(mig.ModelUUID(), gc.Equals, s.State2.ModelUUID())
+	c.Check(mig.ExternalControl(), jc.IsTrue)
 }
 
 func (s *MigrationSuite) TestIsMigrationActive(c *gc.C) {


### PR DESCRIPTION
This is part of the changes to allow migrations to be controlled by an external process.

(Review request: http://reviews.vapour.ws/r/5602/)