### PR TITLE
Overhaul local login macaroon auth (WIP)

### DIFF
--- a/api/authentication/package_test.go
+++ b/api/authentication/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package authentication_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/api/authentication/visitor.go
+++ b/api/authentication/visitor.go
@@ -1,0 +1,63 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package authentication
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"github.com/juju/errors"
+
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
+)
+
+const authMethod = "juju_userpass"
+
+// Visitor is a httpbakery.Visitor that will login directly
+// to the Juju controller using password authentication. This
+// only applies when logging in as a local user.
+type Visitor struct {
+	username    string
+	getPassword func(string) (string, error)
+}
+
+// NewVisitor returns a new Visitor.
+func NewVisitor(username string, getPassword func(string) (string, error)) *Visitor {
+	return &Visitor{
+		username:    username,
+		getPassword: getPassword,
+	}
+}
+
+func (v *Visitor) VisitWebPage(client *httpbakery.Client, methodURLs map[string]*url.URL) error {
+	methodURL := methodURLs[authMethod]
+	if methodURL == nil {
+		return httpbakery.ErrMethodNotSupported
+	}
+
+	password, err := v.getPassword(v.username)
+	if err != nil {
+		return err
+	}
+
+	// POST to the URL with username and password.
+	resp, err := client.PostForm(methodURL.String(), url.Values{
+		"user":     {v.username},
+		"password": {password},
+	})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+	var jsonError httpbakery.Error
+	if err := json.NewDecoder(resp.Body).Decode(&jsonError); err != nil {
+		return errors.Annotate(err, "unmarshalling error")
+	}
+	return &jsonError
+}

--- a/api/authentication/visitor_test.go
+++ b/api/authentication/visitor_test.go
@@ -1,0 +1,88 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package authentication_test
+
+import (
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+
+	"github.com/juju/juju/api/authentication"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
+)
+
+type VisitorSuite struct {
+	testing.IsolationSuite
+
+	jar     *cookiejar.Jar
+	client  *httpbakery.Client
+	server  *httptest.Server
+	handler http.Handler
+}
+
+var _ = gc.Suite(&VisitorSuite{})
+
+func (s *VisitorSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	var err error
+	s.jar, err = cookiejar.New(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.client = httpbakery.NewClient()
+	s.client.Jar = s.jar
+	s.handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.handler.ServeHTTP(w, r)
+	}))
+	s.AddCleanup(func(c *gc.C) { s.server.Close() })
+}
+
+func (s *VisitorSuite) TestVisitWebPage(c *gc.C) {
+	v := authentication.NewVisitor("bob", func(username string) (string, error) {
+		c.Assert(username, gc.Equals, "bob")
+		return "hunter2", nil
+	})
+	var formUser, formPassword string
+	s.handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		formUser = r.Form.Get("user")
+		formPassword = r.Form.Get("password")
+	})
+	err := v.VisitWebPage(s.client, map[string]*url.URL{
+		"juju_userpass": mustParseURL(s.server.URL),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(formUser, gc.Equals, "bob")
+	c.Assert(formPassword, gc.Equals, "hunter2")
+}
+
+func (s *VisitorSuite) TestVisitWebPageMethodNotSupported(c *gc.C) {
+	v := authentication.NewVisitor("bob", nil)
+	err := v.VisitWebPage(s.client, map[string]*url.URL{})
+	c.Assert(err, gc.Equals, httpbakery.ErrMethodNotSupported)
+}
+
+func (s *VisitorSuite) TestVisitWebPageErrorResult(c *gc.C) {
+	v := authentication.NewVisitor("bob", func(username string) (string, error) {
+		return "hunter2", nil
+	})
+	s.handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"Message":"bleh"}`, http.StatusInternalServerError)
+	})
+	err := v.VisitWebPage(s.client, map[string]*url.URL{
+		"juju_userpass": mustParseURL(s.server.URL),
+	})
+	c.Assert(err, gc.ErrorMatches, "bleh")
+}
+
+func mustParseURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}

--- a/api/interface.go
+++ b/api/interface.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"net/url"
 	"time"
 
 	"github.com/juju/errors"
@@ -196,6 +197,10 @@ type Connection interface {
 
 	// ControllerAccess returns the access level of authorized user to the controller.
 	ControllerAccess() string
+
+	// CookieURL returns the URL that HTTP cookies for the API will be
+	// associated with.
+	CookieURL() *url.URL
 
 	// These methods expose a bunch of worker-specific facades, and basically
 	// just should not exist; but removing them is too noisy for a single CL.

--- a/api/state.go
+++ b/api/state.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"net"
+	"net/url"
 	"strconv"
 
 	"github.com/juju/errors"
@@ -40,7 +41,7 @@ func (st *state) Login(tag names.Tag, password, nonce string, macaroons []macaro
 		Nonce:       nonce,
 		Macaroons:   macaroons,
 	}
-	if tag == nil {
+	if password == "" {
 		// Add any macaroons from the cookie jar that might work for
 		// authenticating the login request.
 		request.Macaroons = append(request.Macaroons,
@@ -81,6 +82,13 @@ func (st *state) Login(tag names.Tag, password, nonce string, macaroons []macaro
 				MacaroonPath: "/",
 			},
 		}); err != nil {
+			cause := errors.Cause(err)
+			if httpbakery.IsInteractionError(cause) {
+				// Just inform the reason of the reason for the
+				// failure, e.g. because the username/password
+				// they presented was invalid.
+				err = cause.(*httpbakery.InteractionError).Reason
+			}
 			return errors.Trace(err)
 		}
 		// Add the macaroons that have been saved by HandleError to our login request.
@@ -186,6 +194,13 @@ func (st *state) ModelAccess() string {
 // ControllerAccess returns the access level of authorized user to the model.
 func (st *state) ControllerAccess() string {
 	return st.controllerAccess
+}
+
+// CookieURL returns the URL that HTTP cookies for the API will be
+// associated with.
+func (st *state) CookieURL() *url.URL {
+	copy := *st.cookieURL
+	return &copy
 }
 
 // slideAddressToFront moves the address at the location (serverIndex, addrIndex) to be

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -98,19 +98,6 @@ func (s *stateSuite) TestTags(c *gc.C) {
 	c.Check(controllerTag, gc.Equals, coretesting.ControllerTag)
 }
 
-func (s *stateSuite) TestLoginMacaroon(c *gc.C) {
-	apistate, tag, _ := s.OpenAPIWithoutLogin(c)
-	defer apistate.Close()
-	// Use a different API connection, because we can't get at UserManager without logging in.
-	loggedInAPI := s.OpenControllerAPI(c)
-	defer loggedInAPI.Close()
-	mac, err := usermanager.NewClient(loggedInAPI).CreateLocalLoginMacaroon(tag.(names.UserTag))
-	c.Assert(err, jc.ErrorIsNil)
-	err = apistate.Login(tag, "", "", []macaroon.Slice{{mac}})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(apistate.AuthTag(), gc.Equals, tag)
-}
-
 func (s *stateSuite) TestLoginSetsModelAccess(c *gc.C) {
 	// The default user has admin access.
 	c.Assert(s.APIState.ModelAccess(), gc.Equals, "admin")
@@ -153,18 +140,6 @@ func (s *stateSuite) TestLoginMacaroonInvalidId(c *gc.C) {
 	mac, err := macaroon.New([]byte("root-key"), "id", "juju")
 	c.Assert(err, jc.ErrorIsNil)
 	err = apistate.Login(tag, "", "", []macaroon.Slice{{mac}})
-	c.Assert(err, gc.ErrorMatches, "invalid entity name or password \\(unauthorized access\\)")
-}
-
-func (s *stateSuite) TestLoginMacaroonInvalidUser(c *gc.C) {
-	apistate, tag, _ := s.OpenAPIWithoutLogin(c)
-	defer apistate.Close()
-	// Use a different API connection, because we can't get at UserManager without logging in.
-	loggedInAPI := s.OpenControllerAPI(c)
-	defer loggedInAPI.Close()
-	mac, err := usermanager.NewClient(loggedInAPI).CreateLocalLoginMacaroon(tag.(names.UserTag))
-	c.Assert(err, jc.ErrorIsNil)
-	err = apistate.Login(names.NewUserTag("bob@local"), "", "", []macaroon.Slice{{mac}})
 	c.Assert(err, gc.ErrorMatches, "invalid entity name or password \\(unauthorized access\\)")
 }
 

--- a/api/usermanager/client.go
+++ b/api/usermanager/client.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/macaroon.v1"
-
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"gopkg.in/juju/names.v2"
@@ -181,23 +179,4 @@ func (c *Client) SetPassword(username, password string) error {
 		return err
 	}
 	return results.OneError()
-}
-
-// CreateLocalLoginMacaroon creates a local login macaroon for the
-// authenticated user.
-func (c *Client) CreateLocalLoginMacaroon(tag names.UserTag) (*macaroon.Macaroon, error) {
-	args := params.Entities{Entities: []params.Entity{{tag.String()}}}
-	var results params.MacaroonResults
-	if err := c.facade.FacadeCall("CreateLocalLoginMacaroon", args, &results); err != nil {
-		return nil, errors.Trace(err)
-	}
-	if n := len(results.Results); n != 1 {
-		logger.Errorf("expected 1 result, got %#v", results)
-		return nil, errors.Errorf("expected 1 result, got %d", n)
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return nil, errors.Trace(result.Error)
-	}
-	return result.Result, nil
 }

--- a/apiserver/authcontext.go
+++ b/apiserver/authcontext.go
@@ -5,6 +5,7 @@ package apiserver
 
 import (
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -12,7 +13,9 @@ import (
 	"github.com/juju/utils/clock"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/apiserver/authentication"
 	"github.com/juju/juju/apiserver/common"
@@ -21,13 +24,31 @@ import (
 	"github.com/juju/juju/state/bakerystorage"
 )
 
+const (
+	localUserIdentityLocationPath = "/auth"
+)
+
 // authContext holds authentication context shared
 // between all API endpoints.
 type authContext struct {
 	st *state.State
 
+	clock     clock.Clock
 	agentAuth authentication.AgentAuthenticator
-	userAuth  authentication.UserAuthenticator
+
+	// localUserBakeryService is the bakery.Service used by the controller
+	// for authenticating local users. In time, we may want to use this for
+	// both local and external users. Note that this service does not
+	// discharge the third-party caveats.
+	localUserBakeryService *expirableStorageBakeryService
+
+	// localUserThirdPartyBakeryService is the bakery.Service used by the
+	// controller for discharging third-party caveats for local users.
+	localUserThirdPartyBakeryService *bakery.Service
+
+	// localUserInteractions maintains a set of in-progress local user
+	// authentication interactions.
+	localUserInteractions *authentication.Interactions
 
 	// macaroonAuthOnce guards the fields below it.
 	macaroonAuthOnce   sync.Once
@@ -37,29 +58,97 @@ type authContext struct {
 
 // newAuthContext creates a new authentication context for st.
 func newAuthContext(st *state.State) (*authContext, error) {
-	ctxt := &authContext{st: st}
+	ctxt := &authContext{
+		st: st,
+		// TODO(fwereade) 2016-07-21 there should be a clock parameter
+		clock: clock.WallClock,
+		localUserInteractions: authentication.NewInteractions(),
+	}
+
+	// Create a bakery service for discharging third-party caveats for
+	// local user authentication. This service does not persist keys;
+	// its macaroons should be very short-lived.
+	localUserThirdPartyBakeryService, _, err := newBakeryService(st, nil, nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	ctxt.localUserThirdPartyBakeryService = localUserThirdPartyBakeryService
+
+	// Create a bakery service for local user authentication. This service
+	// persists keys into MongoDB in a TTL collection.
 	store, err := st.NewBakeryStorage()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	// We use a non-nil, but empty key, because we don't use the
-	// key, and don't want to incur the overhead of generating one
-	// each time we create a service.
-	bakeryService, key, err := newBakeryService(st, store, nil)
+	locator := bakeryServicePublicKeyLocator{ctxt.localUserThirdPartyBakeryService}
+	localUserBakeryService, localUserBakeryServiceKey, err := newBakeryService(
+		st, store, locator,
+	)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	ctxt.userAuth.Service = &expirableStorageBakeryService{bakeryService, key, store, nil}
-	// TODO(fwereade) 2016-07-21 there should be a clock parameter
-	ctxt.userAuth.Clock = clock.WallClock
+	ctxt.localUserBakeryService = &expirableStorageBakeryService{
+		localUserBakeryService, localUserBakeryServiceKey, store, locator,
+	}
 	return ctxt, nil
+}
+
+type bakeryServicePublicKeyLocator struct {
+	service *bakery.Service
+}
+
+// PublicKeyForLocation implements bakery.PublicKeyLocator.
+func (b bakeryServicePublicKeyLocator) PublicKeyForLocation(string) (*bakery.PublicKey, error) {
+	return b.service.PublicKey(), nil
+}
+
+// CreateLocalLoginMacaroon creates a macaroon that may be provided to a user
+// as proof that they have logged in with a valid username and password. This
+// macaroon may then be used to obtain a discharge macaroon so that the user
+// can log in without presenting their password for a set amount of time.
+func (ctxt *authContext) CreateLocalLoginMacaroon(tag names.UserTag) (*macaroon.Macaroon, error) {
+	return authentication.CreateLocalLoginMacaroon(tag, ctxt.localUserThirdPartyBakeryService, ctxt.clock)
+}
+
+// CheckLocalLoginCaveat parses and checks that the given caveat string is
+// valid for a local login request, and returns the tag of the local user
+// that the caveat asserts is logged in. checkers.ErrCaveatNotRecognized will
+// be returned if the caveat is not recognised.
+func (ctxt *authContext) CheckLocalLoginCaveat(caveat string) (names.UserTag, error) {
+	return authentication.CheckLocalLoginCaveat(caveat)
+}
+
+// CheckLocalLoginRequest checks that the given HTTP request contains at least
+// one valid local login macaroon minted using CreateLocalLoginMacaroon. It
+// returns an error with a *bakery.VerificationError cause if the macaroon
+// verification failed. If the macaroon is valid, CheckLocalLoginRequest returns
+// a list of caveats to add to the discharge macaroon.
+func (ctxt *authContext) CheckLocalLoginRequest(req *http.Request, tag names.UserTag) ([]checkers.Caveat, error) {
+	return authentication.CheckLocalLoginRequest(ctxt.localUserThirdPartyBakeryService, req, tag, ctxt.clock)
+}
+
+// authenticator returns an authenticator.EntityAuthenticator for the API
+// connection associated with the specified API server host.
+func (ctxt *authContext) authenticator(serverHost string) authenticator {
+	return authenticator{ctxt: ctxt, serverHost: serverHost}
+}
+
+// authenticator implements authenticator.EntityAuthenticator, delegating
+// to the appropriate authenticator based on the tag kind.
+type authenticator struct {
+	ctxt       *authContext
+	serverHost string
 }
 
 // Authenticate implements authentication.EntityAuthenticator
 // by choosing the right kind of authentication for the given
 // tag.
-func (ctxt *authContext) Authenticate(entityFinder authentication.EntityFinder, tag names.Tag, req params.LoginRequest) (state.Entity, error) {
-	auth, err := ctxt.authenticatorForTag(tag)
+func (a authenticator) Authenticate(
+	entityFinder authentication.EntityFinder,
+	tag names.Tag,
+	req params.LoginRequest,
+) (state.Entity, error) {
+	auth, err := a.authenticatorForTag(tag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -68,9 +157,9 @@ func (ctxt *authContext) Authenticate(entityFinder authentication.EntityFinder, 
 
 // authenticatorForTag returns the authenticator appropriate
 // to use for a login with the given possibly-nil tag.
-func (ctxt *authContext) authenticatorForTag(tag names.Tag) (authentication.EntityAuthenticator, error) {
+func (a authenticator) authenticatorForTag(tag names.Tag) (authentication.EntityAuthenticator, error) {
 	if tag == nil {
-		auth, err := ctxt.macaroonAuth()
+		auth, err := a.ctxt.externalMacaroonAuth()
 		if errors.Cause(err) == errMacaroonAuthNotConfigured {
 			// Make a friendlier error message.
 			err = errors.New("no credentials provided")
@@ -82,17 +171,32 @@ func (ctxt *authContext) authenticatorForTag(tag names.Tag) (authentication.Enti
 	}
 	switch tag.Kind() {
 	case names.UnitTagKind, names.MachineTagKind:
-		return &ctxt.agentAuth, nil
+		return &a.ctxt.agentAuth, nil
 	case names.UserTagKind:
-		return &ctxt.userAuth, nil
+		return a.localUserAuth(), nil
 	default:
 		return nil, errors.Annotatef(common.ErrBadRequest, "unexpected login entity tag")
 	}
 }
 
-// macaroonAuth returns an authenticator that can authenticate macaroon-based
-// logins. If it fails once, it will always fail.
-func (ctxt *authContext) macaroonAuth() (authentication.EntityAuthenticator, error) {
+// localUserAuth returns an authenticator that can authenticate logins for
+// local users with either passwords or macaroons.
+func (a authenticator) localUserAuth() authentication.EntityAuthenticator {
+	localUserIdentityLocation := url.URL{
+		Scheme: "https",
+		Host:   a.serverHost,
+		Path:   localUserIdentityLocationPath,
+	}
+	return &authentication.UserAuthenticator{
+		Service: a.ctxt.localUserBakeryService,
+		Clock:   a.ctxt.clock,
+		LocalUserIdentityLocation: localUserIdentityLocation.String(),
+	}
+}
+
+// externalMacaroonAuth returns an authenticator that can authenticate macaroon-based
+// logins for external users. If it fails once, it will always fail.
+func (ctxt *authContext) externalMacaroonAuth() (authentication.EntityAuthenticator, error) {
 	ctxt.macaroonAuthOnce.Do(func() {
 		ctxt._macaroonAuth, ctxt._macaroonAuthError = newExternalMacaroonAuth(ctxt.st)
 	})
@@ -106,7 +210,7 @@ var errMacaroonAuthNotConfigured = errors.New("macaroon authentication is not co
 
 // newExternalMacaroonAuth returns an authenticator that can authenticate
 // macaroon-based logins for external users. This is just a helper function
-// for authCtxt.macaroonAuth.
+// for authCtxt.externalMacaroonAuth.
 func newExternalMacaroonAuth(st *state.State) (*authentication.ExternalMacaroonAuthenticator, error) {
 	controllerCfg, err := st.ControllerConfig()
 	if err != nil {

--- a/apiserver/authentication/interactions.go
+++ b/apiserver/authentication/interactions.go
@@ -1,0 +1,136 @@
+// Copyright 2016 Canonical Ltd. All rights reserved.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package authentication
+
+import (
+	"crypto/rand"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+)
+
+// ErrWaitCanceled is returned by Interactions.Wait when the cancel
+// channel is signalled.
+var ErrWaitCanceled = errors.New("wait canceled")
+
+// ErrExpired is returned by Interactions.Wait when interactions expire
+// before they are done.
+var ErrExpired = errors.New("interaction timed out")
+
+// Interactions maintains a set of Interactions.
+type Interactions struct {
+	mu    sync.Mutex
+	items map[string]*item
+}
+
+type item struct {
+	c        chan Interaction
+	caveatId string
+	expiry   time.Time
+	done     bool
+}
+
+// Interaction records details of an in-progress interactive
+// macaroon-based login.
+type Interaction struct {
+	CaveatId   string
+	LoginUser  names.UserTag
+	LoginError error
+}
+
+// NewInteractions returns a new Interactions.
+func NewInteractions() *Interactions {
+	return &Interactions{
+		items: make(map[string]*item),
+	}
+}
+
+func newId() (string, error) {
+	var id [12]byte
+	if _, err := rand.Read(id[:]); err != nil {
+		return "", fmt.Errorf("cannot read random id: %v", err)
+	}
+	return fmt.Sprintf("%x", id[:]), nil
+}
+
+// Start records the start of an interactive login, and returns a random ID
+// that uniquely identifies it. A call to Wait with the same ID will return
+// the Interaction once it is done.
+func (m *Interactions) Start(caveatId string, expiry time.Time) (string, error) {
+	id, err := newId()
+	if err != nil {
+		return "", err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.items[id] = &item{
+		c:        make(chan Interaction, 1),
+		caveatId: caveatId,
+		expiry:   expiry,
+	}
+	return id, nil
+}
+
+// Done signals that the user has either logged in, or attempted to and failed.
+func (m *Interactions) Done(id string, loginUser names.UserTag, loginError error) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	item := m.items[id]
+
+	if item == nil {
+		return errors.NotFoundf("interaction %q", id)
+	}
+	if item.done {
+		return errors.Errorf("interaction %q already done", id)
+	}
+	item.done = true
+	item.c <- Interaction{
+		CaveatId:   item.caveatId,
+		LoginUser:  loginUser,
+		LoginError: loginError,
+	}
+	return nil
+}
+
+// Wait waits until the identified interaction is done, and returns the
+// corresponding Interaction. If the cancel channel is signalled before
+// the interaction is done, then ErrWaitCanceled is returned. If the
+// interaction expires before it is done, ErrExpired is returned.
+func (m *Interactions) Wait(id string, cancel <-chan struct{}) (*Interaction, error) {
+	m.mu.Lock()
+	item := m.items[id]
+	m.mu.Unlock()
+	if item == nil {
+		return nil, errors.NotFoundf("interaction %q", id)
+	}
+	select {
+	case <-cancel:
+		return nil, ErrWaitCanceled
+	case interaction, ok := <-item.c:
+		if !ok {
+			return nil, ErrExpired
+		}
+		m.mu.Lock()
+		delete(m.items, id)
+		m.mu.Unlock()
+		return &interaction, nil
+	}
+}
+
+// Expire removes any interactions that were due to expire by the
+// specified time.
+func (m *Interactions) Expire(t time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for id, item := range m.items {
+		if item.done || item.expiry.After(t) {
+			continue
+		}
+		delete(m.items, id)
+		close(item.c)
+	}
+}

--- a/apiserver/authentication/interactions_test.go
+++ b/apiserver/authentication/interactions_test.go
@@ -1,0 +1,164 @@
+// Copyright 2016 Canonical Ltd. All rights reserved.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package authentication_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/authentication"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type InteractionsSuite struct {
+	testing.IsolationSuite
+	interactions *authentication.Interactions
+}
+
+var _ = gc.Suite(&InteractionsSuite{})
+
+func (s *InteractionsSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.interactions = authentication.NewInteractions()
+}
+
+func (s *InteractionsSuite) TestStart(c *gc.C) {
+	waitId, err := s.interactions.Start("caveat-id", time.Time{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(waitId, gc.Not(gc.Equals), "")
+}
+
+func (s *InteractionsSuite) TestDone(c *gc.C) {
+	waitId := s.start(c, "caveat-id")
+	err := s.interactions.Done(waitId, names.NewUserTag("admin@local"), nil)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *InteractionsSuite) TestDoneNotFound(c *gc.C) {
+	err := s.interactions.Done("not-found", names.NewUserTag("admin@local"), nil)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	c.Assert(err, gc.ErrorMatches, `interaction "not-found" not found`)
+}
+
+func (s *InteractionsSuite) TestDoneTwice(c *gc.C) {
+	waitId := s.start(c, "caveat-id")
+	err := s.interactions.Done(waitId, names.NewUserTag("admin@local"), nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.interactions.Done(waitId, names.NewUserTag("admin@local"), nil)
+	c.Assert(err, gc.ErrorMatches, `interaction ".*" already done`)
+}
+
+func (s *InteractionsSuite) TestWait(c *gc.C) {
+	waitId := s.start(c, "caveat-id")
+	loginUser := names.NewUserTag("admin@local")
+	loginError := errors.New("login failed")
+	s.done(c, waitId, loginUser, loginError)
+	interaction, err := s.interactions.Wait(waitId, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(interaction, gc.NotNil)
+	c.Assert(interaction, jc.DeepEquals, &authentication.Interaction{
+		CaveatId:   "caveat-id",
+		LoginUser:  loginUser,
+		LoginError: loginError,
+	})
+}
+
+func (s *InteractionsSuite) TestWaitNotFound(c *gc.C) {
+	interaction, err := s.interactions.Wait("not-found", nil)
+	c.Assert(err, gc.ErrorMatches, `interaction "not-found" not found`)
+	c.Assert(interaction, gc.IsNil)
+}
+
+func (s *InteractionsSuite) TestWaitTwice(c *gc.C) {
+	waitId := s.start(c, "caveat-id")
+	s.done(c, waitId, names.NewUserTag("admin@local"), nil)
+
+	_, err := s.interactions.Wait(waitId, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// The Wait call above should have removed the item.
+	_, err = s.interactions.Wait(waitId, nil)
+	c.Assert(err, gc.ErrorMatches, `interaction ".*" not found`)
+}
+
+func (s *InteractionsSuite) TestWaitCancellation(c *gc.C) {
+	waitId := s.start(c, "caveat-id")
+
+	cancel := make(chan struct{})
+	waitResult := make(chan error)
+	go func() {
+		_, err := s.interactions.Wait(waitId, cancel)
+		waitResult <- err
+	}()
+
+	// Wait should not pass until we've cancelled.
+	select {
+	case err := <-waitResult:
+		c.Fatalf("unexpected result: %v", err)
+	case <-time.After(coretesting.ShortWait):
+	}
+
+	cancel <- struct{}{}
+	select {
+	case err := <-waitResult:
+		c.Assert(err, gc.Equals, authentication.ErrWaitCanceled)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for Wait to return")
+	}
+}
+
+func (s *InteractionsSuite) TestWaitExpired(c *gc.C) {
+	t0 := time.Now()
+	t1 := t0.Add(time.Second)
+	t2 := t1.Add(time.Second)
+
+	waitId, err := s.interactions.Start("caveat-id", t2)
+	c.Assert(err, jc.ErrorIsNil)
+
+	type waitResult struct {
+		interaction *authentication.Interaction
+		err         error
+	}
+	waitResultC := make(chan waitResult)
+	go func() {
+		interaction, err := s.interactions.Wait(waitId, nil)
+		waitResultC <- waitResult{interaction, err}
+	}()
+
+	// This should do nothing, because there's nothing
+	// due to expire until t2.
+	s.interactions.Expire(t1)
+
+	// Wait should not pass until the interaction expires.
+	select {
+	case result := <-waitResultC:
+		c.Fatalf("unexpected result: %v", result)
+	case <-time.After(coretesting.ShortWait):
+	}
+
+	s.interactions.Expire(t2)
+	select {
+	case result := <-waitResultC:
+		c.Assert(result.err, gc.Equals, authentication.ErrExpired)
+		c.Assert(result.interaction, gc.IsNil)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for Wait to return")
+	}
+}
+
+func (s *InteractionsSuite) start(c *gc.C, caveatId string) string {
+	waitId, err := s.interactions.Start(caveatId, time.Time{})
+	c.Assert(err, jc.ErrorIsNil)
+	return waitId
+}
+
+func (s *InteractionsSuite) done(c *gc.C, waitId string, loginUser names.UserTag, loginError error) {
+	err := s.interactions.Done(waitId, loginUser, loginError)
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/apiserver/authentication/user_test.go
+++ b/apiserver/authentication/user_test.go
@@ -139,7 +139,6 @@ func (s *userAuthenticatorSuite) TestInvalidRelationLogin(c *gc.C) {
 		Nonce:       "",
 	})
 	c.Assert(err, gc.ErrorMatches, "invalid request")
-
 }
 
 func (s *userAuthenticatorSuite) TestValidMacaroonUserLogin(c *gc.C) {
@@ -166,57 +165,49 @@ func (s *userAuthenticatorSuite) TestValidMacaroonUserLogin(c *gc.C) {
 	// no check for checker function, can't compare functions
 }
 
-func (s *userAuthenticatorSuite) TestMacaroonUserLoginExpired(c *gc.C) {
-	user := s.Factory.MakeUser(c, &factory.UserParams{
-		Name: "bobbrown",
-	})
-	clock := testing.NewClock(time.Now())
-
-	m := &macaroon.Macaroon{}
-	err := m.AddFirstPartyCaveat(
-		checkers.TimeBeforeCaveat(clock.Now().Add(-time.Second)).Condition,
+func (s *userAuthenticatorSuite) TestCreateLocalLoginMacaroon(c *gc.C) {
+	service := mockBakeryService{}
+	clock := testing.NewClock(time.Time{})
+	_, err := authentication.CreateLocalLoginMacaroon(
+		names.NewUserTag("bobbrown"), &service, clock,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-
-	macaroons := []macaroon.Slice{{m}}
-	service := mockBakeryService{}
-	service.SetErrors(errors.New("auth failed"))
-
-	// User login
-	authenticator := &authentication.UserAuthenticator{
-		Service: &service,
-		Clock:   clock,
-	}
-	_, err = authenticator.Authenticate(s.State, user.Tag(), params.LoginRequest{
-		Credentials: "",
-		Nonce:       "",
-		Macaroons:   macaroons,
+	service.CheckCallNames(c, "NewMacaroon")
+	service.CheckCall(c, 0, "NewMacaroon", "", []byte(nil), []checkers.Caveat{
+		{Condition: "is-authenticated-user bobbrown@local"},
 	})
-	c.Assert(err, gc.Equals, common.ErrLoginExpired)
 }
 
-func (s *userAuthenticatorSuite) TestCreateLocalLoginMacaroon(c *gc.C) {
+func (s *userAuthenticatorSuite) TestAuthenticateLocalLoginMacaroon(c *gc.C) {
 	service := mockBakeryService{}
 	clock := testing.NewClock(time.Time{})
 	authenticator := &authentication.UserAuthenticator{
 		Service: &service,
 		Clock:   clock,
+		LocalUserIdentityLocation: "https://testing.invalid:1234/auth",
 	}
 
-	_, err := authenticator.CreateLocalLoginMacaroon(names.NewUserTag("bobbrown"))
-	c.Assert(err, jc.ErrorIsNil)
+	service.SetErrors(&bakery.VerificationError{})
+	_, err := authenticator.Authenticate(
+		authentication.EntityFinder(nil),
+		names.NewUserTag("bobbrown"),
+		params.LoginRequest{},
+	)
+	c.Assert(err, gc.FitsTypeOf, &common.DischargeRequiredError{})
 
-	service.CheckCallNames(c, "ExpireStorageAt", "NewMacaroon", "AddCaveat")
+	service.CheckCallNames(c, "CheckAny", "ExpireStorageAt", "NewMacaroon")
 	calls := service.Calls()
-	c.Assert(calls[0].Args, jc.DeepEquals, []interface{}{clock.Now().Add(24 * time.Hour)})
-	c.Assert(calls[1].Args, jc.DeepEquals, []interface{}{
-		"", []byte(nil), []checkers.Caveat{
-			checkers.DeclaredCaveat("username", "bobbrown@local"),
-		},
-	})
+	c.Assert(calls[1].Args, jc.DeepEquals, []interface{}{clock.Now().Add(24 * time.Hour)})
 	c.Assert(calls[2].Args, jc.DeepEquals, []interface{}{
-		&macaroon.Macaroon{},
-		checkers.TimeBeforeCaveat(clock.Now().Add(24 * time.Hour)),
+		"", []byte(nil), []checkers.Caveat{
+			checkers.NeedDeclaredCaveat(
+				checkers.Caveat{
+					Location:  "https://testing.invalid:1234/auth",
+					Condition: "is-authenticated-user bobbrown@local",
+				},
+				"username",
+			),
+		},
 	})
 }
 

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -353,6 +353,7 @@ func (s *controllerSuite) TestInitiateMigration(c *gc.C) {
 					CACert:        "cert2",
 					AuthTag:       names.NewUserTag("admin2").String(),
 					Macaroons:     string(macsJSON),
+					Password:      "secret2",
 				},
 				ExternalControl: true,
 			},

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -32,7 +32,7 @@ var (
 )
 
 func ServerMacaroon(srv *Server) (*macaroon.Macaroon, error) {
-	auth, err := srv.authCtxt.macaroonAuth()
+	auth, err := srv.authCtxt.externalMacaroonAuth()
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func ServerMacaroon(srv *Server) (*macaroon.Macaroon, error) {
 }
 
 func ServerBakeryService(srv *Server) (authentication.BakeryService, error) {
-	auth, err := srv.authCtxt.macaroonAuth()
+	auth, err := srv.authCtxt.externalMacaroonAuth()
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func ServerBakeryService(srv *Server) (authentication.BakeryService, error) {
 // ServerAuthenticatorForTag calls the authenticatorForTag method
 // of the server's authContext.
 func ServerAuthenticatorForTag(srv *Server, tag names.Tag) (authentication.EntityAuthenticator, error) {
-	return srv.authCtxt.authenticatorForTag(tag)
+	return srv.authCtxt.authenticator("testing.invalid:1234").authenticatorForTag(tag)
 }
 
 func APIHandlerWithEntity(entity state.Entity) *apiHandler {
@@ -98,7 +98,7 @@ func TestingAPIHandler(c *gc.C, srvSt, st *state.State) (*apiHandler, *common.Re
 		state:    srvSt,
 		tag:      names.NewMachineTag("0"),
 	}
-	h, err := newAPIHandler(srv, st, nil, st.ModelUUID())
+	h, err := newAPIHandler(srv, st, nil, st.ModelUUID(), "testing.invalid:1234")
 	c.Assert(err, jc.ErrorIsNil)
 	return h, h.getResources()
 }

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -62,7 +62,8 @@ func (ctxt *httpContext) stateForRequestAuthenticated(r *http.Request) (*state.S
 	if err != nil {
 		return nil, nil, errors.NewUnauthorized(err, "")
 	}
-	entity, _, err := checkCreds(st, req, true, ctxt.srv.authCtxt)
+	authenticator := ctxt.srv.authCtxt.authenticator(r.Host)
+	entity, _, err := checkCreds(st, req, true, authenticator)
 	if err != nil {
 		if common.IsDischargeRequiredError(err) {
 			return nil, nil, errors.Trace(err)
@@ -71,7 +72,7 @@ func (ctxt *httpContext) stateForRequestAuthenticated(r *http.Request) (*state.S
 		// Handle the special case of a worker on a controller machine
 		// acting on behalf of a hosted model.
 		if isMachineTag(req.AuthTag) {
-			entity, err := checkControllerMachineCreds(ctxt.srv.state, req, ctxt.srv.authCtxt)
+			entity, err := checkControllerMachineCreds(ctxt.srv.state, req, authenticator)
 			if err != nil {
 				return nil, nil, errors.NewUnauthorized(err, "")
 			}

--- a/apiserver/params/registration.go
+++ b/apiserver/params/registration.go
@@ -3,10 +3,6 @@
 
 package params
 
-import (
-	"gopkg.in/macaroon.v1"
-)
-
 // SecretKeyLoginRequest contains the parameters for completing
 // the registration of a user. The request contains the tag of
 // the user, and an encrypted and authenticated payload that
@@ -57,8 +53,4 @@ type SecretKeyLoginResponsePayload struct {
 
 	// ControllerUUID is the UUID of the Juju controller.
 	ControllerUUID string `json:"controller-uuid"`
-
-	// Macaroon is a time-limited macaroon that can be used for
-	// authenticating as the registered user.
-	Macaroon *macaroon.Macaroon `json:"macaroon"`
 }

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -48,22 +48,28 @@ type apiHandler struct {
 	rpcConn   *rpc.Conn
 	resources *common.Resources
 	entity    state.Entity
+
 	// An empty modelUUID means that the user has logged in through the
 	// root of the API server rather than the /model/:model-uuid/api
 	// path, logins processed with v2 or later will only offer the
 	// user manager and model manager api endpoints from here.
 	modelUUID string
+
+	// serverHost is the host:port of the API server that the client
+	// connected to.
+	serverHost string
 }
 
 var _ = (*apiHandler)(nil)
 
 // newAPIHandler returns a new apiHandler.
-func newAPIHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID string) (*apiHandler, error) {
+func newAPIHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID string, serverHost string) (*apiHandler, error) {
 	r := &apiHandler{
-		state:     st,
-		resources: common.NewResources(),
-		rpcConn:   rpcConn,
-		modelUUID: modelUUID,
+		state:      st,
+		resources:  common.NewResources(),
+		rpcConn:    rpcConn,
+		modelUUID:  modelUUID,
+		serverHost: serverHost,
 	}
 	if err := r.resources.RegisterNamed("machineID", common.StringResource(srv.tag.Id())); err != nil {
 		return nil, errors.Trace(err)
@@ -75,7 +81,7 @@ func newAPIHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID st
 		return nil, errors.Trace(err)
 	}
 	if err := r.resources.RegisterNamed("createLocalLoginMacaroon", common.ValueResource{
-		srv.authCtxt.userAuth.CreateLocalLoginMacaroon,
+		srv.authCtxt.CreateLocalLoginMacaroon,
 	}); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/usermanager/usermanager.go
+++ b/apiserver/usermanager/usermanager.go
@@ -6,8 +6,6 @@ package usermanager
 import (
 	"time"
 
-	"gopkg.in/macaroon.v1"
-
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"gopkg.in/juju/names.v2"
@@ -28,12 +26,11 @@ func init() {
 // UserManagerAPI implements the user manager interface and is the concrete
 // implementation of the api end point.
 type UserManagerAPI struct {
-	state                    *state.State
-	authorizer               facade.Authorizer
-	createLocalLoginMacaroon func(names.UserTag) (*macaroon.Macaroon, error)
-	check                    *common.BlockChecker
-	apiUser                  names.UserTag
-	isAdmin                  bool
+	state      *state.State
+	authorizer facade.Authorizer
+	check      *common.BlockChecker
+	apiUser    names.UserTag
+	isAdmin    bool
 }
 
 func NewUserManagerAPI(
@@ -55,22 +52,12 @@ func NewUserManagerAPI(
 		return nil, errors.Trace(err)
 	}
 
-	resource, ok := resources.Get("createLocalLoginMacaroon").(common.ValueResource)
-	if !ok {
-		return nil, errors.NotFoundf("userAuth resource")
-	}
-	createLocalLoginMacaroon, ok := resource.Value.(func(names.UserTag) (*macaroon.Macaroon, error))
-	if !ok {
-		return nil, errors.NotValidf("userAuth resource")
-	}
-
 	return &UserManagerAPI{
-		state:                    st,
-		authorizer:               authorizer,
-		createLocalLoginMacaroon: createLocalLoginMacaroon,
-		check:   common.NewBlockChecker(st),
-		apiUser: apiUser,
-		isAdmin: isAdmin,
+		state:      st,
+		authorizer: authorizer,
+		check:      common.NewBlockChecker(st),
+		apiUser:    apiUser,
+		isAdmin:    isAdmin,
 	}, nil
 }
 
@@ -408,37 +395,4 @@ func (api *UserManagerAPI) setPassword(arg params.EntityPassword) error {
 		return errors.Annotate(err, "failed to set password")
 	}
 	return nil
-}
-
-// CreateLocalLoginMacaroon creates a macaroon for the specified users to use
-// for future logins.
-func (api *UserManagerAPI) CreateLocalLoginMacaroon(args params.Entities) (params.MacaroonResults, error) {
-	results := params.MacaroonResults{
-		Results: make([]params.MacaroonResult, len(args.Entities)),
-	}
-	createLocalLoginMacaroon := func(arg params.Entity) (*macaroon.Macaroon, error) {
-		user, err := api.getUser(arg.Tag)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-
-		isSuperUser, err := api.hasControllerAdminAccess()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-
-		if api.apiUser != user.UserTag() && !api.isAdmin && isSuperUser {
-			return nil, errors.Trace(common.ErrPerm)
-		}
-		return api.createLocalLoginMacaroon(user.UserTag())
-	}
-	for i, arg := range args.Entities {
-		m, err := createLocalLoginMacaroon(arg)
-		if err != nil {
-			results.Results[i].Error = common.ServerError(err)
-			continue
-		}
-		results.Results[i].Result = m
-	}
-	return results, nil
 }

--- a/apiserver/usermanager/usermanager_test.go
+++ b/apiserver/usermanager/usermanager_test.go
@@ -11,7 +11,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
-	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/apiserver/common"
 	commontesting "github.com/juju/juju/apiserver/common/testing"
@@ -28,11 +27,10 @@ import (
 type userManagerSuite struct {
 	jujutesting.JujuConnSuite
 
-	usermanager              *usermanager.UserManagerAPI
-	authorizer               apiservertesting.FakeAuthorizer
-	adminName                string
-	resources                *common.Resources
-	createLocalLoginMacaroon func(names.UserTag) (*macaroon.Macaroon, error)
+	usermanager *usermanager.UserManagerAPI
+	authorizer  apiservertesting.FakeAuthorizer
+	adminName   string
+	resources   *common.Resources
 
 	commontesting.BlockHelper
 }
@@ -42,16 +40,7 @@ var _ = gc.Suite(&userManagerSuite{})
 func (s *userManagerSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 
-	s.createLocalLoginMacaroon = func(tag names.UserTag) (*macaroon.Macaroon, error) {
-		return nil, errors.NotSupportedf("CreateLocalLoginMacaroon")
-	}
 	s.resources = common.NewResources()
-	s.resources.RegisterNamed("createLocalLoginMacaroon", common.ValueResource{
-		func(tag names.UserTag) (*macaroon.Macaroon, error) {
-			return s.createLocalLoginMacaroon(tag)
-		},
-	})
-
 	adminTag := s.AdminUserTag(c)
 	s.adminName = adminTag.Name()
 	s.authorizer = apiservertesting.FakeAuthorizer{

--- a/cmd/juju/commands/migrate_test.go
+++ b/cmd/juju/commands/migrate_test.go
@@ -4,11 +4,18 @@
 package commands
 
 import (
+	"net/http"
+	"net/url"
+	"time"
+
 	"github.com/juju/cmd"
+	cookiejar "github.com/juju/persistent-cookiejar"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/macaroon.v1"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/controller"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -20,9 +27,10 @@ import (
 
 type MigrateSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
-	api   *fakeMigrateAPI
-	store *jujuclienttesting.MemStore
-	mac   *macaroon.Macaroon
+	api                 *fakeMigrateAPI
+	targetControllerAPI *fakeTargetControllerAPI
+	store               *jujuclienttesting.MemStore
+	password            string
 }
 
 var _ = gc.Suite(&MigrateSuite{})
@@ -58,17 +66,9 @@ func (s *MigrateSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Define the account for the target controller.
-	s.mac, err = macaroon.New([]byte("secret"), "id", "location")
-	c.Assert(err, jc.ErrorIsNil)
-	macJSON, err := s.mac.MarshalJSON()
-	c.Assert(err, jc.ErrorIsNil)
-
 	err = s.store.UpdateAccount("target", jujuclient.AccountDetails{
-		User: "target@local",
-		// It's unlikely that both will actually be set for a single
-		// account but it's fine for the tests.
+		User:     "target@local",
 		Password: "secret",
-		Macaroon: string(macJSON),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -81,6 +81,41 @@ func (s *MigrateSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.api = &fakeMigrateAPI{}
+
+	mac0, err := macaroon.New([]byte("secret0"), "id0", "location0")
+	c.Assert(err, jc.ErrorIsNil)
+	mac1, err := macaroon.New([]byte("secret1"), "id1", "location1")
+	c.Assert(err, jc.ErrorIsNil)
+
+	jar, err := cookiejar.New(&cookiejar.Options{
+		Filename: cookiejar.DefaultCookieFile(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.targetControllerAPI = &fakeTargetControllerAPI{
+		cookieURL: &url.URL{
+			Scheme: "https",
+			Host:   "testing.invalid",
+			Path:   "/",
+		},
+		macaroons: []macaroon.Slice{{mac0}},
+	}
+	addCookie(c, jar, mac0, s.targetControllerAPI.cookieURL)
+	addCookie(c, jar, mac1, &url.URL{
+		Scheme: "https",
+		Host:   "tasting.invalid",
+		Path:   "/",
+	})
+
+	err = jar.Save()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func addCookie(c *gc.C, jar *cookiejar.Jar, mac *macaroon.Macaroon, url *url.URL) {
+	cookie, err := httpbakery.NewCookie(macaroon.Slice{mac})
+	c.Assert(err, jc.ErrorIsNil)
+	cookie.Expires = time.Now().Add(time.Hour) // only persistent cookies are stored
+	jar.SetCookies(url, []*http.Cookie{cookie})
 }
 
 func (s *MigrateSuite) TestMissingModel(c *gc.C) {
@@ -110,7 +145,27 @@ func (s *MigrateSuite) TestSuccess(c *gc.C) {
 		TargetCACert:         "cert",
 		TargetUser:           "target@local",
 		TargetPassword:       "secret",
-		TargetMacaroons:      []macaroon.Slice{{s.mac}},
+	})
+}
+
+func (s *MigrateSuite) TestSuccessMacaroons(c *gc.C) {
+	err := s.store.UpdateAccount("target", jujuclient.AccountDetails{
+		User:     "target@local",
+		Password: "",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx, err := s.makeAndRun(c, "model", "target")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(testing.Stderr(ctx), gc.Matches, "Migration started with ID \"uuid:0\"\n")
+	c.Check(s.api.specSeen, jc.DeepEquals, &controller.MigrationSpec{
+		ModelUUID:            modelUUID,
+		TargetControllerUUID: targetControllerUUID,
+		TargetAddrs:          []string{"1.2.3.4:5"},
+		TargetCACert:         "cert",
+		TargetUser:           "target@local",
+		TargetMacaroons:      s.targetControllerAPI.macaroons,
 	})
 }
 
@@ -143,6 +198,9 @@ func (s *MigrateSuite) makeAndRun(c *gc.C, args ...string) (*cmd.Context, error)
 func (s *MigrateSuite) makeCommand() *migrateCommand {
 	cmd := &migrateCommand{
 		api: s.api,
+		newAPIRoot: func(jujuclient.ClientStore, string, string) (api.Connection, error) {
+			return s.targetControllerAPI, nil
+		},
 	}
 	cmd.SetClientStore(s.store)
 	return cmd
@@ -177,5 +235,19 @@ func (m *fakeModelAPI) ListModels(user string) ([]base.UserModel, error) {
 }
 
 func (m *fakeModelAPI) Close() error {
+	return nil
+}
+
+type fakeTargetControllerAPI struct {
+	api.Connection
+	cookieURL *url.URL
+	macaroons []macaroon.Slice
+}
+
+func (a *fakeTargetControllerAPI) CookieURL() *url.URL {
+	return a.cookieURL
+}
+
+func (a *fakeTargetControllerAPI) Close() error {
 	return nil
 }

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -128,7 +128,10 @@ func (c *registerCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	// Make the registration call.
+	// Make the registration call. If this is successful, the client's
+	// cookie jar will be populated with a macaroon that may be used
+	// to log in below without the user having to type in the password
+	// again.
 	req := params.SecretKeyLoginRequest{
 		Nonce: registrationParams.nonce[:],
 		User:  registrationParams.userTag.String(),
@@ -168,13 +171,8 @@ func (c *registerCommand) Run(ctx *cmd.Context) error {
 	if err := store.AddController(registrationParams.controllerName, controllerDetails); err != nil {
 		return errors.Trace(err)
 	}
-	macaroonJSON, err := responsePayload.Macaroon.MarshalJSON()
-	if err != nil {
-		return errors.Annotate(err, "marshalling temporary credential to JSON")
-	}
 	accountDetails := jujuclient.AccountDetails{
 		User:            registrationParams.userTag.Canonical(),
-		Macaroon:        string(macaroonJSON),
 		LastKnownAccess: string(description.LoginAccess),
 	}
 	if err := store.UpdateAccount(registrationParams.controllerName, accountDetails); err != nil {
@@ -320,6 +318,11 @@ func (c *registerCommand) getParameters(ctx *cmd.Context, store jujuclient.Clien
 }
 
 func (c *registerCommand) secretKeyLogin(addrs []string, request params.SecretKeyLoginRequest) (*params.SecretKeyLoginResponse, error) {
+	apiContext, err := c.APIContext()
+	if err != nil {
+		return nil, errors.Annotate(err, "getting API context")
+	}
+
 	buf, err := json.Marshal(&request)
 	if err != nil {
 		return nil, errors.Annotate(err, "marshalling request")
@@ -351,6 +354,8 @@ func (c *registerCommand) secretKeyLogin(addrs []string, request params.SecretKe
 	}
 
 	// Using the address we connected to above, perform the request.
+	// A success response will include a macaroon cookie that we can
+	// use to log in with.
 	urlString := fmt.Sprintf("https://%s/register", apiAddr)
 	httpReq, err := http.NewRequest("POST", urlString, r)
 	if err != nil {
@@ -358,6 +363,7 @@ func (c *registerCommand) secretKeyLogin(addrs []string, request params.SecretKe
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpClient := utils.GetNonValidatingHTTPClient()
+	httpClient.Jar = apiContext.Jar
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -20,7 +20,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"golang.org/x/crypto/nacl/secretbox"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
@@ -219,18 +218,12 @@ func (s *RegisterSuite) testRegister(c *gc.C, expectedError string) *cmd.Context
 	secretKey := []byte(strings.Repeat("X", 32))
 	respNonce := []byte(strings.Repeat("X", 24))
 
-	macaroon, err := macaroon.New(nil, "mymacaroon", "tone")
-	c.Assert(err, jc.ErrorIsNil)
-	macaroonJSON, err := macaroon.MarshalJSON()
-	c.Assert(err, jc.ErrorIsNil)
-
 	var requests []*http.Request
 	var requestBodies [][]byte
 	const controllerUUID = "df136476-12e9-11e4-8a70-b2227cce2b54"
 	responsePayloadPlaintext, err := json.Marshal(params.SecretKeyLoginResponsePayload{
 		CACert:         testing.CACert,
 		ControllerUUID: controllerUUID,
-		Macaroon:       macaroon,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	response, err := json.Marshal(params.SecretKeyLoginResponse{
@@ -287,7 +280,6 @@ func (s *RegisterSuite) testRegister(c *gc.C, expectedError string) *cmd.Context
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(account, jc.DeepEquals, &jujuclient.AccountDetails{
 		User:            "bob@local",
-		Macaroon:        string(macaroonJSON),
 		LastKnownAccess: "login",
 	})
 	return ctx

--- a/cmd/juju/user/change_password_test.go
+++ b/cmd/juju/user/change_password_test.go
@@ -11,12 +11,9 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/names.v2"
-	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -76,12 +73,7 @@ func (s *ChangePasswordCommandSuite) TestInit(c *gc.C) {
 }
 
 func (s *ChangePasswordCommandSuite) assertAPICalls(c *gc.C, user, pass string) {
-	var offset int
-	if user == "current-user@local" {
-		s.mockAPI.CheckCall(c, 0, "CreateLocalLoginMacaroon", names.NewUserTag(user))
-		offset += 1
-	}
-	s.mockAPI.CheckCall(c, offset, "SetPassword", user, pass)
+	s.mockAPI.CheckCall(c, 0, "SetPassword", user, pass)
 }
 
 func (s *ChangePasswordCommandSuite) TestChangePassword(c *gc.C) {
@@ -90,35 +82,17 @@ func (s *ChangePasswordCommandSuite) TestChangePassword(c *gc.C) {
 	s.assertAPICalls(c, "current-user@local", "sekrit")
 	c.Assert(coretesting.Stdout(context), gc.Equals, "")
 	c.Assert(coretesting.Stderr(context), gc.Equals, `
-password: 
-type password again: 
+new password: 
+type new password again: 
 Your password has been updated.
 `[1:])
 }
 
 func (s *ChangePasswordCommandSuite) TestChangePasswordFail(c *gc.C) {
-	s.mockAPI.SetErrors(nil, errors.New("failed to do something"))
+	s.mockAPI.SetErrors(errors.New("failed to do something"))
 	_, err := s.run(c)
 	c.Assert(err, gc.ErrorMatches, "failed to do something")
 	s.assertAPICalls(c, "current-user@local", "sekrit")
-}
-
-// We create a macaroon, but fail to write it to accounts.yaml.
-// We should not call SetPassword subsequently.
-func (s *ChangePasswordCommandSuite) TestNoSetPasswordAfterFailedWrite(c *gc.C) {
-	store := jujuclienttesting.NewStubStore()
-	store.AccountDetailsFunc = func(string) (*jujuclient.AccountDetails, error) {
-		return &jujuclient.AccountDetails{"user", "old-password", "", ""}, nil
-	}
-	store.ControllerByNameFunc = func(string) (*jujuclient.ControllerDetails, error) {
-		return &jujuclient.ControllerDetails{}, nil
-	}
-	s.store = store
-	store.SetErrors(nil, errors.New("failed to write"))
-
-	_, err := s.run(c)
-	c.Assert(err, gc.ErrorMatches, "failed to update client credentials: failed to write")
-	s.mockAPI.CheckCallNames(c, "CreateLocalLoginMacaroon") // no SetPassword
 }
 
 func (s *ChangePasswordCommandSuite) TestChangeOthersPassword(c *gc.C) {
@@ -133,14 +107,6 @@ type mockChangePasswordAPI struct {
 	testing.Stub
 }
 
-func (m *mockChangePasswordAPI) CreateLocalLoginMacaroon(tag names.UserTag) (*macaroon.Macaroon, error) {
-	m.MethodCall(m, "CreateLocalLoginMacaroon", tag)
-	if err := m.NextErr(); err != nil {
-		return nil, err
-	}
-	return fakeLocalLoginMacaroon(tag), nil
-}
-
 func (m *mockChangePasswordAPI) SetPassword(username, password string) error {
 	m.MethodCall(m, "SetPassword", username, password)
 	return m.NextErr()
@@ -148,12 +114,4 @@ func (m *mockChangePasswordAPI) SetPassword(username, password string) error {
 
 func (*mockChangePasswordAPI) Close() error {
 	return nil
-}
-
-func fakeLocalLoginMacaroon(tag names.UserTag) *macaroon.Macaroon {
-	mac, err := macaroon.New([]byte("abcdefghijklmnopqrstuvwx"), tag.Canonical(), "juju")
-	if err != nil {
-		panic(err)
-	}
-	return mac
 }

--- a/cmd/juju/user/login.go
+++ b/cmd/juju/user/login.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
-	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api/usermanager"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -74,7 +73,6 @@ func (c *loginCommand) Init(args []string) error {
 
 // LoginAPI provides the API methods that the login command uses.
 type LoginAPI interface {
-	CreateLocalLoginMacaroon(names.UserTag) (*macaroon.Macaroon, error)
 	Close() error
 }
 
@@ -121,16 +119,12 @@ func (c *loginCommand) Run(ctx *cmd.Context) error {
 Run "juju logout" first before attempting to log in as a different user.
 `)
 	}
-	// Read password from the terminal, and attempt to log in using that.
-	fmt.Fprint(ctx.Stderr, "password: ")
-	password, err := readPassword(ctx.Stdin)
-	fmt.Fprintln(ctx.Stderr)
-	if err != nil {
-		return errors.Trace(err)
-	}
+
+	// Log in without specifying a password in the account details. This
+	// will trigger macaroon-based authentication, which will prompt the
+	// user for their password.
 	accountDetails = &jujuclient.AccountDetails{
-		User:     userTag.Canonical(),
-		Password: password,
+		User: userTag.Canonical(),
 	}
 	params, err := c.NewAPIConnectionParams(store, controllerName, "", accountDetails)
 	if err != nil {
@@ -142,19 +136,6 @@ Run "juju logout" first before attempting to log in as a different user.
 	}
 	defer api.Close()
 
-	// Create a new local login macaroon, and update the account details
-	// in the client store, removing the recorded password (if any) and
-	// storing the macaroon.
-	macaroon, err := api.CreateLocalLoginMacaroon(userTag)
-	if err != nil {
-		return errors.Annotate(err, "failed to create a temporary credential")
-	}
-	macaroonJSON, err := macaroon.MarshalJSON()
-	if err != nil {
-		return errors.Annotate(err, "marshalling temporary credential to JSON")
-	}
-	accountDetails.Password = ""
-	accountDetails.Macaroon = string(macaroonJSON)
 	accountDetails.LastKnownAccess = conn.ControllerAccess()
 	if err := store.UpdateAccount(controllerName, *accountDetails); err != nil {
 		return errors.Annotate(err, "failed to record temporary credential")

--- a/cmd/juju/user/login_test.go
+++ b/cmd/juju/user/login_test.go
@@ -4,13 +4,11 @@
 package user_test
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/juju"
@@ -87,15 +85,12 @@ func (s *LoginCommandSuite) TestLogin(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(coretesting.Stdout(context), gc.Equals, "")
 	c.Assert(coretesting.Stderr(context), gc.Equals, `
-username: password: 
-You are now logged in to "testing" as "current-user@local".
+username: You are now logged in to "testing" as "current-user@local".
 `[1:],
 	)
 	s.assertStorePassword(c, "current-user@local", "", "superuser")
-	s.assertStoreMacaroon(c, "current-user@local", fakeLocalLoginMacaroon(names.NewUserTag("current-user@local")))
 	c.Assert(args.AccountDetails, jc.DeepEquals, &jujuclient.AccountDetails{
-		User:     "current-user@local",
-		Password: "sekrit",
+		User: "current-user@local",
 	})
 }
 
@@ -106,15 +101,12 @@ func (s *LoginCommandSuite) TestLoginNewUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(coretesting.Stdout(context), gc.Equals, "")
 	c.Assert(coretesting.Stderr(context), gc.Equals, `
-password: 
 You are now logged in to "testing" as "new-user@local".
 `[1:],
 	)
 	s.assertStorePassword(c, "new-user@local", "", "superuser")
-	s.assertStoreMacaroon(c, "new-user@local", fakeLocalLoginMacaroon(names.NewUserTag("new-user@local")))
 	c.Assert(args.AccountDetails, jc.DeepEquals, &jujuclient.AccountDetails{
-		User:     "new-user@local",
-		Password: "sekrit",
+		User: "new-user@local",
 	})
 }
 
@@ -131,16 +123,10 @@ Run "juju logout" first before attempting to log in as a different user.
 `)
 }
 
-func (s *LoginCommandSuite) TestLoginFail(c *gc.C) {
-	s.mockAPI.SetErrors(errors.New("failed to do something"))
-	_, _, err := s.run(c, "", "current-user")
-	c.Assert(err, gc.ErrorMatches, "failed to create a temporary credential: failed to do something")
-	s.assertStorePassword(c, "current-user@local", "old-password", "")
-	s.assertStoreMacaroon(c, "current-user@local", nil)
-}
+type mockLoginAPI struct{}
 
-type mockLoginAPI struct {
-	mockChangePasswordAPI
+func (*mockLoginAPI) Close() error {
+	return nil
 }
 
 func (*mockLoginAPI) ControllerAccess() string {

--- a/cmd/juju/user/logout.go
+++ b/cmd/juju/user/logout.go
@@ -116,7 +116,7 @@ func (c *logoutCommand) logout(store jujuclient.ClientStore, controllerName stri
 	// they know their password. If they have just bootstrapped,
 	// they will have a randomly generated password which they will
 	// be unaware of.
-	if accountDetails.Macaroon == "" && accountDetails.Password != "" && !c.Force {
+	if accountDetails.Password != "" && !c.Force {
 		return errors.New(`preventing account loss
 
 It appears that you have not changed the password for

--- a/cmd/juju/user/logout_test.go
+++ b/cmd/juju/user/logout_test.go
@@ -55,9 +55,7 @@ func (s *LogoutCommandSuite) TestInit(c *gc.C) {
 }
 
 func (s *LogoutCommandSuite) TestLogout(c *gc.C) {
-	details := s.store.Accounts["testing"]
-	details.Macaroon = "a-macaroon"
-	s.store.Accounts["testing"] = details
+	s.setPassword(c, "testing", "")
 	ctx, err := s.run(c)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(coretesting.Stdout(ctx), gc.Equals, "")
@@ -72,9 +70,9 @@ Logged out. You are no longer logged into any controllers.
 func (s *LogoutCommandSuite) TestLogoutCount(c *gc.C) {
 	// Create multiple controllers. We'll log out of each one
 	// to observe the messages printed out by "logout".
+	s.setPassword(c, "testing", "")
 	controllers := []string{"testing", "testing2", "testing3"}
 	details := s.store.Accounts["testing"]
-	details.Macaroon = "a-macaroon"
 	for _, controller := range controllers {
 		s.store.Controllers[controller] = s.store.Controllers["testing"]
 		err := s.store.UpdateAccount(controller, details)
@@ -95,9 +93,8 @@ func (s *LogoutCommandSuite) TestLogoutCount(c *gc.C) {
 	}
 }
 
-func (s *LogoutCommandSuite) TestLogoutWithoutMacaroon(c *gc.C) {
+func (s *LogoutCommandSuite) TestLogoutWithPassword(c *gc.C) {
 	s.assertStorePassword(c, "current-user@local", "old-password", "")
-	s.assertStoreMacaroon(c, "current-user@local", nil)
 	_, err := s.run(c)
 	c.Assert(err, gc.NotNil)
 	c.Assert(err.Error(), gc.Equals, `preventing account loss
@@ -114,9 +111,8 @@ this command again with the "--force" flag.
 `)
 }
 
-func (s *LogoutCommandSuite) TestLogoutWithoutMacaroonForced(c *gc.C) {
+func (s *LogoutCommandSuite) TestLogoutWithPasswordForced(c *gc.C) {
 	s.assertStorePassword(c, "current-user@local", "old-password", "")
-	s.assertStoreMacaroon(c, "current-user@local", nil)
 	_, err := s.run(c, "--force")
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.store.AccountDetails("testing")

--- a/cmd/juju/user/user_test.go
+++ b/cmd/juju/user/user_test.go
@@ -6,7 +6,6 @@ package user_test
 import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
@@ -34,22 +33,17 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	}
 }
 
+func (s *BaseSuite) setPassword(c *gc.C, controller, pass string) {
+	details, ok := s.store.Accounts[controller]
+	c.Assert(ok, jc.IsTrue)
+	details.Password = pass
+	s.store.Accounts[controller] = details
+}
+
 func (s *BaseSuite) assertStorePassword(c *gc.C, user, pass, access string) {
 	details, err := s.store.AccountDetails("testing")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(details.User, gc.Equals, user)
 	c.Assert(details.Password, gc.Equals, pass)
 	c.Assert(details.LastKnownAccess, gc.Equals, access)
-}
-
-func (s *BaseSuite) assertStoreMacaroon(c *gc.C, user string, mac *macaroon.Macaroon) {
-	details, err := s.store.AccountDetails("testing")
-	c.Assert(err, jc.ErrorIsNil)
-	if mac == nil {
-		c.Assert(details.Macaroon, gc.Equals, "")
-		return
-	}
-	macaroonJSON, err := mac.MarshalJSON()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(details.Macaroon, gc.Equals, string(macaroonJSON))
 }

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -4,8 +4,13 @@
 package modelcmd
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
+
+	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -14,6 +19,7 @@ import (
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/authentication"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/apiserver/params"
@@ -158,13 +164,29 @@ func (c *JujuCommandBase) NewAPIConnectionParams(
 	controllerName, modelName string,
 	accountDetails *jujuclient.AccountDetails,
 ) (juju.NewAPIConnectionParams, error) {
-	if err := c.initAPIContext(); err != nil {
+	bakeryClient, err := c.BakeryClient()
+	if err != nil {
 		return juju.NewAPIConnectionParams{}, errors.Trace(err)
 	}
+	var getPassword func(username string) (string, error)
+	if c.cmdContext != nil {
+		getPassword = func(username string) (string, error) {
+			fmt.Fprintf(c.cmdContext.Stderr, "password for %s on %s: ", username, controllerName)
+			defer fmt.Fprintln(c.cmdContext.Stderr)
+			return readPassword(c.cmdContext.Stdin)
+		}
+	} else {
+		getPassword = func(username string) (string, error) {
+			return "", errors.New("no context to prompt for password")
+		}
+	}
+
 	return newAPIConnectionParams(
 		store, controllerName, modelName,
-		accountDetails, c.apiContext.BakeryClient,
+		accountDetails,
+		bakeryClient,
 		c.apiOpen,
+		getPassword,
 	)
 }
 
@@ -174,10 +196,11 @@ func (c *JujuCommandBase) NewAPIConnectionParams(
 // have the correct TLS setup - use api.Connection.HTTPClient
 // for that.
 func (c *JujuCommandBase) HTTPClient() (*http.Client, error) {
-	if err := c.initAPIContext(); err != nil {
+	bakeryClient, err := c.BakeryClient()
+	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return c.apiContext.BakeryClient.Client, nil
+	return bakeryClient.Client, nil
 }
 
 // BakeryClient returns a macaroon bakery client that
@@ -186,7 +209,7 @@ func (c *JujuCommandBase) BakeryClient() (*httpbakery.Client, error) {
 	if err := c.initAPIContext(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	return c.apiContext.BakeryClient, nil
+	return c.apiContext.NewBakeryClient(), nil
 }
 
 // APIOpen establishes a connection to the API server using the
@@ -303,6 +326,7 @@ func newAPIConnectionParams(
 	accountDetails *jujuclient.AccountDetails,
 	bakery *httpbakery.Client,
 	apiOpen api.OpenFunc,
+	getPassword func(string) (string, error),
 ) (juju.NewAPIConnectionParams, error) {
 	if controllerName == "" {
 		return juju.NewAPIConnectionParams{}, errors.Trace(errNoNameSpecified)
@@ -318,31 +342,10 @@ func newAPIConnectionParams(
 	dialOpts := api.DefaultDialOpts()
 	dialOpts.BakeryClient = bakery
 
-	openAPI := func(info *api.Info, opts api.DialOpts) (api.Connection, error) {
-		conn, err := apiOpen(info, opts)
-		if err != nil {
-			userTag, ok := info.Tag.(names.UserTag)
-			if ok && userTag.IsLocal() && params.IsCodeLoginExpired(err) {
-				// This is a bit gross, but we don't seem to have
-				// a way of having an error with a cause that does
-				// not influence the error message. We want to keep
-				// the type/code so we don't lose the fact that the
-				// error was caused by an API login expiry.
-				return nil, &params.Error{
-					Code: params.CodeLoginExpired,
-					Message: fmt.Sprintf(`login expired
-
-Your login for the %q controller has expired.
-To log back in, run the following command:
-
-    juju login %v
-`, controllerName, userTag.Name()),
-				}
-			}
-			return nil, err
-		}
-		return conn, nil
-	}
+	bakery.WebPageVisitor = httpbakery.NewMultiVisitor(
+		authentication.NewVisitor(accountDetails.User, getPassword),
+		bakery.WebPageVisitor,
+	)
 
 	return juju.NewAPIConnectionParams{
 		Store:          store,
@@ -350,7 +353,7 @@ To log back in, run the following command:
 		AccountDetails: accountDetails,
 		ModelUUID:      modelUUID,
 		DialOpts:       dialOpts,
-		OpenAPI:        openAPI,
+		OpenAPI:        apiOpen,
 	}, nil
 }
 
@@ -442,4 +445,32 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 		},
 		cfg,
 	}, nil
+}
+
+// TODO(axw) this is now in three places: change-password,
+// register, and here. Refactor and move to a common location.
+func readPassword(stdin io.Reader) (string, error) {
+	if f, ok := stdin.(*os.File); ok && terminal.IsTerminal(int(f.Fd())) {
+		password, err := terminal.ReadPassword(int(f.Fd()))
+		return string(password), err
+	}
+	return readLine(stdin)
+}
+
+func readLine(stdin io.Reader) (string, error) {
+	// Read one byte at a time to avoid reading beyond the delimiter.
+	line, err := bufio.NewReader(byteAtATimeReader{stdin}).ReadString('\n')
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return line[:len(line)-1], nil
+}
+
+type byteAtATimeReader struct {
+	io.Reader
+}
+
+// Read is part of the io.Reader interface.
+func (r byteAtATimeReader) Read(out []byte) (int, error) {
+	return r.Reader.Read(out[:1])
 }

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -44,23 +44,6 @@ func (s *BaseCommandSuite) SetUpTest(c *gc.C) {
 	}
 }
 
-func (s *BaseCommandSuite) TestLoginExpiry(c *gc.C) {
-	apiOpen := func(*api.Info, api.DialOpts) (api.Connection, error) {
-		return nil, &params.Error{Code: params.CodeLoginExpired, Message: "meep"}
-	}
-	var cmd modelcmd.JujuCommandBase
-	cmd.SetAPIOpen(apiOpen)
-	conn, err := cmd.NewAPIRoot(s.store, "foo", "")
-	c.Assert(conn, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, `login expired
-
-Your login for the "foo" controller has expired.
-To log back in, run the following command:
-
-    juju login bar
-`)
-}
-
 func (s *BaseCommandSuite) assertUnknownModel(c *gc.C, current, expectedCurrent string) {
 	s.store.Models["foo"].CurrentModel = current
 	apiOpen := func(*api.Info, api.DialOpts) (api.Connection, error) {

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -345,11 +345,6 @@ func BootstrapContextNoVerify(cmdContext *cmd.Context) environs.BootstrapContext
 	}
 }
 
-type ModelGetter interface {
-	ModelGet() (map[string]interface{}, error)
-	Close() error
-}
-
 // SplitModelName splits a model name into its controller
 // and model parts. If the model is unqualified, then the
 // returned controller string will be empty, and the returned

--- a/featuretests/cmd_juju_login_test.go
+++ b/featuretests/cmd_juju_login_test.go
@@ -63,7 +63,7 @@ func (s *cmdLoginSuite) TestLoginCommand(c *gc.C) {
 	context := s.run(c, strings.NewReader("hunter2\nhunter2\n"), "login", "test")
 	c.Assert(testing.Stdout(context), gc.Equals, "")
 	c.Assert(testing.Stderr(context), gc.Equals, `
-password: 
+password for test@local on kontroll: 
 You are now logged in to "kontroll" as "test@local".
 `[1:])
 
@@ -72,7 +72,6 @@ You are now logged in to "kontroll" as "test@local".
 	accountDetails, err := store.AccountDetails("kontroll")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(accountDetails.Password, gc.Equals, "")
-	c.Assert(accountDetails.Macaroon, gc.Not(gc.Equals), "")
 
 	// We should be able to login with the macaroon.
 	s.run(c, nil, "status")

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -55,11 +55,6 @@ type AccountDetails struct {
 	// Password is the password for the account.
 	Password string `yaml:"password,omitempty"`
 
-	// Macaroon is a time-limited macaroon that may be
-	// used to log in. This string is the JSON-encoding
-	// of a gopkg.in/macaroon.v1.Macaroon.
-	Macaroon string `yaml:"macaroon,omitempty"`
-
 	// LastKnownAccess is the last known access level for the account.
 	LastKnownAccess string `yaml:"last-known-access,omitempty"`
 }

--- a/jujuclient/validation.go
+++ b/jujuclient/validation.go
@@ -34,10 +34,6 @@ func ValidateAccountDetails(details AccountDetails) error {
 	}
 	// It is valid for a password to be blank, because the client
 	// may use macaroons instead.
-	//
-	// TODO(axw) expand validation rules to check that at least
-	// one of Password or Macaroon is non-empty, for local users.
-	// External users may have neither.
 	return nil
 }
 

--- a/resource/cmd/list_charm_resources.go
+++ b/resource/cmd/list_charm_resources.go
@@ -127,12 +127,12 @@ func (c *ListCharmResourcesCommand) Run(ctx *cmd.Context) error {
 // ListCharmResources implements CharmResourceLister by getting the charmstore client
 // from the command's ModelCommandBase.
 func (c *ListCharmResourcesCommand) ListResources(ids []charmstore.CharmID) ([][]charmresource.Resource, error) {
-	apiContext, err := c.APIContext()
+	// We use the default for URL.
+	bakeryClient, err := c.BakeryClient()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	// We use the default for URL.
-	client, err := charmstore.NewCustomClient(apiContext.BakeryClient, nil)
+	client, err := charmstore.NewCustomClient(bakeryClient, nil)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
This is a long overdue overhaul of the local
login macaroon authentication in Juju, bringing
macaroon authentication for local users in line
with how we do it for external users.

The controller now acts as a discharger for
macaroons authenticating local users. When you
first attempt to connect without a password you
will be handed a macaroon with the location
pointing back at the controller. The client
has a special "web-page" visitor which can
interact with the controller to obtain a caveat
discharge macaroon with which it can authenticate.

The macaroon field in accounts.yaml has been
dropped, in favour of storing macaroons only in
the cookie jar ($JUJU_COOKIEFILE or ~/.go-cookies).

There is currently no browser-based login page
for local users, though this could be added later.

Fixes https://bugs.launchpad.net/juju/+bug/1603176

(Review request: http://reviews.vapour.ws/r/5603/)