### PR TITLE
Add cloud and controller info to charmstore Juju-Metadata header

### DIFF
--- a/apiserver/charmrevisionupdater/updater.go
+++ b/apiserver/charmrevisionupdater/updater.go
@@ -139,7 +139,18 @@ func retrieveLatestCharmInfo(st *state.State) ([]latestCharmInfo, error) {
 		resultsIndexedServices = append(resultsIndexedServices, service)
 	}
 
-	results, err := charmstore.LatestCharmInfo(client, charms, env.UUID())
+	metadata := map[string]string{
+		"environment_uuid": env.UUID(),
+		"cloud":            env.Cloud(),
+		"cloud_region":     env.CloudRegion(),
+	}
+	cloud, err := st.Cloud(env.Cloud())
+	if err != nil {
+		metadata["provider"] = "unknown"
+	} else {
+		metadata["provider"] = cloud.Type
+	}
+	results, err := charmstore.LatestCharmInfo(client, charms, metadata)
 	if err != nil {
 		return nil, err
 	}

--- a/charmstore/latest.go
+++ b/charmstore/latest.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+
+	"github.com/juju/juju/version"
 )
 
 const jujuMetadataHTTPHeader = "Juju-Metadata"
@@ -17,13 +19,19 @@ const jujuMetadataHTTPHeader = "Juju-Metadata"
 // the macaroon has been updated. This updated macaroon should be stored for
 // use in any further requests.  Note that this map may be non-empty even if
 // this method returns an error (and the macaroons should be stored).
-func LatestCharmInfo(client Client, charms []CharmID, modelUUID string) ([]CharmInfoResult, error) {
+func LatestCharmInfo(client Client, charms []CharmID, metadata map[string]string) ([]CharmInfoResult, error) {
 	// TODO(perrito666) 2016-05-02 lp:1558657
 	now := time.Now().UTC()
 	// Do a bulk call to get the revision info for all charms.
 	logger.Infof("retrieving revision information for %d charms", len(charms))
 	revResults, err := client.LatestRevisions(charms, map[string][]string{
-		jujuMetadataHTTPHeader: []string{"environment_uuid=" + modelUUID},
+		jujuMetadataHTTPHeader: []string{
+			"environment_uuid=" + metadata["environment_uuid"],
+			"cloud=" + metadata["cloud"],
+			"cloud_region=" + metadata["cloud_region"],
+			"provider=" + metadata["provider"],
+			"controller_version=" + version.Current.String(),
+		},
 	})
 	if err != nil {
 		err = errors.Annotate(err, "while getting latest charm revision info")

--- a/charmstore/latest_test.go
+++ b/charmstore/latest_test.go
@@ -13,6 +13,8 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
+
+	"github.com/juju/juju/version"
 )
 
 type LatestCharmInfoSuite struct {
@@ -67,12 +69,19 @@ func (s *LatestCharmInfoSuite) TestSuccess(c *gc.C) {
 	client, err := newCachingClient(s.cache, nil, s.lowLevel.makeWrapper)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := LatestCharmInfo(client, charms, "foobar")
+	metadata := map[string]string{
+		"environment_uuid": "foouuid",
+		"cloud":            "foocloud",
+		"cloud_region":     "fooregion",
+		"provider":         "fooprovider",
+	}
+	results, err := LatestCharmInfo(client, charms, metadata)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.lowLevel.stableStub.CheckCall(c, 0, "Latest", params.StableChannel, []*charm.URL{spam}, map[string][]string{"Juju-Metadata": []string{"environment_uuid=foobar"}})
-	s.lowLevel.stableStub.CheckCall(c, 1, "Latest", params.StableChannel, []*charm.URL{eggs}, map[string][]string{"Juju-Metadata": []string{"environment_uuid=foobar"}})
-	s.lowLevel.stableStub.CheckCall(c, 2, "Latest", params.StableChannel, []*charm.URL{ham}, map[string][]string{"Juju-Metadata": []string{"environment_uuid=foobar"}})
+	header := []string{"environment_uuid=foouuid", "cloud=foocloud", "cloud_region=fooregion", "provider=fooprovider", "controller_version=" + version.Current.String()}
+	s.lowLevel.stableStub.CheckCall(c, 0, "Latest", params.StableChannel, []*charm.URL{spam}, map[string][]string{"Juju-Metadata": header})
+	s.lowLevel.stableStub.CheckCall(c, 1, "Latest", params.StableChannel, []*charm.URL{eggs}, map[string][]string{"Juju-Metadata": header})
+	s.lowLevel.stableStub.CheckCall(c, 2, "Latest", params.StableChannel, []*charm.URL{ham}, map[string][]string{"Juju-Metadata": header})
 	s.lowLevel.stableStub.CheckCall(c, 3, "ListResources", params.StableChannel, spam)
 	s.lowLevel.stableStub.CheckCall(c, 4, "ListResources", params.StableChannel, eggs)
 	s.lowLevel.stableStub.CheckCall(c, 5, "ListResources", params.StableChannel, ham)


### PR DESCRIPTION
Previously, only environment_uuid has been sent in the charmstore request. This change adds cloud and controller information to the metrics list.

(Review request: http://reviews.vapour.ws/r/5606/)