### PR TITLE
Show machine and model count in list-controllers

### DIFF
--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -241,6 +241,10 @@ func (s *restoreSuite) TestRestoreReboostrapWritesUpdatedControllerInfo(c *gc.C)
 		return nil
 	})
 
+	intPtr := func(i int) *int {
+		return &i
+	}
+
 	_, err := testing.RunCommand(c, s.command, "restore", "-m", "testing:test1", "--file", "afile", "-b")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(boostrapped, jc.IsTrue)
@@ -252,6 +256,8 @@ func (s *restoreSuite) TestRestoreReboostrapWritesUpdatedControllerInfo(c *gc.C)
 		APIEndpoints:           []string{"10.0.0.1:17777"},
 		UnresolvedAPIEndpoints: []string{"10.0.0.1:17777"},
 		AgentVersion:           version.Current.String(),
+		ModelCount:             intPtr(2),
+		MachineCount:           intPtr(1),
 	})
 }
 

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -426,6 +426,20 @@ func (s *BootstrapSuite) TestBootstrapSetsCurrentModel(c *gc.C) {
 	c.Assert(modelName, gc.Equals, "admin@local/default")
 }
 
+func (s *BootstrapSuite) TestBootstrapSetsControllerDetails(c *gc.C) {
+	s.patchVersionAndSeries(c, "raring")
+
+	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "devcontroller", "dummy", "--auto-upgrade")
+	c.Assert(err, jc.ErrorIsNil)
+	currentController := s.store.CurrentControllerName
+	c.Assert(currentController, gc.Equals, "devcontroller")
+	details, err := s.store.ControllerByName(currentController)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(*details.ModelCount, gc.Equals, 2)
+	c.Assert(*details.MachineCount, gc.Equals, 1)
+	c.Assert(details.AgentVersion, gc.Equals, jujuversion.Current.String())
+}
+
 func (s *BootstrapSuite) TestBootstrapDefaultModel(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
 

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -58,7 +58,15 @@ func SetBootstrapEndpointAddress(
 		return errors.Annotate(err, "failed to get bootstrap instance addresses")
 	}
 	apiHostPorts := network.AddressesWithPort(netAddrs, apiPort)
-	return juju.UpdateControllerDetailsFromLogin(store, controllerName, agentVersion.String(), nil, apiHostPorts...)
+	// At bootstrap we have 2 models, the controller model and the default.
+	two := 2
+	params := juju.UpdateControllerParams{
+		AgentVersion:    agentVersion.String(),
+		AddrConnectedTo: apiHostPorts,
+		MachineCount:    &length,
+		ModelCount:      &two,
+	}
+	return juju.UpdateControllerDetailsFromLogin(store, controllerName, params)
 }
 
 var (

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -15,7 +15,7 @@ import (
 
 // NewListControllersCommandForTest returns a listControllersCommand with the clientstore provided
 // as specified.
-func NewListControllersCommandForTest(testStore jujuclient.ClientStore, api api.Connection) *listControllersCommand {
+func NewListControllersCommandForTest(testStore jujuclient.ClientStore, api func(string) ControllerAccessAPI) *listControllersCommand {
 	return &listControllersCommand{
 		store: testStore,
 		api:   api,

--- a/cmd/juju/controller/listcontrollers.go
+++ b/cmd/juju/controller/listcontrollers.go
@@ -11,8 +11,10 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/controller"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 )
@@ -61,11 +63,15 @@ func (c *listControllersCommand) SetFlags(f *gnuflag.FlagSet) {
 	})
 }
 
-func (c *listControllersCommand) getAPI(controllerName string) (api.Connection, error) {
+func (c *listControllersCommand) getAPI(controllerName string) (ControllerAccessAPI, error) {
 	if c.api != nil {
-		return c.api, nil
+		return c.api(controllerName), nil
 	}
-	return c.NewAPIRoot(c.store, controllerName, "")
+	api, err := c.NewAPIRoot(c.store, controllerName, "")
+	if err != nil {
+		return nil, errors.Annotate(err, "opening API connection")
+	}
+	return controller.NewClient(api), nil
 }
 
 // Run implements Command.Run
@@ -75,9 +81,6 @@ func (c *listControllersCommand) Run(ctx *cmd.Context) error {
 		return errors.Annotate(err, "failed to list controllers")
 	}
 	if c.refresh && len(controllers) > 0 {
-		// For each controller, simply opening an API
-		// connection is enough to login and refresh the
-		// cached data.
 		var wg sync.WaitGroup
 		wg.Add(len(controllers))
 		for controllerName := range controllers {
@@ -86,10 +89,13 @@ func (c *listControllersCommand) Run(ctx *cmd.Context) error {
 				defer wg.Done()
 				client, err := c.getAPI(name)
 				if err != nil {
-					fmt.Fprintf(ctx.GetStderr(), "error updating cached details for %q: %v", name, err)
+					fmt.Fprintf(ctx.GetStderr(), "error connecting to api for %q: %v", name, err)
 					return
 				}
-				client.Close()
+				defer client.Close()
+				if err := c.refreshControllerDetails(client, name); err != nil {
+					fmt.Fprintf(ctx.GetStderr(), "error updating cached details for %q: %v", name, err)
+				}
 			}()
 		}
 		wg.Wait()
@@ -116,11 +122,46 @@ func (c *listControllersCommand) Run(ctx *cmd.Context) error {
 	return c.out.Write(ctx, controllerSet)
 }
 
+func (c *listControllersCommand) refreshControllerDetails(client ControllerAccessAPI, controllerName string) error {
+	// First, get all the models the user can see, and their details.
+	var modelStatus []base.ModelStatus
+	allModels, err := client.AllModels()
+	if err != nil {
+		return err
+	}
+	modelTags := make([]names.ModelTag, len(allModels))
+	for i, m := range allModels {
+		modelTags[i] = names.NewModelTag(m.UUID)
+	}
+	modelStatus, err = client.ModelStatus(modelTags...)
+	if err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Use the model information to update the cached controller details.
+	details, err := c.store.ControllerByName(controllerName)
+	if err != nil {
+		return err
+	}
+
+	modelCount := len(allModels)
+	details.ModelCount = &modelCount
+	machineCount := 0
+	for _, s := range modelStatus {
+		machineCount += s.TotalMachineCount
+	}
+	details.MachineCount = &machineCount
+	return c.store.UpdateController(controllerName, *details)
+}
+
 type listControllersCommand struct {
 	modelcmd.JujuCommandBase
 
 	out     cmd.Output
 	store   jujuclient.ClientStore
-	api     api.Connection
+	api     func(controllerName string) ControllerAccessAPI
 	refresh bool
+	mu      sync.Mutex
 }

--- a/cmd/juju/controller/listcontrollersconverters.go
+++ b/cmd/juju/controller/listcontrollersconverters.go
@@ -32,6 +32,8 @@ type ControllerItem struct {
 	Cloud          string   `yaml:"cloud" json:"cloud"`
 	CloudRegion    string   `yaml:"region,omitempty" json:"region,omitempty"`
 	AgentVersion   string   `yaml:"agent-version,omitempty" json:"agent-version,omitempty"`
+	ModelCount     *int     `yaml:"model-count,omitempty" json:"model-count,omitempty"`
+	MachineCount   *int     `yaml:"machine-count,omitempty" json:"machine-count,omitempty"`
 }
 
 // convertControllerDetails takes a map of Controllers and
@@ -98,6 +100,8 @@ func (c *listControllersCommand) convertControllerDetails(storeControllers map[s
 			CACert:         details.CACert,
 			Cloud:          details.Cloud,
 			CloudRegion:    details.CloudRegion,
+			ModelCount:     details.ModelCount,
+			MachineCount:   details.MachineCount,
 			AgentVersion:   details.AgentVersion,
 		}
 	}

--- a/cmd/juju/controller/package_test.go
+++ b/cmd/juju/controller/package_test.go
@@ -60,6 +60,8 @@ controllers:
     ca-cert: this-is-aws-test-ca-cert
     cloud: aws
     region: us-east-1
+    model-count: 2
+    machine-count: 5
     agent-version: 2.0.1
   mallards:
     uuid: this-is-another-uuid

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -72,8 +72,8 @@ func (s *cmdControllerSuite) createModelNormalUser(c *gc.C, modelname string, is
 func (s *cmdControllerSuite) TestControllerListCommand(c *gc.C) {
 	context := s.run(c, "list-controllers")
 	expectedOutput := `
-CONTROLLER  MODEL       USER         ACCESS      CLOUD/REGION        VERSION
-kontroll*   controller  admin@local  superuser+  dummy/dummy-region  (unknown)+
+CONTROLLER  MODEL       USER         ACCESS      CLOUD/REGION        MODELS  MACHINES  VERSION
+kontroll*   controller  admin@local  superuser+  dummy/dummy-region  -       -         (unknown)+  
 
 + these are the last known values, run with --refresh to see the latest information.
 

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -371,6 +371,8 @@ func (s *CacheAPIEndpointsSuite) assertControllerDetailsUpdated(c *gc.C, name st
 	c.Assert(found.UnresolvedAPIEndpoints, check, 0)
 	c.Assert(found.APIEndpoints, check, 0)
 	c.Assert(found.AgentVersion, gc.Equals, "1.2.3")
+	c.Assert(found.ModelCount, gc.IsNil)
+	c.Assert(found.MachineCount, gc.IsNil)
 }
 
 func (s *CacheAPIEndpointsSuite) assertControllerUpdated(c *gc.C, name string) {
@@ -383,12 +385,39 @@ func (s *CacheAPIEndpointsSuite) assertControllerNotUpdated(c *gc.C, name string
 
 func (s *CacheAPIEndpointsSuite) TestPrepareEndpointsForCaching(c *gc.C) {
 	s.assertCreateController(c, "controller-name1")
-	err := juju.UpdateControllerDetailsFromLogin(s.ControllerStore, "controller-name1", "1.2.3", s.hostPorts, s.apiHostPort)
+	params := juju.UpdateControllerParams{
+		AgentVersion:     "1.2.3",
+		AddrConnectedTo:  []network.HostPort{s.apiHostPort},
+		CurrentHostPorts: s.hostPorts,
+	}
+	err := juju.UpdateControllerDetailsFromLogin(s.ControllerStore, "controller-name1", params)
 	c.Assert(err, jc.ErrorIsNil)
 	controllerDetails, err := s.ControllerStore.ControllerByName("controller-name1")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertEndpoints(c, controllerDetails)
 	s.assertControllerUpdated(c, "controller-name1")
+}
+
+func intptr(i int) *int {
+	return &i
+}
+
+func (s *CacheAPIEndpointsSuite) TestUpdateModelMachineCount(c *gc.C) {
+	s.assertCreateController(c, "controller-name1")
+	params := juju.UpdateControllerParams{
+		AgentVersion: "1.2.3",
+		ModelCount:   intptr(2),
+		MachineCount: intptr(3),
+	}
+	err := juju.UpdateControllerDetailsFromLogin(s.ControllerStore, "controller-name1", params)
+	c.Assert(err, jc.ErrorIsNil)
+	controllerDetails, err := s.ControllerStore.ControllerByName("controller-name1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(controllerDetails.UnresolvedAPIEndpoints, gc.HasLen, 0)
+	c.Assert(controllerDetails.APIEndpoints, gc.HasLen, 0)
+	c.Assert(controllerDetails.AgentVersion, gc.Equals, "1.2.3")
+	c.Assert(*controllerDetails.ModelCount, gc.Equals, 2)
+	c.Assert(*controllerDetails.MachineCount, gc.Equals, 3)
 }
 
 func (s *CacheAPIEndpointsSuite) TestResolveSkippedWhenHostnamesUnchanged(c *gc.C) {

--- a/jujuclient/controllers_test.go
+++ b/jujuclient/controllers_test.go
@@ -28,13 +28,12 @@ func (s *ControllersSuite) SetUpTest(c *gc.C) {
 	s.store = jujuclient.NewFileClientStore()
 	s.controllerName = "test.controller"
 	s.controller = jujuclient.ControllerDetails{
-		[]string{"test.server.hostname"},
-		"test.uuid",
-		[]string{"test.api.endpoint"},
-		"test.ca.cert",
-		"aws",
-		"southeastasia",
-		"",
+		UnresolvedAPIEndpoints: []string{"test.server.hostname"},
+		ControllerUUID:         "test.uuid",
+		APIEndpoints:           []string{"test.api.endpoint"},
+		CACert:                 "test.ca.cert",
+		Cloud:                  "aws",
+		CloudRegion:            "southeastasia",
 	}
 }
 

--- a/jujuclient/controllervalidation_test.go
+++ b/jujuclient/controllervalidation_test.go
@@ -18,13 +18,12 @@ type ControllerValidationSuite struct {
 func (s *ControllerValidationSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.controller = jujuclient.ControllerDetails{
-		[]string{"test.server.hostname"},
-		"test.uuid",
-		[]string{"test.api.endpoint"},
-		"test.ca.cert",
-		"aws",
-		"southeastasia",
-		"",
+		UnresolvedAPIEndpoints: []string{"test.server.hostname"},
+		ControllerUUID:         "test.uuid",
+		APIEndpoints:           []string{"test.api.endpoint"},
+		CACert:                 "test.ca.cert",
+		Cloud:                  "aws",
+		CloudRegion:            "southeastasia",
 	}
 }
 

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -39,6 +39,16 @@ type ControllerDetails struct {
 	// While this isn't strictly needed to connect to a controller, it is used
 	// in formatting show-controller output where this struct is also used.
 	AgentVersion string `yaml:"agent-version,omitempty"`
+
+	// ModelCount is the number of models to which a user has access.
+	// It is cached here so under normal usage list-controllers
+	// does not need to hit the server.
+	ModelCount *int `yaml:"model-count,omitempty"`
+
+	// MachineCount is the number of machines in all models to
+	// which a user has access. It is cached here so under normal
+	// usage list-controllers does not need to hit the server.
+	MachineCount *int `yaml:"machine-count,omitempty"`
 }
 
 // ModelDetails holds details of a model.

--- a/jujuclient/jujuclienttesting/mem.go
+++ b/jujuclient/jujuclienttesting/mem.go
@@ -34,7 +34,11 @@ func NewMemStore() *MemStore {
 
 // AllController implements ControllerGetter.AllController
 func (c *MemStore) AllControllers() (map[string]jujuclient.ControllerDetails, error) {
-	return c.Controllers, nil
+	result := make(map[string]jujuclient.ControllerDetails)
+	for name, details := range c.Controllers {
+		result[name] = details
+	}
+	return result, nil
 }
 
 // ControllerByName implements ControllerGetter.ControllerByName


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju/+bug/1602032

juju list-controllers now shows model and machine count
At bootstrap, the model count is set to 2, and machine count to 1.
Thereafter, the info can be refreshed using list-controllers --refresh

Also fixed the source of a race in the jujuclient MemStore test helper.