### PR TITLE
Support multiple macaroons for migrations

### DIFF
--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -250,9 +250,10 @@ func (c *Client) InitiateMigration(spec MigrationSpec) (string, error) {
 	if err := spec.Validate(); err != nil {
 		return "", errors.Trace(err)
 	}
-	macsJSON, err := json.Marshal(spec.TargetMacaroons)
+
+	macsJSON, err := macaroonsToJSON(spec.TargetMacaroons)
 	if err != nil {
-		return "", errors.Annotate(err, "marshalling macaroons")
+		return "", errors.Trace(err)
 	}
 
 	args := params.InitiateMigrationArgs{
@@ -281,4 +282,15 @@ func (c *Client) InitiateMigration(spec MigrationSpec) (string, error) {
 		return "", errors.Trace(result.Error)
 	}
 	return result.MigrationId, nil
+}
+
+func macaroonsToJSON(macs []macaroon.Slice) (string, error) {
+	if len(macs) == 0 {
+		return "", nil
+	}
+	out, err := json.Marshal(macs)
+	if err != nil {
+		return "", errors.Annotate(err, "marshalling macaroons")
+	}
+	return string(out), nil
 }

--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -4,6 +4,8 @@
 package migrationmaster
 
 import (
+	"encoding/json"
+
 	"github.com/juju/errors"
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
@@ -78,10 +80,9 @@ func (c *Client) MigrationStatus() (migration.MigrationStatus, error) {
 		return empty, errors.Annotatef(err, "unable to parse auth tag")
 	}
 
-	var mac *macaroon.Macaroon
-	if target.Macaroon != "" {
-		mac = new(macaroon.Macaroon)
-		if err := mac.UnmarshalJSON([]byte(target.Macaroon)); err != nil {
+	var macs []macaroon.Slice
+	if target.Macaroons != "" {
+		if err := json.Unmarshal([]byte(target.Macaroons), &macs); err != nil {
 			return empty, errors.Annotatef(err, "unmarshalling macaroon")
 		}
 	}
@@ -97,7 +98,7 @@ func (c *Client) MigrationStatus() (migration.MigrationStatus, error) {
 			CACert:        target.CACert,
 			AuthTag:       authTag,
 			Password:      target.Password,
-			Macaroon:      mac,
+			Macaroons:     macs,
 		},
 	}, nil
 }

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -4,6 +4,7 @@
 package migrationmaster_test
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/juju/errors"
@@ -64,7 +65,8 @@ func (s *ClientSuite) TestWatchCallError(c *gc.C) {
 func (s *ClientSuite) TestMigrationStatus(c *gc.C) {
 	mac, err := macaroon.New([]byte("secret"), "id", "location")
 	c.Assert(err, jc.ErrorIsNil)
-	macJSON, err := mac.MarshalJSON()
+	macs := []macaroon.Slice{{mac}}
+	macsJSON, err := json.Marshal(macs)
 	c.Assert(err, jc.ErrorIsNil)
 
 	modelUUID := utils.MustNewUUID().String()
@@ -81,7 +83,7 @@ func (s *ClientSuite) TestMigrationStatus(c *gc.C) {
 					CACert:        "cert",
 					AuthTag:       names.NewUserTag("admin").String(),
 					Password:      "secret",
-					Macaroon:      string(macJSON),
+					Macaroons:     string(macsJSON),
 				},
 			},
 			MigrationId:      "id",
@@ -105,7 +107,7 @@ func (s *ClientSuite) TestMigrationStatus(c *gc.C) {
 			CACert:        "cert",
 			AuthTag:       names.NewUserTag("admin"),
 			Password:      "secret",
-			Macaroon:      mac,
+			Macaroons:     macs,
 		},
 	})
 }

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -6,6 +6,7 @@
 package controller
 
 import (
+	"encoding/json"
 	"sort"
 
 	"github.com/juju/errors"
@@ -406,12 +407,10 @@ func (c *ControllerAPI) initiateOneMigration(spec params.MigrationSpec) (string,
 	if err != nil {
 		return "", errors.Annotate(err, "auth tag")
 	}
-	var mac *macaroon.Macaroon
-	if specTarget.Macaroon != "" {
-		mac = new(macaroon.Macaroon)
-		err := mac.UnmarshalJSON([]byte(specTarget.Macaroon))
-		if err != nil {
-			return "", errors.Annotate(err, "invalid macaroon")
+	var macs []macaroon.Slice
+	if specTarget.Macaroons != "" {
+		if err := json.Unmarshal([]byte(specTarget.Macaroons), &macs); err != nil {
+			return "", errors.Annotate(err, "invalid macaroons")
 		}
 	}
 	targetInfo := coremigration.TargetInfo{
@@ -420,7 +419,7 @@ func (c *ControllerAPI) initiateOneMigration(spec params.MigrationSpec) (string,
 		CACert:        specTarget.CACert,
 		AuthTag:       authTag,
 		Password:      specTarget.Password,
-		Macaroon:      mac,
+		Macaroons:     macs,
 	}
 
 	// Check if the migration is likely to succeed.
@@ -565,16 +564,13 @@ func makeModelInfo(st *state.State) (coremigration.ModelInfo, error) {
 }
 
 func targetToAPIInfo(ti coremigration.TargetInfo) *api.Info {
-	out := &api.Info{
-		Addrs:    ti.Addrs,
-		CACert:   ti.CACert,
-		Tag:      ti.AuthTag,
-		Password: ti.Password,
+	return &api.Info{
+		Addrs:     ti.Addrs,
+		CACert:    ti.CACert,
+		Tag:       ti.AuthTag,
+		Password:  ti.Password,
+		Macaroons: ti.Macaroons,
 	}
-	if ti.Macaroon != nil {
-		out.Macaroons = []macaroon.Slice{{ti.Macaroon}}
-	}
-	return out
 }
 
 func grantControllerAccess(accessor *state.State, targetUserTag, apiUser names.UserTag, access description.Access) error {

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -324,7 +324,6 @@ func (s *controllerSuite) TestInitiateMigration(c *gc.C) {
 					CACert:        "cert1",
 					AuthTag:       names.NewUserTag("admin1").String(),
 					Password:      "secret1",
-					Macaroons:     "null",
 				},
 			}, {
 				ModelTag: st2.ModelTag().String(),
@@ -370,10 +369,11 @@ func (s *controllerSuite) TestInitiateMigration(c *gc.C) {
 		c.Check(targetInfo.AuthTag.String(), gc.Equals, spec.TargetInfo.AuthTag)
 		c.Check(targetInfo.Password, gc.Equals, spec.TargetInfo.Password)
 
-		var macJSONdb []byte
-		macJSONdb, err = json.Marshal(targetInfo.Macaroons)
-		c.Assert(err, jc.ErrorIsNil)
-		c.Check(string(macJSONdb), gc.Equals, spec.TargetInfo.Macaroons)
+		if spec.TargetInfo.Macaroons != "" {
+			macJSONdb, err := json.Marshal(targetInfo.Macaroons)
+			c.Assert(err, jc.ErrorIsNil)
+			c.Check(string(macJSONdb), gc.Equals, spec.TargetInfo.Macaroons)
+		}
 	}
 }
 

--- a/apiserver/migrationmaster/facade.go
+++ b/apiserver/migrationmaster/facade.go
@@ -4,6 +4,8 @@
 package migrationmaster
 
 import (
+	"encoding/json"
+
 	"github.com/juju/errors"
 	"github.com/juju/utils"
 	"github.com/juju/utils/set"
@@ -75,25 +77,18 @@ func (api *API) MigrationStatus() (params.MasterMigrationStatus, error) {
 	if err != nil {
 		return empty, errors.Annotate(err, "retrieving model migration")
 	}
-
 	target, err := mig.TargetInfo()
 	if err != nil {
 		return empty, errors.Annotate(err, "retrieving target info")
 	}
-
 	phase, err := mig.Phase()
 	if err != nil {
 		return empty, errors.Annotate(err, "retrieving phase")
 	}
-
-	var macJSON []byte
-	if target.Macaroon != nil {
-		macJSON, err = target.Macaroon.MarshalJSON()
-		if err != nil {
-			return empty, errors.Annotate(err, "marshalling macaroon")
-		}
+	macsJSON, err := json.Marshal(target.Macaroons)
+	if err != nil {
+		return empty, errors.Annotate(err, "marshalling macaroons")
 	}
-
 	return params.MasterMigrationStatus{
 		Spec: params.MigrationSpec{
 			ModelTag: names.NewModelTag(mig.ModelUUID()).String(),
@@ -103,7 +98,7 @@ func (api *API) MigrationStatus() (params.MasterMigrationStatus, error) {
 				CACert:        target.CACert,
 				AuthTag:       target.AuthTag.String(),
 				Password:      target.Password,
-				Macaroon:      string(macJSON),
+				Macaroons:     string(macsJSON),
 			},
 		},
 		MigrationId:      mig.Id(),

--- a/apiserver/migrationmaster/facade_test.go
+++ b/apiserver/migrationmaster/facade_test.go
@@ -89,8 +89,8 @@ func (s *Suite) TestWatch(c *gc.C) {
 }
 
 func (s *Suite) TestMigrationStatus(c *gc.C) {
-	var expectedMacaroon = `
-{"caveats":[],"location":"location","identifier":"id","signature":"a9802bf274262733d6283a69c62805b5668dbf475bcd7edc25a962833f7c2cba"}`[1:]
+	var expectedMacaroons = `
+[[{"caveats":[],"location":"location","identifier":"id","signature":"a9802bf274262733d6283a69c62805b5668dbf475bcd7edc25a962833f7c2cba"}]]`[1:]
 
 	api := s.mustMakeAPI(c)
 	status, err := api.MigrationStatus()
@@ -105,7 +105,7 @@ func (s *Suite) TestMigrationStatus(c *gc.C) {
 				CACert:        "trust me",
 				AuthTag:       names.NewUserTag("admin").String(),
 				Password:      "secret",
-				Macaroon:      expectedMacaroon,
+				Macaroons:     expectedMacaroons,
 			},
 		},
 		MigrationId:      "id",
@@ -399,7 +399,7 @@ func (m *stubMigration) TargetInfo() (*coremigration.TargetInfo, error) {
 		CACert:        "trust me",
 		AuthTag:       names.NewUserTag("admin"),
 		Password:      "secret",
-		Macaroon:      mac,
+		Macaroons:     []macaroon.Slice{{mac}},
 	}, nil
 }
 

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -31,7 +31,7 @@ type MigrationTargetInfo struct {
 	CACert        string   `json:"ca-cert"`
 	AuthTag       string   `json:"auth-tag"`
 	Password      string   `json:"password,omitempty"`
-	Macaroon      string   `json:"macaroon,omitempty"`
+	Macaroons     string   `json:"macaroons,omitempty"`
 }
 
 // InitiateMigrationResults is used to return the result of one or

--- a/cmd/juju/commands/migrate.go
+++ b/cmd/juju/commands/migrate.go
@@ -6,6 +6,7 @@ package commands
 import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api/controller"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -103,6 +104,15 @@ func (c *migrateCommand) getMigrationSpec() (*controller.MigrationSpec, error) {
 		return nil, err
 	}
 
+	var macs []macaroon.Slice
+	if accountInfo.Macaroon != "" {
+		mac := new(macaroon.Macaroon)
+		if err := mac.UnmarshalJSON([]byte(accountInfo.Macaroon)); err != nil {
+			return nil, errors.Annotate(err, "unmarshalling macaroon")
+		}
+		macs = []macaroon.Slice{{mac}}
+	}
+
 	return &controller.MigrationSpec{
 		ModelUUID:            modelUUID,
 		TargetControllerUUID: controllerInfo.ControllerUUID,
@@ -110,7 +120,7 @@ func (c *migrateCommand) getMigrationSpec() (*controller.MigrationSpec, error) {
 		TargetCACert:         controllerInfo.CACert,
 		TargetUser:           accountInfo.User,
 		TargetPassword:       accountInfo.Password,
-		TargetMacaroon:       accountInfo.Macaroon,
+		TargetMacaroons:      macs,
 	}, nil
 }
 

--- a/core/migration/targetinfo.go
+++ b/core/migration/targetinfo.go
@@ -14,10 +14,10 @@ import (
 // TargetInfo holds the details required to connect to a
 // migration's target controller.
 //
-// TODO(mjs) - Note the similarity to api.Info. It would be nice
-// to be able to use api.Info here but state can't import api and
-// moving api.Info to live under the core package is too big a project
-// to be done right now.
+// TODO(mjs) - Note the similarity to api.Info. It would be nice to be
+// able to use api.Info here but state can't import api and moving
+// api.Info to live under the core package is too big a project to be
+// done right now.
 type TargetInfo struct {
 	// ControllerTag holds tag for the target controller.
 	ControllerTag names.ModelTag
@@ -37,9 +37,9 @@ type TargetInfo struct {
 	// Password holds the password to use with AuthTag.
 	Password string
 
-	// Macroon holds the macaroon to use with AuthTag. At least one of
-	// Password or Macaroon must be set.
-	Macaroon *macaroon.Macaroon
+	// Macaroons holds macaroons to use with AuthTag. At least one of
+	// Password or Macaroons must be set.
+	Macaroons []macaroon.Slice
 }
 
 // Validate returns an error if the TargetInfo contains bad data. Nil
@@ -67,8 +67,8 @@ func (info *TargetInfo) Validate() error {
 		return errors.NotValidf("empty AuthTag")
 	}
 
-	if info.Password == "" && info.Macaroon == nil {
-		return errors.NotValidf("missing Password & Macaroon")
+	if info.Password == "" && len(info.Macaroons) == 0 {
+		return errors.NotValidf("missing Password & Macaroons")
 	}
 
 	return nil

--- a/core/migration/targetinfo_test.go
+++ b/core/migration/targetinfo_test.go
@@ -63,12 +63,12 @@ func (s *TargetInfoSuite) TestValidation(c *gc.C) {
 		},
 		"empty AuthTag not valid",
 	}, {
-		"Password & Macaroon",
+		"Password & Macaroons",
 		func(info *migration.TargetInfo) {
 			info.Password = ""
-			info.Macaroon = nil
+			info.Macaroons = nil
 		},
-		"missing Password & Macaroon not valid",
+		"missing Password & Macaroons not valid",
 	}, {
 		"Success - empty Password",
 		func(info *migration.TargetInfo) {
@@ -76,9 +76,9 @@ func (s *TargetInfoSuite) TestValidation(c *gc.C) {
 		},
 		"",
 	}, {
-		"Success - empty Macaroon",
+		"Success - empty Macaroons",
 		func(info *migration.TargetInfo) {
-			info.Macaroon = nil
+			info.Macaroons = nil
 		},
 		"",
 	}, {
@@ -111,6 +111,6 @@ func makeValidTargetInfo(c *gc.C) migration.TargetInfo {
 		CACert:        "cert",
 		AuthTag:       names.NewUserTag("user"),
 		Password:      "password",
-		Macaroon:      mac,
+		Macaroons:     []macaroon.Slice{{mac}},
 	}
 }

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -674,6 +674,9 @@ func (st *State) CreateMigration(spec MigrationSpec) (ModelMigration, error) {
 }
 
 func macaroonsToJSON(m []macaroon.Slice) (string, error) {
+	if len(m) == 0 {
+		return "", nil
+	}
 	j, err := json.Marshal(m)
 	if err != nil {
 		return "", errors.Annotate(err, "marshalling macaroons")
@@ -682,6 +685,9 @@ func macaroonsToJSON(m []macaroon.Slice) (string, error) {
 }
 
 func jsonToMacaroons(raw string) ([]macaroon.Slice, error) {
+	if raw == "" {
+		return nil, nil
+	}
 	var macs []macaroon.Slice
 	if err := json.Unmarshal([]byte(raw), &macs); err != nil {
 		return nil, errors.Annotate(err, "unmarshalling macaroon")

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -56,7 +56,7 @@ func (s *MigrationSuite) SetUpTest(c *gc.C) {
 			CACert:        "cert",
 			AuthTag:       names.NewUserTag("user"),
 			Password:      "password",
-			Macaroon:      mac,
+			Macaroons:     []macaroon.Slice{{mac}},
 		},
 	}
 }

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils/clock"
 	"gopkg.in/juju/names.v2"
-	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/migrationtarget"
@@ -633,14 +632,12 @@ func (w *Worker) openAPIConn(targetInfo coremigration.TargetInfo) (api.Connectio
 
 func (w *Worker) openAPIConnForModel(targetInfo coremigration.TargetInfo, modelUUID string) (api.Connection, error) {
 	apiInfo := &api.Info{
-		Addrs:    targetInfo.Addrs,
-		CACert:   targetInfo.CACert,
-		Tag:      targetInfo.AuthTag,
-		Password: targetInfo.Password,
-		ModelTag: names.NewModelTag(modelUUID),
-	}
-	if targetInfo.Macaroon != nil {
-		apiInfo.Macaroons = []macaroon.Slice{{targetInfo.Macaroon}}
+		Addrs:     targetInfo.Addrs,
+		CACert:    targetInfo.CACert,
+		Tag:       targetInfo.AuthTag,
+		Password:  targetInfo.Password,
+		ModelTag:  names.NewModelTag(modelUUID),
+		Macaroons: targetInfo.Macaroons,
 	}
 
 	// Use zero DialOpts (no retries) because the worker must stay

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -711,8 +711,9 @@ func (s *Suite) TestAPIConnectWithMacaroon(c *gc.C) {
 	// Set up macaroon based auth to the target.
 	mac, err := macaroon.New([]byte("secret"), "id", "location")
 	c.Assert(err, jc.ErrorIsNil)
+	macs := []macaroon.Slice{{mac}}
 	s.masterFacade.status.TargetInfo.Password = ""
-	s.masterFacade.status.TargetInfo.Macaroon = mac
+	s.masterFacade.status.TargetInfo.Macaroons = macs
 
 	// Use ABORT because it involves an API connection to the target
 	// and is convenient.
@@ -735,7 +736,7 @@ func (s *Suite) TestAPIConnectWithMacaroon(c *gc.C) {
 						Addrs:     []string{"1.2.3.4:5"},
 						CACert:    "cert",
 						Tag:       names.NewUserTag("admin"),
-						Macaroons: []macaroon.Slice{{mac}}, // <----
+						Macaroons: macs, // <---
 					},
 					api.DialOpts{},
 				},


### PR DESCRIPTION
It is now possible to supply multiple macaroons for connecting to target controller. This is required for remote users where multiple macaroons might be available in the cookie jar.



(Review request: http://reviews.vapour.ws/r/5614/)