### PR TITLE
Remove local: prefix from personal clouds

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/gnuflag"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/common"
 )
 
 var usageAddCloudSummary = `
@@ -89,12 +90,23 @@ func (c *addCloudCommand) Run(ctxt *cmd.Context) error {
 	if !ok {
 		return errors.Errorf("cloud %q not found in file %q", c.Cloud, c.CloudFile)
 	}
+	publicClouds, _, err := cloud.PublicCloudMetadata()
+	if err != nil {
+		return err
+	}
+	if _, ok = publicClouds[c.Cloud]; ok && !c.Replace {
+		return errors.Errorf("%q is the name of a public cloud; use --replace to use your cloud definition instead", c.Cloud)
+	}
+	builtinClouds := common.BuiltInClouds()
+	if _, ok = builtinClouds[c.Cloud]; ok && !c.Replace {
+		return errors.Errorf("%q is the name of a built-in cloud; use --replace to use your cloud definition instead", c.Cloud)
+	}
 	personalClouds, err := cloud.PersonalCloudMetadata()
 	if err != nil {
 		return err
 	}
 	if _, ok = personalClouds[c.Cloud]; ok && !c.Replace {
-		return errors.Errorf("cloud called %q already exists; use --replace to replace this existing cloud", c.Cloud)
+		return errors.Errorf("%q already exists; use --replace to replace this existing cloud", c.Cloud)
 	}
 	if personalClouds == nil {
 		personalClouds = make(map[string]cloud.Cloud)

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -69,8 +69,6 @@ func (c *listCloudsCommand) SetFlags(f *gnuflag.FlagSet) {
 	})
 }
 
-const localPrefix = "local:"
-
 func (c *listCloudsCommand) Run(ctxt *cmd.Context) error {
 	details, err := listCloudDetails()
 	if err != nil {
@@ -146,10 +144,12 @@ func listCloudDetails() (*cloudList, error) {
 		return nil, err
 	}
 	for name, cloud := range personalClouds {
-		// Add to result with "local:" prefix.
 		cloudDetails := makeCloudDetails(cloud)
 		cloudDetails.Source = "local"
-		details.personal[localPrefix+name] = cloudDetails
+		details.personal[name] = cloudDetails
+		// Delete any built-in or public clouds with same name.
+		delete(details.builtin, name)
+		delete(details.public, name)
 	}
 
 	return details, nil

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -54,8 +54,30 @@ clouds:
 	out := testing.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
 	// Just check a snippet of the output to make sure it looks ok.
-	// local: clouds are last.
-	c.Assert(out, jc.Contains, `local:homestack  openstack   london`)
+	// local clouds are last.
+	// homestack should abut localhost and hence come last in the output.
+	c.Assert(out, jc.Contains, `localhosthomestack    openstack   london`)
+}
+
+func (s *listSuite) TestListPublicAndPersonalSameName(c *gc.C) {
+	data := `
+clouds:
+  aws:
+    type: ec2
+    auth-types: [access-key]
+    endpoint: http://custom
+`[1:]
+	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx, err := testing.RunCommand(c, cloud.NewListCloudsCommand(), "--format", "yaml")
+	c.Assert(err, jc.ErrorIsNil)
+	out := testing.Stdout(ctx)
+	out = strings.Replace(out, "\n", "", -1)
+	// Just check a snippet of the output to make sure it looks ok.
+	// local clouds are last.
+	c.Assert(out, gc.Not(gc.Matches), `.*aws:[ ]*defined: public[ ]*type: ec2[ ]*auth-types: \[access-key\].*`)
+	c.Assert(out, gc.Matches, `.*aws:[ ]*defined: local[ ]*type: ec2[ ]*auth-types: \[access-key\].*`)
 }
 
 func (s *listSuite) TestListYAML(c *gc.C) {

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -109,17 +109,6 @@ func (c *listCredentialsCommand) personalClouds() (map[string]jujucloud.Cloud, e
 	return c.personalCloudsFunc()
 }
 
-// displayCloudName returns the provided cloud name prefixed
-// with "local:" if it is a local cloud.
-func displayCloudName(cloudName string, personalCloudNames []string) string {
-	for _, name := range personalCloudNames {
-		if cloudName == name {
-			return localPrefix + cloudName
-		}
-	}
-	return cloudName
-}
-
 func (c *listCredentialsCommand) Run(ctxt *cmd.Context) error {
 	var credentials map[string]jujucloud.CloudCredential
 	credentials, err := c.store.AllCredentials()
@@ -151,7 +140,7 @@ func (c *listCredentialsCommand) Run(ctxt *cmd.Context) error {
 				return errors.Annotatef(err, "removing secrets from credentials for cloud %v", cloudName)
 			}
 		}
-		displayCredentials[displayCloudName(cloudName, personalCloudNames)] = cred
+		displayCredentials[cloudName] = cred
 	}
 	return c.out.Write(ctxt, credentialsMap{displayCredentials})
 }

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -107,11 +107,11 @@ func (s *listCredentialsSuite) SetUpTest(c *gc.C) {
 func (s *listCredentialsSuite) TestListCredentialsTabular(c *gc.C) {
 	out := s.listCredentials(c)
 	c.Assert(out, gc.Equals, `
-CLOUD          CREDENTIALS
-aws            down*, bob
-azure          azhja
-google         default
-local:mycloud  me
+CLOUD    CREDENTIALS
+aws      down*, bob
+azure    azhja
+google   default
+mycloud  me
 
 `[1:])
 }
@@ -153,7 +153,7 @@ credentials:
       client-email: email
       client-id: id
       private-key: key
-  local:mycloud:
+  mycloud:
     me:
       auth-type: access-key
       access-key: key
@@ -185,7 +185,7 @@ credentials:
       auth-type: oauth2
       client-email: email
       client-id: id
-  local:mycloud:
+  mycloud:
     me:
       auth-type: access-key
       access-key: key

--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -55,7 +55,7 @@ clouds:
 `[1:]
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 
-	ctx, err := testing.RunCommand(c, cloud.NewShowCloudCommand(), "local:homestack")
+	ctx, err := testing.RunCommand(c, cloud.NewShowCloudCommand(), "homestack")
 	c.Assert(err, jc.ErrorIsNil)
 	out := testing.Stdout(ctx)
 	c.Assert(out, gc.Equals, `
@@ -87,7 +87,7 @@ clouds:
 `[1:]
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 
-	ctx, err := testing.RunCommand(c, cloud.NewShowCloudCommand(), "local:homestack")
+	ctx, err := testing.RunCommand(c, cloud.NewShowCloudCommand(), "homestack")
 	c.Assert(err, jc.ErrorIsNil)
 	out := testing.Stdout(ctx)
 	c.Assert(out, gc.Equals, `


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju/+bug/1600063

We retain grouping of clouds when listing, but personal clouds no longer have the local: prefix.
When adding a cloud, if the name would overwrite a public or built in cloud, a warning is printed and --replace is required.
When listing clouds, if a personal cloud is defined with the same name as a public cloud, the public cloud is omitted from the output since the personal cloud takes precedence.

(Review request: http://reviews.vapour.ws/r/5615/)