### PR TITLE
Introduce juju_userpass httpbakery.Visitor

### DIFF
--- a/api/authentication/package_test.go
+++ b/api/authentication/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package authentication_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/api/authentication/visitor.go
+++ b/api/authentication/visitor.go
@@ -1,0 +1,64 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package authentication
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"github.com/juju/errors"
+
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
+)
+
+const authMethod = "juju_userpass"
+
+// Visitor is a httpbakery.Visitor that will login directly
+// to the Juju controller using password authentication. This
+// only applies when logging in as a local user.
+type Visitor struct {
+	username    string
+	getPassword func(string) (string, error)
+}
+
+// NewVisitor returns a new Visitor.
+func NewVisitor(username string, getPassword func(string) (string, error)) *Visitor {
+	return &Visitor{
+		username:    username,
+		getPassword: getPassword,
+	}
+}
+
+// VisitWebPage is part of the httpbakery.Visitor interface.
+func (v *Visitor) VisitWebPage(client *httpbakery.Client, methodURLs map[string]*url.URL) error {
+	methodURL := methodURLs[authMethod]
+	if methodURL == nil {
+		return httpbakery.ErrMethodNotSupported
+	}
+
+	password, err := v.getPassword(v.username)
+	if err != nil {
+		return err
+	}
+
+	// POST to the URL with username and password.
+	resp, err := client.PostForm(methodURL.String(), url.Values{
+		"user":     {v.username},
+		"password": {password},
+	})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+	var jsonError httpbakery.Error
+	if err := json.NewDecoder(resp.Body).Decode(&jsonError); err != nil {
+		return errors.Annotate(err, "unmarshalling error")
+	}
+	return &jsonError
+}

--- a/api/authentication/visitor_test.go
+++ b/api/authentication/visitor_test.go
@@ -1,0 +1,88 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package authentication_test
+
+import (
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+
+	"github.com/juju/juju/api/authentication"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
+)
+
+type VisitorSuite struct {
+	testing.IsolationSuite
+
+	jar     *cookiejar.Jar
+	client  *httpbakery.Client
+	server  *httptest.Server
+	handler http.Handler
+}
+
+var _ = gc.Suite(&VisitorSuite{})
+
+func (s *VisitorSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	var err error
+	s.jar, err = cookiejar.New(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.client = httpbakery.NewClient()
+	s.client.Jar = s.jar
+	s.handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.handler.ServeHTTP(w, r)
+	}))
+	s.AddCleanup(func(c *gc.C) { s.server.Close() })
+}
+
+func (s *VisitorSuite) TestVisitWebPage(c *gc.C) {
+	v := authentication.NewVisitor("bob", func(username string) (string, error) {
+		c.Assert(username, gc.Equals, "bob")
+		return "hunter2", nil
+	})
+	var formUser, formPassword string
+	s.handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		formUser = r.Form.Get("user")
+		formPassword = r.Form.Get("password")
+	})
+	err := v.VisitWebPage(s.client, map[string]*url.URL{
+		"juju_userpass": mustParseURL(s.server.URL),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(formUser, gc.Equals, "bob")
+	c.Assert(formPassword, gc.Equals, "hunter2")
+}
+
+func (s *VisitorSuite) TestVisitWebPageMethodNotSupported(c *gc.C) {
+	v := authentication.NewVisitor("bob", nil)
+	err := v.VisitWebPage(s.client, map[string]*url.URL{})
+	c.Assert(err, gc.Equals, httpbakery.ErrMethodNotSupported)
+}
+
+func (s *VisitorSuite) TestVisitWebPageErrorResult(c *gc.C) {
+	v := authentication.NewVisitor("bob", func(username string) (string, error) {
+		return "hunter2", nil
+	})
+	s.handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"Message":"bleh"}`, http.StatusInternalServerError)
+	})
+	err := v.VisitWebPage(s.client, map[string]*url.URL{
+		"juju_userpass": mustParseURL(s.server.URL),
+	})
+	c.Assert(err, gc.ErrorMatches, "bleh")
+}
+
+func mustParseURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}

--- a/api/interface.go
+++ b/api/interface.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"net/url"
 	"time"
 
 	"github.com/juju/errors"
@@ -196,6 +197,10 @@ type Connection interface {
 
 	// ControllerAccess returns the access level of authorized user to the controller.
 	ControllerAccess() string
+
+	// CookieURL returns the URL that HTTP cookies for the API will be
+	// associated with.
+	CookieURL() *url.URL
 
 	// These methods expose a bunch of worker-specific facades, and basically
 	// just should not exist; but removing them is too noisy for a single CL.

--- a/cmd/modelcmd/apicontext.go
+++ b/cmd/modelcmd/apicontext.go
@@ -20,8 +20,8 @@ import (
 // APIContext holds the context required for making connections to
 // APIs used by juju.
 type APIContext struct {
-	Jar          *cookiejar.Jar
-	BakeryClient *httpbakery.Client
+	Jar            *cookiejar.Jar
+	WebPageVisitor httpbakery.Visitor
 }
 
 // AuthOpts holds flags relating to authentication.
@@ -52,10 +52,7 @@ func NewAPIContext(ctxt *cmd.Context, opts *AuthOpts) (*APIContext, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	client := httpbakery.NewClient()
-	client.Jar = jar
 	var visitors []httpbakery.Visitor
-
 	if ctxt != nil && opts != nil && opts.NoBrowser {
 		filler := &form.IOFiller{
 			In:  ctxt.Stdin,
@@ -65,11 +62,20 @@ func NewAPIContext(ctxt *cmd.Context, opts *AuthOpts) (*APIContext, error) {
 	} else {
 		visitors = append(visitors, httpbakery.WebBrowserVisitor)
 	}
-	client.WebPageVisitor = httpbakery.NewMultiVisitor(visitors...)
+	webPageVisitor := httpbakery.NewMultiVisitor(visitors...)
 	return &APIContext{
-		Jar:          jar,
-		BakeryClient: client,
+		Jar:            jar,
+		WebPageVisitor: webPageVisitor,
 	}, nil
+}
+
+// NewBakeryClient returns a new httpbakery.Client, using the API context's
+// persistent cookie jar and web page visitor.
+func (ctx *APIContext) NewBakeryClient() *httpbakery.Client {
+	client := httpbakery.NewClient()
+	client.Jar = ctx.Jar
+	client.WebPageVisitor = ctx.WebPageVisitor
+	return client
 }
 
 // cookieFile returns the path to the cookie used to store authorization

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -4,16 +4,21 @@
 package modelcmd
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"golang.org/x/crypto/ssh/terminal"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/authentication"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/apiserver/params"
@@ -158,13 +163,29 @@ func (c *JujuCommandBase) NewAPIConnectionParams(
 	controllerName, modelName string,
 	accountDetails *jujuclient.AccountDetails,
 ) (juju.NewAPIConnectionParams, error) {
-	if err := c.initAPIContext(); err != nil {
+	bakeryClient, err := c.BakeryClient()
+	if err != nil {
 		return juju.NewAPIConnectionParams{}, errors.Trace(err)
 	}
+	var getPassword func(username string) (string, error)
+	if c.cmdContext != nil {
+		getPassword = func(username string) (string, error) {
+			fmt.Fprintf(c.cmdContext.Stderr, "please enter password for %s on %s: ", username, controllerName)
+			defer fmt.Fprintln(c.cmdContext.Stderr)
+			return readPassword(c.cmdContext.Stdin)
+		}
+	} else {
+		getPassword = func(username string) (string, error) {
+			return "", errors.New("no context to prompt for password")
+		}
+	}
+
 	return newAPIConnectionParams(
 		store, controllerName, modelName,
-		accountDetails, c.apiContext.BakeryClient,
+		accountDetails,
+		bakeryClient,
 		c.apiOpen,
+		getPassword,
 	)
 }
 
@@ -174,10 +195,11 @@ func (c *JujuCommandBase) NewAPIConnectionParams(
 // have the correct TLS setup - use api.Connection.HTTPClient
 // for that.
 func (c *JujuCommandBase) HTTPClient() (*http.Client, error) {
-	if err := c.initAPIContext(); err != nil {
+	bakeryClient, err := c.BakeryClient()
+	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return c.apiContext.BakeryClient.Client, nil
+	return bakeryClient.Client, nil
 }
 
 // BakeryClient returns a macaroon bakery client that
@@ -186,7 +208,7 @@ func (c *JujuCommandBase) BakeryClient() (*httpbakery.Client, error) {
 	if err := c.initAPIContext(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	return c.apiContext.BakeryClient, nil
+	return c.apiContext.NewBakeryClient(), nil
 }
 
 // APIOpen establishes a connection to the API server using the
@@ -303,6 +325,7 @@ func newAPIConnectionParams(
 	accountDetails *jujuclient.AccountDetails,
 	bakery *httpbakery.Client,
 	apiOpen api.OpenFunc,
+	getPassword func(string) (string, error),
 ) (juju.NewAPIConnectionParams, error) {
 	if controllerName == "" {
 		return juju.NewAPIConnectionParams{}, errors.Trace(errNoNameSpecified)
@@ -318,31 +341,10 @@ func newAPIConnectionParams(
 	dialOpts := api.DefaultDialOpts()
 	dialOpts.BakeryClient = bakery
 
-	openAPI := func(info *api.Info, opts api.DialOpts) (api.Connection, error) {
-		conn, err := apiOpen(info, opts)
-		if err != nil {
-			userTag, ok := info.Tag.(names.UserTag)
-			if ok && userTag.IsLocal() && params.IsCodeLoginExpired(err) {
-				// This is a bit gross, but we don't seem to have
-				// a way of having an error with a cause that does
-				// not influence the error message. We want to keep
-				// the type/code so we don't lose the fact that the
-				// error was caused by an API login expiry.
-				return nil, &params.Error{
-					Code: params.CodeLoginExpired,
-					Message: fmt.Sprintf(`login expired
-
-Your login for the %q controller has expired.
-To log back in, run the following command:
-
-    juju login %v
-`, controllerName, userTag.Name()),
-				}
-			}
-			return nil, err
-		}
-		return conn, nil
-	}
+	bakery.WebPageVisitor = httpbakery.NewMultiVisitor(
+		authentication.NewVisitor(accountDetails.User, getPassword),
+		bakery.WebPageVisitor,
+	)
 
 	return juju.NewAPIConnectionParams{
 		Store:          store,
@@ -350,7 +352,7 @@ To log back in, run the following command:
 		AccountDetails: accountDetails,
 		ModelUUID:      modelUUID,
 		DialOpts:       dialOpts,
-		OpenAPI:        openAPI,
+		OpenAPI:        apiOpen,
 	}, nil
 }
 
@@ -442,4 +444,32 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 		},
 		cfg,
 	}, nil
+}
+
+// TODO(axw) this is now in three places: change-password,
+// register, and here. Refactor and move to a common location.
+func readPassword(stdin io.Reader) (string, error) {
+	if f, ok := stdin.(*os.File); ok && terminal.IsTerminal(int(f.Fd())) {
+		password, err := terminal.ReadPassword(int(f.Fd()))
+		return string(password), err
+	}
+	return readLine(stdin)
+}
+
+func readLine(stdin io.Reader) (string, error) {
+	// Read one byte at a time to avoid reading beyond the delimiter.
+	line, err := bufio.NewReader(byteAtATimeReader{stdin}).ReadString('\n')
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return line[:len(line)-1], nil
+}
+
+type byteAtATimeReader struct {
+	io.Reader
+}
+
+// Read is part of the io.Reader interface.
+func (r byteAtATimeReader) Read(out []byte) (int, error) {
+	return r.Reader.Read(out[:1])
 }

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -44,23 +44,6 @@ func (s *BaseCommandSuite) SetUpTest(c *gc.C) {
 	}
 }
 
-func (s *BaseCommandSuite) TestLoginExpiry(c *gc.C) {
-	apiOpen := func(*api.Info, api.DialOpts) (api.Connection, error) {
-		return nil, &params.Error{Code: params.CodeLoginExpired, Message: "meep"}
-	}
-	var cmd modelcmd.JujuCommandBase
-	cmd.SetAPIOpen(apiOpen)
-	conn, err := cmd.NewAPIRoot(s.store, "foo", "")
-	c.Assert(conn, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, `login expired
-
-Your login for the "foo" controller has expired.
-To log back in, run the following command:
-
-    juju login bar
-`)
-}
-
 func (s *BaseCommandSuite) assertUnknownModel(c *gc.C, current, expectedCurrent string) {
 	s.store.Models["foo"].CurrentModel = current
 	apiOpen := func(*api.Info, api.DialOpts) (api.Connection, error) {

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -345,11 +345,6 @@ func BootstrapContextNoVerify(cmdContext *cmd.Context) environs.BootstrapContext
 	}
 }
 
-type ModelGetter interface {
-	ModelGet() (map[string]interface{}, error)
-	Close() error
-}
-
 // SplitModelName splits a model name into its controller
 // and model parts. If the model is unqualified, then the
 // returned controller string will be empty, and the returned

--- a/resource/cmd/list_charm_resources.go
+++ b/resource/cmd/list_charm_resources.go
@@ -127,12 +127,11 @@ func (c *ListCharmResourcesCommand) Run(ctx *cmd.Context) error {
 // ListCharmResources implements CharmResourceLister by getting the charmstore client
 // from the command's ModelCommandBase.
 func (c *ListCharmResourcesCommand) ListResources(ids []charmstore.CharmID) ([][]charmresource.Resource, error) {
-	apiContext, err := c.APIContext()
+	bakeryClient, err := c.BakeryClient()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	// We use the default for URL.
-	client, err := charmstore.NewCustomClient(apiContext.BakeryClient, nil)
+	client, err := charmstore.NewCustomClient(bakeryClient, nil)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
We introduce an implementation of httpbakery.Visitor
which will handle the juju_userpass authentication
method. There is no server-side implementation yet;
that will be introduced in a following patch.

(Review request: http://reviews.vapour.ws/r/5617/)