### PR TITLE
apiserver: pass server address to auth context

### DIFF
--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -32,7 +32,7 @@ var (
 )
 
 func ServerMacaroon(srv *Server) (*macaroon.Macaroon, error) {
-	auth, err := srv.authCtxt.macaroonAuth()
+	auth, err := srv.authCtxt.externalMacaroonAuth()
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func ServerMacaroon(srv *Server) (*macaroon.Macaroon, error) {
 }
 
 func ServerBakeryService(srv *Server) (authentication.BakeryService, error) {
-	auth, err := srv.authCtxt.macaroonAuth()
+	auth, err := srv.authCtxt.externalMacaroonAuth()
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func ServerBakeryService(srv *Server) (authentication.BakeryService, error) {
 // ServerAuthenticatorForTag calls the authenticatorForTag method
 // of the server's authContext.
 func ServerAuthenticatorForTag(srv *Server, tag names.Tag) (authentication.EntityAuthenticator, error) {
-	return srv.authCtxt.authenticatorForTag(tag)
+	return srv.authCtxt.authenticator("testing.invalid:1234").authenticatorForTag(tag)
 }
 
 func APIHandlerWithEntity(entity state.Entity) *apiHandler {
@@ -98,7 +98,7 @@ func TestingAPIHandler(c *gc.C, srvSt, st *state.State) (*apiHandler, *common.Re
 		state:    srvSt,
 		tag:      names.NewMachineTag("0"),
 	}
-	h, err := newAPIHandler(srv, st, nil, st.ModelUUID())
+	h, err := newAPIHandler(srv, st, nil, st.ModelUUID(), "testing.invalid:1234")
 	c.Assert(err, jc.ErrorIsNil)
 	return h, h.getResources()
 }

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -62,7 +62,8 @@ func (ctxt *httpContext) stateForRequestAuthenticated(r *http.Request) (*state.S
 	if err != nil {
 		return nil, nil, errors.NewUnauthorized(err, "")
 	}
-	entity, _, err := checkCreds(st, req, true, ctxt.srv.authCtxt)
+	authenticator := ctxt.srv.authCtxt.authenticator(r.Host)
+	entity, _, err := checkCreds(st, req, true, authenticator)
 	if err != nil {
 		if common.IsDischargeRequiredError(err) {
 			return nil, nil, errors.Trace(err)
@@ -71,7 +72,7 @@ func (ctxt *httpContext) stateForRequestAuthenticated(r *http.Request) (*state.S
 		// Handle the special case of a worker on a controller machine
 		// acting on behalf of a hosted model.
 		if isMachineTag(req.AuthTag) {
-			entity, err := checkControllerMachineCreds(ctxt.srv.state, req, ctxt.srv.authCtxt)
+			entity, err := checkControllerMachineCreds(ctxt.srv.state, req, authenticator)
 			if err != nil {
 				return nil, nil, errors.NewUnauthorized(err, "")
 			}

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -48,22 +48,28 @@ type apiHandler struct {
 	rpcConn   *rpc.Conn
 	resources *common.Resources
 	entity    state.Entity
+
 	// An empty modelUUID means that the user has logged in through the
 	// root of the API server rather than the /model/:model-uuid/api
 	// path, logins processed with v2 or later will only offer the
 	// user manager and model manager api endpoints from here.
 	modelUUID string
+
+	// serverHost is the host:port of the API server that the client
+	// connected to.
+	serverHost string
 }
 
 var _ = (*apiHandler)(nil)
 
 // newAPIHandler returns a new apiHandler.
-func newAPIHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID string) (*apiHandler, error) {
+func newAPIHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID string, serverHost string) (*apiHandler, error) {
 	r := &apiHandler{
-		state:     st,
-		resources: common.NewResources(),
-		rpcConn:   rpcConn,
-		modelUUID: modelUUID,
+		state:      st,
+		resources:  common.NewResources(),
+		rpcConn:    rpcConn,
+		modelUUID:  modelUUID,
+		serverHost: serverHost,
 	}
 	if err := r.resources.RegisterNamed("machineID", common.StringResource(srv.tag.Id())); err != nil {
 		return nil, errors.Trace(err)
@@ -75,7 +81,11 @@ func newAPIHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID st
 		return nil, errors.Trace(err)
 	}
 	if err := r.resources.RegisterNamed("createLocalLoginMacaroon", common.ValueResource{
-		srv.authCtxt.userAuth.CreateLocalLoginMacaroon,
+		// NOTE(axw) the string we pass in at the moment is
+		// unimportant, as it is not used in the branch. In
+		// the next branch, we won't need to register this
+		// resource.
+		srv.authCtxt.authenticator("").localUserAuth().CreateLocalLoginMacaroon,
 	}); err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
When a client connects, we record the Host value from the HTTP request, and
pass it through to the auth context. This will be used in a following
patch, as the Location field of a third-party caveat for local users.