### PR TITLE
Overhaul local login macaroon auth

### DIFF
--- a/api/state_test.go
+++ b/api/state_test.go
@@ -98,19 +98,6 @@ func (s *stateSuite) TestTags(c *gc.C) {
 	c.Check(controllerTag, gc.Equals, coretesting.ControllerTag)
 }
 
-func (s *stateSuite) TestLoginMacaroon(c *gc.C) {
-	apistate, tag, _ := s.OpenAPIWithoutLogin(c)
-	defer apistate.Close()
-	// Use a different API connection, because we can't get at UserManager without logging in.
-	loggedInAPI := s.OpenControllerAPI(c)
-	defer loggedInAPI.Close()
-	mac, err := usermanager.NewClient(loggedInAPI).CreateLocalLoginMacaroon(tag.(names.UserTag))
-	c.Assert(err, jc.ErrorIsNil)
-	err = apistate.Login(tag, "", "", []macaroon.Slice{{mac}})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(apistate.AuthTag(), gc.Equals, tag)
-}
-
 func (s *stateSuite) TestLoginSetsModelAccess(c *gc.C) {
 	// The default user has admin access.
 	c.Assert(s.APIState.ModelAccess(), gc.Equals, "admin")
@@ -153,19 +140,7 @@ func (s *stateSuite) TestLoginMacaroonInvalidId(c *gc.C) {
 	mac, err := macaroon.New([]byte("root-key"), "id", "juju")
 	c.Assert(err, jc.ErrorIsNil)
 	err = apistate.Login(tag, "", "", []macaroon.Slice{{mac}})
-	c.Assert(err, gc.ErrorMatches, "invalid entity name or password \\(unauthorized access\\)")
-}
-
-func (s *stateSuite) TestLoginMacaroonInvalidUser(c *gc.C) {
-	apistate, tag, _ := s.OpenAPIWithoutLogin(c)
-	defer apistate.Close()
-	// Use a different API connection, because we can't get at UserManager without logging in.
-	loggedInAPI := s.OpenControllerAPI(c)
-	defer loggedInAPI.Close()
-	mac, err := usermanager.NewClient(loggedInAPI).CreateLocalLoginMacaroon(tag.(names.UserTag))
-	c.Assert(err, jc.ErrorIsNil)
-	err = apistate.Login(names.NewUserTag("bob@local"), "", "", []macaroon.Slice{{mac}})
-	c.Assert(err, gc.ErrorMatches, "invalid entity name or password \\(unauthorized access\\)")
+	c.Assert(err, gc.ErrorMatches, "interaction required but not possible")
 }
 
 func (s *stateSuite) TestLoginTracksFacadeVersions(c *gc.C) {

--- a/api/usermanager/client.go
+++ b/api/usermanager/client.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/macaroon.v1"
-
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"gopkg.in/juju/names.v2"
@@ -181,23 +179,4 @@ func (c *Client) SetPassword(username, password string) error {
 		return err
 	}
 	return results.OneError()
-}
-
-// CreateLocalLoginMacaroon creates a local login macaroon for the
-// authenticated user.
-func (c *Client) CreateLocalLoginMacaroon(tag names.UserTag) (*macaroon.Macaroon, error) {
-	args := params.Entities{Entities: []params.Entity{{tag.String()}}}
-	var results params.MacaroonResults
-	if err := c.facade.FacadeCall("CreateLocalLoginMacaroon", args, &results); err != nil {
-		return nil, errors.Trace(err)
-	}
-	if n := len(results.Results); n != 1 {
-		logger.Errorf("expected 1 result, got %#v", results)
-		return nil, errors.Errorf("expected 1 result, got %d", n)
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return nil, errors.Trace(result.Error)
-	}
-	return result.Result, nil
 }

--- a/apiserver/authentication/user.go
+++ b/apiserver/authentication/user.go
@@ -4,6 +4,7 @@
 package authentication
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/juju/errors"
@@ -12,6 +13,7 @@ import (
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/bakery"
 	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/apiserver/common"
@@ -30,6 +32,12 @@ type UserAuthenticator struct {
 
 	// Clock is used to calculate the expiry time for macaroons.
 	Clock clock.Clock
+
+	// LocalUserIdentityLocation holds the URL of the trusted third party
+	// that is used to address the is-authenticated-user third party caveat
+	// to for local users. This always points at the same controller
+	// agent that is servicing the authorisation request.
+	LocalUserIdentityLocation string
 }
 
 const (
@@ -69,40 +77,75 @@ func (u *UserAuthenticator) Authenticate(
 	return u.AgentAuthenticator.Authenticate(entityFinder, tag, req)
 }
 
-// CreateLocalLoginMacaroon creates a time-limited macaroon for a local user
-// to log into the controller with. The macaroon will be valid for use with
-// UserAuthenticator.Authenticate until the time limit expires, or the Juju
-// controller agent restarts.
-//
-// NOTE(axw) this method will generate a key for a previously unseen user,
-// and store it in the bakery.Service's storage. Callers should first ensure
-// the user is valid before calling this, to avoid filling storage with keys
-// for invalid users.
-func (u *UserAuthenticator) CreateLocalLoginMacaroon(tag names.UserTag) (*macaroon.Macaroon, error) {
-
-	// Ensure that the private key that we generate and store will be
-	// removed from storage once the expiry time has elapsed.
-	expiryTime := u.Clock.Now().Add(localLoginExpiryTime)
-	bakeryService, err := u.Service.ExpireStorageAt(expiryTime)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
+// CreateLocalLoginMacaroon creates a macaroon that may be provided to a
+// user as proof that they have logged in with a valid username and password.
+// This macaroon may then be used to obtain a discharge macaroon so that
+// the user can log in without presenting their password for a set amount
+// of time.
+func CreateLocalLoginMacaroon(
+	tag names.UserTag,
+	service BakeryService,
+	clock clock.Clock,
+) (*macaroon.Macaroon, error) {
 	// We create the macaroon with a random ID and random root key, which
 	// enables multiple clients to login as the same user and obtain separate
 	// macaroons without having them use the same root key.
-	m, err := bakeryService.NewMacaroon("", nil, []checkers.Caveat{
-		// The macaroon may only be used to log in as the user
-		// specified by the tag passed to CreateLocalUserMacaroon.
-		checkers.DeclaredCaveat(usernameKey, tag.Canonical()),
+	return service.NewMacaroon("", nil, []checkers.Caveat{
+		{Condition: "is-authenticated-user " + tag.Canonical()},
+		checkers.TimeBeforeCaveat(clock.Now().Add(LocalLoginInteractionTimeout)),
+	})
+}
+
+// CheckLocalLoginCaveat parses and checks that the given caveat string is
+// valid for a local login request, and returns the tag of the local user
+// that the caveat asserts is logged in. checkers.ErrCaveatNotRecognized will
+// be returned if the caveat is not recognised.
+func CheckLocalLoginCaveat(caveat string) (names.UserTag, error) {
+	var tag names.UserTag
+	op, rest, err := checkers.ParseCaveat(caveat)
+	if err != nil {
+		return tag, errors.Annotatef(err, "cannot parse caveat %q", caveat)
+	}
+	if op != "is-authenticated-user" {
+		return tag, checkers.ErrCaveatNotRecognized
+	}
+	if !names.IsValidUser(rest) {
+		return tag, errors.NotValidf("username %q", rest)
+	}
+	tag = names.NewUserTag(rest)
+	if !tag.IsLocal() {
+		tag = names.UserTag{}
+		return tag, errors.NotValidf("non-local username %q", rest)
+	}
+	return tag, nil
+}
+
+// CheckLocalLoginRequest checks that the given HTTP request contains at least
+// one valid local login macaroon minted by the given service using
+// CreateLocalLoginMacaroon. It returns an error with a
+// *bakery.VerificationError cause if the macaroon verification failed. If the
+// macaroon is valid, CheckLocalLoginRequest returns a list of caveats to add
+// to the discharge macaroon.
+func CheckLocalLoginRequest(
+	service *bakery.Service,
+	req *http.Request,
+	tag names.UserTag,
+	clock clock.Clock,
+) ([]checkers.Caveat, error) {
+	_, err := httpbakery.CheckRequest(service, req, nil, checkers.CheckerFunc{
+		// Having a macaroon with an is-authenticated-user
+		// caveat is proof that the user is "logged in".
+		"is-authenticated-user",
+		func(cond, arg string) error { return nil },
 	})
 	if err != nil {
-		return nil, errors.Annotate(err, "cannot create macaroon")
-	}
-	if err := addMacaroonTimeBeforeCaveat(bakeryService, m, expiryTime); err != nil {
 		return nil, errors.Trace(err)
 	}
-	return m, nil
+	firstPartyCaveats := []checkers.Caveat{
+		checkers.DeclaredCaveat("username", tag.Canonical()),
+		checkers.TimeBeforeCaveat(clock.Now().Add(localLoginExpiryTime)),
+	}
+	return firstPartyCaveats, nil
 }
 
 func (u *UserAuthenticator) authenticateMacaroons(
@@ -112,11 +155,37 @@ func (u *UserAuthenticator) authenticateMacaroons(
 	assert := map[string]string{usernameKey: tag.Canonical()}
 	_, err := u.Service.CheckAny(req.Macaroons, assert, checkers.New(checkers.TimeBefore))
 	if err != nil {
-		logger.Debugf("local-login macaroon authentication failed: %v", err)
-		if allMacaroonsExpired(u.Clock.Now(), req.Macaroons) {
-			return nil, common.ErrLoginExpired
+		cause := err
+		logger.Debugf("local-login macaroon authentication failed: %v", cause)
+		if _, ok := errors.Cause(err).(*bakery.VerificationError); !ok {
+			return nil, errors.Trace(err)
 		}
-		return nil, errors.Trace(common.ErrBadCreds)
+
+		// The root keys for these macaroons are stored in MongoDB.
+		// Expire the documents after after a set amount of time.
+		expiryTime := u.Clock.Now().Add(localLoginExpiryTime)
+		service, err := u.Service.ExpireStorageAt(expiryTime)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		m, err := service.NewMacaroon("", nil, []checkers.Caveat{
+			checkers.NeedDeclaredCaveat(
+				checkers.Caveat{
+					Location:  u.LocalUserIdentityLocation,
+					Condition: "is-authenticated-user " + tag.Canonical(),
+				},
+				usernameKey,
+			),
+			checkers.TimeBeforeCaveat(expiryTime),
+		})
+		if err != nil {
+			return nil, errors.Annotate(err, "cannot create macaroon")
+		}
+		return nil, &common.DischargeRequiredError{
+			Cause:    cause,
+			Macaroon: m,
+		}
 	}
 	entity, err := entityFinder.FindEntity(tag)
 	if errors.IsNotFound(err) {
@@ -126,41 +195,6 @@ func (u *UserAuthenticator) authenticateMacaroons(
 		return nil, errors.Trace(err)
 	}
 	return entity, nil
-}
-
-// allMacaroonsExpired reports whether or not all of the macaroon
-// slices' primary macaroons have expired.
-func allMacaroonsExpired(now time.Time, ms []macaroon.Slice) bool {
-	for _, ms := range ms {
-		if len(ms) == 0 {
-			continue
-		}
-		m := ms[0]
-		var expired bool
-		for _, c := range m.Caveats() {
-			if c.Location != "" {
-				continue
-			}
-			cond, arg, err := checkers.ParseCaveat(c.Id)
-			if err != nil {
-				continue
-			}
-			if cond != checkers.CondTimeBefore {
-				continue
-			}
-			t, err := time.Parse(time.RFC3339Nano, arg)
-			if err != nil {
-				return false
-			}
-			if !now.Before(t) {
-				expired = true
-			}
-		}
-		if !expired {
-			return false
-		}
-	}
-	return true
 }
 
 // ExternalMacaroonAuthenticator performs authentication for external users using

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -353,6 +353,7 @@ func (s *controllerSuite) TestInitiateMigration(c *gc.C) {
 					CACert:        "cert2",
 					AuthTag:       names.NewUserTag("admin2").String(),
 					Macaroons:     string(macsJSON),
+					Password:      "secret2",
 				},
 				ExternalControl: true,
 			},

--- a/apiserver/locallogin.go
+++ b/apiserver/locallogin.go
@@ -1,0 +1,190 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"net/http"
+
+	"github.com/juju/errors"
+	"github.com/juju/httprequest"
+	"github.com/julienschmidt/httprouter"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	macaroon "gopkg.in/macaroon.v1"
+
+	"github.com/juju/juju/apiserver/authentication"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+var (
+	errorMapper httprequest.ErrorMapper = httpbakery.ErrorToResponse
+	handleJSON                          = errorMapper.HandleJSON
+)
+
+func makeHandler(h httprouter.Handle) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		h(w, req, nil)
+	})
+}
+
+type localLoginHandlers struct {
+	authCtxt *authContext
+	state    *state.State
+}
+
+func (h *localLoginHandlers) serveLogin(p httprequest.Params) (interface{}, error) {
+	switch p.Request.Method {
+	case "POST":
+		return h.serveLoginPost(p)
+	case "GET":
+		return h.serveLoginGet(p)
+	default:
+		return nil, errors.Errorf("unsupported method %q", p.Request.Method)
+	}
+}
+
+func (h *localLoginHandlers) serveLoginPost(p httprequest.Params) (interface{}, error) {
+	if err := p.Request.ParseForm(); err != nil {
+		return nil, err
+	}
+	waitId := p.Request.Form.Get("waitid")
+	if waitId == "" {
+		return nil, errors.NotValidf("missing waitid")
+	}
+	username := p.Request.Form.Get("user")
+	password := p.Request.Form.Get("password")
+	if !names.IsValidUser(username) {
+		return nil, errors.NotValidf("username %q", username)
+	}
+	userTag := names.NewUserTag(username)
+	if !userTag.IsLocal() {
+		return nil, errors.NotValidf("non-local username %q", username)
+	}
+
+	authenticator := h.authCtxt.authenticator(p.Request.Host)
+	if _, err := authenticator.Authenticate(h.state, userTag, params.LoginRequest{
+		Credentials: password,
+	}); err != nil {
+		// Mark the interaction as done (but failed),
+		// unblocking a pending "/auth/wait" request.
+		if err := h.authCtxt.localUserInteractions.Done(waitId, userTag, err); err != nil {
+			if !errors.IsNotFound(err) {
+				logger.Warningf(
+					"failed to record completion of interaction %q for %q",
+					waitId, userTag.Id(),
+				)
+			}
+		}
+		return nil, errors.Trace(err)
+	}
+
+	// Provide the client with a macaroon that they can use to
+	// prove that they have logged in, and obtain a discharge
+	// macaroon.
+	m, err := h.authCtxt.CreateLocalLoginMacaroon(userTag)
+	if err != nil {
+		return nil, err
+	}
+	cookie, err := httpbakery.NewCookie(macaroon.Slice{m})
+	if err != nil {
+		return nil, err
+	}
+	http.SetCookie(p.Response, cookie)
+
+	// Mark the interaction as done, unblocking a pending
+	// "/auth/wait" request.
+	if err := h.authCtxt.localUserInteractions.Done(
+		waitId, userTag, nil,
+	); err != nil {
+		if errors.IsNotFound(err) {
+			err = errors.New("login timed out")
+		}
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (h *localLoginHandlers) serveLoginGet(p httprequest.Params) (interface{}, error) {
+	if p.Request.Header.Get("Accept") == "application/json" {
+		// The application/json content-type is used to
+		// inform the client of the supported auth methods.
+		return map[string]string{
+			"juju_userpass": p.Request.URL.String(),
+		}, nil
+	}
+	// TODO(axw) return an HTML form. If waitid is supplied,
+	// it should be passed through so we can unblock a request
+	// on the /auth/wait endpoint. We should also support logging
+	// in when not specifically directed to the login page.
+	return nil, errors.NotImplementedf("GET")
+}
+
+func (h *localLoginHandlers) serveWait(p httprequest.Params) (interface{}, error) {
+	if err := p.Request.ParseForm(); err != nil {
+		return nil, err
+	}
+	if p.Request.Method != "GET" {
+		return nil, errors.Errorf("unsupported method %q", p.Request.Method)
+	}
+	waitId := p.Request.Form.Get("waitid")
+	if waitId == "" {
+		return nil, errors.NotValidf("missing waitid")
+	}
+	interaction, err := h.authCtxt.localUserInteractions.Wait(waitId, nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if interaction.LoginError != nil {
+		return nil, errors.Trace(err)
+	}
+	ctx := macaroonAuthContext{
+		authContext: h.authCtxt,
+		req:         p.Request,
+	}
+	macaroon, err := h.authCtxt.localUserThirdPartyBakeryService.Discharge(
+		&ctx, interaction.CaveatId,
+	)
+	if err != nil {
+		return nil, errors.Annotate(err, "discharging macaroon")
+	}
+	return httpbakery.WaitResponse{macaroon}, nil
+}
+
+func (h *localLoginHandlers) checkThirdPartyCaveat(req *http.Request, cavId, cav string) ([]checkers.Caveat, error) {
+	ctx := &macaroonAuthContext{authContext: h.authCtxt, req: req}
+	return ctx.CheckThirdPartyCaveat(cavId, cav)
+}
+
+type macaroonAuthContext struct {
+	*authContext
+	req *http.Request
+}
+
+// CheckThirdPartyCaveat is part of the bakery.ThirdPartyChecker interface.
+func (ctx *macaroonAuthContext) CheckThirdPartyCaveat(cavId, cav string) ([]checkers.Caveat, error) {
+	tag, err := ctx.CheckLocalLoginCaveat(cav)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	firstPartyCaveats, err := ctx.CheckLocalLoginRequest(ctx.req, tag)
+	if err != nil {
+		if _, ok := errors.Cause(err).(*bakery.VerificationError); ok {
+			waitId, err := ctx.localUserInteractions.Start(
+				cavId,
+				ctx.clock.Now().Add(authentication.LocalLoginInteractionTimeout),
+			)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			visitURL := localUserIdentityLocationPath + "/login?waitid=" + waitId
+			waitURL := localUserIdentityLocationPath + "/wait?waitid=" + waitId
+			return nil, httpbakery.NewInteractionRequiredError(visitURL, waitURL, nil, ctx.req)
+		}
+		return nil, errors.Trace(err)
+	}
+	return firstPartyCaveats, nil
+}

--- a/apiserver/params/registration.go
+++ b/apiserver/params/registration.go
@@ -3,10 +3,6 @@
 
 package params
 
-import (
-	"gopkg.in/macaroon.v1"
-)
-
 // SecretKeyLoginRequest contains the parameters for completing
 // the registration of a user. The request contains the tag of
 // the user, and an encrypted and authenticated payload that
@@ -57,8 +53,4 @@ type SecretKeyLoginResponsePayload struct {
 
 	// ControllerUUID is the UUID of the Juju controller.
 	ControllerUUID string `json:"controller-uuid"`
-
-	// Macaroon is a time-limited macaroon that can be used for
-	// authenticating as the registered user.
-	Macaroon *macaroon.Macaroon `json:"macaroon"`
 }

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -80,15 +80,6 @@ func newAPIHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID st
 	if err := r.resources.RegisterNamed("logDir", common.StringResource(srv.logDir)); err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := r.resources.RegisterNamed("createLocalLoginMacaroon", common.ValueResource{
-		// NOTE(axw) the string we pass in at the moment is
-		// unimportant, as it is not used in the branch. In
-		// the next branch, we won't need to register this
-		// resource.
-		srv.authCtxt.authenticator("").localUserAuth().CreateLocalLoginMacaroon,
-	}); err != nil {
-		return nil, errors.Trace(err)
-	}
 	return r, nil
 }
 

--- a/apiserver/usermanager/usermanager.go
+++ b/apiserver/usermanager/usermanager.go
@@ -6,8 +6,6 @@ package usermanager
 import (
 	"time"
 
-	"gopkg.in/macaroon.v1"
-
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"gopkg.in/juju/names.v2"
@@ -28,12 +26,11 @@ func init() {
 // UserManagerAPI implements the user manager interface and is the concrete
 // implementation of the api end point.
 type UserManagerAPI struct {
-	state                    *state.State
-	authorizer               facade.Authorizer
-	createLocalLoginMacaroon func(names.UserTag) (*macaroon.Macaroon, error)
-	check                    *common.BlockChecker
-	apiUser                  names.UserTag
-	isAdmin                  bool
+	state      *state.State
+	authorizer facade.Authorizer
+	check      *common.BlockChecker
+	apiUser    names.UserTag
+	isAdmin    bool
 }
 
 func NewUserManagerAPI(
@@ -55,22 +52,12 @@ func NewUserManagerAPI(
 		return nil, errors.Trace(err)
 	}
 
-	resource, ok := resources.Get("createLocalLoginMacaroon").(common.ValueResource)
-	if !ok {
-		return nil, errors.NotFoundf("userAuth resource")
-	}
-	createLocalLoginMacaroon, ok := resource.Value.(func(names.UserTag) (*macaroon.Macaroon, error))
-	if !ok {
-		return nil, errors.NotValidf("userAuth resource")
-	}
-
 	return &UserManagerAPI{
-		state:                    st,
-		authorizer:               authorizer,
-		createLocalLoginMacaroon: createLocalLoginMacaroon,
-		check:   common.NewBlockChecker(st),
-		apiUser: apiUser,
-		isAdmin: isAdmin,
+		state:      st,
+		authorizer: authorizer,
+		check:      common.NewBlockChecker(st),
+		apiUser:    apiUser,
+		isAdmin:    isAdmin,
 	}, nil
 }
 
@@ -408,37 +395,4 @@ func (api *UserManagerAPI) setPassword(arg params.EntityPassword) error {
 		return errors.Annotate(err, "failed to set password")
 	}
 	return nil
-}
-
-// CreateLocalLoginMacaroon creates a macaroon for the specified users to use
-// for future logins.
-func (api *UserManagerAPI) CreateLocalLoginMacaroon(args params.Entities) (params.MacaroonResults, error) {
-	results := params.MacaroonResults{
-		Results: make([]params.MacaroonResult, len(args.Entities)),
-	}
-	createLocalLoginMacaroon := func(arg params.Entity) (*macaroon.Macaroon, error) {
-		user, err := api.getUser(arg.Tag)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-
-		isSuperUser, err := api.hasControllerAdminAccess()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-
-		if api.apiUser != user.UserTag() && !api.isAdmin && isSuperUser {
-			return nil, errors.Trace(common.ErrPerm)
-		}
-		return api.createLocalLoginMacaroon(user.UserTag())
-	}
-	for i, arg := range args.Entities {
-		m, err := createLocalLoginMacaroon(arg)
-		if err != nil {
-			results.Results[i].Error = common.ServerError(err)
-			continue
-		}
-		results.Results[i].Result = m
-	}
-	return results, nil
 }

--- a/apiserver/usermanager/usermanager_test.go
+++ b/apiserver/usermanager/usermanager_test.go
@@ -11,7 +11,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
-	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/apiserver/common"
 	commontesting "github.com/juju/juju/apiserver/common/testing"
@@ -28,11 +27,10 @@ import (
 type userManagerSuite struct {
 	jujutesting.JujuConnSuite
 
-	usermanager              *usermanager.UserManagerAPI
-	authorizer               apiservertesting.FakeAuthorizer
-	adminName                string
-	resources                *common.Resources
-	createLocalLoginMacaroon func(names.UserTag) (*macaroon.Macaroon, error)
+	usermanager *usermanager.UserManagerAPI
+	authorizer  apiservertesting.FakeAuthorizer
+	adminName   string
+	resources   *common.Resources
 
 	commontesting.BlockHelper
 }
@@ -42,16 +40,7 @@ var _ = gc.Suite(&userManagerSuite{})
 func (s *userManagerSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 
-	s.createLocalLoginMacaroon = func(tag names.UserTag) (*macaroon.Macaroon, error) {
-		return nil, errors.NotSupportedf("CreateLocalLoginMacaroon")
-	}
 	s.resources = common.NewResources()
-	s.resources.RegisterNamed("createLocalLoginMacaroon", common.ValueResource{
-		func(tag names.UserTag) (*macaroon.Macaroon, error) {
-			return s.createLocalLoginMacaroon(tag)
-		},
-	})
-
 	adminTag := s.AdminUserTag(c)
 	s.adminName = adminTag.Name()
 	s.authorizer = apiservertesting.FakeAuthorizer{

--- a/cmd/juju/commands/migrate_test.go
+++ b/cmd/juju/commands/migrate_test.go
@@ -4,11 +4,18 @@
 package commands
 
 import (
+	"net/http"
+	"net/url"
+	"time"
+
 	"github.com/juju/cmd"
+	cookiejar "github.com/juju/persistent-cookiejar"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/macaroon.v1"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/controller"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -20,9 +27,10 @@ import (
 
 type MigrateSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
-	api   *fakeMigrateAPI
-	store *jujuclienttesting.MemStore
-	mac   *macaroon.Macaroon
+	api                 *fakeMigrateAPI
+	targetControllerAPI *fakeTargetControllerAPI
+	store               *jujuclienttesting.MemStore
+	password            string
 }
 
 var _ = gc.Suite(&MigrateSuite{})
@@ -58,17 +66,9 @@ func (s *MigrateSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Define the account for the target controller.
-	s.mac, err = macaroon.New([]byte("secret"), "id", "location")
-	c.Assert(err, jc.ErrorIsNil)
-	macJSON, err := s.mac.MarshalJSON()
-	c.Assert(err, jc.ErrorIsNil)
-
 	err = s.store.UpdateAccount("target", jujuclient.AccountDetails{
-		User: "target@local",
-		// It's unlikely that both will actually be set for a single
-		// account but it's fine for the tests.
+		User:     "target@local",
 		Password: "secret",
-		Macaroon: string(macJSON),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -81,6 +81,41 @@ func (s *MigrateSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.api = &fakeMigrateAPI{}
+
+	mac0, err := macaroon.New([]byte("secret0"), "id0", "location0")
+	c.Assert(err, jc.ErrorIsNil)
+	mac1, err := macaroon.New([]byte("secret1"), "id1", "location1")
+	c.Assert(err, jc.ErrorIsNil)
+
+	jar, err := cookiejar.New(&cookiejar.Options{
+		Filename: cookiejar.DefaultCookieFile(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.targetControllerAPI = &fakeTargetControllerAPI{
+		cookieURL: &url.URL{
+			Scheme: "https",
+			Host:   "testing.invalid",
+			Path:   "/",
+		},
+		macaroons: []macaroon.Slice{{mac0}},
+	}
+	addCookie(c, jar, mac0, s.targetControllerAPI.cookieURL)
+	addCookie(c, jar, mac1, &url.URL{
+		Scheme: "https",
+		Host:   "tasting.invalid",
+		Path:   "/",
+	})
+
+	err = jar.Save()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func addCookie(c *gc.C, jar *cookiejar.Jar, mac *macaroon.Macaroon, url *url.URL) {
+	cookie, err := httpbakery.NewCookie(macaroon.Slice{mac})
+	c.Assert(err, jc.ErrorIsNil)
+	cookie.Expires = time.Now().Add(time.Hour) // only persistent cookies are stored
+	jar.SetCookies(url, []*http.Cookie{cookie})
 }
 
 func (s *MigrateSuite) TestMissingModel(c *gc.C) {
@@ -110,7 +145,27 @@ func (s *MigrateSuite) TestSuccess(c *gc.C) {
 		TargetCACert:         "cert",
 		TargetUser:           "target@local",
 		TargetPassword:       "secret",
-		TargetMacaroons:      []macaroon.Slice{{s.mac}},
+	})
+}
+
+func (s *MigrateSuite) TestSuccessMacaroons(c *gc.C) {
+	err := s.store.UpdateAccount("target", jujuclient.AccountDetails{
+		User:     "target@local",
+		Password: "",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx, err := s.makeAndRun(c, "model", "target")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(testing.Stderr(ctx), gc.Matches, "Migration started with ID \"uuid:0\"\n")
+	c.Check(s.api.specSeen, jc.DeepEquals, &controller.MigrationSpec{
+		ModelUUID:            modelUUID,
+		TargetControllerUUID: targetControllerUUID,
+		TargetAddrs:          []string{"1.2.3.4:5"},
+		TargetCACert:         "cert",
+		TargetUser:           "target@local",
+		TargetMacaroons:      s.targetControllerAPI.macaroons,
 	})
 }
 
@@ -143,6 +198,9 @@ func (s *MigrateSuite) makeAndRun(c *gc.C, args ...string) (*cmd.Context, error)
 func (s *MigrateSuite) makeCommand() *migrateCommand {
 	cmd := &migrateCommand{
 		api: s.api,
+		newAPIRoot: func(jujuclient.ClientStore, string, string) (api.Connection, error) {
+			return s.targetControllerAPI, nil
+		},
 	}
 	cmd.SetClientStore(s.store)
 	return cmd
@@ -177,5 +235,19 @@ func (m *fakeModelAPI) ListModels(user string) ([]base.UserModel, error) {
 }
 
 func (m *fakeModelAPI) Close() error {
+	return nil
+}
+
+type fakeTargetControllerAPI struct {
+	api.Connection
+	cookieURL *url.URL
+	macaroons []macaroon.Slice
+}
+
+func (a *fakeTargetControllerAPI) CookieURL() *url.URL {
+	return a.cookieURL
+}
+
+func (a *fakeTargetControllerAPI) Close() error {
 	return nil
 }

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -128,7 +128,10 @@ func (c *registerCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	// Make the registration call.
+	// Make the registration call. If this is successful, the client's
+	// cookie jar will be populated with a macaroon that may be used
+	// to log in below without the user having to type in the password
+	// again.
 	req := params.SecretKeyLoginRequest{
 		Nonce: registrationParams.nonce[:],
 		User:  registrationParams.userTag.String(),
@@ -168,13 +171,8 @@ func (c *registerCommand) Run(ctx *cmd.Context) error {
 	if err := store.AddController(registrationParams.controllerName, controllerDetails); err != nil {
 		return errors.Trace(err)
 	}
-	macaroonJSON, err := responsePayload.Macaroon.MarshalJSON()
-	if err != nil {
-		return errors.Annotate(err, "marshalling temporary credential to JSON")
-	}
 	accountDetails := jujuclient.AccountDetails{
 		User:            registrationParams.userTag.Canonical(),
-		Macaroon:        string(macaroonJSON),
 		LastKnownAccess: string(description.LoginAccess),
 	}
 	if err := store.UpdateAccount(registrationParams.controllerName, accountDetails); err != nil {
@@ -320,6 +318,11 @@ func (c *registerCommand) getParameters(ctx *cmd.Context, store jujuclient.Clien
 }
 
 func (c *registerCommand) secretKeyLogin(addrs []string, request params.SecretKeyLoginRequest) (*params.SecretKeyLoginResponse, error) {
+	apiContext, err := c.APIContext()
+	if err != nil {
+		return nil, errors.Annotate(err, "getting API context")
+	}
+
 	buf, err := json.Marshal(&request)
 	if err != nil {
 		return nil, errors.Annotate(err, "marshalling request")
@@ -351,6 +354,8 @@ func (c *registerCommand) secretKeyLogin(addrs []string, request params.SecretKe
 	}
 
 	// Using the address we connected to above, perform the request.
+	// A success response will include a macaroon cookie that we can
+	// use to log in with.
 	urlString := fmt.Sprintf("https://%s/register", apiAddr)
 	httpReq, err := http.NewRequest("POST", urlString, r)
 	if err != nil {
@@ -358,6 +363,7 @@ func (c *registerCommand) secretKeyLogin(addrs []string, request params.SecretKe
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpClient := utils.GetNonValidatingHTTPClient()
+	httpClient.Jar = apiContext.Jar
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -20,7 +20,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"golang.org/x/crypto/nacl/secretbox"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
@@ -219,18 +218,12 @@ func (s *RegisterSuite) testRegister(c *gc.C, expectedError string) *cmd.Context
 	secretKey := []byte(strings.Repeat("X", 32))
 	respNonce := []byte(strings.Repeat("X", 24))
 
-	macaroon, err := macaroon.New(nil, "mymacaroon", "tone")
-	c.Assert(err, jc.ErrorIsNil)
-	macaroonJSON, err := macaroon.MarshalJSON()
-	c.Assert(err, jc.ErrorIsNil)
-
 	var requests []*http.Request
 	var requestBodies [][]byte
 	const controllerUUID = "df136476-12e9-11e4-8a70-b2227cce2b54"
 	responsePayloadPlaintext, err := json.Marshal(params.SecretKeyLoginResponsePayload{
 		CACert:         testing.CACert,
 		ControllerUUID: controllerUUID,
-		Macaroon:       macaroon,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	response, err := json.Marshal(params.SecretKeyLoginResponse{
@@ -287,7 +280,6 @@ func (s *RegisterSuite) testRegister(c *gc.C, expectedError string) *cmd.Context
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(account, jc.DeepEquals, &jujuclient.AccountDetails{
 		User:            "bob@local",
-		Macaroon:        string(macaroonJSON),
 		LastKnownAccess: "login",
 	})
 	return ctx

--- a/cmd/juju/user/change_password.go
+++ b/cmd/juju/user/change_password.go
@@ -13,10 +13,14 @@ import (
 	"github.com/juju/errors"
 	"golang.org/x/crypto/ssh/terminal"
 	"gopkg.in/juju/names.v2"
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/authentication"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/juju"
+	"github.com/juju/juju/jujuclient"
 )
 
 const userChangePasswordDoc = `
@@ -37,14 +41,17 @@ See also:
 `
 
 func NewChangePasswordCommand() cmd.Command {
-	return modelcmd.WrapController(&changePasswordCommand{})
+	var cmd changePasswordCommand
+	cmd.newAPIConnection = juju.NewAPIConnection
+	return modelcmd.WrapController(&cmd)
 }
 
 // changePasswordCommand changes the password for a user.
 type changePasswordCommand struct {
 	modelcmd.ControllerCommandBase
-	api  ChangePasswordAPI
-	User string
+	newAPIConnection func(juju.NewAPIConnectionParams) (api.Connection, error)
+	api              ChangePasswordAPI
+	User             string
 }
 
 // Info implements Command.Info.
@@ -70,7 +77,6 @@ func (c *changePasswordCommand) Init(args []string) error {
 // ChangePasswordAPI defines the usermanager API methods that the change
 // password command uses.
 type ChangePasswordAPI interface {
-	CreateLocalLoginMacaroon(names.UserTag) (*macaroon.Macaroon, error)
 	SetPassword(username, password string) error
 	Close() error
 }
@@ -119,39 +125,53 @@ func (c *changePasswordCommand) Run(ctx *cmd.Context) error {
 			return errors.Errorf("cannot change password for external user %q", userTag)
 		}
 	}
-
-	if accountDetails != nil && accountDetails.Macaroon == "" {
-		// Generate a macaroon first to guard against I/O failures
-		// occurring after the password has been changed, preventing
-		// future logins.
-		macaroon, err := c.api.CreateLocalLoginMacaroon(userTag)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		accountDetails.Password = ""
-
-		// TODO(axw) update jujuclient with code for marshalling
-		// and unmarshalling macaroons as YAML.
-		macaroonJSON, err := macaroon.MarshalJSON()
-		if err != nil {
-			return errors.Trace(err)
-		}
-		accountDetails.Macaroon = string(macaroonJSON)
-
-		if err := store.UpdateAccount(controllerName, *accountDetails); err != nil {
-			return errors.Annotate(err, "failed to update client credentials")
-		}
-	}
-
 	if err := c.api.SetPassword(userTag.Canonical(), newPassword); err != nil {
 		return block.ProcessBlockedError(err, block.BlockChange)
 	}
+
 	if accountDetails == nil {
 		ctx.Infof("Password for %q has been updated.", c.User)
 	} else {
+		if accountDetails.Password != "" {
+			// Log back in with macaroon authentication, so we can
+			// discard the password without having to log back in
+			// immediately.
+			if err := c.recordMacaroon(accountDetails.User, newPassword); err != nil {
+				return errors.Annotate(err, "recording macaroon")
+			}
+			// Wipe the password from disk. In the event of an
+			// error occurring after SetPassword and before the
+			// account details being updated, the user will be
+			// able to recover by running "juju login".
+			accountDetails.Password = ""
+			if err := store.UpdateAccount(controllerName, *accountDetails); err != nil {
+				return errors.Annotate(err, "failed to update client credentials")
+			}
+		}
 		ctx.Infof("Your password has been updated.")
 	}
 	return nil
+}
+
+func (c *changePasswordCommand) recordMacaroon(user, password string) error {
+	accountDetails := &jujuclient.AccountDetails{User: user}
+	args, err := c.NewAPIConnectionParams(
+		c.ClientStore(), c.ControllerName(), "", accountDetails,
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	args.DialOpts.BakeryClient.WebPageVisitor = httpbakery.NewMultiVisitor(
+		authentication.NewVisitor(accountDetails.User, func(string) (string, error) {
+			return password, nil
+		}),
+		args.DialOpts.BakeryClient.WebPageVisitor,
+	)
+	api, err := c.newAPIConnection(args)
+	if err != nil {
+		return errors.Annotate(err, "connecting to API")
+	}
+	return api.Close()
 }
 
 func readAndConfirmPassword(ctx *cmd.Context) (string, error) {
@@ -160,7 +180,7 @@ func readAndConfirmPassword(ctx *cmd.Context) (string, error) {
 	// on their own lines.
 	//
 	// TODO(axw) retry/loop on failure
-	fmt.Fprint(ctx.Stderr, "password: ")
+	fmt.Fprint(ctx.Stderr, "new password: ")
 	password, err := readPassword(ctx.Stdin)
 	fmt.Fprint(ctx.Stderr, "\n")
 	if err != nil {
@@ -170,7 +190,7 @@ func readAndConfirmPassword(ctx *cmd.Context) (string, error) {
 		return "", errors.Errorf("you must enter a password")
 	}
 
-	fmt.Fprint(ctx.Stderr, "type password again: ")
+	fmt.Fprint(ctx.Stderr, "type new password again: ")
 	verify, err := readPassword(ctx.Stdin)
 	fmt.Fprint(ctx.Stderr, "\n")
 	if err != nil {

--- a/cmd/juju/user/change_password_test.go
+++ b/cmd/juju/user/change_password_test.go
@@ -11,12 +11,11 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/names.v2"
-	"gopkg.in/macaroon.v1"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/cmd/juju/user"
+	"github.com/juju/juju/juju"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -34,15 +33,22 @@ func (s *ChangePasswordCommandSuite) SetUpTest(c *gc.C) {
 	s.store = s.BaseSuite.store
 }
 
-func (s *ChangePasswordCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
-	changePasswordCommand, _ := user.NewChangePasswordCommandForTest(s.mockAPI, s.store)
+func (s *ChangePasswordCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, *juju.NewAPIConnectionParams, error) {
+	var argsOut juju.NewAPIConnectionParams
+	newAPIConnection := func(args juju.NewAPIConnectionParams) (api.Connection, error) {
+		argsOut = args
+		return mockAPIConnection{}, nil
+	}
+	changePasswordCommand, _ := user.NewChangePasswordCommandForTest(
+		newAPIConnection, s.mockAPI, s.store,
+	)
 	ctx := coretesting.Context(c)
 	ctx.Stdin = strings.NewReader("sekrit\nsekrit\n")
 	err := coretesting.InitCommand(changePasswordCommand, args)
 	if err != nil {
-		return ctx, err
+		return ctx, nil, err
 	}
-	return ctx, changePasswordCommand.Run(ctx)
+	return ctx, &argsOut, changePasswordCommand.Run(ctx)
 }
 
 func (s *ChangePasswordCommandSuite) TestInit(c *gc.C) {
@@ -65,7 +71,7 @@ func (s *ChangePasswordCommandSuite) TestInit(c *gc.C) {
 		},
 	} {
 		c.Logf("test %d", i)
-		wrappedCommand, command := user.NewChangePasswordCommandForTest(nil, s.store)
+		wrappedCommand, command := user.NewChangePasswordCommandForTest(nil, nil, s.store)
 		err := coretesting.InitCommand(wrappedCommand, test.args)
 		if test.errorString == "" {
 			c.Check(command.User, gc.Equals, test.user)
@@ -76,69 +82,42 @@ func (s *ChangePasswordCommandSuite) TestInit(c *gc.C) {
 }
 
 func (s *ChangePasswordCommandSuite) assertAPICalls(c *gc.C, user, pass string) {
-	var offset int
-	if user == "current-user@local" {
-		s.mockAPI.CheckCall(c, 0, "CreateLocalLoginMacaroon", names.NewUserTag(user))
-		offset += 1
-	}
-	s.mockAPI.CheckCall(c, offset, "SetPassword", user, pass)
+	s.mockAPI.CheckCall(c, 0, "SetPassword", user, pass)
 }
 
 func (s *ChangePasswordCommandSuite) TestChangePassword(c *gc.C) {
-	context, err := s.run(c)
+	context, args, err := s.run(c)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertAPICalls(c, "current-user@local", "sekrit")
 	c.Assert(coretesting.Stdout(context), gc.Equals, "")
 	c.Assert(coretesting.Stderr(context), gc.Equals, `
-password: 
-type password again: 
+new password: 
+type new password again: 
 Your password has been updated.
 `[1:])
+	// The command should have logged in without a password to get a macaroon.
+	c.Assert(args.AccountDetails, jc.DeepEquals, &jujuclient.AccountDetails{
+		User: "current-user@local",
+	})
 }
 
 func (s *ChangePasswordCommandSuite) TestChangePasswordFail(c *gc.C) {
-	s.mockAPI.SetErrors(nil, errors.New("failed to do something"))
-	_, err := s.run(c)
+	s.mockAPI.SetErrors(errors.New("failed to do something"))
+	_, _, err := s.run(c)
 	c.Assert(err, gc.ErrorMatches, "failed to do something")
 	s.assertAPICalls(c, "current-user@local", "sekrit")
-}
-
-// We create a macaroon, but fail to write it to accounts.yaml.
-// We should not call SetPassword subsequently.
-func (s *ChangePasswordCommandSuite) TestNoSetPasswordAfterFailedWrite(c *gc.C) {
-	store := jujuclienttesting.NewStubStore()
-	store.AccountDetailsFunc = func(string) (*jujuclient.AccountDetails, error) {
-		return &jujuclient.AccountDetails{"user", "old-password", "", ""}, nil
-	}
-	store.ControllerByNameFunc = func(string) (*jujuclient.ControllerDetails, error) {
-		return &jujuclient.ControllerDetails{}, nil
-	}
-	s.store = store
-	store.SetErrors(nil, errors.New("failed to write"))
-
-	_, err := s.run(c)
-	c.Assert(err, gc.ErrorMatches, "failed to update client credentials: failed to write")
-	s.mockAPI.CheckCallNames(c, "CreateLocalLoginMacaroon") // no SetPassword
 }
 
 func (s *ChangePasswordCommandSuite) TestChangeOthersPassword(c *gc.C) {
 	// The checks for user existence and admin rights are tested
 	// at the apiserver level.
-	_, err := s.run(c, "other")
+	_, _, err := s.run(c, "other")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertAPICalls(c, "other@local", "sekrit")
 }
 
 type mockChangePasswordAPI struct {
 	testing.Stub
-}
-
-func (m *mockChangePasswordAPI) CreateLocalLoginMacaroon(tag names.UserTag) (*macaroon.Macaroon, error) {
-	m.MethodCall(m, "CreateLocalLoginMacaroon", tag)
-	if err := m.NextErr(); err != nil {
-		return nil, err
-	}
-	return fakeLocalLoginMacaroon(tag), nil
 }
 
 func (m *mockChangePasswordAPI) SetPassword(username, password string) error {
@@ -150,10 +129,10 @@ func (*mockChangePasswordAPI) Close() error {
 	return nil
 }
 
-func fakeLocalLoginMacaroon(tag names.UserTag) *macaroon.Macaroon {
-	mac, err := macaroon.New([]byte("abcdefghijklmnopqrstuvwx"), tag.Canonical(), "juju")
-	if err != nil {
-		panic(err)
-	}
-	return mac
+type mockAPIConnection struct {
+	api.Connection
+}
+
+func (mockAPIConnection) Close() error {
+	return nil
 }

--- a/cmd/juju/user/export_test.go
+++ b/cmd/juju/user/export_test.go
@@ -6,6 +6,7 @@ package user
 import (
 	"github.com/juju/cmd"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/jujuclient"
@@ -56,8 +57,15 @@ func NewShowUserCommandForTest(api UserInfoAPI, store jujuclient.ClientStore) cm
 
 // NewChangePasswordCommand returns a ChangePasswordCommand with the api
 // and writer provided as specified.
-func NewChangePasswordCommandForTest(api ChangePasswordAPI, store jujuclient.ClientStore) (cmd.Command, *ChangePasswordCommand) {
-	c := &changePasswordCommand{api: api}
+func NewChangePasswordCommandForTest(
+	newAPIConnection func(juju.NewAPIConnectionParams) (api.Connection, error),
+	api ChangePasswordAPI,
+	store jujuclient.ClientStore,
+) (cmd.Command, *ChangePasswordCommand) {
+	c := &changePasswordCommand{
+		newAPIConnection: newAPIConnection,
+		api:              api,
+	}
 	c.SetClientStore(store)
 	return modelcmd.WrapController(c), &ChangePasswordCommand{c}
 }

--- a/cmd/juju/user/login_test.go
+++ b/cmd/juju/user/login_test.go
@@ -4,7 +4,6 @@
 package user_test
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -95,15 +94,12 @@ func (s *LoginCommandSuite) TestLogin(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(coretesting.Stdout(context), gc.Equals, "")
 	c.Assert(coretesting.Stderr(context), gc.Equals, `
-username: password: 
-You are now logged in to "testing" as "current-user@local".
+username: You are now logged in to "testing" as "current-user@local".
 `[1:],
 	)
 	s.assertStorePassword(c, "current-user@local", "", "superuser")
-	s.assertStoreMacaroon(c, "current-user@local", fakeLocalLoginMacaroon(names.NewUserTag("current-user@local")))
 	c.Assert(args.AccountDetails, jc.DeepEquals, &jujuclient.AccountDetails{
-		User:     "current-user@local",
-		Password: "sekrit",
+		User: "current-user@local",
 	})
 }
 
@@ -114,15 +110,12 @@ func (s *LoginCommandSuite) TestLoginNewUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(coretesting.Stdout(context), gc.Equals, "")
 	c.Assert(coretesting.Stderr(context), gc.Equals, `
-password: 
 You are now logged in to "testing" as "new-user@local".
 `[1:],
 	)
 	s.assertStorePassword(c, "new-user@local", "", "superuser")
-	s.assertStoreMacaroon(c, "new-user@local", fakeLocalLoginMacaroon(names.NewUserTag("new-user@local")))
 	c.Assert(args.AccountDetails, jc.DeepEquals, &jujuclient.AccountDetails{
-		User:     "new-user@local",
-		Password: "sekrit",
+		User: "new-user@local",
 	})
 }
 
@@ -137,14 +130,6 @@ func (s *LoginCommandSuite) TestLoginAlreadyLoggedInDifferentUser(c *gc.C) {
 
 Run "juju logout" first before attempting to log in as a different user.
 `)
-}
-
-func (s *LoginCommandSuite) TestLoginFail(c *gc.C) {
-	s.mockAPI.SetErrors(errors.New("failed to do something"))
-	_, _, err := s.run(c, "", "current-user")
-	c.Assert(err, gc.ErrorMatches, "failed to create a temporary credential: failed to do something")
-	s.assertStorePassword(c, "current-user@local", "old-password", "")
-	s.assertStoreMacaroon(c, "current-user@local", nil)
 }
 
 func (s *LoginCommandSuite) TestLoginWithMacaroons(c *gc.C) {
@@ -168,14 +153,15 @@ func (s *LoginCommandSuite) TestLoginWithMacaroonsNotSupported(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(coretesting.Stdout(context), gc.Equals, "")
 	c.Assert(coretesting.Stderr(context), gc.Equals, `
-username: password: 
-You are now logged in to "testing" as "new-user@local".
+username: You are now logged in to "testing" as "new-user@local".
 `[1:],
 	)
 }
 
-type mockLoginAPI struct {
-	mockChangePasswordAPI
+type mockLoginAPI struct{}
+
+func (*mockLoginAPI) Close() error {
+	return nil
 }
 
 func (*mockLoginAPI) AuthTag() names.Tag {

--- a/cmd/juju/user/logout.go
+++ b/cmd/juju/user/logout.go
@@ -116,7 +116,7 @@ func (c *logoutCommand) logout(store jujuclient.ClientStore, controllerName stri
 	// they know their password. If they have just bootstrapped,
 	// they will have a randomly generated password which they will
 	// be unaware of.
-	if accountDetails.Macaroon == "" && accountDetails.Password != "" && !c.Force {
+	if accountDetails.Password != "" && !c.Force {
 		return errors.New(`preventing account loss
 
 It appears that you have not changed the password for

--- a/cmd/juju/user/logout_test.go
+++ b/cmd/juju/user/logout_test.go
@@ -55,9 +55,7 @@ func (s *LogoutCommandSuite) TestInit(c *gc.C) {
 }
 
 func (s *LogoutCommandSuite) TestLogout(c *gc.C) {
-	details := s.store.Accounts["testing"]
-	details.Macaroon = "a-macaroon"
-	s.store.Accounts["testing"] = details
+	s.setPassword(c, "testing", "")
 	ctx, err := s.run(c)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(coretesting.Stdout(ctx), gc.Equals, "")
@@ -72,9 +70,9 @@ Logged out. You are no longer logged into any controllers.
 func (s *LogoutCommandSuite) TestLogoutCount(c *gc.C) {
 	// Create multiple controllers. We'll log out of each one
 	// to observe the messages printed out by "logout".
+	s.setPassword(c, "testing", "")
 	controllers := []string{"testing", "testing2", "testing3"}
 	details := s.store.Accounts["testing"]
-	details.Macaroon = "a-macaroon"
 	for _, controller := range controllers {
 		s.store.Controllers[controller] = s.store.Controllers["testing"]
 		err := s.store.UpdateAccount(controller, details)
@@ -95,9 +93,8 @@ func (s *LogoutCommandSuite) TestLogoutCount(c *gc.C) {
 	}
 }
 
-func (s *LogoutCommandSuite) TestLogoutWithoutMacaroon(c *gc.C) {
+func (s *LogoutCommandSuite) TestLogoutWithPassword(c *gc.C) {
 	s.assertStorePassword(c, "current-user@local", "old-password", "")
-	s.assertStoreMacaroon(c, "current-user@local", nil)
 	_, err := s.run(c)
 	c.Assert(err, gc.NotNil)
 	c.Assert(err.Error(), gc.Equals, `preventing account loss
@@ -114,9 +111,8 @@ this command again with the "--force" flag.
 `)
 }
 
-func (s *LogoutCommandSuite) TestLogoutWithoutMacaroonForced(c *gc.C) {
+func (s *LogoutCommandSuite) TestLogoutWithPasswordForced(c *gc.C) {
 	s.assertStorePassword(c, "current-user@local", "old-password", "")
-	s.assertStoreMacaroon(c, "current-user@local", nil)
 	_, err := s.run(c, "--force")
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.store.AccountDetails("testing")

--- a/cmd/juju/user/user_test.go
+++ b/cmd/juju/user/user_test.go
@@ -6,7 +6,6 @@ package user_test
 import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
@@ -34,22 +33,17 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	}
 }
 
+func (s *BaseSuite) setPassword(c *gc.C, controller, pass string) {
+	details, ok := s.store.Accounts[controller]
+	c.Assert(ok, jc.IsTrue)
+	details.Password = pass
+	s.store.Accounts[controller] = details
+}
+
 func (s *BaseSuite) assertStorePassword(c *gc.C, user, pass, access string) {
 	details, err := s.store.AccountDetails("testing")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(details.User, gc.Equals, user)
 	c.Assert(details.Password, gc.Equals, pass)
 	c.Assert(details.LastKnownAccess, gc.Equals, access)
-}
-
-func (s *BaseSuite) assertStoreMacaroon(c *gc.C, user string, mac *macaroon.Macaroon) {
-	details, err := s.store.AccountDetails("testing")
-	c.Assert(err, jc.ErrorIsNil)
-	if mac == nil {
-		c.Assert(details.Macaroon, gc.Equals, "")
-		return
-	}
-	macaroonJSON, err := mac.MarshalJSON()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(details.Macaroon, gc.Equals, string(macaroonJSON))
 }

--- a/juju/api.go
+++ b/juju/api.go
@@ -4,13 +4,11 @@
 package juju
 
 import (
-	"encoding/json"
 	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"gopkg.in/juju/names.v2"
-	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/jujuclient"
@@ -177,25 +175,17 @@ func connectionInfo(args NewAPIConnectionParams) (*api.Info, *jujuclient.Control
 		return apiInfo, controller, nil
 	}
 	account := args.AccountDetails
-	if args.AccountDetails.Password != "" {
-		// If a password is available, we always use
-		// that.
-		//
-		// TODO(axw) make it invalid to store both
-		// password and macaroon in accounts.yaml?
-		apiInfo.Tag = names.NewUserTag(account.User)
-		apiInfo.Password = account.Password
-	} else if args.AccountDetails.Macaroon != "" {
-		var m macaroon.Macaroon
-		if err := json.Unmarshal([]byte(account.Macaroon), &m); err != nil {
-			return nil, nil, errors.Trace(err)
+	if account.User != "" {
+		userTag := names.NewUserTag(account.User)
+		if userTag.IsLocal() {
+			apiInfo.Tag = userTag
 		}
-		apiInfo.Tag = names.NewUserTag(account.User)
-		apiInfo.Macaroons = []macaroon.Slice{{&m}}
-	} else {
-		// Neither a password nor a local user macaroon was
-		// found, so we'll use external macaroon authentication,
-		// which requires that no tag be specified.
+	}
+	if args.AccountDetails.Password != "" {
+		// If a password is available, we always use that.
+		// If no password is recorded, we'll attempt to
+		// authenticate using macaroons.
+		apiInfo.Password = account.Password
 	}
 	return apiInfo, controller, nil
 }

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -65,11 +65,6 @@ type AccountDetails struct {
 	// Password is the password for the account.
 	Password string `yaml:"password,omitempty"`
 
-	// Macaroon is a time-limited macaroon that may be
-	// used to log in. This string is the JSON-encoding
-	// of a gopkg.in/macaroon.v1.Macaroon.
-	Macaroon string `yaml:"macaroon,omitempty"`
-
 	// LastKnownAccess is the last known access level for the account.
 	LastKnownAccess string `yaml:"last-known-access,omitempty"`
 }

--- a/jujuclient/validation.go
+++ b/jujuclient/validation.go
@@ -34,10 +34,6 @@ func ValidateAccountDetails(details AccountDetails) error {
 	}
 	// It is valid for a password to be blank, because the client
 	// may use macaroons instead.
-	//
-	// TODO(axw) expand validation rules to check that at least
-	// one of Password or Macaroon is non-empty, for local users.
-	// External users may have neither.
 	return nil
 }
 


### PR DESCRIPTION
This is a long overdue overhaul of the local login macaroon authentication
in Juju, bringing macaroon authentication for local users in line with how
we do it for external users.

The controller now acts as a discharger for macaroons authenticating local
users. When you first attempt to connect without a password you will be
handed a macaroon with the location pointing back at the controller. The
client has a special "web-page" visitor which can interact with the
controller to obtain a caveat discharge macaroon with which it can
authenticate.

The macaroon field in accounts.yaml has been dropped, in favour of storing
macaroons only in the cookie jar ($JUJU_COOKIEFILE or ~/.go-cookies).

There is currently no browser-based login page for local users, though this
could be added later.

Fixes https://bugs.launchpad.net/juju/+bug/1603176

(Review request: http://reviews.vapour.ws/r/5620/)