### PR TITLE
Add extra logging around bootstrap.

### DIFF
--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -111,7 +111,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 
 	err = c.ReadConfig("machine-0")
 	if err != nil {
-		return err
+		return errors.Annotate(err, "cannot read config")
 	}
 	agentConfig := c.CurrentConfig()
 
@@ -141,7 +141,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		Config: args.ControllerModelConfig,
 	})
 	if err != nil {
-		return err
+		return errors.Annotate(err, "new environ")
 	}
 	newConfigAttrs := make(map[string]interface{})
 
@@ -175,11 +175,11 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 
 	instances, err := env.Instances([]instance.Id{args.BootstrapMachineInstanceId})
 	if err != nil {
-		return err
+		return errors.Annotate(err, "getting bootstrap instance")
 	}
 	addrs, err := instances[0].Addresses()
 	if err != nil {
-		return err
+		return errors.Annotate(err, "bootstrap instance addresses")
 	}
 
 	// When machine addresses are reported from state, they have
@@ -226,7 +226,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 	}
 
 	if err := c.startMongo(addrs, agentConfig); err != nil {
-		return err
+		return errors.Annotate(err, "failed to start mongo")
 	}
 
 	controllerModelCfg, err := env.Config().Apply(newConfigAttrs)

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -399,7 +399,7 @@ func (s *BootstrapSuite) TestInitializeEnvironmentInvalidOplogSize(c *gc.C) {
 	_, cmd, err := s.initBootstrapCommand(c, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
-	c.Assert(err, gc.ErrorMatches, `invalid oplog size: "NaN"`)
+	c.Assert(err, gc.ErrorMatches, `failed to start mongo: invalid oplog size: "NaN"`)
 }
 
 func (s *BootstrapSuite) TestInitializeEnvironmentToolsNotFound(c *gc.C) {

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -131,7 +131,6 @@ func jujuCMain(commandName string, ctx *cmd.Context, args []string) (code int, e
 func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 	// Assuming an average of 200 bytes per log message, use up to
 	// 200MB for the log buffer.
-	logger.Debugf("jujud args: %v", args)
 	defer logger.Debugf("jujud complete, code %d, err %v", code, err)
 	logCh, err := logsender.InstallBufferedLogWriter(1048576)
 	if err != nil {

--- a/cmd/supercommand.go
+++ b/cmd/supercommand.go
@@ -61,4 +61,5 @@ func NewSubSuperCommand(p cmd.SuperCommandParams) *cmd.SuperCommand {
 
 func runNotifier(name string) {
 	logger.Infof("running %s [%s %s %s]", name, jujuversion.Current, runtime.Compiler, runtime.Version())
+	logger.Debugf("  args: %#v", os.Args)
 }

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1365,7 +1365,6 @@ type SecurityGroupCleaner interface {
 }
 
 var deleteSecurityGroupInsistently = func(inst SecurityGroupCleaner, group ec2.SecurityGroup, clock clock.Clock) error {
-	var lastErr error
 	err := retry.Call(retry.CallArgs{
 		Attempts:    30,
 		Delay:       time.Second,
@@ -1375,17 +1374,17 @@ var deleteSecurityGroupInsistently = func(inst SecurityGroupCleaner, group ec2.S
 		Func: func() error {
 			_, err := inst.DeleteSecurityGroup(group)
 			if err == nil || isNotFoundError(err) {
+				logger.Debugf("deleting security group %q", group.Name)
 				return nil
 			}
 			return errors.Trace(err)
 		},
 		NotifyFunc: func(err error, attempt int) {
-			lastErr = err
-			logger.Infof(fmt.Sprintf("deleting security group %q, attempt %d", group.Name, attempt))
+			logger.Debugf("deleting security group %q, attempt %d", group.Name, attempt)
 		},
 	})
 	if err != nil {
-		return errors.Annotatef(lastErr, "cannot delete security group %q: consider deleting it manually", group.Name)
+		return errors.Annotatef(err, "cannot delete security group %q: consider deleting it manually", group.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
While investigating http://pad.lv/1620415 it became apparent that we were missing some extra error annotation for jujud bootstrap.

(Review request: http://reviews.vapour.ws/r/5623/)