### PR TITLE
cmd/juju/user: support logging in as external user

### DIFF
--- a/apiserver/authcontext.go
+++ b/apiserver/authcontext.go
@@ -72,8 +72,7 @@ func (ctxt *authContext) authenticatorForTag(tag names.Tag) (authentication.Enti
 	if tag == nil {
 		auth, err := ctxt.macaroonAuth()
 		if errors.Cause(err) == errMacaroonAuthNotConfigured {
-			// Make a friendlier error message.
-			err = errors.New("no credentials provided")
+			err = errors.Trace(common.ErrNoCreds)
 		}
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -89,6 +89,7 @@ func IsUpgradeInProgressError(err error) bool {
 var (
 	ErrBadId              = errors.New("id not found")
 	ErrBadCreds           = errors.New("invalid entity name or password")
+	ErrNoCreds            = errors.New("no credentials provided")
 	ErrLoginExpired       = errors.New("login expired")
 	ErrPerm               = errors.New("permission denied")
 	ErrNotLoggedIn        = errors.New("not logged in")
@@ -122,6 +123,7 @@ var singletonErrorCodes = map[error]string{
 	lease.ErrClaimDenied:         params.CodeLeaseClaimDenied,
 	ErrBadId:                     params.CodeNotFound,
 	ErrBadCreds:                  params.CodeUnauthorized,
+	ErrNoCreds:                   params.CodeNoCreds,
 	ErrLoginExpired:              params.CodeLoginExpired,
 	ErrPerm:                      params.CodeUnauthorized,
 	ErrNotLoggedIn:               params.CodeUnauthorized,

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -62,6 +62,7 @@ const (
 	CodeModelNotFound             = "model not found"
 	CodeUnauthorized              = "unauthorized access"
 	CodeLoginExpired              = "login expired"
+	CodeNoCreds                   = "no credentials provided"
 	CodeCannotEnterScope          = "cannot enter scope"
 	CodeCannotEnterScopeYet       = "cannot enter scope yet"
 	CodeExcessiveContention       = "excessive contention"
@@ -124,6 +125,10 @@ func IsCodeModelNotFound(err error) bool {
 
 func IsCodeUnauthorized(err error) bool {
 	return ErrCode(err) == CodeUnauthorized
+}
+
+func IsCodeNoCreds(err error) bool {
+	return ErrCode(err) == CodeNoCreds
 }
 
 func IsCodeLoginExpired(err error) bool {

--- a/cmd/juju/user/login.go
+++ b/cmd/juju/user/login.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api/usermanager"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/jujuclient"
@@ -80,6 +81,7 @@ type LoginAPI interface {
 
 // ConnectionAPI provides relevant API methods off the underlying connection.
 type ConnectionAPI interface {
+	AuthTag() names.Tag
 	ControllerAccess() string
 }
 
@@ -87,11 +89,39 @@ type ConnectionAPI interface {
 func (c *loginCommand) Run(ctx *cmd.Context) error {
 	controllerName := c.ControllerName()
 	store := c.ClientStore()
+	accountDetails, err := store.AccountDetails(controllerName)
+	if err != nil && !errors.IsNotFound(err) {
+		return errors.Trace(err)
+	}
 
 	user := c.User
+	if user == "" && accountDetails == nil {
+		// The username has not been specified, and there
+		// is no current account. See if the user can log
+		// in with macaroons.
+		args, err := c.NewAPIConnectionParams(
+			store, controllerName, "",
+			&jujuclient.AccountDetails{},
+		)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		api, conn, err := c.newLoginAPI(args)
+		if err == nil {
+			authTag := conn.AuthTag()
+			api.Close()
+			ctx.Infof("You are now logged in to %q as %q.", controllerName, authTag.Id())
+			return nil
+		}
+		if !params.IsCodeNoCreds(err) {
+			return errors.Annotate(err, "creating API connection")
+		}
+		// CodeNoCreds was returned, which means that external
+		// users are not supported. Fall back to prompting the
+		// user for their username and password.
+	}
+
 	if user == "" {
-		// TODO(rog) Try macaroon login first before
-		// falling back to prompting for username.
 		// The username has not been specified, so prompt for it.
 		fmt.Fprint(ctx.Stderr, "username: ")
 		var err error
@@ -111,10 +141,6 @@ func (c *loginCommand) Run(ctx *cmd.Context) error {
 	// Make sure that the client is not already logged in,
 	// or if it is, that it is logged in as the specified
 	// user.
-	accountDetails, err := store.AccountDetails(controllerName)
-	if err != nil && !errors.IsNotFound(err) {
-		return errors.Trace(err)
-	}
 	if accountDetails != nil && accountDetails.User != userTag.Canonical() {
 		return errors.New(`already logged in
 

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -341,10 +341,12 @@ func newAPIConnectionParams(
 	dialOpts := api.DefaultDialOpts()
 	dialOpts.BakeryClient = bakery
 
-	bakery.WebPageVisitor = httpbakery.NewMultiVisitor(
-		authentication.NewVisitor(accountDetails.User, getPassword),
-		bakery.WebPageVisitor,
-	)
+	if accountDetails != nil {
+		bakery.WebPageVisitor = httpbakery.NewMultiVisitor(
+			authentication.NewVisitor(accountDetails.User, getPassword),
+			bakery.WebPageVisitor,
+		)
+	}
 
 	return juju.NewAPIConnectionParams{
 		Store:          store,


### PR DESCRIPTION
If you type "juju login" without specifying a user,
and there is no active account, then we will attempt
to log in using external user macaroon auth. If that
fails for a reason other than failure to authenticate,
then we'll fall back to logging in as a local user.

(Review request: http://reviews.vapour.ws/r/5624/)