### PR TITLE
Display controller HA status in list and show controllers

### DIFF
--- a/api/base/types.go
+++ b/api/base/types.go
@@ -28,4 +28,14 @@ type ModelStatus struct {
 	CoreCount          int
 	HostedMachineCount int
 	ServiceCount       int
+	Machines           []Machine
+}
+
+// Machine holds information about a machine in a juju model.
+type Machine struct {
+	Id         string
+	InstanceId string
+	HasVote    bool
+	WantsVote  bool
+	Status     string
 }

--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -143,10 +143,17 @@ func (c *Client) ModelStatus(tags ...names.ModelTag) ([]base.ModelStatus, error)
 			ServiceCount:       r.ApplicationCount,
 			TotalMachineCount:  len(r.Machines),
 		}
-		// For now, we just care about core count.
-		for _, mm := range r.Machines {
+		results[i].Machines = make([]base.Machine, len(r.Machines))
+		for j, mm := range r.Machines {
 			if mm.Hardware != nil && mm.Hardware.Cores != nil {
 				results[i].CoreCount += int(*mm.Hardware.Cores)
+			}
+			results[i].Machines[j] = base.Machine{
+				Id:         mm.Id,
+				InstanceId: mm.InstanceId,
+				HasVote:    mm.HasVote,
+				WantsVote:  mm.WantsVote,
+				Status:     mm.Status,
 			}
 		}
 	}

--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -247,15 +247,18 @@ func (s *legacySuite) TestAPIServerCanShutdownWithOutstandingNext(c *gc.C) {
 func (s *legacySuite) TestModelStatus(c *gc.C) {
 	sysManager := s.OpenAPI(c)
 	defer sysManager.Close()
+	s.Factory.MakeMachine(c, nil)
 	modelTag := s.State.ModelTag()
 	results, err := sysManager.ModelStatus(modelTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, []base.ModelStatus{{
 		UUID:               modelTag.Id(),
-		HostedMachineCount: 0,
+		TotalMachineCount:  1,
+		HostedMachineCount: 1,
 		ServiceCount:       0,
 		Owner:              "admin@local",
 		Life:               params.Alive,
+		Machines:           []base.Machine{{Id: "0", InstanceId: "id-2", Status: "pending"}},
 	}})
 }
 

--- a/apiserver/common/machine.go
+++ b/apiserver/common/machine.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/status"
 )
 
 // StateJobs translates a slice of multiwatcher jobs to their equivalents in state.
@@ -55,6 +56,10 @@ func (st *stateShim) Machine(id string) (Machine, error) {
 
 type Machine interface {
 	Id() string
+	InstanceId() (instance.Id, error)
+	WantsVote() bool
+	HasVote() bool
+	Status() (status.StatusInfo, error)
 	ContainerType() instance.ContainerType
 	HardwareCharacteristics() (*instance.HardwareCharacteristics, error)
 	Life() state.Life
@@ -99,7 +104,28 @@ func ModelMachineInfo(st ModelManagerBackend) (machineInfo []params.ModelMachine
 		if m.Life() != state.Alive {
 			continue
 		}
-		mInfo := params.ModelMachineInfo{Id: m.Id()}
+		var status string
+		statusInfo, err := m.Status()
+		if err == nil {
+			status = string(statusInfo.Status)
+		} else {
+			status = err.Error()
+		}
+		mInfo := params.ModelMachineInfo{
+			Id:        m.Id(),
+			HasVote:   m.HasVote(),
+			WantsVote: m.WantsVote(),
+			Status:    status,
+		}
+		instId, err := m.InstanceId()
+		switch {
+		case err == nil:
+			mInfo.InstanceId = string(instId)
+		case errors.IsNotProvisioned(err):
+			// ok, but no instance ID to get.
+		default:
+			return nil, errors.Trace(err)
+		}
 		if m.ContainerType() != "" && m.ContainerType() != instance.NONE {
 			machineInfo = append(machineInfo, mInfo)
 			continue

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -267,15 +267,17 @@ func (s *controllerSuite) TestModelStatus(c *gc.C) {
 	s.Factory.MakeMachine(c, &factory.MachineParams{
 		Jobs:            []state.MachineJob{state.JobManageModel},
 		Characteristics: &instance.HardwareCharacteristics{CpuCores: &eight},
+		InstanceId:      "id-4",
 	})
-	s.Factory.MakeMachine(c, &factory.MachineParams{Jobs: []state.MachineJob{state.JobHostUnits}})
+	s.Factory.MakeMachine(c, &factory.MachineParams{
+		Jobs: []state.MachineJob{state.JobHostUnits}, InstanceId: "id-5"})
 	s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: s.Factory.MakeCharm(c, nil),
 	})
 
 	otherFactory := factory.NewFactory(otherSt)
-	otherFactory.MakeMachine(c, nil)
-	otherFactory.MakeMachine(c, nil)
+	otherFactory.MakeMachine(c, &factory.MachineParams{InstanceId: "id-8"})
+	otherFactory.MakeMachine(c, &factory.MachineParams{InstanceId: "id-9"})
 	otherFactory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: otherFactory.MakeCharm(c, nil),
 	})
@@ -295,15 +297,15 @@ func (s *controllerSuite) TestModelStatus(c *gc.C) {
 		Arch: &arch,
 		Mem:  &mem,
 	}
-	c.Assert(results.Results, gc.DeepEquals, []params.ModelStatus{{
+	c.Assert(results.Results, jc.DeepEquals, []params.ModelStatus{{
 		ModelTag:           controllerEnvTag,
 		HostedMachineCount: 1,
 		ApplicationCount:   1,
 		OwnerTag:           "user-admin@local",
 		Life:               params.Alive,
 		Machines: []params.ModelMachineInfo{
-			{Id: "0", Hardware: &params.MachineHardware{Cores: &eight}},
-			{Id: "1", Hardware: stdHw},
+			{Id: "0", Hardware: &params.MachineHardware{Cores: &eight}, InstanceId: "id-4", Status: "pending", WantsVote: true},
+			{Id: "1", Hardware: stdHw, InstanceId: "id-5", Status: "pending"},
 		},
 	}, {
 		ModelTag:           hostedEnvTag,
@@ -312,8 +314,8 @@ func (s *controllerSuite) TestModelStatus(c *gc.C) {
 		OwnerTag:           otherEnvOwner.UserTag.String(),
 		Life:               params.Alive,
 		Machines: []params.ModelMachineInfo{
-			{Id: "0", Hardware: stdHw},
-			{Id: "1", Hardware: stdHw},
+			{Id: "0", Hardware: stdHw, InstanceId: "id-8", Status: "pending"},
+			{Id: "1", Hardware: stdHw, InstanceId: "id-9", Status: "pending"},
 		},
 	}})
 }

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -499,6 +499,22 @@ func (m *mockMachine) HardwareCharacteristics() (*instance.HardwareCharacteristi
 	return m.hw, nil
 }
 
+func (m *mockMachine) InstanceId() (instance.Id, error) {
+	return "", nil
+}
+
+func (m *mockMachine) WantsVote() bool {
+	return false
+}
+
+func (m *mockMachine) HasVote() bool {
+	return false
+}
+
+func (m *mockMachine) Status() (status.StatusInfo, error) {
+	return status.StatusInfo{}, nil
+}
+
 type mockModel struct {
 	gitjujutesting.Stub
 	owner  names.UserTag

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -150,8 +150,12 @@ type ModelInfoListResults struct {
 
 // ModelMachineInfo holds information about a machine in a model.
 type ModelMachineInfo struct {
-	Id       string           `json:"id"`
-	Hardware *MachineHardware `json:"hardware,omitempty"`
+	Id         string           `json:"id"`
+	Hardware   *MachineHardware `json:"hardware,omitempty"`
+	InstanceId string           `json:"instance-id,omitempty"`
+	Status     string           `json:"status,omitempty"`
+	HasVote    bool             `json:"has-vote,omitempty"`
+	WantsVote  bool             `json:"wants-vote,omitempty"`
 }
 
 // MachineHardware holds information about a machine's hardware characteristics.

--- a/cmd/juju/controller/listcontrollersconverters.go
+++ b/cmd/juju/controller/listcontrollersconverters.go
@@ -22,18 +22,19 @@ type ControllerSet struct {
 
 // ControllerItem defines the serialization behaviour of controller information.
 type ControllerItem struct {
-	ModelName      string   `yaml:"current-model,omitempty" json:"current-model,omitempty"`
-	User           string   `yaml:"user,omitempty" json:"user,omitempty"`
-	Access         string   `yaml:"access,omitempty" json:"access,omitempty"`
-	Server         string   `yaml:"recent-server,omitempty" json:"recent-server,omitempty"`
-	ControllerUUID string   `yaml:"uuid" json:"uuid"`
-	APIEndpoints   []string `yaml:"api-endpoints,flow" json:"api-endpoints"`
-	CACert         string   `yaml:"ca-cert" json:"ca-cert"`
-	Cloud          string   `yaml:"cloud" json:"cloud"`
-	CloudRegion    string   `yaml:"region,omitempty" json:"region,omitempty"`
-	AgentVersion   string   `yaml:"agent-version,omitempty" json:"agent-version,omitempty"`
-	ModelCount     *int     `yaml:"model-count,omitempty" json:"model-count,omitempty"`
-	MachineCount   *int     `yaml:"machine-count,omitempty" json:"machine-count,omitempty"`
+	ModelName          string   `yaml:"current-model,omitempty" json:"current-model,omitempty"`
+	User               string   `yaml:"user,omitempty" json:"user,omitempty"`
+	Access             string   `yaml:"access,omitempty" json:"access,omitempty"`
+	Server             string   `yaml:"recent-server,omitempty" json:"recent-server,omitempty"`
+	ControllerUUID     string   `yaml:"uuid" json:"uuid"`
+	APIEndpoints       []string `yaml:"api-endpoints,flow" json:"api-endpoints"`
+	CACert             string   `yaml:"ca-cert" json:"ca-cert"`
+	Cloud              string   `yaml:"cloud" json:"cloud"`
+	CloudRegion        string   `yaml:"region,omitempty" json:"region,omitempty"`
+	AgentVersion       string   `yaml:"agent-version,omitempty" json:"agent-version,omitempty"`
+	ModelCount         *int     `yaml:"model-count,omitempty" json:"model-count,omitempty"`
+	MachineCount       *int     `yaml:"machine-count,omitempty" json:"machine-count,omitempty"`
+	ControllerMachines string   `yaml:"controller-machines,omitempty" json:"controller-machines,omitempty"`
 }
 
 // convertControllerDetails takes a map of Controllers and
@@ -91,18 +92,19 @@ func (c *listControllersCommand) convertControllerDetails(storeControllers map[s
 		}
 
 		controllers[controllerName] = ControllerItem{
-			ModelName:      modelName,
-			User:           userName,
-			Access:         access,
-			Server:         serverName,
-			APIEndpoints:   details.APIEndpoints,
-			ControllerUUID: details.ControllerUUID,
-			CACert:         details.CACert,
-			Cloud:          details.Cloud,
-			CloudRegion:    details.CloudRegion,
-			ModelCount:     details.ModelCount,
-			MachineCount:   details.MachineCount,
-			AgentVersion:   details.AgentVersion,
+			ModelName:          modelName,
+			User:               userName,
+			Access:             access,
+			Server:             serverName,
+			APIEndpoints:       details.APIEndpoints,
+			ControllerUUID:     details.ControllerUUID,
+			CACert:             details.CACert,
+			Cloud:              details.Cloud,
+			CloudRegion:        details.CloudRegion,
+			ModelCount:         details.ModelCount,
+			MachineCount:       details.MachineCount,
+			AgentVersion:       details.AgentVersion,
+			ControllerMachines: details.ControllerMachines,
 		}
 	}
 	return controllers, errs

--- a/cmd/juju/controller/listcontrollersformatters.go
+++ b/cmd/juju/controller/listcontrollersformatters.go
@@ -34,7 +34,20 @@ func (c *listControllersCommand) formatControllersListTabular(writer io.Writer, 
 func formatControllersTabular(writer io.Writer, set ControllerSet, promptRefresh bool) error {
 	tw := output.TabWriter(writer)
 	w := output.Wrapper{tw}
-	w.Println("CONTROLLER", "MODEL", "USER", "ACCESS", "CLOUD/REGION", "MODELS", "MACHINES", "VERSION")
+
+	// See if we need the HA column.
+	showHA := false
+	for _, c := range set.Controllers {
+		if c.ControllerMachines != "" {
+			showHA = true
+			break
+		}
+	}
+	if showHA {
+		w.Println("CONTROLLER", "MODEL", "USER", "ACCESS", "CLOUD/REGION", "MODELS", "MACHINES", "HA", "VERSION")
+	} else {
+		w.Println("CONTROLLER", "MODEL", "USER", "ACCESS", "CLOUD/REGION", "MODELS", "MACHINES", "VERSION")
+	}
 
 	names := []string{}
 	for name := range set.Controllers {
@@ -96,6 +109,13 @@ func formatControllersTabular(writer io.Writer, set ControllerSet, promptRefresh
 			}
 		}
 		w.Print(modelName, userName, access, cloudRegion, modelCount, machineCount)
+		if showHA {
+			controllerMachineInfo := c.ControllerMachines
+			if promptRefresh {
+				controllerMachineInfo += refresh
+			}
+			w.Print(controllerMachineInfo)
+		}
 		if staleVersion {
 			w.PrintColor(output.WarningHighlight, agentVersion)
 		} else {

--- a/cmd/juju/controller/package_test.go
+++ b/cmd/juju/controller/package_test.go
@@ -81,12 +81,12 @@ const testModelsYaml = `
 controllers:
   aws-test:
     models:
-      admin:
+      controller:
         uuid: ghi
-    current-model: admin
+    current-model: controller
   mallards:
     models:
-      admin:
+      controller:
         uuid: abc
       my-model:
         uuid: def

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -16,7 +16,9 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/description"
+	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/status"
 )
 
 var usageShowControllerSummary = `
@@ -190,6 +192,9 @@ type ShowControllerDetails struct {
 	// Details contains the same details that client store caches for this controller.
 	Details ControllerDetails `yaml:"details,omitempty" json:"details,omitempty"`
 
+	// Machines is a collection of all machines forming the controller cluster.
+	Machines map[string]MachineDetails `yaml:"controller-machines,omitempty" json:"controller-machines,omitempty"`
+
 	// Models is a collection of all models for this controller.
 	Models map[string]ModelDetails `yaml:"models,omitempty" json:"models,omitempty"`
 
@@ -225,6 +230,18 @@ type ControllerDetails struct {
 	// used in both list-controller and show-controller. show-controller
 	// displays the agent version where list-controller does not.
 	AgentVersion string `yaml:"agent-version,omitempty" json:"agent-version,omitempty"`
+}
+
+// ModelDetails holds details of a model to show.
+type MachineDetails struct {
+	// ID holds the id of the machine.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
+	// InstanceID holds the cloud instance id of the machine.
+	InstanceID string `yaml:"instance-id,omitempty" json:"instance-id,omitempty"`
+
+	// HAStatus holds information informing of the HA status of the machine.
+	HAStatus string `yaml:"ha-status,omitempty" json:"ha-status,omitempty"`
 }
 
 // ModelDetails holds details of a model to show.
@@ -270,6 +287,27 @@ func (c *showControllerCommand) convertControllerForShow(
 	}
 	c.convertModelsForShow(controllerName, controller, allModels, modelStatus)
 	c.convertAccountsForShow(controllerName, controller, access)
+	var controllerModelUUID string
+	for _, m := range allModels {
+		if m.Name == bootstrap.ControllerModelName {
+			controllerModelUUID = m.UUID
+			break
+		}
+	}
+	if controllerModelUUID != "" {
+		var controllerModel base.ModelStatus
+		found := false
+		for _, m := range modelStatus {
+			if m.UUID == controllerModelUUID {
+				controllerModel = m
+				found = true
+				break
+			}
+		}
+		if found {
+			c.convertMachinesForShow(controllerName, controller, controllerModel)
+		}
+	}
 }
 
 func (c *showControllerCommand) convertAccountsForShow(controllerName string, controller *ShowControllerDetails, access string) {
@@ -314,4 +352,40 @@ func (c *showControllerCommand) convertModelsForShow(
 	if err != nil && !errors.IsNotFound(err) {
 		controller.Errors = append(controller.Errors, err.Error())
 	}
+}
+
+func (c *showControllerCommand) convertMachinesForShow(
+	controllerName string,
+	controller *ShowControllerDetails,
+	controllerModel base.ModelStatus,
+) {
+	controller.Machines = make(map[string]MachineDetails)
+	for _, m := range controllerModel.Machines {
+		if !m.WantsVote {
+			// Skip non controller machines.
+			continue
+		}
+		instId := m.InstanceId
+		if instId == "" {
+			instId = "(unprovisioned)"
+		}
+		details := MachineDetails{InstanceID: instId}
+		if len(controllerModel.Machines) > 1 {
+			details.HAStatus = haStatus(m.HasVote, m.WantsVote, m.Status)
+		}
+		controller.Machines[m.Id] = details
+	}
+}
+
+func haStatus(hasVote bool, wantsVote bool, statusStr string) string {
+	if statusStr == string(status.StatusDown) {
+		return "down, lost connection"
+	}
+	if !wantsVote {
+		return ""
+	}
+	if hasVote {
+		return "ha-enabled"
+	}
+	return "ha-pending"
 }

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -40,6 +40,13 @@ type ControllerDetails struct {
 	// in formatting show-controller output where this struct is also used.
 	AgentVersion string `yaml:"agent-version,omitempty"`
 
+	// ControllerMachines represents the number of controller machines
+	// and which ones are active in the HA cluster.
+	// Either: #active/#total or #total (if all machines are active)
+	// It is cached here so under normal usage list-controllers
+	// does not need to hit the server.
+	ControllerMachines string `yaml:"controller-machines,omitempty"`
+
 	// ModelCount is the number of models to which a user has access.
 	// It is cached here so under normal usage list-controllers
 	// does not need to hit the server.


### PR DESCRIPTION
A proposal for: https://bugs.launchpad.net/juju/+bug/1600453

juju list-controllers and show-controller now show information about the controller machines themselves. The list command displays a little HA status column reflecting num_active/num_total controller machines. The show command displays for each controller machine its instance id and HA status.

(Review request: http://reviews.vapour.ws/r/5625/)