### PR TITLE
Support openstack clouds with no cinder.

### DIFF
--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -154,6 +154,7 @@ type Environ struct {
 	ecfgUnlocked *environConfig
 	client       client.AuthenticatingClient
 	novaUnlocked *nova.Client
+	volumeURL    *url.URL
 
 	// keystoneImageDataSource caches the result of getKeystoneImageSource.
 	keystoneImageDataSourceMutex sync.Mutex
@@ -648,6 +649,15 @@ func (e *Environ) SetConfig(cfg *config.Config) error {
 	}
 	e.client = client
 	e.novaUnlocked = nova.New(e.client)
+
+	if url, err := getVolumeEndpointURL(client, e.cloud.Region); err != nil {
+		if !errors.IsNotFound(err) {
+			return errors.Trace(err)
+		}
+	} else {
+		e.volumeURL = url
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Check to see if cinder is available when the environment is opened and cache it.

(Review request: http://reviews.vapour.ws/r/5628/)