### PR TITLE
Tweak list controllers output, right align some columns

### DIFF
--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -38,9 +38,9 @@ CONTROLLER  MODEL  USER  ACCESS  CLOUD/REGION  MODELS  MACHINES  VERSION
 func (s *ListControllersSuite) TestListControllers(c *gc.C) {
 	s.expectedOutput = `
 CONTROLLER           MODEL       USER         ACCESS      CLOUD/REGION        MODELS  MACHINES  VERSION
-aws-test             controller  -            -           aws/us-east-1       2+      5+        2.0.1+      
-mallards*            my-model    admin@local  superuser+  mallards/mallards1  -       -         (unknown)+  
-mark-test-prodstack  -           admin@local  (unknown)+  prodstack           -       -         (unknown)+  
+aws-test             controller  -            -           aws/us-east-1           2+        5+  2.0.1+      
+mallards*            my-model    admin@local  superuser+  mallards/mallards1       -         -  (unknown)+  
+mark-test-prodstack  -           admin@local  (unknown)+  prodstack                -         -  (unknown)+  
 
 + these are the last known values, run with --refresh to see the latest information.
 
@@ -67,9 +67,9 @@ func (s *ListControllersSuite) TestListControllersRefresh(c *gc.C) {
 	}
 	s.expectedOutput = `
 CONTROLLER           MODEL       USER         ACCESS     CLOUD/REGION        MODELS  MACHINES  VERSION
-aws-test             controller  admin@local  (unknown)  aws/us-east-1       1       2         2.0.1      
-mallards*            my-model    admin@local  superuser  mallards/mallards1  2       4         (unknown)  
-mark-test-prodstack  -           admin@local  (unknown)  prodstack           0       0         (unknown)  
+aws-test             controller  admin@local  (unknown)  aws/us-east-1            1         2  2.0.1      
+mallards*            my-model    admin@local  superuser  mallards/mallards1       2         4  (unknown)  
+mark-test-prodstack  -           admin@local  (unknown)  prodstack                0         0  (unknown)  
 
 `[1:]
 	s.assertListControllers(c, "--refresh")
@@ -99,10 +99,10 @@ func (s *ListControllersSuite) TestListControllersHAStatus(c *gc.C) {
 		return fakeController
 	}
 	s.expectedOutput = `
-CONTROLLER           MODEL       USER         ACCESS     CLOUD/REGION        MODELS  MACHINES  HA   VERSION
-aws-test             controller  admin@local  (unknown)  aws/us-east-1       1       2         1/3  2.0.1      
-mallards*            my-model    admin@local  superuser  mallards/mallards1  2       4              (unknown)  
-mark-test-prodstack  -           admin@local  (unknown)  prodstack           0       0              (unknown)  
+CONTROLLER           MODEL       USER         ACCESS     CLOUD/REGION        MODELS  MACHINES   HA  VERSION
+aws-test             controller  admin@local  (unknown)  aws/us-east-1            1         2  1/3  2.0.1      
+mallards*            my-model    admin@local  superuser  mallards/mallards1       2         4    1  (unknown)  
+mark-test-prodstack  -           admin@local  (unknown)  prodstack                0         0    1  (unknown)  
 
 `[1:]
 	s.assertListControllers(c, "--refresh")

--- a/cmd/juju/controller/listcontrollersformatters.go
+++ b/cmd/juju/controller/listcontrollersformatters.go
@@ -45,8 +45,13 @@ func formatControllersTabular(writer io.Writer, set ControllerSet, promptRefresh
 	}
 	if showHA {
 		w.Println("CONTROLLER", "MODEL", "USER", "ACCESS", "CLOUD/REGION", "MODELS", "MACHINES", "HA", "VERSION")
+		tw.SetColumnAlignRight(5)
+		tw.SetColumnAlignRight(6)
+		tw.SetColumnAlignRight(7)
 	} else {
 		w.Println("CONTROLLER", "MODEL", "USER", "ACCESS", "CLOUD/REGION", "MODELS", "MACHINES", "VERSION")
+		tw.SetColumnAlignRight(5)
+		tw.SetColumnAlignRight(6)
 	}
 
 	names := []string{}
@@ -111,6 +116,9 @@ func formatControllersTabular(writer io.Writer, set ControllerSet, promptRefresh
 		w.Print(modelName, userName, access, cloudRegion, modelCount, machineCount)
 		if showHA {
 			controllerMachineInfo := c.ControllerMachines
+			if controllerMachineInfo == "" {
+				controllerMachineInfo = "1"
+			}
 			if promptRefresh {
 				controllerMachineInfo += refresh
 			}

--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -283,6 +283,12 @@ func (c *modelsCommand) formatTabular(writer io.Writer, value interface{}) error
 	}
 	if haveMachineInfo {
 		w.Println("OWNER", "STATUS", "MACHINES", "CORES", "ACCESS", "LAST CONNECTION")
+		offset := 0
+		if c.listUUID {
+			offset++
+		}
+		tw.SetColumnAlignRight(3 + offset)
+		tw.SetColumnAlignRight(4 + offset)
 	} else {
 		w.Println("OWNER", "STATUS", "ACCESS", "LAST CONNECTION")
 	}
@@ -309,10 +315,7 @@ func (c *modelsCommand) formatTabular(writer io.Writer, value interface{}) error
 		access := model.Users[userForAccess.Canonical()].Access
 		w.Print(model.Owner, model.Status.Current)
 		if haveMachineInfo {
-			machineInfo := "-"
-			if len(model.Machines) > 0 {
-				machineInfo = fmt.Sprintf("%d", len(model.Machines))
-			}
+			machineInfo := fmt.Sprintf("%d", len(model.Machines))
 			cores := uint64(0)
 			for _, m := range model.Machines {
 				cores += m.Cores

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -201,16 +201,17 @@ func (s *ModelsSuite) TestAllModelsNoneCurrent(c *gc.C) {
 }
 
 func (s *ModelsSuite) TestModelsUUID(c *gc.C) {
+	s.api.inclMachines = true
 	context, err := testing.RunCommand(c, s.newCommand(), "--uuid")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.user, gc.Equals, "admin@local")
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
 		"CONTROLLER: fake\n"+
 		"\n"+
-		"MODEL                        UUID              OWNER            STATUS      ACCESS  LAST CONNECTION\n"+
-		"test-model1*                 test-model1-UUID  admin@local      active      read    2015-03-20\n"+
-		"carlotta/test-model2         test-model2-UUID  carlotta@local   active      write   2015-03-01\n"+
-		"daiwik@external/test-model3  test-model3-UUID  daiwik@external  destroying          never connected\n"+
+		"MODEL                        UUID              OWNER            STATUS      MACHINES  CORES  ACCESS  LAST CONNECTION\n"+
+		"test-model1*                 test-model1-UUID  admin@local      active             2      1  read    2015-03-20\n"+
+		"carlotta/test-model2         test-model2-UUID  carlotta@local   active             0      -  write   2015-03-01\n"+
+		"daiwik@external/test-model3  test-model3-UUID  daiwik@external  destroying         0      -          never connected\n"+
 		"\n")
 }
 
@@ -223,9 +224,9 @@ func (s *ModelsSuite) TestModelsMachineInfo(c *gc.C) {
 		"CONTROLLER: fake\n"+
 		"\n"+
 		"MODEL                        OWNER            STATUS      MACHINES  CORES  ACCESS  LAST CONNECTION\n"+
-		"test-model1*                 admin@local      active      2         1      read    2015-03-20\n"+
-		"carlotta/test-model2         carlotta@local   active      -         -      write   2015-03-01\n"+
-		"daiwik@external/test-model3  daiwik@external  destroying  -         -              never connected\n"+
+		"test-model1*                 admin@local      active             2      1  read    2015-03-20\n"+
+		"carlotta/test-model2         carlotta@local   active             0      -  write   2015-03-01\n"+
+		"daiwik@external/test-model3  daiwik@external  destroying         0      -          never connected\n"+
 		"\n")
 }
 

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -73,7 +73,7 @@ func (s *cmdControllerSuite) TestControllerListCommand(c *gc.C) {
 	context := s.run(c, "list-controllers")
 	expectedOutput := `
 CONTROLLER  MODEL       USER         ACCESS      CLOUD/REGION        MODELS  MACHINES  VERSION
-kontroll*   controller  admin@local  superuser+  dummy/dummy-region  -       -         (unknown)+  
+kontroll*   controller  admin@local  superuser+  dummy/dummy-region       -         -  (unknown)+  
 
 + these are the last known values, run with --refresh to see the latest information.
 


### PR DESCRIPTION
MACHINES, MODELS, HA columns right aligned.
If HA column is shown, display "1" instead of empty.

(Review request: http://reviews.vapour.ws/r/5630/)