### PR TITLE
Add missing newline to error output

### DIFF
--- a/cmd/juju/controller/listcontrollers.go
+++ b/cmd/juju/controller/listcontrollers.go
@@ -91,7 +91,7 @@ func (c *listControllersCommand) Run(ctx *cmd.Context) error {
 				defer wg.Done()
 				client, err := c.getAPI(name)
 				if err != nil {
-					fmt.Fprintf(ctx.GetStderr(), "error connecting to api for %q: %v", name, err)
+					fmt.Fprintf(ctx.GetStderr(), "error connecting to api for %q: %v\n", name, err)
 					return
 				}
 				defer client.Close()


### PR DESCRIPTION
Printing an error was missing a newline

(Review request: http://reviews.vapour.ws/r/5632/)