### PR TITLE
Highlight when active controllers < total

### DIFF
--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -37,10 +37,10 @@ CONTROLLER  MODEL  USER  ACCESS  CLOUD/REGION  MODELS  MACHINES  VERSION
 
 func (s *ListControllersSuite) TestListControllers(c *gc.C) {
 	s.expectedOutput = `
-CONTROLLER           MODEL       USER         ACCESS      CLOUD/REGION        MODELS  MACHINES  VERSION
-aws-test             controller  -            -           aws/us-east-1           2+        5+  2.0.1+      
-mallards*            my-model    admin@local  superuser+  mallards/mallards1       -         -  (unknown)+  
-mark-test-prodstack  -           admin@local  (unknown)+  prodstack                -         -  (unknown)+  
+CONTROLLER           MODEL       USER         ACCESS+    CLOUD/REGION        MODELS+  MACHINES+  VERSION+
+aws-test             controller  -            -          aws/us-east-1             2          5  2.0.1      
+mallards*            my-model    admin@local  superuser  mallards/mallards1        -          -  (unknown)  
+mark-test-prodstack  -           admin@local  (unknown)  prodstack                 -          -  (unknown)  
 
 + these are the last known values, run with --refresh to see the latest information.
 
@@ -69,14 +69,13 @@ func (s *ListControllersSuite) TestListControllersRefresh(c *gc.C) {
 CONTROLLER           MODEL       USER         ACCESS     CLOUD/REGION        MODELS  MACHINES  VERSION
 aws-test             controller  admin@local  (unknown)  aws/us-east-1            1         2  2.0.1      
 mallards*            my-model    admin@local  superuser  mallards/mallards1       2         4  (unknown)  
-mark-test-prodstack  -           admin@local  (unknown)  prodstack                0         0  (unknown)  
+mark-test-prodstack  -           admin@local  (unknown)  prodstack                -         -  (unknown)  
 
 `[1:]
 	s.assertListControllers(c, "--refresh")
 }
 
-func (s *ListControllersSuite) TestListControllersHAStatus(c *gc.C) {
-	s.createTestClientStore(c)
+func (s *ListControllersSuite) setupAPIForControllerMachines() {
 	s.api = func(controllerName string) controller.ControllerAccessAPI {
 		fakeController := &fakeController{
 			controllerName: controllerName,
@@ -87,22 +86,40 @@ func (s *ListControllersSuite) TestListControllersHAStatus(c *gc.C) {
 			},
 			store: s.store,
 		}
-		if controllerName == "aws-test" {
+		switch controllerName {
+		case "aws-test":
 			fakeController.machines = map[string][]base.Machine{
 				"ghi": {
 					{Id: "1", HasVote: true, WantsVote: true, Status: "active"},
 					{Id: "2", HasVote: true, WantsVote: true, Status: "down"},
 					{Id: "3", HasVote: false, WantsVote: true, Status: "active"},
 				},
+				"abc": {
+					{Id: "1", HasVote: true, WantsVote: true, Status: "active"},
+				},
+				"def": {
+					{Id: "1", HasVote: true, WantsVote: true, Status: "active"},
+				},
+			}
+		case "mallards":
+			fakeController.machines = map[string][]base.Machine{
+				"abc": {
+					{Id: "1", HasVote: true, WantsVote: true, Status: "active"},
+				},
 			}
 		}
 		return fakeController
 	}
+}
+
+func (s *ListControllersSuite) TestListControllersHAStatus(c *gc.C) {
+	s.createTestClientStore(c)
+	s.setupAPIForControllerMachines()
 	s.expectedOutput = `
 CONTROLLER           MODEL       USER         ACCESS     CLOUD/REGION        MODELS  MACHINES   HA  VERSION
 aws-test             controller  admin@local  (unknown)  aws/us-east-1            1         2  1/3  2.0.1      
 mallards*            my-model    admin@local  superuser  mallards/mallards1       2         4    1  (unknown)  
-mark-test-prodstack  -           admin@local  (unknown)  prodstack                0         0    1  (unknown)  
+mark-test-prodstack  -           admin@local  (unknown)  prodstack                -         -    -  (unknown)  
 
 `[1:]
 	s.assertListControllers(c, "--refresh")
@@ -121,8 +138,11 @@ controllers:
     cloud: aws
     region: us-east-1
     agent-version: 2.0.1
-    model-count: 2
-    machine-count: 5
+    model-count: 1
+    machine-count: 2
+    controller-machines:
+      active: 1
+      total: 3
   mallards:
     current-model: my-model
     user: admin@local
@@ -133,6 +153,11 @@ controllers:
     ca-cert: this-is-another-ca-cert
     cloud: mallards
     region: mallards1
+    model-count: 2
+    machine-count: 4
+    controller-machines:
+      active: 1
+      total: 1
   mark-test-prodstack:
     user: admin@local
     recent-server: this-is-one-of-many-api-endpoints
@@ -144,7 +169,8 @@ current-controller: mallards
 `[1:]
 
 	s.createTestClientStore(c)
-	s.assertListControllers(c, "--format", "yaml")
+	s.setupAPIForControllerMachines()
+	s.assertListControllers(c, "--format", "yaml", "--refresh")
 }
 
 func intPtr(i int) *int {

--- a/cmd/juju/controller/listcontrollersconverters.go
+++ b/cmd/juju/controller/listcontrollersconverters.go
@@ -20,21 +20,28 @@ type ControllerSet struct {
 	CurrentController string                    `yaml:"current-controller" json:"current-controller"`
 }
 
+// ControllerMachines holds the total number of controller
+// machines and the number of active ones.
+type ControllerMachines struct {
+	Active int `yaml:"active"`
+	Total  int `yaml:"total"`
+}
+
 // ControllerItem defines the serialization behaviour of controller information.
 type ControllerItem struct {
-	ModelName          string   `yaml:"current-model,omitempty" json:"current-model,omitempty"`
-	User               string   `yaml:"user,omitempty" json:"user,omitempty"`
-	Access             string   `yaml:"access,omitempty" json:"access,omitempty"`
-	Server             string   `yaml:"recent-server,omitempty" json:"recent-server,omitempty"`
-	ControllerUUID     string   `yaml:"uuid" json:"uuid"`
-	APIEndpoints       []string `yaml:"api-endpoints,flow" json:"api-endpoints"`
-	CACert             string   `yaml:"ca-cert" json:"ca-cert"`
-	Cloud              string   `yaml:"cloud" json:"cloud"`
-	CloudRegion        string   `yaml:"region,omitempty" json:"region,omitempty"`
-	AgentVersion       string   `yaml:"agent-version,omitempty" json:"agent-version,omitempty"`
-	ModelCount         *int     `yaml:"model-count,omitempty" json:"model-count,omitempty"`
-	MachineCount       *int     `yaml:"machine-count,omitempty" json:"machine-count,omitempty"`
-	ControllerMachines string   `yaml:"controller-machines,omitempty" json:"controller-machines,omitempty"`
+	ModelName          string              `yaml:"current-model,omitempty" json:"current-model,omitempty"`
+	User               string              `yaml:"user,omitempty" json:"user,omitempty"`
+	Access             string              `yaml:"access,omitempty" json:"access,omitempty"`
+	Server             string              `yaml:"recent-server,omitempty" json:"recent-server,omitempty"`
+	ControllerUUID     string              `yaml:"uuid" json:"uuid"`
+	APIEndpoints       []string            `yaml:"api-endpoints,flow" json:"api-endpoints"`
+	CACert             string              `yaml:"ca-cert" json:"ca-cert"`
+	Cloud              string              `yaml:"cloud" json:"cloud"`
+	CloudRegion        string              `yaml:"region,omitempty" json:"region,omitempty"`
+	AgentVersion       string              `yaml:"agent-version,omitempty" json:"agent-version,omitempty"`
+	ModelCount         *int                `yaml:"model-count,omitempty" json:"model-count,omitempty"`
+	MachineCount       *int                `yaml:"machine-count,omitempty" json:"machine-count,omitempty"`
+	ControllerMachines *ControllerMachines `yaml:"controller-machines,omitempty" json:"controller-machins,omitempty"`
 }
 
 // convertControllerDetails takes a map of Controllers and
@@ -91,21 +98,31 @@ func (c *listControllersCommand) convertControllerDetails(storeControllers map[s
 			}
 		}
 
-		controllers[controllerName] = ControllerItem{
-			ModelName:          modelName,
-			User:               userName,
-			Access:             access,
-			Server:             serverName,
-			APIEndpoints:       details.APIEndpoints,
-			ControllerUUID:     details.ControllerUUID,
-			CACert:             details.CACert,
-			Cloud:              details.Cloud,
-			CloudRegion:        details.CloudRegion,
-			ModelCount:         details.ModelCount,
-			MachineCount:       details.MachineCount,
-			AgentVersion:       details.AgentVersion,
-			ControllerMachines: details.ControllerMachines,
+		item := ControllerItem{
+			ModelName:      modelName,
+			User:           userName,
+			Access:         access,
+			Server:         serverName,
+			APIEndpoints:   details.APIEndpoints,
+			ControllerUUID: details.ControllerUUID,
+			CACert:         details.CACert,
+			Cloud:          details.Cloud,
+			CloudRegion:    details.CloudRegion,
+			AgentVersion:   details.AgentVersion,
 		}
+		if details.MachineCount != nil && *details.MachineCount > 0 {
+			item.MachineCount = details.MachineCount
+		}
+		if details.ModelCount != nil && *details.ModelCount > 0 {
+			item.ModelCount = details.ModelCount
+		}
+		if details.ControllerMachineCount > 0 {
+			item.ControllerMachines = &ControllerMachines{
+				Total:  details.ControllerMachineCount,
+				Active: details.ActiveControllerMachineCount,
+			}
+		}
+		controllers[controllerName] = item
 	}
 	return controllers, errs
 }

--- a/cmd/juju/controller/listcontrollersformatters.go
+++ b/cmd/juju/controller/listcontrollersformatters.go
@@ -38,18 +38,32 @@ func formatControllersTabular(writer io.Writer, set ControllerSet, promptRefresh
 	// See if we need the HA column.
 	showHA := false
 	for _, c := range set.Controllers {
-		if c.ControllerMachines != "" {
+		if c.ControllerMachines != nil && c.ControllerMachines.Total > 1 {
 			showHA = true
 			break
 		}
 	}
+
+	p := func(headers ...interface{}) {
+		if promptRefresh && len(set.Controllers) > 0 {
+			for i, h := range headers {
+				switch h {
+				case "ACCESS", "MACHINES", "MODELS", "HA", "VERSION":
+					h = h.(string) + refresh
+				}
+				headers[i] = h
+			}
+		}
+		w.Println(headers...)
+	}
+
 	if showHA {
-		w.Println("CONTROLLER", "MODEL", "USER", "ACCESS", "CLOUD/REGION", "MODELS", "MACHINES", "HA", "VERSION")
+		p("CONTROLLER", "MODEL", "USER", "ACCESS", "CLOUD/REGION", "MODELS", "MACHINES", "HA", "VERSION")
 		tw.SetColumnAlignRight(5)
 		tw.SetColumnAlignRight(6)
 		tw.SetColumnAlignRight(7)
 	} else {
-		w.Println("CONTROLLER", "MODEL", "USER", "ACCESS", "CLOUD/REGION", "MODELS", "MACHINES", "VERSION")
+		p("CONTROLLER", "MODEL", "USER", "ACCESS", "CLOUD/REGION", "MODELS", "MACHINES", "VERSION")
 		tw.SetColumnAlignRight(5)
 		tw.SetColumnAlignRight(6)
 	}
@@ -74,9 +88,6 @@ func formatControllersTabular(writer io.Writer, set ControllerSet, promptRefresh
 			if c.Access != "" {
 				access = c.Access
 			}
-			if promptRefresh {
-				access += refresh
-			}
 		}
 		if name == set.CurrentController {
 			name += "*"
@@ -96,33 +107,22 @@ func formatControllersTabular(writer io.Writer, set ControllerSet, promptRefresh
 			agentVersionNum, err := version.Parse(agentVersion)
 			staleVersion = err == nil && jujuversion.Current.Compare(agentVersionNum) > 0
 		}
-		if promptRefresh {
-			agentVersion += refresh
-		}
 		machineCount := noValueDisplay
-		if c.MachineCount != nil {
+		if c.MachineCount != nil && *c.MachineCount > 0 {
 			machineCount = fmt.Sprintf("%d", *c.MachineCount)
-			if promptRefresh {
-				machineCount += refresh
-			}
 		}
 		modelCount := noValueDisplay
-		if c.ModelCount != nil {
+		if c.ModelCount != nil && *c.ModelCount > 0 {
 			modelCount = fmt.Sprintf("%d", *c.ModelCount)
-			if promptRefresh {
-				modelCount += refresh
-			}
 		}
 		w.Print(modelName, userName, access, cloudRegion, modelCount, machineCount)
 		if showHA {
-			controllerMachineInfo := c.ControllerMachines
-			if controllerMachineInfo == "" {
-				controllerMachineInfo = "1"
+			controllerMachineInfo, warn := controllerMachineStatus(c.ControllerMachines)
+			if warn {
+				w.PrintColor(output.WarningHighlight, controllerMachineInfo)
+			} else {
+				w.Print(controllerMachineInfo)
 			}
-			if promptRefresh {
-				controllerMachineInfo += refresh
-			}
-			w.Print(controllerMachineInfo)
 		}
 		if staleVersion {
 			w.PrintColor(output.WarningHighlight, agentVersion)
@@ -136,4 +136,17 @@ func formatControllersTabular(writer io.Writer, set ControllerSet, promptRefresh
 		fmt.Fprintln(writer, "\n+ these are the last known values, run with --refresh to see the latest information.")
 	}
 	return nil
+}
+
+func controllerMachineStatus(machines *ControllerMachines) (string, bool) {
+	if machines == nil || machines.Total == 0 {
+		return "-", false
+	}
+	controllerMachineStatus := ""
+	warn := machines.Active < machines.Total
+	controllerMachineStatus = fmt.Sprintf("%d", machines.Total)
+	if machines.Active < machines.Total {
+		controllerMachineStatus = fmt.Sprintf("%d/%d", machines.Active, machines.Total)
+	}
+	return controllerMachineStatus, warn
 }

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -360,6 +360,13 @@ func (c *showControllerCommand) convertMachinesForShow(
 	controllerModel base.ModelStatus,
 ) {
 	controller.Machines = make(map[string]MachineDetails)
+	numControllers := 0
+	for _, m := range controllerModel.Machines {
+		if !m.WantsVote {
+			continue
+		}
+		numControllers++
+	}
 	for _, m := range controllerModel.Machines {
 		if !m.WantsVote {
 			// Skip non controller machines.
@@ -370,7 +377,7 @@ func (c *showControllerCommand) convertMachinesForShow(
 			instId = "(unprovisioned)"
 		}
 		details := MachineDetails{InstanceID: instId}
-		if len(controllerModel.Machines) > 1 {
+		if numControllers > 1 {
 			details.HAStatus = haStatus(m.HasVote, m.WantsVote, m.Status)
 		}
 		controller.Machines[m.Id] = details

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -72,8 +72,8 @@ func (s *cmdControllerSuite) createModelNormalUser(c *gc.C, modelname string, is
 func (s *cmdControllerSuite) TestControllerListCommand(c *gc.C) {
 	context := s.run(c, "list-controllers")
 	expectedOutput := `
-CONTROLLER  MODEL       USER         ACCESS      CLOUD/REGION        MODELS  MACHINES  VERSION
-kontroll*   controller  admin@local  superuser+  dummy/dummy-region       -         -  (unknown)+  
+CONTROLLER  MODEL       USER         ACCESS+    CLOUD/REGION        MODELS+  MACHINES+  VERSION+
+kontroll*   controller  admin@local  superuser  dummy/dummy-region        -          -  (unknown)  
 
 + these are the last known values, run with --refresh to see the latest information.
 

--- a/jujuclient/controllersfile_test.go
+++ b/jujuclient/controllersfile_test.go
@@ -29,18 +29,24 @@ controllers:
     ca-cert: this-is-aws-test-ca-cert
     cloud: aws
     region: us-east-1
+    controller-machine-count: 0
+    active-controller-machine-count: 0
   mallards:
     unresolved-api-endpoints: [maas-1-05.cluster.mallards]
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
     cloud: mallards
+    controller-machine-count: 0
+    active-controller-machine-count: 0
   mark-test-prodstack:
     unresolved-api-endpoints: [vm-23532.prodstack.canonical.com, great.test.server.hostname.co.nz]
     uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
     ca-cert: this-is-a-ca-cert
     cloud: prodstack
+    controller-machine-count: 0
+    active-controller-machine-count: 0
 current-controller: mallards
 `
 

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -40,12 +40,16 @@ type ControllerDetails struct {
 	// in formatting show-controller output where this struct is also used.
 	AgentVersion string `yaml:"agent-version,omitempty"`
 
-	// ControllerMachines represents the number of controller machines
-	// and which ones are active in the HA cluster.
-	// Either: #active/#total or #total (if all machines are active)
+	// ControllerMachineCount represents the number of controller machines
 	// It is cached here so under normal usage list-controllers
 	// does not need to hit the server.
-	ControllerMachines string `yaml:"controller-machines,omitempty"`
+	ControllerMachineCount int `yaml:"controller-machine-count"`
+
+	// ActiveControllerMachineCount represents the number of controller machines
+	// and which are active in the HA cluster.
+	// It is cached here so under normal usage list-controllers
+	// does not need to hit the server.
+	ActiveControllerMachineCount int `yaml:"active-controller-machine-count"`
 
 	// ModelCount is the number of models to which a user has access.
 	// It is cached here so under normal usage list-controllers


### PR DESCRIPTION
In juju list-controllers, highlight in colour when number of active controllers is less than total.
We also as a consequence store the separate active and total count in controllers.yaml

Also a drive by fix for show-controllers to not print ha status when there's only one.

(Review request: http://reviews.vapour.ws/r/5635/)