### PR TITLE
fixes 1554116 - show resource-get in help-tool

### DIFF
--- a/cmd/juju/commands/helptool.go
+++ b/cmd/juju/commands/helptool.go
@@ -85,6 +85,10 @@ func (dummyHookContext) SetStatus(jujuc.StatusInfo) error {
 	return nil
 }
 
+func (dummyHookContext) Component(name string) (jujuc.ContextComponent, error) {
+	return nil, nil
+}
+
 func newHelpToolCommand() cmd.Command {
 	return &helpToolCommand{}
 }

--- a/component/all/resource.go
+++ b/component/all/resource.go
@@ -53,6 +53,9 @@ func (r resources) registerForServer() error {
 // for the component in a "juju" command context.
 func (r resources) registerForClient() error {
 	r.registerPublicCommands()
+
+	// needed for help-tool
+	r.registerHookContextCommands()
 	return nil
 }
 
@@ -173,7 +176,7 @@ func (r resources) registerHookContext() {
 	r.registerHookContextFacade()
 }
 
-func (c resources) registerHookContextCommands() {
+func (r resources) registerHookContextCommands() {
 	if markRegistered(resource.ComponentName, "hook-context-commands") == false {
 		return
 	}
@@ -185,11 +188,7 @@ func (c resources) registerHookContextCommands() {
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			typedCtx, ok := compCtx.(*context.Context)
-			if !ok {
-				return nil, errors.Trace(err)
-			}
-			cmd, err := contextcmd.NewGetCmd(typedCtx)
+			cmd, err := contextcmd.NewGetCmd(compCtx)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/resource/context/cmd/get_test.go
+++ b/resource/context/cmd/get_test.go
@@ -63,7 +63,7 @@ func (s *GetCmdSuite) TestInit(c *gc.C) {
 
 func (s *GetCmdSuite) TestRunOkay(c *gc.C) {
 	getCmd := GetCmd{
-		hookContext:  s.hctx,
+		compContext:  s.hctx,
 		resourceName: "spam",
 	}
 	const expected = "/var/lib/juju/agents/unit-foo-1/resources/spam/a-file.tgz"
@@ -81,7 +81,7 @@ func (s *GetCmdSuite) TestRunOkay(c *gc.C) {
 
 func (s *GetCmdSuite) TestRunDownloadFailure(c *gc.C) {
 	getCmd := GetCmd{
-		hookContext:  s.hctx,
+		compContext:  s.hctx,
 		resourceName: "spam",
 	}
 	failure := errors.New("<failure>")

--- a/resource/context/cmd/stub_test.go
+++ b/resource/context/cmd/stub_test.go
@@ -22,3 +22,5 @@ func (s *stubHookContext) Download(name string) (string, error) {
 
 	return s.ReturnDownload, nil
 }
+
+func (s *stubHookContext) Flush() error { return nil }


### PR DESCRIPTION
There were two problems here.  The first is that we weren't registering the resource-get command when running the client... buit we need to, so we can run help-tool.

This then revealed a second problem - help-tool was passing in a dummy hook context into the command creation function, and hoped it wasn't actually looking too closely at the value.  Well, the resource-get command creation function *was* looking fairly closely at that value.  Luckily, it doesn't *really* need to, so I delayed that until we actually run the command.

A better general solution (proposed by Andrew) would be to pass the hook context into Run itself, since it's really only information that should need to be looked at when the command is actually run.  But that's a bigger change.

http://reviews.vapour.ws/r/5636/