### PR TITLE
state: Charm now has Life

### DIFF
--- a/state/application_test.go
+++ b/state/application_test.go
@@ -1055,7 +1055,7 @@ func (s *ServiceSuite) TestSettingsRefCreateRace(c *gc.C) {
 	defer state.SetBeforeHooks(c, s.State, dropSettings).Check()
 
 	err = unit.SetCharmURL(oldCh.URL())
-	c.Check(err, gc.ErrorMatches, "refcount does not exist")
+	c.Check(err, gc.ErrorMatches, "settings reference: does not exist")
 }
 
 func (s *ServiceSuite) TestSettingsRefRemoveRace(c *gc.C) {

--- a/state/charm.go
+++ b/state/charm.go
@@ -4,7 +4,6 @@
 package state
 
 import (
-	"net/url"
 	"regexp"
 
 	"github.com/juju/errors"
@@ -48,7 +47,26 @@ func (m MacaroonCache) Get(u *charm.URL) (macaroon.Slice, error) {
 // charmDoc represents the internal state of a charm in MongoDB.
 type charmDoc struct {
 	DocID string     `bson:"_id"`
-	URL   *charm.URL `bson:"url"` // DANGEROUS see below
+	URL   *charm.URL `bson:"url"` // DANGEROUS see charm.* fields below
+
+	// Life should only be used for local charms; a value of Dead is
+	// used to indicate that the charm no longer exists, but the doc
+	// itself needs to stick around so we don't accidentally reuse
+	// charm URLs (which must be unique within a model).
+	Life Life `bson:"life"`
+
+	// These fields are flags; if any of them is set, the charm
+	// cannot actually be safely used for anything.
+	PendingUpload bool `bson:"pendingupload"`
+	Placeholder   bool `bson:"placeholder"`
+
+	// These fields control access to the charm archive.
+	BundleSha256 string `bson:"bundlesha256"`
+	StoragePath  string `bson:"storagepath"`
+	Macaroon     []byte `bson:"macaroon"`
+
+	// The remaining fields hold data sufficient to define a
+	// charm.Charm.
 
 	// TODO(fwereade) 2015-06-18 lp:1467964
 	// DANGEROUS: our schema can change any time the charm package changes,
@@ -62,17 +80,6 @@ type charmDoc struct {
 	Config  *charm.Config  `bson:"config"`
 	Actions *charm.Actions `bson:"actions"`
 	Metrics *charm.Metrics `bson:"metrics"`
-
-	// DEPRECATED: BundleURL is deprecated, and exists here
-	// only for migration purposes. We should remove this
-	// when migrations are no longer necessary.
-	BundleURL *url.URL `bson:"bundleurl,omitempty"`
-
-	BundleSha256  string `bson:"bundlesha256"`
-	StoragePath   string `bson:"storagepath"`
-	PendingUpload bool   `bson:"pendingupload"`
-	Placeholder   bool   `bson:"placeholder"`
-	Macaroon      []byte `bson:"macaroon"`
 }
 
 // CharmInfo contains all the data necessary to store a charm's metadata.
@@ -142,6 +149,20 @@ func insertPendingCharmOps(st *State, curl *charm.URL) ([]txn.Op, error) {
 // insertAnyCharmOps returns the txn operations necessary to insert the supplied
 // charm document.
 func insertAnyCharmOps(st modelBackend, cdoc *charmDoc) ([]txn.Op, error) {
+
+	charms, closer := st.getCollection(charmsC)
+	defer closer()
+
+	life, err := nsLife.read(charms, cdoc.DocID)
+	if errors.IsNotFound(err) {
+		// everything is as it should be
+	} else if err != nil {
+		return nil, errors.Trace(err)
+	} else if life == Dead {
+		return nil, errors.New("url already consumed")
+	} else {
+		return nil, errors.New("already exists")
+	}
 	charmOp := txn.Op{
 		C:      charmsC,
 		Id:     cdoc.DocID,
@@ -166,8 +187,22 @@ func insertAnyCharmOps(st modelBackend, cdoc *charmDoc) ([]txn.Op, error) {
 // document with the supplied data, so long as the supplied assert still holds
 // true.
 func updateCharmOps(
-	st *State, info CharmInfo, assert interface{},
+	st *State, info CharmInfo, assert bson.D,
 ) ([]txn.Op, error) {
+
+	charms, closer := st.getCollection(charmsC)
+	defer closer()
+
+	charmKey := info.ID.String()
+	op, err := nsLife.aliveOp(charms, charmKey)
+	if err != nil {
+		return nil, errors.Annotate(err, "charm")
+	}
+	lifeAssert, ok := op.Assert.(bson.D)
+	if !ok {
+		return nil, errors.Errorf("expected bson.D, got %#v", op.Assert)
+	}
+	op.Assert = append(lifeAssert, assert...)
 
 	data := bson.D{
 		{"meta", info.Charm.Meta()},
@@ -179,7 +214,6 @@ func updateCharmOps(
 		{"pendingupload", false},
 		{"placeholder", false},
 	}
-
 	if len(info.Macaroon) > 0 {
 		mac, err := info.Macaroon.MarshalBinary()
 		if err != nil {
@@ -188,13 +222,8 @@ func updateCharmOps(
 		data = append(data, bson.DocElem{"macaroon", mac})
 	}
 
-	updateFields := bson.D{{"$set", data}}
-	return []txn.Op{{
-		C:      charmsC,
-		Id:     info.ID.String(),
-		Assert: assert,
-		Update: updateFields,
-	}}, nil
+	op.Update = bson.D{{"$set", data}}
+	return []txn.Op{op}, nil
 }
 
 // convertPlaceholderCharmOps returns the txn operations necessary to convert
@@ -297,6 +326,76 @@ func (c *Charm) Tag() names.Tag {
 	return names.NewCharmTag(c.URL().String())
 }
 
+// Life returns the charm's life state.
+func (c *Charm) Life() Life {
+	return c.doc.Life
+}
+
+// Refresh loads fresh charm data from the database. In practice, the
+// only observable change should be to its Life value.
+func (c *Charm) Refresh() error {
+	ch, err := c.st.Charm(c.doc.URL)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	c.doc = ch.doc
+	return nil
+}
+
+// Destroy sets the charm to Dying and prevents it from being used by
+// applications or units. It only works on local charms, and only when
+// the charm is not referenced by any application.
+func (c *Charm) Destroy() error {
+	buildTxn := func(_ int) ([]txn.Op, error) {
+		ops, err := charmDestroyOps(c.st, c.doc.URL)
+		switch errors.Cause(err) {
+		case nil:
+		case errNotAlive:
+			return nil, jujutxn.ErrNoOperations
+		default:
+			return nil, errors.Trace(err)
+		}
+		return ops, nil
+	}
+	if err := c.st.run(buildTxn); err != nil {
+		return errors.Trace(err)
+	}
+	c.doc.Life = Dying
+	return nil
+}
+
+// Remove will delete the charm's stored archive and render the charm
+// inaccessible to future clients. It will fail unless the charm is
+// already Dying (indicating that someone has called Destroy).
+func (c *Charm) Remove() error {
+	if c.doc.Life == Alive {
+		return errors.New("still alive")
+	}
+
+	err := c.st.deleteCharmArchive(c.doc.URL, c.doc.StoragePath)
+	if err != nil {
+		return errors.Annotate(err, "deleting archive")
+	}
+
+	buildTxn := func(_ int) ([]txn.Op, error) {
+		ops, err := charmRemoveOps(c.st, c.doc.URL)
+		switch errors.Cause(err) {
+		case nil:
+		case errAlreadyDead:
+			return nil, jujutxn.ErrNoOperations
+		default:
+			return nil, errors.Trace(err)
+		}
+		return ops, nil
+	}
+	if err := c.st.run(buildTxn); err != nil {
+		return errors.Trace(err)
+	}
+	c.doc.Life = Dead
+	return nil
+
+}
+
 // charmGlobalKey returns the global database key for the charm
 // with the given url.
 func charmGlobalKey(charmURL *charm.URL) string {
@@ -390,7 +489,7 @@ func (c *Charm) UpdateMacaroon(m macaroon.Slice) error {
 		SHA256:      c.BundleSha256(),
 		Macaroon:    m,
 	}
-	ops, err := updateCharmOps(c.st, info, txn.DocExists)
+	ops, err := updateCharmOps(c.st, info, nil)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -403,8 +502,11 @@ func (c *Charm) UpdateMacaroon(m macaroon.Slice) error {
 // deleteCharmArchive deletes a charm archive from blob storage.
 func (st *State) deleteCharmArchive(curl *charm.URL, storagePath string) error {
 	stor := storage.NewStorage(st.ModelUUID(), st.MongoSession())
-	if err := stor.Remove(storagePath); err != nil {
-		return errors.Annotate(err, "cannot delete charm from storage")
+	err := stor.Remove(storagePath)
+	if errors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return errors.Trace(err)
 	}
 	return nil
 }
@@ -461,7 +563,7 @@ func (st *State) AllCharms() ([]*Charm, error) {
 	defer closer()
 	var cdoc charmDoc
 	var charms []*Charm
-	iter := charmsCollection.Find(nil).Iter()
+	iter := charmsCollection.Find(nsLife.notDead()).Iter()
 	for iter.Next(&cdoc) {
 		ch := newCharm(st, &cdoc)
 		charms = append(charms, ch)
@@ -481,6 +583,7 @@ func (st *State) Charm(curl *charm.URL) (*Charm, error) {
 		{"placeholder", bson.D{{"$ne", true}}},
 		{"pendingupload", bson.D{{"$ne", true}}},
 	}
+	what = append(what, nsLife.notDead()...)
 	err := charms.Find(what).One(&cdoc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("charm %q", curl)

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -17,23 +18,46 @@ import (
 	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/storage"
 	"github.com/juju/juju/testcharms"
+	"github.com/juju/juju/testing/factory"
 )
 
 type CharmSuite struct {
 	ConnSuite
-	curl *charm.URL
+	charm *state.Charm
+	curl  *charm.URL
 }
 
 var _ = gc.Suite(&CharmSuite{})
 
 func (s *CharmSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
-	added := s.AddTestingCharm(c, "dummy")
-	s.curl = added.URL()
+	s.charm = s.AddTestingCharm(c, "dummy")
+	s.curl = s.charm.URL()
 }
 
-func (s *CharmSuite) TestCharm(c *gc.C) {
+func (s *CharmSuite) destroy(c *gc.C) {
+	err := s.charm.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *CharmSuite) remove(c *gc.C) {
+	s.destroy(c)
+	err := s.charm.Remove()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *CharmSuite) TestAliveCharm(c *gc.C) {
+	s.testCharm(c)
+}
+
+func (s *CharmSuite) TestDyingCharm(c *gc.C) {
+	s.destroy(c)
+	s.testCharm(c)
+}
+
+func (s *CharmSuite) testCharm(c *gc.C) {
 	dummy, err := s.State.Charm(s.curl)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dummy.URL().String(), gc.Equals, s.curl.String())
@@ -74,6 +98,25 @@ func (s *CharmSuite) TestCharm(c *gc.C) {
 		})
 }
 
+func (s *CharmSuite) TestRemovedCharmNotFound(c *gc.C) {
+	s.remove(c)
+	_, err := s.State.Charm(s.curl)
+	c.Check(err, gc.ErrorMatches, `charm ".*" not found`)
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *CharmSuite) TestRemovedCharmNotListed(c *gc.C) {
+	s.remove(c)
+	charms, err := s.State.AllCharms()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(charms, gc.HasLen, 0)
+}
+
+func (s *CharmSuite) TestRemoveWithoutDestroy(c *gc.C) {
+	err := s.charm.Remove()
+	c.Assert(err, gc.ErrorMatches, "still alive")
+}
+
 func (s *CharmSuite) TestCharmNotFound(c *gc.C) {
 	curl := charm.MustParseURL("local:anotherseries/dummy-1")
 	_, err := s.State.Charm(curl)
@@ -95,6 +138,92 @@ func (s *CharmSuite) dummyCharm(c *gc.C, curlOverride string) state.CharmInfo {
 		)
 	}
 	return info
+}
+
+func (s *CharmSuite) TestDestroyStoreCharm(c *gc.C) {
+	info := s.dummyCharm(c, "cs:precise/dummy-2")
+	sch, err := s.State.AddCharm(info)
+	c.Assert(err, jc.ErrorIsNil)
+	err = sch.Destroy()
+	c.Assert(err, gc.ErrorMatches, "cannot destroy non-local charms")
+}
+
+func (s *CharmSuite) TestRemoveDeletesStorage(c *gc.C) {
+	// We normally don't actually set up charm storage in state
+	// tests, but we need it here.
+	path := s.charm.StoragePath()
+	stor := storage.NewStorage(s.State.ModelUUID(), s.State.MongoSession())
+	err := stor.Put(path, strings.NewReader("abc"), 3)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.destroy(c)
+	closer, _, err := stor.Get(path)
+	c.Assert(err, jc.ErrorIsNil)
+	closer.Close()
+
+	s.remove(c)
+	_, _, err = stor.Get(path)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *CharmSuite) TestReferenceDyingCharm(c *gc.C) {
+
+	s.destroy(c)
+
+	args := state.AddApplicationArgs{
+		Name:  "blah",
+		Charm: s.charm,
+	}
+	_, err := s.State.AddApplication(args)
+	c.Check(err, gc.ErrorMatches, `cannot add application "blah": charm: not found or not alive`)
+}
+
+func (s *CharmSuite) TestReferenceDyingCharmRace(c *gc.C) {
+
+	defer state.SetBeforeHooks(c, s.State, func() {
+		s.destroy(c)
+	}).Check()
+
+	args := state.AddApplicationArgs{
+		Name:  "blah",
+		Charm: s.charm,
+	}
+	_, err := s.State.AddApplication(args)
+	// bad message: see lp:1621754. should match
+	// TestReferenceDyingCharm above.
+	c.Check(err, gc.ErrorMatches, `cannot add application "blah": application already exists`)
+}
+
+func (s *CharmSuite) TestDestroyReferencedCharm(c *gc.C) {
+	s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Charm: s.charm,
+	})
+
+	err := s.charm.Destroy()
+	c.Check(err, gc.ErrorMatches, "charm in use")
+}
+
+func (s *CharmSuite) TestDestroyReferencedCharmRace(c *gc.C) {
+
+	defer state.SetBeforeHooks(c, s.State, func() {
+		s.Factory.MakeApplication(c, &factory.ApplicationParams{
+			Charm: s.charm,
+		})
+	}).Check()
+
+	err := s.charm.Destroy()
+	c.Check(err, gc.ErrorMatches, "charm in use")
+}
+
+func (s *CharmSuite) TestDestroyUnreferencedCharm(c *gc.C) {
+	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Charm: s.charm,
+	})
+	err := app.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.charm.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *CharmSuite) TestAddCharm(c *gc.C) {
@@ -208,6 +337,15 @@ func (s *CharmSuite) TestPrepareLocalCharmUpload(c *gc.C) {
 	curl, err = s.State.PrepareLocalCharmUpload(curl.WithRevision(1234))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(curl.Revision, gc.Equals, 1234)
+}
+
+func (s *CharmSuite) TestPrepareLocalCharmUploadRemoved(c *gc.C) {
+	// Remove the fixture charm and try to re-add it; it gets a new
+	// revision.
+	s.remove(c)
+	curl, err := s.State.PrepareLocalCharmUpload(s.curl)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(curl.Revision, gc.Equals, s.curl.Revision+1)
 }
 
 func (s *CharmSuite) TestPrepareStoreCharmUpload(c *gc.C) {

--- a/state/charmref.go
+++ b/state/charmref.go
@@ -9,7 +9,30 @@ import (
 	"gopkg.in/mgo.v2/txn"
 )
 
-func charmIncRefOps(st modelBackend, appName string, curl *charm.URL, canCreate bool) ([]txn.Op, error) {
+var errCharmInUse = errors.New("charm in use")
+
+// appCharmIncRefOps returns the operations necessary to record a reference
+// to a charm and its per-application settings document. It will fail if
+// the charm is not Alive.
+func appCharmIncRefOps(st modelBackend, appName string, curl *charm.URL, canCreate bool) ([]txn.Op, error) {
+
+	charms, closer := st.getCollection(charmsC)
+	defer closer()
+
+	// If we're migrating. charm document will not be present. But
+	// if we're not migrating, we need to check the charm is alive.
+	var checkOps []txn.Op
+	count, err := charms.FindId(curl.String()).Count()
+	if err != nil {
+		return nil, errors.Annotate(err, "charm")
+	} else if count != 0 {
+		checkOp, err := nsLife.aliveOp(charms, curl.String())
+		if err != nil {
+			return nil, errors.Annotate(err, "charm")
+		}
+		checkOps = []txn.Op{checkOp}
+	}
+
 	refcounts, closer := st.getCollection(refcountsC)
 	defer closer()
 
@@ -17,35 +40,39 @@ func charmIncRefOps(st modelBackend, appName string, curl *charm.URL, canCreate 
 	if !canCreate {
 		getIncRefOp = nsRefcounts.StrictIncRefOp
 	}
-
 	settingsKey := applicationSettingsKey(appName, curl)
 	settingsOp, err := getIncRefOp(refcounts, settingsKey)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotate(err, "settings reference")
 	}
 	charmKey := charmGlobalKey(curl)
 	charmOp, err := getIncRefOp(refcounts, charmKey)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotate(err, "charm reference")
 	}
 
-	return []txn.Op{
-		settingsOp,
-		charmOp,
-	}, nil
+	return append(checkOps, settingsOp, charmOp), nil
 }
 
-func charmDecRefOps(st modelBackend, appName string, curl *charm.URL) ([]txn.Op, error) {
+// appCharmDecRefOps returns the operations necessary to delete a
+// reference to a charm and its per-application settings document. If no
+// references to a given (app, charm) pair remain, the operations
+// returned will also remove the settings document for that pair.
+func appCharmDecRefOps(st modelBackend, appName string, curl *charm.URL) ([]txn.Op, error) {
+
 	refcounts, closer := st.getCollection(refcountsC)
 	defer closer()
 
 	charmKey := charmGlobalKey(curl)
 	charmOp, err := nsRefcounts.AliveDecRefOp(refcounts, charmKey)
+	if err != nil {
+		return nil, errors.Annotate(err, "charm reference")
+	}
 
 	settingsKey := applicationSettingsKey(appName, curl)
 	settingsOp, isFinal, err := nsRefcounts.DyingDecRefOp(refcounts, settingsKey)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err, "settings reference %s", settingsKey)
 	}
 
 	ops := []txn.Op{settingsOp, charmOp}
@@ -57,4 +84,62 @@ func charmDecRefOps(st modelBackend, appName string, curl *charm.URL) ([]txn.Op,
 		})
 	}
 	return ops, nil
+}
+
+// charmDestroyOps implements the logic of charm.Destroy.
+func charmDestroyOps(st modelBackend, curl *charm.URL) ([]txn.Op, error) {
+
+	if curl.Schema != "local" {
+		// local charms keep a document around to prevent reuse
+		// of charm URLs, which several components believe to be
+		// unique keys (this is always true within a model).
+		//
+		// it's not so much that it's bad to delete store
+		// charms; but we don't have a way to reinstate them
+		// once purged, so we don't allow removal in the first
+		// place.
+		return nil, errors.New("cannot destroy non-local charms")
+	}
+
+	charms, closer := st.getCollection(charmsC)
+	defer closer()
+
+	charmKey := curl.String()
+	charmOp, err := nsLife.destroyOp(charms, charmKey, nil)
+	if err != nil {
+		return nil, errors.Annotate(err, "charm")
+	}
+
+	refcounts, closer := st.getCollection(refcountsC)
+	defer closer()
+
+	refcountKey := charmGlobalKey(curl)
+	refcountOp, err := nsRefcounts.RemoveOp(refcounts, refcountKey, 0)
+	switch errors.Cause(err) {
+	case nil:
+	case errRefcountChanged:
+		return nil, errCharmInUse
+	default:
+		return nil, errors.Annotate(err, "charm reference")
+	}
+
+	return []txn.Op{charmOp, refcountOp}, nil
+}
+
+// charmRemoveOps implements the logic of charm.Remove.
+func charmRemoveOps(st modelBackend, curl *charm.URL) ([]txn.Op, error) {
+
+	charms, closer := st.getCollection(charmsC)
+	defer closer()
+
+	// NOTE: we do *not* actually remove the charm document, to
+	// prevent its URL from being recycled, and breaking caches.
+	// The "remove" terminology refers to the client's view of the
+	// change (after which the charm really will be inaccessible).
+	charmKey := curl.String()
+	charmOp, err := nsLife.dieOp(charms, charmKey, nil)
+	if err != nil {
+		return nil, errors.Annotate(err, "charm")
+	}
+	return []txn.Op{charmOp}, nil
 }

--- a/state/life.go
+++ b/state/life.go
@@ -41,7 +41,9 @@ var (
 
 	errDeadOrGone     = errors.New("neither alive nor dying")
 	errAlreadyDying   = errors.New("already dying")
+	errAlreadyDead    = errors.New("already dead")
 	errAlreadyRemoved = errors.New("already removed")
+	errNotDying       = errors.New("not dying")
 )
 
 // Living describes state entities with a lifecycle.

--- a/state/life_ns.go
+++ b/state/life_ns.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
@@ -23,23 +24,131 @@ type nsLife_ struct{}
 // to be good ideas, and should ideally be extended as we continue.
 var nsLife = nsLife_{}
 
+// destroyOp returns errNotAlive if the identified entity is not Alive;
+// or a txn.Op that will fail if the condition no longer holds, and
+// otherwise set Life to Dying and make any other updates supplied in
+// update.
+func (nsLife_) destroyOp(entities mongo.Collection, docID string, update bson.D) (txn.Op, error) {
+	op, err := nsLife.aliveOp(entities, docID)
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
+	setDying := bson.D{{"$set", bson.D{{"life", Dying}}}}
+	op.Update = append(setDying, update...)
+	return op, nil
+}
+
+// dieOp returns errNotDying if the identified entity is Alive, or
+// errAlreadyDead if the entity is Dead or gone; or a txn.Op that will
+// fail if the condition no longer holds, and otherwise set Life to
+// Dead, and make any other updates supplied in update.
+func (nsLife_) dieOp(entities mongo.Collection, docID string, update bson.D) (txn.Op, error) {
+	life, err := nsLife.read(entities, docID)
+	if errors.IsNotFound(err) {
+		return txn.Op{}, errAlreadyDead
+	} else if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
+	switch life {
+	case Alive:
+		return txn.Op{}, errNotDying
+	case Dead:
+		return txn.Op{}, errAlreadyDead
+	}
+	setDead := bson.D{{"$set", bson.D{{"life", Dead}}}}
+	return txn.Op{
+		C:      entities.Name(),
+		Id:     docID,
+		Assert: nsLife.dying(),
+		Update: append(setDead, update...),
+	}, nil
+}
+
+// aliveOp returns errNotAlive if the identified entity is not Alive; or
+// a txn.Op that will fail if the condition no longer holds.
+func (nsLife_) aliveOp(entities mongo.Collection, docID string) (txn.Op, error) {
+	op, err := nsLife.checkOp(entities, docID, nsLife.alive())
+	switch errors.Cause(err) {
+	case nil:
+	case errCheckFailed:
+		return txn.Op{}, errNotAlive
+	default:
+		return txn.Op{}, errors.Trace(err)
+	}
+	return op, nil
+}
+
+// dyingOp returns errNotDying if the identified entity is not Dying; or
+// a txn.Op that will fail if the condition no longer holds.
+func (nsLife_) dyingOp(entities mongo.Collection, docID string) (txn.Op, error) {
+	op, err := nsLife.checkOp(entities, docID, nsLife.dying())
+	switch errors.Cause(err) {
+	case nil:
+	case errCheckFailed:
+		return txn.Op{}, errNotDying
+	default:
+		return txn.Op{}, errors.Trace(err)
+	}
+	return op, nil
+}
+
 // notDeadOp returns errDeadOrGone if the identified entity is not Alive
 // or Dying, or a txn.Op that will fail if the condition no longer
 // holds.
 func (nsLife_) notDeadOp(entities mongo.Collection, docID string) (txn.Op, error) {
-	notDead := nsLife.notDead()
-	sel := append(bson.D{{"_id", docID}}, notDead...)
+	op, err := nsLife.checkOp(entities, docID, nsLife.notDead())
+	switch errors.Cause(err) {
+	case nil:
+	case errCheckFailed:
+		return txn.Op{}, errDeadOrGone
+	default:
+		return txn.Op{}, errors.Trace(err)
+	}
+	return op, nil
+}
+
+var errCheckFailed = errors.New("check failed")
+
+func (nsLife_) checkOp(entities mongo.Collection, docID string, check bson.D) (txn.Op, error) {
+	sel := append(bson.D{{"_id", docID}}, check...)
 	count, err := entities.Find(sel).Count()
 	if err != nil {
 		return txn.Op{}, errors.Trace(err)
 	} else if count == 0 {
-		return txn.Op{}, errDeadOrGone
+		return txn.Op{}, errCheckFailed
 	}
 	return txn.Op{
 		C:      entities.Name(),
 		Id:     docID,
-		Assert: notDead,
+		Assert: check,
 	}, nil
+}
+
+func (nsLife_) read(entities mongo.Collection, docID string) (Life, error) {
+	var doc struct {
+		Life Life `bson:"life"`
+	}
+	err := entities.FindId(docID).One(&doc)
+	switch errors.Cause(err) {
+	case nil:
+	case mgo.ErrNotFound:
+		return Dead, errors.NotFoundf("entity")
+	default:
+		return Dead, errors.Trace(err)
+	}
+	return doc.Life, nil
+}
+
+// alive returns a selector that matches only documents whose life
+// field is set to Alive.
+func (nsLife_) alive() bson.D {
+	return bson.D{{"life", Alive}}
+}
+
+// dying returns a selector that matches only documents whose life
+// field is set to Dying.
+func (nsLife_) dying() bson.D {
+	return bson.D{{"life", Dying}}
 }
 
 // notDead returns a selector that matches only documents whose life

--- a/state/relation.go
+++ b/state/relation.go
@@ -200,7 +200,11 @@ func (r *Relation) removeOps(ignoreService string, departingUnit *Unit) ([]txn.O
 			hasLastRef := bson.D{{"life", Dying}, {"unitcount", 0}, {"relationcount", 1}}
 			removable := append(bson.D{{"_id", ep.ApplicationName}}, hasLastRef...)
 			if err := applications.Find(removable).One(&svc.doc); err == nil {
-				ops = append(ops, svc.removeOps(hasLastRef)...)
+				appRemoveOps, err := svc.removeOps(hasLastRef)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				ops = append(ops, appRemoveOps...)
 				continue
 			} else if err != mgo.ErrNotFound {
 				return nil, err

--- a/state/state.go
+++ b/state/state.go
@@ -1148,6 +1148,12 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		if err := checkModelActive(st); err != nil {
 			return nil, errors.Trace(err)
 		}
+		// TODO(fwereade): 2016-09-09 lp:1621754
+		// This is not always correct -- there are a million
+		// operations collected in this func, not *all* of them
+		// imply that this is the problem. (e.g. the charm being
+		// destroyed just as we add application will fail, but
+		// not because "application already exists")
 		return nil, errors.Errorf("application already exists")
 	} else if err != nil {
 		return nil, errors.Trace(err)

--- a/state/unit.go
+++ b/state/unit.go
@@ -1095,7 +1095,7 @@ func (u *Unit) SetCharmURL(curl *charm.URL) error {
 		}
 
 		// Add a reference to the service settings for the new charm.
-		incOps, err := charmIncRefOps(u.st, u.doc.Application, curl, false)
+		incOps, err := appCharmIncRefOps(u.st, u.doc.Application, curl, false)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1111,7 +1111,7 @@ func (u *Unit) SetCharmURL(curl *charm.URL) error {
 			})
 		if u.doc.CharmURL != nil {
 			// Drop the reference to the old charm.
-			decOps, err := charmDecRefOps(u.st, u.doc.Application, u.doc.CharmURL)
+			decOps, err := appCharmDecRefOps(u.st, u.doc.Application, u.doc.CharmURL)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -2315,7 +2315,7 @@ func addUnitOps(st *State, args addUnitOpsArgs) ([]txn.Op, error) {
 	// create the settings doc.
 	if curl := args.unitDoc.CharmURL; curl != nil {
 		appName := args.unitDoc.Application
-		charmRefOps, err := charmIncRefOps(st, appName, curl, false)
+		charmRefOps, err := appCharmIncRefOps(st, appName, curl, false)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}


### PR DESCRIPTION
...along with the associated Destroy, Remove, and Refresh methods.
Only implemented for local charms; store charms are immortal, as
discussed in comments.

All attempts to reference a charm now check the charm's life; the
charm's life will not advance when any reference exists. Once a charm
has been destroyed, it can be removed; at which point any storage it is
using will be reclaimed.

This CL doesn't change observable behaviour: nothing actually uses
Life methods except the tests. That's coming next.

(Review request: http://reviews.vapour.ws/r/5637/)