### PR TITLE
Use MAAS 2.0 owner data to store Juju tags on instances

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -27,7 +27,7 @@ github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:3
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
-github.com/juju/gomaasapi	git	0d72ac79f9a32e98262ac529fa5184e18213f447	2016-08-23T23:45:13Z
+github.com/juju/gomaasapi	git	5235db1b6fa70c564751ed35b10b881fe156d8cb	2016-09-08T13:07:13Z
 github.com/juju/govmomi	git	4354a88d4b34abe467215f77c2fc1cb9f78b66f7	2015-04-24T01:54:48Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	796aaafaf712f666df58d31a482c51233038bf9f	2016-05-03T15:03:27Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -27,7 +27,7 @@ github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:3
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
-github.com/juju/gomaasapi	git	5235db1b6fa70c564751ed35b10b881fe156d8cb	2016-09-08T13:07:13Z
+github.com/juju/gomaasapi	git	b46b01a54c64f50e64439ef0f9a40b084e7068f1	2016-09-09T00:19:59Z
 github.com/juju/govmomi	git	4354a88d4b34abe467215f77c2fc1cb9f78b66f7	2015-04-24T01:54:48Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	796aaafaf712f666df58d31a482c51233038bf9f	2016-05-03T15:03:27Z

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -229,6 +229,11 @@ func (m *fakeMachine) Tags() []string {
 	return m.tags
 }
 
+func (m *fakeMachine) SetOwnerData(data map[string]string) error {
+	m.MethodCall(m, "SetOwnerData", data)
+	return m.NextErr()
+}
+
 func (m *fakeMachine) CPUCount() int {
 	return m.cpuCount
 }

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -120,6 +120,9 @@ func (s *providerSuite) TearDownSuite(c *gc.C) {
 var maasEnvAttrs = coretesting.Attrs{
 	"name": "test-env",
 	"type": "maas",
+	config.ResourceTagsKey: map[string]string{
+		"claude": "rains",
+	},
 }
 
 // makeEnviron creates a functional maasEnviron for a test.


### PR DESCRIPTION
This is a step towards completely removing the Storage interface - the
MAAS provider is the only one that still uses it.

The 1.0 API code still uses MAAS file storage to track controller
instance ids, but for 2.0 we can use the key/value storage instead. 
This is cleared automatically when the machine is released back to 
MAAS.

Testing done:
Bootstrapped and deployed postgresql on both MAAS 1.9 and MAAS 2. On MAAS 2 you can see the tags applied:
```
12:11 $ maas maas2 machines read | grep -A 4 owner_data                                               
        "owner_data": {
            "juju-controller-uuid": "f24c4362-bd80-46d3-860e-34562d055613",
            "juju-model-uuid": "a7ab39c4-6ed2-427e-824c-c3a8dbe8d9e1",
            "juju-is-controller": "true"
        },
--
        "owner_data": {
            "juju-controller-uuid": "f24c4362-bd80-46d3-860e-34562d055613",
            "juju-model-uuid": "aae78508-5e4b-4ccb-8729-d0bd6d51aac5",
            "juju-units-deployed": "ubuntu/0"
        },
--
```

(Review request: http://reviews.vapour.ws/r/5638/)