### PR TITLE
Resolve the unit name before looking up metrics for it.

### DIFF
--- a/state/metrics.go
+++ b/state/metrics.go
@@ -197,6 +197,10 @@ func (st *State) queryMetricBatches(query bson.M) ([]MetricBatch, error) {
 
 // MetricBatchesForUnit returns metric batches for the given unit.
 func (st *State) MetricBatchesForUnit(unit string) ([]MetricBatch, error) {
+	_, err := st.Unit(unit)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return st.queryMetricBatches(bson.M{"unit": unit})
 }
 

--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -588,6 +588,16 @@ func (s *MetricSuite) TestUnitMetricBatchesMatchesAllCharms(c *gc.C) {
 	c.Assert(metricBatches, gc.HasLen, 1)
 }
 
+func (s *MetricSuite) TestNoSuchUnitMetricBatches(c *gc.C) {
+	_, err := s.State.MetricBatchesForUnit("chimerical-unit/0")
+	c.Assert(err, gc.ErrorMatches, `unit "chimerical-unit/0" not found`)
+}
+
+func (s *MetricSuite) TestNoSuchApplicationMetricBatches(c *gc.C) {
+	_, err := s.State.MetricBatchesForApplication("unicorn-app")
+	c.Assert(err, gc.ErrorMatches, `application "unicorn-app" not found`)
+}
+
 type MetricLocalCharmSuite struct {
 	ConnSuite
 	unit         *state.Unit


### PR DESCRIPTION
QA steps:
- `juju metrics no-such-unit/99` shows a "unit not found" error.
- `juju metrics no-such-app` shows an "application not found" error.

(Review request: http://reviews.vapour.ws/r/5643/)