### PR TITLE
state: replace charm cleanups

### DIFF
--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -614,7 +614,7 @@ func destroyFilesystemOps(st *State, f *filesystem) []txn.Op {
 		}}
 	}
 	hasAttachments := bson.D{{"attachmentcount", bson.D{{"$gt", 0}}}}
-	cleanupOp := st.newCleanupOp(cleanupAttachmentsForDyingFilesystem, f.doc.FilesystemId)
+	cleanupOp := newCleanupOp(cleanupAttachmentsForDyingFilesystem, f.doc.FilesystemId)
 	return []txn.Op{{
 		C:      filesystemsC,
 		Id:     f.doc.FilesystemId,

--- a/state/machine.go
+++ b/state/machine.go
@@ -486,7 +486,7 @@ func (m *Machine) forceDestroyOps() ([]txn.Op, error) {
 		C:      machinesC,
 		Id:     m.doc.DocID,
 		Assert: bson.D{{"jobs", bson.D{{"$nin", []MachineJob{JobManageModel}}}}},
-	}, m.st.newCleanupOp(cleanupForceDestroyedMachine, m.doc.Id)}, nil
+	}, newCleanupOp(cleanupForceDestroyedMachine, m.doc.Id)}, nil
 }
 
 // EnsureDead sets the machine lifecycle to Dead if it is Alive or Dying.
@@ -623,7 +623,7 @@ func (original *Machine) advanceLifecycle(life Life) (err error) {
 			{{"principals", bson.D{{"$exists", false}}}},
 		},
 	}
-	cleanupOp := m.st.newCleanupOp(cleanupDyingMachine, m.doc.Id)
+	cleanupOp := newCleanupOp(cleanupDyingMachine, m.doc.Id)
 	// multiple attempts: one with original data, one with refreshed data, and a final
 	// one intended to determine the cause of failure of the preceding attempt.
 	buildTxn := func(attempt int) ([]txn.Op, error) {

--- a/state/model.go
+++ b/state/model.go
@@ -846,7 +846,7 @@ func (m *Model) destroyOps(ensureNoHostedModels, ensureEmpty bool) ([]txn.Op, er
 	// causes a state change that's still consistent; so we make
 	// sure the cleanup ops are the last thing that will execute.
 	if m.isControllerModel() {
-		cleanupOp := st.newCleanupOp(cleanupModelsForDyingController, modelUUID)
+		cleanupOp := newCleanupOp(cleanupModelsForDyingController, modelUUID)
 		ops = append(ops, cleanupOp)
 	}
 	if !isEmpty {
@@ -856,8 +856,8 @@ func (m *Model) destroyOps(ensureNoHostedModels, ensureEmpty bool) ([]txn.Op, er
 		// hosted model in the course of destroying the controller. In
 		// that case we'll get errors if we try to enqueue hosted-model
 		// cleanups, because the cleanups collection is non-global.
-		cleanupMachinesOp := st.newCleanupOp(cleanupMachinesForDyingModel, modelUUID)
-		cleanupServicesOp := st.newCleanupOp(cleanupServicesForDyingModel, modelUUID)
+		cleanupMachinesOp := newCleanupOp(cleanupMachinesForDyingModel, modelUUID)
+		cleanupServicesOp := newCleanupOp(cleanupServicesForDyingModel, modelUUID)
 		ops = append(ops, cleanupMachinesOp, cleanupServicesOp)
 	}
 	return append(prereqOps, ops...), nil

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -431,8 +431,7 @@ func (s *ModelSuite) TestDestroyControllerAndHostedModelsWithResources(c *gc.C) 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(controllerEnv.DestroyIncludingHosted(), jc.ErrorIsNil)
 
-	assertCleanupRuns(c, s.State)
-	assertDoesNotNeedCleanup(c, s.State)
+	assertCleanupCount(c, s.State, 2)
 	assertAllMachinesDeadAndRemove(c, s.State)
 	assertEnv(controllerEnv, s.State, state.Dying, 0, 0)
 

--- a/state/persistence.go
+++ b/state/persistence.go
@@ -113,5 +113,5 @@ func (sp *statePersistence) IncCharmModifiedVersionOps(applicationID string) []t
 // NewCleanupOp creates a mgo transaction operation that queues up
 // some cleanup action in state.
 func (sp *statePersistence) NewCleanupOp(kind, prefix string) txn.Op {
-	return sp.st.newCleanupOp(cleanupKind(kind), prefix)
+	return newCleanupOp(cleanupKind(kind), prefix)
 }

--- a/state/relation.go
+++ b/state/relation.go
@@ -224,7 +224,7 @@ func (r *Relation) removeOps(ignoreService string, departingUnit *Unit) ([]txn.O
 			Update: bson.D{{"$inc", bson.D{{"relationcount", -1}}}},
 		})
 	}
-	cleanupOp := r.st.newCleanupOp(cleanupRelationSettings, fmt.Sprintf("r#%d#", r.Id()))
+	cleanupOp := newCleanupOp(cleanupRelationSettings, fmt.Sprintf("r#%d#", r.Id()))
 	return append(ops, cleanupOp), nil
 }
 

--- a/state/storage.go
+++ b/state/storage.go
@@ -268,7 +268,7 @@ func (st *State) destroyStorageInstanceOps(s *storageInstance) ([]txn.Op, error)
 	}
 	update := bson.D{{"$set", bson.D{{"life", Dying}}}}
 	ops := []txn.Op{
-		st.newCleanupOp(cleanupAttachmentsForDyingStorage, s.doc.Id),
+		newCleanupOp(cleanupAttachmentsForDyingStorage, s.doc.Id),
 		{
 			C:      storageInstancesC,
 			Id:     s.doc.Id,

--- a/state/unit.go
+++ b/state/unit.go
@@ -390,7 +390,7 @@ func (u *Unit) destroyOps() ([]txn.Op, error) {
 	// the number of tests that have to change and defer that improvement to
 	// its own CL.
 	minUnitsOp := minUnitsTriggerOp(u.st, u.ApplicationName())
-	cleanupOp := u.st.newCleanupOp(cleanupDyingUnit, u.doc.Name)
+	cleanupOp := newCleanupOp(cleanupDyingUnit, u.doc.Name)
 	setDyingOp := txn.Op{
 		C:      unitsC,
 		Id:     u.doc.DocID,

--- a/state/volume.go
+++ b/state/volume.go
@@ -673,7 +673,7 @@ func destroyVolumeOps(st *State, v *volume) []txn.Op {
 			Update: bson.D{{"$set", bson.D{{"life", Dead}}}},
 		}}
 	}
-	cleanupOp := st.newCleanupOp(cleanupAttachmentsForDyingVolume, v.doc.Name)
+	cleanupOp := newCleanupOp(cleanupAttachmentsForDyingVolume, v.doc.Name)
 	hasAttachments := bson.D{{"attachmentcount", bson.D{{"$gt", 0}}}}
 	return []txn.Op{{
 		C:      volumesC,


### PR DESCRIPTION
Whenever an app-settings doc is removed, we queue a cleanup that will
try to destroy the associated charm, if it's local. This replaces the
previous unconditional removal of the local charm archive on app
destruction.

driveby: addCleanupOp doesn't need state at all, so it's now a free
func.

(Review request: http://reviews.vapour.ws/r/5644/)