### PR TITLE
Retry when connecting to target during migrations

### DIFF
--- a/api/interface.go
+++ b/api/interface.go
@@ -119,7 +119,7 @@ type DialOpts struct {
 	Timeout time.Duration
 
 	// RetryDelay is the amount of time to wait between
-	// unsucssful connection attempts.
+	// unsuccessful connection attempts.
 	RetryDelay time.Duration
 
 	// BakeryClient is the httpbakery Client, which

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -519,7 +519,7 @@ var runMigrationPrechecks = func(st *state.State, targetInfo coremigration.Targe
 	}
 
 	// Check target controller.
-	conn, err := api.Open(targetToAPIInfo(targetInfo), api.DialOpts{})
+	conn, err := api.Open(targetToAPIInfo(targetInfo), migration.ControllerDialOpts())
 	if err != nil {
 		return errors.Annotate(err, "connect to target controller")
 	}

--- a/migration/dialopts.go
+++ b/migration/dialopts.go
@@ -1,0 +1,24 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migration
+
+import (
+	"time"
+
+	"github.com/juju/juju/api"
+)
+
+// ControllerDialOpts returns dial parameters suitable for connecting
+// from the source controller to the target controller during model
+// migrations. The total attempt time can't be too long because the
+// areas of the code which make these connections need to be
+// interruptable but a number of retries is useful to deal with short
+// lived issues.
+func ControllerDialOpts() api.DialOpts {
+	return api.DialOpts{
+		DialAddressInterval: 50 * time.Millisecond,
+		Timeout:             1 * time.Second,
+		RetryDelay:          100 * time.Millisecond,
+	}
+}

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -678,11 +678,7 @@ func (w *Worker) openAPIConnForModel(targetInfo coremigration.TargetInfo, modelU
 		ModelTag:  names.NewModelTag(modelUUID),
 		Macaroons: targetInfo.Macaroons,
 	}
-
-	// Use zero DialOpts (no retries) because the worker must stay
-	// responsive to Kill requests. We don't want it to be blocked by
-	// a long set of retry attempts.
-	return w.config.APIOpen(apiInfo, api.DialOpts{})
+	return w.config.APIOpen(apiInfo, migration.ControllerDialOpts())
 }
 
 func modelHasMigrated(phase coremigration.Phase) bool {

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -59,7 +59,7 @@ var (
 				Tag:      names.NewUserTag("admin"),
 				Password: "secret",
 			},
-			api.DialOpts{},
+			migration.ControllerDialOpts(),
 		},
 	}
 	apiOpenCallModel = jujutesting.StubCall{
@@ -72,7 +72,7 @@ var (
 				Password: "secret",
 				ModelTag: modelTag,
 			},
-			api.DialOpts{},
+			migration.ControllerDialOpts(),
 		},
 	}
 	importCall = jujutesting.StubCall{
@@ -614,7 +614,7 @@ func (s *Suite) TestAPIConnectWithMacaroon(c *gc.C) {
 						Tag:       names.NewUserTag("admin"),
 						Macaroons: macs, // <---
 					},
-					api.DialOpts{},
+					migration.ControllerDialOpts(),
 				},
 			},
 			abortCall,


### PR DESCRIPTION
Previously, connections from the source controller to the target controller didn't use retries at all. In order to deal with transient issues a small number of retries are now performed.

(Review request: http://reviews.vapour.ws/r/5646/)