### PR TITLE
Migrations: use controller tag to identify controllers

### DIFF
--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -273,7 +273,7 @@ func (c *Client) InitiateMigration(spec MigrationSpec) (string, error) {
 		Specs: []params.MigrationSpec{{
 			ModelTag: names.NewModelTag(spec.ModelUUID).String(),
 			TargetInfo: params.MigrationTargetInfo{
-				ControllerTag: names.NewModelTag(spec.TargetControllerUUID).String(),
+				ControllerTag: names.NewControllerTag(spec.TargetControllerUUID).String(),
 				Addrs:         spec.TargetAddrs,
 				CACert:        spec.TargetCACert,
 				AuthTag:       names.NewUserTag(spec.TargetUser).String(),

--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -69,7 +69,7 @@ func specToArgs(spec controller.MigrationSpec) params.InitiateMigrationArgs {
 		Specs: []params.MigrationSpec{{
 			ModelTag: names.NewModelTag(spec.ModelUUID).String(),
 			TargetInfo: params.MigrationTargetInfo{
-				ControllerTag: names.NewModelTag(spec.TargetControllerUUID).String(),
+				ControllerTag: names.NewControllerTag(spec.TargetControllerUUID).String(),
 				Addrs:         spec.TargetAddrs,
 				CACert:        spec.TargetCACert,
 				AuthTag:       names.NewUserTag(spec.TargetUser).String(),

--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -70,7 +70,7 @@ func (c *Client) MigrationStatus() (migration.MigrationStatus, error) {
 	}
 
 	target := status.Spec.TargetInfo
-	controllerTag, err := names.ParseModelTag(target.ControllerTag)
+	controllerTag, err := names.ParseControllerTag(target.ControllerTag)
 	if err != nil {
 		return empty, errors.Annotatef(err, "parsing controller tag")
 	}

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -71,6 +71,7 @@ func (s *ClientSuite) TestMigrationStatus(c *gc.C) {
 
 	modelUUID := utils.MustNewUUID().String()
 	controllerUUID := utils.MustNewUUID().String()
+	controllerTag := names.NewControllerTag(controllerUUID)
 	timestamp := time.Date(2016, 6, 22, 16, 42, 44, 0, time.UTC)
 	apiCaller := apitesting.APICallerFunc(func(_ string, _ int, _, _ string, _, result interface{}) error {
 		out := result.(*params.MasterMigrationStatus)
@@ -78,7 +79,7 @@ func (s *ClientSuite) TestMigrationStatus(c *gc.C) {
 			Spec: params.MigrationSpec{
 				ModelTag: names.NewModelTag(modelUUID).String(),
 				TargetInfo: params.MigrationTargetInfo{
-					ControllerTag: names.NewModelTag(controllerUUID).String(),
+					ControllerTag: controllerTag.String(),
 					Addrs:         []string{"2.2.2.2:2"},
 					CACert:        "cert",
 					AuthTag:       names.NewUserTag("admin").String(),
@@ -104,7 +105,7 @@ func (s *ClientSuite) TestMigrationStatus(c *gc.C) {
 		PhaseChangedTime: timestamp,
 		ExternalControl:  true,
 		TargetInfo: migration.TargetInfo{
-			ControllerTag: names.NewModelTag(controllerUUID),
+			ControllerTag: controllerTag,
 			Addrs:         []string{"2.2.2.2:2"},
 			CACert:        "cert",
 			AuthTag:       names.NewUserTag("admin"),

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -323,7 +323,7 @@ func (s *migrationSuite) TestMigrationStatusWatcher(c *gc.C) {
 	spec := state.MigrationSpec{
 		InitiatedBy: names.NewUserTag("someone"),
 		TargetInfo: migration.TargetInfo{
-			ControllerTag: names.NewModelTag(utils.MustNewUUID().String()),
+			ControllerTag: names.NewControllerTag(utils.MustNewUUID().String()),
 			Addrs:         []string{"1.2.3.4:5"},
 			CACert:        "cert",
 			AuthTag:       names.NewUserTag("dog"),

--- a/apiserver/client/status_test.go
+++ b/apiserver/client/status_test.go
@@ -251,7 +251,7 @@ func (s *statusUnitTestSuite) TestMigrationInProgress(c *gc.C) {
 	mig, err := state2.CreateMigration(state.MigrationSpec{
 		InitiatedBy: names.NewUserTag("admin"),
 		TargetInfo: migration.TargetInfo{
-			ControllerTag: names.NewModelTag(utils.MustNewUUID().String()),
+			ControllerTag: names.NewControllerTag(utils.MustNewUUID().String()),
 			Addrs:         []string{"1.2.3.4:5555", "4.3.2.1:6666"},
 			CACert:        "cert",
 			AuthTag:       names.NewUserTag("user"),

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -382,7 +382,7 @@ func (c *ControllerAPI) initiateOneMigration(spec params.MigrationSpec) (string,
 
 	// Construct target info.
 	specTarget := spec.TargetInfo
-	controllerTag, err := names.ParseModelTag(specTarget.ControllerTag)
+	controllerTag, err := names.ParseControllerTag(specTarget.ControllerTag)
 	if err != nil {
 		return "", errors.Annotate(err, "controller tag")
 	}

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -341,7 +341,7 @@ func (s *controllerSuite) TestInitiateMigration(c *gc.C) {
 			{
 				ModelTag: st1.ModelTag().String(),
 				TargetInfo: params.MigrationTargetInfo{
-					ControllerTag: randomModelTag(),
+					ControllerTag: randomControllerTag(),
 					Addrs:         []string{"1.1.1.1:1111", "2.2.2.2:2222"},
 					CACert:        "cert1",
 					AuthTag:       names.NewUserTag("admin1").String(),
@@ -350,7 +350,7 @@ func (s *controllerSuite) TestInitiateMigration(c *gc.C) {
 			}, {
 				ModelTag: st2.ModelTag().String(),
 				TargetInfo: params.MigrationTargetInfo{
-					ControllerTag: randomModelTag(),
+					ControllerTag: randomControllerTag(),
 					Addrs:         []string{"3.3.3.3:3333"},
 					CACert:        "cert2",
 					AuthTag:       names.NewUserTag("admin2").String(),
@@ -431,7 +431,7 @@ func (s *controllerSuite) TestInitiateMigrationPartialFailure(c *gc.C) {
 			{
 				ModelTag: st.ModelTag().String(),
 				TargetInfo: params.MigrationTargetInfo{
-					ControllerTag: randomModelTag(),
+					ControllerTag: randomControllerTag(),
 					Addrs:         []string{"1.1.1.1:1111", "2.2.2.2:2222"},
 					CACert:        "cert",
 					AuthTag:       names.NewUserTag("admin").String(),
@@ -462,7 +462,7 @@ func (s *controllerSuite) TestInitiateMigrationInvalidMacaroons(c *gc.C) {
 			{
 				ModelTag: st.ModelTag().String(),
 				TargetInfo: params.MigrationTargetInfo{
-					ControllerTag: randomModelTag(),
+					ControllerTag: randomControllerTag(),
 					Addrs:         []string{"1.1.1.1:1111", "2.2.2.2:2222"},
 					CACert:        "cert",
 					AuthTag:       names.NewUserTag("admin").String(),
@@ -489,7 +489,7 @@ func (s *controllerSuite) TestInitiateMigrationPrecheckFail(c *gc.C) {
 		Specs: []params.MigrationSpec{{
 			ModelTag: st.ModelTag().String(),
 			TargetInfo: params.MigrationTargetInfo{
-				ControllerTag: randomModelTag(),
+				ControllerTag: randomControllerTag(),
 				Addrs:         []string{"1.1.1.1:1111"},
 				CACert:        "cert1",
 				AuthTag:       names.NewUserTag("admin1").String(),
@@ -505,6 +505,11 @@ func (s *controllerSuite) TestInitiateMigrationPrecheckFail(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(active, jc.IsFalse)
 
+}
+
+func randomControllerTag() string {
+	uuid := utils.MustNewUUID().String()
+	return names.NewControllerTag(uuid).String()
 }
 
 func randomModelTag() string {

--- a/apiserver/migrationmaster/facade_test.go
+++ b/apiserver/migrationmaster/facade_test.go
@@ -100,7 +100,7 @@ func (s *Suite) TestMigrationStatus(c *gc.C) {
 		Spec: params.MigrationSpec{
 			ModelTag: names.NewModelTag(modelUUID).String(),
 			TargetInfo: params.MigrationTargetInfo{
-				ControllerTag: names.NewModelTag(controllerUUID).String(),
+				ControllerTag: names.NewControllerTag(controllerUUID).String(),
 				Addrs:         []string{"1.1.1.1:1", "2.2.2.2:2"},
 				CACert:        "trust me",
 				AuthTag:       names.NewUserTag("admin").String(),
@@ -406,7 +406,7 @@ func (m *stubMigration) TargetInfo() (*coremigration.TargetInfo, error) {
 		panic(err)
 	}
 	return &coremigration.TargetInfo{
-		ControllerTag: names.NewModelTag(controllerUUID),
+		ControllerTag: names.NewControllerTag(controllerUUID),
 		Addrs:         []string{"1.1.1.1:1", "2.2.2.2:2"},
 		CACert:        "trust me",
 		AuthTag:       names.NewUserTag("admin"),

--- a/apiserver/watcher_test.go
+++ b/apiserver/watcher_test.go
@@ -206,7 +206,7 @@ func (m *fakeModelMigration) Phase() (migration.Phase, error) {
 
 func (m *fakeModelMigration) TargetInfo() (*migration.TargetInfo, error) {
 	return &migration.TargetInfo{
-		ControllerTag: names.NewModelTag("uuid"),
+		ControllerTag: names.NewControllerTag("uuid"),
 		Addrs:         []string{"1.2.3.4:5555"},
 		CACert:        "trust me",
 		AuthTag:       names.NewUserTag("admin"),

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3256,7 +3256,7 @@ func (s *StatusSuite) setupMigrationTest(c *gc.C) *state.State {
 	mig, err := hostedSt.CreateMigration(state.MigrationSpec{
 		InitiatedBy: names.NewUserTag("admin"),
 		TargetInfo: migration.TargetInfo{
-			ControllerTag: names.NewModelTag(utils.MustNewUUID().String()),
+			ControllerTag: names.NewControllerTag(utils.MustNewUUID().String()),
 			Addrs:         []string{"1.2.3.4:5555", "4.3.2.1:6666"},
 			CACert:        "cert",
 			AuthTag:       names.NewUserTag("user"),

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1308,7 +1308,7 @@ func (s *MachineSuite) TestMigratingModelWorkers(c *gc.C) {
 	instrumented := TrackModels(c, tracker, modelManifoldsDisablingMigrationMaster)
 	s.PatchValue(&modelManifolds, instrumented)
 
-	targetControllerTag := names.NewModelTag(utils.MustNewUUID().String())
+	targetControllerTag := names.NewControllerTag(utils.MustNewUUID().String())
 	_, err := st.CreateMigration(state.MigrationSpec{
 		InitiatedBy: names.NewUserTag("admin"),
 		TargetInfo: migration.TargetInfo{

--- a/core/migration/targetinfo.go
+++ b/core/migration/targetinfo.go
@@ -20,7 +20,7 @@ import (
 // done right now.
 type TargetInfo struct {
 	// ControllerTag holds tag for the target controller.
-	ControllerTag names.ModelTag
+	ControllerTag names.ControllerTag
 
 	// Addrs holds the addresses and ports of the target controller's
 	// API servers.

--- a/core/migration/targetinfo_test.go
+++ b/core/migration/targetinfo_test.go
@@ -29,13 +29,13 @@ func (s *TargetInfoSuite) TestValidation(c *gc.C) {
 	}{{
 		"empty ControllerTag",
 		func(info *migration.TargetInfo) {
-			info.ControllerTag = names.NewModelTag("fooo")
+			info.ControllerTag = names.NewControllerTag("fooo")
 		},
 		"ControllerTag not valid",
 	}, {
 		"invalid ControllerTag",
 		func(info *migration.TargetInfo) {
-			info.ControllerTag = names.NewModelTag("")
+			info.ControllerTag = names.NewControllerTag("")
 		},
 		"ControllerTag not valid",
 	}, {
@@ -102,11 +102,10 @@ func (s *TargetInfoSuite) TestValidation(c *gc.C) {
 }
 
 func makeValidTargetInfo(c *gc.C) migration.TargetInfo {
-	modelTag := names.NewModelTag(utils.MustNewUUID().String())
 	mac, err := macaroon.New([]byte("secret"), "id", "location")
 	c.Assert(err, jc.ErrorIsNil)
 	return migration.TargetInfo{
-		ControllerTag: modelTag,
+		ControllerTag: names.NewControllerTag(utils.MustNewUUID().String()),
 		Addrs:         []string{"1.2.3.4:5555"},
 		CACert:        "cert",
 		AuthTag:       names.NewUserTag("user"),

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -281,7 +281,7 @@ func (mig *modelMigration) TargetInfo() (*migration.TargetInfo, error) {
 		return nil, errors.Trace(err)
 	}
 	return &migration.TargetInfo{
-		ControllerTag: names.NewModelTag(mig.doc.TargetController),
+		ControllerTag: names.NewControllerTag(mig.doc.TargetController),
 		Addrs:         mig.doc.TargetAddrs,
 		CACert:        mig.doc.TargetCACert,
 		AuthTag:       authTag,
@@ -695,12 +695,12 @@ func jsonToMacaroons(raw string) ([]macaroon.Slice, error) {
 	return macs, nil
 }
 
-func checkTargetController(st *State, targetControllerTag names.ModelTag) error {
+func checkTargetController(st *State, targetControllerTag names.ControllerTag) error {
 	currentController, err := st.ControllerModel()
 	if err != nil {
 		return errors.Annotate(err, "failed to load existing controller model")
 	}
-	if targetControllerTag == currentController.ModelTag() {
+	if targetControllerTag == currentController.ControllerTag() {
 		return errors.New("model already attached to target controller")
 	}
 	return nil

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -42,7 +42,7 @@ func (s *MigrationSuite) SetUpTest(c *gc.C) {
 	s.State2 = s.Factory.MakeModel(c, nil)
 	s.AddCleanup(func(*gc.C) { s.State2.Close() })
 
-	targetControllerTag := names.NewModelTag(utils.MustNewUUID().String())
+	targetControllerTag := names.NewControllerTag(utils.MustNewUUID().String())
 
 	mac, err := macaroon.New([]byte("secret"), "id", "location")
 	c.Assert(err, jc.ErrorIsNil)
@@ -247,7 +247,7 @@ func (s *MigrationSuite) TestCreateMigrationWhenModelNotAlive(c *gc.C) {
 
 func (s *MigrationSuite) TestMigrationToSameController(c *gc.C) {
 	spec := s.stdSpec
-	spec.TargetInfo.ControllerTag = s.State.ModelTag()
+	spec.TargetInfo.ControllerTag = s.State.ControllerTag()
 
 	mig, err := s.State2.CreateMigration(spec)
 	c.Check(mig, gc.IsNil)

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -159,7 +159,7 @@ func (s *Suite) makeStatus(phase coremigration.Phase) coremigration.MigrationSta
 		Phase:            phase,
 		PhaseChangedTime: s.clock.Now(),
 		TargetInfo: coremigration.TargetInfo{
-			ControllerTag: names.NewModelTag("controller-uuid"),
+			ControllerTag: names.NewControllerTag("controller-uuid"),
 			Addrs:         []string{"1.2.3.4:5"},
 			CACert:        "cert",
 			AuthTag:       names.NewUserTag("admin"),


### PR DESCRIPTION
Model tags were being inappropriately used in some areas of migrations when controller tags should have been used instead.

(Review request: http://reviews.vapour.ws/r/5648/)