### PR TITLE
Fixes lp#1619957: Re-instate supported architectures for vsphere provider.

### DIFF
--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -31,6 +31,9 @@ type environ struct {
 
 	lock sync.Mutex // lock protects access the following fields.
 	ecfg *environConfig
+
+	archLock               sync.Mutex
+	supportedArchitectures []string
 }
 
 func newEnviron(cloud environs.CloudSpec, cfg *config.Config) (*environ, error) {

--- a/provider/vsphere/environ_policy.go
+++ b/provider/vsphere/environ_policy.go
@@ -6,7 +6,13 @@
 package vsphere
 
 import (
+	"github.com/juju/errors"
+	"github.com/juju/utils/set"
+
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/imagemetadata"
+	"github.com/juju/juju/environs/simplestreams"
 )
 
 // PrecheckInstance verifies that the provided series and constraints
@@ -20,6 +26,47 @@ func (env *environ) PrecheckInstance(series string, cons constraints.Value, plac
 	return nil
 }
 
+// SupportedArchitectures returns the image architectures which can
+// be hosted by this environment.
+func (env *environ) SupportedArchitectures() ([]string, error) {
+	env.archLock.Lock()
+	defer env.archLock.Unlock()
+
+	if env.supportedArchitectures != nil {
+		return env.supportedArchitectures, nil
+	}
+
+	archList, err := env.lookupArchitectures()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	env.supportedArchitectures = archList
+	return archList, nil
+}
+
+func (env *environ) lookupArchitectures() ([]string, error) {
+	// Create a filter to get all images for the
+	// correct stream.
+	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
+		Stream: env.Config().ImageStream(),
+	})
+	sources, err := environs.ImageMetadataSources(env)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	matchingImages, err := imageMetadataFetch(sources, imageConstraint)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var arches = set.NewStrings()
+	for _, im := range matchingImages {
+		arches.Add(im.Arch)
+	}
+
+	return arches.Values(), nil
+}
+
 var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.VirtType,
@@ -30,6 +77,12 @@ var unsupportedConstraints = []string{
 func (env *environ) ConstraintsValidator() (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 	validator.RegisterUnsupported(unsupportedConstraints)
+
+	supportedArches, err := env.SupportedArchitectures()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	validator.RegisterVocabulary(constraints.Arch, supportedArches)
 	return validator, nil
 }
 

--- a/provider/vsphere/environ_policy.go
+++ b/provider/vsphere/environ_policy.go
@@ -26,9 +26,9 @@ func (env *environ) PrecheckInstance(series string, cons constraints.Value, plac
 	return nil
 }
 
-// SupportedArchitectures returns the image architectures which can
+// supportedArchitectures returns the image architectures which can
 // be hosted by this environment.
-func (env *environ) SupportedArchitectures() ([]string, error) {
+func (env *environ) allSupportedArchitectures() ([]string, error) {
 	env.archLock.Lock()
 	defer env.archLock.Unlock()
 
@@ -78,7 +78,7 @@ func (env *environ) ConstraintsValidator() (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 	validator.RegisterUnsupported(unsupportedConstraints)
 
-	supportedArches, err := env.SupportedArchitectures()
+	supportedArches, err := env.allSupportedArchitectures()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/vsphere/environ_policy_test.go
+++ b/provider/vsphere/environ_policy_test.go
@@ -7,7 +7,6 @@ package vsphere_test
 
 import (
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/arch"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/constraints"
@@ -19,13 +18,6 @@ type environPolSuite struct {
 }
 
 var _ = gc.Suite(&environPolSuite{})
-
-func (s *environPolSuite) TestSupportedArchitectures(c *gc.C) {
-	archList, err := s.Env.SupportedArchitectures()
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(archList, jc.SameContents, []string{arch.AMD64})
-}
 
 func (s *environPolSuite) TestConstraintsValidator(c *gc.C) {
 	validator, err := s.Env.ConstraintsValidator()

--- a/provider/vsphere/environ_policy_test.go
+++ b/provider/vsphere/environ_policy_test.go
@@ -7,6 +7,7 @@ package vsphere_test
 
 import (
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/arch"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/constraints"
@@ -18,6 +19,13 @@ type environPolSuite struct {
 }
 
 var _ = gc.Suite(&environPolSuite{})
+
+func (s *environPolSuite) TestSupportedArchitectures(c *gc.C) {
+	archList, err := s.Env.SupportedArchitectures()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(archList, jc.SameContents, []string{arch.AMD64})
+}
 
 func (s *environPolSuite) TestConstraintsValidator(c *gc.C) {
 	validator, err := s.Env.ConstraintsValidator()
@@ -57,7 +65,7 @@ func (s *environPolSuite) TestConstraintsValidatorVocabArch(c *gc.C) {
 
 	cons := constraints.MustParse("arch=ppc64el")
 	_, err = validator.Validate(cons)
-	c.Check(err, jc.ErrorIsNil)
+	c.Check(err, gc.ErrorMatches, "invalid constraint value: arch=ppc64el\nvalid values are:.*")
 }
 
 func (s *environPolSuite) TestSupportNetworks(c *gc.C) {


### PR DESCRIPTION
VSphere has its own custom format of retrieving image metadata from simplestreams. Since it doe s not conform to standard, we have to re-instate custom way of determining supported architectures.

(Review request: http://reviews.vapour.ws/r/5649/)