### PR TITLE
worker/migrationmaster: Check target UUID

### DIFF
--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -317,6 +317,12 @@ func (w *Worker) prechecks(status coremigration.MigrationStatus) error {
 		return errors.Annotate(err, "failed to connect to target controller during prechecks")
 	}
 	defer conn.Close()
+
+	if conn.ControllerTag() != status.TargetInfo.ControllerTag {
+		return errors.Errorf("unexpected target controller UUID (got %s, expected %s)",
+			conn.ControllerTag(), status.TargetInfo.ControllerTag)
+	}
+
 	targetClient := migrationtarget.NewClient(conn)
 	err = targetClient.Prechecks(model)
 	return errors.Annotate(err, "target prechecks failed")


### PR DESCRIPTION
The migrationmaster now checks that the target controller being migrated to actually has the controller tag specified when the migration was initiated. This is unlikely to happen but is a good backstop to have.

Also a drive-by cleanup of various test data variables.

(Review request: http://reviews.vapour.ws/r/5650/)