### PR TITLE
Report machine down

### DIFF
--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -797,7 +797,7 @@ func populateStatusFromStatusInfoAndErr(agent *params.DetailedStatus, statusInfo
 // processMachine retrieves version and status information for the given machine.
 // It also returns deprecated legacy status information.
 func processMachine(machine *state.Machine) (out params.DetailedStatus) {
-	statusInfo, err := machine.Status()
+	statusInfo, err := common.MachineStatus(machine)
 	populateStatusFromStatusInfoAndErr(&out, statusInfo, err)
 
 	out.Life = processLife(machine)

--- a/apiserver/common/machine.go
+++ b/apiserver/common/machine.go
@@ -65,6 +65,7 @@ type Machine interface {
 	Life() state.Life
 	ForceDestroy() error
 	Destroy() error
+	AgentPresence() (bool, error)
 }
 
 func DestroyMachines(st origStateInterface, force bool, ids ...string) error {
@@ -105,7 +106,7 @@ func ModelMachineInfo(st ModelManagerBackend) (machineInfo []params.ModelMachine
 			continue
 		}
 		var status string
-		statusInfo, err := m.Status()
+		statusInfo, err := MachineStatus(m)
 		if err == nil {
 			status = string(statusInfo.Status)
 		} else {

--- a/apiserver/common/machine_test.go
+++ b/apiserver/common/machine_test.go
@@ -171,10 +171,13 @@ type mockMachine struct {
 	instId             instance.Id
 	hasVote, wantsVote bool
 	status             status.Status
+	statusErr          error
 	destroyErr         error
 	forceDestroyErr    error
 	forceDestroyCalled bool
 	destroyCalled      bool
+	presenceDead       bool
+	presenceErr        error
 }
 
 func (m *mockMachine) Id() string {
@@ -200,11 +203,15 @@ func (m *mockMachine) HasVote() bool {
 func (m *mockMachine) Status() (status.StatusInfo, error) {
 	return status.StatusInfo{
 		Status: m.status,
-	}, nil
+	}, m.statusErr
 }
 
 func (m *mockMachine) HardwareCharacteristics() (*instance.HardwareCharacteristics, error) {
 	return m.hw, nil
+}
+
+func (m *mockMachine) AgentPresence() (bool, error) {
+	return !m.presenceDead, m.presenceErr
 }
 
 func (m *mockMachine) ForceDestroy() error {

--- a/apiserver/common/machine_test.go
+++ b/apiserver/common/machine_test.go
@@ -176,7 +176,7 @@ type mockMachine struct {
 	forceDestroyErr    error
 	forceDestroyCalled bool
 	destroyCalled      bool
-	presenceDead       bool
+	agentDead          bool
 	presenceErr        error
 }
 
@@ -211,7 +211,7 @@ func (m *mockMachine) HardwareCharacteristics() (*instance.HardwareCharacteristi
 }
 
 func (m *mockMachine) AgentPresence() (bool, error) {
-	return !m.presenceDead, m.presenceErr
+	return !m.agentDead, m.presenceErr
 }
 
 func (m *mockMachine) ForceDestroy() error {

--- a/apiserver/common/machinestatus.go
+++ b/apiserver/common/machinestatus.go
@@ -1,0 +1,52 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
+)
+
+// MachineStatusGetter defines the machine functionality
+// required to status.
+type MachineStatusGetter interface {
+	Status() (status.StatusInfo, error)
+	AgentPresence() (bool, error)
+	Id() string
+	Life() state.Life
+}
+
+// MachineStatus returns the machine agent status for a given
+// machine, with special handling for agent presence.
+func MachineStatus(machine MachineStatusGetter) (status.StatusInfo, error) {
+	machineStatus, err := machine.Status()
+	if err != nil {
+		return status.StatusInfo{}, err
+	}
+
+	if !canMachineBeDown(machineStatus) {
+		// The machine still being provisioned - there's no point in
+		// enquiring about the agent liveness.
+		return machineStatus, err
+	}
+
+	agentAlive, err := machine.AgentPresence()
+	if err != nil {
+		// We don't want any presence errors affecting status.
+		return machineStatus, nil
+	}
+	if machine.Life() != state.Dead && !agentAlive {
+		machineStatus.Status = status.StatusDown
+		machineStatus.Message = "agent is not communicating with the server"
+	}
+	return machineStatus, nil
+}
+
+func canMachineBeDown(machineStatus status.StatusInfo) bool {
+	switch machineStatus.Status {
+	case status.StatusPending, status.StatusStopped:
+		return false
+	}
+	return true
+}

--- a/apiserver/common/machinestatus.go
+++ b/apiserver/common/machinestatus.go
@@ -34,6 +34,7 @@ func MachineStatus(machine MachineStatusGetter) (status.StatusInfo, error) {
 	agentAlive, err := machine.AgentPresence()
 	if err != nil {
 		// We don't want any presence errors affecting status.
+		logger.Debugf("error determining presence for machine %s: %v", machine.Id(), err)
 		return machineStatus, nil
 	}
 	if machine.Life() != state.Dead && !agentAlive {

--- a/apiserver/common/machinestatus_test.go
+++ b/apiserver/common/machinestatus_test.go
@@ -1,0 +1,76 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common_test
+
+import (
+	"errors"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
+)
+
+type MachineStatusSuite struct {
+	testing.IsolationSuite
+	machine *mockMachine
+}
+
+var _ = gc.Suite(&MachineStatusSuite{})
+
+func (s *MachineStatusSuite) SetUpTest(c *gc.C) {
+	s.machine = &mockMachine{
+		status: status.StatusStarted,
+	}
+}
+
+func (s *MachineStatusSuite) checkUntouched(c *gc.C) {
+	agent, err := common.MachineStatus(s.machine)
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(agent.Status, jc.DeepEquals, s.machine.status)
+}
+
+func (s *MachineStatusSuite) TestNormal(c *gc.C) {
+	s.checkUntouched(c)
+}
+
+func (s *MachineStatusSuite) TestErrors(c *gc.C) {
+	s.machine.statusErr = errors.New("status error")
+
+	_, err := common.MachineStatus(s.machine)
+	c.Assert(err, gc.ErrorMatches, "status error")
+}
+
+func (s *MachineStatusSuite) TestDown(c *gc.C) {
+	s.machine.presenceDead = true
+	agent, err := common.MachineStatus(s.machine)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(agent, jc.DeepEquals, status.StatusInfo{
+		Status:  status.StatusDown,
+		Message: "agent is not communicating with the server",
+	})
+}
+
+func (s *MachineStatusSuite) TestDownAndDead(c *gc.C) {
+	s.machine.presenceDead = true
+	s.machine.life = state.Dead
+	// Status is untouched if unit is Dead.
+	s.checkUntouched(c)
+}
+
+func (s *MachineStatusSuite) TestPresenceError(c *gc.C) {
+	s.machine.presenceDead = true
+	s.machine.presenceErr = errors.New("boom")
+	// Presence error gets ignored, so no output is unchanged.
+	s.checkUntouched(c)
+}
+
+func (s *MachineStatusSuite) TestNotDownIfPending(c *gc.C) {
+	s.machine.presenceDead = true
+	s.machine.status = status.StatusPending
+	s.checkUntouched(c)
+}

--- a/apiserver/common/machinestatus_test.go
+++ b/apiserver/common/machinestatus_test.go
@@ -46,7 +46,7 @@ func (s *MachineStatusSuite) TestErrors(c *gc.C) {
 }
 
 func (s *MachineStatusSuite) TestDown(c *gc.C) {
-	s.machine.presenceDead = true
+	s.machine.agentDead = true
 	agent, err := common.MachineStatus(s.machine)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(agent, jc.DeepEquals, status.StatusInfo{
@@ -56,21 +56,21 @@ func (s *MachineStatusSuite) TestDown(c *gc.C) {
 }
 
 func (s *MachineStatusSuite) TestDownAndDead(c *gc.C) {
-	s.machine.presenceDead = true
+	s.machine.agentDead = true
 	s.machine.life = state.Dead
 	// Status is untouched if unit is Dead.
 	s.checkUntouched(c)
 }
 
 func (s *MachineStatusSuite) TestPresenceError(c *gc.C) {
-	s.machine.presenceDead = true
+	s.machine.agentDead = true
 	s.machine.presenceErr = errors.New("boom")
 	// Presence error gets ignored, so no output is unchanged.
 	s.checkUntouched(c)
 }
 
 func (s *MachineStatusSuite) TestNotDownIfPending(c *gc.C) {
-	s.machine.presenceDead = true
+	s.machine.agentDead = true
 	s.machine.status = status.StatusPending
 	s.checkUntouched(c)
 }

--- a/apiserver/common/unitstatus.go
+++ b/apiserver/common/unitstatus.go
@@ -52,7 +52,7 @@ func UnitStatus(unit UnitStatusGetter) (agent StatusAndErr, workload StatusAndEr
 		// error information would then be lost.
 		if workload.Status.Status != status.StatusError {
 			workload.Status.Status = status.StatusUnknown
-			workload.Status.Message = fmt.Sprintf("agent lost, see 'juju status-history %s'", unit.Name())
+			workload.Status.Message = fmt.Sprintf("agent lost, see 'juju show-status-log %s'", unit.Name())
 		}
 		agent.Status.Status = status.StatusLost
 		agent.Status.Message = "agent is not communicating with the server"

--- a/apiserver/common/unitstatus_test.go
+++ b/apiserver/common/unitstatus_test.go
@@ -67,7 +67,7 @@ func (s *UnitStatusSuite) TestLost(c *gc.C) {
 	c.Check(agent.Err, jc.ErrorIsNil)
 	c.Check(workload.Status, jc.DeepEquals, status.StatusInfo{
 		Status:  status.StatusUnknown,
-		Message: "agent lost, see 'juju status-history foo/2'",
+		Message: "agent lost, see 'juju show-status-log foo/2'",
 	})
 	c.Check(workload.Err, jc.ErrorIsNil)
 }

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -557,6 +557,10 @@ func (m *mockMachine) HardwareCharacteristics() (*instance.HardwareCharacteristi
 	return m.hw, nil
 }
 
+func (m *mockMachine) AgentPresence() (bool, error) {
+	return true, nil
+}
+
 func (m *mockMachine) InstanceId() (instance.Id, error) {
 	return "", nil
 }

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1244,10 +1244,31 @@ func (s *ParseBindSuite) checkParseFailsForArgs(c *gc.C, args string, expectedEr
 
 type DeployUnitTestSuite struct {
 	jujutesting.IsolationSuite
+	jujutesting.FakeHomeSuite
 	DeployAPI
 }
 
 var _ = gc.Suite(&DeployUnitTestSuite{})
+
+func (s *DeployUnitTestSuite) SetUpSuite(c *gc.C) {
+	s.IsolationSuite.SetUpSuite(c)
+	s.FakeHomeSuite.SetUpSuite(c)
+}
+
+func (s *DeployUnitTestSuite) TearDownSuite(c *gc.C) {
+	s.FakeHomeSuite.TearDownSuite(c)
+	s.IsolationSuite.TearDownSuite(c)
+}
+
+func (s *DeployUnitTestSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.FakeHomeSuite.SetUpTest(c)
+}
+
+func (s *DeployUnitTestSuite) TearDownTest(c *gc.C) {
+	s.FakeHomeSuite.TearDownTest(c)
+	s.IsolationSuite.TearDownTest(c)
+}
 
 func (s *DeployUnitTestSuite) TestDeployLocalCharm_GivesCorrectUserMessage(c *gc.C) {
 	// Copy dummy charm to path where we can deploy it from

--- a/cmd/juju/status/history.go
+++ b/cmd/juju/status/history.go
@@ -20,6 +20,8 @@ import (
 	"github.com/juju/juju/status"
 )
 
+// TODO(peritto666) - add tests
+
 // NewStatusHistoryCommand returns a command that reports the history
 // of status changes for the specified unit.
 func NewStatusHistoryCommand() cmd.Command {
@@ -144,7 +146,7 @@ func (c *statusHistoryCommand) Run(ctx *cmd.Context) error {
 		}
 		tag = names.NewUnitTag(c.entityName)
 	default:
-		if names.IsValidMachine(c.entityName) {
+		if !names.IsValidMachine(c.entityName) {
 			return errors.Errorf("%q is not a valid name for a %s", c.entityName, kind)
 		}
 		tag = names.NewMachineTag(c.entityName)

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -1288,7 +1288,7 @@ var statusTests = []testCase{
 								"machine": "0",
 								"workload-status": M{
 									"current": "unknown",
-									"message": "agent lost, see 'juju status-history dummy-application/0'",
+									"message": "agent lost, see 'juju show-status-log dummy-application/0'",
 									"since":   "01 Apr 15 01:23+10:00",
 								},
 								"juju-status": M{


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju/+bug/1621661

When a machine agent does not phone home, juju status now reports the machine as "down".
This is reflected in list-controllers, show-controller (for HA reporting), as well as juju status for all machines including non-controller machines.

Also a drive by test isolation fix, and a fix for some incorrect terminology due to a renamed command.

(Review request: http://reviews.vapour.ws/r/5651/)