### PR TITLE
CA cert is optional, remove validation checks

### DIFF
--- a/jujuclient/controllervalidation_test.go
+++ b/jujuclient/controllervalidation_test.go
@@ -38,11 +38,6 @@ func (s *ControllerValidationSuite) TestValidateControllerDetailsNoControllerUUI
 	s.assertValidateControllerDetailsFails(c, "missing uuid, controller details not valid")
 }
 
-func (s *ControllerValidationSuite) TestValidateControllerDetailsNoCACert(c *gc.C) {
-	s.controller.CACert = ""
-	s.assertValidateControllerDetailsFails(c, "missing ca-cert, controller details not valid")
-}
-
 func (s *ControllerValidationSuite) assertValidateControllerDetailsFails(c *gc.C, failureMessage string) {
 	err := jujuclient.ValidateControllerDetails(s.controller)
 	c.Assert(err, gc.ErrorMatches, failureMessage)

--- a/jujuclient/validation.go
+++ b/jujuclient/validation.go
@@ -13,9 +13,6 @@ func ValidateControllerDetails(details ControllerDetails) error {
 	if details.ControllerUUID == "" {
 		return errors.NotValidf("missing uuid, controller details")
 	}
-	if details.CACert == "" {
-		return errors.NotValidf("missing ca-cert, controller details")
-	}
 	return nil
 }
 


### PR DESCRIPTION
CA cert is optional, so we need to remove the validation checks for it.

QA: bootstrap juju on AWS to ensure no regression.


(Review request: http://reviews.vapour.ws/r/5652/)