### PR TITLE
Unset the LESS environment variable in juju agree.

### DIFF
--- a/cmd/juju/romulus/agree/agree.go
+++ b/cmd/juju/romulus/agree/agree.go
@@ -236,6 +236,7 @@ func printTerms(ctx *cmd.Context, terms []wireformat.GetTermsResponse) (returnEr
 }
 
 func pagerCmd() (*exec.Cmd, error) {
+	os.Unsetenv("LESS")
 	if pager := os.Getenv("PAGER"); pager != "" {
 		if pagerPath, err := exec.LookPath(pager); err == nil {
 			return exec.Command(pagerPath), nil


### PR DESCRIPTION
The LESS environment variable can customize the behavior of the `less`
command by adding command-line options by default. In some cases, these
can interfere with the display of the terms, so this environment
variable is unset prior to launching $PAGER (which could be `less`) and
`less` directly.

QA steps:
```
export LESS="-S"
juju agree lorem-ipsum/1  # some term you haven't agreed to before
```
Term is displayed with line wrapping, even though the `-S` switch would otherwise disable it.

(Review request: http://reviews.vapour.ws/r/5655/)