### PR TITLE
add cores constraint & alias cpu-cores

### DIFF
--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -280,7 +280,7 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "machine 1 not provisioned")
 	c.Assert(instanceId, gc.Equals, instance.Id(""))
 
-	hwChars := instance.MustParseHardware("cpu-cores=123", "mem=4G")
+	hwChars := instance.MustParseHardware("cores=123", "mem=4G")
 
 	volumes := []params.Volume{{
 		VolumeTag: "volume-1-0",
@@ -415,7 +415,7 @@ func (s *provisionerSuite) TestProvisioningInfo(c *gc.C) {
 		SpaceName:        "{{if (lt . 2)}}space1{{else}}space2{{end}}",
 	})
 
-	cons := constraints.MustParse("cpu-cores=12 mem=8G spaces=^space1,space2")
+	cons := constraints.MustParse("cores=12 mem=8G spaces=^space1,space2")
 	template := state.MachineTemplate{
 		Series:      "quantal",
 		Jobs:        []state.MachineJob{state.JobHostUnits},

--- a/apiserver/application/application_test.go
+++ b/apiserver/application/application_test.go
@@ -1354,7 +1354,7 @@ func (s *serviceSuite) TestServiceUpdateSetConstraints(c *gc.C) {
 	application := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
 	// Update constraints for the application.
-	cons, err := constraints.Parse("mem=4096", "cpu-cores=2")
+	cons, err := constraints.Parse("mem=4096", "cores=2")
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.ApplicationUpdate{
 		ApplicationName: "dummy",
@@ -1379,7 +1379,7 @@ func (s *serviceSuite) TestServiceUpdateAllParams(c *gc.C) {
 
 	// Update all the service attributes.
 	minUnits := 3
-	cons, err := constraints.Parse("mem=4096", "cpu-cores=2")
+	cons, err := constraints.Parse("mem=4096", "cores=2")
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.ApplicationUpdate{
 		ApplicationName: "application",
@@ -2323,7 +2323,7 @@ func (s *serviceSuite) TestClientSetServiceConstraints(c *gc.C) {
 	application := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
 	// Update constraints for the application.
-	cons, err := constraints.Parse("mem=4096", "cpu-cores=2")
+	cons, err := constraints.Parse("mem=4096", "cores=2")
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.applicationAPI.SetConstraints(params.SetConstraints{ApplicationName: "dummy", Constraints: cons})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2337,7 +2337,7 @@ func (s *serviceSuite) TestClientSetServiceConstraints(c *gc.C) {
 func (s *serviceSuite) setupSetServiceConstraints(c *gc.C) (*state.Application, constraints.Value) {
 	application := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 	// Update constraints for the application.
-	cons, err := constraints.Parse("mem=4096", "cpu-cores=2")
+	cons, err := constraints.Parse("mem=4096", "cores=2")
 	c.Assert(err, jc.ErrorIsNil)
 	return application, cons
 }
@@ -2378,7 +2378,7 @@ func (s *serviceSuite) TestClientGetServiceConstraints(c *gc.C) {
 	application := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
 	// Set constraints for the application.
-	cons, err := constraints.Parse("mem=4096", "cpu-cores=2")
+	cons, err := constraints.Parse("mem=4096", "cores=2")
 	c.Assert(err, jc.ErrorIsNil)
 	err = application.SetConstraints(cons)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -617,7 +617,7 @@ func (s *clientSuite) TestClientWatchAll(c *gc.C) {
 
 func (s *clientSuite) TestClientSetModelConstraints(c *gc.C) {
 	// Set constraints for the model.
-	cons, err := constraints.Parse("mem=4096", "cpu-cores=2")
+	cons, err := constraints.Parse("mem=4096", "cores=2")
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.APIState.Client().SetModelConstraints(cons)
 	c.Assert(err, jc.ErrorIsNil)
@@ -630,7 +630,7 @@ func (s *clientSuite) TestClientSetModelConstraints(c *gc.C) {
 
 func (s *clientSuite) assertSetModelConstraints(c *gc.C) {
 	// Set constraints for the model.
-	cons, err := constraints.Parse("mem=4096", "cpu-cores=2")
+	cons, err := constraints.Parse("mem=4096", "cores=2")
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.APIState.Client().SetModelConstraints(cons)
 	c.Assert(err, jc.ErrorIsNil)
@@ -642,7 +642,7 @@ func (s *clientSuite) assertSetModelConstraints(c *gc.C) {
 
 func (s *clientSuite) assertSetModelConstraintsBlocked(c *gc.C, msg string) {
 	// Set constraints for the model.
-	cons, err := constraints.Parse("mem=4096", "cpu-cores=2")
+	cons, err := constraints.Parse("mem=4096", "cores=2")
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.APIState.Client().SetModelConstraints(cons)
 	s.AssertBlocked(c, err, msg)
@@ -665,7 +665,7 @@ func (s *clientSuite) TestBlockChangesClientSetModelConstraints(c *gc.C) {
 
 func (s *clientSuite) TestClientGetModelConstraints(c *gc.C) {
 	// Set constraints for the model.
-	cons, err := constraints.Parse("mem=4096", "cpu-cores=2")
+	cons, err := constraints.Parse("mem=4096", "cores=2")
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.SetModelConstraints(cons)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/highavailability/highavailability_test.go
+++ b/apiserver/highavailability/highavailability_test.go
@@ -50,7 +50,7 @@ func assertKill(c *gc.C, killer KillerForTesting) {
 
 var (
 	emptyCons      = constraints.Value{}
-	controllerCons = constraints.MustParse("mem=16G cpu-cores=16")
+	controllerCons = constraints.MustParse("mem=16G cores=16")
 	defaultSeries  = ""
 )
 

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -822,7 +822,7 @@ func (s *withoutControllerSuite) TestDistributionGroupMachineAgentAuth(c *gc.C) 
 
 func (s *withoutControllerSuite) TestConstraints(c *gc.C) {
 	// Add a machine with some constraints.
-	cons := constraints.MustParse("cpu-cores=123", "mem=8G")
+	cons := constraints.MustParse("cores=123", "mem=8G")
 	template := state.MachineTemplate{
 		Series:      "quantal",
 		Jobs:        []state.MachineJob{state.JobHostUnits},

--- a/apiserver/provisioner/provisioninginfo_test.go
+++ b/apiserver/provisioner/provisioninginfo_test.go
@@ -25,7 +25,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithStorage(c *gc.C) {
 	_, err := pm.Create("static-pool", "static", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	cons := constraints.MustParse("cpu-cores=123 mem=8G")
+	cons := constraints.MustParse("cores=123 mem=8G")
 	template := state.MachineTemplate{
 		Series:      "quantal",
 		Jobs:        []state.MachineJob{state.JobHostUnits},
@@ -116,7 +116,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithStorage(c *gc.C) {
 func (s *withoutControllerSuite) TestProvisioningInfoWithSingleNegativeAndPositiveSpaceInConstraints(c *gc.C) {
 	s.addSpacesAndSubnets(c)
 
-	cons := constraints.MustParse("cpu-cores=123 mem=8G spaces=^space1,space2")
+	cons := constraints.MustParse("cores=123 mem=8G spaces=^space1,space2")
 	template := state.MachineTemplate{
 		Series:      "quantal",
 		Jobs:        []state.MachineJob{state.JobHostUnits},
@@ -234,8 +234,8 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithUnsuitableSpacesConstra
 	_, err := s.State.AddSpace("empty", "", nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 
-	consEmptySpace := constraints.MustParse("cpu-cores=123 mem=8G spaces=empty")
-	consMissingSpace := constraints.MustParse("cpu-cores=123 mem=8G spaces=missing")
+	consEmptySpace := constraints.MustParse("cores=123 mem=8G spaces=empty")
+	consMissingSpace := constraints.MustParse("cores=123 mem=8G spaces=missing")
 	templates := []state.MachineTemplate{{
 		Series:      "quantal",
 		Jobs:        []state.MachineJob{state.JobHostUnits},

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -546,7 +546,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationConstrants(c *g
         applications:
             wordpress:
                 charm: wordpress
-                constraints: mem=4G cpu-cores=2
+                constraints: mem=4G cores=2
             customized:
                 charm: precise/dummy-0
                 num_units: 1
@@ -561,7 +561,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationConstrants(c *g
 		},
 		"wordpress": {
 			charm:       "cs:xenial/wordpress-42",
-			constraints: constraints.MustParse("mem=4G cpu-cores=2"),
+			constraints: constraints.MustParse("mem=4G cores=2"),
 		},
 	})
 	s.assertUnitsCreated(c, map[string]string{
@@ -598,7 +598,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationUpgrade(c *gc.C
                 num_units: 1
                 options:
                     blog-title: new title
-                constraints: spaces=new cpu-cores=8
+                constraints: spaces=new cores=8
             up:
                 charm: vivid/upgrade-2
                 num_units: 1
@@ -610,7 +610,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationUpgrade(c *gc.C
 		"wordpress": {
 			charm:       "cs:xenial/wordpress-42",
 			config:      charm.Settings{"blog-title": "new title"},
-			constraints: constraints.MustParse("spaces=new cpu-cores=8"),
+			constraints: constraints.MustParse("spaces=new cores=8"),
 		},
 	})
 	s.assertUnitsCreated(c, map[string]string{
@@ -897,7 +897,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMachineAttributes(c *gc.C)
         machines:
             1:
                 series: xenial
-                constraints: "cpu-cores=4 mem=4G"
+                constraints: "cores=4 mem=4G"
                 annotations:
                     foo: bar
     `)
@@ -915,7 +915,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMachineAttributes(c *gc.C)
 	c.Assert(m.Series(), gc.Equals, "xenial")
 	cons, err := m.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	expectedCons, err := constraints.Parse("cpu-cores=4 mem=4G")
+	expectedCons, err := constraints.Parse("cores=4 mem=4G")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cons, jc.DeepEquals, expectedCons)
 	ann, err := s.State.Annotations(m)

--- a/cmd/juju/application/constraints.go
+++ b/cmd/juju/application/constraints.go
@@ -59,7 +59,7 @@ the first unit set them at the model level or pass them as an argument
 when deploying.
 
 Examples:
-    juju set-constraints mysql mem=8G cpu-cores=4
+    juju set-constraints mysql mem=8G cores=4
     juju set-constraints -m mymodel apache2 mem=8G arch=amd64
 
 See also: 

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -92,9 +92,6 @@ var initErrorTests = []struct {
 		args: []string{"craziness", "burble1", "--to", "#:foo"},
 		err:  `invalid --to parameter "#:foo"`,
 	}, {
-		args: []string{"craziness", "burble1", "--constraints", "gibber=plop"},
-		err:  `invalid value "gibber=plop" for flag --constraints: unknown constraint "gibber"`,
-	}, {
 		args: []string{"charm", "application", "--force"},
 		err:  `--force is only used with --series`,
 	},
@@ -279,13 +276,13 @@ func (s *DeploySuite) TestConfigError(c *gc.C) {
 
 func (s *DeploySuite) TestConstraints(c *gc.C) {
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "dummy")
-	err := runDeploy(c, ch, "--constraints", "mem=2G cpu-cores=2", "--series", "trusty")
+	err := runDeploy(c, ch, "--constraints", "mem=2G cores=2", "--series", "trusty")
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:trusty/dummy-1")
 	application, _ := s.AssertService(c, "dummy", curl, 1, 0)
 	cons, err := application.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cons, jc.DeepEquals, constraints.MustParse("mem=2G cpu-cores=2"))
+	c.Assert(cons, jc.DeepEquals, constraints.MustParse("mem=2G cores=2"))
 }
 
 func (s *DeploySuite) TestResources(c *gc.C) {

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -123,18 +123,20 @@ func newBootstrapCommand() cmd.Command {
 type bootstrapCommand struct {
 	modelcmd.ModelCommandBase
 
-	Constraints           constraints.Value
-	BootstrapConstraints  constraints.Value
-	BootstrapSeries       string
-	BootstrapImage        string
-	BuildAgent            bool
-	MetadataSource        string
-	Placement             string
-	KeepBrokenEnvironment bool
-	AutoUpgrade           bool
-	AgentVersionParam     string
-	AgentVersion          *version.Number
-	config                common.ConfigFlag
+	Constraints             constraints.Value
+	ConstraintsStr          string
+	BootstrapConstraints    constraints.Value
+	BootstrapConstraintsStr string
+	BootstrapSeries         string
+	BootstrapImage          string
+	BuildAgent              bool
+	MetadataSource          string
+	Placement               string
+	KeepBrokenEnvironment   bool
+	AutoUpgrade             bool
+	AgentVersionParam       string
+	AgentVersion            *version.Number
+	config                  common.ConfigFlag
 
 	showClouds          bool
 	showRegionsForCloud string
@@ -158,8 +160,8 @@ func (c *bootstrapCommand) Info() *cmd.Info {
 
 func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	f.Var(constraints.ConstraintsValue{Target: &c.Constraints}, "constraints", "Set model constraints")
-	f.Var(constraints.ConstraintsValue{Target: &c.BootstrapConstraints}, "bootstrap-constraints", "Specify bootstrap machine constraints")
+	f.StringVar(&c.ConstraintsStr, "constraints", "", "Set model constraints")
+	f.StringVar(&c.BootstrapConstraintsStr, "bootstrap-constraints", "", "Specify bootstrap machine constraints")
 	f.StringVar(&c.BootstrapSeries, "bootstrap-series", "", "Specify the series of the bootstrap machine")
 	if featureflag.Enabled(feature.ImageMetadata) {
 		f.StringVar(&c.BootstrapImage, "bootstrap-image", "", "Specify the image of the bootstrap machine")
@@ -194,18 +196,6 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 	}
 	if c.BootstrapSeries != "" && !charm.IsValidSeries(c.BootstrapSeries) {
 		return errors.NotValidf("series %q", c.BootstrapSeries)
-	}
-	if c.BootstrapImage != "" {
-		if c.BootstrapSeries == "" {
-			return errors.Errorf("--bootstrap-image must be used with --bootstrap-series")
-		}
-		cons, err := constraints.Merge(c.Constraints, c.BootstrapConstraints)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if !cons.HasArch() {
-			return errors.Errorf("--bootstrap-image must be used with --bootstrap-constraints, specifying architecture")
-		}
 	}
 
 	// Parse the placement directive. Bootstrap currently only
@@ -290,10 +280,51 @@ more than one credential is available
 specify a credential using the --credential argument`[1:],
 )
 
+func (c *bootstrapCommand) parseConstraints(ctx *cmd.Context) (err error) {
+	allAliases := map[string]string{}
+	defer common.WarnConstraintAliases(ctx, allAliases)
+	if c.ConstraintsStr != "" {
+		cons, aliases, err := constraints.ParseWithAliases(c.ConstraintsStr)
+		for k, v := range aliases {
+			allAliases[k] = v
+		}
+		if err != nil {
+			return err
+		}
+		c.Constraints = cons
+	}
+	if c.BootstrapConstraintsStr != "" {
+		cons, aliases, err := constraints.ParseWithAliases(c.BootstrapConstraintsStr)
+		for k, v := range aliases {
+			allAliases[k] = v
+		}
+		if err != nil {
+			return err
+		}
+		c.BootstrapConstraints = cons
+	}
+	return nil
+}
+
 // Run connects to the environment specified on the command line and bootstraps
 // a juju in that environment if none already exists. If there is as yet no environments.yaml file,
 // the user is informed how to create one.
 func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
+	if err := c.parseConstraints(ctx); err != nil {
+		return err
+	}
+	if c.BootstrapImage != "" {
+		if c.BootstrapSeries == "" {
+			return errors.Errorf("--bootstrap-image must be used with --bootstrap-series")
+		}
+		cons, err := constraints.Merge(c.Constraints, c.BootstrapConstraints)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if !cons.HasArch() {
+			return errors.Errorf("--bootstrap-image must be used with --bootstrap-constraints, specifying architecture")
+		}
+	}
 	if c.interactive {
 		if err := c.runInteractive(ctx); err != nil {
 			return errors.Trace(err)

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -311,7 +311,7 @@ var bootstrapTests = []bootstrapTest{{
 }, {
 	info: "bad --constraints",
 	args: []string{"--constraints", "bad=wrong"},
-	err:  `invalid value "bad=wrong" for flag --constraints: unknown constraint "bad"`,
+	err:  `unknown constraint "bad"`,
 }, {
 	info: "conflicting --constraints",
 	args: []string{"--constraints", "instance-type=foo mem=4G"},
@@ -323,17 +323,17 @@ var bootstrapTests = []bootstrapTest{{
 	err:     `failed to bootstrap model: dummy.Bootstrap is broken`,
 }, {
 	info:        "constraints",
-	args:        []string{"--constraints", "mem=4G cpu-cores=4"},
-	constraints: constraints.MustParse("mem=4G cpu-cores=4"),
+	args:        []string{"--constraints", "mem=4G cores=4"},
+	constraints: constraints.MustParse("mem=4G cores=4"),
 }, {
 	info:                 "bootstrap and environ constraints",
-	args:                 []string{"--constraints", "mem=4G cpu-cores=4", "--bootstrap-constraints", "mem=8G"},
-	constraints:          constraints.MustParse("mem=4G cpu-cores=4"),
-	bootstrapConstraints: constraints.MustParse("mem=8G cpu-cores=4"),
+	args:                 []string{"--constraints", "mem=4G cores=4", "--bootstrap-constraints", "mem=8G"},
+	constraints:          constraints.MustParse("mem=4G cores=4"),
+	bootstrapConstraints: constraints.MustParse("mem=8G cores=4"),
 }, {
 	info:        "unsupported constraint passed through but no error",
-	args:        []string{"--constraints", "mem=4G cpu-cores=4 cpu-power=10"},
-	constraints: constraints.MustParse("mem=4G cpu-cores=4 cpu-power=10"),
+	args:        []string{"--constraints", "mem=4G cores=4 cpu-power=10"},
+	constraints: constraints.MustParse("mem=4G cores=4 cpu-power=10"),
 }, {
 	info:        "--build-agent uses arch from constraint if it matches current version",
 	version:     "1.3.3-saucy-ppc64el",

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -100,6 +100,8 @@ type addCommand struct {
 	Series string
 	// If specified, these constraints are merged with those already in the model.
 	Constraints constraints.Value
+	// If specified, these constraints are merged with those already in the model.
+	ConstraintsStr string
 	// Placement is passed verbatim to the API, to be parsed and evaluated server-side.
 	Placement *instance.Placement
 	// NumMachines is the number of machines to add.
@@ -121,7 +123,7 @@ func (c *addCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	f.StringVar(&c.Series, "series", "", "The charm series")
 	f.IntVar(&c.NumMachines, "n", 1, "The number of machines to add")
-	f.Var(constraints.ConstraintsValue{Target: &c.Constraints}, "constraints", "Additional machine constraints")
+	f.StringVar(&c.ConstraintsStr, "constraints", "", "Additional machine constraints")
 	f.Var(disksFlag{&c.Disks}, "disks", "Constraints for disks to attach to the machine")
 }
 
@@ -203,6 +205,11 @@ func (c *addCommand) getMachineManagerAPI() (MachineManagerAPI, error) {
 }
 
 func (c *addCommand) Run(ctx *cmd.Context) error {
+	var err error
+	c.Constraints, err = common.ParseConstraints(ctx, c.ConstraintsStr)
+	if err != nil {
+		return err
+	}
 	client, err := c.getClientAPI()
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -67,13 +67,6 @@ func (s *AddMachineSuite) TestInit(c *gc.C) {
 			count:     1,
 			placement: "lxd:4",
 		}, {
-			args:        []string{"--constraints", "mem=8G"},
-			count:       1,
-			constraints: "mem=8192M",
-		}, {
-			args:        []string{"--constraints", "container=lxd"},
-			errorString: `container constraint "lxd" not allowed when adding a machine`,
-		}, {
 			args:      []string{"ssh:user@10.10.0.3"},
 			count:     1,
 			placement: "ssh:user@10.10.0.3",

--- a/cmd/juju/model/constraints.go
+++ b/cmd/juju/model/constraints.go
@@ -54,7 +54,7 @@ const setConstraintsDoc = "" +
 const setConstraintsDocExamples = `
 Examples:
 
-    juju set-model-constraints cpu-cores=8 mem=16G
+    juju set-model-constraints cores=8 mem=16G
     juju set-model-constraints -m mymodel root-disk=64G
 
 See also:

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -178,7 +178,7 @@ var (
 			"since":   "01 Apr 15 01:23+10:00",
 		},
 		"series":                   "quantal",
-		"hardware":                 "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+		"hardware":                 "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 		"controller-member-status": "adding-vote",
 	}
 	machine1 = M{
@@ -193,7 +193,7 @@ var (
 			"since":   "01 Apr 15 01:23+10:00",
 		},
 		"series":   "quantal",
-		"hardware": "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+		"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 	}
 	machine2 = M{
 		"juju-status": M{
@@ -207,7 +207,7 @@ var (
 			"since":   "01 Apr 15 01:23+10:00",
 		},
 		"series":   "quantal",
-		"hardware": "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+		"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 	}
 	machine3 = M{
 		"juju-status": M{
@@ -221,7 +221,7 @@ var (
 			"since":   "01 Apr 15 01:23+10:00",
 		},
 		"series":   "quantal",
-		"hardware": "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+		"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 	}
 	machine4 = M{
 		"juju-status": M{
@@ -235,7 +235,7 @@ var (
 			"since":   "01 Apr 15 01:23+10:00",
 		},
 		"series":   "quantal",
-		"hardware": "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+		"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 	}
 	machine1WithContainers = M{
 		"juju-status": M{
@@ -292,7 +292,7 @@ var (
 		},
 
 		"series":   "quantal",
-		"hardware": "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+		"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 	}
 	unexposedService = dummyCharm(M{
 		"application-status": M{
@@ -343,7 +343,7 @@ var statusFormats = []outputFormat{
 	{"json", json.Marshal, json.Unmarshal},
 }
 
-var machineCons = constraints.MustParse("cpu-cores=2 mem=8G root-disk=8G")
+var machineCons = constraints.MustParse("cores=2 mem=8G root-disk=8G")
 
 var statusTests = []testCase{
 	// Status tests
@@ -396,7 +396,7 @@ var statusTests = []testCase{
 							"since":   "01 Apr 15 01:23+10:00",
 						},
 						"series":                   "quantal",
-						"hardware":                 "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+						"hardware":                 "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 						"controller-member-status": "adding-vote",
 					},
 				},
@@ -435,7 +435,7 @@ var statusTests = []testCase{
 							"version": "1.2.3",
 						},
 						"series":                   "quantal",
-						"hardware":                 "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+						"hardware":                 "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 						"controller-member-status": "adding-vote",
 					},
 				},
@@ -469,7 +469,7 @@ var statusTests = []testCase{
 							"since":   "01 Apr 15 01:23+10:00",
 						},
 						"series":                   "quantal",
-						"hardware":                 "arch=amd64 cpu-cores=2 mem=8192M root-disk=8192M",
+						"hardware":                 "arch=amd64 cores=2 mem=8192M root-disk=8192M",
 						"controller-member-status": "adding-vote",
 					},
 				},
@@ -498,7 +498,7 @@ var statusTests = []testCase{
 							"since":   "01 Apr 15 01:23+10:00",
 						},
 						"series":                   "quantal",
-						"hardware":                 "arch=amd64 cpu-cores=2 mem=8192M root-disk=8192M",
+						"hardware":                 "arch=amd64 cores=2 mem=8192M root-disk=8192M",
 						"controller-member-status": "adding-vote",
 					},
 				},
@@ -550,7 +550,7 @@ var statusTests = []testCase{
 							"since":   "01 Apr 15 01:23+10:00",
 						},
 						"series":                   "quantal",
-						"hardware":                 "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+						"hardware":                 "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 						"controller-member-status": "adding-vote",
 					},
 				},
@@ -733,7 +733,7 @@ var statusTests = []testCase{
 							"since":   "01 Apr 15 01:23+10:00",
 						},
 						"series":   "quantal",
-						"hardware": "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+						"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 					},
 					"4": M{
 						"dns-name":    "controller-4.dns",
@@ -748,7 +748,7 @@ var statusTests = []testCase{
 							"since":   "01 Apr 15 01:23+10:00",
 						},
 						"series":   "quantal",
-						"hardware": "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+						"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 					},
 					"5": M{
 						"juju-status": M{
@@ -1274,7 +1274,7 @@ var statusTests = []testCase{
 						},
 
 						"series":   "quantal",
-						"hardware": "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+						"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 					},
 				},
 				"applications": M{
@@ -1983,7 +1983,7 @@ var statusTests = []testCase{
 						},
 
 						"series":   "quantal",
-						"hardware": "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+						"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 					},
 				},
 				"applications": M{
@@ -3842,7 +3842,7 @@ func (s *StatusSuite) TestFilterToContainer(c *gc.C) {
 		"          current: pending\n" +
 		"          since: 01 Apr 15 01:23+10:00\n" +
 		"        series: quantal\n" +
-		"    hardware: arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M\n" +
+		"    hardware: arch=amd64 cores=1 mem=1024M root-disk=8192M\n" +
 		"    controller-member-status: adding-vote\n" +
 		"applications: {}\n"
 

--- a/constraints/constraints_test.go
+++ b/constraints/constraints_test.go
@@ -100,36 +100,42 @@ var parseConstraintsTests = []struct {
 		err:     `bad "arch" constraint: already set`,
 	},
 
-	// "cpu-cores" in detail.
+	// "cores" in detail.
 	{
-		summary: "set cpu-cores empty",
-		args:    []string{"cpu-cores="},
+		summary: "set cores empty",
+		args:    []string{"cores="},
 	}, {
-		summary: "set cpu-cores zero",
-		args:    []string{"cpu-cores=0"},
+		summary: "set cores zero",
+		args:    []string{"cores=0"},
 	}, {
+		summary: "set cores",
+		args:    []string{"cores=4"},
+	}, {
+		summary: "set nonsense cores 1",
+		args:    []string{"cores=cheese"},
+		err:     `bad "cores" constraint: must be a non-negative integer`,
+	}, {
+		summary: "set nonsense cores 2",
+		args:    []string{"cores=-1"},
+		err:     `bad "cores" constraint: must be a non-negative integer`,
+	}, {
+		summary: "set nonsense cores 3",
+		args:    []string{"cores=123.45"},
+		err:     `bad "cores" constraint: must be a non-negative integer`,
+	}, {
+		summary: "double set cores together",
+		args:    []string{"cores=128 cores=1"},
+		err:     `bad "cores" constraint: already set`,
+	}, {
+		summary: "double set cores separately",
+		args:    []string{"cores=128", "cores=1"},
+		err:     `bad "cores" constraint: already set`,
+	},
+
+	// "cpu-cores"
+	{
 		summary: "set cpu-cores",
 		args:    []string{"cpu-cores=4"},
-	}, {
-		summary: "set nonsense cpu-cores 1",
-		args:    []string{"cpu-cores=cheese"},
-		err:     `bad "cpu-cores" constraint: must be a non-negative integer`,
-	}, {
-		summary: "set nonsense cpu-cores 2",
-		args:    []string{"cpu-cores=-1"},
-		err:     `bad "cpu-cores" constraint: must be a non-negative integer`,
-	}, {
-		summary: "set nonsense cpu-cores 3",
-		args:    []string{"cpu-cores=123.45"},
-		err:     `bad "cpu-cores" constraint: must be a non-negative integer`,
-	}, {
-		summary: "double set cpu-cores together",
-		args:    []string{"cpu-cores=128 cpu-cores=1"},
-		err:     `bad "cpu-cores" constraint: already set`,
-	}, {
-		summary: "double set cpu-cores separately",
-		args:    []string{"cpu-cores=128", "cpu-cores=1"},
-		err:     `bad "cpu-cores" constraint: already set`,
 	},
 
 	// "cpu-power" in detail.
@@ -311,13 +317,13 @@ var parseConstraintsTests = []struct {
 	{
 		summary: "kitchen sink together",
 		args: []string{
-			"root-disk=8G mem=2T  arch=i386  cpu-cores=4096 cpu-power=9001 container=lxd " +
+			"root-disk=8G mem=2T  arch=i386  cores=4096 cpu-power=9001 container=lxd " +
 				"tags=foo,bar spaces=space1,^space2 instance-type=foo",
 			"virt-type=kvm"},
 	}, {
 		summary: "kitchen sink separately",
 		args: []string{
-			"root-disk=8G", "mem=2T", "cpu-cores=4096", "cpu-power=9001", "arch=armhf",
+			"root-disk=8G", "mem=2T", "cores=4096", "cpu-power=9001", "arch=armhf",
 			"container=lxd", "tags=foo,bar", "spaces=space1,^space2",
 			"instance-type=foo", "virt-type=kvm"},
 	},
@@ -342,22 +348,34 @@ func (s *ConstraintsSuite) TestParseConstraints(c *gc.C) {
 	}
 }
 
+func (s *ConstraintsSuite) TestParseAliases(c *gc.C) {
+	v, aliases, err := constraints.ParseWithAliases("cpu-cores=5 arch=amd64")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(v, gc.DeepEquals, constraints.Value{
+		CpuCores: uint64p(5),
+		Arch:     strp("amd64"),
+	})
+	c.Assert(aliases, gc.DeepEquals, map[string]string{
+		"cpu-cores": "cores",
+	})
+}
+
 func (s *ConstraintsSuite) TestMerge(c *gc.C) {
 	con1 := constraints.MustParse("arch=amd64 mem=4G")
-	con2 := constraints.MustParse("cpu-cores=42")
+	con2 := constraints.MustParse("cores=42")
 	con3 := constraints.MustParse(
 		"root-disk=8G container=lxd spaces=space1,^space2",
 	)
 	merged, err := constraints.Merge(con1, con2)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(merged, jc.DeepEquals, constraints.MustParse("arch=amd64 mem=4G cpu-cores=42"))
+	c.Assert(merged, jc.DeepEquals, constraints.MustParse("arch=amd64 mem=4G cores=42"))
 	merged, err = constraints.Merge(con1)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(merged, jc.DeepEquals, con1)
 	merged, err = constraints.Merge(con1, con2, con3)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(merged, jc.DeepEquals, constraints.
-		MustParse("arch=amd64 mem=4G cpu-cores=42 root-disk=8G container=lxd spaces=space1,^space2"),
+		MustParse("arch=amd64 mem=4G cores=42 root-disk=8G container=lxd spaces=space1,^space2"),
 	)
 	merged, err = constraints.Merge()
 	c.Assert(err, jc.ErrorIsNil)
@@ -374,14 +392,14 @@ func (s *ConstraintsSuite) TestMerge(c *gc.C) {
 }
 
 func (s *ConstraintsSuite) TestParseMissingTagsAndSpaces(c *gc.C) {
-	con := constraints.MustParse("arch=amd64 mem=4G cpu-cores=1 root-disk=8G")
+	con := constraints.MustParse("arch=amd64 mem=4G cores=1 root-disk=8G")
 	c.Check(con.Tags, gc.IsNil)
 	c.Check(con.Spaces, gc.IsNil)
 }
 
 func (s *ConstraintsSuite) TestParseNoTagsNoSpaces(c *gc.C) {
 	con := constraints.MustParse(
-		"arch=amd64 mem=4G cpu-cores=1 root-disk=8G tags= spaces=",
+		"arch=amd64 mem=4G cores=1 root-disk=8G tags= spaces=",
 	)
 	c.Assert(con.Tags, gc.Not(gc.IsNil))
 	c.Assert(con.Spaces, gc.Not(gc.IsNil))
@@ -439,7 +457,7 @@ func (s *ConstraintsSuite) TestIsEmpty(c *gc.C) {
 	c.Check(&con, gc.Not(jc.Satisfies), constraints.IsEmpty)
 	con = constraints.MustParse("cpu-power=")
 	c.Check(&con, gc.Not(jc.Satisfies), constraints.IsEmpty)
-	con = constraints.MustParse("cpu-cores=")
+	con = constraints.MustParse("cores=")
 	c.Check(&con, gc.Not(jc.Satisfies), constraints.IsEmpty)
 	con = constraints.MustParse("container=")
 	c.Check(&con, gc.Not(jc.Satisfies), constraints.IsEmpty)
@@ -579,7 +597,7 @@ func (s *ConstraintsSuite) TestHasInstanceType(c *gc.C) {
 	c.Check(cons.HasInstanceType(), jc.IsTrue)
 }
 
-const initialWithoutCons = "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 spaces=space1,^space2 tags=foo container=lxd instance-type=bar"
+const initialWithoutCons = "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cores=4 spaces=space1,^space2 tags=foo container=lxd instance-type=bar"
 
 var withoutTests = []struct {
 	initial string
@@ -588,113 +606,51 @@ var withoutTests = []struct {
 }{{
 	initial: initialWithoutCons,
 	without: []string{"root-disk"},
-	final:   "mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo spaces=space1,^space2 container=lxd instance-type=bar",
+	final:   "mem=4G arch=amd64 cpu-power=1000 cores=4 tags=foo spaces=space1,^space2 container=lxd instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"mem"},
-	final:   "root-disk=8G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo spaces=space1,^space2 container=lxd instance-type=bar",
+	final:   "root-disk=8G arch=amd64 cpu-power=1000 cores=4 tags=foo spaces=space1,^space2 container=lxd instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"arch"},
-	final:   "root-disk=8G mem=4G cpu-power=1000 cpu-cores=4 tags=foo spaces=space1,^space2 container=lxd instance-type=bar",
+	final:   "root-disk=8G mem=4G cpu-power=1000 cores=4 tags=foo spaces=space1,^space2 container=lxd instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"cpu-power"},
-	final:   "root-disk=8G mem=4G arch=amd64 cpu-cores=4 tags=foo spaces=space1,^space2 container=lxd instance-type=bar",
+	final:   "root-disk=8G mem=4G arch=amd64 cores=4 tags=foo spaces=space1,^space2 container=lxd instance-type=bar",
 }, {
 	initial: initialWithoutCons,
-	without: []string{"cpu-cores"},
+	without: []string{"cores"},
 	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 tags=foo spaces=space1,^space2 container=lxd instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"tags"},
-	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 spaces=space1,^space2 container=lxd instance-type=bar",
+	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cores=4 spaces=space1,^space2 container=lxd instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"spaces"},
-	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo container=lxd instance-type=bar",
+	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cores=4 tags=foo container=lxd instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"container"},
-	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo spaces=space1,^space2 instance-type=bar",
+	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cores=4 tags=foo spaces=space1,^space2 instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"instance-type"},
-	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo spaces=space1,^space2 container=lxd",
+	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cores=4 tags=foo spaces=space1,^space2 container=lxd",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"root-disk", "mem", "arch"},
-	final:   "cpu-power=1000 cpu-cores=4 tags=foo spaces=space1,^space2 container=lxd instance-type=bar",
+	final:   "cpu-power=1000 cores=4 tags=foo spaces=space1,^space2 container=lxd instance-type=bar",
 }}
 
 func (s *ConstraintsSuite) TestWithout(c *gc.C) {
 	for i, t := range withoutTests {
 		c.Logf("test %d", i)
 		initial := constraints.MustParse(t.initial)
-		final, err := constraints.Without(initial, t.without...)
-		c.Assert(err, jc.ErrorIsNil)
+		final := constraints.Without(initial, t.without...)
 		c.Check(final, jc.DeepEquals, constraints.MustParse(t.final))
-	}
-}
-
-func (s *ConstraintsSuite) TestWithoutError(c *gc.C) {
-	cons := constraints.MustParse("mem=4G")
-	_, err := constraints.Without(cons, "foo")
-	c.Assert(err, gc.ErrorMatches, `unknown constraint "foo"`)
-}
-
-func (s *ConstraintsSuite) TestAttributesWithValues(c *gc.C) {
-	for i, consStr := range []string{
-		"",
-		"root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 instance-type=foo tags=foo,bar spaces=space1,^space2",
-	} {
-		c.Logf("test %d", i)
-		cons := constraints.MustParse(consStr)
-		obtained := constraints.AttributesWithValues(cons)
-		assertMissing := func(attrName string) {
-			_, ok := obtained[attrName]
-			c.Check(ok, jc.IsFalse)
-		}
-		if cons.Arch != nil {
-			c.Check(obtained["arch"], gc.Equals, *cons.Arch)
-		} else {
-			assertMissing("arch")
-		}
-		if cons.Mem != nil {
-			c.Check(obtained["mem"], gc.Equals, *cons.Mem)
-		} else {
-			assertMissing("mem")
-		}
-		if cons.CpuCores != nil {
-			c.Check(obtained["cpu-cores"], gc.Equals, *cons.CpuCores)
-		} else {
-			assertMissing("cpu-cores")
-		}
-		if cons.CpuPower != nil {
-			c.Check(obtained["cpu-power"], gc.Equals, *cons.CpuPower)
-		} else {
-			assertMissing("cpu-power")
-		}
-		if cons.RootDisk != nil {
-			c.Check(obtained["root-disk"], gc.Equals, *cons.RootDisk)
-		} else {
-			assertMissing("root-disk")
-		}
-		if cons.Tags != nil {
-			c.Check(obtained["tags"], gc.DeepEquals, *cons.Tags)
-		} else {
-			assertMissing("tags")
-		}
-		if cons.Spaces != nil {
-			c.Check(obtained["spaces"], gc.DeepEquals, *cons.Spaces)
-		} else {
-			assertMissing("spaces")
-		}
-		if cons.InstanceType != nil {
-			c.Check(obtained["instance-type"], gc.Equals, *cons.InstanceType)
-		} else {
-			assertMissing("instance-type")
-		}
 	}
 }
 
@@ -704,17 +660,17 @@ var hasAnyTests = []struct {
 	expected []string
 }{
 	{
-		cons:     "root-disk=8G mem=4G arch=amd64 cpu-power=1000 spaces=space1,^space2 cpu-cores=4",
+		cons:     "root-disk=8G mem=4G arch=amd64 cpu-power=1000 spaces=space1,^space2 cores=4",
 		attrs:    []string{"root-disk", "tags", "mem", "spaces"},
 		expected: []string{"root-disk", "mem", "spaces"},
 	},
 	{
-		cons:     "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4",
+		cons:     "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cores=4",
 		attrs:    []string{"root-disk", "tags", "mem"},
 		expected: []string{"root-disk", "mem"},
 	},
 	{
-		cons:     "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4",
+		cons:     "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cores=4",
 		attrs:    []string{"tags", "spaces"},
 		expected: []string{},
 	},

--- a/constraints/export_test.go
+++ b/constraints/export_test.go
@@ -5,7 +5,7 @@ package constraints
 
 var WithFallbacks = withFallbacks
 
-func Without(cons Value, attrTags ...string) (Value, error) {
+func Without(cons Value, attrTags ...string) Value {
 	return cons.without(attrTags...)
 }
 

--- a/constraints/validation.go
+++ b/constraints/validation.go
@@ -5,7 +5,6 @@ package constraints
 
 import (
 	"fmt"
-	"math"
 	"reflect"
 
 	"github.com/juju/utils/set"
@@ -80,7 +79,7 @@ func (v *validator) RegisterUnsupported(unsupported []string) {
 
 // RegisterVocabulary is defined on Validator.
 func (v *validator) RegisterVocabulary(attributeName string, allowedValues interface{}) {
-	v.vocab[attributeName] = convertToSlice(allowedValues)
+	v.vocab[resolveAlias(attributeName)] = convertToSlice(allowedValues)
 }
 
 var checkIsCollection = func(coll interface{}) {
@@ -102,6 +101,7 @@ var convertToSlice = func(coll interface{}) []interface{} {
 
 // UpdateVocabulary is defined on Validator.
 func (v *validator) UpdateVocabulary(attributeName string, allowedValues interface{}) {
+	attributeName = resolveAlias(attributeName)
 	// If this attribute is not registered, delegate to RegisterVocabulary()
 	currentValues, ok := v.vocab[attributeName]
 	if !ok {
@@ -124,6 +124,7 @@ func (v *validator) UpdateVocabulary(attributeName string, allowedValues interfa
 }
 
 func (v *validator) updateVocabularyFromMap(attributeName string, valuesMap map[interface{}]bool) {
+	attributeName = resolveAlias(attributeName)
 	var merged []interface{}
 	for one, _ := range valuesMap {
 		// TODO (anastasiamac) Because it's coming from the map, the order maybe affected
@@ -186,7 +187,7 @@ func (v *validator) checkValidValues(cons Value) error {
 // checkInVocab returns an error if the attribute value is not allowed by the
 // vocab which may have been registered for it.
 func (v *validator) checkInVocab(attributeName string, attributeValue interface{}) error {
-	validValues, ok := v.vocab[attributeName]
+	validValues, ok := v.vocab[resolveAlias(attributeName)]
 	if !ok {
 		return nil
 	}
@@ -199,40 +200,54 @@ func (v *validator) checkInVocab(attributeName string, attributeValue interface{
 		"invalid constraint value: %v=%v\nvalid values are: %v", attributeName, attributeValue, validValues)
 }
 
-// coerce returns v in a format that allows constraint values to be easily compared.
-// Its main purpose is to cast all numeric values to int64 or float64.
+// coerce returns v in a format that allows constraint values to be easily
+// compared. Its main purpose is to cast all numeric values to float64 (since
+// the numbers we compare are generated from json serialization).
 func coerce(v interface{}) interface{} {
-	if v != nil {
-		switch vv := reflect.TypeOf(v); vv.Kind() {
-		case reflect.String:
-			return v
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			return int64(reflect.ValueOf(v).Int())
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			uval := reflect.ValueOf(v).Uint()
-			// Just double check the value is in range.
-			if uval > math.MaxInt64 {
-				panic(fmt.Errorf("constraint value %v is too large", uval))
-			}
-			return int64(uval)
-		case reflect.Float32, reflect.Float64:
-			return float64(reflect.ValueOf(v).Float())
-		}
+	switch val := v.(type) {
+	case string:
+		return v
+	// Yes, these are all the same, however we can't put them into a single
+	// case, or the value becomes interface{}, which can't be converted to a
+	// float64.
+	case int:
+		return float64(val)
+	case int8:
+		return float64(val)
+	case int16:
+		return float64(val)
+	case int32:
+		return float64(val)
+	case int64:
+		return float64(val)
+	case uint:
+		return float64(val)
+	case uint8:
+		return float64(val)
+	case uint16:
+		return float64(val)
+	case uint32:
+		return float64(val)
+	case uint64:
+		return float64(val)
+	case float32:
+		return float64(val)
+	case float64:
+		return val
 	}
 	return v
 }
 
 // withFallbacks returns a copy of v with nil values taken from vFallback.
 func withFallbacks(v Value, vFallback Value) Value {
-	result := vFallback
-	for _, fieldName := range fieldNames {
-		resultVal := reflect.ValueOf(&result).Elem().FieldByName(fieldName)
-		val := reflect.ValueOf(&v).Elem().FieldByName(fieldName)
-		if !val.IsNil() {
-			resultVal.Set(val)
+	vAttr := v.attributesWithValues()
+	fbAttr := vFallback.attributesWithValues()
+	for k, v := range fbAttr {
+		if _, ok := vAttr[k]; !ok {
+			vAttr[k] = v
 		}
 	}
-	return result
+	return fromAttributes(vAttr)
 }
 
 // Validate is defined on Validator.
@@ -266,7 +281,7 @@ func (v *validator) Merge(consFallback, cons Value) (Value, error) {
 	// Null out the conflicting consFallback attribute values because
 	// cons takes priority. We can't error here because we
 	// know that aConflicts contains valid attr names.
-	consFallbackMinusConflicts, _ := consFallback.without(fallbackConflicts...)
+	consFallbackMinusConflicts := consFallback.without(fallbackConflicts...)
 	// The result is cons with fallbacks coming from any
 	// non conflicting consFallback attributes.
 	return withFallbacks(cons, consFallbackMinusConflicts), nil

--- a/container/kvm/kvm.go
+++ b/container/kvm/kvm.go
@@ -30,7 +30,7 @@ var (
 
 	// In order for Juju to be able to create the hardware characteristics of
 	// the kvm machines it creates, we need to be explicit in our definition
-	// of memory, cpu-cores and root-disk.  The defaults here have been
+	// of memory, cores and root-disk.  The defaults here have been
 	// extracted from the uvt-kvm executable.
 	DefaultMemory uint64 = 512 // MB
 	DefaultCpu    uint64 = 1
@@ -164,7 +164,7 @@ func (manager *containerManager) CreateContainer(
 
 	var hardware instance.HardwareCharacteristics
 	hardware, err = instance.ParseHardware(
-		fmt.Sprintf("arch=%s mem=%vM root-disk=%vG cpu-cores=%v",
+		fmt.Sprintf("arch=%s mem=%vM root-disk=%vG cores=%v",
 			startParams.Arch, startParams.Memory, startParams.RootDisk, startParams.CpuCores))
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "failed to parse hardware")

--- a/container/kvm/kvm_test.go
+++ b/container/kvm/kvm_test.go
@@ -266,14 +266,14 @@ func (s *ConstraintsSuite) TestDefaults(c *gc.C) {
 			RootDisk: kvm.DefaultDisk,
 		},
 	}, {
-		cons: "cpu-cores=4",
+		cons: "cores=4",
 		expected: kvm.StartParams{
 			Memory:   kvm.DefaultMemory,
 			CpuCores: 4,
 			RootDisk: kvm.DefaultDisk,
 		},
 	}, {
-		cons: "cpu-cores=0",
+		cons: "cores=0",
 		expected: kvm.StartParams{
 			Memory:   kvm.DefaultMemory,
 			CpuCores: kvm.MinCpu,
@@ -334,7 +334,7 @@ func (s *ConstraintsSuite) TestDefaults(c *gc.C) {
 			`tags constraint of "foo,bar" being ignored as not supported`,
 		},
 	}, {
-		cons: "mem=4G cpu-cores=4 root-disk=20G arch=armhf cpu-power=100 container=lxd tags=foo,bar",
+		cons: "mem=4G cores=4 root-disk=20G arch=armhf cpu-power=100 container=lxd tags=foo,bar",
 		expected: kvm.StartParams{
 			Memory:   4 * 1024,
 			CpuCores: 4,

--- a/container/kvm/live_test.go
+++ b/container/kvm/live_test.go
@@ -106,7 +106,7 @@ func createContainer(c *gc.C, manager container.Manager, machineId string) insta
 	inst, hardware, err := manager.CreateContainer(instanceConfig, constraints.Value{}, "precise", network, nil, callback)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hardware, gc.NotNil)
-	expected := fmt.Sprintf("arch=%s cpu-cores=1 mem=512M root-disk=8192M", arch.HostArch())
+	expected := fmt.Sprintf("arch=%s cores=1 mem=512M root-disk=8192M", arch.HostArch())
 	c.Assert(hardware.String(), gc.Equals, expected)
 	return inst
 }

--- a/core/description/machine.go
+++ b/core/description/machine.go
@@ -589,7 +589,7 @@ type cloudInstance struct {
 	Architecture_     string   `yaml:"architecture,omitempty"`
 	Memory_           uint64   `yaml:"memory,omitempty"`
 	RootDisk_         uint64   `yaml:"root-disk,omitempty"`
-	CpuCores_         uint64   `yaml:"cpu-cores,omitempty"`
+	CpuCores_         uint64   `yaml:"cores,omitempty"`
 	CpuPower_         uint64   `yaml:"cpu-power,omitempty"`
 	Tags_             []string `yaml:"tags,omitempty"`
 	AvailabilityZone_ string   `yaml:"availability-zone,omitempty"`
@@ -669,7 +669,7 @@ func importCloudInstanceV1(source map[string]interface{}) (*cloudInstance, error
 		"architecture":      schema.String(),
 		"memory":            schema.ForceUint(),
 		"root-disk":         schema.ForceUint(),
-		"cpu-cores":         schema.ForceUint(),
+		"cores":         schema.ForceUint(),
 		"cpu-power":         schema.ForceUint(),
 		"tags":              schema.List(schema.String()),
 		"availability-zone": schema.String(),
@@ -679,7 +679,7 @@ func importCloudInstanceV1(source map[string]interface{}) (*cloudInstance, error
 		"architecture":      "",
 		"memory":            uint64(0),
 		"root-disk":         uint64(0),
-		"cpu-cores":         uint64(0),
+		"cores":         uint64(0),
 		"cpu-power":         uint64(0),
 		"tags":              schema.Omit,
 		"availability-zone": "",
@@ -701,7 +701,7 @@ func importCloudInstanceV1(source map[string]interface{}) (*cloudInstance, error
 		Architecture_:     valid["architecture"].(string),
 		Memory_:           valid["memory"].(uint64),
 		RootDisk_:         valid["root-disk"].(uint64),
-		CpuCores_:         valid["cpu-cores"].(uint64),
+		CpuCores_:         valid["cores"].(uint64),
 		CpuPower_:         valid["cpu-power"].(uint64),
 		Tags_:             convertToStringSlice(valid["tags"]),
 		AvailabilityZone_: valid["availability-zone"].(string),

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -136,8 +136,8 @@ func (s *bootstrapSuite) TestBootstrapEmptyConstraints(c *gc.C) {
 func (s *bootstrapSuite) TestBootstrapSpecifiedConstraints(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
-	bootstrapCons := constraints.MustParse("cpu-cores=3 mem=7G")
-	modelCons := constraints.MustParse("cpu-cores=2 mem=4G")
+	bootstrapCons := constraints.MustParse("cores=3 mem=7G")
+	modelCons := constraints.MustParse("cores=2 mem=4G")
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
 		ControllerConfig:     coretesting.FakeControllerConfig(),
 		AdminSecret:          "admin-secret",

--- a/environs/instances/instancetype.go
+++ b/environs/instances/instancetype.go
@@ -103,7 +103,7 @@ func MatchingInstanceTypes(allInstanceTypes []InstanceType, region string, cons 
 	var itypes []InstanceType
 
 	// Rules used to select instance types:
-	// - non memory constraints like cpu-cores etc are always honoured
+	// - non memory constraints like cores etc are always honoured
 	// - if no mem constraint specified and instance-type not specified,
 	//   try opinionated default with enough mem to run a server.
 	// - if no matches and no mem constraint specified, try again and

--- a/environs/instances/instancetype_test.go
+++ b/environs/instances/instancetype_test.go
@@ -124,8 +124,8 @@ var getInstanceTypesTest = []struct {
 	arches         []string
 }{
 	{
-		about: "cpu-cores",
-		cons:  "cpu-cores=2",
+		about: "cores",
+		cons:  "cores=2",
 		expectedItypes: []string{
 			"c1.medium", "m1.large", "m1.xlarge", "c1.xlarge", "cc1.4xlarge",
 			"cc2.8xlarge",
@@ -154,7 +154,7 @@ var getInstanceTypesTest = []struct {
 	},
 	{
 		about: "enough memory for mongodb if mem not specified",
-		cons:  "cpu-cores=4",
+		cons:  "cores=4",
 		itypesToUse: []InstanceType{
 			{Id: "5", Name: "it-5", Arches: []string{"amd64"}, Mem: 1024, CpuCores: 2},
 			{Id: "4", Name: "it-4", Arches: []string{"amd64"}, Mem: 2048, CpuCores: 4},
@@ -198,7 +198,7 @@ var getInstanceTypesTest = []struct {
 	},
 	{
 		about: "largest mem available matching other constraints if mem not specified",
-		cons:  "cpu-cores=4",
+		cons:  "cores=4",
 		itypesToUse: []InstanceType{
 			{Id: "3", Name: "it-3", Arches: []string{"amd64"}, Mem: 1024, CpuCores: 2},
 			{Id: "2", Name: "it-2", Arches: []string{"amd64"}, Mem: 256, CpuCores: 4},
@@ -208,7 +208,7 @@ var getInstanceTypesTest = []struct {
 	},
 	{
 		about: "largest mem available matching other constraints if mem not specified, cost is tie breaker",
-		cons:  "cpu-cores=4",
+		cons:  "cores=4",
 		itypesToUse: []InstanceType{
 			{Id: "4", Name: "it-4", Arches: []string{"amd64"}, Mem: 1024, CpuCores: 2},
 			{Id: "3", Name: "it-3", Arches: []string{"amd64"}, Mem: 256, CpuCores: 4},
@@ -261,8 +261,8 @@ func (s *instanceTypeSuite) TestGetMatchingInstanceTypesErrors(c *gc.C) {
 	_, err = MatchingInstanceTypes(instanceTypes, "test", constraints.MustParse("arch=i386 mem=8G"))
 	c.Check(err, gc.ErrorMatches, `no instance types in test matching constraints "arch=i386 mem=8192M"`)
 
-	_, err = MatchingInstanceTypes(instanceTypes, "test", constraints.MustParse("cpu-cores=9000"))
-	c.Check(err, gc.ErrorMatches, `no instance types in test matching constraints "cpu-cores=9000"`)
+	_, err = MatchingInstanceTypes(instanceTypes, "test", constraints.MustParse("cores=9000"))
+	c.Check(err, gc.ErrorMatches, `no instance types in test matching constraints "cores=9000"`)
 
 	_, err = MatchingInstanceTypes(instanceTypes, "test", constraints.MustParse("mem=90000M"))
 	c.Check(err, gc.ErrorMatches, `no instance types in test matching constraints "mem=90000M"`)
@@ -280,7 +280,7 @@ var instanceTypeMatchTests = []struct {
 	{"", "m1.large", []string{"amd64"}},
 	{"cpu-power=100", "m1.small", []string{"amd64", "armhf"}},
 	{"arch=amd64", "m1.small", []string{"amd64"}},
-	{"cpu-cores=3", "m1.xlarge", []string{"amd64"}},
+	{"cores=3", "m1.xlarge", []string{"amd64"}},
 	{"cpu-power=", "t1.micro", []string{"amd64", "armhf"}},
 	{"cpu-power=500", "c1.medium", []string{"amd64", "armhf"}},
 	{"cpu-power=2000", "c1.xlarge", []string{"amd64"}},

--- a/environs/manual/init_test.go
+++ b/environs/manual/init_test.go
@@ -49,7 +49,7 @@ func (s *initialisationSuite) TestDetectionError(c *gc.C) {
 	defer installFakeSSH(c, manual.DetectionScript, []string{scriptResponse, "non-empty-stderr"}, 0)()
 	hc, _, err = manual.DetectSeriesAndHardwareCharacteristics("hostname")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(hc.String(), gc.Equals, "arch=armhf cpu-cores=1 mem=4M")
+	c.Assert(hc.String(), gc.Equals, "arch=armhf cores=1 mem=4M")
 }
 
 func (s *initialisationSuite) TestDetectHardwareCharacteristics(c *gc.C) {
@@ -60,7 +60,7 @@ func (s *initialisationSuite) TestDetectHardwareCharacteristics(c *gc.C) {
 	}{{
 		"Single CPU socket, single core, no hyper-threading",
 		[]string{"edgy", "armv4", "MemTotal: 4096 kB", "processor: 0"},
-		"arch=armhf cpu-cores=1 mem=4M",
+		"arch=armhf cores=1 mem=4M",
 	}, {
 		"Single CPU socket, single core, hyper-threading",
 		[]string{
@@ -72,7 +72,7 @@ func (s *initialisationSuite) TestDetectHardwareCharacteristics(c *gc.C) {
 			"physical id: 0",
 			"cpu cores: 1",
 		},
-		"arch=armhf cpu-cores=1 mem=4M",
+		"arch=armhf cores=1 mem=4M",
 	}, {
 		"Single CPU socket, dual-core, no hyper-threading",
 		[]string{
@@ -84,7 +84,7 @@ func (s *initialisationSuite) TestDetectHardwareCharacteristics(c *gc.C) {
 			"physical id: 0",
 			"cpu cores: 2",
 		},
-		"arch=armhf cpu-cores=2 mem=4M",
+		"arch=armhf cores=2 mem=4M",
 	}, {
 		"Dual CPU socket, each single-core, hyper-threading",
 		[]string{
@@ -102,7 +102,7 @@ func (s *initialisationSuite) TestDetectHardwareCharacteristics(c *gc.C) {
 			"physical id: 1",
 			"cpu cores: 1",
 		},
-		"arch=armhf cpu-cores=2 mem=4M",
+		"arch=armhf cores=2 mem=4M",
 	}}
 	for i, test := range tests {
 		c.Logf("test %d: %s", i, test.summary)

--- a/featuretests/cmdjuju_test.go
+++ b/featuretests/cmdjuju_test.go
@@ -47,7 +47,7 @@ func (s *cmdJujuSuite) TestGetConstraints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	context, err := testing.RunCommand(c, application.NewServiceGetConstraintsCommand(), "svc")
-	c.Assert(testing.Stdout(context), gc.Equals, "cpu-cores=64\n")
+	c.Assert(testing.Stdout(context), gc.Equals, "cores=64\n")
 	c.Assert(testing.Stderr(context), gc.Equals, "")
 }
 

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -57,13 +57,25 @@ type Instance interface {
 // HardwareCharacteristics represents the characteristics of the instance (if known).
 // Attributes that are nil are unknown or not supported.
 type HardwareCharacteristics struct {
-	Arch     *string   `json:"arch,omitempty" yaml:"arch,omitempty"`
-	Mem      *uint64   `json:"mem,omitempty" yaml:"mem,omitempty"`
-	RootDisk *uint64   `json:"root-disk,omitempty" yaml:"rootdisk,omitempty"`
-	CpuCores *uint64   `json:"cpu-cores,omitempty" yaml:"cpucores,omitempty"`
-	CpuPower *uint64   `json:"cpu-power,omitempty" yaml:"cpupower,omitempty"`
-	Tags     *[]string `json:"tags,omitempty" yaml:"tags,omitempty"`
+	// Arch is the architecture of the processor.
+	Arch *string `json:"arch,omitempty" yaml:"arch,omitempty"`
 
+	// Mem is the size of RAM in megabytes.
+	Mem *uint64 `json:"mem,omitempty" yaml:"mem,omitempty"`
+
+	// RootDisk is the size of the disk in megabytes.
+	RootDisk *uint64 `json:"root-disk,omitempty" yaml:"rootdisk,omitempty"`
+
+	// CpuCores is the number of logical cores the processor has.
+	CpuCores *uint64 `json:"cpu-cores,omitempty" yaml:"cpucores,omitempty"`
+
+	// CpuPower is a relative representation of the speed of the processor.
+	CpuPower *uint64 `json:"cpu-power,omitempty" yaml:"cpupower,omitempty"`
+
+	// Tags is a list of strings that identify the machine.
+	Tags *[]string `json:"tags,omitempty" yaml:"tags,omitempty"`
+
+	// AvailabilityZone defines the zone in which the machine resides.
 	AvailabilityZone *string `json:"availability-zone,omitempty" yaml:"availabilityzone,omitempty"`
 }
 
@@ -73,7 +85,7 @@ func (hc HardwareCharacteristics) String() string {
 		strs = append(strs, fmt.Sprintf("arch=%s", *hc.Arch))
 	}
 	if hc.CpuCores != nil {
-		strs = append(strs, fmt.Sprintf("cpu-cores=%d", *hc.CpuCores))
+		strs = append(strs, fmt.Sprintf("cores=%d", *hc.CpuCores))
 	}
 	if hc.CpuPower != nil {
 		strs = append(strs, fmt.Sprintf("cpu-power=%d", *hc.CpuPower))
@@ -91,16 +103,6 @@ func (hc HardwareCharacteristics) String() string {
 		strs = append(strs, fmt.Sprintf("availability-zone=%s", *hc.AvailabilityZone))
 	}
 	return strings.Join(strs, " ")
-}
-
-// Implement gnuflag.Value
-func (hc *HardwareCharacteristics) Set(s string) error {
-	parsed, err := ParseHardware(s)
-	if err != nil {
-		return err
-	}
-	*hc = parsed
-	return nil
 }
 
 // MustParseHardware constructs a HardwareCharacteristics from the supplied arguments,
@@ -143,7 +145,7 @@ func (hc *HardwareCharacteristics) setRaw(raw string) error {
 	switch name {
 	case "arch":
 		err = hc.setArch(str)
-	case "cpu-cores":
+	case "cores":
 		err = hc.setCpuCores(str)
 	case "cpu-power":
 		err = hc.setCpuPower(str)

--- a/instance/instance_test.go
+++ b/instance/instance_test.go
@@ -96,36 +96,36 @@ var parseHardwareTests = []parseHardwareTestSpec{
 		err:     `bad "arch" characteristic: already set`,
 	},
 
-	// "cpu-cores" in detail.
+	// "cores" in detail.
 	{
-		summary: "set cpu-cores empty",
-		args:    []string{"cpu-cores="},
+		summary: "set cores empty",
+		args:    []string{"cores="},
 	}, {
-		summary: "set cpu-cores zero",
-		args:    []string{"cpu-cores=0"},
+		summary: "set cores zero",
+		args:    []string{"cores=0"},
 	}, {
-		summary: "set cpu-cores",
-		args:    []string{"cpu-cores=4"},
+		summary: "set cores",
+		args:    []string{"cores=4"},
 	}, {
-		summary: "set nonsense cpu-cores 1",
-		args:    []string{"cpu-cores=cheese"},
-		err:     `bad "cpu-cores" characteristic: must be a non-negative integer`,
+		summary: "set nonsense cores 1",
+		args:    []string{"cores=cheese"},
+		err:     `bad "cores" characteristic: must be a non-negative integer`,
 	}, {
-		summary: "set nonsense cpu-cores 2",
-		args:    []string{"cpu-cores=-1"},
-		err:     `bad "cpu-cores" characteristic: must be a non-negative integer`,
+		summary: "set nonsense cores 2",
+		args:    []string{"cores=-1"},
+		err:     `bad "cores" characteristic: must be a non-negative integer`,
 	}, {
-		summary: "set nonsense cpu-cores 3",
-		args:    []string{"cpu-cores=123.45"},
-		err:     `bad "cpu-cores" characteristic: must be a non-negative integer`,
+		summary: "set nonsense cores 3",
+		args:    []string{"cores=123.45"},
+		err:     `bad "cores" characteristic: must be a non-negative integer`,
 	}, {
-		summary: "double set cpu-cores together",
-		args:    []string{"cpu-cores=128 cpu-cores=1"},
-		err:     `bad "cpu-cores" characteristic: already set`,
+		summary: "double set cores together",
+		args:    []string{"cores=128 cores=1"},
+		err:     `bad "cores" characteristic: already set`,
 	}, {
-		summary: "double set cpu-cores separately",
-		args:    []string{"cpu-cores=128", "cpu-cores=1"},
-		err:     `bad "cpu-cores" characteristic: already set`,
+		summary: "double set cores separately",
+		args:    []string{"cores=128", "cores=1"},
+		err:     `bad "cores" characteristic: already set`,
 	},
 
 	// "cpu-power" in detail.
@@ -264,10 +264,10 @@ var parseHardwareTests = []parseHardwareTestSpec{
 	// Everything at once.
 	{
 		summary: "kitchen sink together",
-		args:    []string{" root-disk=4G mem=2T  arch=i386  cpu-cores=4096 cpu-power=9001 availability-zone=a_zone"},
+		args:    []string{" root-disk=4G mem=2T  arch=i386  cores=4096 cpu-power=9001 availability-zone=a_zone"},
 	}, {
 		summary: "kitchen sink separately",
-		args:    []string{"root-disk=4G", "mem=2T", "cpu-cores=4096", "cpu-power=9001", "arch=armhf", "availability-zone=a_zone"},
+		args:    []string{"root-disk=4G", "mem=2T", "cores=4096", "cpu-power=9001", "arch=armhf", "availability-zone=a_zone"},
 	},
 }
 

--- a/juju/deploy_test.go
+++ b/juju/deploy_test.go
@@ -251,7 +251,7 @@ func (s *DeployLocalSuite) TestDeploySettingsError(c *gc.C) {
 func (s *DeployLocalSuite) TestDeployConstraints(c *gc.C) {
 	err := s.State.SetModelConstraints(constraints.MustParse("mem=2G"))
 	c.Assert(err, jc.ErrorIsNil)
-	serviceCons := constraints.MustParse("cpu-cores=2")
+	serviceCons := constraints.MustParse("cores=2")
 	service, err := juju.DeployApplication(s.State,
 		juju.DeployApplicationParams{
 			ApplicationName: "bob",
@@ -265,7 +265,7 @@ func (s *DeployLocalSuite) TestDeployConstraints(c *gc.C) {
 func (s *DeployLocalSuite) TestDeployNumUnits(c *gc.C) {
 	f := &fakeDeployer{State: s.State}
 
-	serviceCons := constraints.MustParse("cpu-cores=2")
+	serviceCons := constraints.MustParse("cores=2")
 	_, err := juju.DeployApplication(f,
 		juju.DeployApplicationParams{
 			ApplicationName: "bob",
@@ -284,7 +284,7 @@ func (s *DeployLocalSuite) TestDeployNumUnits(c *gc.C) {
 func (s *DeployLocalSuite) TestDeployForceMachineId(c *gc.C) {
 	f := &fakeDeployer{State: s.State}
 
-	serviceCons := constraints.MustParse("cpu-cores=2")
+	serviceCons := constraints.MustParse("cores=2")
 	_, err := juju.DeployApplication(f,
 		juju.DeployApplicationParams{
 			ApplicationName: "bob",
@@ -306,7 +306,7 @@ func (s *DeployLocalSuite) TestDeployForceMachineId(c *gc.C) {
 func (s *DeployLocalSuite) TestDeployForceMachineIdWithContainer(c *gc.C) {
 	f := &fakeDeployer{State: s.State}
 
-	serviceCons := constraints.MustParse("cpu-cores=2")
+	serviceCons := constraints.MustParse("cores=2")
 	_, err := juju.DeployApplication(f,
 		juju.DeployApplicationParams{
 			ApplicationName: "bob",
@@ -327,7 +327,7 @@ func (s *DeployLocalSuite) TestDeployForceMachineIdWithContainer(c *gc.C) {
 func (s *DeployLocalSuite) TestDeploy(c *gc.C) {
 	f := &fakeDeployer{State: s.State}
 
-	serviceCons := constraints.MustParse("cpu-cores=2")
+	serviceCons := constraints.MustParse("cores=2")
 	placement := []*instance.Placement{
 		{Scope: s.State.ModelUUID(), Directive: "valid"},
 		{Scope: "#", Directive: "0"},
@@ -353,7 +353,7 @@ func (s *DeployLocalSuite) TestDeploy(c *gc.C) {
 
 func (s *DeployLocalSuite) TestDeployWithFewerPlacement(c *gc.C) {
 	f := &fakeDeployer{State: s.State}
-	serviceCons := constraints.MustParse("cpu-cores=2")
+	serviceCons := constraints.MustParse("cores=2")
 	placement := []*instance.Placement{{Scope: s.State.ModelUUID(), Directive: "valid"}}
 	_, err := juju.DeployApplication(f,
 		juju.DeployApplicationParams{

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -451,7 +451,7 @@ func (env *azureEnviron) ConstraintsValidator() (constraints.Validator, error) {
 		[]string{constraints.InstanceType},
 		[]string{
 			constraints.Mem,
-			constraints.CpuCores,
+			constraints.Cores,
 			constraints.Arch,
 		},
 	)

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -154,7 +154,7 @@ func (e *environ) ConstraintsValidator() (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 	validator.RegisterConflicts(
 		[]string{constraints.InstanceType},
-		[]string{constraints.Mem, constraints.CpuCores, constraints.CpuPower})
+		[]string{constraints.Mem, constraints.Cores, constraints.CpuPower})
 	validator.RegisterUnsupported(unsupportedConstraints)
 	instTypeNames := make([]string, len(allInstanceTypes))
 	for i, itype := range allInstanceTypes {

--- a/provider/ec2/image_test.go
+++ b/provider/ec2/image_test.go
@@ -69,7 +69,7 @@ var findInstanceSpecTests = []struct {
 	}, {
 		series: "xenial",
 		arches: []string{"amd64"},
-		cons:   "cpu-cores=4",
+		cons:   "cores=4",
 		itype:  "m3.xlarge",
 		image:  "ami-00000133",
 	}, {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1169,7 +1169,7 @@ func (t *localServerSuite) TestConstraintsMerge(c *gc.C) {
 	env := t.Prepare(c)
 	validator, err := env.ConstraintsValidator()
 	c.Assert(err, jc.ErrorIsNil)
-	consA := constraints.MustParse("arch=amd64 mem=1G cpu-power=10 cpu-cores=2 tags=bar")
+	consA := constraints.MustParse("arch=amd64 mem=1G cpu-power=10 cores=2 tags=bar")
 	consB := constraints.MustParse("arch=i386 instance-type=m1.small")
 	cons, err := validator.Merge(consA, consB)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/gce/environ_policy.go
+++ b/provider/gce/environ_policy.go
@@ -34,7 +34,7 @@ var unsupportedConstraints = []string{
 // instance types.  See instancetypes.go.
 var instanceTypeConstraints = []string{
 	constraints.Arch, // Arches
-	constraints.CpuCores,
+	constraints.Cores,
 	constraints.CpuPower,
 	constraints.Mem,
 	constraints.Container, // VirtType

--- a/provider/gce/environ_policy_test.go
+++ b/provider/gce/environ_policy_test.go
@@ -182,7 +182,7 @@ func (s *environPolSuite) TestConstraintsValidatorConflicts(c *gc.C) {
 	cons := constraints.MustParse("instance-type=n1-standard-1")
 	// We do not check arch or container since there is only one valid
 	// value for each and will always match.
-	consFallback := constraints.MustParse("cpu-cores=2 cpu-power=1000 mem=10000 tags=bar")
+	consFallback := constraints.MustParse("cores=2 cpu-power=1000 mem=10000 tags=bar")
 	merged, err := validator.Merge(consFallback, cons)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -6,7 +6,6 @@
 package lxd
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/juju/errors"
@@ -298,19 +297,13 @@ func (env *environ) getHardwareCharacteristics(args environs.StartInstanceParams
 		// TODO(ericsnow) This special-case should be improved.
 		archStr = arch.HostArch()
 	}
-
-	hwc, err := instance.ParseHardware(
-		"arch="+archStr,
-		fmt.Sprintf("cpu-cores=%d", raw.NumCores),
-		fmt.Sprintf("mem=%dM", raw.MemoryMB),
-		//"root-disk=",
-		//"tags=",
-	)
-	if err != nil {
-		logger.Errorf("unexpected problem parsing hardware info: %v", err)
-		// Keep moving...
+	cores := uint64(raw.NumCores)
+	mem := uint64(raw.MemoryMB)
+	return &instance.HardwareCharacteristics{
+		Arch:     &archStr,
+		CpuCores: &cores,
+		Mem:      &mem,
 	}
-	return &hwc
 }
 
 // AllInstances implements environs.InstanceBroker.

--- a/provider/lxd/environ_policy.go
+++ b/provider/lxd/environ_policy.go
@@ -27,7 +27,7 @@ func (env *environ) PrecheckInstance(series string, cons constraints.Value, plac
 }
 
 var unsupportedConstraints = []string{
-	constraints.CpuCores,
+	constraints.Cores,
 	constraints.CpuPower,
 	//TODO(ericsnow) Add constraints.Mem as unsupported?
 	constraints.InstanceType,

--- a/provider/lxd/environ_policy_test.go
+++ b/provider/lxd/environ_policy_test.go
@@ -108,7 +108,7 @@ func (s *environPolSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 		"tags=foo",
 		"mem=3",
 		"instance-type=some-type",
-		"cpu-cores=2",
+		"cores=2",
 		"cpu-power=250",
 		"virt-type=kvm",
 	}, " "))
@@ -118,7 +118,7 @@ func (s *environPolSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 	expected := []string{
 		"tags",
 		"instance-type",
-		"cpu-cores",
+		"cores",
 		"cpu-power",
 		"virt-type",
 	}
@@ -167,12 +167,12 @@ func (s *environPolSuite) TestConstraintsValidatorConflicts(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("instance-type=n1-standard-1")
-	consFallback := constraints.MustParse("cpu-cores=2 cpu-power=1000 mem=10000 tags=bar")
+	consFallback := constraints.MustParse("cores=2 cpu-power=1000 mem=10000 tags=bar")
 	merged, err := validator.Merge(consFallback, cons)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// tags is not supported, but we're not validating here...
-	expected := constraints.MustParse("instance-type=n1-standard-1 tags=bar cpu-cores=2 cpu-power=1000 mem=10000")
+	expected := constraints.MustParse("instance-type=n1-standard-1 tags=bar cores=2 cpu-power=1000 mem=10000")
 	c.Check(merged, jc.DeepEquals, expected)
 }
 

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -184,7 +184,7 @@ func (suite *environSuite) TestStartInstanceStartsInstance(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(instance, gc.NotNil)
 	c.Assert(hc, gc.NotNil)
-	c.Check(hc.String(), gc.Equals, fmt.Sprintf("arch=%s cpu-cores=1 mem=1024M availability-zone=test_zone", arch.HostArch()))
+	c.Check(hc.String(), gc.Equals, fmt.Sprintf("arch=%s cores=1 mem=1024M availability-zone=test_zone", arch.HostArch()))
 
 	// The instance number 1 has been acquired and started.
 	actions, found = operations["node1"]

--- a/provider/maas/instance_test.go
+++ b/provider/maas/instance_test.go
@@ -217,7 +217,7 @@ func (s *instanceTest) TestHardwareCharacteristics(c *gc.C) {
 	hc, err := inst.hardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hc, gc.NotNil)
-	c.Assert(hc.String(), gc.Equals, `arch=amd64 cpu-cores=6 mem=16384M availability-zone=tst`)
+	c.Assert(hc.String(), gc.Equals, `arch=amd64 cores=6 mem=16384M availability-zone=tst`)
 }
 
 func (s *instanceTest) TestHardwareCharacteristicsWithTags(c *gc.C) {
@@ -238,7 +238,7 @@ func (s *instanceTest) TestHardwareCharacteristicsWithTags(c *gc.C) {
 	hc, err := inst.hardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hc, gc.NotNil)
-	c.Assert(hc.String(), gc.Equals, `arch=amd64 cpu-cores=6 mem=16384M tags=a,b availability-zone=tst`)
+	c.Assert(hc.String(), gc.Equals, `arch=amd64 cores=6 mem=16384M tags=a,b availability-zone=tst`)
 }
 
 func (s *instanceTest) TestHardwareCharacteristicsMissing(c *gc.C) {

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -1549,7 +1549,7 @@ func (suite *maas2EnvironSuite) TestStartInstanceEndToEnd(c *gc.C) {
 	instance, hc := jujutesting.AssertStartInstance(c, env, suite.controllerUUID, "1")
 	c.Check(instance, gc.NotNil)
 	c.Assert(hc, gc.NotNil)
-	c.Check(hc.String(), gc.Equals, fmt.Sprintf("arch=%s cpu-cores=1 mem=1024M availability-zone=test_zone", arch.HostArch()))
+	c.Check(hc.String(), gc.Equals, fmt.Sprintf("arch=%s cores=1 mem=1024M availability-zone=test_zone", arch.HostArch()))
 
 	node1.Stub.CheckCallNames(c, "Start", "SetOwnerData")
 	startArgs, ok := node1.Stub.Calls()[0].Args[0].(gomaasapi.StartArgs)

--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -149,7 +149,7 @@ func (s *environSuite) TestConstraintsValidator(c *gc.C) {
 
 	validator, err := s.env.ConstraintsValidator()
 	c.Assert(err, jc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64 instance-type=foo tags=bar cpu-power=10 cpu-cores=2 mem=1G virt-type=kvm")
+	cons := constraints.MustParse("arch=amd64 instance-type=foo tags=bar cpu-power=10 cores=2 mem=1G virt-type=kvm")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "instance-type", "tags", "virt-type"})

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -362,7 +362,7 @@ func (e *Environ) ConstraintsValidator() (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 	validator.RegisterConflicts(
 		[]string{constraints.InstanceType},
-		[]string{constraints.Mem, constraints.RootDisk, constraints.CpuCores})
+		[]string{constraints.Mem, constraints.RootDisk, constraints.Cores})
 	validator.RegisterUnsupported(unsupportedConstraints)
 	novaClient := e.nova()
 	flavors, err := novaClient.ListFlavorsDetail()

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -1279,7 +1279,7 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 				initialContents: []multiwatcher.EntityInfo{&multiwatcher.ApplicationInfo{
 					ModelUUID:   st.ModelUUID(),
 					Name:        "wordpress",
-					Constraints: constraints.MustParse("mem=99M cpu-cores=2 cpu-power=4"),
+					Constraints: constraints.MustParse("mem=99M cores=2 cpu-power=4"),
 				}},
 				change: watcher.Change{
 					C:  "constraints",
@@ -2275,7 +2275,7 @@ func testChangeServicesConstraints(c *gc.C, owner names.UserTag, runChangeTests 
 				initialContents: []multiwatcher.EntityInfo{&multiwatcher.ApplicationInfo{
 					ModelUUID:   st.ModelUUID(),
 					Name:        "wordpress",
-					Constraints: constraints.MustParse("mem=99M cpu-cores=2 cpu-power=4"),
+					Constraints: constraints.MustParse("mem=99M cores=2 cpu-power=4"),
 				}},
 				change: watcher.Change{
 					C:  "constraints",

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -222,7 +222,7 @@ func (s *AssignSuite) TestDirectAssignIgnoresConstraints(c *gc.C) {
 	scons := constraints.MustParse("mem=2G cpu-power=400")
 	err := s.wordpress.SetConstraints(scons)
 	c.Assert(err, jc.ErrorIsNil)
-	econs := constraints.MustParse("mem=4G cpu-cores=2")
+	econs := constraints.MustParse("mem=4G cores=2")
 	err = s.State.SetModelConstraints(econs)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -405,7 +405,7 @@ func (s *AssignSuite) TestAssignUnitToNewMachineSetsConstraints(c *gc.C) {
 	scons := constraints.MustParse("mem=2G cpu-power=400")
 	err := s.wordpress.SetConstraints(scons)
 	c.Assert(err, jc.ErrorIsNil)
-	econs := constraints.MustParse("mem=4G cpu-cores=2")
+	econs := constraints.MustParse("mem=4G cores=2")
 	err = s.State.SetModelConstraints(econs)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -417,7 +417,7 @@ func (s *AssignSuite) TestAssignUnitToNewMachineSetsConstraints(c *gc.C) {
 	scons = constraints.MustParse("mem=6G cpu-power=800")
 	err = s.wordpress.SetConstraints(scons)
 	c.Assert(err, jc.ErrorIsNil)
-	econs = constraints.MustParse("cpu-cores=4")
+	econs = constraints.MustParse("cores=4")
 	err = s.State.SetModelConstraints(econs)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -432,7 +432,7 @@ func (s *AssignSuite) TestAssignUnitToNewMachineSetsConstraints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	mcons, err := machine.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	expect := constraints.MustParse("mem=2G cpu-cores=2 cpu-power=400")
+	expect := constraints.MustParse("mem=2G cores=2 cpu-power=400")
 	c.Assert(mcons, gc.DeepEquals, expect)
 }
 
@@ -852,7 +852,7 @@ var assignUsingConstraintsTests = []struct {
 		assignOk:                false,
 	}, {
 		unitConstraints:         "arch=amd64",
-		hardwareCharacteristics: "cpu-cores=1",
+		hardwareCharacteristics: "cores=1",
 		assignOk:                false,
 	}, {
 		unitConstraints:         "arch=amd64",
@@ -868,7 +868,7 @@ var assignUsingConstraintsTests = []struct {
 		assignOk:                false,
 	}, {
 		unitConstraints:         "mem=4G",
-		hardwareCharacteristics: "cpu-cores=1",
+		hardwareCharacteristics: "cores=1",
 		assignOk:                false,
 	}, {
 		unitConstraints:         "mem=4G",
@@ -879,15 +879,15 @@ var assignUsingConstraintsTests = []struct {
 		hardwareCharacteristics: "mem=2G",
 		assignOk:                false,
 	}, {
-		unitConstraints:         "cpu-cores=2",
-		hardwareCharacteristics: "cpu-cores=2",
+		unitConstraints:         "cores=2",
+		hardwareCharacteristics: "cores=2",
 		assignOk:                true,
 	}, {
-		unitConstraints:         "cpu-cores=2",
-		hardwareCharacteristics: "cpu-cores=1",
+		unitConstraints:         "cores=2",
+		hardwareCharacteristics: "cores=1",
 		assignOk:                false,
 	}, {
-		unitConstraints:         "cpu-cores=2",
+		unitConstraints:         "cores=2",
 		hardwareCharacteristics: "mem=4G",
 		assignOk:                false,
 	}, {
@@ -915,12 +915,12 @@ var assignUsingConstraintsTests = []struct {
 		hardwareCharacteristics: "root-disk=8192",
 		assignOk:                true,
 	}, {
-		unitConstraints:         "arch=amd64 mem=4G cpu-cores=2 root-disk=8192",
-		hardwareCharacteristics: "arch=amd64 mem=8G cpu-cores=2 root-disk=8192 cpu-power=50",
+		unitConstraints:         "arch=amd64 mem=4G cores=2 root-disk=8192",
+		hardwareCharacteristics: "arch=amd64 mem=8G cores=2 root-disk=8192 cpu-power=50",
 		assignOk:                true,
 	}, {
-		unitConstraints:         "arch=amd64 mem=4G cpu-cores=2 root-disk=8192",
-		hardwareCharacteristics: "arch=amd64 mem=8G cpu-cores=1 root-disk=4096 cpu-power=50",
+		unitConstraints:         "arch=amd64 mem=4G cores=2 root-disk=8192",
+		hardwareCharacteristics: "arch=amd64 mem=8G cores=1 root-disk=4096 cpu-power=50",
 		assignOk:                false,
 	},
 }

--- a/state/constraintsvalidation_test.go
+++ b/state/constraintsvalidation_test.go
@@ -81,84 +81,84 @@ var setConstraintsTests = []struct {
 }, {
 	about:        "(implicitly) empty constraints never override explictly set fallbacks",
 	consToSet:    "",
-	consFallback: "arch=amd64 cpu-cores=42 mem=2G tags=foo",
+	consFallback: "arch=amd64 cores=42 mem=2G tags=foo",
 
-	effectiveModelCons:   "arch=amd64 cpu-cores=42 mem=2G tags=foo",
+	effectiveModelCons:   "arch=amd64 cores=42 mem=2G tags=foo",
 	effectiveServiceCons: "", // set as given.
-	effectiveUnitCons:    "arch=amd64 cpu-cores=42 mem=2G tags=foo",
+	effectiveUnitCons:    "arch=amd64 cores=42 mem=2G tags=foo",
 	// set as given, then merged with fallbacks; since consToSet is
 	// empty, the effective values inherit everything from fallbacks;
 	// like the unit, but only because the service constraints are
 	// also empty.
-	effectiveMachineCons: "arch=amd64 cpu-cores=42 mem=2G tags=foo",
+	effectiveMachineCons: "arch=amd64 cores=42 mem=2G tags=foo",
 }, {
 	about:        "(explicitly) empty constraints are OK and stored as given",
-	consToSet:    "cpu-cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
+	consToSet:    "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
 	consFallback: "",
 
 	effectiveModelCons:   "",
-	effectiveServiceCons: "cpu-cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
-	effectiveUnitCons:    "cpu-cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
-	effectiveMachineCons: "cpu-cores= cpu-power= instance-type= root-disk= tags= spaces=", // container= is dropped
+	effectiveServiceCons: "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
+	effectiveUnitCons:    "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
+	effectiveMachineCons: "cores= cpu-power= instance-type= root-disk= tags= spaces=", // container= is dropped
 }, {
 	about:        "(explicitly) empty fallback constraints are OK and stored as given",
 	consToSet:    "",
-	consFallback: "cpu-cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
+	consFallback: "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
 
-	effectiveModelCons:   "cpu-cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
+	effectiveModelCons:   "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
 	effectiveServiceCons: "",
-	effectiveUnitCons:    "cpu-cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
-	effectiveMachineCons: "cpu-cores= cpu-power= instance-type= root-disk= tags= spaces=", // container= is dropped
+	effectiveUnitCons:    "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
+	effectiveMachineCons: "cores= cpu-power= instance-type= root-disk= tags= spaces=", // container= is dropped
 }, {
 	about:                "(explicitly) empty constraints and fallbacks are OK and stored as given",
-	consToSet:            "arch= mem= cpu-cores= container=",
-	consFallback:         "cpu-cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
-	effectiveModelCons:   "cpu-cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
-	effectiveServiceCons: "arch= mem= cpu-cores= container=",
-	effectiveUnitCons:    "arch= container= cpu-cores= cpu-power= mem= root-disk= tags= spaces=",
-	effectiveMachineCons: "arch= cpu-cores= cpu-power= mem= root-disk= tags= spaces=", // container= is dropped
+	consToSet:            "arch= mem= cores= container=",
+	consFallback:         "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
+	effectiveModelCons:   "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
+	effectiveServiceCons: "arch= mem= cores= container=",
+	effectiveUnitCons:    "arch= container= cores= cpu-power= mem= root-disk= tags= spaces=",
+	effectiveMachineCons: "arch= cores= cpu-power= mem= root-disk= tags= spaces=", // container= is dropped
 }, {
 	about:        "(explicitly) empty constraints override set fallbacks for deployment and provisioning",
-	consToSet:    "cpu-cores= arch= spaces= cpu-power=",
-	consFallback: "cpu-cores=42 arch=amd64 tags=foo spaces=default,^dmz mem=4G",
+	consToSet:    "cores= arch= spaces= cpu-power=",
+	consFallback: "cores=42 arch=amd64 tags=foo spaces=default,^dmz mem=4G",
 
-	effectiveModelCons:   "cpu-cores=42 arch=amd64 tags=foo spaces=default,^dmz mem=4G",
-	effectiveServiceCons: "cpu-cores= arch= spaces= cpu-power=",
-	effectiveUnitCons:    "arch= cpu-cores= cpu-power= mem=4G tags=foo spaces=",
-	effectiveMachineCons: "arch= cpu-cores= cpu-power= mem=4G tags=foo spaces=",
+	effectiveModelCons:   "cores=42 arch=amd64 tags=foo spaces=default,^dmz mem=4G",
+	effectiveServiceCons: "cores= arch= spaces= cpu-power=",
+	effectiveUnitCons:    "arch= cores= cpu-power= mem=4G tags=foo spaces=",
+	effectiveMachineCons: "arch= cores= cpu-power= mem=4G tags=foo spaces=",
 	// we're also checking if m.SetConstraints() does the same with
 	// regards to the effective constraints as AddMachine(), because
 	// some of these tests proved they had different behavior (i.e.
 	// container= was not set to empty)
 }, {
 	about:        "non-empty constraints always override empty or unset fallbacks",
-	consToSet:    "cpu-cores=42 root-disk=20G arch=amd64 tags=foo,bar",
-	consFallback: "cpu-cores= arch= tags=",
+	consToSet:    "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
+	consFallback: "cores= arch= tags=",
 
-	effectiveModelCons:   "cpu-cores= arch= tags=",
-	effectiveServiceCons: "cpu-cores=42 root-disk=20G arch=amd64 tags=foo,bar",
-	effectiveUnitCons:    "cpu-cores=42 root-disk=20G arch=amd64 tags=foo,bar",
-	effectiveMachineCons: "cpu-cores=42 root-disk=20G arch=amd64 tags=foo,bar",
+	effectiveModelCons:   "cores= arch= tags=",
+	effectiveServiceCons: "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
+	effectiveUnitCons:    "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
+	effectiveMachineCons: "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
 }, {
 	about:        "non-empty constraints always override set fallbacks",
-	consToSet:    "cpu-cores=42 root-disk=20G arch=amd64 tags=foo,bar",
-	consFallback: "cpu-cores=12 root-disk=10G arch=i386  tags=bar",
+	consToSet:    "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
+	consFallback: "cores=12 root-disk=10G arch=i386  tags=bar",
 
-	effectiveModelCons:   "cpu-cores=12 root-disk=10G arch=i386  tags=bar",
-	effectiveServiceCons: "cpu-cores=42 root-disk=20G arch=amd64 tags=foo,bar",
-	effectiveUnitCons:    "cpu-cores=42 root-disk=20G arch=amd64 tags=foo,bar",
-	effectiveMachineCons: "cpu-cores=42 root-disk=20G arch=amd64 tags=foo,bar",
+	effectiveModelCons:   "cores=12 root-disk=10G arch=i386  tags=bar",
+	effectiveServiceCons: "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
+	effectiveUnitCons:    "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
+	effectiveMachineCons: "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
 }, {
 	about:        "non-empty constraints override conflicting set fallbacks",
-	consToSet:    "mem=8G arch=amd64 cpu-cores=4 tags=bar",
+	consToSet:    "mem=8G arch=amd64 cores=4 tags=bar",
 	consFallback: "instance-type=small cpu-power=1000", // instance-type conflicts mem, arch
 
 	effectiveModelCons:   "instance-type=small cpu-power=1000",
-	effectiveServiceCons: "mem=8G arch=amd64 cpu-cores=4 tags=bar",
+	effectiveServiceCons: "mem=8G arch=amd64 cores=4 tags=bar",
 	// both of the following contain the explicitly set constraints after
 	// resolving any conflicts with fallbacks (by dropping them).
-	effectiveUnitCons:    "mem=8G arch=amd64 cpu-cores=4 tags=bar cpu-power=1000",
-	effectiveMachineCons: "mem=8G arch=amd64 cpu-cores=4 tags=bar cpu-power=1000",
+	effectiveUnitCons:    "mem=8G arch=amd64 cores=4 tags=bar cpu-power=1000",
+	effectiveMachineCons: "mem=8G arch=amd64 cores=4 tags=bar cpu-power=1000",
 }, {
 	about:        "set fallbacks are overriden the same way for provisioning and deployment",
 	consToSet:    "tags= cpu-power= spaces=bar",

--- a/state/prechecker_test.go
+++ b/state/prechecker_test.go
@@ -102,7 +102,7 @@ func (s *PrecheckerSuite) addOneMachine(c *gc.C, envCons constraints.Value, plac
 	err := s.State.SetModelConstraints(envCons)
 	c.Assert(err, jc.ErrorIsNil)
 	oneJob := []state.MachineJob{state.JobHostUnits}
-	extraCons := constraints.MustParse("cpu-cores=4")
+	extraCons := constraints.MustParse("cores=4")
 	template := state.MachineTemplate{
 		Series:      "precise",
 		Constraints: extraCons,

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -861,7 +861,7 @@ func (s *StateSuite) TestAddMachineExtraConstraints(c *gc.C) {
 	err := s.State.SetModelConstraints(constraints.MustParse("mem=4G"))
 	c.Assert(err, jc.ErrorIsNil)
 	oneJob := []state.MachineJob{state.JobHostUnits}
-	extraCons := constraints.MustParse("cpu-cores=4")
+	extraCons := constraints.MustParse("cores=4")
 	m, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series:      "quantal",
 		Constraints: extraCons,
@@ -871,7 +871,7 @@ func (s *StateSuite) TestAddMachineExtraConstraints(c *gc.C) {
 	c.Assert(m.Id(), gc.Equals, "0")
 	c.Assert(m.Series(), gc.Equals, "quantal")
 	c.Assert(m.Jobs(), gc.DeepEquals, oneJob)
-	expectedCons := constraints.MustParse("cpu-cores=4 mem=4G")
+	expectedCons := constraints.MustParse("cores=4 mem=4G")
 	mcons, err := m.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mcons, gc.DeepEquals, expectedCons)

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -107,7 +107,7 @@ var _ = gc.Suite(&ProvisionerSuite{})
 
 func (s *CommonProvisionerSuite) SetUpSuite(c *gc.C) {
 	s.JujuConnSuite.SetUpSuite(c)
-	s.defaultConstraints = constraints.MustParse("arch=amd64 mem=4G cpu-cores=1 root-disk=8G")
+	s.defaultConstraints = constraints.MustParse("arch=amd64 mem=4G cores=1 root-disk=8G")
 }
 
 func (s *CommonProvisionerSuite) SetUpTest(c *gc.C) {
@@ -453,7 +453,7 @@ func (s *ProvisionerSuite) TestConstraints(c *gc.C) {
 	// Create a machine with non-standard constraints.
 	m, err := s.addMachine()
 	c.Assert(err, jc.ErrorIsNil)
-	cons := constraints.MustParse("mem=8G arch=amd64 cpu-cores=2 root-disk=10G")
+	cons := constraints.MustParse("mem=8G arch=amd64 cores=2 root-disk=10G")
 	err = m.SetConstraints(cons)
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
This fixes-1620056 constraints should support cores=X 
Added the concept of aliases of constraint names.
Changed default name of CpuCores to cores.
Added alias from cpu-cores to cores.

This change adds a warning message that is displayed if you specify "cpu-cores" on the CLI, because any error messages will reference "cores" (and everything is displayed as cores).  Unfortunately, the way our flag parsing works, there's no way to display this message if the flag parsing fails, so I have to take the constraints as a string flag and then parse during run (at which time we have the ctx and thus can output the correct message).

Most of the changes are trivial conversion of "cpu-cores" to "cores" in tests... for many places it wasn't strictly necessary, we could just use the alias, but this way if we eventually remove the alias, we won't have to update those.  Plus, some of them were testing the output, which is always "cores" and it was easier to just change every instance than try to pick out the ones that mattered.

Note, this changes the output of machine hardware characteristics as well, so that change could break some people.  It does *not* change the API representation of cpu-cores for hardware characteristics, so we don't break the API (and that doesn't *really* matter anyway).

(Review request: http://reviews.vapour.ws/r/5656/)