### PR TITLE
Use clock interface for leadership worker

### DIFF
--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -195,6 +195,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		leadershipTrackerName: ifNotMigrating(leadership.Manifold(leadership.ManifoldConfig{
 			AgentName:           agentName,
 			APICallerName:       apiCallerName,
+			Clock:               clock.WallClock,
 			LeadershipGuarantee: config.LeadershipGuarantee,
 		})),
 


### PR DESCRIPTION
Make the clock a part of the manifold config, and use the testing.Clock in the tests.

Fixes http://pad.lv/1612745 and http://pad.lv/1519189

(Review request: http://reviews.vapour.ws/r/5657/)