### PR TITLE
Allow initial migration prechecks to be skipped

### DIFF
--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -220,13 +220,14 @@ func (c *Client) GetControllerAccess(user string) (description.Access, error) {
 // a single model.
 type MigrationSpec struct {
 	ModelUUID            string
-	ExternalControl      bool
 	TargetControllerUUID string
 	TargetAddrs          []string
 	TargetCACert         string
 	TargetUser           string
 	TargetPassword       string
 	TargetMacaroons      []macaroon.Slice
+	ExternalControl      bool
+	SkipInitialPrechecks bool
 }
 
 // Validate performs sanity checks on the migration configuration it
@@ -280,7 +281,8 @@ func (c *Client) InitiateMigration(spec MigrationSpec) (string, error) {
 				Password:      spec.TargetPassword,
 				Macaroons:     string(macsJSON),
 			},
-			ExternalControl: spec.ExternalControl,
+			ExternalControl:      spec.ExternalControl,
+			SkipInitialPrechecks: spec.SkipInitialPrechecks,
 		}},
 	}
 	response := params.InitiateMigrationResults{}

--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -56,6 +56,21 @@ func (s *Suite) TestInitiateMigrationExternalControl(c *gc.C) {
 	})
 }
 
+func (s *Suite) TestInitiateMigrationSkipPrechecks(c *gc.C) {
+	client, stub := makeClient(params.InitiateMigrationResults{
+		Results: []params.InitiateMigrationResult{{
+			MigrationId: "id",
+		}},
+	})
+	spec := makeSpec()
+	spec.SkipInitialPrechecks = true
+	_, err := client.InitiateMigration(spec)
+	c.Assert(err, jc.ErrorIsNil)
+	stub.CheckCalls(c, []jujutesting.StubCall{
+		{"Controller.InitiateMigration", []interface{}{specToArgs(spec)}},
+	})
+}
+
 func specToArgs(spec controller.MigrationSpec) params.InitiateMigrationArgs {
 	var macsJSON []byte
 	if len(spec.TargetMacaroons) > 0 {
@@ -76,7 +91,8 @@ func specToArgs(spec controller.MigrationSpec) params.InitiateMigrationArgs {
 				Password:      spec.TargetPassword,
 				Macaroons:     string(macsJSON),
 			},
-			ExternalControl: spec.ExternalControl,
+			ExternalControl:      spec.ExternalControl,
+			SkipInitialPrechecks: spec.SkipInitialPrechecks,
 		}},
 	}
 }

--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -27,45 +27,30 @@ type Suite struct {
 var _ = gc.Suite(&Suite{})
 
 func (s *Suite) TestInitiateMigration(c *gc.C) {
-	client, stub := makeClient(params.InitiateMigrationResults{
-		Results: []params.InitiateMigrationResult{{
-			MigrationId: "id",
-		}},
-	})
-	spec := makeSpec()
-	id, err := client.InitiateMigration(spec)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(id, gc.Equals, "id")
-	stub.CheckCalls(c, []jujutesting.StubCall{
-		{"Controller.InitiateMigration", []interface{}{specToArgs(spec)}},
-	})
+	s.checkInitiateMigration(c, makeSpec())
 }
 
 func (s *Suite) TestInitiateMigrationExternalControl(c *gc.C) {
-	client, stub := makeClient(params.InitiateMigrationResults{
-		Results: []params.InitiateMigrationResult{{
-			MigrationId: "id",
-		}},
-	})
 	spec := makeSpec()
 	spec.ExternalControl = true
-	_, err := client.InitiateMigration(spec)
-	c.Assert(err, jc.ErrorIsNil)
-	stub.CheckCalls(c, []jujutesting.StubCall{
-		{"Controller.InitiateMigration", []interface{}{specToArgs(spec)}},
-	})
+	s.checkInitiateMigration(c, spec)
 }
 
 func (s *Suite) TestInitiateMigrationSkipPrechecks(c *gc.C) {
+	spec := makeSpec()
+	spec.SkipInitialPrechecks = true
+	s.checkInitiateMigration(c, spec)
+}
+
+func (s *Suite) checkInitiateMigration(c *gc.C, spec controller.MigrationSpec) {
 	client, stub := makeClient(params.InitiateMigrationResults{
 		Results: []params.InitiateMigrationResult{{
 			MigrationId: "id",
 		}},
 	})
-	spec := makeSpec()
-	spec.SkipInitialPrechecks = true
-	_, err := client.InitiateMigration(spec)
+	id, err := client.InitiateMigration(spec)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Check(id, gc.Equals, "id")
 	stub.CheckCalls(c, []jujutesting.StubCall{
 		{"Controller.InitiateMigration", []interface{}{specToArgs(spec)}},
 	})

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -406,8 +406,10 @@ func (c *ControllerAPI) initiateOneMigration(spec params.MigrationSpec) (string,
 	}
 
 	// Check if the migration is likely to succeed.
-	if err := runMigrationPrechecks(hostedState, targetInfo); err != nil {
-		return "", errors.Trace(err)
+	if !(spec.ExternalControl && spec.SkipInitialPrechecks) {
+		if err := runMigrationPrechecks(hostedState, targetInfo); err != nil {
+			return "", errors.Trace(err)
+		}
 	}
 
 	// Trigger the migration.

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -21,6 +21,11 @@ type MigrationSpec struct {
 	ModelTag        string              `json:"model-tag"`
 	TargetInfo      MigrationTargetInfo `json:"target-info"`
 	ExternalControl bool                `json:"external-control"`
+
+	// SkipInitialPrechecks allows the migration prechecks run during
+	// handling of the InitiateMigration API call to be bypassed. It
+	// is only honoured if ExternalControl is true.
+	SkipInitialPrechecks bool `json:"skip-initial-prechecks"`
 }
 
 // MigrationTargetInfo holds the details required to connect to and


### PR DESCRIPTION
If a migration is externally controlled it could be useful to be able to skip the prechecks performed during the InitiateMigration API call, in case the source controller Juju version has checks against the target controller which are no longer correct/relevant.

Also refactored the tests in api/controller somewhat to remove duplication.

(Review request: http://reviews.vapour.ws/r/5658/)