### PR TITLE
migration: Use presence when checking machines 

### DIFF
--- a/apiserver/common/machinestatus.go
+++ b/apiserver/common/machinestatus.go
@@ -28,7 +28,7 @@ func MachineStatus(machine MachineStatusGetter) (status.StatusInfo, error) {
 	if !canMachineBeDown(machineStatus) {
 		// The machine still being provisioned - there's no point in
 		// enquiring about the agent liveness.
-		return machineStatus, err
+		return machineStatus, nil
 	}
 
 	agentAlive, err := machine.AgentPresence()

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -49,6 +49,7 @@ type PrecheckMachine interface {
 	AgentTools() (*tools.Tools, error)
 	Life() state.Life
 	Status() (status.StatusInfo, error)
+	AgentPresence() (bool, error)
 	InstanceStatus() (status.StatusInfo, error)
 	ShouldRebootOrShutdown() (state.RebootAction, error)
 }
@@ -218,10 +219,11 @@ func checkMachines(backend PrecheckBackend) error {
 			return newStatusError("machine %s not running", machine.Id(), statusInfo.Status)
 		}
 
-		if statusInfo, err := machine.Status(); err != nil {
+		if statusInfo, err := common.MachineStatus(machine); err != nil {
 			return errors.Annotatef(err, "retrieving machine %s status", machine.Id())
 		} else if statusInfo.Status != status.StatusStarted {
-			return newStatusError("machine %s not started", machine.Id(), statusInfo.Status)
+			return newStatusError("machine %s agent not functioning at this time",
+				machine.Id(), statusInfo.Status)
 		}
 
 		if rebootAction, err := machine.ShouldRebootOrShutdown(); err != nil {


### PR DESCRIPTION
Use the new MachineStatus helper to determine machine status. This takes presence into account which wasn't being considered before.

(Review request: http://reviews.vapour.ws/r/5660/)