### PR TITLE
provider/azure: use ARM templates

### DIFF
--- a/provider/azure/config_test.go
+++ b/provider/azure/config_test.go
@@ -18,7 +18,6 @@ const (
 	fakeApplicationId     = "00000000-0000-0000-0000-000000000000"
 	fakeTenantId          = "11111111-1111-1111-1111-111111111111"
 	fakeSubscriptionId    = "22222222-2222-2222-2222-222222222222"
-	fakeStorageAccount    = "mrblobby"
 	fakeStorageAccountKey = "quay"
 )
 

--- a/provider/azure/deployments.go
+++ b/provider/azure/deployments.go
@@ -1,0 +1,42 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azure
+
+import (
+	"github.com/Azure/azure-sdk-for-go/arm/resources/resources"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/provider/azure/internal/armtemplates"
+)
+
+func createDeployment(
+	callAPI callAPIFunc,
+	client resources.DeploymentsClient,
+	resourceGroup string,
+	deploymentName string,
+	t armtemplates.Template,
+) error {
+	templateMap, err := t.Map()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	deployment := resources.Deployment{
+		&resources.DeploymentProperties{
+			Template: &templateMap,
+			Mode:     resources.Incremental,
+		},
+	}
+	if err := callAPI(func() (autorest.Response, error) {
+		return client.CreateOrUpdate(
+			resourceGroup,
+			deploymentName,
+			deployment,
+			nil, // abort channel
+		)
+	}); err != nil {
+		return errors.Annotatef(err, "creating deployment %q", deploymentName)
+	}
+	return nil
+}

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -24,7 +24,6 @@ import (
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/os"
 	jujuseries "github.com/juju/utils/series"
-	"github.com/juju/utils/set"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/cloudconfig/instancecfg"
@@ -37,6 +36,7 @@ import (
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/instance"
 	jujunetwork "github.com/juju/juju/network"
+	"github.com/juju/juju/provider/azure/internal/armtemplates"
 	internalazurestorage "github.com/juju/juju/provider/azure/internal/azurestorage"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state"
@@ -49,6 +49,15 @@ const (
 	// defaultRootDiskSize is the default root disk size to give
 	// to a VM, if none is specified.
 	defaultRootDiskSize = 30 * 1024 // 30 GiB
+
+	// serviceErrorCodeDeploymentCannotBeCancelled is the error code for
+	// service errors in response to an attempt to cancel a deployment
+	// that cannot be cancelled.
+	serviceErrorCodeDeploymentCannotBeCancelled = "DeploymentCannotBeCancelled"
+
+	// controllerAvailabilitySet is the name of the availability set
+	// used for controller machines.
+	controllerAvailabilitySet = "juju-controller"
 )
 
 type azureEnviron struct {
@@ -80,11 +89,12 @@ type azureEnviron struct {
 	// azure auth token, and management clients
 	token *azure.ServicePrincipalToken
 
-	compute       compute.ManagementClient
-	resources     resources.ManagementClient
-	storage       storage.ManagementClient
-	network       network.ManagementClient
-	storageClient azurestorage.Client
+	compute            compute.ManagementClient
+	resources          resources.ManagementClient
+	storage            storage.ManagementClient
+	network            network.ManagementClient
+	storageClient      azurestorage.Client
+	storageAccountName string
 
 	mu                sync.Mutex
 	config            *azureModelConfig
@@ -122,9 +132,23 @@ func newEnviron(
 	if err := env.SetConfig(cfg); err != nil {
 		return nil, errors.Trace(err)
 	}
+
 	modelTag := names.NewModelTag(cfg.UUID())
 	env.resourceGroup = resourceGroupName(modelTag, cfg.Name())
 	env.envName = cfg.Name()
+
+	// We need a deterministic storage account name, so that we can
+	// defer creation of the storage account to the VM deployment,
+	// and retain the ability to create multiple deployments in
+	// parallel.
+	//
+	// We use the last 20 non-hyphen hex characters of the model's
+	// UUID as the storage account name, prefixed with "juju". The
+	// probability of clashing with another storage account should
+	// be negligible.
+	uuidAlphaNumeric := strings.Replace(env.config.Config.UUID(), "-", "", -1)
+	env.storageAccountName = "juju" + uuidAlphaNumeric[len(uuidAlphaNumeric)-20:]
+
 	return &env, nil
 }
 
@@ -210,7 +234,7 @@ func (env *azureEnviron) Create(args environs.CreateParams) error {
 	if err := verifyCredentials(env); err != nil {
 		return errors.Trace(err)
 	}
-	return errors.Trace(env.initResourceGroup(args.ControllerUUID, nil))
+	return errors.Trace(env.initResourceGroup(args.ControllerUUID))
 }
 
 // Bootstrap is part of the Environ interface.
@@ -218,9 +242,7 @@ func (env *azureEnviron) Bootstrap(
 	ctx environs.BootstrapContext,
 	args environs.BootstrapParams,
 ) (*environs.BootstrapResult, error) {
-
-	apiPort := args.ControllerConfig.APIPort()
-	if err := env.initResourceGroup(args.ControllerConfig.ControllerUUID(), &apiPort); err != nil {
+	if err := env.initResourceGroup(args.ControllerConfig.ControllerUUID()); err != nil {
 		return nil, errors.Annotate(err, "creating controller resource group")
 	}
 	result, err := common.Bootstrap(ctx, env, args)
@@ -234,14 +256,10 @@ func (env *azureEnviron) Bootstrap(
 	return result, nil
 }
 
-// initResourceGroup creates and initialises a resource group for this
-// environment. The resource group will have a storage account, and
-// internal network and subnet.
-func (env *azureEnviron) initResourceGroup(controllerUUID string, apiPort *int) error {
+// initResourceGroup creates a resource group for this environment.
+func (env *azureEnviron) initResourceGroup(controllerUUID string) error {
 	location := env.location
 	resourceGroupsClient := resources.GroupsClient{env.resources}
-	networkClient := env.network
-	storageAccountsClient := storage.AccountsClient{env.storage}
 
 	env.mu.Lock()
 	tags := tags.ResourceTags(
@@ -249,149 +267,31 @@ func (env *azureEnviron) initResourceGroup(controllerUUID string, apiPort *int) 
 		names.NewControllerTag(controllerUUID),
 		env.config,
 	)
-	storageAccountType := env.config.storageAccountType
 	env.mu.Unlock()
 
 	logger.Debugf("creating resource group %q", env.resourceGroup)
-	if err := env.callAPI(func() (autorest.Response, error) {
+	err := env.callAPI(func() (autorest.Response, error) {
 		group, err := resourceGroupsClient.CreateOrUpdate(env.resourceGroup, resources.ResourceGroup{
 			Location: to.StringPtr(location),
 			Tags:     to.StringMapPtr(tags),
 		})
 		return group.Response, err
-	}); err != nil {
-		return errors.Annotate(err, "creating resource group")
-	}
-
-	// Create an internal network for all VMs in the
-	// resource group to connect to.
-	if _, err := createInternalVirtualNetwork(
-		env.callAPI, networkClient,
-		env.subscriptionId, env.resourceGroup,
-		location, tags,
-	); err != nil {
-		return errors.Annotate(err, "creating virtual network")
-	}
-
-	// Create an network security group which will be
-	// associated with all machines.
-	if _, err := createInternalNetworkSecurityGroup(
-		env.callAPI, networkClient,
-		env.subscriptionId, env.resourceGroup,
-		location, tags, apiPort,
-	); err != nil {
-		return errors.Annotate(err, "creating security group")
-	}
-
-	// Create a subnet to which all machines will be attached.
-	if _, err := createInternalNetworkSubnet(
-		env.callAPI, networkClient,
-		env.subscriptionId, env.resourceGroup,
-		internalSubnetName, internalSubnetPrefix,
-		location, tags,
-	); err != nil {
-		return errors.Annotate(err, "creating subnet")
-	}
-
-	if apiPort != nil {
-		// apiPort is non-nil only for the controller model. Create
-		// a subnet to which controller machines will be attached.
-		if _, err := createInternalNetworkSubnet(
-			env.callAPI, networkClient,
-			env.subscriptionId, env.resourceGroup,
-			controllerSubnetName, controllerSubnetPrefix,
-			location, tags,
-		); err != nil {
-			return errors.Annotate(err, "creating subnet")
-		}
-	}
-
-	// Create a storage account for the resource group.
-	if err := createStorageAccount(
-		env.callAPI, storageAccountsClient, storageAccountType,
-		env.resourceGroup, location, tags,
-		env.provider.config.StorageAccountNameGenerator,
-	); err != nil {
-		return errors.Annotate(err, "creating storage account")
-	}
-	return nil
-}
-
-func createStorageAccount(
-	callAPI callAPIFunc,
-	client storage.AccountsClient,
-	accountType string,
-	resourceGroup string,
-	location string,
-	tags map[string]string,
-	accountNameGenerator func() string,
-) error {
-	logger.Debugf("creating storage account (finding available name)")
-	const maxAttempts = 10
-	for remaining := maxAttempts; remaining > 0; remaining-- {
-		accountName := accountNameGenerator()
-		logger.Debugf("- checking storage account name %q", accountName)
-		var result storage.CheckNameAvailabilityResult
-		if err := callAPI(func() (autorest.Response, error) {
-			var err error
-			result, err = client.CheckNameAvailability(
-				storage.AccountCheckNameAvailabilityParameters{
-					Name: to.StringPtr(accountName),
-					// Azure is a little inconsistent with when Type is
-					// required. It's required here.
-					Type: to.StringPtr("Microsoft.Storage/storageAccounts"),
-				},
-			)
-			return result.Response, err
-		}); err != nil {
-			return errors.Annotate(err, "checking account name availability")
-		}
-		if !to.Bool(result.NameAvailable) {
-			logger.Debugf(
-				"%q is not available (%v): %v",
-				accountName, result.Reason, result.Message,
-			)
-			continue
-		}
-		createParams := storage.AccountCreateParameters{
-			Location: to.StringPtr(location),
-			Tags:     to.StringMapPtr(tags),
-			Sku: &storage.Sku{
-				Name: storage.SkuName(accountType),
-			},
-		}
-		logger.Debugf("- creating %q storage account %q", accountType, accountName)
-		// TODO(axw) account creation can fail if the account name is
-		// available, but contains profanity. We should retry a set
-		// number of times even if creating fails.
-		if err := callAPI(func() (autorest.Response, error) {
-			return client.Create(resourceGroup, accountName, createParams, nil)
-		}); err != nil {
-			return errors.Trace(err)
-		}
-		return nil
-	}
-	return errors.New("could not find available storage account name")
+	})
+	return errors.Annotate(err, "creating resource group")
 }
 
 // ControllerInstances is specified in the Environ interface.
 func (env *azureEnviron) ControllerInstances(controllerUUID string) ([]instance.Id, error) {
-	// controllers are tagged with tags.JujuIsController, so just
-	// list the instances in the controller resource group and pick
-	// those ones out.
-	instances, err := env.allInstances(env.resourceGroup, true)
+	instances, err := env.allInstances(env.resourceGroup, false, true)
 	if err != nil {
 		return nil, err
 	}
-	var ids []instance.Id
-	for _, inst := range instances {
-		azureInstance := inst.(*azureInstance)
-		if toTags(azureInstance.Tags)[tags.JujuIsController] == "true" {
-			ids = append(ids, inst.Id())
-		}
-	}
-	if len(ids) == 0 {
+	if len(instances) == 0 {
 		return nil, environs.ErrNoInstances
+	}
+	ids := make([]instance.Id, len(instances))
+	for i, inst := range instances {
+		ids[i] = inst.Id()
 	}
 	return ids, nil
 }
@@ -490,13 +390,6 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 		return nil, errors.New("missing controller UUID")
 	}
 
-	location := env.location
-	vmClient := compute.VirtualMachinesClient{env.compute}
-	availabilitySetClient := compute.AvailabilitySetsClient{env.compute}
-	networkClient := env.network
-	vmImagesClient := compute.VirtualMachineImagesClient{env.compute}
-	vmExtensionClient := compute.VirtualMachineExtensionsClient{env.compute}
-
 	// Get the required configuration and config-dependent information
 	// required to create the instance. We take the lock just once, to
 	// ensure we obtain all information based on the same configuration.
@@ -506,16 +399,12 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 		names.NewControllerTag(args.ControllerUUID),
 		env.config,
 	)
+	storageAccountType := env.config.storageAccountType
 	imageStream := env.config.ImageStream()
 	instanceTypes, err := env.getInstanceTypesLocked()
 	if err != nil {
 		env.mu.Unlock()
 		return nil, errors.Trace(err)
-	}
-	storageAccount, err := env.getStorageAccountLocked(false)
-	if err != nil {
-		env.mu.Unlock()
-		return nil, errors.Annotate(err, "getting storage account")
 	}
 	env.mu.Unlock()
 
@@ -532,10 +421,10 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 	// Identify the instance type and image to provision.
 	series := args.Tools.OneSeries()
 	instanceSpec, err := findInstanceSpec(
-		vmImagesClient,
+		compute.VirtualMachineImagesClient{env.compute},
 		instanceTypes,
 		&instances.InstanceConstraint{
-			Region:      location,
+			Region:      env.location,
 			Series:      series,
 			Arches:      args.Tools.Arches(),
 			Constraints: args.Constraints,
@@ -595,18 +484,11 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 	// machine with this.
 	vmTags[jujuMachineNameTag] = vmName
 
-	vm, err := createVirtualMachine(
-		env.subscriptionId, env.resourceGroup,
-		location, vmName, vmTags, envTags,
+	if err := env.createVirtualMachine(
+		vmName, vmTags, envTags,
 		instanceSpec, args.InstanceConfig,
-		args.DistributionGroup,
-		env.Instances,
-		storageAccount,
-		networkClient, vmClient,
-		availabilitySetClient, vmExtensionClient,
-		env.callAPI,
-	)
-	if err != nil {
+		storageAccountType,
+	); err != nil {
 		logger.Errorf("creating instance failed, destroying: %v", err)
 		if err := env.StopInstances(instance.Id(vmName)); err != nil {
 			logger.Errorf("could not destroy failed virtual machine: %v", err)
@@ -617,7 +499,7 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 	// Note: the instance is initialised without addresses to keep the
 	// API chatter down. We will refresh the instance if we need to know
 	// the addresses.
-	inst := &azureInstance{vm, env, nil, nil}
+	inst := &azureInstance{vmName, "Creating", env, nil, nil}
 	amd64 := arch.AMD64
 	hc := &instance.HardwareCharacteristics{
 		Arch:     &amd64,
@@ -635,61 +517,151 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 //
 // All resources created are tagged with the specified "vmTags", so if
 // this function fails then all resources can be deleted by tag.
-func createVirtualMachine(
-	subscriptionId, resourceGroup, location, vmName string,
+func (env *azureEnviron) createVirtualMachine(
+	vmName string,
 	vmTags, envTags map[string]string,
 	instanceSpec *instances.InstanceSpec,
 	instanceConfig *instancecfg.InstanceConfig,
-	distributionGroupFunc func() ([]instance.Id, error),
-	instancesFunc func([]instance.Id) ([]instance.Instance, error),
-	storageAccount *storage.Account,
-	networkClient network.ManagementClient,
-	vmClient compute.VirtualMachinesClient,
-	availabilitySetClient compute.AvailabilitySetsClient,
-	vmExtensionClient compute.VirtualMachineExtensionsClient,
-	callAPI callAPIFunc,
-) (compute.VirtualMachine, error) {
+	storageAccountType string,
+) error {
 
-	storageProfile, err := newStorageProfile(
-		vmName, instanceSpec, storageAccount,
+	deploymentsClient := resources.DeploymentsClient{env.resources}
+
+	var apiPort int
+	if instanceConfig.Controller != nil {
+		apiPortValue := instanceConfig.Controller.Config.APIPort()
+		apiPort = apiPortValue
+	} else {
+		apiPorts := instanceConfig.APIInfo.Ports()
+		if len(apiPorts) != 1 {
+			return errors.Errorf("expected one API port, found %v", apiPorts)
+		}
+		apiPort = apiPorts[0]
+	}
+	resources := networkTemplateResources(env.location, envTags, apiPort)
+	resources = append(resources, storageAccountTemplateResource(
+		env.location, envTags,
+		env.storageAccountName, storageAccountType,
+	))
+
+	osProfile, seriesOS, err := newOSProfile(
+		vmName, instanceConfig,
+		env.provider.config.RandomWindowsAdminPassword,
 	)
 	if err != nil {
-		return compute.VirtualMachine{}, errors.Annotate(err, "creating storage profile")
+		return errors.Annotate(err, "creating OS profile")
 	}
-
-	osProfile, seriesOS, err := newOSProfile(vmName, instanceConfig)
+	storageProfile, err := newStorageProfile(vmName, env.storageAccountName, instanceSpec)
 	if err != nil {
-		return compute.VirtualMachine{}, errors.Annotate(err, "creating OS profile")
+		return errors.Annotate(err, "creating storage profile")
 	}
 
-	networkProfile, err := newNetworkProfile(
-		callAPI, networkClient,
-		vmName,
-		instanceConfig.Controller != nil,
-		subscriptionId,
-		resourceGroup,
-		location,
-		vmTags,
+	var vmDependsOn []string
+	var availabilitySetSubResource *compute.SubResource
+	availabilitySetName, err := availabilitySetName(
+		vmName, vmTags, instanceConfig.Controller != nil,
 	)
 	if err != nil {
-		return compute.VirtualMachine{}, errors.Annotate(err, "creating network profile")
+		return errors.Annotate(err, "getting availability set name")
+	}
+	if availabilitySetName != "" {
+		availabilitySetId := fmt.Sprintf(
+			`[resourceId('Microsoft.Compute/availabilitySets','%s')]`,
+			availabilitySetName,
+		)
+		resources = append(resources, armtemplates.Resource{
+			APIVersion: compute.APIVersion,
+			Type:       "Microsoft.Compute/availabilitySets",
+			Name:       availabilitySetName,
+			Location:   env.location,
+			Tags:       envTags,
+		})
+		availabilitySetSubResource = &compute.SubResource{
+			ID: to.StringPtr(availabilitySetId),
+		}
+		vmDependsOn = append(vmDependsOn, availabilitySetId)
 	}
 
-	availabilitySetId, err := createAvailabilitySet(
-		callAPI, availabilitySetClient,
-		vmName, resourceGroup, location,
-		vmTags, envTags,
-		distributionGroupFunc, instancesFunc,
+	publicIPAddressName := vmName + "-public-ip"
+	publicIPAddressId := fmt.Sprintf(`[resourceId('Microsoft.Network/publicIPAddresses', '%s')]`, publicIPAddressName)
+	resources = append(resources, armtemplates.Resource{
+		APIVersion: network.APIVersion,
+		Type:       "Microsoft.Network/publicIPAddresses",
+		Name:       publicIPAddressName,
+		Location:   env.location,
+		Tags:       vmTags,
+		Properties: &network.PublicIPAddressPropertiesFormat{
+			PublicIPAllocationMethod: network.Dynamic,
+		},
+	})
+
+	// Controller and non-controller machines are assigned to separate
+	// subnets. This enables us to create controller-specific NSG rules
+	// just by targeting the controller subnet.
+	subnetName := internalSubnetName
+	subnetPrefix := internalSubnetPrefix
+	if instanceConfig.Controller != nil {
+		subnetName = controllerSubnetName
+		subnetPrefix = controllerSubnetPrefix
+	}
+	subnetId := fmt.Sprintf(
+		`[concat(resourceId('Microsoft.Network/virtualNetworks', '%s'), '/subnets/%s')]`,
+		internalNetworkName, subnetName,
 	)
-	if err != nil {
-		return compute.VirtualMachine{}, errors.Annotate(err, "creating availability set")
-	}
 
-	logger.Debugf("- creating virtual machine")
-	vm := compute.VirtualMachine{
-		Location: to.StringPtr(location),
-		Tags:     to.StringMapPtr(vmTags),
-		Name:     to.StringPtr(vmName),
+	privateIP, err := machineSubnetIP(subnetPrefix, instanceConfig.MachineId)
+	if err != nil {
+		return errors.Annotatef(err, "computing private IP address")
+	}
+	nicName := vmName + "-primary"
+	nicId := fmt.Sprintf(`[resourceId('Microsoft.Network/networkInterfaces', '%s')]`, nicName)
+	ipConfigurations := []network.InterfaceIPConfiguration{{
+		Name: to.StringPtr("primary"),
+		Properties: &network.InterfaceIPConfigurationPropertiesFormat{
+			Primary:                   to.BoolPtr(true),
+			PrivateIPAddress:          to.StringPtr(privateIP.String()),
+			PrivateIPAllocationMethod: network.Static,
+			Subnet: &network.Subnet{ID: to.StringPtr(subnetId)},
+			PublicIPAddress: &network.PublicIPAddress{
+				ID: to.StringPtr(publicIPAddressId),
+			},
+		},
+	}}
+	resources = append(resources, armtemplates.Resource{
+		APIVersion: network.APIVersion,
+		Type:       "Microsoft.Network/networkInterfaces",
+		Name:       nicName,
+		Location:   env.location,
+		Tags:       vmTags,
+		Properties: &network.InterfacePropertiesFormat{
+			IPConfigurations: &ipConfigurations,
+		},
+		DependsOn: []string{
+			publicIPAddressId,
+			fmt.Sprintf(
+				`[resourceId('Microsoft.Network/virtualNetworks', '%s')]`,
+				internalNetworkName,
+			),
+		},
+	})
+
+	nics := []compute.NetworkInterfaceReference{{
+		ID: to.StringPtr(nicId),
+		Properties: &compute.NetworkInterfaceReferenceProperties{
+			Primary: to.BoolPtr(true),
+		},
+	}}
+	vmDependsOn = append(vmDependsOn, nicId)
+	vmDependsOn = append(vmDependsOn, fmt.Sprintf(
+		`[resourceId('Microsoft.Storage/storageAccounts', '%s')]`,
+		env.storageAccountName,
+	))
+	resources = append(resources, armtemplates.Resource{
+		APIVersion: compute.APIVersion,
+		Type:       "Microsoft.Compute/virtualMachines",
+		Name:       vmName,
+		Location:   env.location,
+		Tags:       vmTags,
 		Properties: &compute.VirtualMachineProperties{
 			HardwareProfile: &compute.HardwareProfile{
 				VMSize: compute.VirtualMachineSizeTypes(
@@ -698,103 +670,78 @@ func createVirtualMachine(
 			},
 			StorageProfile: storageProfile,
 			OsProfile:      osProfile,
-			NetworkProfile: networkProfile,
-			AvailabilitySet: &compute.SubResource{
-				ID: to.StringPtr(availabilitySetId),
+			NetworkProfile: &compute.NetworkProfile{
+				&nics,
 			},
+			AvailabilitySet: availabilitySetSubResource,
 		},
-	}
-
-	// NOTE(axw) VMs take a long time to go to "Succeeded", so we do not
-	// block waiting for them to be fully provisioned. This means we won't
-	// return an error from StartInstance if the VM fails provisioning;
-	// we will instead report the error via the instance's status.
-	vmClient.Client.ResponseInspector = asyncCreationRespondDecorator(
-		vmClient.Client.ResponseInspector,
-	)
-	if err := callAPI(func() (autorest.Response, error) {
-		return vmClient.CreateOrUpdate(resourceGroup, vmName, vm, nil)
-	}); err != nil {
-		return compute.VirtualMachine{}, errors.Annotate(err, "creating virtual machine")
-	}
+		DependsOn: vmDependsOn,
+	})
 
 	// On Windows and CentOS, we must add the CustomScript VM
 	// extension to run the CustomData script.
 	switch seriesOS {
 	case os.Windows, os.CentOS:
-		vmExtensionClient.Client.ResponseInspector = asyncCreationRespondDecorator(
-			vmExtensionClient.Client.ResponseInspector,
-		)
-		if err := createVMExtension(
-			callAPI, vmExtensionClient, seriesOS,
-			resourceGroup, vmName, location, vmTags,
-		); err != nil {
-			return compute.VirtualMachine{}, errors.Annotate(
+		properties, err := vmExtensionProperties(seriesOS)
+		if err != nil {
+			return errors.Annotate(
 				err, "creating virtual machine extension",
 			)
 		}
+		resources = append(resources, armtemplates.Resource{
+			APIVersion: compute.APIVersion,
+			Type:       "Microsoft.Compute/virtualMachines/extensions",
+			Name:       vmName + "/" + extensionName,
+			Location:   env.location,
+			Tags:       vmTags,
+			Properties: properties,
+			DependsOn:  []string{"Microsoft.Compute/virtualMachines/" + vmName},
+		})
 	}
-	return vm, nil
+
+	logger.Debugf("- creating virtual machine deployment")
+	template := armtemplates.Template{Resources: resources}
+	// NOTE(axw) VMs take a long time to go to "Succeeded", so we do not
+	// block waiting for them to be fully provisioned. This means we won't
+	// return an error from StartInstance if the VM fails provisioning;
+	// we will instead report the error via the instance's status.
+	deploymentsClient.ResponseInspector = asyncCreationRespondDecorator(
+		deploymentsClient.ResponseInspector,
+	)
+	if err := createDeployment(
+		env.callAPI,
+		deploymentsClient,
+		env.resourceGroup,
+		vmName, // deployment name
+		template,
+	); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 // createAvailabilitySet creates the availability set for a machine to use
 // if it doesn't already exist, and returns the availability set's ID. The
 // algorithm used for choosing the availability set is:
-//  - if there is a distribution group, use the same availability set as
-//    the instances in that group. Instances in the group may be in
-//    different availability sets (when multiple services colocated on a
-//    machine), so we pick one arbitrarily
-//  - if there is no distribution group, create an availability name with
-//    a name based on the value of the tags.JujuUnitsDeployed tag in vmTags,
-//    if it exists
-//  - if there are no units assigned to the machine, then use the "juju"
-//    availability set
-func createAvailabilitySet(
-	callAPI callAPIFunc,
-	client compute.AvailabilitySetsClient,
-	vmName, resourceGroup, location string,
-	vmTags, envTags map[string]string,
-	distributionGroupFunc func() ([]instance.Id, error),
-	instancesFunc func([]instance.Id) ([]instance.Instance, error),
+//  - if the machine is a controller, use the availability set name
+//    "juju-controller";
+//  - if the machine has units assigned, create an availability
+//    name with a name based on the value of the tags.JujuUnitsDeployed tag
+//    in vmTags, if it exists;
+//  - otherwise, do not assign the machine to an availability set
+func availabilitySetName(
+	vmName string,
+	vmTags map[string]string,
+	controller bool,
 ) (string, error) {
 	logger.Debugf("selecting availability set for %q", vmName)
-
-	// First we check if there's a distribution group, and if so,
-	// use the availability set of the first instance we find in it.
-	var instanceIds []instance.Id
-	if distributionGroupFunc != nil {
-		var err error
-		instanceIds, err = distributionGroupFunc()
-		if err != nil {
-			return "", errors.Annotate(
-				err, "querying distribution group",
-			)
-		}
-	}
-	instances, err := instancesFunc(instanceIds)
-	switch err {
-	case nil, environs.ErrPartialInstances, environs.ErrNoInstances:
-	default:
-		return "", errors.Annotate(
-			err, "querying distribution group instances",
-		)
-	}
-	for _, instance := range instances {
-		if instance == nil {
-			continue
-		}
-		instance := instance.(*azureInstance)
-		availabilitySetSubResource := instance.Properties.AvailabilitySet
-		if availabilitySetSubResource == nil || availabilitySetSubResource.ID == nil {
-			continue
-		}
-		logger.Debugf("- selecting availability set of %q", instance.Name)
-		return to.String(availabilitySetSubResource.ID), nil
+	if controller {
+		return controllerAvailabilitySet, nil
 	}
 
 	// We'll have to create an availability set. Use the name of one of the
 	// services assigned to the machine.
-	availabilitySetName := "juju"
+	var availabilitySetName string
 	if unitNames, ok := vmTags[tags.JujuUnitsDeployed]; ok {
 		for _, unitName := range strings.Fields(unitNames) {
 			if !names.IsValidUnit(unitName) {
@@ -802,42 +749,21 @@ func createAvailabilitySet(
 			}
 			serviceName, err := names.UnitApplication(unitName)
 			if err != nil {
-				return "", errors.Annotate(
-					err, "getting service name",
-				)
+				return "", errors.Annotate(err, "getting service name")
 			}
 			availabilitySetName = serviceName
 			break
 		}
 	}
-
-	logger.Debugf("- creating availability set %q", availabilitySetName)
-	var availabilitySet compute.AvailabilitySet
-	if err := callAPI(func() (autorest.Response, error) {
-		var err error
-		availabilitySet, err = client.CreateOrUpdate(
-			resourceGroup, availabilitySetName, compute.AvailabilitySet{
-				Location: to.StringPtr(location),
-				// NOTE(axw) we do *not* want to use vmTags here,
-				// because an availability set is shared by machines.
-				Tags: to.StringMapPtr(envTags),
-			},
-		)
-		return availabilitySet.Response, err
-	}); err != nil {
-		return "", errors.Annotatef(
-			err, "creating availability set %q", availabilitySetName,
-		)
-	}
-	return to.String(availabilitySet.ID), nil
+	return availabilitySetName, nil
 }
 
 // newStorageProfile creates the storage profile for a virtual machine,
 // based on the series and chosen instance spec.
 func newStorageProfile(
 	vmName string,
+	storageAccountName string,
 	instanceSpec *instances.InstanceSpec,
-	storageAccount *storage.Account,
 ) (*compute.StorageProfile, error) {
 	logger.Debugf("creating storage profile for %q", vmName)
 
@@ -850,19 +776,22 @@ func newStorageProfile(
 	sku := urnParts[2]
 	version := urnParts[3]
 
-	osDisksRoot := osDiskVhdRoot(storageAccount)
+	osDisksRoot := fmt.Sprintf(
+		`reference(resourceId('Microsoft.Storage/storageAccounts', '%s'), '%s').primaryEndpoints.blob`,
+		storageAccountName, storage.APIVersion,
+	)
 	osDiskName := vmName
+	osDiskURI := fmt.Sprintf(
+		`[concat(%s, '%s/%s%s')]`,
+		osDisksRoot, osDiskVHDContainer, osDiskName, vhdExtension,
+	)
 	osDiskSizeGB := mibToGB(instanceSpec.InstanceType.RootDisk)
 	osDisk := &compute.OSDisk{
 		Name:         to.StringPtr(osDiskName),
 		CreateOption: compute.FromImage,
 		Caching:      compute.ReadWrite,
-		Vhd: &compute.VirtualHardDisk{
-			URI: to.StringPtr(
-				osDisksRoot + osDiskName + vhdExtension,
-			),
-		},
-		DiskSizeGB: to.Int32Ptr(int32(osDiskSizeGB)),
+		Vhd:          &compute.VirtualHardDisk{URI: to.StringPtr(osDiskURI)},
+		DiskSizeGB:   to.Int32Ptr(int32(osDiskSizeGB)),
 	}
 	return &compute.StorageProfile{
 		ImageReference: &compute.ImageReference{
@@ -880,7 +809,11 @@ func mibToGB(mib uint64) uint64 {
 	return uint64(b / (1000 * 1000 * 1000))
 }
 
-func newOSProfile(vmName string, instanceConfig *instancecfg.InstanceConfig) (*compute.OSProfile, os.OSType, error) {
+func newOSProfile(
+	vmName string,
+	instanceConfig *instancecfg.InstanceConfig,
+	randomAdminPassword func() string,
+) (*compute.OSProfile, os.OSType, error) {
 	logger.Debugf("creating OS profile for %q", vmName)
 
 	customData, err := providerinit.ComposeUserData(instanceConfig, nil, AzureRenderer{})
@@ -930,153 +863,194 @@ func newOSProfile(vmName string, instanceConfig *instancecfg.InstanceConfig) (*c
 
 // StopInstances is specified in the InstanceBroker interface.
 func (env *azureEnviron) StopInstances(ids ...instance.Id) error {
-	computeClient := env.compute
-	networkClient := env.network
-
-	// Query the instances, so we can inspect the VirtualMachines
-	// and delete related resources.
-	instances, err := env.Instances(ids)
-	switch err {
-	case environs.ErrNoInstances:
+	if len(ids) == 0 {
 		return nil
-	default:
-		return errors.Trace(err)
-	case nil, environs.ErrPartialInstances:
-		// handled below
-		break
 	}
 
-	storageClient, err := env.getStorageClient()
+	// First up, cancel the deployments. Then we can identify the resources
+	// that need to be deleted without racing with their creation.
+	var wg sync.WaitGroup
+	var existing int
+	cancelResults := make([]error, len(ids))
+	for i, id := range ids {
+		logger.Debugf("canceling deployment for instance %q", id)
+		wg.Add(1)
+		go func(i int, id instance.Id) {
+			defer wg.Done()
+			cancelResults[i] = errors.Annotatef(
+				env.cancelDeployment(string(id)),
+				"canceling deployment %q", id,
+			)
+		}(i, id)
+	}
+	wg.Wait()
+	for _, err := range cancelResults {
+		if err == nil {
+			existing++
+		} else if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	if existing == 0 {
+		// None of the instances exist, so we can stop now.
+		return nil
+	}
+
+	maybeStorageClient, err := env.getStorageClient()
+	if errors.IsNotFound(err) {
+		// It is possible, if unlikely, that the first deployment for a
+		// hosted model will fail or be canceled before the model's
+		// storage account is created. We must therefore cater for the
+		// account being missing or incomplete here.
+		maybeStorageClient = nil
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+
+	// List network interfaces and public IP addresses.
+	instanceNics, err := instanceNetworkInterfaces(
+		env.callAPI, env.resourceGroup,
+		network.InterfacesClient{env.network},
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	instancePips, err := instancePublicIPAddresses(
+		env.callAPI, env.resourceGroup,
+		network.PublicIPAddressesClient{env.network},
+	)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	for _, inst := range instances {
-		if inst == nil {
+	// Delete the deployments, virtual machines, and related resources.
+	deleteResults := make([]error, len(ids))
+	for i, id := range ids {
+		if errors.IsNotFound(cancelResults[i]) {
 			continue
 		}
-		if err := deleteInstance(
-			inst.(*azureInstance),
-			env.callAPI, computeClient, networkClient, storageClient,
-		); err != nil {
-			return errors.Annotatef(err, "deleting instance %q", inst.Id())
+		// The deployment does not exist, so there's nothing more to do.
+		logger.Debugf("deleting instance %q", id)
+		wg.Add(1)
+		go func(i int, id instance.Id) {
+			defer wg.Done()
+			err := env.deleteVirtualMachine(
+				id,
+				maybeStorageClient,
+				instanceNics[id],
+				instancePips[id],
+			)
+			deleteResults[i] = errors.Annotatef(
+				err, "deleting instance %q", id,
+			)
+		}(i, id)
+	}
+	wg.Wait()
+	for _, err := range deleteResults {
+		if err != nil && !errors.IsNotFound(err) {
+			return errors.Trace(err)
 		}
+	}
+
+	return nil
+}
+
+// cancelDeployment cancels a template deployment.
+func (env *azureEnviron) cancelDeployment(name string) error {
+	deploymentsClient := resources.DeploymentsClient{env.resources}
+	logger.Debugf("- canceling deployment %q", name)
+	var cancelResult autorest.Response
+	if err := env.callAPI(func() (autorest.Response, error) {
+		var err error
+		cancelResult, err = deploymentsClient.Cancel(env.resourceGroup, name)
+		return cancelResult, err
+	}); err != nil {
+		if cancelResult.Response != nil {
+			switch cancelResult.StatusCode {
+			case http.StatusNotFound:
+				return errors.NewNotFound(err, fmt.Sprintf("deployment %q not found", name))
+			case http.StatusConflict:
+				if err, ok := azureServiceError(err); ok {
+					if err.Code == serviceErrorCodeDeploymentCannotBeCancelled {
+						// Deployments can only canceled while they're running.
+						return nil
+					}
+				}
+			}
+		}
+		return errors.Annotatef(err, "canceling deployment %q", name)
 	}
 	return nil
 }
 
-// deleteInstances deletes a virtual machine and all of the resources that
+// deleteVirtualMachine deletes a virtual machine and all of the resources that
 // it owns, and any corresponding network security rules.
-func deleteInstance(
-	inst *azureInstance,
-	callAPI callAPIFunc,
-	computeClient compute.ManagementClient,
-	networkClient network.ManagementClient,
-	storageClient internalazurestorage.Client,
+func (env *azureEnviron) deleteVirtualMachine(
+	instId instance.Id,
+	maybeStorageClient internalazurestorage.Client,
+	networkInterfaces []network.Interface,
+	publicIPAddresses []network.PublicIPAddress,
 ) error {
-	vmName := string(inst.Id())
-	vmClient := compute.VirtualMachinesClient{computeClient}
-	nicClient := network.InterfacesClient{networkClient}
-	nsgClient := network.SecurityGroupsClient{networkClient}
-	securityRuleClient := network.SecurityRulesClient{networkClient}
-	publicIPClient := network.PublicIPAddressesClient{networkClient}
-	logger.Debugf("deleting instance %q", vmName)
+	vmClient := compute.VirtualMachinesClient{env.compute}
+	nicClient := network.InterfacesClient{env.network}
+	nsgClient := network.SecurityGroupsClient{env.network}
+	securityRuleClient := network.SecurityRulesClient{env.network}
+	pipClient := network.PublicIPAddressesClient{env.network}
+	deploymentsClient := resources.DeploymentsClient{env.resources}
+	vmName := string(instId)
 
-	logger.Debugf("- deleting virtual machine")
-	var deleteResult autorest.Response
-	if err := callAPI(func() (autorest.Response, error) {
-		var err error
-		deleteResult, err = vmClient.Delete(inst.env.resourceGroup, vmName, nil)
-		return deleteResult, err
-	}); err != nil {
-		if deleteResult.Response == nil || deleteResult.StatusCode != http.StatusNotFound {
+	logger.Debugf("- deleting virtual machine (%s)", vmName)
+	if err := deleteResource(env.callAPI, vmClient, env.resourceGroup, vmName); err != nil {
+		if !errors.IsNotFound(err) {
 			return errors.Annotate(err, "deleting virtual machine")
 		}
 	}
 
-	// Delete the VM's OS disk VHD.
-	logger.Debugf("- deleting OS VHD")
-	blobClient := storageClient.GetBlobService()
-	if _, err := blobClient.DeleteBlobIfExists(osDiskVHDContainer, vmName, nil); err != nil {
-		return errors.Annotate(err, "deleting OS VHD")
+	if maybeStorageClient != nil {
+		logger.Debugf("- deleting OS VHD (%s)", vmName)
+		blobClient := maybeStorageClient.GetBlobService()
+		if _, err := blobClient.DeleteBlobIfExists(osDiskVHDContainer, vmName, nil); err != nil {
+			return errors.Annotate(err, "deleting OS VHD")
+		}
 	}
 
-	// Delete network security rules that refer to the VM.
-	logger.Debugf("- deleting security rules")
+	logger.Debugf("- deleting security rules (%s)", vmName)
 	if err := deleteInstanceNetworkSecurityRules(
-		inst.env.resourceGroup, inst.Id(), nsgClient,
-		securityRuleClient, inst.env.callAPI,
+		env.resourceGroup, instId, nsgClient,
+		securityRuleClient, env.callAPI,
 	); err != nil {
 		return errors.Annotate(err, "deleting network security rules")
 	}
 
-	// Detach public IPs from NICs. This must be done before public
-	// IPs can be deleted. In the future, VMs may not necessarily
-	// have a public IP, so we don't use the presence of a public
-	// IP to indicate the existence of an instance.
-	logger.Debugf("- detaching public IP addresses")
-	for _, nic := range inst.networkInterfaces {
-		if nic.Properties.IPConfigurations == nil {
-			continue
-		}
-		var detached bool
-		for i, ipConfiguration := range *nic.Properties.IPConfigurations {
-			if ipConfiguration.Properties.PublicIPAddress == nil {
-				continue
-			}
-			ipConfiguration.Properties.PublicIPAddress = nil
-			(*nic.Properties.IPConfigurations)[i] = ipConfiguration
-			detached = true
-		}
-		if detached {
-			if err := callAPI(func() (autorest.Response, error) {
-				return nicClient.CreateOrUpdate(
-					inst.env.resourceGroup,
-					to.String(nic.Name), nic,
-					nil, // abort channel
-				)
-			}); err != nil {
-				return errors.Annotate(err, "detaching public IP addresses")
-			}
-		}
-	}
-
-	// Delete public IPs.
-	logger.Debugf("- deleting public IPs")
-	for _, pip := range inst.publicIPAddresses {
-		pipName := to.String(pip.Name)
-		logger.Tracef("deleting public IP %q", pipName)
-		var result autorest.Response
-		if err := callAPI(func() (autorest.Response, error) {
-			var err error
-			result, err = publicIPClient.Delete(inst.env.resourceGroup, pipName, nil)
-			return result, err
-		}); err != nil {
-			if result.Response == nil || result.StatusCode != http.StatusNotFound {
-				return errors.Annotate(err, "deleting public IP")
-			}
-		}
-	}
-
-	// Delete NICs.
-	//
-	// NOTE(axw) this *must* be deleted last, or we risk leaking resources.
-	logger.Debugf("- deleting network interfaces")
-	for _, nic := range inst.networkInterfaces {
+	logger.Debugf("- deleting network interfaces (%s)", vmName)
+	for _, nic := range networkInterfaces {
 		nicName := to.String(nic.Name)
 		logger.Tracef("deleting NIC %q", nicName)
-		var result autorest.Response
-		if err := callAPI(func() (autorest.Response, error) {
-			var err error
-			result, err = nicClient.Delete(inst.env.resourceGroup, nicName, nil)
-			return result, err
-		}); err != nil {
-			if result.Response == nil || result.StatusCode != http.StatusNotFound {
+		if err := deleteResource(env.callAPI, nicClient, env.resourceGroup, nicName); err != nil {
+			if !errors.IsNotFound(err) {
 				return errors.Annotate(err, "deleting NIC")
 			}
 		}
 	}
 
+	logger.Debugf("- deleting public IPs (%s)", vmName)
+	for _, pip := range publicIPAddresses {
+		pipName := to.String(pip.Name)
+		logger.Tracef("deleting public IP %q", pipName)
+		if err := deleteResource(env.callAPI, pipClient, env.resourceGroup, pipName); err != nil {
+			if !errors.IsNotFound(err) {
+				return errors.Annotate(err, "deleting public IP")
+			}
+		}
+	}
+
+	// The deployment must be deleted last, or we risk leaking resources.
+	logger.Debugf("- deleting deployment (%s)", vmName)
+	if err := deleteResource(env.callAPI, deploymentsClient, env.resourceGroup, vmName); err != nil {
+		if !errors.IsNotFound(err) {
+			return errors.Annotate(err, "deleting deployment")
+		}
+	}
 	return nil
 }
 
@@ -1093,7 +1067,7 @@ func (env *azureEnviron) instances(
 	if len(ids) == 0 {
 		return nil, nil
 	}
-	all, err := env.allInstances(resourceGroup, refreshAddresses)
+	all, err := env.allInstances(resourceGroup, refreshAddresses, false)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1121,7 +1095,7 @@ func (env *azureEnviron) instances(
 
 // AllInstances is specified in the InstanceBroker interface.
 func (env *azureEnviron) AllInstances() ([]instance.Instance, error) {
-	return env.allInstances(env.resourceGroup, true /* refresh addresses */)
+	return env.allInstances(env.resourceGroup, true /* refresh addresses */, false /* all instances */)
 }
 
 // allInstances returns all of the instances in the given resource group,
@@ -1129,87 +1103,77 @@ func (env *azureEnviron) AllInstances() ([]instance.Instance, error) {
 func (env *azureEnviron) allInstances(
 	resourceGroup string,
 	refreshAddresses bool,
+	controllerOnly bool,
 ) ([]instance.Instance, error) {
-	vmClient := compute.VirtualMachinesClient{env.compute}
-	nicClient := network.InterfacesClient{env.network}
-	pipClient := network.PublicIPAddressesClient{env.network}
-
-	// Due to how deleting instances works, we have to get creative about
-	// listing instances. We list NICs and return an instance for each
-	// unique value of the jujuMachineNameTag tag.
-	//
-	// The machine provisioner will call AllInstances so it can delete
-	// unknown instances. StopInstances must delete VMs before NICs and
-	// public IPs, because a VM cannot have less than 1 NIC. Thus, we can
-	// potentially delete a VM but then fail to delete its NIC.
-	var nicsResult network.InterfaceListResult
+	deploymentsClient := resources.DeploymentsClient{env.resources}
+	var deploymentsResult resources.DeploymentListResult
 	if err := env.callAPI(func() (autorest.Response, error) {
 		var err error
-		nicsResult, err = nicClient.List(resourceGroup)
-		return nicsResult.Response, err
+		deploymentsResult, err = deploymentsClient.List(resourceGroup, "", nil)
+		return deploymentsResult.Response, err
 	}); err != nil {
-		if nicsResult.Response.Response != nil && nicsResult.StatusCode == http.StatusNotFound {
+		if deploymentsResult.Response.Response != nil && deploymentsResult.StatusCode == http.StatusNotFound {
 			// This will occur if the resource group does not
 			// exist, e.g. in a fresh hosted environment.
 			return nil, nil
 		}
 		return nil, errors.Trace(err)
 	}
-	if nicsResult.Value == nil || len(*nicsResult.Value) == 0 {
+	if deploymentsResult.Value == nil || len(*deploymentsResult.Value) == 0 {
 		return nil, nil
 	}
 
-	// Create an azureInstance for each VM.
-	var result compute.VirtualMachineListResult
-	if err := env.callAPI(func() (autorest.Response, error) {
-		var err error
-		result, err = vmClient.List(resourceGroup)
-		return result.Response, err
-	}); err != nil {
-		return nil, errors.Annotate(err, "listing virtual machines")
-	}
-	vmNames := make(set.Strings)
-	var azureInstances []*azureInstance
-	if result.Value != nil {
-		azureInstances = make([]*azureInstance, len(*result.Value))
-		for i, vm := range *result.Value {
-			inst := &azureInstance{vm, env, nil, nil}
-			azureInstances[i] = inst
-			vmNames.Add(to.String(vm.Name))
-		}
-	}
-
-	// Create additional azureInstances for NICs without machines. See
-	// comments above for rationale. This needs to happen before calling
-	// setInstanceAddresses, so we still associate the NICs/PIPs.
-	for _, nic := range *nicsResult.Value {
-		vmName, ok := toTags(nic.Tags)[jujuMachineNameTag]
-		if !ok || vmNames.Contains(vmName) {
+	azureInstances := make([]*azureInstance, 0, len(*deploymentsResult.Value))
+	for _, deployment := range *deploymentsResult.Value {
+		name := to.String(deployment.Name)
+		if deployment.Properties == nil || deployment.Properties.Dependencies == nil {
 			continue
 		}
-		vm := compute.VirtualMachine{
-			Name: to.StringPtr(vmName),
-			Properties: &compute.VirtualMachineProperties{
-				ProvisioningState: to.StringPtr("Partially Deleted"),
-			},
+		if controllerOnly && !isControllerDeployment(deployment) {
+			continue
 		}
-		inst := &azureInstance{vm, env, nil, nil}
+		provisioningState := to.String(deployment.Properties.ProvisioningState)
+		inst := &azureInstance{name, provisioningState, env, nil, nil}
 		azureInstances = append(azureInstances, inst)
-		vmNames.Add(to.String(vm.Name))
 	}
 
 	if len(azureInstances) > 0 && refreshAddresses {
 		if err := setInstanceAddresses(
-			pipClient, resourceGroup, azureInstances, nicsResult,
+			env.callAPI,
+			resourceGroup,
+			network.InterfacesClient{env.network},
+			network.PublicIPAddressesClient{env.network},
+			azureInstances,
 		); err != nil {
 			return nil, errors.Trace(err)
 		}
 	}
+
 	instances := make([]instance.Instance, len(azureInstances))
 	for i, inst := range azureInstances {
 		instances[i] = inst
 	}
 	return instances, nil
+}
+
+func isControllerDeployment(deployment resources.DeploymentExtended) bool {
+	for _, d := range *deployment.Properties.Dependencies {
+		if d.DependsOn == nil {
+			continue
+		}
+		if to.String(d.ResourceType) != "Microsoft.Compute/virtualMachines" {
+			continue
+		}
+		for _, on := range *d.DependsOn {
+			if to.String(on.ResourceType) != "Microsoft.Compute/availabilitySets" {
+				continue
+			}
+			if to.String(on.ResourceName) == controllerAvailabilitySet {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // Destroy is specified in the Environ interface.
@@ -1434,36 +1398,24 @@ func (env *azureEnviron) getStorageAccountLocked(refresh bool) (*storage.Account
 		return env.storageAccount, nil
 	}
 	client := storage.AccountsClient{env.storage}
-	var result storage.AccountListResult
+	var account storage.Account
 	if err := env.callAPI(func() (autorest.Response, error) {
 		var err error
-		result, err = client.List()
-		return result.Response, err
+		account, err = client.GetProperties(env.resourceGroup, env.storageAccountName)
+		return account.Response, err
 	}); err != nil {
-		return nil, errors.Annotate(err, "listing storage accounts")
-	}
-	if result.Value == nil || len(*result.Value) == 0 {
-		return nil, errors.NotFoundf("storage account")
-	}
-	for _, account := range *result.Value {
-		if toTags(account.Tags)[tags.JujuModel] != env.config.UUID() {
-			continue
+		if account.Response.Response != nil && account.Response.StatusCode == http.StatusNotFound {
+			return nil, errors.NewNotFound(err, fmt.Sprintf("storage account not found"))
 		}
-		env.storageAccount = &account
-		return &account, nil
+		return nil, errors.Annotate(err, "getting storage account")
 	}
-	return nil, errors.NotFoundf("storage account")
+	env.storageAccount = &account
+	return env.storageAccount, nil
 }
 
-// getStorageAccountKey returns a storage account key for this
-// environment's storage account. If refresh is true, any cached
-// key will be refreshed.
-func (env *azureEnviron) getStorageAccountKeys(accountName string, refresh bool) (*storage.AccountKey, error) {
-	env.mu.Lock()
-	defer env.mu.Unlock()
-	return env.getStorageAccountKeyLocked(accountName, refresh)
-}
-
+// getStorageAccountKeysLocked returns a storage account key for this
+// environment's storage account. If refresh is true, any cached key
+// will be refreshed. This method assumes that env.mu is held.
 func (env *azureEnviron) getStorageAccountKeyLocked(accountName string, refresh bool) (*storage.AccountKey, error) {
 	if !refresh && env.storageAccountKey != nil {
 		return env.storageAccountKey, nil

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -24,7 +24,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
-	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
@@ -39,10 +38,60 @@ import (
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/azure"
+	"github.com/juju/juju/provider/azure/internal/armtemplates"
 	"github.com/juju/juju/provider/azure/internal/azuretesting"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 	"github.com/juju/version"
+)
+
+const storageAccountName = "juju400d80004b1d0d06f00d"
+
+var (
+	quantalImageReference = compute.ImageReference{
+		Publisher: to.StringPtr("Canonical"),
+		Offer:     to.StringPtr("UbuntuServer"),
+		Sku:       to.StringPtr("12.10"),
+		Version:   to.StringPtr("latest"),
+	}
+	win2012ImageReference = compute.ImageReference{
+		Publisher: to.StringPtr("MicrosoftWindowsServer"),
+		Offer:     to.StringPtr("WindowsServer"),
+		Sku:       to.StringPtr("2012-Datacenter"),
+		Version:   to.StringPtr("latest"),
+	}
+	centos7ImageReference = compute.ImageReference{
+		Publisher: to.StringPtr("OpenLogic"),
+		Offer:     to.StringPtr("CentOS"),
+		Sku:       to.StringPtr("7.1"),
+		Version:   to.StringPtr("latest"),
+	}
+
+	sshPublicKeys = []compute.SSHPublicKey{{
+		Path:    to.StringPtr("/home/ubuntu/.ssh/authorized_keys"),
+		KeyData: to.StringPtr(testing.FakeAuthKeys),
+	}}
+	linuxOsProfile = compute.OSProfile{
+		ComputerName:  to.StringPtr("machine-0"),
+		CustomData:    to.StringPtr("<juju-goes-here>"),
+		AdminUsername: to.StringPtr("ubuntu"),
+		LinuxConfiguration: &compute.LinuxConfiguration{
+			DisablePasswordAuthentication: to.BoolPtr(true),
+			SSH: &compute.SSHConfiguration{
+				PublicKeys: &sshPublicKeys,
+			},
+		},
+	}
+	windowsOsProfile = compute.OSProfile{
+		ComputerName:  to.StringPtr("machine-0"),
+		CustomData:    to.StringPtr("<juju-goes-here>"),
+		AdminUsername: to.StringPtr("JujuAdministrator"),
+		AdminPassword: to.StringPtr("sorandom"),
+		WindowsConfiguration: &compute.WindowsConfiguration{
+			ProvisionVMAgent:       to.BoolPtr(true),
+			EnableAutomaticUpdates: to.BoolPtr(true),
+		},
+	}
 )
 
 type environSuite struct {
@@ -54,28 +103,16 @@ type environSuite struct {
 	sender        azuretesting.Senders
 	retryClock    mockClock
 
-	controllerUUID                string
-	envTags                       map[string]*string
-	vmTags                        map[string]*string
-	group                         *resources.ResourceGroup
-	vmSizes                       *compute.VirtualMachineSizeListResult
-	storageAccounts               []storage.Account
-	storageNameAvailabilityResult *storage.CheckNameAvailabilityResult
-	storageAccount                *storage.Account
-	storageAccountKeys            *storage.AccountListKeysResult
-	vnet                          *network.VirtualNetwork
-	nsg                           *network.SecurityGroup
-	internalSubnet                *network.Subnet
-	controllerSubnet              *network.Subnet
-	ubuntuServerSKUs              []compute.VirtualMachineImageResource
-	publicIPAddress               *network.PublicIPAddress
-	oldNetworkInterfaces          *network.InterfaceListResult
-	newNetworkInterface           *network.Interface
-	jujuAvailabilitySet           *compute.AvailabilitySet
-	sshPublicKeys                 []compute.SSHPublicKey
-	networkInterfaceReferences    []compute.NetworkInterfaceReference
-	virtualMachine                *compute.VirtualMachine
-	vmExtension                   *compute.VirtualMachineExtension
+	controllerUUID     string
+	envTags            map[string]*string
+	vmTags             map[string]*string
+	group              *resources.ResourceGroup
+	vmSizes            *compute.VirtualMachineSizeListResult
+	storageAccounts    []storage.Account
+	storageAccount     *storage.Account
+	storageAccountKeys *storage.AccountListKeysResult
+	ubuntuServerSKUs   []compute.VirtualMachineImageResource
+	deployment         *resources.Deployment
 }
 
 var _ = gc.Suite(&environSuite{})
@@ -94,6 +131,7 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 		RetryClock: &gitjujutesting.AutoAdvancingClock{
 			&s.retryClock, s.retryClock.Advance,
 		},
+		RandomWindowsAdminPassword: func() string { return "sorandom" },
 	})
 
 	s.controllerUUID = testing.ControllerTag.Id()
@@ -102,7 +140,9 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 		"juju-controller-uuid": to.StringPtr(s.controllerUUID),
 	}
 	s.vmTags = map[string]*string{
-		"juju-machine-name": to.StringPtr("machine-0"),
+		"juju-model-uuid":      to.StringPtr(testing.ModelTag.Id()),
+		"juju-controller-uuid": to.StringPtr(s.controllerUUID),
+		"juju-machine-name":    to.StringPtr("machine-0"),
 	}
 
 	s.group = &resources.ResourceGroup{
@@ -123,17 +163,13 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 	}}
 	s.vmSizes = &compute.VirtualMachineSizeListResult{Value: &vmSizes}
 
-	s.storageNameAvailabilityResult = &storage.CheckNameAvailabilityResult{
-		NameAvailable: to.BoolPtr(true),
-	}
-
 	s.storageAccount = &storage.Account{
 		Name: to.StringPtr("my-storage-account"),
 		Type: to.StringPtr("Standard_LRS"),
 		Tags: &s.envTags,
 		Properties: &storage.AccountProperties{
 			PrimaryEndpoints: &storage.Endpoints{
-				Blob: to.StringPtr(fmt.Sprintf("https://%s.blob.storage.azurestack.local/", fakeStorageAccount)),
+				Blob: to.StringPtr(fmt.Sprintf("https://%s.blob.storage.azurestack.local/", storageAccountName)),
 			},
 			ProvisioningState: "Succeeded",
 		},
@@ -148,54 +184,6 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 		Keys: &keys,
 	}
 
-	addressPrefixes := []string{"192.168.0.0/20", "192.168.16.0/20"}
-	s.vnet = &network.VirtualNetwork{
-		ID:       to.StringPtr("juju-internal-network"),
-		Name:     to.StringPtr("juju-internal-network"),
-		Location: to.StringPtr("westus"),
-		Tags:     &s.envTags,
-		Properties: &network.VirtualNetworkPropertiesFormat{
-			AddressSpace:      &network.AddressSpace{&addressPrefixes},
-			ProvisioningState: to.StringPtr("Succeeded"),
-		},
-	}
-
-	s.nsg = &network.SecurityGroup{
-		ID: to.StringPtr(path.Join(
-			"/subscriptions", fakeSubscriptionId,
-			"resourceGroups", "juju-testenv-model-"+testing.ModelTag.Id(),
-			"providers/Microsoft.Network/networkSecurityGroups/juju-internal-nsg",
-		)),
-		Tags: &s.envTags,
-		Properties: &network.SecurityGroupPropertiesFormat{
-			ProvisioningState: to.StringPtr("Succeeded"),
-		},
-	}
-
-	s.internalSubnet = &network.Subnet{
-		ID:   to.StringPtr("/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/juju-testenv-model-deadbeef-0bad-400d-8000-4b1d0d06f00d/providers/Microsoft.Network/virtualNetworks/juju-internal-network/subnets/juju-internal-subnet"),
-		Name: to.StringPtr("juju-internal-subnet"),
-		Properties: &network.SubnetPropertiesFormat{
-			AddressPrefix: to.StringPtr("192.168.0.0/20"),
-			NetworkSecurityGroup: &network.SecurityGroup{
-				ID: to.StringPtr("/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/juju-testenv-model-deadbeef-0bad-400d-8000-4b1d0d06f00d/providers/Microsoft.Network/networkSecurityGroups/juju-internal-nsg"),
-			},
-			ProvisioningState: to.StringPtr("Succeeded"),
-		},
-	}
-
-	s.controllerSubnet = &network.Subnet{
-		ID:   to.StringPtr("/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/juju-testenv-model-deadbeef-0bad-400d-8000-4b1d0d06f00d/providers/Microsoft.Network/virtualNetworks/juju-internal-network/subnets/juju-controller-subnet"),
-		Name: to.StringPtr("juju-controller-subnet"),
-		Properties: &network.SubnetPropertiesFormat{
-			AddressPrefix: to.StringPtr("192.168.16.0/20"),
-			NetworkSecurityGroup: &network.SecurityGroup{
-				ID: to.StringPtr("/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/juju-testenv-model-deadbeef-0bad-400d-8000-4b1d0d06f00d/providers/Microsoft.Network/networkSecurityGroups/juju-internal-nsg"),
-			},
-			ProvisioningState: to.StringPtr("Succeeded"),
-		},
-	}
-
 	s.ubuntuServerSKUs = []compute.VirtualMachineImageResource{
 		{Name: to.StringPtr("12.04-LTS")},
 		{Name: to.StringPtr("12.10")},
@@ -205,133 +193,7 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 		{Name: to.StringPtr("16.04-LTS")},
 	}
 
-	s.publicIPAddress = &network.PublicIPAddress{
-		ID:       to.StringPtr("/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/juju-testenv-model-deadbeef-0bad-400d-8000-4b1d0d06f00d/providers/Microsoft.Network/publicIPAddresses/machine-0-public-ip"),
-		Name:     to.StringPtr("machine-0-public-ip"),
-		Location: to.StringPtr("westus"),
-		Tags:     &s.vmTags,
-		Properties: &network.PublicIPAddressPropertiesFormat{
-			PublicIPAllocationMethod: network.Dynamic,
-			IPAddress:                to.StringPtr("1.2.3.4"),
-			ProvisioningState:        to.StringPtr("Succeeded"),
-		},
-	}
-
-	// Existing IPs/NICs. These are the results of querying NICs so we
-	// can tell which IP to allocate.
-	oldIPConfigurations := []network.InterfaceIPConfiguration{{
-		ID:   to.StringPtr("ip-configuration-0-id"),
-		Name: to.StringPtr("ip-configuration-0"),
-		Properties: &network.InterfaceIPConfigurationPropertiesFormat{
-			PrivateIPAddress:          to.StringPtr("192.168.0.4"),
-			PrivateIPAllocationMethod: network.Static,
-			Subnet:            s.internalSubnet,
-			ProvisioningState: to.StringPtr("Succeeded"),
-		},
-	}}
-	oldNetworkInterfaces := []network.Interface{{
-		ID:   to.StringPtr("network-interface-0-id"),
-		Name: to.StringPtr("network-interface-0"),
-		Properties: &network.InterfacePropertiesFormat{
-			IPConfigurations:  &oldIPConfigurations,
-			Primary:           to.BoolPtr(true),
-			ProvisioningState: to.StringPtr("Succeeded"),
-		},
-	}}
-	s.oldNetworkInterfaces = &network.InterfaceListResult{
-		Value: &oldNetworkInterfaces,
-	}
-
-	// The newly created IP/NIC.
-	newIPConfigurations := []network.InterfaceIPConfiguration{{
-		ID:   to.StringPtr("ip-configuration-1-id"),
-		Name: to.StringPtr("primary"),
-		Properties: &network.InterfaceIPConfigurationPropertiesFormat{
-			PrivateIPAddress:          to.StringPtr("192.168.0.5"),
-			PrivateIPAllocationMethod: network.Static,
-			Subnet:            s.internalSubnet,
-			PublicIPAddress:   s.publicIPAddress,
-			ProvisioningState: to.StringPtr("Succeeded"),
-		},
-	}}
-	s.newNetworkInterface = &network.Interface{
-		ID:       to.StringPtr("/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/juju-testenv-model-deadbeef-0bad-400d-8000-4b1d0d06f00d/providers/Microsoft.Network/networkInterfaces/machine-0-primary"),
-		Name:     to.StringPtr("network-interface-1"),
-		Location: to.StringPtr("westus"),
-		Tags:     &s.vmTags,
-		Properties: &network.InterfacePropertiesFormat{
-			IPConfigurations:  &newIPConfigurations,
-			ProvisioningState: to.StringPtr("Succeeded"),
-		},
-	}
-
-	s.jujuAvailabilitySet = &compute.AvailabilitySet{
-		ID:       to.StringPtr("juju-availability-set-id"),
-		Name:     to.StringPtr("juju"),
-		Location: to.StringPtr("westus"),
-		Tags:     &s.envTags,
-	}
-
-	s.sshPublicKeys = []compute.SSHPublicKey{{
-		Path:    to.StringPtr("/home/ubuntu/.ssh/authorized_keys"),
-		KeyData: to.StringPtr(testing.FakeAuthKeys),
-	}}
-	s.networkInterfaceReferences = []compute.NetworkInterfaceReference{{
-		ID: s.newNetworkInterface.ID,
-		Properties: &compute.NetworkInterfaceReferenceProperties{
-			Primary: to.BoolPtr(true),
-		},
-	}}
-	s.virtualMachine = &compute.VirtualMachine{
-		ID:       to.StringPtr("machine-0-id"),
-		Name:     to.StringPtr("machine-0"),
-		Location: to.StringPtr("westus"),
-		Tags:     &s.vmTags,
-		Properties: &compute.VirtualMachineProperties{
-			HardwareProfile: &compute.HardwareProfile{
-				VMSize: "Standard_D1",
-			},
-			StorageProfile: &compute.StorageProfile{
-				ImageReference: &compute.ImageReference{
-					Publisher: to.StringPtr("Canonical"),
-					Offer:     to.StringPtr("UbuntuServer"),
-					Sku:       to.StringPtr("12.10"),
-					Version:   to.StringPtr("latest"),
-				},
-				OsDisk: &compute.OSDisk{
-					Name:         to.StringPtr("machine-0"),
-					CreateOption: compute.FromImage,
-					Caching:      compute.ReadWrite,
-					Vhd: &compute.VirtualHardDisk{
-						URI: to.StringPtr(fmt.Sprintf(
-							"https://%s.blob.storage.azurestack.local/osvhds/machine-0.vhd",
-							fakeStorageAccount,
-						)),
-					},
-					// 30 GiB is roughly 32 GB.
-					DiskSizeGB: to.Int32Ptr(32),
-				},
-			},
-			OsProfile: &compute.OSProfile{
-				ComputerName:  to.StringPtr("machine-0"),
-				CustomData:    to.StringPtr("<juju-goes-here>"),
-				AdminUsername: to.StringPtr("ubuntu"),
-				LinuxConfiguration: &compute.LinuxConfiguration{
-					DisablePasswordAuthentication: to.BoolPtr(true),
-					SSH: &compute.SSHConfiguration{
-						PublicKeys: &s.sshPublicKeys,
-					},
-				},
-			},
-			NetworkProfile: &compute.NetworkProfile{
-				NetworkInterfaces: &s.networkInterfaceReferences,
-			},
-			AvailabilitySet:   &compute.SubResource{ID: s.jujuAvailabilitySet.ID},
-			ProvisioningState: to.StringPtr("Succeeded"),
-		},
-	}
-
-	s.vmExtension = nil
+	s.deployment = nil
 }
 
 func (s *environSuite) openEnviron(c *gc.C, attrs ...testing.Attrs) environs.Environ {
@@ -410,46 +272,18 @@ func tokenRefreshSender() *azuretesting.MockSender {
 	return tokenRefreshSender
 }
 
-func (s *environSuite) initResourceGroupSenders(controller bool) azuretesting.Senders {
+func (s *environSuite) initResourceGroupSenders() azuretesting.Senders {
 	resourceGroupName := "juju-testenv-model-deadbeef-0bad-400d-8000-4b1d0d06f00d"
-	senders := azuretesting.Senders{
-		s.makeSender(".*/resourcegroups/"+resourceGroupName, s.group),
-		s.makeSender(".*/virtualNetworks/juju-internal-network", s.vnet),
-		s.makeSender(".*/networkSecurityGroups/juju-internal-nsg", s.nsg),
-		s.makeSender(".*/virtualNetworks/juju-internal-network/subnets/juju-internal-subnet", s.internalSubnet),
-	}
-	if controller {
-		senders = append(senders,
-			s.makeSender(".*/virtualNetworks/juju-internal-network/subnets/juju-controller-subnet", s.controllerSubnet),
-		)
-	}
-	senders = append(senders,
-		s.makeSender(".*/checkNameAvailability", s.storageNameAvailabilityResult),
-		s.makeSender(".*/storageAccounts/.*", s.storageAccount),
-	)
+	senders := azuretesting.Senders{s.makeSender(".*/resourcegroups/"+resourceGroupName, s.group)}
 	return senders
 }
 
 func (s *environSuite) startInstanceSenders(controller bool) azuretesting.Senders {
-	senders := azuretesting.Senders{
-		s.vmSizesSender(),
-		s.storageAccountsSender(),
-	}
+	senders := azuretesting.Senders{s.vmSizesSender()}
 	if s.ubuntuServerSKUs != nil {
 		senders = append(senders, s.makeSender(".*/Canonical/.*/UbuntuServer/skus", s.ubuntuServerSKUs))
 	}
-	senders = append(senders,
-		s.makeSender(".*/publicIPAddresses/machine-0-public-ip", s.publicIPAddress),
-		s.makeSender(".*/networkInterfaces", s.oldNetworkInterfaces),
-		s.makeSender(".*/networkInterfaces/machine-0-primary", s.newNetworkInterface),
-		s.makeSender(".*/availabilitySets/.*", s.jujuAvailabilitySet),
-		s.makeSender(".*/virtualMachines/machine-0", s.virtualMachine),
-	)
-	if s.vmExtension != nil {
-		senders = append(senders, s.makeSender(
-			".*/virtualMachines/machine-0/extensions/JujuCustomScriptExtension", s.vmExtension),
-		)
-	}
+	senders = append(senders, s.makeSender("/deployments/machine-0", s.deployment))
 	return senders
 }
 
@@ -469,9 +303,8 @@ func (s *environSuite) vmSizesSender() *azuretesting.MockSender {
 	return s.makeSender(".*/vmSizes", s.vmSizes)
 }
 
-func (s *environSuite) storageAccountsSender() *azuretesting.MockSender {
-	accounts := []storage.Account{*s.storageAccount}
-	return s.makeSender(".*/storageAccounts", storage.AccountListResult{Value: &accounts})
+func (s *environSuite) storageAccountSender() *azuretesting.MockSender {
+	return s.makeSender(".*/storageAccounts/"+storageAccountName, s.storageAccount)
 }
 
 func (s *environSuite) storageAccountKeysSender() *azuretesting.MockSender {
@@ -487,7 +320,7 @@ func (s *environSuite) makeSender(pattern string, v interface{}) *azuretesting.M
 func makeStartInstanceParams(c *gc.C, controllerUUID, series string) environs.StartInstanceParams {
 	machineTag := names.NewMachineTag("0")
 	apiInfo := &api.Info{
-		Addrs:    []string{"localhost:246"},
+		Addrs:    []string{"localhost:17777"},
 		CACert:   testing.CACert,
 		Password: "admin",
 		Tag:      machineTag,
@@ -500,6 +333,10 @@ func makeStartInstanceParams(c *gc.C, controllerUUID, series string) environs.St
 		series, apiInfo,
 	)
 	c.Assert(err, jc.ErrorIsNil)
+	icfg.Tags = map[string]string{
+		tags.JujuModel:      testing.ModelTag.Id(),
+		tags.JujuController: controllerUUID,
+	}
 
 	return environs.StartInstanceParams{
 		ControllerUUID: controllerUUID,
@@ -585,27 +422,31 @@ func (s *environSuite) TestStartInstance(c *gc.C) {
 		RootDisk: &rootDisk,
 		CpuCores: &cpuCores,
 	})
-	requests := s.assertStartInstanceRequests(c, s.requests)
-	availabilitySetName := path.Base(requests.availabilitySet.URL.Path)
-	c.Assert(availabilitySetName, gc.Equals, "juju")
+	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
+		imageReference: &quantalImageReference,
+		diskSizeGB:     32,
+		osProfile:      &linuxOsProfile,
+	})
 }
 
 func (s *environSuite) TestStartInstanceWindowsMinRootDisk(c *gc.C) {
 	// The minimum OS disk size for Windows machines is 127GiB.
 	cons := constraints.MustParse("root-disk=44G")
-	s.testStartInstanceWindowsRootDisk(c, cons, 127*1024)
+	s.testStartInstanceWindows(c, cons, 127*1024, 136)
 }
 
 func (s *environSuite) TestStartInstanceWindowsGrowableRootDisk(c *gc.C) {
 	// The OS disk size may be grown larger than 127GiB.
 	cons := constraints.MustParse("root-disk=200G")
-	s.testStartInstanceWindowsRootDisk(c, cons, 200*1024)
+	s.testStartInstanceWindows(c, cons, 200*1024, 214)
 }
 
-func (s *environSuite) testStartInstanceWindowsRootDisk(c *gc.C, cons constraints.Value, expect uint64) {
+func (s *environSuite) testStartInstanceWindows(
+	c *gc.C, cons constraints.Value,
+	expect uint64, requestValue int,
+) {
 	// Starting a Windows VM, we should not expect an image query.
 	s.PatchValue(&s.ubuntuServerSKUs, nil)
-	s.PatchValue(&s.vmExtension, &compute.VirtualMachineExtension{})
 
 	env := s.openEnviron(c)
 	s.sender = s.startInstanceSenders(false)
@@ -616,6 +457,53 @@ func (s *environSuite) testStartInstanceWindowsRootDisk(c *gc.C, cons constraint
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.NotNil)
 	c.Assert(result.Hardware.RootDisk, jc.DeepEquals, &expect)
+
+	vmExtensionSettings := map[string]interface{}{
+		"commandToExecute": `` +
+			`move C:\AzureData\CustomData.bin C:\AzureData\CustomData.ps1 && ` +
+			`powershell.exe -ExecutionPolicy Unrestricted -File C:\AzureData\CustomData.ps1 && ` +
+			`del /q C:\AzureData\CustomData.ps1`,
+	}
+	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
+		imageReference: &win2012ImageReference,
+		diskSizeGB:     requestValue,
+		vmExtension: &compute.VirtualMachineExtensionProperties{
+			Publisher:               to.StringPtr("Microsoft.Compute"),
+			Type:                    to.StringPtr("CustomScriptExtension"),
+			TypeHandlerVersion:      to.StringPtr("1.4"),
+			AutoUpgradeMinorVersion: to.BoolPtr(true),
+			Settings:                &vmExtensionSettings,
+		},
+		osProfile: &windowsOsProfile,
+	})
+}
+
+func (s *environSuite) TestStartInstanceCentOS(c *gc.C) {
+	// Starting a CentOS VM, we should not expect an image query.
+	s.PatchValue(&s.ubuntuServerSKUs, nil)
+
+	env := s.openEnviron(c)
+	s.sender = s.startInstanceSenders(false)
+	s.requests = nil
+	args := makeStartInstanceParams(c, s.controllerUUID, "centos7")
+	_, err := env.StartInstance(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	vmExtensionSettings := map[string]interface{}{
+		"commandToExecute": `bash -c 'base64 -d /var/lib/waagent/CustomData | bash'`,
+	}
+	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
+		imageReference: &centos7ImageReference,
+		diskSizeGB:     32,
+		vmExtension: &compute.VirtualMachineExtensionProperties{
+			Publisher:               to.StringPtr("Microsoft.OSTCExtensions"),
+			Type:                    to.StringPtr("CustomScriptForLinux"),
+			TypeHandlerVersion:      to.StringPtr("1.4"),
+			AutoUpgradeMinorVersion: to.BoolPtr(true),
+			Settings:                &vmExtensionSettings,
+		},
+		osProfile: &linuxOsProfile,
+	})
 }
 
 func (s *environSuite) TestStartInstanceTooManyRequests(c *gc.C) {
@@ -646,7 +534,11 @@ func (s *environSuite) TestStartInstanceTooManyRequests(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(s.requests, gc.HasLen, numExpectedStartInstanceRequests+failures)
-	s.assertStartInstanceRequests(c, s.requests[:numExpectedStartInstanceRequests])
+	s.assertStartInstanceRequests(c, s.requests[:numExpectedStartInstanceRequests], assertStartInstanceRequestsParams{
+		imageReference: &quantalImageReference,
+		diskSizeGB:     32,
+		osProfile:      &linuxOsProfile,
+	})
 
 	// The final requests should all be identical.
 	for i := numExpectedStartInstanceRequests; i < numExpectedStartInstanceRequests+failures; i++ {
@@ -689,7 +581,7 @@ func (s *environSuite) TestStartInstanceTooManyRequestsTimeout(c *gc.C) {
 	s.sender = senders
 
 	_, err := env.StartInstance(makeStartInstanceParams(c, s.controllerUUID, "quantal"))
-	c.Assert(err, gc.ErrorMatches, `creating virtual machine "machine-0": creating virtual machine: max duration exceeded: .*`)
+	c.Assert(err, gc.ErrorMatches, `creating virtual machine "machine-0": creating deployment "machine-0": max duration exceeded: .*`)
 
 	s.retryClock.CheckCalls(c, []gitjujutesting.StubCall{
 		{"After", []interface{}{5 * time.Second}},  // t0 + 5s
@@ -719,184 +611,30 @@ func (s *environSuite) TestStartInstanceServiceAvailabilitySet(c *gc.C) {
 
 	_, err := env.StartInstance(params)
 	c.Assert(err, jc.ErrorIsNil)
-	requests := s.assertStartInstanceRequests(c, s.requests)
-	availabilitySetName := path.Base(requests.availabilitySet.URL.Path)
-	c.Assert(availabilitySetName, gc.Equals, "mysql")
+	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
+		availabilitySetName: "mysql",
+		imageReference:      &quantalImageReference,
+		diskSizeGB:          32,
+		osProfile:           &linuxOsProfile,
+	})
 }
 
-const numExpectedStartInstanceRequests = 8
+const numExpectedStartInstanceRequests = 3
 
-func (s *environSuite) assertStartInstanceRequests(c *gc.C, requests []*http.Request) startInstanceRequests {
-	// The values defined here are the *request* values. They lack IDs,
-	// Names (in most places), and ProvisioningStates. The values defined
-	// on the suite are the *response* values; they are supersets of the
-	// request values.
-
-	publicIPAddress := &network.PublicIPAddress{
-		Location: to.StringPtr("westus"),
-		Tags:     &s.vmTags,
-		Properties: &network.PublicIPAddressPropertiesFormat{
-			PublicIPAllocationMethod: network.Dynamic,
-		},
-	}
-	newIPConfigurations := []network.InterfaceIPConfiguration{{
-		Name: to.StringPtr("primary"),
-		Properties: &network.InterfaceIPConfigurationPropertiesFormat{
-			Primary:                   to.BoolPtr(true),
-			PrivateIPAddress:          to.StringPtr("192.168.0.5"),
-			PrivateIPAllocationMethod: network.Static,
-			Subnet: &network.Subnet{
-				ID: s.internalSubnet.ID,
-			},
-			PublicIPAddress: &network.PublicIPAddress{
-				ID: s.publicIPAddress.ID,
-			},
-		},
-	}}
-	newNetworkInterface := &network.Interface{
-		Location: to.StringPtr("westus"),
-		Tags:     &s.vmTags,
-		Properties: &network.InterfacePropertiesFormat{
-			IPConfigurations: &newIPConfigurations,
-		},
-	}
-	jujuAvailabilitySet := &compute.AvailabilitySet{
-		Location: to.StringPtr("westus"),
-		Tags:     &s.envTags,
-	}
-	virtualMachine := &compute.VirtualMachine{
-		Name:     to.StringPtr("machine-0"),
-		Location: to.StringPtr("westus"),
-		Tags:     &s.vmTags,
-		Properties: &compute.VirtualMachineProperties{
-			HardwareProfile: &compute.HardwareProfile{
-				VMSize: "Standard_D1",
-			},
-			StorageProfile: &compute.StorageProfile{
-				ImageReference: &compute.ImageReference{
-					Publisher: to.StringPtr("Canonical"),
-					Offer:     to.StringPtr("UbuntuServer"),
-					Sku:       to.StringPtr("12.10"),
-					Version:   to.StringPtr("latest"),
-				},
-				OsDisk: &compute.OSDisk{
-					Name:         to.StringPtr("machine-0"),
-					CreateOption: compute.FromImage,
-					Caching:      compute.ReadWrite,
-					Vhd: &compute.VirtualHardDisk{
-						URI: to.StringPtr(fmt.Sprintf(
-							"https://%s.blob.storage.azurestack.local/osvhds/machine-0.vhd",
-							fakeStorageAccount,
-						)),
-					},
-					// 30 GiB is roughly 32 GB.
-					DiskSizeGB: to.Int32Ptr(32),
-				},
-			},
-			OsProfile: &compute.OSProfile{
-				ComputerName:  to.StringPtr("machine-0"),
-				CustomData:    to.StringPtr("<juju-goes-here>"),
-				AdminUsername: to.StringPtr("ubuntu"),
-				LinuxConfiguration: &compute.LinuxConfiguration{
-					DisablePasswordAuthentication: to.BoolPtr(true),
-					SSH: &compute.SSHConfiguration{
-						PublicKeys: &s.sshPublicKeys,
-					},
-				},
-			},
-			NetworkProfile: &compute.NetworkProfile{
-				NetworkInterfaces: &s.networkInterfaceReferences,
-			},
-			AvailabilitySet: &compute.SubResource{ID: s.jujuAvailabilitySet.ID},
-		},
-	}
-
-	// Validate HTTP request bodies.
-	c.Assert(requests, gc.HasLen, numExpectedStartInstanceRequests)
-	c.Assert(requests[0].Method, gc.Equals, "GET") // vmSizes
-	c.Assert(requests[1].Method, gc.Equals, "GET") // storage accounts
-	c.Assert(requests[2].Method, gc.Equals, "GET") // skus
-	c.Assert(requests[3].Method, gc.Equals, "PUT")
-	assertRequestBody(c, requests[3], publicIPAddress)
-	c.Assert(requests[4].Method, gc.Equals, "GET") // list NICs (to choose private IP address)
-	c.Assert(requests[5].Method, gc.Equals, "PUT") // create NIC
-	assertRequestBody(c, requests[5], newNetworkInterface)
-	c.Assert(requests[6].Method, gc.Equals, "PUT") // create availability set
-	assertRequestBody(c, requests[6], jujuAvailabilitySet)
-	c.Assert(requests[7].Method, gc.Equals, "PUT") // create VM
-	assertCreateVirtualMachineRequestBody(c, requests[7], virtualMachine)
-
-	return startInstanceRequests{
-		vmSizes:          requests[0],
-		storageAccounts:  requests[1],
-		skus:             requests[2],
-		publicIPAddress:  requests[3],
-		nics:             requests[4],
-		networkInterface: requests[5],
-		availabilitySet:  requests[6],
-		virtualMachine:   requests[7],
-	}
+type assertStartInstanceRequestsParams struct {
+	availabilitySetName string
+	imageReference      *compute.ImageReference
+	vmExtension         *compute.VirtualMachineExtensionProperties
+	diskSizeGB          int
+	osProfile           *compute.OSProfile
 }
 
-func assertCreateVirtualMachineRequestBody(c *gc.C, req *http.Request, expect *compute.VirtualMachine) {
-	// CustomData is non-deterministic, so don't compare it.
-	// TODO(axw) shouldn't CustomData be deterministic? Look into this.
-	var virtualMachine compute.VirtualMachine
-	unmarshalRequestBody(c, req, &virtualMachine)
-	c.Assert(to.String(virtualMachine.Properties.OsProfile.CustomData), gc.Not(gc.HasLen), 0)
-	virtualMachine.Properties.OsProfile.CustomData = to.StringPtr("<juju-goes-here>")
-	c.Assert(&virtualMachine, jc.DeepEquals, expect)
-}
-
-type startInstanceRequests struct {
-	vmSizes          *http.Request
-	storageAccounts  *http.Request
-	subnet           *http.Request
-	skus             *http.Request
-	publicIPAddress  *http.Request
-	nics             *http.Request
-	networkInterface *http.Request
-	availabilitySet  *http.Request
-	virtualMachine   *http.Request
-}
-
-func (s *environSuite) TestBootstrap(c *gc.C) {
-	defer envtesting.DisableFinishBootstrap()()
-
-	ctx := envtesting.BootstrapContext(c)
-	env := prepareForBootstrap(c, ctx, s.provider, &s.sender)
-
-	s.sender = s.initResourceGroupSenders(true)
-	s.sender = append(s.sender, s.startInstanceSenders(true)...)
-	s.requests = nil
-	result, err := env.Bootstrap(
-		ctx, environs.BootstrapParams{
-			ControllerConfig: testing.FakeControllerConfig(),
-			AvailableTools:   makeToolsList(series.LatestLts()),
-		},
-	)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Arch, gc.Equals, "amd64")
-	c.Assert(result.Series, gc.Equals, series.LatestLts())
-
-	c.Assert(len(s.requests), gc.Equals, 15)
-
-	c.Assert(s.requests[0].Method, gc.Equals, "PUT")  // resource group
-	c.Assert(s.requests[1].Method, gc.Equals, "PUT")  // create vnet
-	c.Assert(s.requests[2].Method, gc.Equals, "PUT")  // create network security group
-	c.Assert(s.requests[3].Method, gc.Equals, "PUT")  // create subnet (internal)
-	c.Assert(s.requests[4].Method, gc.Equals, "PUT")  // create subnet (controller)
-	c.Assert(s.requests[5].Method, gc.Equals, "POST") // check storage account name
-	c.Assert(s.requests[6].Method, gc.Equals, "PUT")  // create storage account
-
-	s.group.Properties = nil
-	assertRequestBody(c, s.requests[0], &s.group)
-
-	s.vnet.ID = nil
-	s.vnet.Name = nil
-	s.vnet.Properties.ProvisioningState = nil
-	assertRequestBody(c, s.requests[1], s.vnet)
-
+func (s *environSuite) assertStartInstanceRequests(
+	c *gc.C,
+	requests []*http.Request,
+	args assertStartInstanceRequestsParams,
+) startInstanceRequests {
+	nsgId := `[resourceId('Microsoft.Network/networkSecurityGroups', 'juju-internal-nsg')]`
 	securityRules := []network.SecurityRule{{
 		Name: to.StringPtr("SSHInbound"),
 		Properties: &network.SecurityRulePropertiesFormat{
@@ -924,34 +662,272 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 			Direction:                network.Inbound,
 		},
 	}}
-	assertRequestBody(c, s.requests[2], &network.SecurityGroup{
-		Location: to.StringPtr("westus"),
-		Tags:     s.nsg.Tags,
+	subnets := []network.Subnet{{
+		Name: to.StringPtr("juju-internal-subnet"),
+		Properties: &network.SubnetPropertiesFormat{
+			AddressPrefix: to.StringPtr("192.168.0.0/20"),
+			NetworkSecurityGroup: &network.SecurityGroup{
+				ID: to.StringPtr(nsgId),
+			},
+		},
+	}, {
+		Name: to.StringPtr("juju-controller-subnet"),
+		Properties: &network.SubnetPropertiesFormat{
+			AddressPrefix: to.StringPtr("192.168.16.0/20"),
+			NetworkSecurityGroup: &network.SecurityGroup{
+				ID: to.StringPtr(nsgId),
+			},
+		},
+	}}
+
+	subnetName := "juju-internal-subnet"
+	privateIPAddress := "192.168.0.4"
+	if args.availabilitySetName == "juju-controller" {
+		subnetName = "juju-controller-subnet"
+		privateIPAddress = "192.168.16.4"
+	}
+	subnetId := fmt.Sprintf(
+		`[concat(resourceId('Microsoft.Network/virtualNetworks', 'juju-internal-network'), '/subnets/%s')]`,
+		subnetName,
+	)
+
+	publicIPAddressId := `[resourceId('Microsoft.Network/publicIPAddresses', 'machine-0-public-ip')]`
+
+	ipConfigurations := []network.InterfaceIPConfiguration{{
+		Name: to.StringPtr("primary"),
+		Properties: &network.InterfaceIPConfigurationPropertiesFormat{
+			Primary:                   to.BoolPtr(true),
+			PrivateIPAddress:          to.StringPtr(privateIPAddress),
+			PrivateIPAllocationMethod: network.Static,
+			Subnet: &network.Subnet{ID: to.StringPtr(subnetId)},
+			PublicIPAddress: &network.PublicIPAddress{
+				ID: to.StringPtr(publicIPAddressId),
+			},
+		},
+	}}
+
+	nicId := `[resourceId('Microsoft.Network/networkInterfaces', 'machine-0-primary')]`
+	nics := []compute.NetworkInterfaceReference{{
+		ID: to.StringPtr(nicId),
+		Properties: &compute.NetworkInterfaceReferenceProperties{
+			Primary: to.BoolPtr(true),
+		},
+	}}
+	vmDependsOn := []string{
+		nicId,
+		`[resourceId('Microsoft.Storage/storageAccounts', '` + storageAccountName + `')]`,
+	}
+
+	addressPrefixes := []string{"192.168.0.0/20", "192.168.16.0/20"}
+	templateResources := []armtemplates.Resource{{
+		APIVersion: network.APIVersion,
+		Type:       "Microsoft.Network/networkSecurityGroups",
+		Name:       "juju-internal-nsg",
+		Location:   "westus",
+		Tags:       to.StringMap(s.envTags),
 		Properties: &network.SecurityGroupPropertiesFormat{
 			SecurityRules: &securityRules,
 		},
-	})
-
-	s.internalSubnet.ID = nil
-	s.internalSubnet.Name = nil
-	s.internalSubnet.Properties.ProvisioningState = nil
-	assertRequestBody(c, s.requests[3], s.internalSubnet)
-	s.controllerSubnet.ID = nil
-	s.controllerSubnet.Name = nil
-	s.controllerSubnet.Properties.ProvisioningState = nil
-	assertRequestBody(c, s.requests[4], s.controllerSubnet)
-
-	assertRequestBody(c, s.requests[5], &storage.AccountCheckNameAvailabilityParameters{
-		Name: to.StringPtr(fakeStorageAccount),
-		Type: to.StringPtr("Microsoft.Storage/storageAccounts"),
-	})
-
-	assertRequestBody(c, s.requests[6], &storage.AccountCreateParameters{
-		Location: to.StringPtr("westus"),
-		Tags:     s.storageAccount.Tags,
-		Sku: &storage.Sku{
-			Name: storage.StandardLRS,
+	}, {
+		APIVersion: network.APIVersion,
+		Type:       "Microsoft.Network/virtualNetworks",
+		Name:       "juju-internal-network",
+		Location:   "westus",
+		Tags:       to.StringMap(s.envTags),
+		Properties: &network.VirtualNetworkPropertiesFormat{
+			AddressSpace: &network.AddressSpace{&addressPrefixes},
+			Subnets:      &subnets,
 		},
+		DependsOn: []string{nsgId},
+	}, {
+		APIVersion: storage.APIVersion,
+		Type:       "Microsoft.Storage/storageAccounts",
+		Name:       storageAccountName,
+		Location:   "westus",
+		Tags:       to.StringMap(s.envTags),
+		StorageSku: &storage.Sku{
+			Name: storage.SkuName("Standard_LRS"),
+		},
+	}}
+
+	var availabilitySetSubResource *compute.SubResource
+	if args.availabilitySetName != "" {
+		availabilitySetId := fmt.Sprintf(
+			`[resourceId('Microsoft.Compute/availabilitySets','%s')]`,
+			args.availabilitySetName,
+		)
+		templateResources = append(templateResources, armtemplates.Resource{
+			APIVersion: compute.APIVersion,
+			Type:       "Microsoft.Compute/availabilitySets",
+			Name:       args.availabilitySetName,
+			Location:   "westus",
+			Tags:       to.StringMap(s.envTags),
+		})
+		availabilitySetSubResource = &compute.SubResource{
+			ID: to.StringPtr(availabilitySetId),
+		}
+		vmDependsOn = append([]string{availabilitySetId}, vmDependsOn...)
+	}
+
+	templateResources = append(templateResources, []armtemplates.Resource{{
+		APIVersion: network.APIVersion,
+		Type:       "Microsoft.Network/publicIPAddresses",
+		Name:       "machine-0-public-ip",
+		Location:   "westus",
+		Tags:       to.StringMap(s.vmTags),
+		Properties: &network.PublicIPAddressPropertiesFormat{
+			PublicIPAllocationMethod: network.Dynamic,
+		},
+	}, {
+		APIVersion: network.APIVersion,
+		Type:       "Microsoft.Network/networkInterfaces",
+		Name:       "machine-0-primary",
+		Location:   "westus",
+		Tags:       to.StringMap(s.vmTags),
+		Properties: &network.InterfacePropertiesFormat{
+			IPConfigurations: &ipConfigurations,
+		},
+		DependsOn: []string{
+			publicIPAddressId,
+			`[resourceId('Microsoft.Network/virtualNetworks', 'juju-internal-network')]`,
+		},
+	}, {
+		APIVersion: compute.APIVersion,
+		Type:       "Microsoft.Compute/virtualMachines",
+		Name:       "machine-0",
+		Location:   "westus",
+		Tags:       to.StringMap(s.vmTags),
+		Properties: &compute.VirtualMachineProperties{
+			HardwareProfile: &compute.HardwareProfile{
+				VMSize: "Standard_D1",
+			},
+			StorageProfile: &compute.StorageProfile{
+				ImageReference: args.imageReference,
+				OsDisk: &compute.OSDisk{
+					Name:         to.StringPtr("machine-0"),
+					CreateOption: compute.FromImage,
+					Caching:      compute.ReadWrite,
+					Vhd: &compute.VirtualHardDisk{
+						URI: to.StringPtr(fmt.Sprintf(
+							`[concat(reference(resourceId('Microsoft.Storage/storageAccounts', '%s'), '%s').primaryEndpoints.blob, 'osvhds/machine-0.vhd')]`,
+							storageAccountName, storage.APIVersion,
+						)),
+					},
+					DiskSizeGB: to.Int32Ptr(int32(args.diskSizeGB)),
+				},
+			},
+			OsProfile:       args.osProfile,
+			NetworkProfile:  &compute.NetworkProfile{&nics},
+			AvailabilitySet: availabilitySetSubResource,
+		},
+		DependsOn: vmDependsOn,
+	}}...)
+	if args.vmExtension != nil {
+		templateResources = append(templateResources, armtemplates.Resource{
+			APIVersion: compute.APIVersion,
+			Type:       "Microsoft.Compute/virtualMachines/extensions",
+			Name:       "machine-0/JujuCustomScriptExtension",
+			Location:   "westus",
+			Tags:       to.StringMap(s.vmTags),
+			Properties: args.vmExtension,
+			DependsOn:  []string{"Microsoft.Compute/virtualMachines/machine-0"},
+		})
+	}
+	templateMap := map[string]interface{}{
+		"$schema":        "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+		"contentVersion": "1.0.0.0",
+		"resources":      templateResources,
+	}
+	deployment := &resources.Deployment{
+		&resources.DeploymentProperties{
+			Template: &templateMap,
+			Mode:     resources.Incremental,
+		},
+	}
+
+	// Validate HTTP request bodies.
+	var startInstanceRequests startInstanceRequests
+	if args.vmExtension != nil {
+		// It must be Windows or CentOS, so
+		// there should be no image query.
+		c.Assert(requests, gc.HasLen, numExpectedStartInstanceRequests-1)
+		c.Assert(requests[0].Method, gc.Equals, "GET") // vmSizes
+		c.Assert(requests[1].Method, gc.Equals, "PUT") // create deployment
+		startInstanceRequests.vmSizes = requests[0]
+		startInstanceRequests.deployment = requests[1]
+	} else {
+		c.Assert(requests, gc.HasLen, numExpectedStartInstanceRequests)
+		c.Assert(requests[0].Method, gc.Equals, "GET") // vmSizes
+		c.Assert(requests[1].Method, gc.Equals, "GET") // skus
+		c.Assert(requests[2].Method, gc.Equals, "PUT") // create deployment
+		startInstanceRequests.vmSizes = requests[0]
+		startInstanceRequests.skus = requests[1]
+		startInstanceRequests.deployment = requests[2]
+	}
+
+	// Marshal/unmarshal the deployment we expect, so it's in map form.
+	var expected resources.Deployment
+	data, err := json.Marshal(&deployment)
+	c.Assert(err, jc.ErrorIsNil)
+	err = json.Unmarshal(data, &expected)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check that we send what we expect. CustomData is non-deterministic,
+	// so don't compare it.
+	// TODO(axw) shouldn't CustomData be deterministic? Look into this.
+	var actual resources.Deployment
+	unmarshalRequestBody(c, startInstanceRequests.deployment, &actual)
+	c.Assert(actual.Properties, gc.NotNil)
+	c.Assert(actual.Properties.Template, gc.NotNil)
+	resources := (*actual.Properties.Template)["resources"].([]interface{})
+	c.Assert(resources, gc.HasLen, len(templateResources))
+
+	vmResourceIndex := len(resources) - 1
+	if args.vmExtension != nil {
+		vmResourceIndex--
+	}
+	vmResource := resources[vmResourceIndex].(map[string]interface{})
+	vmResourceProperties := vmResource["properties"].(map[string]interface{})
+	osProfile := vmResourceProperties["osProfile"].(map[string]interface{})
+	osProfile["customData"] = "<juju-goes-here>"
+	c.Assert(actual, jc.DeepEquals, expected)
+
+	return startInstanceRequests
+}
+
+type startInstanceRequests struct {
+	vmSizes    *http.Request
+	skus       *http.Request
+	deployment *http.Request
+}
+
+func (s *environSuite) TestBootstrap(c *gc.C) {
+	defer envtesting.DisableFinishBootstrap()()
+
+	ctx := envtesting.BootstrapContext(c)
+	env := prepareForBootstrap(c, ctx, s.provider, &s.sender)
+
+	s.sender = s.initResourceGroupSenders()
+	s.sender = append(s.sender, s.startInstanceSenders(true)...)
+	s.requests = nil
+	result, err := env.Bootstrap(
+		ctx, environs.BootstrapParams{
+			ControllerConfig: testing.FakeControllerConfig(),
+			AvailableTools:   makeToolsList("quantal"),
+			BootstrapSeries:  "quantal",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Arch, gc.Equals, "amd64")
+	c.Assert(result.Series, gc.Equals, "quantal")
+
+	c.Assert(len(s.requests), gc.Equals, numExpectedStartInstanceRequests+1)
+	s.vmTags[tags.JujuIsController] = to.StringPtr("true")
+	s.assertStartInstanceRequests(c, s.requests[1:], assertStartInstanceRequestsParams{
+		availabilitySetName: "juju-controller",
+		imageReference:      &quantalImageReference,
+		diskSizeGB:          32,
+		osProfile:           &linuxOsProfile,
 	})
 }
 
@@ -969,10 +945,10 @@ func (s *environSuite) TestAllInstancesResourceGroupNotFound(c *gc.C) {
 func (s *environSuite) TestStopInstancesNotFound(c *gc.C) {
 	env := s.openEnviron(c)
 	sender := mocks.NewSender()
-	sender.AppendResponse(mocks.NewResponseWithStatus(
+	sender.AppendAndRepeatResponse(mocks.NewResponseWithStatus(
 		"vm not found", http.StatusNotFound,
-	))
-	s.sender = azuretesting.Senders{sender, sender, sender}
+	), 2)
+	s.sender = azuretesting.Senders{sender, sender}
 	err := env.StopInstances("a", "b")
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -980,8 +956,7 @@ func (s *environSuite) TestStopInstancesNotFound(c *gc.C) {
 func (s *environSuite) TestStopInstances(c *gc.C) {
 	env := s.openEnviron(c)
 
-	// Security group has rules for machine-0 but not machine-1, and
-	// has a rule that doesn't match either.
+	// Security group has rules for machine-0, as well as a rule that doesn't match.
 	nsg := makeSecurityGroup(
 		makeSecurityRule("machine-0-80", "192.168.0.4", "80"),
 		makeSecurityRule("machine-0-1000-2000", "192.168.0.4", "1000-2000"),
@@ -995,66 +970,116 @@ func (s *environSuite) TestStopInstances(c *gc.C) {
 	nic0 := makeNetworkInterface("nic-0", "machine-0", nic0IPConfiguration)
 
 	s.sender = azuretesting.Senders{
-		s.networkInterfacesSender(
-			nic0,
-			makeNetworkInterface("nic-1", "machine-1"),
-			makeNetworkInterface("nic-2", "machine-1"),
-		),
-		s.virtualMachinesSender(makeVirtualMachine("machine-0")),
-		s.publicIPAddressesSender(
-			makePublicIPAddress("pip-0", "machine-0", "1.2.3.4"),
-		),
-		s.storageAccountsSender(),
+		s.makeSender(".*/deployments/machine-0/cancel", nil), // POST
+		s.storageAccountSender(),
 		s.storageAccountKeysSender(),
+		s.networkInterfacesSender(nic0),
+		s.publicIPAddressesSender(makePublicIPAddress("pip-0", "machine-0", "1.2.3.4")),
 		s.makeSender(".*/virtualMachines/machine-0", nil),                                                 // DELETE
 		s.makeSender(".*/networkSecurityGroups/juju-internal-nsg", nsg),                                   // GET
 		s.makeSender(".*/networkSecurityGroups/juju-internal-nsg/securityRules/machine-0-80", nil),        // DELETE
 		s.makeSender(".*/networkSecurityGroups/juju-internal-nsg/securityRules/machine-0-1000-2000", nil), // DELETE
-		s.makeSender(".*/networkInterfaces/nic-0", nic0),                                                  // PUT
-		s.makeSender(".*/publicIPAddresses/pip-0", nil),                                                   // DELETE
 		s.makeSender(".*/networkInterfaces/nic-0", nil),                                                   // DELETE
-		s.makeSender(".*/virtualMachines/machine-1", nil),                                                 // DELETE
-		s.makeSender(".*/networkSecurityGroups/juju-internal-nsg", nsg),                                   // GET
-		s.makeSender(".*/networkInterfaces/nic-1", nil),                                                   // DELETE
-		s.makeSender(".*/networkInterfaces/nic-2", nil),                                                   // DELETE
+		s.makeSender(".*/publicIPAddresses/pip-0", nil),                                                   // DELETE
+		s.makeSender(".*/deployments/machine-0", nil),                                                     // DELETE
 	}
-	err := env.StopInstances("machine-0", "machine-1", "machine-2")
+	err := env.StopInstances("machine-0")
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.storageClient.CheckCallNames(c,
-		"NewClient", "DeleteBlobIfExists", "DeleteBlobIfExists",
+		"NewClient", "DeleteBlobIfExists",
 	)
 	s.storageClient.CheckCall(c, 1, "DeleteBlobIfExists", "osvhds", "machine-0")
-	s.storageClient.CheckCall(c, 2, "DeleteBlobIfExists", "osvhds", "machine-1")
+}
+
+func (s *environSuite) TestStopInstancesMultiple(c *gc.C) {
+	env := s.openEnviron(c)
+
+	vmDeleteSender0 := s.makeSender(".*/virtualMachines/machine-[01]", nil)
+	vmDeleteSender1 := s.makeSender(".*/virtualMachines/machine-[01]", nil)
+	vmDeleteSender0.SetError(errors.New("blargh"))
+	vmDeleteSender1.SetError(errors.New("blargh"))
+
+	s.sender = azuretesting.Senders{
+		s.makeSender(".*/deployments/machine-[01]/cancel", nil), // POST
+		s.makeSender(".*/deployments/machine-[01]/cancel", nil), // POST
+
+		// We should only query the NICs, public IPs, and storage
+		// account/keys, regardless of how many instances are deleted.
+		s.storageAccountSender(),
+		s.storageAccountKeysSender(),
+		s.networkInterfacesSender(),
+		s.publicIPAddressesSender(),
+
+		vmDeleteSender0,
+		vmDeleteSender1,
+	}
+	err := env.StopInstances("machine-0", "machine-1")
+	c.Assert(err, gc.ErrorMatches, `deleting instance "machine-[01]":.*blargh`)
+}
+
+func (s *environSuite) TestStopInstancesDeploymentNotFound(c *gc.C) {
+	env := s.openEnviron(c)
+
+	cancelSender := mocks.NewSender()
+	cancelSender.AppendResponse(mocks.NewResponseWithStatus(
+		"deployment not found", http.StatusNotFound,
+	))
+	s.sender = azuretesting.Senders{cancelSender}
+	err := env.StopInstances("machine-0")
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *environSuite) TestStopInstancesStorageAccountNoKeys(c *gc.C) {
 	s.PatchValue(&s.storageAccountKeys.Keys, nil)
-	s.testStopInstancesStorageKeysError(c, "getting storage account key: storage account keys not found")
+	s.testStopInstancesStorageAccountNotFound(c)
 }
 
 func (s *environSuite) TestStopInstancesStorageAccountNoFullKey(c *gc.C) {
 	keys := *s.storageAccountKeys.Keys
 	s.PatchValue(&keys[0].Permissions, storage.READ)
-	s.testStopInstancesStorageKeysError(c, `getting storage account key: storage account key with "FULL" permission not found`)
+	s.testStopInstancesStorageAccountNotFound(c)
 }
 
-func (s *environSuite) testStopInstancesStorageKeysError(c *gc.C, expect string) {
+func (s *environSuite) testStopInstancesStorageAccountNotFound(c *gc.C) {
 	env := s.openEnviron(c)
-
-	nic0IPConfiguration := makeIPConfiguration("192.168.0.4")
-	nic0IPConfiguration.Properties.PublicIPAddress = &network.PublicIPAddress{}
-	nic0 := makeNetworkInterface("nic-0", "machine-0", nic0IPConfiguration)
 	s.sender = azuretesting.Senders{
-		s.networkInterfacesSender(nic0),
-		s.virtualMachinesSender(makeVirtualMachine("machine-0")),
-		s.publicIPAddressesSender(makePublicIPAddress("pip-0", "machine-0", "1.2.3.4")),
-		s.storageAccountsSender(),
+		s.makeSender("/deployments/machine-0", s.deployment), // Cancel
+		s.storageAccountSender(),
 		s.storageAccountKeysSender(),
+		s.networkInterfacesSender(),                                                     // GET: no NICs
+		s.publicIPAddressesSender(),                                                     // GET: no public IPs
+		s.makeSender(".*/virtualMachines/machine-0", nil),                               // DELETE
+		s.makeSender(".*/networkSecurityGroups/juju-internal-nsg", makeSecurityGroup()), // GET: no rules
+		s.makeSender(".*/deployments/machine-0", nil),                                   // DELETE
 	}
-
 	err := env.StopInstances("machine-0")
-	c.Assert(err, gc.ErrorMatches, expect)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *environSuite) TestStopInstancesStorageAccountError(c *gc.C) {
+	env := s.openEnviron(c)
+	errorSender := s.storageAccountSender()
+	errorSender.SetError(errors.New("blargh"))
+	s.sender = azuretesting.Senders{
+		s.makeSender("/deployments/machine-0", s.deployment), // Cancel
+		errorSender,
+	}
+	err := env.StopInstances("machine-0")
+	c.Assert(err, gc.ErrorMatches, "getting storage account:.*blargh")
+}
+
+func (s *environSuite) TestStopInstancesStorageAccountKeysError(c *gc.C) {
+	env := s.openEnviron(c)
+	errorSender := s.storageAccountKeysSender()
+	errorSender.SetError(errors.New("blargh"))
+	s.sender = azuretesting.Senders{
+		s.makeSender("/deployments/machine-0", s.deployment), // Cancel
+		s.storageAccountSender(),
+		errorSender,
+	}
+	err := env.StopInstances("machine-0")
+	c.Assert(err, gc.ErrorMatches, "getting storage account key:.*blargh")
 }
 
 func (s *environSuite) TestConstraintsValidatorUnsupported(c *gc.C) {

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -33,12 +33,12 @@ type ProviderConfig struct {
 	// clients.
 	NewStorageClient azurestorage.NewClientFunc
 
-	// StorageAccountNameGenerator is a function returning storage
-	// account names.
-	StorageAccountNameGenerator func() string
-
 	// RetryClock is used when retrying API calls due to rate-limiting.
 	RetryClock clock.Clock
+
+	// RandomWindowsAdminPassword is a function used to generate
+	// a random password for the Windows admin user.
+	RandomWindowsAdminPassword func() string
 }
 
 // Validate validates the Azure provider configuration.
@@ -46,11 +46,11 @@ func (cfg ProviderConfig) Validate() error {
 	if cfg.NewStorageClient == nil {
 		return errors.NotValidf("nil NewStorageClient")
 	}
-	if cfg.StorageAccountNameGenerator == nil {
-		return errors.NotValidf("nil StorageAccountNameGenerator")
-	}
 	if cfg.RetryClock == nil {
 		return errors.NotValidf("nil RetryClock")
+	}
+	if cfg.RandomWindowsAdminPassword == nil {
+		return errors.NotValidf("nil RandomWindowsAdminPassword")
 	}
 	return nil
 }

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -35,8 +35,9 @@ var _ = gc.Suite(&environProviderSuite{})
 func (s *environProviderSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.provider = newProvider(c, azure.ProviderConfig{
-		Sender:           &s.sender,
-		RequestInspector: requestRecorder(&s.requests),
+		Sender:                     &s.sender,
+		RequestInspector:           requestRecorder(&s.requests),
+		RandomWindowsAdminPassword: func() string { return "sorandom" },
 	})
 	s.spec = environs.CloudSpec{
 		Type:             "azure",
@@ -107,14 +108,10 @@ func newProvider(c *gc.C, config azure.ProviderConfig) environs.EnvironProvider 
 		var storage azuretesting.MockStorageClient
 		config.NewStorageClient = storage.NewClient
 	}
-	if config.StorageAccountNameGenerator == nil {
-		config.StorageAccountNameGenerator = func() string {
-			return fakeStorageAccount
-		}
-	}
 	if config.RetryClock == nil {
 		config.RetryClock = jujutesting.NewClock(time.Time{})
 	}
+	config.RandomWindowsAdminPassword = func() string { return "sorandom" }
 	environProvider, err := azure.NewProvider(config)
 	c.Assert(err, jc.ErrorIsNil)
 	return environProvider

--- a/provider/azure/init.go
+++ b/provider/azure/init.go
@@ -27,9 +27,9 @@ func NewProvider(config ProviderConfig) (environs.EnvironProvider, error) {
 
 func init() {
 	environProvider, err := NewProvider(ProviderConfig{
-		NewStorageClient:            azurestorage.NewClient,
-		StorageAccountNameGenerator: RandomStorageAccountName,
-		RetryClock:                  &clock.WallClock,
+		NewStorageClient:           azurestorage.NewClient,
+		RetryClock:                 &clock.WallClock,
+		RandomWindowsAdminPassword: randomAdminPassword,
 	})
 	if err != nil {
 		panic(err)

--- a/provider/azure/instance.go
+++ b/provider/azure/instance.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -21,7 +20,8 @@ import (
 )
 
 type azureInstance struct {
-	compute.VirtualMachine
+	vmName            string
+	provisioningState string
 	env               *azureEnviron
 	networkInterfaces []network.Interface
 	publicIPAddresses []network.PublicIPAddress
@@ -32,25 +32,39 @@ func (inst *azureInstance) Id() instance.Id {
 	// Note: we use Name and not Id, since all VM operations are in
 	// terms of the VM name (qualified by resource group). The ID is
 	// an internal detail.
-	return instance.Id(to.String(inst.VirtualMachine.Name))
+	return instance.Id(inst.vmName)
 }
 
 // Status is specified in the Instance interface.
 func (inst *azureInstance) Status() instance.InstanceStatus {
-	// NOTE(axw) ideally we would use the power state, but that is only
-	// available when using the "instance view". Instance view is only
-	// delivered when explicitly requested, and you can only request it
-	// when querying a single VM. This means the results of AllInstances
-	// or Instances would have the instance view missing.
-	//
-	// TODO(axw) if the provisioning state is "Failed", then
-	// we should query the operation status and report the error
-	// here.
-	return instance.InstanceStatus{
-		Status:  status.Empty,
-		Message: to.String(inst.Properties.ProvisioningState),
+	instanceStatus := status.Empty
+	message := inst.provisioningState
+	switch inst.provisioningState {
+	case "Succeeded":
+		// TODO(axw) once a VM has been started, we should
+		// start using its power state to show if it's
+		// really running or not. This is just a nice to
+		// have, since we should not expect a VM to ever
+		// be stopped.
+		instanceStatus = status.Running
+		message = ""
+	case "Canceled", "Failed":
+		// TODO(axw) if the provisioning state is "Failed", then we
+		// should use the error message from the deployment description
+		// as the Message. The error details are not currently exposed
+		// in the Azure SDK. See:
+		//     https://github.com/Azure/azure-sdk-for-go/issues/399
+		instanceStatus = status.ProvisioningError
+	case "Running":
+		message = ""
+		fallthrough
+	default:
+		instanceStatus = status.Provisioning
 	}
-
+	return instance.InstanceStatus{
+		Status:  instanceStatus,
+		Message: message,
+	}
 }
 
 // setInstanceAddresses queries Azure for the NICs and public IPs associated
@@ -58,69 +72,83 @@ func (inst *azureInstance) Status() instance.InstanceStatus {
 // VirtualMachines are up-to-date, and that there are no concurrent accesses
 // to the instances.
 func setInstanceAddresses(
-	pipClient network.PublicIPAddressesClient,
+	callAPI callAPIFunc,
 	resourceGroup string,
+	nicClient network.InterfacesClient,
+	pipClient network.PublicIPAddressesClient,
 	instances []*azureInstance,
-	nicsResult network.InterfaceListResult,
 ) (err error) {
-
-	instanceNics := make(map[instance.Id][]network.Interface)
-	instancePips := make(map[instance.Id][]network.PublicIPAddress)
-	for _, inst := range instances {
-		instanceNics[inst.Id()] = nil
-		instancePips[inst.Id()] = nil
+	instanceNics, err := instanceNetworkInterfaces(
+		callAPI, resourceGroup, nicClient,
+	)
+	if err != nil {
+		return errors.Annotate(err, "listing network interfaces")
 	}
-
-	// When setAddresses returns without error, update each
-	// instance's network interfaces and public IP addresses.
-	setInstanceFields := func(inst *azureInstance) {
-		inst.networkInterfaces = instanceNics[inst.Id()]
-		inst.publicIPAddresses = instancePips[inst.Id()]
-	}
-	defer func() {
-		if err != nil {
-			return
-		}
-		for _, inst := range instances {
-			setInstanceFields(inst)
-		}
-	}()
-
-	// We do not rely on references because of how StopInstances works.
-	// In order to not leak resources we must not delete the virtual
-	// machine until after all of its dependencies are deleted.
-	//
-	// NICs and PIPs cannot be deleted until they have no references.
-	// Thus, we cannot delete a PIP until there is no reference to it
-	// in any NICs, and likewise we cannot delete a NIC until there
-	// is no reference to it in any virtual machine.
-
-	if nicsResult.Value != nil {
-		for _, nic := range *nicsResult.Value {
-			instanceId := instance.Id(toTags(nic.Tags)[jujuMachineNameTag])
-			if _, ok := instanceNics[instanceId]; !ok {
-				continue
-			}
-			instanceNics[instanceId] = append(instanceNics[instanceId], nic)
-		}
-	}
-
-	pipsResult, err := pipClient.List(resourceGroup)
+	instancePips, err := instancePublicIPAddresses(
+		callAPI, resourceGroup, pipClient,
+	)
 	if err != nil {
 		return errors.Annotate(err, "listing public IP addresses")
 	}
-	if pipsResult.Value != nil {
-		for _, pip := range *pipsResult.Value {
-			instanceId := instance.Id(toTags(pip.Tags)[jujuMachineNameTag])
-			if _, ok := instanceNics[instanceId]; !ok {
-				continue
-			}
-			instancePips[instanceId] = append(instancePips[instanceId], pip)
-		}
+	for _, inst := range instances {
+		inst.networkInterfaces = instanceNics[inst.Id()]
+		inst.publicIPAddresses = instancePips[inst.Id()]
 	}
-
-	// Fields will be assigned to instances by the deferred call.
 	return nil
+}
+
+// instanceNetworkInterfaces lists all network interfaces in the resource
+// group, and returns a mapping from instance ID to the network interfaces
+// associated with that instance.
+func instanceNetworkInterfaces(
+	callAPI callAPIFunc,
+	resourceGroup string,
+	nicClient network.InterfacesClient,
+) (map[instance.Id][]network.Interface, error) {
+	var nicsResult network.InterfaceListResult
+	if err := callAPI(func() (autorest.Response, error) {
+		var err error
+		nicsResult, err = nicClient.List(resourceGroup)
+		return nicsResult.Response, err
+	}); err != nil {
+		return nil, errors.Annotate(err, "listing network interfaces")
+	}
+	if nicsResult.Value == nil || len(*nicsResult.Value) == 0 {
+		return nil, nil
+	}
+	instanceNics := make(map[instance.Id][]network.Interface)
+	for _, nic := range *nicsResult.Value {
+		instanceId := instance.Id(toTags(nic.Tags)[jujuMachineNameTag])
+		instanceNics[instanceId] = append(instanceNics[instanceId], nic)
+	}
+	return instanceNics, nil
+}
+
+// interfacePublicIPAddresses lists all public IP addresses in the resource
+// group, and returns a mapping from instance ID to the public IP addresses
+// associated with that instance.
+func instancePublicIPAddresses(
+	callAPI callAPIFunc,
+	resourceGroup string,
+	pipClient network.PublicIPAddressesClient,
+) (map[instance.Id][]network.PublicIPAddress, error) {
+	var pipsResult network.PublicIPAddressListResult
+	if err := callAPI(func() (autorest.Response, error) {
+		var err error
+		pipsResult, err = pipClient.List(resourceGroup)
+		return pipsResult.Response, err
+	}); err != nil {
+		return nil, errors.Annotate(err, "listing public IP addresses")
+	}
+	if pipsResult.Value == nil || len(*pipsResult.Value) == 0 {
+		return nil, nil
+	}
+	instancePips := make(map[instance.Id][]network.PublicIPAddress)
+	for _, pip := range *pipsResult.Value {
+		instanceId := instance.Id(toTags(pip.Tags)[jujuMachineNameTag])
+		instancePips[instanceId] = append(instancePips[instanceId], pip)
+	}
+	return instancePips, nil
 }
 
 // Addresses is specified in the Instance interface.

--- a/provider/azure/instance_test.go
+++ b/provider/azure/instance_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/Azure/azure-sdk-for-go/arm/resources/resources"
 	"github.com/Azure/go-autorest/autorest/mocks"
 	"github.com/Azure/go-autorest/autorest/to"
 	jc "github.com/juju/testing/checkers"
@@ -19,6 +20,7 @@ import (
 	jujunetwork "github.com/juju/juju/network"
 	"github.com/juju/juju/provider/azure"
 	"github.com/juju/juju/provider/azure/internal/azuretesting"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/testing"
 )
 
@@ -29,7 +31,7 @@ type instanceSuite struct {
 	requests          []*http.Request
 	sender            azuretesting.Senders
 	env               environs.Environ
-	virtualMachines   []compute.VirtualMachine
+	deployments       []resources.DeploymentExtended
 	networkInterfaces []network.Interface
 	publicIPAddresses []network.PublicIPAddress
 }
@@ -39,8 +41,9 @@ var _ = gc.Suite(&instanceSuite{})
 func (s *instanceSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.provider = newProvider(c, azure.ProviderConfig{
-		Sender:           &s.sender,
-		RequestInspector: requestRecorder(&s.requests),
+		Sender:                     &s.sender,
+		RequestInspector:           requestRecorder(&s.requests),
+		RandomWindowsAdminPassword: func() string { return "sorandom" },
 	})
 	s.env = openEnviron(c, s.provider, &s.sender)
 	s.sender = nil
@@ -49,9 +52,27 @@ func (s *instanceSuite) SetUpTest(c *gc.C) {
 		makeNetworkInterface("nic-0", "machine-0"),
 	}
 	s.publicIPAddresses = nil
-	s.virtualMachines = []compute.VirtualMachine{
-		makeVirtualMachine("machine-0"),
-		makeVirtualMachine("machine-1"),
+	s.deployments = []resources.DeploymentExtended{
+		makeDeployment("machine-0"),
+		makeDeployment("machine-1"),
+	}
+}
+
+func makeDeployment(name string) resources.DeploymentExtended {
+	dependsOn := []resources.BasicDependency{{
+		ResourceType: to.StringPtr("Microsoft.Compute/availabilitySets"),
+		ResourceName: to.StringPtr("mysql"),
+	}}
+	dependencies := []resources.Dependency{{
+		ResourceType: to.StringPtr("Microsoft.Compute/virtualMachines"),
+		DependsOn:    &dependsOn,
+	}}
+	return resources.DeploymentExtended{
+		Name: to.StringPtr(name),
+		Properties: &resources.DeploymentPropertiesExtended{
+			ProvisioningState: to.StringPtr("Succeeded"),
+			Dependencies:      &dependencies,
+		},
 	}
 }
 
@@ -59,7 +80,7 @@ func makeVirtualMachine(name string) compute.VirtualMachine {
 	return compute.VirtualMachine{
 		Name: to.StringPtr(name),
 		Properties: &compute.VirtualMachineProperties{
-			ProvisioningState: to.StringPtr("Successful"),
+			ProvisioningState: to.StringPtr("Succeeded"),
 		},
 	}
 }
@@ -127,29 +148,28 @@ func (s *instanceSuite) getInstance(c *gc.C) instance.Instance {
 }
 
 func (s *instanceSuite) getInstances(c *gc.C, ids ...instance.Id) []instance.Instance {
-
-	nicsSender := azuretesting.NewSenderWithValue(&network.InterfaceListResult{
-		Value: &s.networkInterfaces,
-	})
-	nicsSender.PathPattern = ".*/networkInterfaces"
-
-	vmsSender := azuretesting.NewSenderWithValue(&compute.VirtualMachineListResult{
-		Value: &s.virtualMachines,
-	})
-	vmsSender.PathPattern = ".*/virtualMachines"
-
-	pipsSender := azuretesting.NewSenderWithValue(&network.PublicIPAddressListResult{
-		Value: &s.publicIPAddresses,
-	})
-	pipsSender.PathPattern = ".*/publicIPAddresses"
-
-	s.sender = azuretesting.Senders{nicsSender, vmsSender, pipsSender}
-
+	s.sender = s.getInstancesSender()
 	instances, err := s.env.Instances(ids)
 	c.Assert(err, jc.ErrorIsNil)
 	s.sender = azuretesting.Senders{}
 	s.requests = nil
 	return instances
+}
+
+func (s *instanceSuite) getInstancesSender() azuretesting.Senders {
+	deploymentsSender := azuretesting.NewSenderWithValue(&resources.DeploymentListResult{
+		Value: &s.deployments,
+	})
+	deploymentsSender.PathPattern = ".*/deployments"
+	nicsSender := azuretesting.NewSenderWithValue(&network.InterfaceListResult{
+		Value: &s.networkInterfaces,
+	})
+	nicsSender.PathPattern = ".*/networkInterfaces"
+	pipsSender := azuretesting.NewSenderWithValue(&network.PublicIPAddressListResult{
+		Value: &s.publicIPAddresses,
+	})
+	pipsSender.PathPattern = ".*/publicIPAddresses"
+	return azuretesting.Senders{deploymentsSender, nicsSender, pipsSender}
 }
 
 func networkSecurityGroupSender(rules []network.SecurityRule) *azuretesting.MockSender {
@@ -164,22 +184,32 @@ func networkSecurityGroupSender(rules []network.SecurityRule) *azuretesting.Mock
 
 func (s *instanceSuite) TestInstanceStatus(c *gc.C) {
 	inst := s.getInstance(c)
-	c.Assert(inst.Status().Message, gc.Equals, "Successful")
+	assertInstanceStatus(c, inst.Status(), status.Running, "")
+}
+
+func (s *instanceSuite) TestInstanceStatusDeploymentFailed(c *gc.C) {
+	s.deployments[0].Properties.ProvisioningState = to.StringPtr("Failed")
+	inst := s.getInstance(c)
+	assertInstanceStatus(c, inst.Status(), status.ProvisioningError, "Failed")
+}
+
+func (s *instanceSuite) TestInstanceStatusDeploymentCanceled(c *gc.C) {
+	s.deployments[0].Properties.ProvisioningState = to.StringPtr("Canceled")
+	inst := s.getInstance(c)
+	assertInstanceStatus(c, inst.Status(), status.ProvisioningError, "Canceled")
 }
 
 func (s *instanceSuite) TestInstanceStatusNilProvisioningState(c *gc.C) {
-	s.virtualMachines[0].Properties.ProvisioningState = nil
+	s.deployments[0].Properties.ProvisioningState = nil
 	inst := s.getInstance(c)
-	c.Assert(inst.Status().Message, gc.Equals, "")
+	assertInstanceStatus(c, inst.Status(), status.Allocating, "")
 }
 
-func (s *instanceSuite) TestInstanceStatusNoVM(c *gc.C) {
-	// Instances will still return an instance if there's a NIC, which is
-	// the last thing we delete. If there's no VM, we return the string
-	// "Partially Deleted" from Instance.Status().
-	s.virtualMachines = nil
-	inst := s.getInstance(c)
-	c.Assert(inst.Status().Message, gc.Equals, "Partially Deleted")
+func assertInstanceStatus(c *gc.C, actual instance.InstanceStatus, status status.Status, message string) {
+	c.Assert(actual, jc.DeepEquals, instance.InstanceStatus{
+		Status:  status,
+		Message: message,
+	})
 }
 
 func (s *instanceSuite) TestInstanceAddressesEmpty(c *gc.C) {
@@ -507,6 +537,24 @@ func (s *instanceSuite) TestInstanceOpenPortsAlreadyOpen(c *gc.C) {
 func (s *instanceSuite) TestInstanceOpenPortsNoInternalAddress(c *gc.C) {
 	err := s.getInstance(c).OpenPorts("0", nil)
 	c.Assert(err, gc.ErrorMatches, "internal network address not found")
+}
+
+func (s *instanceSuite) TestAllInstances(c *gc.C) {
+	s.sender = s.getInstancesSender()
+	instances, err := s.env.AllInstances()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(instances, gc.HasLen, 2)
+	c.Assert(instances[0].Id(), gc.Equals, instance.Id("machine-0"))
+	c.Assert(instances[1].Id(), gc.Equals, instance.Id("machine-1"))
+}
+
+func (s *instanceSuite) TestControllerInstances(c *gc.C) {
+	*(*(*s.deployments[0].Properties.Dependencies)[0].DependsOn)[0].ResourceName = "juju-controller"
+	s.sender = s.getInstancesSender()
+	ids, err := s.env.ControllerInstances("foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ids, gc.HasLen, 1)
+	c.Assert(ids[0], gc.Equals, instance.Id("machine-0"))
 }
 
 var internalSecurityGroupPath = path.Join(

--- a/provider/azure/internal/armtemplates/template.go
+++ b/provider/azure/internal/armtemplates/template.go
@@ -1,0 +1,44 @@
+package armtemplates
+
+import "github.com/Azure/azure-sdk-for-go/arm/storage"
+
+const (
+	schema         = "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"
+	contentVersion = "1.0.0.0"
+)
+
+// Template represents an Azure Resource Manager (ARM) Template.
+// See: https://azure.microsoft.com/en-us/documentation/articles/resource-group-authoring-templates/
+type Template struct {
+	// Resources contains the definitions of resources that will
+	// be created by the template.
+	Resources []Resource `json:"resources"`
+}
+
+// Map returns the template as a map, suitable for use in
+// azure-sdk-for-go/arm/resources/resources/DeploymentProperties.Template.
+func (t *Template) Map() (map[string]interface{}, error) {
+	m := map[string]interface{}{
+		"$schema":        schema,
+		"contentVersion": contentVersion,
+		"resources":      t.Resources,
+	}
+	return m, nil
+}
+
+// Resource describes a template resource. For information on the
+// individual fields, see https://azure.microsoft.com/en-us/documentation/articles/resource-group-authoring-templates/.
+type Resource struct {
+	APIVersion string            `json:"apiVersion"`
+	Type       string            `json:"type"`
+	Name       string            `json:"name"`
+	Location   string            `json:"location,omitempty"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Comments   string            `json:"comments,omitempty"`
+	DependsOn  []string          `json:"dependsOn,omitempty"`
+	Properties interface{}       `json:"properties,omitempty"`
+	Resources  []Resource        `json:"resources,omitempty"`
+
+	// Non-uniform attributes.
+	StorageSku *storage.Sku `json:"sku,omitempty"`
+}

--- a/provider/azure/internal/iputils/iputils_test.go
+++ b/provider/azure/internal/iputils/iputils_test.go
@@ -47,6 +47,16 @@ func (*iputilsSuite) TestNextSubnetIPErrors(c *gc.C) {
 	)
 }
 
+func (*iputilsSuite) TestNthSubnetIP(c *gc.C) {
+	assertNthSubnetIP(c, "10.0.0.0/8", 0, "10.0.0.4")
+	assertNthSubnetIP(c, "10.0.0.0/8", 1, "10.0.0.5")
+	assertNthSubnetIP(c, "10.0.0.0/29", 0, "10.0.0.4")
+	assertNthSubnetIP(c, "10.0.0.0/29", 1, "10.0.0.5")
+	assertNthSubnetIP(c, "10.0.0.0/29", 2, "10.0.0.6")
+	assertNthSubnetIP(c, "10.0.0.0/29", 3, "") // all bits set, broadcast
+	assertNthSubnetIP(c, "10.1.2.0/30", 0, "")
+}
+
 func assertNextSubnetIP(c *gc.C, ipnetString string, inuseStrings []string, expectedString string) {
 	ipnet := parseIPNet(c, ipnetString)
 	inuse := parseIPs(c, inuseStrings...)
@@ -60,6 +70,17 @@ func assertNextSubnetIPError(c *gc.C, ipnetString string, inuseStrings []string,
 	inuse := parseIPs(c, inuseStrings...)
 	_, err := iputils.NextSubnetIP(ipnet, inuse)
 	c.Assert(err, gc.ErrorMatches, expect)
+}
+
+func assertNthSubnetIP(c *gc.C, ipnetString string, n int, expectedString string) {
+	ipnet := parseIPNet(c, ipnetString)
+	ip := iputils.NthSubnetIP(ipnet, n)
+	if expectedString == "" {
+		c.Assert(ip, gc.IsNil)
+	} else {
+		c.Assert(ip, gc.NotNil)
+		c.Assert(ip.String(), gc.Equals, expectedString)
+	}
 }
 
 func parseIPs(c *gc.C, ipStrings ...string) []net.IP {

--- a/provider/azure/networking.go
+++ b/provider/azure/networking.go
@@ -6,14 +6,13 @@ package azure
 import (
 	"fmt"
 	"net"
-	"path"
+	"strconv"
 
-	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	"github.com/Azure/azure-sdk-for-go/arm/network"
-	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/provider/azure/internal/armtemplates"
 	"github.com/juju/juju/provider/azure/internal/iputils"
 )
 
@@ -106,216 +105,71 @@ var (
 	}
 )
 
-func createInternalVirtualNetwork(
-	callAPI callAPIFunc,
-	client network.ManagementClient,
-	subscriptionId, resourceGroup string,
+// networkTemplateResources returns resource definitions for creating network
+// resources shared by all machines in a model.
+func networkTemplateResources(
 	location string,
-	tags map[string]string,
-) (*network.VirtualNetwork, error) {
-	addressPrefixes := []string{internalSubnetPrefix, controllerSubnetPrefix}
-	vnet := network.VirtualNetwork{
-		Location: to.StringPtr(location),
-		Tags:     to.StringMapPtr(tags),
-		Properties: &network.VirtualNetworkPropertiesFormat{
-			AddressSpace: &network.AddressSpace{&addressPrefixes},
-		},
-	}
-	logger.Debugf("creating virtual network %q", internalNetworkName)
-	vnetClient := network.VirtualNetworksClient{client}
-	if err := callAPI(func() (autorest.Response, error) {
-		return vnetClient.CreateOrUpdate(
-			resourceGroup, internalNetworkName, vnet,
-			nil, // abort channel
-		)
-	}); err != nil {
-		return nil, errors.Annotatef(err, "creating virtual network %q", internalNetworkName)
-	}
-	vnet.ID = to.StringPtr(internalNetworkId(subscriptionId, resourceGroup))
-	return &vnet, nil
-}
-
-func createInternalNetworkSecurityGroup(
-	callAPI callAPIFunc,
-	client network.ManagementClient,
-	subscriptionId, resourceGroup string,
-	location string,
-	tags map[string]string,
-	apiPort *int,
-) (*network.SecurityGroup, error) {
+	envTags map[string]string,
+	apiPort int,
+) []armtemplates.Resource {
 	// Create a network security group for the environment. There is only
 	// one NSG per environment (there's a limit of 100 per subscription),
 	// in which we manage rules for each exposed machine.
-	securityRules := []network.SecurityRule{sshSecurityRule}
-	if apiPort != nil {
-		rule := apiSecurityRule
-		properties := *rule.Properties
-		properties.DestinationPortRange = to.StringPtr(fmt.Sprint(*apiPort))
-		rule.Properties = &properties
-		securityRules = append(securityRules, rule)
-	}
-	nsg := network.SecurityGroup{
-		Location: to.StringPtr(location),
-		Tags:     to.StringMapPtr(tags),
+	apiSecurityRule := apiSecurityRule
+	properties := *apiSecurityRule.Properties
+	properties.DestinationPortRange = to.StringPtr(fmt.Sprint(apiPort))
+	apiSecurityRule.Properties = &properties
+	securityRules := []network.SecurityRule{sshSecurityRule, apiSecurityRule}
+
+	// NOTE(axw) we create the API rule for all models to avoid having to
+	// make queries when creating resources, making deployment faster and
+	// more robust. The controller subnet is never used in non-controller
+	// models, so there are no security implications.
+	nsgId := fmt.Sprintf(
+		`[resourceId('Microsoft.Network/networkSecurityGroups', '%s')]`,
+		internalSecurityGroupName,
+	)
+	subnets := []network.Subnet{{
+		Name: to.StringPtr(internalSubnetName),
+		Properties: &network.SubnetPropertiesFormat{
+			AddressPrefix: to.StringPtr(internalSubnetPrefix),
+			NetworkSecurityGroup: &network.SecurityGroup{
+				ID: to.StringPtr(nsgId),
+			},
+		},
+	}, {
+		Name: to.StringPtr(controllerSubnetName),
+		Properties: &network.SubnetPropertiesFormat{
+			AddressPrefix: to.StringPtr(controllerSubnetPrefix),
+			NetworkSecurityGroup: &network.SecurityGroup{
+				ID: to.StringPtr(nsgId),
+			},
+		},
+	}}
+
+	addressPrefixes := []string{internalSubnetPrefix, controllerSubnetPrefix}
+	resources := []armtemplates.Resource{{
+		APIVersion: network.APIVersion,
+		Type:       "Microsoft.Network/networkSecurityGroups",
+		Name:       internalSecurityGroupName,
+		Location:   location,
+		Tags:       envTags,
 		Properties: &network.SecurityGroupPropertiesFormat{
 			SecurityRules: &securityRules,
 		},
-	}
-	securityGroupClient := network.SecurityGroupsClient{client}
-	securityGroupName := internalSecurityGroupName
-	logger.Debugf("creating security group %q", securityGroupName)
-	if err := callAPI(func() (autorest.Response, error) {
-		return securityGroupClient.CreateOrUpdate(
-			resourceGroup, securityGroupName, nsg,
-			nil, // abort channel
-		)
-	}); err != nil {
-		return nil, errors.Annotatef(err, "creating security group %q", securityGroupName)
-	}
-	nsg.ID = to.StringPtr(internalNetworkSecurityGroupId(subscriptionId, resourceGroup))
-	return &nsg, nil
-}
-
-// createInternalSubnet creates an internal subnet for the specified resource group,
-// within the specified virtual network.
-//
-// NOTE(axw) this method expects an up-to-date VirtualNetwork, and expects that are
-// no concurrent subnet additions to the virtual network. At the moment we have only
-// three places where we modify subnets: at bootstrap, when a new environment is
-// created, and when an environment is destroyed.
-func createInternalNetworkSubnet(
-	callAPI callAPIFunc,
-	client network.ManagementClient,
-	subscriptionId, resourceGroup string,
-	subnetName, addressPrefix string,
-	location string,
-	tags map[string]string,
-) (*network.Subnet, error) {
-	// Now create a subnet with the next available address prefix, and
-	// associate the subnet with the NSG created above.
-	subnet := network.Subnet{
-		Properties: &network.SubnetPropertiesFormat{
-			AddressPrefix: to.StringPtr(addressPrefix),
-			NetworkSecurityGroup: &network.SecurityGroup{
-				ID: to.StringPtr(internalNetworkSecurityGroupId(
-					subscriptionId, resourceGroup,
-				)),
-			},
+	}, {
+		APIVersion: network.APIVersion,
+		Type:       "Microsoft.Network/virtualNetworks",
+		Name:       internalNetworkName,
+		Location:   location,
+		Tags:       envTags,
+		Properties: &network.VirtualNetworkPropertiesFormat{
+			AddressSpace: &network.AddressSpace{&addressPrefixes},
+			Subnets:      &subnets,
 		},
-	}
-	logger.Debugf("creating subnet %q (%s)", subnetName, addressPrefix)
-	subnetClient := network.SubnetsClient{client}
-	if err := callAPI(func() (autorest.Response, error) {
-		return subnetClient.CreateOrUpdate(
-			resourceGroup, internalNetworkName, subnetName, subnet,
-			nil, // abort channel
-		)
-	}); err != nil {
-		return nil, errors.Annotatef(err, "creating subnet %q", subnetName)
-	}
-	subnet.ID = to.StringPtr(internalNetworkSubnetId(
-		subscriptionId, resourceGroup, subnetName,
-	))
-	return &subnet, nil
-}
-
-type subnetParams struct {
-	name   string
-	prefix string
-}
-
-// newNetworkProfile creates a public IP and NIC(s) for the VM with the
-// specified name. A separate NIC will be created for each subnet; the
-// first subnet in the list will be associated with the primary NIC.
-func newNetworkProfile(
-	callAPI callAPIFunc,
-	client network.ManagementClient,
-	vmName string,
-	controller bool,
-	subscriptionId, resourceGroup string,
-	location string,
-	tags map[string]string,
-) (*compute.NetworkProfile, error) {
-	logger.Debugf("creating network profile for %q", vmName)
-
-	// Create a public IP for the NIC. Public IP addresses are dynamic.
-	logger.Debugf("- allocating public IP address")
-	pipClient := network.PublicIPAddressesClient{client}
-	publicIPAddress := network.PublicIPAddress{
-		Location: to.StringPtr(location),
-		Tags:     to.StringMapPtr(tags),
-		Properties: &network.PublicIPAddressPropertiesFormat{
-			PublicIPAllocationMethod: network.Dynamic,
-		},
-	}
-	publicIPAddressName := vmName + "-public-ip"
-	if err := callAPI(func() (autorest.Response, error) {
-		return pipClient.CreateOrUpdate(
-			resourceGroup, publicIPAddressName, publicIPAddress,
-			nil, // abort channel
-		)
-	}); err != nil {
-		return nil, errors.Annotatef(err, "creating public IP address for %q", vmName)
-	}
-	publicIPAddress.ID = to.StringPtr(publicIPAddressId(
-		subscriptionId, resourceGroup, publicIPAddressName,
-	))
-
-	// Controller and non-controller machines are assigned to separate
-	// subnets. This enables us to create controller-specific NSG rules
-	// just by targeting the controller subnet.
-	subnetName := internalSubnetName
-	subnetPrefix := internalSubnetPrefix
-	if controller {
-		subnetName = controllerSubnetName
-		subnetPrefix = controllerSubnetPrefix
-	}
-	subnetId := internalNetworkSubnetId(subscriptionId, resourceGroup, subnetName)
-
-	// Determine the next available private IP address.
-	nicClient := network.InterfacesClient{client}
-	privateIPAddress, err := nextSubnetIPAddress(nicClient, resourceGroup, subnetPrefix)
-	if err != nil {
-		return nil, errors.Annotatef(err, "querying private IP addresses")
-	}
-
-	// Create a primary NIC for the machine. The private IP address needs
-	// to be static so that we can create NSG rules that don't become
-	// invalid.
-	logger.Debugf("- creating primary NIC")
-	ipConfigurations := []network.InterfaceIPConfiguration{{
-		Name: to.StringPtr("primary"),
-		Properties: &network.InterfaceIPConfigurationPropertiesFormat{
-			Primary:                   to.BoolPtr(true),
-			PrivateIPAddress:          to.StringPtr(privateIPAddress),
-			PrivateIPAllocationMethod: network.Static,
-			Subnet: &network.Subnet{ID: to.StringPtr(subnetId)},
-			PublicIPAddress: &network.PublicIPAddress{
-				ID: publicIPAddress.ID,
-			},
-		},
+		DependsOn: []string{nsgId},
 	}}
-	nicName := vmName + "-primary"
-	nic := network.Interface{
-		Location: to.StringPtr(location),
-		Tags:     to.StringMapPtr(tags),
-		Properties: &network.InterfacePropertiesFormat{
-			IPConfigurations: &ipConfigurations,
-		},
-	}
-	if err := callAPI(func() (autorest.Response, error) {
-		return nicClient.CreateOrUpdate(resourceGroup, nicName, nic, nil)
-	}); err != nil {
-		return nil, errors.Annotatef(err, "creating network interface for %q", vmName)
-	}
-
-	nics := []compute.NetworkInterfaceReference{{
-		ID: to.StringPtr(networkInterfaceId(subscriptionId, resourceGroup, nicName)),
-		Properties: &compute.NetworkInterfaceReferenceProperties{
-			Primary: to.BoolPtr(true),
-		},
-	}}
-	return &compute.NetworkProfile{&nics}, nil
+	return resources
 }
 
 // nextSecurityRulePriority returns the next available priority in the given
@@ -341,81 +195,26 @@ func nextSecurityRulePriority(group network.SecurityGroup, min, max int32) (int3
 	)
 }
 
-// nextSubnetIPAddress returns the next available IP address in the given subnet.
-func nextSubnetIPAddress(
-	nicClient network.InterfacesClient,
-	resourceGroup string,
-	subnetPrefix string,
-) (string, error) {
+// machineSubnetIP returns the private IP address to use for the given
+// subnet prefix.
+func machineSubnetIP(subnetPrefix, machineId string) (net.IP, error) {
 	_, ipnet, err := net.ParseCIDR(subnetPrefix)
 	if err != nil {
-		return "", errors.Annotate(err, "parsing subnet prefix")
+		return nil, errors.Annotate(err, "parsing subnet prefix")
 	}
-	results, err := nicClient.List(resourceGroup)
+	n, err := strconv.Atoi(machineId)
 	if err != nil {
-		return "", errors.Annotate(err, "listing NICs")
+		return nil, errors.Annotate(err, "parsing machine ID")
 	}
-	var ipsInUse []net.IP
-	if results.Value != nil {
-		ipsInUse = make([]net.IP, 0, len(*results.Value))
-		for _, item := range *results.Value {
-			if item.Properties.IPConfigurations == nil {
-				continue
-			}
-			for _, ipConfiguration := range *item.Properties.IPConfigurations {
-				ip := net.ParseIP(to.String(ipConfiguration.Properties.PrivateIPAddress))
-				if ip != nil && ipnet.Contains(ip) {
-					ipsInUse = append(ipsInUse, ip)
-				}
-			}
-		}
+	ip := iputils.NthSubnetIP(ipnet, n)
+	if ip == nil {
+		// TODO(axw) getting nil means we've cycled through roughly
+		// 2^12 machines. To work around this limitation, we must
+		// maintain an in-memory set of in-use IP addresses for each
+		// subnet.
+		return nil, errors.Errorf(
+			"no available IP addresses in %s", subnetPrefix,
+		)
 	}
-	ip, err := iputils.NextSubnetIP(ipnet, ipsInUse)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	return ip.String(), nil
-}
-
-// internalNetworkSubnetId returns the Azure resource ID of the subnet with
-// the specified name, within the internal network subnet for the specified
-// resource group.
-func internalNetworkSubnetId(subscriptionId, resourceGroup, subnetName string) string {
-	return path.Join(
-		internalNetworkId(subscriptionId, resourceGroup),
-		"subnets", subnetName,
-	)
-}
-
-func internalNetworkId(subscriptionId, resourceGroup string) string {
-	return resourceId(subscriptionId, resourceGroup, "Microsoft.Network",
-		"virtualNetworks", internalNetworkName,
-	)
-}
-
-func internalNetworkSecurityGroupId(subscriptionId, resourceGroup string) string {
-	return resourceId(subscriptionId, resourceGroup, "Microsoft.Network",
-		"networkSecurityGroups", internalSecurityGroupName,
-	)
-}
-
-func publicIPAddressId(subscriptionId, resourceGroup, publicIPAddressName string) string {
-	return resourceId(subscriptionId, resourceGroup, "Microsoft.Network",
-		"publicIPAddresses", publicIPAddressName,
-	)
-}
-
-func networkInterfaceId(subscriptionId, resourceGroup, interfaceName string) string {
-	return resourceId(subscriptionId, resourceGroup, "Microsoft.Network",
-		"networkInterfaces", interfaceName,
-	)
-}
-
-func resourceId(subscriptionId, resourceGroup, provider string, resourceId ...string) string {
-	args := append([]string{
-		"/subscriptions", subscriptionId,
-		"resourceGroups", resourceGroup,
-		"providers", provider,
-	}, resourceId...)
-	return path.Join(args...)
+	return ip, nil
 }

--- a/provider/azure/storage_test.go
+++ b/provider/azure/storage_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
-	"github.com/Azure/azure-sdk-for-go/arm/network"
 	armstorage "github.com/Azure/azure-sdk-for-go/arm/storage"
 	azurestorage "github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -40,9 +39,10 @@ func (s *storageSuite) SetUpTest(c *gc.C) {
 	s.storageClient = azuretesting.MockStorageClient{}
 	s.requests = nil
 	envProvider := newProvider(c, azure.ProviderConfig{
-		Sender:           &s.sender,
-		NewStorageClient: s.storageClient.NewClient,
-		RequestInspector: requestRecorder(&s.requests),
+		Sender:                     &s.sender,
+		NewStorageClient:           s.storageClient.NewClient,
+		RequestInspector:           requestRecorder(&s.requests),
+		RandomWindowsAdminPassword: func() string { return "sorandom" },
 	})
 	s.sender = nil
 
@@ -67,23 +67,23 @@ func (s *storageSuite) volumeSource(c *gc.C, attrs ...testing.Attrs) storage.Vol
 	return volumeSource
 }
 
-func (s *storageSuite) accountsSender() *azuretesting.MockSender {
+func (s *storageSuite) accountSender() *azuretesting.MockSender {
 	envTags := map[string]*string{
 		"juju-model-uuid": to.StringPtr(testing.ModelTag.Id()),
 	}
-	accounts := []armstorage.Account{{
-		Name: to.StringPtr(fakeStorageAccount),
+	account := armstorage.Account{
+		Name: to.StringPtr(storageAccountName),
 		Type: to.StringPtr("Standard_LRS"),
 		Tags: &envTags,
 		Properties: &armstorage.AccountProperties{
 			PrimaryEndpoints: &armstorage.Endpoints{
-				Blob: to.StringPtr(fmt.Sprintf("https://%s.blob.storage.azurestack.local/", fakeStorageAccount)),
+				Blob: to.StringPtr(fmt.Sprintf("https://%s.blob.storage.azurestack.local/", storageAccountName)),
 			},
 		},
-	}}
-	accountsSender := azuretesting.NewSenderWithValue(armstorage.AccountListResult{Value: &accounts})
-	accountsSender.PathPattern = ".*/storageAccounts"
-	return accountsSender
+	}
+	accountSender := azuretesting.NewSenderWithValue(account)
+	accountSender.PathPattern = ".*/storageAccounts/" + storageAccountName + ".*"
+	return accountSender
 }
 
 func (s *storageSuite) accountKeysSender() *azuretesting.MockSender {
@@ -182,17 +182,7 @@ func (s *storageSuite) TestCreateVolumes(c *gc.C) {
 		},
 	}}
 
-	// There should be a couple of API calls to list instances,
-	// and one update per modified instance.
-	nics := []network.Interface{
-		makeNetworkInterface("nic-0", "machine-0"),
-		makeNetworkInterface("nic-1", "machine-1"),
-		makeNetworkInterface("nic-2", "machine-2"),
-	}
-	nicsSender := azuretesting.NewSenderWithValue(network.InterfaceListResult{
-		Value: &nics,
-	})
-	nicsSender.PathPattern = `.*/Microsoft\.Network/networkInterfaces`
+	// There should be a one API calls to list VMs, and one update per modified instance.
 	virtualMachinesSender := azuretesting.NewSenderWithValue(compute.VirtualMachineListResult{
 		Value: &virtualMachines,
 	})
@@ -203,9 +193,8 @@ func (s *storageSuite) TestCreateVolumes(c *gc.C) {
 	updateVirtualMachine1Sender.PathPattern = `.*/Microsoft\.Compute/virtualMachines/machine-1`
 	volumeSource := s.volumeSource(c)
 	s.sender = azuretesting.Senders{
-		nicsSender,
 		virtualMachinesSender,
-		s.accountsSender(),
+		s.accountSender(),
 		updateVirtualMachine0Sender,
 		updateVirtualMachine1Sender,
 	}
@@ -221,12 +210,11 @@ func (s *storageSuite) TestCreateVolumes(c *gc.C) {
 	c.Check(results[4].Error, gc.ErrorMatches, "choosing LUN: all LUNs are in use")
 
 	// Validate HTTP request bodies.
-	c.Assert(s.requests, gc.HasLen, 5)
-	c.Assert(s.requests[0].Method, gc.Equals, "GET") // list NICs
-	c.Assert(s.requests[1].Method, gc.Equals, "GET") // list virtual machines
-	c.Assert(s.requests[2].Method, gc.Equals, "GET") // list storage accounts
-	c.Assert(s.requests[3].Method, gc.Equals, "PUT") // update machine-0
-	c.Assert(s.requests[4].Method, gc.Equals, "PUT") // update machine-1
+	c.Assert(s.requests, gc.HasLen, 4)
+	c.Assert(s.requests[0].Method, gc.Equals, "GET") // list virtual machines
+	c.Assert(s.requests[1].Method, gc.Equals, "GET") // list storage accounts
+	c.Assert(s.requests[2].Method, gc.Equals, "PUT") // update machine-0
+	c.Assert(s.requests[3].Method, gc.Equals, "PUT") // update machine-1
 
 	machine0DataDisks := []compute.DataDisk{{
 		Lun:        to.Int32Ptr(0),
@@ -234,7 +222,7 @@ func (s *storageSuite) TestCreateVolumes(c *gc.C) {
 		Name:       to.StringPtr("volume-0"),
 		Vhd: &compute.VirtualHardDisk{URI: to.StringPtr(fmt.Sprintf(
 			"https://%s.blob.storage.azurestack.local/datavhds/volume-0.vhd",
-			fakeStorageAccount,
+			storageAccountName,
 		))},
 		Caching:      compute.ReadWrite,
 		CreateOption: compute.Empty,
@@ -244,13 +232,13 @@ func (s *storageSuite) TestCreateVolumes(c *gc.C) {
 		Name:       to.StringPtr("volume-2"),
 		Vhd: &compute.VirtualHardDisk{URI: to.StringPtr(fmt.Sprintf(
 			"https://%s.blob.storage.azurestack.local/datavhds/volume-2.vhd",
-			fakeStorageAccount,
+			storageAccountName,
 		))},
 		Caching:      compute.ReadWrite,
 		CreateOption: compute.Empty,
 	}}
 	virtualMachines[0].Properties.StorageProfile.DataDisks = &machine0DataDisks
-	assertRequestBody(c, s.requests[3], &virtualMachines[0])
+	assertRequestBody(c, s.requests[2], &virtualMachines[0])
 
 	machine1DataDisks = append(machine1DataDisks, compute.DataDisk{
 		Lun:        to.Int32Ptr(1),
@@ -258,12 +246,12 @@ func (s *storageSuite) TestCreateVolumes(c *gc.C) {
 		Name:       to.StringPtr("volume-1"),
 		Vhd: &compute.VirtualHardDisk{URI: to.StringPtr(fmt.Sprintf(
 			"https://%s.blob.storage.azurestack.local/datavhds/volume-1.vhd",
-			fakeStorageAccount,
+			storageAccountName,
 		))},
 		Caching:      compute.ReadWrite,
 		CreateOption: compute.Empty,
 	})
-	assertRequestBody(c, s.requests[4], &virtualMachines[1])
+	assertRequestBody(c, s.requests[3], &virtualMachines[1])
 }
 
 func (s *storageSuite) TestListVolumes(c *gc.C) {
@@ -292,14 +280,14 @@ func (s *storageSuite) TestListVolumes(c *gc.C) {
 
 	volumeSource := s.volumeSource(c)
 	s.sender = azuretesting.Senders{
-		s.accountsSender(),
+		s.accountSender(),
 		s.accountKeysSender(),
 	}
 	volumeIds, err := volumeSource.ListVolumes()
 	c.Assert(err, jc.ErrorIsNil)
 	s.storageClient.CheckCallNames(c, "NewClient", "ListBlobs")
 	s.storageClient.CheckCall(
-		c, 0, "NewClient", fakeStorageAccount, fakeStorageAccountKey,
+		c, 0, "NewClient", storageAccountName, fakeStorageAccountKey,
 		"storage.azurestack.local", azurestorage.DefaultAPIVersion, true,
 	)
 	s.storageClient.CheckCall(c, 1, "ListBlobs", "datavhds", azurestorage.ListBlobsParameters{})
@@ -309,7 +297,7 @@ func (s *storageSuite) TestListVolumes(c *gc.C) {
 func (s *storageSuite) TestListVolumesErrors(c *gc.C) {
 	volumeSource := s.volumeSource(c)
 	s.sender = azuretesting.Senders{
-		s.accountsSender(),
+		s.accountSender(),
 		s.accountKeysSender(),
 	}
 
@@ -344,14 +332,14 @@ func (s *storageSuite) TestDescribeVolumes(c *gc.C) {
 
 	volumeSource := s.volumeSource(c)
 	s.sender = azuretesting.Senders{
-		s.accountsSender(),
+		s.accountSender(),
 		s.accountKeysSender(),
 	}
 	results, err := volumeSource.DescribeVolumes([]string{"volume-0", "volume-1", "volume-0", "volume-42"})
 	c.Assert(err, jc.ErrorIsNil)
 	s.storageClient.CheckCallNames(c, "NewClient", "ListBlobs")
 	s.storageClient.CheckCall(
-		c, 0, "NewClient", fakeStorageAccount, fakeStorageAccountKey,
+		c, 0, "NewClient", storageAccountName, fakeStorageAccountKey,
 		"storage.azurestack.local", azurestorage.DefaultAPIVersion, true,
 	)
 	c.Assert(results, gc.HasLen, 4)
@@ -380,7 +368,7 @@ func (s *storageSuite) TestDescribeVolumes(c *gc.C) {
 func (s *storageSuite) TestDestroyVolumes(c *gc.C) {
 	volumeSource := s.volumeSource(c)
 	s.sender = azuretesting.Senders{
-		s.accountsSender(),
+		s.accountSender(),
 		s.accountKeysSender(),
 	}
 	results, err := volumeSource.DestroyVolumes([]string{"volume-0", "volume-42"})
@@ -401,7 +389,7 @@ func (s *storageSuite) TestAttachVolumes(c *gc.C) {
 		Vhd: &compute.VirtualHardDisk{
 			URI: to.StringPtr(fmt.Sprintf(
 				"https://%s.blob.storage.azurestack.local/datavhds/volume-1.vhd",
-				fakeStorageAccount,
+				storageAccountName,
 			)),
 		},
 	}}
@@ -413,7 +401,7 @@ func (s *storageSuite) TestAttachVolumes(c *gc.C) {
 		machine2DataDisks[i].Vhd = &compute.VirtualHardDisk{
 			URI: to.StringPtr(fmt.Sprintf(
 				"https://%s.blob.storage.azurestack.local/datavhds/volume-%d.vhd",
-				fakeStorageAccount, i,
+				storageAccountName, i,
 			)),
 		}
 	}
@@ -458,17 +446,7 @@ func (s *storageSuite) TestAttachVolumes(c *gc.C) {
 		},
 	}}
 
-	// There should be a couple of API calls to list instances,
-	// and one update per modified instance.
-	nics := []network.Interface{
-		makeNetworkInterface("nic-0", "machine-0"),
-		makeNetworkInterface("nic-1", "machine-1"),
-		makeNetworkInterface("nic-2", "machine-2"),
-	}
-	nicsSender := azuretesting.NewSenderWithValue(network.InterfaceListResult{
-		Value: &nics,
-	})
-	nicsSender.PathPattern = `.*/Microsoft\.Network/networkInterfaces`
+	// There should be a one API calls to list VMs, and one update per modified instance.
 	virtualMachinesSender := azuretesting.NewSenderWithValue(compute.VirtualMachineListResult{
 		Value: &virtualMachines,
 	})
@@ -477,9 +455,8 @@ func (s *storageSuite) TestAttachVolumes(c *gc.C) {
 	updateVirtualMachine0Sender.PathPattern = `.*/Microsoft\.Compute/virtualMachines/machine-0`
 	volumeSource := s.volumeSource(c)
 	s.sender = azuretesting.Senders{
-		nicsSender,
 		virtualMachinesSender,
-		s.accountsSender(),
+		s.accountSender(),
 		updateVirtualMachine0Sender,
 	}
 
@@ -494,18 +471,17 @@ func (s *storageSuite) TestAttachVolumes(c *gc.C) {
 	c.Check(results[4].Error, gc.ErrorMatches, "choosing LUN: all LUNs are in use")
 
 	// Validate HTTP request bodies.
-	c.Assert(s.requests, gc.HasLen, 4)
-	c.Assert(s.requests[0].Method, gc.Equals, "GET") // list NICs
-	c.Assert(s.requests[1].Method, gc.Equals, "GET") // list virtual machines
-	c.Assert(s.requests[2].Method, gc.Equals, "GET") // list storage accounts
-	c.Assert(s.requests[3].Method, gc.Equals, "PUT") // update machine-0
+	c.Assert(s.requests, gc.HasLen, 3)
+	c.Assert(s.requests[0].Method, gc.Equals, "GET") // list virtual machines
+	c.Assert(s.requests[1].Method, gc.Equals, "GET") // list storage accounts
+	c.Assert(s.requests[2].Method, gc.Equals, "PUT") // update machine-0
 
 	machine0DataDisks := []compute.DataDisk{{
 		Lun:  to.Int32Ptr(0),
 		Name: to.StringPtr("volume-0"),
 		Vhd: &compute.VirtualHardDisk{URI: to.StringPtr(fmt.Sprintf(
 			"https://%s.blob.storage.azurestack.local/datavhds/volume-0.vhd",
-			fakeStorageAccount,
+			storageAccountName,
 		))},
 		Caching:      compute.ReadWrite,
 		CreateOption: compute.Attach,
@@ -514,13 +490,13 @@ func (s *storageSuite) TestAttachVolumes(c *gc.C) {
 		Name: to.StringPtr("volume-2"),
 		Vhd: &compute.VirtualHardDisk{URI: to.StringPtr(fmt.Sprintf(
 			"https://%s.blob.storage.azurestack.local/datavhds/volume-2.vhd",
-			fakeStorageAccount,
+			storageAccountName,
 		))},
 		Caching:      compute.ReadWrite,
 		CreateOption: compute.Attach,
 	}}
 	virtualMachines[0].Properties.StorageProfile.DataDisks = &machine0DataDisks
-	assertRequestBody(c, s.requests[3], &virtualMachines[0])
+	assertRequestBody(c, s.requests[2], &virtualMachines[0])
 }
 
 func (s *storageSuite) TestDetachVolumes(c *gc.C) {
@@ -531,7 +507,7 @@ func (s *storageSuite) TestDetachVolumes(c *gc.C) {
 		Vhd: &compute.VirtualHardDisk{
 			URI: to.StringPtr(fmt.Sprintf(
 				"https://%s.blob.storage.azurestack.local/datavhds/volume-0.vhd",
-				fakeStorageAccount,
+				storageAccountName,
 			)),
 		},
 	}, {
@@ -540,7 +516,7 @@ func (s *storageSuite) TestDetachVolumes(c *gc.C) {
 		Vhd: &compute.VirtualHardDisk{
 			URI: to.StringPtr(fmt.Sprintf(
 				"https://%s.blob.storage.azurestack.local/datavhds/volume-1.vhd",
-				fakeStorageAccount,
+				storageAccountName,
 			)),
 		},
 	}, {
@@ -549,7 +525,7 @@ func (s *storageSuite) TestDetachVolumes(c *gc.C) {
 		Vhd: &compute.VirtualHardDisk{
 			URI: to.StringPtr(fmt.Sprintf(
 				"https://%s.blob.storage.azurestack.local/datavhds/volume-2.vhd",
-				fakeStorageAccount,
+				storageAccountName,
 			)),
 		},
 	}}
@@ -584,16 +560,7 @@ func (s *storageSuite) TestDetachVolumes(c *gc.C) {
 		},
 	}}
 
-	// There should be a couple of API calls to list instances,
-	// and one update per modified instance.
-	nics := []network.Interface{
-		makeNetworkInterface("nic-0", "machine-0"),
-		makeNetworkInterface("nic-1", "machine-1"),
-	}
-	nicsSender := azuretesting.NewSenderWithValue(network.InterfaceListResult{
-		Value: &nics,
-	})
-	nicsSender.PathPattern = `.*/Microsoft\.Network/networkInterfaces`
+	// There should be a one API calls to list VMs, and one update per modified instance.
 	virtualMachinesSender := azuretesting.NewSenderWithValue(compute.VirtualMachineListResult{
 		Value: &virtualMachines,
 	})
@@ -602,9 +569,8 @@ func (s *storageSuite) TestDetachVolumes(c *gc.C) {
 	updateVirtualMachine0Sender.PathPattern = `.*/Microsoft\.Compute/virtualMachines/machine-0`
 	volumeSource := s.volumeSource(c)
 	s.sender = azuretesting.Senders{
-		nicsSender,
 		virtualMachinesSender,
-		s.accountsSender(),
+		s.accountSender(),
 		updateVirtualMachine0Sender,
 	}
 
@@ -618,16 +584,15 @@ func (s *storageSuite) TestDetachVolumes(c *gc.C) {
 	c.Check(results[3], gc.ErrorMatches, "instance machine-42 not found")
 
 	// Validate HTTP request bodies.
-	c.Assert(s.requests, gc.HasLen, 4)
-	c.Assert(s.requests[0].Method, gc.Equals, "GET") // list NICs
-	c.Assert(s.requests[1].Method, gc.Equals, "GET") // list virtual machines
-	c.Assert(s.requests[2].Method, gc.Equals, "GET") // list storage accounts
-	c.Assert(s.requests[3].Method, gc.Equals, "PUT") // update machine-0
+	c.Assert(s.requests, gc.HasLen, 3)
+	c.Assert(s.requests[0].Method, gc.Equals, "GET") // list virtual machines
+	c.Assert(s.requests[1].Method, gc.Equals, "GET") // list storage accounts
+	c.Assert(s.requests[2].Method, gc.Equals, "PUT") // update machine-0
 
 	machine0DataDisks = []compute.DataDisk{
 		machine0DataDisks[0],
 		machine0DataDisks[2],
 	}
 	virtualMachines[0].Properties.StorageProfile.DataDisks = &machine0DataDisks
-	assertRequestBody(c, s.requests[3], &virtualMachines[0])
+	assertRequestBody(c, s.requests[2], &virtualMachines[0])
 }

--- a/provider/azure/utils.go
+++ b/provider/azure/utils.go
@@ -4,12 +4,15 @@
 package azure
 
 import (
+	"fmt"
 	"math/rand"
 	"net/http"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/juju/errors"
 	"github.com/juju/retry"
 	"github.com/juju/utils"
 	"github.com/juju/utils/clock"
@@ -83,4 +86,37 @@ func (c backoffAPIRequestCaller) call(f func() (autorest.Response, error)) error
 		BackoffFunc: retry.DoubleDelay,
 		Clock:       c.clock,
 	})
+}
+
+// deleteResource deletes a resource with the given name from the resource
+// group, using the provided "Deleter". If the resource does not exist, an
+// error satisfying errors.IsNotFound will be returned.
+func deleteResource(callAPI callAPIFunc, deleter resourceDeleter, resourceGroup, name string) error {
+	var result autorest.Response
+	if err := callAPI(func() (autorest.Response, error) {
+		var err error
+		result, err = deleter.Delete(resourceGroup, name, nil)
+		return result, err
+	}); err != nil {
+		if result.Response != nil && result.StatusCode == http.StatusNotFound {
+			return errors.NewNotFound(err, fmt.Sprintf("resource %q not found", name))
+		}
+		return errors.Annotate(err, "canceling deployment")
+	}
+	return nil
+}
+
+type resourceDeleter interface {
+	Delete(resourceGroup, name string, cancel <-chan struct{}) (autorest.Response, error)
+}
+
+func azureServiceError(err error) (*azure.ServiceError, bool) {
+	err = errors.Cause(err)
+	if d, ok := err.(autorest.DetailedError); ok {
+		err = d.Original
+	}
+	if err, ok := err.(*azure.RequestError); ok {
+		return err.ServiceError, true
+	}
+	return nil, false
 }

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -51,7 +51,7 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 
 func (s *environSuite) TestStartInstance(c *gc.C) {
 	configurator := &fakeConfigurator{}
-	s.PatchValue(rackspace.WaitSSH, func(stdErr io.Writer, interrupted <-chan os.Signal, client ssh.Client, checkHostScript string, inst common.Addresser, timeout environs.BootstrapDialOpts) (addr string, err error) {
+	s.PatchValue(rackspace.WaitSSH, func(stdErr io.Writer, interrupted <-chan os.Signal, client ssh.Client, checkHostScript string, inst common.InstanceRefresher, timeout environs.BootstrapDialOpts) (addr string, err error) {
 		addresses, err := inst.Addresses()
 		if err != nil {
 			return "", err


### PR DESCRIPTION
This diff fundamentally changes how we provision
resources in Azure. Instead of creating the resources
individually, we now create them using ARM templates.
Templates describe all of the resources we require,
and their dependencies; and Azure parallelises the
creation of those as well as it can. In addition, we
now delete VMs in parallel.

The main benefit is that bootstrap time is back to how
it was before we updated the Azure SDK recently. There
are several other improvements:
 - few API requests
 - VM deployments are now fully parallelisable
 - add-model is faster, as we now only create the
   resource group synchronously
 - simpler code and tests
 - listing instances is now less awkward; each instance
   has a corresponding deployment. If that deployment
   exists, the instance exists. Compare and contrast to
   how it was before, where an instance's existence was
   based on whether its *NIC* existed.

There are a couple of major changes that are required
to enable this:
 - we no longer generate a random storage account name,
   and cycle through until we choose one. Instead, we
   take the last 10 bytes of the model UUID, format it
   as hex, and prepend "juju". This should be enough to
   ensure a unique name. If it is not, we will need to
   create the storage account at the same time as the
   resource group, which will slow down deployments.
 - we no longer make an API query to determine the next
   available private IP address. Instead, we compute
   the address based on the machine ID. One problem this
   introduces is that if we cycle through ~4K machine
   IDs in a model, then we won't be able to create any
   new instances. We can address this later by maintaining
   in memory the set of in-use IP addresses.

(Review request: http://reviews.vapour.ws/r/5663/)