### PR TITLE
Rename status.Status* values to status.*

### DIFF
--- a/api/instancepoller/machine_test.go
+++ b/api/instancepoller/machine_test.go
@@ -208,14 +208,14 @@ func (s *MachineSuite) TestInstanceStatusSuccess(c *gc.C) {
 	var called int
 	results := params.StatusResults{
 		Results: []params.StatusResult{{
-			Status: status.StatusProvisioning.String(),
+			Status: status.Provisioning.String(),
 		}},
 	}
 	apiCaller := successAPICaller(c, "InstanceStatus", entitiesArgs, results, &called)
 	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
 	statusResult, err := machine.InstanceStatus()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusResult.Status, gc.DeepEquals, status.StatusProvisioning.String())
+	c.Check(statusResult.Status, gc.DeepEquals, status.Provisioning.String())
 	c.Check(called, gc.Equals, 1)
 }
 

--- a/api/machiner/machiner_test.go
+++ b/api/machiner/machiner_test.go
@@ -71,16 +71,16 @@ func (s *machinerSuite) TestSetStatus(c *gc.C) {
 
 	statusInfo, err := s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusPending)
+	c.Assert(statusInfo.Status, gc.Equals, status.Pending)
 	c.Assert(statusInfo.Message, gc.Equals, "")
 	c.Assert(statusInfo.Data, gc.HasLen, 0)
 
-	err = machine.SetStatus(status.StatusStarted, "blah", nil)
+	err = machine.SetStatus(status.Started, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	statusInfo, err = s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusStarted)
+	c.Assert(statusInfo.Status, gc.Equals, status.Started)
 	c.Assert(statusInfo.Message, gc.Equals, "blah")
 	c.Assert(statusInfo.Data, gc.HasLen, 0)
 	c.Assert(statusInfo.Since, gc.NotNil)
@@ -193,7 +193,7 @@ func (s *machinerSuite) TestWatch(c *gc.C) {
 
 	// Change something other than the lifecycle and make sure it's
 	// not detected.
-	err = machine.SetStatus(status.StatusStarted, "not really", nil)
+	err = machine.SetStatus(status.Started, "not really", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -97,15 +97,15 @@ func (s *provisionerSuite) TestGetSetStatus(c *gc.C) {
 
 	machineStatus, info, err := apiMachine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machineStatus, gc.Equals, status.StatusPending)
+	c.Assert(machineStatus, gc.Equals, status.Pending)
 	c.Assert(info, gc.Equals, "")
 
-	err = apiMachine.SetStatus(status.StatusStarted, "blah", nil)
+	err = apiMachine.SetStatus(status.Started, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	machineStatus, info, err = apiMachine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machineStatus, gc.Equals, status.StatusStarted)
+	c.Assert(machineStatus, gc.Equals, status.Started)
 	c.Assert(info, gc.Equals, "blah")
 	statusInfo, err := s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
@@ -118,13 +118,13 @@ func (s *provisionerSuite) TestGetSetInstanceStatus(c *gc.C) {
 
 	instanceStatus, info, err := apiMachine.InstanceStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(instanceStatus, gc.Equals, status.StatusPending)
+	c.Assert(instanceStatus, gc.Equals, status.Pending)
 	c.Assert(info, gc.Equals, "")
-	err = apiMachine.SetInstanceStatus(status.StatusStarted, "blah", nil)
+	err = apiMachine.SetInstanceStatus(status.Started, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	instanceStatus, info, err = apiMachine.InstanceStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(instanceStatus, gc.Equals, status.StatusStarted)
+	c.Assert(instanceStatus, gc.Equals, status.Started)
 	c.Assert(info, gc.Equals, "blah")
 	statusInfo, err := s.machine.InstanceStatus()
 	c.Assert(err, jc.ErrorIsNil)
@@ -135,12 +135,12 @@ func (s *provisionerSuite) TestGetSetStatusWithData(c *gc.C) {
 	apiMachine, err := s.provisioner.Machine(s.machine.Tag().(names.MachineTag))
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = apiMachine.SetStatus(status.StatusError, "blah", map[string]interface{}{"foo": "bar"})
+	err = apiMachine.SetStatus(status.Error, "blah", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	machineStatus, info, err := apiMachine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machineStatus, gc.Equals, status.StatusError)
+	c.Assert(machineStatus, gc.Equals, status.Error)
 	c.Assert(info, gc.Equals, "blah")
 	statusInfo, err := s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
@@ -152,7 +152,7 @@ func (s *provisionerSuite) TestMachinesWithTransientErrors(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "blah",
 		Data:    map[string]interface{}{"transient": true},
 		Since:   &now,
@@ -474,7 +474,7 @@ func (s *provisionerSuite) TestWatchContainers(c *gc.C) {
 
 	// Change something other than the containers and make sure it's
 	// not detected.
-	err = apiMachine.SetStatus(status.StatusStarted, "not really", nil)
+	err = apiMachine.SetStatus(status.Started, "not really", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 

--- a/api/uniter/application_test.go
+++ b/api/uniter/application_test.go
@@ -126,20 +126,20 @@ func (s *serviceSuite) TestSetServiceStatus(c *gc.C) {
 	message := "a test message"
 	stat, err := s.wordpressService.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(stat.Status, gc.Not(gc.Equals), status.StatusActive)
+	c.Assert(stat.Status, gc.Not(gc.Equals), status.Active)
 	c.Assert(stat.Message, gc.Not(gc.Equals), message)
 
-	err = s.apiService.SetStatus(s.wordpressUnit.Name(), status.StatusActive, message, map[string]interface{}{})
+	err = s.apiService.SetStatus(s.wordpressUnit.Name(), status.Active, message, map[string]interface{}{})
 	c.Check(err, gc.ErrorMatches, `"wordpress/0" is not leader of "wordpress"`)
 
 	s.claimLeadership(c, s.wordpressUnit, s.wordpressService)
 
-	err = s.apiService.SetStatus(s.wordpressUnit.Name(), status.StatusActive, message, map[string]interface{}{})
+	err = s.apiService.SetStatus(s.wordpressUnit.Name(), status.Active, message, map[string]interface{}{})
 	c.Check(err, jc.ErrorIsNil)
 
 	stat, err = s.wordpressService.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(stat.Status, gc.Equals, status.StatusActive)
+	c.Check(stat.Status, gc.Equals, status.Active)
 	c.Check(stat.Message, gc.Equals, message)
 }
 
@@ -147,12 +147,12 @@ func (s *serviceSuite) TestServiceStatus(c *gc.C) {
 	message := "a test message"
 	stat, err := s.wordpressService.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(stat.Status, gc.Not(gc.Equals), status.StatusActive)
+	c.Assert(stat.Status, gc.Not(gc.Equals), status.Active)
 	c.Assert(stat.Message, gc.Not(gc.Equals), message)
 
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusActive,
+		Status:  status.Active,
 		Message: message,
 		Data:    map[string]interface{}{},
 		Since:   &now,
@@ -162,7 +162,7 @@ func (s *serviceSuite) TestServiceStatus(c *gc.C) {
 
 	stat, err = s.wordpressService.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(stat.Status, gc.Equals, status.StatusActive)
+	c.Check(stat.Status, gc.Equals, status.Active)
 	c.Check(stat.Message, gc.Equals, message)
 
 	result, err := s.apiService.Status(s.wordpressUnit.Name())
@@ -171,7 +171,7 @@ func (s *serviceSuite) TestServiceStatus(c *gc.C) {
 	s.claimLeadership(c, s.wordpressUnit, s.wordpressService)
 	result, err = s.apiService.Status(s.wordpressUnit.Name())
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(result.Application.Status, gc.Equals, status.StatusActive.String())
+	c.Check(result.Application.Status, gc.Equals, status.Active.String())
 }
 
 func (s *serviceSuite) claimLeadership(c *gc.C, unit *state.Unit, service *state.Application) {

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -63,22 +63,22 @@ func (s *unitSuite) TestUnitAndUnitTag(c *gc.C) {
 func (s *unitSuite) TestSetAgentStatus(c *gc.C) {
 	statusInfo, err := s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusAllocating)
+	c.Assert(statusInfo.Status, gc.Equals, status.Allocating)
 	c.Assert(statusInfo.Message, gc.Equals, "")
 	c.Assert(statusInfo.Data, gc.HasLen, 0)
 
 	unitStatusInfo, err := s.wordpressUnit.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unitStatusInfo.Status, gc.Equals, status.StatusUnknown)
+	c.Assert(unitStatusInfo.Status, gc.Equals, status.Unknown)
 	c.Assert(unitStatusInfo.Message, gc.Equals, "Waiting for agent initialization to finish")
 	c.Assert(unitStatusInfo.Data, gc.HasLen, 0)
 
-	err = s.apiUnit.SetAgentStatus(status.StatusIdle, "blah", nil)
+	err = s.apiUnit.SetAgentStatus(status.Idle, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	statusInfo, err = s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusIdle)
+	c.Assert(statusInfo.Status, gc.Equals, status.Idle)
 	c.Assert(statusInfo.Message, gc.Equals, "blah")
 	c.Assert(statusInfo.Data, gc.HasLen, 0)
 	c.Assert(statusInfo.Since, gc.NotNil)
@@ -86,7 +86,7 @@ func (s *unitSuite) TestSetAgentStatus(c *gc.C) {
 	// Ensure that unit has not changed.
 	unitStatusInfo, err = s.wordpressUnit.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unitStatusInfo.Status, gc.Equals, status.StatusUnknown)
+	c.Assert(unitStatusInfo.Status, gc.Equals, status.Unknown)
 	c.Assert(unitStatusInfo.Message, gc.Equals, "Waiting for agent initialization to finish")
 	c.Assert(unitStatusInfo.Data, gc.HasLen, 0)
 }
@@ -94,22 +94,22 @@ func (s *unitSuite) TestSetAgentStatus(c *gc.C) {
 func (s *unitSuite) TestSetUnitStatus(c *gc.C) {
 	statusInfo, err := s.wordpressUnit.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusUnknown)
+	c.Assert(statusInfo.Status, gc.Equals, status.Unknown)
 	c.Assert(statusInfo.Message, gc.Equals, "Waiting for agent initialization to finish")
 	c.Assert(statusInfo.Data, gc.HasLen, 0)
 
 	agentStatusInfo, err := s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(agentStatusInfo.Status, gc.Equals, status.StatusAllocating)
+	c.Assert(agentStatusInfo.Status, gc.Equals, status.Allocating)
 	c.Assert(agentStatusInfo.Message, gc.Equals, "")
 	c.Assert(agentStatusInfo.Data, gc.HasLen, 0)
 
-	err = s.apiUnit.SetUnitStatus(status.StatusActive, "blah", nil)
+	err = s.apiUnit.SetUnitStatus(status.Active, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	statusInfo, err = s.wordpressUnit.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusActive)
+	c.Assert(statusInfo.Status, gc.Equals, status.Active)
 	c.Assert(statusInfo.Message, gc.Equals, "blah")
 	c.Assert(statusInfo.Data, gc.HasLen, 0)
 	c.Assert(statusInfo.Since, gc.NotNil)
@@ -117,7 +117,7 @@ func (s *unitSuite) TestSetUnitStatus(c *gc.C) {
 	// Ensure unit's agent has not changed.
 	agentStatusInfo, err = s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(agentStatusInfo.Status, gc.Equals, status.StatusAllocating)
+	c.Assert(agentStatusInfo.Status, gc.Equals, status.Allocating)
 	c.Assert(agentStatusInfo.Message, gc.Equals, "")
 	c.Assert(agentStatusInfo.Data, gc.HasLen, 0)
 }
@@ -125,7 +125,7 @@ func (s *unitSuite) TestSetUnitStatus(c *gc.C) {
 func (s *unitSuite) TestUnitStatus(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusMaintenance,
+		Status:  status.Maintenance,
 		Message: "blah",
 		Since:   &now,
 	}
@@ -137,7 +137,7 @@ func (s *unitSuite) TestUnitStatus(c *gc.C) {
 	c.Assert(result.Since, gc.NotNil)
 	result.Since = nil
 	c.Assert(result, gc.DeepEquals, params.StatusResult{
-		Status: status.StatusMaintenance.String(),
+		Status: status.Maintenance.String(),
 		Info:   "blah",
 		Data:   map[string]interface{}{},
 	})
@@ -229,7 +229,7 @@ func (s *unitSuite) TestWatch(c *gc.C) {
 
 	// Change something other than the lifecycle and make sure it's
 	// not detected.
-	err = s.apiUnit.SetAgentStatus(status.StatusIdle, "not really", nil)
+	err = s.apiUnit.SetAgentStatus(status.Idle, "not really", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 

--- a/apiserver/application/application_test.go
+++ b/apiserver/application/application_test.go
@@ -2071,7 +2071,7 @@ func (s *serviceSuite) TestDestroyPrincipalUnits(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		now := time.Now()
 		sInfo := status.StatusInfo{
-			Status:  status.StatusIdle,
+			Status:  status.Idle,
 			Message: "",
 			Since:   &now,
 		}
@@ -2154,7 +2154,7 @@ func (s *serviceSuite) setupDestroyPrincipalUnits(c *gc.C) []*state.Unit {
 		c.Assert(err, jc.ErrorIsNil)
 		now := time.Now()
 		sInfo := status.StatusInfo{
-			Status:  status.StatusIdle,
+			Status:  status.Idle,
 			Message: "",
 			Since:   &now,
 		}

--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -113,7 +113,7 @@ type setStatuser interface {
 func setDefaultStatus(c *gc.C, entity setStatuser) {
 	now := time.Now()
 	s := status.StatusInfo{
-		Status:  status.StatusStarted,
+		Status:  status.Started,
 		Message: "",
 		Since:   &now,
 	}
@@ -174,7 +174,7 @@ var scenarioStatus = &params.FullStatus{
 				Data:   make(map[string]interface{}),
 			},
 			InstanceStatus: params.DetailedStatus{
-				Status: status.StatusPending.String(),
+				Status: status.Pending.String(),
 				Data:   make(map[string]interface{}),
 			},
 			Series:     "quantal",
@@ -191,7 +191,7 @@ var scenarioStatus = &params.FullStatus{
 				Data:   make(map[string]interface{}),
 			},
 			InstanceStatus: params.DetailedStatus{
-				Status: status.StatusPending.String(),
+				Status: status.Pending.String(),
 				Data:   make(map[string]interface{}),
 			},
 			Series:     "quantal",
@@ -208,7 +208,7 @@ var scenarioStatus = &params.FullStatus{
 				Data:   make(map[string]interface{}),
 			},
 			InstanceStatus: params.DetailedStatus{
-				Status: status.StatusPending.String(),
+				Status: status.Pending.String(),
 				Data:   make(map[string]interface{}),
 			},
 			Series:     "quantal",
@@ -453,7 +453,7 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 			}
 			now := time.Now()
 			sInfo := status.StatusInfo{
-				Status:  status.StatusError,
+				Status:  status.Error,
 				Message: "blam",
 				Data:    sd,
 				Since:   &now,

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -460,7 +460,7 @@ func (s *clientSuite) testClientUnitResolved(c *gc.C, retry bool, expectedResolv
 	c.Assert(err, jc.ErrorIsNil)
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "gaaah",
 		Since:   &now,
 	}
@@ -492,7 +492,7 @@ func (s *clientSuite) setupResolved(c *gc.C) *state.Unit {
 	c.Assert(err, jc.ErrorIsNil)
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "gaaah",
 		Since:   &now,
 	}
@@ -594,10 +594,10 @@ func (s *clientSuite) TestClientWatchAll(c *gc.C) {
 			Id:         m.Id(),
 			InstanceId: "i-0",
 			AgentStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 			},
 			Life:                    multiwatcher.Life("alive"),
 			Series:                  "quantal",
@@ -1219,7 +1219,7 @@ func (s *clientSuite) TestRetryProvisioning(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "error",
 		Since:   &now,
 	}
@@ -1230,7 +1230,7 @@ func (s *clientSuite) TestRetryProvisioning(c *gc.C) {
 
 	statusInfo, err := machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusError)
+	c.Assert(statusInfo.Status, gc.Equals, status.Error)
 	c.Assert(statusInfo.Message, gc.Equals, "error")
 	c.Assert(statusInfo.Data["transient"], jc.IsTrue)
 }
@@ -1240,7 +1240,7 @@ func (s *clientSuite) setupRetryProvisioning(c *gc.C) *state.Machine {
 	c.Assert(err, jc.ErrorIsNil)
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "error",
 		Since:   &now,
 	}
@@ -1254,7 +1254,7 @@ func (s *clientSuite) assertRetryProvisioning(c *gc.C, machine *state.Machine) {
 	c.Assert(err, jc.ErrorIsNil)
 	statusInfo, err := machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusError)
+	c.Assert(statusInfo.Status, gc.Equals, status.Error)
 	c.Assert(statusInfo.Message, gc.Equals, "error")
 	c.Assert(statusInfo.Data["transient"], jc.IsTrue)
 }

--- a/apiserver/client/filtering.go
+++ b/apiserver/client/filtering.go
@@ -328,7 +328,7 @@ func matchWorkloadStatus(patterns []string, workloadStatus status.Status, agentS
 		oneValidStatus = true
 		// To preserve current expected behaviour, we only report on workload status
 		// if the agent itself is not in error.
-		if agentStatus != status.StatusError && workloadStatus.WorkloadMatches(ps) {
+		if agentStatus != status.Error && workloadStatus.WorkloadMatches(ps) {
 			return true, true, nil
 		}
 	}

--- a/apiserver/client/statushistory_test.go
+++ b/apiserver/client/statushistory_test.go
@@ -125,17 +125,17 @@ func (s *statusHistoryTestSuite) TestNoConflictingFilters(c *gc.C) {
 func (s *statusHistoryTestSuite) TestStatusHistoryUnitOnly(c *gc.C) {
 	s.st.unitHistory = statusInfoWithDates([]status.StatusInfo{
 		{
-			Status:  status.StatusMaintenance,
+			Status:  status.Maintenance,
 			Message: "working",
 		},
 		{
-			Status:  status.StatusActive,
+			Status:  status.Active,
 			Message: "running",
 		},
 	})
 	s.st.agentHistory = statusInfoWithDates([]status.StatusInfo{
 		{
-			Status: status.StatusIdle,
+			Status: status.Idle,
 		},
 	})
 	h := s.api.StatusHistory(params.StatusHistoryRequests{
@@ -152,20 +152,20 @@ func (s *statusHistoryTestSuite) TestStatusHistoryUnitOnly(c *gc.C) {
 func (s *statusHistoryTestSuite) TestStatusHistoryAgentOnly(c *gc.C) {
 	s.st.unitHistory = statusInfoWithDates([]status.StatusInfo{
 		{
-			Status:  status.StatusMaintenance,
+			Status:  status.Maintenance,
 			Message: "working",
 		},
 		{
-			Status:  status.StatusActive,
+			Status:  status.Active,
 			Message: "running",
 		},
 	})
 	s.st.agentHistory = statusInfoWithDates([]status.StatusInfo{
 		{
-			Status: status.StatusExecuting,
+			Status: status.Executing,
 		},
 		{
-			Status: status.StatusIdle,
+			Status: status.Idle,
 		},
 	})
 	h := s.api.StatusHistory(params.StatusHistoryRequests{
@@ -182,24 +182,24 @@ func (s *statusHistoryTestSuite) TestStatusHistoryAgentOnly(c *gc.C) {
 func (s *statusHistoryTestSuite) TestStatusHistoryCombined(c *gc.C) {
 	s.st.unitHistory = statusInfoWithDates([]status.StatusInfo{
 		{
-			Status:  status.StatusMaintenance,
+			Status:  status.Maintenance,
 			Message: "working",
 		},
 		{
-			Status:  status.StatusActive,
+			Status:  status.Active,
 			Message: "running",
 		},
 		{
-			Status:  status.StatusBlocked,
+			Status:  status.Blocked,
 			Message: "waiting",
 		},
 	})
 	s.st.agentHistory = statusInfoWithDates([]status.StatusInfo{
 		{
-			Status: status.StatusExecuting,
+			Status: status.Executing,
 		},
 		{
-			Status: status.StatusIdle,
+			Status: status.Idle,
 		},
 	})
 	h := s.api.StatusHistory(params.StatusHistoryRequests{

--- a/apiserver/common/getstatus_test.go
+++ b/apiserver/common/getstatus_test.go
@@ -70,7 +70,7 @@ func (s *statusGetterSuite) TestGetMachineStatus(c *gc.C) {
 	c.Assert(result.Results, gc.HasLen, 1)
 	machineStatus := result.Results[0]
 	c.Assert(machineStatus.Error, gc.IsNil)
-	c.Assert(machineStatus.Status, gc.Equals, status.StatusPending.String())
+	c.Assert(machineStatus.Status, gc.Equals, status.Pending.String())
 }
 
 func (s *statusGetterSuite) TestGetUnitStatus(c *gc.C) {
@@ -78,7 +78,7 @@ func (s *statusGetterSuite) TestGetUnitStatus(c *gc.C) {
 	// on the unit returns the workload status not the agent status as it
 	// does on a machine.
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Status: &status.StatusInfo{
-		Status: status.StatusMaintenance,
+		Status: status.Maintenance,
 	}})
 	result, err := s.getter.Status(params.Entities{[]params.Entity{{
 		unit.Tag().String(),
@@ -87,12 +87,12 @@ func (s *statusGetterSuite) TestGetUnitStatus(c *gc.C) {
 	c.Assert(result.Results, gc.HasLen, 1)
 	unitStatus := result.Results[0]
 	c.Assert(unitStatus.Error, gc.IsNil)
-	c.Assert(unitStatus.Status, gc.Equals, status.StatusMaintenance.String())
+	c.Assert(unitStatus.Status, gc.Equals, status.Maintenance.String())
 }
 
 func (s *statusGetterSuite) TestGetServiceStatus(c *gc.C) {
 	service := s.Factory.MakeApplication(c, &factory.ApplicationParams{Status: &status.StatusInfo{
-		Status: status.StatusMaintenance,
+		Status: status.Maintenance,
 	}})
 	result, err := s.getter.Status(params.Entities{[]params.Entity{{
 		service.Tag().String(),
@@ -101,7 +101,7 @@ func (s *statusGetterSuite) TestGetServiceStatus(c *gc.C) {
 	c.Assert(result.Results, gc.HasLen, 1)
 	serviceStatus := result.Results[0]
 	c.Assert(serviceStatus.Error, gc.IsNil)
-	c.Assert(serviceStatus.Status, gc.Equals, status.StatusMaintenance.String())
+	c.Assert(serviceStatus.Status, gc.Equals, status.Maintenance.String())
 }
 
 func (s *statusGetterSuite) TestBulk(c *gc.C) {
@@ -118,7 +118,7 @@ func (s *statusGetterSuite) TestBulk(c *gc.C) {
 	c.Assert(result.Results, gc.HasLen, 3)
 	c.Assert(result.Results[0].Error, jc.Satisfies, params.IsCodeUnauthorized)
 	c.Assert(result.Results[1].Error, gc.IsNil)
-	c.Assert(result.Results[1].Status, gc.Equals, status.StatusPending.String())
+	c.Assert(result.Results[1].Status, gc.Equals, status.Pending.String())
 	c.Assert(result.Results[2].Error, gc.ErrorMatches, `"bad-tag" is not a valid tag`)
 }
 
@@ -180,7 +180,7 @@ func (s *serviceStatusGetterSuite) TestGetMachineStatus(c *gc.C) {
 
 func (s *serviceStatusGetterSuite) TestGetServiceStatus(c *gc.C) {
 	service := s.Factory.MakeApplication(c, &factory.ApplicationParams{Status: &status.StatusInfo{
-		Status: status.StatusMaintenance,
+		Status: status.Maintenance,
 	}})
 	result, err := s.getter.Status(params.Entities{[]params.Entity{{
 		service.Tag().String(),
@@ -194,7 +194,7 @@ func (s *serviceStatusGetterSuite) TestGetServiceStatus(c *gc.C) {
 func (s *serviceStatusGetterSuite) TestGetUnitStatusNotLeader(c *gc.C) {
 	// If the unit isn't the leader, it can't get it.
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Status: &status.StatusInfo{
-		Status: status.StatusMaintenance,
+		Status: status.Maintenance,
 	}})
 	result, err := s.getter.Status(params.Entities{[]params.Entity{{
 		unit.Tag().String(),
@@ -208,7 +208,7 @@ func (s *serviceStatusGetterSuite) TestGetUnitStatusNotLeader(c *gc.C) {
 func (s *serviceStatusGetterSuite) TestGetUnitStatusIsLeader(c *gc.C) {
 	// If the unit isn't the leader, it can't get it.
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Status: &status.StatusInfo{
-		Status: status.StatusMaintenance,
+		Status: status.Maintenance,
 	}})
 	service, err := unit.Application()
 	c.Assert(err, jc.ErrorIsNil)
@@ -224,13 +224,13 @@ func (s *serviceStatusGetterSuite) TestGetUnitStatusIsLeader(c *gc.C) {
 	r := result.Results[0]
 	c.Assert(r.Error, gc.IsNil)
 	c.Assert(r.Application.Error, gc.IsNil)
-	c.Assert(r.Application.Status, gc.Equals, status.StatusMaintenance.String())
+	c.Assert(r.Application.Status, gc.Equals, status.Maintenance.String())
 	units := r.Units
 	c.Assert(units, gc.HasLen, 1)
 	unitStatus, ok := units[unit.Name()]
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(unitStatus.Error, gc.IsNil)
-	c.Assert(unitStatus.Status, gc.Equals, status.StatusMaintenance.String())
+	c.Assert(unitStatus.Status, gc.Equals, status.Maintenance.String())
 }
 
 func (s *serviceStatusGetterSuite) TestBulk(c *gc.C) {

--- a/apiserver/common/machine_test.go
+++ b/apiserver/common/machine_test.go
@@ -121,7 +121,7 @@ func (s *machineSuite) TestMachineHardwareInfo(c *gc.C) {
 func (s *machineSuite) TestMachineInstanceInfo(c *gc.C) {
 	st := mockState{
 		machines: map[string]*mockMachine{
-			"1": {id: "1", instId: instance.Id("123"), status: status.StatusDown, hasVote: true, wantsVote: true},
+			"1": {id: "1", instId: instance.Id("123"), status: status.Down, hasVote: true, wantsVote: true},
 		},
 	}
 	info, err := common.ModelMachineInfo(&st)

--- a/apiserver/common/machinestatus.go
+++ b/apiserver/common/machinestatus.go
@@ -38,7 +38,7 @@ func MachineStatus(machine MachineStatusGetter) (status.StatusInfo, error) {
 		return machineStatus, nil
 	}
 	if machine.Life() != state.Dead && !agentAlive {
-		machineStatus.Status = status.StatusDown
+		machineStatus.Status = status.Down
 		machineStatus.Message = "agent is not communicating with the server"
 	}
 	return machineStatus, nil
@@ -46,7 +46,7 @@ func MachineStatus(machine MachineStatusGetter) (status.StatusInfo, error) {
 
 func canMachineBeDown(machineStatus status.StatusInfo) bool {
 	switch machineStatus.Status {
-	case status.StatusPending, status.StatusStopped:
+	case status.Pending, status.Stopped:
 		return false
 	}
 	return true

--- a/apiserver/common/machinestatus_test.go
+++ b/apiserver/common/machinestatus_test.go
@@ -24,7 +24,7 @@ var _ = gc.Suite(&MachineStatusSuite{})
 
 func (s *MachineStatusSuite) SetUpTest(c *gc.C) {
 	s.machine = &mockMachine{
-		status: status.StatusStarted,
+		status: status.Started,
 	}
 }
 
@@ -50,7 +50,7 @@ func (s *MachineStatusSuite) TestDown(c *gc.C) {
 	agent, err := common.MachineStatus(s.machine)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(agent, jc.DeepEquals, status.StatusInfo{
-		Status:  status.StatusDown,
+		Status:  status.Down,
 		Message: "agent is not communicating with the server",
 	})
 }
@@ -71,6 +71,6 @@ func (s *MachineStatusSuite) TestPresenceError(c *gc.C) {
 
 func (s *MachineStatusSuite) TestNotDownIfPending(c *gc.C) {
 	s.machine.agentDead = true
-	s.machine.status = status.StatusPending
+	s.machine.status = status.Pending
 	s.checkUntouched(c)
 }

--- a/apiserver/common/setstatus.go
+++ b/apiserver/common/setstatus.go
@@ -209,7 +209,7 @@ func (s *StatusSetter) updateEntityStatusData(tag names.Tag, data map[string]int
 	if !ok {
 		return NotSupportedError(tag, "updating status")
 	}
-	if len(newData) > 0 && existingStatusInfo.Status != status.StatusError {
+	if len(newData) > 0 && existingStatusInfo.Status != status.Error {
 		return fmt.Errorf("%s is not in an error state", names.ReadableString(tag))
 	}
 	// TODO(perrito666) 2016-05-02 lp:1558657

--- a/apiserver/common/setstatus_test.go
+++ b/apiserver/common/setstatus_test.go
@@ -38,7 +38,7 @@ func (s *statusSetterSuite) TestUnauthorized(c *gc.C) {
 	s.badTag = tag
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    tag.String(),
-		Status: status.StatusExecuting.String(),
+		Status: status.Executing.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -48,7 +48,7 @@ func (s *statusSetterSuite) TestUnauthorized(c *gc.C) {
 func (s *statusSetterSuite) TestNotATag(c *gc.C) {
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    "not a tag",
-		Status: status.StatusExecuting.String(),
+		Status: status.Executing.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -58,7 +58,7 @@ func (s *statusSetterSuite) TestNotATag(c *gc.C) {
 func (s *statusSetterSuite) TestNotFound(c *gc.C) {
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    names.NewMachineTag("42").String(),
-		Status: status.StatusDown.String(),
+		Status: status.Down.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -69,7 +69,7 @@ func (s *statusSetterSuite) TestSetMachineStatus(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, nil)
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    machine.Tag().String(),
-		Status: status.StatusStarted.String(),
+		Status: status.Started.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -79,7 +79,7 @@ func (s *statusSetterSuite) TestSetMachineStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	machineStatus, err := machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machineStatus.Status, gc.Equals, status.StatusStarted)
+	c.Assert(machineStatus.Status, gc.Equals, status.Started)
 }
 
 func (s *statusSetterSuite) TestSetUnitStatus(c *gc.C) {
@@ -87,11 +87,11 @@ func (s *statusSetterSuite) TestSetUnitStatus(c *gc.C) {
 	// on the unit returns the workload status not the agent status as it
 	// does on a machine.
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Status: &status.StatusInfo{
-		Status: status.StatusMaintenance,
+		Status: status.Maintenance,
 	}})
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    unit.Tag().String(),
-		Status: status.StatusActive.String(),
+		Status: status.Active.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -101,7 +101,7 @@ func (s *statusSetterSuite) TestSetUnitStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	unitStatus, err := unit.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unitStatus.Status, gc.Equals, status.StatusActive)
+	c.Assert(unitStatus.Status, gc.Equals, status.Active)
 }
 
 func (s *statusSetterSuite) TestSetServiceStatus(c *gc.C) {
@@ -109,11 +109,11 @@ func (s *statusSetterSuite) TestSetServiceStatus(c *gc.C) {
 	// ServiceStatusSetter that checks for leadership, so permission denied
 	// here.
 	service := s.Factory.MakeApplication(c, &factory.ApplicationParams{Status: &status.StatusInfo{
-		Status: status.StatusMaintenance,
+		Status: status.Maintenance,
 	}})
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    service.Tag().String(),
-		Status: status.StatusActive.String(),
+		Status: status.Active.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -123,17 +123,17 @@ func (s *statusSetterSuite) TestSetServiceStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	serviceStatus, err := service.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(serviceStatus.Status, gc.Equals, status.StatusMaintenance)
+	c.Assert(serviceStatus.Status, gc.Equals, status.Maintenance)
 }
 
 func (s *statusSetterSuite) TestBulk(c *gc.C) {
 	s.badTag = names.NewMachineTag("42")
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    s.badTag.String(),
-		Status: status.StatusActive.String(),
+		Status: status.Active.String(),
 	}, {
 		Tag:    "bad-tag",
-		Status: status.StatusActive.String(),
+		Status: status.Active.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 2)
@@ -162,7 +162,7 @@ func (s *serviceStatusSetterSuite) TestUnauthorized(c *gc.C) {
 	s.badTag = tag
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    tag.String(),
-		Status: status.StatusActive.String(),
+		Status: status.Active.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -172,7 +172,7 @@ func (s *serviceStatusSetterSuite) TestUnauthorized(c *gc.C) {
 func (s *serviceStatusSetterSuite) TestNotATag(c *gc.C) {
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    "not a tag",
-		Status: status.StatusActive.String(),
+		Status: status.Active.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -182,7 +182,7 @@ func (s *serviceStatusSetterSuite) TestNotATag(c *gc.C) {
 func (s *serviceStatusSetterSuite) TestNotFound(c *gc.C) {
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    names.NewUnitTag("foo/0").String(),
-		Status: status.StatusActive.String(),
+		Status: status.Active.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -193,7 +193,7 @@ func (s *serviceStatusSetterSuite) TestSetMachineStatus(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, nil)
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    machine.Tag().String(),
-		Status: status.StatusActive.String(),
+		Status: status.Active.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -206,11 +206,11 @@ func (s *serviceStatusSetterSuite) TestSetServiceStatus(c *gc.C) {
 	// simple status setter to check to see if the unit (authTag) is a leader
 	// and able to set the service status. However, that is for another day.
 	service := s.Factory.MakeApplication(c, &factory.ApplicationParams{Status: &status.StatusInfo{
-		Status: status.StatusMaintenance,
+		Status: status.Maintenance,
 	}})
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    service.Tag().String(),
-		Status: status.StatusActive.String(),
+		Status: status.Active.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -222,11 +222,11 @@ func (s *serviceStatusSetterSuite) TestSetServiceStatus(c *gc.C) {
 func (s *serviceStatusSetterSuite) TestSetUnitStatusNotLeader(c *gc.C) {
 	// If the unit isn't the leader, it can't set it.
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Status: &status.StatusInfo{
-		Status: status.StatusMaintenance,
+		Status: status.Maintenance,
 	}})
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    unit.Tag().String(),
-		Status: status.StatusActive.String(),
+		Status: status.Active.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -236,12 +236,12 @@ func (s *serviceStatusSetterSuite) TestSetUnitStatusNotLeader(c *gc.C) {
 
 func (s *serviceStatusSetterSuite) TestSetUnitStatusIsLeader(c *gc.C) {
 	service := s.Factory.MakeApplication(c, &factory.ApplicationParams{Status: &status.StatusInfo{
-		Status: status.StatusMaintenance,
+		Status: status.Maintenance,
 	}})
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{
 		Application: service,
 		Status: &status.StatusInfo{
-			Status: status.StatusMaintenance,
+			Status: status.Maintenance,
 		}})
 	s.State.LeadershipClaimer().ClaimLeadership(
 		service.Name(),
@@ -249,7 +249,7 @@ func (s *serviceStatusSetterSuite) TestSetUnitStatusIsLeader(c *gc.C) {
 		time.Minute)
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    unit.Tag().String(),
-		Status: status.StatusActive.String(),
+		Status: status.Active.String(),
 	}}})
 
 	c.Assert(err, jc.ErrorIsNil)
@@ -260,7 +260,7 @@ func (s *serviceStatusSetterSuite) TestSetUnitStatusIsLeader(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	unitStatus, err := service.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unitStatus.Status, gc.Equals, status.StatusActive)
+	c.Assert(unitStatus.Status, gc.Equals, status.Active)
 }
 
 func (s *serviceStatusSetterSuite) TestBulk(c *gc.C) {
@@ -268,13 +268,13 @@ func (s *serviceStatusSetterSuite) TestBulk(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, nil)
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    s.badTag.String(),
-		Status: status.StatusActive.String(),
+		Status: status.Active.String(),
 	}, {
 		Tag:    machine.Tag().String(),
-		Status: status.StatusActive.String(),
+		Status: status.Active.String(),
 	}, {
 		Tag:    "bad-tag",
-		Status: status.StatusActive.String(),
+		Status: status.Active.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 3)

--- a/apiserver/common/unitstatus.go
+++ b/apiserver/common/unitstatus.go
@@ -50,11 +50,11 @@ func UnitStatus(unit UnitStatusGetter) (agent StatusAndErr, workload StatusAndEr
 		// If the unit is in error, it would be bad to throw away
 		// the error information as when the agent reconnects, that
 		// error information would then be lost.
-		if workload.Status.Status != status.StatusError {
-			workload.Status.Status = status.StatusUnknown
+		if workload.Status.Status != status.Error {
+			workload.Status.Status = status.Unknown
 			workload.Status.Message = fmt.Sprintf("agent lost, see 'juju show-status-log %s'", unit.Name())
 		}
-		agent.Status.Status = status.StatusLost
+		agent.Status.Status = status.Lost
 		agent.Status.Message = "agent is not communicating with the server"
 	}
 	return
@@ -62,9 +62,9 @@ func UnitStatus(unit UnitStatusGetter) (agent StatusAndErr, workload StatusAndEr
 
 func canBeLost(agent, workload status.StatusInfo) bool {
 	switch agent.Status {
-	case status.StatusAllocating:
+	case status.Allocating:
 		return false
-	case status.StatusExecuting:
+	case status.Executing:
 		return agent.Message != operation.RunningHookMessage(string(hooks.Install))
 	}
 
@@ -76,5 +76,5 @@ func canBeLost(agent, workload status.StatusInfo) bool {
 }
 
 func isWorkloadInstalled(workload status.StatusInfo) bool {
-	return workload.Status != status.StatusMaintenance || workload.Message != status.MessageInstalling
+	return workload.Status != status.Maintenance || workload.Message != status.MessageInstalling
 }

--- a/apiserver/common/unitstatus_test.go
+++ b/apiserver/common/unitstatus_test.go
@@ -25,11 +25,11 @@ var _ = gc.Suite(&UnitStatusSuite{})
 func (s *UnitStatusSuite) SetUpTest(c *gc.C) {
 	s.unit = &fakeStatusUnit{
 		agentStatus: status.StatusInfo{
-			Status:  status.StatusStarted,
+			Status:  status.Started,
 			Message: "agent ok",
 		},
 		status: status.StatusInfo{
-			Status:  status.StatusIdle,
+			Status:  status.Idle,
 			Message: "unit ok",
 		},
 		presence: true,
@@ -61,12 +61,12 @@ func (s *UnitStatusSuite) TestLost(c *gc.C) {
 	s.unit.presence = false
 	agent, workload := common.UnitStatus(s.unit)
 	c.Check(agent.Status, jc.DeepEquals, status.StatusInfo{
-		Status:  status.StatusLost,
+		Status:  status.Lost,
 		Message: "agent is not communicating with the server",
 	})
 	c.Check(agent.Err, jc.ErrorIsNil)
 	c.Check(workload.Status, jc.DeepEquals, status.StatusInfo{
-		Status:  status.StatusUnknown,
+		Status:  status.Unknown,
 		Message: "agent lost, see 'juju show-status-log foo/2'",
 	})
 	c.Check(workload.Err, jc.ErrorIsNil)
@@ -88,20 +88,20 @@ func (s *UnitStatusSuite) TestPresenceError(c *gc.C) {
 
 func (s *UnitStatusSuite) TestNotLostIfAllocating(c *gc.C) {
 	s.unit.presence = false
-	s.unit.agentStatus.Status = status.StatusAllocating
+	s.unit.agentStatus.Status = status.Allocating
 	s.checkUntouched(c)
 }
 
 func (s *UnitStatusSuite) TestCantBeLostDuringInstall(c *gc.C) {
 	s.unit.presence = false
-	s.unit.agentStatus.Status = status.StatusExecuting
+	s.unit.agentStatus.Status = status.Executing
 	s.unit.agentStatus.Message = "running install hook"
 	s.checkUntouched(c)
 }
 
 func (s *UnitStatusSuite) TestCantBeLostDuringWorkloadInstall(c *gc.C) {
 	s.unit.presence = false
-	s.unit.status.Status = status.StatusMaintenance
+	s.unit.status.Status = status.Maintenance
 	s.unit.status.Message = "installing charm software"
 	s.checkUntouched(c)
 }

--- a/apiserver/instancepoller/instancepoller_test.go
+++ b/apiserver/instancepoller/instancepoller_test.go
@@ -343,7 +343,7 @@ func (s *InstancePollerSuite) TestInstanceIdFailure(c *gc.C) {
 func (s *InstancePollerSuite) TestStatusSuccess(c *gc.C) {
 	now := time.Now()
 	s1 := status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "not really",
 		Data: map[string]interface{}{
 			"price": 4.2,
@@ -361,7 +361,7 @@ func (s *InstancePollerSuite) TestStatusSuccess(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
 			{
-				Status: status.StatusError.String(),
+				Status: status.Error.String(),
 				Info:   s1.Message,
 				Data:   s1.Data,
 				Since:  s1.Since,

--- a/apiserver/machine/machiner_test.go
+++ b/apiserver/machine/machiner_test.go
@@ -59,14 +59,14 @@ func (s *machinerSuite) TestMachinerFailsWithNonMachineAgentUser(c *gc.C) {
 func (s *machinerSuite) TestSetStatus(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusStarted,
+		Status:  status.Started,
 		Message: "blah",
 		Since:   &now,
 	}
 	err := s.machine0.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusStopped,
+		Status:  status.Stopped,
 		Message: "foo",
 		Since:   &now,
 	}
@@ -75,9 +75,9 @@ func (s *machinerSuite) TestSetStatus(c *gc.C) {
 
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: "machine-1", Status: status.StatusError.String(), Info: "not really"},
-			{Tag: "machine-0", Status: status.StatusStopped.String(), Info: "foobar"},
-			{Tag: "machine-42", Status: status.StatusStarted.String(), Info: "blah"},
+			{Tag: "machine-1", Status: status.Error.String(), Info: "not really"},
+			{Tag: "machine-0", Status: status.Stopped.String(), Info: "foobar"},
+			{Tag: "machine-42", Status: status.Started.String(), Info: "blah"},
 		}}
 	result, err := s.machiner.SetStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -92,12 +92,12 @@ func (s *machinerSuite) TestSetStatus(c *gc.C) {
 	// Verify machine 0 - no change.
 	statusInfo, err := s.machine0.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusStarted)
+	c.Assert(statusInfo.Status, gc.Equals, status.Started)
 	c.Assert(statusInfo.Message, gc.Equals, "blah")
 	// ...machine 1 is fine though.
 	statusInfo, err = s.machine1.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusError)
+	c.Assert(statusInfo.Status, gc.Equals, status.Error)
 	c.Assert(statusInfo.Message, gc.Equals, "not really")
 }
 

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -75,7 +75,7 @@ func (s *modelInfoSuite) SetUpTest(c *gc.C) {
 		life:  state.Alive,
 		cfg:   coretesting.ModelConfig(c),
 		status: status.StatusInfo{
-			Status: status.StatusAvailable,
+			Status: status.Available,
 			Since:  &time.Time{},
 		},
 		users: []*mockModelUser{{
@@ -92,7 +92,7 @@ func (s *modelInfoSuite) SetUpTest(c *gc.C) {
 		cfg:   coretesting.ModelConfig(c),
 		life:  state.Dying,
 		status: status.StatusInfo{
-			Status: status.StatusDestroying,
+			Status: status.Destroying,
 			Since:  &time.Time{},
 		},
 
@@ -157,7 +157,7 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		DefaultSeries:      series.LatestLts(),
 		Life:               params.Dying,
 		Status: params.EntityStatus{
-			Status: status.StatusDestroying,
+			Status: status.Destroying,
 			Since:  &time.Time{},
 		},
 		Users: []params.ModelUserInfo{{

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -79,7 +79,7 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 			life:  state.Alive,
 			cfg:   cfg,
 			status: status.StatusInfo{
-				Status: status.StatusAvailable,
+				Status: status.Available,
 				Since:  &time.Time{},
 			},
 			users: []*mockModelUser{{
@@ -96,7 +96,7 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 			tag:   coretesting.ModelTag,
 			cfg:   cfg,
 			status: status.StatusInfo{
-				Status: status.StatusAvailable,
+				Status: status.Available,
 				Since:  &time.Time{},
 			},
 			users: []*mockModelUser{{

--- a/apiserver/params/params_test.go
+++ b/apiserver/params/params_test.go
@@ -43,11 +43,11 @@ var marshalTestCases = []struct {
 			Id:         "Benji",
 			InstanceId: "Shazam",
 			AgentStatus: multiwatcher.StatusInfo{
-				Current: status.StatusError,
+				Current: status.Error,
 				Message: "foo",
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 			},
 			Life:                    multiwatcher.Life("alive"),
 			Series:                  "trusty",
@@ -75,7 +75,7 @@ var marshalTestCases = []struct {
 				"foo":   false,
 			},
 			Status: multiwatcher.StatusInfo{
-				Current: status.StatusActive,
+				Current: status.Active,
 				Message: "all good",
 			},
 		},
@@ -103,11 +103,11 @@ var marshalTestCases = []struct {
 			PrivateAddress: "10.0.0.1",
 			MachineId:      "1",
 			WorkloadStatus: multiwatcher.StatusInfo{
-				Current: status.StatusActive,
+				Current: status.Active,
 				Message: "all good",
 			},
 			AgentStatus: multiwatcher.StatusInfo{
-				Current: status.StatusIdle,
+				Current: status.Idle,
 			},
 		},
 	},

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -305,7 +305,7 @@ func (p *ProvisionerAPI) MachinesWithTransientErrors() (params.StatusResults, er
 		result.Status = statusInfo.Status.String()
 		result.Info = statusInfo.Message
 		result.Data = statusInfo.Data
-		if statusInfo.Status != status.StatusError {
+		if statusInfo.Status != status.Error {
 			continue
 		}
 		// Transient errors are marked as such in the status data.

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -321,21 +321,21 @@ func (s *withoutControllerSuite) TestRemove(c *gc.C) {
 func (s *withoutControllerSuite) TestSetStatus(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusStarted,
+		Status:  status.Started,
 		Message: "blah",
 		Since:   &now,
 	}
 	err := s.machines[0].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusStopped,
+		Status:  status.Stopped,
 		Message: "foo",
 		Since:   &now,
 	}
 	err = s.machines[1].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "not really",
 		Since:   &now,
 	}
@@ -344,13 +344,13 @@ func (s *withoutControllerSuite) TestSetStatus(c *gc.C) {
 
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: s.machines[0].Tag().String(), Status: status.StatusError.String(), Info: "not really",
+			{Tag: s.machines[0].Tag().String(), Status: status.Error.String(), Info: "not really",
 				Data: map[string]interface{}{"foo": "bar"}},
-			{Tag: s.machines[1].Tag().String(), Status: status.StatusStopped.String(), Info: "foobar"},
-			{Tag: s.machines[2].Tag().String(), Status: status.StatusStarted.String(), Info: "again"},
-			{Tag: "machine-42", Status: status.StatusStarted.String(), Info: "blah"},
-			{Tag: "unit-foo-0", Status: status.StatusStopped.String(), Info: "foobar"},
-			{Tag: "application-bar", Status: status.StatusStopped.String(), Info: "foobar"},
+			{Tag: s.machines[1].Tag().String(), Status: status.Stopped.String(), Info: "foobar"},
+			{Tag: s.machines[2].Tag().String(), Status: status.Started.String(), Info: "again"},
+			{Tag: "machine-42", Status: status.Started.String(), Info: "blah"},
+			{Tag: "unit-foo-0", Status: status.Stopped.String(), Info: "foobar"},
+			{Tag: "application-bar", Status: status.Stopped.String(), Info: "foobar"},
 		}}
 	result, err := s.provisioner.SetStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -366,22 +366,22 @@ func (s *withoutControllerSuite) TestSetStatus(c *gc.C) {
 	})
 
 	// Verify the changes.
-	s.assertStatus(c, 0, status.StatusError, "not really", map[string]interface{}{"foo": "bar"})
-	s.assertStatus(c, 1, status.StatusStopped, "foobar", map[string]interface{}{})
-	s.assertStatus(c, 2, status.StatusStarted, "again", map[string]interface{}{})
+	s.assertStatus(c, 0, status.Error, "not really", map[string]interface{}{"foo": "bar"})
+	s.assertStatus(c, 1, status.Stopped, "foobar", map[string]interface{}{})
+	s.assertStatus(c, 2, status.Started, "again", map[string]interface{}{})
 }
 
 func (s *withoutControllerSuite) TestMachinesWithTransientErrors(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusStarted,
+		Status:  status.Started,
 		Message: "blah",
 		Since:   &now,
 	}
 	err := s.machines[0].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "transient error",
 		Data:    map[string]interface{}{"transient": true, "foo": "bar"},
 		Since:   &now,
@@ -389,7 +389,7 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrors(c *gc.C) {
 	err = s.machines[1].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "error",
 		Data:    map[string]interface{}{"transient": false},
 		Since:   &now,
@@ -397,7 +397,7 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrors(c *gc.C) {
 	err = s.machines[2].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "error",
 		Since:   &now,
 	}
@@ -405,7 +405,7 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrors(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	// Machine 4 is provisioned but error not reset yet.
 	sInfo = status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "transient error",
 		Data:    map[string]interface{}{"transient": true, "foo": "bar"},
 		Since:   &now,
@@ -435,14 +435,14 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrorsPermission(c *gc
 		anAuthorizer)
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusStarted,
+		Status:  status.Started,
 		Message: "blah",
 		Since:   &now,
 	}
 	err = s.machines[0].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "transient error",
 		Data:    map[string]interface{}{"transient": true, "foo": "bar"},
 		Since:   &now,
@@ -450,7 +450,7 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrorsPermission(c *gc
 	err = s.machines[1].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "error",
 		Data:    map[string]interface{}{"transient": false},
 		Since:   &now,
@@ -458,7 +458,7 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrorsPermission(c *gc
 	err = s.machines[2].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "error",
 		Since:   &now,
 	}
@@ -614,21 +614,21 @@ func (s *withoutControllerSuite) TestModelConfigNonManager(c *gc.C) {
 func (s *withoutControllerSuite) TestStatus(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusStarted,
+		Status:  status.Started,
 		Message: "blah",
 		Since:   &now,
 	}
 	err := s.machines[0].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusStopped,
+		Status:  status.Stopped,
 		Message: "foo",
 		Since:   &now,
 	}
 	err = s.machines[1].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "not really",
 		Data:    map[string]interface{}{"foo": "bar"},
 		Since:   &now,
@@ -657,9 +657,9 @@ func (s *withoutControllerSuite) TestStatus(c *gc.C) {
 	}
 	c.Assert(result, gc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
-			{Status: status.StatusStarted.String(), Info: "blah", Data: map[string]interface{}{}},
-			{Status: status.StatusStopped.String(), Info: "foo", Data: map[string]interface{}{}},
-			{Status: status.StatusError.String(), Info: "not really", Data: map[string]interface{}{"foo": "bar"}},
+			{Status: status.Started.String(), Info: "blah", Data: map[string]interface{}{}},
+			{Status: status.Stopped.String(), Info: "foo", Data: map[string]interface{}{}},
+			{Status: status.Error.String(), Info: "not really", Data: map[string]interface{}{"foo": "bar"}},
 			{Error: apiservertesting.NotFoundError("machine 42")},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},

--- a/apiserver/storage/mock_test.go
+++ b/apiserver/storage/mock_test.go
@@ -209,7 +209,7 @@ func (m *mockVolume) Info() (state.VolumeInfo, error) {
 }
 
 func (m *mockVolume) Status() (status.StatusInfo, error) {
-	return status.StatusInfo{Status: status.StatusAttached}, nil
+	return status.StatusInfo{Status: status.Attached}, nil
 }
 
 type mockFilesystem struct {
@@ -246,7 +246,7 @@ func (m *mockFilesystem) Info() (state.FilesystemInfo, error) {
 }
 
 func (m *mockFilesystem) Status() (status.StatusInfo, error) {
-	return status.StatusInfo{Status: status.StatusAttached}, nil
+	return status.StatusInfo{Status: status.Attached}, nil
 }
 
 type mockFilesystemAttachment struct {

--- a/apiserver/storage/storage_test.go
+++ b/apiserver/storage/storage_test.go
@@ -84,7 +84,7 @@ func (s *storageSuite) TestStorageListVolume(c *gc.C) {
 	c.Assert(found.Results[0].Result, gc.HasLen, 1)
 	wantedDetails := s.createTestStorageDetails()
 	wantedDetails.Kind = params.StorageKindBlock
-	wantedDetails.Status.Status = status.StatusAttached
+	wantedDetails.Status.Status = status.Attached
 	c.Assert(found.Results[0].Result[0], jc.DeepEquals, wantedDetails)
 }
 

--- a/apiserver/storage/volumelist_test.go
+++ b/apiserver/storage/volumelist_test.go
@@ -151,7 +151,7 @@ func (s *volumeSuite) TestListVolumesStorageLocationNoBlockDevice(c *gc.C) {
 	}
 	expected := s.expectedVolumeDetails()
 	expected.Storage.Kind = params.StorageKindBlock
-	expected.Storage.Status.Status = status.StatusAttached
+	expected.Storage.Status.Status = status.Attached
 	expected.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentInfo{
 		ReadOnly: true,
 	}
@@ -177,7 +177,7 @@ func (s *volumeSuite) TestListVolumesStorageLocationBlockDevicePath(c *gc.C) {
 	}
 	expected := s.expectedVolumeDetails()
 	expected.Storage.Kind = params.StorageKindBlock
-	expected.Storage.Status.Status = status.StatusAttached
+	expected.Storage.Status.Status = status.Attached
 	storageAttachmentDetails := expected.Storage.Attachments["unit-mysql-0"]
 	storageAttachmentDetails.Location = filepath.FromSlash("/dev/sdd")
 	expected.Storage.Attachments["unit-mysql-0"] = storageAttachmentDetails

--- a/apiserver/undertaker/undertaker_test.go
+++ b/apiserver/undertaker/undertaker_test.go
@@ -161,14 +161,14 @@ func (s *undertakerSuite) TestSetStatus(c *gc.C) {
 
 	results, err := hostedAPI.SetStatus(params.SetStatus{
 		Entities: []params.EntityStatusArgs{{
-			mock.env.Tag().String(), status.StatusDestroying.String(),
+			mock.env.Tag().String(), status.Destroying.String(),
 			"woop", map[string]interface{}{"da": "ta"},
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
-	c.Assert(mock.env.status, gc.Equals, status.StatusDestroying)
+	c.Assert(mock.env.status, gc.Equals, status.Destroying)
 	c.Assert(mock.env.statusInfo, gc.Equals, "woop")
 	c.Assert(mock.env.statusData, jc.DeepEquals, map[string]interface{}{"da": "ta"})
 }
@@ -177,7 +177,7 @@ func (s *undertakerSuite) TestSetStatusControllerPermissions(c *gc.C) {
 	_, hostedAPI := s.setupStateAndAPI(c, true, "hostedenv")
 	results, err := hostedAPI.SetStatus(params.SetStatus{
 		Entities: []params.EntityStatusArgs{{
-			"model-6ada782f-bcd4-454b-a6da-d1793fbcb35e", status.StatusDestroying.String(),
+			"model-6ada782f-bcd4-454b-a6da-d1793fbcb35e", status.Destroying.String(),
 			"woop", map[string]interface{}{"da": "ta"},
 		}},
 	})
@@ -190,7 +190,7 @@ func (s *undertakerSuite) TestSetStatusNonControllerPermissions(c *gc.C) {
 	_, hostedAPI := s.setupStateAndAPI(c, false, "hostedenv")
 	results, err := hostedAPI.SetStatus(params.SetStatus{
 		Entities: []params.EntityStatusArgs{{
-			"model-6ada782f-bcd4-454b-a6da-d1793fbcb35e", status.StatusDestroying.String(),
+			"model-6ada782f-bcd4-454b-a6da-d1793fbcb35e", status.Destroying.String(),
 			"woop", map[string]interface{}{"da": "ta"},
 		}},
 	})

--- a/apiserver/uniter/uniter_test.go
+++ b/apiserver/uniter/uniter_test.go
@@ -134,14 +134,14 @@ func (s *uniterSuite) TestUniterFailsWithNonUnitAgentUser(c *gc.C) {
 func (s *uniterSuite) TestSetStatus(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusExecuting,
+		Status:  status.Executing,
 		Message: "blah",
 		Since:   &now,
 	}
 	err := s.wordpressUnit.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusExecuting,
+		Status:  status.Executing,
 		Message: "foo",
 		Since:   &now,
 	}
@@ -150,9 +150,9 @@ func (s *uniterSuite) TestSetStatus(c *gc.C) {
 
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: "unit-mysql-0", Status: status.StatusError.String(), Info: "not really"},
-			{Tag: "unit-wordpress-0", Status: status.StatusRebooting.String(), Info: "foobar"},
-			{Tag: "unit-foo-42", Status: status.StatusActive.String(), Info: "blah"},
+			{Tag: "unit-mysql-0", Status: status.Error.String(), Info: "not really"},
+			{Tag: "unit-wordpress-0", Status: status.Rebooting.String(), Info: "foobar"},
+			{Tag: "unit-foo-42", Status: status.Active.String(), Info: "blah"},
 		}}
 	result, err := s.uniter.SetStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -167,26 +167,26 @@ func (s *uniterSuite) TestSetStatus(c *gc.C) {
 	// Verify mysqlUnit - no change.
 	statusInfo, err := s.mysqlUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusExecuting)
+	c.Assert(statusInfo.Status, gc.Equals, status.Executing)
 	c.Assert(statusInfo.Message, gc.Equals, "foo")
 	// ...wordpressUnit is fine though.
 	statusInfo, err = s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusRebooting)
+	c.Assert(statusInfo.Status, gc.Equals, status.Rebooting)
 	c.Assert(statusInfo.Message, gc.Equals, "foobar")
 }
 
 func (s *uniterSuite) TestSetAgentStatus(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusExecuting,
+		Status:  status.Executing,
 		Message: "blah",
 		Since:   &now,
 	}
 	err := s.wordpressUnit.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusExecuting,
+		Status:  status.Executing,
 		Message: "foo",
 		Since:   &now,
 	}
@@ -195,9 +195,9 @@ func (s *uniterSuite) TestSetAgentStatus(c *gc.C) {
 
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: "unit-mysql-0", Status: status.StatusError.String(), Info: "not really"},
-			{Tag: "unit-wordpress-0", Status: status.StatusExecuting.String(), Info: "foobar"},
-			{Tag: "unit-foo-42", Status: status.StatusRebooting.String(), Info: "blah"},
+			{Tag: "unit-mysql-0", Status: status.Error.String(), Info: "not really"},
+			{Tag: "unit-wordpress-0", Status: status.Executing.String(), Info: "foobar"},
+			{Tag: "unit-foo-42", Status: status.Rebooting.String(), Info: "blah"},
 		}}
 	result, err := s.uniter.SetAgentStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -212,26 +212,26 @@ func (s *uniterSuite) TestSetAgentStatus(c *gc.C) {
 	// Verify mysqlUnit - no change.
 	statusInfo, err := s.mysqlUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusExecuting)
+	c.Assert(statusInfo.Status, gc.Equals, status.Executing)
 	c.Assert(statusInfo.Message, gc.Equals, "foo")
 	// ...wordpressUnit is fine though.
 	statusInfo, err = s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusExecuting)
+	c.Assert(statusInfo.Status, gc.Equals, status.Executing)
 	c.Assert(statusInfo.Message, gc.Equals, "foobar")
 }
 
 func (s *uniterSuite) TestSetUnitStatus(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusActive,
+		Status:  status.Active,
 		Message: "blah",
 		Since:   &now,
 	}
 	err := s.wordpressUnit.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusTerminated,
+		Status:  status.Terminated,
 		Message: "foo",
 		Since:   &now,
 	}
@@ -240,9 +240,9 @@ func (s *uniterSuite) TestSetUnitStatus(c *gc.C) {
 
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: "unit-mysql-0", Status: status.StatusError.String(), Info: "not really"},
-			{Tag: "unit-wordpress-0", Status: status.StatusTerminated.String(), Info: "foobar"},
-			{Tag: "unit-foo-42", Status: status.StatusActive.String(), Info: "blah"},
+			{Tag: "unit-mysql-0", Status: status.Error.String(), Info: "not really"},
+			{Tag: "unit-wordpress-0", Status: status.Terminated.String(), Info: "foobar"},
+			{Tag: "unit-foo-42", Status: status.Active.String(), Info: "blah"},
 		}}
 	result, err := s.uniter.SetUnitStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -257,12 +257,12 @@ func (s *uniterSuite) TestSetUnitStatus(c *gc.C) {
 	// Verify mysqlUnit - no change.
 	statusInfo, err := s.mysqlUnit.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusTerminated)
+	c.Assert(statusInfo.Status, gc.Equals, status.Terminated)
 	c.Assert(statusInfo.Message, gc.Equals, "foo")
 	// ...wordpressUnit is fine though.
 	statusInfo, err = s.wordpressUnit.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusTerminated)
+	c.Assert(statusInfo.Status, gc.Equals, status.Terminated)
 	c.Assert(statusInfo.Message, gc.Equals, "foobar")
 }
 
@@ -2139,14 +2139,14 @@ func (s *uniterSuite) TestStorageAttachments(c *gc.C) {
 func (s *uniterSuite) TestUnitStatus(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusMaintenance,
+		Status:  status.Maintenance,
 		Message: "blah",
 		Since:   &now,
 	}
 	err := s.wordpressUnit.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusTerminated,
+		Status:  status.Terminated,
 		Message: "foo",
 		Since:   &now,
 	}
@@ -2175,7 +2175,7 @@ func (s *uniterSuite) TestUnitStatus(c *gc.C) {
 	c.Assert(result, gc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
 			{Error: apiservertesting.ErrUnauthorized},
-			{Status: status.StatusMaintenance.String(), Info: "blah", Data: map[string]interface{}{}},
+			{Status: status.Maintenance.String(), Info: "blah", Data: map[string]interface{}{}},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ServerError(`"invalid" is not a valid tag`)},

--- a/cmd/juju/commands/resolved_test.go
+++ b/cmd/juju/commands/resolved_test.go
@@ -100,7 +100,7 @@ func (s *ResolvedSuite) TestResolved(c *gc.C) {
 		u, err := s.State.Unit(name)
 		c.Assert(err, jc.ErrorIsNil)
 		sInfo := status.StatusInfo{
-			Status:  status.StatusError,
+			Status:  status.Error,
 			Message: "lol borken",
 			Since:   &now,
 		}
@@ -135,7 +135,7 @@ func (s *ResolvedSuite) TestBlockResolved(c *gc.C) {
 		u, err := s.State.Unit(name)
 		c.Assert(err, jc.ErrorIsNil)
 		sInfo := status.StatusInfo{
-			Status:  status.StatusError,
+			Status:  status.Error,
 			Message: "lol borken",
 			Since:   &now,
 		}

--- a/cmd/juju/controller/listcontrollers.go
+++ b/cmd/juju/controller/listcontrollers.go
@@ -173,7 +173,7 @@ func controllerMachineCounts(controllerModelUUID string, modelStatus []base.Mode
 				continue
 			}
 			totalCount++
-			if m.Status != string(status.StatusDown) && m.HasVote {
+			if m.Status != string(status.Down) && m.HasVote {
 				activeCount++
 			}
 		}

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -73,7 +73,7 @@ func (f *fakeModelMgrAPIClient) ModelInfo(tags []names.ModelTag) ([]params.Model
 			switch model.Name {
 			case "test-model1":
 				last1 := time.Date(2015, 3, 20, 0, 0, 0, 0, time.UTC)
-				result.Status.Status = status.StatusActive
+				result.Status.Status = status.Active
 				if f.user != "" {
 					result.Users = []params.ModelUserInfo{{
 						UserName:       f.user,
@@ -89,7 +89,7 @@ func (f *fakeModelMgrAPIClient) ModelInfo(tags []names.ModelTag) ([]params.Model
 				}
 			case "test-model2":
 				last2 := time.Date(2015, 3, 1, 0, 0, 0, 0, time.UTC)
-				result.Status.Status = status.StatusActive
+				result.Status.Status = status.Active
 				if f.user != "" {
 					result.Users = []params.ModelUserInfo{{
 						UserName:       f.user,
@@ -98,7 +98,7 @@ func (f *fakeModelMgrAPIClient) ModelInfo(tags []names.ModelTag) ([]params.Model
 					}}
 				}
 			case "test-model3":
-				result.Status.Status = status.StatusDestroying
+				result.Status.Status = status.Destroying
 			}
 			results[i].Result = result
 		}

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -385,7 +385,7 @@ func (c *showControllerCommand) convertMachinesForShow(
 }
 
 func haStatus(hasVote bool, wantsVote bool, statusStr string) string {
-	if statusStr == string(status.StatusDown) {
+	if statusStr == string(status.Down) {
 		return "down, lost connection"
 	}
 	if !wantsVote {

--- a/cmd/juju/model/show_test.go
+++ b/cmd/juju/model/show_test.go
@@ -80,7 +80,7 @@ func (s *ShowCommandSuite) SetUpTest(c *gc.C) {
 		ProviderType:   "openstack",
 		Life:           params.Alive,
 		Status: params.EntityStatus{
-			Status: status.StatusActive,
+			Status: status.Active,
 			Since:  &statusSince,
 		},
 		Users: users,

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -131,7 +131,7 @@ func (s *formattedStatus) applicationScale(name string) (string, bool) {
 	match := func(u unitStatus) {
 		desiredUnitCount += 1
 		switch u.JujuStatusInfo.Current {
-		case status.StatusExecuting, status.StatusIdle:
+		case status.Executing, status.Idle:
 			currentUnitCount += 1
 		}
 	}

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -267,7 +267,7 @@ func (sf *statusFormatter) getAgentStatusInfo(unit params.UnitStatus) statusInfo
 
 func (sf *statusFormatter) updateUnitStatusInfo(unit *params.UnitStatus, applicationName string) {
 	// TODO(perrito66) add status validation.
-	if status.Status(unit.WorkloadStatus.Status) == status.StatusError {
+	if status.Status(unit.WorkloadStatus.Status) == status.Error {
 		if relation, ok := sf.relations[getRelationIdFromData(unit)]; ok {
 			// Append the details of the other endpoint on to the status info string.
 			if ep, ok := findOtherEndpoint(relation.Endpoints, applicationName); ok {

--- a/cmd/juju/status/output_summary.go
+++ b/cmd/juju/status/output_summary.go
@@ -163,7 +163,7 @@ func (f *summaryFormatter) aggregateMachineStates(machines map[string]machineSta
 		f.resolveAndTrackIp(m.DNSName)
 
 		if agentState := m.JujuStatus.Current; agentState == "" {
-			agentState = status.StatusPending
+			agentState = status.Pending
 		} else {
 			stateToMachine[agentState]++
 		}

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -279,7 +279,7 @@ func FormatMachineTabular(writer io.Writer, forceColor bool, value interface{}) 
 // the agent is currently executing.
 // The hook name or action is extracted from the agent message.
 func agentDoing(agentStatus statusInfoContents) string {
-	if agentStatus.Current != status.StatusExecuting {
+	if agentStatus.Current != status.Executing {
 		return ""
 	}
 	// First see if we can determine a hook name.

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -404,7 +404,7 @@ var statusTests = []testCase{
 			},
 		},
 
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 		expect{
 			"simulate the MA started and set the machine status",
 			M{
@@ -451,7 +451,7 @@ var statusTests = []testCase{
 			network.NewScopedAddress("controller-0.dns", network.ScopePublic),
 		}},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 		expect{
 			"machine 0 has specific hardware characteristics",
 			M{
@@ -481,7 +481,7 @@ var statusTests = []testCase{
 		"instance without addresses",
 		addMachine{machineId: "0", cons: machineCons, job: state.JobManageModel},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 		expect{
 			"machine 0 has no dns-name",
 			M{
@@ -564,7 +564,7 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("controller-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 		addCharm{"dummy"},
 		addService{name: "dummy-application", charm: "dummy"},
 		addService{name: "exposed-application", charm: "dummy"},
@@ -602,11 +602,11 @@ var statusTests = []testCase{
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("controller-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", status.StatusStarted, ""},
+		setMachineStatus{"1", status.Started, ""},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("controller-2.dns")},
 		startAliveMachine{"2"},
-		setMachineStatus{"2", status.StatusStarted, ""},
+		setMachineStatus{"2", status.Started, ""},
 		expect{
 			"two more machines added",
 			M{
@@ -626,7 +626,7 @@ var statusTests = []testCase{
 		// step 19
 		addAliveUnit{"dummy-application", "1"},
 		addAliveUnit{"exposed-application", "2"},
-		setAgentStatus{"exposed-application/0", status.StatusError, "You Require More Vespene Gas", nil},
+		setAgentStatus{"exposed-application/0", status.Error, "You Require More Vespene Gas", nil},
 		// Open multiple ports with different protocols,
 		// ensure they're sorted on protocol, then number.
 		openUnitPort{"exposed-application/0", "udp", 10},
@@ -636,8 +636,8 @@ var statusTests = []testCase{
 		// Simulate some status with no info, while the agent is down.
 		// Status used to be down, we no longer support said state.
 		// now is one of: pending, started, error.
-		setUnitStatus{"dummy-application/0", status.StatusTerminated, "", nil},
-		setAgentStatus{"dummy-application/0", status.StatusIdle, "", nil},
+		setUnitStatus{"dummy-application/0", status.Terminated, "", nil},
+		setAgentStatus{"dummy-application/0", status.Idle, "", nil},
 
 		expect{
 			"add two units, one alive (in error state), one started",
@@ -704,11 +704,11 @@ var statusTests = []testCase{
 		startMachine{"3"},
 		// Simulate some status with info, while the agent is down.
 		setAddresses{"3", network.NewAddresses("controller-3.dns")},
-		setMachineStatus{"3", status.StatusStopped, "Really?"},
+		setMachineStatus{"3", status.Stopped, "Really?"},
 		addMachine{machineId: "4", job: state.JobHostUnits},
 		setAddresses{"4", network.NewAddresses("controller-4.dns")},
 		startAliveMachine{"4"},
-		setMachineStatus{"4", status.StatusError, "Beware the red toys"},
+		setMachineStatus{"4", status.Error, "Beware the red toys"},
 		ensureDyingUnit{"dummy-application/0"},
 		addMachine{machineId: "5", job: state.JobHostUnits},
 		ensureDeadMachine{"5"},
@@ -1021,12 +1021,12 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("controller-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("controller-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", status.StatusStarted, ""},
+		setMachineStatus{"1", status.Started, ""},
 
 		addCharm{"wordpress"},
 		addService{name: "wordpress", charm: "wordpress"},
@@ -1038,7 +1038,7 @@ var statusTests = []testCase{
 
 		relateServices{"wordpress", "mysql"},
 
-		setAgentStatus{"wordpress/0", status.StatusError,
+		setAgentStatus{"wordpress/0", status.Error,
 			"hook failed: some-relation-changed",
 			map[string]interface{}{"relation-id": 0}},
 
@@ -1110,12 +1110,12 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("controller-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("controller-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", status.StatusStarted, ""},
+		setMachineStatus{"1", status.Started, ""},
 
 		addCharm{"wordpress"},
 		addService{name: "wordpress", charm: "wordpress"},
@@ -1127,7 +1127,7 @@ var statusTests = []testCase{
 
 		relateServices{"wordpress", "mysql"},
 
-		setAgentStatus{"wordpress/0", status.StatusError,
+		setAgentStatus{"wordpress/0", status.Error,
 			"hook failed: some-relation-changed",
 			map[string]interface{}{"relation-id": 0}},
 
@@ -1253,10 +1253,10 @@ var statusTests = []testCase{
 		addService{name: "dummy-application", charm: "dummy"},
 		addMachine{machineId: "0", job: state.JobHostUnits},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 		addUnit{"dummy-application", "0"},
-		setAgentStatus{"dummy-application/0", status.StatusIdle, "", nil},
-		setUnitStatus{"dummy-application/0", status.StatusActive, "", nil},
+		setAgentStatus{"dummy-application/0", status.Idle, "", nil},
+		setUnitStatus{"dummy-application/0", status.Active, "", nil},
 		expect{
 			"unit shows that agent is lost",
 			M{
@@ -1310,7 +1310,7 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("controller-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 		addCharm{"wordpress"},
 		addCharm{"mysql"},
 		addCharm{"varnish"},
@@ -1320,27 +1320,27 @@ var statusTests = []testCase{
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("controller-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", status.StatusStarted, ""},
+		setMachineStatus{"1", status.Started, ""},
 		addAliveUnit{"project", "1"},
-		setAgentStatus{"project/0", status.StatusIdle, "", nil},
-		setUnitStatus{"project/0", status.StatusActive, "", nil},
+		setAgentStatus{"project/0", status.Idle, "", nil},
+		setUnitStatus{"project/0", status.Active, "", nil},
 
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("controller-2.dns")},
 		startAliveMachine{"2"},
-		setMachineStatus{"2", status.StatusStarted, ""},
+		setMachineStatus{"2", status.Started, ""},
 		addAliveUnit{"mysql", "2"},
-		setAgentStatus{"mysql/0", status.StatusIdle, "", nil},
-		setUnitStatus{"mysql/0", status.StatusActive, "", nil},
+		setAgentStatus{"mysql/0", status.Idle, "", nil},
+		setUnitStatus{"mysql/0", status.Active, "", nil},
 
 		addService{name: "varnish", charm: "varnish"},
 		setServiceExposed{"varnish", true},
 		addMachine{machineId: "3", job: state.JobHostUnits},
 		setAddresses{"3", network.NewAddresses("controller-3.dns")},
 		startAliveMachine{"3"},
-		setMachineStatus{"3", status.StatusStarted, ""},
+		setMachineStatus{"3", status.Started, ""},
 		addAliveUnit{"varnish", "3"},
 
 		addService{name: "private", charm: "wordpress"},
@@ -1348,7 +1348,7 @@ var statusTests = []testCase{
 		addMachine{machineId: "4", job: state.JobHostUnits},
 		setAddresses{"4", network.NewAddresses("controller-4.dns")},
 		startAliveMachine{"4"},
-		setMachineStatus{"4", status.StatusStarted, ""},
+		setMachineStatus{"4", status.Started, ""},
 		addAliveUnit{"private", "4"},
 
 		relateServices{"project", "mysql"},
@@ -1483,7 +1483,7 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("controller-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 		addCharm{"riak"},
 		addCharm{"wordpress"},
 
@@ -1492,24 +1492,24 @@ var statusTests = []testCase{
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("controller-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", status.StatusStarted, ""},
+		setMachineStatus{"1", status.Started, ""},
 		addAliveUnit{"riak", "1"},
-		setAgentStatus{"riak/0", status.StatusIdle, "", nil},
-		setUnitStatus{"riak/0", status.StatusActive, "", nil},
+		setAgentStatus{"riak/0", status.Idle, "", nil},
+		setUnitStatus{"riak/0", status.Active, "", nil},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("controller-2.dns")},
 		startAliveMachine{"2"},
-		setMachineStatus{"2", status.StatusStarted, ""},
+		setMachineStatus{"2", status.Started, ""},
 		addAliveUnit{"riak", "2"},
-		setAgentStatus{"riak/1", status.StatusIdle, "", nil},
-		setUnitStatus{"riak/1", status.StatusActive, "", nil},
+		setAgentStatus{"riak/1", status.Idle, "", nil},
+		setUnitStatus{"riak/1", status.Active, "", nil},
 		addMachine{machineId: "3", job: state.JobHostUnits},
 		setAddresses{"3", network.NewAddresses("controller-3.dns")},
 		startAliveMachine{"3"},
-		setMachineStatus{"3", status.StatusStarted, ""},
+		setMachineStatus{"3", status.Started, ""},
 		addAliveUnit{"riak", "3"},
-		setAgentStatus{"riak/2", status.StatusIdle, "", nil},
-		setUnitStatus{"riak/2", status.StatusActive, "", nil},
+		setAgentStatus{"riak/2", status.Idle, "", nil},
+		setUnitStatus{"riak/2", status.Active, "", nil},
 
 		expect{
 			"multiples related peer units",
@@ -1587,7 +1587,7 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("controller-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 		addCharm{"wordpress"},
 		addCharm{"mysql"},
 		addCharm{"logging"},
@@ -1597,20 +1597,20 @@ var statusTests = []testCase{
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("controller-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", status.StatusStarted, ""},
+		setMachineStatus{"1", status.Started, ""},
 		addAliveUnit{"wordpress", "1"},
-		setAgentStatus{"wordpress/0", status.StatusIdle, "", nil},
-		setUnitStatus{"wordpress/0", status.StatusActive, "", nil},
+		setAgentStatus{"wordpress/0", status.Idle, "", nil},
+		setUnitStatus{"wordpress/0", status.Active, "", nil},
 
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("controller-2.dns")},
 		startAliveMachine{"2"},
-		setMachineStatus{"2", status.StatusStarted, ""},
+		setMachineStatus{"2", status.Started, ""},
 		addAliveUnit{"mysql", "2"},
-		setAgentStatus{"mysql/0", status.StatusIdle, "", nil},
-		setUnitStatus{"mysql/0", status.StatusActive, "", nil},
+		setAgentStatus{"mysql/0", status.Idle, "", nil},
+		setUnitStatus{"mysql/0", status.Active, "", nil},
 
 		addService{name: "logging", charm: "logging"},
 		setServiceExposed{"logging", true},
@@ -1623,9 +1623,9 @@ var statusTests = []testCase{
 		addSubordinate{"mysql/0", "logging"},
 
 		setUnitsAlive{"logging"},
-		setAgentStatus{"logging/0", status.StatusIdle, "", nil},
-		setUnitStatus{"logging/0", status.StatusActive, "", nil},
-		setAgentStatus{"logging/1", status.StatusError, "somehow lost in all those logs", nil},
+		setAgentStatus{"logging/0", status.Idle, "", nil},
+		setUnitStatus{"logging/0", status.Active, "", nil},
+		setAgentStatus{"logging/1", status.Error, "somehow lost in all those logs", nil},
 
 		expect{
 			"multiples related peer units",
@@ -1871,7 +1871,7 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("controller-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 		addCharm{"mysql"},
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
@@ -1880,26 +1880,26 @@ var statusTests = []testCase{
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("controller-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", status.StatusStarted, ""},
+		setMachineStatus{"1", status.Started, ""},
 		addAliveUnit{"mysql", "1"},
-		setAgentStatus{"mysql/0", status.StatusIdle, "", nil},
-		setUnitStatus{"mysql/0", status.StatusActive, "", nil},
+		setAgentStatus{"mysql/0", status.Idle, "", nil},
+		setUnitStatus{"mysql/0", status.Active, "", nil},
 
 		// step 14: A container on machine 1.
 		addContainer{"1", "1/lxd/0", state.JobHostUnits},
 		setAddresses{"1/lxd/0", network.NewAddresses("controller-2.dns")},
 		startAliveMachine{"1/lxd/0"},
-		setMachineStatus{"1/lxd/0", status.StatusStarted, ""},
+		setMachineStatus{"1/lxd/0", status.Started, ""},
 		addAliveUnit{"mysql", "1/lxd/0"},
-		setAgentStatus{"mysql/1", status.StatusIdle, "", nil},
-		setUnitStatus{"mysql/1", status.StatusActive, "", nil},
+		setAgentStatus{"mysql/1", status.Idle, "", nil},
+		setUnitStatus{"mysql/1", status.Active, "", nil},
 		addContainer{"1", "1/lxd/1", state.JobHostUnits},
 
 		// step 22: A nested container.
 		addContainer{"1/lxd/0", "1/lxd/0/lxd/0", state.JobHostUnits},
 		setAddresses{"1/lxd/0/lxd/0", network.NewAddresses("controller-3.dns")},
 		startAliveMachine{"1/lxd/0/lxd/0"},
-		setMachineStatus{"1/lxd/0/lxd/0", status.StatusStarted, ""},
+		setMachineStatus{"1/lxd/0/lxd/0", status.Started, ""},
 
 		expect{
 			"machines with nested containers",
@@ -2017,11 +2017,11 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("controller-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("controller-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", status.StatusStarted, ""},
+		setMachineStatus{"1", status.Started, ""},
 		addCharm{"mysql"},
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
@@ -2070,11 +2070,11 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("controller-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("controller-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", status.StatusStarted, ""},
+		setMachineStatus{"1", status.Started, ""},
 		addCharm{"mysql"},
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
@@ -2125,11 +2125,11 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("controller-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("controller-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", status.StatusStarted, ""},
+		setMachineStatus{"1", status.Started, ""},
 		addCharm{"mysql"},
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
@@ -2182,11 +2182,11 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("controller-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("controller-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", status.StatusStarted, ""},
+		setMachineStatus{"1", status.Started, ""},
 		addCharm{"mysql"},
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
@@ -2238,27 +2238,27 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("controller-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("controller-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", status.StatusStarted, ""},
+		setMachineStatus{"1", status.Started, ""},
 
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("controller-2.dns")},
 		startAliveMachine{"2"},
-		setMachineStatus{"2", status.StatusStarted, ""},
+		setMachineStatus{"2", status.Started, ""},
 
 		addMachine{machineId: "3", job: state.JobHostUnits},
 		setAddresses{"3", network.NewAddresses("controller-3.dns")},
 		startAliveMachine{"3"},
-		setMachineStatus{"3", status.StatusStarted, ""},
+		setMachineStatus{"3", status.Started, ""},
 
 		addMachine{machineId: "4", job: state.JobHostUnits},
 		setAddresses{"4", network.NewAddresses("controller-4.dns")},
 		startAliveMachine{"4"},
-		setMachineStatus{"4", status.StatusStarted, ""},
+		setMachineStatus{"4", status.Started, ""},
 
 		addCharm{"mysql"},
 		addService{name: "mysql", charm: "mysql"},
@@ -2273,14 +2273,14 @@ var statusTests = []testCase{
 
 		setServiceExposed{"mysql", true},
 
-		setAgentStatus{"mysql/0", status.StatusIdle, "", nil},
-		setUnitStatus{"mysql/0", status.StatusActive, "", nil},
-		setAgentStatus{"servicewithmeterstatus/0", status.StatusIdle, "", nil},
-		setUnitStatus{"servicewithmeterstatus/0", status.StatusActive, "", nil},
-		setAgentStatus{"servicewithmeterstatus/1", status.StatusIdle, "", nil},
-		setUnitStatus{"servicewithmeterstatus/1", status.StatusActive, "", nil},
-		setAgentStatus{"servicewithmeterstatus/2", status.StatusIdle, "", nil},
-		setUnitStatus{"servicewithmeterstatus/2", status.StatusActive, "", nil},
+		setAgentStatus{"mysql/0", status.Idle, "", nil},
+		setUnitStatus{"mysql/0", status.Active, "", nil},
+		setAgentStatus{"servicewithmeterstatus/0", status.Idle, "", nil},
+		setUnitStatus{"servicewithmeterstatus/0", status.Active, "", nil},
+		setAgentStatus{"servicewithmeterstatus/1", status.Idle, "", nil},
+		setUnitStatus{"servicewithmeterstatus/1", status.Active, "", nil},
+		setAgentStatus{"servicewithmeterstatus/2", status.Idle, "", nil},
+		setUnitStatus{"servicewithmeterstatus/2", status.Active, "", nil},
 
 		setUnitMeterStatus{"servicewithmeterstatus/1", "GREEN", "test green status"},
 		setUnitMeterStatus{"servicewithmeterstatus/2", "RED", "test red status"},
@@ -2399,7 +2399,7 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("controller-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 
 		addCharm{"mysql"},
 		addService{name: "mysql", charm: "mysql"},
@@ -2407,7 +2407,7 @@ var statusTests = []testCase{
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("controller-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", status.StatusStarted, ""},
+		setMachineStatus{"1", status.Started, ""},
 		addAliveUnit{"mysql", "1"},
 		setUnitWorkloadVersion{"mysql/0", "the best!"},
 
@@ -2452,7 +2452,7 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("controller-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 
 		addCharm{"mysql"},
 		addService{name: "mysql", charm: "mysql"},
@@ -2460,14 +2460,14 @@ var statusTests = []testCase{
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("controller-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", status.StatusStarted, ""},
+		setMachineStatus{"1", status.Started, ""},
 		addAliveUnit{"mysql", "1"},
 		setUnitWorkloadVersion{"mysql/0", "the best!"},
 
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("controller-2.dns")},
 		startAliveMachine{"2"},
-		setMachineStatus{"2", status.StatusStarted, ""},
+		setMachineStatus{"2", status.Started, ""},
 		addAliveUnit{"mysql", "2"},
 		setUnitWorkloadVersion{"mysql/1", "not as good"},
 
@@ -2638,7 +2638,7 @@ func (sm startMissingMachine) step(c *gc.C, ctx *context) {
 	// lp:1558657
 	now := time.Now()
 	s := status.StatusInfo{
-		Status:  status.StatusUnknown,
+		Status:  status.Unknown,
 		Message: "missing",
 		Since:   &now,
 	}
@@ -2933,14 +2933,14 @@ func (uc setUnitCharmURL) step(c *gc.C, ctx *context) {
 	// lp:1558657
 	now := time.Now()
 	s := status.StatusInfo{
-		Status:  status.StatusActive,
+		Status:  status.Active,
 		Message: "",
 		Since:   &now,
 	}
 	err = u.SetStatus(s)
 	c.Assert(err, jc.ErrorIsNil)
 	sInfo := status.StatusInfo{
-		Status:  status.StatusIdle,
+		Status:  status.Idle,
 		Message: "",
 		Since:   &now,
 	}
@@ -3293,7 +3293,7 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("localhost")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 		addCharm{"wordpress"},
 		addCharm{"mysql"},
 		addCharm{"logging"},
@@ -3302,19 +3302,19 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("localhost")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", status.StatusStarted, ""},
+		setMachineStatus{"1", status.Started, ""},
 		addAliveUnit{"wordpress", "1"},
-		setAgentStatus{"wordpress/0", status.StatusIdle, "", nil},
-		setUnitStatus{"wordpress/0", status.StatusActive, "", nil},
+		setAgentStatus{"wordpress/0", status.Idle, "", nil},
+		setUnitStatus{"wordpress/0", status.Active, "", nil},
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("10.0.0.1")},
 		startAliveMachine{"2"},
-		setMachineStatus{"2", status.StatusStarted, ""},
+		setMachineStatus{"2", status.Started, ""},
 		addAliveUnit{"mysql", "2"},
-		setAgentStatus{"mysql/0", status.StatusIdle, "", nil},
-		setUnitStatus{"mysql/0", status.StatusActive, "", nil},
+		setAgentStatus{"mysql/0", status.Idle, "", nil},
+		setUnitStatus{"mysql/0", status.Active, "", nil},
 		addService{name: "logging", charm: "logging"},
 		setServiceExposed{"logging", true},
 		relateServices{"wordpress", "mysql"},
@@ -3323,9 +3323,9 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 		addSubordinate{"wordpress/0", "logging"},
 		addSubordinate{"mysql/0", "logging"},
 		setUnitsAlive{"logging"},
-		setAgentStatus{"logging/0", status.StatusIdle, "", nil},
-		setUnitStatus{"logging/0", status.StatusActive, "", nil},
-		setAgentStatus{"logging/1", status.StatusError, "somehow lost in all those logs", nil},
+		setAgentStatus{"logging/0", status.Idle, "", nil},
+		setUnitStatus{"logging/0", status.Active, "", nil},
+		setAgentStatus{"logging/1", status.Error, "somehow lost in all those logs", nil},
 	}
 	for _, s := range steps {
 		s.step(c, ctx)
@@ -3357,7 +3357,7 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("controller-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 		addCharm{"wordpress"},
 		addCharm{"mysql"},
 		addCharm{"logging"},
@@ -3367,20 +3367,20 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("controller-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", status.StatusStarted, ""},
+		setMachineStatus{"1", status.Started, ""},
 		addAliveUnit{"wordpress", "1"},
-		setAgentStatus{"wordpress/0", status.StatusIdle, "", nil},
-		setUnitStatus{"wordpress/0", status.StatusActive, "", nil},
+		setAgentStatus{"wordpress/0", status.Idle, "", nil},
+		setUnitStatus{"wordpress/0", status.Active, "", nil},
 
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("controller-2.dns")},
 		startAliveMachine{"2"},
-		setMachineStatus{"2", status.StatusStarted, ""},
+		setMachineStatus{"2", status.Started, ""},
 		addAliveUnit{"mysql", "2"},
-		setAgentStatus{"mysql/0", status.StatusIdle, "", nil},
-		setUnitStatus{"mysql/0", status.StatusActive, "", nil},
+		setAgentStatus{"mysql/0", status.Idle, "", nil},
+		setUnitStatus{"mysql/0", status.Active, "", nil},
 
 		addService{name: "logging", charm: "logging"},
 		setServiceExposed{"logging", true},
@@ -3393,9 +3393,9 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 		addSubordinate{"mysql/0", "logging"},
 
 		setUnitsAlive{"logging"},
-		setAgentStatus{"logging/0", status.StatusIdle, "", nil},
-		setUnitStatus{"logging/0", status.StatusActive, "", nil},
-		setAgentStatus{"logging/1", status.StatusError, "somehow lost in all those logs", nil},
+		setAgentStatus{"logging/0", status.Idle, "", nil},
+		setUnitStatus{"logging/0", status.Active, "", nil},
+		setAgentStatus{"logging/1", status.Error, "somehow lost in all those logs", nil},
 	}
 
 	ctx.run(c, steps)
@@ -3435,7 +3435,7 @@ func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("controller-0.dns")},
 		startMachineWithHardware{"0", instance.MustParseHardware("availability-zone=us-east-1a")},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 		addCharm{"wordpress"},
 		addCharm{"mysql"},
 		addCharm{"logging"},
@@ -3444,22 +3444,22 @@ func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("controller-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", status.StatusStarted, ""},
+		setMachineStatus{"1", status.Started, ""},
 		addAliveUnit{"wordpress", "1"},
-		setAgentStatus{"wordpress/0", status.StatusIdle, "", nil},
-		setUnitStatus{"wordpress/0", status.StatusActive, "", nil},
+		setAgentStatus{"wordpress/0", status.Idle, "", nil},
+		setUnitStatus{"wordpress/0", status.Active, "", nil},
 		setUnitTools{"wordpress/0", version.MustParseBinary("1.2.3-trusty-ppc")},
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("controller-2.dns")},
 		startAliveMachine{"2"},
-		setMachineStatus{"2", status.StatusStarted, ""},
+		setMachineStatus{"2", status.Started, ""},
 		addAliveUnit{"mysql", "2"},
-		setAgentStatus{"mysql/0", status.StatusIdle, "", nil},
+		setAgentStatus{"mysql/0", status.Idle, "", nil},
 		setUnitStatus{
 			"mysql/0",
-			status.StatusMaintenance,
+			status.Maintenance,
 			"installing all the things", nil},
 		setUnitTools{"mysql/0", version.MustParseBinary("1.2.3-trusty-ppc")},
 		addService{name: "logging", charm: "logging"},
@@ -3470,9 +3470,9 @@ func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 		addSubordinate{"wordpress/0", "logging"},
 		addSubordinate{"mysql/0", "logging"},
 		setUnitsAlive{"logging"},
-		setAgentStatus{"logging/0", status.StatusIdle, "", nil},
-		setUnitStatus{"logging/0", status.StatusActive, "", nil},
-		setAgentStatus{"logging/1", status.StatusError, "somehow lost in all those logs", nil},
+		setAgentStatus{"logging/0", status.Idle, "", nil},
+		setUnitStatus{"logging/0", status.Active, "", nil},
+		setAgentStatus{"logging/1", status.Error, "somehow lost in all those logs", nil},
 		setUnitWorkloadVersion{"logging/1", "a bit too long, really"},
 		setUnitWorkloadVersion{"wordpress/0", "4.5.3"},
 		setUnitWorkloadVersion{"mysql/0", "5.7.13"},
@@ -3535,21 +3535,21 @@ func (s *StatusSuite) TestFormatTabularHookActionName(c *gc.C) {
 				Units: map[string]unitStatus{
 					"foo/0": {
 						JujuStatusInfo: statusInfoContents{
-							Current: status.StatusExecuting,
+							Current: status.Executing,
 							Message: "running config-changed hook",
 						},
 						WorkloadStatusInfo: statusInfoContents{
-							Current: status.StatusMaintenance,
+							Current: status.Maintenance,
 							Message: "doing some work",
 						},
 					},
 					"foo/1": {
 						JujuStatusInfo: statusInfoContents{
-							Current: status.StatusExecuting,
+							Current: status.Executing,
 							Message: "running action backup database",
 						},
 						WorkloadStatusInfo: statusInfoContents{
-							Current: status.StatusMaintenance,
+							Current: status.Maintenance,
 							Message: "doing some work",
 						},
 					},
@@ -3609,7 +3609,7 @@ func (s *StatusSuite) TestStatusWithNilStatusApi(c *gc.C) {
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("controller-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 	}
 
 	for _, s := range steps {
@@ -3686,7 +3686,7 @@ func (s *StatusSuite) FilteringTestSetup(c *gc.C) *context {
 		// And the machine's job is to manage the environment
 		addMachine{machineId: "0", job: state.JobManageModel},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", status.StatusStarted, ""},
+		setMachineStatus{"0", status.Started, ""},
 		// And the machine's address is "controller-0.dns"
 		setAddresses{"0", network.NewAddresses("controller-0.dns")},
 		// And a container is started
@@ -3707,28 +3707,28 @@ func (s *StatusSuite) FilteringTestSetup(c *gc.C) *context {
 		// And the machine's job is to host units
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", status.StatusStarted, ""},
+		setMachineStatus{"1", status.Started, ""},
 		// And the machine's address is "controller-1.dns"
 		setAddresses{"1", network.NewAddresses("controller-1.dns")},
 		// And a unit of "wordpress" is deployed to machine "1"
 		addAliveUnit{"wordpress", "1"},
 		// And the unit is started
-		setAgentStatus{"wordpress/0", status.StatusIdle, "", nil},
-		setUnitStatus{"wordpress/0", status.StatusActive, "", nil},
+		setAgentStatus{"wordpress/0", status.Idle, "", nil},
+		setUnitStatus{"wordpress/0", status.Active, "", nil},
 		// And a machine is started
 
 		// And the machine's ID is "2"
 		// And the machine's job is to host units
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		startAliveMachine{"2"},
-		setMachineStatus{"2", status.StatusStarted, ""},
+		setMachineStatus{"2", status.Started, ""},
 		// And the machine's address is "controller-2.dns"
 		setAddresses{"2", network.NewAddresses("controller-2.dns")},
 		// And a unit of "mysql" is deployed to machine "2"
 		addAliveUnit{"mysql", "2"},
 		// And the unit is started
-		setAgentStatus{"mysql/0", status.StatusIdle, "", nil},
-		setUnitStatus{"mysql/0", status.StatusActive, "", nil},
+		setAgentStatus{"mysql/0", status.Idle, "", nil},
+		setUnitStatus{"mysql/0", status.Active, "", nil},
 		// And the "logging" service is added
 		addService{name: "logging", charm: "logging"},
 		// And the service is exposed
@@ -3741,12 +3741,12 @@ func (s *StatusSuite) FilteringTestSetup(c *gc.C) *context {
 		relateServices{"mysql", "logging"},
 		// And the "logging" service is a subordinate to unit 0 of the "wordpress" service
 		addSubordinate{"wordpress/0", "logging"},
-		setAgentStatus{"logging/0", status.StatusIdle, "", nil},
-		setUnitStatus{"logging/0", status.StatusActive, "", nil},
+		setAgentStatus{"logging/0", status.Idle, "", nil},
+		setUnitStatus{"logging/0", status.Active, "", nil},
 		// And the "logging" service is a subordinate to unit 0 of the "mysql" service
 		addSubordinate{"mysql/0", "logging"},
-		setAgentStatus{"logging/1", status.StatusIdle, "", nil},
-		setUnitStatus{"logging/1", status.StatusActive, "", nil},
+		setAgentStatus{"logging/1", status.Idle, "", nil},
+		setUnitStatus{"logging/1", status.Active, "", nil},
 		setUnitsAlive{"logging"},
 	}
 
@@ -3760,9 +3760,9 @@ func (s *StatusSuite) TestFilterToActive(c *gc.C) {
 	defer s.resetContext(c, ctx)
 
 	// Given unit 1 of the "logging" service has an error
-	setAgentStatus{"logging/1", status.StatusError, "mock error", nil}.step(c, ctx)
+	setAgentStatus{"logging/1", status.Error, "mock error", nil}.step(c, ctx)
 	// And unit 0 of the "mysql" service has an error
-	setAgentStatus{"mysql/0", status.StatusError, "mock error", nil}.step(c, ctx)
+	setAgentStatus{"mysql/0", status.Error, "mock error", nil}.step(c, ctx)
 	// When I run juju status --format oneline started
 	_, stdout, stderr := runStatus(c, "--format", "oneline", "active")
 	c.Assert(string(stderr), gc.Equals, "")
@@ -3855,7 +3855,7 @@ func (s *StatusSuite) TestFilterToErrored(c *gc.C) {
 	defer s.resetContext(c, ctx)
 
 	// Given unit 1 of the "logging" service has an error
-	setAgentStatus{"logging/1", status.StatusError, "mock error", nil}.step(c, ctx)
+	setAgentStatus{"logging/1", status.Error, "mock error", nil}.step(c, ctx)
 	// When I run juju status --format oneline error
 	_, stdout, stderr := runStatus(c, "--format", "oneline", "error")
 	c.Assert(stderr, gc.IsNil)
@@ -4095,14 +4095,14 @@ var statusTimeTest = test(
 	addMachine{machineId: "0", job: state.JobManageModel},
 	setAddresses{"0", network.NewAddresses("controller-0.dns")},
 	startAliveMachine{"0"},
-	setMachineStatus{"0", status.StatusStarted, ""},
+	setMachineStatus{"0", status.Started, ""},
 	addCharm{"dummy"},
 	addService{name: "dummy-application", charm: "dummy"},
 
 	addMachine{machineId: "1", job: state.JobHostUnits},
 	startAliveMachine{"1"},
 	setAddresses{"1", network.NewAddresses("controller-1.dns")},
-	setMachineStatus{"1", status.StatusStarted, ""},
+	setMachineStatus{"1", status.Started, ""},
 
 	addAliveUnit{"dummy-application", "1"},
 	expect{

--- a/cmd/juju/storage/filesystemlist_test.go
+++ b/cmd/juju/storage/filesystemlist_test.go
@@ -182,7 +182,7 @@ func (s mockListAPI) ListFilesystems(machines []string) ([]params.FilesystemDeta
 				FilesystemId: "provider-supplied-filesystem-0-0",
 				Size:         512,
 			},
-			Status: createTestStatus(status.StatusAttached, ""),
+			Status: createTestStatus(status.Attached, ""),
 			MachineAttachments: map[string]params.FilesystemAttachmentInfo{
 				"machine-0": params.FilesystemAttachmentInfo{
 					MountPoint: "/mnt/fuji",
@@ -192,7 +192,7 @@ func (s mockListAPI) ListFilesystems(machines []string) ([]params.FilesystemDeta
 				StorageTag: "storage-db-dir-1001",
 				OwnerTag:   "unit-abc-0",
 				Kind:       params.StorageKindBlock,
-				Status:     createTestStatus(status.StatusAttached, ""),
+				Status:     createTestStatus(status.Attached, ""),
 				Attachments: map[string]params.StorageAttachmentDetails{
 					"unit-abc-0": params.StorageAttachmentDetails{
 						StorageTag: "storage-db-dir-1001",
@@ -211,7 +211,7 @@ func (s mockListAPI) ListFilesystems(machines []string) ([]params.FilesystemDeta
 				FilesystemId: "provider-supplied-filesystem-1",
 				Size:         2048,
 			},
-			Status: createTestStatus(status.StatusAttaching, "failed to attach, will retry"),
+			Status: createTestStatus(status.Attaching, "failed to attach, will retry"),
 			MachineAttachments: map[string]params.FilesystemAttachmentInfo{
 				"machine-0": params.FilesystemAttachmentInfo{},
 			},
@@ -223,7 +223,7 @@ func (s mockListAPI) ListFilesystems(machines []string) ([]params.FilesystemDeta
 			Info: params.FilesystemInfo{
 				Size: 42,
 			},
-			Status: createTestStatus(status.StatusPending, ""),
+			Status: createTestStatus(status.Pending, ""),
 			MachineAttachments: map[string]params.FilesystemAttachmentInfo{
 				"machine-1": params.FilesystemAttachmentInfo{},
 			},
@@ -236,7 +236,7 @@ func (s mockListAPI) ListFilesystems(machines []string) ([]params.FilesystemDeta
 				FilesystemId: "provider-supplied-filesystem-2",
 				Size:         3,
 			},
-			Status: createTestStatus(status.StatusAttached, ""),
+			Status: createTestStatus(status.Attached, ""),
 			MachineAttachments: map[string]params.FilesystemAttachmentInfo{
 				"machine-1": params.FilesystemAttachmentInfo{
 					MountPoint: "/mnt/zion",
@@ -251,7 +251,7 @@ func (s mockListAPI) ListFilesystems(machines []string) ([]params.FilesystemDeta
 				FilesystemId: "provider-supplied-filesystem-4",
 				Size:         1024,
 			},
-			Status: createTestStatus(status.StatusAttached, ""),
+			Status: createTestStatus(status.Attached, ""),
 			MachineAttachments: map[string]params.FilesystemAttachmentInfo{
 				"machine-0": params.FilesystemAttachmentInfo{
 					MountPoint: "/mnt/doom",
@@ -266,7 +266,7 @@ func (s mockListAPI) ListFilesystems(machines []string) ([]params.FilesystemDeta
 				StorageTag: "storage-shared-fs-0",
 				OwnerTag:   "application-transcode",
 				Kind:       params.StorageKindBlock,
-				Status:     createTestStatus(status.StatusAttached, ""),
+				Status:     createTestStatus(status.Attached, ""),
 				Attachments: map[string]params.StorageAttachmentDetails{
 					"unit-transcode-0": params.StorageAttachmentDetails{
 						StorageTag: "storage-shared-fs-0",

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -154,7 +154,7 @@ func (s mockListAPI) ListStorageDetails() ([]params.StorageDetails, error) {
 		OwnerTag:   "unit-transcode-0",
 		Kind:       params.StorageKindBlock,
 		Status: params.EntityStatus{
-			Status: status.StatusPending,
+			Status: status.Pending,
 			Since:  &epoch,
 		},
 		Attachments: map[string]params.StorageAttachmentDetails{
@@ -167,7 +167,7 @@ func (s mockListAPI) ListStorageDetails() ([]params.StorageDetails, error) {
 		OwnerTag:   "unit-postgresql-0",
 		Kind:       params.StorageKindBlock,
 		Status: params.EntityStatus{
-			Status: status.StatusAttached,
+			Status: status.Attached,
 			Since:  &epoch,
 		},
 		Persistent: true,
@@ -181,7 +181,7 @@ func (s mockListAPI) ListStorageDetails() ([]params.StorageDetails, error) {
 		OwnerTag:   "application-transcode",
 		Kind:       params.StorageKindFilesystem,
 		Status: params.EntityStatus{
-			Status: status.StatusAttached,
+			Status: status.Attached,
 			Since:  &epoch,
 		},
 		Persistent: true,

--- a/cmd/juju/storage/volumelist_test.go
+++ b/cmd/juju/storage/volumelist_test.go
@@ -182,7 +182,7 @@ func (s mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsListR
 				VolumeId: "provider-supplied-volume-0-0",
 				Size:     512,
 			},
-			Status: createTestStatus(status.StatusAttached, ""),
+			Status: createTestStatus(status.Attached, ""),
 			MachineAttachments: map[string]params.VolumeAttachmentInfo{
 				"machine-0": params.VolumeAttachmentInfo{
 					DeviceName: "loop0",
@@ -192,7 +192,7 @@ func (s mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsListR
 				StorageTag: "storage-db-dir-1001",
 				OwnerTag:   "unit-abc-0",
 				Kind:       params.StorageKindBlock,
-				Status:     createTestStatus(status.StatusAttached, ""),
+				Status:     createTestStatus(status.Attached, ""),
 				Attachments: map[string]params.StorageAttachmentDetails{
 					"unit-abc-0": params.StorageAttachmentDetails{
 						StorageTag: "storage-db-dir-1001",
@@ -213,7 +213,7 @@ func (s mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsListR
 				Persistent: true,
 				Size:       2048,
 			},
-			Status: createTestStatus(status.StatusAttaching, "failed to attach, will retry"),
+			Status: createTestStatus(status.Attaching, "failed to attach, will retry"),
 			MachineAttachments: map[string]params.VolumeAttachmentInfo{
 				"machine-0": params.VolumeAttachmentInfo{},
 			},
@@ -225,7 +225,7 @@ func (s mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsListR
 			Info: params.VolumeInfo{
 				Size: 42,
 			},
-			Status: createTestStatus(status.StatusPending, ""),
+			Status: createTestStatus(status.Pending, ""),
 			MachineAttachments: map[string]params.VolumeAttachmentInfo{
 				"machine-1": params.VolumeAttachmentInfo{},
 			},
@@ -238,7 +238,7 @@ func (s mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsListR
 				VolumeId: "provider-supplied-volume-2",
 				Size:     3,
 			},
-			Status: createTestStatus(status.StatusAttached, ""),
+			Status: createTestStatus(status.Attached, ""),
 			MachineAttachments: map[string]params.VolumeAttachmentInfo{
 				"machine-1": params.VolumeAttachmentInfo{
 					DeviceName: "xvdf1",
@@ -254,7 +254,7 @@ func (s mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsListR
 				Persistent: true,
 				Size:       1024,
 			},
-			Status: createTestStatus(status.StatusAttached, ""),
+			Status: createTestStatus(status.Attached, ""),
 			MachineAttachments: map[string]params.VolumeAttachmentInfo{
 				"machine-0": params.VolumeAttachmentInfo{
 					DeviceName: "xvdf2",
@@ -269,7 +269,7 @@ func (s mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsListR
 				StorageTag: "storage-shared-fs-0",
 				OwnerTag:   "application-transcode",
 				Kind:       params.StorageKindBlock,
-				Status:     createTestStatus(status.StatusAttached, ""),
+				Status:     createTestStatus(status.Attached, ""),
 				Attachments: map[string]params.StorageAttachmentDetails{
 					"unit-transcode-0": params.StorageAttachmentDetails{
 						StorageTag: "storage-shared-fs-0",

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -261,7 +261,7 @@ func (s *MachineSuite) TestHostUnits(c *gc.C) {
 	// lp:1558657
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusIdle,
+		Status:  status.Idle,
 		Message: "",
 		Since:   &now,
 	}

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -140,13 +140,13 @@ func waitForUnitActive(stateConn *state.State, unit *state.Unit, c *gc.C) {
 			statusInfo, err := unit.Status()
 			c.Assert(err, jc.ErrorIsNil)
 			switch statusInfo.Status {
-			case status.StatusMaintenance, status.StatusWaiting, status.StatusBlocked:
+			case status.Maintenance, status.Waiting, status.Blocked:
 				c.Logf("waiting...")
 				continue
-			case status.StatusActive:
+			case status.Active:
 				c.Logf("active!")
 				return
-			case status.StatusUnknown:
+			case status.Unknown:
 				// Active units may have a status of unknown if they have
 				// started but not run status-set.
 				c.Logf("unknown but active!")
@@ -157,10 +157,10 @@ func waitForUnitActive(stateConn *state.State, unit *state.Unit, c *gc.C) {
 			statusInfo, err = unit.AgentStatus()
 			c.Assert(err, jc.ErrorIsNil)
 			switch statusInfo.Status {
-			case status.StatusAllocating, status.StatusExecuting, status.StatusRebooting, status.StatusIdle:
+			case status.Allocating, status.Executing, status.Rebooting, status.Idle:
 				c.Logf("waiting...")
 				continue
-			case status.StatusError:
+			case status.Error:
 				stateConn.StartSync()
 				c.Logf("unit is still down")
 			default:

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -92,21 +92,21 @@ var GoodHighlight = ansiterm.Foreground(ansiterm.Green)
 
 var statusColors = map[status.Status]*ansiterm.Context{
 	// good
-	status.StatusActive:  GoodHighlight,
-	status.StatusIdle:    GoodHighlight,
-	status.StatusStarted: GoodHighlight,
+	status.Active:  GoodHighlight,
+	status.Idle:    GoodHighlight,
+	status.Started: GoodHighlight,
 	// busy
-	status.StatusAllocating:  WarningHighlight,
-	status.StatusExecuting:   WarningHighlight,
-	status.StatusLost:        WarningHighlight,
-	status.StatusMaintenance: WarningHighlight,
-	status.StatusPending:     WarningHighlight,
-	status.StatusRebooting:   WarningHighlight,
-	status.StatusStopped:     WarningHighlight,
-	status.StatusUnknown:     WarningHighlight,
+	status.Allocating:  WarningHighlight,
+	status.Executing:   WarningHighlight,
+	status.Lost:        WarningHighlight,
+	status.Maintenance: WarningHighlight,
+	status.Pending:     WarningHighlight,
+	status.Rebooting:   WarningHighlight,
+	status.Stopped:     WarningHighlight,
+	status.Unknown:     WarningHighlight,
 	// bad
-	status.StatusBlocked: ErrorHighlight,
-	status.StatusDown:    ErrorHighlight,
-	status.StatusError:   ErrorHighlight,
-	status.StatusFailed:  ErrorHighlight,
+	status.Blocked: ErrorHighlight,
+	status.Down:    ErrorHighlight,
+	status.Error:   ErrorHighlight,
+	status.Failed:  ErrorHighlight,
 }

--- a/container/kvm/instance.go
+++ b/container/kvm/instance.go
@@ -27,12 +27,12 @@ func (kvm *kvmInstance) Id() instance.Id {
 func (kvm *kvmInstance) Status() instance.InstanceStatus {
 	if kvm.container.IsRunning() {
 		return instance.InstanceStatus{
-			Status:  status.StatusRunning,
+			Status:  status.Running,
 			Message: "running",
 		}
 	}
 	return instance.InstanceStatus{
-		Status:  status.StatusStopped,
+		Status:  status.Stopped,
 		Message: "stopped",
 	}
 }

--- a/container/kvm/kvm.go
+++ b/container/kvm/kvm.go
@@ -124,7 +124,7 @@ func (manager *containerManager) CreateContainer(
 
 	defer func() {
 		if err != nil {
-			callback(status.StatusProvisioningError, fmt.Sprintf("Creating container: %v", err), nil)
+			callback(status.ProvisioningError, fmt.Sprintf("Creating container: %v", err), nil)
 		}
 	}()
 
@@ -170,7 +170,7 @@ func (manager *containerManager) CreateContainer(
 		return nil, nil, errors.Annotate(err, "failed to parse hardware")
 	}
 
-	callback(status.StatusAllocating, "Creating container; it might take some time", nil)
+	callback(status.Allocating, "Creating container; it might take some time", nil)
 	logger.Tracef("create the container, constraints: %v", cons)
 	if err := kvmContainer.Start(startParams); err != nil {
 		err = errors.Annotate(err, "kvm container creation failed")

--- a/container/lxd/instance.go
+++ b/container/lxd/instance.go
@@ -38,23 +38,23 @@ func (lxd *lxdInstance) Addresses() ([]network.Address, error) {
 
 // Status implements instance.Instance.Status.
 func (lxd *lxdInstance) Status() instance.InstanceStatus {
-	jujuStatus := status.StatusPending
+	jujuStatus := status.Pending
 	instStatus, err := lxd.client.Status(lxd.id)
 	if err != nil {
 		return instance.InstanceStatus{
-			Status:  status.StatusEmpty,
+			Status:  status.Empty,
 			Message: fmt.Sprintf("could not get status: %v", err),
 		}
 	}
 	switch instStatus {
 	case lxdclient.StatusStarting, lxdclient.StatusStarted:
-		jujuStatus = status.StatusAllocating
+		jujuStatus = status.Allocating
 	case lxdclient.StatusRunning:
-		jujuStatus = status.StatusRunning
+		jujuStatus = status.Running
 	case lxdclient.StatusFreezing, lxdclient.StatusFrozen, lxdclient.StatusThawed, lxdclient.StatusStopping, lxdclient.StatusStopped:
-		jujuStatus = status.StatusEmpty
+		jujuStatus = status.Empty
 	default:
-		jujuStatus = status.StatusEmpty
+		jujuStatus = status.Empty
 	}
 	return instance.InstanceStatus{
 		Status:  jujuStatus,

--- a/container/lxd/lxd.go
+++ b/container/lxd/lxd.go
@@ -96,7 +96,7 @@ func (manager *containerManager) CreateContainer(
 
 	defer func() {
 		if err != nil {
-			callback(status.StatusProvisioningError, fmt.Sprintf("Creating container: %v", err), nil)
+			callback(status.ProvisioningError, fmt.Sprintf("Creating container: %v", err), nil)
 		}
 	}()
 
@@ -111,7 +111,7 @@ func (manager *containerManager) CreateContainer(
 	err = manager.client.EnsureImageExists(series,
 		lxdclient.DefaultImageSources,
 		func(progress string) {
-			callback(status.StatusProvisioning, progress, nil)
+			callback(status.Provisioning, progress, nil)
 		})
 	if err != nil {
 		err = errors.Annotatef(err, "failed to ensure LXD image")
@@ -161,13 +161,13 @@ func (manager *containerManager) CreateContainer(
 	}
 
 	logger.Infof("starting instance %q (image %q)...", spec.Name, spec.Image)
-	callback(status.StatusProvisioning, "Starting container", nil)
+	callback(status.Provisioning, "Starting container", nil)
 	_, err = manager.client.AddInstance(spec)
 	if err != nil {
 		return
 	}
 
-	callback(status.StatusRunning, "Container started", nil)
+	callback(status.Running, "Container started", nil)
 	inst = &lxdInstance{name, manager.client}
 	return
 }

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -149,7 +149,7 @@ func (s *cmdControllerSuite) TestListDeadModels(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusDestroying,
+		Status:  status.Destroying,
 		Message: "",
 		Since:   &now,
 	}

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -215,13 +215,13 @@ func checkMachines(backend PrecheckBackend) error {
 
 		if statusInfo, err := machine.InstanceStatus(); err != nil {
 			return errors.Annotatef(err, "retrieving machine %s instance status", machine.Id())
-		} else if statusInfo.Status != status.StatusRunning {
+		} else if statusInfo.Status != status.Running {
 			return newStatusError("machine %s not running", machine.Id(), statusInfo.Status)
 		}
 
 		if statusInfo, err := common.MachineStatus(machine); err != nil {
 			return errors.Annotatef(err, "retrieving machine %s status", machine.Id())
-		} else if statusInfo.Status != status.StatusStarted {
+		} else if statusInfo.Status != status.Started {
 			return newStatusError("machine %s agent not functioning at this time",
 				machine.Id(), statusInfo.Status)
 		}
@@ -298,7 +298,7 @@ func checkUnitAgentStatus(unit PrecheckUnit) error {
 		return errors.Annotatef(statusData.Err, "retrieving unit %s status", unit.Name())
 	}
 	agentStatus := statusData.Status.Status
-	if agentStatus != status.StatusIdle {
+	if agentStatus != status.Idle {
 		return newStatusError("unit %s not idle", unit.Name(), agentStatus)
 	}
 	return nil
@@ -323,7 +323,7 @@ type agentToolsGetter interface {
 
 func newStatusError(format, id string, s status.Status) error {
 	msg := fmt.Sprintf(format, id)
-	if s != status.StatusEmpty {
+	if s != status.Empty {
 		msg += fmt.Sprintf(" (%s)", s)
 	}
 	return errors.New(msg)

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -205,7 +205,7 @@ func (s *SourcePrecheckSuite) TestUnitNotIdle(c *gc.C) {
 			&fakeApp{
 				name: "foo",
 				units: []migration.PrecheckUnit{
-					&fakeUnit{name: "foo/0", agentStatus: status.StatusFailed},
+					&fakeUnit{name: "foo/0", agentStatus: status.Failed},
 				},
 			},
 		},
@@ -503,7 +503,7 @@ func newBackendWithDyingMachine() *fakeBackend {
 func newBackendWithDownMachine() *fakeBackend {
 	return &fakeBackend{
 		machines: []migration.PrecheckMachine{
-			&fakeMachine{id: "0", status: status.StatusDown},
+			&fakeMachine{id: "0", status: status.Down},
 			&fakeMachine{id: "1"},
 		},
 	}
@@ -512,7 +512,7 @@ func newBackendWithDownMachine() *fakeBackend {
 func newBackendWithProvisioningMachine() *fakeBackend {
 	return &fakeBackend{
 		machines: []migration.PrecheckMachine{
-			&fakeMachine{id: "0", instanceStatus: status.StatusProvisioning},
+			&fakeMachine{id: "0", instanceStatus: status.Provisioning},
 			&fakeMachine{id: "1"},
 		},
 	}
@@ -647,7 +647,7 @@ func (m *fakeMachine) Status() (status.StatusInfo, error) {
 	s := m.status
 	if s == "" {
 		// Avoid the need to specify this everywhere.
-		s = status.StatusStarted
+		s = status.Started
 	}
 	return status.StatusInfo{Status: s}, nil
 }
@@ -656,7 +656,7 @@ func (m *fakeMachine) InstanceStatus() (status.StatusInfo, error) {
 	s := m.instanceStatus
 	if s == "" {
 		// Avoid the need to specify this everywhere.
-		s = status.StatusRunning
+		s = status.Running
 	}
 	return status.StatusInfo{Status: s}, nil
 }
@@ -757,13 +757,13 @@ func (u *fakeUnit) AgentStatus() (status.StatusInfo, error) {
 	s := u.agentStatus
 	if s == "" {
 		// Avoid the need to specify this everywhere.
-		s = status.StatusIdle
+		s = status.Idle
 	}
 	return status.StatusInfo{Status: s}, nil
 }
 
 func (u *fakeUnit) Status() (status.StatusInfo, error) {
-	return status.StatusInfo{Status: status.StatusIdle}, nil
+	return status.StatusInfo{Status: status.Idle}, nil
 }
 
 func (u *fakeUnit) AgentPresence() (bool, error) {

--- a/provider/azure/instance.go
+++ b/provider/azure/instance.go
@@ -47,7 +47,7 @@ func (inst *azureInstance) Status() instance.InstanceStatus {
 	// we should query the operation status and report the error
 	// here.
 	return instance.InstanceStatus{
-		Status:  status.StatusEmpty,
+		Status:  status.Empty,
 		Message: to.String(inst.Properties.ProvisioningState),
 	}
 

--- a/provider/cloudsigma/instance.go
+++ b/provider/cloudsigma/instance.go
@@ -31,19 +31,19 @@ func (i sigmaInstance) Id() instance.Id {
 func (i sigmaInstance) Status() instance.InstanceStatus {
 	entityStatus := i.server.Status()
 	logger.Tracef("sigmaInstance.Status: %s", entityStatus)
-	jujuStatus := status.StatusPending
+	jujuStatus := status.Pending
 	switch entityStatus {
 	case gosigma.ServerStarting:
-		jujuStatus = status.StatusAllocating
+		jujuStatus = status.Allocating
 	case gosigma.ServerRunning:
-		jujuStatus = status.StatusRunning
+		jujuStatus = status.Running
 	case gosigma.ServerStopping, gosigma.ServerStopped:
-		jujuStatus = status.StatusEmpty
+		jujuStatus = status.Empty
 	case gosigma.ServerUnavailable:
 		// I am not sure about this one.
-		jujuStatus = status.StatusPending
+		jujuStatus = status.Pending
 	default:
-		jujuStatus = status.StatusPending
+		jujuStatus = status.Pending
 	}
 
 	return instance.InstanceStatus{

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1433,7 +1433,7 @@ func (inst *dummyInstance) Status() instance.InstanceStatus {
 	inst.mu.Lock()
 	defer inst.mu.Unlock()
 	// TODO(perrito666) add a provider status -> juju status mapping.
-	jujuStatus := status.StatusPending
+	jujuStatus := status.Pending
 	if inst.status != "" {
 		dummyStatus := status.Status(inst.status)
 		if dummyStatus.KnownInstanceStatus() {

--- a/provider/ec2/instance.go
+++ b/provider/ec2/instance.go
@@ -32,16 +32,16 @@ func (inst *ec2Instance) Id() instance.Id {
 
 func (inst *ec2Instance) Status() instance.InstanceStatus {
 	// pending | running | shutting-down | terminated | stopping | stopped
-	jujuStatus := status.StatusPending
+	jujuStatus := status.Pending
 	switch inst.State.Name {
 	case "pending":
-		jujuStatus = status.StatusPending
+		jujuStatus = status.Pending
 	case "running":
-		jujuStatus = status.StatusRunning
+		jujuStatus = status.Running
 	case "shutting-down", "terminated", "stopping", "stopped":
-		jujuStatus = status.StatusEmpty
+		jujuStatus = status.Empty
 	default:
-		jujuStatus = status.StatusEmpty
+		jujuStatus = status.Empty
 	}
 	return instance.InstanceStatus{
 		Status:  jujuStatus,

--- a/provider/gce/instance.go
+++ b/provider/gce/instance.go
@@ -34,16 +34,16 @@ func (inst *environInstance) Id() instance.Id {
 // Status implements instance.Instance.
 func (inst *environInstance) Status() instance.InstanceStatus {
 	instStatus := inst.base.Status()
-	jujuStatus := status.StatusProvisioning
+	jujuStatus := status.Provisioning
 	switch instStatus {
 	case "PROVISIONING", "STAGING":
-		jujuStatus = status.StatusProvisioning
+		jujuStatus = status.Provisioning
 	case "RUNNING":
-		jujuStatus = status.StatusRunning
+		jujuStatus = status.Running
 	case "STOPPING", "TERMINATED":
-		jujuStatus = status.StatusEmpty
+		jujuStatus = status.Empty
 	default:
-		jujuStatus = status.StatusEmpty
+		jujuStatus = status.Empty
 	}
 	return instance.InstanceStatus{
 		Status:  jujuStatus,

--- a/provider/joyent/instance.go
+++ b/provider/joyent/instance.go
@@ -24,18 +24,18 @@ func (inst *joyentInstance) Id() instance.Id {
 
 func (inst *joyentInstance) Status() instance.InstanceStatus {
 	instStatus := inst.machine.State
-	jujuStatus := status.StatusPending
+	jujuStatus := status.Pending
 	switch instStatus {
 	case "configured", "incomplete", "unavailable", "provisioning":
-		jujuStatus = status.StatusAllocating
+		jujuStatus = status.Allocating
 	case "ready", "running":
-		jujuStatus = status.StatusRunning
+		jujuStatus = status.Running
 	case "halting", "stopping", "shutting_down", "off", "down", "installed", "stopped", "destroyed", "unreachable":
-		jujuStatus = status.StatusEmpty
+		jujuStatus = status.Empty
 	case "failed":
-		jujuStatus = status.StatusProvisioningError
+		jujuStatus = status.ProvisioningError
 	default:
-		jujuStatus = status.StatusEmpty
+		jujuStatus = status.Empty
 	}
 	return instance.InstanceStatus{
 		Status:  jujuStatus,

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -50,7 +50,7 @@ func (env *environ) StartInstance(args environs.StartInstanceParams) (*environs.
 	raw, err := env.newRawInstance(args)
 	if err != nil {
 		if args.StatusCallback != nil {
-			args.StatusCallback(status.StatusProvisioningError, err.Error(), nil)
+			args.StatusCallback(status.ProvisioningError, err.Error(), nil)
 		}
 		return nil, errors.Trace(err)
 	}
@@ -170,7 +170,7 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams) (*lxdclien
 	defer cleanupCallback()
 
 	imageCallback := func(copyProgress string) {
-		statusCallback(status.StatusAllocating, copyProgress)
+		statusCallback(status.Allocating, copyProgress)
 	}
 	if err := env.raw.EnsureImageExists(series, imageSources, imageCallback); err != nil {
 		return nil, errors.Trace(err)
@@ -240,12 +240,12 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams) (*lxdclien
 
 	logger.Infof("starting instance %q (image %q)...", instSpec.Name, instSpec.Image)
 
-	statusCallback(status.StatusAllocating, "preparing image")
+	statusCallback(status.Allocating, "preparing image")
 	inst, err := env.raw.AddInstance(instSpec)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	statusCallback(status.StatusRunning, "container started")
+	statusCallback(status.Running, "container started")
 	return inst, nil
 }
 

--- a/provider/lxd/instance.go
+++ b/provider/lxd/instance.go
@@ -35,17 +35,17 @@ func (inst *environInstance) Id() instance.Id {
 
 // Status implements instance.Instance.
 func (inst *environInstance) Status() instance.InstanceStatus {
-	jujuStatus := status.StatusPending
+	jujuStatus := status.Pending
 	instStatus := inst.raw.Status()
 	switch instStatus {
 	case lxdclient.StatusStarting, lxdclient.StatusStarted:
-		jujuStatus = status.StatusAllocating
+		jujuStatus = status.Allocating
 	case lxdclient.StatusRunning:
-		jujuStatus = status.StatusRunning
+		jujuStatus = status.Running
 	case lxdclient.StatusFreezing, lxdclient.StatusFrozen, lxdclient.StatusThawed, lxdclient.StatusStopping, lxdclient.StatusStopped:
-		jujuStatus = status.StatusEmpty
+		jujuStatus = status.Empty
 	default:
-		jujuStatus = status.StatusEmpty
+		jujuStatus = status.Empty
 	}
 	return instance.InstanceStatus{
 		Status:  jujuStatus,

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1106,10 +1106,10 @@ func (environ *maasEnviron) waitForNodeDeployment2(id instance.Id, timeout time.
 			return errors.Trace(err)
 		}
 		stat := machine.Status()
-		if stat.Status == status.StatusRunning {
+		if stat.Status == status.Running {
 			return nil
 		}
-		if stat.Status == status.StatusProvisioningError {
+		if stat.Status == status.ProvisioningError {
 			return errors.Errorf("instance %q failed to deploy", id)
 
 		}

--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -52,25 +52,25 @@ func maasObjectId(maasObject *gomaasapi.MAASObject) instance.Id {
 }
 
 func convertInstanceStatus(statusMsg, substatus string, id instance.Id) instance.InstanceStatus {
-	maasInstanceStatus := status.StatusEmpty
+	maasInstanceStatus := status.Empty
 	switch statusMsg {
 	case "":
 		logger.Debugf("unable to obtain status of instance %s", id)
 		statusMsg = "error in getting status"
 	case "Deployed":
-		maasInstanceStatus = status.StatusRunning
+		maasInstanceStatus = status.Running
 	case "Deploying":
-		maasInstanceStatus = status.StatusAllocating
+		maasInstanceStatus = status.Allocating
 		if substatus != "" {
 			statusMsg = fmt.Sprintf("%s: %s", statusMsg, substatus)
 		}
 	case "Failed Deployment":
-		maasInstanceStatus = status.StatusProvisioningError
+		maasInstanceStatus = status.ProvisioningError
 		if substatus != "" {
 			statusMsg = fmt.Sprintf("%s: %s", statusMsg, substatus)
 		}
 	default:
-		maasInstanceStatus = status.StatusEmpty
+		maasInstanceStatus = status.Empty
 		statusMsg = fmt.Sprintf("%s: %s", statusMsg, substatus)
 	}
 	return instance.InstanceStatus{

--- a/provider/maas/maas2instance_test.go
+++ b/provider/maas/maas2instance_test.go
@@ -54,7 +54,7 @@ func (s *maas2InstanceSuite) TestZone(c *gc.C) {
 func (s *maas2InstanceSuite) TestStatusSuccess(c *gc.C) {
 	thing := &maas2Instance{machine: &fakeMachine{statusMessage: "Wexler", statusName: "Deploying"}}
 	result := thing.Status()
-	c.Assert(result, jc.DeepEquals, instance.InstanceStatus{status.StatusAllocating, "Deploying: Wexler"})
+	c.Assert(result, jc.DeepEquals, instance.InstanceStatus{status.Allocating, "Deploying: Wexler"})
 }
 
 func (s *maas2InstanceSuite) TestStatusError(c *gc.C) {

--- a/provider/manual/instance.go
+++ b/provider/manual/instance.go
@@ -22,7 +22,7 @@ func (manualBootstrapInstance) Status() instance.InstanceStatus {
 	// We asume that if we are deploying in manual provider the
 	// underlying machine is clearly running.
 	return instance.InstanceStatus{
-		Status: status.StatusRunning,
+		Status: status.Running,
 	}
 }
 

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -698,7 +698,7 @@ var instanceGathering = []struct {
 func (s *localServerSuite) TestInstanceStatus(c *gc.C) {
 	// goose's test service always returns ACTIVE state.
 	inst, _ := testing.AssertStartInstance(c, s.env, s.ControllerUUID, "100")
-	c.Assert(inst.Status().Status, gc.Equals, status.StatusRunning)
+	c.Assert(inst.Status().Status, gc.Equals, status.Running)
 	err := s.env.StopInstances(inst.Id())
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -216,23 +216,23 @@ func (inst *openstackInstance) Id() instance.Id {
 
 func (inst *openstackInstance) Status() instance.InstanceStatus {
 	instStatus := inst.getServerDetail().Status
-	jujuStatus := status.StatusPending
+	jujuStatus := status.Pending
 	switch instStatus {
 	case nova.StatusActive:
-		jujuStatus = status.StatusRunning
+		jujuStatus = status.Running
 	case nova.StatusError:
-		jujuStatus = status.StatusProvisioningError
+		jujuStatus = status.ProvisioningError
 	case nova.StatusBuild, nova.StatusBuildSpawning,
 		nova.StatusDeleted, nova.StatusHardReboot,
 		nova.StatusPassword, nova.StatusReboot,
 		nova.StatusRebuild, nova.StatusRescue,
 		nova.StatusResize, nova.StatusShutoff,
 		nova.StatusSuspended, nova.StatusVerifyResize:
-		jujuStatus = status.StatusEmpty
+		jujuStatus = status.Empty
 	case nova.StatusUnknown:
-		jujuStatus = status.StatusUnknown
+		jujuStatus = status.Unknown
 	default:
-		jujuStatus = status.StatusEmpty
+		jujuStatus = status.Empty
 	}
 	return instance.InstanceStatus{
 		Status:  jujuStatus,

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -281,7 +281,7 @@ func (e *fakeInstance) Id() instance.Id {
 func (e *fakeInstance) Status() instance.InstanceStatus {
 	e.Push("Status")
 	return instance.InstanceStatus{
-		Status:  status.StatusProvisioning,
+		Status:  status.Provisioning,
 		Message: "a message",
 	}
 }

--- a/provider/vsphere/instance.go
+++ b/provider/vsphere/instance.go
@@ -41,7 +41,7 @@ func (inst *environInstance) Status() instance.InstanceStatus {
 	// but that method does not exist.
 	// return inst.base.Status()
 	return instance.InstanceStatus{
-		Status: status.StatusPending,
+		Status: status.Pending,
 	}
 }
 

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -463,13 +463,13 @@ func (st *State) machineDocForTemplate(template MachineTemplate, id string) *mac
 // taken from the template.
 func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate) (prereqOps []txn.Op, machineOp txn.Op, err error) {
 	machineStatusDoc := statusDoc{
-		Status:    status.StatusPending,
+		Status:    status.Pending,
 		ModelUUID: st.ModelUUID(),
 		// TODO(fwereade): 2016-03-17 lp:1558657
 		Updated: time.Now().UnixNano(),
 	}
 	instanceStatusDoc := statusDoc{
-		Status:    status.StatusPending,
+		Status:    status.Pending,
 		ModelUUID: st.ModelUUID(),
 		Updated:   time.Now().UnixNano(),
 	}

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -426,7 +426,7 @@ func (svc *backingApplication) updated(st *State, store *multiwatcherStore, id s
 			// TODO(fwereade): 2016-03-17 lp:1558657
 			now := time.Now()
 			info.Status = multiwatcher.StatusInfo{
-				Current: status.StatusUnknown,
+				Current: status.Unknown,
 				Since:   &now,
 				Data:    normaliseStatusData(nil),
 			}
@@ -648,13 +648,13 @@ func (s *backingStatus) updatedUnitStatus(st *State, store *multiwatcherStore, i
 	// Unit or workload status - display the agent status or any error.
 	// NOTE: thumper 2016-06-27, this is truely horrible, and we are lying to our users.
 	// however, this is explicitly what has been asked for as much as we dislike it.
-	if strings.HasSuffix(id, "#charm") || s.Status == status.StatusError {
+	if strings.HasSuffix(id, "#charm") || s.Status == status.Error {
 		newInfo.WorkloadStatus = s.toStatusInfo()
 	} else {
 		newInfo.AgentStatus = s.toStatusInfo()
 		// If the unit was in error and now it's not, we need to reset its
 		// status back to what was previously recorded.
-		if newInfo.WorkloadStatus.Current == status.StatusError {
+		if newInfo.WorkloadStatus.Current == status.Error {
 			newInfo.WorkloadStatus.Current = unitStatus.Status
 			newInfo.WorkloadStatus.Message = unitStatus.Message
 			newInfo.WorkloadStatus.Data = unitStatus.Data

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -100,11 +100,11 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 		Id:         "0",
 		InstanceId: "i-machine-0",
 		AgentStatus: multiwatcher.StatusInfo{
-			Current: status.StatusPending,
+			Current: status.Pending,
 			Data:    map[string]interface{}{},
 		},
 		InstanceStatus: multiwatcher.StatusInfo{
-			Current: status.StatusPending,
+			Current: status.Pending,
 			Data:    map[string]interface{}{},
 		},
 		Life:                    multiwatcher.Life("alive"),
@@ -218,7 +218,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 		c.Assert(err, jc.ErrorIsNil)
 		now := time.Now()
 		sInfo := status.StatusInfo{
-			Status:  status.StatusError,
+			Status:  status.Error,
 			Message: m.Tag().String(),
 			Since:   &now,
 		}
@@ -231,12 +231,12 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 			Id:         fmt.Sprint(i + 1),
 			InstanceId: "i-" + m.Tag().String(),
 			AgentStatus: multiwatcher.StatusInfo{
-				Current: status.StatusError,
+				Current: status.Error,
 				Message: m.Tag().String(),
 				Data:    map[string]interface{}{},
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 			},
 			Life:                    multiwatcher.Life("alive"),
@@ -731,12 +731,12 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			ModelUUID: s.state.ModelUUID(),
 			Id:        "0",
 			AgentStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
@@ -752,12 +752,12 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			ModelUUID: s.state.ModelUUID(),
 			Id:        "1",
 			AgentStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
@@ -781,12 +781,12 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			ModelUUID: s.state.ModelUUID(),
 			Id:        "1",
 			AgentStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
@@ -809,12 +809,12 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			ModelUUID: s.state.ModelUUID(),
 			Id:        "1",
 			AgentStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
@@ -861,12 +861,12 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			Id:         "0",
 			InstanceId: "i-0",
 			AgentStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
@@ -889,12 +889,12 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			ModelUUID: s.state.ModelUUID(),
 			Id:        "2",
 			AgentStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
@@ -1022,7 +1022,7 @@ func (s *allWatcherStateSuite) TestStateWatcherTwoModels(c *gc.C) {
 
 				now := time.Now()
 				sInfo := status.StatusInfo{
-					Status:  status.StatusError,
+					Status:  status.Error,
 					Message: "pete tong",
 					Since:   &now,
 				}
@@ -1410,11 +1410,11 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			ModelUUID: st0.ModelUUID(),
 			Id:        "0",
 			AgentStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 			},
 			Life:      multiwatcher.Life("alive"),
@@ -1429,11 +1429,11 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			ModelUUID: st1.ModelUUID(),
 			Id:        "0",
 			AgentStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 			},
 			Life:      multiwatcher.Life("alive"),
@@ -1456,11 +1456,11 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			ModelUUID: st1.ModelUUID(),
 			Id:        "0",
 			AgentStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 			},
 			Life:      multiwatcher.Life("dying"),
@@ -1482,11 +1482,11 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			ModelUUID: st1.ModelUUID(),
 			Id:        "0",
 			AgentStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 			},
 			Life:      multiwatcher.Life("dead"),
@@ -1534,11 +1534,11 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			Id:         "0",
 			InstanceId: "i-0",
 			AgentStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 			},
 			Life:                    multiwatcher.Life("alive"),
@@ -1560,11 +1560,11 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			ModelUUID: st1.ModelUUID(),
 			Id:        "1",
 			AgentStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 			},
 			Life:      multiwatcher.Life("alive"),
@@ -1618,11 +1618,11 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			ModelUUID: st2.ModelUUID(),
 			Id:        "0",
 			AgentStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
-				Current: status.StatusPending,
+				Current: status.Pending,
 				Data:    map[string]interface{}{},
 			},
 			Life:      multiwatcher.Life("alive"),
@@ -1770,7 +1770,7 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 			c.Assert(err, jc.ErrorIsNil)
 			now := time.Now()
 			sInfo := status.StatusInfo{
-				Status:  status.StatusError,
+				Status:  status.Error,
 				Message: "failure",
 				Since:   &now,
 			}
@@ -1788,12 +1788,12 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 						ModelUUID: st.ModelUUID(),
 						Id:        "0",
 						AgentStatus: multiwatcher.StatusInfo{
-							Current: status.StatusError,
+							Current: status.Error,
 							Message: "failure",
 							Data:    map[string]interface{}{},
 						},
 						InstanceStatus: multiwatcher.StatusInfo{
-							Current: status.StatusPending,
+							Current: status.Pending,
 							Data:    map[string]interface{}{},
 						},
 						Life:      multiwatcher.Life("alive"),
@@ -1819,13 +1819,13 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 						ModelUUID: st.ModelUUID(),
 						Id:        "0",
 						AgentStatus: multiwatcher.StatusInfo{
-							Current: status.StatusError,
+							Current: status.Error,
 							Message: "another failure",
 							Data:    map[string]interface{}{},
 							Since:   &now,
 						},
 						InstanceStatus: multiwatcher.StatusInfo{
-							Current: status.StatusPending,
+							Current: status.Pending,
 							Data:    map[string]interface{}{},
 							Since:   &now,
 						},
@@ -1841,12 +1841,12 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 						Id:         "0",
 						InstanceId: "i-0",
 						AgentStatus: multiwatcher.StatusInfo{
-							Current: status.StatusError,
+							Current: status.Error,
 							Message: "another failure",
 							Data:    map[string]interface{}{},
 						},
 						InstanceStatus: multiwatcher.StatusInfo{
-							Current: status.StatusPending,
+							Current: status.Pending,
 							Data:    map[string]interface{}{},
 						},
 						Life:                     multiwatcher.Life("alive"),
@@ -1865,7 +1865,7 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 					ModelUUID: st.ModelUUID(),
 					Id:        "0",
 					AgentStatus: multiwatcher.StatusInfo{
-						Current: status.StatusError,
+						Current: status.Error,
 						Message: "failure",
 						Data:    map[string]interface{}{},
 						Since:   &now,
@@ -1880,7 +1880,7 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 						ModelUUID: st.ModelUUID(),
 						Id:        "0",
 						AgentStatus: multiwatcher.StatusInfo{
-							Current: status.StatusError,
+							Current: status.Error,
 							Message: "failure",
 							Data:    map[string]interface{}{},
 						},
@@ -1891,7 +1891,7 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 			c.Assert(err, jc.ErrorIsNil)
 			now := time.Now()
 			sInfo := status.StatusInfo{
-				Status:  status.StatusStarted,
+				Status:  status.Started,
 				Message: "",
 				Since:   &now,
 			}
@@ -1904,7 +1904,7 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 					ModelUUID: st.ModelUUID(),
 					Id:        "0",
 					AgentStatus: multiwatcher.StatusInfo{
-						Current: status.StatusError,
+						Current: status.Error,
 						Message: "failure",
 						Data:    map[string]interface{}{},
 						Since:   &now,
@@ -1919,7 +1919,7 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 						ModelUUID: st.ModelUUID(),
 						Id:        "0",
 						AgentStatus: multiwatcher.StatusInfo{
-							Current: status.StatusStarted,
+							Current: status.Started,
 							Data:    make(map[string]interface{}),
 						},
 					}}}
@@ -2333,7 +2333,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			c.Assert(err, jc.ErrorIsNil)
 			now := time.Now()
 			sInfo := status.StatusInfo{
-				Status:  status.StatusError,
+				Status:  status.Error,
 				Message: "failure",
 				Since:   &now,
 			}
@@ -2538,7 +2538,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			c.Assert(err, jc.ErrorIsNil)
 			now := time.Now()
 			sInfo := status.StatusInfo{
-				Status:  status.StatusError,
+				Status:  status.Error,
 				Message: "failure",
 				Since:   &now,
 			}
@@ -2629,7 +2629,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			c.Assert(err, jc.ErrorIsNil)
 			now := time.Now()
 			sInfo := status.StatusInfo{
-				Status:  status.StatusIdle,
+				Status:  status.Idle,
 				Message: "",
 				Since:   &now,
 			}
@@ -2682,14 +2682,14 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			c.Assert(err, jc.ErrorIsNil)
 			now := time.Now()
 			sInfo := status.StatusInfo{
-				Status:  status.StatusIdle,
+				Status:  status.Idle,
 				Message: "",
 				Since:   &now,
 			}
 			err = u.SetAgentStatus(sInfo)
 			c.Assert(err, jc.ErrorIsNil)
 			sInfo = status.StatusInfo{
-				Status:  status.StatusMaintenance,
+				Status:  status.Maintenance,
 				Message: "doing work",
 				Since:   &now,
 			}
@@ -2742,7 +2742,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			c.Assert(err, jc.ErrorIsNil)
 			now := time.Now()
 			sInfo := status.StatusInfo{
-				Status:  status.StatusError,
+				Status:  status.Error,
 				Message: "hook error",
 				Data: map[string]interface{}{
 					"1st-key": "one",
@@ -2802,7 +2802,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			c.Assert(err, jc.ErrorIsNil)
 			now := time.Now()
 			sInfo := status.StatusInfo{
-				Status:  status.StatusActive,
+				Status:  status.Active,
 				Message: "",
 				Since:   &now,
 			}

--- a/state/application.go
+++ b/state/application.go
@@ -1042,17 +1042,17 @@ func (s *Application) addUnitOpsWithCons(args applicationAddUnitOpsArgs) (string
 	// TODO(fwereade): 2016-03-17 lp:1558657
 	now := time.Now()
 	agentStatusDoc := statusDoc{
-		Status:  status.StatusAllocating,
+		Status:  status.Allocating,
 		Updated: now.UnixNano(),
 	}
 	unitStatusDoc := statusDoc{
 		// TODO(fwereade): this violates the spec. Should be "waiting".
-		Status:     status.StatusUnknown,
+		Status:     status.Unknown,
 		StatusInfo: MessageWaitForAgentInit,
 		Updated:    now.UnixNano(),
 	}
 	workloadVersionDoc := statusDoc{
-		Status:  status.StatusUnknown,
+		Status:  status.Unknown,
 		Updated: now.UnixNano(),
 	}
 
@@ -1626,13 +1626,13 @@ func (s *Application) deriveStatus(units []*Unit) (status.StatusInfo, error) {
 // statusSeverities holds status values with a severity measure.
 // Status values with higher severity are used in preference to others.
 var statusServerities = map[status.Status]int{
-	status.StatusError:       100,
-	status.StatusBlocked:     90,
-	status.StatusWaiting:     80,
-	status.StatusMaintenance: 70,
-	status.StatusTerminated:  60,
-	status.StatusActive:      50,
-	status.StatusUnknown:     40,
+	status.Error:       100,
+	status.Blocked:     90,
+	status.Waiting:     80,
+	status.Maintenance: 70,
+	status.Terminated:  60,
+	status.Active:      50,
+	status.Unknown:     40,
 }
 
 type addApplicationOpsArgs struct {

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -2164,7 +2164,7 @@ func (s *ServiceSuite) testStatus(c *gc.C, status1, status2, expected status.Sta
 		Message: "status 2",
 		Since:   &now,
 	}
-	if status2 == status.StatusError {
+	if status2 == status.Error {
 		err = u2.SetAgentStatus(sInfo)
 	} else {
 		err = u2.SetStatus(sInfo)
@@ -2184,15 +2184,15 @@ func (s *ServiceSuite) testStatus(c *gc.C, status1, status2, expected status.Sta
 
 func (s *ServiceSuite) TestStatus(c *gc.C) {
 	for _, t := range []struct{ status1, status2, expected status.Status }{
-		{status.StatusActive, status.StatusWaiting, status.StatusWaiting},
-		{status.StatusMaintenance, status.StatusWaiting, status.StatusWaiting},
-		{status.StatusActive, status.StatusBlocked, status.StatusBlocked},
-		{status.StatusWaiting, status.StatusBlocked, status.StatusBlocked},
-		{status.StatusMaintenance, status.StatusBlocked, status.StatusBlocked},
-		{status.StatusMaintenance, status.StatusError, status.StatusError},
-		{status.StatusBlocked, status.StatusError, status.StatusError},
-		{status.StatusWaiting, status.StatusError, status.StatusError},
-		{status.StatusActive, status.StatusError, status.StatusError},
+		{status.Active, status.Waiting, status.Waiting},
+		{status.Maintenance, status.Waiting, status.Waiting},
+		{status.Active, status.Blocked, status.Blocked},
+		{status.Waiting, status.Blocked, status.Blocked},
+		{status.Maintenance, status.Blocked, status.Blocked},
+		{status.Maintenance, status.Error, status.Error},
+		{status.Blocked, status.Error, status.Error},
+		{status.Waiting, status.Error, status.Error},
+		{status.Active, status.Error, status.Error},
 	} {
 		s.testStatus(c, t.status1, t.status2, t.expected)
 	}

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -754,7 +754,7 @@ func (st *State) addFilesystemOps(params FilesystemParams, machineId string) ([]
 	}
 
 	status := statusDoc{
-		Status: status.StatusPending,
+		Status: status.Pending,
 		// TODO(fwereade): 2016-03-17 lp:1558657
 		Updated: time.Now().UnixNano(),
 	}
@@ -1147,12 +1147,12 @@ func (st *State) FilesystemStatus(tag names.FilesystemTag) (status.StatusInfo, e
 // SetFilesystemStatus sets the status of the specified filesystem.
 func (st *State) SetFilesystemStatus(tag names.FilesystemTag, fsStatus status.Status, info string, data map[string]interface{}, updated *time.Time) error {
 	switch fsStatus {
-	case status.StatusAttaching, status.StatusAttached, status.StatusDetaching, status.StatusDetached, status.StatusDestroying:
-	case status.StatusError:
+	case status.Attaching, status.Attached, status.Detaching, status.Detached, status.Destroying:
+	case status.Error:
 		if info == "" {
 			return errors.Errorf("cannot set status %q without info", fsStatus)
 		}
-	case status.StatusPending:
+	case status.Pending:
 		// If a filesystem is not yet provisioned, we allow its status
 		// to be set back to pending (when a retry is to occur).
 		v, err := st.Filesystem(tag)

--- a/state/machine.go
+++ b/state/machine.go
@@ -1526,12 +1526,12 @@ func (m *Machine) Status() (status.StatusInfo, error) {
 // SetStatus sets the status of the machine.
 func (m *Machine) SetStatus(statusInfo status.StatusInfo) error {
 	switch statusInfo.Status {
-	case status.StatusStarted, status.StatusStopped:
-	case status.StatusError:
+	case status.Started, status.Stopped:
+	case status.Error:
 		if statusInfo.Message == "" {
 			return errors.Errorf("cannot set status %q without info", statusInfo.Status)
 		}
-	case status.StatusPending:
+	case status.Pending:
 		// If a machine is not yet provisioned, we allow its status
 		// to be set back to pending (when a retry is to occur).
 		_, err := m.InstanceId()
@@ -1540,7 +1540,7 @@ func (m *Machine) SetStatus(statusInfo status.StatusInfo) error {
 			break
 		}
 		fallthrough
-	case status.StatusDown:
+	case status.Down:
 		return errors.Errorf("cannot set status %q", statusInfo.Status)
 	default:
 		return errors.Errorf("cannot set invalid status %q", statusInfo.Status)
@@ -1656,12 +1656,12 @@ func (m *Machine) markInvalidContainers() error {
 				logger.Errorf("finding status of container %v to mark as invalid: %v", containerId, err)
 				continue
 			}
-			if statusInfo.Status == status.StatusPending {
+			if statusInfo.Status == status.Pending {
 				containerType := ContainerTypeFromId(containerId)
 				// TODO(perrito666) 2016-05-02 lp:1558657
 				now := time.Now()
 				s := status.StatusInfo{
-					Status:  status.StatusError,
+					Status:  status.Error,
 					Message: "unsupported container",
 					Data:    map[string]interface{}{"type": containerType},
 					Since:   &now,

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -903,7 +903,7 @@ func (s *MachineSuite) TestMachineSetInstanceStatus(c *gc.C) {
 
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusRunning,
+		Status:  status.Running,
 		Message: "alive",
 		Since:   &now,
 	}
@@ -915,7 +915,7 @@ func (s *MachineSuite) TestMachineSetInstanceStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	machineStatus, err := s.machine.InstanceStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machineStatus.Status, gc.DeepEquals, status.StatusRunning)
+	c.Assert(machineStatus.Status, gc.DeepEquals, status.Running)
 	c.Assert(machineStatus.Message, gc.DeepEquals, "alive")
 }
 
@@ -1156,7 +1156,7 @@ func (s *MachineSuite) TestWatchPrincipalUnits(c *gc.C) {
 	// Change the unit; no change.
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusIdle,
+		Status:  status.Idle,
 		Message: "",
 		Since:   &now,
 	}
@@ -1190,7 +1190,7 @@ func (s *MachineSuite) TestWatchPrincipalUnits(c *gc.C) {
 
 	// Change the subordinate; no change.
 	sInfo = status.StatusInfo{
-		Status:  status.StatusIdle,
+		Status:  status.Idle,
 		Message: "",
 		Since:   &now,
 	}
@@ -1271,7 +1271,7 @@ func (s *MachineSuite) TestWatchUnits(c *gc.C) {
 	// Change the unit; no change.
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusIdle,
+		Status:  status.Idle,
 		Message: "",
 		Since:   &now,
 	}
@@ -1306,7 +1306,7 @@ func (s *MachineSuite) TestWatchUnits(c *gc.C) {
 
 	// Change the subordinate; no change.
 	sInfo = status.StatusInfo{
-		Status:  status.StatusIdle,
+		Status:  status.Idle,
 		Message: "",
 		Since:   &now,
 	}
@@ -2177,14 +2177,14 @@ func (s *MachineSuite) TestSetSupportedContainersSetsUnknownToError(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	statusInfo, err := supportedContainer.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusPending)
+	c.Assert(statusInfo.Status, gc.Equals, status.Pending)
 
 	// An unsupported (lxd) container will have an error status.
 	err = container.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	statusInfo, err = container.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusError)
+	c.Assert(statusInfo.Status, gc.Equals, status.Error)
 	c.Assert(statusInfo.Message, gc.Equals, "unsupported container")
 	c.Assert(statusInfo.Data, gc.DeepEquals, map[string]interface{}{"type": "lxd"})
 }
@@ -2212,7 +2212,7 @@ func (s *MachineSuite) TestSupportsNoContainersSetsAllToError(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		statusInfo, err := container.Status()
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(statusInfo.Status, gc.Equals, status.StatusError)
+		c.Assert(statusInfo.Status, gc.Equals, status.Error)
 		c.Assert(statusInfo.Message, gc.Equals, "unsupported container")
 		containerType := state.ContainerTypeFromId(container.Id())
 		c.Assert(statusInfo.Data, gc.DeepEquals, map[string]interface{}{"type": string(containerType)})

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -237,7 +237,7 @@ func (s *MigrationExportSuite) assertMachinesMigrated(c *gc.C, cons constraints.
 	nested := s.Factory.MakeMachineNested(c, machine1.Id(), nil)
 	err := s.State.SetAnnotations(machine1, testAnnotations)
 	c.Assert(err, jc.ErrorIsNil)
-	s.primeStatusHistory(c, machine1, status.StatusStarted, addedHistoryCount)
+	s.primeStatusHistory(c, machine1, status.Started, addedHistoryCount)
 
 	model, err := s.State.Export()
 	c.Assert(err, jc.ErrorIsNil)
@@ -265,7 +265,7 @@ func (s *MigrationExportSuite) assertMachinesMigrated(c *gc.C, cons constraints.
 
 	history := exported.StatusHistory()
 	c.Assert(history, gc.HasLen, expectedHistoryCount)
-	s.checkStatusHistory(c, history[:addedHistoryCount], status.StatusStarted)
+	s.checkStatusHistory(c, history[:addedHistoryCount], status.Started)
 
 	containers := exported.Containers()
 	c.Assert(containers, gc.HasLen, 1)
@@ -341,7 +341,7 @@ func (s *MigrationExportSuite) assertMigrateApplications(c *gc.C, cons constrain
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.SetAnnotations(application, testAnnotations)
 	c.Assert(err, jc.ErrorIsNil)
-	s.primeStatusHistory(c, application, status.StatusActive, addedHistoryCount)
+	s.primeStatusHistory(c, application, status.Active, addedHistoryCount)
 
 	model, err := s.State.Export()
 	c.Assert(err, jc.ErrorIsNil)
@@ -373,7 +373,7 @@ func (s *MigrationExportSuite) assertMigrateApplications(c *gc.C, cons constrain
 
 	history := exported.StatusHistory()
 	c.Assert(history, gc.HasLen, expectedHistoryCount)
-	s.checkStatusHistory(c, history[:addedHistoryCount], status.StatusActive)
+	s.checkStatusHistory(c, history[:addedHistoryCount], status.Active)
 }
 
 func (s *MigrationExportSuite) TestMultipleApplications(c *gc.C) {
@@ -400,8 +400,8 @@ func (s *MigrationExportSuite) TestUnits(c *gc.C) {
 	}
 	err = s.State.SetAnnotations(unit, testAnnotations)
 	c.Assert(err, jc.ErrorIsNil)
-	s.primeStatusHistory(c, unit, status.StatusActive, addedHistoryCount)
-	s.primeStatusHistory(c, unit.Agent(), status.StatusIdle, addedHistoryCount)
+	s.primeStatusHistory(c, unit, status.Active, addedHistoryCount)
+	s.primeStatusHistory(c, unit.Agent(), status.Idle, addedHistoryCount)
 
 	model, err := s.State.Export()
 	c.Assert(err, jc.ErrorIsNil)
@@ -429,11 +429,11 @@ func (s *MigrationExportSuite) TestUnits(c *gc.C) {
 
 	workloadHistory := exported.WorkloadStatusHistory()
 	c.Assert(workloadHistory, gc.HasLen, expectedHistoryCount)
-	s.checkStatusHistory(c, workloadHistory[:addedHistoryCount], status.StatusActive)
+	s.checkStatusHistory(c, workloadHistory[:addedHistoryCount], status.Active)
 
 	agentHistory := exported.AgentStatusHistory()
 	c.Assert(agentHistory, gc.HasLen, expectedHistoryCount)
-	s.checkStatusHistory(c, agentHistory[:addedHistoryCount], status.StatusIdle)
+	s.checkStatusHistory(c, agentHistory[:addedHistoryCount], status.Idle)
 
 	versionHistory := exported.WorkloadVersionHistory()
 	// There are extra entries at the start that we don't care about.

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -290,7 +290,7 @@ func (i *importer) machine(m description.Machine) error {
 	// (a card exists for the work). Fake it for now.
 	instanceStatusDoc := statusDoc{
 		ModelUUID: i.st.ModelUUID(),
-		Status:    status.StatusStarted,
+		Status:    status.Started,
 	}
 	cons := i.constraints(m.Constraints())
 	prereqOps, machineOp := i.st.baseNewMachineOps(
@@ -708,9 +708,9 @@ func (i *importer) unit(s description.Application, u description.Unit) error {
 	workloadStatusDoc := i.makeStatusDoc(workloadStatus)
 
 	workloadVersion := u.WorkloadVersion()
-	versionStatus := status.StatusActive
+	versionStatus := status.Active
 	if workloadVersion == "" {
-		versionStatus = status.StatusUnknown
+		versionStatus = status.Unknown
 	}
 	workloadVersionDoc := statusDoc{
 		Status:     versionStatus,

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -234,7 +234,7 @@ func (s *MigrationImportSuite) TestMachines(c *gc.C) {
 	})
 	err := s.State.SetAnnotations(machine1, testAnnotations)
 	c.Assert(err, jc.ErrorIsNil)
-	s.primeStatusHistory(c, machine1, status.StatusStarted, 5)
+	s.primeStatusHistory(c, machine1, status.Started, 5)
 
 	// machine1 should have some instance data.
 	hardware, err := machine1.HardwareCharacteristics()
@@ -327,7 +327,7 @@ func (s *MigrationImportSuite) TestApplications(c *gc.C) {
 	c.Assert(application.SetExposed(), jc.ErrorIsNil)
 	err = s.State.SetAnnotations(application, testAnnotations)
 	c.Assert(err, jc.ErrorIsNil)
-	s.primeStatusHistory(c, application, status.StatusActive, 5)
+	s.primeStatusHistory(c, application, status.Active, 5)
 
 	allApplications, err := s.State.AllApplications()
 	c.Assert(err, jc.ErrorIsNil)
@@ -404,8 +404,8 @@ func (s *MigrationImportSuite) assertUnitsMigrated(c *gc.C, cons constraints.Val
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.SetAnnotations(exported, testAnnotations)
 	c.Assert(err, jc.ErrorIsNil)
-	s.primeStatusHistory(c, exported, status.StatusActive, 5)
-	s.primeStatusHistory(c, exported.Agent(), status.StatusIdle, 5)
+	s.primeStatusHistory(c, exported, status.Active, 5)
+	s.primeStatusHistory(c, exported.Agent(), status.Idle, 5)
 
 	_, newSt := s.importModel(c)
 

--- a/state/open.go
+++ b/state/open.go
@@ -320,7 +320,7 @@ func (st *State) modelSetupOps(controllerUUID string, args ModelArgs, inherited 
 		// TODO(axw) 2016-04-13 lp:1569632
 		// We need to decide how we will
 		// represent migration in model status.
-		Status: status.StatusAvailable,
+		Status: status.Available,
 	}
 
 	modelUserOps := createModelUserOps(

--- a/state/state.go
+++ b/state/state.go
@@ -1077,7 +1077,7 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		// TODO(fwereade): this violates the spec. Should be "waiting".
 		// Implemented like this to be consistent with incorrect add-unit
 		// behaviour.
-		Status:     status.StatusUnknown,
+		Status:     status.Unknown,
 		StatusInfo: MessageWaitForAgentInit,
 		// TODO(fwereade): 2016-03-17 lp:1558657
 		Updated: time.Now().UnixNano(),

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -57,7 +57,7 @@ var alternatePassword = "bar-12345678901234567890"
 func preventUnitDestroyRemove(c *gc.C, u *state.Unit) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusIdle,
+		Status:  status.Idle,
 		Message: "",
 		Since:   &now,
 	}
@@ -492,7 +492,7 @@ func (s *MultiEnvStateSuite) TestWatchTwoEnvironments(c *gc.C) {
 
 				now := time.Now()
 				sInfo := status.StatusInfo{
-					Status:  status.StatusError,
+					Status:  status.Error,
 					Message: "some status",
 					Since:   &now,
 				}

--- a/state/status_filesystem_test.go
+++ b/state/status_filesystem_test.go
@@ -53,7 +53,7 @@ func (s *FilesystemStatusSuite) TestInitialStatus(c *gc.C) {
 func (s *FilesystemStatusSuite) checkInitialStatus(c *gc.C) {
 	statusInfo, err := s.filesystem.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusInfo.Status, gc.Equals, status.StatusPending)
+	c.Check(statusInfo.Status, gc.Equals, status.Pending)
 	c.Check(statusInfo.Message, gc.Equals, "")
 	c.Check(statusInfo.Data, gc.HasLen, 0)
 	c.Check(statusInfo.Since, gc.NotNil)
@@ -62,7 +62,7 @@ func (s *FilesystemStatusSuite) checkInitialStatus(c *gc.C) {
 func (s *FilesystemStatusSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "",
 		Since:   &now,
 	}
@@ -88,7 +88,7 @@ func (s *FilesystemStatusSuite) TestSetUnknownStatus(c *gc.C) {
 func (s *FilesystemStatusSuite) TestSetOverwritesData(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusAttaching,
+		Status:  status.Attaching,
 		Message: "blah",
 		Data: map[string]interface{}{
 			"pew.pew": "zap",
@@ -108,7 +108,7 @@ func (s *FilesystemStatusSuite) TestGetSetStatusAlive(c *gc.C) {
 func (s *FilesystemStatusSuite) checkGetSetStatus(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusAttaching,
+		Status:  status.Attaching,
 		Message: "blah",
 		Data: map[string]interface{}{
 			"$foo.bar.baz": map[string]interface{}{
@@ -125,7 +125,7 @@ func (s *FilesystemStatusSuite) checkGetSetStatus(c *gc.C) {
 
 	statusInfo, err := filesystem.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusInfo.Status, gc.Equals, status.StatusAttaching)
+	c.Check(statusInfo.Status, gc.Equals, status.Attaching)
 	c.Check(statusInfo.Message, gc.Equals, "blah")
 	c.Check(statusInfo.Data, jc.DeepEquals, map[string]interface{}{
 		"$foo.bar.baz": map[string]interface{}{
@@ -165,7 +165,7 @@ func (s *FilesystemStatusSuite) TestGetSetStatusGone(c *gc.C) {
 
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusAttaching,
+		Status:  status.Attaching,
 		Message: "not really",
 		Since:   &now,
 	}
@@ -180,7 +180,7 @@ func (s *FilesystemStatusSuite) TestGetSetStatusGone(c *gc.C) {
 func (s *FilesystemStatusSuite) TestSetStatusPendingUnprovisioned(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusPending,
+		Status:  status.Pending,
 		Message: "still",
 		Since:   &now,
 	}
@@ -195,7 +195,7 @@ func (s *FilesystemStatusSuite) TestSetStatusPendingProvisioned(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusPending,
+		Status:  status.Pending,
 		Message: "",
 		Since:   &now,
 	}

--- a/state/status_history_test.go
+++ b/state/status_history_test.go
@@ -148,20 +148,20 @@ func (s *StatusHistorySuite) TestStatusHistoryFiltersByDateAndDelta(c *gc.C) {
 	twoDaysAgo := now.Add(-twoDaysBack)
 	threeDaysAgo := now.Add(-threeDaysBack)
 	sInfo := status.StatusInfo{
-		Status:  status.StatusActive,
+		Status:  status.Active,
 		Message: "current status",
 		Since:   &now,
 	}
 	err := unit.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusActive,
+		Status:  status.Active,
 		Message: "2 days ago",
 		Since:   &twoDaysAgo,
 	}
 	unit.SetStatus(sInfo)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusActive,
+		Status:  status.Active,
 		Message: "3 days ago",
 		Since:   &threeDaysAgo,
 	}

--- a/state/status_machine_test.go
+++ b/state/status_machine_test.go
@@ -32,7 +32,7 @@ func (s *MachineStatusSuite) TestInitialStatus(c *gc.C) {
 func (s *MachineStatusSuite) checkInitialStatus(c *gc.C) {
 	statusInfo, err := s.machine.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusInfo.Status, gc.Equals, status.StatusPending)
+	c.Check(statusInfo.Status, gc.Equals, status.Pending)
 	c.Check(statusInfo.Message, gc.Equals, "")
 	c.Check(statusInfo.Data, gc.HasLen, 0)
 	c.Check(statusInfo.Since, gc.NotNil)
@@ -41,7 +41,7 @@ func (s *MachineStatusSuite) checkInitialStatus(c *gc.C) {
 func (s *MachineStatusSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "",
 		Since:   &now,
 	}
@@ -54,7 +54,7 @@ func (s *MachineStatusSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
 func (s *MachineStatusSuite) TestSetDownStatus(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusDown,
+		Status:  status.Down,
 		Message: "",
 		Since:   &now,
 	}
@@ -80,7 +80,7 @@ func (s *MachineStatusSuite) TestSetUnknownStatus(c *gc.C) {
 func (s *MachineStatusSuite) TestSetOverwritesData(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusStarted,
+		Status:  status.Started,
 		Message: "blah",
 		Data: map[string]interface{}{
 			"pew.pew": "zap",
@@ -100,7 +100,7 @@ func (s *MachineStatusSuite) TestGetSetStatusAlive(c *gc.C) {
 func (s *MachineStatusSuite) checkGetSetStatus(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusStarted,
+		Status:  status.Started,
 		Message: "blah",
 		Data: map[string]interface{}{
 			"$foo.bar.baz": map[string]interface{}{
@@ -117,7 +117,7 @@ func (s *MachineStatusSuite) checkGetSetStatus(c *gc.C) {
 
 	statusInfo, err := machine.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusInfo.Status, gc.Equals, status.StatusStarted)
+	c.Check(statusInfo.Status, gc.Equals, status.Started)
 	c.Check(statusInfo.Message, gc.Equals, "blah")
 	c.Check(statusInfo.Data, jc.DeepEquals, map[string]interface{}{
 		"$foo.bar.baz": map[string]interface{}{
@@ -152,7 +152,7 @@ func (s *MachineStatusSuite) TestGetSetStatusGone(c *gc.C) {
 
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusStarted,
+		Status:  status.Started,
 		Message: "not really",
 		Since:   &now,
 	}
@@ -167,7 +167,7 @@ func (s *MachineStatusSuite) TestGetSetStatusGone(c *gc.C) {
 func (s *MachineStatusSuite) TestSetStatusPendingProvisioned(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusPending,
+		Status:  status.Pending,
 		Message: "",
 		Since:   &now,
 	}
@@ -180,7 +180,7 @@ func (s *MachineStatusSuite) TestSetStatusPendingUnprovisioned(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusPending,
+		Status:  status.Pending,
 		Message: "",
 		Since:   &now,
 	}

--- a/state/status_model_test.go
+++ b/state/status_model_test.go
@@ -46,7 +46,7 @@ func (s *ModelStatusSuite) TestInitialStatus(c *gc.C) {
 func (s *ModelStatusSuite) checkInitialStatus(c *gc.C) {
 	statusInfo, err := s.model.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusInfo.Status, gc.Equals, status.StatusAvailable)
+	c.Check(statusInfo.Status, gc.Equals, status.Available)
 	c.Check(statusInfo.Message, gc.Equals, "")
 	c.Check(statusInfo.Data, gc.HasLen, 0)
 	c.Check(statusInfo.Since, gc.NotNil)
@@ -68,7 +68,7 @@ func (s *ModelStatusSuite) TestSetUnknownStatus(c *gc.C) {
 func (s *ModelStatusSuite) TestSetOverwritesData(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusAvailable,
+		Status:  status.Available,
 		Message: "blah",
 		Data: map[string]interface{}{
 			"pew.pew": "zap",
@@ -111,7 +111,7 @@ func (s *ModelStatusSuite) TestGetSetStatusGone(c *gc.C) {
 
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusAvailable,
+		Status:  status.Available,
 		Message: "not really",
 		Since:   &now,
 	}
@@ -125,7 +125,7 @@ func (s *ModelStatusSuite) TestGetSetStatusGone(c *gc.C) {
 func (s *ModelStatusSuite) checkGetSetStatus(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusAvailable,
+		Status:  status.Available,
 		Message: "blah",
 		Data: map[string]interface{}{
 			"$foo.bar.baz": map[string]interface{}{
@@ -141,7 +141,7 @@ func (s *ModelStatusSuite) checkGetSetStatus(c *gc.C) {
 
 	statusInfo, err := model.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusInfo.Status, gc.Equals, status.StatusAvailable)
+	c.Check(statusInfo.Status, gc.Equals, status.Available)
 	c.Check(statusInfo.Message, gc.Equals, "blah")
 	c.Check(statusInfo.Data, jc.DeepEquals, map[string]interface{}{
 		"$foo.bar.baz": map[string]interface{}{

--- a/state/status_service_test.go
+++ b/state/status_service_test.go
@@ -51,7 +51,7 @@ func (s *ServiceStatusSuite) TestSetUnknownStatus(c *gc.C) {
 func (s *ServiceStatusSuite) TestSetOverwritesData(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusActive,
+		Status:  status.Active,
 		Message: "healthy",
 		Data: map[string]interface{}{
 			"pew.pew": "zap",
@@ -71,7 +71,7 @@ func (s *ServiceStatusSuite) TestGetSetStatusAlive(c *gc.C) {
 func (s *ServiceStatusSuite) checkGetSetStatus(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusActive,
+		Status:  status.Active,
 		Message: "healthy",
 		Data: map[string]interface{}{
 			"$ping": map[string]interface{}{
@@ -88,7 +88,7 @@ func (s *ServiceStatusSuite) checkGetSetStatus(c *gc.C) {
 
 	statusInfo, err := service.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusInfo.Status, gc.Equals, status.StatusActive)
+	c.Check(statusInfo.Status, gc.Equals, status.Active)
 	c.Check(statusInfo.Message, gc.Equals, "healthy")
 	c.Check(statusInfo.Data, jc.DeepEquals, map[string]interface{}{
 		"$ping": map[string]interface{}{
@@ -113,7 +113,7 @@ func (s *ServiceStatusSuite) TestGetSetStatusGone(c *gc.C) {
 
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusActive,
+		Status:  status.Active,
 		Message: "not really",
 		Since:   &now,
 	}
@@ -128,7 +128,7 @@ func (s *ServiceStatusSuite) TestGetSetStatusGone(c *gc.C) {
 func (s *ServiceStatusSuite) TestSetStatusSince(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusMaintenance,
+		Status:  status.Maintenance,
 		Message: "",
 		Since:   &now,
 	}
@@ -143,7 +143,7 @@ func (s *ServiceStatusSuite) TestSetStatusSince(c *gc.C) {
 	// Setting the same status a second time also updates the timestamp.
 	now = now.Add(1 * time.Second)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusMaintenance,
+		Status:  status.Maintenance,
 		Message: "",
 		Since:   &now,
 	}
@@ -173,19 +173,19 @@ func (s *ServiceStatusSuite) TestDeriveStatus(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 		return unit
 	}
-	blockedUnit := addUnit(status.StatusBlocked)
-	waitingUnit := addUnit(status.StatusWaiting)
-	maintenanceUnit := addUnit(status.StatusMaintenance)
-	terminatedUnit := addUnit(status.StatusTerminated)
-	activeUnit := addUnit(status.StatusActive)
-	unknownUnit := addUnit(status.StatusUnknown)
+	blockedUnit := addUnit(status.Blocked)
+	waitingUnit := addUnit(status.Waiting)
+	maintenanceUnit := addUnit(status.Maintenance)
+	terminatedUnit := addUnit(status.Terminated)
+	activeUnit := addUnit(status.Active)
+	unknownUnit := addUnit(status.Unknown)
 
 	// ...and create one with error status by setting it on the agent :-/.
 	errorUnit, err := s.service.AddUnit()
 	c.Assert(err, gc.IsNil)
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "blam",
 		Since:   &now,
 	}
@@ -207,13 +207,13 @@ func (s *ServiceStatusSuite) TestDeriveStatus(c *gc.C) {
 		err = unit.Remove()
 		c.Assert(err, jc.ErrorIsNil)
 	}
-	checkAndRemove(errorUnit, status.StatusError)
-	checkAndRemove(blockedUnit, status.StatusBlocked)
-	checkAndRemove(waitingUnit, status.StatusWaiting)
-	checkAndRemove(maintenanceUnit, status.StatusMaintenance)
-	checkAndRemove(terminatedUnit, status.StatusTerminated)
-	checkAndRemove(activeUnit, status.StatusActive)
-	checkAndRemove(unknownUnit, status.StatusUnknown)
+	checkAndRemove(errorUnit, status.Error)
+	checkAndRemove(blockedUnit, status.Blocked)
+	checkAndRemove(waitingUnit, status.Waiting)
+	checkAndRemove(maintenanceUnit, status.Maintenance)
+	checkAndRemove(terminatedUnit, status.Terminated)
+	checkAndRemove(activeUnit, status.Active)
+	checkAndRemove(unknownUnit, status.Unknown)
 }
 
 func (s *ServiceStatusSuite) TestServiceStatusOverridesDerivedStatus(c *gc.C) {
@@ -221,14 +221,14 @@ func (s *ServiceStatusSuite) TestServiceStatusOverridesDerivedStatus(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusBlocked,
+		Status:  status.Blocked,
 		Message: "pow",
 		Since:   &now,
 	}
 	err = unit.SetStatus(sInfo)
 	c.Assert(err, gc.IsNil)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusMaintenance,
+		Status:  status.Maintenance,
 		Message: "zot",
 		Since:   &now,
 	}
@@ -237,5 +237,5 @@ func (s *ServiceStatusSuite) TestServiceStatusOverridesDerivedStatus(c *gc.C) {
 
 	info, err := s.service.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(info.Status, gc.Equals, status.StatusMaintenance)
+	c.Check(info.Status, gc.Equals, status.Maintenance)
 }

--- a/state/status_unit_test.go
+++ b/state/status_unit_test.go
@@ -51,7 +51,7 @@ func (s *UnitStatusSuite) TestSetUnknownStatus(c *gc.C) {
 func (s *UnitStatusSuite) TestSetOverwritesData(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusActive,
+		Status:  status.Active,
 		Message: "healthy",
 		Data: map[string]interface{}{
 			"pew.pew": "zap",
@@ -71,7 +71,7 @@ func (s *UnitStatusSuite) TestGetSetStatusAlive(c *gc.C) {
 func (s *UnitStatusSuite) checkGetSetStatus(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusActive,
+		Status:  status.Active,
 		Message: "healthy",
 		Data: map[string]interface{}{
 			"$ping": map[string]interface{}{
@@ -87,7 +87,7 @@ func (s *UnitStatusSuite) checkGetSetStatus(c *gc.C) {
 
 	statusInfo, err := unit.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusInfo.Status, gc.Equals, status.StatusActive)
+	c.Check(statusInfo.Status, gc.Equals, status.Active)
 	c.Check(statusInfo.Message, gc.Equals, "healthy")
 	c.Check(statusInfo.Data, jc.DeepEquals, map[string]interface{}{
 		"$ping": map[string]interface{}{
@@ -124,7 +124,7 @@ func (s *UnitStatusSuite) TestGetSetStatusGone(c *gc.C) {
 
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusActive,
+		Status:  status.Active,
 		Message: "not really",
 		Since:   &now,
 	}
@@ -139,7 +139,7 @@ func (s *UnitStatusSuite) TestGetSetStatusGone(c *gc.C) {
 func (s *UnitStatusSuite) TestSetUnitStatusSince(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusMaintenance,
+		Status:  status.Maintenance,
 		Message: "",
 		Since:   &now,
 	}
@@ -154,7 +154,7 @@ func (s *UnitStatusSuite) TestSetUnitStatusSince(c *gc.C) {
 	// Setting the same status a second time also updates the timestamp.
 	now = now.Add(1 * time.Second)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusMaintenance,
+		Status:  status.Maintenance,
 		Message: "",
 		Since:   &now,
 	}

--- a/state/status_unitagent_test.go
+++ b/state/status_unitagent_test.go
@@ -53,7 +53,7 @@ func (s *StatusUnitAgentSuite) TestSetUnknownStatus(c *gc.C) {
 func (s *StatusUnitAgentSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "",
 		Since:   &now,
 	}
@@ -66,7 +66,7 @@ func (s *StatusUnitAgentSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
 func (s *StatusUnitAgentSuite) TestSetOverwritesData(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusIdle,
+		Status:  status.Idle,
 		Message: "something",
 		Data: map[string]interface{}{
 			"pew.pew": "zap",
@@ -86,7 +86,7 @@ func (s *StatusUnitAgentSuite) TestGetSetStatusAlive(c *gc.C) {
 func (s *StatusUnitAgentSuite) checkGetSetStatus(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusIdle,
+		Status:  status.Idle,
 		Message: "something",
 		Data: map[string]interface{}{
 			"$foo":    "bar",
@@ -106,7 +106,7 @@ func (s *StatusUnitAgentSuite) checkGetSetStatus(c *gc.C) {
 
 	statusInfo, err := agent.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusInfo.Status, gc.Equals, status.StatusIdle)
+	c.Check(statusInfo.Status, gc.Equals, status.Idle)
 	c.Check(statusInfo.Message, gc.Equals, "something")
 	c.Check(statusInfo.Data, jc.DeepEquals, map[string]interface{}{
 		"$foo":    "bar",
@@ -145,7 +145,7 @@ func (s *StatusUnitAgentSuite) TestGetSetStatusGone(c *gc.C) {
 
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusIdle,
+		Status:  status.Idle,
 		Message: "not really",
 		Since:   &now,
 	}
@@ -160,7 +160,7 @@ func (s *StatusUnitAgentSuite) TestGetSetStatusGone(c *gc.C) {
 func (s *StatusUnitAgentSuite) TestGetSetErrorStatus(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "test-hook failed",
 		Data: map[string]interface{}{
 			"foo": "bar",
@@ -173,7 +173,7 @@ func (s *StatusUnitAgentSuite) TestGetSetErrorStatus(c *gc.C) {
 	// Agent error is reported as unit error.
 	statusInfo, err := s.unit.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusInfo.Status, gc.Equals, status.StatusError)
+	c.Check(statusInfo.Status, gc.Equals, status.Error)
 	c.Check(statusInfo.Message, gc.Equals, "test-hook failed")
 	c.Check(statusInfo.Data, gc.DeepEquals, map[string]interface{}{
 		"foo": "bar",
@@ -182,7 +182,7 @@ func (s *StatusUnitAgentSuite) TestGetSetErrorStatus(c *gc.C) {
 	// For agents, error is reported as idle.
 	statusInfo, err = s.agent.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusInfo.Status, gc.Equals, status.StatusIdle)
+	c.Check(statusInfo.Status, gc.Equals, status.Idle)
 	c.Check(statusInfo.Message, gc.Equals, "")
 	c.Check(statusInfo.Data, gc.HasLen, 0)
 }
@@ -194,7 +194,7 @@ func timeBeforeOrEqual(timeBefore, timeOther time.Time) bool {
 func (s *StatusUnitAgentSuite) TestSetAgentStatusSince(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusIdle,
+		Status:  status.Idle,
 		Message: "",
 		Since:   &now,
 	}
@@ -209,7 +209,7 @@ func (s *StatusUnitAgentSuite) TestSetAgentStatusSince(c *gc.C) {
 	// Setting the same status a second time also updates the timestamp.
 	now = now.Add(1 * time.Second)
 	sInfo = status.StatusInfo{
-		Status:  status.StatusIdle,
+		Status:  status.Idle,
 		Message: "",
 		Since:   &now,
 	}

--- a/state/status_util_test.go
+++ b/state/status_util_test.go
@@ -43,40 +43,40 @@ func primeStatusHistory(c *gc.C, entity statusSetter, statusVal status.Status, c
 }
 
 func checkInitialWorkloadStatus(c *gc.C, statusInfo status.StatusInfo) {
-	c.Check(statusInfo.Status, gc.Equals, status.StatusUnknown)
+	c.Check(statusInfo.Status, gc.Equals, status.Unknown)
 	c.Check(statusInfo.Message, gc.Equals, "Waiting for agent initialization to finish")
 	c.Check(statusInfo.Data, gc.HasLen, 0)
 	c.Check(statusInfo.Since, gc.NotNil)
 }
 
 func primeUnitStatusHistory(c *gc.C, unit *state.Unit, count int, delta time.Duration) {
-	primeStatusHistory(c, unit, status.StatusActive, count, func(i int) map[string]interface{} {
+	primeStatusHistory(c, unit, status.Active, count, func(i int) map[string]interface{} {
 		return map[string]interface{}{"$foo": i, "$delta": delta}
 	}, delta)
 }
 
 func checkPrimedUnitStatus(c *gc.C, statusInfo status.StatusInfo, expect int, expectDelta time.Duration) {
-	c.Check(statusInfo.Status, gc.Equals, status.StatusActive)
+	c.Check(statusInfo.Status, gc.Equals, status.Active)
 	c.Check(statusInfo.Message, gc.Equals, "")
 	c.Check(statusInfo.Data, jc.DeepEquals, map[string]interface{}{"$foo": expect, "$delta": int64(expectDelta)})
 	c.Check(statusInfo.Since, gc.NotNil)
 }
 
 func checkInitialUnitAgentStatus(c *gc.C, statusInfo status.StatusInfo) {
-	c.Check(statusInfo.Status, gc.Equals, status.StatusAllocating)
+	c.Check(statusInfo.Status, gc.Equals, status.Allocating)
 	c.Check(statusInfo.Message, gc.Equals, "")
 	c.Check(statusInfo.Data, gc.HasLen, 0)
 	c.Assert(statusInfo.Since, gc.NotNil)
 }
 
 func primeUnitAgentStatusHistory(c *gc.C, agent *state.UnitAgent, count int, delta time.Duration) {
-	primeStatusHistory(c, agent, status.StatusExecuting, count, func(i int) map[string]interface{} {
+	primeStatusHistory(c, agent, status.Executing, count, func(i int) map[string]interface{} {
 		return map[string]interface{}{"$bar": i, "$delta": delta}
 	}, delta)
 }
 
 func checkPrimedUnitAgentStatus(c *gc.C, statusInfo status.StatusInfo, expect int, expectDelta time.Duration) {
-	c.Check(statusInfo.Status, gc.Equals, status.StatusExecuting)
+	c.Check(statusInfo.Status, gc.Equals, status.Executing)
 	c.Check(statusInfo.Message, gc.Equals, "")
 	c.Check(statusInfo.Data, jc.DeepEquals, map[string]interface{}{"$bar": expect, "$delta": int64(expectDelta)})
 	c.Check(statusInfo.Since, gc.NotNil)

--- a/state/status_volume_test.go
+++ b/state/status_volume_test.go
@@ -53,7 +53,7 @@ func (s *VolumeStatusSuite) TestInitialStatus(c *gc.C) {
 func (s *VolumeStatusSuite) checkInitialStatus(c *gc.C) {
 	statusInfo, err := s.volume.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusInfo.Status, gc.Equals, status.StatusPending)
+	c.Check(statusInfo.Status, gc.Equals, status.Pending)
 	c.Check(statusInfo.Message, gc.Equals, "")
 	c.Check(statusInfo.Data, gc.HasLen, 0)
 	c.Check(statusInfo.Since, gc.NotNil)
@@ -62,7 +62,7 @@ func (s *VolumeStatusSuite) checkInitialStatus(c *gc.C) {
 func (s *VolumeStatusSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "",
 		Since:   &now,
 	}
@@ -88,7 +88,7 @@ func (s *VolumeStatusSuite) TestSetUnknownStatus(c *gc.C) {
 func (s *VolumeStatusSuite) TestSetOverwritesData(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusAttaching,
+		Status:  status.Attaching,
 		Message: "blah",
 		Data: map[string]interface{}{
 			"pew.pew": "zap",
@@ -98,13 +98,13 @@ func (s *VolumeStatusSuite) TestSetOverwritesData(c *gc.C) {
 	err := s.volume.SetStatus(sInfo)
 	c.Check(err, jc.ErrorIsNil)
 
-	s.checkGetSetStatus(c, status.StatusAttaching)
+	s.checkGetSetStatus(c, status.Attaching)
 }
 
 func (s *VolumeStatusSuite) TestGetSetStatusAlive(c *gc.C) {
 	validStatuses := []status.Status{
-		status.StatusAttaching, status.StatusAttached, status.StatusDetaching,
-		status.StatusDetached, status.StatusDestroying,
+		status.Attaching, status.Attached, status.Detaching,
+		status.Detached, status.Destroying,
 	}
 	for _, status := range validStatuses {
 		s.checkGetSetStatus(c, status)
@@ -145,7 +145,7 @@ func (s *VolumeStatusSuite) TestGetSetStatusDying(c *gc.C) {
 	err := s.State.DestroyVolume(s.volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.checkGetSetStatus(c, status.StatusAttaching)
+	s.checkGetSetStatus(c, status.Attaching)
 }
 
 func (s *VolumeStatusSuite) TestGetSetStatusDead(c *gc.C) {
@@ -163,7 +163,7 @@ func (s *VolumeStatusSuite) TestGetSetStatusDead(c *gc.C) {
 	// NOTE: it would be more technically correct to reject status updates
 	// while Dead, but it's easier and clearer, not to mention more efficient,
 	// to just depend on status doc existence.
-	s.checkGetSetStatus(c, status.StatusAttaching)
+	s.checkGetSetStatus(c, status.Attaching)
 }
 
 func (s *VolumeStatusSuite) TestGetSetStatusGone(c *gc.C) {
@@ -171,7 +171,7 @@ func (s *VolumeStatusSuite) TestGetSetStatusGone(c *gc.C) {
 
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusAttaching,
+		Status:  status.Attaching,
 		Message: "not really",
 		Since:   &now,
 	}
@@ -186,7 +186,7 @@ func (s *VolumeStatusSuite) TestGetSetStatusGone(c *gc.C) {
 func (s *VolumeStatusSuite) TestSetStatusPendingUnprovisioned(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusPending,
+		Status:  status.Pending,
 		Message: "still",
 		Since:   &now,
 	}
@@ -201,7 +201,7 @@ func (s *VolumeStatusSuite) TestSetStatusPendingProvisioned(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusPending,
+		Status:  status.Pending,
 		Message: "",
 		Since:   &now,
 	}

--- a/state/unit.go
+++ b/state/unit.go
@@ -216,7 +216,7 @@ func (u *Unit) SetWorkloadVersion(version string) error {
 	return setStatus(u.st, setStatusParams{
 		badge:     "workload",
 		globalKey: u.globalWorkloadVersionKey(),
-		status:    status.StatusActive,
+		status:    status.Active,
 		message:   version,
 		updated:   &now,
 	})
@@ -413,14 +413,14 @@ func (u *Unit) destroyOps() ([]txn.Op, error) {
 	} else if agentErr != nil {
 		return nil, errors.Trace(agentErr)
 	}
-	if agentStatusInfo.Status != status.StatusAllocating {
+	if agentStatusInfo.Status != status.Allocating {
 		return setDyingOps, nil
 	}
 
 	ops := []txn.Op{{
 		C:      statusesC,
 		Id:     u.st.docID(agentStatusDocId),
-		Assert: bson.D{{"status", status.StatusAllocating}},
+		Assert: bson.D{{"status", status.Allocating}},
 	}, minUnitsOp}
 	removeAsserts := append(isAliveDoc, bson.DocElem{
 		"$and", []bson.D{
@@ -855,7 +855,7 @@ func (u *Unit) Status() (status.StatusInfo, error) {
 	if err != nil {
 		return status.StatusInfo{}, err
 	}
-	if info.Status != status.StatusError {
+	if info.Status != status.Error {
 		info, err = getStatus(u.st, u.globalKey(), "unit")
 		if err != nil {
 			return status.StatusInfo{}, err
@@ -2215,7 +2215,7 @@ func (u *Unit) Resolve(retryHooks bool) error {
 	if err != nil {
 		return err
 	}
-	if statusInfo.Status != status.StatusError {
+	if statusInfo.Status != status.Error {
 		return errors.Errorf("unit %q is not in an error state", u)
 	}
 	mode := ResolvedNoHooks

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -685,7 +685,7 @@ func (s *UnitSuite) TestDestroySetStatusRetry(c *gc.C) {
 	defer state.SetRetryHooks(c, s.State, func() {
 		now := time.Now()
 		sInfo := status.StatusInfo{
-			Status:  status.StatusIdle,
+			Status:  status.Idle,
 			Message: "",
 			Since:   &now,
 		}
@@ -796,13 +796,13 @@ func (s *UnitSuite) TestCannotShortCircuitDestroyWithAgentStatus(c *gc.C) {
 		status status.Status
 		info   string
 	}{{
-		status.StatusExecuting, "blah",
+		status.Executing, "blah",
 	}, {
-		status.StatusIdle, "blah",
+		status.Idle, "blah",
 	}, {
-		status.StatusFailed, "blah",
+		status.Failed, "blah",
 	}, {
-		status.StatusRebooting, "blah",
+		status.Rebooting, "blah",
 	}} {
 		c.Logf("test %d: %s", i, test.status)
 		unit, err := s.service.AddUnit()
@@ -922,7 +922,7 @@ func (s *UnitSuite) TestResolve(c *gc.C) {
 
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusError,
+		Status:  status.Error,
 		Message: "gaaah",
 		Since:   &now,
 	}

--- a/state/unitagent.go
+++ b/state/unitagent.go
@@ -43,9 +43,9 @@ func (u *UnitAgent) Status() (status.StatusInfo, error) {
 	// be in error state, but the state model more correctly records the agent
 	// itself as being in error. So we'll do that model translation here.
 	// TODO(fwereade): this should absolutely not be happpening in the model.
-	if info.Status == status.StatusError {
+	if info.Status == status.Error {
 		return status.StatusInfo{
-			Status:  status.StatusIdle,
+			Status:  status.Idle,
 			Message: "",
 			Data:    map[string]interface{}{},
 			Since:   info.Since,
@@ -58,12 +58,12 @@ func (u *UnitAgent) Status() (status.StatusInfo, error) {
 // allow to pass additional helpful status data.
 func (u *UnitAgent) SetStatus(unitAgentStatus status.StatusInfo) (err error) {
 	switch unitAgentStatus.Status {
-	case status.StatusIdle, status.StatusExecuting, status.StatusRebooting, status.StatusFailed:
-	case status.StatusError:
+	case status.Idle, status.Executing, status.Rebooting, status.Failed:
+	case status.Error:
 		if unitAgentStatus.Message == "" {
 			return errors.Errorf("cannot set status %q without info", unitAgentStatus.Status)
 		}
-	case status.StatusAllocating, status.StatusLost:
+	case status.Allocating, status.Lost:
 		return errors.Errorf("cannot set status %q", unitAgentStatus.Status)
 	default:
 		return errors.Errorf("cannot set invalid status %q", unitAgentStatus.Status)

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -105,7 +105,7 @@ func AddFilesystemStatus(st *State) error {
 // it should be Attaching; otherwise it is Attached.
 func upgradingFilesystemStatus(st *State, filesystem Filesystem) (status.Status, error) {
 	if _, err := filesystem.Info(); errors.IsNotProvisioned(err) {
-		return status.StatusPending, nil
+		return status.Pending, nil
 	}
 	attachments, err := st.FilesystemAttachments(filesystem.FilesystemTag())
 	if err != nil {
@@ -114,10 +114,10 @@ func upgradingFilesystemStatus(st *State, filesystem Filesystem) (status.Status,
 	for _, attachment := range attachments {
 		_, err := attachment.Info()
 		if errors.IsNotProvisioned(err) {
-			return status.StatusAttaching, nil
+			return status.Attaching, nil
 		}
 	}
-	return status.StatusAttached, nil
+	return status.Attached, nil
 }
 
 // MigrateSettingsSchema migrates the schema of the settings collection,

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -264,7 +264,7 @@ func (s *upgradesSuite) TestAddFilesystemStatus(c *gc.C) {
 	removeStatusDoc(c, s.state, filesystem)
 	_, err := filesystem.Status()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	s.assertAddFilesystemStatus(c, filesystem, status.StatusPending)
+	s.assertAddFilesystemStatus(c, filesystem, status.Pending)
 }
 
 func (s *upgradesSuite) TestAddFilesystemStatusDoesNotOverwrite(c *gc.C) {
@@ -273,13 +273,13 @@ func (s *upgradesSuite) TestAddFilesystemStatusDoesNotOverwrite(c *gc.C) {
 
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusDestroying,
+		Status:  status.Destroying,
 		Message: "",
 		Since:   &now,
 	}
 	err := filesystem.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertAddFilesystemStatus(c, filesystem, status.StatusDestroying)
+	s.assertAddFilesystemStatus(c, filesystem, status.Destroying)
 }
 
 func (s *upgradesSuite) TestAddFilesystemStatusProvisioned(c *gc.C) {
@@ -291,7 +291,7 @@ func (s *upgradesSuite) TestAddFilesystemStatusProvisioned(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	removeStatusDoc(c, s.state, filesystem)
-	s.assertAddFilesystemStatus(c, filesystem, status.StatusAttaching)
+	s.assertAddFilesystemStatus(c, filesystem, status.Attaching)
 }
 
 func (s *upgradesSuite) TestAddFilesystemStatusAttached(c *gc.C) {
@@ -314,7 +314,7 @@ func (s *upgradesSuite) TestAddFilesystemStatusAttached(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	removeStatusDoc(c, s.state, filesystem)
-	s.assertAddFilesystemStatus(c, filesystem, status.StatusAttached)
+	s.assertAddFilesystemStatus(c, filesystem, status.Attached)
 }
 
 func (s *upgradesSuite) assertAddFilesystemStatus(c *gc.C, filesystem Filesystem, expect status.Status) {

--- a/state/volume.go
+++ b/state/volume.go
@@ -747,7 +747,7 @@ func (st *State) addVolumeOps(params VolumeParams, machineId string) ([]txn.Op, 
 		return nil, names.VolumeTag{}, errors.Annotate(err, "cannot generate volume name")
 	}
 	status := statusDoc{
-		Status: status.StatusPending,
+		Status: status.Pending,
 		// TODO(fwereade): 2016-03-17 lp:1558657
 		Updated: time.Now().UnixNano(),
 	}
@@ -1040,12 +1040,12 @@ func (st *State) VolumeStatus(tag names.VolumeTag) (status.StatusInfo, error) {
 // SetVolumeStatus sets the status of the specified volume.
 func (st *State) SetVolumeStatus(tag names.VolumeTag, volumeStatus status.Status, info string, data map[string]interface{}, updated *time.Time) error {
 	switch volumeStatus {
-	case status.StatusAttaching, status.StatusAttached, status.StatusDetaching, status.StatusDetached, status.StatusDestroying:
-	case status.StatusError:
+	case status.Attaching, status.Attached, status.Detaching, status.Detached, status.Destroying:
+	case status.Error:
 		if info == "" {
 			return errors.Errorf("cannot set status %q without info", volumeStatus)
 		}
-	case status.StatusPending:
+	case status.Pending:
 		// If a volume is not yet provisioned, we allow its status
 		// to be set back to pending (when a retry is to occur).
 		v, err := st.Volume(tag)

--- a/status/status.go
+++ b/status/status.go
@@ -46,151 +46,151 @@ type InstanceStatusGetter interface {
 const (
 	// Status values common to machine and unit agents.
 
-	// StatusError means the entity requires human intervention
+	// Error means the entity requires human intervention
 	// in order to operate correctly.
-	StatusError Status = "error"
+	Error Status = "error"
 
-	// StatusStarted is set when:
+	// Started is set when:
 	// The entity is actively participating in the model.
 	// For unit agents, this is a state we preserve for backwards
 	// compatibility with scripts during the life of Juju 1.x.
 	// In Juju 2.x, the agent-state will remain “active” and scripts
 	// will watch the unit-state instead for signals of service readiness.
-	StatusStarted Status = "started"
+	Started Status = "started"
 )
 
 const (
 	// Status values specific to machine agents.
 
-	// StatusPending is set when:
+	// Pending is set when:
 	// The machine is not yet participating in the model.
-	StatusPending Status = "pending"
+	Pending Status = "pending"
 
-	// StatusStopped is set when:
+	// Stopped is set when:
 	// The machine's agent will perform no further action, other than
 	// to set the unit to Dead at a suitable moment.
-	StatusStopped Status = "stopped"
+	Stopped Status = "stopped"
 
-	// StatusDown is set when:
+	// Down is set when:
 	// The machine ought to be signalling activity, but it cannot be
 	// detected.
-	StatusDown Status = "down"
+	Down Status = "down"
 )
 
 const (
 	// Status values specific to unit agents.
 
-	// StatusAllocating is set when:
+	// Allocating is set when:
 	// The machine on which a unit is to be hosted is still being
 	// spun up in the cloud.
-	StatusAllocating Status = "allocating"
+	Allocating Status = "allocating"
 
-	// StatusRebooting is set when:
+	// Rebooting is set when:
 	// The machine on which this agent is running is being rebooted.
 	// The juju-agent should move from rebooting to idle when the reboot is complete.
-	StatusRebooting Status = "rebooting"
+	Rebooting Status = "rebooting"
 
-	// StatusExecuting is set when:
+	// Executing is set when:
 	// The agent is running a hook or action. The human-readable message should reflect
 	// which hook or action is being run.
-	StatusExecuting Status = "executing"
+	Executing Status = "executing"
 
-	// StatusIdle is set when:
+	// Idle is set when:
 	// Once the agent is installed and running it will notify the Juju server and its state
 	// becomes "idle". It will stay "idle" until some action (e.g. it needs to run a hook) or
 	// error (e.g it loses contact with the Juju server) moves it to a different state.
-	StatusIdle Status = "idle"
+	Idle Status = "idle"
 
-	// StatusFailed is set when:
+	// Failed is set when:
 	// The unit agent has failed in some way,eg the agent ought to be signalling
 	// activity, but it cannot be detected. It might also be that the unit agent
 	// detected an unrecoverable condition and managed to tell the Juju server about it.
-	StatusFailed Status = "failed"
+	Failed Status = "failed"
 
-	// StatusLost is set when:
+	// Lost is set when:
 	// The juju agent has has not communicated with the juju server for an unexpectedly long time;
 	// the unit agent ought to be signalling activity, but none has been detected.
-	StatusLost Status = "lost"
+	Lost Status = "lost"
 )
 
 const (
 	// Status values specific to services and units, reflecting the
 	// state of the software itself.
 
-	// StatusMaintenance is set when:
+	// Maintenance is set when:
 	// The unit is not yet providing services, but is actively doing stuff
 	// in preparation for providing those services.
 	// This is a "spinning" state, not an error state.
 	// It reflects activity on the unit itself, not on peers or related units.
-	StatusMaintenance Status = "maintenance"
+	Maintenance Status = "maintenance"
 
-	// StatusTerminated is set when:
+	// Terminated is set when:
 	// This unit used to exist, we have a record of it (perhaps because of storage
 	// allocated for it that was flagged to survive it). Nonetheless, it is now gone.
-	StatusTerminated Status = "terminated"
+	Terminated Status = "terminated"
 
-	// StatusUnknown is set when:
+	// Unknown is set when:
 	// A unit-agent has finished calling install, config-changed, and start,
 	// but the charm has not called status-set yet.
-	StatusUnknown Status = "unknown"
+	Unknown Status = "unknown"
 
-	// StatusWaiting is set when:
+	// Waiting is set when:
 	// The unit is unable to progress to an active state because a service to
 	// which it is related is not running.
-	StatusWaiting Status = "waiting"
+	Waiting Status = "waiting"
 
-	// StatusBlocked is set when:
+	// Blocked is set when:
 	// The unit needs manual intervention to get back to the Running state.
-	StatusBlocked Status = "blocked"
+	Blocked Status = "blocked"
 
-	// StatusActive is set when:
+	// Active is set when:
 	// The unit believes it is correctly offering all the services it has
 	// been asked to offer.
-	StatusActive Status = "active"
+	Active Status = "active"
 )
 
 const (
 	// Status values specific to storage.
 
-	// StatusAttaching indicates that the storage is being attached
+	// Attaching indicates that the storage is being attached
 	// to a machine.
-	StatusAttaching Status = "attaching"
+	Attaching Status = "attaching"
 
-	// StatusAttached indicates that the storage is attached to a
+	// Attached indicates that the storage is attached to a
 	// machine.
-	StatusAttached Status = "attached"
+	Attached Status = "attached"
 
-	// StatusDetaching indicates that the storage is being detached
+	// Detaching indicates that the storage is being detached
 	// from a machine.
-	StatusDetaching Status = "detaching"
+	Detaching Status = "detaching"
 
-	// StatusDetached indicates that the storage is not attached to
+	// Detached indicates that the storage is not attached to
 	// any machine.
-	StatusDetached Status = "detached"
+	Detached Status = "detached"
 )
 
 const (
 	// Status values specific to models.
 
-	// StatusAvailable indicates that the model is available for use.
-	StatusAvailable Status = "available"
+	// Available indicates that the model is available for use.
+	Available Status = "available"
 )
 
 const (
 	// Status values that are common to several entities.
 
-	// StatusDestroying indicates that the entity is being destroyed.
+	// Destroying indicates that the entity is being destroyed.
 	//
 	// This is valid for volumes, filesystems, and models.
-	StatusDestroying Status = "destroying"
+	Destroying Status = "destroying"
 )
 
 // InstanceStatus
 const (
-	StatusEmpty             Status = ""
-	StatusProvisioning      Status = "allocating"
-	StatusRunning           Status = "running"
-	StatusProvisioningError Status = "provisioning error"
+	Empty             Status = ""
+	Provisioning      Status = "allocating"
+	Running           Status = "running"
+	ProvisioningError Status = "provisioning error"
 )
 
 const (
@@ -208,11 +208,11 @@ const (
 func (status Status) KnownInstanceStatus() bool {
 	switch status {
 	case
-		StatusPending,
-		StatusProvisioningError,
-		StatusAllocating,
-		StatusRunning,
-		StatusUnknown:
+		Pending,
+		ProvisioningError,
+		Allocating,
+		Running,
+		Unknown:
 		return true
 	}
 	return false
@@ -224,12 +224,12 @@ func (status Status) KnownInstanceStatus() bool {
 func (status Status) KnownAgentStatus() bool {
 	switch status {
 	case
-		StatusAllocating,
-		StatusError,
-		StatusFailed,
-		StatusRebooting,
-		StatusExecuting,
-		StatusIdle:
+		Allocating,
+		Error,
+		Failed,
+		Rebooting,
+		Executing,
+		Idle:
 		return true
 	}
 	return false
@@ -243,7 +243,7 @@ func (status Status) KnownWorkloadStatus() bool {
 		return true
 	}
 	switch status {
-	case StatusError: // include error so that we can filter on what the spec says is valid
+	case Error: // include error so that we can filter on what the spec says is valid
 		return true
 	default:
 		return false
@@ -255,12 +255,12 @@ func (status Status) KnownWorkloadStatus() bool {
 func ValidWorkloadStatus(status Status) bool {
 	switch status {
 	case
-		StatusBlocked,
-		StatusMaintenance,
-		StatusWaiting,
-		StatusActive,
-		StatusUnknown,
-		StatusTerminated:
+		Blocked,
+		Maintenance,
+		Waiting,
+		Active,
+		Unknown,
+		Terminated:
 		return true
 	default:
 		return false
@@ -279,8 +279,8 @@ func (status Status) WorkloadMatches(candidate Status) bool {
 func ValidModelStatus(status Status) bool {
 	switch status {
 	case
-		StatusAvailable,
-		StatusDestroying:
+		Available,
+		Destroying:
 		return true
 	default:
 		return false

--- a/status/status_history.go
+++ b/status/status_history.go
@@ -92,7 +92,7 @@ func (h *History) SquashLogs(cycleSize int) History {
 	var repeat int
 	var i int
 	repeatStatus := DetailedStatus{
-		Status: StatusIdle,
+		Status: Idle,
 		Info:   "",
 		Since:  &now,
 	}

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -21,47 +21,47 @@ func (h *statusHistorySuite) TestStatusSquashing(c *gc.C) {
 	since := time.Now()
 	statuses := status.History{
 		{
-			Status: status.StatusActive,
+			Status: status.Active,
 			Info:   "unique status one",
 			Since:  &since,
 		},
 		{
-			Status: status.StatusActive,
+			Status: status.Active,
 			Info:   "unique status two",
 			Since:  &since,
 		},
 		{
-			Status: status.StatusActive,
+			Status: status.Active,
 			Info:   "unique status three",
 			Since:  &since,
 		},
 		{
-			Status: status.StatusExecuting,
+			Status: status.Executing,
 			Info:   "repeated status one",
 			Since:  &since,
 		},
 		{
-			Status: status.StatusIdle,
+			Status: status.Idle,
 			Info:   "repeated status two",
 			Since:  &since,
 		},
 		{
-			Status: status.StatusExecuting,
+			Status: status.Executing,
 			Info:   "repeated status one",
 			Since:  &since,
 		},
 		{
-			Status: status.StatusIdle,
+			Status: status.Idle,
 			Info:   "repeated status two",
 			Since:  &since,
 		},
 		{
-			Status: status.StatusExecuting,
+			Status: status.Executing,
 			Info:   "repeated status one",
 			Since:  &since,
 		},
 		{
-			Status: status.StatusIdle,
+			Status: status.Idle,
 			Info:   "repeated status two",
 			Since:  &since,
 		},
@@ -72,32 +72,32 @@ func (h *statusHistorySuite) TestStatusSquashing(c *gc.C) {
 	newStatuses[5].Since = &since
 	expectedStatuses := status.History{
 		{
-			Status: status.StatusActive,
+			Status: status.Active,
 			Info:   "unique status one",
 			Since:  &since,
 		},
 		{
-			Status: status.StatusActive,
+			Status: status.Active,
 			Info:   "unique status two",
 			Since:  &since,
 		},
 		{
-			Status: status.StatusActive,
+			Status: status.Active,
 			Info:   "unique status three",
 			Since:  &since,
 		},
 		{
-			Status: status.StatusExecuting,
+			Status: status.Executing,
 			Info:   "repeated status one",
 			Since:  &since,
 		},
 		{
-			Status: status.StatusIdle,
+			Status: status.Idle,
 			Info:   "repeated status two",
 			Since:  &since,
 		},
 		{
-			Status: status.StatusIdle,
+			Status: status.Idle,
 			Info:   "last 2 statuses repeated 2 times",
 			Since:  &since,
 		},

--- a/worker/deployer/deployer_test.go
+++ b/worker/deployer/deployer_test.go
@@ -79,7 +79,7 @@ func (s *deployerSuite) TestDeployRecallRemovePrincipals(c *gc.C) {
 	// Cause a unit to become Dying, and check no change.
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusIdle,
+		Status:  status.Idle,
 		Message: "",
 		Since:   &now,
 	}
@@ -128,7 +128,7 @@ func (s *deployerSuite) TestRemoveNonAlivePrincipals(c *gc.C) {
 	// would happen if it were possible to have a dying unit in this situation.
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusIdle,
+		Status:  status.Idle,
 		Message: "",
 		Since:   &now,
 	}

--- a/worker/instancepoller/aggregate_test.go
+++ b/worker/instancepoller/aggregate_test.go
@@ -49,7 +49,7 @@ func (t *testInstance) Addresses() ([]network.Address, error) {
 }
 
 func (t *testInstance) Status() instance.InstanceStatus {
-	return instance.InstanceStatus{Status: status.StatusUnknown, Message: t.status}
+	return instance.InstanceStatus{Status: status.Unknown, Message: t.status}
 }
 
 type testInstanceGetter struct {

--- a/worker/instancepoller/machine_test.go
+++ b/worker/instancepoller/machine_test.go
@@ -64,7 +64,7 @@ func (s *machineSuite) TestSetsInstanceInfoInitially(c *gc.C) {
 func (s *machineSuite) TestShortPollIntervalWhenNoAddress(c *gc.C) {
 	s.PatchValue(&ShortPoll, 1*time.Millisecond)
 	s.PatchValue(&LongPoll, coretesting.LongWait)
-	count := countPolls(c, nil, "i1234", "running", status.StatusStarted)
+	count := countPolls(c, nil, "i1234", "running", status.Started)
 	c.Assert(count, jc.GreaterThan, 2)
 }
 
@@ -78,14 +78,14 @@ func (s *machineSuite) TestShortPollIntervalWhenNoStatus(c *gc.C) {
 func (s *machineSuite) TestShortPollIntervalWhenNotStarted(c *gc.C) {
 	s.PatchValue(&ShortPoll, 1*time.Millisecond)
 	s.PatchValue(&LongPoll, coretesting.LongWait)
-	count := countPolls(c, testAddrs, "i1234", "pending", status.StatusPending)
+	count := countPolls(c, testAddrs, "i1234", "pending", status.Pending)
 	c.Assert(count, jc.GreaterThan, 2)
 }
 
 func (s *machineSuite) TestShortPollIntervalWhenNotProvisioned(c *gc.C) {
 	s.PatchValue(&ShortPoll, 1*time.Millisecond)
 	s.PatchValue(&LongPoll, coretesting.LongWait)
-	count := countPolls(c, testAddrs, "", "pending", status.StatusPending)
+	count := countPolls(c, testAddrs, "", "pending", status.Pending)
 	c.Assert(count, gc.Equals, 0)
 }
 
@@ -99,7 +99,7 @@ func (s *machineSuite) TestNoPollWhenNotProvisioned(c *gc.C) {
 		case polled <- struct{}{}:
 		default:
 		}
-		return instanceInfo{testAddrs, instance.InstanceStatus{Status: status.StatusUnknown, Message: "pending"}}, nil
+		return instanceInfo{testAddrs, instance.InstanceStatus{Status: status.Unknown, Message: "pending"}}, nil
 	}
 	context := &testMachineContext{
 		getInstanceInfo: getInstanceInfo,
@@ -159,7 +159,7 @@ func (s *machineSuite) TestShortPollIntervalExponent(c *gc.C) {
 	// ShortPollBackoff of ShortWait/ShortPoll, given that sleep will
 	// sleep for at least the requested interval.
 	maxCount := int(math.Log(float64(coretesting.ShortWait)/float64(ShortPoll))/math.Log(ShortPollBackoff) + 1)
-	count := countPolls(c, nil, "i1234", "", status.StatusStarted)
+	count := countPolls(c, nil, "i1234", "", status.Started)
 	c.Assert(count, jc.GreaterThan, 2)
 	c.Assert(count, jc.LessThan, maxCount)
 	c.Logf("actual count: %v; max %v", count, maxCount)
@@ -168,7 +168,7 @@ func (s *machineSuite) TestShortPollIntervalExponent(c *gc.C) {
 func (s *machineSuite) TestLongPollIntervalWhenHasAllInstanceInfo(c *gc.C) {
 	s.PatchValue(&ShortPoll, coretesting.LongWait)
 	s.PatchValue(&LongPoll, 1*time.Millisecond)
-	count := countPolls(c, testAddrs, "i1234", "running", status.StatusStarted)
+	count := countPolls(c, testAddrs, "i1234", "running", status.Started)
 	c.Assert(count, jc.GreaterThan, 2)
 }
 
@@ -184,7 +184,7 @@ func countPolls(c *gc.C, addrs []network.Address, instId, instStatus string, mac
 		if addrs == nil {
 			return instanceInfo{}, fmt.Errorf("no instance addresses available")
 		}
-		return instanceInfo{addrs, instance.InstanceStatus{Status: status.StatusUnknown, Message: instStatus}}, nil
+		return instanceInfo{addrs, instance.InstanceStatus{Status: status.Unknown, Message: instStatus}}, nil
 	}
 	context := &testMachineContext{
 		getInstanceInfo: getInstanceInfo,
@@ -329,7 +329,7 @@ func instanceInfoGetter(
 
 	return func(id instance.Id) (instanceInfo, error) {
 		c.Check(id, gc.Equals, expectId)
-		return instanceInfo{addrs, instance.InstanceStatus{Status: status.StatusUnknown, Message: instanceStatus}}, err
+		return instanceInfo{addrs, instance.InstanceStatus{Status: status.Unknown, Message: instanceStatus}}, err
 	}
 }
 

--- a/worker/instancepoller/updater.go
+++ b/worker/instancepoller/updater.go
@@ -182,7 +182,7 @@ func machineLoop(context machineContext, m machine, lifeChanged <-chan struct{},
 			return err
 		}
 
-		machineStatus := status.StatusPending
+		machineStatus := status.Pending
 		if err == nil {
 			if statusInfo, err := m.Status(); err != nil {
 				logger.Warningf("cannot get current machine status for machine %v: %v", m.Id(), err)
@@ -194,8 +194,8 @@ func machineLoop(context machineContext, m machine, lifeChanged <-chan struct{},
 
 		// the extra condition below (checking allocating/pending) is here to improve user experience
 		// without it the instance status will say "pending" for +10 minutes after the agent comes up to "started"
-		if instInfo.status.Status != status.StatusAllocating && instInfo.status.Status != status.StatusPending {
-			if len(instInfo.addresses) > 0 && machineStatus == status.StatusStarted {
+		if instInfo.status.Status != status.Allocating && instInfo.status.Status != status.Pending {
+			if len(instInfo.addresses) > 0 && machineStatus == status.Started {
 				// We've got at least one address and a status and instance is started, so poll infrequently.
 				pollInterval = LongPoll
 			} else if pollInterval < LongPoll {
@@ -259,7 +259,7 @@ func pollInstanceInfo(context machineContext, m machine) (instInfo instanceInfo,
 		// This should never occur since the machine is provisioned.
 		// But just in case, we reset polled status so we try again next time.
 		logger.Warningf("cannot get current instance status for machine %v: %v", m.Id(), err)
-		instInfo.status = instance.InstanceStatus{status.StatusUnknown, ""}
+		instInfo.status = instance.InstanceStatus{status.Unknown, ""}
 	} else {
 		// TODO(perrito666) add status validation.
 		currentInstStatus := instance.InstanceStatus{

--- a/worker/instancepoller/updater_test.go
+++ b/worker/instancepoller/updater_test.go
@@ -97,7 +97,7 @@ func (s *updaterSuite) TestManualMachinesIgnored(c *gc.C) {
 		// Signal that we're in Status.
 		waitStatus <- struct{}{}
 		return params.StatusResult{
-			Status: status.StatusPending.String(),
+			Status: status.Pending.String(),
 			Info:   "",
 			Data:   map[string]interface{}{},
 			Since:  nil,

--- a/worker/instancepoller/worker_test.go
+++ b/worker/instancepoller/worker_test.go
@@ -101,7 +101,7 @@ func (s *workerSuite) TestWorker(c *gc.C) {
 			}
 			instanceStatus, err := m.InstanceStatus()
 			c.Logf("instance message is: %q", instanceStatus.Info)
-			c.Assert(instanceStatus.Status, gc.Equals, status.StatusPending.String())
+			c.Assert(instanceStatus.Status, gc.Equals, status.Pending.String())
 			stm, err := s.State.Machine(m.Id())
 			c.Assert(err, jc.ErrorIsNil)
 			return len(stm.Addresses()) == 0
@@ -128,7 +128,7 @@ func (s *workerSuite) TestWorker(c *gc.C) {
 			}
 			// Machines in second half still have no addresses, nor status.
 			instanceStatus, err := m.InstanceStatus()
-			c.Assert(instanceStatus.Status, gc.Equals, status.StatusPending.String())
+			c.Assert(instanceStatus.Status, gc.Equals, status.Pending.String())
 			stm, err := s.State.Machine(m.Id())
 			c.Assert(err, jc.ErrorIsNil)
 			return len(stm.Addresses()) == 0

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -99,7 +99,7 @@ func (mr *Machiner) SetUp() (watcher.NotifyWatcher, error) {
 	}
 
 	// Mark the machine as started and log it.
-	if err := m.SetStatus(status.StatusStarted, "", nil); err != nil {
+	if err := m.SetStatus(status.Started, "", nil); err != nil {
 		return nil, errors.Annotatef(err, "%s failed to set status started", mr.config.Tag)
 	}
 	logger.Infof("%q started", mr.config.Tag)
@@ -173,7 +173,7 @@ func (mr *Machiner) Handle(_ <-chan struct{}) error {
 		return nil
 	}
 	logger.Debugf("%q is now %s", mr.config.Tag, life)
-	if err := mr.machine.SetStatus(status.StatusStopped, "", nil); err != nil {
+	if err := mr.machine.SetStatus(status.Stopped, "", nil); err != nil {
 		return errors.Annotatef(err, "%s failed to set status stopped", mr.config.Tag)
 	}
 

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -131,7 +131,7 @@ func (s *MachinerSuite) TestMachinerSetStatusStopped(c *gc.C) {
 	)
 	s.accessor.machine.CheckCall(
 		c, 5, "SetStatus",
-		status.StatusStopped,
+		status.Stopped,
 		"",
 		map[string]interface{}(nil),
 	)
@@ -232,7 +232,7 @@ func (s *MachinerSuite) TestMachinerStorageAttached(c *gc.C) {
 	}, {
 		FuncName: "SetStatus",
 		Args: []interface{}{
-			status.StatusStarted,
+			status.Started,
 			"",
 			map[string]interface{}(nil),
 		},
@@ -245,7 +245,7 @@ func (s *MachinerSuite) TestMachinerStorageAttached(c *gc.C) {
 	}, {
 		FuncName: "SetStatus",
 		Args: []interface{}{
-			status.StatusStopped,
+			status.Stopped,
 			"",
 			map[string]interface{}(nil),
 		},
@@ -371,20 +371,20 @@ func (s *MachinerStateSuite) TestRunStop(c *gc.C) {
 func (s *MachinerStateSuite) TestStartSetsStatus(c *gc.C) {
 	statusInfo, err := s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusPending)
+	c.Assert(statusInfo.Status, gc.Equals, status.Pending)
 	c.Assert(statusInfo.Message, gc.Equals, "")
 
 	mr := s.makeMachiner(c, false, nil)
 	defer worker.Stop(mr)
 
-	s.waitMachineStatus(c, s.machine, status.StatusStarted)
+	s.waitMachineStatus(c, s.machine, status.Started)
 }
 
 func (s *MachinerStateSuite) TestSetsStatusWhenDying(c *gc.C) {
 	mr := s.makeMachiner(c, false, nil)
 	defer worker.Stop(mr)
 	c.Assert(s.machine.Destroy(), jc.ErrorIsNil)
-	s.waitMachineStatus(c, s.machine, status.StatusStopped)
+	s.waitMachineStatus(c, s.machine, status.Stopped)
 }
 
 func (s *MachinerStateSuite) TestSetDead(c *gc.C) {

--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -359,7 +359,7 @@ func (m *fakeMachine) APIHostPorts() []network.HostPort {
 
 func (m *fakeMachine) Status() (status.StatusInfo, error) {
 	return status.StatusInfo{
-		Status: status.StatusStarted,
+		Status: status.Started,
 	}, nil
 }
 

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -288,7 +288,7 @@ func (w *pgWorker) updateControllerMachines() (bool, error) {
 		if err != nil {
 			return false, errors.Annotatef(err, "cannot get status for machine %q", id)
 		}
-		if machineStatus.Status == status.StatusStarted {
+		if machineStatus.Status == status.Started {
 			logger.Debugf("machine %q has started, adding it to peergrouper list", id)
 			tracker, err := newMachineTracker(stm, w.machineChanges)
 			if err != nil {

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -203,7 +203,7 @@ func (task *provisionerTask) processMachinesWithTransientErrors() error {
 			continue
 		}
 		machine := machines[i]
-		if err := machine.SetStatus(status.StatusPending, "", nil); err != nil {
+		if err := machine.SetStatus(status.Pending, "", nil); err != nil {
 			logger.Errorf("cannot reset status of machine %q: %v", statusResult.Id, err)
 			continue
 		}
@@ -396,7 +396,7 @@ func classifyMachine(machine ClassifiableMachine) (
 			logger.Infof("cannot get machine id:%s, details:%v, err:%v", machine.Id(), machine, err)
 			return None, nil
 		}
-		if machineStatus == status.StatusPending {
+		if machineStatus == status.Pending {
 			logger.Infof("found machine pending provisioning id:%s, details:%v", machine.Id(), machine)
 			return Pending, nil
 		}
@@ -680,7 +680,7 @@ func (task *provisionerTask) startMachines(machines []*apiprovisioner.Machine) e
 
 func (task *provisionerTask) setErrorStatus(message string, machine *apiprovisioner.Machine, err error) error {
 	logger.Errorf(message, machine, err)
-	if err1 := machine.SetStatus(status.StatusError, err.Error(), nil); err1 != nil {
+	if err1 := machine.SetStatus(status.Error, err.Error(), nil); err1 != nil {
 		// Something is wrong with this machine, better report it back.
 		return errors.Annotatef(err1, "cannot set error status for machine %q", machine)
 	}
@@ -707,7 +707,7 @@ func (task *provisionerTask) startMachine(
 
 		logger.Warningf("%v", errors.Annotate(err, "starting instance"))
 		retryMsg := fmt.Sprintf("will retry to start instance in %v", task.retryStartInstanceStrategy.retryDelay)
-		if err2 := machine.SetStatus(status.StatusPending, retryMsg, nil); err2 != nil {
+		if err2 := machine.SetStatus(status.Pending, retryMsg, nil); err2 != nil {
 			logger.Errorf("%v", err2)
 		}
 		logger.Infof(retryMsg)

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -527,11 +527,11 @@ func (s *ProvisionerSuite) TestProvisionerSetsErrorStatusWhenNoToolsAreAvailable
 		// And check the machine status is set to error.
 		statusInfo, err := m.Status()
 		c.Assert(err, jc.ErrorIsNil)
-		if statusInfo.Status == status.StatusPending {
+		if statusInfo.Status == status.Pending {
 			time.Sleep(coretesting.ShortWait)
 			continue
 		}
-		c.Assert(statusInfo.Status, gc.Equals, status.StatusError)
+		c.Assert(statusInfo.Status, gc.Equals, status.Error)
 		c.Assert(statusInfo.Message, gc.Equals, "no matching tools available")
 		break
 	}
@@ -574,11 +574,11 @@ func (s *ProvisionerSuite) TestProvisionerFailedStartInstanceWithInjectedCreatio
 		// And check the machine status is set to error.
 		statusInfo, err := m.Status()
 		c.Assert(err, jc.ErrorIsNil)
-		if statusInfo.Status == status.StatusPending {
+		if statusInfo.Status == status.Pending {
 			time.Sleep(coretesting.ShortWait)
 			continue
 		}
-		c.Assert(statusInfo.Status, gc.Equals, status.StatusError)
+		c.Assert(statusInfo.Status, gc.Equals, status.Error)
 		// check that the status matches the error message
 		c.Assert(statusInfo.Message, gc.Equals, destroyError.Error())
 		return
@@ -635,7 +635,7 @@ func (s *ProvisionerSuite) TestProvisionerStopRetryingIfDying(c *gc.C) {
 	stop(c, p)
 	statusInfo, err := m.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusPending)
+	c.Assert(statusInfo.Status, gc.Equals, status.Pending)
 	s.checkNoOperations(c)
 }
 
@@ -744,23 +744,23 @@ type machineClassificationTest struct {
 var machineClassificationTests = []machineClassificationTest{{
 	description:    "Dead machine is dead",
 	life:           params.Dead,
-	status:         status.StatusStarted,
+	status:         status.Started,
 	classification: provisioner.Dead,
 }, {
 	description:    "Dying machine can carry on dying",
 	life:           params.Dying,
-	status:         status.StatusStarted,
+	status:         status.Started,
 	classification: provisioner.None,
 }, {
 	description:    "Dying unprovisioned machine is ensured dead",
 	life:           params.Dying,
-	status:         status.StatusStarted,
+	status:         status.Started,
 	classification: provisioner.Dead,
 	idErr:          params.CodeNotProvisioned,
 }, {
 	description:    "Can't load provisioned dying machine",
 	life:           params.Dying,
-	status:         status.StatusStarted,
+	status:         status.Started,
 	classification: provisioner.None,
 	idErr:          params.CodeNotFound,
 	expectErrCode:  params.CodeNotFound,
@@ -768,14 +768,14 @@ var machineClassificationTests = []machineClassificationTest{{
 }, {
 	description:    "Alive machine is not provisioned - pending",
 	life:           params.Alive,
-	status:         status.StatusPending,
+	status:         status.Pending,
 	classification: provisioner.Pending,
 	idErr:          params.CodeNotProvisioned,
 	expectErrFmt:   "found machine pending provisioning id:%s.*",
 }, {
 	description:    "Alive, pending machine not found",
 	life:           params.Alive,
-	status:         status.StatusPending,
+	status:         status.Pending,
 	classification: provisioner.None,
 	idErr:          params.CodeNotFound,
 	expectErrCode:  params.CodeNotFound,
@@ -789,7 +789,7 @@ var machineClassificationTests = []machineClassificationTest{{
 }, {
 	description:    "Dying machine fails to ensure dead",
 	life:           params.Dying,
-	status:         status.StatusStarted,
+	status:         status.Started,
 	classification: provisioner.None,
 	idErr:          params.CodeNotProvisioned,
 	expectErrCode:  params.CodeNotFound,
@@ -800,14 +800,14 @@ var machineClassificationTests = []machineClassificationTest{{
 var machineClassificationTestsRequireMaintenance = machineClassificationTest{
 	description:    "Machine needs maintaining",
 	life:           params.Alive,
-	status:         status.StatusStarted,
+	status:         status.Started,
 	classification: provisioner.Maintain,
 }
 
 var machineClassificationTestsNoMaintenance = machineClassificationTest{
 	description:    "Machine doesn't need maintaining",
 	life:           params.Alive,
-	status:         status.StatusStarted,
+	status:         status.Started,
 	classification: provisioner.None,
 }
 
@@ -911,11 +911,11 @@ func (s *ProvisionerSuite) testProvisioningFailsAndSetsErrorStatusForConstraints
 	for time.Since(t0) < coretesting.LongWait {
 		statusInfo, err := machine.Status()
 		c.Assert(err, jc.ErrorIsNil)
-		if statusInfo.Status == status.StatusPending {
+		if statusInfo.Status == status.Pending {
 			time.Sleep(coretesting.ShortWait)
 			continue
 		}
-		c.Assert(statusInfo.Status, gc.Equals, status.StatusError)
+		c.Assert(statusInfo.Status, gc.Equals, status.Error)
 		c.Assert(statusInfo.Message, gc.Equals, expectedErrorStatus)
 		break
 	}
@@ -1272,7 +1272,7 @@ func (s *ProvisionerSuite) TestProvisionerRetriesTransientErrors(c *gc.C) {
 			case <-time.After(coretesting.ShortWait):
 				now := time.Now()
 				sInfo := status.StatusInfo{
-					Status:  status.StatusError,
+					Status:  status.Error,
 					Message: "info",
 					Data:    map[string]interface{}{"transient": true},
 					Since:   &now,
@@ -1288,7 +1288,7 @@ func (s *ProvisionerSuite) TestProvisionerRetriesTransientErrors(c *gc.C) {
 	// Machine 4 is never provisioned.
 	statusInfo, err := m4.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.StatusError)
+	c.Assert(statusInfo.Status, gc.Equals, status.Error)
 	_, err = m4.InstanceId()
 	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
 }

--- a/worker/storageprovisioner/filesystem_ops.go
+++ b/worker/storageprovisioner/filesystem_ops.go
@@ -44,7 +44,7 @@ func createFilesystems(ctx *context, ops map[names.FilesystemTag]*createFilesyst
 			}
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    filesystemParams[i].Tag.String(),
-				Status: status.StatusError.String(),
+				Status: status.Error.String(),
 				Info:   err.Error(),
 			})
 			logger.Debugf(
@@ -63,7 +63,7 @@ func createFilesystems(ctx *context, ops map[names.FilesystemTag]*createFilesyst
 		for i, result := range results {
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    filesystemParams[i].Tag.String(),
-				Status: status.StatusAttaching.String(),
+				Status: status.Attaching.String(),
 			})
 			entityStatus := &statuses[len(statuses)-1]
 			if result.Error != nil {
@@ -74,7 +74,7 @@ func createFilesystems(ctx *context, ops map[names.FilesystemTag]*createFilesyst
 				// that we will retry. When we distinguish between
 				// transient and permanent errors, we will set the
 				// status to "error" for permanent errors.
-				entityStatus.Status = status.StatusPending.String()
+				entityStatus.Status = status.Pending.String()
 				entityStatus.Info = result.Error.Error()
 				logger.Debugf(
 					"failed to create %s: %v",
@@ -148,7 +148,7 @@ func attachFilesystems(ctx *context, ops map[params.MachineStorageId]*attachFile
 			p := filesystemAttachmentParams[i]
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    p.Filesystem.String(),
-				Status: status.StatusAttached.String(),
+				Status: status.Attached.String(),
 			})
 			entityStatus := &statuses[len(statuses)-1]
 			if result.Error != nil {
@@ -163,7 +163,7 @@ func attachFilesystems(ctx *context, ops map[params.MachineStorageId]*attachFile
 				// indicate that we will retry. When we distinguish
 				// between transient and permanent errors, we will
 				// set the status to "error" for permanent errors.
-				entityStatus.Status = status.StatusAttaching.String()
+				entityStatus.Status = status.Attaching.String()
 				entityStatus.Info = result.Error.Error()
 				logger.Debugf(
 					"failed to attach %s to %s: %v",
@@ -216,7 +216,7 @@ func destroyFilesystems(ctx *context, ops map[names.FilesystemTag]*destroyFilesy
 			}
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    filesystemParams[i].Tag.String(),
-				Status: status.StatusError.String(),
+				Status: status.Error.String(),
 				Info:   err.Error(),
 			})
 			logger.Debugf(
@@ -250,7 +250,7 @@ func destroyFilesystems(ctx *context, ops map[names.FilesystemTag]*destroyFilesy
 			reschedule = append(reschedule, ops[tag])
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    tag.String(),
-				Status: status.StatusDestroying.String(),
+				Status: status.Destroying.String(),
 				Info:   err.Error(),
 			})
 		}
@@ -297,7 +297,7 @@ func detachFilesystems(ctx *context, ops map[params.MachineStorageId]*detachFile
 				// attachment, we'll have to check if
 				// there are any other attachments
 				// before saying the status "detached".
-				Status: status.StatusDetached.String(),
+				Status: status.Detached.String(),
 			})
 			id := params.MachineStorageId{
 				MachineTag:    p.Machine.String(),
@@ -306,7 +306,7 @@ func detachFilesystems(ctx *context, ops map[params.MachineStorageId]*detachFile
 			entityStatus := &statuses[len(statuses)-1]
 			if err != nil {
 				reschedule = append(reschedule, ops[id])
-				entityStatus.Status = status.StatusDetaching.String()
+				entityStatus.Status = status.Detaching.String()
 				entityStatus.Info = err.Error()
 				logger.Debugf(
 					"failed to detach %s from %s: %v",

--- a/worker/storageprovisioner/volume_ops.go
+++ b/worker/storageprovisioner/volume_ops.go
@@ -38,7 +38,7 @@ func createVolumes(ctx *context, ops map[names.VolumeTag]*createVolumeOp) error 
 			}
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    volumeParams[i].Tag.String(),
-				Status: status.StatusError.String(),
+				Status: status.Error.String(),
 				Info:   err.Error(),
 			})
 			logger.Debugf(
@@ -57,7 +57,7 @@ func createVolumes(ctx *context, ops map[names.VolumeTag]*createVolumeOp) error 
 		for i, result := range results {
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    volumeParams[i].Tag.String(),
-				Status: status.StatusAttaching.String(),
+				Status: status.Attaching.String(),
 			})
 			entityStatus := &statuses[len(statuses)-1]
 			if result.Error != nil {
@@ -68,7 +68,7 @@ func createVolumes(ctx *context, ops map[names.VolumeTag]*createVolumeOp) error 
 				// that we will retry. When we distinguish between
 				// transient and permanent errors, we will set the
 				// status to "error" for permanent errors.
-				entityStatus.Status = status.StatusPending.String()
+				entityStatus.Status = status.Pending.String()
 				entityStatus.Info = result.Error.Error()
 				logger.Debugf(
 					"failed to create %s: %v",
@@ -79,7 +79,7 @@ func createVolumes(ctx *context, ops map[names.VolumeTag]*createVolumeOp) error 
 			}
 			volumes = append(volumes, *result.Volume)
 			if result.VolumeAttachment != nil {
-				entityStatus.Status = status.StatusAttached.String()
+				entityStatus.Status = status.Attached.String()
 				volumeAttachments = append(volumeAttachments, *result.VolumeAttachment)
 			}
 		}
@@ -147,7 +147,7 @@ func attachVolumes(ctx *context, ops map[params.MachineStorageId]*attachVolumeOp
 			p := volumeAttachmentParams[i]
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    p.Volume.String(),
-				Status: status.StatusAttached.String(),
+				Status: status.Attached.String(),
 			})
 			entityStatus := &statuses[len(statuses)-1]
 			if result.Error != nil {
@@ -162,7 +162,7 @@ func attachVolumes(ctx *context, ops map[params.MachineStorageId]*attachVolumeOp
 				// indicate that we will retry. When we distinguish
 				// between transient and permanent errors, we will
 				// set the status to "error" for permanent errors.
-				entityStatus.Status = status.StatusAttaching.String()
+				entityStatus.Status = status.Attaching.String()
 				entityStatus.Info = result.Error.Error()
 				logger.Debugf(
 					"failed to attach %s to %s: %v",
@@ -212,7 +212,7 @@ func destroyVolumes(ctx *context, ops map[names.VolumeTag]*destroyVolumeOp) erro
 			}
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    volumeParams[i].Tag.String(),
-				Status: status.StatusError.String(),
+				Status: status.Error.String(),
 				Info:   err.Error(),
 			})
 			logger.Debugf(
@@ -246,7 +246,7 @@ func destroyVolumes(ctx *context, ops map[names.VolumeTag]*destroyVolumeOp) erro
 			reschedule = append(reschedule, ops[tag])
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    tag.String(),
-				Status: status.StatusDestroying.String(),
+				Status: status.Destroying.String(),
 				Info:   err.Error(),
 			})
 		}
@@ -289,7 +289,7 @@ func detachVolumes(ctx *context, ops map[params.MachineStorageId]*detachVolumeOp
 				// attachment, we'll have to check if
 				// there are any other attachments
 				// before saying the status "detached".
-				Status: status.StatusDetached.String(),
+				Status: status.Detached.String(),
 			})
 			id := params.MachineStorageId{
 				MachineTag:    p.Machine.String(),
@@ -298,7 +298,7 @@ func detachVolumes(ctx *context, ops map[params.MachineStorageId]*detachVolumeOp
 			entityStatus := &statuses[len(statuses)-1]
 			if err != nil {
 				reschedule = append(reschedule, ops[id])
-				entityStatus.Status = status.StatusDetaching.String()
+				entityStatus.Status = status.Detaching.String()
 				entityStatus.Info = err.Error()
 				logger.Debugf(
 					"failed to detach %s from %s: %v",

--- a/worker/undertaker/undertaker.go
+++ b/worker/undertaker/undertaker.go
@@ -97,7 +97,7 @@ func (u *Undertaker) run() error {
 		// checking the emptiness criteria before
 		// attempting to remove the model.
 		if err := u.setStatus(
-			status.StatusDestroying,
+			status.Destroying,
 			"cleaning up cloud resources",
 		); err != nil {
 			return errors.Trace(err)
@@ -125,7 +125,7 @@ func (u *Undertaker) run() error {
 	// Now the model is known to be hosted and dead, we can tidy up any
 	// provider resources it might have used.
 	if err := u.setStatus(
-		status.StatusDestroying, "tearing down cloud environment",
+		status.Destroying, "tearing down cloud environment",
 	); err != nil {
 		return errors.Trace(err)
 	}

--- a/worker/undertaker/undertaker_test.go
+++ b/worker/undertaker/undertaker_test.go
@@ -72,11 +72,11 @@ func (s *UndertakerSuite) TestSetStatusDestroying(c *gc.C) {
 		workertest.CheckKilled(c, w)
 	})
 	stub.CheckCall(
-		c, 1, "SetStatus", status.StatusDestroying,
+		c, 1, "SetStatus", status.Destroying,
 		"cleaning up cloud resources", map[string]interface{}(nil),
 	)
 	stub.CheckCall(
-		c, 4, "SetStatus", status.StatusDestroying,
+		c, 4, "SetStatus", status.Destroying,
 		"tearing down cloud environment", map[string]interface{}(nil),
 	)
 }

--- a/worker/unitassigner/unitassigner.go
+++ b/worker/unitassigner/unitassigner.go
@@ -77,7 +77,7 @@ func (u unitAssignerHandler) Handle(_ <-chan struct{}, ids []string) error {
 		for unit, err := range failures {
 			args.Entities[x] = params.EntityStatusArgs{
 				Tag:    unit,
-				Status: status.StatusError.String(),
+				Status: status.Error.String(),
 				Info:   err.Error(),
 			}
 			x++

--- a/worker/unitassigner/unitassigner_test.go
+++ b/worker/unitassigner/unitassigner_test.go
@@ -63,7 +63,7 @@ func (testsuite) TestHandleError(c *gc.C) {
 	c.Assert(entities, gc.HasLen, 1)
 	c.Assert(entities[0], gc.DeepEquals, params.EntityStatusArgs{
 		Tag:    "unit-foo-0",
-		Status: status.StatusError.String(),
+		Status: status.Error.String(),
 		Info:   e.Error(),
 	})
 }

--- a/worker/uniter/agent.go
+++ b/worker/uniter/agent.go
@@ -25,7 +25,7 @@ func reportAgentError(u *Uniter, userMessage string, err error) {
 	if err == nil {
 		return
 	}
-	err2 := setAgentStatus(u, status.StatusFailed, userMessage, nil)
+	err2 := setAgentStatus(u, status.Failed, userMessage, nil)
 	if err2 != nil {
 		logger.Errorf("updating agent status: %v", err2)
 	}

--- a/worker/uniter/op_callbacks.go
+++ b/worker/uniter/op_callbacks.go
@@ -120,5 +120,5 @@ func (opc *operationCallbacks) SetCurrentCharm(charmURL *corecharm.URL) error {
 
 // SetExecutingStatus is part of the operation.Callbacks interface.
 func (opc *operationCallbacks) SetExecutingStatus(message string) error {
-	return setAgentStatus(opc.u, status.StatusExecuting, message, nil)
+	return setAgentStatus(opc.u, status.Executing, message, nil)
 }

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -134,12 +134,12 @@ func (rh *runHook) beforeHook() error {
 	switch rh.info.Kind {
 	case hooks.Install:
 		err = rh.runner.Context().SetUnitStatus(jujuc.StatusInfo{
-			Status: string(status.StatusMaintenance),
+			Status: string(status.Maintenance),
 			Info:   "installing charm software",
 		})
 	case hooks.Stop:
 		err = rh.runner.Context().SetUnitStatus(jujuc.StatusInfo{
-			Status: string(status.StatusMaintenance),
+			Status: string(status.Maintenance),
 			Info:   "cleaning up prior to charm deletion",
 		})
 	}
@@ -161,7 +161,7 @@ func (rh *runHook) afterHook(state State) (bool, error) {
 	case hooks.Stop:
 		// Charm is no longer of this world.
 		err = rh.runner.Context().SetUnitStatus(jujuc.StatusInfo{
-			Status: string(status.StatusTerminated),
+			Status: string(status.Terminated),
 		})
 	case hooks.Start:
 		if hasRunStatusSet {
@@ -171,7 +171,7 @@ func (rh *runHook) afterHook(state State) (bool, error) {
 		// We've finished the start hook and the charm has not updated its
 		// own status so we'll set it to unknown.
 		err = rh.runner.Context().SetUnitStatus(jujuc.StatusInfo{
-			Status: string(status.StatusUnknown),
+			Status: string(status.Unknown),
 		})
 	}
 	if err != nil {

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -616,7 +616,7 @@ func (ctx *HookContext) handleReboot(err *error) {
 	case jujuc.RebootNow:
 		*err = ErrRequeueAndReboot
 	}
-	err2 := ctx.unit.SetUnitStatus(status.StatusRebooting, "", nil)
+	err2 := ctx.unit.SetUnitStatus(status.Rebooting, "", nil)
 	if err2 != nil {
 		logger.Errorf("updating agent status: %v", err2)
 	}

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -160,7 +160,7 @@ func (s *InterfaceSuite) TestUnitStatusCaching(c *gc.C) {
 	// Change remote state.
 	now := time.Now()
 	sInfo := status.StatusInfo{
-		Status:  status.StatusActive,
+		Status:  status.Active,
 		Message: "it works",
 		Since:   &now,
 	}

--- a/worker/uniter/runner/jujuc/status-get.go
+++ b/worker/uniter/runner/jujuc/status-get.go
@@ -79,7 +79,7 @@ func (c *StatusGetCommand) ApplicationStatus(ctx *cmd.Context) error {
 	serviceStatus, err := c.ctx.ApplicationStatus()
 	if err != nil {
 		if errors.IsNotImplemented(err) {
-			return c.out.Write(ctx, status.StatusUnknown)
+			return c.out.Write(ctx, status.Unknown)
 		}
 		return errors.Annotatef(err, "finding service status")
 	}
@@ -111,7 +111,7 @@ func (c *StatusGetCommand) unitOrServiceStatus(ctx *cmd.Context) error {
 	unitStatus, err := c.ctx.UnitStatus()
 	if err != nil {
 		if errors.IsNotImplemented(err) {
-			return c.out.Write(ctx, status.StatusUnknown)
+			return c.out.Write(ctx, status.Unknown)
 		}
 		return errors.Annotatef(err, "finding workload status")
 	}

--- a/worker/uniter/runner/jujuc/status-set.go
+++ b/worker/uniter/runner/jujuc/status-set.go
@@ -40,10 +40,10 @@ status and message are the same as what's already set.
 }
 
 var validStatus = []status.Status{
-	status.StatusMaintenance,
-	status.StatusBlocked,
-	status.StatusWaiting,
-	status.StatusActive,
+	status.Maintenance,
+	status.Blocked,
+	status.Waiting,
+	status.Active,
 }
 
 func (c *StatusSetCommand) SetFlags(f *gnuflag.FlagSet) {

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -256,7 +256,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 			// error state.
 			return nil
 		}
-		return setAgentStatus(u, status.StatusIdle, "", nil)
+		return setAgentStatus(u, status.Idle, "", nil)
 	}
 
 	clearResolved := func() error {
@@ -335,7 +335,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 				// handling is outside of the resolver's control.
 				if operation.IsDeployConflictError(cause) {
 					localState.Conflicted = true
-					err = setAgentStatus(u, status.StatusError, "upgrade failed", nil)
+					err = setAgentStatus(u, status.Error, "upgrade failed", nil)
 				} else {
 					reportAgentError(u, "resolver loop error", err)
 				}
@@ -547,5 +547,5 @@ func (u *Uniter) reportHookError(hookInfo hook.Info) error {
 	}
 	statusData["hook"] = hookName
 	statusMessage := fmt.Sprintf("hook failed: %q", hookName)
-	return setAgentStatus(u, status.StatusError, statusMessage, statusData)
+	return setAgentStatus(u, status.Error, statusMessage, statusData)
 }

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -195,11 +195,11 @@ func (s *UniterSuite) TestUniterInstallHook(c *gc.C) {
 
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 			waitHooks{"leader-elected", "config-changed", "start"},
 		), ut(
@@ -210,7 +210,7 @@ func (s *UniterSuite) TestUniterInstallHook(c *gc.C) {
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         `hook failed: "install"`,
 				data: map[string]interface{}{
 					"hook": "install",
@@ -222,7 +222,7 @@ func (s *UniterSuite) TestUniterInstallHook(c *gc.C) {
 
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 		),
@@ -237,7 +237,7 @@ func (s *UniterSuite) TestUniterUpdateStatusHook(c *gc.C) {
 			serveCharm{},
 			createUniter{},
 			waitHooks(startupHooks(false)),
-			waitUnitAgent{status: status.StatusIdle},
+			waitUnitAgent{status: status.Idle},
 			updateStatusHookTick{},
 			waitHooks{"update-status"},
 		),
@@ -256,7 +256,7 @@ func (s *UniterSuite) TestNoUniterUpdateStatusHookInError(c *gc.C) {
 			// Resolve and hook should run.
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 			},
 			waitHooks{},
 			updateStatusHookTick{},
@@ -274,11 +274,11 @@ func (s *UniterSuite) TestUniterStartHook(c *gc.C) {
 
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusMaintenance,
+				status:       status.Maintenance,
 				info:         "installing charm software",
 			},
 			waitHooks{"config-changed"},
@@ -291,7 +291,7 @@ func (s *UniterSuite) TestUniterStartHook(c *gc.C) {
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         `hook failed: "start"`,
 				data: map[string]interface{}{
 					"hook": "start",
@@ -303,7 +303,7 @@ func (s *UniterSuite) TestUniterStartHook(c *gc.C) {
 			fixHook{"start"},
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 			},
 			waitHooks{"start", "config-changed"},
 			verifyRunning{},
@@ -320,7 +320,7 @@ func (s *UniterSuite) TestUniterMultipleErrors(c *gc.C) {
 			createUniter{},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         `hook failed: "install"`,
 				data: map[string]interface{}{
 					"hook": "install",
@@ -329,7 +329,7 @@ func (s *UniterSuite) TestUniterMultipleErrors(c *gc.C) {
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         `hook failed: "leader-elected"`,
 				data: map[string]interface{}{
 					"hook": "leader-elected",
@@ -338,7 +338,7 @@ func (s *UniterSuite) TestUniterMultipleErrors(c *gc.C) {
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         `hook failed: "config-changed"`,
 				data: map[string]interface{}{
 					"hook": "config-changed",
@@ -347,7 +347,7 @@ func (s *UniterSuite) TestUniterMultipleErrors(c *gc.C) {
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         `hook failed: "start"`,
 				data: map[string]interface{}{
 					"hook": "start",
@@ -370,11 +370,11 @@ func (s *UniterSuite) TestUniterConfigChangedHook(c *gc.C) {
 			fixHook{"config-changed"},
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 			// TODO(axw) confirm with fwereade that this is correct.
 			// Previously we would see "start", "config-changed".
@@ -394,7 +394,7 @@ func (s *UniterSuite) TestUniterConfigChangedHook(c *gc.C) {
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         `hook failed: "config-changed"`,
 				data: map[string]interface{}{
 					"hook": "config-changed",
@@ -406,7 +406,7 @@ func (s *UniterSuite) TestUniterConfigChangedHook(c *gc.C) {
 			fixHook{"config-changed"},
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 			},
 			waitHooks{"config-changed", "start"},
 			verifyRunning{},
@@ -420,7 +420,7 @@ func (s *UniterSuite) TestUniterConfigChangedHook(c *gc.C) {
 			serveCharm{},
 			createUniter{},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			assertYaml{"charm/config.out", map[string]interface{}{
@@ -459,7 +459,7 @@ func (s *UniterSuite) TestUniterHookSynchronisation(c *gc.C) {
 			waitAddresses{},
 			waitHooks{},
 			lock.release(),
-			waitUnitAgent{status: status.StatusIdle},
+			waitUnitAgent{status: status.Idle},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 		),
 	})
@@ -508,12 +508,12 @@ func (s *UniterSuite) TestUniterSteadyStateUpgrade(c *gc.C) {
 			createCharm{revision: 1},
 			upgradeCharm{revision: 1},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 				charm:  1,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 				charm:        1,
 			},
 			waitHooks{"upgrade-charm", "config-changed"},
@@ -531,12 +531,12 @@ func (s *UniterSuite) TestUniterSteadyStateUpgradeForce(c *gc.C) {
 			createCharm{revision: 1},
 			upgradeCharm{revision: 1, forced: true},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 				charm:  1,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 				charm:        1,
 			},
 			waitHooks{"upgrade-charm", "config-changed"},
@@ -555,7 +555,7 @@ func (s *UniterSuite) TestUniterSteadyStateUpgradeResolve(c *gc.C) {
 			upgradeCharm{revision: 1},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         `hook failed: "upgrade-charm"`,
 				data: map[string]interface{}{
 					"hook": "upgrade-charm",
@@ -568,12 +568,12 @@ func (s *UniterSuite) TestUniterSteadyStateUpgradeResolve(c *gc.C) {
 
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 				charm:  1,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 				charm:        1,
 			},
 			waitHooks{"config-changed"},
@@ -591,7 +591,7 @@ func (s *UniterSuite) TestUniterSteadyStateUpgradeRetry(c *gc.C) {
 			upgradeCharm{revision: 1},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         `hook failed: "upgrade-charm"`,
 				data: map[string]interface{}{
 					"hook": "upgrade-charm",
@@ -605,7 +605,7 @@ func (s *UniterSuite) TestUniterSteadyStateUpgradeRetry(c *gc.C) {
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         `hook failed: "upgrade-charm"`,
 				data: map[string]interface{}{
 					"hook": "upgrade-charm",
@@ -618,7 +618,7 @@ func (s *UniterSuite) TestUniterSteadyStateUpgradeRetry(c *gc.C) {
 			fixHook{"upgrade-charm"},
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 				charm:  1,
 			},
 			waitHooks{"upgrade-charm", "config-changed"},
@@ -683,7 +683,7 @@ resources:
 			createCharm{customize: appendResource},
 			serveCharm{},
 			createUniter{},
-			waitUnitAgent{status: status.StatusIdle},
+			waitUnitAgent{status: status.Idle},
 			waitHooks(startupHooks(false)),
 			verifyCharm{},
 
@@ -717,11 +717,11 @@ func (s *UniterSuite) TestUniterUpgradeOverwrite(c *gc.C) {
 			serveCharm{},
 			createUniter{},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 
@@ -734,12 +734,12 @@ func (s *UniterSuite) TestUniterUpgradeOverwrite(c *gc.C) {
 			serveCharm{},
 			upgradeCharm{revision: 1},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 				charm:  1,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 				charm:        1,
 			},
 			waitHooks{"upgrade-charm", "config-changed"},
@@ -799,7 +799,7 @@ func (s *UniterSuite) TestUniterErrorStateUnforcedUpgrade(c *gc.C) {
 			upgradeCharm{revision: 1},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         `hook failed: "start"`,
 				data: map[string]interface{}{
 					"hook": "start",
@@ -811,12 +811,12 @@ func (s *UniterSuite) TestUniterErrorStateUnforcedUpgrade(c *gc.C) {
 
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 				charm:  1,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusMaintenance,
+				status:       status.Maintenance,
 				info:         "installing charm software",
 				charm:        1,
 			},
@@ -840,7 +840,7 @@ func (s *UniterSuite) TestUniterErrorStateForcedUpgrade(c *gc.C) {
 			// useful to wait until that point...
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         `hook failed: "start"`,
 				data: map[string]interface{}{
 					"hook": "start",
@@ -856,7 +856,7 @@ func (s *UniterSuite) TestUniterErrorStateForcedUpgrade(c *gc.C) {
 
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 				charm:  1,
 			},
 			waitHooks{"config-changed"},
@@ -882,12 +882,12 @@ func (s *UniterSuite) TestUniterUpgradeConflicts(c *gc.C) {
 			resolveError{state.ResolvedNoHooks},
 			waitHooks{"upgrade-charm", "config-changed"},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 				charm:  1,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 				charm:        1,
 			},
 			verifyCharm{revision: 1},
@@ -902,12 +902,12 @@ func (s *UniterSuite) TestUniterUpgradeConflicts(c *gc.C) {
 			upgradeCharm{revision: 2, forced: true},
 			waitHooks{"upgrade-charm", "config-changed"},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 				charm:  2,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 				charm:        2,
 			},
 			verifyCharm{revision: 2},
@@ -1048,11 +1048,11 @@ func (s *UniterSuite) TestUniterRelations(c *gc.C) {
 			serveCharm{},
 			createUniter{},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			addRelation{waitJoin: true},
@@ -1089,7 +1089,7 @@ func (s *UniterSuite) TestUniterRelationErrors(c *gc.C) {
 			startupRelationError{"db-relation-joined"},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         `hook failed: "db-relation-joined"`,
 				data: map[string]interface{}{
 					"hook":        "db-relation-joined",
@@ -1102,7 +1102,7 @@ func (s *UniterSuite) TestUniterRelationErrors(c *gc.C) {
 			startupRelationError{"db-relation-changed"},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         `hook failed: "db-relation-changed"`,
 				data: map[string]interface{}{
 					"hook":        "db-relation-changed",
@@ -1117,7 +1117,7 @@ func (s *UniterSuite) TestUniterRelationErrors(c *gc.C) {
 			removeRelationUnit{"mysql/0"},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         `hook failed: "db-relation-departed"`,
 				data: map[string]interface{}{
 					"hook":        "db-relation-departed",
@@ -1133,7 +1133,7 @@ func (s *UniterSuite) TestUniterRelationErrors(c *gc.C) {
 			relationDying,
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         `hook failed: "db-relation-broken"`,
 				data: map[string]interface{}{
 					"hook":        "db-relation-broken",
@@ -1159,10 +1159,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			createServiceAndUnit{},
 			startUniter{},
 			waitAddresses{},
-			waitUnitAgent{status: status.StatusIdle},
+			waitUnitAgent{status: status.Idle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
@@ -1172,10 +1172,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				results: map[string]interface{}{},
 				status:  params.ActionCompleted,
 			}}},
-			waitUnitAgent{status: status.StatusIdle},
+			waitUnitAgent{status: status.Idle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 		), ut(
 			"action-fail causes the action to fail with a message",
@@ -1190,10 +1190,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			createServiceAndUnit{},
 			startUniter{},
 			waitAddresses{},
-			waitUnitAgent{status: status.StatusIdle},
+			waitUnitAgent{status: status.Idle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
@@ -1206,9 +1206,9 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				message: "I'm afraid I can't let you do that, Dave.",
 				status:  params.ActionFailed,
 			}}},
-			waitUnitAgent{status: status.StatusIdle}, waitUnitAgent{
+			waitUnitAgent{status: status.Idle}, waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 		), ut(
 			"action-fail with the wrong arguments fails but is not an error",
@@ -1223,10 +1223,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			createServiceAndUnit{},
 			startUniter{},
 			waitAddresses{},
-			waitUnitAgent{status: status.StatusIdle},
+			waitUnitAgent{status: status.Idle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
@@ -1239,10 +1239,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				message: "A real message",
 				status:  params.ActionFailed,
 			}}},
-			waitUnitAgent{status: status.StatusIdle},
+			waitUnitAgent{status: status.Idle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 		), ut(
 			"actions with correct params passed are not an error",
@@ -1257,10 +1257,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			createServiceAndUnit{},
 			startUniter{},
 			waitAddresses{},
-			waitUnitAgent{status: status.StatusIdle},
+			waitUnitAgent{status: status.Idle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
@@ -1282,10 +1282,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				},
 				status: params.ActionCompleted,
 			}}},
-			waitUnitAgent{status: status.StatusIdle},
+			waitUnitAgent{status: status.Idle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 		), ut(
 			"actions with incorrect params passed are not an error but fail",
@@ -1300,10 +1300,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			createServiceAndUnit{},
 			startUniter{},
 			waitAddresses{},
-			waitUnitAgent{status: status.StatusIdle},
+			waitUnitAgent{status: status.Idle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
@@ -1317,10 +1317,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				status:  params.ActionFailed,
 				message: `cannot run "snapshot" action: validation failed: (root).outfile : must be of type string, given 2`,
 			}}},
-			waitUnitAgent{status: status.StatusIdle},
+			waitUnitAgent{status: status.Idle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 		), ut(
 			"actions not defined in actions.yaml fail without causing a uniter error",
@@ -1334,10 +1334,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			createServiceAndUnit{},
 			startUniter{},
 			waitAddresses{},
-			waitUnitAgent{status: status.StatusIdle},
+			waitUnitAgent{status: status.Idle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
@@ -1348,10 +1348,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				status:  params.ActionFailed,
 				message: `cannot run "snapshot" action: not defined`,
 			}}},
-			waitUnitAgent{status: status.StatusIdle},
+			waitUnitAgent{status: status.Idle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 		), ut(
 			"pending actions get consumed",
@@ -1369,10 +1369,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			addAction{"action-log", nil},
 			startUniter{},
 			waitAddresses{},
-			waitUnitAgent{status: status.StatusIdle},
+			waitUnitAgent{status: status.Idle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
@@ -1389,10 +1389,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				results: map[string]interface{}{},
 				status:  params.ActionCompleted,
 			}}},
-			waitUnitAgent{status: status.StatusIdle},
+			waitUnitAgent{status: status.Idle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 		), ut(
 			"actions not implemented fail but are not errors",
@@ -1406,10 +1406,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			createServiceAndUnit{},
 			startUniter{},
 			waitAddresses{},
-			waitUnitAgent{status: status.StatusIdle},
+			waitUnitAgent{status: status.Idle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
@@ -1420,10 +1420,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				status:  params.ActionFailed,
 				message: `action not implemented on unit "u/0"`,
 			}}},
-			waitUnitAgent{status: status.StatusIdle},
+			waitUnitAgent{status: status.Idle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 		), ut(
 			"actions may run from ModeHookError, but do not clear the error",
@@ -1437,7 +1437,7 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			addAction{"action-log", nil},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         `hook failed: "start"`,
 				data: map[string]interface{}{
 					"hook": "start",
@@ -1450,16 +1450,16 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			}}},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         `hook failed: "start"`,
 				data:         map[string]interface{}{"hook": "start"},
 			},
 			verifyWaiting{},
 			resolveError{state.ResolvedNoHooks},
-			waitUnitAgent{status: status.StatusIdle},
+			waitUnitAgent{status: status.Idle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusMaintenance,
+				status:       status.Maintenance,
 				info:         "installing charm software",
 			},
 		),
@@ -1566,11 +1566,11 @@ func (s *UniterSuite) TestRebootDisabledInActions(c *gc.C) {
 			startUniter{},
 			waitAddresses{},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 			waitActionResults{[]actionResult{{
 				name: "action-reboot",
@@ -1602,11 +1602,11 @@ func (s *UniterSuite) TestRebootFinishesHook(c *gc.C) {
 			waitHooks{"install"},
 			startUniter{},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 			waitHooks{"leader-elected", "config-changed", "start"},
 		)})
@@ -1631,11 +1631,11 @@ func (s *UniterSuite) TestRebootNowKillsHook(c *gc.C) {
 			waitHooks{"install"},
 			startUniter{},
 			waitUnitAgent{
-				status: status.StatusIdle,
+				status: status.Idle,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusUnknown,
+				status:       status.Unknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 		)})
@@ -1658,7 +1658,7 @@ func (s *UniterSuite) TestRebootDisabledOnHookError(c *gc.C) {
 			waitAddresses{},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         fmt.Sprintf(`hook failed: "install"`),
 			},
 		),
@@ -1674,7 +1674,7 @@ func (s *UniterSuite) TestJujuRunExecutionSerialized(c *gc.C) {
 			createUniter{},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         `hook failed: "config-changed"`,
 				data: map[string]interface{}{
 					"hook": "config-changed",
@@ -1683,7 +1683,7 @@ func (s *UniterSuite) TestJujuRunExecutionSerialized(c *gc.C) {
 			runCommands{"exit 0"},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       status.StatusError,
+				status:       status.Error,
 				info:         `hook failed: "config-changed"`,
 				data: map[string]interface{}{
 					"hook": "config-changed",
@@ -1898,7 +1898,7 @@ func (s *UniterSuite) TestOperationErrorReported(c *gc.C) {
 			serveCharm{},
 			createUniter{executorFunc: executorFunc},
 			waitUnitAgent{
-				status: status.StatusFailed,
+				status: status.Failed,
 				info:   "resolver loop error",
 			},
 			expectError{".*some error occurred.*"},

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -613,7 +613,7 @@ func (s startupErrorWithCustomCharm) step(c *gc.C, ctx *context) {
 	step(c, ctx, createUniter{})
 	step(c, ctx, waitUnitAgent{
 		statusGetter: unitStatusGetter,
-		status:       status.StatusError,
+		status:       status.Error,
 		info:         fmt.Sprintf(`hook failed: %q`, s.badHook),
 	})
 	for _, hook := range startupHooks(false) {
@@ -636,7 +636,7 @@ func (s startupError) step(c *gc.C, ctx *context) {
 	step(c, ctx, createUniter{})
 	step(c, ctx, waitUnitAgent{
 		statusGetter: unitStatusGetter,
-		status:       status.StatusError,
+		status:       status.Error,
 		info:         fmt.Sprintf(`hook failed: %q`, s.badHook),
 	})
 	for _, hook := range startupHooks(false) {
@@ -657,7 +657,7 @@ func (s quickStart) step(c *gc.C, ctx *context) {
 	step(c, ctx, createCharm{})
 	step(c, ctx, serveCharm{})
 	step(c, ctx, createUniter{minion: s.minion})
-	step(c, ctx, waitUnitAgent{status: status.StatusIdle})
+	step(c, ctx, waitUnitAgent{status: status.Idle})
 	step(c, ctx, waitHooks(startupHooks(s.minion)))
 	step(c, ctx, verifyCharm{})
 }
@@ -680,7 +680,7 @@ func (s startupRelationError) step(c *gc.C, ctx *context) {
 	step(c, ctx, createCharm{badHooks: []string{s.badHook}})
 	step(c, ctx, serveCharm{})
 	step(c, ctx, createUniter{})
-	step(c, ctx, waitUnitAgent{status: status.StatusIdle})
+	step(c, ctx, waitUnitAgent{status: status.Idle})
 	step(c, ctx, waitHooks(startupHooks(false)))
 	step(c, ctx, verifyCharm{})
 	step(c, ctx, addRelation{})
@@ -1017,7 +1017,7 @@ func (s startUpgradeError) step(c *gc.C, ctx *context) {
 		serveCharm{},
 		createUniter{},
 		waitUnitAgent{
-			status: status.StatusIdle,
+			status: status.Idle,
 		},
 		waitHooks(startupHooks(false)),
 		verifyCharm{},
@@ -1027,7 +1027,7 @@ func (s startUpgradeError) step(c *gc.C, ctx *context) {
 		upgradeCharm{revision: 1},
 		waitUnitAgent{
 			statusGetter: unitStatusGetter,
-			status:       status.StatusError,
+			status:       status.Error,
 			info:         "upgrade failed",
 			charm:        1,
 		},
@@ -1047,7 +1047,7 @@ func (s verifyWaitingUpgradeError) step(c *gc.C, ctx *context) {
 	verifyCharmSteps := []stepper{
 		waitUnitAgent{
 			statusGetter: unitStatusGetter,
-			status:       status.StatusError,
+			status:       status.Error,
 			info:         "upgrade failed",
 			charm:        s.revision,
 		},
@@ -1062,7 +1062,7 @@ func (s verifyWaitingUpgradeError) step(c *gc.C, ctx *context) {
 			// upgrade; and thus puts us in an unexpected state for future steps.
 			now := time.Now()
 			sInfo := status.StatusInfo{
-				Status:  status.StatusIdle,
+				Status:  status.Idle,
 				Message: "",
 				Since:   &now,
 			}

--- a/worker/upgradesteps/worker.go
+++ b/worker/upgradesteps/worker.go
@@ -223,7 +223,7 @@ func (w *upgradesteps) run() error {
 	} else {
 		// Upgrade succeeded - signal that the upgrade is complete.
 		logger.Infof("upgrade to %v completed successfully.", w.toVersion)
-		w.machine.SetStatus(status.StatusStarted, "", nil)
+		w.machine.SetStatus(status.Started, "", nil)
 		w.upgradeComplete.Unlock()
 	}
 	return nil
@@ -343,7 +343,7 @@ func (w *upgradesteps) waitForOtherControllers(info *state.UpgradeInfo) error {
 // designed to be called via a machine agent's ChangeConfig method.
 func (w *upgradesteps) runUpgradeSteps(agentConfig agent.ConfigSetter) error {
 	var upgradeErr error
-	w.machine.SetStatus(status.StatusStarted, fmt.Sprintf("upgrading to %v", w.toVersion), nil)
+	w.machine.SetStatus(status.Started, fmt.Sprintf("upgrading to %v", w.toVersion), nil)
 
 	context := upgrades.NewContext(agentConfig, w.apiConn, w.st)
 	logger.Infof("starting upgrade from %v to %v for %q", w.fromVersion, w.toVersion, w.tag)
@@ -377,7 +377,7 @@ func (w *upgradesteps) reportUpgradeFailure(err error, willRetry bool) {
 	}
 	logger.Errorf("upgrade from %v to %v for %q failed (%s): %v",
 		w.fromVersion, w.toVersion, w.tag, retryText, err)
-	w.machine.SetStatus(status.StatusError,
+	w.machine.SetStatus(status.Error,
 		fmt.Sprintf("upgrade to %v failed (%s): %v", w.toVersion, retryText, err), nil)
 }
 

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -292,7 +292,7 @@ func (s *UpgradeSuite) TestAbortWhenOtherControllerDoesntStartUpgrade(c *gc.C) {
 			"aborted wait for other controllers:" + causeMsg},
 	})
 	c.Assert(statusCalls, jc.DeepEquals, []StatusCall{{
-		status.StatusError,
+		status.Error,
 		fmt.Sprintf(
 			"upgrade to %s failed (giving up): aborted wait for other controllers:"+causeMsg,
 			jujuversion.Current),
@@ -389,7 +389,7 @@ func (s *UpgradeSuite) TestPreUpgradeFail(c *gc.C) {
 	statusMessage := fmt.Sprintf(
 		`upgrade to %s failed (giving up): %s`, jujuversion.Current, causeMessage)
 	c.Assert(statusCalls, jc.DeepEquals, []StatusCall{{
-		status.StatusError, statusMessage,
+		status.Error, statusMessage,
 	}})
 }
 
@@ -502,22 +502,22 @@ func (s *UpgradeSuite) setInstantRetryStrategy(c *gc.C) {
 
 func (s *UpgradeSuite) makeExpectedStatusCalls(retryCount int, expectFail bool, failReason string) []StatusCall {
 	calls := []StatusCall{{
-		status.StatusStarted,
+		status.Started,
 		fmt.Sprintf("upgrading to %s", jujuversion.Current),
 	}}
 	for i := 0; i < retryCount; i++ {
 		calls = append(calls, StatusCall{
-			status.StatusError,
+			status.Error,
 			fmt.Sprintf("upgrade to %s failed (will retry): %s", jujuversion.Current, failReason),
 		})
 	}
 	if expectFail {
 		calls = append(calls, StatusCall{
-			status.StatusError,
+			status.Error,
 			fmt.Sprintf("upgrade to %s failed (giving up): %s", jujuversion.Current, failReason),
 		})
 	} else {
-		calls = append(calls, StatusCall{status.StatusStarted, ""})
+		calls = append(calls, StatusCall{status.Started, ""})
 	}
 	return calls
 }


### PR DESCRIPTION
Everywhere they're used they're prefixed with "status.", so the "Status"
prefix is just noise. I left the type names alone. While status.StatusInfo is 
redundant, status.Info is too generic (and gets confused with all sorts of other
Info types).

Fixes http://pad.lv/1577587

(Review request: http://reviews.vapour.ws/r/5665/)