### PR TITLE
Fixed agents restore.

### DIFF
--- a/state/backups/backups_linux.go
+++ b/state/backups/backups_linux.go
@@ -250,7 +250,7 @@ func (b *backups) Restore(backupId string, dbInfo *DBInfo, args RestoreArgs) (na
 		}
 		machines = append(machines, machinesForModel...)
 	}
-	if err := updateAllMachines(args.PrivateAddress, machines); err != nil {
+	if err := updateAllMachines(args.PrivateAddress, args.PublicAddress, machines); err != nil {
 		return nil, errors.Annotate(err, "cannot update agents")
 	}
 

--- a/state/backups/backups_linux.go
+++ b/state/backups/backups_linux.go
@@ -238,9 +238,17 @@ func (b *backups) Restore(backupId string, dbInfo *DBInfo, args RestoreArgs) (na
 	// TODO(perrito666): We should never stop process because of this.
 	// updateAllMachines will not return errors for individual
 	// agent update failures
-	machines, err := st.AllMachines()
+	models, err := st.AllModels()
 	if err != nil {
 		return nil, errors.Trace(err)
+	}
+	machines := []*state.Machine{}
+	for _, model := range models {
+		machinesForModel, err := st.AllMachinesFor(model.UUID())
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		machines = append(machines, machinesForModel...)
 	}
 	if err := updateAllMachines(args.PrivateAddress, machines); err != nil {
 		return nil, errors.Annotate(err, "cannot update agents")

--- a/state/state.go
+++ b/state/state.go
@@ -690,9 +690,9 @@ func (st *State) allMachines(machinesCollection mongo.Collection) ([]*Machine, e
 		return nil, errors.Annotatef(err, "cannot get all machines")
 	}
 	sort.Sort(mdocs)
-	machines := []*Machine{}
-	for _, doc := range mdocs {
-		machines = append(machines, newMachine(st, &doc))
+	machines := make([]*Machine, len(mdocs))
+	for i, doc := range mdocs {
+		machines[i] = newMachine(st, &doc)
 	}
 	return machines, nil
 }

--- a/state/state.go
+++ b/state/state.go
@@ -683,22 +683,34 @@ func (st *State) SetModelConstraints(cons constraints.Value) error {
 	return writeConstraints(st, modelGlobalKey, cons)
 }
 
-// AllMachines returns all machines in the model
-// ordered by id.
-func (st *State) AllMachines() (machines []*Machine, err error) {
-	machinesCollection, closer := st.getCollection(machinesC)
-	defer closer()
-
+func (st *State) allMachines(machinesCollection mongo.Collection) ([]*Machine, error) {
 	mdocs := machineDocSlice{}
-	err = machinesCollection.Find(nil).All(&mdocs)
+	err := machinesCollection.Find(nil).All(&mdocs)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot get all machines")
 	}
 	sort.Sort(mdocs)
+	machines := []*Machine{}
 	for _, doc := range mdocs {
 		machines = append(machines, newMachine(st, &doc))
 	}
-	return
+	return machines, nil
+}
+
+// AllMachines returns all machines in the model
+// ordered by id.
+func (st *State) AllMachines() ([]*Machine, error) {
+	machinesCollection, closer := st.getCollection(machinesC)
+	defer closer()
+	return st.allMachines(machinesCollection)
+}
+
+// AllMachinesFor returns all machines for the model represented
+// by the given modeluuid
+func (st *State) AllMachinesFor(modelUUID string) ([]*Machine, error) {
+	machinesCollection, closer := st.getCollectionFor(modelUUID, machinesC)
+	defer closer()
+	return st.allMachines(machinesCollection)
 }
 
 type machineDocSlice []machineDoc


### PR DESCRIPTION
After a succesful restore, agents where not updated to reflect
the new api server.
A way to list all the machines on all the models was added
to help the restore method get all the IPs for all the machines
it needs to update.

(Review request: http://reviews.vapour.ws/r/5669/)