### PR TITLE
Update juju/txn to latest.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -43,7 +43,7 @@ github.com/juju/romulus	git	bf7827fa2f360ab762c134766ff1d4fff959ea03	2016-08-17T
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	c84079384079574bbd4461c37f903afa57472f3b	2016-09-06T21:43:14Z
-github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
+github.com/juju/txn	git	18d812a45ffc407a4d5f849036b7d8d12febaf08	2016-09-13T21:23:40Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	dbc08fbee4c1bcf60d65f5a523149310ece56a08	2016-09-05T01:56:06Z
 github.com/juju/version	git	4ae6172c00626779a5a462c3e3d22fc0e889431a	2016-06-03T19:49:58Z


### PR DESCRIPTION
Bring in the latest juju/txn which retries "unexpected message" errors in the Run method.

(Review request: http://reviews.vapour.ws/r/5671/)