### PR TITLE
Make juju run require admin permissions on the model.

### DIFF
--- a/apiserver/action/action.go
+++ b/apiserver/action/action.go
@@ -39,6 +39,7 @@ func NewActionAPI(st *state.State, resources facade.Resources, authorizer facade
 		check:      common.NewBlockChecker(st),
 	}, nil
 }
+
 func (a *ActionAPI) checkCanRead() error {
 	canRead, err := a.authorizer.HasPermission(description.ReadAccess, a.state.ModelTag())
 	if err != nil {
@@ -56,6 +57,17 @@ func (a *ActionAPI) checkCanWrite() error {
 		return errors.Trace(err)
 	}
 	if !canWrite {
+		return common.ErrPerm
+	}
+	return nil
+}
+
+func (a *ActionAPI) checkCanAdmin() error {
+	canAdmin, err := a.authorizer.HasPermission(description.AdminAccess, a.state.ModelTag())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if !canAdmin {
 		return common.ErrPerm
 	}
 	return nil

--- a/apiserver/action/run.go
+++ b/apiserver/action/run.go
@@ -44,7 +44,7 @@ func getAllUnitNames(st *state.State, units, services []string) (result []names.
 // Run the commands specified on the machines identified through the
 // list of machines, units and services.
 func (a *ActionAPI) Run(run params.RunParams) (results params.ActionResults, err error) {
-	if err := a.checkCanWrite(); err != nil {
+	if err := a.checkCanAdmin(); err != nil {
 		return results, err
 	}
 	if err := a.check.ChangeAllowed(); err != nil {
@@ -71,7 +71,7 @@ func (a *ActionAPI) Run(run params.RunParams) (results params.ActionResults, err
 
 // RunOnAllMachines attempts to run the specified command on all the machines.
 func (a *ActionAPI) RunOnAllMachines(run params.RunParams) (results params.ActionResults, err error) {
-	if err := a.checkCanWrite(); err != nil {
+	if err := a.checkCanAdmin(); err != nil {
 		return results, err
 	}
 

--- a/cmd/juju/commands/run.go
+++ b/cmd/juju/commands/run.go
@@ -39,7 +39,8 @@ type runCommand struct {
 }
 
 const runDoc = `
-Run the commands on the specified targets.
+Run the commands on the specified targets. Only admin users of a model
+are able to use this command.
 
 Targets are specified using either machine ids, application names or unit
 names.  At least one target specifier is needed.


### PR DESCRIPTION
Addresses http://pad.lv/1595720. Part of the problem there was that adding a ssh key was considered an admin task but 'juju run' was not. We address this by making 'juju run' require admin access on the model in question.

(Review request: http://reviews.vapour.ws/r/5673/)