### PR TITLE
Change log level in worker/diskmanager.

### DIFF
--- a/worker/diskmanager/lsblk.go
+++ b/worker/diskmanager/lsblk.go
@@ -111,9 +111,7 @@ func listBlockDevices() ([]storage.BlockDevice, error) {
 			// host, but the devices will typically not be present.
 			continue
 		} else if err != nil {
-			logger.Errorf(
-				"error checking if %q is in use: %v", dev.DeviceName, err,
-			)
+			logger.Infof("could not check if %q is in use: %v", dev.DeviceName, err)
 			// We cannot detect, so err on the side of caution and default to
 			// "in use" so the device cannot be used.
 			dev.InUse = true


### PR DESCRIPTION
This log message is noisy and is not actually an error that a user needs to act on. Changed to Info level.

Based on feedback and proposal from https://github.com/juju/juju/pull/2732

(Review request: http://reviews.vapour.ws/r/5675/)