### PR TITLE
Use cloud tags not cloud names for various api calls

### DIFF
--- a/api/base/types.go
+++ b/api/base/types.go
@@ -6,7 +6,8 @@ package base
 import (
 	"time"
 
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/status"
 )
 
 // UserModel holds information about a model and the last
@@ -22,7 +23,7 @@ type UserModel struct {
 // ModelStatus holds information about the status of a juju model.
 type ModelStatus struct {
 	UUID               string
-	Life               params.Life
+	Life               string
 	Owner              string
 	TotalMachineCount  int
 	CoreCount          int
@@ -38,4 +39,38 @@ type Machine struct {
 	HasVote    bool
 	WantsVote  bool
 	Status     string
+	Hardware   *instance.HardwareCharacteristics
+}
+
+// ModelInfo holds information about a model.
+type ModelInfo struct {
+	Name            string
+	UUID            string
+	ControllerUUID  string
+	ProviderType    string
+	DefaultSeries   string
+	Cloud           string
+	CloudRegion     string
+	CloudCredential string
+	Owner           string
+	Life            string
+	Status          Status
+	Users           []UserInfo
+	Machines        []Machine
+}
+
+// Status represents the status of a machine, application, or unit.
+type Status struct {
+	Status status.Status
+	Info   string
+	Data   map[string]interface{}
+	Since  *time.Time
+}
+
+// UserInfo holds information about a user in a juju model.
+type UserInfo struct {
+	UserName       string
+	DisplayName    string
+	LastConnection *time.Time
+	Access         string
 }

--- a/api/client.go
+++ b/api/client.go
@@ -195,13 +195,6 @@ func (c *Client) ModelUUID() (string, bool) {
 	return tag.Id(), true
 }
 
-// ModelInfo returns details about the Juju model.
-func (c *Client) ModelInfo() (params.ModelInfo, error) {
-	var info params.ModelInfo
-	err := c.facade.FacadeCall("ModelInfo", nil, &info)
-	return info, err
-}
-
 // ModelUserInfo returns information on all users in the model.
 func (c *Client) ModelUserInfo() ([]params.ModelUserInfo, error) {
 	var results params.ModelUserInfoResults

--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -137,7 +137,7 @@ func (c *Client) ModelStatus(tags ...names.ModelTag) ([]base.ModelStatus, error)
 
 		results[i] = base.ModelStatus{
 			UUID:               model.Id(),
-			Life:               r.Life,
+			Life:               string(r.Life),
 			Owner:              owner.Canonical(),
 			HostedMachineCount: r.HostedMachineCount,
 			ServiceCount:       r.ApplicationCount,

--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -257,7 +257,7 @@ func (s *legacySuite) TestModelStatus(c *gc.C) {
 		HostedMachineCount: 1,
 		ServiceCount:       0,
 		Owner:              "admin@local",
-		Life:               params.Alive,
+		Life:               string(params.Alive),
 		Machines:           []base.Machine{{Id: "0", InstanceId: "id-2", Status: "pending"}},
 	}})
 }

--- a/api/modelmanager/modelmanager_test.go
+++ b/api/modelmanager/modelmanager_test.go
@@ -63,7 +63,7 @@ func (s *modelmanagerSuite) testCreateModel(c *gc.C, cloud, region string) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newModel.Name, gc.Equals, "new-model")
-	c.Assert(newModel.OwnerTag, gc.Equals, user.Tag().String())
+	c.Assert(newModel.Owner, gc.Equals, user.String())
 	c.Assert(newModel.CloudRegion, gc.Equals, "dummy-region")
 	c.Assert(utils.IsValidUUIDString(newModel.UUID), jc.IsTrue)
 }

--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -161,7 +161,7 @@ func (s *baseSuite) openAs(c *gc.C, tag names.Tag) api.Connection {
 var scenarioStatus = &params.FullStatus{
 	Model: params.ModelStatusInfo{
 		Name:        "controller",
-		Cloud:       "dummy",
+		CloudTag:    "cloud-dummy",
 		CloudRegion: "dummy-region",
 		Version:     "1.2.3",
 	},

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -431,7 +431,7 @@ func (c *Client) ModelInfo() (params.ModelInfo, error) {
 	}
 	info := params.ModelInfo{
 		DefaultSeries: config.PreferredSeries(conf),
-		Cloud:         model.Cloud(),
+		CloudTag:      names.NewCloudTag(model.Cloud()).String(),
 		CloudRegion:   model.CloudRegion(),
 		ProviderType:  conf.Type(),
 		Name:          conf.Name(),

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -288,7 +288,7 @@ func (c *Client) modelStatus() (params.ModelStatusInfo, error) {
 		return info, errors.Annotate(err, "cannot get model")
 	}
 	info.Name = m.Name()
-	info.Cloud = m.Cloud()
+	info.CloudTag = names.NewCloudTag(m.Cloud()).String()
 	info.CloudRegion = m.CloudRegion()
 
 	cfg, err := m.Config()

--- a/apiserver/client/status_test.go
+++ b/apiserver/client/status_test.go
@@ -46,7 +46,7 @@ func (s *statusSuite) TestFullStatus(c *gc.C) {
 	status, err := client.Status(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(status.Model.Name, gc.Equals, "controller")
-	c.Check(status.Model.Cloud, gc.Equals, "dummy")
+	c.Check(status.Model.CloudTag, gc.Equals, "cloud-dummy")
 	c.Check(status.Applications, gc.HasLen, 0)
 	c.Check(status.Machines, gc.HasLen, 1)
 	resultMachine, ok := status.Machines[machine.Id()]

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -152,7 +152,7 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		ControllerUUID:     "deadbeef-1bad-500d-9000-4b1d0d06f00d",
 		OwnerTag:           "user-bob@local",
 		ProviderType:       "someprovider",
-		Cloud:              "some-cloud",
+		CloudTag:           "cloud-some-cloud",
 		CloudRegion:        "some-region",
 		CloudCredentialTag: "cloudcred-some-cloud_bob@local_some-credential",
 		DefaultSeries:      series.LatestLts(),

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -580,7 +580,7 @@ func (m *ModelManagerAPI) getModelInfo(tag names.ModelTag) (params.ModelInfo, er
 		Status:         common.EntityStatusFromState(status),
 		ProviderType:   cfg.Type(),
 		DefaultSeries:  config.PreferredSeries(cfg),
-		Cloud:          model.Cloud(),
+		CloudTag:       names.NewCloudTag(model.Cloud()).String(),
 		CloudRegion:    model.CloudRegion(),
 	}
 

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -95,7 +95,7 @@ type ModelInfo struct {
 	ControllerUUID     string `json:"controller-uuid"`
 	ProviderType       string `json:"provider-type"`
 	DefaultSeries      string `json:"default-series"`
-	Cloud              string `json:"cloud"`
+	CloudTag           string `json:"cloud-tag"`
 	CloudRegion        string `json:"cloud-region,omitempty"`
 	CloudCredentialTag string `json:"cloud-credential-tag,omitempty"`
 

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -30,7 +30,7 @@ type FullStatus struct {
 // ModelStatusInfo holds status information about the model itself.
 type ModelStatusInfo struct {
 	Name             string `json:"name"`
-	Cloud            string `json:"cloud"`
+	CloudTag         string `json:"cloud-tag"`
 	CloudRegion      string `json:"region,omitempty"`
 	Version          string `json:"version"`
 	AvailableVersion string `json:"available-version"`

--- a/cmd/juju/common/model.go
+++ b/cmd/juju/common/model.go
@@ -64,6 +64,10 @@ func ModelInfoFromParams(info params.ModelInfo, now time.Time) (ModelInfo, error
 	if info.Status.Since != nil {
 		status.Since = UserFriendlyDuration(*info.Status.Since, now)
 	}
+	cloudTag, err := names.ParseCloudTag(info.CloudTag)
+	if err != nil {
+		return ModelInfo{}, errors.Trace(err)
+	}
 	return ModelInfo{
 		Name:           info.Name,
 		UUID:           info.UUID,
@@ -71,7 +75,7 @@ func ModelInfoFromParams(info params.ModelInfo, now time.Time) (ModelInfo, error
 		Owner:          tag.Id(),
 		Life:           string(info.Life),
 		Status:         status,
-		Cloud:          info.Cloud,
+		Cloud:          cloudTag.Id(),
 		CloudRegion:    info.CloudRegion,
 		ProviderType:   info.ProviderType,
 		Users:          ModelUserInfoFromParams(info.Users, now),

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -129,7 +129,7 @@ type AddModelAPI interface {
 		name, owner, cloudName, cloudRegion string,
 		cloudCredential names.CloudCredentialTag,
 		config map[string]interface{},
-	) (params.ModelInfo, error)
+	) (base.ModelInfo, error)
 }
 
 type CloudAPI interface {
@@ -235,11 +235,8 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 		messageFormat += " on %s"
 		messageArgs = append(messageArgs, cloudRegion)
 	}
-	if model.CloudCredentialTag != "" {
-		tag, err := names.ParseCloudCredentialTag(model.CloudCredentialTag)
-		if err != nil {
-			return errors.Trace(err)
-		}
+	if model.CloudCredential != "" {
+		tag := names.NewCloudCredentialTag(model.CloudCredential)
 		credentialName := tag.Name()
 		if tag.Owner().Canonical() != modelOwner {
 			credentialName = fmt.Sprintf("%s/%s", tag.Owner().Canonical(), credentialName)

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -13,9 +13,11 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/controller"
@@ -23,7 +25,6 @@ import (
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	_ "github.com/juju/juju/provider/ec2"
 	"github.com/juju/juju/testing"
-	"gopkg.in/juju/names.v2"
 )
 
 type AddModelSuite struct {
@@ -38,10 +39,10 @@ var _ = gc.Suite(&AddModelSuite{})
 func (s *AddModelSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.fakeAddModelAPI = &fakeAddClient{
-		model: params.ModelInfo{
-			Name:     "test",
-			UUID:     "fake-model-uuid",
-			OwnerTag: "ignored-for-now",
+		model: base.ModelInfo{
+			Name:  "test",
+			UUID:  "fake-model-uuid",
+			Owner: "ignored-for-now",
 		},
 	}
 	s.fakeCloudAPI = &fakeCloudAPI{}
@@ -401,7 +402,7 @@ type fakeAddClient struct {
 	cloudCredential names.CloudCredentialTag
 	config          map[string]interface{}
 	err             error
-	model           params.ModelInfo
+	model           base.ModelInfo
 }
 
 var _ controller.AddModelAPI = (*fakeAddClient)(nil)
@@ -410,9 +411,9 @@ func (*fakeAddClient) Close() error {
 	return nil
 }
 
-func (f *fakeAddClient) CreateModel(name, owner, cloudName, cloudRegion string, cloudCredential names.CloudCredentialTag, config map[string]interface{}) (params.ModelInfo, error) {
+func (f *fakeAddClient) CreateModel(name, owner, cloudName, cloudRegion string, cloudCredential names.CloudCredentialTag, config map[string]interface{}) (base.ModelInfo, error) {
 	if f.err != nil {
-		return params.ModelInfo{}, f.err
+		return base.ModelInfo{}, f.err
 	}
 	f.owner = owner
 	f.cloudCredential = cloudCredential

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -186,7 +186,7 @@ func (c *destroyCommand) checkNoAliveHostedModels(ctx *cmd.Context, models []mod
 	// and there are models still alive.
 	var buf bytes.Buffer
 	for _, model := range models {
-		if model.Life != params.Alive {
+		if model.Life != string(params.Alive) {
 			continue
 		}
 		buf.WriteString(fmtModelStatus(model))

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -213,7 +213,7 @@ func (s *baseDestroySuite) SetUpTest(c *gc.C) {
 		})
 		s.api.envStatus[model.modelUUID] = base.ModelStatus{
 			UUID:               uuid,
-			Life:               params.Dead,
+			Life:               string(params.Dead),
 			HostedMachineCount: 0,
 			ServiceCount:       0,
 			Owner:              owner.Canonical(),
@@ -317,7 +317,7 @@ func (s *DestroySuite) TestFailedDestroyController(c *gc.C) {
 
 func (s *DestroySuite) TestDestroyControllerAliveModels(c *gc.C) {
 	for uuid, status := range s.api.envStatus {
-		status.Life = params.Alive
+		status.Life = string(params.Alive)
 		s.api.envStatus[uuid] = status
 	}
 	s.api.SetErrors(&params.Error{Code: params.CodeHasHostedModels})

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -191,7 +191,7 @@ func (s *KillSuite) TestControllerStatus(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		s.api.envStatus[env.UUID] = base.ModelStatus{
 			UUID:               env.UUID,
-			Life:               params.Dying,
+			Life:               string(params.Dying),
 			HostedMachineCount: 2,
 			ServiceCount:       1,
 			Owner:              owner.Canonical(),
@@ -228,7 +228,7 @@ func (s *KillSuite) TestControllerStatus(c *gc.C) {
 	} {
 		c.Assert(envsStatus[i].Owner, gc.Equals, expected.Owner)
 		c.Assert(envsStatus[i].Name, gc.Equals, expected.Name)
-		c.Assert(envsStatus[i].Life, gc.Equals, expected.Life)
+		c.Assert(envsStatus[i].Life, gc.Equals, string(expected.Life))
 		c.Assert(envsStatus[i].HostedMachineCount, gc.Equals, expected.HostedMachineCount)
 		c.Assert(envsStatus[i].ServiceCount, gc.Equals, expected.ServiceCount)
 	}
@@ -238,7 +238,7 @@ func (s *KillSuite) TestControllerStatus(c *gc.C) {
 func (s *KillSuite) TestFmtControllerStatus(c *gc.C) {
 	data := controller.CtrData{
 		"uuid",
-		params.Alive,
+		string(params.Alive),
 		3,
 		20,
 		8,
@@ -252,7 +252,7 @@ func (s *KillSuite) TestFmtEnvironStatus(c *gc.C) {
 		"uuid",
 		"owner@local",
 		"envname",
-		params.Dying,
+		string(params.Dying),
 		8,
 		1,
 	}

--- a/cmd/juju/controller/killstatus.go
+++ b/cmd/juju/controller/killstatus.go
@@ -15,7 +15,7 @@ import (
 
 type ctrData struct {
 	UUID               string
-	Life               params.Life
+	Life               string
 	HostedModelCount   int
 	HostedMachineCount int
 	ServiceCount       int
@@ -25,7 +25,7 @@ type modelData struct {
 	UUID  string
 	Owner string
 	Name  string
-	Life  params.Life
+	Life  string
 
 	HostedMachineCount int
 	ServiceCount       int
@@ -88,7 +88,7 @@ func newData(api destroyControllerAPI, controllerModelUUID string) (ctrData, []m
 	var modelsData []modelData
 	var aliveModelCount int
 	for _, model := range hostedStatus {
-		if model.Life == params.Dead {
+		if model.Life == string(params.Dead) {
 			continue
 		}
 		modelsData = append(modelsData, modelData{
@@ -118,7 +118,7 @@ func newData(api destroyControllerAPI, controllerModelUUID string) (ctrData, []m
 
 func hasUnDeadModels(models []modelData) bool {
 	for _, model := range models {
-		if model.Life != params.Dead {
+		if model.Life != string(params.Dead) {
 			return true
 		}
 	}
@@ -127,7 +127,7 @@ func hasUnDeadModels(models []modelData) bool {
 
 func hasAliveModels(models []modelData) bool {
 	for _, model := range models {
-		if model.Life == params.Alive {
+		if model.Life == string(params.Alive) {
 			return true
 		}
 	}

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -69,6 +69,7 @@ func (f *fakeModelMgrAPIClient) ModelInfo(tags []names.ModelTag) ([]params.Model
 				Name:     model.Name,
 				UUID:     model.UUID,
 				OwnerTag: names.NewUserTag(model.Owner).String(),
+				CloudTag: "cloud-dummy",
 			}
 			switch model.Name {
 			case "test-model1":

--- a/cmd/juju/model/show_test.go
+++ b/cmd/juju/model/show_test.go
@@ -75,7 +75,7 @@ func (s *ShowCommandSuite) SetUpTest(c *gc.C) {
 		UUID:           testing.ModelTag.Id(),
 		ControllerUUID: "1ca2293b-fdb9-4299-97d6-55583bb39364",
 		OwnerTag:       "user-admin@local",
-		Cloud:          "some-cloud",
+		CloudTag:       "cloud-some-cloud",
 		CloudRegion:    "some-region",
 		ProviderType:   "openstack",
 		Life:           params.Alive,

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/utils/series"
 	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/common"
@@ -41,15 +42,19 @@ func newStatusFormatter(status *params.FullStatus, controllerName string, isoTim
 	return &sf
 }
 
-func (sf *statusFormatter) format() formattedStatus {
+func (sf *statusFormatter) format() (formattedStatus, error) {
 	if sf.status == nil {
-		return formattedStatus{}
+		return formattedStatus{}, nil
+	}
+	cloudTag, err := names.ParseCloudTag(sf.status.Model.CloudTag)
+	if err != nil {
+		return formattedStatus{}, err
 	}
 	out := formattedStatus{
 		Model: modelStatus{
 			Name:             sf.status.Model.Name,
 			Controller:       sf.controllerName,
-			Cloud:            sf.status.Model.Cloud,
+			Cloud:            cloudTag.Id(),
 			CloudRegion:      sf.status.Model.CloudRegion,
 			Version:          sf.status.Model.Version,
 			AvailableVersion: sf.status.Model.AvailableVersion,
@@ -64,7 +69,7 @@ func (sf *statusFormatter) format() formattedStatus {
 	for sn, s := range sf.status.Applications {
 		out.Applications[sn] = sf.formatApplication(sn, s)
 	}
-	return out
+	return out, nil
 }
 
 // MachineFormat takes stored model information (params.FullStatus) and formats machine status info.

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -153,7 +153,10 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 	}
 
 	formatter := newStatusFormatter(status, c.ControllerName(), c.isoTime)
-	formatted := formatter.format()
+	formatted, err := formatter.format()
+	if err != nil {
+		return err
+	}
 	return c.out.Write(ctx, formatted)
 }
 

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -4176,6 +4176,9 @@ func (s *StatusSuite) TestIsoTimeFormat(c *gc.C) {
 
 func (s *StatusSuite) TestFormatProvisioningError(c *gc.C) {
 	status := &params.FullStatus{
+		Model: params.ModelStatusInfo{
+			CloudTag: "cloud-dummy",
+		},
 		Machines: map[string]params.MachineStatus{
 			"1": {
 				AgentStatus: params.DetailedStatus{
@@ -4191,9 +4194,13 @@ func (s *StatusSuite) TestFormatProvisioningError(c *gc.C) {
 		},
 	}
 	formatter := NewStatusFormatter(status, true)
-	formatted := formatter.format()
+	formatted, err := formatter.format()
+	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(formatted, jc.DeepEquals, formattedStatus{
+		Model: modelStatus{
+			Cloud: "dummy",
+		},
 		Machines: map[string]machineStatus{
 			"1": {
 				JujuStatus: statusInfoContents{Current: "error", Message: "<error while provisioning>"},

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -17,8 +17,8 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/modelmanager"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/commands"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju"
@@ -44,7 +44,7 @@ func (s *cmdControllerSuite) run(c *gc.C, args ...string) *cmd.Context {
 	return context
 }
 
-func (s *cmdControllerSuite) createModelAdminUser(c *gc.C, modelname string, isServer bool) params.ModelInfo {
+func (s *cmdControllerSuite) createModelAdminUser(c *gc.C, modelname string, isServer bool) base.ModelInfo {
 	modelManager := modelmanager.NewClient(s.OpenControllerAPI(c))
 	defer modelManager.Close()
 	model, err := modelManager.CreateModel(


### PR DESCRIPTION
For some APIs, we were sending cloud names not cloud tags over the wire. This fixes that, but as a side effect it also required creating more non params structs in api/base. So CreateModel() for example no longer returns a params struct (which it never should have).