### PR TITLE
Limit number of sends performed by the metricsender in one invocation.

### DIFF
--- a/apiserver/metricsender/metricsender.go
+++ b/apiserver/metricsender/metricsender.go
@@ -23,8 +23,9 @@ type MetricSender interface {
 }
 
 var (
-	defaultMaxBatchesPerSend              = 10
-	defaultSender            MetricSender = &HttpSender{}
+	defaultMaxSendsPerInvocation              = 5
+	defaultMaxBatchesPerSend                  = 1000
+	defaultSender                MetricSender = &HttpSender{}
 )
 
 func handleResponse(mm *state.MetricsManager, st ModelBackend, response wireformat.Response) {
@@ -63,7 +64,7 @@ func SendMetrics(st ModelBackend, sender MetricSender, clock clock.Clock, batchS
 	}
 	sent := 0
 	held := 0
-	for {
+	for i := 0; i < defaultMaxSendsPerInvocation; i++ {
 		metrics, err := st.MetricsToSend(batchSize)
 		if err != nil {
 			return errors.Trace(err)


### PR DESCRIPTION
The metric sender should send 5 sets of metrics batches in one invocation. Each set has a maximum length of 100.