### PR TITLE
Better error message for bad MAAS endpoint URL

### DIFF
--- a/provider/maas/config_test.go
+++ b/provider/maas/config_test.go
@@ -48,11 +48,11 @@ func newConfig(values map[string]interface{}) (*maasModelConfig, error) {
 
 func (s *configSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	mockCapabilities := func(client *gomaasapi.MAASObject) (set.Strings, error) {
+	mockCapabilities := func(*gomaasapi.MAASObject, string) (set.Strings, error) {
 		return set.NewStrings("network-deployment-ubuntu"), nil
 	}
 	s.PatchValue(&GetCapabilities, mockCapabilities)
-	mockGetController := func(maasServer, apiKey string) (gomaasapi.Controller, error) {
+	mockGetController := func(string, string) (gomaasapi.Controller, error) {
 		return nil, gomaasapi.NewUnsupportedVersionError("oops")
 	}
 	s.PatchValue(&GetMAAS2Controller, mockGetController)

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -276,7 +276,7 @@ func (env *maasEnviron) SetConfig(cfg *config.Config) error {
 			return errors.Trace(err)
 		}
 		if !caps.Contains(capNetworkDeploymentUbuntu) {
-			return errors.NotSupportedf("MAAS 1.9 or more recent is required")
+			return errors.NewNotSupported(nil, "MAAS 1.9 or more recent is required")
 		}
 	case err != nil:
 		return errors.Trace(err)
@@ -607,7 +607,7 @@ func getCapabilities(client *gomaasapi.MAASObject) (set.Strings, error) {
 		result, err = version.CallGet("", nil)
 		if err != nil {
 			if err, ok := errors.Cause(err).(gomaasapi.ServerError); ok && err.StatusCode == 404 {
-				return caps, errors.NotSupportedf("MAAS version 1.9 or more recent is required")
+				return caps, errors.NewNotSupported(nil, "Couldn't get MAAS version - check the endpoint is correct")
 			}
 		} else {
 			break

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -271,7 +271,7 @@ func (env *maasEnviron) SetConfig(cfg *config.Config) error {
 			return errors.Trace(err)
 		}
 		env.maasClientUnlocked = gomaasapi.NewMAAS(*authClient)
-		caps, err := GetCapabilities(env.maasClientUnlocked)
+		caps, err := GetCapabilities(env.maasClientUnlocked, maasServer)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -597,7 +597,7 @@ const (
 
 // getCapabilities asks the MAAS server for its capabilities, if
 // supported by the server.
-func getCapabilities(client *gomaasapi.MAASObject) (set.Strings, error) {
+func getCapabilities(client *gomaasapi.MAASObject, serverURL string) (set.Strings, error) {
 	caps := make(set.Strings)
 	var result gomaasapi.JSONObject
 	var err error
@@ -607,7 +607,12 @@ func getCapabilities(client *gomaasapi.MAASObject) (set.Strings, error) {
 		result, err = version.CallGet("", nil)
 		if err != nil {
 			if err, ok := errors.Cause(err).(gomaasapi.ServerError); ok && err.StatusCode == 404 {
-				return caps, errors.NewNotSupported(nil, "Couldn't get MAAS version - check the endpoint is correct")
+				message := "could not connect to MAAS controller - check the endpoint is correct"
+				trimmedUrl := strings.TrimRight(serverURL, "/")
+				if !strings.HasSuffix(trimmedUrl, "/MAAS") {
+					message += " (it normally ends with /MAAS)"
+				}
+				return caps, errors.NewNotSupported(nil, message)
 			}
 		} else {
 			break

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -4,6 +4,9 @@
 package maas_test
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
 	stdtesting "testing"
 
 	"github.com/juju/gomaasapi"
@@ -11,6 +14,7 @@ import (
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/errors"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -22,7 +26,6 @@ import (
 type environSuite struct {
 	coretesting.BaseSuite
 	envtesting.ToolsFixture
-	testMAASObject  *gomaasapi.TestMAASObject
 	restoreTimeouts func()
 }
 
@@ -38,8 +41,6 @@ func TestMAAS(t *stdtesting.T) {
 func (s *environSuite) SetUpSuite(c *gc.C) {
 	s.restoreTimeouts = envtesting.PatchAttemptStrategies(maas.ShortAttempt)
 	s.BaseSuite.SetUpSuite(c)
-	TestMAASObject := gomaasapi.NewTestMAAS("1.0")
-	s.testMAASObject = TestMAASObject
 }
 
 func (s *environSuite) SetUpTest(c *gc.C) {
@@ -57,13 +58,11 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *environSuite) TearDownTest(c *gc.C) {
-	s.testMAASObject.TestServer.Clear()
 	s.ToolsFixture.TearDownTest(c)
 	s.BaseSuite.TearDownTest(c)
 }
 
 func (s *environSuite) TearDownSuite(c *gc.C) {
-	s.testMAASObject.Close()
 	s.restoreTimeouts()
 	s.BaseSuite.TearDownSuite(c)
 }
@@ -167,4 +166,39 @@ func (*environSuite) TestNewCloudinitConfigWithDisabledNetworkManagement(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudcfg.SystemUpdate(), jc.IsTrue)
 	c.Assert(cloudcfg.RunCmds(), jc.DeepEquals, expectedCloudinitConfig)
+}
+
+type badEndpointSuite struct {
+	coretesting.BaseSuite
+
+	fakeServer *httptest.Server
+	cloudSpec  environs.CloudSpec
+}
+
+var _ = gc.Suite(&badEndpointSuite{})
+
+func (s *badEndpointSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+	always404 := func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		io.WriteString(w, "uh-oh")
+	}
+	s.fakeServer = httptest.NewServer(http.HandlerFunc(always404))
+	cred := cloud.NewCredential(cloud.OAuth1AuthType, map[string]string{
+		"maas-oauth": "a:b:c",
+	})
+	s.cloudSpec = environs.CloudSpec{
+		Type:       "maas",
+		Name:       "maas",
+		Endpoint:   s.fakeServer.URL,
+		Credential: &cred,
+	}
+}
+
+func (s *badEndpointSuite) TestBadEndpointMessage(c *gc.C) {
+	cfg := getSimpleTestConfig(c, coretesting.Attrs{})
+	env, err := maas.NewEnviron(s.cloudSpec, cfg)
+	c.Assert(env, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "Couldn't get MAAS version - check the endpoint is correct")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -95,10 +95,10 @@ func (s *providerSuite) SetUpSuite(c *gc.C) {
 
 func (s *providerSuite) SetUpTest(c *gc.C) {
 	s.baseProviderSuite.SetUpTest(c)
-	mockCapabilities := func(client *gomaasapi.MAASObject) (set.Strings, error) {
+	mockCapabilities := func(*gomaasapi.MAASObject, string) (set.Strings, error) {
 		return set.NewStrings("network-deployment-ubuntu"), nil
 	}
-	mockGetController := func(maasServer, apiKey string) (gomaasapi.Controller, error) {
+	mockGetController := func(string, string) (gomaasapi.Controller, error) {
 		return nil, gomaasapi.NewUnsupportedVersionError("oops")
 	}
 	s.PatchValue(&GetCapabilities, mockCapabilities)


### PR DESCRIPTION
Fixes http://pad.lv/1623184

When the MAAS endpoint is wrong (in the bug's case, didn't end in MAAS)
Juju would report "ERROR MAAS version 1.9 or more recent is required not
supported". Change that error to indicate that actually we couldn't work
out what version of MAAS we were talking to, and the endpoint is
probably wrong.

Fix the other badly-worded NotSupported error as well.

Drive-by cleanup for the environ tests that created a TestMAASObject and
then never used it.

(Review request: http://reviews.vapour.ws/r/5680/)