### PR TITLE
Revert PR 6237: Get stream value from simplestreams

### DIFF
--- a/apiserver/imagemetadata/metadata.go
+++ b/apiserver/imagemetadata/metadata.go
@@ -289,7 +289,7 @@ var convertToParams = func(info *simplestreams.ResolveInfo, priority int, publis
 		m := params.CloudImageMetadata{
 			Source:          info.Source,
 			ImageId:         p.Id,
-			Stream:          info.Stream,
+			Stream:          p.Stream,
 			Region:          p.RegionName,
 			Arch:            p.Arch,
 			VirtType:        p.VirtType,

--- a/apiserver/imagemetadata/updatefrompublished_test.go
+++ b/apiserver/imagemetadata/updatefrompublished_test.go
@@ -392,7 +392,7 @@ func (s *regionMetadataSuite) TestUpdateFromPublishedImagesMultipleDS(c *gc.C) {
 	priority := s.setupMetadata(c, anotherDS, cloudSpec, m1)
 	m1.Source = anotherDS
 	m1.Priority = priority
-	m1.Stream = "custom"
+	m1.Stream = "released"
 
 	s.expected = append(s.expected, m1)
 

--- a/apiserver/provisioner/provisioninginfo.go
+++ b/apiserver/provisioner/provisioninginfo.go
@@ -497,7 +497,8 @@ func (p *ProvisionerAPI) imageMetadataFromDataSources(env environs.Environ, cons
 		return nil, errors.Trace(err)
 	}
 
-	toModel := func(m *imagemetadata.ImageMetadata, mSeries, source, stream string, priority int) cloudimagemetadata.Metadata {
+	cfg := env.Config()
+	toModel := func(m *imagemetadata.ImageMetadata, mSeries string, source string, priority int) cloudimagemetadata.Metadata {
 		result := cloudimagemetadata.Metadata{
 			cloudimagemetadata.MetadataAttributes{
 				Region:          m.RegionName,
@@ -506,11 +507,20 @@ func (p *ProvisionerAPI) imageMetadataFromDataSources(env environs.Environ, cons
 				RootStorageType: m.Storage,
 				Source:          source,
 				Series:          mSeries,
-				Stream:          stream,
+				Stream:          m.Stream,
 				Version:         m.Version,
 			},
 			priority,
 			m.Id,
+		}
+		// TODO (anastasiamac 2016-08-24) This is a band-aid solution.
+		// Once correct value is read from simplestreams, this needs to go.
+		// Bug# 1616295
+		if result.Stream == "" {
+			result.Stream = constraint.Stream
+		}
+		if result.Stream == "" {
+			result.Stream = cfg.ImageStream()
 		}
 		return result
 	}
@@ -530,7 +540,7 @@ func (p *ProvisionerAPI) imageMetadataFromDataSources(env environs.Environ, cons
 				logger.Warningf("could not determine series for image id %s: %v", m.Id, err)
 				continue
 			}
-			metadataState = append(metadataState, toModel(m, mSeries, info.Source, info.Stream, source.Priority()))
+			metadataState = append(metadataState, toModel(m, mSeries, info.Source, source.Priority()))
 		}
 	}
 	if len(metadataState) > 0 {

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -560,17 +560,14 @@ func bootstrapImageMetadata(
 	// Since order of data source matters, order of image metadata matters too. Append is important here.
 	var publicImageMetadata []*imagemetadata.ImageMetadata
 	for _, source := range sources {
-		sourceMetadata, info, err := imagemetadata.Fetch([]simplestreams.DataSource{source}, imageConstraint)
+		sourceMetadata, _, err := imagemetadata.Fetch([]simplestreams.DataSource{source}, imageConstraint)
 		if err != nil {
 			logger.Debugf("ignoring image metadata in %s: %v", source.Description(), err)
 			// Just keep looking...
 			continue
 		}
 		logger.Debugf("found %d image metadata in %s", len(sourceMetadata), source.Description())
-		for _, metadata := range sourceMetadata {
-			metadata.Stream = info.Stream
-			publicImageMetadata = append(publicImageMetadata, metadata)
-		}
+		publicImageMetadata = append(publicImageMetadata, sourceMetadata...)
 	}
 
 	logger.Debugf("found %d image metadata from all image data sources", len(publicImageMetadata))

--- a/environs/imagemetadata/generate_test.go
+++ b/environs/imagemetadata/generate_test.go
@@ -28,12 +28,11 @@ func assertFetch(c *gc.C, stor storage.Storage, series, arch, region, endpoint s
 		Arches:    []string{arch},
 	})
 	dataSource := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "images", simplestreams.DEFAULT_CLOUD_DATA, false)
-	metadata, info, err := imagemetadata.Fetch([]simplestreams.DataSource{dataSource}, cons)
+	metadata, _, err := imagemetadata.Fetch([]simplestreams.DataSource{dataSource}, cons)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metadata, gc.HasLen, len(ids))
 	for i, id := range ids {
 		c.Assert(metadata[i].Id, gc.Equals, id)
-		metadata[i].Stream = info.Stream
 	}
 }
 

--- a/environs/imagemetadata/simplestreams_test.go
+++ b/environs/imagemetadata/simplestreams_test.go
@@ -305,7 +305,6 @@ func (s *simplestreamsSuite) TestFetch(c *gc.C) {
 			Signed:    s.RequireSigned,
 			IndexURL:  "test:/streams/v1/index.json",
 			MirrorURL: "",
-			Stream:    "released",
 		})
 	}
 }
@@ -405,7 +404,6 @@ func (s *signedSuite) TestSignedImageMetadata(c *gc.C) {
 		Signed:    true,
 		IndexURL:  "test://host/signed/streams/v1/index.sjson",
 		MirrorURL: "",
-		Stream:    "released",
 	})
 }
 

--- a/environs/imagemetadata/validation_test.go
+++ b/environs/imagemetadata/validation_test.go
@@ -70,7 +70,6 @@ func (s *ValidateSuite) assertMatch(c *gc.C, stream string) {
 		Signed:    false,
 		IndexURL:  utils.MakeFileURL(path.Join(metadataPath, "streams/v1/index.json")),
 		MirrorURL: "",
-		Stream:    "custom",
 	})
 }
 

--- a/environs/simplestreams/simplestreams_test.go
+++ b/environs/simplestreams/simplestreams_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/simplestreams"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 )
@@ -25,9 +24,18 @@ func Test(t *testing.T) {
 func registerSimpleStreamsTests() {
 	gc.Suite(&simplestreamsSuite{
 		LocalLiveSimplestreamsSuite: sstesting.LocalLiveSimplestreamsSuite{
+			Source:         simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false),
 			RequireSigned:  false,
 			DataType:       "image-ids",
 			StreamsVersion: "v1",
+			ValidConstraint: sstesting.NewTestConstraint(simplestreams.LookupParams{
+				CloudSpec: simplestreams.CloudSpec{
+					Region:   "us-east-1",
+					Endpoint: "https://ec2.us-east-1.amazonaws.com",
+				},
+				Series: []string{"precise"},
+				Arches: []string{"amd64", "arm"},
+			}),
 		},
 	})
 }
@@ -39,27 +47,6 @@ type simplestreamsSuite struct {
 
 func (s *simplestreamsSuite) SetUpSuite(c *gc.C) {
 	s.LocalLiveSimplestreamsSuite.SetUpSuite(c)
-	s.TestDataSuite.SetUpSuite(c)
-}
-
-func (s *simplestreamsSuite) SetUpTest(c *gc.C) {
-	s.LocalLiveSimplestreamsSuite.SetUpTest(c)
-
-	s.LocalLiveSimplestreamsSuite.Source = simplestreams.NewURLDataSource(
-		"test",
-		"test:",
-		utils.VerifySSLHostnames,
-		simplestreams.DEFAULT_CLOUD_DATA, false)
-
-	s.LocalLiveSimplestreamsSuite.ValidConstraint = sstesting.NewTestConstraint(simplestreams.LookupParams{
-		CloudSpec: simplestreams.CloudSpec{
-			Region:   "us-east-1",
-			Endpoint: "https://ec2.us-east-1.amazonaws.com",
-		},
-		Series: []string{"precise"},
-		Arches: []string{"amd64", "arm"},
-	})
-
 	s.TestDataSuite.SetUpSuite(c)
 }
 
@@ -473,45 +460,6 @@ func (s *simplestreamsSuite) assertImageMetadata(c *gc.C, one storageVirtTest) {
 	ti := ic.Items[one.item].(*sstesting.TestItem)
 	c.Check(ti.Storage, gc.Equals, one.storage)
 	c.Check(ti.VirtType, gc.Equals, one.virt)
-}
-
-func (s *simplestreamsSuite) TestMetadataStreamFromProductName(c *gc.C) {
-	s.assertExpectedStreamFromGetMetadata(c, "released")
-}
-
-func (s *simplestreamsSuite) TestMetadataStreamEmptyInProductName(c *gc.C) {
-	testConstraints := sstesting.NewTestConstraint(simplestreams.LookupParams{
-		CloudSpec: s.ValidConstraint.Params().CloudSpec,
-		Series:    []string{"raring"},
-		Arches:    s.ValidConstraint.Params().Arches,
-	})
-	s.ValidConstraint = testConstraints
-	s.Source = simplestreams.NewURLDataSource("test", "test:/daily/", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false)
-	// even though stream is empty in simplestreams, it should be defaulted to "released"
-	s.assertExpectedStreamFromGetMetadata(c, "released")
-}
-
-func (s *simplestreamsSuite) assertExpectedStreamFromGetMetadata(c *gc.C, expectedStream string) {
-	filterFunc := func(source simplestreams.DataSource, prev []interface{}, images map[string]interface{}, cons simplestreams.LookupConstraint) ([]interface{}, error) {
-		result := []interface{}{}
-		for _, val := range images {
-			result = append(result, val)
-		}
-		return result, nil
-	}
-
-	params := simplestreams.GetMetadataParams{
-		StreamsVersion:   s.StreamsVersion,
-		LookupConstraint: s.ValidConstraint,
-		ValueParams: simplestreams.ValueParams{
-			DataType:      s.DataType,
-			FilterFunc:    filterFunc,
-			ValueTemplate: imagemetadata.ImageMetadata{},
-		},
-	}
-	_, info, err := simplestreams.GetMetadata([]simplestreams.DataSource{s.Source}, params)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(info.Stream, gc.Equals, expectedStream)
 }
 
 var getMirrorTests = []struct {

--- a/environs/simplestreams/testing/testing.go
+++ b/environs/simplestreams/testing/testing.go
@@ -590,34 +590,6 @@ var imageData = map[string]string{
  },
  "format": "products:1.0"
 }
-`, "/daily/streams/v1/raring_metadata.json": `
-{
- "updated": "Wed, 01 May 2013 13:31:26 +0000",
- "content_id": "com.ubuntu.cloud",
- "region": "nz-east-1",
- "endpoint": "https://anywhere",
- "root_store": "ebs",
- "virt": "pv", 
- "products": {
-  "com.ubuntu.cloud:server:13.04:amd64": {
-   "release": "raring",
-   "version": "13.04",
-   "arch": "amd64",
-   "versions": {
-    "20160318": {
-     "items": {
-      "nzww1pe": {
-       "id": "ami-36745463"
-      }
-     },
-     "pubname": "ubuntu-utopic-13.04-amd64-server-20160318",
-     "label": "release"
-    }
-   }
-  }
- },
- "format": "products:1.0"
-}
 `,
 }
 

--- a/environs/tools/simplestreams_test.go
+++ b/environs/tools/simplestreams_test.go
@@ -278,7 +278,6 @@ func (s *simplestreamsSuite) TestFetch(c *gc.C) {
 			Signed:    s.RequireSigned,
 			IndexURL:  "test:/streams/v1/index.json",
 			MirrorURL: "",
-			Stream:    "tools",
 		})
 	}
 }
@@ -324,7 +323,6 @@ func (s *simplestreamsSuite) TestFetchWithMirror(c *gc.C) {
 		Signed:    s.RequireSigned,
 		IndexURL:  "test:/streams/v1/index.json",
 		MirrorURL: "test:/",
-		Stream:    "tools",
 	})
 }
 
@@ -1079,7 +1077,6 @@ func (s *signedSuite) TestSignedToolsMetadata(c *gc.C) {
 		Signed:    true,
 		IndexURL:  "signedtest://host/signed/streams/v1/index.sjson",
 		MirrorURL: "",
-		Stream:    "released",
 	})
 }
 

--- a/environs/tools/validation_test.go
+++ b/environs/tools/validation_test.go
@@ -74,7 +74,6 @@ func (s *ValidateSuite) TestExactVersionMatch(c *gc.C) {
 		Signed:    false,
 		IndexURL:  utils.MakeFileURL(path.Join(s.metadataDir, "tools/streams/v1/index2.json")),
 		MirrorURL: "",
-		Stream:    "released",
 	})
 }
 
@@ -101,7 +100,6 @@ func (s *ValidateSuite) TestMajorVersionMatch(c *gc.C) {
 		Signed:    false,
 		IndexURL:  utils.MakeFileURL(path.Join(s.metadataDir, "tools/streams/v1/index2.json")),
 		MirrorURL: "",
-		Stream:    "released",
 	})
 }
 
@@ -128,7 +126,6 @@ func (s *ValidateSuite) TestMajorMinorVersionMatch(c *gc.C) {
 		Signed:    false,
 		IndexURL:  utils.MakeFileURL(path.Join(s.metadataDir, "tools/streams/v1/index2.json")),
 		MirrorURL: "",
-		Stream:    "released",
 	})
 }
 

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -225,12 +225,9 @@ func SetImageMetadata(env environs.Environ, series, arches []string, out *[]*ima
 		Arches:    arches,
 		Stream:    env.Config().ImageStream(),
 	})
-	imageMetadata, info, err := imagemetadata.Fetch(sources, imageConstraint)
+	imageMetadata, _, err := imagemetadata.Fetch(sources, imageConstraint)
 	if err != nil {
 		return errors.Trace(err)
-	}
-	for _, metadata := range imageMetadata {
-		metadata.Stream = info.Stream
 	}
 	*out = imageMetadata
 	return nil


### PR DESCRIPTION
The change is causing this CI test regression: https://launchpad.net/bugs/1623560

Reverts the following commits:
693ef8e 4ed0d8f 91f14f0 35a7f8b

These are all the commits in merge commit c46ddff.

(Review request: http://reviews.vapour.ws/r/5682/)