### PR TITLE
provider/azure: discover AD/auth URL

### DIFF
--- a/api/deployer/deployer_test.go
+++ b/api/deployer/deployer_test.go
@@ -242,7 +242,7 @@ func (s *deployerSuite) TestStateAddresses(c *gc.C) {
 func (s *deployerSuite) TestUnitSetStatus(c *gc.C) {
 	unit, err := s.st.Unit(s.principal.Tag().(names.UnitTag))
 	c.Assert(err, jc.ErrorIsNil)
-	err = unit.SetStatus(status.StatusBlocked, "waiting", map[string]interface{}{"foo": "bar"})
+	err = unit.SetStatus(status.Blocked, "waiting", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	stateUnit, err := s.BackingState.Unit(unit.Name())
@@ -251,7 +251,7 @@ func (s *deployerSuite) TestUnitSetStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	sInfo.Since = nil
 	c.Assert(sInfo, jc.DeepEquals, status.StatusInfo{
-		Status:  status.StatusBlocked,
+		Status:  status.Blocked,
 		Message: "waiting",
 		Data:    map[string]interface{}{"foo": "bar"},
 	})

--- a/apiserver/deployer/deployer_test.go
+++ b/apiserver/deployer/deployer_test.go
@@ -377,7 +377,7 @@ func (s *deployerSuite) TestSetStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	sInfo.Since = nil
 	c.Assert(sInfo, jc.DeepEquals, status.StatusInfo{
-		Status:  status.StatusBlocked,
+		Status:  status.Blocked,
 		Message: "waiting",
 		Data:    map[string]interface{}{"foo": "bar"},
 	})

--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -55,75 +55,75 @@ clouds:
       centralus:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       eastus:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       eastus2:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       northcentralus:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       southcentralus:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       westus:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       northeurope:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       westeurope:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       eastasia:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       southeastasia:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       japaneast:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       japanwest:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       brazilsouth:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       australiaeast:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       australiasoutheast:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       centralindia:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       southindia:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       westindia:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
   azure-china:
     type: azure
     auth-types: [ userpass ]
@@ -131,11 +131,11 @@ clouds:
       chinaeast:
         endpoint: https://management.chinacloudapi.cn
         storage-endpoint: https://core.chinacloudapi.cn
-        identity-endpoint: https://login.chinacloudapi.cn
+        identity-endpoint: https://graph.chinacloudapi.cn
       chinanorth:
         endpoint: https://management.chinacloudapi.cn
         storage-endpoint: https://core.chinacloudapi.cn
-        identity-endpoint: https://login.chinacloudapi.cn
+        identity-endpoint: https://graph.chinacloudapi.cn
   rackspace:
     type: rackspace
     auth-types: [ access-key, userpass ]

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -62,75 +62,75 @@ clouds:
       centralus:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       eastus:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       eastus2:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       northcentralus:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       southcentralus:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       westus:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       northeurope:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       westeurope:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       eastasia:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       southeastasia:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       japaneast:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       japanwest:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       brazilsouth:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       australiaeast:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       australiasoutheast:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       centralindia:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       southindia:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
       westindia:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://login.microsoftonline.com
+        identity-endpoint: https://graph.windows.net
   azure-china:
     type: azure
     auth-types: [ userpass ]
@@ -138,11 +138,11 @@ clouds:
       chinaeast:
         endpoint: https://management.chinacloudapi.cn
         storage-endpoint: https://core.chinacloudapi.cn
-        identity-endpoint: https://login.chinacloudapi.cn
+        identity-endpoint: https://graph.chinacloudapi.cn
       chinanorth:
         endpoint: https://management.chinacloudapi.cn
         storage-endpoint: https://core.chinacloudapi.cn
-        identity-endpoint: https://login.chinacloudapi.cn
+        identity-endpoint: https://graph.chinacloudapi.cn
   rackspace:
     type: rackspace
     auth-types: [ access-key, userpass ]

--- a/cmd/juju/backups/export_test.go
+++ b/cmd/juju/backups/export_test.go
@@ -72,7 +72,7 @@ func NewRestoreCommandForTest(
 	api RestoreAPI,
 	getArchive func(string) (ArchiveReader, *params.BackupsMetadataResult, error),
 	newEnviron func(environs.OpenParams) (environs.Environ, error),
-	getRebootstrapParams func(string, *params.BackupsMetadataResult) (*restoreBootstrapParams, error),
+	getRebootstrapParams func(*cmd.Context, string, *params.BackupsMetadataResult) (*restoreBootstrapParams, error),
 ) cmd.Command {
 	c := &restoreCommand{
 		getArchiveFunc:           getArchive,
@@ -102,8 +102,8 @@ func GetEnvironFunc(e environs.Environ) func(environs.OpenParams) (environs.Envi
 	}
 }
 
-func GetRebootstrapParamsFunc(cloud string) func(string, *params.BackupsMetadataResult) (*restoreBootstrapParams, error) {
-	return func(string, *params.BackupsMetadataResult) (*restoreBootstrapParams, error) {
+func GetRebootstrapParamsFunc(cloud string) func(*cmd.Context, string, *params.BackupsMetadataResult) (*restoreBootstrapParams, error) {
+	return func(*cmd.Context, string, *params.BackupsMetadataResult) (*restoreBootstrapParams, error) {
 		return &restoreBootstrapParams{
 			ControllerConfig: testing.FakeControllerConfig(),
 			Cloud: environs.CloudSpec{
@@ -115,8 +115,8 @@ func GetRebootstrapParamsFunc(cloud string) func(string, *params.BackupsMetadata
 	}
 }
 
-func GetRebootstrapParamsFuncWithError() func(string, *params.BackupsMetadataResult) (*restoreBootstrapParams, error) {
-	return func(string, *params.BackupsMetadataResult) (*restoreBootstrapParams, error) {
+func GetRebootstrapParamsFuncWithError() func(*cmd.Context, string, *params.BackupsMetadataResult) (*restoreBootstrapParams, error) {
+	return func(*cmd.Context, string, *params.BackupsMetadataResult) (*restoreBootstrapParams, error) {
 		return nil, errors.New("failed")
 	}
 }

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -56,7 +56,7 @@ type restoreCommand struct {
 
 	newAPIClientFunc         func() (RestoreAPI, error)
 	newEnvironFunc           func(environs.OpenParams) (environs.Environ, error)
-	getRebootstrapParamsFunc func(string, *params.BackupsMetadataResult) (*restoreBootstrapParams, error)
+	getRebootstrapParamsFunc func(*cmd.Context, string, *params.BackupsMetadataResult) (*restoreBootstrapParams, error)
 	getArchiveFunc           func(string) (ArchiveReader, *params.BackupsMetadataResult, error)
 	waitForAgentFunc         func(ctx *cmd.Context, c *modelcmd.ModelCommandBase, controllerName, hostedModelName string) error
 }
@@ -147,7 +147,7 @@ type restoreBootstrapParams struct {
 // getRebootstrapParams returns the params for rebootstrapping the
 // specified controller.
 func (c *restoreCommand) getRebootstrapParams(
-	controllerName string, meta *params.BackupsMetadataResult,
+	ctx *cmd.Context, controllerName string, meta *params.BackupsMetadataResult,
 ) (*restoreBootstrapParams, error) {
 	// TODO(axw) delete this and -b. We will update bootstrap with a flag
 	// to specify a restore file. When we do that, we'll need to extract
@@ -160,7 +160,7 @@ func (c *restoreCommand) getRebootstrapParams(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	config, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(store)(controllerName)
+	config, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(ctx, store)(controllerName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -219,7 +219,7 @@ func (c *restoreCommand) getRebootstrapParams(
 // rebootstrap will bootstrap a new server in safe-mode (not killing any other agent)
 // if there is no current server available to restore to.
 func (c *restoreCommand) rebootstrap(ctx *cmd.Context, meta *params.BackupsMetadataResult) error {
-	params, err := c.getRebootstrapParamsFunc(c.ControllerName(), meta)
+	params, err := c.getRebootstrapParamsFunc(ctx, c.ControllerName(), meta)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -390,7 +390,7 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	store := c.ClientStore()
 	var detectedCredentialName string
 	credential, credentialName, regionName, err := modelcmd.GetCredentials(
-		store, c.Region, c.CredentialName, c.Cloud, cloud.Type,
+		ctx, store, c.Region, c.CredentialName, c.Cloud, cloud.Type,
 	)
 	if errors.Cause(err) == modelcmd.ErrMultipleCredentials {
 		return ambiguousCredentialError

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -839,7 +839,9 @@ func (s *BootstrapSuite) TestAutoSyncLocalSource(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	bootstrapConfig, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(s.store)("devcontroller")
+	bootstrapConfig, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(
+		coretesting.Context(c), s.store,
+	)("devcontroller")
 	c.Assert(err, jc.ErrorIsNil)
 	provider, err := environs.Provider(bootstrapConfig.CloudType)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -426,7 +426,7 @@ func (c *addModelCommand) maybeUploadCredential(
 
 	// Upload the credential from the client, if it exists locally.
 	credential, _, _, err := modelcmd.GetCredentials(
-		c.ClientStore(), c.CloudRegion, credentialTag.Name(),
+		ctx, c.ClientStore(), c.CloudRegion, credentialTag.Name(),
 		cloudTag.Id(), cloud.Type,
 	)
 	if err != nil {

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -125,7 +125,7 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	defer api.Close()
 
 	// Obtain controller environ so we can clean up afterwards.
-	controllerEnviron, err := c.getControllerEnviron(store, controllerName, api)
+	controllerEnviron, err := c.getControllerEnviron(ctx, store, controllerName, api)
 	if err != nil {
 		return errors.Annotate(err, "getting controller environ")
 	}
@@ -308,11 +308,12 @@ func (c *destroyCommandBase) Init(args []string) error {
 // Environ by first checking the config store, then querying the
 // API if the information is not in the store.
 func (c *destroyCommandBase) getControllerEnviron(
+	ctx *cmd.Context,
 	store jujuclient.ClientStore,
 	controllerName string,
 	sysAPI destroyControllerAPI,
 ) (environs.Environ, error) {
-	env, err := c.getControllerEnvironFromStore(store, controllerName)
+	env, err := c.getControllerEnvironFromStore(ctx, store, controllerName)
 	if errors.IsNotFound(err) {
 		return c.getControllerEnvironFromAPI(sysAPI, controllerName)
 	} else if err != nil {
@@ -322,10 +323,11 @@ func (c *destroyCommandBase) getControllerEnviron(
 }
 
 func (c *destroyCommandBase) getControllerEnvironFromStore(
+	ctx *cmd.Context,
 	store jujuclient.ClientStore,
 	controllerName string,
 ) (environs.Environ, error) {
-	bootstrapConfig, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(store)(controllerName)
+	bootstrapConfig, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(ctx, store)(controllerName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -102,7 +102,7 @@ func (c *killCommand) Run(ctx *cmd.Context) error {
 	}
 
 	// Obtain controller environ so we can clean up afterwards.
-	controllerEnviron, err := c.getControllerEnviron(store, controllerName, api)
+	controllerEnviron, err := c.getControllerEnviron(ctx, store, controllerName, api)
 	if err != nil {
 		return errors.Annotate(err, "getting controller environ")
 	}

--- a/cmd/modelcmd/credentials.go
+++ b/cmd/modelcmd/credentials.go
@@ -6,6 +6,7 @@ package modelcmd
 import (
 	"io/ioutil"
 
+	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/utils"
 
@@ -25,7 +26,9 @@ var (
 // finalises the values to resolve things like json files.
 // If region is not specified, the default credential region is used.
 func GetCredentials(
-	store jujuclient.CredentialGetter, region, credentialName, cloudName, cloudType string,
+	ctx *cmd.Context,
+	store jujuclient.CredentialGetter,
+	region, credentialName, cloudName, cloudType string,
 ) (_ *cloud.Credential, chosenCredentialName, regionName string, _ error) {
 
 	credential, credentialName, defaultRegion, err := credentialByName(
@@ -59,10 +62,11 @@ func GetCredentials(
 	)
 	if err != nil {
 		return nil, "", "", errors.Annotatef(
-			err, "validating %q credential for cloud %q",
+			err, "finalizing %q credential for cloud %q",
 			credentialName, cloudName,
 		)
 	}
+	// TODO(axw) call provider.FinalizeCredential
 	return credential, credentialName, regionName, nil
 }
 

--- a/cmd/modelcmd/credentials_test.go
+++ b/cmd/modelcmd/credentials_test.go
@@ -70,7 +70,7 @@ func (s *credentialsSuite) assertGetCredentials(c *gc.C, region string) {
 	}
 
 	credential, credentialName, regionName, err := modelcmd.GetCredentials(
-		store, region, "secrets", "cloud", "fake",
+		testing.Context(c), store, region, "secrets", "cloud", "fake",
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedRegion := region

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -31,7 +31,7 @@ func (c *imageMetadataCommandBase) prepare(context *cmd.Context) (environs.Envir
 	// NOTE(axw) this is a work-around for the TODO below. This
 	// means that the command will only work if you've bootstrapped
 	// the specified environment.
-	bootstrapConfig, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(c.ClientStore())(c.ControllerName())
+	bootstrapConfig, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(context, c.ClientStore())(c.ControllerName())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/plugins/juju-metadata/validateimagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata_test.go
@@ -130,7 +130,6 @@ func cacheTestEnvConfig(c *gc.C, store *jujuclienttesting.MemStore) {
 		"subscription-id":      "foo",
 		"application-id":       "bar",
 		"application-password": "baz",
-		"tenant-id":            "qux",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	store.Controllers["azure-controller"] = jujuclient.ControllerDetails{
@@ -158,7 +157,6 @@ func cacheTestEnvConfig(c *gc.C, store *jujuclienttesting.MemStore) {
 				map[string]string{
 					"application-id":       "application-id",
 					"subscription-id":      "subscription-id",
-					"tenant-id":            "tenant-id",
 					"application-password": "application-password",
 				},
 			),

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -4,6 +4,8 @@
 package environs
 
 import (
+	"io"
+
 	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/cloud"
@@ -88,6 +90,19 @@ type ProviderCredentials interface {
 	// If no credentials can be detected, DetectCredentials should
 	// return an error satisfying errors.IsNotFound.
 	DetectCredentials() (*cloud.CloudCredential, error)
+
+	// FinalizeCredential finalizes a credential, updating any attributes
+	// as necessary. This is always done client-side, before uploading
+	// credentials to the controller. The provider may completely alter
+	// a credential, even going as far as changing the auth-type, but
+	// the output must be a fully formed credential.
+	FinalizeCredential(FinalizeCredentialContext, cloud.Credential) (cloud.Credential, error)
+}
+
+// FinalizeCredentialContext is an interface passed into FinalizeCredential
+// to provide a means of interacting with the user when finalizing credentials.
+type FinalizeCredentialContext interface {
+	GetStderr() io.Writer
 }
 
 // CloudRegionDetector is an interface that an EnvironProvider implements

--- a/provider/azure/auth.go
+++ b/provider/azure/auth.go
@@ -1,0 +1,122 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azure
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/provider/azure/internal/ad"
+)
+
+// cloudSpecAuth is an implementation of autorest.Authorizer.
+type cloudSpecAuth struct {
+	cloud  environs.CloudSpec
+	sender autorest.Sender
+	mu     sync.Mutex
+	token  *azure.ServicePrincipalToken
+}
+
+// WithAuthorization is part of the autorest.Authorizer interface.
+func (c *cloudSpecAuth) WithAuthorization() autorest.PrepareDecorator {
+	return func(p autorest.Preparer) autorest.Preparer {
+		return autorest.PreparerFunc(func(r *http.Request) (*http.Request, error) {
+			r, err := p.Prepare(r)
+			if err != nil {
+				return nil, err
+			}
+			token, err := c.getToken()
+			if err != nil {
+				return nil, err
+			}
+			return autorest.CreatePreparer(token.WithAuthorization()).Prepare(r)
+		})
+	}
+}
+
+func (c *cloudSpecAuth) refresh() error {
+	token, err := c.getToken()
+	if err != nil {
+		return err
+	}
+	return token.Refresh()
+}
+
+func (c *cloudSpecAuth) getToken() (*azure.ServicePrincipalToken, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.token != nil {
+		return c.token, nil
+	}
+	token, err := AuthToken(c.cloud, c.sender)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	c.token = token
+	return c.token, nil
+}
+
+// AuthToken returns a service principal token, suitable for authorizing
+// Resource Manager API requests, based on the supplied CloudSpec.
+func AuthToken(cloud environs.CloudSpec, sender autorest.Sender) (*azure.ServicePrincipalToken, error) {
+	credAttrs := cloud.Credential.Attributes()
+	subscriptionId := credAttrs[credAttrSubscriptionId]
+	appId := credAttrs[credAttrAppId]
+	appPassword := credAttrs[credAttrAppPassword]
+
+	subscriptionsClient := subscriptions.Client{
+		subscriptions.NewWithBaseURI(cloud.Endpoint),
+	}
+	if sender != nil {
+		subscriptionsClient.Sender = sender
+	}
+	authURI, err := ad.DiscoverAuthorizationURI(subscriptionsClient, subscriptionId)
+	if err != nil {
+		return nil, errors.Annotate(err, "detecting auth URI")
+	}
+	logger.Debugf("discovered auth URI: %s", authURI)
+
+	// The authorization URI scheme and host identifies the AD endpoint.
+	// The authorization URI path identifies the AD tenant.
+	tenantId, err := ad.AuthorizationURITenantID(authURI)
+	if err != nil {
+		return nil, errors.Annotate(err, "getting tenant ID")
+	}
+	authURI.Path = ""
+	adEndpoint := authURI.String()
+
+	cloudEnv := azure.Environment{ActiveDirectoryEndpoint: adEndpoint}
+	oauthConfig, err := cloudEnv.OAuthConfigForTenant(tenantId)
+	if err != nil {
+		return nil, errors.Annotate(err, "getting OAuth configuration")
+	}
+
+	// We want to create a service principal token for the resource
+	// manager endpoint. Azure demands that the URL end with a '/'.
+	resource := cloud.Endpoint
+	if !strings.HasSuffix(resource, "/") {
+		resource += "/"
+	}
+
+	token, err := azure.NewServicePrincipalToken(
+		*oauthConfig,
+		appId,
+		appPassword,
+		resource,
+	)
+	if err != nil {
+		return nil, errors.Annotate(err, "constructing service principal token")
+	}
+	if sender != nil {
+		token.SetSender(sender)
+	}
+	return token, nil
+}

--- a/provider/azure/config_test.go
+++ b/provider/azure/config_test.go
@@ -16,7 +16,6 @@ import (
 
 const (
 	fakeApplicationId     = "00000000-0000-0000-0000-000000000000"
-	fakeTenantId          = "11111111-1111-1111-1111-111111111111"
 	fakeSubscriptionId    = "22222222-2222-2222-2222-222222222222"
 	fakeStorageAccountKey = "quay"
 )

--- a/provider/azure/credentials.go
+++ b/provider/azure/credentials.go
@@ -7,12 +7,12 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 )
 
 const (
 	credAttrAppId          = "application-id"
 	credAttrSubscriptionId = "subscription-id"
-	credAttrTenantId       = "tenant-id"
 	credAttrAppPassword    = "application-password"
 )
 
@@ -30,8 +30,6 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 			}, {
 				credAttrSubscriptionId, cloud.CredentialAttr{Description: "Azure subscription ID"},
 			}, {
-				credAttrTenantId, cloud.CredentialAttr{Description: "Azure Active Directory tenant ID"},
-			}, {
 				credAttrAppPassword, cloud.CredentialAttr{
 					Description: "Azure Active Directory application password",
 					Hidden:      true,
@@ -44,4 +42,9 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 // DetectCredentials is part of the environs.ProviderCredentials interface.
 func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
 	return nil, errors.NotFoundf("credentials")
+}
+
+// FinalizeCredential is part of the environs.ProviderCredentials interface.
+func (environProviderCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
+	return in, nil
 }

--- a/provider/azure/credentials_test.go
+++ b/provider/azure/credentials_test.go
@@ -34,7 +34,6 @@ var sampleCredentialAttributes = map[string]string{
 	"application-id":       "application",
 	"application-password": "password",
 	"subscription-id":      "subscription",
-	"tenant-id":            "tenant",
 }
 
 func (s *credentialsSuite) TestUserPassCredentialsValid(c *gc.C) {
@@ -42,7 +41,6 @@ func (s *credentialsSuite) TestUserPassCredentialsValid(c *gc.C) {
 		"application-id":       "application",
 		"application-password": "password",
 		"subscription-id":      "subscription",
-		"tenant-id":            "tenant",
 	})
 }
 

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -109,5 +109,5 @@ func validateCloudSpec(spec environs.CloudSpec) error {
 // level.
 var verifyCredentials = func(e *azureEnviron) error {
 	// TODO(axw) user-friendly error message
-	return e.token.EnsureFresh()
+	return e.authorizer.refresh()
 }

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -57,7 +57,6 @@ func fakeUserPassCredential() *cloud.Credential {
 		map[string]string{
 			"application-id":       fakeApplicationId,
 			"subscription-id":      fakeSubscriptionId,
-			"tenant-id":            fakeTenantId,
 			"application-password": "opensezme",
 		},
 	)

--- a/provider/azure/export_test.go
+++ b/provider/azure/export_test.go
@@ -13,5 +13,5 @@ func ForceVolumeSourceTokenRefresh(vs storage.VolumeSource) error {
 }
 
 func ForceTokenRefresh(env environs.Environ) error {
-	return env.(*azureEnviron).token.Refresh()
+	return env.(*azureEnviron).authorizer.refresh()
 }

--- a/provider/azure/internal/ad/discovery.go
+++ b/provider/azure/internal/ad/discovery.go
@@ -1,0 +1,59 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ad
+
+import (
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions"
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+)
+
+const authenticateHeaderKey = "WWW-Authenticate"
+
+var authorizationUriRegexp = regexp.MustCompile(`authorization_uri="([^"]*)"`)
+
+// DiscoverAuthorizationID returns the OAuth authorization URI for the given
+// subscription ID. This can be used to determine the AD tenant ID.
+func DiscoverAuthorizationURI(client subscriptions.Client, subscriptionID string) (*url.URL, error) {
+	// We make an unauthenticated request to the Azure API, which
+	// responds with the authentication URL with the tenant ID in it.
+	result, err := client.Get(subscriptionID)
+	if err == nil {
+		return nil, errors.New("expected unauthorized error response")
+	}
+	if result.Response.Response == nil {
+		return nil, errors.Trace(err)
+	}
+	if result.StatusCode != http.StatusUnauthorized {
+		return nil, errors.Annotatef(err, "expected unauthorized error response, got %v", result.StatusCode)
+	}
+
+	header := result.Header.Get(authenticateHeaderKey)
+	if header == "" {
+		return nil, errors.Errorf("%s header not found", authenticateHeaderKey)
+	}
+	match := authorizationUriRegexp.FindStringSubmatch(header)
+	if match == nil {
+		return nil, errors.Errorf(
+			"authorization_uri not found in %s header (%q)",
+			authenticateHeaderKey, header,
+		)
+	}
+	return url.Parse(match[1])
+}
+
+// AuthorizationURITenantID returns the tenant ID portion of the given URL,
+// which is expected to have come from DiscoverAuthorizationURI.
+func AuthorizationURITenantID(url *url.URL) (string, error) {
+	path := strings.TrimPrefix(url.Path, "/")
+	if _, err := utils.UUIDFromString(path); err != nil {
+		return "", errors.NotValidf("authorization_uri %q", url)
+	}
+	return path, nil
+}

--- a/provider/azure/internal/ad/discovery_test.go
+++ b/provider/azure/internal/ad/discovery_test.go
@@ -1,0 +1,100 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ad_test
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions"
+	"github.com/Azure/go-autorest/autorest/mocks"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/provider/azure/internal/ad"
+)
+
+type DiscoverySuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&DiscoverySuite{})
+
+func (*DiscoverySuite) TestDiscoverAuthorizationURI(c *gc.C) {
+	sender := mocks.NewSender()
+	resp := mocks.NewResponseWithStatus("", http.StatusUnauthorized)
+	mocks.SetResponseHeaderValues(resp, "WWW-Authenticate", []string{
+		`foo bar authorization_uri="https://testing.invalid/meep" baz`,
+	})
+	sender.AppendResponse(resp)
+
+	client := subscriptions.NewClient()
+	client.Sender = sender
+	authURI, err := ad.DiscoverAuthorizationURI(client, "subscription_id")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(authURI, jc.DeepEquals, &url.URL{
+		Scheme: "https",
+		Host:   "testing.invalid",
+		Path:   "/meep",
+	})
+}
+
+func (*DiscoverySuite) TestDiscoverAuthorizationURIMissingHeader(c *gc.C) {
+	sender := mocks.NewSender()
+	resp := mocks.NewResponseWithStatus("", http.StatusUnauthorized)
+	sender.AppendResponse(resp)
+
+	client := subscriptions.NewClient()
+	client.Sender = sender
+	_, err := ad.DiscoverAuthorizationURI(client, "subscription_id")
+	c.Assert(err, gc.ErrorMatches, `WWW-Authenticate header not found`)
+}
+
+func (*DiscoverySuite) TestDiscoverAuthorizationURIHeaderMismatch(c *gc.C) {
+	sender := mocks.NewSender()
+	resp := mocks.NewResponseWithStatus("", http.StatusUnauthorized)
+	mocks.SetResponseHeaderValues(resp, "WWW-Authenticate", []string{`foo bar baz`})
+	sender.AppendResponse(resp)
+
+	client := subscriptions.NewClient()
+	client.Sender = sender
+	_, err := ad.DiscoverAuthorizationURI(client, "subscription_id")
+	c.Assert(err, gc.ErrorMatches, `authorization_uri not found in WWW-Authenticate header \("foo bar baz"\)`)
+}
+
+func (*DiscoverySuite) TestDiscoverAuthorizationURIUnexpectedSuccess(c *gc.C) {
+	sender := mocks.NewSender()
+	resp := mocks.NewResponseWithStatus("", http.StatusOK)
+	sender.AppendResponse(resp)
+
+	client := subscriptions.NewClient()
+	client.Sender = sender
+	_, err := ad.DiscoverAuthorizationURI(client, "subscription_id")
+	c.Assert(err, gc.ErrorMatches, "expected unauthorized error response")
+}
+
+func (*DiscoverySuite) TestDiscoverAuthorizationURIUnexpectedStatusCode(c *gc.C) {
+	sender := mocks.NewSender()
+	resp := mocks.NewResponseWithStatus("", http.StatusNotFound)
+	sender.AppendResponse(resp)
+
+	client := subscriptions.NewClient()
+	client.Sender = sender
+	_, err := ad.DiscoverAuthorizationURI(client, "subscription_id")
+	c.Assert(err, gc.ErrorMatches, "expected unauthorized error response, got 404: .*")
+}
+
+func (*DiscoverySuite) TestAuthorizationURITenantID(c *gc.C) {
+	tenantId, err := ad.AuthorizationURITenantID(&url.URL{Path: "/3671f5a9-c0d0-472b-a80c-48135cf5a9f1"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tenantId, gc.Equals, "3671f5a9-c0d0-472b-a80c-48135cf5a9f1")
+}
+
+func (*DiscoverySuite) TestAuthorizationURITenantIDError(c *gc.C) {
+	url, err := url.Parse("https://testing.invalid/foo")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = ad.AuthorizationURITenantID(url)
+	c.Assert(err, gc.ErrorMatches, `authorization_uri "https://testing.invalid/foo" not valid`)
+}

--- a/provider/azure/internal/ad/package_test.go
+++ b/provider/azure/internal/ad/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ad_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/provider/azure/storage_test.go
+++ b/provider/azure/storage_test.go
@@ -61,7 +61,9 @@ func (s *storageSuite) volumeSource(c *gc.C, attrs ...testing.Attrs) storage.Vol
 
 	// Force an explicit refresh of the access token, so it isn't done
 	// implicitly during the tests.
-	s.sender = azuretesting.Senders{tokenRefreshSender()}
+	s.sender = azuretesting.Senders{
+		tokenRefreshSender(),
+	}
 	err = azure.ForceVolumeSourceTokenRefresh(volumeSource)
 	c.Assert(err, jc.ErrorIsNil)
 	return volumeSource

--- a/provider/cloudsigma/credentials.go
+++ b/provider/cloudsigma/credentials.go
@@ -6,6 +6,7 @@ package cloudsigma
 import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 )
 
 type environProviderCredentials struct{}
@@ -34,4 +35,9 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 // DetectCredentials is part of the environs.ProviderCredentials interface.
 func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
 	return nil, errors.NotFoundf("credentials")
+}
+
+// FinalizeCredential is part of the environs.ProviderCredentials interface.
+func (environProviderCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
+	return in, nil
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -562,6 +562,10 @@ func (*environProvider) DetectCredentials() (*cloud.CloudCredential, error) {
 	return cloud.NewEmptyCloudCredential(), nil
 }
 
+func (*environProvider) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
+	return in, nil
+}
+
 func (*environProvider) DetectRegions() ([]cloud.Region, error) {
 	return []cloud.Region{{Name: "dummy"}}, nil
 }

--- a/provider/ec2/credentials.go
+++ b/provider/ec2/credentials.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/ini.v1"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 )
 
 type environProviderCredentials struct{}
@@ -125,4 +126,9 @@ func (environProviderCredentials) detectEnvCredentials() (*cloud.CloudCredential
 		AuthCredentials: map[string]cloud.Credential{
 			user: accessKeyCredential,
 		}}, nil
+}
+
+// FinalizeCredential is part of the environs.ProviderCredentials interface.
+func (environProviderCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
+	return in, nil
 }

--- a/provider/gce/credentials.go
+++ b/provider/gce/credentials.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/utils"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/gce/google"
 )
 
@@ -135,4 +136,9 @@ func parseJSONAuthFile(r io.Reader) (cloud.Credential, error) {
 		credAttrClientEmail: creds.ClientEmail,
 		credAttrPrivateKey:  string(creds.PrivateKey),
 	}), nil
+}
+
+// FinalizeCredential is part of the environs.ProviderCredentials interface.
+func (environProviderCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
+	return in, nil
 }

--- a/provider/joyent/credentials.go
+++ b/provider/joyent/credentials.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 )
 
 const (
@@ -48,4 +49,9 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 // DetectCredentials is part of the environs.ProviderCredentials interface.
 func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
 	return nil, errors.NotFoundf("credentials")
+}
+
+// FinalizeCredential is part of the environs.ProviderCredentials interface.
+func (environProviderCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
+	return in, nil
 }

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -7,6 +7,7 @@ package lxd
 
 import (
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 )
 
 type environProviderCredentials struct{}
@@ -22,4 +23,9 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 // DetectCredentials is part of the environs.ProviderCredentials interface.
 func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
 	return cloud.NewEmptyCloudCredential(), nil
+}
+
+// FinalizeCredential is part of the environs.ProviderCredentials interface.
+func (environProviderCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
+	return in, nil
 }

--- a/provider/maas/credentials.go
+++ b/provider/maas/credentials.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/utils"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 )
 
 const (
@@ -82,3 +83,8 @@ func parseOAuthToken(cred cloud.Credential) (string, error) {
 }
 
 var errMalformedMaasOAuth = errors.New("malformed maas-oauth (3 items separated by colons)")
+
+// FinalizeCredential is part of the environs.ProviderCredentials interface.
+func (environProviderCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
+	return in, nil
+}

--- a/provider/manual/credentials.go
+++ b/provider/manual/credentials.go
@@ -5,6 +5,7 @@ package manual
 
 import (
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 )
 
 type environProviderCredentials struct{}
@@ -17,4 +18,9 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 // DetectCredentials is part of the environs.ProviderCredentials interface.
 func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
 	return cloud.NewEmptyCloudCredential(), nil
+}
+
+// FinalizeCredential is part of the environs.ProviderCredentials interface.
+func (environProviderCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
+	return in, nil
 }

--- a/provider/openstack/credentials.go
+++ b/provider/openstack/credentials.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/ini.v1"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 )
 
 const (
@@ -147,4 +148,9 @@ func (c OpenstackCredentials) detectCredential() (*cloud.Credential, string, str
 	}
 	credential.Label = fmt.Sprintf("openstack region %q project %q user %q", region, creds.TenantName, user)
 	return &credential, user, creds.Region, nil
+}
+
+// FinalizeCredential is part of the environs.ProviderCredentials interface.
+func (OpenstackCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
+	return in, nil
 }

--- a/provider/rackspace/provider_test.go
+++ b/provider/rackspace/provider_test.go
@@ -94,3 +94,8 @@ func (p *fakeProvider) DetectCredentials() (*cloud.CloudCredential, error) {
 	p.MethodCall(p, "DetectCredentials")
 	return nil, errors.NotFoundf("credentials")
 }
+
+func (p *fakeProvider) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
+	p.MethodCall(p, "FinalizeCredential", ctx, in)
+	return in, nil
+}

--- a/provider/vsphere/credentials.go
+++ b/provider/vsphere/credentials.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 )
 
 const (
@@ -37,4 +38,9 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 // DetectCredentials is part of the environs.ProviderCredentials interface.
 func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
 	return nil, errors.NotFoundf("credentials")
+}
+
+// FinalizeCredential is part of the environs.ProviderCredentials interface.
+func (environProviderCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
+	return in, nil
 }


### PR DESCRIPTION
This diff introduces several changes that will
be used for a new auth method for Azure.

- remove tenant-id, and instead we discover it along
  with the AD endpoint, using the subscription ID
- introduce a means for providers to transform
  credentials. Azure will be updated so that it
  supports device-code auth, which it will use to
  generate service principal / client-secret credentials
- change the identity-url for azure from the AD endpoint
  to the graph endpoint. We need the graph endpoint
  for making changes to AD.