### PR TITLE
provider/azure: update auth-types

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -50,7 +50,7 @@ clouds:
         endpoint: https://www.googleapis.com
   azure:
     type: azure
-    auth-types: [ userpass ]
+    auth-types: [ service-principal-secret, userpass ]
     regions:
       centralus:
         endpoint: https://management.azure.com
@@ -126,7 +126,7 @@ clouds:
         identity-endpoint: https://graph.windows.net
   azure-china:
     type: azure
-    auth-types: [ userpass ]
+    auth-types: [ service-principal-secret, userpass ]
     regions:
       chinaeast:
         endpoint: https://management.chinacloudapi.cn

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -57,7 +57,7 @@ clouds:
         endpoint: https://www.googleapis.com
   azure:
     type: azure
-    auth-types: [ userpass ]
+    auth-types: [ service-principal-secret, userpass ]
     regions:
       centralus:
         endpoint: https://management.azure.com
@@ -133,7 +133,7 @@ clouds:
         identity-endpoint: https://graph.windows.net
   azure-china:
     type: azure
-    auth-types: [ userpass ]
+    auth-types: [ service-principal-secret, userpass ]
     regions:
       chinaeast:
         endpoint: https://management.chinacloudapi.cn

--- a/cmd/modelcmd/credentials.go
+++ b/cmd/modelcmd/credentials.go
@@ -66,8 +66,14 @@ func GetCredentials(
 			credentialName, cloudName,
 		)
 	}
-	// TODO(axw) call provider.FinalizeCredential
-	return credential, credentialName, regionName, nil
+	finalizedCredential, err := provider.FinalizeCredential(ctx, *credential)
+	if err != nil {
+		return nil, "", "", errors.Annotatef(
+			err, "finalizing %q credential for cloud %q",
+			credentialName, cloudName,
+		)
+	}
+	return &finalizedCredential, credentialName, regionName, nil
 }
 
 // credentialByName returns the credential and default region to use for the

--- a/provider/azure/credentials.go
+++ b/provider/azure/credentials.go
@@ -4,6 +4,8 @@
 package azure
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/cloud"
@@ -13,7 +15,17 @@ import (
 const (
 	credAttrAppId          = "application-id"
 	credAttrSubscriptionId = "subscription-id"
+	credAttrTenantId       = "tenant-id"
 	credAttrAppPassword    = "application-password"
+
+	// clientCredentialsAuthType is the auth-type for the
+	// "client credentials" OAuth flow, which requires a
+	// service principal with a password.
+	clientCredentialsAuthType cloud.AuthType = "service-principal-secret"
+
+	// deviceCodeAuthType is the auth-type for the interactive
+	// "device code" OAuth flow.
+	deviceCodeAuthType cloud.AuthType = "interactive"
 )
 
 // environPoviderCredentials is an implementation of
@@ -24,7 +36,39 @@ type environProviderCredentials struct{}
 // CredentialSchemas is part of the environs.ProviderCredentials interface.
 func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
 	return map[cloud.AuthType]cloud.CredentialSchema{
+		// TODO(axw) 2016-09-15 #1623761
+		// UserPassAuthType is here for backwards
+		// compatibility. Drop it when rc1 is out.
 		cloud.UserPassAuthType: {
+			{
+				credAttrAppId, cloud.CredentialAttr{Description: "Azure Active Directory application ID"},
+			}, {
+				credAttrSubscriptionId, cloud.CredentialAttr{Description: "Azure subscription ID"},
+			}, {
+				credAttrTenantId, cloud.CredentialAttr{
+					Description: "Azure Active Directory tenant ID",
+					Optional:    true,
+				},
+			}, {
+				credAttrAppPassword, cloud.CredentialAttr{
+					Description: "Azure Active Directory application password",
+					Hidden:      true,
+				},
+			},
+		},
+
+		// deviceCodeAuthType is the interactive device-code oauth
+		// flow. This is only supported on the client side; it will
+		// be used to generate a service principal, and transformed
+		// into clientCredentialsAuthType.
+		deviceCodeAuthType: {{
+			credAttrSubscriptionId, cloud.CredentialAttr{Description: "Azure subscription ID"},
+		}},
+
+		// clientCredentialsAuthType is the "client credentials"
+		// oauth flow, which requires a service principal with a
+		// password.
+		clientCredentialsAuthType: {
 			{
 				credAttrAppId, cloud.CredentialAttr{Description: "Azure Active Directory application ID"},
 			}, {
@@ -46,5 +90,26 @@ func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, e
 
 // FinalizeCredential is part of the environs.ProviderCredentials interface.
 func (environProviderCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
-	return in, nil
+	switch authType := in.AuthType(); authType {
+	case cloud.UserPassAuthType:
+		fmt.Fprintf(ctx.GetStderr(), `
+WARNING: The %q auth-type is deprecated, and will be removed soon.
+
+Please update the credential in ~/.local/share/juju/credentials.yaml,
+changing auth-type to %q, and dropping the tenant-id field.
+
+`[1:],
+			authType, clientCredentialsAuthType,
+		)
+		attrs := in.Attributes()
+		delete(attrs, credAttrTenantId)
+		label := in.Label
+		in = cloud.NewCredential(clientCredentialsAuthType, attrs)
+		in.Label = label
+		return in, nil
+	case clientCredentialsAuthType:
+		return in, nil
+	default:
+		return cloud.Credential{}, errors.NotSupportedf("%q auth-type", authType)
+	}
 }

--- a/provider/azure/credentials_test.go
+++ b/provider/azure/credentials_test.go
@@ -8,6 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/provider/azure"
@@ -27,7 +28,11 @@ func (s *credentialsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *credentialsSuite) TestCredentialSchemas(c *gc.C) {
-	envtesting.AssertProviderAuthTypes(c, s.provider, "userpass")
+	envtesting.AssertProviderAuthTypes(c, s.provider,
+		"interactive",
+		"service-principal-secret",
+		"userpass",
+	)
 }
 
 var sampleCredentialAttributes = map[string]string{
@@ -41,14 +46,49 @@ func (s *credentialsSuite) TestUserPassCredentialsValid(c *gc.C) {
 		"application-id":       "application",
 		"application-password": "password",
 		"subscription-id":      "subscription",
+		"tenant-id":            "tenant",
 	})
 }
 
-func (s *credentialsSuite) TestUserPassHiddenAttributes(c *gc.C) {
-	envtesting.AssertProviderCredentialsAttributesHidden(c, s.provider, "userpass", "application-password")
+func (s *credentialsSuite) TestServicePrincipalSecretCredentialsValid(c *gc.C) {
+	envtesting.AssertProviderCredentialsValid(c, s.provider, "service-principal-secret", map[string]string{
+		"application-id":       "application",
+		"application-password": "password",
+		"subscription-id":      "subscription",
+	})
+}
+
+func (s *credentialsSuite) TestServicePrincipalSecretHiddenAttributes(c *gc.C) {
+	envtesting.AssertProviderCredentialsAttributesHidden(c, s.provider, "service-principal-secret", "application-password")
 }
 
 func (s *credentialsSuite) TestDetectCredentials(c *gc.C) {
 	_, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *credentialsSuite) TestFinalizeCredentialUserPass(c *gc.C) {
+	in := cloud.NewCredential("userpass", map[string]string{
+		"application-id":       "application",
+		"application-password": "password",
+		"subscription-id":      "subscription",
+		"tenant-id":            "tenant",
+	})
+	ctx := testing.Context(c)
+	out, err := s.provider.FinalizeCredential(ctx, in)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out.AuthType(), gc.Equals, cloud.AuthType("service-principal-secret"))
+	c.Assert(out.Attributes(), jc.DeepEquals, map[string]string{
+		"application-id":       "application",
+		"application-password": "password",
+		"subscription-id":      "subscription",
+	})
+	stderr := testing.Stderr(ctx)
+	c.Assert(stderr, gc.Equals, `
+WARNING: The "userpass" auth-type is deprecated, and will be removed soon.
+
+Please update the credential in ~/.local/share/juju/credentials.yaml,
+changing auth-type to "service-principal-secret", and dropping the tenant-id field.
+
+`[1:])
 }

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -264,7 +264,7 @@ func fakeCloudSpec() environs.CloudSpec {
 		Endpoint:         "https://api.azurestack.local",
 		IdentityEndpoint: "https://login.microsoftonline.com",
 		StorageEndpoint:  "https://storage.azurestack.local",
-		Credential:       fakeUserPassCredential(),
+		Credential:       fakeServicePrincipalCredential(),
 	}
 }
 

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils/clock"
 
-	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/provider/azure/internal/azurestorage"
@@ -97,7 +96,7 @@ func validateCloudSpec(spec environs.CloudSpec) error {
 	if spec.Credential == nil {
 		return errors.NotValidf("missing credential")
 	}
-	if authType := spec.Credential.AuthType(); authType != cloud.UserPassAuthType {
+	if authType := spec.Credential.AuthType(); authType != clientCredentialsAuthType {
 		return errors.NotSupportedf("%q auth-type", authType)
 	}
 	return nil

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -46,14 +46,14 @@ func (s *environProviderSuite) SetUpTest(c *gc.C) {
 		Endpoint:         "https://api.azurestack.local",
 		IdentityEndpoint: "https://login.azurestack.local",
 		StorageEndpoint:  "https://storage.azurestack.local",
-		Credential:       fakeUserPassCredential(),
+		Credential:       fakeServicePrincipalCredential(),
 	}
 	s.sender = nil
 }
 
-func fakeUserPassCredential() *cloud.Credential {
+func fakeServicePrincipalCredential() *cloud.Credential {
 	cred := cloud.NewCredential(
-		cloud.UserPassAuthType,
+		"service-principal-secret",
 		map[string]string{
 			"application-id":       fakeApplicationId,
 			"subscription-id":      fakeSubscriptionId,


### PR DESCRIPTION
We introduces two new auth-types, and deprecate
use of "userpass", for Azure. The userpass auth-type
is superseded by service-principal-secret, which is
identical except that it does not include the
tenant-id field. There is a new "interactive"
auth-type which is defined, but not yet supported.

If a user uses "userpass", they will receive a
warning explaining that it is deprecated, and what
they need to do to migrate. The credential will
continue to work, we'll just ignore the tenant-id.