### PR TITLE
provider/azure: fix race in tests

### DIFF
--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -967,11 +967,15 @@ func (s *environSuite) TestAllInstancesResourceGroupNotFound(c *gc.C) {
 
 func (s *environSuite) TestStopInstancesNotFound(c *gc.C) {
 	env := s.openEnviron(c)
-	sender := mocks.NewSender()
-	sender.AppendAndRepeatResponse(mocks.NewResponseWithStatus(
+	sender0 := mocks.NewSender()
+	sender0.AppendResponse(mocks.NewResponseWithStatus(
 		"vm not found", http.StatusNotFound,
-	), 2)
-	s.sender = azuretesting.Senders{sender, sender}
+	))
+	sender1 := mocks.NewSender()
+	sender1.AppendResponse(mocks.NewResponseWithStatus(
+		"vm not found", http.StatusNotFound,
+	))
+	s.sender = azuretesting.Senders{sender0, sender1}
 	err := env.StopInstances("a", "b")
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/provider/azure/tracing.go
+++ b/provider/azure/tracing.go
@@ -16,12 +16,14 @@ import (
 func tracingPrepareDecorator(logger loggo.Logger) autorest.PrepareDecorator {
 	return func(p autorest.Preparer) autorest.Preparer {
 		return autorest.PreparerFunc(func(r *http.Request) (*http.Request, error) {
-			dump, err := httputil.DumpRequest(r, true)
-			if err != nil {
-				logger.Tracef("failed to dump request: %v", err)
-				logger.Tracef("%+v", r)
-			} else {
-				logger.Tracef("%s", dump)
+			if logger.IsTraceEnabled() {
+				dump, err := httputil.DumpRequest(r, true)
+				if err != nil {
+					logger.Tracef("failed to dump request: %v", err)
+					logger.Tracef("%+v", r)
+				} else {
+					logger.Tracef("%s", dump)
+				}
 			}
 			return p.Prepare(r)
 		})
@@ -33,12 +35,14 @@ func tracingPrepareDecorator(logger loggo.Logger) autorest.PrepareDecorator {
 func tracingRespondDecorator(logger loggo.Logger) autorest.RespondDecorator {
 	return func(r autorest.Responder) autorest.Responder {
 		return autorest.ResponderFunc(func(resp *http.Response) error {
-			dump, err := httputil.DumpResponse(resp, true)
-			if err != nil {
-				logger.Tracef("failed to dump response: %v", err)
-				logger.Tracef("%+v", resp)
-			} else {
-				logger.Tracef("%s", dump)
+			if logger.IsTraceEnabled() {
+				dump, err := httputil.DumpResponse(resp, true)
+				if err != nil {
+					logger.Tracef("failed to dump response: %v", err)
+					logger.Tracef("%+v", resp)
+				} else {
+					logger.Tracef("%s", dump)
+				}
 			}
 			return r.Respond(resp)
 		})


### PR DESCRIPTION
Fix a test that was reusing a mock sender, which
is not goroutine-safe.

Drive-by: stop dumping request/response contents
if we're not trace-logging.

Fixes https://bugs.launchpad.net/juju/+bug/1623485