### PR TITLE
Add credential watcher to state

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -78,7 +78,7 @@ gopkg.in/juju/charmrepo.v2-unstable	git	73c1113f7ddee0306f4b3c19773d35a3f153c04a
 gopkg.in/juju/charmstore.v5-unstable	git	714c25cd43dbb8eb51f57a55d76d521fc2126455	2016-08-09T13:45:06Z
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/juju/jujusvg.v2	git	d82160011935ef79fc7aca84aba2c6f74700fe75	2016-06-09T10:52:15Z
-gopkg.in/juju/names.v2	git	fa4c1959bef64b8f18569dc83a85b25d15204503	2016-08-16T07:05:44Z
+gopkg.in/juju/names.v2	git	6f338bfd0b607bba6f80e8d512486ae49d3da2d4	2016-09-15T03:41:08Z
 gopkg.in/macaroon-bakery.v1	git	469b44e6f1f9479e115c8ae879ef80695be624d5	2016-06-22T12:14:21Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	f2b6f6c918c452ad107eec89615f074e3bd80e33	2016-08-18T01:52:18Z

--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -10,6 +10,8 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
 )
 
 type CloudCredentialsSuite struct {
@@ -61,6 +63,7 @@ func (s *CloudCredentialsSuite) TestUpdateCloudCredentialsExisting(c *gc.C) {
 		"user":     "bob's nephew",
 		"password": "simple",
 	})
+	cred.Revoked = true
 	err = s.State.UpdateCloudCredential(tag, cred)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -153,4 +156,53 @@ func (s *CloudCredentialsSuite) TestRemoveCredentials(c *gc.C) {
 	// Check it.
 	_, err = s.State.CloudCredential(tag)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *CloudCredentialsSuite) createCredentialWatcher(c *gc.C, st *state.State, cred names.CloudCredentialTag) (
+	state.NotifyWatcher, statetesting.NotifyWatcherC,
+) {
+	w := st.WatchCredential(cred)
+	s.AddCleanup(func(c *gc.C) { statetesting.AssertStop(c, w) })
+	return w, statetesting.NewNotifyWatcherC(c, st, w)
+}
+
+func (s *CloudCredentialsSuite) TestWatchCredential(c *gc.C) {
+	cred := names.NewCloudCredentialTag("dummy/fred/default")
+	w, wc := s.createCredentialWatcher(c, s.State, cred)
+	wc.AssertOneChange() // Initial event.
+
+	// Create
+	dummyCred := cloud.NewCredential(cloud.EmptyAuthType, nil)
+	err := s.State.UpdateCloudCredential(cred, dummyCred)
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+
+	// Revoke
+	dummyCred.Revoked = true
+	err = s.State.UpdateCloudCredential(cred, dummyCred)
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+
+	// Remove.
+	err = s.State.RemoveCloudCredential(cred)
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+
+	statetesting.AssertStop(c, w)
+	wc.AssertClosed()
+}
+
+func (s *CloudCredentialsSuite) TestWatchCredentialIgnoresOther(c *gc.C) {
+	cred := names.NewCloudCredentialTag("dummy/fred/default")
+	w, wc := s.createCredentialWatcher(c, s.State, cred)
+	wc.AssertOneChange() // Initial event.
+
+	anotherCred := names.NewCloudCredentialTag("dummy/mary/default")
+	dummyCred := cloud.NewCredential(cloud.EmptyAuthType, nil)
+	err := s.State.UpdateCloudCredential(anotherCred, dummyCred)
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertNoChange()
+
+	statetesting.AssertStop(c, w)
+	wc.AssertClosed()
 }


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju/+bug/1622789

Pulls in a dep change to allow credential names to contain @ and _.
Also adds a credential watcher to state.