### PR TITLE
Add credential watchers to provisioner and storageprovisioner api servers

### DIFF
--- a/worker/environ/environ.go
+++ b/worker/environ/environ.go
@@ -5,6 +5,7 @@ package environ
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/watcher"
@@ -16,6 +17,7 @@ import (
 type ConfigObserver interface {
 	environs.EnvironConfigGetter
 	WatchForModelConfigChanges() (watcher.NotifyWatcher, error)
+	WatchCredential(tag names.CloudCredentialTag) (watcher.NotifyWatcher, error)
 }
 
 // Config describes the dependencies of a Tracker.

--- a/worker/environ/environ_test.go
+++ b/worker/environ/environ_test.go
@@ -152,7 +152,7 @@ func (s *TrackerSuite) TestWatchCloses(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		defer workertest.DirtyKill(c, tracker)
 
-		context.CloseNotify()
+		context.CloseModelConfigNotify()
 		err = workertest.CheckKilled(c, tracker)
 		c.Check(err, gc.ErrorMatches, "environ config watch closed")
 		context.CheckCallNames(c, "ModelConfig", "CloudSpec", "WatchForModelConfigChanges")
@@ -173,7 +173,7 @@ func (s *TrackerSuite) TestWatchedModelConfigFails(c *gc.C) {
 		c.Check(err, jc.ErrorIsNil)
 		defer workertest.DirtyKill(c, tracker)
 
-		context.SendNotify()
+		context.SendModelConfigNotify()
 		err = workertest.CheckKilled(c, tracker)
 		c.Check(err, gc.ErrorMatches, "cannot read environ config: blam ouch")
 		context.CheckCallNames(c, "ModelConfig", "CloudSpec", "WatchForModelConfigChanges", "ModelConfig")
@@ -194,7 +194,7 @@ func (s *TrackerSuite) TestWatchedModelConfigIncompatible(c *gc.C) {
 		c.Check(err, jc.ErrorIsNil)
 		defer workertest.DirtyKill(c, tracker)
 
-		context.SendNotify()
+		context.SendModelConfigNotify()
 		err = workertest.CheckKilled(c, tracker)
 		c.Check(err, gc.ErrorMatches, "cannot update environ config: SetConfig is broken")
 		context.CheckCallNames(c, "ModelConfig", "CloudSpec", "WatchForModelConfigChanges", "ModelConfig")
@@ -223,7 +223,7 @@ func (s *TrackerSuite) TestWatchedModelConfigUpdates(c *gc.C) {
 
 		timeout := time.After(coretesting.LongWait)
 		attempt := time.After(0)
-		context.SendNotify()
+		context.SendModelConfigNotify()
 		for {
 			select {
 			case <-attempt:

--- a/worker/environ/wait.go
+++ b/worker/environ/wait.go
@@ -31,6 +31,7 @@ var ErrWaitAborted = errors.New("environ wait aborted")
 // responsible for detecting and handling any watcher errors that may occur,
 // whether this func succeeds or fails.
 func WaitForEnviron(
+	// TODO(wallyworld) - pass in credential watcher
 	w watcher.NotifyWatcher,
 	getter environs.EnvironConfigGetter,
 	newEnviron environs.NewEnvironFunc,

--- a/worker/environ/wait_test.go
+++ b/worker/environ/wait_test.go
@@ -58,7 +58,7 @@ func (s *WaitSuite) TestWatchClosed(c *gc.C) {
 			c.Check(err, gc.ErrorMatches, "environ config watch closed")
 		}()
 
-		context.CloseNotify()
+		context.CloseModelConfigNotify()
 		select {
 		case <-done:
 		case <-time.After(coretesting.LongWait):
@@ -86,7 +86,7 @@ func (s *WaitSuite) TestConfigError(c *gc.C) {
 			c.Check(err, gc.ErrorMatches, "cannot read environ config: biff zonk")
 		}()
 
-		context.SendNotify()
+		context.SendModelConfigNotify()
 		select {
 		case <-done:
 		case <-time.After(coretesting.LongWait):
@@ -121,7 +121,7 @@ func (s *WaitSuite) TestIgnoresBadConfig(c *gc.C) {
 			}
 		}()
 
-		context.SendNotify()
+		context.SendModelConfigNotify()
 		select {
 		case <-time.After(coretesting.ShortWait):
 		case <-done:
@@ -131,7 +131,7 @@ func (s *WaitSuite) TestIgnoresBadConfig(c *gc.C) {
 		context.SetConfig(c, coretesting.Attrs{
 			"name": "expected-name",
 		})
-		context.SendNotify()
+		context.SendModelConfigNotify()
 		select {
 		case <-done:
 		case <-time.After(coretesting.LongWait):


### PR DESCRIPTION
Add a credential watcher to the environ tracker for use later.