### PR TITLE
state.CloudCredentials now returns a map of credentials keyed on canonical tag

### DIFF
--- a/apiserver/cloud/backend.go
+++ b/apiserver/cloud/backend.go
@@ -13,7 +13,7 @@ import (
 type Backend interface {
 	Clouds() (map[names.CloudTag]cloud.Cloud, error)
 	Cloud(cloudName string) (cloud.Cloud, error)
-	CloudCredentials(user names.UserTag, cloudName string) (map[names.CloudCredentialTag]cloud.Credential, error)
+	CloudCredentials(user names.UserTag, cloudName string) (map[string]cloud.Credential, error)
 	ControllerModel() (Model, error)
 	ControllerTag() names.ControllerTag
 	ModelTag() names.ModelTag

--- a/apiserver/cloud/cloud.go
+++ b/apiserver/cloud/cloud.go
@@ -174,8 +174,8 @@ func (api *CloudAPI) UserCredentials(args params.UserClouds) (params.StringsResu
 			continue
 		}
 		out := make([]string, 0, len(cloudCredentials))
-		for tag := range cloudCredentials {
-			out = append(out, tag.String())
+		for tagId := range cloudCredentials {
+			out = append(out, names.NewCloudCredentialTag(tagId).String())
 		}
 		results.Results[i].Result = out
 	}
@@ -289,7 +289,7 @@ func (api *CloudAPI) Credential(args params.Entities) (params.CloudCredentialRes
 			continue
 		}
 
-		cred, ok := cloudCredentials[credentialTag]
+		cred, ok := cloudCredentials[credentialTag.Canonical()]
 		if !ok {
 			results.Results[i].Error = common.ServerError(errors.NotFoundf("credential %q", credentialTag.Name()))
 			continue

--- a/apiserver/cloud/cloud_test.go
+++ b/apiserver/cloud/cloud_test.go
@@ -36,9 +36,9 @@ func (s *cloudSuite) SetUpTest(c *gc.C) {
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
 			Regions:   []cloud.Region{{Name: "nether", Endpoint: "endpoint"}},
 		},
-		creds: map[names.CloudCredentialTag]cloud.Credential{
-			names.NewCloudCredentialTag("meep/bruce@local/one"): cloud.NewEmptyCredential(),
-			names.NewCloudCredentialTag("meep/bruce@local/two"): cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+		creds: map[string]cloud.Credential{
+			names.NewCloudCredentialTag("meep/bruce@local/one").Canonical(): cloud.NewEmptyCredential(),
+			names.NewCloudCredentialTag("meep/bruce@local/two").Canonical(): cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
 				"username": "admin",
 				"password": "adm1n",
 			}),
@@ -265,7 +265,7 @@ func (s *cloudSuite) TestCredentialAdminAccess(c *gc.C) {
 type mockBackend struct {
 	gitjujutesting.Stub
 	cloud cloud.Cloud
-	creds map[names.CloudCredentialTag]cloud.Credential
+	creds map[string]cloud.Credential
 }
 
 func (st *mockBackend) IsControllerAdmin(user names.UserTag) (bool, error) {
@@ -301,7 +301,7 @@ func (st *mockBackend) Clouds() (map[names.CloudTag]cloud.Cloud, error) {
 	}, st.NextErr()
 }
 
-func (st *mockBackend) CloudCredentials(user names.UserTag, cloudName string) (map[names.CloudCredentialTag]cloud.Credential, error) {
+func (st *mockBackend) CloudCredentials(user names.UserTag, cloudName string) (map[string]cloud.Credential, error) {
 	st.MethodCall(st, "CloudCredentials", user, cloudName)
 	return st.creds, st.NextErr()
 }

--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -123,12 +123,14 @@ func (s *CloudCredentialsSuite) TestCloudCredentials(c *gc.C) {
 	cred1.Label = "bobcred1"
 	cred2.Label = "bobcred2"
 
-	creds, err := s.State.CloudCredentials(names.NewUserTag("bob"), "stratus")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(creds, jc.DeepEquals, map[names.CloudCredentialTag]cloud.Credential{
-		tag1: cred1,
-		tag3: cred2,
-	})
+	for _, userName := range []string{"bob", "bob@local"} {
+		creds, err := s.State.CloudCredentials(names.NewUserTag(userName), "stratus")
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(creds, jc.DeepEquals, map[string]cloud.Credential{
+			tag1.Canonical(): cred1,
+			tag3.Canonical(): cred2,
+		})
+	}
 }
 
 func (s *CloudCredentialsSuite) TestRemoveCredentials(c *gc.C) {

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -172,7 +172,11 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	c.Assert(credentialTag, gc.Equals, userPassCredentialTag)
 	cloudCredentials, err := s.State.CloudCredentials(model.Owner(), "dummy")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cloudCredentials, jc.DeepEquals, cloudCredentialsIn)
+	expectedCred := make(map[string]cloud.Credential, len(cloudCredentialsIn))
+	for tag, cred := range cloudCredentialsIn {
+		expectedCred[tag.Canonical()] = cred
+	}
+	c.Assert(cloudCredentials, jc.DeepEquals, expectedCred)
 }
 
 func (s *InitializeSuite) TestInitializeWithInvalidCredentialType(c *gc.C) {

--- a/state/model.go
+++ b/state/model.go
@@ -366,7 +366,7 @@ func validateCloudRegion(cloud jujucloud.Cloud, cloudName, regionName string) (t
 func validateCloudCredential(
 	cloud jujucloud.Cloud,
 	cloudName string,
-	cloudCredentials map[names.CloudCredentialTag]jujucloud.Credential,
+	cloudCredentials map[string]jujucloud.Credential,
 	cloudCredential names.CloudCredentialTag,
 ) (txn.Op, error) {
 	if cloudCredential != (names.CloudCredentialTag{}) {
@@ -375,7 +375,7 @@ func validateCloudCredential(
 		}
 		var found bool
 		for tag := range cloudCredentials {
-			if tag.Canonical() == cloudCredential.Canonical() {
+			if tag == cloudCredential.Canonical() {
 				found = true
 				break
 			}

--- a/state/open.go
+++ b/state/open.go
@@ -176,10 +176,14 @@ func (p InitializeParams) Validate() error {
 	if _, err := validateCloudCredentials(p.Cloud, p.CloudName, p.CloudCredentials); err != nil {
 		return errors.Annotate(err, "validating cloud credentials")
 	}
+	creds := make(map[string]cloud.Credential, len(p.CloudCredentials))
+	for tag, cred := range p.CloudCredentials {
+		creds[tag.Canonical()] = cred
+	}
 	if _, err := validateCloudCredential(
 		p.Cloud,
 		p.CloudName,
-		p.CloudCredentials,
+		creds,
 		p.ControllerModelArgs.CloudCredential,
 	); err != nil {
 		return errors.Annotate(err, "validating controller model cloud credential")


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju/+bug/1623808

state.CloudCredentials returned a map[credentialTag]Credential

However, depending on how the credential tag was constructed (eg user being fred vs fred@local), looking up a tag in the result map could fail.
The method is changed to return a map of credentials keyed on tag.Canonical(). This ensures the caller can perform map lookups based on searchTag.Canonical() not avoid erroneous credential not found errors.