### PR TITLE
provider/maas: Allow unlinked / unconfigured host machine devices for containers

### DIFF
--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -514,7 +514,7 @@ func MergeProviderAndObservedNetworkConfigs(providerConfigs, observedConfigs []p
 	var results []params.NetworkConfig
 	for _, observed := range observedConfigs {
 
-		name, address := observed.InterfaceName, observed.Address
+		name, ipAddress := observed.InterfaceName, observed.Address
 		mergedConfig := observed
 
 		providerConfig, known := providerConfigByName[name]
@@ -523,7 +523,7 @@ func MergeProviderAndObservedNetworkConfigs(providerConfigs, observedConfigs []p
 			logger.Debugf("updated observed interface config for %q with: %+v", name, providerConfig)
 		}
 
-		providerConfig, known = providerConfigByAddress[address]
+		providerConfig, known = providerConfigByAddress[ipAddress]
 		if known {
 			mergedConfig = mergeObservedAndProviderAddressConfig(mergedConfig, providerConfig)
 			logger.Debugf("updated observed address config for %q with: %+v", name, providerConfig)

--- a/apiserver/common/networkingcommon/types_test.go
+++ b/apiserver/common/networkingcommon/types_test.go
@@ -178,7 +178,7 @@ var exampleObservedInterfaceAddrs = map[string][]net.Addr{
 	"br-eth1.13":  {fakeAddr("10.13.19.101/24"), fakeAddr("fe80::5054:ff:fedd:eef1/64")},
 }
 
-var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
+var expectedObservedNetworkConfigs = []params.NetworkConfig{{
 	DeviceIndex:   1,
 	InterfaceName: "lo",
 	InterfaceType: string(network.LoopbackInterface),
@@ -333,7 +333,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 	ConfigType:          string(network.ConfigManual),
 }}
 
-var expectedSortedProviderNetworkConfigs = []params.NetworkConfig{{
+var expectedProviderNetworkConfigs = []params.NetworkConfig{{
 	InterfaceName:       "eth0",
 	InterfaceType:       string(network.EthernetInterface),
 	MACAddress:          "aa:bb:cc:dd:ee:f0",
@@ -461,7 +461,7 @@ var expectedSortedProviderNetworkConfigs = []params.NetworkConfig{{
 	ProviderAddressId:   "1302",
 }}
 
-var expectedSortedMergedNetworkConfigs = []params.NetworkConfig{{
+var expectedFinalNetworkConfigs = []params.NetworkConfig{{
 	DeviceIndex:         1,
 	InterfaceName:       "lo",
 	InterfaceType:       string(network.LoopbackInterface),
@@ -694,7 +694,7 @@ var expectedSortedMergedNetworkConfigs = []params.NetworkConfig{{
 	VLANTag:             13,
 }}
 
-var expectedLinkLayerDeviceArgsWithMergedNetworkConfig = []state.LinkLayerDeviceArgs{{
+var expectedLinkLayerDeviceArgsWithFinalNetworkConfig = []state.LinkLayerDeviceArgs{{
 	Name:        "lo",
 	MTU:         65536,
 	Type:        state.LoopbackDevice,
@@ -836,7 +836,7 @@ var expectedLinkLayerDeviceArgsWithMergedNetworkConfig = []state.LinkLayerDevice
 	ParentName:  "br-eth1.13",
 }}
 
-var expectedLinkLayerDeviceAdressesWithMergedNetworkConfig = []state.LinkLayerDeviceAddress{{
+var expectedLinkLayerDeviceAdressesWithFinalNetworkConfig = []state.LinkLayerDeviceAddress{{
 	DeviceName:   "lo",
 	ConfigMethod: state.LoopbackAddress,
 	CIDRAddress:  "127.0.0.1/8",
@@ -888,10 +888,10 @@ var expectedLinkLayerDeviceAdressesWithMergedNetworkConfig = []state.LinkLayerDe
 }}
 
 func (s *TypesSuite) TestNetworkConfigsToStateArgs(c *gc.C) {
-	devicesArgs, devicesAddrs := networkingcommon.NetworkConfigsToStateArgs(expectedSortedMergedNetworkConfigs)
+	devicesArgs, devicesAddrs := networkingcommon.NetworkConfigsToStateArgs(expectedFinalNetworkConfigs)
 
-	c.Check(devicesArgs, jc.DeepEquals, expectedLinkLayerDeviceArgsWithMergedNetworkConfig)
-	c.Check(devicesAddrs, jc.DeepEquals, expectedLinkLayerDeviceAdressesWithMergedNetworkConfig)
+	c.Check(devicesArgs, jc.DeepEquals, expectedLinkLayerDeviceArgsWithFinalNetworkConfig)
+	c.Check(devicesAddrs, jc.DeepEquals, expectedLinkLayerDeviceAdressesWithFinalNetworkConfig)
 }
 
 func (s *TypesSuite) TestMergeProviderAndObservedNetworkConfigsBothNil(c *gc.C) {
@@ -900,22 +900,22 @@ func (s *TypesSuite) TestMergeProviderAndObservedNetworkConfigsBothNil(c *gc.C) 
 }
 
 func (s *TypesSuite) TestMergeProviderAndObservedNetworkConfigsNilObservedConfigs(c *gc.C) {
-	input := expectedSortedProviderNetworkConfigs
+	input := expectedProviderNetworkConfigs
 	result := networkingcommon.MergeProviderAndObservedNetworkConfigs(input, nil)
 	c.Check(result, gc.IsNil)
 }
 
 func (s *TypesSuite) TestMergeProviderAndObservedNetworkConfigsNilProviderConfigs(c *gc.C) {
-	input := expectedSortedObservedNetworkConfigs
+	input := expectedObservedNetworkConfigs
 	result := networkingcommon.MergeProviderAndObservedNetworkConfigs(nil, input)
 	c.Check(result, jc.DeepEquals, input)
 }
 
 func (s *TypesSuite) TestMergeProviderAndObservedNetworkConfigs(c *gc.C) {
-	observedConfig := expectedSortedObservedNetworkConfigs
-	providerConfig := expectedSortedProviderNetworkConfigs
+	observedConfig := expectedObservedNetworkConfigs
+	providerConfig := expectedProviderNetworkConfigs
 	result := networkingcommon.MergeProviderAndObservedNetworkConfigs(providerConfig, observedConfig)
-	c.Check(result, jc.DeepEquals, expectedSortedMergedNetworkConfigs)
+	c.Check(result, jc.DeepEquals, expectedFinalNetworkConfigs)
 }
 
 func (s *TypesSuite) TestGetObservedNetworkConfigInterfacesError(c *gc.C) {

--- a/apiserver/common/networkingcommon/types_test.go
+++ b/apiserver/common/networkingcommon/types_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"net"
 	"os"
 	"path/filepath"
@@ -206,7 +205,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 }, {
 	DeviceIndex:   10,
 	InterfaceName: "br-eth0",
-	InterfaceType: string(network.EthernetInterface),
+	InterfaceType: string(network.BridgeInterface),
 	MACAddress:    "aa:bb:cc:dd:ee:f0",
 	CIDR:          "10.20.19.0/24",
 	Address:       "10.20.19.100",
@@ -214,7 +213,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 }, {
 	DeviceIndex:   10,
 	InterfaceName: "br-eth0",
-	InterfaceType: string(network.EthernetInterface),
+	InterfaceType: string(network.BridgeInterface),
 	MACAddress:    "aa:bb:cc:dd:ee:f0",
 	CIDR:          "10.20.19.0/24",
 	Address:       "10.20.19.123",
@@ -222,7 +221,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 }, {
 	DeviceIndex:   12,
 	InterfaceName: "br-eth0.100",
-	InterfaceType: string(network.VLAN_8021QInterface),
+	InterfaceType: string(network.BridgeInterface),
 	MACAddress:    "aa:bb:cc:dd:ee:f0",
 	CIDR:          "10.100.19.0/24",
 	Address:       "10.100.19.100",
@@ -230,7 +229,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 }, {
 	DeviceIndex:   14,
 	InterfaceName: "br-eth0.250",
-	InterfaceType: string(network.VLAN_8021QInterface),
+	InterfaceType: string(network.BridgeInterface),
 	MACAddress:    "aa:bb:cc:dd:ee:f0",
 	CIDR:          "10.250.19.0/24",
 	Address:       "10.250.19.100",
@@ -238,39 +237,43 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 }, {
 	DeviceIndex:   16,
 	InterfaceName: "br-eth0.50",
-	InterfaceType: string(network.VLAN_8021QInterface),
+	InterfaceType: string(network.BridgeInterface),
 	MACAddress:    "aa:bb:cc:dd:ee:f0",
 	CIDR:          "10.50.19.0/24",
 	Address:       "10.50.19.100",
 	MTU:           1500,
 }, {
-	DeviceIndex:   2,
-	InterfaceName: "eth0",
-	InterfaceType: string(network.EthernetInterface),
-	MACAddress:    "aa:bb:cc:dd:ee:f0",
-	MTU:           1500,
+	DeviceIndex:         2,
+	InterfaceName:       "eth0",
+	ParentInterfaceName: "br-eth0",
+	InterfaceType:       string(network.EthernetInterface),
+	MACAddress:          "aa:bb:cc:dd:ee:f0",
+	MTU:                 1500,
 }, {
-	DeviceIndex:   13,
-	InterfaceName: "eth0.100",
-	InterfaceType: string(network.VLAN_8021QInterface),
-	MACAddress:    "aa:bb:cc:dd:ee:f0",
-	MTU:           1500,
+	DeviceIndex:         13,
+	InterfaceName:       "eth0.100",
+	ParentInterfaceName: "br-eth0.100",
+	InterfaceType:       string(network.VLAN_8021QInterface),
+	MACAddress:          "aa:bb:cc:dd:ee:f0",
+	MTU:                 1500,
 }, {
-	DeviceIndex:   15,
-	InterfaceName: "eth0.250",
-	InterfaceType: string(network.VLAN_8021QInterface),
-	MACAddress:    "aa:bb:cc:dd:ee:f0",
-	MTU:           1500,
+	DeviceIndex:         15,
+	InterfaceName:       "eth0.250",
+	ParentInterfaceName: "br-eth0.250",
+	InterfaceType:       string(network.VLAN_8021QInterface),
+	MACAddress:          "aa:bb:cc:dd:ee:f0",
+	MTU:                 1500,
 }, {
-	DeviceIndex:   17,
-	InterfaceName: "eth0.50",
-	InterfaceType: string(network.VLAN_8021QInterface),
-	MACAddress:    "aa:bb:cc:dd:ee:f0",
-	MTU:           1500,
+	DeviceIndex:         17,
+	InterfaceName:       "eth0.50",
+	ParentInterfaceName: "br-eth0.50",
+	InterfaceType:       string(network.VLAN_8021QInterface),
+	MACAddress:          "aa:bb:cc:dd:ee:f0",
+	MTU:                 1500,
 }, {
 	DeviceIndex:   11,
 	InterfaceName: "br-eth1",
-	InterfaceType: string(network.EthernetInterface),
+	InterfaceType: string(network.BridgeInterface),
 	MACAddress:    "aa:bb:cc:dd:ee:f1",
 	CIDR:          "10.20.19.0/24",
 	Address:       "10.20.19.105",
@@ -278,7 +281,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 }, {
 	DeviceIndex:   18,
 	InterfaceName: "br-eth1.11",
-	InterfaceType: string(network.VLAN_8021QInterface),
+	InterfaceType: string(network.BridgeInterface),
 	MACAddress:    "aa:bb:cc:dd:ee:f1",
 	CIDR:          "10.11.19.0/24",
 	Address:       "10.11.19.101",
@@ -286,7 +289,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 }, {
 	DeviceIndex:   20,
 	InterfaceName: "br-eth1.12",
-	InterfaceType: string(network.VLAN_8021QInterface),
+	InterfaceType: string(network.BridgeInterface),
 	MACAddress:    "aa:bb:cc:dd:ee:f1",
 	CIDR:          "10.12.19.0/24",
 	Address:       "10.12.19.101",
@@ -294,35 +297,39 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 }, {
 	DeviceIndex:   22,
 	InterfaceName: "br-eth1.13",
-	InterfaceType: string(network.VLAN_8021QInterface),
+	InterfaceType: string(network.BridgeInterface),
 	MACAddress:    "aa:bb:cc:dd:ee:f1",
 	CIDR:          "10.13.19.0/24",
 	Address:       "10.13.19.101",
 	MTU:           1500,
 }, {
-	DeviceIndex:   3,
-	InterfaceName: "eth1",
-	InterfaceType: string(network.EthernetInterface),
-	MACAddress:    "aa:bb:cc:dd:ee:f1",
-	MTU:           1500,
+	DeviceIndex:         3,
+	InterfaceName:       "eth1",
+	ParentInterfaceName: "br-eth1",
+	InterfaceType:       string(network.EthernetInterface),
+	MACAddress:          "aa:bb:cc:dd:ee:f1",
+	MTU:                 1500,
 }, {
-	DeviceIndex:   19,
-	InterfaceName: "eth1.11",
-	InterfaceType: string(network.VLAN_8021QInterface),
-	MACAddress:    "aa:bb:cc:dd:ee:f1",
-	MTU:           1500,
+	DeviceIndex:         19,
+	InterfaceName:       "eth1.11",
+	ParentInterfaceName: "br-eth1.11",
+	InterfaceType:       string(network.VLAN_8021QInterface),
+	MACAddress:          "aa:bb:cc:dd:ee:f1",
+	MTU:                 1500,
 }, {
-	DeviceIndex:   21,
-	InterfaceName: "eth1.12",
-	InterfaceType: string(network.VLAN_8021QInterface),
-	MACAddress:    "aa:bb:cc:dd:ee:f1",
-	MTU:           1500,
+	DeviceIndex:         21,
+	InterfaceName:       "eth1.12",
+	ParentInterfaceName: "br-eth1.12",
+	InterfaceType:       string(network.VLAN_8021QInterface),
+	MACAddress:          "aa:bb:cc:dd:ee:f1",
+	MTU:                 1500,
 }, {
-	DeviceIndex:   23,
-	InterfaceName: "eth1.13",
-	InterfaceType: string(network.VLAN_8021QInterface),
-	MACAddress:    "aa:bb:cc:dd:ee:f1",
-	MTU:           1500,
+	DeviceIndex:         23,
+	InterfaceName:       "eth1.13",
+	ParentInterfaceName: "br-eth1.13",
+	InterfaceType:       string(network.VLAN_8021QInterface),
+	MACAddress:          "aa:bb:cc:dd:ee:f1",
+	MTU:                 1500,
 }}
 
 var expectedSortedProviderNetworkConfigs = []params.NetworkConfig{{
@@ -919,13 +926,16 @@ func (s *TypesSuite) networkConfigsAsJSON(c *gc.C, input []params.NetworkConfig)
 }
 
 func shuffleNetworkConfigs(input []params.NetworkConfig) []params.NetworkConfig {
-	inputLength := len(input)
-	output := make([]params.NetworkConfig, inputLength)
-	shuffled := rand.Perm(inputLength)
-	for i, j := range shuffled {
-		output[i] = input[j]
-	}
-	return output
+	return input
+	/*
+		inputLength := len(input)
+		output := make([]params.NetworkConfig, inputLength)
+		shuffled := rand.Perm(inputLength)
+		for i, j := range shuffled {
+			output[i] = input[j]
+		}
+		return output
+	*/
 }
 
 func (s *TypesSuite) TestSortNetworkConfigsByParentsWithProviderConfigs(c *gc.C) {
@@ -956,8 +966,9 @@ func (s *TypesSuite) TestNetworkConfigsToStateArgs(c *gc.C) {
 }
 
 func (s *TypesSuite) TestMergeProviderAndObservedNetworkConfigs(c *gc.C) {
-	observedConfigsLength := len(expectedSortedObservedNetworkConfigs)
-	providerConfigsLength := len(expectedSortedProviderNetworkConfigs)
+	observedConfigsLength := 1 //len(expectedSortedObservedNetworkConfigs)
+	providerConfigsLength := 1 //len(expectedSortedProviderNetworkConfigs)
+
 	jsonExpected := s.networkConfigsAsJSON(c, expectedSortedMergedNetworkConfigs)
 	for i := 0; i < observedConfigsLength; i++ {
 		shuffledObservedConfigs := shuffleNetworkConfigs(expectedSortedObservedNetworkConfigs)

--- a/apiserver/common/networkingcommon/types_test.go
+++ b/apiserver/common/networkingcommon/types_test.go
@@ -40,21 +40,6 @@ func (s *TypesSuite) SetUpTest(c *gc.C) {
 	}
 }
 
-func (s *TypesSuite) TestCopyNetworkConfig(c *gc.C) {
-	inputAndExpectedOutput := []params.NetworkConfig{{
-		InterfaceName: "foo",
-		DNSServers:    []string{"bar", "baz"},
-		Address:       "0.1.2.3",
-	}, {
-		DeviceIndex:         124,
-		ParentInterfaceName: "parent",
-		ProviderId:          "nic-id",
-	}}
-
-	output := networkingcommon.CopyNetworkConfigs(inputAndExpectedOutput)
-	c.Assert(output, jc.DeepEquals, inputAndExpectedOutput)
-}
-
 func mustParseMAC(value string) net.HardwareAddr {
 	parsedMAC, err := net.ParseMAC(value)
 	if err != nil {
@@ -210,6 +195,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 	CIDR:          "10.20.19.0/24",
 	Address:       "10.20.19.100",
 	MTU:           1500,
+	ConfigType:    string(network.ConfigStatic),
 }, {
 	DeviceIndex:   10,
 	InterfaceName: "br-eth0",
@@ -218,6 +204,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 	CIDR:          "10.20.19.0/24",
 	Address:       "10.20.19.123",
 	MTU:           1500,
+	ConfigType:    string(network.ConfigStatic),
 }, {
 	DeviceIndex:   12,
 	InterfaceName: "br-eth0.100",
@@ -234,6 +221,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 	CIDR:          "10.250.19.0/24",
 	Address:       "10.250.19.100",
 	MTU:           1500,
+	ConfigType:    string(network.ConfigStatic),
 }, {
 	DeviceIndex:   16,
 	InterfaceName: "br-eth0.50",
@@ -242,6 +230,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 	CIDR:          "10.50.19.0/24",
 	Address:       "10.50.19.100",
 	MTU:           1500,
+	ConfigType:    string(network.ConfigStatic),
 }, {
 	DeviceIndex:         2,
 	InterfaceName:       "eth0",
@@ -249,6 +238,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 	InterfaceType:       string(network.EthernetInterface),
 	MACAddress:          "aa:bb:cc:dd:ee:f0",
 	MTU:                 1500,
+	ConfigType:          string(network.ConfigManual),
 }, {
 	DeviceIndex:         13,
 	InterfaceName:       "eth0.100",
@@ -256,6 +246,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 	InterfaceType:       string(network.VLAN_8021QInterface),
 	MACAddress:          "aa:bb:cc:dd:ee:f0",
 	MTU:                 1500,
+	ConfigType:          string(network.ConfigManual),
 }, {
 	DeviceIndex:         15,
 	InterfaceName:       "eth0.250",
@@ -263,6 +254,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 	InterfaceType:       string(network.VLAN_8021QInterface),
 	MACAddress:          "aa:bb:cc:dd:ee:f0",
 	MTU:                 1500,
+	ConfigType:          string(network.ConfigManual),
 }, {
 	DeviceIndex:         17,
 	InterfaceName:       "eth0.50",
@@ -270,6 +262,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 	InterfaceType:       string(network.VLAN_8021QInterface),
 	MACAddress:          "aa:bb:cc:dd:ee:f0",
 	MTU:                 1500,
+	ConfigType:          string(network.ConfigManual),
 }, {
 	DeviceIndex:   11,
 	InterfaceName: "br-eth1",
@@ -278,6 +271,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 	CIDR:          "10.20.19.0/24",
 	Address:       "10.20.19.105",
 	MTU:           1500,
+	ConfigType:    string(network.ConfigStatic),
 }, {
 	DeviceIndex:   18,
 	InterfaceName: "br-eth1.11",
@@ -286,6 +280,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 	CIDR:          "10.11.19.0/24",
 	Address:       "10.11.19.101",
 	MTU:           1500,
+	ConfigType:    string(network.ConfigStatic),
 }, {
 	DeviceIndex:   20,
 	InterfaceName: "br-eth1.12",
@@ -294,6 +289,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 	CIDR:          "10.12.19.0/24",
 	Address:       "10.12.19.101",
 	MTU:           1500,
+	ConfigType:    string(network.ConfigStatic),
 }, {
 	DeviceIndex:   22,
 	InterfaceName: "br-eth1.13",
@@ -302,6 +298,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 	CIDR:          "10.13.19.0/24",
 	Address:       "10.13.19.101",
 	MTU:           1500,
+	ConfigType:    string(network.ConfigStatic),
 }, {
 	DeviceIndex:         3,
 	InterfaceName:       "eth1",
@@ -309,6 +306,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 	InterfaceType:       string(network.EthernetInterface),
 	MACAddress:          "aa:bb:cc:dd:ee:f1",
 	MTU:                 1500,
+	ConfigType:          string(network.ConfigManual),
 }, {
 	DeviceIndex:         19,
 	InterfaceName:       "eth1.11",
@@ -316,6 +314,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 	InterfaceType:       string(network.VLAN_8021QInterface),
 	MACAddress:          "aa:bb:cc:dd:ee:f1",
 	MTU:                 1500,
+	ConfigType:          string(network.ConfigManual),
 }, {
 	DeviceIndex:         21,
 	InterfaceName:       "eth1.12",
@@ -323,6 +322,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 	InterfaceType:       string(network.VLAN_8021QInterface),
 	MACAddress:          "aa:bb:cc:dd:ee:f1",
 	MTU:                 1500,
+	ConfigType:          string(network.ConfigManual),
 }, {
 	DeviceIndex:         23,
 	InterfaceName:       "eth1.13",
@@ -330,6 +330,7 @@ var expectedSortedObservedNetworkConfigs = []params.NetworkConfig{{
 	InterfaceType:       string(network.VLAN_8021QInterface),
 	MACAddress:          "aa:bb:cc:dd:ee:f1",
 	MTU:                 1500,
+	ConfigType:          string(network.ConfigManual),
 }}
 
 var expectedSortedProviderNetworkConfigs = []params.NetworkConfig{{
@@ -506,7 +507,7 @@ var expectedSortedMergedNetworkConfigs = []params.NetworkConfig{{
 	Address:             "10.100.19.100",
 	MTU:                 1500,
 	ConfigType:          string(network.ConfigStatic),
-	ParentInterfaceName: "br-eth0",
+	ParentInterfaceName: "",
 	ProviderSubnetId:    "6",
 	ProviderVLANId:      "5005",
 	VLANTag:             100,
@@ -520,7 +521,7 @@ var expectedSortedMergedNetworkConfigs = []params.NetworkConfig{{
 	Address:             "10.250.19.100",
 	MTU:                 1500,
 	ConfigType:          string(network.ConfigStatic),
-	ParentInterfaceName: "br-eth0",
+	ParentInterfaceName: "",
 	ProviderSubnetId:    "8",
 	ProviderVLANId:      "5008",
 	VLANTag:             250,
@@ -534,7 +535,7 @@ var expectedSortedMergedNetworkConfigs = []params.NetworkConfig{{
 	Address:             "10.50.19.100",
 	MTU:                 1500,
 	ConfigType:          string(network.ConfigStatic),
-	ParentInterfaceName: "br-eth0",
+	ParentInterfaceName: "",
 	ProviderSubnetId:    "5",
 	ProviderVLANId:      "5004",
 	VLANTag:             50,
@@ -610,7 +611,7 @@ var expectedSortedMergedNetworkConfigs = []params.NetworkConfig{{
 	Address:             "10.11.19.101",
 	MTU:                 1500,
 	ConfigType:          string(network.ConfigStatic),
-	ParentInterfaceName: "br-eth1",
+	ParentInterfaceName: "",
 	ProviderSubnetId:    "9",
 	ProviderVLANId:      "5013",
 	VLANTag:             11,
@@ -624,7 +625,7 @@ var expectedSortedMergedNetworkConfigs = []params.NetworkConfig{{
 	Address:             "10.12.19.101",
 	MTU:                 1500,
 	ConfigType:          string(network.ConfigStatic),
-	ParentInterfaceName: "br-eth1",
+	ParentInterfaceName: "",
 	ProviderSubnetId:    "10",
 	ProviderVLANId:      "5014",
 	VLANTag:             12,
@@ -637,7 +638,7 @@ var expectedSortedMergedNetworkConfigs = []params.NetworkConfig{{
 	CIDR:                "10.13.19.0/24",
 	Address:             "10.13.19.101",
 	MTU:                 1500,
-	ParentInterfaceName: "br-eth1",
+	ParentInterfaceName: "",
 	ConfigType:          string(network.ConfigStatic),
 	ProviderSubnetId:    "11",
 	ProviderVLANId:      "5015",
@@ -693,23 +694,6 @@ var expectedSortedMergedNetworkConfigs = []params.NetworkConfig{{
 	VLANTag:             13,
 }}
 
-var expectedSortedNetworkConfigsByInterfaceName = []params.NetworkConfig{
-	{InterfaceName: "br-eth0"},
-	{InterfaceName: "br-eth0.12"},
-	{InterfaceName: "br-eth0.34"},
-	{InterfaceName: "br-eth1"},
-	{InterfaceName: "br-eth1.100"},
-	{InterfaceName: "br-eth1.250"},
-	{InterfaceName: "br-eth1.50"},
-	{InterfaceName: "eth0"},
-	{InterfaceName: "eth0.12"},
-	{InterfaceName: "eth0.34"},
-	{InterfaceName: "eth1"},
-	{InterfaceName: "eth1.100"},
-	{InterfaceName: "eth1.250"},
-	{InterfaceName: "eth1.50"},
-}
-
 var expectedLinkLayerDeviceArgsWithMergedNetworkConfig = []state.LinkLayerDeviceArgs{{
 	Name:        "lo",
 	MTU:         65536,
@@ -730,7 +714,7 @@ var expectedLinkLayerDeviceArgsWithMergedNetworkConfig = []state.LinkLayerDevice
 	MACAddress:  "aa:bb:cc:dd:ee:f0",
 	IsAutoStart: true,
 	IsUp:        true,
-	ParentName:  "br-eth0",
+	ParentName:  "",
 }, {
 	Name:        "br-eth0.250",
 	MTU:         1500,
@@ -738,7 +722,7 @@ var expectedLinkLayerDeviceArgsWithMergedNetworkConfig = []state.LinkLayerDevice
 	MACAddress:  "aa:bb:cc:dd:ee:f0",
 	IsAutoStart: true,
 	IsUp:        true,
-	ParentName:  "br-eth0",
+	ParentName:  "",
 }, {
 	Name:        "br-eth0.50",
 	MTU:         1500,
@@ -746,7 +730,7 @@ var expectedLinkLayerDeviceArgsWithMergedNetworkConfig = []state.LinkLayerDevice
 	MACAddress:  "aa:bb:cc:dd:ee:f0",
 	IsAutoStart: true,
 	IsUp:        true,
-	ParentName:  "br-eth0",
+	ParentName:  "",
 }, {
 	Name:        "eth0",
 	MTU:         1500,
@@ -797,7 +781,7 @@ var expectedLinkLayerDeviceArgsWithMergedNetworkConfig = []state.LinkLayerDevice
 	MACAddress:  "aa:bb:cc:dd:ee:f1",
 	IsAutoStart: true,
 	IsUp:        true,
-	ParentName:  "br-eth1",
+	ParentName:  "",
 }, {
 	Name:        "br-eth1.12",
 	MTU:         1500,
@@ -805,7 +789,7 @@ var expectedLinkLayerDeviceArgsWithMergedNetworkConfig = []state.LinkLayerDevice
 	MACAddress:  "aa:bb:cc:dd:ee:f1",
 	IsAutoStart: true,
 	IsUp:        true,
-	ParentName:  "br-eth1",
+	ParentName:  "",
 }, {
 	Name:        "br-eth1.13",
 	MTU:         1500,
@@ -813,7 +797,7 @@ var expectedLinkLayerDeviceArgsWithMergedNetworkConfig = []state.LinkLayerDevice
 	MACAddress:  "aa:bb:cc:dd:ee:f1",
 	IsAutoStart: true,
 	IsUp:        true,
-	ParentName:  "br-eth1",
+	ParentName:  "",
 }, {
 	Name:        "eth1",
 	MTU:         1500,
@@ -903,61 +887,6 @@ var expectedLinkLayerDeviceAdressesWithMergedNetworkConfig = []state.LinkLayerDe
 	ProviderID:   "1302",
 }}
 
-func (s *TypesSuite) TestSortNetworkConfigsByParentsWithObservedConfigs(c *gc.C) {
-	s.checkSortNetworkConfigsByParentsWithAllInputPremutationsMatches(c, expectedSortedObservedNetworkConfigs)
-}
-
-func (s *TypesSuite) checkSortNetworkConfigsByParentsWithAllInputPremutationsMatches(c *gc.C, expectedOutput []params.NetworkConfig) {
-	expectedLength := len(expectedOutput)
-	jsonExpected := s.networkConfigsAsJSON(c, expectedOutput)
-	for i := 0; i < expectedLength; i++ {
-		shuffledInput := shuffleNetworkConfigs(expectedOutput)
-		result := networkingcommon.SortNetworkConfigsByParents(shuffledInput)
-		c.Assert(result, gc.HasLen, expectedLength)
-		jsonResult := s.networkConfigsAsJSON(c, result)
-		c.Check(jsonResult, gc.Equals, jsonExpected)
-	}
-}
-
-func (s *TypesSuite) networkConfigsAsJSON(c *gc.C, input []params.NetworkConfig) string {
-	asJSON, err := networkingcommon.NetworkConfigsToIndentedJSON(input)
-	c.Assert(err, jc.ErrorIsNil)
-	return asJSON
-}
-
-func shuffleNetworkConfigs(input []params.NetworkConfig) []params.NetworkConfig {
-	return input
-	/*
-		inputLength := len(input)
-		output := make([]params.NetworkConfig, inputLength)
-		shuffled := rand.Perm(inputLength)
-		for i, j := range shuffled {
-			output[i] = input[j]
-		}
-		return output
-	*/
-}
-
-func (s *TypesSuite) TestSortNetworkConfigsByParentsWithProviderConfigs(c *gc.C) {
-	s.checkSortNetworkConfigsByParentsWithAllInputPremutationsMatches(c, expectedSortedProviderNetworkConfigs)
-}
-
-func (s *TypesSuite) TestSortNetworkConfigsByParentsWithMergedConfigs(c *gc.C) {
-	s.checkSortNetworkConfigsByParentsWithAllInputPremutationsMatches(c, expectedSortedMergedNetworkConfigs)
-}
-
-func (s *TypesSuite) TestSortNetworkConfigsByInterfaceName(c *gc.C) {
-	expectedLength := len(expectedSortedNetworkConfigsByInterfaceName)
-	jsonExpected := s.networkConfigsAsJSON(c, expectedSortedNetworkConfigsByInterfaceName)
-	for i := 0; i < expectedLength; i++ {
-		shuffledInput := shuffleNetworkConfigs(expectedSortedNetworkConfigsByInterfaceName)
-		result := networkingcommon.SortNetworkConfigsByInterfaceName(shuffledInput)
-		c.Assert(result, gc.HasLen, expectedLength)
-		jsonResult := s.networkConfigsAsJSON(c, result)
-		c.Check(jsonResult, gc.Equals, jsonExpected)
-	}
-}
-
 func (s *TypesSuite) TestNetworkConfigsToStateArgs(c *gc.C) {
 	devicesArgs, devicesAddrs := networkingcommon.NetworkConfigsToStateArgs(expectedSortedMergedNetworkConfigs)
 
@@ -965,22 +894,28 @@ func (s *TypesSuite) TestNetworkConfigsToStateArgs(c *gc.C) {
 	c.Check(devicesAddrs, jc.DeepEquals, expectedLinkLayerDeviceAdressesWithMergedNetworkConfig)
 }
 
+func (s *TypesSuite) TestMergeProviderAndObservedNetworkConfigsBothNil(c *gc.C) {
+	result := networkingcommon.MergeProviderAndObservedNetworkConfigs(nil, nil)
+	c.Check(result, gc.IsNil)
+}
+
+func (s *TypesSuite) TestMergeProviderAndObservedNetworkConfigsNilObservedConfigs(c *gc.C) {
+	input := expectedSortedProviderNetworkConfigs
+	result := networkingcommon.MergeProviderAndObservedNetworkConfigs(input, nil)
+	c.Check(result, gc.IsNil)
+}
+
+func (s *TypesSuite) TestMergeProviderAndObservedNetworkConfigsNilProviderConfigs(c *gc.C) {
+	input := expectedSortedObservedNetworkConfigs
+	result := networkingcommon.MergeProviderAndObservedNetworkConfigs(nil, input)
+	c.Check(result, jc.DeepEquals, input)
+}
+
 func (s *TypesSuite) TestMergeProviderAndObservedNetworkConfigs(c *gc.C) {
-	observedConfigsLength := 1 //len(expectedSortedObservedNetworkConfigs)
-	providerConfigsLength := 1 //len(expectedSortedProviderNetworkConfigs)
-
-	jsonExpected := s.networkConfigsAsJSON(c, expectedSortedMergedNetworkConfigs)
-	for i := 0; i < observedConfigsLength; i++ {
-		shuffledObservedConfigs := shuffleNetworkConfigs(expectedSortedObservedNetworkConfigs)
-		for j := 0; j < providerConfigsLength; j++ {
-			shuffledProviderConfigs := shuffleNetworkConfigs(expectedSortedProviderNetworkConfigs)
-
-			mergedConfigs, err := networkingcommon.MergeProviderAndObservedNetworkConfigs(shuffledProviderConfigs, shuffledObservedConfigs)
-			c.Assert(err, jc.ErrorIsNil)
-			jsonResult := s.networkConfigsAsJSON(c, mergedConfigs)
-			c.Check(jsonResult, gc.Equals, jsonExpected)
-		}
-	}
+	observedConfig := expectedSortedObservedNetworkConfigs
+	providerConfig := expectedSortedProviderNetworkConfigs
+	result := networkingcommon.MergeProviderAndObservedNetworkConfigs(providerConfig, observedConfig)
+	c.Check(result, jc.DeepEquals, expectedSortedMergedNetworkConfigs)
 }
 
 func (s *TypesSuite) TestGetObservedNetworkConfigInterfacesError(c *gc.C) {

--- a/apiserver/machine/machiner.go
+++ b/apiserver/machine/machiner.go
@@ -167,10 +167,7 @@ func (api *MachinerAPI) SetObservedNetworkConfig(args params.SetMachineNetworkCo
 		return nil
 	}
 
-	mergedConfig, err := networkingcommon.MergeProviderAndObservedNetworkConfigs(providerConfig, observedConfig)
-	if err != nil {
-		return errors.Trace(err)
-	}
+	mergedConfig := networkingcommon.MergeProviderAndObservedNetworkConfigs(providerConfig, observedConfig)
 	logger.Tracef("merged observed and provider network config: %+v", mergedConfig)
 
 	return api.setOneMachineNetworkConfig(m, mergedConfig)
@@ -245,10 +242,9 @@ func (api *MachinerAPI) SetProviderNetworkConfig(args params.Entities) (params.E
 			continue
 		}
 
-		sortedProviderConfig := networkingcommon.SortNetworkConfigsByParents(providerConfig)
-		logger.Tracef("sorted provider network config for %q: %+v", m.Id(), sortedProviderConfig)
+		logger.Tracef("provider network config for %q: %+v", m.Id(), providerConfig)
 
-		if err := api.setOneMachineNetworkConfig(m, sortedProviderConfig); err != nil {
+		if err := api.setOneMachineNetworkConfig(m, providerConfig); err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -714,9 +714,8 @@ func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(args params.Entities
 		logger.Debugf("got allocated info from provider: %+v", allocatedInfo)
 
 		allocatedConfig := networkingcommon.NetworkConfigFromInterfaceInfo(allocatedInfo)
-		sortedAllocatedConfig := networkingcommon.SortNetworkConfigsByInterfaceName(allocatedConfig)
-		logger.Tracef("allocated sorted network config: %+v", sortedAllocatedConfig)
-		result.Results[i].Config = sortedAllocatedConfig
+		logger.Tracef("allocated network config: %+v", allocatedConfig)
+		result.Results[i].Config = allocatedConfig
 	}
 	return result, nil
 }

--- a/provider/maas/devices.go
+++ b/provider/maas/devices.go
@@ -212,23 +212,17 @@ func (env *maasEnviron) deviceInterfaceInfo(deviceID instance.Id, nameToParentNa
 		}
 
 		for _, link := range nic.Links {
-			switch link.Mode {
-			case modeUnknown:
-				nicInfo.ConfigType = network.ConfigUnknown
-			case modeDHCP:
-				nicInfo.ConfigType = network.ConfigDHCP
-			case modeStatic, modeLinkUp:
-				nicInfo.ConfigType = network.ConfigStatic
-			default:
-				nicInfo.ConfigType = network.ConfigManual
-			}
+			nicInfo.ConfigType = maasLinkToInterfaceConfigType(string(link.Mode), link.IPAddress)
 
 			if link.IPAddress == "" {
 				logger.Debugf("device %q interface %q has no address", deviceID, nic.Name)
+				interfaceInfo = append(interfaceInfo, nicInfo)
 				continue
 			}
+
 			if link.Subnet == nil {
 				logger.Debugf("device %q interface %q link %d missing subnet", deviceID, nic.Name, link.ID)
+				interfaceInfo = append(interfaceInfo, nicInfo)
 				continue
 			}
 
@@ -290,21 +284,12 @@ func (env *maasEnviron) deviceInterfaceInfo2(deviceID string, nameToParentName m
 		}
 
 		for _, link := range nic.Links() {
-			mode := maasLinkMode(link.Mode())
-			switch mode {
-			case modeUnknown:
-				nicInfo.ConfigType = network.ConfigUnknown
-			case modeDHCP:
-				nicInfo.ConfigType = network.ConfigDHCP
-			case modeStatic, modeLinkUp:
-				nicInfo.ConfigType = network.ConfigStatic
-			default:
-				nicInfo.ConfigType = network.ConfigManual
-			}
+			nicInfo.ConfigType = maasLinkToInterfaceConfigType(link.Mode(), link.IPAddress())
 
 			subnet := link.Subnet()
 			if link.IPAddress() == "" || subnet == nil {
 				logger.Debugf("device %q interface %q has no address", deviceID, nic.Name())
+				interfaceInfo = append(interfaceInfo, nicInfo)
 				continue
 			}
 

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -2120,8 +2120,15 @@ func (env *maasEnviron) allocateContainerAddresses1(hostInstanceID instance.Id, 
 	for i, nic := range preparedInfo {
 		maasNICID := ""
 		nameToParentName[nic.InterfaceName] = nic.ParentInterfaceName
+		nicVLANID, knownSubnet := subnetCIDRToVLANID[nic.CIDR]
 		if nic.InterfaceName != primaryNICName {
-			nicVLANID := subnetCIDRToVLANID[nic.CIDR]
+			if !knownSubnet {
+				logger.Warningf("NIC %v has no subnet - setting to manual and using untagged VLAN", nic.InterfaceName)
+				nicVLANID = primaryNICVLANID
+			} else {
+				logger.Infof("linking NIC %v to subnet %v - using static IP", nic.InterfaceName, nic.CIDR)
+			}
+
 			createdNIC, err := env.createDeviceInterface(deviceID, nic.InterfaceName, nic.MACAddress, nicVLANID)
 			if err != nil {
 				return nil, errors.Annotate(err, "creating device interface")
@@ -2134,17 +2141,24 @@ func (env *maasEnviron) allocateContainerAddresses1(hostInstanceID instance.Id, 
 		deviceNICIDs[i] = maasNICID
 		subnetID := string(nic.ProviderSubnetId)
 
+		if !knownSubnet {
+			continue
+		}
+
 		linkedInterface, err := env.linkDeviceInterfaceToSubnet(deviceID, maasNICID, subnetID, modeStatic)
 		if err != nil {
-			return nil, errors.Annotate(err, "cannot link device interface to subnet")
+			logger.Warningf("linking NIC %v to subnet %v failed: %v", nic.InterfaceName, nic.CIDR, err)
+		} else {
+			logger.Debugf("linked device interface to subnet: %+v", linkedInterface)
 		}
-		logger.Debugf("linked device interface to subnet: %+v", linkedInterface)
 	}
+
 	finalInterfaces, err := env.deviceInterfaceInfo(deviceID, nameToParentName)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get device interfaces")
 	}
 	logger.Debugf("allocated device interfaces: %+v", finalInterfaces)
+
 	return finalInterfaces, nil
 }
 
@@ -2209,44 +2223,58 @@ func (env *maasEnviron) allocateContainerAddresses2(hostInstanceID instance.Id, 
 	if len(interface_set) != 1 {
 		// Shouldn't be possible as machine.CreateDevice always returns us
 		// one interface.
-		return nil, errors.Errorf("unexpected number of interfaces inresponse from creating device: %v", interface_set)
+		return nil, errors.Errorf("unexpected number of interfaces in response from creating device: %v", interface_set)
 	}
+	primaryNICVLAN := interface_set[0].VLAN()
 
 	nameToParentName := make(map[string]string)
 	for _, nic := range preparedInfo {
 		nameToParentName[nic.InterfaceName] = nic.ParentInterfaceName
 		if nic.InterfaceName != primaryNICName {
-			subnet, ok := subnetCIDRToSubnet[nic.CIDR]
-			if !ok {
-				return nil, errors.Errorf("NIC %v subnet %v not found", nic.InterfaceName, nic.CIDR)
+			createArgs := gomaasapi.CreateInterfaceArgs{
+				Name:       nic.InterfaceName,
+				MTU:        nic.MTU,
+				MACAddress: nic.MACAddress,
 			}
-			createdNIC, err := device.CreateInterface(
-				gomaasapi.CreateInterfaceArgs{
-					Name:       nic.InterfaceName,
-					MACAddress: nic.MACAddress,
-					VLAN:       subnet.VLAN(),
-				})
+
+			subnet, knownSubnet := subnetCIDRToSubnet[nic.CIDR]
+			if !knownSubnet {
+				logger.Warningf("NIC %v has no subnet - setting to manual and using untagged VLAN", nic.InterfaceName)
+				createArgs.VLAN = primaryNICVLAN
+			} else {
+				createArgs.VLAN = subnet.VLAN()
+				logger.Infof("linking NIC %v to subnet %v - using static IP", nic.InterfaceName, subnet.CIDR())
+			}
+
+			createdNIC, err := device.CreateInterface(createArgs)
 			if err != nil {
 				return nil, errors.Annotate(err, "creating device interface")
 			}
 			logger.Debugf("created device interface: %+v", createdNIC)
 
+			if !knownSubnet {
+				continue
+			}
+
 			linkArgs := gomaasapi.LinkSubnetArgs{
 				Mode:   gomaasapi.LinkModeStatic,
 				Subnet: subnet,
 			}
-			err = createdNIC.LinkSubnet(linkArgs)
-			if err != nil {
-				return nil, errors.Annotate(err, "cannot link device interface to subnet")
+
+			if err := createdNIC.LinkSubnet(linkArgs); err != nil {
+				logger.Warningf("linking NIC %v to subnet %v failed: %v", nic.InterfaceName, subnet.CIDR(), err)
+			} else {
+				logger.Debugf("linked device interface to subnet: %+v", createdNIC)
 			}
-			logger.Debugf("linked device interface to subnet: %+v", createdNIC)
 		}
 	}
+
 	finalInterfaces, err := env.deviceInterfaceInfo2(device.SystemID(), nameToParentName)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get device interfaces")
 	}
 	logger.Debugf("allocated device interfaces: %+v", finalInterfaces)
+
 	return finalInterfaces, nil
 }
 


### PR DESCRIPTION
AllocateContainerAddresses() handles unlinked parent devices, selectively
allocating addresses only if possible, without failing the whole process

Part of fixing http://pad.lv/1566791. Includes #6219.