### PR TITLE
Fix agent config clone and mutex copy.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -522,6 +522,10 @@ func (c0 *configInternal) Clone() Config {
 	for key, val := range c0.values {
 		c1.values[key] = val
 	}
+	if c0.servingInfo != nil {
+		info := *c0.servingInfo
+		c1.servingInfo = &info
+	}
 	return &c1
 }
 

--- a/api/agent/machine_test.go
+++ b/api/agent/machine_test.go
@@ -53,7 +53,8 @@ func (s *servingInfoSuite) TestStateServingInfo(c *gc.C) {
 		APIPort:      ssi.APIPort,
 		StatePort:    ssi.StatePort,
 	}
-	s.State.SetStateServingInfo(ssi)
+	err := s.State.SetStateServingInfo(ssi)
+	c.Assert(err, jc.ErrorIsNil)
 	info, err := apiagent.NewState(st).StateServingInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, expected)

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1043,7 +1043,9 @@ func (s *MachineSuite) TestCertificateUpdateWorkerUpdatesCertificate(c *gc.C) {
 		for {
 			stateInfo, _ := a.CurrentConfig().StateServingInfo()
 			srvCert, err := cert.ParseCert(stateInfo.Cert)
-			c.Assert(err, jc.ErrorIsNil)
+			if !c.Check(err, jc.ErrorIsNil) {
+				break
+			}
 			sanIPs := make([]string, len(srvCert.IPAddresses))
 			for i, ip := range srvCert.IPAddresses {
 				sanIPs[i] = ip.String()
@@ -1052,7 +1054,7 @@ func (s *MachineSuite) TestCertificateUpdateWorkerUpdatesCertificate(c *gc.C) {
 				close(updated)
 				break
 			}
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 		}
 	}()
 


### PR DESCRIPTION
Don't copy tlsConfig, and hence its mutex.
Agent config needs to clone the state serving info rather than the pointer to it.

Hopefully addresses the intermittent test failure http://pad.lv/1466514.