### PR TITLE
Allow client to work on any Linux

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -45,7 +45,7 @@ github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-0
 github.com/juju/testing	git	c84079384079574bbd4461c37f903afa57472f3b	2016-09-06T21:43:14Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils	git	dbc08fbee4c1bcf60d65f5a523149310ece56a08	2016-09-05T01:56:06Z
+github.com/juju/utils	git	50f2d54645aeb2828a0081a72704457cece7e4cb	2016-09-16T02:08:06Z
 github.com/juju/version	git	4ae6172c00626779a5a462c3e3d22fc0e889431a	2016-06-03T19:49:58Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z

--- a/environs/bootstrap/tools.go
+++ b/environs/bootstrap/tools.go
@@ -39,7 +39,7 @@ func validateUploadAllowed(env environs.Environ, toolsArch, toolsSeries *string,
 		if err != nil {
 			return errors.Trace(err)
 		}
-		if toolsSeriesOS != hostOS {
+		if !toolsSeriesOS.EquivalentTo(hostOS) {
 			return errors.Errorf("cannot use agent built for %q using a machine running %q", *toolsSeries, hostOS)
 		}
 	}
@@ -85,7 +85,7 @@ func locallyBuildableTools(toolsSeries *string) (buildable coretools.List, _ ver
 	// Increment the build number so we know it's a custom build.
 	buildNumber.Build++
 	for _, ser := range series.SupportedSeries() {
-		if os, err := series.GetOSFromSeries(ser); err != nil || os != jujuos.HostOS() {
+		if os, err := series.GetOSFromSeries(ser); err != nil || !os.EquivalentTo(jujuos.HostOS()) {
 			continue
 		}
 		if toolsSeries != nil && ser != *toolsSeries {

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -898,7 +898,7 @@ func newOSProfile(vmName string, instanceConfig *instancecfg.InstanceConfig) (*c
 		return nil, os.Unknown, errors.Trace(err)
 	}
 	switch seriesOS {
-	case os.Ubuntu, os.CentOS, os.Arch:
+	case os.Ubuntu, os.CentOS:
 		// SSH keys are handled by custom data, but must also be
 		// specified in order to forego providing a password, and
 		// disable password authentication.

--- a/provider/azure/internal/imageutils/images_test.go
+++ b/provider/azure/internal/imageutils/images_test.go
@@ -70,9 +70,9 @@ func (s *imageutilsSuite) TestSeriesImageCentOS(c *gc.C) {
 	s.assertImageId(c, "centos7", "released", "OpenLogic:CentOS:7.1:latest")
 }
 
-func (s *imageutilsSuite) TestSeriesImageArch(c *gc.C) {
-	_, err := imageutils.SeriesImage("arch", "released", "westus", s.client)
-	c.Assert(err, gc.ErrorMatches, "deploying Arch not supported")
+func (s *imageutilsSuite) TestSeriesImageGenericLinux(c *gc.C) {
+	_, err := imageutils.SeriesImage("genericlinux", "released", "westus", s.client)
+	c.Assert(err, gc.ErrorMatches, "deploying GenericLinux not supported")
 }
 
 func (s *imageutilsSuite) TestSeriesImageStream(c *gc.C) {

--- a/provider/ec2/userdata_test.go
+++ b/provider/ec2/userdata_test.go
@@ -50,7 +50,7 @@ func (s *UserdataSuite) TestAmazonWindows(c *gc.C) {
 func (s *UserdataSuite) TestAmazonUnknownOS(c *gc.C) {
 	renderer := ec2.AmazonRenderer{}
 	cloudcfg := &cloudinittest.CloudConfig{}
-	result, err := renderer.Render(cloudcfg, os.Arch)
+	result, err := renderer.Render(cloudcfg, os.GenericLinux)
 	c.Assert(result, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: Arch")
+	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: GenericLinux")
 }

--- a/provider/gce/environ_broker_test.go
+++ b/provider/gce/environ_broker_test.go
@@ -146,10 +146,10 @@ func (s *environBrokerSuite) TestGetMetadataWindows(c *gc.C) {
 }
 
 func (s *environBrokerSuite) TestGetMetadataOSNotSupported(c *gc.C) {
-	metadata, err := gce.GetMetadata(s.StartInstArgs, jujuos.Arch)
+	metadata, err := gce.GetMetadata(s.StartInstArgs, jujuos.GenericLinux)
 
 	c.Assert(metadata, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "cannot pack metadata for os Arch on the gce provider")
+	c.Assert(err, gc.ErrorMatches, "cannot pack metadata for os GenericLinux on the gce provider")
 }
 
 var getDisksTests = []struct {

--- a/provider/gce/userdata_test.go
+++ b/provider/gce/userdata_test.go
@@ -52,7 +52,7 @@ func (s *UserdataSuite) TestGCEUnknownOS(c *gc.C) {
 	renderer := gce.GCERenderer{}
 	cloudcfg := &cloudinittest.CloudConfig{}
 
-	result, err := renderer.Render(cloudcfg, os.Arch)
+	result, err := renderer.Render(cloudcfg, os.GenericLinux)
 	c.Assert(result, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: Arch")
+	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: GenericLinux")
 }

--- a/provider/maas/userdata_test.go
+++ b/provider/maas/userdata_test.go
@@ -52,7 +52,7 @@ func (s *RenderersSuite) TestMAASWindows(c *gc.C) {
 func (s *RenderersSuite) TestMAASUnknownOS(c *gc.C) {
 	renderer := maas.MAASRenderer{}
 	cloudcfg := &cloudinittest.CloudConfig{}
-	result, err := renderer.Render(cloudcfg, os.Arch)
+	result, err := renderer.Render(cloudcfg, os.GenericLinux)
 	c.Assert(result, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: Arch")
+	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: GenericLinux")
 }

--- a/provider/openstack/userdata_test.go
+++ b/provider/openstack/userdata_test.go
@@ -47,7 +47,7 @@ func (s *UserdataSuite) TestOpenstackWindows(c *gc.C) {
 func (s *UserdataSuite) TestOpenstackUnknownOS(c *gc.C) {
 	renderer := openstack.OpenstackRenderer{}
 	cloudcfg := &cloudinittest.CloudConfig{}
-	result, err := renderer.Render(cloudcfg, os.Arch)
+	result, err := renderer.Render(cloudcfg, os.GenericLinux)
 	c.Assert(result, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: Arch")
+	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: GenericLinux")
 }


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/juju/+bug/1616531.

There are several parts to the change:

1. The juju/utils dependency has been updated so pull in the os.Arch -> os.GenericLinux change.
2. References to Arch (Arch Linux) constant have been replaced with GenericLinux.
3. The Azure provider no longer pretends to support Arch Linux instances in one area.
4. When using local tools, bootstrap will allow the client running on any Linux to bootstrap any Ubuntu or Centos series. Previously it was only possible for an Ubuntu client to bootstrap an Ubuntu controller or a Centos client to bootstrap a Centos controller.

### QA

Using local tools, bootstrapped:
* xenial controller using fedora client
* trusty controller using fedora client
* xenial controller using xenial client
* trusty controller using xenial client
* xenial controller using arch client
* xenial controller using debian client

Also confirmed that bootstrapping with --agent-version=2.0-beta18 works from:
* xenial
* fedora

