### PR TITLE
provider/azure: Active Directory/Graph API client

### DIFF
--- a/provider/azure/internal/ad/applications.go
+++ b/provider/azure/internal/ad/applications.go
@@ -1,0 +1,175 @@
+// NOTE(axw) this file contains a client for a subset of the
+// Microsoft Graph API, which is not currently supported by
+// the Azure SDK. When it is, this will be deleted.
+
+package ad
+
+import (
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ApplicationsClient struct {
+	ManagementClient
+}
+
+func (client ApplicationsClient) CreateOrUpdate(parameters Application, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(parameters, cancel)
+	if err != nil {
+		return result, autorest.NewErrorWithError(err, "ad.ApplicationsClient", "CreateOrUpdate", nil, "Failure preparing request")
+	}
+
+	resp, err := client.CreateOrUpdateSender(req)
+	if err != nil {
+		result.Response = resp
+		return result, autorest.NewErrorWithError(err, "ad.ApplicationsClient", "CreateOrUpdate", nil, "Failure sending request")
+	}
+
+	result, err = client.CreateOrUpdateResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "ad.ApplicationsClient", "CreateOrUpdate", nil, "Failure responding to request")
+	}
+
+	return
+}
+
+func (client ApplicationsClient) CreateOrUpdatePreparer(parameters Application, cancel <-chan struct{}) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": client.APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsJSON(),
+		autorest.AsPost(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPath("/applications"),
+		autorest.WithJSON(parameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare(&http.Request{Cancel: cancel})
+}
+
+func (client ApplicationsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
+}
+
+func (client ApplicationsClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
+		autorest.ByClosing())
+	result.Response = resp
+	return
+}
+
+func (client ApplicationsClient) List(filter string) (result ApplicationListResult, err error) {
+	req, err := client.ListPreparer(filter)
+	if err != nil {
+		return result, autorest.NewErrorWithError(err, "ad.ApplicationsClient", "List", nil, "Failure preparing request")
+	}
+
+	resp, err := client.ListSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		return result, autorest.NewErrorWithError(err, "ad.ApplicationsClient", "List", nil, "Failure sending request")
+	}
+
+	result, err = client.ListResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "ad.ApplicationsClient", "List", nil, "Failure responding to request")
+	}
+
+	return
+}
+
+func (client ApplicationsClient) ListPreparer(filter string) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": client.APIVersion,
+	}
+	if filter != "" {
+		queryParameters["$filter"] = autorest.Encode("query", filter)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPath("/applications"),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare(&http.Request{})
+}
+
+func (client ApplicationsClient) ListSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req)
+}
+
+func (client ApplicationsClient) ListResponder(resp *http.Response) (result ApplicationListResult, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+func (client ApplicationsClient) SetPassword(objectId string, parameters PasswordCredential) (result autorest.Response, err error) {
+	req, err := client.SetPasswordPreparer(objectId, parameters)
+	if err != nil {
+		return result, autorest.NewErrorWithError(err, "ad.ApplicationsClient", "SetPassword", nil, "Failure preparing request")
+	}
+
+	resp, err := client.SetPasswordSender(req)
+	if err != nil {
+		result.Response = resp
+		return result, autorest.NewErrorWithError(err, "ad.ApplicationsClient", "SetPassword", nil, "Failure sending request")
+	}
+
+	result, err = client.SetPasswordResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "ad.ApplicationsClient", "SetPassword", nil, "Failure responding to request")
+	}
+
+	return
+}
+
+func (client ApplicationsClient) SetPasswordPreparer(objectId string, parameters PasswordCredential) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"objectId": autorest.Encode("path", objectId),
+	}
+
+	queryParameters := map[string]interface{}{
+		"api-version": client.APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsJSON(),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/applications/{objectId}", pathParameters),
+		autorest.WithJSON(Application{
+			PasswordCredentials: []PasswordCredential{parameters},
+		}),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare(&http.Request{})
+}
+
+func (client ApplicationsClient) SetPasswordSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
+}
+
+func (client ApplicationsClient) SetPasswordResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
+		autorest.ByClosing())
+	result.Response = resp
+	return
+}

--- a/provider/azure/internal/ad/client.go
+++ b/provider/azure/internal/ad/client.go
@@ -1,0 +1,33 @@
+// NOTE(axw) this file contains a client for a subset of the
+// Microsoft Graph API, which is not currently supported by
+// the Azure SDK. When it is, this will be deleted.
+
+package ad
+
+import (
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/juju/juju/version"
+)
+
+const (
+	// APIVersion is the version of the Active Directory API
+	APIVersion = "1.6"
+)
+
+func UserAgent() string {
+	return "Juju/" + version.Current.String()
+}
+
+type ManagementClient struct {
+	autorest.Client
+	BaseURI    string
+	APIVersion string
+}
+
+func NewManagementClient(baseURI string) ManagementClient {
+	return ManagementClient{
+		Client:     autorest.NewClientWithUserAgent(UserAgent()),
+		BaseURI:    baseURI,
+		APIVersion: APIVersion,
+	}
+}

--- a/provider/azure/internal/ad/models.go
+++ b/provider/azure/internal/ad/models.go
@@ -1,0 +1,45 @@
+// NOTE(axw) this file contains types for a subset of the
+// Microsoft Graph API, which is not currently supported by
+// the Azure SDK. When it is, this will be deleted.
+
+package ad
+
+import (
+	"time"
+
+	"github.com/Azure/go-autorest/autorest"
+)
+
+type ApplicationListResult struct {
+	autorest.Response `json:"-"`
+	Value             []Application `json:"value,omitempty"`
+}
+
+type Application struct {
+	autorest.Response       `json:"-"`
+	ApplicationID           string               `json:"appId,omitempty"`
+	ObjectID                string               `json:"objectId,omitempty"`
+	AvailableToOtherTenants *bool                `json:"availableToOtherTenants,omitempty"`
+	DisplayName             string               `json:"displayName,omitempty"`
+	Homepage                string               `json:"homepage,omitempty"`
+	IdentifierURIs          []string             `json:"identifierUris,omitempty"`
+	PasswordCredentials     []PasswordCredential `json:"passwordCredentials,omitempty"`
+}
+
+type PasswordCredential struct {
+	KeyId     string    `json:"keyId,omitempty"`
+	Value     string    `json:"value,omitempty"`
+	StartDate time.Time `json:"startDate,omitempty"`
+	EndDate   time.Time `json:"endDate,omitempty"`
+}
+
+type ServicePrincipalListResult struct {
+	autorest.Response `json:"-"`
+	Value             []ServicePrincipal `json:"value,omitempty"`
+}
+
+type ServicePrincipal struct {
+	ApplicationID  string `json:"appId,omitempty"`
+	ObjectID       string `json:"objectId,omitempty"`
+	AccountEnabled bool   `json:"accountEnabled,omitempty"`
+}

--- a/provider/azure/internal/ad/serviceprincipals.go
+++ b/provider/azure/internal/ad/serviceprincipals.go
@@ -1,0 +1,118 @@
+// NOTE(axw) this file contains a client for a subset of the
+// Microsoft Graph API, which is not currently supported by
+// the Azure SDK. When it is, this will be deleted.
+
+package ad
+
+import (
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ServicePrincipalsClient struct {
+	ManagementClient
+}
+
+func (client ServicePrincipalsClient) CreateOrUpdate(parameters ServicePrincipal, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(parameters, cancel)
+	if err != nil {
+		return result, autorest.NewErrorWithError(err, "ad.ServicePrincipalsClient", "CreateOrUpdate", nil, "Failure preparing request")
+	}
+
+	resp, err := client.CreateOrUpdateSender(req)
+	if err != nil {
+		result.Response = resp
+		return result, autorest.NewErrorWithError(err, "ad.ServicePrincipalsClient", "CreateOrUpdate", nil, "Failure sending request")
+	}
+
+	result, err = client.CreateOrUpdateResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "ad.ServicePrincipalsClient", "CreateOrUpdate", nil, "Failure responding to request")
+	}
+
+	return
+}
+
+func (client ServicePrincipalsClient) CreateOrUpdatePreparer(parameters ServicePrincipal, cancel <-chan struct{}) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": client.APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsJSON(),
+		autorest.AsPost(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPath("/servicePrincipals"),
+		autorest.WithJSON(parameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare(&http.Request{Cancel: cancel})
+}
+
+func (client ServicePrincipalsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
+}
+
+func (client ServicePrincipalsClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
+		autorest.ByClosing())
+	result.Response = resp
+	return
+}
+
+func (client ServicePrincipalsClient) List(filter string) (result ServicePrincipalListResult, err error) {
+	req, err := client.ListPreparer(filter)
+	if err != nil {
+		return result, autorest.NewErrorWithError(err, "ad.ServicePrincipalsClient", "List", nil, "Failure preparing request")
+	}
+
+	resp, err := client.ListSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		return result, autorest.NewErrorWithError(err, "ad.ServicePrincipalsClient", "List", nil, "Failure sending request")
+	}
+
+	result, err = client.ListResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "ad.ServicePrincipalsClient", "List", nil, "Failure responding to request")
+	}
+
+	return
+}
+
+func (client ServicePrincipalsClient) ListPreparer(filter string) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": client.APIVersion,
+	}
+	if filter != "" {
+		queryParameters["$filter"] = autorest.Encode("query", filter)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPath("/servicePrincipals"),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare(&http.Request{})
+}
+
+func (client ServicePrincipalsClient) ListSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req)
+}
+
+func (client ServicePrincipalsClient) ListResponder(resp *http.Response) (result ServicePrincipalListResult, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}


### PR DESCRIPTION
We add a minimal client for the Active Directory/Graph API.
This will be used by the Azure provider to manipulate
application and service principal objects in order to
automate credential creation.