### PR TITLE
Update FinalizeCredential, use in add-credential

### DIFF
--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -76,6 +76,22 @@ func (p *mockProvider) CredentialSchemas() map[jujucloud.AuthType]jujucloud.Cred
 	return *p.credSchemas
 }
 
+func (p *mockProvider) FinalizeCredential(
+	ctx environs.FinalizeCredentialContext,
+	args environs.FinalizeCredentialParams,
+) (*jujucloud.Credential, error) {
+	if args.Credential.AuthType() == "interactive" {
+		fmt.Fprintln(ctx.GetStderr(), "generating userpass credential")
+		out := jujucloud.NewCredential(jujucloud.UserPassAuthType, map[string]string{
+			"username":             args.Credential.Attributes()["username"],
+			"password":             args.CloudEndpoint,
+			"application-password": args.CloudIdentityEndpoint,
+		})
+		return &out, nil
+	}
+	return &args.Credential, nil
+}
+
 func (s *detectCredentialsSuite) SetUpSuite(c *gc.C) {
 	environs.RegisterProvider("mock-provider", &mockProvider{detectedCreds: &s.aCredential})
 }

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -421,7 +421,12 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	store := c.ClientStore()
 	var detectedCredentialName string
 	credential, credentialName, regionName, err := modelcmd.GetCredentials(
-		ctx, store, c.Region, c.CredentialName, c.Cloud, cloud.Type,
+		ctx, store, modelcmd.GetCredentialsParams{
+			Cloud:          *cloud,
+			CloudName:      c.Cloud,
+			CloudRegion:    c.Region,
+			CredentialName: c.CredentialName,
+		},
 	)
 	if errors.Cause(err) == modelcmd.ErrMultipleCredentials {
 		return ambiguousCredentialError

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -426,8 +426,12 @@ func (c *addModelCommand) maybeUploadCredential(
 
 	// Upload the credential from the client, if it exists locally.
 	credential, _, _, err := modelcmd.GetCredentials(
-		ctx, c.ClientStore(), c.CloudRegion, credentialTag.Name(),
-		cloudTag.Id(), cloud.Type,
+		ctx, c.ClientStore(), modelcmd.GetCredentialsParams{
+			Cloud:          cloud,
+			CloudName:      cloudTag.Id(),
+			CloudRegion:    c.CloudRegion,
+			CredentialName: credentialTag.Name(),
+		},
 	)
 	if err != nil {
 		return names.CloudCredentialTag{}, errors.Trace(err)

--- a/cmd/juju/controller/listcontrollersformatters.go
+++ b/cmd/juju/controller/listcontrollersformatters.go
@@ -35,7 +35,8 @@ func formatControllersTabular(writer io.Writer, set ControllerSet, promptRefresh
 	w := output.Wrapper{tw}
 
 	if promptRefresh && len(set.Controllers) > 0 {
-		fmt.Fprintln(writer, "Use --refresh to see the latest information.\n")
+		fmt.Fprintln(writer, "Use --refresh to see the latest information.")
+		fmt.Fprintln(writer)
 	}
 	w.Println("CONTROLLER", "MODEL", "USER", "ACCESS", "CLOUD/REGION", "MODELS", "MACHINES", "HA", "VERSION")
 	tw.SetColumnAlignRight(5)

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -392,13 +392,26 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 
 	var credential *cloud.Credential
 	if bootstrapConfig.Credential != "" {
+		bootstrapCloud := cloud.Cloud{
+			Type:             bootstrapConfig.CloudType,
+			Endpoint:         bootstrapConfig.CloudEndpoint,
+			IdentityEndpoint: bootstrapConfig.CloudIdentityEndpoint,
+		}
+		if bootstrapConfig.CloudRegion != "" {
+			bootstrapCloud.Regions = []cloud.Region{{
+				Name:             bootstrapConfig.CloudRegion,
+				Endpoint:         bootstrapConfig.CloudEndpoint,
+				IdentityEndpoint: bootstrapConfig.CloudIdentityEndpoint,
+			}}
+		}
 		credential, _, _, err = GetCredentials(
-			g.ctx,
-			g.store,
-			bootstrapConfig.CloudRegion,
-			bootstrapConfig.Credential,
-			bootstrapConfig.Cloud,
-			bootstrapConfig.CloudType,
+			g.ctx, g.store,
+			GetCredentialsParams{
+				Cloud:          bootstrapCloud,
+				CloudName:      bootstrapConfig.Cloud,
+				CloudRegion:    bootstrapConfig.CloudRegion,
+				CredentialName: bootstrapConfig.Credential,
+			},
 		)
 		if err != nil {
 			return nil, nil, errors.Trace(err)

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -92,17 +92,38 @@ type ProviderCredentials interface {
 	DetectCredentials() (*cloud.CloudCredential, error)
 
 	// FinalizeCredential finalizes a credential, updating any attributes
-	// as necessary. This is always done client-side, before uploading
-	// credentials to the controller. The provider may completely alter
-	// a credential, even going as far as changing the auth-type, but
-	// the output must be a fully formed credential.
-	FinalizeCredential(FinalizeCredentialContext, cloud.Credential) (cloud.Credential, error)
+	// as necessary. This is always done client-side, when adding the
+	// credential to credentials.yaml and before uploading credentials to
+	// the controller. The provider may completely alter a credential, even
+	// going as far as changing the auth-type, but the output must be a
+	// fully formed credential.
+	FinalizeCredential(
+		FinalizeCredentialContext,
+		FinalizeCredentialParams,
+	) (*cloud.Credential, error)
 }
 
 // FinalizeCredentialContext is an interface passed into FinalizeCredential
 // to provide a means of interacting with the user when finalizing credentials.
 type FinalizeCredentialContext interface {
 	GetStderr() io.Writer
+}
+
+// FinalizeCredentialParams contains the parameters for
+// ProviderCredentials.FinalizeCredential.
+type FinalizeCredentialParams struct {
+	// Credential is the credential that the provider should finalize.`
+	Credential cloud.Credential
+
+	// CloudEndpoint is the endpoint for the cloud that the credentials are
+	// for. This may be used by the provider to communicate with the cloud
+	// to finalize the credentials.
+	CloudEndpoint string
+
+	// CloudIdentityEndpoint is the identity endpoint for the cloud that the
+	// credentials are for. This may be used by the provider to communicate
+	// with the cloud to finalize the credentials.
+	CloudIdentityEndpoint string
 }
 
 // CloudRegionDetector is an interface that an EnvironProvider implements

--- a/provider/azure/credentials_test.go
+++ b/provider/azure/credentials_test.go
@@ -75,8 +75,9 @@ func (s *credentialsSuite) TestFinalizeCredentialUserPass(c *gc.C) {
 		"tenant-id":            "tenant",
 	})
 	ctx := testing.Context(c)
-	out, err := s.provider.FinalizeCredential(ctx, in)
+	out, err := s.provider.FinalizeCredential(ctx, environs.FinalizeCredentialParams{Credential: in})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out, gc.NotNil)
 	c.Assert(out.AuthType(), gc.Equals, cloud.AuthType("service-principal-secret"))
 	c.Assert(out.Attributes(), jc.DeepEquals, map[string]string{
 		"application-id":       "application",

--- a/provider/cloudsigma/credentials.go
+++ b/provider/cloudsigma/credentials.go
@@ -38,6 +38,6 @@ func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, e
 }
 
 // FinalizeCredential is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
-	return in, nil
+func (environProviderCredentials) FinalizeCredential(_ environs.FinalizeCredentialContext, args environs.FinalizeCredentialParams) (*cloud.Credential, error) {
+	return &args.Credential, nil
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -562,8 +562,8 @@ func (*environProvider) DetectCredentials() (*cloud.CloudCredential, error) {
 	return cloud.NewEmptyCloudCredential(), nil
 }
 
-func (*environProvider) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
-	return in, nil
+func (*environProvider) FinalizeCredential(ctx environs.FinalizeCredentialContext, args environs.FinalizeCredentialParams) (*cloud.Credential, error) {
+	return &args.Credential, nil
 }
 
 func (*environProvider) DetectRegions() ([]cloud.Region, error) {

--- a/provider/ec2/credentials.go
+++ b/provider/ec2/credentials.go
@@ -129,6 +129,6 @@ func (environProviderCredentials) detectEnvCredentials() (*cloud.CloudCredential
 }
 
 // FinalizeCredential is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
-	return in, nil
+func (environProviderCredentials) FinalizeCredential(_ environs.FinalizeCredentialContext, args environs.FinalizeCredentialParams) (*cloud.Credential, error) {
+	return &args.Credential, nil
 }

--- a/provider/gce/credentials.go
+++ b/provider/gce/credentials.go
@@ -139,6 +139,6 @@ func parseJSONAuthFile(r io.Reader) (cloud.Credential, error) {
 }
 
 // FinalizeCredential is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
-	return in, nil
+func (environProviderCredentials) FinalizeCredential(_ environs.FinalizeCredentialContext, args environs.FinalizeCredentialParams) (*cloud.Credential, error) {
+	return &args.Credential, nil
 }

--- a/provider/joyent/credentials.go
+++ b/provider/joyent/credentials.go
@@ -52,6 +52,6 @@ func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, e
 }
 
 // FinalizeCredential is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
-	return in, nil
+func (environProviderCredentials) FinalizeCredential(_ environs.FinalizeCredentialContext, args environs.FinalizeCredentialParams) (*cloud.Credential, error) {
+	return &args.Credential, nil
 }

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -26,6 +26,6 @@ func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, e
 }
 
 // FinalizeCredential is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
-	return in, nil
+func (environProviderCredentials) FinalizeCredential(_ environs.FinalizeCredentialContext, args environs.FinalizeCredentialParams) (*cloud.Credential, error) {
+	return &args.Credential, nil
 }

--- a/provider/maas/credentials.go
+++ b/provider/maas/credentials.go
@@ -85,6 +85,6 @@ func parseOAuthToken(cred cloud.Credential) (string, error) {
 var errMalformedMaasOAuth = errors.New("malformed maas-oauth (3 items separated by colons)")
 
 // FinalizeCredential is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
-	return in, nil
+func (environProviderCredentials) FinalizeCredential(_ environs.FinalizeCredentialContext, args environs.FinalizeCredentialParams) (*cloud.Credential, error) {
+	return &args.Credential, nil
 }

--- a/provider/manual/credentials.go
+++ b/provider/manual/credentials.go
@@ -21,6 +21,6 @@ func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, e
 }
 
 // FinalizeCredential is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
-	return in, nil
+func (environProviderCredentials) FinalizeCredential(_ environs.FinalizeCredentialContext, args environs.FinalizeCredentialParams) (*cloud.Credential, error) {
+	return &args.Credential, nil
 }

--- a/provider/openstack/credentials.go
+++ b/provider/openstack/credentials.go
@@ -151,6 +151,6 @@ func (c OpenstackCredentials) detectCredential() (*cloud.Credential, string, str
 }
 
 // FinalizeCredential is part of the environs.ProviderCredentials interface.
-func (OpenstackCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
-	return in, nil
+func (OpenstackCredentials) FinalizeCredential(_ environs.FinalizeCredentialContext, args environs.FinalizeCredentialParams) (*cloud.Credential, error) {
+	return &args.Credential, nil
 }

--- a/provider/rackspace/provider_test.go
+++ b/provider/rackspace/provider_test.go
@@ -95,7 +95,7 @@ func (p *fakeProvider) DetectCredentials() (*cloud.CloudCredential, error) {
 	return nil, errors.NotFoundf("credentials")
 }
 
-func (p *fakeProvider) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
-	p.MethodCall(p, "FinalizeCredential", ctx, in)
-	return in, nil
+func (p *fakeProvider) FinalizeCredential(ctx environs.FinalizeCredentialContext, args environs.FinalizeCredentialParams) (*cloud.Credential, error) {
+	p.MethodCall(p, "FinalizeCredential", ctx, args)
+	return &args.Credential, nil
 }

--- a/provider/vsphere/credentials.go
+++ b/provider/vsphere/credentials.go
@@ -41,6 +41,6 @@ func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, e
 }
 
 // FinalizeCredential is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, in cloud.Credential) (cloud.Credential, error) {
-	return in, nil
+func (environProviderCredentials) FinalizeCredential(_ environs.FinalizeCredentialContext, args environs.FinalizeCredentialParams) (*cloud.Credential, error) {
+	return &args.Credential, nil
 }


### PR DESCRIPTION
This diff updates the FinalizeCredential provider
method to take cloud endpoints, so that providers
can communicate with the cloud in order to finalize
the credential. Specifically, Azure needs to connect
to Active Directory to perform interactive authentication,
and then configure the service principal.

**QA**

With a follow-up branch that adds interactive auth-type
for azure, I have done the following:

 1. juju add-credential azure
 2. specify credential name, and select "interactive" auth-type
 3. go to microsoft login page as directed, wait while Juju
    sets up the service principal
 4. bootstrap with the new credential
 5. bob's your uncle

It is also possible, even if undesirable, to add an
interactive auth-type credential in credentials.yaml by
hand, and go through the above steps at bootstrap or
add-model time. The service principal password will not
be persisted to disk then.