### PR TITLE
Update LXD network templates for Juju

### DIFF
--- a/tools/lxdclient/instance.go
+++ b/tools/lxdclient/instance.go
@@ -76,8 +76,11 @@ type InstanceSpec struct {
 	// Metadata is the instance metadata.
 	Metadata map[string]string
 
-	// Devices to be added at container initialisation time
+	// Devices to be added at container initialisation time.
 	Devices
+
+	// LXD templates to be written before start.
+	Templates
 
 	// TODO(ericsnow) Other possible fields:
 	// Disks


### PR DESCRIPTION
Adds the ability to write out LXD templates before a container is
started, and uses this to update the networking templates with what Juju
requires for the container's ENI.

This prevents the default LXD behaviour, which is to expect DHCP on
eth0, breaking container provisioning when DHCP is not available on eth0.

Fixes lp:1611981

QA steps:
  * Test in a MAAS environment with two NICs per node, where the NIC with the higher sorting name  is on the PXE/DHCP space, and ensuring the other space does not serve DHCP
    - NICs can be renamed in MAAS on a node's page
    - For example, if ens3 and ens4 are named by default, and ens3 is the PXE/DHCP interface, rename ens3 as 'nicZ' and ens4 as 'nicA'
    - You may also like to assign a static IP addr to the second ('nicA' in this example) interface
  * `juju add-machine lxd:<host>` for a xenial container
    - The container should start
    - In the container, `/etc/network/interfaces` should source `/etc/network/interfaces.d/*.cfg`
    - In the container, `/etc/network/interfaces.d/` should have a `.cfg` file configuring its interfaces and nameservers correct for the environment (eth0 with an address in nicA's space, in this example, and eth1 in nicZ's)
  * Repeat with a trusty container, `juju add-machine --series trusty lxd:<host>`

(RB link: http://reviews.vapour.ws/r/5706/)