### PR TITLE
Reword N/A to none in list-controllers

### DIFF
--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -116,10 +116,10 @@ func (s *ListControllersSuite) TestListControllersKnownHAStatus(c *gc.C) {
 	s.createTestClientStore(c)
 	s.setupAPIForControllerMachines()
 	s.expectedOutput = `
-CONTROLLER           MODEL       USER         ACCESS     CLOUD/REGION        MODELS  MACHINES   HA  VERSION
-aws-test             controller  admin@local  (unknown)  aws/us-east-1            1         2  1/3  2.0.1      
-mallards*            my-model    admin@local  superuser  mallards/mallards1       2         4  N/A  (unknown)  
-mark-test-prodstack  -           admin@local  (unknown)  prodstack                -         -    -  (unknown)  
+CONTROLLER           MODEL       USER         ACCESS     CLOUD/REGION        MODELS  MACHINES    HA  VERSION
+aws-test             controller  admin@local  (unknown)  aws/us-east-1            1         2   1/3  2.0.1      
+mallards*            my-model    admin@local  superuser  mallards/mallards1       2         4  none  (unknown)  
+mark-test-prodstack  -           admin@local  (unknown)  prodstack                -         -     -  (unknown)  
 
 `[1:]
 	s.assertListControllers(c, "--refresh")

--- a/cmd/juju/controller/listcontrollersformatters.go
+++ b/cmd/juju/controller/listcontrollersformatters.go
@@ -113,7 +113,7 @@ func controllerMachineStatus(machines *ControllerMachines) (string, bool) {
 		return "-", false
 	}
 	if machines.Total == 1 {
-		return "N/A", false
+		return "none", false
 	}
 	controllerMachineStatus := ""
 	warn := machines.Active < machines.Total


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1623919

When there is no HA, list controllers will show "none" instead of "N/A"