### PR TITLE
Add region to model-defaults

### DIFF
--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -41,7 +41,7 @@ type ModelManagerBackend interface {
 	GetModel(names.ModelTag) (Model, error)
 	Model() (Model, error)
 	ModelConfigDefaultValues() (config.ModelDefaultAttributes, error)
-	UpdateModelConfigDefaultValues(update map[string]interface{}, remove []string) error
+	UpdateModelConfigDefaultValues(update map[string]interface{}, remove []string, cloudTag, regionName string) error
 	Unit(name string) (*state.Unit, error)
 	ModelTag() names.ModelTag
 	ModelConfig() (*config.Config, error)

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -804,7 +804,6 @@ func (c *ModelManagerAPI) SetModelDefaults(args params.SetModelDefaults) (params
 		return results, errors.Trace(err)
 	}
 	for i, arg := range args.Config {
-		// TODO(wallyworld) - use arg.Cloud and arg.CloudRegion as appropriate
 		results.Results[i].Error = common.ServerError(
 			c.setModelDefaults(arg),
 		)
@@ -824,7 +823,8 @@ func (c *ModelManagerAPI) setModelDefaults(args params.ModelDefaultValues) error
 	if _, found := args.Config["agent-version"]; found {
 		return errors.New("agent-version cannot have a default value")
 	}
-	return c.state.UpdateModelConfigDefaultValues(args.Config, nil)
+
+	return c.state.UpdateModelConfigDefaultValues(args.Config, nil, args.CloudTag, args.CloudRegion)
 }
 
 // UnsetModelDefaults removes the specified default model settings.
@@ -837,10 +837,10 @@ func (c *ModelManagerAPI) UnsetModelDefaults(args params.UnsetModelDefaults) (pa
 	if err := c.check.ChangeAllowed(); err != nil {
 		return results, errors.Trace(err)
 	}
+
 	for i, arg := range args.Keys {
-		// TODO(wallyworld) - use arg.Cloud and arg.CloudRegion as appropriate
 		results.Results[i].Error = common.ServerError(
-			c.state.UpdateModelConfigDefaultValues(nil, arg.Keys),
+			c.state.UpdateModelConfigDefaultValues(nil, arg.Keys, arg.CloudTag, arg.CloudRegion),
 		)
 	}
 	return results, nil

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -389,14 +389,21 @@ func (s *modelManagerSuite) TestUnsetModelDefaults(c *gc.C) {
 	result, err := s.api.UnsetModelDefaults(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.OneError(), jc.ErrorIsNil)
-	c.Assert(s.st.cfgDefaults, jc.DeepEquals, config.ModelDefaultAttributes{
-		"attr2": {
-			Controller: "val3",
+	want := config.ModelDefaultAttributes{
+		"attr": config.AttributeDefaultValues{
+			Regions: []config.RegionDefaultValue{
+				config.RegionDefaultValue{
+					Name:  "dummy",
+					Value: "val++"},
+			}},
+		"attr2": config.AttributeDefaultValues{
 			Default:    "val2",
-			Regions: []config.RegionDefaultValue{{
-				Name:  "left",
-				Value: "spam"}}},
-	})
+			Controller: "val3",
+			Regions: []config.RegionDefaultValue{
+				config.RegionDefaultValue{
+					Name:  "left",
+					Value: "spam"}}}}
+	c.Assert(s.st.cfgDefaults, jc.DeepEquals, want)
 }
 
 func (s *modelManagerSuite) TestBlockUnsetModelDefaults(c *gc.C) {

--- a/cmd/juju/model/defaultscommand.go
+++ b/cmd/juju/model/defaultscommand.go
@@ -2,18 +2,31 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 package model
 
+// tests to add
+// Test for no arg
+// Test for region only
+// Test for cloud only - fail because unknown key -- just cloud is invalid
+// Test for cloud/region - valid
+// TEst for cloud/region - invalid
+
 import (
 	"bytes"
 	"io"
 	"sort"
 	"strings"
 
+	names "gopkg.in/juju/names.v2"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/utils/keyvalues"
 
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	cloudapi "github.com/juju/juju/api/cloud"
 	"github.com/juju/juju/api/modelmanager"
+	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
@@ -45,20 +58,41 @@ See also:
 
 // NewDefaultsCommand wraps defaultsCommand with sane model settings.
 func NewDefaultsCommand() cmd.Command {
-	return modelcmd.WrapController(&defaultsCommand{})
+	defaultsCmd := &defaultsCommand{
+		newCloudAPI: func(caller base.APICallCloser) cloudAPI {
+			return cloudapi.NewClient(caller)
+		},
+		newDefaultsAPI: func(caller base.APICallCloser) defaultsCommandAPI {
+			return modelmanager.NewClient(caller)
+		},
+	}
+	defaultsCmd.newAPIRoot = defaultsCmd.NewAPIRoot
+	return modelcmd.WrapController(defaultsCmd)
 }
 
 // defaultsCommand is compound command for accessing and setting attributes
 // related to default model configuration.
 type defaultsCommand struct {
-	modelcmd.ControllerCommandBase
-	api defaultsCommandAPI
 	out cmd.Output
+	modelcmd.ControllerCommandBase
 
-	action func(defaultsCommandAPI, *cmd.Context) error // The function handling the input, set in Init.
-	keys   []string
-	reset  bool // Flag indicating if we are resetting the keys provided.
-	values attributes
+	newAPIRoot     func() (api.Connection, error)
+	newDefaultsAPI func(base.APICallCloser) defaultsCommandAPI
+	newCloudAPI    func(base.APICallCloser) cloudAPI
+
+	action                func(defaultsCommandAPI, *cmd.Context) error // The function handling the input, set in Init.
+	key                   string
+	resetKeys             []string
+	cloudName, regionName string
+	reset                 string // Flag containing a comma seperated list of keys to reset.
+	values                attributes
+}
+
+// cloudAPI defines an API to be passed in for testing.
+type cloudAPI interface {
+	Close() error
+	DefaultCloud() (names.CloudTag, error)
+	Cloud(names.CloudTag) (jujucloud.Cloud, error)
 }
 
 // defaultsCommandAPI defines an API to be used during testing.
@@ -97,120 +131,425 @@ func (c *defaultsCommand) SetFlags(f *gnuflag.FlagSet) {
 		"json":    cmd.FormatJson,
 		"tabular": formatDefaultConfigTabular,
 	})
-	f.BoolVar(&c.reset, "reset", false, "Reset the provided keys to be empty")
+	f.StringVar(&c.reset, "reset", "", "Reset the provided keys")
 }
 
 // Init implements part of the cmd.Command interface.
+// Abandon all hope ye who enter here....
+// This needs to parse the a command line invocation as defined in
+// https://goo.gl/yqrrPI.
+// So the following 3 lines are all equivalent:
+// juju model-defaults aws/us-east-1 foo=baz --reset bar
+// juju model-defaults aws/us-east-1 --reset bar foo=baz
+// juju model-defaults --reset bar aws/us-east-1 foo=baz
+//
+// They all set foo=baz and unset bar in aws/us-east-1
+// If aws is the cloud of the current or specified controller -- as specified
+// by -c somecontroller or -m somecontroller:somemodel -- then the following
+// 3 lines would also be equivalent.
+// juju model-defaults us-east-1 foo=baz --reset bar
+// juju model-defaults us-east-1 --reset bar foo=baz
+// juju model-defaults --reset bar us-east-1 foo=baz
+//
+// If one doesn't specify a cloud or region the command is still valid but for
+// setting the default on the controller. So the following two commands are
+// equivalent.
+// juju model-defaults foo=baz --reset bar
+// juju model-defaults --reset bar foo=baz
+//
+// Of course one can specify multiple keys to reset --reset a,b,c and one can
+// also specify multiple values to set a=b c=d e=f. I.e. comma separated for
+// reset and space separated for setting. One may also only set or reset as a
+// singular action. The last two here are equivalent.
+// juju model-defaults --reset foo
+// juju model-defaults a=b c=d e=f
+// juju model-defaults a=b c=d --reset e,f
+// juju model-defaults --reset e,f a=b c=d
+//
+// cloud/region may also be specified so above examples with that option might
+// be like the following three equivalent invokations.
+// juju model-defaults us-east-1 a=b c=d --reset e,f
+// juju model-defaults us-east-1 --reset e,f a=b c=d
+// juju model-defaults --reset e,f us-east-1 a=b c=d
+//
+// Finally one can also ask for the all the defaults or the defaults for one
+// specific setting. In this case specifying a region is not valid as
+// model-defaults shows the settings for a value at all locations that it has a
+// default set -- or at a minimum the default and  "-" for a controller with no
+// value set.
+// simultaneously.
+// juju model-defaults
+// juju model-defaults no-proxy
+//
+// It is not valid to reset and get or to set and get values. It is also neiter
+// valid to reset and set the same key, nor to set the same key to different
+// values in the same command.
+//
+// For those playing along that all means the first positional arg can be a
+// cloud/region, a region, a key=value to set, a key to get the settings for,
+// or empty. Other caveats are that one cannot set and reset a value for the
+// same key, that is to say keys to be mutated must be unique.
+//
+// Here we go...
 func (c *defaultsCommand) Init(args []string) error {
-	if c.reset {
-		// We're resetting defaults.
-		if len(args) == 0 {
-			return errors.New("no keys specified")
-		}
-		for _, k := range args {
+	var err error
+	//  If there's nothing to reset and no args we're returning everything. So
+	//  we short circuit immediately.
+	if len(args) == 0 && c.reset == "" {
+		c.action = c.getDefaults
+		return nil
+	}
+
+	// If there is an argument provided to reset, we turn it into a slice of
+	// strings and verify them. If there is one or more valid keys to reset and
+	// no other errors initalizing the command, c.resetDefaults will be called
+	// in c.Run.
+	if err = c.parseResetKeys(); err != nil {
+		return errors.Trace(err)
+	}
+
+	// Look at the first positional arg and test to see if it is a valid
+	// optional specification of cloud/region or region. If it is then
+	// cloudName and regionName or only regionName are set on the object and
+	// the positional args are returned without the first element. If it cannot
+	// be validated; cloudName and regionName are left empty and we get back
+	// the same args we passed in.
+	args, err = c.parseArgsForRegion(args)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Remember we *might* have one less arg at this point if we chopped the
+	// first off because it was a valid cloud/region option.
+	switch {
+	case len(args) > 0 && strings.Contains(args[len(args)-1], "="):
+		// In the event that we are setting values, the final positional arg
+		// will always have an "=" in it. So if we see that we know we want to
+		// set args.
+		return c.handleSetArgs(args)
+	case len(args) == 0:
+		// This should be reset only (but possibly for a region).
+		return c.handleZeroArgs()
+	case len(args) == 1:
+		// We want to get settings for the provided key.
+		return c.handleOneArg(args[0])
+	default: // case args > 1
+		// Specifying any positional args after a key=value pair is
+		// invalid input. So if we have more than one the input is almost
+		// certainly invalid, but in different possible ways.
+		return c.handleExtraArgs(args)
+	}
+
+}
+
+// parseResetKeys splits the keys provided to --reset after trimming any
+// leading or trailing comma. It then verifies that we haven't incorrectly
+// received any key=value pairs and finally sets the value(s) on c.resetKeys.
+func (c *defaultsCommand) parseResetKeys() error {
+	if c.reset != "" {
+		resetKeys := strings.Split(strings.Trim(c.reset, ","), ",")
+
+		for _, k := range resetKeys {
 			if k == config.AgentVersionKey {
 				return errors.Errorf("%q cannot be reset", config.AgentVersionKey)
 			}
-		}
-		c.keys = args
-
-		c.action = c.resetDefaults
-		return nil
-	}
-
-	if len(args) > 0 && strings.Contains(args[0], "=") {
-		// We're setting defaults.
-		options, err := keyvalues.Parse(args, true)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		c.values = make(attributes)
-		for k, v := range options {
-			if k == config.AgentVersionKey {
-				return errors.Errorf(`%q must be set via "upgrade-juju"`, config.AgentVersionKey)
+			if strings.Contains(k, "=") {
+				return errors.Errorf(
+					`--reset accepts a single key "a" or comma delimited keys "a,b,c", received: %q`, k)
 			}
-			c.values[k] = v
 		}
-
-		c.action = c.setDefaults
-		return nil
-
+		c.resetKeys = resetKeys
 	}
-	// We're getting defaults.
-	val, err := cmd.ZeroOrOneArgs(args)
-	if err != nil {
-		return errors.New("can only retrieve a single value, or all values")
-	}
-	if val != "" {
-		c.keys = []string{val}
-	}
-	c.action = c.getDefaults
 	return nil
 }
 
-// getAPI sets the api on the command. This allows passing in a test
-// ModelDefaultsAPI implementation.
-func (c *defaultsCommand) getAPI() (defaultsCommandAPI, error) {
-	if c.api != nil {
-		return c.api, nil
+// parseArgsForRegion parses args to check if the first arg is a region and
+// returns the appropriate remaining args.
+func (c *defaultsCommand) parseArgsForRegion(args []string) ([]string, error) {
+	var err error
+	if len(args) > 0 {
+		// determine if the first arg is cloud/region or region and return
+		// appropriate positional args.
+		args, err = c.parseCloudRegion(args)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+	return args, nil
+}
+
+// parseCloudRegion examines args to see if the first arg is a cloud/region or
+// region. If not it returns the full args slice. If it is then it sets cloud
+// and/or region on the object and sends the remaining args back to the caller.
+func (c *defaultsCommand) parseCloudRegion(args []string) ([]string, error) {
+	var cloud, region string
+	cr := args[0]
+	// Must have no more than one slash and it must not be at the beginning or end.
+	if strings.Count(cr, "/") == 1 && !strings.HasPrefix(cr, "/") && !strings.HasSuffix(cr, "/") {
+		elems := strings.Split(cr, "/")
+		cloud, region = elems[0], elems[1]
+	} else {
+		region = cr
 	}
 
-	api, err := c.NewAPIRoot()
+	valid, err := c.validCloudRegion(cloud, region)
 	if err != nil {
-		return nil, errors.Annotate(err, "opening API connection")
+		return nil, errors.Trace(err)
 	}
-	client := modelmanager.NewClient(api)
+	if !valid {
+		return args, nil
+	}
+	c.cloudName = cloud
+	c.regionName = region
+	return args[1:], nil
+}
 
-	return client, nil
+// validCloudRegion checks that region is a valid region in cloud, or default cloud
+// if cloud is not specified.
+func (c *defaultsCommand) validCloudRegion(cloudName, region string) (bool, error) {
+	var (
+		isCloudRegion bool
+		cloud         jujucloud.Cloud
+		cTag          names.CloudTag
+		err           error
+	)
+
+	root, err := c.newAPIRoot()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	cc := c.newCloudAPI(root)
+	defer cc.Close()
+
+	if cloudName == "" {
+		cTag, err = cc.DefaultCloud()
+		if err != nil {
+			return false, errors.Trace(err)
+		}
+	} else {
+		cTag = names.NewCloudTag(cloudName)
+	}
+	cloud, err = cc.Cloud(cTag)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+
+	for _, r := range cloud.Regions {
+		if r.Name == region {
+			isCloudRegion = true
+			break
+		}
+	}
+	return isCloudRegion, nil
+}
+
+// parseSetKeys iterates over the args and make sure that the key=value pairs
+// are valid. It also checks that the same key isn't also being reset.
+func (c *defaultsCommand) parseSetKeys(args []string) error {
+	options, err := keyvalues.Parse(args, true)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	keyCounter := map[string]int{}
+	c.values = make(attributes)
+	for k, v := range options {
+		if k == config.AgentVersionKey {
+			return errors.Errorf(`%q must be set via "upgrade-juju"`, config.AgentVersionKey)
+		}
+		keyCounter[k]++
+		c.values[k] = v
+	}
+	for _, resetKey := range c.resetKeys {
+		keyCounter[resetKey]++
+		if keyCounter[resetKey] > 1 {
+			return errors.Errorf(`key %q specified more than once`, resetKey)
+		}
+	}
+	return nil
+
+}
+
+// handleSetArgs parses args for setting defaults.
+func (c *defaultsCommand) handleSetArgs(args []string) error {
+	argZeroKeyOnly := !strings.Contains(args[0], "=")
+	// If an invalid region was specified, the first positional arg won't have
+	// an "=". If we see one here we know it is invalid.
+	switch {
+	case argZeroKeyOnly && c.regionName == "":
+		return errors.Errorf("invalid region specified: %q", args[0])
+	case argZeroKeyOnly && c.regionName != "":
+		return errors.New("cannot set and retrieve default values simultaneously")
+	default:
+		if err := c.parseSetKeys(args); err != nil {
+			return errors.Trace(err)
+		}
+		c.action = c.setDefaults
+		return nil
+	}
+}
+
+// handleZeroArgs determines whether we are doing a reset only and if any
+// additional arguments are valid -- or why they are not.
+func (c *defaultsCommand) handleZeroArgs() error {
+	resetSpecified := c.resetKeys != nil
+	regionSpecified := c.regionName != ""
+
+	switch {
+	case regionSpecified && !resetSpecified:
+		// It doesn't make sense to specify a region unless we are resetting
+		// values here.
+		return errors.New("specifying a region when retrieving defaults is invalid")
+	case regionSpecified && resetSpecified:
+		// We can reset for a region, c.action stays nil. We want do reset
+		// only.
+		return nil
+	case !regionSpecified && resetSpecified:
+		// Again we want to reset, this is for resetting the controller as
+		// there is no region specified. So c.action remains nil.
+		return nil
+		// case !regionSpecified && !resetSpecified:
+		// This means just get everything, but we should never arrive here if
+		// we short circuited at the begining of c.Init.
+		// c.action = c.getDefaults
+		// return nil
+	default:
+		// This should be unreachable.
+		return errors.New("unexpected input, please file a bug")
+	}
+}
+
+// handleOneArg handles the case where we have one positional arg after
+// processing for a region and the reset flag after processing for a region and
+// the reset flagg.
+func (c *defaultsCommand) handleOneArg(arg string) error {
+	resetSpecified := c.resetKeys != nil
+	regionSpecified := c.regionName != ""
+
+	switch {
+	case regionSpecified && !resetSpecified:
+		// It doesn't make sense to specify a region unless we are resetting
+		// values here.
+		return errors.New("specifying a region when retrieving defaults for a setting is invalid")
+	case !regionSpecified && resetSpecified:
+		// It makes no sense to supply a positional arg that isn't a region if
+		// we are resetting a region, so we must have gotten an invalid region.
+		return errors.Errorf("invalid region specified: %q", arg)
+	case !regionSpecified && !resetSpecified:
+		// Phew, we can retrieve a value.
+		c.key = arg
+		c.action = c.getDefaults
+		return nil
+	case regionSpecified && resetSpecified:
+		// If a region was specified and reset was specified, we shouldn't have
+		// an extra arg. If it had an "=" in it, we should have handled it
+		// already.
+		return errors.New("cannot retrieve defaults for a key and reset args at the same time")
+	default:
+		// This should be unreachable.
+		return errors.New("unexpected input, please file a bug")
+	}
+}
+
+// handleExtraArgs handles the case where too many args were supplied.
+func (c *defaultsCommand) handleExtraArgs(args []string) error {
+	resetSpecified := c.resetKeys != nil
+	regionSpecified := c.regionName != ""
+	numArgs := len(args)
+
+	// if we have a key=value pair here then something is wrong because the
+	// last positional arg is not one. We assume the user intended to get a
+	// value after setting them.
+	for _, arg := range args {
+		if strings.Contains(arg, "=") {
+			return errors.New("cannot set and retrieve default values simultaneously")
+		}
+	}
+
+	switch {
+	case numArgs == 2 && !regionSpecified && resetSpecified:
+		// It makes no sense to supply a positional arg that isn't a region if
+		// we are resetting a region, so we must have gotten an invalid region.
+		return errors.Errorf("invalid region specified: %q", args[0])
+	case !regionSpecified && !resetSpecified:
+		// If we land here it is because there are extraneous positional args.
+		return errors.New("can only retrieve defaults for one key or all")
+	default:
+		// Anything else just has extra positional args, which is invalid in an
+		// unreliably guessable way.
+		return errors.New("invalid input")
+	}
 }
 
 // Run implements part of the cmd.Command interface.
 func (c *defaultsCommand) Run(ctx *cmd.Context) error {
-	client, err := c.getAPI()
+	root, err := c.newAPIRoot()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	client := c.newDefaultsAPI(root)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	defer client.Close()
 
+	if len(c.resetKeys) > 0 {
+		err := c.resetDefaults(client, ctx)
+		if err != nil {
+			// We return this error naked as it is almost certainly going to be
+			// cmd.ErrSilent and the cmd.Command framework expects that back
+			// from cmd.Run if the process is blocked.
+			return err
+		}
+	}
+	if c.action == nil {
+		// If we are reset only we end up here, only we've already done that.
+		return nil
+	}
 	return c.action(client, ctx)
 }
 
+// getDefaults writes out the value for a single key or the full tree of
+// defaults.
 func (c *defaultsCommand) getDefaults(client defaultsCommandAPI, ctx *cmd.Context) error {
 	attrs, err := client.ModelDefaults()
 	if err != nil {
 		return err
 	}
 
-	if len(c.keys) == 1 {
-		key := c.keys[0]
-		if value, ok := attrs[key]; ok {
+	if c.key != "" {
+		if value, ok := attrs[c.key]; ok {
 			attrs = config.ModelDefaultAttributes{
-				key: value,
+				c.key: value,
 			}
 		} else {
-			return errors.Errorf("key %q not found in %q model defaults.", key, attrs["name"])
+			return errors.Errorf("key %q not found in %q model defaults.", c.key, attrs["name"])
 		}
 	}
 	// If c.keys is empty, write out the whole lot.
 	return c.out.Write(ctx, attrs)
 }
 
+// setDefaults sets defaults as provided in c.values.
 func (c *defaultsCommand) setDefaults(client defaultsCommandAPI, ctx *cmd.Context) error {
 	// ctx unused in this method.
 	if err := c.verifyKnownKeys(client); err != nil {
 		return errors.Trace(err)
 	}
-	// TODO(wallyworld) - call with cloud and region when that bit is done
-	return block.ProcessBlockedError(client.SetModelDefaults("", "", c.values), block.BlockChange)
+	return block.ProcessBlockedError(
+		client.SetModelDefaults(
+			c.cloudName, c.regionName, c.values), block.BlockChange)
 }
 
+// resetDefaults resets the keys in resetKeys.
 func (c *defaultsCommand) resetDefaults(client defaultsCommandAPI, ctx *cmd.Context) error {
 	// ctx unused in this method.
 	if err := c.verifyKnownKeys(client); err != nil {
 		return errors.Trace(err)
 	}
-	// TODO(wallyworld) - call with cloud and region when that bit is done
-	return block.ProcessBlockedError(client.UnsetModelDefaults("", "", c.keys...), block.BlockChange)
+	return block.ProcessBlockedError(
+		client.UnsetModelDefaults(
+			c.cloudName, c.regionName, c.resetKeys...), block.BlockChange)
 
 }
 
@@ -221,17 +560,28 @@ func (c *defaultsCommand) verifyKnownKeys(client defaultsCommandAPI) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	keys := func() []string {
-		if c.keys != nil {
-			return c.keys
-		}
+	// allKeys gets the all the set and reset keys to validate. This should get
+	// caught in Init so maybe we don't need it here too.
+	// TODO(reviewer) Should we keep this and the init check?
+	allkeys := func() []string {
 		keys := []string{}
-		for k, _ := range c.values {
+		for k := range c.values {
 			keys = append(keys, k)
 		}
+		keys = append(keys, c.resetKeys...)
 		return keys
 	}
-	for _, key := range keys() {
+
+	keys := allkeys()
+	repeats := map[string]int{}
+	// Make sure we aren't trying to reset and set a key.
+	for _, k := range keys {
+		repeats[k]++
+		if repeats[k] > 1 {
+			return errors.Errorf("conflicting operations on key: %q not allowed", k)
+		}
+	}
+	for _, key := range allkeys() {
 		// check if the key exists in the known config
 		// and warn the user if the key is not defined
 		if _, exists := known[key]; !exists {

--- a/cmd/juju/model/defaultscommand.go
+++ b/cmd/juju/model/defaultscommand.go
@@ -2,20 +2,13 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 package model
 
-// tests to add
-// Test for no arg
-// Test for region only
-// Test for cloud only - fail because unknown key -- just cloud is invalid
-// Test for cloud/region - valid
-// TEst for cloud/region - invalid
-
 import (
 	"bytes"
 	"io"
 	"sort"
 	"strings"
 
-	names "gopkg.in/juju/names.v2"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -367,7 +360,6 @@ func (c *defaultsCommand) parseSetKeys(args []string) error {
 		}
 	}
 	return nil
-
 }
 
 // handleSetArgs parses args for setting defaults.
@@ -401,18 +393,15 @@ func (c *defaultsCommand) handleZeroArgs() error {
 		// values here.
 		return errors.New("specifying a region when retrieving defaults is invalid")
 	case regionSpecified && resetSpecified:
-		// We can reset for a region, c.action stays nil. We want do reset
+		// We can reset for a region, c.action stays nil. We want to do reset
 		// only.
 		return nil
 	case !regionSpecified && resetSpecified:
 		// Again we want to reset, this is for resetting the controller as
 		// there is no region specified. So c.action remains nil.
 		return nil
-		// case !regionSpecified && !resetSpecified:
-		// This means just get everything, but we should never arrive here if
-		// we short circuited at the begining of c.Init.
-		// c.action = c.getDefaults
-		// return nil
+		// We short circuited at the begining of c.Init so we should never
+		// reach a case where "!regionSpecified && !resetSpecified"
 	default:
 		// This should be unreachable.
 		return errors.New("unexpected input, please file a bug")
@@ -436,7 +425,7 @@ func (c *defaultsCommand) handleOneArg(arg string) error {
 		// we are resetting a region, so we must have gotten an invalid region.
 		return errors.Errorf("invalid region specified: %q", arg)
 	case !regionSpecified && !resetSpecified:
-		// Phew, we can retrieve a value.
+		// We can retrieve a value.
 		c.key = arg
 		c.action = c.getDefaults
 		return nil

--- a/cmd/juju/model/defaultscommand_test.go
+++ b/cmd/juju/model/defaultscommand_test.go
@@ -29,62 +29,177 @@ func (s *DefaultsCommandSuite) SetUpTest(c *gc.C) {
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = "controller"
 	s.store.Controllers["controller"] = jujuclient.ControllerDetails{}
+
 }
 
 func (s *DefaultsCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
-	command := model.NewDefaultsCommandForTest(s.fake, s.store)
+	command := model.NewDefaultsCommandForTest(s.fakeAPIRoot, s.fakeDefaultsAPI, s.fakeCloudAPI, s.store)
 	return testing.RunCommand(c, command, args...)
 }
 
 func (s *DefaultsCommandSuite) TestDefaultsInit(c *gc.C) {
 	for i, test := range []struct {
-		args       []string
-		errorMatch string
-		nilErr     bool
+		description string
+		args        []string
+		errorMatch  string
+		nilErr      bool
 	}{
 		{
 			// Test set
-			// 0
-			args:       []string{"special=extra", "special=other"},
-			errorMatch: `key "special" specified more than once`,
+			description: "test set key specified more than once",
+			args:        []string{"special=extra", "special=other"},
+			errorMatch:  `key "special" specified more than once`,
 		}, {
-			// 1
-			args:       []string{"agent-version=2.0.0"},
-			errorMatch: `"agent-version" must be set via "upgrade-juju"`,
+			description: "test cannot set agent-version",
+			args:        []string{"agent-version=2.0.0"},
+			errorMatch:  `"agent-version" must be set via "upgrade-juju"`,
 		}, {
-			// 2
-			args:   []string{"foo=bar", "baz=eggs"},
-			nilErr: true,
+			description: "test set multiple keys",
+			args:        []string{"foo=bar", "baz=eggs"},
+			nilErr:      true,
 		}, {
 			// Test reset
-			// 3
-			args:       []string{"--reset"},
-			errorMatch: "no keys specified",
+			description: "test empty args with reset fails",
+			args:        []string{"--reset"},
+			errorMatch:  "flag needs an argument: --reset",
 		}, {
-			// 4
-			args:   []string{"--reset", "something", "weird"},
-			nilErr: true,
+			description: "test reset with positional arg interpereted as invalid region",
+			args:        []string{"--reset", "something", "weird"},
+			errorMatch:  `invalid region specified: "weird"`,
+		},
+		{
+			description: "test reset with valid region and duplicate key set",
+			args:        []string{"--reset", "something", "dummy-region", "something=weird"},
+			errorMatch:  `key "something" specified more than once`,
+		},
+		{
+			description: "test reset with valid region and extra positional arg",
+			args:        []string{"--reset", "something", "dummy-region", "weird"},
+			errorMatch:  "cannot retrieve defaults for a key and reset args at the same time",
 		}, {
-			// 5
-			args:       []string{"--reset", "agent-version"},
-			errorMatch: `"agent-version" cannot be reset`,
+			description: "test reset with valid region only",
+			args:        []string{"--reset", "foo", "dummy-region"},
+			nilErr:      true,
 		}, {
-			// Test get
-			// 6
-			args:   nil,
-			nilErr: true,
+			description: "test cannot reset agent version",
+			args:        []string{"--reset", "agent-version"},
+			errorMatch:  `"agent-version" cannot be reset`,
 		}, {
-			// 7
-			args:   []string{"one"},
-			nilErr: true,
+			description: "test reset inits",
+			args:        []string{"--reset", "foo"},
+			nilErr:      true,
 		}, {
-			// 8
-			args:       []string{"one", "two"},
-			errorMatch: "can only retrieve a single value, or all values",
+			description: "test trailing reset fails",
+			args:        []string{"foo=bar", "--reset"},
+			errorMatch:  "flag needs an argument: --reset",
+		}, {
+			description: "test reset and get init",
+			args:        []string{"--reset", "agent-version,b", "foo=bar"},
+			errorMatch:  `"agent-version" cannot be reset`,
+		}, {
+			description: "test reset with key=val fails",
+			args:        []string{"--reset", "foo=bar"},
+			errorMatch:  `--reset accepts a single key "a" or comma delimited keys "a,b,c", received: "foo=bar"`,
+		}, {
+			description: "test reset multiple with key=val fails",
+			args:        []string{"--reset", "a,foo=bar,b"},
+			errorMatch:  `--reset accepts a single key "a" or comma delimited keys "a,b,c", received: "foo=bar"`,
+		}, {
+			description: "test reset with two positional args fails expecting a region",
+			args:        []string{"--reset", "a", "b", "c"},
+			errorMatch:  `invalid region specified: "b"`,
+		}, {
+			description: "test reset with two positional args fails expecting a region reordered",
+			args:        []string{"a", "--reset", "b", "c"},
+			errorMatch:  `invalid region specified: "a"`,
+		}, {
+			// test get
+			description: "test no args inits",
+			args:        nil,
+			nilErr:      true,
+		}, {
+			description: "one key arg inits",
+			args:        []string{"one"},
+			nilErr:      true,
+		}, {
+			description: "test two key args fails",
+			args:        []string{"one", "two"},
+			errorMatch:  "can only retrieve defaults for one key or all",
+		}, {
+			description: "test multiple key args fails",
+			args:        []string{"one", "two", "three"},
+			errorMatch:  "can only retrieve defaults for one key or all",
+		}, {
+			description: "test valid region and one arg",
+			args:        []string{"dummy-region", "one"},
+			errorMatch:  "specifying a region when retrieving defaults for a setting is invalid",
+		}, {
+			description: "test valid region and no args",
+			args:        []string{"dummy-region"},
+			errorMatch:  "specifying a region when retrieving defaults is invalid",
+		}, {
+			// test cloud/region
+			description: "test invalid cloud fails",
+			args:        []string{"invalidCloud/invalidRegion", "one=two"},
+			errorMatch:  "Unknown cloud",
+		}, {
+			description: "test valid cloud with invalid region fails",
+			args:        []string{"dummy/invalidRegion", "one=two"},
+			errorMatch:  `invalid region specified: "dummy/invalidRegion"`,
+		}, {
+			description: "test no cloud with invalid region fails",
+			args:        []string{"invalidRegion", "one=two"},
+			errorMatch:  `invalid region specified: "invalidRegion"`,
+		}, {
+			description: "test valid region with set arg succeeds",
+			args:        []string{"dummy-region", "one=two"},
+			nilErr:      true,
+		}, {
+			description: "test valid region with set and reset succeeds",
+			args:        []string{"dummy-region", "one=two", "--reset", "three"},
+			nilErr:      true,
+		}, {
+			description: "test reset and set with extra key is interpereted as invalid region",
+			args:        []string{"--reset", "something,else", "invalidRegion", "is=weird"},
+			errorMatch:  `invalid region specified: "invalidRegion"`,
+		}, {
+			description: "test reset and set with valid region and extra key fails",
+			args:        []string{"--reset", "something,else", "dummy-region", "invalidkey", "is=weird"},
+			errorMatch:  "cannot set and retrieve default values simultaneously",
+		}, {
+			// test various invalid
+			description: "test too many positional args with reset",
+			args:        []string{"--reset", "a", "b", "c", "d"},
+			errorMatch:  "invalid input",
+		}, {
+			description: "test too many positional args with invalid region set",
+			args:        []string{"a", "a=b", "b", "c=d"},
+			errorMatch:  `invalid region specified: "a"`,
+		}, {
+			description: "test invalid positional args with set",
+			args:        []string{"a=b", "b", "c=d"},
+			errorMatch:  `expected "key=value", got "b"`,
+		}, {
+			description: "test invalid positional args with set and trailing key",
+			args:        []string{"a=b", "c=d", "e"},
+			errorMatch:  "cannot set and retrieve default values simultaneously",
+		}, {
+			description: "test invalid positional args with valid region, set, reset",
+			args:        []string{"dummy-region", "a=b", "--reset", "c,d,", "e=f", "g"},
+			errorMatch:  "cannot set and retrieve default values simultaneously",
+		}, {
+			// Test some random orderings
+			description: "test invalid positional args with set, reset with trailing comman and split key=values",
+			args:        []string{"dummy-region", "a=b", "--reset", "c,d,", "e=f"},
+			nilErr:      true,
+		}, {
+			description: "test leading comma with reset",
+			args:        []string{"--reset", ",a,b"},
+			nilErr:      true,
 		},
 	} {
-		c.Logf("test %d", i)
-		cmd := model.NewDefaultsCommandForTest(s.fake, s.store)
+		c.Logf("test %d: %s", i, test.description)
+		cmd := model.NewDefaultsCommandForTest(s.fakeAPIRoot, s.fakeDefaultsAPI, s.fakeCloudAPI, s.store)
 		err := testing.InitCommand(cmd, test.args)
 		if test.nilErr {
 			c.Check(err, jc.ErrorIsNil)
@@ -95,16 +210,16 @@ func (s *DefaultsCommandSuite) TestDefaultsInit(c *gc.C) {
 }
 
 func (s *DefaultsCommandSuite) TestResetUnknownValueLogs(c *gc.C) {
-	_, err := s.run(c, "--reset", "attr", "weird")
+	_, err := s.run(c, "--reset", "attr,weird")
 	c.Assert(err, jc.ErrorIsNil)
 	expected := `key "weird" is not defined in the known model configuration: possible misspelling`
 	c.Check(c.GetTestLog(), jc.Contains, expected)
 }
 
 func (s *DefaultsCommandSuite) TestResetAttr(c *gc.C) {
-	_, err := s.run(c, "--reset", "attr", "unknown")
+	_, err := s.run(c, "--reset", "attr,unknown")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.fake.defaults, jc.DeepEquals, config.ModelDefaultAttributes{
+	c.Assert(s.fakeDefaultsAPI.defaults, jc.DeepEquals, config.ModelDefaultAttributes{
 		"attr2": {Controller: "bar", Default: nil, Regions: []config.RegionDefaultValue{{
 			Name:  "dummy-region",
 			Value: "dummy-value",
@@ -113,7 +228,7 @@ func (s *DefaultsCommandSuite) TestResetAttr(c *gc.C) {
 }
 
 func (s *DefaultsCommandSuite) TestResetBlockedError(c *gc.C) {
-	s.fake.err = common.OperationBlockedError("TestBlockedError")
+	s.fakeDefaultsAPI.err = common.OperationBlockedError("TestBlockedError")
 	_, err := s.run(c, "--reset", "attr")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	// msg is logged
@@ -130,7 +245,7 @@ func (s *DefaultsCommandSuite) TestSetUnknownValueLogs(c *gc.C) {
 func (s *DefaultsCommandSuite) TestSet(c *gc.C) {
 	_, err := s.run(c, "special=extra", "attr=baz")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.fake.defaults, jc.DeepEquals, config.ModelDefaultAttributes{
+	c.Assert(s.fakeDefaultsAPI.defaults, jc.DeepEquals, config.ModelDefaultAttributes{
 		"attr": {Controller: "baz", Default: nil, Regions: nil},
 		"attr2": {Controller: "bar", Default: nil, Regions: []config.RegionDefaultValue{{
 			Name:  "dummy-region",
@@ -141,7 +256,7 @@ func (s *DefaultsCommandSuite) TestSet(c *gc.C) {
 }
 
 func (s *DefaultsCommandSuite) TestBlockedErrorOnSet(c *gc.C) {
-	s.fake.err = common.OperationBlockedError("TestBlockedError")
+	s.fakeDefaultsAPI.err = common.OperationBlockedError("TestBlockedError")
 	_, err := s.run(c, "special=extra")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	// msg is logged

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -6,6 +6,8 @@ package model
 import (
 	"github.com/juju/cmd"
 
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 )
@@ -20,9 +22,11 @@ func NewConfigCommandForTest(api configCommandAPI) cmd.Command {
 }
 
 // NewDefaultsCommandForTest returns a defaultsCommand with the api provided as specified.
-func NewDefaultsCommandForTest(api defaultsCommandAPI, store jujuclient.ClientStore) cmd.Command {
+func NewDefaultsCommandForTest(apiRoot api.Connection, dAPI defaultsCommandAPI, cAPI cloudAPI, store jujuclient.ClientStore) cmd.Command {
 	cmd := &defaultsCommand{
-		api: api,
+		newAPIRoot:     func() (api.Connection, error) { return apiRoot, nil },
+		newDefaultsAPI: func(caller base.APICallCloser) defaultsCommandAPI { return dAPI },
+		newCloudAPI:    func(caller base.APICallCloser) cloudAPI { return cAPI },
 	}
 	cmd.SetClientStore(store)
 	return modelcmd.WrapController(cmd)

--- a/cmd/juju/model/fakeenv_test.go
+++ b/cmd/juju/model/fakeenv_test.go
@@ -7,12 +7,12 @@ import (
 	"errors"
 
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/testing"
-	"gopkg.in/juju/names.v2"
 )
 
 // ModelConfig related fake environment for testing.

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -6,6 +6,7 @@ package state
 import (
 	"github.com/juju/errors"
 	"github.com/juju/schema"
+	names "gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs"
@@ -134,8 +135,18 @@ func (st *State) modelConfigValues(modelCfg attrValues) (config.ConfigValues, er
 }
 
 // UpdateModelConfigDefaultValues updates the inherited settings used when creating a new model.
-func (st *State) UpdateModelConfigDefaultValues(attrs map[string]interface{}, removed []string) error {
-	settings, err := readSettings(st, globalSettingsC, controllerInheritedSettingsGlobalKey)
+func (st *State) UpdateModelConfigDefaultValues(attrs map[string]interface{}, removed []string, cloudTag, regionName string) error {
+	var key string
+	if cloudTag != "" && regionName != "" {
+		cloud, err := names.ParseCloudTag(cloudTag)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		key = regionSettingsGlobalKey(cloud.Id(), regionName)
+	} else {
+		key = controllerInheritedSettingsGlobalKey
+	}
+	settings, err := readSettings(st, globalSettingsC, key)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -426,13 +426,13 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaults(c *gc.C) {
 		"http-proxy":  "http://http-proxy",
 		"https-proxy": "https://https-proxy",
 	}
-	err := s.State.UpdateModelConfigDefaultValues(attrs, nil)
+	err := s.State.UpdateModelConfigDefaultValues(attrs, nil, "", "")
 	c.Assert(err, jc.ErrorIsNil)
 
 	attrs = map[string]interface{}{
 		"apt-mirror": "http://different-mirror",
 	}
-	err = s.State.UpdateModelConfigDefaultValues(attrs, []string{"http-proxy", "https-proxy"})
+	err = s.State.UpdateModelConfigDefaultValues(attrs, []string{"http-proxy", "https-proxy"}, "", "")
 	c.Assert(err, jc.ErrorIsNil)
 
 	info := statetesting.NewMongoInfo()
@@ -462,6 +462,78 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaults(c *gc.C) {
 		Regions: []config.RegionDefaultValue{{
 			Name:  "dummy-region",
 			Value: "dummy-proxy",
+		}}}
+	c.Assert(cfg, jc.DeepEquals, expectedValues)
+}
+
+func (s *ModelConfigSourceSuite) TestUpdateModelConfigRegionDefaults(c *gc.C) {
+	// The test env is setup with dummy/dummy-region having a no-proxy
+	// dummy-proxy value and nether-region with a nether-proxy value.
+	//
+	// First we change the no-proxy setting in dummy-region
+	attrs := map[string]interface{}{
+		"no-proxy": "changed-proxy",
+	}
+	err := s.State.UpdateModelConfigDefaultValues(attrs, nil, "cloud-dummy", "dummy-region")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Then check in another state.
+	info := statetesting.NewMongoInfo()
+	anotherState, err := state.Open(s.modelTag, s.State.ControllerTag(), info, mongotest.DialOpts(), state.NewPolicyFunc(nil))
+	c.Assert(err, jc.ErrorIsNil)
+	defer anotherState.Close()
+
+	cfg, err := anotherState.ModelConfigDefaultValues()
+	c.Assert(err, jc.ErrorIsNil)
+	expectedValues := make(config.ModelDefaultAttributes)
+	for attr, val := range config.ConfigDefaults() {
+		expectedValues[attr] = config.AttributeDefaultValues{
+			Default: val,
+		}
+	}
+	expectedValues["http-proxy"] = config.AttributeDefaultValues{
+		Controller: "http://proxy",
+		Default:    "",
+	}
+	expectedValues["apt-mirror"] = config.AttributeDefaultValues{
+		Controller: "http://mirror",
+		Default:    "",
+		Regions: []config.RegionDefaultValue{{
+			Name:  "dummy-region",
+			Value: "http://dummy-mirror",
+		}}}
+	expectedValues["no-proxy"] = config.AttributeDefaultValues{
+		Default: "",
+		Regions: []config.RegionDefaultValue{{
+			Name:  "dummy-region",
+			Value: "changed-proxy",
+		}}}
+	c.Assert(cfg, jc.DeepEquals, expectedValues)
+
+	// remove the dummy-region setting
+	err = s.State.UpdateModelConfigDefaultValues(nil, []string{"no-proxy"}, "cloud-dummy", "dummy-region")
+
+	// and check again
+	cfg, err = anotherState.ModelConfigDefaultValues()
+	c.Assert(err, jc.ErrorIsNil)
+	cfg, err = anotherState.ModelConfigDefaultValues()
+	c.Assert(err, jc.ErrorIsNil)
+	expectedValues = make(config.ModelDefaultAttributes)
+	for attr, val := range config.ConfigDefaults() {
+		expectedValues[attr] = config.AttributeDefaultValues{
+			Default: val,
+		}
+	}
+	expectedValues["http-proxy"] = config.AttributeDefaultValues{
+		Controller: "http://proxy",
+		Default:    "",
+	}
+	expectedValues["apt-mirror"] = config.AttributeDefaultValues{
+		Controller: "http://mirror",
+		Default:    "",
+		Regions: []config.RegionDefaultValue{{
+			Name:  "dummy-region",
+			Value: "http://dummy-mirror",
 		}}}
 	c.Assert(cfg, jc.DeepEquals, expectedValues)
 }


### PR DESCRIPTION
Also changes --reset to be a stringvar. All tests pass at this point but
it needs more tests for the new features. It also adds a lot of command
arg scrutiny and tests

It turns out that regions don't work yet. I think because we don't actually do anything with them in state.UpdateModelConfigDefaultValues. I haven't had time to look at this over the weekend though. So this is up wihtout QA steps to get some eyes/review on it before I get back monday. 

Refs: config command collapse spec https://goo.gl/yqrrPI
Refs: model-config-tree