### PR TITLE
provider/azure: reorganise utility code

### DIFF
--- a/provider/azure/auth.go
+++ b/provider/azure/auth.go
@@ -14,7 +14,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/provider/azure/internal/ad"
+	"github.com/juju/juju/provider/azure/internal/azureauth"
 )
 
 // cloudSpecAuth is an implementation of autorest.Authorizer.
@@ -78,7 +78,7 @@ func AuthToken(cloud environs.CloudSpec, sender autorest.Sender) (*azure.Service
 	if sender != nil {
 		subscriptionsClient.Sender = sender
 	}
-	authURI, err := ad.DiscoverAuthorizationURI(subscriptionsClient, subscriptionId)
+	authURI, err := azureauth.DiscoverAuthorizationURI(subscriptionsClient, subscriptionId)
 	if err != nil {
 		return nil, errors.Annotate(err, "detecting auth URI")
 	}
@@ -86,7 +86,7 @@ func AuthToken(cloud environs.CloudSpec, sender autorest.Sender) (*azure.Service
 
 	// The authorization URI scheme and host identifies the AD endpoint.
 	// The authorization URI path identifies the AD tenant.
-	tenantId, err := ad.AuthorizationURITenantID(authURI)
+	tenantId, err := azureauth.AuthorizationURITenantID(authURI)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting tenant ID")
 	}

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -126,7 +126,7 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 
 	s.provider = newProvider(c, azure.ProviderConfig{
 		Sender:           azuretesting.NewSerialSender(&s.sender),
-		RequestInspector: requestRecorder(&s.requests),
+		RequestInspector: azuretesting.RequestRecorder(&s.requests),
 		NewStorageClient: s.storageClient.NewClient,
 		RetryClock: &gitjujutesting.AutoAdvancingClock{
 			&s.retryClock, s.retryClock.Advance,

--- a/provider/azure/instance_test.go
+++ b/provider/azure/instance_test.go
@@ -42,7 +42,7 @@ func (s *instanceSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.provider = newProvider(c, azure.ProviderConfig{
 		Sender:                     &s.sender,
-		RequestInspector:           requestRecorder(&s.requests),
+		RequestInspector:           azuretesting.RequestRecorder(&s.requests),
 		RandomWindowsAdminPassword: func() string { return "sorandom" },
 	})
 	s.env = openEnviron(c, s.provider, &s.sender)

--- a/provider/azure/internal/azureauth/discovery.go
+++ b/provider/azure/internal/azureauth/discovery.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package ad
+package azureauth
 
 import (
 	"net/http"

--- a/provider/azure/internal/azureauth/discovery_test.go
+++ b/provider/azure/internal/azureauth/discovery_test.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package ad_test
+package azureauth_test
 
 import (
 	"net/http"
@@ -13,7 +13,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/provider/azure/internal/ad"
+	"github.com/juju/juju/provider/azure/internal/azureauth"
 )
 
 type DiscoverySuite struct {
@@ -32,7 +32,7 @@ func (*DiscoverySuite) TestDiscoverAuthorizationURI(c *gc.C) {
 
 	client := subscriptions.NewClient()
 	client.Sender = sender
-	authURI, err := ad.DiscoverAuthorizationURI(client, "subscription_id")
+	authURI, err := azureauth.DiscoverAuthorizationURI(client, "subscription_id")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(authURI, jc.DeepEquals, &url.URL{
 		Scheme: "https",
@@ -48,7 +48,7 @@ func (*DiscoverySuite) TestDiscoverAuthorizationURIMissingHeader(c *gc.C) {
 
 	client := subscriptions.NewClient()
 	client.Sender = sender
-	_, err := ad.DiscoverAuthorizationURI(client, "subscription_id")
+	_, err := azureauth.DiscoverAuthorizationURI(client, "subscription_id")
 	c.Assert(err, gc.ErrorMatches, `WWW-Authenticate header not found`)
 }
 
@@ -60,7 +60,7 @@ func (*DiscoverySuite) TestDiscoverAuthorizationURIHeaderMismatch(c *gc.C) {
 
 	client := subscriptions.NewClient()
 	client.Sender = sender
-	_, err := ad.DiscoverAuthorizationURI(client, "subscription_id")
+	_, err := azureauth.DiscoverAuthorizationURI(client, "subscription_id")
 	c.Assert(err, gc.ErrorMatches, `authorization_uri not found in WWW-Authenticate header \("foo bar baz"\)`)
 }
 
@@ -71,7 +71,7 @@ func (*DiscoverySuite) TestDiscoverAuthorizationURIUnexpectedSuccess(c *gc.C) {
 
 	client := subscriptions.NewClient()
 	client.Sender = sender
-	_, err := ad.DiscoverAuthorizationURI(client, "subscription_id")
+	_, err := azureauth.DiscoverAuthorizationURI(client, "subscription_id")
 	c.Assert(err, gc.ErrorMatches, "expected unauthorized error response")
 }
 
@@ -82,12 +82,12 @@ func (*DiscoverySuite) TestDiscoverAuthorizationURIUnexpectedStatusCode(c *gc.C)
 
 	client := subscriptions.NewClient()
 	client.Sender = sender
-	_, err := ad.DiscoverAuthorizationURI(client, "subscription_id")
+	_, err := azureauth.DiscoverAuthorizationURI(client, "subscription_id")
 	c.Assert(err, gc.ErrorMatches, "expected unauthorized error response, got 404: .*")
 }
 
 func (*DiscoverySuite) TestAuthorizationURITenantID(c *gc.C) {
-	tenantId, err := ad.AuthorizationURITenantID(&url.URL{Path: "/3671f5a9-c0d0-472b-a80c-48135cf5a9f1"})
+	tenantId, err := azureauth.AuthorizationURITenantID(&url.URL{Path: "/3671f5a9-c0d0-472b-a80c-48135cf5a9f1"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(tenantId, gc.Equals, "3671f5a9-c0d0-472b-a80c-48135cf5a9f1")
 }
@@ -95,6 +95,6 @@ func (*DiscoverySuite) TestAuthorizationURITenantID(c *gc.C) {
 func (*DiscoverySuite) TestAuthorizationURITenantIDError(c *gc.C) {
 	url, err := url.Parse("https://testing.invalid/foo")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = ad.AuthorizationURITenantID(url)
+	_, err = azureauth.AuthorizationURITenantID(url)
 	c.Assert(err, gc.ErrorMatches, `authorization_uri "https://testing.invalid/foo" not valid`)
 }

--- a/provider/azure/internal/azureauth/oauth.go
+++ b/provider/azure/internal/azureauth/oauth.go
@@ -1,0 +1,44 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azureauth
+
+import (
+	"github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+)
+
+var logger = loggo.GetLogger("juju.provider.azure.internal.azureauth")
+
+// OAuthConfig returns an azure.OAuthConfig based on the given resource
+// manager endpoint and subscription ID. This will make a request to the
+// resource manager API to discover the Active Directory tenant ID.
+func OAuthConfig(
+	client subscriptions.Client,
+	resourceManagerEndpoint string,
+	subscriptionId string,
+) (*azure.OAuthConfig, string, error) {
+	authURI, err := DiscoverAuthorizationURI(client, subscriptionId)
+	if err != nil {
+		return nil, "", errors.Annotate(err, "detecting auth URI")
+	}
+	logger.Debugf("discovered auth URI: %s", authURI)
+
+	// The authorization URI scheme and host identifies the AD endpoint.
+	// The authorization URI path identifies the AD tenant.
+	tenantId, err := AuthorizationURITenantID(authURI)
+	if err != nil {
+		return nil, "", errors.Annotate(err, "getting tenant ID")
+	}
+	authURI.Path = ""
+	adEndpoint := authURI.String()
+
+	cloudEnv := azure.Environment{ActiveDirectoryEndpoint: adEndpoint}
+	oauthConfig, err := cloudEnv.OAuthConfigForTenant(tenantId)
+	if err != nil {
+		return nil, "", errors.Annotate(err, "getting OAuth configuration")
+	}
+	return oauthConfig, tenantId, nil
+}

--- a/provider/azure/internal/azureauth/oauth_test.go
+++ b/provider/azure/internal/azureauth/oauth_test.go
@@ -1,0 +1,61 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azureauth_test
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/mocks"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/provider/azure/internal/azureauth"
+)
+
+type OAuthConfigSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&OAuthConfigSuite{})
+
+const fakeTenantId = "11111111-1111-1111-1111-111111111111"
+
+func oauthConfigSender() autorest.Sender {
+	sender := mocks.NewSender()
+	resp := mocks.NewResponseWithStatus("", http.StatusUnauthorized)
+	mocks.SetResponseHeaderValues(resp, "WWW-Authenticate", []string{
+		`authorization_uri="https://testing.invalid/` + fakeTenantId + `"`,
+	})
+	sender.AppendResponse(resp)
+	return sender
+}
+
+func (s *OAuthConfigSuite) TestOAuthConfig(c *gc.C) {
+	client := subscriptions.Client{subscriptions.NewWithBaseURI("https://testing.invalid")}
+	client.Sender = oauthConfigSender()
+	cfg, tenantId, err := azureauth.OAuthConfig(client, "https://testing.invalid", "subscription-id")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tenantId, gc.Equals, fakeTenantId)
+
+	baseURL := url.URL{
+		Scheme:   "https",
+		Host:     "testing.invalid",
+		RawQuery: "api-version=1.0",
+	}
+	expectedCfg := &azure.OAuthConfig{
+		AuthorizeEndpoint:  baseURL,
+		TokenEndpoint:      baseURL,
+		DeviceCodeEndpoint: baseURL,
+	}
+	expectedCfg.AuthorizeEndpoint.Path = "/11111111-1111-1111-1111-111111111111/oauth2/authorize"
+	expectedCfg.TokenEndpoint.Path = "/11111111-1111-1111-1111-111111111111/oauth2/token"
+	expectedCfg.DeviceCodeEndpoint.Path = "/11111111-1111-1111-1111-111111111111/oauth2/devicecode"
+
+	c.Assert(cfg, jc.DeepEquals, expectedCfg)
+}

--- a/provider/azure/internal/azureauth/package_test.go
+++ b/provider/azure/internal/azureauth/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azureauth_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/provider/azure/internal/azureauth/utils.go
+++ b/provider/azure/internal/azureauth/utils.go
@@ -1,0 +1,16 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azureauth
+
+import "strings"
+
+// TokenResource returns a resource value suitable for auth tokens, based on
+// an endpoint URI.
+func TokenResource(uri string) string {
+	resource := uri
+	if !strings.HasSuffix(resource, "/") {
+		resource += "/"
+	}
+	return resource
+}

--- a/provider/azure/internal/azureauth/utils_test.go
+++ b/provider/azure/internal/azureauth/utils_test.go
@@ -1,0 +1,24 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azureauth_test
+
+import (
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/provider/azure/internal/azureauth"
+)
+
+type TokenResourceSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&TokenResourceSuite{})
+
+func (s *TokenResourceSuite) TestTokenResource(c *gc.C) {
+	out := azureauth.TokenResource("https://graph.windows.net")
+	c.Assert(out, gc.Equals, "https://graph.windows.net/")
+	out = azureauth.TokenResource("https://graph.windows.net/")
+	c.Assert(out, gc.Equals, "https://graph.windows.net/")
+}

--- a/provider/azure/internal/azuretesting/recorder.go
+++ b/provider/azure/internal/azuretesting/recorder.go
@@ -1,0 +1,43 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azuretesting
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"sync"
+
+	"github.com/Azure/go-autorest/autorest"
+)
+
+// RequestRecorder returns an autorest.PrepareDecorator that records requests
+// to ghe given slice.
+func RequestRecorder(requests *[]*http.Request) autorest.PrepareDecorator {
+	if requests == nil {
+		return nil
+	}
+	var mu sync.Mutex
+	return func(p autorest.Preparer) autorest.Preparer {
+		return autorest.PreparerFunc(func(req *http.Request) (*http.Request, error) {
+			// Save the request body, since it will be consumed.
+			reqCopy := *req
+			if req.Body != nil {
+				var buf bytes.Buffer
+				if _, err := buf.ReadFrom(req.Body); err != nil {
+					return nil, err
+				}
+				if err := req.Body.Close(); err != nil {
+					return nil, err
+				}
+				reqCopy.Body = ioutil.NopCloser(&buf)
+				req.Body = ioutil.NopCloser(bytes.NewReader(buf.Bytes()))
+			}
+			mu.Lock()
+			*requests = append(*requests, &reqCopy)
+			mu.Unlock()
+			return req, nil
+		})
+	}
+}

--- a/provider/azure/internal/azuretesting/senders.go
+++ b/provider/azure/internal/azuretesting/senders.go
@@ -12,7 +12,10 @@ import (
 
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/mocks"
+	"github.com/juju/loggo"
 )
+
+var logger = loggo.GetLogger("juju.provider.azure.internal.azuretesting")
 
 // MockSender is a wrapper around autorest/mocks.Sender, extending it with
 // request path checking to ease testing.
@@ -58,6 +61,7 @@ func NewSenderWithValue(v interface{}) *MockSender {
 type Senders []autorest.Sender
 
 func (s *Senders) Do(req *http.Request) (*http.Response, error) {
+	logger.Debugf("Senders.Do(%s)", req.URL)
 	if len(*s) == 0 {
 		response := mocks.NewResponseWithStatus("", http.StatusInternalServerError)
 		return response, fmt.Errorf("no sender for %q", req.URL)

--- a/provider/azure/internal/errorutils/errors.go
+++ b/provider/azure/internal/errorutils/errors.go
@@ -1,0 +1,25 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package errorutils
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// ServiceError returns the *azure.ServiceError underlying the
+// supplied error, if any, and a bool indicating whether one
+// was found.
+func ServiceError(err error) (*azure.ServiceError, bool) {
+	err = errors.Cause(err)
+	if d, ok := err.(autorest.DetailedError); ok {
+		err = d.Original
+	}
+	if r, ok := err.(*azure.RequestError); ok {
+		return r.ServiceError, true
+	}
+	return nil, false
+}

--- a/provider/azure/internal/tracing/tracing.go
+++ b/provider/azure/internal/tracing/tracing.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package azure
+package tracing
 
 import (
 	"net/http"
@@ -11,9 +11,9 @@ import (
 	"github.com/juju/loggo"
 )
 
-// tracingPrepareDecorator returns an autorest.PrepareDecorator that
+// PrepareDecorator returns an autorest.PrepareDecorator that
 // logs requests at trace level.
-func tracingPrepareDecorator(logger loggo.Logger) autorest.PrepareDecorator {
+func PrepareDecorator(logger loggo.Logger) autorest.PrepareDecorator {
 	return func(p autorest.Preparer) autorest.Preparer {
 		return autorest.PreparerFunc(func(r *http.Request) (*http.Request, error) {
 			if logger.IsTraceEnabled() {
@@ -30,9 +30,9 @@ func tracingPrepareDecorator(logger loggo.Logger) autorest.PrepareDecorator {
 	}
 }
 
-// tracingRespondDecorator returns an autorest.RespondDecorator that
+// RespondDecorator returns an autorest.RespondDecorator that
 // logs responses at trace level.
-func tracingRespondDecorator(logger loggo.Logger) autorest.RespondDecorator {
+func RespondDecorator(logger loggo.Logger) autorest.RespondDecorator {
 	return func(r autorest.Responder) autorest.Responder {
 		return autorest.ResponderFunc(func(resp *http.Response) error {
 			if logger.IsTraceEnabled() {

--- a/provider/azure/storage_test.go
+++ b/provider/azure/storage_test.go
@@ -41,7 +41,7 @@ func (s *storageSuite) SetUpTest(c *gc.C) {
 	envProvider := newProvider(c, azure.ProviderConfig{
 		Sender:                     &s.sender,
 		NewStorageClient:           s.storageClient.NewClient,
-		RequestInspector:           requestRecorder(&s.requests),
+		RequestInspector:           azuretesting.RequestRecorder(&s.requests),
 		RandomWindowsAdminPassword: func() string { return "sorandom" },
 	})
 	s.sender = nil

--- a/provider/azure/utils.go
+++ b/provider/azure/utils.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/juju/errors"
 	"github.com/juju/retry"
@@ -108,15 +107,4 @@ func deleteResource(callAPI callAPIFunc, deleter resourceDeleter, resourceGroup,
 
 type resourceDeleter interface {
 	Delete(resourceGroup, name string, cancel <-chan struct{}) (autorest.Response, error)
-}
-
-func azureServiceError(err error) (*azure.ServiceError, bool) {
-	err = errors.Cause(err)
-	if d, ok := err.(autorest.DetailedError); ok {
-		err = d.Original
-	}
-	if err, ok := err.(*azure.RequestError); ok {
-		return err.ServiceError, true
-	}
-	return nil, false
 }


### PR DESCRIPTION
This diff reorganises some utility functions
into internal packages, so other internal
packages can use them. Also, move the auth-
related utilities into the new azureauth
internal package.