### PR TITLE
Increase version length in status output.

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -80,7 +80,7 @@ func (r *relationFormatter) get(k string) *statusRelation {
 // units. Any subordinate items are indented by two spaces beneath
 // their superior.
 func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
-	const maxVersionWidth = 7
+	const maxVersionWidth = 15
 	const ellipsis = "..."
 	const truncatedWidth = maxVersionWidth - len(ellipsis)
 

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3514,10 +3514,10 @@ func (s *StatusSuite) testStatusWithFormatTabular(c *gc.C, useFeatureFlag bool) 
 MODEL       CONTROLLER  CLOUD/REGION        VERSION  NOTES
 controller  kontroll    dummy/dummy-region  1.2.3    upgrade available: 1.2.4
 
-APP        VERSION  STATUS       SCALE  CHARM      STORE       REV  OS      NOTES
-logging    a bi...  error            2  logging    jujucharms    1  ubuntu  exposed
-mysql      5.7.13   maintenance      1  mysql      jujucharms    1  ubuntu  exposed
-wordpress  4.5.3    active           1  wordpress  jujucharms    3  ubuntu  exposed
+APP        VERSION          STATUS       SCALE  CHARM      STORE       REV  OS      NOTES
+logging    a bit too lo...  error            2  logging    jujucharms    1  ubuntu  exposed
+mysql      5.7.13           maintenance      1  mysql      jujucharms    1  ubuntu  exposed
+wordpress  4.5.3            active           1  wordpress  jujucharms    3  ubuntu  exposed
 
 UNIT         WORKLOAD     AGENT  MACHINE  PUBLIC-ADDRESS    PORTS  MESSAGE
 mysql/0      maintenance  idle   2        controller-2.dns         installing all the things


### PR DESCRIPTION
Reducing version length to 7 characters seems too small, e.g. "9.0.0~b3" was shown as "9.0....".

This PR increases the length to 15 and adjusts unit tests accordingly.

 