### PR TITLE
Fixes lp#1552274 - added json output to list-credentials command.

### DIFF
--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -61,6 +61,7 @@ type listCredentialsCommand struct {
 	cloudByNameFunc    func(string) (*jujucloud.Cloud, error)
 }
 
+// CloudCredential contains attributes used to define credentials for a cloud.
 type CloudCredential struct {
 	// DefaultCredential is the named credential to use by default.
 	DefaultCredential string `json:"default-credential,omitempty" yaml:"default-credential,omitempty"`
@@ -212,6 +213,11 @@ func formatCredentialsTabular(writer io.Writer, value interface{}) error {
 	credentials, ok := value.(credentialsMap)
 	if !ok {
 		return errors.Errorf("expected value of type %T, got %T", credentials, value)
+	}
+
+	if len(credentials.Credentials) == 0 {
+		fmt.Fprintln(writer, "No credentials to display.")
+		return nil
 	}
 
 	// For tabular we'll sort alphabetically by cloud, and then by credential name.

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -206,8 +206,10 @@ credentials:
 }
 
 func (s *listCredentialsSuite) TestListCredentialsJSON(c *gc.C) {
-	// TODO(axw) test once json marshalling works properly
-	c.Skip("not implemented: credentials don't marshal to JSON yet")
+	out := s.listCredentials(c, "--format", "json", "azure")
+	c.Assert(out, gc.Equals, `
+{"credentials":{"azure":{"cloud-credentials":{"azhja":{"auth-type":"userpass","details":{"application-id":"app-id","subscription-id":"subscription-id","tenant-id":"tenant-id"}}}}}}
+`[1:])
 }
 
 func (s *listCredentialsSuite) TestListCredentialsNone(c *gc.C) {
@@ -224,7 +226,11 @@ func (s *listCredentialsSuite) TestListCredentialsNone(c *gc.C) {
 	out = strings.Replace(testing.Stdout(ctx), "\n", "", -1)
 	c.Assert(out, gc.Equals, "credentials: {}")
 
-	// TODO(axw) test json once json marshaling works properly
+	ctx, err = testing.RunCommand(c, listCmd, "--format", "json")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stderr(ctx), gc.Equals, "")
+	out = strings.Replace(testing.Stdout(ctx), "\n", "", -1)
+	c.Assert(out, gc.Equals, `{"credentials":{}}`)
 }
 
 func (s *listCredentialsSuite) listCredentials(c *gc.C, args ...string) string {

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -255,7 +255,7 @@ func (s *listCredentialsSuite) TestListCredentialsNone(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stderr(ctx), gc.Equals, "")
 	out := strings.Replace(testing.Stdout(ctx), "\n", "", -1)
-	c.Assert(out, gc.Equals, "CLOUD  CREDENTIALS")
+	c.Assert(out, gc.Equals, "No credentials to display.")
 
 	ctx, err = testing.RunCommand(c, listCmd, "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Added presentation layer credentials struct. Added tests for json output.

QA:
1. Run 'juju credentials --format json"
[expected] output should have lower-cased representation of credentials with empty properties omitted