### PR TITLE
Generate ENI and push to LXD container before start

### DIFF
--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -202,17 +202,19 @@ func PrepareNetworkConfigFromInterfaces(interfaces []network.InterfaceInfo) *Pre
 // might include per-interface networking config if both networkConfig
 // is not nil and its Interfaces field is not empty.
 func newCloudInitConfigWithNetworks(series string, networkConfig *container.NetworkConfig) (cloudinit.CloudConfig, error) {
-	config, err := GenerateNetworkConfig(networkConfig)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	cloudConfig, err := cloudinit.New(series)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	cloudConfig.AddBootTextFile(networkInterfacesFile, config, 0644)
-	cloudConfig.AddRunCmd(raiseJujuNetworkInterfacesScript(systemNetworkInterfacesFile, networkInterfacesFile))
+	if networkConfig != nil {
+		config, err := GenerateNetworkConfig(networkConfig)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		cloudConfig.AddBootTextFile(networkInterfacesFile, config, 0644)
+		cloudConfig.AddRunCmd(raiseJujuNetworkInterfacesScript(systemNetworkInterfacesFile, networkInterfacesFile))
+	}
 
 	return cloudConfig, nil
 }

--- a/tools/lxdclient/client_instance.go
+++ b/tools/lxdclient/client_instance.go
@@ -6,7 +6,10 @@
 package lxdclient
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 
 	"github.com/juju/errors"
@@ -19,6 +22,15 @@ import (
 
 type Device map[string]string
 type Devices map[string]Device
+
+type File struct {
+	Content []byte
+	Path    string
+	GID     int
+	UID     int
+	Mode    os.FileMode
+}
+type Files []File
 
 // TODO(ericsnow) We probably need to address some of the things that
 // get handled in container/lxc/clonetemplate.go.
@@ -33,6 +45,7 @@ type rawInstanceClient interface {
 	WaitForSuccess(waitURL string) error
 	ContainerState(name string) (*shared.ContainerState, error)
 	ContainerDeviceAdd(container, devname, devtype string, props []string) (*lxd.Response, error)
+	PushFile(container, path string, gid int, uid int, mode string, buf io.ReadSeeker) error
 }
 
 type instanceClient struct {
@@ -87,6 +100,14 @@ func (client *instanceClient) addInstance(spec InstanceSpec) error {
 		// TODO(ericsnow) Handle different failures (from the async
 		// operation) differently?
 		return errors.Trace(err)
+	}
+
+	for _, file := range spec.Files {
+		logger.Infof("pushing file %q to container %q", file.Path, spec.Name)
+		err := client.raw.PushFile(spec.Name, file.Path, file.GID, file.UID, file.Mode.String(), bytes.NewReader(file.Content))
+		if err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	return nil

--- a/tools/lxdclient/instance.go
+++ b/tools/lxdclient/instance.go
@@ -76,8 +76,12 @@ type InstanceSpec struct {
 	// Metadata is the instance metadata.
 	Metadata map[string]string
 
-	// Devices to be added at container initialisation time
+	// Devices to be added at container initialisation time.
 	Devices
+
+	// Files to be pushed after initialisation has completed but
+	// before the container is started.
+	Files
 
 	// TODO(ericsnow) Other possible fields:
 	// Disks


### PR DESCRIPTION
Uses PushFile to write the correct /etc/network/interfaces config to the
container rootfs between (lxc) init and start.

This prevents the default LXD behaviour, which is to expect DHCP on
eth0, breaking container provisioning when DHCP is not available in the
eth0 space.

Fixes lp:1611981

QA steps:
  * Test in a MAAS environment with two NICs per node, where the NIC with the higher sorting name  is on the PXE/DHCP space, and ensuring the other space does not serve DHCP
    - NICs can be renamed in MAAS on a node's page
    - For example, if ens3 and ens4 are named by default, and ens3 is the PXE/DHCP interface, rename ens3 as 'nicZ' and ens4 as 'nicA'
    - You may also like to assign a static IP addr to the second ('nicA' in this example) interface
  * `juju add-machine lxd:<host>` for a xenial container
    - The container should start
    - In the container, `/etc/network/interfaces` should configure its interfaces and nameservers correct for the environment (eth0 with an address in nicA's space, in this example, and eth1 in nicZ's) and should not source `/etc/network/interfaces.d/*.cfg`
  * Repeat with a trusty container, `juju add-machine --series trusty lxd:<host>`