### PR TITLE
state: create per-charm storage constraints docs

### DIFF
--- a/state/storage.go
+++ b/state/storage.go
@@ -782,6 +782,15 @@ func createStorageConstraintsOp(key string, cons map[string]StorageConstraints) 
 	}
 }
 
+func replaceStorageConstraintsOp(key string, cons map[string]StorageConstraints) txn.Op {
+	return txn.Op{
+		C:      storageConstraintsC,
+		Id:     key,
+		Assert: txn.DocExists,
+		Update: bson.D{{"$set", bson.D{{"constraints", cons}}}},
+	}
+}
+
 func removeStorageConstraintsOp(key string) txn.Op {
 	return txn.Op{
 		C:      storageConstraintsC,
@@ -797,7 +806,7 @@ func readStorageConstraints(st *State, key string) (map[string]StorageConstraint
 	var doc storageConstraintsDoc
 	err := coll.FindId(key).One(&doc)
 	if err == mgo.ErrNotFound {
-		return nil, nil
+		return nil, errors.NotFoundf("storage constraints for %q", key)
 	}
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot get storage constraints for %q", key)


### PR DESCRIPTION
We now store storage constraints for each unique charm URL for an
application, as we do for charm settings. This will enable us to update
storage constraints on upgrade without existing units.

**QA**

1. bootstrap lxd
2. deploy charm with storage
3. upgrade application with same charm (bumps rev)
4. add-unit
5. ensure both units come up with storage attached

Requires https://github.com/juju/juju/pull/6278