### PR TITLE
Reverse retry default for the "juju resolved" command

### DIFF
--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -453,7 +453,7 @@ func (s *clientSuite) TestForceDestroyMachines(c *gc.C) {
 	s.assertForceDestroyMachines(c)
 }
 
-func (s *clientSuite) testClientUnitResolved(c *gc.C, retry bool, expectedResolvedMode state.ResolvedMode) {
+func (s *clientSuite) testClientUnitResolved(c *gc.C, noretry bool, expectedResolvedMode state.ResolvedMode) {
 	// Setup:
 	s.setUpScenario(c)
 	u, err := s.State.Unit("wordpress/0")
@@ -467,7 +467,7 @@ func (s *clientSuite) testClientUnitResolved(c *gc.C, retry bool, expectedResolv
 	err = u.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	// Code under test:
-	err = s.APIState.Client().Resolved("wordpress/0", retry)
+	err = s.APIState.Client().Resolved("wordpress/0", noretry)
 	c.Assert(err, jc.ErrorIsNil)
 	// Freshen the unit's state.
 	err = u.Refresh()
@@ -479,11 +479,11 @@ func (s *clientSuite) testClientUnitResolved(c *gc.C, retry bool, expectedResolv
 }
 
 func (s *clientSuite) TestClientUnitResolved(c *gc.C) {
-	s.testClientUnitResolved(c, false, state.ResolvedNoHooks)
+	s.testClientUnitResolved(c, true, state.ResolvedNoHooks)
 }
 
 func (s *clientSuite) TestClientUnitResolvedRetry(c *gc.C) {
-	s.testClientUnitResolved(c, true, state.ResolvedRetryHooks)
+	s.testClientUnitResolved(c, false, state.ResolvedRetryHooks)
 }
 
 func (s *clientSuite) setupResolved(c *gc.C) *state.Unit {
@@ -502,7 +502,7 @@ func (s *clientSuite) setupResolved(c *gc.C) *state.Unit {
 }
 
 func (s *clientSuite) assertResolved(c *gc.C, u *state.Unit) {
-	err := s.APIState.Client().Resolved("wordpress/0", true)
+	err := s.APIState.Client().Resolved("wordpress/0", false)
 	c.Assert(err, jc.ErrorIsNil)
 	// Freshen the unit's state.
 	err = u.Refresh()
@@ -514,7 +514,7 @@ func (s *clientSuite) assertResolved(c *gc.C, u *state.Unit) {
 }
 
 func (s *clientSuite) assertResolvedBlocked(c *gc.C, u *state.Unit, msg string) {
-	err := s.APIState.Client().Resolved("wordpress/0", true)
+	err := s.APIState.Client().Resolved("wordpress/0", false)
 	s.AssertBlocked(c, err, msg)
 }
 

--- a/cmd/juju/commands/resolved.go
+++ b/cmd/juju/commands/resolved.go
@@ -21,7 +21,7 @@ func newResolvedCommand() cmd.Command {
 type resolvedCommand struct {
 	modelcmd.ModelCommandBase
 	UnitName string
-	NoRetry    bool
+	NoRetry  bool
 }
 
 func (c *resolvedCommand) Info() *cmd.Info {

--- a/cmd/juju/commands/resolved.go
+++ b/cmd/juju/commands/resolved.go
@@ -21,21 +21,20 @@ func newResolvedCommand() cmd.Command {
 type resolvedCommand struct {
 	modelcmd.ModelCommandBase
 	UnitName string
-	Retry    bool
+	NoRetry    bool
 }
 
 func (c *resolvedCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "resolved",
 		Args:    "<unit>",
-		Purpose: "Marks unit errors resolved.",
+		Purpose: "Marks unit errors resolved and re-execute failed hooks",
 	}
 }
 
 func (c *resolvedCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	f.BoolVar(&c.Retry, "r", false, "Re-execute failed hooks")
-	f.BoolVar(&c.Retry, "retry", false, "")
+	f.BoolVar(&c.NoRetry, "no-retry", false, "do not re-execute failed hooks on the unit")
 }
 
 func (c *resolvedCommand) Init(args []string) error {
@@ -57,5 +56,5 @@ func (c *resolvedCommand) Run(_ *cmd.Context) error {
 		return err
 	}
 	defer client.Close()
-	return block.ProcessBlockedError(client.Resolved(c.UnitName, c.Retry), block.BlockChange)
+	return block.ProcessBlockedError(client.Resolved(c.UnitName, c.NoRetry), block.BlockChange)
 }

--- a/cmd/juju/commands/resolved.go
+++ b/cmd/juju/commands/resolved.go
@@ -28,7 +28,7 @@ func (c *resolvedCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "resolved",
 		Args:    "<unit>",
-		Purpose: "Marks unit errors resolved and re-execute failed hooks",
+		Purpose: "Marks unit errors resolved and re-executes failed hooks",
 	}
 }
 

--- a/cmd/juju/commands/resolved.go
+++ b/cmd/juju/commands/resolved.go
@@ -34,7 +34,7 @@ func (c *resolvedCommand) Info() *cmd.Info {
 
 func (c *resolvedCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	f.BoolVar(&c.NoRetry, "no-retry", false, "do not re-execute failed hooks on the unit")
+	f.BoolVar(&c.NoRetry, "no-retry", false, "Do not re-execute failed hooks on the unit")
 }
 
 func (c *resolvedCommand) Init(args []string) error {

--- a/cmd/juju/commands/resolved_test.go
+++ b/cmd/juju/commands/resolved_test.go
@@ -61,21 +61,21 @@ var resolvedTests = []struct {
 		unit: "dummy/0",
 		mode: state.ResolvedNone,
 	}, {
-		args: []string{"dummy/1", "--retry"},
+		args: []string{"dummy/1", "--no-retry"},
 		err:  `unit "dummy/1" is not in an error state`,
 		unit: "dummy/1",
 		mode: state.ResolvedNone,
 	}, {
-		args: []string{"dummy/2"},
+		args: []string{"dummy/2", "--no-retry"},
 		unit: "dummy/2",
 		mode: state.ResolvedNoHooks,
 	}, {
-		args: []string{"dummy/2", "--retry"},
+		args: []string{"dummy/2", "--no-retry"},
 		err:  `cannot set resolved mode for unit "dummy/2": already resolved`,
 		unit: "dummy/2",
 		mode: state.ResolvedNoHooks,
 	}, {
-		args: []string{"dummy/3", "--retry"},
+		args: []string{"dummy/3"},
 		unit: "dummy/3",
 		mode: state.ResolvedRetryHooks,
 	}, {

--- a/state/unit.go
+++ b/state/unit.go
@@ -2207,7 +2207,7 @@ func (u *Unit) RunningActions() ([]Action, error) {
 // reestablish normal workflow. The retryHooks parameter informs
 // whether to attempt to reexecute previous failed hooks or to continue
 // as if they had succeeded before.
-func (u *Unit) Resolve(retryHooks bool) error {
+func (u *Unit) Resolve(noretryHooks bool) error {
 	// We currently check agent status to see if a unit is
 	// in error state. As the new Juju Health work is completed,
 	// this will change to checking the unit status.
@@ -2218,9 +2218,9 @@ func (u *Unit) Resolve(retryHooks bool) error {
 	if statusInfo.Status != status.Error {
 		return errors.Errorf("unit %q is not in an error state", u)
 	}
-	mode := ResolvedNoHooks
-	if retryHooks {
-		mode = ResolvedRetryHooks
+	mode := ResolvedRetryHooks
+	if noretryHooks {
+		mode = ResolvedNoHooks
 	}
 	return u.SetResolved(mode)
 }

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -932,7 +932,7 @@ func (s *UnitSuite) TestResolve(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.unit.Resolve(true)
 	c.Assert(err, gc.ErrorMatches, `cannot set resolved mode for unit "wordpress/0": already resolved`)
-	c.Assert(s.unit.Resolved(), gc.Equals, state.ResolvedNoHooks)
+	c.Assert(s.unit.Resolved(), gc.Equals, state.ResolvedRetryHooks)
 
 	err = s.unit.ClearResolved()
 	c.Assert(err, jc.ErrorIsNil)
@@ -940,7 +940,7 @@ func (s *UnitSuite) TestResolve(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.unit.Resolve(false)
 	c.Assert(err, gc.ErrorMatches, `cannot set resolved mode for unit "wordpress/0": already resolved`)
-	c.Assert(s.unit.Resolved(), gc.Equals, state.ResolvedRetryHooks)
+	c.Assert(s.unit.Resolved(), gc.Equals, state.ResolvedNoHooks)
 }
 
 func (s *UnitSuite) TestGetSetClearResolved(c *gc.C) {


### PR DESCRIPTION
Reverse the default for the "juju resolved" command.  Errored hooks are re-executed by default.

juju resolved --retry <unit> --> juju resolved <unit>
juju resolved <unit> --> juju resolved --no-retry <unit>

QA steps:
all unit test pass locally

run:
$juju resolved --help
(see):
"Usage: juju resolved [options] <unit>

Summary:
Marks unit errors resolved and re-executes failed hooks

Options:
-B, --no-browser-login  (= false)
    Do not use web browser for authentication
-m, --model (= "")
    Model to operate in. Accepts [<controller name>:]<model name>
--no-retry  (= false)
    do not re-execute failed hooks on the unit"

manual testing:
(download cassandra charm):
charm pull-source -v cs:xenial/cassandra
(edit bootstrap hook to just return an error state; in hooks.py):
"def bootstrap():
    raise SystemExit(1)"

juju bootstrap mytestlxd lxd
juju add-model uniterrortest
juju deploy ./cassandra --series xenial
(wait for the error state)
juju resolved cassandra/0
(observe that bootstrap hook is re-run and errors again)
juju resolved --no-retry cassandra/0
(observe that unit error is cleared and the next hook errors)


