### PR TITLE
A number of fixes for restore-backup.

### DIFF
--- a/state/backups/backups_linux.go
+++ b/state/backups/backups_linux.go
@@ -6,17 +6,12 @@
 package backups
 
 import (
-	"fmt"
 	"net"
-	"os"
-	"path/filepath"
 	"strconv"
-	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/shell"
 	"gopkg.in/juju/names.v2"
-	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/juju/paths"
@@ -105,15 +100,11 @@ func (b *backups) Restore(backupId string, dbInfo *DBInfo, args RestoreArgs) (na
 		return nil, errors.Annotate(err, "cannot determine DataDir for the restored machine")
 	}
 
-	logDataDir(oldDatadir)
-
 	var oldAgentConfig agent.ConfigSetterWriter
 	oldAgentConfigFile := agent.ConfigPath(oldDatadir, args.NewInstTag)
 	if oldAgentConfig, err = agent.ReadConfig(oldAgentConfigFile); err != nil {
 		return nil, errors.Annotate(err, "cannot load old agent config from disk")
 	}
-
-	logAgentConfig("old config", oldAgentConfigFile, oldAgentConfig)
 
 	logger.Infof("stopping juju-db")
 	if err = mongo.StopService(); err != nil {
@@ -152,8 +143,6 @@ func (b *backups) Restore(backupId string, dbInfo *DBInfo, args RestoreArgs) (na
 		return nil, errors.Annotate(err, "cannot write new agent configuration")
 	}
 	logger.Infof("wrote new agent config for restore")
-	logAgentConfig("new config", agentConfigFile, agentConfig)
-	logDataDir(datadir)
 
 	if backupMachine.Id() != "0" {
 		logger.Infof("extra work needed backup belongs to %q machine", backupMachine.String())
@@ -302,68 +291,4 @@ func (b *backups) Restore(backupId string, dbInfo *DBInfo, args RestoreArgs) (na
 type machineModel struct {
 	machine *state.Machine
 	model   *state.Model
-}
-
-func logAgentConfig(prefix, filename string, config agent.Config) {
-	out := map[string]interface{}{
-		"data-dir":      config.DataDir(),
-		"log-dir":       config.LogDir(),
-		"identity-path": config.SystemIdentityPath(),
-		"jobs":          config.Jobs(),
-		"tag":           config.Tag(),
-		"agent-dir":     config.Dir(),
-		"nonce":         config.Nonce(),
-		// don't care about ca-cert
-		"old-password":        config.OldPassword(),
-		"upgraded-to-version": config.UpgradedToVersion(),
-		"model":               config.Model().Id(),
-		"controller":          config.Controller().Id(),
-		"mongo-version":       config.MongoVersion().String(),
-	}
-	if addresses, err := config.APIAddresses(); err != nil {
-		out["api-addresses"] = fmt.Sprintf("err: %v", err)
-	} else {
-		out["api-addresses"] = addresses
-	}
-	if info, ok := config.StateServingInfo(); ok {
-		out["state-serving-info"] = info
-	}
-	if info, ok := config.APIInfo(); ok {
-		out["api-info"] = info
-	}
-	if info, ok := config.MongoInfo(); ok {
-		out["mongo-info"] = info
-	}
-
-	bytes, err := yaml.Marshal(out)
-	if err != nil {
-		logger.Errorf("error marshalling config: %v", err)
-		return
-	}
-	logger.Infof("%s from %s\n----- start -----\n%s\n----- end ------", prefix, filename, string(bytes))
-}
-
-func logDataDir(datadir string) {
-	var out []string
-	filepath.Walk(datadir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			out = append(out, fmt.Sprintf("%s, err: %s", path, err))
-			return nil
-		}
-		format := "%s (%s)"
-		args := []interface{}{path}
-		if (info.Mode() & os.ModeDir) > 0 {
-			args = append(args, "dir")
-		} else if (info.Mode() & os.ModeSymlink) > 0 {
-			args = append(args, "symlink")
-		} else {
-			format += " size %d,"
-			args = append(args, "file", info.Size)
-		}
-		format += " mod time %s"
-		args = append(args, info.ModTime().Format("2006-01-02 15:04:05"))
-		out = append(out, fmt.Sprintf(format, args...))
-		return nil
-	})
-	logger.Infof("datadir %s\n%s", datadir, strings.Join(out, "\n"))
 }

--- a/state/backups/db.go
+++ b/state/backups/db.go
@@ -335,6 +335,8 @@ func NewDBRestorer(args RestorerArgs) (DBRestorer, error) {
 	}
 
 	installedMongo := mongoInstalledVersion()
+	logger.Debugf("args: is %#v", args)
+	logger.Infof("installed mongo is %s", installedMongo)
 	// NewerThan will check Major and Minor so migration between micro versions
 	// will work, before changing this bewar, Mongo has been known to break
 	// compatibility between minors.
@@ -495,6 +497,7 @@ func (md *mongoRestorer32) ensureTagUser() error {
 }
 
 func (md *mongoRestorer32) Restore(dumpDir string, dialInfo *mgo.DialInfo) error {
+	logger.Debugf("start restore, dumpDir %s", dumpDir)
 	if err := md.ensureOplogPermissions(dialInfo); err != nil {
 		return errors.Annotate(err, "setting special user permission in db")
 	}

--- a/state/backups/files.go
+++ b/state/backups/files.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 
 	"github.com/juju/errors"
+
+	"github.com/juju/juju/mongo"
 )
 
 // TODO(ericsnow) lp-1392876
@@ -96,14 +98,23 @@ var replaceableFolders = replaceableFoldersFunc
 
 // replaceableFoldersFunc will return a map with the folders that need to
 // be replaced so they can be deleted prior to a restore.
-func replaceableFoldersFunc() (map[string]os.FileMode, error) {
+// Mongo 2.4 requires that the database directory be removed, while
+// Mongo 3.2 requires that it not be removed
+func replaceableFoldersFunc(mongoVersion mongo.Version) (map[string]os.FileMode, error) {
 	replaceables := map[string]os.FileMode{}
 
-	for _, replaceable := range []string{
-		filepath.Join(dataDir, "db"),
+	// NOTE: never put dataDir in here directly as that will unconditionally
+	// remove tehe database.
+	dirs := []string{
 		filepath.Join(dataDir, "init"),
-		dataDir,
-	} {
+		filepath.Join(dataDir, "tools"),
+		filepath.Join(dataDir, "agents"),
+	}
+	if mongoVersion.Major == 2 {
+		dirs = append(dirs, filepath.Join(dataDir, "db"))
+	}
+
+	for _, replaceable := range dirs {
 		dirStat, err := os.Stat(replaceable)
 		if os.IsNotExist(err) {
 			continue
@@ -124,8 +135,8 @@ func replaceableFoldersFunc() (map[string]os.FileMode, error) {
 // directories that are to contain new files; this is to avoid
 // possible mixup from new/old files that lead to an inconsistent
 // restored state machine.
-func PrepareMachineForRestore() error {
-	replaceFolders, err := replaceableFolders()
+func PrepareMachineForRestore(mongoVersion mongo.Version) error {
+	replaceFolders, err := replaceableFolders(mongoVersion)
 	if err != nil {
 		return errors.Annotate(err, "cannot retrieve the list of folders to be cleaned before restore")
 	}
@@ -144,6 +155,7 @@ func PrepareMachineForRestore() error {
 		if !fmode.IsDir() {
 			continue
 		}
+		logger.Debugf("removing dir: %s", toBeRecreated)
 		if err := os.RemoveAll(toBeRecreated); err != nil {
 			return errors.Trace(err)
 		}

--- a/state/backups/files.go
+++ b/state/backups/files.go
@@ -100,11 +100,11 @@ var replaceableFolders = replaceableFoldersFunc
 // be replaced so they can be deleted prior to a restore.
 // Mongo 2.4 requires that the database directory be removed, while
 // Mongo 3.2 requires that it not be removed
-func replaceableFoldersFunc(mongoVersion mongo.Version) (map[string]os.FileMode, error) {
+func replaceableFoldersFunc(dataDir string, mongoVersion mongo.Version) (map[string]os.FileMode, error) {
 	replaceables := map[string]os.FileMode{}
 
 	// NOTE: never put dataDir in here directly as that will unconditionally
-	// remove tehe database.
+	// remove the database.
 	dirs := []string{
 		filepath.Join(dataDir, "init"),
 		filepath.Join(dataDir, "tools"),
@@ -136,7 +136,7 @@ func replaceableFoldersFunc(mongoVersion mongo.Version) (map[string]os.FileMode,
 // possible mixup from new/old files that lead to an inconsistent
 // restored state machine.
 func PrepareMachineForRestore(mongoVersion mongo.Version) error {
-	replaceFolders, err := replaceableFolders(mongoVersion)
+	replaceFolders, err := replaceableFolders(dataDir, mongoVersion)
 	if err != nil {
 		return errors.Annotate(err, "cannot retrieve the list of folders to be cleaned before restore")
 	}

--- a/state/backups/restore.go
+++ b/state/backups/restore.go
@@ -172,24 +172,26 @@ func newStateConnection(controllerTag names.ControllerTag, modelTag names.ModelT
 // better chance of being fixed by the user, if we were to fail
 // we risk an inconsistent controller because of one unresponsive
 // agent, we should nevertheless return the err info to the user.
-func updateAllMachines(privateAddress, publicAddress string, machines []*state.Machine) error {
+func updateAllMachines(privateAddress, publicAddress string, machines []machineModel) error {
 	var machineUpdating sync.WaitGroup
-	for key := range machines {
-		// key is used to have machine be scope bound to the loop iteration.
-		machine := machines[key]
+	for _, item := range machines {
+		machine := item.machine
 		// A newly resumed controller requires no updating, and more
 		// than one controller is not yet supported by this code.
 		if machine.IsManager() || machine.Life() == state.Dead {
 			continue
 		}
 		machineUpdating.Add(1)
-		go func() {
+		go func(machine *state.Machine, model *state.Model) {
 			defer machineUpdating.Done()
+			logger.Debugf("updating addresses for machine %s in model %s/%s", machine.Tag().Id(), model.Owner().Canonical(), model.Name())
+			// TODO: thumper 2016-09-20
+			// runMachineUpdate only handles linux machines, what about windows?
 			err := runMachineUpdate(machine, setAgentAddressScript(privateAddress, publicAddress))
 			if err != nil {
 				logger.Errorf("failed updating machine: %v", err)
 			}
-		}()
+		}(machine, item.model)
 	}
 	machineUpdating.Wait()
 
@@ -205,18 +207,12 @@ set -xu
 cd /var/lib/juju/agents
 for agent in *
 do
-	initctl stop jujud-$agent > /dev/null
-        systemctl stop jujud-$agent > /dev/null
 	service jujud-$agent stop > /dev/null
 
 	# The below statement will work in cases where there
 	# is a private address for the api server only
 	# or where there are a private and a public, which are
 	# the two common cases.
-	sed -i.old -r "/^(stateaddresses|apiaddresses):/{
-		n
-		s/- .*(:[0-9]+)/- {{.Address}}\1/
-	}" $agent/agent.conf
 	sed -i.old -r "/^(stateaddresses|apiaddresses):/{
 		n
 		s/- .*(:[0-9]+)/- {{.Address}}\1/
@@ -233,9 +229,6 @@ do
 	then
 		find $agent/state/relations -type f -exec sed -i -r 's/change-version: [0-9]+$/change-version: 0/' {} \;
 	fi
-	# Just in case is a stale unit
-	initctl start jujud-$agent > /dev/null
-        systemctl start jujud-$agent > /dev/null
 	service jujud-$agent start > /dev/null
 done
 `))
@@ -275,10 +268,14 @@ func runViaSSH(addr string, script string) error {
 	sshOptions := ssh.Options{}
 	sshOptions.SetIdentities("/var/lib/juju/system-identity")
 	userCmd := sshCommand(userAddr, []string{"sudo", "-n", "bash", "-c " + utils.ShQuote(script)}, &sshOptions)
+	var stdoutBuf bytes.Buffer
 	var stderrBuf bytes.Buffer
+	userCmd.Stdout = &stdoutBuf
 	userCmd.Stderr = &stderrBuf
+	logger.Debugf("updating %s, script:\n%s", addr, script)
 	if err := userCmd.Run(); err != nil {
 		return errors.Annotatef(err, "ssh command failed: %q", stderrBuf.String())
 	}
+	logger.Debugf("result %s\nstdout: \n%s\nstderr: %s", addr, stdoutBuf.String(), stderrBuf.String())
 	return nil
 }

--- a/worker/apiaddressupdater/manifold.go
+++ b/worker/apiaddressupdater/manifold.go
@@ -5,11 +5,11 @@ package apiaddressupdater
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/api/machiner"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/machiner"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/cmd/jujud/agent/engine"
 	"github.com/juju/juju/worker"


### PR DESCRIPTION
On xenial, systemd does not automatically start a service that is added, unlike upstart on trusty. The restore function would ensure that the juju-db service existed. This would cause it to be stopped, removed, and re-added. Unfortunately it was missing a start causing the restore to hang sometimes.

Also, best to stop the juju-db service before we, possibly, remove all the files from under it.
Now we only remove file for mongo 2.x, and leave them for 3.x. This is due to the different mongo restore methods. 2.x requires mongo to be not running, and 3.x requires a mongo service to be running.

There was also a race between the peergrouper setting the API host ports, and the machine and unit agents of the other machines and units being managed by the controller getting restarted. This is fixed by the restore method explicitly setting the API host ports before moving on to the other machines.

Extra logging is added around the updating of the other machines.

The multiple different ways of stopping an agent are unneeded. All of trusty, xenial, and centos have the service wrapper.  Worth noting that there is a problem if there are any windows workload machines, as the method to update the agent configuration won't work for them. But this isn't new with this branch.

## QA

A LXD controller was set up with an ubuntu unit deployed in the default model.
A backup was taken, and then restored with the a new bootstrap node.
All agents come back on line, and start properly.

Runs have also been done on the CI machines testing the CI restore tests.

This branch appears to fix http://pad.lv/1606265, although I have to be honest and say I don't know why.