### PR TITLE
Make deploy steps configurable for testing.

### DIFF
--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -34,7 +34,7 @@ import (
 // charm or bundle. The deployment output and error are returned.
 func runDeployCommand(c *gc.C, id string, args ...string) (string, error) {
 	args = append([]string{id}, args...)
-	ctx, err := coretesting.RunCommand(c, NewDeployCommand(), args...)
+	ctx, err := coretesting.RunCommand(c, NewDefaultDeployCommand(), args...)
 	return strings.Trim(coretesting.Stderr(ctx), "\n"), err
 }
 

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -68,7 +68,7 @@ func (s *DeploySuite) SetUpTest(c *gc.C) {
 }
 
 func runDeploy(c *gc.C, args ...string) error {
-	_, err := coretesting.RunCommand(c, NewDeployCommand(), args...)
+	_, err := coretesting.RunCommand(c, NewDefaultDeployCommand(), args...)
 	return err
 }
 
@@ -100,7 +100,7 @@ var initErrorTests = []struct {
 func (s *DeploySuite) TestInitErrors(c *gc.C) {
 	for i, t := range initErrorTests {
 		c.Logf("test %d", i)
-		err := coretesting.InitCommand(NewDeployCommand(), t.args)
+		err := coretesting.InitCommand(NewDefaultDeployCommand(), t.args)
 		c.Assert(err, gc.ErrorMatches, t.err)
 	}
 }
@@ -603,7 +603,7 @@ func (s *DeployCharmStoreSuite) TestDeployAuthorization(c *gc.C) {
 		if test.readPermUser != "" {
 			s.changeReadPerm(c, url, test.readPermUser)
 		}
-		_, err := coretesting.RunCommand(c, NewDeployCommand(), test.deployURL, fmt.Sprintf("wordpress%d", i))
+		_, err := coretesting.RunCommand(c, NewDefaultDeployCommand(), test.deployURL, fmt.Sprintf("wordpress%d", i))
 		if test.expectError != "" {
 			c.Check(err, gc.ErrorMatches, test.expectError)
 			continue
@@ -1283,9 +1283,9 @@ func (s *DeployUnitTestSuite) TestDeployLocalCharm_GivesCorrectUserMessage(c *gc
 	withLocalCharmDeployable(fakeAPI, dummyURL, charmDir)
 	withCharmDeployable(fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1)
 
-	cmd := NewDeployCommandWithAPI(func() (DeployAPI, error) {
+	cmd := NewDeployCommand(func() (DeployAPI, error) {
 		return fakeAPI, nil
-	})
+	}, nil)
 	context, err := jtesting.RunCommand(c, cmd, charmDir.Path, "--series", "trusty")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1306,7 +1306,9 @@ func (s *DeployUnitTestSuite) TestAddMetricCredentialsDefaultForUnmeteredCharm(c
 	withLocalCharmDeployable(fakeAPI, dummyURL, charmDir)
 	withCharmDeployable(fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), true, 1)
 
-	deployCmd := NewDeployCommandWithAPI(func() (DeployAPI, error) { return fakeAPI, nil })
+	deployCmd := NewDeployCommand(func() (DeployAPI, error) {
+		return fakeAPI, nil
+	}, nil)
 	_, err := coretesting.RunCommand(c, deployCmd, charmDir.Path, "--series", "trusty")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1331,7 +1333,9 @@ func (s *DeployUnitTestSuite) TestRedeployLocalCharm_SucceedsWhenDeployed(c *gc.
 	withLocalCharmDeployable(fakeAPI, dummyURL, charmDir)
 	withCharmDeployable(fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1)
 
-	deployCmd := NewDeployCommandWithAPI(func() (DeployAPI, error) { return fakeAPI, nil })
+	deployCmd := NewDeployCommand(func() (DeployAPI, error) {
+		return fakeAPI, nil
+	}, nil)
 	context, err := jtesting.RunCommand(c, deployCmd, dummyURL.String())
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1389,7 +1393,9 @@ func (s *DeployUnitTestSuite) TestDeployBundle_OutputsCorrectMessage(c *gc.C) {
 		error(nil),
 	)
 
-	deployCmd := NewDeployCommandWithAPI(func() (DeployAPI, error) { return fakeAPI, nil })
+	deployCmd := NewDeployCommand(func() (DeployAPI, error) {
+		return fakeAPI, nil
+	}, nil)
 	context, err := jtesting.RunCommand(c, deployCmd, "cs:bundle/wordpress-simple")
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -67,7 +67,7 @@ func (s *RemoveServiceSuite) TestSuccess(c *gc.C) {
 
 func (s *RemoveServiceSuite) TestRemoveLocalMetered(c *gc.C) {
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "metered")
-	deploy := NewDeployCommand()
+	deploy := NewDefaultDeployCommand()
 	_, err := testing.RunCommand(c, deploy, ch, "--series", "quantal")
 	c.Assert(err, jc.ErrorIsNil)
 	err = runRemoveService(c, "metered")

--- a/cmd/juju/application/upgradecharm_resources_test.go
+++ b/cmd/juju/application/upgradecharm_resources_test.go
@@ -45,7 +45,7 @@ func (s *UpgradeCharmResourceSuite) SetUpTest(c *gc.C) {
 	s.RepoSuite.SetUpTest(c)
 	chPath := testcharms.Repo.ClonedDirPath(s.CharmsPath, "riak")
 
-	_, err := testing.RunCommand(c, application.NewDeployCommand(), chPath, "riak", "--series", "quantal")
+	_, err := testing.RunCommand(c, application.NewDefaultDeployCommand(), chPath, "riak", "--series", "quantal")
 	c.Assert(err, jc.ErrorIsNil)
 	riak, err := s.State.Application("riak")
 	c.Assert(err, jc.ErrorIsNil)
@@ -193,7 +193,7 @@ func (s *UpgradeCharmStoreResourceSuite) TestDeployStarsaySuccess(c *gc.C) {
 	err := ioutil.WriteFile(resourceFile, []byte(resourceContent), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctx, err := testing.RunCommand(c, application.NewDeployCommand(), "trusty/starsay", "--resource", "upload-resource="+resourceFile)
+	ctx, err := testing.RunCommand(c, application.NewDefaultDeployCommand(), "trusty/starsay", "--resource", "upload-resource="+resourceFile)
 	c.Assert(err, jc.ErrorIsNil)
 	output := testing.Stderr(ctx)
 

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -329,7 +329,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	// Manage and control services
 	r.Register(application.NewAddUnitCommand())
 	r.Register(application.NewConfigCommand())
-	r.Register(application.NewDeployCommand())
+	r.Register(application.NewDefaultDeployCommand())
 	r.Register(application.NewExposeCommand())
 	r.Register(application.NewUnexposeCommand())
 	r.Register(application.NewServiceGetConstraintsCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -41,7 +41,7 @@ type MainSuite struct {
 var _ = gc.Suite(&MainSuite{})
 
 func deployHelpText() string {
-	return cmdtesting.HelpText(application.NewDeployCommand(), "juju deploy")
+	return cmdtesting.HelpText(application.NewDefaultDeployCommand(), "juju deploy")
 }
 func configHelpText() string {
 	return cmdtesting.HelpText(application.NewConfigCommand(), "juju config")

--- a/cmd/juju/commands/resolved_test.go
+++ b/cmd/juju/commands/resolved_test.go
@@ -37,7 +37,7 @@ func runResolved(c *gc.C, args []string) error {
 }
 
 func runDeploy(c *gc.C, args ...string) error {
-	_, err := testing.RunCommand(c, application.NewDeployCommand(), args...)
+	_, err := testing.RunCommand(c, application.NewDefaultDeployCommand(), args...)
 	return err
 }
 


### PR DESCRIPTION
The added function (NewDeployCommandWithSteps) mirrors the existing NewDeployCommandWithAPI and is to be used in testing the deploy command with custom deploy steps outside of juju.