### PR TITLE
Fix all watcher dealing with remove/create

### DIFF
--- a/state/multiwatcher.go
+++ b/state/multiwatcher.go
@@ -495,6 +495,8 @@ func (a *multiwatcherStore) Update(info multiwatcher.EntityInfo) {
 	a.latestRevno++
 	entry.revno = a.latestRevno
 	entry.info = info
+	// The app might have been removed and re-added.
+	entry.removed = false
 	a.list.MoveToFront(elem)
 }
 

--- a/state/multiwatcher_internal_test.go
+++ b/state/multiwatcher_internal_test.go
@@ -91,6 +91,45 @@ var StoreChangeMethodTests = []struct {
 		info:          &multiwatcher.MachineInfo{Id: "1"},
 	}},
 }, {
+	about: "mark application removed then update",
+	change: func(all *multiwatcherStore) {
+		all.Update(&multiwatcher.ApplicationInfo{ModelUUID: "uuid0", Name: "logging"})
+		all.Update(&multiwatcher.ApplicationInfo{ModelUUID: "uuid0", Name: "wordpress"})
+		StoreIncRef(all, multiwatcher.EntityId{"application", "uuid0", "logging"})
+		all.Remove(multiwatcher.EntityId{"application", "uuid0", "logging"})
+		all.Update(&multiwatcher.ApplicationInfo{
+			ModelUUID: "uuid0",
+			Name:      "wordpress",
+			Exposed:   true,
+		})
+		all.Update(&multiwatcher.ApplicationInfo{
+			ModelUUID: "uuid0",
+			Name:      "logging",
+			Exposed:   true,
+		})
+	},
+	expectRevno: 5,
+	expectContents: []entityEntry{{
+		revno:         4,
+		creationRevno: 2,
+		removed:       false,
+		refCount:      0,
+		info: &multiwatcher.ApplicationInfo{
+			ModelUUID: "uuid0",
+			Name:      "wordpress",
+			Exposed:   true,
+		}}, {
+		revno:         5,
+		creationRevno: 1,
+		removed:       false,
+		refCount:      1,
+		info: &multiwatcher.ApplicationInfo{
+			ModelUUID: "uuid0",
+			Name:      "logging",
+			Exposed:   true,
+		},
+	}},
+}, {
 	about: "mark removed on existing entry",
 	change: func(all *multiwatcherStore) {
 		all.Update(&multiwatcher.MachineInfo{ModelUUID: "uuid", Id: "0"})


### PR DESCRIPTION
When removing and creating again an application, allwatcher
would report the application as removed in all deltas until
a new watching connection was made.

This fixes: https://launchpad.net/bugs/1610007

### QA steps:
* Run the tests.