### PR TITLE
Synchronise between worker and test.

### DIFF
--- a/worker/txnpruner/txnpruner_test.go
+++ b/worker/txnpruner/txnpruner_test.go
@@ -43,6 +43,13 @@ func (s *TxnPrunerSuite) TestPrunes(c *gc.C) {
 		case <-time.After(coretesting.LongWait):
 			c.Fatal("timed out waiting for pruning to happen")
 		}
+		// Now we need to wait for the txn pruner to call clock.After again
+		// before we advance the clock, or it will be waiting for the wrong time.
+		select {
+		case <-testClock.Alarms():
+		case <-time.After(coretesting.LongWait):
+			c.Fatalf("timed out waiting for worker to loop around")
+		}
 	}
 }
 


### PR DESCRIPTION
After adding more logging and running under the race detector, I was finally able to determine what was going on.

The test was looping around as soon as the worker signalled that the transactions were pruned, so the test clock was advanced another minute before the worker loop got around to call the next clock.After. Since we were waiting for a response every time we advanced the clock, it would fail because the worker already thought it was a minute after it should have been.

Fixes http://pad.lv/1623178

## QA

Ran the test repeatedly with the race detector.