### PR TITLE
mongo: Increase socket timeout

### DIFF
--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -203,8 +203,6 @@ func ServerError(err error) *params.Error {
 	var info *params.ErrorInfo
 	switch {
 	case ok:
-	case isIOTimeout(err):
-		code = params.CodeRetry
 	case errors.IsUnauthorized(err):
 		code = params.CodeUnauthorized
 	case errors.IsNotFound(err):
@@ -252,17 +250,6 @@ func ServerError(err error) *params.Error {
 		Code:    code,
 		Info:    info,
 	}
-}
-
-// Unfortunately there is no specific type of error for i/o timeout,
-// and the error that bubbles up from mgo is annotated and a string type,
-// so all we can do is look at the error suffix and see if it matches.
-func isIOTimeout(err error) bool {
-	// Perhaps sometime in the future, we'll have additional ways to tell if
-	// the error is an i/o timeout type error, but for now this is all we
-	// have.
-	msg := err.Error()
-	return strings.HasSuffix(msg, "i/o timeout")
 }
 
 func DestroyErr(desc string, ids, errs []string) error {

--- a/apiserver/common/errors_test.go
+++ b/apiserver/common/errors_test.go
@@ -191,10 +191,6 @@ var errorTransformTests = []struct {
 	status:     http.StatusNotFound,
 	helperFunc: params.IsCodeModelNotFound,
 }, {
-	err:    errors.Annotate(errors.New("i/o timeout"), "annotated"),
-	code:   params.CodeRetry,
-	status: http.StatusServiceUnavailable,
-}, {
 	err:    nil,
 	code:   "",
 	status: http.StatusOK,

--- a/mongo/open.go
+++ b/mongo/open.go
@@ -19,17 +19,19 @@ import (
 	"github.com/juju/juju/cert"
 )
 
-// SocketTimeout should be long enough that
-// even a slow mongo server will respond in that
-// length of time. Since mongo servers ping themselves
-// every 10 seconds, we use a value of just over 2
-// ping periods to allow for delayed pings due to
-// issues such as CPU starvation etc.
-const SocketTimeout = 21 * time.Second
+// SocketTimeout should be long enough that even a slow mongo server
+// will respond in that length of time, and must also be long enough
+// to allow for completion of heavyweight queries.
+//
+// Note: 1 minute is mgo's default socket timeout value.
+//
+// Also note: We have observed mongodb occasionally getting "stuck"
+// for over 30s in the field.
+const SocketTimeout = time.Minute
 
-// defaultDialTimeout should be representative of
-// the upper bound of time taken to dial a mongo
-// server from within the same cloud/private network.
+// defaultDialTimeout should be representative of the upper bound of
+// time taken to dial a mongo server from within the same
+// cloud/private network.
 const defaultDialTimeout = 30 * time.Second
 
 // DialOpts holds configuration parameters that control the


### PR DESCRIPTION
This will hopefully fix https://bugs.launchpad.net/juju/+bug/1597601.

The OIL team are seeing MongoDB "i/o timeout" errors about once a day in their testing. These are handled well by the controller machine agent workers which simply restart but could also make it out to the client as errors.

The socket timeout has now been been increased to 1 min (OIL were seeing mongodb get stuck for about 30s). This also happens to be mgo's default timeout.

This PR also reverts part of an earlier attempt at dealing with this issue.

### QA

I was unable to reproduce the issue directly but I was able to generate the same symptoms by modifying one of Juju's AddApplication API handler to sent a SIGSTOP to mongod and spinning off a goroutine which sent SIGCONT some time later. With the timeout increase in place, jujud is able to handle MongoDB being unresponsive for up to 60s.