### PR TITLE
provider/gce: don't set sshKeys instance metadata

### DIFF
--- a/provider/gce/environ_broker.go
+++ b/provider/gce/environ_broker.go
@@ -203,12 +203,6 @@ func getMetadata(args environs.StartInstanceParams, os jujuos.OSType) (map[strin
 		// See: http://cloudinit.readthedocs.org
 		metadata[metadataKeyEncoding] = "base64"
 
-		authKeys, err := google.FormatAuthorizedKeys(args.InstanceConfig.AuthorizedKeys, "ubuntu")
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-
-		metadata[metadataKeySSHKeys] = authKeys
 	case jujuos.Windows:
 		metadata[metadataKeyWindowsUserdata] = string(userData)
 

--- a/provider/gce/gce.go
+++ b/provider/gce/gce.go
@@ -17,9 +17,6 @@ const (
 	metadataKeyEncoding        = "user-data-encoding"
 	metadataKeyWindowsUserdata = "windows-startup-script-ps1"
 	metadataKeyWindowsSysprep  = "sysprep-specialize-script-ps1"
-	// GCE uses this specific key for authentication (*handwaving*)
-	// https://cloud.google.com/compute/docs/instances#sshkeys
-	metadataKeySSHKeys = "sshKeys"
 )
 
 const (

--- a/provider/gce/google/instance.go
+++ b/provider/gce/google/instance.go
@@ -6,9 +6,7 @@ package google
 import (
 	"fmt"
 	"path"
-	"strings"
 
-	"github.com/juju/errors"
 	"google.golang.org/api/compute/v1"
 
 	"github.com/juju/juju/network"
@@ -175,27 +173,6 @@ func (gi Instance) Addresses() []network.Address {
 func (gi Instance) Metadata() map[string]string {
 	// TODO*ericsnow) return a copy?
 	return gi.InstanceSummary.Metadata
-}
-
-// FormatAuthorizedKeys returns our authorizedKeys with
-// the username prepended to it. This is the format that
-// GCE expects when we upload sshKeys metadata. The sshKeys
-// metadata is what is used by our scripts and commands
-// like juju ssh to connect to juju machines.
-func FormatAuthorizedKeys(rawAuthorizedKeys, user string) (string, error) {
-	if rawAuthorizedKeys == "" {
-		return "", errors.New("empty rawAuthorizedKeys")
-	}
-	if user == "" {
-		return "", errors.New("empty user")
-	}
-
-	var userKeys string
-	keys := strings.Split(rawAuthorizedKeys, "\n")
-	for _, key := range keys {
-		userKeys += user + ":" + key + "\n"
-	}
-	return userKeys, nil
 }
 
 // packMetadata composes the provided data into the format required

--- a/provider/gce/google/instance_test.go
+++ b/provider/gce/google/instance_test.go
@@ -74,32 +74,6 @@ func (s *instanceSuite) TestInstanceMetadata(c *gc.C) {
 	c.Check(metadata, jc.DeepEquals, map[string]string{"eggs": "steak"})
 }
 
-func (s *instanceSuite) TestFormatAuthorizedKeys(c *gc.C) {
-	formatted, err := google.FormatAuthorizedKeys("abcd", "john")
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(formatted, gc.Equals, "john:abcd\n")
-}
-
-func (s *instanceSuite) TestFormatAuthorizedKeysEmpty(c *gc.C) {
-	_, err := google.FormatAuthorizedKeys("", "john")
-
-	c.Check(err, gc.ErrorMatches, "empty rawAuthorizedKeys")
-}
-
-func (s *instanceSuite) TestFormatAuthorizedKeysNoUser(c *gc.C) {
-	_, err := google.FormatAuthorizedKeys("abcd", "")
-
-	c.Check(err, gc.ErrorMatches, "empty user")
-}
-
-func (s *instanceSuite) TestFormatAuthorizedKeysMultiple(c *gc.C) {
-	formatted, err := google.FormatAuthorizedKeys("abcd\ndcba\nqwer", "john")
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(formatted, gc.Equals, "john:abcd\njohn:dcba\njohn:qwer\n")
-}
-
 func (s *instanceSuite) TestPackMetadata(c *gc.C) {
 	expected := compute.Metadata{Items: []*compute.MetadataItems{{
 		Key:   "spam",

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -166,15 +166,11 @@ func (s *BaseSuiteUnpatched) initInst(c *gc.C) {
 	userData, err := providerinit.ComposeUserData(instanceConfig, nil, GCERenderer{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	authKeys, err := google.FormatAuthorizedKeys(instanceConfig.AuthorizedKeys, "ubuntu")
-	c.Assert(err, jc.ErrorIsNil)
-
 	s.UbuntuMetadata = map[string]string{
 		tags.JujuIsController: "true",
 		tags.JujuController:   s.ControllerUUID,
 		metadataKeyCloudInit:  string(userData),
 		metadataKeyEncoding:   "base64",
-		metadataKeySSHKeys:    authKeys,
 	}
 	instanceConfig.Tags = map[string]string{
 		tags.JujuIsController: "true",


### PR DESCRIPTION
The GCE provider is bailing from StartInstances if
authorized-keys is empty. It should not be doing
this.

Also, we're only looking at authorized-keys in the
GCE provider to set the sshKeys instance metadata.
This is what GCE uses to keep track of the SSH keys
that *it* manages on an instance. We should not be
setting this; using cloud-init is sufficient.

Fixes https://bugs.launchpad.net/bugs/1625881