### PR TITLE
mongo: Increase socket timeout

### DIFF
--- a/mongo/open.go
+++ b/mongo/open.go
@@ -19,17 +19,19 @@ import (
 	"github.com/juju/juju/cert"
 )
 
-// SocketTimeout should be long enough that
-// even a slow mongo server will respond in that
-// length of time. Since mongo servers ping themselves
-// every 10 seconds, we use a value of just over 2
-// ping periods to allow for delayed pings due to
-// issues such as CPU starvation etc.
-const SocketTimeout = 21 * time.Second
+// SocketTimeout should be long enough that even a slow mongo server
+// will respond in that length of time, and must also be long enough
+// to allow for completion of heavyweight queries.
+//
+// Note: 1 minute is mgo's default socket timeout value.
+//
+// Also note: We have observed mongodb occasionally getting "stuck"
+// for over 30s in the field.
+const SocketTimeout = time.Minute
 
-// defaultDialTimeout should be representative of
-// the upper bound of time taken to dial a mongo
-// server from within the same cloud/private network.
+// defaultDialTimeout should be representative of the upper bound of
+// time taken to dial a mongo server from within the same
+// cloud/private network.
 const defaultDialTimeout = 30 * time.Second
 
 // DialOpts holds configuration parameters that control the


### PR DESCRIPTION
This will hopefully fix https://bugs.launchpad.net/juju/+bug/1597601.

The OIL team are seeing MongoDB "i/o timeout" errors about once a day in
their testing. These are handled well by the controler machine agent
workers which simply restart but could also make it out to the client as
errors.

The socket timeout has now been been increased to 1 min (OIL were seeing
mongodb get stuck for about 30s). This also happens to be mgo's default
timeout.