### PR TITLE
Add region handling to UpdateModelConfigDefaultValues

### DIFF
--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -41,7 +41,7 @@ type ModelManagerBackend interface {
 	GetModel(names.ModelTag) (Model, error)
 	Model() (Model, error)
 	ModelConfigDefaultValues() (config.ModelDefaultAttributes, error)
-	UpdateModelConfigDefaultValues(update map[string]interface{}, remove []string) error
+	UpdateModelConfigDefaultValues(update map[string]interface{}, remove []string, regionSpec *environs.RegionSpec) error
 	Unit(name string) (*state.Unit, error)
 	ModelTag() names.ModelTag
 	ModelConfig() (*config.Config, error)

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -491,13 +491,37 @@ func (st *mockState) ModelConfigDefaultValues() (config.ModelDefaultAttributes, 
 	return st.cfgDefaults, nil
 }
 
-func (st *mockState) UpdateModelConfigDefaultValues(update map[string]interface{}, remove []string) error {
-	st.MethodCall(st, "UpdateModelConfigDefaultValues", update, remove)
+func (st *mockState) UpdateModelConfigDefaultValues(update map[string]interface{}, remove []string, rspec *environs.RegionSpec) error {
+	st.MethodCall(st, "UpdateModelConfigDefaultValues", update, remove, rspec)
 	for k, v := range update {
-		st.cfgDefaults[k] = config.AttributeDefaultValues{Controller: v}
+		if rspec != nil {
+			adv := st.cfgDefaults[k]
+			adv.Regions = append(adv.Regions, config.RegionDefaultValue{
+				Name:  rspec.Region,
+				Value: v})
+
+		} else {
+			st.cfgDefaults[k] = config.AttributeDefaultValues{Controller: v}
+		}
 	}
 	for _, n := range remove {
-		delete(st.cfgDefaults, n)
+		if rspec != nil {
+			for i, r := range st.cfgDefaults[n].Regions {
+				if r.Name == rspec.Region {
+					adv := st.cfgDefaults[n]
+					adv.Regions = append(adv.Regions[:i], adv.Regions[i+1:]...)
+					st.cfgDefaults[n] = adv
+				}
+			}
+		} else {
+			if len(st.cfgDefaults[n].Regions) == 0 {
+				delete(st.cfgDefaults, n)
+			} else {
+
+				st.cfgDefaults[n] = config.AttributeDefaultValues{
+					Regions: st.cfgDefaults[n].Regions}
+			}
+		}
 	}
 	return nil
 }

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -804,7 +804,6 @@ func (c *ModelManagerAPI) SetModelDefaults(args params.SetModelDefaults) (params
 		return results, errors.Trace(err)
 	}
 	for i, arg := range args.Config {
-		// TODO(wallyworld) - use arg.Cloud and arg.CloudRegion as appropriate
 		results.Results[i].Error = common.ServerError(
 			c.setModelDefaults(arg),
 		)
@@ -824,7 +823,16 @@ func (c *ModelManagerAPI) setModelDefaults(args params.ModelDefaultValues) error
 	if _, found := args.Config["agent-version"]; found {
 		return errors.New("agent-version cannot have a default value")
 	}
-	return c.state.UpdateModelConfigDefaultValues(args.Config, nil)
+
+	var rspec *environs.RegionSpec
+	if args.CloudRegion != "" {
+		spec, err := c.makeRegionSpec(args.CloudTag, args.CloudRegion)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		rspec = spec
+	}
+	return c.state.UpdateModelConfigDefaultValues(args.Config, nil, rspec)
 }
 
 // UnsetModelDefaults removes the specified default model settings.
@@ -837,11 +845,35 @@ func (c *ModelManagerAPI) UnsetModelDefaults(args params.UnsetModelDefaults) (pa
 	if err := c.check.ChangeAllowed(); err != nil {
 		return results, errors.Trace(err)
 	}
+
 	for i, arg := range args.Keys {
-		// TODO(wallyworld) - use arg.Cloud and arg.CloudRegion as appropriate
+		var rspec *environs.RegionSpec
+		if arg.CloudRegion != "" {
+			spec, err := c.makeRegionSpec(arg.CloudTag, arg.CloudRegion)
+			if err != nil {
+				results.Results[i].Error = common.ServerError(
+					errors.Trace(err))
+				continue
+			}
+			rspec = spec
+		}
 		results.Results[i].Error = common.ServerError(
-			c.state.UpdateModelConfigDefaultValues(nil, arg.Keys),
+			c.state.UpdateModelConfigDefaultValues(nil, arg.Keys, rspec),
 		)
 	}
 	return results, nil
+}
+
+// makeRegionSpec is a helper method for methods that call
+// state.UpdateModelConfigDefaultValues.
+func (c *ModelManagerAPI) makeRegionSpec(cloudTag, r string) (*environs.RegionSpec, error) {
+	cTag, err := names.ParseCloudTag(cloudTag)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	rspec, err := environs.NewRegionSpec(cTag.Id(), r)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return rspec, nil
 }

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -114,8 +114,8 @@ func (m *ModelManagerAPI) authCheck(user names.UserTag) error {
 	return common.ErrPerm
 }
 
-func (s *ModelManagerAPI) hasWriteAccess(modelTag names.ModelTag) (bool, error) {
-	canWrite, err := s.authorizer.HasPermission(permission.WriteAccess, modelTag)
+func (m *ModelManagerAPI) hasWriteAccess(modelTag names.ModelTag) (bool, error) {
+	canWrite, err := m.authorizer.HasPermission(permission.WriteAccess, modelTag)
 	if errors.IsNotFound(err) {
 		return false, nil
 	}
@@ -128,7 +128,7 @@ type ConfigSource interface {
 	Config() (*config.Config, error)
 }
 
-func (mm *ModelManagerAPI) newModelConfig(
+func (m *ModelManagerAPI) newModelConfig(
 	cloudSpec environs.CloudSpec,
 	args params.ModelCreateArgs,
 	source ConfigSource,
@@ -157,14 +157,14 @@ func (mm *ModelManagerAPI) newModelConfig(
 	}
 
 	regionSpec := &environs.RegionSpec{Cloud: cloudSpec.Name, Region: cloudSpec.Region}
-	if joint, err = mm.state.ComposeNewModelConfig(joint, regionSpec); err != nil {
+	if joint, err = m.state.ComposeNewModelConfig(joint, regionSpec); err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	creator := modelmanager.ModelConfigCreator{
 		Provider: environs.Provider,
 		FindTools: func(n version.Number) (tools.List, error) {
-			result, err := mm.toolsFinder.FindTools(params.FindToolsParams{
+			result, err := m.toolsFinder.FindTools(params.FindToolsParams{
 				Number: n,
 			})
 			if err != nil {
@@ -178,9 +178,9 @@ func (mm *ModelManagerAPI) newModelConfig(
 
 // CreateModel creates a new model using the account and
 // model config specified in the args.
-func (mm *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.ModelInfo, error) {
+func (m *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.ModelInfo, error) {
 	result := params.ModelInfo{}
-	canAddModel, err := mm.authorizer.HasPermission(permission.AddModelAccess, mm.state.ControllerTag())
+	canAddModel, err := m.authorizer.HasPermission(permission.AddModelAccess, m.state.ControllerTag())
 	if err != nil {
 		return result, errors.Trace(err)
 	}
@@ -190,7 +190,7 @@ func (mm *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Mode
 
 	// Get the controller model first. We need it both for the state
 	// server owner and the ability to get the config.
-	controllerModel, err := mm.state.ControllerModel()
+	controllerModel, err := m.state.ControllerModel()
 	if err != nil {
 		return result, errors.Trace(err)
 	}
@@ -215,12 +215,12 @@ func (mm *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Mode
 		cloudRegionName = controllerModel.CloudRegion()
 	}
 
-	cloud, err := mm.state.Cloud(cloudTag.Id())
+	cloud, err := m.state.Cloud(cloudTag.Id())
 	if err != nil {
 		if errors.IsNotFound(err) && args.CloudTag != "" {
 			// A cloud was specified, and it was not found.
 			// Annotate the error with the supported clouds.
-			clouds, err := mm.state.Clouds()
+			clouds, err := m.state.Clouds()
 			if err != nil {
 				return result, errors.Trace(err)
 			}
@@ -268,7 +268,7 @@ func (mm *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Mode
 
 	var credential *jujucloud.Credential
 	if cloudCredentialTag != (names.CloudCredentialTag{}) {
-		credentialValue, err := mm.state.CloudCredential(cloudCredentialTag)
+		credentialValue, err := m.state.CloudCredential(cloudCredentialTag)
 		if err != nil {
 			return result, errors.Annotate(err, "getting credential")
 		}
@@ -280,12 +280,12 @@ func (mm *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Mode
 		return result, errors.Trace(err)
 	}
 
-	controllerCfg, err := mm.state.ControllerConfig()
+	controllerCfg, err := m.state.ControllerConfig()
 	if err != nil {
 		return result, errors.Trace(err)
 	}
 
-	newConfig, err := mm.newModelConfig(cloudSpec, args, controllerModel)
+	newConfig, err := m.newModelConfig(cloudSpec, args, controllerModel)
 	if err != nil {
 		return result, errors.Annotate(err, "failed to create config")
 	}
@@ -308,7 +308,7 @@ func (mm *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Mode
 	// NOTE: check the agent-version of the config, and if it is > the current
 	// version, it is not supported, also check existing tools, and if we don't
 	// have tools for that version, also die.
-	model, st, err := mm.state.NewModel(state.ModelArgs{
+	model, st, err := m.state.NewModel(state.ModelArgs{
 		CloudName:       cloudTag.Id(),
 		CloudRegion:     cloudRegionName,
 		CloudCredential: cloudCredentialTag,
@@ -321,26 +321,26 @@ func (mm *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Mode
 	}
 	defer st.Close()
 
-	return mm.getModelInfo(model.ModelTag())
+	return m.getModelInfo(model.ModelTag())
 }
 
-func (mm *ModelManagerAPI) dumpModel(args params.Entity) (map[string]interface{}, error) {
+func (m *ModelManagerAPI) dumpModel(args params.Entity) (map[string]interface{}, error) {
 	modelTag, err := names.ParseModelTag(args.Tag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	isModelAdmin, err := mm.authorizer.HasPermission(permission.AdminAccess, modelTag)
+	isModelAdmin, err := m.authorizer.HasPermission(permission.AdminAccess, modelTag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if !isModelAdmin && !mm.isAdmin {
+	if !isModelAdmin && !m.isAdmin {
 		return nil, common.ErrPerm
 	}
 
-	st := mm.state
+	st := m.state
 	if st.ModelTag() != modelTag {
-		st, err = mm.state.ForModel(modelTag)
+		st, err = m.state.ForModel(modelTag)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				return nil, errors.Trace(common.ErrBadId)
@@ -370,23 +370,23 @@ func (mm *ModelManagerAPI) dumpModel(args params.Entity) (map[string]interface{}
 	return out.(map[string]interface{}), nil
 }
 
-func (mm *ModelManagerAPI) dumpModelDB(args params.Entity) (map[string]interface{}, error) {
+func (m *ModelManagerAPI) dumpModelDB(args params.Entity) (map[string]interface{}, error) {
 	modelTag, err := names.ParseModelTag(args.Tag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	isModelAdmin, err := mm.authorizer.HasPermission(permission.AdminAccess, modelTag)
+	isModelAdmin, err := m.authorizer.HasPermission(permission.AdminAccess, modelTag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if !isModelAdmin && !mm.isAdmin {
+	if !isModelAdmin && !m.isAdmin {
 		return nil, common.ErrPerm
 	}
 
-	st := mm.state
+	st := m.state
 	if st.ModelTag() != modelTag {
-		st, err = mm.state.ForModel(modelTag)
+		st, err = m.state.ForModel(modelTag)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				return nil, errors.Trace(common.ErrBadId)
@@ -402,12 +402,12 @@ func (mm *ModelManagerAPI) dumpModelDB(args params.Entity) (map[string]interface
 // DumpModels will export the models into the database agnostic
 // representation. The user needs to either be a controller admin, or have
 // admin privileges on the model itself.
-func (mm *ModelManagerAPI) DumpModels(args params.Entities) params.MapResults {
+func (m *ModelManagerAPI) DumpModels(args params.Entities) params.MapResults {
 	results := params.MapResults{
 		Results: make([]params.MapResult, len(args.Entities)),
 	}
 	for i, entity := range args.Entities {
-		dumped, err := mm.dumpModel(entity)
+		dumped, err := m.dumpModel(entity)
 		if err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue
@@ -420,12 +420,12 @@ func (mm *ModelManagerAPI) DumpModels(args params.Entities) params.MapResults {
 // DumpModelsDB will gather all documents from all model collections
 // for the specified model. The map result contains a map of collection
 // names to lists of documents represented as maps.
-func (mm *ModelManagerAPI) DumpModelsDB(args params.Entities) params.MapResults {
+func (m *ModelManagerAPI) DumpModelsDB(args params.Entities) params.MapResults {
 	results := params.MapResults{
 		Results: make([]params.MapResult, len(args.Entities)),
 	}
 	for i, entity := range args.Entities {
-		dumped, err := mm.dumpModelDB(entity)
+		dumped, err := m.dumpModelDB(entity)
 		if err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue
@@ -439,7 +439,7 @@ func (mm *ModelManagerAPI) DumpModelsDB(args params.Entities) params.MapResults 
 // has access to in the current server.  Only that controller owner
 // can list models for any user (at this stage).  Other users
 // can only ask about their own models.
-func (mm *ModelManagerAPI) ListModels(user params.Entity) (params.UserModelList, error) {
+func (m *ModelManagerAPI) ListModels(user params.Entity) (params.UserModelList, error) {
 	result := params.UserModelList{}
 
 	userTag, err := names.ParseUserTag(user.Tag)
@@ -447,12 +447,12 @@ func (mm *ModelManagerAPI) ListModels(user params.Entity) (params.UserModelList,
 		return result, errors.Trace(err)
 	}
 
-	err = mm.authCheck(userTag)
+	err = m.authCheck(userTag)
 	if err != nil {
 		return result, errors.Trace(err)
 	}
 
-	models, err := mm.state.ModelsForUser(userTag)
+	models, err := m.state.ModelsForUser(userTag)
 	if err != nil {
 		return result, errors.Trace(err)
 	}
@@ -770,13 +770,13 @@ func changeModelAccess(accessor common.ModelManagerBackend, modelTag names.Model
 }
 
 // ModelDefaults returns the default config values used when creating a new model.
-func (c *ModelManagerAPI) ModelDefaults() (params.ModelDefaultsResult, error) {
+func (m *ModelManagerAPI) ModelDefaults() (params.ModelDefaultsResult, error) {
 	result := params.ModelDefaultsResult{}
-	if !c.isAdmin {
+	if !m.isAdmin {
 		return result, common.ErrPerm
 	}
 
-	values, err := c.state.ModelConfigDefaultValues()
+	values, err := m.state.ModelConfigDefaultValues()
 	if err != nil {
 		return result, errors.Trace(err)
 	}
@@ -798,25 +798,25 @@ func (c *ModelManagerAPI) ModelDefaults() (params.ModelDefaultsResult, error) {
 }
 
 // SetModelDefaults writes new values for the specified default model settings.
-func (c *ModelManagerAPI) SetModelDefaults(args params.SetModelDefaults) (params.ErrorResults, error) {
+func (m *ModelManagerAPI) SetModelDefaults(args params.SetModelDefaults) (params.ErrorResults, error) {
 	results := params.ErrorResults{Results: make([]params.ErrorResult, len(args.Config))}
-	if err := c.check.ChangeAllowed(); err != nil {
+	if err := m.check.ChangeAllowed(); err != nil {
 		return results, errors.Trace(err)
 	}
 	for i, arg := range args.Config {
 		results.Results[i].Error = common.ServerError(
-			c.setModelDefaults(arg),
+			m.setModelDefaults(arg),
 		)
 	}
 	return results, nil
 }
 
-func (c *ModelManagerAPI) setModelDefaults(args params.ModelDefaultValues) error {
-	if !c.isAdmin {
+func (m *ModelManagerAPI) setModelDefaults(args params.ModelDefaultValues) error {
+	if !m.isAdmin {
 		return common.ErrPerm
 	}
 
-	if err := c.check.ChangeAllowed(); err != nil {
+	if err := m.check.ChangeAllowed(); err != nil {
 		return errors.Trace(err)
 	}
 	// Make sure we don't allow changing agent-version.
@@ -826,30 +826,30 @@ func (c *ModelManagerAPI) setModelDefaults(args params.ModelDefaultValues) error
 
 	var rspec *environs.RegionSpec
 	if args.CloudRegion != "" {
-		spec, err := c.makeRegionSpec(args.CloudTag, args.CloudRegion)
+		spec, err := m.makeRegionSpec(args.CloudTag, args.CloudRegion)
 		if err != nil {
 			return errors.Trace(err)
 		}
 		rspec = spec
 	}
-	return c.state.UpdateModelConfigDefaultValues(args.Config, nil, rspec)
+	return m.state.UpdateModelConfigDefaultValues(args.Config, nil, rspec)
 }
 
 // UnsetModelDefaults removes the specified default model settings.
-func (c *ModelManagerAPI) UnsetModelDefaults(args params.UnsetModelDefaults) (params.ErrorResults, error) {
+func (m *ModelManagerAPI) UnsetModelDefaults(args params.UnsetModelDefaults) (params.ErrorResults, error) {
 	results := params.ErrorResults{Results: make([]params.ErrorResult, len(args.Keys))}
-	if !c.isAdmin {
+	if !m.isAdmin {
 		return results, common.ErrPerm
 	}
 
-	if err := c.check.ChangeAllowed(); err != nil {
+	if err := m.check.ChangeAllowed(); err != nil {
 		return results, errors.Trace(err)
 	}
 
 	for i, arg := range args.Keys {
 		var rspec *environs.RegionSpec
 		if arg.CloudRegion != "" {
-			spec, err := c.makeRegionSpec(arg.CloudTag, arg.CloudRegion)
+			spec, err := m.makeRegionSpec(arg.CloudTag, arg.CloudRegion)
 			if err != nil {
 				results.Results[i].Error = common.ServerError(
 					errors.Trace(err))
@@ -858,7 +858,7 @@ func (c *ModelManagerAPI) UnsetModelDefaults(args params.UnsetModelDefaults) (pa
 			rspec = spec
 		}
 		results.Results[i].Error = common.ServerError(
-			c.state.UpdateModelConfigDefaultValues(nil, arg.Keys, rspec),
+			m.state.UpdateModelConfigDefaultValues(nil, arg.Keys, rspec),
 		)
 	}
 	return results, nil
@@ -866,7 +866,7 @@ func (c *ModelManagerAPI) UnsetModelDefaults(args params.UnsetModelDefaults) (pa
 
 // makeRegionSpec is a helper method for methods that call
 // state.UpdateModelConfigDefaultValues.
-func (c *ModelManagerAPI) makeRegionSpec(cloudTag, r string) (*environs.RegionSpec, error) {
+func (m *ModelManagerAPI) makeRegionSpec(cloudTag, r string) (*environs.RegionSpec, error) {
 	cTag, err := names.ParseCloudTag(cloudTag)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -389,14 +389,21 @@ func (s *modelManagerSuite) TestUnsetModelDefaults(c *gc.C) {
 	result, err := s.api.UnsetModelDefaults(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.OneError(), jc.ErrorIsNil)
-	c.Assert(s.st.cfgDefaults, jc.DeepEquals, config.ModelDefaultAttributes{
-		"attr2": {
-			Controller: "val3",
+	want := config.ModelDefaultAttributes{
+		"attr": config.AttributeDefaultValues{
+			Regions: []config.RegionDefaultValue{
+				config.RegionDefaultValue{
+					Name:  "dummy",
+					Value: "val++"},
+			}},
+		"attr2": config.AttributeDefaultValues{
 			Default:    "val2",
-			Regions: []config.RegionDefaultValue{{
-				Name:  "left",
-				Value: "spam"}}},
-	})
+			Controller: "val3",
+			Regions: []config.RegionDefaultValue{
+				config.RegionDefaultValue{
+					Name:  "left",
+					Value: "spam"}}}}
+	c.Assert(s.st.cfgDefaults, jc.DeepEquals, want)
 }
 
 func (s *modelManagerSuite) TestBlockUnsetModelDefaults(c *gc.C) {

--- a/environs/cloudspec.go
+++ b/environs/cloudspec.go
@@ -85,3 +85,11 @@ type RegionSpec struct {
 	// Region is the name of the cloud region.
 	Region string
 }
+
+// NewRegionSpec returns a RegionSpec ensuring neither arg is empty.
+func NewRegionSpec(cloud, region string) (*RegionSpec, error) {
+	if cloud == "" || region == "" {
+		return nil, errors.New("cloud and region are required to be non empty strings")
+	}
+	return &RegionSpec{Cloud: cloud, Region: region}, nil
+}

--- a/environs/cloudspec_test.go
+++ b/environs/cloudspec_test.go
@@ -1,0 +1,53 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package environs_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs"
+)
+
+type cloudSpecSuite struct {
+}
+
+var _ = gc.Suite(&cloudSpecSuite{})
+
+func (s *cloudSpecSuite) TestNewRegionSpec(c *gc.C) {
+	tests := []struct {
+		description, cloud, region, errMatch string
+		nilErr                               bool
+		want                                 *environs.RegionSpec
+	}{
+		{
+			description: "test empty cloud",
+			cloud:       "",
+			region:      "aregion",
+			errMatch:    "cloud and region are required to be non empty strings",
+			want:        nil,
+		}, {
+			description: "test empty region",
+			cloud:       "acloud",
+			region:      "",
+			errMatch:    "cloud and region are required to be non empty strings",
+			want:        nil,
+		}, {
+			description: "test valid",
+			cloud:       "acloud",
+			region:      "aregion",
+			nilErr:      true,
+			want:        &environs.RegionSpec{Cloud: "acloud", Region: "aregion"},
+		},
+	}
+	for i, test := range tests {
+		c.Logf("Test %d: %s", i, test.description)
+		rspec, err := environs.NewRegionSpec(test.cloud, test.region)
+		if !test.nilErr {
+			c.Check(err, gc.ErrorMatches, test.errMatch)
+		} else {
+			c.Check(err, jc.ErrorIsNil)
+		}
+		c.Check(rspec, jc.DeepEquals, test.want)
+	}
+}

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -134,8 +134,14 @@ func (st *State) modelConfigValues(modelCfg attrValues) (config.ConfigValues, er
 }
 
 // UpdateModelConfigDefaultValues updates the inherited settings used when creating a new model.
-func (st *State) UpdateModelConfigDefaultValues(attrs map[string]interface{}, removed []string) error {
-	settings, err := readSettings(st, globalSettingsC, controllerInheritedSettingsGlobalKey)
+func (st *State) UpdateModelConfigDefaultValues(attrs map[string]interface{}, removed []string, regionSpec *environs.RegionSpec) error {
+	var key string
+	if regionSpec != nil {
+		key = regionSettingsGlobalKey(regionSpec.Cloud, regionSpec.Region)
+	} else {
+		key = controllerInheritedSettingsGlobalKey
+	}
+	settings, err := readSettings(st, globalSettingsC, key)
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
Refs: model-config-tree

QA: Unit tests all pass.  This should have gone in with the rest of the backend model-config region bits. But it didn't it is required for the cli bits to work, so hoping to merge this so we can get feedback on the CLI bits.