### PR TITLE
state: add safe refcounts for charm storage

### DIFF
--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -521,7 +521,9 @@ func (s *cmdStorageSuite) TestStorageAddToUnitStorageDoesntExist(c *gc.C) {
 	context, err := runAddToUnit(c, u, "nonstorage=1")
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "cmd: error out silently")
 	c.Assert(testing.Stdout(context), gc.Equals, "")
-	c.Assert(testing.Stderr(context), gc.Equals, "failed to add \"nonstorage\": charm storage \"nonstorage\" not found\n")
+	c.Assert(testing.Stderr(context), gc.Equals,
+		`failed to add "nonstorage": adding storage to unit storage-block/0: charm storage "nonstorage" not found`+"\n",
+	)
 
 	instancesAfter, err := s.State.AllStorageInstances()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/application.go
+++ b/state/application.go
@@ -452,15 +452,11 @@ func (s *Application) checkRelationsOps(ch *Charm, relations []*Relation) ([]txn
 	return asserts, nil
 }
 
-func (s *Application) checkStorageUpgrade(newMeta *charm.Meta) (_ []txn.Op, err error) {
+func (s *Application) checkStorageUpgrade(newMeta, oldMeta *charm.Meta, units []*Unit) (_ []txn.Op, err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot upgrade application %q to charm %q", s, newMeta.Name)
-	ch, _, err := s.Charm()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	oldMeta := ch.Meta()
+
+	// Make sure no storage instances are added or removed.
 	var ops []txn.Op
-	var units []*Unit
 	for name, oldStorageMeta := range oldMeta.Storage {
 		if _, ok := newMeta.Storage[name]; ok {
 			continue
@@ -472,70 +468,24 @@ func (s *Application) checkStorageUpgrade(newMeta *charm.Meta) (_ []txn.Op, err 
 		// are no instances of the store, it can safely be
 		// removed.
 		if oldStorageMeta.Shared {
-			n, err := s.st.countEntityStorageInstancesForName(
-				s.Tag(), name,
-			)
+			op, n, err := s.st.countEntityStorageInstances(s.Tag(), name)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
 			if n > 0 {
 				return nil, errors.Errorf("in-use storage %q removed", name)
 			}
-			// TODO(axw) if/when it is possible to
-			// add shared storage instance to an
-			// application post-deployment, we must
-			// include a txn.Op here that asserts
-			// that the number of instances is zero.
+			ops = append(ops, op)
 		} else {
-			if units == nil {
-				var err error
-				units, err = s.AllUnits()
+			for _, u := range units {
+				op, n, err := s.st.countEntityStorageInstances(u.Tag(), name)
 				if err != nil {
 					return nil, errors.Trace(err)
 				}
-				ops = append(ops, txn.Op{
-					C:      applicationsC,
-					Id:     s.doc.DocID,
-					Assert: bson.D{{"unitcount", len(units)}},
-				})
-				for _, unit := range units {
-					// Here we check that the storage
-					// attachment count remains the same.
-					// To get around the ABA problem, we
-					// also add ops for the individual
-					// attachments below.
-					ops = append(ops, txn.Op{
-						C:  unitsC,
-						Id: unit.doc.DocID,
-						Assert: bson.D{{
-							"storageattachmentcount",
-							unit.doc.StorageAttachmentCount,
-						}},
-					})
+				if n > 0 {
+					return nil, errors.Errorf("in-use storage %q removed", name)
 				}
-			}
-			for _, unit := range units {
-				attachments, err := s.st.UnitStorageAttachments(unit.UnitTag())
-				if err != nil {
-					return nil, errors.Trace(err)
-				}
-				for _, attachment := range attachments {
-					storageTag := attachment.StorageInstance()
-					storageName, err := names.StorageName(storageTag.Id())
-					if err != nil {
-						return nil, errors.Trace(err)
-					}
-					if storageName == name {
-						return nil, errors.Errorf("in-use storage %q removed", name)
-					}
-					// We assert that other storage attachments still exist to
-					// avoid the ABA problem.
-					ops = append(ops, txn.Op{
-						C:      storageAttachmentsC,
-						Id:     storageAttachmentId(unit.Name(), storageTag.Id()),
-						Assert: txn.DocExists,
-					})
-				}
+				ops = append(ops, op)
 			}
 		}
 	}
@@ -682,12 +632,36 @@ func (s *Application) changeCharmOps(
 		}
 	}
 
+	// Make sure no units are added or removed while the upgrade
+	// transaction is being executed. This allows us to make
+	// changes to units during the upgrade, e.g. add storage
+	// to existing units, or remove optional storage so long as
+	// it is unreferenced.
+	units, err := s.AllUnits()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	unitOps := make([]txn.Op, len(units))
+	for i, u := range units {
+		unitOps[i] = txn.Op{
+			C:      unitsC,
+			Id:     u.doc.DocID,
+			Assert: txn.DocExists,
+		}
+	}
+	unitOps = append(unitOps, txn.Op{
+		C:      applicationsC,
+		Id:     s.doc.DocID,
+		Assert: bson.D{{"unitcount", len(units)}},
+	})
+
 	// Build the transaction.
 	var ops []txn.Op
 	if oldSettings != nil {
 		// Old settings shouldn't change (when they exist).
 		ops = append(ops, oldSettings.assertUnchangedOp())
 	}
+	ops = append(ops, unitOps...)
 	ops = append(ops, incOps...)
 	ops = append(ops, []txn.Op{
 		// Create or replace new settings.
@@ -761,9 +735,8 @@ func (s *Application) changeCharmOps(
 		return nil, errors.Trace(err)
 	}
 
-	// Check storage to ensure no referenced storage is removed, or changed
-	// in an incompatible way.
-	storageOps, err := s.checkStorageUpgrade(ch.Meta())
+	// Upgrade charm storage.
+	storageOps, err := s.upgradeStorageOps(ch.Meta(), units, newStorageConstraints)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -771,6 +744,25 @@ func (s *Application) changeCharmOps(
 
 	// And finally, decrement the old charm and settings.
 	return append(ops, decOps...), nil
+}
+
+func (a *Application) upgradeStorageOps(
+	meta *charm.Meta,
+	units []*Unit,
+	allStorageCons map[string]StorageConstraints,
+) ([]txn.Op, error) {
+	// Check storage to ensure no referenced storage is removed, or changed
+	// in an incompatible way.
+	oldCharm, _, err := a.Charm()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	oldMeta := oldCharm.Meta()
+	ops, err := a.checkStorageUpgrade(meta, oldMeta, units)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return ops, nil
 }
 
 // incCharmModifiedVersionOps returns the operations necessary to increment

--- a/state/charmref.go
+++ b/state/charmref.go
@@ -41,17 +41,17 @@ func appCharmIncRefOps(st modelBackend, appName string, curl *charm.URL, canCrea
 		getIncRefOp = nsRefcounts.StrictIncRefOp
 	}
 	settingsKey := applicationSettingsKey(appName, curl)
-	settingsOp, err := getIncRefOp(refcounts, settingsKey)
+	settingsOp, err := getIncRefOp(refcounts, settingsKey, 1)
 	if err != nil {
 		return nil, errors.Annotate(err, "settings reference")
 	}
 	storageConstraintsKey := applicationStorageConstraintsKey(appName, curl)
-	storageConstraintsOp, err := getIncRefOp(refcounts, storageConstraintsKey)
+	storageConstraintsOp, err := getIncRefOp(refcounts, storageConstraintsKey, 1)
 	if err != nil {
 		return nil, errors.Annotate(err, "storage constraints reference")
 	}
 	charmKey := charmGlobalKey(curl)
-	charmOp, err := getIncRefOp(refcounts, charmKey)
+	charmOp, err := getIncRefOp(refcounts, charmKey, 1)
 	if err != nil {
 		return nil, errors.Annotate(err, "charm reference")
 	}

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1340,6 +1340,16 @@ func (i *importer) addStorageInstance(storage description.Storage) error {
 		Assert: txn.DocMissing,
 		Insert: doc,
 	})
+
+	refcounts, closer := i.st.getCollection(refcountsC)
+	defer closer()
+	storageRefcountKey := entityStorageRefcountKey(owner, storage.Name())
+	incRefOp, err := nsRefcounts.CreateOrIncRefOp(refcounts, storageRefcountKey, 1)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	ops = append(ops, incRefOp)
+
 	if err := i.st.runTransaction(ops); err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
This branch adds refcounts for charm storage:
when a storage instance is added, a refcount
is incremented for (owner, storage-name); and
decremented when the storage instance is removed.

We also check that no units are added to or
removed from an application while its charm
is being upgraded. This enables us to safely
drop charm storage if it is unreferenced.

These changes pave the way for upgrading charms
with storage, and make validation of charm-storage
min/max count constraints simpler. Previously we
were relying on there being a one-to-one mapping
between storage instances and attachments, which
leaves shared storage out in the cold; this new
approach caters for both.

**QA**

1. bootstrap lxd
2. deploy charm with optional storage, min-count 0; don't assign any
3. remove storage from charm, and upgrade to it; fine, as it's not in-use
4. add required storage to charm, and upgrade to it; fails as you cannot
   add required storage during upgrade (yet)
5. make storage optional in charm again, and upgrade to it; works, as it's
   optional
6. add instances of the optional storage to the deployed unit, until we
   hit the declared maximum; ensure that once we hit the maximum, we cannot
   add any more
7. remove storage from charm, and try to upgrade to it; fails as the storage
   is in-use
8. make the storage required in the charm, and upgrade to it. Then remove
   the storage from the charm and try to upgrade to it; fails, as you cannot
   remove required storage (yet)