### PR TITLE
Remove wrong region validation on add-model

### DIFF
--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -196,7 +196,7 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 				return errors.Trace(err)
 			}
 		}
-		credentialTag, err = c.maybeUploadCredential(ctx, cloudClient, cloudTag, cloud, modelOwner)
+		credentialTag, err = c.maybeUploadCredential(ctx, cloudClient, cloudTag, cloudRegion, cloud, modelOwner)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -386,6 +386,7 @@ func (c *addModelCommand) maybeUploadCredential(
 	ctx *cmd.Context,
 	cloudClient CloudAPI,
 	cloudTag names.CloudTag,
+	cloudRegion string,
 	cloud jujucloud.Cloud,
 	modelOwner string,
 ) (names.CloudCredentialTag, error) {
@@ -429,7 +430,7 @@ func (c *addModelCommand) maybeUploadCredential(
 		ctx, c.ClientStore(), modelcmd.GetCredentialsParams{
 			Cloud:          cloud,
 			CloudName:      cloudTag.Id(),
-			CloudRegion:    c.CloudRegion,
+			CloudRegion:    cloudRegion,
 			CredentialName: credentialTag.Name(),
 		},
 	)

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -183,6 +183,13 @@ func (s *AddModelSuite) TestCredentialsOtherUserPassedThrough(c *gc.C) {
 	c.Assert(s.fakeAddModelAPI.cloudCredential, gc.Equals, names.NewCloudCredentialTag("aws/other/secrets"))
 }
 
+func (s *AddModelSuite) TestCredentialsOtherUserPassedThroughWhenCloud(c *gc.C) {
+	_, err := s.run(c, "test", "--credential", "other/secrets", "aws/us-west-1")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.fakeAddModelAPI.cloudCredential, gc.Equals, names.NewCloudCredentialTag("aws/other/secrets"))
+}
+
 func (s *AddModelSuite) TestCredentialsNoDefaultCloud(c *gc.C) {
 	s.fakeCloudAPI.SetErrors(&params.Error{Code: params.CodeNotFound})
 	_, err := s.run(c, "test", "--credential", "secrets")


### PR DESCRIPTION
add-model command was performing a double validation for region
and cloud and the second one was wrong.

This fixes https://bugs.launchpad.net/juju/+bug/1625657

## QA steps
* Bootstrap a controller,
* Add a model with credentials not used to bootstrap the model.