### PR TITLE
apiserver: Remove charm get cache

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -276,7 +276,7 @@ func (s *clientSuite) TestOpenCharmMissing(c *gc.C) {
 
 	_, err := client.OpenCharm(curl)
 
-	c.Check(err, gc.ErrorMatches, `.*unable to retrieve and save the charm: cannot get charm from state: charm "cs:quantal/spam-3" not found`)
+	c.Check(err, gc.ErrorMatches, `.*cannot get charm from state: charm "cs:quantal/spam-3" not found`)
 }
 
 func addLocalCharm(c *gc.C, client *api.Client, name string) (*charm.URL, *charm.CharmArchive) {

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -78,7 +78,7 @@ func (h *charmsHandler) serveGet(w http.ResponseWriter, r *http.Request) error {
 	// Retrieve or list charm files.
 	// Requires "url" (charm URL) and an optional "file" (the path to the
 	// charm file) to be included in the query.
-	charmArchivePath, filePath, err := h.processGet(r, st)
+	charmArchivePath, fileArg, err := h.processGet(r, st)
 	if err != nil {
 		// An error occurred retrieving the charm bundle.
 		if errors.IsNotFound(err) {
@@ -86,8 +86,10 @@ func (h *charmsHandler) serveGet(w http.ResponseWriter, r *http.Request) error {
 		}
 		return errors.NewBadRequest(err, "")
 	}
+	defer os.Remove(charmArchivePath)
+
 	var sender bundleContentSenderFunc
-	switch filePath {
+	switch fileArg {
 	case "":
 		// The client requested the list of charm files.
 		sender = h.manifestSender
@@ -96,7 +98,7 @@ func (h *charmsHandler) serveGet(w http.ResponseWriter, r *http.Request) error {
 		sender = h.archiveSender
 	default:
 		// The client requested a specific file.
-		sender = h.archiveEntrySender(filePath)
+		sender = h.archiveEntrySender(fileArg)
 	}
 	if err := h.sendBundleContent(w, r, charmArchivePath, sender); err != nil {
 		return errors.Trace(err)
@@ -428,76 +430,41 @@ func (h *charmsHandler) processGet(r *http.Request, st *state.State) (string, st
 		return "", "", errors.Annotate(err, "cannot parse charm URL")
 	}
 
-	var filePath string
-	file := query.Get("file")
-	if file == "" {
-		filePath = ""
-	} else {
-		filePath = path.Clean(file)
+	fileArg := query.Get("file")
+	if fileArg != "" {
+		fileArg = path.Clean(fileArg)
 	}
 
-	// Prepare the bundle directories.
-	name := charm.Quote(curlString)
-	charmArchivePath := filepath.Join(
-		h.dataDir,
-		"charm-get-cache",
-		st.ModelUUID(),
-		name+".zip",
-	)
-
-	// Check if the charm archive is already in the cache.
-	if _, err := os.Stat(charmArchivePath); os.IsNotExist(err) {
-		// Download the charm archive and save it to the cache.
-		if err = h.downloadCharm(st, curl, charmArchivePath); err != nil {
-			return "", "", errors.Annotate(err, "unable to retrieve and save the charm")
-		}
-	} else if err != nil {
-		return "", "", errors.Annotate(err, "cannot access the charms cache")
+	// Ensure the working directory exists.
+	tmpDir := filepath.Join(h.dataDir, "charm-get-tmp")
+	if err = os.MkdirAll(tmpDir, 0755); err != nil {
+		return "", "", errors.Annotate(err, "cannot create charms tmp directory")
 	}
-	return charmArchivePath, filePath, nil
-}
 
-// downloadCharm downloads the given charm name from the provider storage and
-// saves the corresponding zip archive to the given charmArchivePath.
-func (h *charmsHandler) downloadCharm(st *state.State, curl *charm.URL, charmArchivePath string) error {
+	// Use the storage to retrieve and save the charm archive.
 	storage := storage.NewStorage(st.ModelUUID(), st.MongoSession())
 	ch, err := st.Charm(curl)
 	if err != nil {
-		return errors.Annotate(err, "cannot get charm from state")
+		return "", "", errors.Annotate(err, "cannot get charm from state")
 	}
 
-	// In order to avoid races, the archive is saved in a temporary file which
-	// is then atomically renamed. The temporary file is created in the
-	// charm cache directory so that we can safely assume the rename source and
-	// target live in the same file system.
-	cacheDir := filepath.Dir(charmArchivePath)
-	if err = os.MkdirAll(cacheDir, 0755); err != nil {
-		return errors.Annotate(err, "cannot create the charms cache")
-	}
-	tempCharmArchive, err := ioutil.TempFile(cacheDir, "charm")
-	if err != nil {
-		return errors.Annotate(err, "cannot create charm archive temp file")
-	}
-	defer cleanupFile(tempCharmArchive)
-
-	// Use the storage to retrieve and save the charm archive.
 	reader, _, err := storage.Get(ch.StoragePath())
 	if err != nil {
-		return errors.Annotate(err, "cannot get charm from model storage")
+		return "", "", errors.Annotate(err, "cannot get charm from model storage")
 	}
 	defer reader.Close()
-	if _, err = io.Copy(tempCharmArchive, reader); err != nil {
-		return errors.Annotate(err, "error processing charm archive download")
-	}
-	tempCharmArchive.Close()
 
-	// Note that os.Rename won't fail if the target already exists;
-	// there's no problem if there's concurrent get requests for the
-	// same charm.
-	if err = os.Rename(tempCharmArchive.Name(), charmArchivePath); err != nil {
-		return errors.Annotate(err, "error renaming the charm archive")
+	charmFile, err := ioutil.TempFile(tmpDir, "charm")
+	if err != nil {
+		return "", "", errors.Annotate(err, "cannot create charm archive file")
 	}
-	return nil
+	if _, err = io.Copy(charmFile, reader); err != nil {
+		cleanupFile(charmFile)
+		return "", "", errors.Annotate(err, "error processing charm archive download")
+	}
+
+	charmFile.Close()
+	return charmFile.Name(), fileArg, nil
 }
 
 // On windows we cannot remove a file until it has been closed

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -18,11 +18,7 @@ import (
 // (below).
 var stateUpgradeOperations = func() []Operation {
 	steps := []Operation{
-		// Replace when we have upgrades to do
-		upgradeToVersion{
-			version.MustParse("1.26-placeholder1"),
-			[]Step{},
-		},
+		upgradeToVersion{version.MustParse("2.0.0"), []Step{}},
 	}
 	return steps
 }
@@ -32,11 +28,7 @@ var stateUpgradeOperations = func() []Operation {
 // state-based operations above, ordering is important.
 var upgradeOperations = func() []Operation {
 	steps := []Operation{
-		// Replace when we have upgrades to do
-		upgradeToVersion{
-			version.MustParse("1.26-placeholder1"),
-			[]Step{},
-		},
+		upgradeToVersion{version.MustParse("2.0.0"), stepsFor20()},
 	}
 	return steps
 }

--- a/upgrades/steps_20.go
+++ b/upgrades/steps_20.go
@@ -1,0 +1,28 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// stepsFor20 returns upgrade steps for Juju 2.0 that only need the API.
+func stepsFor20() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "remove apiserver charm get cache",
+			targets:     []Target{Controller},
+			run:         removeCharmGetCache,
+		},
+	}
+}
+
+// removeCharmGetCache removes the cache directory that was previously
+// used by the charms API endpoint. It is no longer necessary.
+func removeCharmGetCache(context Context) error {
+	dataDir := context.AgentConfig().DataDir()
+	cacheDir := filepath.Join(dataDir, "charm-get-cache")
+	return os.RemoveAll(cacheDir)
+}

--- a/upgrades/steps_20_test.go
+++ b/upgrades/steps_20_test.go
@@ -1,0 +1,61 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+)
+
+var v200 = version.MustParse("2.0.0")
+
+type steps20Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps20Suite{})
+
+func (s *steps20Suite) TestCharmGetCacheDir(c *gc.C) {
+	// Create a cache directory with some stuff in it.
+	dataDir := c.MkDir()
+	cacheDir := filepath.Join(dataDir, "charm-get-cache")
+	c.Assert(os.MkdirAll(cacheDir, 0777), jc.ErrorIsNil)
+	err := ioutil.WriteFile(filepath.Join(cacheDir, "stuff"), []byte("things"), 0777)
+	c.Assert(err, jc.ErrorIsNil)
+
+	step := findStep(c, v200, "remove apiserver charm get cache")
+
+	check := func() {
+		context := &mockContext{
+			agentConfig: &mockAgentConfig{dataDir: dataDir},
+		}
+		err = step.Run(context)
+		c.Assert(err, jc.ErrorIsNil)
+
+		// Cache directory should be gone, but data dir should still be there.
+		c.Check(pathExists(cacheDir), jc.IsFalse)
+		c.Check(pathExists(dataDir), jc.IsTrue)
+	}
+
+	check()
+	check() // Check OK when directory not present
+}
+
+func pathExists(p string) bool {
+	_, err := os.Stat(p)
+	if err == nil {
+		return true
+	} else if os.IsNotExist(err) {
+		return false
+	}
+	panic(fmt.Sprintf("stat for %q failed: %v", p, err))
+}


### PR DESCRIPTION
The filesystem cache used when retrieving charms has been removed. It
was implemented when charms lived in a remote S3 bucket and is no longer
necessary now that charm live in MongoDB's GridFS store. This helps to
reduce disk space usage in the controllers and is one less thing that
needs cleaning up when models are removed.

See https://bugs.launchpad.net/juju/+bug/1608959

### QA

Manually deployed charms and confirmed that old cache directory at `<datadir>/charm-get-cache` is no longer created and new `<datadir>/charm-get-tmp` directory is left empty.

Manually created the old `<datadir>/charm-get-cache` directory and populated it and then ran an upgrade. The directory was removed.
