### PR TITLE
Fix bootstrap status cleanup

### DIFF
--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -154,7 +154,9 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 	// current stderr line before the next use, removing any residual status
 	// reporting output.
 	statusCleanup := func(info string) error {
-		fmt.Fprintf(ctx.GetStderr(), "%s\r", info)
+		// The leading spaces account for the leading characters
+		// emitted by instanceStatus above.
+		fmt.Fprintf(ctx.GetStderr(), "   %s\r", info)
 		return nil
 	}
 	result, err := env.StartInstance(environs.StartInstanceParams{


### PR DESCRIPTION
The cleanup of the provisioning status output wasn't accounting for the
3 extra characters prepended by the output function. This was leaving
the last characters of the provisioning output on the screen.