### PR TITLE
apiserver/application: update SetCharm

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -17,7 +17,7 @@ var facadeVersions = map[string]int{
 	"AllModelWatcher":              2,
 	"AllWatcher":                   1,
 	"Annotations":                  2,
-	"Application":                  1,
+	"Application":                  2,
 	"ApplicationScaler":            1,
 	"Backups":                      1,
 	"Block":                        2,

--- a/apiserver/application/application_unit_test.go
+++ b/apiserver/application/application_unit_test.go
@@ -1,0 +1,197 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/application"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type ApplicationSuite struct {
+	testing.IsolationSuite
+	backend     mockBackend
+	application mockApplication
+	charm       mockCharm
+
+	blockChecker mockBlockChecker
+	authorizer   apiservertesting.FakeAuthorizer
+	api          *application.API
+}
+
+var _ = gc.Suite(&ApplicationSuite{})
+
+func (s *ApplicationSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.authorizer = apiservertesting.FakeAuthorizer{
+		Tag: names.NewUserTag("admin"),
+	}
+	s.application = mockApplication{}
+	s.charm = mockCharm{
+		config: &charm.Config{
+			Options: map[string]charm.Option{
+				"stringOption": {Type: "string"},
+				"intOption":    {Type: "int", Default: int(123)},
+			},
+		},
+	}
+	s.backend = mockBackend{
+		application: &s.application,
+		charm:       &s.charm,
+	}
+	s.blockChecker = mockBlockChecker{}
+	api, err := application.NewAPI(
+		&s.backend,
+		s.authorizer,
+		&s.blockChecker,
+		func(application.Charm) *state.Charm {
+			return &state.Charm{}
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	s.api = api
+}
+
+func (s *ApplicationSuite) TestSetCharmStorageConstraints(c *gc.C) {
+	toUint64Ptr := func(v uint64) *uint64 {
+		return &v
+	}
+	err := s.api.SetCharm(params.ApplicationSetCharm{
+		ApplicationName: "postgresql",
+		CharmUrl:        "cs:postgresql",
+		StorageConstraints: map[string]params.StorageConstraints{
+			"a": {},
+			"b": {Pool: "radiant"},
+			"c": {Size: toUint64Ptr(123)},
+			"d": {Count: toUint64Ptr(456)},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.backend.CheckCallNames(c, "ModelTag", "Application", "Charm")
+	s.application.CheckCallNames(c, "SetCharm")
+	s.application.CheckCall(c, 0, "SetCharm", state.SetCharmConfig{
+		Charm: &state.Charm{},
+		StorageConstraints: map[string]state.StorageConstraints{
+			"a": {},
+			"b": {Pool: "radiant"},
+			"c": {Size: 123},
+			"d": {Count: 456},
+		},
+	})
+}
+
+func (s *ApplicationSuite) TestSetCharmConfigSettings(c *gc.C) {
+	err := s.api.SetCharm(params.ApplicationSetCharm{
+		ApplicationName: "postgresql",
+		CharmUrl:        "cs:postgresql",
+		ConfigSettings:  map[string]string{"stringOption": "value"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.backend.CheckCallNames(c, "ModelTag", "Application", "Charm")
+	s.charm.CheckCallNames(c, "Config")
+	s.application.CheckCallNames(c, "SetCharm")
+	s.application.CheckCall(c, 0, "SetCharm", state.SetCharmConfig{
+		Charm:          &state.Charm{},
+		ConfigSettings: charm.Settings{"stringOption": "value"},
+	})
+}
+
+func (s *ApplicationSuite) TestSetCharmConfigSettingsYAML(c *gc.C) {
+	err := s.api.SetCharm(params.ApplicationSetCharm{
+		ApplicationName: "postgresql",
+		CharmUrl:        "cs:postgresql",
+		ConfigSettingsYAML: `
+postgresql:
+  stringOption: value
+`,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.backend.CheckCallNames(c, "ModelTag", "Application", "Charm")
+	s.charm.CheckCallNames(c, "Config")
+	s.application.CheckCallNames(c, "SetCharm")
+	s.application.CheckCall(c, 0, "SetCharm", state.SetCharmConfig{
+		Charm:          &state.Charm{},
+		ConfigSettings: charm.Settings{"stringOption": "value"},
+	})
+}
+
+type mockBackend struct {
+	application.Backend
+	testing.Stub
+	application *mockApplication
+	charm       *mockCharm
+}
+
+func (b *mockBackend) ModelTag() names.ModelTag {
+	b.MethodCall(b, "ModelTag")
+	b.PopNoErr()
+	return coretesting.ModelTag
+}
+
+func (b *mockBackend) Application(name string) (application.Application, error) {
+	b.MethodCall(b, "Application", name)
+	if err := b.NextErr(); err != nil {
+		return nil, err
+	}
+	if b.application != nil {
+		return b.application, nil
+	}
+	return nil, errors.NotFoundf("application %q", name)
+}
+
+func (b *mockBackend) Charm(curl *charm.URL) (application.Charm, error) {
+	b.MethodCall(b, "Charm", curl)
+	if err := b.NextErr(); err != nil {
+		return nil, err
+	}
+	if b.charm != nil {
+		return b.charm, nil
+	}
+	return nil, errors.NotFoundf("charm %q", curl)
+}
+
+type mockApplication struct {
+	application.Application
+	testing.Stub
+}
+
+func (a *mockApplication) SetCharm(cfg state.SetCharmConfig) error {
+	a.MethodCall(a, "SetCharm", cfg)
+	return a.NextErr()
+}
+
+type mockCharm struct {
+	application.Charm
+	testing.Stub
+	config *charm.Config
+}
+
+func (c *mockCharm) Config() *charm.Config {
+	c.MethodCall(c, "Config")
+	c.PopNoErr()
+	return c.config
+}
+
+type mockBlockChecker struct {
+	testing.Stub
+}
+
+func (c *mockBlockChecker) ChangeAllowed() error {
+	c.MethodCall(c, "ChangeAllowed")
+	return c.NextErr()
+}
+
+func (c *mockBlockChecker) RemoveAllowed() error {
+	c.MethodCall(c, "RemoveAllowed")
+	return c.NextErr()
+}

--- a/apiserver/application/backend.go
+++ b/apiserver/application/backend.go
@@ -1,0 +1,190 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"gopkg.in/juju/charm.v6-unstable"
+	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/state"
+)
+
+// Backend defines the state functionality required by the application
+// facade. For details on the methods, see the methods on state.State
+// with the same names.
+type Backend interface {
+	Application(string) (Application, error)
+	AddApplication(state.AddApplicationArgs) (*state.Application, error)
+	AddRelation(...state.Endpoint) (Relation, error)
+	AssignUnit(*state.Unit, state.AssignmentPolicy) error
+	AssignUnitWithPlacement(*state.Unit, *instance.Placement) error
+	Charm(*charm.URL) (Charm, error)
+	EndpointsRelation(...state.Endpoint) (Relation, error)
+	InferEndpoints(...string) ([]state.Endpoint, error)
+	Machine(string) (Machine, error)
+	ModelTag() names.ModelTag
+	Unit(string) (Unit, error)
+}
+
+// BlockChecker defines the block-checking functionality required by
+// the application facade. This is implemented by
+// apiserver/common.BlockChecker.
+type BlockChecker interface {
+	ChangeAllowed() error
+	RemoveAllowed() error
+}
+
+// Application defines a subset of the functionality provided by the
+// state.Application type, as required by the application facade. For
+// details on the methods, see the methods on state.Application with
+// the same names.
+type Application interface {
+	AddUnit() (*state.Unit, error)
+	Charm() (Charm, bool, error)
+	CharmURL() (*charm.URL, bool)
+	Channel() csparams.Channel
+	ClearExposed() error
+	ConfigSettings() (charm.Settings, error)
+	Constraints() (constraints.Value, error)
+	Destroy() error
+	Endpoints() ([]state.Endpoint, error)
+	IsPrincipal() bool
+	Series() string
+	SetCharm(state.SetCharmConfig) error
+	SetConstraints(constraints.Value) error
+	SetExposed() error
+	SetMetricCredentials([]byte) error
+	SetMinUnits(int) error
+	UpdateConfigSettings(charm.Settings) error
+}
+
+// Charm defines a subset of the functionality provided by the
+// state.Charm type, as required by the application facade. For
+// details on the methods, see the methods on state.Charm with
+// the same names.
+type Charm interface {
+	charm.Charm
+}
+
+// Machine defines a subset of the functionality provided by the
+// state.Machine type, as required by the application facade. For
+// details on the methods, see the methods on state.Machine with
+// the same names.
+type Machine interface {
+}
+
+// Relation defines a subset of the functionality provided by the
+// state.Relation type, as required by the application facade. For
+// details on the methods, see the methods on state.Relation with
+// the same names.
+type Relation interface {
+	Destroy() error
+	Endpoint(string) (state.Endpoint, error)
+}
+
+// Unit defines a subset of the functionality provided by the
+// state.Unit type, as required by the application facade. For
+// details on the methods, see the methods on state.Unit with
+// the same names.
+type Unit interface {
+	Destroy() error
+	IsPrincipal() bool
+	Life() state.Life
+}
+
+type stateShim struct {
+	*state.State
+}
+
+// NewStateBackend converts a state.State into a Backend.
+func NewStateBackend(st *state.State) Backend {
+	return stateShim{st}
+}
+
+// CharmToStateCharm converts a Charm into a state.Charm. This is
+// a hack that is required until the State interface methods we
+// deal with stop accepting state.Charms, and start accepting
+// charm.Charm and charm.URL.
+func CharmToStateCharm(ch Charm) *state.Charm {
+	return ch.(stateCharmShim).Charm
+}
+
+func (s stateShim) Application(name string) (Application, error) {
+	a, err := s.State.Application(name)
+	if err != nil {
+		return nil, err
+	}
+	return stateApplicationShim{a}, nil
+}
+
+func (s stateShim) AddRelation(eps ...state.Endpoint) (Relation, error) {
+	r, err := s.State.AddRelation(eps...)
+	if err != nil {
+		return nil, err
+	}
+	return stateRelationShim{r}, nil
+}
+
+func (s stateShim) Charm(curl *charm.URL) (Charm, error) {
+	ch, err := s.State.Charm(curl)
+	if err != nil {
+		return nil, err
+	}
+	return stateCharmShim{ch}, nil
+}
+
+func (s stateShim) EndpointsRelation(eps ...state.Endpoint) (Relation, error) {
+	r, err := s.State.EndpointsRelation(eps...)
+	if err != nil {
+		return nil, err
+	}
+	return stateRelationShim{r}, nil
+}
+
+func (s stateShim) Machine(name string) (Machine, error) {
+	m, err := s.State.Machine(name)
+	if err != nil {
+		return nil, err
+	}
+	return stateMachineShim{m}, nil
+}
+
+func (s stateShim) Unit(name string) (Unit, error) {
+	u, err := s.State.Unit(name)
+	if err != nil {
+		return nil, err
+	}
+	return stateUnitShim{u}, nil
+}
+
+type stateApplicationShim struct {
+	*state.Application
+}
+
+func (a stateApplicationShim) Charm() (Charm, bool, error) {
+	ch, force, err := a.Application.Charm()
+	if err != nil {
+		return nil, false, err
+	}
+	return ch, force, nil
+}
+
+type stateCharmShim struct {
+	*state.Charm
+}
+
+type stateMachineShim struct {
+	*state.Machine
+}
+
+type stateRelationShim struct {
+	*state.Relation
+}
+
+type stateUnitShim struct {
+	*state.Unit
+}

--- a/apiserver/application/get.go
+++ b/apiserver/application/get.go
@@ -15,7 +15,7 @@ func (api *API) Get(args params.ApplicationGet) (params.ApplicationGetResults, e
 	if err := api.checkCanRead(); err != nil {
 		return params.ApplicationGetResults{}, err
 	}
-	app, err := api.state.Application(args.ApplicationName)
+	app, err := api.backend.Application(args.ApplicationName)
 	if err != nil {
 		return params.ApplicationGetResults{}, err
 	}

--- a/apiserver/application/get_test.go
+++ b/apiserver/application/get_test.go
@@ -12,6 +12,7 @@ import (
 
 	apiapplication "github.com/juju/juju/api/application"
 	"github.com/juju/juju/apiserver/application"
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/constraints"
@@ -34,7 +35,12 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 		Tag: s.AdminUserTag(c),
 	}
 	var err error
-	s.serviceAPI, err = application.NewAPI(s.State, nil, s.authorizer)
+	backend := application.NewStateBackend(s.State)
+	blockChecker := common.NewBlockChecker(s.State)
+	s.serviceAPI, err = application.NewAPI(
+		backend, s.authorizer, blockChecker,
+		application.CharmToStateCharm,
+	)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -243,18 +243,39 @@ type ApplicationUpdate struct {
 type ApplicationSetCharm struct {
 	// ApplicationName is the name of the application to set the charm on.
 	ApplicationName string `json:"application"`
+
 	// CharmUrl is the new url for the charm.
 	CharmUrl string `json:"charm-url"`
+
 	// Channel is the charm store channel from which the charm came.
 	Channel string `json:"channel"`
+
+	// ConfigSettings is the charm settings to set during the upgrade.
+	// This field is only understood by Application facade version 2
+	// and greater.
+	ConfigSettings map[string]string `json:"config-settings,omitempty"`
+
+	// ConfigSettingsYAML is the charm settings in YAML format to set
+	// during the upgrade. If this is non-empty, it will take precedence
+	// over ConfigSettings. This field is only understood by Application
+	// facade version 2
+	ConfigSettingsYAML string `json:"config-settings-yaml,omitempty"`
+
 	// ForceUnits forces the upgrade on units in an error state.
 	ForceUnits bool `json:"force-units"`
+
 	// ForceSeries forces the use of the charm even if it doesn't match the
 	// series of the unit.
 	ForceSeries bool `json:"force-series"`
+
 	// ResourceIDs is a map of resource names to resource IDs to activate during
 	// the upgrade.
 	ResourceIDs map[string]string `json:"resource-ids,omitempty"`
+
+	// StorageConstraints is a map of storage names to storage constraints to
+	// update during the upgrade. This field is only understood by Application
+	// facade version 2 and greater.
+	StorageConstraints map[string]StorageConstraints `json:"storage-constraints,omitempty"`
 }
 
 // ApplicationExpose holds the parameters for making the application Expose call.

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -337,7 +337,7 @@ func (s *MachineSuite) TestManageModel(c *gc.C) {
 	svc := s.AddTestingService(c, "test-service", charm)
 	err := svc.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
-	units, err := juju.AddUnits(s.State, svc, 1, nil)
+	units, err := juju.AddUnits(s.State, svc, svc.Name(), 1, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// It should be allocated to a machine, which should then be provisioned.
@@ -387,7 +387,7 @@ func (s *MachineSuite) TestManageModelRunsInstancePoller(c *gc.C) {
 	// Add one unit to a service;
 	charm := s.AddTestingCharm(c, "dummy")
 	svc := s.AddTestingService(c, "test-service", charm)
-	units, err := juju.AddUnits(s.State, svc, 1, nil)
+	units, err := juju.AddUnits(s.State, svc, svc.Name(), 1, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	m, instId := s.waitProvisioned(c, units[0])

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -542,7 +542,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	svc, err := st.AddApplication(state.AddApplicationArgs{Name: "dummy", Charm: sch})
 	c.Assert(err, jc.ErrorIsNil)
-	units, err := juju.AddUnits(st, svc, 1, nil)
+	units, err := juju.AddUnits(st, svc, "dummy", 1, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	unit := units[0]
 

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -114,8 +114,8 @@ func (s *firewallerBaseSuite) assertEnvironPorts(c *gc.C, expected []network.Por
 	}
 }
 
-func (s *firewallerBaseSuite) addUnit(c *gc.C, svc *state.Application) (*state.Unit, *state.Machine) {
-	units, err := juju.AddUnits(s.State, svc, 1, nil)
+func (s *firewallerBaseSuite) addUnit(c *gc.C, app *state.Application) (*state.Unit, *state.Machine) {
+	units, err := juju.AddUnits(s.State, app, app.Name(), 1, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	u := units[0]
 	id, err := u.AssignedMachineId()
@@ -158,8 +158,8 @@ func (s *InstanceModeSuite) TestNotExposedService(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
 
-	svc := s.AddTestingService(c, "wordpress", s.charm)
-	u, m := s.addUnit(c, svc)
+	app := s.AddTestingService(c, "wordpress", s.charm)
+	u, m := s.addUnit(c, app)
 	inst := s.startInstance(c, m)
 
 	err = u.OpenPort("tcp", 80)
@@ -180,11 +180,11 @@ func (s *InstanceModeSuite) TestExposedService(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
 
-	svc := s.AddTestingService(c, "wordpress", s.charm)
+	app := s.AddTestingService(c, "wordpress", s.charm)
 
-	err = svc.SetExposed()
+	err = app.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
-	u, m := s.addUnit(c, svc)
+	u, m := s.addUnit(c, app)
 	inst := s.startInstance(c, m)
 
 	err = u.OpenPorts("tcp", 80, 90)
@@ -205,23 +205,23 @@ func (s *InstanceModeSuite) TestMultipleExposedServices(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
 
-	svc1 := s.AddTestingService(c, "wordpress", s.charm)
-	err = svc1.SetExposed()
+	app1 := s.AddTestingService(c, "wordpress", s.charm)
+	err = app1.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 
-	u1, m1 := s.addUnit(c, svc1)
+	u1, m1 := s.addUnit(c, app1)
 	inst1 := s.startInstance(c, m1)
 	err = u1.OpenPort("tcp", 80)
 	c.Assert(err, jc.ErrorIsNil)
 	err = u1.OpenPort("tcp", 8080)
 	c.Assert(err, jc.ErrorIsNil)
 
-	svc2 := s.AddTestingService(c, "mysql", s.charm)
+	app2 := s.AddTestingService(c, "mysql", s.charm)
 	c.Assert(err, jc.ErrorIsNil)
-	err = svc2.SetExposed()
+	err = app2.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 
-	u2, m2 := s.addUnit(c, svc2)
+	u2, m2 := s.addUnit(c, app2)
 	inst2 := s.startInstance(c, m2)
 	err = u2.OpenPort("tcp", 3306)
 	c.Assert(err, jc.ErrorIsNil)
@@ -243,15 +243,15 @@ func (s *InstanceModeSuite) TestMachineWithoutInstanceId(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
 
-	svc := s.AddTestingService(c, "wordpress", s.charm)
-	err = svc.SetExposed()
+	app := s.AddTestingService(c, "wordpress", s.charm)
+	err = app.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 	// add a unit but don't start its instance yet.
-	u1, m1 := s.addUnit(c, svc)
+	u1, m1 := s.addUnit(c, app)
 
 	// add another unit and start its instance, so that
 	// we're sure the firewaller has seen the first instance.
-	u2, m2 := s.addUnit(c, svc)
+	u2, m2 := s.addUnit(c, app)
 	inst2 := s.startInstance(c, m2)
 	err = u2.OpenPort("tcp", 80)
 	c.Assert(err, jc.ErrorIsNil)
@@ -268,16 +268,16 @@ func (s *InstanceModeSuite) TestMultipleUnits(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
 
-	svc := s.AddTestingService(c, "wordpress", s.charm)
-	err = svc.SetExposed()
+	app := s.AddTestingService(c, "wordpress", s.charm)
+	err = app.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 
-	u1, m1 := s.addUnit(c, svc)
+	u1, m1 := s.addUnit(c, app)
 	inst1 := s.startInstance(c, m1)
 	err = u1.OpenPort("tcp", 80)
 	c.Assert(err, jc.ErrorIsNil)
 
-	u2, m2 := s.addUnit(c, svc)
+	u2, m2 := s.addUnit(c, app)
 	inst2 := s.startInstance(c, m2)
 	err = u2.OpenPort("tcp", 80)
 	c.Assert(err, jc.ErrorIsNil)
@@ -295,10 +295,10 @@ func (s *InstanceModeSuite) TestMultipleUnits(c *gc.C) {
 }
 
 func (s *InstanceModeSuite) TestStartWithState(c *gc.C) {
-	svc := s.AddTestingService(c, "wordpress", s.charm)
-	err := svc.SetExposed()
+	app := s.AddTestingService(c, "wordpress", s.charm)
+	err := app.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
-	u, m := s.addUnit(c, svc)
+	u, m := s.addUnit(c, app)
 	inst := s.startInstance(c, m)
 
 	err = u.OpenPort("tcp", 80)
@@ -316,7 +316,7 @@ func (s *InstanceModeSuite) TestStartWithState(c *gc.C) {
 
 	s.assertPorts(c, inst, m.Id(), []network.PortRange{{80, 80, "tcp"}, {8080, 8080, "tcp"}})
 
-	err = svc.SetExposed()
+	err = app.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -325,8 +325,8 @@ func (s *InstanceModeSuite) TestStartWithPartialState(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	inst := s.startInstance(c, m)
 
-	svc := s.AddTestingService(c, "wordpress", s.charm)
-	err = svc.SetExposed()
+	app := s.AddTestingService(c, "wordpress", s.charm)
+	err = app.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Starting the firewaller, no open ports.
@@ -337,7 +337,7 @@ func (s *InstanceModeSuite) TestStartWithPartialState(c *gc.C) {
 	s.assertPorts(c, inst, m.Id(), nil)
 
 	// Complete steps to open port.
-	u, err := svc.AddUnit()
+	u, err := app.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.AssignToMachine(m)
 	c.Assert(err, jc.ErrorIsNil)
@@ -352,8 +352,8 @@ func (s *InstanceModeSuite) TestStartWithUnexposedService(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	inst := s.startInstance(c, m)
 
-	svc := s.AddTestingService(c, "wordpress", s.charm)
-	u, err := svc.AddUnit()
+	app := s.AddTestingService(c, "wordpress", s.charm)
+	u, err := app.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.AssignToMachine(m)
 	c.Assert(err, jc.ErrorIsNil)
@@ -368,7 +368,7 @@ func (s *InstanceModeSuite) TestStartWithUnexposedService(c *gc.C) {
 	s.assertPorts(c, inst, m.Id(), nil)
 
 	// Expose service.
-	err = svc.SetExposed()
+	err = app.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertPorts(c, inst, m.Id(), []network.PortRange{{80, 80, "tcp"}})
 }
@@ -378,9 +378,9 @@ func (s *InstanceModeSuite) TestSetClearExposedService(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
 
-	svc := s.AddTestingService(c, "wordpress", s.charm)
+	app := s.AddTestingService(c, "wordpress", s.charm)
 
-	u, m := s.addUnit(c, svc)
+	u, m := s.addUnit(c, app)
 	inst := s.startInstance(c, m)
 	err = u.OpenPort("tcp", 80)
 	c.Assert(err, jc.ErrorIsNil)
@@ -391,13 +391,13 @@ func (s *InstanceModeSuite) TestSetClearExposedService(c *gc.C) {
 	s.assertPorts(c, inst, m.Id(), nil)
 
 	// SeExposed opens the ports.
-	err = svc.SetExposed()
+	err = app.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.assertPorts(c, inst, m.Id(), []network.PortRange{{80, 80, "tcp"}, {8080, 8080, "tcp"}})
 
 	// ClearExposed closes the ports again.
-	err = svc.ClearExposed()
+	err = app.ClearExposed()
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.assertPorts(c, inst, m.Id(), nil)
@@ -408,16 +408,16 @@ func (s *InstanceModeSuite) TestRemoveUnit(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
 
-	svc := s.AddTestingService(c, "wordpress", s.charm)
-	err = svc.SetExposed()
+	app := s.AddTestingService(c, "wordpress", s.charm)
+	err = app.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 
-	u1, m1 := s.addUnit(c, svc)
+	u1, m1 := s.addUnit(c, app)
 	inst1 := s.startInstance(c, m1)
 	err = u1.OpenPort("tcp", 80)
 	c.Assert(err, jc.ErrorIsNil)
 
-	u2, m2 := s.addUnit(c, svc)
+	u2, m2 := s.addUnit(c, app)
 	inst2 := s.startInstance(c, m2)
 	err = u2.OpenPort("tcp", 80)
 	c.Assert(err, jc.ErrorIsNil)
@@ -440,11 +440,11 @@ func (s *InstanceModeSuite) TestRemoveService(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
 
-	svc := s.AddTestingService(c, "wordpress", s.charm)
-	err = svc.SetExposed()
+	app := s.AddTestingService(c, "wordpress", s.charm)
+	err = app.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 
-	u, m := s.addUnit(c, svc)
+	u, m := s.addUnit(c, app)
 	inst := s.startInstance(c, m)
 	err = u.OpenPort("tcp", 80)
 	c.Assert(err, jc.ErrorIsNil)
@@ -456,7 +456,7 @@ func (s *InstanceModeSuite) TestRemoveService(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.Remove()
 	c.Assert(err, jc.ErrorIsNil)
-	err = svc.Destroy()
+	err = app.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertPorts(c, inst, m.Id(), nil)
 }
@@ -466,20 +466,20 @@ func (s *InstanceModeSuite) TestRemoveMultipleServices(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
 
-	svc1 := s.AddTestingService(c, "wordpress", s.charm)
-	err = svc1.SetExposed()
+	app1 := s.AddTestingService(c, "wordpress", s.charm)
+	err = app1.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 
-	u1, m1 := s.addUnit(c, svc1)
+	u1, m1 := s.addUnit(c, app1)
 	inst1 := s.startInstance(c, m1)
 	err = u1.OpenPort("tcp", 80)
 	c.Assert(err, jc.ErrorIsNil)
 
-	svc2 := s.AddTestingService(c, "mysql", s.charm)
-	err = svc2.SetExposed()
+	app2 := s.AddTestingService(c, "mysql", s.charm)
+	err = app2.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 
-	u2, m2 := s.addUnit(c, svc2)
+	u2, m2 := s.addUnit(c, app2)
 	inst2 := s.startInstance(c, m2)
 	err = u2.OpenPort("tcp", 3306)
 	c.Assert(err, jc.ErrorIsNil)
@@ -492,14 +492,14 @@ func (s *InstanceModeSuite) TestRemoveMultipleServices(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = u2.Remove()
 	c.Assert(err, jc.ErrorIsNil)
-	err = svc2.Destroy()
+	err = app2.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = u1.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
 	err = u1.Remove()
 	c.Assert(err, jc.ErrorIsNil)
-	err = svc1.Destroy()
+	err = app1.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.assertPorts(c, inst1, m1.Id(), nil)
@@ -511,11 +511,11 @@ func (s *InstanceModeSuite) TestDeadMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
 
-	svc := s.AddTestingService(c, "wordpress", s.charm)
-	err = svc.SetExposed()
+	app := s.AddTestingService(c, "wordpress", s.charm)
+	err = app.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 
-	u, m := s.addUnit(c, svc)
+	u, m := s.addUnit(c, app)
 	inst := s.startInstance(c, m)
 	err = u.OpenPort("tcp", 80)
 	c.Assert(err, jc.ErrorIsNil)
@@ -527,7 +527,7 @@ func (s *InstanceModeSuite) TestDeadMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.Remove()
 	c.Assert(err, jc.ErrorIsNil)
-	err = svc.Destroy()
+	err = app.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Kill machine.
@@ -544,11 +544,11 @@ func (s *InstanceModeSuite) TestRemoveMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
 
-	svc := s.AddTestingService(c, "wordpress", s.charm)
-	err = svc.SetExposed()
+	app := s.AddTestingService(c, "wordpress", s.charm)
+	err = app.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 
-	u, m := s.addUnit(c, svc)
+	u, m := s.addUnit(c, app)
 	inst := s.startInstance(c, m)
 	err = u.OpenPort("tcp", 80)
 	c.Assert(err, jc.ErrorIsNil)
@@ -573,10 +573,10 @@ func (s *InstanceModeSuite) TestRemoveMachine(c *gc.C) {
 }
 
 func (s *InstanceModeSuite) TestStartWithStateOpenPortsBroken(c *gc.C) {
-	svc := s.AddTestingService(c, "wordpress", s.charm)
-	err := svc.SetExposed()
+	app := s.AddTestingService(c, "wordpress", s.charm)
+	err := app.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
-	u, m := s.addUnit(c, svc)
+	u, m := s.addUnit(c, app)
 	inst := s.startInstance(c, m)
 
 	err = u.OpenPort("tcp", 80)
@@ -631,23 +631,23 @@ func (s *GlobalModeSuite) TestGlobalMode(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
 
-	svc1 := s.AddTestingService(c, "wordpress", s.charm)
-	err = svc1.SetExposed()
+	app1 := s.AddTestingService(c, "wordpress", s.charm)
+	err = app1.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 
-	u1, m1 := s.addUnit(c, svc1)
+	u1, m1 := s.addUnit(c, app1)
 	s.startInstance(c, m1)
 	err = u1.OpenPorts("tcp", 80, 90)
 	c.Assert(err, jc.ErrorIsNil)
 	err = u1.OpenPort("tcp", 8080)
 	c.Assert(err, jc.ErrorIsNil)
 
-	svc2 := s.AddTestingService(c, "moinmoin", s.charm)
+	app2 := s.AddTestingService(c, "moinmoin", s.charm)
 	c.Assert(err, jc.ErrorIsNil)
-	err = svc2.SetExposed()
+	err = app2.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 
-	u2, m2 := s.addUnit(c, svc2)
+	u2, m2 := s.addUnit(c, app2)
 	s.startInstance(c, m2)
 	err = u2.OpenPorts("tcp", 80, 90)
 	c.Assert(err, jc.ErrorIsNil)
@@ -675,8 +675,8 @@ func (s *GlobalModeSuite) TestStartWithUnexposedService(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.startInstance(c, m)
 
-	svc := s.AddTestingService(c, "wordpress", s.charm)
-	u, err := svc.AddUnit()
+	app := s.AddTestingService(c, "wordpress", s.charm)
+	u, err := app.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.AssignToMachine(m)
 	c.Assert(err, jc.ErrorIsNil)
@@ -691,7 +691,7 @@ func (s *GlobalModeSuite) TestStartWithUnexposedService(c *gc.C) {
 	s.assertEnvironPorts(c, nil)
 
 	// Expose service.
-	err = svc.SetExposed()
+	err = app.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertEnvironPorts(c, []network.PortRange{{80, 80, "tcp"}})
 }
@@ -701,11 +701,11 @@ func (s *GlobalModeSuite) TestRestart(c *gc.C) {
 	fw, err := firewaller.NewFirewaller(s.firewaller)
 	c.Assert(err, jc.ErrorIsNil)
 
-	svc := s.AddTestingService(c, "wordpress", s.charm)
-	err = svc.SetExposed()
+	app := s.AddTestingService(c, "wordpress", s.charm)
+	err = app.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 
-	u, m := s.addUnit(c, svc)
+	u, m := s.addUnit(c, app)
 	s.startInstance(c, m)
 	err = u.OpenPorts("tcp", 80, 90)
 	c.Assert(err, jc.ErrorIsNil)
@@ -736,11 +736,11 @@ func (s *GlobalModeSuite) TestRestartUnexposedService(c *gc.C) {
 	fw, err := firewaller.NewFirewaller(s.firewaller)
 	c.Assert(err, jc.ErrorIsNil)
 
-	svc := s.AddTestingService(c, "wordpress", s.charm)
-	err = svc.SetExposed()
+	app := s.AddTestingService(c, "wordpress", s.charm)
+	err = app.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 
-	u, m := s.addUnit(c, svc)
+	u, m := s.addUnit(c, app)
 	s.startInstance(c, m)
 	err = u.OpenPort("tcp", 80)
 	c.Assert(err, jc.ErrorIsNil)
@@ -753,7 +753,7 @@ func (s *GlobalModeSuite) TestRestartUnexposedService(c *gc.C) {
 	err = worker.Stop(fw)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = svc.ClearExposed()
+	err = app.ClearExposed()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Start firewaller and check port.
@@ -769,11 +769,11 @@ func (s *GlobalModeSuite) TestRestartPortCount(c *gc.C) {
 	fw, err := firewaller.NewFirewaller(s.firewaller)
 	c.Assert(err, jc.ErrorIsNil)
 
-	svc1 := s.AddTestingService(c, "wordpress", s.charm)
-	err = svc1.SetExposed()
+	app1 := s.AddTestingService(c, "wordpress", s.charm)
+	err = app1.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 
-	u1, m1 := s.addUnit(c, svc1)
+	u1, m1 := s.addUnit(c, app1)
 	s.startInstance(c, m1)
 	err = u1.OpenPort("tcp", 80)
 	c.Assert(err, jc.ErrorIsNil)
@@ -786,11 +786,11 @@ func (s *GlobalModeSuite) TestRestartPortCount(c *gc.C) {
 	err = worker.Stop(fw)
 	c.Assert(err, jc.ErrorIsNil)
 
-	svc2 := s.AddTestingService(c, "moinmoin", s.charm)
-	err = svc2.SetExposed()
+	app2 := s.AddTestingService(c, "moinmoin", s.charm)
+	err = app2.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 
-	u2, m2 := s.addUnit(c, svc2)
+	u2, m2 := s.addUnit(c, app2)
 	s.startInstance(c, m2)
 	err = u2.OpenPort("tcp", 80)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
This diff updates Application.SetCharm,
adding the ConfigSettings, ConfigSettingsYAML,
and StorageConstraints parameters. We will
pass these on to state, but state currently
will reject their use. This constitutes an
API break, so the facade version has been
bumped.

The apiserver/application code has been
updated to be mockable, and new tests have
been written using a mock backend.

**QA**

(server from 2.0rc1, client from this branch)
1. bootstrap 2.0rc1
2. deploy ubuntu
3. (with client built from this branch) upgrade-charm ubuntu

(server from this branch, client from 2.0rc1)
1. bootstrap from this branch
2. deploy ubuntu
3. (with client from 2.0rc1) upgrade-charm ubuntu

No QA for updating storage constraints or charm
settings yet, as that is not yet supported in state,
nor in the CLI/API client.