### PR TITLE
fix up error handling when no current controller

### DIFF
--- a/cmd/juju/controller/listcontrollers.go
+++ b/cmd/juju/controller/listcontrollers.go
@@ -82,6 +82,10 @@ func (c *listControllersCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Annotate(err, "failed to list controllers")
 	}
+	if len(controllers) == 0 && c.out.Name() == "tabular" {
+		ctx.Infof("%s", modelcmd.ErrNoControllersDefined)
+		return nil
+	}
 	if c.refresh && len(controllers) > 0 {
 		var wg sync.WaitGroup
 		wg.Add(len(controllers))

--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/cmd/juju/controller"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
@@ -26,13 +27,11 @@ type ListControllersSuite struct {
 var _ = gc.Suite(&ListControllersSuite{})
 
 func (s *ListControllersSuite) TestListControllersEmptyStore(c *gc.C) {
-	s.expectedOutput = `
-CONTROLLER  MODEL  USER  ACCESS  CLOUD/REGION  MODELS  MACHINES  HA  VERSION
-
-`[1:]
-
 	s.store = jujuclienttesting.NewMemStore()
-	s.assertListControllers(c)
+	context, err := s.runListControllers(c)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(testing.Stdout(context), gc.Equals, "")
+	c.Check(testing.Stderr(context), gc.Equals, modelcmd.ErrNoControllersDefined.Error())
 }
 
 func (s *ListControllersSuite) TestListControllers(c *gc.C) {

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -24,7 +24,7 @@ var logger = loggo.GetLogger("juju.cmd.modelcmd")
 // ErrNoModelSpecified is returned by commands that operate on
 // an environment if there is no current model, no model
 // has been explicitly specified, and there is no default model.
-var ErrNoModelSpecified = errors.New(`no model in focus
+var ErrNoModelSpecified = errors.New(`No model in focus.
 
 Please use "juju models" to see models available to you.
 You can set current model by running "juju switch"
@@ -215,7 +215,7 @@ func (c *ModelCommandBase) newAPIRoot(modelName string) (api.Connection, error) 
 		if len(controllers) == 0 {
 			return nil, errors.Trace(ErrNoControllersDefined)
 		}
-		return nil, errors.Trace(ErrNotLoggedInToController)
+		return nil, errors.Trace(ErrNoCurrentController)
 	}
 	opener := c.opener
 	if opener == nil {
@@ -312,7 +312,7 @@ func (w *modelCommandWrapper) Init(args []string) error {
 	}
 	if w.modelName != "" {
 		if err := w.SetModelName(w.modelName); err != nil {
-			return errors.Annotate(err, "setting model name")
+			return translateControllerError(store, err)
 		}
 	}
 	return w.ModelCommand.Init(args)


### PR DESCRIPTION
fixes https://bugs.launchpad.net/juju/+bug/1618998
list-models should point out list-controllers command in error message

QA:
Edit ~/.local/share/juju/controllers.yaml to remove the value for current-controller
(it's at the bottom).  Then run juju status and juju models.  You should get nice 
error messages that tell you how to get out of the situation.  Also try changing
current-controller to a controller name that doesn't exist.  It should behave the
same as not having a current controller.