### PR TITLE
feature/add region to model defaults cli

### DIFF
--- a/cmd/juju/model/defaultscommand.go
+++ b/cmd/juju/model/defaultscommand.go
@@ -108,7 +108,7 @@ type defaultsCommandAPI interface {
 // Info implements part of the cmd.Command interface.
 func (c *defaultsCommand) Info() *cmd.Info {
 	return &cmd.Info{
-		Args:    "[<model-key>[<=value>] ...]",
+		Args:    "[[<cloud/>]<region> ]<model-key>[<=value>] ...]",
 		Doc:     modelDefaultsHelpDoc,
 		Name:    "model-defaults",
 		Purpose: modelDefaultsSummary,
@@ -124,7 +124,7 @@ func (c *defaultsCommand) SetFlags(f *gnuflag.FlagSet) {
 		"json":    cmd.FormatJson,
 		"tabular": formatDefaultConfigTabular,
 	})
-	f.Var(cmd.NewAppendStringsValue(&c.reset), "reset", "Reset the provided keys")
+	f.Var(cmd.NewAppendStringsValue(&c.reset), "reset", "Reset the provided comma delimited keys")
 }
 
 // Init implements part of the cmd.Command interface.

--- a/cmd/juju/model/defaultscommand.go
+++ b/cmd/juju/model/defaultscommand.go
@@ -128,7 +128,7 @@ func (c *defaultsCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 // Init implements part of the cmd.Command interface.
-// This needs to parse the a command line invocation to reset and set, or get
+// This needs to parse a command line invocation to reset and set, or get
 // model-default values. The arguments may be interspersed as demosntrated in
 // the examples.
 //
@@ -136,8 +136,7 @@ func (c *defaultsCommand) SetFlags(f *gnuflag.FlagSet) {
 //     juju model-defaults aws/us-east-1 foo=baz --reset bar
 //
 // If aws is the cloud of the current or specified controller -- specified by
-// -c somecontroller or -m somecontroller:somemodel -- then the following would
-// also be equivalent.
+// -c somecontroller -- then the following would also be equivalent.
 //     juju model-defaults --reset bar us-east-1 foo=baz
 //
 // If one doesn't specify a cloud or region the command is still valid but for
@@ -280,8 +279,8 @@ func (c *defaultsCommand) parseCloudRegion(args []string) ([]string, error) {
 		region = cr
 	}
 
-	// NB(redir) http://pad.lv/1627162 -- We don't disallow "=" in region
-	// names, but probably should.
+	// TODO(redir) 2016-10-05 #1627162
+	// We don't disallow "=" in region names, but probably should.
 	if strings.Contains(region, "=") {
 		return args, nil
 	}

--- a/cmd/juju/model/defaultscommand.go
+++ b/cmd/juju/model/defaultscommand.go
@@ -75,13 +75,10 @@ type defaultsCommand struct {
 
 	action                func(defaultsCommandAPI, *cmd.Context) error // The function handling the input, set in Init.
 	key                   string
-	resetKeys             []string
+	resetKeys             []string // Holds the keys to be reset once parsed.
 	cloudName, regionName string
-	// reset holds the contents of the reset flag. It contains a list of comma
-	// seperated lists of keys to reset. e.g. []string{"a,b,c", "d", "e,f",
-	// "g,h,i"}
-	reset  []string
-	values attributes
+	reset                 []string // Holds the keys to be reset until parsed.
+	values                attributes
 }
 
 // cloudAPI defines an API to be passed in for testing.
@@ -131,55 +128,45 @@ func (c *defaultsCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 // Init implements part of the cmd.Command interface.
-// Abandon all hope ye who enter here....
-// This needs to parse the a command line invocation as defined in
-// https://goo.gl/yqrrPI.
-// So the following 3 lines are all equivalent:
-// juju model-defaults aws/us-east-1 foo=baz --reset bar
-// juju model-defaults aws/us-east-1 --reset bar foo=baz
-// juju model-defaults --reset bar aws/us-east-1 foo=baz
+// This needs to parse the a command line invocation to reset and set, or get
+// model-default values. The arguments may be interspersed as demosntrated in
+// the examples.
 //
-// They all set foo=baz and unset bar in aws/us-east-1
-// If aws is the cloud of the current or specified controller -- as specified
-// by -c somecontroller or -m somecontroller:somemodel -- then the following
-// 3 lines would also be equivalent.
-// juju model-defaults us-east-1 foo=baz --reset bar
-// juju model-defaults us-east-1 --reset bar foo=baz
-// juju model-defaults --reset bar us-east-1 foo=baz
+// This sets foo=baz and unsets bar in aws/us-east-1
+//     juju model-defaults aws/us-east-1 foo=baz --reset bar
+//
+// If aws is the cloud of the current or specified controller -- specified by
+// -c somecontroller or -m somecontroller:somemodel -- then the following would
+// also be equivalent.
+//     juju model-defaults --reset bar us-east-1 foo=baz
 //
 // If one doesn't specify a cloud or region the command is still valid but for
-// setting the default on the controller. So the following two commands are
-// equivalent.
-// juju model-defaults foo=baz --reset bar
-// juju model-defaults --reset bar foo=baz
+// setting the default on the controller:
+//     juju model-defaults foo=baz --reset bar
 //
 // Of course one can specify multiple keys to reset --reset a,b,c and one can
 // also specify multiple values to set a=b c=d e=f. I.e. comma separated for
-// reset and space separated for setting. One may also only set or reset as a
-// singular action. The last two here are equivalent.
-// juju model-defaults --reset foo
-// juju model-defaults a=b c=d e=f
-// juju model-defaults a=b c=d --reset e,f
-// juju model-defaults --reset e,f a=b c=d
+// resetting and space separated for setting. One may also only set or reset as
+// a singular action.
+//     juju model-defaults --reset foo
+//     juju model-defaults a=b c=d e=f
+//     juju model-defaults a=b c=d --reset e,f
 //
 // cloud/region may also be specified so above examples with that option might
-// be like the following three equivalent invokations.
-// juju model-defaults us-east-1 a=b c=d --reset e,f
-// juju model-defaults us-east-1 --reset e,f a=b c=d
-// juju model-defaults --reset e,f us-east-1 a=b c=d
+// be like the following invokation.
+//     juju model-defaults us-east-1 a=b c=d --reset e,f
 //
 // Finally one can also ask for the all the defaults or the defaults for one
 // specific setting. In this case specifying a region is not valid as
 // model-defaults shows the settings for a value at all locations that it has a
 // default set -- or at a minimum the default and  "-" for a controller with no
 // value set.
-// simultaneously.
-// juju model-defaults
-// juju model-defaults no-proxy
+//     juju model-defaults
+//     juju model-defaults no-proxy
 //
-// It is not valid to reset and get or to set and get values. It is also neiter
-// valid to reset and set the same key, nor to set the same key to different
-// values in the same command.
+// It is not valid to reset and get or to set and get values. It is also
+// neither valid to reset and set the same key, nor to set the same key to
+// different values in the same command.
 //
 // For those playing along that all means the first positional arg can be a
 // cloud/region, a region, a key=value to set, a key to get the settings for,
@@ -206,10 +193,10 @@ func (c *defaultsCommand) Init(args []string) error {
 
 	// Look at the first positional arg and test to see if it is a valid
 	// optional specification of cloud/region or region. If it is then
-	// cloudName and regionName or only regionName are set on the object and
-	// the positional args are returned without the first element. If it cannot
-	// be validated; cloudName and regionName are left empty and we get back
-	// the same args we passed in.
+	// cloudName and regionName are set on the object and the positional args
+	// are returned without the first element. If it cannot be validated;
+	// cloudName and regionName are left empty and we get back the same args we
+	// passed in.
 	args, err = c.parseArgsForRegion(args)
 	if err != nil {
 		return errors.Trace(err)
@@ -230,8 +217,8 @@ func (c *defaultsCommand) Init(args []string) error {
 		// We want to get settings for the provided key.
 		return c.handleOneArg(args[0])
 	default: // case args > 1
-		// Specifying any positional args after a key=value pair is
-		// invalid input. So if we have more than one the input is almost
+		// Specifying any non key=value positional args after a key=value pair
+		// is invalid input. So if we have more than one the input is almost
 		// certainly invalid, but in different possible ways.
 		return c.handleExtraArgs(args)
 	}
@@ -242,24 +229,25 @@ func (c *defaultsCommand) Init(args []string) error {
 // leading or trailing comma. It then verifies that we haven't incorrectly
 // received any key=value pairs and finally sets the value(s) on c.resetKeys.
 func (c *defaultsCommand) parseResetKeys() error {
-	if len(c.reset) > 0 {
-		var resetKeys []string
-		for _, value := range c.reset {
-			keys := strings.Split(strings.Trim(value, ","), ",")
-			resetKeys = append(resetKeys, keys...)
-		}
-
-		for _, k := range resetKeys {
-			if k == config.AgentVersionKey {
-				return errors.Errorf("%q cannot be reset", config.AgentVersionKey)
-			}
-			if strings.Contains(k, "=") {
-				return errors.Errorf(
-					`--reset accepts a single key "a" or comma delimited keys "a,b,c", received: %q`, k)
-			}
-		}
-		c.resetKeys = resetKeys
+	if len(c.reset) == 0 {
+		return nil
 	}
+	var resetKeys []string
+	for _, value := range c.reset {
+		keys := strings.Split(strings.Trim(value, ","), ",")
+		resetKeys = append(resetKeys, keys...)
+	}
+
+	for _, k := range resetKeys {
+		if k == config.AgentVersionKey {
+			return errors.Errorf("%q cannot be reset", config.AgentVersionKey)
+		}
+		if strings.Contains(k, "=") {
+			return errors.Errorf(
+				`--reset accepts a comma delimited set of keys "a,b,c", received: %q`, k)
+		}
+	}
+	c.resetKeys = resetKeys
 	return nil
 }
 
@@ -290,6 +278,12 @@ func (c *defaultsCommand) parseCloudRegion(args []string) ([]string, error) {
 		cloud, region = elems[0], elems[1]
 	} else {
 		region = cr
+	}
+
+	// NB(redir) http://pad.lv/1627162 -- We don't disallow "=" in region
+	// names, but probably should.
+	if strings.Contains(region, "=") {
+		return args, nil
 	}
 
 	valid, err := c.validCloudRegion(cloud, region)
@@ -325,6 +319,9 @@ func (c *defaultsCommand) validCloudRegion(cloudName, region string) (bool, erro
 			return false, errors.Trace(err)
 		}
 	} else {
+		if !names.IsValidCloud(cloudName) {
+			return false, errors.Errorf("invalid cloud %q", cloudName)
+		}
 		cTag = names.NewCloudTag(cloudName)
 	}
 	cloud, err = cc.Cloud(cTag)
@@ -341,32 +338,6 @@ func (c *defaultsCommand) validCloudRegion(cloudName, region string) (bool, erro
 		}
 	}
 	return isCloudRegion, nil
-}
-
-// parseSetKeys iterates over the args and make sure that the key=value pairs
-// are valid. It also checks that the same key isn't also being reset.
-func (c *defaultsCommand) parseSetKeys(args []string) error {
-	options, err := keyvalues.Parse(args, true)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	keyCounter := map[string]int{}
-	c.values = make(attributes)
-	for k, v := range options {
-		if k == config.AgentVersionKey {
-			return errors.Errorf(`%q must be set via "upgrade-juju"`, config.AgentVersionKey)
-		}
-		keyCounter[k]++
-		c.values[k] = v
-	}
-	for _, resetKey := range c.resetKeys {
-		keyCounter[resetKey]++
-		if keyCounter[resetKey] > 1 {
-			return errors.Errorf(`key %q specified more than once`, resetKey)
-		}
-	}
-	return nil
 }
 
 // handleSetArgs parses args for setting defaults.
@@ -388,63 +359,74 @@ func (c *defaultsCommand) handleSetArgs(args []string) error {
 	}
 }
 
+// parseSetKeys iterates over the args and make sure that the key=value pairs
+// are valid. It also checks that the same key isn't also being reset.
+func (c *defaultsCommand) parseSetKeys(args []string) error {
+	options, err := keyvalues.Parse(args, true)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	c.values = make(attributes)
+	for k, v := range options {
+		if k == config.AgentVersionKey {
+			return errors.Errorf(`%q must be set via "upgrade-juju"`, config.AgentVersionKey)
+		}
+		c.values[k] = v
+	}
+	for _, k := range c.resetKeys {
+		if _, ok := c.values[k]; ok {
+			return errors.Errorf(
+				"key %q cannot be both set and unset in the same command", k)
+		}
+	}
+	return nil
+}
+
 // handleZeroArgs determines whether we are doing a reset only and if any
 // additional arguments are valid -- or why they are not.
 func (c *defaultsCommand) handleZeroArgs() error {
-	resetSpecified := c.resetKeys != nil
-	regionSpecified := c.regionName != ""
-
-	switch {
-	case regionSpecified && !resetSpecified:
-		// It doesn't make sense to specify a region unless we are resetting
-		// values here.
-		return errors.New("specifying a region when retrieving defaults is invalid")
-	case regionSpecified && resetSpecified:
-		// We can reset for a region, c.action stays nil. We want to do reset
-		// only.
-		return nil
-	case !regionSpecified && resetSpecified:
-		// Again we want to reset, this is for resetting the controller as
-		// there is no region specified. So c.action remains nil.
-		return nil
-		// We short circuited at the begining of c.Init so we should never
-		// reach a case where "!regionSpecified && !resetSpecified"
-	default:
-		// This should be unreachable.
-		return errors.New("unexpected input, please file a bug")
+	if c.regionName != "" {
+		if c.resetKeys == nil {
+			// It doesn't make sense to specify a region unless we are resetting
+			// values here.
+			return errors.New("specifying a region when retrieving defaults is invalid")
+		}
 	}
+	// We can reset for a region. We can also reset for a controller if there
+	// is no region specified. In either case c.action remains nil. We short
+	// circuited at the begining of c.Init so we should never reach a case
+	// where there is no region or reset keys specified.
+	return nil
 }
 
 // handleOneArg handles the case where we have one positional arg after
-// processing for a region and the reset flag after processing for a region and
-// the reset flagg.
+// processing for a region and the reset flag.
 func (c *defaultsCommand) handleOneArg(arg string) error {
 	resetSpecified := c.resetKeys != nil
 	regionSpecified := c.regionName != ""
 
-	switch {
-	case regionSpecified && !resetSpecified:
-		// It doesn't make sense to specify a region unless we are resetting
-		// values here.
-		return errors.New("specifying a region when retrieving defaults for a setting is invalid")
-	case !regionSpecified && resetSpecified:
-		// It makes no sense to supply a positional arg that isn't a region if
-		// we are resetting a region, so we must have gotten an invalid region.
-		return errors.Errorf("invalid region specified: %q", arg)
-	case !regionSpecified && !resetSpecified:
-		// We can retrieve a value.
-		c.key = arg
-		c.action = c.getDefaults
-		return nil
-	case regionSpecified && resetSpecified:
+	if regionSpecified {
+		if !resetSpecified {
+			// It doesn't make sense to specify a region unless we are resetting
+			// values here.
+			return errors.New("specifying a region when retrieving defaults for a setting is invalid")
+		}
 		// If a region was specified and reset was specified, we shouldn't have
 		// an extra arg. If it had an "=" in it, we should have handled it
 		// already.
 		return errors.New("cannot retrieve defaults for a key and reset args at the same time")
-	default:
-		// This should be unreachable.
-		return errors.New("unexpected input, please file a bug")
 	}
+	if resetSpecified {
+		// It makes no sense to supply a positional arg that isn't a region if
+		// we are resetting keys in a region, so we must have gotten an invalid
+		// region.
+		return errors.Errorf("invalid region specified: %q", arg)
+	}
+	// We can retrieve a value.
+	c.key = arg
+	c.action = c.getDefaults
+	return nil
 }
 
 // handleExtraArgs handles the case where too many args were supplied.
@@ -462,19 +444,22 @@ func (c *defaultsCommand) handleExtraArgs(args []string) error {
 		}
 	}
 
-	switch {
-	case numArgs == 2 && !regionSpecified && resetSpecified:
-		// It makes no sense to supply a positional arg that isn't a region if
-		// we are resetting a region, so we must have gotten an invalid region.
-		return errors.Errorf("invalid region specified: %q", args[0])
-	case !regionSpecified && !resetSpecified:
-		// If we land here it is because there are extraneous positional args.
-		return errors.New("can only retrieve defaults for one key or all")
-	default:
-		// Anything else just has extra positional args, which is invalid in an
-		// unreliably guessable way.
-		return errors.New("invalid input")
+	if !regionSpecified {
+		if resetSpecified {
+			if numArgs == 2 {
+				// It makes no sense to supply a positional arg that isn't a
+				// region if we are resetting a region, so we must have gotten
+				// an invalid region.
+				return errors.Errorf("invalid region specified: %q", args[0])
+			}
+		}
+		if !resetSpecified {
+			// If we land here it is because there are extraneous positional
+			// args.
+			return errors.New("can only retrieve defaults for one key or all")
+		}
 	}
+	return errors.New("invalid input")
 }
 
 // Run implements part of the cmd.Command interface.
@@ -556,28 +541,13 @@ func (c *defaultsCommand) verifyKnownKeys(client defaultsCommandAPI) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	// allKeys gets the all the set and reset keys to validate. This should get
-	// caught in Init so maybe we don't need it here too.
-	// TODO(reviewer) Should we keep this and the init check?
-	allkeys := func() []string {
-		keys := []string{}
-		for k := range c.values {
-			keys = append(keys, k)
-		}
-		keys = append(keys, c.resetKeys...)
-		return keys
+
+	allKeys := c.resetKeys[:]
+	for k := range c.values {
+		allKeys = append(allKeys, k)
 	}
 
-	keys := allkeys()
-	repeats := map[string]int{}
-	// Make sure we aren't trying to reset and set a key.
-	for _, k := range keys {
-		repeats[k]++
-		if repeats[k] > 1 {
-			return errors.Errorf("conflicting operations on key: %q not allowed", k)
-		}
-	}
-	for _, key := range allkeys() {
+	for _, key := range allKeys {
 		// check if the key exists in the known config
 		// and warn the user if the key is not defined
 		if _, exists := known[key]; !exists {

--- a/cmd/juju/model/defaultscommand_test.go
+++ b/cmd/juju/model/defaultscommand_test.go
@@ -29,62 +29,197 @@ func (s *DefaultsCommandSuite) SetUpTest(c *gc.C) {
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = "controller"
 	s.store.Controllers["controller"] = jujuclient.ControllerDetails{}
+
 }
 
 func (s *DefaultsCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
-	command := model.NewDefaultsCommandForTest(s.fake, s.store)
+	command := model.NewDefaultsCommandForTest(s.fakeAPIRoot, s.fakeDefaultsAPI, s.fakeCloudAPI, s.store)
 	return testing.RunCommand(c, command, args...)
 }
 
 func (s *DefaultsCommandSuite) TestDefaultsInit(c *gc.C) {
 	for i, test := range []struct {
-		args       []string
-		errorMatch string
-		nilErr     bool
+		description string
+		args        []string
+		errorMatch  string
+		nilErr      bool
 	}{
 		{
 			// Test set
-			// 0
-			args:       []string{"special=extra", "special=other"},
-			errorMatch: `key "special" specified more than once`,
+			description: "test set key specified more than once",
+			args:        []string{"special=extra", "special=other"},
+			errorMatch:  `key "special" specified more than once`,
 		}, {
-			// 1
-			args:       []string{"agent-version=2.0.0"},
-			errorMatch: `"agent-version" must be set via "upgrade-juju"`,
+			description: "test cannot set agent-version",
+			args:        []string{"agent-version=2.0.0"},
+			errorMatch:  `"agent-version" must be set via "upgrade-juju"`,
 		}, {
-			// 2
-			args:   []string{"foo=bar", "baz=eggs"},
-			nilErr: true,
+			description: "test set multiple keys",
+			args:        []string{"foo=bar", "baz=eggs"},
+			nilErr:      true,
 		}, {
 			// Test reset
-			// 3
-			args:       []string{"--reset"},
-			errorMatch: "no keys specified",
+			description: "test empty args with reset fails",
+			args:        []string{"--reset"},
+			errorMatch:  "flag needs an argument: --reset",
 		}, {
-			// 4
-			args:   []string{"--reset", "something", "weird"},
-			nilErr: true,
+			description: "test reset with positional arg interpereted as invalid region",
+			args:        []string{"--reset", "something", "weird"},
+			errorMatch:  `invalid region specified: "weird"`,
+		},
+		{
+			description: "test reset with valid region and duplicate key set",
+			args:        []string{"--reset", "something", "dummy-region", "something=weird"},
+			errorMatch:  `key "something" specified more than once`,
+		},
+		{
+			description: "test reset with valid region and extra positional arg",
+			args:        []string{"--reset", "something", "dummy-region", "weird"},
+			errorMatch:  "cannot retrieve defaults for a key and reset args at the same time",
 		}, {
-			// 5
-			args:       []string{"--reset", "agent-version"},
-			errorMatch: `"agent-version" cannot be reset`,
+			description: "test reset with valid region only",
+			args:        []string{"--reset", "foo", "dummy-region"},
+			nilErr:      true,
 		}, {
-			// Test get
-			// 6
-			args:   nil,
-			nilErr: true,
+			description: "test cannot reset agent version",
+			args:        []string{"--reset", "agent-version"},
+			errorMatch:  `"agent-version" cannot be reset`,
 		}, {
-			// 7
-			args:   []string{"one"},
-			nilErr: true,
+			description: "test reset inits",
+			args:        []string{"--reset", "foo"},
+			nilErr:      true,
 		}, {
-			// 8
-			args:       []string{"one", "two"},
-			errorMatch: "can only retrieve a single value, or all values",
+			description: "test trailing reset fails",
+			args:        []string{"foo=bar", "--reset"},
+			errorMatch:  "flag needs an argument: --reset",
+		}, {
+			description: "test reset and get init",
+			args:        []string{"--reset", "agent-version,b", "foo=bar"},
+			errorMatch:  `"agent-version" cannot be reset`,
+		}, {
+			description: "test reset with key=val fails",
+			args:        []string{"--reset", "foo=bar"},
+			errorMatch:  `--reset accepts a single key "a" or comma delimited keys "a,b,c", received: "foo=bar"`,
+		}, {
+			description: "test reset multiple with key=val fails",
+			args:        []string{"--reset", "a,foo=bar,b"},
+			errorMatch:  `--reset accepts a single key "a" or comma delimited keys "a,b,c", received: "foo=bar"`,
+		}, {
+			description: "test reset with two positional args fails expecting a region",
+			args:        []string{"--reset", "a", "b", "c"},
+			errorMatch:  `invalid region specified: "b"`,
+		}, {
+			description: "test reset with two positional args fails expecting a region reordered",
+			args:        []string{"a", "--reset", "b", "c"},
+			errorMatch:  `invalid region specified: "a"`,
+		}, {
+			description: "test multiple reset inits",
+			args:        []string{"--reset", "a", "--reset", "b"},
+			nilErr:      true,
+		}, {
+			description: "test multiple reset and set inits",
+			args:        []string{"--reset", "a", "b=c", "--reset", "d"},
+			nilErr:      true,
+		}, {
+			description: "test multiple reset with valid region inits",
+			args:        []string{"dummy-region", "--reset", "a", "--reset", "b"},
+			nilErr:      true,
+		}, {
+			description: "test multiple reset with two positional args fails expecting a region reordered",
+			args:        []string{"a", "--reset", "b", "--reset", "c", "d"},
+			errorMatch:  `invalid region specified: "a"`,
+		}, {
+			description: "test reset multiple with key=val fails",
+			args:        []string{"--reset", "a", "--reset", "b,foo=bar,c"},
+			errorMatch:  `--reset accepts a single key "a" or comma delimited keys "a,b,c", received: "foo=bar"`,
+		}, {
+			// test get
+			description: "test no args inits",
+			args:        nil,
+			nilErr:      true,
+		}, {
+			description: "one key arg inits",
+			args:        []string{"one"},
+			nilErr:      true,
+		}, {
+			description: "test two key args fails",
+			args:        []string{"one", "two"},
+			errorMatch:  "can only retrieve defaults for one key or all",
+		}, {
+			description: "test multiple key args fails",
+			args:        []string{"one", "two", "three"},
+			errorMatch:  "can only retrieve defaults for one key or all",
+		}, {
+			description: "test valid region and one arg",
+			args:        []string{"dummy-region", "one"},
+			errorMatch:  "specifying a region when retrieving defaults for a setting is invalid",
+		}, {
+			description: "test valid region and no args",
+			args:        []string{"dummy-region"},
+			errorMatch:  "specifying a region when retrieving defaults is invalid",
+		}, {
+			// test cloud/region
+			description: "test invalid cloud fails",
+			args:        []string{"invalidCloud/invalidRegion", "one=two"},
+			errorMatch:  "Unknown cloud",
+		}, {
+			description: "test valid cloud with invalid region fails",
+			args:        []string{"dummy/invalidRegion", "one=two"},
+			errorMatch:  `invalid region specified: "dummy/invalidRegion"`,
+		}, {
+			description: "test no cloud with invalid region fails",
+			args:        []string{"invalidRegion", "one=two"},
+			errorMatch:  `invalid region specified: "invalidRegion"`,
+		}, {
+			description: "test valid region with set arg succeeds",
+			args:        []string{"dummy-region", "one=two"},
+			nilErr:      true,
+		}, {
+			description: "test valid region with set and reset succeeds",
+			args:        []string{"dummy-region", "one=two", "--reset", "three"},
+			nilErr:      true,
+		}, {
+			description: "test reset and set with extra key is interpereted as invalid region",
+			args:        []string{"--reset", "something,else", "invalidRegion", "is=weird"},
+			errorMatch:  `invalid region specified: "invalidRegion"`,
+		}, {
+			description: "test reset and set with valid region and extra key fails",
+			args:        []string{"--reset", "something,else", "dummy-region", "invalidkey", "is=weird"},
+			errorMatch:  "cannot set and retrieve default values simultaneously",
+		}, {
+			// test various invalid
+			description: "test too many positional args with reset",
+			args:        []string{"--reset", "a", "b", "c", "d"},
+			errorMatch:  "invalid input",
+		}, {
+			description: "test too many positional args with invalid region set",
+			args:        []string{"a", "a=b", "b", "c=d"},
+			errorMatch:  `invalid region specified: "a"`,
+		}, {
+			description: "test invalid positional args with set",
+			args:        []string{"a=b", "b", "c=d"},
+			errorMatch:  `expected "key=value", got "b"`,
+		}, {
+			description: "test invalid positional args with set and trailing key",
+			args:        []string{"a=b", "c=d", "e"},
+			errorMatch:  "cannot set and retrieve default values simultaneously",
+		}, {
+			description: "test invalid positional args with valid region, set, reset",
+			args:        []string{"dummy-region", "a=b", "--reset", "c,d,", "e=f", "g"},
+			errorMatch:  "cannot set and retrieve default values simultaneously",
+		}, {
+			// Test some random orderings
+			description: "test invalid positional args with set, reset with trailing comman and split key=values",
+			args:        []string{"dummy-region", "a=b", "--reset", "c,d,", "e=f"},
+			nilErr:      true,
+		}, {
+			description: "test leading comma with reset",
+			args:        []string{"--reset", ",a,b"},
+			nilErr:      true,
 		},
 	} {
-		c.Logf("test %d", i)
-		cmd := model.NewDefaultsCommandForTest(s.fake, s.store)
+		c.Logf("test %d: %s", i, test.description)
+		cmd := model.NewDefaultsCommandForTest(s.fakeAPIRoot, s.fakeDefaultsAPI, s.fakeCloudAPI, s.store)
 		err := testing.InitCommand(cmd, test.args)
 		if test.nilErr {
 			c.Check(err, jc.ErrorIsNil)
@@ -95,16 +230,16 @@ func (s *DefaultsCommandSuite) TestDefaultsInit(c *gc.C) {
 }
 
 func (s *DefaultsCommandSuite) TestResetUnknownValueLogs(c *gc.C) {
-	_, err := s.run(c, "--reset", "attr", "weird")
+	_, err := s.run(c, "--reset", "attr,weird")
 	c.Assert(err, jc.ErrorIsNil)
 	expected := `key "weird" is not defined in the known model configuration: possible misspelling`
 	c.Check(c.GetTestLog(), jc.Contains, expected)
 }
 
 func (s *DefaultsCommandSuite) TestResetAttr(c *gc.C) {
-	_, err := s.run(c, "--reset", "attr", "unknown")
+	_, err := s.run(c, "--reset", "attr,unknown")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.fake.defaults, jc.DeepEquals, config.ModelDefaultAttributes{
+	c.Assert(s.fakeDefaultsAPI.defaults, jc.DeepEquals, config.ModelDefaultAttributes{
 		"attr2": {Controller: "bar", Default: nil, Regions: []config.RegionDefaultValue{{
 			Name:  "dummy-region",
 			Value: "dummy-value",
@@ -113,7 +248,7 @@ func (s *DefaultsCommandSuite) TestResetAttr(c *gc.C) {
 }
 
 func (s *DefaultsCommandSuite) TestResetBlockedError(c *gc.C) {
-	s.fake.err = common.OperationBlockedError("TestBlockedError")
+	s.fakeDefaultsAPI.err = common.OperationBlockedError("TestBlockedError")
 	_, err := s.run(c, "--reset", "attr")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	// msg is logged
@@ -130,7 +265,7 @@ func (s *DefaultsCommandSuite) TestSetUnknownValueLogs(c *gc.C) {
 func (s *DefaultsCommandSuite) TestSet(c *gc.C) {
 	_, err := s.run(c, "special=extra", "attr=baz")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.fake.defaults, jc.DeepEquals, config.ModelDefaultAttributes{
+	c.Assert(s.fakeDefaultsAPI.defaults, jc.DeepEquals, config.ModelDefaultAttributes{
 		"attr": {Controller: "baz", Default: nil, Regions: nil},
 		"attr2": {Controller: "bar", Default: nil, Regions: []config.RegionDefaultValue{{
 			Name:  "dummy-region",
@@ -141,7 +276,7 @@ func (s *DefaultsCommandSuite) TestSet(c *gc.C) {
 }
 
 func (s *DefaultsCommandSuite) TestBlockedErrorOnSet(c *gc.C) {
-	s.fake.err = common.OperationBlockedError("TestBlockedError")
+	s.fakeDefaultsAPI.err = common.OperationBlockedError("TestBlockedError")
 	_, err := s.run(c, "special=extra")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	// msg is logged

--- a/cmd/juju/model/defaultscommand_test.go
+++ b/cmd/juju/model/defaultscommand_test.go
@@ -29,8 +29,10 @@ func (s *DefaultsCommandSuite) SetUpTest(c *gc.C) {
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = "controller"
 	s.store.Controllers["controller"] = jujuclient.ControllerDetails{}
-
 }
+
+// XXX(ro) Add test to ensure region and cloud are correctly passed to the
+// api
 
 func (s *DefaultsCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
 	command := model.NewDefaultsCommandForTest(s.fakeAPIRoot, s.fakeDefaultsAPI, s.fakeCloudAPI, s.store)
@@ -70,7 +72,7 @@ func (s *DefaultsCommandSuite) TestDefaultsInit(c *gc.C) {
 		{
 			description: "test reset with valid region and duplicate key set",
 			args:        []string{"--reset", "something", "dummy-region", "something=weird"},
-			errorMatch:  `key "something" specified more than once`,
+			errorMatch:  `key "something" cannot be both set and unset in the same command`,
 		},
 		{
 			description: "test reset with valid region and extra positional arg",
@@ -99,11 +101,11 @@ func (s *DefaultsCommandSuite) TestDefaultsInit(c *gc.C) {
 		}, {
 			description: "test reset with key=val fails",
 			args:        []string{"--reset", "foo=bar"},
-			errorMatch:  `--reset accepts a single key "a" or comma delimited keys "a,b,c", received: "foo=bar"`,
+			errorMatch:  `--reset accepts a comma delimited set of keys "a,b,c", received: "foo=bar"`,
 		}, {
 			description: "test reset multiple with key=val fails",
 			args:        []string{"--reset", "a,foo=bar,b"},
-			errorMatch:  `--reset accepts a single key "a" or comma delimited keys "a,b,c", received: "foo=bar"`,
+			errorMatch:  `--reset accepts a comma delimited set of keys "a,b,c", received: "foo=bar"`,
 		}, {
 			description: "test reset with two positional args fails expecting a region",
 			args:        []string{"--reset", "a", "b", "c"},
@@ -131,7 +133,7 @@ func (s *DefaultsCommandSuite) TestDefaultsInit(c *gc.C) {
 		}, {
 			description: "test reset multiple with key=val fails",
 			args:        []string{"--reset", "a", "--reset", "b,foo=bar,c"},
-			errorMatch:  `--reset accepts a single key "a" or comma delimited keys "a,b,c", received: "foo=bar"`,
+			errorMatch:  `--reset accepts a comma delimited set of keys "a,b,c", received: "foo=bar"`,
 		}, {
 			// test get
 			description: "test no args inits",

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -6,6 +6,8 @@ package model
 import (
 	"github.com/juju/cmd"
 
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 )
@@ -20,9 +22,11 @@ func NewConfigCommandForTest(api configCommandAPI) cmd.Command {
 }
 
 // NewDefaultsCommandForTest returns a defaultsCommand with the api provided as specified.
-func NewDefaultsCommandForTest(api defaultsCommandAPI, store jujuclient.ClientStore) cmd.Command {
+func NewDefaultsCommandForTest(apiRoot api.Connection, dAPI defaultsCommandAPI, cAPI cloudAPI, store jujuclient.ClientStore) cmd.Command {
 	cmd := &defaultsCommand{
-		api: api,
+		newAPIRoot:     func() (api.Connection, error) { return apiRoot, nil },
+		newDefaultsAPI: func(caller base.APICallCloser) defaultsCommandAPI { return dAPI },
+		newCloudAPI:    func(caller base.APICallCloser) cloudAPI { return cAPI },
 	}
 	cmd.SetClientStore(store)
 	return modelcmd.WrapController(cmd)

--- a/cmd/juju/model/fakeenv_test.go
+++ b/cmd/juju/model/fakeenv_test.go
@@ -4,8 +4,13 @@
 package model_test
 
 import (
-	gc "gopkg.in/check.v1"
+	"errors"
 
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api"
+	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/testing"
 )
@@ -71,12 +76,15 @@ func (f *fakeEnvAPI) ModelUnset(keys ...string) error {
 
 type fakeModelDefaultEnvSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
-	fake *fakeModelDefaultsAPI
+	fakeAPIRoot     *fakeAPIConnection
+	fakeDefaultsAPI *fakeModelDefaultsAPI
+	fakeCloudAPI    *fakeCloudAPI
 }
 
 func (s *fakeModelDefaultEnvSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	s.fake = &fakeModelDefaultsAPI{
+	s.fakeAPIRoot = &fakeAPIConnection{}
+	s.fakeDefaultsAPI = &fakeModelDefaultsAPI{
 		values: map[string]interface{}{
 			"name":    "test-model",
 			"special": "special value",
@@ -91,6 +99,24 @@ func (s *fakeModelDefaultEnvSuite) SetUpTest(c *gc.C) {
 					"dummy-value"}}},
 		},
 	}
+	s.fakeCloudAPI = &fakeCloudAPI{
+		clouds: map[string]jujucloud.Cloud{
+			"cloud-dummy": {
+				Type: "dummy-cloud",
+				Regions: []jujucloud.Region{
+					{Name: "dummy-region"},
+				},
+			},
+		},
+	}
+}
+
+type fakeAPIConnection struct {
+	api.Connection
+}
+
+func (*fakeAPIConnection) Close() error {
+	return nil
 }
 
 type fakeModelDefaultsAPI struct {
@@ -145,4 +171,23 @@ func (f *fakeModelDefaultsAPI) ModelSet(config map[string]interface{}) error {
 func (f *fakeModelDefaultsAPI) ModelUnset(keys ...string) error {
 	f.keys = keys
 	return f.err
+}
+
+type fakeCloudAPI struct {
+	clouds map[string]jujucloud.Cloud
+}
+
+func (f *fakeCloudAPI) Close() error { return nil }
+func (f *fakeCloudAPI) DefaultCloud() (names.CloudTag, error) {
+	return names.NewCloudTag("dummy"), nil
+}
+func (f *fakeCloudAPI) Cloud(name names.CloudTag) (jujucloud.Cloud, error) {
+	var (
+		c  jujucloud.Cloud
+		ok bool
+	)
+	if c, ok = f.clouds[name.String()]; !ok {
+		return jujucloud.Cloud{}, errors.New("Unknown cloud")
+	}
+	return c, nil
 }

--- a/cmd/juju/model/fakeenv_test.go
+++ b/cmd/juju/model/fakeenv_test.go
@@ -105,6 +105,7 @@ func (s *fakeModelDefaultEnvSuite) SetUpTest(c *gc.C) {
 				Type: "dummy-cloud",
 				Regions: []jujucloud.Region{
 					{Name: "dummy-region"},
+					{Name: "another-region"},
 				},
 			},
 		},

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -135,27 +135,24 @@ func (st *State) modelConfigValues(modelCfg attrValues) (config.ConfigValues, er
 
 // UpdateModelConfigDefaultValues updates the inherited settings used when creating a new model.
 func (st *State) UpdateModelConfigDefaultValues(attrs map[string]interface{}, removed []string, regionSpec *environs.RegionSpec) error {
-	var (
-		err      error
-		key      string
-		settings *Settings
-	)
+	var key string
 
 	if regionSpec != nil {
 		key = regionSettingsGlobalKey(regionSpec.Cloud, regionSpec.Region)
 	} else {
 		key = controllerInheritedSettingsGlobalKey
 	}
-	settings, err = readSettings(st, globalSettingsC, key)
+	settings, err := readSettings(st, globalSettingsC, key)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return errors.Trace(err)
 		}
 		// We haven't created settings for this region yet.
-		settings, err = createSettings(st, globalSettingsC, key, attrs)
+		_, err := createSettings(st, globalSettingsC, key, attrs)
 		if err != nil {
 			return errors.Trace(err)
 		}
+		return nil
 	}
 
 	// TODO(axw) 2013-12-6 #1167616

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -556,13 +556,8 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaultValuesUnknownRegion
 	err = s.State.UpdateModelConfigDefaultValues(attrs, nil, rspec)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Then check in another state.
-	info := statetesting.NewMongoInfo()
-	anotherState, err := state.Open(s.modelTag, s.State.ControllerTag(), info, mongotest.DialOpts(), state.NewPolicyFunc(nil))
-	c.Assert(err, jc.ErrorIsNil)
-	defer anotherState.Close()
-
-	cfg, err := anotherState.ModelConfigDefaultValues()
+	// Then check config.
+	cfg, err := s.State.ModelConfigDefaultValues()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg["no-proxy"], jc.DeepEquals, config.AttributeDefaultValues{
 		Default:    "",

--- a/state/testing/conn.go
+++ b/state/testing/conn.go
@@ -60,6 +60,12 @@ func Initialize(c *gc.C, owner names.UserTag, cfg *config.Config, controllerInhe
 					IdentityEndpoint: "nether-identity-endpoint",
 					StorageEndpoint:  "nether-storage-endpoint",
 				},
+				cloud.Region{
+					Name:             "unused-region",
+					Endpoint:         "unused-endpoint",
+					IdentityEndpoint: "unused-identity-endpoint",
+					StorageEndpoint:  "unused-storage-endpoint",
+				},
 			},
 			RegionConfig: regionConfig,
 		},


### PR DESCRIPTION
Also changes --reset to be a stringvar. All tests pass at this point but
it needs more tests for the new features. It also adds a lot of command
arg scrutiny and tests

This was originally part of #6269 but has been split from the backend
bits here. Addtionally per review in pr #6269, updates the reset variable
so we can specify it repeatedly and reset all the keys set in all the
reset flags.

Ensure the cloud is always set, even if we only get the region on the
CLI. Finally, create new region settings if they weren't created at
bootstrap.

Refs: config command collapse spec https://goo.gl/yqrrPI
Refs: model-config-tree


QA:
1. Run all unit tests and all pass.
2. juju bootstrap reed/aws/us-west-1 --build-agent 
   # bootstrap a controller with settings similar to  
   # http://paste.ubuntu.com/23080517/
3. juju model-defaults --reset no-proxy  
   # verify the controller val was reset
4. juju model-defaults --reset no-proxy us-east-1 
   # verify it was reset in us-east-1. 
5. juju model-defaults us-west-2 no-proxy=west-2 agent-stream=foobar 
   # verify both items were set on us-west-2
6. juju model-defaults us-west-2 no-proxy=west-updated --reset agent-stream
   # verify no-proxy was changed and agent-stream reset
7. juju model-defaults awstest/us-east-1 no-proxy=https://foo-east
    # verify us-east-1 is set again
8. juju model-defaults no-proxy=https://local
   # be sure the controller default was set again.
9. juju model-defaults us-east-2 no-proxy=foo
error: invalid region specified: "us-east-2" # verify this error.
... Do other things to try breaking it.