### PR TITLE
apiserver: Remove charm get cache

### DIFF
--- a/upgrades/export_test.go
+++ b/upgrades/export_test.go
@@ -51,10 +51,11 @@ var (
 	CopyFile         = copyFile
 
 	// 125 upgrade functions
-	AddInstanceTags   = addInstanceTags
-	RemoveJujudpass   = removeJujudpass
-	AddJujuRegKey     = addJujuRegKey
-	CleanToolsStorage = cleanToolsStorage
+	AddInstanceTags     = addInstanceTags
+	RemoveJujudpass     = removeJujudpass
+	AddJujuRegKey       = addJujuRegKey
+	CleanToolsStorage   = cleanToolsStorage
+	RemoveCharmGetCache = removeCharmGetCache
 )
 
 type EnvironConfigUpdater environConfigUpdater

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -76,6 +76,10 @@ var upgradeOperations = func() []Operation {
 			version.MustParse("1.25.0"),
 			stepsFor125(),
 		},
+		upgradeToVersion{
+			version.MustParse("1.25.7"),
+			stepsFor1257(),
+		},
 	}
 	return steps
 }

--- a/upgrades/steps125.go
+++ b/upgrades/steps125.go
@@ -4,6 +4,8 @@
 package upgrades
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/juju/errors"
@@ -143,6 +145,17 @@ func stepsFor125() []Step {
 	}
 }
 
+// stepsFor1257 returns upgrade steps for Juju 1.25.7 that only need the API.
+func stepsFor1257() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "remove apiserver charm get cache",
+			targets:     []Target{StateServer},
+			run:         removeCharmGetCache,
+		},
+	}
+}
+
 // removeJujudpass removes a file that is no longer used on versions >1.25
 // The Jujud.pass file was created during cloud init before
 // so we know it's location for sure in case it exists
@@ -177,4 +190,12 @@ func addJujuRegKey(context Context) error {
 		return nil
 	}
 	return nil
+}
+
+// removeCharmGetCache removes the cache directory that was previously
+// used by the charms API endpoint. It is no longer necessary.
+func removeCharmGetCache(context Context) error {
+	dataDir := context.AgentConfig().DataDir()
+	cacheDir := filepath.Join(dataDir, "charm-get-cache")
+	return os.RemoveAll(cacheDir)
 }

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -678,7 +678,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 
 func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.UpgradeOperations)())
-	c.Assert(versions, gc.DeepEquals, []string{"1.18.0", "1.22.0", "1.23.0", "1.24.0", "1.25.0"})
+	c.Assert(versions, gc.DeepEquals, []string{"1.18.0", "1.22.0", "1.23.0", "1.24.0", "1.25.0", "1.25.7"})
 }
 
 func extractUpgradeVersions(c *gc.C, ops []upgrades.Operation) []string {


### PR DESCRIPTION
(this is a backport from 2.0 - see also: https://github.com/juju/juju/pull/6302)

The filesystem cache used when retrieving charms has been removed. It was implemented when charms lived in a remote S3 bucket and is no longer necessary now that charm live in MongoDB's GridFS store. This helps to reduce disk space usage in the controllers and is one less thing that needs cleaning up when models are removed.

An upgrade step was also added. Now that the apiserver's charm get cache is no longer used it is removed to free up disk space.

This is part of the fix for https://bugs.launchpad.net/juju/+bug/1626304