### PR TITLE
fix list-disabled-commands with empty output

### DIFF
--- a/cmd/juju/block/list.go
+++ b/cmd/juju/block/list.go
@@ -98,7 +98,7 @@ func (c *listCommand) listForModel(ctx *cmd.Context) (err error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if len(result) == 0 {
+	if len(result) == 0 && c.out.Name() == "tabular" {
 		ctx.Infof(noBlocks)
 		return nil
 	}
@@ -116,7 +116,7 @@ func (c *listCommand) listForController(ctx *cmd.Context) (err error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if len(result) == 0 {
+	if len(result) == 0 && c.out.Name() == "tabular" {
 		ctx.Infof(noBlocks)
 		return nil
 	}

--- a/cmd/juju/block/list_test.go
+++ b/cmd/juju/block/list_test.go
@@ -98,6 +98,12 @@ func (s *listCommandSuite) TestListYAML(c *gc.C) {
 	)
 }
 
+func (s *listCommandSuite) TestListJSONEmpty(c *gc.C) {
+	ctx, err := testing.RunCommand(c, block.NewListCommandForTest(&mockListClient{}, nil), "--format", "json")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stdout(ctx), gc.Equals, "[]\n")
+}
+
 func (s *listCommandSuite) TestListJSON(c *gc.C) {
 	cmd := block.NewListCommandForTest(s.mock(), nil)
 	ctx, err := testing.RunCommand(c, cmd, "--format", "json")


### PR DESCRIPTION
When we fixed the error message for tabular output, we
accidentally messed up the json and yaml output, since
there was no restriction to only output the error message
for tabular.

fixes https://bugs.launchpad.net/juju/+bug/1626824