### PR TITLE
worker/uniter: Remove temp download files

### DIFF
--- a/worker/uniter/charm/bundles.go
+++ b/worker/uniter/charm/bundles.go
@@ -66,8 +66,17 @@ func (d *BundlesDir) download(info BundleInfo, abort <-chan struct{}) (err error
 	if err != nil {
 		return err
 	}
+	defer func() {
+		st.File.Close()
+		if err != nil {
+			name := st.File.Name()
+			if removeErr := os.Remove(name); removeErr != nil {
+				logger.Warningf("cannot remove download file for %s (%s): %v",
+					info.URL(), name, removeErr)
+			}
+		}
+	}()
 	logger.Infof("download complete")
-	defer st.File.Close()
 	actualSha256, _, err := utils.ReadSHA256(st.File)
 	if err != nil {
 		return err

--- a/worker/uniter/charm/bundles.go
+++ b/worker/uniter/charm/bundles.go
@@ -5,10 +5,8 @@ package charm
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
-	"path/filepath"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils"
@@ -135,23 +133,10 @@ func (d *BundlesDir) bundleURLPath(url *charm.URL) string {
 
 // ClearDownloads removes any entries in the temporary bundle download
 // directory. It is intended to be called on uniter startup.
-func ClearDownloads(bundlesDir string) (err error) {
-	defer errors.DeferredAnnotatef(&err, "unable to clear bundle downloads")
-
+func ClearDownloads(bundlesDir string) error {
 	downloadDir := downloadsPath(bundlesDir)
-	entries, err := ioutil.ReadDir(downloadDir)
-	if os.IsNotExist(err) {
-		return nil
-	} else if err != nil {
-		return
-	}
-	for _, entry := range entries {
-		path := filepath.Join(downloadDir, entry.Name())
-		if err = os.RemoveAll(path); err != nil {
-			return
-		}
-	}
-	return
+	err := os.RemoveAll(downloadDir)
+	return errors.Annotate(err, "unable to clear bundle downloads")
 }
 
 // downloadsPath returns the path to the directory into which charms are

--- a/worker/uniter/charm/bundles_test.go
+++ b/worker/uniter/charm/bundles_test.go
@@ -115,7 +115,9 @@ func (s *BundlesDirSuite) TestGet(c *gc.C) {
 	d := charm.NewBundlesDir(bunsDir)
 
 	checkDownloadsEmpty := func() {
-		checkDirEmpty(c, filepath.Join(bunsDir, "downloads"))
+		files, err := ioutil.ReadDir(filepath.Join(bunsDir, "downloads"))
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(files, gc.HasLen, 0)
 	}
 
 	// Check it doesn't get created until it's needed.
@@ -191,7 +193,7 @@ func (s *ClearDownloadsSuite) TestWorks(c *gc.C) {
 
 	err := charm.ClearDownloads(bunsDir)
 	c.Assert(err, jc.ErrorIsNil)
-	checkDirEmpty(c, downloadDir)
+	checkMissing(c, downloadDir)
 }
 
 func (s *ClearDownloadsSuite) TestEmptyOK(c *gc.C) {
@@ -202,7 +204,7 @@ func (s *ClearDownloadsSuite) TestEmptyOK(c *gc.C) {
 
 	err := charm.ClearDownloads(bunsDir)
 	c.Assert(err, jc.ErrorIsNil)
-	checkDirEmpty(c, downloadDir)
+	checkMissing(c, downloadDir)
 }
 
 func (s *ClearDownloadsSuite) TestMissingOK(c *gc.C) {
@@ -228,8 +230,9 @@ func assertCharm(c *gc.C, bun charm.Bundle, sch *state.Charm) {
 	c.Assert(actual.Config(), gc.DeepEquals, sch.Config())
 }
 
-func checkDirEmpty(c *gc.C, p string) {
-	files, err := ioutil.ReadDir(p)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(files, gc.HasLen, 0)
+func checkMissing(c *gc.C, p string) {
+	_, err := os.Stat(p)
+	if !os.IsNotExist(err) {
+		c.Fatalf("checking %s is missing: %v", p, err)
+	}
 }

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -236,6 +236,9 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 	u.storage = storageAttachments
 	u.addCleanup(storageAttachments.Stop)
 
+	if err := charm.ClearDownloads(u.paths.State.BundlesDir); err != nil {
+		logger.Warningf(err.Error())
+	}
 	deployer, err := charm.NewDeployer(
 		u.paths.State.CharmDir,
 		u.paths.State.DeployerDir,

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -159,6 +159,23 @@ func (s *UniterSuite) TestUniterStartup(c *gc.C) {
 	})
 }
 
+func (s *UniterSuite) TestPreviousDownloadsCleared(c *gc.C) {
+	s.runUniterTests(c, []uniterTest{
+		ut(
+			"Ensure stale download files are cleared on uniter startup",
+			createCharm{},
+			serveCharm{},
+			ensureStateWorker{},
+			createServiceAndUnit{},
+			createDownloads{},
+			startUniter{},
+			waitAddresses{},
+			waitUnitAgent{status: params.StatusIdle},
+			verifyDownloadsCleared{},
+		),
+	})
+}
+
 func (s *UniterSuite) TestUniterBootstrap(c *gc.C) {
 	//TODO(bogdanteleaga): Fix this on windows
 	if runtime.GOOS == "windows" {

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -640,6 +640,30 @@ func (s startupError) step(c *gc.C, ctx *context) {
 	step(c, ctx, verifyCharm{})
 }
 
+type createDownloads struct{}
+
+func (s createDownloads) step(c *gc.C, ctx *context) {
+	dir := downloadDir(ctx)
+	c.Assert(os.MkdirAll(dir, 0775), jc.ErrorIsNil)
+	c.Assert(
+		ioutil.WriteFile(filepath.Join(dir, "foo"), []byte("bar"), 0775),
+		jc.ErrorIsNil,
+	)
+}
+
+type verifyDownloadsCleared struct{}
+
+func (s verifyDownloadsCleared) step(c *gc.C, ctx *context) {
+	files, err := ioutil.ReadDir(downloadDir(ctx))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(files, gc.HasLen, 0)
+}
+
+func downloadDir(ctx *context) string {
+	paths := uniter.NewPaths(ctx.dataDir, ctx.unit.UnitTag())
+	return filepath.Join(paths.State.BundlesDir, "downloads")
+}
+
 type quickStart struct {
 	minion bool
 }


### PR DESCRIPTION
The temporary files created during charm downloads were being left behind if an error occured. In some cases (a repeating permanent error) this would lead to disk space exhaustion.

The uniter will now also clear any temporary charm download files for the unit it manages when it starts. Although this shouldn't happen now, previous versions of Juju could leave a significant amount of data behind from failed download attempts.

This completes the fixes for https://bugs.launchpad.net/juju/+bug/1626304.