### PR TITLE
New API call, Controller.HostedModelConfig

### DIFF
--- a/api/common/cloudspec/cloudspec.go
+++ b/api/common/cloudspec/cloudspec.go
@@ -44,6 +44,8 @@ func (api *CloudSpecAPI) CloudSpec(tag names.ModelTag) (environs.CloudSpec, erro
 	return api.MakeCloudSpec(result.Result)
 }
 
+// MakeCloudSpec creates an environs.CloudSpec from a params.CloudSpec
+// that has been returned from the apiserver.
 func (api *CloudSpecAPI) MakeCloudSpec(pSpec *params.CloudSpec) (environs.CloudSpec, error) {
 	if pSpec == nil {
 		return environs.CloudSpec{}, errors.NotValidf("nil value")

--- a/api/common/cloudspec/cloudspec.go
+++ b/api/common/cloudspec/cloudspec.go
@@ -41,21 +41,28 @@ func (api *CloudSpecAPI) CloudSpec(tag names.ModelTag) (environs.CloudSpec, erro
 	if result.Error != nil {
 		return environs.CloudSpec{}, errors.Annotate(result.Error, "API request failed")
 	}
+	return api.MakeCloudSpec(result.Result)
+}
+
+func (api *CloudSpecAPI) MakeCloudSpec(pSpec *params.CloudSpec) (environs.CloudSpec, error) {
+	if pSpec == nil {
+		return environs.CloudSpec{}, errors.NotValidf("nil value")
+	}
 	var credential *cloud.Credential
-	if result.Result.Credential != nil {
+	if pSpec.Credential != nil {
 		credentialValue := cloud.NewCredential(
-			cloud.AuthType(result.Result.Credential.AuthType),
-			result.Result.Credential.Attributes,
+			cloud.AuthType(pSpec.Credential.AuthType),
+			pSpec.Credential.Attributes,
 		)
 		credential = &credentialValue
 	}
 	spec := environs.CloudSpec{
-		Type:             result.Result.Type,
-		Name:             result.Result.Name,
-		Region:           result.Result.Region,
-		Endpoint:         result.Result.Endpoint,
-		IdentityEndpoint: result.Result.IdentityEndpoint,
-		StorageEndpoint:  result.Result.StorageEndpoint,
+		Type:             pSpec.Type,
+		Name:             pSpec.Name,
+		Region:           pSpec.Region,
+		Endpoint:         pSpec.Endpoint,
+		IdentityEndpoint: pSpec.IdentityEndpoint,
+		StorageEndpoint:  pSpec.StorageEndpoint,
 		Credential:       credential,
 	}
 	if err := spec.Validate(); err != nil {

--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -88,9 +88,9 @@ type HostedConfig struct {
 
 // HostedModelsConfig returns all model settings for the
 // controller model.
-func (c *Client) HostedModelConfig() ([]HostedConfig, error) {
-	result := params.HostedModelConfigResults{}
-	err := c.facade.FacadeCall("HostedModelConfig", nil, &result)
+func (c *Client) HostedModelConfigs() ([]HostedConfig, error) {
+	result := params.HostedModelConfigsResults{}
+	err := c.facade.FacadeCall("HostedModelConfigs", nil, &result)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/api/common/cloudspec"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/permission"
 )
 
@@ -73,6 +74,51 @@ func (c *Client) ModelConfig() (map[string]interface{}, error) {
 		values[name] = val.Value
 	}
 	return values, err
+}
+
+// HostedConfig contains the model config and the cloud spec for that
+// model such that direct access to the provider can be used.
+type HostedConfig struct {
+	Name      string
+	Owner     names.UserTag
+	Config    map[string]interface{}
+	CloudSpec environs.CloudSpec
+	Error     error
+}
+
+// HostedModelsConfig returns all model settings for the
+// controller model.
+func (c *Client) HostedModelConfig() ([]HostedConfig, error) {
+	result := params.HostedModelConfigResults{}
+	err := c.facade.FacadeCall("HostedModelConfig", nil, &result)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	// If we get to here, we have some values. Each value may or
+	// may not have an error, but it should at least have a name
+	// and owner.
+	hostedConfigs := make([]HostedConfig, len(result.Models))
+	for i, modelConfig := range result.Models {
+		hostedConfigs[i].Name = modelConfig.Name
+		tag, err := names.ParseUserTag(modelConfig.OwnerTag)
+		if err != nil {
+			hostedConfigs[i].Error = errors.Trace(err)
+			continue
+		}
+		hostedConfigs[i].Owner = tag
+		if modelConfig.Error != nil {
+			hostedConfigs[i].Error = errors.Trace(modelConfig.Error)
+			continue
+		}
+		hostedConfigs[i].Config = modelConfig.Config
+		spec, err := c.MakeCloudSpec(modelConfig.CloudSpec)
+		if err != nil {
+			hostedConfigs[i].Error = errors.Trace(err)
+			continue
+		}
+		hostedConfigs[i].CloudSpec = spec
+	}
+	return hostedConfigs, err
 }
 
 // DestroyController puts the controller model into a "dying" state,

--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/api/controller"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs"
 	jujutesting "github.com/juju/testing"
 	"github.com/juju/utils"
 )
@@ -123,6 +124,74 @@ func (s *Suite) TestInitiateMigrationValidationError(c *gc.C) {
 	c.Check(id, gc.Equals, "")
 	c.Check(err, gc.ErrorMatches, "model UUID not valid")
 	c.Check(stub.Calls(), gc.HasLen, 0) // API call shouldn't have happened
+}
+
+func (s *Suite) TestHostedModelConfig_CallError(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(string, int, string, string, interface{}, interface{}) error {
+		return errors.New("boom")
+	})
+	client := controller.NewClient(apiCaller)
+	config, err := client.HostedModelConfig()
+	c.Check(config, gc.HasLen, 0)
+	c.Check(err, gc.ErrorMatches, "boom")
+}
+
+func (s *Suite) TestHostedModelConfig_FormatResults(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Assert(objType, gc.Equals, "Controller")
+		c.Assert(request, gc.Equals, "HostedModelConfig")
+		c.Assert(arg, gc.IsNil)
+		out := result.(*params.HostedModelConfigResults)
+		c.Assert(out, gc.NotNil)
+		*out = params.HostedModelConfigResults{
+			Models: []params.HostedModelConfig{
+				{
+					Name:     "first",
+					OwnerTag: "user-foo@bar",
+					Config: map[string]interface{}{
+						"name": "first",
+					},
+					CloudSpec: &params.CloudSpec{
+						Type: "magic",
+						Name: "first",
+					},
+				}, {
+					Name:     "second",
+					OwnerTag: "bad-tag",
+				}, {
+					Name:     "third",
+					OwnerTag: "user-foo@bar",
+					Config: map[string]interface{}{
+						"name": "third",
+					},
+					CloudSpec: &params.CloudSpec{
+						Name: "third",
+					},
+				},
+			},
+		}
+		return nil
+	})
+	client := controller.NewClient(apiCaller)
+	config, err := client.HostedModelConfig()
+	c.Assert(config, gc.HasLen, 3)
+	c.Assert(err, jc.ErrorIsNil)
+	first := config[0]
+	c.Assert(first.Name, gc.Equals, "first")
+	c.Assert(first.Owner, gc.Equals, names.NewUserTag("foo@bar"))
+	c.Assert(first.Config, gc.DeepEquals, map[string]interface{}{
+		"name": "first",
+	})
+	c.Assert(first.CloudSpec, gc.DeepEquals, environs.CloudSpec{
+		Type: "magic",
+		Name: "first",
+	})
+	second := config[1]
+	c.Assert(second.Name, gc.Equals, "second")
+	c.Assert(second.Error.Error(), gc.Equals, `"bad-tag" is not a valid tag`)
+	third := config[2]
+	c.Assert(third.Name, gc.Equals, "third")
+	c.Assert(third.Error.Error(), gc.Equals, "validating CloudSpec: empty Type not valid")
 }
 
 func makeClient(results params.InitiateMigrationResults) (

--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -126,24 +126,24 @@ func (s *Suite) TestInitiateMigrationValidationError(c *gc.C) {
 	c.Check(stub.Calls(), gc.HasLen, 0) // API call shouldn't have happened
 }
 
-func (s *Suite) TestHostedModelConfig_CallError(c *gc.C) {
+func (s *Suite) TestHostedModelConfigs_CallError(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(string, int, string, string, interface{}, interface{}) error {
 		return errors.New("boom")
 	})
 	client := controller.NewClient(apiCaller)
-	config, err := client.HostedModelConfig()
+	config, err := client.HostedModelConfigs()
 	c.Check(config, gc.HasLen, 0)
 	c.Check(err, gc.ErrorMatches, "boom")
 }
 
-func (s *Suite) TestHostedModelConfig_FormatResults(c *gc.C) {
+func (s *Suite) TestHostedModelConfigs_FormatResults(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Controller")
-		c.Assert(request, gc.Equals, "HostedModelConfig")
+		c.Assert(request, gc.Equals, "HostedModelConfigs")
 		c.Assert(arg, gc.IsNil)
-		out := result.(*params.HostedModelConfigResults)
+		out := result.(*params.HostedModelConfigsResults)
 		c.Assert(out, gc.NotNil)
-		*out = params.HostedModelConfigResults{
+		*out = params.HostedModelConfigsResults{
 			Models: []params.HostedModelConfig{
 				{
 					Name:     "first",
@@ -173,7 +173,7 @@ func (s *Suite) TestHostedModelConfig_FormatResults(c *gc.C) {
 		return nil
 	})
 	client := controller.NewClient(apiCaller)
-	config, err := client.HostedModelConfig()
+	config, err := client.HostedModelConfigs()
 	c.Assert(config, gc.HasLen, 3)
 	c.Assert(err, jc.ErrorIsNil)
 	first := config[0]

--- a/apiserver/common/cloudspec/cloudspec.go
+++ b/apiserver/common/cloudspec/cloudspec.go
@@ -66,27 +66,34 @@ func (s CloudSpecAPI) CloudSpec(args params.Entities) (params.CloudSpecResults, 
 			results.Results[i].Error = common.ServerError(common.ErrPerm)
 			continue
 		}
-		spec, err := s.getCloudSpec(tag)
-		if err != nil {
-			results.Results[i].Error = common.ServerError(err)
-			continue
-		}
-		var paramsCloudCredential *params.CloudCredential
-		if spec.Credential != nil && spec.Credential.AuthType() != "" {
-			paramsCloudCredential = &params.CloudCredential{
-				AuthType:   string(spec.Credential.AuthType()),
-				Attributes: spec.Credential.Attributes(),
-			}
-		}
-		results.Results[i].Result = &params.CloudSpec{
-			spec.Type,
-			spec.Name,
-			spec.Region,
-			spec.Endpoint,
-			spec.IdentityEndpoint,
-			spec.StorageEndpoint,
-			paramsCloudCredential,
-		}
+		results.Results[i] = s.GetCloudSpec(tag)
 	}
 	return results, nil
+}
+
+// GetCloudSpec constucts the CloudSpec for a validated and authorized model.
+func (s CloudSpecAPI) GetCloudSpec(tag names.ModelTag) params.CloudSpecResult {
+	var result params.CloudSpecResult
+	spec, err := s.getCloudSpec(tag)
+	if err != nil {
+		result.Error = common.ServerError(err)
+		return result
+	}
+	var paramsCloudCredential *params.CloudCredential
+	if spec.Credential != nil && spec.Credential.AuthType() != "" {
+		paramsCloudCredential = &params.CloudCredential{
+			AuthType:   string(spec.Credential.AuthType()),
+			Attributes: spec.Credential.Attributes(),
+		}
+	}
+	result.Result = &params.CloudSpec{
+		spec.Type,
+		spec.Name,
+		spec.Region,
+		spec.Endpoint,
+		spec.IdentityEndpoint,
+		spec.StorageEndpoint,
+		paramsCloudCredential,
+	}
+	return result
 }

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -40,6 +40,7 @@ type Controller interface {
 	AllModels() (params.UserModelList, error)
 	DestroyController(args params.DestroyControllerArgs) error
 	ModelConfig() (params.ModelConfigResults, error)
+	HostedModelConfig() (params.HostedModelConfigResults, error)
 	GetControllerAccess(params.Entities) (params.UserAccessResults, error)
 	ControllerConfig() (params.ControllerConfigResult, error)
 	ListBlockedModels() (params.ModelBlockInfoList, error)
@@ -230,6 +231,49 @@ func (s *ControllerAPI) ModelConfig() (params.ModelConfigResults, error) {
 			Value: val,
 		}
 	}
+	return result, nil
+}
+
+// HostedModelConfig returns all the information that the client needs
+// in order to connect directly with the host model's provider and destroy
+// it directly.
+func (s *ControllerAPI) HostedModelConfig() (params.HostedModelConfigResults, error) {
+	result := params.HostedModelConfigResults{}
+	if err := s.checkHasAdmin(); err != nil {
+		return result, errors.Trace(err)
+	}
+
+	controllerModel, err := s.state.ControllerModel()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	allModels, err := s.state.AllModels()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	for _, model := range allModels {
+		if model.UUID() != controllerModel.UUID() {
+			config := params.HostedModelConfig{
+				Name:     model.Name(),
+				OwnerTag: model.Owner().String(),
+			}
+			modelConf, err := model.Config()
+			if err != nil {
+				config.Error = common.ServerError(err)
+			} else {
+				config.Config = modelConf.AllAttrs()
+			}
+			cloudSpec := s.GetCloudSpec(model.ModelTag())
+			if config.Error == nil {
+				config.CloudSpec = cloudSpec.Result
+				config.Error = cloudSpec.Error
+			}
+			result.Models = append(result.Models, config)
+		}
+	}
+
 	return result, nil
 }
 

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -40,7 +40,7 @@ type Controller interface {
 	AllModels() (params.UserModelList, error)
 	DestroyController(args params.DestroyControllerArgs) error
 	ModelConfig() (params.ModelConfigResults, error)
-	HostedModelConfig() (params.HostedModelConfigResults, error)
+	HostedModelConfigs() (params.HostedModelConfigsResults, error)
 	GetControllerAccess(params.Entities) (params.UserAccessResults, error)
 	ControllerConfig() (params.ControllerConfigResult, error)
 	ListBlockedModels() (params.ModelBlockInfoList, error)
@@ -234,11 +234,11 @@ func (s *ControllerAPI) ModelConfig() (params.ModelConfigResults, error) {
 	return result, nil
 }
 
-// HostedModelConfig returns all the information that the client needs
-// in order to connect directly with the host model's provider and destroy
-// it directly.
-func (s *ControllerAPI) HostedModelConfig() (params.HostedModelConfigResults, error) {
-	result := params.HostedModelConfigResults{}
+// HostedModelConfigs returns all the information that the client needs in
+// order to connect directly with the host model's provider and destroy it
+// directly.
+func (s *ControllerAPI) HostedModelConfigs() (params.HostedModelConfigsResults, error) {
+	result := params.HostedModelConfigsResults{}
 	if err := s.checkHasAdmin(); err != nil {
 		return result, errors.Trace(err)
 	}

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -22,17 +22,20 @@ import (
 	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
-	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
+	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
 
 type controllerSuite struct {
-	jujutesting.JujuConnSuite
+	statetesting.StateSuite
 
 	controller *controller.ControllerAPI
 	resources  *common.Resources
@@ -42,12 +45,18 @@ type controllerSuite struct {
 var _ = gc.Suite(&controllerSuite{})
 
 func (s *controllerSuite) SetUpTest(c *gc.C) {
-	s.JujuConnSuite.SetUpTest(c)
+	// Initial config needs to be set before the StateSuite SetUpTest.
+	s.InitialConfig = testing.CustomModelConfig(c, testing.Attrs{
+		"name": "controller",
+	})
+
+	s.StateSuite.SetUpTest(c)
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		Tag: s.AdminUserTag(c),
+		Tag:      s.Owner,
+		AdminTag: s.Owner,
 	}
 
 	controller, err := controller.NewControllerAPI(s.State, s.resources, s.authorizer)
@@ -105,6 +114,76 @@ func (s *controllerSuite) TestAllModels(c *gc.C) {
 	c.Assert(obtained, jc.DeepEquals, expected)
 }
 
+func (s *controllerSuite) TestHostedModelConfig_OnlyHostedModelsReturned(c *gc.C) {
+	owner := s.Factory.MakeUser(c, nil)
+	s.Factory.MakeModel(c, &factory.ModelParams{
+		Name: "first", Owner: owner.UserTag()}).Close()
+	remoteUserTag := names.NewUserTag("user@remote")
+	s.Factory.MakeModel(c, &factory.ModelParams{
+		Name: "second", Owner: remoteUserTag}).Close()
+
+	results, err := s.controller.HostedModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(results.Models), gc.Equals, 2)
+
+	one := results.Models[0]
+	two := results.Models[1]
+
+	c.Assert(one.Name, gc.Equals, "first")
+	c.Assert(one.OwnerTag, gc.Equals, owner.UserTag().String())
+	c.Assert(two.Name, gc.Equals, "second")
+	c.Assert(two.OwnerTag, gc.Equals, remoteUserTag.String())
+}
+
+func (s *controllerSuite) makeCloudSpec(c *gc.C, pSpec *params.CloudSpec) environs.CloudSpec {
+	c.Assert(pSpec, gc.NotNil)
+	var credential *cloud.Credential
+	if pSpec.Credential != nil {
+		credentialValue := cloud.NewCredential(
+			cloud.AuthType(pSpec.Credential.AuthType),
+			pSpec.Credential.Attributes,
+		)
+		credential = &credentialValue
+	}
+	spec := environs.CloudSpec{
+		Type:             pSpec.Type,
+		Name:             pSpec.Name,
+		Region:           pSpec.Region,
+		Endpoint:         pSpec.Endpoint,
+		IdentityEndpoint: pSpec.IdentityEndpoint,
+		StorageEndpoint:  pSpec.StorageEndpoint,
+		Credential:       credential,
+	}
+	c.Assert(spec.Validate(), jc.ErrorIsNil)
+	return spec
+}
+
+func (s *controllerSuite) TestHostedModelConfig_CanOpenEnviron(c *gc.C) {
+	owner := s.Factory.MakeUser(c, nil)
+	s.Factory.MakeModel(c, &factory.ModelParams{
+		Name: "first", Owner: owner.UserTag()}).Close()
+	remoteUserTag := names.NewUserTag("user@remote")
+	s.Factory.MakeModel(c, &factory.ModelParams{
+		Name: "second", Owner: remoteUserTag}).Close()
+
+	results, err := s.controller.HostedModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(results.Models), gc.Equals, 2)
+
+	for _, model := range results.Models {
+		c.Assert(model.Error, gc.IsNil)
+
+		cfg, err := config.New(config.NoDefaults, model.Config)
+		c.Assert(err, jc.ErrorIsNil)
+		spec := s.makeCloudSpec(c, model.CloudSpec)
+		_, err = environs.New(environs.OpenParams{
+			Cloud:  spec,
+			Config: cfg,
+		})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}
+
 func (s *controllerSuite) TestListBlockedModels(c *gc.C) {
 	st := s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "test"})
@@ -122,7 +201,7 @@ func (s *controllerSuite) TestListBlockedModels(c *gc.C) {
 		params.ModelBlockInfo{
 			Name:     "controller",
 			UUID:     s.State.ModelUUID(),
-			OwnerTag: s.AdminUserTag(c).String(),
+			OwnerTag: s.Owner.String(),
 			Blocks: []string{
 				"BlockDestroy",
 				"BlockChange",
@@ -131,7 +210,7 @@ func (s *controllerSuite) TestListBlockedModels(c *gc.C) {
 		params.ModelBlockInfo{
 			Name:     "test",
 			UUID:     st.ModelUUID(),
-			OwnerTag: s.AdminUserTag(c).String(),
+			OwnerTag: s.Owner.String(),
 			Blocks: []string{
 				"BlockDestroy",
 				"BlockChange",
@@ -158,7 +237,10 @@ func (s *controllerSuite) TestModelConfigFromNonController(c *gc.C) {
 		Name: "test"})
 	defer st.Close()
 
-	authorizer := &apiservertesting.FakeAuthorizer{Tag: s.AdminUserTag(c)}
+	authorizer := &apiservertesting.FakeAuthorizer{
+		Tag:      s.Owner,
+		AdminTag: s.Owner,
+	}
 	controller, err := controller.NewControllerAPI(st, common.NewResources(), authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := controller.ModelConfig()
@@ -181,7 +263,7 @@ func (s *controllerSuite) TestControllerConfigFromNonController(c *gc.C) {
 		Name: "test"})
 	defer st.Close()
 
-	authorizer := &apiservertesting.FakeAuthorizer{Tag: s.AdminUserTag(c)}
+	authorizer := &apiservertesting.FakeAuthorizer{Tag: s.Owner}
 	controller, err := controller.NewControllerAPI(st, common.NewResources(), authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := controller.ControllerConfig()
@@ -301,7 +383,7 @@ func (s *controllerSuite) TestModelStatus(c *gc.C) {
 		ModelTag:           controllerEnvTag,
 		HostedMachineCount: 1,
 		ApplicationCount:   1,
-		OwnerTag:           "user-admin@local",
+		OwnerTag:           s.Owner.String(),
 		Life:               params.Alive,
 		Machines: []params.ModelMachineInfo{
 			{Id: "0", Hardware: &params.MachineHardware{Cores: &eight}, InstanceId: "id-4", Status: "pending", WantsVote: true},
@@ -381,7 +463,7 @@ func (s *controllerSuite) TestInitiateMigration(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(mig.Id(), gc.Equals, expectedId)
 		c.Check(mig.ModelUUID(), gc.Equals, st.ModelUUID())
-		c.Check(mig.InitiatedBy(), gc.Equals, s.AdminUserTag(c).Id())
+		c.Check(mig.InitiatedBy(), gc.Equals, s.Owner.Id())
 		c.Check(mig.ExternalControl(), gc.Equals, args.Specs[i].ExternalControl)
 
 		targetInfo, err := mig.TargetInfo()

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -114,7 +114,7 @@ func (s *controllerSuite) TestAllModels(c *gc.C) {
 	c.Assert(obtained, jc.DeepEquals, expected)
 }
 
-func (s *controllerSuite) TestHostedModelConfig_OnlyHostedModelsReturned(c *gc.C) {
+func (s *controllerSuite) TestHostedModelConfigs_OnlyHostedModelsReturned(c *gc.C) {
 	owner := s.Factory.MakeUser(c, nil)
 	s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "first", Owner: owner.UserTag()}).Close()
@@ -122,7 +122,7 @@ func (s *controllerSuite) TestHostedModelConfig_OnlyHostedModelsReturned(c *gc.C
 	s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "second", Owner: remoteUserTag}).Close()
 
-	results, err := s.controller.HostedModelConfig()
+	results, err := s.controller.HostedModelConfigs()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(results.Models), gc.Equals, 2)
 
@@ -158,7 +158,7 @@ func (s *controllerSuite) makeCloudSpec(c *gc.C, pSpec *params.CloudSpec) enviro
 	return spec
 }
 
-func (s *controllerSuite) TestHostedModelConfig_CanOpenEnviron(c *gc.C) {
+func (s *controllerSuite) TestHostedModelConfigs_CanOpenEnviron(c *gc.C) {
 	owner := s.Factory.MakeUser(c, nil)
 	s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "first", Owner: owner.UserTag()}).Close()
@@ -166,7 +166,7 @@ func (s *controllerSuite) TestHostedModelConfig_CanOpenEnviron(c *gc.C) {
 	s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "second", Owner: remoteUserTag}).Close()
 
-	results, err := s.controller.HostedModelConfig()
+	results, err := s.controller.HostedModelConfigs()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(results.Models), gc.Equals, 2)
 

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -23,7 +23,7 @@ type ModelConfigResults struct {
 }
 
 // HostedModelConfig contains the model config and the cloud spec
-// for the model, both things that the CLI needs to talk directly
+// for the model, both things that a client needs to talk directly
 // with the provider. This is used to take down mis-behaving models
 // aggressively.
 type HostedModelConfig struct {
@@ -34,9 +34,9 @@ type HostedModelConfig struct {
 	Error     *Error                 `json:"error,omitempty"`
 }
 
-// HostedModelConfigResults contains an entry for each hosted model
+// HostedModelConfigsResults contains an entry for each hosted model
 // in the controller.
-type HostedModelConfigResults struct {
+type HostedModelConfigsResults struct {
 	Models []HostedModelConfig `json:"models"`
 }
 

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -22,6 +22,24 @@ type ModelConfigResults struct {
 	Config map[string]ConfigValue `json:"config"`
 }
 
+// HostedModelConfig contains the model config and the cloud spec
+// for the model, both things that the CLI needs to talk directly
+// with the provider. This is used to take down mis-behaving models
+// aggressively.
+type HostedModelConfig struct {
+	Name      string                 `json:"name"`
+	OwnerTag  string                 `json:"owner"`
+	Config    map[string]interface{} `json:"config,omitempty"`
+	CloudSpec *CloudSpec             `json:"cloud-spec,omitempty"`
+	Error     *Error                 `json:"error,omitempty"`
+}
+
+// HostedModelConfigResults contains an entry for each hosted model
+// in the controller.
+type HostedModelConfigResults struct {
+	Models []HostedModelConfig `json:"models"`
+}
+
 // ModelDefaultsResult contains the result of client API calls to get the
 // model default values.
 type ModelDefaultsResult struct {

--- a/state/model.go
+++ b/state/model.go
@@ -142,7 +142,7 @@ func (st *State) AllModels() ([]*Model, error) {
 	defer closer()
 
 	var modelDocs []modelDoc
-	err := models.Find(nil).All(&modelDocs)
+	err := models.Find(nil).Sort("name", "owner").All(&modelDocs)
 	if err != nil {
 		return nil, err
 	}

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -795,11 +795,11 @@ func (s *ModelSuite) TestAllModels(c *gc.C) {
 		obtained = append(obtained, fmt.Sprintf("%s/%s", env.Owner().Canonical(), env.Name()))
 	}
 	expected := []string{
-		"test-admin@local/testenv",
 		"bob@remote/test",
 		"mary@remote/test",
+		"test-admin@local/testenv",
 	}
-	c.Assert(obtained, jc.SameContents, expected)
+	c.Assert(obtained, jc.DeepEquals, expected)
 }
 
 func (s *ModelSuite) TestHostedModelCount(c *gc.C) {

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -33,6 +33,7 @@ import (
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/catacomb"
+	"github.com/juju/juju/wrench"
 	"github.com/juju/version"
 )
 
@@ -465,6 +466,10 @@ func (task *provisionerTask) stopInstances(instances []instance.Instance) error 
 	if len(instances) == 0 {
 		return nil
 	}
+	if wrench.IsActive("provisioner", "stop-instances") {
+		return errors.New("wrench in the works")
+	}
+
 	ids := make([]instance.Id, len(instances))
 	for i, inst := range instances {
 		ids[i] = inst.Id()


### PR DESCRIPTION
This new API call is used in an upcoming PR that adds a timeout to the kill-controller command. Once the timeout is hit, the client will attempt to destroy all the models by talking to the provider directly. To do this, it needs to have the model's config and cloud config in order to be able to instantiate an Environ.

The facade version is not bumped as it is no danger to the client. If the client is newer than the server, which is possible for early RCs, then a timeout of 5 minutes will happen before the provider is invoked directly. The call will fail with NotImplemented, so will cause no further damage. kill-controller was written with the ability to call it more than once, so running the command again is expected behaviour.