### PR TITLE
Add a timeout to the kill-controller.

### DIFF
--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils/clock"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
@@ -75,6 +76,7 @@ Continue? (y/N):`[1:]
 type destroyControllerAPI interface {
 	Close() error
 	ModelConfig() (map[string]interface{}, error)
+	HostedModelConfigs() ([]controller.HostedConfig, error)
 	CloudSpec(names.ModelTag) (environs.CloudSpec, error)
 	DestroyController(destroyModels bool) error
 	ListBlockedModels() ([]params.ModelBlockInfo, error)
@@ -146,7 +148,7 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 			}
 		}
 
-		updateStatus := newTimedStatusUpdater(ctx, api, controllerEnviron.Config().UUID())
+		updateStatus := newTimedStatusUpdater(ctx, api, controllerEnviron.Config().UUID(), clock.WallClock)
 		ctrStatus, modelsStatus := updateStatus(0)
 		if !c.destroyModels {
 			if err := c.checkNoAliveHostedModels(ctx, modelsStatus); err != nil {

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
+	apicontroller "github.com/juju/juju/api/controller"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -54,12 +55,13 @@ type baseDestroySuite struct {
 // fakeDestroyAPI mocks out the controller API
 type fakeDestroyAPI struct {
 	gitjujutesting.Stub
-	cloud      environs.CloudSpec
-	env        map[string]interface{}
-	destroyAll bool
-	blocks     []params.ModelBlockInfo
-	envStatus  map[string]base.ModelStatus
-	allModels  []base.UserModel
+	cloud        environs.CloudSpec
+	env          map[string]interface{}
+	destroyAll   bool
+	blocks       []params.ModelBlockInfo
+	envStatus    map[string]base.ModelStatus
+	allModels    []base.UserModel
+	hostedConfig []apicontroller.HostedConfig
 }
 
 func (f *fakeDestroyAPI) Close() error {
@@ -81,6 +83,14 @@ func (f *fakeDestroyAPI) ModelConfig() (map[string]interface{}, error) {
 		return nil, err
 	}
 	return f.env, nil
+}
+
+func (f *fakeDestroyAPI) HostedModelConfigs() ([]apicontroller.HostedConfig, error) {
+	f.MethodCall(f, "HostedModelConfigs")
+	if err := f.NextErr(); err != nil {
+		return nil, err
+	}
+	return f.hostedConfig, nil
 }
 
 func (f *fakeDestroyAPI) DestroyController(destroyAll bool) error {

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -140,9 +140,9 @@ func KillTimeout(c *gc.C, command cmd.Command) time.Duration {
 }
 
 // KillWaitForModels calls the WaitForModels method of the kill command.
-func KillWaitForModels(command cmd.Command, ctx *cmd.Context, api destroyControllerAPI, cloudName, uuid string) error {
+func KillWaitForModels(command cmd.Command, ctx *cmd.Context, api destroyControllerAPI, uuid string) error {
 	kill := command.(*killCommand)
-	return kill.WaitForModels(ctx, api, cloudName, uuid)
+	return kill.WaitForModels(ctx, api, uuid)
 }
 
 // NewGetConfigCommandCommandForTest returns a GetConfigCommandCommand with

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -108,7 +108,7 @@ func (s *KillSuite) TestKillWaitForModels_AllGood(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := coretesting.Context(c)
-	err = controller.KillWaitForModels(inner, ctx, s.api, "magic", test1UUID)
+	err = controller.KillWaitForModels(inner, ctx, s.api, test1UUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(coretesting.Stderr(ctx), gc.Equals, "All hosted models reclaimed, cleaning up controller machines\n")
 }
@@ -129,7 +129,7 @@ func (s *KillSuite) TestKillWaitForModels_ActuallyWaits(c *gc.C) {
 	ctx := coretesting.Context(c)
 	result := make(chan error)
 	go func() {
-		err := controller.KillWaitForModels(inner, ctx, s.api, "magic", test1UUID)
+		err := controller.KillWaitForModels(inner, ctx, s.api, test1UUID)
 		result <- err
 	}()
 
@@ -176,7 +176,7 @@ func (s *KillSuite) TestKillWaitForModels_TimeoutResetsWithChange(c *gc.C) {
 	ctx := coretesting.Context(c)
 	result := make(chan error)
 	go func() {
-		err := controller.KillWaitForModels(inner, ctx, s.api, "magic", test1UUID)
+		err := controller.KillWaitForModels(inner, ctx, s.api, test1UUID)
 		result <- err
 	}()
 
@@ -203,9 +203,9 @@ func (s *KillSuite) TestKillWaitForModels_TimeoutResetsWithChange(c *gc.C) {
 		c.Fatal("timed out waiting for result")
 	}
 	expect := "" +
-		"Waiting on 1 model, 2 machines, 2 applications - will kill directly via magic in 20s\n" +
-		"Waiting on 1 model, 2 machines, 2 applications - will kill directly via magic in 15s\n" +
-		"Waiting on 1 model, 1 machine - will kill directly via magic in 20s\n" +
+		"Waiting on 1 model, 2 machines, 2 applications, will kill machines directly in 20s\n" +
+		"Waiting on 1 model, 2 machines, 2 applications, will kill machines directly in 15s\n" +
+		"Waiting on 1 model, 1 machine, will kill machines directly in 20s\n" +
 		"All hosted models reclaimed, cleaning up controller machines\n"
 
 	c.Assert(coretesting.Stderr(ctx), gc.Equals, expect)
@@ -227,7 +227,7 @@ func (s *KillSuite) TestKillWaitForModels_TimeoutWithNoChange(c *gc.C) {
 	ctx := coretesting.Context(c)
 	result := make(chan error)
 	go func() {
-		err := controller.KillWaitForModels(inner, ctx, s.api, "magic", test1UUID)
+		err := controller.KillWaitForModels(inner, ctx, s.api, test1UUID)
 		result <- err
 	}()
 
@@ -250,11 +250,11 @@ func (s *KillSuite) TestKillWaitForModels_TimeoutWithNoChange(c *gc.C) {
 		"Waiting on 1 model, 2 machines, 2 applications\n" +
 		"Waiting on 1 model, 2 machines, 2 applications\n" +
 		"Waiting on 1 model, 2 machines, 2 applications\n" +
-		"Waiting on 1 model, 2 machines, 2 applications - will kill directly via magic in 25s\n" +
-		"Waiting on 1 model, 2 machines, 2 applications - will kill directly via magic in 20s\n" +
-		"Waiting on 1 model, 2 machines, 2 applications - will kill directly via magic in 15s\n" +
-		"Waiting on 1 model, 2 machines, 2 applications - will kill directly via magic in 10s\n" +
-		"Waiting on 1 model, 2 machines, 2 applications - will kill directly via magic in 5s\n"
+		"Waiting on 1 model, 2 machines, 2 applications, will kill machines directly in 25s\n" +
+		"Waiting on 1 model, 2 machines, 2 applications, will kill machines directly in 20s\n" +
+		"Waiting on 1 model, 2 machines, 2 applications, will kill machines directly in 15s\n" +
+		"Waiting on 1 model, 2 machines, 2 applications, will kill machines directly in 10s\n" +
+		"Waiting on 1 model, 2 machines, 2 applications, will kill machines directly in 5s\n"
 
 	c.Assert(coretesting.Stderr(ctx), gc.Equals, expect)
 }
@@ -350,7 +350,7 @@ func (s *KillSuite) TestKillDestroysControllerWithAPIError(c *gc.C) {
 	s.api.SetErrors(errors.New("some destroy error"))
 	ctx, err := s.runKillCommand(c, "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(coretesting.Stderr(ctx), jc.Contains, "Unable to destroy controller through the API: some destroy error.  Destroying through provider.")
+	c.Check(coretesting.Stderr(ctx), jc.Contains, "Unable to destroy controller through the API: some destroy error\nDestroying through provider")
 	c.Assert(s.api.destroyAll, jc.IsTrue)
 	checkControllerRemovedFromStore(c, "test1", s.store)
 }

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
@@ -23,22 +24,39 @@ import (
 	cmdtesting "github.com/juju/juju/cmd/testing"
 	"github.com/juju/juju/jujuclient"
 	_ "github.com/juju/juju/provider/dummy"
-	"github.com/juju/juju/testing"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type KillSuite struct {
 	baseDestroySuite
+
+	clock *testing.Clock
 }
 
 var _ = gc.Suite(&KillSuite{})
 
+func (s *KillSuite) SetUpTest(c *gc.C) {
+	s.baseDestroySuite.SetUpTest(c)
+	s.clock = testing.NewClock(time.Now())
+}
+
 func (s *KillSuite) runKillCommand(c *gc.C, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c, s.newKillCommand(), args...)
+	return coretesting.RunCommand(c, s.newKillCommand(), args...)
 }
 
 func (s *KillSuite) newKillCommand() cmd.Command {
+	wrapped, _ := controller.NewKillCommandForTest(
+		s.api, s.clientapi, s.store, s.apierror, s.clock, nil)
+	return wrapped
+}
+
+func (s *KillSuite) newKillCommandBoth() (cmd.Command, cmd.Command) {
+	clock := s.clock
+	if clock == nil {
+		clock = testing.NewClock(time.Now())
+	}
 	return controller.NewKillCommandForTest(
-		s.api, s.clientapi, s.store, s.apierror, &mockClock{}, nil)
+		s.api, s.clientapi, s.store, s.apierror, clock, nil)
 }
 
 func (s *KillSuite) TestKillNoControllerNameError(c *gc.C) {
@@ -49,6 +67,238 @@ func (s *KillSuite) TestKillNoControllerNameError(c *gc.C) {
 func (s *KillSuite) TestKillBadFlags(c *gc.C) {
 	_, err := s.runKillCommand(c, "-n")
 	c.Assert(err, gc.ErrorMatches, "flag provided but not defined: -n")
+}
+
+func (s *KillSuite) TestKillDurationFlags(c *gc.C) {
+	for i, test := range []struct {
+		args     []string
+		expected time.Duration
+		err      string
+	}{
+		{
+			expected: 5 * time.Minute,
+		}, {
+			args:     []string{"-t", "2m"},
+			expected: 2 * time.Minute,
+		}, {
+			args:     []string{"--timeout", "2m"},
+			expected: 2 * time.Minute,
+		}, {
+			args:     []string{"-t", "0"},
+			expected: 0,
+		},
+	} {
+		c.Logf("duration test %d", i)
+		wrapped, inner := s.newKillCommandBoth()
+		args := append([]string{"test1"}, test.args...)
+		err := coretesting.InitCommand(wrapped, args)
+		if test.err == "" {
+			c.Check(err, jc.ErrorIsNil)
+			c.Check(controller.KillTimeout(c, inner), gc.Equals, test.expected)
+		} else {
+			c.Check(err, gc.ErrorMatches, test.err)
+		}
+	}
+}
+
+func (s *KillSuite) TestKillWaitForModels_AllGood(c *gc.C) {
+	s.resetAPIModels(c)
+	wrapped, inner := s.newKillCommandBoth()
+	err := coretesting.InitCommand(wrapped, []string{"test1", "--timeout=1m"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx := coretesting.Context(c)
+	err = controller.KillWaitForModels(inner, ctx, s.api, "magic", test1UUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(coretesting.Stderr(ctx), gc.Equals, "All hosted models reclaimed, cleaning up controller machines\n")
+}
+
+func (s *KillSuite) TestKillWaitForModels_ActuallyWaits(c *gc.C) {
+	s.resetAPIModels(c)
+	s.addModel("model-1", base.ModelStatus{
+		UUID:               test2UUID,
+		Life:               string(params.Dying),
+		Owner:              "admin",
+		HostedMachineCount: 2,
+		ServiceCount:       2,
+	})
+	wrapped, inner := s.newKillCommandBoth()
+	err := coretesting.InitCommand(wrapped, []string{"test1", "--timeout=1m"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx := coretesting.Context(c)
+	result := make(chan error)
+	go func() {
+		err := controller.KillWaitForModels(inner, ctx, s.api, "magic", test1UUID)
+		result <- err
+	}()
+
+	s.syncClockAlarm(c)
+	s.setModelStatus(base.ModelStatus{
+		UUID:               test2UUID,
+		Life:               string(params.Dying),
+		Owner:              "admin",
+		HostedMachineCount: 1,
+	})
+	s.clock.Advance(5 * time.Second)
+
+	s.syncClockAlarm(c)
+	s.removeModel(test2UUID)
+	s.clock.Advance(5 * time.Second)
+
+	select {
+	case err := <-result:
+		c.Assert(err, jc.ErrorIsNil)
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for result")
+	}
+	expect := "" +
+		"Waiting on 1 model, 2 machines, 2 applications\n" +
+		"Waiting on 1 model, 1 machine\n" +
+		"All hosted models reclaimed, cleaning up controller machines\n"
+
+	c.Assert(coretesting.Stderr(ctx), gc.Equals, expect)
+}
+
+func (s *KillSuite) TestKillWaitForModels_TimeoutResetsWithChange(c *gc.C) {
+	s.resetAPIModels(c)
+	s.addModel("model-1", base.ModelStatus{
+		UUID:               test2UUID,
+		Life:               string(params.Dying),
+		Owner:              "admin",
+		HostedMachineCount: 2,
+		ServiceCount:       2,
+	})
+	wrapped, inner := s.newKillCommandBoth()
+	err := coretesting.InitCommand(wrapped, []string{"test1", "--timeout=20s"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx := coretesting.Context(c)
+	result := make(chan error)
+	go func() {
+		err := controller.KillWaitForModels(inner, ctx, s.api, "magic", test1UUID)
+		result <- err
+	}()
+
+	s.syncClockAlarm(c)
+	s.clock.Advance(5 * time.Second)
+
+	s.syncClockAlarm(c)
+	s.setModelStatus(base.ModelStatus{
+		UUID:               test2UUID,
+		Life:               string(params.Dying),
+		Owner:              "admin",
+		HostedMachineCount: 1,
+	})
+	s.clock.Advance(5 * time.Second)
+
+	s.syncClockAlarm(c)
+	s.removeModel(test2UUID)
+	s.clock.Advance(5 * time.Second)
+
+	select {
+	case err := <-result:
+		c.Assert(err, jc.ErrorIsNil)
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for result")
+	}
+	expect := "" +
+		"Waiting on 1 model, 2 machines, 2 applications - will kill directly via magic in 20s\n" +
+		"Waiting on 1 model, 2 machines, 2 applications - will kill directly via magic in 15s\n" +
+		"Waiting on 1 model, 1 machine - will kill directly via magic in 20s\n" +
+		"All hosted models reclaimed, cleaning up controller machines\n"
+
+	c.Assert(coretesting.Stderr(ctx), gc.Equals, expect)
+}
+
+func (s *KillSuite) TestKillWaitForModels_TimeoutWithNoChange(c *gc.C) {
+	s.resetAPIModels(c)
+	s.addModel("model-1", base.ModelStatus{
+		UUID:               test2UUID,
+		Life:               string(params.Dying),
+		Owner:              "admin",
+		HostedMachineCount: 2,
+		ServiceCount:       2,
+	})
+	wrapped, inner := s.newKillCommandBoth()
+	err := coretesting.InitCommand(wrapped, []string{"test1", "--timeout=1m"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx := coretesting.Context(c)
+	result := make(chan error)
+	go func() {
+		err := controller.KillWaitForModels(inner, ctx, s.api, "magic", test1UUID)
+		result <- err
+	}()
+
+	for i := 0; i < 12; i++ {
+		s.syncClockAlarm(c)
+		s.clock.Advance(5 * time.Second)
+	}
+
+	select {
+	case err := <-result:
+		c.Assert(err, gc.ErrorMatches, "timed out")
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for result")
+	}
+	expect := "" +
+		"Waiting on 1 model, 2 machines, 2 applications\n" +
+		"Waiting on 1 model, 2 machines, 2 applications\n" +
+		"Waiting on 1 model, 2 machines, 2 applications\n" +
+		"Waiting on 1 model, 2 machines, 2 applications\n" +
+		"Waiting on 1 model, 2 machines, 2 applications\n" +
+		"Waiting on 1 model, 2 machines, 2 applications\n" +
+		"Waiting on 1 model, 2 machines, 2 applications\n" +
+		"Waiting on 1 model, 2 machines, 2 applications - will kill directly via magic in 25s\n" +
+		"Waiting on 1 model, 2 machines, 2 applications - will kill directly via magic in 20s\n" +
+		"Waiting on 1 model, 2 machines, 2 applications - will kill directly via magic in 15s\n" +
+		"Waiting on 1 model, 2 machines, 2 applications - will kill directly via magic in 10s\n" +
+		"Waiting on 1 model, 2 machines, 2 applications - will kill directly via magic in 5s\n"
+
+	c.Assert(coretesting.Stderr(ctx), gc.Equals, expect)
+}
+
+func (s *KillSuite) resetAPIModels(c *gc.C) {
+	s.api.allModels = nil
+	s.api.envStatus = map[string]base.ModelStatus{}
+	s.addModel("controller", base.ModelStatus{
+		UUID:              test1UUID,
+		Life:              string(params.Alive),
+		Owner:             "admin",
+		TotalMachineCount: 1,
+	})
+}
+
+func (s *KillSuite) addModel(name string, status base.ModelStatus) {
+	s.api.allModels = append(s.api.allModels, base.UserModel{
+		Name:  name,
+		UUID:  status.UUID,
+		Owner: status.Owner,
+	})
+	s.api.envStatus[status.UUID] = status
+}
+
+func (s *KillSuite) setModelStatus(status base.ModelStatus) {
+	s.api.envStatus[status.UUID] = status
+}
+
+func (s *KillSuite) removeModel(uuid string) {
+	for i, v := range s.api.allModels {
+		if v.UUID == uuid {
+			s.api.allModels = append(s.api.allModels[:i], s.api.allModels[i+1:]...)
+			break
+		}
+	}
+	delete(s.api.envStatus, uuid)
+}
+
+func (s *KillSuite) syncClockAlarm(c *gc.C) {
+	select {
+	case <-s.clock.Alarms():
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for test clock After call")
+	}
 }
 
 func (s *KillSuite) TestKillUnknownArgument(c *gc.C) {
@@ -65,7 +315,7 @@ func (s *KillSuite) TestKillCannotConnectToAPISucceeds(c *gc.C) {
 	s.apierror = errors.New("connection refused")
 	ctx, err := s.runKillCommand(c, "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(testing.Stderr(ctx), jc.Contains, "Unable to open API: connection refused")
+	c.Check(coretesting.Stderr(ctx), jc.Contains, "Unable to open API: connection refused")
 	checkControllerRemovedFromStore(c, "test1", s.store)
 }
 
@@ -100,7 +350,7 @@ func (s *KillSuite) TestKillDestroysControllerWithAPIError(c *gc.C) {
 	s.api.SetErrors(errors.New("some destroy error"))
 	ctx, err := s.runKillCommand(c, "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(testing.Stderr(ctx), jc.Contains, "Unable to destroy controller through the API: some destroy error.  Destroying through provider.")
+	c.Check(coretesting.Stderr(ctx), jc.Contains, "Unable to destroy controller through the API: some destroy error.  Destroying through provider.")
 	c.Assert(s.api.destroyAll, jc.IsTrue)
 	checkControllerRemovedFromStore(c, "test1", s.store)
 }
@@ -118,15 +368,15 @@ func (s *KillSuite) TestKillCommandConfirmation(c *gc.C) {
 	select {
 	case err := <-errc:
 		c.Check(err, gc.ErrorMatches, "controller destruction aborted")
-	case <-time.After(testing.LongWait):
+	case <-time.After(coretesting.LongWait):
 		c.Fatalf("command took too long")
 	}
-	c.Check(testing.Stdout(ctx), gc.Matches, "WARNING!.*test1(.|\n)*")
+	c.Check(coretesting.Stdout(ctx), gc.Matches, "WARNING!.*test1(.|\n)*")
 	checkControllerExistsInStore(c, "test1", s.store)
 }
 
 func (s *KillSuite) TestKillCommandControllerAlias(c *gc.C) {
-	_, err := testing.RunCommand(c, s.newKillCommand(), "test1", "-y")
+	_, err := coretesting.RunCommand(c, s.newKillCommand(), "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
 	checkControllerRemovedFromStore(c, "test1:test1", s.store)
 }
@@ -135,8 +385,8 @@ func (s *KillSuite) TestKillAPIPermErrFails(c *gc.C) {
 	testDialer := func(_ jujuclient.ClientStore, controllerName, modelName string) (api.Connection, error) {
 		return nil, common.ErrPerm
 	}
-	cmd := controller.NewKillCommandForTest(nil, nil, s.store, nil, clock.WallClock, modelcmd.OpenFunc(testDialer))
-	_, err := testing.RunCommand(c, cmd, "test1", "-y")
+	cmd, _ := controller.NewKillCommandForTest(nil, nil, s.store, nil, clock.WallClock, modelcmd.OpenFunc(testDialer))
+	_, err := coretesting.RunCommand(c, cmd, "test1", "-y")
 	c.Assert(err, gc.ErrorMatches, "cannot destroy controller: permission denied")
 	checkControllerExistsInStore(c, "test1", s.store)
 }
@@ -151,10 +401,10 @@ func (s *KillSuite) TestKillEarlyAPIConnectionTimeout(c *gc.C) {
 		return nil, errors.New("kill command waited too long")
 	}
 
-	cmd := controller.NewKillCommandForTest(nil, nil, s.store, nil, clock, modelcmd.OpenFunc(testDialer))
-	ctx, err := testing.RunCommand(c, cmd, "test1", "-y")
+	cmd, _ := controller.NewKillCommandForTest(nil, nil, s.store, nil, clock, modelcmd.OpenFunc(testDialer))
+	ctx, err := coretesting.RunCommand(c, cmd, "test1", "-y")
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(testing.Stderr(ctx), jc.Contains, "Unable to open API: open connection timed out")
+	c.Check(coretesting.Stderr(ctx), jc.Contains, "Unable to open API: open connection timed out")
 	checkControllerRemovedFromStore(c, "test1", s.store)
 	// Check that we were actually told to wait for 10s.
 	c.Assert(clock.wait, gc.Equals, 10*time.Second)

--- a/cmd/juju/controller/killstatus.go
+++ b/cmd/juju/controller/killstatus.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/utils/clock"
 	"gopkg.in/juju/names.v2"
 )
 
@@ -33,9 +34,11 @@ type modelData struct {
 
 // newTimedStatusUpdater returns a function which waits a given period of time
 // before querying the apiserver for updated data.
-func newTimedStatusUpdater(ctx *cmd.Context, api destroyControllerAPI, controllerModelUUID string) func(time.Duration) (ctrData, []modelData) {
+func newTimedStatusUpdater(ctx *cmd.Context, api destroyControllerAPI, controllerModelUUID string, clock clock.Clock) func(time.Duration) (ctrData, []modelData) {
 	return func(wait time.Duration) (ctrData, []modelData) {
-		time.Sleep(wait)
+		if wait > 0 {
+			<-clock.After(wait)
+		}
 
 		// If we hit an error, status.HostedModelCount will be 0, the polling
 		// loop will stop and we'll go directly to destroying the model.


### PR DESCRIPTION
This branch adds a timeout option to kill-controller.

The timeout is the amount of time the command will wait for a change in the controller summary, which counts the number of hosted models, machines and applications that still need to be torn down. If there is no change in the specified time, the command switches to a direct destruction mode where the commands calls the server to get the configuration for all the remaining models. The client then destroys them directly.

## QA

Started three different LXD controllers, and deployed ubuntu into each of the default models.
One of them was killed with a timeout set to zero.
Another used the default timeout, which is 5m.
The third added a wrench to the provisioner so it couldn't destroy the machine, leading to to fall back to direct destruction.

Details here: http://pastebin.ubuntu.com/23232497/