### PR TITLE
Fix 1604965: machine stays in pending state even though node has been marked failed deployment in MAAS

### DIFF
--- a/apiserver/instancepoller/instancepoller.go
+++ b/apiserver/instancepoller/instancepoller.go
@@ -212,6 +212,12 @@ func (a *InstancePollerAPI) SetInstanceStatus(args params.SetStatus) (params.Err
 				Since:   &now,
 			}
 			err = machine.SetInstanceStatus(s)
+			if status.Status(arg.Status) == status.ProvisioningError {
+				s.Status = status.Error
+				if err == nil {
+					err = machine.SetStatus(s)
+				}
+			}
 		}
 		result.Results[i].Error = common.ServerError(err)
 	}

--- a/apiserver/instancepoller/state.go
+++ b/apiserver/instancepoller/state.go
@@ -20,6 +20,7 @@ type StateMachine interface {
 	SetProviderAddresses(...network.Address) error
 	InstanceStatus() (status.StatusInfo, error)
 	SetInstanceStatus(status.StatusInfo) error
+	SetStatus(status.StatusInfo) error
 	String() string
 	Refresh() error
 	Life() state.Life

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -809,6 +809,12 @@ func (p *ProvisionerAPI) SetInstanceStatus(args params.SetStatus) (params.ErrorR
 				Since:   &now,
 			}
 			err = machine.SetInstanceStatus(s)
+			if status.Status(arg.Status) == status.ProvisioningError {
+				s.Status = status.Error
+				if err == nil {
+					err = machine.SetStatus(s)
+				}
+			}
 		}
 		result.Results[i].Error = common.ServerError(err)
 	}

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -741,7 +741,7 @@ func (environ *maasEnviron) acquireNode2(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &maas2Instance{machine, constraintMatches}, nil
+	return &maas2Instance{machine, constraintMatches, environ.maasController}, nil
 }
 
 // acquireNode allocates a node from the MAAS.
@@ -843,7 +843,7 @@ func (environ *maasEnviron) startNode2(node maas2Instance, series string, userda
 		return nil, errors.Trace(err)
 	}
 	// Machine.Start updates the machine in-place when it succeeds.
-	return &maas2Instance{machine: node.machine}, nil
+	return &maas2Instance{machine: node.machine, maasController: environ.maasController}, nil
 
 }
 
@@ -1533,7 +1533,7 @@ func (environ *maasEnviron) instances2(args gomaasapi.MachinesArgs) ([]instance.
 	}
 	instances := make([]instance.Instance, len(machines))
 	for index, machine := range machines {
-		instances[index] = &maas2Instance{machine: machine}
+		instances[index] = &maas2Instance{machine: machine, maasController: environ.maasController}
 	}
 	return instances, nil
 }

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -743,7 +743,7 @@ func (environ *maasEnviron) acquireNode2(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &maas2Instance{machine, constraintMatches, environ.maasController}, nil
+	return &maas2Instance{machine, constraintMatches}, nil
 }
 
 // acquireNode allocates a node from the MAAS.
@@ -845,7 +845,7 @@ func (environ *maasEnviron) startNode2(node maas2Instance, series string, userda
 		return nil, errors.Trace(err)
 	}
 	// Machine.Start updates the machine in-place when it succeeds.
-	return &maas2Instance{machine: node.machine, maasController: environ.maasController}, nil
+	return &maas2Instance{machine: node.machine}, nil
 
 }
 
@@ -1536,7 +1536,7 @@ func (environ *maasEnviron) instances2(args gomaasapi.MachinesArgs) ([]instance.
 	}
 	instances := make([]instance.Instance, len(machines))
 	for index, machine := range machines {
-		instances[index] = &maas2Instance{machine: machine, maasController: environ.maasController}
+		instances[index] = &maas2Instance{machine: machine}
 	}
 	return instances, nil
 }

--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -51,20 +51,24 @@ func maasObjectId(maasObject *gomaasapi.MAASObject) instance.Id {
 	return instance.Id(maasObject.URI().String())
 }
 
+func normalizeStatus(statusMsg string) string {
+	return strings.ToLower(strings.TrimSpace(statusMsg))
+}
+
 func convertInstanceStatus(statusMsg, substatus string, id instance.Id) instance.InstanceStatus {
 	maasInstanceStatus := status.Empty
-	switch statusMsg {
+	switch normalizeStatus(statusMsg) {
 	case "":
 		logger.Debugf("unable to obtain status of instance %s", id)
 		statusMsg = "error in getting status"
-	case "Deployed":
+	case "deployed":
 		maasInstanceStatus = status.Running
-	case "Deploying":
+	case "deploying":
 		maasInstanceStatus = status.Allocating
 		if substatus != "" {
 			statusMsg = fmt.Sprintf("%s: %s", statusMsg, substatus)
 		}
-	case "Failed Deployment", "Failed deployment":
+	case "failed deployment":
 		maasInstanceStatus = status.ProvisioningError
 		if substatus != "" {
 			statusMsg = fmt.Sprintf("%s: %s", statusMsg, substatus)

--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -64,7 +64,7 @@ func convertInstanceStatus(statusMsg, substatus string, id instance.Id) instance
 		if substatus != "" {
 			statusMsg = fmt.Sprintf("%s: %s", statusMsg, substatus)
 		}
-	case "Failed Deployment":
+	case "Failed Deployment", "Failed deployment":
 		maasInstanceStatus = status.ProvisioningError
 		if substatus != "" {
 			statusMsg = fmt.Sprintf("%s: %s", statusMsg, substatus)

--- a/provider/maas/interfaces_test.go
+++ b/provider/maas/interfaces_test.go
@@ -806,8 +806,7 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 		GatewayAddress:      newAddressOnSpaceWithId("storage", network.Id("3"), "10.250.19.2"),
 	}}
 	machine := &fakeMachine{interfaceSet: exampleInterfaces}
-	instance := &maas2Instance{machine: machine,
-		maasController: &fakeMachineOnlyController{[]gomaasapi.Machine{machine}}}
+	instance := &maas2Instance{machine: machine}
 
 	infos, err := maas2NetworkInterfaces(instance, subnetsMap)
 	c.Assert(err, jc.ErrorIsNil)
@@ -849,8 +848,7 @@ func (s *interfacesSuite) TestMAAS2InterfacesNilVLAN(c *gc.C) {
 		},
 	}
 	machine := &fakeMachine{interfaceSet: exampleInterfaces}
-	instance := &maas2Instance{machine: machine,
-		maasController: &fakeMachineOnlyController{[]gomaasapi.Machine{machine}}}
+	instance := &maas2Instance{machine: machine}
 
 	expected := []network.InterfaceInfo{{
 		DeviceIndex:       0,

--- a/provider/maas/interfaces_test.go
+++ b/provider/maas/interfaces_test.go
@@ -805,8 +805,9 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 		MTU:                 1500,
 		GatewayAddress:      newAddressOnSpaceWithId("storage", network.Id("3"), "10.250.19.2"),
 	}}
-
-	instance := &maas2Instance{machine: &fakeMachine{interfaceSet: exampleInterfaces}}
+	machine := &fakeMachine{interfaceSet: exampleInterfaces}
+	instance := &maas2Instance{machine: machine,
+		maasController: &fakeMachineOnlyController{[]gomaasapi.Machine{machine}}}
 
 	infos, err := maas2NetworkInterfaces(instance, subnetsMap)
 	c.Assert(err, jc.ErrorIsNil)
@@ -847,8 +848,9 @@ func (s *interfacesSuite) TestMAAS2InterfacesNilVLAN(c *gc.C) {
 			children: []string{"eth0.100", "eth0.250", "eth0.50"},
 		},
 	}
-
-	instance := &maas2Instance{machine: &fakeMachine{interfaceSet: exampleInterfaces}}
+	machine := &fakeMachine{interfaceSet: exampleInterfaces}
+	instance := &maas2Instance{machine: machine,
+		maasController: &fakeMachineOnlyController{[]gomaasapi.Machine{machine}}}
 
 	expected := []network.InterfaceInfo{{
 		DeviceIndex:       0,

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -184,6 +184,14 @@ func (c *fakeController) ReleaseMachines(args gomaasapi.ReleaseMachinesArgs) err
 	return c.NextErr()
 }
 
+type fakeMachineOnlyController struct {
+	machines []gomaasapi.Machine
+}
+
+func (f *fakeMachineOnlyController) Machines(gomaasapi.MachinesArgs) ([]gomaasapi.Machine, error) {
+	return f.machines, nil
+}
+
 type fakeBootResource struct {
 	gomaasapi.BootResource
 	name         string

--- a/provider/maas/maas2instance.go
+++ b/provider/maas/maas2instance.go
@@ -67,7 +67,6 @@ func (mi *maas2Instance) Addresses() ([]network.Address, error) {
 // Status returns a juju status based on the maas instance returned
 // status message.
 func (mi *maas2Instance) Status() instance.InstanceStatus {
-	// TODO (babbageclunk): this should rerequest to get live status.
 	args := gomaasapi.MachinesArgs{SystemIDs: []string{mi.machine.SystemID()}}
 	machines, err := mi.maasController.Machines(args)
 	if err != nil {

--- a/provider/maas/maas2instance_test.go
+++ b/provider/maas/maas2instance_test.go
@@ -4,7 +4,6 @@
 package maas
 
 import (
-	"github.com/juju/gomaasapi"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -21,15 +20,13 @@ var _ = gc.Suite(&maas2InstanceSuite{})
 
 func (s *maas2InstanceSuite) TestString(c *gc.C) {
 	machine := &fakeMachine{hostname: "peewee", systemID: "herman"}
-	instance := &maas2Instance{machine: machine,
-		maasController: &fakeMachineOnlyController{[]gomaasapi.Machine{machine}}}
+	instance := &maas2Instance{machine: machine}
 	c.Assert(instance.String(), gc.Equals, "peewee:herman")
 }
 
 func (s *maas2InstanceSuite) TestID(c *gc.C) {
 	machine := &fakeMachine{systemID: "herman"}
-	thing := &maas2Instance{machine: machine,
-		maasController: &fakeMachineOnlyController{[]gomaasapi.Machine{machine}}}
+	thing := &maas2Instance{machine: machine}
 	c.Assert(thing.Id(), gc.Equals, instance.Id("herman"))
 }
 
@@ -39,8 +36,7 @@ func (s *maas2InstanceSuite) TestAddresses(c *gc.C) {
 		"1.2.3.4",
 		"127.0.0.1",
 	}}
-	instance := &maas2Instance{machine: machine,
-		maasController: &fakeMachineOnlyController{[]gomaasapi.Machine{machine}}}
+	instance := &maas2Instance{machine: machine}
 	expectedAddresses := []network.Address{
 		network.NewAddress("0.0.0.0"),
 		network.NewAddress("1.2.3.4"),
@@ -53,8 +49,7 @@ func (s *maas2InstanceSuite) TestAddresses(c *gc.C) {
 
 func (s *maas2InstanceSuite) TestZone(c *gc.C) {
 	machine := &fakeMachine{zoneName: "inflatable"}
-	instance := &maas2Instance{machine: machine,
-		maasController: &fakeMachineOnlyController{[]gomaasapi.Machine{machine}}}
+	instance := &maas2Instance{machine: machine}
 	zone, err := instance.zone()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(zone, gc.Equals, "inflatable")
@@ -62,24 +57,21 @@ func (s *maas2InstanceSuite) TestZone(c *gc.C) {
 
 func (s *maas2InstanceSuite) TestStatusSuccess(c *gc.C) {
 	machine := &fakeMachine{statusMessage: "Wexler", statusName: "Deploying"}
-	thing := &maas2Instance{machine: machine,
-		maasController: &fakeMachineOnlyController{[]gomaasapi.Machine{machine}}}
+	thing := &maas2Instance{machine: machine}
 	result := thing.Status()
 	c.Assert(result, jc.DeepEquals, instance.InstanceStatus{status.Allocating, "Deploying: Wexler"})
 }
 
 func (s *maas2InstanceSuite) TestStatusError(c *gc.C) {
 	machine := &fakeMachine{statusMessage: "", statusName: ""}
-	thing := &maas2Instance{machine: machine,
-		maasController: &fakeMachineOnlyController{[]gomaasapi.Machine{machine}}}
+	thing := &maas2Instance{machine: machine}
 	result := thing.Status()
 	c.Assert(result, jc.DeepEquals, instance.InstanceStatus{"", "error in getting status"})
 }
 
 func (s *maas2InstanceSuite) TestHostname(c *gc.C) {
 	machine := &fakeMachine{hostname: "saul-goodman"}
-	thing := &maas2Instance{machine: machine,
-		maasController: &fakeMachineOnlyController{[]gomaasapi.Machine{machine}}}
+	thing := &maas2Instance{machine: machine}
 	result, err := thing.hostname()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.Equals, "saul-goodman")
@@ -93,8 +85,7 @@ func (s *maas2InstanceSuite) TestHardwareCharacteristics(c *gc.C) {
 		zoneName:     "bar",
 		tags:         []string{"foo", "bar"},
 	}
-	thing := &maas2Instance{machine: machine,
-		maasController: &fakeMachineOnlyController{[]gomaasapi.Machine{machine}}}
+	thing := &maas2Instance{machine: machine}
 	arch := "foo"
 	cpu := uint64(3)
 	mem := uint64(4)

--- a/provider/maas/volumes_test.go
+++ b/provider/maas/volumes_test.go
@@ -76,7 +76,8 @@ func (s *volumeSuite) TestBuildMAASVolumeParametersWithTags(c *gc.C) {
 
 func (s *volumeSuite) TestInstanceVolumesMAAS2(c *gc.C) {
 	instance := maas2Instance{
-		machine: &fakeMachine{},
+		machine:        &fakeMachine{},
+		maasController: &fakeMachineOnlyController{[]gomaasapi.Machine{&fakeMachine{}}},
 		constraintMatches: gomaasapi.ConstraintMatches{
 			Storage: map[string][]gomaasapi.BlockDevice{
 				"root": {&fakeBlockDevice{name: "sda", path: "/dev/disk/by-dname/sda", size: 250059350016}},

--- a/provider/maas/volumes_test.go
+++ b/provider/maas/volumes_test.go
@@ -76,8 +76,7 @@ func (s *volumeSuite) TestBuildMAASVolumeParametersWithTags(c *gc.C) {
 
 func (s *volumeSuite) TestInstanceVolumesMAAS2(c *gc.C) {
 	instance := maas2Instance{
-		machine:        &fakeMachine{},
-		maasController: &fakeMachineOnlyController{[]gomaasapi.Machine{&fakeMachine{}}},
+		machine: &fakeMachine{},
 		constraintMatches: gomaasapi.ConstraintMatches{
 			Storage: map[string][]gomaasapi.BlockDevice{
 				"root": {&fakeBlockDevice{name: "sda", path: "/dev/disk/by-dname/sda", size: 250059350016}},

--- a/worker/instancepoller/updater.go
+++ b/worker/instancepoller/updater.go
@@ -271,6 +271,7 @@ func pollInstanceInfo(context machineContext, m machine) (instInfo instanceInfo,
 				return instanceInfo{}, err
 			}
 		}
+
 	}
 	if m.Life() != params.Dead {
 		providerAddresses, err := m.ProviderAddresses()


### PR DESCRIPTION
Maas provider was missing an error state by the maas controller, it is now handled.
Additionally juju machine status is updated upon failure.

### QA Steps
* Deploy a maas controller
* tamper with the machines power profiles
* deploy a charm
* within moments you will see a failed deployment and the machine will be down.