### PR TITLE
Fix intermittent test failure

### DIFF
--- a/state/multiwatcher_internal_test.go
+++ b/state/multiwatcher_internal_test.go
@@ -701,14 +701,9 @@ func (*storeManagerSuite) TestMultiwatcherStop(c *gc.C) {
 		c.Check(sm.Stop(), gc.IsNil)
 	}()
 	w := &Multiwatcher{all: sm}
-	done := make(chan struct{})
-	go func() {
-		checkNext(c, w, nil, ErrStopped.Error())
-		done <- struct{}{}
-	}()
 	err := w.Stop()
 	c.Assert(err, jc.ErrorIsNil)
-	<-done
+	checkNext(c, w, nil, ErrStopped.Error())
 }
 
 func (*storeManagerSuite) TestMultiwatcherStopBecauseStoreManagerError(c *gc.C) {


### PR DESCRIPTION
Occasionally storeManagerSuite.TestMultiwatcherStop would fail because 
the initial event would be picked up before the stop actually happened in the
watcher - we could see that clearly by adding a sleep between the checkNext
goroutine and calling w.Stop(). It doesn't actually need the checkNext call to be 
done concurrently.

Fixes https://bugs.launchpad.net/juju/+bug/1606310