### PR TITLE
 clean up uniter downloads

### DIFF
--- a/downloader/download.go
+++ b/downloader/download.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils"
-	"gopkg.in/tomb.v1"
 )
 
 // Request holds a single download request.
@@ -27,125 +26,88 @@ type Request struct {
 	// the download is invalid then the func must return errors.NotValid.
 	// If no func is provided then no verification happens.
 	Verify func(*os.File) error
+
+	// Abort is a channel that will cancel the download when it is closed.
+	Abort <-chan struct{}
 }
 
 // Status represents the status of a completed download.
 type Status struct {
-	// File holds the downloaded data on success.
-	File *os.File
+	// Filename is the name of the file which holds the downloaded
+	// data on success.
+	Filename string
 
 	// Err describes any error encountered while downloading.
 	Err error
 }
 
-// Download can download a file from the network.
-type Download struct {
-	tomb     tomb.Tomb
-	done     chan Status
-	openBlob func(*url.URL) (io.ReadCloser, error)
-}
-
-// StartDownload returns a new Download instance based on the provided
-// request. openBlob is used to gain access to the blob, whether through
-// an HTTP request or some other means.
+// StartDownload starts a new download as specified by `req` using
+// `openBlob` to actually pull the remote data.
 func StartDownload(req Request, openBlob func(*url.URL) (io.ReadCloser, error)) *Download {
-	dl := newDownload(openBlob)
+	if openBlob == nil {
+		openBlob = NewHTTPBlobOpener(utils.NoVerifySSLHostnames)
+	}
+	dl := &Download{
+		done:     make(chan Status, 1),
+		openBlob: openBlob,
+	}
 	go dl.run(req)
 	return dl
 }
 
-func newDownload(openBlob func(*url.URL) (io.ReadCloser, error)) *Download {
-	if openBlob == nil {
-		openBlob = NewHTTPBlobOpener(utils.NoVerifySSLHostnames)
-	}
-	return &Download{
-		done:     make(chan Status),
-		openBlob: openBlob,
-	}
-}
-
-// Stop stops any download that's in progress.
-func (dl *Download) Stop() {
-	dl.tomb.Kill(nil)
-	dl.tomb.Wait()
+// Download can download a file from the network.
+type Download struct {
+	done     chan Status
+	openBlob func(*url.URL) (io.ReadCloser, error)
 }
 
 // Done returns a channel that receives a status when the download has
-// completed.  It is the receiver's responsibility to close and remove
-// the received file.
+// completed or is aborted. Exactly one Status value will be sent for
+// each download once it finishes (successfully or otherwise) or is
+// aborted.
+//
+// It is the receiver's responsibility to handle and remove the
+// downloaded file.
 func (dl *Download) Done() <-chan Status {
 	return dl.done
 }
 
-// Wait blocks until the download completes or the abort channel receives.
-func (dl *Download) Wait(abort <-chan struct{}) (*os.File, error) {
-	defer dl.Stop()
-
-	select {
-	case <-abort:
-		logger.Infof("download aborted")
-		return nil, errors.New("aborted")
-	case status := <-dl.Done():
-		if status.Err != nil {
-			if status.File != nil {
-				if err := status.File.Close(); err != nil {
-					logger.Errorf("failed to close file: %v", err)
-				}
-			}
-			return nil, errors.Trace(status.Err)
-		}
-		return status.File, nil
-	}
+// Wait blocks until the download finishes (successfully or
+// otherwise), or the download is aborted. There will only be a
+// filename if err is nil.
+func (dl *Download) Wait() (string, error) {
+	// No select required here because each download will always
+	// return a value once it completes. Downloads can be aborted via
+	// the Abort channel provided a creation time.
+	status := <-dl.Done()
+	return status.Filename, errors.Trace(status.Err)
 }
 
 func (dl *Download) run(req Request) {
-	defer dl.tomb.Done()
-
 	// TODO(dimitern) 2013-10-03 bug #1234715
 	// Add a testing HTTPS storage to verify the
 	// disableSSLHostnameVerification behavior here.
-	file, err := download(req, dl.openBlob)
+	filename, err := dl.download(req)
 	if err != nil {
 		err = errors.Annotatef(err, "cannot download %q", req.URL)
-	}
-
-	if err == nil {
+	} else {
 		logger.Infof("download complete (%q)", req.URL)
-		if req.Verify != nil {
-			err = verifyDownload(file, req)
+		err = verifyDownload(filename, req)
+		if err != nil {
+			os.Remove(filename)
+			filename = ""
 		}
 	}
 
-	status := Status{
-		File: file,
-		Err:  err,
-	}
-	select {
-	case dl.done <- status:
-		// no-op
-	case <-dl.tomb.Dying():
-		cleanTempFile(file)
+	// No select needed here because the channel has a size of 1 and
+	// will only be written to once.
+	dl.done <- Status{
+		Filename: filename,
+		Err:      err,
 	}
 }
 
-func verifyDownload(file *os.File, req Request) error {
-	err := req.Verify(file)
-	if err != nil {
-		if errors.IsNotValid(err) {
-			logger.Errorf("download of %s invalid: %v", req.URL, err)
-		}
-		return errors.Trace(err)
-	}
-	logger.Infof("download verified (%q)", req.URL)
-
-	if _, err := file.Seek(0, os.SEEK_SET); err != nil {
-		logger.Errorf("failed to seek to beginning of file: %v", err)
-		return errors.Trace(err)
-	}
-	return nil
-}
-
-func download(req Request, openBlob func(*url.URL) (io.ReadCloser, error)) (file *os.File, err error) {
+func (dl *Download) download(req Request) (filename string, err error) {
 	logger.Infof("downloading from %s", req.URL)
 
 	dir := req.TargetDir
@@ -154,37 +116,44 @@ func download(req Request, openBlob func(*url.URL) (io.ReadCloser, error)) (file
 	}
 	tempFile, err := ioutil.TempFile(dir, "inprogress-")
 	if err != nil {
-		return nil, errors.Trace(err)
+		return "", errors.Trace(err)
 	}
 	defer func() {
+		tempFile.Close()
 		if err != nil {
-			cleanTempFile(tempFile)
+			os.Remove(tempFile.Name())
 		}
 	}()
 
-	reader, err := openBlob(req.URL)
+	reader, err := dl.openBlob(req.URL)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return "", errors.Trace(err)
 	}
 	defer reader.Close()
 
+	// XXX this should honor the Abort channel
 	_, err = io.Copy(tempFile, reader)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return "", errors.Trace(err)
 	}
-	if _, err := tempFile.Seek(0, 0); err != nil {
-		return nil, errors.Trace(err)
-	}
-	return tempFile, nil
+
+	return tempFile.Name(), nil
 }
 
-func cleanTempFile(f *os.File) {
-	if f == nil {
-		return
+func verifyDownload(filename string, req Request) error {
+	if req.Verify == nil {
+		return nil
 	}
 
-	f.Close()
-	if err := os.Remove(f.Name()); err != nil {
-		logger.Errorf("cannot remove temp file %q: %v", f.Name(), err)
+	file, err := os.Open(filename)
+	if err != nil {
+		return errors.Annotate(err, "opening for verify")
 	}
+	defer file.Close()
+
+	if err := req.Verify(file); err != nil {
+		return errors.Trace(err)
+	}
+	logger.Infof("download verified (%q)", req.URL)
+	return nil
 }

--- a/downloader/download.go
+++ b/downloader/download.go
@@ -89,7 +89,7 @@ func (dl *Download) run(req Request) {
 	// disableSSLHostnameVerification behavior here.
 	filename, err := dl.download(req)
 	if err != nil {
-		err = errors.Annotatef(err, "cannot download %q", req.URL)
+		err = errors.Trace(err)
 	} else {
 		logger.Infof("download complete (%q)", req.URL)
 		err = verifyDownload(filename, req)

--- a/downloader/download_test.go
+++ b/downloader/download_test.go
@@ -91,7 +91,7 @@ func (s *DownloadSuite) TestDownloadError(c *gc.C) {
 	)
 	filename, err := d.Wait()
 	c.Assert(filename, gc.Equals, "")
-	c.Assert(err, gc.ErrorMatches, `cannot download ".*": bad http response: 404 Not Found`)
+	c.Assert(err, gc.ErrorMatches, `bad http response: 404 Not Found`)
 	checkDirEmpty(c, tmp)
 }
 
@@ -154,7 +154,7 @@ func (s *DownloadSuite) TestAbort(c *gc.C) {
 	)
 	filename, err := dl.Wait()
 	c.Check(filename, gc.Equals, "")
-	c.Check(err, gc.ErrorMatches, ".+ download aborted")
+	c.Check(err, gc.ErrorMatches, "download aborted")
 	checkDirEmpty(c, tmp)
 }
 

--- a/downloader/download_test.go
+++ b/downloader/download_test.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
@@ -65,13 +64,11 @@ func (s *DownloadSuite) testDownload(c *gc.C, hostnameVerification utils.SSLHost
 		downloader.NewHTTPBlobOpener(hostnameVerification),
 	)
 	status := <-d.Done()
-	defer status.File.Close()
 	c.Assert(status.Err, gc.IsNil)
-	c.Assert(status.File, gc.NotNil)
 
-	dir, _ := filepath.Split(status.File.Name())
+	dir, _ := filepath.Split(status.Filename)
 	c.Assert(filepath.Clean(dir), gc.Equals, tmp)
-	assertFileContents(c, status.File, "archive")
+	assertFileContents(c, status.Filename, "archive")
 }
 
 func (s *DownloadSuite) TestDownloadWithoutDisablingSSLHostnameVerification(c *gc.C) {
@@ -84,36 +81,18 @@ func (s *DownloadSuite) TestDownloadWithDisablingSSLHostnameVerification(c *gc.C
 
 func (s *DownloadSuite) TestDownloadError(c *gc.C) {
 	gitjujutesting.Server.Response(404, nil, nil)
-	d := downloader.StartDownload(
-		downloader.Request{
-			URL:       s.URL(c, "/archive.tgz"),
-			TargetDir: c.MkDir(),
-		},
-		downloader.NewHTTPBlobOpener(utils.VerifySSLHostnames),
-	)
-	status := <-d.Done()
-	c.Assert(status.File, gc.IsNil)
-	c.Assert(status.Err, gc.ErrorMatches, `cannot download ".*": bad http response: 404 Not Found`)
-}
-
-func (s *DownloadSuite) TestStop(c *gc.C) {
 	tmp := c.MkDir()
 	d := downloader.StartDownload(
 		downloader.Request{
-			URL:       s.URL(c, "/x.tgz"),
+			URL:       s.URL(c, "/archive.tgz"),
 			TargetDir: tmp,
 		},
 		downloader.NewHTTPBlobOpener(utils.VerifySSLHostnames),
 	)
-	d.Stop()
-	select {
-	case status := <-d.Done():
-		c.Fatalf("received status %#v after stop", status)
-	case <-time.After(testing.ShortWait):
-	}
-	infos, err := ioutil.ReadDir(tmp)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(infos, gc.HasLen, 0)
+	filename, err := d.Wait()
+	c.Assert(filename, gc.Equals, "")
+	c.Assert(err, gc.ErrorMatches, `cannot download ".*": bad http response: 404 Not Found`)
+	checkDirEmpty(c, tmp)
 }
 
 func (s *DownloadSuite) TestVerifyValid(c *gc.C) {
@@ -131,11 +110,10 @@ func (s *DownloadSuite) TestVerifyValid(c *gc.C) {
 		},
 		downloader.NewHTTPBlobOpener(utils.VerifySSLHostnames),
 	)
-	status := <-dl.Done()
-	c.Assert(status.Err, jc.ErrorIsNil)
-
+	filename, err := dl.Wait()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(filename, gc.Not(gc.Equals), "")
 	stub.CheckCallNames(c, "Verify")
-	stub.CheckCall(c, 0, "Verify", status.File)
 }
 
 func (s *DownloadSuite) TestVerifyInvalid(c *gc.C) {
@@ -154,19 +132,21 @@ func (s *DownloadSuite) TestVerifyInvalid(c *gc.C) {
 		},
 		downloader.NewHTTPBlobOpener(utils.VerifySSLHostnames),
 	)
-	status := <-dl.Done()
-
-	c.Check(errors.Cause(status.Err), gc.Equals, invalid)
+	filename, err := dl.Wait()
+	c.Check(filename, gc.Equals, "")
+	c.Check(errors.Cause(err), gc.Equals, invalid)
 	stub.CheckCallNames(c, "Verify")
-	stub.CheckCall(c, 0, "Verify", status.File)
+	checkDirEmpty(c, tmp)
 }
 
-func assertFileContents(c *gc.C, f *os.File, expect string) {
-	got, err := ioutil.ReadAll(f)
+func assertFileContents(c *gc.C, filename, expect string) {
+	got, err := ioutil.ReadFile(filename)
 	c.Assert(err, jc.ErrorIsNil)
-	if !c.Check(string(got), gc.Equals, expect) {
-		info, err := f.Stat()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Logf("info %#v", info)
-	}
+	c.Check(string(got), gc.Equals, expect)
+}
+
+func checkDirEmpty(c *gc.C, dir string) {
+	files, err := ioutil.ReadDir(dir)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(files, gc.HasLen, 0)
 }

--- a/worker/uniter/charm/bundles.go
+++ b/worker/uniter/charm/bundles.go
@@ -70,7 +70,7 @@ func (d *BundlesDir) download(info BundleInfo, target string, abort <-chan struc
 	expectedSha256, err := info.ArchiveSha256()
 	req := downloader.Request{
 		URL:       curl,
-		TargetDir: d.downloadsPath(),
+		TargetDir: downloadsPath(d.path), // XXX check this
 		Verify:    downloader.NewSha256Verifier(expectedSha256),
 		Abort:     abort,
 	}
@@ -103,8 +103,16 @@ func (d *BundlesDir) bundleURLPath(url *charm.URL) string {
 	return path.Join(d.path, charm.Quote(url.String()))
 }
 
+// ClearDownloads removes any entries in the temporary bundle download
+// directory. It is intended to be called on uniter startup.
+func ClearDownloads(bundlesDir string) error {
+	downloadDir := downloadsPath(bundlesDir)
+	err := os.RemoveAll(downloadDir)
+	return errors.Annotate(err, "unable to clear bundle downloads")
+}
+
 // downloadsPath returns the path to the directory into which charms are
 // downloaded.
-func (d *BundlesDir) downloadsPath() string {
-	return path.Join(d.path, "downloads")
+func downloadsPath(bunsDir string) string {
+	return path.Join(bunsDir, "downloads")
 }

--- a/worker/uniter/charm/bundles.go
+++ b/worker/uniter/charm/bundles.go
@@ -70,7 +70,7 @@ func (d *BundlesDir) download(info BundleInfo, target string, abort <-chan struc
 	expectedSha256, err := info.ArchiveSha256()
 	req := downloader.Request{
 		URL:       curl,
-		TargetDir: downloadsPath(d.path), // XXX check this
+		TargetDir: downloadsPath(d.path),
 		Verify:    downloader.NewSha256Verifier(expectedSha256),
 		Abort:     abort,
 	}

--- a/worker/uniter/charm/bundles.go
+++ b/worker/uniter/charm/bundles.go
@@ -19,7 +19,7 @@ import (
 type Downloader interface {
 	// Download starts a new charm archive download, waits for it to
 	// complete, and returns the local name of the file.
-	Download(req downloader.Request, abort <-chan struct{}) (string, error)
+	Download(req downloader.Request) (string, error)
 }
 
 // BundlesDir is responsible for storing and retrieving charm bundles
@@ -36,7 +36,6 @@ func NewBundlesDir(path string, dlr Downloader) *BundlesDir {
 			HostnameVerification: utils.NoVerifySSLHostnames,
 		})
 	}
-
 	return &BundlesDir{
 		path:       path,
 		downloader: dlr,
@@ -73,9 +72,10 @@ func (d *BundlesDir) download(info BundleInfo, target string, abort <-chan struc
 		URL:       curl,
 		TargetDir: d.downloadsPath(),
 		Verify:    downloader.NewSha256Verifier(expectedSha256),
+		Abort:     abort,
 	}
 	logger.Infof("downloading %s from API server", info.URL())
-	filename, err := d.downloader.Download(req, abort)
+	filename, err := d.downloader.Download(req)
 	if err != nil {
 		return errors.Annotatef(err, "failed to download charm %q from API server", info.URL())
 	}

--- a/worker/uniter/charm/bundles_test.go
+++ b/worker/uniter/charm/bundles_test.go
@@ -111,12 +111,12 @@ func (s *BundlesDirSuite) TestGet(c *gc.C) {
 
 	// Try to get the charm when the content doesn't match.
 	_, err = d.Read(&fakeBundleInfo{apiCharm, nil, "..."}, nil)
-	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`failed to download charm "cs:quantal/dummy-1" from API server: `)+`expected sha256 "...", got ".*"`)
+	c.Check(err, gc.ErrorMatches, regexp.QuoteMeta(`failed to download charm "cs:quantal/dummy-1" from API server: `)+`expected sha256 "...", got ".*"`)
 
 	// Try to get a charm whose bundle doesn't exist.
 	otherURL := corecharm.MustParseURL("cs:quantal/spam-1")
 	_, err = d.Read(&fakeBundleInfo{apiCharm, otherURL, ""}, nil)
-	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`failed to download charm "cs:quantal/spam-1" from API server: `)+`.* not found`)
+	c.Check(err, gc.ErrorMatches, regexp.QuoteMeta(`failed to download charm "cs:quantal/spam-1" from API server: `)+`.* not found`)
 
 	// Get a charm whose bundle exists and whose content matches.
 	ch, err := d.Read(apiCharm, nil)
@@ -135,8 +135,8 @@ func (s *BundlesDirSuite) TestGet(c *gc.C) {
 	close(abort)
 
 	ch, err = d.Read(apiCharm, abort)
-	c.Assert(ch, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`failed to download charm "cs:quantal/dummy-1" from API server: download aborted`))
+	c.Check(ch, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, regexp.QuoteMeta(`failed to download charm "cs:quantal/dummy-1" from API server: download aborted`))
 }
 
 func assertCharm(c *gc.C, bun charm.Bundle, sch *state.Charm) {

--- a/worker/uniter/charm/bundles_test.go
+++ b/worker/uniter/charm/bundles_test.go
@@ -136,7 +136,7 @@ func (s *BundlesDirSuite) TestGet(c *gc.C) {
 
 	ch, err = d.Read(apiCharm, abort)
 	c.Assert(ch, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`failed to download charm "cs:quantal/dummy-1" from API server: aborted`))
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`failed to download charm "cs:quantal/dummy-1" from API server: download aborted`))
 }
 
 func assertCharm(c *gc.C, bun charm.Bundle, sch *state.Charm) {

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -436,6 +436,9 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 	u.commands = runcommands.NewCommands()
 	u.commandChannel = make(chan string)
 
+	if err := charm.ClearDownloads(u.paths.State.BundlesDir); err != nil {
+		logger.Warningf(err.Error())
+	}
 	deployer, err := charm.NewDeployer(
 		u.paths.State.CharmDir,
 		u.paths.State.DeployerDir,

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -150,6 +150,23 @@ func (s *UniterSuite) TestUniterStartup(c *gc.C) {
 	})
 }
 
+func (s *UniterSuite) TestPreviousDownloadsCleared(c *gc.C) {
+	s.runUniterTests(c, []uniterTest{
+		ut(
+			"Ensure stale download files are cleared on uniter startup",
+			createCharm{},
+			serveCharm{},
+			ensureStateWorker{},
+			createServiceAndUnit{},
+			createDownloads{},
+			startUniter{},
+			waitAddresses{},
+			waitUnitAgent{status: status.Idle},
+			verifyDownloadsCleared{},
+		),
+	})
+}
+
 func (s *UniterSuite) TestUniterBootstrap(c *gc.C) {
 	//TODO(bogdanteleaga): Fix this on windows
 	if runtime.GOOS == "windows" {

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -649,6 +649,30 @@ func (s startupError) step(c *gc.C, ctx *context) {
 	step(c, ctx, verifyCharm{})
 }
 
+type createDownloads struct{}
+
+func (s createDownloads) step(c *gc.C, ctx *context) {
+	dir := downloadDir(ctx)
+	c.Assert(os.MkdirAll(dir, 0775), jc.ErrorIsNil)
+	c.Assert(
+		ioutil.WriteFile(filepath.Join(dir, "foo"), []byte("bar"), 0775),
+		jc.ErrorIsNil,
+	)
+}
+
+type verifyDownloadsCleared struct{}
+
+func (s verifyDownloadsCleared) step(c *gc.C, ctx *context) {
+	files, err := ioutil.ReadDir(downloadDir(ctx))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(files, gc.HasLen, 0)
+}
+
+func downloadDir(ctx *context) string {
+	paths := uniter.NewPaths(ctx.dataDir, ctx.unit.UnitTag())
+	return filepath.Join(paths.State.BundlesDir, "downloads")
+}
+
 type quickStart struct {
 	minion bool
 }


### PR DESCRIPTION
This PR fixes https://bugs.launchpad.net/juju/+bug/1626304 for 2.0. It begins with significant refactoring of the downloads package, removing unused functionality and unnecessary complexity. This also ensure that temporary download files are always removed if downloads or download verification fails.

The second part of the PR changes the uniter worker to remove its temporary downloads directory in case files from previous failed download attempts have been left behind.

### QA

Deploy a charm while running `while true; do echo `find /var/lib/juju/agents/`; sleep 0.05; done` on the machine. With this it was possible to see the charm's download files appear in the correct location and then moved to the correct final location.

A large bundle (openstack-base) was deployed and logs were checked to ensure that charm downloads succeeded.

A unit's charm downloads directory was populated with files and the agent was restarted. The downloads directory was removed on startup.