### PR TITLE
upgrade-juju: don't auto-upload with --version

### DIFF
--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -321,7 +321,7 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 	}
 	// If we're running a custom build or the user has asked for a new agent
 	// to be built, upload a local jujud binary if possible.
-	uploadLocalBinary := isControllerModel && tryImplicitUpload(agentVersion)
+	uploadLocalBinary := isControllerModel && c.Version == version.Zero && tryImplicitUpload(agentVersion)
 	if !warnCompat && (uploadLocalBinary || c.BuildAgent) && !c.DryRun {
 		if err := context.uploadTools(c.BuildAgent); err != nil {
 			// If we've explicitly asked to build an agent binary, or the upload failed
@@ -329,14 +329,14 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 			if err2 := block.ProcessBlockedError(err, block.BlockChange); c.BuildAgent || err2 == cmd.ErrSilent {
 				return err2
 			}
-		} else if err == nil {
-			builtMsg := ""
-			if c.BuildAgent {
-				builtMsg = " (built from source)"
-			}
-			fmt.Fprintf(ctx.Stdout, "no prepackaged tools available, using local agent binary %v%s\n", context.chosen, builtMsg)
 		}
+		builtMsg := ""
+		if c.BuildAgent {
+			builtMsg = " (built from source)"
+		}
+		fmt.Fprintf(ctx.Stdout, "no prepackaged tools available, using local agent binary %v%s\n", context.chosen, builtMsg)
 	}
+
 	// If there was an error implicitly uploading a binary, we'll still look for any packaged binaries
 	// since there may still be a valid upgrade and the user didn't ask for any local binary.
 	if err := context.validate(); err != nil {

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -170,7 +170,7 @@ var upgradeJujuTests = []struct {
 	currentVersion: "3.0.2-quantal-amd64",
 	agentVersion:   "2.8.2",
 	args:           []string{"--version", "3.0.2"},
-	expectVersion:  "3.0.2.1",
+	expectVersion:  "3.0.2",
 	upgradeMap:     map[int]version.Number{3: version.MustParse("2.8.2")},
 }, {
 	about:          "specified version missing, but already set",
@@ -682,7 +682,7 @@ func (s *UpgradeJujuSuite) TestUpgradesDifferentMajor(c *gc.C) {
 		tools:             []string{"6.0.5-trusty-amd64", "5.9.9-trusty-amd64"},
 		currentVersion:    "6.0.0-trusty-amd64",
 		agentVersion:      "5.9.8",
-		expectedVersion:   "6.0.5.1",
+		expectedVersion:   "6.0.5",
 		excludedLogOutput: `incompatible with this client (6.0.0)`,
 		upgradeMap:        map[int]version.Number{6: version.MustParse("5.9.8")},
 	}, {
@@ -691,7 +691,7 @@ func (s *UpgradeJujuSuite) TestUpgradesDifferentMajor(c *gc.C) {
 		tools:             []string{"6.0.5-trusty-amd64", "5.11.0-trusty-amd64"},
 		currentVersion:    "6.0.1-trusty-amd64",
 		agentVersion:      "5.10.8",
-		expectedVersion:   "6.0.5.1",
+		expectedVersion:   "6.0.5",
 		excludedLogOutput: `incompatible with this client (6.0.1)`,
 		upgradeMap:        map[int]version.Number{6: version.MustParse("5.9.8")},
 	}, {


### PR DESCRIPTION
If you pass --version to upgrade-juju, Juju should
not attempt to automatically build and upload the
agent; it should always get the specified version
from streams.

Fixes https://bugs.launchpad.net/juju/+bug/1626784

**QA**

1. bootstrap 2.0rc1:

  juju bootstrap lxd lxd --config agent-metadata-url=http://juju-dist.s3.amazonaws.com/parallel-testing/agents --config agent-stream=revision-build-4415

2. Confirmed that the agent is 2.0rc1.1, because there's no metadata for 2.0rc1.
3. Confirmed that the stream has 2.0rc2 agents, using github.com/axw/juju-tools.
4. with "2.0rc2" (master), ran upgrade-juju:

  juju upgrade-juju -m controller --version 2.0-rc2

Confirmed the resultant version is 2.0rc2, not 2.0rc2.1.