### PR TITLE
Migrate state tests from time.Now() to ZeroTime()

### DIFF
--- a/state/status_filesystem_test.go
+++ b/state/status_filesystem_test.go
@@ -4,13 +4,12 @@
 package state_test
 
 import (
-	"time"
-
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
+	"github.com/juju/juju/testing"
 )
 
 type FilesystemStatusSuite struct {
@@ -60,7 +59,7 @@ func (s *FilesystemStatusSuite) checkInitialStatus(c *gc.C) {
 }
 
 func (s *FilesystemStatusSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Error,
 		Message: "",
@@ -73,7 +72,7 @@ func (s *FilesystemStatusSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
 }
 
 func (s *FilesystemStatusSuite) TestSetUnknownStatus(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Status("vliegkat"),
 		Message: "orville",
@@ -86,7 +85,7 @@ func (s *FilesystemStatusSuite) TestSetUnknownStatus(c *gc.C) {
 }
 
 func (s *FilesystemStatusSuite) TestSetOverwritesData(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Attaching,
 		Message: "blah",
@@ -106,7 +105,7 @@ func (s *FilesystemStatusSuite) TestGetSetStatusAlive(c *gc.C) {
 }
 
 func (s *FilesystemStatusSuite) checkGetSetStatus(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Attaching,
 		Message: "blah",
@@ -163,7 +162,7 @@ func (s *FilesystemStatusSuite) TestGetSetStatusDead(c *gc.C) {
 func (s *FilesystemStatusSuite) TestGetSetStatusGone(c *gc.C) {
 	s.obliterateFilesystem(c, s.filesystem.FilesystemTag())
 
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Attaching,
 		Message: "not really",
@@ -178,7 +177,7 @@ func (s *FilesystemStatusSuite) TestGetSetStatusGone(c *gc.C) {
 }
 
 func (s *FilesystemStatusSuite) TestSetStatusPendingUnprovisioned(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Pending,
 		Message: "still",
@@ -193,7 +192,7 @@ func (s *FilesystemStatusSuite) TestSetStatusPendingProvisioned(c *gc.C) {
 		FilesystemId: "fs-id",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Pending,
 		Message: "",

--- a/state/status_machine_test.go
+++ b/state/status_machine_test.go
@@ -4,13 +4,12 @@
 package state_test
 
 import (
-	"time"
-
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
+	"github.com/juju/juju/testing"
 )
 
 type MachineStatusSuite struct {
@@ -39,7 +38,7 @@ func (s *MachineStatusSuite) checkInitialStatus(c *gc.C) {
 }
 
 func (s *MachineStatusSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Error,
 		Message: "",
@@ -52,7 +51,7 @@ func (s *MachineStatusSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
 }
 
 func (s *MachineStatusSuite) TestSetDownStatus(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Down,
 		Message: "",
@@ -65,7 +64,7 @@ func (s *MachineStatusSuite) TestSetDownStatus(c *gc.C) {
 }
 
 func (s *MachineStatusSuite) TestSetUnknownStatus(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Status("vliegkat"),
 		Message: "orville",
@@ -78,7 +77,7 @@ func (s *MachineStatusSuite) TestSetUnknownStatus(c *gc.C) {
 }
 
 func (s *MachineStatusSuite) TestSetOverwritesData(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Started,
 		Message: "blah",
@@ -98,7 +97,7 @@ func (s *MachineStatusSuite) TestGetSetStatusAlive(c *gc.C) {
 }
 
 func (s *MachineStatusSuite) checkGetSetStatus(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Started,
 		Message: "blah",
@@ -150,7 +149,7 @@ func (s *MachineStatusSuite) TestGetSetStatusGone(c *gc.C) {
 	err = s.machine.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Started,
 		Message: "not really",
@@ -165,7 +164,7 @@ func (s *MachineStatusSuite) TestGetSetStatusGone(c *gc.C) {
 }
 
 func (s *MachineStatusSuite) TestSetStatusPendingProvisioned(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Pending,
 		Message: "",
@@ -178,7 +177,7 @@ func (s *MachineStatusSuite) TestSetStatusPendingProvisioned(c *gc.C) {
 func (s *MachineStatusSuite) TestSetStatusPendingUnprovisioned(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Pending,
 		Message: "",

--- a/state/status_model_test.go
+++ b/state/status_model_test.go
@@ -4,13 +4,12 @@
 package state_test
 
 import (
-	"time"
-
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
+	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -53,7 +52,7 @@ func (s *ModelStatusSuite) checkInitialStatus(c *gc.C) {
 }
 
 func (s *ModelStatusSuite) TestSetUnknownStatus(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Status("vliegkat"),
 		Message: "orville",
@@ -66,7 +65,7 @@ func (s *ModelStatusSuite) TestSetUnknownStatus(c *gc.C) {
 }
 
 func (s *ModelStatusSuite) TestSetOverwritesData(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Available,
 		Message: "blah",
@@ -109,7 +108,7 @@ func (s *ModelStatusSuite) TestGetSetStatusGone(c *gc.C) {
 	err = s.st.RemoveAllModelDocs()
 	c.Assert(err, jc.ErrorIsNil)
 
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Available,
 		Message: "not really",
@@ -123,7 +122,7 @@ func (s *ModelStatusSuite) TestGetSetStatusGone(c *gc.C) {
 }
 
 func (s *ModelStatusSuite) checkGetSetStatus(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Available,
 		Message: "blah",

--- a/state/status_service_test.go
+++ b/state/status_service_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
+	"github.com/juju/juju/testing"
 )
 
 type ServiceStatusSuite struct {
@@ -36,7 +37,7 @@ func (s *ServiceStatusSuite) checkInitialStatus(c *gc.C) {
 }
 
 func (s *ServiceStatusSuite) TestSetUnknownStatus(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Status("vliegkat"),
 		Message: "orville",
@@ -49,7 +50,7 @@ func (s *ServiceStatusSuite) TestSetUnknownStatus(c *gc.C) {
 }
 
 func (s *ServiceStatusSuite) TestSetOverwritesData(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Active,
 		Message: "healthy",
@@ -69,7 +70,7 @@ func (s *ServiceStatusSuite) TestGetSetStatusAlive(c *gc.C) {
 }
 
 func (s *ServiceStatusSuite) checkGetSetStatus(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Active,
 		Message: "healthy",
@@ -111,7 +112,7 @@ func (s *ServiceStatusSuite) TestGetSetStatusGone(c *gc.C) {
 	err := s.service.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Active,
 		Message: "not really",
@@ -126,7 +127,7 @@ func (s *ServiceStatusSuite) TestGetSetStatusGone(c *gc.C) {
 }
 
 func (s *ServiceStatusSuite) TestSetStatusSince(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Maintenance,
 		Message: "",
@@ -163,7 +164,7 @@ func (s *ServiceStatusSuite) TestDeriveStatus(c *gc.C) {
 	addUnit := func(unitStatus status.Status) *state.Unit {
 		unit, err := s.service.AddUnit()
 		c.Assert(err, gc.IsNil)
-		now := time.Now()
+		now := testing.ZeroTime()
 		sInfo := status.StatusInfo{
 			Status:  unitStatus,
 			Message: "blam",
@@ -183,7 +184,7 @@ func (s *ServiceStatusSuite) TestDeriveStatus(c *gc.C) {
 	// ...and create one with error status by setting it on the agent :-/.
 	errorUnit, err := s.service.AddUnit()
 	c.Assert(err, gc.IsNil)
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Error,
 		Message: "blam",
@@ -219,7 +220,7 @@ func (s *ServiceStatusSuite) TestDeriveStatus(c *gc.C) {
 func (s *ServiceStatusSuite) TestServiceStatusOverridesDerivedStatus(c *gc.C) {
 	unit, err := s.service.AddUnit()
 	c.Assert(err, gc.IsNil)
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Blocked,
 		Message: "pow",

--- a/state/status_unit_test.go
+++ b/state/status_unit_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
+	"github.com/juju/juju/testing"
 )
 
 type UnitStatusSuite struct {
@@ -36,7 +37,7 @@ func (s *UnitStatusSuite) checkInitialStatus(c *gc.C) {
 }
 
 func (s *UnitStatusSuite) TestSetUnknownStatus(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Status("vliegkat"),
 		Message: "orville",
@@ -49,7 +50,7 @@ func (s *UnitStatusSuite) TestSetUnknownStatus(c *gc.C) {
 }
 
 func (s *UnitStatusSuite) TestSetOverwritesData(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Active,
 		Message: "healthy",
@@ -69,7 +70,7 @@ func (s *UnitStatusSuite) TestGetSetStatusAlive(c *gc.C) {
 }
 
 func (s *UnitStatusSuite) checkGetSetStatus(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Active,
 		Message: "healthy",
@@ -122,7 +123,7 @@ func (s *UnitStatusSuite) TestGetSetStatusGone(c *gc.C) {
 	err := s.unit.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Active,
 		Message: "not really",
@@ -137,7 +138,7 @@ func (s *UnitStatusSuite) TestGetSetStatusGone(c *gc.C) {
 }
 
 func (s *UnitStatusSuite) TestSetUnitStatusSince(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Maintenance,
 		Message: "",

--- a/state/status_unitagent_test.go
+++ b/state/status_unitagent_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
+	"github.com/juju/juju/testing"
 )
 
 type StatusUnitAgentSuite struct {
@@ -38,7 +39,7 @@ func (s *StatusUnitAgentSuite) checkInitialStatus(c *gc.C) {
 }
 
 func (s *StatusUnitAgentSuite) TestSetUnknownStatus(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Status("vliegkat"),
 		Message: "orville",
@@ -51,7 +52,7 @@ func (s *StatusUnitAgentSuite) TestSetUnknownStatus(c *gc.C) {
 }
 
 func (s *StatusUnitAgentSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Error,
 		Message: "",
@@ -64,7 +65,7 @@ func (s *StatusUnitAgentSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
 }
 
 func (s *StatusUnitAgentSuite) TestSetOverwritesData(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Idle,
 		Message: "something",
@@ -84,7 +85,7 @@ func (s *StatusUnitAgentSuite) TestGetSetStatusAlive(c *gc.C) {
 }
 
 func (s *StatusUnitAgentSuite) checkGetSetStatus(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Idle,
 		Message: "something",
@@ -143,7 +144,7 @@ func (s *StatusUnitAgentSuite) TestGetSetStatusGone(c *gc.C) {
 	err := s.unit.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Idle,
 		Message: "not really",
@@ -158,7 +159,7 @@ func (s *StatusUnitAgentSuite) TestGetSetStatusGone(c *gc.C) {
 }
 
 func (s *StatusUnitAgentSuite) TestGetSetErrorStatus(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Error,
 		Message: "test-hook failed",
@@ -192,7 +193,7 @@ func timeBeforeOrEqual(timeBefore, timeOther time.Time) bool {
 }
 
 func (s *StatusUnitAgentSuite) TestSetAgentStatusSince(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Idle,
 		Message: "",

--- a/state/status_volume_test.go
+++ b/state/status_volume_test.go
@@ -4,13 +4,12 @@
 package state_test
 
 import (
-	"time"
-
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
+	"github.com/juju/juju/testing"
 )
 
 type VolumeStatusSuite struct {
@@ -60,7 +59,7 @@ func (s *VolumeStatusSuite) checkInitialStatus(c *gc.C) {
 }
 
 func (s *VolumeStatusSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Error,
 		Message: "",
@@ -73,7 +72,7 @@ func (s *VolumeStatusSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
 }
 
 func (s *VolumeStatusSuite) TestSetUnknownStatus(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Status("vliegkat"),
 		Message: "orville",
@@ -86,7 +85,7 @@ func (s *VolumeStatusSuite) TestSetUnknownStatus(c *gc.C) {
 }
 
 func (s *VolumeStatusSuite) TestSetOverwritesData(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Attaching,
 		Message: "blah",
@@ -112,7 +111,7 @@ func (s *VolumeStatusSuite) TestGetSetStatusAlive(c *gc.C) {
 }
 
 func (s *VolumeStatusSuite) checkGetSetStatus(c *gc.C, volumeStatus status.Status) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  volumeStatus,
 		Message: "blah",
@@ -169,7 +168,7 @@ func (s *VolumeStatusSuite) TestGetSetStatusDead(c *gc.C) {
 func (s *VolumeStatusSuite) TestGetSetStatusGone(c *gc.C) {
 	s.obliterateVolume(c, s.volume.VolumeTag())
 
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Attaching,
 		Message: "not really",
@@ -184,7 +183,7 @@ func (s *VolumeStatusSuite) TestGetSetStatusGone(c *gc.C) {
 }
 
 func (s *VolumeStatusSuite) TestSetStatusPendingUnprovisioned(c *gc.C) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Pending,
 		Message: "still",
@@ -199,7 +198,7 @@ func (s *VolumeStatusSuite) TestSetStatusPendingProvisioned(c *gc.C) {
 		VolumeId: "vol-ume",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Pending,
 		Message: "",


### PR DESCRIPTION
Introduces, to state tests, the use of ZeroTime() from the testing
package, to replace time.Now() in cases where the the actual current
time is not required.

QA steps:

 * state tests should still pass