### PR TITLE
Fsync mongo so new lease queries are up to date

### DIFF
--- a/state/state_leader_test.go
+++ b/state/state_leader_test.go
@@ -130,6 +130,7 @@ func (s *LeadershipSuite) TestHackLeadershipUnblocksClaimer(c *gc.C) {
 
 func (s *LeadershipSuite) expire(c *gc.C, applicationname string) {
 	s.clock.Advance(time.Hour)
+	s.Session.Fsync(false)
 	select {
 	case err := <-s.expiryChan(applicationname):
 		c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Mongo doesn't know about our clock implementation. So even though we've
advanced our clock we might not have waited for mongo to write the
changes to disk before asking for the expired leases and trying to
claim a new one.

I was able to reproduce this pretty easily within 100 or so runs. With
mgo.Session.Fsync I haven't triggered it within ~3000 runs.

Fixes https://bugs.launchpad.net/juju/+bug/1614256


QA: stress the test with methods described at: https://github.com/juju/juju/wiki/Debugging-Races