### PR TITLE
Migrate state tests from time.Now() to [Non]ZeroTime()

### DIFF
--- a/state/application_test.go
+++ b/state/application_test.go
@@ -6,7 +6,6 @@ package state_test
 import (
 	"fmt"
 	"sort"
-	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -22,6 +21,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
 	"github.com/juju/juju/status"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -2172,7 +2172,7 @@ func (s *ServiceSuite) TestMetricCredentialsOnDying(c *gc.C) {
 func (s *ServiceSuite) testStatus(c *gc.C, status1, status2, expected status.Status) {
 	u1, err := s.mysql.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
-	now := time.Now()
+	now := coretesting.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status1,
 		Message: "status 1",

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -5,7 +5,6 @@ package state_test
 
 import (
 	"sort"
-	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -901,7 +900,7 @@ func (s *MachineSuite) TestMachineSetInstanceStatus(c *gc.C) {
 	err := s.machine.SetProvisioned("umbrella/0", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	now := time.Now()
+	now := coretesting.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Running,
 		Message: "alive",
@@ -1154,7 +1153,7 @@ func (s *MachineSuite) TestWatchPrincipalUnits(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Change the unit; no change.
-	now := time.Now()
+	now := coretesting.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Idle,
 		Message: "",
@@ -1269,7 +1268,7 @@ func (s *MachineSuite) TestWatchUnits(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Change the unit; no change.
-	now := time.Now()
+	now := coretesting.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Idle,
 		Message: "",

--- a/state/resources_mongo_test.go
+++ b/state/resources_mongo_test.go
@@ -5,7 +5,6 @@ package state
 
 import (
 	"strings"
-	"time"
 
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -13,6 +12,7 @@ import (
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 
 	"github.com/juju/juju/resource"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type ResourcesMongoSuite struct {
@@ -25,7 +25,7 @@ func (s *ResourcesMongoSuite) TestResource2DocUploadFull(c *gc.C) {
 	content := "some data\n..."
 	fp, err := charmresource.GenerateFingerprint(strings.NewReader(content))
 	c.Assert(err, jc.ErrorIsNil)
-	now := time.Now().UTC()
+	now := coretesting.ZeroTime()
 
 	applicationID := "a-application"
 	docID := applicationResourceID("spam")
@@ -80,7 +80,7 @@ func (s *ResourcesMongoSuite) TestResource2DocUploadBasic(c *gc.C) {
 	content := "some data\n..."
 	fp, err := charmresource.GenerateFingerprint(strings.NewReader(content))
 	c.Assert(err, jc.ErrorIsNil)
-	now := time.Now().UTC()
+	now := coretesting.ZeroTime()
 
 	applicationID := "a-application"
 	docID := applicationResourceID("spam")
@@ -129,7 +129,7 @@ func (s *ResourcesMongoSuite) TestResource2DocUploadPending(c *gc.C) {
 	content := "some data\n..."
 	fp, err := charmresource.GenerateFingerprint(strings.NewReader(content))
 	c.Assert(err, jc.ErrorIsNil)
-	now := time.Now().UTC()
+	now := coretesting.ZeroTime()
 
 	applicationID := "a-application"
 	docID := pendingResourceID("spam", "some-unique-ID-001")
@@ -182,7 +182,7 @@ func (s *ResourcesMongoSuite) TestDoc2Resource(c *gc.C) {
 	content := "some data\n..."
 	fp, err := charmresource.GenerateFingerprint(strings.NewReader(content))
 	c.Assert(err, jc.ErrorIsNil)
-	now := time.Now().UTC()
+	now := coretesting.NonZeroTime()
 
 	res, err := doc2resource(resourceDoc{
 		DocID:         docID,
@@ -233,7 +233,7 @@ func (s *ResourcesMongoSuite) TestDoc2BasicResourceUploadFull(c *gc.C) {
 	content := "some data\n..."
 	fp, err := charmresource.GenerateFingerprint(strings.NewReader(content))
 	c.Assert(err, jc.ErrorIsNil)
-	now := time.Now().UTC()
+	now := coretesting.NonZeroTime()
 
 	res, err := doc2basicResource(resourceDoc{
 		DocID:         docID,
@@ -285,7 +285,7 @@ func (s *ResourcesMongoSuite) TestDoc2BasicResourceUploadBasic(c *gc.C) {
 	content := "some data\n..."
 	fp, err := charmresource.GenerateFingerprint(strings.NewReader(content))
 	c.Assert(err, jc.ErrorIsNil)
-	now := time.Now().UTC()
+	now := coretesting.NonZeroTime()
 
 	res, err := doc2basicResource(resourceDoc{
 		DocID:         docID,
@@ -329,7 +329,7 @@ func (s *ResourcesMongoSuite) TestResource2DocCharmstoreFull(c *gc.C) {
 	content := "some data\n..."
 	fp, err := charmresource.GenerateFingerprint(strings.NewReader(content))
 	c.Assert(err, jc.ErrorIsNil)
-	now := time.Now().UTC()
+	now := coretesting.ZeroTime()
 
 	applicationID := "a-application"
 	docID := applicationResourceID("spam")
@@ -387,7 +387,7 @@ func (s *ResourcesMongoSuite) TestDoc2BasicResourceCharmstoreFull(c *gc.C) {
 	content := "some data\n..."
 	fp, err := charmresource.GenerateFingerprint(strings.NewReader(content))
 	c.Assert(err, jc.ErrorIsNil)
-	now := time.Now().UTC()
+	now := coretesting.NonZeroTime()
 
 	res, err := doc2basicResource(resourceDoc{
 		DocID:     docID,
@@ -505,7 +505,7 @@ func (s *ResourcesMongoSuite) TestCharmStoreResource2DocFull(c *gc.C) {
 	content := "some data\n..."
 	fp, err := charmresource.GenerateFingerprint(strings.NewReader(content))
 	c.Assert(err, jc.ErrorIsNil)
-	now := time.Now().UTC()
+	now := coretesting.ZeroTime()
 
 	applicationID := "a-application"
 	id := applicationID + "/spam"

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -4,8 +4,6 @@
 package state
 
 import (
-	"time"
-
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -16,6 +14,7 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/status"
+	"github.com/juju/juju/testing"
 )
 
 type upgradesSuite struct {
@@ -271,7 +270,7 @@ func (s *upgradesSuite) TestAddFilesystemStatusDoesNotOverwrite(c *gc.C) {
 	_, _, filesystem, cleanup := setupMachineBoundStorageTests(c, s.state)
 	defer cleanup()
 
-	now := time.Now()
+	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Destroying,
 		Message: "",


### PR DESCRIPTION
Continue the migration of state tests to use ZeroTime() or NonZeroTime()
from the testing package in place of time.Now().