### PR TITLE
Relation add and remove commands improvements.

### DIFF
--- a/cmd/juju/application/addrelation.go
+++ b/cmd/juju/application/addrelation.go
@@ -44,12 +44,7 @@ func (c *addRelationCommand) Info() *cmd.Info {
 }
 
 func (c *addRelationCommand) Init(args []string) error {
-	// Must have only 2 arguments
 	if len(args) != 2 {
-		return errors.Errorf("a relation must involve two applications")
-	}
-	// None of the arguments can be empty.
-	if args[0] == "" || args[1] == "" {
 		return errors.Errorf("a relation must involve two applications")
 	}
 	c.Endpoints = args

--- a/cmd/juju/application/addrelation_test.go
+++ b/cmd/juju/application/addrelation_test.go
@@ -65,7 +65,7 @@ func (s *AddRelationSuite) TestAddRelationSuccess(c *gc.C) {
 }
 
 func (s *AddRelationSuite) TestAddRelationFail(c *gc.C) {
-	msg := "fail add relation"
+	msg := "fail add-relation call at API"
 	s.mockAPI = &mockAddAPI{
 		addRelationFunc: func(endpoints ...string) (*params.AddRelationResults, error) {
 			return nil, errors.New(msg)

--- a/cmd/juju/application/addrelation_test.go
+++ b/cmd/juju/application/addrelation_test.go
@@ -1,189 +1,97 @@
-// Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2012 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package application
 
 import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	jujutesting "github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/testcharms"
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type AddRelationSuite struct {
-	jujutesting.RepoSuite
-	testing.CmdBlockHelper
+	testing.IsolationSuite
+	mockAPI *mockAddAPI
 }
 
 func (s *AddRelationSuite) SetUpTest(c *gc.C) {
-	s.RepoSuite.SetUpTest(c)
-	s.CmdBlockHelper = testing.NewCmdBlockHelper(s.APIState)
-	c.Assert(s.CmdBlockHelper, gc.NotNil)
-	s.AddCleanup(func(*gc.C) { s.CmdBlockHelper.Close() })
+	s.IsolationSuite.SetUpTest(c)
+	s.mockAPI = &mockAddAPI{
+		addRelationFunc: func(endpoints ...string) (*params.AddRelationResults, error) {
+			// At the moment, cmd implementation ignores the return values,
+			// so nil is an acceptable return for testing purposes.
+			return nil, nil
+		},
+	}
 }
 
 var _ = gc.Suite(&AddRelationSuite{})
 
-func runAddRelation(c *gc.C, args ...string) error {
-	_, err := testing.RunCommand(c, NewAddRelationCommand(), args...)
+func (s *AddRelationSuite) runAddRelation(c *gc.C, args ...string) error {
+	_, err := coretesting.RunCommand(c, NewAddRelationCommandForTest(s.mockAPI), args...)
 	return err
 }
 
-var msWpAlreadyExists = `cannot add relation "wp:db ms:server": relation already exists`
-var msLgAlreadyExists = `cannot add relation "lg:info ms:juju-info": relation already exists`
-var wpLgAlreadyExists = `cannot add relation "lg:logging-directory wp:logging-dir": relation already exists`
-var wpLgAlreadyExistsJuju = `cannot add relation "lg:info wp:juju-info": relation already exists`
+func (s *AddRelationSuite) TestAddRelationNotEnoughArguments(c *gc.C) {
+	// No arguments
+	err := s.runAddRelation(c)
+	c.Assert(err, gc.ErrorMatches, "a relation must involve two applications")
 
-var addRelationTests = []struct {
-	args []string
-	err  string
-}{
-	{
-		args: []string{"rk", "ms"},
-		err:  "no relations found",
-	}, {
-		err: "a relation must involve two applications",
-	}, {
-		args: []string{"rk"},
-		err:  "a relation must involve two applications",
-	}, {
-		args: []string{"rk:ring"},
-		err:  "a relation must involve two applications",
-	}, {
-		args: []string{"ping:pong", "tic:tac", "icki:wacki"},
-		err:  "a relation must involve two applications",
-	},
+	// 1 empty argument
+	err = s.runAddRelation(c, "")
+	c.Assert(err, gc.ErrorMatches, "a relation must involve two applications")
 
-	// Add a real relation, and check various ways of failing to re-add it.
-	{
-		args: []string{"ms", "wp"},
-	}, {
-		args: []string{"ms", "wp"},
-		err:  msWpAlreadyExists,
-	}, {
-		args: []string{"wp", "ms"},
-		err:  msWpAlreadyExists,
-	}, {
-		args: []string{"ms", "wp:db"},
-		err:  msWpAlreadyExists,
-	}, {
-		args: []string{"ms:server", "wp"},
-		err:  msWpAlreadyExists,
-	}, {
-		args: []string{"ms:server", "wp:db"},
-		err:  msWpAlreadyExists,
-	},
+	// 2 empty arguments
+	err = s.runAddRelation(c, "", "")
+	c.Assert(err, gc.ErrorMatches, "a relation must involve two applications")
 
-	// Add a real relation using an implicit endpoint.
-	{
-		args: []string{"ms", "lg"},
-	}, {
-		args: []string{"ms", "lg"},
-		err:  msLgAlreadyExists,
-	}, {
-		args: []string{"lg", "ms"},
-		err:  msLgAlreadyExists,
-	}, {
-		args: []string{"ms:juju-info", "lg"},
-		err:  msLgAlreadyExists,
-	}, {
-		args: []string{"ms", "lg:info"},
-		err:  msLgAlreadyExists,
-	}, {
-		args: []string{"ms:juju-info", "lg:info"},
-		err:  msLgAlreadyExists,
-	},
+	// 1 empty and 1 non-empty arguments
+	err = s.runAddRelation(c, "application1", "")
+	c.Assert(err, gc.ErrorMatches, "a relation must involve two applications")
 
-	// Add a real relation using an explicit endpoint, avoiding the potential implicit one.
-	{
-		args: []string{"wp", "lg"},
-	}, {
-		args: []string{"wp", "lg"},
-		err:  wpLgAlreadyExists,
-	}, {
-		args: []string{"lg", "wp"},
-		err:  wpLgAlreadyExists,
-	}, {
-		args: []string{"wp:logging-dir", "lg"},
-		err:  wpLgAlreadyExists,
-	}, {
-		args: []string{"wp", "lg:logging-directory"},
-		err:  wpLgAlreadyExists,
-	}, {
-		args: []string{"wp:logging-dir", "lg:logging-directory"},
-		err:  wpLgAlreadyExists,
-	},
-
-	// Check we can still use the implicit endpoint if specified explicitly.
-	{
-		args: []string{"wp:juju-info", "lg"},
-	}, {
-		args: []string{"wp:juju-info", "lg"},
-		err:  wpLgAlreadyExistsJuju,
-	}, {
-		args: []string{"lg", "wp:juju-info"},
-		err:  wpLgAlreadyExistsJuju,
-	}, {
-		args: []string{"wp:juju-info", "lg"},
-		err:  wpLgAlreadyExistsJuju,
-	}, {
-		args: []string{"wp", "lg:info"},
-		err:  wpLgAlreadyExistsJuju,
-	}, {
-		args: []string{"wp:juju-info", "lg:info"},
-		err:  wpLgAlreadyExistsJuju,
-	},
+	// 1 empty and 1 non-empty arguments
+	err = s.runAddRelation(c, "", "application2")
+	c.Assert(err, gc.ErrorMatches, "a relation must involve two applications")
 }
 
-func (s *AddRelationSuite) TestAddRelation(c *gc.C) {
-	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "wordpress")
-	err := runDeploy(c, ch, "wp", "--series", "quantal")
+func (s *AddRelationSuite) TestAddRelationSuccess(c *gc.C) {
+	err := s.runAddRelation(c, "application1", "application2")
 	c.Assert(err, jc.ErrorIsNil)
-	ch = testcharms.Repo.CharmArchivePath(s.CharmsPath, "mysql")
-	err = runDeploy(c, ch, "ms", "--series", "quantal")
-	c.Assert(err, jc.ErrorIsNil)
-	ch = testcharms.Repo.CharmArchivePath(s.CharmsPath, "riak")
-	err = runDeploy(c, ch, "rk", "--series", "quantal")
-	c.Assert(err, jc.ErrorIsNil)
-	ch = testcharms.Repo.CharmArchivePath(s.CharmsPath, "logging")
-	err = runDeploy(c, ch, "lg", "--series", "quantal")
-	c.Assert(err, jc.ErrorIsNil)
+}
 
-	for i, t := range addRelationTests {
-		c.Logf("test %d: %v", i, t.args)
-		err := runAddRelation(c, t.args...)
-		if t.err != "" {
-			c.Assert(err, gc.ErrorMatches, t.err)
-		}
+func (s *AddRelationSuite) TestAddRelationFail(c *gc.C) {
+	msg := "fail add relation"
+	s.mockAPI = &mockAddAPI{
+		addRelationFunc: func(endpoints ...string) (*params.AddRelationResults, error) {
+			return nil, errors.New(msg)
+		},
 	}
+	err := s.runAddRelation(c, "application1", "application2")
+	c.Assert(err, gc.ErrorMatches, msg)
 }
 
-func (s *AddRelationSuite) TestBlockAddRelation(c *gc.C) {
-	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "wordpress")
-	err := runDeploy(c, ch, "wp", "--series", "quantal")
-	c.Assert(err, jc.ErrorIsNil)
-	ch = testcharms.Repo.CharmArchivePath(s.CharmsPath, "mysql")
-	err = runDeploy(c, ch, "ms", "--series", "quantal")
-	c.Assert(err, jc.ErrorIsNil)
-	ch = testcharms.Repo.CharmArchivePath(s.CharmsPath, "riak")
-	err = runDeploy(c, ch, "rk", "--series", "quantal")
-	c.Assert(err, jc.ErrorIsNil)
-	ch = testcharms.Repo.CharmArchivePath(s.CharmsPath, "logging")
-	err = runDeploy(c, ch, "lg", "--series", "quantal")
-	c.Assert(err, jc.ErrorIsNil)
-
+func (s *AddRelationSuite) TestAddRelationBlocked(c *gc.C) {
 	// Block operation
-	s.BlockAllChanges(c, "TestBlockAddRelation")
-
-	for i, t := range addRelationTests {
-		c.Logf("test %d: %v", i, t.args)
-		err := runAddRelation(c, t.args...)
-		if len(t.args) == 2 {
-			// Only worry about Run being blocked.
-			// For len(t.args) != 2, an Init will fail
-			s.AssertBlocked(c, err, ".*TestBlockAddRelation.*")
-		}
+	s.mockAPI.addRelationFunc = func(endpoints ...string) (*params.AddRelationResults, error) {
+		return nil, common.OperationBlockedError("TestBlockAddRelation")
 	}
+	err := s.runAddRelation(c, "application1", "application2")
+	coretesting.AssertOperationWasBlocked(c, err, ".*TestBlockAddRelation.*")
+}
+
+type mockAddAPI struct {
+	addRelationFunc func(endpoints ...string) (*params.AddRelationResults, error)
+}
+
+func (s mockAddAPI) Close() error {
+	return nil
+}
+
+func (s mockAddAPI) AddRelation(endpoints ...string) (*params.AddRelationResults, error) {
+	return s.addRelationFunc(endpoints...)
 }

--- a/cmd/juju/application/addrelation_test.go
+++ b/cmd/juju/application/addrelation_test.go
@@ -53,7 +53,8 @@ func (s *AddRelationSuite) TestAddRelationWrongNumberOfArguments(c *gc.C) {
 func (s *AddRelationSuite) TestAddRelationSuccess(c *gc.C) {
 	err := s.runAddRelation(c, "application1", "application2")
 	c.Assert(err, jc.ErrorIsNil)
-	s.mockAPI.CheckCallNames(c, "AddRelation", "Close")
+	s.mockAPI.CheckCall(c, 0, "AddRelation", []string{"application1", "application2"})
+	s.mockAPI.CheckCall(c, 1, "Close")
 }
 
 func (s *AddRelationSuite) TestAddRelationFail(c *gc.C) {
@@ -61,14 +62,16 @@ func (s *AddRelationSuite) TestAddRelationFail(c *gc.C) {
 	s.mockAPI.SetErrors(errors.New(msg))
 	err := s.runAddRelation(c, "application1", "application2")
 	c.Assert(err, gc.ErrorMatches, msg)
-	s.mockAPI.CheckCallNames(c, "AddRelation", "Close")
+	s.mockAPI.CheckCall(c, 0, "AddRelation", []string{"application1", "application2"})
+	s.mockAPI.CheckCall(c, 1, "Close")
 }
 
 func (s *AddRelationSuite) TestAddRelationBlocked(c *gc.C) {
 	s.mockAPI.SetErrors(common.OperationBlockedError("TestBlockAddRelation"))
 	err := s.runAddRelation(c, "application1", "application2")
 	coretesting.AssertOperationWasBlocked(c, err, ".*TestBlockAddRelation.*")
-	s.mockAPI.CheckCallNames(c, "AddRelation", "Close")
+	s.mockAPI.CheckCall(c, 0, "AddRelation", []string{"application1", "application2"})
+	s.mockAPI.CheckCall(c, 1, "Close")
 }
 
 type mockAddAPI struct {

--- a/cmd/juju/application/addrelation_test.go
+++ b/cmd/juju/application/addrelation_test.go
@@ -37,25 +37,17 @@ func (s *AddRelationSuite) runAddRelation(c *gc.C, args ...string) error {
 	return err
 }
 
-func (s *AddRelationSuite) TestAddRelationNotEnoughArguments(c *gc.C) {
+func (s *AddRelationSuite) TestAddRelationWrongNumberOfArguments(c *gc.C) {
 	// No arguments
 	err := s.runAddRelation(c)
 	c.Assert(err, gc.ErrorMatches, "a relation must involve two applications")
 
-	// 1 empty argument
+	// 1 argument
 	err = s.runAddRelation(c, "")
 	c.Assert(err, gc.ErrorMatches, "a relation must involve two applications")
 
-	// 2 empty arguments
-	err = s.runAddRelation(c, "", "")
-	c.Assert(err, gc.ErrorMatches, "a relation must involve two applications")
-
-	// 1 empty and 1 non-empty arguments
-	err = s.runAddRelation(c, "application1", "")
-	c.Assert(err, gc.ErrorMatches, "a relation must involve two applications")
-
-	// 1 empty and 1 non-empty arguments
-	err = s.runAddRelation(c, "", "application2")
+	// more than 2 arguments
+	err = s.runAddRelation(c, "", "", "")
 	c.Assert(err, gc.ErrorMatches, "a relation must involve two applications")
 }
 

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -53,6 +53,22 @@ func NewAddUnitCommandForTest(api serviceAddUnitAPI) cmd.Command {
 	})
 }
 
+// NewAddRelationCommandForTest returns an AddRelationCommand with the api provided as specified.
+func NewAddRelationCommandForTest(api ApplicationAddRelationAPI) cmd.Command {
+	cmd := &addRelationCommand{newAPIFunc: func() (ApplicationAddRelationAPI, error) {
+		return api, nil
+	}}
+	return modelcmd.Wrap(cmd)
+}
+
+// NewRemoveRelationCommandForTest returns an RemoveRelationCommand with the api provided as specified.
+func NewRemoveRelationCommandForTest(api ApplicationDestroyRelationAPI) cmd.Command {
+	cmd := &removeRelationCommand{newAPIFunc: func() (ApplicationDestroyRelationAPI, error) {
+		return api, nil
+	}}
+	return modelcmd.Wrap(cmd)
+}
+
 type Patcher interface {
 	PatchValue(dest, value interface{})
 }

--- a/cmd/juju/application/removerelation.go
+++ b/cmd/juju/application/removerelation.go
@@ -39,13 +39,23 @@ See also:
 
 // NewRemoveRelationCommand returns a command to remove a relation between 2 services.
 func NewRemoveRelationCommand() cmd.Command {
-	return modelcmd.Wrap(&removeRelationCommand{})
+	cmd := &removeRelationCommand{}
+	cmd.newAPIFunc = func() (ApplicationDestroyRelationAPI, error) {
+		root, err := cmd.NewAPIRoot()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return application.NewClient(root), nil
+
+	}
+	return modelcmd.Wrap(cmd)
 }
 
 // removeRelationCommand causes an existing application relation to be shut down.
 type removeRelationCommand struct {
 	modelcmd.ModelCommandBase
-	Endpoints []string
+	Endpoints  []string
+	newAPIFunc func() (ApplicationDestroyRelationAPI, error)
 }
 
 func (c *removeRelationCommand) Info() *cmd.Info {
@@ -61,25 +71,22 @@ func (c *removeRelationCommand) Init(args []string) error {
 	if len(args) != 2 {
 		return errors.Errorf("a relation must involve two applications")
 	}
+	// None of the arguments can be empty.
+	if args[0] == "" || args[1] == "" {
+		return errors.Errorf("a relation must involve two applications")
+	}
 	c.Endpoints = args
 	return nil
 }
 
-type serviceDestroyRelationAPI interface {
+// ApplicationDestroyRelationAPI defines the API methods that application remove relation command uses.
+type ApplicationDestroyRelationAPI interface {
 	Close() error
 	DestroyRelation(endpoints ...string) error
 }
 
-func (c *removeRelationCommand) getAPI() (serviceDestroyRelationAPI, error) {
-	root, err := c.NewAPIRoot()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return application.NewClient(root), nil
-}
-
 func (c *removeRelationCommand) Run(_ *cmd.Context) error {
-	client, err := c.getAPI()
+	client, err := c.newAPIFunc()
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/application/removerelation.go
+++ b/cmd/juju/application/removerelation.go
@@ -71,10 +71,6 @@ func (c *removeRelationCommand) Init(args []string) error {
 	if len(args) != 2 {
 		return errors.Errorf("a relation must involve two applications")
 	}
-	// None of the arguments can be empty.
-	if args[0] == "" || args[1] == "" {
-		return errors.Errorf("a relation must involve two applications")
-	}
 	c.Endpoints = args
 	return nil
 }

--- a/cmd/juju/application/removerelation_test.go
+++ b/cmd/juju/application/removerelation_test.go
@@ -62,7 +62,7 @@ func (s *RemoveRelationSuite) TestRemoveRelationSuccess(c *gc.C) {
 }
 
 func (s *RemoveRelationSuite) TestRemoveRelationFail(c *gc.C) {
-	msg := "fail remove relation"
+	msg := "fail remove-relation at API"
 	s.mockAPI = &mockRemoveAPI{
 		removeRelationFunc: func(endpoints ...string) error {
 			return errors.New(msg)

--- a/cmd/juju/application/removerelation_test.go
+++ b/cmd/juju/application/removerelation_test.go
@@ -34,25 +34,17 @@ func (s *RemoveRelationSuite) runRemoveRelation(c *gc.C, args ...string) error {
 	return err
 }
 
-func (s *RemoveRelationSuite) TestRemoveRelationNotEnoughArguments(c *gc.C) {
+func (s *RemoveRelationSuite) TestRemoveRelationWrongNumberOfArguments(c *gc.C) {
 	// No arguments
 	err := s.runRemoveRelation(c)
 	c.Assert(err, gc.ErrorMatches, "a relation must involve two applications")
 
-	// 1 empty argument
+	// 1 argument
 	err = s.runRemoveRelation(c, "")
 	c.Assert(err, gc.ErrorMatches, "a relation must involve two applications")
 
-	// 2 empty arguments
-	err = s.runRemoveRelation(c, "", "")
-	c.Assert(err, gc.ErrorMatches, "a relation must involve two applications")
-
-	// 1 empty and 1 non-empty arguments
-	err = s.runRemoveRelation(c, "application1", "")
-	c.Assert(err, gc.ErrorMatches, "a relation must involve two applications")
-
-	// 1 empty and 1 non-empty arguments
-	err = s.runRemoveRelation(c, "", "application2")
+	// More than 2 arguments
+	err = s.runRemoveRelation(c, "", "", "")
 	c.Assert(err, gc.ErrorMatches, "a relation must involve two applications")
 }
 

--- a/cmd/juju/application/removerelation_test.go
+++ b/cmd/juju/application/removerelation_test.go
@@ -50,7 +50,8 @@ func (s *RemoveRelationSuite) TestRemoveRelationWrongNumberOfArguments(c *gc.C) 
 func (s *RemoveRelationSuite) TestRemoveRelationSuccess(c *gc.C) {
 	err := s.runRemoveRelation(c, "application1", "application2")
 	c.Assert(err, jc.ErrorIsNil)
-	s.mockAPI.CheckCallNames(c, "DestroyRelation", "Close")
+	s.mockAPI.CheckCall(c, 0, "DestroyRelation", []string{"application1", "application2"})
+	s.mockAPI.CheckCall(c, 1, "Close")
 }
 
 func (s *RemoveRelationSuite) TestRemoveRelationFail(c *gc.C) {
@@ -58,14 +59,16 @@ func (s *RemoveRelationSuite) TestRemoveRelationFail(c *gc.C) {
 	s.mockAPI.SetErrors(errors.New(msg))
 	err := s.runRemoveRelation(c, "application1", "application2")
 	c.Assert(err, gc.ErrorMatches, msg)
-	s.mockAPI.CheckCallNames(c, "DestroyRelation", "Close")
+	s.mockAPI.CheckCall(c, 0, "DestroyRelation", []string{"application1", "application2"})
+	s.mockAPI.CheckCall(c, 1, "Close")
 }
 
 func (s *RemoveRelationSuite) TestRemoveRelationBlocked(c *gc.C) {
 	s.mockAPI.SetErrors(common.OperationBlockedError("TestRemoveRelationBlocked"))
 	err := s.runRemoveRelation(c, "application1", "application2")
 	coretesting.AssertOperationWasBlocked(c, err, ".*TestRemoveRelationBlocked.*")
-	s.mockAPI.CheckCallNames(c, "DestroyRelation", "Close")
+	s.mockAPI.CheckCall(c, 0, "DestroyRelation", []string{"application1", "application2"})
+	s.mockAPI.CheckCall(c, 1, "Close")
 }
 
 type mockRemoveAPI struct {

--- a/featuretests/cmd_juju_relation_test.go
+++ b/featuretests/cmd_juju_relation_test.go
@@ -4,10 +4,8 @@
 package featuretests
 
 import (
-	"bytes"
 	"os"
 
-	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/juju/osenv"
@@ -30,36 +28,20 @@ func (s *CmdRelationSuite) SetUpTest(c *gc.C) {
 	}
 }
 
-func run(c *gc.C, command, expectedError string, args ...string) {
-	cmdArgs := append([]string{command}, args...)
-	context, err := runCommand(c, cmdArgs...)
-	if expectedError == "" {
-		c.Assert(err, jc.ErrorIsNil)
-	} else {
-		c.Assert(err, gc.ErrorMatches, "cmd: error out silently")
-		buff, ok := context.GetStderr().(*bytes.Buffer)
-		if !ok {
-			c.Log("could not get stderr content")
-			c.Fail()
-		}
-		c.Assert(buff.String(), jc.Contains, expectedError)
-	}
-}
-
 func (s *CmdRelationSuite) TestAddRelationSuccess(c *gc.C) {
-	run(c, "add-relation", "", s.apps...)
+	runCommandExpectSuccess(c, "add-relation", s.apps...)
 }
 
 func (s *CmdRelationSuite) TestAddRelationFail(c *gc.C) {
-	run(c, "add-relation", "", s.apps...)
-	run(c, "add-relation", `cannot add relation "wordpress:db mysql:server": relation already exists`, s.apps...)
+	runCommandExpectSuccess(c, "add-relation", s.apps...)
+	runCommandExpectFailure(c, "add-relation", `cannot add relation "wordpress:db mysql:server": relation already exists`, s.apps...)
 }
 
 func (s *CmdRelationSuite) TestRemoveRelationSuccess(c *gc.C) {
-	run(c, "add-relation", "", s.apps...)
-	run(c, "remove-relation", "", s.apps...)
+	runCommandExpectSuccess(c, "add-relation", s.apps...)
+	runCommandExpectSuccess(c, "remove-relation", s.apps...)
 }
 
 func (s *CmdRelationSuite) TestRemoveRelationFail(c *gc.C) {
-	run(c, "remove-relation", `relation "wordpress:db mysql:server" not found`, s.apps...)
+	runCommandExpectFailure(c, "remove-relation", `relation "wordpress:db mysql:server" not found`, s.apps...)
 }

--- a/featuretests/cmd_juju_relation_test.go
+++ b/featuretests/cmd_juju_relation_test.go
@@ -1,0 +1,65 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	"bytes"
+	"os"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/juju/osenv"
+	jujutesting "github.com/juju/juju/juju/testing"
+)
+
+type CmdRelationSuite struct {
+	jujutesting.JujuConnSuite
+	apps []string
+}
+
+func (s *CmdRelationSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	os.Setenv(osenv.JujuModelEnvKey, "")
+
+	s.apps = []string{"wordpress", "mysql"}
+	for _, app := range s.apps {
+		ch := s.AddTestingCharm(c, app)
+		s.AddTestingService(c, app, ch)
+	}
+}
+
+func run(c *gc.C, command, expectedError string, args ...string) {
+	cmdArgs := append([]string{command}, args...)
+	context, err := runCommand(c, cmdArgs...)
+	if expectedError == "" {
+		c.Assert(err, jc.ErrorIsNil)
+	} else {
+		c.Assert(err, gc.ErrorMatches, "cmd: error out silently")
+		buff, ok := context.GetStderr().(*bytes.Buffer)
+		if !ok {
+			c.Log("could not get stderr content")
+			c.Fail()
+		}
+		c.Assert(buff.String(), jc.Contains, expectedError)
+	}
+}
+
+func (s *CmdRelationSuite) TestAddRelationSuccess(c *gc.C) {
+	run(c, "add-relation", "", s.apps...)
+}
+
+func (s *CmdRelationSuite) TestAddRelationFail(c *gc.C) {
+	run(c, "add-relation", "", s.apps...)
+	run(c, "add-relation", `cannot add relation "wordpress:db mysql:server": relation already exists`, s.apps...)
+}
+
+func (s *CmdRelationSuite) TestRemoveRelationSuccess(c *gc.C) {
+	run(c, "add-relation", "", s.apps...)
+	run(c, "remove-relation", "", s.apps...)
+}
+
+func (s *CmdRelationSuite) TestRemoveRelationFail(c *gc.C) {
+	run(c, "remove-relation", `relation "wordpress:db mysql:server" not found`, s.apps...)
+}

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -6,7 +6,7 @@ package featuretests
 import (
 	"flag"
 	"runtime"
-	stdtesting "testing"
+	"testing"
 
 	"github.com/juju/cmd"
 	"github.com/juju/loggo"
@@ -52,7 +52,7 @@ func init() {
 	}
 }
 
-func TestPackage(t *stdtesting.T) {
+func TestPackage(t *testing.T) {
 	coretesting.MgoTestPackage(t)
 }
 
@@ -62,8 +62,18 @@ func runCommand(c *gc.C, args ...string) (*cmd.Context, error) {
 	// return an error if we attempt to run two commands in the
 	// same test.
 	loggo.ResetWriters()
-	ctx, err := cmd.DefaultContext()
-	c.Assert(err, jc.ErrorIsNil)
+	ctx := coretesting.Context(c)
 	command := jujucmd.NewJujuCommand(ctx)
 	return coretesting.RunCommand(c, command, args...)
+}
+
+func runCommandExpectSuccess(c *gc.C, command string, args ...string) {
+	_, err := runCommand(c, append([]string{command}, args...)...)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func runCommandExpectFailure(c *gc.C, command, expectedError string, args ...string) {
+	context, err := runCommand(c, append([]string{command}, args...)...)
+	c.Assert(err, gc.ErrorMatches, "cmd: error out silently")
+	c.Assert(coretesting.Stderr(context), jc.Contains, expectedError)
 }

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -8,15 +8,18 @@ import (
 	"runtime"
 	stdtesting "testing"
 
+	"github.com/juju/cmd"
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	jujucmd "github.com/juju/juju/cmd/juju/commands"
 	coretesting "github.com/juju/juju/testing"
 )
 
 var runFeatureTests = flag.Bool("featuretests", true, "Run long-running feature tests.")
 
 func init() {
-
 	flag.Parse()
 
 	if *runFeatureTests == false {
@@ -39,6 +42,7 @@ func init() {
 	gc.Suite(&dumpLogsCommandSuite{})
 	gc.Suite(&undertakerSuite{})
 	gc.Suite(&upgradeSuite{})
+	gc.Suite(&CmdRelationSuite{})
 
 	// TODO (anastasiamac 2016-07-19) Bug#1603585
 	// These tests cannot run on windows - they require a bootstrapped controller.
@@ -50,4 +54,16 @@ func init() {
 
 func TestPackage(t *stdtesting.T) {
 	coretesting.MgoTestPackage(t)
+}
+
+func runCommand(c *gc.C, args ...string) (*cmd.Context, error) {
+	// Writers need to be reset, because
+	// they are set globally in the juju/cmd package and will
+	// return an error if we attempt to run two commands in the
+	// same test.
+	loggo.ResetWriters()
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, jc.ErrorIsNil)
+	command := jujucmd.NewJujuCommand(ctx)
+	return coretesting.RunCommand(c, command, args...)
 }

--- a/testing/cmdblockhelper.go
+++ b/testing/cmdblockhelper.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/juju/cmd"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api/base"
@@ -66,4 +67,5 @@ func AssertOperationWasBlocked(c *gc.C, err error, msg string) {
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
 	c.Check(stripped, gc.Matches, msg)
+	c.Check(stripped, jc.Contains, "disabled")
 }

--- a/testing/cmdblockhelper.go
+++ b/testing/cmdblockhelper.go
@@ -60,3 +60,10 @@ func (s *CmdBlockHelper) AssertBlocked(c *gc.C, err error, msg string) {
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
 	c.Check(stripped, gc.Matches, msg)
 }
+
+func AssertOperationWasBlocked(c *gc.C, err error, msg string) {
+	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
+	// msg is logged
+	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
+	c.Check(stripped, gc.Matches, msg)
+}


### PR DESCRIPTION
This PR:
1. changes relation commands to have api-getter functions;
2. ensures related cmd package are unit tests by testing command behavior with mock API;
3. adds related full-stack tests to featuretests package to ensure that all connections are made as expected.

I have consciously removed some tests like relation validation as those belong in the package where validation actually happens - see apiserver/application. And, indeed, we have the tests that cover all possible permutations there.