### PR TITLE
Update juju testing dep

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -42,10 +42,10 @@ github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:4
 github.com/juju/romulus	git	bf7827fa2f360ab762c134766ff1d4fff959ea03	2016-08-17T23:29:48Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
-github.com/juju/testing	git	cad2dd5fff869bac963652191cf2cc41a72a41a2	2016-09-16T06:01:18Z
+github.com/juju/testing	git	6d7e9c5f21a86d05e8c466c0f2f9d37d150b3af1	2016-09-27T13:51:18Z
 github.com/juju/txn	git	18d812a45ffc407a4d5f849036b7d8d12febaf08	2016-09-13T21:23:40Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils	git	50f2d54645aeb2828a0081a72704457cece7e4cb	2016-09-16T02:08:06Z
+github.com/juju/utils	git	406e7197d0690a3f28c5a147138774eec4c1355e	2016-09-26T13:08:26Z
 github.com/juju/version	git	4ae6172c00626779a5a462c3e3d22fc0e889431a	2016-06-03T19:49:58Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z


### PR DESCRIPTION
This increases the number of lines that we carry over from mongo -- when
mongo exits unexpectedly -- from 20 to 100.

QA: run godeps and ensure you get the updated testing repo.