### PR TITLE
provider/maas: only bridge specified interfaces

### DIFF
--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -111,7 +111,7 @@ class LogicalInterface(object):
         return result
 
     # Returns an ordered set of stanzas to bridge this interface.
-    def bridge(self, prefix, bridge_name):
+    def _bridge(self, prefix, bridge_name):
         if bridge_name is None:
             bridge_name = prefix + self.name
         # Note: the testing order here is significant.
@@ -286,15 +286,11 @@ class NetworkInterfaceParser(object):
             return bridge_port in iface.bridge_ports
         return False
 
-    def bridge_all(self, interface_name_to_bridge, bridge_prefix, bridge_name):
-        # The interface_name_to_bridge test is to bridge a single interface
-        # only, which is only used for juju < 2.0. And if that
-        # argument is specified then bridge_name takes precedence over
-        # any bridge_prefix.
+    def bridge(self, interface_names_to_bridge, bridge_prefix, bridge_name):
         bridged_stanzas = []
         for s in self.stanzas():
             if s.is_logical_interface:
-                if interface_name_to_bridge and interface_name_to_bridge != s.iface.name:
+                if s.iface.name not in interface_names_to_bridge:
                     if s.iface.has_auto_stanza:
                         bridged_stanzas.append(AutoStanza(s.iface.name))
                     bridged_stanzas.append(s)
@@ -305,7 +301,7 @@ class NetworkInterfaceParser(object):
                             bridged_stanzas.append(AutoStanza(s.iface.name))
                         bridged_stanzas.append(s)
                     else:
-                        bridged_stanzas.extend(s.iface.bridge(bridge_prefix, bridge_name))
+                        bridged_stanzas.extend(s.iface._bridge(bridge_prefix, bridge_name))
             elif not s.is_physical_interface:
                 bridged_stanzas.append(s)
         return bridged_stanzas
@@ -410,23 +406,25 @@ def arg_parser():
     parser.add_argument('--bridge-prefix', help="bridge prefix", type=str, required=False, default='br-')
     parser.add_argument('--one-time-backup', help='A one time backup of filename', action='store_true', default=True, required=False)
     parser.add_argument('--activate', help='activate new configuration', action='store_true', default=False, required=False)
-    parser.add_argument('--interface-to-bridge', help="interface to bridge", type=str, required=False)
+    parser.add_argument('--interfaces-to-bridge', help="interfaces to bridge; space delimited", type=str, required=True)
     parser.add_argument('--bridge-name', help="bridge name", type=str, required=False)
     parser.add_argument('filename', help="interfaces(5) based filename")
     return parser
 
 
 def main(args):
-    if args.bridge_name and args.interface_to_bridge is None:
-        sys.stderr.write("error: --interface-to-bridge required when using --bridge-name\n")
+    interfaces = args.interfaces_to_bridge.split()
+
+    if len(interfaces) == 0:
+        sys.stderr.write("error: no interfaces specified\n")
         exit(1)
 
-    if args.interface_to_bridge and args.bridge_name is None:
-        sys.stderr.write("error: --bridge-name required when using --interface-to-bridge\n")
+    if args.bridge_name and len(interfaces) > 1:
+        sys.stderr.write("error: cannot use single bridge name '{}' against multiple interface names\n".format(args.bridge_name))
         exit(1)
 
     parser = NetworkInterfaceParser(args.filename)
-    stanzas = parser.bridge_all(args.interface_to_bridge, args.bridge_prefix, args.bridge_name)
+    stanzas = parser.bridge(interfaces, args.bridge_prefix, args.bridge_name)
 
     if not args.activate:
         print_stanzas(stanzas)

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -73,12 +73,12 @@ func (s *bridgeConfigSuite) assertScript(c *gc.C, initialConfig, expectedConfig,
 	}
 }
 
-func (s *bridgeConfigSuite) assertScriptWithPrefix(c *gc.C, initial, expected, prefix string) {
-	s.assertScript(c, initial, expected, prefix, "", "")
+func (s *bridgeConfigSuite) assertScriptWithPrefix(c *gc.C, initial, expected, prefix, interfaceToBridge string) {
+	s.assertScript(c, initial, expected, prefix, "", interfaceToBridge)
 }
 
-func (s *bridgeConfigSuite) assertScriptWithDefaultPrefix(c *gc.C, initial, expected string) {
-	s.assertScript(c, initial, expected, "", "", "")
+func (s *bridgeConfigSuite) assertScriptWithDefaultPrefix(c *gc.C, initial, expected, interfaceToBridge string) {
+	s.assertScript(c, initial, expected, "", "", interfaceToBridge)
 }
 
 func (s *bridgeConfigSuite) assertScriptWithoutPrefix(c *gc.C, initial, expected, bridgeName, interfaceToBridge string) {
@@ -89,52 +89,54 @@ func (s *bridgeConfigSuite) TestBridgeScriptWithUndefinedArgs(c *gc.C) {
 	for i, python := range s.pythonVersions {
 		c.Logf("test #%v using %s", i, python)
 		_, code := s.runScript(c, python, "", "", "", "")
-		c.Check(code, gc.Equals, 1)
+		c.Check(code, gc.Equals, 2)
 	}
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptWithPrefixTransformation(c *gc.C) {
 	for i, v := range []struct {
-		initial  string
-		expected string
-		prefix   string
+		interfaceToBridge string
+		initial           string
+		expected          string
+		prefix            string
 	}{
-		{networkDHCPInitial, networkDHCPExpected, "test-br-"},
-		{networkStaticWithAliasInitial, networkStaticWithAliasExpected, "test-br-"},
-		{networkDHCPWithBondInitial, networkDHCPWithBondExpected, "test-br-"},
-		{networkDualNICInitial, networkDualNICExpected, "test-br-"},
-		{networkMultipleAliasesInitial, networkMultipleAliasesExpected, "test-br-"},
-		{networkMultipleStaticWithAliasesInitial, networkMultipleStaticWithAliasesExpected, "test-br-"},
-		{networkSmorgasboardInitial, networkSmorgasboardExpected, "juju-br-"},
-		{networkStaticInitial, networkStaticExpected, "test-br-"},
-		{networkVLANInitial, networkVLANExpected, "vlan-br-"},
-		{networkWithAliasInitial, networkWithAliasExpected, "test-br-"},
+		{networkDHCPInterfacesToBridge, networkDHCPInitial, networkDHCPExpected, "test-br-"},
+		{networkStaticWithAliasInterfacesToBridge, networkStaticWithAliasInitial, networkStaticWithAliasExpected, "test-br-"},
+		{networkDHCPWithBondInterfacesToBridge, networkDHCPWithBondInitial, networkDHCPWithBondExpected, "test-br-"},
+		{networkDualNICInterfacesToBridge, networkDualNICInitial, networkDualNICExpected, "test-br-"},
+		{networkMultipleAliasesInterfacesToBridge, networkMultipleAliasesInitial, networkMultipleAliasesExpected, "test-br-"},
+		{networkMultipleStaticWithAliasesInterfacesToBridge, networkMultipleStaticWithAliasesInitial, networkMultipleStaticWithAliasesExpected, "test-br-"},
+		{networkSmorgasboardInterfacesToBridge, networkSmorgasboardInitial, networkSmorgasboardExpected, "juju-br-"},
+		{networkStaticInterfacesToBridge, networkStaticInitial, networkStaticExpected, "test-br-"},
+		{networkVLANInterfacesToBridge, networkVLANInitial, networkVLANExpected, "vlan-br-"},
+		{networkWithAliasInterfacesToBridge, networkWithAliasInitial, networkWithAliasExpected, "test-br-"},
 	} {
 		c.Logf("test #%v - expected transformation", i)
-		s.assertScriptWithPrefix(c, v.initial, v.expected, v.prefix)
+		s.assertScriptWithPrefix(c, v.initial, v.expected, v.prefix, v.interfaceToBridge)
 		c.Logf("test #%v - idempotent transformation", i)
-		s.assertScriptWithPrefix(c, v.expected, v.expected, v.prefix)
+		s.assertScriptWithPrefix(c, v.expected, v.expected, v.prefix, v.interfaceToBridge)
 	}
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptWithDefaultPrefixTransformation(c *gc.C) {
 	for i, v := range []struct {
-		initial  string
-		expected string
+		interfaceToBridge string
+		initial           string
+		expected          string
 	}{
-		{networkLoopbackOnlyInitial, networkLoopbackOnlyExpected},
-		{networkStaticBondWithVLANsInitial, networkStaticBondWithVLANsExpected},
-		{networkVLANWithActiveDHCPDeviceInitial, networkVLANWithActiveDHCPDeviceExpected},
-		{networkVLANWithInactiveDeviceInitial, networkVLANWithInactiveDeviceExpected},
-		{networkVLANWithMultipleNameserversInitial, networkVLANWithMultipleNameserversExpected},
-		{networkWithEmptyDNSValuesInitial, networkWithEmptyDNSValuesExpected},
-		{networkWithMultipleDNSValuesInitial, networkWithMultipleDNSValuesExpected},
-		{networkPartiallyBridgedInitial, networkPartiallyBridgedExpected},
+		{networkLoopbackOnlyInterfacesToBridge, networkLoopbackOnlyInitial, networkLoopbackOnlyExpected},
+		{networkStaticBondWithVLANsInterfacesToBridge, networkStaticBondWithVLANsInitial, networkStaticBondWithVLANsExpected},
+		{networkVLANWithActiveDHCPDeviceInterfacesToBridge, networkVLANWithActiveDHCPDeviceInitial, networkVLANWithActiveDHCPDeviceExpected},
+		{networkVLANWithInactiveDeviceInterfacesToBridge, networkVLANWithInactiveDeviceInitial, networkVLANWithInactiveDeviceExpected},
+		{networkVLANWithMultipleNameserversInterfacesToBridge, networkVLANWithMultipleNameserversInitial, networkVLANWithMultipleNameserversExpected},
+		{networkWithEmptyDNSValuesInterfacesToBridge, networkWithEmptyDNSValuesInitial, networkWithEmptyDNSValuesExpected},
+		{networkWithMultipleDNSValuesInterfacesToBridge, networkWithMultipleDNSValuesInitial, networkWithMultipleDNSValuesExpected},
+		{networkPartiallyBridgedInterfacesToBridge, networkPartiallyBridgedInitial, networkPartiallyBridgedExpected},
 	} {
 		c.Logf("test #%v - expected transformation", i)
-		s.assertScriptWithDefaultPrefix(c, v.initial, v.expected)
+		s.assertScriptWithDefaultPrefix(c, v.initial, v.expected, v.interfaceToBridge)
 		c.Logf("test #%v - idempotent transformation", i)
-		s.assertScriptWithDefaultPrefix(c, v.expected, v.expected)
+		s.assertScriptWithDefaultPrefix(c, v.expected, v.expected, v.interfaceToBridge)
 	}
 }
 
@@ -142,22 +144,12 @@ func (s *bridgeConfigSuite) TestBridgeScriptInterfaceNameArgumentRequired(c *gc.
 	for i, python := range s.pythonVersions {
 		c.Logf("test #%v using %s", i, python)
 		output, code := s.runScript(c, python, "# no content", "", "juju-br0", "")
-		c.Check(code, gc.Equals, 1)
-		c.Check(strings.Trim(output, "\n"), gc.Equals, "error: --interface-to-bridge required when using --bridge-name")
+		c.Check(code, gc.Equals, 2)
+		// We match very lazily here to isolate ourselves from
+		// the different formatting of argparse error messages
+		// that has occured between Python 2 and Python 3.
+		c.Check(strings.Trim(output, "\n"), gc.Matches, "(\n|.)*error:.*--interfaces-to-bridge.*")
 	}
-}
-
-func (s *bridgeConfigSuite) TestBridgeScriptBridgeNameArgumentRequired(c *gc.C) {
-	for i, python := range s.pythonVersions {
-		c.Logf("test #%v using %s", i, python)
-		output, code := s.runScript(c, python, "# no content", "", "", "eth0")
-		c.Check(code, gc.Equals, 1)
-		c.Check(strings.Trim(output, "\n"), gc.Equals, "error: --bridge-name required when using --interface-to-bridge")
-	}
-}
-
-func (s *bridgeConfigSuite) TestBridgeScriptMatchingNonExistentSpecificIface(c *gc.C) {
-	s.assertScriptWithoutPrefix(c, networkStaticInitial, networkStaticInitial, "juju-br0", "eth1234567890")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptMatchingExistingSpecificIfaceButMissingAutoStanza(c *gc.C) {
@@ -178,7 +170,7 @@ func (s *bridgeConfigSuite) runScript(c *gc.C, pythonBinary, configFile, bridgeP
 	}
 
 	if interfaceToBridge != "" {
-		interfaceToBridge = fmt.Sprintf("--interface-to-bridge=%q", interfaceToBridge)
+		interfaceToBridge = fmt.Sprintf("--interfaces-to-bridge=%q", interfaceToBridge)
 	}
 
 	script := fmt.Sprintf("%q %q %s %s %s %q\n", pythonBinary, s.testPythonScript, bridgePrefix, bridgeName, interfaceToBridge, configFile)
@@ -206,6 +198,8 @@ iface eth0 inet static
     netmask 255.255.255.0
     gateway 4.3.2.1`
 
+const networkStaticInterfacesToBridge = "eth0"
+
 const networkStaticExpected = `auto lo
 iface lo inet loopback
 
@@ -224,6 +218,8 @@ iface lo inet loopback
 
 auto eth0
 iface eth0 inet dhcp`
+
+const networkDHCPInterfacesToBridge = "eth0"
 
 const networkDHCPExpected = `auto lo
 iface lo inet loopback
@@ -249,6 +245,8 @@ iface eth1 inet static
     address 1.2.3.5
     netmask 255.255.255.0
     gateway 4.3.2.1`
+
+const networkDualNICInterfacesToBridge = "eth0 eth1"
 
 const networkDualNICExpected = `auto lo
 iface lo inet loopback
@@ -286,6 +284,9 @@ auto eth0:1
 iface eth0:1 inet static
     address 1.2.3.5`
 
+const networkWithAliasInterfacesToBridge = "eth0 eth0:1"
+const networkWithAliasInterfacesToBridgePass2 = "eth0"
+
 const networkWithAliasExpected = `auto lo
 iface lo inet loopback
 
@@ -320,6 +321,8 @@ iface eth0:2 inet static
     address 10.14.0.100/24
 
 dns-nameserver 192.168.1.142`
+
+const networkStaticWithAliasInterfacesToBridge = "eth0 eth0:1 eth0:2"
 
 const networkStaticWithAliasExpected = `auto lo
 iface lo inet loopback
@@ -361,6 +364,8 @@ iface eth1 inet manual
 dns-nameservers 10.17.20.200
 dns-search maas`
 
+const networkMultipleStaticWithAliasesInterfacesToBridge = "eth0 eth0:1"
+
 const networkMultipleStaticWithAliasesExpected = `auto eth0
 iface eth0 inet manual
     mtu 1500
@@ -379,10 +384,6 @@ iface test-br-eth0:1 inet static
 auto eth1
 iface eth1 inet manual
     mtu 1500
-
-auto test-br-eth1
-iface test-br-eth1 inet manual
-    bridge_ports eth1
     dns-nameservers 10.17.20.200
     dns-search maas`
 
@@ -416,6 +417,8 @@ iface bond0 inet dhcp
 
 dns-nameservers 10.17.20.200
 dns-search maas19`
+
+const networkDHCPWithBondInterfacesToBridge = "bond0"
 
 const networkDHCPWithBondExpected = `auto eth0
 iface eth0 inet manual
@@ -476,6 +479,8 @@ iface eth10:2 inet static
 
 dns-nameservers 10.17.20.200
 dns-search maas19`
+
+const networkMultipleAliasesInterfacesToBridge = "eth0 eth1 eth10 eth10:1 eth10:2"
 
 const networkMultipleAliasesExpected = `auto eth0
 iface eth0 inet manual
@@ -607,6 +612,8 @@ iface bond1 inet dhcp
 
 dns-nameservers 10.17.20.200
 dns-search maas19`
+
+const networkSmorgasboardInterfacesToBridge = "eth4 eth5 eth6 eth6:1 eth6:2 eth6:3 eth6:4 bond0 bond1"
 
 const networkSmorgasboardExpected = `auto eth0
 iface eth0 inet manual
@@ -751,6 +758,8 @@ iface eth1.3 inet static
 dns-nameservers 10.17.20.200
 dns-search maas19`
 
+const networkVLANInterfacesToBridge = "eth0 eth0.2 eth1.3"
+
 const networkVLANExpected = `auto eth0
 iface eth0 inet manual
     mtu 1500
@@ -764,10 +773,6 @@ iface vlan-br-eth0 inet static
 auto eth1
 iface eth1 inet manual
     mtu 1500
-
-auto vlan-br-eth1
-iface vlan-br-eth1 inet manual
-    bridge_ports eth1
 
 auto eth0.2
 iface eth0.2 inet manual
@@ -847,6 +852,8 @@ iface eth1.2670 inet static
 dns-nameservers 10.245.168.2
 dns-search dellstack`
 
+const networkVLANWithMultipleNameserversInterfacesToBridge = "eth0 eth1.2667 eth1.2668 eth1.2669 eth1.2670"
+
 const networkVLANWithMultipleNameserversExpected = `auto eth0
 iface eth0 inet manual
     mtu 1500
@@ -862,25 +869,13 @@ auto eth1
 iface eth1 inet manual
     mtu 1500
 
-auto br-eth1
-iface br-eth1 inet manual
-    bridge_ports eth1
-
 auto eth2
 iface eth2 inet manual
     mtu 1500
 
-auto br-eth2
-iface br-eth2 inet manual
-    bridge_ports eth2
-
 auto eth3
 iface eth3 inet manual
     mtu 1500
-
-auto br-eth3
-iface br-eth3 inet manual
-    bridge_ports eth3
 
 auto eth1.2667
 iface eth1.2667 inet manual
@@ -934,6 +929,8 @@ iface br-eth1.2670 inet static
 const networkLoopbackOnlyInitial = `auto lo
 iface lo inet loopback`
 
+const networkLoopbackOnlyInterfacesToBridge = "lo"
+
 const networkLoopbackOnlyExpected = `auto lo
 iface lo inet loopback`
 
@@ -984,6 +981,8 @@ iface bond0.3 inet static
 
 dns-nameservers 10.17.20.200
 dns-search maas19`
+
+const networkStaticBondWithVLANsInterfacesToBridge = "bond0 bond0.2 bond0.3"
 
 const networkStaticBondWithVLANsExpected = `auto eth0
 iface eth0 inet manual
@@ -1066,6 +1065,8 @@ dns-nameservers 10.17.20.200
 dns-search maas19
 `
 
+const networkVLANWithInactiveDeviceInterfacesToBridge = "eth0 eth1.2"
+
 const networkVLANWithInactiveDeviceExpected = `auto eth0
 iface eth0 inet manual
     mtu 1500
@@ -1080,10 +1081,6 @@ iface br-eth0 inet static
 auto eth1
 iface eth1 inet manual
     mtu 1500
-
-auto br-eth1
-iface br-eth1 inet manual
-    bridge_ports eth1
 
 auto eth1.2
 iface eth1.2 inet manual
@@ -1117,6 +1114,8 @@ iface eth1.2 inet dhcp
 dns-nameservers 10.17.20.200
 dns-search maas19
 `
+
+const networkVLANWithActiveDHCPDeviceInterfacesToBridge = "eth0 eth1 eth1.2"
 
 const networkVLANWithActiveDHCPDeviceExpected = `auto eth0
 iface eth0 inet manual
@@ -1189,6 +1188,8 @@ iface eth3 inet static
 dns-search ubuntu juju
 dns-search dellstack ubuntu dellstack`
 
+const networkWithMultipleDNSValuesInterfacesToBridge = "eth0 eth1 eth2 eth3"
+
 const networkWithMultipleDNSValuesExpected = `auto eth0
 iface eth0 inet manual
     mtu 1500
@@ -1256,6 +1257,8 @@ iface eth1 inet static
 dns-nameservers
 dns-search
 dns-sortlist`
+
+const networkWithEmptyDNSValuesInterfacesToBridge = "eth0 eth1"
 
 const networkWithEmptyDNSValuesExpected = `auto eth0
 iface eth0 inet manual
@@ -1387,6 +1390,8 @@ iface bond1.1019 inet static
 dns-nameservers 10.38.160.10
 dns-search maas`
 
+const networkLP1532167InterfacesToBridge = "bond0 bond0.1016 bond0.161 bond0.162 bond0.163 bond1.1017 bond1.1018 bond1.1019"
+
 const networkLP1532167Expected = `auto eth0
 iface eth0 inet manual
     bond-lacp_rate fast
@@ -1515,6 +1520,8 @@ iface eth1 inet static
     netmask 255.255.255.0
     gateway 4.3.2.1`
 
+const networkWithExistingSpecificIfaceInterfacesToBridge = "eth0 eth1"
+
 const networkWithExistingSpecificIfaceExpected = `auto lo
 iface lo inet loopback
 
@@ -1549,6 +1556,8 @@ iface eth1 inet static
     address 1.2.3.5
     netmask 255.255.255.0
     gateway 4.3.2.1`
+
+const networkPartiallyBridgedInterfacesToBridge = "br-eth0 eth1"
 
 const networkPartiallyBridgedExpected = `auto lo
 iface lo inet loopback

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -285,7 +285,6 @@ iface eth0:1 inet static
     address 1.2.3.5`
 
 const networkWithAliasInterfacesToBridge = "eth0 eth0:1"
-const networkWithAliasInterfacesToBridgePass2 = "eth0"
 
 const networkWithAliasExpected = `auto lo
 iface lo inet loopback

--- a/provider/maas/devices.go
+++ b/provider/maas/devices.go
@@ -212,7 +212,7 @@ func (env *maasEnviron) deviceInterfaceInfo(deviceID instance.Id, nameToParentNa
 		}
 
 		for _, link := range nic.Links {
-			nicInfo.ConfigType = maasLinkToInterfaceConfigType(string(link.Mode), link.IPAddress)
+			nicInfo.ConfigType = maasLinkToInterfaceConfigType(string(link.Mode))
 
 			if link.IPAddress == "" {
 				logger.Debugf("device %q interface %q has no address", deviceID, nic.Name)
@@ -284,7 +284,7 @@ func (env *maasEnviron) deviceInterfaceInfo2(deviceID string, nameToParentName m
 		}
 
 		for _, link := range nic.Links() {
-			nicInfo.ConfigType = maasLinkToInterfaceConfigType(link.Mode(), link.IPAddress())
+			nicInfo.ConfigType = maasLinkToInterfaceConfigType(link.Mode())
 
 			subnet := link.Subnet()
 			if link.IPAddress() == "" || subnet == nil {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -981,20 +981,30 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 		return nil, errors.Trace(err)
 	}
 
-	cloudcfg, err := environ.newCloudinitConfig(hostname, series)
+	subnetsMap, err := environ.subnetToSpaceIds()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	// We need to extract the names of all interfaces of the selected node,
+	// which are both linked to subnets, and have an IP address, in order to
+	// pass those to the bridge script.
+	interfaceNamesToBridge, err := instanceConfiguredInterfaceNames(environ.usingMAAS2(), inst, subnetsMap)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	cloudcfg, err := environ.newCloudinitConfig(hostname, series, interfaceNamesToBridge)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	userdata, err := providerinit.ComposeUserData(args.InstanceConfig, cloudcfg, MAASRenderer{})
 	if err != nil {
 		return nil, errors.Annotatef(err, "could not compose userdata for bootstrap node")
 	}
 	logger.Debugf("maas user data; %d bytes", len(userdata))
 
-	subnetsMap, err := environ.subnetToSpaceIds()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	var interfaces []network.InterfaceInfo
 	if !environ.usingMAAS2() {
 		inst1 := inst.(*maas1Instance)
@@ -1006,7 +1016,7 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 		// assigned IP addresses, even when NICs are set to "auto" instead of
 		// "static". So instead of selectedNode, which only contains the
 		// acquire-time details (no IP addresses for NICs set to "auto" vs
-		// "static"), we use the up-to-date startedNode response to get the
+		// "static"),e we use the up-to-date startedNode response to get the
 		// interfaces.
 		interfaces, err = maasObjectNetworkInterfaces(startedNode, subnetsMap)
 		if err != nil {
@@ -1050,6 +1060,55 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 		Volumes:           resultVolumes,
 		VolumeAttachments: resultAttachments,
 	}, nil
+}
+
+func instanceConfiguredInterfaceNames(usingMAAS2 bool, inst instance.Instance, subnetsMap map[string]network.Id) ([]string, error) {
+	var (
+		interfaces []network.InterfaceInfo
+		err        error
+	)
+	if !usingMAAS2 {
+		inst1 := inst.(*maas1Instance)
+		interfaces, err = maasObjectNetworkInterfaces(inst1.maasObject, subnetsMap)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	} else {
+		inst2 := inst.(*maas2Instance)
+		interfaces, err = maas2NetworkInterfaces(inst2, subnetsMap)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	nameToNumAliases := make(map[string]int)
+	var linkedNames []string
+	for _, iface := range interfaces {
+		if iface.CIDR == "" { // CIDR comes from a linked subnet.
+			continue
+		}
+
+		switch iface.ConfigType {
+		case network.ConfigUnknown, network.ConfigManual:
+			continue // link is unconfigured
+		}
+
+		finalName := iface.InterfaceName
+		numAliases, seen := nameToNumAliases[iface.InterfaceName]
+		if !seen {
+			nameToNumAliases[iface.InterfaceName] = 0
+		} else {
+			numAliases++ // aliases start from 1
+			finalName += fmt.Sprintf(":%d", numAliases)
+			nameToNumAliases[iface.InterfaceName] = numAliases
+		}
+
+		linkedNames = append(linkedNames, finalName)
+	}
+	systemID := extractSystemId(inst.Id())
+	logger.Infof("interface names to bridge for node %q: %v", systemID, linkedNames)
+
+	return linkedNames, nil
 }
 
 func (environ *maasEnviron) tagInstance1(inst *maas1Instance, instanceConfig *instancecfg.InstanceConfig) {
@@ -1264,7 +1323,7 @@ func (environ *maasEnviron) selectNode2(args selectNodeArgs) (maasInstance, erro
 
 // setupJujuNetworking returns a string representing the script to run
 // in order to prepare the Juju-specific networking config on a node.
-func setupJujuNetworking() string {
+func setupJujuNetworking(interfacesToBridge []string) string {
 	// For ubuntu series < xenial we prefer python2 over python3
 	// as we don't want to invalidate lots of testing against
 	// known cloud-image contents. A summary of Ubuntu releases
@@ -1293,16 +1352,17 @@ fi
 
 if [ ! -z "${juju_networking_preferred_python_binary:-}" ]; then
     if [ -f %[1]q ]; then
-# We are sharing this code between master, maas-spaces2 and 1.25.
-# For the moment we want master and 1.25 to not bridge all interfaces.
+# We are sharing this code between 2.0 and 1.25.
+# For the moment we want 2.0 to bridge all interfaces linked
+# to a subnet, while for 1.25 we only bridge the default route interface.
 # This setting allows us to easily switch the behaviour when merging
 # the code between those various branches.
-        juju_bridge_all_interfaces=1
-        if [ $juju_bridge_all_interfaces -eq 1 ]; then
-            $juju_networking_preferred_python_binary %[1]q --bridge-prefix=%[2]q --one-time-backup --activate %[4]q
+        juju_bridge_linked_interfaces=1
+        if [ $juju_bridge_linked_interfaces -eq 1 ]; then
+            $juju_networking_preferred_python_binary %[1]q --bridge-prefix=%[2]q --interfaces-to-bridge=%[5]q --one-time-backup --activate %[4]q
         else
             juju_ipv4_interface_to_bridge=$(ip -4 route list exact default | head -n1 | cut -d' ' -f5)
-            $juju_networking_preferred_python_binary %[1]q --bridge-name=%[3]q --interface-to-bridge="${juju_ipv4_interface_to_bridge:-unknown}" --one-time-backup --activate %[4]q
+            $juju_networking_preferred_python_binary %[1]q --bridge-name=%[3]q --interfaces-to-bridge="${juju_ipv4_interface_to_bridge:-unknown}" --one-time-backup --activate %[4]q
         fi
     fi
 else
@@ -1311,16 +1371,18 @@ fi`,
 		bridgeScriptPath,
 		instancecfg.DefaultBridgePrefix,
 		instancecfg.DefaultBridgeName,
-		"/etc/network/interfaces")
+		"/etc/network/interfaces",
+		strings.Join(interfacesToBridge, " "),
+	)
 }
 
-func renderEtcNetworkInterfacesScript() string {
-	return setupJujuNetworking()
+func renderEtcNetworkInterfacesScript(interfacesToBridge ...string) string {
+	return setupJujuNetworking(interfacesToBridge)
 }
 
 // newCloudinitConfig creates a cloudinit.Config structure suitable as a base
 // for initialising a MAAS node.
-func (environ *maasEnviron) newCloudinitConfig(hostname, forSeries string) (cloudinit.CloudConfig, error) {
+func (environ *maasEnviron) newCloudinitConfig(hostname, forSeries string, interfacesToBridge []string) (cloudinit.CloudConfig, error) {
 	cloudcfg, err := cloudinit.New(forSeries)
 	if err != nil {
 		return nil, err
@@ -1352,7 +1414,7 @@ func (environ *maasEnviron) newCloudinitConfig(hostname, forSeries string) (clou
 		}
 		cloudcfg.AddPackage("bridge-utils")
 		cloudcfg.AddBootTextFile(bridgeScriptPath, bridgeScriptPython, 0755)
-		cloudcfg.AddScripts(setupJujuNetworking())
+		cloudcfg.AddScripts(setupJujuNetworking(interfacesToBridge))
 	}
 	return cloudcfg, nil
 }

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -146,10 +146,10 @@ func (*environSuite) TestNewCloudinitConfig(c *gc.C) {
 	cfg := getSimpleTestConfig(c, nil)
 	env, err := maas.NewEnviron(getSimpleCloudSpec(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	modifyNetworkScript := maas.RenderEtcNetworkInterfacesScript()
+	modifyNetworkScript := maas.RenderEtcNetworkInterfacesScript("eth0", "eth1")
 	script := expectedCloudinitConfig
 	script = append(script, modifyNetworkScript)
-	cloudcfg, err := maas.NewCloudinitConfig(env, "testing.invalid", "quantal")
+	cloudcfg, err := maas.NewCloudinitConfig(env, "testing.invalid", "quantal", []string{"eth0", "eth1"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudcfg.SystemUpdate(), jc.IsTrue)
 	c.Assert(cloudcfg.RunCmds(), jc.DeepEquals, script)
@@ -162,10 +162,22 @@ func (*environSuite) TestNewCloudinitConfigWithDisabledNetworkManagement(c *gc.C
 	cfg := getSimpleTestConfig(c, attrs)
 	env, err := maas.NewEnviron(getSimpleCloudSpec(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	cloudcfg, err := maas.NewCloudinitConfig(env, "testing.invalid", "quantal")
+	cloudcfg, err := maas.NewCloudinitConfig(env, "testing.invalid", "quantal", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudcfg.SystemUpdate(), jc.IsTrue)
 	c.Assert(cloudcfg.RunCmds(), jc.DeepEquals, expectedCloudinitConfig)
+}
+
+func (*environSuite) TestRenderEtcNetworkInterfacesScriptMultipleNames(c *gc.C) {
+	script := maas.RenderEtcNetworkInterfacesScript("eth0", "eth0:1", "eth2", "eth1")
+	c.Check(script, jc.Contains, `--interfaces-to-bridge="eth0 eth0:1 eth2 eth1"`)
+	c.Check(script, jc.Contains, `--bridge-prefix="br-"`)
+}
+
+func (*environSuite) TestRenderEtcNetworkInterfacesScriptSingleName(c *gc.C) {
+	script := maas.RenderEtcNetworkInterfacesScript("eth0")
+	c.Check(script, jc.Contains, `--interfaces-to-bridge="eth0"`)
+	c.Check(script, jc.Contains, `--bridge-prefix="br-"`)
 }
 
 type badEndpointSuite struct {

--- a/provider/maas/export_test.go
+++ b/provider/maas/export_test.go
@@ -18,8 +18,8 @@ func GetMAASClient(env environs.Environ) *gomaasapi.MAASObject {
 	return env.(*maasEnviron).getMAASClient()
 }
 
-func NewCloudinitConfig(env environs.Environ, hostname, series string) (cloudinit.CloudConfig, error) {
-	return env.(*maasEnviron).newCloudinitConfig(hostname, series)
+func NewCloudinitConfig(env environs.Environ, hostname, series string, interfacesToBridge []string) (cloudinit.CloudConfig, error) {
+	return env.(*maasEnviron).newCloudinitConfig(hostname, series, interfacesToBridge)
 }
 
 var RenderEtcNetworkInterfacesScript = renderEtcNetworkInterfacesScript

--- a/provider/maas/interfaces_test.go
+++ b/provider/maas/interfaces_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"text/template"
 
+	"github.com/juju/errors"
 	"github.com/juju/gomaasapi"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -271,6 +272,112 @@ const exampleInterfaceSetJSON = `
 	}
 ]`
 
+var exampleParsedInterfaceSetJSON = []network.InterfaceInfo{{
+	DeviceIndex:       0,
+	MACAddress:        "52:54:00:70:9b:fe",
+	CIDR:              "10.20.19.0/24",
+	ProviderId:        "91",
+	ProviderSubnetId:  "3",
+	AvailabilityZones: nil,
+	VLANTag:           0,
+	ProviderVLANId:    "5001",
+	ProviderAddressId: "436",
+	InterfaceName:     "eth0",
+	InterfaceType:     "ethernet",
+	Disabled:          false,
+	NoAutoStart:       false,
+	ConfigType:        "static",
+	Address:           network.NewAddressOnSpace("default", "10.20.19.103"),
+	DNSServers:        network.NewAddressesOnSpace("default", "10.20.19.2", "10.20.19.3"),
+	DNSSearchDomains:  nil,
+	MTU:               1500,
+	GatewayAddress:    network.NewAddressOnSpace("default", "10.20.19.2"),
+}, {
+	DeviceIndex:       0,
+	MACAddress:        "52:54:00:70:9b:fe",
+	CIDR:              "10.20.19.0/24",
+	ProviderId:        "91",
+	ProviderSubnetId:  "3",
+	AvailabilityZones: nil,
+	VLANTag:           0,
+	ProviderVLANId:    "5001",
+	ProviderAddressId: "437",
+	InterfaceName:     "eth0",
+	InterfaceType:     "ethernet",
+	Disabled:          false,
+	NoAutoStart:       false,
+	ConfigType:        "static",
+	Address:           network.NewAddressOnSpace("default", "10.20.19.104"),
+	DNSServers:        network.NewAddressesOnSpace("default", "10.20.19.2", "10.20.19.3"),
+	DNSSearchDomains:  nil,
+	MTU:               1500,
+	GatewayAddress:    network.NewAddressOnSpace("default", "10.20.19.2"),
+}, {
+	DeviceIndex:         1,
+	MACAddress:          "52:54:00:70:9b:fe",
+	CIDR:                "10.50.19.0/24",
+	ProviderId:          "150",
+	ProviderSubnetId:    "5",
+	AvailabilityZones:   nil,
+	VLANTag:             50,
+	ProviderVLANId:      "5004",
+	ProviderAddressId:   "517",
+	InterfaceName:       "eth0.50",
+	ParentInterfaceName: "eth0",
+	InterfaceType:       "802.1q",
+	Disabled:            false,
+	NoAutoStart:         false,
+	ConfigType:          "static",
+	Address:             network.NewAddressOnSpace("admin", "10.50.19.103"),
+	DNSServers:          nil,
+	DNSSearchDomains:    nil,
+	MTU:                 1500,
+	GatewayAddress:      network.NewAddressOnSpace("admin", "10.50.19.2"),
+}, {
+	DeviceIndex:         2,
+	MACAddress:          "52:54:00:70:9b:fe",
+	CIDR:                "10.100.19.0/24",
+	ProviderId:          "151",
+	ProviderSubnetId:    "6",
+	AvailabilityZones:   nil,
+	VLANTag:             100,
+	ProviderVLANId:      "5005",
+	ProviderAddressId:   "519",
+	InterfaceName:       "eth0.100",
+	ParentInterfaceName: "eth0",
+	InterfaceType:       "802.1q",
+	Disabled:            false,
+	NoAutoStart:         false,
+	ConfigType:          "static",
+	Address:             network.NewAddressOnSpace("public", "10.100.19.103"),
+	DNSServers:          nil,
+	DNSSearchDomains:    nil,
+	MTU:                 1500,
+	GatewayAddress:      network.NewAddressOnSpace("public", "10.100.19.2"),
+}, {
+	DeviceIndex:         3,
+	MACAddress:          "52:54:00:70:9b:fe",
+	CIDR:                "10.250.19.0/24",
+	ProviderId:          "152",
+	ProviderSubnetId:    "8",
+	AvailabilityZones:   nil,
+	VLANTag:             250,
+	ProviderVLANId:      "5008",
+	ProviderAddressId:   "523",
+	ProviderSpaceId:     "3",
+	InterfaceName:       "eth0.250",
+	ParentInterfaceName: "eth0",
+	InterfaceType:       "802.1q",
+	Disabled:            false,
+	NoAutoStart:         false,
+	ConfigType:          "static",
+	Address:             newAddressOnSpaceWithId("storage", network.Id("3"), "10.250.19.103"),
+	DNSServers:          nil,
+	DNSSearchDomains:    nil,
+	MTU:                 1500,
+	GatewayAddress:      newAddressOnSpaceWithId("storage", network.Id("3"), "10.250.19.2"),
+}}
+
 func (s *interfacesSuite) TestParseInterfacesNoJSON(c *gc.C) {
 	result, err := parseInterfaces(nil)
 	c.Check(err, gc.ErrorMatches, "parsing interfaces: unexpected end of JSON input")
@@ -449,115 +556,126 @@ func (s *interfacesSuite) TestMAASObjectNetworkInterfaces(c *gc.C) {
 	subnetsMap["10.250.19.0/24"] = network.Id("3")
 	subnetsMap["192.168.1.0/24"] = network.Id("0")
 
-	expected := []network.InterfaceInfo{{
-		DeviceIndex:       0,
-		MACAddress:        "52:54:00:70:9b:fe",
-		CIDR:              "10.20.19.0/24",
-		ProviderId:        "91",
-		ProviderSubnetId:  "3",
-		AvailabilityZones: nil,
-		VLANTag:           0,
-		ProviderVLANId:    "5001",
-		ProviderAddressId: "436",
-		InterfaceName:     "eth0",
-		InterfaceType:     "ethernet",
-		Disabled:          false,
-		NoAutoStart:       false,
-		ConfigType:        "static",
-		Address:           network.NewAddressOnSpace("default", "10.20.19.103"),
-		DNSServers:        network.NewAddressesOnSpace("default", "10.20.19.2", "10.20.19.3"),
-		DNSSearchDomains:  nil,
-		MTU:               1500,
-		GatewayAddress:    network.NewAddressOnSpace("default", "10.20.19.2"),
-	}, {
-		DeviceIndex:       0,
-		MACAddress:        "52:54:00:70:9b:fe",
-		CIDR:              "10.20.19.0/24",
-		ProviderId:        "91",
-		ProviderSubnetId:  "3",
-		AvailabilityZones: nil,
-		VLANTag:           0,
-		ProviderVLANId:    "5001",
-		ProviderAddressId: "437",
-		InterfaceName:     "eth0",
-		InterfaceType:     "ethernet",
-		Disabled:          false,
-		NoAutoStart:       false,
-		ConfigType:        "static",
-		Address:           network.NewAddressOnSpace("default", "10.20.19.104"),
-		DNSServers:        network.NewAddressesOnSpace("default", "10.20.19.2", "10.20.19.3"),
-		DNSSearchDomains:  nil,
-		MTU:               1500,
-		GatewayAddress:    network.NewAddressOnSpace("default", "10.20.19.2"),
-	}, {
-		DeviceIndex:         1,
-		MACAddress:          "52:54:00:70:9b:fe",
-		CIDR:                "10.50.19.0/24",
-		ProviderId:          "150",
-		ProviderSubnetId:    "5",
-		AvailabilityZones:   nil,
-		VLANTag:             50,
-		ProviderVLANId:      "5004",
-		ProviderAddressId:   "517",
-		InterfaceName:       "eth0.50",
-		ParentInterfaceName: "eth0",
-		InterfaceType:       "802.1q",
-		Disabled:            false,
-		NoAutoStart:         false,
-		ConfigType:          "static",
-		Address:             network.NewAddressOnSpace("admin", "10.50.19.103"),
-		DNSServers:          nil,
-		DNSSearchDomains:    nil,
-		MTU:                 1500,
-		GatewayAddress:      network.NewAddressOnSpace("admin", "10.50.19.2"),
-	}, {
-		DeviceIndex:         2,
-		MACAddress:          "52:54:00:70:9b:fe",
-		CIDR:                "10.100.19.0/24",
-		ProviderId:          "151",
-		ProviderSubnetId:    "6",
-		AvailabilityZones:   nil,
-		VLANTag:             100,
-		ProviderVLANId:      "5005",
-		ProviderAddressId:   "519",
-		InterfaceName:       "eth0.100",
-		ParentInterfaceName: "eth0",
-		InterfaceType:       "802.1q",
-		Disabled:            false,
-		NoAutoStart:         false,
-		ConfigType:          "static",
-		Address:             network.NewAddressOnSpace("public", "10.100.19.103"),
-		DNSServers:          nil,
-		DNSSearchDomains:    nil,
-		MTU:                 1500,
-		GatewayAddress:      network.NewAddressOnSpace("public", "10.100.19.2"),
-	}, {
-		DeviceIndex:         3,
-		MACAddress:          "52:54:00:70:9b:fe",
-		CIDR:                "10.250.19.0/24",
-		ProviderId:          "152",
-		ProviderSubnetId:    "8",
-		AvailabilityZones:   nil,
-		VLANTag:             250,
-		ProviderVLANId:      "5008",
-		ProviderAddressId:   "523",
-		ProviderSpaceId:     "3",
-		InterfaceName:       "eth0.250",
-		ParentInterfaceName: "eth0",
-		InterfaceType:       "802.1q",
-		Disabled:            false,
-		NoAutoStart:         false,
-		ConfigType:          "static",
-		Address:             newAddressOnSpaceWithId("storage", network.Id("3"), "10.250.19.103"),
-		DNSServers:          nil,
-		DNSSearchDomains:    nil,
-		MTU:                 1500,
-		GatewayAddress:      newAddressOnSpaceWithId("storage", network.Id("3"), "10.250.19.2"),
-	}}
-
 	infos, err := maasObjectNetworkInterfaces(&obj, subnetsMap)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(infos, jc.DeepEquals, expected)
+	c.Check(infos, jc.DeepEquals, exampleParsedInterfaceSetJSON)
+}
+
+const (
+	notUsingMAAS2 = false
+	notUsingMAAS1 = true
+)
+
+func (s *interfacesSuite) TestInstanceConfiguredInterfaceNamesWithExampleMAAS1InterfaceSet(c *gc.C) {
+	nodeJSON := fmt.Sprintf(`{
+        "system_id": "foo",
+        "interface_set": %s
+    }`, exampleInterfaceSetJSON)
+	obj := s.testMAASObject.TestServer.NewNode(nodeJSON)
+
+	inst := &maas1Instance{maasObject: &obj}
+	names, err := instanceConfiguredInterfaceNames(notUsingMAAS2, inst, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(names, jc.DeepEquals, []string{"eth0", "eth0:1", "eth0.50", "eth0.100", "eth0.250"})
+}
+
+func (s *interfacesSuite) TestInstanceConfiguredNamesWithoutInterfaceSetMAAS1(c *gc.C) {
+	nodeJSON := `{"system_id": "foo"}`
+	obj := s.testMAASObject.TestServer.NewNode(nodeJSON)
+
+	inst := &maas1Instance{maasObject: &obj}
+	names, err := instanceConfiguredInterfaceNames(notUsingMAAS2, inst, nil)
+	c.Assert(err, gc.ErrorMatches, "interface_set not supported")
+	c.Check(err, jc.Satisfies, errors.IsNotSupported)
+	c.Check(names, gc.HasLen, 0)
+}
+
+func (s *interfacesSuite) TestInstanceConfiguredInterfaceNamesPartiallyConfiguredMAAS1(c *gc.C) {
+	nodeJSON := `{
+        "system_id": "foo",
+        "interface_set": [{
+          "name": "eth0",
+          "links": [
+              {"subnet": {"cidr": "1.2.3.4/5"}, "mode": "static", "ip_address": "1.2.3.4"},
+              {"subnet": {"cidr": "1.2.3.4/5"}, "mode": "auto"},
+              {"subnet": {"cidr": "1.2.3.4/5"}, "mode": "dhcp"}
+          ]
+        }, {
+          "name": "eth1",
+          "links": [{"mode": "link_up"}]
+        }, {
+          "name": "eth1.99",
+          "links": [{"subnet": {"cidr": "192.168.99.0/24"}, "mode": "auto"}]
+        }]}`
+	obj := s.testMAASObject.TestServer.NewNode(nodeJSON)
+
+	inst := &maas1Instance{maasObject: &obj}
+	names, err := instanceConfiguredInterfaceNames(notUsingMAAS2, inst, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(names, jc.DeepEquals, []string{"eth0", "eth0:1", "eth0:2", "eth1.99"})
+}
+
+func (s *interfacesSuite) TestInstanceConfiguredInterfaceNamesWithoutInterfaceSetMAAS2(c *gc.C) {
+	inst := &maas2Instance{machine: &fakeMachine{interfaceSet: nil}}
+
+	names, err := instanceConfiguredInterfaceNames(notUsingMAAS1, inst, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(names, gc.HasLen, 0)
+}
+
+func (s *interfacesSuite) TestInstanceConfiguredInterfaceNamesPartiallyConfiguredMAAS2(c *gc.C) {
+
+	subnet50 := &fakeSubnet{
+		cidr: "10.50.19.0/24",
+		vlan: &fakeVLAN{id: 5050},
+	}
+	subnet250 := &fakeSubnet{
+		cidr: "10.250.19.0/24",
+		vlan: &fakeVLAN{id: 5250},
+	}
+
+	interfaces := []gomaasapi.Interface{
+		&fakeInterface{
+			name: "eth0",
+			links: []gomaasapi.Link{
+				&fakeLink{mode: "link_up"},
+			},
+		},
+		&fakeInterface{
+			name: "eth0.50",
+			links: []gomaasapi.Link{
+				&fakeLink{
+					subnet:    subnet50,
+					ipAddress: "10.50.19.103",
+					mode:      "static",
+				},
+				&fakeLink{ // alias :1
+					subnet: subnet50,
+					mode:   "auto", // no address yet, but will have at startNode time
+				},
+				&fakeLink{ // alias :2
+					subnet: subnet50,
+					mode:   "dhcp", // will get address at boot via DHCP
+				},
+			},
+		},
+		&fakeInterface{name: "eth0.100", links: nil},
+		&fakeInterface{
+			name: "eth0.250",
+			links: []gomaasapi.Link{
+				&fakeLink{
+					subnet: subnet250,
+					mode:   "auto",
+				},
+			},
+		},
+	}
+
+	inst := &maas2Instance{machine: &fakeMachine{interfaceSet: interfaces}}
+
+	names, err := instanceConfiguredInterfaceNames(notUsingMAAS1, inst, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(names, jc.DeepEquals, []string{"eth0.50", "eth0.50:1", "eth0.50:2", "eth0.250"})
 }
 
 func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {


### PR DESCRIPTION
The list of interfaces to be bridged is no longer automatically
determined by the bridge script; you know need to specify a space
separated list of interface names that you want bridging.

For example:

 $ add-juju-bridge.py \
     --interfaces-to-bridge="eth0 eth0:1 eth0:2 bond2" /e/n/i

The MAAS provider now works out which interfaces are to be bridged and
invokes the script with a specific set of interface names. The MAAS
provider will now bridge any interface that has a subnet and is not
unconfigured (i.e., it has an IP address).

Fixes [LP:#1627037](https://bugs.launchpad.net/juju/+bug/1627037)