### PR TITLE
LXCs can resolve own hostname

### DIFF
--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -239,8 +239,11 @@ func CloudInitUserData(
 	cloudConfig.AddRunCmd("ifconfig")
 
 	if instanceConfig.MachineContainerHostname != "" {
+		logger.Debugf("Cloud-init configured to set hostname")
 		cloudConfig.SetAttr("hostname", instanceConfig.MachineContainerHostname)
 	}
+
+	cloudConfig.SetAttr("manage_etc_hosts", true)
 
 	data, err := cloudConfig.RenderYAML()
 	if err != nil {

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -205,6 +205,9 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams) (*lxdclien
 		cloudcfg.AddRunTextFile(serverCertPath, serverState.Environment.Certificate, 0600)
 	}
 
+	cloudcfg.SetAttr("hostname", hostname)
+	cloudcfg.SetAttr("manage_etc_hosts", true)
+
 	metadata, err := getMetadata(cloudcfg, args)
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
Instruct cloud-init to manage /etc/hosts for LXCs, which adds the hostame to the localhost entry. This allows each host to be able to resolve its own hostname.

The bulk of the change is shifting some test code around to test the path in cloudconfig/containerinit/container_userdata.go. The provider/lxd/environ_broker.go changes don't have a test because the cloudinit data ends up buried in private data that isn't easy to get at. Live testing shows that it works.

QA Steps:

1. juju bootstrap lxd lxd
2. juju add-machine lxd
3. juju ssh 0
4. sudo ls  # shouldn't complain about hostnames