### PR TITLE
Prevent import keys from accepting unprefixed ids.

### DIFF
--- a/cmd/juju/commands/import_sshkeys.go
+++ b/cmd/juju/commands/import_sshkeys.go
@@ -4,10 +4,10 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -39,7 +39,7 @@ GitHub service:
 
 Multiple identities may be specified in a space delimited list:
 
-    juju import-ssh-key rheinlein lp:iasmiov gh:hharrison
+juju import-ssh-key gh:rheinlein lp:iasmiov gh:hharrison
 
 See also: 
     add-ssh-key
@@ -69,11 +69,20 @@ func (c *importKeysCommand) Info() *cmd.Info {
 
 // Init implements Command.Init.
 func (c *importKeysCommand) Init(args []string) error {
-	switch len(args) {
-	case 0:
+	if len(args) == 0 {
 		return errors.New("no ssh key id specified")
-	default:
-		c.sshKeyIds = args
+	}
+	c.sshKeyIds = args
+	for _, k := range c.sshKeyIds {
+		if len(k) < 3 {
+			return errors.NotValidf("%q key ID", k)
+		}
+		switch k[:3] {
+		case "lp:", "gh:":
+		default:
+			return errors.NewNotSupported(nil,
+				fmt.Sprintf("prefix in Key ID %q not supported, only lp: and gh: are allowed", k))
+		}
 	}
 	return nil
 }

--- a/cmd/juju/commands/sshkeys_test.go
+++ b/cmd/juju/commands/sshkeys_test.go
@@ -191,9 +191,9 @@ func (s *ImportKeySuite) TestImportKeys(c *gc.C) {
 	key1 := sshtesting.ValidKeyOne.Key + " user@host"
 	s.setAuthorizedKeys(c, key1)
 
-	context, err := coretesting.RunCommand(c, NewImportKeysCommand(), "lp:validuser", "invalid-key")
+	context, err := coretesting.RunCommand(c, NewImportKeysCommand(), "lp:validuser", "lp:invalid-key")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(context), gc.Matches, `cannot import key id "invalid-key".*\n`)
+	c.Assert(coretesting.Stderr(context), gc.Matches, `cannot import key id "lp:invalid-key".*\n`)
 	s.assertEnvironKeys(c, key1, sshtesting.ValidKeyThree.Key)
 }
 
@@ -203,6 +203,6 @@ func (s *ImportKeySuite) TestBlockImportKeys(c *gc.C) {
 
 	// Block operation
 	s.BlockAllChanges(c, "TestBlockImportKeys")
-	_, err := coretesting.RunCommand(c, NewImportKeysCommand(), "lp:validuser", "invalid-key")
+	_, err := coretesting.RunCommand(c, NewImportKeysCommand(), "lp:validuser", "lp:invalid-key")
 	s.AssertBlocked(c, err, ".*TestBlockImportKeys.*")
 }


### PR DESCRIPTION
Accepting up-prefixed key ids might lead to accidentally importing
unexpected keys.

### QA Steps
* find a working controller
* run: juju import-ssh-key lp:a-valid-launchpad-key
* run: juju import-ssh-key gh:a-valid-github-key
* run: juju import-ssh-key a-valid-launchpad-key
* the third one should fail, feel free to try combination of those, any one including the third option should fail.