### PR TITLE
apiserver: implement LetsEncrypt support

### DIFF
--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -180,8 +180,8 @@ func (s *legacySuite) TestAPIServerCanShutdownWithOutstandingNext(c *gc.C) {
 
 	srv, err := apiserver.NewServer(s.State, lis, apiserver.ServerConfig{
 		Clock:       clock.WallClock,
-		Cert:        []byte(testing.ServerCert),
-		Key:         []byte(testing.ServerKey),
+		Cert:        testing.ServerCert,
+		Key:         testing.ServerKey,
 		Tag:         names.NewMachineTag("0"),
 		DataDir:     c.MkDir(),
 		LogDir:      c.MkDir(),

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -574,8 +574,8 @@ func (s *baseLoginSuite) setupServerForModelWithValidator(c *gc.C, modelTag name
 		listener,
 		apiserver.ServerConfig{
 			Clock:       clock.WallClock,
-			Cert:        []byte(coretesting.ServerCert),
-			Key:         []byte(coretesting.ServerKey),
+			Cert:        coretesting.ServerCert,
+			Key:         coretesting.ServerKey,
 			Validator:   validator,
 			Tag:         names.NewMachineTag("0"),
 			LogDir:      c.MkDir(),

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -42,8 +42,8 @@ func (s *apiserverBaseSuite) SetUpTest(c *gc.C) {
 func (s *apiserverBaseSuite) sampleConfig(c *gc.C) apiserver.ServerConfig {
 	return apiserver.ServerConfig{
 		Clock:       clock.WallClock,
-		Cert:        []byte(coretesting.ServerCert),
-		Key:         []byte(coretesting.ServerKey),
+		Cert:        coretesting.ServerCert,
+		Key:         coretesting.ServerKey,
 		Tag:         names.NewMachineTag("0"),
 		LogDir:      c.MkDir(),
 		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -528,8 +528,8 @@ func newServer(c *gc.C, st *state.State) *apiserver.Server {
 	c.Assert(err, jc.ErrorIsNil)
 	srv, err := apiserver.NewServer(st, listener, apiserver.ServerConfig{
 		Clock:       clock.WallClock,
-		Cert:        []byte(coretesting.ServerCert),
-		Key:         []byte(coretesting.ServerKey),
+		Cert:        coretesting.ServerCert,
+		Key:         coretesting.ServerKey,
 		Tag:         names.NewMachineTag("0"),
 		LogDir:      c.MkDir(),
 		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1055,8 +1055,8 @@ func (a *MachineAgent) newApiserverWorker(st *state.State, certChanged chan para
 	if !ok {
 		return nil, &cmdutil.FatalError{"StateServingInfo not available and we need it"}
 	}
-	cert := []byte(info.Cert)
-	key := []byte(info.PrivateKey)
+	cert := info.Cert
+	key := info.PrivateKey
 
 	if len(cert) == 0 || len(key) == 0 {
 		return nil, &cmdutil.FatalError{"configuration does not have controller cert/key"}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -62,7 +62,7 @@ github.com/prometheus/client_model	git	fa8ad6fec33561be4280a8f0514318c79d7f6cb6	
 github.com/prometheus/common	git	dd586c1c5abb0be59e60f942c22af711a2008cb4	2016-05-03T22:05:32Z
 github.com/prometheus/procfs	git	abf152e5f3e97f2fafac028d2cc06c1feb87ffa5	2016-04-11T19:08:41Z
 github.com/rogpeppe/fastuuid	git	6724a57986aff9bff1a1770e9347036def7c89f6	2015-01-06T09:32:20Z
-golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:06:42Z
+golang.org/x/crypto	git	8e06e8ddd9629eb88639aba897641bff8031f1d3	2016-09-22T17:06:29Z
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
 golang.org/x/oauth2	git	11c60b6f71a6ad48ed6f93c65fa4c6f9b1b5b46a	2015-03-25T02:00:22Z
 google.golang.org/api	git	0d3983fb069cb6651353fc44c5cb604e263f2a93	2014-12-10T23:51:26Z

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -804,8 +804,8 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 
 			estate.apiServer, err = apiserver.NewServer(st, estate.apiListener, apiserver.ServerConfig{
 				Clock:       clock.WallClock,
-				Cert:        []byte(testing.ServerCert),
-				Key:         []byte(testing.ServerKey),
+				Cert:        testing.ServerCert,
+				Key:         testing.ServerKey,
 				Tag:         names.NewMachineTag("0"),
 				DataDir:     DataDir,
 				LogDir:      LogDir,

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -190,6 +190,13 @@ func allCollections() collectionSchema {
 			global: true,
 		},
 
+		// This collection holds information cached by autocert certificate
+		// acquisition.
+		autocertCacheC: {
+			global:    true,
+			rawAccess: true,
+		},
+
 		// This collection holds the last time the model user connected
 		// to the model.
 		modelUserLastConnectionC: {
@@ -400,6 +407,7 @@ const (
 	actionresultsC           = "actionresults"
 	actionsC                 = "actions"
 	annotationsC             = "annotations"
+	autocertCacheC           = "autocertCache"
 	assignUnitC              = "assignUnits"
 	auditingC                = "audit.log"
 	bakeryStorageItemsC      = "bakeryStorageItems"

--- a/state/autocertcache.go
+++ b/state/autocertcache.go
@@ -1,0 +1,73 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+	"golang.org/x/crypto/acme/autocert"
+	"golang.org/x/net/context"
+	"gopkg.in/mgo.v2"
+
+	"github.com/juju/juju/mongo"
+)
+
+// AutocertCache returns an implementation
+// of autocert.Cache backed by the state.
+func (st *State) AutocertCache() autocert.Cache {
+	return autocertCache{st}
+}
+
+type autocertCache struct {
+	st *State
+}
+
+type autocertCacheDoc struct {
+	Name string `bson:"_id"`
+	Data []byte `bson:"data"`
+}
+
+// Put implements autocert.Cache.Put.
+func (cache autocertCache) Put(ctx context.Context, name string, data []byte) error {
+	coll, closeColl := cache.coll()
+	defer closeColl()
+	_, err := coll.UpsertId(name, autocertCacheDoc{
+		Name: name,
+		Data: data,
+	})
+	if err != nil {
+		return errors.Annotatef(err, "cannot store autocert key %q", name)
+	}
+	return nil
+}
+
+// Get implements autocert.Cache.Get.
+func (cache autocertCache) Get(ctx context.Context, name string) ([]byte, error) {
+	coll, closeColl := cache.coll()
+	defer closeColl()
+	var doc autocertCacheDoc
+	err := coll.FindId(name).One(&doc)
+	if err == nil {
+		return doc.Data, nil
+	}
+	if errors.Cause(err) == mgo.ErrNotFound {
+		return nil, autocert.ErrCacheMiss
+	}
+	return nil, errors.Annotatef(err, "cannot get autocert key %q", name)
+}
+
+// Delete implements autocert.Cache.Delete.
+func (cache autocertCache) Delete(ctx context.Context, name string) error {
+	coll, closeColl := cache.coll()
+	defer closeColl()
+	err := coll.RemoveId(name)
+	if err == nil || errors.Cause(err) == mgo.ErrNotFound {
+		return nil
+	}
+	return errors.Annotatef(err, "cannot delete autocert key %q", name)
+}
+
+func (cache autocertCache) coll() (mongo.WriteCollection, func()) {
+	coll, closer := cache.st.getCollection(autocertCacheC)
+	return coll.Writeable(), closer
+}

--- a/state/autocertcache_test.go
+++ b/state/autocertcache_test.go
@@ -1,0 +1,94 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"golang.org/x/crypto/acme/autocert"
+	"golang.org/x/net/context"
+	gc "gopkg.in/check.v1"
+
+	statetesting "github.com/juju/juju/state/testing"
+)
+
+type autocertCacheSuite struct {
+	statetesting.StateSuite
+}
+
+var _ = gc.Suite(&autocertCacheSuite{})
+
+func (s *autocertCacheSuite) TestCachePutGet(c *gc.C) {
+	ctx := context.Background()
+	cache := s.State.AutocertCache()
+
+	err := cache.Put(ctx, "a", []byte("aval"))
+	c.Assert(err, jc.ErrorIsNil)
+	err = cache.Put(ctx, "b", []byte("bval"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check that we can get the existing entries.
+	data, err := cache.Get(ctx, "a")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), gc.Equals, "aval")
+
+	data, err = cache.Get(ctx, "b")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), gc.Equals, "bval")
+}
+
+func (s *autocertCacheSuite) TestGetNonexistentEntry(c *gc.C) {
+	ctx := context.Background()
+	cache := s.State.AutocertCache()
+
+	// Getting a non-existent entry must return ErrCacheMiss.
+	data, err := cache.Get(ctx, "c")
+	c.Assert(err, gc.Equals, autocert.ErrCacheMiss)
+	c.Assert(data, gc.IsNil)
+}
+
+func (s *autocertCacheSuite) TestDelete(c *gc.C) {
+	ctx := context.Background()
+	cache := s.State.AutocertCache()
+
+	err := cache.Put(ctx, "a", []byte("aval"))
+	c.Assert(err, jc.ErrorIsNil)
+	err = cache.Put(ctx, "b", []byte("bval"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check that we can delete an entry.
+	err = cache.Delete(ctx, "b")
+	c.Assert(err, jc.ErrorIsNil)
+
+	data, err := cache.Get(ctx, "b")
+	c.Assert(err, gc.Equals, autocert.ErrCacheMiss)
+	c.Assert(data, gc.IsNil)
+
+	// Check that the non-deleted entry is still there.
+	data, err = cache.Get(ctx, "a")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), gc.Equals, "aval")
+}
+
+func (s *autocertCacheSuite) TestDeleteNonexistentEntry(c *gc.C) {
+	ctx := context.Background()
+	cache := s.State.AutocertCache()
+
+	err := cache.Delete(ctx, "a")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *autocertCacheSuite) TestPutExistingEntry(c *gc.C) {
+	ctx := context.Background()
+	cache := s.State.AutocertCache()
+
+	err := cache.Put(ctx, "a", []byte("aval"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = cache.Put(ctx, "a", []byte("aval2"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	data, err := cache.Get(ctx, "a")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), gc.Equals, "aval2")
+}

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -77,6 +77,9 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// machine removals.
 		cleanupsC,
 		machineRemovalsC,
+		// The autocert cache is non-critical. After migration
+		// you'll just need to acquire new certificates.
+		autocertCacheC,
 		// We don't export the controller model at this stage.
 		controllersC,
 		// Clouds aren't migrated. They must exist in the


### PR DESCRIPTION
This enables a controller to be contacted via a real
domain name - it will obtain an official HTTPS certificate
from the letsencrypt service.

It's not easy to test this without doing it for real, so to QA:

- bootstrap a controller with api-port=443
- set the IP address associated with a domain you control to the public
IP address of the new controller.
- edit controllers.yaml to change the addresses associated
with the controller to <yourdomain>:443.
- use the controller.

Note that as is, this is open to the DoS vulnerability described
in https://godoc.org/golang.org/x/crypto/acme/autocert#Manager
under the HostPolicy field. We really want to whitelist a single
domain, but that involves adding controller configuration, so we
reserve that for a future PR.