### PR TITLE
stop prompting for domain name for rackspace credentials

### DIFF
--- a/provider/openstack/credentials.go
+++ b/provider/openstack/credentials.go
@@ -19,12 +19,12 @@ import (
 )
 
 const (
-	credAttrTenantName = "tenant-name"
-	credAttrUserName   = "username"
-	credAttrPassword   = "password"
-	credAttrDomainName = "domain-name"
-	credAttrAccessKey  = "access-key"
-	credAttrSecretKey  = "secret-key"
+	CredAttrTenantName = "tenant-name"
+	CredAttrUserName   = "username"
+	CredAttrPassword   = "password"
+	CredAttrDomainName = "domain-name"
+	CredAttrAccessKey  = "access-key"
+	CredAttrSecretKey  = "secret-key"
 )
 
 type OpenstackCredentials struct{}
@@ -34,16 +34,16 @@ func (OpenstackCredentials) CredentialSchemas() map[cloud.AuthType]cloud.Credent
 	return map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.UserPassAuthType: {
 			{
-				credAttrUserName, cloud.CredentialAttr{Description: "The username to authenticate with."},
+				CredAttrUserName, cloud.CredentialAttr{Description: "The username to authenticate with."},
 			}, {
-				credAttrPassword, cloud.CredentialAttr{
+				CredAttrPassword, cloud.CredentialAttr{
 					Description: "The password for the specified username.",
 					Hidden:      true,
 				},
 			}, {
-				credAttrTenantName, cloud.CredentialAttr{Description: "The OpenStack tenant name."},
+				CredAttrTenantName, cloud.CredentialAttr{Description: "The OpenStack tenant name."},
 			}, {
-				credAttrDomainName, cloud.CredentialAttr{
+				CredAttrDomainName, cloud.CredentialAttr{
 					Description: "The OpenStack domain name.",
 					Optional:    true,
 				},
@@ -51,14 +51,14 @@ func (OpenstackCredentials) CredentialSchemas() map[cloud.AuthType]cloud.Credent
 		},
 		cloud.AccessKeyAuthType: {
 			{
-				credAttrAccessKey, cloud.CredentialAttr{Description: "The access key to authenticate with."},
+				CredAttrAccessKey, cloud.CredentialAttr{Description: "The access key to authenticate with."},
 			}, {
-				credAttrSecretKey, cloud.CredentialAttr{
+				CredAttrSecretKey, cloud.CredentialAttr{
 					Description: "The secret key to authenticate with.",
 					Hidden:      true,
 				},
 			}, {
-				credAttrTenantName, cloud.CredentialAttr{Description: "The OpenStack tenant name."},
+				CredAttrTenantName, cloud.CredentialAttr{Description: "The OpenStack tenant name."},
 			},
 		},
 	}
@@ -126,19 +126,19 @@ func (c OpenstackCredentials) detectCredential() (*cloud.Credential, string, str
 		credential = cloud.NewCredential(
 			cloud.UserPassAuthType,
 			map[string]string{
-				credAttrUserName:   creds.User,
-				credAttrPassword:   creds.Secrets,
-				credAttrTenantName: creds.TenantName,
-				credAttrDomainName: creds.DomainName,
+				CredAttrUserName:   creds.User,
+				CredAttrPassword:   creds.Secrets,
+				CredAttrTenantName: creds.TenantName,
+				CredAttrDomainName: creds.DomainName,
 			},
 		)
 	} else {
 		credential = cloud.NewCredential(
 			cloud.AccessKeyAuthType,
 			map[string]string{
-				credAttrAccessKey:  creds.User,
-				credAttrSecretKey:  creds.Secrets,
-				credAttrTenantName: creds.TenantName,
+				CredAttrAccessKey:  creds.User,
+				CredAttrSecretKey:  creds.Secrets,
+				CredAttrTenantName: creds.TenantName,
 			},
 		)
 	}

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -539,7 +539,7 @@ func newCredentials(spec environs.CloudSpec) (identity.Credentials, identity.Aut
 	cred := identity.Credentials{
 		Region:     spec.Region,
 		URL:        spec.Endpoint,
-		TenantName: credAttrs[credAttrTenantName],
+		TenantName: credAttrs[CredAttrTenantName],
 	}
 
 	// AuthType is validated when the environment is opened, so it's known
@@ -548,16 +548,16 @@ func newCredentials(spec environs.CloudSpec) (identity.Credentials, identity.Aut
 	switch spec.Credential.AuthType() {
 	case cloud.UserPassAuthType:
 		// TODO(axw) we need a way of saying to use legacy auth.
-		cred.User = credAttrs[credAttrUserName]
-		cred.Secrets = credAttrs[credAttrPassword]
-		cred.DomainName = credAttrs[credAttrDomainName]
+		cred.User = credAttrs[CredAttrUserName]
+		cred.Secrets = credAttrs[CredAttrPassword]
+		cred.DomainName = credAttrs[CredAttrDomainName]
 		authMode = identity.AuthUserPass
 		if cred.DomainName != "" {
 			authMode = identity.AuthUserPassV3
 		}
 	case cloud.AccessKeyAuthType:
-		cred.User = credAttrs[credAttrAccessKey]
-		cred.Secrets = credAttrs[credAttrSecretKey]
+		cred.User = credAttrs[CredAttrAccessKey]
+		cred.Secrets = credAttrs[CredAttrSecretKey]
 		authMode = identity.AuthKeyPair
 	}
 	return cred, authMode

--- a/provider/rackspace/credentials.go
+++ b/provider/rackspace/credentials.go
@@ -1,0 +1,48 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rackspace
+
+import (
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/provider/openstack"
+)
+
+// Credentials represents openstack credentials specifically tailored
+// to rackspace.  Mostly this means that they're appropriate for the v2 API, and
+// thus there's no domain name.
+type Credentials struct {
+	openstack.OpenstackCredentials
+}
+
+// CredentialSchemas is part of the environs.ProviderCredentials interface.
+func (c Credentials) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
+	m := c.OpenstackCredentials.CredentialSchemas()
+	schema := m[cloud.UserPassAuthType]
+	// remove domain name from attributes.
+	for i, attr := range schema {
+		if attr.Name == openstack.CredAttrDomainName {
+			m[cloud.UserPassAuthType] = append(schema[:i], schema[i+1:]...)
+			break
+		}
+	}
+	return m
+}
+
+// DetectCredentials is part of the environs.ProviderCredentials interface.
+func (c Credentials) DetectCredentials() (*cloud.CloudCredential, error) {
+	result, err := c.OpenstackCredentials.DetectCredentials()
+	if err != nil {
+		return nil, err
+	}
+	// delete domain name from creds, since rackspace doesn't use it, and it
+	// confuses our code.
+	for k, v := range result.AuthCredentials {
+		attr := v.Attributes()
+		if _, ok := attr[openstack.CredAttrDomainName]; ok {
+			delete(attr, openstack.CredAttrDomainName)
+			result.AuthCredentials[k] = cloud.NewCredential(v.AuthType(), attr)
+		}
+	}
+	return result, nil
+}

--- a/provider/rackspace/credentials_test.go
+++ b/provider/rackspace/credentials_test.go
@@ -1,0 +1,47 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rackspace_test
+
+import (
+	"os"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/provider/openstack"
+	"github.com/juju/juju/provider/rackspace"
+)
+
+var _ = gc.Suite(&CredentialSuite{})
+
+type CredentialSuite struct {
+	testing.IsolationSuite
+}
+
+func (CredentialSuite) TestCredentialSchemasNoDomain(c *gc.C) {
+	schemas := rackspace.Credentials{}.CredentialSchemas()
+	for name, schema := range schemas {
+		for _, attr := range schema {
+			if attr.Name == openstack.CredAttrDomainName {
+				c.Fatalf("schema %q has domain name attribute", name)
+			}
+		}
+	}
+}
+
+func (CredentialSuite) TestDetectCredentialsNoDomain(c *gc.C) {
+	os.Setenv("OS_USERNAME", "foo")
+	os.Setenv("OS_TENANT_NAME", "baz")
+	os.Setenv("OS_PASSWORD", "bar")
+	os.Setenv("OS_DOMAIN_NAME", "domain")
+	result, err := rackspace.Credentials{}.DetectCredentials()
+	c.Assert(err, jc.ErrorIsNil)
+	for _, v := range result.AuthCredentials {
+		attr := v.Attributes()
+		if _, ok := attr[openstack.CredAttrDomainName]; ok {
+			c.Fatal("Domain name exists in rackspace creds and should not.")
+		}
+	}
+}

--- a/provider/rackspace/init.go
+++ b/provider/rackspace/init.go
@@ -14,7 +14,7 @@ const (
 
 func init() {
 	osProvider := openstack.EnvironProvider{
-		openstack.OpenstackCredentials{},
+		Credentials{},
 		&rackspaceConfigurator{},
 		&firewallerFactory{},
 	}


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/juju/+bug/1624831

Rackspace uses openstack's v2 API, and thus doesn't use
the domain name.  Additionally, if you do give a domain
name, juju gets confused and can't connect to rackspace
with a confusing error.  This PR fixes the UX problem
of interactive add-credential prompting for domain-name.