### PR TITLE
Corrects misleading error message when deploying

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -336,11 +336,16 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 	add("/model/:modeluuid/logsink", logSinkHandler)
 	add("/model/:modeluuid/logstream", logStreamHandler)
 	add("/model/:modeluuid/log", debugLogHandler)
-	add("/model/:modeluuid/charms",
-		&charmsHandler{
-			ctxt:    httpCtxt,
-			dataDir: srv.dataDir},
-	)
+
+	charmsHandler := &charmsHandler{
+		ctxt:    httpCtxt,
+		dataDir: srv.dataDir,
+	}
+	charmsServer := &CharmsHTTPHandler{
+		PostHandler: charmsHandler.ServePost,
+		GetHandler:  charmsHandler.ServeGet,
+	}
+	add("/model/:modeluuid/charms", charmsServer)
 	add("/model/:modeluuid/tools",
 		&toolsUploadHandler{
 			ctxt: httpCtxt,
@@ -369,12 +374,7 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 	// For backwards compatibility we register all the old paths
 	add("/log", debugLogHandler)
 
-	add("/charms",
-		&charmsHandler{
-			ctxt:    httpCtxt,
-			dataDir: srv.dataDir,
-		},
-	)
+	add("/charms", charmsServer)
 	add("/tools",
 		&toolsUploadHandler{
 			ctxt: httpCtxt,

--- a/apiserver/backup.go
+++ b/apiserver/backup.go
@@ -101,7 +101,9 @@ func (h *backupHandler) upload(backups backups.Backups, resp http.ResponseWriter
 		return "", err
 	}
 
-	sendStatusAndJSON(resp, http.StatusOK, &params.BackupsUploadResult{ID: id})
+	if err := sendStatusAndJSON(resp, http.StatusOK, &params.BackupsUploadResult{ID: id}); err != nil {
+		return "", errors.Trace(err)
+	}
 	return id, nil
 }
 
@@ -162,6 +164,7 @@ func (h *backupHandler) sendFile(file io.Reader, checksum string, resp http.Resp
 // rather than in the Error field.
 func (h *backupHandler) sendError(w http.ResponseWriter, err error) {
 	err, status := common.ServerErrorAndStatus(err)
-
-	sendStatusAndJSON(w, status, err)
+	if err := sendStatusAndJSON(w, status, err); err != nil {
+		logger.Errorf("%v", err)
+	}
 }

--- a/apiserver/bundle/bundle_test.go
+++ b/apiserver/bundle/bundle_test.go
@@ -58,7 +58,7 @@ func (s *bundleSuite) TestGetChangesBundleVerificationErrors(c *gc.C) {
 	c.Assert(r.Errors, jc.SameContents, []string{
 		`placement "1" refers to a machine not defined in this bundle`,
 		`too many units specified in unit placement for application "django"`,
-		`invalid charm URL in application "haproxy": URL has invalid charm or bundle name: "42"`,
+		`invalid charm URL in application "haproxy": cannot parse URL "42": name "42" not valid`,
 		`negative number of units specified on application "haproxy"`,
 	})
 }

--- a/apiserver/charms/client_test.go
+++ b/apiserver/charms/client_test.go
@@ -171,13 +171,13 @@ func (s *charmsSuite) TestClientCharmInfo(c *gc.C) {
 			about: "invalid URL",
 			charm: "wordpress",
 			url:   "not-valid!",
-			err:   `URL has invalid charm or bundle name: "not-valid!"`,
+			err:   `cannot parse URL "not-valid!": name "not-valid!" not valid`,
 		},
 		{
 			about: "invalid schema",
 			charm: "wordpress",
 			url:   "not-valid:your-arguments",
-			err:   `charm or bundle URL has invalid schema: "not-valid:your-arguments"`,
+			err:   `cannot parse URL "not-valid:your-arguments": schema "not-valid" not valid`,
 		},
 		{
 			about: "unknown charm",
@@ -195,7 +195,9 @@ func (s *charmsSuite) TestClientCharmInfo(c *gc.C) {
 			c.Check(err, gc.ErrorMatches, t.err)
 			continue
 		}
-		c.Assert(err, jc.ErrorIsNil)
+		if c.Check(err, jc.ErrorIsNil) == false {
+			continue
+		}
 		c.Check(info, jc.DeepEquals, t.expected)
 	}
 }

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -1131,51 +1131,51 @@ func (s *clientSuite) TestProvisioningScriptDisablePackageCommands(c *gc.C) {
 	c.Check(script, gc.Not(jc.Contains), "apt-get upgrade")
 }
 
-var resolveCharmTests = []struct {
-	about      string
-	url        string
-	resolved   string
-	parseErr   string
-	resolveErr string
-}{{
-	about:    "wordpress resolved",
-	url:      "cs:wordpress",
-	resolved: "cs:trusty/wordpress",
-}, {
-	about:    "mysql resolved",
-	url:      "cs:mysql",
-	resolved: "cs:precise/mysql",
-}, {
-	about:    "riak resolved",
-	url:      "cs:riak",
-	resolved: "cs:trusty/riak",
-}, {
-	about:    "fully qualified char reference",
-	url:      "cs:utopic/riak-5",
-	resolved: "cs:utopic/riak-5",
-}, {
-	about:    "charm with series and no revision",
-	url:      "cs:precise/wordpress",
-	resolved: "cs:precise/wordpress",
-}, {
-	about:      "fully qualified reference not found",
-	url:        "cs:utopic/riak-42",
-	resolveErr: `cannot resolve URL "cs:utopic/riak-42": charm not found`,
-}, {
-	about:      "reference not found",
-	url:        "cs:no-such",
-	resolveErr: `cannot resolve URL "cs:no-such": charm or bundle not found`,
-}, {
-	about:    "invalid charm name",
-	url:      "cs:",
-	parseErr: `URL has invalid charm or bundle name: "cs:"`,
-}, {
-	about:      "local charm",
-	url:        "local:wordpress",
-	resolveErr: `only charm store charm references are supported, with cs: schema`,
-}}
-
 func (s *clientRepoSuite) TestResolveCharm(c *gc.C) {
+	resolveCharmTests := []struct {
+		about      string
+		url        string
+		resolved   string
+		parseErr   string
+		resolveErr string
+	}{{
+		about:    "wordpress resolved",
+		url:      "cs:wordpress",
+		resolved: "cs:trusty/wordpress",
+	}, {
+		about:    "mysql resolved",
+		url:      "cs:mysql",
+		resolved: "cs:precise/mysql",
+	}, {
+		about:    "riak resolved",
+		url:      "cs:riak",
+		resolved: "cs:trusty/riak",
+	}, {
+		about:    "fully qualified char reference",
+		url:      "cs:utopic/riak-5",
+		resolved: "cs:utopic/riak-5",
+	}, {
+		about:    "charm with series and no revision",
+		url:      "cs:precise/wordpress",
+		resolved: "cs:precise/wordpress",
+	}, {
+		about:      "fully qualified reference not found",
+		url:        "cs:utopic/riak-42",
+		resolveErr: `cannot resolve URL "cs:utopic/riak-42": charm not found`,
+	}, {
+		about:      "reference not found",
+		url:        "cs:no-such",
+		resolveErr: `cannot resolve URL "cs:no-such": charm or bundle not found`,
+	}, {
+		about:    "invalid charm name",
+		url:      "cs:",
+		parseErr: `cannot parse URL "cs://": name "" not valid`,
+	}, {
+		about:      "local charm",
+		url:        "local:wordpress",
+		resolveErr: `only charm store charm references are supported, with cs: schema`,
+	}}
+
 	// Add some charms to be resolved later.
 	for _, url := range []string{
 		"precise/wordpress-1",
@@ -1194,18 +1194,22 @@ func (s *clientRepoSuite) TestResolveCharm(c *gc.C) {
 		client := s.APIState.Client()
 		ref, err := charm.ParseURL(test.url)
 		if test.parseErr == "" {
-			if !c.Check(err, jc.ErrorIsNil) {
+			if c.Check(err, jc.ErrorIsNil) == false {
 				continue
 			}
 		} else {
-			c.Assert(err, gc.NotNil)
+			if c.Check(err, gc.NotNil) == false {
+				continue
+			}
 			c.Check(err, gc.ErrorMatches, test.parseErr)
 			continue
 		}
 
 		curl, err := client.ResolveCharm(ref)
 		if test.resolveErr == "" {
-			c.Assert(err, jc.ErrorIsNil)
+			if c.Check(err, jc.ErrorIsNil) == false {
+				continue
+			}
 			c.Check(curl.String(), gc.Equals, test.resolved)
 			continue
 		}

--- a/apiserver/gui_test.go
+++ b/apiserver/gui_test.go
@@ -385,12 +385,14 @@ func (s *guiSuite) TestGUIHandler(c *gc.C) {
 		}
 		body := assertResponse(c, resp, test.expectedStatus, test.expectedContentType)
 		if test.expectedError == "" {
-			c.Assert(string(body), gc.Equals, test.expectedBody)
+			c.Check(string(body), gc.Equals, test.expectedBody)
 		} else {
 			var jsonResp params.ErrorResult
 			err := json.Unmarshal(body, &jsonResp)
-			c.Assert(err, jc.ErrorIsNil, gc.Commentf("body: %s", body))
-			c.Assert(jsonResp.Error.Message, gc.Matches, test.expectedError)
+			if !c.Check(err, jc.ErrorIsNil, gc.Commentf("body: %s", body)) {
+				continue
+			}
+			c.Check(jsonResp.Error.Message, gc.Matches, test.expectedError)
 		}
 	}
 }

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -63,12 +63,6 @@ type ModelAPI interface {
 	ModelGet() (map[string]interface{}, error)
 }
 
-type CharmRepository interface {
-	Get(curl *charm.URL) (charm.Charm, error)
-	GetBundle(curl *charm.URL) (charm.Bundle, error)
-	Resolve(*charm.URL) (canonRef *charm.URL, supportedSeries []string, _ error)
-}
-
 // MeteredDeployAPI represents the methods of the API the deploy
 // command needs for metered charms.
 type MeteredDeployAPI interface {
@@ -848,11 +842,10 @@ func (c *DeployCommand) maybeReadLocalCharm() (deployFn, error) {
 			// Local charms don't need a channel.
 		}
 
-		var csMac *macaroon.Macaroon // local charms don't need one.
 		ctx.Infof("Deploying charm %q.", curl.String())
 		return errors.Trace(c.deployCharm(
 			id,
-			csMac,
+			(*macaroon.Macaroon)(nil), // local charms don't need one.
 			curl.Series,
 			ctx,
 			apiRoot,

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -138,11 +138,6 @@ func (s *DeploySuite) TestPathWithNoCharmOrBundle(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `charm or bundle at .*`)
 }
 
-func (s *DeploySuite) TestInvalidURL(c *gc.C) {
-	err := runDeploy(c, "cs:craz~ness")
-	c.Assert(err, gc.ErrorMatches, `URL has invalid charm or bundle name: "cs:craz~ness"`)
-}
-
 func (s *DeploySuite) TestCharmDir(c *gc.C) {
 	ch := testcharms.Repo.ClonedDirPath(s.CharmsPath, "dummy")
 	err := runDeploy(c, ch, "--series", "trusty")

--- a/cmd/juju/application/register_test.go
+++ b/cmd/juju/application/register_test.go
@@ -49,7 +49,6 @@ func (s *registrationSuite) TearDownTest(c *gc.C) {
 	s.server.Close()
 }
 
-// FAILING
 func (s *registrationSuite) TestMeteredCharm(c *gc.C) {
 	client := httpbakery.NewClient()
 	d := DeploymentInfo{
@@ -167,7 +166,6 @@ func (s *registrationSuite) TestPlanNotSpecifiedCharm(c *gc.C) {
 	})
 }
 
-// FAILING
 func (s *registrationSuite) TestMeteredCharmAPIError(c *gc.C) {
 	s.stub.SetErrors(nil, errors.New("something failed"))
 	client := httpbakery.NewClient()
@@ -224,7 +222,6 @@ func (s *registrationSuite) TestMeteredCharmInvalidAllocation(c *gc.C) {
 	s.stub.CheckNoCalls(c)
 }
 
-// FAILING
 func (s *registrationSuite) TestMeteredCharmDeployError(c *gc.C) {
 	client := httpbakery.NewClient()
 	d := DeploymentInfo{
@@ -420,7 +417,6 @@ func (s *registrationSuite) TestMeteredCharmNoDefaultPlan(c *gc.C) {
 	}})
 }
 
-// FAILING
 func (s *registrationSuite) TestMeteredCharmFailToQueryDefaultCharm(c *gc.C) {
 	s.stub.SetErrors(nil, errors.New("something failed"))
 	s.register = &RegisterMeteredCharm{
@@ -474,7 +470,6 @@ func (s *registrationSuite) TestUnmeteredCharm(c *gc.C) {
 	s.stub.CheckCalls(c, []testing.StubCall{})
 }
 
-// FAILING
 func (s *registrationSuite) TestFailedAuth(c *gc.C) {
 	s.stub.SetErrors(nil, errors.Errorf("could not authorize"))
 	client := httpbakery.NewClient()

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -73,9 +73,9 @@ gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:
 gopkg.in/goose.v1	git	495e6fa2ab89bc5ed2c8e1bbcbc4c9e4a3c97d37	2016-03-17T17:25:46Z
 gopkg.in/ini.v1	git	776aa739ce9373377cd16f526cdf06cb4c89b40f	2016-02-22T23:24:41Z
 gopkg.in/juju/blobstore.v2	git	51fa6e26128d74e445c72d3a91af555151cc3654	2016-01-25T02:37:03Z
-gopkg.in/juju/charm.v6-unstable	git	70121953601b8bbdd8bb66e29e1bfddecd1005cc	2016-08-25T10:09:43Z
+gopkg.in/juju/charm.v6-unstable	git	83771c4919d6810bce5b7e63f46bea5fbfed0b93	2016-10-03T20:31:18Z
 gopkg.in/juju/charmrepo.v2-unstable	git	73c1113f7ddee0306f4b3c19773d35a3f153c04a	2016-08-11T14:04:21Z
-gopkg.in/juju/charmstore.v5-unstable	git	714c25cd43dbb8eb51f57a55d76d521fc2126455	2016-08-09T13:45:06Z
+gopkg.in/juju/charmstore.v5-unstable	git	fd1eef3002fc6b6daff5e97efab6f5056d22dcc7	2016-09-16T10:09:07Z
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/juju/jujusvg.v2	git	d82160011935ef79fc7aca84aba2c6f74700fe75	2016-06-09T10:52:15Z
 gopkg.in/juju/names.v2	git	6f338bfd0b607bba6f80e8d512486ae49d3da2d4	2016-09-15T03:41:08Z


### PR DESCRIPTION
This addresses lp:1616200, with caveats.

Previously deploying a charm with an incorrect name would:
- Add the charm to the environment
- Display:

> "ERROR bad charm URL in response: URL has invalid charm or bundle name: "local:<series>/<charm>-<rev>""

Subsequent deploys of the charm with an incorrect name would display:
> ERROR POST https://10.1.118.174:17070/model/ba258aba-b24d-497f-8a38-aebba03105ee/charms?revision=0&schema=local&series=xenial: bad charm URL in response: URL has invalid charm or bundle name: "local:<series>/<charm>-<rev>""

This patch corrects the chain of errors to have proper causes which implicitly corrects the error message to:
> cannot upload charm: name "b_1605096" not valid

or series, or whatever the case may be. However, because it fails faster, it takes a different path through the code. The bad charm won't be added to the `charms` mongo collection (good), but we now always see the verbose POST prepended in front of the error (bad).

To correct this properly, I think we should modify the juju/httprequest `Do` method. I plan on doing this in a subsequent patch.