### PR TITLE
Show the unit leader in status.

### DIFF
--- a/apiserver/client/backend.go
+++ b/apiserver/client/backend.go
@@ -32,40 +32,41 @@ type Unit interface {
 // Backend contains the state.State methods used in this package,
 // allowing stubs to be created for testing.
 type Backend interface {
-	FindEntity(names.Tag) (state.Entity, error)
-	Unit(string) (Unit, error)
-	Application(string) (*state.Application, error)
-	Machine(string) (*state.Machine, error)
-	AllMachines() ([]*state.Machine, error)
-	AllApplications() ([]*state.Application, error)
-	AllRelations() ([]*state.Relation, error)
-	AddOneMachine(state.MachineTemplate) (*state.Machine, error)
+	AbortCurrentUpgrade() error
+	AddControllerUser(state.UserAccessSpec) (permission.UserAccess, error)
 	AddMachineInsideMachine(state.MachineTemplate, string, instance.ContainerType) (*state.Machine, error)
 	AddMachineInsideNewMachine(template, parentTemplate state.MachineTemplate, containerType instance.ContainerType) (*state.Machine, error)
-	ModelConstraints() (constraints.Value, error)
+	AddModelUser(string, state.UserAccessSpec) (permission.UserAccess, error)
+	AddOneMachine(state.MachineTemplate) (*state.Machine, error)
+	AddRelation(...state.Endpoint) (*state.Relation, error)
+	AllApplications() ([]*state.Application, error)
+	AllMachines() ([]*state.Machine, error)
+	AllRelations() ([]*state.Relation, error)
+	Annotations(state.GlobalEntity) (map[string]string, error)
+	APIHostPorts() ([][]network.HostPort, error)
+	Application(string) (*state.Application, error)
+	ApplicationLeaders() (map[string]string, error)
+	Charm(*charm.URL) (*state.Charm, error)
+	EndpointsRelation(...state.Endpoint) (*state.Relation, error)
+	FindEntity(names.Tag) (state.Entity, error)
+	ForModel(tag names.ModelTag) (*state.State, error)
+	InferEndpoints(...string) ([]state.Endpoint, error)
+	LatestMigration() (state.ModelMigration, error)
+	LatestPlaceholderCharm(*charm.URL) (*state.Charm, error)
+	Machine(string) (*state.Machine, error)
+	Model() (*state.Model, error)
 	ModelConfig() (*config.Config, error)
 	ModelConfigValues() (config.ConfigValues, error)
-	UpdateModelConfig(map[string]interface{}, []string, state.ValidateConfigFunc) error
-	SetModelConstraints(constraints.Value) error
-	ModelUUID() string
+	ModelConstraints() (constraints.Value, error)
 	ModelTag() names.ModelTag
-	Model() (*state.Model, error)
-	ForModel(tag names.ModelTag) (*state.State, error)
-	SetModelAgentVersion(version.Number) error
-	SetAnnotations(state.GlobalEntity, map[string]string) error
-	Annotations(state.GlobalEntity) (map[string]string, error)
-	InferEndpoints(...string) ([]state.Endpoint, error)
-	EndpointsRelation(...state.Endpoint) (*state.Relation, error)
-	Charm(*charm.URL) (*state.Charm, error)
-	LatestPlaceholderCharm(*charm.URL) (*state.Charm, error)
-	AddRelation(...state.Endpoint) (*state.Relation, error)
-	AddModelUser(string, state.UserAccessSpec) (permission.UserAccess, error)
-	AddControllerUser(state.UserAccessSpec) (permission.UserAccess, error)
+	ModelUUID() string
 	RemoveUserAccess(names.UserTag, names.Tag) error
+	SetAnnotations(state.GlobalEntity, map[string]string) error
+	SetModelAgentVersion(version.Number) error
+	SetModelConstraints(constraints.Value) error
+	Unit(string) (Unit, error)
+	UpdateModelConfig(map[string]interface{}, []string, state.ValidateConfigFunc) error
 	Watch() *state.Multiwatcher
-	AbortCurrentUpgrade() error
-	APIHostPorts() ([][]network.HostPort, error)
-	LatestMigration() (state.ModelMigration, error)
 }
 
 func NewStateBackend(st *state.State) Backend {

--- a/apiserver/client/status_test.go
+++ b/apiserver/client/status_test.go
@@ -57,6 +57,19 @@ func (s *statusSuite) TestFullStatus(c *gc.C) {
 	c.Check(resultMachine.Series, gc.Equals, machine.Series())
 }
 
+func (s *statusSuite) TestFullStatusUnitLeadership(c *gc.C) {
+	u := s.Factory.MakeUnit(c, nil)
+	s.State.LeadershipClaimer().ClaimLeadership(u.ApplicationName(), u.Name(), time.Minute)
+	client := s.APIState.Client()
+	status, err := client.Status(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	app, ok := status.Applications[u.ApplicationName()]
+	c.Assert(ok, jc.IsTrue)
+	unit, ok := app.Units[u.Name()]
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(unit.Leader, jc.IsTrue)
+}
+
 var _ = gc.Suite(&statusUnitTestSuite{})
 
 type statusUnitTestSuite struct {

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -89,6 +89,7 @@ type UnitStatus struct {
 	PublicAddress string                `json:"public-address"`
 	Charm         string                `json:"charm"`
 	Subordinates  map[string]UnitStatus `json:"subordinates"`
+	Leader        bool                  `json:"leader"`
 }
 
 // RelationStatus holds status info about a relation.

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -89,7 +89,7 @@ type UnitStatus struct {
 	PublicAddress string                `json:"public-address"`
 	Charm         string                `json:"charm"`
 	Subordinates  map[string]UnitStatus `json:"subordinates"`
-	Leader        bool                  `json:"leader"`
+	Leader        bool                  `json:"leader,omitempty"`
 }
 
 // RelationStatus holds status info about a relation.

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -114,6 +114,7 @@ type unitStatus struct {
 	JujuStatusInfo     statusInfoContents `json:"juju-status,omitempty" yaml:"juju-status"`
 	MeterStatus        *meterStatus       `json:"meter-status,omitempty" yaml:"meter-status,omitempty"`
 
+	Leader        bool                  `json:"leader,omitempty" yaml:"leader,omitempty"`
 	Charm         string                `json:"upgrading-from,omitempty" yaml:"upgrading-from,omitempty"`
 	Machine       string                `json:"machine,omitempty" yaml:"machine,omitempty"`
 	OpenedPorts   []string              `json:"open-ports,omitempty" yaml:"open-ports,omitempty"`

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -207,6 +207,7 @@ func (sf *statusFormatter) formatUnit(info unitFormatInfo) unitStatus {
 		PublicAddress:      info.unit.PublicAddress,
 		Charm:              info.unit.Charm,
 		Subordinates:       make(map[string]unitStatus),
+		Leader:             info.unit.Leader,
 	}
 
 	if ms, ok := info.meterStatuses[info.unitName]; ok {

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -177,6 +177,9 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		if agentDoing != "" {
 			message = fmt.Sprintf("(%s) %s", agentDoing, message)
 		}
+		if u.Leader {
+			name += "*"
+		}
 		w.Print(indent("", level*2, name))
 		w.PrintStatus(u.WorkloadStatusInfo.Current)
 		w.PrintStatus(u.JujuStatusInfo.Current)

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -472,7 +472,7 @@ func (e *exporter) applications() error {
 		return errors.Trace(err)
 	}
 
-	leaders, err := e.readApplicationLeaders()
+	leaders, err := e.st.ApplicationLeaders()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -527,19 +527,6 @@ func (e *exporter) storageConstraints(doc storageConstraintsDoc) map[string]desc
 		}
 	}
 	return result
-}
-
-func (e *exporter) readApplicationLeaders() (map[string]string, error) {
-	client, err := e.st.getLeadershipLeaseClient()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	leases := client.Leases()
-	result := make(map[string]string, len(leases))
-	for key, value := range leases {
-		result[key] = value.Holder
-	}
-	return result, nil
 }
 
 func (e *exporter) readAllPayloads() (map[string][]payload.FullPayloadInfo, error) {

--- a/state/state.go
+++ b/state/state.go
@@ -377,6 +377,21 @@ func (st *State) start(controllerTag names.ControllerTag) (err error) {
 	return nil
 }
 
+// ApplicationLeaders returns a map of the application name to the
+// unit name that is the current leader.
+func (st *State) ApplicationLeaders() (map[string]string, error) {
+	client, err := st.getLeadershipLeaseClient()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	leases := client.Leases()
+	result := make(map[string]string, len(leases))
+	for key, value := range leases {
+		result[key] = value.Holder
+	}
+	return result, nil
+}
+
 func (st *State) getLeadershipLeaseClient() (lease.Client, error) {
 	client, err := statelease.NewClient(statelease.ClientConfig{
 		Id:         st.leaseClientId,

--- a/state/state_leader_test.go
+++ b/state/state_leader_test.go
@@ -128,6 +128,20 @@ func (s *LeadershipSuite) TestHackLeadershipUnblocksClaimer(c *gc.C) {
 	}
 }
 
+func (s *LeadershipSuite) TestApplicationLeaders(c *gc.C) {
+	err := s.claimer.ClaimLeadership("blah", "blah/0", time.Minute)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.claimer.ClaimLeadership("application", "application/1", time.Minute)
+	c.Assert(err, jc.ErrorIsNil)
+
+	leaders, err := s.State.ApplicationLeaders()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(leaders, jc.DeepEquals, map[string]string{
+		"application": "application/1",
+		"blah":        "blah/0",
+	})
+}
+
 func (s *LeadershipSuite) expire(c *gc.C, applicationname string) {
 	s.clock.Advance(time.Hour)
 	s.Session.Fsync(false)


### PR DESCRIPTION
Addresses http://pad.lv/1620063.

Whether the unit is the leader or not is now returned in the FullStatus. The leader is indicated in tabular output with an * at the end of the unit name. YAML and JSON have a map value called "leader" that is only added when it is true.

The addition of the field into the FullStatus output does not need any facade version bump. It is optional, and the code handles it if it is missing by just not indicating a leader. This has been confirmed by running the new client against an old server.

## QA
```
$ juju bootstrap status-test lxd
$ juju deploy ubuntu -n 2
# wait
$ juju status
juju status
MODEL    CONTROLLER   CLOUD/REGION   VERSION
default  status-test  lxd/localhost  2.0-rc2.1

APP     VERSION  STATUS  SCALE  CHARM   STORE       REV  OS      NOTES
ubuntu  16.04    active      2  ubuntu  jujucharms    8  ubuntu  

UNIT       WORKLOAD  AGENT  MACHINE  PUBLIC-ADDRESS  PORTS  MESSAGE
ubuntu/0*  active    idle   0        10.250.171.239         ready
ubuntu/1   active    idle   1        10.250.171.225         ready

MACHINE  STATE    DNS             INS-ID         SERIES  AZ
0        started  10.250.171.239  juju-3ae63c-0  xenial  
1        started  10.250.171.225  juju-3ae63c-1  xenial  
```