### PR TITLE
Clean up relation settings transactionally

### DIFF
--- a/apiserver/undertaker/mock_test.go
+++ b/apiserver/undertaker/mock_test.go
@@ -64,7 +64,7 @@ func (m *mockState) EnsureModelRemoved() error {
 
 func (m *mockState) RemoveAllModelDocs() error {
 	if m.env.life != state.Dead {
-		return errors.New("transaction aborted")
+		return errors.New("model not dead")
 	}
 	m.removed = true
 	return nil

--- a/apiserver/undertaker/undertaker.go
+++ b/apiserver/undertaker/undertaker.go
@@ -86,14 +86,7 @@ func (u *UndertakerAPI) ProcessDyingModel() error {
 
 // RemoveModel removes any records of this model from Juju.
 func (u *UndertakerAPI) RemoveModel() error {
-	err := u.st.RemoveAllModelDocs()
-	if err != nil {
-		// TODO(waigani) Return a human friendly error for now. The proper fix
-		// is to run a buildTxn within state.RemoveAllModelDocs, so we
-		// can return better errors than "transaction aborted".
-		return errors.New("an error occurred, unable to remove model")
-	}
-	return nil
+	return u.st.RemoveAllModelDocs()
 }
 
 func (u *UndertakerAPI) environResourceWatcher() params.NotifyWatchResult {

--- a/apiserver/undertaker/undertaker_test.go
+++ b/apiserver/undertaker/undertaker_test.go
@@ -115,7 +115,7 @@ func (s *undertakerSuite) TestRemoveAliveEnviron(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = hostedAPI.RemoveModel()
-	c.Assert(err, gc.ErrorMatches, "an error occurred, unable to remove model")
+	c.Assert(err, gc.ErrorMatches, "model not dead")
 }
 
 func (s *undertakerSuite) TestRemoveDyingEnviron(c *gc.C) {
@@ -128,7 +128,7 @@ func (s *undertakerSuite) TestRemoveDyingEnviron(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = hostedAPI.RemoveModel()
-	c.Assert(err, gc.ErrorMatches, "an error occurred, unable to remove model")
+	c.Assert(err, gc.ErrorMatches, "model not dead")
 }
 
 func (s *undertakerSuite) TestDeadRemoveEnviron(c *gc.C) {

--- a/featuretests/api_undertaker_test.go
+++ b/featuretests/api_undertaker_test.go
@@ -88,7 +88,7 @@ func (s *undertakerSuite) TestStateRemoveEnvironFails(c *gc.C) {
 	undertakerClient, err := undertaker.NewClient(st, apiwatcher.NewNotifyWatcher)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(undertakerClient, gc.NotNil)
-	c.Assert(undertakerClient.RemoveModel(), gc.ErrorMatches, "an error occurred, unable to remove model")
+	c.Assert(undertakerClient.RemoveModel(), gc.ErrorMatches, "can't remove model: model not dead")
 }
 
 func (s *undertakerSuite) TestHostedEnvironInfo(c *gc.C) {
@@ -147,7 +147,7 @@ func (s *undertakerSuite) TestHostedRemoveEnviron(c *gc.C) {
 
 	// Aborts on alive environ.
 	err := undertakerClient.RemoveModel()
-	c.Assert(err, gc.ErrorMatches, "an error occurred, unable to remove model")
+	c.Assert(err, gc.ErrorMatches, "can't remove model: model not dead")
 
 	factory.NewFactory(otherSt).MakeApplication(c, nil)
 	env, err := otherSt.Model()
@@ -156,7 +156,7 @@ func (s *undertakerSuite) TestHostedRemoveEnviron(c *gc.C) {
 
 	// Aborts on dying environ.
 	err = undertakerClient.RemoveModel()
-	c.Assert(err, gc.ErrorMatches, "an error occurred, unable to remove model")
+	c.Assert(err, gc.ErrorMatches, "can't remove model: model not dead")
 
 	err = otherSt.Cleanup()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -117,7 +117,7 @@ func (st *State) Cleanup() (err error) {
 			}
 		}
 		if err != nil {
-			logger.Errorf("cleanup failed: %v", err)
+			logger.Errorf("cleanup failed for %v(%q): %v", doc.Kind, doc.Prefix, err)
 			continue
 		}
 		ops := []txn.Op{{
@@ -150,20 +150,9 @@ func RegisterCleanupHandler(kindStr string, handler CleanupHandler) error {
 }
 
 func (st *State) cleanupRelationSettings(prefix string) error {
-	settings, closer := st.getCollection(settingsC)
-	defer closer()
-	// Documents marked for cleanup are not otherwise referenced in the
-	// system, and will not be under watch, and are therefore safe to
-	// delete directly.
-	settingsW := settings.Writeable()
-
-	sel := bson.D{{"_id", bson.D{{"$regex", "^" + st.docID(prefix)}}}}
-	if count, err := settingsW.Find(sel).Count(); err != nil {
-		return fmt.Errorf("cannot detect cleanup targets: %v", err)
-	} else if count != 0 {
-		if _, err := settingsW.RemoveAll(sel); err != nil {
-			return fmt.Errorf("cannot remove documents marked for cleanup: %v", err)
-		}
+	change := relationSettingsCleanupChange{Prefix: st.docID(prefix)}
+	if err := Apply(st.database, change); err != nil {
+		return errors.Trace(err)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes http://pad.lv/1611093, http://pad.lv/1611159 and the underlying
cause of http://pad.lv/1566426 (I think).

When the cleanup for relation settings deletes them directly we can get
a sequence like the following when a model with relations is destroyed:

1. Cleanup for relation settings is queued
2. The undertaker prepares a txn to remove the settings (including the
still-present relation settings)
3. The cleanup runs, deleting the settings directly (so not leaving any
bookkeeping info for the txn system)
4. The settings removal txn tries to run but can't find the relation
settings
5. This blocks any other txns that try to look at the model, because the 
blocked txn asserts that the model is dead.

Includes some drive-by logging improvements: 
* When a cleanup fails, say what kind of cleanup it was.
* We already catch ErrAborted errors in state.RemoveAllModels - the if statement
in the api facade just masks any *other* possible errors.

Testing done: 
The fix was tested locally by bootstrapping, deploying applications and connecting 
them up, then destroying the models.
It was also used in the OIL lab CI tests to try to reproduce the hang, but it didn't reoccur.