### PR TITLE
Move the GetBundleChanges call in a new Bundle facade.

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -21,6 +21,7 @@ var facadeVersions = map[string]int{
 	"ApplicationScaler":            1,
 	"Backups":                      1,
 	"Block":                        2,
+	"Bundle":                       1,
 	"CharmRevisionUpdater":         2,
 	"Charms":                       2,
 	"Cleaner":                      2,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/juju/juju/apiserver/applicationscaler"
 	_ "github.com/juju/juju/apiserver/backups" // ModelUser Write
 	_ "github.com/juju/juju/apiserver/block"   // ModelUser Write
+	_ "github.com/juju/juju/apiserver/bundle"
 	_ "github.com/juju/juju/apiserver/charmrevisionupdater"
 	_ "github.com/juju/juju/apiserver/charms" // ModelUser Write
 	_ "github.com/juju/juju/apiserver/cleaner"

--- a/apiserver/bundle/bundle.go
+++ b/apiserver/bundle/bundle.go
@@ -21,11 +21,15 @@ import (
 
 // init registers the Bundle facade.
 func init() {
-	common.RegisterStandardFacade("Bundle", 1, NewFacade)
+	common.RegisterStandardFacade("Bundle", 1, newFacade)
+}
+
+func newFacade(_ *state.State, _ facade.Resources, auth facade.Authorizer) (Bundle, error) {
+	return NewFacade(auth)
 }
 
 // NewFacade creates and returns a new Bundle API facade.
-func NewFacade(_ *state.State, _ facade.Resources, auth facade.Authorizer) (Bundle, error) {
+func NewFacade(auth facade.Authorizer) (Bundle, error) {
 	if !auth.AuthClient() {
 		return nil, common.ErrPerm
 	}

--- a/apiserver/bundle/bundle.go
+++ b/apiserver/bundle/bundle.go
@@ -21,11 +21,11 @@ import (
 
 // init registers the Bundle facade.
 func init() {
-	common.RegisterStandardFacade("Bundle", 0, newFacade)
+	common.RegisterStandardFacade("Bundle", 1, NewFacade)
 }
 
-// newFacade creates and returns a new Bundle API facade.
-func newFacade(_ *state.State, _ facade.Resources, auth facade.Authorizer) (Bundle, error) {
+// NewFacade creates and returns a new Bundle API facade.
+func NewFacade(_ *state.State, _ facade.Resources, auth facade.Authorizer) (Bundle, error) {
 	if !auth.AuthClient() {
 		return nil, common.ErrPerm
 	}
@@ -36,7 +36,7 @@ func newFacade(_ *state.State, _ facade.Resources, auth facade.Authorizer) (Bund
 type Bundle interface {
 	// GetChanges returns the list of changes required to deploy the given
 	// bundle data.
-	GetChanges(params.BundleGetChangesParams) (params.BundleGetChangesResults, error)
+	GetChanges(params.BundleChangesParams) (params.BundleChangesResults, error)
 }
 
 // bundleAPI implements the Bundle interface and is the concrete implementation
@@ -46,8 +46,8 @@ type bundleAPI struct{}
 // GetChanges returns the list of changes required to deploy the given bundle
 // data. The changes are sorted by requirements, so that they can be applied in
 // order.
-func (b *bundleAPI) GetChanges(args params.BundleGetChangesParams) (params.BundleGetChangesResults, error) {
-	var results params.BundleGetChangesResults
+func (b *bundleAPI) GetChanges(args params.BundleChangesParams) (params.BundleChangesResults, error) {
+	var results params.BundleChangesResults
 	data, err := charm.ReadBundleData(strings.NewReader(args.BundleDataYAML))
 	if err != nil {
 		return results, errors.Annotate(err, "cannot read bundle YAML")
@@ -72,9 +72,9 @@ func (b *bundleAPI) GetChanges(args params.BundleGetChangesParams) (params.Bundl
 		return results, errors.Annotate(err, "cannot verify bundle")
 	}
 	changes := bundlechanges.FromData(data)
-	results.Changes = make([]*params.BundleChangesChange, len(changes))
+	results.Changes = make([]*params.BundleChange, len(changes))
 	for i, c := range changes {
-		results.Changes[i] = &params.BundleChangesChange{
+		results.Changes[i] = &params.BundleChange{
 			Id:       c.Id(),
 			Method:   c.Method(),
 			Args:     c.GUIArgs(),

--- a/apiserver/bundle/bundle_test.go
+++ b/apiserver/bundle/bundle_test.go
@@ -6,29 +6,27 @@ package bundle_test
 import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/bundle"
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	statetesting "github.com/juju/juju/state/testing"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type bundleSuite struct {
-	statetesting.StateSuite
+	coretesting.BaseSuite
 	facade bundle.Bundle
 }
 
 var _ = gc.Suite(&bundleSuite{})
 
 func (s *bundleSuite) SetUpTest(c *gc.C) {
-	s.StateSuite.SetUpTest(c)
-	model, err := s.State.ControllerModel()
-	c.Assert(err, jc.ErrorIsNil)
+	s.BaseSuite.SetUpTest(c)
 	auth := apiservertesting.FakeAuthorizer{
-		Tag: model.Owner(),
+		Tag: names.NewUserTag("who"),
 	}
-	facade, err := bundle.NewFacade(s.State, common.NewResources(), auth)
+	facade, err := bundle.NewFacade(auth)
 	c.Assert(err, jc.ErrorIsNil)
 	s.facade = facade
 }

--- a/apiserver/bundle/export_test.go
+++ b/apiserver/bundle/export_test.go
@@ -1,6 +1,0 @@
-// Copyright 2016 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
-
-package bundle
-
-var NewFacade = newFacade

--- a/apiserver/bundle/export_test.go
+++ b/apiserver/bundle/export_test.go
@@ -1,0 +1,6 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bundle
+
+var NewFacade = newFacade

--- a/apiserver/bundle/package_test.go
+++ b/apiserver/bundle/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bundle_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func Test(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}

--- a/apiserver/client/bundles.go
+++ b/apiserver/client/bundles.go
@@ -14,7 +14,7 @@ import (
 // This call is deprecated, clients should use the GetChanges endpoint on the
 // Bundle facade.
 func (c *Client) GetBundleChanges(args params.BundleChangesParams) (params.BundleChangesResults, error) {
-	bundleAPI, err := bundle.NewFacade(c.api.state(), c.api.resources, c.api.auth)
+	bundleAPI, err := bundle.NewFacade(c.api.auth)
 	if err != nil {
 		return params.BundleChangesResults{}, err
 	}

--- a/apiserver/client/bundles.go
+++ b/apiserver/client/bundles.go
@@ -1,0 +1,22 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package client
+
+import (
+	"github.com/juju/juju/apiserver/bundle"
+	"github.com/juju/juju/apiserver/params"
+)
+
+// GetBundleChanges returns the list of changes required to deploy the given
+// bundle data. The changes are sorted by requirements, so that they can be
+// applied in order.
+// This call is deprecated, clients should use the GetChanges endpoint on the
+// Bundle facade.
+func (c *Client) GetBundleChanges(args params.BundleChangesParams) (params.BundleChangesResults, error) {
+	bundleAPI, err := bundle.NewFacade(c.api.state(), c.api.resources, c.api.auth)
+	if err != nil {
+		return params.BundleChangesResults{}, err
+	}
+	return bundleAPI.GetChanges(args)
+}

--- a/apiserver/client/bundles_test.go
+++ b/apiserver/client/bundles_test.go
@@ -1,0 +1,77 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package client_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+)
+
+// This test is here only to make sure that the endpoint is still provided by
+// the Client facade. For full coverage, see tests in the Bundle facade.
+func (s *serverSuite) TestGetBundleChangesSuccess(c *gc.C) {
+	args := params.BundleChangesParams{
+		BundleDataYAML: `
+            applications:
+                django:
+                    charm: django
+                    options:
+                        debug: true
+                    storage:
+                        tmpfs: tmpfs,1G
+                haproxy:
+                    charm: cs:trusty/haproxy-42
+            relations:
+                - - django:web
+                  - haproxy:web
+        `,
+	}
+	r, err := s.client.GetBundleChanges(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r.Changes, jc.DeepEquals, []*params.BundleChange{{
+		Id:     "addCharm-0",
+		Method: "addCharm",
+		Args:   []interface{}{"django", ""},
+	}, {
+		Id:     "deploy-1",
+		Method: "deploy",
+		Args: []interface{}{
+			"$addCharm-0",
+			"",
+			"django",
+			map[string]interface{}{"debug": true},
+			"",
+			map[string]string{"tmpfs": "tmpfs,1G"},
+			map[string]string{},
+			map[string]int{},
+		},
+		Requires: []string{"addCharm-0"},
+	}, {
+		Id:     "addCharm-2",
+		Method: "addCharm",
+		Args:   []interface{}{"cs:trusty/haproxy-42", "trusty"},
+	}, {
+		Id:     "deploy-3",
+		Method: "deploy",
+		Args: []interface{}{
+			"$addCharm-2",
+			"trusty",
+			"haproxy",
+			map[string]interface{}{},
+			"",
+			map[string]string{},
+			map[string]string{},
+			map[string]int{},
+		},
+		Requires: []string{"addCharm-2"},
+	}, {
+		Id:       "addRelation-4",
+		Method:   "addRelation",
+		Args:     []interface{}{"$deploy-1:web", "$deploy-3:web"},
+		Requires: []string{"deploy-1", "deploy-3"},
+	}})
+	c.Assert(r.Errors, gc.IsNil)
+}

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -801,15 +801,15 @@ type LogRecord struct {
 	Message  string    `json:"x"`
 }
 
-// GetBundleChangesParams holds parameters for making GetBundleChanges calls.
-type GetBundleChangesParams struct {
+// BundleGetChangesParams holds parameters for making Bundle.GetChanges calls.
+type BundleGetChangesParams struct {
 	// BundleDataYAML is the YAML-encoded charm bundle data
 	// (see "github.com/juju/charm.BundleData").
 	BundleDataYAML string `json:"yaml"`
 }
 
-// GetBundleChangesResults holds results of the GetBundleChanges call.
-type GetBundleChangesResults struct {
+// BundleGetChangesResults holds results of the Bundle.GetChanges call.
+type BundleGetChangesResults struct {
 	// Changes holds the list of changes required to deploy the bundle.
 	// It is omitted if the provided bundle YAML has verification errors.
 	Changes []*BundleChangesChange `json:"changes,omitempty"`

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -801,24 +801,24 @@ type LogRecord struct {
 	Message  string    `json:"x"`
 }
 
-// BundleGetChangesParams holds parameters for making Bundle.GetChanges calls.
-type BundleGetChangesParams struct {
+// BundleChangesParams holds parameters for making Bundle.GetChanges calls.
+type BundleChangesParams struct {
 	// BundleDataYAML is the YAML-encoded charm bundle data
 	// (see "github.com/juju/charm.BundleData").
 	BundleDataYAML string `json:"yaml"`
 }
 
-// BundleGetChangesResults holds results of the Bundle.GetChanges call.
-type BundleGetChangesResults struct {
+// BundleChangesResults holds results of the Bundle.GetChanges call.
+type BundleChangesResults struct {
 	// Changes holds the list of changes required to deploy the bundle.
 	// It is omitted if the provided bundle YAML has verification errors.
-	Changes []*BundleChangesChange `json:"changes,omitempty"`
+	Changes []*BundleChange `json:"changes,omitempty"`
 	// Errors holds possible bundle verification errors.
 	Errors []string `json:"errors,omitempty"`
 }
 
-// BundleChangesChange holds a single change required to deploy a bundle.
-type BundleChangesChange struct {
+// BundleChange holds a single change required to deploy a bundle.
+type BundleChange struct {
 	// Id is the unique identifier for this change.
 	Id string `json:"id"`
 	// Method is the action to be performed to apply this change.

--- a/apiserver/restrict_controller.go
+++ b/apiserver/restrict_controller.go
@@ -22,6 +22,8 @@ var controllerFacadeNames = set.NewStrings(
 	"UserManager",
 )
 
+// commonFacadeNames holds root names that can be accessed using both
+// controller and model connections.
 var commonFacadeNames = set.NewStrings(
 	"Pinger",
 	"Bundle",
@@ -34,8 +36,8 @@ func controllerFacadesOnly(facadeName, _ string) error {
 	return nil
 }
 
+// isControllerFacade reports whether the given facade name can be accessed
+// using the controller connection.
 func isControllerFacade(facadeName string) bool {
-	// Note: the Pinger facade can be used in both model and controller
-	// connections.
 	return controllerFacadeNames.Contains(facadeName) || commonFacadeNames.Contains(facadeName)
 }

--- a/apiserver/restrict_controller.go
+++ b/apiserver/restrict_controller.go
@@ -22,6 +22,11 @@ var controllerFacadeNames = set.NewStrings(
 	"UserManager",
 )
 
+var commonFacadeNames = set.NewStrings(
+	"Pinger",
+	"Bundle",
+)
+
 func controllerFacadesOnly(facadeName, _ string) error {
 	if !isControllerFacade(facadeName) {
 		return errors.NewNotSupported(nil, fmt.Sprintf("facade %q not supported for controller API connection", facadeName))
@@ -32,5 +37,5 @@ func controllerFacadesOnly(facadeName, _ string) error {
 func isControllerFacade(facadeName string) bool {
 	// Note: the Pinger facade can be used in both model and controller
 	// connections.
-	return controllerFacadeNames.Contains(facadeName) || facadeName == "Pinger"
+	return controllerFacadeNames.Contains(facadeName) || commonFacadeNames.Contains(facadeName)
 }

--- a/apiserver/restrict_controller_test.go
+++ b/apiserver/restrict_controller_test.go
@@ -31,6 +31,7 @@ func (s *restrictControllerSuite) TestAllowed(c *gc.C) {
 	s.assertMethod(c, "ModelManager", 2, "CreateModel")
 	s.assertMethod(c, "ModelManager", 2, "ListModels")
 	s.assertMethod(c, "Pinger", 1, "Ping")
+	s.assertMethod(c, "Bundle", 0, "GetChanges")
 }
 
 func (s *restrictControllerSuite) TestNotAllowed(c *gc.C) {

--- a/apiserver/restrict_controller_test.go
+++ b/apiserver/restrict_controller_test.go
@@ -31,7 +31,7 @@ func (s *restrictControllerSuite) TestAllowed(c *gc.C) {
 	s.assertMethod(c, "ModelManager", 2, "CreateModel")
 	s.assertMethod(c, "ModelManager", 2, "ListModels")
 	s.assertMethod(c, "Pinger", 1, "Ping")
-	s.assertMethod(c, "Bundle", 0, "GetChanges")
+	s.assertMethod(c, "Bundle", 1, "GetChanges")
 }
 
 func (s *restrictControllerSuite) TestNotAllowed(c *gc.C) {

--- a/apiserver/restrict_restore.go
+++ b/apiserver/restrict_restore.go
@@ -30,5 +30,6 @@ var allowedMethodsAboutToRestore = set.NewStrings(
 	"Client.WatchDebugLog",  // for "juju debug-log"
 	"Backups.Restore",       // for "juju backups restore"
 	"Backups.FinishRestore", // for "juju backups restore"
+	"Bundle.GetChanges",     // for retrieving bundle changes
 	"Pinger.Ping",           // for connection health checks
 )


### PR DESCRIPTION
Also make the new facade available on both controller and model connections.

This is done so that GUI users can render the bundle uncommitted state even without a model connection.
Note that, even if this is a backward incompatible API change, I think we can be quite sure that the GUI is the only client of this API.