### PR TITLE
state: Export NowToTheSecond() using internal State.clock

### DIFF
--- a/state/action.go
+++ b/state/action.go
@@ -192,7 +192,7 @@ func (a *action) Begin() (Action, error) {
 			Assert: bson.D{{"status", ActionPending}},
 			Update: bson.D{{"$set", bson.D{
 				{"status", ActionRunning},
-				{"started", nowToTheSecond()},
+				{"started", a.st.NowToTheSecond()},
 			}}},
 		}})
 	if err != nil {
@@ -225,7 +225,7 @@ func (a *action) removeAndLog(finalStatus ActionStatus, results map[string]inter
 				{"status", finalStatus},
 				{"message", message},
 				{"results", results},
-				{"completed", nowToTheSecond()},
+				{"completed", a.st.NowToTheSecond()},
 			}}},
 		}, {
 			C:      actionNotificationsC,
@@ -261,7 +261,7 @@ func newActionDoc(st *State, receiverTag names.Tag, actionName string, parameter
 			Receiver:   receiverTag.Id(),
 			Name:       actionName,
 			Parameters: parameters,
-			Enqueued:   nowToTheSecond(),
+			Enqueued:   st.NowToTheSecond(),
 			Status:     ActionPending,
 		}, actionNotificationDoc{
 			DocId:     st.docID(prefix + actionId.String()),

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -131,7 +131,7 @@ func (s *ActionSuite) TestAddAction(c *gc.C) {
 		expectedErr: "validation failed: \\(root\\)\\.outfile : must be of type string, given 5",
 	}} {
 		c.Logf("Test %d: should %s", i, t.should)
-		before := state.NowToTheSecond()
+		before := s.State.NowToTheSecond()
 		later := before.Add(testing.LongWait)
 
 		// Copy params over into empty premade map for comparison later
@@ -161,7 +161,7 @@ func (s *ActionSuite) TestAddAction(c *gc.C) {
 
 			// Enqueued time should be within a reasonable time of the beginning
 			// of the test
-			now := state.NowToTheSecond()
+			now := s.State.NowToTheSecond()
 			c.Check(action.Enqueued(), jc.TimeBetween(before, now))
 			c.Check(action.Enqueued(), jc.TimeBetween(before, later))
 			continue

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -52,7 +52,6 @@ var (
 	ControllerAvailable                  = &controllerAvailable
 	GetOrCreatePorts                     = getOrCreatePorts
 	GetPorts                             = getPorts
-	NowToTheSecond                       = nowToTheSecond
 	AddVolumeOps                         = (*State).addVolumeOps
 	CombineMeterStatus                   = combineMeterStatus
 	ApplicationGlobalKey                 = applicationGlobalKey

--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -33,7 +33,7 @@ func (s *MetricSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *MetricSuite) TestAddNoMetrics(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := s.State.NowToTheSecond()
 	_, err := s.State.AddMetrics(state.BatchParam{
 		UUID:     utils.MustNewUUID().String(),
 		CharmURL: s.meteredCharm.URL().String(),
@@ -56,7 +56,7 @@ func ensureUnitDead(c *gc.C, unit *state.Unit) {
 }
 
 func (s *MetricSuite) TestAddMetric(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := s.State.NowToTheSecond()
 	modelUUID := s.State.ModelUUID()
 	m := state.Metric{"pings", "5", now}
 	metricBatch, err := s.State.AddMetrics(
@@ -95,7 +95,7 @@ func (s *MetricSuite) TestAddMetric(c *gc.C) {
 
 func (s *MetricSuite) TestAddMetricNonExistentUnit(c *gc.C) {
 	removeUnit(c, s.unit)
-	now := state.NowToTheSecond()
+	now := s.State.NowToTheSecond()
 	m := state.Metric{"pings", "5", now}
 	unitTag := names.NewUnitTag("test/0")
 	_, err := s.State.AddMetrics(
@@ -112,7 +112,7 @@ func (s *MetricSuite) TestAddMetricNonExistentUnit(c *gc.C) {
 
 func (s *MetricSuite) TestAddMetricDeadUnit(c *gc.C) {
 	ensureUnitDead(c, s.unit)
-	now := state.NowToTheSecond()
+	now := s.State.NowToTheSecond()
 	m := state.Metric{"pings", "5", now}
 	_, err := s.State.AddMetrics(
 		state.BatchParam{
@@ -127,7 +127,7 @@ func (s *MetricSuite) TestAddMetricDeadUnit(c *gc.C) {
 }
 
 func (s *MetricSuite) TestSetMetricSent(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := s.State.NowToTheSecond()
 	m := state.Metric{"pings", "5", now}
 	added, err := s.State.AddMetrics(
 		state.BatchParam{
@@ -245,7 +245,7 @@ func (s *MetricSuite) TestCleanupMetricsIgnoreNotSent(c *gc.C) {
 }
 
 func (s *MetricSuite) TestAllMetricBatches(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := s.State.NowToTheSecond()
 	m := state.Metric{"pings", "5", now}
 	_, err := s.State.AddMetrics(
 		state.BatchParam{
@@ -267,7 +267,7 @@ func (s *MetricSuite) TestAllMetricBatches(c *gc.C) {
 }
 
 func (s *MetricSuite) TestAllMetricBatchesCustomCharmURLAndUUID(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := s.State.NowToTheSecond()
 	m := state.Metric{"pings", "5", now}
 	uuid := utils.MustNewUUID().String()
 	charmUrl := "cs:quantal/metered"
@@ -292,7 +292,7 @@ func (s *MetricSuite) TestAllMetricBatchesCustomCharmURLAndUUID(c *gc.C) {
 }
 
 func (s *MetricSuite) TestMetricCredentials(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := s.State.NowToTheSecond()
 	m := state.Metric{"pings", "5", now}
 	err := s.application.SetMetricCredentials([]byte("hello there"))
 	c.Assert(err, gc.IsNil)
@@ -349,7 +349,7 @@ func (s *MetricSuite) TestSetMetricBatchesSent(c *gc.C) {
 }
 
 func (s *MetricSuite) TestMetricsToSend(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := s.State.NowToTheSecond()
 	m := []state.Metric{{Key: "pings", Value: "123", Time: now}}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: m})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: m})
@@ -361,7 +361,7 @@ func (s *MetricSuite) TestMetricsToSend(c *gc.C) {
 
 // TestMetricsToSendBatches checks that metrics are properly batched.
 func (s *MetricSuite) TestMetricsToSendBatches(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := s.State.NowToTheSecond()
 	for i := 0; i < 6; i++ {
 		m := []state.Metric{{Key: "pings", Value: "123", Time: now}}
 		s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: m})
@@ -464,7 +464,7 @@ func (s *MetricSuite) TestMetricValidation(c *gc.C) {
 }
 
 func (s *MetricSuite) TestAddMetricDuplicateUUID(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := s.State.NowToTheSecond()
 	mUUID := utils.MustNewUUID().String()
 	_, err := s.State.AddMetrics(
 		state.BatchParam{
@@ -513,7 +513,7 @@ func (s *MetricSuite) TestAddBuiltInMetric(c *gc.C) {
 	}
 	for _, test := range tests {
 		c.Logf("running test: %v", test.about)
-		now := state.NowToTheSecond()
+		now := s.State.NowToTheSecond()
 		modelUUID := s.State.ModelUUID()
 		m := state.Metric{"juju-units", test.value, now}
 		metricBatch, err := s.State.AddMetrics(
@@ -556,7 +556,7 @@ func (s *MetricSuite) TestAddBuiltInMetric(c *gc.C) {
 }
 
 func (s *MetricSuite) TestUnitMetricBatchesMatchesAllCharms(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := s.State.NowToTheSecond()
 	m := state.Metric{"pings", "5", now}
 	_, err := s.State.AddMetrics(
 		state.BatchParam{
@@ -615,7 +615,7 @@ func (s *MetricLocalCharmSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *MetricLocalCharmSuite) TestUnitMetricBatches(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := s.State.NowToTheSecond()
 	m := state.Metric{"pings", "5", now}
 	m2 := state.Metric{"pings", "10", now}
 	_, err := s.State.AddMetrics(
@@ -661,7 +661,7 @@ func (s *MetricLocalCharmSuite) TestUnitMetricBatches(c *gc.C) {
 }
 
 func (s *MetricLocalCharmSuite) TestApplicationMetricBatches(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := s.State.NowToTheSecond()
 	m := state.Metric{"pings", "5", now}
 	m2 := state.Metric{"pings", "10", now}
 	_, err := s.State.AddMetrics(
@@ -705,7 +705,7 @@ func (s *MetricLocalCharmSuite) TestApplicationMetricBatches(c *gc.C) {
 }
 
 func (s *MetricLocalCharmSuite) TestModelMetricBatches(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := s.State.NowToTheSecond()
 	// Add 2 metric batches to a single unit.
 	m := state.Metric{"pings", "5", now}
 	m2 := state.Metric{"pings", "10", now}
@@ -857,7 +857,7 @@ func assertMetricBatchesTimeAscending(c *gc.C, batches []state.MetricBatch) {
 }
 
 func (s *MetricLocalCharmSuite) TestUnitMetricBatchesReturnsAllCharms(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := s.State.NowToTheSecond()
 	m := state.Metric{"pings", "5", now}
 	_, err := s.State.AddMetrics(
 		state.BatchParam{
@@ -890,7 +890,7 @@ func (s *MetricLocalCharmSuite) TestUnitMetricBatchesReturnsAllCharms(c *gc.C) {
 }
 
 func (s *MetricLocalCharmSuite) TestUnique(c *gc.C) {
-	t0 := state.NowToTheSecond()
+	t0 := s.State.NowToTheSecond()
 	t1 := t0.Add(time.Second)
 	batch, err := s.State.AddMetrics(
 		state.BatchParam{
@@ -973,7 +973,7 @@ func mustCreateMeteredModel(c *gc.C, stateFactory *factory.Factory) (modelData, 
 }
 
 func (s *CrossModelMetricSuite) TestMetricsAcrossEnvironments(c *gc.C) {
-	now := state.NowToTheSecond().Add(-48 * time.Hour)
+	now := s.State.NowToTheSecond().Add(-48 * time.Hour)
 	m := state.Metric{"pings", "5", now}
 	m1, err := s.models[0].state.AddMetrics(
 		state.BatchParam{

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -182,7 +182,7 @@ func (s *MigrationExportSuite) TestModelInfo(c *gc.C) {
 func (s *MigrationExportSuite) TestModelUsers(c *gc.C) {
 	// Make sure we have some last connection times for the admin user,
 	// and create a few other users.
-	lastConnection := state.NowToTheSecond()
+	lastConnection := s.State.NowToTheSecond()
 	owner, err := s.State.UserAccess(s.Owner, s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	err = state.UpdateModelUserLastConnection(s.State, owner, lastConnection)

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -188,7 +188,7 @@ func (s *MigrationImportSuite) TestModelUsers(c *gc.C) {
 	err := s.State.RemoveUserAccess(s.Owner, s.modelTag)
 	c.Assert(err, jc.ErrorIsNil)
 
-	lastConnection := state.NowToTheSecond()
+	lastConnection := s.State.NowToTheSecond()
 
 	bravo := s.newModelUser(c, "bravo@external", false, lastConnection)
 	charlie := s.newModelUser(c, "charlie@external", true, lastConnection)

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -5,7 +5,7 @@ package state_test
 
 import (
 	"fmt"
-	"time"
+	"time" // only uses time.Time values
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -192,7 +193,7 @@ func (s *MigrationImportSuite) TestModelUsers(c *gc.C) {
 
 	bravo := s.newModelUser(c, "bravo@external", false, lastConnection)
 	charlie := s.newModelUser(c, "charlie@external", true, lastConnection)
-	delta := s.newModelUser(c, "delta@external", true, time.Time{})
+	delta := s.newModelUser(c, "delta@external", true, coretesting.ZeroTime())
 
 	newModel, newSt := s.importModel(c)
 

--- a/state/model.go
+++ b/state/model.go
@@ -823,7 +823,7 @@ func (m *Model) destroyOps(ensureNoHostedModels, ensureEmpty bool) ([]txn.Op, er
 		prereqOps = append(prereqOps, assertHostedModelsOp(aliveEmpty+dead))
 	}
 
-	timeOfDying := nowToTheSecond()
+	timeOfDying := st.NowToTheSecond()
 	modelUpdateValues := bson.D{
 		{"life", nextLife},
 		{"time-of-dying", timeOfDying},

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -5,7 +5,6 @@ package state_test
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
@@ -48,11 +47,6 @@ func (s *ModelSuite) TestModel(c *gc.C) {
 func (s *ModelSuite) TestModelDestroy(c *gc.C) {
 	env, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
-
-	now := state.NowToTheSecond()
-	s.PatchValue(&state.NowToTheSecond, func() time.Time {
-		return now
-	})
 
 	err = env.Destroy()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -79,7 +79,7 @@ func IsNeverConnectedError(err error) bool {
 
 // UpdateLastModelConnection updates the last connection time of the model user.
 func (st *State) UpdateLastModelConnection(user names.UserTag) error {
-	return st.updateLastModelConnection(user, nowToTheSecond())
+	return st.updateLastModelConnection(user, st.NowToTheSecond())
 }
 
 func (st *State) updateLastModelConnection(user names.UserTag, when time.Time) error {

--- a/state/modeluser_test.go
+++ b/state/modeluser_test.go
@@ -27,7 +27,7 @@ type ModelUserSuite struct {
 var _ = gc.Suite(&ModelUserSuite{})
 
 func (s *ModelUserSuite) TestAddModelUser(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := s.State.NowToTheSecond()
 	user := s.Factory.MakeUser(c,
 		&factory.UserParams{
 			Name:        "validusername",
@@ -304,7 +304,7 @@ func (s *ModelUserSuite) TestRemoveModelUserFails(c *gc.C) {
 }
 
 func (s *ModelUserSuite) TestUpdateLastConnection(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := s.State.NowToTheSecond()
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "validusername", Creator: createdBy.Tag()})
 	modelUser, err := s.State.UserAccess(user.UserTag(), s.State.ModelTag())
@@ -319,7 +319,7 @@ func (s *ModelUserSuite) TestUpdateLastConnection(c *gc.C) {
 }
 
 func (s *ModelUserSuite) TestUpdateLastConnectionTwoModelUsers(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := s.State.NowToTheSecond()
 
 	// Create a user and add them to the inital model.
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})

--- a/state/open.go
+++ b/state/open.go
@@ -249,7 +249,14 @@ func Initialize(args InitializeParams) (_ *State, err error) {
 		return nil, err
 	}
 
-	ops := createInitialUserOps(args.ControllerConfig.ControllerUUID(), args.ControllerModelArgs.Owner, args.MongoInfo.Password, salt)
+	dateCreated := st.NowToTheSecond()
+	ops := createInitialUserOps(
+		args.ControllerConfig.ControllerUUID(),
+		args.ControllerModelArgs.Owner,
+		args.MongoInfo.Password,
+		salt,
+		dateCreated,
+	)
 	ops = append(ops,
 
 		txn.Op{
@@ -332,7 +339,7 @@ func (st *State) modelSetupOps(controllerUUID string, args ModelArgs, inherited 
 	}
 
 	modelUserOps := createModelUserOps(
-		modelUUID, args.Owner, args.Owner, args.Owner.Name(), nowToTheSecond(), permission.AdminAccess,
+		modelUUID, args.Owner, args.Owner, args.Owner.Name(), st.NowToTheSecond(), permission.AdminAccess,
 	)
 	ops := []txn.Op{
 		createStatusOp(st, modelGlobalKey, modelStatusDoc),

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4035,7 +4035,7 @@ func (s *StateSuite) TestWatchMachineAddresses(c *gc.C) {
 }
 
 func (s *StateSuite) TestNowToTheSecond(c *gc.C) {
-	t := state.NowToTheSecond()
+	t := s.State.NowToTheSecond()
 	rounded := t.Round(time.Second)
 	c.Assert(t, gc.DeepEquals, rounded)
 }

--- a/state/undertaker.go
+++ b/state/undertaker.go
@@ -46,7 +46,7 @@ func (st *State) ProcessDyingModel() (err error) {
 			Assert: isDyingDoc,
 			Update: bson.M{"$set": bson.M{
 				"life":          Dead,
-				"time-of-death": nowToTheSecond(),
+				"time-of-death": st.NowToTheSecond(),
 			}},
 		}}
 		return ops, nil

--- a/state/user_internal_test.go
+++ b/state/user_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/permission"
+	"github.com/juju/juju/testing"
 )
 
 type internalUserSuite struct {
@@ -20,7 +21,7 @@ var _ = gc.Suite(&internalUserSuite{})
 
 func (s *internalUserSuite) TestCreateInitialUserOps(c *gc.C) {
 	tag := names.NewUserTag("AdMiN")
-	ops := createInitialUserOps(s.state.ControllerUUID(), tag, "abc", "salt")
+	ops := createInitialUserOps(s.state.ControllerUUID(), tag, "abc", "salt", testing.ZeroTime())
 	c.Assert(ops, gc.HasLen, 3)
 	op := ops[0]
 	c.Assert(op.Id, gc.Equals, "admin")

--- a/state/useraccess.go
+++ b/state/useraccess.go
@@ -89,7 +89,7 @@ func (st *State) addUserAccess(spec UserAccessSpec, target userAccessTarget) (pe
 			spec.User,
 			spec.CreatedBy,
 			spec.DisplayName,
-			nowToTheSecond(),
+			st.NowToTheSecond(),
 			spec.Access)
 		targetTag = names.NewModelTag(target.uuid)
 	case controllerGlobalKey:
@@ -98,7 +98,7 @@ func (st *State) addUserAccess(spec UserAccessSpec, target userAccessTarget) (pe
 			spec.User,
 			spec.CreatedBy,
 			spec.DisplayName,
-			nowToTheSecond(),
+			st.NowToTheSecond(),
 			spec.Access)
 		targetTag = st.controllerTag
 	default:


### PR DESCRIPTION
Simplifies the tests, drops some unnecessary patching, a global var,
incl. from export_test. Makes the necessary changes to use the internal
State.clock easier for NowToTheSecond().