### PR TITLE
Provide return blocked operation message to a user.

### DIFF
--- a/cmd/juju/block/protection.go
+++ b/cmd/juju/block/protection.go
@@ -4,7 +4,7 @@
 package block
 
 import (
-	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/api"
@@ -91,8 +91,9 @@ func ProcessBlockedError(err error, block Block) error {
 		return nil
 	}
 	if params.IsCodeOperationBlocked(err) {
-		logger.Errorf("%v\n%v", err, blockedMessages[block])
-		return cmd.ErrSilent
+		msg := blockedMessages[block]
+		logger.Errorf("%v\n%v", err, msg)
+		return errors.New(msg)
 	}
 	return err
 }

--- a/cmd/juju/commands/enableha_test.go
+++ b/cmd/juju/commands/enableha_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
@@ -115,11 +114,7 @@ func (s *EnableHASuite) TestEnableHA(c *gc.C) {
 func (s *EnableHASuite) TestBlockEnableHA(c *gc.C) {
 	s.fake.err = common.OperationBlockedError("TestBlockEnableHA")
 	_, err := s.runEnableHA(c, "-n", "1")
-	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
-
-	// msg is logged
-	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*TestBlockEnableHA.*")
+	coretesting.AssertOperationWasBlocked(c, err, ".*TestBlockEnableHA.*")
 }
 
 func (s *EnableHASuite) TestEnableHAFormatYaml(c *gc.C) {

--- a/cmd/juju/commands/resolved_test.go
+++ b/cmd/juju/commands/resolved_test.go
@@ -146,5 +146,5 @@ func (s *ResolvedSuite) TestBlockResolved(c *gc.C) {
 	// Block operation
 	s.BlockAllChanges(c, "TestBlockResolved")
 	err = runResolved(c, []string{"dummy/2"})
-	s.AssertBlocked(c, err, ".*TestBlockResolved.*")
+	testing.AssertOperationWasBlocked(c, err, ".*TestBlockResolved.*")
 }

--- a/cmd/juju/commands/run_test.go
+++ b/cmd/juju/commands/run_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/juju/cmd"
@@ -274,10 +273,7 @@ func (s *RunSuite) TestBlockRunForMachineAndUnit(c *gc.C) {
 	_, err := testing.RunCommand(c, newRunCommand(),
 		"--format=json", "--machine=0", "--unit=unit/0", "hostname",
 	)
-	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
-	// msg is logged
-	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To enable changes.*")
+	testing.AssertOperationWasBlocked(c, err, ".*To enable changes.*")
 }
 
 func (s *RunSuite) TestAllMachines(c *gc.C) {
@@ -334,10 +330,7 @@ func (s *RunSuite) TestBlockAllMachines(c *gc.C) {
 	// Block operation
 	mock.block = true
 	_, err := testing.RunCommand(c, newRunCommand(), "--format=json", "--all", "hostname")
-	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
-	// msg is logged
-	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To enable changes.*")
+	testing.AssertOperationWasBlocked(c, err, ".*To enable changes.*")
 }
 
 func (s *RunSuite) TestSingleResponse(c *gc.C) {

--- a/cmd/juju/commands/sshkeys_test.go
+++ b/cmd/juju/commands/sshkeys_test.go
@@ -143,7 +143,7 @@ func (s *AddKeySuite) TestBlockAddKey(c *gc.C) {
 	// Block operation
 	s.BlockAllChanges(c, "TestBlockAddKey")
 	_, err := coretesting.RunCommand(c, NewAddKeysCommand(), key2, "invalid-key")
-	s.AssertBlocked(c, err, ".*TestBlockAddKey.*")
+	coretesting.AssertOperationWasBlocked(c, err, ".*TestBlockAddKey.*")
 }
 
 type RemoveKeySuite struct {
@@ -173,7 +173,7 @@ func (s *RemoveKeySuite) TestBlockRemoveKeys(c *gc.C) {
 	s.BlockAllChanges(c, "TestBlockRemoveKeys")
 	_, err := coretesting.RunCommand(c, NewRemoveKeysCommand(),
 		sshtesting.ValidKeyTwo.Fingerprint, "invalid-key")
-	s.AssertBlocked(c, err, ".*TestBlockRemoveKeys.*")
+	coretesting.AssertOperationWasBlocked(c, err, ".*TestBlockRemoveKeys.*")
 }
 
 type ImportKeySuite struct {
@@ -204,5 +204,5 @@ func (s *ImportKeySuite) TestBlockImportKeys(c *gc.C) {
 	// Block operation
 	s.BlockAllChanges(c, "TestBlockImportKeys")
 	_, err := coretesting.RunCommand(c, NewImportKeysCommand(), "lp:validuser", "lp:invalid-key")
-	s.AssertBlocked(c, err, ".*TestBlockImportKeys.*")
+	coretesting.AssertOperationWasBlocked(c, err, ".*TestBlockImportKeys.*")
 }

--- a/cmd/juju/commands/synctools_test.go
+++ b/cmd/juju/commands/synctools_test.go
@@ -6,7 +6,6 @@ package commands
 import (
 	"io"
 	"io/ioutil"
-	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -286,10 +285,7 @@ func (s *syncToolsSuite) TestAPIAdapterBlockUploadTools(c *gc.C) {
 		return common.OperationBlockedError("TestAPIAdapterBlockUploadTools")
 	}
 	_, err := s.runSyncToolsCommand(c, "-m", "test-target", "--destination", c.MkDir(), "--stream", "released")
-	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
-	// msg is logged
-	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*TestAPIAdapterBlockUploadTools.*")
+	coretesting.AssertOperationWasBlocked(c, err, ".*TestAPIAdapterBlockUploadTools.*")
 }
 
 type fakeSyncToolsAPI struct {

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -526,7 +526,7 @@ func (s *UpgradeJujuSuite) TestBlockUpgradeJujuWithRealUpload(c *gc.C) {
 	// Block operation
 	s.BlockAllChanges(c, "TestBlockUpgradeJujuWithRealUpload")
 	_, err := coretesting.RunCommand(c, cmd, "--build-agent")
-	s.AssertBlocked(c, err, ".*TestBlockUpgradeJujuWithRealUpload.*")
+	coretesting.AssertOperationWasBlocked(c, err, ".*TestBlockUpgradeJujuWithRealUpload.*")
 }
 
 func (s *UpgradeJujuSuite) TestFailUploadOnNonController(c *gc.C) {

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -5,7 +5,6 @@ package machine_test
 
 import (
 	"strconv"
-	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -175,10 +174,7 @@ failed to create 2 machines
 func (s *AddMachineSuite) TestBlockedError(c *gc.C) {
 	s.fakeAddMachine.addError = common.OperationBlockedError("TestBlockedError")
 	_, err := s.run(c)
-	c.Assert(err, gc.Equals, cmd.ErrSilent)
-	// msg is logged
-	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*TestBlockedError.*")
+	testing.AssertOperationWasBlocked(c, err, ".*TestBlockedError.*")
 }
 
 func (s *AddMachineSuite) TestAddMachineWithDisks(c *gc.C) {

--- a/cmd/juju/machine/remove_test.go
+++ b/cmd/juju/machine/remove_test.go
@@ -4,8 +4,6 @@
 package machine_test
 
 import (
-	"strings"
-
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -93,21 +91,15 @@ func (s *RemoveMachineSuite) TestRemoveForce(c *gc.C) {
 func (s *RemoveMachineSuite) TestBlockedError(c *gc.C) {
 	s.fake.removeError = common.OperationBlockedError("TestBlockedError")
 	_, err := s.run(c, "1")
-	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	c.Assert(s.fake.forced, jc.IsFalse)
-	// msg is logged
-	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Assert(stripped, gc.Matches, ".*TestBlockedError.*")
+	testing.AssertOperationWasBlocked(c, err, ".*TestBlockedError.*")
 }
 
 func (s *RemoveMachineSuite) TestForceBlockedError(c *gc.C) {
 	s.fake.removeError = common.OperationBlockedError("TestForceBlockedError")
 	_, err := s.run(c, "--force", "1")
-	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	c.Assert(s.fake.forced, jc.IsTrue)
-	// msg is logged
-	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Assert(stripped, gc.Matches, ".*TestForceBlockedError.*")
+	testing.AssertOperationWasBlocked(c, err, ".*TestForceBlockedError.*")
 }
 
 type fakeRemoveMachineAPI struct {

--- a/cmd/juju/model/configcommand_test.go
+++ b/cmd/juju/model/configcommand_test.go
@@ -164,9 +164,7 @@ func (s *ConfigCommandSuite) TestSettingKnownValue(c *gc.C) {
 func (s *ConfigCommandSuite) TestBlockedError(c *gc.C) {
 	s.fake.err = common.OperationBlockedError("TestBlockedError")
 	_, err := s.run(c, "special=extra")
-	c.Assert(err, gc.Equals, cmd.ErrSilent)
-	// msg is logged
-	c.Check(c.GetTestLog(), jc.Contains, "TestBlockedError")
+	testing.AssertOperationWasBlocked(c, err, ".*TestBlockedError.*")
 }
 
 func (s *ConfigCommandSuite) TestResetPassesValues(c *gc.C) {
@@ -187,7 +185,5 @@ func (s *ConfigCommandSuite) TestResettingKnownValue(c *gc.C) {
 func (s *ConfigCommandSuite) TestResetBlockedError(c *gc.C) {
 	s.fake.err = common.OperationBlockedError("TestBlockedError")
 	_, err := s.run(c, "--reset", "special")
-	c.Assert(err, gc.Equals, cmd.ErrSilent)
-	// msg is logged
-	c.Check(c.GetTestLog(), jc.Contains, "TestBlockedError")
+	testing.AssertOperationWasBlocked(c, err, ".*TestBlockedError.*")
 }

--- a/cmd/juju/model/defaultscommand_test.go
+++ b/cmd/juju/model/defaultscommand_test.go
@@ -115,9 +115,7 @@ func (s *DefaultsCommandSuite) TestResetAttr(c *gc.C) {
 func (s *DefaultsCommandSuite) TestResetBlockedError(c *gc.C) {
 	s.fake.err = common.OperationBlockedError("TestBlockedError")
 	_, err := s.run(c, "--reset", "attr")
-	c.Assert(err, gc.Equals, cmd.ErrSilent)
-	// msg is logged
-	c.Check(c.GetTestLog(), jc.Contains, "TestBlockedError")
+	testing.AssertOperationWasBlocked(c, err, ".*TestBlockedError.*")
 }
 
 func (s *DefaultsCommandSuite) TestSetUnknownValueLogs(c *gc.C) {
@@ -143,9 +141,7 @@ func (s *DefaultsCommandSuite) TestSet(c *gc.C) {
 func (s *DefaultsCommandSuite) TestBlockedErrorOnSet(c *gc.C) {
 	s.fake.err = common.OperationBlockedError("TestBlockedError")
 	_, err := s.run(c, "special=extra")
-	c.Assert(err, gc.Equals, cmd.ErrSilent)
-	// msg is logged
-	c.Check(c.GetTestLog(), jc.Contains, "TestBlockedError")
+	testing.AssertOperationWasBlocked(c, err, ".*TestBlockedError.*")
 }
 
 func (s *DefaultsCommandSuite) TestGetSingleValue(c *gc.C) {

--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -13,7 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/cmd/modelcmd"
 	cmdtesting "github.com/juju/juju/cmd/testing"
@@ -191,7 +191,7 @@ func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 }
 
 func (s *DestroySuite) TestBlockedDestroy(c *gc.C) {
-	s.api.err = &params.Error{Code: params.CodeOperationBlocked}
-	s.runDestroyCommand(c, "test2", "-y")
-	c.Check(c.GetTestLog(), jc.Contains, "To enable the command")
+	s.api.err = common.OperationBlockedError("TestBlockedDestroy")
+	_, err := s.runDestroyCommand(c, "test2", "-y")
+	testing.AssertOperationWasBlocked(c, err, ".*TestBlockedDestroy.*")
 }

--- a/cmd/juju/model/grantrevoke_test.go
+++ b/cmd/juju/model/grantrevoke_test.go
@@ -8,7 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
@@ -82,10 +82,9 @@ func (s *grantRevokeSuite) TestAccess(c *gc.C) {
 }
 
 func (s *grantRevokeSuite) TestBlockGrant(c *gc.C) {
-	s.fake.err = &params.Error{Code: params.CodeOperationBlocked}
+	s.fake.err = common.OperationBlockedError("TestBlockGrant")
 	_, err := s.run(c, "sam", "read", "foo")
-	c.Assert(err, gc.Equals, cmd.ErrSilent)
-	c.Check(c.GetTestLog(), jc.Contains, "To enable changes")
+	testing.AssertOperationWasBlocked(c, err, ".*TestBlockGrant.*")
 }
 
 type grantSuite struct {

--- a/cmd/juju/model/retryprovisioning_test.go
+++ b/cmd/juju/model/retryprovisioning_test.go
@@ -6,7 +6,6 @@ package model_test
 import (
 	"strings"
 
-	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -152,9 +151,6 @@ func (s *retryProvisioningSuite) TestBlockRetryProvisioning(c *gc.C) {
 			c.Check(err, gc.ErrorMatches, t.err)
 			continue
 		}
-		c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
-		// msg is logged
-		stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-		c.Check(stripped, gc.Matches, ".*TestBlockRetryProvisioning.*")
+		testing.AssertOperationWasBlocked(c, err, ".*TestBlockRetryProvisioning.*")
 	}
 }

--- a/cmd/juju/user/add_test.go
+++ b/cmd/juju/user/add_test.go
@@ -125,10 +125,7 @@ func (s *UserAddCommandSuite) TestBlockAddUser(c *gc.C) {
 	// Block operation
 	s.mockAPI.blocked = true
 	_, err := s.run(c, "foobar", "Foo Bar")
-	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
-	// msg is logged
-	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To enable changes.*")
+	testing.AssertOperationWasBlocked(c, err, ".*To enable changes.*")
 }
 
 func (s *UserAddCommandSuite) TestAddUserErrorResponse(c *gc.C) {

--- a/testing/cmdblockhelper.go
+++ b/testing/cmdblockhelper.go
@@ -6,7 +6,6 @@ package testing
 import (
 	"strings"
 
-	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -55,15 +54,16 @@ func (s *CmdBlockHelper) Close() {
 	s.blockClient.Close()
 }
 
+// AssertBlocked is going to be removed as soon as all cmd tests mock out API.
+// the corect method to call will become AssertOperationWasBlocked.
 func (s *CmdBlockHelper) AssertBlocked(c *gc.C, err error, msg string) {
-	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
-	// msg is logged
+	c.Assert(err.Error(), jc.Contains, "disabled")
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
 	c.Check(stripped, gc.Matches, msg)
 }
 
 func AssertOperationWasBlocked(c *gc.C, err error, msg string) {
-	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
+	c.Assert(err.Error(), jc.Contains, "disabled")
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
 	c.Check(stripped, gc.Matches, msg)


### PR DESCRIPTION
Previously, when juju model was locked for any type of change - destruction, removal, changes to Juju components such as models, machines, units, etc - when a user ran any of the commands that are blocked, the command will return silently without providing any feedback. There was no way for user to know that the command was blocked except to examine the log.

With this PR, we now inform the user that the operation was blocked and that the environment is locked.

Adjust unit tests accordingly.

* QA steps *
1. Bootstrap 
2. Run "disable-command" to block operations
3. Run any of the disabled commands
[observe command feedback that operation is blocked]