### PR TITLE
remove access-key auth from rackspace

### DIFF
--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -60,7 +60,7 @@ func (s *cloudSuite) TestParseCloudsEndpointDenormalisation(c *gc.C) {
 func (s *cloudSuite) TestParseCloudsAuthTypes(c *gc.C) {
 	clouds := parsePublicClouds(c)
 	rackspace := clouds["rackspace"]
-	c.Assert(rackspace.AuthTypes, jc.SameContents, cloud.AuthTypes{"access-key", "userpass"})
+	c.Assert(rackspace.AuthTypes, jc.SameContents, cloud.AuthTypes{"userpass"})
 }
 
 func (s *cloudSuite) TestParseCloudsConfig(c *gc.C) {

--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -138,7 +138,7 @@ clouds:
         identity-endpoint: https://graph.chinacloudapi.cn
   rackspace:
     type: rackspace
-    auth-types: [ access-key, userpass ]
+    auth-types: [ userpass ]
     endpoint: https://identity.api.rackspacecloud.com/v2.0
     regions:
       dfw:

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -145,7 +145,7 @@ clouds:
         identity-endpoint: https://graph.chinacloudapi.cn
   rackspace:
     type: rackspace
-    auth-types: [ access-key, userpass ]
+    auth-types: [ userpass ]
     endpoint: https://identity.api.rackspacecloud.com/v2.0
     regions:
       dfw:


### PR DESCRIPTION
This fixes rackspace so that it no longer prompts for or tries to
support access-key authentication. Rackspace does not support 
openstack's access-key style authentication.  Rackspace does support
username and apikey, but that is different and is not part of this
patch.

Fixes https://bugs.launchpad.net/juju/+bug/1617394

QA:

run juju add-credential rackspace
note it just defaults to userpass auth type.