### PR TITLE
openstack: defer querying volume endpoints

### DIFF
--- a/apiserver/storage/poollist_test.go
+++ b/apiserver/storage/poollist_test.go
@@ -255,7 +255,9 @@ func (s *poolSuite) TestListFilterInvalidProvidersAndNames(c *gc.C) {
 
 func (s *poolSuite) registerProviders(c *gc.C) {
 	common := provider.CommonStorageProviders()
-	for _, providerType := range common.StorageProviderTypes() {
+	providerTypes, err := common.StorageProviderTypes()
+	c.Assert(err, jc.ErrorIsNil)
+	for _, providerType := range providerTypes {
 		p, err := common.StorageProvider(providerType)
 		c.Assert(err, jc.ErrorIsNil)
 		s.registry.Providers[providerType] = p

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -258,7 +258,10 @@ func (a *API) listPools(filter params.StoragePoolFilter) ([]params.StoragePool, 
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	providers := a.registry.StorageProviderTypes()
+	providers, err := a.registry.StorageProviderTypes()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	matches := buildFilter(filter)
 	results := append(
 		filterPools(pools, matches),

--- a/cmd/juju/user/add.go
+++ b/cmd/juju/user/add.go
@@ -20,8 +20,7 @@ import (
 var usageSummary = `
 Adds a Juju user to a controller.`[1:]
 
-const usageDetails = (
-"A `juju register` command will be printed, which must be executed by the" + `
+const usageDetails = "A `juju register` command will be printed, which must be executed by the" + `
 user to complete the registration process. The user's details are stored
 within the shared model, and will be removed when the model is destroyed.
 
@@ -40,7 +39,7 @@ See also:
     disable-user
     enable-user
     change-user-password
-    remove-user`)
+    remove-user`
 
 // AddUserAPI defines the usermanager API methods that the add command uses.
 type AddUserAPI interface {

--- a/provider/azure/storage.go
+++ b/provider/azure/storage.go
@@ -44,8 +44,8 @@ const (
 )
 
 // StorageProviderTypes implements storage.ProviderRegistry.
-func (env *azureEnviron) StorageProviderTypes() []storage.ProviderType {
-	return []storage.ProviderType{azureStorageProviderType}
+func (env *azureEnviron) StorageProviderTypes() ([]storage.ProviderType, error) {
+	return []storage.ProviderType{azureStorageProviderType}, nil
 }
 
 // StorageProvider implements storage.ProviderRegistry.

--- a/provider/cloudsigma/storage.go
+++ b/provider/cloudsigma/storage.go
@@ -10,8 +10,8 @@ import (
 )
 
 // StorageProviderTypes implements storage.ProviderRegistry.
-func (*environ) StorageProviderTypes() []storage.ProviderType {
-	return nil
+func (*environ) StorageProviderTypes() ([]storage.ProviderType, error) {
+	return nil, nil
 }
 
 // StorageProvider implements storage.ProviderRegistry.

--- a/provider/common/destroy.go
+++ b/provider/common/destroy.go
@@ -49,7 +49,11 @@ func destroyInstances(env environs.Environ) error {
 
 func destroyStorage(env environs.Environ) error {
 	logger.Infof("destroying storage")
-	for _, storageProviderType := range env.StorageProviderTypes() {
+	storageProviderTypes, err := env.StorageProviderTypes()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, storageProviderType := range storageProviderTypes {
 		storageProvider, err := env.StorageProvider(storageProviderType)
 		if err != nil {
 			return errors.Trace(err)

--- a/provider/common/mock_test.go
+++ b/provider/common/mock_test.go
@@ -86,7 +86,7 @@ func (env *mockEnviron) GetToolsSources() ([]simplestreams.DataSource, error) {
 	return []simplestreams.DataSource{datasource}, nil
 }
 
-func (env *mockEnviron) StorageProviderTypes() []jujustorage.ProviderType {
+func (env *mockEnviron) StorageProviderTypes() ([]jujustorage.ProviderType, error) {
 	return env.storageProviders.StorageProviderTypes()
 }
 

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -115,8 +115,8 @@ const (
 var deviceInUseRegexp = regexp.MustCompile(".*Attachment point .* is already in use")
 
 // StorageProviderTypes implements storage.ProviderRegistry.
-func (env *environ) StorageProviderTypes() []storage.ProviderType {
-	return []storage.ProviderType{EBS_ProviderType}
+func (env *environ) StorageProviderTypes() ([]storage.ProviderType, error) {
+	return []storage.ProviderType{EBS_ProviderType}, nil
 }
 
 // StorageProvider implements storage.ProviderRegistry.

--- a/provider/gce/disks.go
+++ b/provider/gce/disks.go
@@ -21,8 +21,8 @@ const (
 )
 
 // StorageProviderTypes implements storage.ProviderRegistry.
-func (env *environ) StorageProviderTypes() []storage.ProviderType {
-	return []storage.ProviderType{storageProviderType}
+func (env *environ) StorageProviderTypes() ([]storage.ProviderType, error) {
+	return []storage.ProviderType{storageProviderType}, nil
 }
 
 // StorageProvider implements storage.ProviderRegistry.

--- a/provider/joyent/storage.go
+++ b/provider/joyent/storage.go
@@ -10,8 +10,8 @@ import (
 )
 
 // StorageProviderTypes implements storage.ProviderRegistry.
-func (*joyentEnviron) StorageProviderTypes() []storage.ProviderType {
-	return nil
+func (*joyentEnviron) StorageProviderTypes() ([]storage.ProviderType, error) {
+	return nil, nil
 }
 
 // StorageProvider implements storage.ProviderRegistry.

--- a/provider/lxd/storage.go
+++ b/provider/lxd/storage.go
@@ -12,8 +12,8 @@ import (
 )
 
 // StorageProviderTypes implements storage.ProviderRegistry.
-func (*environ) StorageProviderTypes() []storage.ProviderType {
-	return nil
+func (*environ) StorageProviderTypes() ([]storage.ProviderType, error) {
+	return nil, nil
 }
 
 // StorageProvider implements storage.ProviderRegistry.

--- a/provider/maas/volumes.go
+++ b/provider/maas/volumes.go
@@ -34,8 +34,8 @@ const (
 )
 
 // StorageProviderTypes implements storage.ProviderRegistry.
-func (*maasEnviron) StorageProviderTypes() []storage.ProviderType {
-	return []storage.ProviderType{maasStorageProviderType}
+func (*maasEnviron) StorageProviderTypes() ([]storage.ProviderType, error) {
+	return []storage.ProviderType{maasStorageProviderType}, nil
 }
 
 // StorageProvider implements storage.ProviderRegistry.

--- a/provider/manual/storage.go
+++ b/provider/manual/storage.go
@@ -10,8 +10,8 @@ import (
 )
 
 // StorageProviderTypes implements storage.ProviderRegistry.
-func (*manualEnviron) StorageProviderTypes() []storage.ProviderType {
-	return nil
+func (*manualEnviron) StorageProviderTypes() ([]storage.ProviderType, error) {
+	return nil, nil
 }
 
 // StorageProvider implements storage.ProviderRegistry.

--- a/provider/openstack/cinder_internal_test.go
+++ b/provider/openstack/cinder_internal_test.go
@@ -1,0 +1,64 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package openstack
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/goose.v1/client"
+	"gopkg.in/goose.v1/identity"
+
+	"github.com/juju/juju/environs"
+)
+
+// TODO(axw) 2016-10-03 #1629721
+// Change this to an external test, which will
+// require refactoring the provider code to make
+// it more easily testable.
+
+type cinderInternalSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&cinderInternalSuite{})
+
+func (s *cinderInternalSuite) TestStorageProviderTypes(c *gc.C) {
+	env := &Environ{
+		cloud: environs.CloudSpec{
+			Region: "foo",
+		},
+		client: &testAuthClient{
+			regionEndpoints: map[string]identity.ServiceURLs{
+				"foo": {"volumev2": "https://bar.invalid"},
+			},
+		}}
+	types, err := env.StorageProviderTypes()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(types, gc.HasLen, 1)
+}
+
+func (s *cinderInternalSuite) TestStorageProviderTypesNotSupported(c *gc.C) {
+	env := &Environ{client: &testAuthClient{}}
+	types, err := env.StorageProviderTypes()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(types, gc.HasLen, 0)
+}
+
+type testAuthClient struct {
+	client.AuthenticatingClient
+	regionEndpoints map[string]identity.ServiceURLs
+}
+
+func (r *testAuthClient) IsAuthenticated() bool {
+	return true
+}
+
+func (r *testAuthClient) TenantId() string {
+	return "tenant-id"
+}
+
+func (r *testAuthClient) EndpointsForRegion(region string) identity.ServiceURLs {
+	return r.regionEndpoints[region]
+}

--- a/provider/openstack/config_test.go
+++ b/provider/openstack/config_test.go
@@ -116,7 +116,7 @@ func (t configTest) check(c *gc.C) {
 
 func (s *ConfigSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.PatchValue(&authenticateClient, func(*Environ) error { return nil })
+	s.PatchValue(&authenticateClient, func(authenticator) error { return nil })
 }
 
 var configTests = []configTest{

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -205,9 +205,9 @@ func (e *fakeEnviron) PrecheckInstance(series string, cons constraints.Value, pl
 	return nil
 }
 
-func (e *fakeEnviron) StorageProviderTypes() []storage.ProviderType {
+func (e *fakeEnviron) StorageProviderTypes() ([]storage.ProviderType, error) {
 	e.Push("StorageProviderTypes")
-	return nil
+	return nil, nil
 }
 
 func (e *fakeEnviron) StorageProvider(t storage.ProviderType) (storage.Provider, error) {

--- a/provider/vsphere/storage.go
+++ b/provider/vsphere/storage.go
@@ -12,8 +12,8 @@ import (
 )
 
 // StorageProviderTypes implements storage.ProviderRegistry.
-func (*environ) StorageProviderTypes() []storage.ProviderType {
-	return nil
+func (*environ) StorageProviderTypes() ([]storage.ProviderType, error) {
+	return nil, nil
 }
 
 // StorageProvider implements storage.ProviderRegistry.

--- a/state/open.go
+++ b/state/open.go
@@ -410,7 +410,11 @@ func (st *State) modelSetupOps(controllerUUID string, args ModelArgs, inherited 
 func (st *State) createDefaultStoragePoolsOps(registry storage.ProviderRegistry) ([]txn.Op, error) {
 	m := poolmanager.MemSettings{make(map[string]map[string]interface{})}
 	pm := poolmanager.New(m, registry)
-	for _, providerType := range registry.StorageProviderTypes() {
+	providerTypes, err := registry.StorageProviderTypes()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for _, providerType := range providerTypes {
 		p, err := registry.StorageProvider(providerType)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -27,7 +27,11 @@ const (
 type ProviderRegistry interface {
 	// StorageProviderTypes returns the storage provider types
 	// contained within this registry.
-	StorageProviderTypes() []ProviderType
+	//
+	// Determining the supported storage providers may be dynamic.
+	// Multiple calls for the same registry must return consistent
+	// results.
+	StorageProviderTypes() ([]ProviderType, error)
 
 	// StorageProvider returns the storage provider with the given
 	// provider type. StorageProvider must return an errors satisfying

--- a/storage/provider/common_test.go
+++ b/storage/provider/common_test.go
@@ -21,7 +21,9 @@ var _ = gc.Suite(&providerCommonSuite{})
 func (s *providerCommonSuite) TestCommonProvidersExported(c *gc.C) {
 	registry := provider.CommonStorageProviders()
 	var common []storage.ProviderType
-	for _, pType := range registry.StorageProviderTypes() {
+	pTypes, err := registry.StorageProviderTypes()
+	c.Assert(err, jc.ErrorIsNil)
+	for _, pType := range pTypes {
 		common = append(common, pType)
 		p, err := registry.StorageProvider(pType)
 		c.Assert(err, jc.ErrorIsNil)

--- a/storage/registries.go
+++ b/storage/registries.go
@@ -15,12 +15,16 @@ import (
 type ChainedProviderRegistry []ProviderRegistry
 
 // StorageProviderTypes implements ProviderRegistry.
-func (r ChainedProviderRegistry) StorageProviderTypes() []ProviderType {
+func (r ChainedProviderRegistry) StorageProviderTypes() ([]ProviderType, error) {
 	var result []ProviderType
 	for _, r := range r {
-		result = append(result, r.StorageProviderTypes()...)
+		types, err := r.StorageProviderTypes()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		result = append(result, types...)
 	}
-	return result
+	return result, nil
 }
 
 // StorageProvider implements ProviderRegistry.
@@ -46,7 +50,7 @@ type StaticProviderRegistry struct {
 }
 
 // StorageProviderTypes implements ProviderRegistry.
-func (r StaticProviderRegistry) StorageProviderTypes() []ProviderType {
+func (r StaticProviderRegistry) StorageProviderTypes() ([]ProviderType, error) {
 	typeStrings := make([]string, 0, len(r.Providers))
 	for t := range r.Providers {
 		typeStrings = append(typeStrings, string(t))
@@ -56,7 +60,7 @@ func (r StaticProviderRegistry) StorageProviderTypes() []ProviderType {
 	for i, s := range typeStrings {
 		types[i] = ProviderType(s)
 	}
-	return types
+	return types, nil
 }
 
 // StorageProvider implements ProviderRegistry.


### PR DESCRIPTION
We were attempting to identify the volume
endpoint for an OpenStack environment when
the Environ was opened. This doesn't work,
as the client is not authenticated at that
time, and so the endpoints aren't known.

We could authenticate at environ-opening
time, but that would slow down prechecking,
among other things. Instead, we change the
StorageProviderTypes method to return an
error, and query the endpoint there.

Fixes https://bugs.launchpad.net/juju/+bug/1615095

**QA**

1. bootstrap canonistack/lcy02
2. juju storage-pools ("cinder" is listed)
3. juju create-storage-pool foo cinder x=y (succeeds)

Then I hacked the code that identifies the endpoint
URL, and forced it to reutrn a "not found" error.
Bootstrapped and ensured that it worked, but the
cinder pool was unavailable and could not be created
as expected.