### PR TITLE
state/workers: dynamic lease managers

### DIFF
--- a/state/workers/fixture_test.go
+++ b/state/workers/fixture_test.go
@@ -298,6 +298,9 @@ type fakePresenceWorker struct {
 // types (as returned by the factory methods) and also wraps the
 // `expect` worker.
 func IsWorker(wrapped interface{}, expect worker.Worker) bool {
+	if w, ok := wrapped.(workers.DynamicLeaseManager); ok {
+		wrapped = w.Underlying()
+	}
 	var actual worker.Worker
 	switch wrapped := wrapped.(type) {
 	case fakeLeaseWorker:

--- a/state/workers/restart_test.go
+++ b/state/workers/restart_test.go
@@ -175,6 +175,7 @@ func (*RestartWorkersSuite) TestLeadershipManagerRestart(c *gc.C) {
 	fix := BasicFixture()
 	fix.LW_errors = []error{errors.New("oof"), nil}
 	fix.RunRestart(c, func(ctx Context, rw *workers.RestartWorkers) {
+		origw := rw.LeadershipManager()
 		w := NextWorker(c, ctx.LWs())
 		c.Assert(w, gc.NotNil)
 		AssertWorker(c, rw.LeadershipManager(), w)
@@ -187,6 +188,11 @@ func (*RestartWorkersSuite) TestLeadershipManagerRestart(c *gc.C) {
 		c.Assert(w, gc.NotNil)
 		WaitWorker(c, LM_getter(rw), w2)
 
+		// The new worker should underlie the originally
+		// acquired leadership manager, so that restarts
+		// do not require callers to acquire a new manager
+		AssertWorker(c, origw, w2)
+
 		workertest.CleanKill(c, rw)
 	})
 }
@@ -195,6 +201,7 @@ func (*RestartWorkersSuite) TestSingularManagerRestart(c *gc.C) {
 	fix := BasicFixture()
 	fix.SW_errors = []error{errors.New("oof"), nil}
 	fix.RunRestart(c, func(ctx Context, rw *workers.RestartWorkers) {
+		origw := rw.SingularManager()
 		w := NextWorker(c, ctx.SWs())
 		c.Assert(w, gc.NotNil)
 		AssertWorker(c, rw.SingularManager(), w)
@@ -206,6 +213,11 @@ func (*RestartWorkersSuite) TestSingularManagerRestart(c *gc.C) {
 		w2 := NextWorker(c, ctx.SWs())
 		c.Assert(w, gc.NotNil)
 		WaitWorker(c, SM_getter(rw), w2)
+
+		// The new worker should underlie the originally
+		// acquired singular manager, so that restarts
+		// do not require callers to acquire a new manager
+		AssertWorker(c, origw, w2)
 
 		workertest.CleanKill(c, rw)
 	})


### PR DESCRIPTION
If a lease (leadership or singular) manager worker
is restarted because of a Mongo timeout, then the
singular API server worker will not currently
recover. This is because the State.SingularWorker()
(and similar Leadership methods) return only the
original worker; the worker returned will continue
to fail until a new worker is acquired through
State.SingularWorker.

Instead of forcing the callers to do that, we
instead wrap the returned lease manager so that
the individual methods operate on the active
manager.

Fixes https://bugs.launchpad.net/juju/+bug/1628206

**QA**

1. hacked code in state/lease/client.go to force
   the lease claims to fail. This simulates an
   mongo query failure.
2. observed that the claim is made multiple times,
   which means that the singular worker is operating
   on a new singular manager.

(Without the change, the singular worker would
get a singular manager once and only once. The
singular worker would make claims over the API,
which would always come back with "lease manager
stopped" after the first claim request failed.)