### PR TITLE
Start the migratation of state tests to a testing clock

### DIFF
--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -6,7 +6,6 @@ package state
 import (
 	"fmt"
 	"sort"
-	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -216,7 +215,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 
 		err = m.SetProvisioned(instance.Id("i-"+m.Tag().String()), "fake_nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
-		now := time.Now()
+		now := testing.ZeroTime()
 		sInfo := status.StatusInfo{
 			Status:  status.Error,
 			Message: m.Tag().String(),
@@ -725,7 +724,7 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 
 	// Expect to see events for the already created machines first.
 	deltas := tw.All(2)
-	now := time.Now()
+	now := testing.ZeroTime()
 	checkDeltasEqual(c, deltas, []multiwatcher.Delta{{
 		Entity: &multiwatcher.MachineInfo{
 			ModelUUID: s.state.ModelUUID(),
@@ -1020,7 +1019,7 @@ func (s *allWatcherStateSuite) TestStateWatcherTwoModels(c *gc.C) {
 				m, err := st.Machine("0")
 				c.Assert(err, jc.ErrorIsNil)
 
-				now := time.Now()
+				now := testing.ZeroTime()
 				sInfo := status.StatusInfo{
 					Status:  status.Error,
 					Message: "pete tong",
@@ -1735,7 +1734,7 @@ func testChangeAnnotations(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 }
 
 func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	changeTestFuncs := []changeTestFunc{
 		func(c *gc.C, st *State) changeTestCase {
 			return changeTestCase{
@@ -1768,7 +1767,7 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 		func(c *gc.C, st *State) changeTestCase {
 			m, err := st.AddMachine("quantal", JobHostUnits)
 			c.Assert(err, jc.ErrorIsNil)
-			now := time.Now()
+			now := testing.ZeroTime()
 			sInfo := status.StatusInfo{
 				Status:  status.Error,
 				Message: "failure",
@@ -1889,7 +1888,7 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 		func(c *gc.C, st *State) changeTestCase {
 			m, err := st.AddMachine("quantal", JobHostUnits)
 			c.Assert(err, jc.ErrorIsNil)
-			now := time.Now()
+			now := testing.ZeroTime()
 			sInfo := status.StatusInfo{
 				Status:  status.Started,
 				Message: "",
@@ -2293,7 +2292,7 @@ func testChangeServicesConstraints(c *gc.C, owner names.UserTag, runChangeTests 
 }
 
 func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []changeTestFunc)) {
-	now := time.Now()
+	now := testing.ZeroTime()
 	changeTestFuncs := []changeTestFunc{
 		func(c *gc.C, st *State) changeTestCase {
 			return changeTestCase{
@@ -2331,7 +2330,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			c.Assert(err, jc.ErrorIsNil)
 			err = u.OpenPorts("tcp", 5555, 5558)
 			c.Assert(err, jc.ErrorIsNil)
-			now := time.Now()
+			now := testing.ZeroTime()
 			sInfo := status.StatusInfo{
 				Status:  status.Error,
 				Message: "failure",
@@ -2536,7 +2535,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			privateAddress := network.NewScopedAddress("private", network.ScopeCloudLocal)
 			err = m.SetProviderAddresses(publicAddress, privateAddress)
 			c.Assert(err, jc.ErrorIsNil)
-			now := time.Now()
+			now := testing.ZeroTime()
 			sInfo := status.StatusInfo{
 				Status:  status.Error,
 				Message: "failure",
@@ -2627,7 +2626,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			u, err := wordpress.AddUnit()
 			c.Assert(err, jc.ErrorIsNil)
-			now := time.Now()
+			now := testing.ZeroTime()
 			sInfo := status.StatusInfo{
 				Status:  status.Idle,
 				Message: "",
@@ -2680,7 +2679,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			u, err := wordpress.AddUnit()
 			c.Assert(err, jc.ErrorIsNil)
-			now := time.Now()
+			now := testing.ZeroTime()
 			sInfo := status.StatusInfo{
 				Status:  status.Idle,
 				Message: "",
@@ -2740,7 +2739,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			u, err := wordpress.AddUnit()
 			c.Assert(err, jc.ErrorIsNil)
-			now := time.Now()
+			now := testing.ZeroTime()
 			sInfo := status.StatusInfo{
 				Status:  status.Error,
 				Message: "hook error",
@@ -2800,7 +2799,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			u, err := wordpress.AddUnit()
 			c.Assert(err, jc.ErrorIsNil)
-			now := time.Now()
+			now := testing.ZeroTime()
 			sInfo := status.StatusInfo{
 				Status:  status.Active,
 				Message: "",
@@ -3107,7 +3106,7 @@ done:
 					break done
 				}
 			}
-		case <-time.After(maxDuration):
+		case <-tw.st.clock.After(maxDuration):
 			// timed out
 			break done
 		}
@@ -3128,7 +3127,7 @@ func (tw *testWatcher) AssertNoChange(c *gc.C) {
 		if len(d) > 0 {
 			c.Error("change detected")
 		}
-	case <-time.After(testing.ShortWait):
+	case <-tw.st.clock.After(testing.ShortWait):
 		// expected
 	}
 }
@@ -3136,7 +3135,7 @@ func (tw *testWatcher) AssertNoChange(c *gc.C) {
 func (tw *testWatcher) AssertChanges(c *gc.C, expected int) {
 	var count int
 	tw.st.StartSync()
-	maxWait := time.After(testing.LongWait)
+	maxWait := tw.st.clock.After(testing.LongWait)
 done:
 	for {
 		select {

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"time"
+	"time" // Only used to Sleep().
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/txn"

--- a/state/backups/restore_test.go
+++ b/state/backups/restore_test.go
@@ -249,7 +249,11 @@ func (r *RestoreSuite) TestNewConnection(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer server.DestroyWithLog()
 
-	st := statetesting.Initialize(c, names.NewLocalUserTag("test-admin"), nil, nil, nil, nil)
+	st := statetesting.InitializeWithArgs(c,
+		statetesting.InitializeArgs{
+			Owner: names.NewLocalUserTag("test-admin"),
+			Clock: gitjujutesting.NewClock(coretesting.NonZeroTime()),
+		})
 	c.Assert(st.Close(), jc.ErrorIsNil)
 
 	r.PatchValue(&mongoDefaultDialOpts, mongotest.DialOpts)

--- a/state/bakerystorage/storage_test.go
+++ b/state/bakerystorage/storage_test.go
@@ -5,7 +5,7 @@ package bakerystorage
 
 import (
 	"errors"
-	"time"
+	"time" // Only used for time types.
 
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -71,7 +71,7 @@ func (s *StorageSuite) TestExpireAt(c *gc.C) {
 	store, err := New(s.config)
 	c.Assert(err, jc.ErrorIsNil)
 
-	expiryTime := time.Now().Add(24 * time.Hour)
+	expiryTime := testing.NonZeroTime().Add(24 * time.Hour)
 	store = store.ExpireAt(expiryTime)
 
 	err = store.Put("foo", "bar")

--- a/state/cloudimagemetadata/image_test.go
+++ b/state/cloudimagemetadata/image_test.go
@@ -5,7 +5,6 @@ package cloudimagemetadata_test
 
 import (
 	"regexp"
-	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/testing"
@@ -17,6 +16,7 @@ import (
 
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state/cloudimagemetadata"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type cloudImageMetadataSuite struct {
@@ -80,7 +80,7 @@ func (s *cloudImageMetadataSuite) TestSaveMetadataWithDateCreated(c *gc.C) {
 		RootStorageType: "rootStorageType-test",
 		Source:          "test",
 	}
-	now := time.Now().UnixNano()
+	now := coretesting.NonZeroTime().UnixNano()
 	metadata := cloudimagemetadata.Metadata{attrs, 0, "1", now}
 	s.assertRecordMetadata(c, metadata)
 	s.assertMetadataRecorded(c, cloudimagemetadata.MetadataAttributes{}, metadata)

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"time"
+	"time" // Only used for time types.
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"

--- a/state/imagestorage/image_test.go
+++ b/state/imagestorage/image_test.go
@@ -10,7 +10,7 @@ import (
 	"io/ioutil"
 	"strings"
 	stdtesting "testing"
-	"time"
+	"time" // Only used for time types.
 
 	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
@@ -76,8 +76,11 @@ func (s *ImageSuite) TestAddImageReplaces(c *gc.C) {
 
 func checkMetadata(c *gc.C, fromDb, metadata *imagestorage.Metadata) {
 	c.Assert(fromDb.Created.IsZero(), jc.IsFalse)
+	// We don't want Now() here, we want NonZeroTime().Add(...). Before
+	// that can happen, we need to look at AddImage for its Created
+	// timestamp.
 	c.Assert(fromDb.Created.Before(time.Now()), jc.IsTrue)
-	fromDb.Created = time.Time{}
+	fromDb.Created = testing.ZeroTime()
 	c.Assert(metadata, gc.DeepEquals, fromDb)
 }
 
@@ -406,7 +409,7 @@ func (s *ImageSuite) addMetadataDoc(c *gc.C, kind, series, arch string, size int
 		Size:      size,
 		SHA256:    checksum,
 		Path:      path,
-		Created:   time.Now(),
+		Created:   testing.NonZeroTime(),
 		SourceURL: sourceURL,
 	}
 	err := s.metadataCollection.Insert(&doc)

--- a/state/internal/audit/audit_test.go
+++ b/state/internal/audit/audit_test.go
@@ -4,11 +4,10 @@
 package audit_test
 
 import (
-	"time"
-
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2/bson"
@@ -16,7 +15,7 @@ import (
 	"github.com/juju/juju/audit"
 	mongoutils "github.com/juju/juju/mongo/utils"
 	stateaudit "github.com/juju/juju/state/internal/audit"
-	"github.com/juju/utils"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type AuditSuite struct {
@@ -30,7 +29,7 @@ func (*AuditSuite) TestPutAuditEntry_PersistAuditEntry(c *gc.C) {
 	requested := audit.AuditEntry{
 		JujuServerVersion: version.MustParse("1.0.0"),
 		ModelUUID:         utils.MustNewUUID().String(),
-		Timestamp:         time.Now().UTC(),
+		Timestamp:         coretesting.NonZeroTime().UTC(),
 		RemoteAddress:     "8.8.8.8",
 		OriginType:        "user",
 		OriginName:        "bob",
@@ -89,7 +88,7 @@ func (*AuditSuite) TestPutAuditEntry_PropagatesWriteError(c *gc.C) {
 	auditEntry := audit.AuditEntry{
 		JujuServerVersion: version.MustParse("1.0.0"),
 		ModelUUID:         uuid.String(),
-		Timestamp:         time.Now().UTC(),
+		Timestamp:         coretesting.NonZeroTime().UTC(),
 		RemoteAddress:     "8.8.8.8",
 		OriginType:        "user",
 		OriginName:        "bob",

--- a/state/lease/client_assert_test.go
+++ b/state/lease/client_assert_test.go
@@ -4,7 +4,7 @@
 package lease_test
 
 import (
-	"time"
+	"time" // Only used for time types.
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"

--- a/state/lease/client_operation_test.go
+++ b/state/lease/client_operation_test.go
@@ -4,7 +4,7 @@
 package lease_test
 
 import (
-	"time"
+	"time" // Only used for time types.
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"

--- a/state/lease/client_race_test.go
+++ b/state/lease/client_race_test.go
@@ -4,7 +4,7 @@
 package lease_test
 
 import (
-	"time"
+	"time" // Only used for time types.
 
 	jc "github.com/juju/testing/checkers"
 	jujutxn "github.com/juju/txn"

--- a/state/lease/client_remote_test.go
+++ b/state/lease/client_remote_test.go
@@ -4,7 +4,7 @@
 package lease_test
 
 import (
-	"time"
+	"time" // Only used for time types.
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"

--- a/state/lease/client_validation_test.go
+++ b/state/lease/client_validation_test.go
@@ -4,7 +4,7 @@
 package lease_test
 
 import (
-	"time"
+	"time" // Only used for time types.
 
 	gc "gopkg.in/check.v1"
 

--- a/state/lease/skew_test.go
+++ b/state/lease/skew_test.go
@@ -4,12 +4,13 @@
 package lease_test
 
 import (
-	"time"
+	"time" // Only used for time types.
 
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state/lease"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type SkewSuite struct {
@@ -19,7 +20,7 @@ type SkewSuite struct {
 var _ = gc.Suite(&SkewSuite{})
 
 func (s *SkewSuite) TestZero(c *gc.C) {
-	now := time.Now()
+	now := coretesting.ZeroTime()
 
 	// The zero Skew should act as unskewed.
 	skew := lease.Skew{}
@@ -29,7 +30,7 @@ func (s *SkewSuite) TestZero(c *gc.C) {
 }
 
 func (s *SkewSuite) TestApparentPastWrite(c *gc.C) {
-	now := time.Now()
+	now := coretesting.ZeroTime()
 	c.Logf("now: %s", now)
 	oneSecondAgo := now.Add(-time.Second)
 	threeSecondsAgo := now.Add(-3 * time.Second)
@@ -60,7 +61,7 @@ func (s *SkewSuite) TestApparentPastWrite(c *gc.C) {
 }
 
 func (s *SkewSuite) TestApparentFutureWrite(c *gc.C) {
-	now := time.Now()
+	now := coretesting.ZeroTime()
 	c.Logf("now: %s", now)
 	oneSecondAgo := now.Add(-time.Second)
 	threeSecondsAgo := now.Add(-3 * time.Second)
@@ -92,7 +93,7 @@ func (s *SkewSuite) TestApparentFutureWrite(c *gc.C) {
 }
 
 func (s *SkewSuite) TestBracketedWrite(c *gc.C) {
-	now := time.Now()
+	now := coretesting.ZeroTime()
 	c.Logf("now: %s", now)
 	oneSecondAgo := now.Add(-time.Second)
 	twoSecondsAgo := now.Add(-2 * time.Second)
@@ -130,7 +131,7 @@ func (s *SkewSuite) TestMixedTimezones(c *gc.C) {
 
 	// This is a straight copy of TestBracketedWrite, with strange timezones
 	// inserted to check that they don't affect the results at all.
-	now := time.Now()
+	now := coretesting.ZeroTime()
 	c.Logf("now: %s", now)
 	oneSecondAgo := now.Add(-time.Second)
 	twoSecondsAgo := now.Add(-2 * time.Second)

--- a/state/meterstatus_test.go
+++ b/state/meterstatus_test.go
@@ -108,7 +108,7 @@ func (s *MeterStateSuite) TestMeterStatusWatcherRespondsToMetricsManager(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 	watcher := s.unit.WatchMeterStatus()
 	assertMeterStatusChanged(c, watcher)
-	err = mm.SetLastSuccessfulSend(time.Now())
+	err = mm.SetLastSuccessfulSend(testing.NonZeroTime())
 	c.Assert(err, jc.ErrorIsNil)
 	for i := 0; i < 3; i++ {
 		err := mm.IncrementConsecutiveErrors()
@@ -124,7 +124,7 @@ func (s *MeterStateSuite) TestMeterStatusWatcherRespondsToMetricsManagerAndStatu
 	c.Assert(err, jc.ErrorIsNil)
 	watcher := s.unit.WatchMeterStatus()
 	assertMeterStatusChanged(c, watcher)
-	err = mm.SetLastSuccessfulSend(time.Now())
+	err = mm.SetLastSuccessfulSend(testing.NonZeroTime())
 	c.Assert(err, jc.ErrorIsNil)
 	for i := 0; i < 3; i++ {
 		err := mm.IncrementConsecutiveErrors()
@@ -155,7 +155,7 @@ func assertMeterStatusNotChanged(c *gc.C, w state.NotifyWatcher) {
 }
 
 func assertMetricsManagerAmberState(c *gc.C, metricsManager *state.MetricsManager) {
-	err := metricsManager.SetLastSuccessfulSend(time.Now())
+	err := metricsManager.SetLastSuccessfulSend(testing.NonZeroTime())
 	c.Assert(err, jc.ErrorIsNil)
 	for i := 0; i < 3; i++ {
 		err := metricsManager.IncrementConsecutiveErrors()
@@ -168,7 +168,7 @@ func assertMetricsManagerAmberState(c *gc.C, metricsManager *state.MetricsManage
 // TODO (mattyw) This function could be moved into a metricsmanager testing package.
 func assertMetricsManagerRedState(c *gc.C, metricsManager *state.MetricsManager) {
 	// To enter the red state we need to set a last successful send as over 1 week ago
-	err := metricsManager.SetLastSuccessfulSend(time.Now().Add(-8 * 24 * time.Hour))
+	err := metricsManager.SetLastSuccessfulSend(testing.NonZeroTime().Add(-8 * 24 * time.Hour))
 	c.Assert(err, jc.ErrorIsNil)
 	for i := 0; i < 3; i++ {
 		err := metricsManager.IncrementConsecutiveErrors()

--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -141,7 +142,7 @@ func (s *MetricSuite) TestSetMetricSent(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	saved, err := s.State.MetricBatch(added.UUID())
 	c.Assert(err, jc.ErrorIsNil)
-	err = saved.SetSent(time.Now())
+	err = saved.SetSent(testing.NonZeroTime())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(saved.Sent(), jc.IsTrue)
 	saved, err = s.State.MetricBatch(added.UUID())
@@ -150,8 +151,8 @@ func (s *MetricSuite) TestSetMetricSent(c *gc.C) {
 }
 
 func (s *MetricSuite) TestCleanupMetrics(c *gc.C) {
-	oldTime := time.Now().Add(-(time.Hour * 25))
-	now := time.Now()
+	oldTime := testing.NonZeroTime().Add(-(time.Hour * 25))
+	now := testing.NonZeroTime()
 	m := state.Metric{"pings", "5", oldTime}
 	oldMetric1, err := s.State.AddMetrics(
 		state.BatchParam{
@@ -163,7 +164,7 @@ func (s *MetricSuite) TestCleanupMetrics(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	oldMetric1.SetSent(time.Now().Add(-25 * time.Hour))
+	oldMetric1.SetSent(testing.NonZeroTime().Add(-25 * time.Hour))
 
 	oldMetric2, err := s.State.AddMetrics(
 		state.BatchParam{
@@ -175,7 +176,7 @@ func (s *MetricSuite) TestCleanupMetrics(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	oldMetric2.SetSent(time.Now().Add(-25 * time.Hour))
+	oldMetric2.SetSent(testing.NonZeroTime().Add(-25 * time.Hour))
 
 	m = state.Metric{"pings", "5", now}
 	newMetric, err := s.State.AddMetrics(
@@ -188,7 +189,7 @@ func (s *MetricSuite) TestCleanupMetrics(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	newMetric.SetSent(time.Now())
+	newMetric.SetSent(testing.NonZeroTime())
 	err = s.State.CleanupOldMetrics()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -208,7 +209,7 @@ func (s *MetricSuite) TestCleanupNoMetrics(c *gc.C) {
 }
 
 func (s *MetricSuite) TestCleanupMetricsIgnoreNotSent(c *gc.C) {
-	oldTime := time.Now().Add(-(time.Hour * 25))
+	oldTime := testing.NonZeroTime().Add(-(time.Hour * 25))
 	m := state.Metric{"pings", "5", oldTime}
 	oldMetric, err := s.State.AddMetrics(
 		state.BatchParam{
@@ -221,7 +222,7 @@ func (s *MetricSuite) TestCleanupMetricsIgnoreNotSent(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	now := time.Now()
+	now := testing.NonZeroTime()
 	m = state.Metric{"pings", "5", now}
 	newMetric, err := s.State.AddMetrics(
 		state.BatchParam{
@@ -233,7 +234,7 @@ func (s *MetricSuite) TestCleanupMetricsIgnoreNotSent(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	newMetric.SetSent(time.Now())
+	newMetric.SetSent(testing.NonZeroTime())
 	err = s.State.CleanupOldMetrics()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -315,7 +316,7 @@ func (s *MetricSuite) TestMetricCredentials(c *gc.C) {
 // TestCountMetrics asserts the correct values are returned
 // by CountOfUnsentMetrics and CountOfSentMetrics.
 func (s *MetricSuite) TestCountMetrics(c *gc.C) {
-	now := time.Now()
+	now := testing.NonZeroTime()
 	m := []state.Metric{{Key: "pings", Value: "123", Time: now}}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: m})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: m})
@@ -330,7 +331,7 @@ func (s *MetricSuite) TestCountMetrics(c *gc.C) {
 }
 
 func (s *MetricSuite) TestSetMetricBatchesSent(c *gc.C) {
-	now := time.Now()
+	now := testing.NonZeroTime()
 	metrics := make([]*state.MetricBatch, 3)
 	for i := range metrics {
 		m := []state.Metric{{Key: "pings", Value: "123", Time: now}}
@@ -395,7 +396,7 @@ func (s *MetricSuite) TestMetricValidation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = dyingUnit.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	now := time.Now()
+	now := testing.NonZeroTime()
 	tests := []struct {
 		about   string
 		metrics []state.Metric
@@ -1009,9 +1010,9 @@ func (s *CrossModelMetricSuite) TestMetricsAcrossEnvironments(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(toSend, gc.HasLen, 1)
 
-	err = m1.SetSent(time.Now().Add(-25 * time.Hour))
+	err = m1.SetSent(testing.NonZeroTime().Add(-25 * time.Hour))
 	c.Assert(err, jc.ErrorIsNil)
-	err = m2.SetSent(time.Now().Add(-25 * time.Hour))
+	err = m2.SetSent(testing.NonZeroTime().Add(-25 * time.Hour))
 	c.Assert(err, jc.ErrorIsNil)
 
 	sent, err := s.models[0].state.CountOfSentMetrics()

--- a/state/metricsmanager_test.go
+++ b/state/metricsmanager_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/state"
 	testing "github.com/juju/juju/state/testing"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type metricsManagerSuite struct {
@@ -42,7 +43,7 @@ func (s *metricsManagerSuite) TestSetLastSuccesfulSend(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = mm.IncrementConsecutiveErrors()
 	c.Assert(err, jc.ErrorIsNil)
-	now := time.Now().Round(time.Second).UTC()
+	now := coretesting.ZeroTime().Round(time.Second).UTC()
 	err = mm.SetLastSuccessfulSend(now)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mm.LastSuccessfulSend(), gc.DeepEquals, now)
@@ -92,7 +93,7 @@ func (s *metricsManagerSuite) TestMeterStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	status := mm.MeterStatus()
 	c.Assert(status.Code, gc.Equals, state.MeterGreen)
-	now := time.Now()
+	now := coretesting.NonZeroTime()
 	err = mm.SetLastSuccessfulSend(now)
 	c.Assert(err, jc.ErrorIsNil)
 	for i := 0; i < 3; i++ {

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -42,7 +42,7 @@ var testAnnotations = map[string]string{
 }
 
 type MigrationBaseSuite struct {
-	ConnSuite
+	ConnWithWallclockSuite
 }
 
 func (s *MigrationBaseSuite) setLatestTools(c *gc.C, latestTools version.Number) {

--- a/state/status_history_test.go
+++ b/state/status_history_test.go
@@ -13,17 +13,19 @@ import (
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/status"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
 
 type StatusHistorySuite struct {
-	statetesting.StateSuite
+	// TODO Migrate to StateSuite (with testing clock).
+	statetesting.StateWithWallclockSuite
 }
 
 var _ = gc.Suite(&StatusHistorySuite{})
 
 func (s *StatusHistorySuite) TestPruneStatusHistoryBySize(c *gc.C) {
-	clock := testing.NewClock(time.Now())
+	clock := testing.NewClock(coretesting.NonZeroTime())
 	err := s.State.SetClockForTesting(clock)
 	c.Assert(err, jc.ErrorIsNil)
 	service := s.Factory.MakeApplication(c, nil)

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -48,7 +49,7 @@ func (s *UserSuite) TestAddUser(c *gc.C) {
 	password := "password"
 	creator := "admin"
 
-	now := time.Now().Round(time.Second).UTC()
+	now := testing.NonZeroTime().Round(time.Second).UTC()
 
 	user, err := s.State.AddUser(name, displayName, password, creator)
 	c.Assert(err, jc.ErrorIsNil)
@@ -93,7 +94,7 @@ func (s *UserSuite) TestString(c *gc.C) {
 }
 
 func (s *UserSuite) TestUpdateLastLogin(c *gc.C) {
-	now := time.Now().Round(time.Second).UTC()
+	now := testing.NonZeroTime().Round(time.Second).UTC()
 	user := s.Factory.MakeUser(c, nil)
 	err := user.UpdateLastLogin()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Continue to remove time.Now() in favour of ZeroTime() and NonZeroTime()
from the testing package in state tests, and begin the required
migration of clocks used in state tests to testing clocks with
NonZeroTime(), not the wallclock.

StateSuite and ConnSuite now each have a 'wallclock' partner, used in
tests that require the wallclock until they are migrated to the testing
clock.