### PR TITLE
controller: add official-dns-name and autocert-url attributes

### DIFF
--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -186,6 +186,7 @@ func (s *legacySuite) TestAPIServerCanShutdownWithOutstandingNext(c *gc.C) {
 		DataDir:     c.MkDir(),
 		LogDir:      c.MkDir(),
 		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
+		AutocertURL: "https://0.1.2.3/no-autocert-here",
 	})
 	c.Assert(err, gc.IsNil)
 

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -580,6 +580,7 @@ func (s *baseLoginSuite) setupServerForModelWithValidator(c *gc.C, modelTag name
 			Tag:         names.NewMachineTag("0"),
 			LogDir:      c.MkDir(),
 			NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
+			AutocertURL: "https://0.1.2.3/no-autocert-here",
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -47,6 +47,7 @@ func (s *apiserverBaseSuite) sampleConfig(c *gc.C) apiserver.ServerConfig {
 		Tag:         names.NewMachineTag("0"),
 		LogDir:      c.MkDir(),
 		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
+		AutocertURL: "https://0.1.2.3/no-autocert-here",
 	}
 }
 

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -533,6 +533,7 @@ func newServer(c *gc.C, st *state.State) *apiserver.Server {
 		Tag:         names.NewMachineTag("0"),
 		LogDir:      c.MkDir(),
 		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
+		AutocertURL: "https://0.1.2.3/no-autocert-here",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return srv

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -136,6 +136,7 @@ type bootstrapCommand struct {
 	AutoUpgrade             bool
 	AgentVersionParam       string
 	AgentVersion            *version.Number
+	ForceAPIPort            bool
 	config                  common.ConfigFlag
 
 	showClouds          bool
@@ -171,6 +172,7 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.Placement, "to", "", "Placement directive indicating an instance to bootstrap")
 	f.BoolVar(&c.KeepBrokenEnvironment, "keep-broken", false, "Do not destroy the model if bootstrap fails")
 	f.BoolVar(&c.AutoUpgrade, "auto-upgrade", false, "Upgrade to the latest patch release tools on first bootstrap")
+	f.BoolVar(&c.ForceAPIPort, "force-api-port", false, "Allow use of non-standard HTTPS port when official DNS name specified")
 	f.StringVar(&c.AgentVersionParam, "agent-version", "", "Version of tools to use for Juju agents")
 	f.StringVar(&c.CredentialName, "credential", "", "Credentials to use when bootstrapping")
 	f.Var(&c.config, "config", "Specify a controller configuration file, or one or more configuration\n    options\n    (--config config.yaml [--config key=value ...])")
@@ -556,6 +558,10 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	if err != nil {
 		return errors.Annotate(err, "constructing controller config")
 	}
+	if controllerConfig.AutocertDNSName() != "" && controllerConfig.APIPort() != 443 && !c.ForceAPIPort {
+		return errors.Errorf(`autocert-dns-name is set but it's not usually possible to obtain official certificates without api-port=443 config; use --force-api-port to override this if you plan on using a port forwarder`)
+	}
+
 	if err := common.FinalizeAuthorizedKeys(ctx, modelConfigAttrs); err != nil {
 		return errors.Annotate(err, "finalizing authorized-keys")
 	}

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1256,6 +1256,35 @@ func (s *BootstrapSuite) TestBootstrapConfigFileAndAdHoc(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *BootstrapSuite) TestBootstrapAutocertDNSNameBadPort(c *gc.C) {
+	s.patchVersionAndSeries(c, "raring")
+	_, err := coretesting.RunCommand(
+		c, s.newBootstrapCommand(), "ctrl", "dummy",
+		"--config", "autocert-dns-name=foo.example",
+	)
+	c.Assert(err, gc.ErrorMatches, `autocert-dns-name is set but it's not usually possible to obtain official certificates without api-port=443 config; use --force-api-port to override this if you plan on using a port forwarder`)
+}
+
+func (s *BootstrapSuite) TestBootstrapAutocertDNSNameOKPort(c *gc.C) {
+	s.patchVersionAndSeries(c, "raring")
+	_, err := coretesting.RunCommand(
+		c, s.newBootstrapCommand(), "ctrl", "dummy",
+		"--config", "autocert-dns-name=foo.example",
+		"--config", "api-port=443",
+	)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *BootstrapSuite) TestBootstrapAutocertDNSNameForceAPIPort(c *gc.C) {
+	s.patchVersionAndSeries(c, "raring")
+	_, err := coretesting.RunCommand(
+		c, s.newBootstrapCommand(), "ctrl", "dummy",
+		"--config", "autocert-dns-name=foo.example",
+		"--force-api-port",
+	)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *BootstrapSuite) TestBootstrapCloudConfigAndAdHoc(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
 	_, err := coretesting.RunCommand(

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1084,14 +1084,16 @@ func (a *MachineAgent) newAPIserverWorker(st *state.State, certChanged chan para
 	}
 
 	server, err := apiserver.NewServer(st, listener, apiserver.ServerConfig{
-		Clock:       clock.WallClock,
-		Cert:        cert,
-		Key:         key,
-		Tag:         tag,
-		DataDir:     dataDir,
-		LogDir:      logDir,
-		Validator:   a.limitLogins,
-		CertChanged: certChanged,
+		Clock:           clock.WallClock,
+		Cert:            cert,
+		Key:             key,
+		Tag:             tag,
+		DataDir:         dataDir,
+		LogDir:          logDir,
+		Validator:       a.limitLogins,
+		CertChanged:     certChanged,
+		AutocertURL:     controllerConfig.AutocertURL(),
+		AutocertDNSName: controllerConfig.AutocertDNSName(),
 		NewObserver: newObserverFn(
 			controllerConfig,
 			clock.WallClock,

--- a/controller/config.go
+++ b/controller/config.go
@@ -43,6 +43,19 @@ const (
 	// NUMAControlPolicyKey stores the value for this setting
 	SetNUMAControlPolicyKey = "set-numa-control-policy"
 
+	// AutocertDNSNameKey sets the DNS name of the controller. If a
+	// client connects to this name, an official certificate will be
+	// automatically requested. Connecting to any other host name
+	// will use the usual self-generated certificate.
+	AutocertDNSNameKey = "autocert-dns-name"
+
+	// AutocertURLKey sets the URL used to obtain official TLS
+	// certificates when a client connects to the API. By default,
+	// certficates are obtains from LetsEncrypt. A good value for
+	// testing is
+	// "https://acme-staging.api.letsencrypt.org/directory".
+	AutocertURLKey = "autocert-url"
+
 	// Attribute Defaults
 
 	// DefaultAuditingEnabled contains the default value for the
@@ -70,6 +83,8 @@ var ControllerOnlyConfigAttributes = []string{
 	IdentityURL,
 	IdentityPublicKey,
 	SetNUMAControlPolicyKey,
+	AutocertDNSNameKey,
+	AutocertURLKey,
 }
 
 // ControllerOnlyAttribute returns true if the specified attribute name
@@ -179,6 +194,19 @@ func (c Config) IdentityURL() string {
 	return c.asString(IdentityURL)
 }
 
+// AutocertURL returns the URL used to obtain official TLS certificates
+// when a client connects to the API. See AutocertURLKey
+// for more details.
+func (c Config) AutocertURL() string {
+	return c.asString(AutocertURLKey)
+}
+
+// AutocertDNSName returns the DNS name of the controller.
+// See AutocertDNSNameKey for more details.
+func (c Config) AutocertDNSName() string {
+	return c.asString(AutocertDNSNameKey)
+}
+
 // IdentityPublicKey returns the public key of the identity manager.
 func (c Config) IdentityPublicKey() *bakery.PublicKey {
 	key := c.asString(IdentityPublicKey)
@@ -251,6 +279,8 @@ var configChecker = schema.FieldMap(schema.Fields{
 	IdentityURL:             schema.String(),
 	IdentityPublicKey:       schema.String(),
 	SetNUMAControlPolicyKey: schema.Bool(),
+	AutocertURLKey:          schema.String(),
+	AutocertDNSNameKey:      schema.String(),
 }, schema.Defaults{
 	APIPort:                 DefaultAPIPort,
 	AuditingEnabled:         DefaultAuditingEnabled,
@@ -258,4 +288,6 @@ var configChecker = schema.FieldMap(schema.Fields{
 	IdentityURL:             schema.Omit,
 	IdentityPublicKey:       schema.Omit,
 	SetNUMAControlPolicyKey: DefaultNUMAControlPolicy,
+	AutocertURLKey:          schema.Omit,
+	AutocertDNSNameKey:      schema.Omit,
 })

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -811,6 +811,8 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 				LogDir:      LogDir,
 				StatePool:   estate.apiStatePool,
 				NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
+				// Should never be used but prevent external access just in case.
+				AutocertURL: "https://0.1.2.3/no-autocert-here",
 			})
 			if err != nil {
 				panic(err)

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -23,12 +23,15 @@ func (s *ControllerConfigSuite) TestControllerAndModelConfigInitialisation(c *gc
 	controllerSettings, err := s.State.ReadSettings(state.ControllersC, "controllerSettings")
 	c.Assert(err, jc.ErrorIsNil)
 
-	optional := func(attr string) bool {
-		return attr == controller.IdentityURL || attr == controller.IdentityPublicKey
+	optional := map[string]bool{
+		controller.IdentityURL:        true,
+		controller.IdentityPublicKey:  true,
+		controller.AutocertURLKey:     true,
+		controller.AutocertDNSNameKey: true,
 	}
 	for _, controllerAttr := range controller.ControllerOnlyConfigAttributes {
 		v, ok := controllerSettings.Get(controllerAttr)
-		if !optional(controllerAttr) {
+		if !optional[controllerAttr] {
 			c.Assert(ok, jc.IsTrue)
 			c.Assert(v, gc.Not(gc.Equals), "")
 		}


### PR DESCRIPTION
This adds a controller configuration option to explicitly enable
autocert retrieval - a request at any other DNS name will use
the self-generated certificate. This means that we won't
be vulnerable to the DoS attack mentioned in https://godoc.org/golang.org/x/crypto/acme/autocert#Manager under the HostPolicy field.

As autocert generation doesn't work unless the controller is listening
on port 443, we make the bootstrap command warn if that's not the
case (but provide an override in case someone wants to do port
forwarding).

To QA, bootstrap a controller with:

    juju bootstrap --debug --config 'autocert-dns-name=<your domain name>' --config 'api-port=443' ec2 aws

Then configure the DNS record for your domain name to point to the IP address of the newly
bootstrapped controller, and change the api-endpoints entries in controllers.yaml to refer to <your domain name>:443 and delete the ca-cert entry.

Then you should be able to connect OK to it.
