### PR TITLE
Change list-spaces command to tabular by default

### DIFF
--- a/cmd/juju/space/list.go
+++ b/cmd/juju/space/list.go
@@ -139,23 +139,33 @@ func (c *listCommand) Run(ctx *cmd.Context) error {
 
 // printTabular prints the list of spaces in tabular format
 func (c *listCommand) printTabular(writer io.Writer, value interface{}) error {
-	list, ok := value.(formattedList)
-	if !ok {
-		return errors.New("unexpected value")
-	}
-
 	tw := output.TabWriter(writer)
-	fmt.Fprintf(tw, "%s\t%s\n", "SPACE", "SUBNETS")
-	for space, subnets := range list.Spaces {
-		fmt.Fprintf(tw, "%s", space)
-		if len(subnets) == 0 {
-			fmt.Fprintf(tw, "\n")
-			continue
+	if c.Short {
+		list, ok := value.(formattedShortList)
+		if !ok {
+			return errors.New("unexpected value")
 		}
-		for subnet, _ := range subnets {
-			fmt.Fprintf(tw, "\t%v\n", subnet)
+		fmt.Fprintf(tw, "SPACE\n")
+		for _, space := range list.Spaces {
+			fmt.Fprintf(tw, "%v\n", space)
+		}
+	} else {
+		list, ok := value.(formattedList)
+		if !ok {
+			return errors.New("unexpected value")
 		}
 
+		fmt.Fprintf(tw, "%s\t%s\n", "SPACE", "SUBNETS")
+		for space, subnets := range list.Spaces {
+			fmt.Fprintf(tw, "%s", space)
+			if len(subnets) == 0 {
+				fmt.Fprintf(tw, "\n")
+				continue
+			}
+			for subnet, _ := range subnets {
+				fmt.Fprintf(tw, "\t%v\n", subnet)
+			}
+		}
 	}
 	tw.Flush()
 	return nil

--- a/cmd/juju/space/list.go
+++ b/cmd/juju/space/list.go
@@ -82,7 +82,7 @@ func (c *listCommand) Run(ctx *cmd.Context) error {
 		}
 		if len(spaces) == 0 {
 			ctx.Infof("no spaces to display")
-			return c.out.Write(ctx, nil)
+			return nil
 		}
 
 		if c.Short {

--- a/cmd/juju/space/list.go
+++ b/cmd/juju/space/list.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sort"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -146,7 +147,9 @@ func (c *listCommand) printTabular(writer io.Writer, value interface{}) error {
 			return errors.New("unexpected value")
 		}
 		fmt.Fprintf(tw, "SPACE\n")
-		for _, space := range list.Spaces {
+		spaces := list.Spaces
+		sort.Strings(spaces)
+		for _, space := range spaces {
 			fmt.Fprintf(tw, "%v\n", space)
 		}
 	} else {
@@ -156,14 +159,25 @@ func (c *listCommand) printTabular(writer io.Writer, value interface{}) error {
 		}
 
 		fmt.Fprintf(tw, "%s\t%s\n", "SPACE", "SUBNETS")
-		for space, subnets := range list.Spaces {
-			fmt.Fprintf(tw, "%s", space)
+		spaces := []string{}
+		for name, _ := range list.Spaces {
+			spaces = append(spaces, name)
+		}
+		sort.Strings(spaces)
+		for _, name := range spaces {
+			subnets := list.Spaces[name]
+			fmt.Fprintf(tw, "%s", name)
 			if len(subnets) == 0 {
 				fmt.Fprintf(tw, "\n")
 				continue
 			}
+			cidrs := []string{}
 			for subnet, _ := range subnets {
-				fmt.Fprintf(tw, "\t%v\n", subnet)
+				cidrs = append(cidrs, subnet)
+			}
+			sort.Strings(cidrs)
+			for _, cidr := range cidrs {
+				fmt.Fprintf(tw, "\t%v\n", cidr)
 			}
 		}
 	}

--- a/cmd/juju/space/list_test.go
+++ b/cmd/juju/space/list_test.go
@@ -42,17 +42,17 @@ func (s *ListSuite) TestInit(c *gc.C) {
 		about:        "unrecognized arguments",
 		args:         s.Strings("foo"),
 		expectErr:    `unrecognized args: \["foo"\]`,
-		expectFormat: "yaml",
+		expectFormat: "tabular",
 	}, {
 		about:        "invalid format",
 		args:         s.Strings("--format", "foo"),
 		expectErr:    `invalid value "foo" for flag --format: unknown format "foo"`,
-		expectFormat: "yaml",
+		expectFormat: "tabular",
 	}, {
 		about:        "invalid format (value is case-sensitive)",
 		args:         s.Strings("--format", "JSON"),
 		expectErr:    `invalid value "JSON" for flag --format: unknown format "JSON"`,
-		expectFormat: "yaml",
+		expectFormat: "tabular",
 	}, {
 		about:        "json format",
 		args:         s.Strings("--format", "json"),
@@ -62,10 +62,14 @@ func (s *ListSuite) TestInit(c *gc.C) {
 		args:         s.Strings("--format", "yaml"),
 		expectFormat: "yaml",
 	}, {
+		about:        "tabular format",
+		args:         s.Strings("--format", "tabular"),
+		expectFormat: "tabular",
+	}, {
 		// --output and -o are tested separately in TestOutputFormats.
 		about:        "both --output and -o specified (latter overrides former)",
 		args:         s.Strings("--output", "foo", "-o", "bar"),
-		expectFormat: "yaml",
+		expectFormat: "tabular",
 	}} {
 		c.Logf("test #%d: %s", i, test.about)
 		// Create a new instance of the subcommand for each test, but

--- a/cmd/juju/space/list_test.go
+++ b/cmd/juju/space/list_test.go
@@ -179,6 +179,19 @@ spaces:
 }
 `, "") + "\n"
 
+	expectedTabular := `SPACE   SUBNETS
+space1  2001:db8::/32
+        invalid
+space2  10.1.2.0/24
+        4.3.2.0/28
+
+`
+	expectedShortTabular := `SPACE
+space1
+space2
+
+`
+
 	assertAPICalls := func() {
 		// Verify the API calls and reset the recorded calls.
 		s.api.CheckCallNames(c, "ListSpaces", "Close")
@@ -243,10 +256,12 @@ spaces:
 		expected string
 		short    bool
 	}{
-		{"", expectedYAML, false}, // default format is YAML
+		{"", expectedTabular, false}, // default format is tabular
+		{"tabular", expectedTabular, false},
 		{"yaml", expectedYAML, false},
 		{"json", expectedJSON, false},
-		{"", expectedShortYAML, true}, // default format is YAML
+		{"", expectedShortTabular, true}, // default format is tabular
+		{"tabular", expectedShortTabular, true},
 		{"yaml", expectedShortYAML, true},
 		{"json", expectedShortJSON, true},
 	} {


### PR DESCRIPTION
Fixes bug: 1625737

https://bugs.launchpad.net/juju/+bug/1625737

QA
Bootstrap to maas
Call "list-spaces", "list-spaces --format=tabular", "list-spaces --short".