### PR TITLE
Update clock.Clock handling to prevent timeouts.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -42,7 +42,7 @@ github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:4
 github.com/juju/romulus	git	bf7827fa2f360ab762c134766ff1d4fff959ea03	2016-08-17T23:29:48Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
-github.com/juju/testing	git	6d7e9c5f21a86d05e8c466c0f2f9d37d150b3af1	2016-09-27T13:51:18Z
+github.com/juju/testing	git	692d58e72934a2e2b56f663259696e035e6351ff	2016-09-30T14:09:10Z
 github.com/juju/txn	git	18d812a45ffc407a4d5f849036b7d8d12febaf08	2016-09-13T21:23:40Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	406e7197d0690a3f28c5a147138774eec4c1355e	2016-09-26T13:08:26Z

--- a/worker/charmrevision/worker_test.go
+++ b/worker/charmrevision/worker_test.go
@@ -45,7 +45,9 @@ func (s *WorkerSuite) TestUpdatesAfterPeriod(c *gc.C) {
 	fix := newFixture(time.Minute)
 	fix.cleanTest(c, func(_ worker.Worker) {
 		fix.waitCall(c)
-		fix.clock.Advance(time.Minute)
+		if err := fix.clock.WaitAdvance(time.Minute, 1*time.Second, 1); err != nil {
+			c.Fatal(err)
+		}
 		fix.waitCall(c)
 		fix.waitNoCall(c)
 	})
@@ -91,7 +93,7 @@ type workerFixture struct {
 func newFixture(period time.Duration) workerFixture {
 	return workerFixture{
 		revisionUpdater: newMockRevisionUpdater(),
-		clock:           testing.NewClock(time.Now()),
+		clock:           testing.NewClock(coretesting.ZeroTime()),
 		period:          period,
 	}
 }


### PR DESCRIPTION
clock.Clock.Advance intermittently advances the time before clock.After
adds an alarm to be notified. This uses a new WaitAdvance method that
only advances time after something is in clock.waiting. It also uses
the zerotime appropriately rather than time now.

More information about this can be found on the wiki: cf.
https://github.com/juju/juju/wiki/Intermittent-failures
There was also discussion on IRC about the use of alarms; cf.
https://irclogs.ubuntu.com/2016/09/30/%23juju-dev.txt

Fixes: https://bugs.launchpad.net/juju/+bug/1607044

QA: 
1. Run unit tests, all pass
2. Run the TestUpdatesAfterPeriod [under stress](https://github.com/juju/juju/wiki/Debugging-Races) an ensure the test no longer fails intermittently. (before fix it failed easily in <15 runs after not after 5000). 
