### PR TITLE
Fix windows test.

### DIFF
--- a/worker/uniter/util_windows_test.go
+++ b/worker/uniter/util_windows_test.go
@@ -136,7 +136,7 @@ func (s *UniterSuite) TestRunCommand(c *gc.C) {
 		), ut(
 			"run commands: proxy settings set",
 			quickStartRelation{},
-			setProxySettings{HTTP: "http", HTTPS: "https", FTP: "ftp", NoProxy: "localhost"},
+			setProxySettings{Http: "http", Https: "https", Ftp: "ftp", NoProxy: "localhost"},
 			runCommands{
 				fmt.Sprintf("Set-Content %s $env:http_proxy", testFile("proxy.output")),
 				fmt.Sprintf("Add-Content %s $env:HTTP_PROXY", testFile("proxy.output")),


### PR DESCRIPTION
Addresses http://pad.lv/1629434. With a recent renaming branch, the fields to the Proxy struct were renamed in error. The linux version was fixed, but windows still had the failure.

Tested on windows, and package compiles.