### PR TITLE
provider/lxd: clean up client certificates

### DIFF
--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -174,9 +174,9 @@ func (env *environ) DestroyController(controllerUUID string) error {
 }
 
 func (env *environ) destroyHostedModelResources(controllerUUID string) error {
-	// Destroy all instances where juju-controller-uuid,
-	// but not juju-model-uuid, matches env.uuid.
-	prefix := env.namespace.Prefix()
+	// Destroy all instances with juju-controller-uuid
+	// matching the specified UUID.
+	const prefix = "juju-"
 	instances, err := env.prefixedInstances(prefix)
 	if err != nil {
 		return errors.Annotate(err, "listing instances")
@@ -193,7 +193,7 @@ func (env *environ) destroyHostedModelResources(controllerUUID string) error {
 		}
 		names = append(names, string(inst.Id()))
 	}
-	if err := env.raw.RemoveInstances(prefix, names...); err != nil {
+	if err := removeInstances(env.raw, prefix, names); err != nil {
 		return errors.Annotate(err, "removing hosted model instances")
 	}
 	return nil

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -6,12 +6,14 @@
 package lxd_test
 
 import (
+	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/provider/lxd"
+	"github.com/juju/juju/tools/lxdclient"
 )
 
 type environBrokerSuite struct {
@@ -52,12 +54,41 @@ func (s *environBrokerSuite) TestStopInstances(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "Instances",
+		Args: []interface{}{
+			"juju-f75cba-",
+			[]string(nil),
+		},
+	}, {
 		FuncName: "RemoveInstances",
 		Args: []interface{}{
 			"juju-f75cba-",
 			[]string{"spam"},
 		},
 	}})
+}
+
+func (s *environBrokerSuite) TestStopInstancesRemoveCertificate(c *gc.C) {
+	s.RawInstance.InstanceSummary.Metadata[lxdclient.CertificateFingerprintKey] = "foo"
+	s.Client.Insts = []lxdclient.Instance{*s.RawInstance}
+
+	err := s.Env.StopInstances(s.Instance.Id())
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.Stub.CheckCallNames(c, "Instances", "RemoveCertByFingerprint", "RemoveInstances")
+	s.Stub.CheckCall(c, 1, "RemoveCertByFingerprint", "foo")
+}
+
+func (s *environBrokerSuite) TestStopInstancesRemoveCertificateNotFound(c *gc.C) {
+	s.RawInstance.InstanceSummary.Metadata[lxdclient.CertificateFingerprintKey] = "foo"
+	s.Client.Insts = []lxdclient.Instance{*s.RawInstance}
+
+	s.Stub.SetErrors(nil, errors.NotFoundf("certificate"))
+	err := s.Env.StopInstances(s.Instance.Id())
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.Stub.CheckCallNames(c, "Instances", "RemoveCertByFingerprint", "RemoveInstances")
+	s.Stub.CheckCall(c, 1, "RemoveCertByFingerprint", "foo")
 }
 
 func (s *environBrokerSuite) TestImageMetadataURL(c *gc.C) {

--- a/provider/lxd/environ_raw.go
+++ b/provider/lxd/environ_raw.go
@@ -41,6 +41,7 @@ type rawProvider struct {
 
 type lxdCerts interface {
 	AddCert(lxdclient.Cert) error
+	RemoveCertByFingerprint(string) error
 }
 
 type lxdConfig interface {

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -126,16 +126,16 @@ func (s *environSuite) TestDestroyHostedModels(c *gc.C) {
 	s.Stub.ResetCalls()
 
 	// machine0 is in the controller model.
-	machine0 := s.NewRawInstance(c, "juju-whatever-machine-0")
+	machine0 := s.NewRawInstance(c, "juju-controller-machine-0")
 	machine0.InstanceSummary.Metadata["juju-model-uuid"] = s.Config.UUID()
 	machine0.InstanceSummary.Metadata["juju-controller-uuid"] = s.Config.UUID()
 	// machine1 is not in the controller model, but managed
 	// by the same controller.
-	machine1 := s.NewRawInstance(c, "juju-whatever-machine-1")
+	machine1 := s.NewRawInstance(c, "juju-hosted-machine-1")
 	machine1.InstanceSummary.Metadata["juju-model-uuid"] = "not-" + s.Config.UUID()
 	machine1.InstanceSummary.Metadata["juju-controller-uuid"] = s.Config.UUID()
 	// machine2 is not managed by the same controller.
-	machine2 := s.NewRawInstance(c, "juju-whatever-machine-2")
+	machine2 := s.NewRawInstance(c, "juju-controller-machine-2")
 	machine2.InstanceSummary.Metadata["juju-model-uuid"] = "not-" + s.Config.UUID()
 	machine2.InstanceSummary.Metadata["juju-controller-uuid"] = "not-" + s.Config.UUID()
 	s.Client.Insts = append(s.Client.Insts, *machine0, *machine1, *machine2)
@@ -143,13 +143,13 @@ func (s *environSuite) TestDestroyHostedModels(c *gc.C) {
 	err := s.Env.DestroyController(s.Config.UUID())
 	c.Assert(err, jc.ErrorIsNil)
 
-	prefix := s.Prefix()
 	fwname := common.EnvFullName(s.Env.Config().UUID())
 	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
 		{"Ports", []interface{}{fwname}},
 		{"Destroy", nil},
-		{"Instances", []interface{}{prefix, lxdclient.AliveStatuses}},
-		{"RemoveInstances", []interface{}{prefix, []string{machine1.Name}}},
+		{"Instances", []interface{}{"juju-", lxdclient.AliveStatuses}},
+		{"Instances", []interface{}{"juju-", []string{}}},
+		{"RemoveInstances", []interface{}{"juju-", []string{machine1.Name}}},
 	})
 }
 

--- a/provider/lxd/lxd.go
+++ b/provider/lxd/lxd.go
@@ -13,13 +13,8 @@ import (
 
 // The metadata keys used when creating new instances.
 const (
-	metadataKeyCloudInit = lxdclient.UserdataKey
-)
-
-// Common metadata values used when creating new instances.
-const (
-	metadataValueTrue  = "true"
-	metadataValueFalse = "false"
+	metadataKeyCloudInit              = lxdclient.UserdataKey
+	metadataKeyCertificateFingerprint = lxdclient.CertificateFingerprintKey
 )
 
 var (

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -465,6 +465,11 @@ func (conn *StubClient) AddCert(cert lxdclient.Cert) error {
 	return conn.NextErr()
 }
 
+func (conn *StubClient) RemoveCertByFingerprint(fingerprint string) error {
+	conn.AddCall("RemoveCertByFingerprint", fingerprint)
+	return conn.NextErr()
+}
+
 func (conn *StubClient) ServerStatus() (*shared.ServerState, error) {
 	conn.AddCall("ServerStatus")
 	if err := conn.NextErr(); err != nil {

--- a/tools/lxdclient/instance.go
+++ b/tools/lxdclient/instance.go
@@ -26,6 +26,11 @@ const (
 	// Also see https://github.com/lxc/lxd/blob/master/specs/configuration.md.
 	UserdataKey = "user-data"
 
+	// CertificateFingerprintKey is a key that we define to associate
+	// a certificate fingerprint with an instance. We use this to clean
+	// up certificates when removing controller instances.
+	CertificateFingerprintKey = "certificate-fingerprint"
+
 	megabyte = 1024 * 1024
 )
 


### PR DESCRIPTION
We now record the fingerprint of the client
certificate in the instance metadata of
controller machines. When destroying the
machine, we check the metadata for a
certificate fingerprint, and then remove
the certificate with that fingerprint from
the server.

Because we did not previously record the
certificate fingerprint, this changes only
enables us to remove certificates for newly
created controllers.

Fixes https://bugs.launchpad.net/juju/+bug/1616346

**QA**

1. juju bootstrap lxd && juju enable-ha -m controller
2. juju destroy-controller -y lxd, ensure all certs removed

3. bootstrap two lxd controllers on the same machine
4. destroy one of them, and ensure only its certificates
   are removed