### PR TITLE
provider/azure: drop userpass auth-type

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -50,7 +50,7 @@ clouds:
         endpoint: https://www.googleapis.com
   azure:
     type: azure
-    auth-types: [ interactive, service-principal-secret, userpass ]
+    auth-types: [ interactive, service-principal-secret ]
     regions:
       centralus:
         endpoint: https://management.azure.com
@@ -126,7 +126,7 @@ clouds:
         identity-endpoint: https://graph.windows.net
   azure-china:
     type: azure
-    auth-types: [ interactive, service-principal-secret, userpass ]
+    auth-types: [ interactive, service-principal-secret ]
     regions:
       chinaeast:
         endpoint: https://management.chinacloudapi.cn

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -57,7 +57,7 @@ clouds:
         endpoint: https://www.googleapis.com
   azure:
     type: azure
-    auth-types: [ interactive, service-principal-secret, userpass ]
+    auth-types: [ interactive, service-principal-secret ]
     regions:
       centralus:
         endpoint: https://management.azure.com
@@ -133,7 +133,7 @@ clouds:
         identity-endpoint: https://graph.windows.net
   azure-china:
     type: azure
-    auth-types: [ interactive, service-principal-secret, userpass ]
+    auth-types: [ interactive, service-principal-secret ]
     regions:
       chinaeast:
         endpoint: https://management.chinacloudapi.cn

--- a/cmd/plugins/juju-metadata/validateimagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata_test.go
@@ -153,7 +153,7 @@ func cacheTestEnvConfig(c *gc.C, store *jujuclienttesting.MemStore) {
 	store.Credentials["azure"] = cloud.CloudCredential{
 		AuthCredentials: map[string]cloud.Credential{
 			"default": cloud.NewCredential(
-				cloud.UserPassAuthType,
+				"service-principal-secret",
 				map[string]string{
 					"application-id":       "application-id",
 					"subscription-id":      "subscription-id",

--- a/provider/azure/credentials_test.go
+++ b/provider/azure/credentials_test.go
@@ -41,7 +41,6 @@ func (s *credentialsSuite) TestCredentialSchemas(c *gc.C) {
 	envtesting.AssertProviderAuthTypes(c, s.provider,
 		"interactive",
 		"service-principal-secret",
-		"userpass",
 	)
 }
 
@@ -49,15 +48,6 @@ var sampleCredentialAttributes = map[string]string{
 	"application-id":       "application",
 	"application-password": "password",
 	"subscription-id":      "subscription",
-}
-
-func (s *credentialsSuite) TestUserPassCredentialsValid(c *gc.C) {
-	envtesting.AssertProviderCredentialsValid(c, s.provider, "userpass", map[string]string{
-		"application-id":       "application",
-		"application-password": "password",
-		"subscription-id":      "subscription",
-		"tenant-id":            "tenant",
-	})
 }
 
 func (s *credentialsSuite) TestServicePrincipalSecretCredentialsValid(c *gc.C) {
@@ -75,33 +65,6 @@ func (s *credentialsSuite) TestServicePrincipalSecretHiddenAttributes(c *gc.C) {
 func (s *credentialsSuite) TestDetectCredentials(c *gc.C) {
 	_, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-}
-
-func (s *credentialsSuite) TestFinalizeCredentialUserPass(c *gc.C) {
-	in := cloud.NewCredential("userpass", map[string]string{
-		"application-id":       "application",
-		"application-password": "password",
-		"subscription-id":      "subscription",
-		"tenant-id":            "tenant",
-	})
-	ctx := coretesting.Context(c)
-	out, err := s.provider.FinalizeCredential(ctx, environs.FinalizeCredentialParams{Credential: in})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(out, gc.NotNil)
-	c.Assert(out.AuthType(), gc.Equals, cloud.AuthType("service-principal-secret"))
-	c.Assert(out.Attributes(), jc.DeepEquals, map[string]string{
-		"application-id":       "application",
-		"application-password": "password",
-		"subscription-id":      "subscription",
-	})
-	stderr := coretesting.Stderr(ctx)
-	c.Assert(stderr, gc.Equals, `
-WARNING: The "userpass" auth-type is deprecated, and will be removed soon.
-
-Please update the credential in ~/.local/share/juju/credentials.yaml,
-changing auth-type to "service-principal-secret", and dropping the tenant-id field.
-
-`[1:])
 }
 
 func (s *credentialsSuite) TestFinalizeCredentialInteractive(c *gc.C) {


### PR DESCRIPTION
The userpass auth-type has been replaced by
service-principal-secret for Azure.

Fixes https://bugs.launchpad.net/juju/+bug/1623761

**QA**

1. juju add-credential azure (userpass is not an option)
2. juju bootstrap azure with service-principal-secret: works
3. juju bootstrap azure with userpass: fails with
     auth-type "userpass" not supported