### PR TITLE
Return appropriate controller-access for remote users.

### DIFF
--- a/api/client_macaroon_test.go
+++ b/api/client_macaroon_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/api"
 	apitesting "github.com/juju/juju/api/testing"
+	"github.com/juju/juju/permission"
 	"github.com/juju/juju/testcharms"
 )
 
@@ -28,9 +29,11 @@ type clientMacaroonSuite struct {
 
 func (s *clientMacaroonSuite) SetUpTest(c *gc.C) {
 	s.MacaroonSuite.SetUpTest(c)
-	s.AddModelUser(c, "testuser@somewhere")
+	const username = "testuser@somewhere"
+	s.AddModelUser(c, username)
+	s.AddControllerUser(c, username, permission.LoginAccess)
 	s.cookieJar = apitesting.NewClearableCookieJar()
-	s.DischargerLogin = func() string { return "testuser@somewhere" }
+	s.DischargerLogin = func() string { return username }
 	s.client = s.OpenAPI(c, nil, s.cookieJar).Client()
 
 	// Even though we've logged into the API, we want

--- a/api/state_macaroon_test.go
+++ b/api/state_macaroon_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/api"
 	apitesting "github.com/juju/juju/api/testing"
+	"github.com/juju/juju/permission"
 	"github.com/juju/juju/rpc"
 )
 
@@ -27,6 +28,7 @@ const testUserName = "testuser@somewhere"
 func (s *macaroonLoginSuite) SetUpTest(c *gc.C) {
 	s.MacaroonSuite.SetUpTest(c)
 	s.AddModelUser(c, testUserName)
+	s.AddControllerUser(c, testUserName, permission.LoginAccess)
 	info := s.APIInfo(c)
 	info.SkipLogin = true
 	s.client = s.OpenAPI(c, info, nil)

--- a/api/testing/macaroonsuite.go
+++ b/api/testing/macaroonsuite.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 
 	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
@@ -18,6 +19,8 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/controller"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/permission"
+	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -73,6 +76,17 @@ func (s *MacaroonSuite) AddModelUser(c *gc.C, username string) {
 	s.Factory.MakeModelUser(c, &factory.ModelUserParams{
 		User: username,
 	})
+}
+
+// AddControllerUser is a convenience funcation that adds
+// a controller user with the specified access.
+func (s *MacaroonSuite) AddControllerUser(c *gc.C, username string, access permission.Access) {
+	_, err := s.State.AddControllerUser(state.UserAccessSpec{
+		User:      names.NewUserTag(username),
+		CreatedBy: s.AdminUserTag(c),
+		Access:    access,
+	})
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 // OpenAPI opens a connection to the API using the given information.

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -1054,7 +1054,7 @@ func (s *macaroonLoginSuite) TestRemoteUserLoginToModelWithControllerAccess(c *g
 		User:   remoteUser,
 		Access: permission.WriteAccess,
 	})
-	s.AddControllerUser(c, remoteUserTag, permission.AddModelAccess)
+	s.AddControllerUser(c, remoteUser, permission.AddModelAccess)
 
 	s.DischargerLogin = func() string {
 		return remoteUser
@@ -1069,20 +1069,11 @@ func (s *macaroonLoginSuite) TestRemoteUserLoginToModelWithControllerAccess(c *g
 	c.Check(result.UserInfo.ModelAccess, gc.Equals, "write")
 }
 
-func (s *macaroonLoginSuite) AddControllerUser(c *gc.C, user names.UserTag, access permission.Access) {
-	_, err := s.State.AddControllerUser(state.UserAccessSpec{
-		User:      user,
-		CreatedBy: s.AdminUserTag(c),
-		Access:    access,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-}
-
 func (s *macaroonLoginSuite) TestLoginToEnvironmentSuccess(c *gc.C) {
 	const remoteUser = "test@somewhere"
 	var remoteUserTag = names.NewUserTag(remoteUser)
 	s.AddModelUser(c, remoteUser)
-	s.AddControllerUser(c, remoteUserTag, permission.LoginAccess)
+	s.AddControllerUser(c, remoteUser, permission.LoginAccess)
 	s.DischargerLogin = func() string {
 		return "test@somewhere"
 	}

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -1071,7 +1071,6 @@ func (s *macaroonLoginSuite) TestRemoteUserLoginToModelWithControllerAccess(c *g
 
 func (s *macaroonLoginSuite) TestLoginToEnvironmentSuccess(c *gc.C) {
 	const remoteUser = "test@somewhere"
-	var remoteUserTag = names.NewUserTag(remoteUser)
 	s.AddModelUser(c, remoteUser)
 	s.AddControllerUser(c, remoteUser, permission.LoginAccess)
 	s.DischargerLogin = func() string {
@@ -1083,7 +1082,7 @@ func (s *macaroonLoginSuite) TestLoginToEnvironmentSuccess(c *gc.C) {
 	defer client.Close()
 
 	// The auth tag has been correctly returned by the server.
-	c.Assert(client.AuthTag(), gc.Equals, names.NewUserTag("test@somewhere"))
+	c.Assert(client.AuthTag(), gc.Equals, names.NewUserTag(remoteUser))
 }
 
 func (s *macaroonLoginSuite) TestFailedToObtainDischargeLogin(c *gc.C) {

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/permission"
 	"github.com/juju/juju/testing"
 )
 
@@ -189,6 +190,7 @@ const testUser = "testuser@somewhere"
 func (s *macaroonLoginSuite) SetUpTest(c *gc.C) {
 	s.MacaroonSuite.SetUpTest(c)
 	s.MacaroonSuite.AddModelUser(c, testUser)
+	s.MacaroonSuite.AddControllerUser(c, testUser, permission.LoginAccess)
 
 	s.controllerName = "my-controller"
 	s.modelName = testUser + "/my-model"

--- a/permission/access.go
+++ b/permission/access.go
@@ -70,47 +70,74 @@ func ValidateControllerAccess(access Access) error {
 	return errors.NotValidf("%q controller access", access)
 }
 
-// EqualOrGreaterModelAccessThan returns true if the provided access is equal or
-// less than the current.
-func (a Access) EqualOrGreaterModelAccessThan(access Access) bool {
-	if a == access {
-		return true
-	}
+func (a Access) controllerValue() int {
 	switch a {
 	case UndefinedAccess:
-		return false
-	case ReadAccess:
-		return access == UndefinedAccess
-	case WriteAccess:
-		return access == ReadAccess ||
-			access == UndefinedAccess
-	case AdminAccess, SuperuserAccess:
-		return access == ReadAccess ||
-			access == WriteAccess
+		return 0
+	case LoginAccess:
+		return 1
+	case AddModelAccess:
+		return 2
+	case SuperuserAccess:
+		return 3
+	default:
+		return -1
 	}
-	return false
 }
 
-// EqualOrGreaterControllerAccessThan returns true if the provided access is equal or
-// less than the current.
-func (a Access) EqualOrGreaterControllerAccessThan(access Access) bool {
-	if a == access {
-		return true
-	}
+func (a Access) modelValue() int {
 	switch a {
 	case UndefinedAccess:
-		return false
-	case LoginAccess:
-		return access == UndefinedAccess
-	case AddModelAccess:
-		return access == UndefinedAccess ||
-			access == LoginAccess
-	case SuperuserAccess:
-		return access == UndefinedAccess ||
-			access == LoginAccess ||
-			access == AddModelAccess
+		return 0
+	case ReadAccess:
+		return 1
+	case WriteAccess:
+		return 2
+	case AdminAccess:
+		return 3
+	default:
+		return -1
 	}
-	return false
+}
+
+// EqualOrGreaterModelAccessThan returns true if the current access is equal
+// or greater than the passed in access level.
+func (a Access) EqualOrGreaterModelAccessThan(access Access) bool {
+	v1, v2 := a.modelValue(), access.modelValue()
+	if v1 < 0 || v2 < 0 {
+		return false
+	}
+	return v1 >= v2
+}
+
+// GreaterModelAccessThan returns true if the current access is greater than
+// the passed in access level.
+func (a Access) GreaterModelAccessThan(access Access) bool {
+	v1, v2 := a.modelValue(), access.modelValue()
+	if v1 < 0 || v2 < 0 {
+		return false
+	}
+	return v1 > v2
+}
+
+// EqualOrGreaterControllerAccessThan returns true if the current access is
+// equal or greater than the passed in access level.
+func (a Access) EqualOrGreaterControllerAccessThan(access Access) bool {
+	v1, v2 := a.controllerValue(), access.controllerValue()
+	if v1 < 0 || v2 < 0 {
+		return false
+	}
+	return v1 >= v2
+}
+
+// GreaterControllerAccessThan returns true if the current access is
+// greater than the passed in access level.
+func (a Access) GreaterControllerAccessThan(access Access) bool {
+	v1, v2 := a.controllerValue(), access.controllerValue()
+	if v1 < 0 || v2 < 0 {
+		return false
+	}
+	return v1 > v2
 }
 
 // accessField returns a Checker that accepts a string value only

--- a/permission/access_test.go
+++ b/permission/access_test.go
@@ -1,0 +1,201 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package permission_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/permission"
+)
+
+type accessSuite struct{}
+
+var _ = gc.Suite(&accessSuite{})
+
+func (*accessSuite) TestEqualOrGreaterModelAccessThan(c *gc.C) {
+	// A very boring but necessary test to test explicit responses.
+	var (
+		undefined = permission.UndefinedAccess
+		read      = permission.ReadAccess
+		write     = permission.WriteAccess
+		admin     = permission.AdminAccess
+		login     = permission.LoginAccess
+		addmodel  = permission.AddModelAccess
+		superuser = permission.SuperuserAccess
+	)
+	// None of the controller permissions return true for any comparison.
+	for _, value := range []permission.Access{login, addmodel, superuser} {
+		c.Check(value.EqualOrGreaterModelAccessThan(undefined), jc.IsFalse)
+		c.Check(value.EqualOrGreaterModelAccessThan(read), jc.IsFalse)
+		c.Check(value.EqualOrGreaterModelAccessThan(write), jc.IsFalse)
+		c.Check(value.EqualOrGreaterModelAccessThan(admin), jc.IsFalse)
+		c.Check(value.EqualOrGreaterModelAccessThan(login), jc.IsFalse)
+		c.Check(value.EqualOrGreaterModelAccessThan(addmodel), jc.IsFalse)
+		c.Check(value.EqualOrGreaterModelAccessThan(superuser), jc.IsFalse)
+	}
+	// No comparison against a controller permission will return true
+	for _, value := range []permission.Access{undefined, read, write, admin} {
+		c.Check(value.EqualOrGreaterModelAccessThan(login), jc.IsFalse)
+		c.Check(value.EqualOrGreaterModelAccessThan(addmodel), jc.IsFalse)
+		c.Check(value.EqualOrGreaterModelAccessThan(superuser), jc.IsFalse)
+	}
+
+	c.Check(undefined.EqualOrGreaterModelAccessThan(undefined), jc.IsTrue)
+	c.Check(undefined.EqualOrGreaterModelAccessThan(read), jc.IsFalse)
+	c.Check(undefined.EqualOrGreaterModelAccessThan(write), jc.IsFalse)
+	c.Check(undefined.EqualOrGreaterModelAccessThan(admin), jc.IsFalse)
+
+	c.Check(read.EqualOrGreaterModelAccessThan(undefined), jc.IsTrue)
+	c.Check(read.EqualOrGreaterModelAccessThan(read), jc.IsTrue)
+	c.Check(read.EqualOrGreaterModelAccessThan(write), jc.IsFalse)
+	c.Check(read.EqualOrGreaterModelAccessThan(admin), jc.IsFalse)
+
+	c.Check(write.EqualOrGreaterModelAccessThan(undefined), jc.IsTrue)
+	c.Check(write.EqualOrGreaterModelAccessThan(read), jc.IsTrue)
+	c.Check(write.EqualOrGreaterModelAccessThan(write), jc.IsTrue)
+	c.Check(write.EqualOrGreaterModelAccessThan(admin), jc.IsFalse)
+
+	c.Check(admin.EqualOrGreaterModelAccessThan(undefined), jc.IsTrue)
+	c.Check(admin.EqualOrGreaterModelAccessThan(read), jc.IsTrue)
+	c.Check(admin.EqualOrGreaterModelAccessThan(write), jc.IsTrue)
+	c.Check(admin.EqualOrGreaterModelAccessThan(admin), jc.IsTrue)
+}
+
+func (*accessSuite) TestGreaterModelAccessThan(c *gc.C) {
+	// A very boring but necessary test to test explicit responses.
+	var (
+		undefined = permission.UndefinedAccess
+		read      = permission.ReadAccess
+		write     = permission.WriteAccess
+		admin     = permission.AdminAccess
+		login     = permission.LoginAccess
+		addmodel  = permission.AddModelAccess
+		superuser = permission.SuperuserAccess
+	)
+	// None of undefined or the controller permissions return true for any comparison.
+	for _, value := range []permission.Access{undefined, login, addmodel, superuser} {
+		c.Check(value.GreaterModelAccessThan(undefined), jc.IsFalse)
+		c.Check(value.GreaterModelAccessThan(read), jc.IsFalse)
+		c.Check(value.GreaterModelAccessThan(write), jc.IsFalse)
+		c.Check(value.GreaterModelAccessThan(admin), jc.IsFalse)
+		c.Check(value.GreaterModelAccessThan(login), jc.IsFalse)
+		c.Check(value.GreaterModelAccessThan(addmodel), jc.IsFalse)
+		c.Check(value.GreaterModelAccessThan(superuser), jc.IsFalse)
+	}
+	// No comparison against a controller permission will return true
+	for _, value := range []permission.Access{undefined, read, write, admin} {
+		c.Check(value.GreaterModelAccessThan(login), jc.IsFalse)
+		c.Check(value.GreaterModelAccessThan(addmodel), jc.IsFalse)
+		c.Check(value.GreaterModelAccessThan(superuser), jc.IsFalse)
+	}
+
+	c.Check(read.GreaterModelAccessThan(undefined), jc.IsTrue)
+	c.Check(read.GreaterModelAccessThan(read), jc.IsFalse)
+	c.Check(read.GreaterModelAccessThan(write), jc.IsFalse)
+	c.Check(read.GreaterModelAccessThan(admin), jc.IsFalse)
+
+	c.Check(write.GreaterModelAccessThan(undefined), jc.IsTrue)
+	c.Check(write.GreaterModelAccessThan(read), jc.IsTrue)
+	c.Check(write.GreaterModelAccessThan(write), jc.IsFalse)
+	c.Check(write.GreaterModelAccessThan(admin), jc.IsFalse)
+
+	c.Check(admin.GreaterModelAccessThan(undefined), jc.IsTrue)
+	c.Check(admin.GreaterModelAccessThan(read), jc.IsTrue)
+	c.Check(admin.GreaterModelAccessThan(write), jc.IsTrue)
+	c.Check(admin.GreaterModelAccessThan(admin), jc.IsFalse)
+}
+
+func (*accessSuite) TestEqualOrGreaterControllerAccessThan(c *gc.C) {
+	// A very boring but necessary test to test explicit responses.
+	var (
+		undefined = permission.UndefinedAccess
+		read      = permission.ReadAccess
+		write     = permission.WriteAccess
+		admin     = permission.AdminAccess
+		login     = permission.LoginAccess
+		addmodel  = permission.AddModelAccess
+		superuser = permission.SuperuserAccess
+	)
+	// None of the model permissions return true for any comparison.
+	for _, value := range []permission.Access{read, write, admin} {
+		c.Check(value.EqualOrGreaterControllerAccessThan(undefined), jc.IsFalse)
+		c.Check(value.EqualOrGreaterControllerAccessThan(read), jc.IsFalse)
+		c.Check(value.EqualOrGreaterControllerAccessThan(write), jc.IsFalse)
+		c.Check(value.EqualOrGreaterControllerAccessThan(admin), jc.IsFalse)
+		c.Check(value.EqualOrGreaterControllerAccessThan(login), jc.IsFalse)
+		c.Check(value.EqualOrGreaterControllerAccessThan(addmodel), jc.IsFalse)
+		c.Check(value.EqualOrGreaterControllerAccessThan(superuser), jc.IsFalse)
+	}
+	// No comparison against a model permission will return true
+	for _, value := range []permission.Access{undefined, login, addmodel, superuser} {
+		c.Check(value.EqualOrGreaterControllerAccessThan(read), jc.IsFalse)
+		c.Check(value.EqualOrGreaterControllerAccessThan(write), jc.IsFalse)
+		c.Check(value.EqualOrGreaterControllerAccessThan(admin), jc.IsFalse)
+	}
+
+	c.Check(undefined.EqualOrGreaterControllerAccessThan(undefined), jc.IsTrue)
+	c.Check(undefined.EqualOrGreaterControllerAccessThan(login), jc.IsFalse)
+	c.Check(undefined.EqualOrGreaterControllerAccessThan(addmodel), jc.IsFalse)
+	c.Check(undefined.EqualOrGreaterControllerAccessThan(superuser), jc.IsFalse)
+
+	c.Check(login.EqualOrGreaterControllerAccessThan(undefined), jc.IsTrue)
+	c.Check(login.EqualOrGreaterControllerAccessThan(login), jc.IsTrue)
+	c.Check(login.EqualOrGreaterControllerAccessThan(addmodel), jc.IsFalse)
+	c.Check(login.EqualOrGreaterControllerAccessThan(superuser), jc.IsFalse)
+
+	c.Check(addmodel.EqualOrGreaterControllerAccessThan(undefined), jc.IsTrue)
+	c.Check(addmodel.EqualOrGreaterControllerAccessThan(login), jc.IsTrue)
+	c.Check(addmodel.EqualOrGreaterControllerAccessThan(addmodel), jc.IsTrue)
+	c.Check(addmodel.EqualOrGreaterControllerAccessThan(superuser), jc.IsFalse)
+
+	c.Check(superuser.EqualOrGreaterControllerAccessThan(undefined), jc.IsTrue)
+	c.Check(superuser.EqualOrGreaterControllerAccessThan(login), jc.IsTrue)
+	c.Check(superuser.EqualOrGreaterControllerAccessThan(addmodel), jc.IsTrue)
+	c.Check(superuser.EqualOrGreaterControllerAccessThan(superuser), jc.IsTrue)
+}
+
+func (*accessSuite) TestGreaterControllerAccessThan(c *gc.C) {
+	// A very boring but necessary test to test explicit responses.
+	var (
+		undefined = permission.UndefinedAccess
+		read      = permission.ReadAccess
+		write     = permission.WriteAccess
+		admin     = permission.AdminAccess
+		login     = permission.LoginAccess
+		addmodel  = permission.AddModelAccess
+		superuser = permission.SuperuserAccess
+	)
+	// None of undefined or the model permissions return true for any comparison.
+	for _, value := range []permission.Access{undefined, read, write, admin} {
+		c.Check(value.GreaterControllerAccessThan(undefined), jc.IsFalse)
+		c.Check(value.GreaterControllerAccessThan(read), jc.IsFalse)
+		c.Check(value.GreaterControllerAccessThan(write), jc.IsFalse)
+		c.Check(value.GreaterControllerAccessThan(admin), jc.IsFalse)
+		c.Check(value.GreaterControllerAccessThan(login), jc.IsFalse)
+		c.Check(value.GreaterControllerAccessThan(addmodel), jc.IsFalse)
+		c.Check(value.GreaterControllerAccessThan(superuser), jc.IsFalse)
+	}
+	// No comparison against a model permission will return true
+	for _, value := range []permission.Access{undefined, login, addmodel, superuser} {
+		c.Check(value.GreaterControllerAccessThan(read), jc.IsFalse)
+		c.Check(value.GreaterControllerAccessThan(write), jc.IsFalse)
+		c.Check(value.GreaterControllerAccessThan(admin), jc.IsFalse)
+	}
+
+	c.Check(login.GreaterControllerAccessThan(undefined), jc.IsTrue)
+	c.Check(login.GreaterControllerAccessThan(login), jc.IsFalse)
+	c.Check(login.GreaterControllerAccessThan(addmodel), jc.IsFalse)
+	c.Check(login.GreaterControllerAccessThan(superuser), jc.IsFalse)
+
+	c.Check(addmodel.GreaterControllerAccessThan(undefined), jc.IsTrue)
+	c.Check(addmodel.GreaterControllerAccessThan(login), jc.IsTrue)
+	c.Check(addmodel.GreaterControllerAccessThan(addmodel), jc.IsFalse)
+	c.Check(addmodel.GreaterControllerAccessThan(superuser), jc.IsFalse)
+
+	c.Check(superuser.GreaterControllerAccessThan(undefined), jc.IsTrue)
+	c.Check(superuser.GreaterControllerAccessThan(login), jc.IsTrue)
+	c.Check(superuser.GreaterControllerAccessThan(addmodel), jc.IsTrue)
+	c.Check(superuser.GreaterControllerAccessThan(superuser), jc.IsFalse)
+}

--- a/permission/package_test.go
+++ b/permission/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package permission_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
This bug addresses two issues:
  http://pad.lv/1621679 - Login succeeds when permissions forbid it but all requests are denied afterwards
  http://pad.lv/1629089 - API Login ACL response values differ from CLI

The authenticiation code was not adding higher level "everyone" controller access to the login response.
Also, the same area of code would not reject access to a model for an unknown user if there was an "everyone" controller permission.

Tidied up the tests a bit to use test cleanup to close api connections rather than adding a defer call to every test.