### PR TITLE
Add a new update-credential command

### DIFF
--- a/apiserver/cloud/cloud.go
+++ b/apiserver/cloud/cloud.go
@@ -208,6 +208,11 @@ func (api *CloudAPI) UpdateCredentials(args params.UpdateCloudCredentials) (para
 			arg.Credential.Attributes,
 		)
 		if err := api.backend.UpdateCloudCredential(tag, in); err != nil {
+			if errors.IsNotFound(err) {
+				err = errors.Errorf(
+					"cannot update credential %q: controller does not manage cloud %q",
+					tag.Name(), tag.Cloud().Id())
+			}
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -4,7 +4,10 @@
 package cloud
 
 import (
+	"github.com/juju/cmd"
+
 	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/modelcmd"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/jujuclient"
 )
@@ -69,4 +72,12 @@ func NewSetDefaultRegionCommandForTest(testStore jujuclient.CredentialStore) *se
 	return &setDefaultRegionCommand{
 		store: testStore,
 	}
+}
+
+func NewUpdateCredentialCommandForTest(testStore jujuclient.ClientStore, api credentialAPI) cmd.Command {
+	c := &updateCredentialCommand{
+		api: api,
+	}
+	c.SetClientStore(testStore)
+	return modelcmd.WrapController(c)
 }

--- a/cmd/juju/cloud/updatecredential.go
+++ b/cmd/juju/cloud/updatecredential.go
@@ -1,0 +1,134 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"gopkg.in/juju/names.v2"
+
+	apicloud "github.com/juju/juju/api/cloud"
+	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+var usageUpdateCredentialSummary = `
+Updates a credential for a cloud.`[1:]
+
+var usageUpdateCredentialDetails = `
+Updates a named credential for a cloud.
+
+Examples:
+    juju update-credential aws mysecrets
+
+See also: 
+    add-credential
+    credentials`[1:]
+
+type updateCredentialCommand struct {
+	modelcmd.ControllerCommandBase
+
+	api credentialAPI
+
+	cloud      string
+	credential string
+}
+
+// NewUpdateCredentialCommand returns a command to update credential details.
+func NewUpdateCredentialCommand() cmd.Command {
+	return modelcmd.WrapController(&updateCredentialCommand{})
+}
+
+// Init implements Command.Init.
+func (c *updateCredentialCommand) Init(args []string) error {
+	if len(args) < 2 {
+		return errors.New("Usage: juju update-credential <cloud-name> <credential-name>")
+	}
+	c.cloud = args[0]
+	c.credential = args[1]
+	return cmd.CheckEmpty(args[2:])
+}
+
+// Info implements Command.Info
+func (c *updateCredentialCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "update-credential",
+		Args:    "<cloud-name> <credential-name>",
+		Purpose: usageUpdateCredentialSummary,
+		Doc:     usageUpdateCredentialDetails,
+	}
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *updateCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.ControllerCommandBase.SetFlags(f)
+	f.StringVar(&c.credential, "credential", "", "Name of credential to update")
+	f.StringVar(&c.cloud, "cloud", "", "Cloud for which to update the credential")
+}
+
+type credentialAPI interface {
+	UpdateCredential(tag names.CloudCredentialTag, credential jujucloud.Credential) error
+	Clouds() (map[names.CloudTag]jujucloud.Cloud, error)
+	Close() error
+}
+
+func (c *updateCredentialCommand) getAPI() (credentialAPI, error) {
+	if c.api != nil {
+		return c.api, nil
+	}
+	api, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, errors.Annotate(err, "opening API connection")
+	}
+	return apicloud.NewClient(api), nil
+}
+
+// Run implements Command.Run
+func (c *updateCredentialCommand) Run(ctx *cmd.Context) error {
+	cred, err := c.ClientStore().CredentialForCloud(c.cloud)
+	if errors.IsNotFound(err) {
+		ctx.Infof("No credentials exist for cloud %q", c.cloud)
+		return nil
+	} else if err != nil {
+		return err
+	}
+	credToUpdate, ok := cred.AuthCredentials[c.credential]
+	if !ok {
+		ctx.Infof("No credential called %q exists for cloud %q", c.credential, c.cloud)
+		return nil
+	}
+
+	accountDetails, err := c.ClientStore().AccountDetails(c.ControllerName())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	credentialTag, err := common.ResolveCloudCredentialTag(
+		names.NewUserTag(accountDetails.User), names.NewCloudTag(c.cloud), c.credential,
+	)
+
+	client, err := c.getAPI()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	if err := client.UpdateCredential(credentialTag, credToUpdate); err != nil {
+		return c.processError(client, err)
+	}
+	ctx.Infof("Updated credential %q for user %q on cloud %q.", c.credential, accountDetails.User, c.cloud)
+	return nil
+}
+
+func (c *updateCredentialCommand) processError(client credentialAPI, initialErr error) error {
+	cloudDetails, err := client.Clouds()
+	if err != nil {
+		return initialErr
+	}
+	if _, ok := cloudDetails[names.NewCloudTag(c.cloud)]; !ok {
+		return errors.Errorf("cannot update credential %q for cloud %q because controller does not run on the specified cloud", c.credential, c.cloud)
+	}
+	return initialErr
+}

--- a/cmd/juju/cloud/updatecredential.go
+++ b/cmd/juju/cloud/updatecredential.go
@@ -71,7 +71,6 @@ func (c *updateCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
 
 type credentialAPI interface {
 	UpdateCredential(tag names.CloudCredentialTag, credential jujucloud.Credential) error
-	Clouds() (map[names.CloudTag]jujucloud.Cloud, error)
 	Close() error
 }
 
@@ -116,19 +115,8 @@ func (c *updateCredentialCommand) Run(ctx *cmd.Context) error {
 	defer client.Close()
 
 	if err := client.UpdateCredential(credentialTag, credToUpdate); err != nil {
-		return c.processError(client, err)
+		return err
 	}
 	ctx.Infof("Updated credential %q for user %q on cloud %q.", c.credential, accountDetails.User, c.cloud)
 	return nil
-}
-
-func (c *updateCredentialCommand) processError(client credentialAPI, initialErr error) error {
-	cloudDetails, err := client.Clouds()
-	if err != nil {
-		return initialErr
-	}
-	if _, ok := cloudDetails[names.NewCloudTag(c.cloud)]; !ok {
-		return errors.Errorf("cannot update credential %q for cloud %q because controller does not run on the specified cloud", c.credential, c.cloud)
-	}
-	return initialErr
 }

--- a/cmd/juju/cloud/updatecredential_test.go
+++ b/cmd/juju/cloud/updatecredential_test.go
@@ -1,0 +1,155 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud_test
+
+import (
+	"fmt"
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/cloud"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/testing"
+)
+
+type updateCredentialSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&updateCredentialSuite{})
+
+func (s *updateCredentialSuite) TestBadArgs(c *gc.C) {
+	cmd := cloud.NewUpdateCredentialCommand()
+	_, err := testing.RunCommand(c, cmd)
+	c.Assert(err, gc.ErrorMatches, "Usage: juju update-credential <cloud-name> <credential-name>")
+	_, err = testing.RunCommand(c, cmd, "cloud", "credential", "extra")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
+}
+
+func (s *updateCredentialSuite) TestMissingCredential(c *gc.C) {
+	store := &jujuclienttesting.MemStore{
+		Controllers: map[string]jujuclient.ControllerDetails{
+			"controller": {},
+		},
+		CurrentControllerName: "controller",
+		Credentials: map[string]jujucloud.CloudCredential{
+			"aws": {
+				AuthCredentials: map[string]jujucloud.Credential{
+					"my-credential": jujucloud.NewCredential(jujucloud.AccessKeyAuthType, nil),
+				},
+			},
+		},
+	}
+	cmd := cloud.NewUpdateCredentialCommandForTest(store, nil)
+	ctx, err := testing.RunCommand(c, cmd, "aws", "foo")
+	c.Assert(err, jc.ErrorIsNil)
+	output := testing.Stderr(ctx)
+	output = strings.Replace(output, "\n", "", -1)
+	c.Assert(output, gc.Equals, `No credential called "foo" exists for cloud "aws"`)
+}
+
+func (s *updateCredentialSuite) TestBadCloudName(c *gc.C) {
+	store := &jujuclienttesting.MemStore{
+		Controllers: map[string]jujuclient.ControllerDetails{
+			"controller": {},
+		},
+		CurrentControllerName: "controller",
+	}
+	cmd := cloud.NewUpdateCredentialCommandForTest(store, nil)
+	ctx, err := testing.RunCommand(c, cmd, "somecloud", "foo")
+	c.Assert(err, jc.ErrorIsNil)
+	output := testing.Stderr(ctx)
+	output = strings.Replace(output, "\n", "", -1)
+	c.Assert(output, gc.Equals, `No credentials exist for cloud "somecloud"`)
+}
+
+func (s *updateCredentialSuite) TestUpdate(c *gc.C) {
+	store := &jujuclienttesting.MemStore{
+		Controllers: map[string]jujuclient.ControllerDetails{
+			"controller": {},
+		},
+		CurrentControllerName: "controller",
+		Accounts: map[string]jujuclient.AccountDetails{
+			"controller": {
+				User: "admin@local",
+			},
+		},
+		Credentials: map[string]jujucloud.CloudCredential{
+			"aws": {
+				AuthCredentials: map[string]jujucloud.Credential{
+					"my-credential":      jujucloud.NewCredential(jujucloud.AccessKeyAuthType, nil),
+					"another-credential": jujucloud.NewCredential(jujucloud.UserPassAuthType, nil),
+				},
+			},
+		},
+	}
+	fake := &fakeUpdateCredentialAPI{
+		clouds: map[names.CloudTag]jujucloud.Cloud{
+			names.NewCloudTag("aws"): {},
+		},
+	}
+	cmd := cloud.NewUpdateCredentialCommandForTest(store, fake)
+	ctx, err := testing.RunCommand(c, cmd, "aws", "my-credential")
+	c.Assert(err, jc.ErrorIsNil)
+	output := testing.Stderr(ctx)
+	output = strings.Replace(output, "\n", "", -1)
+	c.Assert(output, gc.Equals, `Updated credential "my-credential" for user "admin@local" on cloud "aws".`)
+	c.Assert(fake.creds, jc.DeepEquals, map[names.CloudCredentialTag]jujucloud.Credential{
+		names.NewCloudCredentialTag("aws/admin@local/my-credential"): jujucloud.NewCredential(jujucloud.AccessKeyAuthType, nil),
+	})
+}
+
+func (s *updateCredentialSuite) TestInvalidCloud(c *gc.C) {
+	store := &jujuclienttesting.MemStore{
+		Controllers: map[string]jujuclient.ControllerDetails{
+			"controller": {},
+		},
+		CurrentControllerName: "controller",
+		Accounts: map[string]jujuclient.AccountDetails{
+			"controller": {
+				User: "admin@local",
+			},
+		},
+		Credentials: map[string]jujucloud.CloudCredential{
+			"aws": {
+				AuthCredentials: map[string]jujucloud.Credential{
+					"my-credential": jujucloud.NewCredential(jujucloud.AccessKeyAuthType, nil),
+				},
+			},
+		},
+	}
+	fake := &fakeUpdateCredentialAPI{}
+	cmd := cloud.NewUpdateCredentialCommandForTest(store, fake)
+	_, err := testing.RunCommand(c, cmd, "aws", "my-credential")
+	c.Assert(err, gc.ErrorMatches, `cannot update credential "my-credential" for cloud "aws" because controller does not run on the specified cloud`)
+}
+
+type fakeUpdateCredentialAPI struct {
+	creds  map[names.CloudCredentialTag]jujucloud.Credential
+	clouds map[names.CloudTag]jujucloud.Cloud
+}
+
+func (f *fakeUpdateCredentialAPI) UpdateCredential(tag names.CloudCredentialTag, credential jujucloud.Credential) error {
+	if _, ok := f.clouds[tag.Cloud()]; !ok {
+		return fmt.Errorf("error")
+	}
+	if f.creds == nil {
+		f.creds = make(map[names.CloudCredentialTag]jujucloud.Credential)
+	}
+	f.creds[tag] = credential
+	return nil
+}
+
+func (f *fakeUpdateCredentialAPI) Clouds() (map[names.CloudTag]jujucloud.Cloud, error) {
+	return f.clouds, nil
+}
+
+func (*fakeUpdateCredentialAPI) Close() error {
+	return nil
+}

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -393,6 +393,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(cloud.NewSetDefaultCredentialCommand())
 	r.Register(cloud.NewAddCredentialCommand())
 	r.Register(cloud.NewRemoveCredentialCommand())
+	r.Register(cloud.NewUpdateCredentialCommand())
 
 	// Juju GUI commands.
 	r.Register(gui.NewGUICommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -516,6 +516,7 @@ var commandNames = []string{
 	"upload-backup",
 	"unregister",
 	"update-clouds",
+	"update-credential",
 	"upgrade-charm",
 	"upgrade-gui",
 	"upgrade-juju",

--- a/featuretests/cmd_juju_credential_test.go
+++ b/featuretests/cmd_juju_credential_test.go
@@ -1,0 +1,57 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	apicloud "github.com/juju/juju/api/cloud"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/commands"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/testing"
+)
+
+type cmdCredentialSuite struct {
+	jujutesting.JujuConnSuite
+}
+
+func (s *cmdCredentialSuite) run(c *gc.C, args ...string) *cmd.Context {
+	context := testing.Context(c)
+	command := commands.NewJujuCommand(context)
+	c.Assert(testing.InitCommand(command, args), jc.ErrorIsNil)
+	c.Assert(command.Run(context), jc.ErrorIsNil)
+	loggo.RemoveWriter("warning")
+	return context
+}
+
+func (s *cmdCredentialSuite) TestUpdateCredentialCommand(c *gc.C) {
+	store := jujuclient.NewFileClientStore()
+	store.UpdateCredential("dummy", cloud.CloudCredential{
+		AuthCredentials: map[string]cloud.Credential{
+			"mine": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{"username": "fred", "password": "secret"}),
+		},
+	})
+	s.run(c, "update-credential", "dummy", "mine")
+
+	client := apicloud.NewClient(s.OpenControllerAPI(c))
+	defer client.Close()
+
+	tag := names.NewCloudCredentialTag("dummy/admin@local/mine")
+	result, err := client.Credentials(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, []params.CloudCredentialResult{
+		{Result: &params.CloudCredential{
+			AuthType:   "userpass",
+			Attributes: map[string]string{"username": "fred"},
+			Redacted:   []string{"password"},
+		}},
+	})
+}

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -32,6 +32,7 @@ func init() {
 	gc.Suite(&BakeryStorageSuite{})
 	gc.Suite(&blockSuite{})
 	gc.Suite(&cmdControllerSuite{})
+	gc.Suite(&cmdCredentialSuite{})
 	gc.Suite(&cmdJujuSuite{})
 	gc.Suite(&cmdLoginSuite{})
 	gc.Suite(&cmdModelSuite{})


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju/+bug/1623811

A new update-credential command is added. This allows locally updated credentials to be uploaded to the controller to replace any existing credentials which may be in use.