### PR TITLE
Introduce provider/ec2/internal/ec2instancetypes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ cmd/jujud/jujud
 cmd/builddb/builddb
 cmd/charmd/charmd
 cmd/charmload/charmload
+provider/ec2/internal/ec2instancetypes/index.json
 tags
 !tags/
 TAGS

--- a/provider/ec2/internal/ec2instancetypes/doc.go
+++ b/provider/ec2/internal/ec2instancetypes/doc.go
@@ -1,0 +1,11 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package ec2instancetypes contains instance type information
+// for the ec2 provider, generated from the AWS Price List API.
+//
+// To update this package, first fetch index.json to this
+// directory, and then run "go generate". The current index.json
+// file can be found at:
+//     https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/index.json
+package ec2instancetypes

--- a/provider/ec2/internal/ec2instancetypes/generated.go
+++ b/provider/ec2/internal/ec2instancetypes/generated.go
@@ -1,0 +1,7405 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ec2instancetypes
+
+import (
+	"github.com/juju/utils/arch"
+
+	"github.com/juju/juju/environs/instances"
+)
+
+var (
+	paravirtual = "pv"
+	hvm         = "hvm"
+	amd64       = []string{arch.AMD64}
+	both        = []string{arch.AMD64, arch.I386}
+)
+
+// Version: 20160901005907
+// Publication date: 2016-09-01 00:59:07 +0000 UTC
+//
+// This pricing list is for informational purposes only. All prices are subject to the additional terms included in the pricing pages on http://aws.amazon.com. All Free Tier prices are also subject to the terms included at https://aws.amazon.com/free/
+
+var allInstanceTypes = map[string][]instances.InstanceType{
+
+	"ap-northeast-1": {
+
+		// SKU: 4BJPFU3PAZJ4AKMM
+		// Instance family: General purpose
+		// Storage: 4 x 420
+		{
+			Name:       "m1.xlarge",
+			Arches:     amd64,
+			CpuCores:   4,
+			CpuPower:   instances.CpuPower(400),
+			Mem:        15360,
+			VirtType:   &paravirtual,
+			Cost:       486,
+			Deprecated: true,
+		},
+
+		// SKU: 4GHFAT5CNS2FEKB2
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     695,
+		},
+
+		// SKU: 4REMK3MMXCZ55ZX3
+		// Instance family: Storage optimized
+		// Storage: 8 x 800 SSD
+		{
+			Name:     "i2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     8004,
+		},
+
+		// SKU: 6JP9PA73B58NZHUN
+		// Instance family: Storage optimized
+		// Storage: 12 x 2000 HDD
+		{
+			Name:     "d2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     3376,
+		},
+
+		// SKU: 6M27QQ6HYCNA5KGA
+		// Instance family: General purpose
+		// Storage: 1 x 4 SSD
+		{
+			Name:     "m3.medium",
+			Arches:   amd64,
+			CpuCores: 1,
+			CpuPower: instances.CpuPower(350),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     96,
+		},
+
+		// SKU: 6TMC6UD2UCCDAMNP
+		// Instance family: General purpose
+		// Storage: 2 x 420
+		{
+			Name:       "m1.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        7680,
+			VirtType:   &paravirtual,
+			Cost:       243,
+			Deprecated: true,
+		},
+
+		// SKU: 77K4UJJUNGQ6UXXN
+		// Instance family: GPU instance
+		// Storage: 1 x 60 SSD
+		{
+			Name:     "g2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2911),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     898,
+		},
+
+		// SKU: 7A24VVDQEZ54FYXU
+		// Instance family: Storage optimized
+		// Storage: 6 x 2000 HDD
+		{
+			Name:     "d2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     1688,
+		},
+
+		// SKU: 7KXQBZSKETPTG6QZ
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(811),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     133,
+		},
+
+		// SKU: 7MYWT7Y96UT3NJ2D
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(672),
+			Mem:      8192,
+			VirtType: &hvm,
+			Cost:     174,
+		},
+
+		// SKU: 8H36QJ2PHPR3SJ48
+		// Instance family: Storage optimized
+		// Storage: 24 x 2000
+		{
+			Name:       "hs1.8xlarge",
+			Arches:     amd64,
+			CpuCores:   17,
+			CpuPower:   instances.CpuPower(4760),
+			Mem:        119808,
+			VirtType:   &hvm,
+			Cost:       5400,
+			Deprecated: true,
+		},
+
+		// SKU: 9KMZWGZVTXKAQXNM
+		// Instance family: Memory optimized
+		// Storage: 1 x 160 SSD
+		{
+			Name:     "r3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     798,
+		},
+
+		// SKU: 9NSP3EV3G593P35X
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(10),
+			Mem:        1024,
+			VirtType:   &hvm,
+			Cost:       20,
+			Deprecated: true,
+		},
+
+		// SKU: AKQ89V8E78T6H534
+		// Instance family: General purpose
+		// Storage: 1 x 160
+		{
+			Name:       "m1.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(100),
+			Mem:        1741,
+			VirtType:   &paravirtual,
+			Cost:       61,
+			Deprecated: true,
+		},
+
+		// SKU: AY6XZ64M22QQJCXE
+		// Instance family: General purpose
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "m3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     193,
+		},
+
+		// SKU: BQQUCAM9PFTSUNQX
+		// Instance family: Memory optimized
+		// Storage: 2 x 840
+		{
+			Name:       "m2.4xlarge",
+			Arches:     amd64,
+			CpuCores:   8,
+			CpuPower:   instances.CpuPower(800),
+			Mem:        70042,
+			VirtType:   &paravirtual,
+			Cost:       1150,
+			Deprecated: true,
+		},
+
+		// SKU: BURRP7APFUCZFSZK
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     348,
+		},
+
+		// SKU: BYV8H4R4VJNAH42Q
+		// Instance family: Memory optimized
+		// Storage: 1 x 320 SSD
+		{
+			Name:     "r3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     1596,
+		},
+
+		// SKU: CTK39QJHQN4CZ3PC
+		// Instance family: GPU instance
+		// Storage: 2 x 120 SSD
+		{
+			Name:     "g2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11647),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     3592,
+		},
+
+		// SKU: DDX2JPPMM28BXD7D
+		// Instance family: Memory optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "r3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     3192,
+		},
+
+		// SKU: E3J2T7B8EQDFXWDR
+		// Instance family: Compute optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "c3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(12543),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     2043,
+		},
+
+		// SKU: E5MWNHYU3BAVZCRP
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6495),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     1061,
+		},
+
+		// SKU: E6F66FZ47YZNXAJ2
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(40),
+			Mem:        4096,
+			VirtType:   &hvm,
+			Cost:       80,
+			Deprecated: true,
+		},
+
+		// SKU: ERVWZ4V3UBYH4NQH
+		// Instance family: Micro instances
+		// Storage: EBS only
+		{
+			Name:       "t1.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        628,
+			VirtType:   &paravirtual,
+			Cost:       26,
+			Deprecated: true,
+		},
+
+		// SKU: EZCSGZJ8PMXA2QF2
+		// Instance family: Storage optimized
+		// Storage: 1 x 800 SSD
+		{
+			Name:     "i2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     1000,
+		},
+
+		// SKU: F2RRJYX33EGMBSFR
+		// Instance family: General purpose
+		// Storage: 1 x 410
+		{
+			Name:       "m1.medium",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(100),
+			Mem:        3840,
+			VirtType:   &paravirtual,
+			Cost:       122,
+			Deprecated: true,
+		},
+
+		// SKU: F7XCNBBYFKX42QF3
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.nano",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(5),
+			Mem:        512,
+			VirtType:   &hvm,
+			Cost:       10,
+			Deprecated: true,
+		},
+
+		// SKU: FBUWUPNC8FXRUS5W
+		// Instance family: Storage optimized
+		// Storage: 4 x 800 SSD
+		{
+			Name:     "i2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     4002,
+		},
+
+		// SKU: G6G6ZNFBYMW2V8BH
+		// Instance family: Memory optimized
+		// Storage: 1 x 420
+		{
+			Name:       "m2.xlarge",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        17511,
+			VirtType:   &paravirtual,
+			Cost:       287,
+			Deprecated: true,
+		},
+
+		// SKU: GJHUHQSUU37VCQ5A
+		// Instance family: Memory optimized
+		// Storage: 1 x 80 SSD
+		{
+			Name:     "r3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     399,
+		},
+
+		// SKU: GP8GQA2T96JQ4MBB
+		// Instance family: Memory optimized
+		// Storage: 2 x 120 SSD
+		{
+			Name:       "cr1.8xlarge",
+			Arches:     amd64,
+			CpuCores:   32,
+			CpuPower:   instances.CpuPower(3200),
+			Mem:        249856,
+			VirtType:   &hvm,
+			Cost:       4105,
+			Deprecated: true,
+		},
+
+		// SKU: HTNXMK8Z5YHMU737
+		// Instance family: Compute optimized
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "c3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1567),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     255,
+		},
+
+		// SKU: J85A5X44TT267EH8
+		// Instance family: General purpose
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "m3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     385,
+		},
+
+		// SKU: JTQKHD7ZTEEM4DC5
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.10xlarge",
+			Arches:   amd64,
+			CpuCores: 40,
+			CpuPower: instances.CpuPower(13440),
+			Mem:      163840,
+			VirtType: &hvm,
+			Cost:     3477,
+		},
+
+		// SKU: KM8DYQWHEC32CGGX
+		// Instance family: Storage optimized
+		// Storage: 2 x 800 SSD
+		{
+			Name:     "i2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     2001,
+		},
+
+		// SKU: M3G65XHCPFQHAQD5
+		// Instance family: Storage optimized
+		// Storage: 2 x 1024 SSD
+		{
+			Name:       "hi1.4xlarge",
+			Arches:     amd64,
+			CpuCores:   16,
+			CpuPower:   instances.CpuPower(5376),
+			Mem:        61952,
+			VirtType:   &hvm,
+			Cost:       3276,
+			Deprecated: true,
+		},
+
+		// SKU: MJ7YVW9J2WD856AC
+		// Instance family: Memory optimized
+		// Storage: 2 x 1,920
+		{
+			Name:       "x1.32xlarge",
+			Arches:     amd64,
+			CpuCores:   128,
+			CpuPower:   instances.CpuPower(41216),
+			Mem:        1998848,
+			VirtType:   &hvm,
+			Cost:       19341,
+			Deprecated: true,
+		},
+
+		// SKU: PCB5ARVZ6TNS7A96
+		// Instance family: General purpose
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "m3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     770,
+		},
+
+		// SKU: PCNBVATW49APFGZQ
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(14615),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     2122,
+		},
+
+		// SKU: PSF2TQK8WMUGUPYK
+		// Instance family: Storage optimized
+		// Storage: 24 x 2000 HDD
+		{
+			Name:     "d2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(12096),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     6752,
+		},
+
+		// SKU: PTSCWYT4DGMHMSYG
+		// Instance family: Compute optimized
+		// Storage: 1 x 350
+		{
+			Name:       "c1.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        1741,
+			VirtType:   &paravirtual,
+			Cost:       158,
+			Deprecated: true,
+		},
+
+		// SKU: Q4QTSF7H37JFW9ER
+		// Instance family: Compute optimized
+		// Storage: 2 x 16 SSD
+		{
+			Name:     "c3.large",
+			Arches:   both,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(783),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     128,
+		},
+
+		// SKU: Q5HVB8NUA7UMHV4Y
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(60),
+			Mem:        8192,
+			VirtType:   &hvm,
+			Cost:       160,
+			Deprecated: true,
+		},
+
+		// SKU: Q85F79PK8VHHZT6X
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3247),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     531,
+		},
+
+		// SKU: UJB452HW969DQZFB
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1623),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     265,
+		},
+
+		// SKU: UMV7384WFS5N9T5F
+		// Instance family: Memory optimized
+		// Storage: 1 x 850
+		{
+			Name:       "m2.2xlarge",
+			Arches:     amd64,
+			CpuCores:   4,
+			CpuPower:   instances.CpuPower(400),
+			Mem:        35021,
+			VirtType:   &paravirtual,
+			Cost:       575,
+			Deprecated: true,
+		},
+
+		// SKU: URZU4GXQC7AT6RE9
+		// Instance family: Compute optimized
+		// Storage: 4 x 420
+		{
+			Name:       "c1.xlarge",
+			Arches:     amd64,
+			CpuCores:   8,
+			CpuPower:   instances.CpuPower(800),
+			Mem:        7168,
+			VirtType:   &paravirtual,
+			Cost:       632,
+			Deprecated: true,
+		},
+
+		// SKU: VWWQ7S3GZ9J8TF77
+		// Instance family: Storage optimized
+		// Storage: 3 x 2000 HDD
+		{
+			Name:     "d2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     844,
+		},
+
+		// SKU: XJ88E6MSR3AYHFXA
+		// Instance family: Compute optimized
+		// Storage: 2 x 160 SSD
+		{
+			Name:     "c3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6271),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     1020,
+		},
+
+		// SKU: XU2NYYPCRTK4T7CN
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      65536,
+			VirtType: &hvm,
+			Cost:     1391,
+		},
+
+		// SKU: YCYU3NQCQRYQ2TU7
+		// Instance family: Memory optimized
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "r3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     200,
+		},
+
+		// SKU: YJ2E4JTYGN2FMNQM
+		// Instance family: Compute optimized
+		// Storage: 4 x 840
+		{
+			Name:       "cc2.8xlarge",
+			Arches:     amd64,
+			CpuCores:   32,
+			CpuPower:   instances.CpuPower(11647),
+			Mem:        61952,
+			VirtType:   &hvm,
+			Cost:       2349,
+			Deprecated: true,
+		},
+
+		// SKU: YR67H6NVBRN37HRZ
+		// Instance family: Compute optimized
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "c3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3135),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     511,
+		},
+
+		// SKU: YUYNTU8AZ9MKK68V
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        2048,
+			VirtType:   &hvm,
+			Cost:       40,
+			Deprecated: true,
+		},
+	},
+
+	"ap-northeast-2": {
+
+		// SKU: 3MBNRY22Y6A2W6WY
+		// Instance family: General purpose
+		// Storage: 1 x 4 SSD
+		{
+			Name:     "m3.medium",
+			Arches:   amd64,
+			CpuCores: 1,
+			CpuPower: instances.CpuPower(350),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     91,
+		},
+
+		// SKU: 3UWMR4BVSMJ3PTQ5
+		// Instance family: Storage optimized
+		// Storage: 1 x 800 SSD
+		{
+			Name:     "i2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     1000,
+		},
+
+		// SKU: 45D7HY2M47KUYJXR
+		// Instance family: Compute optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "c3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(12543),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     1839,
+		},
+
+		// SKU: 5CB9VHZSJWQTZN3W
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(811),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     120,
+		},
+
+		// SKU: 5RC27Y2XYGFJVP7K
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     331,
+		},
+
+		// SKU: 65JJWWKAHFAMNF85
+		// Instance family: Memory optimized
+		// Storage: 2 x 1,920
+		{
+			Name:       "x1.32xlarge",
+			Arches:     amd64,
+			CpuCores:   128,
+			CpuPower:   instances.CpuPower(41216),
+			Mem:        1998848,
+			VirtType:   &hvm,
+			Cost:       19341,
+			Deprecated: true,
+		},
+
+		// SKU: 6K25ZNG5NAXQC5AB
+		// Instance family: GPU instance
+		// Storage: 1 x 60 SSD
+		{
+			Name:     "g2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2911),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     898,
+		},
+
+		// SKU: 6NSPY3BTJRX47KWG
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      65536,
+			VirtType: &hvm,
+			Cost:     1321,
+		},
+
+		// SKU: 6TYE4QER4XX5TSC5
+		// Instance family: Memory optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "r3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     3192,
+		},
+
+		// SKU: 6U3CMEPEAZEVZSV8
+		// Instance family: Memory optimized
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "r3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     200,
+		},
+
+		// SKU: 7GTTQXNXREPMU7WY
+		// Instance family: General purpose
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "m3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     366,
+		},
+
+		// SKU: 7MQ7AMJWV8BPWH88
+		// Instance family: Compute optimized
+		// Storage: 2 x 160 SSD
+		{
+			Name:     "c3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6271),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     919,
+		},
+
+		// SKU: 7VFMGFAWZ9QPBHST
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(40),
+			Mem:        4096,
+			VirtType:   &hvm,
+			Cost:       80,
+			Deprecated: true,
+		},
+
+		// SKU: 852A82DVHUAQRBUS
+		// Instance family: Storage optimized
+		// Storage: 3 x 2000 HDD
+		{
+			Name:     "d2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     844,
+		},
+
+		// SKU: 98ZFCFAZXXRGF7CG
+		// Instance family: GPU instance
+		// Storage: 2 x 120 SSD
+		{
+			Name:     "g2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11647),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     3592,
+		},
+
+		// SKU: 9XQJDHCZD834J68K
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(672),
+			Mem:      8192,
+			VirtType: &hvm,
+			Cost:     165,
+		},
+
+		// SKU: BHS4CH7UVYY7QN2H
+		// Instance family: Storage optimized
+		// Storage: 4 x 800 SSD
+		{
+			Name:     "i2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     4002,
+		},
+
+		// SKU: BQDV4FCR9QJEQHQS
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6495),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     955,
+		},
+
+		// SKU: BRTSXYEA84EMVTVE
+		// Instance family: Memory optimized
+		// Storage: 1 x 160 SSD
+		{
+			Name:     "r3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     798,
+		},
+
+		// SKU: CEU6V4KXWNQA6DD3
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(60),
+			Mem:        8192,
+			VirtType:   &hvm,
+			Cost:       160,
+			Deprecated: true,
+		},
+
+		// SKU: CFXCUT5A22XNZ43Y
+		// Instance family: Compute optimized
+		// Storage: 2 x 16 SSD
+		{
+			Name:     "c3.large",
+			Arches:   both,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(783),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     115,
+		},
+
+		// SKU: DTEVN35HD43BM5ST
+		// Instance family: General purpose
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "m3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     732,
+		},
+
+		// SKU: G6ATM6E28ZDDBNCE
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1623),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     239,
+		},
+
+		// SKU: HUNMAJP6W7UHJAAG
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(14615),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     1910,
+		},
+
+		// SKU: JZYQ7EEFZRRYYC5S
+		// Instance family: Storage optimized
+		// Storage: 6 x 2000 HDD
+		{
+			Name:     "d2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     1688,
+		},
+
+		// SKU: K79C7JVTDAKRA842
+		// Instance family: General purpose
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "m3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     183,
+		},
+
+		// SKU: KGFSNH7UYJEDWTQQ
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.nano",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(5),
+			Mem:        512,
+			VirtType:   &hvm,
+			Cost:       10,
+			Deprecated: true,
+		},
+
+		// SKU: KUKJATN7HCNF2UFT
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     660,
+		},
+
+		// SKU: KW2ZPRSC298WFJ94
+		// Instance family: Memory optimized
+		// Storage: 1 x 80 SSD
+		{
+			Name:     "r3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     399,
+		},
+
+		// SKU: MXYJRCMDAHMFNUAB
+		// Instance family: Memory optimized
+		// Storage: 1 x 320 SSD
+		{
+			Name:     "r3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     1596,
+		},
+
+		// SKU: N6M9WS3F7XHZ2TXS
+		// Instance family: Storage optimized
+		// Storage: 24 x 2000 HDD
+		{
+			Name:     "d2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(12096),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     6752,
+		},
+
+		// SKU: P75FYMSDEYRH34VG
+		// Instance family: Storage optimized
+		// Storage: 2 x 800 SSD
+		{
+			Name:     "i2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     2001,
+		},
+
+		// SKU: PBRNAGPS98SBSDRS
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3247),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     478,
+		},
+
+		// SKU: PSBR72NYUMRACH7E
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        2048,
+			VirtType:   &hvm,
+			Cost:       40,
+			Deprecated: true,
+		},
+
+		// SKU: R7GFV82WRF8QTZYP
+		// Instance family: Compute optimized
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "c3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1567),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     230,
+		},
+
+		// SKU: RM2KHQ9S45BW6B7M
+		// Instance family: Compute optimized
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "c3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3135),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     460,
+		},
+
+		// SKU: WFBUYA3WPRPDVNEH
+		// Instance family: Storage optimized
+		// Storage: 12 x 2000 HDD
+		{
+			Name:     "d2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     3376,
+		},
+
+		// SKU: XCB734X2BM8PZ77F
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.10xlarge",
+			Arches:   amd64,
+			CpuCores: 40,
+			CpuPower: instances.CpuPower(13440),
+			Mem:      163840,
+			VirtType: &hvm,
+			Cost:     3303,
+		},
+
+		// SKU: YG3C8Z588MN6BXGW
+		// Instance family: Storage optimized
+		// Storage: 8 x 800 SSD
+		{
+			Name:     "i2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     8004,
+		},
+
+		// SKU: YMCDAKZ8EVGJJDRM
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(10),
+			Mem:        1024,
+			VirtType:   &hvm,
+			Cost:       20,
+			Deprecated: true,
+		},
+	},
+
+	"ap-south-1": {
+
+		// SKU: 2BHQP3WKDU9A2DSC
+		// Instance family: Storage optimized
+		// Storage: 3 x 2000 HDD
+		{
+			Name:     "d2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     827,
+		},
+
+		// SKU: 2T64ZB6E54RM9GA2
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(14615),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     2195,
+		},
+
+		// SKU: 3P5UPPTRJJQ6TKSU
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(672),
+			Mem:      8192,
+			VirtType: &hvm,
+			Cost:     169,
+		},
+
+		// SKU: 5N383TJKMC5FSCKD
+		// Instance family: Memory optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "r3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     3032,
+		},
+
+		// SKU: 673MQ62EKV4VCTT8
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.nano",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(5),
+			Mem:        512,
+			VirtType:   &hvm,
+			Cost:       9,
+			Deprecated: true,
+		},
+
+		// SKU: 6WAFB82CP99WZXD9
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        2048,
+			VirtType:   &hvm,
+			Cost:       38,
+			Deprecated: true,
+		},
+
+		// SKU: 7HYM8MHNNFW2NN6T
+		// Instance family: Storage optimized
+		// Storage: 4 x 800 SSD
+		{
+			Name:     "i2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     3867,
+		},
+
+		// SKU: 8BG4ECAGKKNWYDVU
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3247),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     549,
+		},
+
+		// SKU: 8U4NEK2635VB7NHD
+		// Instance family: Memory optimized
+		// Storage: 1 x 160 SSD
+		{
+			Name:     "r3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     758,
+		},
+
+		// SKU: 9Q2KYTZY2YDQZCM8
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     337,
+		},
+
+		// SKU: AFU2HU8WVY9T6QAK
+		// Instance family: Storage optimized
+		// Storage: 2 x 800 SSD
+		{
+			Name:     "i2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     1933,
+		},
+
+		// SKU: CA3Y8U6BUYR54NVM
+		// Instance family: Memory optimized
+		// Storage: 1 x 320 SSD
+		{
+			Name:     "r3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     1516,
+		},
+
+		// SKU: FQ7FVC9B3R8RBBXA
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.10xlarge",
+			Arches:   amd64,
+			CpuCores: 40,
+			CpuPower: instances.CpuPower(13440),
+			Mem:      163840,
+			VirtType: &hvm,
+			Cost:     3375,
+		},
+
+		// SKU: G4283CPK5MQ5QQ2A
+		// Instance family: Storage optimized
+		// Storage: 8 x 800 SSD
+		{
+			Name:     "i2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     7733,
+		},
+
+		// SKU: G69QDQNHE5SR7846
+		// Instance family: Storage optimized
+		// Storage: 12 x 2000 HDD
+		{
+			Name:     "d2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     3306,
+		},
+
+		// SKU: GG7UHJRKQSGP364T
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(60),
+			Mem:        8192,
+			VirtType:   &hvm,
+			Cost:       152,
+			Deprecated: true,
+		},
+
+		// SKU: GGTGBU32M4STN8YS
+		// Instance family: Storage optimized
+		// Storage: 6 x 2000 HDD
+		{
+			Name:     "d2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     1653,
+		},
+
+		// SKU: JXAMSKC2ZXKCA37S
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(10),
+			Mem:        1024,
+			VirtType:   &hvm,
+			Cost:       19,
+			Deprecated: true,
+		},
+
+		// SKU: KFTR5EQCGQ6AUYXP
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(811),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     137,
+		},
+
+		// SKU: MKNAAVQMBXXNTPQQ
+		// Instance family: Memory optimized
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "r3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     190,
+		},
+
+		// SKU: NH9KFSA26V6F5742
+		// Instance family: Storage optimized
+		// Storage: 24 x 2000 HDD
+		{
+			Name:     "d2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(12096),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     6612,
+		},
+
+		// SKU: Q5HCF2WEXJ7TRHNF
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(40),
+			Mem:        4096,
+			VirtType:   &hvm,
+			Cost:       76,
+			Deprecated: true,
+		},
+
+		// SKU: TEV889FX73ZKZ8TU
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6495),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     1097,
+		},
+
+		// SKU: TPTBS44NNEJN3HUG
+		// Instance family: Storage optimized
+		// Storage: 1 x 800 SSD
+		{
+			Name:     "i2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     967,
+		},
+
+		// SKU: TPVVGJC63DQYU7EJ
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1623),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     275,
+		},
+
+		// SKU: YKUFHRZDYCT9JG3A
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      65536,
+			VirtType: &hvm,
+			Cost:     1350,
+		},
+
+		// SKU: ZEEU583UYCZMVJZV
+		// Instance family: Memory optimized
+		// Storage: 1 x 80 SSD
+		{
+			Name:     "r3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     379,
+		},
+
+		// SKU: ZVMAFPQR3NKB6VVP
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     675,
+		},
+	},
+
+	"ap-southeast-1": {
+
+		// SKU: 2B4AFZB6SYHMPZGS
+		// Instance family: General purpose
+		// Storage: 2 x 420
+		{
+			Name:       "m1.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        7680,
+			VirtType:   &paravirtual,
+			Cost:       233,
+			Deprecated: true,
+		},
+
+		// SKU: 39ZR86RYWKDSK82K
+		// Instance family: Memory optimized
+		// Storage: 1 x 420
+		{
+			Name:       "m2.xlarge",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        17511,
+			VirtType:   &paravirtual,
+			Cost:       296,
+			Deprecated: true,
+		},
+
+		// SKU: 3ZUGJVTA8NWE9NZT
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6495),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     1155,
+		},
+
+		// SKU: 57M4AZ4NRYTPT6NM
+		// Instance family: Memory optimized
+		// Storage: 2 x 1,920
+		{
+			Name:       "x1.32xlarge",
+			Arches:     amd64,
+			CpuCores:   128,
+			CpuPower:   instances.CpuPower(41216),
+			Mem:        1998848,
+			VirtType:   &hvm,
+			Cost:       19341,
+			Deprecated: true,
+		},
+
+		// SKU: 5ES8X7PS795W6ZD4
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      65536,
+			VirtType: &hvm,
+			Cost:     1421,
+		},
+
+		// SKU: 6R4QVUNHTJVS9J2S
+		// Instance family: General purpose
+		// Storage: 1 x 160
+		{
+			Name:       "m1.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(100),
+			Mem:        1741,
+			VirtType:   &paravirtual,
+			Cost:       58,
+			Deprecated: true,
+		},
+
+		// SKU: 7FQD2RCMJSS57GFA
+		// Instance family: General purpose
+		// Storage: 1 x 410
+		{
+			Name:       "m1.medium",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(100),
+			Mem:        3840,
+			VirtType:   &paravirtual,
+			Cost:       117,
+			Deprecated: true,
+		},
+
+		// SKU: 7QHAUE39SCU6N9N9
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        2048,
+			VirtType:   &hvm,
+			Cost:       40,
+			Deprecated: true,
+		},
+
+		// SKU: 7TMGTEJPM5UPWQ8X
+		// Instance family: General purpose
+		// Storage: 4 x 420
+		{
+			Name:       "m1.xlarge",
+			Arches:     amd64,
+			CpuCores:   4,
+			CpuPower:   instances.CpuPower(400),
+			Mem:        15360,
+			VirtType:   &paravirtual,
+			Cost:       467,
+			Deprecated: true,
+		},
+
+		// SKU: 8E9KB9CNE94Z4AHE
+		// Instance family: Storage optimized
+		// Storage: 4 x 800 SSD
+		{
+			Name:     "i2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     4070,
+		},
+
+		// SKU: 8V5MYBMPUD434579
+		// Instance family: Compute optimized
+		// Storage: 4 x 420
+		{
+			Name:       "c1.xlarge",
+			Arches:     amd64,
+			CpuCores:   8,
+			CpuPower:   instances.CpuPower(800),
+			Mem:        7168,
+			VirtType:   &paravirtual,
+			Cost:       655,
+			Deprecated: true,
+		},
+
+		// SKU: 8VCD85YY26XCKZDE
+		// Instance family: General purpose
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "m3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     392,
+		},
+
+		// SKU: ABMNUJ6SQ7A595A4
+		// Instance family: Compute optimized
+		// Storage: 2 x 16 SSD
+		{
+			Name:     "c3.large",
+			Arches:   both,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(783),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     132,
+		},
+
+		// SKU: AEUJF75AZR2WPVWK
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.10xlarge",
+			Arches:   amd64,
+			CpuCores: 40,
+			CpuPower: instances.CpuPower(13440),
+			Mem:      163840,
+			VirtType: &hvm,
+			Cost:     3553,
+		},
+
+		// SKU: B9DFHMNNN499Z259
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(672),
+			Mem:      8192,
+			VirtType: &hvm,
+			Cost:     178,
+		},
+
+		// SKU: DK6FJW8STXUGW6PA
+		// Instance family: GPU instance
+		// Storage: 2 x 120 SSD
+		{
+			Name:     "g2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11647),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     4000,
+		},
+
+		// SKU: DKFKKEAW78H8X64T
+		// Instance family: Storage optimized
+		// Storage: 2 x 800 SSD
+		{
+			Name:     "i2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     2035,
+		},
+
+		// SKU: DTZY5KW9NPT6V929
+		// Instance family: Storage optimized
+		// Storage: 3 x 2000 HDD
+		{
+			Name:     "d2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     870,
+		},
+
+		// SKU: EERGZVYFKRBMSYKW
+		// Instance family: Storage optimized
+		// Storage: 24 x 2000
+		{
+			Name:       "hs1.8xlarge",
+			Arches:     amd64,
+			CpuCores:   17,
+			CpuPower:   instances.CpuPower(4760),
+			Mem:        119808,
+			VirtType:   &hvm,
+			Cost:       5570,
+			Deprecated: true,
+		},
+
+		// SKU: EEUHF7PCXDQT2MYE
+		// Instance family: Storage optimized
+		// Storage: 24 x 2000 HDD
+		{
+			Name:     "d2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(12096),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     6960,
+		},
+
+		// SKU: EV2HH2XUX6RZEAW3
+		// Instance family: Memory optimized
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "r3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     200,
+		},
+
+		// SKU: G9Z5RTPAVX5KWH4Z
+		// Instance family: Compute optimized
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "c3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1567),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     265,
+		},
+
+		// SKU: GCVKBN38AXXGHBQH
+		// Instance family: Storage optimized
+		// Storage: 1 x 800 SSD
+		{
+			Name:     "i2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     1018,
+		},
+
+		// SKU: J23MFJ7UXYN9HFKS
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(40),
+			Mem:        4096,
+			VirtType:   &hvm,
+			Cost:       80,
+			Deprecated: true,
+		},
+
+		// SKU: J65Z38YCBYKP7Q49
+		// Instance family: Micro instances
+		// Storage: EBS only
+		{
+			Name:       "t1.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        628,
+			VirtType:   &paravirtual,
+			Cost:       20,
+			Deprecated: true,
+		},
+
+		// SKU: JDH4WM7E92WUS9JS
+		// Instance family: Memory optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "r3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     3192,
+		},
+
+		// SKU: KCZD349CGXR5DRQ3
+		// Instance family: Memory optimized
+		// Storage: 1 x 320 SSD
+		{
+			Name:     "r3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     1596,
+		},
+
+		// SKU: M5ZT2V2ZMSBCEB2Q
+		// Instance family: Storage optimized
+		// Storage: 12 x 2000 HDD
+		{
+			Name:     "d2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     3480,
+		},
+
+		// SKU: N55SZ6XU92JF33VX
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     355,
+		},
+
+		// SKU: P6BPTANASQKJ8FJX
+		// Instance family: Memory optimized
+		// Storage: 1 x 80 SSD
+		{
+			Name:     "r3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     399,
+		},
+
+		// SKU: PJ8AKRU5VVMS9DFN
+		// Instance family: Compute optimized
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "c3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3135),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     529,
+		},
+
+		// SKU: QB3EG2XVBQ5BYA5F
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(811),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     144,
+		},
+
+		// SKU: R8K75VHRAADAJJ2W
+		// Instance family: General purpose
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "m3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     784,
+		},
+
+		// SKU: RZV9MRNEARCGY297
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(10),
+			Mem:        1024,
+			VirtType:   &hvm,
+			Cost:       20,
+			Deprecated: true,
+		},
+
+		// SKU: SKTEJ2QN2YW8UFKF
+		// Instance family: Storage optimized
+		// Storage: 6 x 2000 HDD
+		{
+			Name:     "d2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     1740,
+		},
+
+		// SKU: SMHSRASDZ66J6CC3
+		// Instance family: Memory optimized
+		// Storage: 1 x 160 SSD
+		{
+			Name:     "r3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     798,
+		},
+
+		// SKU: T2PU2JF8K7NGF3AH
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.nano",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(5),
+			Mem:        512,
+			VirtType:   &hvm,
+			Cost:       10,
+			Deprecated: true,
+		},
+
+		// SKU: TYGKARPH33A4B8DT
+		// Instance family: Memory optimized
+		// Storage: 1 x 850
+		{
+			Name:       "m2.2xlarge",
+			Arches:     amd64,
+			CpuCores:   4,
+			CpuPower:   instances.CpuPower(400),
+			Mem:        35021,
+			VirtType:   &paravirtual,
+			Cost:       592,
+			Deprecated: true,
+		},
+
+		// SKU: U9CPUKN22CXMPGRV
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1623),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     289,
+		},
+
+		// SKU: UKF69K7GTUQKKRPH
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     711,
+		},
+
+		// SKU: UKGPAABCGR48DYC4
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3247),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     578,
+		},
+
+		// SKU: UKY8RWKR7MVYC863
+		// Instance family: Compute optimized
+		// Storage: 2 x 160 SSD
+		{
+			Name:     "c3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6271),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     1058,
+		},
+
+		// SKU: UYUWYNASFB3J75S6
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(60),
+			Mem:        8192,
+			VirtType:   &hvm,
+			Cost:       160,
+			Deprecated: true,
+		},
+
+		// SKU: VE5MWWHUXS2VR8DV
+		// Instance family: Storage optimized
+		// Storage: 8 x 800 SSD
+		{
+			Name:     "i2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     8140,
+		},
+
+		// SKU: VVKTWPMARM4HESXU
+		// Instance family: GPU instance
+		// Storage: 1 x 60 SSD
+		{
+			Name:     "g2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2911),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     1000,
+		},
+
+		// SKU: XUVJRQ9MSAQKDXE9
+		// Instance family: Compute optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "c3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(12543),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     2117,
+		},
+
+		// SKU: Y3RWQDFC7G8TZ3A8
+		// Instance family: Memory optimized
+		// Storage: 2 x 840
+		{
+			Name:       "m2.4xlarge",
+			Arches:     amd64,
+			CpuCores:   8,
+			CpuPower:   instances.CpuPower(800),
+			Mem:        70042,
+			VirtType:   &paravirtual,
+			Cost:       1183,
+			Deprecated: true,
+		},
+
+		// SKU: YDP6BX3WNNZ488BZ
+		// Instance family: Compute optimized
+		// Storage: 1 x 350
+		{
+			Name:       "c1.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        1741,
+			VirtType:   &paravirtual,
+			Cost:       164,
+			Deprecated: true,
+		},
+
+		// SKU: YSKUUH777M98DWE4
+		// Instance family: General purpose
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "m3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     196,
+		},
+
+		// SKU: Z3DQKNTFUZ68H6TT
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(14615),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     2310,
+		},
+
+		// SKU: ZAGTVD3ADUUPS6QV
+		// Instance family: General purpose
+		// Storage: 1 x 4 SSD
+		{
+			Name:     "m3.medium",
+			Arches:   amd64,
+			CpuCores: 1,
+			CpuPower: instances.CpuPower(350),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     98,
+		},
+	},
+
+	"ap-southeast-2": {
+
+		// SKU: 296YCXVCWAKPXKRE
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     673,
+		},
+
+		// SKU: 2PKSXUFC38ZY888Q
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(811),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     137,
+		},
+
+		// SKU: 46ZVWU6WX68NZCE7
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(14615),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     2195,
+		},
+
+		// SKU: 4PRF9CZZBT3AM9D4
+		// Instance family: Memory optimized
+		// Storage: 2 x 840
+		{
+			Name:       "m2.4xlarge",
+			Arches:     amd64,
+			CpuCores:   8,
+			CpuPower:   instances.CpuPower(800),
+			Mem:        70042,
+			VirtType:   &paravirtual,
+			Cost:       1183,
+			Deprecated: true,
+		},
+
+		// SKU: 5BKJJZ77BSJPMR4D
+		// Instance family: Storage optimized
+		// Storage: 24 x 2000
+		{
+			Name:       "hs1.8xlarge",
+			Arches:     amd64,
+			CpuCores:   17,
+			CpuPower:   instances.CpuPower(4760),
+			Mem:        119808,
+			VirtType:   &hvm,
+			Cost:       5570,
+			Deprecated: true,
+		},
+
+		// SKU: 66QVG55FP52WHCFH
+		// Instance family: Memory optimized
+		// Storage: 2 x 1,920
+		{
+			Name:       "x1.32xlarge",
+			Arches:     amd64,
+			CpuCores:   128,
+			CpuPower:   instances.CpuPower(41216),
+			Mem:        1998848,
+			VirtType:   &hvm,
+			Cost:       19341,
+			Deprecated: true,
+		},
+
+		// SKU: 69UM5U8QFXRAU255
+		// Instance family: General purpose
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "m3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     372,
+		},
+
+		// SKU: 6CK52R5BRMQEVGRW
+		// Instance family: Storage optimized
+		// Storage: 2 x 800 SSD
+		{
+			Name:     "i2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     2035,
+		},
+
+		// SKU: 6PB95M6GG8CNXMMR
+		// Instance family: Memory optimized
+		// Storage: 1 x 850
+		{
+			Name:       "m2.2xlarge",
+			Arches:     amd64,
+			CpuCores:   4,
+			CpuPower:   instances.CpuPower(400),
+			Mem:        35021,
+			VirtType:   &paravirtual,
+			Cost:       592,
+			Deprecated: true,
+		},
+
+		// SKU: 6UHS7YAMM8JY7X52
+		// Instance family: Storage optimized
+		// Storage: 4 x 800 SSD
+		{
+			Name:     "i2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     4070,
+		},
+
+		// SKU: 6UMTMKVFBXENW3BF
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(672),
+			Mem:      8192,
+			VirtType: &hvm,
+			Cost:     168,
+		},
+
+		// SKU: 6WEMUEK6JNZU6PTC
+		// Instance family: General purpose
+		// Storage: 1 x 4 SSD
+		{
+			Name:     "m3.medium",
+			Arches:   amd64,
+			CpuCores: 1,
+			CpuPower: instances.CpuPower(350),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     93,
+		},
+
+		// SKU: 7NYHPHSMD45SYSNN
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(10),
+			Mem:        1024,
+			VirtType:   &hvm,
+			Cost:       20,
+			Deprecated: true,
+		},
+
+		// SKU: 8A5X9KQR4YKYYXCQ
+		// Instance family: General purpose
+		// Storage: 4 x 420
+		{
+			Name:       "m1.xlarge",
+			Arches:     amd64,
+			CpuCores:   4,
+			CpuPower:   instances.CpuPower(400),
+			Mem:        15360,
+			VirtType:   &paravirtual,
+			Cost:       467,
+			Deprecated: true,
+		},
+
+		// SKU: 8XZUT4AHDH972AME
+		// Instance family: Compute optimized
+		// Storage: 2 x 16 SSD
+		{
+			Name:     "c3.large",
+			Arches:   both,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(783),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     132,
+		},
+
+		// SKU: 9CYSN2TKZDN6GFWQ
+		// Instance family: Micro instances
+		// Storage: EBS only
+		{
+			Name:       "t1.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        628,
+			VirtType:   &paravirtual,
+			Cost:       20,
+			Deprecated: true,
+		},
+
+		// SKU: C4A5RM72TUGX8R5D
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      65536,
+			VirtType: &hvm,
+			Cost:     1345,
+		},
+
+		// SKU: CMDB58FT3PAJJNGN
+		// Instance family: Compute optimized
+		// Storage: 4 x 420
+		{
+			Name:       "c1.xlarge",
+			Arches:     amd64,
+			CpuCores:   8,
+			CpuPower:   instances.CpuPower(800),
+			Mem:        7168,
+			VirtType:   &paravirtual,
+			Cost:       655,
+			Deprecated: true,
+		},
+
+		// SKU: CP3U32VDAT67RT9R
+		// Instance family: Storage optimized
+		// Storage: 6 x 2000 HDD
+		{
+			Name:     "d2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     1740,
+		},
+
+		// SKU: D29U26UAEX6WK4TW
+		// Instance family: General purpose
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "m3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     745,
+		},
+
+		// SKU: DBMRRDDSPZZKNV49
+		// Instance family: Memory optimized
+		// Storage: 1 x 320 SSD
+		{
+			Name:     "r3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     1596,
+		},
+
+		// SKU: DS7EYGXHAG6T6NTV
+		// Instance family: GPU instance
+		// Storage: 1 x 60 SSD
+		{
+			Name:     "g2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2911),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     898,
+		},
+
+		// SKU: E6JQJZ8BQHCG328E
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        2048,
+			VirtType:   &hvm,
+			Cost:       40,
+			Deprecated: true,
+		},
+
+		// SKU: F9BAR5QA2VU3ZTBF
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6495),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     1097,
+		},
+
+		// SKU: FFBDA7VFHVPEJXS6
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3247),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     549,
+		},
+
+		// SKU: FJURXZQ9HT9HN2YJ
+		// Instance family: Storage optimized
+		// Storage: 1 x 800 SSD
+		{
+			Name:     "i2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     1018,
+		},
+
+		// SKU: FYMCPD2A3YBTSUPQ
+		// Instance family: Compute optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "c3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(12543),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     2117,
+		},
+
+		// SKU: GKVR3QEC5B7WJXTD
+		// Instance family: Memory optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "r3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     3192,
+		},
+
+		// SKU: HDSPKHDAUP2HXQTR
+		// Instance family: Storage optimized
+		// Storage: 3 x 2000 HDD
+		{
+			Name:     "d2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     870,
+		},
+
+		// SKU: HHJGN8MDU3U6DFE5
+		// Instance family: General purpose
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "m3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     186,
+		},
+
+		// SKU: JT2PVSWTGS2BMV4D
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(60),
+			Mem:        8192,
+			VirtType:   &hvm,
+			Cost:       160,
+			Deprecated: true,
+		},
+
+		// SKU: KEVDJ9YEEGJZZGDS
+		// Instance family: Storage optimized
+		// Storage: 24 x 2000 HDD
+		{
+			Name:     "d2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(12096),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     6960,
+		},
+
+		// SKU: KNJZFWCSBKY8N4NF
+		// Instance family: Memory optimized
+		// Storage: 1 x 80 SSD
+		{
+			Name:     "r3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     399,
+		},
+
+		// SKU: KWTW9RNYJG6GG3J2
+		// Instance family: General purpose
+		// Storage: 2 x 420
+		{
+			Name:       "m1.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        7680,
+			VirtType:   &paravirtual,
+			Cost:       233,
+			Deprecated: true,
+		},
+
+		// SKU: KYSFQQQ4H28QEHFQ
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.nano",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(5),
+			Mem:        512,
+			VirtType:   &hvm,
+			Cost:       10,
+			Deprecated: true,
+		},
+
+		// SKU: MSGAHYMZTGGJN5WS
+		// Instance family: Storage optimized
+		// Storage: 12 x 2000 HDD
+		{
+			Name:     "d2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     3480,
+		},
+
+		// SKU: N32CG42C5KFN6GDH
+		// Instance family: Compute optimized
+		// Storage: 2 x 160 SSD
+		{
+			Name:     "c3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6271),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     1058,
+		},
+
+		// SKU: N3D6SQF6HU9ENSPR
+		// Instance family: Memory optimized
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "r3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     200,
+		},
+
+		// SKU: R8KMJWXSQ8BJC35M
+		// Instance family: Compute optimized
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "c3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3135),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     529,
+		},
+
+		// SKU: RAWDW374YPCAB65D
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     336,
+		},
+
+		// SKU: RW8353QQ8DWZ4WQD
+		// Instance family: Storage optimized
+		// Storage: 8 x 800 SSD
+		{
+			Name:     "i2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     8140,
+		},
+
+		// SKU: SPJKFAB8G379JD6R
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.10xlarge",
+			Arches:   amd64,
+			CpuCores: 40,
+			CpuPower: instances.CpuPower(13440),
+			Mem:      163840,
+			VirtType: &hvm,
+			Cost:     3363,
+		},
+
+		// SKU: T72BQ8E4ETD9K62R
+		// Instance family: Compute optimized
+		// Storage: 1 x 350
+		{
+			Name:       "c1.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        1741,
+			VirtType:   &paravirtual,
+			Cost:       164,
+			Deprecated: true,
+		},
+
+		// SKU: TD8NW4BSBCYU646U
+		// Instance family: GPU instance
+		// Storage: 2 x 120 SSD
+		{
+			Name:     "g2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11647),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     3592,
+		},
+
+		// SKU: TPJVBXMBFDUBJM83
+		// Instance family: General purpose
+		// Storage: 1 x 410
+		{
+			Name:       "m1.medium",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(100),
+			Mem:        3840,
+			VirtType:   &paravirtual,
+			Cost:       117,
+			Deprecated: true,
+		},
+
+		// SKU: V5SUYWWSC9HUZFWJ
+		// Instance family: Memory optimized
+		// Storage: 1 x 420
+		{
+			Name:       "m2.xlarge",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        17511,
+			VirtType:   &paravirtual,
+			Cost:       296,
+			Deprecated: true,
+		},
+
+		// SKU: VM2PFN8ME9595UGP
+		// Instance family: General purpose
+		// Storage: 1 x 160
+		{
+			Name:       "m1.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(100),
+			Mem:        1741,
+			VirtType:   &paravirtual,
+			Cost:       58,
+			Deprecated: true,
+		},
+
+		// SKU: WNYWP7QUJ3MU8NVV
+		// Instance family: Memory optimized
+		// Storage: 1 x 160 SSD
+		{
+			Name:     "r3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     798,
+		},
+
+		// SKU: XD4VKMMZMCMZYFWJ
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1623),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     275,
+		},
+
+		// SKU: XPAKDV3PWHYTJU3X
+		// Instance family: Compute optimized
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "c3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1567),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     265,
+		},
+
+		// SKU: ZNG78GP248PZPM6R
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(40),
+			Mem:        4096,
+			VirtType:   &hvm,
+			Cost:       80,
+			Deprecated: true,
+		},
+	},
+
+	"eu-central-1": {
+
+		// SKU: 3AFDFDJ9FGMNBBUZ
+		// Instance family: Memory optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "r3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     3201,
+		},
+
+		// SKU: 3KCGMZRVWDY4AC5R
+		// Instance family: Memory optimized
+		// Storage: 1 x 320 SSD
+		{
+			Name:     "r3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     1600,
+		},
+
+		// SKU: 4TT65SC5HVYUSGR2
+		// Instance family: Storage optimized
+		// Storage: 4 x 800 SSD
+		{
+			Name:     "i2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     4051,
+		},
+
+		// SKU: 5P7657GQ9EZ2Z4ZY
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(40),
+			Mem:        4096,
+			VirtType:   &hvm,
+			Cost:       60,
+			Deprecated: true,
+		},
+
+		// SKU: 5RNA3KEVYJW8UJWT
+		// Instance family: Storage optimized
+		// Storage: 12 x 2000 HDD
+		{
+			Name:     "d2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     3176,
+		},
+
+		// SKU: 5ZZCF2WTD3M2NVHT
+		// Instance family: General purpose
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "m3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     315,
+		},
+
+		// SKU: 686NEEYZAPY5GJ8N
+		// Instance family: Compute optimized
+		// Storage: 2 x 16 SSD
+		{
+			Name:     "c3.large",
+			Arches:   both,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(783),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     129,
+		},
+
+		// SKU: 6PSHDB8D545JMBBD
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.nano",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(5),
+			Mem:        512,
+			VirtType:   &hvm,
+			Cost:       7,
+			Deprecated: true,
+		},
+
+		// SKU: 6Y959B8MKQZ55MGT
+		// Instance family: Storage optimized
+		// Storage: 6 x 2000 HDD
+		{
+			Name:     "d2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     1588,
+		},
+
+		// SKU: 7EJH5CWEXABPY2ST
+		// Instance family: Memory optimized
+		// Storage: 2 x 1,920
+		{
+			Name:       "x1.32xlarge",
+			Arches:     amd64,
+			CpuCores:   128,
+			CpuPower:   instances.CpuPower(41216),
+			Mem:        1998848,
+			VirtType:   &hvm,
+			Cost:       18674,
+			Deprecated: true,
+		},
+
+		// SKU: 7W6DNQ55YG9FCPXZ
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(60),
+			Mem:        8192,
+			VirtType:   &hvm,
+			Cost:       120,
+			Deprecated: true,
+		},
+
+		// SKU: 8KTQAHWA58GUHDGC
+		// Instance family: General purpose
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "m3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     158,
+		},
+
+		// SKU: ABFDCPB959KUGRH8
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(672),
+			Mem:      8192,
+			VirtType: &hvm,
+			Cost:     143,
+		},
+
+		// SKU: ATHMXFEBFCM8TPWK
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6495),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     1069,
+		},
+
+		// SKU: C2EDZ5DQN8NMN54X
+		// Instance family: GPU instance
+		// Storage: 1 x 60 SSD
+		{
+			Name:     "g2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2911),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     772,
+		},
+
+		// SKU: CDQ3VSAVRNG39R6V
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     570,
+		},
+
+		// SKU: CNP4PV4Y2J8YZVAR
+		// Instance family: General purpose
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "m3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     632,
+		},
+
+		// SKU: CU49Z77S6UH36JXW
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        2048,
+			VirtType:   &hvm,
+			Cost:       30,
+			Deprecated: true,
+		},
+
+		// SKU: D8BFUEFHTHMN4XUY
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(14615),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     2138,
+		},
+
+		// SKU: EF7GKFKJ3Y5DM7E9
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     285,
+		},
+
+		// SKU: ER456JE239VN5TQY
+		// Instance family: Memory optimized
+		// Storage: 1 x 80 SSD
+		{
+			Name:     "r3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     400,
+		},
+
+		// SKU: F5FY39C3HWRVW8M7
+		// Instance family: Storage optimized
+		// Storage: 24 x 2000 HDD
+		{
+			Name:     "d2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(12096),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     6352,
+		},
+
+		// SKU: FECZ7UBC3GFUYSJC
+		// Instance family: Storage optimized
+		// Storage: 2 x 800 SSD
+		{
+			Name:     "i2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     2025,
+		},
+
+		// SKU: FXJNETA7Z34Z9BAR
+		// Instance family: Storage optimized
+		// Storage: 3 x 2000 HDD
+		{
+			Name:     "d2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     794,
+		},
+
+		// SKU: GDZZPNEEZXAN7X9J
+		// Instance family: General purpose
+		// Storage: 1 x 4 SSD
+		{
+			Name:     "m3.medium",
+			Arches:   amd64,
+			CpuCores: 1,
+			CpuPower: instances.CpuPower(350),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     79,
+		},
+
+		// SKU: HW3SH7C5H3K3MV7E
+		// Instance family: Compute optimized
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "c3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1567),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     258,
+		},
+
+		// SKU: JG83GAMRHT9DJ8TH
+		// Instance family: Memory optimized
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "r3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     200,
+		},
+
+		// SKU: JGXEWM5NJCZJPHGG
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      65536,
+			VirtType: &hvm,
+			Cost:     1140,
+		},
+
+		// SKU: KYFX85FCPCCT57BD
+		// Instance family: Compute optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "c3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(12543),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     2064,
+		},
+
+		// SKU: MB3JDB58W76ZHFT8
+		// Instance family: Compute optimized
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "c3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3135),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     516,
+		},
+
+		// SKU: MTQWAHX8C4T4FYVW
+		// Instance family: Memory optimized
+		// Storage: 1 x 160 SSD
+		{
+			Name:     "r3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     800,
+		},
+
+		// SKU: N2333QQ45Q3K9RT9
+		// Instance family: Storage optimized
+		// Storage: 1 x 800 SSD
+		{
+			Name:     "i2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     1012,
+		},
+
+		// SKU: N7WSYHVUT72KMK3V
+		// Instance family: Compute optimized
+		// Storage: 2 x 160 SSD
+		{
+			Name:     "c3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6271),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     1032,
+		},
+
+		// SKU: NZS3Z83VUDZA9SPY
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3247),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     534,
+		},
+
+		// SKU: Q5D9K2QEBW7SS9YP
+		// Instance family: GPU instance
+		// Storage: 2 x 120 SSD
+		{
+			Name:     "g2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11647),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     3088,
+		},
+
+		// SKU: SMTUMBHX6YKRBJQB
+		// Instance family: Storage optimized
+		// Storage: 8 x 800 SSD
+		{
+			Name:     "i2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     8102,
+		},
+
+		// SKU: T9GCN3NZ9U6N5BGN
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(10),
+			Mem:        1024,
+			VirtType:   &hvm,
+			Cost:       15,
+			Deprecated: true,
+		},
+
+		// SKU: WWTVB5GY85P5FGNW
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(811),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     134,
+		},
+
+		// SKU: XWVCP8TVZ3EZXHJT
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.10xlarge",
+			Arches:   amd64,
+			CpuCores: 40,
+			CpuPower: instances.CpuPower(13440),
+			Mem:      163840,
+			VirtType: &hvm,
+			Cost:     2850,
+		},
+
+		// SKU: ZAC36C46HPYXADA7
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1623),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     267,
+		},
+	},
+
+	"eu-west-1": {
+
+		// SKU: 2D5G3BCXGXH9GCH3
+		// Instance family: Memory optimized
+		// Storage: 2 x 1,920
+		{
+			Name:       "x1.32xlarge",
+			Arches:     amd64,
+			CpuCores:   128,
+			CpuPower:   instances.CpuPower(41216),
+			Mem:        1998848,
+			VirtType:   &hvm,
+			Cost:       16006,
+			Deprecated: true,
+		},
+
+		// SKU: 2SX63SRBXZK94TSA
+		// Instance family: Storage optimized
+		// Storage: 6 x 2000 HDD
+		{
+			Name:     "d2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     1470,
+		},
+
+		// SKU: 3H8WR8FBAE4DWNRB
+		// Instance family: GPU instance
+		// Storage: 2 x 840
+		{
+			Name:     "cg1.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(1600),
+			Mem:      23040,
+			VirtType: &hvm,
+			Cost:     2360,
+		},
+
+		// SKU: 4G2Z3WVSPDEGMKFH
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(60),
+			Mem:        8192,
+			VirtType:   &hvm,
+			Cost:       112,
+			Deprecated: true,
+		},
+
+		// SKU: 6FU9JEK79WWSARQ9
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     264,
+		},
+
+		// SKU: 6HX9NKE3BQ5V3PMJ
+		// Instance family: Storage optimized
+		// Storage: 12 x 2000 HDD
+		{
+			Name:     "d2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     2940,
+		},
+
+		// SKU: 7X4K64YA59VZZAC3
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(672),
+			Mem:      8192,
+			VirtType: &hvm,
+			Cost:     132,
+		},
+
+		// SKU: 8FFUWN2ESZYSB84N
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     528,
+		},
+
+		// SKU: 926EPQHVQ6AGDX5P
+		// Instance family: Compute optimized
+		// Storage: 2 x 160 SSD
+		{
+			Name:     "c3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6271),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     956,
+		},
+
+		// SKU: 9QYQQRQ9FD9YCPNB
+		// Instance family: General purpose
+		// Storage: 4 x 420
+		{
+			Name:       "m1.xlarge",
+			Arches:     amd64,
+			CpuCores:   4,
+			CpuPower:   instances.CpuPower(400),
+			Mem:        15360,
+			VirtType:   &paravirtual,
+			Cost:       379,
+			Deprecated: true,
+		},
+
+		// SKU: 9VHN6EZGZGFZEHHK
+		// Instance family: Storage optimized
+		// Storage: 3 x 2000 HDD
+		{
+			Name:     "d2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     735,
+		},
+
+		// SKU: ADT8TJSCKTFKTBMX
+		// Instance family: Storage optimized
+		// Storage: 8 x 800 SSD
+		{
+			Name:     "i2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     7502,
+		},
+
+		// SKU: BG8E99UBN6RZV6WV
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6495),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     953,
+		},
+
+		// SKU: BNSCBCWPZHWPDKKS
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      65536,
+			VirtType: &hvm,
+			Cost:     1056,
+		},
+
+		// SKU: C3M6ZGSU66GC75NF
+		// Instance family: Memory optimized
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "r3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     185,
+		},
+
+		// SKU: CP6AQ5U62SXMQV9P
+		// Instance family: Memory optimized
+		// Storage: 1 x 160 SSD
+		{
+			Name:     "r3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     741,
+		},
+
+		// SKU: DFX4Y9GW9C3HE99V
+		// Instance family: Micro instances
+		// Storage: EBS only
+		{
+			Name:       "t1.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        628,
+			VirtType:   &paravirtual,
+			Cost:       20,
+			Deprecated: true,
+		},
+
+		// SKU: DYTSK9JJGPSR6VQB
+		// Instance family: Storage optimized
+		// Storage: 2 x 800 SSD
+		{
+			Name:     "i2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     1876,
+		},
+
+		// SKU: E9FTXSZ49KS3R3HY
+		// Instance family: GPU instance
+		// Storage: 2 x 120 SSD
+		{
+			Name:     "g2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11647),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     2808,
+		},
+
+		// SKU: EB2QM2B74W2YCANP
+		// Instance family: General purpose
+		// Storage: 1 x 160
+		{
+			Name:       "m1.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(100),
+			Mem:        1741,
+			VirtType:   &paravirtual,
+			Cost:       47,
+			Deprecated: true,
+		},
+
+		// SKU: EQP9JWYVRCW49MPW
+		// Instance family: Storage optimized
+		// Storage: 4 x 800 SSD
+		{
+			Name:     "i2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     3751,
+		},
+
+		// SKU: FSS42UA3US5PWMV7
+		// Instance family: Memory optimized
+		// Storage: 2 x 120 SSD
+		{
+			Name:       "cr1.8xlarge",
+			Arches:     amd64,
+			CpuCores:   32,
+			CpuPower:   instances.CpuPower(3200),
+			Mem:        249856,
+			VirtType:   &hvm,
+			Cost:       3750,
+			Deprecated: true,
+		},
+
+		// SKU: HB5V2X8TXQUTDZBV
+		// Instance family: Compute optimized
+		// Storage: 1 x 350
+		{
+			Name:       "c1.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        1741,
+			VirtType:   &paravirtual,
+			Cost:       148,
+			Deprecated: true,
+		},
+
+		// SKU: HF7N6NNE7N8GDMBE
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(40),
+			Mem:        4096,
+			VirtType:   &hvm,
+			Cost:       56,
+			Deprecated: true,
+		},
+
+		// SKU: HG3TP7M3FQZ54HKR
+		// Instance family: Memory optimized
+		// Storage: 2 x 840
+		{
+			Name:       "m2.4xlarge",
+			Arches:     amd64,
+			CpuCores:   8,
+			CpuPower:   instances.CpuPower(800),
+			Mem:        70042,
+			VirtType:   &paravirtual,
+			Cost:       1100,
+			Deprecated: true,
+		},
+
+		// SKU: JGXNGK5X7WE7K3VF
+		// Instance family: General purpose
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "m3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     146,
+		},
+
+		// SKU: KKQD5EPCF8JFUDDA
+		// Instance family: Storage optimized
+		// Storage: 1 x 800 SSD
+		{
+			Name:     "i2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     938,
+		},
+
+		// SKU: N6KDUVR23T758UUC
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        2048,
+			VirtType:   &hvm,
+			Cost:       28,
+			Deprecated: true,
+		},
+
+		// SKU: NSCRWEDQZZESFDFG
+		// Instance family: General purpose
+		// Storage: 2 x 420
+		{
+			Name:       "m1.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        7680,
+			VirtType:   &paravirtual,
+			Cost:       190,
+			Deprecated: true,
+		},
+
+		// SKU: NV44PJXFFQV9UNQZ
+		// Instance family: Storage optimized
+		// Storage: 24 x 2000 HDD
+		{
+			Name:     "d2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(12096),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     5880,
+		},
+
+		// SKU: P3CTRQJY7SHQ6BJR
+		// Instance family: General purpose
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "m3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     585,
+		},
+
+		// SKU: P75KF3MVS7BD8VRA
+		// Instance family: Compute optimized
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "c3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3135),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     478,
+		},
+
+		// SKU: P7JTZV2EPW3T8GT2
+		// Instance family: Memory optimized
+		// Storage: 1 x 850
+		{
+			Name:       "m2.2xlarge",
+			Arches:     amd64,
+			CpuCores:   4,
+			CpuPower:   instances.CpuPower(400),
+			Mem:        35021,
+			VirtType:   &paravirtual,
+			Cost:       550,
+			Deprecated: true,
+		},
+
+		// SKU: PCKAVX9UQTRXBNNF
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.10xlarge",
+			Arches:   amd64,
+			CpuCores: 40,
+			CpuPower: instances.CpuPower(13440),
+			Mem:      163840,
+			VirtType: &hvm,
+			Cost:     2641,
+		},
+
+		// SKU: PR4SS7VH54V5XAZZ
+		// Instance family: Memory optimized
+		// Storage: 1 x 320 SSD
+		{
+			Name:     "r3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     1482,
+		},
+
+		// SKU: PY52HJB9NWEKKBZK
+		// Instance family: Memory optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "r3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     2964,
+		},
+
+		// SKU: Q3BP5KJZEPCUMKM3
+		// Instance family: Memory optimized
+		// Storage: 1 x 420
+		{
+			Name:       "m2.xlarge",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        17511,
+			VirtType:   &paravirtual,
+			Cost:       275,
+			Deprecated: true,
+		},
+
+		// SKU: QRP5VBPEA34W72YQ
+		// Instance family: General purpose
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "m3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     293,
+		},
+
+		// SKU: RASFAC97JWEGEPYS
+		// Instance family: Compute optimized
+		// Storage: 2 x 16 SSD
+		{
+			Name:     "c3.large",
+			Arches:   both,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(783),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     120,
+		},
+
+		// SKU: SDFJSCXXJEFDV7P2
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.nano",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(5),
+			Mem:        512,
+			VirtType:   &hvm,
+			Cost:       7,
+			Deprecated: true,
+		},
+
+		// SKU: STTHYT3WDDQU8UBR
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(10),
+			Mem:        1024,
+			VirtType:   &hvm,
+			Cost:       14,
+			Deprecated: true,
+		},
+
+		// SKU: T3ZC3B9VPS8PA59H
+		// Instance family: Compute optimized
+		// Storage: 4 x 840
+		{
+			Name:       "cc2.8xlarge",
+			Arches:     amd64,
+			CpuCores:   32,
+			CpuPower:   instances.CpuPower(11647),
+			Mem:        61952,
+			VirtType:   &hvm,
+			Cost:       2250,
+			Deprecated: true,
+		},
+
+		// SKU: TDVRYW6K68T4XJHJ
+		// Instance family: Storage optimized
+		// Storage: 24 x 2000
+		{
+			Name:       "hs1.8xlarge",
+			Arches:     amd64,
+			CpuCores:   17,
+			CpuPower:   instances.CpuPower(4760),
+			Mem:        119808,
+			VirtType:   &hvm,
+			Cost:       4900,
+			Deprecated: true,
+		},
+
+		// SKU: UNEZG8PVCP3RUSQG
+		// Instance family: General purpose
+		// Storage: 1 x 4 SSD
+		{
+			Name:     "m3.medium",
+			Arches:   amd64,
+			CpuCores: 1,
+			CpuPower: instances.CpuPower(350),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     73,
+		},
+
+		// SKU: V2SRX3YBPSJPD8E4
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3247),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     477,
+		},
+
+		// SKU: V4Q928Z7YAM3TJ6X
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1623),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     238,
+		},
+
+		// SKU: VM3SRW97DB2T2U8Z
+		// Instance family: GPU instance
+		// Storage: 1 x 60 SSD
+		{
+			Name:     "g2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2911),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     702,
+		},
+
+		// SKU: VPAFYT3KA5TFAK4M
+		// Instance family: Memory optimized
+		// Storage: 1 x 80 SSD
+		{
+			Name:     "r3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     371,
+		},
+
+		// SKU: WDZRKB8HUJXEKH45
+		// Instance family: Compute optimized
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "c3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1567),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     239,
+		},
+
+		// SKU: WTE2TS5FTMMJQXHK
+		// Instance family: Compute optimized
+		// Storage: 4 x 420
+		{
+			Name:       "c1.xlarge",
+			Arches:     amd64,
+			CpuCores:   8,
+			CpuPower:   instances.CpuPower(800),
+			Mem:        7168,
+			VirtType:   &paravirtual,
+			Cost:       592,
+			Deprecated: true,
+		},
+
+		// SKU: XWEGA3UJZ88J37T5
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(811),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     119,
+		},
+
+		// SKU: YC9UG3ESW33SS2WK
+		// Instance family: General purpose
+		// Storage: 1 x 410
+		{
+			Name:       "m1.medium",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(100),
+			Mem:        3840,
+			VirtType:   &paravirtual,
+			Cost:       95,
+			Deprecated: true,
+		},
+
+		// SKU: YMCJTDYUBRJ9G3JJ
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(14615),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     1906,
+		},
+
+		// SKU: YT7Q7XWV392U2M45
+		// Instance family: Compute optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "c3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(12543),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     1912,
+		},
+
+		// SKU: YVBHSQT9PFQ3DB5S
+		// Instance family: Storage optimized
+		// Storage: 2 x 1024 SSD
+		{
+			Name:       "hi1.4xlarge",
+			Arches:     amd64,
+			CpuCores:   16,
+			CpuPower:   instances.CpuPower(5376),
+			Mem:        61952,
+			VirtType:   &hvm,
+			Cost:       3100,
+			Deprecated: true,
+		},
+	},
+
+	"sa-east-1": {
+
+		// SKU: 2DQW6R4PKSZDG2T6
+		// Instance family: Memory optimized
+		// Storage: 2 x 1,920
+		{
+			Name:       "x1.32xlarge",
+			Arches:     amd64,
+			CpuCores:   128,
+			CpuPower:   instances.CpuPower(41216),
+			Mem:        1998848,
+			VirtType:   &hvm,
+			Cost:       26010,
+			Deprecated: true,
+		},
+
+		// SKU: 3AW2EEGJZNBGCQTC
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(60),
+			Mem:        8192,
+			VirtType:   &hvm,
+			Cost:       216,
+			Deprecated: true,
+		},
+
+		// SKU: 4KCYN288G4U4BEAG
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(14615),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     2600,
+		},
+
+		// SKU: 5GTG8UXYNCRDW5C4
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(811),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     163,
+		},
+
+		// SKU: 5YDAVRN5B6TSD9NF
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1623),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     325,
+		},
+
+		// SKU: 6TN6BMN8S44CMRDW
+		// Instance family: General purpose
+		// Storage: 1 x 410
+		{
+			Name:       "m1.medium",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(100),
+			Mem:        3840,
+			VirtType:   &paravirtual,
+			Cost:       117,
+			Deprecated: true,
+		},
+
+		// SKU: 72TGAF9QN2XH5C5V
+		// Instance family: General purpose
+		// Storage: 2 x 420
+		{
+			Name:       "m1.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        7680,
+			VirtType:   &paravirtual,
+			Cost:       233,
+			Deprecated: true,
+		},
+
+		// SKU: 7DYQRTNH9TX2QQCF
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.nano",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(5),
+			Mem:        512,
+			VirtType:   &hvm,
+			Cost:       13,
+			Deprecated: true,
+		},
+
+		// SKU: 84JB45JJDJXM67K4
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        2048,
+			VirtType:   &hvm,
+			Cost:       54,
+			Deprecated: true,
+		},
+
+		// SKU: 8VWG8TTVN5G378AH
+		// Instance family: General purpose
+		// Storage: 4 x 420
+		{
+			Name:       "m1.xlarge",
+			Arches:     amd64,
+			CpuCores:   4,
+			CpuPower:   instances.CpuPower(400),
+			Mem:        15360,
+			VirtType:   &paravirtual,
+			Cost:       467,
+			Deprecated: true,
+		},
+
+		// SKU: ADMZJH7G4TK3XW72
+		// Instance family: General purpose
+		// Storage: 1 x 4 SSD
+		{
+			Name:     "m3.medium",
+			Arches:   amd64,
+			CpuCores: 1,
+			CpuPower: instances.CpuPower(350),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     95,
+		},
+
+		// SKU: AGV5N34XYJNRXKRG
+		// Instance family: Compute optimized
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "c3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1567),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     325,
+		},
+
+		// SKU: B6W433SSVKEY68BH
+		// Instance family: General purpose
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "m3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     761,
+		},
+
+		// SKU: CPGF97CV44XU5R37
+		// Instance family: General purpose
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "m3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     190,
+		},
+
+		// SKU: CSJECZGEN7MJ4PNS
+		// Instance family: Memory optimized
+		// Storage: 2 x 840
+		{
+			Name:       "m2.4xlarge",
+			Arches:     amd64,
+			CpuCores:   8,
+			CpuPower:   instances.CpuPower(800),
+			Mem:        70042,
+			VirtType:   &paravirtual,
+			Cost:       1291,
+			Deprecated: true,
+		},
+
+		// SKU: DE4F8GSMG9ZHARG8
+		// Instance family: Compute optimized
+		// Storage: 2 x 160 SSD
+		{
+			Name:     "c3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6271),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     1300,
+		},
+
+		// SKU: EY7JV9JX6H66P24B
+		// Instance family: Memory optimized
+		// Storage: 1 x 420
+		{
+			Name:       "m2.xlarge",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        17511,
+			VirtType:   &paravirtual,
+			Cost:       323,
+			Deprecated: true,
+		},
+
+		// SKU: FDUDDQXMYRBXXPU6
+		// Instance family: General purpose
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "m3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     381,
+		},
+
+		// SKU: FSDH6G8FD9Z6EUM2
+		// Instance family: Compute optimized
+		// Storage: 1 x 350
+		{
+			Name:       "c1.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        1741,
+			VirtType:   &paravirtual,
+			Cost:       179,
+			Deprecated: true,
+		},
+
+		// SKU: H8BY38DSCNH87FAD
+		// Instance family: Compute optimized
+		// Storage: 2 x 16 SSD
+		{
+			Name:     "c3.large",
+			Arches:   both,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(783),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     163,
+		},
+
+		// SKU: HKWECXA9X8UKDCGK
+		// Instance family: Compute optimized
+		// Storage: 4 x 420
+		{
+			Name:       "c1.xlarge",
+			Arches:     amd64,
+			CpuCores:   8,
+			CpuPower:   instances.CpuPower(800),
+			Mem:        7168,
+			VirtType:   &paravirtual,
+			Cost:       718,
+			Deprecated: true,
+		},
+
+		// SKU: HR6CM3GFVDT3BAMU
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(10),
+			Mem:        1024,
+			VirtType:   &hvm,
+			Cost:       27,
+			Deprecated: true,
+		},
+
+		// SKU: M6GCPQTQDNQK5XUW
+		// Instance family: General purpose
+		// Storage: 1 x 160
+		{
+			Name:       "m1.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(100),
+			Mem:        1741,
+			VirtType:   &paravirtual,
+			Cost:       58,
+			Deprecated: true,
+		},
+
+		// SKU: MD2REDTVEQDNK4XJ
+		// Instance family: Micro instances
+		// Storage: EBS only
+		{
+			Name:       "t1.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        628,
+			VirtType:   &paravirtual,
+			Cost:       27,
+			Deprecated: true,
+		},
+
+		// SKU: PDY52X9T9DZY9CT5
+		// Instance family: Memory optimized
+		// Storage: 1 x 850
+		{
+			Name:       "m2.2xlarge",
+			Arches:     amd64,
+			CpuCores:   4,
+			CpuPower:   instances.CpuPower(400),
+			Mem:        35021,
+			VirtType:   &paravirtual,
+			Cost:       645,
+			Deprecated: true,
+		},
+
+		// SKU: SHPTTVUVD5P7R2FX
+		// Instance family: Compute optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "c3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(12543),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     2600,
+		},
+
+		// SKU: SUWWGGR72MSFMMCK
+		// Instance family: Compute optimized
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "c3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3135),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     650,
+		},
+
+		// SKU: TRBTF7WUCDPWNYFM
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(40),
+			Mem:        4096,
+			VirtType:   &hvm,
+			Cost:       108,
+			Deprecated: true,
+		},
+
+		// SKU: W6ARQS59M94CBPW2
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6495),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     1300,
+		},
+
+		// SKU: W8DSYP8X87Q34DGY
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3247),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     650,
+		},
+
+		// SKU: WCYXWR44SF5RDQSK
+		// Instance family: Memory optimized
+		// Storage: 1 x 320 SSD
+		{
+			Name:     "r3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     2799,
+		},
+
+		// SKU: YW6RW65SRZ3Y2FP5
+		// Instance family: Memory optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "r3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     5597,
+		},
+	},
+
+	"us-east-1": {
+
+		// SKU: 2GCTBU78G22TGEXZ
+		// Instance family: General purpose
+		// Storage: 1 x 160
+		{
+			Name:       "m1.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(100),
+			Mem:        1741,
+			VirtType:   &paravirtual,
+			Cost:       44,
+			Deprecated: true,
+		},
+
+		// SKU: 39748UVFEUKY3MVQ
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3247),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     419,
+		},
+
+		// SKU: 3DX9M63484ZSZFJV
+		// Instance family: Compute optimized
+		// Storage: 4 x 840
+		{
+			Name:       "cc2.8xlarge",
+			Arches:     amd64,
+			CpuCores:   32,
+			CpuPower:   instances.CpuPower(11647),
+			Mem:        61952,
+			VirtType:   &hvm,
+			Cost:       2000,
+			Deprecated: true,
+		},
+
+		// SKU: 3RUU5T58T7XAFAAF
+		// Instance family: Memory optimized
+		// Storage: 2 x 120 SSD
+		{
+			Name:       "cr1.8xlarge",
+			Arches:     amd64,
+			CpuCores:   32,
+			CpuPower:   instances.CpuPower(3200),
+			Mem:        249856,
+			VirtType:   &hvm,
+			Cost:       3500,
+			Deprecated: true,
+		},
+
+		// SKU: 3UP33R2RXCADSPSX
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      65536,
+			VirtType: &hvm,
+			Cost:     958,
+		},
+
+		// SKU: 47GP959QAF69YPG5
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     239,
+		},
+
+		// SKU: 48VURD6MVAZ3M5JX
+		// Instance family: GPU instance
+		// Storage: 1 x 60 SSD
+		{
+			Name:     "g2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2911),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     650,
+		},
+
+		// SKU: 4C7N4APU9GEUZ6H6
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(811),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     105,
+		},
+
+		// SKU: 4J62B76AXGGMHG57
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1623),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     209,
+		},
+
+		// SKU: 4TCUDNKW7PMPSUT2
+		// Instance family: Memory optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "r3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     2660,
+		},
+
+		// SKU: 5KHB4S5E8M74C6ES
+		// Instance family: Storage optimized
+		// Storage: 1 x 800 SSD
+		{
+			Name:     "i2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     853,
+		},
+
+		// SKU: 639ZEB9D49ASFB26
+		// Instance family: Micro instances
+		// Storage: EBS only
+		{
+			Name:       "t1.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        628,
+			VirtType:   &paravirtual,
+			Cost:       20,
+			Deprecated: true,
+		},
+
+		// SKU: 6TEX73KEE94WMEED
+		// Instance family: Compute optimized
+		// Storage: 4 x 420
+		{
+			Name:       "c1.xlarge",
+			Arches:     amd64,
+			CpuCores:   8,
+			CpuPower:   instances.CpuPower(800),
+			Mem:        7168,
+			VirtType:   &paravirtual,
+			Cost:       520,
+			Deprecated: true,
+		},
+
+		// SKU: 8QZCKNB62EDMDT63
+		// Instance family: Memory optimized
+		// Storage: 2 x 1,920
+		{
+			Name:       "x1.32xlarge",
+			Arches:     amd64,
+			CpuCores:   128,
+			CpuPower:   instances.CpuPower(41216),
+			Mem:        1998848,
+			VirtType:   &hvm,
+			Cost:       13338,
+			Deprecated: true,
+		},
+
+		// SKU: 8VCNEHQMSCQS4P39
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(672),
+			Mem:      8192,
+			VirtType: &hvm,
+			Cost:     120,
+		},
+
+		// SKU: 9G23QA9CK3NU3BRY
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(14615),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     1675,
+		},
+
+		// SKU: A67CJDV9B3YBP6N6
+		// Instance family: GPU instance
+		// Storage: 2 x 120 SSD
+		{
+			Name:     "g2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11647),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     2600,
+		},
+
+		// SKU: A83EBS2T67UP72G2
+		// Instance family: General purpose
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "m3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     266,
+		},
+
+		// SKU: AGHHWVT6KDRBWTWP
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.nano",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(5),
+			Mem:        512,
+			VirtType:   &hvm,
+			Cost:       6,
+			Deprecated: true,
+		},
+
+		// SKU: ARPJFM962U4P5HAT
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6495),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     838,
+		},
+
+		// SKU: ASDZTDFMC5425T7P
+		// Instance family: General purpose
+		// Storage: 1 x 4 SSD
+		{
+			Name:     "m3.medium",
+			Arches:   amd64,
+			CpuCores: 1,
+			CpuPower: instances.CpuPower(350),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     67,
+		},
+
+		// SKU: B4JUK3U7ZG63RGSF
+		// Instance family: Compute optimized
+		// Storage: 2 x 160 SSD
+		{
+			Name:     "c3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6271),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     840,
+		},
+
+		// SKU: CRRB3H2DYHU6K9FV
+		// Instance family: Storage optimized
+		// Storage: 24 x 2000
+		{
+			Name:       "hs1.8xlarge",
+			Arches:     amd64,
+			CpuCores:   17,
+			CpuPower:   instances.CpuPower(4760),
+			Mem:        119808,
+			VirtType:   &hvm,
+			Cost:       4600,
+			Deprecated: true,
+		},
+
+		// SKU: D5JBSPHEHDXDUWJR
+		// Instance family: Memory optimized
+		// Storage: 1 x 160 SSD
+		{
+			Name:     "r3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     665,
+		},
+
+		// SKU: EYGMRBWWFGSQBSBZ
+		// Instance family: General purpose
+		// Storage: 4 x 420
+		{
+			Name:       "m1.xlarge",
+			Arches:     amd64,
+			CpuCores:   4,
+			CpuPower:   instances.CpuPower(400),
+			Mem:        15360,
+			VirtType:   &paravirtual,
+			Cost:       350,
+			Deprecated: true,
+		},
+
+		// SKU: GEDBVWHPGWMPYFMC
+		// Instance family: Compute optimized
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "c3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1567),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     210,
+		},
+
+		// SKU: H48ZRU3X7FXGTGQM
+		// Instance family: Compute optimized
+		// Storage: 2 x 16 SSD
+		{
+			Name:     "c3.large",
+			Arches:   both,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(783),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     105,
+		},
+
+		// SKU: H6T3SYB5G6QCVMZM
+		// Instance family: Compute optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "c3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(12543),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     1680,
+		},
+
+		// SKU: HZC9FAP4F9Y8JW67
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(10),
+			Mem:        1024,
+			VirtType:   &hvm,
+			Cost:       13,
+			Deprecated: true,
+		},
+
+		// SKU: J4T9ZF4AJ2DXE7SA
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.10xlarge",
+			Arches:   amd64,
+			CpuCores: 40,
+			CpuPower: instances.CpuPower(13440),
+			Mem:      163840,
+			VirtType: &hvm,
+			Cost:     2394,
+		},
+
+		// SKU: J5XXRJGFYZHJVQZJ
+		// Instance family: Memory optimized
+		// Storage: 1 x 80 SSD
+		{
+			Name:     "r3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     333,
+		},
+
+		// SKU: J6U6GMEFVH686HBN
+		// Instance family: Memory optimized
+		// Storage: 1 x 420
+		{
+			Name:       "m2.xlarge",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        17511,
+			VirtType:   &paravirtual,
+			Cost:       245,
+			Deprecated: true,
+		},
+
+		// SKU: KG9YWSKMK27V6W6V
+		// Instance family: General purpose
+		// Storage: 2 x 420
+		{
+			Name:       "m1.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        7680,
+			VirtType:   &paravirtual,
+			Cost:       175,
+			Deprecated: true,
+		},
+
+		// SKU: MU4QGTJYWR6T73MZ
+		// Instance family: Storage optimized
+		// Storage: 2 x 800 SSD
+		{
+			Name:     "i2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     1705,
+		},
+
+		// SKU: NARXYND9H74FTC7A
+		// Instance family: Storage optimized
+		// Storage: 8 x 800 SSD
+		{
+			Name:     "i2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     6820,
+		},
+
+		// SKU: NF67K4WANEWZZV22
+		// Instance family: GPU instance
+		// Storage: 2 x 840
+		{
+			Name:     "cg1.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(1600),
+			Mem:      23040,
+			VirtType: &hvm,
+			Cost:     2100,
+		},
+
+		// SKU: P63NKZQXED5H7HUK
+		// Instance family: Storage optimized
+		// Storage: 6 x 2000 HDD
+		{
+			Name:     "d2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     1380,
+		},
+
+		// SKU: QCQ27AYFPSSTJG55
+		// Instance family: Memory optimized
+		// Storage: 1 x 850
+		{
+			Name:       "m2.2xlarge",
+			Arches:     amd64,
+			CpuCores:   4,
+			CpuPower:   instances.CpuPower(400),
+			Mem:        35021,
+			VirtType:   &paravirtual,
+			Cost:       490,
+			Deprecated: true,
+		},
+
+		// SKU: QG5G45WKDWDDHTFV
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(60),
+			Mem:        8192,
+			VirtType:   &hvm,
+			Cost:       104,
+			Deprecated: true,
+		},
+
+		// SKU: QSNKQ8P78YXPTAH8
+		// Instance family: General purpose
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "m3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     532,
+		},
+
+		// SKU: QY3YSEST3C6FQNQH
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(40),
+			Mem:        4096,
+			VirtType:   &hvm,
+			Cost:       52,
+			Deprecated: true,
+		},
+
+		// SKU: RJZ63YZJGC58TPTS
+		// Instance family: Storage optimized
+		// Storage: 2 x 1024 SSD
+		{
+			Name:       "hi1.4xlarge",
+			Arches:     amd64,
+			CpuCores:   16,
+			CpuPower:   instances.CpuPower(5376),
+			Mem:        61952,
+			VirtType:   &hvm,
+			Cost:       3100,
+			Deprecated: true,
+		},
+
+		// SKU: RKCQDTMY5DZS4JWT
+		// Instance family: Memory optimized
+		// Storage: 2 x 840
+		{
+			Name:       "m2.4xlarge",
+			Arches:     amd64,
+			CpuCores:   8,
+			CpuPower:   instances.CpuPower(800),
+			Mem:        70042,
+			VirtType:   &paravirtual,
+			Cost:       980,
+			Deprecated: true,
+		},
+
+		// SKU: RSN2RZ8JSX98HFVM
+		// Instance family: Memory optimized
+		// Storage: 1 x 320 SSD
+		{
+			Name:     "r3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     1330,
+		},
+
+		// SKU: U3KDJRF6FGANNG5Z
+		// Instance family: Memory optimized
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "r3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     166,
+		},
+
+		// SKU: U7343ZA6ABZUXFZ9
+		// Instance family: Storage optimized
+		// Storage: 3 x 2000 HDD
+		{
+			Name:     "d2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     690,
+		},
+
+		// SKU: VA8Q43DVPX4YV6NG
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        2048,
+			VirtType:   &hvm,
+			Cost:       26,
+			Deprecated: true,
+		},
+
+		// SKU: VHC3YWSZ6ZFZPJN4
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     479,
+		},
+
+		// SKU: X4RWGEB2DKQGCWC2
+		// Instance family: Compute optimized
+		// Storage: 1 x 350
+		{
+			Name:       "c1.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        1741,
+			VirtType:   &paravirtual,
+			Cost:       130,
+			Deprecated: true,
+		},
+
+		// SKU: XP5P8NMSB2W7KP3U
+		// Instance family: Storage optimized
+		// Storage: 24 x 2000 HDD
+		{
+			Name:     "d2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(12096),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     5520,
+		},
+
+		// SKU: YGU2QZY8VPP94FSR
+		// Instance family: General purpose
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "m3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     133,
+		},
+
+		// SKU: YUXKRQ5SQSHVKD58
+		// Instance family: General purpose
+		// Storage: 1 x 410
+		{
+			Name:       "m1.medium",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(100),
+			Mem:        3840,
+			VirtType:   &paravirtual,
+			Cost:       87,
+			Deprecated: true,
+		},
+
+		// SKU: ZA47RH8PF27SDZKP
+		// Instance family: Compute optimized
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "c3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3135),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     420,
+		},
+
+		// SKU: ZESHW7CZVERW2BN2
+		// Instance family: Storage optimized
+		// Storage: 4 x 800 SSD
+		{
+			Name:     "i2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     3410,
+		},
+
+		// SKU: ZJC9VZJF5NZNYSVK
+		// Instance family: Storage optimized
+		// Storage: 12 x 2000 HDD
+		{
+			Name:     "d2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     2760,
+		},
+	},
+
+	"us-gov-west-1": {
+
+		// SKU: 28MYFN2XX2772KFF
+		// Instance family: Memory optimized
+		// Storage: 1 x 420
+		{
+			Name:       "m2.xlarge",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        17511,
+			VirtType:   &paravirtual,
+			Cost:       293,
+			Deprecated: true,
+		},
+
+		// SKU: 6CVNTPV3HMNBWRCF
+		// Instance family: General purpose
+		// Storage: 1 x 4 SSD
+		{
+			Name:     "m3.medium",
+			Arches:   amd64,
+			CpuCores: 1,
+			CpuPower: instances.CpuPower(350),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     84,
+		},
+
+		// SKU: 6DWB5HXXA6HTFHVP
+		// Instance family: General purpose
+		// Storage: 1 x 410
+		{
+			Name:       "m1.medium",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(100),
+			Mem:        3840,
+			VirtType:   &paravirtual,
+			Cost:       106,
+			Deprecated: true,
+		},
+
+		// SKU: 6J7ZTVPXJKAX6EB3
+		// Instance family: General purpose
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "m3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     672,
+		},
+
+		// SKU: 6PMSJ4V5N26J36BG
+		// Instance family: Memory optimized
+		// Storage: 1 x 80 SSD
+		{
+			Name:     "r3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     399,
+		},
+
+		// SKU: 6R6V4F6BTSJKCC7Q
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6495),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     1008,
+		},
+
+		// SKU: 6VTUAGVX6J37U9GQ
+		// Instance family: Compute optimized
+		// Storage: 2 x 160 SSD
+		{
+			Name:     "c3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6271),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     1008,
+		},
+
+		// SKU: 7BBW4T3J39FZV85H
+		// Instance family: General purpose
+		// Storage: 1 x 160
+		{
+			Name:       "m1.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(100),
+			Mem:        1741,
+			VirtType:   &paravirtual,
+			Cost:       53,
+			Deprecated: true,
+		},
+
+		// SKU: 89EV5BSMPDHAKNGR
+		// Instance family: Compute optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "c3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(12543),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     2016,
+		},
+
+		// SKU: 98882H5A8BVY29GC
+		// Instance family: General purpose
+		// Storage: 4 x 420
+		{
+			Name:       "m1.xlarge",
+			Arches:     amd64,
+			CpuCores:   4,
+			CpuPower:   instances.CpuPower(400),
+			Mem:        15360,
+			VirtType:   &paravirtual,
+			Cost:       423,
+			Deprecated: true,
+		},
+
+		// SKU: 9PTNMYF3BTTMXQXW
+		// Instance family: Storage optimized
+		// Storage: 1 x 800 SSD
+		{
+			Name:     "i2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     1022,
+		},
+
+		// SKU: BP3D9JS4K9UCBBZ3
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(60),
+			Mem:        8192,
+			VirtType:   &hvm,
+			Cost:       124,
+			Deprecated: true,
+		},
+
+		// SKU: BXAR9D46EJJXYWD9
+		// Instance family: Compute optimized
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "c3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3135),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     504,
+		},
+
+		// SKU: CMWE8B43GS86ZUFX
+		// Instance family: Compute optimized
+		// Storage: 4 x 840
+		{
+			Name:       "cc2.8xlarge",
+			Arches:     amd64,
+			CpuCores:   32,
+			CpuPower:   instances.CpuPower(11647),
+			Mem:        61952,
+			VirtType:   &hvm,
+			Cost:       2250,
+			Deprecated: true,
+		},
+
+		// SKU: CQDRUMDTUB5DGT63
+		// Instance family: Memory optimized
+		// Storage: 1 x 850
+		{
+			Name:       "m2.2xlarge",
+			Arches:     amd64,
+			CpuCores:   4,
+			CpuPower:   instances.CpuPower(400),
+			Mem:        35021,
+			VirtType:   &paravirtual,
+			Cost:       586,
+			Deprecated: true,
+		},
+
+		// SKU: CXM9YR66XHMFFJDD
+		// Instance family: General purpose
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "m3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     168,
+		},
+
+		// SKU: EFPYDPDNRQTJBP3V
+		// Instance family: Memory optimized
+		// Storage: 2 x 1,920
+		{
+			Name:       "x1.32xlarge",
+			Arches:     amd64,
+			CpuCores:   128,
+			CpuPower:   instances.CpuPower(41216),
+			Mem:        1998848,
+			VirtType:   &hvm,
+			Cost:       16006,
+			Deprecated: true,
+		},
+
+		// SKU: EG7K36A6WPQ4YM89
+		// Instance family: Storage optimized
+		// Storage: 2 x 800 SSD
+		{
+			Name:     "i2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     2045,
+		},
+
+		// SKU: EXPVWKGGASGW4CEJ
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3247),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     504,
+		},
+
+		// SKU: FUTAFX3ARUD9RJJQ
+		// Instance family: General purpose
+		// Storage: 2 x 420
+		{
+			Name:       "m1.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        7680,
+			VirtType:   &paravirtual,
+			Cost:       211,
+			Deprecated: true,
+		},
+
+		// SKU: FZTFNX6E6VTCH3BH
+		// Instance family: Memory optimized
+		// Storage: 2 x 840
+		{
+			Name:       "m2.4xlarge",
+			Arches:     amd64,
+			CpuCores:   8,
+			CpuPower:   instances.CpuPower(800),
+			Mem:        70042,
+			VirtType:   &paravirtual,
+			Cost:       1171,
+			Deprecated: true,
+		},
+
+		// SKU: GWPUCHQBWTA9GWE7
+		// Instance family: Micro instances
+		// Storage: EBS only
+		{
+			Name:       "t1.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        628,
+			VirtType:   &paravirtual,
+			Cost:       24,
+			Deprecated: true,
+		},
+
+		// SKU: K5CWXN5HSW7SME2R
+		// Instance family: Memory optimized
+		// Storage: 1 x 160 SSD
+		{
+			Name:     "r3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     798,
+		},
+
+		// SKU: KNCYTRUPV9RQUJ4J
+		// Instance family: Storage optimized
+		// Storage: 4 x 800 SSD
+		{
+			Name:     "i2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     4091,
+		},
+
+		// SKU: N5HCW4AX6C3QWS7P
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(10),
+			Mem:        1024,
+			VirtType:   &hvm,
+			Cost:       15,
+			Deprecated: true,
+		},
+
+		// SKU: P76AN6DXWYCD69GD
+		// Instance family: Memory optimized
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "r3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     200,
+		},
+
+		// SKU: Q864N6CVS6UKQ3WZ
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1623),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     252,
+		},
+
+		// SKU: QFVQE44FY9YSYTTR
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(14615),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     2016,
+		},
+
+		// SKU: R75SXSFUFBHZPRSS
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.nano",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(5),
+			Mem:        512,
+			VirtType:   &hvm,
+			Cost:       7,
+			Deprecated: true,
+		},
+
+		// SKU: RG9GWJUK8NQBF57M
+		// Instance family: Compute optimized
+		// Storage: 1 x 350
+		{
+			Name:       "c1.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        1741,
+			VirtType:   &paravirtual,
+			Cost:       157,
+			Deprecated: true,
+		},
+
+		// SKU: RQ2E87MS29TV3CDY
+		// Instance family: Compute optimized
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "c3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1567),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     252,
+		},
+
+		// SKU: RY97T2T2385G4KXW
+		// Instance family: Memory optimized
+		// Storage: 1 x 320 SSD
+		{
+			Name:     "r3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     1596,
+		},
+
+		// SKU: SPN86ZCGXTJQR3TZ
+		// Instance family: Storage optimized
+		// Storage: 24 x 2000
+		{
+			Name:       "hs1.8xlarge",
+			Arches:     amd64,
+			CpuCores:   17,
+			CpuPower:   instances.CpuPower(4760),
+			Mem:        119808,
+			VirtType:   &hvm,
+			Cost:       5520,
+			Deprecated: true,
+		},
+
+		// SKU: UF55C3729FAEBSYW
+		// Instance family: Storage optimized
+		// Storage: 8 x 800 SSD
+		{
+			Name:     "i2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     8183,
+		},
+
+		// SKU: VR6H7WYKMFWVPAUK
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        2048,
+			VirtType:   &hvm,
+			Cost:       31,
+			Deprecated: true,
+		},
+
+		// SKU: VXKKRPEQERAMFSFJ
+		// Instance family: General purpose
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "m3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     336,
+		},
+
+		// SKU: W6ABH88PE5BKSJZQ
+		// Instance family: Memory optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "r3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     3192,
+		},
+
+		// SKU: XBS8PBKJMH9G6SDB
+		// Instance family: Compute optimized
+		// Storage: 4 x 420
+		{
+			Name:       "c1.xlarge",
+			Arches:     amd64,
+			CpuCores:   8,
+			CpuPower:   instances.CpuPower(800),
+			Mem:        7168,
+			VirtType:   &paravirtual,
+			Cost:       628,
+			Deprecated: true,
+		},
+
+		// SKU: XYAF9UA2YWC7DNZT
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(811),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     126,
+		},
+
+		// SKU: YYGVB3MJTV4Q348E
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(40),
+			Mem:        4096,
+			VirtType:   &hvm,
+			Cost:       62,
+			Deprecated: true,
+		},
+
+		// SKU: ZZTR42B59D85VUCY
+		// Instance family: Compute optimized
+		// Storage: 2 x 16 SSD
+		{
+			Name:     "c3.large",
+			Arches:   both,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(783),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     126,
+		},
+	},
+
+	"us-west-1": {
+
+		// SKU: 2EBX6PMG5FBY92KC
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     279,
+		},
+
+		// SKU: 2M44JQQN3ZP9874A
+		// Instance family: GPU instance
+		// Storage: 2 x 120 SSD
+		{
+			Name:     "g2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11647),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     2808,
+		},
+
+		// SKU: 3CUFXRHG38QDZNHT
+		// Instance family: Storage optimized
+		// Storage: 8 x 800 SSD
+		{
+			Name:     "i2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     7502,
+		},
+
+		// SKU: 3MU3SGMJKBFABKE9
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(672),
+			Mem:      8192,
+			VirtType: &hvm,
+			Cost:     140,
+		},
+
+		// SKU: 4GAV6VD5FWD8W8B4
+		// Instance family: Compute optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "c3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(12543),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     1912,
+		},
+
+		// SKU: 5JEH726H8KDYDWPP
+		// Instance family: Micro instances
+		// Storage: EBS only
+		{
+			Name:       "t1.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        628,
+			VirtType:   &paravirtual,
+			Cost:       25,
+			Deprecated: true,
+		},
+
+		// SKU: 5JQZHK4R7B7U6R3D
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     559,
+		},
+
+		// SKU: 6H5EA7PH345UPBVC
+		// Instance family: Memory optimized
+		// Storage: 2 x 840
+		{
+			Name:       "m2.4xlarge",
+			Arches:     amd64,
+			CpuCores:   8,
+			CpuPower:   instances.CpuPower(800),
+			Mem:        70042,
+			VirtType:   &paravirtual,
+			Cost:       1100,
+			Deprecated: true,
+		},
+
+		// SKU: 7AJJ9ANNCNNX5WY6
+		// Instance family: General purpose
+		// Storage: 1 x 410
+		{
+			Name:       "m1.medium",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(100),
+			Mem:        3840,
+			VirtType:   &paravirtual,
+			Cost:       95,
+			Deprecated: true,
+		},
+
+		// SKU: 7QXMEKWFBRKXCR5T
+		// Instance family: Compute optimized
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "c3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3135),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     478,
+		},
+
+		// SKU: 7T9BSUQBURKAGP2T
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(40),
+			Mem:        4096,
+			VirtType:   &hvm,
+			Cost:       68,
+			Deprecated: true,
+		},
+
+		// SKU: 87ZU79BG86PYWTSG
+		// Instance family: GPU instance
+		// Storage: 1 x 60 SSD
+		{
+			Name:     "g2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2911),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     702,
+		},
+
+		// SKU: 8RXDZ4H62GHK7Y7N
+		// Instance family: General purpose
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "m3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     154,
+		},
+
+		// SKU: 8XWJMTS7HY3XFPBD
+		// Instance family: Storage optimized
+		// Storage: 4 x 800 SSD
+		{
+			Name:     "i2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     3751,
+		},
+
+		// SKU: A78J2XTXBB29NGT4
+		// Instance family: Memory optimized
+		// Storage: 2 x 1,920
+		{
+			Name:       "x1.32xlarge",
+			Arches:     amd64,
+			CpuCores:   128,
+			CpuPower:   instances.CpuPower(41216),
+			Mem:        1998848,
+			VirtType:   &hvm,
+			Cost:       17340,
+			Deprecated: true,
+		},
+
+		// SKU: CTG879VYY65QE94C
+		// Instance family: General purpose
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "m3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     616,
+		},
+
+		// SKU: CTW2PCJK622MCHPV
+		// Instance family: Memory optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "r3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     2964,
+		},
+
+		// SKU: D7EXY7CNAHW9BTHD
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(60),
+			Mem:        8192,
+			VirtType:   &hvm,
+			Cost:       136,
+			Deprecated: true,
+		},
+
+		// SKU: EVYB78ZE853DF3CC
+		// Instance family: General purpose
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "m3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     308,
+		},
+
+		// SKU: F4RA9QG9BAGEHG29
+		// Instance family: Storage optimized
+		// Storage: 24 x 2000 HDD
+		{
+			Name:     "d2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(12096),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     6250,
+		},
+
+		// SKU: F5KDHTDT282JC5R3
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      65536,
+			VirtType: &hvm,
+			Cost:     1117,
+		},
+
+		// SKU: FA7B379WCHNBVMNU
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6495),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     1049,
+		},
+
+		// SKU: G3EQX8J7UNTWEVC7
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3247),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     524,
+		},
+
+		// SKU: GRGVZYA9QN53ASFB
+		// Instance family: General purpose
+		// Storage: 2 x 420
+		{
+			Name:       "m1.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        7680,
+			VirtType:   &paravirtual,
+			Cost:       190,
+			Deprecated: true,
+		},
+
+		// SKU: GRKGK4BN2EGBK686
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.nano",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(5),
+			Mem:        512,
+			VirtType:   &hvm,
+			Cost:       8,
+			Deprecated: true,
+		},
+
+		// SKU: GSN36ZXJH466ES5F
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(14615),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     2098,
+		},
+
+		// SKU: H8QFMXWT89NGP6VU
+		// Instance family: Compute optimized
+		// Storage: 2 x 16 SSD
+		{
+			Name:     "c3.large",
+			Arches:   both,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(783),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     120,
+		},
+
+		// SKU: J5UNF2XTPQCS5N59
+		// Instance family: Memory optimized
+		// Storage: 1 x 320 SSD
+		{
+			Name:     "r3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     1482,
+		},
+
+		// SKU: J6T772QKJ5B49GMC
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(10),
+			Mem:        1024,
+			VirtType:   &hvm,
+			Cost:       17,
+			Deprecated: true,
+		},
+
+		// SKU: JHV4BKWFVMXQ2T6R
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        2048,
+			VirtType:   &hvm,
+			Cost:       34,
+			Deprecated: true,
+		},
+
+		// SKU: JJRB8PAXGN6JTB3D
+		// Instance family: General purpose
+		// Storage: 4 x 420
+		{
+			Name:       "m1.xlarge",
+			Arches:     amd64,
+			CpuCores:   4,
+			CpuPower:   instances.CpuPower(400),
+			Mem:        15360,
+			VirtType:   &paravirtual,
+			Cost:       379,
+			Deprecated: true,
+		},
+
+		// SKU: JUT2GARXC5CE93CM
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1623),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     262,
+		},
+
+		// SKU: P5VFWENV9YDAQVFH
+		// Instance family: General purpose
+		// Storage: 1 x 160
+		{
+			Name:       "m1.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(100),
+			Mem:        1741,
+			VirtType:   &paravirtual,
+			Cost:       47,
+			Deprecated: true,
+		},
+
+		// SKU: PSNEQGH9XVX3FSE8
+		// Instance family: Compute optimized
+		// Storage: 2 x 160 SSD
+		{
+			Name:     "c3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6271),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     956,
+		},
+
+		// SKU: PYE3YUCCZCUBD7Z6
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(811),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     131,
+		},
+
+		// SKU: RMARGSE4CA952UDV
+		// Instance family: Memory optimized
+		// Storage: 1 x 80 SSD
+		{
+			Name:     "r3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     371,
+		},
+
+		// SKU: RT9NWVFZWQDDRNES
+		// Instance family: General purpose
+		// Storage: 1 x 4 SSD
+		{
+			Name:     "m3.medium",
+			Arches:   amd64,
+			CpuCores: 1,
+			CpuPower: instances.CpuPower(350),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     77,
+		},
+
+		// SKU: S6XCDNADM5DDPNUP
+		// Instance family: Compute optimized
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "c3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1567),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     239,
+		},
+
+		// SKU: S7T2R43H93585V7D
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.10xlarge",
+			Arches:   amd64,
+			CpuCores: 40,
+			CpuPower: instances.CpuPower(13440),
+			Mem:      163840,
+			VirtType: &hvm,
+			Cost:     2793,
+		},
+
+		// SKU: TMYBBH8MNS5KCXDG
+		// Instance family: Storage optimized
+		// Storage: 2 x 800 SSD
+		{
+			Name:     "i2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     1876,
+		},
+
+		// SKU: V3KZ88KMZGE7XS8G
+		// Instance family: Storage optimized
+		// Storage: 3 x 2000 HDD
+		{
+			Name:     "d2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     781,
+		},
+
+		// SKU: VZ7V29X35F98VENC
+		// Instance family: Memory optimized
+		// Storage: 1 x 160 SSD
+		{
+			Name:     "r3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     741,
+		},
+
+		// SKU: VZA22HBW4H82PHGF
+		// Instance family: Memory optimized
+		// Storage: 1 x 850
+		{
+			Name:       "m2.2xlarge",
+			Arches:     amd64,
+			CpuCores:   4,
+			CpuPower:   instances.CpuPower(400),
+			Mem:        35021,
+			VirtType:   &paravirtual,
+			Cost:       550,
+			Deprecated: true,
+		},
+
+		// SKU: WNGPF3ZVZEAVC7FH
+		// Instance family: Storage optimized
+		// Storage: 12 x 2000 HDD
+		{
+			Name:     "d2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     3125,
+		},
+
+		// SKU: X7EQJS6PVD6RDBPD
+		// Instance family: Storage optimized
+		// Storage: 1 x 800 SSD
+		{
+			Name:     "i2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     938,
+		},
+
+		// SKU: XFDUQKGKAPWHG6P5
+		// Instance family: Compute optimized
+		// Storage: 1 x 350
+		{
+			Name:       "c1.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        1741,
+			VirtType:   &paravirtual,
+			Cost:       148,
+			Deprecated: true,
+		},
+
+		// SKU: XKAXY7525KWTBXQJ
+		// Instance family: Memory optimized
+		// Storage: 1 x 420
+		{
+			Name:       "m2.xlarge",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        17511,
+			VirtType:   &paravirtual,
+			Cost:       275,
+			Deprecated: true,
+		},
+
+		// SKU: YY26V92H8QNEPQER
+		// Instance family: Memory optimized
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "r3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     185,
+		},
+
+		// SKU: ZXHBSSRM8QPYG3GC
+		// Instance family: Storage optimized
+		// Storage: 6 x 2000 HDD
+		{
+			Name:     "d2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     1563,
+		},
+
+		// SKU: ZXWJ6NZFPEP89DVZ
+		// Instance family: Compute optimized
+		// Storage: 4 x 420
+		{
+			Name:       "c1.xlarge",
+			Arches:     amd64,
+			CpuCores:   8,
+			CpuPower:   instances.CpuPower(800),
+			Mem:        7168,
+			VirtType:   &paravirtual,
+			Cost:       592,
+			Deprecated: true,
+		},
+	},
+
+	"us-west-2": {
+
+		// SKU: 2ES9C4RF3WGQZAQN
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(40),
+			Mem:        4096,
+			VirtType:   &hvm,
+			Cost:       52,
+			Deprecated: true,
+		},
+
+		// SKU: 2J3G8CUM4UVYVFJH
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.nano",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(5),
+			Mem:        512,
+			VirtType:   &hvm,
+			Cost:       6,
+			Deprecated: true,
+		},
+
+		// SKU: 2JUMD5V8V9V6D9JC
+		// Instance family: General purpose
+		// Storage: 1 x 410
+		{
+			Name:       "m1.medium",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(100),
+			Mem:        3840,
+			VirtType:   &paravirtual,
+			Cost:       87,
+			Deprecated: true,
+		},
+
+		// SKU: 34G9YZGUJNTY6HG9
+		// Instance family: Memory optimized
+		// Storage: 2 x 1,920
+		{
+			Name:       "x1.32xlarge",
+			Arches:     amd64,
+			CpuCores:   128,
+			CpuPower:   instances.CpuPower(41216),
+			Mem:        1998848,
+			VirtType:   &hvm,
+			Cost:       13338,
+			Deprecated: true,
+		},
+
+		// SKU: 3FTJBHZMWT7D76MD
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6495),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     838,
+		},
+
+		// SKU: 4SCSPCTHFCXYY6GT
+		// Instance family: General purpose
+		// Storage: 4 x 420
+		{
+			Name:       "m1.xlarge",
+			Arches:     amd64,
+			CpuCores:   4,
+			CpuPower:   instances.CpuPower(400),
+			Mem:        15360,
+			VirtType:   &paravirtual,
+			Cost:       350,
+			Deprecated: true,
+		},
+
+		// SKU: 584JD8RT9GR57BFS
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1623),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     209,
+		},
+
+		// SKU: 5EPUM8UK2RTQKW5E
+		// Instance family: Compute optimized
+		// Storage: 4 x 420
+		{
+			Name:       "c1.xlarge",
+			Arches:     amd64,
+			CpuCores:   8,
+			CpuPower:   instances.CpuPower(800),
+			Mem:        7168,
+			VirtType:   &paravirtual,
+			Cost:       520,
+			Deprecated: true,
+		},
+
+		// SKU: 5WF4ZHD94FEY4YDX
+		// Instance family: Memory optimized
+		// Storage: 1 x 850
+		{
+			Name:       "m2.2xlarge",
+			Arches:     amd64,
+			CpuCores:   4,
+			CpuPower:   instances.CpuPower(400),
+			Mem:        35021,
+			VirtType:   &paravirtual,
+			Cost:       490,
+			Deprecated: true,
+		},
+
+		// SKU: 672XUMHHEC7SYFT7
+		// Instance family: Compute optimized
+		// Storage: 2 x 16 SSD
+		{
+			Name:     "c3.large",
+			Arches:   both,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(783),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     105,
+		},
+
+		// SKU: 6P434MFC33XNF65Z
+		// Instance family: Compute optimized
+		// Storage: 4 x 840
+		{
+			Name:       "cc2.8xlarge",
+			Arches:     amd64,
+			CpuCores:   32,
+			CpuPower:   instances.CpuPower(11647),
+			Mem:        61952,
+			VirtType:   &hvm,
+			Cost:       2000,
+			Deprecated: true,
+		},
+
+		// SKU: 7528XD9PPHXN6NN2
+		// Instance family: GPU instance
+		// Storage: 2 x 120 SSD
+		{
+			Name:     "g2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11647),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     2600,
+		},
+
+		// SKU: 7RMRB492WTPDQ5Z4
+		// Instance family: Memory optimized
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "r3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     166,
+		},
+
+		// SKU: 9GHZN7VCNV2MGV4N
+		// Instance family: Compute optimized
+		// Storage: 2 x 160 SSD
+		{
+			Name:     "c3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6271),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     840,
+		},
+
+		// SKU: 9HMZJQ3SKEW4P7ST
+		// Instance family: Storage optimized
+		// Storage: 4 x 800 SSD
+		{
+			Name:     "i2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     3410,
+		},
+
+		// SKU: 9NSBRG2FE96XPHXK
+		// Instance family: Compute optimized
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "c3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1567),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     210,
+		},
+
+		// SKU: 9RYWCN75CJX2C238
+		// Instance family: Storage optimized
+		// Storage: 6 x 2000 HDD
+		{
+			Name:     "d2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     1380,
+		},
+
+		// SKU: AKWXS6FJQE43VAZ9
+		// Instance family: Storage optimized
+		// Storage: 8 x 800 SSD
+		{
+			Name:     "i2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     6820,
+		},
+
+		// SKU: B2M25Y2U9824Q5TG
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(672),
+			Mem:      8192,
+			VirtType: &hvm,
+			Cost:     120,
+		},
+
+		// SKU: BMEYUTP658QKQRTP
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      65536,
+			VirtType: &hvm,
+			Cost:     958,
+		},
+
+		// SKU: BNBBBYA6WNXQ3TZV
+		// Instance family: Storage optimized
+		// Storage: 12 x 2000 HDD
+		{
+			Name:     "d2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     2760,
+		},
+
+		// SKU: CP2TNWZCKSRY486E
+		// Instance family: General purpose
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "m3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     532,
+		},
+
+		// SKU: CVFJSWADA39YVNW2
+		// Instance family: General purpose
+		// Storage: 2 x 420
+		{
+			Name:       "m1.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        7680,
+			VirtType:   &paravirtual,
+			Cost:       175,
+			Deprecated: true,
+		},
+
+		// SKU: D8RPR5AJPDXSC9DF
+		// Instance family: General purpose
+		// Storage: 1 x 160
+		{
+			Name:       "m1.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(100),
+			Mem:        1741,
+			VirtType:   &paravirtual,
+			Cost:       44,
+			Deprecated: true,
+		},
+
+		// SKU: DTDPGWV4T5RAVP44
+		// Instance family: Storage optimized
+		// Storage: 24 x 2000
+		{
+			Name:       "hs1.8xlarge",
+			Arches:     amd64,
+			CpuCores:   17,
+			CpuPower:   instances.CpuPower(4760),
+			Mem:        119808,
+			VirtType:   &hvm,
+			Cost:       4600,
+			Deprecated: true,
+		},
+
+		// SKU: DW2RY9FQP8VE6V74
+		// Instance family: Storage optimized
+		// Storage: 24 x 2000 HDD
+		{
+			Name:     "d2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(12096),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     5520,
+		},
+
+		// SKU: E7T5V224CMC9A43F
+		// Instance family: General purpose
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "m3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     133,
+		},
+
+		// SKU: F6544RN8RCJHYC5Z
+		// Instance family: Compute optimized
+		// Storage: 2 x 80 SSD
+		{
+			Name:     "c3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3135),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     420,
+		},
+
+		// SKU: GMTWE5CTY4FEUYDN
+		// Instance family: Memory optimized
+		// Storage: 1 x 160 SSD
+		{
+			Name:     "r3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     665,
+		},
+
+		// SKU: J9H28ZVG9UDW7CX4
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     479,
+		},
+
+		// SKU: JH68FQ55JWMC4CG9
+		// Instance family: General purpose
+		// Storage: 1 x 4 SSD
+		{
+			Name:     "m3.medium",
+			Arches:   amd64,
+			CpuCores: 1,
+			CpuPower: instances.CpuPower(350),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     67,
+		},
+
+		// SKU: JNZ6ESS4AS6RFUAF
+		// Instance family: Memory optimized
+		// Storage: 1 x 320 SSD
+		{
+			Name:     "r3.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5600),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     1330,
+		},
+
+		// SKU: K24TXC5VMFQZ53MC
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(811),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     105,
+		},
+
+		// SKU: K5MSZ8JUCECB23H9
+		// Instance family: Storage optimized
+		// Storage: 2 x 1024 SSD
+		{
+			Name:       "hi1.4xlarge",
+			Arches:     amd64,
+			CpuCores:   16,
+			CpuPower:   instances.CpuPower(5376),
+			Mem:        61952,
+			VirtType:   &hvm,
+			Cost:       3100,
+			Deprecated: true,
+		},
+
+		// SKU: KCTVWQQPE9VFXHGP
+		// Instance family: Memory optimized
+		// Storage: 1 x 420
+		{
+			Name:       "m2.xlarge",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        17511,
+			VirtType:   &paravirtual,
+			Cost:       245,
+			Deprecated: true,
+		},
+
+		// SKU: MBANS55WTSZ5HYS8
+		// Instance family: Memory optimized
+		// Storage: 1 x 80 SSD
+		{
+			Name:     "r3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     333,
+		},
+
+		// SKU: MNG2Y3YRJK7GPKQR
+		// Instance family: Compute optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "c3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(12543),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     1680,
+		},
+
+		// SKU: MWG952JV6DF8YBYE
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.10xlarge",
+			Arches:   amd64,
+			CpuCores: 40,
+			CpuPower: instances.CpuPower(13440),
+			Mem:      163840,
+			VirtType: &hvm,
+			Cost:     2394,
+		},
+
+		// SKU: N4D3MGNKSH7Q9KT3
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(10),
+			Mem:        1024,
+			VirtType:   &hvm,
+			Cost:       13,
+			Deprecated: true,
+		},
+
+		// SKU: N5F93UFYUKWKB8KE
+		// Instance family: Storage optimized
+		// Storage: 1 x 800 SSD
+		{
+			Name:     "i2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     853,
+		},
+
+		// SKU: NA6BZ2FSPKCZGWTA
+		// Instance family: Memory optimized
+		// Storage: 2 x 320 SSD
+		{
+			Name:     "r3.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(11200),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     2660,
+		},
+
+		// SKU: P9ZPWZF7CCR7MS77
+		// Instance family: Compute optimized
+		// Storage: 1 x 350
+		{
+			Name:       "c1.medium",
+			Arches:     both,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(200),
+			Mem:        1741,
+			VirtType:   &paravirtual,
+			Cost:       130,
+			Deprecated: true,
+		},
+
+		// SKU: PWGQ6MKD7A6EHVXN
+		// Instance family: Memory optimized
+		// Storage: 2 x 120 SSD
+		{
+			Name:       "cr1.8xlarge",
+			Arches:     amd64,
+			CpuCores:   32,
+			CpuPower:   instances.CpuPower(3200),
+			Mem:        249856,
+			VirtType:   &hvm,
+			Cost:       3500,
+			Deprecated: true,
+		},
+
+		// SKU: QBRGX479S7RZ4QEA
+		// Instance family: GPU instance
+		// Storage: 1 x 60 SSD
+		{
+			Name:     "g2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2911),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     650,
+		},
+
+		// SKU: QBYJCF2RGQTF5H5D
+		// Instance family: Memory optimized
+		// Storage: 2 x 840
+		{
+			Name:       "m2.4xlarge",
+			Arches:     amd64,
+			CpuCores:   8,
+			CpuPower:   instances.CpuPower(800),
+			Mem:        70042,
+			VirtType:   &paravirtual,
+			Cost:       980,
+			Deprecated: true,
+		},
+
+		// SKU: UNB4R4KS4XXHQFD2
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(14615),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     1675,
+		},
+
+		// SKU: VBKTV5SAFT4WNV9X
+		// Instance family: General purpose
+		// Storage: 2 x 40 SSD
+		{
+			Name:     "m3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     266,
+		},
+
+		// SKU: WE87HQHP89BK3AXK
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.large",
+			Arches:     amd64,
+			CpuCores:   2,
+			CpuPower:   instances.CpuPower(60),
+			Mem:        8192,
+			VirtType:   &hvm,
+			Cost:       104,
+			Deprecated: true,
+		},
+
+		// SKU: X5NPE8XF7KHV7AAD
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     239,
+		},
+
+		// SKU: XK9YF9AJ9EBH7W4U
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:       "t2.small",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        2048,
+			VirtType:   &hvm,
+			Cost:       26,
+			Deprecated: true,
+		},
+
+		// SKU: XUTTHNZ5B5VJKKDE
+		// Instance family: Micro instances
+		// Storage: EBS only
+		{
+			Name:       "t1.micro",
+			Arches:     both,
+			CpuCores:   1,
+			CpuPower:   instances.CpuPower(20),
+			Mem:        628,
+			VirtType:   &paravirtual,
+			Cost:       20,
+			Deprecated: true,
+		},
+
+		// SKU: YBN8Q7AQJD9ZT57S
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3247),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     419,
+		},
+
+		// SKU: YMWQW8W92QHE628D
+		// Instance family: Storage optimized
+		// Storage: 3 x 2000 HDD
+		{
+			Name:     "d2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     690,
+		},
+
+		// SKU: ZKYE77DHMC32Y9BK
+		// Instance family: Storage optimized
+		// Storage: 2 x 800 SSD
+		{
+			Name:     "i2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     1705,
+		},
+	},
+}

--- a/provider/ec2/internal/ec2instancetypes/instancetypes.go
+++ b/provider/ec2/internal/ec2instancetypes/instancetypes.go
@@ -1,0 +1,21 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ec2instancetypes
+
+//go:generate go run process_cost_data.go -o generated.go index.json
+
+import "github.com/juju/juju/environs/instances"
+
+// RegionInstanceTypes returns the instance types for the named region.
+func RegionInstanceTypes(region string) []instances.InstanceType {
+	// NOTE(axw) at the time of writing, there is no cost
+	// information for China (Beijing). For any regions
+	// that we don't know about, we substitute us-east-1
+	// and hope that they're equivalent.
+	instanceTypes, ok := allInstanceTypes[region]
+	if !ok {
+		instanceTypes = allInstanceTypes["us-east-1"]
+	}
+	return instanceTypes
+}

--- a/provider/ec2/internal/ec2instancetypes/instancetypes_test.go
+++ b/provider/ec2/internal/ec2instancetypes/instancetypes_test.go
@@ -1,0 +1,79 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ec2instancetypes_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/provider/ec2/internal/ec2instancetypes"
+)
+
+type InstanceTypesSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&InstanceTypesSuite{})
+
+func (s *InstanceTypesSuite) TestRegionInstanceTypes(c *gc.C) {
+	// This is the set of instance type names we had hard coded previously.
+	knownInstanceTypes := set.NewStrings(
+		"m1.small", "m1.medium", "m1.large", "m1.xlarge",
+		"m4.large", "m4.xlarge", "m4.2xlarge", "m4.4xlarge", "m4.10xlarge",
+		"m3.medium", "m3.large", "m3.xlarge", "m3.2xlarge",
+		"c1.medium", "c1.xlarge", "cc2.8xlarge",
+		"c3.large", "c3.xlarge", "c3.2xlarge", "c3.4xlarge", "c3.8xlarge",
+		"cg1.4xlarge",
+		"g2.2xlarge",
+		"m2.xlarge", "m2.2xlarge", "m2.4xlarge", "cr1.8xlarge",
+		"r3.large", "r3.xlarge", "r3.2xlarge", "r3.4xlarge", "r3.8xlarge",
+		"hi1.4xlarge",
+		"i2.xlarge", "i2.2xlarge", "i2.8xlarge", "hs1.8xlarge",
+		"t1.micro",
+		"t2.micro", "t2.small", "t2.medium",
+		"c4.large", "c4.xlarge", "c4.2xlarge", "c4.4xlarge", "c4.8xlarge",
+	)
+	seen := make(map[string]bool)
+	var unknownInstanceTypes []string
+	instanceTypes := ec2instancetypes.RegionInstanceTypes("us-east-1")
+	for _, instanceType := range instanceTypes {
+		c.Assert(instanceType.Cost, gc.Not(gc.Equals), 0)
+		c.Assert(seen[instanceType.Name], jc.IsFalse) // no duplicates
+		seen[instanceType.Name] = true
+
+		if !knownInstanceTypes.Contains(instanceType.Name) {
+			unknownInstanceTypes = append(unknownInstanceTypes, instanceType.Name)
+		} else {
+			knownInstanceTypes.Remove(instanceType.Name)
+		}
+	}
+	c.Assert(knownInstanceTypes, gc.HasLen, 0) // all accounted for
+	if len(unknownInstanceTypes) > 0 {
+		c.Logf("unknown instance types: %s", unknownInstanceTypes)
+	}
+}
+
+func (s *InstanceTypesSuite) TestRegionInstanceTypesAvailability(c *gc.C) {
+	// Some instance types are only available in some regions.
+	usWest1InstanceTypes := set.NewStrings()
+	usEast1InstanceTypes := set.NewStrings()
+	for _, instanceType := range ec2instancetypes.RegionInstanceTypes("us-west-1") {
+		usWest1InstanceTypes.Add(instanceType.Name)
+	}
+	for _, instanceType := range ec2instancetypes.RegionInstanceTypes("us-east-1") {
+		usEast1InstanceTypes.Add(instanceType.Name)
+	}
+	c.Assert(
+		usEast1InstanceTypes.Difference(usWest1InstanceTypes).SortedValues(),
+		jc.DeepEquals,
+		[]string{"cc2.8xlarge", "cg1.4xlarge", "cr1.8xlarge", "hi1.4xlarge", "hs1.8xlarge"},
+	)
+}
+
+func (s *InstanceTypesSuite) TestRegionInstanceTypesUnknownRegion(c *gc.C) {
+	instanceTypes := ec2instancetypes.RegionInstanceTypes("cn-north-1")
+	c.Assert(instanceTypes, jc.DeepEquals, ec2instancetypes.RegionInstanceTypes("us-east-1"))
+}

--- a/provider/ec2/internal/ec2instancetypes/package_test.go
+++ b/provider/ec2/internal/ec2instancetypes/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ec2instancetypes_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/provider/ec2/internal/ec2instancetypes/process_cost_data.go
+++ b/provider/ec2/internal/ec2instancetypes/process_cost_data.go
@@ -1,0 +1,402 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build ignore
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/format"
+	"io"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+	"github.com/juju/utils/set"
+)
+
+const (
+	baseURL      = `https://pricing.us-east-1.amazonaws.com`
+	ec2IndexPath = `/offers/v1.0/aws/AmazonEC2/current/index.json`
+)
+
+var (
+	nowish = time.Now()
+)
+
+func Main() (int, error) {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s [-o outfile] [json-file]:\n", os.Args[0])
+	}
+
+	var outfilename string
+	flag.StringVar(&outfilename, "o", "-", "Name of a file to write the output to")
+	flag.Parse()
+
+	var infilename string
+	var fin *os.File
+	switch flag.NArg() {
+	case 0:
+		infilename = "<stdin>"
+		fin = os.Stdin
+	case 1:
+		var err error
+		infilename = flag.Arg(0)
+		fin, err = os.Open(infilename)
+		if err != nil {
+			return -1, err
+		}
+		defer fin.Close()
+	default:
+		fmt.Println(flag.Args())
+		flag.Usage()
+		return 2, nil
+	}
+
+	fout := os.Stdout
+	if outfilename != "-" {
+		var err error
+		fout, err = os.Create(outfilename)
+		if err != nil {
+			return -1, err
+		}
+		defer fout.Close()
+	}
+
+	tmpl, err := template.New("instanceTypes").Parse(`
+// Copyright {{.Year}} Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ec2instancetypes
+
+import (
+	"github.com/juju/utils/arch"
+
+	"github.com/juju/juju/environs/instances"
+)
+
+var (
+	paravirtual = "pv"
+	hvm         = "hvm"
+	amd64       = []string{arch.AMD64}
+	both        = []string{arch.AMD64, arch.I386}
+)
+
+// Version: {{.Meta.Version}}
+// Publication date: {{.Meta.PublicationDate}}
+//
+// {{.Meta.Disclaimer}}
+
+var allInstanceTypes = map[string][]instances.InstanceType{
+{{range $region, $instanceTypes := .InstanceTypes}}
+{{printf "%q: {" $region}}
+{{range $index, $instanceType := $instanceTypes}}{{with $instanceType}}
+  // SKU: {{.SKU}}
+  // Instance family: {{.InstanceFamily}}
+  // Storage: {{.Storage}}
+  {
+    Name:       {{printf "%q" .Name}},
+    Arches:     {{.Arches}},
+    CpuCores:   {{.CpuCores}},
+    CpuPower:   instances.CpuPower({{.CpuPower}}),
+    Mem:        {{.Mem}},
+    VirtType:   &{{.VirtType}},
+    Cost:       {{.Cost}},
+    {{if .Deprecated}}Deprecated: true,{{end}}
+  },
+{{end}}{{end}}
+},
+{{end}}
+}`)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Fprintln(os.Stderr, "Processing", infilename)
+	instanceTypes, meta, err := process(fin)
+	if err != nil {
+		return -1, err
+	}
+
+	templateData := struct {
+		Year          int
+		InstanceTypes map[string][]instanceType
+		Meta          metadata
+	}{
+		nowish.Year(),
+		instanceTypes,
+		meta,
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, templateData); err != nil {
+		return -1, err
+	}
+
+	formatted, err := format.Source(buf.Bytes())
+	if err != nil {
+		return -1, err
+	}
+	if _, err := fout.Write(formatted); err != nil {
+		return -1, err
+	}
+
+	return 0, nil
+}
+
+func process(in io.Reader) (map[string][]instanceType, metadata, error) {
+	var index indexFile
+	if err := json.NewDecoder(in).Decode(&index); err != nil {
+		return nil, metadata{}, err
+	}
+	meta := metadata{
+		Version:         index.Version,
+		Disclaimer:      index.Disclaimer,
+		PublicationDate: index.PublicationDate,
+	}
+	instanceTypes := make(map[string][]instanceType)
+	skus := set.NewStrings()
+	for sku := range index.Products {
+		skus.Add(sku)
+	}
+	for _, sku := range skus.SortedValues() {
+		productInfo := index.Products[sku]
+		if productInfo.ProductFamily != "Compute Instance" {
+			continue
+		}
+		if productInfo.OperatingSystem != "Linux" {
+			// We don't care about absolute cost, so we don't need
+			// to include the cost of OS.
+			continue
+		}
+		if productInfo.Tenancy != "Shared" {
+			continue
+		}
+		fmt.Fprintf(os.Stderr, "- Processing %q\n", sku)
+
+		// Some instance types support both 32-bit and 64-bit, some
+		// only support 64-bit.
+		arches := "amd64"
+		if productInfo.ProcessorArchitecture == "32-bit or 64-bit" {
+			arches = "both"
+		}
+
+		// NOTE(axw) it's not really either/or. Some instance types are
+		// capable of launching either HVM or PV images (e.g. T1, C3).
+		// HVM is preferred, though, so we err on that side.
+		virtType := "hvm"
+		if isParavirtualOnly(productInfo) {
+			virtType = "paravirtual"
+		}
+
+		memMB, err := parseMem(productInfo.Memory)
+		if err != nil {
+			return nil, metadata{}, errors.Annotate(err, "parsing mem")
+		}
+
+		cpuPower, err := calculateCPUPower(productInfo)
+		if err != nil {
+			return nil, metadata{}, errors.Annotate(err, "calculating CPU power")
+		}
+
+		instanceType := instanceType{
+			Name:     productInfo.InstanceType,
+			Arches:   arches,
+			CpuCores: productInfo.VCPU,
+			CpuPower: cpuPower,
+			Mem:      memMB,
+			VirtType: virtType,
+
+			// Extended information
+			SKU:            sku,
+			InstanceFamily: productInfo.InstanceFamily,
+			Storage:        productInfo.Storage,
+		}
+		if strings.ToLower(productInfo.CurrentGeneration) != "yes" {
+			instanceType.Deprecated = true
+		}
+
+		// Get cost information. We only support on-demand.
+		for skuOfferTermCode, skuTerms := range index.Terms.OnDemand[sku] {
+			if !skuTerms.EffectiveDate.Before(nowish) {
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "-- Processing offer %q\n", skuOfferTermCode)
+			for skuOfferTermCodeRateCode, pricingDetails := range skuTerms.PriceDimensions {
+				fmt.Fprintf(os.Stderr, "--- Processing rate code %q\n", skuOfferTermCodeRateCode)
+				fmt.Fprintf(os.Stderr, "     Description: %s\n", pricingDetails.Description)
+				fmt.Fprintf(os.Stderr, "     Cost: $%f/%s\n",
+					pricingDetails.PricePerUnit.USD, pricingDetails.Unit,
+				)
+				instanceType.Cost = uint64(pricingDetails.PricePerUnit.USD * 1000)
+				break
+			}
+		}
+
+		region, ok := locationToRegion(productInfo.Location)
+		if !ok {
+			return nil, metadata{}, errors.Errorf("unknown location %q", productInfo.Location)
+		}
+		regionInstanceTypes := instanceTypes[region]
+		regionInstanceTypes = append(regionInstanceTypes, instanceType)
+		instanceTypes[region] = regionInstanceTypes
+	}
+	return instanceTypes, meta, nil
+}
+
+func calculateCPUPower(info productInfo) (uint64, error) {
+	// T-class instances have burstable CPU. This is not captured
+	// in the pricing information, so we have to hard-code it. We
+	// will have to update this list when T3 instances come along.
+	switch info.InstanceType {
+	case "t1.micro":
+		return 20, nil
+	case "t2.nano":
+		return 5, nil
+	case "t2.micro":
+		return 10, nil
+	case "t2.small":
+		return 20, nil
+	case "t2.medium":
+		return 40, nil
+	case "t2.large":
+		return 60, nil
+	}
+	if info.ClockSpeed == "" {
+		return info.VCPU * 100, nil
+	}
+
+	// If the information includes a clock speed, we use that
+	// to estimate the ECUs. The pricing information does not
+	// include the ECUs, but they're only estimates anyway.
+	// Amazon moved to "vCPUs" quite some time ago.
+	clock, err := strconv.ParseFloat(strings.Fields(info.ClockSpeed)[0], 64)
+	if err != nil {
+		return 0, errors.Annotate(err, "parsing clock speed")
+	}
+	return uint64(clock * 1.4 * 100 * float64(info.VCPU)), nil
+}
+
+func parseMem(s string) (uint64, error) {
+	s = strings.Replace(s, " ", "", -1)
+	s = strings.Replace(s, ",", "", -1) // e.g. 1,952 -> 1952
+
+	// Sometimes it's GiB, sometimes Gib. We don't like Gib.
+	s = strings.Replace(s, "Gib", "GiB", 1)
+	return utils.ParseSize(s)
+}
+
+func locationToRegion(loc string) (string, bool) {
+	regions := map[string]string{
+		"US East (N. Virginia)":     "us-east-1",
+		"US West (N. California)":   "us-west-1",
+		"US West (Oregon)":          "us-west-2",
+		"Asia Pacific (Mumbai)":     "ap-south-1",
+		"Asia Pacific (Seoul)":      "ap-northeast-2",
+		"Asia Pacific (Singapore)":  "ap-southeast-1",
+		"Asia Pacific (Sydney)":     "ap-southeast-2",
+		"Asia Pacific (Tokyo)":      "ap-northeast-1",
+		"EU (Frankfurt)":            "eu-central-1",
+		"EU (Ireland)":              "eu-west-1",
+		"South America (Sao Paulo)": "sa-east-1",
+		"AWS GovCloud (US)":         "us-gov-west-1",
+
+		// NOTE(axw) at the time of writing, there is no
+		// pricing information for cn-north-1.
+		"China (Beijing)": "cn-north-1",
+	}
+	region, ok := regions[loc]
+	return region, ok
+}
+
+func isParavirtualOnly(info productInfo) bool {
+	// Only very old instance types are restricted to paravirtual.
+	switch strings.SplitN(info.InstanceType, ".", 2)[0] {
+	case "t1", "m1", "c1", "m2":
+		return true
+	}
+	return false
+}
+
+type metadata struct {
+	Version         string
+	PublicationDate time.Time
+	Disclaimer      string
+}
+
+type indexFile struct {
+	Version         string                 `json:"version"`
+	PublicationDate time.Time              `json:"publicationDate"`
+	Disclaimer      string                 `json:"disclaimer"`
+	Products        map[string]productInfo `json:"products"`
+	Terms           terms                  `json:"terms"`
+}
+
+type productInfo struct {
+	ProductFamily     string `json:"productFamily"` // Compute Instance
+	ProductAttributes `json:"attributes"`
+}
+
+type ProductAttributes struct {
+	Location              string `json:"location"`              // e.g. US East (N. Virginia)
+	InstanceType          string `json:"instanceType"`          // e.g. t2.nano
+	CurrentGeneration     string `json:"currentGeneration"`     // Yes|No
+	InstanceFamily        string `json:"instanceFamily"`        // e.g. Storage optimised
+	Storage               string `json:"storage"`               // e.g. 24 x 2000
+	VCPU                  uint64 `json:"vcpu,string"`           // e.g. 16
+	ClockSpeed            string `json:"clockSpeed"`            // e.g. 2.5 GHz
+	Memory                string `json:"memory"`                // N.NN GiB
+	OperatingSystem       string `json:"operatingSystem"`       // Windows|RHEL|SUSE|Linux
+	Tenancy               string `json:"tenancy"`               // Dedicated|Host|Shared
+	ProcessorArchitecture string `json:"processorArchitecture"` // (32-bit or )?64-bit
+}
+
+type terms struct {
+	OnDemand map[string]map[string]skuTerms `json:"OnDemand"`
+}
+
+type skuTerms struct {
+	EffectiveDate   time.Time                 `json:"effectiveDate"`
+	PriceDimensions map[string]pricingDetails `json:"priceDimensions"`
+}
+
+type pricingDetails struct {
+	Description  string `json:"description"`
+	Unit         string `json:"unit"`
+	PricePerUnit struct {
+		USD float64 `json:"USD,string"`
+	} `json:"pricePerUnit"`
+}
+
+type instanceType struct {
+	Name       string
+	Arches     string // amd64|both
+	CpuCores   uint64
+	Mem        uint64
+	Cost       uint64 // paravirtual|hvm
+	VirtType   string
+	CpuPower   uint64
+	Deprecated bool // i.e. not current generation
+
+	// extended information, for comments
+	SKU            string
+	InstanceFamily string
+	Storage        string
+}
+
+func main() {
+	rc, err := Main()
+	if err != nil {
+		log.Fatal(err)
+	}
+	os.Exit(rc)
+}


### PR DESCRIPTION
This diff adds a new internal package to the ec2
provider to contain instance type information.
The data is generated from the "Price List API":
    http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/price-changes.html

Included is a command that will be run by
"go generate". You must download the index.json
file from https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/index.json,
and then "go generate" will write generated.go.

In the future we may wish to extract functionality
from the "process_cost_data.go" command, so that
we can refresh the instance types and cost data
at runtime. This should not be difficult to do,
but it is beyond the scope of this diff.

The output has been compared to the existing hard-
coded instance type data in provider/ec2. There
are some differences:
 - the "cpu-power" values for the new data are
   not completely correct. This is because the
   price list API does not include that information.
   These values are estimated based on a rough
   formula involving the vCPUs and clock speed.
 - some of the old data was out-dated
 - there is information for regions that we did
   not previously include (namely ap-south-1)
 - some instance types are now considered HVM
   whereas they were PV before. For example, the
   M3 instance types are capable of both PV and
   HVM, but we previously said they were PV. We
   *should* allow either, but in lieu of doing
   that, we prefer HVM as Amazon suggests.