### PR TITLE
Setup lxd network unit test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ define DEPENDENCIES
   git-core
   mercurial
   zip
+  golang-1.[6-9]-race-detector-runtime
   $(GO_C)
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ define DEPENDENCIES
   git-core
   mercurial
   zip
-  golang-1.[6-9]-race-detector-runtime
   $(GO_C)
 endef
 

--- a/scripts/setup-lxd.sh
+++ b/scripts/setup-lxd.sh
@@ -15,7 +15,7 @@ if [[ "$VERSION" > "2.2" ]]; then
         # Configure a known address ranges for lxdbr0.
         lxc network create lxdbr0 \
             ipv4.address=10.0.8.1/24 ipv4.nat=true \
-            ipv6.address=d42:964b:da9f:f1a5::1/64 ipv6.nat=true
+            ipv6.address=none ipv6.nat=false
     fi
     lxc network show lxdbr0
     exit 0

--- a/scripts/setup-lxd.sh
+++ b/scripts/setup-lxd.sh
@@ -1,12 +1,27 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2016 Canonical Ltd.
 # Licensed under the AGPLv3, see LICENCE file for details.
-set -ex
+set -eux
 
 # Do the manual steps a user has to run on a fresh system to get an lxd
 # bridge so the juju lxd provider can function. Taken from changes made
 # to cloud-init to do approximately this.
 
+VERSION=$(lxd --version)
+
+# LXD 2.3+ needs lxdbr0 setup via lxc.
+if [[ "$VERSION" > "2.2" ]]; then
+    if [[ ! $(lxc network list | grep lxdbr0) ]]; then
+        # Configure a known address ranges for lxdbr0.
+        lxc network create lxdbr0 \
+            ipv4.address=10.0.8.1/24 ipv4.nat=true \
+            ipv6.address=d42:964b:da9f:f1a5::1/64 ipv6.nat=true
+    fi
+    lxc network show lxdbr0
+    exit 0
+fi
+
+# LXD 2.2 and earlier use debconf to create and configure the network.
 debconf-communicate << EOF
 set lxd/setup-bridge true
 set lxd/bridge-domain lxd


### PR DESCRIPTION
Setup local lxd 2.3 lxdbr0 bridge interface.

Local juju development and unit-tests need to configure lxdbr0 for lxd 2.3+. The old debconf approach is no longer supported.

I also added "golang-1.[6-9]-race-detector-runtime" to the list of required devel packages. This allows race testing without additional installs. Once this is merged, the Juju CI race test jobs can switch to the Makefile.

Testing:
A. Run setup-lxd-sh on a pristine yakkety with 2.3 as the only lxd ever installed.
   Run once to setup the network, run again to verify it just shows the current configuration
B. Run setup-lxd.sh on a pristine xenial host with lxd 2.0.4
   Run once to setup the network, run again to verify it reconfigures the network.
C Run setup-lxd.sh on an existing xenial host with lxd 2.0.4
   Run once to setup the network, run again to verify it reconfigures the network.