### PR TITLE
Improve error text for unauthorized add commands

### DIFF
--- a/cmd/juju/application/addrelation.go
+++ b/cmd/juju/application/addrelation.go
@@ -58,7 +58,7 @@ type ApplicationAddRelationAPI interface {
 	AddRelation(endpoints ...string) (*params.AddRelationResults, error)
 }
 
-func (c *addRelationCommand) Run(_ *cmd.Context) error {
+func (c *addRelationCommand) Run(ctx *cmd.Context) error {
 	client, err := c.newAPIFunc()
 	if err != nil {
 		return err
@@ -66,7 +66,7 @@ func (c *addRelationCommand) Run(_ *cmd.Context) error {
 	defer client.Close()
 	_, err = client.AddRelation(c.Endpoints...)
 	if params.IsCodeUnauthorized(err) {
-		return common.PermissionsError(err, "add a relation")
+		return common.PermissionsError(err, ctx.Stdout, "add a relation")
 	}
 	return block.ProcessBlockedError(err, block.BlockChange)
 }

--- a/cmd/juju/application/addrelation.go
+++ b/cmd/juju/application/addrelation.go
@@ -66,7 +66,7 @@ func (c *addRelationCommand) Run(ctx *cmd.Context) error {
 	defer client.Close()
 	_, err = client.AddRelation(c.Endpoints...)
 	if params.IsCodeUnauthorized(err) {
-		return common.PermissionsError(err, ctx.Stdout, "add a relation")
+		common.PermissionsMessage(ctx.Stderr, "add a relation")
 	}
 	return block.ProcessBlockedError(err, block.BlockChange)
 }

--- a/cmd/juju/application/addrelation.go
+++ b/cmd/juju/application/addrelation.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/block"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
@@ -64,5 +65,8 @@ func (c *addRelationCommand) Run(_ *cmd.Context) error {
 	}
 	defer client.Close()
 	_, err = client.AddRelation(c.Endpoints...)
+	if params.IsCodeUnauthorized(err) {
+		return common.PermissionsError(err, "add a relation")
+	}
 	return block.ProcessBlockedError(err, block.BlockChange)
 }

--- a/cmd/juju/application/addrelation_test.go
+++ b/cmd/juju/application/addrelation_test.go
@@ -81,9 +81,9 @@ func (s *AddRelationSuite) TestAddRelationUnauthorizedMentionsJujuGrant(c *gc.C)
 		Message: "permission denied",
 		Code:    params.CodeUnauthorized,
 	})
-	err := s.runAddRelation(c, "application1", "application2")
-	errString := strings.Replace(err.Error(), "\n", " ", -1)
-	c.Assert(errString, gc.Matches, `.*juju grant.*`)
+	ctx, _ := coretesting.RunCommand(c, NewAddRelationCommandForTest(s.mockAPI), "application1", "application2")
+	outString := strings.Replace(coretesting.Stdout(ctx), "\n", " ", -1)
+	c.Assert(outString, gc.Matches, `.*juju grant.*`)
 }
 
 type mockAddAPI struct {

--- a/cmd/juju/application/addrelation_test.go
+++ b/cmd/juju/application/addrelation_test.go
@@ -82,8 +82,8 @@ func (s *AddRelationSuite) TestAddRelationUnauthorizedMentionsJujuGrant(c *gc.C)
 		Code:    params.CodeUnauthorized,
 	})
 	ctx, _ := coretesting.RunCommand(c, NewAddRelationCommandForTest(s.mockAPI), "application1", "application2")
-	outString := strings.Replace(coretesting.Stdout(ctx), "\n", " ", -1)
-	c.Assert(outString, gc.Matches, `.*juju grant.*`)
+	errString := strings.Replace(coretesting.Stderr(ctx), "\n", " ", -1)
+	c.Assert(errString, gc.Matches, `.*juju grant.*`)
 }
 
 type mockAddAPI struct {

--- a/cmd/juju/application/addrelation_test.go
+++ b/cmd/juju/application/addrelation_test.go
@@ -4,6 +4,8 @@
 package application
 
 import (
+	"strings"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -72,6 +74,16 @@ func (s *AddRelationSuite) TestAddRelationBlocked(c *gc.C) {
 	coretesting.AssertOperationWasBlocked(c, err, ".*TestBlockAddRelation.*")
 	s.mockAPI.CheckCall(c, 0, "AddRelation", []string{"application1", "application2"})
 	s.mockAPI.CheckCall(c, 1, "Close")
+}
+
+func (s *AddRelationSuite) TestAddRelationUnauthorizedMentionsJujuGrant(c *gc.C) {
+	s.mockAPI.SetErrors(&params.Error{
+		Message: "permission denied",
+		Code:    params.CodeUnauthorized,
+	})
+	err := s.runAddRelation(c, "application1", "application2")
+	errString := strings.Replace(err.Error(), "\n", " ", -1)
+	c.Assert(errString, gc.Matches, `.*juju grant.*`)
 }
 
 type mockAddAPI struct {

--- a/cmd/juju/application/addunit.go
+++ b/cmd/juju/application/addunit.go
@@ -13,7 +13,9 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/application"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/block"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/instance"
 )
@@ -179,6 +181,9 @@ func (c *addUnitCommand) Run(_ *cmd.Context) error {
 		c.Placement[i] = p
 	}
 	_, err = apiclient.AddUnits(c.ApplicationName, c.NumUnits, c.Placement)
+	if params.IsCodeUnauthorized(err) {
+		return common.PermissionsError(err, "add a unit")
+	}
 	return block.ProcessBlockedError(err, block.BlockChange)
 }
 

--- a/cmd/juju/application/addunit.go
+++ b/cmd/juju/application/addunit.go
@@ -182,7 +182,7 @@ func (c *addUnitCommand) Run(ctx *cmd.Context) error {
 	}
 	_, err = apiclient.AddUnits(c.ApplicationName, c.NumUnits, c.Placement)
 	if params.IsCodeUnauthorized(err) {
-		return common.PermissionsError(err, ctx.Stdout, "add a unit")
+		common.PermissionsMessage(ctx.Stderr, "add a unit")
 	}
 	return block.ProcessBlockedError(err, block.BlockChange)
 }

--- a/cmd/juju/application/addunit.go
+++ b/cmd/juju/application/addunit.go
@@ -167,7 +167,7 @@ func (c *addUnitCommand) getAPI() (serviceAddUnitAPI, error) {
 
 // Run connects to the environment specified on the command line
 // and calls AddUnits for the given application.
-func (c *addUnitCommand) Run(_ *cmd.Context) error {
+func (c *addUnitCommand) Run(ctx *cmd.Context) error {
 	apiclient, err := c.getAPI()
 	if err != nil {
 		return err
@@ -182,7 +182,7 @@ func (c *addUnitCommand) Run(_ *cmd.Context) error {
 	}
 	_, err = apiclient.AddUnits(c.ApplicationName, c.NumUnits, c.Placement)
 	if params.IsCodeUnauthorized(err) {
-		return common.PermissionsError(err, "add a unit")
+		return common.PermissionsError(err, ctx.Stdout, "add a unit")
 	}
 	return block.ProcessBlockedError(err, block.BlockChange)
 }

--- a/cmd/juju/application/addunit_test.go
+++ b/cmd/juju/application/addunit_test.go
@@ -142,8 +142,8 @@ func (s *AddUnitSuite) TestUnauthorizedMentionsJujuGrant(c *gc.C) {
 		Code:    params.CodeUnauthorized,
 	}
 	ctx, _ := testing.RunCommand(c, application.NewAddUnitCommandForTest(s.fake), "some-application-name")
-	outString := strings.Replace(testing.Stdout(ctx), "\n", " ", -1)
-	c.Assert(outString, gc.Matches, `.*juju grant.*`)
+	errString := strings.Replace(testing.Stderr(ctx), "\n", " ", -1)
+	c.Assert(errString, gc.Matches, `.*juju grant.*`)
 }
 
 func (s *AddUnitSuite) TestForceMachine(c *gc.C) {

--- a/cmd/juju/application/addunit_test.go
+++ b/cmd/juju/application/addunit_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
@@ -133,6 +134,17 @@ func (s *AddUnitSuite) TestBlockAddUnit(c *gc.C) {
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
 	c.Check(stripped, gc.Matches, ".*TestBlockAddUnit.*")
+}
+
+func (s *AddUnitSuite) TestUnauthorizedMentionsJujuGrant(c *gc.C) {
+	s.fake.err = &params.Error{
+		Message: "permission denied",
+		Code:    params.CodeUnauthorized,
+	}
+	err := s.runAddUnit(c, "some-application-name")
+
+	stripped := strings.Replace(err.Error(), "\n", " ", -1)
+	c.Assert(stripped, gc.Matches, `.*juju grant.*`)
 }
 
 func (s *AddUnitSuite) TestForceMachine(c *gc.C) {

--- a/cmd/juju/application/addunit_test.go
+++ b/cmd/juju/application/addunit_test.go
@@ -141,10 +141,9 @@ func (s *AddUnitSuite) TestUnauthorizedMentionsJujuGrant(c *gc.C) {
 		Message: "permission denied",
 		Code:    params.CodeUnauthorized,
 	}
-	err := s.runAddUnit(c, "some-application-name")
-
-	stripped := strings.Replace(err.Error(), "\n", " ", -1)
-	c.Assert(stripped, gc.Matches, `.*juju grant.*`)
+	ctx, _ := testing.RunCommand(c, application.NewAddUnitCommandForTest(s.fake), "some-application-name")
+	outString := strings.Replace(testing.Stdout(ctx), "\n", " ", -1)
+	c.Assert(outString, gc.Matches, `.*juju grant.*`)
 }
 
 func (s *AddUnitSuite) TestForceMachine(c *gc.C) {

--- a/cmd/juju/common/errors.go
+++ b/cmd/juju/common/errors.go
@@ -1,0 +1,21 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+)
+
+var permMsg = "You do not have permission to %s."
+var grantMsg = `You may ask an administrator to grant you access with "juju grant".`
+
+func PermissionsError(err error, command string) error {
+	if command == "" {
+		command = "complete this operation"
+	}
+	permMsg := fmt.Sprintf(permMsg, command)
+	return errors.Errorf("%v\n\n%s\n%s\n", err, permMsg, grantMsg)
+}

--- a/cmd/juju/common/errors.go
+++ b/cmd/juju/common/errors.go
@@ -8,16 +8,14 @@ import (
 	"io"
 )
 
-var permMsg = "You do not have permission to %s."
-var grantMsg = `You may ask an administrator to grant you access with "juju grant".`
+func PermissionsMessage(writer io.Writer, command string) {
+	const (
+		perm  = "You do not have permission to %s."
+		grant = `You may ask an administrator to grant you access with "juju grant".`
+	)
 
-func PermissionsError(err error, stdout io.Writer, command string) error {
 	if command == "" {
 		command = "complete this operation"
 	}
-	permMsg := fmt.Sprintf(permMsg, command)
-	stdout.Write([]byte(
-		fmt.Sprintf("\n%s\n%s\n\n", permMsg, grantMsg)),
-	)
-	return err
+	fmt.Fprintf(writer, "\n%s\n%s\n\n", fmt.Sprintf(perm, command), grant)
 }

--- a/cmd/juju/common/errors.go
+++ b/cmd/juju/common/errors.go
@@ -5,17 +5,19 @@ package common
 
 import (
 	"fmt"
-
-	"github.com/juju/errors"
+	"io"
 )
 
 var permMsg = "You do not have permission to %s."
 var grantMsg = `You may ask an administrator to grant you access with "juju grant".`
 
-func PermissionsError(err error, command string) error {
+func PermissionsError(err error, stdout io.Writer, command string) error {
 	if command == "" {
 		command = "complete this operation"
 	}
 	permMsg := fmt.Sprintf(permMsg, command)
-	return errors.Errorf("%v\n\n%s\n%s\n", err, permMsg, grantMsg)
+	stdout.Write([]byte(
+		fmt.Sprintf("\n%s\n%s\n\n", permMsg, grantMsg)),
+	)
+	return err
 }

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -206,7 +206,7 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 	model, err := addModelClient.CreateModel(c.Name, modelOwner, cloudTag.Id(), cloudRegion, credentialTag, attrs)
 	if err != nil {
 		if params.IsCodeUnauthorized(err) {
-			return common.PermissionsError(err, "add a model")
+			return common.PermissionsError(err, ctx.Stdout, "add a model")
 		}
 		return errors.Trace(err)
 	}

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -205,6 +205,9 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 	addModelClient := c.newAddModelAPI(api)
 	model, err := addModelClient.CreateModel(c.Name, modelOwner, cloudTag.Id(), cloudRegion, credentialTag, attrs)
 	if err != nil {
+		if params.IsCodeUnauthorized(err) {
+			return common.PermissionsError(err, "add a model")
+		}
 		return errors.Trace(err)
 	}
 

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -206,7 +206,7 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 	model, err := addModelClient.CreateModel(c.Name, modelOwner, cloudTag.Id(), cloudRegion, credentialTag, attrs)
 	if err != nil {
 		if params.IsCodeUnauthorized(err) {
-			return common.PermissionsError(err, ctx.Stdout, "add a model")
+			common.PermissionsMessage(ctx.Stderr, "add a model")
 		}
 		return errors.Trace(err)
 	}

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -175,10 +175,9 @@ func (s *AddModelSuite) TestAddModelUnauthorizedMentionsJujuGrant(c *gc.C) {
 		Message: "permission denied",
 		Code:    params.CodeUnauthorized,
 	}
-	_, err := s.run(c, "test")
-	// Expect a friendly message mentioning the need use `juju grant`.
-	stripped := strings.Replace(err.Error(), "\n", " ", -1)
-	c.Assert(stripped, gc.Matches, `.*juju grant.*`)
+	ctx, _ := s.run(c, "test")
+	outString := strings.Replace(testing.Stdout(ctx), "\n", " ", -1)
+	c.Assert(outString, gc.Matches, `.*juju grant.*`)
 }
 
 func (s *AddModelSuite) TestCredentialsPassedThrough(c *gc.C) {

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -176,8 +176,8 @@ func (s *AddModelSuite) TestAddModelUnauthorizedMentionsJujuGrant(c *gc.C) {
 		Code:    params.CodeUnauthorized,
 	}
 	ctx, _ := s.run(c, "test")
-	outString := strings.Replace(testing.Stdout(ctx), "\n", " ", -1)
-	c.Assert(outString, gc.Matches, `.*juju grant.*`)
+	errString := strings.Replace(testing.Stderr(ctx), "\n", " ", -1)
+	c.Assert(errString, gc.Matches, `.*juju grant.*`)
 }
 
 func (s *AddModelSuite) TestCredentialsPassedThrough(c *gc.C) {

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -6,6 +6,7 @@ package controller_test
 import (
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -167,6 +168,17 @@ func (s *AddModelSuite) TestAddExistingName(c *gc.C) {
 	details, err := s.store.ModelByName("test-master", "bob/test")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(details, jc.DeepEquals, &jujuclient.ModelDetails{"fake-model-uuid"})
+}
+
+func (s *AddModelSuite) TestAddModelUnauthorizedMentionsJujuGrant(c *gc.C) {
+	s.fakeAddModelAPI.err = &params.Error{
+		Message: "permission denied",
+		Code:    params.CodeUnauthorized,
+	}
+	_, err := s.run(c, "test")
+	// Expect a friendly message mentioning the need use `juju grant`.
+	stripped := strings.Replace(err.Error(), "\n", " ", -1)
+	c.Assert(stripped, gc.Matches, `.*juju grant.*`)
 }
 
 func (s *AddModelSuite) TestCredentialsPassedThrough(c *gc.C) {

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -236,6 +236,9 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 	defer modelConfigClient.Close()
 	configAttrs, err := modelConfigClient.ModelGet()
 	if err != nil {
+		if params.IsCodeUnauthorized(err) {
+			return common.PermissionsError(err, "add a machine to this model")
+		}
 		return errors.Trace(err)
 	}
 	config, err := config.New(config.NoDefaults, configAttrs)

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -237,7 +237,7 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 	configAttrs, err := modelConfigClient.ModelGet()
 	if err != nil {
 		if params.IsCodeUnauthorized(err) {
-			return common.PermissionsError(err, ctx.Stdout, "add a machine to this model")
+			common.PermissionsMessage(ctx.Stderr, "add a machine to this model")
 		}
 		return errors.Trace(err)
 	}

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -237,7 +237,7 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 	configAttrs, err := modelConfigClient.ModelGet()
 	if err != nil {
 		if params.IsCodeUnauthorized(err) {
-			return common.PermissionsError(err, "add a machine to this model")
+			return common.PermissionsError(err, ctx.Stdout, "add a machine to this model")
 		}
 		return errors.Trace(err)
 	}

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -129,8 +129,8 @@ func (s *AddMachineSuite) TestAddMachineUnauthorizedMentionsJujuGrant(c *gc.C) {
 		Code:    params.CodeUnauthorized,
 	}
 	ctx, _ := s.run(c)
-	outString := strings.Replace(testing.Stdout(ctx), "\n", " ", -1)
-	c.Assert(outString, gc.Matches, `.*juju grant.*`)
+	errString := strings.Replace(testing.Stderr(ctx), "\n", " ", -1)
+	c.Assert(errString, gc.Matches, `.*juju grant.*`)
 }
 
 func (s *AddMachineSuite) TestSSHPlacement(c *gc.C) {

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -128,10 +128,9 @@ func (s *AddMachineSuite) TestAddMachineUnauthorizedMentionsJujuGrant(c *gc.C) {
 		Message: "permission denied",
 		Code:    params.CodeUnauthorized,
 	}
-	_, err := s.run(c)
-	// Expect a friendly message mentioning the need use `juju grant`.
-	stripped := strings.Replace(err.Error(), "\n", " ", -1)
-	c.Assert(stripped, gc.Matches, `.*juju grant.*`)
+	ctx, _ := s.run(c)
+	outString := strings.Replace(testing.Stdout(ctx), "\n", " ", -1)
+	c.Assert(outString, gc.Matches, `.*juju grant.*`)
 }
 
 func (s *AddMachineSuite) TestSSHPlacement(c *gc.C) {

--- a/cmd/juju/space/add.go
+++ b/cmd/juju/space/add.go
@@ -70,7 +70,7 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 				ctx.Infof("cannot add space %q: %v", c.Name, err)
 			}
 			if params.IsCodeUnauthorized(err) {
-				return common.PermissionsError(err, ctx.Stdout, "add a space")
+				common.PermissionsMessage(ctx.Stderr, "add a space")
 			}
 			return errors.Annotatef(err, "cannot add space %q", c.Name)
 		}

--- a/cmd/juju/space/add.go
+++ b/cmd/juju/space/add.go
@@ -70,7 +70,7 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 				ctx.Infof("cannot add space %q: %v", c.Name, err)
 			}
 			if params.IsCodeUnauthorized(err) {
-				return common.PermissionsError(err, "add a space")
+				return common.PermissionsError(err, ctx.Stdout, "add a space")
 			}
 			return errors.Annotatef(err, "cannot add space %q", c.Name)
 		}

--- a/cmd/juju/space/add.go
+++ b/cmd/juju/space/add.go
@@ -11,6 +11,8 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/set"
 
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
@@ -66,6 +68,9 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 		if err != nil {
 			if errors.IsNotSupported(err) {
 				ctx.Infof("cannot add space %q: %v", c.Name, err)
+			}
+			if params.IsCodeUnauthorized(err) {
+				return common.PermissionsError(err, "add a space")
 			}
 			return errors.Annotatef(err, "cannot add space %q", c.Name)
 		}

--- a/cmd/juju/space/add_test.go
+++ b/cmd/juju/space/add_test.go
@@ -8,6 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/space"
 )
 
@@ -71,4 +72,16 @@ func (s *AddSuite) TestRunWhenSpacesAPIFails(c *gc.C) {
 
 	s.api.CheckCallNames(c, "AddSpace", "Close")
 	s.api.CheckCall(c, 0, "AddSpace", "foo", s.Strings("10.1.2.0/24"), true)
+}
+
+func (s *AddSuite) TestRunUnauthorizedMentionsJujuGrant(c *gc.C) {
+	s.api.SetErrors(&params.Error{
+		Message: "permission denied",
+		Code:    params.CodeUnauthorized,
+	})
+
+	s.AssertRunFailsUnauthorized(c,
+		`*.juju grant.*`,
+		"foo", "10.1.2.0/24",
+	)
 }

--- a/cmd/juju/space/package_test.go
+++ b/cmd/juju/space/package_test.go
@@ -96,9 +96,8 @@ func (s *BaseSpaceSuite) AssertRunSpacesNotSupported(c *gc.C, expectErr string, 
 // passed args then asserting the error is as expected, finally returning the
 // error.
 func (s *BaseSpaceSuite) AssertRunFailsUnauthorized(c *gc.C, expectErr string, args ...string) error {
-	_, _, err := s.RunCommand(c, args...)
-	errString := strings.Replace(err.Error(), "\n", " ", -1)
-	c.Assert(errString, gc.Matches, expectErr)
+	stdout, _, _ := s.RunCommand(c, args...)
+	c.Assert(strings.Replace(stdout, "\n", " ", -1), gc.Matches, `.*juju grant.*`)
 	return err
 }
 

--- a/cmd/juju/space/package_test.go
+++ b/cmd/juju/space/package_test.go
@@ -96,8 +96,8 @@ func (s *BaseSpaceSuite) AssertRunSpacesNotSupported(c *gc.C, expectErr string, 
 // passed args then asserting the error is as expected, finally returning the
 // error.
 func (s *BaseSpaceSuite) AssertRunFailsUnauthorized(c *gc.C, expectErr string, args ...string) error {
-	stdout, _, _ := s.RunCommand(c, args...)
-	c.Assert(strings.Replace(stdout, "\n", " ", -1), gc.Matches, `.*juju grant.*`)
+	_, stderr, err := s.RunCommand(c, args...)
+	c.Assert(strings.Replace(stderr, "\n", " ", -1), gc.Matches, `.*juju grant.*`)
 	return err
 }
 

--- a/cmd/juju/space/package_test.go
+++ b/cmd/juju/space/package_test.go
@@ -4,6 +4,7 @@
 package space_test
 
 import (
+	"strings"
 	stdtesting "testing"
 
 	"github.com/juju/cmd"
@@ -88,6 +89,16 @@ func (s *BaseSpaceSuite) AssertRunSpacesNotSupported(c *gc.C, expectErr string, 
 	c.Assert(err, gc.ErrorMatches, expectErr)
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, expectErr+"\n")
+	return err
+}
+
+// AssertRunFailsUnauthoirzed is a shortcut for calling RunCommand with the
+// passed args then asserting the error is as expected, finally returning the
+// error.
+func (s *BaseSpaceSuite) AssertRunFailsUnauthorized(c *gc.C, expectErr string, args ...string) error {
+	_, _, err := s.RunCommand(c, args...)
+	errString := strings.Replace(err.Error(), "\n", " ", -1)
+	c.Assert(errString, gc.Matches, expectErr)
 	return err
 }
 

--- a/cmd/juju/storage/add.go
+++ b/cmd/juju/storage/add.go
@@ -132,7 +132,7 @@ func (c *addCommand) Run(ctx *cmd.Context) (err error) {
 	results, err := api.AddToUnit(storages)
 	if err != nil {
 		if params.IsCodeUnauthorized(err) {
-			return common.PermissionsError(err, "add storage")
+			return common.PermissionsError(err, ctx.Stdout, "add storage")
 		}
 		return err
 	}

--- a/cmd/juju/storage/add.go
+++ b/cmd/juju/storage/add.go
@@ -132,7 +132,7 @@ func (c *addCommand) Run(ctx *cmd.Context) (err error) {
 	results, err := api.AddToUnit(storages)
 	if err != nil {
 		if params.IsCodeUnauthorized(err) {
-			return common.PermissionsError(err, ctx.Stdout, "add storage")
+			common.PermissionsMessage(ctx.Stderr, "add storage")
 		}
 		return err
 	}

--- a/cmd/juju/storage/add.go
+++ b/cmd/juju/storage/add.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/storage"
 )
@@ -130,6 +131,9 @@ func (c *addCommand) Run(ctx *cmd.Context) (err error) {
 	storages := c.createStorageAddParams()
 	results, err := api.AddToUnit(storages)
 	if err != nil {
+		if params.IsCodeUnauthorized(err) {
+			return common.PermissionsError(err, "add storage")
+		}
 		return err
 	}
 

--- a/cmd/juju/storage/add_test.go
+++ b/cmd/juju/storage/add_test.go
@@ -223,6 +223,20 @@ func (s *addSuite) TestCollapseUnitErrors(c *gc.C) {
 	s.assertAddErrorOutput(c, "cmd: error out silently", "", fmt.Sprintf("%v\n", expectedErr))
 }
 
+func (s *addSuite) TestUnauthorizedMentionsJujuGrant(c *gc.C) {
+	s.args = []string{"tst/123", "data"}
+	s.mockAPI.addToUnitFunc = func(storages []params.StorageAddParams) ([]params.ErrorResult, error) {
+		return nil, &params.Error{
+			Message: "permission denied",
+			Code:    params.CodeUnauthorized,
+		}
+	}
+
+	_, err := s.runAdd(c, s.args...)
+	errString := strings.Replace(err.Error(), "\n", " ", -1)
+	c.Assert(errString, gc.Matches, `.*juju grant.*`)
+}
+
 func (s *addSuite) assertAddOutput(c *gc.C, expectedOut, expectedErr string) {
 	context, err := s.runAdd(c, s.args...)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/storage/add_test.go
+++ b/cmd/juju/storage/add_test.go
@@ -233,8 +233,8 @@ func (s *addSuite) TestUnauthorizedMentionsJujuGrant(c *gc.C) {
 	}
 
 	ctx, _ := s.runAdd(c, s.args...)
-	outString := strings.Replace(testing.Stdout(ctx), "\n", " ", -1)
-	c.Assert(outString, gc.Matches, `.*juju grant.*`)
+	errString := strings.Replace(testing.Stderr(ctx), "\n", " ", -1)
+	c.Assert(errString, gc.Matches, `.*juju grant.*`)
 }
 
 func (s *addSuite) assertAddOutput(c *gc.C, expectedOut, expectedErr string) {

--- a/cmd/juju/storage/add_test.go
+++ b/cmd/juju/storage/add_test.go
@@ -232,9 +232,9 @@ func (s *addSuite) TestUnauthorizedMentionsJujuGrant(c *gc.C) {
 		}
 	}
 
-	_, err := s.runAdd(c, s.args...)
-	errString := strings.Replace(err.Error(), "\n", " ", -1)
-	c.Assert(errString, gc.Matches, `.*juju grant.*`)
+	ctx, _ := s.runAdd(c, s.args...)
+	outString := strings.Replace(testing.Stdout(ctx), "\n", " ", -1)
+	c.Assert(outString, gc.Matches, `.*juju grant.*`)
 }
 
 func (s *addSuite) assertAddOutput(c *gc.C, expectedOut, expectedErr string) {

--- a/cmd/juju/subnet/add.go
+++ b/cmd/juju/subnet/add.go
@@ -11,6 +11,8 @@ import (
 	"github.com/juju/juju/network"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
@@ -111,6 +113,8 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 			// Special case: multiple subnets with the same CIDR exist
 			ctx.Infof("ERROR: %v.", err)
 			return nil
+		} else if err != nil && params.IsCodeUnauthorized(err) {
+			return common.PermissionsError(err, "add a subnet")
 		} else if err != nil {
 			return errors.Annotatef(err, "cannot add subnet")
 		}

--- a/cmd/juju/subnet/add.go
+++ b/cmd/juju/subnet/add.go
@@ -113,9 +113,10 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 			// Special case: multiple subnets with the same CIDR exist
 			ctx.Infof("ERROR: %v.", err)
 			return nil
-		} else if err != nil && params.IsCodeUnauthorized(err) {
-			return common.PermissionsError(err, ctx.Stdout, "add a subnet")
 		} else if err != nil {
+			if params.IsCodeUnauthorized(err) {
+				common.PermissionsMessage(ctx.Stderr, "add a subnet")
+			}
 			return errors.Annotatef(err, "cannot add subnet")
 		}
 

--- a/cmd/juju/subnet/add.go
+++ b/cmd/juju/subnet/add.go
@@ -114,7 +114,7 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 			ctx.Infof("ERROR: %v.", err)
 			return nil
 		} else if err != nil && params.IsCodeUnauthorized(err) {
-			return common.PermissionsError(err, "add a subnet")
+			return common.PermissionsError(err, ctx.Stdout, "add a subnet")
 		} else if err != nil {
 			return errors.Annotatef(err, "cannot add subnet")
 		}

--- a/cmd/juju/subnet/add_test.go
+++ b/cmd/juju/subnet/add_test.go
@@ -225,9 +225,8 @@ func (s *AddSuite) TestRunUnauthorizedMentionsJujuGrant(c *gc.C) {
 		Message: "permission denied",
 		Code:    params.CodeUnauthorized,
 	})
-	_, _, err := s.RunCommand(c, "10.10.0.0/24", "myspace")
-	errString := strings.Replace(err.Error(), "\n", " ", -1)
-	c.Assert(errString, gc.Matches, `.*juju grant.*`)
+	stdout, _, _ := s.RunCommand(c, "10.10.0.0/24", "myspace")
+	c.Assert(strings.Replace(stdout, "\n", " ", -1), gc.Matches, `.*juju grant.*`)
 }
 
 func (s *AddSuite) TestRunWithAmbiguousCIDRDisplaysError(c *gc.C) {

--- a/cmd/juju/subnet/add_test.go
+++ b/cmd/juju/subnet/add_test.go
@@ -225,8 +225,8 @@ func (s *AddSuite) TestRunUnauthorizedMentionsJujuGrant(c *gc.C) {
 		Message: "permission denied",
 		Code:    params.CodeUnauthorized,
 	})
-	stdout, _, _ := s.RunCommand(c, "10.10.0.0/24", "myspace")
-	c.Assert(strings.Replace(stdout, "\n", " ", -1), gc.Matches, `.*juju grant.*`)
+	_, stderr, _ := s.RunCommand(c, "10.10.0.0/24", "myspace")
+	c.Assert(strings.Replace(stderr, "\n", " ", -1), gc.Matches, `.*juju grant.*`)
 }
 
 func (s *AddSuite) TestRunWithAmbiguousCIDRDisplaysError(c *gc.C) {

--- a/cmd/juju/subnet/add_test.go
+++ b/cmd/juju/subnet/add_test.go
@@ -12,6 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/subnet"
 	"github.com/juju/juju/network"
 	coretesting "github.com/juju/juju/testing"
@@ -217,6 +218,16 @@ func (s *AddSuite) TestRunWithNonExistingSpaceFails(c *gc.C) {
 		names.NewSpaceTag("space"),
 		s.Strings("zone1", "zone2"),
 	)
+}
+
+func (s *AddSuite) TestRunUnauthorizedMentionsJujuGrant(c *gc.C) {
+	s.api.SetErrors(&params.Error{
+		Message: "permission denied",
+		Code:    params.CodeUnauthorized,
+	})
+	_, _, err := s.RunCommand(c, "10.10.0.0/24", "myspace")
+	errString := strings.Replace(err.Error(), "\n", " ", -1)
+	c.Assert(errString, gc.Matches, `.*juju grant.*`)
 }
 
 func (s *AddSuite) TestRunWithAmbiguousCIDRDisplaysError(c *gc.C) {

--- a/cmd/juju/user/add.go
+++ b/cmd/juju/user/add.go
@@ -102,7 +102,7 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 	_, secretKey, err := api.AddUser(c.User, c.DisplayName, "")
 	if err != nil {
 		if params.IsCodeUnauthorized(err) {
-			return common.PermissionsError(err, ctx.Stdout, "add a user")
+			common.PermissionsMessage(ctx.Stderr, "add a user")
 		}
 		return block.ProcessBlockedError(err, block.BlockChange)
 	}

--- a/cmd/juju/user/add.go
+++ b/cmd/juju/user/add.go
@@ -102,7 +102,7 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 	_, secretKey, err := api.AddUser(c.User, c.DisplayName, "")
 	if err != nil {
 		if params.IsCodeUnauthorized(err) {
-			return common.PermissionsError(err, "add a user")
+			return common.PermissionsError(err, ctx.Stdout, "add a user")
 		}
 		return block.ProcessBlockedError(err, block.BlockChange)
 	}

--- a/cmd/juju/user/add.go
+++ b/cmd/juju/user/add.go
@@ -12,7 +12,9 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/block"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 )
@@ -99,6 +101,9 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 	// "juju register".
 	_, secretKey, err := api.AddUser(c.User, c.DisplayName, "")
 	if err != nil {
+		if params.IsCodeUnauthorized(err) {
+			return common.PermissionsError(err, "add a user")
+		}
 		return block.ProcessBlockedError(err, block.BlockChange)
 	}
 

--- a/cmd/juju/user/add_test.go
+++ b/cmd/juju/user/add_test.go
@@ -140,9 +140,9 @@ func (s *UserAddCommandSuite) TestAddUserUnauthorizedMentionsJujuGrant(c *gc.C) 
 		Message: "permission denied",
 		Code:    params.CodeUnauthorized,
 	}
-	_, err := s.run(c, "foobar")
-	errString := strings.Replace(err.Error(), "\n", " ", -1)
-	c.Assert(errString, gc.Matches, `*.juju grant.*`)
+	ctx, _ := s.run(c, "foobar")
+	outString := strings.Replace(testing.Stdout(ctx), "\n", " ", -1)
+	c.Assert(outString, gc.Matches, `.*juju grant.*`)
 }
 
 type mockAddUserAPI struct {

--- a/cmd/juju/user/add_test.go
+++ b/cmd/juju/user/add_test.go
@@ -141,8 +141,8 @@ func (s *UserAddCommandSuite) TestAddUserUnauthorizedMentionsJujuGrant(c *gc.C) 
 		Code:    params.CodeUnauthorized,
 	}
 	ctx, _ := s.run(c, "foobar")
-	outString := strings.Replace(testing.Stdout(ctx), "\n", " ", -1)
-	c.Assert(outString, gc.Matches, `.*juju grant.*`)
+	errString := strings.Replace(testing.Stderr(ctx), "\n", " ", -1)
+	c.Assert(errString, gc.Matches, `.*juju grant.*`)
 }
 
 type mockAddUserAPI struct {


### PR DESCRIPTION
The following commands now output more user-friendly responses,
mentioning the use of `juju grant`, when the API returns an
"unauthorized access" error.

 * add-machine
 * add-model
 * add-relation
 * add-space
 * add-storage
 * add-subnet
 * add-unit
 * add-user

Fixes lp:1612046

QA steps:

  * Add both a new local user and a new Juju user
    * `juju add-user foo`  and `juju grant foo read default` 
    * `sudo adduser foo` and `sudo su - foo`
  * As the new local user foo,
    * `juju register <as output by juju register>` 
    * `juju switch <controller>:admin@local/default`
  * Now that you are logged into Juju as the Juju user foo, test each of the list commands. When each errors for lack of permissions, you should see an error message mentioning the use of `juju grant`.