### PR TITLE
upgrade-charm now allows upgrading local charms

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -61,29 +61,40 @@ func (c *Client) ModelUUID() string {
 
 // DeployArgs holds the arguments to be sent to Client.ServiceDeploy.
 type DeployArgs struct {
+
 	// CharmID identifies the charm to deploy.
 	CharmID charmstore.CharmID
+
 	// ApplicationName is the name to give the application.
 	ApplicationName string
+
 	// Series to be used for the machine.
 	Series string
+
 	// NumUnits is the number of units to deploy.
 	NumUnits int
+
 	// ConfigYAML is a string that overrides the default config.yml.
 	ConfigYAML string
-	// Cons contains constraints on where units of this application may be
-	// placed.
+
+	// Cons contains constraints on where units of this application
+	// may be placed.
 	Cons constraints.Value
+
 	// Placement directives on where the machines for the unit must be
 	// created.
 	Placement []*instance.Placement
+
 	// Storage contains Constraints specifying how storage should be
 	// handled.
 	Storage map[string]storage.Constraints
+
 	// EndpointBindings
 	EndpointBindings map[string]string
-	// Collection of resource names for the application, with the value being the
-	// unique ID of a pre-uploaded resources in storage.
+
+	// Collection of resource names for the application, with the
+	// value being the unique ID of a pre-uploaded resources in
+	// storage.
 	Resources map[string]string
 }
 
@@ -110,9 +121,9 @@ func (c *Client) Deploy(args DeployArgs) error {
 	var err error
 	err = c.facade.FacadeCall("Deploy", deployArgs, &results)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
-	return results.OneError()
+	return errors.Trace(results.OneError())
 }
 
 // GetCharmURL returns the charm URL the given service is
@@ -122,10 +133,10 @@ func (c *Client) GetCharmURL(serviceName string) (*charm.URL, error) {
 	args := params.ApplicationGet{ApplicationName: serviceName}
 	err := c.facade.FacadeCall("GetCharmURL", args, result)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	if result.Error != nil {
-		return nil, result.Error
+		return nil, errors.Trace(result.Error)
 	}
 	return charm.ParseURL(result.Result)
 }

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -675,20 +675,6 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 	return block.ProcessBlockedError(deploy(ctx, apiRoot), block.BlockChange)
 }
 
-func (c *DeployCommand) newResolver(apiRoot DeployAPI) (*config.Config, *csclient.Client, error) {
-	bakeryClient, err := c.BakeryClient()
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
-	csClient := newCharmStoreClient(bakeryClient).WithChannel(c.Channel)
-	conf, err := getModelConfig(apiRoot)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
-
-	return conf, csClient, nil
-}
-
 func findDeployerFIFO(maybeDeployers ...func() (deployFn, error)) (deployFn, error) {
 	for _, d := range maybeDeployers {
 		if deploy, err := d(); err != nil {

--- a/cmd/juju/application/upgradecharm_resources_test.go
+++ b/cmd/juju/application/upgradecharm_resources_test.go
@@ -55,8 +55,9 @@ func (s *UpgradeCharmResourceSuite) SetUpTest(c *gc.C) {
 	c.Assert(forced, jc.IsFalse)
 }
 
-var riakResourceMeta = []byte(`
-name: riakresource
+func (s *UpgradeCharmResourceSuite) TestUpgradeWithResources(c *gc.C) {
+	const riakResourceMeta = `
+name: riak
 summary: "K/V storage engine"
 description: "Scalable K/V Store in Erlang with Clocks :-)"
 provides:
@@ -72,11 +73,10 @@ resources:
     type: file
     filename: foo.lib
     description: some comment
-`)
+`
 
-func (s *UpgradeCharmResourceSuite) TestUpgradeWithResources(c *gc.C) {
 	myriakPath := testcharms.Repo.ClonedDir(c.MkDir(), "riak")
-	err := ioutil.WriteFile(path.Join(myriakPath.Path, "metadata.yaml"), riakResourceMeta, 0644)
+	err := ioutil.WriteFile(path.Join(myriakPath.Path, "metadata.yaml"), []byte(riakResourceMeta), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	data := []byte("some-data")


### PR DESCRIPTION
This fixes lp:1609463.

This had a few root causes:

1. We naively assumed that arg[0] was the application name. In the case of local charms, this is just the path to a local charm.
2. Even if it is the application name, such checks need to be left to the controller because of potential client/server version mismatches. The controller has the ultimate say on what is considered acceptable.
3. In the event that we try and add a local charm, to verify we're upgrading the same charm, we check whether the application names are the same. We were incorrectly checking the argument to `--path` as the charm name and not the application name in the metadata.yaml. This was an implicit assumption that the path reflects the application name (not always true).

There are also some very minor drive-by clean-ups in our Sisyphusian effort to converge towards a better codebase.

Further clean-ups in this area are possible; namely:

- Passing in an `UpgradeCharmAPI` type and using it throughout.
- There is commonality between `deploy` and `upgrade-charm` in resolving arguments and doing something useful with them. There is an opportunity to create a component and to pass it into both commands.