### PR TITLE
Improve HA recovery

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -252,8 +252,8 @@ func (srv *Server) run() {
 		err := srv.lis.Close()
 		logger.Infof("closed listening socket %q with final error: %v", addr, err)
 
-		srv.state.HackLeadership() // Break deadlocks caused by BlockUntil... calls.
-		srv.wg.Wait()              // wait for any outstanding requests to complete.
+		srv.state.KillWorkers() // Break deadlocks caused by leadership BlockUntil... calls.
+		srv.wg.Wait()           // wait for any outstanding requests to complete.
 		srv.tomb.Done()
 		srv.statePool.Close()
 		srv.state.Close()

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -252,8 +252,11 @@ func (srv *Server) run() {
 		err := srv.lis.Close()
 		logger.Infof("closed listening socket %q with final error: %v", addr, err)
 
-		srv.state.KillWorkers() // Break deadlocks caused by leadership BlockUntil... calls.
-		srv.wg.Wait()           // wait for any outstanding requests to complete.
+		// Break deadlocks caused by leadership BlockUntil... calls.
+		srv.statePool.KillWorkers()
+		srv.state.KillWorkers()
+
+		srv.wg.Wait() // wait for any outstanding requests to complete.
 		srv.tomb.Done()
 		srv.statePool.Close()
 		srv.state.Close()

--- a/mongo/open.go
+++ b/mongo/open.go
@@ -131,12 +131,12 @@ func DialInfo(info Info, opts DialOpts) (*mgo.DialInfo, error) {
 		addr := server.TCPAddr().String()
 		c, err := net.DialTimeout("tcp", addr, opts.Timeout)
 		if err != nil {
-			logger.Errorf("mongodb connection failed, will retry: %v", err)
+			logger.Warningf("mongodb connection failed, will retry: %v", err)
 			return nil, err
 		}
 		cc := tls.Client(c, tlsConfig)
 		if err := cc.Handshake(); err != nil {
-			logger.Errorf("TLS handshake failed: %v", err)
+			logger.Warningf("TLS handshake failed: %v", err)
 			return nil, err
 		}
 		logger.Debugf("dialled mongodb server at %q", addr)

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/version"
+	"github.com/juju/juju/worker"
 )
 
 const (
@@ -555,4 +556,10 @@ func PrimeUnitStatusHistory(
 	buildTxn := updateStatusSource(unit.st, globalKey, doc)
 	err := unit.st.run(buildTxn)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+// GetInternalWorkers returns the internal workers managed by a State
+// to allow inspection in tests.
+func GetInternalWorkers(st *State) worker.Worker {
+	return st.workers
 }

--- a/state/leadership.go
+++ b/state/leadership.go
@@ -37,25 +37,6 @@ func (st *State) LeadershipChecker() leadership.Checker {
 	return leadershipChecker{st.workers.LeadershipManager()}
 }
 
-// HackLeadership stops the state's internal leadership manager to prevent it
-// from interfering with apiserver shutdown.
-func (st *State) HackLeadership() {
-	// TODO(fwereade): 2015-08-07 lp:1482634
-	// obviously, this should not exist: it's a quick hack to address lp:1481368 in
-	// 1.24.4, and should be quickly replaced with something that isn't so heinous.
-	//
-	// But.
-	//
-	// I *believe* that what it'll take to fix this is to extract the mongo-session-
-	// opening from state.Open, so we can create a mongosessioner Manifold on which
-	// state, leadership, watching, tools storage, etc etc etc can all independently
-	// depend. (Each dependency would/should have a separate session so they can
-	// close them all on their own schedule, without panics -- but the failure of
-	// the shared component should successfully goose them all into shutting down,
-	// in parallel, of their own accord.)
-	st.workers.Kill()
-}
-
 // buildTxnWithLeadership returns a transaction source that combines the supplied source
 // with checks and asserts on the supplied token.
 func buildTxnWithLeadership(buildTxn jujutxn.TransactionSource, token leadership.Token) jujutxn.TransactionSource {

--- a/state/pool.go
+++ b/state/pool.go
@@ -55,6 +55,16 @@ func (p *StatePool) SystemState() *State {
 	return p.systemState
 }
 
+// KillWorkers tells the internal worker for all cached State
+// instances in the pool to die.
+func (p *StatePool) KillWorkers() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, st := range p.pool {
+		st.KillWorkers()
+	}
+}
+
 // Close closes all State instances in the pool.
 func (p *StatePool) Close() error {
 	p.mu.Lock()

--- a/state/state.go
+++ b/state/state.go
@@ -377,6 +377,26 @@ func (st *State) start(controllerTag names.ControllerTag) (err error) {
 	return nil
 }
 
+// KillWorkers tells the state's internal workers to die. This is
+// mainly used to kill the leadership manager to prevent it from
+// interfering with apiserver shutdown.
+func (st *State) KillWorkers() {
+	// TODO(fwereade): 2015-08-07 lp:1482634
+	// obviously, this should not exist: it's a quick hack to address lp:1481368 in
+	// 1.24.4, and should be quickly replaced with something that isn't so heinous.
+	//
+	// But.
+	//
+	// I *believe* that what it'll take to fix this is to extract the mongo-session-
+	// opening from state.Open, so we can create a mongosessioner Manifold on which
+	// state, leadership, watching, tools storage, etc etc etc can all independently
+	// depend. (Each dependency would/should have a separate session so they can
+	// close them all on their own schedule, without panics -- but the failure of
+	// the shared component should successfully goose them all into shutting down,
+	// in parallel, of their own accord.)
+	st.workers.Kill()
+}
+
 // ApplicationLeaders returns a map of the application name to the
 // unit name that is the current leader.
 func (st *State) ApplicationLeaders() (map[string]string, error) {

--- a/state/state_leader_test.go
+++ b/state/state_leader_test.go
@@ -115,11 +115,11 @@ func (s *LeadershipSuite) TestCheck(c *gc.C) {
 	c.Check(ops2, gc.IsNil)
 }
 
-func (s *LeadershipSuite) TestHackLeadershipUnblocksClaimer(c *gc.C) {
+func (s *LeadershipSuite) TestKillWorkersUnblocksClaimer(c *gc.C) {
 	err := s.claimer.ClaimLeadership("blah", "blah/0", time.Minute)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.State.HackLeadership()
+	s.State.KillWorkers()
 	select {
 	case err := <-s.expiryChan("blah"):
 		c.Check(err, gc.ErrorMatches, "lease manager stopped")


### PR DESCRIPTION
This contains 2 fixes which improve Juju's handling of a HA primary change. 

1. A timeout is now used when dialling a mongodb server. This greatly reduces the time for mgo to respond to a mongodb server going away and therefore also improves Juju's recovery to the mongodb master changing.
2. HackLeadership (now called KillWorkers) is now called on all States in the apiserver's StatePool. This prevents a leadership API request for a hosted model from preventing apiserver shutdown (observed during HA failovers).

Fixes https://bugs.launchpad.net/juju/+bug/1588224

### QA

Bootstrap and use enable-ha to create a 3 node controller. Once stable, stop the primary node. Watch the logs to see when controllers recover. Before these changes it would take minutes for the controllers to recover and the apiserver to be back up again. With these changes the time between the primary being stopped and the apiserver being back up again is < 60s.

There are many more improvements that can be made but they are more risky/invasive and will be tackled in future PRs.