### PR TITLE
provider/openstack: shorten hostnames

### DIFF
--- a/instance/namespace.go
+++ b/instance/namespace.go
@@ -19,6 +19,7 @@ const uuidSuffixDigits = 6
 type Namespace interface {
 	// Prefix returns the common part of the hostnames. i.e. 'juju-xxxxxx-'
 	Prefix() string
+
 	// Hostname returns a name suitable to be used for a machine hostname.
 	// This function returns an error if the machine tags is invalid.
 	Hostname(machineID string) (string, error)
@@ -26,6 +27,9 @@ type Namespace interface {
 	// MachineTag does the reverse of the Hostname method, and extracts the
 	// Tag from the hostname.
 	MachineTag(hostname string) (names.MachineTag, error)
+
+	// Value returns the input prefixed with the namespace prefix.
+	Value(string) string
 }
 
 type namespace struct {
@@ -50,7 +54,12 @@ func (n *namespace) Hostname(machineID string) (string, error) {
 		return "", errors.Errorf("machine ID %q is not a valid machine", machineID)
 	}
 	machineID = strings.Replace(machineID, "/", "-", -1)
-	return n.Prefix() + machineID, nil
+	return n.Value(machineID), nil
+}
+
+// Value returns the input prefixed with the namespace prefix.
+func (n *namespace) Value(s string) string {
+	return n.Prefix() + s
 }
 
 // Hostname implements Namespace.

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -77,7 +77,20 @@ var (
 func NewCinderVolumeSource(s OpenstackStorage) storage.VolumeSource {
 	const envName = "testenv"
 	modelUUID := testing.ModelTag.Id()
-	return &cinderVolumeSource{s, envName, modelUUID}
+	return &cinderVolumeSource{
+		storageAdapter: s,
+		envName:        envName,
+		modelUUID:      modelUUID,
+		namespace:      fakeNamespace{},
+	}
+}
+
+type fakeNamespace struct {
+	instance.Namespace
+}
+
+func (fakeNamespace) Value(s string) string {
+	return "juju-" + s
 }
 
 // Include images for arches currently supported.  i386 is no longer

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -427,6 +427,13 @@ func (s *localServerSuite) TestStartInstanceHardwareCharacteristics(c *gc.C) {
 	c.Assert(hc.CpuPower, gc.IsNil)
 }
 
+func (s *localServerSuite) TestInstanceName(c *gc.C) {
+	inst, _ := testing.AssertStartInstance(c, s.env, s.ControllerUUID, "100")
+	serverDetail := openstack.InstanceServerDetail(inst)
+	envName := s.env.Config().Name()
+	c.Assert(serverDetail.Name, gc.Matches, "juju-06f00d-"+envName+"-100")
+}
+
 func (s *localServerSuite) TestStartInstanceNetwork(c *gc.C) {
 	cfg, err := s.env.Config().Apply(coretesting.Attrs{
 		// A label that corresponds to a nova test service network


### PR DESCRIPTION
Shorten the hostnames we apply to instances
created by the OpenStack provider. We were
including the full model UUID, which is quite
long. Instead, we should include just the
suffix, and the model name.

When listing instances, don't do a prefix
filter on the model UUID. Instead, just look
for "juju-.*" and then match the model UUID
in the client code.

Example old hostname:
    juju-fd943864-df2e-4da1-8e7d-5116a87d4e7c-machine-14

Example new hostname:
    juju-df7591-controller-0

Fixes https://bugs.launchpad.net/juju/+bug/1615601

**QA**

1. bootstrap canonistack
2. ssh to machine 0, check its hostname
3. add a machine with cinder disks (their names are changed also)