### PR TITLE
cmd/juju/controller: allow registering public controller

### DIFF
--- a/apiserver/cert_test.go
+++ b/apiserver/cert_test.go
@@ -75,7 +75,7 @@ func (s *certSuite) TestUpdateCert(c *gc.C) {
 }
 
 func (s *certSuite) TestAutocertFailure(c *gc.C) {
-	// We don't have a fake autocert server, but we can at lease
+	// We don't have a fake autocert server, but we can at least
 	// smoke test that the autocert path is followed when we try
 	// to connect to a DNS name - the AutocertURL configured
 	// by the testing suite is invalid so it should fail.
@@ -95,7 +95,7 @@ func (s *certSuite) TestAutocertFailure(c *gc.C) {
 			// by a valid authority. This could be problematic.
 			expectedErr = "x509: certificate signed by unknown authority"
 		}
-		// If we can't get an autocert certificate, so we'll fall back to the local certificate
+		// We can't get an autocert certificate, so we'll fall back to the local certificate
 		// which isn't valid for connecting to somewhere.example.
 		c.Assert(err, gc.ErrorMatches, expectedErr)
 	})
@@ -123,7 +123,7 @@ func (s *certSuite) TestAutocertNameMismatch(c *gc.C) {
 			// by a valid authority. This could be problematic.
 			expectedErr = "x509: certificate signed by unknown authority"
 		}
-		// If we can't get an autocert certificate, so we'll fall back to the local certificate
+		// We can't get an autocert certificate, so we'll fall back to the local certificate
 		// which isn't valid for connecting to somewhere.example.
 		c.Assert(err, gc.ErrorMatches, expectedErr)
 	})
@@ -150,7 +150,7 @@ func (s *certSuite) TestAutocertNoAutocertDNSName(c *gc.C) {
 			// by a valid authority. This could be problematic.
 			expectedErr = "x509: certificate signed by unknown authority"
 		}
-		// If we can't get an autocert certificate, so we'll fall back to the local certificate
+		// We can't get an autocert certificate, so we'll fall back to the local certificate
 		// which isn't valid for connecting to somewhere.example.
 		c.Assert(err, gc.ErrorMatches, expectedErr)
 	})

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -464,11 +464,3 @@ func (c *addModelCommand) getConfigValues(ctx *cmd.Context) (map[string]interfac
 	}
 	return attrs, nil
 }
-
-func canonicalCredentialIds(tags []names.CloudCredentialTag) []string {
-	ids := make([]string, len(tags))
-	for i, tag := range tags {
-		ids[i] = tag.Canonical()
-	}
-	return ids
-}

--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -190,7 +190,7 @@ func (c *modelsCommand) Run(ctx *cmd.Context) error {
 		// When the output is tabular, we inform the user when there
 		// are no models available, and tell them how to go about
 		// creating or granting access to them.
-		fmt.Fprintf(ctx.Stderr, "\n%s\n\n", errNoModels.Error())
+		fmt.Fprintln(ctx.Stderr, noModelsMessage)
 	}
 	return nil
 }

--- a/cmd/juju/controller/mock_test.go
+++ b/cmd/juju/controller/mock_test.go
@@ -5,19 +5,25 @@ package controller_test
 
 import (
 	"github.com/juju/juju/api"
-	"github.com/juju/juju/network"
 	"gopkg.in/juju/names.v2"
 )
 
+// mockAPIConnection implements just enough of the api.Connection interface
+// to satisfy the methods used by the register command.
 type mockAPIConnection struct {
 	api.Connection
-	info          *api.Info
-	opts          api.DialOpts
-	addr          string
-	apiHostPorts  [][]network.HostPort
+
+	// addr is returned by Addr.
+	addr string
+
+	// controllerTag is returned by ControllerTag.
 	controllerTag names.ControllerTag
-	username      string
-	password      string
+
+	// authTag is returned by AuthTag.
+	authTag names.Tag
+
+	// controllerAccess is returned by ControllerAccess.
+	controllerAccess string
 }
 
 func (*mockAPIConnection) Close() error {
@@ -28,16 +34,14 @@ func (m *mockAPIConnection) Addr() string {
 	return m.addr
 }
 
-func (m *mockAPIConnection) APIHostPorts() [][]network.HostPort {
-	return m.apiHostPorts
-}
-
 func (m *mockAPIConnection) ControllerTag() names.ControllerTag {
 	return m.controllerTag
 }
 
-func (m *mockAPIConnection) SetPassword(username, password string) error {
-	m.username = username
-	m.password = password
-	return nil
+func (m *mockAPIConnection) AuthTag() names.Tag {
+	return m.authTag
+}
+
+func (m *mockAPIConnection) ControllerAccess() string {
+	return m.controllerAccess
 }

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -34,18 +34,19 @@ import (
 	"github.com/juju/juju/permission"
 )
 
-var errNoModels = errors.New(`
+var noModelsMessage = `
 There are no models available. You can add models with
 "juju add-model", or you can ask an administrator or owner
-of a model to grant access to that model with "juju grant".`[1:])
+of a model to grant access to that model with "juju grant".
+`
 
 // NewRegisterCommand returns a command to allow the user to register a controller.
 func NewRegisterCommand() cmd.Command {
-	cmd := &registerCommand{}
-	cmd.apiOpen = cmd.APIOpen
-	cmd.listModelsFunc = cmd.listModels
-	cmd.store = jujuclient.NewFileClientStore()
-	return modelcmd.WrapBase(cmd)
+	c := &registerCommand{}
+	c.apiOpen = c.APIOpen
+	c.listModelsFunc = c.listModels
+	c.store = jujuclient.NewFileClientStore()
+	return modelcmd.WrapBase(c)
 }
 
 // registerCommand logs in to a Juju controller and caches the connection
@@ -55,26 +56,36 @@ type registerCommand struct {
 	apiOpen        api.OpenFunc
 	listModelsFunc func(_ jujuclient.ClientStore, controller, user string) ([]base.UserModel, error)
 	store          jujuclient.ClientStore
-	EncodedData    string
+	Arg            string
 }
 
 var usageRegisterSummary = `
-Registers a Juju user to a controller.`[1:]
+Registers a controller.`[1:]
 
 var usageRegisterDetails = `
-Connects to a controller and completes the user registration process that began
-with the `[1:] + "`juju add-user`" + ` command. The latter prints out the 'string' that is
-referred to in Usage.
+The register command adds details of a controller to the local system.
+This is done either by completing the user registration process that
+began with the 'juju add-user' command, or by providing the DNS host
+name of a public controller.
 
-The user will be prompted for a password, which, once set, causes the
-registration string to be voided. In order to start using Juju the user can now
-either add a model or wait for a model to be shared with them.  Some machine
-providers will require the user to be in possession of certain credentials in
-order to add a model.
+To complete the user registration process, you should have been provided
+with a base64-encoded blob of data (the output of 'juju add-user')
+which can be copied and pasted as the <string> argument to 'register'.
+You will be prompted for a password, which, once set, causes the
+registration string to be voided. In order to start using Juju the user
+can now either add a model or wait for a model to be shared with them.
+Some machine providers will require the user to be in possession of
+certain credentials in order to add a model.
+
+When adding a controller at a public address, authentication via some
+external third party (for example Ubuntu SSO) will be required, usually
+by using a web browser.
 
 Examples:
 
     juju register MFATA3JvZDAnExMxMDQuMTU0LjQyLjQ0OjE3MDcwExAxMC4xMjguMC4yOjE3MDcwBCBEFCaXerhNImkKKabuX5ULWf2Bp4AzPNJEbXVWgraLrAA=
+
+    juju register public-controller.example.com
 
 See also: 
     add-user
@@ -87,7 +98,7 @@ See also:
 func (c *registerCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "register",
-		Args:    "<string>",
+		Args:    "<registration string>|<controller host name>",
 		Purpose: usageRegisterSummary,
 		Doc:     usageRegisterDetails,
 	}
@@ -98,34 +109,133 @@ func (c *registerCommand) Init(args []string) error {
 	if len(args) < 1 {
 		return errors.New("registration data missing")
 	}
-	c.EncodedData, args = args[0], args[1:]
+	c.Arg, args = args[0], args[1:]
 	if err := cmd.CheckEmpty(args); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	return nil
 }
 
 func (c *registerCommand) Run(ctx *cmd.Context) error {
-
 	store := modelcmd.QualifyingClientStore{c.store}
 	registrationParams, err := c.getParameters(ctx, store)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	_, err = store.ControllerByName(registrationParams.controllerName)
-	if err == nil {
-		return errors.AlreadyExistsf("controller %q", registrationParams.controllerName)
-	} else if !errors.IsNotFound(err) {
+	controllerDetails, accountDetails, err := c.controllerDetails(ctx, registrationParams)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	controllerName, err := c.updateController(
+		ctx,
+		store,
+		registrationParams.defaultControllerName,
+		controllerDetails,
+		accountDetails,
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// Log into the controller to verify the credentials, and
+	// list the models available.
+	models, err := c.listModelsFunc(store, controllerName, accountDetails.User)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, model := range models {
+		owner := names.NewUserTag(model.Owner)
+		if err := store.UpdateModel(
+			controllerName,
+			jujuclient.JoinOwnerModelName(owner, model.Name),
+			jujuclient.ModelDetails{model.UUID},
+		); err != nil {
+			return errors.Annotate(err, "storing model details")
+		}
+	}
+	if err := store.SetCurrentController(controllerName); err != nil {
 		return errors.Trace(err)
 	}
 
+	fmt.Fprintf(
+		ctx.Stderr, "\nWelcome, %s. You are now logged into %q.\n",
+		friendlyUserName(accountDetails.User), controllerName,
+	)
+	return c.maybeSetCurrentModel(ctx, store, controllerName, accountDetails.User, models)
+}
+
+func friendlyUserName(user string) string {
+	u := names.NewUserTag(user)
+	if u.IsLocal() {
+		return u.Name()
+	}
+	return u.Id()
+}
+
+// controllerDetails returns controller and account details to be registered for the
+// given registration parameters.
+func (c *registerCommand) controllerDetails(ctx *cmd.Context, p *registrationParams) (jujuclient.ControllerDetails, jujuclient.AccountDetails, error) {
+	if p.publicHost != "" {
+		return c.publicControllerDetails(p.publicHost)
+	}
+	return c.nonPublicControllerDetails(ctx, p)
+}
+
+// publicControllerDetails returns controller and account details to be registered
+// for the given public controller host name.
+func (c *registerCommand) publicControllerDetails(host string) (jujuclient.ControllerDetails, jujuclient.AccountDetails, error) {
+	errRet := func(err error) (jujuclient.ControllerDetails, jujuclient.AccountDetails, error) {
+		return jujuclient.ControllerDetails{}, jujuclient.AccountDetails{}, err
+	}
+	apiAddr := host
+	if !strings.Contains(apiAddr, ":") {
+		apiAddr += ":443"
+	}
+	// Make a direct API connection because we don't yet know the
+	// controller UUID so can't store the thus-incomplete controller
+	// details to make a conventional connection.
+	//
+	// Unfortunately this means we'll connect twice to the controller
+	// but it's probably best to go through the conventional path the
+	// second time.
+	bclient, err := c.BakeryClient()
+	if err != nil {
+		return errRet(errors.Trace(err))
+	}
+	dialOpts := api.DefaultDialOpts()
+	dialOpts.BakeryClient = bclient
+	conn, err := c.apiOpen(&api.Info{
+		Addrs: []string{apiAddr},
+	}, dialOpts)
+	if err != nil {
+		return errRet(errors.Trace(err))
+	}
+	defer conn.Close()
+	user, ok := conn.AuthTag().(names.UserTag)
+	if !ok {
+		return errRet(errors.Errorf("logged in as %v, not a user", conn.AuthTag()))
+	}
+	return jujuclient.ControllerDetails{
+			APIEndpoints:   []string{apiAddr},
+			ControllerUUID: conn.ControllerTag().Id(),
+		}, jujuclient.AccountDetails{
+			User:            user.Canonical(),
+			LastKnownAccess: conn.ControllerAccess(),
+		}, nil
+}
+
+// nonPublicControllerDetails returns controller and account details to be registered with
+// respect to the given registration parameters.
+func (c *registerCommand) nonPublicControllerDetails(ctx *cmd.Context, registrationParams *registrationParams) (jujuclient.ControllerDetails, jujuclient.AccountDetails, error) {
+	errRet := func(err error) (jujuclient.ControllerDetails, jujuclient.AccountDetails, error) {
+		return jujuclient.ControllerDetails{}, jujuclient.AccountDetails{}, err
+	}
 	// During registration we must set a new password. This has to be done
 	// atomically with the clearing of the secret key.
 	payloadBytes, err := json.Marshal(params.SecretKeyLoginRequestPayload{
 		registrationParams.newPassword,
 	})
 	if err != nil {
-		return errors.Trace(err)
+		return errRet(errors.Trace(err))
 	}
 
 	// Make the registration call. If this is successful, the client's
@@ -143,67 +253,70 @@ func (c *registerCommand) Run(ctx *cmd.Context) error {
 	}
 	resp, err := c.secretKeyLogin(registrationParams.controllerAddrs, req)
 	if err != nil {
-		return errors.Trace(err)
+		return errRet(errors.Trace(err))
 	}
 
 	// Decrypt the response to authenticate the controller and
 	// obtain its CA certificate.
 	if len(resp.Nonce) != len(registrationParams.nonce) {
-		return errors.NotValidf("response nonce")
+		return errRet(errors.NotValidf("response nonce"))
 	}
 	var respNonce [24]byte
 	copy(respNonce[:], resp.Nonce)
 	payloadBytes, ok := secretbox.Open(nil, resp.PayloadCiphertext, &respNonce, &registrationParams.key)
 	if !ok {
-		return errors.NotValidf("response payload")
+		return errRet(errors.NotValidf("response payload"))
 	}
 	var responsePayload params.SecretKeyLoginResponsePayload
 	if err := json.Unmarshal(payloadBytes, &responsePayload); err != nil {
-		return errors.Annotate(err, "unmarshalling response payload")
+		return errRet(errors.Annotate(err, "unmarshalling response payload"))
 	}
+	user := registrationParams.userTag.Canonical()
+	ctx.Infof("Initial password successfully set for %s.", friendlyUserName(user))
+	return jujuclient.ControllerDetails{
+			APIEndpoints:   registrationParams.controllerAddrs,
+			ControllerUUID: responsePayload.ControllerUUID,
+			CACert:         responsePayload.CACert,
+		}, jujuclient.AccountDetails{
+			User:            user,
+			LastKnownAccess: string(permission.LoginAccess),
+		}, nil
+}
 
-	// Store the controller and account details.
-	controllerDetails := jujuclient.ControllerDetails{
-		APIEndpoints:   registrationParams.controllerAddrs,
-		ControllerUUID: responsePayload.ControllerUUID,
-		CACert:         responsePayload.CACert,
-	}
-	if err := store.AddController(registrationParams.controllerName, controllerDetails); err != nil {
-		return errors.Trace(err)
-	}
-	accountDetails := jujuclient.AccountDetails{
-		User:            registrationParams.userTag.Canonical(),
-		LastKnownAccess: string(permission.LoginAccess),
-	}
-	if err := store.UpdateAccount(registrationParams.controllerName, accountDetails); err != nil {
-		return errors.Trace(err)
-	}
-
-	// Log into the controller to verify the credentials, and
-	// list the models available.
-	models, err := c.listModelsFunc(store, registrationParams.controllerName, accountDetails.User)
+// updateController prompts for a controller name and updates the
+// controller and account details in the given client store.
+// It returns the name of the updated controller.
+func (c *registerCommand) updateController(
+	ctx *cmd.Context,
+	store jujuclient.ClientStore,
+	defaultControllerName string,
+	controllerDetails jujuclient.ControllerDetails,
+	accountDetails jujuclient.AccountDetails,
+) (string, error) {
+	// Check that the same controller isn't already stored, so that we
+	// can avoid needlessly asking for a controller name in that case.
+	all, err := store.AllControllers()
 	if err != nil {
-		return errors.Trace(err)
+		return "", errors.Trace(err)
 	}
-	for _, model := range models {
-		owner := names.NewUserTag(model.Owner)
-		if err := store.UpdateModel(
-			registrationParams.controllerName,
-			jujuclient.JoinOwnerModelName(owner, model.Name),
-			jujuclient.ModelDetails{model.UUID},
-		); err != nil {
-			return errors.Annotate(err, "storing model details")
+	for name, ctl := range all {
+		if ctl.ControllerUUID == controllerDetails.ControllerUUID {
+			// TODO(rogpeppe) lp#1614010 Succeed but override the account details in this case?
+			return "", errors.Errorf("controller is already registered as %q", name)
 		}
 	}
-	if err := store.SetCurrentController(registrationParams.controllerName); err != nil {
-		return errors.Trace(err)
+	controllerName, err := c.promptControllerName(store, defaultControllerName, ctx.Stderr, ctx.Stdin)
+	if err != nil {
+		return "", errors.Trace(err)
 	}
 
-	fmt.Fprintf(
-		ctx.Stderr, "\nWelcome, %s. You are now logged into %q.\n",
-		registrationParams.userTag.Id(), registrationParams.controllerName,
-	)
-	return c.maybeSetCurrentModel(ctx, store, registrationParams.controllerName, accountDetails.User, models)
+	if err := store.AddController(controllerName, controllerDetails); err != nil {
+		return "", errors.Trace(err)
+	}
+	if err := store.UpdateAccount(controllerName, accountDetails); err != nil {
+		return "", errors.Annotatef(err, "cannot update account information: %v", err)
+	}
+	return controllerName, nil
 }
 
 func (c *registerCommand) listModels(store jujuclient.ClientStore, controllerName, userName string) ([]base.UserModel, error) {
@@ -218,7 +331,7 @@ func (c *registerCommand) listModels(store jujuclient.ClientStore, controllerNam
 
 func (c *registerCommand) maybeSetCurrentModel(ctx *cmd.Context, store jujuclient.ClientStore, controllerName, userName string, models []base.UserModel) error {
 	if len(models) == 0 {
-		fmt.Fprintf(ctx.Stderr, "\n%s\n\n", errNoModels.Error())
+		fmt.Fprint(ctx.Stderr, noModelsMessage)
 		return nil
 	}
 
@@ -233,51 +346,62 @@ func (c *registerCommand) maybeSetCurrentModel(ctx *cmd.Context, store jujuclien
 		if err != nil {
 			return errors.Trace(err)
 		}
-		fmt.Fprintf(ctx.Stderr, "\nCurrent model set to %q.\n\n", modelName)
-	} else {
-		fmt.Fprintf(ctx.Stderr, `
+		fmt.Fprintf(ctx.Stderr, "\nCurrent model set to %q.\n", modelName)
+		return nil
+	}
+	fmt.Fprintf(ctx.Stderr, `
 There are %d models available. Use "juju switch" to select
 one of them:
 `, len(models))
-		user := names.NewUserTag(userName)
-		ownerModelNames := make(set.Strings)
-		otherModelNames := make(set.Strings)
-		for _, model := range models {
-			if model.Owner == userName {
-				ownerModelNames.Add(model.Name)
-				continue
-			}
-			owner := names.NewUserTag(model.Owner)
-			modelName := common.OwnerQualifiedModelName(model.Name, owner, user)
-			otherModelNames.Add(modelName)
+	user := names.NewUserTag(userName)
+	ownerModelNames := make(set.Strings)
+	otherModelNames := make(set.Strings)
+	for _, model := range models {
+		if model.Owner == userName {
+			ownerModelNames.Add(model.Name)
+			continue
 		}
-		for _, modelName := range ownerModelNames.SortedValues() {
-			fmt.Fprintf(ctx.Stderr, "  - juju switch %s\n", modelName)
-		}
-		for _, modelName := range otherModelNames.SortedValues() {
-			fmt.Fprintf(ctx.Stderr, "  - juju switch %s\n", modelName)
-		}
-		fmt.Fprintln(ctx.Stderr)
+		owner := names.NewUserTag(model.Owner)
+		modelName := common.OwnerQualifiedModelName(model.Name, owner, user)
+		otherModelNames.Add(modelName)
+	}
+	for _, modelName := range ownerModelNames.SortedValues() {
+		fmt.Fprintf(ctx.Stderr, "  - juju switch %s\n", modelName)
+	}
+	for _, modelName := range otherModelNames.SortedValues() {
+		fmt.Fprintf(ctx.Stderr, "  - juju switch %s\n", modelName)
 	}
 	return nil
 }
 
 type registrationParams struct {
-	userTag         names.UserTag
-	controllerName  string
-	controllerAddrs []string
-	key             [32]byte
-	nonce           [24]byte
-	newPassword     string
+	// publicHost holds the host name of a public controller.
+	// If this is set, all other fields will be empty.
+	publicHost string
+
+	defaultControllerName string
+	userTag               names.UserTag
+	controllerAddrs       []string
+	key                   [32]byte
+	nonce                 [24]byte
+	newPassword           string
 }
 
 // getParameters gets all of the parameters required for registering, prompting
 // the user as necessary.
 func (c *registerCommand) getParameters(ctx *cmd.Context, store jujuclient.ClientStore) (*registrationParams, error) {
-
+	var params registrationParams
+	if strings.Contains(c.Arg, ".") || c.Arg == "localhost" {
+		// Looks like a host name - no URL-encoded base64 string should
+		// contain a dot and every public controller name should.
+		// Allow localhost for development purposes.
+		params.publicHost = c.Arg
+		// No need for password shenanigans if we're using a public controller.
+		return &params, nil
+	}
 	// Decode key, username, controller addresses from the string supplied
 	// on the command line.
-	decodedData, err := base64.URLEncoding.DecodeString(c.EncodedData)
+	decodedData, err := base64.URLEncoding.DecodeString(c.Arg)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -286,21 +410,13 @@ func (c *registerCommand) getParameters(ctx *cmd.Context, store jujuclient.Clien
 		return nil, errors.Trace(err)
 	}
 
-	params := registrationParams{
-		controllerAddrs: info.Addrs,
-		userTag:         names.NewUserTag(info.User),
-	}
+	params.controllerAddrs = info.Addrs
+	params.userTag = names.NewUserTag(info.User)
 	if len(info.SecretKey) != len(params.key) {
 		return nil, errors.NotValidf("secret key")
 	}
 	copy(params.key[:], info.SecretKey)
-
-	// Prompt the user for the controller name.
-	controllerName, err := c.promptControllerName(store, info.ControllerName, ctx.Stderr, ctx.Stdin)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	params.controllerName = controllerName
+	params.defaultControllerName = info.ControllerName
 
 	// Prompt the user for the new password to set.
 	newPassword, err := c.promptNewPassword(ctx.Stderr, ctx.Stdin)
@@ -380,7 +496,7 @@ func (c *registerCommand) secretKeyLogin(addrs []string, request params.SecretKe
 
 	var resp params.SecretKeyLoginResponse
 	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err, "cannot decode login response")
 	}
 	return &resp, nil
 }
@@ -388,7 +504,7 @@ func (c *registerCommand) secretKeyLogin(addrs []string, request params.SecretKe
 func (c *registerCommand) promptNewPassword(stderr io.Writer, stdin io.Reader) (string, error) {
 	password, err := c.readPassword("Enter a new password: ", stderr, stdin)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Annotatef(err, "cannot read password")
 	}
 	if password == "" {
 		return "", errors.NewNotValid(nil, "you must specify a non-empty password")
@@ -403,36 +519,38 @@ func (c *registerCommand) promptNewPassword(stderr io.Writer, stdin io.Reader) (
 	return password, nil
 }
 
-const errControllerConflicts = `WARNING: You already have a controller registered with the name %q. Please choose a different name for the new controller.
-
-`
-
 func (c *registerCommand) promptControllerName(store jujuclient.ClientStore, suggestedName string, stderr io.Writer, stdin io.Reader) (string, error) {
-	_, err := store.ControllerByName(suggestedName)
-	if err == nil {
-		fmt.Fprintf(stderr, errControllerConflicts, suggestedName)
-		suggestedName = ""
-	}
-	var setMsg string
-	setMsg = "Enter a name for this controller: "
 	if suggestedName != "" {
-		setMsg = fmt.Sprintf("Enter a name for this controller [%s]: ",
-			suggestedName)
+		if _, err := store.ControllerByName(suggestedName); err == nil {
+			suggestedName = ""
+		}
 	}
-	fmt.Fprintf(stderr, setMsg)
-	defer stderr.Write([]byte{'\n'})
-	name, err := c.readLine(stdin)
-	if err != nil {
-		return "", errors.Trace(err)
+	for {
+		var setMsg string
+		setMsg = "Enter a name for this controller: "
+		if suggestedName != "" {
+			setMsg = fmt.Sprintf("Enter a name for this controller [%s]: ", suggestedName)
+		}
+		fmt.Fprintf(stderr, setMsg)
+		name, err := c.readLine(stdin)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		name = strings.TrimSpace(name)
+		if name == "" {
+			if suggestedName == "" {
+				fmt.Fprintln(stderr, "You must specify a non-empty controller name.")
+				continue
+			}
+			name = suggestedName
+		}
+		_, err = store.ControllerByName(name)
+		if err == nil {
+			fmt.Fprintf(stderr, "Controller %q already exists.\n", name)
+			continue
+		}
+		return name, nil
 	}
-	name = strings.TrimSpace(name)
-	if name == "" && suggestedName == "" {
-		return "", errors.NewNotValid(nil, "you must specify a non-empty controller name")
-	}
-	if name == "" && suggestedName != "" {
-		return suggestedName, nil
-	}
-	return name, nil
 }
 
 func (c *registerCommand) readPassword(prompt string, stderr io.Writer, stdin io.Reader) (string, error) {

--- a/cmd/testing/package_test.go
+++ b/cmd/testing/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/cmd/testing/prompt.go
+++ b/cmd/testing/prompt.go
@@ -1,0 +1,220 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"io"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	gc "gopkg.in/check.v1"
+)
+
+var logger = loggo.GetLogger("juju.cmd.testing")
+
+// NewSeqPrompter returns a prompter that can be used to check a sequence of
+// IO interactions. Expected input from the user is marked with the
+// given user input marker (for example a distinctive unicode character
+// that will not occur in the rest of the text) and runs to the end of a
+// line.
+//
+// All output text in between user input is treated as regular expressions.
+//
+// As a special case, if an input marker is followed only by a single input
+// marker on that line, the checker will cause io.EOF to be returned for
+// that prompt.
+//
+// The returned SeqPrompter wraps a Prompter and checks that each
+// read and write corresponds to the expected action in the sequence.
+//
+// After all interaction is done, CheckDone or AssertDone should be called to
+// check that no more interactions are expected.
+//
+// Any failures will result in the test failing.
+//
+// For example given the prompter created with:
+//
+//		checker := NewSeqPrompter(c, "»",  `What is your name: »Bob
+//	And your age: »148
+//	You're .* old, Bob!
+//	`)
+//
+// The following code will pass the checker:
+//
+//	fmt.Fprintf(checker, "What is your name: ")
+//	buf := make([]byte, 100)
+//	n, _ := checker.Read(buf)
+//	name := strings.TrimSpace(string(buf[0:n]))
+//	fmt.Fprintf(checker, "And your age: ")
+//	n, _ = checker.Read(buf)
+//	age, err := strconv.Atoi(strings.TrimSpace(string(buf[0:n])))
+//	c.Assert(err, gc.IsNil)
+//	if age > 90 {
+//		fmt.Fprintf(checker, "You're very old, %s!\n", name)
+//	}
+//	checker.CheckDone()
+func NewSeqPrompter(c *gc.C, userInputMarker, text string) *SeqPrompter {
+	p := &SeqPrompter{
+		c: c,
+	}
+	for {
+		i := strings.Index(text, userInputMarker)
+		if i == -1 {
+			p.finalText = text
+			break
+		}
+		prompt := text[0:i]
+		text = text[i+len(userInputMarker):]
+		endLine := strings.Index(text, "\n")
+		if endLine == -1 {
+			c.Errorf("no newline found after expected input %q", text)
+		}
+		reply := text[0 : endLine+1]
+		if reply[0:len(reply)-1] == userInputMarker {
+			// EOF line.
+			reply = ""
+		}
+		text = text[endLine+1:]
+		if prompt == "" && len(p.ios) > 0 {
+			// Combine multiple contiguous inputs together.
+			p.ios[len(p.ios)-1].reply += reply
+		} else {
+			p.ios = append(p.ios, ioInteraction{
+				prompt: prompt,
+				reply:  reply,
+			})
+		}
+	}
+	p.Prompter = NewPrompter(p.prompt)
+	return p
+}
+
+type SeqPrompter struct {
+	*Prompter
+	c         *gc.C
+	ios       []ioInteraction
+	finalText string
+	failed    bool
+}
+
+type ioInteraction struct {
+	prompt string
+	reply  string
+}
+
+func (p *SeqPrompter) prompt(text string) (string, error) {
+	if p.failed {
+		return "", errors.New("prompter failed")
+	}
+	if len(p.ios) == 0 {
+		p.c.Errorf("unexpected prompt %q; expected none", text)
+		return "", errors.New("unexpected prompt")
+	}
+	if !p.c.Check(text, gc.Matches, p.ios[0].prompt) {
+		p.failed = true
+		return "", errors.Errorf("unexpected prompt %q; expected %q", text, p.ios[0].prompt)
+	}
+	reply := p.ios[0].reply
+	logger.Infof("prompt %q -> %q", text, reply)
+	p.ios = p.ios[1:]
+	return reply, nil
+}
+
+// CheckDone asserts that all the expected prompts
+// have been printed and all the replies read, and
+// reports whether the check succeeded.
+func (p *SeqPrompter) CheckDone() bool {
+	if p.failed {
+		// No point in doing the details checks if
+		// a prompt failed earlier - it just makes
+		// the resulting test failure noisy.
+		p.c.Errorf("prompter has failed")
+		return false
+	}
+	r := p.c.Check(p.ios, gc.HasLen, 0, gc.Commentf("unused prompts"))
+	r = p.c.Check(p.HasUnread(), gc.Equals, false, gc.Commentf("some input was not read")) && r
+	r = p.c.Check(p.Tail(), gc.Matches, p.finalText, gc.Commentf("final text mismatch")) && r
+	return r
+}
+
+// AssertDone is like CheckDone but aborts the test if
+// the check fails.
+func (p *SeqPrompter) AssertDone() {
+	if !p.CheckDone() {
+		p.c.FailNow()
+	}
+}
+
+// NewPrompter returns an io.ReadWriter implementation that calls the
+// given function every time Read is called after some text has been
+// written or if all the previously returned text has been read. The
+// function's argument contains all the text printed since the last
+// input. The function should return the text that the user is expected
+// to type, or an error to return from Read. If it returns an empty string,
+// and no error, it will return io.EOF instead.
+func NewPrompter(prompt func(string) (string, error)) *Prompter {
+	return &Prompter{
+		prompt: prompt,
+	}
+}
+
+// Prompter is designed to be used in a cmd.Context to
+// check interactive request-response sequences
+// using stdin and stdout.
+type Prompter struct {
+	prompt func(string) (string, error)
+
+	written      []byte
+	allWritten   []byte
+	pending      []byte
+	pendingError error
+}
+
+// Tail returns all the text written since the last prompt.
+func (p *Prompter) Tail() string {
+	return string(p.written)
+}
+
+// HasUnread reports whether any input
+// from the last prompt remains unread.
+func (p *Prompter) HasUnread() bool {
+	return len(p.pending) != 0
+}
+
+// Read implements io.Reader.
+func (p *Prompter) Read(buf []byte) (int, error) {
+	if len(p.pending) == 0 && p.pendingError == nil {
+		s, err := p.prompt(string(p.written))
+		if s == "" && err == nil {
+			err = io.EOF
+		}
+		p.written = nil
+		p.pending = []byte(s)
+		p.pendingError = err
+	}
+	if len(p.pending) > 0 {
+		n := copy(buf, p.pending)
+		p.pending = p.pending[n:]
+		return n, nil
+	}
+	if err := p.pendingError; err != nil {
+		p.pendingError = nil
+		return 0, err
+	}
+	panic("unreachable")
+}
+
+// String returns all the text that has been written to
+// the prompter since it was created.
+func (p *Prompter) String() string {
+	return string(p.allWritten)
+}
+
+// Write implements io.Writer.
+func (p *Prompter) Write(buf []byte) (int, error) {
+	p.written = append(p.written, buf...)
+	p.allWritten = append(p.allWritten, buf...)
+	return len(buf), nil
+}

--- a/cmd/testing/prompt_test.go
+++ b/cmd/testing/prompt_test.go
@@ -1,0 +1,136 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing_test
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	cmdtesting "github.com/juju/juju/cmd/testing"
+	"github.com/juju/testing"
+)
+
+type prompterSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&prompterSuite{})
+
+func (*prompterSuite) TestPrompter(c *gc.C) {
+	noPrompt := func(p string) (string, error) {
+		c.Fatalf("unpexected prompt (text %q)", p)
+		panic("unreachable")
+	}
+	promptFn := noPrompt
+	p := cmdtesting.NewPrompter(func(p string) (string, error) {
+		return promptFn(p)
+	})
+
+	promptText := "hello: "
+	promptReply := "reply\n"
+
+	fmt.Fprint(p, promptText)
+	promptFn = func(p string) (string, error) {
+		c.Assert(p, gc.Equals, promptText)
+		return promptReply, nil
+	}
+	c.Assert(readStr(c, p, 20), gc.Equals, promptReply)
+
+	promptText = "some text\ngoodbye: "
+	promptReply = "again\n"
+	fmt.Fprint(p, promptText[0:10])
+	fmt.Fprint(p, promptText[10:])
+
+	c.Assert(readStr(c, p, 3), gc.Equals, promptReply[0:3])
+	c.Assert(readStr(c, p, 20), gc.Equals, promptReply[3:])
+
+	fmt.Fprint(p, "final text\n")
+
+	c.Assert(p.Tail(), gc.Equals, "final text\n")
+	c.Assert(p.HasUnread(), gc.Equals, false)
+}
+
+func (*prompterSuite) TestUnreadInput(c *gc.C) {
+	p := cmdtesting.NewPrompter(func(s string) (string, error) {
+		return "hello world", nil
+	})
+	c.Assert(readStr(c, p, 3), gc.Equals, "hel")
+
+	c.Assert(p.HasUnread(), gc.Equals, true)
+}
+
+func (*prompterSuite) TestError(c *gc.C) {
+	expectErr := errors.New("something")
+	p := cmdtesting.NewPrompter(func(s string) (string, error) {
+		return "", expectErr
+	})
+	buf := make([]byte, 3)
+	n, err := p.Read(buf)
+	c.Assert(n, gc.Equals, 0)
+	c.Assert(err, gc.Equals, expectErr)
+}
+
+func (*prompterSuite) TestSeqPrompter(c *gc.C) {
+	p := cmdtesting.NewSeqPrompter(c, "»", `
+hello: »reply
+some text
+goodbye: »again
+final
+`[1:])
+	fmt.Fprint(p, "hello: ")
+	c.Assert(readStr(c, p, 1), gc.Equals, "r")
+	c.Assert(readStr(c, p, 20), gc.Equals, "eply\n")
+	fmt.Fprint(p, "some text\n")
+	fmt.Fprint(p, "goodbye: ")
+	c.Assert(readStr(c, p, 20), gc.Equals, "again\n")
+	fmt.Fprint(p, "final\n")
+	p.AssertDone()
+}
+
+func (*prompterSuite) TestSeqPrompterEOF(c *gc.C) {
+	p := cmdtesting.NewSeqPrompter(c, "»", `
+hello: »»
+final
+`[1:])
+	fmt.Fprint(p, "hello: ")
+	n, err := p.Read(make([]byte, 10))
+	c.Assert(n, gc.Equals, 0)
+	c.Assert(err, gc.Equals, io.EOF)
+	fmt.Fprint(p, "final\n")
+	p.AssertDone()
+}
+
+func (*prompterSuite) TestNewIOChecker(c *gc.C) {
+	checker := cmdtesting.NewSeqPrompter(c, "»", `What is your name: »Bob
+»more
+And your age: »148
+You're .* old, Bob
+more!
+`)
+	fmt.Fprintf(checker, "What is your name: ")
+	buf := make([]byte, 100)
+	n, _ := checker.Read(buf)
+	name := strings.TrimSpace(string(buf[0:n]))
+	fmt.Fprintf(checker, "And your age: ")
+	n, _ = checker.Read(buf)
+	age, err := strconv.Atoi(strings.TrimSpace(string(buf[0:n])))
+	c.Assert(err, gc.IsNil)
+	if age > 90 {
+		fmt.Fprintf(checker, "You're very old, %s!\n", name)
+	}
+	checker.CheckDone()
+}
+
+func readStr(c *gc.C, r io.Reader, nb int) string {
+	buf := make([]byte, nb)
+	n, err := r.Read(buf)
+	c.Assert(err, jc.ErrorIsNil)
+	return string(buf[0:n])
+}


### PR DESCRIPTION
This allows a controller with an officially signed certificate to be
registered with:

	juju register <hostname>

Because it's got an officially signed certificate, we can trust it to
obtain the controller UUID, and external user authentication lets us
know what user has been chosen without needing to select one explicitly.

This caused a significant reshuffle of the register command. In
particular, we now ask for the password before asking for
the controller name because we can't get the controller UUID
without the password.  That moves us in the direction of fixing
https://bugs.launchpad.net/juju/+bug/1614010 because we no longer prompt
for the controller name if we know that the controller cannot be stored.

We also update the controller-name input code so that it loops until a
correct controller name is supplied rather than immediately returning
an error.

The tests needed significant change because all the tests that previously
assumed that the controller name was prompted before any interaction
with the server now need a mock server.

To make this a bit more straightforward,  we add a the Prompter types
in cmd/testing which means that the interaction requirements can be
specified more declaratively.  This has the side effect of testing that
the read/write interleaving is exactly as expected.

### QA

Bootstrap a controller with an officially signed certificate and externally configured users:

    juju bootstrap --debug --config 'autocert-dns-name=<your domain name>' --config 'api-port=443' --config identity-url=https://api.jujucharms.com/identity ec2 aws

Grant everyone permission to access the controller and create models:

    juju grant everyone@external addmodel

Then configure the DNS record for your domain name to point to the IP address of the newly
bootstrapped controller.

Then, on a fresh juju client instance (or with the new controller entry removed from controller.yaml and accounts.yaml) run:

    juju register <your domain name>

That should succeed and log in as your USSO username@external.  You should then be able to create models and list models etc.
