### PR TITLE
lxdclient: add a flag indicating whether to check the local bridge co…

### DIFF
--- a/container/lxd/lxd.go
+++ b/container/lxd/lxd.go
@@ -51,7 +51,7 @@ func ConnectLocal() (*lxdclient.Client, error) {
 		return nil, errors.Trace(err)
 	}
 
-	client, err := lxdclient.Connect(cfg)
+	client, err := lxdclient.Connect(cfg, false)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/lxd/environ_raw.go
+++ b/provider/lxd/environ_raw.go
@@ -101,7 +101,7 @@ func newClient(
 		return nil, errors.Trace(err)
 	}
 
-	client, err := lxdclient.Connect(*config)
+	client, err := lxdclient.Connect(*config, true)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -26,7 +26,7 @@ import (
 func skipIfWily(c *gc.C) {
 	if series.HostSeries() == "wily" {
 		cfg, _ := lxdclient.Config{}.WithDefaults()
-		_, err := lxdclient.Connect(cfg)
+		_, err := lxdclient.Connect(cfg, false)
 		// We try to create a client here. On wily this should fail, because
 		// the default 0.20 lxd version should make juju/tools/lxdclient return
 		// an error.

--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -137,7 +137,7 @@ func Connect(cfg Config, verifyBridgeConfig bool) (*Client, error) {
 	}
 
 	var bridgeName string
-	if verifyBridgeConfig {
+	if remoteID == remoteIDForLocal && verifyBridgeConfig {
 		// If this is the LXD provider on the localhost, let's do an extra check to
 		// make sure the default profile has a correctly configured bridge, and
 		// which one is it.

--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -112,7 +112,7 @@ func (c Client) DefaultProfileBridgeName() string {
 
 // Connect opens an API connection to LXD and returns a high-level
 // Client wrapper around that connection.
-func Connect(cfg Config) (*Client, error) {
+func Connect(cfg Config, verifyBridgeConfig bool) (*Client, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -137,7 +137,7 @@ func Connect(cfg Config) (*Client, error) {
 	}
 
 	var bridgeName string
-	if remoteID == remoteIDForLocal {
+	if verifyBridgeConfig {
 		// If this is the LXD provider on the localhost, let's do an extra check to
 		// make sure the default profile has a correctly configured bridge, and
 		// which one is it.

--- a/tools/lxdclient/client_test.go
+++ b/tools/lxdclient/client_test.go
@@ -46,7 +46,7 @@ func (cs *ConnectSuite) TestLocalConnectError(c *gc.C) {
 	/* ECONNREFUSED because it's not a socket (mimics behavior of a socket
 	 * with nobody listening)
 	 */
-	_, err = Connect(cfg)
+	_, err = Connect(cfg, false)
 	c.Assert(err.Error(), gc.Equals, `can't connect to the local LXD server: LXD refused connections; is LXD running?
 
 Please configure LXD by running:
@@ -56,7 +56,7 @@ Please configure LXD by running:
 
 	/* EACCESS because we can't read/write */
 	c.Assert(f.Chmod(0400), jc.ErrorIsNil)
-	_, err = Connect(cfg)
+	_, err = Connect(cfg, false)
 	c.Assert(err.Error(), gc.Equals, `can't connect to the local LXD server: Permisson denied, are you in the lxd group?
 
 Please configure LXD by running:
@@ -66,7 +66,7 @@ Please configure LXD by running:
 
 	/* ENOENT because it doesn't exist */
 	c.Assert(os.RemoveAll(f.Name()), jc.ErrorIsNil)
-	_, err = Connect(cfg)
+	_, err = Connect(cfg, false)
 	c.Assert(err.Error(), gc.Equals, `can't connect to the local LXD server: LXD socket not found; is LXD installed & running?
 
 Please install LXD by running:
@@ -79,7 +79,7 @@ and then configure it with:
 	// Yes, the error message actually matters here... this is being displayed
 	// to the user.
 	cs.PatchValue(&lxdNewClientFromInfo, fakeNewClientFromInfo)
-	_, err = Connect(cfg)
+	_, err = Connect(cfg, false)
 	c.Assert(err.Error(), gc.Equals, `can't connect to the local LXD server: boo!
 
 Please install LXD by running:
@@ -191,7 +191,7 @@ func (cs *ConnectSuite) TestRemoteConnectError(c *gc.C) {
 		},
 	}.WithDefaults()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = Connect(cfg)
+	_, err = Connect(cfg, false)
 
 	c.Assert(errors.Cause(err), gc.Equals, testerr)
 }


### PR DESCRIPTION
…nfig

The problem here is a chicken and egg problem: the container type needs to
connect to the local LXD to figure out how to configure the bridge,
but lxdclient has code to check the (old style) bridge configuration when
connecting to the local LXD.

Really, this code that checks the bridge configuration should live in the
LXD provider, but I suspect that there'd need to be some abstraction
untangling to do that.

Instead, for now, let's add a boolean flag to Connect() that just indicates
whether or not we should verify the bridge configuration.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>