### PR TITLE
Refresh the store's models if not found.

### DIFF
--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -36,8 +36,10 @@ func NewDestroyCommand() cmd.Command {
 // destroyCommand destroys the specified model.
 type destroyCommand struct {
 	modelcmd.ModelCommandBase
-	// RefreshModels is hides the RefreshModels function defined
+	// RefreshModels hides the RefreshModels function defined
 	// in ModelCommandBase. This allows overriding for testing.
+	// NOTE: ideal solution would be to have the base implement a method
+	// like store.ModelByName which auto-refreshes.
 	RefreshModels func(jujuclient.ClientStore, string) error
 
 	envName   string

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -37,8 +37,8 @@ func NewRetryProvisioningCommandForTest(api RetryProvisioningAPI) cmd.Command {
 }
 
 // NewShowCommandForTest returns a ShowCommand with the api provided as specified.
-func NewShowCommandForTest(api ShowModelAPI, store jujuclient.ClientStore) cmd.Command {
-	cmd := &showModelCommand{api: api}
+func NewShowCommandForTest(api ShowModelAPI, refreshFunc func(jujuclient.ClientStore, string) error, store jujuclient.ClientStore) cmd.Command {
+	cmd := &showModelCommand{api: api, RefreshModels: refreshFunc}
 	cmd.SetClientStore(store)
 	return modelcmd.Wrap(cmd)
 }
@@ -58,9 +58,10 @@ func NewDumpDBCommandForTest(api DumpDBAPI, store jujuclient.ClientStore) cmd.Co
 }
 
 // NewDestroyCommandForTest returns a DestroyCommand with the api provided as specified.
-func NewDestroyCommandForTest(api DestroyModelAPI, store jujuclient.ClientStore) cmd.Command {
+func NewDestroyCommandForTest(api DestroyModelAPI, refreshFunc func(jujuclient.ClientStore, string) error, store jujuclient.ClientStore) cmd.Command {
 	cmd := &destroyCommand{
-		api: api,
+		api:           api,
+		RefreshModels: refreshFunc,
 	}
 	cmd.SetClientStore(store)
 	return modelcmd.Wrap(

--- a/cmd/juju/model/show.go
+++ b/cmd/juju/model/show.go
@@ -30,8 +30,10 @@ func NewShowCommand() cmd.Command {
 // showModelCommand shows all the users with access to the current model.
 type showModelCommand struct {
 	modelcmd.ModelCommandBase
-	// RefreshModels is hides the RefreshModels function defined
+	// RefreshModels hides the RefreshModels function defined
 	// in ModelCommandBase. This allows overriding for testing.
+	// NOTE: ideal solution would be to have the base implement a method
+	// like store.ModelByName which auto-refreshes.
 	RefreshModels func(jujuclient.ClientStore, string) error
 
 	out cmd.Output

--- a/cmd/juju/model/show.go
+++ b/cmd/juju/model/show.go
@@ -16,17 +16,24 @@ import (
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/jujuclient"
 )
 
 const showModelCommandDoc = `Show information about the current or specified model`
 
 func NewShowCommand() cmd.Command {
-	return modelcmd.Wrap(&showModelCommand{}, modelcmd.WrapSkipModelFlags)
+	showCmd := &showModelCommand{}
+	showCmd.RefreshModels = showCmd.ModelCommandBase.RefreshModels
+	return modelcmd.Wrap(showCmd, modelcmd.WrapSkipModelFlags)
 }
 
 // showModelCommand shows all the users with access to the current model.
 type showModelCommand struct {
 	modelcmd.ModelCommandBase
+	// RefreshModels is hides the RefreshModels function defined
+	// in ModelCommandBase. This allows overriding for testing.
+	RefreshModels func(jujuclient.ClientStore, string) error
+
 	out cmd.Output
 	api ShowModelAPI
 }
@@ -97,6 +104,16 @@ func (c *showModelCommand) Run(ctx *cmd.Context) (err error) {
 		c.ControllerName(),
 		c.ModelName(),
 	)
+	if errors.IsNotFound(err) {
+		if err := c.RefreshModels(store, c.ControllerName()); err != nil {
+			return errors.Annotate(err, "refreshing models cache")
+		}
+		// Now try again.
+		modelDetails, err = store.ModelByName(
+			c.ControllerName(),
+			c.ModelName(),
+		)
+	}
 	if err != nil {
 		return errors.Annotate(err, "getting model details")
 	}


### PR DESCRIPTION
This fix addresses http://pad.lv/1630067. It does that by refreshing the model cache if the store returns a not found error.

A more optimal fix that we should look at later is to add a method on the command base command that does this automatically.