### PR TITLE
Change the grant addmodel permission to add-model

### DIFF
--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -268,9 +268,9 @@ func (s *legacySuite) TestModelStatus(c *gc.C) {
 func (s *legacySuite) TestGetControllerAccess(c *gc.C) {
 	controller := s.OpenAPI(c)
 	defer controller.Close()
-	err := controller.GrantController("fred@external", "addmodel")
+	err := controller.GrantController("fred@external", "add-model")
 	c.Assert(err, jc.ErrorIsNil)
 	access, err := controller.GetControllerAccess("fred@external")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(access, gc.Equals, permission.Access("addmodel"))
+	c.Assert(access, gc.Equals, permission.Access("add-model"))
 }

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -1012,7 +1012,7 @@ func (s *macaroonLoginSuite) TestRemoteUserLoginToControllerAddModelAccess(c *gc
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(result.UserInfo, gc.NotNil)
 	c.Check(result.UserInfo.Identity, gc.Equals, remoteUserTag.String())
-	c.Check(result.UserInfo.ControllerAccess, gc.Equals, "addmodel")
+	c.Check(result.UserInfo.ControllerAccess, gc.Equals, "add-model")
 	c.Check(result.UserInfo.ModelAccess, gc.Equals, "")
 }
 
@@ -1065,7 +1065,7 @@ func (s *macaroonLoginSuite) TestRemoteUserLoginToModelWithControllerAccess(c *g
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(result.UserInfo, gc.NotNil)
 	c.Check(result.UserInfo.Identity, gc.Equals, remoteUserTag.String())
-	c.Check(result.UserInfo.ControllerAccess, gc.Equals, "addmodel")
+	c.Check(result.UserInfo.ControllerAccess, gc.Equals, "add-model")
 	c.Check(result.UserInfo.ModelAccess, gc.Equals, "write")
 }
 

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -649,7 +649,7 @@ func (s *controllerSuite) TestGrantOnlyGreaterAccess(c *gc.C) {
 	c.Assert(controllerUser.Access, gc.Equals, permission.AddModelAccess)
 
 	err = s.controllerGrant(c, user.UserTag(), string(permission.AddModelAccess))
-	expectedErr := `could not grant controller access: user already has "addmodel" access or greater`
+	expectedErr := `could not grant controller access: user already has "add-model" access or greater`
 	c.Assert(err, gc.ErrorMatches, expectedErr)
 }
 
@@ -775,7 +775,7 @@ func (s *controllerSuite) TestGetControllerAccess(c *gc.C) {
 			UserTag: user.Tag().String(),
 		}}, {
 		Result: &params.UserAccess{
-			Access:  "addmodel",
+			Access:  "add-model",
 			UserTag: user2.Tag().String(),
 		}}})
 }

--- a/apiserver/usermanager/usermanager_test.go
+++ b/apiserver/usermanager/usermanager_test.go
@@ -388,7 +388,7 @@ func (s *userManagerSuite) TestUserInfo(c *gc.C) {
 		}, {
 			info: &params.UserInfo{
 				Username: "fred@external",
-				Access:   "addmodel",
+				Access:   "add-model",
 			},
 		}, {
 			err: &params.Error{
@@ -518,7 +518,7 @@ func (s *userManagerSuite) TestUserInfoEveryonePermission(c *gc.C) {
 	c.Assert(results, jc.DeepEquals, params.UserInfoResults{
 		Results: []params.UserInfoResult{{Result: &params.UserInfo{
 			Username: "aardvark@external",
-			Access:   "addmodel",
+			Access:   "add-model",
 		}}},
 	})
 }

--- a/cmd/juju/model/grantrevoke.go
+++ b/cmd/juju/model/grantrevoke.go
@@ -34,9 +34,9 @@ Grant user 'sam' 'read' access to models 'model1' and 'model2':
 
     juju grant sam read model1 model2
 
-Grant user 'maria' 'addmodel' access to the controller:
+Grant user 'maria' 'add-model' access to the controller:
 
-    juju grant maria addmodel
+    juju grant maria add-model
 
 Valid access levels for models are:
     read
@@ -45,7 +45,7 @@ Valid access levels for models are:
 
 Valid access levels for controllers are:
     login
-    addmodel
+    add-model
     superuser
 
 See also: 
@@ -71,9 +71,9 @@ Revoke 'write' access from user 'sam' for models 'model1' and 'model2':
 
     juju revoke sam write model1 model2
 
-Revoke 'addmodel' acces from user 'maria' to the controller:
+Revoke 'add-model' access from user 'maria' to the controller:
 
-    juju revoke maria addmodel
+    juju revoke maria add-model
 
 See also: 
     grant`[1:]

--- a/cmd/juju/model/grantrevoke.go
+++ b/cmd/juju/model/grantrevoke.go
@@ -99,6 +99,10 @@ func (c *accessCommand) Init(args []string) error {
 	c.User = args[0]
 	c.ModelNames = args[2:]
 	c.ModelAccess = args[1]
+	// Special case for backwards compatibility.
+	if c.ModelAccess == "addmodel" {
+		c.ModelAccess = "add-model"
+	}
 	if len(c.ModelNames) > 0 {
 		err := permission.ValidateModelAccess(permission.Access(c.ModelAccess))
 		if err != nil {

--- a/cmd/juju/model/grantrevoke_test.go
+++ b/cmd/juju/model/grantrevoke_test.go
@@ -116,6 +116,20 @@ func (s *grantSuite) TestInit(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `no user specified`)
 }
 
+// TestInitGrantAddModel checks that both the documented 'add-model' access and
+// the backwards-compatible 'addmodel' work to grant the AddModel permission.
+func (s *grantSuite) TestInitGrantAddModel(c *gc.C) {
+	wrappedCmd, grantCmd := model.NewGrantCommandForTest(s.fake, s.store)
+	// The documented case, add-model.
+	err := testing.InitCommand(wrappedCmd, []string{"bob", "add-model"})
+	c.Check(err, jc.ErrorIsNil)
+
+	// The backwards-compatible case, addmodel.
+	err = testing.InitCommand(wrappedCmd, []string{"bob", "addmodel"})
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(grantCmd.ModelAccess, gc.Equals, "add-model")
+}
+
 type revokeSuite struct {
 	grantRevokeSuite
 }
@@ -144,6 +158,20 @@ func (s *revokeSuite) TestInit(c *gc.C) {
 	err = testing.InitCommand(wrappedCmd, []string{})
 	c.Assert(err, gc.ErrorMatches, `no user specified`)
 
+}
+
+// TestInitRevokeAddModel checks that both the documented 'add-model' access and
+// the backwards-compatible 'addmodel' work to revoke the AddModel permission.
+func (s *grantSuite) TestInitRevokeAddModel(c *gc.C) {
+	wrappedCmd, revokeCmd := model.NewRevokeCommandForTest(s.fake, s.store)
+	// The documented case, add-model.
+	err := testing.InitCommand(wrappedCmd, []string{"bob", "add-model"})
+	c.Check(err, jc.ErrorIsNil)
+
+	// The backwards-compatible case, addmodel.
+	err = testing.InitCommand(wrappedCmd, []string{"bob", "addmodel"})
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(revokeCmd.ModelAccess, gc.Equals, "add-model")
 }
 
 type fakeGrantRevokeAPI struct {

--- a/cmd/juju/user/info_test.go
+++ b/cmd/juju/user/info_test.go
@@ -53,7 +53,7 @@ func (*fakeUserInfoAPI) UserInfo(usernames []string, all usermanager.IncludeDisa
 	switch usernames[0] {
 	case "current-user":
 		info.Username = "current-user"
-		info.Access = "addmodel"
+		info.Access = "add-model"
 	case "foobar":
 		info.Username = "foobar"
 		info.DisplayName = "Foo Bar"
@@ -61,7 +61,7 @@ func (*fakeUserInfoAPI) UserInfo(usernames []string, all usermanager.IncludeDisa
 	case "fred@external":
 		info.Username = "fred@external"
 		info.DisplayName = "Fred External"
-		info.Access = "addmodel"
+		info.Access = "add-model"
 	default:
 		return nil, common.ErrPerm
 	}
@@ -72,7 +72,7 @@ func (s *UserInfoCommandSuite) TestUserInfo(c *gc.C) {
 	context, err := testing.RunCommand(c, s.NewShowUserCommand())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, `user-name: current-user
-access: addmodel
+access: add-model
 date-created: 1981-02-27
 last-connection: 2014-01-01
 `)
@@ -82,7 +82,7 @@ func (s *UserInfoCommandSuite) TestUserInfoExactTime(c *gc.C) {
 	context, err := testing.RunCommand(c, s.NewShowUserCommand(), "--exact-time")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, `user-name: current-user
-access: addmodel
+access: add-model
 date-created: 1981-02-27 16:10:05 +0000 UTC
 last-connection: 2014-01-01 00:00:00 +0000 UTC
 `)
@@ -104,7 +104,7 @@ func (s *UserInfoCommandSuite) TestUserInfoExternalUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, `user-name: fred@external
 display-name: Fred External
-access: addmodel
+access: add-model
 `)
 }
 
@@ -117,7 +117,7 @@ func (s *UserInfoCommandSuite) TestUserInfoFormatJson(c *gc.C) {
 	context, err := testing.RunCommand(c, s.NewShowUserCommand(), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, `
-{"user-name":"current-user","access":"addmodel","date-created":"1981-02-27","last-connection":"2014-01-01"}
+{"user-name":"current-user","access":"add-model","date-created":"1981-02-27","last-connection":"2014-01-01"}
 `[1:])
 }
 
@@ -133,7 +133,7 @@ func (s *UserInfoCommandSuite) TestUserInfoFormatYaml(c *gc.C) {
 	context, err := testing.RunCommand(c, s.NewShowUserCommand(), "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, `user-name: current-user
-access: addmodel
+access: add-model
 date-created: 1981-02-27
 last-connection: 2014-01-01
 `)

--- a/cmd/juju/user/list_test.go
+++ b/cmd/juju/user/list_test.go
@@ -92,7 +92,7 @@ func (f *fakeUserListAPI) UserInfo(usernames []string, all usermanager.IncludeDi
 		}, {
 			Username:       "barbara",
 			DisplayName:    "Barbara Yellow",
-			Access:         "addmodel",
+			Access:         "add-model",
 			DateCreated:    time.Date(2013, 5, 2, 0, 0, 0, 0, time.UTC),
 			LastConnection: &now,
 		}, {
@@ -129,7 +129,7 @@ func (s *UserListCommandSuite) TestUserInfo(c *gc.C) {
 		"Controller: testing\n\n"+
 		"Name     Display name    Access     Date created  Last connection\n"+
 		"adam*    Adam Zulu       login      2012-10-08    2014-01-01\n"+
-		"barbara  Barbara Yellow  addmodel   2013-05-02    just now\n"+
+		"barbara  Barbara Yellow  add-model  2013-05-02    just now\n"+
 		"charlie  Charlie Xavier  superuser  6 hours ago   never connected\n"+
 		"\n")
 }
@@ -141,7 +141,7 @@ func (s *UserListCommandSuite) TestUserInfoWithDisabled(c *gc.C) {
 		"Controller: testing\n\n"+
 		"Name     Display name    Access     Date created  Last connection\n"+
 		"adam*    Adam Zulu       login      2012-10-08    2014-01-01\n"+
-		"barbara  Barbara Yellow  addmodel   2013-05-02    just now\n"+
+		"barbara  Barbara Yellow  add-model  2013-05-02    just now\n"+
 		"charlie  Charlie Xavier  superuser  6 hours ago   never connected\n"+
 		"davey    Davey Willow               2014-10-09    35 minutes ago (disabled)\n"+
 		"\n")
@@ -154,7 +154,7 @@ func (s *UserListCommandSuite) TestUserInfoExactTime(c *gc.C) {
 		"Controller: testing\n\n"+
 		"Name     Display name    Access     Date created                   Last connection\n"+
 		"adam*    Adam Zulu       login      2012-10-08 00:00:00 +0000 UTC  2014-01-01 00:00:00 +0000 UTC\n"+
-		"barbara  Barbara Yellow  addmodel   2013-05-02 00:00:00 +0000 UTC  2016-09-15 12:00:00 +0000 UTC\n"+
+		"barbara  Barbara Yellow  add-model  2013-05-02 00:00:00 +0000 UTC  2016-09-15 12:00:00 +0000 UTC\n"+
 		"charlie  Charlie Xavier  superuser  2016-09-15 06:00:00 +0000 UTC  never connected\n"+
 		"\n")
 }
@@ -164,7 +164,7 @@ func (s *UserListCommandSuite) TestUserInfoFormatJson(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, "["+
 		`{"user-name":"adam","display-name":"Adam Zulu","access":"login","date-created":"2012-10-08","last-connection":"2014-01-01"},`+
-		`{"user-name":"barbara","display-name":"Barbara Yellow","access":"addmodel","date-created":"2013-05-02","last-connection":"just now"},`+
+		`{"user-name":"barbara","display-name":"Barbara Yellow","access":"add-model","date-created":"2013-05-02","last-connection":"just now"},`+
 		`{"user-name":"charlie","display-name":"Charlie Xavier","access":"superuser","date-created":"6 hours ago","last-connection":"never connected"}`+
 		"]\n")
 }
@@ -180,7 +180,7 @@ func (s *UserListCommandSuite) TestUserInfoFormatYaml(c *gc.C) {
 		"  last-connection: 2014-01-01\n"+
 		"- user-name: barbara\n"+
 		"  display-name: Barbara Yellow\n"+
-		"  access: addmodel\n"+
+		"  access: add-model\n"+
 		"  date-created: 2013-05-02\n"+
 		"  last-connection: just now\n"+
 		"- user-name: charlie\n"+

--- a/jujuclient/accounts_test.go
+++ b/jujuclient/accounts_test.go
@@ -75,7 +75,7 @@ func (s *AccountsSuite) TestUpdateAccountOverwrites(c *gc.C) {
 	testAccountDetails := jujuclient.AccountDetails{
 		User:            "admin",
 		Password:        "fnord",
-		LastKnownAccess: "addmodel",
+		LastKnownAccess: "add-model",
 	}
 	for i := 0; i < 2; i++ {
 		// Twice so we exercise the code path of updating with

--- a/permission/access.go
+++ b/permission/access.go
@@ -34,7 +34,7 @@ const (
 	LoginAccess Access = "login"
 
 	// AddModelAccess allows user to add new models in subjects supporting it.
-	AddModelAccess Access = "addmodel"
+	AddModelAccess Access = "add-model"
 
 	// SuperuserAccess allows user unrestricted permissions in the subject.
 	SuperuserAccess Access = "superuser"


### PR DESCRIPTION
Standardise the `juju grant` add model permission from "addmodel" to the
"add-model" phrasing used elsewhere in the CLI.

Fixes lp:1622433

QA steps:

  * `juju add-user foo` and `juju grant foo add-model`
    * User foo should be granted permission without error
  * `juju grant foo addmodel` (using the previous permission)
    * You should see an error that "addmodel"  access is not valid