### PR TITLE
Updated reference to httprequest library

### DIFF
--- a/api/backups/download_test.go
+++ b/api/backups/download_test.go
@@ -46,7 +46,7 @@ func (s *downloadSuite) TestSuccessfulRequest(c *gc.C) {
 
 func (s *downloadSuite) TestFailedRequest(c *gc.C) {
 	resultArchive, err := s.client.Download("unknown")
-	c.Assert(err, gc.ErrorMatches, `GET https://.*/model/.*/backups: backup metadata "unknown" not found`)
+	c.Assert(err, gc.ErrorMatches, `.*backup metadata "unknown" not found$`)
 	c.Assert(err, jc.Satisfies, params.IsCodeNotFound)
 	c.Assert(resultArchive, gc.Equals, nil)
 }

--- a/api/backups/upload_test.go
+++ b/api/backups/upload_test.go
@@ -61,6 +61,6 @@ func (s *uploadSuite) TestFailedRequest(c *gc.C) {
 	meta.Model = ""
 
 	id, err := s.client.Upload(archive, meta)
-	c.Assert(err, gc.ErrorMatches, `PUT https://.*/model/.*/backups: while storing backup archive: missing Model`)
+	c.Assert(err, gc.ErrorMatches, `.*while storing backup archive: missing Model$`)
 	c.Assert(id, gc.Equals, "")
 }

--- a/api/client_macaroon_test.go
+++ b/api/client_macaroon_test.go
@@ -79,5 +79,5 @@ func (s *clientMacaroonSuite) TestAddLocalCharmUnauthorized(c *gc.C) {
 	)
 	// Upload an archive with its original revision.
 	_, err := s.client.AddLocalCharm(curl, charmArchive)
-	c.Assert(err, gc.ErrorMatches, `POST https://.+: invalid entity name or password`)
+	c.Assert(err, gc.ErrorMatches, `.*invalid entity name or password$`)
 }

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -167,7 +167,7 @@ func (s *clientSuite) TestAddLocalCharmError(c *gc.C) {
 	)
 
 	_, err := client.AddLocalCharm(curl, charmArchive)
-	c.Assert(err, gc.ErrorMatches, `POST http://.+: the POST method is not allowed`)
+	c.Assert(err, gc.ErrorMatches, `.*the POST method is not allowed$`)
 }
 
 func (s *clientSuite) TestMinVersionLocalCharm(c *gc.C) {
@@ -252,7 +252,7 @@ func (s *clientSuite) TestOpenURIFound(c *gc.C) {
 func (s *clientSuite) TestOpenURIError(c *gc.C) {
 	client := s.APIState.Client()
 	_, err := client.OpenURI("/tools/foobar", nil)
-	c.Assert(err, gc.ErrorMatches, ".+error parsing version.+")
+	c.Assert(err, gc.ErrorMatches, ".*error parsing version.+")
 }
 
 func (s *clientSuite) TestOpenCharmFound(c *gc.C) {

--- a/api/http_test.go
+++ b/api/http_test.go
@@ -110,7 +110,7 @@ var httpClientTests = []struct {
 			},
 		})
 	},
-	expectError:     `GET http://.*/: some error`,
+	expectError:     `.*some error$`,
 	expectErrorCode: params.CodeBadRequest,
 	expectErrorInfo: &params.ErrorInfo{
 		MacaroonPath: "foo",

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -30,7 +30,7 @@ github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-0
 github.com/juju/gomaasapi	git	8c484173e0870fc49c9214c56c6ae8dc9c26463d	2016-09-19T18:34:33Z
 github.com/juju/govmomi	git	4354a88d4b34abe467215f77c2fc1cb9f78b66f7	2015-04-24T01:54:48Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
-github.com/juju/httprequest	git	796aaafaf712f666df58d31a482c51233038bf9f	2016-05-03T15:03:27Z
+github.com/juju/httprequest	git	266fd1e9debf09c037a63f074d099a2da4559ece	2016-10-06T15:09:09Z
 github.com/juju/idmclient	git	3dda079a75cccb85083d4c3877e638f5d6ab79c2	2016-05-26T05:00:34Z
 github.com/juju/loggo	git	3b7ece48644d35850f4ced4c2cbc2cf8413f58e0	2016-08-18T02:57:24Z
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z


### PR DESCRIPTION
This helps address lp:161200.

A prior commit was landed to clean up the error messages coming from Juju's controllers, but the httprequest library was prepending these messages with the details of the request. In the latest version of httprequest, this is no longer done.