### PR TITLE
Changes --reset to be a stringvar

### DIFF
--- a/cmd/juju/model/configcommand.go
+++ b/cmd/juju/model/configcommand.go
@@ -134,7 +134,7 @@ func (c *configCommand) handleOneArg(arg string) error {
 	// make sure that we are not resetting because it is not valid to get and
 	// reset simultaneously.
 	if len(c.reset) > 0 {
-		return errors.New("cannot set and retrieve default values simultaneously")
+		return errors.New("cannot set and retrieve model values simultaneously")
 	}
 	c.keys = []string{arg}
 	c.action = c.getConfig
@@ -172,7 +172,7 @@ func (c *configCommand) parseSetKeys(args []string) error {
 	for _, k := range c.resetKeys {
 		if _, ok := c.values[k]; ok {
 			return errors.Errorf(
-				"key %q cannot be both set and unset in the same command", k)
+				"key %q cannot be both set and reset in the same command", k)
 		}
 	}
 

--- a/cmd/juju/model/configcommand_test.go
+++ b/cmd/juju/model/configcommand_test.go
@@ -41,15 +41,15 @@ func (s *ConfigCommandSuite) TestInit(c *gc.C) {
 			// Test reset
 			// 2
 			args:       []string{"--reset"},
-			errorMatch: "no keys specified",
+			errorMatch: "flag needs an argument: --reset",
 		}, {
 			// 3
-			args:   []string{"--reset", "something", "weird"},
-			nilErr: true,
+			args:       []string{"--reset", "something", "weird"},
+			errorMatch: "cannot set and retrieve default values simultaneously",
 		}, {
 			// 4
 			args:       []string{"--reset", "agent-version"},
-			errorMatch: "agent-version cannot be reset",
+			errorMatch: `"agent-version" cannot be reset`,
 		}, {
 			// Test get
 			// 5
@@ -168,15 +168,15 @@ func (s *ConfigCommandSuite) TestBlockedError(c *gc.C) {
 }
 
 func (s *ConfigCommandSuite) TestResetPassesValues(c *gc.C) {
-	_, err := s.run(c, "--reset", "special", "running")
+	_, err := s.run(c, "--reset", "special,running")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.fake.keys, jc.DeepEquals, []string{"special", "running"})
+	c.Assert(s.fake.resetKeys, jc.DeepEquals, []string{"special", "running"})
 }
 
-func (s *ConfigCommandSuite) TestResettingKnownValue(c *gc.C) {
+func (s *ConfigCommandSuite) TestResettingUnKnownValue(c *gc.C) {
 	_, err := s.run(c, "--reset", "unknown")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.fake.keys, jc.DeepEquals, []string{"unknown"})
+	c.Assert(s.fake.resetKeys, jc.DeepEquals, []string{"unknown"})
 	// Command succeeds, but warning logged.
 	expected := `key "unknown" is not defined in the current model configuration: possible misspelling`
 	c.Check(c.GetTestLog(), jc.Contains, expected)

--- a/cmd/juju/model/fakeenv_test.go
+++ b/cmd/juju/model/fakeenv_test.go
@@ -39,6 +39,7 @@ type fakeEnvAPI struct {
 	defaults      config.ConfigValues
 	err           error
 	keys          []string
+	resetKeys     []string
 }
 
 func (f *fakeEnvAPI) Close() error {
@@ -63,7 +64,7 @@ func (f *fakeEnvAPI) ModelSet(config map[string]interface{}) error {
 }
 
 func (f *fakeEnvAPI) ModelUnset(keys ...string) error {
-	f.keys = keys
+	f.resetKeys = keys
 	return f.err
 }
 


### PR DESCRIPTION
Also allows reset and set to run in the same command, per the spec.
All tests pass at this point but it needs more tests

Refs: config command collapse spec https://goo.gl/yqrrPI
Refs: model-config-tree

QA:

With an lxd cloud like (see [Faster LXD](https://github.com/juju/juju/wiki/Faster-LXD) for details on apt-http proxy and other items, or don't use them)
		
```
lxdtest:
    type: lxd
    config:
        apt-http-proxy: http://10.0.4.1:8000
        bootstrap-timeout: 300
        default-series: xenial
        enable-os-refresh-update: true
        enable-os-upgrade: false
        logging-config: <root>=DEBUG
        no-proxy: https://lxd-no-regions
```

1. `juju bootstrap lxd-model-config lxdtest`
2. `juju model-config`  and verify no-proxy value

    ATTRIBUTE                   FROM        VALUE
    agent-metadata-url          default     ""
    agent-stream                default     released
    agent-version               model       2.0.0.1
    apt-ftp-proxy               default     ""
    apt-http-proxy              controller  http://10.0.4.1:8000
    apt-https-proxy             default     ""
    apt-mirror                  default     ""
    automatically-retry-hooks   default     true
    default-series              controller  xenial
    development                 default     false
    disable-network-management  default     false
    enable-os-refresh-update    controller  true
    enable-os-upgrade           controller  false
    firewall-mode               default     instance
    ftp-proxy                   default     ""
    http-proxy                  default     ""
    https-proxy                 default     ""
    ignore-machine-addresses    default     false
    image-metadata-url          default     ""
    image-stream                default     released
    logforward-enabled          default     false
    logging-config              model       <root>=DEBUG;unit=DEBUG
    no-proxy                    controller  https://lxd-no-regions
    provisioner-harvest-mode    default     destroyed
    proxy-ssh                   default     false
    resource-tags               model       {}
    ssl-hostname-verification   default     true
    test-mode                   default     false
    transmit-vendor-metrics     default     true

3. set no-proxy `juju model-config no-proxy=different`
4. verify `juju model-config no-proxy` is `different`
5. set others and reset no proxy `juju model-config agent-stream=devel apt-mirror=mirror`
6. verify the keys are set `for k in apt-mirror agent-stream; do juju model-config $k; done`
7. set these to be different and reset no-proxy `juju model-config agent-stream=stage --reset no-proxy apt-mirror=anothermirror`
8. verify `for k in apt-mirror agent-stream no-proxy; do juju model-config $k; done`

    anothermirror
    stage
    https://lxd-no-regions

9. reset multiple and set multiple  `juju model-config no-proxy=foo --reset agent-stream,apt-mirror default-series=yakkety`
10. verify `for k in apt-mirror agent-stream no-proxy default-series; do juju model-config $k; done`

    ""
    released
    foo
    yakkety

11. Try invalid command `juju model-config no-proxy=foo --reset no-proxy`

    error: key "no-proxy" cannot be both set and reset in the same command

12. Try another `juju model-config no-proxy=foo no-proxy=bar`

    error: key "no-proxy" specified more than once

13. Try multiple get `juju model-config no-proxy apt-mirror`

    error: can only retrieve a single value, or all values

14. Try reset and get `juju model-config --reset no-proxy apt-mirror`

    error: cannot set and retrieve model values simultaneously

15. Try things I didn't think about here
16. `juju kill-controller -y lxd-model-config`
