### PR TITLE
Remove Ping from api.Connection interface

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -245,7 +245,7 @@ func open(
 
 	go (&monitor{
 		clock:       clock,
-		ping:        st.Ping,
+		ping:        st.ping,
 		pingPeriod:  PingPeriod,
 		pingTimeout: pingTimeout,
 		closed:      st.closed,
@@ -460,8 +460,7 @@ func (st *state) apiEndpoint(path, query string) (*url.URL, error) {
 	}, nil
 }
 
-// Ping implements api.Connection.
-func (s *state) Ping() error {
+func (s *state) ping() error {
 	return s.APICall("Pinger", s.pingerFacadeVersion, "", "Ping", nil, nil)
 }
 

--- a/api/interface.go
+++ b/api/interface.go
@@ -178,12 +178,6 @@ type Connection interface {
 	// All the rest are strange and questionable and deserve extra attention
 	// and/or discussion.
 
-	// Something-or-other expects Ping to exist, and *maybe* the heartbeat
-	// *should* be handled outside the State type, but it's also handled
-	// inside it as well. We should figure this out sometime -- we should
-	// either expose Ping() or Broken() but not both.
-	Ping() error
-
 	// I think this is actually dead code. It's tested, at least, so I'm
 	// keeping it for now, but it's not apparently used anywhere else.
 	AllFacadeVersions() map[string][]int

--- a/apiserver/cert_test.go
+++ b/apiserver/cert_test.go
@@ -33,8 +33,7 @@ func (s *certSuite) TestUpdateCert(c *gc.C) {
 
 	// Sanity check that the server works initially.
 	conn := s.OpenAPIAsAdmin(c, srv)
-	err := conn.Ping()
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pingConn(conn), jc.ErrorIsNil)
 
 	// Create a new certificate that's a year out of date, so we can
 	// tell that the server is using it because the connection
@@ -70,8 +69,7 @@ func (s *certSuite) TestUpdateCert(c *gc.C) {
 	certChanged <- info
 
 	conn = s.OpenAPIAsAdmin(c, srv)
-	err = conn.Ping()
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pingConn(conn), jc.ErrorIsNil)
 }
 
 func (s *certSuite) TestAutocertFailure(c *gc.C) {

--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -115,18 +115,16 @@ func AgentDone(logger loggo.Logger, err error) error {
 	return err
 }
 
-// Pinger provides a type that knows how to ping.
-type Pinger interface {
-
-	// Ping pings something.
-	Ping() error
+// Brokener provides a type that exposes a "broken" channel.
+type Brokener interface {
+	Broken() <-chan struct{}
 }
 
 // ConnectionIsFatal returns a function suitable for passing as the
 // isFatal argument to worker.NewRunner, that diagnoses an error as
 // fatal if the connection has failed or if the error is otherwise
 // fatal.
-func ConnectionIsFatal(logger loggo.Logger, conns ...Pinger) func(err error) bool {
+func ConnectionIsFatal(logger loggo.Logger, conns ...Brokener) func(err error) bool {
 	return func(err error) bool {
 		if IsFatal(err) {
 			return true
@@ -140,8 +138,47 @@ func ConnectionIsFatal(logger loggo.Logger, conns ...Pinger) func(err error) boo
 	}
 }
 
-// ConnectionIsDead returns true if the given pinger fails to ping.
-var ConnectionIsDead = func(logger loggo.Logger, conn Pinger) bool {
+// ConnectionIsDead returns true if the given Brokener is broken.
+var ConnectionIsDead = func(logger loggo.Logger, conn Brokener) bool {
+	select {
+	case <-conn.Broken():
+		return true
+	default:
+		return false
+	}
+}
+
+// Pinger provides a type that knows how to ping.
+type Pinger interface {
+	Ping() error
+}
+
+// PingerIsFatal returns a function suitable for passing as the
+// isFatal argument to worker.NewRunner, that diagnoses an error as
+// fatal if the Pinger has failed or if the error is otherwise fatal.
+//
+// TODO(mjs) - this only exists for checking State instances in the
+// machine agent and won't be necessary once either:
+// 1. State grows a Broken() channel like api.Connection (which is
+//    actually quite a nice idea).
+// 2. The dependency engine conversion is completed for the machine
+//    agent.
+func PingerIsFatal(logger loggo.Logger, conns ...Pinger) func(err error) bool {
+	return func(err error) bool {
+		if IsFatal(err) {
+			return true
+		}
+		for _, conn := range conns {
+			if PingerIsDead(logger, conn) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// PingerIsDead returns true if the given pinger fails to ping.
+var PingerIsDead = func(logger loggo.Logger, conn Pinger) bool {
 	if err := conn.Ping(); err != nil {
 		logger.Infof("error pinging %T: %v", conn, err)
 		return true

--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -115,8 +115,8 @@ func AgentDone(logger loggo.Logger, err error) error {
 	return err
 }
 
-// Brokener provides a type that exposes a "broken" channel.
-type Brokener interface {
+// Breakable provides a type that exposes a "broken" channel.
+type Breakable interface {
 	Broken() <-chan struct{}
 }
 
@@ -124,7 +124,7 @@ type Brokener interface {
 // isFatal argument to worker.NewRunner, that diagnoses an error as
 // fatal if the connection has failed or if the error is otherwise
 // fatal.
-func ConnectionIsFatal(logger loggo.Logger, conns ...Brokener) func(err error) bool {
+func ConnectionIsFatal(logger loggo.Logger, conns ...Breakable) func(err error) bool {
 	return func(err error) bool {
 		if IsFatal(err) {
 			return true
@@ -138,8 +138,8 @@ func ConnectionIsFatal(logger loggo.Logger, conns ...Brokener) func(err error) b
 	}
 }
 
-// ConnectionIsDead returns true if the given Brokener is broken.
-var ConnectionIsDead = func(logger loggo.Logger, conn Brokener) bool {
+// ConnectionIsDead returns true if the given Breakable is broken.
+var ConnectionIsDead = func(logger loggo.Logger, conn Breakable) bool {
 	select {
 	case <-conn.Broken():
 		return true

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -77,7 +77,7 @@ func (s *UpgradeSuite) SetUpTest(c *gc.C) {
 
 	// Allow tests to make the API connection appear to be dead.
 	s.connectionDead = false
-	s.PatchValue(&cmdutil.ConnectionIsDead, func(loggo.Logger, cmdutil.Pinger) bool {
+	s.PatchValue(&cmdutil.ConnectionIsDead, func(loggo.Logger, cmdutil.Breakable) bool {
 		return s.connectionDead
 	})
 


### PR DESCRIPTION
As per pre-existing comments, there should only be one way to check whether an API connection is alive. Given that connections now do a great job of checking themselves - the results of which are exposed via
Broken - the Ping method was removed.

This had some bigger-than-expected fallout in the agent code but this can be cleaned up by making a similar change to State (later).