### PR TITLE
worker/uniter/runner/debug: better test logging

### DIFF
--- a/worker/uniter/runner/debug/export_test.go
+++ b/worker/uniter/runner/debug/export_test.go
@@ -1,11 +1,16 @@
-// Copyright 2013 Canonical Ltd.
+// Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package debug
 
-// RunHookOutput returns the most recent combined output from RunHook.
-func (s *ServerSession) RunHookOutput() string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.output
+import "io"
+
+// FindSessionWithWriter returns the server session with the writer
+// specified so the run output can be captured for tests.
+func (c *HooksContext) FindSessionWithWriter(writer io.Writer) (*ServerSession, error) {
+	session, err := c.FindSession()
+	if session != nil {
+		session.output = writer
+	}
+	return session, err
 }

--- a/worker/uniter/runner/debug/export_test.go
+++ b/worker/uniter/runner/debug/export_test.go
@@ -1,0 +1,11 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package debug
+
+// RunHookOutput returns the most recent combined output from RunHook.
+func (s *ServerSession) RunHookOutput() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.output
+}

--- a/worker/uniter/runner/debug/server_test.go
+++ b/worker/uniter/runner/debug/server_test.go
@@ -4,6 +4,7 @@
 package debug
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -142,7 +143,8 @@ func (s *DebugHooksServerSuite) TestRunHookExceptional(c *gc.C) {
 func (s *DebugHooksServerSuite) TestRunHook(c *gc.C) {
 	err := ioutil.WriteFile(s.ctx.ClientFileLock(), []byte{}, 0777)
 	c.Assert(err, jc.ErrorIsNil)
-	session, err := s.ctx.FindSession()
+	var output bytes.Buffer
+	session, err := s.ctx.FindSessionWithWriter(&output)
 	c.Assert(session, gc.NotNil)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -171,7 +173,7 @@ func (s *DebugHooksServerSuite) TestRunHook(c *gc.C) {
 			c.Fatal("test timed out")
 		case err = <-ch:
 			// flock was released before we found the debug dir.
-			c.Fatalf("could not find hook.sh\nerr: %v\noutput: %s", err, session.RunHookOutput())
+			c.Fatalf("could not find hook.sh\nerr: %v\noutput: %s", err, output.String())
 		case <-ticker:
 			tmpdir, err := os.Open(s.tmpdir)
 			if err != nil {

--- a/worker/uniter/runner/debug/server_test.go
+++ b/worker/uniter/runner/debug/server_test.go
@@ -154,6 +154,8 @@ func (s *DebugHooksServerSuite) TestRunHook(c *gc.C) {
 	// exit cleanly (as if the PID were real and no longer running).
 	cmd := exec.Command("flock", s.ctx.ClientExitFileLock(), "-c", "sleep 5s")
 	c.Assert(cmd.Start(), gc.IsNil)
+	defer cmd.Process.Kill() // kill flock
+
 	ch := make(chan error)
 	go func() {
 		ch <- session.RunHook(hookName, s.tmpdir, os.Environ())
@@ -162,12 +164,14 @@ func (s *DebugHooksServerSuite) TestRunHook(c *gc.C) {
 	// Wait until either we find the debug dir, or the flock is released.
 	ticker := time.Tick(10 * time.Millisecond)
 	var debugdir os.FileInfo
+	timeout := time.After(testing.LongWait)
 	for debugdir == nil {
 		select {
+		case <-timeout:
+			c.Fatal("test timed out")
 		case err = <-ch:
 			// flock was released before we found the debug dir.
-			c.Error("could not find hook.sh")
-
+			c.Fatalf("could not find hook.sh\nerr: %v\noutput: %s", err, session.RunHookOutput())
 		case <-ticker:
 			tmpdir, err := os.Open(s.tmpdir)
 			if err != nil {
@@ -203,9 +207,12 @@ func (s *DebugHooksServerSuite) TestRunHook(c *gc.C) {
 
 	// RunHook should complete without waiting to be
 	// killed, and despite the exit lock being held.
-	err = <-ch
-	c.Assert(err, jc.ErrorIsNil)
-	cmd.Process.Kill() // kill flock
+	select {
+	case err = <-ch:
+		c.Assert(err, jc.ErrorIsNil)
+	case <-time.After(testing.LongWait):
+		c.Fatal("RunHook did not complete")
+	}
 }
 
 func (s *DebugHooksServerSuite) verifyEnvshFile(c *gc.C, envshPath string, hookName string) {


### PR DESCRIPTION
This work was in response to a test timeout in the debug package.

After much examination it was determined that the test timed out because RunHook failed to start properly, and the case statement in the first select was only calling c.Error. Error only marks the test as failing, it doesn't actually cause the test to stop, so when it did fail there, the test kept looping.

Extra testing.LongWait calls added to each select as a firm backdoor. Now the ServerSession captures the output of the hook execution in order to allow the test to write it out in the failure case.