### PR TITLE
remove macaroons on logout

### DIFF
--- a/cmd/juju/user/logout.go
+++ b/cmd/juju/user/logout.go
@@ -131,6 +131,22 @@ this command again with the "--force" flag.
 `)
 	}
 
+	details, err := store.ControllerByName(controllerName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	apictx, err := c.APIContext()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	for _, s := range details.APIEndpoints {
+		apictx.Jar.RemoveAllHost(s)
+	}
+	if err := apictx.Jar.Save(); err != nil {
+		return errors.Annotate(err, "can't remove cached authentication cookie")
+	}
+
 	// Remove the account credentials.
 	if err := store.RemoveAccount(controllerName); err != nil {
 		return errors.Annotate(err, "failed to clear credentials")

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -35,7 +35,7 @@ github.com/juju/idmclient	git	3dda079a75cccb85083d4c3877e638f5d6ab79c2	2016-05-2
 github.com/juju/loggo	git	3b7ece48644d35850f4ced4c2cbc2cf8413f58e0	2016-08-18T02:57:24Z
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z
 github.com/juju/mutex	git	59c26ee163447c5c57f63ff71610d433862013de	2016-06-17T01:09:07Z
-github.com/juju/persistent-cookiejar	git	e710b897c13ca52828ca2fc9769465186fd6d15c	2016-03-31T17:12:27Z
+github.com/juju/persistent-cookiejar	git	b48f5b9290d63455d10de0c0e4c26e06e6e74842	2016-10-07T16:41:21Z
 github.com/juju/replicaset	git	fb7294cf57a1e2f08a57691f1246d129a87ab7e8	2015-05-08T02:21:43Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:42:13Z

--- a/featuretests/cmd_juju_login_test.go
+++ b/featuretests/cmd_juju_login_test.go
@@ -6,13 +6,11 @@ package featuretests
 import (
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/commands"
@@ -61,10 +59,6 @@ func (s *cmdLoginSuite) TestLoginCommand(c *gc.C) {
 	// a non-random password before we can do so.
 	s.changeUserPassword(c, "admin", "hunter2")
 	s.run(c, nil, "logout")
-
-	// TODO(axw) 2016-09-08 #1621375
-	// "juju logout" should clear the cookies for the controller.
-	os.Remove(filepath.Join(utils.Home(), ".go-cookies"))
 
 	context := s.run(c, strings.NewReader("hunter2\nhunter2\n"), "login", "test")
 	c.Assert(testing.Stdout(context), gc.Equals, "")


### PR DESCRIPTION
this fixes https://bugs.launchpad.net/juju/+bug/1621375
juju logout should clear cookies for the controller

QA steps:  
* bootstrap something other than lxd.  
* juju change-user-password
* juju logout
* juju login

ensure that login asks for your password as well as your username.