### PR TITLE
juju destroy-model blocks

### DIFF
--- a/api/common/modelstatus.go
+++ b/api/common/modelstatus.go
@@ -1,0 +1,74 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+)
+
+// ModelStatusAPI provides common client-side API functions
+// to call into apiserver.common.ModelStatusAPI.
+type ModelStatusAPI struct {
+	facade base.FacadeCaller
+}
+
+// NewModelStatusAPI creates a ModelStatusAPI on the specified facade,
+// and uses this name when calling through the caller.
+func NewModelStatusAPI(facade base.FacadeCaller) *ModelStatusAPI {
+	return &ModelStatusAPI{facade}
+}
+
+// ModelStatus returns a status summary for each model tag passed in.
+func (c *ModelStatusAPI) ModelStatus(tags ...names.ModelTag) ([]base.ModelStatus, error) {
+	result := params.ModelStatusResults{}
+	models := make([]params.Entity, len(tags))
+	for i, tag := range tags {
+		models[i] = params.Entity{Tag: tag.String()}
+	}
+	req := params.Entities{
+		Entities: models,
+	}
+	if err := c.facade.FacadeCall("ModelStatus", req, &result); err != nil {
+		return nil, err
+	}
+
+	results := make([]base.ModelStatus, len(result.Results))
+	for i, r := range result.Results {
+		model, err := names.ParseModelTag(r.ModelTag)
+		if err != nil {
+			return nil, errors.Annotatef(err, "ModelTag %q at position %d", r.ModelTag, i)
+		}
+		owner, err := names.ParseUserTag(r.OwnerTag)
+		if err != nil {
+			return nil, errors.Annotatef(err, "OwnerTag %q at position %d", r.OwnerTag, i)
+		}
+
+		results[i] = base.ModelStatus{
+			UUID:               model.Id(),
+			Life:               string(r.Life),
+			Owner:              owner.Id(),
+			HostedMachineCount: r.HostedMachineCount,
+			ServiceCount:       r.ApplicationCount,
+			TotalMachineCount:  len(r.Machines),
+		}
+		results[i].Machines = make([]base.Machine, len(r.Machines))
+		for j, mm := range r.Machines {
+			if mm.Hardware != nil && mm.Hardware.Cores != nil {
+				results[i].CoreCount += int(*mm.Hardware.Cores)
+			}
+			results[i].Machines[j] = base.Machine{
+				Id:         mm.Id,
+				InstanceId: mm.InstanceId,
+				HasVote:    mm.HasVote,
+				WantsVote:  mm.WantsVote,
+				Status:     mm.Status,
+			}
+		}
+	}
+	return results, nil
+}

--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
@@ -22,13 +23,18 @@ var logger = loggo.GetLogger("juju.api.modelmanager")
 type Client struct {
 	base.ClientFacade
 	facade base.FacadeCaller
+	*common.ModelStatusAPI
 }
 
 // NewClient creates a new `Client` based on an existing authenticated API
 // connection.
 func NewClient(st base.APICallCloser) *Client {
 	frontend, backend := base.NewClientFacade(st, "ModelManager")
-	return &Client{ClientFacade: frontend, facade: backend}
+	return &Client{
+		ClientFacade:   frontend,
+		facade:         backend,
+		ModelStatusAPI: common.NewModelStatusAPI(backend),
+	}
 }
 
 // Close closes the api connection.

--- a/apiserver/common/machine.go
+++ b/apiserver/common/machine.go
@@ -66,6 +66,7 @@ type Machine interface {
 	ForceDestroy() error
 	Destroy() error
 	AgentPresence() (bool, error)
+	IsManager() bool
 }
 
 func DestroyMachines(st origStateInterface, force bool, ids ...string) error {

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -51,6 +51,7 @@ type ModelManagerBackend interface {
 	RemoveUserAccess(names.UserTag, names.Tag) error
 	UserAccess(names.UserTag, names.Tag) (permission.UserAccess, error)
 	AllMachines() (machines []Machine, err error)
+	AllApplications() (applications []Application, err error)
 	ControllerUUID() string
 	ControllerTag() names.ControllerTag
 	Export() (description.Model, error)
@@ -176,6 +177,25 @@ func (st modelManagerStateShim) AllMachines() ([]Machine, error) {
 	all := make([]Machine, len(allStateMachines))
 	for i, m := range allStateMachines {
 		all[i] = machineShim{m}
+	}
+	return all, nil
+}
+
+// Application defines methods provided by a state.Application instance.
+type Application interface{}
+
+type applicationShim struct {
+	*state.Application
+}
+
+func (st modelManagerStateShim) AllApplications() ([]Application, error) {
+	allStateApplications, err := st.State.AllApplications()
+	if err != nil {
+		return nil, err
+	}
+	all := make([]Application, len(allStateApplications))
+	for i, a := range allStateApplications {
+		all[i] = applicationShim{a}
 	}
 	return all, nil
 }

--- a/apiserver/common/modelstatus.go
+++ b/apiserver/common/modelstatus.go
@@ -1,0 +1,132 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/permission"
+)
+
+// ModelStatusAPI implements the ModelStatus() API.
+type ModelStatusAPI struct {
+	authorizer facade.Authorizer
+	apiUser    names.UserTag
+	backend    ModelManagerBackend
+}
+
+// NewModelStatusAPI creates an implementation providing the ModelStatus() API.
+func NewModelStatusAPI(st ModelManagerBackend, authorizer facade.Authorizer, apiUser names.UserTag) *ModelStatusAPI {
+	return &ModelStatusAPI{
+		authorizer: authorizer,
+		apiUser:    apiUser,
+		backend:    st,
+	}
+}
+
+func (s *ModelStatusAPI) checkHasAdmin() error {
+	isAdmin, err := s.authorizer.HasPermission(permission.SuperuserAccess, s.backend.ControllerTag())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if !isAdmin {
+		return ServerError(ErrPerm)
+	}
+	return nil
+}
+
+// modelAuthCheck checks if the user is acting on their own behalf, or if they
+// are an administrator acting on behalf of another user.
+func (s *ModelStatusAPI) modelAuthCheck(modelTag names.ModelTag, owner names.UserTag) error {
+	if err := s.checkHasAdmin(); err == nil {
+		logger.Tracef("%q is a controller admin", s.apiUser.Id())
+		return nil
+	}
+	if s.apiUser == owner {
+		return nil
+	}
+	isAdmin, err := s.authorizer.HasPermission(permission.AdminAccess, modelTag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if isAdmin {
+		return nil
+	}
+	return ErrPerm
+}
+
+// ModelStatus returns a summary of the model.
+func (c *ModelStatusAPI) ModelStatus(req params.Entities) (params.ModelStatusResults, error) {
+	models := req.Entities
+	results := params.ModelStatusResults{}
+
+	status := make([]params.ModelStatus, len(models))
+	for i, model := range models {
+		modelStatus, err := c.modelStatus(model.Tag)
+		if err != nil {
+			return results, errors.Trace(err)
+		}
+		status[i] = modelStatus
+	}
+	results.Results = status
+	return results, nil
+}
+
+func (c *ModelStatusAPI) modelStatus(tag string) (params.ModelStatus, error) {
+	var status params.ModelStatus
+	modelTag, err := names.ParseModelTag(tag)
+	if err != nil {
+		return status, errors.Trace(err)
+	}
+	st := c.backend
+	if modelTag != c.backend.ModelTag() {
+		if st, err = c.backend.ForModel(modelTag); err != nil {
+			return status, errors.Trace(err)
+		}
+		defer st.Close()
+	}
+
+	model, err := st.Model()
+	if err != nil {
+		return status, errors.Trace(err)
+	}
+	if err := c.modelAuthCheck(modelTag, model.Owner()); err != nil {
+		return status, errors.Trace(err)
+	}
+
+	machines, err := st.AllMachines()
+	if err != nil {
+		return status, errors.Trace(err)
+	}
+
+	var hostedMachines []Machine
+	for _, m := range machines {
+		if !m.IsManager() {
+			hostedMachines = append(hostedMachines, m)
+		}
+	}
+
+	applications, err := st.AllApplications()
+	if err != nil {
+		return status, errors.Trace(err)
+	}
+
+	modelMachines, err := ModelMachineInfo(st)
+	if err != nil {
+		return status, errors.Trace(err)
+	}
+
+	return params.ModelStatus{
+		ModelTag:           tag,
+		OwnerTag:           model.Owner().String(),
+		Life:               params.Life(model.Life().String()),
+		HostedMachineCount: len(hostedMachines),
+		ApplicationCount:   len(applications),
+		Machines:           modelMachines,
+	}, nil
+}

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -1,0 +1,155 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common_test
+
+import (
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/controller"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
+)
+
+type modelStatusSuite struct {
+	statetesting.StateSuite
+
+	controller *controller.ControllerAPI
+	resources  *common.Resources
+	authorizer apiservertesting.FakeAuthorizer
+}
+
+var _ = gc.Suite(&modelStatusSuite{})
+
+func (s *modelStatusSuite) SetUpTest(c *gc.C) {
+	// Initial config needs to be set before the StateSuite SetUpTest.
+	s.InitialConfig = testing.CustomModelConfig(c, testing.Attrs{
+		"name": "controller",
+	})
+
+	s.StateSuite.SetUpTest(c)
+	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
+
+	s.authorizer = apiservertesting.FakeAuthorizer{
+		Tag:      s.Owner,
+		AdminTag: s.Owner,
+	}
+
+	controller, err := controller.NewControllerAPI(s.State, s.resources, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	s.controller = controller
+
+	loggo.GetLogger("juju.apiserver.controller").SetLogLevel(loggo.TRACE)
+}
+
+func (s *modelStatusSuite) TestModelStatusNonAuth(c *gc.C) {
+	// Set up the user making the call.
+	user := s.Factory.MakeUser(c, &factory.UserParams{NoModelUser: true})
+	anAuthoriser := apiservertesting.FakeAuthorizer{
+		Tag: user.Tag(),
+	}
+	endpoint, err := controller.NewControllerAPI(s.State, s.resources, anAuthoriser)
+	c.Assert(err, jc.ErrorIsNil)
+	controllerModelTag := s.State.ModelTag().String()
+
+	req := params.Entities{
+		Entities: []params.Entity{{Tag: controllerModelTag}},
+	}
+	_, err = endpoint.ModelStatus(req)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *modelStatusSuite) TestModelStatusOwnerAllowed(c *gc.C) {
+	// Set up the user making the call.
+	owner := s.Factory.MakeUser(c, nil)
+	anAuthoriser := apiservertesting.FakeAuthorizer{
+		Tag: owner.Tag(),
+	}
+	st := s.Factory.MakeModel(c, &factory.ModelParams{Owner: owner.Tag()})
+	defer st.Close()
+	endpoint, err := controller.NewControllerAPI(s.State, s.resources, anAuthoriser)
+	c.Assert(err, jc.ErrorIsNil)
+
+	req := params.Entities{
+		Entities: []params.Entity{{Tag: st.ModelTag().String()}},
+	}
+	_, err = endpoint.ModelStatus(req)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *modelStatusSuite) TestModelStatus(c *gc.C) {
+	otherModelOwner := s.Factory.MakeModelUser(c, nil)
+	otherSt := s.Factory.MakeModel(c, &factory.ModelParams{
+		Name:  "dummytoo",
+		Owner: otherModelOwner.UserTag,
+		ConfigAttrs: testing.Attrs{
+			"controller": false,
+		},
+	})
+	defer otherSt.Close()
+
+	eight := uint64(8)
+	s.Factory.MakeMachine(c, &factory.MachineParams{
+		Jobs:            []state.MachineJob{state.JobManageModel},
+		Characteristics: &instance.HardwareCharacteristics{CpuCores: &eight},
+		InstanceId:      "id-4",
+	})
+	s.Factory.MakeMachine(c, &factory.MachineParams{
+		Jobs: []state.MachineJob{state.JobHostUnits}, InstanceId: "id-5"})
+	s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Charm: s.Factory.MakeCharm(c, nil),
+	})
+
+	otherFactory := factory.NewFactory(otherSt)
+	otherFactory.MakeMachine(c, &factory.MachineParams{InstanceId: "id-8"})
+	otherFactory.MakeMachine(c, &factory.MachineParams{InstanceId: "id-9"})
+	otherFactory.MakeApplication(c, &factory.ApplicationParams{
+		Charm: otherFactory.MakeCharm(c, nil),
+	})
+
+	controllerModelTag := s.State.ModelTag().String()
+	hostedModelTag := otherSt.ModelTag().String()
+
+	req := params.Entities{
+		Entities: []params.Entity{{Tag: controllerModelTag}, {Tag: hostedModelTag}},
+	}
+	results, err := s.controller.ModelStatus(req)
+	c.Assert(err, jc.ErrorIsNil)
+
+	arch := "amd64"
+	mem := uint64(64 * 1024 * 1024 * 1024)
+	stdHw := &params.MachineHardware{
+		Arch: &arch,
+		Mem:  &mem,
+	}
+	c.Assert(results.Results, jc.DeepEquals, []params.ModelStatus{{
+		ModelTag:           controllerModelTag,
+		HostedMachineCount: 1,
+		ApplicationCount:   1,
+		OwnerTag:           s.Owner.String(),
+		Life:               params.Alive,
+		Machines: []params.ModelMachineInfo{
+			{Id: "0", Hardware: &params.MachineHardware{Cores: &eight}, InstanceId: "id-4", Status: "pending", WantsVote: true},
+			{Id: "1", Hardware: stdHw, InstanceId: "id-5", Status: "pending"},
+		},
+	}, {
+		ModelTag:           hostedModelTag,
+		HostedMachineCount: 2,
+		ApplicationCount:   1,
+		OwnerTag:           otherModelOwner.UserTag.String(),
+		Life:               params.Alive,
+		Machines: []params.ModelMachineInfo{
+			{Id: "0", Hardware: stdHw, InstanceId: "id-8", Status: "pending"},
+			{Id: "1", Hardware: stdHw, InstanceId: "id-9", Status: "pending"},
+		},
+	}})
+}

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -342,6 +342,11 @@ func (st *mockState) ModelsForUser(user names.UserTag) ([]*state.UserModel, erro
 	return nil, st.NextErr()
 }
 
+func (st *mockState) AllApplications() ([]common.Application, error) {
+	st.MethodCall(st, "AllApplications")
+	return nil, st.NextErr()
+}
+
 func (st *mockState) IsControllerAdmin(user names.UserTag) (bool, error) {
 	st.MethodCall(st, "IsControllerAdmin", user)
 	if st.controllerModel == nil {

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -52,6 +52,7 @@ type ModelManager interface {
 // ModelManagerAPI implements the model manager interface and is
 // the concrete implementation of the api end point.
 type ModelManagerAPI struct {
+	*common.ModelStatusAPI
 	state       common.ModelManagerBackend
 	check       *common.BlockChecker
 	authorizer  facade.Authorizer
@@ -88,12 +89,13 @@ func NewModelManagerAPI(
 	}
 	urlGetter := common.NewToolsURLGetter(st.ModelUUID(), st)
 	return &ModelManagerAPI{
-		state:       st,
-		check:       common.NewBlockChecker(st),
-		authorizer:  authorizer,
-		toolsFinder: common.NewToolsFinder(configGetter, st, urlGetter),
-		apiUser:     apiUser,
-		isAdmin:     isAdmin,
+		ModelStatusAPI: common.NewModelStatusAPI(st, authorizer, apiUser),
+		state:          st,
+		check:          common.NewBlockChecker(st),
+		authorizer:     authorizer,
+		toolsFinder:    common.NewToolsFinder(configGetter, st, urlGetter),
+		apiUser:        apiUser,
+		isAdmin:        isAdmin,
 	}, nil
 }
 

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -4,6 +4,8 @@
 package model
 
 import (
+	"time"
+
 	"github.com/juju/cmd"
 
 	"github.com/juju/juju/api"
@@ -62,10 +64,15 @@ func NewDumpDBCommandForTest(api DumpDBAPI, store jujuclient.ClientStore) cmd.Co
 }
 
 // NewDestroyCommandForTest returns a DestroyCommand with the api provided as specified.
-func NewDestroyCommandForTest(api DestroyModelAPI, refreshFunc func(jujuclient.ClientStore, string) error, store jujuclient.ClientStore) cmd.Command {
+func NewDestroyCommandForTest(
+	api DestroyModelAPI,
+	refreshFunc func(jujuclient.ClientStore, string) error, store jujuclient.ClientStore,
+	sleepFunc func(time.Duration),
+) cmd.Command {
 	cmd := &destroyCommand{
 		api:           api,
 		RefreshModels: refreshFunc,
+		sleepFunc:     sleepFunc,
 	}
 	cmd.SetClientStore(store)
 	return modelcmd.Wrap(


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju/+bug/1611111

juju destroy-model will block until the model is completely cleaned up.
As soon as the command returns, add-model can be called again with the same model name.

QA:
$ juju add-model amodel
Added 'amodel' model on lxd/localhost with credential 'default' for user 'admin'
$ juju destroy-model amodel -y
Destroying model
Waititng on model to be removed, 1 machine(s), 1 application(s)...
Waititng on model to be removed, 1 machine(s), 1 application(s)...
Waititng on model to be removed, 1 machine(s), 1 application(s)...
Waititng on model to be removed, 1 machine(s), 1 application(s)...
Waititng on model to be removed, 1 machine(s)...
Waititng on model to be removed, 1 machine(s)...
Waititng on model to be removed, 1 machine(s)...
Waititng on model to be removed, 1 machine(s)...
Waititng on model to be removed, 1 machine(s)...
Waititng on model to be removed...
Waititng on model to be removed...
Waititng on model to be removed...
$ juju add-model amodel
Added 'amodel' model on lxd/localhost with credential 'default' for user 'admin'
$