### PR TITLE
api: add SNIHostName to Info

### DIFF
--- a/api/certpool.go
+++ b/api/certpool.go
@@ -27,7 +27,7 @@ func CreateCertPool(caCert string) (*x509.CertPool, error) {
 	if caCert != "" {
 		xcert, err := cert.ParseCert(caCert)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Annotatef(err, "cannot parse certificate %q", caCert)
 		}
 		pool.AddCert(xcert)
 	}

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -12,14 +12,13 @@ import (
 )
 
 var (
-	CertDir               = &certDir
-	NewWebsocketDialer    = newWebsocketDialer
-	NewWebsocketDialerPtr = &newWebsocketDialer
-	WebsocketDialConfig   = &websocketDialConfig
-	SlideAddressToFront   = slideAddressToFront
-	BestVersion           = bestVersion
-	FacadeVersions        = &facadeVersions
-	ConnectWebsocket      = connectWebsocket
+	CertDir             = &certDir
+	NewWebsocketDialer  = newWebsocketDialer
+	WebsocketDialConfig = &websocketDialConfig
+	SlideAddressToFront = slideAddressToFront
+	BestVersion         = bestVersion
+	FacadeVersions      = &facadeVersions
+	DialAPI             = dialAPI
 )
 
 // RPCConnection defines the methods that are called on the rpc.Conn instance.

--- a/api/interface.go
+++ b/api/interface.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/version"
+	"golang.org/x/net/websocket"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/macaroon.v1"
@@ -35,6 +36,12 @@ type Info struct {
 
 	// Addrs holds the addresses of the controllers.
 	Addrs []string
+
+	// SNIHostName optionally holds the host name to use for
+	// server name indication (SNI) when connecting
+	// to the addresses in Addrs above. If CACert is non-empty,
+	// this field is ignored.
+	SNIHostName string
 
 	// CACert holds the CA certificate that will be used
 	// to validate the controller's certificate, in PEM format.
@@ -134,6 +141,15 @@ type DialOpts struct {
 	// be used in tests, or when verification cannot be
 	// performed and the communication need not be secure.
 	InsecureSkipVerify bool
+
+	// DialWebsocket is used to make connections to API servers.
+	// It will be called with a websocket URL to connect to,
+	// and the TLS configuration to use to secure the connection.
+	//
+	// If DialWebsocket is nil, webaocket.DialConfig will be used.
+	//
+	// This field is provided for testing purposes only.
+	DialWebsocket func(cfg *websocket.Config) (*websocket.Conn, error)
 }
 
 // DefaultDialOpts returns a DialOpts representing the default

--- a/api/monitor_internal_test.go
+++ b/api/monitor_internal_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
-	jjtesting "github.com/juju/juju/testing"
+	jtesting "github.com/juju/juju/testing"
 )
 
 var _ = gc.Suite(&MonitorSuite{})
@@ -108,7 +108,7 @@ func (s *MonitorSuite) waitThenAdvance(c *gc.C, d time.Duration) {
 func assertEvent(c *gc.C, ch <-chan struct{}) {
 	select {
 	case <-ch:
-	case <-time.After(jjtesting.LongWait):
+	case <-time.After(jtesting.LongWait):
 		c.Fatal("timed out waiting for channel event")
 	}
 }

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -482,11 +482,6 @@ func (c *registerCommand) secretKeyLogin(addrs []string, request params.SecretKe
 	conn, err := c.apiOpen(&api.Info{
 		Addrs:     addrs,
 		SkipLogin: true,
-		// NOTE(axw) CACert is required, but ignored if
-		// InsecureSkipVerify is set. We should try to
-		// bring together CACert and InsecureSkipVerify
-		// so they can be validated together.
-		CACert: "ignored",
 	}, opts)
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
This means that we can have an arbitrary API addresses
in api.Info, including resolved IP addresses, but still connect
using the officially signed certificate to check. If there's
a private Juju CA cert available, we use that by preference
to make it possible to connect even if the server cannot
obtain an officially signed certificate.