### PR TITLE
Remove and close pooled states when a model is destroyed

### DIFF
--- a/apiserver/authenticator_test.go
+++ b/apiserver/authenticator_test.go
@@ -32,7 +32,7 @@ var _ = gc.Suite(&agentAuthenticatorSuite{})
 func (s *agentAuthenticatorSuite) TestAuthenticatorForTag(c *gc.C) {
 	fact := factory.NewFactory(s.State)
 	user := fact.MakeUser(c, &factory.UserParams{Password: "password"})
-	srv := newServer(c, s.State)
+	srv := newServer(c, s.State, nil)
 	defer srv.Stop()
 	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, user.Tag())
 	c.Assert(err, jc.ErrorIsNil)
@@ -48,7 +48,7 @@ func (s *agentAuthenticatorSuite) TestAuthenticatorForTag(c *gc.C) {
 }
 
 func (s *agentAuthenticatorSuite) TestMachineGetsAgentAuthenticator(c *gc.C) {
-	srv := newServer(c, s.State)
+	srv := newServer(c, s.State, nil)
 	defer srv.Stop()
 	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, names.NewMachineTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -57,7 +57,7 @@ func (s *agentAuthenticatorSuite) TestMachineGetsAgentAuthenticator(c *gc.C) {
 }
 
 func (s *agentAuthenticatorSuite) TestUnitGetsAgentAuthenticator(c *gc.C) {
-	srv := newServer(c, s.State)
+	srv := newServer(c, s.State, nil)
 	defer srv.Stop()
 	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, names.NewUnitTag("wordpress/0"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -66,7 +66,7 @@ func (s *agentAuthenticatorSuite) TestUnitGetsAgentAuthenticator(c *gc.C) {
 }
 
 func (s *agentAuthenticatorSuite) TestNotSupportedTag(c *gc.C) {
-	srv := newServer(c, s.State)
+	srv := newServer(c, s.State, nil)
 	defer srv.Stop()
 	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, names.NewApplicationTag("not-support"))
 	c.Assert(err, gc.ErrorMatches, "unexpected login entity tag: invalid request")

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -53,7 +53,7 @@ var _ = gc.Suite(&serverSuite{})
 func (s *serverSuite) TestStop(c *gc.C) {
 	// Start our own instance of the server so we have
 	// a handle on it to stop it.
-	srv := newServer(c, s.State)
+	srv := newServer(c, s.State, nil)
 	defer srv.Stop()
 
 	machine, password := s.Factory.MakeMachineReturningPassword(
@@ -98,7 +98,7 @@ func (s *serverSuite) TestAPIServerCanListenOnBothIPv4AndIPv6(c *gc.C) {
 
 	// Start our own instance of the server listening on
 	// both IPv4 and IPv6 localhost addresses and an ephemeral port.
-	srv := newServer(c, s.State)
+	srv := newServer(c, s.State, nil)
 	defer srv.Stop()
 
 	port := srv.Addr().Port
@@ -208,7 +208,7 @@ func (s *serverSuite) TestNewServerDoesNotAccessState(c *gc.C) {
 	// Creating the server should succeed because it doesn't
 	// access the state (note that newServer does not log in,
 	// which *would* access the state).
-	srv := newServer(c, st)
+	srv := newServer(c, st, nil)
 	srv.Stop()
 }
 
@@ -279,7 +279,7 @@ func dialWebsocket(c *gc.C, addr, path string, tlsVersion uint16) (*websocket.Co
 
 func (s *serverSuite) TestMinTLSVersion(c *gc.C) {
 	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
-	srv := newServer(c, s.State)
+	srv := newServer(c, s.State, nil)
 	defer srv.Stop()
 
 	// We have to use 'localhost' because that is what the TLS cert says.
@@ -295,7 +295,7 @@ func (s *serverSuite) TestNonCompatiblePathsAre404(c *gc.C) {
 	// We expose the API at '/api', '/' (controller-only), and at '/ModelUUID/api'
 	// for the correct location, but other paths should fail.
 	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
-	srv := newServer(c, s.State)
+	srv := newServer(c, s.State, nil)
 	defer srv.Stop()
 
 	// We have to use 'localhost' because that is what the TLS cert says.
@@ -326,7 +326,7 @@ func (s *serverSuite) TestNonCompatiblePathsAre404(c *gc.C) {
 }
 
 func (s *serverSuite) TestNoBakeryWhenNoIdentityURL(c *gc.C) {
-	srv := newServer(c, s.State)
+	srv := newServer(c, s.State, nil)
 	defer srv.Stop()
 	// By default, when there is no identity location, no
 	// bakery service or macaroon is created.
@@ -357,7 +357,7 @@ func (s *macaroonServerSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *macaroonServerSuite) TestServerBakery(c *gc.C) {
-	srv := newServer(c, s.State)
+	srv := newServer(c, s.State, nil)
 	defer srv.Stop()
 	m, err := apiserver.ServerMacaroon(srv)
 	c.Assert(err, gc.IsNil)
@@ -408,7 +408,7 @@ func (s *macaroonServerWrongPublicKeySuite) TearDownTest(c *gc.C) {
 }
 
 func (s *macaroonServerWrongPublicKeySuite) TestDischargeFailsWithWrongPublicKey(c *gc.C) {
-	srv := newServer(c, s.State)
+	srv := newServer(c, s.State, nil)
 	defer srv.Stop()
 	m, err := apiserver.ServerMacaroon(srv)
 	c.Assert(err, gc.IsNil)
@@ -512,6 +512,64 @@ func (s *serverSuite) TestAPIHandlerConnectedModel(c *gc.C) {
 	c.Check(handler.ConnectedModel(), gc.Equals, otherState.ModelUUID())
 }
 
+func (s *serverSuite) TestClosesStateFromPool(c *gc.C) {
+	pool := state.NewStatePool(s.State)
+	server := newServer(c, s.State, pool)
+	defer server.Stop()
+
+	otherState := s.Factory.MakeModel(c, nil)
+	defer otherState.Close()
+
+	s.State.StartSync()
+	// This ensures that the model exists for more than one of the
+	// time slices that the watcher uses for coalescing
+	// events. Without it the model appears and disappears quickly
+	// enough that it never generates a change from WatchModels.
+	// Many Bothans died to bring us this information.
+	time.Sleep(coretesting.ShortWait)
+
+	model, err := otherState.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure the model's in the pool but not referenced.
+	st, err := pool.Get(otherState.ModelUUID())
+	c.Assert(err, jc.ErrorIsNil)
+	err = pool.Put(otherState.ModelUUID())
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Make a request for the model API to check it puts
+	// state back into the pool once the connection is closed.
+	addr := fmt.Sprintf("localhost:%d", server.Addr().Port)
+	conn, err := dialWebsocket(c, addr, fmt.Sprintf("/model/%s/api", st.ModelUUID()), 0)
+	c.Assert(err, jc.ErrorIsNil)
+	conn.Close()
+
+	// When the model goes away the API server should ensure st gets closed.
+	err = model.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.State.StartSync()
+	assertStateBecomesClosed(c, st)
+}
+
+func assertStateBecomesClosed(c *gc.C, st *state.State) {
+	// This is gross but I can't see any other way to check for
+	// closedness outside the state package.
+	checkModel := func() {
+		attempt := utils.AttemptStrategy{
+			Total: coretesting.LongWait,
+			Delay: coretesting.ShortWait,
+		}
+		for a := attempt.Start(); a.Next(); {
+			// This will panic once the state is closed.
+			_, _ = st.Model()
+		}
+		// If we got here then st is still open.
+		st.Close()
+	}
+	c.Assert(checkModel, gc.PanicMatches, "Session already closed")
+}
+
 func (s *serverSuite) checkAPIHandlerTeardown(c *gc.C, srvSt, st *state.State) {
 	handler, resources := apiserver.TestingAPIHandler(c, srvSt, st)
 	resource := new(fakeResource)
@@ -523,7 +581,7 @@ func (s *serverSuite) checkAPIHandlerTeardown(c *gc.C, srvSt, st *state.State) {
 }
 
 // newServer returns a new running API server.
-func newServer(c *gc.C, st *state.State) *apiserver.Server {
+func newServer(c *gc.C, st *state.State, pool *state.StatePool) *apiserver.Server {
 	listener, err := net.Listen("tcp", ":0")
 	c.Assert(err, jc.ErrorIsNil)
 	srv, err := apiserver.NewServer(st, listener, apiserver.ServerConfig{
@@ -534,6 +592,7 @@ func newServer(c *gc.C, st *state.State) *apiserver.Server {
 		LogDir:      c.MkDir(),
 		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
 		AutocertURL: "https://0.1.2.3/no-autocert-here",
+		StatePool:   pool,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return srv

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -534,10 +534,10 @@ func (s *serverSuite) TestClosesStateFromPool(c *gc.C) {
 	// Ensure the model's in the pool but not referenced.
 	st, err := pool.Get(otherState.ModelUUID())
 	c.Assert(err, jc.ErrorIsNil)
-	err = pool.Put(otherState.ModelUUID())
+	err = pool.Release(otherState.ModelUUID())
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Make a request for the model API to check it puts
+	// Make a request for the model API to check it releases
 	// state back into the pool once the connection is closed.
 	addr := fmt.Sprintf("localhost:%d", server.Addr().Port)
 	conn, err := dialWebsocket(c, addr, fmt.Sprintf("/model/%s/api", st.ModelUUID()), 0)

--- a/state/pool.go
+++ b/state/pool.go
@@ -28,7 +28,7 @@ type PoolItem struct {
 }
 
 // StatePool is a cache of State instances for multiple
-// models. Clients should call Put when they have finished with any
+// models. Clients should call Release when they have finished with any
 // state.
 type StatePool struct {
 	systemState *State
@@ -67,10 +67,10 @@ func (p *StatePool) Get(modelUUID string) (*State, error) {
 	return st, nil
 }
 
-// Put indicates that the client has finished using the State. If the
+// Release indicates that the client has finished using the State. If the
 // state has been marked for removal, it will be closed and removed
-// when the final Put is done.
-func (p *StatePool) Put(modelUUID string) error {
+// when the final Release is done.
+func (p *StatePool) Release(modelUUID string) error {
 	if modelUUID == p.systemState.ModelUUID() {
 		// We don't maintain a refcount for the controller.
 		return nil
@@ -92,7 +92,7 @@ func (p *StatePool) Put(modelUUID string) error {
 
 // Remove takes the state out of the pool and closes it, or marks it
 // for removal if it's currently being used (indicated by Gets without
-// corresponding Puts).
+// corresponding Releases).
 func (p *StatePool) Remove(modelUUID string) error {
 	if modelUUID == p.systemState.ModelUUID() {
 		// We don't manage the controller state.
@@ -105,7 +105,7 @@ func (p *StatePool) Remove(modelUUID string) error {
 	item, ok := p.pool[modelUUID]
 	if !ok {
 		// Don't require the client to keep track of what we've seen -
-		// ignore unknown model ids.
+		// ignore unknown model uuids.
 		return nil
 	}
 	item.remove = true

--- a/state/pool.go
+++ b/state/pool.go
@@ -142,6 +142,14 @@ func (p *StatePool) Close() error {
 
 	var lastErr error
 	for _, item := range p.pool {
+		if item.references != 0 || item.remove {
+			logger.Warningf(
+				"state for %v leaked from pool - references: %v, removed: %v",
+				item.state.ModelUUID(),
+				item.references,
+				item.remove,
+			)
+		}
 		err := item.state.Close()
 		if err != nil {
 			lastErr = err

--- a/state/pool.go
+++ b/state/pool.go
@@ -15,20 +15,31 @@ import (
 func NewStatePool(systemState *State) *StatePool {
 	return &StatePool{
 		systemState: systemState,
-		pool:        make(map[string]*State),
+		pool:        make(map[string]*PoolItem),
 	}
 }
 
-// StatePool is a simple cache of State instances for multiple models.
+// PoolItem holds a State and tracks how many requests are using it
+// and whether it's been marked for removal.
+type PoolItem struct {
+	state      *State
+	references uint
+	remove     bool
+}
+
+// StatePool is a cache of State instances for multiple
+// models. Clients should call Put when they have finished with any
+// state.
 type StatePool struct {
 	systemState *State
 	// mu protects pool
 	mu   sync.Mutex
-	pool map[string]*State
+	pool map[string]*PoolItem
 }
 
-// Get returns a State for a given model from the pool, creating
-// one if required.
+// Get returns a State for a given model from the pool, creating one
+// if required. If the State has been marked for removal because there
+// are outstanding uses, an error will be returned.
 func (p *StatePool) Get(modelUUID string) (*State, error) {
 	if modelUUID == p.systemState.ModelUUID() {
 		return p.systemState, nil
@@ -37,17 +48,76 @@ func (p *StatePool) Get(modelUUID string) (*State, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	st, ok := p.pool[modelUUID]
+	item, ok := p.pool[modelUUID]
+	if ok && item.remove {
+		// We don't want to allow increasing the refcount of a model
+		// that's been removed.
+		return nil, errors.Errorf("model %v has been removed", modelUUID)
+	}
 	if ok {
-		return st, nil
+		item.references++
+		return item.state, nil
 	}
 
 	st, err := p.systemState.ForModel(names.NewModelTag(modelUUID))
 	if err != nil {
 		return nil, errors.Annotatef(err, "failed to create state for model %v", modelUUID)
 	}
-	p.pool[modelUUID] = st
+	p.pool[modelUUID] = &PoolItem{state: st, references: 1}
 	return st, nil
+}
+
+// Put indicates that the client has finished using the State. If the
+// state has been marked for removal, it will be closed and removed
+// when the final Put is done.
+func (p *StatePool) Put(modelUUID string) error {
+	if modelUUID == p.systemState.ModelUUID() {
+		// We don't maintain a refcount for the controller.
+		return nil
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	item, ok := p.pool[modelUUID]
+	if !ok {
+		return errors.Errorf("unable to return unknown model %v to the pool", modelUUID)
+	}
+	if item.references == 0 {
+		return errors.Errorf("state pool refcount for model %v is already 0", modelUUID)
+	}
+	item.references--
+	return p.maybeRemoveItem(modelUUID, item)
+}
+
+// Remove takes the state out of the pool and closes it, or marks it
+// for removal if it's currently being used (indicated by Gets without
+// corresponding Puts).
+func (p *StatePool) Remove(modelUUID string) error {
+	if modelUUID == p.systemState.ModelUUID() {
+		// We don't manage the controller state.
+		return nil
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	item, ok := p.pool[modelUUID]
+	if !ok {
+		// Don't require the client to keep track of what we've seen -
+		// ignore unknown model ids.
+		return nil
+	}
+	item.remove = true
+	return p.maybeRemoveItem(modelUUID, item)
+}
+
+func (p *StatePool) maybeRemoveItem(modelUUID string, item *PoolItem) error {
+	if item.remove && item.references == 0 {
+		delete(p.pool, modelUUID)
+		return item.state.Close()
+	}
+	return nil
 }
 
 // SystemState returns the State passed in to NewStatePool.
@@ -60,8 +130,8 @@ func (p *StatePool) SystemState() *State {
 func (p *StatePool) KillWorkers() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	for _, st := range p.pool {
-		st.KillWorkers()
+	for _, item := range p.pool {
+		item.state.KillWorkers()
 	}
 }
 
@@ -71,12 +141,12 @@ func (p *StatePool) Close() error {
 	defer p.mu.Unlock()
 
 	var lastErr error
-	for _, st := range p.pool {
-		err := st.Close()
+	for _, item := range p.pool {
+		err := item.state.Close()
 		if err != nil {
 			lastErr = err
 		}
 	}
-	p.pool = make(map[string]*State)
+	p.pool = make(map[string]*PoolItem)
 	return errors.Annotate(lastErr, "at least one error closing a state")
 }

--- a/state/pool_test.go
+++ b/state/pool_test.go
@@ -4,6 +4,8 @@
 package state_test
 
 import (
+	"fmt"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -15,6 +17,7 @@ import (
 type statePoolSuite struct {
 	statetesting.StateSuite
 	State1, State2                    *state.State
+	Pool                              *state.StatePool
 	ModelUUID, ModelUUID1, ModelUUID2 string
 }
 
@@ -31,68 +34,59 @@ func (s *statePoolSuite) SetUpTest(c *gc.C) {
 	s.State2 = s.Factory.MakeModel(c, nil)
 	s.AddCleanup(func(*gc.C) { s.State2.Close() })
 	s.ModelUUID2 = s.State2.ModelUUID()
+
+	s.Pool = state.NewStatePool(s.State)
+	s.AddCleanup(func(*gc.C) { s.Pool.Close() })
 }
 
 func (s *statePoolSuite) TestGet(c *gc.C) {
-	p := state.NewStatePool(s.State)
-	defer p.Close()
-
-	st1, err := p.Get(s.ModelUUID1)
+	st1, err := s.Pool.Get(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st1.ModelUUID(), gc.Equals, s.ModelUUID1)
 
-	st2, err := p.Get(s.ModelUUID2)
+	st2, err := s.Pool.Get(s.ModelUUID2)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st2.ModelUUID(), gc.Equals, s.ModelUUID2)
 
 	// Check that the same instances are returned
 	// when a State for the same env is re-requested.
-	st1_, err := p.Get(s.ModelUUID1)
+	st1_, err := s.Pool.Get(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st1_, gc.Equals, st1)
 
-	st2_, err := p.Get(s.ModelUUID2)
+	st2_, err := s.Pool.Get(s.ModelUUID2)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st2_, gc.Equals, st2)
 }
 
 func (s *statePoolSuite) TestGetWithControllerEnv(c *gc.C) {
-	p := state.NewStatePool(s.State)
-	defer p.Close()
-
 	// When a State for the controller env is requested, the same
 	// State that was original passed in should be returned.
-	st0, err := p.Get(s.ModelUUID)
+	st0, err := s.Pool.Get(s.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st0, gc.Equals, s.State)
 }
 
-func (s *statePoolSuite) TestSystemState(c *gc.C) {
-	p := state.NewStatePool(s.State)
-	defer p.Close()
-
-	st0 := p.SystemState()
+func (s *statePoolSuite) TestGetSystemState(c *gc.C) {
+	st0 := s.Pool.SystemState()
 	c.Assert(st0, gc.Equals, s.State)
 }
 
 func (s *statePoolSuite) TestKillWorkers(c *gc.C) {
-	p := state.NewStatePool(s.State)
-	defer p.Close()
-
 	// Get some State instances via the pool and extract their
 	// internal workers.
-	st1, err := p.Get(s.ModelUUID1)
+	st1, err := s.Pool.Get(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
 	w1 := state.GetInternalWorkers(st1)
 	workertest.CheckAlive(c, w1)
 
-	st2, err := p.Get(s.ModelUUID1)
+	st2, err := s.Pool.Get(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
 	w2 := state.GetInternalWorkers(st2)
 	workertest.CheckAlive(c, w2)
 
 	// Now kill their workers.
-	p.KillWorkers()
+	s.Pool.KillWorkers()
 
 	// Ensure the internal workers for each State died.
 	c.Check(workertest.CheckKilled(c, w1), jc.ErrorIsNil)
@@ -100,18 +94,15 @@ func (s *statePoolSuite) TestKillWorkers(c *gc.C) {
 }
 
 func (s *statePoolSuite) TestClose(c *gc.C) {
-	p := state.NewStatePool(s.State)
-	defer p.Close()
-
 	// Get some State instances.
-	st1, err := p.Get(s.ModelUUID1)
+	st1, err := s.Pool.Get(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
 
-	st2, err := p.Get(s.ModelUUID1)
+	st2, err := s.Pool.Get(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Now close them.
-	err = p.Close()
+	err = s.Pool.Close()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Confirm that controller State isn't closed.
@@ -120,11 +111,102 @@ func (s *statePoolSuite) TestClose(c *gc.C) {
 
 	// Ensure that new ones are returned if further States are
 	// requested.
-	st1_, err := p.Get(s.ModelUUID1)
+	st1_, err := s.Pool.Get(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st1_, gc.Not(gc.Equals), st1)
 
-	st2_, err := p.Get(s.ModelUUID2)
+	st2_, err := s.Pool.Get(s.ModelUUID2)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st2_, gc.Not(gc.Equals), st2)
+}
+
+func (s *statePoolSuite) TestPutSystemState(c *gc.C) {
+	// Doesn't maintain a refcount for the system state.
+	err := s.Pool.Put(s.ModelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *statePoolSuite) TestPutUnknownModel(c *gc.C) {
+	err := s.Pool.Put("deadbeef")
+	c.Assert(err, gc.ErrorMatches, "unable to return unknown model deadbeef to the pool")
+}
+
+func (s *statePoolSuite) TestTooManyPuts(c *gc.C) {
+	_, err := s.Pool.Get(s.ModelUUID1)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.Pool.Put(s.ModelUUID1)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.Pool.Put(s.ModelUUID1)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(
+		"state pool refcount for model %s is already 0", s.ModelUUID1))
+}
+
+func (s *statePoolSuite) TestRemoveSystemStateUUID(c *gc.C) {
+	err := s.Pool.Remove(s.ModelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	assertNotClosed(c, s.State)
+}
+
+func (s *statePoolSuite) TestRemoveNonExistentModel(c *gc.C) {
+	err := s.Pool.Remove("abaddad")
+	// Allow models that haven't been seen by state to be removed.
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func assertNotClosed(c *gc.C, st *state.State) {
+	_, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func assertClosed(c *gc.C, st *state.State) {
+	w := state.GetInternalWorkers(st)
+	c.Check(workertest.CheckKilled(c, w), jc.ErrorIsNil)
+}
+
+func (s *statePoolSuite) TestRemoveWithNoRefsCloses(c *gc.C) {
+	st, err := s.Pool.Get(s.ModelUUID1)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.Pool.Put(s.ModelUUID1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Confirm the state isn't closed.
+	assertNotClosed(c, st)
+
+	err = s.Pool.Remove(s.ModelUUID1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	assertClosed(c, st)
+}
+
+func (s *statePoolSuite) TestRemoveWithRefsClosesOnLastPut(c *gc.C) {
+	st, err := s.Pool.Get(s.ModelUUID1)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.Pool.Get(s.ModelUUID1)
+	c.Assert(err, jc.ErrorIsNil)
+	// Now there are two references to the state.
+	// Sanity check!
+	assertNotClosed(c, st)
+
+	// Doesn't close while there are refs still held.
+	err = s.Pool.Remove(s.ModelUUID1)
+	c.Assert(err, jc.ErrorIsNil)
+	assertNotClosed(c, st)
+
+	err = s.Pool.Put(s.ModelUUID1)
+	c.Assert(err, jc.ErrorIsNil)
+	// Hasn't been closed - still one outstanding reference.
+	assertNotClosed(c, st)
+
+	// Should be closed when it's put back into the pool.
+	err = s.Pool.Put(s.ModelUUID1)
+	c.Assert(err, jc.ErrorIsNil)
+	assertClosed(c, st)
+}
+
+func (s *statePoolSuite) TestGetRemovedNotAllowed(c *gc.C) {
+	_, err := s.Pool.Get(s.ModelUUID1)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.Pool.Remove(s.ModelUUID1)
+	_, err = s.Pool.Get(s.ModelUUID1)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("model %v has been removed", s.ModelUUID1))
 }


### PR DESCRIPTION
Investigating http://pad.lv/1625774 revealed that there were a lot of state instances (with their attendant goroutines) lingering after a model had been destroyed. They turned out to be held by the API server's StatePool.

Add StatePool.Remove and change the API server to watch for model removals and call it. This also required adding reference counting to the items in the pool - the State instances are designed to be shared between multiple requests, but we need to be sure that they aren't in use when they are closed. StatePool.Put was added so the API server could indicate that it's finished with a State.

QA done: 
* bootstrapped to LXD
* dumped goroutines using the following commands to query the introspection worker on the controller machine
```
socat tcp-listen:8080,fork,reuseaddr abstract-connect:jujud-machine-0 &
curl localhost:8080/debug/pprof/goroutine?debug=2 > goroutines.txt
# Using this format because it's easier to compare old and new.
```
* added and destroyed a model
* dumped the goroutines again and checked there weren't any new ones for state workers.