### PR TITLE
Filter out update-status from status history.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -56,9 +56,10 @@ func (c *Client) StatusHistory(kind status.HistoryKind, tag names.Tag, filter st
 	args := params.StatusHistoryRequest{
 		Kind: string(kind),
 		Filter: params.StatusHistoryFilter{
-			Size:  filter.Size,
-			Date:  filter.Date,
-			Delta: filter.Delta,
+			Size:    filter.Size,
+			Date:    filter.FromDate,
+			Delta:   filter.Delta,
+			Exclude: filter.Exclude.Values(),
 		},
 		Tag: tag.String(),
 	}

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -109,9 +109,10 @@ func (c *Client) StatusHistory(request params.StatusHistoryRequests) params.Stat
 	// a oneHistory method for clarity.
 	for _, request := range request.Requests {
 		filter := status.StatusHistoryFilter{
-			Size:  request.Filter.Size,
-			Date:  request.Filter.Date,
-			Delta: request.Filter.Delta,
+			Size:     request.Filter.Size,
+			FromDate: request.Filter.Date,
+			Delta:    request.Filter.Delta,
+			Exclude:  set.NewStrings(request.Filter.Exclude...),
 		}
 		if err := c.checkCanRead(); err != nil {
 			history := params.StatusHistoryResult{

--- a/apiserver/client/statushistory_test.go
+++ b/apiserver/client/statushistory_test.go
@@ -88,7 +88,7 @@ func (s *statusHistoryTestSuite) TestSizeRequired(c *gc.C) {
 			Filter: params.StatusHistoryFilter{Size: 0},
 		}}})
 	c.Assert(r.Results, gc.HasLen, 1)
-	c.Assert(r.Results[0].Error.Message, gc.Equals, "cannot validate status history filter: empty struct not valid")
+	c.Assert(r.Results[0].Error.Message, gc.Equals, "cannot validate status history filter: missing filter parameters not valid")
 }
 
 func (s *statusHistoryTestSuite) TestNoConflictingFilters(c *gc.C) {

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -192,9 +192,10 @@ type History struct {
 
 // StatusHistoryFilter holds arguments that can be use to filter a status history backlog.
 type StatusHistoryFilter struct {
-	Size  int            `json:"size"`
-	Date  *time.Time     `json:"date"`
-	Delta *time.Duration `json:"delta"`
+	Size    int            `json:"size"`
+	Date    *time.Time     `json:"date"`
+	Delta   *time.Duration `json:"delta"`
+	Exclude []string       `json:"exclude"`
 }
 
 // StatusHistoryRequest holds the parameters to filter a status history query.

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -72,7 +72,7 @@ func (s *MigrationBaseSuite) setRandSequenceValue(c *gc.C, name string) int {
 func (s *MigrationBaseSuite) primeStatusHistory(c *gc.C, entity statusSetter, statusVal status.Status, count int) {
 	primeStatusHistory(c, entity, statusVal, count, func(i int) map[string]interface{} {
 		return map[string]interface{}{"index": count - i}
-	}, 0)
+	}, 0, "")
 }
 
 func (s *MigrationBaseSuite) makeApplicationWithLeader(c *gc.C, applicationname string, count int, leader int) {

--- a/state/status_unitagent_test.go
+++ b/state/status_unitagent_test.go
@@ -264,7 +264,7 @@ func (s *StatusUnitAgentSuite) TestStatusHistoryInitial(c *gc.C) {
 }
 
 func (s *StatusUnitAgentSuite) TestStatusHistoryShort(c *gc.C) {
-	primeUnitAgentStatusHistory(c, s.agent, 5, 0)
+	primeUnitAgentStatusHistory(c, s.agent, 5, 0, "")
 
 	history, err := s.agent.StatusHistory(status.StatusHistoryFilter{Size: 10})
 	c.Check(err, jc.ErrorIsNil)
@@ -278,7 +278,7 @@ func (s *StatusUnitAgentSuite) TestStatusHistoryShort(c *gc.C) {
 }
 
 func (s *StatusUnitAgentSuite) TestStatusHistoryLong(c *gc.C) {
-	primeUnitAgentStatusHistory(c, s.agent, 25, 0)
+	primeUnitAgentStatusHistory(c, s.agent, 25, 0, "")
 
 	history, err := s.agent.StatusHistory(status.StatusHistoryFilter{Size: 15})
 	c.Check(err, jc.ErrorIsNil)

--- a/status/status_history.go
+++ b/status/status_history.go
@@ -8,24 +8,31 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/set"
 )
 
 // StatusHistoryFilter holds arguments that can be use to filter a status history backlog.
 type StatusHistoryFilter struct {
-	Size  int
-	Date  *time.Time
+	// Size indicates how many results are expected at most.
+	Size int
+	// FromDate indicates the earliest date from which logs are expected.
+	FromDate *time.Time
+	// Delta indicates the age of the oldest log expected.
 	Delta *time.Duration
+	// Exclude indicates the status messages that should be excluded
+	// from the returned result.
+	Exclude set.Strings
 }
 
 // Validate checks that the minimum requirements of a StatusHistoryFilter are met.
 func (f *StatusHistoryFilter) Validate() error {
 	s := f.Size > 0
-	t := f.Date != nil
+	t := f.FromDate != nil
 	d := f.Delta != nil
 
 	switch {
 	case !(s || t || d):
-		return errors.NotValidf("empty struct")
+		return errors.NotValidf("missing filter parameters")
 	case s && t:
 		return errors.NotValidf("Size and Date together")
 	case s && d:


### PR DESCRIPTION
"running update-status hook" messages where spamming status history
to avoid deletion of potentially useful data from the history log
a new filtering option was added to the status history args struct
status messages can now be excluded from the results on demand.
### QA steps
- Bootstrap juju
- Deploy cs:ubuntu
- Wait 10 minutes
- juju show-status-log --type unit ubuntu/0  # should yield no "running update-status hook" messages
