### PR TITLE
api: Export Connection.Ping again

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -245,7 +245,7 @@ func open(
 
 	go (&monitor{
 		clock:       clock,
-		ping:        st.ping,
+		ping:        st.Ping,
 		pingPeriod:  PingPeriod,
 		pingTimeout: pingTimeout,
 		closed:      st.closed,
@@ -460,7 +460,8 @@ func (st *state) apiEndpoint(path, query string) (*url.URL, error) {
 	}, nil
 }
 
-func (s *state) ping() error {
+// Ping implements api.Connection.
+func (s *state) Ping() error {
 	return s.APICall("Pinger", s.pingerFacadeVersion, "", "Ping", nil, nil)
 }
 

--- a/api/interface.go
+++ b/api/interface.go
@@ -178,6 +178,12 @@ type Connection interface {
 	// All the rest are strange and questionable and deserve extra attention
 	// and/or discussion.
 
+	// Something-or-other expects Ping to exist, and *maybe* the heartbeat
+	// *should* be handled outside the State type, but it's also handled
+	// inside it as well. We should figure this out sometime -- we should
+	// either expose Ping() or Broken() but not both.
+	Ping() error
+
 	// I think this is actually dead code. It's tested, at least, so I'm
 	// keeping it for now, but it's not apparently used anywhere else.
 	AllFacadeVersions() map[string][]int


### PR DESCRIPTION
... and implement a unit test (it was never tested before).

https://github.com/juju/juju/pull/6400 removed Ping but this was being used by some external projects.

### QA

Full unit test suite run and examined behaviour of a HA failover to ensure no regressions.