### PR TITLE
api: Add Connection.IsBroken

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -605,9 +605,23 @@ func (s *state) Close() error {
 	return err
 }
 
-// Broken returns a channel that's closed when the connection is broken.
+// Broken implements api.Connection.
 func (s *state) Broken() <-chan struct{} {
 	return s.broken
+}
+
+// IsBroken implements api.Connection.
+func (s *state) IsBroken() bool {
+	select {
+	case <-s.broken:
+		return true
+	default:
+	}
+	if err := s.Ping(); err != nil {
+		logger.Debugf("connection ping failed: %v", err)
+		return true
+	}
+	return false
 }
 
 // Addr returns the address used to connect to the API server.

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -295,6 +295,33 @@ func (s *apiclientSuite) TestPing(c *gc.C) {
 	}})
 }
 
+func (s *apiclientSuite) TestIsBrokenOk(c *gc.C) {
+	conn := api.NewTestingState(api.TestingStateParams{
+		RPCConnection: newRPCConnection(),
+		Clock:         new(fakeClock),
+	})
+	c.Assert(conn.IsBroken(), jc.IsFalse)
+}
+
+func (s *apiclientSuite) TestIsBrokenChannelClosed(c *gc.C) {
+	broken := make(chan struct{})
+	close(broken)
+	conn := api.NewTestingState(api.TestingStateParams{
+		RPCConnection: newRPCConnection(),
+		Clock:         new(fakeClock),
+		Broken:        broken,
+	})
+	c.Assert(conn.IsBroken(), jc.IsTrue)
+}
+
+func (s *apiclientSuite) TestIsBrokenPingFailed(c *gc.C) {
+	conn := api.NewTestingState(api.TestingStateParams{
+		RPCConnection: newRPCConnection(errors.New("no biscuit")),
+		Clock:         new(fakeClock),
+	})
+	c.Assert(conn.IsBroken(), jc.IsTrue)
+}
+
 type fakeClock struct {
 	clock.Clock
 

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -48,6 +48,7 @@ type TestingStateParams struct {
 	ServerRoot     string
 	RPCConnection  RPCConnection
 	Clock          clock.Clock
+	Broken         chan struct{}
 }
 
 // NewTestingState creates an api.State object that can be used for testing. It
@@ -71,6 +72,7 @@ func NewTestingState(params TestingStateParams) Connection {
 		facadeVersions:    params.FacadeVersions,
 		serverScheme:      params.ServerScheme,
 		serverRootAddress: params.ServerRoot,
+		broken:            params.Broken,
 	}
 	return st
 }

--- a/api/interface.go
+++ b/api/interface.go
@@ -158,9 +158,18 @@ type Connection interface {
 
 	// This first block of methods is pretty close to a sane Connection interface.
 	Close() error
-	Broken() <-chan struct{}
 	Addr() string
 	APIHostPorts() [][]network.HostPort
+
+	// Broken returns a channel which will be closed if the connection
+	// is detected to be broken, either because the underlying
+	// connection has closed or because API pings have failed.
+	Broken() <-chan struct{}
+
+	// IsBroken returns whether the connection is broken. It checks
+	// the Broken channel and if that is open, attempts a connection
+	// ping.
+	IsBroken() bool
 
 	// These are a bit off -- ServerVersion is apparently not known until after
 	// Login()? Maybe evidence of need for a separate AuthenticatedConnection..?
@@ -178,10 +187,9 @@ type Connection interface {
 	// All the rest are strange and questionable and deserve extra attention
 	// and/or discussion.
 
-	// Something-or-other expects Ping to exist, and *maybe* the heartbeat
-	// *should* be handled outside the State type, but it's also handled
-	// inside it as well. We should figure this out sometime -- we should
-	// either expose Ping() or Broken() but not both.
+	// Ping makes an API request which checks if the connection is
+	// still functioning.
+	// NOTE: This method is deprecated. Please use IsBroken or Broken instead.
 	Ping() error
 
 	// I think this is actually dead code. It's tested, at least, so I'm

--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -115,9 +115,9 @@ func AgentDone(logger loggo.Logger, err error) error {
 	return err
 }
 
-// Breakable provides a type that exposes a "broken" channel.
+// Breakable provides a type that exposes an IsBroken check.
 type Breakable interface {
-	Broken() <-chan struct{}
+	IsBroken() bool
 }
 
 // ConnectionIsFatal returns a function suitable for passing as the
@@ -140,12 +140,7 @@ func ConnectionIsFatal(logger loggo.Logger, conns ...Breakable) func(err error) 
 
 // ConnectionIsDead returns true if the given Breakable is broken.
 var ConnectionIsDead = func(logger loggo.Logger, conn Breakable) bool {
-	select {
-	case <-conn.Broken():
-		return true
-	default:
-		return false
-	}
+	return conn.IsBroken()
 }
 
 // Pinger provides a type that knows how to ping.

--- a/cmd/jujud/util/util_test.go
+++ b/cmd/jujud/util/util_test.go
@@ -78,9 +78,8 @@ var isFatalTests = []struct {
 }
 
 func (s *toolSuite) TestConnectionIsFatal(c *gc.C) {
-	okConn := &testConn{make(chan struct{})}
-	errConn := &testConn{make(chan struct{})}
-	close(errConn.broken)
+	okConn := &testConn{broken: false}
+	errConn := &testConn{broken: true}
 
 	for i, conn := range []*testConn{errConn, okConn} {
 		for j, test := range isFatalTests {
@@ -96,9 +95,8 @@ func (s *toolSuite) TestConnectionIsFatal(c *gc.C) {
 }
 
 func (s *toolSuite) TestConnectionIsFatalWithMultipleConns(c *gc.C) {
-	okConn := &testConn{make(chan struct{})}
-	errConn := &testConn{make(chan struct{})}
-	close(errConn.broken)
+	okConn := &testConn{broken: false}
+	errConn := &testConn{broken: true}
 
 	someErr := stderrors.New("foo")
 
@@ -165,10 +163,10 @@ func (*toolSuite) TestIsFatal(c *gc.C) {
 }
 
 type testConn struct {
-	broken chan struct{}
+	broken bool
 }
 
-func (c *testConn) Broken() <-chan struct{} {
+func (c *testConn) IsBroken() bool {
 	return c.broken
 }
 


### PR DESCRIPTION
This supports a blocking check of an api connection. It first checks the Broken channel, and if that's open tries an api ping (in most cases the ping won't be necessary).

Also updated the agent helpers to use IsBroken instead of the Broken channel when identifying failed connections. This eliminates a race and is more straightforward.

