### PR TITLE
cmd/jujud/agent/machine: Preserve key too! 

### DIFF
--- a/cmd/jujud/agent/machine/servinginfo_setter.go
+++ b/cmd/jujud/agent/machine/servinginfo_setter.go
@@ -65,12 +65,15 @@ func ServingInfoSetterManifold(config ServingInfoSetterConfig) dependency.Manifo
 						return nil, errors.Errorf("cannot get state serving info: %v", err)
 					}
 					if hasInfo {
-						// Use the existing Cert as it may have been updated already
-						// by the cert updater worker to have this machine's IP address
-						// as part of the cert. This changed cert is never put back into
-						// the database, so it isn't reflected in the copy we have got
-						// from apiState.
+						// Use the existing cert and key as they
+						// appear to have been already updated by the
+						// cert updater worker to have this machine's
+						// IP address as part of the cert. This
+						// changed cert is never put back into the
+						// database, so it isn't reflected in the copy
+						// we have got from apiState.
 						info.Cert = existing.Cert
+						info.PrivateKey = existing.PrivateKey
 					}
 					err = agent.ChangeConfig(func(config coreagent.ConfigSetter) error {
 						config.SetStateServingInfo(info)

--- a/cmd/jujud/agent/machine/servinginfo_setter_test.go
+++ b/cmd/jujud/agent/machine/servinginfo_setter_test.go
@@ -97,7 +97,7 @@ func (s *ServingInfoSetterSuite) TestEntityLookupFailure(c *gc.C) {
 	})
 	w, err := s.manifold.Start(context)
 	c.Assert(w, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "boom")
+	c.Assert(err, gc.ErrorMatches, "checking controller status: boom")
 }
 
 func (s *ServingInfoSetterSuite) startManifold(c *gc.C, a coreagent.Agent, mockAPIPort int) {

--- a/cmd/jujud/agent/machine/servinginfo_setter_test.go
+++ b/cmd/jujud/agent/machine/servinginfo_setter_test.go
@@ -114,8 +114,9 @@ func (s *ServingInfoSetterSuite) startManifold(c *gc.C, a coreagent.Agent, mockA
 			case "StateServingInfo":
 				result := response.(*params.StateServingInfo)
 				*result = params.StateServingInfo{
-					Cert:    testing.CACert,
-					APIPort: mockAPIPort,
+					Cert:       "cert",
+					PrivateKey: "key",
+					APIPort:    mockAPIPort,
 				}
 			default:
 				c.Fatalf("not sure how to handle: %q", request)
@@ -142,7 +143,8 @@ func (s *ServingInfoSetterSuite) TestJobManageEnviron(c *gc.C) {
 	// Verify that the state serving info was actually set.
 	c.Assert(a.conf.ssiSet, jc.IsTrue)
 	c.Assert(a.conf.ssi.APIPort, gc.Equals, mockAPIPort)
-	c.Assert(a.conf.ssi.Cert, gc.Equals, testing.CACert)
+	c.Assert(a.conf.ssi.Cert, gc.Equals, "cert")
+	c.Assert(a.conf.ssi.PrivateKey, gc.Equals, "key")
 }
 
 func (s *ServingInfoSetterSuite) TestJobManageEnvironNotOverwriteCert(c *gc.C) {
@@ -150,9 +152,11 @@ func (s *ServingInfoSetterSuite) TestJobManageEnvironNotOverwriteCert(c *gc.C) {
 	const mockAPIPort = 1234
 
 	a := &mockAgent{}
-	existingCert := "some cert updated by certupdater"
+	existingCert := "some cert set by certupdater"
+	existingKey := "some key set by certupdater"
 	a.conf.SetStateServingInfo(params.StateServingInfo{
-		Cert: existingCert,
+		Cert:       existingCert,
+		PrivateKey: existingKey,
 	})
 
 	s.startManifold(c, a, mockAPIPort)
@@ -161,6 +165,7 @@ func (s *ServingInfoSetterSuite) TestJobManageEnvironNotOverwriteCert(c *gc.C) {
 	c.Assert(a.conf.ssiSet, jc.IsTrue)
 	c.Assert(a.conf.ssi.APIPort, gc.Equals, mockAPIPort)
 	c.Assert(a.conf.ssi.Cert, gc.Equals, existingCert)
+	c.Assert(a.conf.ssi.PrivateKey, gc.Equals, existingKey)
 }
 
 func (s *ServingInfoSetterSuite) TestJobHostUnits(c *gc.C) {


### PR DESCRIPTION
When the stateservinginfo setter preserves an already set certificate, the key that goes with it needs to be copied with it. Failing to do this results in key mismatches when the apiserver is restarted.

Also make the agent config updates safer by performing the whole update inside a ChangeConfig func.

Fixes https://bugs.launchpad.net/juju/+bug/1631145

### QA

Bootstrapped and restarted the controller machine agent multiple times without being able to trigger the problem. Previously it was fairly easy to trigger the problem.