### PR TITLE
Revised list-cloud output to show region count

### DIFF
--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -150,8 +150,9 @@ clouds:
 	c.Assert(fallbackUsed, jc.IsFalse)
 	c.Assert(clouds, jc.DeepEquals, map[string]cloud.Cloud{
 		"aws-me": cloud.Cloud{
-			Type:      "aws",
-			AuthTypes: []cloud.AuthType{"userpass"},
+			Type:        "aws",
+			Description: "Amazon Web Services",
+			AuthTypes:   []cloud.AuthType{"userpass"},
 		},
 	})
 }
@@ -169,8 +170,9 @@ func (s *cloudSuite) TestGeneratedPublicCloudInfo(c *gc.C) {
 func (s *cloudSuite) TestWritePublicCloudsMetadata(c *gc.C) {
 	clouds := map[string]cloud.Cloud{
 		"aws-me": cloud.Cloud{
-			Type:      "aws",
-			AuthTypes: []cloud.AuthType{"userpass"},
+			Type:        "aws",
+			Description: "Amazon Web Services",
+			AuthTypes:   []cloud.AuthType{"userpass"},
 		},
 	}
 	err := cloud.WritePublicCloudMetadata(clouds)

--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -2,6 +2,7 @@
 clouds:
   aws:
     type: ec2
+    description: Amazon Web Services
     auth-types: [ access-key ]
     regions:
       us-east-1:
@@ -28,18 +29,21 @@ clouds:
         endpoint: https://ec2.sa-east-1.amazonaws.com
   aws-china:
     type: ec2
+    description: Amazon China
     auth-types: [ access-key ]
     regions:
       cn-north-1:
         endpoint: https://ec2.cn-north-1.amazonaws.com.cn
   aws-gov:
     type: ec2
+    description: Amazon (USA Government)
     auth-types: [ access-key ]
     regions:
       us-gov-west-1:
         endpoint: https://ec2.us-gov-west-1.amazonaws.com
   google:
     type: gce
+    description: Google Cloud Platform
     auth-types: [ jsonfile, oauth2 ]
     regions:
       us-east1:
@@ -52,6 +56,7 @@ clouds:
         endpoint: https://www.googleapis.com
   azure:
     type: azure
+    description: Microsoft Azure
     auth-types: [ interactive, service-principal-secret ]
     regions:
       centralus:
@@ -128,6 +133,7 @@ clouds:
         identity-endpoint: https://graph.windows.net
   azure-china:
     type: azure
+    description: Microsoft Azure China
     auth-types: [ interactive, service-principal-secret ]
     regions:
       chinaeast:
@@ -140,6 +146,7 @@ clouds:
         identity-endpoint: https://graph.chinacloudapi.cn
   rackspace:
     type: rackspace
+    description: Rackspace Cloud
     auth-types: [ userpass ]
     endpoint: https://identity.api.rackspacecloud.com/v2.0
     regions:
@@ -157,6 +164,7 @@ clouds:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
   joyent:
     type: joyent
+    description: Joyent Cloud
     auth-types: [ userpass ]
     regions:
       eu-ams-1: 
@@ -173,6 +181,7 @@ clouds:
         endpoint: https://us-west-1.api.joyentcloud.com
   cloudsigma:
     type: cloudsigma
+    description: CloudSigma Cloud
     auth-types: [ userpass ]
     regions:
       hnl:

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -9,6 +9,7 @@ const fallbackPublicCloudInfo = `# DO NOT EDIT, will be overwritten, use "juju u
 clouds:
   aws:
     type: ec2
+    description: Amazon Web Services
     auth-types: [ access-key ]
     regions:
       us-east-1:
@@ -35,18 +36,21 @@ clouds:
         endpoint: https://ec2.sa-east-1.amazonaws.com
   aws-china:
     type: ec2
+    description: Amazon China
     auth-types: [ access-key ]
     regions:
       cn-north-1:
         endpoint: https://ec2.cn-north-1.amazonaws.com.cn
   aws-gov:
     type: ec2
+    description: Amazon (USA Government)
     auth-types: [ access-key ]
     regions:
       us-gov-west-1:
         endpoint: https://ec2.us-gov-west-1.amazonaws.com
   google:
     type: gce
+    description: Google Cloud Platform
     auth-types: [ jsonfile, oauth2 ]
     regions:
       us-east1:
@@ -59,6 +63,7 @@ clouds:
         endpoint: https://www.googleapis.com
   azure:
     type: azure
+    description: Microsoft Azure
     auth-types: [ interactive, service-principal-secret ]
     regions:
       centralus:
@@ -135,6 +140,7 @@ clouds:
         identity-endpoint: https://graph.windows.net
   azure-china:
     type: azure
+    description: Microsoft Azure China
     auth-types: [ interactive, service-principal-secret ]
     regions:
       chinaeast:
@@ -147,6 +153,7 @@ clouds:
         identity-endpoint: https://graph.chinacloudapi.cn
   rackspace:
     type: rackspace
+    description: Rackspace Cloud
     auth-types: [ userpass ]
     endpoint: https://identity.api.rackspacecloud.com/v2.0
     regions:
@@ -164,6 +171,7 @@ clouds:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
   joyent:
     type: joyent
+    description: Joyent Cloud
     auth-types: [ userpass ]
     regions:
       eu-ams-1: 
@@ -180,6 +188,7 @@ clouds:
         endpoint: https://us-west-1.api.joyentcloud.com
   cloudsigma:
     type: cloudsigma
+    description: CloudSigma Cloud
     auth-types: [ userpass ]
     regions:
       hnl:

--- a/cloud/personalclouds_test.go
+++ b/cloud/personalclouds_test.go
@@ -95,15 +95,17 @@ func (s *personalCloudSuite) TestReadUserSpecifiedClouds(c *gc.C) {
 func (s *personalCloudSuite) assertPersonalClouds(c *gc.C, clouds map[string]cloud.Cloud) {
 	c.Assert(clouds, jc.DeepEquals, map[string]cloud.Cloud{
 		"homestack": cloud.Cloud{
-			Type:      "openstack",
-			AuthTypes: []cloud.AuthType{"userpass", "access-key"},
-			Endpoint:  "http://homestack",
+			Type:        "openstack",
+			Description: "Openstack Cloud",
+			AuthTypes:   []cloud.AuthType{"userpass", "access-key"},
+			Endpoint:    "http://homestack",
 			Regions: []cloud.Region{
 				cloud.Region{Name: "london", Endpoint: "http://london/1.0"},
 			},
 		},
 		"azurestack": cloud.Cloud{
 			Type:             "azure",
+			Description:      "Microsoft Azure",
 			AuthTypes:        []cloud.AuthType{"userpass"},
 			IdentityEndpoint: "http://login.azurestack.local",
 			StorageEndpoint:  "http://storage.azurestack.local",

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -29,7 +29,7 @@ func (s *listSuite) TestListPublic(c *gc.C) {
 	out := testing.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
 	// Just check couple of snippets of the output to make sure it looks ok.
-	c.Assert(out, gc.Matches, `.*aws-china[ ]*ec2[ ]*cn-north-1.*`)
+	c.Assert(out, gc.Matches, `.*aws-china[ ]*1[ ]*cn-north-1[ ]*ec2.*`)
 	// TODO(wallyworld) - uncomment when we build with go 1.3 or greater
 	// LXD should be there too.
 	// c.Assert(out, gc.Matches, `.*localhost[ ]*lxd[ ]*localhost.*`)
@@ -56,7 +56,7 @@ clouds:
 	// Just check a snippet of the output to make sure it looks ok.
 	// local clouds are last.
 	// homestack should abut localhost and hence come last in the output.
-	c.Assert(out, jc.Contains, `localhosthomestack    openstack   london`)
+	c.Assert(out, jc.Contains, `Hypervisorhomestack          1  london         openstack   Openstack Cloud`)
 }
 
 func (s *listSuite) TestListPublicAndPersonalSameName(c *gc.C) {
@@ -77,7 +77,7 @@ clouds:
 	// Just check a snippet of the output to make sure it looks ok.
 	// local clouds are last.
 	c.Assert(out, gc.Not(gc.Matches), `.*aws:[ ]*defined: public[ ]*type: ec2[ ]*auth-types: \[access-key\].*`)
-	c.Assert(out, gc.Matches, `.*aws:[ ]*defined: local[ ]*type: ec2[ ]*auth-types: \[access-key\].*`)
+	c.Assert(out, gc.Matches, `.*aws:[ ]*defined: local[ ]*type: ec2[ ]*description: Amazon Web Services[ ]*auth-types: \[access-key\].*`)
 }
 
 func (s *listSuite) TestListYAML(c *gc.C) {
@@ -86,7 +86,7 @@ func (s *listSuite) TestListYAML(c *gc.C) {
 	out := testing.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
 	// Just check a snippet of the output to make sure it looks ok.
-	c.Assert(out, gc.Matches, `.*aws:[ ]*defined: public[ ]*type: ec2[ ]*auth-types: \[access-key\].*`)
+	c.Assert(out, gc.Matches, `.*aws:[ ]*defined: public[ ]*type: ec2[ ]*description: Amazon Web Services[ ]*auth-types: \[access-key\].*`)
 }
 
 func (s *listSuite) TestListJSON(c *gc.C) {
@@ -95,7 +95,7 @@ func (s *listSuite) TestListJSON(c *gc.C) {
 	out := testing.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
 	// Just check a snippet of the output to make sure it looks ok.
-	c.Assert(out, gc.Matches, `.*{"aws":{"defined":"public","type":"ec2","auth-types":\["access-key"\].*`)
+	c.Assert(out, gc.Matches, `.*{"aws":{"defined":"public","type":"ec2","description":"Amazon Web Services","auth-types":\["access-key"\].*`)
 }
 
 func (s *listSuite) TestListPreservesRegionOrder(c *gc.C) {

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -237,11 +237,8 @@ func formatCredentialsTabular(writer io.Writer, value interface{}) error {
 	sort.Strings(cloudNames)
 
 	tw := output.TabWriter(writer)
-	p := func(values ...string) {
-		text := strings.Join(values, "\t")
-		fmt.Fprintln(tw, text)
-	}
-	p("CLOUD\tCREDENTIALS")
+	w := output.Wrapper{tw}
+	w.Println("Cloud", "Credentials")
 	for _, cloudName := range cloudNames {
 		var haveDefault bool
 		var credentialNames []string
@@ -259,7 +256,7 @@ func formatCredentialsTabular(writer io.Writer, value interface{}) error {
 		} else {
 			sort.Strings(credentialNames)
 		}
-		p(cloudName, strings.Join(credentialNames, ", "))
+		w.Println(cloudName, strings.Join(credentialNames, ", "))
 	}
 	tw.Flush()
 

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -110,7 +110,7 @@ func (s *listCredentialsSuite) SetUpTest(c *gc.C) {
 func (s *listCredentialsSuite) TestListCredentialsTabular(c *gc.C) {
 	out := s.listCredentials(c)
 	c.Assert(out, gc.Equals, `
-CLOUD    CREDENTIALS
+Cloud    Credentials
 aws      down*, bob
 azure    azhja
 google   default
@@ -126,7 +126,7 @@ func (s *listCredentialsSuite) TestListCredentialsTabularMissingCloud(c *gc.C) {
 The following clouds have been removed and are omitted from the results to avoid leaking secrets.
 Run with --show-secrets to display these clouds' credentials: missingcloud
 
-CLOUD    CREDENTIALS
+Cloud    Credentials
 aws      down*, bob
 azure    azhja
 google   default
@@ -138,7 +138,7 @@ mycloud  me
 func (s *listCredentialsSuite) TestListCredentialsTabularFiltered(c *gc.C) {
 	out := s.listCredentials(c, "aws")
 	c.Assert(out, gc.Equals, `
-CLOUD  CREDENTIALS
+Cloud  Credentials
 aws    down*, bob
 
 `[1:])
@@ -286,7 +286,7 @@ func (s *listCredentialsSuite) TestListCredentialsEmpty(c *gc.C) {
 		},
 	}
 	out := strings.Replace(s.listCredentials(c), "\n", "", -1)
-	c.Assert(out, gc.Equals, "CLOUD  CREDENTIALSaws    bob")
+	c.Assert(out, gc.Equals, "Cloud  Credentialsaws    bob")
 
 	out = strings.Replace(s.listCredentials(c, "--format", "yaml"), "\n", "", -1)
 	c.Assert(out, gc.Equals, "credentials:  aws:    bob:      auth-type: oauth2")

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -87,11 +87,12 @@ type regionDetails struct {
 type cloudDetails struct {
 	Source           string   `yaml:"defined,omitempty" json:"defined,omitempty"`
 	CloudType        string   `yaml:"type" json:"type"`
+	CloudDescription string   `yaml:"description" json:"description"`
 	AuthTypes        []string `yaml:"auth-types,omitempty,flow" json:"auth-types,omitempty"`
 	Endpoint         string   `yaml:"endpoint,omitempty" json:"endpoint,omitempty"`
 	IdentityEndpoint string   `yaml:"identity-endpoint,omitempty" json:"identity-endpoint,omitempty"`
 	StorageEndpoint  string   `yaml:"storage-endpoint,omitempty" json:"storage-endpoint,omitempty"`
-	// Regions is for when we want to print regions in order for yaml or tabular output.
+	// Regions is for when we want to print regions in order for yaml output.
 	Regions yaml.MapSlice `yaml:"regions,omitempty" json:"-"`
 	// Regions map is for json marshalling where format is important but not order.
 	RegionsMap   map[string]regionDetails `yaml:"-" json:"regions,omitempty"`
@@ -108,6 +109,7 @@ func makeCloudDetails(cloud jujucloud.Cloud) *cloudDetails {
 		StorageEndpoint:  cloud.StorageEndpoint,
 		Config:           cloud.Config,
 		RegionConfig:     cloud.RegionConfig,
+		CloudDescription: cloud.Description,
 	}
 	result.AuthTypes = make([]string, len(cloud.AuthTypes))
 	for i, at := range cloud.AuthTypes {

--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -33,6 +33,7 @@ func (s *showSuite) TestShow(c *gc.C) {
 	c.Assert(out, gc.Equals, `
 defined: public
 type: ec2
+description: Amazon China
 auth-types: [access-key]
 regions:
   cn-north-1:
@@ -45,6 +46,7 @@ func (s *showSuite) TestShowWithConfig(c *gc.C) {
 clouds:
   homestack:
     type: openstack
+    description: Openstack Cloud
     auth-types: [userpass, access-key]
     endpoint: http://homestack
     regions:
@@ -61,6 +63,7 @@ clouds:
 	c.Assert(out, gc.Equals, `
 defined: local
 type: openstack
+description: Openstack Cloud
 auth-types: [userpass, access-key]
 endpoint: http://homestack
 regions:
@@ -76,6 +79,7 @@ func (s *showSuite) TestShowWithRegionConfig(c *gc.C) {
 clouds:
   homestack:
     type: openstack
+    description: Openstack Cloud
     auth-types: [userpass, access-key]
     endpoint: http://homestack
     regions:
@@ -93,6 +97,7 @@ clouds:
 	c.Assert(out, gc.Equals, `
 defined: local
 type: openstack
+description: Openstack Cloud
 auth-types: [userpass, access-key]
 endpoint: http://homestack
 regions:


### PR DESCRIPTION
Partially fixes: https://bugs.launchpad.net/juju/+bug/1629591

list-clouds output is revised to only show region count and add extra text to point the user to other commands.
Also add a Description field to clouds.yaml. If empty, there is default text used based on the cloud name (for public clouds) or cloud type (for private clouds). The default public clouds yaml has been updated and a new copy with the description ban also be pushed for use with update-clouds.

QA
$ juju list-clouds
Cloud        Regions  Default        Type        Description
aws               11  us-east-1      ec2         Amazon Web Services
aws-china          1  cn-north-1     ec2         Amazon China
aws-gov            1  us-gov-west-1  ec2         Amazon (USA Government)
azure             18  centralus      azure       Microsoft Azure
azure-china        2  chinaeast      azure       Microsoft Azure China
cloudsigma         5  hnl            cloudsigma  CloudSigma Cloud
google             4  us-east1       gce         Google Cloud Platform
joyent             6  eu-ams-1       joyent      Joyent Cloud
rackspace          6  dfw            rackspace   Rackspace Cloud
localhost          1  localhost      lxd         LXD Container Hypervisor
canonistack        2  lcy01          openstack   Openstack Cloud

Try 'list-regions <cloud>' to see available regions.
'show-cloud <cloud>' can be used to see region endpoints.
'add-cloud' can add private clouds or private infrastructure.
Update the known public clouds with 'update-clouds'.

