### PR TITLE
New list-regions command

### DIFF
--- a/cmd/juju/cloud/regions.go
+++ b/cmd/juju/cloud/regions.go
@@ -1,0 +1,131 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"gopkg.in/yaml.v2"
+
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/output"
+)
+
+type listRegionsCommand struct {
+	cmd.CommandBase
+	out       cmd.Output
+	cloudName string
+}
+
+var listRegionsDoc = `
+Examples:
+
+    juju regions aws
+
+See also:
+    add-cloud
+    clouds
+    show-cloud
+    update-clouds
+`
+
+// NewListRegionsCommand returns a command to list cloud region information.
+func NewListRegionsCommand() cmd.Command {
+	return &listRegionsCommand{}
+}
+
+// Info implements Command.Info.
+func (c *listRegionsCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "regions",
+		Args:    "<cloud>",
+		Purpose: "Lists regions for a given cloud.",
+		Doc:     listRegionsDoc,
+		Aliases: []string{"list-regions"},
+	}
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *listRegionsCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
+		"yaml":    cmd.FormatYaml,
+		"json":    cmd.FormatJson,
+		"tabular": c.formatRegionsListTabular,
+	})
+}
+
+// Init implements Command.Init.
+func (c *listRegionsCommand) Init(args []string) error {
+	switch len(args) {
+	case 0:
+		return errors.New("no cloud specified")
+	case 1:
+		c.cloudName = args[0]
+	}
+	return cmd.CheckEmpty(args[1:])
+}
+
+// Run implements Command.Run.
+func (c *listRegionsCommand) Run(ctxt *cmd.Context) error {
+	cloud, err := cloud.CloudByName(c.cloudName)
+	if err != nil {
+		return err
+	}
+
+	if len(cloud.Regions) == 0 {
+		fmt.Fprintln(ctxt.GetStdout(), "Cloud %q has no regions defined.", c.cloudName)
+		return nil
+	}
+	var regions interface{}
+	if c.out.Name() == "json" {
+		details := make(map[string]regionDetails)
+		for _, r := range cloud.Regions {
+			details[r.Name] = regionDetails{
+				Endpoint:         r.Endpoint,
+				IdentityEndpoint: r.IdentityEndpoint,
+				StorageEndpoint:  r.StorageEndpoint,
+			}
+		}
+		regions = details
+	} else {
+		details := make(yaml.MapSlice, len(cloud.Regions))
+		for i, r := range cloud.Regions {
+			details[i] = yaml.MapItem{r.Name, regionDetails{
+				Name:             r.Name,
+				Endpoint:         r.Endpoint,
+				IdentityEndpoint: r.IdentityEndpoint,
+				StorageEndpoint:  r.StorageEndpoint,
+			}}
+		}
+		regions = details
+	}
+	err = c.out.Write(ctxt, regions)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *listRegionsCommand) formatRegionsListTabular(writer io.Writer, value interface{}) error {
+	regions, ok := value.(yaml.MapSlice)
+	if !ok {
+		return errors.Errorf("expected value of type %T, got %T", regions, value)
+	}
+	return formatRegionsTabular(writer, regions)
+}
+
+func formatRegionsTabular(writer io.Writer, regions yaml.MapSlice) error {
+	tw := output.TabWriter(writer)
+	w := output.Wrapper{tw}
+	for _, r := range regions {
+		w.Println(r.Key)
+	}
+	tw.Flush()
+	return nil
+}

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -1,0 +1,116 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud_test
+
+import (
+	"encoding/json"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/cloud"
+	_ "github.com/juju/juju/provider/all"
+	"github.com/juju/juju/testing"
+)
+
+type regionsSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
+}
+
+var _ = gc.Suite(&regionsSuite{})
+
+func (s *regionsSuite) TestListRegionsInvalidCloud(c *gc.C) {
+	_, err := testing.RunCommand(c, cloud.NewListRegionsCommand(), "invalid")
+	c.Assert(err, gc.ErrorMatches, "cloud invalid not found")
+}
+
+func (s *regionsSuite) TestListRegionsInvalidArgs(c *gc.C) {
+	_, err := testing.RunCommand(c, cloud.NewListRegionsCommand(), "aws", "another")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["another"\]`)
+}
+
+func (s *regionsSuite) TestListRegions(c *gc.C) {
+	ctx, err := testing.RunCommand(c, cloud.NewListRegionsCommand(), "aws")
+	c.Assert(err, jc.ErrorIsNil)
+	out := testing.Stdout(ctx)
+	c.Assert(out, jc.DeepEquals, `
+us-east-1
+us-west-1
+us-west-2
+eu-west-1
+eu-central-1
+ap-south-1
+ap-southeast-1
+ap-southeast-2
+ap-northeast-1
+ap-northeast-2
+sa-east-1
+
+`[1:])
+}
+
+func (s *regionsSuite) TestListRegionsYaml(c *gc.C) {
+	ctx, err := testing.RunCommand(c, cloud.NewListRegionsCommand(), "aws", "--format", "yaml")
+	c.Assert(err, jc.ErrorIsNil)
+	out := testing.Stdout(ctx)
+	c.Assert(out, jc.DeepEquals, `
+us-east-1:
+  endpoint: https://ec2.us-east-1.amazonaws.com
+us-west-1:
+  endpoint: https://ec2.us-west-1.amazonaws.com
+us-west-2:
+  endpoint: https://ec2.us-west-2.amazonaws.com
+eu-west-1:
+  endpoint: https://ec2.eu-west-1.amazonaws.com
+eu-central-1:
+  endpoint: https://ec2.eu-central-1.amazonaws.com
+ap-south-1:
+  endpoint: https://ec2.ap-south-1.amazonaws.com
+ap-southeast-1:
+  endpoint: https://ec2.ap-southeast-1.amazonaws.com
+ap-southeast-2:
+  endpoint: https://ec2.ap-southeast-2.amazonaws.com
+ap-northeast-1:
+  endpoint: https://ec2.ap-northeast-1.amazonaws.com
+ap-northeast-2:
+  endpoint: https://ec2.ap-northeast-2.amazonaws.com
+sa-east-1:
+  endpoint: https://ec2.sa-east-1.amazonaws.com
+`[1:])
+}
+
+type regionDetails struct {
+	Endpoint         string `json:"endpoint"`
+	IdentityEndpoint string `json:"identity-endpoint"`
+	StorageEndpoint  string `json:"storage-endpoint"`
+}
+
+func (s *regionsSuite) TestListRegionsJson(c *gc.C) {
+	ctx, err := testing.RunCommand(c, cloud.NewListRegionsCommand(), "azure", "--format", "json")
+	c.Assert(err, jc.ErrorIsNil)
+	out := testing.Stdout(ctx)
+	var data map[string]regionDetails
+	err = json.Unmarshal([]byte(out), &data)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, jc.DeepEquals, map[string]regionDetails{
+		"northeurope":        {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"eastasia":           {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"japanwest":          {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"centralus":          {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"eastus2":            {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"japaneast":          {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"northcentralus":     {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"southcentralus":     {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"australiaeast":      {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"brazilsouth":        {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"centralindia":       {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"southindia":         {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"westeurope":         {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"westindia":          {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"westus":             {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"australiasoutheast": {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"eastus":             {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"southeastasia":      {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+	})
+}

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -384,6 +384,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	// Manage clouds and credentials
 	r.Register(cloud.NewUpdateCloudsCommand())
 	r.Register(cloud.NewListCloudsCommand())
+	r.Register(cloud.NewListRegionsCommand())
 	r.Register(cloud.NewShowCloudCommand())
 	r.Register(cloud.NewAddCloudCommand())
 	r.Register(cloud.NewRemoveCloudCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -451,6 +451,7 @@ var commandNames = []string{
 	"list-machines",
 	"list-models",
 	"list-plans",
+	"list-regions",
 	"list-ssh-keys",
 	"list-spaces",
 	"list-storage",
@@ -465,6 +466,7 @@ var commandNames = []string{
 	"model-defaults",
 	"models",
 	"plans",
+	"regions",
 	"register",
 	"relate", //alias for add-relation
 	"remove-application",


### PR DESCRIPTION
Partially Fixes: https://bugs.launchpad.net/juju/+bug/1629591

Add a new list-regions command.

QA

$ juju regions aws
Region
us-east-1
us-west-1
us-west-2
eu-west-1
eu-central-1
ap-south-1
ap-southeast-1
ap-southeast-2
ap-northeast-1
ap-northeast-2
sa-east-1

Try 'show-cloud aws' to see more detail for each region.