### PR TITLE
Display message when bootstrapping with lxd provider

### DIFF
--- a/environs/interface.go
+++ b/environs/interface.go
@@ -205,6 +205,10 @@ type Environ interface {
 	// architecture.
 	Bootstrap(ctx BootstrapContext, params BootstrapParams) (*BootstrapResult, error)
 
+	// BootstrapMessage optionally provides a message to be displayed to
+	// the user at bootstrap time.
+	BootstrapMessage() string
+
 	// Create creates the environment for a new hosted model.
 	//
 	// This will be called before any workers begin operating on the

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -229,6 +229,11 @@ func (env *azureEnviron) Bootstrap(
 	return result, nil
 }
 
+// BootstrapMessage is part of the Environ interface.
+func (env *azureEnviron) BootstrapMessage() string {
+	return ""
+}
+
 // initResourceGroup creates a resource group for this environment.
 func (env *azureEnviron) initResourceGroup(controllerUUID string) error {
 	location := env.location

--- a/provider/cloudsigma/environ.go
+++ b/provider/cloudsigma/environ.go
@@ -93,6 +93,11 @@ func (env *environ) Bootstrap(ctx environs.BootstrapContext, params environs.Boo
 	return common.Bootstrap(ctx, env, params)
 }
 
+// BootstrapMessage is part of the Environ interface.
+func (env *environ) BootstrapMessage() string {
+	return ""
+}
+
 func (e *environ) ControllerInstances(controllerUUID string) ([]instance.Id, error) {
 	return e.client.getControllerIds()
 }

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -134,7 +134,7 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 
 	bootstrapMsg := env.BootstrapMessage()
 	if bootstrapMsg != "" {
-		fmt.Println(bootstrapMsg)
+		ctx.Infof(bootstrapMsg)
 	}
 
 	cloudRegion := args.CloudName

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -132,6 +132,11 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 	}
 	maybeSetBridge(instanceConfig)
 
+	bootstrapMsg := env.BootstrapMessage()
+	if bootstrapMsg != "" {
+		fmt.Println(bootstrapMsg)
+	}
+
 	cloudRegion := args.CloudName
 	if args.CloudRegion != "" {
 		cloudRegion += "/" + args.CloudRegion

--- a/provider/common/mock_test.go
+++ b/provider/common/mock_test.go
@@ -45,6 +45,11 @@ func (env *mockEnviron) Storage() storage.Storage {
 func (env *mockEnviron) AllInstances() ([]instance.Instance, error) {
 	return env.allInstances()
 }
+
+func (env *mockEnviron) BootstrapMessage() string {
+	return ""
+}
+
 func (env *mockEnviron) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	inst, hw, networkInfo, err := env.startInstance(
 		args.Placement,

--- a/provider/common/mock_test.go
+++ b/provider/common/mock_test.go
@@ -47,7 +47,7 @@ func (env *mockEnviron) AllInstances() ([]instance.Instance, error) {
 }
 
 func (env *mockEnviron) BootstrapMessage() string {
-	return ""
+	return "Some message"
 }
 
 func (env *mockEnviron) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -831,6 +831,11 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 	return bsResult, nil
 }
 
+// BootstrapMessage is part of the Environ interface.
+func (e *environ) BootstrapMessage() string {
+	return ""
+}
+
 func (e *environ) ControllerInstances(controllerUUID string) ([]instance.Id, error) {
 	estate, err := e.state()
 	if err != nil {

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -132,6 +132,11 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 	return common.Bootstrap(ctx, e, args)
 }
 
+// BootstrapMessage is part of the Environ interface.
+func (e *environ) BootstrapMessage() string {
+	return ""
+}
+
 // SupportsSpaces is specified on environs.Networking.
 func (e *environ) SupportsSpaces() (bool, error) {
 	return true, nil

--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -202,6 +202,11 @@ func (env *environ) Bootstrap(ctx environs.BootstrapContext, params environs.Boo
 	return bootstrap(ctx, env, params)
 }
 
+// BootstrapMessage is part of the Environ interface.
+func (env *environ) BootstrapMessage() string {
+	return ""
+}
+
 // Destroy shuts down all known machines and destroys the rest of the
 // known environment.
 func (env *environ) Destroy() error {

--- a/provider/joyent/environ.go
+++ b/provider/joyent/environ.go
@@ -113,6 +113,11 @@ func (env *joyentEnviron) Bootstrap(ctx environs.BootstrapContext, args environs
 	return common.Bootstrap(ctx, env, args)
 }
 
+// BootstrapMessage is part of the Environ interface.
+func (env *joyentEnviron) BootstrapMessage() string {
+	return ""
+}
+
 func (env *joyentEnviron) ControllerInstances(controllerUUID string) ([]instance.Id, error) {
 	instanceIds := []instance.Id{}
 

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -147,6 +147,11 @@ func (env *environ) Bootstrap(ctx environs.BootstrapContext, params environs.Boo
 	return env.base.BootstrapEnv(ctx, params)
 }
 
+// BootstrapMessage is part of the Environ interface.
+func (env *environ) BootstrapMessage() string {
+	return ""
+}
+
 // Destroy shuts down all known machines and destroys the rest of the
 // known environment.
 func (env *environ) Destroy() error {

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -18,6 +18,8 @@ import (
 	"github.com/juju/juju/tools/lxdclient"
 )
 
+const bootstrapMessage = `To configure your system to better support LXD containers, please see: https://github.com/lxc/lxd/blob/master/doc/production-setup.md`
+
 type baseProvider interface {
 	// BootstrapEnv bootstraps a Juju environment.
 	BootstrapEnv(environs.BootstrapContext, environs.BootstrapParams) (*environs.BootstrapResult, error)
@@ -149,7 +151,7 @@ func (env *environ) Bootstrap(ctx environs.BootstrapContext, params environs.Boo
 
 // BootstrapMessage is part of the Environ interface.
 func (env *environ) BootstrapMessage() string {
-	return ""
+	return bootstrapMessage
 }
 
 // Destroy shuts down all known machines and destroys the rest of the

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -182,6 +182,11 @@ func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 	return bsResult, nil
 }
 
+// BootstrapMessage is part of the Environ interface.
+func (env *maasEnviron) BootstrapMessage() string {
+	return ""
+}
+
 // ControllerInstances is specified in the Environ interface.
 func (env *maasEnviron) ControllerInstances(controllerUUID string) ([]instance.Id, error) {
 	if !env.usingMAAS2() {

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -130,6 +130,11 @@ func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 	return result, nil
 }
 
+// BootstrapMessage is part of the Environ interface.
+func (e *manualEnviron) BootstrapMessage() string {
+	return ""
+}
+
 // ControllerInstances is specified in the Environ interface.
 func (e *manualEnviron) ControllerInstances(controllerUUID string) ([]instance.Id, error) {
 	if !isRunningController() {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -518,6 +518,11 @@ func (e *Environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 	return common.Bootstrap(ctx, e, args)
 }
 
+// BootstrapMessage is part of the Environ interface.
+func (e *Environ) BootstrapMessage() string {
+	return ""
+}
+
 func (e *Environ) ControllerInstances(controllerUUID string) ([]instance.Id, error) {
 	// Find all instances tagged with tags.JujuIsController.
 	instances, err := e.allControllerManagedInstances(controllerUUID, e.ecfg().useFloatingIP())

--- a/provider/rackspace/environ.go
+++ b/provider/rackspace/environ.go
@@ -30,6 +30,11 @@ func (e environ) Bootstrap(ctx environs.BootstrapContext, params environs.Bootst
 	return bootstrap(ctx, e, params)
 }
 
+// BootstrapMessage is part of the Environ interface.
+func (e environ) BootstrapMessage() string {
+	return ""
+}
+
 var waitSSH = common.WaitSSH
 
 // StartInstance implements environs.Environ.

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -124,6 +124,10 @@ func (e *fakeEnviron) Bootstrap(ctx environs.BootstrapContext, params environs.B
 	return nil, nil
 }
 
+func (e *fakeEnviron) BootstrapMessage() string {
+	return ""
+}
+
 func (e *fakeEnviron) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	e.Push("StartInstance", args)
 	return &environs.StartInstanceResult{

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -116,6 +116,11 @@ func (env *environ) Bootstrap(ctx environs.BootstrapContext, params environs.Boo
 	return Bootstrap(ctx, env, params)
 }
 
+// BootstrapMessage is part of the Environ interface.
+func (env *environ) BootstrapMessage() string {
+	return ""
+}
+
 //this variable is exported, because it has to be rewritten in external unit tests
 var DestroyEnv = common.Destroy
 


### PR DESCRIPTION
Partial fix for bug 1602192.

https://bugs.launchpad.net/juju/+bug/1602192

Display a custom message when bootstrapping with the lxd provider, pointing the user to configuration information.

The reason we're displaying an advisory rather than making the changes from Juju is that  these settings need to be set on the host machine and they need system privileges plus a reboot. We could do it at Juju install time, but not at bootstrap time as we only have user privileges and we shouldn't be making intrusive system changes just because the user has installed Juju.

QA
Bootstrap with the lxd provider. It should look something like this:

$ juju bootstrap foo lxd
Creating Juju controller "foo" on lxd/localhost
Looking for packaged Juju agent version 2.0.0 for amd64
No packaged binary found, preparing local Juju agent binary
To configure your system to better support LXD containers, please see: https://github.com/lxc/lxd/blob/master/doc/production-setup.md
Launching controller instance(s) on lxd/localhost...
 - juju-6e02cd-0
Fetching Juju GUI 2.2.0