### PR TITLE
Allow enable-ha to work regardless of selected model

### DIFF
--- a/api/highavailability/client.go
+++ b/api/highavailability/client.go
@@ -7,7 +7,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/replicaset"
-	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
@@ -20,15 +19,13 @@ var logger = loggo.GetLogger("juju.api.highavailability")
 // Client provides access to the high availability service, used to manage controllers.
 type Client struct {
 	base.ClientFacade
-	facade   base.FacadeCaller
-	modelTag names.ModelTag
+	facade base.FacadeCaller
 }
 
 // NewClient returns a new HighAvailability client.
 func NewClient(caller base.APICallCloser) *Client {
-	modelTag, _ := caller.ModelTag()
 	frontend, backend := base.NewClientFacade(caller, "HighAvailability")
-	return &Client{ClientFacade: frontend, facade: backend, modelTag: modelTag}
+	return &Client{ClientFacade: frontend, facade: backend}
 }
 
 // EnableHA ensures the availability of Juju controllers.
@@ -39,7 +36,6 @@ func (c *Client) EnableHA(
 	var results params.ControllersChangeResults
 	arg := params.ControllersSpecs{
 		Specs: []params.ControllersSpec{{
-			ModelTag:       c.modelTag.String(),
 			NumControllers: numControllers,
 			Constraints:    cons,
 			Placement:      placement,

--- a/apiserver/highavailability/highavailability.go
+++ b/apiserver/highavailability/highavailability.go
@@ -54,6 +54,8 @@ func NewHighAvailabilityAPI(st *state.State, resources facade.Resources, authori
 	}, nil
 }
 
+// EnableHA adds controller machines as necessary to ensure the
+// controller has the number of machines specified.
 func (api *HighAvailabilityAPI) EnableHA(args params.ControllersSpecs) (params.ControllersChangeResults, error) {
 	results := params.ControllersChangeResults{Results: make([]params.ControllersChangeResult, len(args.Specs))}
 	for i, controllersServersSpec := range args.Specs {
@@ -67,7 +69,7 @@ func (api *HighAvailabilityAPI) EnableHA(args params.ControllersSpecs) (params.C
 			}
 
 		}
-		result, err := EnableHASingle(api.state, controllersServersSpec)
+		result, err := enableHASingle(api.state, controllersServersSpec)
 		results.Results[i].Result = result
 		results.Results[i].Error = common.ServerError(err)
 	}
@@ -95,9 +97,7 @@ func controllersChanges(change state.ControllersChanges) params.ControllersChang
 	}
 }
 
-// EnableHASingle applies a single ControllersServersSpec specification to the current environment.
-// Exported so it can be called by the legacy client API in the client package.
-func EnableHASingle(st *state.State, spec params.ControllersSpec) (params.ControllersChanges, error) {
+func enableHASingle(st *state.State, spec params.ControllersSpec) (params.ControllersChanges, error) {
 	if !st.IsController() {
 		return params.ControllersChanges{}, errors.New("unsupported with hosted models")
 	}

--- a/apiserver/highavailability/highavailability.go
+++ b/apiserver/highavailability/highavailability.go
@@ -43,7 +43,7 @@ var _ HighAvailability = (*HighAvailabilityAPI)(nil)
 
 // NewHighAvailabilityAPI creates a new server-side highavailability API end point.
 func NewHighAvailabilityAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*HighAvailabilityAPI, error) {
-	// Only clients and environment managers can access the high availability service.
+	// Only clients and model managers can access the high availability facade.
 	if !authorizer.AuthClient() && !authorizer.AuthModelManager() {
 		return nil, common.ErrPerm
 	}
@@ -112,16 +112,6 @@ func enableHASingle(st *state.State, spec params.ControllersSpec) (params.Contro
 	blockChecker := common.NewBlockChecker(st)
 	if err := blockChecker.ChangeAllowed(); err != nil {
 		return params.ControllersChanges{}, errors.Trace(err)
-	}
-	// Validate the environment tag if present.
-	if spec.ModelTag != "" {
-		tag, err := names.ParseModelTag(spec.ModelTag)
-		if err != nil {
-			return params.ControllersChanges{}, errors.Errorf("invalid model tag: %v", err)
-		}
-		if _, err := st.FindEntity(tag); err != nil {
-			return params.ControllersChanges{}, err
-		}
 	}
 
 	series := spec.Series

--- a/apiserver/highavailability/highavailability_test.go
+++ b/apiserver/highavailability/highavailability_test.go
@@ -379,3 +379,24 @@ func (s *clientSuite) TestEnableHAHostedEnvErrors(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 0)
 }
+
+func (s *clientSuite) TestEnableHAMultipleSpecs(c *gc.C) {
+	arg := params.ControllersSpecs{
+		Specs: []params.ControllersSpec{
+			{NumControllers: 3},
+			{NumControllers: 5},
+		},
+	}
+	results, err := s.haServer.EnableHA(arg)
+	c.Check(err, gc.ErrorMatches, "only one controller spec is supported")
+	c.Check(results.Results, gc.HasLen, 0)
+}
+
+func (s *clientSuite) TestEnableHANoSpecs(c *gc.C) {
+	arg := params.ControllersSpecs{
+		Specs: []params.ControllersSpec{},
+	}
+	results, err := s.haServer.EnableHA(arg)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(results.Results, gc.HasLen, 0)
+}

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -685,7 +685,6 @@ type LoginResult struct {
 // ControllersServersSpec contains arguments for
 // the EnableHA client API call.
 type ControllersSpec struct {
-	ModelTag       string            `json:"model-tag"`
 	NumControllers int               `json:"num-controllers"`
 	Constraints    constraints.Value `json:"constraints,omitempty"`
 	// Series is the series to associate with new controller machines.

--- a/apiserver/restrict_controller.go
+++ b/apiserver/restrict_controller.go
@@ -27,7 +27,11 @@ var controllerFacadeNames = set.NewStrings(
 var commonFacadeNames = set.NewStrings(
 	"Pinger",
 	"Bundle",
-	"HighAvailability", // Exposed for model logins for backwards compatibility.
+
+	// TODO(mjs) - bug 1632172 - Exposed for model logins for
+	// backwards compatibility. Remove once we're sure no non-Juju
+	// clients care about it.
+	"HighAvailability",
 )
 
 func controllerFacadesOnly(facadeName, _ string) error {

--- a/apiserver/restrict_controller.go
+++ b/apiserver/restrict_controller.go
@@ -27,6 +27,7 @@ var controllerFacadeNames = set.NewStrings(
 var commonFacadeNames = set.NewStrings(
 	"Pinger",
 	"Bundle",
+	"HighAvailability", // Exposed for model logins for backwards compatibility.
 )
 
 func controllerFacadesOnly(facadeName, _ string) error {

--- a/apiserver/restrict_controller_test.go
+++ b/apiserver/restrict_controller_test.go
@@ -32,6 +32,7 @@ func (s *restrictControllerSuite) TestAllowed(c *gc.C) {
 	s.assertMethod(c, "ModelManager", 2, "ListModels")
 	s.assertMethod(c, "Pinger", 1, "Ping")
 	s.assertMethod(c, "Bundle", 1, "GetChanges")
+	s.assertMethod(c, "HighAvailability", 2, "EnableHA")
 }
 
 func (s *restrictControllerSuite) TestNotAllowed(c *gc.C) {

--- a/apiserver/restrict_model_test.go
+++ b/apiserver/restrict_model_test.go
@@ -28,6 +28,7 @@ func (s *restrictModelSuite) SetUpSuite(c *gc.C) {
 func (s *restrictModelSuite) TestAllowed(c *gc.C) {
 	s.assertMethod(c, "Client", 1, "FullStatus")
 	s.assertMethod(c, "Pinger", 1, "Ping")
+	s.assertMethod(c, "HighAvailability", 2, "EnableHA")
 }
 
 func (s *restrictModelSuite) TestBlocked(c *gc.C) {

--- a/apiserver/restrict_model_test.go
+++ b/apiserver/restrict_model_test.go
@@ -26,9 +26,8 @@ func (s *restrictModelSuite) SetUpSuite(c *gc.C) {
 }
 
 func (s *restrictModelSuite) TestAllowed(c *gc.C) {
-	caller, err := s.root.FindMethod("Client", 1, "FullStatus")
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(caller, gc.NotNil)
+	s.assertMethod(c, "Client", 1, "FullStatus")
+	s.assertMethod(c, "Pinger", 1, "Ping")
 }
 
 func (s *restrictModelSuite) TestBlocked(c *gc.C) {
@@ -36,4 +35,10 @@ func (s *restrictModelSuite) TestBlocked(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `facade "ModelManager" not supported for model API connection`)
 	c.Assert(errors.IsNotSupported(err), jc.IsTrue)
 	c.Assert(caller, gc.IsNil)
+}
+
+func (s *restrictModelSuite) assertMethod(c *gc.C, facadeName string, version int, method string) {
+	caller, err := s.root.FindMethod(facadeName, version, method)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(caller, gc.NotNil)
 }

--- a/cmd/juju/commands/enableha.go
+++ b/cmd/juju/commands/enableha.go
@@ -33,12 +33,12 @@ func newEnableHACommand() cmd.Command {
 		// NewClient does not return an error, so we'll return nil
 		return highavailability.NewClient(root), nil
 	}
-	return modelcmd.Wrap(haCommand)
+	return modelcmd.WrapController(haCommand)
 }
 
 // enableHACommand makes the controller highly available.
 type enableHACommand struct {
-	modelcmd.ModelCommandBase
+	modelcmd.ControllerCommandBase
 	out cmd.Output
 
 	// newHAClientFunc returns HA Client to be used by the command.
@@ -66,8 +66,9 @@ type enableHACommand struct {
 
 const enableHADoc = `
 To ensure availability of deployed applications, the Juju infrastructure
-must itself be highly available.  enable-ha must be called
-to ensure that the specified number of controllers are made available.
+must itself be highly available. The enable-ha command will ensure
+that the specified number of controller machines are used to make up the
+controller.
 
 An odd number of controllers is required.
 
@@ -148,7 +149,7 @@ func (c *enableHACommand) Info() *cmd.Info {
 }
 
 func (c *enableHACommand) SetFlags(f *gnuflag.FlagSet) {
-	c.ModelCommandBase.SetFlags(f)
+	c.ControllerCommandBase.SetFlags(f)
 	f.IntVar(&c.NumControllers, "n", 0, "Number of controllers to make available")
 	f.StringVar(&c.PlacementSpec, "to", "", "The machine(s) to become controllers, bypasses constraints")
 	f.StringVar(&c.ConstraintsStr, "constraints", "", "Additional machine constraints")

--- a/cmd/juju/commands/enableha_test.go
+++ b/cmd/juju/commands/enableha_test.go
@@ -98,7 +98,7 @@ var _ = gc.Suite(&EnableHASuite{})
 
 func (s *EnableHASuite) runEnableHA(c *gc.C, args ...string) (*cmd.Context, error) {
 	command := &enableHACommand{newHAClientFunc: func() (MakeHAClient, error) { return s.fake, nil }}
-	return coretesting.RunCommand(c, modelcmd.Wrap(command), args...)
+	return coretesting.RunCommand(c, modelcmd.WrapController(command), args...)
 }
 
 func (s *EnableHASuite) TestEnableHA(c *gc.C) {


### PR DESCRIPTION
`juju enable-ha` now just works without requiring the controller model be selected.

There were a number of things done to make this work and some cleanup too:
* The HighAvailability facade is now available for controller logins. It is also still available for model logins for compatibility with clients outside of Juju.
* The unnecessarily exposed `apiserver.highavailability.EnableHASingle` function has been hidden.
* The `EnableHA` API call will now fail if given more than one controller spec. Passing more than one makes no sense. This allowed `EnableHA` to be somewhat simplified.
* Support has been removed for the `model-tag` field previously validated (but not used) by the `EnableHA` API. This will not break old clients if they send it, but it is no longer checked.
* The client side highavailability facade no longer sends the model tag.
* The `juju enable-ha` command is now a controller command instead of a model command. This means that `-m controller` is no longer necessary and the `-c ` arg is now available if needed.

Fixes https://bugs.launchpad.net/juju/+bug/1607170

### QA

Ran `juju enable-ha` with various arguments when the `default` model was selected.

Also confirmed that an rc3 client can enable HA as before using `juju enable-ha -m controller`.