### PR TITLE
Table headers are now FirstLetter case

### DIFF
--- a/cmd/juju/action/list.go
+++ b/cmd/juju/action/list.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/juju/cmd"
-	errors "github.com/juju/errors"
+	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/utils"
 	"gopkg.in/juju/names.v2"
@@ -145,7 +145,7 @@ func (c *listCommand) printTabular(writer io.Writer, value interface{}) error {
 	}
 
 	tw := output.TabWriter(writer)
-	fmt.Fprintf(tw, "%s\t%s\n", "ACTION", "DESCRIPTION")
+	fmt.Fprintf(tw, "%s\t%s\n", "Action", "Description")
 	for _, value := range list {
 		fmt.Fprintf(tw, "%s\t%s\n", value.action, strings.TrimSpace(value.description))
 	}

--- a/cmd/juju/action/list_test.go
+++ b/cmd/juju/action/list_test.go
@@ -88,7 +88,7 @@ func (s *ListSuite) TestInit(c *gc.C) {
 
 func (s *ListSuite) TestRun(c *gc.C) {
 	simpleOutput := `
-ACTION          DESCRIPTION
+Action          Description
 kill            Kill the database.
 no-description  No description
 no-params       An action with no parameters.

--- a/cmd/juju/block/list.go
+++ b/cmd/juju/block/list.go
@@ -184,7 +184,7 @@ func formatBlocks(writer io.Writer, value interface{}) error {
 
 	tw := output.TabWriter(writer)
 	w := output.Wrapper{tw}
-	w.Println("DISABLED COMMANDS", "MESSAGE")
+	w.Println("Disabled commands", "Message")
 	for _, info := range blocks {
 		w.Println(info.Commands, info.Message)
 	}
@@ -240,7 +240,7 @@ func FormatTabularBlockedModels(writer io.Writer, value interface{}) error {
 
 	tw := output.TabWriter(writer)
 	w := output.Wrapper{tw}
-	w.Println("NAME", "MODEL UUID", "OWNER", "DISABLED COMMANDS")
+	w.Println("Name", "Model UUID", "Owner", "Disabled commands")
 	for _, model := range models {
 		w.Println(model.Name, model.UUID, model.Owner, strings.Join(model.CommandSets, ", "))
 	}

--- a/cmd/juju/block/list_test.go
+++ b/cmd/juju/block/list_test.go
@@ -79,7 +79,7 @@ func (s *listCommandSuite) TestList(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stderr(ctx), gc.Equals, "")
 	c.Assert(testing.Stdout(ctx), gc.Equals, ""+
-		"DISABLED COMMANDS  MESSAGE\n"+
+		"Disabled commands  Message\n"+
 		"destroy-model      Sysadmins in control.\n"+
 		"all                just temporary\n"+
 		"\n",
@@ -119,7 +119,7 @@ func (s *listCommandSuite) TestListAll(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stderr(ctx), gc.Equals, "")
 	c.Assert(testing.Stdout(ctx), gc.Equals, ""+
-		"NAME        MODEL UUID   OWNER             DISABLED COMMANDS\n"+
+		"Name        Model UUID   Owner             Disabled commands\n"+
 		"controller  fake-uuid-1  admin             destroy-model, remove-object\n"+
 		"model-a     fake-uuid-2  bob@external      all\n"+
 		"model-b     fake-uuid-3  charlie@external  all, destroy-model\n"+

--- a/cmd/juju/cloud/regions.go
+++ b/cmd/juju/cloud/regions.go
@@ -79,7 +79,7 @@ func (c *listRegionsCommand) Run(ctxt *cmd.Context) error {
 	}
 
 	if len(cloud.Regions) == 0 {
-		fmt.Fprintln(ctxt.GetStdout(), "Cloud %q has no regions defined.", c.cloudName)
+		fmt.Fprintf(ctxt.GetStdout(), "Cloud %q has no regions defined.\n", c.cloudName)
 		return nil
 	}
 	var regions interface{}

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -337,7 +337,7 @@ func (c *addModelCommand) unsupportedCloudOrRegionError(cloudClient CloudAPI, de
 
 	var buf bytes.Buffer
 	tw := output.TabWriter(&buf)
-	fmt.Fprintln(tw, "CLOUD\tREGIONS")
+	fmt.Fprintln(tw, "Cloud\tRegions")
 	for _, cloudName := range cloudNames {
 		cloud := clouds[names.NewCloudTag(cloudName)]
 		regionNames := make([]string, len(cloud.Regions))

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -238,7 +238,7 @@ func (s *AddModelSuite) TestNoDefaultCloudRegion(c *gc.C) {
 and there is no default cloud. The clouds/regions supported
 by this controller are:
 
-CLOUD  REGIONS
+Cloud  Regions
 aws    us-east-1, us-west-1
 lxd    
 `[1:])
@@ -264,7 +264,7 @@ func (s *AddModelSuite) TestInvalidCloudOrRegionName(c *gc.C) {
 nor a region in the controller's default cloud "aws".
 The clouds/regions supported by this controller are:
 
-CLOUD  REGIONS
+Cloud  Regions
 aws    us-east-1, us-west-1
 lxd    
 `[1:])

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -476,7 +476,7 @@ func (s *DestroySuite) TestDestroyReturnsBlocks(c *gc.C) {
 	}
 	ctx, _ := s.runDestroyCommand(c, "test1", "-y", "--destroy-all-models")
 	c.Assert(testing.Stderr(ctx), gc.Equals, "Destroying controller\n"+
-		"NAME   MODEL UUID                            OWNER   DISABLED COMMANDS\n"+
+		"Name   Model UUID                            Owner   Disabled commands\n"+
 		"test1  1871299e-1370-4f3e-83ab-1849ed7b1076  cheryl  destroy-model\n"+
 		"test2  c59d0e3b-2bd7-4867-b1b9-f1ef8a0bb004  bob     all, destroy-model\n")
 	c.Assert(testing.Stdout(ctx), gc.Equals, "")

--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -38,7 +38,7 @@ func (s *ListControllersSuite) TestListControllers(c *gc.C) {
 	s.expectedOutput = `
 Use --refresh to see the latest information.
 
-CONTROLLER           MODEL       USER   ACCESS     CLOUD/REGION        MODELS  MACHINES  HA  VERSION
+Controller           Model       User   Access     Cloud/Region        Models  Machines  HA  Version
 aws-test             controller  -      -          aws/us-east-1            2         5   -  2.0.1      
 mallards*            my-model    admin  superuser  mallards/mallards1       -         -   -  (unknown)  
 mark-test-prodstack  -           admin  (unknown)  prodstack                -         -   -  (unknown)  
@@ -65,7 +65,7 @@ func (s *ListControllersSuite) TestListControllersRefresh(c *gc.C) {
 		return fakeController
 	}
 	s.expectedOutput = `
-CONTROLLER           MODEL       USER   ACCESS     CLOUD/REGION        MODELS  MACHINES  HA  VERSION
+Controller           Model       User   Access     Cloud/Region        Models  Machines  HA  Version
 aws-test             controller  admin  (unknown)  aws/us-east-1            1         2   -  2.0.1      
 mallards*            my-model    admin  superuser  mallards/mallards1       2         4   -  (unknown)  
 mark-test-prodstack  -           admin  (unknown)  prodstack                -         -   -  (unknown)  
@@ -115,7 +115,7 @@ func (s *ListControllersSuite) TestListControllersKnownHAStatus(c *gc.C) {
 	s.createTestClientStore(c)
 	s.setupAPIForControllerMachines()
 	s.expectedOutput = `
-CONTROLLER           MODEL       USER   ACCESS     CLOUD/REGION        MODELS  MACHINES    HA  VERSION
+Controller           Model       User   Access     Cloud/Region        Models  Machines    HA  Version
 aws-test             controller  admin  (unknown)  aws/us-east-1            1         2   1/3  2.0.1      
 mallards*            my-model    admin  superuser  mallards/mallards1       2         4  none  (unknown)  
 mark-test-prodstack  -           admin  (unknown)  prodstack                -         -     -  (unknown)  

--- a/cmd/juju/controller/listcontrollersformatters.go
+++ b/cmd/juju/controller/listcontrollersformatters.go
@@ -38,7 +38,7 @@ func formatControllersTabular(writer io.Writer, set ControllerSet, promptRefresh
 		fmt.Fprintln(writer, "Use --refresh to see the latest information.")
 		fmt.Fprintln(writer)
 	}
-	w.Println("CONTROLLER", "MODEL", "USER", "ACCESS", "CLOUD/REGION", "MODELS", "MACHINES", "HA", "VERSION")
+	w.Println("Controller", "Model", "User", "Access", "Cloud/Region", "Models", "Machines", "HA", "Version")
 	tw.SetColumnAlignRight(5)
 	tw.SetColumnAlignRight(6)
 	tw.SetColumnAlignRight(7)

--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -268,9 +268,9 @@ func (c *modelsCommand) formatTabular(writer io.Writer, value interface{}) error
 
 	tw := output.TabWriter(writer)
 	w := output.Wrapper{tw}
-	w.Println("CONTROLLER: " + c.ControllerName())
+	w.Println("Controller: " + c.ControllerName())
 	w.Println()
-	w.Print("MODEL")
+	w.Print("Model")
 	if c.listUUID {
 		w.Print("UUID")
 	}
@@ -282,7 +282,7 @@ func (c *modelsCommand) formatTabular(writer io.Writer, value interface{}) error
 		}
 	}
 	if haveMachineInfo {
-		w.Println("OWNER", "STATUS", "MACHINES", "CORES", "ACCESS", "LAST CONNECTION")
+		w.Println("Owner", "Status", "Machines", "Cores", "Access", "Last connection")
 		offset := 0
 		if c.listUUID {
 			offset++
@@ -290,7 +290,7 @@ func (c *modelsCommand) formatTabular(writer io.Writer, value interface{}) error
 		tw.SetColumnAlignRight(3 + offset)
 		tw.SetColumnAlignRight(4 + offset)
 	} else {
-		w.Println("OWNER", "STATUS", "ACCESS", "LAST CONNECTION")
+		w.Println("Owner", "Status", "Access", "Last connection")
 	}
 	for _, model := range modelSet.Models {
 		owner := names.NewUserTag(model.Owner)

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -150,9 +150,9 @@ func (s *ModelsSuite) TestModelsOwner(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.user, gc.Equals, "admin")
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"CONTROLLER: fake\n"+
+		"Controller: fake\n"+
 		"\n"+
-		"MODEL                        OWNER            STATUS      ACCESS  LAST CONNECTION\n"+
+		"Model                        Owner            Status      Access  Last connection\n"+
 		"test-model1*                 admin            active      read    2015-03-20\n"+
 		"carlotta/test-model2         carlotta         active      write   2015-03-01\n"+
 		"daiwik@external/test-model3  daiwik@external  destroying          never connected\n"+
@@ -164,9 +164,9 @@ func (s *ModelsSuite) TestModelsNonOwner(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.user, gc.Equals, "bob")
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"CONTROLLER: fake\n"+
+		"Controller: fake\n"+
 		"\n"+
-		"MODEL                        OWNER            STATUS      ACCESS  LAST CONNECTION\n"+
+		"Model                        Owner            Status      Access  Last connection\n"+
 		"admin/test-model1*           admin            active      read    2015-03-20\n"+
 		"carlotta/test-model2         carlotta         active      write   2015-03-01\n"+
 		"daiwik@external/test-model3  daiwik@external  destroying          never connected\n"+
@@ -178,9 +178,9 @@ func (s *ModelsSuite) TestAllModels(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.all, jc.IsTrue)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"CONTROLLER: fake\n"+
+		"Controller: fake\n"+
 		"\n"+
-		"MODEL                        OWNER            STATUS      ACCESS  LAST CONNECTION\n"+
+		"Model                        Owner            Status      Access  Last connection\n"+
 		"admin/test-model1*           admin            active      read    2015-03-20\n"+
 		"carlotta/test-model2         carlotta         active      write   2015-03-01\n"+
 		"daiwik@external/test-model3  daiwik@external  destroying          never connected\n"+
@@ -192,9 +192,9 @@ func (s *ModelsSuite) TestAllModelsNoneCurrent(c *gc.C) {
 	context, err := testing.RunCommand(c, s.newCommand())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"CONTROLLER: fake\n"+
+		"Controller: fake\n"+
 		"\n"+
-		"MODEL                        OWNER            STATUS      ACCESS  LAST CONNECTION\n"+
+		"Model                        Owner            Status      Access  Last connection\n"+
 		"test-model1                  admin            active      read    2015-03-20\n"+
 		"carlotta/test-model2         carlotta         active      write   2015-03-01\n"+
 		"daiwik@external/test-model3  daiwik@external  destroying          never connected\n"+
@@ -207,9 +207,9 @@ func (s *ModelsSuite) TestModelsUUID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.user, gc.Equals, "admin")
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"CONTROLLER: fake\n"+
+		"Controller: fake\n"+
 		"\n"+
-		"MODEL                        UUID              OWNER            STATUS      MACHINES  CORES  ACCESS  LAST CONNECTION\n"+
+		"Model                        UUID              Owner            Status      Machines  Cores  Access  Last connection\n"+
 		"test-model1*                 test-model1-UUID  admin            active             2      1  read    2015-03-20\n"+
 		"carlotta/test-model2         test-model2-UUID  carlotta         active             0      -  write   2015-03-01\n"+
 		"daiwik@external/test-model3  test-model3-UUID  daiwik@external  destroying         0      -          never connected\n"+
@@ -222,9 +222,9 @@ func (s *ModelsSuite) TestModelsMachineInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.user, gc.Equals, "admin")
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"CONTROLLER: fake\n"+
+		"Controller: fake\n"+
 		"\n"+
-		"MODEL                        OWNER            STATUS      MACHINES  CORES  ACCESS  LAST CONNECTION\n"+
+		"Model                        Owner            Status      Machines  Cores  Access  Last connection\n"+
 		"test-model1*                 admin            active             2      1  read    2015-03-20\n"+
 		"carlotta/test-model2         carlotta         active             0      -  write   2015-03-01\n"+
 		"daiwik@external/test-model3  daiwik@external  destroying         0      -          never connected\n"+

--- a/cmd/juju/machine/list_test.go
+++ b/cmd/juju/machine/list_test.go
@@ -79,7 +79,7 @@ func (s *MachineListCommandSuite) TestMachine(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineListCommand())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"MACHINE  STATE    DNS       INS-ID               SERIES  AZ\n"+
+		"Machine  State    DNS       Inst id              Series  AZ\n"+
 		"0        started  10.0.0.1  juju-badd06-0        trusty  us-east-1\n"+
 		"1        started  10.0.0.2  juju-badd06-1        trusty  \n"+
 		"1/lxd/0  pending  10.0.0.3  juju-badd06-1-lxd-0  trusty  \n"+

--- a/cmd/juju/machine/show_test.go
+++ b/cmd/juju/machine/show_test.go
@@ -72,7 +72,7 @@ func (s *MachineShowCommandSuite) TestShowTabularMachine(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineShowCommand(), "--format", "tabular", "0", "1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"MACHINE  STATE    DNS       INS-ID               SERIES  AZ\n"+
+		"Machine  State    DNS       Inst id              Series  AZ\n"+
 		"0        started  10.0.0.1  juju-badd06-0        trusty  us-east-1\n"+
 		"1        started  10.0.0.2  juju-badd06-1        trusty  \n"+
 		"1/lxd/0  pending  10.0.0.3  juju-badd06-1-lxd-0  trusty  \n"+

--- a/cmd/juju/model/configcommand.go
+++ b/cmd/juju/model/configcommand.go
@@ -268,7 +268,7 @@ func formatConfigTabular(writer io.Writer, value interface{}) error {
 		valueNames = append(valueNames, name)
 	}
 	sort.Strings(valueNames)
-	w.Println("ATTRIBUTE", "FROM", "VALUE")
+	w.Println("Attribute", "From", "Value")
 
 	for _, name := range valueNames {
 		info := configValues[name]

--- a/cmd/juju/model/configcommand_test.go
+++ b/cmd/juju/model/configcommand_test.go
@@ -136,7 +136,7 @@ func (s *ConfigCommandSuite) TestAllValuesTabular(c *gc.C) {
 
 	output := testing.Stdout(context)
 	expected := "" +
-		"ATTRIBUTE  FROM   VALUE\n" +
+		"Attribute  From   Value\n" +
 		"running    model  true\n" +
 		"special    model  special value\n" +
 		"\n"

--- a/cmd/juju/romulus/listplans/list_plans.go
+++ b/cmd/juju/romulus/listplans/list_plans.go
@@ -169,7 +169,7 @@ func formatSummary(writer io.Writer, value interface{}) error {
 		}
 		fmt.Fprintln(tw)
 	}
-	p("PLAN", "PRICE")
+	p("Plan", "Price")
 	for _, plan := range plans {
 		p(plan.URL, plan.Price)
 	}
@@ -188,7 +188,7 @@ func formatTabular(writer io.Writer, value interface{}) error {
 	table.MaxColWidth = 50
 	table.Wrap = true
 
-	table.AddRow("PLAN", "PRICE", "DESCRIPTION")
+	table.AddRow("Plan", "Price", "Description")
 	for _, plan := range plans {
 		table.AddRow(plan.URL, plan.Price, plan.Description)
 	}

--- a/cmd/juju/romulus/listplans/list_plans_test.go
+++ b/cmd/juju/romulus/listplans/list_plans_test.go
@@ -70,7 +70,7 @@ func (s *ListPlansCommandSuite) TestTabularOutput(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, listPlans, "some-charm-url")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals,
-		`PLAN             	PRICE	DESCRIPTION                                       
+		`Plan             	Price	Description                                       
 bob/test-plan-1  	     	Lorem ipsum dolor sit amet,                       
                  	     	consectetur adipiscing elit.                      
                  	     	Nunc pretium purus nec magna faucibus, sed        

--- a/cmd/juju/space/list.go
+++ b/cmd/juju/space/list.go
@@ -146,7 +146,7 @@ func (c *listCommand) printTabular(writer io.Writer, value interface{}) error {
 		if !ok {
 			return errors.New("unexpected value")
 		}
-		fmt.Fprintf(tw, "SPACE\n")
+		fmt.Fprintln(tw, "Space")
 		spaces := list.Spaces
 		sort.Strings(spaces)
 		for _, space := range spaces {
@@ -158,7 +158,7 @@ func (c *listCommand) printTabular(writer io.Writer, value interface{}) error {
 			return errors.New("unexpected value")
 		}
 
-		fmt.Fprintf(tw, "%s\t%s\n", "SPACE", "SUBNETS")
+		fmt.Fprintf(tw, "%s\t%s\n", "Space", "Subnets")
 		spaces := []string{}
 		for name, _ := range list.Spaces {
 			spaces = append(spaces, name)

--- a/cmd/juju/space/list_test.go
+++ b/cmd/juju/space/list_test.go
@@ -179,14 +179,14 @@ spaces:
 }
 `, "") + "\n"
 
-	expectedTabular := `SPACE   SUBNETS
+	expectedTabular := `Space   Subnets
 space1  2001:db8::/32
         invalid
 space2  10.1.2.0/24
         4.3.2.0/28
 
 `
-	expectedShortTabular := `SPACE
+	expectedShortTabular := `Space
 space1
 space2
 

--- a/cmd/juju/status/output_summary.go
+++ b/cmd/juju/status/output_summary.go
@@ -48,15 +48,15 @@ func FormatSummary(writer io.Writer, value interface{}) error {
 
 	// Right align summary information
 	f.tw.Init(writer, 0, 1, 2, ' ', tabwriter.AlignRight)
-	p("# MACHINES:", fmt.Sprintf("(%d)", len(fs.Machines)))
+	p("# Machines:", fmt.Sprintf("(%d)", len(fs.Machines)))
 	f.printStateToCount(stateToMachine)
 	p(" ")
 
-	p("# UNITS:", fmt.Sprintf("(%d)", f.numUnits))
+	p("# Units:", fmt.Sprintf("(%d)", f.numUnits))
 	f.printStateToCount(f.stateToUnit)
 	p(" ")
 
-	p("# APPLICATIONS:", fmt.Sprintf("(%d)", len(fs.Applications)))
+	p("# Applications:", fmt.Sprintf("(%d)", len(fs.Applications)))
 	for _, svcName := range utils.SortStringsNaturally(stringKeysFromMap(svcExposure)) {
 		s := svcExposure[svcName]
 		p(svcName, fmt.Sprintf("%d/%d\texposed", s[true], s[true]+s[false]))

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -105,11 +105,11 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		cloudRegion += "/" + fs.Model.CloudRegion
 	}
 
-	header := []interface{}{"MODEL", "CONTROLLER", "CLOUD/REGION", "VERSION"}
+	header := []interface{}{"Model", "Controller", "Cloud/Region", "Version"}
 	values := []interface{}{fs.Model.Name, fs.Model.Controller, cloudRegion, fs.Model.Version}
 	message := getModelMessage(fs.Model)
 	if message != "" {
-		header = append(header, "NOTES")
+		header = append(header, "Notes")
 		values = append(values, message)
 	}
 
@@ -120,7 +120,7 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	units := make(map[string]unitStatus)
 	metering := false
 	relations := newRelationFormatter()
-	outputHeaders("APP", "VERSION", "STATUS", "SCALE", "CHARM", "STORE", "REV", "OS", "NOTES")
+	outputHeaders("App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Notes")
 	tw.SetColumnAlignRight(3)
 	tw.SetColumnAlignRight(6)
 	for _, appName := range utils.SortStringsNaturally(stringKeysFromMap(fs.Applications)) {
@@ -191,7 +191,7 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		)
 	}
 
-	outputHeaders("UNIT", "WORKLOAD", "AGENT", "MACHINE", "PUBLIC-ADDRESS", "PORTS", "MESSAGE")
+	outputHeaders("Unit", "Workload", "Agent", "Machine", "Public address", "Ports", "Message")
 	for _, name := range utils.SortStringsNaturally(stringKeysFromMap(units)) {
 		u := units[name]
 		pUnit(name, u, 0)
@@ -200,7 +200,7 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	}
 
 	if metering {
-		outputHeaders("METER", "STATUS", "MESSAGE")
+		outputHeaders("Meter", "Status", "Message")
 		for _, name := range utils.SortStringsNaturally(stringKeysFromMap(units)) {
 			u := units[name]
 			if u.MeterStatus != nil {
@@ -213,7 +213,7 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	printMachines(tw, fs.Machines)
 
 	if relations.len() > 0 {
-		outputHeaders("RELATION", "PROVIDES", "CONSUMES", "TYPE")
+		outputHeaders("Relation", "Provides", "Consumes", "Type")
 		for _, k := range relations.sorted() {
 			r := relations.get(k)
 			if r != nil {
@@ -240,7 +240,7 @@ func getModelMessage(model modelStatus) string {
 
 func printMachines(tw *ansiterm.TabWriter, machines map[string]machineStatus) {
 	w := output.Wrapper{tw}
-	w.Println("MACHINE", "STATE", "DNS", "INS-ID", "SERIES", "AZ")
+	w.Println("Machine", "State", "DNS", "Inst id", "Series", "AZ")
 	for _, name := range utils.SortStringsNaturally(stringKeysFromMap(machines)) {
 		printMachine(w, machines[name])
 	}

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -65,9 +65,9 @@ The available output formats are:
       address and agent status are listed.
 - summary: Displays the subnet(s) and port(s) the model utilises. Also displays
       aggregate information about:
-      - MACHINES: total #, and # in each state.
-      - UNITS: total #, and # in each state.
-      - APPLICATIONS: total #, and # exposed of each application.
+      - Machines: total #, and # in each state.
+      - Units: total #, and # in each state.
+      - Applications: total #, and # exposed of each application.
 - yaml: Displays information about the model, machines, applications, and units
       in structured YAML format.
 - json: Displays information about the model, machines, applications, and units

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3239,14 +3239,14 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 
 func (s *StatusSuite) TestMigrationInProgressTabular(c *gc.C) {
 	expected := `
-MODEL   CONTROLLER  CLOUD/REGION        VERSION  NOTES
+Model   Controller  Cloud/Region        Version  Notes
 hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar
 
-APP  VERSION  STATUS  SCALE  CHARM  STORE  REV  OS  NOTES
+App  Version  Status  Scale  Charm  Store  Rev  OS  Notes
 
-UNIT  WORKLOAD  AGENT  MACHINE  PUBLIC-ADDRESS  PORTS  MESSAGE
+Unit  Workload  Agent  Machine  Public address  Ports  Message
 
-MACHINE  STATE  DNS  INS-ID  SERIES  AZ
+Machine  State  DNS  Inst id  Series  AZ
 
 `[1:]
 
@@ -3260,14 +3260,14 @@ MACHINE  STATE  DNS  INS-ID  SERIES  AZ
 
 func (s *StatusSuite) TestMigrationInProgressAndUpgradeAvailable(c *gc.C) {
 	expected := `
-MODEL   CONTROLLER  CLOUD/REGION        VERSION  NOTES
+Model   Controller  Cloud/Region        Version  Notes
 hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar
 
-APP  VERSION  STATUS  SCALE  CHARM  STORE  REV  OS  NOTES
+App  Version  Status  Scale  Charm  Store  Rev  OS  Notes
 
-UNIT  WORKLOAD  AGENT  MACHINE  PUBLIC-ADDRESS  PORTS  MESSAGE
+Unit  Workload  Agent  Machine  Public address  Ports  Message
 
-MACHINE  STATE  DNS  INS-ID  SERIES  AZ
+Machine  State  DNS  Inst id  Series  AZ
 
 `[1:]
 
@@ -3377,14 +3377,14 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 	c.Assert(string(stdout), gc.Equals, `
 Running on subnets:  127.0.0.1/8, 10.0.0.1/8  
  Utilizing ports:                             
-      # MACHINES:  (3)
+      # Machines:  (3)
          started:   3 
                  
-         # UNITS:  (4)
+         # Units:  (4)
           active:   3 
            error:   1 
                  
-  # APPLICATIONS:  (3)
+  # Applications:  (3)
           logging  1/1  exposed
             mysql  1/1  exposed
         wordpress  1/1  exposed
@@ -3538,26 +3538,26 @@ func (s *StatusSuite) testStatusWithFormatTabular(c *gc.C, useFeatureFlag bool) 
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	expected := `
-MODEL       CONTROLLER  CLOUD/REGION        VERSION  NOTES
+Model       Controller  Cloud/Region        Version  Notes
 controller  kontroll    dummy/dummy-region  1.2.3    upgrade available: 1.2.4
 
-APP        VERSION          STATUS       SCALE  CHARM      STORE       REV  OS      NOTES
+App        Version          Status       Scale  Charm      Store       Rev  OS      Notes
 logging    a bit too lo...  error            2  logging    jujucharms    1  ubuntu  exposed
 mysql      5.7.13           maintenance      1  mysql      jujucharms    1  ubuntu  exposed
 wordpress  4.5.3            active           1  wordpress  jujucharms    3  ubuntu  exposed
 
-UNIT          WORKLOAD     AGENT  MACHINE  PUBLIC-ADDRESS    PORTS  MESSAGE
+Unit          Workload     Agent  Machine  Public address    Ports  Message
 mysql/0*      maintenance  idle   2        controller-2.dns         installing all the things
   logging/1*  error        idle            controller-2.dns         somehow lost in all those logs
 wordpress/0*  active       idle   1        controller-1.dns         
   logging/0   active       idle            controller-1.dns         
 
-MACHINE  STATE    DNS               INS-ID        SERIES   AZ
+Machine  State    DNS               Inst id       Series   AZ
 0        started  controller-0.dns  controller-0  quantal  us-east-1a
 1        started  controller-1.dns  controller-1  quantal  
 2        started  controller-2.dns  controller-2  quantal  
 
-RELATION           PROVIDES   CONSUMES   TYPE
+Relation           Provides   Consumes   Type
 juju-info          logging    mysql      regular
 logging-dir        logging    wordpress  regular
 info               mysql      logging    subordinate
@@ -3605,17 +3605,17 @@ func (s *StatusSuite) TestFormatTabularHookActionName(c *gc.C) {
 	err := FormatTabular(out, false, status)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out.String(), gc.Equals, `
-MODEL  CONTROLLER  CLOUD/REGION  VERSION
+Model  Controller  Cloud/Region  Version
                                  
 
-APP  VERSION  STATUS  SCALE  CHARM  STORE  REV  OS  NOTES
+App  Version  Status  Scale  Charm  Store  Rev  OS  Notes
 foo                       2                  0      
 
-UNIT   WORKLOAD     AGENT      MACHINE  PUBLIC-ADDRESS  PORTS  MESSAGE
+Unit   Workload     Agent      Machine  Public address  Ports  Message
 foo/0  maintenance  executing                                  (config-changed) doing some work
 foo/1  maintenance  executing                                  (backup database) doing some work
 
-MACHINE  STATE  DNS  INS-ID  SERIES  AZ
+Machine  State  DNS  Inst id  Series  AZ
 `[1:])
 }
 
@@ -3640,8 +3640,8 @@ func (s *StatusSuite) TestFormatTabularConsistentPeerRelationName(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	sections, err := splitTableSections(out.Bytes())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sections["RELATION"], gc.DeepEquals, []string{
-		"RELATION    PROVIDES  CONSUMES  TYPE",
+	c.Assert(sections["Relation"], gc.DeepEquals, []string{
+		"Relation    Provides  Consumes  Type",
 		"replicator  foo       foo       peer",
 	})
 }
@@ -3699,21 +3699,21 @@ func (s *StatusSuite) TestFormatTabularMetering(c *gc.C) {
 	err := FormatTabular(out, false, status)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out.String(), gc.Equals, `
-MODEL  CONTROLLER  CLOUD/REGION  VERSION
+Model  Controller  Cloud/Region  Version
                                  
 
-APP  VERSION  STATUS  SCALE  CHARM  STORE  REV  OS  NOTES
+App  Version  Status  Scale  Charm  Store  Rev  OS  Notes
 foo                     0/2                  0      
 
-UNIT   WORKLOAD  AGENT  MACHINE  PUBLIC-ADDRESS  PORTS  MESSAGE
+Unit   Workload  Agent  Machine  Public address  Ports  Message
 foo/0                                                   
 foo/1                                                   
 
-METER  STATUS   MESSAGE
+Meter  Status   Message
 foo/0  strange  warning: stable strangelets
 foo/1  up       things are looking up
 
-MACHINE  STATE  DNS  INS-ID  SERIES  AZ
+Machine  State  DNS  Inst id  Series  AZ
 `[1:])
 }
 

--- a/cmd/juju/storage/filesystemlist_test.go
+++ b/cmd/juju/storage/filesystemlist_test.go
@@ -88,7 +88,7 @@ func (s *ListSuite) TestFilesystemListWithErrorResults(c *gc.C) {
 }
 
 var expectedFilesystemListTabular = `
-MACHINE  UNIT         STORAGE      ID   VOLUME  PROVIDER-ID                       MOUNTPOINT  SIZE    STATE      MESSAGE
+Machine  Unit         Storage      Id   Volume  Provider id                       Mountpoint  Size    State      Message
 0        abc/0        db-dir/1001  0/0  0/1     provider-supplied-filesystem-0-0  /mnt/fuji   512MiB  attached   
 0        transcode/0  shared-fs/0  4            provider-supplied-filesystem-4    /mnt/doom   1.0GiB  attached   
 0                                  1            provider-supplied-filesystem-1                2.0GiB  attaching  failed to attach, will retry

--- a/cmd/juju/storage/filesystemlistformatters.go
+++ b/cmd/juju/storage/filesystemlistformatters.go
@@ -20,7 +20,7 @@ func formatFilesystemListTabular(writer io.Writer, infos map[string]FilesystemIn
 	print := func(values ...string) {
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
 	}
-	print("MACHINE", "UNIT", "STORAGE", "ID", "VOLUME", "PROVIDER-ID", "MOUNTPOINT", "SIZE", "STATE", "MESSAGE")
+	print("Machine", "Unit", "Storage", "Id", "Volume", "Provider id", "Mountpoint", "Size", "State", "Message")
 
 	filesystemAttachmentInfos := make(filesystemAttachmentInfos, 0, len(infos))
 	for filesystemId, info := range infos {

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -41,7 +41,7 @@ func (s *ListSuite) TestList(c *gc.C) {
 		// Default format is tabular
 		`
 \[Storage\]     
-UNIT          ID           LOCATION  STATUS    MESSAGE  
+Unit          Id           Location  Status    Message  
 postgresql/0  db-dir/1100  hither    attached           
 transcode/0   db-dir/1000  thither   pending            
 transcode/0   shared-fs/0  there     attached           
@@ -98,7 +98,7 @@ func (s *ListSuite) TestListOwnerStorageIdSort(c *gc.C) {
 		// Default format is tabular
 		`
 \[Storage\]     
-UNIT          ID           LOCATION  STATUS    MESSAGE  
+Unit          Id           Location  Status    Message  
 postgresql/0  db-dir/1100  hither    attached           
 transcode/0   db-dir/1000  thither   pending            
 transcode/0   shared-fs/0  there     attached           

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -23,7 +23,7 @@ func formatStorageListTabular(writer io.Writer, storageInfo map[string]StorageIn
 		fmt.Fprintln(tw)
 	}
 	p("[Storage]")
-	p("UNIT\tID\tLOCATION\tSTATUS\tMESSAGE")
+	p("Unit\tId\tLocation\tStatus\tMessage")
 
 	byUnit := make(map[string]map[string]storageAttachmentInfo)
 	for storageId, storageInfo := range storageInfo {

--- a/cmd/juju/storage/poollist_test.go
+++ b/cmd/juju/storage/poollist_test.go
@@ -84,7 +84,7 @@ func (s *poolListSuite) TestPoolListTabular(c *gc.C) {
 			"--name", "xyz", "--name", "abc",
 			"--format", "tabular"},
 		`
-NAME       PROVIDER  ATTRS
+Name       Provider  Attrs
 abc        testType  key=value one=1 two=2
 testName0  a         key=value one=1 two=2
 testName1  b         key=value one=1 two=2
@@ -102,7 +102,7 @@ func (s *poolListSuite) TestPoolListTabularSortedWithAttrs(c *gc.C) {
 		[]string{"--name", "myaw", "--name", "xyz", "--name", "abc",
 			"--format", "tabular"},
 		`
-NAME  PROVIDER  ATTRS
+Name  Provider  Attrs
 abc   testType  a=true b=maybe c=well
 myaw  testType  a=true b=maybe c=well
 xyz   testType  a=true b=maybe c=well

--- a/cmd/juju/storage/poollistformatters.go
+++ b/cmd/juju/storage/poollistformatters.go
@@ -31,7 +31,7 @@ func formatPoolsTabular(writer io.Writer, pools map[string]PoolInfo) {
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
 	}
 
-	print("NAME", "PROVIDER", "ATTRS")
+	print("Name", "Provider", "Attrs")
 
 	poolNames := make([]string, 0, len(pools))
 	for name := range pools {

--- a/cmd/juju/storage/volumelist_test.go
+++ b/cmd/juju/storage/volumelist_test.go
@@ -89,7 +89,7 @@ func (s *ListSuite) TestVolumeListWithErrorResults(c *gc.C) {
 }
 
 var expectedVolumeListTabular = `
-MACHINE  UNIT         STORAGE      ID   PROVIDER-ID                   DEVICE  SIZE    STATE      MESSAGE
+Machine  Unit         Storage      Id   Provider Id                   Device  Size    State      Message
 0        abc/0        db-dir/1001  0/0  provider-supplied-volume-0-0  loop0   512MiB  attached   
 0        transcode/0  shared-fs/0  4    provider-supplied-volume-4    xvdf2   1.0GiB  attached   
 0                                  1    provider-supplied-volume-1            2.0GiB  attaching  failed to attach, will retry

--- a/cmd/juju/storage/volumelistformatters.go
+++ b/cmd/juju/storage/volumelistformatters.go
@@ -20,7 +20,7 @@ func formatVolumeListTabular(writer io.Writer, infos map[string]VolumeInfo) erro
 	print := func(values ...string) {
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
 	}
-	print("MACHINE", "UNIT", "STORAGE", "ID", "PROVIDER-ID", "DEVICE", "SIZE", "STATE", "MESSAGE")
+	print("Machine", "Unit", "Storage", "Id", "Provider Id", "Device", "Size", "State", "Message")
 
 	volumeAttachmentInfos := make(volumeAttachmentInfos, 0, len(infos))
 	for volumeId, info := range infos {

--- a/cmd/juju/user/list.go
+++ b/cmd/juju/user/list.go
@@ -191,7 +191,7 @@ func (c *listCommand) formatModelUsers(writer io.Writer, value interface{}) erro
 	}
 	tw := output.TabWriter(writer)
 	w := output.Wrapper{tw}
-	w.Println("NAME", "DISPLAY NAME", "ACCESS", "LAST CONNECTION")
+	w.Println("Name", "Display name", "Access", "Last connection")
 	for _, name := range modelUsers.SortedValues() {
 		user := users[name]
 
@@ -216,9 +216,9 @@ func (c *listCommand) formatControllerUsers(writer io.Writer, value interface{})
 
 	tw := output.TabWriter(writer)
 	w := output.Wrapper{tw}
-	w.Println("CONTROLLER: " + c.ControllerName())
+	w.Println("Controller: " + c.ControllerName())
 	w.Println()
-	w.Println("NAME", "DISPLAY NAME", "ACCESS", "DATE CREATED", "LAST CONNECTION")
+	w.Println("Name", "Display name", "Access", "Date created", "Last connection")
 	for _, user := range users {
 		conn := user.LastConnection
 		if user.Disabled {

--- a/cmd/juju/user/list_test.go
+++ b/cmd/juju/user/list_test.go
@@ -126,8 +126,8 @@ func (s *UserListCommandSuite) TestUserInfo(c *gc.C) {
 	context, err := testing.RunCommand(c, s.newUserListCommand())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"CONTROLLER: testing\n\n"+
-		"NAME     DISPLAY NAME    ACCESS     DATE CREATED  LAST CONNECTION\n"+
+		"Controller: testing\n\n"+
+		"Name     Display name    Access     Date created  Last connection\n"+
 		"adam*    Adam Zulu       login      2012-10-08    2014-01-01\n"+
 		"barbara  Barbara Yellow  addmodel   2013-05-02    just now\n"+
 		"charlie  Charlie Xavier  superuser  6 hours ago   never connected\n"+
@@ -138,8 +138,8 @@ func (s *UserListCommandSuite) TestUserInfoWithDisabled(c *gc.C) {
 	context, err := testing.RunCommand(c, s.newUserListCommand(), "--all")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"CONTROLLER: testing\n\n"+
-		"NAME     DISPLAY NAME    ACCESS     DATE CREATED  LAST CONNECTION\n"+
+		"Controller: testing\n\n"+
+		"Name     Display name    Access     Date created  Last connection\n"+
 		"adam*    Adam Zulu       login      2012-10-08    2014-01-01\n"+
 		"barbara  Barbara Yellow  addmodel   2013-05-02    just now\n"+
 		"charlie  Charlie Xavier  superuser  6 hours ago   never connected\n"+
@@ -151,8 +151,8 @@ func (s *UserListCommandSuite) TestUserInfoExactTime(c *gc.C) {
 	context, err := testing.RunCommand(c, s.newUserListCommand(), "--exact-time")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"CONTROLLER: testing\n\n"+
-		"NAME     DISPLAY NAME    ACCESS     DATE CREATED                   LAST CONNECTION\n"+
+		"Controller: testing\n\n"+
+		"Name     Display name    Access     Date created                   Last connection\n"+
 		"adam*    Adam Zulu       login      2012-10-08 00:00:00 +0000 UTC  2014-01-01 00:00:00 +0000 UTC\n"+
 		"barbara  Barbara Yellow  addmodel   2013-05-02 00:00:00 +0000 UTC  2016-09-15 12:00:00 +0000 UTC\n"+
 		"charlie  Charlie Xavier  superuser  2016-09-15 06:00:00 +0000 UTC  never connected\n"+
@@ -194,7 +194,7 @@ func (s *UserListCommandSuite) TestModelUsers(c *gc.C) {
 	context, err := testing.RunCommand(c, s.newUserListCommand(), "admin")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"NAME                DISPLAY NAME  ACCESS  LAST CONNECTION\n"+
+		"Name                Display name  Access  Last connection\n"+
 		"adam*               Adam          read    2015-03-01\n"+
 		"admin                             write   2015-03-20\n"+
 		"charlie@ubuntu.com  Charlie       read    never connected\n"+

--- a/cmd/plugins/juju-metadata/listformatter.go
+++ b/cmd/plugins/juju-metadata/listformatter.go
@@ -27,7 +27,7 @@ func formatMetadataTabular(writer io.Writer, metadata []MetadataInfo) {
 	print := func(values ...string) {
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
 	}
-	print("SOURCE", "SERIES", "ARCH", "REGION", "IMAGE-ID", "STREAM", "VIRT-TYPE", "STORAGE-TYPE")
+	print("Source", "Series", "Arch", "Region", "Image id", "Stream", "Virt Type", "Storage Type")
 
 	for _, m := range metadata {
 		print(m.Source, m.Series, m.Arch, m.Region, m.ImageId, m.Stream, m.VirtType, m.RootStorageType)

--- a/cmd/plugins/juju-metadata/listimages_test.go
+++ b/cmd/plugins/juju-metadata/listimages_test.go
@@ -64,7 +64,7 @@ func runList(c *gc.C, args []string) (*cmd.Context, error) {
 func (s *ListSuite) TestListDefault(c *gc.C) {
 	// Default format is tabular
 	s.assertValidList(c, `
-SOURCE  SERIES  ARCH   REGION  IMAGE-ID  STREAM    VIRT-TYPE  STORAGE-TYPE
+Source  Series  Arch   Region  Image id  Stream    Virt Type  Storage Type
 custom  vivid   amd64  asia    im-21     released  kvm        ebs
 custom  vivid   amd64  europe  im-21     released  kvm        ebs
 custom  vivid   amd64  us      im-21     released  kvm        ebs

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -74,7 +74,7 @@ func (s *cmdControllerSuite) TestControllerListCommand(c *gc.C) {
 	expectedOutput := `
 Use --refresh to see the latest information.
 
-CONTROLLER  MODEL       USER   ACCESS     CLOUD/REGION        MODELS  MACHINES  HA  VERSION
+Controller  Model       User   Access     Cloud/Region        Models  Machines  HA  Version
 kontroll*   controller  admin  superuser  dummy/dummy-region       -         -   -  (unknown)  
 
 `[1:]
@@ -85,9 +85,9 @@ func (s *cmdControllerSuite) TestCreateModelAdminUser(c *gc.C) {
 	s.createModelAdminUser(c, "new-model", false)
 	context := s.run(c, "list-models")
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"CONTROLLER: kontroll\n"+
+		"Controller: kontroll\n"+
 		"\n"+
-		"MODEL        OWNER  STATUS     ACCESS  LAST CONNECTION\n"+
+		"Model        Owner  Status     Access  Last connection\n"+
 		"controller*  admin  available  admin   just now\n"+
 		"new-model    admin  available  admin   never connected\n"+
 		"\n")
@@ -97,9 +97,9 @@ func (s *cmdControllerSuite) TestAddModelNormalUser(c *gc.C) {
 	s.createModelNormalUser(c, "new-model", false)
 	context := s.run(c, "list-models", "--all")
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"CONTROLLER: kontroll\n"+
+		"Controller: kontroll\n"+
 		"\n"+
-		"MODEL              OWNER  STATUS     ACCESS  LAST CONNECTION\n"+
+		"Model              Owner  Status     Access  Last connection\n"+
 		"admin/controller*  admin  available  admin   just now\n"+
 		"test/new-model     test   available          never connected\n"+
 		"\n")
@@ -160,9 +160,9 @@ func (s *cmdControllerSuite) TestListDeadModels(c *gc.C) {
 	// don't exist, and they will go away quickly.
 	context := s.run(c, "list-models")
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"CONTROLLER: kontroll\n"+
+		"Controller: kontroll\n"+
 		"\n"+
-		"MODEL        OWNER  STATUS      ACCESS  LAST CONNECTION\n"+
+		"Model        Owner  Status      Access  Last connection\n"+
 		"controller*  admin  available   admin   just now\n"+
 		"new-model    admin  destroying  admin   never connected\n"+
 		"\n")

--- a/featuretests/cmd_juju_model_test.go
+++ b/featuretests/cmd_juju_model_test.go
@@ -99,7 +99,7 @@ func (s *cmdModelSuite) TestModelUsersCmd(c *gc.C) {
 	context = s.run(c, "list-users", "controller")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"NAME           DISPLAY NAME  ACCESS  LAST CONNECTION\n"+
+		"Name           Display name  Access  Last connection\n"+
 		"admin*         admin         admin   just now\n"+
 		"bar@ubuntuone                read    never connected\n"+
 		"\n")

--- a/featuretests/cmd_juju_user_test.go
+++ b/featuretests/cmd_juju_user_test.go
@@ -121,9 +121,9 @@ func (s *UserSuite) TestUserList(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	periodPattern := `(just now|\d+ \S+ ago)`
 	expected := fmt.Sprintf(`
-CONTROLLER: kontroll
+Controller: kontroll
 
-NAME\s+DISPLAY NAME\s+ACCESS\s+DATE CREATED\s+LAST CONNECTION
+Name\s+Display name\s+Access\s+Date created\s+Last connection
 admin.*\s+admin\s+superuser\s+%s\s+%s
 
 `[1:], periodPattern, periodPattern)

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -126,7 +126,7 @@ func (s *cmdStorageSuite) TestStorageList(c *gc.C) {
 
 	expected := `
 [Storage]        
-UNIT             ID      LOCATION  STATUS   MESSAGE  
+Unit             Id      Location  Status   Message  
 storage-block/0  data/0            pending           
 
 `[1:]
@@ -140,7 +140,7 @@ func (s *cmdStorageSuite) TestStorageListPersistent(c *gc.C) {
 	// will be persistent until it has been provisioned.
 	expected := `
 [Storage]        
-UNIT             ID      LOCATION  STATUS   MESSAGE  
+Unit             Id      Location  Status   Message  
 storage-block/0  data/0            pending           
 
 `[1:]
@@ -250,7 +250,7 @@ func (s *cmdStorageSuite) TestListPoolsTabular(c *gc.C) {
 	stdout, _, err := runPoolList(c)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := `
-NAME                 PROVIDER             ATTRS
+Name                 Provider             Attrs
 block                loop                 it=works
 environscoped        environscoped        
 environscoped-block  environscoped-block  
@@ -443,7 +443,7 @@ func (s *cmdStorageSuite) TestListVolumeTabularFilterMatch(c *gc.C) {
 	stdout, _, err := runVolumeList(c, "0")
 	c.Assert(err, jc.ErrorIsNil)
 	expected := `
-MACHINE  UNIT             STORAGE  ID   PROVIDER-ID  DEVICE  SIZE  STATE    MESSAGE
+Machine  Unit             Storage  Id   Provider Id  Device  Size  State    Message
 0        storage-block/0  data/0   0/0                             pending  
 
 `[1:]
@@ -548,7 +548,7 @@ func (s *cmdStorageSuite) TestStorageAddToUnitHasVolumes(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, `
 [Storage]             
-UNIT                  ID      LOCATION  STATUS   MESSAGE  
+Unit                  Id      Location  Status   Message  
 storage-filesystem/0  data/0            pending           
 
 `[1:])
@@ -571,7 +571,7 @@ storage-filesystem/0  data/0            pending
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, `
 [Storage]             
-UNIT                  ID      LOCATION  STATUS   MESSAGE  
+Unit                  Id      Location  Status   Message  
 storage-filesystem/0  data/0            pending           
 storage-filesystem/0  data/1            pending           
 

--- a/payload/status/list_test.go
+++ b/payload/status/list_test.go
@@ -82,7 +82,7 @@ func (s *listSuite) TestOkay(c *gc.C) {
 
 	c.Check(stdout, gc.Equals, `
 [Unit Payloads]
-UNIT                   MACHINE  PAYLOAD-CLASS  STATUS   TYPE    ID      TAGS   
+Unit                   Machine  Payload class  Status   Type    Id      Tags   
 a-application/0        1        spam           running  docker  idspam  a-tag  
 another-application/1  2        eggs           running  docker  ideggs         
 
@@ -117,7 +117,7 @@ func (s *listSuite) TestPatternsOkay(c *gc.C) {
 
 	c.Check(stdout, gc.Equals, `
 [Unit Payloads]
-UNIT                   MACHINE  PAYLOAD-CLASS  STATUS   TYPE    ID      TAGS   
+Unit                   Machine  Payload class  Status   Type    Id      Tags   
 a-application/0        1        spam           running  docker  idspam  a-tag  
 another-application/1  2        eggs           running  docker  ideggs  a-tag  
 
@@ -154,7 +154,7 @@ func (s *listSuite) TestOutputFormats(c *gc.C) {
 	formats := map[string]string{
 		"tabular": `
 [Unit Payloads]
-UNIT                   MACHINE  PAYLOAD-CLASS  STATUS   TYPE    ID      TAGS   
+Unit                   Machine  Payload class  Status   Type    Id      Tags   
 a-application/0        1        spam           running  docker  idspam  a-tag  
 another-application/1  2        eggs           running  docker  ideggs         
 

--- a/payload/status/output_tabular.go
+++ b/payload/status/output_tabular.go
@@ -16,13 +16,13 @@ const tabularSection = "[Unit Payloads]"
 
 var (
 	tabularColumns = []string{
-		"UNIT",
-		"MACHINE",
-		"PAYLOAD-CLASS",
-		"STATUS",
-		"TYPE",
-		"ID",
-		"TAGS", // TODO(ericsnow) Chane this to "LABELS"?
+		"Unit",
+		"Machine",
+		"Payload class",
+		"Status",
+		"Type",
+		"Id",
+		"Tags", // TODO(ericsnow) Chane this to "LABELS"?
 	}
 
 	tabularHeader = strings.Join(tabularColumns, "\t") + "\t"

--- a/payload/status/output_tabular_test.go
+++ b/payload/status/output_tabular_test.go
@@ -29,7 +29,7 @@ func (s *outputTabularSuite) TestFormatTabularOkay(c *gc.C) {
 
 	c.Check(buff.String(), gc.Equals, `
 [Unit Payloads]
-UNIT             MACHINE  PAYLOAD-CLASS  STATUS   TYPE    ID      TAGS         
+Unit             Machine  Payload class  Status   Type    Id      Tags         
 a-application/0  1        spam           running  docker  idspam  a-tag other  
 `[1:])
 }
@@ -43,7 +43,7 @@ func (s *outputTabularSuite) TestFormatTabularMinimal(c *gc.C) {
 
 	c.Check(buff.String(), gc.Equals, `
 [Unit Payloads]
-UNIT             MACHINE  PAYLOAD-CLASS  STATUS   TYPE    ID      TAGS  
+Unit             Machine  Payload class  Status   Type    Id      Tags  
 a-application/0  1        spam           running  docker  idspam        
 `[1:])
 }
@@ -75,7 +75,7 @@ func (s *outputTabularSuite) TestFormatTabularMulti(c *gc.C) {
 
 	c.Check(buff.String(), gc.Equals, `
 [Unit Payloads]
-UNIT                   MACHINE  PAYLOAD-CLASS  STATUS   TYPE    ID       TAGS         
+Unit                   Machine  Payload class  Status   Type    Id       Tags         
 a-application/0        1        spam           running  docker  idspam   a-tag        
 a-application/1        2        spam           stopped  docker  idspam   a-tag        
 a-application/1        2        spam           running  docker  idspamB               

--- a/resource/cmd/list_charm_resources_test.go
+++ b/resource/cmd/list_charm_resources_test.go
@@ -73,7 +73,7 @@ func (s *ListCharmSuite) TestOkay(c *gc.C) {
 	c.Check(code, gc.Equals, 0)
 
 	c.Check(stdout, gc.Equals, `
-RESOURCE  REVISION
+Resource  Revision
 website   2
 music     1
 
@@ -116,7 +116,7 @@ func (s *ListCharmSuite) TestOutputFormats(c *gc.C) {
 
 	formats := map[string]string{
 		"tabular": `
-RESOURCE  REVISION
+Resource  Revision
 website   1
 music     1
 

--- a/resource/cmd/output_tabular.go
+++ b/resource/cmd/output_tabular.go
@@ -27,7 +27,7 @@ func FormatCharmTabular(writer io.Writer, value interface{}) error {
 
 	// Write the header.
 	// We do not print a section label.
-	fmt.Fprintln(tw, "RESOURCE\tREVISION")
+	fmt.Fprintln(tw, "Resource\tRevision")
 
 	// Print each info to its own row.
 	for _, res := range resources {
@@ -67,7 +67,7 @@ func formatServiceTabular(writer io.Writer, info FormattedServiceInfo) {
 
 	fmt.Fprintln(writer, "[Service]")
 	tw := output.TabWriter(writer)
-	fmt.Fprintln(tw, "RESOURCE\tSUPPLIED BY\tREVISION")
+	fmt.Fprintln(tw, "Resource\tSupplied by\tRevision")
 
 	// Print each info to its own row.
 	for _, r := range info.Resources {
@@ -91,7 +91,7 @@ func writeUpdates(updates []FormattedCharmResource, out io.Writer, tw *ansiterm.
 	if len(updates) > 0 {
 		fmt.Fprintln(out, "")
 		fmt.Fprintln(out, "[Updates Available]")
-		fmt.Fprintln(tw, "RESOURCE\tREVISION")
+		fmt.Fprintln(tw, "Resource\tRevision")
 		for _, r := range updates {
 			fmt.Fprintf(tw, "%v\t%v\n",
 				r.Name,
@@ -113,7 +113,7 @@ func formatUnitTabular(writer io.Writer, resources []FormattedUnitResource) {
 
 	// Write the header.
 	// We do not print a section label.
-	fmt.Fprintln(tw, "RESOURCE\tREVISION")
+	fmt.Fprintln(tw, "Resource\tRevision")
 
 	// Print each info to its own row.
 	for _, r := range resources {
@@ -137,7 +137,7 @@ func formatServiceDetailTabular(writer io.Writer, resources FormattedServiceDeta
 	tw := output.TabWriter(writer)
 
 	// Write the header.
-	fmt.Fprintln(tw, "UNIT\tRESOURCE\tREVISION\tEXPECTED")
+	fmt.Fprintln(tw, "Unit\tResource\tRevision\tExpected")
 
 	for _, r := range resources.Resources {
 		fmt.Fprintf(tw, "%v\t%v\t%v\t%v\n",
@@ -163,7 +163,7 @@ func formatUnitDetailTabular(writer io.Writer, resources FormattedUnitDetails) {
 	tw := output.TabWriter(writer)
 
 	// Write the header.
-	fmt.Fprintln(tw, "RESOURCE\tREVISION\tEXPECTED")
+	fmt.Fprintln(tw, "Resource\tRevision\tExpected")
 
 	for _, r := range resources {
 		fmt.Fprintf(tw, "%v\t%v\t%v\n",

--- a/resource/cmd/output_tabular_test.go
+++ b/resource/cmd/output_tabular_test.go
@@ -34,7 +34,7 @@ func (s *CharmTabularSuite) TestFormatCharmTabularOkay(c *gc.C) {
 
 	data := s.formatTabular(c, formatted)
 	c.Check(data, gc.Equals, `
-RESOURCE  REVISION
+Resource  Revision
 spam      1
 `[1:])
 }
@@ -45,7 +45,7 @@ func (s *CharmTabularSuite) TestFormatCharmTabularMinimal(c *gc.C) {
 
 	data := s.formatTabular(c, formatted)
 	c.Check(data, gc.Equals, `
-RESOURCE  REVISION
+Resource  Revision
 spam      1
 `[1:])
 }
@@ -57,7 +57,7 @@ func (s *CharmTabularSuite) TestFormatCharmTabularUpload(c *gc.C) {
 
 	data := s.formatTabular(c, formatted)
 	c.Check(data, gc.Equals, `
-RESOURCE  REVISION
+Resource  Revision
 spam      1
 `[1:])
 }
@@ -74,7 +74,7 @@ func (s *CharmTabularSuite) TestFormatCharmTabularMulti(c *gc.C) {
 
 	data := s.formatTabular(c, formatted)
 	c.Check(data, gc.Equals, `
-RESOURCE      REVISION
+Resource      Revision
 spam          1
 eggs          2
 somethingbig  1
@@ -123,7 +123,7 @@ func (s *SvcTabularSuite) TestFormatServiceOkay(c *gc.C) {
 	data := s.formatTabular(c, formatted)
 	c.Check(data, gc.Equals, `
 [Service]
-RESOURCE  SUPPLIED BY  REVISION
+Resource  Supplied by  Revision
 openjdk   charmstore   7
 `[1:])
 }
@@ -149,7 +149,7 @@ func (s *SvcTabularSuite) TestFormatUnitOkay(c *gc.C) {
 	data := s.formatTabular(c, formatted)
 	c.Check(data, gc.Equals, `
 [Unit]
-RESOURCE  REVISION
+Resource  Revision
 openjdk   7
 `[1:])
 }
@@ -252,14 +252,14 @@ func (s *SvcTabularSuite) TestFormatSvcTabularMulti(c *gc.C) {
 	// Notes: sorted by name, then by revision, newest first.
 	c.Check(data, gc.Equals, `
 [Service]
-RESOURCE  SUPPLIED BY  REVISION
+Resource  Supplied by  Revision
 openjdk   charmstore   7
 website   upload       -
 openjdk2  charmstore   8
 website2  Bill User    2012-12-12T12:12
 
 [Updates Available]
-RESOURCE  REVISION
+Resource  Revision
 openjdk   10
 `[1:])
 }
@@ -299,12 +299,12 @@ func (s *SvcTabularSuite) TestFormatServiceDetailsOkay(c *gc.C) {
 	output := s.formatTabular(c, data)
 	c.Assert(output, gc.Equals, `
 [Units]
-UNIT  RESOURCE  REVISION  EXPECTED
+Unit  Resource  Revision  Expected
 5     config    combRev2  combRev3
 10    data      combRev1  combRev1 (fetching: 17%)
 
 [Updates Available]
-RESOURCE  REVISION
+Resource  Revision
 spam      1
 `[1:])
 }
@@ -332,7 +332,7 @@ func (s *SvcTabularSuite) TestFormatUnitDetailsOkay(c *gc.C) {
 	output := s.formatTabular(c, data)
 	c.Assert(output, gc.Equals, `
 [Unit]
-RESOURCE  REVISION  EXPECTED
+Resource  Revision  Expected
 config    combRev2  combRev3 (fetching: 91%)
 data      combRev1  combRev1
 `[1:])

--- a/resource/cmd/show_service_test.go
+++ b/resource/cmd/show_service_test.go
@@ -175,14 +175,14 @@ func (s *ShowServiceSuite) TestRun(c *gc.C) {
 
 	c.Check(stdout, gc.Equals, `
 [Service]
-RESOURCE  SUPPLIED BY  REVISION
+Resource  Supplied by  Revision
 openjdk   charmstore   7
 website   upload       -
 rsc1234   charmstore   15
 website2  Bill User    2012-12-12T12:12
 
 [Updates Available]
-RESOURCE  REVISION
+Resource  Revision
 openjdk   10
 
 `[1:])
@@ -238,7 +238,7 @@ func (s *ShowServiceSuite) TestRunUnit(c *gc.C) {
 
 	c.Check(stdout, gc.Equals, `
 [Unit]
-RESOURCE  REVISION
+Resource  Revision
 rsc1234   15
 website2  2012-12-12T12:12
 
@@ -402,7 +402,7 @@ func (s *ShowServiceSuite) TestRunDetails(c *gc.C) {
 
 	c.Check(stdout, gc.Equals, `
 [Units]
-UNIT  RESOURCE  REVISION          EXPECTED
+Unit  Resource  Revision          Expected
 5     alpha     10                15
 5     beta      2012-12-12T12:12  2012-12-12T12:12
 5     charlie   2011-11-11T11:11  2012-12-12T12:12 (fetching: 2%)
@@ -542,7 +542,7 @@ func (s *ShowServiceSuite) TestRunUnitDetails(c *gc.C) {
 
 	c.Check(stdout, gc.Equals, `
 [Unit]
-RESOURCE  REVISION          EXPECTED
+Resource  Revision          Expected
 alpha     10                15
 beta      -                 2012-12-12T12:12
 charlie   2011-11-11T11:11  2012-12-12T12:12 (fetching: 0%)


### PR DESCRIPTION
All tables headers are now FirstLetter case. Except for things like "Model UUID" because UUID is generally capitalised.

QA - bootstrap and run various list related commands.