### PR TITLE
Remove bootstrap instance warning, show details

### DIFF
--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -172,8 +172,9 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 	if err != nil {
 		return nil, "", nil, errors.Annotate(err, "cannot start bootstrap instance")
 	}
-	// We need some padding below to overwrite any previous messages. We'll use a width of 40.
-	msg := fmt.Sprintf(" - %s", result.Instance.Id())
+
+	msg := fmt.Sprintf(" - %s (%s)", result.Instance.Id(), formatHardware(result.Hardware))
+	// We need some padding below to overwrite any previous messages.
 	if len(msg) < 40 {
 		padding := make([]string, 40-len(msg))
 		msg += strings.Join(padding, " ")
@@ -198,6 +199,31 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 		return FinishBootstrap(ctx, client, env, result.Instance, icfg, opts)
 	}
 	return result, selectedSeries, finalize, nil
+}
+
+func formatHardware(hw *instance.HardwareCharacteristics) string {
+	if hw == nil {
+		return ""
+	}
+	out := make([]string, 0, 3)
+	if hw.Arch != nil && *hw.Arch != "" {
+		out = append(out, fmt.Sprintf("arch=%s", *hw.Arch))
+	}
+	if hw.Mem != nil && *hw.Mem > 0 {
+		out = append(out, fmt.Sprintf("mem=%s", formatMemory(*hw.Mem)))
+	}
+	if hw.CpuCores != nil && *hw.CpuCores > 0 {
+		out = append(out, fmt.Sprintf("cores=%d", *hw.CpuCores))
+	}
+	return strings.Join(out, " ")
+}
+
+func formatMemory(m uint64) string {
+	if m < 1024 {
+		return fmt.Sprintf("%dM", m)
+	}
+	s := fmt.Sprintf("%.1f", float32(m)/1024.0)
+	return strings.TrimSuffix(s, ".0") + "G"
 }
 
 // FinishBootstrap completes the bootstrap process by connecting

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -398,3 +398,56 @@ func (s *BootstrapSuite) TestWaitSSHRefreshAddresses(c *gc.C) {
 		"Waiting for address\n"+
 			"(.|\n)*(Attempting to connect to 0.1.2.4:22\n)+(.|\n)*")
 }
+
+type FormatHardwareSuite struct{}
+
+var _ = gc.Suite(&FormatHardwareSuite{})
+
+func (s *FormatHardwareSuite) check(c *gc.C, hw *instance.HardwareCharacteristics, expected string) {
+	c.Check(common.FormatHardware(hw), gc.Equals, expected)
+}
+
+func (s *FormatHardwareSuite) TestNil(c *gc.C) {
+	s.check(c, nil, "")
+}
+
+func (s *FormatHardwareSuite) TestFieldsNil(c *gc.C) {
+	s.check(c, &instance.HardwareCharacteristics{}, "")
+}
+
+func (s *FormatHardwareSuite) TestArch(c *gc.C) {
+	arch := ""
+	s.check(c, &instance.HardwareCharacteristics{Arch: &arch}, "")
+	arch = "amd64"
+	s.check(c, &instance.HardwareCharacteristics{Arch: &arch}, "arch=amd64")
+}
+
+func (s *FormatHardwareSuite) TestCores(c *gc.C) {
+	var cores uint64
+	s.check(c, &instance.HardwareCharacteristics{CpuCores: &cores}, "")
+	cores = 24
+	s.check(c, &instance.HardwareCharacteristics{CpuCores: &cores}, "cores=24")
+}
+
+func (s *FormatHardwareSuite) TestMem(c *gc.C) {
+	var mem uint64
+	s.check(c, &instance.HardwareCharacteristics{Mem: &mem}, "")
+	mem = 800
+	s.check(c, &instance.HardwareCharacteristics{Mem: &mem}, "mem=800M")
+	mem = 1024
+	s.check(c, &instance.HardwareCharacteristics{Mem: &mem}, "mem=1G")
+	mem = 2712
+	s.check(c, &instance.HardwareCharacteristics{Mem: &mem}, "mem=2.6G")
+}
+
+func (s *FormatHardwareSuite) TestAll(c *gc.C) {
+	arch := "ppc64"
+	var cores uint64 = 2
+	var mem uint64 = 123
+	hw := &instance.HardwareCharacteristics{
+		Arch:     &arch,
+		CpuCores: &cores,
+		Mem:      &mem,
+	}
+	s.check(c, hw, "arch=ppc64 mem=123M cores=2")
+}

--- a/provider/common/export_test.go
+++ b/provider/common/export_test.go
@@ -6,4 +6,5 @@ package common
 var (
 	ConnectSSH                          = &connectSSH
 	InternalAvailabilityZoneAllocations = &internalAvailabilityZoneAllocations
+	FormatHardware                      = formatHardware
 )

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -733,10 +733,6 @@ func (environ *maasEnviron) acquireNode2(
 	}
 	if nodeName != "" {
 		acquireParams.Hostname = nodeName
-	} else if cons.Arch == nil {
-		logger.Warningf(
-			"no architecture was specified, acquiring an arbitrary node",
-		)
 	}
 	machine, constraintMatches, err := environ.maasController.AllocateMachine(acquireParams)
 
@@ -753,6 +749,15 @@ func (environ *maasEnviron) acquireNode(
 	interfaces []interfaceBinding,
 	volumes []volumeInfo,
 ) (gomaasapi.MAASObject, error) {
+
+	// TODO(axw) 2014-08-18 #1358219
+	// We should be requesting preferred architectures if unspecified,
+	// like in the other providers.
+	//
+	// This is slightly complicated in MAAS as there are a finite
+	// number of each architecture; preference may also conflict with
+	// other constraints, such as tags. Thus, a preference becomes a
+	// demand (which may fail) if not handled properly.
 
 	acquireParams := convertConstraints(cons)
 	positiveSpaceNames, negativeSpaceNames := convertSpacesFromConstraints(cons.Spaces)
@@ -772,22 +777,6 @@ func (environ *maasEnviron) acquireNode(
 	}
 	if nodeName != "" {
 		acquireParams.Add("name", nodeName)
-	} else if cons.Arch == nil {
-		// TODO(axw) 2014-08-18 #1358219
-		// We should be requesting preferred
-		// architectures if unspecified, like
-		// in the other providers.
-		//
-		// This is slightly complicated in MAAS
-		// as there are a finite number of each
-		// architecture; preference may also
-		// conflict with other constraints, such
-		// as tags. Thus, a preference becomes a
-		// demand (which may fail) if not handled
-		// properly.
-		logger.Warningf(
-			"no architecture was specified, acquiring an arbitrary node",
-		)
 	}
 
 	var result gomaasapi.JSONObject


### PR DESCRIPTION
The MAAS warning about selection of a default node during bootstrap has been removed and the arch, cores and memory for the bootstrap instance are now shown instead (for all providers).This is generally useful and also informs the user about instance selection decisions made by the provider.

Example output:

```
$ juju bootstrap G google 
Creating Juju controller "G" on google/us-east1
Looking for packaged Juju agent version 2.0.0 for amd64
No packaged binary found, preparing local Juju agent binary
Launching controller instance(s) on google/us-east1...
 - juju-3020c2-0 (arch=amd64 mem=1.7G cores=1)
...
```

```
$ juju bootstrap M maas2
Creating Juju controller "M" on maas2
Looking for packaged Juju agent version 2.0.0 for amd64
No packaged binary found, preparing local Juju agent binary
Launching controller instance(s) on maas2...
 - 4y3h7p (arch=amd64 mem=1G cores=1)
...    
```

### QA

Have confirmed the new output is sensible using MAAS, AWS, GCE and LXD.

