### PR TITLE
network: Added reusable FastestHostPort() helper

### DIFF
--- a/network/hostport.go
+++ b/network/hostport.go
@@ -247,7 +247,7 @@ func EnsureFirstHostPort(first HostPort, hps []HostPort) []HostPort {
 // successfully connected to - the one with the lowest latency - or an error if
 // none of the given hostPorts can be reached.
 //
-// Timeout should be short, e.g. between 100ms and 1000ms.
+// Timeout should be short, e.g. between 100ms and 3s.
 func FastestHostPort(timeout time.Duration, hostPorts ...HostPort) (*HostPort, error) {
 	maxParallel := runtime.GOMAXPROCS(0) // 0 just returns the value unchanged
 	try := parallel.NewTry(maxParallel, nil)
@@ -269,6 +269,5 @@ func FastestHostPort(timeout time.Duration, hostPorts ...HostPort) (*HostPort, e
 	conn, _ := result.(net.Conn) // cannot fail
 	defer conn.Close()
 
-	fastest := conn.RemoteAddr().String()
-	return ParseHostPort(fastest)
+	return ParseHostPort(conn.RemoteAddr().String())
 }

--- a/network/hostport.go
+++ b/network/hostport.go
@@ -4,11 +4,15 @@
 package network
 
 import (
+	"io"
 	"net"
+	"runtime"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/parallel"
 	"github.com/juju/utils/set"
 )
 
@@ -235,4 +239,36 @@ func EnsureFirstHostPort(first HostPort, hps []HostPort) []HostPort {
 	// Insert it at the top.
 	result = append([]HostPort{first}, result...)
 	return result
+}
+
+// FastestHostPort tries to connect to all given hostPorts in parallel, waiting
+// up to the given timeout for each connection to be established, and using up
+// to GOMAXPROCS concurrent connection attempts. Returns the first HostPort
+// successfully connected to - the one with the lowest latency - or an error if
+// none of the given hostPorts can be reached.
+//
+// Timeout should be short, e.g. between 100ms and 1000ms.
+func FastestHostPort(timeout time.Duration, hostPorts ...HostPort) (*HostPort, error) {
+	maxParallel := runtime.GOMAXPROCS(0) // 0 just returns the value unchanged
+	try := parallel.NewTry(maxParallel, nil)
+	defer try.Kill()
+
+	endpoints := set.NewStrings(HostPortsToStrings(hostPorts)...)
+	for _, endpoint := range endpoints.Values() {
+		try.Start(func(stop <-chan struct{}) (io.Closer, error) {
+			return net.DialTimeout("tcp", endpoint, timeout)
+		})
+	}
+	try.Close()
+
+	result, err := try.Result()
+	if err != nil {
+		return nil, errors.Annotatef(err, "no reachable endpoints in %v", endpoints)
+	}
+
+	conn, _ := result.(net.Conn) // cannot fail
+	defer conn.Close()
+
+	fastest := conn.RemoteAddr().String()
+	return ParseHostPort(fastest)
 }

--- a/network/hostport_test.go
+++ b/network/hostport_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -509,4 +510,80 @@ func (*HostPortSuite) makeHostPorts() []network.HostPort {
 			"fe80::2",     // link-local
 		)...,
 	)
+}
+
+const (
+	shortTimeout  = 250 * time.Millisecond
+	mediumTimeout = 4 * shortTimeout
+	longTimeout   = 5 * mediumTimeout
+	noTimeout     = 0
+)
+
+func (*HostPortSuite) TestFastestHostPortAllUnreachable(c *gc.C) {
+	// All of the endpoints below should either block indefinitely (without a
+	// timeout) or fail immediately.
+	unreachableHPs := network.NewHostPorts(49151, // IANA reserved port (unreachable)
+		"255.1.2.3",       // IPv4 route unreachable
+		"bad.example.com", // unresolvable
+		"2001:db8::1",     // IPv6 route unreachable
+		"localhost",       // dualstack, port unreachable
+		"example.org",     // resolvable, but unreachable
+		"127.0.0.1",       // IPv4 port unreachable
+	)
+
+	fastest, err := network.FastestHostPort(shortTimeout, unreachableHPs...)
+	c.Check(err, gc.ErrorMatches, "no reachable endpoints in .*")
+	c.Check(fastest, gc.IsNil)
+}
+
+func (*HostPortSuite) TestFastestHostPortSlowConnection(c *gc.C) {
+	slowServerHP := testTCPServer(c, mediumTimeout)
+
+	fastest, err := network.FastestHostPort(shortTimeout, slowServerHP)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(*fastest, jc.DeepEquals, slowServerHP)
+}
+
+func (*HostPortSuite) TestFastestHostPortSingleListener(c *gc.C) {
+	testHostPort := testTCPServer(c, noTimeout)
+
+	fastest, err := network.FastestHostPort(shortTimeout, testHostPort)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(*fastest, jc.DeepEquals, testHostPort)
+}
+
+func (*HostPortSuite) TestFastestHostPortMultipleListeners(c *gc.C) {
+	fastest, err := network.FastestHostPort(
+		noTimeout,
+		testTCPServer(c, longTimeout),
+		testTCPServer(c, mediumTimeout),
+		testTCPServer(c, shortTimeout),
+	)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(fastest, gc.NotNil) // can be any one of the 3 listeners.
+}
+
+func testTCPServer(c *gc.C, acceptDelay time.Duration) network.HostPort {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	c.Assert(err, jc.ErrorIsNil)
+
+	listenAddress := listener.Addr().String()
+	hostPort, err := network.ParseHostPort(listenAddress)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Logf("listening on %q", hostPort)
+
+	go func() {
+		defer listener.Close()
+
+		conn, err := listener.Accept()
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(conn, gc.NotNil)
+
+		conn.SetDeadline(time.Now())
+		conn.Close()
+
+		time.Sleep(acceptDelay)
+	}()
+
+	return *hostPort
 }

--- a/network/hostport_test.go
+++ b/network/hostport_test.go
@@ -523,12 +523,11 @@ func (*HostPortSuite) TestFastestHostPortAllUnreachable(c *gc.C) {
 	// All of the endpoints below should either block indefinitely (without a
 	// timeout) or fail immediately.
 	unreachableHPs := network.NewHostPorts(49151, // IANA reserved port (unreachable)
-		"255.1.2.3",       // IPv4 route unreachable
-		"bad.example.com", // unresolvable
-		"2001:db8::1",     // IPv6 route unreachable
-		"localhost",       // dualstack, port unreachable
-		"example.org",     // resolvable, but unreachable
-		"127.0.0.1",       // IPv4 port unreachable
+		"255.1.2.3",   // IPv4 route unreachable
+		"2001:db8::1", // IPv6 route unreachable
+		"localhost",   // dualstack, port unreachable
+		"example.org", // resolvable, but unreachable
+		"127.0.0.1",   // IPv4 port unreachable
 	)
 
 	fastest, err := network.FastestHostPort(shortTimeout, unreachableHPs...)


### PR DESCRIPTION
Takes a timeout and a slice of []network.HostPort entires.
Uses parallel.Try internally to connect to all of them
concurrently, with the given timeout. Needed to overcome
the limitation of the openssh client hanging when trying
to connect to an unreachable or blackhole routes.

Prerequisite to fix http://pad.lv/1616098.