### PR TITLE
controller: add allow-model-access flag

### DIFF
--- a/apiserver/adminv3_test.go
+++ b/apiserver/adminv3_test.go
@@ -30,9 +30,6 @@ var _ = gc.Suite(&loginV3Suite{
 })
 
 func (s *loginV3Suite) TestClientLoginToEnvironment(c *gc.C) {
-	_, cleanup := s.setupServer(c)
-	defer cleanup()
-
 	info := s.APIInfo(c)
 	apiState, err := api.Open(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -44,9 +41,6 @@ func (s *loginV3Suite) TestClientLoginToEnvironment(c *gc.C) {
 }
 
 func (s *loginV3Suite) TestClientLoginToServer(c *gc.C) {
-	_, cleanup := s.setupServer(c)
-	defer cleanup()
-
 	info := s.APIInfo(c)
 	info.ModelTag = names.ModelTag{}
 	apiState, err := api.Open(info, api.DialOpts{})
@@ -62,9 +56,6 @@ func (s *loginV3Suite) TestClientLoginToServer(c *gc.C) {
 }
 
 func (s *loginV3Suite) TestClientLoginToServerNoAccessToControllerEnv(c *gc.C) {
-	_, cleanup := s.setupServer(c)
-	defer cleanup()
-
 	password := "shhh..."
 	user := s.Factory.MakeUser(c, &factory.UserParams{
 		NoModelUser: true,
@@ -87,9 +78,6 @@ func (s *loginV3Suite) TestClientLoginToServerNoAccessToControllerEnv(c *gc.C) {
 }
 
 func (s *loginV3Suite) TestClientLoginToRootOldClient(c *gc.C) {
-	_, cleanup := s.setupServer(c)
-	defer cleanup()
-
 	info := s.APIInfo(c)
 	info.Tag = nil
 	info.Password = ""

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -61,6 +61,7 @@ type Server struct {
 	connCount         int64
 	certChanged       <-chan params.StateServingInfo
 	tlsConfig         *tls.Config
+	allowModelAccess  bool
 
 	// mu guards the fields below it.
 	mu sync.Mutex
@@ -97,6 +98,11 @@ type ServerConfig struct {
 	// TLS certificates will be obtained. By default,
 	// acme.LetsEncryptURL will be used.
 	AutocertURL string
+
+	// AllowModelAccess holds whether users will be allowed to
+	// access models that they have access rights to even when
+	// they don't have access to the controller.
+	AllowModelAccess bool
 
 	// NewObserver is a function which will return an observer. This
 	// is used per-connection to instantiate a new observer to be
@@ -162,7 +168,8 @@ func newServer(s *state.State, lis net.Listener, cfg ServerConfig) (_ *Server, e
 		adminAPIFactories: map[int]adminAPIFactory{
 			3: newAdminAPIV3,
 		},
-		certChanged: cfg.CertChanged,
+		certChanged:      cfg.CertChanged,
+		allowModelAccess: cfg.AllowModelAccess,
 	}
 
 	srv.tlsConfig = srv.newTLSConfig(cfg)

--- a/apiserver/authenticator_test.go
+++ b/apiserver/authenticator_test.go
@@ -32,8 +32,9 @@ var _ = gc.Suite(&agentAuthenticatorSuite{})
 func (s *agentAuthenticatorSuite) TestAuthenticatorForTag(c *gc.C) {
 	fact := factory.NewFactory(s.State)
 	user := fact.MakeUser(c, &factory.UserParams{Password: "password"})
-	srv := newServer(c, s.State, nil)
-	defer srv.Stop()
+	_, srv := newServer(c, s.State)
+	defer assertStop(c, srv)
+
 	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, user.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(authenticator, gc.NotNil)
@@ -48,7 +49,7 @@ func (s *agentAuthenticatorSuite) TestAuthenticatorForTag(c *gc.C) {
 }
 
 func (s *agentAuthenticatorSuite) TestMachineGetsAgentAuthenticator(c *gc.C) {
-	srv := newServer(c, s.State, nil)
+	_, srv := newServer(c, s.State)
 	defer srv.Stop()
 	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, names.NewMachineTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -57,7 +58,7 @@ func (s *agentAuthenticatorSuite) TestMachineGetsAgentAuthenticator(c *gc.C) {
 }
 
 func (s *agentAuthenticatorSuite) TestUnitGetsAgentAuthenticator(c *gc.C) {
-	srv := newServer(c, s.State, nil)
+	_, srv := newServer(c, s.State)
 	defer srv.Stop()
 	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, names.NewUnitTag("wordpress/0"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -66,7 +67,7 @@ func (s *agentAuthenticatorSuite) TestUnitGetsAgentAuthenticator(c *gc.C) {
 }
 
 func (s *agentAuthenticatorSuite) TestNotSupportedTag(c *gc.C) {
-	srv := newServer(c, s.State, nil)
+	_, srv := newServer(c, s.State)
 	defer srv.Stop()
 	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, names.NewApplicationTag("not-support"))
 	c.Assert(err, gc.ErrorMatches, "unexpected login entity tag: invalid request")

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -640,7 +640,9 @@ type AuthUserInfo struct {
 	Credentials *string `json:"credentials,omitempty"`
 
 	// ControllerAccess holds the access the user has to the connected controller.
+	// It will be empty if the user has no access to the controller.
 	ControllerAccess string `json:"controller-access"`
+
 	// ModelAccess holds the access the user has to the connected model.
 	ModelAccess string `json:"model-access"`
 }

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1099,16 +1099,17 @@ func (a *MachineAgent) newAPIserverWorker(st *state.State, certChanged chan para
 	}
 
 	server, err := apiserver.NewServer(st, listener, apiserver.ServerConfig{
-		Clock:           clock.WallClock,
-		Cert:            cert,
-		Key:             key,
-		Tag:             tag,
-		DataDir:         dataDir,
-		LogDir:          logDir,
-		Validator:       a.limitLogins,
-		CertChanged:     certChanged,
-		AutocertURL:     controllerConfig.AutocertURL(),
-		AutocertDNSName: controllerConfig.AutocertDNSName(),
+		Clock:            clock.WallClock,
+		Cert:             cert,
+		Key:              key,
+		Tag:              tag,
+		DataDir:          dataDir,
+		LogDir:           logDir,
+		Validator:        a.limitLogins,
+		CertChanged:      certChanged,
+		AutocertURL:      controllerConfig.AutocertURL(),
+		AutocertDNSName:  controllerConfig.AutocertDNSName(),
+		AllowModelAccess: controllerConfig.AllowModelAccess(),
 		NewObserver: newObserverFn(
 			controllerConfig,
 			clock.WallClock,

--- a/controller/config.go
+++ b/controller/config.go
@@ -56,6 +56,11 @@ const (
 	// "https://acme-staging.api.letsencrypt.org/directory".
 	AutocertURLKey = "autocert-url"
 
+	// AllowModelAccessKey sets whether the controller will allow users to
+	// connect to models they have been authorized for even when
+	// they don't have any access rights to the controller itself.
+	AllowModelAccessKey = "allow-model-access"
+
 	// Attribute Defaults
 
 	// DefaultAuditingEnabled contains the default value for the
@@ -76,15 +81,16 @@ const (
 // ControllerOnlyConfigAttributes are attributes which are only relevant
 // for a controller, never a model.
 var ControllerOnlyConfigAttributes = []string{
+	AllowModelAccessKey,
 	APIPort,
-	StatePort,
-	CACertKey,
-	ControllerUUIDKey,
-	IdentityURL,
-	IdentityPublicKey,
-	SetNUMAControlPolicyKey,
 	AutocertDNSNameKey,
 	AutocertURLKey,
+	CACertKey,
+	ControllerUUIDKey,
+	IdentityPublicKey,
+	IdentityURL,
+	SetNUMAControlPolicyKey,
+	StatePort,
 }
 
 // ControllerOnlyAttribute returns true if the specified attribute name
@@ -231,6 +237,14 @@ func (c Config) NUMACtlPreference() bool {
 	return DefaultNUMAControlPolicy
 }
 
+// AllowModelAccess reports whether users are allowed to access models
+// they have been granted permission for even when they can't access
+// the controller.
+func (c Config) AllowModelAccess() bool {
+	value, _ := c[AllowModelAccessKey].(bool)
+	return value
+}
+
 // Validate ensures that config is a valid configuration.
 func Validate(c Config) error {
 	if v, ok := c[IdentityPublicKey].(string); ok {
@@ -284,6 +298,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	SetNUMAControlPolicyKey: schema.Bool(),
 	AutocertURLKey:          schema.String(),
 	AutocertDNSNameKey:      schema.String(),
+	AllowModelAccessKey:     schema.Bool(),
 }, schema.Defaults{
 	APIPort:                 DefaultAPIPort,
 	AuditingEnabled:         DefaultAuditingEnabled,
@@ -293,4 +308,5 @@ var configChecker = schema.FieldMap(schema.Fields{
 	SetNUMAControlPolicyKey: DefaultNUMAControlPolicy,
 	AutocertURLKey:          schema.Omit,
 	AutocertDNSNameKey:      schema.Omit,
+	AllowModelAccessKey:     schema.Omit,
 })

--- a/permission/access.go
+++ b/permission/access.go
@@ -12,9 +12,8 @@ import (
 type Access string
 
 const (
-	// UndefinedAccess is not a valid access type. It is the value
-	// used when access is not defined at all.
-	UndefinedAccess Access = ""
+	// NoAccess allows a user no permissions at all.
+	NoAccess Access = ""
 
 	// Model Permissions
 
@@ -43,7 +42,7 @@ const (
 // Validate returns error if the current is not a valid access level.
 func (a Access) Validate() error {
 	switch a {
-	case UndefinedAccess, AdminAccess, ReadAccess, WriteAccess,
+	case NoAccess, AdminAccess, ReadAccess, WriteAccess,
 		LoginAccess, AddModelAccess, SuperuserAccess:
 		return nil
 	}
@@ -72,7 +71,7 @@ func ValidateControllerAccess(access Access) error {
 
 func (a Access) controllerValue() int {
 	switch a {
-	case UndefinedAccess:
+	case NoAccess:
 		return 0
 	case LoginAccess:
 		return 1
@@ -87,7 +86,7 @@ func (a Access) controllerValue() int {
 
 func (a Access) modelValue() int {
 	switch a {
-	case UndefinedAccess:
+	case NoAccess:
 		return 0
 	case ReadAccess:
 		return 1

--- a/permission/access_test.go
+++ b/permission/access_test.go
@@ -17,7 +17,7 @@ var _ = gc.Suite(&accessSuite{})
 func (*accessSuite) TestEqualOrGreaterModelAccessThan(c *gc.C) {
 	// A very boring but necessary test to test explicit responses.
 	var (
-		undefined = permission.UndefinedAccess
+		undefined = permission.NoAccess
 		read      = permission.ReadAccess
 		write     = permission.WriteAccess
 		admin     = permission.AdminAccess
@@ -66,7 +66,7 @@ func (*accessSuite) TestEqualOrGreaterModelAccessThan(c *gc.C) {
 func (*accessSuite) TestGreaterModelAccessThan(c *gc.C) {
 	// A very boring but necessary test to test explicit responses.
 	var (
-		undefined = permission.UndefinedAccess
+		undefined = permission.NoAccess
 		read      = permission.ReadAccess
 		write     = permission.WriteAccess
 		admin     = permission.AdminAccess
@@ -110,7 +110,7 @@ func (*accessSuite) TestGreaterModelAccessThan(c *gc.C) {
 func (*accessSuite) TestEqualOrGreaterControllerAccessThan(c *gc.C) {
 	// A very boring but necessary test to test explicit responses.
 	var (
-		undefined = permission.UndefinedAccess
+		undefined = permission.NoAccess
 		read      = permission.ReadAccess
 		write     = permission.WriteAccess
 		admin     = permission.AdminAccess
@@ -159,7 +159,7 @@ func (*accessSuite) TestEqualOrGreaterControllerAccessThan(c *gc.C) {
 func (*accessSuite) TestGreaterControllerAccessThan(c *gc.C) {
 	// A very boring but necessary test to test explicit responses.
 	var (
-		undefined = permission.UndefinedAccess
+		undefined = permission.NoAccess
 		read      = permission.ReadAccess
 		write     = permission.WriteAccess
 		admin     = permission.AdminAccess

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -24,10 +24,11 @@ func (s *ControllerConfigSuite) TestControllerAndModelConfigInitialisation(c *gc
 	c.Assert(err, jc.ErrorIsNil)
 
 	optional := map[string]bool{
-		controller.IdentityURL:        true,
-		controller.IdentityPublicKey:  true,
-		controller.AutocertURLKey:     true,
-		controller.AutocertDNSNameKey: true,
+		controller.IdentityURL:         true,
+		controller.IdentityPublicKey:   true,
+		controller.AutocertURLKey:      true,
+		controller.AutocertDNSNameKey:  true,
+		controller.AllowModelAccessKey: true,
 	}
 	for _, controllerAttr := range controller.ControllerOnlyConfigAttributes {
 		v, ok := controllerSettings.Get(controllerAttr)

--- a/state/userpermission.go
+++ b/state/userpermission.go
@@ -71,7 +71,7 @@ func (st *State) controllerUserPermission(objectGlobalKey, subjectGlobalKey stri
 // isReadOnly returns whether or not the user has write access or only
 // read access to the model.
 func (p *userPermission) isReadOnly() bool {
-	return stringToAccess(p.doc.Access) == permission.UndefinedAccess || stringToAccess(p.doc.Access) == permission.ReadAccess
+	return stringToAccess(p.doc.Access) == permission.NoAccess || stringToAccess(p.doc.Access) == permission.ReadAccess
 }
 
 // isAdmin is a convenience method that

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -181,7 +181,7 @@ func (factory *Factory) MakeUser(c *gc.C, params *UserParams) *state.User {
 		c.Assert(err, jc.ErrorIsNil)
 		params.Creator = env.Owner()
 	}
-	if params.Access == permission.UndefinedAccess {
+	if params.Access == permission.NoAccess {
 		params.Access = permission.AdminAccess
 	}
 	creatorUserTag := params.Creator.(names.UserTag)
@@ -219,7 +219,7 @@ func (factory *Factory) MakeModelUser(c *gc.C, params *ModelUserParams) permissi
 	if params.DisplayName == "" {
 		params.DisplayName = uniqueString("display name")
 	}
-	if params.Access == permission.UndefinedAccess {
+	if params.Access == permission.NoAccess {
 		params.Access = permission.AdminAccess
 	}
 	if params.CreatedBy == nil {


### PR DESCRIPTION
This allows model users access to a model they've been granted
access to without the requirement for them to have access
to the controller too.

This required the ability for some apiserver tests to be able
to start the API server with a custom configuration, which
required some changes in the apiserver tests. Specifically
we consolidate the API server test starting code into
one place and use it throughout.

We also rename permission.UndefinedAccess to permission.NoAccess
because that's what it actually implies (note that although the
comment on UndefinedAccess states that it's an invalid
permission, Access.Validate begs to differ as do a fair number
of other places that rely on UndefinedAccess meaning
"no permissions").

Fixes https://bugs.launchpad.net/juju/+bug/1631449.

### QA instructions

- bootstrap a controller:

    juju bootstrap <region> <cloud> --config identity-url=https://api.jujucharms.com/identity --config allow-model-access=true

- create a model and grant access to an external user on that model

- check that that user can access the model and that they cannot list models in the controller or do anything else that requires a controller-level API connection.