### PR TITLE
Update app config to use --reset as string var

### DIFF
--- a/featuretests/cmdjuju_test.go
+++ b/featuretests/cmdjuju_test.go
@@ -81,7 +81,7 @@ func (s *cmdJujuSuite) TestServiceUnset(c *gc.C) {
 	err := svc.UpdateConfigSettings(settings)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = testing.RunCommand(c, application.NewConfigCommand(), "--reset", "dummy-service", "username")
+	_, err = testing.RunCommand(c, application.NewConfigCommand(), "dummy-service", "--reset", "username")
 	c.Assert(err, jc.ErrorIsNil)
 
 	expect := charm.Settings{


### PR DESCRIPTION
This also allows simultaneous set/reset as with model-defaults and
model-config.

Refs: config command collapse spec https://goo.gl/yqrrPI

QA:
1. Run all unit tests and they pass
2. With an [lxd cloud like](http://pastebin.ubuntu.com/23309877/) (see [Faster LXD](https://github.com/juju/juju/wiki/Faster-LXD) for details on apt-http proxy and other items, or don't use them)
3. juju bootstrap reed/lxd-app-config lxdtest 
4. juju deploy haproxy && juju deploy wordpress && juju deploy mysql && juju add-relation haproxy wordpress && juju add-relation wordpress mysql && juju expose haproxy
5. juju config wordpress 

    verify output is [like this](http://paste.ubuntu.com/23156363/)
   
6. juju config wordpress debug=yes 
7. juju config wordpress debug

    "yes"

8. juju config wordpress --reset debug
9. juju config wordpress debug

    "no"

10. save the contents of the mysql settings to a file with `juju config mysql --format=yaml > mysql.yaml. It should look [like this](http://paste.ubuntu.com/23156375/).
11 Edit the file [like this](http://paste.ubuntu.com/23156406/)
11.  juju config mysql --file mysql.yaml 
12. for v in size type; do juju config mysql query-cache-$v;done

    1.2345679e+08
    "ON"
        
13. juju config mysql --reset query-cache-size,query-cache-type
14. for v in size type; do juju config mysql query-cache-$v;done

    0
    "OFF"

15. juju config mysql query-cache-size=123456789 query-cache-type=DEMAND
16. for v in size type; do juju config mysql query-cache-$v;done

    1.2345679e+08
    "ON"
 
15. juju config mysql query-cache-size 

    1.2345679e+08 

16. juju config mysql --reset query-cache-size 
17. juju config mysql query-cache-size 
    
    0
    
18.  juju config mysql query-cache-type 
    
    DEMAND
    
19. juju config mysql --reset query-cache-type
20. juju config mysql query-cache-type

    "OFF"

20. juju config mysql --reset 

    error: flag needs an argument: --reset

21. juju config mysql foo bar 

    error: can only retrieve a single value, or all values
    
22. juju kill-controller reed/lxd-app-config -y 
