### PR TITLE
lxd: disable ipv6 when creating a new-style bridge

### DIFF
--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -271,7 +271,7 @@ func verifyDefaultProfileBridgeConfig(client *lxd.Client, networkAPISupported bo
 		return "", errors.Trace(err)
 	}
 
-	// If the default profile doesn't have eth0 in it, then the user has messed
+	// If the default profile has eth0 in it, then the user has messed
 	// with it, so let's just use whatever they set up.
 	eth0, ok := config.Devices[configEth0]
 	if !ok {
@@ -287,6 +287,10 @@ func verifyDefaultProfileBridgeConfig(client *lxd.Client, networkAPISupported bo
 			return network.DefaultLXDBridge, nil
 		}
 		return "", errors.Errorf("unexpected LXD %q profile config without eth0: %+v", defaultProfileName, config)
+	} else if networkAPISupported {
+		if err := checkBridgeConfig(client, eth0[configParentKey]); err != nil {
+			return "", err
+		}
 	}
 
 	// If eth0 is there, but not with the expected attributes, likewise fail

--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -358,10 +358,15 @@ func checkLXDBridgeConfiguration(conf string) error {
 			if name != network.DefaultLXDBridge {
 				return bridgeConfigError(fmt.Sprintf(LXDBridgeFile+" has a bridge named %s, not lxdbr0", name))
 			}
-		} else if strings.HasPrefix(line, "LXD_IPV4_ADDR=") || strings.HasPrefix(line, "LXD_IPV6_ADDR=") {
-			contents := strings.Trim(line[len("LXD_IPVN_ADDR="):], " \"")
+		} else if strings.HasPrefix(line, "LXD_IPV4_ADDR=") {
+			contents := strings.Trim(line[len("LXD_IPV4_ADDR="):], " \"")
 			if len(contents) > 0 {
 				foundSubnetConfig = true
+			}
+		} else if strings.HasPrefix(line, "LXD_IPV6_ADDR=") {
+			contents := strings.Trim(line[len("LXD_IPV6_ADDR="):], " \"")
+			if len(contents) > 0 {
+				return bridgeConfigError(LXDBridgeFile+" has IPV6 configuration, which juju doesn't support.")
 			}
 		}
 	}

--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -336,6 +336,17 @@ It looks like your lxdbr0 has not yet been configured. Please configure it via:
 and then bootstrap again.`, err)
 }
 
+func ipv6BridgeConfigError(filename string) error {
+       return errors.Errorf(`%s has IPv6 enabled.
+Juju doesn't currently support IPv6.
+
+IPv6 can be disabled by running:
+
+       sudo dpkg-reconfigure -p medium lxd
+
+and then bootstrap again.`, filename)
+}
+
 func checkLXDBridgeConfiguration(conf string) error {
 	foundSubnetConfig := false
 	for _, line := range strings.Split(conf, "\n") {
@@ -366,7 +377,7 @@ func checkLXDBridgeConfiguration(conf string) error {
 		} else if strings.HasPrefix(line, "LXD_IPV6_ADDR=") {
 			contents := strings.Trim(line[len("LXD_IPV6_ADDR="):], " \"")
 			if len(contents) > 0 {
-				return bridgeConfigError(LXDBridgeFile+" has IPV6 configuration, which juju doesn't support.")
+				return ipv6BridgeConfigError(LXDBridgeFile)
 			}
 		}
 	}

--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -271,8 +271,6 @@ func verifyDefaultProfileBridgeConfig(client *lxd.Client, networkAPISupported bo
 		return "", errors.Trace(err)
 	}
 
-	// If the default profile has eth0 in it, then the user has messed
-	// with it, so let's just use whatever they set up.
 	eth0, ok := config.Devices[configEth0]
 	if !ok {
 		/* on lxd >= 2.3, there is nothing in the default profile

--- a/tools/lxdclient/client_test.go
+++ b/tools/lxdclient/client_test.go
@@ -181,10 +181,12 @@ LXD_IPV6_ADDR="2001:470:b368:4242::1"
 `
 
 	err = checkLXDBridgeConfiguration(ipv6)
-	c.Assert(err.Error(), gc.Equals, LXDBridgeFile+` has IPV6 configuration, which juju doesn't support.
-It looks like your lxdbr0 has not yet been configured. Please configure it via:
+	c.Assert(err.Error(), gc.Equals, LXDBridgeFile+` has IPv6 enabled.
+Juju doesn't currently support IPv6.
 
-	sudo dpkg-reconfigure -p medium lxd
+IPv6 can be disabled by running:
+
+       sudo dpkg-reconfigure -p medium lxd
 
 and then bootstrap again.`)
 

--- a/tools/lxdclient/client_test.go
+++ b/tools/lxdclient/client_test.go
@@ -174,6 +174,20 @@ It looks like your lxdbr0 has not yet been configured. Please configure it via:
 
 and then bootstrap again.`)
 
+	ipv6 := `
+USE_LXD_BRIDGE="true"
+LXD_BRIDGE="lxdbr0"
+LXD_IPV6_ADDR="2001:470:b368:4242::1"
+`
+
+	err = checkLXDBridgeConfiguration(ipv6)
+	c.Assert(err.Error(), gc.Equals, LXDBridgeFile+` has IPV6 configuration, which juju doesn't support.
+It looks like your lxdbr0 has not yet been configured. Please configure it via:
+
+	sudo dpkg-reconfigure -p medium lxd
+
+and then bootstrap again.`)
+
 }
 
 func (cs *ConnectSuite) TestRemoteConnectError(c *gc.C) {


### PR DESCRIPTION
Also add a check in case the default bridge for eth0 has ipv6, which looks
something like:

$ juju bootstrap lxd lxd
ERROR creating LXD client: juju doesn't support ipv6. Please disable LXD's IPV6:

	$ lxc network set lxdbr0 ipv6.address none

and rebootstrap

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>