### PR TITLE
apiserver: Separate clock for pinger

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -143,7 +143,7 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 	a.loggedIn = true
 
 	if !controllerMachineLogin {
-		if err := startPingerIfAgent(a.srv.clock, a.root, entity); err != nil {
+		if err := startPingerIfAgent(a.srv.pingClock, a.root, entity); err != nil {
 			return fail, errors.Trace(err)
 		}
 	}

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -44,6 +44,7 @@ const loginRateLimit = 10
 type Server struct {
 	tomb              tomb.Tomb
 	clock             clock.Clock
+	pingClock         clock.Clock
 	wg                sync.WaitGroup
 	state             *state.State
 	statePool         *state.StatePool
@@ -81,6 +82,7 @@ type LoginValidator func(params.LoginRequest) error
 // ServerConfig holds parameters required to set up an API server.
 type ServerConfig struct {
 	Clock       clock.Clock
+	PingClock   clock.Clock
 	Cert        string
 	Key         string
 	Tag         names.Tag
@@ -124,6 +126,13 @@ func (c *ServerConfig) Validate() error {
 	return nil
 }
 
+func (c *ServerConfig) pingClock() clock.Clock {
+	if c.PingClock == nil {
+		return c.Clock
+	}
+	return c.PingClock
+}
+
 // NewServer serves the given state by accepting requests on the given
 // listener, using the given certificate and key (in PEM format) for
 // authentication.
@@ -156,6 +165,7 @@ func newServer(s *state.State, lis net.Listener, cfg ServerConfig) (_ *Server, e
 
 	srv := &Server{
 		clock:       cfg.Clock,
+		pingClock:   cfg.pingClock(),
 		lis:         lis,
 		newObserver: cfg.NewObserver,
 		state:       s,

--- a/apiserver/pinger_test.go
+++ b/apiserver/pinger_test.go
@@ -19,18 +19,20 @@ import (
 	coretesting "github.com/juju/juju/testing"
 )
 
+// pingerSuite exercises the apiserver's ping timeout functionality
+// from the outside. Ping API requests are made (or not) to a running
+// API server to ensure that the server shuts down the API connection
+// as expected once there's been no pings within the timeout period.
 type pingerSuite struct {
 	apiserverBaseSuite
 }
 
 var _ = gc.Suite(&pingerSuite{})
 
-var testPingPeriod = 100 * time.Millisecond
-
 func (s *pingerSuite) newServerWithTestClock(c *gc.C) (*apiserver.Server, *testing.Clock) {
 	clock := testing.NewClock(time.Now())
 	config := s.sampleConfig(c)
-	config.Clock = clock
+	config.PingClock = clock
 	server := s.newServer(c, config)
 	return server, clock
 }


### PR DESCRIPTION
Allow a separate clock to be used for the apiserver's connection ping timeout functionality. Without this it's impossible to test the ping functionality reliabily as there are a number of goroutines in the apiserver which wait on the server's clock.

If a pinger clock isn't specified, the server's main clock is used.

Likely fix for https://bugs.launchpad.net/juju/+bug/1632412

### QA 

Bootstrapped controller and deployed some units, then examined logs for problems or unusual activity.