### PR TITLE
If register fails, clear the macaroons that may have been stored.

### DIFF
--- a/cmd/juju/user/logout.go
+++ b/cmd/juju/user/logout.go
@@ -135,16 +135,8 @@ this command again with the "--force" flag.
 	if err != nil {
 		return errors.Trace(err)
 	}
-	apictx, err := c.APIContext()
-	if err != nil {
+	if err := c.ClearControllerMacaroons(details.APIEndpoints); err != nil {
 		return errors.Trace(err)
-	}
-
-	for _, s := range details.APIEndpoints {
-		apictx.Jar.RemoveAllHost(s)
-	}
-	if err := apictx.Jar.Save(); err != nil {
-		return errors.Annotate(err, "can't remove cached authentication cookie")
 	}
 
 	// Remove the account credentials.

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -276,6 +276,23 @@ func (c *JujuCommandBase) APIContext() (*APIContext, error) {
 	return c.apiContext, nil
 }
 
+// ClearControllerMacaroons will remove all macaroons stored
+// for the controller from the persistent cookie jar.
+// This is called both from 'juju logout' and a failed 'juju register'.
+func (c *JujuCommandBase) ClearControllerMacaroons(endpoints []string) error {
+	apictx, err := c.APIContext()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, s := range endpoints {
+		apictx.Jar.RemoveAllHost(s)
+	}
+	if err := apictx.Jar.Save(); err != nil {
+		return errors.Annotate(err, "can't remove cached authentication cookie")
+	}
+	return nil
+}
+
 func (c *JujuCommandBase) setCmdContext(ctx *cmd.Context) {
 	c.cmdContext = ctx
 }


### PR DESCRIPTION
This branch fixes the last remaining hole (that we know of) related to http://pad.lv/1632404.

If register fails for any reason, clear any macaroons that may have been stored for the controller.

I can't work out how to test this in a unit test, but have done much interactive testing.