### PR TITLE
New upgrade step to rename addmodel permission

### DIFF
--- a/upgrades/steps_20.go
+++ b/upgrades/steps_20.go
@@ -20,6 +20,13 @@ func stateStepsFor20() []Step {
 				return state.StripLocalUserDomain(context.State())
 			},
 		},
+		&upgradeStep{
+			description: "rename addmodel permission to add-model",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.RenameAddModelPermission(context.State())
+			},
+		},
 	}
 }
 

--- a/upgrades/steps_20_test.go
+++ b/upgrades/steps_20_test.go
@@ -31,6 +31,12 @@ func (s *steps20Suite) TestStripLocalUserDomain(c *gc.C) {
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
 
+func (s *steps20Suite) TestRenameAddModelPermission(c *gc.C) {
+	step := findStateStep(c, v200, "rename addmodel permission to add-model")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}
+
 func (s *steps20Suite) TestCharmGetCacheDir(c *gc.C) {
 	// Create a cache directory with some stuff in it.
 	dataDir := c.MkDir()


### PR DESCRIPTION
addmodel permission was recently renamed to add-model.
This PR adds upgrade steps to convert any existing values.

QA: bootstrap older juju. Add addmodel permission to a user. upgrade. Check permission updated.