### PR TITLE
apiserver: listen on localhost in tests

### DIFF
--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -625,12 +625,14 @@ func newServer(c *gc.C, st *state.State) (*api.Info, *apiserver.Server) {
 // server configuration may be specified (see defaultServerConfig
 // for a suitable starting point).
 func newServerWithConfig(c *gc.C, st *state.State, cfg apiserver.ServerConfig) (*api.Info, *apiserver.Server) {
+	// Note that we can't listen on localhost here because TestAPIServerCanListenOnBothIPv4AndIPv6 assumes
+	// that we listen on IPv6 too, and listening on localhost does not do that.
 	listener, err := net.Listen("tcp", ":0")
 	c.Assert(err, jc.ErrorIsNil)
 	srv, err := apiserver.NewServer(st, listener, cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	return &api.Info{
-		Addrs:  []string{srv.Addr().String()},
+		Addrs:  []string{fmt.Sprintf("localhost:%d", srv.Addr().Port)},
 		CACert: coretesting.CACert,
 	}, srv
 }


### PR DESCRIPTION
The old newServer code listened on ":0" not localhost,
but that wasn't a problem because nothing relied
on dialing the address taken from the listener.

When the two server-starting pieces of code were consolidated
into one, we didn't change the code to listen on "localhost:0"
instead of ":0", which causes the tests to fail on Windows
where dialing 0.0.0.0 doesn't count as dialing localhost.

Fixes https://bugs.launchpad.net/juju/+bug/1466011.