### PR TITLE
Remove deprecated streams directory

### DIFF
--- a/environs/sync/sync.go
+++ b/environs/sync/sync.go
@@ -76,7 +76,7 @@ type ToolsUploader interface {
 func SyncTools(syncContext *SyncContext) error {
 	sourceDataSource, err := selectSourceDatasource(syncContext)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	logger.Infof("listing available tools")
@@ -93,8 +93,8 @@ func SyncTools(syncContext *SyncContext) error {
 	if syncContext.Stream == "" {
 		// We now store the tools in a directory named after their stream, but the
 		// legacy behaviour is to store all tools in a single "releases" directory.
-		toolsDir = envtools.LegacyReleaseDirectory
-		syncContext.Stream = envtools.PreferredStream(&jujuversion.Current, false, syncContext.Stream)
+		toolsDir = envtools.ReleasedStream
+		syncContext.Stream = envtools.PreferredStream(&jujuversion.Current, false, "")
 	}
 	sourceTools, err := envtools.FindToolsForCloud(
 		[]simplestreams.DataSource{sourceDataSource}, simplestreams.CloudSpec{},
@@ -108,7 +108,7 @@ func SyncTools(syncContext *SyncContext) error {
 			envtools.ReleasedStream, syncContext.MajorVersion, syncContext.MinorVersion, coretools.Filter{})
 	}
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	logger.Infof("found %d tools", len(sourceTools))
@@ -126,7 +126,7 @@ func SyncTools(syncContext *SyncContext) error {
 	switch err {
 	case nil, coretools.ErrNoMatches, envtools.ErrNoTools:
 	default:
-		return err
+		return errors.Trace(err)
 	}
 	for _, tool := range targetTools {
 		logger.Debugf("found target tool: %v", tool)

--- a/environs/tools/simplestreams.go
+++ b/environs/tools/simplestreams.go
@@ -51,9 +51,6 @@ var currentStreamsVersion = StreamsVersionV1
 var DefaultBaseURL = "https://streams.canonical.com/juju/tools"
 
 const (
-	// Legacy release directory for Juju < 1.21.
-	LegacyReleaseDirectory = "releases"
-
 	// Used to specify the released tools metadata.
 	ReleasedStream = "released"
 


### PR DESCRIPTION
This addresses lp:1613858.

When running `juju metadata generate-tools`, Juju would attempt to look in a deprecated path "releases" for tools to generate streams. If you specified a value in the `--stream` flag (e.g. "devel"), Juju would work correctly. This was because we set this flag to the 1.x default of "releases" (notice: not "released").

This patch sets the default of the `stream` flag to envtools.ReleasedStream to give some transparancy to the user and follow a more common idiom. This also fixes the bug.

I also added some `errors.Trace` around error paths in the functions I touched.