### PR TITLE
Fix region handling in model-defaults --reset

### DIFF
--- a/cmd/juju/cloud/updatecredential_test.go
+++ b/cmd/juju/cloud/updatecredential_test.go
@@ -24,7 +24,13 @@ type updateCredentialSuite struct {
 var _ = gc.Suite(&updateCredentialSuite{})
 
 func (s *updateCredentialSuite) TestBadArgs(c *gc.C) {
-	cmd := cloud.NewUpdateCredentialCommand()
+	store := &jujuclienttesting.MemStore{
+		Controllers: map[string]jujuclient.ControllerDetails{
+			"controller": {},
+		},
+		CurrentControllerName: "controller",
+	}
+	cmd := cloud.NewUpdateCredentialCommandForTest(store, nil)
 	_, err := testing.RunCommand(c, cmd)
 	c.Assert(err, gc.ErrorMatches, "Usage: juju update-credential <cloud-name> <credential-name>")
 	_, err = testing.RunCommand(c, cmd, "cloud", "credential", "extra")

--- a/cmd/juju/model/defaultscommand.go
+++ b/cmd/juju/model/defaultscommand.go
@@ -40,8 +40,12 @@ Examples:
     juju model-defaults http-proxy
     juju model-defaults -m mymodel type
     juju model-defaults ftp-proxy=10.0.0.1:8000
+    juju model-defaults aws/us-east-1 ftp-proxy=10.0.0.1:8000
+    juju model-defaults us-east-1 ftp-proxy=10.0.0.1:8000
     juju model-defaults -m othercontroller:mymodel default-series=yakkety test-mode=false
     juju model-defaults --reset default-series test-mode
+    juju model-defaults aws/us-east-1 --reset http-proxy
+    juju model-defaults us-east-1 --reset http-proxy
 
 See also:
     models
@@ -596,7 +600,7 @@ func formatDefaultConfigTabular(writer io.Writer, value interface{}) error {
 	}
 	sort.Strings(valueNames)
 
-	w.Println("ATTRIBUTE", "DEFAULT", "CONTROLLER")
+	w.Println("Attribute", "Default", "Controller")
 
 	for _, name := range valueNames {
 		info := defaultValues[name]

--- a/cmd/juju/model/defaultscommand_test.go
+++ b/cmd/juju/model/defaultscommand_test.go
@@ -307,7 +307,7 @@ func (s *DefaultsCommandSuite) TestGetSingleValue(c *gc.C) {
 
 	output := strings.TrimSpace(testing.Stdout(context))
 	expected := "" +
-		"ATTRIBUTE       DEFAULT      CONTROLLER\n" +
+		"Attribute       Default      Controller\n" +
 		"attr2           -            bar\n" +
 		"  dummy-region  dummy-value  -"
 	c.Assert(output, gc.Equals, expected)
@@ -353,7 +353,7 @@ func (s *DefaultsCommandSuite) TestGetAllValuesTabular(c *gc.C) {
 
 	output := strings.TrimSpace(testing.Stdout(context))
 	expected := "" +
-		"ATTRIBUTE       DEFAULT      CONTROLLER\n" +
+		"Attribute       Default      Controller\n" +
 		"attr            foo          -\n" +
 		"attr2           -            bar\n" +
 		"  dummy-region  dummy-value  -"

--- a/cmd/juju/model/grantrevoke_test.go
+++ b/cmd/juju/model/grantrevoke_test.go
@@ -4,6 +4,8 @@
 package model_test
 
 import (
+	"strings"
+
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -127,7 +129,7 @@ func (s *grantSuite) TestInitGrantAddModel(c *gc.C) {
 	// The backwards-compatible case, addmodel.
 	err = testing.InitCommand(wrappedCmd, []string{"bob", "addmodel"})
 	c.Check(err, jc.ErrorIsNil)
-	c.Assert(grantCmd.ModelAccess, gc.Equals, "add-model")
+	c.Assert(grantCmd.Access, gc.Equals, "add-model")
 }
 
 type revokeSuite struct {
@@ -171,7 +173,21 @@ func (s *grantSuite) TestInitRevokeAddModel(c *gc.C) {
 	// The backwards-compatible case, addmodel.
 	err = testing.InitCommand(wrappedCmd, []string{"bob", "addmodel"})
 	c.Check(err, jc.ErrorIsNil)
-	c.Assert(revokeCmd.ModelAccess, gc.Equals, "add-model")
+	c.Assert(revokeCmd.Access, gc.Equals, "add-model")
+}
+
+func (s *grantSuite) TestModelAccessForController(c *gc.C) {
+	wrappedCmd, _ := model.NewRevokeCommandForTest(s.fake, s.store)
+	err := testing.InitCommand(wrappedCmd, []string{"bob", "write"})
+	msg := strings.Replace(err.Error(), "\n", "", -1)
+	c.Check(msg, gc.Matches, `You have specified a model access permission "write".*`)
+}
+
+func (s *grantSuite) TestControllerAccessForModel(c *gc.C) {
+	wrappedCmd, _ := model.NewRevokeCommandForTest(s.fake, s.store)
+	err := testing.InitCommand(wrappedCmd, []string{"bob", "superuser", "default"})
+	msg := strings.Replace(err.Error(), "\n", "", -1)
+	c.Check(msg, gc.Matches, `You have specified a controller access permission "superuser".*`)
 }
 
 type fakeGrantRevokeAPI struct {

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -270,10 +270,6 @@ func (w *sysCommandWrapper) Init(args []string) error {
 	store = QualifyingClientStore{store}
 	w.SetClientStore(store)
 
-	return w.ControllerCommand.Init(args)
-}
-
-func (w *sysCommandWrapper) Run(ctx *cmd.Context) error {
 	if w.setControllerFlags {
 		if w.controllerName == "" && w.useDefaultController {
 			store := w.ClientStore()
@@ -292,7 +288,7 @@ func (w *sysCommandWrapper) Run(ctx *cmd.Context) error {
 			return translateControllerError(w.ClientStore(), err)
 		}
 	}
-	return w.ControllerCommand.Run(ctx)
+	return w.ControllerCommand.Init(args)
 }
 
 func translateControllerError(store jujuclient.ClientStore, err error) error {

--- a/cmd/modelcmd/controller_test.go
+++ b/cmd/modelcmd/controller_test.go
@@ -23,9 +23,7 @@ type ControllerCommandSuite struct {
 var _ = gc.Suite(&ControllerCommandSuite{})
 
 func (s *ControllerCommandSuite) TestControllerCommandNoneSpecified(c *gc.C) {
-	cmd, _, err := initTestControllerCommand(c, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	err = cmd.Run(nil)
+	_, _, err := initTestControllerCommand(c, nil)
 	c.Assert(errors.Cause(err), gc.Equals, modelcmd.ErrNoControllersDefined)
 }
 


### PR DESCRIPTION
A few fixes here:
1. juju model-defaults region --reset foo
Fixed to work properly with region specified. The fix was to revert a change made elsewhere in sysCmdWrapper
2. Fix case of table headers in model-defaults command
3. Improve error message for juju grant

Also added feature tests for model-defaults command to test the issue fixed.