### PR TITLE
juju model-defaults supports region for get

### DIFF
--- a/cmd/juju/model/fakeenv_test.go
+++ b/cmd/juju/model/fakeenv_test.go
@@ -97,7 +97,11 @@ func (s *fakeModelDefaultEnvSuite) SetUpTest(c *gc.C) {
 				Controller: "bar",
 				Regions: []config.RegionDefaultValue{{
 					"dummy-region",
-					"dummy-value"}}},
+					"dummy-value",
+				}, {
+					"another-region",
+					"another-value",
+				}}},
 		},
 	}
 	s.fakeCloudAPI = &fakeCloudAPI{

--- a/featuretests/cmd_juju_model_test.go
+++ b/featuretests/cmd_juju_model_test.go
@@ -141,6 +141,19 @@ special    -        known
 `[1:])
 }
 
+func (s *cmdModelSuite) TestModelDefaultsGetRegion(c *gc.C) {
+	err := s.State.UpdateModelConfigDefaultValues(map[string]interface{}{"special": "known"}, nil, &environs.RegionSpec{"dummy", "dummy-region"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	context := s.run(c, "model-defaults", "dummy-region", "special")
+	c.Assert(testing.Stdout(context), gc.Equals, `
+Attribute       Default  Controller
+special         -        -
+  dummy-region  known    -
+
+`[1:])
+}
+
 func (s *cmdModelSuite) TestModelDefaultsSet(c *gc.C) {
 	s.run(c, "model-defaults", "special=known")
 	defaults, err := s.State.ModelConfigDefaultValues()


### PR DESCRIPTION
juju model-defaults command now supports specifying a region for which we want the default values.
$ juju model-defaults us-east-1

QA. bootstrap aws, set some defaults
$juju model-defaults us-east-1 
Attribute    Default  Controller
ftp-proxy    ""       -
  us-east-1  foobar   -
no-proxy     ""       -
  us-east-1  foo      -
