### PR TITLE
Swap bootstrap controller and cloud args

### DIFF
--- a/cmd/juju/commands/bootstrap_interactive.go
+++ b/cmd/juju/commands/bootstrap_interactive.go
@@ -91,15 +91,11 @@ func queryRegion(cloud string, regions []jujucloud.Region, scanner *bufio.Scanne
 	return regionName, nil
 }
 
-func defaultControllerName(username, cloudname, region string, cloud *jujucloud.Cloud) string {
-	name := cloudname
-	if len(cloud.Regions) > 1 {
-		name = region
+func defaultControllerName(cloudname, region string) string {
+	if region == "" {
+		return cloudname
 	}
-	if username == "" {
-		return name
-	}
-	return username + "-" + name
+	return cloudname + "-" + region
 }
 
 func queryName(defName string, scanner *bufio.Scanner, w io.Writer) (string, error) {

--- a/cmd/juju/commands/bootstrap_interactive_test.go
+++ b/cmd/juju/commands/bootstrap_interactive_test.go
@@ -42,7 +42,7 @@ func (BSInteractSuite) TestInitBuildAgent(c *gc.C) {
 func (BSInteractSuite) TestInitArg(c *gc.C) {
 	cmd := &bootstrapCommand{}
 	err := jujutesting.InitCommand(cmd, []string{"foo"})
-	c.Assert(err, gc.ErrorMatches, "controller name and cloud name are required")
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmd.interactive, jc.IsFalse)
 }
 


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju/+bug/1632919

The arg order for cloud and controller for bootstrap are swapped.
$ juju bootstrap aws myctrlname

Controller name is optional (controller name will be cloud-region):
$ juju bootstrap aws

Another change as per the bug is that if the cloud has no regions, the default controller name will just be the cloud and, and not user-cloud.

QA
$ juju bootstrap aws
Creating Juju controller "aws-us-east-1" on aws/us-east-1
...

$ juju bootstrap aws/us-west-1
Creating Juju controller "aws-us-west-1" on aws/us-east-1
...

$ juju bootstrap aws ian
Creating Juju controller "ian" on aws/us-east-1
...