### PR TITLE
network: Added ReachableHostPort() and a few helpers

### DIFF
--- a/juju/api.go
+++ b/juju/api.go
@@ -290,7 +290,7 @@ func PrepareEndpointsForCaching(
 func usableHostPorts(hps [][]network.HostPort) []network.HostPort {
 	collapsed := network.CollapseHostPorts(hps)
 	usable := network.FilterUnusableHostPorts(collapsed)
-	unique := network.DropDuplicatedHostPorts(usable)
+	unique := network.UniqueHostPorts(usable)
 	return unique
 }
 

--- a/network/hostport.go
+++ b/network/hostport.go
@@ -247,11 +247,6 @@ type Dialer interface {
 	Dial(network, address string) (net.Conn, error)
 }
 
-type dialResult struct {
-	endpoint HostPort
-	err      error
-}
-
 // FastestHostPort dials the unique entries in the given hostPorts, in parallel,
 // using the given dialer, closing successfully established connections
 // immediately. Individual connection errors are discarded, and an error is

--- a/network/hostport.go
+++ b/network/hostport.go
@@ -263,7 +263,7 @@ func FastestHostPort(hostPorts []HostPort, dialer Dialer, timeout time.Duration)
 		go func(hp HostPort) {
 			conn, err := dialer.Dial("tcp", hp.NetAddr())
 			if err == nil {
-				defer conn.Close()
+				conn.Close()
 				successful <- hp
 			}
 		}(hostPort)

--- a/network/hostport.go
+++ b/network/hostport.go
@@ -247,7 +247,7 @@ type Dialer interface {
 	Dial(network, address string) (net.Conn, error)
 }
 
-// FastestHostPort dials the unique entries in the given hostPorts, in parallel,
+// ReachableHostPort dials the entries in the given hostPorts, in parallel,
 // using the given dialer, closing successfully established connections
 // immediately. Individual connection errors are discarded, and an error is
 // returned only if none of the hostPorts can be reached when the given timeout
@@ -255,7 +255,7 @@ type Dialer interface {
 //
 // Usually, a net.Dialer initialized with a non-empty Timeout field is passed
 // for dialer.
-func FastestHostPort(hostPorts []HostPort, dialer Dialer, timeout time.Duration) (HostPort, error) {
+func ReachableHostPort(hostPorts []HostPort, dialer Dialer, timeout time.Duration) (HostPort, error) {
 	uniqueHPs := UniqueHostPorts(hostPorts)
 	successful := make(chan HostPort, 1)
 

--- a/network/hostport_test.go
+++ b/network/hostport_test.go
@@ -10,9 +10,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/network"
@@ -402,43 +400,6 @@ func (*HostPortSuite) TestNetAddrAndString(c *gc.C) {
 	}
 }
 
-func (s *HostPortSuite) TestDropDuplicatedHostPorts(c *gc.C) {
-	hps := s.makeHostPorts()
-	noDups := network.DropDuplicatedHostPorts(hps)
-	c.Assert(noDups, gc.Not(gc.HasLen), len(hps))
-	c.Assert(noDups, jc.DeepEquals, append(
-		network.NewHostPorts(1234,
-			"127.0.0.1",
-			"localhost",
-			"example.com",
-			"127.0.1.1",
-			"example.org",
-			"2001:db8::2",
-			"169.254.1.1",
-			"example.net",
-			"invalid host",
-			"fd00::22",
-			"2001:db8::1",
-			"169.254.1.2",
-			"ff01::22",
-			"0.1.2.0",
-			"10.0.0.1",
-			"::1",
-			"fc00::1",
-			"fe80::2",
-			"172.16.0.1",
-			"8.8.8.8",
-			"7.8.8.8",
-		),
-		network.NewHostPorts(9999,
-			"127.0.0.1",   // machine-local
-			"10.0.0.1",    // cloud-local
-			"2001:db8::1", // public
-			"fe80::2",     // link-local
-		)...,
-	))
-}
-
 func (s *HostPortSuite) TestHostPortsToStrings(c *gc.C) {
 	hps := s.makeHostPorts()
 	strHPs := network.HostPortsToStrings(hps)
@@ -518,125 +479,34 @@ func (s *HostPortSuite) TestUniqueHostPortsSimpleInput(c *gc.C) {
 	input := network.NewHostPorts(1234, "127.0.0.1", "::1")
 	expected := input
 
-	// Ensure it works just the same with nil or already-closed stop channel.
-	stopChannels := []chan struct{}{
-		nil,
-		make(chan struct{}), // closed below.
-		make(chan struct{}),
-	}
-	close(stopChannels[1])
-
-	for _, stopChannel := range stopChannels {
-		results := network.UniqueHostPorts(stopChannel, input)
-		s.assertUniqueHostPorts(c, stopChannel, results, expected)
-		s.ensureStopped(c, stopChannel)
-		s.assertClosed(c, results)
-	}
+	results := network.UniqueHostPorts(input)
+	c.Assert(results, jc.DeepEquals, expected)
 }
 
 func (s *HostPortSuite) TestUniqueHostPortsOnlyDuplicates(c *gc.C) {
 	input := s.manyHostPorts(c, 10000, 1234) // use the same port for all.
 	expected := input[0:1]
-	stop := make(chan struct{})
 
-	results := network.UniqueHostPorts(stop, input)
-	s.assertUniqueHostPorts(c, stop, results, expected)
-	s.ensureStopped(c, stop)
-	s.assertClosed(c, results)
+	results := network.UniqueHostPorts(input)
+	c.Assert(results, jc.DeepEquals, expected)
 }
 
 func (s *HostPortSuite) TestUniqueHostPortsHugeUniqueInput(c *gc.C) {
 	input := s.manyHostPorts(c, maxTCPPort, -1) // use sequential ports from 1.
 	expected := input
-	stop := make(chan struct{})
 
-	results := network.UniqueHostPorts(stop, input)
-	s.assertUniqueHostPorts(c, stop, results, expected)
-	s.ensureStopped(c, stop)
-	s.assertClosed(c, results)
-}
-
-func (s *HostPortSuite) TestUniqueHostPortsHugeInputEarlyStop(c *gc.C) {
-	input := s.manyHostPorts(c, maxTCPPort, -1) // use sequential ports from 1.
-	expected := input
-
-	// Ensure we can stop before consuming all input.
-	stoppedEarly := make(chan struct{})
-	go func() {
-		time.Sleep(coretesting.ShortWait / 2)
-		close(stoppedEarly)
-	}()
-	results := network.UniqueHostPorts(stoppedEarly, input)
-	s.assertUniqueHostPorts(c, stoppedEarly, results, expected)
-	s.ensureStopped(c, stoppedEarly)
-	s.assertClosed(c, results)
-}
-
-func (s *HostPortSuite) TestDialHostPortSuccess(c *gc.C) {
-	delay := 42 * time.Millisecond
-	stub, clock, dialer := s.setupDialingStubs(delay)
-	hostPort := network.NewHostPorts(1234, "localhost")[0]
-
-	select {
-	case result := <-network.DialHostPort(hostPort, dialer, clock):
-		c.Check(result.Endpoint, jc.DeepEquals, &hostPort)
-		c.Check(result.Error, jc.ErrorIsNil)
-		c.Check(result.Duration, gc.Equals, delay)
-
-		stub.CheckCallNames(c,
-			"Dial",  // dialer.Dial()
-			"Close", // dialed conn.Close()
-		)
-		stub.CheckCall(c, 0, "Dial", "tcp", "localhost:1234")
-		stub.ResetCalls()
-
-	case <-time.After(coretesting.ShortWait):
-		c.Fatalf("timed out waiting for a result")
-	}
-}
-
-func (s *HostPortSuite) TestDialHostPortError(c *gc.C) {
-	delay := 42 * time.Millisecond
-	stub, clock, dialer := s.setupDialingStubs(delay)
-	stub.SetErrors(errors.New("boom!"))
-	hostPort := network.NewHostPorts(1234, "localhost")[0]
-
-	select {
-	case result := <-network.DialHostPort(hostPort, dialer, clock):
-		c.Check(result.Endpoint, jc.DeepEquals, &hostPort)
-		c.Check(result.Error, gc.ErrorMatches, "boom!")
-		c.Check(result.Duration, gc.Equals, delay)
-
-	case <-time.After(coretesting.ShortWait):
-		c.Fatalf("timed out waiting for a result")
-	}
+	results := network.UniqueHostPorts(input)
+	c.Assert(results, jc.DeepEquals, expected)
 }
 
 func (s *HostPortSuite) TestFastestHostPortAllUnreachable(c *gc.C) {
 	dialer := &net.Dialer{Timeout: 100 * time.Millisecond}
-	clock := testing.NewClock(coretesting.ZeroTime())
 	unreachableHPs := s.manyHostPorts(c, 10000, 49151) // IANA reserved port
+	timeout := 300 * time.Millisecond
 
-	best, err := network.FastestHostPort(dialer, clock, unreachableHPs)
+	best, err := network.FastestHostPort(unreachableHPs, dialer, timeout)
 	c.Check(err, gc.ErrorMatches, "cannot connect to any address: .*")
 	c.Check(best, gc.Equals, network.HostPort{})
-}
-
-func (s *HostPortSuite) TestFastestHostPortPicksFastest(c *gc.C) {
-	_, clock, dialer := s.setupDialingStubs(0) // no fixed delay
-	hostPorts := s.manyHostPorts(c, 100, -1)   // IANA reserved port
-
-	initialDelay := 10000 * time.Millisecond
-	delayStep := 10 * time.Millisecond
-	dialer.dialDelayFunc = func() time.Duration {
-		currentDelay := initialDelay
-		initialDelay -= delayStep
-		return currentDelay
-	}
-
-	best, err := network.FastestHostPort(dialer, clock, hostPorts)
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(best, jc.DeepEquals, hostPorts[99]) // last one had the lowest duration.
 }
 
 func (s *HostPortSuite) TestFastestHostPortRealDial(c *gc.C) {
@@ -645,59 +515,12 @@ func (s *HostPortSuite) TestFastestHostPortRealDial(c *gc.C) {
 		fakeHostPort,
 		testTCPServer(c),
 	}
+	timeout := 300 * time.Millisecond
 
 	dialer := &net.Dialer{Timeout: 100 * time.Millisecond}
-	clock := clock.WallClock
-
-	best, err := network.FastestHostPort(dialer, clock, hostPorts)
+	best, err := network.FastestHostPort(hostPorts, dialer, timeout)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(best, jc.DeepEquals, hostPorts[1]) // the only real listener
-}
-
-func (s *HostPortSuite) assertUniqueHostPorts(c *gc.C, stop <-chan struct{}, input <-chan network.HostPort, expected []network.HostPort) {
-	numReceived, numExpected := 0, len(expected)
-	timeout := time.After(coretesting.LongWait)
-	for {
-		select {
-		case <-stop:
-			if numReceived < numExpected {
-				c.Logf("stopped: received %d of %d", numReceived, numExpected)
-			}
-			return
-
-		case result, ok := <-input:
-			if !ok {
-				if numReceived < numExpected {
-					c.Logf("stopped or done: received %d of %d", numReceived, numExpected)
-				}
-				return
-			}
-			c.Check(result, gc.Equals, expected[numReceived])
-			numReceived++
-
-		case <-timeout:
-			c.Fatalf("timed out waiting for HostPorts - received %d of %d", numReceived, numExpected)
-		}
-	}
-}
-
-func (s *HostPortSuite) assertClosed(c *gc.C, input <-chan network.HostPort) {
-	select {
-	case _, ok := <-input:
-		c.Check(ok, jc.IsFalse)
-	case <-time.After(coretesting.ShortWait):
-		c.Fatalf("timed out waiting for the input channel to close")
-	}
-}
-
-func (s *HostPortSuite) ensureStopped(c *gc.C, stop chan struct{}) {
-	select {
-	case <-stop:
-	default:
-		if stop != nil {
-			close(stop)
-		}
-	}
 }
 
 const maxTCPPort = 65535
@@ -716,69 +539,6 @@ func (s *HostPortSuite) manyHostPorts(c *gc.C, count, portToUse int) []network.H
 		results[i] = hostPort
 	}
 	return results
-}
-
-func (s *HostPortSuite) setupDialingStubs(delay time.Duration) (*testing.Stub, *fakeClock, *stubDialer) {
-	stub := &testing.Stub{}
-	clock := &fakeClock{
-		now:     coretesting.ZeroTime(),
-		advance: delay,
-	}
-	dialer := &stubDialer{
-		Stub:      stub,
-		clock:     clock,
-		dialDelay: delay,
-	}
-
-	return stub, clock, dialer
-}
-
-type stubDialer struct {
-	*testing.Stub
-	net.Conn
-
-	clock     *fakeClock
-	dialDelay time.Duration
-
-	dialDelayFunc func() time.Duration
-}
-
-// Dial implements network.Dialer.
-func (s *stubDialer) Dial(network, address string) (net.Conn, error) {
-	s.Stub.AddCall("Dial", network, address)
-
-	dialDelay := s.dialDelay
-	if s.dialDelayFunc != nil {
-		dialDelay = s.dialDelayFunc()
-	}
-	s.clock.Advance(dialDelay)
-
-	if err := s.Stub.NextErr(); err != nil {
-		return nil, err
-	}
-
-	return s, nil
-}
-
-// Close implements io.Closer, which is also implemented by net.Conn.
-func (s *stubDialer) Close() error {
-	s.Stub.AddCall("Close")
-	return s.Stub.NextErr()
-}
-
-type fakeClock struct {
-	clock.Clock
-
-	now     time.Time
-	advance time.Duration
-}
-
-func (f *fakeClock) Now() time.Time {
-	return f.now
-}
-
-func (f *fakeClock) Advance(duration time.Duration) {
-	f.now = f.now.Add(duration)
 }
 
 func testTCPServer(c *gc.C) network.HostPort {


### PR DESCRIPTION
Based on PR #6426, but using a different, hopefuly simpler  approach
with full test coverage. None of the added helpers are used yet, but
will be in a follow-up.

Prerequiste to fix http://pad.lv/1616098.