### PR TITLE
Controllers cmd help change.

### DIFF
--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -36,7 +36,7 @@ func (s *ListControllersSuite) TestListControllersEmptyStore(c *gc.C) {
 
 func (s *ListControllersSuite) TestListControllers(c *gc.C) {
 	s.expectedOutput = `
-Use --refresh to see the latest information.
+Use --refresh flag to see the latest information.
 
 Controller           Model       User   Access     Cloud/Region        Models  Machines  HA  Version
 aws-test             controller  -      -          aws/us-east-1            2         5   -  2.0.1      

--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -36,7 +36,7 @@ func (s *ListControllersSuite) TestListControllersEmptyStore(c *gc.C) {
 
 func (s *ListControllersSuite) TestListControllers(c *gc.C) {
 	s.expectedOutput = `
-Use --refresh flag to see the latest information.
+Use --refresh flag with this command to see the latest information.
 
 Controller           Model       User   Access     Cloud/Region        Models  Machines  HA  Version
 aws-test             controller  -      -          aws/us-east-1            2         5   -  2.0.1      

--- a/cmd/juju/controller/listcontrollersformatters.go
+++ b/cmd/juju/controller/listcontrollersformatters.go
@@ -35,7 +35,7 @@ func formatControllersTabular(writer io.Writer, set ControllerSet, promptRefresh
 	w := output.Wrapper{tw}
 
 	if promptRefresh && len(set.Controllers) > 0 {
-		fmt.Fprintln(writer, "Use --refresh flag to see the latest information.")
+		fmt.Fprintln(writer, "Use --refresh flag with this command to see the latest information.")
 		fmt.Fprintln(writer)
 	}
 	w.Println("Controller", "Model", "User", "Access", "Cloud/Region", "Models", "Machines", "HA", "Version")

--- a/cmd/juju/controller/listcontrollersformatters.go
+++ b/cmd/juju/controller/listcontrollersformatters.go
@@ -35,7 +35,7 @@ func formatControllersTabular(writer io.Writer, set ControllerSet, promptRefresh
 	w := output.Wrapper{tw}
 
 	if promptRefresh && len(set.Controllers) > 0 {
-		fmt.Fprintln(writer, "Use --refresh to see the latest information.")
+		fmt.Fprintln(writer, "Use --refresh flag to see the latest information.")
 		fmt.Fprintln(writer)
 	}
 	w.Println("Controller", "Model", "User", "Access", "Cloud/Region", "Models", "Machines", "HA", "Version")

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -72,7 +72,7 @@ func (s *cmdControllerSuite) createModelNormalUser(c *gc.C, modelname string, is
 func (s *cmdControllerSuite) TestControllerListCommand(c *gc.C) {
 	context := s.run(c, "list-controllers")
 	expectedOutput := `
-Use --refresh to see the latest information.
+Use --refresh flag with this command to see the latest information.
 
 Controller  Model       User   Access     Cloud/Region        Models  Machines  HA  Version
 kontroll*   controller  admin  superuser  dummy/dummy-region       -         -   -  (unknown)  


### PR DESCRIPTION
There is potential for user confusion about how to update controllers information when listing controllers.
We do guide users to "Use --refresh to see the latest information." 
However, sometimes users can interprete it as a direction to run "juju --refresh" (see https://bugs.launchpad.net/bugs/1632699)

This PR attempts to make obvious that --refresh is a flag on "juju controllers" command not "juju" itself.