### PR TITLE
Fixes lp#1633604: Renamed "service" to "application".

### DIFF
--- a/resource/cmd/output_tabular.go
+++ b/resource/cmd/output_tabular.go
@@ -65,7 +65,7 @@ func FormatSvcTabular(writer io.Writer, value interface{}) error {
 func formatServiceTabular(writer io.Writer, info FormattedServiceInfo) {
 	// TODO(ericsnow) sort the rows first?
 
-	fmt.Fprintln(writer, "[Service]")
+	fmt.Fprintln(writer, "[Application]")
 	tw := output.TabWriter(writer)
 	fmt.Fprintln(tw, "Resource\tSupplied by\tRevision")
 

--- a/resource/cmd/output_tabular_test.go
+++ b/resource/cmd/output_tabular_test.go
@@ -122,7 +122,7 @@ func (s *SvcTabularSuite) TestFormatServiceOkay(c *gc.C) {
 
 	data := s.formatTabular(c, formatted)
 	c.Check(data, gc.Equals, `
-[Service]
+[Application]
 Resource  Supplied by  Revision
 openjdk   charmstore   7
 `[1:])
@@ -251,7 +251,7 @@ func (s *SvcTabularSuite) TestFormatSvcTabularMulti(c *gc.C) {
 	data := s.formatTabular(c, formatted)
 	// Notes: sorted by name, then by revision, newest first.
 	c.Check(data, gc.Equals, `
-[Service]
+[Application]
 Resource  Supplied by  Revision
 openjdk   charmstore   7
 website   upload       -

--- a/resource/cmd/show_service.go
+++ b/resource/cmd/show_service.go
@@ -51,7 +51,7 @@ func (c *ShowServiceCommand) Info() *cmd.Info {
 		Name:    "resources",
 		Aliases: []string{"list-resources"},
 		Args:    "application-or-unit",
-		Purpose: "show the resources for a service or unit",
+		Purpose: "show the resources for an application or unit",
 		Doc: `
 This command shows the resources required by and those in use by an existing
 application or unit in your model.  When run for an application, it will also show any

--- a/resource/cmd/show_service_test.go
+++ b/resource/cmd/show_service_test.go
@@ -64,7 +64,7 @@ func (s *ShowServiceSuite) TestInfo(c *gc.C) {
 		Name:    "resources",
 		Aliases: []string{"list-resources"},
 		Args:    "application-or-unit",
-		Purpose: "show the resources for a service or unit",
+		Purpose: "show the resources for an application or unit",
 		Doc: `
 This command shows the resources required by and those in use by an existing
 application or unit in your model.  When run for an application, it will also show any
@@ -174,7 +174,7 @@ func (s *ShowServiceSuite) TestRun(c *gc.C) {
 	c.Check(stderr, gc.Equals, "")
 
 	c.Check(stdout, gc.Equals, `
-[Service]
+[Application]
 Resource  Supplied by  Revision
 openjdk   charmstore   7
 website   upload       -


### PR DESCRIPTION
An oversight during renaming -  resources command outputs "Service" instead of "Application".