### PR TITLE
Fix LXD domain name to be ".lxd" to match the default network configuration

### DIFF
--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -243,8 +243,6 @@ func CloudInitUserData(
 		cloudConfig.SetAttr("hostname", instanceConfig.MachineContainerHostname)
 	}
 
-	cloudConfig.SetAttr("manage_etc_hosts", true)
-
 	data, err := cloudConfig.RenderYAML()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -281,8 +281,6 @@ func (s *UserDataSuite) TestCloudInitUserDataFallbackConfig(c *gc.C) {
 		expectedLinesToMatch = append(expectedLinesToMatch, line)
 	}
 
-	expectedLinesToMatch = append(expectedLinesToMatch, "manage_etc_hosts: true")
-
 	c.Assert(strings.Join(linesToMatch, "\n")+"\n", gc.Equals, strings.Join(expectedLinesToMatch, "\n")+"\n")
 }
 
@@ -308,7 +306,6 @@ func (s *UserDataSuite) TestCloudInitUserDataFallbackConfigWithContainerHostname
 	}
 
 	expectedLinesToMatch = append(expectedLinesToMatch, "hostname: lxdhostname")
-	expectedLinesToMatch = append(expectedLinesToMatch, "manage_etc_hosts: true")
 
 	c.Assert(strings.Join(linesToMatch, "\n")+"\n", gc.Equals, strings.Join(expectedLinesToMatch, "\n")+"\n")
 }

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -212,7 +212,7 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams) (*lxdclien
 		cloudcfg.AddRunTextFile(serverCertPath, serverState.Environment.Certificate, 0600)
 	}
 
-	cloudcfg.SetAttr("hostname", hostname)
+	cloudcfg.SetAttr("fqdn", hostname+".lxd")
 	cloudcfg.SetAttr("manage_etc_hosts", true)
 
 	metadata, err := getMetadata(cloudcfg, args)
@@ -253,6 +253,7 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams) (*lxdclien
 		return nil, errors.Trace(err)
 	}
 	statusCallback(status.Running, "container started")
+
 	return inst, nil
 }
 


### PR DESCRIPTION

This is a temporary fix until we can discover the correct domain.

Don't set manage_etc_hosts in cloudconfig/containerinit because it isn't needed for non-LXD provider cases (or so it seems).

Tested by checking that .lxd is the domain used in LXD environments
1. Bootstrap a lxd environment + add a machine
2. juju ssh 0 hostname -f
3. ...should show hostname.lxd

Tested by checking that .lxd is not used in non-LXD environments (I tried MAAS)
1. Bootstrap a non-LXD environment + add a machine
2. juju ssh 0 hostname -f
3. ...should show $hostname.$something where $something != 'lxd'.

I have also tested by deploying a rabbitmq-server cluster on LXD, which needs name resolution to work.

Fixes:
http://pad.lv/1563271
http://pad.lv/1633126