### PR TITLE
Fix breakage that occurred adding get for a region

### DIFF
--- a/cmd/juju/model/defaultscommand.go
+++ b/cmd/juju/model/defaultscommand.go
@@ -217,7 +217,13 @@ func (c *defaultsCommand) Init(args []string) error {
 		// set args.
 		return c.handleSetArgs(args)
 	case len(args) == 0:
-		c.action = c.getDefaults
+		if len(c.resetKeys) == 0 {
+			// If there's no positional args and reset is not set then we're
+			// getting all attrs.
+			c.action = c.getDefaults
+			return nil
+		}
+		// Reset only.
 		return nil
 	case len(args) == 1:
 		// We want to get settings for the provided key.
@@ -519,6 +525,11 @@ func (c *defaultsCommand) getDefaults(client defaultsCommandAPI, ctx *cmd.Contex
 			return errors.New(msg)
 		}
 	}
+	if c.regionName != "" && len(attrs) == 0 {
+		return errors.New(fmt.Sprintf(
+			"there are no default model values in region %q", c.regionName))
+	}
+
 	// If c.keys is empty, write out the whole lot.
 	return c.out.Write(ctx, attrs)
 }

--- a/featuretests/cmd_juju_model_test.go
+++ b/featuretests/cmd_juju_model_test.go
@@ -44,6 +44,15 @@ func (s *cmdModelSuite) run(c *gc.C, args ...string) *cmd.Context {
 	return context
 }
 
+func (s *cmdModelSuite) runErr(c *gc.C, args ...string) (*cmd.Context, error) {
+	context := testing.Context(c)
+	jujuCmd := commands.NewJujuCommand(context)
+	err := testing.InitCommand(jujuCmd, args)
+	c.Assert(err, jc.ErrorIsNil)
+	err = jujuCmd.Run(context)
+	return context, err
+}
+
 func (s *cmdModelSuite) TestGrantModelCmdStack(c *gc.C) {
 	username := "bar@ubuntuone"
 	context := s.run(c, "grant", username, "read", "controller")
@@ -154,6 +163,26 @@ special         -        -
 `[1:])
 }
 
+func (s *cmdModelSuite) TestModelDefaultsGetOneRegionNoVal(c *gc.C) {
+	context, _ := s.runErr(c, "model-defaults", "dummy-region", "attr")
+	c.Assert(testing.Stdout(context), gc.Equals, "")
+	c.Assert(
+		testing.Stderr(context),
+		jc.DeepEquals,
+		`ERROR there are no default model values for "attr" in region "dummy-region"
+`)
+}
+
+func (s *cmdModelSuite) TestModelDefaultsGetRegionNoVal(c *gc.C) {
+	context, _ := s.runErr(c, "model-defaults", "dummy-region")
+	c.Assert(testing.Stdout(context), gc.Equals, "")
+	c.Assert(
+		testing.Stderr(context),
+		jc.DeepEquals,
+		`ERROR there are no default model values in region "dummy-region"
+`)
+}
+
 func (s *cmdModelSuite) TestModelDefaultsSet(c *gc.C) {
 	s.run(c, "model-defaults", "special=known")
 	defaults, err := s.State.ModelConfigDefaultValues()
@@ -177,7 +206,8 @@ func (s *cmdModelSuite) TestModelDefaultsReset(c *gc.C) {
 	err := s.State.UpdateModelConfigDefaultValues(map[string]interface{}{"special": "known"}, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.run(c, "model-defaults", "--reset", "special")
+	ctx := s.run(c, "model-defaults", "--reset", "special")
+	c.Check(testing.Stdout(ctx), jc.DeepEquals, "")
 	defaults, err := s.State.ModelConfigDefaultValues()
 	c.Assert(err, jc.ErrorIsNil)
 	_, found := defaults["special"]
@@ -188,7 +218,8 @@ func (s *cmdModelSuite) TestModelDefaultsResetRegion(c *gc.C) {
 	err := s.State.UpdateModelConfigDefaultValues(map[string]interface{}{"special": "known"}, nil, &environs.RegionSpec{"dummy", "dummy-region"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.run(c, "model-defaults", "dummy-region", "--reset", "special")
+	ctx := s.run(c, "model-defaults", "dummy-region", "--reset", "special")
+	c.Check(testing.Stdout(ctx), jc.DeepEquals, "")
 	defaults, err := s.State.ModelConfigDefaultValues()
 	c.Assert(err, jc.ErrorIsNil)
 	_, found := defaults["special"]


### PR DESCRIPTION
Ensure we aren't resetting and getting at the same time -- which is
invalid. When adding the feature to allow getting all settings
for a specific region we removed the check to see if reset was set and
prevent also setting getConfig from being called in Run. This fixes the
issue by putting the appropriate check in place and adding tests to
ensure there is no stdout when resetting.

Fixes: lp:1634197

QA: 
- Run the unit tests and ensure they all pass
- `juju bootstrap awstest reed/aws/us-west-1` a controller in a cloud with regions, using a config like; [awstest here]( https://gist.github.com/reedobrien/a8fd311fb44e647f2c496d6cdeefb285) 
- `juju model-defaults`    

```
    Attribute                   Default           Controller
    ...
    logging-config              ""                <root>=TRACE
    no-proxy                    ""                https://local
      us-east-1                 https://foo-east  -
      us-west-1                 https://foo-west  -
    provisioner-harvest-mode    destroyed         -
    ...
```
- `juju model-defaults us-east-1`
```
Attribute    Default           Controller
no-proxy     ""                https://local
  us-east-1  https://foo-east  -
```
- `juju model-defaults --reset ftp-proxy us-east-1` # no output
- `juju model-defaults --reset ftp-proxy` # no output
- `juju model-defaults --reset no-proxy us-east-1` # no output
- `juju model-defaults us-east-1` 
`ERROR there are no default model values in region "us-east-1"`
- `juju model-defaults us-east-1 no-proxy`  
`ERROR there are no default model values for "no-proxy" in region "us-east-1"`
