### PR TITLE
Add new aws us-east-2 region

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -7,6 +7,8 @@ clouds:
     regions:
       us-east-1:
         endpoint: https://ec2.us-east-1.amazonaws.com
+      us-east-2:
+        endpoint: https://ec2.us-east-2.amazonaws.com
       us-west-1:
         endpoint: https://ec2.us-west-1.amazonaws.com
       us-west-2:

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -14,6 +14,8 @@ clouds:
     regions:
       us-east-1:
         endpoint: https://ec2.us-east-1.amazonaws.com
+      us-east-2:
+        endpoint: https://ec2.us-east-2.amazonaws.com
       us-west-1:
         endpoint: https://ec2.us-west-1.amazonaws.com
       us-west-2:

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -36,6 +36,7 @@ func (s *regionsSuite) TestListRegions(c *gc.C) {
 	out := testing.Stdout(ctx)
 	c.Assert(out, jc.DeepEquals, `
 us-east-1
+us-east-2
 us-west-1
 us-west-2
 eu-west-1
@@ -57,6 +58,8 @@ func (s *regionsSuite) TestListRegionsYaml(c *gc.C) {
 	c.Assert(out, jc.DeepEquals, `
 us-east-1:
   endpoint: https://ec2.us-east-1.amazonaws.com
+us-east-2:
+  endpoint: https://ec2.us-east-2.amazonaws.com
 us-west-1:
   endpoint: https://ec2.us-west-1.amazonaws.com
 us-west-2:

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1399,6 +1399,7 @@ func (s *BootstrapSuite) TestBootstrapPrintCloudRegions(c *gc.C) {
 	c.Assert(coretesting.Stdout(ctx), jc.DeepEquals, `
 Showing regions for aws:
 us-east-1
+us-east-2
 us-west-1
 us-west-2
 eu-west-1


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju/+bug/1634289

Add new us-east-2 region for AWS.

QA: bootstrap aws/us-east-2