### PR TITLE
Revert the addition of the cloud-init flag manage_etc_hosts

### DIFF
--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -243,8 +243,6 @@ func CloudInitUserData(
 		cloudConfig.SetAttr("hostname", instanceConfig.MachineContainerHostname)
 	}
 
-	cloudConfig.SetAttr("manage_etc_hosts", true)
-
 	data, err := cloudConfig.RenderYAML()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -281,8 +281,6 @@ func (s *UserDataSuite) TestCloudInitUserDataFallbackConfig(c *gc.C) {
 		expectedLinesToMatch = append(expectedLinesToMatch, line)
 	}
 
-	expectedLinesToMatch = append(expectedLinesToMatch, "manage_etc_hosts: true")
-
 	c.Assert(strings.Join(linesToMatch, "\n")+"\n", gc.Equals, strings.Join(expectedLinesToMatch, "\n")+"\n")
 }
 
@@ -308,7 +306,6 @@ func (s *UserDataSuite) TestCloudInitUserDataFallbackConfigWithContainerHostname
 	}
 
 	expectedLinesToMatch = append(expectedLinesToMatch, "hostname: lxdhostname")
-	expectedLinesToMatch = append(expectedLinesToMatch, "manage_etc_hosts: true")
 
 	c.Assert(strings.Join(linesToMatch, "\n")+"\n", gc.Equals, strings.Join(expectedLinesToMatch, "\n")+"\n")
 }

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -212,9 +212,6 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams) (*lxdclien
 		cloudcfg.AddRunTextFile(serverCertPath, serverState.Environment.Certificate, 0600)
 	}
 
-	cloudcfg.SetAttr("hostname", hostname)
-	cloudcfg.SetAttr("manage_etc_hosts", true)
-
 	metadata, err := getMetadata(cloudcfg, args)
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
Reverts most changes in rev e6a7303. Tests have been kept and fixed up because they provide better coverage.

The bug that the above rev fixed (http://pad.lv/1593185) is no longer seen without this flag and that change introduced two new bugs (http://pad.lv/1563271 http://pad.lv/1633126).

# Testing performed:
On both the LXD and MAAS providers:

1. Bootstrap + add machine using LXD provider.
2. Check that hostname -f produces the correct output.

## Just LXD (no Juju):
This show that LXD itself gets this right, so either we stopped breaking something or LXD fixed something:
```
dooferlad@homework2 ~/dev/jujuWand $ lxc launch ubuntu-xenial
Creating communal-walrus
Starting communal-walrus

dooferlad@homework2 ~/dev/jujuWand $ lxc exec communal-walrus bash
root@communal-walrus:~# hostname -f 
communal-walrus.lxd
```