### PR TITLE
state: Added AllNetworkAddresses() and NetworkAddress() helpers

### DIFF
--- a/state/ipaddresses_internal_test.go
+++ b/state/ipaddresses_internal_test.go
@@ -123,6 +123,7 @@ func (s *ipAddressesInternalSuite) TestRemainingSimpleGetterMethods(c *gc.C) {
 	c.Check(result.DNSServers(), jc.DeepEquals, []string{"ns1.example.com", "ns2.example.org"})
 	c.Check(result.DNSSearchDomains(), jc.DeepEquals, []string{"example.com", "example.org"})
 	c.Check(result.GatewayAddress(), gc.Equals, "10.20.30.1")
+	c.Check(result.NetworkAddress(), jc.DeepEquals, network.NewAddress(result.Value()))
 }
 
 func (s *ipAddressesInternalSuite) TestIsValidAddressConfigMethodWithValidValues(c *gc.C) {

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -284,6 +284,18 @@ func (s *ipAddressesStateSuite) TestMachineAllAddressesSuccess(c *gc.C) {
 	c.Assert(allAddresses, jc.DeepEquals, addedAddresses)
 }
 
+func (s *ipAddressesStateSuite) TestMachineAllNetworkAddresses(c *gc.C) {
+	addedAddresses := s.addTwoDevicesWithTwoAddressesEach(c)
+	expected := make([]network.Address, len(addedAddresses))
+	for i := range addedAddresses {
+		expected[i] = addedAddresses[i].NetworkAddress()
+	}
+
+	networkAddresses, err := s.machine.AllNetworkAddresses()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(networkAddresses, jc.DeepEquals, expected)
+}
+
 func (s *ipAddressesStateSuite) TestLinkLayerDeviceRemoveAlsoRemovesDeviceAddresses(c *gc.C) {
 	device, _ := s.addNamedDeviceWithAddresses(c, "eth0", "10.20.30.40/16", "fc00::/64")
 	s.assertAllAddressesOnMachineMatchCount(c, s.machine, 2)

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -97,6 +97,11 @@ func newIPAddress(st *State, doc ipAddressDoc) *Address {
 	return &Address{st: st, doc: doc}
 }
 
+// NetworkAddress returns the address transformed to a network.Address.
+func (addr *Address) NetworkAddress() network.Address {
+	return network.NewAddress(addr.Value())
+}
+
 // DocID returns the globally unique ID of the IP address, including the model
 // UUID as prefix.
 func (addr *Address) DocID() string {

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -847,6 +847,21 @@ func (m *Machine) AllAddresses() ([]*Address, error) {
 	return allAddresses, nil
 }
 
+// AllNetworkAddresses returns the result of AllAddresses(), but transformed to
+// []network.Address.
+func (m *Machine) AllNetworkAddresses() ([]network.Address, error) {
+	stateAddresses, err := m.AllAddresses()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	networkAddresses := make([]network.Address, len(stateAddresses))
+	for i := range stateAddresses {
+		networkAddresses[i] = stateAddresses[i].NetworkAddress()
+	}
+	return networkAddresses, nil
+}
+
 // SetParentLinkLayerDevicesBeforeTheirChildren splits the given devicesArgs
 // into multiple sets of args and calls SetLinkLayerDevices() for each set, such
 // that child devices are set only after their parents.


### PR DESCRIPTION
Machine.AllNetworkAddresses() method added, which is a simple
wrapper around the existing Machine.AllAddresses() method, but
returns a network.Address slice, more suitable for use across
the state package boundary. A related helper method added on
Address as well - NetworkAddress().

QA Steps (only unit tests):
 1. Run `go test -check.v -check.f ipAddresses -cover` in the
    state/ package directory.
 2. Ensure tests pass and there is no reduction of coverage
    before and after this fix.

Prerequisite to fix bug http://pad.lv/1616098.