### PR TITLE
api;apiserver: AllAddresses() added to SSHClient facade (v2)

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -74,7 +74,7 @@ var facadeVersions = map[string]int{
 	"RetryStrategy":                1,
 	"Singular":                     1,
 	"Spaces":                       2,
-	"SSHClient":                    1,
+	"SSHClient":                    2,
 	"StatusHistory":                2,
 	"Storage":                      3,
 	"StorageProvisioner":           3,

--- a/api/sshclient/facade.go
+++ b/api/sshclient/facade.go
@@ -39,6 +39,27 @@ func (facade *Facade) PrivateAddress(target string) (string, error) {
 	return addr, errors.Trace(err)
 }
 
+// AllAddresses returns all addresses for the SSH target provided. The target
+// may be provided as a machine ID or unit name.
+func (facade *Facade) AllAddresses(target string) ([]string, error) {
+	entities, err := targetToEntities(target)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var out params.SSHAddressesResults
+	err = facade.caller.FacadeCall("AllAddresses", entities, &out)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(out.Results) != 1 {
+		return nil, countError(len(out.Results))
+	}
+	if err := out.Results[0].Error; err != nil {
+		return nil, errors.Trace(err)
+	}
+	return out.Results[0].Addresses, nil
+}
+
 func (facade *Facade) addressCall(callName, target string) (string, error) {
 	entities, err := targetToEntities(target)
 	if err != nil {

--- a/apiserver/params/ssh.go
+++ b/apiserver/params/ssh.go
@@ -33,6 +33,19 @@ type SSHAddressResult struct {
 	Address string `json:"address,omitempty"`
 }
 
+// SSHAddressesResults defines the response from AllAddresses on the SSHClient
+// API facade.
+type SSHAddressesResults struct {
+	Results []SSHAddressesResult `json:"results"`
+}
+
+// SSHAddressesResult defines a single result with multiple addresses (see
+// SSHAddressesResults).
+type SSHAddressesResult struct {
+	Error     *Error   `json:"error,omitempty"`
+	Addresses []string `json:"addresses"`
+}
+
 // SSHPublicKeysResults is used to return SSH public host keys for one
 // or more target for the SSHClient.PublicKeys API.
 type SSHPublicKeysResults struct {

--- a/apiserver/sshclient/facade.go
+++ b/apiserver/sshclient/facade.go
@@ -17,6 +17,9 @@ import (
 
 func init() {
 	common.RegisterStandardFacade("SSHClient", 1, newFacade)
+
+	// Facade version 2 adds AllAddresses() method.
+	common.RegisterStandardFacade("SSHClient", 2, newFacade)
 }
 
 // Facade implements the API required by the sshclient worker.
@@ -52,7 +55,7 @@ func (facade *Facade) PublicAddress(args params.Entities) (params.SSHAddressResu
 	}
 
 	getter := func(m SSHMachine) (network.Address, error) { return m.PublicAddress() }
-	return facade.getAddresses(args, getter)
+	return facade.getAddressPerEntity(args, getter)
 }
 
 // PrivateAddress reports the preferred private network address for one or
@@ -63,28 +66,84 @@ func (facade *Facade) PrivateAddress(args params.Entities) (params.SSHAddressRes
 	}
 
 	getter := func(m SSHMachine) (network.Address, error) { return m.PrivateAddress() }
-	return facade.getAddresses(args, getter)
+	return facade.getAddressPerEntity(args, getter)
 }
 
-func (facade *Facade) getAddresses(args params.Entities, getter func(SSHMachine) (network.Address, error)) (
-	params.SSHAddressResults, error,
+// AllAddresses reports all addresses known to Juju for each given entity in
+// args. Machines and units are suppored as entity types. Since the returned
+// addresses are gathered from multiple sources, results can include duplicates.
+func (facade *Facade) AllAddresses(args params.Entities) (params.SSHAddressesResults, error) {
+	if err := facade.checkIsModelAdmin(); err != nil {
+		return params.SSHAddressesResults{}, errors.Trace(err)
+	}
+
+	getter := func(m SSHMachine) ([]network.Address, error) {
+		devicesAddresses, err := m.AllNetworkAddresses()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		legacyAddresses := m.Addresses()
+		return append(devicesAddresses, legacyAddresses...), nil
+	}
+
+	return facade.getAllEntityAddresses(args, getter)
+}
+
+func (facade *Facade) getAllEntityAddresses(args params.Entities, getter func(SSHMachine) ([]network.Address, error)) (
+	params.SSHAddressesResults, error,
 ) {
-	out := params.SSHAddressResults{
-		Results: make([]params.SSHAddressResult, len(args.Entities)),
+	out := params.SSHAddressesResults{
+		Results: make([]params.SSHAddressesResult, len(args.Entities)),
 	}
 	for i, entity := range args.Entities {
 		machine, err := facade.backend.GetMachineForEntity(entity.Tag)
 		if err != nil {
 			out.Results[i].Error = common.ServerError(err)
 		} else {
-			address, err := getter(machine)
+			addresses, err := getter(machine)
 			if err != nil {
 				out.Results[i].Error = common.ServerError(err)
-			} else {
-				out.Results[i].Address = address.Value
+				continue
+			}
+
+			out.Results[i].Addresses = make([]string, len(addresses))
+			for j := range addresses {
+				out.Results[i].Addresses[j] = addresses[j].Value
 			}
 		}
 	}
+	return out, nil
+}
+
+func (facade *Facade) getAddressPerEntity(args params.Entities, getter func(SSHMachine) (network.Address, error)) (
+	params.SSHAddressResults, error,
+) {
+	out := params.SSHAddressResults{
+		Results: make([]params.SSHAddressResult, len(args.Entities)),
+	}
+
+	getterWrapper := func(m SSHMachine) ([]network.Address, error) {
+		address, err := getter(m)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return []network.Address{address}, nil
+	}
+
+	fullResults, err := facade.getAllEntityAddresses(args, getterWrapper)
+	if err != nil {
+		return params.SSHAddressResults{}, errors.Trace(err)
+	}
+
+	for i, result := range fullResults.Results {
+		if result.Error != nil {
+			out.Results[i].Error = result.Error
+		} else {
+			out.Results[i].Address = result.Addresses[0]
+		}
+	}
+
 	return out, nil
 }
 

--- a/apiserver/sshclient/facade.go
+++ b/apiserver/sshclient/facade.go
@@ -70,8 +70,8 @@ func (facade *Facade) PrivateAddress(args params.Entities) (params.SSHAddressRes
 }
 
 // AllAddresses reports all addresses known to Juju for each given entity in
-// args. Machines and units are suppored as entity types. Since the returned
-// addresses are gathered from multiple sources, results can include duplicates.
+// args. Machines and units are supported as entity types. Since the returned
+// addresses are gathered from multiple sources, results may include duplicates.
 func (facade *Facade) AllAddresses(args params.Entities) (params.SSHAddressesResults, error) {
 	if err := facade.checkIsModelAdmin(); err != nil {
 		return params.SSHAddressesResults{}, errors.Trace(err)
@@ -116,22 +116,22 @@ func (facade *Facade) getAllEntityAddresses(args params.Entities, getter func(SS
 	return out, nil
 }
 
-func (facade *Facade) getAddressPerEntity(args params.Entities, getter func(SSHMachine) (network.Address, error)) (
+func (facade *Facade) getAddressPerEntity(args params.Entities, addressGetter func(SSHMachine) (network.Address, error)) (
 	params.SSHAddressResults, error,
 ) {
 	out := params.SSHAddressResults{
 		Results: make([]params.SSHAddressResult, len(args.Entities)),
 	}
 
-	getterWrapper := func(m SSHMachine) ([]network.Address, error) {
-		address, err := getter(m)
+	getter := func(m SSHMachine) ([]network.Address, error) {
+		address, err := addressGetter(m)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		return []network.Address{address}, nil
 	}
 
-	fullResults, err := facade.getAllEntityAddresses(args, getterWrapper)
+	fullResults, err := facade.getAllEntityAddresses(args, getter)
 	if err != nil {
 		return params.SSHAddressResults{}, errors.Trace(err)
 	}

--- a/apiserver/sshclient/shim.go
+++ b/apiserver/sshclient/shim.go
@@ -27,6 +27,8 @@ type SSHMachine interface {
 	MachineTag() names.MachineTag
 	PublicAddress() (network.Address, error)
 	PrivateAddress() (network.Address, error)
+	Addresses() []network.Address
+	AllNetworkAddresses() ([]network.Address, error)
 }
 
 // newFacade wraps New to express the supplied *state.State as a Backend.


### PR DESCRIPTION
The SSHClient API facade only has methods getting the preferred
public or private addresses of a machine/unit entity. This PR
adds a new AllAddresses() method to the facade, and bumps the
version to 2.

QA Steps (only unit tests):

  1. Run go test -check.v -cover in the api/sshclient/ and then
     in the apiserver/ package directories.
  2. Ensure tests pass and there is no reduction of coverage before
     and after this PR.

Requires (and includes!) PR #6467 - please review the state/ changes there.
Prerequisite (3/3) to fix bug http://pad.lv/1616098.