### PR TITLE
Add cross-model feature flag

### DIFF
--- a/api/facadeversions_test.go
+++ b/api/facadeversions_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/component/all"
+	"github.com/juju/juju/feature"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -19,6 +20,11 @@ type facadeVersionSuite struct {
 }
 
 var _ = gc.Suite(&facadeVersionSuite{})
+
+func (s *facadeVersionSuite) SetUpTest(c *gc.C) {
+	s.SetInitialFeatureFlags(feature.CrossModelRelations)
+	s.BaseSuite.SetUpTest(c)
+}
 
 func (s *facadeVersionSuite) TestFacadeVersionsMatchServerVersions(c *gc.C) {
 	// The client side code doesn't want to directly import the server side

--- a/apiserver/application/application.go
+++ b/apiserver/application/application.go
@@ -20,11 +20,13 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	jjj "github.com/juju/juju/juju"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 	statestorage "github.com/juju/juju/state/storage"
+	"github.com/juju/utils/featureflag"
 )
 
 var (
@@ -709,6 +711,11 @@ func (api *API) AddRelation(args params.AddRelation) (params.AddRelationResults,
 	// We'll iterate the endpoints to check.
 	for i, ep := range args.Endpoints {
 		endpoints[i] = ep
+
+		// If cross model relations not enabled, ignore remote endpoints.
+		if !featureflag.Enabled(feature.CrossModelRelations) {
+			continue
+		}
 
 		// If the endpoint is not remote, skip it.
 		// We first need to strip off any relation name

--- a/apiserver/crossmodel/applicationdirectory.go
+++ b/apiserver/crossmodel/applicationdirectory.go
@@ -13,11 +13,12 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/crossmodel"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 )
 
 func init() {
-	common.RegisterStandardFacade("ApplicationOffers", 1, newApplicationOffersAPI)
+	common.RegisterStandardFacadeForFeature("ApplicationOffers", 1, newApplicationOffersAPI, feature.CrossModelRelations)
 }
 
 // ApplicationOffersAPI implements the cross model interface and is the concrete

--- a/apiserver/crossmodel/applicationdirectory_test.go
+++ b/apiserver/crossmodel/applicationdirectory_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/testing"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/feature"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -53,6 +54,7 @@ func (s *applicationdirectorySuite) constructApplicationDirectory() *mockApplica
 }
 
 func (s *applicationdirectorySuite) SetUpTest(c *gc.C) {
+	s.SetInitialFeatureFlags(feature.CrossModelRelations)
 	s.authoriser = testing.FakeAuthorizer{
 		Tag: names.NewUserTag("testuser"),
 	}

--- a/apiserver/crossmodel/crossmodel.go
+++ b/apiserver/crossmodel/crossmodel.go
@@ -14,13 +14,14 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 )
 
 var logger = loggo.GetLogger("juju.apiserver.crossmodel")
 
 func init() {
-	common.RegisterStandardFacade("CrossModelRelations", 1, NewAPI)
+	common.RegisterStandardFacadeForFeature("CrossModelRelations", 1, NewAPI, feature.CrossModelRelations)
 }
 
 // API implements the cross model interface and is the concrete

--- a/apiserver/crossmodel/crossmodel_test.go
+++ b/apiserver/crossmodel/crossmodel_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/feature"
 )
 
 type crossmodelSuite struct {
@@ -21,6 +22,7 @@ type crossmodelSuite struct {
 var _ = gc.Suite(&crossmodelSuite{})
 
 func (s *crossmodelSuite) SetUpTest(c *gc.C) {
+	s.SetInitialFeatureFlags(feature.CrossModelRelations)
 	s.baseCrossmodelSuite.SetUpTest(c)
 }
 

--- a/apiserver/crossmodel/offeredapplications.go
+++ b/apiserver/crossmodel/offeredapplications.go
@@ -10,12 +10,13 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
 )
 
 func init() {
-	common.RegisterStandardFacade("OfferedApplications", 1, newOfferedApplicationAPI)
+	common.RegisterStandardFacadeForFeature("OfferedApplications", 1, newOfferedApplicationAPI, feature.CrossModelRelations)
 }
 
 // OfferedApplicationLister instances allow offered applications to be queried.

--- a/apiserver/crossmodel/offeredapplications_test.go
+++ b/apiserver/crossmodel/offeredapplications_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/testing"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -32,6 +33,7 @@ type offeredApplicationsSuite struct {
 var _ = gc.Suite(&offeredApplicationsSuite{})
 
 func (s *offeredApplicationsSuite) SetUpTest(c *gc.C) {
+	s.SetInitialFeatureFlags(feature.CrossModelRelations)
 	s.authoriser = testing.FakeAuthorizer{
 		EnvironManager: true,
 	}

--- a/apiserver/remoterelations/remoterelations.go
+++ b/apiserver/remoterelations/remoterelations.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
 )
@@ -20,7 +21,7 @@ import (
 var logger = loggo.GetLogger("juju.apiserver.remoterelations")
 
 func init() {
-	common.RegisterStandardFacade("RemoteRelations", 1, NewStateRemoteRelationsAPI)
+	common.RegisterStandardFacadeForFeature("RemoteRelations", 1, NewStateRemoteRelationsAPI, feature.CrossModelRelations)
 }
 
 // RemoteRelationsAPI provides access to the Provisioner API facade.

--- a/cmd/juju/application/addremoterelation_test.go
+++ b/cmd/juju/application/addremoterelation_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/feature"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/testing"
 )
@@ -147,6 +148,7 @@ type baseAddRemoteRelationSuite struct {
 }
 
 func (s *baseAddRemoteRelationSuite) SetUpTest(c *gc.C) {
+	s.SetInitialFeatureFlags(feature.CrossModelRelations)
 	s.RepoSuite.SetUpTest(c)
 	s.mockAPI = &mockAddRelationAPI{
 		addRelation: func(endpoints ...string) (*params.AddRelationResults, error) {

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -234,10 +234,13 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	// Creation commands.
 	r.Register(newBootstrapCommand())
 	r.Register(application.NewAddRelationCommand())
-	r.Register(crossmodel.NewOfferCommand())
-	r.Register(crossmodel.NewShowOfferedEndpointCommand())
-	r.Register(crossmodel.NewListEndpointsCommand())
-	r.Register(crossmodel.NewFindEndpointsCommand())
+
+	if featureflag.Enabled(feature.CrossModelRelations) {
+		r.Register(crossmodel.NewOfferCommand())
+		r.Register(crossmodel.NewShowOfferedEndpointCommand())
+		r.Register(crossmodel.NewListEndpointsCommand())
+		r.Register(crossmodel.NewFindEndpointsCommand())
+	}
 
 	// Destruction commands.
 	r.Register(application.NewRemoveRelationCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -431,7 +431,6 @@ var commandNames = []string{
 	"enable-destroy-controller",
 	"enable-user",
 	"expose",
-	"find-endpoints",
 	"get-constraints",
 	"get-model-constraints",
 	"grant",
@@ -451,7 +450,6 @@ var commandNames = []string{
 	"list-disabled-commands",
 	"list-machines",
 	"list-models",
-	"list-offers",
 	"list-plans",
 	"list-regions",
 	"list-ssh-keys",
@@ -466,7 +464,6 @@ var commandNames = []string{
 	"metrics",
 	"model-config",
 	"model-defaults",
-	"offer",
 	"models",
 	"plans",
 	"regions",
@@ -501,7 +498,6 @@ var commandNames = []string{
 	"show-budget",
 	"show-cloud",
 	"show-controller",
-	"show-endpoints",
 	"show-machine",
 	"show-model",
 	"show-status",
@@ -532,11 +528,16 @@ var commandNames = []string{
 }
 
 // devFeatures are feature flags that impact registration of commands.
-var devFeatures = []string{feature.Migration}
+var devFeatures = []string{feature.Migration, feature.CrossModelRelations}
 
 // These are the commands that are behind the `devFeatures`.
 var commandNamesBehindFlags = set.NewStrings(
+	"find-endpoints",
+	"list-offers",
 	"migrate",
+	"offer",
+	"offers",
+	"show-endpoints",
 )
 
 func (s *MainSuite) TestHelpCommands(c *gc.C) {

--- a/cmd/juju/crossmodel/list.go
+++ b/cmd/juju/crossmodel/list.go
@@ -80,7 +80,8 @@ func (c *listCommand) Init(args []string) (err error) {
 // Info implements Command.Info.
 func (c *listCommand) Info() *cmd.Info {
 	return &cmd.Info{
-		Name:    "list-offers",
+		Name:    "offers",
+		Aliases: []string{"list-offers"},
 		Purpose: "Lists shared endpoints",
 		Doc:     listCommandDoc,
 	}

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -39,3 +39,6 @@ const Migration = "migration"
 
 // DeveloperMode allows access to developer specific commands and behaviour.
 const DeveloperMode = "developer-mode"
+
+// CrossModelRelations allows cross model relations functionality.
+const CrossModelRelations = "cross-model"

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -38,6 +38,7 @@ import (
 	"github.com/juju/juju/environs/storage"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/environs/tools"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
@@ -107,6 +108,7 @@ type JujuConnSuite struct {
 const AdminSecret = "dummy-secret"
 
 func (s *JujuConnSuite) SetUpSuite(c *gc.C) {
+	s.SetInitialFeatureFlags(feature.CrossModelRelations)
 	s.MgoSuite.SetUpSuite(c)
 	s.FakeJujuXDGDataHomeSuite.SetUpSuite(c)
 	s.PatchValue(&utils.OutgoingAccessAllowed, false)

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/mongo/mongotest"
@@ -45,6 +46,7 @@ func (s *internalStateSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *internalStateSuite) SetUpTest(c *gc.C) {
+	s.SetInitialFeatureFlags(feature.CrossModelRelations)
 	s.MgoSuite.SetUpTest(c)
 	s.BaseSuite.SetUpTest(c)
 

--- a/state/testing/suite.go
+++ b/state/testing/suite.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -43,6 +44,7 @@ func (s *StateSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *StateSuite) SetUpTest(c *gc.C) {
+	s.SetInitialFeatureFlags(feature.CrossModelRelations)
 	s.MgoSuite.SetUpTest(c)
 	s.BaseSuite.SetUpTest(c)
 

--- a/state/testing/suite_wallclock.go
+++ b/state/testing/suite_wallclock.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -43,6 +44,7 @@ func (s *StateWithWallClockSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *StateWithWallClockSuite) SetUpTest(c *gc.C) {
+	s.SetInitialFeatureFlags(feature.CrossModelRelations)
 	s.MgoSuite.SetUpTest(c)
 	s.BaseSuite.SetUpTest(c)
 


### PR DESCRIPTION
Add cross-model feature flag to hide cross model relations functionality until it is ready. This includes CLI, API facades, and database collections.