### PR TITLE
DHCP release and cruft cleanup on LXC template shutdown

### DIFF
--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -256,7 +256,7 @@ func shutdownInitCommands(initSystem, series string) ([]string, error) {
 
 	// This intentionally avoids a for loop, keeping the ExecStart validation code more generic.
 	ifaces := `$(/usr/bin/awk '/^iface.*dhcp$/ {print $2}' /etc/network/interfaces /etc/network/interfaces.d/*)`
-	dhcpRelease := fmt.Sprintf("/sbin/dhclient -r %s &&\n  /sbin/ifdown %s\n  ", ifaces, ifaces)
+	dhcpRelease := fmt.Sprintf("/sbin/dhclient -r %s\n  /sbin/ifdown %s\n  ", ifaces, ifaces)
 
 	var execStart string
 	if environs.AddressAllocationEnabled() {

--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -229,9 +229,9 @@ iface eth0 inet dhcp
 `
 
 func shutdownInitCommands(initSystem, series string) ([]string, error) {
-	// These files are removed just before the template shuts down.
+	// These files are moved just before the template shuts down.
 	cleanupOnShutdown := []string{
-		// We remove any dhclient lease files so there's no chance a
+		// We move any dhclient lease files so there's no chance a
 		// clone to reuse a lease from the template it was cloned
 		// from.
 		"/var/lib/dhcp/dhclient*",
@@ -242,7 +242,7 @@ func shutdownInitCommands(initSystem, series string) ([]string, error) {
 		"/var/log/cloud-init*.log",
 	}
 	paths := strings.Join(cleanupOnShutdown, " ")
-	removeCmd := fmt.Sprintf("/bin/rm -fr %s\n  ", paths)
+	moveCmd := fmt.Sprintf("/usr/bin/rename 's/$/.juju-template/' %s\n  ", paths)
 	shutdownCmd := "/sbin/shutdown -h now"
 	name := "juju-template-restart"
 	desc := "juju shutdown job"
@@ -262,10 +262,10 @@ func shutdownInitCommands(initSystem, series string) ([]string, error) {
 	if environs.AddressAllocationEnabled() {
 		// Only do the replacement of /e/n/i when address allocation
 		// feature flag is enabled.
-		execStart = replaceNetConfCmd + removeCmd + shutdownCmd
+		execStart = replaceNetConfCmd + moveCmd + shutdownCmd
 	} else {
 		// Release any DHCP-assigned IP addresses.
-		execStart = dhcpRelease + removeCmd + shutdownCmd
+		execStart = dhcpRelease + moveCmd + shutdownCmd
 	}
 
 	conf := common.Conf{

--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -241,6 +241,11 @@ func shutdownInitCommands(initSystem, series string) ([]string, error) {
 		// keep clean logs for diagnosing issues / debugging.
 		"/var/log/cloud-init*.log",
 	}
+	paths := strings.Join(cleanupOnShutdown, " ")
+	removeCmd := fmt.Sprintf("/bin/rm -fr %s\n  ", paths)
+	shutdownCmd := "/sbin/shutdown -h now"
+	name := "juju-template-restart"
+	desc := "juju shutdown job"
 
 	// Using EOC below as the template shutdown script is itself
 	// passed through cat > ... < EOF.
@@ -248,17 +253,19 @@ func shutdownInitCommands(initSystem, series string) ([]string, error) {
 		"/bin/cat > /etc/network/interfaces << EOC%sEOC\n  ",
 		defaultEtcNetworkInterfaces,
 	)
-	paths := strings.Join(cleanupOnShutdown, " ")
-	removeCmd := fmt.Sprintf("/bin/rm -fr %s\n  ", paths)
-	shutdownCmd := "/sbin/shutdown -h now"
-	name := "juju-template-restart"
-	desc := "juju shutdown job"
 
-	execStart := shutdownCmd
+	// This intentionally avoids a for loop, keeping the ExecStart validation code more generic.
+	ifaces := `$(/usr/bin/awk '/^iface.*dhcp$/ {print $2}' /etc/network/interfaces /etc/network/interfaces.d/*)`
+	dhcpRelease := fmt.Sprintf("/sbin/dhclient -r %s &&\n  /sbin/ifdown %s\n  ", ifaces, ifaces)
+
+	var execStart string
 	if environs.AddressAllocationEnabled() {
-		// Only do the cleanup and replacement of /e/n/i when address
-		// allocation feature flag is enabled.
+		// Only do the replacement of /e/n/i when address allocation
+		// feature flag is enabled.
 		execStart = replaceNetConfCmd + removeCmd + shutdownCmd
+	} else {
+		// Release any DHCP-assigned IP addresses.
+		execStart = dhcpRelease + removeCmd + shutdownCmd
 	}
 
 	conf := common.Conf{

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -198,7 +198,7 @@ author "Juju Team <juju@lists.ubuntu.com>"
 start on stopped cloud-final
 
 script
-  /sbin/dhclient -r $(/usr/bin/awk '/^iface.*dhcp$/ {print $2}' /etc/network/interfaces /etc/network/interfaces.d/*) &&
+  /sbin/dhclient -r $(/usr/bin/awk '/^iface.*dhcp$/ {print $2}' /etc/network/interfaces /etc/network/interfaces.d/*)
   /sbin/ifdown $(/usr/bin/awk '/^iface.*dhcp$/ {print $2}' /etc/network/interfaces /etc/network/interfaces.d/*)
   /usr/bin/rename 's/$/.juju-template/' /var/lib/dhcp/dhclient* /var/log/cloud-init*.log
   /sbin/shutdown -h now
@@ -274,7 +274,7 @@ ExecStopPost=/bin/systemctl disable juju-template-restart.service
 WantedBy=multi-user.target
 `[1:],
 		Script: `
-/sbin/dhclient -r $(/usr/bin/awk '/^iface.*dhcp$/ {print $2}' /etc/network/interfaces /etc/network/interfaces.d/*) &&
+/sbin/dhclient -r $(/usr/bin/awk '/^iface.*dhcp$/ {print $2}' /etc/network/interfaces /etc/network/interfaces.d/*)
   /sbin/ifdown $(/usr/bin/awk '/^iface.*dhcp$/ {print $2}' /etc/network/interfaces /etc/network/interfaces.d/*)
   /usr/bin/rename 's/$/.juju-template/' /var/lib/dhcp/dhclient* /var/log/cloud-init*.log
   /sbin/shutdown -h now`[1:],

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -175,7 +175,7 @@ iface lo inet loopback
 auto eth0
 iface eth0 inet dhcp
 EOC
-  /bin/rm -fr /var/lib/dhcp/dhclient* /var/log/cloud-init*.log
+  /usr/bin/rename 's/$/.juju-template/' /var/lib/dhcp/dhclient* /var/log/cloud-init*.log
   /sbin/shutdown -h now
 end script
 
@@ -200,7 +200,7 @@ start on stopped cloud-final
 script
   /sbin/dhclient -r $(/usr/bin/awk '/^iface.*dhcp$/ {print $2}' /etc/network/interfaces /etc/network/interfaces.d/*) &&
   /sbin/ifdown $(/usr/bin/awk '/^iface.*dhcp$/ {print $2}' /etc/network/interfaces /etc/network/interfaces.d/*)
-  /bin/rm -fr /var/lib/dhcp/dhclient* /var/log/cloud-init*.log
+  /usr/bin/rename 's/$/.juju-template/' /var/lib/dhcp/dhclient* /var/log/cloud-init*.log
   /sbin/shutdown -h now
 end script
 
@@ -245,7 +245,7 @@ iface lo inet loopback
 auto eth0
 iface eth0 inet dhcp
 EOC
-  /bin/rm -fr /var/lib/dhcp/dhclient* /var/log/cloud-init*.log
+  /usr/bin/rename 's/$/.juju-template/' /var/lib/dhcp/dhclient* /var/log/cloud-init*.log
   /sbin/shutdown -h now`[1:],
 	}
 	test.CheckInstallAndStartCommands(c, commands)
@@ -276,7 +276,7 @@ WantedBy=multi-user.target
 		Script: `
 /sbin/dhclient -r $(/usr/bin/awk '/^iface.*dhcp$/ {print $2}' /etc/network/interfaces /etc/network/interfaces.d/*) &&
   /sbin/ifdown $(/usr/bin/awk '/^iface.*dhcp$/ {print $2}' /etc/network/interfaces /etc/network/interfaces.d/*)
-  /bin/rm -fr /var/lib/dhcp/dhclient* /var/log/cloud-init*.log
+  /usr/bin/rename 's/$/.juju-template/' /var/lib/dhcp/dhclient* /var/log/cloud-init*.log
   /sbin/shutdown -h now`[1:],
 	}
 	test.CheckInstallAndStartCommands(c, commands)

--- a/service/common/conf.go
+++ b/service/common/conf.go
@@ -56,7 +56,9 @@ type Conf struct {
 
 	// TODO(ericsnow) Turn ExtraScript into ExecStartPre.
 
-	// ExtraScript allows to insert script before command execution.
+	// ExtraScript allows for the insertion of scripting before command
+	// execution. This is not the same as ExecStartPre, but rather
+	// scripting that will be prepended to ExecStart.
 	ExtraScript string
 
 	// ServiceBinary is the actual binary without any arguments.


### PR DESCRIPTION
Adds a DHCP release to the LXC template shutdown service config in
user-data.

dhclient lease and cloud-init log files were previously only cleaned
from template containers when address-allocation was used. This left
cruft in templates to be adopted by all copied containers.

These files' cleanup command and the DHCP release command are now
included in the script run on ExecStart for the template shutdown
service.

Fixes lp:1498642

QA steps:

  * Bootstrap a Juju 1.25 environment (MAAS or LXC)
  * Add a LXC machine
  * Inspect syslog to see a `DHCPRELEASE` of the IP addr assigned to the `juju-<release>-lxc-template` container
  * Test with trusty and xenial