### PR TITLE
Derive address scope instead of setting it explicitly in vsphere

### DIFF
--- a/provider/vsphere/instance.go
+++ b/provider/vsphere/instance.go
@@ -53,11 +53,7 @@ func (inst *environInstance) Addresses() ([]network.Address, error) {
 	res := make([]network.Address, 0)
 	for _, net := range inst.base.Guest.Net {
 		for _, ip := range net.IpAddress {
-			scope := network.ScopeCloudLocal
-			if net.Network == inst.env.ecfg.externalNetwork() {
-				scope = network.ScopePublic
-			}
-			res = append(res, network.NewScopedAddress(ip, scope))
+			res = append(res, network.NewAddress(ip))
 		}
 	}
 	return res, nil

--- a/state/machine.go
+++ b/state/machine.go
@@ -1133,7 +1133,7 @@ func (m *Machine) SetInstanceInfo(
 	volumes map[names.VolumeTag]VolumeInfo,
 	volumeAttachments map[names.VolumeTag]VolumeAttachmentInfo,
 ) error {
-	logger.Tracef("Setting instance info: machine %v, deviceAddrs: %#v, devicesArgs: %#v", m.Id(), devicesAddrs, devicesArgs)
+	logger.Tracef("setting instance info: machine %v, deviceAddrs: %#v, devicesArgs: %#v", m.Id(), devicesAddrs, devicesArgs)
 
 	if err := m.SetParentLinkLayerDevicesBeforeTheirChildren(devicesArgs); err != nil {
 		return errors.Trace(err)

--- a/state/machine.go
+++ b/state/machine.go
@@ -1133,7 +1133,7 @@ func (m *Machine) SetInstanceInfo(
 	volumes map[names.VolumeTag]VolumeInfo,
 	volumeAttachments map[names.VolumeTag]VolumeAttachmentInfo,
 ) error {
-	logger.Tracef("Setting instance info: machine %v, deviceAddrs: %#v, devicesArgs: %#v", m.Id, devicesAddrs, devicesArgs)
+	logger.Tracef("Setting instance info: machine %v, deviceAddrs: %#v, devicesArgs: %#v", m.Id(), devicesAddrs, devicesArgs)
 
 	if err := m.SetParentLinkLayerDevicesBeforeTheirChildren(devicesArgs); err != nil {
 		return errors.Trace(err)
@@ -1277,7 +1277,7 @@ func (m *Machine) setPreferredAddressOps(addr address, isPublic bool) []txn.Op {
 
 func (m *Machine) setPublicAddressOps(providerAddresses []address, machineAddresses []address) ([]txn.Op, address, bool) {
 	publicAddress := m.doc.PreferredPublicAddress
-	logger.Tracef("machine %v: current public address: %#v \nprovider addresses: %#v \nmachine addresses: %#v", m.Id, publicAddress, providerAddresses, machineAddresses)
+	logger.Tracef("machine %v: current public address: %#v \nprovider addresses: %#v \nmachine addresses: %#v", m.Id(), publicAddress, providerAddresses, machineAddresses)
 	// Always prefer an exact match if available.
 	checkScope := func(addr address) bool {
 		return network.ExactScopeMatch(addr.networkAddress(), network.ScopePublic)

--- a/state/machine.go
+++ b/state/machine.go
@@ -1271,7 +1271,7 @@ func (m *Machine) setPreferredAddressOps(addr address, isPublic bool) []txn.Op {
 		Update: bson.D{{"$set", bson.D{{fieldName, addr}}}},
 		Assert: assert,
 	}}
-	logger.Infof("setting preferred address to %v (isPublic %#v)", addr, isPublic)
+	logger.Tracef("setting preferred address to %v (isPublic %#v)", addr, isPublic)
 	return ops
 }
 

--- a/state/machine.go
+++ b/state/machine.go
@@ -1133,6 +1133,7 @@ func (m *Machine) SetInstanceInfo(
 	volumes map[names.VolumeTag]VolumeInfo,
 	volumeAttachments map[names.VolumeTag]VolumeAttachmentInfo,
 ) error {
+	logger.Tracef("Setting instance info: machine %v, deviceAddrs: %#v, devicesArgs: %#v", m.Id, devicesAddrs, devicesArgs)
 
 	if err := m.SetParentLinkLayerDevicesBeforeTheirChildren(devicesArgs); err != nil {
 		return errors.Trace(err)
@@ -1270,11 +1271,13 @@ func (m *Machine) setPreferredAddressOps(addr address, isPublic bool) []txn.Op {
 		Update: bson.D{{"$set", bson.D{{fieldName, addr}}}},
 		Assert: assert,
 	}}
+	logger.Infof("setting preferred address to %v (isPublic %#v)", addr, isPublic)
 	return ops
 }
 
 func (m *Machine) setPublicAddressOps(providerAddresses []address, machineAddresses []address) ([]txn.Op, address, bool) {
 	publicAddress := m.doc.PreferredPublicAddress
+	logger.Tracef("machine %v: current public address: %#v \nprovider addresses: %#v \nmachine addresses: %#v", m.Id, publicAddress, providerAddresses, machineAddresses)
 	// Always prefer an exact match if available.
 	checkScope := func(addr address) bool {
 		return network.ExactScopeMatch(addr.networkAddress(), network.ScopePublic)


### PR DESCRIPTION
Fixes bug #1629452
https://bugs.launchpad.net/juju/+bug/1629452 

Change the vsphere provider to use derived scope for all addresses instead of explicitly setting an incorrect public scope.

The vsphere provider has no infrastructure for configuring fake instances, so it's not possible to unit test this change. All existing unit tests pass though.

QA steps
Bootstrap to vsphere
Deploy Ubuntu units on xenial
Se that the units get IPv4 addresses and you can ssh to them.