### PR TITLE
OpenStack firewaller now takes a clock.Clock

### DIFF
--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	jujuerrors "github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
@@ -564,6 +565,12 @@ func (s *localServerSuite) TestStopInstanceSecurityGroupNotDeleted(c *gc.C) {
 		fmt.Sprintf("juju-%v-%v-%v", s.ControllerUUID, modelUUID, instanceName),
 	}
 	assertSecurityGroups(c, env, allSecurityGroups)
+
+	// Make time advance in zero time
+	clk := gitjujutesting.NewClock(time.Time{})
+	clock := gitjujutesting.AutoAdvancingClock{clk, clk.Advance}
+	env.(*openstack.Environ).SetClock(&clock)
+
 	err := env.StopInstances(inst.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	assertSecurityGroups(c, env, allSecurityGroups)


### PR DESCRIPTION
This change is just to speed up testing. By taking a clock.Clock deleteSecurityGroup can be tested near-instantly rather than taking 30 seconds. The provider itself now has a clock, which is initialized by default to clock.WallClock to match the existing behavior during normal operation.

QA Steps:
This is a non-change in terms of Juju's normal usage, so just running the unit tests is sufficient.

Fixes https://bugs.launchpad.net/juju/+bug/1580626