### PR TITLE
lp:1616098: ssh,scp,dh pick reachable address among all

### DIFF
--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -681,9 +681,9 @@ func (s *clientSuite) TestClientPublicAddressErrors(c *gc.C) {
 	_, err := s.APIState.Client().PublicAddress("wordpress")
 	c.Assert(err, gc.ErrorMatches, `unknown unit or machine "wordpress"`)
 	_, err = s.APIState.Client().PublicAddress("0")
-	c.Assert(err, gc.ErrorMatches, `error fetching address for machine "0": no public address`)
+	c.Assert(err, gc.ErrorMatches, `error fetching address for machine "0": no public address\(es\)`)
 	_, err = s.APIState.Client().PublicAddress("wordpress/0")
-	c.Assert(err, gc.ErrorMatches, `error fetching address for unit "wordpress/0": no public address`)
+	c.Assert(err, gc.ErrorMatches, `error fetching address for unit "wordpress/0": no public address\(es\)`)
 }
 
 func (s *clientSuite) TestClientPublicAddressMachine(c *gc.C) {
@@ -723,9 +723,9 @@ func (s *clientSuite) TestClientPrivateAddressErrors(c *gc.C) {
 	_, err := s.APIState.Client().PrivateAddress("wordpress")
 	c.Assert(err, gc.ErrorMatches, `unknown unit or machine "wordpress"`)
 	_, err = s.APIState.Client().PrivateAddress("0")
-	c.Assert(err, gc.ErrorMatches, `error fetching address for machine "0": no private address`)
+	c.Assert(err, gc.ErrorMatches, `error fetching address for machine "0": no private address\(es\)`)
 	_, err = s.APIState.Client().PrivateAddress("wordpress/0")
-	c.Assert(err, gc.ErrorMatches, `error fetching address for unit "wordpress/0": no private address`)
+	c.Assert(err, gc.ErrorMatches, `error fetching address for unit "wordpress/0": no private address\(es\)`)
 }
 
 func (s *clientSuite) TestClientPrivateAddress(c *gc.C) {

--- a/apiserver/restrict_upgrades.go
+++ b/apiserver/restrict_upgrades.go
@@ -40,6 +40,8 @@ var allowedMethodsDuringUpgrades = map[string]set.Strings{
 	"SSHClient": set.NewStrings( // allow all SSH client related calls
 		"PublicAddress",
 		"PrivateAddress",
+		"BestAPIVersion",
+		"AllAddresses",
 		"PublicKeys",
 		"Proxy",
 	),

--- a/cmd/juju/commands/debughooks.go
+++ b/cmd/juju/commands/debughooks.go
@@ -15,11 +15,14 @@ import (
 
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/network"
 	unitdebug "github.com/juju/juju/worker/uniter/runner/debug"
 )
 
-func newDebugHooksCommand() cmd.Command {
-	return modelcmd.Wrap(&debugHooksCommand{})
+func newDebugHooksCommand(hostDialer network.Dialer) cmd.Command {
+	c := new(debugHooksCommand)
+	c.setHostDialer(hostDialer)
+	return modelcmd.Wrap(c)
 }
 
 // debugHooksCommand is responsible for launching a ssh shell on a given unit or machine.

--- a/cmd/juju/commands/debughooks_test.go
+++ b/cmd/juju/commands/debughooks_test.go
@@ -19,15 +19,17 @@ type DebugHooksSuite struct {
 }
 
 var debugHooksTests = []struct {
-	info     string
-	args     []string
-	error    string
-	proxy    bool
-	expected *argsSpec
+	info       string
+	args       []string
+	dialWith   dialerFunc
+	forceAPIv1 bool
+	error      string
+	expected   *argsSpec
 }{{
-	info:  "unit name without hook",
-	args:  []string{"mysql/0"},
-	proxy: true,
+	info:       "literal script (api v1: unit name w/o hook or proxy)",
+	args:       []string{"mysql/0"},
+	dialWith:   dialerFuncFor("0.private", "0.public"),
+	forceAPIv1: true,
 	expected: &argsSpec{
 		hostKeyChecking: "yes",
 		knownHosts:      "0",
@@ -35,14 +37,50 @@ var debugHooksTests = []struct {
 		args:            "ubuntu@0.public sudo /bin/bash -c 'F=$(mktemp); echo IyEvYmluL2Jhc2gKKApjbGVhbnVwX29uX2V4aXQoKSAKeyAKCWVjaG8gIkNsZWFuaW5nIHVwIHRoZSBkZWJ1ZyBzZXNzaW9uIgoJdG11eCBraWxsLXNlc3Npb24gLXQgbXlzcWwvMDsgCn0KdHJhcCBjbGVhbnVwX29uX2V4aXQgRVhJVAoKIyBMb2NrIHRoZSBqdWp1LTx1bml0Pi1kZWJ1ZyBsb2NrZmlsZS4KZmxvY2sgLW4gOCB8fCAoCgllY2hvICJGb3VuZCBleGlzdGluZyBkZWJ1ZyBzZXNzaW9ucywgYXR0ZW1wdGluZyB0byByZWNvbm5lY3QiIDI+JjEKCWV4ZWMgdG11eCBhdHRhY2gtc2Vzc2lvbiAtdCBteXNxbC8wCglleGl0ICQ/CgkpCigKIyBDbG9zZSB0aGUgaW5oZXJpdGVkIGxvY2sgRkQsIG9yIHRtdXggd2lsbCBrZWVwIGl0IG9wZW4uCmV4ZWMgOD4mLQoKIyBXcml0ZSBvdXQgdGhlIGRlYnVnLWhvb2tzIGFyZ3MuCmVjaG8gImUzMEsiIHwgYmFzZTY0IC1kID4gL3RtcC9qdWp1LXVuaXQtbXlzcWwtMC1kZWJ1Zy1ob29rcwoKIyBMb2NrIHRoZSBqdWp1LTx1bml0Pi1kZWJ1Zy1leGl0IGxvY2tmaWxlLgpmbG9jayAtbiA5IHx8IGV4aXQgMQoKIyBXYWl0IGZvciB0bXV4IHRvIGJlIGluc3RhbGxlZC4Kd2hpbGUgWyAhIC1mIC91c3IvYmluL3RtdXggXTsgZG8KICAgIHNsZWVwIDEKZG9uZQoKaWYgWyAhIC1mIH4vLnRtdXguY29uZiBdOyB0aGVuCiAgICAgICAgaWYgWyAtZiAvdXNyL3NoYXJlL2J5b2J1L3Byb2ZpbGVzL3RtdXggXTsgdGhlbgogICAgICAgICAgICAgICAgIyBVc2UgYnlvYnUvdG11eCBwcm9maWxlIGZvciBmYW1pbGlhciBrZXliaW5kaW5ncyBhbmQgYnJhbmRpbmcKICAgICAgICAgICAgICAgIGVjaG8gInNvdXJjZS1maWxlIC91c3Ivc2hhcmUvYnlvYnUvcHJvZmlsZXMvdG11eCIgPiB+Ly50bXV4LmNvbmYKICAgICAgICBlbHNlCiAgICAgICAgICAgICAgICAjIE90aGVyd2lzZSwgdXNlIHRoZSBsZWdhY3kganVqdS90bXV4IGNvbmZpZ3VyYXRpb24KICAgICAgICAgICAgICAgIGNhdCA+IH4vLnRtdXguY29uZiA8PEVORAogICAgICAgICAgICAgICAgCiMgU3RhdHVzIGJhcgpzZXQtb3B0aW9uIC1nIHN0YXR1cy1iZyBibGFjawpzZXQtb3B0aW9uIC1nIHN0YXR1cy1mZyB3aGl0ZQoKc2V0LXdpbmRvdy1vcHRpb24gLWcgd2luZG93LXN0YXR1cy1jdXJyZW50LWJnIHJlZApzZXQtd2luZG93LW9wdGlvbiAtZyB3aW5kb3ctc3RhdHVzLWN1cnJlbnQtYXR0ciBicmlnaHQKCnNldC1vcHRpb24gLWcgc3RhdHVzLXJpZ2h0ICcnCgojIFBhbmVzCnNldC1vcHRpb24gLWcgcGFuZS1ib3JkZXItZmcgd2hpdGUKc2V0LW9wdGlvbiAtZyBwYW5lLWFjdGl2ZS1ib3JkZXItZmcgd2hpdGUKCiMgTW9uaXRvciBhY3Rpdml0eSBvbiB3aW5kb3dzCnNldC13aW5kb3ctb3B0aW9uIC1nIG1vbml0b3ItYWN0aXZpdHkgb24KCiMgU2NyZWVuIGJpbmRpbmdzLCBzaW5jZSBwZW9wbGUgYXJlIG1vcmUgZmFtaWxpYXIgd2l0aCB0aGF0LgpzZXQtb3B0aW9uIC1nIHByZWZpeCBDLWEKYmluZCBDLWEgbGFzdC13aW5kb3cKYmluZCBhIHNlbmQta2V5IEMtYQoKYmluZCB8IHNwbGl0LXdpbmRvdyAtaApiaW5kIC0gc3BsaXQtd2luZG93IC12CgojIEZpeCBDVFJMLVBHVVAvUEdET1dOIGZvciB2aW0Kc2V0LXdpbmRvdy1vcHRpb24gLWcgeHRlcm0ta2V5cyBvbgoKIyBQcmV2ZW50IEVTQyBrZXkgZnJvbSBhZGRpbmcgZGVsYXkgYW5kIGJyZWFraW5nIFZpbSdzIEVTQyA+IGFycm93IGtleQpzZXQtb3B0aW9uIC1zIGVzY2FwZS10aW1lIDAKCkVORAogICAgICAgIGZpCmZpCgooCiAgICAjIENsb3NlIHRoZSBpbmhlcml0ZWQgbG9jayBGRCwgb3IgdG11eCB3aWxsIGtlZXAgaXQgb3Blbi4KICAgIGV4ZWMgOT4mLQogICAgaWYgISB0bXV4IGhhcy1zZXNzaW9uIC10IG15c3FsLzA7IHRoZW4KCQl0bXV4IG5ldy1zZXNzaW9uIC1kIC1zIG15c3FsLzAKCWZpCgljbGllbnRfY291bnQ9JCh0bXV4IGxpc3QtY2xpZW50cyB8IHdjIC1sKQoJaWYgWyAkY2xpZW50X2NvdW50IC1nZSAxIF07IHRoZW4KCQlzZXNzaW9uX25hbWU9bXlzcWwvMCItIiRjbGllbnRfY250CgkJZXhlYyB0bXV4IG5ldy1zZXNzaW9uIC1kIC10IG15c3FsLzAgLXMgJHNlc3Npb25fbmFtZQoJCWV4ZWMgdG11eCBhdHRhY2gtc2Vzc2lvbiAtdCAkc2Vzc2lvbl9uYW1lIFw7IHNldC1vcHRpb24gZGVzdHJveS11bmF0dGFjaGVkCgllbHNlCgkgICAgZXhlYyB0bXV4IGF0dGFjaC1zZXNzaW9uIC10IG15c3FsLzAKCWZpCikKKSA5Pi90bXAvanVqdS11bml0LW15c3FsLTAtZGVidWctaG9va3MtZXhpdAopIDg+L3RtcC9qdWp1LXVuaXQtbXlzcWwtMC1kZWJ1Zy1ob29rcwpleGl0ICQ/Cg== | base64 -d > $F; . $F'",
 	},
 }, {
-	info: "proxy",
-	args: []string{"--proxy=true", "mysql/0"},
+	info:       "unit name without hook (api v1)",
+	args:       []string{"mysql/0"},
+	dialWith:   dialerFuncFor("0.private", "0.public"),
+	forceAPIv1: true,
+	expected: &argsSpec{
+		hostKeyChecking: "yes",
+		knownHosts:      "0",
+		enablePty:       true,
+		argsMatch:       `ubuntu@0\.public sudo /bin/bash .+`,
+	},
+}, {
+	info:       "unit name without hook (api v2)",
+	args:       []string{"mysql/0"},
+	dialWith:   dialerFuncFor("0.private", "0.public", "0.1.2.3"), // last one set on machine 0 eth0
+	forceAPIv1: false,
+	expected: &argsSpec{
+		hostKeyChecking: "yes",
+		knownHosts:      "0",
+		enablePty:       true,
+		argsMatch:       `ubuntu@0\.(private|public|1\.2\.3) sudo .+`, // can be any of the 3
+	},
+}, {
+	info:       "proxy (api v1)",
+	args:       []string{"--proxy=true", "mysql/0"},
+	dialWith:   dialerFuncFor("0.private", "0.public"),
+	forceAPIv1: true,
 	expected: &argsSpec{
 		hostKeyChecking: "yes",
 		knownHosts:      "0",
 		enablePty:       true,
 		withProxy:       true,
-		args:            "ubuntu@0.private sudo /bin/bash -c 'F=$(mktemp); echo IyEvYmluL2Jhc2gKKApjbGVhbnVwX29uX2V4aXQoKSAKeyAKCWVjaG8gIkNsZWFuaW5nIHVwIHRoZSBkZWJ1ZyBzZXNzaW9uIgoJdG11eCBraWxsLXNlc3Npb24gLXQgbXlzcWwvMDsgCn0KdHJhcCBjbGVhbnVwX29uX2V4aXQgRVhJVAoKIyBMb2NrIHRoZSBqdWp1LTx1bml0Pi1kZWJ1ZyBsb2NrZmlsZS4KZmxvY2sgLW4gOCB8fCAoCgllY2hvICJGb3VuZCBleGlzdGluZyBkZWJ1ZyBzZXNzaW9ucywgYXR0ZW1wdGluZyB0byByZWNvbm5lY3QiIDI+JjEKCWV4ZWMgdG11eCBhdHRhY2gtc2Vzc2lvbiAtdCBteXNxbC8wCglleGl0ICQ/CgkpCigKIyBDbG9zZSB0aGUgaW5oZXJpdGVkIGxvY2sgRkQsIG9yIHRtdXggd2lsbCBrZWVwIGl0IG9wZW4uCmV4ZWMgOD4mLQoKIyBXcml0ZSBvdXQgdGhlIGRlYnVnLWhvb2tzIGFyZ3MuCmVjaG8gImUzMEsiIHwgYmFzZTY0IC1kID4gL3RtcC9qdWp1LXVuaXQtbXlzcWwtMC1kZWJ1Zy1ob29rcwoKIyBMb2NrIHRoZSBqdWp1LTx1bml0Pi1kZWJ1Zy1leGl0IGxvY2tmaWxlLgpmbG9jayAtbiA5IHx8IGV4aXQgMQoKIyBXYWl0IGZvciB0bXV4IHRvIGJlIGluc3RhbGxlZC4Kd2hpbGUgWyAhIC1mIC91c3IvYmluL3RtdXggXTsgZG8KICAgIHNsZWVwIDEKZG9uZQoKaWYgWyAhIC1mIH4vLnRtdXguY29uZiBdOyB0aGVuCiAgICAgICAgaWYgWyAtZiAvdXNyL3NoYXJlL2J5b2J1L3Byb2ZpbGVzL3RtdXggXTsgdGhlbgogICAgICAgICAgICAgICAgIyBVc2UgYnlvYnUvdG11eCBwcm9maWxlIGZvciBmYW1pbGlhciBrZXliaW5kaW5ncyBhbmQgYnJhbmRpbmcKICAgICAgICAgICAgICAgIGVjaG8gInNvdXJjZS1maWxlIC91c3Ivc2hhcmUvYnlvYnUvcHJvZmlsZXMvdG11eCIgPiB+Ly50bXV4LmNvbmYKICAgICAgICBlbHNlCiAgICAgICAgICAgICAgICAjIE90aGVyd2lzZSwgdXNlIHRoZSBsZWdhY3kganVqdS90bXV4IGNvbmZpZ3VyYXRpb24KICAgICAgICAgICAgICAgIGNhdCA+IH4vLnRtdXguY29uZiA8PEVORAogICAgICAgICAgICAgICAgCiMgU3RhdHVzIGJhcgpzZXQtb3B0aW9uIC1nIHN0YXR1cy1iZyBibGFjawpzZXQtb3B0aW9uIC1nIHN0YXR1cy1mZyB3aGl0ZQoKc2V0LXdpbmRvdy1vcHRpb24gLWcgd2luZG93LXN0YXR1cy1jdXJyZW50LWJnIHJlZApzZXQtd2luZG93LW9wdGlvbiAtZyB3aW5kb3ctc3RhdHVzLWN1cnJlbnQtYXR0ciBicmlnaHQKCnNldC1vcHRpb24gLWcgc3RhdHVzLXJpZ2h0ICcnCgojIFBhbmVzCnNldC1vcHRpb24gLWcgcGFuZS1ib3JkZXItZmcgd2hpdGUKc2V0LW9wdGlvbiAtZyBwYW5lLWFjdGl2ZS1ib3JkZXItZmcgd2hpdGUKCiMgTW9uaXRvciBhY3Rpdml0eSBvbiB3aW5kb3dzCnNldC13aW5kb3ctb3B0aW9uIC1nIG1vbml0b3ItYWN0aXZpdHkgb24KCiMgU2NyZWVuIGJpbmRpbmdzLCBzaW5jZSBwZW9wbGUgYXJlIG1vcmUgZmFtaWxpYXIgd2l0aCB0aGF0LgpzZXQtb3B0aW9uIC1nIHByZWZpeCBDLWEKYmluZCBDLWEgbGFzdC13aW5kb3cKYmluZCBhIHNlbmQta2V5IEMtYQoKYmluZCB8IHNwbGl0LXdpbmRvdyAtaApiaW5kIC0gc3BsaXQtd2luZG93IC12CgojIEZpeCBDVFJMLVBHVVAvUEdET1dOIGZvciB2aW0Kc2V0LXdpbmRvdy1vcHRpb24gLWcgeHRlcm0ta2V5cyBvbgoKIyBQcmV2ZW50IEVTQyBrZXkgZnJvbSBhZGRpbmcgZGVsYXkgYW5kIGJyZWFraW5nIFZpbSdzIEVTQyA+IGFycm93IGtleQpzZXQtb3B0aW9uIC1zIGVzY2FwZS10aW1lIDAKCkVORAogICAgICAgIGZpCmZpCgooCiAgICAjIENsb3NlIHRoZSBpbmhlcml0ZWQgbG9jayBGRCwgb3IgdG11eCB3aWxsIGtlZXAgaXQgb3Blbi4KICAgIGV4ZWMgOT4mLQogICAgaWYgISB0bXV4IGhhcy1zZXNzaW9uIC10IG15c3FsLzA7IHRoZW4KCQl0bXV4IG5ldy1zZXNzaW9uIC1kIC1zIG15c3FsLzAKCWZpCgljbGllbnRfY291bnQ9JCh0bXV4IGxpc3QtY2xpZW50cyB8IHdjIC1sKQoJaWYgWyAkY2xpZW50X2NvdW50IC1nZSAxIF07IHRoZW4KCQlzZXNzaW9uX25hbWU9bXlzcWwvMCItIiRjbGllbnRfY250CgkJZXhlYyB0bXV4IG5ldy1zZXNzaW9uIC1kIC10IG15c3FsLzAgLXMgJHNlc3Npb25fbmFtZQoJCWV4ZWMgdG11eCBhdHRhY2gtc2Vzc2lvbiAtdCAkc2Vzc2lvbl9uYW1lIFw7IHNldC1vcHRpb24gZGVzdHJveS11bmF0dGFjaGVkCgllbHNlCgkgICAgZXhlYyB0bXV4IGF0dGFjaC1zZXNzaW9uIC10IG15c3FsLzAKCWZpCikKKSA5Pi90bXAvanVqdS11bml0LW15c3FsLTAtZGVidWctaG9va3MtZXhpdAopIDg+L3RtcC9qdWp1LXVuaXQtbXlzcWwtMC1kZWJ1Zy1ob29rcwpleGl0ICQ/Cg== | base64 -d > $F; . $F'",
+		argsMatch:       `ubuntu@0\.private sudo /bin/bash .+`,
+	},
+}, {
+	info:       "proxy (api v2)",
+	args:       []string{"--proxy=true", "mysql/0"},
+	dialWith:   dialerFuncFor("0.private", "0.public", "0.1.2.3"), // last one set on machine 0 eth0
+	forceAPIv1: false,
+	expected: &argsSpec{
+		hostKeyChecking: "yes",
+		knownHosts:      "0",
+		enablePty:       true,
+		withProxy:       true,
+		argsMatch:       `ubuntu@0\.(private|public|1\.2\.3) sudo .+`, // can be any of the 3
 	},
 }, {
 	info:     `"*" is a valid hook name: it means hook everything`,
@@ -72,6 +110,10 @@ var debugHooksTests = []struct {
 	info:  `invalid hook`,
 	args:  []string{"mysql/0", "invalid-hook"},
 	error: `unit "mysql/0" does not contain hook "invalid-hook"`,
+}, {
+	info:  `no args at all`,
+	args:  nil,
+	error: `no unit name specified`,
 }}
 
 func (s *DebugHooksSuite) TestDebugHooksCommand(c *gc.C) {
@@ -85,7 +127,10 @@ func (s *DebugHooksSuite) TestDebugHooksCommand(c *gc.C) {
 	for i, t := range debugHooksTests {
 		c.Logf("test %d: %s\n\t%s\n", i, t.info, t.args)
 
-		ctx, err := coretesting.RunCommand(c, newDebugHooksCommand(), t.args...)
+		s.setHostDialerFunc(t.dialWith)
+		s.setForceAPIv1(t.forceAPIv1)
+
+		ctx, err := coretesting.RunCommand(c, newDebugHooksCommand(s.hostDialer), t.args...)
 		if t.error != "" {
 			c.Check(err, gc.ErrorMatches, t.error)
 		} else {

--- a/cmd/juju/commands/debughooks_test.go
+++ b/cmd/juju/commands/debughooks_test.go
@@ -50,7 +50,7 @@ var debugHooksTests = []struct {
 }, {
 	info:       "unit name without hook (api v2)",
 	args:       []string{"mysql/0"},
-	dialWith:   dialerFuncFor("0.private", "0.public", "0.1.2.3"), // last one set on machine 0 eth0
+	dialWith:   dialerFuncFor("0.private", "0.public", "0.1.2.3"), // set by setAddresses() and setLinkLayerDevicesAddresses()
 	forceAPIv1: false,
 	expected: &argsSpec{
 		hostKeyChecking: "yes",
@@ -73,7 +73,7 @@ var debugHooksTests = []struct {
 }, {
 	info:       "proxy (api v2)",
 	args:       []string{"--proxy=true", "mysql/0"},
-	dialWith:   dialerFuncFor("0.private", "0.public", "0.1.2.3"), // last one set on machine 0 eth0
+	dialWith:   dialerFuncFor("0.private", "0.public", "0.1.2.3"), // set by setAddresses() and setLinkLayerDevicesAddresses()
 	forceAPIv1: false,
 	expected: &argsSpec{
 		hostKeyChecking: "yes",

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -246,11 +246,11 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 
 	// Error resolution and debugging commands.
 	r.Register(newRunCommand())
-	r.Register(newSCPCommand())
-	r.Register(newSSHCommand())
+	r.Register(newSCPCommand(nil))
+	r.Register(newSSHCommand(nil))
 	r.Register(newResolvedCommand())
 	r.Register(newDebugLogCommand())
-	r.Register(newDebugHooksCommand())
+	r.Register(newDebugHooksCommand(nil))
 
 	// Configuration commands.
 	r.Register(model.NewModelGetConstraintsCommand())

--- a/cmd/juju/commands/scp.go
+++ b/cmd/juju/commands/scp.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/utils/ssh"
 
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/network"
 )
 
 var usageSCPSummary = `
@@ -72,8 +73,10 @@ causes the transfer to be made via the client):
 See also: 
     ssh`
 
-func newSCPCommand() cmd.Command {
-	return modelcmd.Wrap(&scpCommand{})
+func newSCPCommand(hostDialer network.Dialer) cmd.Command {
+	c := new(scpCommand)
+	c.setHostDialer(hostDialer)
+	return modelcmd.Wrap(c)
 }
 
 // scpCommand is responsible for launching a scp command to copy files to/from remote machine(s)

--- a/cmd/juju/commands/scp_unix_test.go
+++ b/cmd/juju/commands/scp_unix_test.go
@@ -42,7 +42,7 @@ var scpTests = []struct {
 	}, {
 		about:      "scp from machine 0 to current dir (api v2)",
 		args:       []string{"0:foo", "."},
-		dialWith:   dialerFuncFor("0.private", "0.public", "0.1.2.3"), // last one set on machine 0 eth0
+		dialWith:   dialerFuncFor("0.private", "0.public", "0.1.2.3"), // set by setAddresses() and setLinkLayerDevicesAddresses()
 		forceAPIv1: false,
 		expected: argsSpec{
 			argsMatch:       `ubuntu@0.(public|private|1\.2\.3):foo \.`, // can be any of the 3

--- a/cmd/juju/commands/scp_unix_test.go
+++ b/cmd/juju/commands/scp_unix_test.go
@@ -22,30 +22,46 @@ type SCPSuite struct {
 }
 
 var scpTests = []struct {
-	about    string
-	args     []string
-	expected argsSpec
-	error    string
+	about      string
+	args       []string
+	dialWith   dialerFunc
+	forceAPIv1 bool
+	expected   argsSpec
+	error      string
 }{
 	{
-		about: "scp from machine 0 to current dir",
-		args:  []string{"0:foo", "."},
+		about:      "scp from machine 0 to current dir (api v1)",
+		args:       []string{"0:foo", "."},
+		dialWith:   dialerFuncFor("0.private", "0.public"),
+		forceAPIv1: true,
 		expected: argsSpec{
 			args:            "ubuntu@0.public:foo .",
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
 		},
 	}, {
-		about: "scp from machine 0 to current dir with extra args",
-		args:  []string{"0:foo", ".", "-rv", "-o", "SomeOption"},
+		about:      "scp from machine 0 to current dir (api v2)",
+		args:       []string{"0:foo", "."},
+		dialWith:   dialerFuncFor("0.private", "0.public", "0.1.2.3"), // last one set on machine 0 eth0
+		forceAPIv1: false,
+		expected: argsSpec{
+			argsMatch:       `ubuntu@0.(public|private|1\.2\.3):foo \.`, // can be any of the 3
+			hostKeyChecking: "yes",
+			knownHosts:      "0",
+		},
+	}, {
+		about:    "scp from machine 0 to current dir with extra args",
+		args:     []string{"0:foo", ".", "-rv", "-o", "SomeOption"},
+		dialWith: dialerFuncFor("0.private", "0.public"),
 		expected: argsSpec{
 			args:            "ubuntu@0.public:foo . -rv -o SomeOption",
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
 		},
 	}, {
-		about: "scp from current dir to machine 0",
-		args:  []string{"foo", "0:"},
+		about:    "scp from current dir to machine 0",
+		args:     []string{"foo", "0:"},
+		dialWith: dialerFuncFor("0.private", "0.public"),
 		expected: argsSpec{
 			args:            "foo ubuntu@0.public:",
 			hostKeyChecking: "yes",
@@ -56,32 +72,36 @@ var scpTests = []struct {
 		args:  []string{"foo", "1:"},
 		error: `retrieving SSH host keys for "1": keys not found`,
 	}, {
-		about: "scp when no keys available, with --no-host-key-checks",
-		args:  []string{"--no-host-key-checks", "foo", "1:"},
+		about:    "scp when no keys available, with --no-host-key-checks",
+		args:     []string{"--no-host-key-checks", "foo", "1:"},
+		dialWith: dialerFuncFor("1.private", "1.public"),
 		expected: argsSpec{
 			args:            "foo ubuntu@1.public:",
 			hostKeyChecking: "no",
 			knownHosts:      "null",
 		},
 	}, {
-		about: "scp from current dir to machine 0 with extra args",
-		args:  []string{"foo", "0:", "-r", "-v"},
+		about:    "scp from current dir to machine 0 with extra args",
+		args:     []string{"foo", "0:", "-r", "-v"},
+		dialWith: dialerFuncFor("0.private", "0.public"),
 		expected: argsSpec{
 			args:            "foo ubuntu@0.public: -r -v",
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
 		},
 	}, {
-		about: "scp from machine 0 to unit mysql/0",
-		args:  []string{"0:foo", "mysql/0:/foo"},
+		about:    "scp from machine 0 to unit mysql/0",
+		args:     []string{"0:foo", "mysql/0:/foo"},
+		dialWith: dialerFuncFor("0.private", "0.public"),
 		expected: argsSpec{
 			args:            "ubuntu@0.public:foo ubuntu@0.public:/foo",
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
 		},
 	}, {
-		about: "scp from machine 0 to unit mysql/0 and extra args",
-		args:  []string{"0:foo", "mysql/0:/foo", "-q"},
+		about:    "scp from machine 0 to unit mysql/0 and extra args",
+		args:     []string{"0:foo", "mysql/0:/foo", "-q"},
+		dialWith: dialerFuncFor("0.private", "0.public"),
 		expected: argsSpec{
 			args:            "ubuntu@0.public:foo ubuntu@0.public:/foo -q",
 			hostKeyChecking: "yes",
@@ -92,32 +112,36 @@ var scpTests = []struct {
 		args:  []string{"-q", "-r", "0:foo", "mysql/0:/foo"},
 		error: "flag provided but not defined: -q",
 	}, {
-		about: "scp two local files to unit mysql/0",
-		args:  []string{"file1", "file2", "mysql/0:/foo/"},
+		about:    "scp two local files to unit mysql/0",
+		args:     []string{"file1", "file2", "mysql/0:/foo/"},
+		dialWith: dialerFuncFor("0.private", "0.public"),
 		expected: argsSpec{
 			args:            "file1 file2 ubuntu@0.public:/foo/",
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
 		},
 	}, {
-		about: "scp from machine 0 to unit mysql/0 and multiple extra args",
-		args:  []string{"0:foo", "mysql/0:", "-r", "-v", "-q", "-l5"},
+		about:    "scp from machine 0 to unit mysql/0 and multiple extra args",
+		args:     []string{"0:foo", "mysql/0:", "-r", "-v", "-q", "-l5"},
+		dialWith: dialerFuncFor("0.private", "0.public"),
 		expected: argsSpec{
 			args:            "ubuntu@0.public:foo ubuntu@0.public: -r -v -q -l5",
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
 		},
 	}, {
-		about: "scp works with IPv6 addresses",
-		args:  []string{"2:foo", "bar"},
+		about:    "scp works with IPv6 addresses",
+		args:     []string{"2:foo", "bar"},
+		dialWith: dialerFuncFor("2001:db8::1"),
 		expected: argsSpec{
 			args:            `ubuntu@[2001:db8::1]:foo bar`,
 			hostKeyChecking: "yes",
 			knownHosts:      "2",
 		},
 	}, {
-		about: "scp from machine 0 to unit mysql/0 with proxy",
-		args:  []string{"--proxy=true", "0:foo", "mysql/0:/bar"},
+		about:    "scp from machine 0 to unit mysql/0 with proxy",
+		args:     []string{"--proxy=true", "0:foo", "mysql/0:/bar"},
+		dialWith: dialerFuncFor("0.private"),
 		expected: argsSpec{
 			args:            "ubuntu@0.private:foo ubuntu@0.private:/bar",
 			withProxy:       true,
@@ -125,16 +149,18 @@ var scpTests = []struct {
 			knownHosts:      "0",
 		},
 	}, {
-		about: "scp from unit mysql/0 to machine 2 with a --",
-		args:  []string{"--", "-r", "-v", "mysql/0:foo", "2:", "-q", "-l5"},
+		about:    "scp from unit mysql/0 to machine 2 with a --",
+		args:     []string{"--", "-r", "-v", "mysql/0:foo", "2:", "-q", "-l5"},
+		dialWith: dialerFuncFor("0.public", "0.private", "2001:db8::1"),
 		expected: argsSpec{
 			args:            "-r -v ubuntu@0.public:foo ubuntu@[2001:db8::1]: -q -l5",
 			hostKeyChecking: "yes",
 			knownHosts:      "0,2",
 		},
 	}, {
-		about: "scp from unit mysql/0 to current dir as 'sam' user",
-		args:  []string{"sam@mysql/0:foo", "."},
+		about:    "scp from unit mysql/0 to current dir as 'sam' user",
+		args:     []string{"sam@mysql/0:foo", "."},
+		dialWith: dialerFuncFor("0.private", "0.public"),
 		expected: argsSpec{
 			args:            "sam@0.public:foo .",
 			hostKeyChecking: "yes",
@@ -145,15 +171,17 @@ var scpTests = []struct {
 		args:  []string{"5:foo", "bar"},
 		error: `machine 5 not found`,
 	}, {
-		about: "scp from arbitrary host name to current dir",
-		args:  []string{"some.host:foo", "."},
+		about:    "scp from arbitrary host name to current dir",
+		args:     []string{"some.host:foo", "."},
+		dialWith: dialerFuncFor("some.host"),
 		expected: argsSpec{
 			args:            "some.host:foo .",
 			hostKeyChecking: "",
 		},
 	}, {
-		about: "scp from arbitrary user & host to current dir",
-		args:  []string{"someone@some.host:foo", "."},
+		about:    "scp from arbitrary user & host to current dir",
+		args:     []string{"someone@some.host:foo", "."},
+		dialWith: dialerFuncFor("some.host"),
 		expected: argsSpec{
 			args:            "someone@some.host:foo .",
 			hostKeyChecking: "",
@@ -163,13 +191,20 @@ var scpTests = []struct {
 		args:  []string{"some.host:foo", "0:"},
 		error: `can't determine host keys for all targets: consider --no-host-key-checks`,
 	}, {
-		about: "scp with arbitrary host name and an entity, --no-host-key-checks",
-		args:  []string{"--no-host-key-checks", "some.host:foo", "0:"},
+		about:      "scp with arbitrary host name and an entity, --no-host-key-checks, --proxy (api v1)",
+		args:       []string{"--no-host-key-checks", "--proxy", "some.host:foo", "0:"},
+		dialWith:   dialerFuncFor("some.host", "0.public", "0.private"),
+		forceAPIv1: true,
 		expected: argsSpec{
-			args:            "some.host:foo ubuntu@0.public:",
+			args:            "some.host:foo ubuntu@0.private:",
 			hostKeyChecking: "no",
+			withProxy:       true,
 			knownHosts:      "null",
 		},
+	}, {
+		about: "scp with no arguments",
+		args:  nil,
+		error: `at least two arguments required`,
 	},
 }
 
@@ -179,7 +214,10 @@ func (s *SCPSuite) TestSCPCommand(c *gc.C) {
 	for i, t := range scpTests {
 		c.Logf("test %d: %s -> %s\n", i, t.about, t.args)
 
-		ctx, err := coretesting.RunCommand(c, newSCPCommand(), t.args...)
+		s.setHostDialerFunc(t.dialWith)
+		s.setForceAPIv1(t.forceAPIv1)
+
+		ctx, err := coretesting.RunCommand(c, newSCPCommand(s.hostDialer), t.args...)
 		if t.error != "" {
 			c.Check(err, gc.ErrorMatches, t.error)
 		} else {

--- a/cmd/juju/commands/ssh.go
+++ b/cmd/juju/commands/ssh.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/utils/ssh"
 
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/network"
 )
 
 var usageSSHSummary = `
@@ -47,8 +48,10 @@ Connect to a jenkins unit as user jenkins:
 See also: 
     scp`
 
-func newSSHCommand() cmd.Command {
-	return modelcmd.Wrap(&sshCommand{})
+func newSSHCommand(hostDialer network.Dialer) cmd.Command {
+	c := new(sshCommand)
+	c.setHostDialer(hostDialer)
+	return modelcmd.Wrap(c)
 }
 
 // sshCommand is responsible for launching a ssh shell on a given unit or machine.

--- a/cmd/juju/commands/ssh_common_test.go
+++ b/cmd/juju/commands/ssh_common_test.go
@@ -216,7 +216,9 @@ func (s *SSHCommonSuite) setupModel(c *gc.C) {
 	// Add machine-0 with a mysql service and mysql/0 unit
 	u := s.Factory.MakeUnit(c, nil)
 
-	// Set addresses and keys for machine-0
+	// Set both the preferred public and private addresses for machine-0, add a
+	// couple of link-layer devices (loopback and ethernet) with addresses, and
+	// the ssh keys.
 	m := s.getMachineForUnit(c, u)
 	s.setAddresses(c, m)
 	s.setKeys(c, m)

--- a/cmd/juju/commands/ssh_common_test.go
+++ b/cmd/juju/commands/ssh_common_test.go
@@ -5,12 +5,15 @@ package commands
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
 	"github.com/juju/utils/ssh"
 	gc "gopkg.in/check.v1"
 
@@ -42,8 +45,12 @@ type argsSpec struct {
 	knownHosts string
 
 	// args specifies any other command line arguments expected. This
-	// includes the SSH/SCP targets.
+	// includes the SSH/SCP targets. Ignored if argsMatch is set as well.
 	args string
+
+	// argsMatch is like args, but instead of a literal string it's interpreted
+	// as a regular expression. When argsMatch is set, args is ignored.
+	argsMatch string
 }
 
 func (s *argsSpec) check(c *gc.C, output string) {
@@ -85,8 +92,14 @@ func (s *argsSpec) check(c *gc.C, output string) {
 		c.Check(actualKnownHosts, gc.Matches, s.expectedKnownHosts())
 	}
 
+	if s.argsMatch != "" {
+		expect(s.argsMatch)
+	} else {
+		expect(regexp.QuoteMeta(s.args))
+	}
+
 	// Check the command line matches what is expected.
-	pattern := "^" + strings.Join(expected, " ") + " " + regexp.QuoteMeta(s.args) + "$"
+	pattern := "^" + strings.Join(expected, " ") + "$"
 	c.Check(actualCommandLine, gc.Matches, pattern)
 }
 
@@ -102,6 +115,7 @@ type SSHCommonSuite struct {
 	testing.JujuConnSuite
 	knownHostsDir string
 	binDir        string
+	hostDialer    network.Dialer
 }
 
 // Commands to patch
@@ -126,10 +140,36 @@ var fakecommand = `#!/bin/bash
 }| tee $0.args
 `
 
+type dialerFunc func(address string) error
+
+type fakeDialer struct {
+	dialWith dialerFunc
+}
+
+func (f *fakeDialer) Dial(network, address string) (net.Conn, error) {
+	if f.dialWith == nil {
+		return &fakeConn{}, nil
+	}
+
+	err := f.dialWith(address)
+	if err != nil {
+		return nil, err
+	}
+
+	return &fakeConn{}, nil
+}
+
+type fakeConn struct {
+	net.Conn
+}
+
+func (f *fakeConn) Close() error { return nil }
+
 func (s *SSHCommonSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	ssh.ClearClientKeys()
 	s.PatchValue(&getJujuExecutable, func() (string, error) { return "juju", nil })
+	s.setForceAPIv1(false)
 
 	s.binDir = c.MkDir()
 	s.PatchEnvPathPrepend(s.binDir)
@@ -146,6 +186,32 @@ func (s *SSHCommonSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&ssh.DefaultClient, client)
 }
 
+func (s *SSHCommonSuite) setForceAPIv1(enabled bool) {
+	if enabled {
+		os.Setenv(jujuSSHClientForceAPIv1, "1")
+	} else {
+		os.Unsetenv(jujuSSHClientForceAPIv1)
+	}
+}
+
+func (s *SSHCommonSuite) setHostDialerFunc(dialWith dialerFunc) {
+	s.hostDialer = &fakeDialer{dialWith: dialWith}
+}
+
+func dialerFuncFor(allowedAddresses ...string) dialerFunc {
+	allowedSet := set.NewStrings(allowedAddresses...)
+
+	return func(address string) error {
+		if strings.HasSuffix(address, ":22") {
+			address, _, _ = net.SplitHostPort(address)
+		}
+		if allowedSet.Contains(address) {
+			return nil
+		}
+		return errors.Errorf("not dialing %q", address)
+	}
+}
+
 func (s *SSHCommonSuite) setupModel(c *gc.C) {
 	// Add machine-0 with a mysql service and mysql/0 unit
 	u := s.Factory.MakeUnit(c, nil)
@@ -154,6 +220,7 @@ func (s *SSHCommonSuite) setupModel(c *gc.C) {
 	m := s.getMachineForUnit(c, u)
 	s.setAddresses(c, m)
 	s.setKeys(c, m)
+	s.setLinkLayerDevicesAddresses(c, m)
 
 	// machine-1 has no public host keys available.
 	m1 := s.Factory.MakeMachine(c, nil)
@@ -183,6 +250,30 @@ func (s *SSHCommonSuite) setAddresses(c *gc.C, m *state.Machine) {
 		network.ScopeCloudLocal,
 	)
 	err := m.SetProviderAddresses(addrPub, addrPriv)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *SSHCommonSuite) setLinkLayerDevicesAddresses(c *gc.C, m *state.Machine) {
+	devicesArgs := []state.LinkLayerDeviceArgs{{
+		Name: "lo",
+		Type: state.LoopbackDevice,
+	}, {
+		Name: "eth0",
+		Type: state.EthernetDevice,
+	}}
+	err := m.SetLinkLayerDevices(devicesArgs...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	addressesArgs := []state.LinkLayerDeviceAddress{{
+		DeviceName:   "lo",
+		CIDRAddress:  "127.0.0.1/8", // will be filtered
+		ConfigMethod: state.LoopbackAddress,
+	}, {
+		DeviceName:   "eth0",
+		CIDRAddress:  "0.1.2.3/24", // needs the be a valid CIDR
+		ConfigMethod: state.StaticAddress,
+	}}
+	err = m.SetDevicesAddresses(addressesArgs...)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/cmd/juju/commands/ssh_unix_test.go
+++ b/cmd/juju/commands/ssh_unix_test.go
@@ -48,7 +48,7 @@ var sshTests = []struct {
 	{
 		about:      "connect to machine 0 (api v2)",
 		args:       []string{"0"},
-		dialWith:   dialerFuncFor("0.private", "0.public", "0.1.2.3"), // last one set on machine 0 eth0
+		dialWith:   dialerFuncFor("0.private", "0.public", "0.1.2.3"), // set by setAddresses() and setLinkLayerDevicesAddresses()
 		forceAPIv1: false,
 		expected: argsSpec{
 			hostKeyChecking: "yes",
@@ -157,7 +157,7 @@ var sshTests = []struct {
 	{
 		about:      "connect to unit mysql/0 with proxy (api v2)",
 		args:       []string{"--proxy=true", "mysql/0"},
-		dialWith:   dialerFuncFor("0.private", "0.public", "0.1.2.3"), // last one set on machine 0 eth0
+		dialWith:   dialerFuncFor("0.private", "0.public", "0.1.2.3"), // set by setAddresses() and setLinkLayerDevicesAddresses()
 		forceAPIv1: false,
 		expected: argsSpec{
 			hostKeyChecking: "yes",

--- a/cmd/juju/commands/ssh_unix_test.go
+++ b/cmd/juju/commands/ssh_unix_test.go
@@ -10,10 +10,12 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/network"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -26,12 +28,16 @@ var _ = gc.Suite(&SSHSuite{})
 var sshTests = []struct {
 	about       string
 	args        []string
+	dialWith    dialerFunc
+	forceAPIv1  bool
 	expected    argsSpec
 	expectedErr string
 }{
 	{
-		about: "connect to machine 0",
-		args:  []string{"0"},
+		about:      "connect to machine 0 (api v1)",
+		args:       []string{"0"},
+		dialWith:   dialerFuncFor("0.private", "0.public"),
+		forceAPIv1: true,
 		expected: argsSpec{
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
@@ -40,8 +46,21 @@ var sshTests = []struct {
 		},
 	},
 	{
-		about: "connect to machine 0 and pass extra arguments",
-		args:  []string{"0", "uname", "-a"},
+		about:      "connect to machine 0 (api v2)",
+		args:       []string{"0"},
+		dialWith:   dialerFuncFor("0.private", "0.public", "0.1.2.3"), // last one set on machine 0 eth0
+		forceAPIv1: false,
+		expected: argsSpec{
+			hostKeyChecking: "yes",
+			knownHosts:      "0",
+			enablePty:       true,
+			argsMatch:       `ubuntu@0.(public|private|1\.2\.3)`, // can be any of the 3
+		},
+	},
+	{
+		about:    "connect to machine 0 and pass extra arguments",
+		args:     []string{"0", "uname", "-a"},
+		dialWith: dialerFuncFor("0.private", "0.public"),
 		expected: argsSpec{
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
@@ -50,8 +69,9 @@ var sshTests = []struct {
 		},
 	},
 	{
-		about: "connect to machine 0 with no pseudo-tty",
-		args:  []string{"--pty=false", "0"},
+		about:    "connect to machine 0 with no pseudo-tty",
+		args:     []string{"--pty=false", "0"},
+		dialWith: dialerFuncFor("0.private", "0.public"),
 		expected: argsSpec{
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
@@ -65,8 +85,9 @@ var sshTests = []struct {
 		expectedErr: `retrieving SSH host keys for "1": keys not found`,
 	},
 	{
-		about: "connect to machine 1 which has no SSH host keys, no host key checks",
-		args:  []string{"--no-host-key-checks", "1"},
+		about:    "connect to machine 1 which has no SSH host keys, no host key checks",
+		args:     []string{"--no-host-key-checks", "1"},
+		dialWith: dialerFuncFor("1.private", "1.public"),
 		expected: argsSpec{
 			hostKeyChecking: "no",
 			knownHosts:      "null",
@@ -75,8 +96,9 @@ var sshTests = []struct {
 		},
 	},
 	{
-		about: "connect to arbitrary (non-entity) hostname",
-		args:  []string{"foo@some.host"},
+		about:    "connect to arbitrary (non-entity) hostname",
+		args:     []string{"foo@some.host"},
+		dialWith: dialerFuncFor("some.host"),
 		expected: argsSpec{
 			// In this case, use the user's own known_hosts and own
 			// StrictHostKeyChecking config.
@@ -87,8 +109,9 @@ var sshTests = []struct {
 		},
 	},
 	{
-		about: "connect to unit mysql/0",
-		args:  []string{"mysql/0"},
+		about:    "connect to unit mysql/0",
+		args:     []string{"mysql/0"},
+		dialWith: dialerFuncFor("0.private", "0.public"),
 		expected: argsSpec{
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
@@ -97,8 +120,9 @@ var sshTests = []struct {
 		},
 	},
 	{
-		about: "connect to unit mysql/0 as the mongo user",
-		args:  []string{"mongo@mysql/0"},
+		about:    "connect to unit mysql/0 as the mongo user",
+		args:     []string{"mongo@mysql/0"},
+		dialWith: dialerFuncFor("0.private", "0.public"),
 		expected: argsSpec{
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
@@ -107,8 +131,9 @@ var sshTests = []struct {
 		},
 	},
 	{
-		about: "connect to unit mysql/0 and pass extra arguments",
-		args:  []string{"mysql/0", "ls", "/"},
+		about:    "connect to unit mysql/0 and pass extra arguments",
+		args:     []string{"mysql/0", "ls", "/"},
+		dialWith: dialerFuncFor("0.private", "0.public"),
 		expected: argsSpec{
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
@@ -117,14 +142,29 @@ var sshTests = []struct {
 		},
 	},
 	{
-		about: "connect to unit mysql/0 with proxy",
-		args:  []string{"--proxy=true", "mysql/0"},
+		about:      "connect to unit mysql/0 with proxy (api v1)",
+		args:       []string{"--proxy=true", "mysql/0"},
+		dialWith:   dialerFuncFor("0.private", "0.public"),
+		forceAPIv1: true,
 		expected: argsSpec{
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
 			enablePty:       true,
 			withProxy:       true,
 			args:            "ubuntu@0.private",
+		},
+	},
+	{
+		about:      "connect to unit mysql/0 with proxy (api v2)",
+		args:       []string{"--proxy=true", "mysql/0"},
+		dialWith:   dialerFuncFor("0.private", "0.public", "0.1.2.3"), // last one set on machine 0 eth0
+		forceAPIv1: false,
+		expected: argsSpec{
+			hostKeyChecking: "yes",
+			knownHosts:      "0",
+			enablePty:       true,
+			withProxy:       true,
+			argsMatch:       `ubuntu@0.(public|private|1\.2\.3)`, // can be any of the 3
 		},
 	},
 }
@@ -135,7 +175,10 @@ func (s *SSHSuite) TestSSHCommand(c *gc.C) {
 	for i, t := range sshTests {
 		c.Logf("test %d: %s -> %s", i, t.about, t.args)
 
-		ctx, err := coretesting.RunCommand(c, newSSHCommand(), t.args...)
+		s.setHostDialerFunc(t.dialWith)
+		s.setForceAPIv1(t.forceAPIv1)
+
+		ctx, err := coretesting.RunCommand(c, newSSHCommand(s.hostDialer), t.args...)
 		if t.expectedErr != "" {
 			c.Check(err, gc.ErrorMatches, t.expectedErr)
 		} else {
@@ -154,7 +197,10 @@ func (s *SSHSuite) TestSSHCommandModelConfigProxySSH(c *gc.C) {
 	err := s.State.UpdateModelConfig(map[string]interface{}{"proxy-ssh": true}, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctx, err := coretesting.RunCommand(c, newSSHCommand(), "0")
+	s.setForceAPIv1(true)
+	s.setHostDialerFunc(dialerFuncFor("0.private", "0.public", "0.1.2.3"))
+
+	ctx, err := coretesting.RunCommand(c, newSSHCommand(s.hostDialer), "0")
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(coretesting.Stderr(ctx), gc.Equals, "")
 	expectedArgs := argsSpec{
@@ -165,6 +211,14 @@ func (s *SSHSuite) TestSSHCommandModelConfigProxySSH(c *gc.C) {
 		args:            "ubuntu@0.private",
 	}
 	expectedArgs.check(c, coretesting.Stdout(ctx))
+
+	s.setForceAPIv1(false)
+	ctx, err = coretesting.RunCommand(c, newSSHCommand(s.hostDialer), "0")
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(coretesting.Stderr(ctx), gc.Equals, "")
+	expectedArgs.argsMatch = `ubuntu@0.(public|private|1\.2\.3)` // can be any of the 3 with api v2.
+	expectedArgs.check(c, coretesting.Stdout(ctx))
+
 }
 
 func (s *SSHSuite) TestSSHWillWorkInUpgrade(c *gc.C) {
@@ -187,11 +241,39 @@ func (s *SSHSuite) TestSSHWillWorkInUpgrade(c *gc.C) {
 	}
 }
 
-func (s *SSHSuite) TestSSHCommandHostAddressRetry(c *gc.C) {
+func (s *SSHSuite) TestSSHCommandHostAddressRetryAPIv1(c *gc.C) {
+	s.setHostDialerFunc(func(address string) error {
+		return network.NoAddressError("public")
+	})
+	s.setForceAPIv1(true)
+
 	s.testSSHCommandHostAddressRetry(c, false)
 }
 
-func (s *SSHSuite) TestSSHCommandHostAddressRetryProxy(c *gc.C) {
+func (s *SSHSuite) TestSSHCommandHostAddressRetryAPIv2(c *gc.C) {
+	s.setHostDialerFunc(func(address string) error {
+		return network.NoAddressError("available")
+	})
+	s.setForceAPIv1(false)
+
+	s.testSSHCommandHostAddressRetry(c, false)
+}
+
+func (s *SSHSuite) TestSSHCommandHostAddressRetryProxyAPIv1(c *gc.C) {
+	s.setHostDialerFunc(func(address string) error {
+		return network.NoAddressError("private")
+	})
+	s.setForceAPIv1(true)
+
+	s.testSSHCommandHostAddressRetry(c, true)
+}
+
+func (s *SSHSuite) TestSSHCommandHostAddressRetryProxyAPIv2(c *gc.C) {
+	s.setHostDialerFunc(func(address string) error {
+		return network.NoAddressError("available")
+	})
+	s.setForceAPIv1(false)
+
 	s.testSSHCommandHostAddressRetry(c, true)
 }
 
@@ -204,14 +286,17 @@ func (s *SSHSuite) testSSHCommandHostAddressRetry(c *gc.C, proxy bool) {
 		called++
 		return called < 2
 	}}
-	s.PatchValue(&sshHostFromTargetAttemptStrategy, attemptStarter)
+	restorer := testing.PatchValue(&sshHostFromTargetAttemptStrategy, attemptStarter)
+	defer restorer.Restore()
 
-	// Ensure that the ssh command waits for a public address, or the attempt
-	// strategy's Done method returns false.
+	// Ensure that the ssh command waits for a public (private with proxy=true)
+	// address, or the attempt strategy's Done method returns false.
 	args := []string{"--proxy=" + fmt.Sprint(proxy), "0"}
-	_, err := coretesting.RunCommand(c, newSSHCommand(), args...)
-	c.Assert(err, gc.ErrorMatches, "no .+ address")
+	_, err := coretesting.RunCommand(c, newSSHCommand(s.hostDialer), args...)
+	c.Assert(err, gc.ErrorMatches, `no .+ address\(es\)`)
 	c.Assert(called, gc.Equals, 2)
+
+	s.setHostDialerFunc(dialerFuncFor("0.private", "0.public"))
 
 	called = 0
 	attemptStarter.next = func() bool {
@@ -222,7 +307,7 @@ func (s *SSHSuite) testSSHCommandHostAddressRetry(c *gc.C, proxy bool) {
 		return true
 	}
 
-	_, err = coretesting.RunCommand(c, newSSHCommand(), args...)
+	_, err = coretesting.RunCommand(c, newSSHCommand(s.hostDialer), args...)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, gc.Equals, 2)
 }

--- a/network/network.go
+++ b/network/network.go
@@ -29,10 +29,10 @@ type noAddress struct {
 }
 
 // NoAddressError returns an error which satisfies IsNoAddressError(). The given
-// addressKind specifies what kind of address is missing, usually "private" or
-// "public".
+// addressKind specifies what kind of address(es) is(are) missing, usually
+// "private" or "public".
 func NoAddressError(addressKind string) error {
-	newErr := errors.NewErr("no %s address", addressKind)
+	newErr := errors.NewErr("no %s address(es)", addressKind)
 	newErr.SetLocation(1)
 	return &noAddress{newErr}
 }

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -172,7 +172,7 @@ LXC_BRIDGE="ignored"`[1:])
 
 func (s *NetworkSuite) TestNoAddressError(c *gc.C) {
 	err := network.NoAddressError("fake")
-	c.Assert(err, gc.ErrorMatches, "no fake address")
+	c.Assert(err, gc.ErrorMatches, `no fake address\(es\)`)
 	c.Assert(network.IsNoAddressError(err), jc.IsTrue)
 	c.Assert(network.IsNoAddressError(errors.New("address found")), jc.IsFalse)
 }


### PR DESCRIPTION
Uses the new SSHClient API facade v2 (from #6468), if
available, and network.ReachableHostPort() (#6454) in
code shared between the ssh, scp, and debug-hooks CLI
commands, to select a reachable address from all known
addresses of the target (machine/unit/host).

Fixes http://pad.lv/1616098.

QA steps (live tested on both MAAS 1.9 with multiple-
NIC nodes and on lxd - see below):

  1. Using the tip of `develop`, bootstrap a lxd xenial controller.
  2. juju switch controller
  3. juju status 0    # note of the IP address (IP1)
  4. lxc exec \<juju-instance-id\> -- ip addr add \<IP2\>/24 dev eth0
(add an extra IP on machine-0, from the same subnet)
  5. lxc exec \<juju-instance-id\> -- systemctl restart jujud-machine-0.service
(bounce the controller agent to pick up the new IP)
  6. juju ssh 0             # should work
  7. sudo ip route add blackhole \<IP1\>/32
(make the preferred public IP unreachable from your laptop)
  8. juju --debug ssh 0     # should fail with 'Invalid argument'
  9. git checkout dimitern/lp-1616098-ssh+scp-alladdresses
(switch to this PR's branch and rebuild juju & jujud)
  10. juju ssh 0                    # should work now, using IP2
  11. juju scp 0:/etc/issue .  # as above
  12. juju deploy ubuntu --to 0
  13. juju debug-hooks ubuntu/0 # should work as well
(small delay ~10s observed on lxd, because of 'sudo')