### PR TITLE
Fixes lp1634770: openstack bootstrap panics with no version specified.

### DIFF
--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -684,7 +684,7 @@ func identityClientVersion(authURL string) (int, error) {
 	}
 	if url.Path == "" || url.Path == "/" {
 		// User explicitely did not provide any version, it is empty.
-		return -1, err
+		return -1, nil
 	}
 	// The last part of the path should be the version #.
 	// Example: https://keystone.foo:443/v3/

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -672,11 +672,13 @@ func identityClientVersion(authURL string) (int, error) {
 	url, err := url.Parse(authURL)
 	if err != nil {
 		return -1, err
+	} else if url.Path == "" {
+		return -1, nil
 	}
 	logger.Tracef("authURL: %s", authURL)
 	// The last part of the path should be the version #.
 	// Example: https://keystone.foo:443/v3/
-	if url.Path == "" || len(url.Path) < 3 {
+	if len(url.Path) < 3 {
 		// Version number was not specified on identity endpoint.
 		return -1, errors.Errorf("identity endpoint url %s has no version number", authURL)
 	}

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -672,12 +672,14 @@ func identityClientVersion(authURL string) (int, error) {
 	url, err := url.Parse(authURL)
 	if err != nil {
 		return -1, err
-	} else if url.Path == "" {
-		return -1, err
 	}
+	logger.Tracef("authURL: %s", authURL)
 	// The last part of the path should be the version #.
 	// Example: https://keystone.foo:443/v3/
-	logger.Tracef("authURL: %s", authURL)
+	if url.Path == "" || len(url.Path) < 3 {
+		// Version number was not specified on identity endpoint.
+		return -1, errors.Errorf("identity endpoint url %s has no version number", authURL)
+	}
 	versionNumStr := url.Path[2:]
 	if versionNumStr[len(versionNumStr)-1] == '/' {
 		versionNumStr = versionNumStr[:len(versionNumStr)-1]


### PR DESCRIPTION
We panic on bootstrap, when openstack identity URL has no version.
For example, given cloud definition (from the bug):

  nuc03-openstack:
    type: openstack
    auth-types: [userpass]
    regions:
      RegionOne:
        endpoint: http://192.168.20.218:5000/

QA:
1. Setup openstack cloud definition without version in identity URL
2. juju bootstrap nuc03-openstack
3. [no panic]

As a drive-by, we also check if version specified was well-formed.
Any of the variations of these following forms of identity URL should produce user-friendly message helpful to correct endpoint URL:
* "https://keystone.internal/a"
* "https://keystone.internal/v"
* "https://keystone.internal/V
* "https://keystone.internal/V/"
* "https://keystone.internal/100"
* "abc123"
* "https://keystone.internal/vot"
