### PR TITLE
Fixes lp#1634405: Juju 2 welcome message update.

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -176,12 +176,8 @@ func (m main) maybeWarnJuju1x() (newInstall bool) {
 Welcome to Juju {{.CurrentJujuVersion}}. 
     See https://jujucharms.com/docs/stable/introducing-2 for more details.
 
-If you meant to use Juju {{.OldJujuVersion}}, run 'juju' commands as '{{.OldJujuCommand}}'. For example, 'juju switch' as '{{.OldJujuCommand}} switch'.
-    Note: 
-    '{{.OldJujuCommand}}' command comes from {{.OldJujuCommand}}-default package.
-    On trusty, use 'update-alternatives'.
-    On xenial/yakkety, use {{.OldJujuCommand}}-default package install.
-    After the installation, you should have /usr/bin/{{.OldJujuCommand}} to use '{{.OldJujuCommand}}' command. 
+If you want to use Juju {{.OldJujuVersion}}, run 'juju' commands as '{{.OldJujuCommand}}'. For example, 'juju bootstrap' as '{{.OldJujuCommand}} bootstrap'.
+   See https://jujucharms.com/docs/stable/juju-coexist for more details. 
 `[1:]
 	t := template.Must(template.New("plugin").Parse(welcomeMsgTemplate))
 	var buf bytes.Buffer

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -176,8 +176,8 @@ func (m main) maybeWarnJuju1x() (newInstall bool) {
 Welcome to Juju {{.CurrentJujuVersion}}. 
     See https://jujucharms.com/docs/stable/introducing-2 for more details.
 
-If you want to use Juju {{.OldJujuVersion}}, run 'juju' commands as '{{.OldJujuCommand}}'. For example, 'juju bootstrap' as '{{.OldJujuCommand}} bootstrap'.
-   See https://jujucharms.com/docs/stable/juju-coexist for more details. 
+If you want to use Juju {{.OldJujuVersion}}, run 'juju' commands as '{{.OldJujuCommand}}'. For example, '{{.OldJujuCommand}} bootstrap'.
+   See https://jujucharms.com/docs/stable/juju-coexist for installation details. 
 `[1:]
 	t := template.Must(template.New("plugin").Parse(welcomeMsgTemplate))
 	var buf bytes.Buffer

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -206,12 +206,8 @@ func (s *MainSuite) TestFirstRun2xFrom1xOnUbuntu(c *gc.C) {
 Welcome to Juju %s. 
     See https://jujucharms.com/docs/stable/introducing-2 for more details.
 
-If you meant to use Juju 1.25.0, run 'juju' commands as 'juju-1'. For example, 'juju switch' as 'juju-1 switch'.
-    Note: 
-    'juju-1' command comes from juju-1-default package.
-    On trusty, use 'update-alternatives'.
-    On xenial/yakkety, use juju-1-default package install.
-    After the installation, you should have /usr/bin/juju-1 to use 'juju-1' command. 
+If you want to use Juju 1.25.0, run 'juju' commands as 'juju-1'. For example, 'juju bootstrap' as 'juju-1 bootstrap'.
+   See https://jujucharms.com/docs/stable/juju-coexist for more details. 
 
 Since Juju 2 is being run for the first time, downloading latest cloud information.`[1:]+"\n", jujuversion.Current))
 	checkVersionOutput(c, string(stdout))

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -206,8 +206,8 @@ func (s *MainSuite) TestFirstRun2xFrom1xOnUbuntu(c *gc.C) {
 Welcome to Juju %s. 
     See https://jujucharms.com/docs/stable/introducing-2 for more details.
 
-If you want to use Juju 1.25.0, run 'juju' commands as 'juju-1'. For example, 'juju bootstrap' as 'juju-1 bootstrap'.
-   See https://jujucharms.com/docs/stable/juju-coexist for more details. 
+If you want to use Juju 1.25.0, run 'juju' commands as 'juju-1'. For example, 'juju-1 bootstrap'.
+   See https://jujucharms.com/docs/stable/juju-coexist for installation details. 
 
 Since Juju 2 is being run for the first time, downloading latest cloud information.`[1:]+"\n", jujuversion.Current))
 	checkVersionOutput(c, string(stdout))


### PR DESCRIPTION
Update welcome message with:
    * link to manual page describing how to get back to Juju 1;
    * use 'juju bootstrap" command as an example instead of "juju switch" which is confusing to users.

*QA*
Welcome message should read:

Welcome to Juju 2.0.1. 
    See https://jujucharms.com/docs/stable/introducing-2 for more details.

If you want to use Juju 1.25.0, run 'juju' commands as 'juju-1'. For example, 'juju-1 bootstrap'.
   See https://jujucharms.com/docs/stable/juju-coexist for installation details.

Since Juju 2 is being run for the first time, downloading latest cloud information.
