### PR TITLE
Refactor vsphere provider.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -28,7 +28,7 @@ github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
 github.com/juju/gomaasapi	git	8c484173e0870fc49c9214c56c6ae8dc9c26463d	2016-09-19T18:34:33Z
-github.com/vmware/govmomi	git	81a74a53a81d69997128d1f938026062bc145474	2016-10-18T03:33:22Z
+github.com/vmware/govmomi	git	c0c7ce63df7edd78e713257b924c89d9a2dac119	2016-06-30T15:37:42Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	266fd1e9debf09c037a63f074d099a2da4559ece	2016-10-06T15:09:09Z
 github.com/juju/idmclient	git	3dda079a75cccb85083d4c3877e638f5d6ab79c2	2016-05-26T05:00:34Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -28,7 +28,7 @@ github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
 github.com/juju/gomaasapi	git	8c484173e0870fc49c9214c56c6ae8dc9c26463d	2016-09-19T18:34:33Z
-github.com/juju/govmomi	git	4354a88d4b34abe467215f77c2fc1cb9f78b66f7	2015-04-24T01:54:48Z
+github.com/vmware/govmomi	git	81a74a53a81d69997128d1f938026062bc145474	2016-10-18T03:33:22Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	266fd1e9debf09c037a63f074d099a2da4559ece	2016-10-06T15:09:09Z
 github.com/juju/idmclient	git	3dda079a75cccb85083d4c3877e638f5d6ab79c2	2016-05-26T05:00:34Z

--- a/provider/vsphere/client.go
+++ b/provider/vsphere/client.go
@@ -234,7 +234,7 @@ func (c *client) Instances(prefix string) ([]*mo.VirtualMachine, error) {
 
 // Refresh refreshes the virtual machine
 func (c *client) Refresh(v *mo.VirtualMachine) error {
-	vm, err := c.getVm(v.Name)
+	vm, err := c.vm(v.Name)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -242,7 +242,7 @@ func (c *client) Refresh(v *mo.VirtualMachine) error {
 	return nil
 }
 
-func (c *client) getVm(name string) (*mo.VirtualMachine, error) {
+func (c *client) vm(name string) (*mo.VirtualMachine, error) {
 	conn, closer, err := c.connection()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -305,7 +305,7 @@ func (c *client) AvailabilityZones() ([]*mo.ComputeResource, error) {
 }
 
 func (c *client) GetNetworkInterfaces(inst instance.Id, ecfg *environConfig) ([]network.InterfaceInfo, error) {
-	vm, err := c.getVm(string(inst))
+	vm, err := c.vm(string(inst))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -336,7 +336,7 @@ func (c *client) Subnets(inst instance.Id, ids []network.Id) ([]network.SubnetIn
 	if len(ids) == 0 {
 		return nil, errors.Errorf("subnetIds must not be empty")
 	}
-	vm, err := c.getVm(string(inst))
+	vm, err := c.vm(string(inst))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/vsphere/client.go
+++ b/provider/vsphere/client.go
@@ -11,12 +11,12 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/govmomi"
-	"github.com/juju/govmomi/find"
-	"github.com/juju/govmomi/list"
-	"github.com/juju/govmomi/object"
-	"github.com/juju/govmomi/property"
-	"github.com/juju/govmomi/vim25/mo"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/list"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
 	"golang.org/x/net/context"
 
 	"github.com/juju/juju/environs"
@@ -33,48 +33,60 @@ const (
 )
 
 type client struct {
-	connection *govmomi.Client
-	datacenter *object.Datacenter
-	finder     *find.Finder
-	recurser   *list.Recurser
+	connectionURL *url.URL
+	cloud         environs.CloudSpec
 }
 
-var newClient = func(cloud environs.CloudSpec) (*client, error) {
+var newConnection = func(url *url.URL) (*govmomi.Client, func() error, error) {
+	conn, err := govmomi.NewClient(context.TODO(), url, true)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	logout := func() error {
+		return conn.Logout(context.TODO())
+	}
 
-	credAttrs := cloud.Credential.Attributes()
+	return conn, logout, nil
+
+}
+
+func (c *client) connection() (*govmomi.Client, func() error, error) {
+	return newConnection(c.connectionURL)
+}
+
+func (c *client) recurser(conn *govmomi.Client) *list.Recurser {
+	return &list.Recurser{
+		Collector: property.DefaultCollector(conn.Client),
+		All:       true,
+	}
+}
+
+func (c *client) finder(conn *govmomi.Client) (*find.Finder, *object.Datacenter, error) {
+	finder := find.NewFinder(conn.Client, true)
+	datacenter, err := finder.Datacenter(context.TODO(), c.cloud.Region)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	finder.SetDatacenter(datacenter)
+	return finder, datacenter, nil
+}
+
+var newClient = func(cloudSpec environs.CloudSpec) (*client, error) {
+
+	credAttrs := cloudSpec.Credential.Attributes()
 	username := credAttrs[credAttrUser]
 	password := credAttrs[credAttrPassword]
 	connURL := &url.URL{
 		Scheme: "https",
 		User:   url.UserPassword(username, password),
-		Host:   cloud.Endpoint,
+		Host:   cloudSpec.Endpoint,
 		Path:   "/sdk",
 	}
 
-	connection, err := newConnection(connURL)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	finder := find.NewFinder(connection.Client, true)
-	datacenter, err := finder.Datacenter(context.TODO(), cloud.Region)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	finder.SetDatacenter(datacenter)
-	recurser := &list.Recurser{
-		Collector: property.DefaultCollector(connection.Client),
-		All:       true,
-	}
 	return &client{
-		connection: connection,
-		datacenter: datacenter,
-		finder:     finder,
-		recurser:   recurser,
+		connectionURL: connURL,
+		cloud:         cloudSpec,
 	}, nil
-}
-
-var newConnection = func(url *url.URL) (*govmomi.Client, error) {
-	return govmomi.NewClient(context.TODO(), url, true)
 }
 
 type instanceSpec struct {
@@ -91,7 +103,16 @@ type instanceSpec struct {
 
 // CreateInstance create new vm in vsphere and run it
 func (c *client) CreateInstance(ecfg *environConfig, spec *instanceSpec) (*mo.VirtualMachine, error) {
-	manager := &ovaImportManager{client: c}
+	conn, closer, err := c.connection()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer closer()
+
+	manager := &ovaImportManager{
+		client:         conn,
+		providerClient: c,
+	}
 	vm, err := manager.importOva(ecfg, spec)
 	if err != nil {
 		return nil, errors.Annotatef(err, "Failed to import OVA file")
@@ -120,7 +141,8 @@ func (c *client) CreateInstance(ecfg *environConfig, spec *instanceSpec) (*mo.Vi
 		}
 	}
 	var res mo.VirtualMachine
-	err = c.connection.RetrieveOne(context.TODO(), *taskInfo.Entity, nil, &res)
+
+	err = conn.RetrieveOne(context.TODO(), *taskInfo.Entity, nil, &res)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -131,8 +153,18 @@ func (c *client) CreateInstance(ecfg *environConfig, spec *instanceSpec) (*mo.Vi
 func (c *client) RemoveInstances(ids ...string) error {
 	var lastError error
 	tasks := make([]*object.Task, 0, len(ids))
+	conn, closer, err := c.connection()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer closer()
+	finder, _, err := c.finder(conn)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	for _, id := range ids {
-		vm, err := c.finder.VirtualMachine(context.TODO(), id)
+		vm, err := finder.VirtualMachine(context.TODO(), id)
 		if err != nil {
 			lastError = err
 			logger.Errorf(err.Error())
@@ -168,16 +200,27 @@ func (c *client) RemoveInstances(ids ...string) error {
 
 // Instances return list of all vms in the system, that match naming convention
 func (c *client) Instances(prefix string) ([]*mo.VirtualMachine, error) {
-	items, err := c.finder.VirtualMachineList(context.TODO(), "*")
+	conn, closer, err := c.connection()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer closer()
+	finder, _, err := c.finder(conn)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	items, err := finder.VirtualMachineList(context.TODO(), "*")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	var vms []*mo.VirtualMachine
 	vms = make([]*mo.VirtualMachine, 0, len(vms))
+
 	for _, item := range items {
 		var vm mo.VirtualMachine
-		err = c.connection.RetrieveOne(context.TODO(), item.Reference(), nil, &vm)
+
+		err = conn.RetrieveOne(context.TODO(), item.Reference(), nil, &vm)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -200,12 +243,23 @@ func (c *client) Refresh(v *mo.VirtualMachine) error {
 }
 
 func (c *client) getVm(name string) (*mo.VirtualMachine, error) {
-	item, err := c.finder.VirtualMachine(context.TODO(), name)
+	conn, closer, err := c.connection()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer closer()
+	finder, _, err := c.finder(conn)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	item, err := finder.VirtualMachine(context.TODO(), name)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	var vm mo.VirtualMachine
-	err = c.connection.RetrieveOne(context.TODO(), item.Reference(), nil, &vm)
+
+	err = conn.RetrieveOne(context.TODO(), item.Reference(), nil, &vm)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -214,14 +268,25 @@ func (c *client) getVm(name string) (*mo.VirtualMachine, error) {
 
 //AvailabilityZones retuns list of all root compute resources in the system
 func (c *client) AvailabilityZones() ([]*mo.ComputeResource, error) {
-	folders, err := c.datacenter.Folders(context.TODO())
+	conn, closer, err := c.connection()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer closer()
+	_, datacenter, err := c.finder(conn)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	folders, err := datacenter.Folders(context.TODO())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	root := list.Element{
 		Object: folders.HostFolder,
 	}
-	es, err := c.recurser.Recurse(context.TODO(), root, []string{"*"})
+
+	es, err := c.recurser(conn).Recurse(context.TODO(), root, []string{"*"})
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +319,7 @@ func (c *client) GetNetworkInterfaces(inst instance.Id, ecfg *environConfig) ([]
 			ipScope = network.ScopePublic
 		}
 		res = append(res, network.InterfaceInfo{
-			DeviceIndex:      net.DeviceConfigId,
+			DeviceIndex:      int(net.DeviceConfigId),
 			MACAddress:       net.MacAddress,
 			Disabled:         !net.Connected,
 			ProviderId:       network.Id(fmt.Sprintf("net-device%d", net.DeviceConfigId)),

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -16,9 +16,6 @@ import (
 	"github.com/juju/juju/provider/common"
 )
 
-// TODO(ericsnow) All imports from github.com/juju/govmomi should change
-// back to github.com/vmware/govmomi once our min Go is 1.3 or higher.
-
 // Note: This provider/environment does *not* implement storage.
 
 type environ struct {

--- a/provider/vsphere/environ_availzones.go
+++ b/provider/vsphere/environ_availzones.go
@@ -7,7 +7,7 @@ package vsphere
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/mo"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -7,7 +7,7 @@ package vsphere
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/mo"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"

--- a/provider/vsphere/export_test.go
+++ b/provider/vsphere/export_test.go
@@ -13,8 +13,10 @@ var (
 	Provider environs.EnvironProvider = providerInstance
 )
 
-func ExposeEnvFakeClient(env *environ) *fakeClient {
-	return env.client.connection.RoundTripper.(*fakeClient)
+func ExposeEnvFakeClient(env *environ) (*fakeClient, func() error, error) {
+	conn, closer, err := env.client.connection()
+	closer = func() error { return nil }
+	return conn.RoundTripper.(*fakeClient), closer, err
 }
 
 var _ environs.Environ = (*environ)(nil)

--- a/provider/vsphere/fake_methods_test.go
+++ b/provider/vsphere/fake_methods_test.go
@@ -11,10 +11,10 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/juju/govmomi/vim25/methods"
-	"github.com/juju/govmomi/vim25/soap"
-	"github.com/juju/govmomi/vim25/types"
 	jc "github.com/juju/testing/checkers"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
 	gc "gopkg.in/check.v1"
 )
 

--- a/provider/vsphere/instance.go
+++ b/provider/vsphere/instance.go
@@ -7,7 +7,7 @@ package vsphere
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/mo"
 
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"

--- a/provider/vsphere/testing_test.go
+++ b/provider/vsphere/testing_test.go
@@ -6,7 +6,6 @@
 package vsphere
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -20,6 +19,7 @@ import (
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"

--- a/provider/vsphere/testing_test.go
+++ b/provider/vsphere/testing_test.go
@@ -6,20 +6,20 @@
 package vsphere
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"reflect"
 
 	"github.com/juju/errors"
-	"github.com/juju/govmomi"
-	"github.com/juju/govmomi/session"
-	"github.com/juju/govmomi/vim25"
-	"github.com/juju/govmomi/vim25/methods"
-	"github.com/juju/govmomi/vim25/soap"
-	"github.com/juju/govmomi/vim25/types"
 	jc "github.com/juju/testing/checkers"
-	"golang.org/x/net/context"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
@@ -61,12 +61,46 @@ type BaseSuite struct {
 	EnvConfig *environConfig
 	Env       *environ
 
-	ServeMux  *http.ServeMux
-	ServerURL string
+	ServeMux   *http.ServeMux
+	ServerURL  string
+	FakeClient *fakeClient
 }
 
 func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	s.FakeClient = &fakeClient{
+		handlers:         make([]fakeAPICall, 0, 100),
+		propertyHandlers: make([]fakePropertiesCall, 0, 100),
+	}
+
+	newFakeConnection := func(url *url.URL) (*govmomi.Client, func() error, error) {
+		logger.Debugf("CONNECT")
+		fakeClient := s.FakeClient
+		if len(fakeClient.propertyHandlers) == 0 {
+			fakeClient.SetPropertyProxyHandler("FakeRootFolder", RetrieveDatacenter)
+		}
+		vimClient := &vim25.Client{
+			Client: &soap.Client{},
+			ServiceContent: types.ServiceContent{
+				RootFolder: types.ManagedObjectReference{
+					Type:  "Folder",
+					Value: "FakeRootFolder",
+				},
+				OvfManager: &types.ManagedObjectReference{
+					Type:  "OvfManager",
+					Value: "FakeOvfManager",
+				},
+			},
+			RoundTripper: fakeClient,
+		}
+
+		c := &govmomi.Client{
+			Client:         vimClient,
+			SessionManager: session.NewManager(vimClient),
+		}
+		fakeLogout := func() error { return nil }
+		return c, fakeLogout, nil
+	}
 
 	s.PatchValue(&newConnection, newFakeConnection)
 	s.initEnv(c)
@@ -158,36 +192,6 @@ func (c *fakeClient) SetProxyHandler(method string, handler fakeAPIHandler) {
 
 func (c *fakeClient) SetPropertyProxyHandler(obj string, handler fakePropertiesHandler) {
 	c.propertyHandlers = append(c.propertyHandlers, fakePropertiesCall{object: obj, handler: handler})
-}
-
-var newFakeConnection = func(url *url.URL) (*govmomi.Client, error) {
-	fakeClient := &fakeClient{
-		handlers:         make([]fakeAPICall, 0, 100),
-		propertyHandlers: make([]fakePropertiesCall, 0, 100),
-	}
-
-	fakeClient.SetPropertyProxyHandler("FakeRootFolder", RetrieveDatacenter)
-
-	vimClient := &vim25.Client{
-		Client: &soap.Client{},
-		ServiceContent: types.ServiceContent{
-			RootFolder: types.ManagedObjectReference{
-				Type:  "Folder",
-				Value: "FakeRootFolder",
-			},
-			OvfManager: &types.ManagedObjectReference{
-				Type:  "OvfManager",
-				Value: "FakeOvfManager",
-			},
-		},
-		RoundTripper: fakeClient,
-	}
-
-	c := &govmomi.Client{
-		Client:         vimClient,
-		SessionManager: session.NewManager(vimClient),
-	}
-	return c, nil
 }
 
 var CommonRetrieveProperties = func(resBody *methods.RetrievePropertiesBody, objType, objValue, propName string, propValue interface{}) {


### PR DESCRIPTION
The provider for vsphere was using the wrong aproach to
connect never logging out and it was leaking 45 conn/min
Now all connections login/logout per request.

### QA Steps
Open the VSPhere Management Console.
Click on vCenter Inventory List --> Resources -- vCenter Servers --> your server ip
Go the right and click on Manage --> Sessions
Bootstrap a vsphere provider juju and deploy a few services.
There should NOT be 45 new open/idle processes every minute, instead numbers of 1 or 2 is expected.