### PR TITLE
Migrate endpoint bindings

### DIFF
--- a/core/description/application.go
+++ b/core/description/application.go
@@ -13,6 +13,40 @@ import (
 	"gopkg.in/juju/names.v2"
 )
 
+// Application represents a deployed charm in a model.
+type Application interface {
+	HasAnnotations
+	HasConstraints
+	HasStatus
+	HasStatusHistory
+
+	Tag() names.ApplicationTag
+	Name() string
+	Series() string
+	Subordinate() bool
+	CharmURL() string
+	Channel() string
+	CharmModifiedVersion() int
+	ForceCharm() bool
+	Exposed() bool
+	MinUnits() int
+
+	EndpointBindings() map[string]string
+
+	Settings() map[string]interface{}
+
+	Leader() string
+	LeadershipSettings() map[string]interface{}
+
+	MetricsCredentials() []byte
+	StorageConstraints() map[string]StorageConstraint
+
+	Units() []Unit
+	AddUnit(UnitArgs) Unit
+
+	Validate() error
+}
+
 type applications struct {
 	Version       int            `yaml:"version"`
 	Applications_ []*application `yaml:"applications"`
@@ -34,6 +68,8 @@ type application struct {
 
 	Status_        *status `yaml:"status"`
 	StatusHistory_ `yaml:"status-history"`
+
+	EndpointBindings_ map[string]string `yaml:"endpoint-bindings,omitempty"`
 
 	Settings_ map[string]interface{} `yaml:"settings"`
 
@@ -62,6 +98,7 @@ type ApplicationArgs struct {
 	ForceCharm           bool
 	Exposed              bool
 	MinUnits             int
+	EndpointBindings     map[string]string
 	Settings             map[string]interface{}
 	Leader               string
 	LeadershipSettings   map[string]interface{}
@@ -81,6 +118,7 @@ func newApplication(args ApplicationArgs) *application {
 		ForceCharm_:           args.ForceCharm,
 		Exposed_:              args.Exposed,
 		MinUnits_:             args.MinUnits,
+		EndpointBindings_:     args.EndpointBindings,
 		Settings_:             args.Settings,
 		Leader_:               args.Leader,
 		LeadershipSettings_:   args.LeadershipSettings,
@@ -98,68 +136,73 @@ func newApplication(args ApplicationArgs) *application {
 }
 
 // Tag implements Application.
-func (s *application) Tag() names.ApplicationTag {
-	return names.NewApplicationTag(s.Name_)
+func (a *application) Tag() names.ApplicationTag {
+	return names.NewApplicationTag(a.Name_)
 }
 
 // Name implements Application.
-func (s *application) Name() string {
-	return s.Name_
+func (a *application) Name() string {
+	return a.Name_
 }
 
 // Series implements Application.
-func (s *application) Series() string {
-	return s.Series_
+func (a *application) Series() string {
+	return a.Series_
 }
 
 // Subordinate implements Application.
-func (s *application) Subordinate() bool {
-	return s.Subordinate_
+func (a *application) Subordinate() bool {
+	return a.Subordinate_
 }
 
 // CharmURL implements Application.
-func (s *application) CharmURL() string {
-	return s.CharmURL_
+func (a *application) CharmURL() string {
+	return a.CharmURL_
 }
 
 // Channel implements Application.
-func (s *application) Channel() string {
-	return s.Channel_
+func (a *application) Channel() string {
+	return a.Channel_
 }
 
 // CharmModifiedVersion implements Application.
-func (s *application) CharmModifiedVersion() int {
-	return s.CharmModifiedVersion_
+func (a *application) CharmModifiedVersion() int {
+	return a.CharmModifiedVersion_
 }
 
 // ForceCharm implements Application.
-func (s *application) ForceCharm() bool {
-	return s.ForceCharm_
+func (a *application) ForceCharm() bool {
+	return a.ForceCharm_
 }
 
 // Exposed implements Application.
-func (s *application) Exposed() bool {
-	return s.Exposed_
+func (a *application) Exposed() bool {
+	return a.Exposed_
 }
 
 // MinUnits implements Application.
-func (s *application) MinUnits() int {
-	return s.MinUnits_
+func (a *application) MinUnits() int {
+	return a.MinUnits_
+}
+
+// EndpointBindings implements Application.
+func (a *application) EndpointBindings() map[string]string {
+	return a.EndpointBindings_
 }
 
 // Settings implements Application.
-func (s *application) Settings() map[string]interface{} {
-	return s.Settings_
+func (a *application) Settings() map[string]interface{} {
+	return a.Settings_
 }
 
 // Leader implements Application.
-func (s *application) Leader() string {
-	return s.Leader_
+func (a *application) Leader() string {
+	return a.Leader_
 }
 
 // LeadershipSettings implements Application.
-func (s *application) LeadershipSettings() map[string]interface{} {
-	return s.LeadershipSettings_
+func (a *application) LeadershipSettings() map[string]interface{} {
+	return a.LeadershipSettings_
 }
 
 // StorageConstraints implements Application.
@@ -172,95 +215,95 @@ func (a *application) StorageConstraints() map[string]StorageConstraint {
 }
 
 // MetricsCredentials implements Application.
-func (s *application) MetricsCredentials() []byte {
+func (a *application) MetricsCredentials() []byte {
 	// Here we are explicitly throwing away any decode error. We check that
 	// the creds can be decoded when we parse the incoming data, or we encode
 	// an incoming byte array, so in both cases, we know that the stored creds
 	// can be decoded.
-	creds, _ := base64.StdEncoding.DecodeString(s.MetricsCredentials_)
+	creds, _ := base64.StdEncoding.DecodeString(a.MetricsCredentials_)
 	return creds
 }
 
 // Status implements Application.
-func (s *application) Status() Status {
+func (a *application) Status() Status {
 	// To avoid typed nils check nil here.
-	if s.Status_ == nil {
+	if a.Status_ == nil {
 		return nil
 	}
-	return s.Status_
+	return a.Status_
 }
 
 // SetStatus implements Application.
-func (s *application) SetStatus(args StatusArgs) {
-	s.Status_ = newStatus(args)
+func (a *application) SetStatus(args StatusArgs) {
+	a.Status_ = newStatus(args)
 }
 
 // Units implements Application.
-func (s *application) Units() []Unit {
-	result := make([]Unit, len(s.Units_.Units_))
-	for i, u := range s.Units_.Units_ {
+func (a *application) Units() []Unit {
+	result := make([]Unit, len(a.Units_.Units_))
+	for i, u := range a.Units_.Units_ {
 		result[i] = u
 	}
 	return result
 }
 
-func (s *application) unitNames() set.Strings {
+func (a *application) unitNames() set.Strings {
 	result := set.NewStrings()
-	for _, u := range s.Units_.Units_ {
+	for _, u := range a.Units_.Units_ {
 		result.Add(u.Name())
 	}
 	return result
 }
 
 // AddUnit implements Application.
-func (s *application) AddUnit(args UnitArgs) Unit {
+func (a *application) AddUnit(args UnitArgs) Unit {
 	u := newUnit(args)
-	s.Units_.Units_ = append(s.Units_.Units_, u)
+	a.Units_.Units_ = append(a.Units_.Units_, u)
 	return u
 }
 
-func (s *application) setUnits(unitList []*unit) {
-	s.Units_ = units{
+func (a *application) setUnits(unitList []*unit) {
+	a.Units_ = units{
 		Version: 1,
 		Units_:  unitList,
 	}
 }
 
 // Constraints implements HasConstraints.
-func (s *application) Constraints() Constraints {
-	if s.Constraints_ == nil {
+func (a *application) Constraints() Constraints {
+	if a.Constraints_ == nil {
 		return nil
 	}
-	return s.Constraints_
+	return a.Constraints_
 }
 
 // SetConstraints implements HasConstraints.
-func (s *application) SetConstraints(args ConstraintsArgs) {
-	s.Constraints_ = newConstraints(args)
+func (a *application) SetConstraints(args ConstraintsArgs) {
+	a.Constraints_ = newConstraints(args)
 }
 
 // Validate implements Application.
-func (s *application) Validate() error {
-	if s.Name_ == "" {
+func (a *application) Validate() error {
+	if a.Name_ == "" {
 		return errors.NotValidf("application missing name")
 	}
-	if s.Status_ == nil {
-		return errors.NotValidf("application %q missing status", s.Name_)
+	if a.Status_ == nil {
+		return errors.NotValidf("application %q missing status", a.Name_)
 	}
 	// If leader is set, it must match one of the units.
 	var leaderFound bool
 	// All of the applications units should also be valid.
-	for _, u := range s.Units() {
+	for _, u := range a.Units() {
 		if err := u.Validate(); err != nil {
 			return errors.Trace(err)
 		}
 		// We know that the unit has a name, because it validated correctly.
-		if u.Name() == s.Leader_ {
+		if u.Name() == a.Leader_ {
 			leaderFound = true
 		}
 	}
-	if s.Leader_ != "" && !leaderFound {
-		return errors.NotValidf("missing unit for leader %q", s.Leader_)
+	if a.Leader_ != "" && !leaderFound {
+		return errors.NotValidf("missing unit for leader %q", a.Leader_)
 	}
 	return nil
 }
@@ -316,6 +359,7 @@ func importApplicationV1(source map[string]interface{}) (*application, error) {
 		"exposed":             schema.Bool(),
 		"min-units":           schema.Int(),
 		"status":              schema.StringMap(schema.Any()),
+		"endpoint-bindings":   schema.StringMap(schema.String()),
 		"settings":            schema.StringMap(schema.Any()),
 		"leader":              schema.String(),
 		"leadership-settings": schema.StringMap(schema.Any()),
@@ -332,6 +376,7 @@ func importApplicationV1(source map[string]interface{}) (*application, error) {
 		"leader":              "",
 		"metrics-creds":       "",
 		"storage-constraints": schema.Omit,
+		"endpoint-bindings":   schema.Omit,
 	}
 	addAnnotationSchema(fields, defaults)
 	addConstraintsSchema(fields, defaults)
@@ -355,12 +400,14 @@ func importApplicationV1(source map[string]interface{}) (*application, error) {
 		ForceCharm_:           valid["force-charm"].(bool),
 		Exposed_:              valid["exposed"].(bool),
 		MinUnits_:             int(valid["min-units"].(int64)),
+		EndpointBindings_:     convertToStringMap(valid["endpoint-bindings"]),
 		Settings_:             valid["settings"].(map[string]interface{}),
 		Leader_:               valid["leader"].(string),
 		LeadershipSettings_:   valid["leadership-settings"].(map[string]interface{}),
 		StatusHistory_:        newStatusHistory(),
 	}
 	result.importAnnotations(valid)
+
 	if err := result.importStatusHistory(valid); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/core/description/application_test.go
+++ b/core/description/application_test.go
@@ -112,6 +112,9 @@ func (s *ApplicationSerializationSuite) TestNewApplication(c *gc.C) {
 		ForceCharm:           true,
 		Exposed:              true,
 		MinUnits:             42, // no judgement is made by the migration code
+		EndpointBindings: map[string]string{
+			"rel-name": "some-space",
+		},
 		Settings: map[string]interface{}{
 			"key": "value",
 		},
@@ -133,6 +136,7 @@ func (s *ApplicationSerializationSuite) TestNewApplication(c *gc.C) {
 	c.Assert(application.ForceCharm(), jc.IsTrue)
 	c.Assert(application.Exposed(), jc.IsTrue)
 	c.Assert(application.MinUnits(), gc.Equals, 42)
+	c.Assert(application.EndpointBindings(), jc.DeepEquals, args.EndpointBindings)
 	c.Assert(application.Settings(), jc.DeepEquals, args.Settings)
 	c.Assert(application.Leader(), gc.Equals, "magic/1")
 	c.Assert(application.LeadershipSettings(), jc.DeepEquals, args.LeadershipSettings)
@@ -177,6 +181,17 @@ func (s *ApplicationSerializationSuite) TestParsingSerializedData(c *gc.C) {
 	svc := minimalApplication()
 	application := s.exportImport(c, svc)
 	c.Assert(application, jc.DeepEquals, svc)
+}
+
+func (s *ApplicationSerializationSuite) TestEndpointBindings(c *gc.C) {
+	args := minimalApplicationArgs()
+	args.EndpointBindings = map[string]string{
+		"rel-name": "some-space",
+		"other":    "other-space",
+	}
+	initial := minimalApplication(args)
+	application := s.exportImport(c, initial)
+	c.Assert(application.EndpointBindings(), jc.DeepEquals, args.EndpointBindings)
 }
 
 func (s *ApplicationSerializationSuite) TestAnnotations(c *gc.C) {

--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -241,38 +241,6 @@ type Status interface {
 	Updated() time.Time
 }
 
-// Application represents a deployed charm in a model.
-type Application interface {
-	HasAnnotations
-	HasConstraints
-	HasStatus
-	HasStatusHistory
-
-	Tag() names.ApplicationTag
-	Name() string
-	Series() string
-	Subordinate() bool
-	CharmURL() string
-	Channel() string
-	CharmModifiedVersion() int
-	ForceCharm() bool
-	Exposed() bool
-	MinUnits() int
-
-	Settings() map[string]interface{}
-
-	Leader() string
-	LeadershipSettings() map[string]interface{}
-
-	MetricsCredentials() []byte
-	StorageConstraints() map[string]StorageConstraint
-
-	Units() []Unit
-	AddUnit(UnitArgs) Unit
-
-	Validate() error
-}
-
 // Unit represents an instance of an application in a model.
 type Unit interface {
 	HasAnnotations

--- a/core/description/model.go
+++ b/core/description/model.go
@@ -896,6 +896,7 @@ func importModelV1(source map[string]interface{}) (*model, error) {
 		"owner":                schema.String(),
 		"cloud":                schema.String(),
 		"cloud-region":         schema.String(),
+		"cloud-credential":     schema.String(),
 		"config":               schema.StringMap(schema.Any()),
 		"latest-tools":         schema.String(),
 		"blocks":               schema.StringMap(schema.String()),
@@ -918,9 +919,10 @@ func importModelV1(source map[string]interface{}) (*model, error) {
 	}
 	// Some values don't have to be there.
 	defaults := schema.Defaults{
-		"latest-tools": schema.Omit,
-		"blocks":       schema.Omit,
-		"cloud-region": schema.Omit,
+		"latest-tools":     schema.Omit,
+		"blocks":           schema.Omit,
+		"cloud-region":     "",
+		"cloud-credential": "",
 	}
 	addAnnotationSchema(fields, defaults)
 	addConstraintsSchema(fields, defaults)
@@ -935,12 +937,14 @@ func importModelV1(source map[string]interface{}) (*model, error) {
 	// contains fields of the right type.
 
 	result := &model{
-		Version:    1,
-		Owner_:     valid["owner"].(string),
-		Config_:    valid["config"].(map[string]interface{}),
-		Sequences_: make(map[string]int),
-		Blocks_:    convertToStringMap(valid["blocks"]),
-		Cloud_:     valid["cloud"].(string),
+		Version:          1,
+		Owner_:           valid["owner"].(string),
+		Config_:          valid["config"].(map[string]interface{}),
+		Sequences_:       make(map[string]int),
+		Blocks_:          convertToStringMap(valid["blocks"]),
+		Cloud_:           valid["cloud"].(string),
+		CloudRegion_:     valid["cloud-region"].(string),
+		CloudCredential_: valid["cloud-credential"].(string),
 	}
 	result.importAnnotations(valid)
 	sequences := valid["sequences"].(map[string]interface{})
@@ -962,14 +966,6 @@ func importModelV1(source map[string]interface{}) (*model, error) {
 			return nil, errors.Trace(err)
 		}
 		result.LatestToolsVersion_ = num
-	}
-
-	if region, ok := valid["cloud-region"]; ok {
-		result.CloudRegion_ = region.(string)
-	}
-
-	if credential, ok := valid["cloud-credential"]; ok {
-		result.CloudCredential_ = credential.(string)
 	}
 
 	userMap := valid["users"].(map[string]interface{})

--- a/core/description/model_test.go
+++ b/core/description/model_test.go
@@ -85,6 +85,9 @@ func (s *ModelSerializationSuite) TestParsingYAML(c *gc.C) {
 		Blocks: map[string]string{
 			"all-changes": "locked down",
 		},
+		Cloud:           "vapour",
+		CloudRegion:     "east-west",
+		CloudCredential: "cirrus",
 	}
 	initial := NewModel(args)
 	adminUser := names.NewUserTag("admin@local")
@@ -100,6 +103,9 @@ func (s *ModelSerializationSuite) TestParsingYAML(c *gc.C) {
 	c.Assert(model.Owner(), gc.Equals, args.Owner)
 	c.Assert(model.Tag().Id(), gc.Equals, "some-uuid")
 	c.Assert(model.Config(), jc.DeepEquals, args.Config)
+	c.Assert(model.Cloud(), gc.Equals, "vapour")
+	c.Assert(model.CloudRegion(), gc.Equals, "east-west")
+	c.Assert(model.CloudCredential(), gc.Equals, "cirrus")
 	c.Assert(model.LatestToolsVersion(), gc.Equals, args.LatestToolsVersion)
 	c.Assert(model.Blocks(), jc.DeepEquals, args.Blocks)
 	users := model.Users()

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -67,6 +67,9 @@ func (st *State) Export() (description.Model, error) {
 		LatestToolsVersion: dbModel.LatestToolsVersion(),
 		Blocks:             blocks,
 	}
+	if creds, credsSet := dbModel.CloudCredential(); credsSet {
+		args.CloudCredential = creds.Id()
+	}
 	export.model = description.NewModel(args)
 	modelKey := dbModel.globalKey()
 	export.model.SetAnnotations(export.getAnnotations(modelKey))

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -472,6 +472,11 @@ func (e *exporter) applications() error {
 		return errors.Trace(err)
 	}
 
+	bindings, err := e.readAllEndpointBindings()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	leaders, err := e.st.ApplicationLeaders()
 	if err != nil {
 		return errors.Trace(err)
@@ -486,11 +491,12 @@ func (e *exporter) applications() error {
 		applicationUnits := e.units[application.Name()]
 		leader := leaders[application.Name()]
 		if err := e.addApplication(addApplicationContext{
-			application: application,
-			units:       applicationUnits,
-			meterStatus: meterStatus,
-			leader:      leader,
-			payloads:    payloads,
+			application:      application,
+			units:            applicationUnits,
+			meterStatus:      meterStatus,
+			leader:           leader,
+			payloads:         payloads,
+			endpoingBindings: bindings,
 		}); err != nil {
 			return errors.Trace(err)
 		}
@@ -542,16 +548,18 @@ func (e *exporter) readAllPayloads() (map[string][]payload.FullPayloadInfo, erro
 }
 
 type addApplicationContext struct {
-	application *Application
-	units       []*Unit
-	meterStatus map[string]*meterStatusDoc
-	leader      string
-	payloads    map[string][]payload.FullPayloadInfo
+	application      *Application
+	units            []*Unit
+	meterStatus      map[string]*meterStatusDoc
+	leader           string
+	payloads         map[string][]payload.FullPayloadInfo
+	endpoingBindings map[string]bindingsMap
 }
 
 func (e *exporter) addApplication(ctx addApplicationContext) error {
 	application := ctx.application
 	appName := application.Name()
+	globalKey := application.globalKey()
 	settingsKey := application.settingsKey()
 	leadershipKey := leadershipSettingsKey(appName)
 	storageConstraintsKey := application.storageConstraintsKey()
@@ -575,6 +583,7 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 		ForceCharm:           application.doc.ForceCharm,
 		Exposed:              application.doc.Exposed,
 		MinUnits:             application.doc.MinUnits,
+		EndpointBindings:     map[string]string(ctx.endpoingBindings[globalKey]),
 		Settings:             applicationSettingsDoc.Settings,
 		Leader:               ctx.leader,
 		LeadershipSettings:   leadershipSettingsDoc.Settings,
@@ -585,7 +594,6 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 	}
 	exApplication := e.model.AddApplication(args)
 	// Find the current application status.
-	globalKey := application.globalKey()
 	statusArgs, err := e.statusArgs(globalKey)
 	if err != nil {
 		return errors.Annotatef(err, "status for application %s", appName)
@@ -929,6 +937,23 @@ func (e *exporter) readAllUnits() (map[string][]*Unit, error) {
 	for _, doc := range docs {
 		units := result[doc.Application]
 		result[doc.Application] = append(units, newUnit(e.st, &doc))
+	}
+	return result, nil
+}
+
+func (e *exporter) readAllEndpointBindings() (map[string]bindingsMap, error) {
+	bindings, closer := e.st.getCollection(endpointBindingsC)
+	defer closer()
+
+	docs := []endpointBindingsDoc{}
+	err := bindings.Find(nil).All(&docs)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot get all application endpoint bindings")
+	}
+	e.logger.Debugf("found %d application endpoint binding docs", len(docs))
+	result := make(map[string]bindingsMap)
+	for _, doc := range docs {
+		result[e.st.localID(doc.DocID)] = doc.Bindings
 	}
 	return result, nil
 }

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -55,7 +55,7 @@ func (st *State) Import(model description.Model) (_ *Model, _ *State, err error)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	dbModel, newSt, err := st.NewModel(ModelArgs{
+	args := ModelArgs{
 		CloudName:     model.Cloud(),
 		CloudRegion:   model.CloudRegion(),
 		Config:        cfg,
@@ -67,7 +67,11 @@ func (st *State) Import(model description.Model) (_ *Model, _ *State, err error)
 		// the model description before adding any volumes,
 		// filesystems or storage instances.
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
-	})
+	}
+	if creds := model.CloudCredential(); creds != "" {
+		args.CloudCredential = names.NewCloudCredentialTag(creds)
+	}
+	dbModel, newSt, err := st.NewModel(args)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -48,6 +48,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		relationScopesC,
 
 		// networking
+		endpointBindingsC,
 		ipAddressesC,
 		spacesC,
 		linkLayerDevicesC,
@@ -168,7 +169,6 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// service / unit
 		charmsC,
 		"resources",
-		endpointBindingsC,
 
 		// uncategorised
 		metricsManagerC, // should really be copied across
@@ -793,6 +793,20 @@ func (s *MigrationSuite) TestPayloadDocFields(c *gc.C) {
 		"Labels",
 	)
 	s.AssertExportedFields(c, payloadDoc{}, migrated.Union(definedThroughContainment))
+}
+
+func (s *MigrationSuite) TestEndpointBindingFields(c *gc.C) {
+	definedThroughContainment := set.NewStrings(
+		"DocID",
+	)
+	migrated := set.NewStrings(
+		"Bindings",
+	)
+	ignored := set.NewStrings(
+		"TxnRevno",
+	)
+	fields := definedThroughContainment.Union(migrated).Union(ignored)
+	s.AssertExportedFields(c, endpointBindingsDoc{}, fields)
 }
 
 func (s *MigrationSuite) AssertExportedFields(c *gc.C, doc interface{}, fields set.Strings) {


### PR DESCRIPTION
Applications can bind endpoints to particular spaces.

This work also fixes an issue with migrated models where there was no endpoint binding doc created for migrated applications, that would cause an assertion failure when upgrading a charm.