### PR TITLE
Resources export, serialisation & deserialisation

### DIFF
--- a/apiserver/migrationtarget/package_test.go
+++ b/apiserver/migrationtarget/package_test.go
@@ -6,9 +6,17 @@ package migrationtarget_test
 import (
 	stdtesting "testing"
 
+	"github.com/juju/juju/component/all"
 	"github.com/juju/juju/testing"
 )
 
 func TestAll(t *stdtesting.T) {
 	testing.MgoTestPackage(t)
+}
+
+func init() {
+	// Required for resources.
+	if err := all.RegisterForServer(); err != nil {
+		panic(err)
+	}
 }

--- a/core/description/action.go
+++ b/core/description/action.go
@@ -179,8 +179,8 @@ func importActionV1(source map[string]interface{}) (*action, error) {
 	}
 	// Some values don't have to be there.
 	defaults := schema.Defaults{
-		"started":   time.Time{},
-		"completed": time.Time{},
+		"started":   schema.Omit,
+		"completed": schema.Omit,
 	}
 	checker := schema.FieldMap(fields, defaults)
 
@@ -198,17 +198,8 @@ func importActionV1(source map[string]interface{}) (*action, error) {
 		Parameters_: valid["parameters"].(map[string]interface{}),
 		Enqueued_:   valid["enqueued"].(time.Time).UTC(),
 		Results_:    valid["results"].(map[string]interface{}),
-	}
-
-	started := valid["started"].(time.Time)
-	if !started.IsZero() {
-		started = started.UTC()
-		action.Started_ = &started
-	}
-	completed := valid["completed"].(time.Time)
-	if !started.IsZero() {
-		completed = completed.UTC()
-		action.Completed_ = &completed
+		Started_:    fieldToTimePtr(valid, "started"),
+		Completed_:  fieldToTimePtr(valid, "completed"),
 	}
 	return action, nil
 }

--- a/core/description/application.go
+++ b/core/description/application.go
@@ -289,8 +289,8 @@ func (a *application) SetConstraints(args ConstraintsArgs) {
 }
 
 // Resources implements Application.
-func (s *application) Resources() []Resource {
-	rs := s.Resources_.Resources_
+func (a *application) Resources() []Resource {
+	rs := a.Resources_.Resources_
 	result := make([]Resource, len(rs))
 	for i, r := range rs {
 		result[i] = r
@@ -299,14 +299,14 @@ func (s *application) Resources() []Resource {
 }
 
 // AddResource implements Application.
-func (s *application) AddResource(args ResourceArgs) Resource {
+func (a *application) AddResource(args ResourceArgs) Resource {
 	r := newResource(args)
-	s.Resources_.Resources_ = append(s.Resources_.Resources_, r)
+	a.Resources_.Resources_ = append(a.Resources_.Resources_, r)
 	return r
 }
 
-func (s *application) setResources(resourceList []*resource) {
-	s.Resources_ = resources{
+func (a *application) setResources(resourceList []*resource) {
+	a.Resources_ = resources{
 		Version:    1,
 		Resources_: resourceList,
 	}
@@ -321,7 +321,7 @@ func (a *application) Validate() error {
 		return errors.NotValidf("application %q missing status", a.Name_)
 	}
 
-	for _, resource := range s.Resources_.Resources_ {
+	for _, resource := range a.Resources_.Resources_ {
 		if err := resource.Validate(); err != nil {
 			return errors.Annotatef(err, "resource %s", resource.Name_)
 		}

--- a/core/description/application.go
+++ b/core/description/application.go
@@ -395,6 +395,7 @@ func importApplicationV1(source map[string]interface{}) (*application, error) {
 		"leadership-settings": schema.StringMap(schema.Any()),
 		"storage-constraints": schema.StringMap(schema.StringMap(schema.Any())),
 		"metrics-creds":       schema.String(),
+		"resources":           schema.StringMap(schema.Any()),
 		"units":               schema.StringMap(schema.Any()),
 	}
 
@@ -471,6 +472,12 @@ func importApplicationV1(source map[string]interface{}) (*application, error) {
 		return nil, errors.Trace(err)
 	}
 	result.Status_ = status
+
+	resources, err := importResources(valid["resources"].(map[string]interface{}))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	result.setResources(resources)
 
 	units, err := importUnits(valid["units"].(map[string]interface{}))
 	if err != nil {

--- a/core/description/application.go
+++ b/core/description/application.go
@@ -84,7 +84,7 @@ type application struct {
 	// unit count will be assumed by the number of units associated.
 	Units_ units `yaml:"units"`
 
-	Resources_ resources `yaml:"resources,omitempty"`
+	Resources_ resources `yaml:"resources"`
 
 	Annotations_ `yaml:"annotations,omitempty"`
 

--- a/core/description/application.go
+++ b/core/description/application.go
@@ -41,6 +41,9 @@ type Application interface {
 	MetricsCredentials() []byte
 	StorageConstraints() map[string]StorageConstraint
 
+	Resources() []Resource
+	AddResource(ResourceArgs) Resource
+
 	Units() []Unit
 	AddUnit(UnitArgs) Unit
 
@@ -80,6 +83,8 @@ type application struct {
 
 	// unit count will be assumed by the number of units associated.
 	Units_ units `yaml:"units"`
+
+	Resources_ resources `yaml:"resources,omitempty"`
 
 	Annotations_ `yaml:"annotations,omitempty"`
 
@@ -126,6 +131,7 @@ func newApplication(args ApplicationArgs) *application {
 		StatusHistory_:        newStatusHistory(),
 	}
 	app.setUnits(nil)
+	app.setResources(nil)
 	if len(args.StorageConstraints) > 0 {
 		app.StorageConstraints_ = make(map[string]*storageconstraint)
 		for key, value := range args.StorageConstraints {
@@ -280,6 +286,30 @@ func (a *application) Constraints() Constraints {
 // SetConstraints implements HasConstraints.
 func (a *application) SetConstraints(args ConstraintsArgs) {
 	a.Constraints_ = newConstraints(args)
+}
+
+// Resources implements Application.
+func (s *application) Resources() []Resource {
+	rs := s.Resources_.Resources_
+	result := make([]Resource, len(rs))
+	for i, r := range rs {
+		result[i] = r
+	}
+	return result
+}
+
+// AddResource implements Application.
+func (s *application) AddResource(args ResourceArgs) Resource {
+	r := newResource(args)
+	s.Resources_.Resources_ = append(s.Resources_.Resources_, r)
+	return r
+}
+
+func (s *application) setResources(resourceList []*resource) {
+	s.Resources_ = resources{
+		Version:    1,
+		Resources_: resourceList,
+	}
 }
 
 // Validate implements Application.

--- a/core/description/application.go
+++ b/core/description/application.go
@@ -320,6 +320,13 @@ func (a *application) Validate() error {
 	if a.Status_ == nil {
 		return errors.NotValidf("application %q missing status", a.Name_)
 	}
+
+	for _, resource := range s.Resources_.Resources_ {
+		if err := resource.Validate(); err != nil {
+			return errors.Annotatef(err, "resource %s", resource.Name_)
+		}
+	}
+
 	// If leader is set, it must match one of the units.
 	var leaderFound bool
 	// All of the applications units should also be valid.

--- a/core/description/application_test.go
+++ b/core/description/application_test.go
@@ -5,7 +5,6 @@ package description
 
 import (
 	jc "github.com/juju/testing/checkers"
-	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/yaml.v2"
@@ -188,8 +187,6 @@ func (s *ApplicationSerializationSuite) exportImport(c *gc.C, application_ *appl
 func (s *ApplicationSerializationSuite) TestParsingSerializedData(c *gc.C) {
 	svc := minimalApplication()
 	application := s.exportImport(c, svc)
-	pretty.Println(application)
-	pretty.Println(svc)
 	c.Assert(application, jc.DeepEquals, svc)
 }
 
@@ -262,4 +259,13 @@ func (s *ApplicationSerializationSuite) TestLeaderValid(c *gc.C) {
 
 	err := application.Validate()
 	c.Assert(err, gc.ErrorMatches, `missing unit for leader "ubuntu/1" not valid`)
+}
+
+func (s *ApplicationSerializationSuite) TestResourcesAreValidated(c *gc.C) {
+	application := minimalApplication()
+	application.setResources([]*resource{
+		newResource(ResourceArgs{Name: "foo"}),
+	})
+	err := application.Validate()
+	c.Assert(err, gc.ErrorMatches, `resource foo: missing application revision .+`)
 }

--- a/core/description/application_test.go
+++ b/core/description/application_test.go
@@ -5,6 +5,7 @@ package description
 
 import (
 	jc "github.com/juju/testing/checkers"
+	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/yaml.v2"
@@ -52,6 +53,12 @@ func minimalApplicationMap() map[interface{}]interface{} {
 			"leader": true,
 		},
 		"metrics-creds": "c2Vrcml0", // base64 encoded
+		"resources": map[interface{}]interface{}{
+			"version": 1,
+			"resources": []interface{}{
+				minimalResourceMap(),
+			},
+		},
 		"units": map[interface{}]interface{}{
 			"version": 1,
 			"units": []interface{}{
@@ -71,6 +78,7 @@ func minimalApplication(args ...ApplicationArgs) *application {
 	u.SetAgentStatus(minimalStatusArgs())
 	u.SetWorkloadStatus(minimalStatusArgs())
 	u.SetTools(minimalAgentToolsArgs())
+	s.setResources([]*resource{minimalResource()})
 	return s
 }
 
@@ -180,6 +188,8 @@ func (s *ApplicationSerializationSuite) exportImport(c *gc.C, application_ *appl
 func (s *ApplicationSerializationSuite) TestParsingSerializedData(c *gc.C) {
 	svc := minimalApplication()
 	application := s.exportImport(c, svc)
+	pretty.Println(application)
+	pretty.Println(svc)
 	c.Assert(application, jc.DeepEquals, svc)
 }
 

--- a/core/description/application_test.go
+++ b/core/description/application_test.go
@@ -263,9 +263,7 @@ func (s *ApplicationSerializationSuite) TestLeaderValid(c *gc.C) {
 
 func (s *ApplicationSerializationSuite) TestResourcesAreValidated(c *gc.C) {
 	application := minimalApplication()
-	application.setResources([]*resource{
-		newResource(ResourceArgs{Name: "foo"}),
-	})
+	application.AddResource(ResourceArgs{Name: "foo"})
 	err := application.Validate()
 	c.Assert(err, gc.ErrorMatches, `resource foo: missing application revision .+`)
 }

--- a/core/description/resource.go
+++ b/core/description/resource.go
@@ -3,7 +3,13 @@
 
 package description
 
-import "time"
+import (
+	"strconv"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+)
 
 // Resource represents an application resource.
 type Resource interface {
@@ -12,6 +18,7 @@ type Resource interface {
 	CharmStoreRevision() int
 	AddRevision(ResourceRevisionArgs)
 	Revisions() map[int]ResourceRevision
+	Validate() error
 }
 
 // ResourceRevision represents a revision of an application resource.
@@ -40,7 +47,7 @@ func newResource(args ResourceArgs) *resource {
 		Name_:               args.Name,
 		Revision_:           args.Revision,
 		CharmStoreRevision_: args.CharmStoreRevision,
-		Revisions_:          make(map[int]ResourceRevision),
+		Revisions_:          make(map[string]ResourceRevision),
 	}
 }
 
@@ -50,12 +57,22 @@ type resources struct {
 }
 
 type resource struct {
-	Name_               string                   `yaml:"name"`
-	Revision_           int                      `yaml:"application-revision"`
-	CharmStoreRevision_ int                      `yaml:"charmstore-revision"`
-	CharmStorePolled_   time.Time                `yaml:"charmstore-polled"`
-	Revisions_          map[int]ResourceRevision `yaml:"revisions"`
+	Name_               string `yaml:"name"`
+	Revision_           int    `yaml:"application-revision"`
+	CharmStoreRevision_ int    `yaml:"charmstore-revision"`
+	// Revisions_ uses string keys to avoid serialisation problems.
+	// XXX make this a type with it's own serialisation?
+	Revisions_ map[string]ResourceRevision `yaml:"revisions"`
 }
+
+/*
+type ResourceRevisionMap map[int]ResourceRevision
+
+// MarshalYAML implements yaml.v2.Marshaller interface.
+func (m ResourceRevisionMap) MarshalYAML() (interface{}, error) {
+	return b.String(), nil
+}
+*/
 
 // Name implements Resource.
 func (r *resource) Name() string {
@@ -88,6 +105,11 @@ type ResourceRevisionArgs struct {
 
 // AddRevision implements Resource.
 func (r *resource) AddRevision(args ResourceRevisionArgs) {
+	var addTs *time.Time
+	if !args.AddTimestamp.IsZero() {
+		t := args.AddTimestamp.UTC()
+		addTs = &t
+	}
 	rev := &resourceRevision{
 		Revision_:     args.Revision,
 		Type_:         args.Type,
@@ -96,32 +118,47 @@ func (r *resource) AddRevision(args ResourceRevisionArgs) {
 		Origin_:       args.Origin,
 		Fingerprint_:  args.Fingerprint,
 		Size_:         args.Size,
-		AddTimestamp_: args.AddTimestamp,
+		AddTimestamp_: addTs,
 		Username_:     args.Username,
 	}
-	r.Revisions_[args.Revision] = rev
+	r.Revisions_[strconv.Itoa(args.Revision)] = rev
 }
 
 // Revisions implements Resource.
 func (r *resource) Revisions() map[int]ResourceRevision {
 	out := make(map[int]ResourceRevision)
 	for k, v := range r.Revisions_ {
-		out[k] = v
+		revId, err := strconv.Atoi(k)
+		if err != nil {
+			// XXX
+			panic(err) // This really is very unlikely.
+		}
+		out[revId] = v
 	}
 	return out
 }
 
+// Validate implements Resource.
+func (r *resource) Validate() error {
+	if _, ok := r.Revisions_[strconv.Itoa(r.Revision_)]; !ok {
+		return errors.Errorf("missing application revision (%d)", r.Revision_)
+	}
+	if _, ok := r.Revisions_[strconv.Itoa(r.CharmStoreRevision_)]; !ok {
+		return errors.Errorf("missing charmstore revision (%d)", r.CharmStoreRevision_)
+	}
+	return nil
+}
+
 type resourceRevision struct {
-	Revision_     int
-	Type_         string
-	Path_         string
-	Description_  string
-	Origin_       string
-	Fingerprint_  string
-	Size_         int64
-	AddTimestamp_ time.Time
-	Username_     string
-	StoragePath_  string
+	Revision_     int        `yaml:"revision"`
+	Type_         string     `yaml:"type"`
+	Path_         string     `yaml:"path"`
+	Description_  string     `yaml:"description"`
+	Origin_       string     `yaml:"origin"`
+	Fingerprint_  string     `yaml:"fingerprint"` // XXX include Hex in the name?
+	Size_         int64      `yaml:"size"`
+	AddTimestamp_ *time.Time `yaml:"add-timestamp,omitempty"`
+	Username_     string     `yaml:"username,omitempty"`
 }
 
 // Revision implements ResourceRevision.
@@ -161,10 +198,130 @@ func (r *resourceRevision) Size() int64 {
 
 // AddTimestamp implements ResourceRevision.
 func (r *resourceRevision) AddTimestamp() time.Time {
-	return r.AddTimestamp_
+	if r.AddTimestamp_ == nil {
+		return time.Time{}
+	}
+	return *r.AddTimestamp_
 }
 
 // Username implements ResourceRevision.
 func (r *resourceRevision) Username() string {
 	return r.Username_
+}
+
+func importResources(source map[string]interface{}) ([]*resource, error) {
+	checker := versionedChecker("resources")
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotate(err, "resources version schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+
+	version := int(valid["version"].(int64))
+	importFunc, ok := resourceDeserializationFuncs[version]
+	if !ok {
+		return nil, errors.NotValidf("version %d", version)
+	}
+	sourceList := valid["resources"].([]interface{})
+	return importResourceList(sourceList, importFunc)
+}
+
+func importResourceList(sourceList []interface{}, importFunc resourceDeserializationFunc) ([]*resource, error) {
+	result := make([]*resource, 0, len(sourceList))
+	for i, value := range sourceList {
+		source, ok := value.(map[string]interface{})
+		if !ok {
+			return nil, errors.Errorf("unexpected value for resource %d, %T", i, value)
+		}
+		resource, err := importFunc(source)
+		if err != nil {
+			return nil, errors.Annotatef(err, "resource %d", i)
+		}
+		result = append(result, resource)
+	}
+	return result, nil
+}
+
+type resourceDeserializationFunc func(map[string]interface{}) (*resource, error)
+
+var resourceDeserializationFuncs = map[int]resourceDeserializationFunc{
+	1: importResourceV1,
+}
+
+func importResourceV1(source map[string]interface{}) (*resource, error) {
+	fields := schema.Fields{
+		"name":                 schema.String(),
+		"application-revision": schema.Int(),
+		"charmstore-revision":  schema.Int(),
+		"revisions":            schema.StringMap(schema.Any()),
+	}
+	checker := schema.FieldMap(fields, nil)
+
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "resource v1 schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+
+	// From here we know that the map returned from the schema coercion
+	// contains fields of the right type.
+	name := valid["name"].(string)
+	r := &resource{
+		Name_:               name,
+		Revision_:           int(valid["application-revision"].(int64)),
+		CharmStoreRevision_: int(valid["charmstore-revision"].(int64)),
+		Revisions_:          make(map[string]ResourceRevision),
+	}
+
+	// Now read in the resource revisions...
+	revsMap := valid["revisions"].(map[string]interface{})
+	for revNum, revSource := range revsMap {
+		revision, err := importResourceRevisionV1(revSource)
+		if err != nil {
+			return nil, errors.Annotatef(err, "resource %s, revision %s", name, revNum)
+		}
+		r.Revisions_[revNum] = revision
+	}
+
+	return r, nil
+}
+
+func importResourceRevisionV1(source interface{}) (*resourceRevision, error) {
+	fields := schema.Fields{
+		"revision":      schema.Int(),
+		"type":          schema.String(),
+		"path":          schema.String(),
+		"description":   schema.String(),
+		"origin":        schema.String(),
+		"fingerprint":   schema.String(),
+		"size":          schema.Int(),
+		"add-timestamp": schema.Time(),
+		"username":      schema.String(),
+	}
+	defaults := schema.Defaults{
+		"add-timestamp": time.Time{},
+		"username":      "",
+	}
+	checker := schema.FieldMap(fields, defaults)
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "resource revision schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+
+	rev := &resourceRevision{
+		Revision_:    int(valid["revision"].(int64)),
+		Type_:        valid["type"].(string),
+		Path_:        valid["path"].(string),
+		Description_: valid["description"].(string),
+		Origin_:      valid["origin"].(string),
+		Fingerprint_: valid["fingerprint"].(string),
+		Size_:        valid["size"].(int64),
+		Username_:    valid["username"].(string),
+	}
+	addTs := valid["add-timestamp"].(time.Time)
+	if !addTs.IsZero() {
+		rev.AddTimestamp_ = &addTs
+	}
+	return rev, nil
 }

--- a/core/description/resource.go
+++ b/core/description/resource.go
@@ -1,0 +1,170 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+import "time"
+
+// Resource represents an application resource.
+type Resource interface {
+	Name() string
+	Revision() int
+	CharmStoreRevision() int
+	AddRevision(ResourceRevisionArgs)
+	Revisions() map[int]ResourceRevision
+}
+
+// ResourceRevision represents a revision of an application resource.
+type ResourceRevision interface {
+	Revision() int
+	Type() string
+	Path() string
+	Description() string
+	Origin() string
+	Fingerprint() string
+	Size() int64
+	AddTimestamp() time.Time
+	Username() string
+}
+
+// ResourceArgs is an argument struct used to create a new internal
+// resource type that supports the Resource interface.
+type ResourceArgs struct {
+	Name               string
+	Revision           int
+	CharmStoreRevision int
+}
+
+func newResource(args ResourceArgs) *resource {
+	return &resource{
+		Name_:               args.Name,
+		Revision_:           args.Revision,
+		CharmStoreRevision_: args.CharmStoreRevision,
+		Revisions_:          make(map[int]ResourceRevision),
+	}
+}
+
+type resources struct {
+	Version    int         `yaml:"version"`
+	Resources_ []*resource `yaml:"resources"`
+}
+
+type resource struct {
+	Name_               string                   `yaml:"name"`
+	Revision_           int                      `yaml:"application-revision"`
+	CharmStoreRevision_ int                      `yaml:"charmstore-revision"`
+	CharmStorePolled_   time.Time                `yaml:"charmstore-polled"`
+	Revisions_          map[int]ResourceRevision `yaml:"revisions"`
+}
+
+// Name implements Resource.
+func (r *resource) Name() string {
+	return r.Name_
+}
+
+// Revision implements Resource.
+func (r *resource) Revision() int {
+	return r.Revision_
+}
+
+// CharmStoreRevision implements Resource.
+func (r *resource) CharmStoreRevision() int {
+	return r.CharmStoreRevision_
+}
+
+// ResourceArgs is an argument struct used to add a new internal
+// resource revision to a Resource.
+type ResourceRevisionArgs struct {
+	Revision     int
+	Type         string
+	Path         string
+	Description  string
+	Origin       string
+	Fingerprint  string
+	Size         int64
+	AddTimestamp time.Time
+	Username     string
+}
+
+// AddRevision implements Resource.
+func (r *resource) AddRevision(args ResourceRevisionArgs) {
+	rev := &resourceRevision{
+		Revision_:     args.Revision,
+		Type_:         args.Type,
+		Path_:         args.Path,
+		Description_:  args.Description,
+		Origin_:       args.Origin,
+		Fingerprint_:  args.Fingerprint,
+		Size_:         args.Size,
+		AddTimestamp_: args.AddTimestamp,
+		Username_:     args.Username,
+	}
+	r.Revisions_[args.Revision] = rev
+}
+
+// Revisions implements Resource.
+func (r *resource) Revisions() map[int]ResourceRevision {
+	out := make(map[int]ResourceRevision)
+	for k, v := range r.Revisions_ {
+		out[k] = v
+	}
+	return out
+}
+
+type resourceRevision struct {
+	Revision_     int
+	Type_         string
+	Path_         string
+	Description_  string
+	Origin_       string
+	Fingerprint_  string
+	Size_         int64
+	AddTimestamp_ time.Time
+	Username_     string
+	StoragePath_  string
+}
+
+// Revision implements ResourceRevision.
+func (r *resourceRevision) Revision() int {
+	return r.Revision_
+}
+
+// Type implements ResourceRevision.
+func (r *resourceRevision) Type() string {
+	return r.Type_
+}
+
+// Path implements ResourceRevision.
+func (r *resourceRevision) Path() string {
+	return r.Path_
+}
+
+// Description implements ResourceRevision.
+func (r *resourceRevision) Description() string {
+	return r.Description_
+}
+
+// Origin implements ResourceRevision.
+func (r *resourceRevision) Origin() string {
+	return r.Origin_
+}
+
+// Fingerprint implements ResourceRevision.
+func (r *resourceRevision) Fingerprint() string {
+	return r.Fingerprint_
+}
+
+// Size implements ResourceRevision.
+func (r *resourceRevision) Size() int64 {
+	return r.Size_
+}
+
+// AddTimestamp implements ResourceRevision.
+func (r *resourceRevision) AddTimestamp() time.Time {
+	return r.AddTimestamp_
+}
+
+// Username implements ResourceRevision.
+func (r *resourceRevision) Username() string {
+	return r.Username_
+}

--- a/core/description/resource.go
+++ b/core/description/resource.go
@@ -27,7 +27,7 @@ type ResourceRevision interface {
 	Path() string
 	Description() string
 	Origin() string
-	Fingerprint() string
+	FingerprintHex() string
 	Size() int64
 	AddTimestamp() time.Time
 	Username() string
@@ -80,15 +80,15 @@ func (r *resource) CharmStoreRevision() int {
 // ResourceArgs is an argument struct used to add a new internal
 // resource revision to a Resource.
 type ResourceRevisionArgs struct {
-	Revision     int
-	Type         string
-	Path         string
-	Description  string
-	Origin       string
-	Fingerprint  string
-	Size         int64
-	AddTimestamp time.Time
-	Username     string
+	Revision       int
+	Type           string
+	Path           string
+	Description    string
+	Origin         string
+	FingerprintHex string
+	Size           int64
+	AddTimestamp   time.Time
+	Username       string
 }
 
 // AddRevision implements Resource.
@@ -99,15 +99,15 @@ func (r *resource) AddRevision(args ResourceRevisionArgs) {
 		addTs = &t
 	}
 	rev := &resourceRevision{
-		Revision_:     args.Revision,
-		Type_:         args.Type,
-		Path_:         args.Path,
-		Description_:  args.Description,
-		Origin_:       args.Origin,
-		Fingerprint_:  args.Fingerprint,
-		Size_:         args.Size,
-		AddTimestamp_: addTs,
-		Username_:     args.Username,
+		Revision_:       args.Revision,
+		Type_:           args.Type,
+		Path_:           args.Path,
+		Description_:    args.Description,
+		Origin_:         args.Origin,
+		FingerprintHex_: args.FingerprintHex,
+		Size_:           args.Size,
+		AddTimestamp_:   addTs,
+		Username_:       args.Username,
 	}
 	r.Revisions_ = append(r.Revisions_, rev)
 }
@@ -144,15 +144,15 @@ func (r *resource) Validate() error {
 }
 
 type resourceRevision struct {
-	Revision_     int        `yaml:"revision"`
-	Type_         string     `yaml:"type"`
-	Path_         string     `yaml:"path"`
-	Description_  string     `yaml:"description"`
-	Origin_       string     `yaml:"origin"`
-	Fingerprint_  string     `yaml:"fingerprint"` // XXX include Hex in the name?
-	Size_         int64      `yaml:"size"`
-	AddTimestamp_ *time.Time `yaml:"add-timestamp,omitempty"`
-	Username_     string     `yaml:"username,omitempty"`
+	Revision_       int        `yaml:"revision"`
+	Type_           string     `yaml:"type"`
+	Path_           string     `yaml:"path"`
+	Description_    string     `yaml:"description"`
+	Origin_         string     `yaml:"origin"`
+	FingerprintHex_ string     `yaml:"fingerprint"`
+	Size_           int64      `yaml:"size"`
+	AddTimestamp_   *time.Time `yaml:"add-timestamp,omitempty"`
+	Username_       string     `yaml:"username,omitempty"`
 }
 
 // Revision implements ResourceRevision.
@@ -180,9 +180,9 @@ func (r *resourceRevision) Origin() string {
 	return r.Origin_
 }
 
-// Fingerprint implements ResourceRevision.
-func (r *resourceRevision) Fingerprint() string {
-	return r.Fingerprint_
+// FingerprintHex implements ResourceRevision.
+func (r *resourceRevision) FingerprintHex() string {
+	return r.FingerprintHex_
 }
 
 // Size implements ResourceRevision.
@@ -300,14 +300,14 @@ func importResourceRevisionV1(source interface{}) (*resourceRevision, error) {
 	valid := coerced.(map[string]interface{})
 
 	rev := &resourceRevision{
-		Revision_:    int(valid["revision"].(int64)),
-		Type_:        valid["type"].(string),
-		Path_:        valid["path"].(string),
-		Description_: valid["description"].(string),
-		Origin_:      valid["origin"].(string),
-		Fingerprint_: valid["fingerprint"].(string),
-		Size_:        valid["size"].(int64),
-		Username_:    valid["username"].(string),
+		Revision_:       int(valid["revision"].(int64)),
+		Type_:           valid["type"].(string),
+		Path_:           valid["path"].(string),
+		Description_:    valid["description"].(string),
+		Origin_:         valid["origin"].(string),
+		FingerprintHex_: valid["fingerprint"].(string),
+		Size_:           valid["size"].(int64),
+		Username_:       valid["username"].(string),
 	}
 	addTs := valid["add-timestamp"].(time.Time)
 	if !addTs.IsZero() {

--- a/core/description/resource.go
+++ b/core/description/resource.go
@@ -307,11 +307,8 @@ func importResourceRevisionV1(source interface{}) (*resourceRevision, error) {
 		Origin_:         valid["origin"].(string),
 		FingerprintHex_: valid["fingerprint"].(string),
 		Size_:           valid["size"].(int64),
+		Timestamp_:      fieldToTimePtr(valid, "timestamp"),
 		Username_:       valid["username"].(string),
-	}
-	addTs := valid["add-timestamp"].(time.Time)
-	if !addTs.IsZero() {
-		rev.AddTimestamp_ = &addTs
 	}
 	return rev, nil
 }

--- a/core/description/resource_test.go
+++ b/core/description/resource_test.go
@@ -1,0 +1,189 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+)
+
+type ResourceSuite struct {
+	SliceSerializationSuite
+}
+
+var _ = gc.Suite(&ResourceSuite{})
+
+func (s *ResourceSuite) SetUpTest(c *gc.C) {
+	s.SerializationSuite.SetUpTest(c)
+	s.importName = "resources"
+	s.sliceName = "resources"
+	s.importFunc = func(m map[string]interface{}) (interface{}, error) {
+		return importResources(m)
+	}
+	s.testFields = func(m map[string]interface{}) {
+		m["resources"] = []interface{}{}
+	}
+}
+
+func minimalResourceMap() map[interface{}]interface{} {
+	return map[interface{}]interface{}{
+		"application-revision": 3,
+		"charmstore-revision":  4,
+		"name":                 "bdist",
+		"revisions": map[interface{}]interface{}{
+			"3": map[interface{}]interface{}{
+				"revision":      3,
+				"add-timestamp": "2016-10-18T02:03:04Z",
+				"description":   "description",
+				"fingerprint":   "aaaaaaaa",
+				"origin":        "store",
+				"path":          "file.tar.gz",
+				"size":          111,
+				"type":          "file",
+				"username":      "user",
+			},
+			"4": map[interface{}]interface{}{
+				"revision":    4,
+				"description": "description",
+				"fingerprint": "bbbbbbbb",
+				"origin":      "store",
+				"path":        "file.tar.gz",
+				"size":        222,
+				"type":        "file",
+			},
+		},
+	}
+}
+
+func minimalResource() *resource {
+	r := newResource(ResourceArgs{
+		Name:               "bdist",
+		Revision:           3,
+		CharmStoreRevision: 4,
+	})
+	r.AddRevision(ResourceRevisionArgs{
+		Revision:     3,
+		Type:         "file",
+		Path:         "file.tar.gz",
+		Description:  "description",
+		Origin:       "store",
+		Fingerprint:  "aaaaaaaa",
+		Size:         111,
+		AddTimestamp: time.Date(2016, 10, 18, 2, 3, 4, 0, time.UTC),
+		Username:     "user",
+	})
+	r.AddRevision(ResourceRevisionArgs{
+		Revision:    4,
+		Type:        "file",
+		Path:        "file.tar.gz",
+		Description: "description",
+		Origin:      "store",
+		Fingerprint: "bbbbbbbb",
+		Size:        222,
+	})
+	return r
+}
+
+func (s *ResourceSuite) TestNew(c *gc.C) {
+	r := minimalResource()
+	c.Check(r.Name(), gc.Equals, "bdist")
+	c.Check(r.Revision(), gc.Equals, 3)
+	c.Check(r.CharmStoreRevision(), gc.Equals, 4)
+
+	rs := r.Revisions()
+	c.Assert(rs, gc.HasLen, 2)
+
+	rev3 := rs[3]
+	c.Check(rev3.Revision(), gc.Equals, 3)
+	c.Check(rev3.Type(), gc.Equals, "file")
+	c.Check(rev3.Path(), gc.Equals, "file.tar.gz")
+	c.Check(rev3.Description(), gc.Equals, "description")
+	c.Check(rev3.Origin(), gc.Equals, "store")
+	c.Check(rev3.Fingerprint(), gc.Equals, "aaaaaaaa")
+	c.Check(rev3.Size(), gc.Equals, int64(111))
+	c.Check(rev3.AddTimestamp(), gc.Equals, time.Date(2016, 10, 18, 2, 3, 4, 0, time.UTC))
+	c.Check(rev3.Username(), gc.Equals, "user")
+
+	rev4 := rs[4]
+	c.Check(rev4.Revision(), gc.Equals, 4)
+	c.Check(rev4.Type(), gc.Equals, "file")
+	c.Check(rev4.Path(), gc.Equals, "file.tar.gz")
+	c.Check(rev4.Description(), gc.Equals, "description")
+	c.Check(rev4.Origin(), gc.Equals, "store")
+	c.Check(rev4.Fingerprint(), gc.Equals, "bbbbbbbb")
+	c.Check(rev4.Size(), gc.Equals, int64(222))
+	c.Check(rev4.AddTimestamp(), gc.Equals, time.Time{})
+	c.Check(rev4.Username(), gc.Equals, "")
+}
+
+func (s *ResourceSuite) TestMinimalValid(c *gc.C) {
+	r := minimalResource()
+	c.Assert(r.Validate(), jc.ErrorIsNil)
+}
+
+func (s *ResourceSuite) TestMinimalMatches(c *gc.C) {
+	bytes, err := yaml.Marshal(minimalResource())
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[interface{}]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(source, jc.DeepEquals, minimalResourceMap())
+}
+
+func (s *ResourceSuite) TestValidateMissingRev(c *gc.C) {
+	r := newResource(ResourceArgs{
+		Name:               "bdist",
+		Revision:           3,
+		CharmStoreRevision: 3,
+	})
+	c.Assert(r.Validate(), gc.ErrorMatches, `missing application revision \(3\)`)
+}
+
+func (s *ResourceSuite) TestValidateMissingCharmStoreRev(c *gc.C) {
+	r := newResource(ResourceArgs{
+		Name:               "bdist",
+		Revision:           3,
+		CharmStoreRevision: 4,
+	})
+	r.AddRevision(ResourceRevisionArgs{
+		Revision:     3,
+		Type:         "file",
+		Path:         "file.tar.gz",
+		Description:  "description",
+		Origin:       "store",
+		Fingerprint:  "aaaaaaaa",
+		Size:         111,
+		AddTimestamp: time.Date(2016, 10, 18, 2, 3, 4, 0, time.UTC),
+		Username:     "user",
+	})
+	c.Assert(r.Validate(), gc.ErrorMatches, `missing charmstore revision \(4\)`)
+}
+
+func (s *ResourceSuite) TestRoundTrip(c *gc.C) {
+	rIn := minimalResource()
+	rOut := s.exportImport(c, rIn)
+	c.Assert(rOut, jc.DeepEquals, rIn)
+}
+
+func (s *ResourceSuite) exportImport(c *gc.C, resourceIn *resource) *resource {
+	resourcesIn := &resources{
+		Version:    1,
+		Resources_: []*resource{resourceIn},
+	}
+	bytes, err := yaml.Marshal(resourcesIn)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	resourcesOut, err := importResources(source)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(resourcesOut, gc.HasLen, 1)
+	return resourcesOut[0]
+}

--- a/core/description/resource_test.go
+++ b/core/description/resource_test.go
@@ -36,15 +36,15 @@ func minimalResourceMap() map[interface{}]interface{} {
 		"name":                 "bdist",
 		"revisions": []interface{}{
 			map[interface{}]interface{}{
-				"revision":      3,
-				"add-timestamp": "2016-10-18T02:03:04Z",
-				"description":   "description",
-				"fingerprint":   "aaaaaaaa",
-				"origin":        "store",
-				"path":          "file.tar.gz",
-				"size":          111,
-				"type":          "file",
-				"username":      "user",
+				"revision":    3,
+				"timestamp":   "2016-10-18T02:03:04Z",
+				"description": "description",
+				"fingerprint": "aaaaaaaa",
+				"origin":      "store",
+				"path":        "file.tar.gz",
+				"size":        111,
+				"type":        "file",
+				"username":    "user",
 			},
 			map[interface{}]interface{}{
 				"revision":    4,
@@ -66,24 +66,24 @@ func minimalResource() *resource {
 		CharmStoreRevision: 4,
 	})
 	r.AddRevision(ResourceRevisionArgs{
-		Revision:     3,
-		Type:         "file",
-		Path:         "file.tar.gz",
-		Description:  "description",
-		Origin:       "store",
-		Fingerprint:  "aaaaaaaa",
-		Size:         111,
-		AddTimestamp: time.Date(2016, 10, 18, 2, 3, 4, 0, time.UTC),
-		Username:     "user",
+		Revision:       3,
+		Type:           "file",
+		Path:           "file.tar.gz",
+		Description:    "description",
+		Origin:         "store",
+		FingerprintHex: "aaaaaaaa",
+		Size:           111,
+		Timestamp:      time.Date(2016, 10, 18, 2, 3, 4, 0, time.UTC),
+		Username:       "user",
 	})
 	r.AddRevision(ResourceRevisionArgs{
-		Revision:    4,
-		Type:        "file",
-		Path:        "file.tar.gz",
-		Description: "description",
-		Origin:      "store",
-		Fingerprint: "bbbbbbbb",
-		Size:        222,
+		Revision:       4,
+		Type:           "file",
+		Path:           "file.tar.gz",
+		Description:    "description",
+		Origin:         "store",
+		FingerprintHex: "bbbbbbbb",
+		Size:           222,
 	})
 	return r
 }
@@ -103,9 +103,9 @@ func (s *ResourceSuite) TestNew(c *gc.C) {
 	c.Check(rev3.Path(), gc.Equals, "file.tar.gz")
 	c.Check(rev3.Description(), gc.Equals, "description")
 	c.Check(rev3.Origin(), gc.Equals, "store")
-	c.Check(rev3.Fingerprint(), gc.Equals, "aaaaaaaa")
+	c.Check(rev3.FingerprintHex(), gc.Equals, "aaaaaaaa")
 	c.Check(rev3.Size(), gc.Equals, int64(111))
-	c.Check(rev3.AddTimestamp(), gc.Equals, time.Date(2016, 10, 18, 2, 3, 4, 0, time.UTC))
+	c.Check(rev3.Timestamp(), gc.Equals, time.Date(2016, 10, 18, 2, 3, 4, 0, time.UTC))
 	c.Check(rev3.Username(), gc.Equals, "user")
 
 	rev4 := rs[4]
@@ -114,9 +114,9 @@ func (s *ResourceSuite) TestNew(c *gc.C) {
 	c.Check(rev4.Path(), gc.Equals, "file.tar.gz")
 	c.Check(rev4.Description(), gc.Equals, "description")
 	c.Check(rev4.Origin(), gc.Equals, "store")
-	c.Check(rev4.Fingerprint(), gc.Equals, "bbbbbbbb")
+	c.Check(rev4.FingerprintHex(), gc.Equals, "bbbbbbbb")
 	c.Check(rev4.Size(), gc.Equals, int64(222))
-	c.Check(rev4.AddTimestamp(), gc.Equals, time.Time{})
+	c.Check(rev4.Timestamp(), gc.Equals, time.Time{})
 	c.Check(rev4.Username(), gc.Equals, "")
 }
 
@@ -151,15 +151,15 @@ func (s *ResourceSuite) TestValidateMissingCharmStoreRev(c *gc.C) {
 		CharmStoreRevision: 4,
 	})
 	r.AddRevision(ResourceRevisionArgs{
-		Revision:     3,
-		Type:         "file",
-		Path:         "file.tar.gz",
-		Description:  "description",
-		Origin:       "store",
-		Fingerprint:  "aaaaaaaa",
-		Size:         111,
-		AddTimestamp: time.Date(2016, 10, 18, 2, 3, 4, 0, time.UTC),
-		Username:     "user",
+		Revision:       3,
+		Type:           "file",
+		Path:           "file.tar.gz",
+		Description:    "description",
+		Origin:         "store",
+		FingerprintHex: "aaaaaaaa",
+		Size:           111,
+		Timestamp:      time.Date(2016, 10, 18, 2, 3, 4, 0, time.UTC),
+		Username:       "user",
 	})
 	c.Assert(r.Validate(), gc.ErrorMatches, `missing charmstore revision \(4\)`)
 }

--- a/core/description/resource_test.go
+++ b/core/description/resource_test.go
@@ -34,8 +34,8 @@ func minimalResourceMap() map[interface{}]interface{} {
 		"application-revision": 3,
 		"charmstore-revision":  4,
 		"name":                 "bdist",
-		"revisions": map[interface{}]interface{}{
-			"3": map[interface{}]interface{}{
+		"revisions": []interface{}{
+			map[interface{}]interface{}{
 				"revision":      3,
 				"add-timestamp": "2016-10-18T02:03:04Z",
 				"description":   "description",
@@ -46,7 +46,7 @@ func minimalResourceMap() map[interface{}]interface{} {
 				"type":          "file",
 				"username":      "user",
 			},
-			"4": map[interface{}]interface{}{
+			map[interface{}]interface{}{
 				"revision":    4,
 				"description": "description",
 				"fingerprint": "bbbbbbbb",
@@ -162,6 +162,17 @@ func (s *ResourceSuite) TestValidateMissingCharmStoreRev(c *gc.C) {
 		Username:     "user",
 	})
 	c.Assert(r.Validate(), gc.ErrorMatches, `missing charmstore revision \(4\)`)
+}
+
+func (s *ResourceSuite) TestDuplicateRevisions(c *gc.C) {
+	r := newResource(ResourceArgs{
+		Name:               "bdist",
+		Revision:           3,
+		CharmStoreRevision: 3,
+	})
+	r.AddRevision(ResourceRevisionArgs{Revision: 3})
+	r.AddRevision(ResourceRevisionArgs{Revision: 3})
+	c.Assert(r.Validate(), gc.ErrorMatches, `revision 3 appears more than once`)
 }
 
 func (s *ResourceSuite) TestRoundTrip(c *gc.C) {

--- a/core/description/serialization.go
+++ b/core/description/serialization.go
@@ -4,6 +4,8 @@
 package description
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 )
@@ -77,4 +79,16 @@ func convertToMapOfMaps(field interface{}) map[string]map[string]interface{} {
 		result[key] = value.(map[string]interface{})
 	}
 	return result
+}
+
+// fieldToTimePtr looks for a field with the given name and converts
+// it to a Time.Time, returning a pointer to it. If the field doesn't
+// exist, nil is returned. This is useful for handling optional time
+// fields.
+func fieldToTimePtr(fields map[string]interface{}, name string) *time.Time {
+	if raw, exists := fields[name]; exists {
+		t := raw.(time.Time).UTC()
+		return &t
+	}
+	return nil
 }

--- a/core/description/unit.go
+++ b/core/description/unit.go
@@ -241,7 +241,7 @@ func (u *unit) setPayloads(payloadList []*payload) {
 	}
 }
 
-// Validate impelements Unit.
+// Validate implements Unit.
 func (u *unit) Validate() error {
 	if u.Name_ == "" {
 		return errors.NotValidf("missing name")

--- a/core/description/user.go
+++ b/core/description/user.go
@@ -138,7 +138,7 @@ func importUserV1(source map[string]interface{}) (*user, error) {
 	// Some values don't have to be there.
 	defaults := schema.Defaults{
 		"display-name":    "",
-		"last-connection": time.Time{},
+		"last-connection": schema.Omit,
 		"read-only":       false,
 	}
 	checker := schema.FieldMap(fields, defaults)
@@ -151,18 +151,13 @@ func importUserV1(source map[string]interface{}) (*user, error) {
 	// contains fields of the right type.
 
 	result := &user{
-		Name_:        valid["name"].(string),
-		DisplayName_: valid["display-name"].(string),
-		CreatedBy_:   valid["created-by"].(string),
-		DateCreated_: valid["date-created"].(time.Time),
-		Access_:      valid["access"].(string),
+		Name_:           valid["name"].(string),
+		DisplayName_:    valid["display-name"].(string),
+		CreatedBy_:      valid["created-by"].(string),
+		DateCreated_:    valid["date-created"].(time.Time),
+		Access_:         valid["access"].(string),
+		LastConnection_: fieldToTimePtr(valid, "last-connection"),
 	}
-
-	lastConn := valid["last-connection"].(time.Time)
-	if !lastConn.IsZero() {
-		result.LastConnection_ = &lastConn
-	}
-
 	return result, nil
 
 }

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -14,12 +14,18 @@ import (
 	gc "gopkg.in/check.v1"
 
 	jujucmd "github.com/juju/juju/cmd/juju/commands"
+	"github.com/juju/juju/component/all"
 	coretesting "github.com/juju/juju/testing"
 )
 
 var runFeatureTests = flag.Bool("featuretests", true, "Run long-running feature tests.")
 
 func init() {
+	// Required for anything requiring components (e.g. resources).
+	if err := all.RegisterForServer(); err != nil {
+		panic(err)
+	}
+
 	flag.Parse()
 
 	if *runFeatureTests == false {

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -17,6 +17,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 
+	"github.com/juju/juju/component/all"
 	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/provider/dummy"
@@ -25,6 +26,13 @@ import (
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 )
+
+func init() {
+	// Required for resources.
+	if err := all.RegisterForServer(); err != nil {
+		panic(err)
+	}
+}
 
 type ImportSuite struct {
 	statetesting.StateSuite
@@ -53,7 +61,7 @@ func (s *ImportSuite) TestBadBytes(c *gc.C) {
 
 func (s *ImportSuite) TestImportModel(c *gc.C) {
 	model, err := s.State.Export()
-	c.Check(err, jc.ErrorIsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	// Update the config values in the exported model for different values for
 	// "state-port", "api-port", and "ca-cert". Also give the model a new UUID
@@ -68,7 +76,7 @@ func (s *ImportSuite) TestImportModel(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 
 	dbModel, dbState, err := migration.ImportModel(s.State, bytes)
-	c.Check(err, jc.ErrorIsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	defer dbState.Close()
 
 	dbConfig, err := dbModel.Config()

--- a/resource/api/client/base_test.go
+++ b/resource/api/client/base_test.go
@@ -81,6 +81,7 @@ func newResource(c *gc.C, name, username, data string) (resource.Resource, api.R
 	apiRes := api.Resource{
 		CharmResource: api.CharmResource{
 			Name:        name,
+			Description: name + " description",
 			Type:        "file",
 			Path:        res.Path,
 			Origin:      "upload",

--- a/resource/api/server/base_test.go
+++ b/resource/api/server/base_test.go
@@ -55,6 +55,7 @@ func newResource(c *gc.C, name, username, data string) (resource.Resource, api.R
 	apiRes := api.Resource{
 		CharmResource: api.CharmResource{
 			Name:        name,
+			Description: name + " description",
 			Type:        "file",
 			Path:        res.Path,
 			Origin:      "upload",

--- a/resource/resourcetesting/resource.go
+++ b/resource/resourcetesting/resource.go
@@ -36,9 +36,10 @@ func NewCharmResource(c *gc.C, name, content string) charmresource.Resource {
 	c.Assert(err, jc.ErrorIsNil)
 	res := charmresource.Resource{
 		Meta: charmresource.Meta{
-			Name: name,
-			Type: charmresource.TypeFile,
-			Path: name + ".tgz",
+			Name:        name,
+			Type:        charmresource.TypeFile,
+			Path:        name + ".tgz",
+			Description: name + " description",
 		},
 		Origin:      charmresource.OriginUpload,
 		Revision:    0,

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -167,7 +167,7 @@ func (s *LogsSuite) TestIndexesCreated(c *gc.C) {
 func (s *LogsSuite) TestDbLogger(c *gc.C) {
 	logger := state.NewDbLogger(s.State, names.NewMachineTag("22"), jujuversion.Current)
 	defer logger.Close()
-	t0 := coretesting.ZeroTime().Truncate(time.Millisecond) // MongoDB only stores timestamps with ms precision.
+	t0 := truncateDBTime(coretesting.ZeroTime())
 	logger.Log(t0, "some.where", "foo.go:99", loggo.INFO, "all is well")
 	t1 := t0.Add(time.Second)
 	logger.Log(t1, "else.where", "bar.go:42", loggo.ERROR, "oh noes")
@@ -227,7 +227,7 @@ func (s *LogsSuite) TestPruneLogsByTime(c *gc.C) {
 func (s *LogsSuite) TestPruneLogsBySize(c *gc.C) {
 	// Set up 3 models and generate different amounts of logs
 	// for them.
-	now := coretesting.NonZeroTime().Truncate(time.Millisecond)
+	now := truncateDBTime(coretesting.NonZeroTime())
 
 	s0 := s.State
 	startingLogsS0 := 10

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/payload"
+	"github.com/juju/juju/resource"
 	"github.com/juju/juju/storage/poolmanager"
 )
 
@@ -490,15 +491,25 @@ func (e *exporter) applications() error {
 		return errors.Trace(err)
 	}
 
+	resourcesSt, err := e.st.Resources()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	for _, application := range applications {
 		applicationUnits := e.units[application.Name()]
 		leader := leaders[application.Name()]
+		resources, err := resourcesSt.ListResources(application.Name())
+		if err != nil {
+			return errors.Trace(err)
+		}
 		if err := e.addApplication(addApplicationContext{
 			application:      application,
 			units:            applicationUnits,
 			meterStatus:      meterStatus,
 			leader:           leader,
 			payloads:         payloads,
+			resources:        resources,
 			endpoingBindings: bindings,
 		}); err != nil {
 			return errors.Trace(err)
@@ -556,6 +567,7 @@ type addApplicationContext struct {
 	meterStatus      map[string]*meterStatusDoc
 	leader           string
 	payloads         map[string][]payload.FullPayloadInfo
+	resources        resource.ServiceResources
 	endpoingBindings map[string]bindingsMap
 }
 
@@ -610,6 +622,10 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 		return errors.Trace(err)
 	}
 	exApplication.SetConstraints(constraintsArgs)
+
+	if err := e.setResources(exApplication, ctx.resources); err != nil {
+		return errors.Trace(err)
+	}
 
 	for _, unit := range ctx.units {
 		agentKey := unit.globalAgentKey()
@@ -682,6 +698,47 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 			return errors.Trace(err)
 		}
 		exUnit.SetConstraints(constraintsArgs)
+	}
+
+	return nil
+}
+
+func (e *exporter) setResources(exApp description.Application, resources resource.ServiceResources) error {
+	if len(resources.Resources) != len(resources.CharmStoreResources) {
+		return errors.New("number of resources don't match charm store resources")
+	}
+
+	for i, resource := range resources.Resources {
+		csResource := resources.CharmStoreResources[i]
+		exResource := exApp.AddResource(description.ResourceArgs{
+			Name:               resource.Name,
+			Revision:           resource.Revision,
+			CharmStoreRevision: csResource.Revision,
+		})
+
+		exResource.AddRevision(description.ResourceRevisionArgs{
+			Revision:     resource.Revision,
+			Type:         resource.Type.String(),
+			Path:         resource.Path,
+			Description:  resource.Description,
+			Origin:       resource.Origin.String(),
+			Fingerprint:  resource.Fingerprint.Hex(),
+			Size:         resource.Size,
+			AddTimestamp: resource.Timestamp,
+			Username:     resource.Username,
+		})
+
+		if csResource.Revision != resource.Revision {
+			exResource.AddRevision(description.ResourceRevisionArgs{
+				Revision:    csResource.Revision,
+				Type:        csResource.Type.String(),
+				Path:        csResource.Path,
+				Description: csResource.Description,
+				Origin:      csResource.Origin.String(),
+				Size:        csResource.Size,
+				Fingerprint: csResource.Fingerprint.Hex(),
+			})
+		}
 	}
 
 	return nil

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -724,7 +724,7 @@ func (e *exporter) setResources(exApp description.Application, resources resourc
 			Origin:         resource.Origin.String(),
 			FingerprintHex: resource.Fingerprint.Hex(),
 			Size:           resource.Size,
-			AddTimestamp:   resource.Timestamp,
+			Timestamp:      resource.Timestamp,
 			Username:       resource.Username,
 		})
 

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -717,26 +717,26 @@ func (e *exporter) setResources(exApp description.Application, resources resourc
 		})
 
 		exResource.AddRevision(description.ResourceRevisionArgs{
-			Revision:     resource.Revision,
-			Type:         resource.Type.String(),
-			Path:         resource.Path,
-			Description:  resource.Description,
-			Origin:       resource.Origin.String(),
-			Fingerprint:  resource.Fingerprint.Hex(),
-			Size:         resource.Size,
-			AddTimestamp: resource.Timestamp,
-			Username:     resource.Username,
+			Revision:       resource.Revision,
+			Type:           resource.Type.String(),
+			Path:           resource.Path,
+			Description:    resource.Description,
+			Origin:         resource.Origin.String(),
+			FingerprintHex: resource.Fingerprint.Hex(),
+			Size:           resource.Size,
+			AddTimestamp:   resource.Timestamp,
+			Username:       resource.Username,
 		})
 
 		if csResource.Revision != resource.Revision {
 			exResource.AddRevision(description.ResourceRevisionArgs{
-				Revision:    csResource.Revision,
-				Type:        csResource.Type.String(),
-				Path:        csResource.Path,
-				Description: csResource.Description,
-				Origin:      csResource.Origin.String(),
-				Size:        csResource.Size,
-				Fingerprint: csResource.Fingerprint.Hex(),
+				Revision:       csResource.Revision,
+				Type:           csResource.Type.String(),
+				Path:           csResource.Path,
+				Description:    csResource.Description,
+				Origin:         csResource.Origin.String(),
+				Size:           csResource.Size,
+				FingerprintHex: csResource.Fingerprint.Hex(),
 			})
 		}
 	}

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1024,13 +1024,6 @@ func (s *MigrationExportSuite) TestResources(c *gc.C) {
 
 	data := "ham"
 
-	/* XXX save rev 1 for units
-	ts1 := time.Date(2016, 10, 1, 0, 0, 0, 0, time.UTC)
-	res1 := s.newResource(c, app.Name(), "spam", 1, ts1, data)
-	res1, err = st.SetResource(app.Name(), res1.Username, res1.Resource, bytes.NewBufferString(data))
-	c.Assert(err, jc.ErrorIsNil)
-	*/
-
 	// Revision 2 is set for the application.
 	ts2 := time.Date(2016, 10, 2, 0, 0, 0, 0, time.UTC)
 	res2 := s.newResource(c, app.Name(), "spam", 2, ts2, data)
@@ -1084,8 +1077,6 @@ func (s *MigrationExportSuite) TestResources(c *gc.C) {
 	// These shouldn't be set for charmstore only revisions.
 	c.Check(exRev3.AddTimestamp(), gc.Equals, time.Time{})
 	c.Check(exRev3.Username(), gc.Equals, "")
-
-	c.Fatal("unit revisions")
 }
 
 func (s *MigrationExportSuite) newResource(c *gc.C, appName, name string, revision int, ts time.Time, data string) resource.Resource {

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1062,7 +1062,7 @@ func (s *MigrationExportSuite) TestResources(c *gc.C) {
 	c.Check(exRev2.Origin(), gc.Equals, res2.Origin.String())
 	c.Check(exRev2.FingerprintHex(), gc.Equals, res2.Fingerprint.Hex())
 	c.Check(exRev2.Size(), gc.Equals, res2.Size)
-	c.Check(exRev2.AddTimestamp().UTC(), gc.Equals, truncateDBTime(res2.Timestamp))
+	c.Check(exRev2.Timestamp().UTC(), gc.Equals, truncateDBTime(res2.Timestamp))
 	c.Check(exRev2.Username(), gc.Equals, res2.Username)
 
 	// Charmstore revision.
@@ -1075,7 +1075,7 @@ func (s *MigrationExportSuite) TestResources(c *gc.C) {
 	c.Check(exRev3.FingerprintHex(), gc.Equals, res3.Fingerprint.Hex())
 	c.Check(exRev3.Size(), gc.Equals, res3.Size)
 	// These shouldn't be set for charmstore only revisions.
-	c.Check(exRev3.AddTimestamp(), gc.Equals, time.Time{})
+	c.Check(exRev3.Timestamp(), gc.Equals, time.Time{})
 	c.Check(exRev3.Username(), gc.Equals, "")
 }
 

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1060,7 +1060,7 @@ func (s *MigrationExportSuite) TestResources(c *gc.C) {
 	c.Check(exRev2.Path(), gc.Equals, res2.Path)
 	c.Check(exRev2.Description(), gc.Equals, res2.Description)
 	c.Check(exRev2.Origin(), gc.Equals, res2.Origin.String())
-	c.Check(exRev2.Fingerprint(), gc.Equals, res2.Fingerprint.Hex())
+	c.Check(exRev2.FingerprintHex(), gc.Equals, res2.Fingerprint.Hex())
 	c.Check(exRev2.Size(), gc.Equals, res2.Size)
 	c.Check(exRev2.AddTimestamp().UTC(), gc.Equals, truncateDBTime(res2.Timestamp))
 	c.Check(exRev2.Username(), gc.Equals, res2.Username)
@@ -1072,7 +1072,7 @@ func (s *MigrationExportSuite) TestResources(c *gc.C) {
 	c.Check(exRev3.Path(), gc.Equals, res3.Path)
 	c.Check(exRev3.Description(), gc.Equals, res3.Description)
 	c.Check(exRev3.Origin(), gc.Equals, res3.Origin.String())
-	c.Check(exRev3.Fingerprint(), gc.Equals, res3.Fingerprint.Hex())
+	c.Check(exRev3.FingerprintHex(), gc.Equals, res3.Fingerprint.Hex())
 	c.Check(exRev3.Size(), gc.Equals, res3.Size)
 	// These shouldn't be set for charmstore only revisions.
 	c.Check(exRev3.AddTimestamp(), gc.Equals, time.Time{})

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -32,7 +32,7 @@ var _ = gc.Suite(new(MigrationSuite))
 
 func (s *MigrationSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
-	s.clock = jujutesting.NewClock(time.Now().Truncate(time.Second))
+	s.clock = jujutesting.NewClock(truncateDBTime(time.Now()))
 	err := s.State.SetClockForTesting(s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/resources.go
+++ b/state/resources.go
@@ -16,7 +16,7 @@ import (
 
 // Resources describes the state functionality for resources.
 type Resources interface {
-	// ListResources returns the list of resources for the given service.
+	// ListResources returns the list of resources for the given application.
 	ListResources(applicationID string) (resource.ServiceResources, error)
 
 	// AddPendingResource adds the resource to the data store in a

--- a/state/upgrade_test.go
+++ b/state/upgrade_test.go
@@ -5,8 +5,7 @@ package state_test
 
 import (
 	"fmt"
-	"time" // Only used for time types.
-
+	// Only used for time types.
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version"
@@ -574,8 +573,7 @@ func (s *UpgradeSuite) checkUpgradeInfoArchived(
 	c.Assert(info.Status(), gc.Equals, expectedStatus)
 	c.Assert(info.PreviousVersion(), gc.Equals, initialInfo.PreviousVersion())
 	c.Assert(info.TargetVersion(), gc.Equals, initialInfo.TargetVersion())
-	// Truncate because mongo only stores times down to millisecond resolution.
-	c.Assert(info.Started().Equal(initialInfo.Started().Truncate(time.Millisecond)), jc.IsTrue)
+	c.Assert(info.Started().Equal(truncateDBTime(initialInfo.Started())), jc.IsTrue)
 	c.Assert(len(info.ControllersDone()), gc.Equals, expectedControllers)
 	if expectedControllers > 0 {
 		c.Assert(info.ControllersDone(), jc.SameContents, info.ControllersReady())

--- a/state/upgrade_test.go
+++ b/state/upgrade_test.go
@@ -5,7 +5,7 @@ package state_test
 
 import (
 	"fmt"
-	// Only used for time types.
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version"

--- a/state/util_test.go
+++ b/state/util_test.go
@@ -1,0 +1,11 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import "time"
+
+func truncateDBTime(t time.Time) time.Time {
+	// MongoDB only stores timestamps with ms precision.
+	return t.Truncate(time.Millisecond)
+}


### PR DESCRIPTION
This pull request covers the export, serialisation and deserialisation of application resources.

Still to come:
* import of resources back into state
* handling of per unit resource revisions
* export and import of resource binaries

### QA

Visual inspection of `juju dump-model` output for a model with a charm which uses resources. More involved QA will be done once the above items have been handled.

Also tested a standard migration to ensure there's no regressions.