### PR TITLE
Move some crossmodel facades to controller

### DIFF
--- a/apiserver/crossmodel/applicationdirectory.go
+++ b/apiserver/crossmodel/applicationdirectory.go
@@ -99,7 +99,7 @@ func (api *applicationOffersAPI) AddOffers(offers params.AddApplicationOffers) (
 // localApplicationOffers provides access to application offers hosted within
 // a local controller.
 type localApplicationOffers struct {
-	applicationdirectory crossmodel.ApplicationDirectory
+	applicationDirectory crossmodel.ApplicationDirectory
 }
 
 // ListOffers returns offers matching the filter from a application directory.
@@ -109,7 +109,7 @@ func (so *localApplicationOffers) ListOffers(filters params.OfferFilters) (param
 	if err != nil {
 		return result, err
 	}
-	offers, err := so.applicationdirectory.ListOffers(offerFilters...)
+	offers, err := so.applicationDirectory.ListOffers(offerFilters...)
 	if err != nil {
 		result.Error = common.ServerError(err)
 		return result, nil
@@ -160,7 +160,7 @@ func (so *localApplicationOffers) AddOffers(offers params.AddApplicationOffers) 
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
-		if err := so.applicationdirectory.AddOffer(offer); err != nil {
+		if err := so.applicationDirectory.AddOffer(offer); err != nil {
 			result.Results[i].Error = common.ServerError(err)
 		}
 	}

--- a/apiserver/crossmodel/export_test.go
+++ b/apiserver/crossmodel/export_test.go
@@ -3,6 +3,8 @@
 
 package crossmodel
 
+import "github.com/juju/juju/apiserver/params"
+
 var (
 	CreateAPI                   = createAPI
 	CreateApplicationOffersAPI  = createApplicationOffersAPI
@@ -10,3 +12,7 @@ var (
 	NewServiceAPIFactory        = newServiceAPIFactory
 	GetStateAccess              = getStateAccess
 )
+
+func MakeOfferedApplicationParams(api *API, p params.ApplicationOfferParams) (params.ApplicationOffer, error) {
+	return api.makeOfferedApplicationParams(p)
+}

--- a/apiserver/crossmodel/mock_test.go
+++ b/apiserver/crossmodel/mock_test.go
@@ -55,6 +55,10 @@ func (m *mockState) WatchOfferedApplications() state.StringsWatcher {
 	return m.watchOfferedApplications()
 }
 
+func (m *mockState) ForModel(tag names.ModelTag) (*state.State, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m *mockState) Application(name string) (application *state.Application, err error) {
 	return nil, errors.New("not implemented")
 }

--- a/apiserver/crossmodel/offeredapplications.go
+++ b/apiserver/crossmodel/offeredapplications.go
@@ -27,7 +27,7 @@ type OfferedApplicationLister interface {
 
 // OfferedApplicationAPI is a facade used to access offered applications.
 type OfferedApplicationAPI struct {
-	st                  stateAccess
+	st                  Backend
 	offeredApplications OfferedApplicationLister
 	resources           facade.Resources
 	authorizer          facade.Authorizer
@@ -35,7 +35,7 @@ type OfferedApplicationAPI struct {
 
 // createApplicationDirectoryAPI returns a new cross model API facade.
 func createOfferedApplicationAPI(
-	st stateAccess,
+	st Backend,
 	offeredApplicationLister OfferedApplicationLister,
 	resources facade.Resources,
 	authorizer facade.Authorizer,

--- a/apiserver/crossmodel/state.go
+++ b/apiserver/crossmodel/state.go
@@ -9,17 +9,18 @@ import (
 	"github.com/juju/juju/state"
 )
 
-// stateAccess provides selected methods off the state.State struct
+// Backend provides selected methods off the state.State struct
 // plus additional helpers.
-type stateAccess interface {
-	Application(name string) (service *state.Application, err error)
+type Backend interface {
+	Application(name string) (*state.Application, error)
+	ForModel(modelTag names.ModelTag) (*state.State, error)
 	ModelTag() names.ModelTag
 	ModelUUID() string
 	WatchOfferedApplications() state.StringsWatcher
 	ModelName() (string, error)
 }
 
-var getStateAccess = func(st *state.State) stateAccess {
+var getStateAccess = func(st *state.State) Backend {
 	return &stateShim{st}
 }
 
@@ -27,7 +28,7 @@ type stateShim struct {
 	*state.State
 }
 
-// EnvironName returns the name of the environment.
+// ModelName returns the name of the model.
 func (s *stateShim) ModelName() (string, error) {
 	cfg, err := s.ModelConfig()
 	if err != nil {

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -79,6 +79,9 @@ type RemoteEndpoint struct {
 
 // ApplicationOfferParams is used to offer remote applications.
 type ApplicationOfferParams struct {
+	// ModelTag is the tag of the model containing the application to offer.
+	ModelTag string `json:"model-tag"`
+
 	// ApplicationURL may contain user supplied application url.
 	ApplicationURL string `json:"application-url,omitempty"`
 

--- a/apiserver/restrict_controller.go
+++ b/apiserver/restrict_controller.go
@@ -20,6 +20,8 @@ var controllerFacadeNames = set.NewStrings(
 	"MigrationTarget",
 	"ModelManager",
 	"UserManager",
+	"ApplicationOffers",
+	"CrossModelRelations",
 )
 
 // commonFacadeNames holds root names that can be accessed using both

--- a/apiserver/restrict_controller_test.go
+++ b/apiserver/restrict_controller_test.go
@@ -9,6 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/testing"
 )
@@ -21,6 +22,7 @@ type restrictControllerSuite struct {
 var _ = gc.Suite(&restrictControllerSuite{})
 
 func (s *restrictControllerSuite) SetUpSuite(c *gc.C) {
+	s.SetInitialFeatureFlags(feature.CrossModelRelations)
 	s.BaseSuite.SetUpSuite(c)
 	s.root = apiserver.TestingControllerOnlyRoot()
 }
@@ -33,6 +35,8 @@ func (s *restrictControllerSuite) TestAllowed(c *gc.C) {
 	s.assertMethod(c, "Pinger", 1, "Ping")
 	s.assertMethod(c, "Bundle", 1, "GetChanges")
 	s.assertMethod(c, "HighAvailability", 2, "EnableHA")
+	s.assertMethod(c, "CrossModelRelations", 1, "FindApplicationOffers")
+	s.assertMethod(c, "ApplicationOffers", 1, "ListOffers")
 }
 
 func (s *restrictControllerSuite) TestNotAllowed(c *gc.C) {

--- a/cmd/juju/crossmodel/crossmodel.go
+++ b/cmd/juju/crossmodel/crossmodel.go
@@ -17,7 +17,7 @@ var logger = loggo.GetLogger("juju.cmd.juju.crossmodel")
 
 // CrossModelCommandBase is a base structure to get cross model managing client.
 type CrossModelCommandBase struct {
-	modelcmd.ModelCommandBase
+	modelcmd.ControllerCommandBase
 }
 
 // NewCrossModelAPI returns a cross model api for the root api endpoint

--- a/cmd/juju/crossmodel/export_test.go
+++ b/cmd/juju/crossmodel/export_test.go
@@ -23,26 +23,29 @@ func NewOfferCommandForTest(store jujuclient.ClientStore, api OfferAPI) cmd.Comm
 		return api, nil
 	}}
 	aCmd.SetClientStore(store)
-	return modelcmd.Wrap(aCmd)
+	return modelcmd.WrapController(aCmd)
 }
 
-func NewShowEndpointsCommandForTest(api ShowAPI) cmd.Command {
+func NewShowEndpointsCommandForTest(store jujuclient.ClientStore, api ShowAPI) cmd.Command {
 	aCmd := &showCommand{newAPIFunc: func() (ShowAPI, error) {
 		return api, nil
 	}}
-	return modelcmd.Wrap(aCmd)
+	aCmd.SetClientStore(store)
+	return modelcmd.WrapController(aCmd)
 }
 
-func NewListEndpointsCommandForTest(api ListAPI) cmd.Command {
+func NewListEndpointsCommandForTest(store jujuclient.ClientStore, api ListAPI) cmd.Command {
 	aCmd := &listCommand{newAPIFunc: func() (ListAPI, error) {
 		return api, nil
 	}}
-	return modelcmd.Wrap(aCmd)
+	aCmd.SetClientStore(store)
+	return modelcmd.WrapController(aCmd)
 }
 
-func NewFindEndpointsCommandForTest(api FindAPI) cmd.Command {
+func NewFindEndpointsCommandForTest(store jujuclient.ClientStore, api FindAPI) cmd.Command {
 	aCmd := &findCommand{newAPIFunc: func() (FindAPI, error) {
 		return api, nil
 	}}
-	return modelcmd.Wrap(aCmd)
+	aCmd.SetClientStore(store)
+	return modelcmd.WrapController(aCmd)
 }

--- a/cmd/juju/crossmodel/find.go
+++ b/cmd/juju/crossmodel/find.go
@@ -54,7 +54,7 @@ func NewFindEndpointsCommand() cmd.Command {
 	findCmd.newAPIFunc = func() (FindAPI, error) {
 		return findCmd.NewCrossModelAPI()
 	}
-	return modelcmd.Wrap(findCmd)
+	return modelcmd.WrapController(findCmd)
 }
 
 // Init implements Command.Init.

--- a/cmd/juju/crossmodel/find_test.go
+++ b/cmd/juju/crossmodel/find_test.go
@@ -34,7 +34,7 @@ func (s *findSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *findSuite) runFind(c *gc.C, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c, crossmodel.NewFindEndpointsCommandForTest(s.mockAPI), args...)
+	return testing.RunCommand(c, crossmodel.NewFindEndpointsCommandForTest(s.store, s.mockAPI), args...)
 }
 
 func (s *findSuite) TestFindNoArgs(c *gc.C) {

--- a/cmd/juju/crossmodel/list.go
+++ b/cmd/juju/crossmodel/list.go
@@ -68,7 +68,7 @@ func NewListEndpointsCommand() cmd.Command {
 	listCmd.newAPIFunc = func() (ListAPI, error) {
 		return listCmd.NewCrossModelAPI()
 	}
-	return modelcmd.Wrap(listCmd)
+	return modelcmd.WrapController(listCmd)
 }
 
 // Init implements Command.Init.
@@ -107,6 +107,9 @@ func (c *listCommand) Run(ctx *cmd.Context) (err error) {
 	}
 	defer api.Close()
 
+	if len(c.filters) == 0 {
+		c.filters = []crossmodel.OfferedApplicationFilter{{ApplicationURL: "local:"}}
+	}
 	// TODO (anastasiamac 2015-11-17) add input filters
 	offeredApplications, err := api.ListOffers(c.filters...)
 	if err != nil {
@@ -145,10 +148,10 @@ type ListAPI interface {
 // ListServiceItem defines the serialization behaviour of a service item in endpoints list.
 type ListServiceItem struct {
 	// CharmName is the charm name of this service.
-	CharmName string `yaml:"charm" json:"charm"`
+	CharmName string `yaml:"charm,omitempty" json:"charm,omitempty"`
 
 	// UsersCount is the count of how many users are connected to this shared service.
-	UsersCount int `yaml:"connected" json:"connected"`
+	UsersCount int `yaml:"connected,omitempty" json:"connected,omitempty"`
 
 	// Store is the name of the store which offers this shared service.
 	Store string `yaml:"store" json:"store"`

--- a/cmd/juju/crossmodel/list_test.go
+++ b/cmd/juju/crossmodel/list_test.go
@@ -124,7 +124,6 @@ func (s *ListSuite) TestListYAML(c *gc.C) {
 local:
   hosted-db2:
     charm: db2
-    connected: 0
     store: local
     url: /u/fred/hosted-db2
     endpoints:
@@ -147,7 +146,7 @@ func (s *ListSuite) createServiceItem(name, store string, count int) *model.Offe
 }
 
 func (s *ListSuite) runList(c *gc.C, args []string) (*cmd.Context, error) {
-	return testing.RunCommand(c, crossmodel.NewListEndpointsCommandForTest(s.mockAPI), args...)
+	return testing.RunCommand(c, crossmodel.NewListEndpointsCommandForTest(s.store, s.mockAPI), args...)
 }
 
 func (s *ListSuite) assertValidList(c *gc.C, args []string, expectedValid, expectedErr string) {

--- a/cmd/juju/crossmodel/package_test.go
+++ b/cmd/juju/crossmodel/package_test.go
@@ -8,6 +8,8 @@ import (
 
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	jujutesting "github.com/juju/juju/testing"
 )
 
@@ -17,4 +19,25 @@ func TestAll(t *testing.T) {
 
 type BaseCrossModelSuite struct {
 	jujutesting.BaseSuite
+
+	store *jujuclienttesting.MemStore
+}
+
+func (s *BaseCrossModelSuite) SetUpTest(c *gc.C) {
+	// Set up the current controller, and write just enough info
+	// so we don't try to refresh
+	controllerName := "test-master"
+	s.store = jujuclienttesting.NewMemStore()
+	s.store.CurrentControllerName = controllerName
+	s.store.Controllers[controllerName] = jujuclient.ControllerDetails{}
+	s.store.Models[controllerName] = &jujuclient.ControllerModels{
+		CurrentModel: "test",
+		Models: map[string]jujuclient.ModelDetails{
+			"bob/test": {"test-uuid"},
+			"bob/prod": {"prod-uuid"},
+		},
+	}
+	s.store.Accounts[controllerName] = jujuclient.AccountDetails{
+		User: "bob",
+	}
 }

--- a/cmd/juju/crossmodel/show.go
+++ b/cmd/juju/crossmodel/show.go
@@ -44,7 +44,7 @@ func NewShowOfferedEndpointCommand() cmd.Command {
 	showCmd.newAPIFunc = func() (ShowAPI, error) {
 		return showCmd.NewCrossModelAPI()
 	}
-	return modelcmd.Wrap(showCmd)
+	return modelcmd.WrapController(showCmd)
 }
 
 // Init implements Command.Init.

--- a/cmd/juju/crossmodel/show_test.go
+++ b/cmd/juju/crossmodel/show_test.go
@@ -32,7 +32,7 @@ func (s *showSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *showSuite) runShow(c *gc.C, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c, crossmodel.NewShowEndpointsCommandForTest(s.mockAPI), args...)
+	return testing.RunCommand(c, crossmodel.NewShowEndpointsCommandForTest(s.store, s.mockAPI), args...)
 }
 
 func (s *showSuite) TestShowNoUrl(c *gc.C) {

--- a/featuretests/cmd_juju_crossmodel_test.go
+++ b/featuretests/cmd_juju_crossmodel_test.go
@@ -10,61 +10,14 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 
-	"github.com/juju/juju/api"
-	apicrossmodel "github.com/juju/juju/api/crossmodel"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/crossmodel"
-	jujucrossmodel "github.com/juju/juju/core/crossmodel"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/testing/factory"
 )
 
 type crossmodelSuite struct {
 	jujutesting.JujuConnSuite
-}
-
-func (s *crossmodelSuite) TestOfferDefaultURL(c *gc.C) {
-	ch := s.AddTestingCharm(c, "riak")
-	s.AddTestingService(c, "riakservice", ch)
-
-	_, err := testing.RunCommand(c, crossmodel.NewOfferCommand(),
-		"riakservice:endpoint")
-	c.Assert(err, jc.ErrorIsNil)
-	offersApi := state.NewOfferedApplications(s.State)
-	offers, err := offersApi.ListOffers()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(offers, gc.HasLen, 1)
-	c.Assert(offers[0], jc.DeepEquals, jujucrossmodel.OfferedApplication{
-		ApplicationName: "riakservice",
-		ApplicationURL:  "local:/u/admin/controller/riakservice",
-		CharmName:       "riak",
-		Endpoints:       map[string]string{"endpoint": "endpoint"},
-		Description:     "Scalable K/V Store in Erlang with Clocks :-)",
-		Registered:      true,
-	})
-}
-
-func (s *crossmodelSuite) TestOffer(c *gc.C) {
-	ch := s.AddTestingCharm(c, "riak")
-	s.AddTestingService(c, "riakservice", ch)
-
-	_, err := testing.RunCommand(c, crossmodel.NewOfferCommand(),
-		"riakservice:endpoint,admin", "local:/u/me/service")
-	c.Assert(err, jc.ErrorIsNil)
-	offersApi := state.NewOfferedApplications(s.State)
-	offers, err := offersApi.ListOffers()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(offers, gc.HasLen, 1)
-	c.Assert(offers[0], jc.DeepEquals, jujucrossmodel.OfferedApplication{
-		ApplicationName: "riakservice",
-		ApplicationURL:  "local:/u/me/service",
-		CharmName:       "riak",
-		Endpoints:       map[string]string{"admin": "admin", "endpoint": "endpoint"},
-		Description:     "Scalable K/V Store in Erlang with Clocks :-)",
-		Registered:      true,
-	})
 }
 
 func (s *crossmodelSuite) TestListEndpoints(c *gc.C) {
@@ -87,8 +40,6 @@ func (s *crossmodelSuite) TestListEndpoints(c *gc.C) {
 	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, `
 local:
   riak:
-    charm: riak
-    connected: 0
     store: local
     url: /u/me/riak
     endpoints:
@@ -96,8 +47,6 @@ local:
         interface: http
         role: provider
   varnish:
-    charm: varnish
-    connected: 0
     store: local
     url: /u/me/varnish
     endpoints:
@@ -105,44 +54,6 @@ local:
         interface: varnish
         role: provider
 `[1:])
-}
-
-func (s *crossmodelSuite) TestLocalURLOtherEnvironment(c *gc.C) {
-	ch := s.AddTestingCharm(c, "riak")
-	s.AddTestingService(c, "riakservice", ch)
-	_, err := testing.RunCommand(c, crossmodel.NewOfferCommand(),
-		"riakservice:endpoint", "local:/u/me/riak")
-	c.Assert(err, jc.ErrorIsNil)
-
-	user := s.Factory.MakeUser(c, &factory.UserParams{
-		NoModelUser: true,
-		Password:    "super-secret",
-	})
-	otherState := s.Factory.MakeModel(c, &factory.ModelParams{
-		Name: "first", Owner: user.Tag()})
-	defer otherState.Close()
-
-	info := s.APIInfo(c)
-	info.ModelTag = otherState.ModelTag()
-	info.Tag = user.Tag()
-	info.Password = "super-secret"
-	otherAPIState, err := api.Open(info, api.DefaultDialOpts())
-	c.Assert(err, jc.ErrorIsNil)
-	defer otherAPIState.Close()
-
-	apiClient := apicrossmodel.NewClient(otherAPIState)
-	offer, err := apiClient.ApplicationOffer("local:/u/me/riak")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(offer, jc.DeepEquals, params.ApplicationOffer{
-		ApplicationURL:         "local:/u/me/riak",
-		SourceModelTag:         "model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
-		SourceLabel:            "controller",
-		ApplicationName:        "riakservice",
-		ApplicationDescription: "Scalable K/V Store in Erlang with Clocks :-)",
-		Endpoints: []params.RemoteEndpoint{
-			{Name: "endpoint", Role: "provider", Interface: "http", Scope: "global"},
-		},
-	})
 }
 
 func (s *crossmodelSuite) TestShow(c *gc.C) {


### PR DESCRIPTION
The main purpose here is to move some of the cross model facades to controller facades.
There's a bunch of followup work to be done to move from what was implemented originally to the latest spec. Part of that is done my necessity here. eg remove AllowedUsers from some structs; also start removing code to show offered applications as these will be removed. These changes are only visible with cross-model-relations feature flag.

QA: bootstrap with feature flag, deploy and offer a service, list and show endpoints