### PR TITLE
Add Prometheus monitoring to agents

### DIFF
--- a/apiserver/observer/metricobserver/config_test.go
+++ b/apiserver/observer/metricobserver/config_test.go
@@ -1,0 +1,41 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package metricobserver_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
+	"github.com/prometheus/client_golang/prometheus"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/observer/metricobserver"
+)
+
+type configSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&configSuite{})
+
+func (*configSuite) TestValidateValid(c *gc.C) {
+	cfg := metricobserver.Config{
+		Clock:                clock.WallClock,
+		PrometheusRegisterer: prometheus.NewRegistry(),
+	}
+	err := cfg.Validate()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (*configSuite) TestValidateInvalid(c *gc.C) {
+	assertConfigInvalid(c, metricobserver.Config{}, "nil Clock not valid")
+	assertConfigInvalid(c, metricobserver.Config{
+		Clock: clock.WallClock,
+	}, "nil PrometheusRegisterer not valid")
+}
+
+func assertConfigInvalid(c *gc.C, cfg metricobserver.Config, expect string) {
+	err := cfg.Validate()
+	c.Assert(err, gc.ErrorMatches, expect)
+}

--- a/apiserver/observer/metricobserver/doc.go
+++ b/apiserver/observer/metricobserver/doc.go
@@ -1,0 +1,7 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package metricobserver provides an implementation
+// of apiserver/observer.ObserverFactory that maintains
+// Prometheus metrics.
+package metricobserver

--- a/apiserver/observer/metricobserver/metricobserver.go
+++ b/apiserver/observer/metricobserver/metricobserver.go
@@ -1,0 +1,150 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package metricobserver
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/clock"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/juju/juju/apiserver/observer"
+	"github.com/juju/juju/rpc"
+)
+
+const (
+	facadeLabel    = "facade"
+	versionLabel   = "version"
+	methodLabel    = "method"
+	errorCodeLabel = "error_code"
+)
+
+var metricLabelNames = []string{
+	facadeLabel,
+	versionLabel,
+	methodLabel,
+	errorCodeLabel,
+}
+
+// Config contains the configuration for a Observer.
+type Config struct {
+	// Clock is the clock to use for all time-related operations.
+	Clock clock.Clock
+
+	// PrometheusRegisterer is the prometheus.Registerer in which metric
+	// collectors will be registered.
+	PrometheusRegisterer prometheus.Registerer
+}
+
+// Validate validates the observer factory configuration.
+func (cfg Config) Validate() error {
+	if cfg.Clock == nil {
+		return errors.NotValidf("nil Clock")
+	}
+	if cfg.PrometheusRegisterer == nil {
+		return errors.NotValidf("nil PrometheusRegisterer")
+	}
+	return nil
+}
+
+// NewObserverFactory returns a function that, when called, returns a new
+// Observer. NewObserverFactory registers the API request metrics, and
+// each Observer updates those metrics.
+func NewObserverFactory(config Config) (observer.ObserverFactory, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Annotate(err, "validating config")
+	}
+
+	apiRequestsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "juju",
+		Subsystem: "api",
+		Name:      "requests_total",
+		Help:      "Number of Juju API requests served.",
+	}, metricLabelNames)
+
+	apiRequestDuration := prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Namespace: "juju",
+		Subsystem: "api",
+		Name:      "request_duration_seconds",
+		Help:      "Latency of Juju API requests in seconds.",
+	}, metricLabelNames)
+
+	if err := config.PrometheusRegisterer.Register(apiRequestsTotal); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := config.PrometheusRegisterer.Register(apiRequestDuration); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Observer is currently stateless, so we return the same one for each
+	// API connection. Individual RPC requests still get their own RPC
+	// observers.
+	o := &Observer{
+		clock: config.Clock,
+		metrics: metrics{
+			apiRequestDuration: apiRequestDuration,
+			apiRequestsTotal:   apiRequestsTotal,
+		},
+	}
+	return func() observer.Observer {
+		return o
+	}, nil
+}
+
+// Observer is an API server request observer that collects Prometheus metrics.
+type Observer struct {
+	clock   clock.Clock
+	metrics metrics
+}
+
+type metrics struct {
+	apiRequestDuration *prometheus.SummaryVec
+	apiRequestsTotal   *prometheus.CounterVec
+}
+
+// Login is part of the observer.Observer interface.
+func (*Observer) Login(entity names.Tag, _ names.ModelTag, _ bool, _ string) {}
+
+// Join is part of the observer.Observer interface.
+func (*Observer) Join(req *http.Request, connectionID uint64) {}
+
+// Leave is part of the observer.Observer interface.
+func (*Observer) Leave() {}
+
+// RPCObserver is part of the observer.Observer interface.
+func (o *Observer) RPCObserver() rpc.Observer {
+	return &rpcObserver{
+		clock:   o.clock,
+		metrics: o.metrics,
+	}
+}
+
+type rpcObserver struct {
+	clock        clock.Clock
+	metrics      metrics
+	requestStart time.Time
+}
+
+// ServerRequest is part of the rpc.Observer interface.
+func (o *rpcObserver) ServerRequest(hdr *rpc.Header, body interface{}) {
+	o.requestStart = o.clock.Now()
+}
+
+// ServerReply is part of the rpc.Observer interface.
+func (o *rpcObserver) ServerReply(req rpc.Request, hdr *rpc.Header, body interface{}) {
+	labels := prometheus.Labels{
+		facadeLabel:    req.Type,
+		versionLabel:   strconv.Itoa(req.Version),
+		methodLabel:    req.Action,
+		errorCodeLabel: hdr.ErrorCode,
+	}
+	duration := o.clock.Now().Sub(o.requestStart)
+	o.metrics.apiRequestDuration.With(labels).Observe(duration.Seconds())
+	o.metrics.apiRequestsTotal.With(labels).Inc()
+}

--- a/apiserver/observer/metricobserver/metricobserver.go
+++ b/apiserver/observer/metricobserver/metricobserver.go
@@ -32,7 +32,7 @@ var metricLabelNames = []string{
 	errorCodeLabel,
 }
 
-// Config contains the configuration for a Observer.
+// Config contains the configuration for an Observer.
 type Config struct {
 	// Clock is the clock to use for all time-related operations.
 	Clock clock.Clock

--- a/apiserver/observer/metricobserver/observer_test.go
+++ b/apiserver/observer/metricobserver/observer_test.go
@@ -1,0 +1,122 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package metricobserver_test
+
+import (
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/observer"
+	"github.com/juju/juju/apiserver/observer/metricobserver"
+	"github.com/juju/juju/rpc"
+)
+
+type observerSuite struct {
+	testing.IsolationSuite
+	clock    *testing.Clock
+	registry *prometheus.Registry
+	factory  observer.ObserverFactory
+}
+
+var _ = gc.Suite(&observerSuite{})
+
+func (s *observerSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.clock = testing.NewClock(time.Time{})
+	s.registry = prometheus.NewPedanticRegistry()
+
+	var err error
+	s.factory, err = metricobserver.NewObserverFactory(metricobserver.Config{
+		Clock:                s.clock,
+		PrometheusRegisterer: s.registry,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *observerSuite) TestObserver(c *gc.C) {
+	o := s.factory()
+	c.Assert(o, gc.NotNil)
+}
+
+func (s *observerSuite) TestRPCObserver(c *gc.C) {
+	o := s.factory().RPCObserver()
+	c.Assert(o, gc.NotNil)
+
+	latencies := []time.Duration{
+		1000 * time.Millisecond,
+		1500 * time.Millisecond,
+		2000 * time.Millisecond,
+	}
+	for _, latency := range latencies {
+		req := rpc.Request{
+			Type:    "api-facade",
+			Version: 42,
+			Action:  "api-method",
+		}
+		o.ServerRequest(&rpc.Header{Request: req}, nil)
+		s.clock.Advance(latency)
+		o.ServerReply(req, &rpc.Header{ErrorCode: "badness"}, nil)
+	}
+
+	stringptr := func(s string) *string {
+		return &s
+	}
+	metricTypePtr := func(t dto.MetricType) *dto.MetricType {
+		return &t
+	}
+	float64ptr := func(f float64) *float64 {
+		return &f
+	}
+	uint64ptr := func(u uint64) *uint64 {
+		return &u
+	}
+
+	labels := []*dto.LabelPair{
+		{stringptr("error_code"), stringptr("badness"), nil},
+		{stringptr("facade"), stringptr("api-facade"), nil},
+		{stringptr("method"), stringptr("api-method"), nil},
+		{stringptr("version"), stringptr("42"), nil},
+	}
+
+	metricFamilies, err := s.registry.Gather()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metricFamilies, gc.HasLen, 2)
+	c.Assert(metricFamilies, jc.DeepEquals, []*dto.MetricFamily{{
+		Name: stringptr("juju_api_request_duration_seconds"),
+		Help: stringptr("Latency of Juju API requests in seconds."),
+		Type: metricTypePtr(dto.MetricType_SUMMARY),
+		Metric: []*dto.Metric{{
+			Label: labels,
+			Summary: &dto.Summary{
+				SampleCount: uint64ptr(3),
+				SampleSum:   float64ptr(4.5),
+				Quantile: []*dto.Quantile{{
+					Quantile: float64ptr(0.5),
+					Value:    float64ptr(1),
+				}, {
+					Quantile: float64ptr(0.9),
+					Value:    float64ptr(1.5),
+				}, {
+					Quantile: float64ptr(0.99),
+					Value:    float64ptr(1.5),
+				}},
+			},
+		}},
+	}, {
+		Name: stringptr("juju_api_requests_total"),
+		Help: stringptr("Number of Juju API requests served."),
+		Type: metricTypePtr(dto.MetricType_COUNTER),
+		Metric: []*dto.Metric{{
+			Label: labels,
+			Counter: &dto.Counter{
+				Value: float64ptr(3),
+			},
+		}},
+	}})
+}

--- a/apiserver/observer/metricobserver/observerfactory_test.go
+++ b/apiserver/observer/metricobserver/observerfactory_test.go
@@ -1,0 +1,64 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package metricobserver_test
+
+import (
+	"errors"
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/prometheus/client_golang/prometheus"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/observer/metricobserver"
+)
+
+type observerFactorySuite struct {
+	testing.IsolationSuite
+	clock      *testing.Clock
+	registerer fakePrometheusRegisterer
+}
+
+var _ = gc.Suite(&observerFactorySuite{})
+
+func (s *observerFactorySuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.clock = testing.NewClock(time.Time{})
+	s.registerer = fakePrometheusRegisterer{}
+}
+
+func (*observerFactorySuite) TestNewObserverFactoryInvalidConfig(c *gc.C) {
+	_, err := metricobserver.NewObserverFactory(metricobserver.Config{})
+	c.Assert(err, gc.ErrorMatches, "validating config: nil Clock not valid")
+}
+
+func (s *observerFactorySuite) TestNewObserverFactoryRegisterError(c *gc.C) {
+	s.registerer.SetErrors(errors.New("oy vey"))
+	_, err := metricobserver.NewObserverFactory(metricobserver.Config{
+		Clock:                s.clock,
+		PrometheusRegisterer: &s.registerer,
+	})
+	c.Assert(err, gc.ErrorMatches, "oy vey")
+}
+
+func (s *observerFactorySuite) TestNewObserverFactoryRegister(c *gc.C) {
+	f, err := metricobserver.NewObserverFactory(metricobserver.Config{
+		Clock:                s.clock,
+		PrometheusRegisterer: &s.registerer,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(f, gc.NotNil)
+	s.registerer.CheckCallNames(c, "Register", "Register")
+}
+
+type fakePrometheusRegisterer struct {
+	prometheus.Registerer
+	testing.Stub
+}
+
+func (r *fakePrometheusRegisterer) Register(c prometheus.Collector) error {
+	r.MethodCall(r, "Register", c)
+	return r.NextErr()
+}

--- a/apiserver/observer/metricobserver/package_test.go
+++ b/apiserver/observer/metricobserver/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package metricobserver_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/cmd/jujud/agent/introspection.go
+++ b/cmd/jujud/agent/introspection.go
@@ -71,9 +71,13 @@ func startIntrospection(cfg introspectionConfig) error {
 // the Go and process metric collectors registered. This registry
 // is exposed by the introspection abstract domain socket on all
 // Linux agents.
-func newPrometheusRegistry() *prometheus.Registry {
+func newPrometheusRegistry() (*prometheus.Registry, error) {
 	r := prometheus.NewRegistry()
-	r.MustRegister(prometheus.NewGoCollector())
-	r.MustRegister(prometheus.NewProcessCollector(os.Getpid(), ""))
-	return r
+	if err := r.Register(prometheus.NewGoCollector()); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := r.Register(prometheus.NewProcessCollector(os.Getpid(), "")); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return r, nil
 }

--- a/cmd/jujud/agent/introspection.go
+++ b/cmd/jujud/agent/introspection.go
@@ -4,9 +4,13 @@
 package agent
 
 import (
+	"os"
 	"runtime"
 
+	names "gopkg.in/juju/names.v2"
+
 	"github.com/juju/errors"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/worker"
@@ -14,12 +18,21 @@ import (
 	"github.com/juju/juju/worker/introspection"
 )
 
+// DefaultIntrospectionSocketName returns the socket name to use for the
+// abstract domain socket that the introspection worker serves requests
+// over.
+func DefaultIntrospectionSocketName(entityTag names.Tag) string {
+	return "jujud-" + entityTag.String()
+}
+
 // introspectionConfig defines the various components that the introspection
 // worker reports on or needs to start up.
 type introspectionConfig struct {
-	Agent      agent.Agent
-	Engine     *dependency.Engine
-	WorkerFunc func(config introspection.Config) (worker.Worker, error)
+	Agent              agent.Agent
+	Engine             *dependency.Engine
+	PrometheusGatherer prometheus.Gatherer
+	NewSocketName      func(names.Tag) string
+	WorkerFunc         func(config introspection.Config) (worker.Worker, error)
 }
 
 // startIntrospection creates the introspection worker. It cannot and should
@@ -34,10 +47,11 @@ func startIntrospection(cfg introspectionConfig) error {
 		return nil
 	}
 
-	socketName := "jujud-" + cfg.Agent.CurrentConfig().Tag().String()
+	socketName := cfg.NewSocketName(cfg.Agent.CurrentConfig().Tag())
 	w, err := cfg.WorkerFunc(introspection.Config{
-		SocketName: socketName,
-		Reporter:   cfg.Engine,
+		SocketName:         socketName,
+		Reporter:           cfg.Engine,
+		PrometheusGatherer: cfg.PrometheusGatherer,
 	})
 	if err != nil {
 		return errors.Trace(err)
@@ -51,4 +65,15 @@ func startIntrospection(cfg introspectionConfig) error {
 	}()
 
 	return nil
+}
+
+// newPrometheusRegistry returns a new prometheus.Registry with
+// the Go and process metric collectors registered. This registry
+// is exposed by the introspection abstract domain socket on all
+// Linux agents.
+func newPrometheusRegistry() *prometheus.Registry {
+	r := prometheus.NewRegistry()
+	r.MustRegister(prometheus.NewGoCollector())
+	r.MustRegister(prometheus.NewProcessCollector(os.Getpid(), ""))
+	return r
 }

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/proxy"
 	"github.com/juju/utils/voyeur"
+	"github.com/prometheus/client_golang/prometheus"
 
 	coreagent "github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
@@ -126,6 +127,10 @@ type ManifoldsConfig struct {
 	// migration process to check that the agent will be ok when
 	// connected to the new target controller.
 	ValidateMigration func(base.APICaller) error
+
+	// PrometheusRegisterer is a prometheus.Registerer that may be used
+	// by workers to register Prometheus metric collectors.
+	PrometheusRegisterer prometheus.Registerer
 }
 
 // Manifolds returns a set of co-configured manifolds covering the

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -100,9 +100,10 @@ func (s *MachineSuite) TestParseUnknown(c *gc.C) {
 func (s *MachineSuite) TestParseSuccess(c *gc.C) {
 	create := func() (cmd.Command, AgentConf) {
 		agentConf := agentConf{dataDir: s.DataDir()}
+		logger := s.newBufferedLogWriter()
 		a := NewMachineAgentCmd(
 			nil,
-			NewTestMachineAgentFactory(&agentConf, nil, c.MkDir()),
+			NewTestMachineAgentFactory(&agentConf, logger, c.MkDir()),
 			&agentConf,
 			&agentConf,
 		)
@@ -124,10 +125,11 @@ func (s *MachineSuite) TestRunInvalidMachineId(c *gc.C) {
 func (s *MachineSuite) TestUseLumberjack(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	agentConf := FakeAgentConfig{}
+	logger := s.newBufferedLogWriter()
 
 	a := NewMachineAgentCmd(
 		ctx,
-		NewTestMachineAgentFactory(&agentConf, nil, c.MkDir()),
+		NewTestMachineAgentFactory(&agentConf, logger, c.MkDir()),
 		agentConf,
 		agentConf,
 	)
@@ -148,10 +150,11 @@ func (s *MachineSuite) TestUseLumberjack(c *gc.C) {
 func (s *MachineSuite) TestDontUseLumberjack(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	agentConf := FakeAgentConfig{}
+	logger := s.newBufferedLogWriter()
 
 	a := NewMachineAgentCmd(
 		ctx,
-		NewTestMachineAgentFactory(&agentConf, nil, c.MkDir()),
+		NewTestMachineAgentFactory(&agentConf, logger, c.MkDir()),
 		agentConf,
 		agentConf,
 	)

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -60,15 +60,19 @@ type UnitAgent struct {
 }
 
 // NewUnitAgent creates a new UnitAgent value properly initialized.
-func NewUnitAgent(ctx *cmd.Context, bufferedLogger *logsender.BufferedLogWriter) *UnitAgent {
+func NewUnitAgent(ctx *cmd.Context, bufferedLogger *logsender.BufferedLogWriter) (*UnitAgent, error) {
+	prometheusRegistry, err := newPrometheusRegistry()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return &UnitAgent{
 		AgentConf:        NewAgentConf(""),
 		configChangedVal: voyeur.NewValue(true),
 		ctx:              ctx,
 		initialUpgradeCheckComplete: make(chan struct{}),
 		bufferedLogger:              bufferedLogger,
-		prometheusRegistry:          newPrometheusRegistry(),
-	}
+		prometheusRegistry:          prometheusRegistry,
+	}, nil
 }
 
 // Info returns usage information for the command.

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/voyeur"
+	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/natefinch/lumberjack.v2"
 	"gopkg.in/tomb.v1"
@@ -44,7 +45,7 @@ type UnitAgent struct {
 	configChangedVal *voyeur.Value
 	UnitName         string
 	runner           worker.Runner
-	bufferedLogs     logsender.LogRecordCh
+	bufferedLogger   *logsender.BufferedLogWriter
 	setupLogging     func(agent.Config) error
 	logToStdErr      bool
 	ctx              *cmd.Context
@@ -54,16 +55,19 @@ type UnitAgent struct {
 	// longer any immediately pending agent upgrades.
 	// Channel used as a selectable bool (closed means true).
 	initialUpgradeCheckComplete chan struct{}
+
+	prometheusRegistry *prometheus.Registry
 }
 
 // NewUnitAgent creates a new UnitAgent value properly initialized.
-func NewUnitAgent(ctx *cmd.Context, bufferedLogs logsender.LogRecordCh) *UnitAgent {
+func NewUnitAgent(ctx *cmd.Context, bufferedLogger *logsender.BufferedLogWriter) *UnitAgent {
 	return &UnitAgent{
 		AgentConf:        NewAgentConf(""),
 		configChangedVal: voyeur.NewValue(true),
 		ctx:              ctx,
 		initialUpgradeCheckComplete: make(chan struct{}),
-		bufferedLogs:                bufferedLogs,
+		bufferedLogger:              bufferedLogger,
+		prometheusRegistry:          newPrometheusRegistry(),
 	}
 }
 
@@ -138,11 +142,12 @@ func (a *UnitAgent) Run(ctx *cmd.Context) error {
 // APIWorkers returns a dependency.Engine running the unit agent's responsibilities.
 func (a *UnitAgent) APIWorkers() (worker.Worker, error) {
 	manifolds := unitManifolds(unit.ManifoldsConfig{
-		Agent:               agent.APIHostPortsSetter{a},
-		LogSource:           a.bufferedLogs,
-		LeadershipGuarantee: 30 * time.Second,
-		AgentConfigChanged:  a.configChangedVal,
-		ValidateMigration:   a.validateMigration,
+		Agent:                agent.APIHostPortsSetter{a},
+		LogSource:            a.bufferedLogger.Logs(),
+		LeadershipGuarantee:  30 * time.Second,
+		AgentConfigChanged:   a.configChangedVal,
+		ValidateMigration:    a.validateMigration,
+		PrometheusRegisterer: a.prometheusRegistry,
 	})
 
 	config := dependency.EngineConfig{
@@ -162,9 +167,11 @@ func (a *UnitAgent) APIWorkers() (worker.Worker, error) {
 		return nil, err
 	}
 	if err := startIntrospection(introspectionConfig{
-		Agent:      a,
-		Engine:     engine,
-		WorkerFunc: introspection.NewWorker,
+		Agent:              a,
+		Engine:             engine,
+		NewSocketName:      DefaultIntrospectionSocketName,
+		PrometheusGatherer: a.prometheusRegistry,
+		WorkerFunc:         introspection.NewWorker,
 	}); err != nil {
 		// If the introspection worker failed to start, we just log error
 		// but continue. It is very unlikely to happen in the real world

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/clock"
 	"github.com/juju/utils/voyeur"
+	"github.com/prometheus/client_golang/prometheus"
 
 	coreagent "github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
@@ -58,6 +59,10 @@ type ManifoldsConfig struct {
 	// migration process to check that the agent will be ok when
 	// connected to the new target controller.
 	ValidateMigration func(base.APICaller) error
+
+	// PrometheusRegisterer is a prometheus.Registerer that may be used
+	// by workers to register Prometheus metric collectors.
+	PrometheusRegisterer prometheus.Registerer
 }
 
 // Manifolds returns a set of co-configured manifolds covering the various

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -78,9 +78,10 @@ func (s *UnitSuite) primeAgent(c *gc.C) (*state.Machine, *state.Unit, agent.Conf
 }
 
 func (s *UnitSuite) newAgent(c *gc.C, unit *state.Unit) *UnitAgent {
-	a := NewUnitAgent(nil, s.newBufferedLogWriter())
+	a, err := NewUnitAgent(nil, s.newBufferedLogWriter())
+	c.Assert(err, jc.ErrorIsNil)
 	s.InitAgent(c, a, "--unit-name", unit.Name(), "--log-to-stderr=true")
-	err := a.ReadConfig(unit.Tag().String())
+	err = a.ReadConfig(unit.Tag().String())
 	c.Assert(err, jc.ErrorIsNil)
 	return a
 }
@@ -92,21 +93,22 @@ func (s *UnitSuite) newBufferedLogWriter() *logsender.BufferedLogWriter {
 }
 
 func (s *UnitSuite) TestParseSuccess(c *gc.C) {
-	a := NewUnitAgent(nil, s.newBufferedLogWriter())
-	err := coretesting.InitCommand(a, []string{
+	a, err := NewUnitAgent(nil, s.newBufferedLogWriter())
+	c.Assert(err, jc.ErrorIsNil)
+	err = coretesting.InitCommand(a, []string{
 		"--data-dir", "jd",
 		"--unit-name", "w0rd-pre55/1",
 		"--log-to-stderr",
 	})
-
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Check(a.AgentConf.DataDir(), gc.Equals, "jd")
 	c.Check(a.UnitName, gc.Equals, "w0rd-pre55/1")
 }
 
 func (s *UnitSuite) TestParseMissing(c *gc.C) {
-	uc := NewUnitAgent(nil, s.newBufferedLogWriter())
-	err := coretesting.InitCommand(uc, []string{
+	uc, err := NewUnitAgent(nil, s.newBufferedLogWriter())
+	c.Assert(err, jc.ErrorIsNil)
+	err = coretesting.InitCommand(uc, []string{
 		"--data-dir", "jc",
 	})
 
@@ -121,15 +123,19 @@ func (s *UnitSuite) TestParseNonsense(c *gc.C) {
 		{"--unit-name", "wordpress/wild/9"},
 		{"--unit-name", "20/20"},
 	} {
-		a := NewUnitAgent(nil, s.newBufferedLogWriter())
-		err := coretesting.InitCommand(a, append(args, "--data-dir", "jc"))
+		a, err := NewUnitAgent(nil, s.newBufferedLogWriter())
+		c.Assert(err, jc.ErrorIsNil)
+
+		err = coretesting.InitCommand(a, append(args, "--data-dir", "jc"))
 		c.Check(err, gc.ErrorMatches, `--unit-name option expects "<service>/<n>" argument`)
 	}
 }
 
 func (s *UnitSuite) TestParseUnknown(c *gc.C) {
-	a := NewUnitAgent(nil, s.newBufferedLogWriter())
-	err := coretesting.InitCommand(a, []string{
+	a, err := NewUnitAgent(nil, s.newBufferedLogWriter())
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = coretesting.InitCommand(a, []string{
 		"--unit-name", "wordpress/1",
 		"thundering typhoons",
 	})
@@ -412,7 +418,8 @@ func (s *UnitSuite) TestWorkers(c *gc.C) {
 
 	_, unit, _, _ := s.primeAgent(c)
 	ctx := cmdtesting.Context(c)
-	a := NewUnitAgent(ctx, s.newBufferedLogWriter())
+	a, err := NewUnitAgent(ctx, s.newBufferedLogWriter())
+	c.Assert(err, jc.ErrorIsNil)
 	s.InitAgent(c, a, "--unit-name", unit.Name())
 
 	go func() { c.Check(a.Run(nil), gc.IsNil) }()

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -195,8 +195,8 @@ func NewTestMachineAgentFactory(
 	agentConfWriter AgentConfigWriter,
 	bufferedLogger *logsender.BufferedLogWriter,
 	rootDir string,
-) func(string) *MachineAgent {
-	return func(machineId string) *MachineAgent {
+) func(string) (*MachineAgent, error) {
+	return func(machineId string) (*MachineAgent, error) {
 		return NewMachineAgent(
 			machineId,
 			agentConfWriter,
@@ -215,7 +215,9 @@ func (s *commonMachineSuite) newAgent(c *gc.C, m *state.Machine) *MachineAgent {
 	agentConf.ReadConfig(names.NewMachineTag(m.Id()).String())
 	logger := s.newBufferedLogWriter()
 	machineAgentFactory := NewTestMachineAgentFactory(&agentConf, logger, c.MkDir())
-	return machineAgentFactory(m.Id())
+	machineAgent, err := machineAgentFactory(m.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	return machineAgent
 }
 
 func (s *commonMachineSuite) newBufferedLogWriter() *logsender.BufferedLogWriter {

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -160,7 +160,11 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 	)
 	jujud.Register(agentcmd.NewMachineAgentCmd(ctx, machineAgentFactory, agentConf, agentConf))
 
-	jujud.Register(agentcmd.NewUnitAgent(ctx, bufferedLogger))
+	unitAgent, err := agentcmd.NewUnitAgent(ctx, bufferedLogger)
+	if err != nil {
+		return -1, errors.Trace(err)
+	}
+	jujud.Register(unitAgent)
 
 	jujud.Register(NewUpgradeMongoCommand())
 

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -57,7 +57,7 @@ github.com/mattn/go-colorable	git	ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8	2016-
 github.com/mattn/go-isatty	git	66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8	2016-08-06T12:27:52Z
 github.com/mattn/go-runewidth	git	d96d1bd051f2bd9e7e43d602782b37b93b1b5666	2015-11-18T07:21:59Z
 github.com/matttproud/golang_protobuf_extensions	git	c12348ce28de40eed0136aa2b644d0ee0650e56c	2016-04-24T11:30:07Z
-github.com/prometheus/client_golang	git	b90ee0840e8e7dfb84c08d13b9c4f3a794586a21	2016-05-13T04:20:11Z
+github.com/prometheus/client_golang	git	c5b7fccd204277076155f10851dad72b76a49317	2016-08-17T15:48:24Z
 github.com/prometheus/client_model	git	fa8ad6fec33561be4280a8f0514318c79d7f6cb6	2015-02-12T10:17:44Z
 github.com/prometheus/common	git	dd586c1c5abb0be59e60f942c22af711a2008cb4	2016-05-03T22:05:32Z
 github.com/prometheus/procfs	git	abf152e5f3e97f2fafac028d2cc06c1feb87ffa5	2016-04-11T19:08:41Z

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -64,7 +64,8 @@ func (s *dblogSuite) runMachineAgentTest(c *gc.C) bool {
 		agentcmd.DefaultIntrospectionSocketName,
 		c.MkDir(),
 	)
-	a := machineAgentFactory(m.Id())
+	a, err := machineAgentFactory(m.Id())
+	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure there's no logs to begin with.
 	c.Assert(s.getLogCount(c, m.Tag()), gc.Equals, 0)
@@ -82,7 +83,8 @@ func (s *dblogSuite) runUnitAgentTest(c *gc.C) bool {
 	s.PrimeAgent(c, u.Tag(), password)
 	logger, err := logsender.InstallBufferedLogWriter(1000)
 	c.Assert(err, jc.ErrorIsNil)
-	a := agentcmd.NewUnitAgent(nil, logger)
+	a, err := agentcmd.NewUnitAgent(nil, logger)
+	c.Assert(err, jc.ErrorIsNil)
 	s.InitAgent(c, a, "--unit-name", u.Name(), "--log-to-stderr=true")
 
 	// Ensure there's no logs to begin with.

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -56,9 +56,14 @@ func (s *dblogSuite) runMachineAgentTest(c *gc.C) bool {
 	s.PrimeAgent(c, m.Tag(), password)
 	agentConf := agentcmd.NewAgentConf(s.DataDir())
 	agentConf.ReadConfig(m.Tag().String())
-	logsCh, err := logsender.InstallBufferedLogWriter(1000)
+	logger, err := logsender.InstallBufferedLogWriter(1000)
 	c.Assert(err, jc.ErrorIsNil)
-	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, logsCh, c.MkDir())
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(
+		agentConf,
+		logger,
+		agentcmd.DefaultIntrospectionSocketName,
+		c.MkDir(),
+	)
 	a := machineAgentFactory(m.Id())
 
 	// Ensure there's no logs to begin with.
@@ -75,9 +80,9 @@ func (s *dblogSuite) runUnitAgentTest(c *gc.C) bool {
 	// Create a unit and an agent for it.
 	u, password := s.Factory.MakeUnitReturningPassword(c, nil)
 	s.PrimeAgent(c, u.Tag(), password)
-	logsCh, err := logsender.InstallBufferedLogWriter(1000)
+	logger, err := logsender.InstallBufferedLogWriter(1000)
 	c.Assert(err, jc.ErrorIsNil)
-	a := agentcmd.NewUnitAgent(nil, logsCh)
+	a := agentcmd.NewUnitAgent(nil, logger)
 	s.InitAgent(c, a, "--unit-name", u.Name(), "--log-to-stderr=true")
 
 	// Ensure there's no logs to begin with.

--- a/featuretests/introspection_test.go
+++ b/featuretests/introspection_test.go
@@ -1,0 +1,122 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"runtime"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	names "gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/agent"
+	agentcmd "github.com/juju/juju/cmd/jujud/agent"
+	"github.com/juju/juju/cmd/jujud/agent/agenttest"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
+	"github.com/juju/juju/worker/logsender"
+)
+
+type introspectionSuite struct {
+	agenttest.AgentSuite
+	logger *logsender.BufferedLogWriter
+}
+
+var _ = gc.Suite(&introspectionSuite{})
+
+func (s *introspectionSuite) SetUpSuite(c *gc.C) {
+	s.AgentSuite.SetUpSuite(c)
+	if runtime.GOOS != "linux" {
+		c.Skip(fmt.Sprintf("the introspection worker does not support %q", runtime.GOOS))
+	}
+}
+
+func (s *introspectionSuite) SetUpTest(c *gc.C) {
+	s.AgentSuite.SetUpTest(c)
+
+	var err error
+	s.logger, err = logsender.InstallBufferedLogWriter(1000)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		err := logsender.UninstallBufferedLogWriter()
+		c.Assert(err, jc.ErrorIsNil)
+	})
+}
+
+// startMachineAgent starts a machine agent and returns the path
+// of its unix socket.
+func (s *introspectionSuite) startMachineAgent(c *gc.C) (*agentcmd.MachineAgent, string) {
+	// Create a machine and an agent for it.
+	m, password := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{
+		Nonce: agent.BootstrapNonce,
+	})
+
+	s.PrimeAgent(c, m.Tag(), password)
+	agentConf := agentcmd.NewAgentConf(s.DataDir())
+	agentConf.ReadConfig(m.Tag().String())
+
+	rootDir := c.MkDir()
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(
+		agentConf,
+		s.logger,
+		func(names.Tag) string { return rootDir },
+		rootDir,
+	)
+	a := machineAgentFactory(m.Id())
+
+	// Start the agent.
+	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
+
+	// Wait for the agent to start serving on the introspection socket.
+	var conn net.Conn
+	for a := testing.LongAttempt.Start(); a.Next(); {
+		var err error
+		conn, err = net.Dial("unix", "@"+rootDir)
+		if err == nil {
+			break
+		}
+	}
+	if conn == nil {
+		a.Stop()
+		c.Fatal("timed out waiting for introspection socket")
+	}
+	conn.Close()
+	return a, "@" + rootDir
+}
+
+func unixSocketHTTPClient(socketPath string) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Dial: func(proto, addr string) (net.Conn, error) {
+				return net.Dial("unix", socketPath)
+			},
+		},
+	}
+}
+
+func (s *introspectionSuite) TestPrometheusMetrics(c *gc.C) {
+	a, socketPath := s.startMachineAgent(c)
+	defer a.Stop()
+	client := unixSocketHTTPClient(socketPath)
+
+	resp, err := client.Get("http://unix.socket/metrics")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(body), jc.Contains, "juju_logsender_capacity 1000")
+
+	// NOTE(axw) the "juju_api_*" metrics are not currently
+	// registered in the test, because AgentSuite is based
+	// on top of JujuConnSuite. JujuConnSuite uses the dummy
+	// provider's API server, rather than the one that the
+	// agent starts. Because of that, the usual observers
+	// do not apply.
+}

--- a/featuretests/introspection_test.go
+++ b/featuretests/introspection_test.go
@@ -67,7 +67,8 @@ func (s *introspectionSuite) startMachineAgent(c *gc.C) (*agentcmd.MachineAgent,
 		func(names.Tag) string { return rootDir },
 		rootDir,
 	)
-	a := machineAgentFactory(m.Id())
+	a, err := machineAgentFactory(m.Id())
+	c.Assert(err, jc.ErrorIsNil)
 
 	// Start the agent.
 	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()

--- a/featuretests/syslog_test.go
+++ b/featuretests/syslog_test.go
@@ -207,14 +207,15 @@ func (s *syslogSuite) TestLogRecordForwarded(c *gc.C) {
 		agentcmd.DefaultIntrospectionSocketName,
 		c.MkDir(),
 	)
-	a := machineAgentFactory(m.Id())
+	a, err := machineAgentFactory(m.Id())
+	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure there's no logs to begin with.
 	// Start the agent.
 	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
 	defer a.Stop()
 
-	err := s.State.UpdateModelConfig(map[string]interface{}{
+	err = s.State.UpdateModelConfig(map[string]interface{}{
 		"logforward-enabled": true,
 	}, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -239,7 +240,8 @@ func (s *syslogSuite) TestConfigChange(c *gc.C) {
 		agentcmd.DefaultIntrospectionSocketName,
 		c.MkDir(),
 	)
-	a := machineAgentFactory(m.Id())
+	a, err := machineAgentFactory(m.Id())
+	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure there's no logs to begin with.
 	// Start the agent.
@@ -250,7 +252,7 @@ func (s *syslogSuite) TestConfigChange(c *gc.C) {
 	received := make(chan rfc5424test.Message)
 	addr := s.createSyslogServer(c, received, done)
 
-	err := s.State.UpdateModelConfig(map[string]interface{}{
+	err = s.State.UpdateModelConfig(map[string]interface{}{
 		"logforward-enabled": true,
 		"syslog-host":        addr,
 		"syslog-ca-cert":     coretesting.CACert,

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -227,7 +227,9 @@ func (s *upgradeSuite) newAgent(c *gc.C, m *state.Machine) *agentcmd.MachineAgen
 		agentcmd.DefaultIntrospectionSocketName,
 		c.MkDir(),
 	)
-	return machineAgentFactory(m.Id())
+	a, err := machineAgentFactory(m.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	return a
 }
 
 // TODO(mjs) - the following should maybe be part of AgentSuite

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/upgrades"
 	jujuversion "github.com/juju/juju/version"
+	"github.com/juju/juju/worker/logsender"
 	"github.com/juju/juju/worker/upgrader"
 	"github.com/juju/juju/worker/upgradesteps"
 	"github.com/juju/version"
@@ -218,7 +219,14 @@ func (s *upgradeSuite) TestDowngradeOnMasterWhenOtherControllerDoesntStartUpgrad
 func (s *upgradeSuite) newAgent(c *gc.C, m *state.Machine) *agentcmd.MachineAgent {
 	agentConf := agentcmd.NewAgentConf(s.DataDir())
 	agentConf.ReadConfig(m.Tag().String())
-	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, nil, c.MkDir())
+	logger := logsender.NewBufferedLogWriter(1024)
+	s.AddCleanup(func(*gc.C) { logger.Close() })
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(
+		agentConf,
+		logger,
+		agentcmd.DefaultIntrospectionSocketName,
+		c.MkDir(),
+	)
 	return machineAgentFactory(m.Id())
 }
 

--- a/worker/introspection/socket_test.go
+++ b/worker/introspection/socket_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/prometheus/client_golang/prometheus"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/worker"
@@ -40,7 +41,8 @@ func (s *suite) TestStartStop(c *gc.C) {
 	}
 
 	w, err := introspection.NewWorker(introspection.Config{
-		SocketName: "introspection-test",
+		SocketName:         "introspection-test",
+		PrometheusGatherer: prometheus.NewRegistry(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	workertest.CheckKill(c, w)
@@ -52,6 +54,7 @@ type introspectionSuite struct {
 	name     string
 	worker   worker.Worker
 	reporter introspection.DepEngineReporter
+	gatherer prometheus.Gatherer
 }
 
 var _ = gc.Suite(&introspectionSuite{})
@@ -63,14 +66,16 @@ func (s *introspectionSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.reporter = nil
 	s.worker = nil
+	s.gatherer = newPrometheusGatherer()
 	s.startWorker(c)
 }
 
 func (s *introspectionSuite) startWorker(c *gc.C) {
 	s.name = fmt.Sprintf("introspection-test-%d", os.Getpid())
 	w, err := introspection.NewWorker(introspection.Config{
-		SocketName: s.name,
-		Reporter:   s.reporter,
+		SocketName:         s.name,
+		Reporter:           s.reporter,
+		PrometheusGatherer: s.gatherer,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.worker = w
@@ -127,6 +132,14 @@ func (s *introspectionSuite) TestEngineReporter(c *gc.C) {
 	matches(c, buf, "working: true")
 }
 
+func (s *introspectionSuite) TestPrometheusMetrics(c *gc.C) {
+	buf := s.call(c, "/metrics")
+	c.Assert(buf, gc.NotNil)
+	matches(c, buf, "# HELP tau Tau")
+	matches(c, buf, "# TYPE tau counter")
+	matches(c, buf, "tau 6.283185")
+}
+
 // matches fails if regex is not found in the contents of b.
 // b is expected to be the response from the pprof http server, and will
 // contain some HTTP preamble that should be ignored.
@@ -149,4 +162,12 @@ type reporter struct {
 
 func (r *reporter) Report() map[string]interface{} {
 	return r.values
+}
+
+func newPrometheusGatherer() prometheus.Gatherer {
+	counter := prometheus.NewCounter(prometheus.CounterOpts{Name: "tau", Help: "Tau."})
+	counter.Set(6.283185)
+	r := prometheus.NewPedanticRegistry()
+	r.MustRegister(counter)
+	return r
 }

--- a/worker/logsender/bufferedlogwriter_test.go
+++ b/worker/logsender/bufferedlogwriter_test.go
@@ -119,6 +119,13 @@ func (s *bufferedLogWriterSuite) TestLimiting(c *gc.C) {
 	for i := 9; i < maxLen+3+maxLen; i++ {
 		expect(i, 0)
 	}
+
+	stats := s.writer.Stats()
+	c.Assert(stats, jc.DeepEquals, logsender.LogStats{
+		Enqueued: maxLen*2 + 3,
+		Sent:     maxLen*2 + 3 - 5,
+		Dropped:  5,
+	})
 }
 
 func (s *bufferedLogWriterSuite) TestClose(c *gc.C) {
@@ -139,7 +146,7 @@ func (s *bufferedLogWriterSuite) TestClose(c *gc.C) {
 }
 
 func (s *bufferedLogWriterSuite) TestInstallBufferedLogWriter(c *gc.C) {
-	logsCh, err := logsender.InstallBufferedLogWriter(10)
+	bufferedLogger, err := logsender.InstallBufferedLogWriter(10)
 	c.Assert(err, jc.ErrorIsNil)
 	defer logsender.UninstallBufferedLogWriter()
 
@@ -149,6 +156,7 @@ func (s *bufferedLogWriterSuite) TestInstallBufferedLogWriter(c *gc.C) {
 		logger.Infof("%d", i)
 	}
 
+	logsCh := bufferedLogger.Logs()
 	for i := 0; i < 5; i++ {
 		select {
 		case rec := <-logsCh:

--- a/worker/logsender/logsendermetrics/logsendermetrics.go
+++ b/worker/logsender/logsendermetrics/logsendermetrics.go
@@ -1,0 +1,75 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logsendermetrics
+
+import (
+	"github.com/juju/juju/worker/logsender"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	jujuLogsenderCapacityDesc = prometheus.NewDesc(
+		"juju_logsender_capacity",
+		"Total number of log messages that can be enqueued before being dropped.",
+		[]string{},
+		prometheus.Labels{},
+	)
+	jujuLogsenderEnqueuedTotalDesc = prometheus.NewDesc(
+		"juju_logsender_enqueued_total",
+		"Total number of log messages enqueued.",
+		[]string{},
+		prometheus.Labels{},
+	)
+	jujuLogsenderSentTotalDesc = prometheus.NewDesc(
+		"juju_logsender_sent_total",
+		"Total number of log messages sent.",
+		[]string{},
+		prometheus.Labels{},
+	)
+	jujuLogsenderDroppedTotalDesc = prometheus.NewDesc(
+		"juju_logsender_dropped_total",
+		"Total number of log messages dropped.",
+		[]string{},
+		prometheus.Labels{},
+	)
+)
+
+// BufferedLogWriterMetrics is a prometheus.Collector that collects metrics
+// from a BufferedLogWriter.
+type BufferedLogWriterMetrics struct {
+	*logsender.BufferedLogWriter
+}
+
+// Describe is part of the prometheus.Collector interface.
+func (BufferedLogWriterMetrics) Describe(ch chan<- *prometheus.Desc) {
+	ch <- jujuLogsenderCapacityDesc
+	ch <- jujuLogsenderEnqueuedTotalDesc
+	ch <- jujuLogsenderSentTotalDesc
+	ch <- jujuLogsenderDroppedTotalDesc
+}
+
+// Collect is part of the prometheus.Collector interface.
+func (b BufferedLogWriterMetrics) Collect(ch chan<- prometheus.Metric) {
+	stats := b.Stats()
+	ch <- prometheus.MustNewConstMetric(
+		jujuLogsenderCapacityDesc,
+		prometheus.CounterValue,
+		float64(b.Capacity()),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		jujuLogsenderEnqueuedTotalDesc,
+		prometheus.CounterValue,
+		float64(stats.Enqueued),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		jujuLogsenderSentTotalDesc,
+		prometheus.CounterValue,
+		float64(stats.Sent),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		jujuLogsenderDroppedTotalDesc,
+		prometheus.CounterValue,
+		float64(stats.Dropped),
+	)
+}

--- a/worker/logsender/logsendermetrics/logsendermetrics_test.go
+++ b/worker/logsender/logsendermetrics/logsendermetrics_test.go
@@ -1,0 +1,112 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENSE file for details.
+
+package logsendermetrics_test
+
+import (
+	"reflect"
+
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/logsender"
+	"github.com/juju/juju/worker/logsender/logsendermetrics"
+)
+
+const maxLen = 3
+
+type bufferedLogWriterSuite struct {
+	testing.IsolationSuite
+	writer    *logsender.BufferedLogWriter
+	collector logsendermetrics.BufferedLogWriterMetrics
+}
+
+var _ = gc.Suite(&bufferedLogWriterSuite{})
+
+func (s *bufferedLogWriterSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.writer = logsender.NewBufferedLogWriter(maxLen)
+	s.collector = logsendermetrics.BufferedLogWriterMetrics{s.writer}
+	s.AddCleanup(func(*gc.C) { s.writer.Close() })
+}
+
+func (s *bufferedLogWriterSuite) TestDescribe(c *gc.C) {
+	ch := make(chan *prometheus.Desc)
+	go func() {
+		defer close(ch)
+		s.collector.Describe(ch)
+	}()
+	var descs []*prometheus.Desc
+	for desc := range ch {
+		descs = append(descs, desc)
+	}
+	c.Assert(descs, gc.HasLen, 4)
+	c.Assert(descs[0].String(), gc.Matches, `.*fqName: "juju_logsender_capacity".*`)
+	c.Assert(descs[1].String(), gc.Matches, `.*fqName: "juju_logsender_enqueued_total".*`)
+	c.Assert(descs[2].String(), gc.Matches, `.*fqName: "juju_logsender_sent_total".*`)
+	c.Assert(descs[3].String(), gc.Matches, `.*fqName: "juju_logsender_dropped_total".*`)
+}
+
+func (s *bufferedLogWriterSuite) TestCollect(c *gc.C) {
+	s.writer.Write(loggo.Entry{})
+	s.writer.Write(loggo.Entry{})
+	s.writer.Write(loggo.Entry{})
+	s.writer.Write(loggo.Entry{})
+	s.writer.Write(loggo.Entry{}) // causes first to be dropped
+
+	for i := 0; i < maxLen; i++ {
+		<-s.writer.Logs()
+	}
+
+	// The statistics are not incremented atomically with the log
+	// writing, so we need to wait for the statistics to be updated.
+	s.waitForStats(c, logsender.LogStats{
+		Enqueued: 5,
+		Sent:     3,
+		Dropped:  1,
+	})
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		defer close(ch)
+		s.collector.Collect(ch)
+	}()
+
+	var metrics []prometheus.Metric
+	for metric := range ch {
+		metrics = append(metrics, metric)
+	}
+	c.Assert(metrics, gc.HasLen, 4)
+
+	var dtoMetrics [4]dto.Metric
+	for i, metric := range metrics {
+		err := metric.Write(&dtoMetrics[i])
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	float64ptr := func(v float64) *float64 {
+		return &v
+	}
+	c.Assert(dtoMetrics, jc.DeepEquals, [4]dto.Metric{
+		{Counter: &dto.Counter{Value: float64ptr(3)}},
+		{Counter: &dto.Counter{Value: float64ptr(5)}},
+		{Counter: &dto.Counter{Value: float64ptr(3)}},
+		{Counter: &dto.Counter{Value: float64ptr(1)}},
+	})
+}
+
+func (s *bufferedLogWriterSuite) waitForStats(c *gc.C, expect logsender.LogStats) {
+	var stats logsender.LogStats
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		stats = s.writer.Stats()
+		if reflect.DeepEqual(stats, expect) {
+			return
+		}
+	}
+	c.Errorf("timed out waiting for statistics: got %+v, expected %+v", stats, expect)
+}

--- a/worker/logsender/logsendermetrics/package_test.go
+++ b/worker/logsender/logsendermetrics/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logsendermetrics_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
We create a Prometheus registry for each
machine and unit agent, and expose it via
the agent's introspection socket. The socket
can be exposed as HTTP using socat or similar,
and then used as a regular Prometheus target.

We add the apiserver/observer/metricobserver
package, which contains an apiserver observer
that maintains Prometheus metrics. We currently
create metrics tracking the total number of API
requests served, and their latencies. Each metric
is grouped by facade, method, version, and error
code.

We also add metrics for the logsender worker,
tracking the number of log records enqueued,
sent (to the controller), and dropped; and
also the capacity of the queue so we can
compute usage %.