### PR TITLE
Bootstrap config: inherited overwrites defaults.

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/provider/openstack"
 	coretesting "github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
@@ -588,6 +589,154 @@ func (s *BootstrapSuite) TestBootstrapDefaultConfigStripsInheritedAttributes(c *
 	c.Assert(ok, jc.IsFalse)
 	_, ok = bootstrap.args.HostedModelConfig["agent-version"]
 	c.Assert(ok, jc.IsFalse)
+}
+
+// checkConfigs runs bootstrapCmd.getBootstrapConfigs and checks the returned configs match
+// the expected values passed in the expect parameter.
+func checkConfigs(
+	c *gc.C,
+	bootstrapCmd bootstrapCommand,
+	key string,
+	ctx *cmd.Context, cloud *cloud.Cloud, provider environs.EnvironProvider,
+	expect map[string]map[string]interface{}) {
+
+	bootstrapModelConfig,
+		controllerConfig,
+		_,
+		inheritedControllerAttrs,
+		userConfigAttrs,
+		err := bootstrapCmd.getBootstrapConfigs(ctx, cloud, provider)
+
+	c.Assert(err, jc.ErrorIsNil)
+
+	checkConfigEntryMatches(c, bootstrapModelConfig, key, "bootstrapModelConfig", expect)
+	checkConfigEntryMatches(c, inheritedControllerAttrs, key, "inheritedControllerAttrs", expect)
+	checkConfigEntryMatches(c, userConfigAttrs, key, "userConfigAttrs", expect)
+
+	_, ok := controllerConfig[key]
+	c.Check(ok, jc.IsFalse)
+}
+
+// checkConfigEntryMatches tests that a keys existence and indexed value in configMap
+// matches those in expect[name].
+func checkConfigEntryMatches(c *gc.C, configMap map[string]interface{}, key, name string, expect map[string]map[string]interface{}) {
+	v, ok := configMap[key]
+	expected_config, expected_config_ok := expect[name]
+	c.Assert(expected_config_ok, jc.IsTrue)
+	v_expect, ok_expect := expected_config[key]
+
+	c.Logf("checkConfigEntryMatches %v %v", name, key)
+	c.Check(ok, gc.Equals, ok_expect)
+	c.Check(v, gc.Equals, v_expect)
+}
+
+func (s *BootstrapSuite) TestBootstrapAttributesInheritedOverDefaults(c *gc.C) {
+	/* Test that defaults are overwritten by inherited attributes by setting
+	   the inherited attribute enable-os-upgrade to true in the cloud
+	   config and ensure that it ends up as true in the model config. */
+	s.patchVersionAndSeries(c, "raring")
+
+	bootstrapCmd := bootstrapCommand{}
+	ctx := coretesting.Context(c)
+
+	// The OpenStack provider has a default of "use-floating-ip": false, so we
+	// use that to test against.
+	env := &openstack.Environ{}
+	provider := env.Provider()
+
+	// First test that use-floating-ip defaults to false
+	testCloud, err := cloud.CloudByName("dummy-cloud")
+	c.Assert(err, jc.ErrorIsNil)
+
+	key := "use-floating-ip"
+	checkConfigs(c, bootstrapCmd, key, ctx, testCloud, provider, map[string]map[string]interface{}{
+		"bootstrapModelConfig":     {key: false},
+		"inheritedControllerAttrs": {},
+		"userConfigAttrs":          {},
+	})
+
+	// Second test that use-floating-ip in the cloud config overwrites the
+	// provider default of false with true
+	testCloud, err = cloud.CloudByName("dummy-cloud-with-config")
+	c.Assert(err, jc.ErrorIsNil)
+
+	checkConfigs(c, bootstrapCmd, key, ctx, testCloud, provider, map[string]map[string]interface{}{
+		"bootstrapModelConfig":     {key: true},
+		"inheritedControllerAttrs": {key: true},
+		"userConfigAttrs":          {},
+	})
+}
+
+func (s *BootstrapSuite) TestBootstrapAttributesCLIOverDefaults(c *gc.C) {
+	/* Test that defaults are overwritten by CLI passed attributes by setting
+	   the inherited attribute enable-os-upgrade to true in the cloud
+	   config and ensure that it ends up as true in the model config. */
+	s.patchVersionAndSeries(c, "raring")
+
+	bootstrapCmd := bootstrapCommand{}
+	ctx := coretesting.Context(c)
+
+	// The OpenStack provider has a default of "use-floating-ip": false, so we
+	// use that to test against.
+	env := &openstack.Environ{}
+	provider := env.Provider()
+
+	// First test that use-floating-ip defaults to false
+	testCloud, err := cloud.CloudByName("dummy-cloud")
+	c.Assert(err, jc.ErrorIsNil)
+
+	key := "use-floating-ip"
+	checkConfigs(c, bootstrapCmd, key, ctx, testCloud, provider, map[string]map[string]interface{}{
+		"bootstrapModelConfig":     {key: false},
+		"inheritedControllerAttrs": {},
+		"userConfigAttrs":          {},
+	})
+
+	// Second test that use-floating-ip passed on the command line overwrites the
+	// provider default of false with true
+	bootstrapCmd.config.Set("use-floating-ip=true")
+	checkConfigs(c, bootstrapCmd, key, ctx, testCloud, provider, map[string]map[string]interface{}{
+		"bootstrapModelConfig":     {key: true},
+		"inheritedControllerAttrs": {},
+		"userConfigAttrs":          {key: true},
+	})
+}
+
+func (s *BootstrapSuite) TestBootstrapAttributesCLIOverInherited(c *gc.C) {
+	/* Test that defaults are overwritten by CLI passed attributes by setting
+	   the inherited attribute enable-os-upgrade to true in the cloud
+	   config and ensure that it ends up as true in the model config. */
+	s.patchVersionAndSeries(c, "raring")
+
+	bootstrapCmd := bootstrapCommand{}
+	ctx := coretesting.Context(c)
+
+	// The OpenStack provider has a default of "use-floating-ip": false, so we
+	// use that to test against.
+	env := &openstack.Environ{}
+	provider := env.Provider()
+
+	// First test that use-floating-ip defaults to false
+	testCloud, err := cloud.CloudByName("dummy-cloud")
+	c.Assert(err, jc.ErrorIsNil)
+
+	key := "use-floating-ip"
+	checkConfigs(c, bootstrapCmd, key, ctx, testCloud, provider, map[string]map[string]interface{}{
+		"bootstrapModelConfig":     {key: false},
+		"inheritedControllerAttrs": {},
+		"userConfigAttrs":          {},
+	})
+
+	// Second test that use-floating-ip passed on the command line overwrites the
+	// inherited attribute
+	testCloud, err = cloud.CloudByName("dummy-cloud-with-config")
+	c.Assert(err, jc.ErrorIsNil)
+	bootstrapCmd.config.Set("use-floating-ip=false")
+	checkConfigs(c, bootstrapCmd, key, ctx, testCloud, provider, map[string]map[string]interface{}{
+		"bootstrapModelConfig":     {key: false},
+		"inheritedControllerAttrs": {key: true},
+		"userConfigAttrs":          {key: false},
+	})
 }
 
 func (s *BootstrapSuite) TestBootstrapWithGUI(c *gc.C) {
@@ -1532,6 +1681,7 @@ clouds:
         config:
             broken: Bootstrap
             controller: not-a-bool
+            use-floating-ip: true
     many-credentials-no-auth-types:
         type: many-credentials
 `[1:]), 0644)

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -600,20 +600,15 @@ func checkConfigs(
 	ctx *cmd.Context, cloud *cloud.Cloud, provider environs.EnvironProvider,
 	expect map[string]map[string]interface{}) {
 
-	bootstrapModelConfig,
-		controllerConfig,
-		_,
-		inheritedControllerAttrs,
-		userConfigAttrs,
-		err := bootstrapCmd.getBootstrapConfigs(ctx, cloud, provider)
+	configs, err := bootstrapCmd.bootstrapConfigs(ctx, cloud, provider)
 
 	c.Assert(err, jc.ErrorIsNil)
 
-	checkConfigEntryMatches(c, bootstrapModelConfig, key, "bootstrapModelConfig", expect)
-	checkConfigEntryMatches(c, inheritedControllerAttrs, key, "inheritedControllerAttrs", expect)
-	checkConfigEntryMatches(c, userConfigAttrs, key, "userConfigAttrs", expect)
+	checkConfigEntryMatches(c, configs.bootstrapModel, key, "bootstrapModelConfig", expect)
+	checkConfigEntryMatches(c, configs.inheritedControllerAttrs, key, "inheritedControllerAttrs", expect)
+	checkConfigEntryMatches(c, configs.userConfigAttrs, key, "userConfigAttrs", expect)
 
-	_, ok := controllerConfig[key]
+	_, ok := configs.controller[key]
 	c.Check(ok, jc.IsFalse)
 }
 


### PR DESCRIPTION
Fixes an error in the bootstrap logic where a default from a cloud would overwrite values read from the users cloud config.

The bootstrap run logic has been split into several functions to aid readability and testing. The logical changes are actually very small and are contained within getBootstrapConfigs, which now builds up configuration by first combining all sources in order of lowest to highest precedence and then splitting the configuration out into bootstrap config, controller config and bootstrap model config. The old logic sort of did this, but it was muddled and had some precedence problems that were causing the fixed bugs.

Fixes http://pad.lv/1614239 and http://pad.lv/1619808

# CI Steps
Bootstrap an OpenStack with config: use-floating-ip: true and check that it is honored. This needs to be set in clouds.yaml, not on the CLI to see the bug fix.

# Notes to reviewers
The github diff viewer isn't being helpful, so open bootstrap.go and look at Run (line 314+) that used to be insanely big and make sure that it reads well. The only logical change is in getBootstrapConfigs (line 729+) where the old code was wrong. The other changes in bootstrap.go are just code being moved into functions and, otherwise, being left unaltered.