### PR TITLE
Sorted output of 'juju metrics'.

### DIFF
--- a/cmd/juju/metricsdebug/metrics.go
+++ b/cmd/juju/metricsdebug/metrics.go
@@ -6,6 +6,7 @@ package metricsdebug
 import (
 	"fmt"
 	"io"
+	"sort"
 	"time"
 
 	"github.com/gosuri/uitable"
@@ -91,6 +92,23 @@ var newClient = func(env modelcmd.ModelCommandBase) (GetMetricsClient, error) {
 	return metricsdebug.NewClient(state), nil
 }
 
+type metricSlice []metric
+
+// Len implements the sort.Interface.
+func (slice metricSlice) Len() int {
+	return len(slice)
+}
+
+// Less implements the sort.Interface.
+func (slice metricSlice) Less(i, j int) bool {
+	return slice[i].Metric < slice[j].Metric
+}
+
+// Swap implements the sort.Interface.
+func (slice metricSlice) Swap(i, j int) {
+	slice[i], slice[j] = slice[j], slice[i]
+}
+
 type metric struct {
 	Unit      string    `json:"unit" yaml:"unit"`
 	Timestamp time.Time `json:"timestamp" yaml:"timestamp"`
@@ -126,6 +144,9 @@ func (c *MetricsCommand) Run(ctx *cmd.Context) error {
 			Value:     m.Value,
 		}
 	}
+	sortedResults := metricSlice(results)
+	sort.Sort(sortedResults)
+
 	return errors.Trace(c.out.Write(ctx, results))
 }
 

--- a/cmd/juju/metricsdebug/metrics_test.go
+++ b/cmd/juju/metricsdebug/metrics_test.go
@@ -54,17 +54,44 @@ func (s *metricsSuite) SetUpTest(c *gc.C) {
 	})
 }
 
-func (s *metricsSuite) TestDefaultTabulatFormat(c *gc.C) {
+func (s *metricsSuite) TestSort(c *gc.C) {
 	s.client.metrics = []params.MetricResult{{
 		Unit:  "unit-metered-0",
-		Key:   "pings",
+		Key:   "c-s",
 		Value: "5.0",
-		Time:  time.Date(2016, 8, 22, 12, 02, 03, 0, time.UTC),
+		Time:  time.Date(2016, 8, 22, 12, 02, 04, 0, time.UTC),
 	}, {
+		Unit:  "unit-metered-0",
+		Key:   "b-s",
+		Value: "10.0",
+		Time:  time.Date(2016, 8, 22, 12, 02, 04, 0, time.UTC),
+	}, {
+		Unit:  "unit-metered-0",
+		Key:   "a-s",
+		Value: "15.0",
+		Time:  time.Date(2016, 8, 22, 12, 02, 04, 0, time.UTC),
+	}}
+	ctx, err := coretesting.RunCommand(c, metricsdebug.New(), "metered/0")
+	c.Assert(err, jc.ErrorIsNil)
+	s.client.CheckCall(c, 0, "GetMetrics", []string{"unit-metered-0"})
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `UNIT          	           TIMESTAMP	METRIC	VALUE
+unit-metered-0	2016-08-22T12:02:04Z	   a-s	 15.0
+unit-metered-0	2016-08-22T12:02:04Z	   b-s	 10.0
+unit-metered-0	2016-08-22T12:02:04Z	   c-s	  5.0
+`)
+}
+
+func (s *metricsSuite) TestDefaultTabulatFormat(c *gc.C) {
+	s.client.metrics = []params.MetricResult{{
 		Unit:  "unit-metered-0",
 		Key:   "pongs",
 		Value: "15.0",
 		Time:  time.Date(2016, 8, 22, 12, 02, 04, 0, time.UTC),
+	}, {
+		Unit:  "unit-metered-0",
+		Key:   "pings",
+		Value: "5.0",
+		Time:  time.Date(2016, 8, 22, 12, 02, 03, 0, time.UTC),
 	}}
 	ctx, err := coretesting.RunCommand(c, metricsdebug.New(), "metered/0")
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
QA instructions:
- deploy charm that reports multiple metrics
- run 'juju metrics <service name>'
- metrics in the output should be sorted by the metric name