### PR TITLE
Create interactive add-cloud command

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -56,6 +56,18 @@ const (
 	// EmptyAuthType is the authentication type used for providers
 	// that require no credentials, e.g. "lxd", and "manual".
 	EmptyAuthType AuthType = "empty"
+
+	// AuthTypesKey is the name of the key in a cloud config or cloud schema
+	// that holds the cloud's auth types.
+	AuthTypesKey = "auth-types"
+
+	// EndpointKey is the name of the key in a cloud config or cloud schema
+	// that holds the cloud's endpoint url.
+	EndpointKey = "endpoint"
+
+	// RegionsKey is the name of the key in a cloud schema that holds the list
+	// of regions a cloud supports.
+	RegionsKey = "regions"
 )
 
 // Attrs serves as a map to hold regions specific configuration attributes.
@@ -264,6 +276,15 @@ func PublicCloudMetadata(searchPath ...string) (result map[string]Cloud, fallbac
 	}
 	clouds, err := ParseCloudMetadata([]byte(fallbackPublicCloudInfo))
 	return clouds, true, err
+}
+
+// ParseOneCloud parses the given yaml bytes into a single Cloud metadata.
+func ParseOneCloud(data []byte) (Cloud, error) {
+	c := &cloud{}
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		return Cloud{}, errors.Annotate(err, "cannot unmarshal yaml cloud metadata")
+	}
+	return cloudFromInternal(c), nil
 }
 
 // ParseCloudMetadata parses the given yaml bytes into Clouds metadata.

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -10,11 +10,9 @@ import (
 
 	yaml "gopkg.in/yaml.v1"
 
-	"github.com/juju/ansiterm"
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/jsonschema"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"
@@ -65,6 +63,7 @@ func NewAddCloudCommand() cmd.Command {
 	return &addCloudCommand{}
 }
 
+// Info returns help information about the command.
 func (c *addCloudCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "add-cloud",
@@ -74,11 +73,13 @@ func (c *addCloudCommand) Info() *cmd.Info {
 	}
 }
 
+// SetFlags initializes the flags supported by the command.
 func (c *addCloudCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CommandBase.SetFlags(f)
 	f.BoolVar(&c.Replace, "replace", false, "Overwrite any existing cloud information")
 }
 
+// Init populates the command with the args from the command line.
 func (c *addCloudCommand) Init(args []string) (err error) {
 	if len(args) > 0 {
 		c.Cloud = args[0]
@@ -92,6 +93,8 @@ func (c *addCloudCommand) Init(args []string) (err error) {
 	return nil
 }
 
+// Run executes the add cloud command, adding a cloud based on a passed-in yaml
+// file or interactive queries.
 func (c *addCloudCommand) Run(ctxt *cmd.Context) error {
 	if c.CloudFile == "" {
 		return c.runInteractive(ctxt)
@@ -116,24 +119,96 @@ func (c *addCloudCommand) Run(ctxt *cmd.Context) error {
 }
 
 func (c *addCloudCommand) runInteractive(ctxt *cmd.Context) error {
-	allproviders := environs.RegisteredProviders()
+	errout := interact.NewErrWriter(ctxt.Stdout)
+	pollster := interact.New(ctxt.Stdin, ctxt.Stdout, errout)
 
+	cloudType, err := queryCloudType(pollster)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	name, err := queryName(pollster)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	provider, err := environs.Provider(cloudType)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	v, err := pollster.QuerySchema(provider.CloudSchema())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	newCloud, err := cloud.ParseOneCloud(b)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	newCloud.Type = cloudType
+	if err := addCloud(name, newCloud); err != nil {
+		return errors.Trace(err)
+	}
+	ctxt.Infof("Cloud %q successfully added", name)
+	ctxt.Infof("You may bootstrap with 'juju bootstrap %s'", name)
+
+	return nil
+}
+
+func queryName(pollster *interact.Pollster) (string, error) {
 	public, _, err := cloud.PublicCloudMetadata()
 	if err != nil {
-		return err
+		return "", err
 	}
 	personal, err := cloud.PersonalCloudMetadata()
 	if err != nil {
-		return err
+		return "", err
 	}
 
+	for {
+		name, err := pollster.Enter("a name for the cloud")
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		if _, ok := personal[name]; ok {
+			override, err := pollster.YN(fmt.Sprintf("A cloud named %q already exists. Do you want to replace that definition", name), false)
+			if err != nil {
+				return "", errors.Trace(err)
+			}
+			if override {
+				return name, nil
+			}
+			// else, ask again
+			continue
+		}
+		msg := nameExists(name, public)
+		if msg == "" {
+			return name, nil
+		}
+		override, err := pollster.YN(msg+", do you want to override that definition", false)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		if override {
+			return name, nil
+		}
+		// else, ask again
+	}
+}
+
+func queryCloudType(pollster *interact.Pollster) (string, error) {
+	allproviders := environs.RegisteredProviders()
 	var unsupported []string
 	var providers []string
 	for _, name := range allproviders {
 		provider, err := environs.Provider(name)
 		if err != nil {
 			// should be impossible
-			return errors.Trace(err)
+			return "", errors.Trace(err)
 		}
 
 		if provider.CloudSchema() != nil {
@@ -164,74 +239,11 @@ func (c *addCloudCommand) runInteractive(ctxt *cmd.Context) error {
 		return false, errmsg, nil
 	}
 
-	w := ansiterm.NewWriter(ctxt.Stdout)
-	pollster := interact.New(ctxt.Stdin, ctxt.Stdout, errWriter{w})
-	cloudType, err := pollster.SelectVerify(interact.List{
+	return pollster.SelectVerify(interact.List{
 		Singular: "cloud type",
 		Plural:   "cloud types",
 		Options:  providers,
 	}, cloudVerify)
-
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	var name string
-	for {
-		name, err = pollster.Enter("a name for the cloud")
-		if err != nil {
-			return errors.Trace(err)
-		}
-		err = nameExists(name, public, personal)
-		if err == nil {
-			break
-		}
-		// we do this instead of returning the error message
-		override, err2 := pollster.YN(err.Error()+", do you want to override that definition", false)
-		if err2 != nil {
-			return errors.Trace(err)
-		}
-		if override {
-			break
-		}
-		// else, ask again
-	}
-
-	provider, err := environs.Provider(cloudType)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	schema := provider.CloudSchema()
-	v, err := pollster.QuerySchema(schema)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	b, err := yaml.Marshal(v)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	newCloud, err := cloud.ParseOneCloud(b)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	newCloud.Type = cloudType
-	err = addCloud(name, newCloud)
-	if err == nil {
-		ctxt.Infof("Cloud %q successfully added", name)
-		ctxt.Infof("You may bootstrap with 'juju bootstrap %s'", name)
-	}
-	return err
-}
-
-type errWriter struct {
-	w *ansiterm.Writer
-}
-
-func (w errWriter) Write(b []byte) (n int, err error) {
-	w.w.SetForeground(ansiterm.BrightRed)
-	defer w.w.Reset()
-	return w.w.Write(b)
 }
 
 func (c *addCloudCommand) verifyName(name string) error {
@@ -246,28 +258,25 @@ func (c *addCloudCommand) verifyName(name string) error {
 	if err != nil {
 		return err
 	}
-	if err := nameExists(name, public, personal); err != nil {
-		return errors.Errorf(err.Error() + "; use --replace to override this definition")
-	}
-	return nil
-}
-
-func nameExists(name string, public, personal map[string]cloud.Cloud) error {
-	if _, ok := public[name]; ok {
-		return errors.Errorf("%q is the name of a public cloud", name)
-	}
-	builtinClouds := common.BuiltInClouds()
-	if _, ok := builtinClouds[name]; ok {
-		return errors.Errorf("%q is the name of a built-in cloud", name)
-	}
 	if _, ok := personal[name]; ok {
-		return errors.Errorf("%q already exists", name)
+		return errors.Errorf("%q already exists; use --replace to replace this existing cloud", name)
+	}
+	if msg := nameExists(name, public); msg != "" {
+		return errors.Errorf(msg + "; use --replace to override this definition")
 	}
 	return nil
 }
 
-func querySchema(schema *jsonschema.Schema, pollster *interact.Pollster) error {
-	return nil
+// nameExists returns either an empty string if the name does not exist, or a
+// non-empty string with an error message if it does exist.
+func nameExists(name string, public map[string]cloud.Cloud) string {
+	if _, ok := public[name]; ok {
+		return fmt.Sprintf("%q is the name of a public cloud", name)
+	}
+	if _, ok := common.BuiltInClouds()[name]; ok {
+		return fmt.Sprintf("%q is the name of a built-in cloud", name)
+	}
+	return ""
 }
 
 func addCloud(name string, newCloud cloud.Cloud) error {

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -92,7 +92,7 @@ func (s *addSuite) TestAddBadCloudName(c *gc.C) {
 func (s *addSuite) TestAddExisting(c *gc.C) {
 	sourceFile := s.createTestCloudData(c)
 	_, err := testing.RunCommand(c, cloud.NewAddCloudCommand(), "homestack", sourceFile)
-	c.Assert(err, gc.ErrorMatches, `"homestack" already exists; use --replace to override this definition`)
+	c.Assert(err, gc.ErrorMatches, `"homestack" already exists; use --replace to replace this existing cloud`)
 }
 
 func (s *addSuite) TestAddExistingReplace(c *gc.C) {

--- a/cmd/juju/commands/bootstrap_interactive.go
+++ b/cmd/juju/commands/bootstrap_interactive.go
@@ -41,10 +41,10 @@ func queryCloud(clouds []string, defCloud string, scanner *bufio.Scanner, w io.W
 	// add support for a default (empty) selection.
 	clouds = append(clouds, "")
 
-	verify := interact.MatchOptions(clouds, errors.Errorf("Invalid cloud."))
+	verify := interact.MatchOptions(clouds, "Invalid cloud.")
 
 	query := fmt.Sprintf("Select a cloud [%s]: ", defCloud)
-	cloud, err := interact.QueryVerify([]byte(query), scanner, w, verify)
+	cloud, err := interact.QueryVerify(query, scanner, w, w, verify)
 	if err != nil {
 		return "", errors.Trace(err)
 	}
@@ -72,10 +72,10 @@ func queryRegion(cloud string, regions []jujucloud.Region, scanner *bufio.Scanne
 	if _, err := fmt.Fprintln(w, strings.Join(names, "\n")); err != nil {
 		return "", errors.Trace(err)
 	}
-	verify := interact.MatchOptions(names, errors.Errorf("Invalid region."))
+	verify := interact.MatchOptions(names, "Invalid region.")
 	defaultRegion := regions[0].Name
 	query := fmt.Sprintf("Select a region in %s [%s]: ", cloud, defaultRegion)
-	region, err := interact.QueryVerify([]byte(query), scanner, w, verify)
+	region, err := interact.QueryVerify(query, scanner, w, w, verify)
 	if err != nil {
 		return "", errors.Trace(err)
 	}
@@ -100,7 +100,7 @@ func defaultControllerName(cloudname, region string) string {
 
 func queryName(defName string, scanner *bufio.Scanner, w io.Writer) (string, error) {
 	query := fmt.Sprintf("Enter a name for the Controller [%s]: ", defName)
-	name, err := interact.QueryVerify([]byte(query), scanner, w, nil)
+	name, err := interact.QueryVerify(query, scanner, w, w, nil)
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/cmd/juju/interact/errwriter.go
+++ b/cmd/juju/interact/errwriter.go
@@ -1,0 +1,25 @@
+package interact
+
+import (
+	"io"
+
+	"github.com/juju/ansiterm"
+)
+
+// NewErrWriter wraps w in a type that will cause all writes to be written as
+// ansi terminal BrightRed.
+func NewErrWriter(w io.Writer) io.Writer {
+	return errWriter{ansiterm.NewWriter(w)}
+}
+
+// errWriter is a little type that ensures that anything written to it is
+// written in BrightRed.
+type errWriter struct {
+	w *ansiterm.Writer
+}
+
+func (w errWriter) Write(b []byte) (n int, err error) {
+	w.w.SetForeground(ansiterm.BrightRed)
+	defer w.w.Reset()
+	return w.w.Write(b)
+}

--- a/cmd/juju/interact/pollster.go
+++ b/cmd/juju/interact/pollster.go
@@ -1,0 +1,515 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package interact
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"html/template"
+	"io"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/jsonschema"
+	"github.com/juju/utils/set"
+)
+
+// Pollster is used to ask multiple questions of the user using a standard
+// formatting.
+type Pollster struct {
+	scanner *bufio.Scanner
+	out     io.Writer
+	errOut  io.Writer
+}
+
+// New returns a Pollster that wraps the given reader and writer.
+func New(in io.Reader, out, errOut io.Writer) *Pollster {
+	return &Pollster{
+		scanner: bufio.NewScanner(in),
+		out:     out,
+		errOut:  errOut,
+	}
+}
+
+// List contains the information necessary to ask the user to select one item
+// from a list of options.
+type List struct {
+	Singular string
+	Plural   string
+	Options  []string
+	Default  string
+}
+
+// MultiList contains the information necessary to ask the user to select form a list
+// of options.
+type MultiList struct {
+	Singular string
+	Plural   string
+	Options  []string
+	Default  []string
+}
+
+var listTmpl = template.Must(template.New("").Funcs(map[string]interface{}{"title": strings.Title}).Parse(`
+{{title .Plural}}
+{{range .Options}}  {{.}}
+{{end}}
+`[1:]))
+
+var selectTmpl = template.Must(template.New("").Parse(`
+Select {{.Singular}}{{if .Default}} [{{.Default}}]{{end}}: `[1:]))
+
+// Select queries the user to select from the give list of options.
+func (p *Pollster) Select(l List) (string, error) {
+	return p.SelectVerify(l, VerifyOptions(l.Singular, l.Options, l.Default != ""))
+}
+
+// SelectVerify queries the user to select from the give list of options, using
+// the custom verifier listed.
+func (p *Pollster) SelectVerify(l List, verify VerifyFunc) (string, error) {
+	if err := listTmpl.Execute(p.out, l); err != nil {
+		return "", err
+	}
+
+	question, err := sprint(selectTmpl, l)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	val, err := QueryVerify(question, p.scanner, p.out, p.errOut, verify)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if val == "" {
+		return l.Default, nil
+	}
+	return val, nil
+}
+
+var multiSelectTmpl = template.Must(template.New("").Funcs(
+	map[string]interface{}{"join": strings.Join}).Parse(`
+Select one or more {{.Plural}} separated by commas{{if .Default}} [{{join .Default ", "}}]{{end}}: `[1:]))
+
+// MultiSelect queries the user to select one more answers from the give list of
+// options by entering values delimited by commas (and thus options must not
+// contain commas).
+func (p *Pollster) MultiSelect(l MultiList) ([]string, error) {
+	if err := listTmpl.Execute(p.out, l); err != nil {
+		return nil, err
+	}
+
+	question, err := sprint(multiSelectTmpl, l)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	a, err := QueryVerify(question, p.scanner, p.out, p.errOut, multiVerify(l.Singular, l.Plural, l.Options, l.Default != nil))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if a == "" {
+		return l.Default, nil
+	}
+	return multiSplit(a), nil
+}
+
+// Enter requests that the user enter a value.  Any value except an empty string
+// is accepted.
+func (p *Pollster) Enter(valueName string) (string, error) {
+	return p.EnterVerify(valueName, nil)
+}
+
+// VerifyFunc is a type that determines whether a value entered by the user is
+// acceptable or not.  If it returns an error, the calling func will return an
+// error, and the other return values are ignored.  If ok is true, the value is
+// acceptable, and that value will be returned by the calling function.  If ok
+// is false, the user will be asked to enter a new value for query.  If ok is
+// false. if errmsg is not empty, it will be printed out as an error to te the
+// user.
+type VerifyFunc func(s string) (ok bool, errmsg string, err error)
+
+// EnterVerify requests that the user enter a value.  Values failing to verify will be
+// rejected with the error message returned by verify.
+func (p *Pollster) EnterVerify(valueName string, verify VerifyFunc) (string, error) {
+	for {
+		s, err := QueryVerify("Enter "+valueName+": ", p.scanner, p.out, p.errOut, verify)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		if s != "" {
+			return s, nil
+		}
+		// retry if we get an empty value, no need to print out an error.
+	}
+}
+
+// YN queries the user with a yes no question q (which should not include a
+// question mark at the end).  It uses def as the default answer.
+func (p *Pollster) YN(q string, def bool) (bool, error) {
+	defstring := "(y/N)"
+	if def {
+		defstring = "(Y/n)"
+	}
+	verify := func(s string) (ok bool, errmsg string, err error) {
+		_, err = yesNoConvert(s, def)
+		if err != nil {
+			return false, err.Error(), nil
+		}
+		return true, "", nil
+	}
+	a, err := QueryVerify(q+"? "+defstring+": ", p.scanner, p.out, p.errOut, verify)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	return yesNoConvert(a, def)
+}
+
+func yesNoConvert(s string, def bool) (bool, error) {
+	if s == "" {
+		return def, nil
+	}
+	switch strings.ToLower(s) {
+	case "y", "yes":
+		return true, nil
+	case "n", "no":
+		return false, nil
+	default:
+		return false, errors.Errorf("Invalid entry: %q, please choose y or n.", s)
+	}
+}
+
+// VerifyOptions is the verifier used by pollster.Select.
+func VerifyOptions(singular string, options []string, hasDefault bool) VerifyFunc {
+	return func(s string) (ok bool, errmsg string, err error) {
+		if s == "" {
+			return hasDefault, "", nil
+		}
+		for _, opt := range options {
+			if strings.ToLower(opt) == strings.ToLower(s) {
+				return true, "", nil
+			}
+		}
+		return false, fmt.Sprintf("Invalid %s: %q", singular, s), nil
+	}
+}
+
+func multiVerify(singular, plural string, options []string, hasDefault bool) VerifyFunc {
+	return func(s string) (ok bool, errmsg string, err error) {
+		if s == "" {
+			return hasDefault, "", nil
+		}
+		vals := set.NewStrings(multiSplit(s)...)
+		opts := set.NewStrings(options...)
+		unknowns := vals.Difference(opts)
+		if len(unknowns) > 1 {
+			list := `"` + strings.Join(unknowns.SortedValues(), `", "`) + `"`
+			return false, fmt.Sprintf("Invalid %s: %s", plural, list), nil
+		}
+		if len(unknowns) > 0 {
+			return false, fmt.Sprintf("Invalid %s: %q", singular, unknowns.Values()[0]), nil
+		}
+		return true, "", nil
+	}
+}
+
+func multiSplit(s string) []string {
+	chosen := strings.Split(s, ",")
+	for i := range chosen {
+		chosen[i] = strings.TrimSpace(chosen[i])
+	}
+	return chosen
+}
+
+func sprint(t *template.Template, data interface{}) (string, error) {
+	b := &bytes.Buffer{}
+	if err := t.Execute(b, data); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+// QuerySchema takes a jsonschema and queries the user to input value(s) for the
+// schema.  It returns an object as defined by the schema (generally a
+// map[string]interface{} for objects, etc).
+func (p *Pollster) QuerySchema(schema *jsonschema.Schema) (interface{}, error) {
+	if len(schema.Type) == 0 {
+		return nil, errors.Errorf("invalid schema, no type specified")
+	}
+	if len(schema.Type) > 1 {
+		return nil, errors.Errorf("don't know how to query for a value with multiple types")
+	}
+	var v interface{}
+	var err error
+	if schema.Type[0] == jsonschema.ObjectType {
+		v, err = p.queryObjectSchema(schema)
+	} else {
+		v, err = p.queryOneSchema(schema)
+	}
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return v, nil
+}
+
+func (p *Pollster) queryObjectSchema(schema *jsonschema.Schema) (map[string]interface{}, error) {
+	// TODO(natefinch): support for optional values.
+	vals := map[string]interface{}{}
+	if len(schema.Order) != 0 {
+		m, err := p.queryOrder(schema)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		vals = m
+	} else {
+		// traverse alphabetically
+		for _, name := range names(schema.Properties) {
+			v, err := p.queryProp(schema.Properties[name])
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			vals[name] = v
+		}
+	}
+
+	if schema.AdditionalProperties != nil {
+		if err := p.queryAdditionalProps(vals, schema); err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	return vals, nil
+}
+
+// names returns the list of names of schema in alphabetical order.
+func names(m map[string]*jsonschema.Schema) []string {
+	ret := make([]string, 0, len(m))
+	for n := range m {
+		ret = append(ret, n)
+	}
+	sort.Strings(ret)
+	return ret
+}
+
+func (p *Pollster) queryOrder(schema *jsonschema.Schema) (map[string]interface{}, error) {
+	vals := map[string]interface{}{}
+	for _, name := range schema.Order {
+		prop, ok := schema.Properties[name]
+		if !ok {
+			return nil, errors.Errorf("property %q from Order not in schema", name)
+		}
+		v, err := p.queryProp(prop)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		vals[name] = v
+	}
+	return vals, nil
+}
+
+func (p *Pollster) queryProp(prop *jsonschema.Schema) (interface{}, error) {
+	if isObject(prop) {
+		return p.queryObjectSchema(prop)
+	}
+	return p.queryOneSchema(prop)
+}
+
+func (p *Pollster) queryAdditionalProps(vals map[string]interface{}, schema *jsonschema.Schema) error {
+	if schema.AdditionalProperties.Type[0] != jsonschema.ObjectType {
+		return errors.Errorf("don't know how to query for additional properties of type %q", schema.AdditionalProperties.Type[0])
+	}
+
+	verifyName := func(s string) (ok bool, errmsg string, err error) {
+		if s == "" {
+			return false, "", nil
+		}
+		if _, ok := vals[s]; ok {
+			return false, fmt.Sprintf("%s %q already exists", strings.Title(schema.Singular), s), nil
+		}
+		return true, "", nil
+	}
+
+	// Currently we assume we always prompt for at least one value for
+	// additional properties, but we may want to change this to ask if they want
+	// to enter any at all.
+	for {
+		// We assume that the name of the schema is the name of the object the
+		// schema describes, and for additional properties the proeperty name
+		// (i.e. map key) is the "name" of the thing.
+		name, err := p.EnterVerify(schema.Singular+" name", verifyName)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		v, err := p.queryObjectSchema(schema.AdditionalProperties)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		vals[name] = v
+		more, err := p.YN("Enter another "+schema.Singular, true)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if !more {
+			break
+		}
+	}
+
+	return nil
+}
+
+func (p *Pollster) queryOneSchema(schema *jsonschema.Schema) (interface{}, error) {
+	if len(schema.Type) == 0 {
+		return nil, errors.Errorf("invalid schema, no type specified")
+	}
+	if len(schema.Type) > 1 {
+		return nil, errors.Errorf("don't know how to query for a value with multiple types")
+	}
+	if len(schema.Enum) == 1 {
+		// if there's only one possible value, don't bother prompting, just
+		// return that value.
+		return schema.Enum[0], nil
+	}
+	if schema.Type[0] == jsonschema.ArrayType {
+		if !supportedArraySchema(schema) {
+			b, err := schema.MarshalJSON()
+			if err != nil {
+				return nil, errors.Errorf("unsupported schema for an array")
+			}
+			return nil, errors.Errorf("unsupported schema for an array: %s", b)
+		}
+		return p.MultiSelect(MultiList{
+			Singular: schema.Singular,
+			Plural:   schema.Plural,
+			Options:  optFromEnum(schema.Items.Schemas[0]),
+		})
+	}
+	if len(schema.Enum) > 1 {
+		return p.selectOne(schema)
+	}
+	var a string
+	var err error
+	switch schema.Format {
+	case "":
+		// anything
+		a, err = p.Enter(schema.Singular)
+	case jsonschema.FormatURI:
+		a, err = p.EnterVerify(schema.Singular, uriVerify)
+	default:
+		// TODO(natefinch): support more formats
+		return nil, errors.Errorf("unsupported format type: %q", schema.Format)
+	}
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return convert(a, schema.Type[0])
+}
+
+func uriVerify(s string) (ok bool, errMsg string, err error) {
+	if s == "" {
+		return false, "", nil
+	}
+	_, err = url.Parse(s)
+	if err != nil {
+		return false, fmt.Sprintf("Invalid URI: %q", s), nil
+	}
+	return true, "", nil
+}
+
+func supportedArraySchema(schema *jsonschema.Schema) bool {
+	// TODO(natefinch): support arrays without schemas.
+	// TODO(natefinch): support arrays with multiple schemas.
+	// TODO(natefinch): support arrays without Enums.
+	if schema.Items == nil ||
+		len(schema.Items.Schemas) != 1 ||
+		len(schema.Items.Schemas[0].Enum) == 0 ||
+		len(schema.Items.Schemas[0].Type) != 1 {
+		return false
+	}
+	switch schema.Items.Schemas[0].Type[0] {
+	case jsonschema.IntegerType,
+		jsonschema.StringType,
+		jsonschema.BooleanType,
+		jsonschema.NumberType:
+		return true
+	default:
+		return false
+	}
+}
+
+func optFromEnum(schema *jsonschema.Schema) []string {
+	ret := make([]string, len(schema.Enum))
+	for i := range schema.Enum {
+		ret[i] = fmt.Sprint(schema.Enum[i])
+	}
+	return ret
+}
+
+func (p *Pollster) selectOne(schema *jsonschema.Schema) (interface{}, error) {
+	options := make([]string, len(schema.Enum))
+	for i := range schema.Enum {
+		options[i] = fmt.Sprint(schema.Enum[i])
+	}
+	def := ""
+	if schema.Default != nil {
+		def = fmt.Sprint(schema.Default)
+	}
+	a, err := p.Select(List{
+		Singular: schema.Singular,
+		Plural:   schema.Plural,
+		Options:  options,
+		Default:  def,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if schema.Default != nil && a == "" {
+		return schema.Default, nil
+	}
+	return convert(a, schema.Type[0])
+}
+
+func isObject(schema *jsonschema.Schema) bool {
+	for _, t := range schema.Type {
+		if t == jsonschema.ObjectType {
+			return true
+		}
+	}
+	return false
+}
+
+func convArray(vals []string, schema *jsonschema.Schema) (interface{}, error) {
+	ret := make([]interface{}, len(vals))
+	for i := range vals {
+		v, err := convert(vals[i], schema.Type[0])
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		ret[i] = v
+	}
+	return ret, nil
+}
+
+// convert converts the given string to a specific value based on the schema
+// type that validated it.
+func convert(s string, t jsonschema.Type) (interface{}, error) {
+	switch t {
+	case jsonschema.IntegerType:
+		return strconv.Atoi(s)
+	case jsonschema.NumberType:
+		return strconv.ParseFloat(s, 64)
+	case jsonschema.StringType:
+		return s, nil
+	case jsonschema.BooleanType:
+		switch strings.ToLower(s) {
+		case "y", "yes", "true", "t":
+			return true, nil
+		case "n", "no", "false", "f":
+			return false, nil
+		default:
+			return nil, errors.Errorf("unknown value for boolean type: %q", s)
+		}
+	default:
+		return nil, errors.Errorf("don't know how to convert value %q of type %q", s, t)
+	}
+}

--- a/cmd/juju/interact/pollster_test.go
+++ b/cmd/juju/interact/pollster_test.go
@@ -316,6 +316,35 @@ Select one or more numbers separated by commas:
 	c.Check(s, jc.SameContents, []string{"one", "three"})
 }
 
+func (PollsterSuite) TestQueryEnum(c *gc.C) {
+	schema := &jsonschema.Schema{
+		Singular: "number",
+		Plural:   "numbers",
+		Type:     []jsonschema.Type{jsonschema.IntegerType},
+		Enum: []interface{}{
+			1,
+			2,
+			3,
+		},
+	}
+	r := strings.NewReader("2")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	v, err := p.QuerySchema(schema)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(w.String(), gc.Equals, `
+Numbers
+  1
+  2
+  3
+
+Select number: 
+`[1:])
+	i, ok := v.(int)
+	c.Check(ok, jc.IsTrue)
+	c.Check(i, gc.Equals, 2)
+}
+
 func (PollsterSuite) TestQueryObjectSchema(c *gc.C) {
 	schema := &jsonschema.Schema{
 		Type: []jsonschema.Type{jsonschema.ObjectType},

--- a/cmd/juju/interact/pollster_test.go
+++ b/cmd/juju/interact/pollster_test.go
@@ -1,0 +1,466 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package interact
+
+import (
+	"bytes"
+	"io"
+	"strings"
+
+	"github.com/juju/jsonschema"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/pkg/errors"
+	gc "gopkg.in/check.v1"
+)
+
+type PollsterSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(PollsterSuite{})
+
+func (PollsterSuite) TestSelect(c *gc.C) {
+	r := strings.NewReader("macintosh")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	s, err := p.Select(List{
+		Singular: "apple",
+		Plural:   "apples",
+		Options:  []string{"macintosh", "granny smith"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s, gc.Equals, "macintosh")
+
+	// Note: please only check the full output here, so that we don't have to
+	// edit a million tests if we make minor tweaks to the output.
+	c.Assert(w.String(), gc.Equals, `
+Apples
+  macintosh
+  granny smith
+
+Select apple: 
+`[1:])
+}
+
+func (PollsterSuite) TestSelectDefault(c *gc.C) {
+	r := strings.NewReader("\n")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	s, err := p.Select(List{
+		Singular: "apple",
+		Plural:   "apples",
+		Options:  []string{"macintosh", "granny smith"},
+		Default:  "macintosh",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s, gc.Equals, "macintosh")
+	c.Assert(w.String(), jc.Contains, `Select apple [macintosh]: `)
+}
+
+func (PollsterSuite) TestSelectIncorrect(c *gc.C) {
+	r := strings.NewReader("mac\nmacintosh")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	s, err := p.Select(List{
+		Singular: "apple",
+		Plural:   "apples",
+		Options:  []string{"macintosh", "granny smith"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s, gc.Equals, "macintosh")
+
+	c.Assert(squash(w.String()), jc.Contains, `Invalid apple: "mac"Select apple:`)
+}
+
+// squash removes all newlines from the given string so our tests can be more
+// resilient in the face of minor tweaks to spacing.
+func squash(s string) string {
+	return strings.Replace(s, "\n", "", -1)
+}
+
+func (PollsterSuite) TestSelectNoMultiple(c *gc.C) {
+	r := strings.NewReader("macintosh,granny smith\ngranny smith")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	s, err := p.Select(List{
+		Singular: "apple",
+		Plural:   "apples",
+		Options:  []string{"macintosh", "granny smith"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s, gc.Equals, "granny smith")
+	c.Assert(w.String(), jc.Contains, `Invalid apple: "macintosh,granny smith"`)
+}
+
+func (PollsterSuite) TestMultiSelectSingle(c *gc.C) {
+	r := strings.NewReader("macintosh")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	vals, err := p.MultiSelect(MultiList{
+		Singular: "apple",
+		Plural:   "apples",
+		Options:  []string{"macintosh", "granny smith", "gala"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(vals, jc.SameContents, []string{"macintosh"})
+}
+
+func (PollsterSuite) TestMultiSelectMany(c *gc.C) {
+	// note there's a couple spaces in the middle here that we're stripping out.
+	r := strings.NewReader("macintosh,  granny smith")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	vals, err := p.MultiSelect(MultiList{
+		Singular: "apple",
+		Plural:   "apples",
+		Options:  []string{"macintosh", "granny smith", "gala"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(vals, jc.SameContents, []string{"macintosh", "granny smith"})
+}
+
+func (PollsterSuite) TestMultiSelectDefault(c *gc.C) {
+	r := strings.NewReader("\n")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	vals, err := p.MultiSelect(MultiList{
+		Singular: "apple",
+		Plural:   "apples",
+		Options:  []string{"macintosh", "granny smith", "gala"},
+		Default:  []string{"gala", "granny smith"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(vals, jc.SameContents, []string{"gala", "granny smith"})
+}
+
+func (PollsterSuite) TestMultiSelectOneError(c *gc.C) {
+	r := strings.NewReader("mac\nmacintosh")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	vals, err := p.MultiSelect(MultiList{
+		Singular: "apple",
+		Plural:   "apples",
+		Options:  []string{"macintosh", "granny smith", "gala"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(vals, jc.SameContents, []string{"macintosh"})
+	c.Assert(w.String(), jc.Contains, `Invalid apple: "mac"`)
+}
+
+func (PollsterSuite) TestMultiSelectManyErrors(c *gc.C) {
+	r := strings.NewReader("mac,  smith\nmacintosh")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	vals, err := p.MultiSelect(MultiList{
+		Singular: "apple",
+		Plural:   "apples",
+		Options:  []string{"macintosh", "granny smith", "gala"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(vals, jc.SameContents, []string{"macintosh"})
+	c.Assert(w.String(), jc.Contains, `Invalid apples: "mac", "smith"`)
+}
+
+func (PollsterSuite) TestEnter(c *gc.C) {
+	r := strings.NewReader("Bill Smith")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	a, err := p.Enter("your name")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(a, gc.Equals, "Bill Smith")
+	c.Assert(w.String(), gc.Equals, "Enter your name: \n")
+}
+
+func (PollsterSuite) TestEnterEmpty(c *gc.C) {
+	r := strings.NewReader("\nBill")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	a, err := p.Enter("your name")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(a, gc.Equals, "Bill")
+	// We should re-query without any error on empty input.
+	c.Assert(squash(w.String()), jc.Contains, "Enter your name: Enter your name: ")
+}
+
+func (PollsterSuite) TestYNDefaultFalse(c *gc.C) {
+	r := strings.NewReader("Y")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	a, err := p.YN("Should this test pass", false)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(a, jc.IsTrue)
+	c.Assert(w.String(), gc.Equals, "Should this test pass? (y/N): \n")
+}
+
+func (PollsterSuite) TestYNDefaultTrue(c *gc.C) {
+	r := strings.NewReader("Y")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	a, err := p.YN("Should this test pass", true)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(a, jc.IsTrue)
+	c.Assert(w.String(), gc.Equals, "Should this test pass? (Y/n): \n")
+}
+
+func (PollsterSuite) TestYNTable(c *gc.C) {
+	tests := []struct {
+		In       string
+		Def, Res bool
+	}{
+		0:  {In: "Y", Def: false, Res: true},
+		1:  {In: "y", Def: false, Res: true},
+		2:  {In: "yes", Def: false, Res: true},
+		3:  {In: "YES", Def: false, Res: true},
+		4:  {In: "N", Def: true, Res: false},
+		5:  {In: "n", Def: true, Res: false},
+		6:  {In: "no", Def: true, Res: false},
+		7:  {In: "NO", Def: true, Res: false},
+		8:  {In: "Y", Def: true, Res: true},
+		9:  {In: "y", Def: true, Res: true},
+		10: {In: "yes", Def: true, Res: true},
+		11: {In: "YES", Def: true, Res: true},
+		12: {In: "N", Def: false, Res: false},
+		13: {In: "n", Def: false, Res: false},
+		14: {In: "no", Def: false, Res: false},
+		15: {In: "NO", Def: false, Res: false},
+	}
+	for i, test := range tests {
+		c.Logf("test %d", i)
+		r := strings.NewReader(test.In)
+		w := &bytes.Buffer{}
+		p := New(r, w, w)
+		a, err := p.YN("doesn't matter", test.Def)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(a, gc.Equals, test.Res)
+	}
+}
+
+func (PollsterSuite) TestYNInvalid(c *gc.C) {
+	r := strings.NewReader("wat\nY")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	a, err := p.YN("Should this test pass", false)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(a, jc.IsTrue)
+	c.Assert(w.String(), jc.Contains, `Invalid entry: "wat", please choose y or n`)
+}
+
+func (PollsterSuite) TestQueryStringSchema(c *gc.C) {
+	schema := &jsonschema.Schema{
+		Singular: "region",
+		Type:     []jsonschema.Type{jsonschema.StringType},
+	}
+	r := strings.NewReader("wat")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	v, err := p.QuerySchema(schema)
+	c.Assert(err, jc.ErrorIsNil)
+	s, ok := v.(string)
+	c.Check(ok, jc.IsTrue)
+	c.Check(s, gc.Equals, "wat")
+	c.Assert(w.String(), jc.Contains, "Enter region:")
+}
+
+func (PollsterSuite) TestQueryURISchema(c *gc.C) {
+	schema := &jsonschema.Schema{
+		Singular: "region",
+		Type:     []jsonschema.Type{jsonschema.StringType},
+		Format:   jsonschema.FormatURI,
+	}
+	// invalid escape sequence
+	r := strings.NewReader("https://&%5abc")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	_, err := p.QuerySchema(schema)
+	c.Check(errors.Cause(err), gc.Equals, io.EOF)
+	c.Assert(w.String(), gc.Equals, `
+Enter region: Invalid URI: "https://&%5abc"
+
+Enter region: 
+`[1:])
+}
+
+func (PollsterSuite) TestQueryArraySchema(c *gc.C) {
+	schema := &jsonschema.Schema{
+		Singular: "number",
+		Plural:   "numbers",
+		Type:     []jsonschema.Type{jsonschema.ArrayType},
+		Items: &jsonschema.ItemSpec{
+			Schemas: []*jsonschema.Schema{{
+				Type: []jsonschema.Type{jsonschema.StringType},
+				Enum: []interface{}{
+					"one",
+					"two",
+					"three",
+				},
+			}},
+		},
+	}
+	r := strings.NewReader("one, three")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	v, err := p.QuerySchema(schema)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(w.String(), gc.Equals, `
+Numbers
+  one
+  two
+  three
+
+Select one or more numbers separated by commas: 
+`[1:])
+	s, ok := v.([]string)
+	c.Check(ok, jc.IsTrue)
+	c.Check(s, jc.SameContents, []string{"one", "three"})
+}
+
+func (PollsterSuite) TestQueryObjectSchema(c *gc.C) {
+	schema := &jsonschema.Schema{
+		Type: []jsonschema.Type{jsonschema.ObjectType},
+		Properties: map[string]*jsonschema.Schema{
+			"numbers": &jsonschema.Schema{
+				Singular: "number",
+				Plural:   "numbers",
+				Type:     []jsonschema.Type{jsonschema.ArrayType},
+				Items: &jsonschema.ItemSpec{
+					Schemas: []*jsonschema.Schema{{
+						Type: []jsonschema.Type{jsonschema.StringType},
+						Enum: []interface{}{
+							"one",
+							"two",
+							"three",
+						},
+					}},
+				},
+			},
+			"name": &jsonschema.Schema{
+				Type:     []jsonschema.Type{jsonschema.StringType},
+				Singular: "the name",
+			},
+		},
+	}
+	// queries should be alphabetical without an order specified, so name then
+	// number.
+	r := strings.NewReader("Bill\ntwo, three")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	v, err := p.QuerySchema(schema)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(v, jc.DeepEquals, map[string]interface{}{
+		"name":    "Bill",
+		"numbers": []string{"two", "three"},
+	})
+}
+
+func (PollsterSuite) TestQueryObjectSchemaOrder(c *gc.C) {
+	schema := &jsonschema.Schema{
+		Type: []jsonschema.Type{jsonschema.ObjectType},
+		// Order should match up with order of input in strings.NewReader below.
+		Order: []string{"numbers", "name"},
+		Properties: map[string]*jsonschema.Schema{
+			"numbers": &jsonschema.Schema{
+				Singular: "number",
+				Plural:   "numbers",
+				Type:     []jsonschema.Type{jsonschema.ArrayType},
+				Items: &jsonschema.ItemSpec{
+					Schemas: []*jsonschema.Schema{{
+						Type: []jsonschema.Type{jsonschema.StringType},
+						Enum: []interface{}{
+							"one",
+							"two",
+							"three",
+						},
+					}},
+				},
+			},
+			"name": &jsonschema.Schema{
+				Type:     []jsonschema.Type{jsonschema.StringType},
+				Singular: "the name",
+			},
+		},
+	}
+	// queries should be ordered by order, so number then name.
+	r := strings.NewReader("two, three\nBill")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	v, err := p.QuerySchema(schema)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(v, jc.DeepEquals, map[string]interface{}{
+		"name":    "Bill",
+		"numbers": []string{"two", "three"},
+	})
+}
+
+func (PollsterSuite) TestQueryObjectSchemaAdditional(c *gc.C) {
+	schema := &jsonschema.Schema{
+		Type:     []jsonschema.Type{jsonschema.ObjectType},
+		Singular: "region",
+		Plural:   "regions",
+		AdditionalProperties: &jsonschema.Schema{
+			Type: []jsonschema.Type{jsonschema.ObjectType},
+			Properties: map[string]*jsonschema.Schema{
+				"loc": {
+					Singular: "location",
+					Type:     []jsonschema.Type{jsonschema.StringType},
+				},
+			},
+		},
+	}
+	r := strings.NewReader(`
+one
+east
+y
+two
+west
+n
+`[1:])
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	v, err := p.QuerySchema(schema)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(v, jc.DeepEquals, map[string]interface{}{
+		"one": map[string]interface{}{"loc": "east"},
+		"two": map[string]interface{}{"loc": "west"},
+	})
+	c.Check(w.String(), gc.Equals, `
+Enter region name: 
+Enter location: 
+Enter another region? (Y/n): 
+Enter region name: 
+Enter location: 
+Enter another region? (Y/n): 
+`[1:])
+}
+
+func (PollsterSuite) TestQueryObjectSchemaAdditionalEmpty(c *gc.C) {
+	schema := &jsonschema.Schema{
+		Type:     []jsonschema.Type{jsonschema.ObjectType},
+		Singular: "region",
+		Plural:   "regions",
+		AdditionalProperties: &jsonschema.Schema{
+			Type: []jsonschema.Type{jsonschema.ObjectType},
+		},
+	}
+	r := strings.NewReader(`
+one
+y
+two
+n
+`[1:])
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	v, err := p.QuerySchema(schema)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(v, jc.DeepEquals, map[string]interface{}{
+		"one": map[string]interface{}{},
+		"two": map[string]interface{}{},
+	})
+	c.Check(w.String(), gc.Equals, `
+Enter region name: 
+Enter another region? (Y/n): 
+Enter region name: 
+Enter another region? (Y/n): 
+`[1:])
+}

--- a/cmd/juju/interact/query.go
+++ b/cmd/juju/interact/query.go
@@ -13,36 +13,57 @@ import (
 // QueryVerify writes a question to w and waits for an answer to be read from
 // scanner.  It will pass the answer into the verify function.  Verify, if
 // non-nil, should check the answer for validity, returning an error that will
-// be written out to the user, or nil if answer is valid.
+// be written out to errOut, or nil if answer is valid.
 //
 // This function takes a scanner rather than an io.Reader to avoid the case
 // where the scanner reads past the delimiter and thus might lose data.  It is
 // expected that this method will be used repeatedly with the same scanner if
 // multiple queries are required.
-func QueryVerify(question []byte, scanner *bufio.Scanner, w io.Writer, verify func(string) error) (answer string, err error) {
-	defer fmt.Fprint(w, "\n")
+func QueryVerify(question string, scanner *bufio.Scanner, out, errOut io.Writer, verify VerifyFunc) (answer string, err error) {
+	defer fmt.Fprint(out, "\n")
 	for {
-		if _, err = w.Write(question); err != nil {
+		if _, err = out.Write([]byte(question)); err != nil {
 			return "", err
 		}
 
-		if !scanner.Scan() {
+		done := !scanner.Scan()
+
+		if done {
 			if err := scanner.Err(); err != nil {
 				return "", err
 			}
-			return "", io.EOF
 		}
 		answer = scanner.Text()
+		if done && answer == "" {
+			// EOF
+			return "", io.EOF
+		}
 		if verify == nil {
 			return answer, nil
 		}
-		err := verify(answer)
+		ok, msg, err := verify(answer)
+		if err != nil {
+			return "", err
+		}
 		// valid answer, return it!
-		if err == nil {
+		if ok {
 			return answer, nil
 		}
+
+		if done {
+			// can't query any more, nothing we can do.
+			return "", io.EOF
+		}
+
 		// invalid answer, inform user of problem and retry.
-		_, err = fmt.Fprint(w, err, "\n\n")
+
+		if msg != "" {
+			_, err := fmt.Fprint(errOut, msg+"\n")
+			if err != nil {
+				return "", err
+			}
+		}
+		_, err = errOut.Write([]byte{'\n'})
 		if err != nil {
 			return "", err
 		}
@@ -52,14 +73,14 @@ func QueryVerify(question []byte, scanner *bufio.Scanner, w io.Writer, verify fu
 // MatchOptions returns a function that performs a case insensitive comparison
 // against the given list of options.  To make a verification function that
 // accepts an empty default, include an empty string in the list.
-func MatchOptions(options []string, err error) func(string) error {
-	return func(s string) error {
+func MatchOptions(options []string, errmsg string) VerifyFunc {
+	return func(s string) (ok bool, msg string, err error) {
 		for _, opt := range options {
 			if strings.ToLower(opt) == strings.ToLower(s) {
-				return nil
+				return true, "", nil
 			}
 		}
-		return err
+		return false, errmsg, nil
 	}
 }
 

--- a/cmd/juju/interact/query.go
+++ b/cmd/juju/interact/query.go
@@ -50,13 +50,7 @@ func QueryVerify(question string, scanner *bufio.Scanner, out, errOut io.Writer,
 			return answer, nil
 		}
 
-		if done {
-			// can't query any more, nothing we can do.
-			return "", io.EOF
-		}
-
 		// invalid answer, inform user of problem and retry.
-
 		if msg != "" {
 			_, err := fmt.Fprint(errOut, msg+"\n")
 			if err != nil {
@@ -66,6 +60,11 @@ func QueryVerify(question string, scanner *bufio.Scanner, out, errOut io.Writer,
 		_, err = errOut.Write([]byte{'\n'})
 		if err != nil {
 			return "", err
+		}
+
+		if done {
+			// can't query any more, nothing we can do.
+			return "", io.EOF
 		}
 	}
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -22,6 +22,7 @@ github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-2
 github.com/juju/bundlechanges	git	6791af0ab78efe88ff99c2a0095208b3b7a32055	2016-07-20T09:32:50Z
 github.com/juju/cmd	git	1c6973d59b804e4d3c293fbf240f067e73436bc9	2016-08-23T10:31:14Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
+github.com/juju/jsonschema	git	a0ef8b74ebcffeeff9fc374854deb4af388f037e	2016-11-02T18:19:19Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:32:58Z
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
@@ -51,12 +52,19 @@ github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 github.com/juju/zip	git	f6b1e93fa2e29a1d7d49b566b2b51efb060c982a	2016-02-05T10:52:21Z
 github.com/julienschmidt/httprouter	git	77a895ad01ebc98a4dc95d8355bc825ce80a56f6	2015-10-13T22:55:20Z
+github.com/lestrrat/go-jspointer	git	f4881e611bdbe9fb413a7780721ef8400a1f2341	2016-02-29T02:13:54Z
+github.com/lestrrat/go-jsref	git	e452c7b5801d1c6494c9e7e0cbc7498c0f88dfd1	2016-06-01T01:32:40Z
+github.com/lestrrat/go-jsschema	git	b09d7650b822d2ea3dc83d5091a5e2acd8330051	2016-09-03T13:19:57Z
+github.com/lestrrat/go-jsval	git	b1258a10419fe0693f7b35ad65cd5074bc0ba1e5	2016-10-12T04:57:17Z
+github.com/lestrrat/go-pdebug	git	2e6eaaa5717f81bda41d27070d3c966f40a1e75f	2016-08-17T06:33:33Z
+github.com/lestrrat/go-structinfo	git	f74c056fe41f860aa6264478c664a6fff8a64298	2016-03-08T13:11:05Z
 github.com/lunixbochs/vtclean	git	4fbf7632a2c6d3fbdb9931439bdbbeded02cbe36	2016-01-25T03:51:06Z
 github.com/lxc/lxd	git	95a324a23696e937c466996d57554e3677b3c84a	2016-10-11T20:54:09Z
 github.com/mattn/go-colorable	git	ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8	2016-07-31T23:54:17Z
 github.com/mattn/go-isatty	git	66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8	2016-08-06T12:27:52Z
 github.com/mattn/go-runewidth	git	d96d1bd051f2bd9e7e43d602782b37b93b1b5666	2015-11-18T07:21:59Z
 github.com/matttproud/golang_protobuf_extensions	git	c12348ce28de40eed0136aa2b644d0ee0650e56c	2016-04-24T11:30:07Z
+github.com/pkg/errors	git	839d9e913e063e28dfd0e6c7b7512793e0a48be9	2016-10-02T05:25:12Z
 github.com/prometheus/client_golang	git	c5b7fccd204277076155f10851dad72b76a49317	2016-08-17T15:48:24Z
 github.com/prometheus/client_model	git	fa8ad6fec33561be4280a8f0514318c79d7f6cb6	2015-02-12T10:17:44Z
 github.com/prometheus/common	git	dd586c1c5abb0be59e60f942c22af711a2008cb4	2016-05-03T22:05:32Z

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -22,6 +22,9 @@ type EnvironProvider interface {
 	config.Validator
 	ProviderCredentials
 
+	// CloudSchema returns the schema used to validate input for add-cloud.  If
+	// a provider does not suppport custom clouds, CloudSchema should return
+	// nil.
 	CloudSchema() *jsonschema.Schema
 
 	// PrepareConfig prepares the configuration for a new model, based on

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -8,6 +8,7 @@ import (
 
 	"gopkg.in/juju/environschema.v1"
 
+	"github.com/juju/jsonschema"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
@@ -21,7 +22,7 @@ type EnvironProvider interface {
 	config.Validator
 	ProviderCredentials
 
-	// TODO(wallyworld) - embed config.ConfigSchemaSource and make all providers implement it
+	CloudSchema() *jsonschema.Schema
 
 	// PrepareConfig prepares the configuration for a new model, based on
 	// the provided arguments. PrepareConfig is expected to produce a

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -6,6 +6,7 @@ package azure
 import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/juju/errors"
+	"github.com/juju/jsonschema"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/clock"
 
@@ -95,6 +96,10 @@ func (prov *azureEnvironProvider) Open(args environs.OpenParams) (environs.Envir
 		return nil, errors.Annotate(err, "opening model")
 	}
 	return environ, nil
+}
+
+func (p azureEnvironProvider) CloudSchema() *jsonschema.Schema {
+	return nil
 }
 
 // PrepareConfig is part of the EnvironProvider interface.

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -98,6 +98,8 @@ func (prov *azureEnvironProvider) Open(args environs.OpenParams) (environs.Envir
 	return environ, nil
 }
 
+// CloudSchema returns the schema used to validate input for add-cloud.  Since
+// this provider does not support custom clouds, this always returns nil.
 func (p azureEnvironProvider) CloudSchema() *jsonschema.Schema {
 	return nil
 }

--- a/provider/cloudsigma/provider.go
+++ b/provider/cloudsigma/provider.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/jsonschema"
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
 
@@ -79,6 +80,9 @@ func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) 
 	}
 
 	return env, nil
+}
+func (p environProvider) CloudSchema() *jsonschema.Schema {
+	return nil
 }
 
 // PrepareConfig is defined by EnvironProvider.

--- a/provider/cloudsigma/provider.go
+++ b/provider/cloudsigma/provider.go
@@ -81,6 +81,9 @@ func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) 
 
 	return env, nil
 }
+
+// CloudSchema returns the schema used to validate input for add-cloud.  Since
+// this provider does not support custom clouds, this always returns nil.
 func (p environProvider) CloudSchema() *jsonschema.Schema {
 	return nil
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/jsonschema"
 	"github.com/juju/loggo"
 	"github.com/juju/retry"
 	"github.com/juju/schema"
@@ -611,6 +612,9 @@ func (p *environProvider) Open(args environs.OpenParams) (environs.Environ, erro
 		return nil, err
 	}
 	return env, nil
+}
+func (p environProvider) CloudSchema() *jsonschema.Schema {
+	return nil
 }
 
 // PrepareConfig is specified in the EnvironProvider interface.

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -613,6 +613,9 @@ func (p *environProvider) Open(args environs.OpenParams) (environs.Environ, erro
 	}
 	return env, nil
 }
+
+// CloudSchema returns the schema used to validate input for add-cloud.  Since
+// this provider does not support custom clouds, this always returns nil.
 func (p environProvider) CloudSchema() *jsonschema.Schema {
 	return nil
 }

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -97,6 +97,9 @@ func awsClient(cloud environs.CloudSpec) (*ec2.EC2, error) {
 	signer := aws.SignV4Factory(cloud.Region, "ec2")
 	return ec2.New(auth, region, signer), nil
 }
+
+// CloudSchema returns the schema used to validate input for add-cloud.  Since
+// this provider does not support custom clouds, this always returns nil.
 func (p environProvider) CloudSchema() *jsonschema.Schema {
 	return nil
 }

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/jsonschema"
 	"github.com/juju/loggo"
 	"gopkg.in/amz.v3/aws"
 	"gopkg.in/amz.v3/ec2"
@@ -95,6 +96,9 @@ func awsClient(cloud environs.CloudSpec) (*ec2.EC2, error) {
 	}
 	signer := aws.SignV4Factory(cloud.Region, "ec2")
 	return ec2.New(auth, region, signer), nil
+}
+func (p environProvider) CloudSchema() *jsonschema.Schema {
+	return nil
 }
 
 // PrepareConfig is specified in the EnvironProvider interface.

--- a/provider/gce/provider.go
+++ b/provider/gce/provider.go
@@ -5,6 +5,7 @@ package gce
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/jsonschema"
 	"github.com/juju/schema"
 	"gopkg.in/juju/environschema.v1"
 
@@ -26,6 +27,9 @@ func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) 
 	}
 	env, err := newEnviron(args.Cloud, args.Config)
 	return env, errors.Trace(err)
+}
+func (p environProvider) CloudSchema() *jsonschema.Schema {
+	return nil
 }
 
 // PrepareConfig implements environs.EnvironProvider.

--- a/provider/gce/provider.go
+++ b/provider/gce/provider.go
@@ -28,6 +28,9 @@ func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) 
 	env, err := newEnviron(args.Cloud, args.Config)
 	return env, errors.Trace(err)
 }
+
+// CloudSchema returns the schema used to validate input for add-cloud.  Since
+// this provider does not support custom clouds, this always returns nil.
 func (p environProvider) CloudSchema() *jsonschema.Schema {
 	return nil
 }

--- a/provider/joyent/provider.go
+++ b/provider/joyent/provider.go
@@ -47,6 +47,8 @@ var _ environs.EnvironProvider = providerInstance
 
 var _ simplestreams.HasRegion = (*joyentEnviron)(nil)
 
+// CloudSchema returns the schema used to validate input for add-cloud.  Since
+// this provider does not support custom clouds, this always returns nil.
 func (p joyentProvider) CloudSchema() *jsonschema.Schema {
 	return nil
 }

--- a/provider/joyent/provider.go
+++ b/provider/joyent/provider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/joyent/gosdc/cloudapi"
 	"github.com/joyent/gosign/auth"
 	"github.com/juju/errors"
+	"github.com/juju/jsonschema"
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/cloud"
@@ -45,6 +46,10 @@ var providerInstance = joyentProvider{}
 var _ environs.EnvironProvider = providerInstance
 
 var _ simplestreams.HasRegion = (*joyentEnviron)(nil)
+
+func (p joyentProvider) CloudSchema() *jsonschema.Schema {
+	return nil
+}
 
 // PrepareConfig is part of the EnvironProvider interface.
 func (p joyentProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -32,6 +32,9 @@ func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) 
 	env, err := newEnviron(args.Cloud, args.Config, newRawProvider)
 	return env, errors.Trace(err)
 }
+
+// CloudSchema returns the schema used to validate input for add-cloud.  Since
+// this provider does not support custom clouds, this always returns nil.
 func (p environProvider) CloudSchema() *jsonschema.Schema {
 	return nil
 }

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -7,6 +7,7 @@ package lxd
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/jsonschema"
 	"github.com/juju/schema"
 	"gopkg.in/juju/environschema.v1"
 
@@ -30,6 +31,9 @@ func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) 
 	// TODO(ericsnow) verify prerequisites (see provider/local/prereq.go)?
 	env, err := newEnviron(args.Cloud, args.Config, newRawProvider)
 	return env, errors.Trace(err)
+}
+func (p environProvider) CloudSchema() *jsonschema.Schema {
+	return nil
 }
 
 // PrepareConfig implements environs.EnvironProvider.

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -62,6 +62,7 @@ func (maasEnvironProvider) Open(args environs.OpenParams) (environs.Environ, err
 var errAgentNameAlreadySet = errors.New(
 	"maas-agent-name is already set; this should not be set by hand")
 
+// CloudSchema returns the schema for adding new clouds of this type.
 func (p maasEnvironProvider) CloudSchema() *jsonschema.Schema {
 	return cloudSchema
 }

--- a/provider/maas/environprovider_test.go
+++ b/provider/maas/environprovider_test.go
@@ -12,7 +12,9 @@ import (
 	"strings"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
+	yaml "gopkg.in/yaml.v1"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
@@ -167,4 +169,20 @@ func (suite *EnvironProviderSuite) TestOpenReturnsNilInterfaceUponFailure(c *gc.
 	// type.
 	c.Check(env, gc.Equals, nil)
 	c.Check(err, gc.ErrorMatches, ".*malformed maas-oauth.*")
+}
+
+func (suite *EnvironProviderSuite) TestSchema(c *gc.C) {
+	y := []byte(`
+auth-types: [oauth1]
+endpoint: http://foo.com/openstack
+`[1:])
+	var v interface{}
+	err := yaml.Unmarshal(y, &v)
+	c.Assert(err, jc.ErrorIsNil)
+	v, err = utils.ConformYAML(v)
+	c.Assert(err, jc.ErrorIsNil)
+
+	p, err := environs.Provider("maas")
+	err = p.CloudSchema().Validate(v)
+	c.Assert(err, jc.ErrorIsNil)
 }

--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/jsonschema"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
@@ -37,6 +38,23 @@ func ensureBootstrapUbuntuUser(ctx environs.BootstrapContext, host, user string,
 // DetectRegions is specified in the environs.CloudRegionDetector interface.
 func (p manualProvider) DetectRegions() ([]cloud.Region, error) {
 	return nil, errors.NotFoundf("regions")
+}
+
+var cloudSchema = &jsonschema.Schema{
+	Type:     []jsonschema.Type{jsonschema.ObjectType},
+	Required: []string{cloud.EndpointKey},
+	Properties: map[string]*jsonschema.Schema{
+		cloud.EndpointKey: &jsonschema.Schema{
+			Singular: "the controller's hostname or IP address",
+			Type:     []jsonschema.Type{jsonschema.StringType},
+			Format:   jsonschema.FormatURI,
+		},
+	},
+}
+
+// CloudSchema returns the schema for verifying cloud
+func (p manualProvider) CloudSchema() *jsonschema.Schema {
+	return cloudSchema
 }
 
 // PrepareConfig is specified in the EnvironProvider interface.

--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -52,7 +52,7 @@ var cloudSchema = &jsonschema.Schema{
 	},
 }
 
-// CloudSchema returns the schema for verifying cloud
+// CloudSchema returns the schema for verifying the cloud configuration.
 func (p manualProvider) CloudSchema() *jsonschema.Schema {
 	return cloudSchema
 }

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -122,3 +122,12 @@ func (s *providerSuite) TestDefaultsCanBeOverriden(c *gc.C) {
 	c.Check(validCfg.EnableOSRefreshUpdate(), jc.IsTrue)
 	c.Check(validCfg.EnableOSUpgrade(), jc.IsTrue)
 }
+
+func (s *providerSuite) TestSchema(c *gc.C) {
+	vals := map[string]interface{}{"endpoint": "http://foo.com/bar"}
+
+	p, err := environs.Provider("manual")
+	c.Assert(err, jc.ErrorIsNil)
+	err = p.CloudSchema().Validate(vals)
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -80,10 +80,10 @@ var cloudSchema = &jsonschema.Schema{
 				Schemas: []*jsonschema.Schema{{
 					Type: []jsonschema.Type{jsonschema.StringType},
 					Enum: []interface{}{
-						cloud.OAuth1AuthType,
-						cloud.OAuth2AuthType,
-						cloud.AccessKeyAuthType,
-						cloud.UserPassAuthType,
+						string(cloud.OAuth1AuthType),
+						string(cloud.OAuth2AuthType),
+						string(cloud.AccessKeyAuthType),
+						string(cloud.UserPassAuthType),
 					},
 				}},
 			},

--- a/provider/rackspace/provider.go
+++ b/provider/rackspace/provider.go
@@ -17,6 +17,8 @@ type environProvider struct {
 
 var providerInstance *environProvider
 
+// CloudSchema returns the schema used to validate input for add-cloud.  Since
+// this provider does not support custom clouds, this always returns nil.
 func (p environProvider) CloudSchema() *jsonschema.Schema {
 	return nil
 }

--- a/provider/rackspace/provider.go
+++ b/provider/rackspace/provider.go
@@ -6,6 +6,7 @@ package rackspace
 import (
 	"strings"
 
+	"github.com/juju/jsonschema"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 )
@@ -15,6 +16,10 @@ type environProvider struct {
 }
 
 var providerInstance *environProvider
+
+func (p environProvider) CloudSchema() *jsonschema.Schema {
+	return nil
+}
 
 // PrepareConfig is part of the EnvironProvider interface.
 func (p *environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {

--- a/provider/rackspace/provider_test.go
+++ b/provider/rackspace/provider_test.go
@@ -4,6 +4,7 @@
 package rackspace_test
 
 import (
+	"github.com/juju/jsonschema"
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
@@ -83,6 +84,11 @@ func (p *fakeProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *c
 func (p *fakeProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {
 	p.MethodCall(p, "Validate", cfg, old)
 	return cfg, nil
+}
+
+func (p *fakeProvider) CloudSchema() *jsonschema.Schema {
+	p.MethodCall(p, "CloudSchema")
+	return nil
 }
 
 func (p *fakeProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -7,6 +7,7 @@ package vsphere
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/jsonschema"
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/cloud"
@@ -30,6 +31,37 @@ func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) 
 	}
 	env, err := newEnviron(args.Cloud, args.Config)
 	return env, errors.Trace(err)
+}
+
+var cloudSchema = &jsonschema.Schema{
+	Type:     []jsonschema.Type{jsonschema.ObjectType},
+	Required: []string{cloud.EndpointKey, cloud.AuthTypesKey, cloud.RegionsKey},
+	Order:    []string{cloud.EndpointKey, cloud.AuthTypesKey, cloud.RegionsKey},
+	Properties: map[string]*jsonschema.Schema{
+		cloud.EndpointKey: {
+			Singular: "the API endpoint url for the cloud",
+			Type:     []jsonschema.Type{jsonschema.StringType},
+			Format:   jsonschema.FormatURI,
+		},
+		cloud.AuthTypesKey: &jsonschema.Schema{
+			// don't need a prompt, since there's only one choice.
+			Type: []jsonschema.Type{jsonschema.ArrayType},
+			Enum: []interface{}{[]string{string(cloud.UserPassAuthType)}},
+		},
+		cloud.RegionsKey: {
+			Type:     []jsonschema.Type{jsonschema.ObjectType},
+			Singular: "region",
+			Plural:   "regions",
+			AdditionalProperties: &jsonschema.Schema{
+				Type:          []jsonschema.Type{jsonschema.ObjectType},
+				MaxProperties: jsonschema.Int(0),
+			},
+		},
+	},
+}
+
+func (p environProvider) CloudSchema() *jsonschema.Schema {
+	return cloudSchema
 }
 
 // PrepareConfig implements environs.EnvironProvider.

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -60,6 +60,7 @@ var cloudSchema = &jsonschema.Schema{
 	},
 }
 
+// CloudSchema returns the schema for adding new clouds of this type.
 func (p environProvider) CloudSchema() *jsonschema.Schema {
 	return cloudSchema
 }

--- a/provider/vsphere/provider_test.go
+++ b/provider/vsphere/provider_test.go
@@ -7,7 +7,9 @@ package vsphere_test
 
 import (
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
+	yaml "gopkg.in/yaml.v1"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
@@ -86,4 +88,22 @@ func (s *providerSuite) TestValidate(c *gc.C) {
 
 	validAttrs := validCfg.AllAttrs()
 	c.Assert(s.Config.AllAttrs(), gc.DeepEquals, validAttrs)
+}
+func (s *providerSuite) TestSchema(c *gc.C) {
+	y := []byte(`
+auth-types: [userpass]
+endpoint: http://foo.com/vsphere
+regions:
+  foo: {}
+  bar: {}
+`[1:])
+	var v interface{}
+	err := yaml.Unmarshal(y, &v)
+	c.Assert(err, jc.ErrorIsNil)
+	v, err = utils.ConformYAML(v)
+	c.Assert(err, jc.ErrorIsNil)
+
+	p, err := environs.Provider("vsphere")
+	err = p.CloudSchema().Validate(v)
+	c.Assert(err, jc.ErrorIsNil)
 }


### PR DESCRIPTION
This PR adds an interactive way to add a cloud via answering prompts
rather than having to specify a premade yaml file.

It also includes changes to the interact package to support 
standardized ways of querying the user for information, which
can be reused for other interactive commands.

QA:
run `juju add-cloud`
Should show options to create clouds of types maas, manual, openstack, and vsphere.   
Should prompt for all required information to add the cloud, which should be added to your clouds.yaml.
You should then be able to use that cloud definition with juju bootstrap.