### PR TITLE
Fixed bash completions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,8 +99,8 @@ endif
 # Install bash_completion
 install-etc:
 	@echo Installing bash completion
-	@sudo install -o root -g root -m 644 etc/bash_completion.d/juju-2.0 /etc/bash_completion.d
-	@sudo install -o root -g root -m 644 etc/bash_completion.d/juju-version /etc/bash_completion.d
+	@sudo install -o root -g root -m 644 etc/bash_completion.d/juju-2.0 /usr/share/bash-completion/completions
+	@sudo install -o root -g root -m 644 etc/bash_completion.d/juju-version /usr/share/bash-completion/completions
 
 setup-lxd:
 ifeq ($(shell ifconfig lxdbr0 2>&1 | grep -q "inet addr" && echo true),true)

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,8 @@ endif
 # Install bash_completion
 install-etc:
 	@echo Installing bash completion
-	@sudo install -o root -g root -m 644 etc/bash_completion.d/juju2 /etc/bash_completion.d
+	@sudo install -o root -g root -m 644 etc/bash_completion.d/juju-2.0 /etc/bash_completion.d
+	@sudo install -o root -g root -m 644 etc/bash_completion.d/juju-version /etc/bash_completion.d
 
 setup-lxd:
 ifeq ($(shell ifconfig lxdbr0 2>&1 | grep -q "inet addr" && echo true),true)

--- a/etc/bash_completion.d/juju-2.0
+++ b/etc/bash_completion.d/juju-2.0
@@ -42,9 +42,11 @@ import json, sys
 sys.stderr.close()
 j = json.load(sys.stdin)
 all_units = []
-for k, v in j.get("applications", {}).items():
-    all_units.extend(v.get("units", {}).keys())
-print ("\n".join([unit + trail for unit in all_units]))
+try:
+    for k, v in j.get("applications", {}).items():
+        all_units.extend(v.get("units", {}).keys())
+    print ("\n".join([unit + trail for unit in all_units]))
+except: pass
 '   < ${cache_fname}
 }
 
@@ -56,7 +58,9 @@ _juju_2_0_applications_from_status() {
 import json, sys
 sys.stderr.close()
 j = json.load(sys.stdin)
-print ("\n".join(j.get("applications", {}).keys()))
+try:
+    print ("\n".join(j.get("applications", {}).keys()))
+except: pass
 '   < ${cache_fname}
 }
 
@@ -335,13 +339,26 @@ _juju_complete_2_0() {
 }
 # _juju_2_0_cache_TTL [mins]
 export _juju_2_0_cache_TTL=2
+
 # All above completion is juju-2.0 specific, uses $_juju_cmd_JUJU_2_0
-export _juju_cmd_JUJU_2_0=/usr/bin/juju-2.0
+
+# Detect juju built from source (highest priority)
+if [ -x "$GOPATH/bin/juju" ]; then 
+    export _juju_cmd_JUJU_2_0="$GOPATH/bin/juju"
+# Detect installed juju-2.0 binary (next highest priority)
+elif [ -x "/usr/bin/juju-2.0" ]; then
+    export _juju_cmd_JUJU_2_0="/usr/bin/juju-2.0"
+# Use /usr/bin/juju as a last resort.
+else
+    export _juju_cmd_JUJU_2_0="/usr/bin/juju"
+fi
+
 # Select python3, else python2
 export _juju_cmd_PYTHON
 for _juju_cmd_PYTHON in /usr/bin/python{3,2};do
   [ -x ${_juju_cmd_PYTHON?} ] && break
 done
+
 # Add juju-2.0 completion
 complete -F _juju_complete_2_0 juju-2.0
 

--- a/etc/bash_completion.d/juju-2.0
+++ b/etc/bash_completion.d/juju-2.0
@@ -42,11 +42,9 @@ import json, sys
 sys.stderr.close()
 j = json.load(sys.stdin)
 all_units = []
-try:
-    for k, v in j.get("applications", {}).items():
-        all_units.extend(v.get("units", {}).keys())
-    print ("\n".join([unit + trail for unit in all_units]))
-except: pass
+for k, v in j.get("applications", {}).items():
+    all_units.extend(v.get("units", {}).keys())
+print ("\n".join([unit + trail for unit in all_units]))
 '   < ${cache_fname}
 }
 
@@ -58,9 +56,7 @@ _juju_2_0_applications_from_status() {
 import json, sys
 sys.stderr.close()
 j = json.load(sys.stdin)
-try:
-    print ("\n".join(j.get("applications", {}).keys()))
-except: pass
+print ("\n".join(j.get("applications", {}).keys()))
 '   < ${cache_fname}
 }
 


### PR DESCRIPTION
Makefile's install-etc was not installing juju-version
Changed the completions to work for a juju binary, built
from source, as well as the one from the juju-2.0 package.

See bug http://pad.lv/1622775 for more details
(PR was intended to fix it, but simply improves CLI UX)

QA steps:
 1. make install-etc && source /etc/bash_completion
 2. juju boo[tab]tstrap
 3. juju de[tab]p[tab]loy ubuntu
 4. juju status [tab]u[tab]buntu/0