### PR TITLE
logsender: fix race in test

### DIFF
--- a/worker/logsender/bufferedlogwriter_test.go
+++ b/worker/logsender/bufferedlogwriter_test.go
@@ -14,6 +14,7 @@ import (
 
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/logsender"
+	"github.com/juju/juju/worker/logsender/logsendertest"
 )
 
 const maxLen = 6
@@ -120,8 +121,7 @@ func (s *bufferedLogWriterSuite) TestLimiting(c *gc.C) {
 		expect(i, 0)
 	}
 
-	stats := s.writer.Stats()
-	c.Assert(stats, jc.DeepEquals, logsender.LogStats{
+	logsendertest.ExpectLogStats(c, s.writer, logsender.LogStats{
 		Enqueued: maxLen*2 + 3,
 		Sent:     maxLen*2 + 3 - 5,
 		Dropped:  5,

--- a/worker/logsender/logsendertest/logsendertest.go
+++ b/worker/logsender/logsendertest/logsendertest.go
@@ -1,0 +1,31 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package logsendertest provides testing utilities related to
+// the logsender package.
+package logsendertest
+
+import (
+	"reflect"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/logsender"
+)
+
+// ExpectLogStats waits for the buffered log writer's
+// statistics to match the expected value. This is
+// provided because statistics are updated after
+// log messages are handed off to the sink, and so
+// tests must cater for the gap or races will occur.
+func ExpectLogStats(c *gc.C, writer *logsender.BufferedLogWriter, expect logsender.LogStats) {
+	var stats logsender.LogStats
+	for a := testing.LongAttempt.Start(); a.Next(); {
+		stats = writer.Stats()
+		if reflect.DeepEqual(stats, expect) {
+			return
+		}
+	}
+	c.Errorf("timed out waiting for statistics: got %+v, expected %+v", stats, expect)
+}


### PR DESCRIPTION
Need to wait for statistics to be updated,
as there's a brief period between a message
being sent and the counter being updated.