### PR TITLE
Add model config to all watcher ModelInfo

### DIFF
--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -423,6 +423,8 @@ type ModelInfo struct {
 	Owner          string                 `json:"owner"`
 	ControllerUUID string                 `json:"controller-uuid"`
 	Config         map[string]interface{} `json:"config,omitempty"`
+	Status         StatusInfo             `json:"status"`
+	Constraints    constraints.Value      `json:"constraints"`
 }
 
 // EntityId returns a unique identifier for an model.

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -129,6 +129,7 @@ type MachineInfo struct {
 	AgentStatus              StatusInfo                        `json:"agent-status"`
 	InstanceStatus           StatusInfo                        `json:"instance-status"`
 	Life                     Life                              `json:"life"`
+	Config                   map[string]interface{}            `json:"config,omitempty"`
 	Series                   string                            `json:"series"`
 	SupportedContainers      []instance.ContainerType          `json:"supported-containers"`
 	SupportedContainersKnown bool                              `json:"supported-containers-known"`
@@ -416,11 +417,12 @@ const (
 // ModelInfo holds the information about an model that is
 // tracked by multiwatcherStore.
 type ModelInfo struct {
-	ModelUUID      string `json:"model-uuid"`
-	Name           string `json:"name"`
-	Life           Life   `json:"life"`
-	Owner          string `json:"owner"`
-	ControllerUUID string `json:"controller-uuid"`
+	ModelUUID      string                 `json:"model-uuid"`
+	Name           string                 `json:"name"`
+	Life           Life                   `json:"life"`
+	Owner          string                 `json:"owner"`
+	ControllerUUID string                 `json:"controller-uuid"`
+	Config         map[string]interface{} `json:"config,omitempty"`
 }
 
 // EntityId returns a unique identifier for an model.


### PR DESCRIPTION
The allwatcher now supplies ModelInfo objects containing the model config as a name-value map.

A nasty bug was discovered and fixed whereby the models were cached twice and the wrong model entities where being updated when new config arrived. The issue didn't matter until we started storing additional data (config) with the watcher model entities.

QA: bootstrap and smoke test GUI