### PR TITLE
worker/instancepoller: improve test reliability

### DIFF
--- a/worker/instancepoller/updater.go
+++ b/worker/instancepoller/updater.go
@@ -201,6 +201,9 @@ func machineLoop(context machineContext, m machine, lifeChanged <-chan struct{},
 				// We have no addresses or not started - poll increasingly rarely
 				// until we do.
 				pollInterval = time.Duration(float64(pollInterval) * ShortPollBackoff)
+				if pollInterval > LongPoll {
+					pollInterval = LongPoll
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
Improve the reliability of some of the tests by
using fake clocks, making the tests deterministic.

This should stop failures such as
http://reports.vapour.ws/releases/4528/job/run-unit-tests-win2012-amd64/attempt/2983
