### PR TITLE
environs.Destroy: handle NotFound properly

### DIFF
--- a/environs/open.go
+++ b/environs/open.go
@@ -29,7 +29,10 @@ func Destroy(
 	store jujuclient.ControllerStore,
 ) error {
 	details, err := store.ControllerByName(controllerName)
-	if err != nil && !errors.IsNotFound(err) {
+	if errors.IsNotFound(err) {
+		// No controller details, nothing to do.
+		return nil
+	} else if err != nil {
 		return errors.Trace(err)
 	}
 	if err := env.DestroyController(details.ControllerUUID); err != nil {

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -5,6 +5,7 @@ package environs_test
 
 import (
 	"github.com/juju/errors"
+	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -169,4 +170,22 @@ func (*OpenSuite) TestDestroy(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "model is not prepared")
 	_, err = store.ControllerByName("controller-name")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (*OpenSuite) TestDestroyNotFound(c *gc.C) {
+	var env destroyControllerEnv
+	store := jujuclienttesting.NewMemStore()
+	err := environs.Destroy("fnord", &env, store)
+	c.Assert(err, jc.ErrorIsNil)
+	env.CheckCallNames(c) // no controller details, no call
+}
+
+type destroyControllerEnv struct {
+	environs.Environ
+	gitjujutesting.Stub
+}
+
+func (e *destroyControllerEnv) DestroyController(uuid string) error {
+	e.MethodCall(e, "DestroyController", uuid)
+	return e.NextErr()
 }


### PR DESCRIPTION
If the controller details are not found in
the client's controller store, we should
exit early. Currently it continues on and
panics.

Fixes the issue found in:
http://juju-ci.vapour.ws:8080/job/github-merge-juju/9570/artifact/artifacts/lxd-err.log/*view*/