### PR TITLE
Update juju/txn dependency

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -43,7 +43,7 @@ github.com/juju/romulus	git	bf7827fa2f360ab762c134766ff1d4fff959ea03	2016-08-17T
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	692d58e72934a2e2b56f663259696e035e6351ff	2016-09-30T14:09:10Z
-github.com/juju/txn	git	18d812a45ffc407a4d5f849036b7d8d12febaf08	2016-09-13T21:23:40Z
+github.com/juju/txn	git	af2fa2051800371a0272610882891a28c719c02c	2016-10-31T02:11:40Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	28c01ec2ad930d41fe5acd9969b96284eb61660b	2016-10-03T23:32:26Z
 github.com/juju/version	git	4ae6172c00626779a5a462c3e3d22fc0e889431a	2016-06-03T19:49:58Z

--- a/mongo/open.go
+++ b/mongo/open.go
@@ -137,6 +137,9 @@ func DialInfo(info Info, opts DialOpts) (*mgo.DialInfo, error) {
 		cc := tls.Client(c, tlsConfig)
 		if err := cc.Handshake(); err != nil {
 			logger.Warningf("TLS handshake failed: %v", err)
+			if err := c.Close(); err != nil {
+				logger.Warningf("failed to close connection: %v", err)
+			}
 			return nil, err
 		}
 		logger.Debugf("dialled mongodb server at %q", addr)


### PR DESCRIPTION
Also fix a bug where we're not closing net.Conns that we create in mogno.Open if the TLS handshake fails. This shouldn't matter much, because Go sets a finalizer for net.Conns that will close them when garbage collected. Closing them ASAP is better though, as they could accumulate quickly.

Should help with https://bugs.launchpad.net/juju/+bug/1635311.