### PR TITLE
Various test fixes

### DIFF
--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -9,12 +9,14 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
@@ -173,9 +175,11 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 		fetchAllApplicationsAndUnits(c.api.stateAccessor, len(args.Patterns) <= 0); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch applications and units")
 	}
-	if context.remoteApplications, err =
-		fetchRemoteApplications(c.api.stateAccessor); err != nil {
-		return noStatus, errors.Annotate(err, "could not fetch remote applications")
+	if featureflag.Enabled(feature.CrossModelRelations) {
+		if context.remoteApplications, err =
+			fetchRemoteApplications(c.api.stateAccessor); err != nil {
+			return noStatus, errors.Annotate(err, "could not fetch remote applications")
+		}
 	}
 	if context.machines, err = fetchMachines(c.api.stateAccessor, nil); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch machines")

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1236,30 +1236,15 @@ func (s *ParseBindSuite) checkParseFailsForArgs(c *gc.C, args string, expectedEr
 
 type DeployUnitTestSuite struct {
 	jujutesting.IsolationSuite
-	jujutesting.FakeHomeSuite
 	DeployAPI
 }
 
 var _ = gc.Suite(&DeployUnitTestSuite{})
 
-func (s *DeployUnitTestSuite) SetUpSuite(c *gc.C) {
-	s.IsolationSuite.SetUpSuite(c)
-	s.FakeHomeSuite.SetUpSuite(c)
-}
-
-func (s *DeployUnitTestSuite) TearDownSuite(c *gc.C) {
-	s.FakeHomeSuite.TearDownSuite(c)
-	s.IsolationSuite.TearDownSuite(c)
-}
-
 func (s *DeployUnitTestSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
-	s.FakeHomeSuite.SetUpTest(c)
-}
-
-func (s *DeployUnitTestSuite) TearDownTest(c *gc.C) {
-	s.FakeHomeSuite.TearDownTest(c)
-	s.IsolationSuite.TearDownTest(c)
+	cookiesFile := filepath.Join(c.MkDir(), ".go-cookies")
+	s.PatchEnvironment("JUJU_COOKIEFILE", cookiesFile)
 }
 
 func (s *DeployUnitTestSuite) TestDeployLocalCharm_GivesCorrectUserMessage(c *gc.C) {

--- a/cmd/juju/user/logout_test.go
+++ b/cmd/juju/user/logout_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/persistent-cookiejar"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/user"
@@ -62,7 +61,7 @@ func (s *LogoutCommandSuite) TestInit(c *gc.C) {
 }
 
 func (s *LogoutCommandSuite) TestLogout(c *gc.C) {
-	cookiefile := filepath.Join(utils.Home(), ".go-cookies")
+	cookiefile := filepath.Join(c.MkDir(), ".go-cookies")
 	jar, err := cookiejar.New(&cookiejar.Options{Filename: cookiefile})
 	c.Assert(err, jc.ErrorIsNil)
 	cont, err := s.store.CurrentController()

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -6,6 +6,7 @@ package state
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -23,7 +24,6 @@ import (
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
-	"time"
 )
 
 var (
@@ -517,35 +517,6 @@ func (s *allWatcherStateSuite) TestChangeUnitsNonNilPorts(c *gc.C) {
 
 func (s *allWatcherStateSuite) TestChangeRemoteApplications(c *gc.C) {
 	testChangeRemoteApplications(c, s.performChangeTestCases)
-}
-
-func (s *allWatcherStateSuite) TestRemoveRemoteApplication(c *gc.C) {
-	mysql, remoteApplicationInfo := addTestingRemoteApplication(
-		c, s.state, "remote-mysql", "local:/u/me/mysql", mysqlRelations,
-	)
-	tw := newTestAllWatcher(s.state, c)
-	defer tw.Stop()
-
-	// We should see the initial remote application entity.
-	deltas := tw.All(1)
-	zeroOutTimestampsForDeltas(c, deltas)
-	checkDeltasEqual(c, deltas, []multiwatcher.Delta{{
-		Entity: &remoteApplicationInfo,
-	}})
-
-	// Destroying the remote application will remove it from state,
-	// because it has no relations.
-	err := mysql.Destroy()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(mysql.Refresh(), jc.Satisfies, errors.IsNotFound)
-	checkDeltasEqual(c, tw.All(1), []multiwatcher.Delta{{
-		Removed: true,
-		Entity: &multiwatcher.RemoteApplicationInfo{
-			ModelUUID:      s.state.ModelUUID(),
-			Name:           "remote-mysql",
-			ApplicationURL: "local:/u/me/mysql",
-		},
-	}})
 }
 
 func (s *allWatcherStateSuite) TestChangeActions(c *gc.C) {
@@ -1158,7 +1129,7 @@ func (s *allWatcherStateSuite) TestStateWatcherTwoModels(c *gc.C) {
 	} {
 		c.Logf("Test %d: %s", i, test.about)
 		func() {
-			checkIsolationForEnv := func(st *State, w, otherW *testWatcher) {
+			checkIsolationForModel := func(st *State, w, otherW *testWatcher) {
 				c.Logf("Making changes to model %s", st.ModelUUID())
 
 				if test.setUpState != nil {
@@ -1183,8 +1154,8 @@ func (s *allWatcherStateSuite) TestStateWatcherTwoModels(c *gc.C) {
 			// The first set of deltas is empty, reflecting an empty model.
 			w1.AssertNoChange(c)
 			w2.AssertNoChange(c)
-			checkIsolationForEnv(s.state, w1, w2)
-			checkIsolationForEnv(otherState, w2, w1)
+			checkIsolationForModel(s.state, w1, w2)
+			checkIsolationForModel(otherState, w2, w1)
 		}()
 		s.reset(c)
 	}
@@ -1416,7 +1387,7 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 	s.performChangeTestCases(c, changeTestFuncs)
 }
 
-func (s *allModelWatcherStateSuite) TestChangeForDeadEnv(c *gc.C) {
+func (s *allModelWatcherStateSuite) TestChangeForDeadModel(c *gc.C) {
 	// Ensure an entity is removed when a change is seen but
 	// the model the entity belonged to has already died.
 


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju/+bug/1637595

The TestRemoveRemoteApplication test was a bit rubbish and the functionality is tested elsewhere so it is deleted.

Also improve the way the DeployUnitTestSuite sets up to use a temp cookie file.

Plus stop status from trying to use a remote application collection unless the feature flag is enabled.