### PR TITLE
state: refactor Open to take OpenParams

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -11,6 +11,7 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/clock"
 	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -298,7 +299,13 @@ LXC_BRIDGE="ignored"`[1:])
 	info, ok := cfg.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(info.Password, gc.Not(gc.Equals), testing.DefaultMongoPassword)
-	st1, err := state.Open(newCfg.Model(), newCfg.Controller(), info, mongotest.DialOpts(), nil)
+	st1, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      newCfg.Controller(),
+		ControllerModelTag: newCfg.Model(),
+		MongoInfo:          info,
+		MongoDialOpts:      mongotest.DialOpts(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer st1.Close()
 
@@ -451,7 +458,13 @@ func (s *bootstrapSuite) assertCanLogInAsAdmin(c *gc.C, modelTag names.ModelTag,
 		Tag:      nil, // admin user
 		Password: password,
 	}
-	st, err := state.Open(modelTag, controllerTag, info, mongotest.DialOpts(), state.NewPolicyFunc(nil))
+	st, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      controllerTag,
+		ControllerModelTag: modelTag,
+		MongoInfo:          info,
+		MongoDialOpts:      mongotest.DialOpts(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	_, err = st.Machine("0")

--- a/api/agent/machine_test.go
+++ b/api/agent/machine_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
@@ -181,7 +182,13 @@ func (s *machineSuite) TestClearReboot(c *gc.C) {
 }
 
 func tryOpenState(modelTag names.ModelTag, controllerTag names.ControllerTag, info *mongo.MongoInfo) error {
-	st, err := state.Open(modelTag, controllerTag, info, mongotest.DialOpts(), nil)
+	st, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      controllerTag,
+		ControllerModelTag: modelTag,
+		MongoInfo:          info,
+		MongoDialOpts:      mongotest.DialOpts(),
+	})
 	if err == nil {
 		st.Close()
 	}

--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
@@ -125,9 +126,16 @@ func (s *baseSuite) tryOpenState(c *gc.C, e apiAuthenticator, password string) e
 	stateInfo := s.MongoInfo(c)
 	stateInfo.Tag = e.Tag()
 	stateInfo.Password = password
-	st, err := state.Open(s.State.ModelTag(), s.State.ControllerTag(), stateInfo, mongo.DialOpts{
-		Timeout: 25 * time.Millisecond,
-	}, nil)
+	st, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      s.State.ControllerTag(),
+		ControllerModelTag: s.State.ModelTag(),
+		MongoInfo:          stateInfo,
+		MongoDialOpts: mongo.DialOpts{
+			Timeout: 25 * time.Millisecond,
+		},
+	})
+
 	if err == nil {
 		st.Close()
 	}

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -198,7 +198,13 @@ func (s *serverSuite) TestNewServerDoesNotAccessState(c *gc.C) {
 		Timeout:       5 * time.Second,
 		SocketTimeout: 5 * time.Second,
 	}
-	st, err := state.Open(s.State.ModelTag(), s.State.ControllerTag(), mongoInfo, dialOpts, nil)
+	st, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      s.State.ControllerTag(),
+		ControllerModelTag: s.State.ModelTag(),
+		MongoInfo:          mongoInfo,
+		MongoDialOpts:      dialOpts,
+	})
 	c.Assert(err, gc.IsNil)
 	defer st.Close()
 

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -12,6 +12,7 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
+	"github.com/juju/utils/clock"
 	"github.com/juju/utils/series"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
@@ -249,9 +250,16 @@ func (s *AgentSuite) AssertCanOpenState(c *gc.C, tag names.Tag, dataDir string) 
 	c.Assert(err, jc.ErrorIsNil)
 	info, ok := config.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
-	st, err := state.Open(config.Model(), config.Controller(), info, mongotest.DialOpts(), stateenvirons.GetNewPolicyFunc(
-		stateenvirons.GetNewEnvironFunc(environs.New),
-	))
+	st, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      config.Controller(),
+		ControllerModelTag: config.Model(),
+		MongoInfo:          info,
+		MongoDialOpts:      mongotest.DialOpts(),
+		NewPolicy: stateenvirons.GetNewPolicyFunc(
+			stateenvirons.GetNewEnvironFunc(environs.New),
+		),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	st.Close()
 }

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -800,11 +800,16 @@ func (a *MachineAgent) openStateForUpgrade() (*state.State, error) {
 	if !ok {
 		return nil, errors.New("no state info available")
 	}
-	st, err := state.Open(agentConfig.Model(), agentConfig.Controller(), info, mongo.DefaultDialOpts(),
-		stateenvirons.GetNewPolicyFunc(
+	st, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      agentConfig.Controller(),
+		ControllerModelTag: agentConfig.Model(),
+		MongoInfo:          info,
+		MongoDialOpts:      mongo.DefaultDialOpts(),
+		NewPolicy: stateenvirons.GetNewPolicyFunc(
 			stateenvirons.GetNewEnvironFunc(environs.New),
 		),
-	)
+	})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1361,11 +1366,16 @@ func openState(agentConfig agent.Config, dialOpts mongo.DialOpts) (_ *state.Stat
 	if !ok {
 		return nil, nil, errors.Errorf("no state info available")
 	}
-	st, err := state.Open(agentConfig.Model(), agentConfig.Controller(), info, dialOpts,
-		stateenvirons.GetNewPolicyFunc(
+	st, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      agentConfig.Controller(),
+		ControllerModelTag: agentConfig.Model(),
+		MongoInfo:          info,
+		MongoDialOpts:      dialOpts,
+		NewPolicy: stateenvirons.GetNewPolicyFunc(
 			stateenvirons.GetNewEnvironFunc(environs.New),
 		),
-	)
+	})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -21,6 +21,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
+	"github.com/juju/utils/clock"
 	"github.com/juju/utils/series"
 	"github.com/juju/utils/set"
 	"github.com/juju/version"
@@ -253,13 +254,20 @@ func (s *BootstrapSuite) TestGUIArchiveSuccess(c *gc.C) {
 	}})
 
 	// Retrieve the state so that it is possible to access the GUI storage.
-	st, err := state.Open(testing.ModelTag, testing.ControllerTag, &mongo.MongoInfo{
-		Info: mongo.Info{
-			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
-			CACert: testing.CACert,
+	st, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      testing.ControllerTag,
+		ControllerModelTag: testing.ModelTag,
+		MongoInfo: &mongo.MongoInfo{
+			Info: mongo.Info{
+				Addrs:  []string{gitjujutesting.MgoServer.Addr()},
+				CACert: testing.CACert,
+			},
+			Password: testPassword,
 		},
-		Password: testPassword,
-	}, mongotest.DialOpts(), nil)
+		MongoDialOpts: mongotest.DialOpts(),
+	})
+
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -363,13 +371,20 @@ func (s *BootstrapSuite) TestInitializeEnvironment(c *gc.C) {
 	c.Assert(s.fakeEnsureMongo.InitiateParams.User, gc.Equals, "")
 	c.Assert(s.fakeEnsureMongo.InitiateParams.Password, gc.Equals, "")
 
-	st, err := state.Open(testing.ModelTag, testing.ControllerTag, &mongo.MongoInfo{
-		Info: mongo.Info{
-			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
-			CACert: testing.CACert,
+	st, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      testing.ControllerTag,
+		ControllerModelTag: testing.ModelTag,
+		MongoInfo: &mongo.MongoInfo{
+			Info: mongo.Info{
+				Addrs:  []string{gitjujutesting.MgoServer.Addr()},
+				CACert: testing.CACert,
+			},
+			Password: testPassword,
 		},
-		Password: testPassword,
-	}, mongotest.DialOpts(), nil)
+		MongoDialOpts: mongotest.DialOpts(),
+	})
+
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	machines, err := st.AllMachines()
@@ -416,13 +431,20 @@ func (s *BootstrapSuite) TestInitializeEnvironmentToolsNotFound(c *gc.C) {
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	st, err := state.Open(testing.ModelTag, testing.ControllerTag, &mongo.MongoInfo{
-		Info: mongo.Info{
-			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
-			CACert: testing.CACert,
+	st, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      testing.ControllerTag,
+		ControllerModelTag: testing.ModelTag,
+		MongoInfo: &mongo.MongoInfo{
+			Info: mongo.Info{
+				Addrs:  []string{gitjujutesting.MgoServer.Addr()},
+				CACert: testing.CACert,
+			},
+			Password: testPassword,
 		},
-		Password: testPassword,
-	}, mongotest.DialOpts(), nil)
+		MongoDialOpts: mongotest.DialOpts(),
+	})
+
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -443,13 +465,20 @@ func (s *BootstrapSuite) TestSetConstraints(c *gc.C) {
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	st, err := state.Open(testing.ModelTag, testing.ControllerTag, &mongo.MongoInfo{
-		Info: mongo.Info{
-			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
-			CACert: testing.CACert,
+	st, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      testing.ControllerTag,
+		ControllerModelTag: testing.ModelTag,
+		MongoInfo: &mongo.MongoInfo{
+			Info: mongo.Info{
+				Addrs:  []string{gitjujutesting.MgoServer.Addr()},
+				CACert: testing.CACert,
+			},
+			Password: testPassword,
 		},
-		Password: testPassword,
-	}, mongotest.DialOpts(), nil)
+		MongoDialOpts: mongotest.DialOpts(),
+	})
+
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -479,13 +508,20 @@ func (s *BootstrapSuite) TestDefaultMachineJobs(c *gc.C) {
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	st, err := state.Open(testing.ModelTag, testing.ControllerTag, &mongo.MongoInfo{
-		Info: mongo.Info{
-			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
-			CACert: testing.CACert,
+	st, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      testing.ControllerTag,
+		ControllerModelTag: testing.ModelTag,
+		MongoInfo: &mongo.MongoInfo{
+			Info: mongo.Info{
+				Addrs:  []string{gitjujutesting.MgoServer.Addr()},
+				CACert: testing.CACert,
+			},
+			Password: testPassword,
 		},
-		Password: testPassword,
-	}, mongotest.DialOpts(), nil)
+		MongoDialOpts: mongotest.DialOpts(),
+	})
+
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	m, err := st.Machine("0")
@@ -500,13 +536,20 @@ func (s *BootstrapSuite) TestConfiguredMachineJobs(c *gc.C) {
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	st, err := state.Open(testing.ModelTag, testing.ControllerTag, &mongo.MongoInfo{
-		Info: mongo.Info{
-			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
-			CACert: testing.CACert,
+	st, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      testing.ControllerTag,
+		ControllerModelTag: testing.ModelTag,
+		MongoInfo: &mongo.MongoInfo{
+			Info: mongo.Info{
+				Addrs:  []string{gitjujutesting.MgoServer.Addr()},
+				CACert: testing.CACert,
+			},
+			Password: testPassword,
 		},
-		Password: testPassword,
-	}, mongotest.DialOpts(), nil)
+		MongoDialOpts: mongotest.DialOpts(),
+	})
+
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	m, err := st.Machine("0")
@@ -530,7 +573,13 @@ func (s *BootstrapSuite) TestInitialPassword(c *gc.C) {
 
 	// Check we can log in to mongo as admin.
 	info.Tag, info.Password = nil, testPassword
-	st, err := state.Open(testing.ModelTag, testing.ControllerTag, info, mongotest.DialOpts(), nil)
+	st, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      testing.ControllerTag,
+		ControllerModelTag: testing.ModelTag,
+		MongoInfo:          info,
+		MongoDialOpts:      mongotest.DialOpts(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -557,7 +606,13 @@ func (s *BootstrapSuite) TestInitialPassword(c *gc.C) {
 
 	stateinfo, ok := machineConf1.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
-	st, err = state.Open(testing.ModelTag, testing.ControllerTag, stateinfo, mongotest.DialOpts(), nil)
+	st, err = state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      testing.ControllerTag,
+		ControllerModelTag: testing.ModelTag,
+		MongoInfo:          stateinfo,
+		MongoDialOpts:      mongotest.DialOpts(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -683,13 +738,20 @@ func (s *BootstrapSuite) testToolsMetadata(c *gc.C, exploded bool) {
 	// The tools should have been added to tools storage, and
 	// exploded into each of the supported series of
 	// the same operating system if the tools were uploaded.
-	st, err := state.Open(testing.ModelTag, testing.ControllerTag, &mongo.MongoInfo{
-		Info: mongo.Info{
-			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
-			CACert: testing.CACert,
+	st, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      testing.ControllerTag,
+		ControllerModelTag: testing.ModelTag,
+		MongoInfo: &mongo.MongoInfo{
+			Info: mongo.Info{
+				Addrs:  []string{gitjujutesting.MgoServer.Addr()},
+				CACert: testing.CACert,
+			},
+			Password: testPassword,
 		},
-		Password: testPassword,
-	}, mongotest.DialOpts(), nil)
+		MongoDialOpts: mongotest.DialOpts(),
+	})
+
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	expectedSeries := make(set.Strings)
@@ -732,13 +794,20 @@ func createImageMetadata() []*imagemetadata.ImageMetadata {
 }
 
 func assertWrittenToState(c *gc.C, metadata cloudimagemetadata.Metadata) {
-	st, err := state.Open(testing.ModelTag, testing.ControllerTag, &mongo.MongoInfo{
-		Info: mongo.Info{
-			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
-			CACert: testing.CACert,
+	st, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      testing.ControllerTag,
+		ControllerModelTag: testing.ModelTag,
+		MongoInfo: &mongo.MongoInfo{
+			Info: mongo.Info{
+				Addrs:  []string{gitjujutesting.MgoServer.Addr()},
+				CACert: testing.CACert,
+			},
+			Password: testPassword,
 		},
-		Password: testPassword,
-	}, mongotest.DialOpts(), nil)
+		MongoDialOpts: mongotest.DialOpts(),
+	})
+
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 

--- a/cmd/jujud/dumplogs/dumplogs.go
+++ b/cmd/jujud/dumplogs/dumplogs.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/loggo"
+	"github.com/juju/utils/clock"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/agent"
@@ -108,7 +109,13 @@ func (c *dumpLogsCommand) Run(ctx *cmd.Context) error {
 		return errors.New("no database connection info available (is this a controller host?)")
 	}
 
-	st0, err := state.Open(config.Model(), config.Controller(), info, mongo.DefaultDialOpts(), nil)
+	st0, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      config.Controller(),
+		ControllerModelTag: config.Model(),
+		MongoInfo:          info,
+		MongoDialOpts:      mongo.DefaultDialOpts(),
+	})
 	if err != nil {
 		return errors.Annotate(err, "failed to connect to database")
 	}

--- a/state/backups/restore.go
+++ b/state/backups/restore.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils"
+	"github.com/juju/utils/clock"
 	"github.com/juju/utils/ssh"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
@@ -157,7 +158,14 @@ func newStateConnection(controllerTag names.ControllerTag, modelTag names.ModelT
 	attempt := utils.AttemptStrategy{Delay: newStateConnDelay, Min: newStateConnMinAttempts}
 	getEnviron := stateenvirons.GetNewEnvironFunc(environs.New)
 	for a := attempt.Start(); a.Next(); {
-		st, err = state.Open(modelTag, controllerTag, info, mongoDefaultDialOpts(), environsGetNewPolicyFunc(getEnviron))
+		st, err = state.Open(state.OpenParams{
+			Clock:              clock.WallClock,
+			ControllerTag:      controllerTag,
+			ControllerModelTag: modelTag,
+			MongoInfo:          info,
+			MongoDialOpts:      mongoDefaultDialOpts(),
+			NewPolicy:          environsGetNewPolicyFunc(getEnviron),
+		})
 		if err == nil {
 			return st, nil
 		}

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -46,13 +46,13 @@ func (s *InitializeSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *InitializeSuite) openState(c *gc.C, modelTag names.ModelTag) {
-	st, err := state.Open(
-		modelTag,
-		testing.ControllerTag,
-		statetesting.NewMongoInfo(),
-		mongotest.DialOpts(),
-		state.NewPolicyFunc(nil),
-	)
+	st, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      testing.ControllerTag,
+		ControllerModelTag: modelTag,
+		MongoInfo:          statetesting.NewMongoInfo(),
+		MongoDialOpts:      mongotest.DialOpts(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.State = st
 }

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	jujutxn "github.com/juju/txn"
+	"github.com/juju/utils/clock"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -603,7 +604,13 @@ func (s *MachineSuite) TestTag(c *gc.C) {
 
 func (s *MachineSuite) TestSetMongoPassword(c *gc.C) {
 	info := testing.NewMongoInfo()
-	st, err := state.Open(s.modelTag, s.State.ControllerTag(), info, mongotest.DialOpts(), state.NewPolicyFunc(nil))
+	st, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      s.State.ControllerTag(),
+		ControllerModelTag: s.modelTag,
+		MongoInfo:          info,
+		MongoDialOpts:      mongotest.DialOpts(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {
 		// Remove the admin password so that the test harness can reset the state.
@@ -634,7 +641,13 @@ func (s *MachineSuite) TestSetMongoPassword(c *gc.C) {
 
 	// Check that we can log in with the correct password.
 	info.Password = "foo"
-	st1, err := state.Open(s.modelTag, s.State.ControllerTag(), info, mongotest.DialOpts(), state.NewPolicyFunc(nil))
+	st1, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      s.State.ControllerTag(),
+		ControllerModelTag: s.modelTag,
+		MongoInfo:          info,
+		MongoDialOpts:      mongotest.DialOpts(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer st1.Close()
 

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/clock"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -436,7 +437,13 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaults(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	info := statetesting.NewMongoInfo()
-	anotherState, err := state.Open(s.modelTag, s.State.ControllerTag(), info, mongotest.DialOpts(), state.NewPolicyFunc(nil))
+	anotherState, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      s.State.ControllerTag(),
+		ControllerModelTag: s.modelTag,
+		MongoInfo:          info,
+		MongoDialOpts:      mongotest.DialOpts(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer anotherState.Close()
 
@@ -483,7 +490,13 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigRegionDefaults(c *gc.C) {
 
 	// Then check in another state.
 	info := statetesting.NewMongoInfo()
-	anotherState, err := state.Open(s.modelTag, s.State.ControllerTag(), info, mongotest.DialOpts(), state.NewPolicyFunc(nil))
+	anotherState, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      s.State.ControllerTag(),
+		ControllerModelTag: s.modelTag,
+		MongoInfo:          info,
+		MongoDialOpts:      mongotest.DialOpts(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer anotherState.Close()
 

--- a/state/offeredapplications_test.go
+++ b/state/offeredapplications_test.go
@@ -5,6 +5,7 @@ package state_test
 
 import (
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
@@ -43,7 +44,13 @@ func (s *offeredApplicationsSuite) TestRemove(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	modelTag := names.NewModelTag(s.State.ModelUUID())
-	anotherState, err := state.Open(modelTag, s.State.ControllerTag(), testing.NewMongoInfo(), mongotest.DialOpts(), nil)
+	anotherState, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      s.State.ControllerTag(),
+		ControllerModelTag: modelTag,
+		MongoInfo:          testing.NewMongoInfo(),
+		MongoDialOpts:      mongotest.DialOpts(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer anotherState.Close()
 
@@ -67,7 +74,13 @@ func (s *offeredApplicationsSuite) TestAddApplicationOffer(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	modelTag := names.NewModelTag(s.State.ModelUUID())
-	anotherState, err := state.Open(modelTag, s.State.ControllerTag(), testing.NewMongoInfo(), mongotest.DialOpts(), nil)
+	anotherState, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      s.State.ControllerTag(),
+		ControllerModelTag: modelTag,
+		MongoInfo:          testing.NewMongoInfo(),
+		MongoDialOpts:      mongotest.DialOpts(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer anotherState.Close()
 
@@ -97,7 +110,13 @@ func (s *offeredApplicationsSuite) TestUpdateApplicationOffer(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	modelTag := names.NewModelTag(s.State.ModelUUID())
-	anotherState, err := state.Open(modelTag, s.State.ControllerTag(), testing.NewMongoInfo(), mongotest.DialOpts(), nil)
+	anotherState, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      s.State.ControllerTag(),
+		ControllerModelTag: modelTag,
+		MongoInfo:          testing.NewMongoInfo(),
+		MongoDialOpts:      mongotest.DialOpts(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer anotherState.Close()
 

--- a/state/open.go
+++ b/state/open.go
@@ -26,35 +26,76 @@ import (
 	"github.com/juju/juju/worker"
 )
 
-// Open connects to the server described by the given
-// info, waits for it to be initialized, and returns a new State
-// representing the model connected to.
-//
-// A policy may be provided, which will be used to validate and
-// modify behaviour of certain operations in state. A nil policy
-// may be provided.
+// OpenParams contains the parameters for opening the state database.
+type OpenParams struct {
+	// Clock is the clock used for time-related operations.
+	Clock clock.Clock
+
+	// ControllerTag is the tag of the controller.
+	ControllerTag names.ControllerTag
+
+	// ControllerModelTag is the tag of the controller model.
+	ControllerModelTag names.ModelTag
+
+	// MongoInfo is the mongo.MongoInfo used for dialling the
+	// Mongo connection.
+	MongoInfo *mongo.MongoInfo
+
+	// MongoDialOpts is the mongo.DialOpts used to control how
+	// Mongo connections are made.
+	MongoDialOpts mongo.DialOpts
+
+	// NewPolicy, if non-nil, returns a policy which will be used to
+	// validate and modify behaviour of certain operations in state.
+	NewPolicy NewPolicyFunc
+}
+
+// Validate validates the OpenParams.
+func (p OpenParams) Validate() error {
+	if p.Clock == nil {
+		return errors.NotValidf("nil Clock")
+	}
+	if p.ControllerTag == (names.ControllerTag{}) {
+		return errors.NotValidf("empty ControllerTag")
+	}
+	if p.ControllerModelTag == (names.ModelTag{}) {
+		return errors.NotValidf("empty ControllerModelTag")
+	}
+	if p.MongoInfo == nil {
+		return errors.NotValidf("nil MongoInfo")
+	}
+	return nil
+}
+
+// Open connects to the server with the given parameters, waits for it
+// to be initialized, and returns a new State representing the model
+// connected to.
 //
 // Open returns unauthorizedError if access is unauthorized.
-func Open(
-	controllerModelTag names.ModelTag,
-	controllerTag names.ControllerTag,
-	info *mongo.MongoInfo, opts mongo.DialOpts,
-	newPolicy NewPolicyFunc,
-) (*State, error) {
-	st, err := open(controllerModelTag, info, opts, newPolicy, clock.WallClock)
+func Open(args OpenParams) (*State, error) {
+	if err := args.Validate(); err != nil {
+		return nil, errors.Annotate(err, "validating args")
+	}
+	st, err := open(
+		args.ControllerModelTag,
+		args.MongoInfo,
+		args.MongoDialOpts,
+		args.NewPolicy,
+		args.Clock,
+	)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	if _, err := st.Model(); err != nil {
 		if err := st.Close(); err != nil {
-			logger.Errorf("closing State for %s: %v", controllerModelTag, err)
+			logger.Errorf("closing State for %s: %v", args.ControllerModelTag, err)
 		}
-		return nil, errors.Annotatef(err, "cannot read model %s", controllerModelTag.Id())
+		return nil, errors.Annotatef(err, "cannot read model %s", args.ControllerModelTag.Id())
 	}
 
 	// State should only be Opened on behalf of a controller environ; all
 	// other *States should be created via ForModel.
-	if err := st.start(controllerTag); err != nil {
+	if err := st.start(args.ControllerTag); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return st, nil

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -12,6 +12,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
+	"github.com/juju/utils/clock"
 	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -414,7 +415,14 @@ func (s *UpgradeSuite) openStateForUpgrade() (*state.State, error) {
 	newPolicy := stateenvirons.GetNewPolicyFunc(
 		stateenvirons.GetNewEnvironFunc(environs.New),
 	)
-	st, err := state.Open(s.State.ModelTag(), s.State.ControllerTag(), mongoInfo, mongotest.DialOpts(), newPolicy)
+	st, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      s.State.ControllerTag(),
+		ControllerModelTag: s.State.ModelTag(),
+		MongoInfo:          mongoInfo,
+		MongoDialOpts:      mongotest.DialOpts(),
+		NewPolicy:          newPolicy,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Introduce a state.OpenParams struct, and
update state.Open to use it. Add a Clock
parameter while we're at it.

A followup will introduce an observer for
recording mgo/txn-related metrics.