### PR TITLE
Introduce mongo/txnmetrics

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -44,7 +44,7 @@ github.com/juju/romulus	git	bf7827fa2f360ab762c134766ff1d4fff959ea03	2016-08-17T
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	3c01e9e4a3208dc72e39b030738b46362ddcfeda	2016-11-07T14:13:10Z
-github.com/juju/txn	git	af2fa2051800371a0272610882891a28c719c02c	2016-10-31T02:11:40Z
+github.com/juju/txn	git	28898197906200d603394d8e4ce537436529f1c5	2016-11-16T04:07:55Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	a84e60da6d18975eaff902cd51922b4da470dd62	2016-11-01T02:02:32Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z

--- a/mongo/txnmetrics/package_test.go
+++ b/mongo/txnmetrics/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package txnmetrics_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/mongo/txnmetrics/txnmetrics.go
+++ b/mongo/txnmetrics/txnmetrics.go
@@ -1,0 +1,86 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package txnmetrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/mgo.v2/txn"
+)
+
+const (
+	databaseLabel   = "database"
+	collectionLabel = "collection"
+	optypeLabel     = "optype"
+	failedLabel     = "failed"
+)
+
+var (
+	jujuMgoTxnLabelNames = []string{
+		databaseLabel,
+		collectionLabel,
+		optypeLabel,
+		failedLabel,
+	}
+)
+
+// Collector is a prometheus.Collector that collects metrics about
+// mgo/txn operations.
+type Collector struct {
+	txnOpsTotalCounter *prometheus.CounterVec
+}
+
+// New returns a new Collector.
+func New() *Collector {
+	return &Collector{
+		prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "juju",
+				Name:      "mgo_txn_ops_total",
+				Help:      "Total number of mgo/txn ops executed.",
+			},
+			jujuMgoTxnLabelNames,
+		),
+	}
+}
+
+// AfterRunTransaction is called when a mgo/txn transaction has run.
+func (c *Collector) AfterRunTransaction(dbName, modelUUID string, ops []txn.Op, err error) {
+	for _, op := range ops {
+		c.updateMetrics(dbName, op, err)
+	}
+}
+
+func (c *Collector) updateMetrics(dbName string, op txn.Op, err error) {
+	var failed string
+	if err != nil {
+		failed = "failed"
+	}
+	var optype string
+	switch {
+	case op.Insert != nil:
+		optype = "insert"
+	case op.Update != nil:
+		optype = "update"
+	case op.Remove:
+		optype = "remove"
+	default:
+		optype = "assert"
+	}
+	c.txnOpsTotalCounter.With(prometheus.Labels{
+		databaseLabel:   dbName,
+		collectionLabel: op.C,
+		optypeLabel:     optype,
+		failedLabel:     failed,
+	}).Inc()
+}
+
+// Describe is part of the prometheus.Collector interface.
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	c.txnOpsTotalCounter.Describe(ch)
+}
+
+// Collect is part of the prometheus.Collector interface.
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	c.txnOpsTotalCounter.Collect(ch)
+}

--- a/mongo/txnmetrics/txnmetrics_test.go
+++ b/mongo/txnmetrics/txnmetrics_test.go
@@ -1,0 +1,151 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENSE file for details.
+
+package txnmetrics_test
+
+import (
+	"errors"
+	"reflect"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/mongo/txnmetrics"
+)
+
+type collectorSuite struct {
+	testing.IsolationSuite
+	collector *txnmetrics.Collector
+}
+
+var _ = gc.Suite(&collectorSuite{})
+
+func (s *collectorSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.collector = txnmetrics.New()
+}
+
+func (s *collectorSuite) TestDescribe(c *gc.C) {
+	ch := make(chan *prometheus.Desc)
+	go func() {
+		defer close(ch)
+		s.collector.Describe(ch)
+	}()
+	var descs []*prometheus.Desc
+	for desc := range ch {
+		descs = append(descs, desc)
+	}
+	c.Assert(descs, gc.HasLen, 1)
+	c.Assert(descs[0].String(), gc.Matches, `.*fqName: "juju_mgo_txn_ops_total".*`)
+}
+
+func (s *collectorSuite) TestCollect(c *gc.C) {
+	s.collector.AfterRunTransaction("dbname", "modeluuid", []txn.Op{{
+		C:      "update-coll",
+		Update: bson.D{},
+	}, {
+		C:      "insert-coll",
+		Insert: bson.D{},
+	}, {
+		C:      "remove-coll",
+		Remove: true,
+	}, {
+		C: "assert-coll",
+	}}, nil)
+
+	s.collector.AfterRunTransaction("dbname", "modeluuid", []txn.Op{{
+		C:      "update-coll",
+		Update: bson.D{},
+	}}, errors.New("bewm"))
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		defer close(ch)
+		s.collector.Collect(ch)
+	}()
+
+	var metrics []prometheus.Metric
+	for metric := range ch {
+		metrics = append(metrics, metric)
+	}
+	c.Assert(metrics, gc.HasLen, 5)
+
+	var dtoMetrics [5]dto.Metric
+	for i, metric := range metrics {
+		err := metric.Write(&dtoMetrics[i])
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	float64ptr := func(v float64) *float64 {
+		return &v
+	}
+	labelpair := func(n, v string) *dto.LabelPair {
+		return &dto.LabelPair{Name: &n, Value: &v}
+	}
+	expected := []dto.Metric{
+		{
+			Counter: &dto.Counter{Value: float64ptr(1)},
+			Label: []*dto.LabelPair{
+				labelpair("collection", "update-coll"),
+				labelpair("database", "dbname"),
+				labelpair("failed", ""),
+				labelpair("optype", "update"),
+			},
+		},
+		{
+			Counter: &dto.Counter{Value: float64ptr(1)},
+			Label: []*dto.LabelPair{
+				labelpair("collection", "insert-coll"),
+				labelpair("database", "dbname"),
+				labelpair("failed", ""),
+				labelpair("optype", "insert"),
+			},
+		},
+		{
+			Counter: &dto.Counter{Value: float64ptr(1)},
+			Label: []*dto.LabelPair{
+				labelpair("collection", "remove-coll"),
+				labelpair("database", "dbname"),
+				labelpair("failed", ""),
+				labelpair("optype", "remove"),
+			},
+		},
+		{
+			Counter: &dto.Counter{Value: float64ptr(1)},
+			Label: []*dto.LabelPair{
+				labelpair("collection", "assert-coll"),
+				labelpair("database", "dbname"),
+				labelpair("failed", ""),
+				labelpair("optype", "assert"),
+			},
+		},
+		{
+			Counter: &dto.Counter{Value: float64ptr(1)},
+			Label: []*dto.LabelPair{
+				labelpair("collection", "update-coll"),
+				labelpair("database", "dbname"),
+				labelpair("failed", "failed"),
+				labelpair("optype", "update"),
+			},
+		},
+	}
+	for _, dm := range dtoMetrics {
+		var found bool
+		for i, m := range expected {
+			if !reflect.DeepEqual(dm, m) {
+				continue
+			}
+			expected = append(expected[:i], expected[i+1:]...)
+			found = true
+			break
+		}
+		if !found {
+			c.Errorf("metric %+v not expected", dm)
+		}
+	}
+}

--- a/state/model.go
+++ b/state/model.go
@@ -265,7 +265,15 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 
 	uuid := args.Config.UUID()
 	session := st.session.Copy()
-	newSt, err := newState(names.NewModelTag(uuid), controllerInfo.ModelTag, session, st.mongoInfo, st.newPolicy, st.clock)
+	newSt, err := newState(
+		names.NewModelTag(uuid),
+		controllerInfo.ModelTag,
+		session,
+		st.mongoInfo,
+		st.newPolicy,
+		st.clock,
+		st.runTransactionObserver,
+	)
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "could not create state for new model")
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -78,15 +78,16 @@ type providerIdDoc struct {
 // State represents the state of an model
 // managed by juju.
 type State struct {
-	clock              clock.Clock
-	modelTag           names.ModelTag
-	controllerModelTag names.ModelTag
-	controllerTag      names.ControllerTag
-	mongoInfo          *mongo.MongoInfo
-	session            *mgo.Session
-	database           Database
-	policy             Policy
-	newPolicy          NewPolicyFunc
+	clock                  clock.Clock
+	modelTag               names.ModelTag
+	controllerModelTag     names.ModelTag
+	controllerTag          names.ControllerTag
+	mongoInfo              *mongo.MongoInfo
+	session                *mgo.Session
+	database               Database
+	policy                 Policy
+	newPolicy              NewPolicyFunc
+	runTransactionObserver RunTransactionObserverFunc
 
 	// cloudName is the name of the cloud on which the model
 	// represented by this state runs.
@@ -306,6 +307,7 @@ func (st *State) ForModel(modelTag names.ModelTag) (*State, error) {
 	session := st.session.Copy()
 	newSt, err := newState(
 		modelTag, st.controllerModelTag, session, st.mongoInfo, st.newPolicy, st.clock,
+		st.runTransactionObserver,
 	)
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
This branch introduces a Prometheus collector for mgo/txn operation counts grouped by (database, collection, operation-type, error-result).

This requires https://github.com/juju/txn/pull/21 and #6520.