### PR TITLE
Ensure controllers have at least 3.5GB of memory

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -251,6 +251,10 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 	if test.bootstrapConstraints == (constraints.Value{}) {
 		test.bootstrapConstraints = test.constraints
 	}
+	if test.bootstrapConstraints.Mem == nil {
+		mem := uint64(3584)
+		test.bootstrapConstraints.Mem = &mem
+	}
 	c.Check(opBootstrap.Args.BootstrapConstraints, gc.DeepEquals, test.bootstrapConstraints)
 	c.Check(opBootstrap.Args.Placement, gc.Equals, test.placement)
 

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -130,7 +130,8 @@ func (s *bootstrapSuite) TestBootstrapEmptyConstraints(c *gc.C) {
 	c.Assert(env.bootstrapCount, gc.Equals, 1)
 	env.args.AvailableTools = nil
 	c.Assert(env.args, gc.DeepEquals, environs.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
+		ControllerConfig:     coretesting.FakeControllerConfig(),
+		BootstrapConstraints: constraints.MustParse("mem=3.5G"),
 	})
 }
 
@@ -187,6 +188,10 @@ func (s *bootstrapSuite) TestBootstrapSpecifiedPlacement(c *gc.C) {
 	c.Assert(env.args.Placement, gc.DeepEquals, placement)
 }
 
+func intPtr(i uint64) *uint64 {
+	return &i
+}
+
 func (s *bootstrapSuite) TestBootstrapImage(c *gc.C) {
 	s.PatchValue(&series.MustHostSeries, func() string { return "precise" })
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
@@ -229,7 +234,9 @@ func (s *bootstrapSuite) TestBootstrapImage(c *gc.C) {
 	c.Assert(env.instanceConfig.Bootstrap.CustomImageMetadata, gc.HasLen, 2)
 	c.Assert(env.instanceConfig.Bootstrap.CustomImageMetadata[0], jc.DeepEquals, metadata[0])
 	c.Assert(env.instanceConfig.Bootstrap.CustomImageMetadata[1], jc.DeepEquals, env.args.ImageMetadata[0])
-	c.Assert(env.instanceConfig.Bootstrap.BootstrapMachineConstraints, jc.DeepEquals, bootstrapCons)
+	expectedCons := bootstrapCons
+	expectedCons.Mem = intPtr(3584)
+	c.Assert(env.instanceConfig.Bootstrap.BootstrapMachineConstraints, jc.DeepEquals, expectedCons)
 }
 
 func (s *bootstrapSuite) TestBootstrapAddsArchFromImageToExistingProviderSupportedArches(c *gc.C) {
@@ -250,7 +257,9 @@ func (s *bootstrapSuite) TestBootstrapAddsArchFromImageToExistingProviderSupport
 		MetadataDir:          data.metadataDir,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertBootstrapImageMetadata(c, env.bootstrapEnviron, data, bootstrapCons)
+	expectedCons := bootstrapCons
+	expectedCons.Mem = intPtr(3584)
+	s.assertBootstrapImageMetadata(c, env.bootstrapEnviron, data, expectedCons)
 }
 
 type testImageMetadata struct {
@@ -329,7 +338,9 @@ func (s *bootstrapSuite) TestBootstrapAddsArchFromImageToProviderWithNoSupported
 		MetadataDir:          data.metadataDir,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertBootstrapImageMetadata(c, env.bootstrapEnviron, data, bootstrapCons)
+	expectedCons := bootstrapCons
+	expectedCons.Mem = intPtr(3584)
+	s.assertBootstrapImageMetadata(c, env.bootstrapEnviron, data, expectedCons)
 }
 
 func (s *bootstrapSuite) setupProviderWithNoSupportedArches(c *gc.C) bootstrapEnvironNoExplicitArchitectures {

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -31,12 +31,15 @@ import (
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/simplestreams"
+	"github.com/juju/juju/environs/sync"
 	"github.com/juju/juju/environs/tags"
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
+	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/provider/azure"
 	"github.com/juju/juju/provider/azure/internal/armtemplates"
 	"github.com/juju/juju/provider/azure/internal/azureauth"
@@ -156,12 +159,26 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 	}
 
 	vmSizes := []compute.VirtualMachineSize{{
+		Name:                 to.StringPtr("Standard_A1"),
+		NumberOfCores:        to.Int32Ptr(1),
+		OsDiskSizeInMB:       to.Int32Ptr(1047552),
+		ResourceDiskSizeInMB: to.Int32Ptr(71680),
+		MemoryInMB:           to.Int32Ptr(1792),
+		MaxDataDiskCount:     to.Int32Ptr(2),
+	}, {
 		Name:                 to.StringPtr("Standard_D1"),
 		NumberOfCores:        to.Int32Ptr(1),
 		OsDiskSizeInMB:       to.Int32Ptr(1047552),
 		ResourceDiskSizeInMB: to.Int32Ptr(51200),
 		MemoryInMB:           to.Int32Ptr(3584),
 		MaxDataDiskCount:     to.Int32Ptr(2),
+	}, {
+		Name:                 to.StringPtr("Standard_D2"),
+		NumberOfCores:        to.Int32Ptr(2),
+		OsDiskSizeInMB:       to.Int32Ptr(1047552),
+		ResourceDiskSizeInMB: to.Int32Ptr(102400),
+		MemoryInMB:           to.Int32Ptr(7168),
+		MaxDataDiskCount:     to.Int32Ptr(4),
 	}}
 	s.vmSizes = &compute.VirtualMachineSizeListResult{Value: &vmSizes}
 
@@ -312,6 +329,15 @@ func (s *environSuite) startInstanceSenders(controller bool) azuretesting.Sender
 	return senders
 }
 
+func (s *environSuite) startInstanceSendersNoSizes() azuretesting.Senders {
+	senders := azuretesting.Senders{}
+	if s.ubuntuServerSKUs != nil {
+		senders = append(senders, s.makeSender(".*/Canonical/.*/UbuntuServer/skus", s.ubuntuServerSKUs))
+	}
+	senders = append(senders, s.makeSender("/deployments/machine-0", s.deployment))
+	return senders
+}
+
 func (s *environSuite) networkInterfacesSender(nics ...network.Interface) *azuretesting.MockSender {
 	return s.makeSender(".*/networkInterfaces", network.InterfaceListResult{Value: &nics})
 }
@@ -438,7 +464,7 @@ func (s *environSuite) TestStartInstance(c *gc.C) {
 	c.Assert(result.VolumeAttachments, gc.HasLen, 0)
 
 	arch := "amd64"
-	mem := uint64(3584)
+	mem := uint64(1792)
 	rootDisk := uint64(30 * 1024) // 30 GiB
 	cpuCores := uint64(1)
 	c.Assert(result.Hardware, jc.DeepEquals, &instance.HardwareCharacteristics{
@@ -451,6 +477,7 @@ func (s *environSuite) TestStartInstance(c *gc.C) {
 		imageReference: &quantalImageReference,
 		diskSizeGB:     32,
 		osProfile:      &linuxOsProfile,
+		instanceType:   "Standard_A1",
 	})
 }
 
@@ -499,7 +526,8 @@ func (s *environSuite) testStartInstanceWindows(
 			AutoUpgradeMinorVersion: to.BoolPtr(true),
 			Settings:                &vmExtensionSettings,
 		},
-		osProfile: &windowsOsProfile,
+		osProfile:    &windowsOsProfile,
+		instanceType: "Standard_A1",
 	})
 }
 
@@ -527,7 +555,8 @@ func (s *environSuite) TestStartInstanceCentOS(c *gc.C) {
 			AutoUpgradeMinorVersion: to.BoolPtr(true),
 			Settings:                &vmExtensionSettings,
 		},
-		osProfile: &linuxOsProfile,
+		osProfile:    &linuxOsProfile,
+		instanceType: "Standard_A1",
 	})
 }
 
@@ -563,6 +592,7 @@ func (s *environSuite) TestStartInstanceTooManyRequests(c *gc.C) {
 		imageReference: &quantalImageReference,
 		diskSizeGB:     32,
 		osProfile:      &linuxOsProfile,
+		instanceType:   "Standard_A1",
 	})
 
 	// The final requests should all be identical.
@@ -641,6 +671,7 @@ func (s *environSuite) TestStartInstanceServiceAvailabilitySet(c *gc.C) {
 		imageReference:      &quantalImageReference,
 		diskSizeGB:          32,
 		osProfile:           &linuxOsProfile,
+		instanceType:        "Standard_A1",
 	})
 }
 
@@ -652,6 +683,8 @@ type assertStartInstanceRequestsParams struct {
 	vmExtension         *compute.VirtualMachineExtensionProperties
 	diskSizeGB          int
 	osProfile           *compute.OSProfile
+	needsProviderInit   bool
+	instanceType        string
 }
 
 func (s *environSuite) assertStartInstanceRequests(
@@ -824,7 +857,7 @@ func (s *environSuite) assertStartInstanceRequests(
 		Tags:       to.StringMap(s.vmTags),
 		Properties: &compute.VirtualMachineProperties{
 			HardwareProfile: &compute.HardwareProfile{
-				VMSize: "Standard_D1",
+				VMSize: compute.VirtualMachineSizeTypes(args.instanceType),
 			},
 			StorageProfile: &compute.StorageProfile{
 				ImageReference: args.imageReference,
@@ -882,12 +915,21 @@ func (s *environSuite) assertStartInstanceRequests(
 		startInstanceRequests.deployment = requests[1]
 	} else {
 		c.Assert(requests, gc.HasLen, numExpectedStartInstanceRequests)
-		c.Assert(requests[0].Method, gc.Equals, "GET") // vmSizes
-		c.Assert(requests[1].Method, gc.Equals, "GET") // skus
-		c.Assert(requests[2].Method, gc.Equals, "PUT") // create deployment
-		startInstanceRequests.vmSizes = requests[0]
-		startInstanceRequests.skus = requests[1]
-		startInstanceRequests.deployment = requests[2]
+		if args.needsProviderInit {
+			c.Assert(requests[0].Method, gc.Equals, "PUT") // resource groups
+			c.Assert(requests[1].Method, gc.Equals, "GET") // skus
+			c.Assert(requests[2].Method, gc.Equals, "PUT") // create deployment
+			startInstanceRequests.resourceGroups = requests[0]
+			startInstanceRequests.skus = requests[1]
+			startInstanceRequests.deployment = requests[2]
+		} else {
+			c.Assert(requests[0].Method, gc.Equals, "GET") // vmSizes
+			c.Assert(requests[1].Method, gc.Equals, "GET") // skus
+			c.Assert(requests[2].Method, gc.Equals, "PUT") // create deployment
+			startInstanceRequests.vmSizes = requests[0]
+			startInstanceRequests.skus = requests[1]
+			startInstanceRequests.deployment = requests[2]
+		}
 	}
 
 	// Marshal/unmarshal the deployment we expect, so it's in map form.
@@ -921,9 +963,10 @@ func (s *environSuite) assertStartInstanceRequests(
 }
 
 type startInstanceRequests struct {
-	vmSizes    *http.Request
-	skus       *http.Request
-	deployment *http.Request
+	resourceGroups *http.Request
+	vmSizes        *http.Request
+	skus           *http.Request
+	deployment     *http.Request
 }
 
 func (s *environSuite) TestBootstrap(c *gc.C) {
@@ -937,9 +980,10 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 	s.requests = nil
 	result, err := env.Bootstrap(
 		ctx, environs.BootstrapParams{
-			ControllerConfig: testing.FakeControllerConfig(),
-			AvailableTools:   makeToolsList("quantal"),
-			BootstrapSeries:  "quantal",
+			ControllerConfig:     testing.FakeControllerConfig(),
+			AvailableTools:       makeToolsList("quantal"),
+			BootstrapSeries:      "quantal",
+			BootstrapConstraints: constraints.MustParse("mem=3.5G"),
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -953,6 +997,43 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 		imageReference:      &quantalImageReference,
 		diskSizeGB:          32,
 		osProfile:           &linuxOsProfile,
+		instanceType:        "Standard_D1",
+	})
+}
+
+func (s *environSuite) TestBootstrapInstanceConstraints(c *gc.C) {
+	defer envtesting.DisableFinishBootstrap()()
+
+	ctx := envtesting.BootstrapContext(c)
+	env := prepareForBootstrap(c, ctx, s.provider, &s.sender)
+
+	s.sender = append(s.sender, s.vmSizesSender())
+	s.sender = append(s.sender, s.initResourceGroupSenders()...)
+	s.sender = append(s.sender, s.startInstanceSendersNoSizes()...)
+	s.requests = nil
+	err := bootstrap.Bootstrap(
+		ctx, env, bootstrap.BootstrapParams{
+			ControllerConfig: testing.FakeControllerConfig(),
+			AdminSecret:      jujutesting.AdminSecret,
+			CAPrivateKey:     testing.CAKey,
+			BootstrapSeries:  "quantal",
+			BuildAgentTarball: func(build bool, ver *version.Number, _ string) (*sync.BuiltAgent, error) {
+				c.Assert(build, jc.IsFalse)
+				return &sync.BuiltAgent{Dir: c.MkDir()}, nil
+			},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(len(s.requests), gc.Equals, numExpectedStartInstanceRequests+1)
+	s.vmTags[tags.JujuIsController] = to.StringPtr("true")
+	s.assertStartInstanceRequests(c, s.requests[1:], assertStartInstanceRequestsParams{
+		availabilitySetName: "juju-controller",
+		imageReference:      &quantalImageReference,
+		diskSizeGB:          32,
+		osProfile:           &linuxOsProfile,
+		needsProviderInit:   true,
+		instanceType:        "Standard_D1",
 	})
 }
 
@@ -1128,7 +1209,7 @@ func (s *environSuite) TestConstraintsValidatorVocabulary(c *gc.C) {
 	)
 	_, err = validator.Validate(constraints.MustParse("instance-type=t1.micro"))
 	c.Assert(err, gc.ErrorMatches,
-		"invalid constraint value: instance-type=t1.micro\nvalid values are: \\[D1 Standard_D1\\]",
+		"invalid constraint value: instance-type=t1.micro\nvalid values are: \\[A1 D1 D2 Standard_A1 Standard_D1 Standard_D2\\]",
 	)
 }
 

--- a/provider/ec2/image.go
+++ b/provider/ec2/image.go
@@ -43,32 +43,13 @@ func findInstanceSpec(
 	ic *instances.InstanceConstraint,
 ) (*instances.InstanceSpec, error) {
 	logger.Debugf("received %d image(s)", len(allImageMetadata))
-	if controller {
-		ic.Constraints = withDefaultControllerConstraints(ic.Constraints)
-	} else {
+	if !controller {
 		ic.Constraints = withDefaultNonControllerConstraints(ic.Constraints)
 	}
 	suitableImages := filterImages(allImageMetadata, ic)
 	logger.Debugf("found %d suitable image(s)", len(suitableImages))
 	images := instances.ImageMetadataToImages(suitableImages)
 	return instances.FindInstanceSpec(images, ic, instanceTypes)
-}
-
-// withDefaultControllerConstraints returns the given constraints,
-// updated to choose a default instance type appropriate for a
-// controller machine. We use this only if the user does not specify
-// any constraints that would otherwise control the instance type
-// selection.
-//
-// At the time of writing, this will choose
-//   - t2.medium, for VPC
-//   - m3.medium, for EC2-Classic
-func withDefaultControllerConstraints(cons constraints.Value) constraints.Value {
-	if !cons.HasInstanceType() && !cons.HasCpuCores() && !cons.HasCpuPower() && !cons.HasMem() {
-		var mem uint64 = 3.75 * 1024
-		cons.Mem = &mem
-	}
-	return cons
 }
 
 // withDefaultNonControllerConstraints returns the given constraints,

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1477,16 +1477,13 @@ func (t *localServerSuite) TestRootDiskTags(c *gc.C) {
 
 func (s *localServerSuite) TestBootstrapInstanceConstraints(c *gc.C) {
 	env := s.prepareAndBootstrap(c)
-	inst, hc := testing.AssertStartControllerInstance(c, env, s.ControllerUUID, "1")
-	ec2inst := ec2.InstanceEC2(inst)
-
+	inst, err := env.AllInstances()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(inst, gc.HasLen, 1)
+	ec2inst := ec2.InstanceEC2(inst[0])
 	// Controllers should be started with a burstable
 	// instance if possible, and a 32 GiB disk.
 	c.Assert(ec2inst.InstanceType, gc.Equals, "t2.medium")
-	c.Assert(*hc.Arch, gc.Equals, "amd64")
-	c.Assert(*hc.Mem, gc.Equals, uint64(4*1024))
-	c.Assert(*hc.RootDisk, gc.Equals, uint64(32*1024))
-	c.Assert(*hc.CpuCores, gc.Equals, uint64(2))
 }
 
 // localNonUSEastSuite is similar to localServerSuite but the S3 mock server

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -144,9 +144,10 @@ func (suite *environSuite) TestStartInstanceStartsInstance(c *gc.C) {
 	suite.newNode(c, "node0", "host0", nil)
 	suite.addSubnet(c, 9, 9, "node0")
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      testing.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
+		ControllerConfig:     coretesting.FakeControllerConfig(),
+		AdminSecret:          testing.AdminSecret,
+		CAPrivateKey:         coretesting.CAKey,
+		BootstrapConstraints: constraints.MustParse("mem=1G"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	// The bootstrap node has been acquired and started.
@@ -340,9 +341,10 @@ func (suite *environSuite) TestBootstrapSucceeds(c *gc.C) {
 	suite.newNode(c, "thenode", "host", nil)
 	suite.addSubnet(c, 9, 9, "thenode")
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      testing.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
+		ControllerConfig:     coretesting.FakeControllerConfig(),
+		AdminSecret:          testing.AdminSecret,
+		CAPrivateKey:         coretesting.CAKey,
+		BootstrapConstraints: constraints.MustParse("mem=1G"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -355,9 +357,10 @@ func (suite *environSuite) TestBootstrapNodeNotDeployed(c *gc.C) {
 	// Ensure node will not be reported as deployed by changing its status.
 	suite.testMAASObject.TestServer.ChangeNode("thenode", "status", "4")
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      testing.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
+		ControllerConfig:     coretesting.FakeControllerConfig(),
+		AdminSecret:          testing.AdminSecret,
+		CAPrivateKey:         coretesting.CAKey,
+		BootstrapConstraints: constraints.MustParse("mem=1G"),
 	})
 	c.Assert(err, gc.ErrorMatches, "bootstrap instance started but did not change to Deployed state.*")
 }
@@ -370,9 +373,10 @@ func (suite *environSuite) TestBootstrapNodeFailedDeploy(c *gc.C) {
 	// Set the node status to "Failed deployment"
 	suite.testMAASObject.TestServer.ChangeNode("thenode", "status", "11")
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      testing.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
+		ControllerConfig:     coretesting.FakeControllerConfig(),
+		AdminSecret:          testing.AdminSecret,
+		CAPrivateKey:         coretesting.CAKey,
+		BootstrapConstraints: constraints.MustParse("mem=1G"),
 	})
 	c.Assert(err, gc.ErrorMatches, "bootstrap instance started but did not change to Deployed state. instance \"/api/.*/nodes/thenode/\" failed to deploy")
 }
@@ -395,9 +399,10 @@ func (suite *environSuite) TestBootstrapFailsIfNoNodes(c *gc.C) {
 	suite.setupFakeTools(c)
 	env := suite.makeEnviron()
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      testing.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
+		ControllerConfig:     coretesting.FakeControllerConfig(),
+		AdminSecret:          testing.AdminSecret,
+		CAPrivateKey:         coretesting.CAKey,
+		BootstrapConstraints: constraints.MustParse("mem=1G"),
 	})
 	// Since there are no nodes, the attempt to allocate one returns a
 	// 409: Conflict.
@@ -903,10 +908,11 @@ func (s *environSuite) bootstrap(c *gc.C) environs.Environ {
 	s.setupFakeTools(c)
 	env := s.makeEnviron()
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		Placement:        "bootstrap-host",
-		AdminSecret:      testing.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
+		ControllerConfig:     coretesting.FakeControllerConfig(),
+		Placement:            "bootstrap-host",
+		AdminSecret:          testing.AdminSecret,
+		CAPrivateKey:         coretesting.CAKey,
+		BootstrapConstraints: constraints.MustParse("mem=1G"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return env
@@ -998,6 +1004,7 @@ func (s *environSuite) TestStartInstanceDistributionFailover(c *gc.C) {
 	c.Assert(s.testMAASObject.TestServer.NodesOperationRequestValues(), gc.DeepEquals, []url.Values{{
 		"name":       []string{"bootstrap-host"},
 		"agent_name": []string{env.Config().UUID()},
+		"mem":        []string{"1024"},
 	}, {
 		"zone":       []string{"zone1"},
 		"agent_name": []string{env.Config().UUID()},


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1638165

When bootstrapping, if the user has not specified an instance type or mem constraint (or other conflicting constraint), then controllers will be provisioned with a minimum memory of 3.5G. The exact memory allocation is provider dependent. We ask for a minimum of 3.5G. That's what Azure has; EC2 will provide a machine with 3.75G etc.

QA:
bootstrap on Azure. Ensure controller machine had 3.5G.
bootstrap on AWS. Ensure controller machine had 3.75G.
Deploy a charm and check that the machine only has the standard 1G minimum.