### PR TITLE
mongo: close conn on TLS handshake error

### DIFF
--- a/mongo/open.go
+++ b/mongo/open.go
@@ -131,6 +131,9 @@ func DialInfo(info Info, opts DialOpts) (*mgo.DialInfo, error) {
 		cc := tls.Client(c, tlsConfig)
 		if err := cc.Handshake(); err != nil {
 			logger.Debugf("TLS handshake failed: %v", err)
+			if err := c.Close(); err != nil {
+				logger.Warningf("failed to close connection: %v", err)
+			}
 			return nil, err
 		}
 		logger.Infof("dialled mongo successfully on address %q", addr)


### PR DESCRIPTION
Close mongo net.Conns if TLS handshake fails. Cherry-pick of https://github.com/juju/juju/pull/6515/commits/bb40aa1e235996d254bccfddbfcf519c43d67736