### PR TITLE
Fix not_networks for MAAS 1.9

### DIFF
--- a/provider/maas/constraints.go
+++ b/provider/maas/constraints.go
@@ -177,11 +177,10 @@ func addInterfaces(
 		params.Add("interfaces", strings.Join(combinedBindingsString, ";"))
 	}
 	if len(negatives) > 0 {
-		negativesString := make([]string, len(negatives))
-		for i, binding := range negatives {
-			negativesString[i] = fmt.Sprintf("space:%s", binding.SpaceProviderId)
+		for _, binding := range negatives {
+			not_network := fmt.Sprintf("space:%s", binding.SpaceProviderId)
+			params.Add("not_networks", not_network)
 		}
-		params.Add("not_networks", strings.Join(negativesString, ","))
 	}
 	return nil
 }

--- a/provider/maas/constraints_test.go
+++ b/provider/maas/constraints_test.go
@@ -386,7 +386,7 @@ func (suite *environSuite) TestAcquireNodePassesPositiveAndNegativeSpaces(c *gc.
 	nodeValues, found := requestValues["node0"]
 	c.Assert(found, jc.IsTrue)
 	c.Check(nodeValues[0].Get("interfaces"), gc.Equals, "0:space=2;1:space=4")
-	c.Check(nodeValues[0].Get("not_networks"), gc.Equals, "space:3,space:5")
+	c.Check(nodeValues[0]["not_networks"], jc.DeepEquals, []string{"space:3", "space:5"})
 }
 
 func (suite *environSuite) createFourSpaces(c *gc.C) {


### PR DESCRIPTION
With MAAS 1.9 the not_networks parameter (for negative space constraints) should be specified as multiple values, not a comma separated list.

Fixes bug #1636969
There is a separate PR (against gomaasapi) to fix the same issue for MAAS 2.x where "not_networks" becomes "not_subnets".

QA
Bootstrap specifying negative space constraints. Juju must honour those constraints in the machine it picks.