### PR TITLE
Enable juju on macOS sierra.

### DIFF
--- a/version/current_test.go
+++ b/version/current_test.go
@@ -27,7 +27,7 @@ func (*CurrentSuite) TestCurrentSeries(c *gc.C) {
 		// platform) then CurrentSeries should be unknown.
 		switch runtime.GOOS {
 		case "darwin":
-			c.Check(s, gc.Matches, `mavericks|mountainlion|lion|snowleopard`)
+			c.Check(s, gc.Matches, `sierra|elcapitan|yosemite|mavericks`)
 		case "windows":
 			c.Check(s, gc.Matches, `win2012hvr2|win2012hv|win2012|win2012r2|win8|win81|win7`)
 		default:

--- a/version/osversion.go
+++ b/version/osversion.go
@@ -125,6 +125,7 @@ func macOSXSeriesFromKernelVersion(getKernelVersion func() (string, error)) (str
 // macOSXSeries maps from the Darwin Kernel Major Version to the Mac OSX
 // series.
 var macOSXSeries = map[int]string{
+	16: "sierra",
 	15: "elcapitan",
 	14: "yosemite",
 	13: "mavericks",

--- a/version/osversion_test.go
+++ b/version/osversion_test.go
@@ -194,7 +194,8 @@ func (*kernelVersionSuite) TestMacOSXSeries(c *gc.C) {
 		{version: 12, series: "mountainlion"},
 		{version: 14, series: "yosemite"},
 		{version: 15, series: "elcapitan"},
-		{version: 16, series: "unknown", err: `unknown series ""`},
+		{version: 16, series: "sierra"},
+		{version: 17, series: "unknown", err: `unknown series ""`},
 		{version: 4, series: "unknown", err: `unknown series ""`},
 		{version: 0, series: "unknown", err: `unknown series ""`},
 	}


### PR DESCRIPTION
This branch adds sierra to the list of known macOS series.

# Changes

This fixes bug https://bugs.launchpad.net/juju-core/+bug/1638560
I also updated the test to reflect the versions testers will use from this decade.

# Testing

The github.com/juju/juju/version unit tests pass on sierra
The built juju does not panic when I run
    juju version

I can see and manage my production 1.x envs.
    juju status -e juju-ci4
