### PR TITLE
Fix 1557726

### DIFF
--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -273,7 +273,7 @@ func (c *restoreCommand) rebootstrap(ctx *cmd.Context, meta *params.BackupsMetad
 	}
 
 	instanceIds, err := env.ControllerInstances(params.ControllerConfig.ControllerUUID())
-	if err != nil && errors.Cause(err) != environs.ErrNotBootstrapped {
+	if err != nil && errors.Cause(err) != environs.ErrNotBootstrapped && !errors.IsNotFound(err) {
 		return errors.Annotatef(err, "cannot determine controller instances")
 	}
 	if len(instanceIds) > 0 {


### PR DESCRIPTION
Restore will try to determine if an instance that is about to be re-bootstraped exists by asking the provider, openstack can answer errors.NotFound to that but was not taken in account as environs.Err.NotBootstrapped is the expected answer in all other providers.
A check for errors.NotFound was added to the rebootstrapper to care for openstack.

This fixes: https://bugs.launchpad.net/juju/+bug/1557726

### QA Steps
Run:
http://juju-ci.vapour.ws/view/Juju%20Revisions/job/functional-backup-restore-rackspace
http://juju-ci.vapour.ws/view/Juju%20Revisions/job/functional-backup-restore-prodstack