### PR TITLE
migrations: Track resource revisions per unit

### DIFF
--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -278,6 +278,9 @@ type Unit interface {
 	AgentStatusHistory() []Status
 	SetAgentStatusHistory([]StatusArgs)
 
+	AddResource(UnitResourceArgs) UnitResource
+	Resources() []UnitResource
+
 	AddPayload(PayloadArgs) Payload
 	Payloads() []Payload
 

--- a/core/description/resource.go
+++ b/core/description/resource.go
@@ -12,11 +12,28 @@ import (
 
 // Resource represents an application resource.
 type Resource interface {
+	// Name returns the name of the resource.
 	Name() string
+
+	// Revision returns the revision of the resource as set on the
+	// application.
 	Revision() int
+
+	// CharmStoreRevision returns the revision the charmstore has, as
+	// seen at the last poll.
 	CharmStoreRevision() int
+
+	// AddRevision defines a revision of the resource. If the revision
+	// has already been added, the revision details will be merged
+	// with the details added before.
 	AddRevision(ResourceRevisionArgs) (ResourceRevision, error)
+
+	// Revisions returns a map of known revisions for the resource,
+	// indexed by the revision number.
 	Revisions() map[int]ResourceRevision
+
+	// Validate checks the consistency of the resource and its
+	// revisions.
 	Validate() error
 }
 

--- a/core/description/resource.go
+++ b/core/description/resource.go
@@ -15,7 +15,7 @@ type Resource interface {
 	Name() string
 	Revision() int
 	CharmStoreRevision() int
-	AddRevision(ResourceRevisionArgs) ResourceRevision
+	AddRevision(ResourceRevisionArgs) (ResourceRevision, error)
 	Revisions() map[int]ResourceRevision
 	Validate() error
 }
@@ -91,11 +91,11 @@ type ResourceRevisionArgs struct {
 }
 
 // AddRevision implements Resource.
-func (r *resource) AddRevision(args ResourceRevisionArgs) ResourceRevision {
-	var addTs *time.Time
-	if !args.Timestamp.IsZero() {
-		t := args.Timestamp.UTC()
-		addTs = &t
+func (r *resource) AddRevision(args ResourceRevisionArgs) (ResourceRevision, error) {
+	for _, rev := range r.Revisions_ {
+		if rev.Revision_ == args.Revision {
+			return rev.merge(args)
+		}
 	}
 	rev := &resourceRevision{
 		Revision_:       args.Revision,
@@ -105,11 +105,11 @@ func (r *resource) AddRevision(args ResourceRevisionArgs) ResourceRevision {
 		Origin_:         args.Origin,
 		FingerprintHex_: args.FingerprintHex,
 		Size_:           args.Size,
-		Timestamp_:      addTs,
+		Timestamp_:      timePtr(args.Timestamp),
 		Username_:       args.Username,
 	}
 	r.Revisions_ = append(r.Revisions_, rev)
-	return rev
+	return rev, nil
 }
 
 // Revisions implements Resource.
@@ -201,6 +201,70 @@ func (r *resourceRevision) Timestamp() time.Time {
 // Username implements ResourceRevision.
 func (r *resourceRevision) Username() string {
 	return r.Username_
+}
+
+func (r *resourceRevision) merge(args ResourceRevisionArgs) (*resourceRevision, error) {
+	// Check fields match where set.
+	mkErr := func(field string) error {
+		return errors.Errorf("%s mismatch for revision %d", field, args.Revision)
+	}
+	checkStr := func(field, a, b string) error {
+		if a != "" && b != "" && a != b {
+			return errors.Trace(mkErr(field))
+		}
+		return nil
+	}
+	if err := checkStr("description", args.Description, r.Description_); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := checkStr("type", args.Type, r.Type_); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := checkStr("path", args.Path, r.Path_); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := checkStr("origin", args.Origin, r.Origin_); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := checkStr("fingerprint", args.FingerprintHex, r.FingerprintHex_); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if args.Size > 0 && r.Size_ > 0 && args.Size != r.Size_ {
+		return nil, mkErr("size")
+	}
+	if !args.Timestamp.IsZero() && r.Timestamp_ != nil && args.Timestamp.UTC() != r.Timestamp() {
+		return nil, mkErr("timestamp")
+	}
+	if err := checkStr("username", args.Username, r.Username_); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Now merge.
+	if args.Description != "" {
+		r.Description_ = args.Description
+	}
+	if args.Type != "" {
+		r.Type_ = args.Type
+	}
+	if args.Path != "" {
+		r.Path_ = args.Path
+	}
+	if args.Origin != "" {
+		r.Origin_ = args.Origin
+	}
+	if args.FingerprintHex != "" {
+		r.FingerprintHex_ = args.FingerprintHex
+	}
+	if args.Size != 0 {
+		r.Size_ = args.Size
+	}
+	if !args.Timestamp.IsZero() {
+		r.Timestamp_ = timePtr(args.Timestamp)
+	}
+	if args.Username != "" {
+		r.Username_ = args.Username
+	}
+	return r, nil
 }
 
 func importResources(source map[string]interface{}) ([]*resource, error) {

--- a/core/description/serialization.go
+++ b/core/description/serialization.go
@@ -92,3 +92,14 @@ func fieldToTimePtr(fields map[string]interface{}, name string) *time.Time {
 	}
 	return nil
 }
+
+// timePtr takes a time.Time and returns a pointer to a time.Time of
+// the same (UTC) value. Nil is returned if the time is the time zero
+// value. This is useful for handling optional time values.
+func timePtr(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	t = t.UTC()
+	return &t
+}

--- a/core/description/unit.go
+++ b/core/description/unit.go
@@ -41,6 +41,8 @@ type unit struct {
 
 	Constraints_ *constraints `yaml:"constraints,omitempty"`
 
+	Resources_ unitResources `yaml:"resources"`
+
 	Payloads_ payloads `yaml:"payloads"`
 }
 
@@ -77,6 +79,7 @@ func newUnit(args UnitArgs) *unit {
 		WorkloadVersionHistory_: newStatusHistory(),
 		AgentStatusHistory_:     newStatusHistory(),
 	}
+	u.setResources(nil)
 	u.setPayloads(nil)
 	return u
 }
@@ -218,6 +221,29 @@ func (u *unit) SetConstraints(args ConstraintsArgs) {
 	u.Constraints_ = newConstraints(args)
 }
 
+// AddResource implements Unit.
+func (u *unit) AddResource(args UnitResourceArgs) UnitResource {
+	resource := newUnitResource(args)
+	u.Resources_.Resources_ = append(u.Resources_.Resources_, resource)
+	return resource
+}
+
+// Resources implements Unit.
+func (u *unit) Resources() []UnitResource {
+	var result []UnitResource
+	for _, resource := range u.Resources_.Resources_ {
+		result = append(result, resource)
+	}
+	return result
+}
+
+func (u *unit) setResources(resourceList []*unitResource) {
+	u.Resources_ = unitResources{
+		Version:    1,
+		Resources_: resourceList,
+	}
+}
+
 // AddPayload implements Unit.
 func (u *unit) AddPayload(args PayloadArgs) Payload {
 	payload := newPayload(args)
@@ -318,7 +344,8 @@ func importUnitV1(source map[string]interface{}) (*unit, error) {
 		"meter-status-code": schema.String(),
 		"meter-status-info": schema.String(),
 
-		"payloads": schema.StringMap(schema.Any()),
+		"resources": schema.StringMap(schema.Any()),
+		"payloads":  schema.StringMap(schema.Any()),
 	}
 	defaults := schema.Defaults{
 		"principal":         "",
@@ -394,6 +421,13 @@ func importUnitV1(source map[string]interface{}) (*unit, error) {
 		return nil, errors.Trace(err)
 	}
 	result.WorkloadStatus_ = workloadStatus
+
+	resourcesMap := valid["resources"].(map[string]interface{})
+	resources, err := importUnitResources(resourcesMap)
+	if err != nil {
+		return nil, errors.Annotate(err, "resources")
+	}
+	result.setResources(resources)
 
 	payloadMap := valid["payloads"].(map[string]interface{})
 	payloads, err := importPayloads(payloadMap)

--- a/core/description/unit_test.go
+++ b/core/description/unit_test.go
@@ -39,6 +39,10 @@ func minimalUnitMap() map[interface{}]interface{} {
 		"workload-version-history": emptyStatusHistoryMap(),
 		"password-hash":            "secure-hash",
 		"tools":                    minimalAgentToolsMap(),
+		"resources": map[interface{}]interface{}{
+			"version":   1,
+			"resources": []interface{}{},
+		},
 		"payloads": map[interface{}]interface{}{
 			"version":  1,
 			"payloads": []interface{}{},
@@ -197,6 +201,21 @@ func (s *UnitSerializationSuite) TestWorkloadStatusHistory(c *gc.C) {
 		c.Check(point.Data(), jc.DeepEquals, args[i].Data)
 		c.Check(point.Updated(), gc.Equals, args[i].Updated)
 	}
+}
+
+func (s *UnitSerializationSuite) TestResources(c *gc.C) {
+	initial := minimalUnit()
+	rFoo := initial.AddResource(UnitResourceArgs{
+		Name:     "foo",
+		Revision: 42,
+	})
+	rBar := initial.AddResource(UnitResourceArgs{
+		Name:     "bar",
+		Revision: 1,
+	})
+
+	unit := s.exportImport(c, initial)
+	c.Assert(unit.Resources(), jc.DeepEquals, []UnitResource{rFoo, rBar})
 }
 
 func (s *UnitSerializationSuite) TestPayloads(c *gc.C) {

--- a/core/description/unitresources.go
+++ b/core/description/unitresources.go
@@ -10,7 +10,11 @@ import (
 
 // UnitResource represents the revision of a resource used by a unit.
 type UnitResource interface {
+	// Name returns the name of the resource.
 	Name() string
+
+	// Revision returns the revision of the resource as used by a
+	// particular unit.
 	Revision() int
 }
 

--- a/core/description/unitresources.go
+++ b/core/description/unitresources.go
@@ -1,0 +1,100 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+)
+
+// UnitResource represents the revision of a resource used by a unit.
+type UnitResource interface {
+	Name() string
+	Revision() int
+}
+
+// UnitResourceArgs is an argument struct used to specify the revision
+// of a resource used by a unit.
+type UnitResourceArgs struct {
+	Name     string
+	Revision int
+}
+
+func newUnitResource(args UnitResourceArgs) *unitResource {
+	return &unitResource{
+		Name_:     args.Name,
+		Revision_: args.Revision,
+	}
+}
+
+type unitResources struct {
+	Version    int             `yaml:"version"`
+	Resources_ []*unitResource `yaml:"resources"`
+}
+
+type unitResource struct {
+	Name_     string `yaml:"name"`
+	Revision_ int    `yaml:"revision"`
+}
+
+// Name implements UnitResource.
+func (ur *unitResource) Name() string {
+	return ur.Name_
+}
+
+// Revision implements UnitResource.
+func (ur *unitResource) Revision() int {
+	return ur.Revision_
+}
+
+func importUnitResources(source map[string]interface{}) ([]*unitResource, error) {
+	checker := versionedChecker("resources")
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "resources version schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+
+	version := int(valid["version"].(int64))
+	if version != 1 {
+		return nil, errors.NotValidf("version %d", version)
+	}
+
+	sourceList := valid["resources"].([]interface{})
+	return importUnitResourceList(sourceList)
+}
+
+func importUnitResourceList(sourceList []interface{}) ([]*unitResource, error) {
+	result := make([]*unitResource, 0, len(sourceList))
+	for i, value := range sourceList {
+		source, ok := value.(map[string]interface{})
+		if !ok {
+			return nil, errors.Errorf("unexpected value for resource %d, %T", i, value)
+		}
+		r, err := importUnitResourceV1(source)
+		if err != nil {
+			return nil, errors.Annotatef(err, "unit resource %d", i)
+		}
+		result = append(result, r)
+	}
+	return result, nil
+}
+
+func importUnitResourceV1(source map[string]interface{}) (*unitResource, error) {
+	fields := schema.Fields{
+		"name":     schema.String(),
+		"revision": schema.Int(),
+	}
+	checker := schema.FieldMap(fields, nil)
+
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "unit resource v1 schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+	return &unitResource{
+		Name_:     valid["name"].(string),
+		Revision_: int(valid["revision"].(int64)),
+	}, nil
+}

--- a/core/description/unitresources_test.go
+++ b/core/description/unitresources_test.go
@@ -1,0 +1,81 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+)
+
+type UnitResourceSuite struct {
+	SliceSerializationSuite
+}
+
+var _ = gc.Suite(&UnitResourceSuite{})
+
+func (s *UnitResourceSuite) SetUpTest(c *gc.C) {
+	s.SliceSerializationSuite.SetUpTest(c)
+	s.importName = "resources"
+	s.sliceName = "resources"
+	s.importFunc = func(m map[string]interface{}) (interface{}, error) {
+		return importUnitResources(m)
+	}
+	s.testFields = func(m map[string]interface{}) {
+		m["resources"] = []interface{}{}
+	}
+}
+
+func (s *UnitResourceSuite) TestNew(c *gc.C) {
+	ur := newUnitResource(UnitResourceArgs{
+		Name:     "blah",
+		Revision: 99,
+	})
+	c.Check(ur.Name(), gc.Equals, "blah")
+	c.Check(ur.Revision(), gc.Equals, 99)
+}
+
+func (s *UnitResourceSuite) TestParsingSerializedData(c *gc.C) {
+	initial := newUnitResource(UnitResourceArgs{
+		Name:     "foo",
+		Revision: 2,
+	})
+	imported := s.exportImport(c, initial)
+	c.Assert(imported, jc.DeepEquals, initial)
+}
+
+func (s *UnitResourceSuite) TestImportEmpty(c *gc.C) {
+	r, err := importUnitResources(map[string]interface{}{
+		"version":   1,
+		"resources": []interface{}{},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r, gc.HasLen, 0)
+}
+
+func (s *UnitResourceSuite) TestUnsupportedVersion(c *gc.C) {
+	_, err := importUnitResources(map[string]interface{}{
+		"version":   999,
+		"resources": []interface{}{},
+	})
+	c.Assert(err, gc.ErrorMatches, "version 999 not valid")
+}
+
+func (s *UnitResourceSuite) exportImport(c *gc.C, ur *unitResource) *unitResource {
+	initial := unitResources{
+		Version:    1,
+		Resources_: []*unitResource{ur},
+	}
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	urs, err := importUnitResources(source)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(urs, gc.HasLen, 1)
+	return urs[0]
+}


### PR DESCRIPTION
This extends the model description format so that application resource revisions are tracked on a per-unit basis. It is possible for a unit to have a different resource revision to the application when it has not yet retrieved a resource or when a resource is being upgraded.

Handling of resource revisions is somewhat awkward due to the denormalised way they are stored in the database.

### QA 

Deployed a resource using charm and watched the output of `juju dump-model`. There is a point where the application has been created but the unit has pulled the resource yet and this was correctly reflected. Once the unit agent had retrieved the resource the dump-model output was reflected 