### PR TITLE
Use API server retry logic

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -520,6 +520,11 @@ func newWebsocketDialer(cfg *websocket.Config, opts DialOpts) func(<-chan struct
 		Total: opts.Timeout,
 		Delay: opts.RetryDelay,
 	}
+
+	if openAttempt.Min == 0 && openAttempt.Delay > 0 {
+		openAttempt.Min = int(openAttempt.Total / openAttempt.Delay)
+	}
+
 	return func(stop <-chan struct{}) (io.Closer, error) {
 		for a := openAttempt.Start(); a.Next(); {
 			select {

--- a/worker/apicaller/connect.go
+++ b/worker/apicaller/connect.go
@@ -88,7 +88,10 @@ func connectFallback(
 	// atom in a func currently seems to be less treacherous
 	// than the alternatives.
 	var tryConnect = func() {
-		conn, err = apiOpen(info, api.DialOpts{})
+		conn, err = apiOpen(info, api.DialOpts{
+			Timeout:    time.Second,
+			RetryDelay: 200 * time.Millisecond,
+		})
 	}
 
 	didFallback = info.Password == ""

--- a/worker/apicaller/util_test.go
+++ b/worker/apicaller/util_test.go
@@ -4,6 +4,8 @@
 package apicaller_test
 
 import (
+	"time"
+
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -187,7 +189,10 @@ func openCalls(model names.ModelTag, entity names.Tag, passwords ...string) []te
 		}
 		calls[i] = testing.StubCall{
 			FuncName: "apiOpen",
-			Args:     []interface{}{info, api.DialOpts{}},
+			Args: []interface{}{info, api.DialOpts{
+				Timeout:    time.Second,
+				RetryDelay: 200 * time.Millisecond,
+			}},
 		}
 	}
 	return calls


### PR DESCRIPTION
When connecting to the API server the retry logic didn't fire, which resulted in all the workers restarting after three seconds. The intent was obviously different. Will now try connecting every 200ms for a second. A pleasing side effect is that tests run much more quickly without 3 second pauses in them.

Tested by running the unit tests.