### PR TITLE
Set the umask before creating directories with specified permissions

### DIFF
--- a/state/backups/files_test.go
+++ b/state/backups/files_test.go
@@ -31,7 +31,18 @@ type filesSuite struct {
 func (s *filesSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
+	// Set the process' umask to 0 so tests that check permission bits don't
+	// fail due to the users umask being an unexpected value.
+	oldUmask := syscall.Umask(0)
+	s.AddCleanup(func(_ *gc.C) {
+		syscall.Umask(oldUmask)
+	})
+
 	s.root = c.MkDir()
+}
+
+func (s *filesSuite) TearDownTest(c *gc.C) {
+	s.BaseSuite.TearDownTest(c)
 }
 
 // createFiles preps the fake FS. The files are all created relative to


### PR DESCRIPTION
Set the umask before creating directories with specified permissions so the result is predictable. Fixed tests that started failing on upgrade to 16.10.