### PR TITLE
Colorize meter status.

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -204,7 +204,11 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		for _, name := range utils.SortStringsNaturally(stringKeysFromMap(units)) {
 			u := units[name]
 			if u.MeterStatus != nil {
-				p(name, u.MeterStatus.Color, u.MeterStatus.Message)
+				w.Print(name)
+				outputColor := fromMeterStatusColor(u.MeterStatus.Color)
+				w.PrintColor(outputColor, u.MeterStatus.Color)
+				w.PrintColor(outputColor, u.MeterStatus.Message)
+				w.Println()
 			}
 		}
 	}
@@ -223,6 +227,18 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	}
 
 	tw.Flush()
+	return nil
+}
+
+func fromMeterStatusColor(msColor string) *ansiterm.Context {
+	switch msColor {
+	case "green":
+		return output.GoodHighlight
+	case "amber":
+		return output.WarningHighlight
+	case "red":
+		return output.ErrorHighlight
+	}
 	return nil
 }
 

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3799,23 +3799,22 @@ func (s *StatusSuite) TestFormatTabularMetering(c *gc.C) {
 	out := &bytes.Buffer{}
 	err := FormatTabular(out, false, status)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(out.String(), gc.Equals, `
-Model  Controller  Cloud/Region  Version
-                                 
-
-App  Version  Status  Scale  Charm  Store  Rev  OS  Notes
-foo                     0/2                  0      
-
-Unit   Workload  Agent  Machine  Public address  Ports  Message
-foo/0                                                   
-foo/1                                                   
-
-Meter  Status   Message
-foo/0  strange  warning: stable strangelets
-foo/1  up       things are looking up
-
-Machine  State  DNS  Inst id  Series  AZ
-`[1:])
+	c.Assert(out.String(), gc.Equals, ""+
+		"Model  Controller  Cloud/Region  Version\n"+
+		"                                 \n"+
+		"\n"+
+		"App  Version  Status  Scale  Charm  Store  Rev  OS  Notes\n"+
+		"foo                     0/2                  0      \n"+
+		"\n"+
+		"Unit   Workload  Agent  Machine  Public address  Ports  Message\n"+
+		"foo/0                                                   \n"+
+		"foo/1                                                   \n"+
+		"\n"+
+		"Meter  Status   Message\n"+
+		"foo/0  strange  warning: stable strangelets  \n"+
+		"foo/1  up       things are looking up        \n"+
+		"\n"+
+		"Machine  State  DNS  Inst id  Series  AZ\n")
 }
 
 //


### PR DESCRIPTION
QA steps: Deploy a charm that has meter status. In a terminal that supports colors, observe meter status in color.