### PR TITLE
Report migration status in show-model

### DIFF
--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -57,6 +57,7 @@ type ModelManagerBackend interface {
 	Export() (description.Model, error)
 	SetUserAccess(subject names.UserTag, target names.Tag, access permission.Access) (permission.UserAccess, error)
 	LastModelConnection(user names.UserTag) (time.Time, error)
+	LatestMigration() (state.ModelMigration, error)
 	DumpAll() (map[string]interface{}, error)
 	Close() error
 }

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -199,6 +199,7 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		{"LastModelConnection", []interface{}{names.NewLocalUserTag("charlotte")}},
 		{"LastModelConnection", []interface{}{names.NewLocalUserTag("mary")}},
 		{"AllMachines", nil},
+		{"LatestMigration", nil},
 		{"Close", nil},
 	})
 	s.st.model.CheckCalls(c, []gitjujutesting.StubCall{
@@ -284,6 +285,52 @@ func (s *modelInfoSuite) TestModelInfoErrorNoAccess(c *gc.C) {
 	s.testModelInfoError(c, coretesting.ModelTag.String(), `permission denied`)
 }
 
+func (s *modelInfoSuite) TestRunningMigration(c *gc.C) {
+	start := time.Now().Add(-20 * time.Minute)
+	s.st.migration = &mockMigration{
+		status: "computing optimal bin packing",
+		start:  start,
+	}
+
+	results, err := s.modelmanager.ModelInfo(params.Entities{
+		Entities: []params.Entity{{coretesting.ModelTag.String()}},
+	})
+
+	c.Assert(err, jc.ErrorIsNil)
+	migrationResult := results.Results[0].Result.Migration
+	c.Assert(migrationResult.Status, gc.Equals, "computing optimal bin packing")
+	c.Assert(*migrationResult.Start, gc.Equals, start)
+	c.Assert(migrationResult.End, gc.IsNil)
+}
+
+func (s *modelInfoSuite) TestFailedMigration(c *gc.C) {
+	start := time.Now().Add(-20 * time.Minute)
+	end := time.Now().Add(-10 * time.Minute)
+	s.st.migration = &mockMigration{
+		status: "couldn't realign alternate time frames",
+		start:  start,
+		end:    end,
+	}
+
+	results, err := s.modelmanager.ModelInfo(params.Entities{
+		Entities: []params.Entity{{coretesting.ModelTag.String()}},
+	})
+
+	c.Assert(err, jc.ErrorIsNil)
+	migrationResult := results.Results[0].Result.Migration
+	c.Assert(migrationResult.Status, gc.Equals, "couldn't realign alternate time frames")
+	c.Assert(*migrationResult.Start, gc.Equals, start)
+	c.Assert(*migrationResult.End, gc.Equals, end)
+}
+
+func (s *modelInfoSuite) TestNoMigration(c *gc.C) {
+	results, err := s.modelmanager.ModelInfo(params.Entities{
+		Entities: []params.Entity{{coretesting.ModelTag.String()}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results[0].Result.Migration, gc.IsNil)
+}
+
 func (s *modelInfoSuite) testModelInfoError(c *gc.C, modelTag, expectedErr string) {
 	results, err := s.modelmanager.ModelInfo(params.Entities{
 		Entities: []params.Entity{{modelTag}},
@@ -320,6 +367,7 @@ type mockState struct {
 	cfgDefaults     config.ModelDefaultAttributes
 	blockMsg        string
 	block           state.BlockType
+	migration       *mockMigration
 }
 
 type fakeModelDescription struct {
@@ -547,6 +595,16 @@ func (st *mockState) DumpAll() (map[string]interface{}, error) {
 	}, st.NextErr()
 }
 
+func (st *mockState) LatestMigration() (state.ModelMigration, error) {
+	st.MethodCall(st, "LatestMigration")
+	if st.migration == nil {
+		// Handle nil->notfound directly here rather than having to
+		// count errors.
+		return nil, errors.NotFoundf("")
+	}
+	return st.migration, st.NextErr()
+}
+
 type mockBlock struct {
 	state.Block
 	t state.BlockType
@@ -698,4 +756,24 @@ type mockModelUser struct {
 	displayName    string
 	lastConnection time.Time
 	access         permission.Access
+}
+
+type mockMigration struct {
+	state.ModelMigration
+
+	status string
+	start  time.Time
+	end    time.Time
+}
+
+func (m *mockMigration) StatusMessage() string {
+	return m.status
+}
+
+func (m *mockMigration) StartTime() time.Time {
+	return m.start
+}
+
+func (m *mockMigration) EndTime() time.Time {
+	return m.end
 }

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -623,6 +623,25 @@ func (m *ModelManagerAPI) getModelInfo(tag names.ModelTag) (params.ModelInfo, er
 			return params.ModelInfo{}, err
 		}
 	}
+
+	migration, err := st.LatestMigration()
+	if err != nil && !errors.IsNotFound(err) {
+		return params.ModelInfo{}, errors.Trace(err)
+	}
+	if err == nil {
+		startTime := migration.StartTime()
+		endTime := new(time.Time)
+		*endTime = migration.EndTime()
+		var zero time.Time
+		if *endTime == zero {
+			endTime = nil
+		}
+		info.Migration = &params.ModelMigrationStatus{
+			Status: migration.StatusMessage(),
+			Start:  &startTime,
+			End:    endTime,
+		}
+	}
 	return info, nil
 }
 

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -106,6 +106,14 @@ type SetModelAgentVersion struct {
 	Version version.Number `json:"version"`
 }
 
+// ModelMigrationStatus holds information about the progress of a (possibly
+// failed) migration.
+type ModelMigrationStatus struct {
+	Status string     `json:"status"`
+	Start  *time.Time `json:"start"`
+	End    *time.Time `json:"end,omitempty"`
+}
+
 // ModelInfo holds information about the Juju model.
 type ModelInfo struct {
 	Name               string `json:"name"`
@@ -135,6 +143,10 @@ type ModelInfo struct {
 	// This information is available to owners and users with write
 	// access or greater.
 	Machines []ModelMachineInfo `json:"machines"`
+
+	// Migration contains information about the latest failed or
+	// currently-running migration. It'll be nil if there isn't one.
+	Migration *ModelMigrationStatus `json:"migration,omitempty"`
 }
 
 // ModelInfoResult holds the result of a ModelInfo call.

--- a/cmd/juju/common/model.go
+++ b/cmd/juju/common/model.go
@@ -38,9 +38,12 @@ type ModelMachineInfo struct {
 
 // ModelStatus contains the current status of a model.
 type ModelStatus struct {
-	Current status.Status `json:"current" yaml:"current"`
-	Message string        `json:"message,omitempty" yaml:"message,omitempty"`
-	Since   string        `json:"since,omitempty" yaml:"since,omitempty"`
+	Current        status.Status `json:"current" yaml:"current"`
+	Message        string        `json:"message,omitempty" yaml:"message,omitempty"`
+	Since          string        `json:"since,omitempty" yaml:"since,omitempty"`
+	Migration      string        `json:"migration,omitempty" yaml:"migration,omitempty"`
+	MigrationStart string        `json:"migration-start,omitempty" yaml:"migration-start,omitempty"`
+	MigrationEnd   string        `json:"migration-end,omitempty" yaml:"migration-end,omitempty"`
 }
 
 // ModelUserInfo defines the serialization behaviour of the model user
@@ -49,6 +52,15 @@ type ModelUserInfo struct {
 	DisplayName    string `yaml:"display-name,omitempty" json:"display-name,omitempty"`
 	Access         string `yaml:"access" json:"access"`
 	LastConnection string `yaml:"last-connection" json:"last-connection"`
+}
+
+// friendlyDuration renders a time pointer that we get from the API as
+// a friendly string.
+func friendlyDuration(when *time.Time, now time.Time) string {
+	if when == nil {
+		return ""
+	}
+	return UserFriendlyDuration(*when, now)
 }
 
 // ModelInfoFromParams translates a params.ModelInfo to ModelInfo.
@@ -60,9 +72,12 @@ func ModelInfoFromParams(info params.ModelInfo, now time.Time) (ModelInfo, error
 	status := ModelStatus{
 		Current: info.Status.Status,
 		Message: info.Status.Info,
+		Since:   friendlyDuration(info.Status.Since, now),
 	}
-	if info.Status.Since != nil {
-		status.Since = UserFriendlyDuration(*info.Status.Since, now)
+	if info.Migration != nil {
+		status.Migration = info.Migration.Status
+		status.MigrationStart = friendlyDuration(info.Migration.Start, now)
+		status.MigrationEnd = friendlyDuration(info.Migration.End, now)
 	}
 	cloudTag, err := names.ParseCloudTag(info.CloudTag)
 	if err != nil {

--- a/cmd/juju/model/show_test.go
+++ b/cmd/juju/model/show_test.go
@@ -58,6 +58,8 @@ func (s *ShowCommandSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	lastConnection := time.Date(2015, 3, 20, 0, 0, 0, 0, time.UTC)
 	statusSince := time.Date(2016, 4, 5, 0, 0, 0, 0, time.UTC)
+	migrationStart := time.Date(2016, 4, 6, 0, 10, 0, 0, time.UTC)
+	migrationEnd := time.Date(2016, 4, 7, 0, 0, 15, 0, time.UTC)
 
 	users := []params.ModelUserInfo{{
 		UserName:       "admin",
@@ -85,6 +87,11 @@ func (s *ShowCommandSuite) SetUpTest(c *gc.C) {
 			Since:  &statusSince,
 		},
 		Users: users,
+		Migration: &params.ModelMigrationStatus{
+			Status: "obfuscating Quigley matrix",
+			Start:  &migrationStart,
+			End:    &migrationEnd,
+		},
 	}
 
 	s.expectedOutput = attrs{
@@ -99,8 +106,11 @@ func (s *ShowCommandSuite) SetUpTest(c *gc.C) {
 			"type":            "openstack",
 			"life":            "alive",
 			"status": attrs{
-				"current": "active",
-				"since":   "2016-04-05",
+				"current":         "active",
+				"since":           "2016-04-05",
+				"migration":       "obfuscating Quigley matrix",
+				"migration-start": "2016-04-06",
+				"migration-end":   "2016-04-07",
 			},
 			"users": attrs{
 				"admin": attrs{


### PR DESCRIPTION
Adds `migration`, `migration-start` and `migration-end` (for failed migrations) fields to the status section of show-model output. These display details about the current migration (if one is running) or the latest failed migration - if the last migration was completed successfully the model would be gone.

Example output:
```
my-model:
  name: my-model
  model-uuid: 7a6051e0-ba0b-4b35-8d9b-627072092933
  controller-uuid: fb82ce82-6da4-4db3-8dc3-01c28f2f25bc
  controller-name: source
  owner: admin
  cloud: lxd
  region: localhost
  type: lxd
  life: alive
  status:
    current: available
    since: 5 minutes ago
    migration: validating, waiting for agents to report back
    migration-start: 10 seconds ago
  users:
    admin:
      display-name: admin
      access: admin
      last-connection: never connected
```

Testing done:
* bootstrapped 2 controllers with the migration feature flag on
* (in source controller) add-model my-model
* deploy ubuntu
* migrate my-model dest
* watch -n 0.5 juju show-model