### PR TITLE
Update juju/testing to work with newer Mongo releases.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -43,7 +43,7 @@ github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:4
 github.com/juju/romulus	git	bf7827fa2f360ab762c134766ff1d4fff959ea03	2016-08-17T23:29:48Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
-github.com/juju/testing	git	692d58e72934a2e2b56f663259696e035e6351ff	2016-09-30T14:09:10Z
+github.com/juju/testing	git	3c01e9e4a3208dc72e39b030738b46362ddcfeda	2016-11-07T14:13:10Z
 github.com/juju/txn	git	af2fa2051800371a0272610882891a28c719c02c	2016-10-31T02:11:40Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	ff639f825faac294524c2fff065f58fed5bcd77e	2016-11-01T02:02:32Z


### PR DESCRIPTION
https://github.com/juju/juju/pull/6545 already gave this a +1. This is the same change cherry picked on top of develop.