### PR TITLE
Juju doesn't support vsphere networking.

### DIFF
--- a/provider/vsphere/environ_network.go
+++ b/provider/vsphere/environ_network.go
@@ -7,36 +7,9 @@ package vsphere
 
 import (
 	"github.com/juju/errors"
-	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 )
-
-// SupportsSpaces is specified on environs.Networking.
-func (env *environ) SupportsSpaces() (bool, error) {
-	return false, errors.NotSupportedf("spaces")
-}
-
-// SupportsSpaceDiscovery implements environs.Networking.
-func (env *environ) SupportsSpaceDiscovery() (bool, error) {
-	return false, errors.NotSupportedf("spaces")
-}
-
-// Spaces implements environs.Networking.
-func (env *environ) Spaces() ([]network.SpaceInfo, error) {
-	return nil, errors.NotSupportedf("spaces")
-}
-
-// Subnets implements environs.Networking.
-func (env *environ) Subnets(inst instance.Id, ids []network.Id) ([]network.SubnetInfo, error) {
-	return env.client.Subnets(inst, ids)
-}
-
-// NetworkInterfaces implements environs.Networking.
-func (env *environ) NetworkInterfaces(inst instance.Id) ([]network.InterfaceInfo, error) {
-	return env.client.GetNetworkInterfaces(inst, env.ecfg)
-}
 
 // OpenPorts opens the given port ranges for the whole environment.
 // Must only be used if the environment was setup with the
@@ -57,14 +30,4 @@ func (env *environ) ClosePorts(ports []network.PortRange) error {
 // FwGlobal firewall mode.
 func (env *environ) Ports() ([]network.PortRange, error) {
 	return nil, errors.Trace(errors.NotSupportedf("Ports"))
-}
-
-// AllocateContainerAddresses implements environs.Networking.
-func (e *environ) AllocateContainerAddresses(hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo []network.InterfaceInfo) ([]network.InterfaceInfo, error) {
-	return nil, errors.NotSupportedf("container address allocation")
-}
-
-// ReleaseContainerAddresses implements environs.Networking.
-func (e *environ) ReleaseContainerAddresses(interfaces []network.ProviderInterfaceInfo) error {
-	return errors.NotSupportedf("container address allocation")
 }

--- a/provider/vsphere/environ_test.go
+++ b/provider/vsphere/environ_test.go
@@ -55,7 +55,6 @@ func (s *environSuite) TestPrepareForBootstrap(c *gc.C) {
 }
 
 func (s *environSuite) TestSupportsNetworking(c *gc.C) {
-	var _ environs.Networking = s.Env
 	_, ok := environs.SupportsNetworking(s.Env)
-	c.Assert(ok, jc.IsTrue)
+	c.Assert(ok, jc.IsFalse)
 }


### PR DESCRIPTION
Don't defined the environs.Networking interface on the vsphere provider - it doesn't support it.

Fixes http://pad.lv/1638401

Testing performed: I don't have vsphere access so I have run the unit tests only. Need a +1 from someone who can confirm this hasn't broken anything.