### PR TITLE
Fixes lp:1638706 azure tests fail on non amd64

### DIFF
--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -942,6 +942,17 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 			BootstrapSeries:  "quantal",
 		},
 	)
+	// If we aren't on amd64, this should correctly fail. See also:
+	// lp#1638706: environSuite.TestBootstrapInstanceConstraints fails on rare archs and series
+	if arch.HostArch() != "amd64" {
+		wantErr := fmt.Sprintf("model %q of type %s does not support instances running on %q",
+			env.Config().Name(),
+			env.Config().Type(),
+			arch.HostArch())
+		c.Assert(err, gc.ErrorMatches, wantErr)
+		c.SucceedNow()
+	}
+	// amd64 should pass the rest of the test.
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Arch, gc.Equals, "amd64")
 	c.Assert(result.Series, gc.Equals, "quantal")


### PR DESCRIPTION
Forward port (cherry picked from commit cd17ec25af0f9dde0bd600a3f28bb4ad074ac793)

QA: Run the target test on arm64-slave
1 .Verify it fails on develop
```
$ git checkout develop
Switched to branch 'develop'
Your branch is up-to-date with 'upstream/develop'.

$ go test -check.f TestBootstrapInstanceConstraints

----------------------------------------------------------------------
FAIL: environ_test.go:1005: environSuite.TestBootstrapInstanceConstraints

[LOG] 0:00.001 DEBUG juju.provider.azure opening model "testenv"
[LOG] 0:00.001 DEBUG juju.provider.azure.internal.azuretesting Senders.Do(https://api.azurestack.local/subscriptions/22222222-2222-2222-2222-222222222222?api-version=2015-11-01)
[LOG] 0:00.001 DEBUG juju.provider.azure.internal.azureauth discovered auth URI: https://testing.invalid/11111111-1111-1111-1111-111111111111
[LOG] 0:00.001 DEBUG juju.provider.azure.internal.azuretesting Senders.Do(https://testing.invalid/11111111-1111-1111-1111-111111111111/oauth2/token?api-version=1.0)
[LOG] 0:00.002 DEBUG juju.environs.bootstrap model "testenv" supports service/machine networks: false
[LOG] 0:00.002 DEBUG juju.environs.bootstrap network management by juju enabled: true
[LOG] 0:00.002 INFO cmd Loading image metadata
[LOG] 0:00.002 DEBUG juju.provider.azure.internal.azuretesting Senders.Do(https://api.azurestack.local/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Compute/locations/westus/vmSizes?api-version=2016-03-30)
[LOG] 0:00.003 INFO juju.environs.bootstrap looking for bootstrap agent binaries: version=1.2.3
[LOG] 0:00.003 INFO juju.environs.tools finding agent binaries in stream "released"
[LOG] 0:00.003 INFO juju.environs.tools reading agent binaries with major.minor version 2.1
[LOG] 0:00.003 INFO juju.environs.tools filtering agent binaries by version: 1.2.3
[LOG] 0:00.003 INFO juju.environs.tools filtering agent binaries by series: quantal
[LOG] 0:00.003 INFO juju.environs.tools filtering agent binaries by architecture: arm64
[LOG] 0:00.003 INFO juju.environs.bootstrap found 0 packaged agent binaries
environ_test.go:1030:
    c.Assert(err, jc.ErrorIsNil)
... value *errors.Err = &errors.Err{message:"model \"testenv\" of type azure does not support instances running on \"arm64\"", cause:error(nil), previous:error(nil), file:"github.com/juju/juju/environs/bootstrap/tools.go", line:51} ("model \"testenv\" of type azure does not support instances running on \"arm64\"")
... error stack:
	github.com/juju/juju/environs/bootstrap/tools.go:51: model "testenv" of type azure does not support instances running on "arm64"

OOPS: 0 passed, 1 FAILED
--- FAIL: TestPackage (0.02s)
FAIL
exit status 1
FAIL	github.com/juju/juju/provider/azure	0.202s
```

2. Verify it passes with forward port.
```
$ go test -check.f TestBootstrapInstanceConstraints
OK: 1 passed
PASS
ok  	github.com/juju/juju/provider/azure	0.183s
```
