### PR TITLE
Add instance types

### DIFF
--- a/apiserver/cloud/backend.go
+++ b/apiserver/cloud/backend.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 )
 
@@ -14,13 +15,17 @@ type Backend interface {
 	Clouds() (map[names.CloudTag]cloud.Cloud, error)
 	Cloud(cloudName string) (cloud.Cloud, error)
 	CloudCredentials(user names.UserTag, cloudName string) (map[string]cloud.Credential, error)
+	CloudCredential(tag names.CloudCredentialTag) (cloud.Credential, error)
 	ControllerModel() (Model, error)
 	ControllerTag() names.ControllerTag
 	ModelTag() names.ModelTag
+	ModelConfig() (*config.Config, error)
 	UpdateCloudCredential(names.CloudCredentialTag, cloud.Credential) error
 	RemoveCloudCredential(names.CloudCredentialTag) error
 
 	IsControllerAdmin(names.UserTag) (bool, error)
+
+	GetModel(tag names.ModelTag) (Model, error)
 
 	Close() error
 }
@@ -41,8 +46,19 @@ func (s stateShim) ControllerModel() (Model, error) {
 	return m, nil
 }
 
+func (s stateShim) GetModel(tag names.ModelTag) (Model, error) {
+	m, err := s.State.GetModel(tag)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 type Model interface {
 	Cloud() string
 	CloudCredential() (names.CloudCredentialTag, bool)
 	CloudRegion() string
+	ModelTag() names.ModelTag
+
+	Config() (*config.Config, error)
 }

--- a/apiserver/cloud/cloud_test.go
+++ b/apiserver/cloud/cloud_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 	_ "github.com/juju/juju/provider/dummy"
 )
 
@@ -277,6 +278,8 @@ type mockBackend struct {
 	gitjujutesting.Stub
 	cloud cloud.Cloud
 	creds map[string]cloud.Credential
+
+	cloudSpec environs.CloudSpec
 }
 
 func (st *mockBackend) IsControllerAdmin(user names.UserTag) (bool, error) {

--- a/apiserver/cloud/export_test.go
+++ b/apiserver/cloud/export_test.go
@@ -1,0 +1,15 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud
+
+import "github.com/juju/juju/apiserver/facade"
+
+var InstanceTypes = instanceTypes
+
+func NewCloudTestingAPI(backend Backend, authorizer facade.Authorizer) *CloudAPI {
+	return &CloudAPI{
+		backend:    backend,
+		authorizer: authorizer,
+	}
+}

--- a/apiserver/cloud/instance_information.go
+++ b/apiserver/cloud/instance_information.go
@@ -1,0 +1,95 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/state/stateenvirons"
+)
+
+// EnvironConfigGetter implements environs.EnvironConfigGetter
+// in terms of a *state.State.
+type cloudEnvironConfigGetter struct {
+	Backend
+	region string
+}
+
+// CloudSpec implements environs.EnvironConfigGetter.
+func (g cloudEnvironConfigGetter) CloudSpec(tag names.ModelTag) (environs.CloudSpec, error) {
+	model, err := g.GetModel(tag)
+	if err != nil {
+		return environs.CloudSpec{}, errors.Trace(err)
+	}
+	cloudName := model.Cloud()
+	regionName := g.region
+	credentialTag, _ := model.CloudCredential()
+	return stateenvirons.CloudSpec(g.Backend, cloudName, regionName, credentialTag)
+}
+
+// InstanceTypes returns instance type information for the cloud and region
+// in which the current model is deployed.
+func (api *CloudAPI) InstanceTypes(cons params.CloudInstanceTypesConstraints) (params.InstanceTypesResults, error) {
+	return instanceTypes(api, environs.GetEnviron, cons)
+}
+
+type environGetFunc func(st environs.EnvironConfigGetter, newEnviron environs.NewEnvironFunc) (environs.Environ, error)
+
+func instanceTypes(api *CloudAPI,
+	environGet environGetFunc,
+	cons params.CloudInstanceTypesConstraints,
+) (params.InstanceTypesResults, error) {
+	c, err := api.backend.ControllerModel()
+	if err != nil {
+		return params.InstanceTypesResults{}, errors.Trace(err)
+	}
+	modelTag := c.ModelTag()
+	m, err := api.backend.GetModel(modelTag)
+	if err != nil {
+		return params.InstanceTypesResults{}, errors.Trace(err)
+	}
+
+	result := make([]params.InstanceTypesResult, len(cons.Constraints))
+	// TODO(perrito666) Cache the results to avoid excessive querying of the cloud.
+	// TODO(perrito666) Add Region<>Cloud validation.
+	for i, cons := range cons.Constraints {
+		value := constraints.Value{}
+		if cons.Constraints != nil {
+			value = *cons.Constraints
+		}
+		backend := cloudEnvironConfigGetter{
+			Backend: api.backend,
+			region:  cons.CloudRegion,
+		}
+		cloudTag, err := names.ParseCloudTag(cons.CloudTag)
+		if err != nil {
+			result[i] = params.InstanceTypesResult{Error: common.ServerError(err)}
+			continue
+		}
+		if m.Cloud() != cloudTag.Id() {
+			result[i] = params.InstanceTypesResult{Error: common.ServerError(errors.NotValidf("asking %s cloud information to %s cloud", cloudTag.Id(), m.Cloud()))}
+			continue
+		}
+
+		env, err := environGet(backend, environs.New)
+		if err != nil {
+			return params.InstanceTypesResults{}, errors.Trace(err)
+		}
+
+		itCons := common.NewInstanceTypeConstraints(env, value)
+		it, err := common.InstanceTypes(itCons)
+		if err != nil {
+			result[i] = params.InstanceTypesResult{Error: common.ServerError(err)}
+			continue
+		}
+		result[i] = it
+	}
+
+	return params.InstanceTypesResults{Results: result}, nil
+}

--- a/apiserver/cloud/instance_information_test.go
+++ b/apiserver/cloud/instance_information_test.go
@@ -1,0 +1,129 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud_test
+
+import (
+	"github.com/juju/errors"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/cloud"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/testing"
+	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/instances"
+	"github.com/juju/juju/provider/dummy"
+)
+
+type instanceTypesSuite struct{}
+
+var _ = gc.Suite(&instanceTypesSuite{})
+
+var over9kCPUCores uint64 = 9001
+
+func (p *instanceTypesSuite) TestInstanceTypes(c *gc.C) {
+	backend := mockBackend{
+		cloudSpec: environs.CloudSpec{},
+	}
+	authorizer := testing.FakeAuthorizer{Tag: names.NewUserTag("admin"),
+		EnvironManager: true}
+	itCons := constraints.Value{CpuCores: &over9kCPUCores}
+	failureCons := constraints.Value{}
+	env := mockEnviron{
+		results: map[constraints.Value]instances.InstanceTypesWithCostMetadata{
+			itCons: instances.InstanceTypesWithCostMetadata{
+				CostUnit:     "USD/h",
+				CostCurrency: "USD",
+				InstanceTypes: []instances.InstanceType{
+					{Name: "instancetype-1"},
+					{Name: "instancetype-2"}},
+			},
+		},
+	}
+	api := cloud.NewCloudTestingAPI(&backend, authorizer)
+
+	cons := params.CloudInstanceTypesConstraints{
+		Constraints: []params.CloudInstanceTypesConstraint{
+			{CloudTag: "cloud-aws",
+				CloudRegion: "a-region",
+				Constraints: &itCons},
+			{CloudTag: "cloud-aws",
+				CloudRegion: "a-region",
+				Constraints: &failureCons},
+			{CloudTag: "cloud-gce",
+				CloudRegion: "a-region",
+				Constraints: &itCons}},
+	}
+	fakeEnvironGet := func(st environs.EnvironConfigGetter,
+		newEnviron environs.NewEnvironFunc,
+	) (environs.Environ, error) {
+		return &env, nil
+	}
+	r, err := cloud.InstanceTypes(api, fakeEnvironGet, cons)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r.Results, gc.HasLen, 3)
+	expected := []params.InstanceTypesResult{
+		params.InstanceTypesResult{
+			InstanceTypes: []params.InstanceType{
+				params.InstanceType{
+					Name: "instancetype-1"},
+				params.InstanceType{Name: "instancetype-2"}},
+			CostUnit:     "USD/h",
+			CostCurrency: "USD",
+		},
+		params.InstanceTypesResult{
+			Error: &params.Error{Message: "Instances matching constraint  not found", Code: "not found"}},
+		params.InstanceTypesResult{
+			Error: &params.Error{Message: "asking gce cloud information to aws cloud not valid", Code: ""}}}
+	c.Assert(r.Results, gc.DeepEquals, expected)
+}
+
+func (*mockBackend) GetModel(t names.ModelTag) (cloud.Model, error) {
+	return &mockModel{cloud: "aws"}, nil
+}
+
+func (*mockBackend) ModelConfig() (*config.Config, error) {
+	return nil, nil
+}
+
+func (fb *mockBackend) CloudSpec(names.ModelTag) (environs.CloudSpec, error) {
+	fb.MethodCall(fb, "CloudSpec")
+	if err := fb.NextErr(); err != nil {
+		return environs.CloudSpec{}, err
+	}
+	return fb.cloudSpec, nil
+}
+
+func (fb *mockBackend) CloudCredential(tag names.CloudCredentialTag) (jujucloud.Credential, error) {
+	return jujucloud.Credential{}, nil
+}
+
+type mockEnviron struct {
+	environs.Environ
+	cloud.Backend
+	jujutesting.Stub
+
+	results map[constraints.Value]instances.InstanceTypesWithCostMetadata
+}
+
+func (m *mockEnviron) InstanceTypes(c constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+	it, ok := m.results[c]
+	if !ok {
+		return instances.InstanceTypesWithCostMetadata{}, errors.NotFoundf("Instances matching constraint %v", c)
+	}
+	return it, nil
+}
+
+func (mockModel) ModelTag() names.ModelTag {
+	return names.NewModelTag("beef1beef1-0000-0000-000011112222")
+}
+
+func (*mockModel) Config() (*config.Config, error) {
+	return config.New(config.UseDefaults, dummy.SampleConfig())
+}

--- a/apiserver/common/environ_config.go
+++ b/apiserver/common/environ_config.go
@@ -1,0 +1,28 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+)
+
+// EnvironConfigGetterFuncs holds implements environs.EnvironConfigGetter
+// in a pluggable way.
+type EnvironConfigGetterFuncs struct {
+	ModelConfigFunc func() (*config.Config, error)
+	CloudSpecFunc   func(names.ModelTag) (environs.CloudSpec, error)
+}
+
+// ModelConfig implements EnvironConfigGetter.
+func (f EnvironConfigGetterFuncs) ModelConfig() (*config.Config, error) {
+	return f.ModelConfigFunc()
+}
+
+// CloudSpec implements environs.EnvironConfigGetter.
+func (f EnvironConfigGetterFuncs) CloudSpec(model names.ModelTag) (environs.CloudSpec, error) {
+	return f.CloudSpecFunc(model)
+}

--- a/apiserver/common/instancetypes.go
+++ b/apiserver/common/instancetypes.go
@@ -1,0 +1,64 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/instances"
+)
+
+func toParamsInstanceTypeResult(itypes []instances.InstanceType) []params.InstanceType {
+	result := make([]params.InstanceType, len(itypes))
+	for i, t := range itypes {
+		virtType := ""
+		if t.VirtType != nil {
+			virtType = *t.VirtType
+		}
+		result[i] = params.InstanceType{
+			Name:         t.Name,
+			Arches:       t.Arches,
+			CPUCores:     int(t.CpuCores),
+			Memory:       int(t.Mem),
+			RootDiskSize: int(t.RootDisk),
+			VirtType:     virtType,
+			Deprecated:   t.Deprecated,
+			Cost:         int(t.Cost),
+		}
+	}
+	return result
+}
+
+// NewInstanceTypeConstraints returns an instanceTypeConstraints with the passed
+// parameters.
+func NewInstanceTypeConstraints(env environs.Environ, constraints constraints.Value) instanceTypeConstraints {
+	return instanceTypeConstraints{
+		environ:     env,
+		constraints: constraints,
+	}
+}
+
+// instanceTypeConstraints holds necesary params to filter instance types.
+type instanceTypeConstraints struct {
+	constraints constraints.Value
+	environ     environs.Environ
+}
+
+// InstanceTypes returns a list of the available instance types in the provider according
+// to the passed constraints.
+func InstanceTypes(cons instanceTypeConstraints) (params.InstanceTypesResult, error) {
+	instanceTypes, err := cons.environ.InstanceTypes(cons.constraints)
+	if err != nil {
+		return params.InstanceTypesResult{}, errors.Trace(err)
+	}
+
+	return params.InstanceTypesResult{
+		InstanceTypes: toParamsInstanceTypeResult(instanceTypes.InstanceTypes),
+		CostUnit:      instanceTypes.CostUnit,
+		CostCurrency:  instanceTypes.CostCurrency,
+		CostDivisor:   instanceTypes.CostDivisor,
+	}, nil
+}

--- a/apiserver/machinemanager/export_test.go
+++ b/apiserver/machinemanager/export_test.go
@@ -3,7 +3,10 @@
 
 package machinemanager
 
-import "github.com/juju/juju/state"
+import (
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/state"
+)
 
 type StateInterface stateInterface
 
@@ -16,3 +19,12 @@ func PatchState(p Patcher, st StateInterface) {
 		return st
 	})
 }
+
+func NewMachineManagerTestingAPI(st stateInterface, authorizer facade.Authorizer) MachineManagerAPI {
+	return MachineManagerAPI{
+		st:         st,
+		authorizer: authorizer,
+	}
+}
+
+var InstanceTypes = instanceTypes

--- a/apiserver/machinemanager/instance_information.go
+++ b/apiserver/machinemanager/instance_information.go
@@ -1,0 +1,62 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machinemanager
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/state/stateenvirons"
+)
+
+// InstanceTypes returns instance type information for the cloud and region
+// in which the current model is deployed.
+func (mm *MachineManagerAPI) InstanceTypes(cons params.ModelInstanceTypesConstraints) (params.InstanceTypesResults, error) {
+	return instanceTypes(mm, environs.GetEnviron, cons)
+}
+
+type environGetFunc func(st environs.EnvironConfigGetter, newEnviron environs.NewEnvironFunc) (environs.Environ, error)
+
+func instanceTypes(mm *MachineManagerAPI,
+	getEnviron environGetFunc,
+	cons params.ModelInstanceTypesConstraints,
+) (params.InstanceTypesResults, error) {
+	model, err := mm.st.GetModel(mm.st.ModelTag())
+	if err != nil {
+		return params.InstanceTypesResults{}, errors.Trace(err)
+	}
+
+	cloudSpec := func(tag names.ModelTag) (environs.CloudSpec, error) {
+		cloudName := model.Cloud()
+		regionName := model.CloudRegion()
+		credentialTag, _ := model.CloudCredential()
+		return stateenvirons.CloudSpec(mm.st, cloudName, regionName, credentialTag)
+	}
+	backend := common.EnvironConfigGetterFuncs{
+		CloudSpecFunc:   cloudSpec,
+		ModelConfigFunc: model.Config,
+	}
+
+	env, err := getEnviron(backend, environs.New)
+	result := make([]params.InstanceTypesResult, len(cons.Constraints))
+	// TODO(perrito666) Cache the results to avoid excessive querying of the cloud.
+	for i, c := range cons.Constraints {
+		value := constraints.Value{}
+		if c.Value != nil {
+			value = *c.Value
+		}
+		itCons := common.NewInstanceTypeConstraints(env, value)
+		it, err := common.InstanceTypes(itCons)
+		if err != nil {
+			it = params.InstanceTypesResult{Error: common.ServerError(err)}
+		}
+		result[i] = it
+	}
+
+	return params.InstanceTypesResults{Results: result}, nil
+}

--- a/apiserver/machinemanager/instance_information_test.go
+++ b/apiserver/machinemanager/instance_information_test.go
@@ -1,0 +1,158 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machinemanager_test
+
+import (
+	"github.com/juju/errors"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/machinemanager"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/instances"
+	"github.com/juju/juju/provider/dummy"
+)
+
+type instanceTypesSuite struct{}
+
+var _ = gc.Suite(&instanceTypesSuite{})
+
+var over9kCPUCores uint64 = 9001
+
+func (p *instanceTypesSuite) TestInstanceTypes(c *gc.C) {
+	backend := mockBackend{
+		cloudSpec: environs.CloudSpec{},
+	}
+	authorizer := testing.FakeAuthorizer{Tag: names.NewUserTag("admin"),
+		EnvironManager: true}
+	itCons := constraints.Value{CpuCores: &over9kCPUCores}
+	failureCons := constraints.Value{}
+	env := mockEnviron{
+		results: map[constraints.Value]instances.InstanceTypesWithCostMetadata{
+			itCons: instances.InstanceTypesWithCostMetadata{
+				CostUnit:     "USD/h",
+				CostCurrency: "USD",
+				InstanceTypes: []instances.InstanceType{
+					{Name: "instancetype-1"},
+					{Name: "instancetype-2"}},
+			},
+		},
+	}
+	api := machinemanager.NewMachineManagerTestingAPI(&backend, authorizer)
+
+	cons := params.ModelInstanceTypesConstraints{
+		Constraints: []params.ModelInstanceTypesConstraint{{Value: &itCons}, {Value: &failureCons}, {}},
+	}
+	fakeEnvironGet := func(st environs.EnvironConfigGetter,
+		newEnviron environs.NewEnvironFunc,
+	) (environs.Environ, error) {
+		return &env, nil
+	}
+	r, err := machinemanager.InstanceTypes(&api, fakeEnvironGet, cons)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r.Results, gc.HasLen, 3)
+	expected := []params.InstanceTypesResult{
+		params.InstanceTypesResult{
+			InstanceTypes: []params.InstanceType{
+				params.InstanceType{
+					Name: "instancetype-1",
+				},
+				params.InstanceType{
+					Name: "instancetype-2",
+				}},
+			CostUnit:     "USD/h",
+			CostCurrency: "USD",
+		},
+		params.InstanceTypesResult{
+			Error: &params.Error{Message: "Instances matching constraint  not found", Code: "not found"}},
+		params.InstanceTypesResult{
+			Error: &params.Error{Message: "Instances matching constraint  not found", Code: "not found"}}}
+	c.Assert(r.Results, gc.DeepEquals, expected)
+}
+
+type mockBackend struct {
+	jujutesting.Stub
+	machinemanager.StateInterface
+
+	cloudSpec environs.CloudSpec
+}
+
+func (*mockBackend) ModelTag() names.ModelTag {
+	return names.NewModelTag("beef1beef1-0000-0000-000011112222")
+}
+
+func (*mockBackend) GetModel(t names.ModelTag) (machinemanager.Model, error) {
+	return &mockModel{}, nil
+}
+
+func (fb *mockBackend) CloudSpec(names.ModelTag) (environs.CloudSpec, error) {
+	fb.MethodCall(fb, "CloudSpec")
+	if err := fb.NextErr(); err != nil {
+		return environs.CloudSpec{}, err
+	}
+	return fb.cloudSpec, nil
+}
+
+func (fb *mockBackend) Cloud(string) (cloud.Cloud, error) {
+	return cloud.Cloud{}, nil
+}
+
+func (fb *mockBackend) Clouds() (map[names.CloudTag]cloud.Cloud, error) {
+	return nil, nil
+}
+
+func (fb *mockBackend) CloudCredentials(user names.UserTag, cloudName string) (map[string]cloud.Credential, error) {
+	return nil, nil
+}
+
+func (fb *mockBackend) CloudCredential(tag names.CloudCredentialTag) (cloud.Credential, error) {
+	return cloud.Credential{}, nil
+}
+
+type mockEnviron struct {
+	environs.Environ
+	machinemanager.StateInterface
+	jujutesting.Stub
+
+	results map[constraints.Value]instances.InstanceTypesWithCostMetadata
+}
+
+func (m *mockEnviron) InstanceTypes(c constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+	it, ok := m.results[c]
+	if !ok {
+		return instances.InstanceTypesWithCostMetadata{}, errors.NotFoundf("Instances matching constraint %v", c)
+	}
+	return it, nil
+}
+
+type mockModel struct {
+	machinemanager.Model
+}
+
+func (mockModel) CloudCredential() (names.CloudCredentialTag, bool) {
+	return names.NewCloudCredentialTag("foo/bob/bar"), true
+}
+
+func (mockModel) ModelTag() names.ModelTag {
+	return names.NewModelTag("beef1beef1-0000-0000-000011112222")
+}
+
+func (*mockModel) Config() (*config.Config, error) {
+	return config.New(config.UseDefaults, dummy.SampleConfig())
+}
+
+func (*mockModel) Cloud() string {
+	return "a-cloud"
+}
+
+func (*mockModel) CloudRegion() string {
+	return "a-region"
+}

--- a/apiserver/machinemanager/machinemanager_test.go
+++ b/apiserver/machinemanager/machinemanager_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/machinemanager"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
@@ -153,6 +154,26 @@ func (st *mockState) AddMachineInsideNewMachine(template, parentTemplate state.M
 
 func (st *mockState) AddMachineInsideMachine(template state.MachineTemplate, parentId string, containerType instance.ContainerType) (*state.Machine, error) {
 	panic("not implemented")
+}
+
+func (st *mockState) Clouds() (map[names.CloudTag]cloud.Cloud, error) {
+	return nil, nil
+}
+
+func (st *mockState) CloudCredentials(user names.UserTag, cloudName string) (map[string]cloud.Credential, error) {
+	return nil, nil
+}
+
+func (st *mockState) CloudCredential(tag names.CloudCredentialTag) (cloud.Credential, error) {
+	return cloud.Credential{}, nil
+}
+
+func (st *mockState) Cloud(string) (cloud.Cloud, error) {
+	return cloud.Cloud{}, nil
+}
+
+func (st *mockState) GetModel(t names.ModelTag) (machinemanager.Model, error) {
+	return &mockModel{}, nil
 }
 
 type mockBlock struct {

--- a/apiserver/machinemanager/state.go
+++ b/apiserver/machinemanager/state.go
@@ -4,6 +4,7 @@
 package machinemanager
 
 import (
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
@@ -18,6 +19,12 @@ type stateInterface interface {
 	AddOneMachine(template state.MachineTemplate) (*state.Machine, error)
 	AddMachineInsideNewMachine(template, parentTemplate state.MachineTemplate, containerType instance.ContainerType) (*state.Machine, error)
 	AddMachineInsideMachine(template state.MachineTemplate, parentId string, containerType instance.ContainerType) (*state.Machine, error)
+
+	GetModel(names.ModelTag) (Model, error)
+	Cloud(string) (cloud.Cloud, error)
+	Clouds() (map[names.CloudTag]cloud.Cloud, error)
+	CloudCredentials(user names.UserTag, cloudName string) (map[string]cloud.Credential, error)
+	CloudCredential(tag names.CloudCredentialTag) (cloud.Credential, error)
 }
 
 type stateShim struct {
@@ -49,4 +56,21 @@ func (s stateShim) AddMachineInsideNewMachine(template, parentTemplate state.Mac
 
 func (s stateShim) AddMachineInsideMachine(template state.MachineTemplate, parentId string, containerType instance.ContainerType) (*state.Machine, error) {
 	return s.State.AddMachineInsideMachine(template, parentId, containerType)
+}
+
+func (s stateShim) GetModel(tag names.ModelTag) (Model, error) {
+	m, err := s.State.GetModel(tag)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+type Model interface {
+	Cloud() string
+	CloudCredential() (names.CloudCredentialTag, bool)
+	CloudRegion() string
+	ModelTag() names.ModelTag
+
+	Config() (*config.Config, error)
 }

--- a/apiserver/params/instance_information.go
+++ b/apiserver/params/instance_information.go
@@ -1,0 +1,74 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package params
+
+import "github.com/juju/juju/constraints"
+
+// CloudInstanceTypesConstraints contains a slice of CloudInstanceTypesConstraint.
+type CloudInstanceTypesConstraints struct {
+	Constraints []CloudInstanceTypesConstraint `json:"constraints"`
+}
+
+// CloudInstanceTypesConstraint contains the cloud information and constraits
+// necessary to query for instance types on a given cloud.
+type CloudInstanceTypesConstraint struct {
+	// CloudTag is the tag of the cloud for which instances types
+	// should be returned.
+	CloudTag string `json:"cloud-tag"`
+
+	// CloudRegion is the name of the region for which instance
+	// types should be returned.
+	CloudRegion string `json:"region"`
+
+	// Constraints, if specified, contains the constraints to filter
+	// the instance types by. If Constraints is not specified, then
+	// no filtering by constraints will take place: all instance
+	// types supported by the region will be returned.
+	Constraints *constraints.Value `json:"constraints,omitempty"`
+}
+
+// ModelInstanceTypesConstraints contains a slice of InstanceTypesConstraint.
+type ModelInstanceTypesConstraints struct {
+	// Constraints, if specified, contains the constraints to filter
+	// the instance types by. If Constraints is not specified, then
+	// no filtering by constraints will take place: all instance
+	// types supported by the model will be returned.
+	Constraints []ModelInstanceTypesConstraint `json:"constraints"`
+}
+
+// ModelInstanceTypesConstraint contains a constraint applied when filtering instance types.
+type ModelInstanceTypesConstraint struct {
+	// Value, if specified, contains the constraints to filter
+	// the instance types by. If Value is not specified, then
+	// no filtering by constraints will take place: all instance
+	// types supported by the region will be returned.
+	Value *constraints.Value `json:"value,omitempty"`
+}
+
+// InstanceTypesResults contains the bulk result of prompting a cloud for its instance types.
+type InstanceTypesResults struct {
+	Results []InstanceTypesResult `json:"results"`
+}
+
+// InstanceTypesResult contains the result of prompting a cloud for its instance types.
+type InstanceTypesResult struct {
+	InstanceTypes []InstanceType `json:"instance-types,omitempty"`
+	CostUnit      string         `json:"cost-unit,omitempty"`
+	CostCurrency  string         `json:"cost-currency,omitempty"`
+	// CostDivisor Will be present only when the Cost is not expressed in CostUnit.
+	CostDivisor uint64 `json:"cost-divisor,omitempty"`
+	Error       *Error `json:"error,omitempty"`
+}
+
+// InstanceType represents an available instance type in a cloud.
+type InstanceType struct {
+	Name         string   `json:"name,omitempty"`
+	Arches       []string `json:"arches"`
+	CPUCores     int      `json:"cpu-cores"`
+	Memory       int      `json:"memory"`
+	RootDiskSize int      `json:"root-disk,omitempty"`
+	VirtType     string   `json:"virt-type,omitempty"`
+	Deprecated   bool     `json:"deprecated,omitempty"`
+	Cost         int      `json:"cost,omitempty"`
+}

--- a/environs/instances/instancetype.go
+++ b/environs/instances/instancetype.go
@@ -26,6 +26,21 @@ type InstanceType struct {
 	Deprecated bool
 }
 
+// InstanceTypesWithCostMetadata holds an array of InstanceType and metadata
+// about their cost.
+type InstanceTypesWithCostMetadata struct {
+	// InstanceTypes holds the array of InstanceTypes affected by this cost scheme.
+	InstanceTypes []InstanceType
+	// CostUnit holds the unit in which the InstanceType.Cost is expressed.
+	CostUnit string
+	// CostCurrency holds the currency in which InstanceType.Cost is expressed.
+	CostCurrency string
+	// CostDivisor indicates a number that must be applied to InstanceType.Cost to obtain
+	// a number that is in CostUnit.
+	// If 0 it means that InstanceType.Cost is already expressed in CostUnit.
+	CostDivisor uint64
+}
+
 func CpuPower(power uint64) *uint64 {
 	return &power
 }

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/storage"
@@ -292,6 +293,10 @@ type Environ interface {
 	// constraints package? Can't be instance, because constraints
 	// import instance...
 	PrecheckInstance(series string, cons constraints.Value, placement string) error
+
+	// InstanceTypesFetcher represents an environment that can return
+	// information about the available instance types.
+	InstanceTypesFetcher
 }
 
 // CreateParams contains the parameters for Environ.Create.
@@ -326,4 +331,10 @@ type InstanceTagger interface {
 	// The specified tags will replace any existing ones with the
 	// same names, but other existing tags will be left alone.
 	TagInstance(id instance.Id, tags map[string]string) error
+}
+
+// InstanceTypesFetcher is an interface that allows for instance information from
+// a provider to be obtained.
+type InstanceTypesFetcher interface {
+	InstanceTypes(constraints.Value) (instances.InstanceTypesWithCostMetadata, error)
 }

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -1335,3 +1335,16 @@ func (s *environSuite) TestDestroyControllerErrors(c *gc.C) {
 	c.Check(destroyErr, gc.ErrorMatches, ".*foo.*")
 	c.Check(destroyErr, gc.ErrorMatches, ".*bar.*")
 }
+
+func (s *environSuite) TestInstanceInformation(c *gc.C) {
+	env := s.openEnviron(c)
+	s.sender = s.startInstanceSenders(false)
+	types, err := env.InstanceTypes(constraints.Value{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(types.InstanceTypes, gc.HasLen, 6)
+
+	cons := constraints.MustParse("mem=4G")
+	types, err = env.InstanceTypes(cons)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(types.InstanceTypes, gc.HasLen, 2)
+}

--- a/provider/azure/instance_information.go
+++ b/provider/azure/instance_information.go
@@ -1,0 +1,37 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azure
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/instances"
+)
+
+var _ environs.InstanceTypesFetcher = (*azureEnviron)(nil)
+
+// InstanceTypes implements InstanceTypesFetcher
+func (env *azureEnviron) InstanceTypes(c constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+	types, err := env.getInstanceTypes()
+	if err != nil {
+		return instances.InstanceTypesWithCostMetadata{}, errors.Trace(err)
+	}
+	result := make([]instances.InstanceType, len(types))
+	i := 0
+	for _, iType := range types {
+		result[i] = iType
+		i++
+	}
+	result, err = instances.MatchingInstanceTypes(result, "", c)
+	if err != nil {
+		return instances.InstanceTypesWithCostMetadata{}, errors.Trace(err)
+	}
+
+	return instances.InstanceTypesWithCostMetadata{
+		InstanceTypes: result,
+		CostUnit:      "",
+		CostCurrency:  "USD"}, nil
+}

--- a/provider/cloudsigma/instance_information.go
+++ b/provider/cloudsigma/instance_information.go
@@ -1,0 +1,20 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/instances"
+)
+
+var _ environs.InstanceTypesFetcher = (*environ)(nil)
+
+// InstanceTypes implements InstanceTypesFetcher
+func (e *environ) InstanceTypes(c constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+	result := instances.InstanceTypesWithCostMetadata{}
+	return result, errors.NotSupportedf("InstanceTypes")
+}

--- a/provider/dummy/instance_information.go
+++ b/provider/dummy/instance_information.go
@@ -1,0 +1,20 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dummy
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/instances"
+)
+
+var _ environs.InstanceTypesFetcher = (*environ)(nil)
+
+// InstanceTypes implements InstanceTypesFetcher
+func (e *environ) InstanceTypes(c constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+	result := instances.InstanceTypesWithCostMetadata{}
+	return result, errors.NotSupportedf("InstanceTypes")
+}

--- a/provider/ec2/instance_information.go
+++ b/provider/ec2/instance_information.go
@@ -1,0 +1,31 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ec2
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/instances"
+)
+
+var _ environs.InstanceTypesFetcher = (*environ)(nil)
+
+// InstanceTypes implements InstanceTypesFetcher
+func (e *environ) InstanceTypes(c constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+	iTypes, err := e.supportedInstanceTypes()
+	if err != nil {
+		return instances.InstanceTypesWithCostMetadata{}, errors.Trace(err)
+	}
+	iTypes, err = instances.MatchingInstanceTypes(iTypes, "", c)
+	if err != nil {
+		return instances.InstanceTypesWithCostMetadata{}, errors.Trace(err)
+	}
+	return instances.InstanceTypesWithCostMetadata{
+		InstanceTypes: iTypes,
+		CostUnit:      "$USD/hour",
+		CostDivisor:   1000,
+		CostCurrency:  "USD"}, nil
+}

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1378,6 +1378,18 @@ func (t *localServerSuite) TestSubnetsWithInstanceIdMissingSubnet(c *gc.C) {
 	c.Assert(subnets, gc.HasLen, 0)
 }
 
+func (t *localServerSuite) TestInstanceInformation(c *gc.C) {
+	env := t.prepareEnviron(c)
+	types, err := env.InstanceTypes(constraints.Value{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(types.InstanceTypes, gc.HasLen, 45)
+
+	cons := constraints.MustParse("mem=4G")
+	types, err = env.InstanceTypes(cons)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(types.InstanceTypes, gc.HasLen, 40)
+}
+
 func validateSubnets(c *gc.C, subnets []network.SubnetInfo) {
 	// These are defined in the test server for the testing default
 	// VPC.

--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -55,6 +55,8 @@ type gceConnection interface {
 	DetachDisk(zone, instanceId, volumeName string) error
 	// InstanceDisks returns a list of the disks attached to the passed instance.
 	InstanceDisks(zone, instanceId string) ([]*google.AttachedDisk, error)
+	// ListMachineTypes returns a list of machines available in the project and zone provided.
+	ListMachineTypes(zone string) ([]google.MachineType, error)
 }
 
 type environ struct {

--- a/provider/gce/environ_instance_test.go
+++ b/provider/gce/environ_instance_test.go
@@ -186,3 +186,17 @@ func (s *environInstSuite) TestCheckInstanceTypeUnknown(c *gc.C) {
 
 	c.Check(matched, jc.IsFalse)
 }
+
+func (s *environInstSuite) TestListMachineTypes(c *gc.C) {
+	_, err := s.Env.InstanceTypes(constraints.Value{})
+	c.Assert(err, gc.ErrorMatches, "no instance types in  matching constraints \"\"")
+
+	zone := google.NewZone("a-zone", google.StatusUp, "", "")
+	s.FakeConn.Zones = []google.AvailabilityZone{zone}
+
+	mem := uint64(1025)
+	types, err := s.Env.InstanceTypes(constraints.Value{Mem: &mem})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(types.InstanceTypes, gc.HasLen, 1)
+
+}

--- a/provider/gce/google/conn.go
+++ b/provider/gce/google/conn.go
@@ -70,6 +70,8 @@ type rawConnectionWrapper interface {
 	// InstanceDisks returns the disks attached to the instance identified
 	// by instanceId
 	InstanceDisks(project, zone, instanceId string) ([]*compute.AttachedDisk, error)
+	// ListMachineTypes returns a list of machines available in the project and zone provided.
+	ListMachineTypes(projectID, zone string) (*compute.MachineTypeList, error)
 }
 
 // TODO(ericsnow) Add specific error types for common failures

--- a/provider/gce/google/conn_machines.go
+++ b/provider/gce/google/conn_machines.go
@@ -1,0 +1,36 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package google
+
+import "github.com/juju/errors"
+
+// ListMachineTypes returns a list of MachineType available for the
+// given zone.
+func (gce *Connection) ListMachineTypes(zone string) ([]MachineType, error) {
+	machines, err := gce.raw.ListMachineTypes(gce.projectID, zone)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	res := make([]MachineType, len(machines.Items))
+	for i, machine := range machines.Items {
+		deprecated := false
+		if machine.Deprecated != nil {
+			deprecated = machine.Deprecated.State != ""
+		}
+		res[i] = MachineType{
+			CreationTimestamp: machine.CreationTimestamp,
+			Deprecated:        deprecated,
+			Description:       machine.Description,
+			GuestCpus:         machine.GuestCpus,
+			Id:                machine.Id,
+			ImageSpaceGb:      machine.ImageSpaceGb,
+			Kind:              machine.Kind,
+			MaximumPersistentDisks:       machine.MaximumPersistentDisks,
+			MaximumPersistentDisksSizeGb: machine.MaximumPersistentDisksSizeGb,
+			MemoryMb:                     machine.MemoryMb,
+			Name:                         machine.Name,
+		}
+	}
+	return res, nil
+}

--- a/provider/gce/google/conn_machines_test.go
+++ b/provider/gce/google/conn_machines_test.go
@@ -1,0 +1,19 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package google_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+func (s *connSuite) TestConnectionListMachineTypesAPI(c *gc.C) {
+	_, err := s.FakeConn.ListMachineTypes("project", "a-zone")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(s.FakeConn.Calls, gc.HasLen, 1)
+	c.Check(s.FakeConn.Calls[0].FuncName, gc.Equals, "ListMachineTypes")
+	c.Check(s.FakeConn.Calls[0].ProjectID, gc.Equals, "project")
+	c.Check(s.FakeConn.Calls[0].ZoneName, gc.Equals, "a-zone")
+}

--- a/provider/gce/google/machine_type.go
+++ b/provider/gce/google/machine_type.go
@@ -1,0 +1,18 @@
+package google
+
+// MachineType represents a gce Machine Type.
+// this is basically a copy of compute.MachineType put here to
+// satisfy an extra layer of abstraction.
+type MachineType struct {
+	CreationTimestamp            string
+	Deprecated                   bool
+	Description                  string
+	GuestCpus                    int64
+	Id                           uint64
+	ImageSpaceGb                 int64
+	Kind                         string
+	MaximumPersistentDisks       int64
+	MaximumPersistentDisksSizeGb int64
+	MemoryMb                     int64
+	Name                         string
+}

--- a/provider/gce/google/raw.go
+++ b/provider/gce/google/raw.go
@@ -357,3 +357,13 @@ func (rc *rawConn) waitOperation(projectID string, op *compute.Operation, attemp
 	logger.Infof("GCE operation %q finished", op.Name)
 	return nil
 }
+
+// ListMachineTypes returns a list of machines available in the project and zone provided.
+func (rc *rawConn) ListMachineTypes(projectID, zone string) (*compute.MachineTypeList, error) {
+	op := rc.MachineTypes.List(projectID, zone)
+	machines, err := op.Do()
+	if err != nil {
+		return nil, errors.Annotatef(err, "listing machine types for project %q and zone %q", projectID, zone)
+	}
+	return machines, nil
+}

--- a/provider/gce/google/testing_test.go
+++ b/provider/gce/google/testing_test.go
@@ -442,3 +442,20 @@ func (rc *fakeConn) InstanceDisks(project, zone, instanceId string) ([]*compute.
 	}
 	return rc.AttachedDisks, err
 }
+
+func (rc *fakeConn) ListMachineTypes(projectID, zone string) (*compute.MachineTypeList, error) {
+	call := fakeCall{
+		FuncName:  "ListMachineTypes",
+		ProjectID: projectID,
+		ZoneName:  zone,
+	}
+	rc.Calls = append(rc.Calls, call)
+	machineType := compute.MachineTypeList{
+		Items: []*compute.MachineType{
+			{Name: "type-1", MemoryMb: 1024},
+			{Name: "type-2", MemoryMb: 2048},
+		},
+	}
+	return &machineType, nil
+
+}

--- a/provider/gce/instance_information.go
+++ b/provider/gce/instance_information.go
@@ -1,0 +1,64 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package gce
+
+import (
+	"strconv"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/arch"
+
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/instances"
+)
+
+var _ environs.InstanceTypesFetcher = (*environ)(nil)
+var virtType = "kvm"
+
+// InstanceTypes implements InstanceTypesFetcher
+func (env *environ) InstanceTypes(c constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+	reg, err := env.Region()
+	if err != nil {
+		return instances.InstanceTypesWithCostMetadata{}, errors.Trace(err)
+	}
+	zones, err := env.gce.AvailabilityZones(reg.Region)
+	if err != nil {
+		return instances.InstanceTypesWithCostMetadata{}, errors.Trace(err)
+	}
+	resultUnique := map[string]instances.InstanceType{}
+
+	for _, z := range zones {
+		if !z.Available() {
+			continue
+		}
+		machines, err := env.gce.ListMachineTypes(z.Name())
+		if err != nil {
+			return instances.InstanceTypesWithCostMetadata{}, errors.Trace(err)
+		}
+		for _, m := range machines {
+			i := instances.InstanceType{
+				Id:       strconv.FormatUint(m.Id, 10),
+				Name:     m.Name,
+				CpuCores: uint64(m.GuestCpus),
+				Mem:      uint64(m.MemoryMb),
+				Arches:   []string{arch.AMD64},
+				VirtType: &virtType,
+			}
+			resultUnique[m.Name] = i
+		}
+	}
+
+	result := make([]instances.InstanceType, len(resultUnique))
+	i := 0
+	for _, it := range resultUnique {
+		result[i] = it
+		i++
+	}
+	result, err = instances.MatchingInstanceTypes(result, "", c)
+	if err != nil {
+		return instances.InstanceTypesWithCostMetadata{}, errors.Trace(err)
+	}
+	return instances.InstanceTypesWithCostMetadata{InstanceTypes: result}, nil
+}

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -644,3 +644,16 @@ func (fc *fakeConn) WasCalled(funcName string) (bool, []fakeConnCall) {
 	}
 	return called, calls
 }
+
+func (fc *fakeConn) ListMachineTypes(zone string) ([]google.MachineType, error) {
+	call := fakeConnCall{
+		FuncName: "ListMachineTypes",
+		ZoneName: zone,
+	}
+	fc.Calls = append(fc.Calls, call)
+
+	return []google.MachineType{
+		{Name: "type-1", MemoryMb: 1024},
+		{Name: "type-2", MemoryMb: 2048},
+	}, nil
+}

--- a/provider/joyent/instance_information.go
+++ b/provider/joyent/instance_information.go
@@ -1,0 +1,26 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package joyent
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/instances"
+)
+
+var _ environs.InstanceTypesFetcher = (*joyentEnviron)(nil)
+
+// InstanceTypes implements InstanceTypesFetcher
+func (env *joyentEnviron) InstanceTypes(c constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+	iTypes, err := env.listInstanceTypes()
+	if err != nil {
+		return instances.InstanceTypesWithCostMetadata{}, errors.Trace(err)
+	}
+	iTypes, err = instances.MatchingInstanceTypes(iTypes, "", c)
+	if err != nil {
+		return instances.InstanceTypesWithCostMetadata{}, errors.Trace(err)
+	}
+	return instances.InstanceTypesWithCostMetadata{InstanceTypes: iTypes}, nil
+}

--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -391,3 +391,15 @@ func (s *localServerSuite) TestConstraintsValidatorVocab(c *gc.C) {
 	_, err = validator.Validate(cons)
 	c.Assert(err, gc.ErrorMatches, "invalid constraint value: instance-type=foo\nvalid values are:.*")
 }
+
+func (t *localServerSuite) TestInstanceInformation(c *gc.C) {
+	env := t.Prepare(c)
+	types, err := env.InstanceTypes(constraints.Value{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(types.InstanceTypes, gc.HasLen, 3)
+
+	cons := constraints.MustParse("mem=4G")
+	types, err = env.InstanceTypes(cons)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(types.InstanceTypes, gc.HasLen, 1)
+}

--- a/provider/lxd/instance_information.go
+++ b/provider/lxd/instance_information.go
@@ -1,0 +1,19 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxd
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/instances"
+)
+
+var _ environs.InstanceTypesFetcher = (*environ)(nil)
+
+// InstanceTypes implements InstanceTypesFetcher
+func (env *environ) InstanceTypes(c constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+	return instances.InstanceTypesWithCostMetadata{}, errors.NotSupportedf("InstanceTypes")
+}

--- a/provider/maas/instance_information.go
+++ b/provider/maas/instance_information.go
@@ -1,0 +1,18 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package maas
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/instances"
+)
+
+var _ environs.InstanceTypesFetcher = (*maasEnviron)(nil)
+
+func (env *maasEnviron) InstanceTypes(c constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+	result := instances.InstanceTypesWithCostMetadata{}
+	return result, errors.NotSupportedf("InstanceTypes")
+}

--- a/provider/manual/instance_information.go
+++ b/provider/manual/instance_information.go
@@ -1,0 +1,20 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package manual
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/instances"
+)
+
+var _ environs.InstanceTypesFetcher = (*manualEnviron)(nil)
+
+// InstanceTypes implements InstanceTypesFetcher
+func (e *manualEnviron) InstanceTypes(c constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+	result := instances.InstanceTypesWithCostMetadata{}
+	return result, errors.NotSupportedf("InstanceTypes")
+}

--- a/provider/openstack/instance_information.go
+++ b/provider/openstack/instance_information.go
@@ -1,0 +1,19 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package openstack
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/instances"
+)
+
+var _ environs.InstanceTypesFetcher = (*Environ)(nil)
+
+func (e *Environ) InstanceTypes(c constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+	result := instances.InstanceTypesWithCostMetadata{}
+	return result, errors.NotSupportedf("InstanceTypes")
+}

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
@@ -217,6 +218,10 @@ func (e *fakeEnviron) StorageProviderTypes() ([]storage.ProviderType, error) {
 func (e *fakeEnviron) StorageProvider(t storage.ProviderType) (storage.Provider, error) {
 	e.Push("StorageProvider", t)
 	return nil, errors.NotImplementedf("StorageProvider")
+}
+
+func (e *fakeEnviron) InstanceTypes(constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+	return instances.InstanceTypesWithCostMetadata{}, nil
 }
 
 type fakeConfigurator struct {

--- a/provider/rackspace/instance_information.go
+++ b/provider/rackspace/instance_information.go
@@ -1,0 +1,19 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rackspace
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/instances"
+)
+
+var _ environs.InstanceTypesFetcher = (*environ)(nil)
+
+func (e environ) InstanceTypes(c constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+	result := instances.InstanceTypesWithCostMetadata{}
+	return result, errors.NotSupportedf("InstanceTypes")
+}

--- a/provider/vsphere/instance_information.go
+++ b/provider/vsphere/instance_information.go
@@ -1,0 +1,20 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package vsphere
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/instances"
+)
+
+var _ environs.InstanceTypesFetcher = (*environ)(nil)
+
+// InstanceTypes implements InstanceTypesFetcher
+func (env *environ) InstanceTypes(c constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+	result := instances.InstanceTypesWithCostMetadata{}
+	return result, errors.NotSupportedf("InstanceTypes")
+}


### PR DESCRIPTION
Added InstanceTypes API endpoint that allows to learn
the available instance types in the model region/zone
to make better deployment decisions.

Tests are missing for 3 out of 4 providers implemented but I am keen to get the rest of the code reviewed as this needs to be merged soon.

This follows: https://docs.google.com/document/d/1m6iNWOMYyGwHbDbl8-u_VSZozeZQklxUOgM5t_0wbMQ/edit#heading=h.kc1rayquamxb

###QA
Run Tests.
Create an API client call that points to the controller and Perform the call for the different providers to obtain lists of available types. (This is intended to be used by the GUI)