### PR TITLE
Add apiserver endpoints for migrating binaries

### DIFF
--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -112,7 +112,7 @@ func (c *Client) httpPost(modelUUID string, content io.ReadSeeker, endpoint, con
 		return errors.Annotate(err, "cannot create upload request")
 	}
 	req.Header.Set("Content-Type", contentType)
-	req.Header.Set("Migration-Model-UUID", modelUUID)
+	req.Header.Set(params.MigrationModelHTTPHeader, modelUUID)
 
 	// The returned httpClient sets the base url to /model/<uuid> if it can.
 	httpClient, err := c.httpClientFactory.HTTPClient()

--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -4,23 +4,43 @@
 package migrationtarget
 
 import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/httprequest"
+	"github.com/juju/version"
+	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 	coremigration "github.com/juju/juju/core/migration"
+	"github.com/juju/juju/tools"
 )
+
+type httpClient interface {
+	HTTPClient() (*httprequest.Client, error)
+}
 
 // NewClient returns a new Client based on an existing API connection.
 func NewClient(caller base.APICaller) *Client {
-	return &Client{base.NewFacadeCaller(caller, "MigrationTarget")}
+	return &Client{
+		caller:            base.NewFacadeCaller(caller, "MigrationTarget"),
+		httpClientFactory: caller,
+	}
 }
 
 // Client is the client-side API for the MigrationTarget facade. It is
 // used by the migrationmaster worker when talking to the target
 // controller during a migration.
 type Client struct {
-	caller base.FacadeCaller
+	caller            base.FacadeCaller
+	httpClientFactory httpClient
 }
 
 func (c *Client) Prechecks(model coremigration.ModelInfo) error {
@@ -50,4 +70,58 @@ func (c *Client) Abort(modelUUID string) error {
 func (c *Client) Activate(modelUUID string) error {
 	args := params.ModelArgs{ModelTag: names.NewModelTag(modelUUID).String()}
 	return c.caller.FacadeCall("Activate", args, nil)
+}
+
+// UploadCharm sends the content to the API server using an HTTP post in order
+// to add the charm binary to the model specified.
+func (c *Client) UploadCharm(modelUUID string, curl *charm.URL, content io.ReadSeeker) (*charm.URL, error) {
+	args := url.Values{}
+	args.Add("series", curl.Series)
+	args.Add("schema", curl.Schema)
+	args.Add("revision", strconv.Itoa(curl.Revision))
+	apiURI := url.URL{Path: "/migrate/charms", RawQuery: args.Encode()}
+
+	contentType := "application/zip"
+	var resp params.CharmsResponse
+	if err := c.httpPost(modelUUID, content, apiURI.String(), contentType, &resp); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	curl, err := charm.ParseURL(resp.CharmURL)
+	if err != nil {
+		return nil, errors.Annotatef(err, "bad charm URL in response")
+	}
+	return curl, nil
+}
+
+// UploadTools uploads tools at the specified location to the API server over HTTPS
+// for the specified model.
+func (c *Client) UploadTools(modelUUID string, r io.ReadSeeker, vers version.Binary, additionalSeries ...string) (tools.List, error) {
+	endpoint := fmt.Sprintf("/migrate/tools?binaryVersion=%s&series=%s", vers, strings.Join(additionalSeries, ","))
+	contentType := "application/x-tar-gz"
+	var resp params.ToolsResult
+	if err := c.httpPost(modelUUID, r, endpoint, contentType, &resp); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return resp.ToolsList, nil
+}
+
+func (c *Client) httpPost(modelUUID string, content io.ReadSeeker, endpoint, contentType string, response interface{}) error {
+	req, err := http.NewRequest("POST", endpoint, nil)
+	if err != nil {
+		return errors.Annotate(err, "cannot create upload request")
+	}
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Migration-Model-UUID", modelUUID)
+
+	// The returned httpClient sets the base url to /model/<uuid> if it can.
+	httpClient, err := c.httpClientFactory.HTTPClient()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := httpClient.Do(req, content, response); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }

--- a/apiserver/backup.go
+++ b/apiserver/backup.go
@@ -32,7 +32,7 @@ type backupHandler struct {
 func (h *backupHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	// Validate before authenticate because the authentication is dependent
 	// on the state connection that is determined during the validation.
-	st, _, err := h.ctxt.stateForRequestAuthenticatedUser(req)
+	st, err := h.ctxt.stateForRequestAuthenticatedUser(req)
 	if err != nil {
 		h.sendError(resp, err)
 		return

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -74,20 +74,25 @@ func (h *CharmsHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // charmsHandler handles charm upload through HTTPS in the API server.
 type charmsHandler struct {
-	ctxt    httpContext
-	dataDir string
+	ctxt          httpContext
+	dataDir       string
+	stateAuthFunc func(*http.Request) (*state.State, error)
 }
 
 // bundleContentSenderFunc functions are responsible for sending a
 // response related to a charm bundle.
 type bundleContentSenderFunc func(w http.ResponseWriter, r *http.Request, bundle *charm.CharmArchive) error
 
+func (h *charmsHandler) ServeUnsupported(w http.ResponseWriter, r *http.Request) error {
+	return errors.Trace(emitUnsupportedMethodErr(r.Method))
+}
+
 func (h *charmsHandler) ServePost(w http.ResponseWriter, r *http.Request) error {
 	if r.Method != "POST" {
 		return errors.Trace(emitUnsupportedMethodErr(r.Method))
 	}
 
-	st, _, err := h.ctxt.stateForRequestAuthenticatedUser(r)
+	st, err := h.stateAuthFunc(r)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -401,7 +401,7 @@ func (s *charmsSuite) TestMigrateCharm(c *gc.C) {
 	err = importedModel.SetMigrationMode(state.MigrationModeImporting)
 	c.Assert(err, jc.ErrorIsNil)
 	s.extraHeaders = map[string]string{
-		"Migration-Model-UUID": importedModel.UUID(),
+		params.MigrationModelHTTPHeader: importedModel.UUID(),
 	}
 
 	// The default user is just a normal user, not a controller admin
@@ -425,7 +425,7 @@ func (s *charmsSuite) TestMigrateCharmNotMigrating(c *gc.C) {
 	migratedModel := s.Factory.MakeModel(c, nil)
 	defer migratedModel.Close()
 	s.extraHeaders = map[string]string{
-		"Migration-Model-UUID": migratedModel.ModelUUID(),
+		params.MigrationModelHTTPHeader: migratedModel.ModelUUID(),
 	}
 
 	// The default user is just a normal user, not a controller admin

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -75,7 +75,7 @@ func (h *debugLogHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			// Validate before authenticate because the authentication is
 			// dependent on the state connection that is determined during the
 			// validation.
-			st, _, err := h.ctxt.stateForRequestAuthenticatedUser(req)
+			st, err := h.ctxt.stateForRequestAuthenticatedUser(req)
 			if err != nil {
 				socket.sendError(err)
 				return

--- a/apiserver/gui.go
+++ b/apiserver/gui.go
@@ -483,7 +483,7 @@ func (h *guiArchiveHandler) handlePost(w http.ResponseWriter, req *http.Request)
 	}
 
 	// Open the GUI archive storage.
-	st, _, err := h.ctxt.stateForRequestAuthenticatedUser(req)
+	st, err := h.ctxt.stateForRequestAuthenticatedUser(req)
 	if err != nil {
 		return errors.Annotate(err, "cannot open state")
 	}
@@ -559,7 +559,7 @@ func (h *guiVersionHandler) handlePut(w http.ResponseWriter, req *http.Request) 
 	}
 
 	// Authenticate the request and retrieve the Juju state.
-	st, _, err := h.ctxt.stateForRequestAuthenticatedUser(req)
+	st, err := h.ctxt.stateForRequestAuthenticatedUser(req)
 	if err != nil {
 		return errors.Annotate(err, "cannot open state")
 	}

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -121,11 +121,13 @@ func (ctxt *httpContext) stateForMigration(r *http.Request) (st *state.State, er
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
+	// Pass the state pointer into the defer so the return statement doesn't
+	// set the st value to nil.
+	defer func(st *state.State) {
 		if err != nil {
 			ctxt.release(st)
 		}
-	}()
+	}(st)
 
 	if !st.IsController() {
 		return nil, errors.BadRequestf("model is not controller model")
@@ -140,7 +142,7 @@ func (ctxt *httpContext) stateForMigration(r *http.Request) (st *state.State, er
 
 	modelUUID, err := validateModelUUID(validateArgs{
 		statePool: ctxt.srv.statePool,
-		modelUUID: r.Header.Get("Migration-Model-UUID"),
+		modelUUID: r.Header.Get(params.MigrationModelHTTPHeader),
 		strict:    true,
 	})
 	if err != nil {

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -9,6 +9,11 @@ import (
 	"github.com/juju/version"
 )
 
+// MigrationModelHTTPHeader is the key for the HTTP header value
+// that is used to specify the model UUID for the model being migrated
+// for the uploading of the binaries for that model.
+const MigrationModelHTTPHeader = "X-Juju-Migration-Model-UUID"
+
 // InitiateMigrationArgs holds the details required to start one or
 // more model migrations.
 type InitiateMigrationArgs struct {

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -29,7 +29,8 @@ import (
 
 // toolsHandler handles tool upload through HTTPS in the API server.
 type toolsUploadHandler struct {
-	ctxt httpContext
+	ctxt          httpContext
+	stateAuthFunc func(*http.Request) (*state.State, error)
 }
 
 // toolsHandler handles tool download through HTTPS in the API server.
@@ -70,7 +71,7 @@ func (h *toolsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 func (h *toolsUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Validate before authenticate because the authentication is dependent
 	// on the state connection that is determined during the validation.
-	st, _, err := h.ctxt.stateForRequestAuthenticatedUser(r)
+	st, err := h.stateAuthFunc(r)
 	if err != nil {
 		if err := sendError(w, err); err != nil {
 			logger.Errorf("%v", err)

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -219,7 +219,7 @@ func (s *toolsSuite) TestMigrateTools(c *gc.C) {
 	err = importedModel.SetMigrationMode(state.MigrationModeImporting)
 	c.Assert(err, jc.ErrorIsNil)
 	s.extraHeaders = map[string]string{
-		"Migration-Model-UUID": importedModel.UUID(),
+		params.MigrationModelHTTPHeader: importedModel.UUID(),
 	}
 
 	uri := s.baseURL(c)
@@ -254,7 +254,7 @@ func (s *toolsSuite) TestMigrateToolsNotMigrating(c *gc.C) {
 	newSt := s.Factory.MakeModel(c, nil)
 	defer newSt.Close()
 	s.extraHeaders = map[string]string{
-		"Migration-Model-UUID": newSt.ModelUUID(),
+		params.MigrationModelHTTPHeader: newSt.ModelUUID(),
 	}
 
 	uri := s.baseURL(c)

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/utils/series"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
 	apiauthentication "github.com/juju/juju/api/authentication"
@@ -30,6 +31,7 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
 	toolstesting "github.com/juju/juju/environs/tools/testing"
+	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/binarystorage"
 	"github.com/juju/juju/testing"
@@ -199,6 +201,90 @@ func (s *toolsSuite) TestUpload(c *gc.C) {
 	c.Assert(uploadedData, gc.DeepEquals, expectedData)
 	allMetadata := s.getToolsMetadataFromStorage(c, s.State)
 	c.Assert(allMetadata, jc.DeepEquals, []binarystorage.Metadata{metadata})
+}
+
+func (s *toolsSuite) TestMigrateTools(c *gc.C) {
+	controllerTag := names.NewControllerTag(s.ControllerConfig.ControllerUUID())
+	_, err := s.State.SetUserAccess(s.userTag, controllerTag, permission.SuperuserAccess)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Make some fake tools.
+	expectedTools, v, toolPath := s.setupToolsForUpload(c)
+	vers := v.String()
+
+	newSt := s.Factory.MakeModel(c, nil)
+	defer newSt.Close()
+	importedModel, err := newSt.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	err = importedModel.SetMigrationMode(state.MigrationModeImporting)
+	c.Assert(err, jc.ErrorIsNil)
+	s.extraHeaders = map[string]string{
+		"Migration-Model-UUID": importedModel.UUID(),
+	}
+
+	uri := s.baseURL(c)
+	uri.Path = "/migrate/tools"
+	uri.RawQuery = "binaryVersion=" + vers
+
+	// Now try uploading them.
+	resp := s.uploadRequest(c, uri.String(), "application/x-tar-gz", toolPath)
+
+	// Check the response.
+	expectedTools[0].URL = fmt.Sprintf("%s/model/%s/tools/%s", s.baseURL(c), importedModel.UUID(), vers)
+	s.assertUploadResponse(c, resp, expectedTools[0])
+
+	// Check the contents.
+	metadata, uploadedData := s.getToolsFromStorage(c, newSt, vers)
+	expectedData, err := ioutil.ReadFile(toolPath)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(uploadedData, gc.DeepEquals, expectedData)
+	allMetadata := s.getToolsMetadataFromStorage(c, newSt)
+	c.Assert(allMetadata, jc.DeepEquals, []binarystorage.Metadata{metadata})
+}
+
+func (s *toolsSuite) TestMigrateToolsNotMigrating(c *gc.C) {
+	controllerTag := names.NewControllerTag(s.ControllerConfig.ControllerUUID())
+	_, err := s.State.SetUserAccess(s.userTag, controllerTag, permission.SuperuserAccess)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Make some fake tools.
+	_, v, toolPath := s.setupToolsForUpload(c)
+	vers := v.String()
+
+	newSt := s.Factory.MakeModel(c, nil)
+	defer newSt.Close()
+	s.extraHeaders = map[string]string{
+		"Migration-Model-UUID": newSt.ModelUUID(),
+	}
+
+	uri := s.baseURL(c)
+	uri.Path = "/migrate/tools"
+	uri.RawQuery = "binaryVersion=" + vers
+
+	// Now try uploading them.
+	resp := s.uploadRequest(c, uri.String(), "application/x-tar-gz", toolPath)
+	s.assertErrorResponse(
+		c, resp, http.StatusBadRequest,
+		"model not importing",
+	)
+}
+
+func (s *toolsSuite) TestMigrateToolsUnauth(c *gc.C) {
+	// The default user is just a normal user, not a controller admin
+	_, v, toolPath := s.setupToolsForUpload(c)
+	vers := v.String()
+
+	uri := s.baseURL(c)
+	uri.Path = "/migrate/tools"
+	uri.RawQuery = "?binaryVersion=" + vers
+
+	// Now try uploading them.
+	resp := s.uploadRequest(c, uri.String(), "application/x-tar-gz", toolPath)
+
+	s.assertErrorResponse(
+		c, resp, http.StatusUnauthorized,
+		"not a controller admin",
+	)
 }
 
 func (s *toolsSuite) TestBlockUpload(c *gc.C) {

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -198,7 +198,6 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 			{"facade.Export", nil},
 			apiOpenControllerCall,
 			importCall,
-			apiOpenModelCall,
 			{"UploadBinaries", []interface{}{
 				[]string{"charm0", "charm1"},
 				fakeCharmDownloader,
@@ -207,7 +206,6 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 				},
 				fakeToolsDownloader,
 			}},
-			apiCloseCall, // for target model
 			apiCloseCall, // for target controller
 			{"facade.SetPhase", []interface{}{coremigration.VALIDATION}},
 


### PR DESCRIPTION
Add specific POST apiserver endpoints for uploading the charm and tool binaries during migration.

In order for a migration of a model that the admin user does not have access to to work, we cannot connect to that model on the migration target. To get around this, we add specific endpoints for migrating the binaries. The model UUID is set as an http header, and validated on the remote to be a model that is being imported.