### PR TITLE
Fix a number of StatePool leaks

### DIFF
--- a/apiserver/backup.go
+++ b/apiserver/backup.go
@@ -37,6 +37,7 @@ func (h *backupHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		h.sendError(resp, err)
 		return
 	}
+	defer h.ctxt.release(st)
 
 	backups, closer := newBackups(st)
 	defer closer.Close()

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -91,6 +91,8 @@ func (h *charmsHandler) ServePost(w http.ResponseWriter, r *http.Request) error 
 	if err != nil {
 		return errors.Trace(err)
 	}
+	defer h.ctxt.release(st)
+
 	// Add a charm to the store provider.
 	charmURL, err := h.processPost(r, st)
 	if err != nil {
@@ -108,6 +110,8 @@ func (h *charmsHandler) ServeGet(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	h.ctxt.release(st)
+
 	// Retrieve or list charm files.
 	// Requires "url" (charm URL) and an optional "file" (the path to the
 	// charm file) to be included in the query. Optionally also receives an

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -80,6 +80,8 @@ func (h *debugLogHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 				socket.sendError(err)
 				return
 			}
+			defer h.ctxt.release(st)
+
 			params, err := readDebugLogParams(req.URL.Query())
 			if err != nil {
 				socket.sendError(err)

--- a/apiserver/gui.go
+++ b/apiserver/gui.go
@@ -140,6 +140,7 @@ func (gr *guiRouter) ensureFiles(req *http.Request) (rootDir string, hash string
 	if err != nil {
 		return "", "", errors.Annotate(err, "cannot open state")
 	}
+	defer gr.ctxt.release(st)
 	storage, err := st.GUIStorage()
 	if err != nil {
 		return "", "", errors.Annotate(err, "cannot open GUI storage")
@@ -418,6 +419,7 @@ func (h *guiArchiveHandler) handleGet(w http.ResponseWriter, req *http.Request) 
 	if err != nil {
 		return errors.Annotate(err, "cannot open state")
 	}
+	defer h.ctxt.release(st)
 	storage, err := st.GUIStorage()
 	if err != nil {
 		return errors.Annotate(err, "cannot open GUI storage")
@@ -485,6 +487,7 @@ func (h *guiArchiveHandler) handlePost(w http.ResponseWriter, req *http.Request)
 	if err != nil {
 		return errors.Annotate(err, "cannot open state")
 	}
+	defer h.ctxt.release(st)
 	storage, err := st.GUIStorage()
 	if err != nil {
 		return errors.Annotate(err, "cannot open GUI storage")
@@ -560,6 +563,7 @@ func (h *guiVersionHandler) handlePut(w http.ResponseWriter, req *http.Request) 
 	if err != nil {
 		return errors.Annotate(err, "cannot open state")
 	}
+	defer h.ctxt.release(st)
 
 	var selected params.GUIVersionRequest
 	decoder := json.NewDecoder(req.Body)

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -173,6 +173,12 @@ func (ctxt *httpContext) loginRequest(r *http.Request) (params.LoginRequest, err
 	}, nil
 }
 
+// release indicates that the client doesn't need this State anymore,
+// so it can be removed from the pool if it needs to be.
+func (ctxt *httpContext) release(st *state.State) error {
+	return ctxt.srv.statePool.Release(st.ModelUUID())
+}
+
 // stop returns a channel which will be closed when a handler should
 // exit.
 func (ctxt *httpContext) stop() <-chan struct{} {

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -4,12 +4,10 @@
 package apiserver
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime/debug"
 	"strings"
 	"time"
 
@@ -138,9 +136,11 @@ func jujuClientVersionFromReq(req *http.Request) (version.Number, error) {
 
 func (h *logSinkHandler) receiveLogs(socket *websocket.Conn) <-chan params.LogRecord {
 	logCh := make(chan params.LogRecord)
-	fmt.Printf("created logCh: %p\n", &logCh)
 
 	go func() {
+		// Close the channel to signal ServeHTTP to finish. Otherwise
+		// we leak goroutines on client disconnect, because the server
+		// isn't shutting down so h.ctxt.stop() is never closed.
 		defer close(logCh)
 		var m params.LogRecord
 		for {
@@ -149,14 +149,6 @@ func (h *logSinkHandler) receiveLogs(socket *websocket.Conn) <-chan params.LogRe
 			// finishes.
 			if err := websocket.JSON.Receive(socket, &m); err != nil {
 				logger.Debugf("logsink receive error: %v", err)
-				// Close the channel to signal ServeHTTP to finish.
-				// Otherwise we leak goroutines on client disconnect,
-				// because the server isn't shutting down so
-				// h.ctxt.stop() is never closed.
-				fmt.Printf("closing logCh: %p\n", &logCh)
-				debug.PrintStack()
-				fmt.Println()
-				close(logCh)
 				return
 			}
 

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -4,10 +4,12 @@
 package apiserver
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -136,6 +138,7 @@ func jujuClientVersionFromReq(req *http.Request) (version.Number, error) {
 
 func (h *logSinkHandler) receiveLogs(socket *websocket.Conn) <-chan params.LogRecord {
 	logCh := make(chan params.LogRecord)
+	fmt.Printf("created logCh: %p\n", &logCh)
 
 	go func() {
 		defer close(logCh)
@@ -150,6 +153,9 @@ func (h *logSinkHandler) receiveLogs(socket *websocket.Conn) <-chan params.LogRe
 				// Otherwise we leak goroutines on client disconnect,
 				// because the server isn't shutting down so
 				// h.ctxt.stop() is never closed.
+				fmt.Printf("closing logCh: %p\n", &logCh)
+				debug.PrintStack()
+				fmt.Println()
 				close(logCh)
 				return
 			}

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -147,9 +147,9 @@ func (h *logSinkHandler) receiveLogs(socket *websocket.Conn) <-chan params.LogRe
 			if err := websocket.JSON.Receive(socket, &m); err != nil {
 				logger.Debugf("logsink receive error: %v", err)
 				// Close the channel to signal ServeHTTP to finish.
-				// Otherwise we leak goroutines on migration, because
-				// the server isn't shutting down so h.ctxt.stop() is
-				// never closed.
+				// Otherwise we leak goroutines on client disconnect,
+				// because the server isn't shutting down so
+				// h.ctxt.stop() is never closed.
 				close(logCh)
 				return
 			}

--- a/apiserver/logstream_test.go
+++ b/apiserver/logstream_test.go
@@ -258,13 +258,17 @@ type stubSource struct {
 	ReturnNewTailer state.LogTailer
 }
 
-func (s *stubSource) newSource(req *http.Request) (logStreamSource, error) {
+func (s *stubSource) newSource(req *http.Request) (logStreamSource, closerFunc, error) {
 	s.stub.AddCall("newSource", req)
 	if err := s.stub.NextErr(); err != nil {
-		return nil, errors.Trace(err)
+		return nil, nil, errors.Trace(err)
 	}
 
-	return s, nil
+	closer := func() error {
+		s.stub.AddCall("close")
+		return s.stub.NextErr()
+	}
+	return s, closer, nil
 }
 
 func (s *stubSource) getStart(sink string, allModels bool) (time.Time, error) {

--- a/apiserver/registration.go
+++ b/apiserver/registration.go
@@ -47,6 +47,7 @@ func (h *registerUserHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 		}
 		return
 	}
+	defer h.ctxt.release(st)
 	userTag, response, err := h.processPost(req, st)
 	if err != nil {
 		if err := sendError(w, err); err != nil {

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -45,6 +45,7 @@ func (h *toolsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		}
 		return
 	}
+	defer h.ctxt.release(st)
 
 	switch r.Method {
 	case "GET":
@@ -76,6 +77,7 @@ func (h *toolsUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	defer h.ctxt.release(st)
 
 	switch r.Method {
 	case "POST":

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1264,6 +1264,7 @@ func (b *allModelWatcherStateBacking) Changed(all *multiwatcherStore, change wat
 		}
 		return errors.Trace(err)
 	}
+	defer b.stPool.Release(modelUUID)
 
 	col, closer := st.getCollection(c.name)
 	defer closer()


### PR DESCRIPTION
These leaks would prevent the StatePool from removing the state for a migrated or removed model because the state appeared to still be in use. This causes goroutine leaks and prevents a model from being migrated from one controller to another and then back.

Part of http://pad.lv/1641824

In most cases the state wasn't passed around and could be released using a defer block.

Manual testing:
* bootstrap a source controller, add a subject model and deploy ubuntu to it
  `juju bootstrap lxd source --build-agent --config="enable-os-upgrade=false" --config='logging-config="<root>=DEBUG"' && juju switch source && juju add-model subject && juju deploy ubuntu`
* bootstrap a destination controller
  `juju bootstrap lxd dest --build-agent --config="enable-os-upgrade=false" --config='logging-config="<root>=DEBUG"'`
* migrate subject from source to dest
  `juju migrate -c source subject dest`
* ensure the model is successfully migrated to dest
* migrate it back
  `juju migrate -c dest subject source`
* ensure the model is successfully migrated back to source
