### PR TITLE
Change persistent-cookiejar version

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -24,7 +24,6 @@ github.com/juju/cmd	git	1c6973d59b804e4d3c293fbf240f067e73436bc9	2016-08-23T10:3
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/jsonschema	git	a0ef8b74ebcffeeff9fc374854deb4af388f037e	2016-11-02T18:19:19Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
-github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:32:58Z
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
@@ -36,7 +35,7 @@ github.com/juju/idmclient	git	3dda079a75cccb85083d4c3877e638f5d6ab79c2	2016-05-2
 github.com/juju/loggo	git	3b7ece48644d35850f4ced4c2cbc2cf8413f58e0	2016-08-18T02:57:24Z
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z
 github.com/juju/mutex	git	59c26ee163447c5c57f63ff71610d433862013de	2016-06-17T01:09:07Z
-github.com/juju/persistent-cookiejar	git	b48f5b9290d63455d10de0c0e4c26e06e6e74842	2016-10-07T16:41:21Z
+github.com/juju/persistent-cookiejar	git	05c678c243d106a63c96835cf96a693d7bc905c8	2016-11-15T10:25:17Z
 github.com/juju/replicaset	git	fb7294cf57a1e2f08a57691f1246d129a87ab7e8	2015-05-08T02:21:43Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:42:13Z


### PR DESCRIPTION
Update the version of persistent-cookiejar (and remove now obsolete dependency). This changes the cookie file locking to use juju/mutex instead of file based locking. 

Addresses issue #1632362.

Full QA of the fix is unlikely until we get this into the develop PPA, however none of the semantics have changed so all existing tests should continue to pass. See: https://bugs.launchpad.net/juju-wait/+bug/1632362