### PR TITLE
Fix hook error on juju-reboot

### DIFF
--- a/cmd/jujud/reboot/reboot.go
+++ b/cmd/jujud/reboot/reboot.go
@@ -8,10 +8,12 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/utils/series"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/agent"
@@ -21,6 +23,8 @@ import (
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/factory"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/service"
+	"github.com/juju/juju/service/common"
 )
 
 var logger = loggo.GetLogger("juju.cmd.jujud.reboot")
@@ -70,12 +74,45 @@ func (r *Reboot) ExecuteReboot(action params.RebootAction) error {
 		return errors.Trace(err)
 	}
 
+	// Stop all units before issuing a reboot. During a reboot, the machine agent
+	// will attempt to hold the execution lock until the reboot happens. However, since
+	// the old file based locking method has been replaced with semaphores (Windows), and
+	// sockets (Linux), if the machine agent is killed by the init system during shutdown,
+	// before the unit agents, the lock is released and unit agents start running hooks.
+	// When they in turn are killed, the hook is thrown into error state. If automatic retries
+	// are disabled, the hook remains in error state.
+	if err := r.stopDeployedUnits(); err != nil {
+		return errors.Trace(err)
+	}
+
 	if err := scheduleAction(action, rebootAfter); err != nil {
 		return errors.Trace(err)
 	}
 
 	err := r.st.ClearReboot()
 	return errors.Trace(err)
+}
+
+func (r *Reboot) stopDeployedUnits() error {
+	osVersion := series.HostSeries()
+	services, err := service.ListServices()
+	if err != nil {
+		return err
+	}
+	for _, svcName := range services {
+		if strings.HasPrefix(svcName, `jujud-unit-`) {
+			svc, err := service.NewService(svcName, common.Conf{}, osVersion)
+			if err != nil {
+				return err
+			}
+			logger.Debugf("Stopping unit agent: %q", svcName)
+			err = svc.Stop()
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (r *Reboot) runningContainers() ([]instance.Instance, error) {


### PR DESCRIPTION
The first implementation of the reboot functionality worked under the assumption that we use file based hook locks. This meant that the machine agent could acquire a lock and choose not to break it until it was restarted, thus blocking any unit agents from running hooks.
    
This decision was made under the pretext that the unit agent would soon be merged with the machine agent, and switching from file locks to mutexes/semaphores would not break it.
    
Juju has moved away from file locks, and we can no longer guarantee a lock will be held by the machine agent until the machine is fully rebooted. On reboot/shutdown the init system can now stop the machine agent first, allowing unit agents to start executing hooks.
    
This change stops all deployed juju unit agents prior to issuing the reboot (or shutdown) command.
