### PR TITLE
Refactor logsink to make it reusable for migration log transfer

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -194,7 +195,8 @@ func newServer(s *state.State, lis net.Listener, cfg ServerConfig) (_ *Server, e
 	if err := srv.updateCertificate(cfg.Cert, cfg.Key); err != nil {
 		return nil, errors.Annotatef(err, "cannot set initial certificate")
 	}
-	logSinkWriter, err := newLogSinkWriter(srv.logDir)
+	logPath := filepath.Join(srv.logDir, "logsink.log")
+	logSinkWriter, err := newLogSinkWriter(logPath)
 	if err != nil {
 		return nil, errors.Annotate(err, "creating logsink writer")
 	}

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -364,7 +364,7 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 	strictCtxt.controllerModelOnly = true
 
 	mainAPIHandler := srv.trackRequests(http.HandlerFunc(srv.apiHandler))
-	logSinkHandler := newLogSinkHandler(httpCtxt, srv.logSinkWriter)
+	logSinkHandler := newLogSinkHandler(httpCtxt, srv.logSinkWriter, newAgentLoggingStrategy)
 	logStreamHandler := srv.trackRequests(newLogStreamEndpointHandler(strictCtxt))
 	debugLogHandler := srv.trackRequests(newDebugLogDBHandler(httpCtxt))
 

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -86,7 +86,7 @@ func (h *logSinkHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			}
 
 			filePrefix := st.ModelUUID() + " " + tag.String() + ":"
-			dbLogger := state.NewDbLogger(st, tag, ver)
+			dbLogger := state.NewEntityDbLogger(st, tag, ver)
 			defer dbLogger.Close()
 
 			// If we get to here, no more errors to report, so we report a nil

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -64,7 +64,7 @@ func (s *AgentLoggingStrategy) Authenticate(req *http.Request) error {
 }
 
 func (s *AgentLoggingStrategy) Start() {
-	s.filePrefix = s.st.ModelUUID() + " " + s.entity.String() + ":"
+	s.filePrefix = s.st.ModelUUID() + ":"
 	s.dbLogger = state.NewEntityDbLogger(s.st, s.entity, s.version)
 }
 
@@ -74,6 +74,7 @@ func (s *AgentLoggingStrategy) Log(m params.LogRecord) bool {
 	if dbErr != nil {
 		logger.Errorf("logging to DB failed: %v", dbErr)
 	}
+	m.Entity = s.entity.String()
 	fileErr := logToFile(s.fileLogger, s.filePrefix, m)
 	if fileErr != nil {
 		logger.Errorf("logging to logsink.log failed: %v", fileErr)
@@ -220,6 +221,7 @@ func (h *logSinkHandler) sendError(w io.Writer, req *http.Request, err error) {
 func logToFile(logger io.Writer, prefix string, m params.LogRecord) error {
 	_, err := logger.Write([]byte(strings.Join([]string{
 		prefix,
+		m.Entity,
 		m.Time.In(time.UTC).Format("2006-01-02 15:04:05"),
 		m.Level,
 		m.Module,

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -95,8 +94,7 @@ func newLogSinkHandler(h httpContext, w io.Writer, newStrategy func(httpContext,
 	return &logSinkHandler{ctxt: h, fileLogger: w, newStrategy: newStrategy}
 }
 
-func newLogSinkWriter(logDir string) (io.WriteCloser, error) {
-	logPath := filepath.Join(logDir, "logsink.log")
+func newLogSinkWriter(logPath string) (io.WriteCloser, error) {
 	if err := primeLogFile(logPath); err != nil {
 		// This isn't a fatal error so log and continue if priming fails.
 		logger.Warningf("Unable to prime %s (proceeding anyway): %v", logPath, err)

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -189,8 +189,8 @@ func (s *logsinkSuite) TestLogging(c *gc.C) {
 	logPath := filepath.Join(s.LogDir, "logsink.log")
 	logContents, err := ioutil.ReadFile(logPath)
 	c.Assert(err, jc.ErrorIsNil)
-	line0 := modelUUID + " machine-0: 2015-06-01 23:02:01 INFO some.where foo.go:42 all is well\n"
-	line1 := modelUUID + " machine-0: 2015-06-01 23:02:02 ERROR else.where bar.go:99 oh noes\n"
+	line0 := modelUUID + ": machine-0 2015-06-01 23:02:01 INFO some.where foo.go:42 all is well\n"
+	line1 := modelUUID + ": machine-0 2015-06-01 23:02:02 ERROR else.where bar.go:99 oh noes\n"
 	c.Assert(string(logContents), gc.Equals, line0+line1)
 
 	// Check the file mode is as expected. This doesn't work on

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -800,6 +800,7 @@ type LogRecord struct {
 	Location string    `json:"l"`
 	Level    string    `json:"v"`
 	Message  string    `json:"x"`
+	Entity   string    `json:"e,omitempty"`
 }
 
 // BundleChangesParams holds parameters for making Bundle.GetChanges calls.

--- a/featuretests/cmd_juju_dumplogs_test.go
+++ b/featuretests/cmd_juju_dumplogs_test.go
@@ -51,7 +51,7 @@ func (s *dumpLogsCommandSuite) TestRun(c *gc.C) {
 
 	t := time.Date(2015, 11, 4, 3, 2, 1, 0, time.UTC)
 	for _, st := range states {
-		w := state.NewDbLogger(st, names.NewMachineTag("42"), version.Current)
+		w := state.NewEntityDbLogger(st, names.NewMachineTag("42"), version.Current)
 		defer w.Close()
 		for i := 0; i < 3; i++ {
 			err := w.Log(t, "module", "location", loggo.INFO, fmt.Sprintf("%d", i))

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -154,7 +154,7 @@ func (s *debugLogDbSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *debugLogDbSuite) TestLogsAPI(c *gc.C) {
-	dbLogger := state.NewDbLogger(s.State, names.NewMachineTag("99"), version.Current)
+	dbLogger := state.NewEntityDbLogger(s.State, names.NewMachineTag("99"), version.Current)
 	defer dbLogger.Close()
 
 	t := time.Date(2015, 6, 23, 13, 8, 49, 0, time.UTC)

--- a/provider/rackspace/config_test.go
+++ b/provider/rackspace/config_test.go
@@ -17,10 +17,9 @@ type ConfigSuite struct {
 
 var _ = gc.Suite(&ConfigSuite{})
 
-
 func (s *ConfigSuite) TestDefaultsPassValidation(c *gc.C) {
 	attrs := testing.FakeConfig().Merge(testing.Attrs{
-		"type":                  "rackspace",
+		"type": "rackspace",
 	})
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/logs.go
+++ b/state/logs.go
@@ -204,27 +204,23 @@ type logDoc struct {
 	Message   string        `bson:"x"`
 }
 
-type EntityDbLogger struct {
+type DbLogger struct {
 	logsColl  *mgo.Collection
 	modelUUID string
-	entity    string
 	version   string
 }
 
-// NewDbLogger returns a DbLogger instance which is used to write logs
-// to the database.
-func NewEntityDbLogger(st ModelSessioner, entity names.Tag, ver version.Number) *EntityDbLogger {
+func NewDbLogger(st ModelSessioner, ver version.Number) *DbLogger {
 	_, logsColl := initLogsSession(st)
-	return &EntityDbLogger{
+	return &DbLogger{
 		logsColl:  logsColl,
 		modelUUID: st.ModelUUID(),
-		entity:    entity.String(),
 		version:   ver.String(),
 	}
 }
 
 // Log writes a log message to the database.
-func (logger *EntityDbLogger) Log(t time.Time, module string, location string, level loggo.Level, msg string) error {
+func (logger *DbLogger) Log(t time.Time, entity string, module string, location string, level loggo.Level, msg string) error {
 	// TODO(ericsnow) Use a controller-global int sequence for Id.
 
 	// UnixNano() returns the "absolute" (UTC) number of nanoseconds
@@ -234,7 +230,7 @@ func (logger *EntityDbLogger) Log(t time.Time, module string, location string, l
 		Id:        bson.NewObjectId(),
 		Time:      unixEpochNanoUTC,
 		ModelUUID: logger.modelUUID,
-		Entity:    logger.entity,
+		Entity:    entity,
 		Version:   logger.version,
 		Module:    module,
 		Location:  location,
@@ -244,10 +240,38 @@ func (logger *EntityDbLogger) Log(t time.Time, module string, location string, l
 }
 
 // Close cleans up resources used by the DbLogger instance.
-func (logger *EntityDbLogger) Close() {
+func (logger *DbLogger) Close() {
 	if logger.logsColl != nil {
 		logger.logsColl.Database.Session.Close()
 	}
+}
+
+// EntityDbLogger writes log records about one entity.
+type EntityDbLogger struct {
+	DbLogger
+	entity string
+}
+
+// NewEntityDbLogger returns an EntityDbLogger instance which is used
+// to write logs to the database.
+func NewEntityDbLogger(st ModelSessioner, entity names.Tag, ver version.Number) *EntityDbLogger {
+	dbLogger := NewDbLogger(st, ver)
+	return &EntityDbLogger{
+		DbLogger: *dbLogger,
+		entity:   entity.String(),
+	}
+}
+
+// Log writes a log message to the database.
+func (logger *EntityDbLogger) Log(t time.Time, module string, location string, level loggo.Level, msg string) error {
+	return logger.DbLogger.Log(
+		t,
+		logger.entity,
+		module,
+		location,
+		level,
+		msg,
+	)
 }
 
 // LogTailer allows for retrieval of Juju's logs from MongoDB. It

--- a/state/logs.go
+++ b/state/logs.go
@@ -204,7 +204,7 @@ type logDoc struct {
 	Message   string        `bson:"x"`
 }
 
-type DbLogger struct {
+type EntityDbLogger struct {
 	logsColl  *mgo.Collection
 	modelUUID string
 	entity    string
@@ -213,9 +213,9 @@ type DbLogger struct {
 
 // NewDbLogger returns a DbLogger instance which is used to write logs
 // to the database.
-func NewDbLogger(st ModelSessioner, entity names.Tag, ver version.Number) *DbLogger {
+func NewEntityDbLogger(st ModelSessioner, entity names.Tag, ver version.Number) *EntityDbLogger {
 	_, logsColl := initLogsSession(st)
-	return &DbLogger{
+	return &EntityDbLogger{
 		logsColl:  logsColl,
 		modelUUID: st.ModelUUID(),
 		entity:    entity.String(),
@@ -224,7 +224,7 @@ func NewDbLogger(st ModelSessioner, entity names.Tag, ver version.Number) *DbLog
 }
 
 // Log writes a log message to the database.
-func (logger *DbLogger) Log(t time.Time, module string, location string, level loggo.Level, msg string) error {
+func (logger *EntityDbLogger) Log(t time.Time, module string, location string, level loggo.Level, msg string) error {
 	// TODO(ericsnow) Use a controller-global int sequence for Id.
 
 	// UnixNano() returns the "absolute" (UTC) number of nanoseconds
@@ -244,7 +244,7 @@ func (logger *DbLogger) Log(t time.Time, module string, location string, level l
 }
 
 // Close cleans up resources used by the DbLogger instance.
-func (logger *DbLogger) Close() {
+func (logger *EntityDbLogger) Close() {
 	if logger.logsColl != nil {
 		logger.logsColl.Database.Session.Close()
 	}

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -165,7 +165,7 @@ func (s *LogsSuite) TestIndexesCreated(c *gc.C) {
 }
 
 func (s *LogsSuite) TestDbLogger(c *gc.C) {
-	logger := state.NewDbLogger(s.State, names.NewMachineTag("22"), jujuversion.Current)
+	logger := state.NewEntityDbLogger(s.State, names.NewMachineTag("22"), jujuversion.Current)
 	defer logger.Close()
 	t0 := truncateDBTime(coretesting.ZeroTime())
 	logger.Log(t0, "some.where", "foo.go:99", loggo.INFO, "all is well")
@@ -195,7 +195,7 @@ func (s *LogsSuite) TestDbLogger(c *gc.C) {
 }
 
 func (s *LogsSuite) TestPruneLogsByTime(c *gc.C) {
-	dbLogger := state.NewDbLogger(s.State, names.NewMachineTag("22"), jujuversion.Current)
+	dbLogger := state.NewEntityDbLogger(s.State, names.NewMachineTag("22"), jujuversion.Current)
 	defer dbLogger.Close()
 	log := func(t time.Time, msg string) {
 		err := dbLogger.Log(t, "module", "loc", loggo.INFO, msg)
@@ -271,7 +271,7 @@ func (s *LogsSuite) TestPruneLogsBySize(c *gc.C) {
 }
 
 func (s *LogsSuite) generateLogs(c *gc.C, st *state.State, endTime time.Time, count int) {
-	dbLogger := state.NewDbLogger(st, names.NewMachineTag("0"), jujuversion.Current)
+	dbLogger := state.NewEntityDbLogger(st, names.NewMachineTag("0"), jujuversion.Current)
 	defer dbLogger.Close()
 	for i := 0; i < count; i++ {
 		ts := endTime.Add(-time.Duration(i) * time.Second)

--- a/worker/dblogpruner/worker_test.go
+++ b/worker/dblogpruner/worker_test.go
@@ -108,7 +108,7 @@ func (s *suite) TestPrunesLogsBySize(c *gc.C) {
 }
 
 func (s *suite) addLogs(c *gc.C, t0 time.Time, text string, count int) {
-	dbLogger := state.NewDbLogger(s.State, names.NewMachineTag("0"), version.Current)
+	dbLogger := state.NewEntityDbLogger(s.State, names.NewMachineTag("0"), version.Current)
 	defer dbLogger.Close()
 
 	for offset := 0; offset < count; offset++ {


### PR DESCRIPTION
Extract the authentication and logging that the logsink handler does into AgentLoggingStrategy. This enables using a different logging strategy for migration log transfer (which will be in a follow-up PR) - in that case the logs won't be coming from a specific machine agent so each record will include the entity that originally logged it.

This also slightly changes the format of logsink.log - entity is moved from the line prefix to a normal column in the log file.