### PR TITLE
Fixes lp#1589641: ActionSuite.TestUnitWatchActionNotifications unexpected change.

### DIFF
--- a/state/action_test.go
+++ b/state/action_test.go
@@ -583,23 +583,33 @@ func (s *ActionSuite) TestUnitWatchActionNotifications(c *gc.C) {
 	wc := statetesting.NewStringsWatcherC(c, s.State, w)
 	// make sure the previously pending actions are sent on the watcher
 	expect := expectActionIds(fa1, fa2)
+	// Fixes lp#1589641: some time, under race & stress testing,
+	// reads of changes from watcher chan seem to get out of order.
+	// This additional Sync, ensures that the changes are processed correctly.
+	wc.State.StartSync()
 	wc.AssertChange(expect...)
+	wc.State.StartSync()
 	wc.AssertNoChange()
 
 	// add watcher on unit2
 	w2 := unit2.WatchActionNotifications()
 	defer statetesting.AssertStop(c, w2)
 	wc2 := statetesting.NewStringsWatcherC(c, s.State, w2)
+	wc2.State.StartSync()
 	wc2.AssertChange()
+	wc2.State.StartSync()
 	wc2.AssertNoChange()
 
 	// add action on unit2 and makes sure unit1 watcher doesn't trigger
 	// and unit2 watcher does
 	fa3, err := unit2.AddAction("snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
+	wc.State.StartSync()
 	wc.AssertNoChange()
 	expect2 := expectActionIds(fa3)
+	wc2.State.StartSync()
 	wc2.AssertChange(expect2...)
+	wc2.State.StartSync()
 	wc2.AssertNoChange()
 
 	// add a couple actions on unit1 and make sure watcher sees events
@@ -609,7 +619,9 @@ func (s *ActionSuite) TestUnitWatchActionNotifications(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	expect = expectActionIds(fa4, fa5)
+	wc.State.StartSync()
 	wc.AssertChange(expect...)
+	wc.State.StartSync()
 	wc.AssertNoChange()
 }
 

--- a/state/testing/watcher.go
+++ b/state/testing/watcher.go
@@ -157,7 +157,13 @@ func (c StringsWatcherC) AssertChanges() {
 }
 
 func (c StringsWatcherC) AssertChange(expect ...string) {
-	c.assertChange(false, expect...)
+	// Fixes lp#1589641: some time, under race & stress testing,
+	// reads of changes from watcher chan seem to get out of order.
+	// This additional Sync, ensures that the changes are processed correctly.
+	c.State.StartSync()
+	// We should assert for either a single or multiple changes,
+	// based on the number of `expect` changes.
+	c.assertChange(len(expect) == 1, expect...)
 }
 
 func (c StringsWatcherC) AssertChangeInSingleEvent(expect ...string) {

--- a/state/testing/watcher.go
+++ b/state/testing/watcher.go
@@ -157,10 +157,6 @@ func (c StringsWatcherC) AssertChanges() {
 }
 
 func (c StringsWatcherC) AssertChange(expect ...string) {
-	// Fixes lp#1589641: some time, under race & stress testing,
-	// reads of changes from watcher chan seem to get out of order.
-	// This additional Sync, ensures that the changes are processed correctly.
-	c.State.StartSync()
 	// We should assert for either a single or multiple changes,
 	// based on the number of `expect` changes.
 	c.assertChange(len(expect) == 1, expect...)


### PR DESCRIPTION
Under race & stress testing, reads of changes from watcher chan seem to get out of order.
The watcher chan is monitoring testing State which seems to get out of sync. This propose syncs testing state.

QA:
Before code change, under stress, with race flag, this test would fail within the 1st 170 runs.
After this code change, the test has not failed after 5391 successful runs over 232 min 15 sec.