### PR TITLE
Release state back to the pool on errors 

### DIFF
--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -110,7 +110,7 @@ func (h *charmsHandler) ServeGet(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	h.ctxt.release(st)
+	defer h.ctxt.release(st)
 
 	// Retrieve or list charm files.
 	// Requires "url" (charm URL) and an optional "file" (the path to the

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -53,8 +53,9 @@ func (ctxt *httpContext) stateForRequestUnauthenticated(r *http.Request) (*state
 // stateForRequestAuthenticated returns a state instance appropriate for
 // using for the model implicit in the given request.
 // It also returns the authenticated entity.
-func (ctxt *httpContext) stateForRequestAuthenticated(r *http.Request) (st *state.State, entity state.Entity, err error) {
-	st, err = ctxt.stateForRequestUnauthenticated(r)
+func (ctxt *httpContext) stateForRequestAuthenticated(r *http.Request) (
+	resultSt *state.State, resultEntity state.Entity, err error) {
+	st, err := ctxt.stateForRequestUnauthenticated(r)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
@@ -69,7 +70,7 @@ func (ctxt *httpContext) stateForRequestAuthenticated(r *http.Request) (st *stat
 		return nil, nil, errors.NewUnauthorized(err, "")
 	}
 	authenticator := ctxt.srv.authCtxt.authenticator(r.Host)
-	entity, _, err = checkCreds(st, req, true, authenticator)
+	entity, _, err := checkCreds(st, req, true, authenticator)
 	if err != nil {
 		if common.IsDischargeRequiredError(err) {
 			return nil, nil, errors.Trace(err)

--- a/apiserver/logstream.go
+++ b/apiserver/logstream.go
@@ -76,7 +76,7 @@ func (eph *logStreamEndpointHandler) ServeHTTP(w http.ResponseWriter, req *http.
 	server.ServeHTTP(w, req)
 }
 
-func (eph *logStreamEndpointHandler) newLogStreamRequestHandler(req *http.Request, clock clock.Clock) (*logStreamRequestHandler, error) {
+func (eph *logStreamEndpointHandler) newLogStreamRequestHandler(req *http.Request, clock clock.Clock) (rh *logStreamRequestHandler, err error) {
 	// Validate before authenticate because the authentication is
 	// dependent on the state connection that is determined during the
 	// validation.
@@ -84,6 +84,11 @@ func (eph *logStreamEndpointHandler) newLogStreamRequestHandler(req *http.Reques
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	defer func() {
+		if err != nil {
+			closer()
+		}
+	}()
 
 	var cfg params.LogStreamConfig
 	query := req.URL.Query()

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -445,7 +445,7 @@ func (s *localServerSuite) TestStartInstanceExternalNetwork(c *gc.C) {
 	cfg, err := s.env.Config().Apply(coretesting.Attrs{
 		// A label that corresponds to a neutron test service external network
 		"external-network": "ext-net",
-		"use-floating-ip": true,
+		"use-floating-ip":  true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.env.SetConfig(cfg)
@@ -474,7 +474,7 @@ func (s *localServerSuite) TestStartInstanceExternalNetworkUnknownLabel(c *gc.C)
 	cfg, err := s.env.Config().Apply(coretesting.Attrs{
 		// A label that has no related network in the neutron test service
 		"external-network": "no-network-with-this-label",
-		"use-floating-ip": true,
+		"use-floating-ip":  true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.env.SetConfig(cfg)


### PR DESCRIPTION
In the functions that do more checks after the StatePool.Get but return
the state (so can't use a deferred release because it should outlive the
scope), we need to make sure that the state is returned to the pool when
we return an error and a nil state.

Use the named return values + deferred if err != nil release trick (which
really needs a catchier name) when there's more than one error path.

Includes a drive-by fix for the charmsHandler where I was releasing the
state immediately rather than deferring it, and a formatting fix - it looks like
someone's git doesn't have the pre-push hook set up.