### PR TITLE
Remove oauth as auth types for openstack

### DIFF
--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -80,8 +80,6 @@ var cloudSchema = &jsonschema.Schema{
 				Schemas: []*jsonschema.Schema{{
 					Type: []jsonschema.Type{jsonschema.StringType},
 					Enum: []interface{}{
-						string(cloud.OAuth1AuthType),
-						string(cloud.OAuth2AuthType),
 						string(cloud.AccessKeyAuthType),
 						string(cloud.UserPassAuthType),
 					},

--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -405,7 +405,7 @@ func (s *providerUnitTests) TestIdentityClientVersion_ParsesGoodURL(c *gc.C) {
 
 func (s *providerUnitTests) TestSchema(c *gc.C) {
 	y := []byte(`
-auth-types: [userpass, oauth1]
+auth-types: [userpass, access-key]
 endpoint: http://foo.com/openstack
 regions: 
   one:


### PR DESCRIPTION
Currently the Openstack provider does not support oauth, so we can't accept
credentials that require oauth.  Once we update the provider, we can add
oauth back in as valid credentials.

Fixes https://bugs.launchpad.net/juju/+bug/1637268

QA steps:
1. Run juju add-cloud
2. Select openstack, give it a name, then see the authentication types. There should be no oauth types.  
3. Finish creating the cloud, then run juju add-credential \<cloudname\> and add a credential, it should work.