### PR TITLE
provider/rackspace: filter out diskless flavors

### DIFF
--- a/provider/rackspace/export_test.go
+++ b/provider/rackspace/export_test.go
@@ -5,6 +5,7 @@ package rackspace
 
 import (
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/provider/openstack"
 )
 
 func NewProvider(innerProvider environs.EnvironProvider) environs.EnvironProvider {
@@ -13,6 +14,10 @@ func NewProvider(innerProvider environs.EnvironProvider) environs.EnvironProvide
 
 func NewEnviron(innerEnviron environs.Environ) environs.Environ {
 	return environ{innerEnviron}
+}
+
+func OpenstackProvider(p environs.EnvironProvider) *openstack.EnvironProvider {
+	return p.(*environProvider).EnvironProvider.(*openstack.EnvironProvider)
 }
 
 var Bootstrap = &bootstrap

--- a/provider/rackspace/flavors.go
+++ b/provider/rackspace/flavors.go
@@ -1,0 +1,28 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rackspace
+
+import (
+	"strings"
+
+	"github.com/juju/loggo"
+
+	"gopkg.in/goose.v1/nova"
+)
+
+var logger = loggo.GetLogger("juju.provider.rackspace")
+
+func acceptRackspaceFlavor(d nova.FlavorDetail) bool {
+	// On Rackspace, the "compute" and "memory" class
+	// flavors do not have ephemeral root disks. You
+	// can only boot them with a Cinder volume.
+	//
+	// TODO(axw) 2016-11-18 #1642795
+	// Support flavors without a root disk by
+	// creating a bootable Cinder volume.
+	if strings.HasPrefix(d.Id, "compute") || strings.HasPrefix(d.Id, "memory") {
+		return false
+	}
+	return true
+}

--- a/provider/rackspace/flavors_test.go
+++ b/provider/rackspace/flavors_test.go
@@ -1,0 +1,42 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rackspace_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/goose.v1/nova"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/provider/openstack"
+	"github.com/juju/juju/provider/rackspace"
+)
+
+type flavorsSuite struct {
+	testing.IsolationSuite
+	filter openstack.FlavorFilter
+}
+
+var _ = gc.Suite(&flavorsSuite{})
+
+func (s *flavorsSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	provider, err := environs.Provider("rackspace")
+	c.Assert(err, jc.ErrorIsNil)
+	openstackProvider := rackspace.OpenstackProvider(provider)
+	s.filter = openstackProvider.FlavorFilter
+}
+
+func (s *flavorsSuite) TestFlavorFilter(c *gc.C) {
+	s.assertAcceptFlavor(c, "", true)
+	s.assertAcceptFlavor(c, "performance1-4", true)
+	s.assertAcceptFlavor(c, "compute1-4", false)
+	s.assertAcceptFlavor(c, "memory1-15", false)
+}
+
+func (s *flavorsSuite) assertAcceptFlavor(c *gc.C, id string, accept bool) {
+	accepted := s.filter.AcceptFlavor(nova.FlavorDetail{Id: id})
+	c.Assert(accepted, gc.Equals, accept)
+}

--- a/provider/rackspace/init.go
+++ b/provider/rackspace/init.go
@@ -13,10 +13,11 @@ const (
 )
 
 func init() {
-	osProvider := openstack.EnvironProvider{
+	osProvider := &openstack.EnvironProvider{
 		Credentials{},
 		&rackspaceConfigurator{},
 		&firewallerFactory{},
+		openstack.FlavorFilterFunc(acceptRackspaceFlavor),
 	}
 	providerInstance = &environProvider{
 		osProvider,

--- a/provider/rackspace/provider_configurator.go
+++ b/provider/rackspace/provider_configurator.go
@@ -40,5 +40,6 @@ func (c *rackspaceConfigurator) GetConfigDefaults() schema.Defaults {
 		"use-floating-ip":      false,
 		"use-default-secgroup": false,
 		"network":              "",
+		"external-network":     "",
 	}
 }


### PR DESCRIPTION
The compute and memory optimised flavors on Rackspace
are diskless, so you must boot them with a volume. For
now, we just filter those flavors out so that we won't
try to use them automatically.

Also add external-network to default config for rackspace,
the lack of which was causing bootstrap to fail.

NOTE: there appears to be no way to do this that will work
across all OpenStack variants, as this comes down to a
policy that cannot be detected from the client ahead of time.
Flavors do specify a disk size, but the zero value does not
mean that the flavor is diskless, rather than its root disk will
be the same size as the image.

**QA**

`$ juju bootstrap rackspace/dfw`

This would previously fail with the API response `{"forbidden": {"message": "Policy doesn't allow compute_flavor:create:image_backed to be performed.", "code": 403}}`, as the compute1-4 flavor was chosen by default. With this change, we now choose "4GB Standard Instance" for the controller by default.

Even if the instance was started, bootstrap would previously have failed due to the lack of "external-network" in the default config for Rackspace. Bootstrap now completes successfully.