### PR TITLE
provider/rackspace: Valid external-network config

### DIFF
--- a/provider/rackspace/config_test.go
+++ b/provider/rackspace/config_test.go
@@ -1,0 +1,31 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rackspace
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/testing"
+)
+
+type ConfigSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&ConfigSuite{})
+
+
+func (s *ConfigSuite) TestDefaultsPassValidation(c *gc.C) {
+	attrs := testing.FakeConfig().Merge(testing.Attrs{
+		"type":                  "rackspace",
+	})
+	cfg, err := config.New(config.NoDefaults, attrs)
+	c.Assert(err, jc.ErrorIsNil)
+	valid, err := providerInstance.Validate(cfg, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(valid.Type(), gc.Equals, "rackspace")
+	c.Assert(valid.Name(), gc.Equals, "testenv")
+}

--- a/provider/rackspace/provider_configurator.go
+++ b/provider/rackspace/provider_configurator.go
@@ -40,5 +40,6 @@ func (c *rackspaceConfigurator) GetConfigDefaults() schema.Defaults {
 		"use-floating-ip":      false,
 		"use-default-secgroup": false,
 		"network":              "",
+		"external-network":     "",
 	}
 }


### PR DESCRIPTION
Fixes lp:1642984.

Changes to the underlying openstack provider included a new
config key 'external-network' which is irrelevent for
rackspace but had no default value, breaking validation.

QA Steps
----

* `(cd provider/rackspace&&go test)`
* `juju bootstrap rackspace/DFW --config test-mode=true`