### PR TITLE
Add migration logtransfer endpoint

### DIFF
--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -54,6 +54,10 @@ type agentLoggingStrategy struct {
 	fileLogger io.Writer
 }
 
+func newAgentLoggingStrategy(ctxt httpContext, fileLogger io.Writer) LoggingStrategy {
+	return &agentLoggingStrategy{ctxt: ctxt, fileLogger: fileLogger}
+}
+
 // Authenticate checks that this is request is from a machine
 // agent. Part of LoggingStrategy.
 func (s *agentLoggingStrategy) Authenticate(req *http.Request) error {
@@ -109,10 +113,6 @@ func (s *agentLoggingStrategy) Log(m params.LogRecord) bool {
 func (s *agentLoggingStrategy) Stop() {
 	s.dbLogger.Close()
 	s.ctxt.release(s.st)
-}
-
-func newAgentLoggingStrategy(ctxt httpContext, fileLogger io.Writer) LoggingStrategy {
-	return &agentLoggingStrategy{ctxt: ctxt, fileLogger: fileLogger}
 }
 
 func newLogSinkHandler(h httpContext, w io.Writer, newStrategy func(httpContext, io.Writer) LoggingStrategy) http.Handler {

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -28,21 +28,8 @@ import (
 	"github.com/juju/juju/version"
 )
 
-// logsinkBaseSuite has functionality that's shared between the the 2 logsink related suites
-type logsinkBaseSuite struct {
-	authHTTPSuite
-}
-
-func (s *logsinkBaseSuite) logsinkURL(c *gc.C, scheme string) *url.URL {
-	server := s.makeURL(c, scheme, "/model/"+s.State.ModelUUID()+"/logsink", nil)
-	query := server.Query()
-	query.Set("jujuclientversion", version.Current.String())
-	server.RawQuery = query.Encode()
-	return server
-}
-
 type logsinkSuite struct {
-	logsinkBaseSuite
+	authHTTPSuite
 	machineTag names.Tag
 	password   string
 	nonce      string
@@ -51,8 +38,16 @@ type logsinkSuite struct {
 
 var _ = gc.Suite(&logsinkSuite{})
 
+func (s *logsinkSuite) logsinkURL(c *gc.C, scheme string) *url.URL {
+	server := s.makeURL(c, scheme, "/model/"+s.State.ModelUUID()+"/logsink", nil)
+	query := server.Query()
+	query.Set("jujuclientversion", version.Current.String())
+	server.RawQuery = query.Encode()
+	return server
+}
+
 func (s *logsinkSuite) SetUpTest(c *gc.C) {
-	s.logsinkBaseSuite.SetUpTest(c)
+	s.authHTTPSuite.SetUpTest(c)
 	s.nonce = "nonce"
 	m, password := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{
 		Nonce: s.nonce,

--- a/apiserver/logtransfer.go
+++ b/apiserver/logtransfer.go
@@ -1,4 +1,4 @@
-// Copyright 2015 Canonical Ltd.
+// Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package apiserver
@@ -64,7 +64,7 @@ func (s *migrationLoggingStrategy) Log(m params.LogRecord) bool {
 	}
 	fileErr := logToFile(s.fileLogger, s.filePrefix, m)
 	if fileErr != nil {
-		logger.Errorf("logging to logsink.log failed: %v", fileErr)
+		logger.Errorf("logging to file logger failed: %v", fileErr)
 	}
 	return dbErr == nil && fileErr == nil
 }

--- a/apiserver/logtransfer.go
+++ b/apiserver/logtransfer.go
@@ -24,6 +24,10 @@ type migrationLoggingStrategy struct {
 	fileLogger io.Writer
 }
 
+func newMigrationLoggingStrategy(ctxt httpContext, fileLogger io.Writer) LoggingStrategy {
+	return &migrationLoggingStrategy{ctxt: ctxt, fileLogger: fileLogger}
+}
+
 // Authenticate checks that the user is a controller superuser and
 // that the requested model is migrating. Part of LoggingStrategy.
 func (s *migrationLoggingStrategy) Authenticate(req *http.Request) error {
@@ -70,8 +74,4 @@ func (s *migrationLoggingStrategy) Log(m params.LogRecord) bool {
 func (s *migrationLoggingStrategy) Stop() {
 	s.dbLogger.Close()
 	s.ctxt.release(s.st)
-}
-
-func newMigrationLoggingStrategy(ctxt httpContext, fileLogger io.Writer) LoggingStrategy {
-	return &migrationLoggingStrategy{ctxt: ctxt, fileLogger: fileLogger}
 }

--- a/apiserver/logtransfer.go
+++ b/apiserver/logtransfer.go
@@ -1,0 +1,71 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/version"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+type MigrationLoggingStrategy struct {
+	ctxt       httpContext
+	st         *state.State
+	version    version.Number
+	filePrefix string
+	dbLogger   *state.DbLogger
+	fileLogger io.Writer
+}
+
+func (s *MigrationLoggingStrategy) Authenticate(req *http.Request) error {
+	// st, err := s.ctxt.stateForRequestMigratingModel(req)
+	st, _, err := s.ctxt.stateForRequestAuthenticatedAgent(req)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Here the log messages are expected to be coming from another
+	// Juju controller, so the version number provided should be the
+	// Juju version of the source controller.
+	ver, err := jujuClientVersionFromReq(req)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	s.st = st
+	s.version = ver
+	return nil
+}
+
+func (s *MigrationLoggingStrategy) Start() {
+	s.filePrefix = s.st.ModelUUID() + ":"
+	s.dbLogger = state.NewDbLogger(s.st, s.version)
+}
+
+func (s *MigrationLoggingStrategy) Log(m params.LogRecord) bool {
+	level, _ := loggo.ParseLevel(m.Level)
+	dbErr := s.dbLogger.Log(m.Time, m.Entity, m.Module, m.Location, level, m.Message)
+	if dbErr != nil {
+		logger.Errorf("logging to DB failed: %v", dbErr)
+	}
+	fileErr := logToFile(s.fileLogger, s.filePrefix, m)
+	if fileErr != nil {
+		logger.Errorf("logging to logsink.log failed: %v", fileErr)
+	}
+	return dbErr == nil && fileErr == nil
+}
+
+func (s *MigrationLoggingStrategy) Stop() {
+	s.dbLogger.Close()
+	s.ctxt.release(s.st)
+}
+
+func newMigrationLoggingStrategy(ctxt httpContext, fileLogger io.Writer) LoggingStrategy {
+	return &MigrationLoggingStrategy{ctxt: ctxt, fileLogger: fileLogger}
+}

--- a/apiserver/logtransfer_test.go
+++ b/apiserver/logtransfer_test.go
@@ -5,13 +5,13 @@ package apiserver_test
 
 import (
 	"bufio"
-	// "io/ioutil"
+	"io/ioutil"
 	"net/http"
 	"net/url"
-	// "os"
-	// "path/filepath"
-	// "runtime"
-	// "time"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
 
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
@@ -19,10 +19,10 @@ import (
 	"golang.org/x/net/websocket"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
-	// "gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/juju/apiserver/params"
-	// coretesting "github.com/juju/juju/testing"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/version"
 )
@@ -48,9 +48,7 @@ func (s *logtransferSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *logtransferSuite) logtransferURL(c *gc.C, scheme string) *url.URL {
-	controllerModel, err := s.State.ControllerModel()
-	c.Assert(err, jc.ErrorIsNil)
-	server := s.makeURL(c, scheme, "/model/"+controllerModel.UUID()+"/migration-logtransfer", nil)
+	server := s.makeURL(c, scheme, "/migrate/logtransfer", nil)
 	query := server.Query()
 	query.Set("jujuclientversion", version.Current.String())
 	server.RawQuery = query.Encode()
@@ -69,33 +67,12 @@ func (s *logtransferSuite) dialWebsocket(c *gc.C) *websocket.Conn {
 
 func (s *logtransferSuite) dialWebsocketInternal(c *gc.C, header http.Header) *websocket.Conn {
 	server := s.logtransferURL(c, "wss").String()
-	conn := dialWebsocketFromURL(c, server, header)
-	s.AddCleanup(func(_ *gc.C) { conn.Close() })
-	return conn
-}
-
-func (s *logtransferSuite) openWebsocketCustomPath(c *gc.C, path string) *bufio.Reader {
-	server := s.logtransferURL(c, "wss")
-	server.Path = path
-	conn := dialWebsocketFromURL(c, server.String(), s.makeAuthHeader())
-	return bufio.NewReader(conn)
-}
-
-func (s *logtransferSuite) TestRejectsBadModelUUID(c *gc.C) {
-	reader := s.openWebsocketCustomPath(c, "/model/does-not-exist/migration-logtransfer")
-	assertJSONError(c, reader, `unknown model: "does-not-exist"`)
-	assertWebsocketClosed(c, reader)
-}
-
-func (s *logtransferSuite) TestRejectsNonControllerURL(c *gc.C) {
-	reader := s.openWebsocketCustomPath(c, "/model/"+s.State.ModelUUID()+"/logsink")
-	assertJSONError(c, reader, `not a controller: "`+s.State.ModelUUID()+`"`)
-	assertWebsocketClosed(c, reader)
+	return dialWebsocketFromURL(c, server, header)
 }
 
 func (s *logtransferSuite) TestRejectsMissingModelHeader(c *gc.C) {
 	header := utils.BasicAuthHeader(s.userTag.String(), s.password)
-	reader := bufio.NewReader(dialWebsocketFromURL(c, s.logtransferURL(c, "wss").String(), header))
+	reader := s.toReader(s.dialWebsocketInternal(c, header))
 	assertJSONError(c, reader, `missing migrating model header`)
 	assertWebsocketClosed(c, reader)
 }
@@ -103,7 +80,140 @@ func (s *logtransferSuite) TestRejectsMissingModelHeader(c *gc.C) {
 func (s *logtransferSuite) TestRejectsBadMigratingModelUUID(c *gc.C) {
 	header := utils.BasicAuthHeader(s.userTag.String(), s.password)
 	header.Add(params.MigrationModelHeader, "does-not-exist")
-	reader := bufio.NewReader(dialWebsocketFromURL(c, s.logtransferURL(c, "wss").String(), header))
+	reader := s.toReader(s.dialWebsocketInternal(c, header))
 	assertJSONError(c, reader, `unknown model: "does-not-exist"`)
 	assertWebsocketClosed(c, reader)
+}
+
+func (s *logtransferSuite) TestRejectsInvalidVersion(c *gc.C) {
+	url := s.logtransferURL(c, "wss")
+	url.Query()["jujuclientversion"] = []string{"blah"}
+	conn := dialWebsocketFromURL(c, url.String(), s.makeAuthHeader())
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+	assertJSONError(c, reader, `invalid jujuclientversion "blah"`)
+	assertWebsocketClosed(c, reader)
+}
+
+func (s *logtransferSuite) TestRejectsMachineLogins(c *gc.C) {
+	m, password := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{
+		Nonce: "nonce",
+	})
+	header := utils.BasicAuthHeader(m.Tag().String(), password)
+	header.Add(params.MachineNonceHeader, "nonce")
+	reader := s.toReader(s.dialWebsocketInternal(c, header))
+	assertJSONError(c, reader, `tag kind machine not valid`)
+	assertWebsocketClosed(c, reader)
+}
+
+func (s *logtransferSuite) TestRejectsBadPasword(c *gc.C) {
+	header := utils.BasicAuthHeader(s.userTag.String(), "wrong")
+	header.Add(params.MigrationModelHeader, s.State.ModelUUID())
+	reader := s.toReader(s.dialWebsocketInternal(c, header))
+	assertJSONError(c, reader, "invalid entity name or password")
+	assertWebsocketClosed(c, reader)
+}
+
+func (s *logtransferSuite) TestLogging(c *gc.C) {
+	conn := s.dialWebsocket(c)
+	reader := s.toReader(conn)
+
+	// Read back the nil error, indicating that all is well.
+	errResult := readJSONErrorLine(c, reader)
+	c.Assert(errResult.Error, gc.IsNil)
+
+	t0 := time.Date(2015, time.June, 1, 23, 2, 1, 0, time.UTC)
+	err := websocket.JSON.Send(conn, &params.LogRecord{
+		Entity:   "machine-23",
+		Time:     t0,
+		Module:   "some.where",
+		Location: "foo.go:42",
+		Level:    loggo.INFO.String(),
+		Message:  "all is well",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	t1 := time.Date(2015, time.June, 1, 23, 2, 2, 0, time.UTC)
+	err = websocket.JSON.Send(conn, &params.LogRecord{
+		Entity:   "machine-101",
+		Time:     t1,
+		Module:   "else.where",
+		Location: "bar.go:99",
+		Level:    loggo.ERROR.String(),
+		Message:  "oh noes",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Wait for the log documents to be written to the DB.
+	logsColl := s.State.MongoSession().DB("logs").C("logs")
+	var docs []bson.M
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		err := logsColl.Find(nil).Sort("t").All(&docs)
+		c.Assert(err, jc.ErrorIsNil)
+		if len(docs) == 2 {
+			break
+		}
+		if len(docs) >= 2 {
+			c.Fatalf("saw more log documents than expected")
+		}
+		if !a.HasNext() {
+			c.Fatalf("timed out waiting for log writes")
+		}
+	}
+
+	// Check the recorded logs are correct.
+	modelUUID := s.State.ModelUUID()
+	c.Assert(docs[0]["t"], gc.Equals, t0.UnixNano())
+	c.Assert(docs[0]["e"], gc.Equals, modelUUID)
+	c.Assert(docs[0]["n"], gc.Equals, "machine-23")
+	c.Assert(docs[0]["m"], gc.Equals, "some.where")
+	c.Assert(docs[0]["l"], gc.Equals, "foo.go:42")
+	c.Assert(docs[0]["v"], gc.Equals, int(loggo.INFO))
+	c.Assert(docs[0]["x"], gc.Equals, "all is well")
+
+	c.Assert(docs[1]["t"], gc.Equals, t1.UnixNano())
+	c.Assert(docs[1]["e"], gc.Equals, modelUUID)
+	c.Assert(docs[1]["n"], gc.Equals, "machine-101")
+	c.Assert(docs[1]["m"], gc.Equals, "else.where")
+	c.Assert(docs[1]["l"], gc.Equals, "bar.go:99")
+	c.Assert(docs[1]["v"], gc.Equals, int(loggo.ERROR))
+	c.Assert(docs[1]["x"], gc.Equals, "oh noes")
+
+	// Close connection.
+	err = conn.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure that no error is logged when the connection is closed
+	// normally.
+	shortAttempt := &utils.AttemptStrategy{
+		Total: coretesting.ShortWait,
+		Delay: 2 * time.Millisecond,
+	}
+	for a := shortAttempt.Start(); a.Next(); {
+		for _, log := range s.logs.Log() {
+			c.Assert(log.Level, jc.LessThan, loggo.ERROR, gc.Commentf("log: %#v", log))
+		}
+	}
+
+	// Check that the logtransfer file was populated as expected
+	logPath := filepath.Join(s.LogDir, "migrated.log")
+	logContents, err := ioutil.ReadFile(logPath)
+	c.Assert(err, jc.ErrorIsNil)
+	line0 := modelUUID + ": machine-23 2015-06-01 23:02:01 INFO some.where foo.go:42 all is well\n"
+	line1 := modelUUID + ": machine-101 2015-06-01 23:02:02 ERROR else.where bar.go:99 oh noes\n"
+	c.Assert(string(logContents), gc.Equals, line0+line1)
+
+	// Check the file mode is as expected. This doesn't work on
+	// Windows (but this code is very unlikely to run on Windows so
+	// it's ok).
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(logPath)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(info.Mode(), gc.Equals, os.FileMode(0600))
+	}
+}
+
+func (s *logtransferSuite) toReader(conn *websocket.Conn) *bufio.Reader {
+	s.AddCleanup(func(_ *gc.C) { conn.Close() })
+	return bufio.NewReader(conn)
 }

--- a/apiserver/logtransfer_test.go
+++ b/apiserver/logtransfer_test.go
@@ -1,0 +1,109 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	"bufio"
+	// "io/ioutil"
+	"net/http"
+	"net/url"
+	// "os"
+	// "path/filepath"
+	// "runtime"
+	// "time"
+
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	"golang.org/x/net/websocket"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+	// "gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/juju/apiserver/params"
+	// coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
+	"github.com/juju/juju/version"
+)
+
+type logtransferSuite struct {
+	authHTTPSuite
+	userTag  names.Tag
+	password string
+	logs     loggo.TestWriter
+}
+
+var _ = gc.Suite(&logtransferSuite{})
+
+func (s *logtransferSuite) SetUpTest(c *gc.C) {
+	s.authHTTPSuite.SetUpTest(c)
+	s.password = "jabberwocky"
+	u := s.Factory.MakeUser(c, &factory.UserParams{Password: s.password})
+	s.userTag = u.Tag()
+
+	s.logs.Clear()
+	writer := loggo.NewMinimumLevelWriter(&s.logs, loggo.INFO)
+	c.Assert(loggo.RegisterWriter("logsink-tests", writer), jc.ErrorIsNil)
+}
+
+func (s *logtransferSuite) logtransferURL(c *gc.C, scheme string) *url.URL {
+	controllerModel, err := s.State.ControllerModel()
+	c.Assert(err, jc.ErrorIsNil)
+	server := s.makeURL(c, scheme, "/model/"+controllerModel.UUID()+"/migration-logtransfer", nil)
+	query := server.Query()
+	query.Set("jujuclientversion", version.Current.String())
+	server.RawQuery = query.Encode()
+	return server
+}
+
+func (s *logtransferSuite) makeAuthHeader() http.Header {
+	header := utils.BasicAuthHeader(s.userTag.String(), s.password)
+	header.Add(params.MigrationModelHeader, s.State.ModelUUID())
+	return header
+}
+
+func (s *logtransferSuite) dialWebsocket(c *gc.C) *websocket.Conn {
+	return s.dialWebsocketInternal(c, s.makeAuthHeader())
+}
+
+func (s *logtransferSuite) dialWebsocketInternal(c *gc.C, header http.Header) *websocket.Conn {
+	server := s.logtransferURL(c, "wss").String()
+	conn := dialWebsocketFromURL(c, server, header)
+	s.AddCleanup(func(_ *gc.C) { conn.Close() })
+	return conn
+}
+
+func (s *logtransferSuite) openWebsocketCustomPath(c *gc.C, path string) *bufio.Reader {
+	server := s.logtransferURL(c, "wss")
+	server.Path = path
+	conn := dialWebsocketFromURL(c, server.String(), s.makeAuthHeader())
+	return bufio.NewReader(conn)
+}
+
+func (s *logtransferSuite) TestRejectsBadModelUUID(c *gc.C) {
+	reader := s.openWebsocketCustomPath(c, "/model/does-not-exist/migration-logtransfer")
+	assertJSONError(c, reader, `unknown model: "does-not-exist"`)
+	assertWebsocketClosed(c, reader)
+}
+
+func (s *logtransferSuite) TestRejectsNonControllerURL(c *gc.C) {
+	reader := s.openWebsocketCustomPath(c, "/model/"+s.State.ModelUUID()+"/logsink")
+	assertJSONError(c, reader, `not a controller: "`+s.State.ModelUUID()+`"`)
+	assertWebsocketClosed(c, reader)
+}
+
+func (s *logtransferSuite) TestRejectsMissingModelHeader(c *gc.C) {
+	header := utils.BasicAuthHeader(s.userTag.String(), s.password)
+	reader := bufio.NewReader(dialWebsocketFromURL(c, s.logtransferURL(c, "wss").String(), header))
+	assertJSONError(c, reader, `missing migrating model header`)
+	assertWebsocketClosed(c, reader)
+}
+
+func (s *logtransferSuite) TestRejectsBadMigratingModelUUID(c *gc.C) {
+	header := utils.BasicAuthHeader(s.userTag.String(), s.password)
+	header.Add(params.MigrationModelHeader, "does-not-exist")
+	reader := bufio.NewReader(dialWebsocketFromURL(c, s.logtransferURL(c, "wss").String(), header))
+	assertJSONError(c, reader, `unknown model: "does-not-exist"`)
+	assertWebsocketClosed(c, reader)
+}

--- a/apiserver/logtransfer_test.go
+++ b/apiserver/logtransfer_test.go
@@ -5,12 +5,8 @@ package apiserver_test
 
 import (
 	"bufio"
-	"io/ioutil"
 	"net/http"
 	"net/url"
-	"os"
-	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/juju/loggo"
@@ -218,23 +214,6 @@ func (s *logtransferSuite) TestLogging(c *gc.C) {
 		for _, log := range s.logs.Log() {
 			c.Assert(log.Level, jc.LessThan, loggo.ERROR, gc.Commentf("log: %#v", log))
 		}
-	}
-
-	// Check that the logtransfer file was populated as expected
-	logPath := filepath.Join(s.LogDir, "migrated.log")
-	logContents, err := ioutil.ReadFile(logPath)
-	c.Assert(err, jc.ErrorIsNil)
-	line0 := modelUUID + ": machine-23 2015-06-01 23:02:01 INFO some.where foo.go:42 all is well\n"
-	line1 := modelUUID + ": machine-101 2015-06-01 23:02:02 ERROR else.where bar.go:99 oh noes\n"
-	c.Assert(string(logContents), gc.Equals, line0+line1)
-
-	// Check the file mode is as expected. This doesn't work on
-	// Windows (but this code is very unlikely to run on Windows so
-	// it's ok).
-	if runtime.GOOS != "windows" {
-		info, err := os.Stat(logPath)
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(info.Mode(), gc.Equals, os.FileMode(0600))
 	}
 }
 

--- a/apiserver/logtransfer_test.go
+++ b/apiserver/logtransfer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 Canonical Ltd.
+// Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package apiserver_test

--- a/apiserver/logtransfer_test.go
+++ b/apiserver/logtransfer_test.go
@@ -69,7 +69,7 @@ func (s *logtransferSuite) logtransferURL(c *gc.C, scheme string) *url.URL {
 
 func (s *logtransferSuite) makeAuthHeader() http.Header {
 	header := utils.BasicAuthHeader(s.userTag.String(), s.password)
-	header.Add(params.MigrationModelHeader, s.State.ModelUUID())
+	header.Add(params.MigrationModelHTTPHeader, s.State.ModelUUID())
 	return header
 }
 
@@ -91,7 +91,7 @@ func (s *logtransferSuite) TestRejectsMissingModelHeader(c *gc.C) {
 
 func (s *logtransferSuite) TestRejectsBadMigratingModelUUID(c *gc.C) {
 	header := utils.BasicAuthHeader(s.userTag.String(), s.password)
-	header.Add(params.MigrationModelHeader, "does-not-exist")
+	header.Add(params.MigrationModelHTTPHeader, "does-not-exist")
 	reader := s.toReader(s.dialWebsocketInternal(c, header))
 	assertJSONError(c, reader, `unknown model: "does-not-exist"`)
 	assertWebsocketClosed(c, reader)
@@ -119,7 +119,7 @@ func (s *logtransferSuite) TestRejectsMachineLogins(c *gc.C) {
 
 func (s *logtransferSuite) TestRejectsBadPasword(c *gc.C) {
 	header := utils.BasicAuthHeader(s.userTag.String(), "wrong")
-	header.Add(params.MigrationModelHeader, s.State.ModelUUID())
+	header.Add(params.MigrationModelHTTPHeader, s.State.ModelUUID())
 	reader := s.toReader(s.dialWebsocketInternal(c, header))
 	assertJSONError(c, reader, "invalid entity name or password")
 	assertWebsocketClosed(c, reader)

--- a/apiserver/params/constants.go
+++ b/apiserver/params/constants.go
@@ -32,4 +32,4 @@ const (
 )
 
 const MachineNonceHeader = "X-Juju-Nonce"
-const MigrationModelHeader = "X-Juju-Migration-Model"
+const MigrationModelHeader = "X-Juju-Migration-Model-UUID"

--- a/apiserver/params/constants.go
+++ b/apiserver/params/constants.go
@@ -32,4 +32,3 @@ const (
 )
 
 const MachineNonceHeader = "X-Juju-Nonce"
-const MigrationModelHeader = "X-Juju-Migration-Model-UUID"

--- a/apiserver/params/constants.go
+++ b/apiserver/params/constants.go
@@ -32,3 +32,4 @@ const (
 )
 
 const MachineNonceHeader = "X-Juju-Nonce"
+const MigrationModelHeader = "X-Juju-Migration-Model"

--- a/state/logs.go
+++ b/state/logs.go
@@ -192,6 +192,7 @@ func (logger *LastSentLogTracker) Get() (int64, int64, error) {
 // document includes the field names.
 // (alesstimec) It would be really nice if we could store Time as int64
 // for increased precision.
+// TODO: remove version from this structure: https://pad.lv/1643743
 type logDoc struct {
 	Id        bson.ObjectId `bson:"_id"`
 	Time      int64         `bson:"t"` // unix nano UTC
@@ -221,8 +222,6 @@ func NewDbLogger(st ModelSessioner) *DbLogger {
 func (logger *DbLogger) Log(t time.Time, entity string, module string, location string, level loggo.Level, msg string) error {
 	// TODO(ericsnow) Use a controller-global int sequence for Id.
 
-	// UnixNano() returns the "absolute" (UTC) number of nanoseconds
-	// since the Unix "epoch".
 	unixEpochNanoUTC := t.UnixNano()
 	return logger.logsColl.Insert(&logDoc{
 		Id:        bson.NewObjectId(),
@@ -265,8 +264,6 @@ func NewEntityDbLogger(st ModelSessioner, entity names.Tag, ver version.Number) 
 func (logger *EntityDbLogger) Log(t time.Time, module string, location string, level loggo.Level, msg string) error {
 	// TODO(ericsnow) Use a controller-global int sequence for Id.
 
-	// UnixNano() returns the "absolute" (UTC) number of nanoseconds
-	// since the Unix "epoch".
 	unixEpochNanoUTC := t.UnixNano()
 	return logger.logsColl.Insert(&logDoc{
 		Id:        bson.NewObjectId(),

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -195,7 +195,7 @@ func (s *LogsSuite) TestEntityDbLogger(c *gc.C) {
 }
 
 func (s *LogsSuite) TestDbLogger(c *gc.C) {
-	logger := state.NewDbLogger(s.State, jujuversion.Current)
+	logger := state.NewDbLogger(s.State)
 	defer logger.Close()
 	t0 := coretesting.ZeroTime().Truncate(time.Millisecond) // MongoDB only stores timestamps with ms precision.
 	logger.Log(t0, names.NewMachineTag("45").String(), "some.where", "foo.go:99", loggo.INFO, "all is well")


### PR DESCRIPTION
This lives on the API server at `/migrate/logtransfer` and is similar to the logsink handler. The main differences are:
* instead of requiring machine agent credentials it requires a controller superuser
* the destination model is determined by the X-Juju-Migration-Model-UUID header instead of the url
* the log records include the entity (rather than it being set as the connected agent), because they're streamed for all entities in the source model.

This will be used by the logtransfer phase of the migrationmaster worker.