### PR TITLE
Add new remote application watchers plus new tests

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -71,6 +71,7 @@ var facadeVersions = map[string]int{
 	"ProxyUpdater":                 1,
 	"Reboot":                       2,
 	"RelationUnitsWatcher":         1,
+	"RemoteApplicationWatcher":     1,
 	"RemoteRelations":              1,
 	"RemoteRelationsWatcher":       1,
 	"Resources":                    1,

--- a/api/remoterelations/remoterelations_test.go
+++ b/api/remoterelations/remoterelations_test.go
@@ -53,9 +53,9 @@ func (s *remoteRelationsSuite) TestWatchRemoteApplicationRelations(c *gc.C) {
 		c.Check(version, gc.Equals, 0)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "WatchRemoteApplicationRelations")
-		c.Assert(result, gc.FitsTypeOf, &params.RemoteRelationsWatchResults{})
-		*(result.(*params.RemoteRelationsWatchResults)) = params.RemoteRelationsWatchResults{
-			Results: []params.RemoteRelationsWatchResult{{
+		c.Assert(result, gc.FitsTypeOf, &params.StringsWatchResults{})
+		*(result.(*params.StringsWatchResults)) = params.StringsWatchResults{
+			Results: []params.StringsWatchResult{{
 				Error: &params.Error{Message: "FAIL"},
 			}},
 		}
@@ -68,11 +68,33 @@ func (s *remoteRelationsSuite) TestWatchRemoteApplicationRelations(c *gc.C) {
 	c.Check(callCount, gc.Equals, 1)
 }
 
-func (s *remoteRelationsSuite) TestWatchRemoteApplicationInvalidService(c *gc.C) {
+func (s *remoteRelationsSuite) TestWatchRemoteApplicationInvalidApplication(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		return nil
 	})
 	st := remoterelations.NewState(apiCaller)
 	_, err := st.WatchRemoteApplicationRelations("!@#")
 	c.Assert(err, gc.ErrorMatches, `application name "!@#" not valid`)
+}
+
+func (s *remoteRelationsSuite) TestWatchLocalRelationUnits(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "RemoteRelations")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "WatchLocalRelationUnits")
+		c.Assert(result, gc.FitsTypeOf, &params.RelationUnitsWatchResults{})
+		*(result.(*params.RelationUnitsWatchResults)) = params.RelationUnitsWatchResults{
+			Results: []params.RelationUnitsWatchResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		callCount++
+		return nil
+	})
+	st := remoterelations.NewState(apiCaller)
+	_, err := st.WatchLocalRelationUnits("relation-wordpress:db mysql:db")
+	c.Check(err, gc.ErrorMatches, "FAIL")
+	c.Check(callCount, gc.Equals, 1)
 }

--- a/api/watcher/watcher.go
+++ b/api/watcher/watcher.go
@@ -537,7 +537,7 @@ func NewRemoteRelationsWatcher(caller base.APICaller, result params.RemoteRelati
 	go func() {
 		defer w.tomb.Done()
 		defer close(w.out)
-		w.tomb.Kill(w.loop(*result.Changes))
+		w.tomb.Kill(w.loop(*result.Change))
 	}()
 	return w
 }
@@ -563,7 +563,7 @@ func (w *remoteRelationsWatcher) loop(initialChanges params.RemoteRelationsChang
 			// at this point, so just return.
 			return nil
 		}
-		changes = copyRemoteRelationsChange(*data.(*params.RemoteRelationsWatchResult).Changes)
+		changes = copyRemoteRelationsChange(*data.(*params.RemoteRelationsWatchResult).Change)
 	}
 }
 

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -162,7 +162,7 @@ type OfferedApplicationDetails struct {
 	// ApplicationName contains name of application being offered.
 	ApplicationName string `json:"application-name"`
 
-	// CharmName is the charm name of this service.
+	// CharmName is the charm name of this application.
 	CharmName string `json:"charm-name"`
 
 	// UsersCount is the count of how many users are connected to this shared application.
@@ -224,11 +224,66 @@ type OfferedApplicationFilterTerm struct {
 	CharmName string `json:"charm-name,omitempty"`
 }
 
+// RemoteEntityId is an identifier for an entity that may be involved in a
+// cross-model relation. This object comprises the UUID of the model to
+// which the entity belongs, and an opaque token that is unique to that model.
+type RemoteEntityId struct {
+	ModelUUID string `json:"model-uuid"`
+	Token     string `json:"token"`
+}
+
+// RemoteEntityIdResult holds a remote entity id and an error.
+type RemoteEntityIdResult struct {
+	Result *RemoteEntityId `json:"result,omitempty"`
+	Error  *Error          `json:"error,omitempty"`
+}
+
+// RemoteEntityIdResults has a set of remote entity id results.
+type RemoteEntityIdResults struct {
+	Results []RemoteEntityIdResult `json:"results,omitempty"`
+}
+
+// RemoteRelation describes the current state of a cross-model relation from
+// the perspective of the local model.
+type RemoteRelation struct {
+	Id   RemoteEntityId `json:"id"`
+	Life Life           `json:"life"`
+}
+
+// RemoteRelationResult holds a remote relation and an error.
+type RemoteRelationResult struct {
+	Result *RemoteRelation `json:"result,omitempty"`
+	Error  *Error          `json:"error,omitempty"`
+}
+
+// RemoteRelationResults holds a set of remote relation results.
+type RemoteRelationResults struct {
+	Results []RemoteRelationResult `json:"results,omitempty"`
+}
+
+// RemoteApplication describes the current state of an application involved in a cross-
+// model relation, from the perspective of the local environment.
+type RemoteApplication struct {
+	Id   RemoteEntityId `json:"id"`
+	Life Life           `json:"life"`
+}
+
+// RemoteApplicationResult holds a remote application and an error.
+type RemoteApplicationResult struct {
+	Result *RemoteApplication `json:"result,omitempty"`
+	Error  *Error             `json:"error,omitempty"`
+}
+
+// RemoteApplicationResults holds a set of remote application results.
+type RemoteApplicationResults struct {
+	Results []RemoteApplicationResult `json:"results,omitempty"`
+}
+
 // RemoteRelationsWatchResult holds a RemoteRelationsWatcher id,
 // changes and an error (if any).
 type RemoteRelationsWatchResult struct {
 	RemoteRelationsWatcherId string
-	Changes                  *RemoteRelationsChange `json:"changes,omitempty"`
+	Change                   *RemoteRelationsChange `json:"change,omitempty"`
 	Error                    *Error                 `json:"error,omitempty"`
 }
 
@@ -238,7 +293,21 @@ type RemoteRelationsWatchResults struct {
 	Results []RemoteRelationsWatchResult `json:"results"`
 }
 
-// RemoteApplicationChange describes changes to a service.
+// RemoteApplicationWatchResult holds a RemoteApplicationWatcher id,
+// changes and an error (if any).
+type RemoteApplicationWatchResult struct {
+	RemoteApplicationWatcherId string                   `json:"id"`
+	Change                     *RemoteApplicationChange `json:"change,omitempty"`
+	Error                      *Error                   `json:"error,omitempty"`
+}
+
+// RemoteApplicationWatchResults holds the results for any API call which ends
+// up returning a list of RemoteServiceWatchers.
+type RemoteApplicationWatchResults struct {
+	Results []RemoteApplicationWatchResult `json:"results,omitempty"`
+}
+
+// RemoteApplicationChange describes changes to an application.
 type RemoteApplicationChange struct {
 	ApplicationTag string                `json:"application-tag"`
 	Life           Life                  `json:"life"`
@@ -252,14 +321,19 @@ type RemoteApplicationChanges struct {
 	Changes []RemoteApplicationChange `json:"changes,omitempty"`
 }
 
-// RemoteRelationsChange describes changes to the relations that
-// an application is involved in.
+// RemoteRelationsChange describes changes to the relations that a remote
+// service is involved in.
 type RemoteRelationsChange struct {
-	// ChangedRelations maps relation IDs to relation changes.
+	// Initial indicates whether or not this is an initial, complete
+	// representation of all relations involving a service. If Initial
+	// is true, then RemovedRelations will be empty.
+	Initial bool `json:"initial"`
+
+	// ChangedRelations contains relation changes.
 	ChangedRelations []RemoteRelationChange `json:"changed,omitempty"`
 
-	// RemovedRelations contains the IDs of relations removed
-	// since the last change.
+	// RemovedRelations contains the IDs corresponding to
+	// relations removed since the last change.
 	RemovedRelations []int `json:"removed,omitempty"`
 }
 

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -1361,13 +1361,13 @@ func (s *WatchScopeSuite) TestProviderRequirerContainer(c *gc.C) {
 	// connections are in place.
 }
 
-type WatchCounterpartEndpointUnitsSuite struct {
+type WatchUnitsSuite struct {
 	ConnSuite
 }
 
-var _ = gc.Suite(&WatchCounterpartEndpointUnitsSuite{})
+var _ = gc.Suite(&WatchUnitsSuite{})
 
-func (s *WatchCounterpartEndpointUnitsSuite) TestProviderRequirerGlobal(c *gc.C) {
+func (s *WatchUnitsSuite) TestProviderRequirerGlobal(c *gc.C) {
 	// Create a pair of services and a relation between them.
 	mysql := s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	mysqlEP, err := mysql.Endpoint("server")
@@ -1389,7 +1389,7 @@ func (s *WatchCounterpartEndpointUnitsSuite) TestProviderRequirerGlobal(c *gc.C)
 	mysql0 := addUnit(mysql)
 	wordpress0 := addUnit(wordpress)
 
-	wordpressWatcher, err := rel.WatchCounterpartEndpointUnits("mysql")
+	wordpressWatcher, err := rel.WatchUnits("wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	defer testing.AssertStop(c, wordpressWatcher)
 	wordpressWatcherC := testing.NewRelationUnitsWatcherC(c, s.State, wordpressWatcher)
@@ -1402,7 +1402,7 @@ func (s *WatchCounterpartEndpointUnitsSuite) TestProviderRequirerGlobal(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	changeSettings(c, mysql0)
 
-	mysqlWatcher, err := rel.WatchCounterpartEndpointUnits("wordpress")
+	mysqlWatcher, err := rel.WatchUnits("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	defer testing.AssertStop(c, mysqlWatcher)
 	mysqlWatcherC := testing.NewRelationUnitsWatcherC(c, s.State, mysqlWatcher)
@@ -1419,7 +1419,7 @@ func (s *WatchCounterpartEndpointUnitsSuite) TestProviderRequirerGlobal(c *gc.C)
 	mysqlWatcherC.AssertNoChange()
 }
 
-func (s *WatchCounterpartEndpointUnitsSuite) TestProviderRequirerContainer(c *gc.C) {
+func (s *WatchUnitsSuite) TestProviderRequirerContainer(c *gc.C) {
 	// Create a pair of services and a relation between them.
 	mysql := s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	mysqlEP, err := mysql.Endpoint("juju-info")
@@ -1430,9 +1430,9 @@ func (s *WatchCounterpartEndpointUnitsSuite) TestProviderRequirerContainer(c *gc
 	rel, err := s.State.AddRelation(mysqlEP, loggingEP)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = rel.WatchCounterpartEndpointUnits("mysql")
+	_, err = rel.WatchUnits("mysql")
 	c.Assert(err, gc.ErrorMatches, `"juju-info" endpoint is not globally scoped`)
-	_, err = rel.WatchCounterpartEndpointUnits("logging")
+	_, err = rel.WatchUnits("logging")
 	c.Assert(err, gc.ErrorMatches, `"info" endpoint is not globally scoped`)
 }
 

--- a/watcher/remoterelations.go
+++ b/watcher/remoterelations.go
@@ -38,11 +38,6 @@ type RemoteRelationsChange struct {
 	RemovedRelations []int
 }
 
-// RemoteRelationsChanges holds a set of RemoteRelationsChange structures.
-type RemoteRelationsChanges struct {
-	Changes []RemoteRelationsChange
-}
-
 // CHECK - PORT params
 // RemoteRelationsChannel is a change channel as described in the CoreWatcher docs.
 type RemoteRelationsChannel <-chan RemoteRelationsChange
@@ -52,4 +47,18 @@ type RemoteRelationsChannel <-chan RemoteRelationsChange
 type RemoteRelationsWatcher interface {
 	CoreWatcher
 	Changes() RemoteRelationsChannel
+}
+
+// RemoteApplicationChange describes changes to a remote application.
+type RemoteApplicationChange struct {
+	// ApplicationTag is the application which has changed.
+	ApplicationTag string `json:"application-tag"`
+
+	// Life is the current lifecycle state of the application.
+	Life multiwatcher.Life `json:"life"`
+
+	// Relations are the changed relations.
+	Relations RemoteRelationsChange `json:"relations"`
+
+	// TODO(wallyworld) - status etc
 }


### PR DESCRIPTION
Add / replace new watchers:
- WatchRemoteApplicationRelations
- WatchLocalRelationUnits

New tests are also added for existing cmr code which was not yet tested. Some existing watcher code is currently unused but is retained until all refactoring is completed.

QA: code is currently unused, so just a quick bootstrap with lxd 