### PR TITLE
Add remote entity infrastructure to state

### DIFF
--- a/apiserver/application/application_test.go
+++ b/apiserver/application/application_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testcharms"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -2540,6 +2541,7 @@ func remoteOffers() []params.ApplicationOffer {
 		{
 			ApplicationURL:  "local:/u/me/prod/hosted-mysql",
 			ApplicationName: "mysqlremote",
+			SourceModelTag:  coretesting.ModelTag.String(),
 			Endpoints: []params.RemoteEndpoint{
 				{
 					Name:      "server",
@@ -2595,6 +2597,7 @@ func (s *serviceSuite) TestRemoteRelationNoMatchingEndpoint(c *gc.C) {
 		{
 			ApplicationURL:  "local:/u/me/prod/hosted-mysql",
 			ApplicationName: "mysqlremote",
+			SourceModelTag:  coretesting.ModelTag.String(),
 			Endpoints: []params.RemoteEndpoint{
 				{
 					Name:      "admin",

--- a/apiserver/application/backend.go
+++ b/apiserver/application/backend.go
@@ -20,7 +20,7 @@ type Backend interface {
 	Application(string) (Application, error)
 	AddApplication(state.AddApplicationArgs) (*state.Application, error)
 	RemoteApplication(name string) (*state.RemoteApplication, error)
-	AddRemoteApplication(name, url string, endpoints []charm.Relation) (*state.RemoteApplication, error)
+	AddRemoteApplication(args state.AddRemoteApplicationParams) (*state.RemoteApplication, error)
 	AddRelation(...state.Endpoint) (Relation, error)
 	AssignUnit(*state.Unit, state.AssignmentPolicy) error
 	AssignUnitWithPlacement(*state.Unit, *instance.Placement) error

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -460,8 +460,11 @@ func fetchRemoteApplications(st Backend) (map[string]*state.RemoteApplication, e
 	if err != nil {
 		return nil, err
 	}
-	for _, s := range applications {
-		appMap[s.Name()] = s
+	for _, a := range applications {
+		if _, ok := a.URL(); !ok {
+			continue
+		}
+		appMap[a.Name()] = a
 	}
 	return appMap, nil
 }
@@ -737,7 +740,7 @@ func (context *statusContext) processRemoteApplications() map[string]params.Remo
 }
 
 func (context *statusContext) processRemoteApplication(application *state.RemoteApplication) (status params.RemoteApplicationStatus) {
-	status.ApplicationURL = application.URL()
+	status.ApplicationURL, _ = application.URL()
 	status.ApplicationName = application.Name()
 	eps, err := application.Endpoints()
 	if err != nil {

--- a/apiserver/crossmodel/crossmodel_test.go
+++ b/apiserver/crossmodel/crossmodel_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/crossmodel"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/feature"
+	"github.com/juju/juju/testing"
 )
 
 type crossmodelSuite struct {
@@ -40,7 +41,7 @@ func (s *crossmodelSuite) TestOffer(c *gc.C) {
 		Offers: []params.AddApplicationOffer{{
 			ApplicationOffer: params.ApplicationOffer{
 				ApplicationURL:         "local:/u/me/test",
-				SourceModelTag:         "model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
+				SourceModelTag:         testing.ModelTag.String(),
 				SourceLabel:            "controller",
 				ApplicationName:        "test",
 				ApplicationDescription: "A pretty popular blog engine",
@@ -98,7 +99,7 @@ func (s *crossmodelSuite) TestOfferSomeFail(c *gc.C) {
 		Offers: []params.AddApplicationOffer{{
 			ApplicationOffer: params.ApplicationOffer{
 				ApplicationURL:         "local:/u/me/one",
-				SourceModelTag:         "model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
+				SourceModelTag:         testing.ModelTag.String(),
 				SourceLabel:            "controller",
 				ApplicationName:        "one",
 				ApplicationDescription: "A pretty popular blog engine",
@@ -112,7 +113,7 @@ func (s *crossmodelSuite) TestOfferSomeFail(c *gc.C) {
 				}}}, {
 			ApplicationOffer: params.ApplicationOffer{
 				ApplicationURL:         "local:/u/me/two",
-				SourceModelTag:         "model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
+				SourceModelTag:         testing.ModelTag.String(),
 				SourceLabel:            "controller",
 				ApplicationName:        "two",
 				ApplicationDescription: "A pretty popular blog engine",
@@ -178,7 +179,7 @@ func (s *crossmodelSuite) TestShow(c *gc.C) {
 		ApplicationName:        applicationName,
 		ApplicationDescription: "description",
 		ApplicationURL:         url,
-		SourceModelTag:         "environment-",
+		SourceModelTag:         "model-",
 		SourceLabel:            "label",
 		Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
 	}
@@ -195,7 +196,7 @@ func (s *crossmodelSuite) TestShow(c *gc.C) {
 				ApplicationName:        applicationName,
 				ApplicationDescription: "description",
 				ApplicationURL:         url,
-				SourceModelTag:         "environment-",
+				SourceModelTag:         "model-",
 				SourceLabel:            "label",
 				Endpoints:              []params.RemoteEndpoint{{Name: "db"}}}},
 		}})
@@ -271,7 +272,7 @@ func (s *crossmodelSuite) TestShowFoundMultiple(c *gc.C) {
 		ApplicationName:        name,
 		ApplicationDescription: "description",
 		ApplicationURL:         url,
-		SourceModelTag:         "environment-",
+		SourceModelTag:         "model-",
 		SourceLabel:            "label",
 		Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
 	}
@@ -282,7 +283,7 @@ func (s *crossmodelSuite) TestShowFoundMultiple(c *gc.C) {
 		ApplicationName:        name2,
 		ApplicationDescription: "description2",
 		ApplicationURL:         url2,
-		SourceModelTag:         "environment-",
+		SourceModelTag:         "model-",
 		SourceLabel:            "label2",
 		Endpoints:              []params.RemoteEndpoint{{Name: "db2"}},
 	}
@@ -301,14 +302,14 @@ func (s *crossmodelSuite) TestShowFoundMultiple(c *gc.C) {
 				ApplicationName:        name,
 				ApplicationDescription: "description",
 				ApplicationURL:         url,
-				SourceModelTag:         "environment-",
+				SourceModelTag:         "model-",
 				SourceLabel:            "label",
 				Endpoints:              []params.RemoteEndpoint{{Name: "db"}}}},
 			{Result: params.ApplicationOffer{
 				ApplicationName:        name2,
 				ApplicationDescription: "description2",
 				ApplicationURL:         url2,
-				SourceModelTag:         "environment-",
+				SourceModelTag:         "model-",
 				SourceLabel:            "label2",
 				Endpoints:              []params.RemoteEndpoint{{Name: "db2"}}}},
 		}})
@@ -342,7 +343,7 @@ func (s *crossmodelSuite) TestFind(c *gc.C) {
 		ApplicationName:        applicationName,
 		ApplicationDescription: "description",
 		ApplicationURL:         url,
-		SourceModelTag:         "environment-",
+		SourceModelTag:         "model-",
 		SourceLabel:            "label",
 		Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
 	}
@@ -371,7 +372,7 @@ func (s *crossmodelSuite) TestFind(c *gc.C) {
 							ApplicationName:        applicationName,
 							ApplicationDescription: "description",
 							ApplicationURL:         url,
-							SourceModelTag:         "environment-",
+							SourceModelTag:         "model-",
 							SourceLabel:            "label",
 							Endpoints:              []params.RemoteEndpoint{{Name: "db"}}}},
 				}}})

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -32,7 +32,7 @@ type OfferFilters struct {
 type OfferFilter struct {
 	ApplicationURL         string                     `json:"application-url"`
 	SourceLabel            string                     `json:"source-label"`
-	SourceModelUUIDTag     string                     `json:"source-uuid"`
+	SourceModelUUIDTag     string                     `json:"source-model-uuid"`
 	ApplicationName        string                     `json:"application-name"`
 	ApplicationDescription string                     `json:"application-description"`
 	ApplicationUser        string                     `json:"application-user"`

--- a/apiserver/remoterelations/mock_test.go
+++ b/apiserver/remoterelations/mock_test.go
@@ -4,13 +4,14 @@
 package remoterelations_test
 
 import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	"gopkg.in/juju/names.v2"
 	"gopkg.in/tomb.v1"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/remoterelations"
 	"github.com/juju/juju/state"
-	"github.com/juju/testing"
 )
 
 type mockState struct {
@@ -30,6 +31,30 @@ func newMockState() *mockState {
 		remoteApplicationsWatcher:    newMockStringsWatcher(),
 		applicationRelationsWatchers: make(map[string]*mockStringsWatcher),
 	}
+}
+
+func (st *mockState) ExportLocalEntity(entity names.Tag) (string, error) {
+	st.MethodCall(st, "ExportLocalEntity", entity)
+	if err := st.NextErr(); err != nil {
+		return "", err
+	}
+	return "", errors.NotImplementedf("ExportLocalEntity")
+}
+
+func (st *mockState) GetRemoteEntity(sourceModel names.ModelTag, token string) (names.Tag, error) {
+	st.MethodCall(st, "GetRemoteEntity", sourceModel, token)
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	return nil, errors.NotImplementedf("GetRemoteEntity")
+}
+
+func (st *mockState) GetToken(sourceModel names.ModelTag, entity names.Tag) (string, error) {
+	st.MethodCall(st, "GetToken", sourceModel, entity)
+	if err := st.NextErr(); err != nil {
+		return "", err
+	}
+	return "", errors.NotImplementedf("GetToken")
 }
 
 func (st *mockState) KeyRelation(key string) (remoterelations.Relation, error) {
@@ -189,9 +214,9 @@ func (r *mockRemoteApplication) Name() string {
 	return r.name
 }
 
-func (r *mockRemoteApplication) URL() string {
+func (r *mockRemoteApplication) URL() (string, bool) {
 	r.MethodCall(r, "URL")
-	return r.url
+	return r.url, r.url != ""
 }
 
 func (r *mockRemoteApplication) Destroy() error {

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -2996,7 +2996,12 @@ func (as addRemoteApplication) step(c *gc.C, ctx *context) {
 		c.Assert(ok, jc.IsTrue)
 		endpoints = append(endpoints, r)
 	}
-	_, err := ctx.st.AddRemoteApplication(as.name, as.url, endpoints)
+	_, err := ctx.st.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        as.name,
+		URL:         as.url,
+		SourceModel: coretesting.ModelTag,
+		Endpoints:   endpoints,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/featuretests/remoterelations_test.go
+++ b/featuretests/remoterelations_test.go
@@ -36,7 +36,11 @@ func (s *remoteRelationsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *remoteRelationsSuite) TestWatchRemoteApplications(c *gc.C) {
-	_, err := s.State.AddRemoteApplication("mysql", "local:/u/me/mysql", nil)
+	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "mysql",
+		URL:         "local:/u/me/mysql",
+		SourceModel: testing.ModelTag,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	w, err := s.client.WatchRemoteApplications()
@@ -52,7 +56,11 @@ func (s *remoteRelationsSuite) TestWatchRemoteApplications(c *gc.C) {
 	wc.AssertChangeInSingleEvent("mysql")
 	wc.AssertNoChange()
 
-	_, err = s.State.AddRemoteApplication("db2", "local:/u/ibm/db2", nil)
+	_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "db2",
+		URL:         "local:/u/me/db2",
+		SourceModel: testing.ModelTag,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChangeInSingleEvent("db2")
 	wc.AssertNoChange()
@@ -61,12 +69,16 @@ func (s *remoteRelationsSuite) TestWatchRemoteApplications(c *gc.C) {
 func (s *remoteRelationsSuite) TestWatchRemoteApplicationRelations(c *gc.C) {
 	// Add a remote application, and watch it. It should initially have no
 	// relations.
-	_, err := s.State.AddRemoteApplication("mysql", "local:/u/me/mysql", []charm.Relation{{
-		Interface: "mysql",
-		Name:      "db",
-		Role:      charm.RoleProvider,
-		Scope:     charm.ScopeGlobal,
-	}})
+	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "mysql",
+		URL:         "local:/u/me/mysql",
+		SourceModel: testing.ModelTag,
+		Endpoints: []charm.Relation{{
+			Interface: "mysql",
+			Name:      "db",
+			Role:      charm.RoleProvider,
+			Scope:     charm.ScopeGlobal,
+		}}})
 	c.Assert(err, jc.ErrorIsNil)
 	w, err := s.client.WatchRemoteApplicationRelations("mysql")
 	c.Assert(err, jc.ErrorIsNil)
@@ -116,12 +128,16 @@ func assertNoRemoteRelationsChange(c *gc.C, ss statetesting.SyncStarter, w watch
 }
 
 func (s *remoteRelationsSuite) TestWatchLocalRelationUnits(c *gc.C) {
-	_, err := s.State.AddRemoteApplication("mysql", "local:/u/me/mysql", []charm.Relation{{
-		Interface: "mysql",
-		Name:      "db",
-		Role:      charm.RoleProvider,
-		Scope:     charm.ScopeGlobal,
-	}})
+	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "mysql",
+		URL:         "local:/u/me/mysql",
+		SourceModel: testing.ModelTag,
+		Endpoints: []charm.Relation{{
+			Interface: "mysql",
+			Name:      "db",
+			Role:      charm.RoleProvider,
+			Scope:     charm.ScopeGlobal,
+		}}})
 	c.Assert(err, jc.ErrorIsNil)
 	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	eps, err := s.State.InferEndpoints("wordpress", "mysql")

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -413,6 +413,17 @@ func allCollections() collectionSchema {
 				}},
 			},
 			remoteApplicationsC: {},
+			// remoteEntitiesC holds information about entities involved in
+			// cross-model relations.
+			remoteEntitiesC: {
+				indexes: []mgo.Index{{
+					Key: []string{"model-uuid", "source-model-uuid", "token"},
+				}, {
+					Key: []string{"model-uuid", "source-model-uuid"},
+				}},
+			},
+			// tokensC holds unique tokens for the model.
+			tokensC: {},
 		} {
 			result[name] = details
 		}
@@ -505,4 +516,6 @@ const (
 	localApplicationDirectoryC = "localapplicationdirectory"
 	applicationOffersC         = "applicationOffers"
 	remoteApplicationsC        = "remoteApplications"
+	remoteEntitiesC            = "remoteEntities"
+	tokensC                    = "tokens"
 )

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -312,7 +312,12 @@ func addTestingRemoteApplication(
 	c *gc.C, st *State, name, url string, relations []charm.Relation,
 ) (*RemoteApplication, multiwatcher.RemoteApplicationInfo) {
 
-	rs, err := st.AddRemoteApplication(name, url, relations)
+	rs, err := st.AddRemoteApplication(AddRemoteApplicationParams{
+		Name:        name,
+		URL:         url,
+		SourceModel: testing.ModelTag,
+		Endpoints:   relations,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	return rs, multiwatcher.RemoteApplicationInfo{
 		ModelUUID:      st.ModelUUID(),

--- a/state/applicationdirectory.go
+++ b/state/applicationdirectory.go
@@ -26,7 +26,7 @@ type applicationOfferDoc struct {
 	URL string `bson:"url"`
 
 	// SourceModelUUID is the UUID of the environment hosting the application.
-	SourceModelUUID string `bson:"source-uuid"`
+	SourceModelUUID string `bson:"source-model-uuid"`
 
 	// SourceLabel is a user friendly name for the source environment.
 	SourceLabel string `bson:"source-label"`
@@ -237,7 +237,7 @@ func (s *applicationDirectory) makeFilterTerm(filterTerm crossmodel.ApplicationO
 		filter = append(filter, bson.DocElem{"source-label", filterTerm.SourceLabel})
 	}
 	if filterTerm.SourceModelUUID != "" {
-		filter = append(filter, bson.DocElem{"source-uuid", filterTerm.SourceModelUUID})
+		filter = append(filter, bson.DocElem{"source-model-uuid", filterTerm.SourceModelUUID})
 	}
 	// We match on partial URLs eg /u/user
 	if filterTerm.ApplicationURL != "" {

--- a/state/applicationdirectory_test.go
+++ b/state/applicationdirectory_test.go
@@ -40,7 +40,7 @@ func (s *applicationDirectorySuite) createDefaultOffer(c *gc.C) crossmodel.Appli
 		ApplicationName:        "mysql",
 		ApplicationDescription: "mysql is a db server",
 		Endpoints:              eps,
-		SourceModelUUID:        "source-uuid",
+		SourceModelUUID:        "source-model-uuid",
 		SourceLabel:            "source",
 	}
 	err := sd.AddOffer(offer)
@@ -51,7 +51,7 @@ func (s *applicationDirectorySuite) createDefaultOffer(c *gc.C) crossmodel.Appli
 func (s *applicationDirectorySuite) TestEndpoints(c *gc.C) {
 	offer := s.createDefaultOffer(c)
 	_, err := state.ApplicationOfferEndpoint(offer, "foo")
-	c.Assert(err, gc.ErrorMatches, `relation "foo" on application offer "source-uuid-mysql" not found`)
+	c.Assert(err, gc.ErrorMatches, `relation "foo" on application offer "source-model-uuid-mysql" not found`)
 
 	serverEP, err := state.ApplicationOfferEndpoint(offer, "db")
 	c.Assert(err, jc.ErrorIsNil)
@@ -96,7 +96,7 @@ func (s *applicationDirectorySuite) TestAddApplicationOffer(c *gc.C) {
 		ApplicationName:        "mysql",
 		ApplicationDescription: "mysql is a db server",
 		Endpoints:              eps,
-		SourceModelUUID:        "source-uuid",
+		SourceModelUUID:        "source-model-uuid",
 		SourceLabel:            "source",
 	}
 	err := sd.AddOffer(offer)

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -191,6 +191,8 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		localApplicationDirectoryC,
 		remoteApplicationsC,
 		applicationOffersC,
+		tokensC,
+		remoteEntitiesC,
 	)
 
 	envCollections := set.NewStrings()

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -150,20 +150,28 @@ func (s *RelationUnitSuite) TestPeerSettings(c *gc.C) {
 }
 
 func (s *RelationUnitSuite) TestRemoteUnitErrors(c *gc.C) {
-	_, err := s.State.AddRemoteApplication("mysql", "local:/u/me/mysql", []charm.Relation{{
-		Interface: "mysql",
-		Name:      "server",
-		Role:      charm.RoleProvider,
-		Scope:     charm.ScopeGlobal,
-	}})
+	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "mysql",
+		URL:         "local:/u/me/mysql",
+		SourceModel: coretesting.ModelTag,
+		Endpoints: []charm.Relation{{
+			Interface: "mysql",
+			Name:      "server",
+			Role:      charm.RoleProvider,
+			Scope:     charm.ScopeGlobal,
+		}}})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.State.AddRemoteApplication("mysql1", "local:/u/me/mysql", []charm.Relation{{
-		Interface: "mysql",
-		Name:      "server",
-		Role:      charm.RoleProvider,
-		Scope:     charm.ScopeGlobal,
-	}})
+	_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "mysql1",
+		URL:         "local:/u/me/mysql",
+		SourceModel: coretesting.ModelTag,
+		Endpoints: []charm.Relation{{
+			Interface: "mysql",
+			Name:      "server",
+			Role:      charm.RoleProvider,
+			Scope:     charm.ScopeGlobal,
+		}}})
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 
@@ -914,12 +922,16 @@ type RemoteProReqRelation struct {
 }
 
 func NewRemoteProReqRelation(c *gc.C, s *ConnSuite) *RemoteProReqRelation {
-	psvc, err := s.State.AddRemoteApplication("mysql", "local:/u/me/mysql", []charm.Relation{{
-		Interface: "mysql",
-		Name:      "server",
-		Role:      charm.RoleProvider,
-		Scope:     charm.ScopeGlobal,
-	}})
+	psvc, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "mysql",
+		URL:         "local:/u/me/mysql",
+		SourceModel: coretesting.ModelTag,
+		Endpoints: []charm.Relation{{
+			Interface: "mysql",
+			Name:      "server",
+			Role:      charm.RoleProvider,
+			Scope:     charm.ScopeGlobal,
+		}}})
 	c.Assert(err, jc.ErrorIsNil)
 	rsvc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 

--- a/state/remoteentities.go
+++ b/state/remoteentities.go
@@ -1,0 +1,241 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+	jujutxn "github.com/juju/txn"
+	"github.com/juju/utils"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+)
+
+// remoteEntityDoc represents the internal state of a remote entity in
+// MongoDB. Remote entities may be exported local entities, or imported
+// remote entities.
+type remoteEntityDoc struct {
+	DocID string `bson:"_id"`
+
+	SourceModelUUID string `bson:"source-model-uuid"`
+	EntityTag       string `bson:"entity"`
+	Token           string `bson:"token"`
+}
+
+type tokenDoc struct {
+	Token     string `bson:"_id"`
+	ModelUUID string `bson:"model-uuid"`
+}
+
+// RemoteEntities wraps State to provide access
+// to the remote entities collection.
+type RemoteEntities struct {
+	st *State
+}
+
+// RemoteEntities returns a wrapped state instance providing
+// access to the remote entities collection.
+func (st *State) RemoteEntities() *RemoteEntities {
+	return &RemoteEntities{st}
+}
+
+// ExportLocalEntity adds an entity to the remote entities collection,
+// returning an opaque token that uniquely identifies the entity within
+// the model.
+//
+// It is an error to export an entity twice.
+func (r *RemoteEntities) ExportLocalEntity(entity names.Tag) (string, error) {
+	var token string
+	sourceModel := r.st.ModelTag()
+	ops := func(attempt int) ([]txn.Op, error) {
+		// The entity must not already be exported.
+		_, err := r.GetToken(sourceModel, entity)
+		if err == nil {
+			return nil, errors.AlreadyExistsf(
+				"token for %s",
+				names.ReadableString(entity),
+			)
+		} else if !errors.IsNotFound(err) {
+			return nil, errors.Trace(err)
+		}
+
+		// Generate a unique token within the model.
+		uuid, err := utils.NewUUID()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		token = uuid.String()
+		exists, err := r.tokenExists(token)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if exists {
+			return nil, jujutxn.ErrTransientFailure
+		}
+
+		aa := []txn.Op{{
+			C:      tokensC,
+			Id:     token,
+			Assert: txn.DocMissing,
+			Insert: &tokenDoc{},
+		}, {
+			C:      remoteEntitiesC,
+			Id:     r.docID(sourceModel, entity),
+			Assert: txn.DocMissing,
+			Insert: &remoteEntityDoc{
+				SourceModelUUID: sourceModel.Id(),
+				EntityTag:       entity.String(),
+				Token:           token,
+			},
+		}}
+		return aa, nil
+	}
+	if err := r.st.run(ops); err != nil {
+		return "", errors.Trace(err)
+	}
+	return token, nil
+}
+
+// ImportRemoteEntity adds an entity to the remote entities collection
+// with the specified opaque token.
+//
+// This method assumes that the provided token is unique within the
+// source model, and does not perform any uniqueness checks on it.
+func (r *RemoteEntities) ImportRemoteEntity(
+	sourceModel names.ModelTag, entity names.Tag, token string,
+) error {
+	ops := r.importRemoteEntityOps(sourceModel, entity, token)
+	err := r.st.runTransaction(ops)
+	if err == txn.ErrAborted {
+		return errors.AlreadyExistsf(
+			"reference to %s in %s",
+			names.ReadableString(entity),
+			names.ReadableString(sourceModel),
+		)
+	}
+	if err != nil {
+		return errors.Annotatef(
+			err, "recording reference to %s in %s",
+			names.ReadableString(entity),
+			names.ReadableString(sourceModel),
+		)
+	}
+	return nil
+}
+
+func (r *RemoteEntities) importRemoteEntityOps(
+	sourceModel names.ModelTag, entity names.Tag, token string,
+) []txn.Op {
+	return []txn.Op{{
+		C:      remoteEntitiesC,
+		Id:     r.docID(sourceModel, entity),
+		Assert: txn.DocMissing,
+		Insert: &remoteEntityDoc{
+			SourceModelUUID: sourceModel.Id(),
+			EntityTag:       entity.String(),
+			Token:           token,
+		},
+	}}
+}
+
+// RemoveRemoteEntity removes the entity from the remote entities collection,
+// and releases the token if the entity belongs to the local model.
+func (r *RemoteEntities) RemoveRemoteEntity(
+	sourceModel names.ModelTag, entity names.Tag,
+) error {
+	ops := func(attempt int) ([]txn.Op, error) {
+		token, err := r.GetToken(sourceModel, entity)
+		if errors.IsNotFound(err) {
+			return nil, jujutxn.ErrNoOperations
+		}
+		ops := []txn.Op{r.removeRemoteEntityOp(sourceModel, entity)}
+		if sourceModel == r.st.ModelTag() {
+			ops = append(ops, txn.Op{
+				C:      tokensC,
+				Id:     token,
+				Remove: true,
+			})
+		}
+		return ops, nil
+	}
+	return r.st.run(ops)
+}
+
+// removeRemoteEntityOp returns the txn.Op to remove the remote entity
+// document. It does not remove the token document for exported entities.
+func (r *RemoteEntities) removeRemoteEntityOp(
+	sourceModel names.ModelTag, entity names.Tag,
+) txn.Op {
+	return txn.Op{
+		C:      remoteEntitiesC,
+		Id:     r.docID(sourceModel, entity),
+		Remove: true,
+	}
+}
+
+// GetToken returns the token associated with the entity with the given tag
+// and model.
+func (r *RemoteEntities) GetToken(sourceModel names.ModelTag, entity names.Tag) (string, error) {
+	remoteEntities, closer := r.st.getCollection(remoteEntitiesC)
+	defer closer()
+
+	var doc remoteEntityDoc
+	err := remoteEntities.FindId(r.docID(sourceModel, entity)).One(&doc)
+	if err == mgo.ErrNotFound {
+		return "", errors.NotFoundf(
+			"token for %s in %s",
+			names.ReadableString(entity),
+			names.ReadableString(sourceModel),
+		)
+	}
+	if err != nil {
+		return "", errors.Annotatef(
+			err, "reading token for %s in %s",
+			names.ReadableString(entity),
+			names.ReadableString(sourceModel),
+		)
+	}
+	return doc.Token, nil
+}
+
+// GetRemoteEntity returns the tag of the entity associated with the given
+// token and model.
+func (r *RemoteEntities) GetRemoteEntity(sourceModel names.ModelTag, token string) (names.Tag, error) {
+	remoteEntities, closer := r.st.getCollection(remoteEntitiesC)
+	defer closer()
+
+	var doc remoteEntityDoc
+	err := remoteEntities.Find(bson.D{
+		{"source-model-uuid", sourceModel.Id()},
+		{"token", token},
+	}).One(&doc)
+	if err == mgo.ErrNotFound {
+		return nil, errors.NotFoundf(
+			"entity for token %q in %s",
+			token, names.ReadableString(sourceModel),
+		)
+	}
+	if err != nil {
+		return nil, errors.Annotatef(
+			err, "getting entity for token %q in %s",
+			token, names.ReadableString(sourceModel),
+		)
+	}
+	return names.ParseTag(doc.EntityTag)
+}
+
+func (r *RemoteEntities) docID(sourceModel names.ModelTag, entity names.Tag) string {
+	return sourceModel.Id() + "-" + entity.String()
+}
+
+func (r *RemoteEntities) tokenExists(token string) (bool, error) {
+	tokens, closer := r.st.getCollection(tokensC)
+	defer closer()
+	n, err := tokens.FindId(token).Count()
+	if err != nil {
+		return false, errors.Annotatef(err, "checking existence of token %q", token)
+	}
+	return n != 0, nil
+}

--- a/state/remoteentities_test.go
+++ b/state/remoteentities_test.go
@@ -1,0 +1,95 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+)
+
+type RemoteEntitiesSuite struct {
+	ConnSuite
+}
+
+var _ = gc.Suite(&RemoteEntitiesSuite{})
+
+func (s *RemoteEntitiesSuite) assertExportLocalEntity(c *gc.C, entity names.Tag) string {
+	re := s.State.RemoteEntities()
+	token, err := re.ExportLocalEntity(entity)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(token, gc.Not(gc.Equals), "")
+	return token
+}
+
+func (s *RemoteEntitiesSuite) TestExportLocalEntity(c *gc.C) {
+	entity := names.NewApplicationTag("mysql")
+	token := s.assertExportLocalEntity(c, entity)
+
+	anotherState, err := s.State.ForModel(s.State.ModelTag())
+	c.Assert(err, jc.ErrorIsNil)
+	defer anotherState.Close()
+
+	re := anotherState.RemoteEntities()
+	expected, err := re.GetToken(s.State.ModelTag(), entity)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(token, gc.Equals, expected)
+}
+
+func (s *RemoteEntitiesSuite) TestExportLocalEntityTwice(c *gc.C) {
+	entity := names.NewApplicationTag("mysql")
+	s.assertExportLocalEntity(c, entity)
+	re := s.State.RemoteEntities()
+	_, err := re.ExportLocalEntity(entity)
+	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
+}
+
+func (s *RemoteEntitiesSuite) TestGetRemoteEntity(c *gc.C) {
+	entity := names.NewApplicationTag("mysql")
+	token := s.assertExportLocalEntity(c, entity)
+
+	anotherState, err := s.State.ForModel(s.State.ModelTag())
+	c.Assert(err, jc.ErrorIsNil)
+	defer anotherState.Close()
+
+	re := anotherState.RemoteEntities()
+	expected, err := re.GetRemoteEntity(s.State.ModelTag(), token)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(entity, gc.Equals, expected)
+}
+
+func (s *RemoteEntitiesSuite) TestRemoveRemoteEntity(c *gc.C) {
+	entity := names.NewApplicationTag("mysql")
+	token := s.assertExportLocalEntity(c, entity)
+
+	anotherState, err := s.State.ForModel(s.State.ModelTag())
+	c.Assert(err, jc.ErrorIsNil)
+	defer anotherState.Close()
+
+	re := anotherState.RemoteEntities()
+	err = re.RemoveRemoteEntity(s.State.ModelTag(), entity)
+	c.Assert(err, jc.ErrorIsNil)
+	re = s.State.RemoteEntities()
+	_, err = re.GetRemoteEntity(s.State.ModelTag(), token)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *RemoteEntitiesSuite) TestImportRemoteEntity(c *gc.C) {
+	re := s.State.RemoteEntities()
+	entity := names.NewApplicationTag("mysql")
+	token := utils.MustNewUUID().String()
+	err := re.ImportRemoteEntity(s.State.ModelTag(), entity, token)
+	c.Assert(err, jc.ErrorIsNil)
+
+	anotherState, err := s.State.ForModel(s.State.ModelTag())
+	c.Assert(err, jc.ErrorIsNil)
+	defer anotherState.Close()
+
+	re = anotherState.RemoteEntities()
+	expected, err := re.GetRemoteEntity(s.State.ModelTag(), token)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(entity, gc.Equals, expected)
+}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -399,7 +399,8 @@ func (s *MultiEnvStateSuite) TestWatchTwoEnvironments(c *gc.C) {
 				return st.WatchRemoteApplications()
 			},
 			triggerEvent: func(st *state.State) {
-				st.AddRemoteApplication("db2", "local:/u/ibm/db2", nil)
+				st.AddRemoteApplication(state.AddRemoteApplicationParams{
+					Name: "db2", URL: "local:/u/ibm/db2", SourceModel: s.State.ModelTag()})
 			},
 		}, {
 			about: "relations",
@@ -1445,7 +1446,8 @@ func (s *StateSuite) TestAddServiceEnvironmentMigrating(c *gc.C) {
 
 func (s *StateSuite) TestAddApplicationSameRemoteExists(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddRemoteApplication("s1", "local:/u/me/dummy", nil)
+	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name: "s1", URL: "local:/u/me/dummy", SourceModel: s.State.ModelTag()})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "s1", Charm: charm})
 	c.Assert(err, gc.ErrorMatches, `cannot add application "s1": remote application with same name already exists`)
@@ -1457,7 +1459,8 @@ func (s *StateSuite) TestAddApplicationRemotedAddedAfterInitial(c *gc.C) {
 	// there is no conflict initially but a remote application is added
 	// before the transaction is run.
 	defer state.SetBeforeHooks(c, s.State, func() {
-		_, err := s.State.AddRemoteApplication("s1", "local:/u/me/s1", nil)
+		_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+			Name: "s1", URL: "local:/u/me/s1", SourceModel: s.State.ModelTag()})
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
 	_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "s1", Charm: charm})


### PR DESCRIPTION
More cross model relations infrastructure.
Add state methods to support assigning token to remote entities.
Use params struct when creating remote applications.

QA: added code not used outside cmr, bootstrap lxd