### PR TITLE
Add worker skeleton for cross model relations

### DIFF
--- a/api/remoterelations/remoterelations.go
+++ b/api/remoterelations/remoterelations.go
@@ -15,20 +15,20 @@ import (
 
 const remoteRelationsFacade = "RemoteRelations"
 
-// State provides access to a remoterelations's view of the state.
-type State struct {
+// Client provides access to the remoterelations api facade.
+type Client struct {
 	facade base.FacadeCaller
 }
 
-// NewState creates a new client-side RemoteRelations facade.
-func NewState(caller base.APICaller) *State {
+// NewClient creates a new client-side RemoteRelations facade.
+func NewClient(caller base.APICaller) *Client {
 	facadeCaller := base.NewFacadeCaller(caller, remoteRelationsFacade)
-	return &State{facadeCaller}
+	return &Client{facadeCaller}
 }
 
 // WatchRemoteApplications returns a strings watcher that notifies of the addition,
 // removal, and lifecycle changes of remote applications in the model.
-func (st *State) WatchRemoteApplications() (watcher.StringsWatcher, error) {
+func (st *Client) WatchRemoteApplications() (watcher.StringsWatcher, error) {
 	var result params.StringsWatchResult
 	err := st.facade.FacadeCall("WatchRemoteApplications", nil, &result)
 	if err != nil {
@@ -46,7 +46,7 @@ func (st *State) WatchRemoteApplications() (watcher.StringsWatcher, error) {
 // relations that the specified remote application is involved in; and also
 // according to the entering, departing, and change of unit settings in
 // those relations.
-func (st *State) WatchRemoteApplicationRelations(application string) (watcher.StringsWatcher, error) {
+func (st *Client) WatchRemoteApplicationRelations(application string) (watcher.StringsWatcher, error) {
 	if !names.IsValidApplication(application) {
 		return nil, errors.NotValidf("application name %q", application)
 	}
@@ -73,7 +73,7 @@ func (st *State) WatchRemoteApplicationRelations(application string) (watcher.St
 
 // WatchLocalRelationUnits returns a watcher that notifies of changes to the
 // local units in the relation with the given key.
-func (st *State) WatchLocalRelationUnits(relationKey string) (watcher.RelationUnitsWatcher, error) {
+func (st *Client) WatchLocalRelationUnits(relationKey string) (watcher.RelationUnitsWatcher, error) {
 	if !names.IsValidRelation(relationKey) {
 		return nil, errors.NotValidf("relation key %q", relationKey)
 	}

--- a/api/remoterelations/remoterelations_test.go
+++ b/api/remoterelations/remoterelations_test.go
@@ -18,11 +18,11 @@ type remoteRelationsSuite struct {
 	coretesting.BaseSuite
 }
 
-func (s *remoteRelationsSuite) TestNewState(c *gc.C) {
+func (s *remoteRelationsSuite) TestNewClient(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		return nil
 	})
-	st := remoterelations.NewState(apiCaller)
+	st := remoterelations.NewClient(apiCaller)
 	c.Assert(st, gc.NotNil)
 }
 
@@ -40,7 +40,7 @@ func (s *remoteRelationsSuite) TestWatchRemoteApplications(c *gc.C) {
 		callCount++
 		return nil
 	})
-	st := remoterelations.NewState(apiCaller)
+	st := remoterelations.NewClient(apiCaller)
 	_, err := st.WatchRemoteApplications()
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
@@ -62,7 +62,7 @@ func (s *remoteRelationsSuite) TestWatchRemoteApplicationRelations(c *gc.C) {
 		callCount++
 		return nil
 	})
-	st := remoterelations.NewState(apiCaller)
+	st := remoterelations.NewClient(apiCaller)
 	_, err := st.WatchRemoteApplicationRelations("db2")
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
@@ -72,7 +72,7 @@ func (s *remoteRelationsSuite) TestWatchRemoteApplicationInvalidApplication(c *g
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		return nil
 	})
-	st := remoterelations.NewState(apiCaller)
+	st := remoterelations.NewClient(apiCaller)
 	_, err := st.WatchRemoteApplicationRelations("!@#")
 	c.Assert(err, gc.ErrorMatches, `application name "!@#" not valid`)
 }
@@ -93,7 +93,7 @@ func (s *remoteRelationsSuite) TestWatchLocalRelationUnits(c *gc.C) {
 		callCount++
 		return nil
 	})
-	st := remoterelations.NewState(apiCaller)
+	st := remoterelations.NewClient(apiCaller)
 	_, err := st.WatchLocalRelationUnits("relation-wordpress:db mysql:db")
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/utils/clock"
+	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/voyeur"
 
 	coreagent "github.com/juju/juju/agent"
@@ -15,6 +16,7 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/engine"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/apicaller"
@@ -36,6 +38,7 @@ import (
 	"github.com/juju/juju/worker/migrationflag"
 	"github.com/juju/juju/worker/migrationmaster"
 	"github.com/juju/juju/worker/provisioner"
+	"github.com/juju/juju/worker/remoterelations"
 	"github.com/juju/juju/worker/singular"
 	"github.com/juju/juju/worker/statushistorypruner"
 	"github.com/juju/juju/worker/storageprovisioner"
@@ -101,7 +104,7 @@ type ManifoldsConfig struct {
 // run together to administer a model, as configured.
 func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 	modelTag := config.Agent.CurrentConfig().Model()
-	return dependency.Manifolds{
+	result := dependency.Manifolds{
 
 		// The first group are foundational; the agent and clock
 		// which wrap those supplied in config, and the api-caller
@@ -291,6 +294,14 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewWorker:     machineundertaker.NewWorker,
 		})),
 	}
+	if featureflag.Enabled(feature.CrossModelRelations) {
+		result[remoteRelationsName] = ifNotMigrating(remoterelations.Manifold(remoterelations.ManifoldConfig{
+			APICallerName: apiCallerName,
+			NewFacade:     remoterelations.NewFacade,
+			NewWorker:     remoterelations.NewWorker,
+		}))
+	}
+	return result
 }
 
 // clockManifold expresses a Clock as a ValueWorker manifold.
@@ -383,4 +394,5 @@ const (
 	stateCleanerName         = "state-cleaner"
 	statusHistoryPrunerName  = "status-history-pruner"
 	machineUndertakerName    = "machine-undertaker"
+	remoteRelationsName      = "remote-relations"
 )

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -4,18 +4,19 @@
 package model_test
 
 import (
-	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/clock"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/jujud/agent/model"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/workertest"
 )
 
 type ManifoldsSuite struct {
-	testing.IsolationSuite
+	testing.BaseSuite
 }
 
 var _ = gc.Suite(&ManifoldsSuite{})
@@ -117,3 +118,54 @@ func (s *ManifoldsSuite) TestClockWrapper(c *gc.C) {
 }
 
 type fakeClock struct{ clock.Clock }
+
+type ManifoldsCrossModelSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&ManifoldsCrossModelSuite{})
+
+func (s *ManifoldsCrossModelSuite) SetUpTest(c *gc.C) {
+	s.SetInitialFeatureFlags(feature.CrossModelRelations)
+	s.BaseSuite.SetUpTest(c)
+}
+
+func (s *ManifoldsCrossModelSuite) TestNames(c *gc.C) {
+	actual := set.NewStrings()
+	manifolds := model.Manifolds(model.ManifoldsConfig{
+		Agent: &mockAgent{},
+	})
+	for name := range manifolds {
+		actual.Add(name)
+	}
+	// NOTE: if this test failed, the cmd/jujud/agent tests will
+	// also fail. Search for 'ModelWorkers' to find affected vars.
+	c.Check(actual.SortedValues(), jc.DeepEquals, []string{
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"application-scaler",
+		"charm-revision-updater",
+		"clock",
+		"compute-provisioner",
+		"environ-tracker",
+		"firewaller",
+		"instance-poller",
+		"is-responsible-flag",
+		"machine-undertaker",
+		"metric-worker",
+		"migration-fortress",
+		"migration-inactive-flag",
+		"migration-master",
+		"not-alive-flag",
+		"not-dead-flag",
+		"remote-relations",
+		"space-importer",
+		"spaces-imported-gate",
+		"state-cleaner",
+		"status-history-pruner",
+		"storage-provisioner",
+		"undertaker",
+		"unit-assigner",
+	})
+}

--- a/featuretests/remoterelations_test.go
+++ b/featuretests/remoterelations_test.go
@@ -26,13 +26,13 @@ import (
 
 type remoteRelationsSuite struct {
 	jujutesting.JujuConnSuite
-	client *remoterelations.State
+	client *remoterelations.Client
 }
 
 func (s *remoteRelationsSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	conn, _ := s.OpenAPIAsNewMachine(c, state.JobManageModel)
-	s.client = remoterelations.NewState(conn)
+	s.client = remoterelations.NewClient(conn)
 }
 
 func (s *remoteRelationsSuite) TestWatchRemoteApplications(c *gc.C) {

--- a/worker/remoterelations/manifold.go
+++ b/worker/remoterelations/manifold.go
@@ -1,0 +1,79 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package remoterelations
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// ManifoldConfig defines the names of the manifolds on which a
+// Worker manifold will depend.
+type ManifoldConfig struct {
+	AgentName     string
+	APICallerName string
+
+	NewFacade func(base.APICaller) (RemoteApplicationsFacade, error)
+	NewWorker func(Config) (worker.Worker, error)
+}
+
+// Validate is called by start to check for bad configuration.
+func (config ManifoldConfig) Validate() error {
+	if config.AgentName == "" {
+		return errors.NotValidf("empty AgentName")
+	}
+	if config.APICallerName == "" {
+		return errors.NotValidf("empty APICallerName")
+	}
+	if config.NewFacade == nil {
+		return errors.NotValidf("nil NewFacade")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	return nil
+}
+
+// start is a StartFunc for a Worker manifold.
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var agent agent.Agent
+	if err := context.Get(config.AgentName, &agent); err != nil {
+		return nil, errors.Trace(err)
+	}
+	var apiConn api.Connection
+	if err := context.Get(config.APICallerName, &apiConn); err != nil {
+		return nil, errors.Trace(err)
+	}
+	facade, err := config.NewFacade(apiConn)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	worker, err := config.NewWorker(Config{
+		Facade: facade,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return worker, nil
+}
+
+// Manifold packages a Worker for use in a dependency.Engine.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.APICallerName,
+		},
+		Start: config.start,
+	}
+}

--- a/worker/remoterelations/manifold_test.go
+++ b/worker/remoterelations/manifold_test.go
@@ -1,0 +1,66 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package remoterelations_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/remoterelations"
+)
+
+type ManifoldConfigSuite struct {
+	testing.IsolationSuite
+	config remoterelations.ManifoldConfig
+}
+
+var _ = gc.Suite(&ManifoldConfigSuite{})
+
+func (s *ManifoldConfigSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.config = s.validConfig()
+}
+
+func (s *ManifoldConfigSuite) validConfig() remoterelations.ManifoldConfig {
+	return remoterelations.ManifoldConfig{
+		AgentName:     "agent",
+		APICallerName: "api-caller",
+		NewFacade:     func(base.APICaller) (remoterelations.RemoteApplicationsFacade, error) { return nil, nil },
+		NewWorker:     func(remoterelations.Config) (worker.Worker, error) { return nil, nil },
+	}
+}
+
+func (s *ManifoldConfigSuite) TestValid(c *gc.C) {
+	c.Check(s.config.Validate(), jc.ErrorIsNil)
+}
+
+func (s *ManifoldConfigSuite) TestMissingAgentName(c *gc.C) {
+	s.config.AgentName = ""
+	s.checkNotValid(c, "empty AgentName not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingAPICallerName(c *gc.C) {
+	s.config.APICallerName = ""
+	s.checkNotValid(c, "empty APICallerName not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingNewFacade(c *gc.C) {
+	s.config.NewFacade = nil
+	s.checkNotValid(c, "nil NewFacade not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingNewWorker(c *gc.C) {
+	s.config.NewWorker = nil
+	s.checkNotValid(c, "nil NewWorker not valid")
+}
+
+func (s *ManifoldConfigSuite) checkNotValid(c *gc.C, expect string) {
+	err := s.config.Validate()
+	c.Check(err, gc.ErrorMatches, expect)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}

--- a/worker/remoterelations/package_test.go
+++ b/worker/remoterelations/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package remoterelations_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -1,0 +1,92 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package remoterelations
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker/catacomb"
+)
+
+var logger = loggo.GetLogger("juju.worker.remoterelations")
+
+// RemoteApplicationsFacade exposes remote relation functionality to a worker.
+type RemoteApplicationsFacade interface {
+	// WatchLocalRelationUnits returns a watcher that notifies of changes to the
+	// local units in the relation with the given key.
+	WatchLocalRelationUnits(relationKey string) (watcher.RelationUnitsWatcher, error)
+
+	// WatchRemoteApplications watches for addition, removal and lifecycle
+	// changes to remote applications known to the local model.
+	WatchRemoteApplications() (watcher.StringsWatcher, error)
+
+	// WatchRemoteApplicationRelations starts a StringsWatcher for watching the relations of
+	// each specified application in the local environment, and returns the watcher IDs
+	// and initial values, or an error if the services' relations could not be
+	// watched.
+	WatchRemoteApplicationRelations(application string) (watcher.StringsWatcher, error)
+}
+
+// Config defines the operation of a Worker.
+type Config struct {
+	Facade RemoteApplicationsFacade
+}
+
+// Validate returns an error if config cannot drive a Worker.
+func (config Config) Validate() error {
+	if config.Facade == nil {
+		return errors.NotValidf("nil Facade")
+	}
+	return nil
+}
+
+// New returns a Worker backed by config, or an error.
+func New(config Config) (*Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	w := &Worker{
+		config: config,
+		logger: logger,
+	}
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// Worker manages relations and associated settings where
+// one end of the relation is a remote application.
+type Worker struct {
+	catacomb catacomb.Catacomb
+	config   Config
+	logger   loggo.Logger
+}
+
+// Kill implements worker.Worker.
+func (w *Worker) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait implements worker.Worker.
+func (w *Worker) Wait() error {
+	return w.catacomb.Wait()
+}
+
+func (w *Worker) loop() error {
+	for {
+		// TODO(wallyworld)
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		}
+	}
+}

--- a/worker/remoterelations/shim.go
+++ b/worker/remoterelations/shim.go
@@ -1,0 +1,25 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package remoterelations
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/remoterelations"
+	"github.com/juju/juju/worker"
+)
+
+func NewFacade(apiCaller base.APICaller) (RemoteApplicationsFacade, error) {
+	facade := remoterelations.NewClient(apiCaller)
+	return facade, nil
+}
+
+func NewWorker(config Config) (worker.Worker, error) {
+	worker, err := New(config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return worker, nil
+}


### PR DESCRIPTION
Skeleton and associated boilerplate for new remote relations worker.

QA: bootstrap lxd