### PR TITLE
provider/openstack: add Nova network/firewall impl

### DIFF
--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -68,8 +68,9 @@ var newOpenstackStorage = func(env *Environ) (OpenstackStorage, error) {
 	env.ecfgMutex.Lock()
 	defer env.ecfgMutex.Unlock()
 
+	client := env.clientUnlocked
 	if env.volumeURL == nil {
-		url, err := getVolumeEndpointURL(env.client, env.cloud.Region)
+		url, err := getVolumeEndpointURL(client, env.cloud.Region)
 		if errors.IsNotFound(err) {
 			// No volume endpoint found; Cinder is not supported.
 			return nil, errors.NotSupportedf("volumes")
@@ -81,7 +82,7 @@ var newOpenstackStorage = func(env *Environ) (OpenstackStorage, error) {
 	}
 
 	return &openstackStorageAdapter{
-		cinderClient{cinder.Basic(env.volumeURL, env.client.TenantId(), env.client.Token)},
+		cinderClient{cinder.Basic(env.volumeURL, client.TenantId(), client.Token)},
 		novaClient{env.novaUnlocked},
 	}, nil
 }

--- a/provider/openstack/cinder_internal_test.go
+++ b/provider/openstack/cinder_internal_test.go
@@ -29,7 +29,7 @@ func (s *cinderInternalSuite) TestStorageProviderTypes(c *gc.C) {
 		cloud: environs.CloudSpec{
 			Region: "foo",
 		},
-		client: &testAuthClient{
+		clientUnlocked: &testAuthClient{
 			regionEndpoints: map[string]identity.ServiceURLs{
 				"foo": {"volumev2": "https://bar.invalid"},
 			},
@@ -40,7 +40,7 @@ func (s *cinderInternalSuite) TestStorageProviderTypes(c *gc.C) {
 }
 
 func (s *cinderInternalSuite) TestStorageProviderTypesNotSupported(c *gc.C) {
-	env := &Environ{client: &testAuthClient{}}
+	env := &Environ{clientUnlocked: &testAuthClient{}}
 	types, err := env.StorageProviderTypes()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(types, gc.HasLen, 0)

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -446,7 +446,7 @@ func FindInstanceSpec(
 }
 
 func GetSwiftURL(e environs.Environ) (string, error) {
-	return e.(*Environ).client.MakeServiceURL("object-store", "", nil)
+	return e.(*Environ).clientUnlocked.MakeServiceURL("object-store", "", nil)
 }
 
 func SetUseFloatingIP(e environs.Environ, val bool) {
@@ -476,7 +476,7 @@ func ImageMetadataStorage(e environs.Environ) envstorage.Storage {
 	env := e.(*Environ)
 	return &openstackstorage{
 		containerName: "imagemetadata",
-		swift:         swift.New(env.client),
+		swift:         swift.New(env.clientUnlocked),
 	}
 }
 
@@ -484,7 +484,7 @@ func ImageMetadataStorage(e environs.Environ) envstorage.Storage {
 // so you can put data into it.
 func CreateCustomStorage(e environs.Environ, containerName string) envstorage.Storage {
 	env := e.(*Environ)
-	swiftClient := swift.New(env.client)
+	swiftClient := swift.New(env.clientUnlocked)
 	if err := swiftClient.CreateContainer(containerName, swift.PublicRead); err != nil {
 		panic(err)
 	}

--- a/provider/openstack/legacy_firewaller.go
+++ b/provider/openstack/legacy_firewaller.go
@@ -1,0 +1,299 @@
+// Copyright 2015-2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package openstack
+
+import (
+	"regexp"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/clock"
+	gooseerrors "gopkg.in/goose.v1/errors"
+	"gopkg.in/goose.v1/neutron"
+	"gopkg.in/goose.v1/nova"
+
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
+)
+
+type legacyNovaFirewaller struct {
+	firewallerBase
+}
+
+// SetUpGroups creates the security groups for the new machine, and
+// returns them.
+//
+// Instances are tagged with a group so they can be distinguished from
+// other instances that might be running on the same OpenStack account.
+// In addition, a specific machine security group is created for each
+// machine, so that its firewall rules can be configured per machine.
+func (c *legacyNovaFirewaller) SetUpGroups(controllerUUID, machineId string, apiPort int) ([]string, error) {
+	jujuGroup, err := c.setUpGlobalGroup(c.jujuGroupName(controllerUUID), apiPort)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var machineGroup nova.SecurityGroup
+	switch c.environ.Config().FirewallMode() {
+	case config.FwInstance:
+		machineGroup, err = c.ensureGroup(c.machineGroupName(controllerUUID, machineId), nil)
+	case config.FwGlobal:
+		machineGroup, err = c.ensureGroup(c.globalGroupName(controllerUUID), nil)
+	}
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	groupNames := []string{jujuGroup.Name, machineGroup.Name}
+	if c.environ.ecfg().useDefaultSecurityGroup() {
+		groupNames = append(groupNames, "default")
+	}
+	return groupNames, nil
+}
+
+func (c *legacyNovaFirewaller) setUpGlobalGroup(groupName string, apiPort int) (nova.SecurityGroup, error) {
+	return c.ensureGroup(groupName,
+		[]nova.RuleInfo{
+			{
+				IPProtocol: "tcp",
+				ToPort:     22,
+				FromPort:   22,
+				Cidr:       "0.0.0.0/0",
+			},
+			{
+				IPProtocol: "tcp",
+				ToPort:     apiPort,
+				FromPort:   apiPort,
+				Cidr:       "0.0.0.0/0",
+			},
+			{
+				IPProtocol: "tcp",
+				FromPort:   1,
+				ToPort:     65535,
+			},
+			{
+				IPProtocol: "udp",
+				FromPort:   1,
+				ToPort:     65535,
+			},
+			{
+				IPProtocol: "icmp",
+				FromPort:   -1,
+				ToPort:     -1,
+			},
+		})
+}
+
+// legacyZeroGroup holds the zero security group.
+var legacyZeroGroup nova.SecurityGroup
+
+// ensureGroup returns the security group with name and perms.
+// If a group with name does not exist, one will be created.
+// If it exists, its permissions are set to perms.
+func (c *legacyNovaFirewaller) ensureGroup(name string, rules []nova.RuleInfo) (nova.SecurityGroup, error) {
+	novaClient := c.environ.nova()
+	// First attempt to look up an existing group by name.
+	group, err := novaClient.SecurityGroupByName(name)
+	if err == nil {
+		// Group exists, so assume it is correctly set up and return it.
+		// TODO(jam): 2013-09-18 http://pad.lv/121795
+		// We really should verify the group is set up correctly,
+		// because deleting and re-creating environments can get us bad
+		// groups (especially if they were set up under Python)
+		return *group, nil
+	}
+	// Doesn't exist, so try and create it.
+	group, err = novaClient.CreateSecurityGroup(name, "juju group")
+	if err != nil {
+		if !gooseerrors.IsDuplicateValue(err) {
+			return legacyZeroGroup, err
+		} else {
+			// We just tried to create a duplicate group, so load the existing group.
+			group, err = novaClient.SecurityGroupByName(name)
+			if err != nil {
+				return legacyZeroGroup, err
+			}
+			return *group, nil
+		}
+	}
+	// The new group is created so now add the rules.
+	group.Rules = make([]nova.SecurityGroupRule, len(rules))
+	for i, rule := range rules {
+		rule.ParentGroupId = group.Id
+		if rule.Cidr == "" {
+			// http://pad.lv/1226996 Rules that don't have a CIDR
+			// are meant to apply only to this group. If you don't
+			// supply CIDR or GroupId then openstack assumes you
+			// mean CIDR=0.0.0.0/0
+			rule.GroupId = &group.Id
+		}
+		groupRule, err := novaClient.CreateSecurityGroupRule(rule)
+		if err != nil && !gooseerrors.IsDuplicateValue(err) {
+			return legacyZeroGroup, err
+		}
+		group.Rules[i] = *groupRule
+	}
+	return *group, nil
+}
+
+func (c *legacyNovaFirewaller) deleteSecurityGroups(match func(name string) bool) error {
+	novaclient := c.environ.nova()
+	securityGroups, err := novaclient.ListSecurityGroups()
+	if err != nil {
+		return errors.Annotate(err, "cannot list security groups")
+	}
+	for _, group := range securityGroups {
+		if match(group.Name) {
+			deleteSecurityGroup(
+				novaclient.DeleteSecurityGroup,
+				group.Name,
+				group.Id,
+				clock.WallClock,
+			)
+		}
+	}
+	return nil
+}
+
+// DeleteAllControllerGroups implements Firewaller interface.
+func (c *legacyNovaFirewaller) DeleteAllControllerGroups(controllerUUID string) error {
+	return deleteSecurityGroupsMatchingName(c.deleteSecurityGroups, c.jujuControllerGroupPrefix(controllerUUID))
+}
+
+// DeleteAllModelGroups implements Firewaller interface.
+func (c *legacyNovaFirewaller) DeleteAllModelGroups() error {
+	return deleteSecurityGroupsMatchingName(c.deleteSecurityGroups, c.jujuGroupRegexp())
+}
+
+// DeleteGroups implements Firewaller interface.
+func (c *legacyNovaFirewaller) DeleteGroups(names ...string) error {
+	return deleteSecurityGroupsOneOfNames(c.deleteSecurityGroups, names...)
+}
+
+// OpenPorts implements Firewaller interface.
+func (c *legacyNovaFirewaller) OpenPorts(ports []network.PortRange) error {
+	return c.openPorts(c.openPortsInGroup, ports)
+}
+
+// ClosePorts implements Firewaller interface.
+func (c *legacyNovaFirewaller) ClosePorts(ports []network.PortRange) error {
+	return c.closePorts(c.closePortsInGroup, ports)
+}
+
+// Ports implements Firewaller interface.
+func (c *legacyNovaFirewaller) Ports() ([]network.PortRange, error) {
+	return c.ports(c.portsInGroup)
+}
+
+// OpenInstancePorts implements Firewaller interface.
+func (c *legacyNovaFirewaller) OpenInstancePorts(inst instance.Instance, machineId string, ports []network.PortRange) error {
+	return c.openInstancePorts(c.openPortsInGroup, machineId, ports)
+}
+
+// CloseInstancePorts implements Firewaller interface.
+func (c *legacyNovaFirewaller) CloseInstancePorts(inst instance.Instance, machineId string, ports []network.PortRange) error {
+	return c.closeInstancePorts(c.closePortsInGroup, machineId, ports)
+}
+
+// InstancePorts implements Firewaller interface.
+func (c *legacyNovaFirewaller) InstancePorts(inst instance.Instance, machineId string) ([]network.PortRange, error) {
+	return c.instancePorts(c.portsInGroup, machineId)
+}
+
+func (c *legacyNovaFirewaller) matchingGroup(nameRegExp string) (nova.SecurityGroup, error) {
+	re, err := regexp.Compile(nameRegExp)
+	if err != nil {
+		return nova.SecurityGroup{}, err
+	}
+	novaclient := c.environ.nova()
+	allGroups, err := novaclient.ListSecurityGroups()
+	if err != nil {
+		return nova.SecurityGroup{}, err
+	}
+	var matchingGroups []nova.SecurityGroup
+	for _, group := range allGroups {
+		if re.MatchString(group.Name) {
+			matchingGroups = append(matchingGroups, group)
+		}
+	}
+	if len(matchingGroups) != 1 {
+		return nova.SecurityGroup{}, errors.NotFoundf("security groups matching %q", nameRegExp)
+	}
+	return matchingGroups[0], nil
+}
+
+func (c *legacyNovaFirewaller) openPortsInGroup(nameRegExp string, portRanges []network.PortRange) error {
+	group, err := c.matchingGroup(nameRegExp)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	novaclient := c.environ.nova()
+	rules := portsToRuleInfo(group.Id, portRanges)
+	for _, rule := range rules {
+		_, err := novaclient.CreateSecurityGroupRule(legacyRuleInfo(rule))
+		if err != nil {
+			// TODO: if err is not rule already exists, raise?
+			logger.Debugf("error creating security group rule: %v", err.Error())
+		}
+	}
+	return nil
+}
+
+func legacyRuleInfo(in neutron.RuleInfoV2) nova.RuleInfo {
+	return nova.RuleInfo{
+		ParentGroupId: in.ParentGroupId,
+		FromPort:      in.PortRangeMin,
+		ToPort:        in.PortRangeMax,
+		IPProtocol:    in.IPProtocol,
+		Cidr:          in.RemoteIPPrefix,
+	}
+}
+
+// ruleMatchesPortRange checks if supplied nova security group rule matches the port range
+func legacyRuleMatchesPortRange(rule nova.SecurityGroupRule, portRange network.PortRange) bool {
+	if rule.IPProtocol == nil || rule.FromPort == nil || rule.ToPort == nil {
+		return false
+	}
+	return *rule.IPProtocol == portRange.Protocol &&
+		*rule.FromPort == portRange.FromPort &&
+		*rule.ToPort == portRange.ToPort
+}
+
+func (c *legacyNovaFirewaller) closePortsInGroup(nameRegExp string, portRanges []network.PortRange) error {
+	if len(portRanges) == 0 {
+		return nil
+	}
+	group, err := c.matchingGroup(nameRegExp)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	novaclient := c.environ.nova()
+	for _, portRange := range portRanges {
+		for _, p := range group.Rules {
+			if !legacyRuleMatchesPortRange(p, portRange) {
+				continue
+			}
+			err := novaclient.DeleteSecurityGroupRule(p.Id)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			break
+		}
+	}
+	return nil
+}
+
+func (c *legacyNovaFirewaller) portsInGroup(nameRegexp string) (portRanges []network.PortRange, err error) {
+	group, err := c.matchingGroup(nameRegexp)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for _, p := range group.Rules {
+		portRanges = append(portRanges, network.PortRange{
+			Protocol: *p.IPProtocol,
+			FromPort: *p.FromPort,
+			ToPort:   *p.ToPort,
+		})
+	}
+	network.SortPortRanges(portRanges)
+	return portRanges, nil
+}

--- a/provider/openstack/legacy_networking.go
+++ b/provider/openstack/legacy_networking.go
@@ -1,0 +1,74 @@
+// Copyright 2012-2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package openstack
+
+import (
+	"github.com/juju/juju/instance"
+	"github.com/juju/utils"
+	"gopkg.in/goose.v1/nova"
+)
+
+// LegacyNovaNetworking is an implementation of Networking that uses the legacy
+// Nova network APIs.
+//
+// NOTE(axw) this is provided on a best-effort basis, primarily for CI testing
+// of Juju until we are no longer dependent on an old OpenStack installation.
+// This should not be relied on in production, and should be removed as soon as
+// possible.
+type LegacyNovaNetworking struct {
+	networkingBase
+}
+
+// AllocatePublicIP is part of the Networking interface.
+func (n *LegacyNovaNetworking) AllocatePublicIP(instId instance.Id) (*string, error) {
+	fips, err := n.env.nova().ListFloatingIPs()
+	if err != nil {
+		return nil, err
+	}
+	var newfip *nova.FloatingIP
+	for _, fip := range fips {
+		newfip = &fip
+		if fip.InstanceId != nil && *fip.InstanceId != "" {
+			// unavailable, skip
+			newfip = nil
+			continue
+		} else {
+			logger.Debugf("found unassigned public ip: %v", newfip.IP)
+			// unassigned, we can use it
+			return &newfip.IP, nil
+		}
+	}
+	if newfip == nil {
+		// allocate a new IP and use it
+		newfip, err = n.env.nova().AllocateFloatingIP()
+		if err != nil {
+			return nil, err
+		}
+		logger.Debugf("allocated new public IP: %v", newfip.IP)
+	}
+	return &newfip.IP, nil
+}
+
+// DefaultNetworks is part of the Networking interface.
+func (*LegacyNovaNetworking) DefaultNetworks() ([]nova.ServerNetworks, error) {
+	return []nova.ServerNetworks{}, nil
+}
+
+// ResolveNetwork is part of the Networking interface.
+func (n *LegacyNovaNetworking) ResolveNetwork(name string) (string, error) {
+	if utils.IsValidUUIDString(name) {
+		return name, nil
+	}
+	var networkIds []string
+	networks, err := n.env.nova().ListNetworks()
+	if err != nil {
+		return "", err
+	}
+	for _, network := range networks {
+		if network.Label == name {
+			networkIds = append(networkIds, network.Id)
+		}
+	}
+	return processResolveNetworkIds(name, networkIds)
+}


### PR DESCRIPTION
Add Nova-based networking and firewalling implementations,
to temporarily support old OpenStacks. This is necessary
until our CI's OpenStack is upgraded, or we migrate to a
newer OpenStack cloud.

If you bootstrap an old OpenStack without neutron support,
a warning will be printed out encouraging you to upgrade,
and informing you of impending removal of support from Juju.

Requires #6594