### PR TITLE
Add facade infrastructure for remote relations

### DIFF
--- a/api/remoterelations/remoterelations.go
+++ b/api/remoterelations/remoterelations.go
@@ -26,18 +26,126 @@ func NewClient(caller base.APICaller) *Client {
 	return &Client{facadeCaller}
 }
 
+// PublishLocalRelationChange publishes local relations changes to the
+// remote side offering those relations.
+func (c *Client) PublishLocalRelationChange(change params.RemoteRelationsChange) error {
+	args := params.RemoteRelationsChanges{
+		Changes: []params.RemoteRelationsChange{change},
+	}
+	var results params.ErrorResults
+	err := c.facade.FacadeCall("PublishLocalRelationChange", args, &results)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		return errors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return errors.Trace(result.Error)
+	}
+	return nil
+}
+
+// ConsumeRemoteApplicationChange consumes remote changes to applications into the local model.
+func (c *Client) ConsumeRemoteApplicationChange(change params.RemoteApplicationChange) error {
+	args := params.RemoteApplicationChanges{
+		Changes: []params.RemoteApplicationChange{change},
+	}
+	var results params.ErrorResults
+	err := c.facade.FacadeCall("ConsumeRemoteApplicationChange", args, &results)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		return errors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return errors.Trace(result.Error)
+	}
+	return nil
+}
+
+// ExportEntities allocates unique, remote entity IDs for the given entities in the local model.
+func (c *Client) ExportEntities(tags []names.Tag) ([]params.RemoteEntityIdResult, error) {
+	args := params.Entities{Entities: make([]params.Entity, len(tags))}
+	for i, tag := range tags {
+		args.Entities[i].Tag = tag.String()
+	}
+	var results params.RemoteEntityIdResults
+	err := c.facade.FacadeCall("ExportEntities", args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.Results) != len(tags) {
+		return nil, errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results))
+	}
+	return results.Results, nil
+}
+
+// RelationUnitSettings returns the relation unit settings for the given relation units in the local model.
+func (c *Client) RelationUnitSettings(relationUnits []params.RelationUnit) ([]params.SettingsResult, error) {
+	args := params.RelationUnits{relationUnits}
+	var results params.SettingsResults
+	err := c.facade.FacadeCall("RelationUnitSettings", args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.Results) != len(relationUnits) {
+		return nil, errors.Errorf("expected %d result(s), got %d", len(relationUnits), len(results.Results))
+	}
+	return results.Results, nil
+}
+
+// RemoteRelations returns information about the cross-model relations with the specified keys
+// in the local model.
+func (c *Client) RemoteRelations(keys []string) ([]params.RemoteRelationResult, error) {
+	args := params.Entities{Entities: make([]params.Entity, len(keys))}
+	for i, key := range keys {
+		args.Entities[i].Tag = names.NewRelationTag(key).String()
+	}
+	var results params.RemoteRelationResults
+	err := c.facade.FacadeCall("RemoteRelations", args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.Results) != len(keys) {
+		return nil, errors.Errorf("expected %d result(s), got %d", len(keys), len(results.Results))
+	}
+	return results.Results, nil
+}
+
+// RemoteApplications returns the current state of the remote applications with
+// the specified names in the local model.
+func (c *Client) RemoteApplications(applications []string) ([]params.RemoteApplicationResult, error) {
+	args := params.Entities{Entities: make([]params.Entity, len(applications))}
+	for i, applicationName := range applications {
+		args.Entities[i].Tag = names.NewApplicationTag(applicationName).String()
+	}
+	var results params.RemoteApplicationResults
+	err := c.facade.FacadeCall("RemoteApplications", args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.Results) != len(applications) {
+		return nil, errors.Errorf("expected %d result(s), got %d", len(applications), len(results.Results))
+	}
+	return results.Results, nil
+}
+
 // WatchRemoteApplications returns a strings watcher that notifies of the addition,
 // removal, and lifecycle changes of remote applications in the model.
-func (st *Client) WatchRemoteApplications() (watcher.StringsWatcher, error) {
+func (c *Client) WatchRemoteApplications() (watcher.StringsWatcher, error) {
 	var result params.StringsWatchResult
-	err := st.facade.FacadeCall("WatchRemoteApplications", nil, &result)
+	err := c.facade.FacadeCall("WatchRemoteApplications", nil, &result)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	if result.Error != nil {
 		return nil, result.Error
 	}
-	w := apiwatcher.NewStringsWatcher(st.facade.RawAPICaller(), result)
+	w := apiwatcher.NewStringsWatcher(c.facade.RawAPICaller(), result)
 	return w, nil
 }
 
@@ -46,7 +154,7 @@ func (st *Client) WatchRemoteApplications() (watcher.StringsWatcher, error) {
 // relations that the specified remote application is involved in; and also
 // according to the entering, departing, and change of unit settings in
 // those relations.
-func (st *Client) WatchRemoteApplicationRelations(application string) (watcher.StringsWatcher, error) {
+func (c *Client) WatchRemoteApplicationRelations(application string) (watcher.StringsWatcher, error) {
 	if !names.IsValidApplication(application) {
 		return nil, errors.NotValidf("application name %q", application)
 	}
@@ -56,33 +164,7 @@ func (st *Client) WatchRemoteApplicationRelations(application string) (watcher.S
 	}
 
 	var results params.StringsWatchResults
-	err := st.facade.FacadeCall("WatchRemoteApplicationRelations", args, &results)
-	if err != nil {
-		return nil, err
-	}
-	if len(results.Results) != 1 {
-		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return nil, result.Error
-	}
-	w := apiwatcher.NewStringsWatcher(st.facade.RawAPICaller(), result)
-	return w, nil
-}
-
-// WatchLocalRelationUnits returns a watcher that notifies of changes to the
-// local units in the relation with the given key.
-func (st *Client) WatchLocalRelationUnits(relationKey string) (watcher.RelationUnitsWatcher, error) {
-	if !names.IsValidRelation(relationKey) {
-		return nil, errors.NotValidf("relation key %q", relationKey)
-	}
-	relationTag := names.NewRelationTag(relationKey)
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: relationTag.String()}},
-	}
-	var results params.RelationUnitsWatchResults
-	err := st.facade.FacadeCall("WatchLocalRelationUnits", args, &results)
+	err := c.facade.FacadeCall("WatchRemoteApplicationRelations", args, &results)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -93,6 +175,32 @@ func (st *Client) WatchLocalRelationUnits(relationKey string) (watcher.RelationU
 	if result.Error != nil {
 		return nil, result.Error
 	}
-	w := apiwatcher.NewRelationUnitsWatcher(st.facade.RawAPICaller(), result)
+	w := apiwatcher.NewStringsWatcher(c.facade.RawAPICaller(), result)
+	return w, nil
+}
+
+// WatchLocalRelationUnits returns a watcher that notifies of changes to the
+// local units in the relation with the given key.
+func (c *Client) WatchLocalRelationUnits(relationKey string) (watcher.RelationUnitsWatcher, error) {
+	if !names.IsValidRelation(relationKey) {
+		return nil, errors.NotValidf("relation key %q", relationKey)
+	}
+	relationTag := names.NewRelationTag(relationKey)
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: relationTag.String()}},
+	}
+	var results params.RelationUnitsWatchResults
+	err := c.facade.FacadeCall("WatchLocalRelationUnits", args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	w := apiwatcher.NewRelationUnitsWatcher(c.facade.RawAPICaller(), result)
 	return w, nil
 }

--- a/api/remoterelations/remoterelations_test.go
+++ b/api/remoterelations/remoterelations_test.go
@@ -4,7 +4,9 @@
 package remoterelations_test
 
 import (
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/remoterelations"
@@ -22,8 +24,8 @@ func (s *remoteRelationsSuite) TestNewClient(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		return nil
 	})
-	st := remoterelations.NewClient(apiCaller)
-	c.Assert(st, gc.NotNil)
+	client := remoterelations.NewClient(apiCaller)
+	c.Assert(client, gc.NotNil)
 }
 
 func (s *remoteRelationsSuite) TestWatchRemoteApplications(c *gc.C) {
@@ -40,8 +42,8 @@ func (s *remoteRelationsSuite) TestWatchRemoteApplications(c *gc.C) {
 		callCount++
 		return nil
 	})
-	st := remoterelations.NewClient(apiCaller)
-	_, err := st.WatchRemoteApplications()
+	client := remoterelations.NewClient(apiCaller)
+	_, err := client.WatchRemoteApplications()
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }
@@ -62,8 +64,8 @@ func (s *remoteRelationsSuite) TestWatchRemoteApplicationRelations(c *gc.C) {
 		callCount++
 		return nil
 	})
-	st := remoterelations.NewClient(apiCaller)
-	_, err := st.WatchRemoteApplicationRelations("db2")
+	client := remoterelations.NewClient(apiCaller)
+	_, err := client.WatchRemoteApplicationRelations("db2")
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }
@@ -72,8 +74,8 @@ func (s *remoteRelationsSuite) TestWatchRemoteApplicationInvalidApplication(c *g
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		return nil
 	})
-	st := remoterelations.NewClient(apiCaller)
-	_, err := st.WatchRemoteApplicationRelations("!@#")
+	client := remoterelations.NewClient(apiCaller)
+	_, err := client.WatchRemoteApplicationRelations("!@#")
 	c.Assert(err, gc.ErrorMatches, `application name "!@#" not valid`)
 }
 
@@ -93,8 +95,159 @@ func (s *remoteRelationsSuite) TestWatchLocalRelationUnits(c *gc.C) {
 		callCount++
 		return nil
 	})
-	st := remoterelations.NewClient(apiCaller)
-	_, err := st.WatchLocalRelationUnits("relation-wordpress:db mysql:db")
+	client := remoterelations.NewClient(apiCaller)
+	_, err := client.WatchLocalRelationUnits("relation-wordpress:db mysql:db")
 	c.Check(err, gc.ErrorMatches, "FAIL")
+	c.Check(callCount, gc.Equals, 1)
+}
+
+func (s *remoteRelationsSuite) TestPublishLocalRelationChange(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "RemoteRelations")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "PublishLocalRelationChange")
+		c.Check(arg, gc.DeepEquals, params.RemoteRelationsChanges{
+			Changes: []params.RemoteRelationsChange{{RemovedRelations: []int{1}}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		callCount++
+		return nil
+	})
+	client := remoterelations.NewClient(apiCaller)
+	err := client.PublishLocalRelationChange(params.RemoteRelationsChange{RemovedRelations: []int{1}})
+	c.Check(err, gc.ErrorMatches, "FAIL")
+	c.Check(callCount, gc.Equals, 1)
+}
+
+func (s *remoteRelationsSuite) TestConsumeRemoteApplicationChange(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "RemoteRelations")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "ConsumeRemoteApplicationChange")
+		c.Check(arg, gc.DeepEquals, params.RemoteApplicationChanges{
+			Changes: []params.RemoteApplicationChange{{ApplicationTag: names.NewApplicationTag("foo").String()}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		callCount++
+		return nil
+	})
+	client := remoterelations.NewClient(apiCaller)
+	err := client.ConsumeRemoteApplicationChange(params.RemoteApplicationChange{
+		ApplicationTag: names.NewApplicationTag("foo").String()})
+	c.Check(err, gc.ErrorMatches, "FAIL")
+	c.Check(callCount, gc.Equals, 1)
+}
+
+func (s *remoteRelationsSuite) TestExportEntities(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "RemoteRelations")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "ExportEntities")
+		c.Check(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "application-foo"}}})
+		c.Assert(result, gc.FitsTypeOf, &params.RemoteEntityIdResults{})
+		*(result.(*params.RemoteEntityIdResults)) = params.RemoteEntityIdResults{
+			Results: []params.RemoteEntityIdResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		callCount++
+		return nil
+	})
+	client := remoterelations.NewClient(apiCaller)
+	result, err := client.ExportEntities([]names.Tag{names.NewApplicationTag("foo")})
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(result, gc.HasLen, 1)
+	c.Check(result[0].Error, gc.ErrorMatches, "FAIL")
+	c.Check(callCount, gc.Equals, 1)
+}
+
+func (s *remoteRelationsSuite) TestRelationUnitSettings(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "RemoteRelations")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "RelationUnitSettings")
+		c.Check(arg, gc.DeepEquals, params.RelationUnits{RelationUnits: []params.RelationUnit{{Relation: "r", Unit: "u"}}})
+		c.Assert(result, gc.FitsTypeOf, &params.SettingsResults{})
+		*(result.(*params.SettingsResults)) = params.SettingsResults{
+			Results: []params.SettingsResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		callCount++
+		return nil
+	})
+	client := remoterelations.NewClient(apiCaller)
+	result, err := client.RelationUnitSettings([]params.RelationUnit{{Relation: "r", Unit: "u"}})
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(result, gc.HasLen, 1)
+	c.Check(result[0].Error, gc.ErrorMatches, "FAIL")
+	c.Check(callCount, gc.Equals, 1)
+}
+
+func (s *remoteRelationsSuite) TestRemoteRelations(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "RemoteRelations")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "RemoteRelations")
+		c.Check(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "relation-foo.db#bar.db"}}})
+		c.Assert(result, gc.FitsTypeOf, &params.RemoteRelationResults{})
+		*(result.(*params.RemoteRelationResults)) = params.RemoteRelationResults{
+			Results: []params.RemoteRelationResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		callCount++
+		return nil
+	})
+	client := remoterelations.NewClient(apiCaller)
+	result, err := client.RemoteRelations([]string{"foo:db bar:db"})
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(result, gc.HasLen, 1)
+	c.Check(result[0].Error, gc.ErrorMatches, "FAIL")
+	c.Check(callCount, gc.Equals, 1)
+}
+
+func (s *remoteRelationsSuite) TestRemoteApplications(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "RemoteRelations")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "RemoteApplications")
+		c.Check(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "application-foo"}}})
+		c.Assert(result, gc.FitsTypeOf, &params.RemoteApplicationResults{})
+		*(result.(*params.RemoteApplicationResults)) = params.RemoteApplicationResults{
+			Results: []params.RemoteApplicationResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		callCount++
+		return nil
+	})
+	client := remoterelations.NewClient(apiCaller)
+	result, err := client.RemoteApplications([]string{"foo"})
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(result, gc.HasLen, 1)
+	c.Check(result[0].Error, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }

--- a/api/remoterelations/remoterelations_test.go
+++ b/api/remoterelations/remoterelations_test.go
@@ -177,6 +177,21 @@ func (s *remoteRelationsSuite) TestExportEntities(c *gc.C) {
 	c.Check(callCount, gc.Equals, 1)
 }
 
+func (s *remoteRelationsSuite) TestExportEntitiesResultCount(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.RemoteEntityIdResults)) = params.RemoteEntityIdResults{
+			Results: []params.RemoteEntityIdResult{
+				{Error: &params.Error{Message: "FAIL"}},
+				{Error: &params.Error{Message: "FAIL"}},
+			},
+		}
+		return nil
+	})
+	client := remoterelations.NewClient(apiCaller)
+	_, err := client.ExportEntities([]names.Tag{names.NewApplicationTag("foo")})
+	c.Check(err, gc.ErrorMatches, `expected 1 result\(s\), got 2`)
+}
+
 func (s *remoteRelationsSuite) TestRelationUnitSettings(c *gc.C) {
 	var callCount int
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
@@ -200,6 +215,21 @@ func (s *remoteRelationsSuite) TestRelationUnitSettings(c *gc.C) {
 	c.Assert(result, gc.HasLen, 1)
 	c.Check(result[0].Error, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
+}
+
+func (s *remoteRelationsSuite) TestRelationUnitSettingsResultsCount(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.SettingsResults)) = params.SettingsResults{
+			Results: []params.SettingsResult{
+				{Error: &params.Error{Message: "FAIL"}},
+				{Error: &params.Error{Message: "FAIL"}},
+			},
+		}
+		return nil
+	})
+	client := remoterelations.NewClient(apiCaller)
+	_, err := client.RelationUnitSettings([]params.RelationUnit{{Relation: "r", Unit: "u"}})
+	c.Check(err, gc.ErrorMatches, `expected 1 result\(s\), got 2`)
 }
 
 func (s *remoteRelationsSuite) TestRemoteRelations(c *gc.C) {
@@ -227,6 +257,21 @@ func (s *remoteRelationsSuite) TestRemoteRelations(c *gc.C) {
 	c.Check(callCount, gc.Equals, 1)
 }
 
+func (s *remoteRelationsSuite) TestRemoteRelationsResultsCount(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.RemoteRelationResults)) = params.RemoteRelationResults{
+			Results: []params.RemoteRelationResult{
+				{Error: &params.Error{Message: "FAIL"}},
+				{Error: &params.Error{Message: "FAIL"}},
+			},
+		}
+		return nil
+	})
+	client := remoterelations.NewClient(apiCaller)
+	_, err := client.RemoteRelations([]string{"foo:db bar:db"})
+	c.Check(err, gc.ErrorMatches, `expected 1 result\(s\), got 2`)
+}
+
 func (s *remoteRelationsSuite) TestRemoteApplications(c *gc.C) {
 	var callCount int
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
@@ -250,4 +295,19 @@ func (s *remoteRelationsSuite) TestRemoteApplications(c *gc.C) {
 	c.Assert(result, gc.HasLen, 1)
 	c.Check(result[0].Error, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
+}
+
+func (s *remoteRelationsSuite) TestRemoteApplicationsResultsCount(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.RemoteApplicationResults)) = params.RemoteApplicationResults{
+			Results: []params.RemoteApplicationResult{
+				{Error: &params.Error{Message: "FAIL"}},
+				{Error: &params.Error{Message: "FAIL"}},
+			},
+		}
+		return nil
+	})
+	client := remoterelations.NewClient(apiCaller)
+	_, err := client.RemoteApplications([]string{"foo"})
+	c.Check(err, gc.ErrorMatches, `expected 1 result\(s\), got 2`)
 }

--- a/apiserver/remoterelations/mock_test.go
+++ b/apiserver/remoterelations/mock_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/remoterelations"
 	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type mockState struct {
@@ -33,12 +34,16 @@ func newMockState() *mockState {
 	}
 }
 
+func (st *mockState) ModelUUID() string {
+	return coretesting.ModelTag.Id()
+}
+
 func (st *mockState) ExportLocalEntity(entity names.Tag) (string, error) {
 	st.MethodCall(st, "ExportLocalEntity", entity)
 	if err := st.NextErr(); err != nil {
 		return "", err
 	}
-	return "", errors.NotImplementedf("ExportLocalEntity")
+	return "token-" + entity.Id(), nil
 }
 
 func (st *mockState) GetRemoteEntity(sourceModel names.ModelTag, token string) (names.Tag, error) {
@@ -201,17 +206,23 @@ type mockRemoteApplication struct {
 	testing.Stub
 	name string
 	url  string
+	life state.Life
 }
 
 func newMockRemoteApplication(name, url string) *mockRemoteApplication {
 	return &mockRemoteApplication{
-		name: name, url: url,
+		name: name, url: url, life: state.Alive,
 	}
 }
 
 func (r *mockRemoteApplication) Name() string {
 	r.MethodCall(r, "Name")
 	return r.name
+}
+
+func (r *mockRemoteApplication) Life() state.Life {
+	r.MethodCall(r, "Life")
+	return r.life
 }
 
 func (r *mockRemoteApplication) URL() (string, bool) {

--- a/apiserver/remoterelations/state.go
+++ b/apiserver/remoterelations/state.go
@@ -13,6 +13,10 @@ import (
 // RemoteRelationState provides the subset of global state required by the
 // remote relations facade.
 type RemoteRelationsState interface {
+	// ModelUUID returns the model UUID for the model
+	// controlled by this state instance.
+	ModelUUID() string
+
 	// KeyRelation returns the existing relation with the given key (which can
 	// be derived unambiguously from the relation's endpoints).
 	KeyRelation(string) (Relation, error)
@@ -111,6 +115,9 @@ type RemoteApplication interface {
 
 	// URL returns the remote application URL, at which it is offered.
 	URL() (string, bool)
+
+	// Life returns the lifecycle state of the application.
+	Life() state.Life
 }
 
 // Application represents the state of a application hosted in the local environment.

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -6,7 +6,9 @@ package remoterelations
 import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker/catacomb"
 )
@@ -15,6 +17,26 @@ var logger = loggo.GetLogger("juju.worker.remoterelations")
 
 // RemoteApplicationsFacade exposes remote relation functionality to a worker.
 type RemoteApplicationsFacade interface {
+	// ExportEntities allocates unique, remote entity IDs for the
+	// given entities in the local model.
+	ExportEntities([]names.Tag) ([]params.RemoteEntityIdResult, error)
+
+	// PublishLocalRelationChange publishes local relation changes to the
+	// model hosting the remote application involved in the relation.
+	PublishLocalRelationChange(params.RemoteRelationsChange) error
+
+	// RelationUnitSettings returns the relation unit settings for the
+	// given relation units in the local model.
+	RelationUnitSettings([]params.RelationUnit) ([]params.SettingsResult, error)
+
+	// RemoteRelations returns information about the cross-model relations
+	// with the specified keys in the local model.
+	RemoteRelations(keys []string) ([]params.RemoteRelationResult, error)
+
+	// RemoteApplications returns the current state of the remote applications with
+	// the specified names in the local model.
+	RemoteApplications(names []string) ([]params.RemoteApplicationResult, error)
+
 	// WatchLocalRelationUnits returns a watcher that notifies of changes to the
 	// local units in the relation with the given key.
 	WatchLocalRelationUnits(relationKey string) (watcher.RelationUnitsWatcher, error)


### PR DESCRIPTION
The remote relations facade layers (api and apiserver) have methods added to support the underlying business logic defined in state. This is all boilerplate which will be used by the remote relations worker in a future PR.

QA: bootstrap lxd