### PR TITLE
provider/maas: persist bridge script

### DIFF
--- a/provider/maas/Makefile
+++ b/provider/maas/Makefile
@@ -8,10 +8,7 @@ bridgescript.go: add-juju-bridge.py Makefile
 	$(RM) $@
 	echo -n '// This file is auto generated. Edits will be lost.\n\n' >> $@
 	echo -n 'package maas\n\n' >> $@
-	echo -n '//go:generate make -q\n\n' >> $@
-	echo -n 'import "path"\n\n' >> $@
 	echo -n 'const bridgeScriptName = "add-juju-bridge.py"\n\n' >> $@
-	echo -n 'var bridgeScriptPath = path.Join("/var/tmp", bridgeScriptName)\n\n' >> $@
 	echo -n "const bridgeScriptPython = \`" >> $@
 	cat add-juju-bridge.py >> $@
 	echo -n '`\n' >> $@

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -2,13 +2,7 @@
 
 package maas
 
-//go:generate make -q
-
-import "path"
-
 const bridgeScriptName = "add-juju-bridge.py"
-
-var bridgeScriptPath = path.Join("/var/tmp", bridgeScriptName)
 
 const bridgeScriptPython = `#!/usr/bin/env python
 

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1407,11 +1407,9 @@ func (environ *maasEnviron) newCloudinitConfig(hostname, forSeries string, inter
 			break
 		}
 
-		var bridgeScriptPath string
-
-		bridgeScriptPath, err = bridgeScriptPathForSeries(forSeries)
+		bridgeScriptPath, err := bridgeScriptPathForSeries(forSeries)
 		if err != nil {
-			return nil, err
+			return nil, errors.Trace(err)
 		}
 
 		cloudcfg.AddPackage("bridge-utils")

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -31,6 +32,7 @@ import (
 	"github.com/juju/juju/environs/storage"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state/multiwatcher"
@@ -1318,9 +1320,10 @@ func (environ *maasEnviron) selectNode2(args selectNodeArgs) (maasInstance, erro
 	return inst, nil
 }
 
-// setupJujuNetworking returns a string representing the script to run
-// in order to prepare the Juju-specific networking config on a node.
-func setupJujuNetworking(interfacesToBridge []string) string {
+// bridgeScriptWrapperForCloudInit returns a string representing the script
+// to run in order to prepare the Juju-specific networking config on a
+// node during cloud-init.
+func bridgeScriptWrapperForCloudInit(bridgeScriptPath string, interfacesToBridge []string) string {
 	// For ubuntu series < xenial we prefer python2 over python3
 	// as we don't want to invalidate lots of testing against
 	// known cloud-image contents. A summary of Ubuntu releases
@@ -1337,8 +1340,6 @@ func setupJujuNetworking(interfacesToBridge []string) string {
 	// going forward:  python 3 only
 
 	return fmt.Sprintf(`
-trap 'rm -f %[1]q' EXIT
-
 if [ -x /usr/bin/python2 ]; then
     juju_networking_preferred_python_binary=/usr/bin/python2
 elif [ -x /usr/bin/python3 ]; then
@@ -1373,10 +1374,6 @@ fi`,
 	)
 }
 
-func renderEtcNetworkInterfacesScript(interfacesToBridge ...string) string {
-	return setupJujuNetworking(interfacesToBridge)
-}
-
 // newCloudinitConfig creates a cloudinit.Config structure suitable as a base
 // for initialising a MAAS node.
 func (environ *maasEnviron) newCloudinitConfig(hostname, forSeries string, interfacesToBridge []string) (cloudinit.CloudConfig, error) {
@@ -1409,9 +1406,17 @@ func (environ *maasEnviron) newCloudinitConfig(hostname, forSeries string, inter
 			)
 			break
 		}
+
+		var bridgeScriptPath string
+
+		bridgeScriptPath, err = bridgeScriptPathForSeries(forSeries)
+		if err != nil {
+			return nil, err
+		}
+
 		cloudcfg.AddPackage("bridge-utils")
 		cloudcfg.AddBootTextFile(bridgeScriptPath, bridgeScriptPython, 0755)
-		cloudcfg.AddScripts(setupJujuNetworking(interfacesToBridge))
+		cloudcfg.AddScripts(bridgeScriptWrapperForCloudInit(bridgeScriptPath, interfacesToBridge))
 	}
 	return cloudcfg, nil
 }
@@ -2413,4 +2418,12 @@ func (env *maasEnviron) releaseContainerAddresses2(macAddresses []string) error 
 		}
 	}
 	return nil
+}
+
+func bridgeScriptPathForSeries(series string) (string, error) {
+	dataDir, err := paths.DataDir(series)
+	if err != nil {
+		return "", err
+	}
+	return path.Join(dataDir, bridgeScriptName), nil
 }

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -146,7 +146,10 @@ func (*environSuite) TestNewCloudinitConfig(c *gc.C) {
 	cfg := getSimpleTestConfig(c, nil)
 	env, err := maas.NewEnviron(getSimpleCloudSpec(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	modifyNetworkScript := maas.RenderEtcNetworkInterfacesScript("eth0", "eth1")
+	var path string
+	path, err = maas.BridgeScriptPathForSeries("quantal")
+	c.Assert(err, jc.ErrorIsNil)
+	modifyNetworkScript := maas.BridgeScriptWrapperForCloudInit(path, []string{"eth0", "eth1"})
 	script := expectedCloudinitConfig
 	script = append(script, modifyNetworkScript)
 	cloudcfg, err := maas.NewCloudinitConfig(env, "testing.invalid", "quantal", []string{"eth0", "eth1"})
@@ -168,14 +171,18 @@ func (*environSuite) TestNewCloudinitConfigWithDisabledNetworkManagement(c *gc.C
 	c.Assert(cloudcfg.RunCmds(), jc.DeepEquals, expectedCloudinitConfig)
 }
 
-func (*environSuite) TestRenderEtcNetworkInterfacesScriptMultipleNames(c *gc.C) {
-	script := maas.RenderEtcNetworkInterfacesScript("eth0", "eth0:1", "eth2", "eth1")
+func (*environSuite) xTestRenderEtcNetworkInterfacesScriptMultipleNames(c *gc.C) {
+	path, err := maas.BridgeScriptPathForSeries("quantal")
+	c.Assert(err, jc.ErrorIsNil)
+	script := maas.BridgeScriptWrapperForCloudInit(path, []string{"eth0", "eth0:1", "eth2", "eth1"})
 	c.Check(script, jc.Contains, `--interfaces-to-bridge="eth0 eth0:1 eth2 eth1"`)
 	c.Check(script, jc.Contains, `--bridge-prefix="br-"`)
 }
 
-func (*environSuite) TestRenderEtcNetworkInterfacesScriptSingleName(c *gc.C) {
-	script := maas.RenderEtcNetworkInterfacesScript("eth0")
+func (*environSuite) xTestRenderEtcNetworkInterfacesScriptSingleName(c *gc.C) {
+	path, err := maas.BridgeScriptPathForSeries("quantal")
+	c.Assert(err, jc.ErrorIsNil)
+	script := maas.BridgeScriptWrapperForCloudInit(path, []string{"eth0"})
 	c.Check(script, jc.Contains, `--interfaces-to-bridge="eth0"`)
 	c.Check(script, jc.Contains, `--bridge-prefix="br-"`)
 }

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -171,7 +171,7 @@ func (*environSuite) TestNewCloudinitConfigWithDisabledNetworkManagement(c *gc.C
 	c.Assert(cloudcfg.RunCmds(), jc.DeepEquals, expectedCloudinitConfig)
 }
 
-func (*environSuite) xTestRenderEtcNetworkInterfacesScriptMultipleNames(c *gc.C) {
+func (*environSuite) TestRenderEtcNetworkInterfacesScriptMultipleNames(c *gc.C) {
 	path, err := maas.BridgeScriptPathForSeries("quantal")
 	c.Assert(err, jc.ErrorIsNil)
 	script := maas.BridgeScriptWrapperForCloudInit(path, []string{"eth0", "eth0:1", "eth2", "eth1"})
@@ -179,7 +179,7 @@ func (*environSuite) xTestRenderEtcNetworkInterfacesScriptMultipleNames(c *gc.C)
 	c.Check(script, jc.Contains, `--bridge-prefix="br-"`)
 }
 
-func (*environSuite) xTestRenderEtcNetworkInterfacesScriptSingleName(c *gc.C) {
+func (*environSuite) TestRenderEtcNetworkInterfacesScriptSingleName(c *gc.C) {
 	path, err := maas.BridgeScriptPathForSeries("quantal")
 	c.Assert(err, jc.ErrorIsNil)
 	script := maas.BridgeScriptWrapperForCloudInit(path, []string{"eth0"})

--- a/provider/maas/export_test.go
+++ b/provider/maas/export_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 var (
-	ShortAttempt = &shortAttempt
+	ShortAttempt                    = &shortAttempt
+	BridgeScriptWrapperForCloudInit = bridgeScriptWrapperForCloudInit
+	BridgeScriptPathForSeries       = bridgeScriptPathForSeries
 )
 
 func GetMAASClient(env environs.Environ) *gomaasapi.MAASObject {
@@ -21,5 +23,3 @@ func GetMAASClient(env environs.Environ) *gomaasapi.MAASObject {
 func NewCloudinitConfig(env environs.Environ, hostname, series string, interfacesToBridge []string) (cloudinit.CloudConfig, error) {
 	return env.(*maasEnviron).newCloudinitConfig(hostname, series, interfacesToBridge)
 }
-
-var RenderEtcNetworkInterfacesScript = renderEtcNetworkInterfacesScript


### PR DESCRIPTION
Previously the MAAS script that bridges interfaces was deleted from
the filesystem after it had run because it was a one-time only event.

As we are now moving towards dynamic bridging we need permanent access
to the script; the script is now persisted in /var/lib/juju. That path
is not hard-coded, it comes from calling: paths.DataDir(series).