### PR TITLE
dependencies.tsv: Update juju/utils

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -46,7 +46,7 @@ github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-0
 github.com/juju/testing	git	3c01e9e4a3208dc72e39b030738b46362ddcfeda	2016-11-07T14:13:10Z
 github.com/juju/txn	git	28898197906200d603394d8e4ce537436529f1c5	2016-11-16T04:07:55Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils	git	a84e60da6d18975eaff902cd51922b4da470dd62	2016-11-01T02:02:32Z
+github.com/juju/utils	git	4559f404c960a3c9c634529159de91fa5993af52	2016-11-22T15:00:28Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z


### PR DESCRIPTION
Fixes lp:1468752 by bringing in new code from utils to
handle carriage returns when using gocrypto ssh on
windows clients.

QA steps
----

* Build and bootstrap on windows
* `juju switch controller`
* `juju ssh 0`
* Run commands on the remote machine, ensure they work