### PR TITLE
dependencies.tsv: Update juju/utils on 2.0

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -47,10 +47,10 @@ const (
 
 // These are base values used for the corresponding defaults.
 var (
-	logDir          = paths.MustSucceed(paths.LogDir(series.HostSeries()))
-	dataDir         = paths.MustSucceed(paths.DataDir(series.HostSeries()))
-	confDir         = paths.MustSucceed(paths.ConfDir(series.HostSeries()))
-	metricsSpoolDir = paths.MustSucceed(paths.MetricsSpoolDir(series.HostSeries()))
+	logDir          = paths.MustSucceed(paths.LogDir(series.MustHostSeries()))
+	dataDir         = paths.MustSucceed(paths.DataDir(series.MustHostSeries()))
+	confDir         = paths.MustSucceed(paths.ConfDir(series.MustHostSeries()))
+	metricsSpoolDir = paths.MustSucceed(paths.MetricsSpoolDir(series.MustHostSeries()))
 )
 
 // Agent exposes the agent's configuration to other components. This

--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -256,9 +256,13 @@ func initBootstrapMachine(c agent.ConfigSetter, st *state.State, args Initialize
 	if args.BootstrapMachineHardwareCharacteristics != nil {
 		hardware = *args.BootstrapMachineHardwareCharacteristics
 	}
+	hostSeries, err := series.HostSeries()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	m, err := st.AddOneMachine(state.MachineTemplate{
 		Addresses:               args.BootstrapMachineAddresses,
-		Series:                  series.HostSeries(),
+		Series:                  hostSeries,
 		Nonce:                   agent.BootstrapNonce,
 		Constraints:             args.BootstrapMachineConstraints,
 		InstanceId:              args.BootstrapMachineInstanceId,
@@ -266,7 +270,7 @@ func initBootstrapMachine(c agent.ConfigSetter, st *state.State, args Initialize
 		Jobs: jobs,
 	})
 	if err != nil {
-		return nil, errors.Errorf("cannot create bootstrap machine in state: %v", err)
+		return nil, errors.Annotate(err, "cannot create bootstrap machine in state")
 	}
 	if m.Id() != agent.BootstrapMachineId {
 		return nil, errors.Errorf("bootstrap machine expected id 0, got %q", m.Id())

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -258,7 +258,7 @@ LXC_BRIDGE="ignored"`[1:])
 	// Check that the bootstrap machine looks correct.
 	c.Assert(m.Id(), gc.Equals, "0")
 	c.Assert(m.Jobs(), gc.DeepEquals, []state.MachineJob{state.JobManageModel})
-	c.Assert(m.Series(), gc.Equals, series.HostSeries())
+	c.Assert(m.Series(), gc.Equals, series.MustHostSeries())
 	c.Assert(m.CheckProvisioned(agent.BootstrapNonce), jc.IsTrue)
 	c.Assert(m.Addresses(), jc.DeepEquals, filteredAddrs)
 	gotBootstrapConstraints, err := m.Constraints()

--- a/api/certpool.go
+++ b/api/certpool.go
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/juju/juju/paths"
 )
 
-var certDir = filepath.FromSlash(paths.MustSucceed(paths.CertDir(series.HostSeries())))
+var certDir = filepath.FromSlash(paths.MustSucceed(paths.CertDir(series.MustHostSeries())))
 
 // CreateCertPool creates a new x509.CertPool and adds in the caCert passed
 // in.  All certs from the cert directory (/etc/juju/cert.d on ubuntu) are

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -633,7 +633,7 @@ func (s *provisionerSuite) testFindTools(c *gc.C, matchArch bool, apiError, logi
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	var toolsList = coretools.List{&coretools.Tools{Version: current}}
 	var called bool
@@ -649,7 +649,7 @@ func (s *provisionerSuite) testFindTools(c *gc.C, matchArch bool, apiError, logi
 		c.Assert(request, gc.Equals, "FindTools")
 		expected := params.FindToolsParams{
 			Number:       jujuversion.Current,
-			Series:       series.HostSeries(),
+			Series:       series.MustHostSeries(),
 			Arch:         a,
 			MinorVersion: -1,
 			MajorVersion: -1,
@@ -662,7 +662,7 @@ func (s *provisionerSuite) testFindTools(c *gc.C, matchArch bool, apiError, logi
 		}
 		return apiError
 	})
-	apiList, err := s.provisioner.FindTools(jujuversion.Current, series.HostSeries(), a)
+	apiList, err := s.provisioner.FindTools(jujuversion.Current, series.MustHostSeries(), a)
 	c.Assert(called, jc.IsTrue)
 	if apiError != nil {
 		c.Assert(err, gc.Equals, apiError)

--- a/api/upgrader/unitupgrader_test.go
+++ b/api/upgrader/unitupgrader_test.go
@@ -40,7 +40,7 @@ var _ = gc.Suite(&unitUpgraderSuite{})
 var current = version.Binary{
 	Number: jujuversion.Current,
 	Arch:   arch.HostArch(),
-	Series: series.HostSeries(),
+	Series: series.MustHostSeries(),
 }
 
 func (s *unitUpgraderSuite) SetUpTest(c *gc.C) {

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -37,7 +37,7 @@ var _ = gc.Suite(&toolsSuite{})
 var current = version.Binary{
 	Number: jujuversion.Current,
 	Arch:   arch.HostArch(),
-	Series: series.HostSeries(),
+	Series: series.MustHostSeries(),
 }
 
 func (s *toolsSuite) SetUpTest(c *gc.C) {
@@ -224,7 +224,7 @@ func (s *toolsSuite) TestFindToolsExactInStorage(c *gc.C) {
 	}
 
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	s.PatchValue(&series.HostSeries, func() string { return "trusty" })
+	s.PatchValue(&series.MustHostSeries, func() string { return "trusty" })
 	s.PatchValue(&jujuversion.Current, version.MustParseBinary("1.22-beta1-trusty-amd64").Number)
 	s.testFindToolsExact(c, mockToolsStorage, true, true)
 	s.PatchValue(&jujuversion.Current, version.MustParseBinary("1.22.0-trusty-amd64").Number)
@@ -244,7 +244,7 @@ func (s *toolsSuite) testFindToolsExact(c *gc.C, t common.ToolsStorageGetter, in
 	s.PatchValue(common.EnvtoolsFindTools, func(e environs.Environ, major, minor int, stream string, filter coretools.Filter) (list coretools.List, err error) {
 		called = true
 		c.Assert(filter.Number, gc.Equals, jujuversion.Current)
-		c.Assert(filter.Series, gc.Equals, series.HostSeries())
+		c.Assert(filter.Series, gc.Equals, series.MustHostSeries())
 		c.Assert(filter.Arch, gc.Equals, arch.HostArch())
 		if develVersion {
 			c.Assert(stream, gc.Equals, "devel")
@@ -258,7 +258,7 @@ func (s *toolsSuite) testFindToolsExact(c *gc.C, t common.ToolsStorageGetter, in
 		Number:       jujuversion.Current,
 		MajorVersion: -1,
 		MinorVersion: -1,
-		Series:       series.HostSeries(),
+		Series:       series.MustHostSeries(),
 		Arch:         arch.HostArch(),
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -305,7 +305,7 @@ func (s *toolsSuite) TestDownloadModelUUIDPath(c *gc.C) {
 	v := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	tools := s.storeFakeTools(c, s.State, "abc", binarystorage.Metadata{
 		Version: v.String(),
@@ -320,7 +320,7 @@ func (s *toolsSuite) TestDownloadOtherModelUUIDPath(c *gc.C) {
 	v := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	tools := s.storeFakeTools(c, envState, "abc", binarystorage.Metadata{
 		Version: v.String(),
@@ -334,7 +334,7 @@ func (s *toolsSuite) TestDownloadTopLevelPath(c *gc.C) {
 	v := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	tools := s.storeFakeTools(c, s.State, "abc", binarystorage.Metadata{
 		Version: v.String(),
@@ -368,7 +368,7 @@ func (s *toolsSuite) TestDownloadFetchesAndVerifiesSize(c *gc.C) {
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	tools := envtesting.AssertUploadFakeToolsVersions(c, stor, "released", "released", current)[0]
 	err := stor.Put(envtools.StorageName(tools.Version, "released"), strings.NewReader("!"), 1)
@@ -387,7 +387,7 @@ func (s *toolsSuite) TestDownloadFetchesAndVerifiesHash(c *gc.C) {
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	tools := envtesting.AssertUploadFakeToolsVersions(c, stor, "released", "released", current)[0]
 	sameSize := strings.Repeat("!", int(tools.Size))
@@ -458,7 +458,7 @@ func (s *toolsSuite) TestDownloadRejectsWrongModelUUIDPath(c *gc.C) {
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	resp := s.downloadRequest(c, current, "dead-beef-123456")
 	s.assertErrorResponse(c, resp, http.StatusNotFound, `unknown model: "dead-beef-123456"`)

--- a/apiserver/upgrader/unitupgrader_test.go
+++ b/apiserver/upgrader/unitupgrader_test.go
@@ -43,7 +43,7 @@ var _ = gc.Suite(&unitUpgraderSuite{})
 var current = version.Binary{
 	Number: jujuversion.Current,
 	Arch:   arch.HostArch(),
-	Series: series.HostSeries(),
+	Series: series.MustHostSeries(),
 }
 
 func (s *unitUpgraderSuite) SetUpTest(c *gc.C) {
@@ -197,7 +197,7 @@ func (s *unitUpgraderSuite) TestSetToolsRefusesWrongAgent(c *gc.C) {
 				Version: version.Binary{
 					Number: jujuversion.Current,
 					Arch:   arch.HostArch(),
-					Series: series.HostSeries(),
+					Series: series.MustHostSeries(),
 				},
 			},
 		}},
@@ -212,7 +212,7 @@ func (s *unitUpgraderSuite) TestSetTools(c *gc.C) {
 	cur := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	_, err := s.rawUnit.AgentTools()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
@@ -270,7 +270,7 @@ func (s *unitUpgraderSuite) TestDesiredVersionNoticesMixedAgents(c *gc.C) {
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	err := s.rawMachine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
@@ -295,7 +295,7 @@ func (s *unitUpgraderSuite) TestDesiredVersionForAgent(c *gc.C) {
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	err := s.rawMachine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/upgrader/upgrader_test.go
+++ b/apiserver/upgrader/upgrader_test.go
@@ -152,7 +152,7 @@ func (s *upgraderSuite) TestToolsForAgent(c *gc.C) {
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	agent := params.Entity{Tag: s.rawMachine.Tag().String()}
 
@@ -196,7 +196,7 @@ func (s *upgraderSuite) TestSetToolsRefusesWrongAgent(c *gc.C) {
 				Version: version.Binary{
 					Number: jujuversion.Current,
 					Arch:   arch.HostArch(),
-					Series: series.HostSeries(),
+					Series: series.MustHostSeries(),
 				},
 			},
 		}},
@@ -211,7 +211,7 @@ func (s *upgraderSuite) TestSetTools(c *gc.C) {
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	_, err := s.rawMachine.AgentTools()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
@@ -295,7 +295,7 @@ func (s *upgraderSuite) bumpDesiredAgentVersion(c *gc.C) version.Number {
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	s.apiMachine.SetAgentVersion(current)
 	s.rawMachine.SetAgentVersion(current)

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -90,7 +90,7 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 	// override this.
 	s.PatchValue(&jujuversion.Current, v100p64.Number)
 	s.PatchValue(&arch.HostArch, func() string { return v100p64.Arch })
-	s.PatchValue(&series.HostSeries, func() string { return v100p64.Series })
+	s.PatchValue(&series.MustHostSeries, func() string { return v100p64.Series })
 	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.Ubuntu })
 
 	// Set up a local source with tools.
@@ -176,7 +176,7 @@ type bootstrapTest struct {
 
 func (s *BootstrapSuite) patchVersionAndSeries(c *gc.C, hostSeries string) {
 	resetJujuXDGDataHome(c)
-	s.PatchValue(&series.HostSeries, func() string { return hostSeries })
+	s.PatchValue(&series.MustHostSeries, func() string { return hostSeries })
 	s.patchVersion(c)
 }
 
@@ -204,7 +204,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 		bootstrapVersion = version.MustParseBinary(useVersion)
 		restore = restore.Add(testing.PatchValue(&jujuversion.Current, bootstrapVersion.Number))
 		restore = restore.Add(testing.PatchValue(&arch.HostArch, func() string { return bootstrapVersion.Arch }))
-		restore = restore.Add(testing.PatchValue(&series.HostSeries, func() string { return bootstrapVersion.Series }))
+		restore = restore.Add(testing.PatchValue(&series.MustHostSeries, func() string { return bootstrapVersion.Series }))
 		bootstrapVersion.Build = 1
 		if test.upload != "" {
 			uploadVers := version.MustParseBinary(test.upload)
@@ -1096,7 +1096,7 @@ func (s *BootstrapSuite) setupAutoUploadTest(c *gc.C, vers, ser string) {
 	// Set the current version to be something for which there are no tools
 	// so we can test that an upload is forced.
 	s.PatchValue(&jujuversion.Current, version.MustParse(vers))
-	s.PatchValue(&series.HostSeries, func() string { return ser })
+	s.PatchValue(&series.MustHostSeries, func() string { return ser })
 
 	// Create home with dummy provider and remove all
 	// of its envtools.
@@ -1104,7 +1104,7 @@ func (s *BootstrapSuite) setupAutoUploadTest(c *gc.C, vers, ser string) {
 }
 
 func (s *BootstrapSuite) TestAutoUploadAfterFailedSync(c *gc.C) {
-	s.PatchValue(&series.HostSeries, func() string { return series.LatestLts() })
+	s.PatchValue(&series.MustHostSeries, func() string { return series.LatestLts() })
 	s.setupAutoUploadTest(c, "1.7.3", "quantal")
 	// Run command and check for that upload has been run for tools matching
 	// the current juju version.

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -209,7 +209,7 @@ func (m main) juju1xVersion() (ver string, exists bool) {
 
 func shouldWarnJuju1x() bool {
 	// this code only applies to Ubuntu, where we renamed Juju 1.x to juju-1.
-	ostype, err := series.GetOSFromSeries(series.HostSeries())
+	ostype, err := series.GetOSFromSeries(series.MustHostSeries())
 	if err != nil || ostype != utilsos.Ubuntu {
 		return false
 	}

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -125,7 +125,7 @@ func (s *MainSuite) TestRunMain(c *gc.C) {
 		out: version.Binary{
 			Number: jujuversion.Current,
 			Arch:   arch.HostArch(),
-			Series: series.HostSeries(),
+			Series: series.MustHostSeries(),
 		}.String() + "\n",
 	}} {
 		c.Logf("test %d: %s", i, t.summary)
@@ -167,7 +167,7 @@ func (s *MainSuite) TestFirstRun2xFrom1xOnUbuntu(c *gc.C) {
 
 	// Code should only run on ubuntu series, so patch out the series for
 	// when non-ubuntu OSes run this test.
-	s.PatchValue(&series.HostSeries, func() string { return "trusty" })
+	s.PatchValue(&series.MustHostSeries, func() string { return "trusty" })
 
 	argChan := make(chan []string, 1)
 
@@ -215,7 +215,7 @@ Since Juju 2 is being run for the first time, downloading latest cloud informati
 
 func (s *MainSuite) TestFirstRun2xFrom1xNotUbuntu(c *gc.C) {
 	// Code should only run on ubuntu series, so pretend to be something else.
-	s.PatchValue(&series.HostSeries, func() string { return "win8" })
+	s.PatchValue(&series.MustHostSeries, func() string { return "win8" })
 
 	argChan := make(chan []string, 1)
 
@@ -255,7 +255,7 @@ Since Juju 2 is being run for the first time, downloading latest cloud informati
 func (s *MainSuite) TestNoWarn1xWith2xData(c *gc.C) {
 	// Code should only rnu on ubuntu series, so patch out the series for
 	// when non-ubuntu OSes run this test.
-	s.PatchValue(&series.HostSeries, func() string { return "trusty" })
+	s.PatchValue(&series.MustHostSeries, func() string { return "trusty" })
 
 	argChan := make(chan []string, 1)
 
@@ -288,7 +288,7 @@ func (s *MainSuite) TestNoWarn1xWith2xData(c *gc.C) {
 func (s *MainSuite) TestNoWarnWithNo1xOr2xData(c *gc.C) {
 	// Code should only rnu on ubuntu series, so patch out the series for
 	// when non-ubuntu OSes run this test.
-	s.PatchValue(&series.HostSeries, func() string { return "trusty" })
+	s.PatchValue(&series.MustHostSeries, func() string { return "trusty" })
 
 	argChan := make(chan []string, 1)
 	// we shouldn't actually be running anything, but if we do, this will
@@ -370,7 +370,7 @@ func checkVersionOutput(c *gc.C, output string) {
 	ver := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 
 	c.Check(output, gc.Equals, ver.String()+"\n")

--- a/cmd/juju/commands/synctools_test.go
+++ b/cmd/juju/commands/synctools_test.go
@@ -263,7 +263,7 @@ func (s *syncToolsSuite) TestAPIAdapterUploadTools(c *gc.C) {
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	fake := fakeSyncToolsAPI{
 		uploadTools: func(r io.Reader, v version.Binary, additionalSeries ...string) (coretools.List, error) {

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -314,7 +314,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJuju(c *gc.C) {
 		current := version.MustParseBinary(test.currentVersion)
 		s.PatchValue(&jujuversion.Current, current.Number)
 		s.PatchValue(&arch.HostArch, func() string { return current.Arch })
-		s.PatchValue(&series.HostSeries, func() string { return current.Series })
+		s.PatchValue(&series.MustHostSeries, func() string { return current.Series })
 		com := newUpgradeJujuCommand(test.upgradeMap)
 		if err := coretesting.InitCommand(com, test.args); err != nil {
 			if test.expectInitErr != "" {
@@ -381,7 +381,7 @@ func (s *UpgradeJujuSuite) checkToolsUploaded(c *gc.C, vers version.Binary, agen
 	expectContent := version.Binary{
 		Number: agentVersion,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	checkToolsContent(c, data, "jujud contents "+expectContent.String())
 }
@@ -448,7 +448,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJujuWithRealUpload(c *gc.C) {
 	vers := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	vers.Build = 1
 	s.checkToolsUploaded(c, vers, vers.Number)
@@ -620,7 +620,7 @@ func (s *UpgradeJujuSuite) setUpEnvAndTools(c *gc.C, currentVersion string, agen
 	current := version.MustParseBinary(currentVersion)
 	s.PatchValue(&jujuversion.Current, current.Number)
 	s.PatchValue(&arch.HostArch, func() string { return current.Arch })
-	s.PatchValue(&series.HostSeries, func() string { return current.Series })
+	s.PatchValue(&series.MustHostSeries, func() string { return current.Series })
 
 	toolsDir := c.MkDir()
 	updateAttrs := map[string]interface{}{
@@ -885,7 +885,7 @@ func NewFakeUpgradeJujuAPI(c *gc.C, st *state.State) *fakeUpgradeJujuAPI {
 	nextVersion := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	nextVersion.Minor++
 	return &fakeUpgradeJujuAPI{

--- a/cmd/jujud/agent/agent_test.go
+++ b/cmd/jujud/agent/agent_test.go
@@ -28,7 +28,7 @@ type acCreator func() (cmd.Command, AgentConf)
 func CheckAgentCommand(c *gc.C, create acCreator, args []string) cmd.Command {
 	com, conf := create()
 	err := coretesting.InitCommand(com, args)
-	dataDir, err := paths.DataDir(series.HostSeries())
+	dataDir, err := paths.DataDir(series.MustHostSeries())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(conf.DataDir(), gc.Equals, dataDir)
 	badArgs := append(args, "--data-dir", "")

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -113,7 +113,7 @@ func (s *AgentSuite) PrimeAgent(c *gc.C, tag names.Tag, password string) (agent.
 	vers := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	return s.PrimeAgentVersion(c, tag, password, vers)
 }
@@ -163,7 +163,7 @@ func (s *AgentSuite) PrimeStateAgent(c *gc.C, tag names.Tag, password string) (a
 	vers := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	return s.PrimeStateAgentVersion(c, tag, password, vers)
 }

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -92,8 +92,8 @@ import (
 
 var (
 	logger       = loggo.GetLogger("juju.cmd.jujud")
-	jujuRun      = paths.MustSucceed(paths.JujuRun(series.HostSeries()))
-	jujuDumpLogs = paths.MustSucceed(paths.JujuDumpLogs(series.HostSeries()))
+	jujuRun      = paths.MustSucceed(paths.JujuRun(series.MustHostSeries()))
+	jujuDumpLogs = paths.MustSucceed(paths.JujuDumpLogs(series.MustHostSeries()))
 
 	// The following are defined as variables to allow the tests to
 	// intercept calls to the functions. In every case, they should

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -511,7 +511,7 @@ func (s *MachineSuite) testUpgradeRequest(c *gc.C, agent runner, tag string, cur
 	newVers := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	newVers.Patch++
 	newTools := envtesting.AssertUploadFakeToolsVersions(
@@ -642,7 +642,7 @@ func (s *MachineSuite) assertAgentSetsToolsVersion(c *gc.C, job state.MachineJob
 	vers := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	vers.Minor++
 	m, _, _ := s.primeAgentVersion(c, vers, job)
@@ -1184,7 +1184,7 @@ func (s *MachineSuite) TestMachineAgentIgnoreAddressesContainer(c *gc.C) {
 	vers := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	s.primeAgentWithMachine(c, m, vers)
 	a := s.newAgent(c, m)

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -184,7 +184,7 @@ func (s *UnitSuite) TestUpgrade(c *gc.C) {
 	newVers := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	newVers.Patch++
 	envtesting.AssertUploadFakeToolsVersions(
@@ -220,7 +220,7 @@ func (s *UnitSuite) TestUpgradeFailsWithoutTools(c *gc.C) {
 	newVers := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	newVers.Patch++
 	err := machine.SetAgentVersion(newVers)
@@ -262,7 +262,7 @@ func (s *UnitSuite) TestAgentSetsToolsVersion(c *gc.C) {
 	vers := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	vers.Minor++
 	err := unit.SetAgentVersion(vers)
@@ -288,7 +288,7 @@ func (s *UnitSuite) TestAgentSetsToolsVersion(c *gc.C) {
 			current := version.Binary{
 				Number: jujuversion.Current,
 				Arch:   arch.HostArch(),
-				Series: series.HostSeries(),
+				Series: series.MustHostSeries(),
 			}
 			c.Assert(agentTools.Version, gc.DeepEquals, current)
 			done = true

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -132,7 +132,7 @@ func (s *commonMachineSuite) primeAgent(c *gc.C, jobs ...state.MachineJob) (m *s
 	vers := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	return s.primeAgentVersion(c, vers, jobs...)
 }

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -153,10 +153,14 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		// tools can actually be found, or else bootstrap won't complete.
 		stream := envtools.PreferredStream(&desiredVersion, args.ControllerModelConfig.Development(), args.ControllerModelConfig.AgentStream())
 		logger.Infof("newer tools requested, looking for %v in stream %v", desiredVersion, stream)
+		hostSeries, err := series.HostSeries()
+		if err != nil {
+			return errors.Trace(err)
+		}
 		filter := tools.Filter{
 			Number: desiredVersion,
 			Arch:   arch.HostArch(),
-			Series: series.HostSeries(),
+			Series: hostSeries,
 		}
 		_, toolsErr := envtools.FindTools(env, -1, -1, stream, filter)
 		if toolsErr == nil {
@@ -359,10 +363,14 @@ func (c *BootstrapCommand) populateTools(st *state.State, env environs.Environ) 
 	agentConfig := c.CurrentConfig()
 	dataDir := agentConfig.DataDir()
 
+	hostSeries, err := series.HostSeries()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: hostSeries,
 	}
 	tools, err := agenttools.ReadTools(dataDir, current)
 	if err != nil {

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -123,7 +123,7 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	toolsDir := filepath.FromSlash(agenttools.SharedToolsDir(s.dataDir, current))
 	err := os.MkdirAll(toolsDir, 0755)
@@ -659,7 +659,7 @@ func (s *BootstrapSuite) TestUploadedToolsMetadata(c *gc.C) {
 		Version: version.Binary{
 			Number: jujuversion.Current,
 			Arch:   arch.HostArch(),
-			Series: series.HostSeries(),
+			Series: series.MustHostSeries(),
 		},
 		URL: "file:///does/not/matter",
 	})
@@ -697,14 +697,14 @@ func (s *BootstrapSuite) testToolsMetadata(c *gc.C, exploded bool) {
 		for _, ser := range series.SupportedSeries() {
 			os, err := series.GetOSFromSeries(ser)
 			c.Assert(err, jc.ErrorIsNil)
-			hostos, err := series.GetOSFromSeries(series.HostSeries())
+			hostos, err := series.GetOSFromSeries(series.MustHostSeries())
 			c.Assert(err, jc.ErrorIsNil)
 			if os == hostos {
 				expectedSeries.Add(ser)
 			}
 		}
 	} else {
-		expectedSeries.Add(series.HostSeries())
+		expectedSeries.Add(series.MustHostSeries())
 	}
 
 	storage, err := st.ToolsStorage()

--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	logger            = loggo.GetLogger("juju.cmd.jujud.util")
-	DataDir           = paths.MustSucceed(paths.DataDir(series.HostSeries()))
+	DataDir           = paths.MustSucceed(paths.DataDir(series.MustHostSeries()))
 	EnsureMongoServer = mongo.EnsureServer
 )
 

--- a/cmd/supercommand.go
+++ b/cmd/supercommand.go
@@ -41,7 +41,7 @@ func NewSuperCommand(p cmd.SuperCommandParams) *cmd.SuperCommand {
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 
 	// p.Version should be a version.Binary, but juju/cmd does not

--- a/container/kvm/initialisation.go
+++ b/container/kvm/initialisation.go
@@ -4,6 +4,7 @@
 package kvm
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/utils/packaging/manager"
 	"github.com/juju/utils/series"
 
@@ -34,7 +35,11 @@ func (ci *containerInitialiser) Initialise() error {
 // getPackageManager is a helper function which returns the
 // package manager implementation for the current system.
 func getPackageManager() (manager.PackageManager, error) {
-	return manager.NewPackageManager(series.HostSeries())
+	hostSeries, err := series.HostSeries()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return manager.NewPackageManager(hostSeries)
 }
 
 func ensureDependencies() error {

--- a/container/lxd/initialisation_test.go
+++ b/container/lxd/initialisation_test.go
@@ -94,7 +94,7 @@ func (s *InitialiserSuite) TestLTSSeriesPackages(c *gc.C) {
 	paccmder, err := commands.NewPackageCommander("trusty")
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.PatchValue(&series.HostSeries, func() string { return "trusty" })
+	s.PatchValue(&series.MustHostSeries, func() string { return "trusty" })
 	container := NewContainerInitialiser("trusty")
 
 	err = container.Initialise()

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -45,8 +45,8 @@ github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-0
 github.com/juju/testing	git	692d58e72934a2e2b56f663259696e035e6351ff	2016-09-30T14:09:10Z
 github.com/juju/txn	git	af2fa2051800371a0272610882891a28c719c02c	2016-10-31T02:11:40Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils	git	28c01ec2ad930d41fe5acd9969b96284eb61660b	2016-10-03T23:32:26Z
-github.com/juju/version	git	4ae6172c00626779a5a462c3e3d22fc0e889431a	2016-06-03T19:49:58Z
+github.com/juju/utils	git	4559f404c960a3c9c634529159de91fa5993af52	2016-11-22T15:00:28Z
+github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 github.com/juju/zip	git	f6b1e93fa2e29a1d7d49b566b2b51efb060c982a	2016-02-05T10:52:21Z

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -193,7 +193,7 @@ func intPtr(i uint64) *uint64 {
 }
 
 func (s *bootstrapSuite) TestBootstrapImage(c *gc.C) {
-	s.PatchValue(&series.HostSeries, func() string { return "precise" })
+	s.PatchValue(&series.MustHostSeries, func() string { return "precise" })
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 
 	metadataDir, metadata := createImageMetadata(c)
@@ -271,7 +271,7 @@ type testImageMetadata struct {
 // setupImageMetadata returns architecture for which metadata was setup
 func (s *bootstrapSuite) setupImageMetadata(c *gc.C) testImageMetadata {
 	testArch := arch.S390X
-	s.PatchValue(&series.HostSeries, func() string { return "precise" })
+	s.PatchValue(&series.MustHostSeries, func() string { return "precise" })
 	s.PatchValue(&arch.HostArch, func() string { return testArch })
 
 	metadataDir, metadata := createImageMetadataForArch(c, testArch)
@@ -373,7 +373,7 @@ func (s *bootstrapSuite) setupProviderWithNoSupportedArches(c *gc.C) bootstrapEn
 // despite image metadata in other data sources compatible with the same configuration as well.
 // Related to bug#1560625.
 func (s *bootstrapSuite) TestBootstrapImageMetadataFromAllSources(c *gc.C) {
-	s.PatchValue(&series.HostSeries, func() string { return "raring" })
+	s.PatchValue(&series.MustHostSeries, func() string { return "raring" })
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 
 	// Ensure that we can find at least one image metadata
@@ -1073,7 +1073,7 @@ func (s *bootstrapSuite) setupBootstrapSpecificVersion(c *gc.C, clientMajor, cli
 	currentVersion.Minor = clientMinor
 	currentVersion.Tag = ""
 	s.PatchValue(&jujuversion.Current, currentVersion)
-	s.PatchValue(&series.HostSeries, func() string { return "trusty" })
+	s.PatchValue(&series.MustHostSeries, func() string { return "trusty" })
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 
 	env := newEnviron("foo", useDefaultKeys, nil)
@@ -1239,7 +1239,7 @@ func (e *bootstrapEnviron) Bootstrap(ctx environs.BootstrapContext, args environ
 		e.instanceConfig = icfg
 		return nil
 	}
-	series := series.HostSeries()
+	series := series.MustHostSeries()
 	if args.BootstrapSeries != "" {
 		series = args.BootstrapSeries
 	}

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -189,7 +189,7 @@ func (s *toolsSuite) TestFindAvailableToolsSpecificVersion(c *gc.C) {
 	currentVersion := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	currentVersion.Major = 2
 	currentVersion.Minor = 3

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -798,7 +798,7 @@ func (t *LiveTests) TestBootstrapWithDefaultSeries(c *gc.C) {
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	other := current
 	other.Series = "quantal"

--- a/environs/sync/sync_test.go
+++ b/environs/sync/sync_test.go
@@ -246,7 +246,7 @@ func (s *uploadSuite) patchBundleTools(c *gc.C, v *version.Number) {
 }
 
 func (s *uploadSuite) assertEqualsCurrentVersion(c *gc.C, v version.Binary) {
-	c.Assert(v, gc.Equals, version.Binary{Number: jujuversion.Current, Arch: arch.HostArch(), Series: series.HostSeries()})
+	c.Assert(v, gc.Equals, version.Binary{Number: jujuversion.Current, Arch: arch.HostArch(), Series: series.MustHostSeries()})
 }
 
 func (s *uploadSuite) TearDownTest(c *gc.C) {
@@ -260,18 +260,18 @@ func (s *uploadSuite) TestUpload(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertEqualsCurrentVersion(c, t.Version)
 	c.Assert(t.URL, gc.Not(gc.Equals), "")
-	s.assertUploadedTools(c, t, []string{series.HostSeries()}, "released")
+	s.assertUploadedTools(c, t, []string{series.MustHostSeries()}, "released")
 }
 
 func (s *uploadSuite) TestUploadFakeSeries(c *gc.C) {
 	s.patchBundleTools(c, nil)
 	seriesToUpload := "precise"
-	if seriesToUpload == series.HostSeries() {
+	if seriesToUpload == series.MustHostSeries() {
 		seriesToUpload = "raring"
 	}
 	t, err := sync.Upload(s.targetStorage, "released", nil, "quantal", seriesToUpload)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertUploadedTools(c, t, []string{seriesToUpload, "quantal", series.HostSeries()}, "released")
+	s.assertUploadedTools(c, t, []string{seriesToUpload, "quantal", series.MustHostSeries()}, "released")
 }
 
 func (s *uploadSuite) TestUploadAndForceVersion(c *gc.C) {
@@ -280,7 +280,7 @@ func (s *uploadSuite) TestUploadAndForceVersion(c *gc.C) {
 	s.patchBundleTools(c, &vers)
 	t, err := sync.Upload(s.targetStorage, "released", &vers)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(t.Version, gc.Equals, version.Binary{Number: jujuversion.Current, Arch: arch.HostArch(), Series: series.HostSeries()})
+	c.Assert(t.Version, gc.Equals, version.Binary{Number: jujuversion.Current, Arch: arch.HostArch(), Series: series.MustHostSeries()})
 }
 
 func (s *uploadSuite) TestSyncTools(c *gc.C) {
@@ -296,7 +296,7 @@ func (s *uploadSuite) TestSyncTools(c *gc.C) {
 func (s *uploadSuite) TestSyncToolsFakeSeries(c *gc.C) {
 	s.patchBundleTools(c, nil)
 	seriesToUpload := "precise"
-	if seriesToUpload == series.HostSeries() {
+	if seriesToUpload == series.MustHostSeries() {
 		seriesToUpload = "raring"
 	}
 	builtTools, err := sync.BuildAgentTarball(true, nil, "testing")
@@ -304,7 +304,7 @@ func (s *uploadSuite) TestSyncToolsFakeSeries(c *gc.C) {
 
 	t, err := sync.SyncBuiltTools(s.targetStorage, "testing", builtTools, "quantal", seriesToUpload)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertUploadedTools(c, t, []string{seriesToUpload, "quantal", series.HostSeries()}, "testing")
+	s.assertUploadedTools(c, t, []string{seriesToUpload, "quantal", series.MustHostSeries()}, "testing")
 }
 
 func (s *uploadSuite) TestSyncAndForceVersion(c *gc.C) {
@@ -316,7 +316,7 @@ func (s *uploadSuite) TestSyncAndForceVersion(c *gc.C) {
 	t, err := sync.SyncBuiltTools(s.targetStorage, "released", builtTools)
 	c.Assert(err, jc.ErrorIsNil)
 	// Reported version from build call matches the real jujud version.
-	c.Assert(t.Version, gc.Equals, version.Binary{Number: jujuversion.Current, Arch: arch.HostArch(), Series: series.HostSeries()})
+	c.Assert(t.Version, gc.Equals, version.Binary{Number: jujuversion.Current, Arch: arch.HostArch(), Series: series.MustHostSeries()})
 }
 
 func (s *uploadSuite) assertUploadedTools(c *gc.C, t *coretools.Tools, expectSeries []string, stream string) {
@@ -413,7 +413,7 @@ func (s *badBuildSuite) assertEqualsCurrentVersion(c *gc.C, v version.Binary) {
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	c.Assert(v, gc.Equals, current)
 }
@@ -521,7 +521,7 @@ func (s *uploadSuite) TestMockBuildTools(c *gc.C) {
 	current := version.MustParseBinary("1.9.1-trusty-amd64")
 	s.PatchValue(&jujuversion.Current, current.Number)
 	s.PatchValue(&arch.HostArch, func() string { return current.Arch })
-	s.PatchValue(&series.HostSeries, func() string { return current.Series })
+	s.PatchValue(&series.MustHostSeries, func() string { return current.Series })
 	buildToolsFunc := toolstesting.GetMockBuildTools(c)
 	builtTools, err := buildToolsFunc(true, nil, "released")
 	c.Assert(err, jc.ErrorIsNil)
@@ -559,7 +559,7 @@ func (s *uploadSuite) testStorageToolsUploaderWriteMirrors(c *gc.C, writeMirrors
 			Version: version.Binary{
 				Number: jujuversion.Current,
 				Arch:   arch.HostArch(),
-				Series: series.HostSeries(),
+				Series: series.MustHostSeries(),
 			},
 			Size:   7,
 			SHA256: "ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73",

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -269,7 +269,7 @@ func MustUploadFakeToolsVersions(stor storage.Storage, stream string, versions .
 
 func uploadFakeTools(stor storage.Storage, toolsDir, stream string) error {
 	toolsSeries := set.NewStrings(toolsLtsSeries...)
-	toolsSeries.Add(series.HostSeries())
+	toolsSeries.Add(series.MustHostSeries())
 	var versions []version.Binary
 	for _, series := range toolsSeries.Values() {
 		vers := version.Binary{
@@ -307,13 +307,13 @@ func RemoveFakeTools(c *gc.C, stor storage.Storage, toolsDir string) {
 	toolsVersion := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	name := envtools.StorageName(toolsVersion, toolsDir)
 	err := stor.Remove(name)
 	c.Check(err, jc.ErrorIsNil)
 	defaultSeries := series.LatestLts()
-	if series.HostSeries() != defaultSeries {
+	if series.MustHostSeries() != defaultSeries {
 		toolsVersion.Series = defaultSeries
 		name := envtools.StorageName(toolsVersion, toolsDir)
 		err := stor.Remove(name)

--- a/environs/tools/simplestreams_test.go
+++ b/environs/tools/simplestreams_test.go
@@ -72,7 +72,7 @@ func setupSimpleStreamsTests(t *testing.T) {
 		registerLiveSimpleStreamsTests(testData.baseURL,
 			tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), simplestreams.LookupParams{
 				CloudSpec: testData.validCloudSpec,
-				Series:    []string{series.HostSeries()},
+				Series:    []string{series.MustHostSeries()},
 				Arches:    []string{"amd64"},
 				Stream:    "released",
 			}), testData.requireSigned)
@@ -356,10 +356,11 @@ func (s *simplestreamsSuite) TestWriteMetadataNoFetch(c *gc.C) {
 	}
 	expected := toolsList
 
-	// Add tools with an unknown series. Do not add an entry in the
-	// expected list as these tools should be ignored.
+	// Add tools with an unknown series.
+	// We need to support this case for times when a new Ubuntu series
+	// is released and jujud does not know about it yet.
 	vers, err := version.ParseBinary("3.2.1-xuanhuaceratops-amd64")
-	c.Assert(err, jc.Satisfies, series.IsUnknownOSForSeriesError)
+	c.Assert(err, jc.ErrorIsNil)
 	toolsList = append(toolsList, &coretools.Tools{
 		Version: vers,
 		Size:    456,

--- a/environs/tools/testing/testing.go
+++ b/environs/tools/testing/testing.go
@@ -47,7 +47,7 @@ func GetMockBundleTools(c *gc.C, expectedForceVersion *version.Number) tools.Bun
 		vers := version.Binary{
 			Number: jujuversion.Current,
 			Arch:   arch.HostArch(),
-			Series: series.HostSeries(),
+			Series: series.MustHostSeries(),
 		}
 		sha256Hash := fmt.Sprintf("%x", sha256.New().Sum(nil))
 		return vers, sha256Hash, nil
@@ -61,7 +61,7 @@ func GetMockBuildTools(c *gc.C) sync.BuildAgentTarballFunc {
 		vers := version.Binary{
 			Number: jujuversion.Current,
 			Arch:   arch.HostArch(),
-			Series: series.HostSeries(),
+			Series: series.MustHostSeries(),
 		}
 		if forceVersion != nil {
 			vers.Number = *forceVersion

--- a/featuretests/syslog_test.go
+++ b/featuretests/syslog_test.go
@@ -100,7 +100,7 @@ func (s *syslogSuite) SetUpTest(c *gc.C) {
 	if runtime.GOOS != "linux" {
 		c.Skip(fmt.Sprintf("this test requires a controller, therefore does not support %q", runtime.GOOS))
 	}
-	currentSeries := series.HostSeries()
+	currentSeries := series.MustHostSeries()
 	osFromSeries, err := series.GetOSFromSeries(currentSeries)
 	c.Assert(err, jc.ErrorIsNil)
 	if osFromSeries != os.Ubuntu {

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -63,7 +63,7 @@ func (s *upgradeSuite) SetUpTest(c *gc.C) {
 	s.oldVersion = version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	s.oldVersion.Major = 1
 	s.oldVersion.Minor = 16
@@ -200,7 +200,7 @@ func (s *upgradeSuite) TestDowngradeOnMasterWhenOtherControllerDoesntStartUpgrad
 		current := version.Binary{
 			Number: jujuversion.Current,
 			Arch:   arch.HostArch(),
-			Series: series.HostSeries(),
+			Series: series.MustHostSeries(),
 		}
 		c.Assert(upgradeReadyErr.OldTools, gc.Equals, current)
 		c.Assert(upgradeReadyErr.NewTools, gc.Equals, s.oldVersion)

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -230,7 +230,7 @@ func DefaultVersions(conf *config.Config) []version.Binary {
 	supported := series.SupportedLts()
 	defaultSeries := set.NewStrings(supported...)
 	defaultSeries.Add(config.PreferredSeries(conf))
-	defaultSeries.Add(series.HostSeries())
+	defaultSeries.Add(series.MustHostSeries())
 	agentVersion, set := conf.AgentVersion()
 	if !set {
 		agentVersion = jujuversion.Current

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -410,8 +410,7 @@ func EnsureServer(args EnsureServerParams) error {
 		}
 	}
 
-	operatingsystem := series.HostSeries()
-	if err := installMongod(operatingsystem, args.SetNUMAControlPolicy); err != nil {
+	if err := installMongod(series.MustHostSeries(), args.SetNUMAControlPolicy); err != nil {
 		// This isn't treated as fatal because the Juju MongoDB
 		// package is likely to be already installed anyway. There
 		// could just be a temporary issue with apt-get/yum/whatever

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -157,7 +157,7 @@ func (s *MongoSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *MongoSuite) patchSeries(ser string) {
-	s.PatchValue(&series.HostSeries, func() string { return ser })
+	s.PatchValue(&series.MustHostSeries, func() string { return ser })
 }
 
 func (s *MongoSuite) TestJujuMongodPath(c *gc.C) {

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -74,7 +74,7 @@ func minimalConfig(c *gc.C) *config.Config {
 		"ca-cert":         coretesting.CACert,
 		"ca-private-key":  coretesting.CAKey,
 		"authorized-keys": coretesting.FakeAuthKeys,
-		"default-series":  series.HostSeries(),
+		"default-series":  series.MustHostSeries(),
 	}
 	cfg, err := config.New(config.UseDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
@@ -134,7 +134,7 @@ func (s *BootstrapSuite) TestCannotStartInstance(c *gc.C) {
 				Version: version.Binary{
 					Number: jujuversion.Current,
 					Arch:   arch.HostArch(),
-					Series: series.HostSeries(),
+					Series: series.MustHostSeries(),
 				},
 			},
 		}})
@@ -143,7 +143,7 @@ func (s *BootstrapSuite) TestCannotStartInstance(c *gc.C) {
 
 func (s *BootstrapSuite) TestBootstrapSeries(c *gc.C) {
 	s.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
-	s.PatchValue(&series.HostSeries, func() string { return "precise" })
+	s.PatchValue(&series.MustHostSeries, func() string { return "precise" })
 	stor := newStorage(s, c)
 	checkInstanceId := "i-success"
 	checkHardware := instance.MustParseHardware("arch=ppc64el mem=2T")
@@ -227,7 +227,7 @@ func (s *BootstrapSuite) TestSuccess(c *gc.C) {
 				Version: version.Binary{
 					Number: jujuversion.Current,
 					Arch:   arch.HostArch(),
-					Series: series.HostSeries(),
+					Series: series.MustHostSeries(),
 				},
 			},
 		}})

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -80,7 +80,7 @@ func (s *ebsSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.BaseSuite.PatchValue(&jujuversion.Current, testing.FakeVersionNumber)
 	s.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	s.BaseSuite.PatchValue(&series.HostSeries, func() string { return series.LatestLts() })
+	s.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return series.LatestLts() })
 	s.srv.startServer(c)
 	s.Tests.SetUpTest(c)
 	s.PatchValue(&ec2.DestroyVolumeAttempt.Delay, time.Duration(0))

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -79,7 +79,7 @@ func (t *LiveTests) SetUpSuite(c *gc.C) {
 	t.LiveTests.SetUpSuite(c)
 	t.BaseSuite.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	t.BaseSuite.PatchValue(&series.HostSeries, func() string { return series.LatestLts() })
+	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return series.LatestLts() })
 }
 
 func (t *LiveTests) TearDownSuite(c *gc.C) {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -214,7 +214,7 @@ func (t *localServerSuite) SetUpSuite(c *gc.C) {
 	t.BaseSuite.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	t.BaseSuite.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	t.BaseSuite.PatchValue(&series.HostSeries, func() string { return series.LatestLts() })
+	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return series.LatestLts() })
 	t.BaseSuite.PatchValue(ec2.DeleteSecurityGroupInsistently, deleteSecurityGroupForTestFunc)
 	t.srv.createRootDisks = true
 	t.srv.startServer(c)

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -24,7 +24,7 @@ import (
 // backported to wily... so we have this:|
 // TODO(redir): Remove after wiley or in yakkety.
 func skipIfWily(c *gc.C) {
-	if series.HostSeries() == "wily" {
+	if series.MustHostSeries() == "wily" {
 		cfg, _ := lxdclient.Config{}.WithDefaults()
 		_, err := lxdclient.Connect(cfg, false)
 		// We try to create a client here. On wily this should fail, because

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -62,7 +62,7 @@ func (s *baseProviderSuite) SetUpTest(c *gc.C) {
 	s.ToolsFixture.SetUpTest(c)
 	s.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	s.PatchValue(&series.HostSeries, func() string { return series.LatestLts() })
+	s.PatchValue(&series.MustHostSeries, func() string { return series.LatestLts() })
 }
 
 func (s *baseProviderSuite) TearDownTest(c *gc.C) {

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -23,23 +23,24 @@ import (
 // DiscoverService returns an interface to a service appropriate
 // for the current system
 func DiscoverService(name string, conf common.Conf) (Service, error) {
-	initName, err := discoverInitSystem()
+	hostSeries := series.MustHostSeries()
+	initName, err := discoverInitSystem(hostSeries)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	service, err := newService(name, conf, initName, series.HostSeries())
+	service, err := newService(name, conf, initName, hostSeries)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return service, nil
 }
 
-func discoverInitSystem() (string, error) {
+func discoverInitSystem(hostSeries string) (string, error) {
 	initName, err := discoverLocalInitSystem()
 	if errors.IsNotFound(err) {
 		// Fall back to checking the juju version.
-		versionInitName, err2 := VersionInitSystem(series.HostSeries())
+		versionInitName, err2 := VersionInitSystem(hostSeries)
 		if err2 != nil {
 			// The key error is the one from discoverLocalInitSystem so
 			// that is what we return.

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -36,8 +36,6 @@ func init() {
 	}
 }
 
-const unknownExecutable = "/sbin/unknown/init/system"
-
 type discoveryTest struct {
 	os       jujuos.OSType
 	series   string
@@ -180,13 +178,13 @@ func (s *discoverySuite) TestDiscoverServiceLocalHost(c *gc.C) {
 	case "windows":
 		localInitSystem = service.InitSystemWindows
 	case "linux":
-		localInitSystem, err = service.VersionInitSystem(series.HostSeries())
+		localInitSystem, err = service.VersionInitSystem(series.MustHostSeries())
 	}
 	c.Assert(err, gc.IsNil)
 
 	test := discoveryTest{
 		os:       jujuos.HostOS(),
-		series:   series.HostSeries(),
+		series:   series.MustHostSeries(),
 		expected: localInitSystem,
 	}
 	test.disableVersionDiscovery(s)
@@ -344,7 +342,7 @@ func (s *discoverySuite) TestDiscoverInitSystemScriptBash(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	initSystem, err := service.DiscoverInitSystem()
+	initSystem, err := service.DiscoverInitSystem(series.MustHostSeries())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(response.Code, gc.Equals, 0)
 	c.Check(string(response.Stdout), gc.Equals, initSystem)
@@ -363,7 +361,7 @@ func (s *discoverySuite) TestDiscoverInitSystemScriptPosix(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	initSystem, err := service.DiscoverInitSystem()
+	initSystem, err := service.DiscoverInitSystem(series.MustHostSeries())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(response.Code, gc.Equals, 0)
 	c.Check(string(response.Stdout), gc.Equals, initSystem)
@@ -405,7 +403,7 @@ func (s *discoverySuite) TestNewShellSelectCommandBash(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	initSystem, err := service.DiscoverInitSystem()
+	initSystem, err := service.DiscoverInitSystem(series.MustHostSeries())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(response.Code, gc.Equals, 0)
 	c.Check(string(response.Stdout), gc.Equals, initSystem)
@@ -431,7 +429,7 @@ func (s *discoverySuite) TestNewShellSelectCommandPosix(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	initSystem, err := service.DiscoverInitSystem()
+	initSystem, err := service.DiscoverInitSystem(series.MustHostSeries())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(response.Code, gc.Equals, 0)
 	c.Check(string(response.Stdout), gc.Equals, initSystem)

--- a/service/service.go
+++ b/service/service.go
@@ -138,7 +138,11 @@ func newService(name string, conf common.Conf, initSystem, series string) (Servi
 
 // ListServices lists all installed services on the running system
 func ListServices() ([]string, error) {
-	initName, err := VersionInitSystem(series.HostSeries())
+	hostSeries, err := series.HostSeries()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	initName, err := VersionInitSystem(hostSeries)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/service/testing_test.go
+++ b/service/testing_test.go
@@ -97,7 +97,7 @@ func (s *BaseSuite) PatchAttempts(retries int) {
 }
 
 func (s *BaseSuite) PatchSeries(ser string) {
-	s.PatchValue(&series.HostSeries, func() string { return ser })
+	s.PatchValue(&series.MustHostSeries, func() string { return ser })
 }
 
 func NewDiscoveryCheck(name string, running bool, failure error) discoveryCheck {

--- a/service/windows/service_windows.go
+++ b/service/windows/service_windows.go
@@ -358,7 +358,11 @@ func (s *SvcManager) Delete(name string) error {
 func (s *SvcManager) Create(name string, conf common.Conf) error {
 	serviceStartName := "LocalSystem"
 	var passwd string
-	if !series.IsWindowsNano(series.HostSeries()) {
+	hostSeries, err := series.HostSeries()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if !series.IsWindowsNano(hostSeries) {
 		password, err := getPassword()
 		if err != nil {
 			return errors.Trace(err)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3366,7 +3366,7 @@ func (s *StateSuite) TestSetEnvironAgentVersionOnOtherEnviron(c *gc.C) {
 	current := version.MustParseBinary("1.24.7-trusty-amd64")
 	s.PatchValue(&jujuversion.Current, current.Number)
 	s.PatchValue(&arch.HostArch, func() string { return current.Arch })
-	s.PatchValue(&series.HostSeries, func() string { return current.Series })
+	s.PatchValue(&series.MustHostSeries, func() string { return current.Series })
 
 	otherSt := s.Factory.MakeModel(c, nil)
 	defer otherSt.Close()

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -294,7 +294,7 @@ func (factory *Factory) MakeMachineNested(c *gc.C, parentId string, params *Mach
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	err = m.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
@@ -360,7 +360,7 @@ func (factory *Factory) makeMachineReturningPassword(c *gc.C, params *MachinePar
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	err = machine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)

--- a/tools/lxdclient/utils.go
+++ b/tools/lxdclient/utils.go
@@ -48,7 +48,11 @@ func IsRunningLocally() (bool, error) {
 		return false, nil
 	}
 
-	svc, err := service.NewService("lxd", common.Conf{}, series.HostSeries())
+	hostSeries, err := series.HostSeries()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	svc, err := service.NewService("lxd", common.Conf{}, hostSeries)
 	if err != nil {
 		return false, errors.Trace(err)
 	}

--- a/version/current_test.go
+++ b/version/current_test.go
@@ -17,7 +17,7 @@ type CurrentSuite struct{}
 var _ = gc.Suite(&CurrentSuite{})
 
 func (*CurrentSuite) TestCurrentSeries(c *gc.C) {
-	s := series.HostSeries()
+	s := series.MustHostSeries()
 	if s == "unknown" {
 		s = "n/a"
 	}

--- a/worker/deployer/simple.go
+++ b/worker/deployer/simple.go
@@ -111,10 +111,14 @@ func (ctx *SimpleContext) DeployUnit(unitName, initialPassword string) (err erro
 	tag := names.NewUnitTag(unitName)
 	dataDir := ctx.agentConfig.DataDir()
 	logDir := ctx.agentConfig.LogDir()
+	hostSeries, err := series.HostSeries()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: hostSeries,
 	}
 	toolsDir := tools.ToolsDir(dataDir, tag.String())
 	defer removeOnErr(&err, toolsDir)

--- a/worker/deployer/simple_test.go
+++ b/worker/deployer/simple_test.go
@@ -162,7 +162,7 @@ func (fix *SimpleToolsFixture) SetUp(c *gc.C, dataDir string) {
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	toolsDir := tools.SharedToolsDir(fix.dataDir, current)
 	err := os.MkdirAll(toolsDir, 0755)

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -179,7 +179,7 @@ func (s *ContainerSetupSuite) TestContainerProvisionerStarted(c *gc.C) {
 		current := version.Binary{
 			Number: jujuversion.Current,
 			Arch:   arch.HostArch(),
-			Series: series.HostSeries(),
+			Series: series.MustHostSeries(),
 		}
 		err = m.SetAgentVersion(current)
 		c.Assert(err, jc.ErrorIsNil)
@@ -212,7 +212,7 @@ func (s *ContainerSetupSuite) testContainerConstraintsArch(c *gc.C, containerTyp
 	s.PatchValue(&provisioner.StartProvisioner, func(runner worker.Runner, containerType instance.ContainerType,
 		pr *apiprovisioner.State, cfg agent.Config, broker environs.InstanceBroker,
 		toolsFinder provisioner.ToolsFinder) error {
-		toolsFinder.FindTools(jujuversion.Current, series.HostSeries(), arch.AMD64)
+		toolsFinder.FindTools(jujuversion.Current, series.MustHostSeries(), arch.AMD64)
 		return nil
 	})
 
@@ -228,7 +228,7 @@ func (s *ContainerSetupSuite) testContainerConstraintsArch(c *gc.C, containerTyp
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	err = m.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
@@ -263,7 +263,7 @@ func (s *ContainerSetupSuite) assertContainerInitialised(c *gc.C, cont Container
 	}
 	s.PatchValue(&provisioner.StartProvisioner, startProvisionerWorker)
 
-	current_os, err := series.GetOSFromSeries(series.HostSeries())
+	current_os, err := series.GetOSFromSeries(series.MustHostSeries())
 	c.Assert(err, jc.ErrorIsNil)
 
 	var ser string
@@ -293,7 +293,7 @@ func (s *ContainerSetupSuite) assertContainerInitialised(c *gc.C, cont Container
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	err = m.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
@@ -339,7 +339,7 @@ func (s *ContainerSetupSuite) TestContainerInitLockError(c *gc.C) {
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	err = m.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -160,7 +160,7 @@ func (s *CommonProvisionerSuite) SetUpTest(c *gc.C) {
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	err = machine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
@@ -474,7 +474,7 @@ func (s *ProvisionerSuite) TestPossibleTools(c *gc.C) {
 	// agent-version in the environ config.
 	currentVersion := version.MustParseBinary("1.2.3-quantal-arm64")
 	s.PatchValue(&arch.HostArch, func() string { return currentVersion.Arch })
-	s.PatchValue(&series.HostSeries, func() string { return currentVersion.Series })
+	s.PatchValue(&series.MustHostSeries, func() string { return currentVersion.Series })
 	s.PatchValue(&jujuversion.Current, currentVersion.Number)
 
 	// Upload some plausible matches, and some that should be filtered out.

--- a/worker/proxyupdater/proxyupdater.go
+++ b/worker/proxyupdater/proxyupdater.go
@@ -166,7 +166,11 @@ func (w *proxyWorker) handleProxyValues(proxySettings proxyutils.Settings) {
 // getPackageCommander is a helper function which returns the
 // package commands implementation for the current system.
 func getPackageCommander() (commands.PackageCommander, error) {
-	return commands.NewPackageCommander(series.HostSeries())
+	hostSeries, err := series.HostSeries()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return commands.NewPackageCommander(hostSeries)
 }
 
 func (w *proxyWorker) handleAptProxyValues(aptSettings proxyutils.Settings) error {

--- a/worker/proxyupdater/proxyupdater_test.go
+++ b/worker/proxyupdater/proxyupdater_test.go
@@ -174,7 +174,7 @@ func (s *ProxyUpdaterSuite) TestInitialState(c *gc.C) {
 	s.waitProxySettings(c, proxySettings)
 	s.waitForFile(c, s.proxyFile, proxySettings.AsScriptEnvironment()+"\n")
 
-	paccmder, err := commands.NewPackageCommander(series.HostSeries())
+	paccmder, err := commands.NewPackageCommander(series.MustHostSeries())
 	c.Assert(err, jc.ErrorIsNil)
 	s.waitForFile(c, pacconfig.AptProxyConfigFile, paccmder.ProxyConfigContents(aptProxySettings)+"\n")
 }
@@ -189,7 +189,7 @@ func (s *ProxyUpdaterSuite) TestWriteSystemFiles(c *gc.C) {
 	s.waitProxySettings(c, proxySettings)
 	s.waitForFile(c, s.proxyFile, proxySettings.AsScriptEnvironment()+"\n")
 
-	paccmder, err := commands.NewPackageCommander(series.HostSeries())
+	paccmder, err := commands.NewPackageCommander(series.MustHostSeries())
 	c.Assert(err, jc.ErrorIsNil)
 	s.waitForFile(c, pacconfig.AptProxyConfigFile, paccmder.ProxyConfigContents(aptProxySettings)+"\n")
 }

--- a/worker/uniter/runner/jujuc/tools_test.go
+++ b/worker/uniter/runner/jujuc/tools_test.go
@@ -34,7 +34,7 @@ func (s *ToolsSuite) SetUpTest(c *gc.C) {
 	s.toolsDir = tools.SharedToolsDir(s.dataDir, version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	})
 	err := os.MkdirAll(s.toolsDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/upgrader/upgrader.go
+++ b/worker/upgrader/upgrader.go
@@ -230,7 +230,7 @@ func toBinaryVersion(vers version.Number) version.Binary {
 	outVers := version.Binary{
 		Number: vers,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	return outVers
 }

--- a/worker/upgrader/upgrader_test.go
+++ b/worker/upgrader/upgrader_test.go
@@ -72,7 +72,7 @@ func (s *UpgraderSuite) SetUpTest(c *gc.C) {
 
 func (s *UpgraderSuite) patchVersion(v version.Binary) {
 	s.PatchValue(&arch.HostArch, func() string { return v.Arch })
-	s.PatchValue(&series.HostSeries, func() string { return v.Series })
+	s.PatchValue(&series.MustHostSeries, func() string { return v.Series })
 	s.PatchValue(&jujuversion.Current, v.Number)
 }
 

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -66,7 +66,7 @@ func (s *UpgradeSuite) SetUpTest(c *gc.C) {
 	s.oldVersion = version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	s.oldVersion.Major = 1
 	s.oldVersion.Minor = 16
@@ -480,7 +480,7 @@ func makeBumpedCurrentVersion() version.Binary {
 	v := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.HostSeries(),
+		Series: series.MustHostSeries(),
 	}
 	v.Build++
 	v.Tag = ""

--- a/wrench/wrench.go
+++ b/wrench/wrench.go
@@ -21,7 +21,7 @@ var (
 	enabledMu sync.Mutex
 	enabled   = true
 
-	dataDir   = paths.MustSucceed(paths.DataDir(series.HostSeries()))
+	dataDir   = paths.MustSucceed(paths.DataDir(series.MustHostSeries()))
 	wrenchDir = filepath.Join(dataDir, "wrench")
 	jujuUid   = os.Getuid()
 )


### PR DESCRIPTION
Fixes lp:1468752 on 2.0 branch by bringing in new code
from utils to handle carriage returns when using gocrypto
ssh on windows clients.

Note this also brings in some other bug fixes from utils
changes that have not yet been brought to the 2.0 branch.

QA steps
----

* Build and bootstrap on windows
* `juju switch controller`
* `juju ssh 0`
* Run commands on the remote machine, ensure they work