### PR TITLE
Fixes the charm registration message.

### DIFF
--- a/cmd/juju/application/register.go
+++ b/cmd/juju/application/register.go
@@ -76,7 +76,11 @@ func (r *RegisterMeteredCharm) RunPre(api MeteredDeployAPI, bakeryClient *httpba
 					return err1
 				}
 				charmURL := deployInfo.CharmID.URL.String()
-				return errors.Errorf(`%v has no default plan. Try "juju deploy --plan <plan-name> with one of %v"`, charmURL, strings.Join(options, ", "))
+				if len(options) > 0 {
+					return errors.Errorf(`%v has no default plan. Try "juju deploy --plan <plan-name> with one of %v"`, charmURL, strings.Join(options, ", "))
+				} else {
+					return errors.Errorf("no plans available for %v.", charmURL)
+				}
 			}
 			return err
 		}

--- a/cmd/juju/application/register_test.go
+++ b/cmd/juju/application/register_test.go
@@ -34,7 +34,13 @@ type registrationSuite struct {
 func (s *registrationSuite) SetUpTest(c *gc.C) {
 	s.CleanupSuite.SetUpTest(c)
 	s.stub = &testing.Stub{}
-	s.handler = &testMetricsRegistrationHandler{Stub: s.stub}
+	s.handler = &testMetricsRegistrationHandler{
+		Stub: s.stub,
+		availablePlans: []availablePlanURL{
+			{URL: "thisplan"},
+			{URL: "thisotherplan"},
+		},
+	}
 	s.server = httptest.NewServer(s.handler)
 	s.register = &RegisterMeteredCharm{
 		Plan:           "someplan",
@@ -417,6 +423,37 @@ func (s *registrationSuite) TestMeteredCharmNoDefaultPlan(c *gc.C) {
 	}})
 }
 
+func (s *registrationSuite) TestMeteredCharmNoAvailablePlan(c *gc.C) {
+	s.stub.SetErrors(nil, errors.NotFoundf("default plan"))
+	s.handler.availablePlans = []availablePlanURL{}
+	s.register = &RegisterMeteredCharm{
+		AllocationSpec: "personal:100",
+		RegisterURL:    s.server.URL,
+		QueryURL:       s.server.URL}
+	client := httpbakery.NewClient()
+	d := DeploymentInfo{
+		CharmID: charmstore.CharmID{
+			URL: charm.MustParseURL("cs:quantal/metered-1"),
+		},
+		ApplicationName: "application name",
+		ModelUUID:       "model uuid",
+		CharmInfo: &apicharms.CharmInfo{
+			Metrics: &charm.Metrics{
+				Plan: &charm.Plan{Required: true},
+			},
+		},
+	}
+	err := s.register.RunPre(&mockMeteredDeployAPI{Stub: s.stub}, client, s.ctx, d)
+	c.Assert(err, gc.ErrorMatches, `no plans available for cs:quantal/metered-1.`)
+	s.stub.CheckCalls(c, []testing.StubCall{{
+		"IsMetered", []interface{}{"cs:quantal/metered-1"},
+	}, {
+		"DefaultPlan", []interface{}{"cs:quantal/metered-1"},
+	}, {
+		"ListPlans", []interface{}{"cs:quantal/metered-1"},
+	}})
+}
+
 func (s *registrationSuite) TestMeteredCharmFailToQueryDefaultCharm(c *gc.C) {
 	s.stub.SetErrors(nil, errors.New("something failed"))
 	s.register = &RegisterMeteredCharm{
@@ -587,8 +624,13 @@ func (s *registrationSuite) TestPlanArgumentPlanRequiredInteraction(c *gc.C) {
 	}
 }
 
+type availablePlanURL struct {
+	URL string `json:"url"`
+}
+
 type testMetricsRegistrationHandler struct {
 	*testing.Stub
+	availablePlans []availablePlanURL
 }
 
 type respErr struct {
@@ -648,13 +690,7 @@ func (c *testMetricsRegistrationHandler) ServeHTTP(w http.ResponseWriter, req *h
 			http.Error(w, rErr.Error(), http.StatusInternalServerError)
 			return
 		}
-		result := []struct {
-			URL string `json:"url"`
-		}{
-			{"thisplan"},
-			{"thisotherplan"},
-		}
-		err := json.NewEncoder(w).Encode(result)
+		err := json.NewEncoder(w).Encode(c.availablePlans)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Improve the charm registration error message. If there is no option make that clear, rather than present a list with no entries.