### PR TITLE
Enable endpoints in LXD provider.

### DIFF
--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -69,9 +69,6 @@ func validateCloudSpec(spec environs.CloudSpec) error {
 	if err := spec.Validate(); err != nil {
 		return errors.Trace(err)
 	}
-	if spec.Endpoint != "" {
-		return errors.NotValidf("non-empty endpoint %q", spec.Endpoint)
-	}
 	if spec.Credential != nil {
 		if authType := spec.Credential.AuthType(); authType != cloud.EmptyAuthType {
 			return errors.NotSupportedf("%q auth-type", authType)

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -127,14 +127,3 @@ func (s *ProviderFunctionalSuite) TestPrepareConfigUnsupportedAuthType(c *gc.C) 
 	})
 	c.Assert(err, gc.ErrorMatches, `validating cloud spec: "certificate" auth-type not supported`)
 }
-
-func (s *ProviderFunctionalSuite) TestPrepareConfigNonEmptyEndpoint(c *gc.C) {
-	_, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
-		Cloud: environs.CloudSpec{
-			Type:     "lxd",
-			Name:     "remotehost",
-			Endpoint: "1.2.3.4",
-		},
-	})
-	c.Assert(err, gc.ErrorMatches, `validating cloud spec: non-empty endpoint "1.2.3.4" not valid`)
-}

--- a/tools/lxdclient/client_network.go
+++ b/tools/lxdclient/client_network.go
@@ -55,7 +55,7 @@ func checkBridgeConfig(client rawNetworkClient, bridge string) error {
 		return err
 	}
 
-	if n.Config["ipv6.address"] != "none" {
+	if n.Managed && n.Config["ipv6.address"] != "none" {
 		return errors.Errorf(`juju doesn't support ipv6. Please disable LXD's IPV6:
 
 	$ lxc network set %s ipv6.address none


### PR DESCRIPTION
These changes propose to unlock the endpoint configuration in the lxd provider to be able to use an endpoint that is not a gateway. It is an initial work needed to address https://bugs.launchpad.net/juju/+bug/1618798.