### PR TITLE
Add basic boilerplate to remoterelation worker to watch relation unit changes

### DIFF
--- a/apiserver/remoterelations/package_test.go
+++ b/apiserver/remoterelations/package_test.go
@@ -4,7 +4,7 @@
 package remoterelations_test
 
 import (
-	testing "testing"
+	"testing"
 
 	gc "gopkg.in/check.v1"
 )

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -1,0 +1,272 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package remoterelations_test
+
+import (
+	"sync"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	"gopkg.in/tomb.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker/remoterelations"
+)
+
+type mockFacade struct {
+	mu   sync.Mutex
+	stub *testing.Stub
+	remoterelations.RemoteApplicationsFacade
+	remoteApplicationsWatcher          *mockStringsWatcher
+	remoteApplicationRelationsWatchers map[string]*mockStringsWatcher
+	remoteApplications                 map[string]*mockRemoteApplication
+	relations                          map[string]*mockRelation
+	relationsUnitsWatchers             map[string]*mockRelationUnitsWatcher
+}
+
+func newMockFacade(stub *testing.Stub) *mockFacade {
+	return &mockFacade{
+		stub:                               stub,
+		remoteApplications:                 make(map[string]*mockRemoteApplication),
+		relations:                          make(map[string]*mockRelation),
+		remoteApplicationsWatcher:          newMockStringsWatcher(),
+		remoteApplicationRelationsWatchers: make(map[string]*mockStringsWatcher),
+		relationsUnitsWatchers:             make(map[string]*mockRelationUnitsWatcher),
+	}
+}
+
+func (m *mockFacade) WatchRemoteApplications() (watcher.StringsWatcher, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stub.MethodCall(m, "WatchRemoteApplications")
+	if err := m.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return m.remoteApplicationsWatcher, nil
+}
+
+func (m *mockFacade) remoteApplicationRelationsWatcher(name string) (*mockStringsWatcher, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	w, ok := m.remoteApplicationRelationsWatchers[name]
+	return w, ok
+}
+
+func (m *mockFacade) removeApplication(name string) (*mockStringsWatcher, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	w, ok := m.remoteApplicationRelationsWatchers[name]
+	delete(m.remoteApplications, name)
+	return w, ok
+}
+
+func (m *mockFacade) relationsUnitsWatcher(key string) (*mockRelationUnitsWatcher, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	w, ok := m.relationsUnitsWatchers[key]
+	return w, ok
+}
+
+func (m *mockFacade) removeRelation(key string) (*mockRelationUnitsWatcher, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	w, ok := m.relationsUnitsWatchers[key]
+	delete(m.relations, key)
+	return w, ok
+}
+
+func (m *mockFacade) updateRelationLife(key string, life params.Life) (*mockRelationUnitsWatcher, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	w, ok := m.relationsUnitsWatchers[key]
+	m.relations[key].life = life
+	return w, ok
+}
+
+func (m *mockFacade) WatchRemoteApplicationRelations(application string) (watcher.StringsWatcher, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stub.MethodCall(m, "WatchRemoteApplicationRelations", application)
+	if err := m.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	m.remoteApplicationRelationsWatchers[application] = newMockStringsWatcher()
+	return m.remoteApplicationRelationsWatchers[application], nil
+}
+
+func (m *mockFacade) RemoteApplications(names []string) ([]params.RemoteApplicationResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stub.MethodCall(m, "RemoteApplications", names)
+	if err := m.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	result := make([]params.RemoteApplicationResult, len(names))
+	for i, name := range names {
+		if app, ok := m.remoteApplications[name]; ok {
+			result[i] = params.RemoteApplicationResult{
+				Result: &params.RemoteApplication{
+					// TODO(wallyworld) - add Id
+					Life: app.life,
+				},
+			}
+		} else {
+			result[i] = params.RemoteApplicationResult{
+				Error: common.ServerError(errors.NotFoundf(name))}
+		}
+	}
+	return result, nil
+}
+
+func (m *mockFacade) RemoteRelations(keys []string) ([]params.RemoteRelationResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stub.MethodCall(m, "RemoteRelations", keys)
+	if err := m.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	result := make([]params.RemoteRelationResult, len(keys))
+	for i, key := range keys {
+		if rel, ok := m.relations[key]; ok {
+			result[i] = params.RemoteRelationResult{
+				Result: &params.RemoteRelation{
+					// TODO(wallyworld) - add Id
+					Life: rel.life,
+				},
+			}
+		} else {
+			result[i] = params.RemoteRelationResult{
+				Error: common.ServerError(errors.NotFoundf(key))}
+		}
+	}
+	return result, nil
+}
+
+func (m *mockFacade) WatchLocalRelationUnits(relationKey string) (watcher.RelationUnitsWatcher, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stub.MethodCall(m, "WatchLocalRelationUnits", relationKey)
+	if err := m.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	m.relationsUnitsWatchers[relationKey] = newMockRelationUnitsWatcher()
+	return m.relationsUnitsWatchers[relationKey], nil
+}
+
+type mockWatcher struct {
+	testing.Stub
+	tomb.Tomb
+	mu         sync.Mutex
+	terminated bool
+}
+
+func (w *mockWatcher) doneWhenDying() {
+	<-w.Tomb.Dying()
+	w.Tomb.Done()
+}
+
+func (w *mockWatcher) killed() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.terminated
+}
+
+func (w *mockWatcher) Kill() {
+	w.MethodCall(w, "Kill")
+	w.Tomb.Kill(nil)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.terminated = true
+}
+
+func (w *mockWatcher) Stop() error {
+	w.MethodCall(w, "Stop")
+	if err := w.NextErr(); err != nil {
+		return err
+	}
+	w.Tomb.Kill(nil)
+	return w.Tomb.Wait()
+}
+
+type mockStringsWatcher struct {
+	mockWatcher
+	changes chan []string
+}
+
+func newMockStringsWatcher() *mockStringsWatcher {
+	w := &mockStringsWatcher{changes: make(chan []string, 5)}
+	go w.doneWhenDying()
+	return w
+}
+
+func (w *mockStringsWatcher) Changes() watcher.StringsChannel {
+	w.MethodCall(w, "Changes")
+	return w.changes
+}
+
+type mockRemoteApplication struct {
+	testing.Stub
+	name string
+	url  string
+	life params.Life
+}
+
+type mockRelationUnitsWatcher struct {
+	mockWatcher
+	changes chan watcher.RelationUnitsChange
+}
+
+func newMockRelationUnitsWatcher() *mockRelationUnitsWatcher {
+	w := &mockRelationUnitsWatcher{
+		changes: make(chan watcher.RelationUnitsChange, 1),
+	}
+	go w.doneWhenDying()
+	return w
+}
+
+func (w *mockRelationUnitsWatcher) Changes() watcher.RelationUnitsChannel {
+	w.MethodCall(w, "Changes")
+	return w.changes
+}
+
+func newMockRemoteApplication(name, url string) *mockRemoteApplication {
+	return &mockRemoteApplication{
+		name: name, url: url, life: params.Alive,
+	}
+}
+
+func (r *mockRemoteApplication) Name() string {
+	r.MethodCall(r, "Name")
+	return r.name
+}
+
+func (r *mockRemoteApplication) Life() params.Life {
+	r.MethodCall(r, "Life")
+	return r.life
+}
+
+type mockRelation struct {
+	testing.Stub
+	id   int
+	life params.Life
+}
+
+func newMockRelation(id int) *mockRelation {
+	return &mockRelation{
+		id:   id,
+		life: params.Alive,
+	}
+}
+
+func (r *mockRelation) Id() int {
+	r.MethodCall(r, "Id")
+	return r.id
+}
+
+func (r *mockRelation) Life() params.Life {
+	r.MethodCall(r, "Life")
+	return r.life
+}

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/catacomb"
 )
 
@@ -47,7 +48,7 @@ type RemoteApplicationsFacade interface {
 
 	// WatchRemoteApplicationRelations starts a StringsWatcher for watching the relations of
 	// each specified application in the local environment, and returns the watcher IDs
-	// and initial values, or an error if the services' relations could not be
+	// and initial values, or an error if the applications' relations could not be
 	// watched.
 	WatchRemoteApplicationRelations(application string) (watcher.StringsWatcher, error)
 }
@@ -72,17 +73,15 @@ func New(config Config) (*Worker, error) {
 	}
 
 	w := &Worker{
-		config: config,
-		logger: logger,
+		config:             config,
+		logger:             logger,
+		applicationWorkers: make(map[string]worker.Worker),
 	}
 	err := catacomb.Invoke(catacomb.Plan{
 		Site: &w.catacomb,
 		Work: w.loop,
 	})
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return w, nil
+	return w, errors.Trace(err)
 }
 
 // Worker manages relations and associated settings where
@@ -91,24 +90,302 @@ type Worker struct {
 	catacomb catacomb.Catacomb
 	config   Config
 	logger   loggo.Logger
+
+	// applicationWorkers holds a worker for each
+	// remote application being watched.
+	applicationWorkers map[string]worker.Worker
 }
 
-// Kill implements worker.Worker.
+// Kill is defined on worker.Worker.
 func (w *Worker) Kill() {
 	w.catacomb.Kill(nil)
 }
 
-// Wait implements worker.Worker.
+// Wait is defined on worker.Worker.
 func (w *Worker) Wait() error {
 	return w.catacomb.Wait()
 }
 
-func (w *Worker) loop() error {
+func (w *Worker) loop() (err error) {
+	changes, err := w.config.Facade.WatchRemoteApplications()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := w.catacomb.Add(changes); err != nil {
+		return errors.Trace(err)
+	}
 	for {
-		// TODO(wallyworld)
 		select {
 		case <-w.catacomb.Dying():
 			return w.catacomb.ErrDying()
+		case applicationIds, ok := <-changes.Changes():
+			if !ok {
+				return errors.New("change channel closed")
+			}
+			err = w.handleApplicationChanges(applicationIds)
+			if err != nil {
+				return err
+			}
 		}
 	}
+}
+
+func (w *Worker) handleApplicationChanges(applicationIds []string) error {
+	logger.Debugf("processing remote application changes for: %s", applicationIds)
+
+	// Fetch the current state of each of the remote applications that have changed.
+	results, err := w.config.Facade.RemoteApplications(applicationIds)
+	if err != nil {
+		return errors.Annotate(err, "querying remote applications")
+	}
+
+	for i, result := range results {
+		name := applicationIds[i]
+		if result.Error != nil {
+			// The the remote application has been removed, stop its worker.
+			if params.IsCodeNotFound(result.Error) {
+				if err := w.killApplicationWorker(name); err != nil {
+					return err
+				}
+				continue
+			}
+			return errors.Annotatef(err, "querying remote application %q", name)
+		}
+		if _, ok := w.applicationWorkers[name]; ok {
+			// TODO(wallyworld): handle application dying or dead.
+			// As of now, if the worker is already running, that's all we need.
+			continue
+		}
+		// A new remote application has appeared, start monitoring relations to it
+		// originating from the local model.
+		relationsWatcher, err := w.config.Facade.WatchRemoteApplicationRelations(name)
+		if errors.IsNotFound(err) {
+			if err := w.killApplicationWorker(name); err != nil {
+				return err
+			}
+			continue
+		} else if err != nil {
+			return errors.Annotatef(err, "watching relations for remote application %q", name)
+		}
+		logger.Debugf("started watcher for remote application %q", name)
+		appWorker, err := newRemoteApplicationWorker(
+			relationsWatcher,
+			w.config.Facade,
+		)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if err := w.catacomb.Add(appWorker); err != nil {
+			return errors.Trace(err)
+		}
+		w.applicationWorkers[name] = appWorker
+	}
+	return nil
+}
+
+func (w *Worker) killApplicationWorker(name string) error {
+	appWorker, ok := w.applicationWorkers[name]
+	if ok {
+		delete(w.applicationWorkers, name)
+		return worker.Stop(appWorker)
+	}
+	return nil
+}
+
+// remoteApplicationWorker listens for changes to relations
+// involving a remote application, and publishes changes to
+// local relation units to the remote model.
+type remoteApplicationWorker struct {
+	catacomb         catacomb.Catacomb
+	relationsWatcher watcher.StringsWatcher
+	facade           RemoteApplicationsFacade
+}
+
+type relation struct {
+	params.RemoteRelationChange
+	ruw *relationUnitsWatcher
+}
+
+func newRemoteApplicationWorker(
+	relationsWatcher watcher.StringsWatcher,
+	facade RemoteApplicationsFacade,
+
+) (worker.Worker, error) {
+	w := &remoteApplicationWorker{
+		relationsWatcher: relationsWatcher,
+		facade:           facade,
+	}
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+		Init: []worker.Worker{relationsWatcher},
+	})
+	return w, err
+}
+
+// Kill is defined on worker.Worker
+func (w *remoteApplicationWorker) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait is defined on worker.Worker
+func (w *remoteApplicationWorker) Wait() error {
+	return w.catacomb.Wait()
+}
+
+func (w *remoteApplicationWorker) loop() error {
+	relations := make(map[string]*relation)
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case change, ok := <-w.relationsWatcher.Changes():
+			logger.Debugf("relations changed: %#v, %v", change, ok)
+			if !ok {
+				// We are dying.
+				continue
+			}
+			results, err := w.facade.RemoteRelations(change)
+			if err != nil {
+				return errors.Annotate(err, "querying relations")
+			}
+			for i, result := range results {
+				key := change[i]
+				if err := w.relationChanged(key, result, relations); err != nil {
+					return errors.Annotatef(err, "handling change for relation %q", key)
+				}
+			}
+		}
+	}
+}
+
+func (w *remoteApplicationWorker) killRelationUnitWatcher(key string, relations map[string]*relation) error {
+	relation, ok := relations[key]
+	if ok {
+		delete(relations, key)
+		return worker.Stop(relation.ruw)
+	}
+	return nil
+}
+
+func (w *remoteApplicationWorker) relationChanged(
+	key string, result params.RemoteRelationResult, relations map[string]*relation,
+) error {
+	logger.Debugf("relation %q changed: %+v", key, result.Result)
+	if result.Error != nil {
+		if params.IsCodeNotFound(result.Error) {
+			// TODO(wallyworld) - once a relation dies, wait for
+			// it to be unregistered from remote side and then use
+			// cleanup to remove.
+			return w.killRelationUnitWatcher(key, relations)
+		}
+		return result.Error
+	}
+
+	// If we have previously started the watcher and the
+	// relation is now dead, stop the watcher.
+	if r := relations[key]; r != nil {
+		r.Life = result.Result.Life
+		if r.Life == params.Dead {
+			return w.killRelationUnitWatcher(key, relations)
+		}
+		// Nothing to do, we have previously started the watcher.
+		return nil
+	}
+
+	// Start a watcher to track changes to the local units in the
+	// relation, and a worker to process those changes.
+	if result.Result.Life != params.Dead {
+		localRelationUnitsWatcher, err := w.facade.WatchLocalRelationUnits(key)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		relationUnitsWatcher, err := newRelationUnitsWatcher(
+			names.NewRelationTag(key),
+			localRelationUnitsWatcher,
+			w.facade,
+		)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if err := w.catacomb.Add(relationUnitsWatcher); err != nil {
+			return errors.Trace(err)
+		}
+		r := &relation{}
+		r.RelationId = 1 // TODO(wallyworld)
+		r.Life = result.Result.Life
+		r.ruw = relationUnitsWatcher
+		relations[key] = r
+	}
+	return nil
+}
+
+// relationUnitsWatcher uses a watcher.RelationUnitsWatcher to listen
+// to changes to relation settings in the local model and converts
+// to a params.RemoteRelationChanges for export to a remote model.
+type relationUnitsWatcher struct {
+	catacomb    catacomb.Catacomb
+	relationTag names.RelationTag
+	ruw         watcher.RelationUnitsWatcher
+	facade      RemoteApplicationsFacade
+}
+
+func newRelationUnitsWatcher(
+	relationTag names.RelationTag,
+	ruw watcher.RelationUnitsWatcher,
+	facade RemoteApplicationsFacade,
+) (*relationUnitsWatcher, error) {
+	w := &relationUnitsWatcher{
+		relationTag: relationTag,
+		ruw:         ruw,
+		facade:      facade,
+	}
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+		Init: []worker.Worker{ruw},
+	})
+	return w, err
+}
+
+// Kill is defined on worker.Worker
+func (w *relationUnitsWatcher) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait is defined on worker.Worker
+func (w *relationUnitsWatcher) Wait() error {
+	return w.catacomb.Wait()
+}
+
+func (w *relationUnitsWatcher) loop() error {
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case change, ok := <-w.ruw.Changes():
+			if !ok {
+				// We are dying.
+				continue
+			}
+			logger.Debugf("relation units changed: %#v", change)
+			if err := w.updateRelationUnitsChange(change); err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+}
+
+func (w *relationUnitsWatcher) updateRelationUnitsChange(
+	change watcher.RelationUnitsChange,
+) error {
+	// TODO(wallyworld)
+	return ObserverRelationUnitsChange(change)
+}
+
+// For testing only.
+// TODO(wallyworld) - remove when more code added.
+var ObserverRelationUnitsChange = func(change watcher.RelationUnitsChange) error {
+	logger.Infof("relation units change: %v", change)
+	return nil
 }

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -1,0 +1,241 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package remoterelations_test
+
+import (
+	"reflect"
+	"time"
+
+	"github.com/juju/errors"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/remoterelations"
+	"github.com/juju/juju/worker/workertest"
+)
+
+var _ = gc.Suite(&remoteRelationsSuite{})
+
+type remoteRelationsSuite struct {
+	coretesting.BaseSuite
+
+	resources  *common.Resources
+	authorizer *apiservertesting.FakeAuthorizer
+	facade     *mockFacade
+	config     remoterelations.Config
+	stub       *jujutesting.Stub
+}
+
+func (s *remoteRelationsSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.stub = new(jujutesting.Stub)
+	s.facade = newMockFacade(s.stub)
+	s.config = remoterelations.Config{
+		Facade: s.facade,
+	}
+}
+
+func (s *remoteRelationsSuite) waitForStubCalls(c *gc.C, expected []jujutesting.StubCall) {
+	var calls []jujutesting.StubCall
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		calls = s.stub.Calls()
+		if reflect.DeepEqual(calls, expected) {
+			return
+		}
+	}
+	c.Fatalf("failed to see expected calls. saw: %v", calls)
+}
+
+func (s *remoteRelationsSuite) assertRemoteApplicationWorkers(c *gc.C) worker.Worker {
+	// Checks that the main worker loop responds to remote application events
+	// by starting relevant relation watchers.
+	s.facade.remoteApplications["db2"] = newMockRemoteApplication("db2", "db2url")
+	s.facade.remoteApplications["django"] = newMockRemoteApplication("django", "djangourl")
+	applicationNames := []string{"db2", "django"}
+	s.facade.remoteApplicationsWatcher.changes <- applicationNames
+
+	w, err := remoterelations.New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	expected := []jujutesting.StubCall{
+		{"WatchRemoteApplications", nil},
+		{"RemoteApplications", []interface{}{[]string{"db2", "django"}}},
+		{"WatchRemoteApplicationRelations", []interface{}{"db2"}},
+		{"WatchRemoteApplicationRelations", []interface{}{"django"}},
+	}
+	s.waitForStubCalls(c, expected)
+	for _, app := range applicationNames {
+		w, ok := s.facade.remoteApplicationRelationsWatcher(app)
+		c.Check(ok, jc.IsTrue)
+		w.CheckCalls(c, []jujutesting.StubCall{
+			{"Changes", []interface{}{}},
+		})
+	}
+	return w
+}
+
+func (s *remoteRelationsSuite) TestRemoteApplicationWorkers(c *gc.C) {
+	w := s.assertRemoteApplicationWorkers(c)
+	workertest.CleanKill(c, w)
+
+	// Check that relation watchers are stopped with the worker.
+	applicationNames := []string{"db2", "django"}
+	for _, app := range applicationNames {
+		w, ok := s.facade.remoteApplicationRelationsWatcher(app)
+		c.Check(ok, jc.IsTrue)
+		c.Check(w.killed(), jc.IsTrue)
+	}
+}
+
+func (s *remoteRelationsSuite) TestRemoteApplicationRemoved(c *gc.C) {
+	// Checks that when a remote application is removed, the relation
+	// worker is killed.
+	w := s.assertRemoteApplicationWorkers(c)
+	defer workertest.CleanKill(c, w)
+	s.stub.ResetCalls()
+
+	relWatcher, _ := s.facade.removeApplication("django")
+	s.facade.remoteApplicationsWatcher.changes <- []string{"django"}
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		_, ok := s.facade.remoteApplicationRelationsWatcher("django")
+		if !ok {
+			break
+		}
+	}
+	c.Check(relWatcher.killed(), jc.IsTrue)
+	expected := []jujutesting.StubCall{
+		{"RemoteApplications", []interface{}{[]string{"django"}}},
+	}
+	s.waitForStubCalls(c, expected)
+}
+
+func (s *remoteRelationsSuite) assertRemoteRelationsWorkers(c *gc.C) worker.Worker {
+	s.facade.relations["db2:db django:db"] = newMockRelation(123)
+	w := s.assertRemoteApplicationWorkers(c)
+	s.stub.ResetCalls()
+
+	relWatcher, _ := s.facade.remoteApplicationRelationsWatcher("django")
+	relWatcher.changes <- []string{"db2:db django:db"}
+
+	expected := []jujutesting.StubCall{
+		{"RemoteRelations", []interface{}{[]string{"db2:db django:db"}}},
+		{"WatchLocalRelationUnits", []interface{}{"db2:db django:db"}},
+	}
+	s.waitForStubCalls(c, expected)
+
+	unitWatcher, ok := s.facade.relationsUnitsWatcher("db2:db django:db")
+	c.Check(ok, jc.IsTrue)
+	unitWatcher.CheckCalls(c, []jujutesting.StubCall{
+		{"Changes", []interface{}{}},
+	})
+	return w
+}
+
+func (s *remoteRelationsSuite) TestRemoteRelationsWorkers(c *gc.C) {
+	w := s.assertRemoteRelationsWorkers(c)
+	workertest.CleanKill(c, w)
+
+	// Check that relation unit watchers are stopped with the worker.
+	relWatcher, ok := s.facade.relationsUnitsWatchers["db2:db django:db"]
+	c.Check(ok, jc.IsTrue)
+	c.Check(relWatcher.killed(), jc.IsTrue)
+}
+
+func (s *remoteRelationsSuite) TestRemoteRelationsDead(c *gc.C) {
+	// Checks that when a remote relation dies, the relation units
+	// worker is killed.
+	w := s.assertRemoteRelationsWorkers(c)
+	defer workertest.CleanKill(c, w)
+	s.stub.ResetCalls()
+
+	unitsWatcher, _ := s.facade.updateRelationLife("db2:db django:db", params.Dead)
+	relWatcher, _ := s.facade.remoteApplicationRelationsWatcher("django")
+	relWatcher.changes <- []string{"db2:db django:db"}
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		_, ok := s.facade.relationsUnitsWatcher("db2:db django:db")
+		if !ok {
+			break
+		}
+	}
+	c.Assert(unitsWatcher.killed(), jc.IsTrue)
+	expected := []jujutesting.StubCall{
+		{"RemoteRelations", []interface{}{[]string{"db2:db django:db"}}},
+	}
+	s.waitForStubCalls(c, expected)
+}
+
+func (s *remoteRelationsSuite) TestRemoteRelationsRemoved(c *gc.C) {
+	// Checks that when a remote relation goes away, the relation units
+	// worker is killed.
+	w := s.assertRemoteRelationsWorkers(c)
+	defer workertest.CleanKill(c, w)
+	s.stub.ResetCalls()
+
+	unitsWatcher, _ := s.facade.removeRelation("db2:db django:db")
+	relWatcher, _ := s.facade.remoteApplicationRelationsWatcher("django")
+	relWatcher.changes <- []string{"db2:db django:db"}
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		_, ok := s.facade.relationsUnitsWatcher("db2:db django:db")
+		if !ok {
+			break
+		}
+	}
+	c.Assert(unitsWatcher.killed(), jc.IsTrue)
+	expected := []jujutesting.StubCall{
+		{"RemoteRelations", []interface{}{[]string{"db2:db django:db"}}},
+	}
+	s.waitForStubCalls(c, expected)
+}
+
+func (s *remoteRelationsSuite) TestRemoteRelationsChangedNotifies(c *gc.C) {
+	var gotChange watcher.RelationUnitsChange
+	changed := make(chan bool)
+	s.PatchValue(&remoterelations.ObserverRelationUnitsChange,
+		func(change watcher.RelationUnitsChange) error {
+			gotChange = change
+			changed <- true
+			return nil
+		})
+	w := s.assertRemoteRelationsWorkers(c)
+	defer workertest.CleanKill(c, w)
+	s.stub.ResetCalls()
+
+	unitsWatcher, _ := s.facade.relationsUnitsWatcher("db2:db django:db")
+	unitsWatcher.changes <- watcher.RelationUnitsChange{
+		Changed:  map[string]watcher.UnitSettings{"unit1": {Version: 2}},
+		Departed: []string{"unit2"},
+	}
+	select {
+	case <-changed:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("waiting for relation changes")
+	}
+	c.Assert(gotChange, jc.DeepEquals, watcher.RelationUnitsChange{
+		Changed:  map[string]watcher.UnitSettings{"unit1": {Version: 2}},
+		Departed: []string{"unit2"},
+	})
+}
+
+func (s *remoteRelationsSuite) TestRemoteRelationsChangedError(c *gc.C) {
+	s.PatchValue(&remoterelations.ObserverRelationUnitsChange,
+		func(change watcher.RelationUnitsChange) error {
+			return errors.New("failed")
+		})
+	w := s.assertRemoteRelationsWorkers(c)
+
+	unitsWatcher, _ := s.facade.relationsUnitsWatcher("db2:db django:db")
+	unitsWatcher.changes <- watcher.RelationUnitsChange{
+		Changed:  map[string]watcher.UnitSettings{"unit1": {Version: 2}},
+		Departed: []string{"unit2"},
+	}
+	err := workertest.CheckKilled(c, w)
+	c.Assert(err, gc.ErrorMatches, "failed")
+}

--- a/worker/remoterelations/shim.go
+++ b/worker/remoterelations/shim.go
@@ -17,9 +17,9 @@ func NewFacade(apiCaller base.APICaller) (RemoteApplicationsFacade, error) {
 }
 
 func NewWorker(config Config) (worker.Worker, error) {
-	worker, err := New(config)
+	w, err := New(config)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return worker, nil
+	return w, nil
 }


### PR DESCRIPTION
The remote relations work listen for remote applications. It starts listeners to respond to when relations are created, and then when units change on those relations. For now, we simply capture the change events for testing. Subsequent PRs will flesh out more detail, specifically propagating those settings changes to the remote model.

QA: bootstrap lxd