### PR TITLE
Remove remoteApplication collection from watcher

### DIFF
--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1087,7 +1087,6 @@ func newAllWatcherStateBacking(st *State) Backing {
 		machinesC,
 		unitsC,
 		applicationsC,
-		remoteApplicationsC,
 		relationsC,
 		annotationsC,
 		statusesC,


### PR DESCRIPTION
The backing state for the all watcher should not have the remoteApplication collection by default.