### PR TITLE
Merge pull request #6610 from wallyworld/remove-bad-watcher-collection

### DIFF
--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1042,7 +1042,6 @@ func newAllWatcherStateBacking(st *State) Backing {
 		machinesC,
 		unitsC,
 		applicationsC,
-		remoteApplicationsC,
 		relationsC,
 		annotationsC,
 		statusesC,


### PR DESCRIPTION
Remove remoteApplication collection from watcher

The backing state for the all watcher should not have the remoteApplication collection by default.