### PR TITLE
Ensure logTailer returns records in time order

### DIFF
--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -158,9 +158,9 @@ func (s *LogsSuite) TestIndexesCreated(c *gc.C) {
 		keys = append(keys, strings.Join(index.Key, "-"))
 	}
 	c.Assert(keys, jc.SameContents, []string{
-		"_id", // default index
-		"e-t", // model-uuid and timestamp
-		"e-n", // model-uuid and entity
+		"_id",     // default index
+		"e-t-_id", // model-uuid and timestamp
+		"e-n",     // model-uuid and entity
 	})
 }
 

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -550,6 +550,26 @@ func (s *LogTailerSuite) TestInitialLines(c *gc.C) {
 	s.assertTailer(c, tailer, 5, expected)
 }
 
+func (s *LogTailerSuite) TestRecordsAddedOutOfTimeOrder(c *gc.C) {
+	format := "2006-01-02 03:04"
+	t1, err := time.Parse(format, "2016-11-25 09:10")
+	c.Assert(err, jc.ErrorIsNil)
+	t2, err := time.Parse(format, "2016-11-25 09:20")
+	c.Assert(err, jc.ErrorIsNil)
+	here := logTemplate{Message: "logged here"}
+	s.writeLogsT(c, t2, t2, 1, here)
+	migrated := logTemplate{Message: "transferred by migration"}
+	s.writeLogsT(c, t1, t1, 1, migrated)
+
+	tailer, err := state.NewLogTailer(s.otherState, &state.LogTailerParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	defer tailer.Stop()
+
+	// They still come back in the right time order.
+	s.assertTailer(c, tailer, 1, migrated)
+	s.assertTailer(c, tailer, 1, here)
+}
+
 func (s *LogTailerSuite) TestInitialLinesWithNotEnoughLines(c *gc.C) {
 	expected := logTemplate{Message: "want"}
 	s.writeLogs(c, 2, expected)

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -232,7 +232,7 @@ func DropOldLogIndex(st *State) error {
 		return nil
 	}
 	if queryErr, ok := err.(*mgo.QueryError); ok {
-		if queryErr.Code == 0 && strings.HasPrefix(queryErr.Message, "index not found") {
+		if strings.HasPrefix(queryErr.Message, "index not found") {
 			return nil
 		}
 	}

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 )
@@ -219,4 +220,21 @@ func stripLocalFromFields(st *State, collName string, fields ...string) ([]txn.O
 		return nil, errors.Trace(err)
 	}
 	return ops, nil
+}
+
+func DropOldLogIndex(st *State) error {
+	// If the log collection still has the old e,t index, remove it.
+	key := []string{"e", "t"}
+	db := st.MongoSession().DB(logsDB)
+	collection := db.C(logsC)
+	err := collection.DropIndex(key...)
+	if err == nil {
+		return nil
+	}
+	if queryErr, ok := err.(*mgo.QueryError); ok {
+		if queryErr.Code == 0 && strings.HasPrefix(queryErr.Message, "index not found") {
+			return nil
+		}
+	}
+	return errors.Trace(err)
 }

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -373,6 +373,10 @@ func (s *upgradesSuite) TestDropOldLogIndex(c *gc.C) {
 	exists, err := hasIndex(coll, []string{"e", "t"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(exists, jc.IsFalse)
+
+	// Sanity check for idempotency.
+	err = DropOldLogIndex(s.state)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *upgradesSuite) TestDropOldIndexWhenNoIndex(c *gc.C) {

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	"reflect"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
@@ -360,4 +361,39 @@ func (s *upgradesSuite) TestRenameAddModelPermission(c *gc.C) {
 		"access":             "add-model",
 	}}
 	s.assertUpgradedData(c, RenameAddModelPermission, coll, expected)
+}
+
+func (s *upgradesSuite) TestDropOldLogIndex(c *gc.C) {
+	coll := s.state.MongoSession().DB(logsDB).C(logsC)
+	err := coll.EnsureIndexKey("e", "t")
+	c.Assert(err, jc.ErrorIsNil)
+	err = DropOldLogIndex(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+
+	exists, err := hasIndex(coll, []string{"e", "t"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(exists, jc.IsFalse)
+}
+
+func (s *upgradesSuite) TestDropOldIndexWhenNoIndex(c *gc.C) {
+	coll := s.state.MongoSession().DB(logsDB).C(logsC)
+	exists, err := hasIndex(coll, []string{"e", "t"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(exists, jc.IsFalse)
+
+	err = DropOldLogIndex(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func hasIndex(coll *mgo.Collection, key []string) (bool, error) {
+	indexes, err := coll.Indexes()
+	if err != nil {
+		return false, err
+	}
+	for _, index := range indexes {
+		if reflect.DeepEqual(index.Key, key) {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -19,6 +19,7 @@ import (
 var stateUpgradeOperations = func() []Operation {
 	steps := []Operation{
 		upgradeToVersion{version.MustParse("2.0.0"), stateStepsFor20()},
+		upgradeToVersion{version.MustParse("2.1.0"), stateStepsFor21()},
 	}
 	return steps
 }

--- a/upgrades/steps_21.go
+++ b/upgrades/steps_21.go
@@ -1,0 +1,21 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+import (
+	"github.com/juju/juju/state"
+)
+
+// stateStepsFor21 returns upgrade steps for Juju 2.1 that manipulate state directly.
+func stateStepsFor21() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "drop old log index",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.DropOldLogIndex(context.State())
+			},
+		},
+	}
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -659,6 +659,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.StateUpgradeOperations)())
 	c.Assert(versions, gc.DeepEquals, []string{
 		"2.0.0",
+		"2.1.0",
 	})
 }
 


### PR DESCRIPTION
Having the separate sort by id worked by coincidence when records were
inserted in time order, but now that old records can be added by
migration the ids don't match up with times so records come back out of order.

Add id to the index instead and use one sort.

QA:
Deployed ubuntu to a new model
Noted the earliest log message for the model
Bootstrapped another controller
Migrated the model to the new controller
Checked that the earliest log message was the same