### PR TITLE
Tweak loading of remore apps and remote relations

### DIFF
--- a/api/remoterelations/remoterelations.go
+++ b/api/remoterelations/remoterelations.go
@@ -98,15 +98,15 @@ func (c *Client) RelationUnitSettings(relationUnits []params.RelationUnit) ([]pa
 	return results.Results, nil
 }
 
-// RemoteRelations returns information about the cross-model relations with the specified keys
+// Relations returns information about the cross-model relations with the specified keys
 // in the local model.
-func (c *Client) RemoteRelations(keys []string) ([]params.RemoteRelationResult, error) {
+func (c *Client) Relations(keys []string) ([]params.RelationResult, error) {
 	args := params.Entities{Entities: make([]params.Entity, len(keys))}
 	for i, key := range keys {
 		args.Entities[i].Tag = names.NewRelationTag(key).String()
 	}
-	var results params.RemoteRelationResults
-	err := c.facade.FacadeCall("RemoteRelations", args, &results)
+	var results params.RelationResults
+	err := c.facade.FacadeCall("Relations", args, &results)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/remoterelations/remoterelations_test.go
+++ b/api/remoterelations/remoterelations_test.go
@@ -232,17 +232,17 @@ func (s *remoteRelationsSuite) TestRelationUnitSettingsResultsCount(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `expected 1 result\(s\), got 2`)
 }
 
-func (s *remoteRelationsSuite) TestRemoteRelations(c *gc.C) {
+func (s *remoteRelationsSuite) TestRelations(c *gc.C) {
 	var callCount int
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "RemoteRelations")
 		c.Check(version, gc.Equals, 0)
 		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "RemoteRelations")
+		c.Check(request, gc.Equals, "Relations")
 		c.Check(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "relation-foo.db#bar.db"}}})
-		c.Assert(result, gc.FitsTypeOf, &params.RemoteRelationResults{})
-		*(result.(*params.RemoteRelationResults)) = params.RemoteRelationResults{
-			Results: []params.RemoteRelationResult{{
+		c.Assert(result, gc.FitsTypeOf, &params.RelationResults{})
+		*(result.(*params.RelationResults)) = params.RelationResults{
+			Results: []params.RelationResult{{
 				Error: &params.Error{Message: "FAIL"},
 			}},
 		}
@@ -250,17 +250,17 @@ func (s *remoteRelationsSuite) TestRemoteRelations(c *gc.C) {
 		return nil
 	})
 	client := remoterelations.NewClient(apiCaller)
-	result, err := client.RemoteRelations([]string{"foo:db bar:db"})
+	result, err := client.Relations([]string{"foo:db bar:db"})
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
 	c.Check(result[0].Error, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }
 
-func (s *remoteRelationsSuite) TestRemoteRelationsResultsCount(c *gc.C) {
+func (s *remoteRelationsSuite) TestRelationsResultsCount(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		*(result.(*params.RemoteRelationResults)) = params.RemoteRelationResults{
-			Results: []params.RemoteRelationResult{
+		*(result.(*params.RelationResults)) = params.RelationResults{
+			Results: []params.RelationResult{
 				{Error: &params.Error{Message: "FAIL"}},
 				{Error: &params.Error{Message: "FAIL"}},
 			},
@@ -268,7 +268,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationsResultsCount(c *gc.C) {
 		return nil
 	})
 	client := remoterelations.NewClient(apiCaller)
-	_, err := client.RemoteRelations([]string{"foo:db bar:db"})
+	_, err := client.Relations([]string{"foo:db bar:db"})
 	c.Check(err, gc.ErrorMatches, `expected 1 result\(s\), got 2`)
 }
 

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -264,8 +264,9 @@ type RemoteRelationResults struct {
 // RemoteApplication describes the current state of an application involved in a cross-
 // model relation, from the perspective of the local environment.
 type RemoteApplication struct {
-	Id   RemoteEntityId `json:"id"`
-	Life Life           `json:"life"`
+	Name   string `json:"name"`
+	Life   Life   `json:"life"`
+	Status string `json:"status"`
 }
 
 // RemoteApplicationResult holds a remote application and an error.

--- a/apiserver/remoterelations/mock_test.go
+++ b/apiserver/remoterelations/mock_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/remoterelations"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -204,9 +205,10 @@ func (r *mockRelation) WatchUnits(applicationName string) (state.RelationUnitsWa
 
 type mockRemoteApplication struct {
 	testing.Stub
-	name string
-	url  string
-	life state.Life
+	name   string
+	url    string
+	life   state.Life
+	status status.Status
 }
 
 func newMockRemoteApplication(name, url string) *mockRemoteApplication {
@@ -223,6 +225,11 @@ func (r *mockRemoteApplication) Name() string {
 func (r *mockRemoteApplication) Life() state.Life {
 	r.MethodCall(r, "Life")
 	return r.life
+}
+
+func (r *mockRemoteApplication) Status() (status.StatusInfo, error) {
+	r.MethodCall(r, "Life")
+	return status.StatusInfo{Status: r.status}, nil
 }
 
 func (r *mockRemoteApplication) URL() (string, bool) {

--- a/apiserver/remoterelations/mock_test.go
+++ b/apiserver/remoterelations/mock_test.go
@@ -228,7 +228,7 @@ func (r *mockRemoteApplication) Life() state.Life {
 }
 
 func (r *mockRemoteApplication) Status() (status.StatusInfo, error) {
-	r.MethodCall(r, "Life")
+	r.MethodCall(r, "Status")
 	return status.StatusInfo{Status: r.status}, nil
 }
 

--- a/apiserver/remoterelations/remoterelations_test.go
+++ b/apiserver/remoterelations/remoterelations_test.go
@@ -471,7 +471,7 @@ func (s *remoteRelationsSuite) TestRemoteApplications(c *gc.C) {
 	result, err := s.api.RemoteApplications(params.Entities{Entities: []params.Entity{{Tag: "application-django"}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, jc.DeepEquals, []params.RemoteApplicationResult{{
-		Result: &params.RemoteApplication{Life: "alive"}}})
+		Result: &params.RemoteApplication{Name: "django", Life: "alive"}}})
 	s.st.CheckCalls(c, []testing.StubCall{
 		{"RemoteApplication", []interface{}{"django"}},
 	})
@@ -483,15 +483,14 @@ func (s *remoteRelationsSuite) TestRemoteRelations(c *gc.C) {
 	db2Relation := newMockRelation(123)
 	db2Relation.units["django/0"] = djangoRelationUnit
 	s.st.relations["db2:db django:db"] = db2Relation
-	result, err := s.api.RemoteRelations(params.Entities{Entities: []params.Entity{{Tag: "relation-db2.db#django.db"}}})
+	result, err := s.api.Relations(params.Entities{Entities: []params.Entity{{Tag: "relation-db2.db#django.db"}}})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Results, jc.DeepEquals, []params.RemoteRelationResult{{
-		Result: &params.RemoteRelation{
-			Id:   params.RemoteEntityId{ModelUUID: coretesting.ModelTag.Id(), Token: "token-db2:db django:db"},
-			Life: "alive",
-		}}})
+	c.Assert(result.Results, jc.DeepEquals, []params.RelationResult{{
+		Id:   123,
+		Life: "alive",
+		Key:  "db2:db django:db",
+	}})
 	s.st.CheckCalls(c, []testing.StubCall{
 		{"KeyRelation", []interface{}{"db2:db django:db"}},
-		{"ExportLocalEntity", []interface{}{names.NewRelationTag("db2:db django:db")}},
 	})
 }

--- a/apiserver/remoterelations/state.go
+++ b/apiserver/remoterelations/state.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 )
 
 // RemoteRelationState provides the subset of global state required by the
@@ -118,6 +119,9 @@ type RemoteApplication interface {
 
 	// Life returns the lifecycle state of the application.
 	Life() state.Life
+
+	// Status returns the status of the remote application.
+	Status() (status.StatusInfo, error)
 }
 
 // Application represents the state of a application hosted in the local environment.

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -296,9 +296,9 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 	}
 	if featureflag.Enabled(feature.CrossModelRelations) {
 		result[remoteRelationsName] = ifNotMigrating(remoterelations.Manifold(remoterelations.ManifoldConfig{
-			APICallerName: apiCallerName,
-			NewFacade:     remoterelations.NewFacade,
-			NewWorker:     remoterelations.NewWorker,
+			APICallerName:            apiCallerName,
+			NewRemoteRelationsFacade: remoterelations.NewRemoteRelationsFacade,
+			NewWorker:                remoterelations.NewWorker,
 		}))
 	}
 	return result

--- a/worker/remoterelations/manifold.go
+++ b/worker/remoterelations/manifold.go
@@ -19,8 +19,8 @@ type ManifoldConfig struct {
 	AgentName     string
 	APICallerName string
 
-	NewFacade func(base.APICaller) (RemoteApplicationsFacade, error)
-	NewWorker func(Config) (worker.Worker, error)
+	NewRemoteRelationsFacade func(base.APICaller) (RemoteRelationsFacade, error)
+	NewWorker                func(Config) (worker.Worker, error)
 }
 
 // Validate is called by start to check for bad configuration.
@@ -31,8 +31,8 @@ func (config ManifoldConfig) Validate() error {
 	if config.APICallerName == "" {
 		return errors.NotValidf("empty APICallerName")
 	}
-	if config.NewFacade == nil {
-		return errors.NotValidf("nil NewFacade")
+	if config.NewRemoteRelationsFacade == nil {
+		return errors.NotValidf("nil NewRemoteRelationsFacade")
 	}
 	if config.NewWorker == nil {
 		return errors.NotValidf("nil NewWorker")
@@ -54,12 +54,12 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	if err := context.Get(config.APICallerName, &apiConn); err != nil {
 		return nil, errors.Trace(err)
 	}
-	facade, err := config.NewFacade(apiConn)
+	facade, err := config.NewRemoteRelationsFacade(apiConn)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	worker, err := config.NewWorker(Config{
-		Facade: facade,
+		RelationsFacade: facade,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/remoterelations/manifold_test.go
+++ b/worker/remoterelations/manifold_test.go
@@ -28,10 +28,10 @@ func (s *ManifoldConfigSuite) SetUpTest(c *gc.C) {
 
 func (s *ManifoldConfigSuite) validConfig() remoterelations.ManifoldConfig {
 	return remoterelations.ManifoldConfig{
-		AgentName:     "agent",
-		APICallerName: "api-caller",
-		NewFacade:     func(base.APICaller) (remoterelations.RemoteApplicationsFacade, error) { return nil, nil },
-		NewWorker:     func(remoterelations.Config) (worker.Worker, error) { return nil, nil },
+		AgentName:                "agent",
+		APICallerName:            "api-caller",
+		NewRemoteRelationsFacade: func(base.APICaller) (remoterelations.RemoteRelationsFacade, error) { return nil, nil },
+		NewWorker:                func(remoterelations.Config) (worker.Worker, error) { return nil, nil },
 	}
 }
 
@@ -49,9 +49,9 @@ func (s *ManifoldConfigSuite) TestMissingAPICallerName(c *gc.C) {
 	s.checkNotValid(c, "empty APICallerName not valid")
 }
 
-func (s *ManifoldConfigSuite) TestMissingNewFacade(c *gc.C) {
-	s.config.NewFacade = nil
-	s.checkNotValid(c, "nil NewFacade not valid")
+func (s *ManifoldConfigSuite) TestMissingNewRemoteRelationsFacade(c *gc.C) {
+	s.config.NewRemoteRelationsFacade = nil
+	s.checkNotValid(c, "nil NewRemoteRelationsFacade not valid")
 }
 
 func (s *ManifoldConfigSuite) TestMissingNewWorker(c *gc.C) {

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -16,10 +16,10 @@ import (
 	"github.com/juju/juju/worker/remoterelations"
 )
 
-type mockFacade struct {
+type mockRelationsFacade struct {
 	mu   sync.Mutex
 	stub *testing.Stub
-	remoterelations.RemoteApplicationsFacade
+	remoterelations.RemoteRelationsFacade
 	remoteApplicationsWatcher          *mockStringsWatcher
 	remoteApplicationRelationsWatchers map[string]*mockStringsWatcher
 	remoteApplications                 map[string]*mockRemoteApplication
@@ -27,8 +27,8 @@ type mockFacade struct {
 	relationsUnitsWatchers             map[string]*mockRelationUnitsWatcher
 }
 
-func newMockFacade(stub *testing.Stub) *mockFacade {
-	return &mockFacade{
+func newMockRelationsFacade(stub *testing.Stub) *mockRelationsFacade {
+	return &mockRelationsFacade{
 		stub:                               stub,
 		remoteApplications:                 make(map[string]*mockRemoteApplication),
 		relations:                          make(map[string]*mockRelation),
@@ -38,7 +38,7 @@ func newMockFacade(stub *testing.Stub) *mockFacade {
 	}
 }
 
-func (m *mockFacade) WatchRemoteApplications() (watcher.StringsWatcher, error) {
+func (m *mockRelationsFacade) WatchRemoteApplications() (watcher.StringsWatcher, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.stub.MethodCall(m, "WatchRemoteApplications")
@@ -48,14 +48,14 @@ func (m *mockFacade) WatchRemoteApplications() (watcher.StringsWatcher, error) {
 	return m.remoteApplicationsWatcher, nil
 }
 
-func (m *mockFacade) remoteApplicationRelationsWatcher(name string) (*mockStringsWatcher, bool) {
+func (m *mockRelationsFacade) remoteApplicationRelationsWatcher(name string) (*mockStringsWatcher, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	w, ok := m.remoteApplicationRelationsWatchers[name]
 	return w, ok
 }
 
-func (m *mockFacade) removeApplication(name string) (*mockStringsWatcher, bool) {
+func (m *mockRelationsFacade) removeApplication(name string) (*mockStringsWatcher, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	w, ok := m.remoteApplicationRelationsWatchers[name]
@@ -63,14 +63,14 @@ func (m *mockFacade) removeApplication(name string) (*mockStringsWatcher, bool) 
 	return w, ok
 }
 
-func (m *mockFacade) relationsUnitsWatcher(key string) (*mockRelationUnitsWatcher, bool) {
+func (m *mockRelationsFacade) relationsUnitsWatcher(key string) (*mockRelationUnitsWatcher, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	w, ok := m.relationsUnitsWatchers[key]
 	return w, ok
 }
 
-func (m *mockFacade) removeRelation(key string) (*mockRelationUnitsWatcher, bool) {
+func (m *mockRelationsFacade) removeRelation(key string) (*mockRelationUnitsWatcher, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	w, ok := m.relationsUnitsWatchers[key]
@@ -78,7 +78,7 @@ func (m *mockFacade) removeRelation(key string) (*mockRelationUnitsWatcher, bool
 	return w, ok
 }
 
-func (m *mockFacade) updateRelationLife(key string, life params.Life) (*mockRelationUnitsWatcher, bool) {
+func (m *mockRelationsFacade) updateRelationLife(key string, life params.Life) (*mockRelationUnitsWatcher, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	w, ok := m.relationsUnitsWatchers[key]
@@ -86,7 +86,7 @@ func (m *mockFacade) updateRelationLife(key string, life params.Life) (*mockRela
 	return w, ok
 }
 
-func (m *mockFacade) WatchRemoteApplicationRelations(application string) (watcher.StringsWatcher, error) {
+func (m *mockRelationsFacade) WatchRemoteApplicationRelations(application string) (watcher.StringsWatcher, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.stub.MethodCall(m, "WatchRemoteApplicationRelations", application)
@@ -97,7 +97,7 @@ func (m *mockFacade) WatchRemoteApplicationRelations(application string) (watche
 	return m.remoteApplicationRelationsWatchers[application], nil
 }
 
-func (m *mockFacade) RemoteApplications(names []string) ([]params.RemoteApplicationResult, error) {
+func (m *mockRelationsFacade) RemoteApplications(names []string) ([]params.RemoteApplicationResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.stub.MethodCall(m, "RemoteApplications", names)
@@ -122,7 +122,7 @@ func (m *mockFacade) RemoteApplications(names []string) ([]params.RemoteApplicat
 	return result, nil
 }
 
-func (m *mockFacade) Relations(keys []string) ([]params.RelationResult, error) {
+func (m *mockRelationsFacade) Relations(keys []string) ([]params.RelationResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.stub.MethodCall(m, "Relations", keys)
@@ -145,7 +145,7 @@ func (m *mockFacade) Relations(keys []string) ([]params.RelationResult, error) {
 	return result, nil
 }
 
-func (m *mockFacade) WatchLocalRelationUnits(relationKey string) (watcher.RelationUnitsWatcher, error) {
+func (m *mockRelationsFacade) WatchLocalRelationUnits(relationKey string) (watcher.RelationUnitsWatcher, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.stub.MethodCall(m, "WatchLocalRelationUnits", relationKey)

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -109,8 +109,9 @@ func (m *mockFacade) RemoteApplications(names []string) ([]params.RemoteApplicat
 		if app, ok := m.remoteApplications[name]; ok {
 			result[i] = params.RemoteApplicationResult{
 				Result: &params.RemoteApplication{
-					// TODO(wallyworld) - add Id
-					Life: app.life,
+					Name:   app.name,
+					Life:   app.life,
+					Status: app.status,
 				},
 			}
 		} else {
@@ -121,24 +122,23 @@ func (m *mockFacade) RemoteApplications(names []string) ([]params.RemoteApplicat
 	return result, nil
 }
 
-func (m *mockFacade) RemoteRelations(keys []string) ([]params.RemoteRelationResult, error) {
+func (m *mockFacade) Relations(keys []string) ([]params.RelationResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.stub.MethodCall(m, "RemoteRelations", keys)
+	m.stub.MethodCall(m, "Relations", keys)
 	if err := m.stub.NextErr(); err != nil {
 		return nil, err
 	}
-	result := make([]params.RemoteRelationResult, len(keys))
+	result := make([]params.RelationResult, len(keys))
 	for i, key := range keys {
 		if rel, ok := m.relations[key]; ok {
-			result[i] = params.RemoteRelationResult{
-				Result: &params.RemoteRelation{
-					// TODO(wallyworld) - add Id
-					Life: rel.life,
-				},
+			result[i] = params.RelationResult{
+				Id:   rel.id,
+				Life: rel.life,
+				Key:  keys[i],
 			}
 		} else {
-			result[i] = params.RemoteRelationResult{
+			result[i] = params.RelationResult{
 				Error: common.ServerError(errors.NotFoundf(key))}
 		}
 	}
@@ -209,9 +209,10 @@ func (w *mockStringsWatcher) Changes() watcher.StringsChannel {
 
 type mockRemoteApplication struct {
 	testing.Stub
-	name string
-	url  string
-	life params.Life
+	name   string
+	url    string
+	life   params.Life
+	status string
 }
 
 type mockRelationUnitsWatcher struct {

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -17,7 +17,7 @@ import (
 var logger = loggo.GetLogger("juju.worker.remoterelations")
 
 // RemoteApplicationsFacade exposes remote relation functionality to a worker.
-type RemoteApplicationsFacade interface {
+type RemoteRelationsFacade interface {
 	// ExportEntities allocates unique, remote entity IDs for the
 	// given entities in the local model.
 	ExportEntities([]names.Tag) ([]params.RemoteEntityIdResult, error)
@@ -55,12 +55,12 @@ type RemoteApplicationsFacade interface {
 
 // Config defines the operation of a Worker.
 type Config struct {
-	Facade RemoteApplicationsFacade
+	RelationsFacade RemoteRelationsFacade
 }
 
 // Validate returns an error if config cannot drive a Worker.
 func (config Config) Validate() error {
-	if config.Facade == nil {
+	if config.RelationsFacade == nil {
 		return errors.NotValidf("nil Facade")
 	}
 	return nil
@@ -107,7 +107,7 @@ func (w *Worker) Wait() error {
 }
 
 func (w *Worker) loop() (err error) {
-	changes, err := w.config.Facade.WatchRemoteApplications()
+	changes, err := w.config.RelationsFacade.WatchRemoteApplications()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -134,7 +134,7 @@ func (w *Worker) handleApplicationChanges(applicationIds []string) error {
 	logger.Debugf("processing remote application changes for: %s", applicationIds)
 
 	// Fetch the current state of each of the remote applications that have changed.
-	results, err := w.config.Facade.RemoteApplications(applicationIds)
+	results, err := w.config.RelationsFacade.RemoteApplications(applicationIds)
 	if err != nil {
 		return errors.Annotate(err, "querying remote applications")
 	}
@@ -158,7 +158,7 @@ func (w *Worker) handleApplicationChanges(applicationIds []string) error {
 		}
 		// A new remote application has appeared, start monitoring relations to it
 		// originating from the local model.
-		relationsWatcher, err := w.config.Facade.WatchRemoteApplicationRelations(name)
+		relationsWatcher, err := w.config.RelationsFacade.WatchRemoteApplicationRelations(name)
 		if errors.IsNotFound(err) {
 			if err := w.killApplicationWorker(name); err != nil {
 				return err
@@ -170,7 +170,7 @@ func (w *Worker) handleApplicationChanges(applicationIds []string) error {
 		logger.Debugf("started watcher for remote application %q", name)
 		appWorker, err := newRemoteApplicationWorker(
 			relationsWatcher,
-			w.config.Facade,
+			w.config.RelationsFacade,
 		)
 		if err != nil {
 			return errors.Trace(err)
@@ -198,7 +198,7 @@ func (w *Worker) killApplicationWorker(name string) error {
 type remoteApplicationWorker struct {
 	catacomb         catacomb.Catacomb
 	relationsWatcher watcher.StringsWatcher
-	facade           RemoteApplicationsFacade
+	facade           RemoteRelationsFacade
 }
 
 type relation struct {
@@ -208,7 +208,7 @@ type relation struct {
 
 func newRemoteApplicationWorker(
 	relationsWatcher watcher.StringsWatcher,
-	facade RemoteApplicationsFacade,
+	facade RemoteRelationsFacade,
 
 ) (worker.Worker, error) {
 	w := &remoteApplicationWorker{
@@ -327,13 +327,13 @@ type relationUnitsWatcher struct {
 	catacomb    catacomb.Catacomb
 	relationTag names.RelationTag
 	ruw         watcher.RelationUnitsWatcher
-	facade      RemoteApplicationsFacade
+	facade      RemoteRelationsFacade
 }
 
 func newRelationUnitsWatcher(
 	relationTag names.RelationTag,
 	ruw watcher.RelationUnitsWatcher,
-	facade RemoteApplicationsFacade,
+	facade RemoteRelationsFacade,
 ) (*relationUnitsWatcher, error) {
 	w := &relationUnitsWatcher{
 		relationTag: relationTag,

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -126,7 +126,7 @@ func (s *remoteRelationsSuite) assertRemoteRelationsWorkers(c *gc.C) worker.Work
 	relWatcher.changes <- []string{"db2:db django:db"}
 
 	expected := []jujutesting.StubCall{
-		{"RemoteRelations", []interface{}{[]string{"db2:db django:db"}}},
+		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
 		{"WatchLocalRelationUnits", []interface{}{"db2:db django:db"}},
 	}
 	s.waitForStubCalls(c, expected)
@@ -167,7 +167,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDead(c *gc.C) {
 	}
 	c.Assert(unitsWatcher.killed(), jc.IsTrue)
 	expected := []jujutesting.StubCall{
-		{"RemoteRelations", []interface{}{[]string{"db2:db django:db"}}},
+		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
 	}
 	s.waitForStubCalls(c, expected)
 }
@@ -190,7 +190,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationsRemoved(c *gc.C) {
 	}
 	c.Assert(unitsWatcher.killed(), jc.IsTrue)
 	expected := []jujutesting.StubCall{
-		{"RemoteRelations", []interface{}{[]string{"db2:db django:db"}}},
+		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
 	}
 	s.waitForStubCalls(c, expected)
 }

--- a/worker/remoterelations/shim.go
+++ b/worker/remoterelations/shim.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/juju/worker"
 )
 
-func NewFacade(apiCaller base.APICaller) (RemoteApplicationsFacade, error) {
+func NewRemoteRelationsFacade(apiCaller base.APICaller) (RemoteRelationsFacade, error) {
 	facade := remoterelations.NewClient(apiCaller)
 	return facade, nil
 }


### PR DESCRIPTION
When loading remote relations in the worker, we no longer export the relations as a side effect of the api call. This will be done separately downstream when the relations details are published.

Also add name and status to remote application struct.