### PR TITLE
provider/maas: conditionally run ifdown/up

### DIFF
--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -15,6 +15,13 @@ import shutil
 import subprocess
 import sys
 
+# StringIO: accommodate Python2 & Python3
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 # These options are to be removed from a sub-interface and applied to
 # the new bridged interface.
 
@@ -416,6 +423,16 @@ def main(args):
 
     if not args.activate:
         print_stanzas(stanzas)
+        exit(0)
+
+    cur = StringIO()
+    new = StringIO()
+
+    print_stanzas(stanzas, new)
+    print_stanzas(parser.stanzas(), cur)
+
+    if cur.getvalue() == new.getvalue():
+        # nothing changed
         exit(0)
 
     if args.one_time_backup:

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -21,6 +21,13 @@ import shutil
 import subprocess
 import sys
 
+# StringIO: accommodate Python2 & Python3
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 # These options are to be removed from a sub-interface and applied to
 # the new bridged interface.
 
@@ -422,6 +429,16 @@ def main(args):
 
     if not args.activate:
         print_stanzas(stanzas)
+        exit(0)
+
+    cur = StringIO()
+    new = StringIO()
+
+    print_stanzas(stanzas, new)
+    print_stanzas(parser.stanzas(), cur)
+
+    if cur.getvalue() == new.getvalue():
+        # nothing changed
         exit(0)
 
     if args.one_time_backup:


### PR DESCRIPTION
If the nett result of bridging interfaces results in nothing-to-do,
because they are already bridged, then don't run ifdown/up
unnecessarily.

This state can exist in MAAS 2.1 because you now have the option of
bridging interfaces ahead of deployment or bootstrap. And as we move
to dynamic bridging in Juju we want to invoke this script on an
interface on an ad-hoc basis but don't want it to do anything if that
interface is already bridged.

QA steps:

On a machine run:

 $ sudo ./add-juju-bridge.py /etc/network/interfaces \
     --activate \
     --interfaces-to-bridge=enp1s0f2

And note that enp1s0f2 gets bridged.

Verify with:

 $ brctl show

Run the add-juju-bridge.py script again with the same arguments and
now you'll see no action taken as it is already bridged as
br-enp1s0f2.

I also configured a node in MAAS 2.1 that had two bridged NICs;
bootstrapping a node doesn't additionally run ifdown/up because
there's nothing to do.