### PR TITLE
Add Ping method to providers

### DIFF
--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -18,6 +18,7 @@ import (
 
 	cloudfile "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/testing"
 )
 
@@ -259,6 +260,9 @@ func (*addSuite) TestInteractiveOpenstack(c *gc.C) {
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", m1Metadata).Returns(nil)
 
 	command := cloud.NewAddCloudCommand(fake)
+	command.Ping = func(environs.EnvironProvider, string) error {
+		return nil
+	}
 	err := testing.InitCommand(command, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -295,6 +299,9 @@ func (*addSuite) TestInteractiveMaas(c *gc.C) {
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", m1Metadata).Returns(nil)
 
 	command := cloud.NewAddCloudCommand(fake)
+	command.Ping = func(environs.EnvironProvider, string) error {
+		return nil
+	}
 	err := testing.InitCommand(command, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -323,6 +330,9 @@ func (*addSuite) TestInteractiveManual(c *gc.C) {
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", manMetadata).Returns(nil)
 
 	command := cloud.NewAddCloudCommand(fake)
+	command.Ping = func(environs.EnvironProvider, string) error {
+		return nil
+	}
 	err := testing.InitCommand(command, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -373,6 +383,9 @@ func (*addSuite) TestInteractiveVSphere(c *gc.C) {
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", vsphereMetadata).Returns(nil)
 
 	command := cloud.NewAddCloudCommand(fake)
+	command.Ping = func(environs.EnvironProvider, string) error {
+		return nil
+	}
 	err := testing.InitCommand(command, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -405,6 +418,9 @@ func (*addSuite) TestInteractiveExistingNameOverride(c *gc.C) {
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", manMetadata).Returns(nil)
 
 	command := cloud.NewAddCloudCommand(fake)
+	command.Ping = func(environs.EnvironProvider, string) error {
+		return nil
+	}
 	err := testing.InitCommand(command, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -441,6 +457,9 @@ func (*addSuite) TestInteractiveExistingNameNoOverride(c *gc.C) {
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", compoundCloudMetadata).Returns(nil)
 
 	command := cloud.NewAddCloudCommand(fake)
+	command.Ping = func(environs.EnvironProvider, string) error {
+		return nil
+	}
 	err := testing.InitCommand(command, nil)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/cmd/juju/interact/pollster.go
+++ b/cmd/juju/interact/pollster.go
@@ -22,9 +22,10 @@ import (
 // Pollster is used to ask multiple questions of the user using a standard
 // formatting.
 type Pollster struct {
-	scanner *bufio.Scanner
-	out     io.Writer
-	errOut  io.Writer
+	VerifyURLs VerifyFunc
+	scanner    *bufio.Scanner
+	out        io.Writer
+	errOut     io.Writer
 }
 
 // New returns a Pollster that wraps the given reader and writer.
@@ -393,7 +394,11 @@ func (p *Pollster) queryOneSchema(schema *jsonschema.Schema) (interface{}, error
 		// anything
 		a, err = p.Enter(schema.Singular)
 	case jsonschema.FormatURI:
-		a, err = p.EnterVerify(schema.Singular, uriVerify)
+		if p.VerifyURLs == nil {
+			a, err = p.EnterVerify(schema.Singular, uriVerify)
+		} else {
+			a, err = p.EnterVerify(schema.Singular, p.VerifyURLs)
+		}
 	default:
 		// TODO(natefinch): support more formats
 		return nil, errors.Errorf("unsupported format type: %q", schema.Format)

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -28,6 +28,9 @@ type EnvironProvider interface {
 	// nil.
 	CloudSchema() *jsonschema.Schema
 
+	// Ping tests the connection to the cloud, to verify the endpoint is valid.
+	Ping(endpoint string) error
+
 	// PrepareConfig prepares the configuration for a new model, based on
 	// the provided arguments. PrepareConfig is expected to produce a
 	// deterministic output. Any unique values should be based on the

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -104,6 +104,11 @@ func (p azureEnvironProvider) CloudSchema() *jsonschema.Schema {
 	return nil
 }
 
+// Ping tests the connection to the cloud, to verify the endpoint is valid.
+func (p azureEnvironProvider) Ping(endpoint string) error {
+	return errors.NotImplementedf("Ping")
+}
+
 // PrepareConfig is part of the EnvironProvider interface.
 func (prov *azureEnvironProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {

--- a/provider/cloudsigma/provider.go
+++ b/provider/cloudsigma/provider.go
@@ -88,6 +88,11 @@ func (p environProvider) CloudSchema() *jsonschema.Schema {
 	return nil
 }
 
+// Ping tests the connection to the cloud, to verify the endpoint is valid.
+func (p environProvider) Ping(endpoint string) error {
+	return errors.NotImplementedf("Ping")
+}
+
 // PrepareConfig is defined by EnvironProvider.
 func (environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -620,6 +620,11 @@ func (p environProvider) CloudSchema() *jsonschema.Schema {
 	return nil
 }
 
+// Ping tests the connection to the cloud, to verify the endpoint is valid.
+func (p environProvider) Ping(endpoint string) error {
+	return errors.NotImplementedf("Ping")
+}
+
 // PrepareConfig is specified in the EnvironProvider interface.
 func (p *environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	if _, err := dummy.newConfig(args.Config); err != nil {

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -104,6 +104,11 @@ func (p environProvider) CloudSchema() *jsonschema.Schema {
 	return nil
 }
 
+// Ping tests the connection to the cloud, to verify the endpoint is valid.
+func (p environProvider) Ping(endpoint string) error {
+	return errors.NotImplementedf("Ping")
+}
+
 // PrepareConfig is specified in the EnvironProvider interface.
 func (p environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {

--- a/provider/gce/provider.go
+++ b/provider/gce/provider.go
@@ -35,6 +35,11 @@ func (p environProvider) CloudSchema() *jsonschema.Schema {
 	return nil
 }
 
+// Ping tests the connection to the cloud, to verify the endpoint is valid.
+func (p environProvider) Ping(endpoint string) error {
+	return errors.NotImplementedf("Ping")
+}
+
 // PrepareConfig implements environs.EnvironProvider.
 func (p environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {

--- a/provider/joyent/provider.go
+++ b/provider/joyent/provider.go
@@ -53,6 +53,11 @@ func (p joyentProvider) CloudSchema() *jsonschema.Schema {
 	return nil
 }
 
+// Ping tests the connection to the cloud, to verify the endpoint is valid.
+func (p joyentProvider) Ping(endpoint string) error {
+	return errors.NotImplementedf("Ping")
+}
+
 // PrepareConfig is part of the EnvironProvider interface.
 func (p joyentProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -39,6 +39,11 @@ func (p environProvider) CloudSchema() *jsonschema.Schema {
 	return nil
 }
 
+// Ping tests the connection to the cloud, to verify the endpoint is valid.
+func (p environProvider) Ping(endpoint string) error {
+	return errors.NotImplementedf("Ping")
+}
+
 // PrepareConfig implements environs.EnvironProvider.
 func (p environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {

--- a/provider/maas/config.go
+++ b/provider/maas/config.go
@@ -27,7 +27,7 @@ type maasModelConfig struct {
 	attrs map[string]interface{}
 }
 
-func (prov maasEnvironProvider) newConfig(cfg *config.Config) (*maasModelConfig, error) {
+func (prov MaasEnvironProvider) newConfig(cfg *config.Config) (*maasModelConfig, error) {
 	validCfg, err := prov.Validate(cfg, nil)
 	if err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func (prov maasEnvironProvider) newConfig(cfg *config.Config) (*maasModelConfig,
 }
 
 // Schema returns the configuration schema for an environment.
-func (maasEnvironProvider) Schema() environschema.Fields {
+func (MaasEnvironProvider) Schema() environschema.Fields {
 	fields, err := config.Schema(configSchema)
 	if err != nil {
 		panic(err)
@@ -49,17 +49,17 @@ func (maasEnvironProvider) Schema() environschema.Fields {
 
 // ConfigSchema returns extra config attributes specific
 // to this provider only.
-func (p maasEnvironProvider) ConfigSchema() schema.Fields {
+func (p MaasEnvironProvider) ConfigSchema() schema.Fields {
 	return configFields
 }
 
 // ConfigDefaults returns the default values for the
 // provider specific config attributes.
-func (p maasEnvironProvider) ConfigDefaults() schema.Defaults {
+func (p MaasEnvironProvider) ConfigDefaults() schema.Defaults {
 	return configDefaults
 }
 
-func (prov maasEnvironProvider) Validate(cfg, oldCfg *config.Config) (*config.Config, error) {
+func (prov MaasEnvironProvider) Validate(cfg, oldCfg *config.Config) (*config.Config, error) {
 	// Validate base configuration change before validating MAAS specifics.
 	err := config.Validate(cfg, oldCfg)
 	if err != nil {

--- a/provider/maas/config_test.go
+++ b/provider/maas/config_test.go
@@ -6,7 +6,6 @@ package maas
 import (
 	"github.com/juju/gomaasapi"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/config"
@@ -15,7 +14,7 @@ import (
 
 // Ensure MAAS provider supports the expected interfaces.
 var (
-	_ config.ConfigSchemaSource = (*maasEnvironProvider)(nil)
+	_ config.ConfigSchemaSource = (*MaasEnvironProvider)(nil)
 )
 
 type configSuite struct {
@@ -48,10 +47,6 @@ func newConfig(values map[string]interface{}) (*maasModelConfig, error) {
 
 func (s *configSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	mockCapabilities := func(*gomaasapi.MAASObject, string) (set.Strings, error) {
-		return set.NewStrings("network-deployment-ubuntu"), nil
-	}
-	s.PatchValue(&GetCapabilities, mockCapabilities)
 	mockGetController := func(string, string) (gomaasapi.Controller, error) {
 		return nil, gomaasapi.NewUnsupportedVersionError("oops")
 	}
@@ -68,7 +63,7 @@ func (*configSuite) TestValidateUpcallsEnvironsConfigValidate(c *gc.C) {
 	newCfg, err := oldCfg.Apply(map[string]interface{}{"name": newName})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = maasEnvironProvider{}.Validate(newCfg, oldCfg.Config)
+	_, err = MaasEnvironProvider{}.Validate(newCfg, oldCfg.Config)
 
 	c.Assert(err, gc.NotNil)
 	c.Check(err, gc.ErrorMatches, ".*cannot change name.*")

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -47,13 +47,9 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
 
-	mockCapabilities := func(*gomaasapi.MAASObject, string) (set.Strings, error) {
-		return set.NewStrings("network-deployment-ubuntu"), nil
-	}
 	mockGetController := func(string, string) (gomaasapi.Controller, error) {
 		return nil, gomaasapi.NewUnsupportedVersionError("oops")
 	}
-	s.PatchValue(&maas.GetCapabilities, mockCapabilities)
 	s.PatchValue(&maas.GetMAAS2Controller, mockGetController)
 }
 
@@ -96,7 +92,7 @@ func (*environSuite) TestSetConfigValidatesFirst(c *gc.C) {
 	// changes in the environment name.
 	oldCfg := getSimpleTestConfig(c, coretesting.Attrs{"name": "old-name"})
 	newCfg := getSimpleTestConfig(c, coretesting.Attrs{"name": "new-name"})
-	env, err := maas.NewEnviron(getSimpleCloudSpec(), oldCfg)
+	env, err := maas.NewEnviron(getSimpleCloudSpec(), oldCfg, fakeGetCapabilities)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// SetConfig() fails, even though both the old and the new config are
@@ -109,12 +105,16 @@ func (*environSuite) TestSetConfigValidatesFirst(c *gc.C) {
 	c.Check(env.Config().Name(), gc.Equals, "old-name")
 }
 
+func fakeGetCapabilities(client *gomaasapi.MAASObject, serverURL string) (set.Strings, error) {
+	return set.NewStrings("network-deployment-ubuntu"), nil
+}
+
 func (*environSuite) TestSetConfigUpdatesConfig(c *gc.C) {
 	origAttrs := coretesting.Attrs{
 		"apt-mirror": "http://testing1.invalid",
 	}
 	cfg := getSimpleTestConfig(c, origAttrs)
-	env, err := maas.NewEnviron(getSimpleCloudSpec(), cfg)
+	env, err := maas.NewEnviron(getSimpleCloudSpec(), cfg, fakeGetCapabilities)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(env.Config().Name(), gc.Equals, "testenv")
 
@@ -131,7 +131,7 @@ func (*environSuite) TestSetConfigUpdatesConfig(c *gc.C) {
 func (*environSuite) TestNewEnvironSetsConfig(c *gc.C) {
 	cfg := getSimpleTestConfig(c, nil)
 
-	env, err := maas.NewEnviron(getSimpleCloudSpec(), cfg)
+	env, err := maas.NewEnviron(getSimpleCloudSpec(), cfg, fakeGetCapabilities)
 
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(env.Config().Name(), gc.Equals, "testenv")
@@ -144,7 +144,7 @@ var expectedCloudinitConfig = []string{
 
 func (*environSuite) TestNewCloudinitConfig(c *gc.C) {
 	cfg := getSimpleTestConfig(c, nil)
-	env, err := maas.NewEnviron(getSimpleCloudSpec(), cfg)
+	env, err := maas.NewEnviron(getSimpleCloudSpec(), cfg, fakeGetCapabilities)
 	c.Assert(err, jc.ErrorIsNil)
 	var path string
 	path, err = maas.BridgeScriptPathForSeries("quantal")
@@ -163,7 +163,7 @@ func (*environSuite) TestNewCloudinitConfigWithDisabledNetworkManagement(c *gc.C
 		"disable-network-management": true,
 	}
 	cfg := getSimpleTestConfig(c, attrs)
-	env, err := maas.NewEnviron(getSimpleCloudSpec(), cfg)
+	env, err := maas.NewEnviron(getSimpleCloudSpec(), cfg, fakeGetCapabilities)
 	c.Assert(err, jc.ErrorIsNil)
 	cloudcfg, err := maas.NewCloudinitConfig(env, "testing.invalid", "quantal", nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -220,7 +220,7 @@ func (s *badEndpointSuite) SetUpTest(c *gc.C) {
 
 func (s *badEndpointSuite) TestBadEndpointMessageNoMAAS(c *gc.C) {
 	cfg := getSimpleTestConfig(c, coretesting.Attrs{})
-	env, err := maas.NewEnviron(s.cloudSpec, cfg)
+	env, err := maas.NewEnviron(s.cloudSpec, cfg, nil)
 	c.Assert(env, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, `could not connect to MAAS controller - check the endpoint is correct \(it normally ends with /MAAS\)`)
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
@@ -229,7 +229,7 @@ func (s *badEndpointSuite) TestBadEndpointMessageNoMAAS(c *gc.C) {
 func (s *badEndpointSuite) TestBadEndpointMessageWithMAAS(c *gc.C) {
 	cfg := getSimpleTestConfig(c, coretesting.Attrs{})
 	s.cloudSpec.Endpoint += "/MAAS"
-	env, err := maas.NewEnviron(s.cloudSpec, cfg)
+	env, err := maas.NewEnviron(s.cloudSpec, cfg, nil)
 	c.Assert(env, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, `could not connect to MAAS controller - check the endpoint is correct`)
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
@@ -238,7 +238,7 @@ func (s *badEndpointSuite) TestBadEndpointMessageWithMAAS(c *gc.C) {
 func (s *badEndpointSuite) TestBadEndpointMessageWithMAASAndSlash(c *gc.C) {
 	cfg := getSimpleTestConfig(c, coretesting.Attrs{})
 	s.cloudSpec.Endpoint += "/MAAS/"
-	env, err := maas.NewEnviron(s.cloudSpec, cfg)
+	env, err := maas.NewEnviron(s.cloudSpec, cfg, nil)
 	c.Assert(env, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, `could not connect to MAAS controller - check the endpoint is correct`)
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -32,6 +32,7 @@ var cloudSchema = &jsonschema.Schema{
 		cloud.EndpointKey: &jsonschema.Schema{
 			Singular: "the API endpoint url",
 			Type:     []jsonschema.Type{jsonschema.StringType},
+			Format:   jsonschema.FormatURI,
 		},
 	},
 }
@@ -39,20 +40,24 @@ var cloudSchema = &jsonschema.Schema{
 // Logger for the MAAS provider.
 var logger = loggo.GetLogger("juju.provider.maas")
 
-type maasEnvironProvider struct {
+type MaasEnvironProvider struct {
 	environProviderCredentials
+
+	// GetCapabilities is a function that connects to MAAS to return its set of
+	// capabilities.
+	GetCapabilities MaasCapabilities
 }
 
-var _ environs.EnvironProvider = (*maasEnvironProvider)(nil)
+var _ environs.EnvironProvider = (*MaasEnvironProvider)(nil)
 
-var providerInstance maasEnvironProvider
+var providerInstance MaasEnvironProvider
 
-func (maasEnvironProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+func (MaasEnvironProvider) Open(args environs.OpenParams) (environs.Environ, error) {
 	logger.Debugf("opening model %q.", args.Config.Name())
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}
-	env, err := NewEnviron(args.Cloud, args.Config)
+	env, err := NewEnviron(args.Cloud, args.Config, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -63,12 +68,36 @@ var errAgentNameAlreadySet = errors.New(
 	"maas-agent-name is already set; this should not be set by hand")
 
 // CloudSchema returns the schema for adding new clouds of this type.
-func (p maasEnvironProvider) CloudSchema() *jsonschema.Schema {
+func (p MaasEnvironProvider) CloudSchema() *jsonschema.Schema {
 	return cloudSchema
 }
 
+// Ping tests the connection to the cloud, to verify the endpoint is valid.
+func (p MaasEnvironProvider) Ping(endpoint string) error {
+	err := p.checkMaas(endpoint, apiVersion2)
+	if err == nil {
+		return nil
+	}
+	err = p.checkMaas(endpoint, apiVersion1)
+	if err == nil {
+		return nil
+	}
+	return errors.Errorf("No MAAS server running at %s", endpoint)
+}
+
+func (p MaasEnvironProvider) checkMaas(endpoint, ver string) error {
+	c, err := gomaasapi.NewAnonymousClient(endpoint, ver)
+	if err != nil {
+		logger.Debugf("Can't create maas API %s client for %q: %v", ver, endpoint, err)
+		return errors.Trace(err)
+	}
+	maas := gomaasapi.NewMAAS(*c)
+	_, err = p.GetCapabilities(maas, endpoint)
+	return errors.Trace(err)
+}
+
 // PrepareConfig is specified in the EnvironProvider interface.
-func (p maasEnvironProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
+func (p MaasEnvironProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}
@@ -101,7 +130,7 @@ Please ensure the credentials are correct.`)
 }
 
 // DetectRegions is specified in the environs.CloudRegionDetector interface.
-func (p maasEnvironProvider) DetectRegions() ([]cloud.Region, error) {
+func (p MaasEnvironProvider) DetectRegions() ([]cloud.Region, error) {
 	return nil, errors.NotFoundf("regions")
 }
 

--- a/provider/maas/init.go
+++ b/provider/maas/init.go
@@ -12,5 +12,5 @@ const (
 )
 
 func init() {
-	environs.RegisterProvider(providerType, maasEnvironProvider{})
+	environs.RegisterProvider(providerType, MaasEnvironProvider{GetCapabilities: getCapabilities})
 }

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -60,7 +60,7 @@ func (suite *maas2EnvironSuite) getEnvWithServer(c *gc.C) (*maasEnviron, error) 
 	attrs := coretesting.FakeConfig().Merge(maasEnvAttrs)
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	return NewEnviron(cloud, cfg)
+	return NewEnviron(cloud, cfg, nil)
 }
 
 func (suite *maas2EnvironSuite) TestNewEnvironWithController(c *gc.C) {

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -53,7 +53,7 @@ func (suite *maas2Suite) makeEnviron(c *gc.C, controller gomaasapi.Controller) *
 	suite.controllerUUID = coretesting.FakeControllerConfig().ControllerUUID()
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := NewEnviron(cloud, cfg)
+	env, err := NewEnviron(cloud, cfg, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env, gc.NotNil)
 	return env

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -95,13 +95,9 @@ func (s *providerSuite) SetUpSuite(c *gc.C) {
 
 func (s *providerSuite) SetUpTest(c *gc.C) {
 	s.baseProviderSuite.SetUpTest(c)
-	mockCapabilities := func(*gomaasapi.MAASObject, string) (set.Strings, error) {
-		return set.NewStrings("network-deployment-ubuntu"), nil
-	}
 	mockGetController := func(string, string) (gomaasapi.Controller, error) {
 		return nil, gomaasapi.NewUnsupportedVersionError("oops")
 	}
-	s.PatchValue(&GetCapabilities, mockCapabilities)
 	s.PatchValue(&GetMAAS2Controller, mockGetController)
 	// Creating a space ensures that the spaces endpoint won't 404.
 	s.testMAASObject.TestServer.NewSpace(spaceJSON(gomaasapi.CreateSpace{Name: "space-0"}))
@@ -142,7 +138,9 @@ func (suite *providerSuite) makeEnviron() *maasEnviron {
 	if err != nil {
 		panic(err)
 	}
-	env, err := NewEnviron(cloud, cfg)
+	env, err := NewEnviron(cloud, cfg, func(client *gomaasapi.MAASObject, serverURL string) (set.Strings, error) {
+		return set.NewStrings("network-deployment-ubuntu"), nil
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/provider/manual/config_test.go
+++ b/provider/manual/config_test.go
@@ -50,7 +50,7 @@ func MinimalConfig(c *gc.C) *config.Config {
 func getModelConfig(c *gc.C, attrs map[string]interface{}) *environConfig {
 	testConfig, err := config.New(config.UseDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	envConfig, err := manualProvider{}.validate(testConfig, nil)
+	envConfig, err := ManualProvider{}.validate(testConfig, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return envConfig
 }

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -181,7 +181,7 @@ func (e *manualEnviron) verifyBootstrapHost() error {
 func (e *manualEnviron) SetConfig(cfg *config.Config) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	_, err := manualProvider{}.validate(cfg, e.cfg.Config)
+	_, err := ManualProvider{}.validate(cfg, e.cfg.Config)
 	if err != nil {
 		return err
 	}
@@ -352,7 +352,7 @@ func (e *manualEnviron) Ports() ([]network.PortRange, error) {
 }
 
 func (*manualEnviron) Provider() environs.EnvironProvider {
-	return manualProvider{}
+	return ManualProvider{}
 }
 
 func isRunningController() bool {

--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -26,7 +26,7 @@ type baseEnvironSuite struct {
 
 func (s *baseEnvironSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	env, err := manualProvider{}.Open(environs.OpenParams{
+	env, err := ManualProvider{}.Open(environs.OpenParams{
 		Cloud:  CloudSpec(),
 		Config: MinimalConfig(c),
 	})

--- a/provider/manual/export_test.go
+++ b/provider/manual/export_test.go
@@ -4,6 +4,6 @@
 package manual
 
 var (
-	ProviderInstance = manualProvider{}
+	ProviderInstance = ManualProvider{}
 	InitUbuntuUser   = &initUbuntuUser
 )

--- a/provider/manual/init.go
+++ b/provider/manual/init.go
@@ -10,6 +10,6 @@ const (
 )
 
 func init() {
-	p := manualProvider{}
+	p := ManualProvider{}
 	environs.RegisterProvider(providerType, p, "null")
 }

--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -4,11 +4,13 @@
 package manual
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/jsonschema"
+	"github.com/juju/utils/ssh"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
@@ -16,12 +18,15 @@ import (
 	"github.com/juju/juju/environs/manual/sshprovisioner"
 )
 
-type manualProvider struct {
+// ManualProvider contains the logic for using a random ubuntu machine as a
+// controller, connected via SSH.
+type ManualProvider struct {
 	environProviderCredentials
+	ping func(endpoint string) error
 }
 
 // Verify that we conform to the interface.
-var _ environs.EnvironProvider = (*manualProvider)(nil)
+var _ environs.EnvironProvider = (*ManualProvider)(nil)
 
 var initUbuntuUser = sshprovisioner.InitUbuntuUser
 
@@ -36,7 +41,7 @@ func ensureBootstrapUbuntuUser(ctx environs.BootstrapContext, host, user string,
 }
 
 // DetectRegions is specified in the environs.CloudRegionDetector interface.
-func (p manualProvider) DetectRegions() ([]cloud.Region, error) {
+func (p ManualProvider) DetectRegions() ([]cloud.Region, error) {
 	return nil, errors.NotFoundf("regions")
 }
 
@@ -53,12 +58,42 @@ var cloudSchema = &jsonschema.Schema{
 }
 
 // CloudSchema returns the schema for verifying the cloud configuration.
-func (p manualProvider) CloudSchema() *jsonschema.Schema {
+func (p ManualProvider) CloudSchema() *jsonschema.Schema {
 	return cloudSchema
 }
 
+// Ping tests the connection to the cloud, to verify the endpoint is valid.
+func (p ManualProvider) Ping(endpoint string) error {
+	if p.ping != nil {
+		return p.ping(endpoint)
+	}
+	return pingMachine(endpoint)
+}
+
+// pingMachine is what is used in production by ManualProvider.Ping().  It
+// attempts a simplistic ssh connection to verify the machine exists and that
+// you can log into it with SSH.
+func pingMachine(endpoint string) error {
+	// There's no "just connect" command for utils/ssh, so we run a command that
+	// should always work.
+	cmd := ssh.Command(endpoint, []string{"echo", "hi"}, nil)
+
+	// os/exec just returns an error that contains the error code from the
+	// executable, which is basically useless, but stderr usually shows
+	// something useful, so we show that instead.
+	buf := bytes.Buffer{}
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		if buf.Len() > 0 {
+			return errors.New(buf.String())
+		}
+		return err
+	}
+	return nil
+}
+
 // PrepareConfig is specified in the EnvironProvider interface.
-func (p manualProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
+func (p ManualProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -69,7 +104,7 @@ func (p manualProvider) PrepareConfig(args environs.PrepareConfigParams) (*confi
 	return args.Config.Apply(envConfig.attrs)
 }
 
-func (p manualProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+func (p ManualProvider) Open(args environs.OpenParams) (environs.Environ, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -98,7 +133,7 @@ func validateCloudSpec(spec environs.CloudSpec) error {
 	return nil
 }
 
-func (p manualProvider) open(host, user string, cfg *environConfig) (environs.Environ, error) {
+func (p ManualProvider) open(host, user string, cfg *environConfig) (environs.Environ, error) {
 	env := &manualEnviron{host: host, user: user, cfg: cfg}
 	// Need to call SetConfig to initialise storage.
 	if err := env.SetConfig(cfg.Config); err != nil {
@@ -114,7 +149,7 @@ func checkImmutableString(cfg, old *environConfig, key string) error {
 	return nil
 }
 
-func (p manualProvider) validate(cfg, old *config.Config) (*environConfig, error) {
+func (p ManualProvider) validate(cfg, old *config.Config) (*environConfig, error) {
 	// Check for valid changes for the base config values.
 	if err := config.Validate(cfg, old); err != nil {
 		return nil, err
@@ -142,7 +177,7 @@ func (p manualProvider) validate(cfg, old *config.Config) (*environConfig, error
 	return envConfig, nil
 }
 
-func (p manualProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {
+func (p ManualProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {
 	envConfig, err := p.validate(cfg, old)
 	if err != nil {
 		return nil, err

--- a/provider/rackspace/init.go
+++ b/provider/rackspace/init.go
@@ -6,6 +6,8 @@ package rackspace
 import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/openstack"
+	"gopkg.in/goose.v1/client"
+	"gopkg.in/goose.v1/identity"
 )
 
 const (
@@ -14,11 +16,14 @@ const (
 
 func init() {
 	osProvider := &openstack.EnvironProvider{
-		Credentials{},
-		&rackspaceConfigurator{},
-		&firewallerFactory{},
-		openstack.FlavorFilterFunc(acceptRackspaceFlavor),
-		rackspaceNetworkingDecorator{},
+		ProviderCredentials: Credentials{},
+		Configurator:        &rackspaceConfigurator{},
+		FirewallerFactory:   &firewallerFactory{},
+		FlavorFilter:        openstack.FlavorFilterFunc(acceptRackspaceFlavor),
+		NetworkingDecorator: rackspaceNetworkingDecorator{},
+		ClientFromEndpoint: func(endpoint string) client.AuthenticatingClient {
+			return client.NewClient(&identity.Credentials{URL: endpoint}, 0, nil)
+		},
 	}
 	providerInstance = &environProvider{
 		osProvider,

--- a/provider/rackspace/provider.go
+++ b/provider/rackspace/provider.go
@@ -6,6 +6,7 @@ package rackspace
 import (
 	"strings"
 
+	"github.com/juju/errors"
 	"github.com/juju/jsonschema"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -21,6 +22,11 @@ var providerInstance *environProvider
 // this provider does not support custom clouds, this always returns nil.
 func (p environProvider) CloudSchema() *jsonschema.Schema {
 	return nil
+}
+
+// Ping tests the connection to the cloud, to verify the endpoint is valid.
+func (p environProvider) Ping(endpoint string) error {
+	return errors.NotImplementedf("Ping")
 }
 
 // PrepareConfig is part of the EnvironProvider interface.

--- a/provider/rackspace/provider_test.go
+++ b/provider/rackspace/provider_test.go
@@ -91,6 +91,11 @@ func (p *fakeProvider) CloudSchema() *jsonschema.Schema {
 	return nil
 }
 
+// Ping tests the connection to the cloud, to verify the endpoint is valid.
+func (p fakeProvider) Ping(endpoint string) error {
+	return errors.NotImplementedf("Ping")
+}
+
 func (p *fakeProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
 	p.MethodCall(p, "CredentialSchemas")
 	return nil

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -6,6 +6,8 @@
 package vsphere
 
 import (
+	"net/url"
+
 	"github.com/juju/errors"
 	"github.com/juju/jsonschema"
 	"github.com/juju/loggo"
@@ -63,6 +65,13 @@ var cloudSchema = &jsonschema.Schema{
 // CloudSchema returns the schema for adding new clouds of this type.
 func (p environProvider) CloudSchema() *jsonschema.Schema {
 	return cloudSchema
+}
+
+// Ping tests the connection to the cloud, to verify the endpoint is valid.
+func (p environProvider) Ping(endpoint string) error {
+	// a stub for now until we get a real implementation.
+	_, err := url.Parse(endpoint)
+	return errors.Trace(err)
 }
 
 // PrepareConfig implements environs.EnvironProvider.


### PR DESCRIPTION
In order to know if an endpoint is correct when adding a cloud,
we need to be able to ping that provider to get an idea if it
even exists.  This is long before bootstrap or even credentials,
so we need a way to reasonably determine if a cloud of the
correct type exists at the hostname/ip.  This is different per
cloud, thus a per-provider endpoint.

This fixes https://bugs.launchpad.net/juju/+bug/1641970