### PR TITLE
migrations: implement log transfer phase

### DIFF
--- a/api/base/caller.go
+++ b/api/base/caller.go
@@ -5,6 +5,7 @@ package base
 
 import (
 	"io"
+	"net/http"
 	"net/url"
 
 	"github.com/juju/httprequest"
@@ -39,6 +40,7 @@ type APICaller interface {
 	HTTPClient() (*httprequest.Client, error)
 
 	StreamConnector
+	ControllerStreamConnector
 }
 
 // StreamConnector is implemented by the client-facing State object.
@@ -51,6 +53,18 @@ type StreamConnector interface {
 	//
 	// The path must start with a "/".
 	ConnectStream(path string, attrs url.Values) (Stream, error)
+}
+
+// ControllerStreamConnector is implemented by the client-facing State object.
+type ControllerStreamConnector interface {
+	// ConnectControllerStream connects to the given HTTP websocket
+	// endpoint path and returns the resulting connection. The given
+	// values are used as URL query values when making the initial
+	// HTTP request. Headers passed in will be added to the HTTP
+	// request.
+	//
+	// The path must be absolute and can't start with "/model".
+	ConnectControllerStream(path string, attrs url.Values, headers http.Header) (Stream, error)
 }
 
 // Stream represents a streaming connection to the API.

--- a/api/base/testing/apicaller.go
+++ b/api/base/testing/apicaller.go
@@ -46,11 +46,11 @@ func (APICallerFunc) HTTPClient() (*httprequest.Client, error) {
 }
 
 func (APICallerFunc) ConnectStream(path string, attrs url.Values) (base.Stream, error) {
-	return nil, errors.New("stream connection unimplemented")
+	return nil, errors.NotImplementedf("stream connection")
 }
 
 func (APICallerFunc) ConnectControllerStream(path string, attrs url.Values, headers http.Header) (base.Stream, error) {
-	return nil, errors.New("stream connection unimplemented")
+	return nil, errors.NotImplementedf("controller stream connection")
 }
 
 // CheckArgs holds the possible arguments to CheckingAPICaller(). Any

--- a/api/base/testing/apicaller.go
+++ b/api/base/testing/apicaller.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"net/http"
 	"net/url"
 
 	"github.com/juju/errors"
@@ -45,6 +46,10 @@ func (APICallerFunc) HTTPClient() (*httprequest.Client, error) {
 }
 
 func (APICallerFunc) ConnectStream(path string, attrs url.Values) (base.Stream, error) {
+	return nil, errors.New("stream connection unimplemented")
+}
+
+func (APICallerFunc) ConnectControllerStream(path string, attrs url.Values, headers http.Header) (base.Stream, error) {
 	return nil, errors.New("stream connection unimplemented")
 }
 

--- a/api/client.go
+++ b/api/client.go
@@ -12,10 +12,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 	"github.com/juju/version"
 	"golang.org/x/net/websocket"
 	"gopkg.in/juju/charm.v6-unstable"
@@ -24,6 +22,7 @@ import (
 	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/downloader"
@@ -524,111 +523,8 @@ func (c websocketStream) WriteJSON(v interface{}) error {
 	return websocket.JSON.Send(c.Conn, v)
 }
 
-// TODO(ericsnow) Fold DebugLogParams into params.LogStreamConfig.
-
-// DebugLogParams holds parameters for WatchDebugLog that control the
-// filtering of the log messages. If the structure is zero initialized, the
-// entire log file is sent back starting from the end, and until the user
-// closes the connection.
-type DebugLogParams struct {
-	// IncludeEntity lists entity tags to include in the response. Tags may
-	// finish with a '*' to match a prefix e.g.: unit-mysql-*, machine-2. If
-	// none are set, then all lines are considered included.
-	IncludeEntity []string
-	// IncludeModule lists logging modules to include in the response. If none
-	// are set all modules are considered included.  If a module is specified,
-	// all the submodules also match.
-	IncludeModule []string
-	// ExcludeEntity lists entity tags to exclude from the response. As with
-	// IncludeEntity the values may finish with a '*'.
-	ExcludeEntity []string
-	// ExcludeModule lists logging modules to exclude from the resposne. If a
-	// module is specified, all the submodules are also excluded.
-	ExcludeModule []string
-	// Limit defines the maximum number of lines to return. Once this many
-	// have been sent, the socket is closed.  If zero, all filtered lines are
-	// sent down the connection until the client closes the connection.
-	Limit uint
-	// Backlog tells the server to try to go back this many lines before
-	// starting filtering. If backlog is zero and replay is false, then there
-	// may be an initial delay until the next matching log message is written.
-	Backlog uint
-	// Level specifies the minimum logging level to be sent back in the response.
-	Level loggo.Level
-	// Replay tells the server to start at the start of the log file rather
-	// than the end. If replay is true, backlog is ignored.
-	Replay bool
-	// NoTail tells the server to only return the logs it has now, and not
-	// to wait for new logs to arrive.
-	NoTail bool
-}
-
-func (args DebugLogParams) URLQuery() url.Values {
-	attrs := url.Values{
-		"includeEntity": args.IncludeEntity,
-		"includeModule": args.IncludeModule,
-		"excludeEntity": args.ExcludeEntity,
-		"excludeModule": args.ExcludeModule,
-	}
-	if args.Replay {
-		attrs.Set("replay", fmt.Sprint(args.Replay))
-	}
-	if args.NoTail {
-		attrs.Set("noTail", fmt.Sprint(args.NoTail))
-	}
-	if args.Limit > 0 {
-		attrs.Set("maxLines", fmt.Sprint(args.Limit))
-	}
-	if args.Backlog > 0 {
-		attrs.Set("backlog", fmt.Sprint(args.Backlog))
-	}
-	if args.Level != loggo.UNSPECIFIED {
-		attrs.Set("level", fmt.Sprint(args.Level))
-	}
-	return attrs
-}
-
-// LogMessage is a structured logging entry.
-type LogMessage struct {
-	Entity    string
-	Timestamp time.Time
-	Severity  string
-	Module    string
-	Location  string
-	Message   string
-}
-
 // WatchDebugLog returns a channel of structured Log Messages. Only log entries
 // that match the filtering specified in the DebugLogParams are returned.
-func (c *Client) WatchDebugLog(args DebugLogParams) (<-chan LogMessage, error) {
-	// Prepare URL query attributes.
-	attrs := args.URLQuery()
-
-	connection, err := c.st.ConnectStream("/log", attrs)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	messages := make(chan LogMessage)
-	go func() {
-		defer close(messages)
-
-		for {
-			var msg params.LogMessage
-			err := connection.ReadJSON(&msg)
-			if err != nil {
-				return
-			}
-			messages <- LogMessage{
-				Entity:    msg.Entity,
-				Timestamp: msg.Timestamp,
-				Severity:  msg.Severity,
-				Module:    msg.Module,
-				Location:  msg.Location,
-				Message:   msg.Message,
-			}
-		}
-	}()
-
-	return messages, nil
+func (c *Client) WatchDebugLog(args common.DebugLogParams) (<-chan common.LogMessage, error) {
+	return common.StreamDebugLog(c.st, args)
 }

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -405,6 +405,32 @@ func (s *clientSuite) TestConnectStreamErrorReadError(c *gc.C) {
 	c.Assert(reader, gc.IsNil)
 }
 
+func (s *clientSuite) TestConnectControllerStreamRejectsRelativePaths(c *gc.C) {
+	reader, err := s.APIState.ConnectControllerStream("foo", nil, nil)
+	c.Assert(err, gc.ErrorMatches, `path "foo" is not absolute`)
+	c.Assert(reader, gc.IsNil)
+}
+
+func (s *clientSuite) TestConnectControllerStreamRejectsModelPaths(c *gc.C) {
+	reader, err := s.APIState.ConnectControllerStream("/model/foo", nil, nil)
+	c.Assert(err, gc.ErrorMatches, `path "/model/foo" is model-specific`)
+	c.Assert(reader, gc.IsNil)
+}
+
+func (s *clientSuite) TestConnectControllerStreamAppliesHeaders(c *gc.C) {
+	catcher := urlCatcher{}
+	headers := http.Header{}
+	headers.Add("thomas", "cromwell")
+	headers.Add("anne", "boleyn")
+	s.PatchValue(api.WebsocketDialConfig, catcher.recordLocation)
+
+	_, err := s.APIState.ConnectControllerStream("/something", nil, headers)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(catcher.headers.Get("thomas"), gc.Equals, "cromwell")
+	c.Assert(catcher.headers.Get("anne"), gc.Equals, "boleyn")
+}
+
 func (s *clientSuite) TestWatchDebugLogParamsEncoded(c *gc.C) {
 	catcher := urlCatcher{}
 	s.PatchValue(api.WebsocketDialConfig, catcher.recordLocation)
@@ -531,10 +557,12 @@ func (r *badReader) Read(p []byte) (n int, err error) {
 
 type urlCatcher struct {
 	location *url.URL
+	headers  http.Header
 }
 
 func (u *urlCatcher) recordLocation(config *websocket.Config) (base.Stream, error) {
 	u.location = config.Location
+	u.headers = config.Header
 	pr, pw := io.Pipe()
 	go func() {
 		fmt.Fprintf(pw, "null\n")

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
 	jujunames "github.com/juju/juju/juju/names"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -356,7 +357,7 @@ func (s *clientSuite) TestWatchDebugLogConnected(c *gc.C) {
 	// Use the no tail option so we don't try to start a tailing cursor
 	// on the oplog when there is no oplog configured in mongo as the tests
 	// don't set up mongo in replicaset mode.
-	messages, err := client.WatchDebugLog(api.DebugLogParams{NoTail: true})
+	messages, err := client.WatchDebugLog(common.DebugLogParams{NoTail: true})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(messages, gc.NotNil)
 }
@@ -408,7 +409,7 @@ func (s *clientSuite) TestWatchDebugLogParamsEncoded(c *gc.C) {
 	catcher := urlCatcher{}
 	s.PatchValue(api.WebsocketDialConfig, catcher.recordLocation)
 
-	params := api.DebugLogParams{
+	params := common.DebugLogParams{
 		IncludeEntity: []string{"a", "b"},
 		IncludeModule: []string{"c", "d"},
 		ExcludeEntity: []string{"e", "f"},

--- a/api/common/logs.go
+++ b/api/common/logs.go
@@ -15,8 +15,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 )
 
-// TODO(ericsnow) Fold DebugLogParams into params.LogStreamConfig.
-
 // DebugLogParams holds parameters for WatchDebugLog that control the
 // filtering of the log messages. If the structure is zero initialized, the
 // entire log file is sent back starting from the end, and until the user

--- a/api/common/logs.go
+++ b/api/common/logs.go
@@ -1,0 +1,123 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+)
+
+// TODO(ericsnow) Fold DebugLogParams into params.LogStreamConfig.
+
+// DebugLogParams holds parameters for WatchDebugLog that control the
+// filtering of the log messages. If the structure is zero initialized, the
+// entire log file is sent back starting from the end, and until the user
+// closes the connection.
+type DebugLogParams struct {
+	// IncludeEntity lists entity tags to include in the response. Tags may
+	// finish with a '*' to match a prefix e.g.: unit-mysql-*, machine-2. If
+	// none are set, then all lines are considered included.
+	IncludeEntity []string
+	// IncludeModule lists logging modules to include in the response. If none
+	// are set all modules are considered included.  If a module is specified,
+	// all the submodules also match.
+	IncludeModule []string
+	// ExcludeEntity lists entity tags to exclude from the response. As with
+	// IncludeEntity the values may finish with a '*'.
+	ExcludeEntity []string
+	// ExcludeModule lists logging modules to exclude from the resposne. If a
+	// module is specified, all the submodules are also excluded.
+	ExcludeModule []string
+	// Limit defines the maximum number of lines to return. Once this many
+	// have been sent, the socket is closed.  If zero, all filtered lines are
+	// sent down the connection until the client closes the connection.
+	Limit uint
+	// Backlog tells the server to try to go back this many lines before
+	// starting filtering. If backlog is zero and replay is false, then there
+	// may be an initial delay until the next matching log message is written.
+	Backlog uint
+	// Level specifies the minimum logging level to be sent back in the response.
+	Level loggo.Level
+	// Replay tells the server to start at the start of the log file rather
+	// than the end. If replay is true, backlog is ignored.
+	Replay bool
+	// NoTail tells the server to only return the logs it has now, and not
+	// to wait for new logs to arrive.
+	NoTail bool
+}
+
+func (args DebugLogParams) URLQuery() url.Values {
+	attrs := url.Values{
+		"includeEntity": args.IncludeEntity,
+		"includeModule": args.IncludeModule,
+		"excludeEntity": args.ExcludeEntity,
+		"excludeModule": args.ExcludeModule,
+	}
+	if args.Replay {
+		attrs.Set("replay", fmt.Sprint(args.Replay))
+	}
+	if args.NoTail {
+		attrs.Set("noTail", fmt.Sprint(args.NoTail))
+	}
+	if args.Limit > 0 {
+		attrs.Set("maxLines", fmt.Sprint(args.Limit))
+	}
+	if args.Backlog > 0 {
+		attrs.Set("backlog", fmt.Sprint(args.Backlog))
+	}
+	if args.Level != loggo.UNSPECIFIED {
+		attrs.Set("level", fmt.Sprint(args.Level))
+	}
+	return attrs
+}
+
+// LogMessage is a structured logging entry.
+type LogMessage struct {
+	Entity    string
+	Timestamp time.Time
+	Severity  string
+	Module    string
+	Location  string
+	Message   string
+}
+
+func StreamDebugLog(source base.StreamConnector, args DebugLogParams) (<-chan LogMessage, error) {
+	// Prepare URL query attributes.
+	attrs := args.URLQuery()
+
+	connection, err := source.ConnectStream("/log", attrs)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	messages := make(chan LogMessage)
+	go func() {
+		defer close(messages)
+
+		for {
+			var msg params.LogMessage
+			err := connection.ReadJSON(&msg)
+			if err != nil {
+				return
+			}
+			messages <- LogMessage{
+				Entity:    msg.Entity,
+				Timestamp: msg.Timestamp,
+				Severity:  msg.Severity,
+				Module:    msg.Module,
+				Location:  msg.Location,
+				Message:   msg.Message,
+			}
+		}
+	}()
+
+	return messages, nil
+}

--- a/api/common/logs.go
+++ b/api/common/logs.go
@@ -89,7 +89,16 @@ type LogMessage struct {
 	Message   string
 }
 
+// StreamDebugLog requests the specified debug log records from the
+// server and returns a channel of the messages that come back.
 func StreamDebugLog(source base.StreamConnector, args DebugLogParams) (<-chan LogMessage, error) {
+	// TODO(babbageclunk): this isn't cancellable - if the caller stops
+	// reading from the channel (because it has an error, for example),
+	// the goroutine will be leaked. This is OK when used from the command
+	// line, but is a problem if it happens in jujud. Change it to accept
+	// a stop channel and use a read deadline so that the client can stop
+	// it. https://pad.lv/1644084
+
 	// Prepare URL query attributes.
 	attrs := args.URLQuery()
 

--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/watcher"
@@ -247,4 +248,8 @@ func groupTagIds(tagStrs []string) ([]string, []string, error) {
 		}
 	}
 	return machines, units, nil
+}
+
+func (c *Client) StreamModelLog() (<-chan common.LogMessage, error) {
+	return common.StreamDebugLog(c.caller.RawAPICaller(), common.DebugLogParams{})
 }

--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -251,5 +251,8 @@ func groupTagIds(tagStrs []string) ([]string, []string, error) {
 }
 
 func (c *Client) StreamModelLog() (<-chan common.LogMessage, error) {
-	return common.StreamDebugLog(c.caller.RawAPICaller(), common.DebugLogParams{})
+	return common.StreamDebugLog(c.caller.RawAPICaller(), common.DebugLogParams{
+		Replay: true,
+		NoTail: true,
+	})
 }

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -389,3 +389,7 @@ func (s *ClientSuite) TestMinionReportsBadFailedTag(c *gc.C) {
 	_, err := client.MinionReports()
 	c.Assert(err, gc.ErrorMatches, `processing failed agents: "dave" is not a valid tag`)
 }
+
+func (s *ClientSuite) TestStreamModelLogs(c *gc.C) {
+	c.Fatalf("writeme")
+}

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -5,6 +5,7 @@ package migrationmaster_test
 
 import (
 	"encoding/json"
+	"net/url"
 	"time"
 
 	"github.com/juju/errors"
@@ -391,5 +392,36 @@ func (s *ClientSuite) TestMinionReportsBadFailedTag(c *gc.C) {
 }
 
 func (s *ClientSuite) TestStreamModelLogs(c *gc.C) {
-	c.Fatalf("writeme")
+	caller := fakeConnector{path: new(string), attrs: &url.Values{}}
+	client := migrationmaster.NewClient(caller, nil)
+	stream, err := client.StreamModelLog()
+	c.Assert(stream, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "colonel abrams")
+
+	c.Assert(*caller.path, gc.Equals, "/log")
+	c.Assert(*caller.attrs, gc.DeepEquals, url.Values{
+		"replay":        {"true"},
+		"noTail":        {"true"},
+		"includeEntity": nil,
+		"includeModule": nil,
+		"excludeEntity": nil,
+		"excludeModule": nil,
+	})
+}
+
+type fakeConnector struct {
+	base.APICaller
+
+	path  *string
+	attrs *url.Values
+}
+
+func (fakeConnector) BestFacadeVersion(string) int {
+	return 0
+}
+
+func (c fakeConnector) ConnectStream(path string, attrs url.Values) (base.Stream, error) {
+	*c.path = path
+	*c.attrs = attrs
+	return nil, errors.New("colonel abrams")
 }

--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/juju/tools"
+	jujuversion "github.com/juju/juju/version"
 )
 
 type httpClient interface {
@@ -124,4 +125,17 @@ func (c *Client) httpPost(modelUUID string, content io.ReadSeeker, endpoint, con
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+func (c *Client) OpenLogTransferStream(modelUUID string) (base.Stream, error) {
+	attrs := url.Values{}
+	attrs.Set("jujuclientversion", jujuversion.Current.String())
+	headers := http.Header{}
+	headers.Set(params.MigrationModelHTTPHeader, modelUUID)
+	caller := c.caller.RawAPICaller()
+	stream, err := caller.ConnectControllerStream("/migrate/logtransfer", attrs, headers)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return stream, nil
 }

--- a/api/migrationtarget/client_test.go
+++ b/api/migrationtarget/client_test.go
@@ -85,6 +85,10 @@ func (s *ClientSuite) TestActivate(c *gc.C) {
 	s.AssertModelCall(c, stub, names.NewModelTag(uuid), "Activate", err)
 }
 
+func (s *ClientSuite) TestOpenLogTransferStream(c *gc.C) {
+	c.Fatalf("writeme")
+}
+
 func (s *ClientSuite) AssertModelCall(c *gc.C, stub *jujutesting.Stub, tag names.ModelTag, call string, err error) {
 	expectedArg := params.ModelArgs{ModelTag: tag.String()}
 	stub.CheckCalls(c, []jujutesting.StubCall{

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -400,7 +400,7 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 	migrateCharmsHandler := &charmsHandler{
 		ctxt:          httpCtxt,
 		dataDir:       srv.dataDir,
-		stateAuthFunc: httpCtxt.stateForMigration,
+		stateAuthFunc: httpCtxt.stateForMigrationImporting,
 	}
 	add("/migrate/charms",
 		&CharmsHTTPHandler{
@@ -411,7 +411,7 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 	add("/migrate/tools",
 		&toolsUploadHandler{
 			ctxt:          httpCtxt,
-			stateAuthFunc: httpCtxt.stateForMigration,
+			stateAuthFunc: httpCtxt.stateForMigrationImporting,
 		},
 	)
 	add("/model/:modeluuid/tools/:version",

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -435,7 +435,7 @@ func (s *charmsSuite) TestMigrateCharmNotMigrating(c *gc.C) {
 	resp := s.uploadRequest(c, url.String(), "application/zip", ch.Path)
 	s.assertErrorResponse(
 		c, resp, http.StatusBadRequest,
-		"cannot upload charm: model not importing",
+		`cannot upload charm: model migration mode is "" instead of "importing"`,
 	)
 }
 

--- a/apiserver/logtransfer.go
+++ b/apiserver/logtransfer.go
@@ -29,7 +29,9 @@ func newMigrationLoggingStrategy(ctxt httpContext, fileLogger io.Writer) Logging
 // Authenticate checks that the user is a controller superuser and
 // that the requested model is migrating. Part of LoggingStrategy.
 func (s *migrationLoggingStrategy) Authenticate(req *http.Request) error {
-	st, err := s.ctxt.stateForMigration(req)
+	// Require MigrationModeNone because logtransfer happens after the
+	// model proper is completely imported.
+	st, err := s.ctxt.stateForMigration(req, state.MigrationModeNone)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/logtransfer_test.go
+++ b/apiserver/logtransfer_test.go
@@ -48,7 +48,6 @@ func (s *logtransferSuite) SetUpTest(c *gc.C) {
 	s.machinePassword = password
 
 	s.setUserAccess(c, permission.SuperuserAccess)
-	s.setMigrationMode(c, state.MigrationModeImporting)
 
 	s.logs.Clear()
 	writer := loggo.NewMinimumLevelWriter(&s.logs, loggo.INFO)
@@ -128,10 +127,10 @@ func (s *logtransferSuite) TestRequiresSuperUser(c *gc.C) {
 	assertWebsocketClosed(c, reader)
 }
 
-func (s *logtransferSuite) TestRequiresMigratingModel(c *gc.C) {
-	s.setMigrationMode(c, state.MigrationModeNone)
+func (s *logtransferSuite) TestRequiresMigrationModeNone(c *gc.C) {
+	s.setMigrationMode(c, state.MigrationModeImporting)
 	reader := s.toReader(s.dialWebsocket(c))
-	assertJSONError(c, reader, `model not importing`)
+	assertJSONError(c, reader, `model migration mode is "importing" instead of ""`)
 	assertWebsocketClosed(c, reader)
 }
 

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -265,7 +265,7 @@ func (s *toolsSuite) TestMigrateToolsNotMigrating(c *gc.C) {
 	resp := s.uploadRequest(c, uri.String(), "application/x-tar-gz", toolPath)
 	s.assertErrorResponse(
 		c, resp, http.StatusBadRequest,
-		"model not importing",
+		`model migration mode is "" instead of "importing"`,
 	)
 }
 

--- a/cmd/juju/commands/debuglog.go
+++ b/cmd/juju/commands/debuglog.go
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/mattn/go-isatty"
 
-	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
@@ -117,7 +117,7 @@ type debugLogCommand struct {
 	modelcmd.ModelCommandBase
 
 	level  string
-	params api.DebugLogParams
+	params common.DebugLogParams
 
 	utc      bool
 	location bool
@@ -186,7 +186,7 @@ func (c *debugLogCommand) Init(args []string) error {
 }
 
 type DebugLogAPI interface {
-	WatchDebugLog(params api.DebugLogParams) (<-chan api.LogMessage, error)
+	WatchDebugLog(params common.DebugLogParams) (<-chan common.LogMessage, error)
 	Close() error
 }
 
@@ -250,7 +250,7 @@ var SeverityColor = map[string]*ansiterm.Context{
 	},
 }
 
-func (c *debugLogCommand) writeLogRecord(w *ansiterm.Writer, r api.LogMessage) {
+func (c *debugLogCommand) writeLogRecord(w *ansiterm.Writer, r common.LogMessage) {
 	ts := r.Timestamp.In(c.tz).Format(c.format)
 	fmt.Fprintf(w, "%s: %s ", r.Entity, ts)
 	SeverityColor[r.Severity].Fprintf(w, r.Severity)

--- a/worker/metrics/sender/manifold_test.go
+++ b/worker/metrics/sender/manifold_test.go
@@ -4,6 +4,7 @@
 package sender_test
 
 import (
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -127,6 +128,10 @@ func (s *stubAPICaller) ModelTag() (names.ModelTag, bool) {
 }
 
 func (s *stubAPICaller) ConnectStream(string, url.Values) (base.Stream, error) {
+	panic("should not be called")
+}
+
+func (s *stubAPICaller) ConnectControllerStream(string, url.Values, http.Header) (base.Stream, error) {
 	panic("should not be called")
 }
 

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -17,6 +17,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/api/migrationtarget"
 	"github.com/juju/juju/apiserver/params"
 	coremigration "github.com/juju/juju/core/migration"
@@ -91,6 +92,11 @@ type Facade interface {
 	// MinionReports returns details of the reports made by migration
 	// minions to the controller for the current migration phase.
 	MinionReports() (coremigration.MinionReports, error)
+
+	// StreamModelLog returns a channel that will yield the logs that
+	// should be transferred to the target after the migration is
+	// successful.
+	StreamModelLog() (<-chan common.LogMessage, error)
 }
 
 // Config defines the operation of a Worker.
@@ -211,7 +217,7 @@ func (w *Worker) run() error {
 		case coremigration.SUCCESS:
 			phase, err = w.doSUCCESS(status)
 		case coremigration.LOGTRANSFER:
-			phase, err = w.doLOGTRANSFER()
+			phase, err = w.doLOGTRANSFER(status.TargetInfo, status.ModelUUID)
 		case coremigration.REAP:
 			phase, err = w.doREAP()
 		case coremigration.ABORT:
@@ -432,9 +438,13 @@ func (w *Worker) doSUCCESS(status coremigration.MigrationStatus) (coremigration.
 	return coremigration.LOGTRANSFER, nil
 }
 
-func (w *Worker) doLOGTRANSFER() (coremigration.Phase, error) {
-	// TODO(mjs) - To be implemented.
-	// w.setInfoStatus("successful: transferring logs to target controller")
+func (w *Worker) doLOGTRANSFER(targetInfo coremigration.TargetInfo, modelUUID string) (coremigration.Phase, error) {
+	w.setInfoStatus("successful: transferring logs to target controller")
+	// sourceRecords, err := w.config.Facade.StreamModelLog()
+	// if err != nil {
+	// 	return coremigration.UNKNOWN, errors.Trace(err)
+	// }
+	// conn, err := w.openAPIConn(targetInfo)
 	return coremigration.REAP, nil
 }
 

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -464,7 +464,8 @@ func (w *Worker) doLOGTRANSFER(targetInfo coremigration.TargetInfo, modelUUID st
 			return unknown, w.catacomb.ErrDying()
 		case msg, ok := <-logSource:
 			if !ok {
-				break
+				// The channel's been closed, we're finished!
+				return coremigration.REAP, nil
 			}
 			err := logTarget.WriteJSON(params.LogRecord{
 				Entity:   msg.Entity,
@@ -479,7 +480,6 @@ func (w *Worker) doLOGTRANSFER(targetInfo coremigration.TargetInfo, modelUUID st
 			}
 		}
 	}
-	return coremigration.REAP, nil
 }
 
 func (w *Worker) doREAP() (coremigration.Phase, error) {

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -684,6 +684,26 @@ func (s *Suite) TestExternalControlABORT(c *gc.C) {
 	))
 }
 
+func (s *Suite) TestLogTransferErrorOpeningLogSource(c *gc.C) {
+	c.Fatalf("writeme")
+}
+
+func (s *Suite) TestLogTransferErrorOpeningTargetAPI(c *gc.C) {
+	c.Fatalf("writeme")
+}
+
+func (s *Suite) TestLogTransferErrorOpeningLogDest(c *gc.C) {
+	c.Fatalf("writeme")
+}
+
+func (s *Suite) TestLogTransferErrorWriting(c *gc.C) {
+	c.Fatalf("writeme")
+}
+
+func (s *Suite) TestLogTransferSendsRecords(c *gc.C) {
+	c.Fatalf("writeme")
+}
+
 func (s *Suite) checkWorkerReturns(c *gc.C, expected error) {
 	err := s.runWorker(c)
 	c.Check(errors.Cause(err), gc.Equals, expected)

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -833,7 +833,7 @@ func (s *Suite) TestLogTransferReportsProgress(c *gc.C) {
 	s.facade.logMessages = func(d chan<- common.LogMessage) {
 		for _, message := range messages {
 			safeSend(c, d, message)
-			s.clock.WaitAdvance(15*time.Second, coretesting.ShortWait, 1)
+			s.clock.WaitAdvance(15*time.Second, coretesting.LongWait, 1)
 		}
 	}
 


### PR DESCRIPTION
Streams model logs from the source controller using the debug-log endpoint, and forwards them on to the /migrate/logtransfer endpoint in the target controller.

At the moment this isn't restartable - if the migration worker is killed and restarted while transferring logs the target model will end up with duplicates of all of the records that had already been transferred. This will be added in a follow-up PR.

QA steps: 
* bootstrap a source controller
* add a model to be migrated
* deploy something to the model
* take note of the number of log messages, and the first and last messages: `juju debug-log --replay`
* bootstrap a destination controller
* migrate the model: `juju migrate the-model dest-controller`
* verify that the log messages for the migrated model include all of the expected messages