### PR TITLE
state/statemetrics: state metrics collector

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -65,7 +65,7 @@ github.com/mattn/go-isatty	git	66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8	2016-08-
 github.com/mattn/go-runewidth	git	d96d1bd051f2bd9e7e43d602782b37b93b1b5666	2015-11-18T07:21:59Z
 github.com/matttproud/golang_protobuf_extensions	git	c12348ce28de40eed0136aa2b644d0ee0650e56c	2016-04-24T11:30:07Z
 github.com/pkg/errors	git	839d9e913e063e28dfd0e6c7b7512793e0a48be9	2016-10-02T05:25:12Z
-github.com/prometheus/client_golang	git	c5b7fccd204277076155f10851dad72b76a49317	2016-08-17T15:48:24Z
+github.com/prometheus/client_golang	git	575f371f7862609249a1be4c9145f429fe065e32	2016-11-24T15:57:32Z
 github.com/prometheus/client_model	git	fa8ad6fec33561be4280a8f0514318c79d7f6cb6	2015-02-12T10:17:44Z
 github.com/prometheus/common	git	dd586c1c5abb0be59e60f942c22af711a2008cb4	2016-05-03T22:05:32Z
 github.com/prometheus/procfs	git	abf152e5f3e97f2fafac028d2cc06c1feb87ffa5	2016-04-11T19:08:41Z

--- a/state/statemetrics/mock_test.go
+++ b/state/statemetrics/mock_test.go
@@ -1,0 +1,177 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENSE file for details.
+
+package statemetrics_test
+
+import (
+	"github.com/juju/testing"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/permission"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/statemetrics"
+	"github.com/juju/juju/status"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type mockState struct {
+	statemetrics.State
+
+	testing.Stub
+	models []*mockModel
+	users  []*mockUser
+}
+
+func (m *mockState) AllModels() ([]statemetrics.Model, error) {
+	m.MethodCall(m, "AllModels")
+	if err := m.NextErr(); err != nil {
+		return nil, err
+	}
+	out := make([]statemetrics.Model, len(m.models))
+	for i, m := range m.models {
+		out[i] = m
+	}
+	return out, nil
+}
+
+func (m *mockState) AllUsers() ([]statemetrics.User, error) {
+	m.MethodCall(m, "AllUsers")
+	if err := m.NextErr(); err != nil {
+		return nil, err
+	}
+	out := make([]statemetrics.User, len(m.users))
+	for i, u := range m.users {
+		out[i] = u
+	}
+	return out, nil
+}
+
+func (m *mockState) ControllerTag() names.ControllerTag {
+	m.MethodCall(m, "ControllerTag")
+	return coretesting.ControllerTag
+}
+
+func (m *mockState) UserAccess(subject names.UserTag, object names.Tag) (permission.UserAccess, error) {
+	m.MethodCall(m, "UserAccess", subject, object)
+	if err := m.NextErr(); err != nil {
+		return permission.UserAccess{}, err
+	}
+	for _, u := range m.users {
+		if u.tag == subject {
+			return permission.UserAccess{Access: u.controllerAccess}, nil
+		}
+	}
+	panic("subject not found")
+}
+
+func (m *mockState) ForModel(tag names.ModelTag) (statemetrics.StateCloser, error) {
+	m.MethodCall(m, "ForModel", tag)
+	if err := m.NextErr(); err != nil {
+		return nil, err
+	}
+	for _, m := range m.models {
+		if m.tag == tag {
+			return mockModelState{mockModel: m}, nil
+		}
+	}
+	panic("model not found")
+}
+
+type mockModelState struct {
+	statemetrics.State
+	*mockModel
+}
+
+func (m mockModelState) AllMachines() ([]statemetrics.Machine, error) {
+	m.MethodCall(m, "AllMachines")
+	if err := m.NextErr(); err != nil {
+		return nil, err
+	}
+	out := make([]statemetrics.Machine, len(m.machines))
+	for i, m := range m.machines {
+		out[i] = m
+	}
+	return out, nil
+}
+
+func (m mockModelState) Close() error {
+	m.MethodCall(m, "Close")
+	return m.NextErr()
+}
+
+type mockModel struct {
+	testing.Stub
+	tag      names.ModelTag
+	life     state.Life
+	status   status.StatusInfo
+	machines []*mockMachine
+}
+
+func (m *mockModel) Life() state.Life {
+	m.MethodCall(m, "Life")
+	return m.life
+}
+
+func (m *mockModel) ModelTag() names.ModelTag {
+	m.MethodCall(m, "ModelTag")
+	return m.tag
+}
+
+func (m *mockModel) Status() (status.StatusInfo, error) {
+	m.MethodCall(m, "Status")
+	if err := m.NextErr(); err != nil {
+		return status.StatusInfo{}, err
+	}
+	return m.status, nil
+}
+
+type mockUser struct {
+	testing.Stub
+	tag              names.UserTag
+	deleted          bool
+	disabled         bool
+	controllerAccess permission.Access
+}
+
+func (u *mockUser) UserTag() names.UserTag {
+	u.MethodCall(u, "UserTag")
+	return u.tag
+}
+
+func (u *mockUser) IsDeleted() bool {
+	u.MethodCall(u, "IsDeleted")
+	return u.deleted
+}
+
+func (u *mockUser) IsDisabled() bool {
+	u.MethodCall(u, "IsDisabled")
+	return u.disabled
+}
+
+type mockMachine struct {
+	testing.Stub
+	instanceStatus status.StatusInfo
+	agentStatus    status.StatusInfo
+	life           state.Life
+}
+
+func (m *mockMachine) Life() state.Life {
+	m.MethodCall(m, "Life")
+	return m.life
+}
+
+func (m *mockMachine) InstanceStatus() (status.StatusInfo, error) {
+	m.MethodCall(m, "InstanceStatus")
+	if err := m.NextErr(); err != nil {
+		return status.StatusInfo{}, err
+	}
+	return m.instanceStatus, nil
+}
+
+func (m *mockMachine) Status() (status.StatusInfo, error) {
+	m.MethodCall(m, "Status")
+	if err := m.NextErr(); err != nil {
+		return status.StatusInfo{}, err
+	}
+	return m.agentStatus, nil
+}

--- a/state/statemetrics/package_test.go
+++ b/state/statemetrics/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package statemetrics_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/state/statemetrics/state.go
+++ b/state/statemetrics/state.go
@@ -1,0 +1,108 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package statemetrics
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/permission"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
+)
+
+// State represents the global state managed by the Juju controller.
+type State interface {
+	AllMachines() ([]Machine, error)
+	AllModels() ([]Model, error)
+	AllUsers() ([]User, error)
+	ControllerTag() names.ControllerTag
+	ForModel(names.ModelTag) (StateCloser, error)
+	UserAccess(names.UserTag, names.Tag) (permission.UserAccess, error)
+}
+
+// StateCloser extends the State interface with a Close method.
+type StateCloser interface {
+	State
+	Close() error
+}
+
+// Machine represents a machine in a Juju model.
+type Machine interface {
+	InstanceStatus() (status.StatusInfo, error)
+	Life() state.Life
+	Status() (status.StatusInfo, error)
+}
+
+// Model represents a Juju model.
+type Model interface {
+	Life() state.Life
+	ModelTag() names.ModelTag
+	Status() (status.StatusInfo, error)
+}
+
+// User represents a user known to the Juju controller.
+type User interface {
+	IsDeleted() bool
+	IsDisabled() bool
+	UserTag() names.UserTag
+}
+
+// NewState takes a *state.State, and returns a State value backed by it.
+func NewState(st *state.State) State {
+	return stateShim{st}
+}
+
+type stateShim struct {
+	*state.State
+}
+
+func (s stateShim) AllMachines() ([]Machine, error) {
+	machines, err := s.State.AllMachines()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	out := make([]Machine, len(machines))
+	for i, m := range machines {
+		if m != nil {
+			out[i] = m
+		}
+	}
+	return out, nil
+}
+
+func (s stateShim) AllModels() ([]Model, error) {
+	models, err := s.State.AllModels()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	out := make([]Model, len(models))
+	for i, m := range models {
+		if m != nil {
+			out[i] = m
+		}
+	}
+	return out, nil
+}
+
+func (s stateShim) AllUsers() ([]User, error) {
+	users, err := s.State.AllUsers(true)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	out := make([]User, len(users))
+	for i, u := range users {
+		if u != nil {
+			out[i] = u
+		}
+	}
+	return out, nil
+}
+
+func (s stateShim) ForModel(tag names.ModelTag) (StateCloser, error) {
+	st, err := s.State.ForModel(tag)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return stateShim{st}, nil
+}

--- a/state/statemetrics/statemetrics.go
+++ b/state/statemetrics/statemetrics.go
@@ -1,0 +1,244 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package statemetrics
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricsNamespace = "juju_state"
+
+	statusLabel           = "status"
+	lifeLabel             = "life"
+	disabledLabel         = "disabled"
+	deletedLabel          = "deleted"
+	controllerAccessLabel = "controller_access"
+	domainLabel           = "domain"
+	agentStatusLabel      = "agent_status"
+	machineStatusLabel    = "machine_status"
+)
+
+var (
+	machineLabelNames = []string{
+		agentStatusLabel,
+		lifeLabel,
+		machineStatusLabel,
+	}
+
+	modelLabelNames = []string{
+		lifeLabel,
+		statusLabel,
+	}
+
+	userLabelNames = []string{
+		controllerAccessLabel,
+		deletedLabel,
+		disabledLabel,
+		domainLabel,
+	}
+
+	logger = loggo.GetLogger("juju.state.statemetrics")
+)
+
+// Collector is a prometheus.Collector that collects metrics about
+// the Juju global state.
+type Collector struct {
+	st State
+
+	scrapeDuration prometheus.Gauge
+	scrapeErrors   prometheus.Gauge
+
+	models   *prometheus.GaugeVec
+	machines *prometheus.GaugeVec
+	users    *prometheus.GaugeVec
+}
+
+// New returns a new Collector.
+func New(st State) *Collector {
+	return &Collector{
+		st: st,
+		scrapeDuration: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "scrape_duration_seconds",
+				Help:      "Amount of time taken to collect state metrics.",
+			},
+		),
+		scrapeErrors: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "scrape_errors",
+				Help:      "Number of errors observed while collecting state metrics.",
+			},
+		),
+
+		models: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "models",
+				Help:      "Number of models in the controller.",
+			},
+			modelLabelNames,
+		),
+		machines: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "machines",
+				Help:      "Number of machines managed by the controller.",
+			},
+			machineLabelNames,
+		),
+		users: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "users",
+				Help:      "Number of local users in the controller.",
+			},
+			userLabelNames,
+		),
+	}
+}
+
+// Describe is part of the prometheus.Collector interface.
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	c.machines.Describe(ch)
+	c.models.Describe(ch)
+	c.users.Describe(ch)
+
+	c.scrapeErrors.Describe(ch)
+	c.scrapeDuration.Describe(ch)
+}
+
+// Collect is part of the prometheus.Collector interface.
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	timer := prometheus.NewTimer(prometheus.ObserverFunc(c.scrapeDuration.Set))
+	defer c.scrapeDuration.Collect(ch)
+	defer timer.ObserveDuration()
+	c.scrapeErrors.Set(0)
+	defer c.scrapeErrors.Collect(ch)
+
+	c.machines.Reset()
+	c.models.Reset()
+	c.users.Reset()
+
+	c.updateMetrics()
+
+	c.machines.Collect(ch)
+	c.models.Collect(ch)
+	c.users.Collect(ch)
+}
+
+func (c *Collector) updateMetrics() {
+	logger.Tracef("updating state metrics")
+	defer logger.Tracef("updated state metrics")
+
+	models, err := c.st.AllModels()
+	if err != nil {
+		logger.Debugf("error getting models: %v", err)
+		c.scrapeErrors.Inc()
+		models = nil
+	}
+	for _, m := range models {
+		c.updateModelMetrics(m)
+	}
+
+	// TODO(axw) AllUsers only returns *local* users. We do not have User
+	// records for external users. To obtain external users, we will need
+	// to get all of the controller and model-level access documents.
+	controllerTag := c.st.ControllerTag()
+	localUsers, err := c.st.AllUsers()
+	if err != nil {
+		logger.Debugf("error getting local users: %v", err)
+		c.scrapeErrors.Inc()
+		localUsers = nil
+	}
+	for _, u := range localUsers {
+		userTag := u.UserTag()
+		access, err := c.st.UserAccess(userTag, controllerTag)
+		if err != nil && !errors.IsNotFound(err) {
+			logger.Debugf("error getting controller user access: %v", err)
+			c.scrapeErrors.Inc()
+			continue
+		}
+		var deleted, disabled string
+		if u.IsDeleted() {
+			deleted = "true"
+		}
+		if u.IsDisabled() {
+			disabled = "true"
+		}
+		c.users.With(prometheus.Labels{
+			controllerAccessLabel: string(access.Access),
+			deletedLabel:          deleted,
+			disabledLabel:         disabled,
+			domainLabel:           userTag.Domain(),
+		}).Inc()
+	}
+}
+
+func (c *Collector) updateModelMetrics(model Model) {
+	modelStatus, err := model.Status()
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return // Model removed
+		}
+		c.scrapeErrors.Inc()
+		logger.Debugf("error getting model status: %v", err)
+		return
+	}
+
+	modelTag := model.ModelTag()
+	st, err := c.st.ForModel(modelTag)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return // Model removed
+		}
+		c.scrapeErrors.Inc()
+		logger.Debugf("error getting model state: %v", err)
+		return
+	}
+	defer st.Close()
+
+	machines, err := st.AllMachines()
+	if err != nil {
+		c.scrapeErrors.Inc()
+		logger.Debugf("error getting machines: %v", err)
+		machines = nil
+	}
+	for _, m := range machines {
+		agentStatus, err := m.Status()
+		if errors.IsNotFound(err) {
+			continue // Machine removed
+		} else if err != nil {
+			c.scrapeErrors.Inc()
+			logger.Debugf("error getting machine status: %v", err)
+			continue
+		}
+
+		machineStatus, err := m.InstanceStatus()
+		if errors.IsNotFound(err) {
+			continue // Machine removed
+		} else if errors.IsNotProvisioned(err) {
+			machineStatus.Status = ""
+		} else if err != nil {
+			c.scrapeErrors.Inc()
+			logger.Debugf("error getting machine status: %v", err)
+			continue
+		}
+
+		c.machines.With(prometheus.Labels{
+			agentStatusLabel:   string(agentStatus.Status),
+			lifeLabel:          m.Life().String(),
+			machineStatusLabel: string(machineStatus.Status),
+		}).Inc()
+	}
+
+	c.models.With(prometheus.Labels{
+		lifeLabel:   model.Life().String(),
+		statusLabel: string(modelStatus.Status),
+	}).Inc()
+}

--- a/state/statemetrics/statemetrics_test.go
+++ b/state/statemetrics/statemetrics_test.go
@@ -1,0 +1,252 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENSE file for details.
+
+package statemetrics_test
+
+import (
+	"errors"
+	"reflect"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/permission"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/statemetrics"
+	"github.com/juju/juju/status"
+)
+
+type collectorSuite struct {
+	testing.IsolationSuite
+	st        mockState
+	collector *statemetrics.Collector
+}
+
+var _ = gc.Suite(&collectorSuite{})
+
+func (s *collectorSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	users := []*mockUser{{
+		tag:              names.NewUserTag("alice"),
+		controllerAccess: permission.NoAccess,
+	}, {
+		tag:              names.NewUserTag("bob"),
+		controllerAccess: permission.NoAccess,
+	}, {
+		tag:              names.NewUserTag("cayley@cambridge"),
+		deleted:          true,
+		controllerAccess: permission.AddModelAccess,
+	}, {
+		tag:              names.NewUserTag("dominique"),
+		disabled:         true,
+		controllerAccess: permission.ReadAccess,
+	}}
+
+	models := []*mockModel{{
+		tag:    names.NewModelTag("b266dff7-eee8-4297-b03a-4692796ec193"),
+		life:   state.Alive,
+		status: status.StatusInfo{Status: status.Available},
+		machines: []*mockMachine{{
+			life:           state.Alive,
+			agentStatus:    status.StatusInfo{Status: status.Started},
+			instanceStatus: status.StatusInfo{Status: status.Running},
+		}},
+	}, {
+		tag:    names.NewModelTag("1ab5799e-e72d-4de7-b70d-499edfab0e5c"),
+		life:   state.Dying,
+		status: status.StatusInfo{Status: status.Destroying},
+		machines: []*mockMachine{{
+			life:           state.Alive,
+			agentStatus:    status.StatusInfo{Status: status.Error},
+			instanceStatus: status.StatusInfo{Status: status.ProvisioningError},
+		}},
+	}}
+
+	s.st = mockState{
+		users:  users,
+		models: models,
+	}
+	s.collector = statemetrics.New(&s.st)
+}
+
+func (s *collectorSuite) TestDescribe(c *gc.C) {
+	ch := make(chan *prometheus.Desc)
+	go func() {
+		defer close(ch)
+		s.collector.Describe(ch)
+	}()
+	var descStrings []string
+	for desc := range ch {
+		descStrings = append(descStrings, desc.String())
+	}
+	expect := []string{
+		`.*fqName: "juju_state_machines".*`,
+		`.*fqName: "juju_state_models".*`,
+		`.*fqName: "juju_state_users".*`,
+		`.*fqName: "juju_state_scrape_errors".*`,
+		`.*fqName: "juju_state_scrape_duration_seconds".*`,
+	}
+	c.Assert(descStrings, gc.HasLen, len(expect))
+	for i, expect := range expect {
+		c.Assert(descStrings[i], gc.Matches, expect)
+	}
+}
+
+func (s *collectorSuite) collect(c *gc.C) ([]prometheus.Metric, []dto.Metric) {
+	ch := make(chan prometheus.Metric)
+	go func() {
+		defer close(ch)
+		s.collector.Collect(ch)
+	}()
+	var metrics []prometheus.Metric
+	for metric := range ch {
+		metrics = append(metrics, metric)
+	}
+	dtoMetrics := make([]dto.Metric, len(metrics))
+	for i, metric := range metrics {
+		err := metric.Write(&dtoMetrics[i])
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	return metrics, dtoMetrics
+}
+
+func (s *collectorSuite) checkExpected(c *gc.C, actual, expected []dto.Metric) {
+	c.Assert(actual, gc.HasLen, len(expected))
+	for i, dm := range actual {
+		var found bool
+		for i, m := range expected {
+			if !reflect.DeepEqual(dm, m) {
+				continue
+			}
+			expected = append(expected[:i], expected[i+1:]...)
+			found = true
+			break
+		}
+		if !found {
+			c.Errorf("metric #%d %+v not expected", i, dm)
+		}
+	}
+}
+
+func float64ptr(v float64) *float64 {
+	return &v
+}
+
+func (s *collectorSuite) TestCollect(c *gc.C) {
+	_, dtoMetrics := s.collect(c)
+
+	// The scrape time metric has a non-deterministic value,
+	// so we just check that it is non-zero.
+	c.Assert(dtoMetrics, gc.Not(gc.HasLen), 0)
+	scrapeDurationMetric := dtoMetrics[len(dtoMetrics)-1]
+	c.Assert(scrapeDurationMetric.Gauge.GetValue(), gc.Not(gc.Equals), 0)
+
+	labelpair := func(n, v string) *dto.LabelPair {
+		return &dto.LabelPair{Name: &n, Value: &v}
+	}
+	s.checkExpected(c, dtoMetrics, []dto.Metric{
+		// juju_state_machines
+		{
+			Gauge: &dto.Gauge{Value: float64ptr(1)},
+			Label: []*dto.LabelPair{
+				labelpair("agent_status", "started"),
+				labelpair("life", "alive"),
+				labelpair("machine_status", "running"),
+			},
+		},
+		{
+			Gauge: &dto.Gauge{Value: float64ptr(1)},
+			Label: []*dto.LabelPair{
+				labelpair("agent_status", "error"),
+				labelpair("life", "alive"),
+				labelpair("machine_status", "provisioning error"),
+			},
+		},
+
+		// juju_state_models
+		{
+			Gauge: &dto.Gauge{Value: float64ptr(1)},
+			Label: []*dto.LabelPair{
+				labelpair("life", "alive"),
+				labelpair("status", "available"),
+			},
+		},
+		{
+			Gauge: &dto.Gauge{Value: float64ptr(1)},
+			Label: []*dto.LabelPair{
+				labelpair("life", "dying"),
+				labelpair("status", "destroying"),
+			},
+		},
+
+		// juju_state_users
+		{
+			Gauge: &dto.Gauge{Value: float64ptr(1)},
+			Label: []*dto.LabelPair{
+				labelpair("controller_access", "add-model"),
+				labelpair("deleted", "true"),
+				labelpair("disabled", ""),
+				labelpair("domain", "cambridge"),
+			},
+		},
+		{
+			Gauge: &dto.Gauge{Value: float64ptr(1)},
+			Label: []*dto.LabelPair{
+				labelpair("controller_access", "read"),
+				labelpair("deleted", ""),
+				labelpair("disabled", "true"),
+				labelpair("domain", ""),
+			},
+		},
+		{
+			Gauge: &dto.Gauge{Value: float64ptr(2)},
+			Label: []*dto.LabelPair{
+				labelpair("controller_access", ""),
+				labelpair("deleted", ""),
+				labelpair("disabled", ""),
+				labelpair("domain", ""),
+			},
+		},
+
+		// juju_state_scrape_errors
+		{
+			Gauge: &dto.Gauge{Value: float64ptr(0)},
+		},
+
+		// juju_state_scrape_interval_seconds
+		{
+			Gauge: &dto.Gauge{Value: scrapeDurationMetric.Gauge.Value},
+		},
+	})
+}
+
+func (s *collectorSuite) TestCollectErrors(c *gc.C) {
+	s.st.SetErrors(
+		errors.New("no models for you"),
+		errors.New("no users for you"),
+	)
+	_, dtoMetrics := s.collect(c)
+
+	// The scrape time metric has a non-deterministic value,
+	// so we just check that it is non-zero.
+	c.Assert(dtoMetrics, gc.Not(gc.HasLen), 0)
+	scrapeDurationMetric := dtoMetrics[len(dtoMetrics)-1]
+	c.Assert(scrapeDurationMetric.Gauge.GetValue(), gc.Not(gc.Equals), 0)
+
+	s.checkExpected(c, dtoMetrics, []dto.Metric{
+		// juju_state_scrape_errors
+		{
+			Gauge: &dto.Gauge{Value: float64ptr(2)},
+		},
+
+		// juju_state_scrape_interval_seconds
+		{
+			Gauge: &dto.Gauge{Value: scrapeDurationMetric.Gauge.Value},
+		},
+	})
+}

--- a/worker/introspection/socket_test.go
+++ b/worker/introspection/socket_test.go
@@ -166,7 +166,7 @@ func (r *reporter) Report() map[string]interface{} {
 
 func newPrometheusGatherer() prometheus.Gatherer {
 	counter := prometheus.NewCounter(prometheus.CounterOpts{Name: "tau", Help: "Tau."})
-	counter.Set(6.283185)
+	counter.Add(6.283185)
 	r := prometheus.NewPedanticRegistry()
 	r.MustRegister(counter)
 	return r


### PR DESCRIPTION
Introduce a Prometheus metric collector for
high-level state metrics. This collector will
gather metrics such as how many models and
machines are managed by the controller; and
how many users are defined in or known to the
controller.