### PR TITLE
Fix manual provider systemd clean-up

### DIFF
--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -258,7 +258,7 @@ if [ $stopped -ne 1 ]; then
     service %s stop
 fi
 rm -f /etc/init/juju*
-rm -f /etc/systemd/system/juju*
+rm -f /etc/systemd/system{,/multi-user.target.wants}/juju*
 rm -fr %s %s
 exit 0
 `

--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -103,7 +103,7 @@ if [ $stopped -ne 1 ]; then
     service juju-db stop
 fi
 rm -f /etc/init/juju*
-rm -f /etc/systemd/system/juju*
+rm -f /etc/systemd/system{,/multi-user.target.wants}/juju*
 rm -fr '/var/lib/juju' '/var/log/juju'
 exit 0
 `)


### PR DESCRIPTION
Adds `/etc/systemd/system/multi-user.target.wants/juju*` to targets
removed by manual provider clean-up script.

Fixes lp:1645381

QA steps:
 * Manual provider machine removal should not leave behind
    /etc/systemd/system/multi-user.target.wants/juju*