### PR TITLE
Delete log records when a model is removed

### DIFF
--- a/state/logs.go
+++ b/state/logs.go
@@ -835,3 +835,9 @@ func getLogCountForEnv(coll *mgo.Collection, modelUUID string) (int, error) {
 	}
 	return count, nil
 }
+
+func removeModelLogs(session *mgo.Session, modelUUID string) error {
+	logsColl := session.DB(logsDB).C(logsC)
+	_, err := logsColl.RemoveAll(bson.M{"e": modelUUID})
+	return errors.Trace(err)
+}

--- a/state/state.go
+++ b/state/state.go
@@ -223,6 +223,9 @@ func (st *State) removeAllModelDocs(modelAssertion bson.D) error {
 			}
 		}
 	}
+	// Logs are in a separate database so don't get caught by that
+	// loop.
+	removeModelLogs(st.MongoSession(), modelUUID)
 
 	// Remove all user permissions for the model.
 	permPattern := bson.M{


### PR DESCRIPTION
It became apparent that they were being left behind after migration, and it turns out also after model destruction (although they'd only be accessible through the Mongo shell). 

QA steps:
* bootstrap a controller
* add a model and deploy a charm like ubuntu to it (to generate model logs)
* check how many log messages there are for the model
* run `juju show-model` and note the UUID
* destroy the model
* confirm there are no log records for the model left in the MongoDB shell. (See https://github.com/juju/juju/wiki/Login-into-MongoDB to connect to the shell.)
```
use logs
db.logs.find({"e": "<model-uuid>"}).count()
```