### PR TITLE
Missing cause.

### DIFF
--- a/worker/migrationmaster/manifold.go
+++ b/worker/migrationmaster/manifold.go
@@ -91,7 +91,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 }
 
 func errorFilter(err error) error {
-	switch err {
+	switch errors.Cause(err) {
 	case ErrMigrated:
 		// If the model has migrated, the migrationmaster should no
 		// longer be running.


### PR DESCRIPTION
The migration master was bouncing when a migration was finished because the error filter function was not checking the cause of the error.