### PR TITLE
Migrations: change how resource revisions are exported 

### DIFF
--- a/core/description/application_test.go
+++ b/core/description/application_test.go
@@ -265,5 +265,5 @@ func (s *ApplicationSerializationSuite) TestResourcesAreValidated(c *gc.C) {
 	application := minimalApplication()
 	application.AddResource(ResourceArgs{Name: "foo"})
 	err := application.Validate()
-	c.Assert(err, gc.ErrorMatches, `resource foo: missing application revision .+`)
+	c.Assert(err, gc.ErrorMatches, `resource foo: no application revision set`)
 }

--- a/core/description/resource.go
+++ b/core/description/resource.go
@@ -15,9 +15,9 @@ type Resource interface {
 	// Name returns the name of the resource.
 	Name() string
 
-	// Revision returns the revision of the resource as set on the
-	// application.
-	Revision() int
+	// ApplicationRevision returns the revision of the resource as set
+	// on the application.
+	ApplicationRevision() int
 
 	// CharmStoreRevision returns the revision the charmstore has, as
 	// seen at the last poll.
@@ -60,9 +60,9 @@ type ResourceArgs struct {
 
 func newResource(args ResourceArgs) *resource {
 	return &resource{
-		Name_:               args.Name,
-		Revision_:           args.Revision,
-		CharmStoreRevision_: args.CharmStoreRevision,
+		Name_:                args.Name,
+		ApplicationRevision_: args.Revision,
+		CharmStoreRevision_:  args.CharmStoreRevision,
 	}
 }
 
@@ -72,10 +72,10 @@ type resources struct {
 }
 
 type resource struct {
-	Name_               string              `yaml:"name"`
-	Revision_           int                 `yaml:"application-revision"`
-	CharmStoreRevision_ int                 `yaml:"charmstore-revision"`
-	Revisions_          []*resourceRevision `yaml:"revisions"`
+	Name_                string              `yaml:"name"`
+	ApplicationRevision_ int                 `yaml:"application-revision"`
+	CharmStoreRevision_  int                 `yaml:"charmstore-revision"`
+	Revisions_           []*resourceRevision `yaml:"revisions"`
 }
 
 // Name implements Resource.
@@ -83,9 +83,9 @@ func (r *resource) Name() string {
 	return r.Name_
 }
 
-// Revision implements Resource.
-func (r *resource) Revision() int {
-	return r.Revision_
+// ApplicationRevision implements Resource.
+func (r *resource) ApplicationRevision() int {
+	return r.ApplicationRevision_
 }
 
 // CharmStoreRevision implements Resource.
@@ -141,8 +141,8 @@ func (r *resource) Revisions() map[int]ResourceRevision {
 // Validate implements Resource.
 func (r *resource) Validate() error {
 	revs := r.Revisions()
-	if _, ok := revs[r.Revision_]; !ok {
-		return errors.Errorf("missing application revision (%d)", r.Revision_)
+	if _, ok := revs[r.ApplicationRevision_]; !ok {
+		return errors.Errorf("missing application revision (%d)", r.ApplicationRevision_)
 	}
 	if _, ok := revs[r.CharmStoreRevision_]; !ok {
 		return errors.Errorf("missing charmstore revision (%d)", r.CharmStoreRevision_)

--- a/core/description/resource_test.go
+++ b/core/description/resource_test.go
@@ -91,7 +91,7 @@ func minimalResource() *resource {
 func (s *ResourceSuite) TestNew(c *gc.C) {
 	r := minimalResource()
 	c.Check(r.Name(), gc.Equals, "bdist")
-	c.Check(r.Revision(), gc.Equals, 3)
+	c.Check(r.ApplicationRevision(), gc.Equals, 3)
 	c.Check(r.CharmStoreRevision(), gc.Equals, 4)
 
 	rs := r.Revisions()

--- a/core/description/unit_test.go
+++ b/core/description/unit_test.go
@@ -206,12 +206,16 @@ func (s *UnitSerializationSuite) TestWorkloadStatusHistory(c *gc.C) {
 func (s *UnitSerializationSuite) TestResources(c *gc.C) {
 	initial := minimalUnit()
 	rFoo := initial.AddResource(UnitResourceArgs{
-		Name:     "foo",
-		Revision: 42,
+		Name: "foo",
+		RevisionArgs: ResourceRevisionArgs{
+			Revision: 3,
+		},
 	})
 	rBar := initial.AddResource(UnitResourceArgs{
-		Name:     "bar",
-		Revision: 1,
+		Name: "bar",
+		RevisionArgs: ResourceRevisionArgs{
+			Revision: 1,
+		},
 	})
 
 	unit := s.exportImport(c, initial)

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -93,6 +93,7 @@ func (res Resource) Validate() error {
 
 // IsPlaceholder indicates whether or not the resource is a
 // "placeholder" (partially populated pending an upload).
+func (res Resource) IsPlaceholder() bool {
 	return res.Timestamp.IsZero()
 }
 

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -93,7 +93,6 @@ func (res Resource) Validate() error {
 
 // IsPlaceholder indicates whether or not the resource is a
 // "placeholder" (partially populated pending an upload).
-func (res Resource) IsPlaceholder() bool {
 	return res.Timestamp.IsZero()
 }
 

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -720,18 +720,11 @@ func (e *exporter) setResources(exApp description.Application, resources resourc
 		return errors.New("number of resources don't match charm store resources")
 	}
 
-	exResources := make(map[string]description.Resource)
-
 	for i, resource := range resources.Resources {
-		csResource := resources.CharmStoreResources[i]
 		exResource := exApp.AddResource(description.ResourceArgs{
-			Name:               resource.Name,
-			Revision:           resource.Revision,
-			CharmStoreRevision: csResource.Revision,
+			Name: resource.Name,
 		})
-		exResources[resource.Name] = exResource
-
-		_, err := exResource.AddRevision(description.ResourceRevisionArgs{
+		exResource.SetApplicationRevision(description.ResourceRevisionArgs{
 			Revision:       resource.Revision,
 			Type:           resource.Type.String(),
 			Path:           resource.Path,
@@ -742,11 +735,8 @@ func (e *exporter) setResources(exApp description.Application, resources resourc
 			Timestamp:      resource.Timestamp,
 			Username:       resource.Username,
 		})
-		if err != nil {
-			return errors.Annotate(err, "resource "+resource.Name)
-		}
-
-		_, err = exResource.AddRevision(description.ResourceRevisionArgs{
+		csResource := resources.CharmStoreResources[i]
+		exResource.SetCharmStoreRevision(description.ResourceRevisionArgs{
 			Revision:       csResource.Revision,
 			Type:           csResource.Type.String(),
 			Path:           csResource.Path,
@@ -755,19 +745,16 @@ func (e *exporter) setResources(exApp description.Application, resources resourc
 			Size:           csResource.Size,
 			FingerprintHex: csResource.Fingerprint.Hex(),
 		})
-		if err != nil {
-			return errors.Annotate(err, "charmstore resource "+resource.Name)
-		}
 	}
 
-	for _, unitResources := range resources.UnitResources {
-		for _, resource := range unitResources.Resources {
-			exResource, found := exResources[resource.Name]
-			if !found {
-				return errors.Errorf("no application resource found for unit %s resource %s",
-					unitResources.Tag.Id(), resource.Name)
-			}
-			_, err := exResource.AddRevision(description.ResourceRevisionArgs{
+	return nil
+}
+
+func (e *exporter) setUnitResources(exUnit description.Unit, allResources []resource.UnitResources) {
+	for _, resource := range findUnitResources(exUnit.Name(), allResources) {
+		exUnit.AddResource(description.UnitResourceArgs{
+			Name: resource.Name,
+			RevisionArgs: description.ResourceRevisionArgs{
 				Revision:       resource.Revision,
 				Type:           resource.Type.String(),
 				Path:           resource.Path,
@@ -777,22 +764,7 @@ func (e *exporter) setResources(exApp description.Application, resources resourc
 				Size:           resource.Size,
 				Timestamp:      resource.Timestamp,
 				Username:       resource.Username,
-			})
-			if err != nil {
-				return errors.Annotatef(err, "unit %s resource %s",
-					unitResources.Tag.Id(), resource.Name)
-			}
-		}
-	}
-
-	return nil
-}
-
-func (e *exporter) setUnitResources(exUnit description.Unit, allResources []resource.UnitResources) {
-	for _, resource := range findUnitResources(exUnit.Name(), allResources) {
-		exUnit.AddResource(description.UnitResourceArgs{
-			Name:     resource.Name,
-			Revision: resource.Revision,
+			},
 		})
 	}
 }

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -42,6 +42,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		unitsC,
 		meterStatusC, // red / green status for metrics of units
 		payloadsC,
+		"resources",
 
 		// relation
 		relationsC,
@@ -182,10 +183,6 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 
 	// THIS SET WILL BE REMOVED WHEN MIGRATIONS ARE COMPLETE
 	todoCollections := set.NewStrings(
-
-		// service / unit
-		"resources",
-
 		// uncategorised
 		//Cross Model Relations - TODO
 		localApplicationDirectoryC,


### PR DESCRIPTION
Practical testing has shown that exporting resource revisions in a normalised way, as was being done, isn't always going to work. Due to the ability for users to upload resources locally, the details for a given resource revision can vary between charmstore, application and unit.

Charmstore, application and unit resource revisions are now stored separately (much like they are in state).  This change touches the model description format and the model export code in state.

### QA

Deployed resource using models and manually verified the output of `juju dump-model`.