### PR TITLE
Migrate precheck allow hook execution

### DIFF
--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -309,8 +309,11 @@ func checkUnitAgentStatus(unit PrecheckUnit) error {
 		return errors.Annotatef(statusData.Err, "retrieving unit %s status", unit.Name())
 	}
 	agentStatus := statusData.Status.Status
-	if agentStatus != status.Idle {
-		return newStatusError("unit %s not idle", unit.Name(), agentStatus)
+	switch agentStatus {
+	case status.Idle, status.Executing:
+		// These two are fine.
+	default:
+		return newStatusError("unit %s not idle or executing", unit.Name(), agentStatus)
 	}
 	return nil
 }

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -200,6 +200,21 @@ func (s *SourcePrecheckSuite) TestDeadUnit(c *gc.C) {
 	c.Assert(err.Error(), gc.Equals, "unit foo/0 is dead")
 }
 
+func (s *SourcePrecheckSuite) TestUnitExecuting(c *gc.C) {
+	backend := &fakeBackend{
+		apps: []migration.PrecheckApplication{
+			&fakeApp{
+				name: "foo",
+				units: []migration.PrecheckUnit{
+					&fakeUnit{name: "foo/0", agentStatus: status.Executing},
+				},
+			},
+		},
+	}
+	err := migration.SourcePrecheck(backend)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *SourcePrecheckSuite) TestUnitNotIdle(c *gc.C) {
 	backend := &fakeBackend{
 		apps: []migration.PrecheckApplication{
@@ -212,7 +227,7 @@ func (s *SourcePrecheckSuite) TestUnitNotIdle(c *gc.C) {
 		},
 	}
 	err := migration.SourcePrecheck(backend)
-	c.Assert(err.Error(), gc.Equals, "unit foo/0 not idle (failed)")
+	c.Assert(err.Error(), gc.Equals, "unit foo/0 not idle or executing (failed)")
 }
 
 func (s *SourcePrecheckSuite) TestUnitLost(c *gc.C) {
@@ -227,7 +242,7 @@ func (s *SourcePrecheckSuite) TestUnitLost(c *gc.C) {
 		},
 	}
 	err := migration.SourcePrecheck(backend)
-	c.Assert(err.Error(), gc.Equals, "unit foo/0 not idle (lost)")
+	c.Assert(err.Error(), gc.Equals, "unit foo/0 not idle or executing (lost)")
 }
 
 func (*SourcePrecheckSuite) TestDyingControllerModel(c *gc.C) {


### PR DESCRIPTION
Loosen up the precheck criteria to allow for hooks to be executing.

This is very important due to the workload status hook that executes every thirty seconds. Given a model of large enough size, it is reasonable to consider that there would always be some hook executing somewhere.

We do need to consider perhaps an extra precheck at a later stage to ensure that no agents are in an error state.