### PR TITLE
Add a start time parameter to debug-log endpoint

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/httprequest"
@@ -445,6 +446,7 @@ func (s *clientSuite) TestWatchDebugLogParamsEncoded(c *gc.C) {
 		Level:         loggo.ERROR,
 		Replay:        true,
 		NoTail:        true,
+		StartTime:     time.Date(2016, 11, 30, 11, 48, 0, 100, time.UTC),
 	}
 
 	client := s.APIState.Client()
@@ -463,6 +465,7 @@ func (s *clientSuite) TestWatchDebugLogParamsEncoded(c *gc.C) {
 		"level":         {"ERROR"},
 		"replay":        {"true"},
 		"noTail":        {"true"},
+		"startTime":     {"2016-11-30T11:48:00.0000001Z"},
 	})
 }
 

--- a/api/common/logs.go
+++ b/api/common/logs.go
@@ -50,6 +50,9 @@ type DebugLogParams struct {
 	// NoTail tells the server to only return the logs it has now, and not
 	// to wait for new logs to arrive.
 	NoTail bool
+	// StartTime should be a time in the past - only records with a
+	// log time on or after StartTime will be returned.
+	StartTime time.Time
 }
 
 func (args DebugLogParams) URLQuery() url.Values {
@@ -73,6 +76,9 @@ func (args DebugLogParams) URLQuery() url.Values {
 	}
 	if args.Level != loggo.UNSPECIFIED {
 		attrs.Set("level", fmt.Sprint(args.Level))
+	}
+	if !args.StartTime.IsZero() {
+		attrs.Set("startTime", args.StartTime.Format(time.RFC3339Nano))
 	}
 	return attrs
 }

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -207,9 +207,6 @@ func readDebugLogParams(queryMap url.Values) (*debugLogParams, error) {
 		if err != nil {
 			return nil, errors.Errorf("start time %q is not a valid time in RFC3339 format", value)
 		}
-		if startTime.After(time.Now()) {
-			return nil, errors.Errorf("start time %q is in the future", value)
-		}
 		params.startTime = startTime
 	}
 

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -144,6 +145,7 @@ func (s *debugLogSocketImpl) sendLogRecord(record *params.LogMessage) error {
 
 // debugLogParams contains the parsed debuglog API request parameters.
 type debugLogParams struct {
+	startTime     time.Time
 	maxLines      uint
 	fromTheStart  bool
 	noTail        bool
@@ -198,6 +200,17 @@ func readDebugLogParams(queryMap url.Values) (*debugLogParams, error) {
 				value, loggo.TRACE, loggo.DEBUG, loggo.INFO, loggo.WARNING, loggo.ERROR)
 		}
 		params.filterLevel = level
+	}
+
+	if value := queryMap.Get("startTime"); value != "" {
+		startTime, err := time.Parse(time.RFC3339Nano, value)
+		if err != nil {
+			return nil, errors.Errorf("start time %q is not a valid time in RFC3339 format", value)
+		}
+		if startTime.After(time.Now()) {
+			return nil, errors.Errorf("start time %q is in the future", value)
+		}
+		params.startTime = startTime
 	}
 
 	params.includeEntity = queryMap["includeEntity"]

--- a/apiserver/debuglog_db.go
+++ b/apiserver/debuglog_db.go
@@ -58,6 +58,7 @@ func makeLogTailerParams(reqParams *debugLogParams) *state.LogTailerParams {
 	params := &state.LogTailerParams{
 		MinLevel:      reqParams.filterLevel,
 		NoTail:        reqParams.noTail,
+		StartTime:     reqParams.startTime,
 		InitialLines:  int(reqParams.backlog),
 		IncludeEntity: reqParams.includeEntity,
 		ExcludeEntity: reqParams.excludeEntity,

--- a/apiserver/debuglog_db_internal_test.go
+++ b/apiserver/debuglog_db_internal_test.go
@@ -30,10 +30,12 @@ func (s *debugLogDBIntSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *debugLogDBIntSuite) TestParamConversion(c *gc.C) {
+	t1 := time.Date(2016, 11, 30, 10, 51, 0, 0, time.UTC)
 	reqParams := &debugLogParams{
 		fromTheStart:  false,
 		noTail:        true,
 		backlog:       11,
+		startTime:     t1,
 		filterLevel:   loggo.INFO,
 		includeEntity: []string{"foo"},
 		includeModule: []string{"bar"},
@@ -47,7 +49,7 @@ func (s *debugLogDBIntSuite) TestParamConversion(c *gc.C) {
 
 		// Start time will be used once the client is extended to send
 		// time range arguments.
-		c.Assert(params.StartTime.IsZero(), jc.IsTrue)
+		c.Assert(params.StartTime, gc.Equals, t1)
 		c.Assert(params.NoTail, jc.IsTrue)
 		c.Assert(params.MinLevel, gc.Equals, loggo.INFO)
 		c.Assert(params.InitialLines, gc.Equals, 11)

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -226,12 +226,12 @@ func (s *debugLogDbSuite) TestLogsUsesStartTime(c *gc.C) {
 	dbLogger.Log(t4, "juju.baz", "go.go.go:23", loggo.WARNING, "cold war kids")
 
 	client := s.APIState.Client()
-	logMessages, err := client.WatchDebugLog(api.DebugLogParams{
+	logMessages, err := client.WatchDebugLog(common.DebugLogParams{
 		StartTime: t3,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	assertMessage := func(expected api.LogMessage) {
+	assertMessage := func(expected common.LogMessage) {
 		select {
 		case actual := <-logMessages:
 			c.Assert(actual, jc.DeepEquals, expected)
@@ -239,7 +239,7 @@ func (s *debugLogDbSuite) TestLogsUsesStartTime(c *gc.C) {
 			c.Fatal("timed out waiting for log line")
 		}
 	}
-	assertMessage(api.LogMessage{
+	assertMessage(common.LogMessage{
 		Entity:    "machine-99",
 		Timestamp: t3,
 		Severity:  "ERROR",
@@ -247,7 +247,7 @@ func (s *debugLogDbSuite) TestLogsUsesStartTime(c *gc.C) {
 		Location:  "go.go:99",
 		Message:   "born ruffians",
 	})
-	assertMessage(api.LogMessage{
+	assertMessage(common.LogMessage{
 		Entity:    "machine-99",
 		Timestamp: t4,
 		Severity:  "WARNING",


### PR DESCRIPTION
This is needed to make the migration log transfer step
restartable without too many duplicated log records.

Add the start time parameter to the client, but not to the debug-log
command at the moment. I'll add a bug to add it there.