### PR TITLE
Migrate remaining hard-coded IPv4 loopback to 'localhost'

### DIFF
--- a/container/kvm/template.go
+++ b/container/kvm/template.go
@@ -36,8 +36,8 @@ var kvmTemplate = `
     </console>
     <input type='mouse' bus='ps2'/>
     <input type='keyboard' bus='ps2'/>
-    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1'>
-      <listen type='address' address='127.0.0.1'/>
+    <graphics type='vnc' port='-1' autoport='yes' listen='localhost'>
+      <listen type='address' address='localhost'/>
     </graphics>
     <video>
       <model type='cirrus' vram='9216' heads='1'/>

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -190,7 +190,7 @@ func fillinStartInstanceParams(env environs.Environ, machineId string, isControl
 			Config: testing.FakeControllerConfig(),
 			MongoInfo: &mongo.MongoInfo{
 				Info: mongo.Info{
-					Addrs:  []string{"127.0.0.1:1234"},
+					Addrs:  []string{"localhost:1234"},
 					CACert: "CA CERT\n" + testing.CACert,
 				},
 				Password: "mongosecret",

--- a/network/address.go
+++ b/network/address.go
@@ -169,7 +169,7 @@ func NewAddressOnSpace(spaceName string, value string) Address {
 	return addr
 }
 
-// NewAddresses is a convenience function to create addresses from a a variable
+// NewAddresses is a convenience function to create addresses from a variable
 // number of string arguments.
 func NewAddresses(inAddresses ...string) (outAddresses []Address) {
 	outAddresses = make([]Address, len(inAddresses))

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -981,7 +981,9 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 	series := args.Tools.OneSeries()
 
 	idString := fmt.Sprintf("%s-%d", e.name, estate.maxId)
-	addrs := network.NewAddresses(idString+".dns", "127.0.0.1")
+	// Add the addresses we want to see in the machine doc. This means both
+	// IPv4 and IPv6 loopback, as well as the DNS name.
+	addrs := network.NewAddresses(idString+".dns", "127.0.0.1", "::1")
 	logger.Debugf("StartInstance addresses: %v", addrs)
 	i := &dummyInstance{
 		id:           instance.Id(idString),


### PR DESCRIPTION
For IPv6 compatibility, use of IPv4 loopback addresses should instead
use 'localhost', which should resolve to both IPv4 and IPv6 adresses.

Tests using loopback addresses have not be changed, as they should still
be correct as tests.

QA steps:
 * Tests should pass