### PR TITLE
Add code to remoterelations worker to publish local changes to remoe model

### DIFF
--- a/api/remoterelations/remoterelations.go
+++ b/api/remoterelations/remoterelations.go
@@ -28,9 +28,9 @@ func NewClient(caller base.APICaller) *Client {
 
 // PublishLocalRelationChange publishes local relations changes to the
 // remote side offering those relations.
-func (c *Client) PublishLocalRelationChange(change params.RemoteRelationsChange) error {
+func (c *Client) PublishLocalRelationChange(change params.RemoteRelationChangeEvent) error {
 	args := params.RemoteRelationsChanges{
-		Changes: []params.RemoteRelationsChange{change},
+		Changes: []params.RemoteRelationChangeEvent{change},
 	}
 	var results params.ErrorResults
 	err := c.facade.FacadeCall("PublishLocalRelationChange", args, &results)

--- a/api/remoterelations/remoterelations_test.go
+++ b/api/remoterelations/remoterelations_test.go
@@ -109,7 +109,8 @@ func (s *remoteRelationsSuite) TestPublishLocalRelationChange(c *gc.C) {
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "PublishLocalRelationChange")
 		c.Check(arg, gc.DeepEquals, params.RemoteRelationsChanges{
-			Changes: []params.RemoteRelationsChange{{RemovedRelations: []int{1}}},
+			Changes: []params.RemoteRelationChangeEvent{{
+				DepartedUnits: []params.RemoteEntityId{{ModelUUID: "model-uuid", Token: "token"}}}},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
 		*(result.(*params.ErrorResults)) = params.ErrorResults{
@@ -121,7 +122,9 @@ func (s *remoteRelationsSuite) TestPublishLocalRelationChange(c *gc.C) {
 		return nil
 	})
 	client := remoterelations.NewClient(apiCaller)
-	err := client.PublishLocalRelationChange(params.RemoteRelationsChange{RemovedRelations: []int{1}})
+	err := client.PublishLocalRelationChange(params.RemoteRelationChangeEvent{
+		DepartedUnits: []params.RemoteEntityId{{ModelUUID: "model-uuid", Token: "token"}},
+	})
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -264,9 +264,17 @@ type RemoteRelationResults struct {
 // RemoteApplication describes the current state of an application involved in a cross-
 // model relation, from the perspective of the local environment.
 type RemoteApplication struct {
-	Name   string `json:"name"`
-	Life   Life   `json:"life"`
+	// Name is the name of the application.
+	Name string `json:"name"`
+
+	// Life is the current lifecycle state of the application.
+	Life Life `json:"life"`
+
+	// Status is the current status of the application.
 	Status string `json:"status"`
+
+	// ModelUUID is the UUId of the model hosting the application.
+	ModelUUID string `json:"model-uuid"`
 }
 
 // RemoteApplicationResult holds a remote application and an error.
@@ -310,9 +318,14 @@ type RemoteApplicationWatchResults struct {
 
 // RemoteApplicationChange describes changes to an application.
 type RemoteApplicationChange struct {
-	ApplicationTag string                `json:"application-tag"`
-	Life           Life                  `json:"life"`
-	Relations      RemoteRelationsChange `json:"relations"`
+	// ApplicationTag is the tag of the application.
+	ApplicationTag string `json:"application-tag"`
+
+	// Life is the current lifecycle state of the application.
+	Life Life `json:"life"`
+
+	// Relations are the relations which have changed.
+	Relations RemoteRelationsChange `json:"relations"`
 	// TODO(wallyworld) - status etc
 }
 
@@ -340,7 +353,7 @@ type RemoteRelationsChange struct {
 
 // RemoteRelationsChanges holds a set of RemoteRelationsChange structures.
 type RemoteRelationsChanges struct {
-	Changes []RemoteRelationsChange `json:"changes,omitempty"`
+	Changes []RemoteRelationChangeEvent `json:"changes,omitempty"`
 }
 
 // RemoteRelationChange describes changes to a relation involving
@@ -360,8 +373,29 @@ type RemoteRelationChange struct {
 	DepartedUnits []string `json:"departed-units,omitempty"`
 }
 
-// RemoteRelationUnitChange describes a relation unit change.
+// RemoteRelationUnitChange describes a relation unit change
+// which has occurred in a remote model.
 type RemoteRelationUnitChange struct {
+	// UnitId uniquely identifies the remote unit.
+	UnitId RemoteEntityId `json:"unit-id"`
+
 	// Settings is the current settings for the relation unit.
 	Settings map[string]interface{} `json:"settings,omitempty"`
+}
+
+// RemoteRelationChangeEvent is pushed to the remote model to communicate
+// changes to relation units from the local model.
+type RemoteRelationChangeEvent struct {
+	// RelationId is the remote id of the relation.
+	RelationId RemoteEntityId `json:"relation-id"`
+
+	// Life is the current lifecycle state of the relation.
+	Life Life `json:"life"`
+
+	// ChangedUnits maps unit tokens to relation unit changes.
+	ChangedUnits []RemoteRelationUnitChange `json:"changed-units,omitempty"`
+
+	// DepartedUnits contains the remote ids of units that have departed
+	// the relation since the last change.
+	DepartedUnits []RemoteEntityId `json:"departed-units,omitempty"`
 }

--- a/apiserver/remoterelations/remoterelations.go
+++ b/apiserver/remoterelations/remoterelations.go
@@ -71,7 +71,9 @@ func (api *RemoteRelationsAPI) ExportEntities(entities params.Entities) (params.
 		token, err := api.st.ExportLocalEntity(tag)
 		if err != nil {
 			results.Results[i].Error = common.ServerError(err)
-			continue
+			if !errors.IsAlreadyExists(err) {
+				continue
+			}
 		}
 		results.Results[i].Result = &params.RemoteEntityId{
 			ModelUUID: api.st.ModelUUID(),
@@ -182,9 +184,10 @@ func (api *RemoteRelationsAPI) RemoteApplications(entities params.Entities) (par
 			return nil, errors.Trace(err)
 		}
 		return &params.RemoteApplication{
-			Name:   remoteApp.Name(),
-			Life:   params.Life(remoteApp.Life().String()),
-			Status: status.Status.String(),
+			Name:      remoteApp.Name(),
+			Life:      params.Life(remoteApp.Life().String()),
+			Status:    status.Status.String(),
+			ModelUUID: remoteApp.SourceModel().Id(),
 		}, nil
 	}
 	for i, entity := range entities.Entities {
@@ -692,7 +695,7 @@ func updateRelationUnits(
 		if err != nil {
 			return errors.Trace(err)
 		}
-		value.changedUnits[unitId] = params.RemoteRelationUnitChange{settings}
+		value.changedUnits[unitId] = params.RemoteRelationUnitChange{Settings: settings}
 		if knownUnits != nil {
 			knownUnits.Add(unitId)
 		}

--- a/apiserver/remoterelations/state.go
+++ b/apiserver/remoterelations/state.go
@@ -114,6 +114,9 @@ type RemoteApplication interface {
 	// Name returns the name of the remote application.
 	Name() string
 
+	// SourceModel returns the tag of the model hosting the remote application.
+	SourceModel() names.ModelTag
+
 	// URL returns the remote application URL, at which it is offered.
 	URL() (string, bool)
 

--- a/state/remoteentities_test.go
+++ b/state/remoteentities_test.go
@@ -41,10 +41,11 @@ func (s *RemoteEntitiesSuite) TestExportLocalEntity(c *gc.C) {
 
 func (s *RemoteEntitiesSuite) TestExportLocalEntityTwice(c *gc.C) {
 	entity := names.NewApplicationTag("mysql")
-	s.assertExportLocalEntity(c, entity)
+	expected := s.assertExportLocalEntity(c, entity)
 	re := s.State.RemoteEntities()
-	_, err := re.ExportLocalEntity(entity)
+	token, err := re.ExportLocalEntity(entity)
 	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
+	c.Assert(token, gc.Equals, expected)
 }
 
 func (s *RemoteEntitiesSuite) TestGetRemoteEntity(c *gc.C) {


### PR DESCRIPTION
The remote relations worker gather the changes in response to a relation units watcher event, and calls the publish api on the remote relations facade to get said changes sent to the remote model.

To make things efficient, the ExportLocalEntity behaviour has been tweaked so that if an entity is exported twice, the existing token is returned with an AlreadyExists error to save a second api call.

QA: bootstrap lxd to ensure no breakages