### PR TITLE
migrations: track the latest log record seen in logtransfer

### DIFF
--- a/apiserver/logtransfer.go
+++ b/apiserver/logtransfer.go
@@ -93,6 +93,10 @@ func newLogTracker(st *state.State) *logTracker {
 	return &logTracker{tracker: state.NewLastSentLogTracker(st, st.ModelUUID(), "migration-logtransfer")}
 }
 
+// logTracker assumes that log messages are sent in time order (which
+// is how they come from debug-log). If not, this won't give
+// meaningful values, and transferring logs could produce large
+// numbers of duplicates if restarted.
 type logTracker struct {
 	tracker     *state.LastSentLogTracker
 	trackedTime time.Time

--- a/apiserver/logtransfer.go
+++ b/apiserver/logtransfer.go
@@ -6,6 +6,7 @@ package apiserver
 import (
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -19,6 +20,7 @@ type migrationLoggingStrategy struct {
 	st         *state.State
 	filePrefix string
 	dbLogger   *state.DbLogger
+	tracker    *logTracker
 	fileLogger io.Writer
 }
 
@@ -54,6 +56,7 @@ func (s *migrationLoggingStrategy) Authenticate(req *http.Request) error {
 func (s *migrationLoggingStrategy) Start() {
 	s.filePrefix = s.st.ModelUUID() + ":"
 	s.dbLogger = state.NewDbLogger(s.st)
+	s.tracker = newLogTracker(s.st)
 }
 
 // Log writes the given record to the DB and to the backup file
@@ -61,13 +64,18 @@ func (s *migrationLoggingStrategy) Start() {
 func (s *migrationLoggingStrategy) Log(m params.LogRecord) bool {
 	level, _ := loggo.ParseLevel(m.Level)
 	dbErr := s.dbLogger.Log(m.Time, m.Entity, m.Module, m.Location, level, m.Message)
+	if dbErr == nil {
+		dbErr = s.tracker.Track(m.Time)
+	}
 	if dbErr != nil {
 		logger.Errorf("logging to DB failed: %v", dbErr)
 	}
+
 	fileErr := logToFile(s.fileLogger, s.filePrefix, m)
 	if fileErr != nil {
 		logger.Errorf("logging to file logger failed: %v", fileErr)
 	}
+
 	return dbErr == nil && fileErr == nil
 }
 
@@ -75,5 +83,36 @@ func (s *migrationLoggingStrategy) Log(m params.LogRecord) bool {
 // release resources and close loggers. Part of LoggingStrategy.
 func (s *migrationLoggingStrategy) Stop() {
 	s.dbLogger.Close()
+	s.tracker.Close()
 	s.ctxt.release(s.st)
+}
+
+const trackingPeriod = 2 * time.Minute
+
+func newLogTracker(st *state.State) *logTracker {
+	return &logTracker{tracker: state.NewLastSentLogTracker(st, st.ModelUUID(), "migration-logtransfer")}
+}
+
+type logTracker struct {
+	tracker     *state.LastSentLogTracker
+	trackedTime time.Time
+	seenTime    time.Time
+}
+
+func (l *logTracker) Track(t time.Time) error {
+	l.seenTime = t
+	if t.Sub(l.trackedTime) < trackingPeriod {
+		return nil
+	}
+	l.trackedTime = t
+	return errors.Trace(l.tracker.Set(0, t.UnixNano()))
+}
+
+func (l *logTracker) Close() error {
+	err := l.tracker.Set(0, l.seenTime.UnixNano())
+	if err != nil {
+		l.tracker.Close()
+		return errors.Trace(err)
+	}
+	return errors.Trace(l.tracker.Close())
 }

--- a/apiserver/migrationtarget/migrationtarget.go
+++ b/apiserver/migrationtarget/migrationtarget.go
@@ -155,6 +155,10 @@ func (api *API) Activate(args params.ModelArgs) error {
 // in some other way (like the source controller going away or a
 // network partition) the time will be up-to-date.
 //
+// Log messages are assumed to be sent in time order (which is how
+// debug-log emits them). If that isn't the case then this mechanism
+// can't be used to avoid duplicates when logtransfer is restarted.
+//
 // Returns the zero time if no logs have been transferred.
 func (api *API) LatestLogTime(args params.ModelArgs) (time.Time, error) {
 	model, err := api.getModel(args)

--- a/apiserver/migrationtarget/migrationtarget.go
+++ b/apiserver/migrationtarget/migrationtarget.go
@@ -4,6 +4,8 @@
 package migrationtarget
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
@@ -99,6 +101,14 @@ func (api *API) getModel(args params.ModelArgs) (*state.Model, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	return model, nil
+}
+
+func (api *API) getImportingModel(args params.ModelArgs) (*state.Model, error) {
+	model, err := api.getModel(args)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	if model.MigrationMode() != state.MigrationModeImporting {
 		return nil, errors.New("migration mode for the model is not importing")
 	}
@@ -108,7 +118,7 @@ func (api *API) getModel(args params.ModelArgs) (*state.Model, error) {
 // Abort removes the specified model from the database. It is an error to
 // attempt to Abort a model that has a migration mode other than importing.
 func (api *API) Abort(args params.ModelArgs) error {
-	model, err := api.getModel(args)
+	model, err := api.getImportingModel(args)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -125,11 +135,40 @@ func (api *API) Abort(args params.ModelArgs) error {
 // Activate sets the migration mode of the model to "active". It is an error to
 // attempt to Abort a model that has a migration mode other than importing.
 func (api *API) Activate(args params.ModelArgs) error {
-	model, err := api.getModel(args)
+	model, err := api.getImportingModel(args)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	// TODO(fwereade) - need to validate binaries here.
 	return model.SetMigrationMode(state.MigrationModeNone)
+}
+
+// LatestLogTime returns the time of the most recent log record
+// received by the logtransfer endpoint. This can be used as the start
+// point for streaming logs from the source if the transfer was
+// interrupted.
+//
+// For performance reasons, not every time is tracked, so if the
+// target controller died during the transfer the latest log time
+// might be up to 2 minutes earlier. If the transfer was interrupted
+// in some other way (like the source controller going away or a
+// network partition) the time will be up-to-date.
+//
+// Returns the zero time if no logs have been transferred.
+func (api *API) LatestLogTime(args params.ModelArgs) (time.Time, error) {
+	model, err := api.getModel(args)
+	if err != nil {
+		return time.Time{}, errors.Trace(err)
+	}
+	tracker := state.NewLastSentLogTracker(api.state, model.UUID(), "migration-logtransfer")
+	defer tracker.Close()
+	_, timestamp, err := tracker.Get()
+	if errors.Cause(err) == state.ErrNeverForwarded {
+		return time.Time{}, nil
+	}
+	if err != nil {
+		return time.Time{}, errors.Trace(err)
+	}
+	return time.Unix(0, timestamp).In(time.UTC), nil
 }


### PR DESCRIPTION
The migration logtransfer endpoint now keeps track of the latest time it's seen to enable restarting the transfer if it's interrupted. The migrationtarget facade has a LatestLogTime method so the migrationmaster can specify the start time to the debug log endpoint.

The latest time is updated every two minutes of log records seen (so as not to spam the database), and when the connection is closed. This means that the log time will be up-to-date unless the target controller is killed for some reason.
