### PR TITLE
migrations: Pass charm URL user component

### DIFF
--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -77,8 +77,9 @@ func (c *Client) Activate(modelUUID string) error {
 // to add the charm binary to the model specified.
 func (c *Client) UploadCharm(modelUUID string, curl *charm.URL, content io.ReadSeeker) (*charm.URL, error) {
 	args := url.Values{}
-	args.Add("series", curl.Series)
 	args.Add("schema", curl.Schema)
+	args.Add("user", curl.User)
+	args.Add("series", curl.Series)
 	args.Add("revision", strconv.Itoa(curl.Revision))
 	apiURI := url.URL{Path: "/migrate/charms", RawQuery: args.Encode()}
 

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -280,12 +280,13 @@ func (h *charmsHandler) processPost(r *http.Request, st *state.State) (*charm.UR
 		Revision: archive.Revision(),
 		Series:   series,
 	}
-	if schema == "local" {
+	switch schema {
+	case "local":
 		curl, err = st.PrepareLocalCharmUpload(curl)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-	} else {
+	case "cs":
 		// "cs:" charms may only be uploaded into models which are
 		// being imported during model migrations. There's currently
 		// no other time where it makes sense to accept charm store
@@ -314,6 +315,8 @@ func (h *charmsHandler) processPost(r *http.Request, st *state.State) (*charm.UR
 		if _, err := st.PrepareStoreCharmUpload(curl); err != nil {
 			return nil, errors.Trace(err)
 		}
+	default:
+		return nil, errors.Errorf("unsupported schema %q", schema)
 	}
 
 	// Now we need to repackage it with the reserved URL, upload it to

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -296,6 +296,10 @@ func (h *charmsHandler) processPost(r *http.Request, st *state.State) (*charm.UR
 			return nil, errors.New("cs charms may only be uploaded during model migration import")
 		}
 
+		// Use the user argument if provided (users only make sense
+		// with cs: charms.
+		curl.User = query.Get("user")
+
 		// If a revision argument is provided, it takes precedence
 		// over the revision in the charm archive. This is required to
 		// handle the revision differences between unpublished and

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -374,11 +374,25 @@ func (s *charmsSuite) TestNonLocalCharmUpload(c *gc.C) {
 	c.Assert(sch.IsUploaded(), jc.IsTrue)
 }
 
+func (s *charmsSuite) TestCharmUploadWithUserOverride(c *gc.C) {
+	s.setModelImporting(c)
+	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+
+	resp := s.uploadRequest(c, s.charmsURI(c, "?schema=cs&user=bobo"), "application/zip", ch.Path)
+
+	expectedURL := charm.MustParseURL("cs:~bobo/dummy-1")
+	s.assertUploadResponse(c, resp, expectedURL.String())
+	sch, err := s.State.Charm(expectedURL)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sch.URL(), gc.DeepEquals, expectedURL)
+	c.Assert(sch.IsUploaded(), jc.IsTrue)
+}
+
 func (s *charmsSuite) TestNonLocalCharmUploadWithRevisionOverride(c *gc.C) {
 	s.setModelImporting(c)
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 
-	resp := s.uploadRequest(c, s.charmsURI(c, "?schema=cs&name=dummy&revision=99"), "application/zip", ch.Path)
+	resp := s.uploadRequest(c, s.charmsURI(c, "?schema=cs&&revision=99"), "application/zip", ch.Path)
 
 	expectedURL := charm.MustParseURL("cs:dummy-99")
 	s.assertUploadResponse(c, resp, expectedURL.String())

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -374,6 +374,17 @@ func (s *charmsSuite) TestNonLocalCharmUpload(c *gc.C) {
 	c.Assert(sch.IsUploaded(), jc.IsTrue)
 }
 
+func (s *charmsSuite) TestUnsupportedSchema(c *gc.C) {
+	s.setModelImporting(c)
+	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+
+	resp := s.uploadRequest(c, s.charmsURI(c, "?schema=zz"), "application/zip", ch.Path)
+	s.assertErrorResponse(
+		c, resp, http.StatusBadRequest,
+		`cannot upload charm: unsupported schema "zz"`,
+	)
+}
+
 func (s *charmsSuite) TestCharmUploadWithUserOverride(c *gc.C) {
 	s.setModelImporting(c)
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")


### PR DESCRIPTION
In order to ensure the cs:~/user/foo style charms migrate correctly, the user component needs to be passed when uploading.

Drive-by: In the upload endpoint, don't assume "cs" if not "local". Fail fast if the schema isn't "cs" or "local".

### QA

Successfully migrated a model which used cs:~user/foo style charms. These failed to migrated before.