### PR TITLE
apiserver: dispose facade object on watcher.Stop

### DIFF
--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -301,17 +301,20 @@ func (s *controllerSuite) TestWatchAllModels(c *gc.C) {
 	watcherId, err := s.controller.WatchAllModels()
 	c.Assert(err, jc.ErrorIsNil)
 
+	var disposed bool
 	watcherAPI_, err := apiserver.NewAllWatcher(facadetest.Context{
 		State_:     s.State,
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
 		ID_:        watcherId.AllWatcherId,
+		Dispose_:   func() { disposed = true },
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	watcherAPI := watcherAPI_.(*apiserver.SrvAllWatcher)
 	defer func() {
 		err := watcherAPI.Stop()
 		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(disposed, jc.IsTrue)
 	}()
 
 	resultC := make(chan params.AllWatcherNextResults)

--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -12,6 +12,7 @@ import (
 type Context struct {
 	Abort_     <-chan struct{}
 	Auth_      facade.Authorizer
+	Dispose_   func()
 	Resources_ facade.Resources
 	State_     *state.State
 	ID_        string
@@ -25,6 +26,11 @@ func (context Context) Abort() <-chan struct{} {
 // Auth is part of the facade.Context interface.
 func (context Context) Auth() facade.Authorizer {
 	return context.Auth_
+}
+
+// Dispose is part of the facade.Context interface.
+func (context Context) Dispose() {
+	context.Dispose_()
 }
 
 // Resources is part of the facade.Context interface.

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -33,6 +33,15 @@ type Context interface {
 	// not *known* to have a responsibility or requirement.
 	Auth() Authorizer
 
+	// Dispose disposes the context and any resources related to
+	// the API server facade object. Normally the context will not
+	// be disposed until the API connection is closed. This is OK
+	// except when contexts are dynamically generated, such as in
+	// the case of watchers. When a facade context is no longer
+	// needed, e.g. when a watcher is closed, then the context may
+	// be disposed by calling this method.
+	Dispose()
+
 	// Resources exposes per-connection capabilities. By adding a
 	// resource, you make it accessible by (returned) id to all
 	// other facades used by this connection. It's mostly used to

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -196,7 +196,7 @@ func (r *apiRoot) FindMethod(rootName string, version int, methodName string) (r
 			// check.
 			return reflect.Value{}, err
 		}
-		obj, err := factory(r.facadeContext(id))
+		obj, err := factory(r.facadeContext(objKey))
 		if err != nil {
 			return reflect.Value{}, err
 		}
@@ -225,37 +225,53 @@ func (r *apiRoot) FindMethod(rootName string, version int, methodName string) (r
 	}, nil
 }
 
-func (r *apiRoot) facadeContext(id string) *facadeContext {
+func (r *apiRoot) dispose(key objectKey) {
+	r.objectMutex.Lock()
+	defer r.objectMutex.Unlock()
+	delete(r.objectCache, key)
+}
+
+func (r *apiRoot) facadeContext(key objectKey) *facadeContext {
 	return &facadeContext{
-		r:  r,
-		id: id,
+		r:   r,
+		key: key,
 	}
 }
 
 // facadeContext implements facade.Context
 type facadeContext struct {
-	r  *apiRoot
-	id string
+	r   *apiRoot
+	key objectKey
 }
 
+// Abort is part of of the facade.Context interface.
 func (ctx *facadeContext) Abort() <-chan struct{} {
 	return nil
 }
 
+// Auth is part of of the facade.Context interface.
 func (ctx *facadeContext) Auth() facade.Authorizer {
 	return ctx.r.authorizer
 }
 
+// Dispose is part of of the facade.Context interface.
+func (ctx *facadeContext) Dispose() {
+	ctx.r.dispose(ctx.key)
+}
+
+// Resources is part of of the facade.Context interface.
 func (ctx *facadeContext) Resources() facade.Resources {
 	return ctx.r.resources
 }
 
+// State is part of of the facade.Context interface.
 func (ctx *facadeContext) State() *state.State {
 	return ctx.r.state
 }
 
+// ID is part of of the facade.Context interface.
 func (ctx *facadeContext) ID() string {
-	return ctx.id
+	return ctx.key.objId
 }
 
 func lookupMethod(rootName string, version int, methodName string) (reflect.Type, rpcreflect.ObjMethod, error) {

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -95,10 +95,29 @@ func NewAllWatcher(context facade.Context) (facade.Facade, error) {
 		return nil, common.ErrUnknownWatcher
 	}
 	return &SrvAllWatcher{
-		watcher:   watcher,
-		id:        id,
-		resources: resources,
+		watcherCommon: newWatcherCommon(context),
+		watcher:       watcher,
 	}, nil
+}
+
+type watcherCommon struct {
+	id        string
+	resources facade.Resources
+	dispose   func()
+}
+
+func newWatcherCommon(context facade.Context) watcherCommon {
+	return watcherCommon{
+		context.ID(),
+		context.Resources(),
+		context.Dispose,
+	}
+}
+
+// Stop stops the watcher.
+func (w *watcherCommon) Stop() error {
+	w.dispose()
+	return w.resources.Stop(w.id)
 }
 
 // SrvAllWatcher defines the API methods on a state.Multiwatcher.
@@ -106,9 +125,8 @@ func NewAllWatcher(context facade.Context) (facade.Facade, error) {
 // current set of watchers, stored in resources. It is used by both
 // the AllWatcher and AllModelWatcher facades.
 type SrvAllWatcher struct {
-	watcher   *state.Multiwatcher
-	id        string
-	resources facade.Resources
+	watcherCommon
+	watcher *state.Multiwatcher
 }
 
 func (aw *SrvAllWatcher) Next() (params.AllWatcherNextResults, error) {
@@ -118,16 +136,11 @@ func (aw *SrvAllWatcher) Next() (params.AllWatcherNextResults, error) {
 	}, err
 }
 
-func (w *SrvAllWatcher) Stop() error {
-	return w.resources.Stop(w.id)
-}
-
 // srvNotifyWatcher defines the API access to methods on a state.NotifyWatcher.
 // Each client has its own current set of watchers, stored in resources.
 type srvNotifyWatcher struct {
-	watcher   state.NotifyWatcher
-	id        string
-	resources facade.Resources
+	watcherCommon
+	watcher state.NotifyWatcher
 }
 
 func isAgent(auth facade.Authorizer) bool {
@@ -147,9 +160,8 @@ func newNotifyWatcher(context facade.Context) (facade.Facade, error) {
 		return nil, common.ErrUnknownWatcher
 	}
 	return &srvNotifyWatcher{
-		watcher:   watcher,
-		id:        id,
-		resources: resources,
+		watcherCommon: newWatcherCommon(context),
+		watcher:       watcher,
 	}, nil
 }
 
@@ -167,19 +179,13 @@ func (w *srvNotifyWatcher) Next() error {
 	return err
 }
 
-// Stop stops the watcher.
-func (w *srvNotifyWatcher) Stop() error {
-	return w.resources.Stop(w.id)
-}
-
 // srvStringsWatcher defines the API for methods on a state.StringsWatcher.
 // Each client has its own current set of watchers, stored in resources.
 // srvStringsWatcher notifies about changes for all entities of a given kind,
 // sending the changes as a list of strings.
 type srvStringsWatcher struct {
-	watcher   state.StringsWatcher
-	id        string
-	resources facade.Resources
+	watcherCommon
+	watcher state.StringsWatcher
 }
 
 func newStringsWatcher(context facade.Context) (facade.Facade, error) {
@@ -195,9 +201,8 @@ func newStringsWatcher(context facade.Context) (facade.Facade, error) {
 		return nil, common.ErrUnknownWatcher
 	}
 	return &srvStringsWatcher{
-		watcher:   watcher,
-		id:        id,
-		resources: resources,
+		watcherCommon: newWatcherCommon(context),
+		watcher:       watcher,
 	}, nil
 }
 
@@ -217,18 +222,12 @@ func (w *srvStringsWatcher) Next() (params.StringsWatchResult, error) {
 	return params.StringsWatchResult{}, err
 }
 
-// Stop stops the watcher.
-func (w *srvStringsWatcher) Stop() error {
-	return w.resources.Stop(w.id)
-}
-
 // srvRelationUnitsWatcher defines the API wrapping a state.RelationUnitsWatcher.
 // It notifies about units entering and leaving the scope of a RelationUnit,
 // and changes to the settings of those units known to have entered.
 type srvRelationUnitsWatcher struct {
-	watcher   state.RelationUnitsWatcher
-	id        string
-	resources facade.Resources
+	watcherCommon
+	watcher state.RelationUnitsWatcher
 }
 
 func newRelationUnitsWatcher(context facade.Context) (facade.Facade, error) {
@@ -244,9 +243,8 @@ func newRelationUnitsWatcher(context facade.Context) (facade.Facade, error) {
 		return nil, common.ErrUnknownWatcher
 	}
 	return &srvRelationUnitsWatcher{
-		watcher:   watcher,
-		id:        id,
-		resources: resources,
+		watcherCommon: newWatcherCommon(context),
+		watcher:       watcher,
 	}, nil
 }
 
@@ -266,18 +264,12 @@ func (w *srvRelationUnitsWatcher) Next() (params.RelationUnitsWatchResult, error
 	return params.RelationUnitsWatchResult{}, err
 }
 
-// Stop stops the watcher.
-func (w *srvRelationUnitsWatcher) Stop() error {
-	return w.resources.Stop(w.id)
-}
-
 // srvRemoteApplicationWatcher will sends changes to relations a service
 // is involved in, including changes to the units involved in those
 // relations, and their settings.
 type srvRemoteApplicationWatcher struct {
-	watcher   state.RemoteApplicationWatcher
-	id        string
-	resources facade.Resources
+	watcherCommon
+	watcher state.RemoteApplicationWatcher
 }
 
 func newRemoteApplicationWatcher(context facade.Context) (facade.Facade, error) {
@@ -293,9 +285,8 @@ func newRemoteApplicationWatcher(context facade.Context) (facade.Facade, error) 
 		return nil, common.ErrUnknownWatcher
 	}
 	return &srvRemoteApplicationWatcher{
-		watcher:   watcher,
-		id:        id,
-		resources: resources,
+		watcherCommon: newWatcherCommon(context),
+		watcher:       watcher,
 	}, nil
 }
 
@@ -315,11 +306,6 @@ func (w *srvRemoteApplicationWatcher) Next() (params.RemoteApplicationWatchResul
 	return params.RemoteApplicationWatchResult{}, err
 }
 
-// Stop stops the watcher.
-func (w *srvRemoteApplicationWatcher) Stop() error {
-	return w.resources.Stop(w.id)
-}
-
 // srvRemoteRelationsWatcher defines the API wrapping a RemoteRelationsWatcher.
 // This watcher notifies about:
 //  - addition and removal of relations of relations to remote applications
@@ -327,9 +313,8 @@ func (w *srvRemoteApplicationWatcher) Stop() error {
 //  - settings of relation units changing
 //  - units departing the relation (joining is implicit in seeing new settings)
 type srvRemoteRelationsWatcher struct {
-	watcher   state.RemoteRelationsWatcher
-	id        string
-	resources facade.Resources
+	watcherCommon
+	watcher state.RemoteRelationsWatcher
 }
 
 // RemoteRelationsWatcher is a watcher that reports on changes to relations
@@ -353,9 +338,8 @@ func newRemoteRelationsWatcher(context facade.Context) (facade.Facade, error) {
 		return nil, common.ErrUnknownWatcher
 	}
 	return &srvRemoteRelationsWatcher{
-		watcher:   watcher,
-		id:        id,
-		resources: resources,
+		watcherCommon: newWatcherCommon(context),
+		watcher:       watcher,
 	}, nil
 }
 
@@ -375,11 +359,6 @@ func (w *srvRemoteRelationsWatcher) Next() (params.RemoteRelationsWatchResult, e
 	return params.RemoteRelationsWatchResult{}, err
 }
 
-// Stop stops the watcher.
-func (w *srvRemoteRelationsWatcher) Stop() error {
-	return w.resources.Stop(w.id)
-}
-
 // srvMachineStorageIdsWatcher defines the API wrapping a state.StringsWatcher
 // watching machine/storage attachments. This watcher notifies about storage
 // entities (volumes/filesystems) being attached to and detached from machines.
@@ -388,40 +367,32 @@ func (w *srvRemoteRelationsWatcher) Stop() error {
 // could do with some deduplication of logic, and I don't want to add to that
 // spaghetti right now.
 type srvMachineStorageIdsWatcher struct {
-	watcher   state.StringsWatcher
-	id        string
-	resources facade.Resources
-	parser    func([]string) ([]params.MachineStorageId, error)
+	watcherCommon
+	watcher state.StringsWatcher
+	parser  func([]string) ([]params.MachineStorageId, error)
 }
 
 func newVolumeAttachmentsWatcher(context facade.Context) (facade.Facade, error) {
-	id := context.ID()
-	auth := context.Auth()
-	resources := context.Resources()
-	st := context.State()
-
 	return newMachineStorageIdsWatcher(
-		st, resources, auth, id, storagecommon.ParseVolumeAttachmentIds,
+		context,
+		storagecommon.ParseVolumeAttachmentIds,
 	)
 }
 
 func newFilesystemAttachmentsWatcher(context facade.Context) (facade.Facade, error) {
-	id := context.ID()
-	auth := context.Auth()
-	resources := context.Resources()
-	st := context.State()
 	return newMachineStorageIdsWatcher(
-		st, resources, auth, id, storagecommon.ParseFilesystemAttachmentIds,
+		context,
+		storagecommon.ParseFilesystemAttachmentIds,
 	)
 }
 
 func newMachineStorageIdsWatcher(
-	st *state.State,
-	resources facade.Resources,
-	auth facade.Authorizer,
-	id string,
+	context facade.Context,
 	parser func([]string) ([]params.MachineStorageId, error),
 ) (facade.Facade, error) {
+	id := context.ID()
+	auth := context.Auth()
+	resources := context.Resources()
 	if !isAgent(auth) {
 		return nil, common.ErrPerm
 	}
@@ -429,7 +400,11 @@ func newMachineStorageIdsWatcher(
 	if !ok {
 		return nil, common.ErrUnknownWatcher
 	}
-	return &srvMachineStorageIdsWatcher{watcher, id, resources, parser}, nil
+	return &srvMachineStorageIdsWatcher{
+		watcherCommon: newWatcherCommon(context),
+		watcher:       watcher,
+		parser:        parser,
+	}, nil
 }
 
 // Next returns when a change has occured to an entity of the
@@ -452,11 +427,6 @@ func (w *srvMachineStorageIdsWatcher) Next() (params.MachineStorageIdsWatchResul
 	return params.MachineStorageIdsWatchResult{}, err
 }
 
-// Stop stops the watcher.
-func (w *srvMachineStorageIdsWatcher) Stop() error {
-	return w.resources.Stop(w.id)
-}
-
 // EntitiesWatcher defines an interface based on the StringsWatcher
 // but also providing a method for the mapping of the received
 // strings to the tags of the according entities.
@@ -475,9 +445,8 @@ type EntitiesWatcher interface {
 // sending the changes as a list of strings, which could be transformed
 // from state entity ids to their corresponding entity tags.
 type srvEntitiesWatcher struct {
-	resources facade.Resources
-	id        string
-	watcher   EntitiesWatcher
+	watcherCommon
+	watcher EntitiesWatcher
 }
 
 func newEntitiesWatcher(context facade.Context) (facade.Facade, error) {
@@ -493,9 +462,8 @@ func newEntitiesWatcher(context facade.Context) (facade.Facade, error) {
 		return nil, common.ErrUnknownWatcher
 	}
 	return &srvEntitiesWatcher{
-		resources: resources,
-		id:        id,
-		watcher:   watcher,
+		watcherCommon: newWatcherCommon(context),
+		watcher:       watcher,
 	}, nil
 }
 
@@ -517,11 +485,6 @@ func (w *srvEntitiesWatcher) Next() (params.EntitiesWatchResult, error) {
 		err = common.ErrStoppedWatcher
 	}
 	return params.EntitiesWatchResult{}, err
-}
-
-// Stop stops the watcher.
-func (w *srvEntitiesWatcher) Stop() error {
-	return w.resources.Stop(w.id)
 }
 
 var getMigrationBackend = func(st *state.State) migrationBackend {
@@ -550,18 +513,16 @@ func newMigrationStatusWatcher(context facade.Context) (facade.Facade, error) {
 		return nil, common.ErrUnknownWatcher
 	}
 	return &srvMigrationStatusWatcher{
-		watcher:   w,
-		id:        id,
-		resources: resources,
-		st:        getMigrationBackend(st),
+		watcherCommon: newWatcherCommon(context),
+		watcher:       w,
+		st:            getMigrationBackend(st),
 	}, nil
 }
 
 type srvMigrationStatusWatcher struct {
-	watcher   state.NotifyWatcher
-	id        string
-	resources facade.Resources
-	st        migrationBackend
+	watcherCommon
+	watcher state.NotifyWatcher
+	st      migrationBackend
 }
 
 // Next returns when the status for a model migration for the
@@ -635,11 +596,6 @@ func (w *srvMigrationStatusWatcher) getLocalHostPorts() ([]string, error) {
 		}
 	}
 	return out, nil
-}
-
-// Stop stops the watcher.
-func (w *srvMigrationStatusWatcher) Stop() error {
-	return w.resources.Stop(w.id)
 }
 
 // This is a shim to avoid the need to use a working State into the


### PR DESCRIPTION
When we stop a watcher, we will now dispose of the
facade object that is cached upon creation. Unless
we do this, the cache grows every time a watcher
is started, and only cleared when the API connection
is severed.

Fixes the issue noted in https://bugs.launchpad.net/juju-core/+bug/1645729, but for the develop branch