### PR TITLE
apiserver: dispose facade object on watcher.Stop

### DIFF
--- a/apiserver/common/registry.go
+++ b/apiserver/common/registry.go
@@ -19,7 +19,11 @@ import (
 // FacadeFactory represent a way of creating a Facade from the current
 // connection to the State.
 type FacadeFactory func(
-	st *state.State, resources *Resources, authorizer Authorizer, id string,
+	st *state.State,
+	resources *Resources,
+	authorizer Authorizer,
+	id string,
+	dispose func(),
 ) (
 	interface{}, error,
 )
@@ -93,7 +97,11 @@ func wrapNewFacade(newFunc interface{}) (FacadeFactory, reflect.Type, error) {
 	// So we know newFunc is a func with the right args in and out, so
 	// wrap it into a helper function that matches the FacadeFactory.
 	wrapped := func(
-		st *state.State, resources *Resources, auth Authorizer, id string,
+		st *state.State,
+		resources *Resources,
+		auth Authorizer,
+		id string,
+		dispose func(),
 	) (
 		interface{}, error,
 	) {
@@ -130,7 +138,7 @@ type NewHookContextFacadeFn func(*state.State, *state.Unit) (interface{}, error)
 // any necessary authorization for the client.
 func RegisterHookContextFacade(name string, version int, newHookContextFacade NewHookContextFacadeFn, facadeType reflect.Type) {
 
-	newFacade := func(st *state.State, _ *Resources, authorizer Authorizer, _ string) (interface{}, error) {
+	newFacade := func(st *state.State, _ *Resources, authorizer Authorizer, _ string, _ func()) (interface{}, error) {
 
 		if !authorizer.AuthUnitAgent() {
 			return nil, ErrPerm

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -180,7 +180,12 @@ func (r *apiRoot) FindMethod(rootName string, version int, methodName string) (r
 			// check.
 			return reflect.Value{}, err
 		}
-		obj, err := factory(r.state, r.resources, r.authorizer, id)
+		dispose := func() {
+			r.objectMutex.Lock()
+			defer r.objectMutex.Unlock()
+			delete(r.objectCache, objKey)
+		}
+		obj, err := factory(r.state, r.resources, r.authorizer, id, dispose)
 		if err != nil {
 			return reflect.Value{}, err
 		}

--- a/apiserver/root_test.go
+++ b/apiserver/root_test.go
@@ -143,21 +143,21 @@ func (r *rootSuite) TestFindMethodEnsuresTypeMatch(c *gc.C) {
 	defer common.Facades.Discard("my-testing-facade", 1)
 	defer common.Facades.Discard("my-testing-facade", 2)
 	myBadFacade := func(
-		*state.State, *common.Resources, common.Authorizer, string,
+		*state.State, *common.Resources, common.Authorizer, string, func(),
 	) (
 		interface{}, error,
 	) {
 		return &badType{}, nil
 	}
 	myGoodFacade := func(
-		*state.State, *common.Resources, common.Authorizer, string,
+		*state.State, *common.Resources, common.Authorizer, string, func(),
 	) (
 		interface{}, error,
 	) {
 		return &testingType{}, nil
 	}
 	myErrFacade := func(
-		*state.State, *common.Resources, common.Authorizer, string,
+		*state.State, *common.Resources, common.Authorizer, string, func(),
 	) (
 		interface{}, error,
 	) {
@@ -255,7 +255,7 @@ func (r *rootSuite) TestFindMethodCachesFacadesWithId(c *gc.C) {
 	// like newCounter, but also tracks the "id" that was requested for
 	// this counter
 	newIdCounter := func(
-		_ *state.State, _ *common.Resources, _ common.Authorizer, id string,
+		_ *state.State, _ *common.Resources, _ common.Authorizer, id string, dispose func(),
 	) (interface{}, error) {
 		count += 1
 		return &countingType{count: count, id: id}, nil
@@ -287,7 +287,7 @@ func (r *rootSuite) TestFindMethodCacheRaceSafe(c *gc.C) {
 	defer common.Facades.Discard("my-counting-facade", 0)
 	var count int64
 	newIdCounter := func(
-		_ *state.State, _ *common.Resources, _ common.Authorizer, id string,
+		_ *state.State, _ *common.Resources, _ common.Authorizer, id string, dispose func(),
 	) (interface{}, error) {
 		count += 1
 		return &countingType{count: count, id: id}, nil

--- a/apiserver/systemmanager/systemmanager_test.go
+++ b/apiserver/systemmanager/systemmanager_test.go
@@ -190,7 +190,13 @@ func (s *systemManagerSuite) TestWatchAllEnvs(c *gc.C) {
 	watcherId, err := s.systemManager.WatchAllEnvs()
 	c.Assert(err, jc.ErrorIsNil)
 
-	watcherAPI_, err := apiserver.NewAllWatcher(s.State, s.resources, s.authorizer, watcherId.AllWatcherId)
+	watcherAPI_, err := apiserver.NewAllWatcher(
+		s.State,
+		s.resources,
+		s.authorizer,
+		watcherId.AllWatcherId,
+		func() {},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	watcherAPI := watcherAPI_.(*apiserver.SrvAllWatcher)
 	defer func() {


### PR DESCRIPTION
When we stop a watcher, we will now dispose of the
facade object that is cached upon creation. Unless
we do this, the cache grows every time a watcher
is started, and only cleared when the API connection
is severed.

Back port of #6643. Different enough that it warrants another review.

Hopefully fixes https://bugs.launchpad.net/juju-core/+bug/1645729