### PR TITLE
migration: make logtransfer restartable again

### DIFF
--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -5,6 +5,7 @@ package migrationmaster
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/version"
@@ -250,9 +251,10 @@ func groupTagIds(tagStrs []string) ([]string, []string, error) {
 	return machines, units, nil
 }
 
-func (c *Client) StreamModelLog() (<-chan common.LogMessage, error) {
+func (c *Client) StreamModelLog(start time.Time) (<-chan common.LogMessage, error) {
 	return common.StreamDebugLog(c.caller.RawAPICaller(), common.DebugLogParams{
-		Replay: true,
-		NoTail: true,
+		Replay:    true,
+		NoTail:    true,
+		StartTime: start,
 	})
 }

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -394,7 +394,7 @@ func (s *ClientSuite) TestMinionReportsBadFailedTag(c *gc.C) {
 func (s *ClientSuite) TestStreamModelLogs(c *gc.C) {
 	caller := fakeConnector{path: new(string), attrs: &url.Values{}}
 	client := migrationmaster.NewClient(caller, nil)
-	stream, err := client.StreamModelLog()
+	stream, err := client.StreamModelLog(time.Date(2016, 12, 2, 10, 24, 1, 1000000, time.UTC))
 	c.Assert(stream, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "colonel abrams")
 
@@ -402,6 +402,7 @@ func (s *ClientSuite) TestStreamModelLogs(c *gc.C) {
 	c.Assert(*caller.attrs, gc.DeepEquals, url.Values{
 		"replay":        {"true"},
 		"noTail":        {"true"},
+		"startTime":     {"2016-12-02T10:24:01.001Z"},
 		"includeEntity": nil,
 		"includeModule": nil,
 		"excludeEntity": nil,

--- a/state/logs.go
+++ b/state/logs.go
@@ -837,7 +837,15 @@ func getLogCountForEnv(coll *mgo.Collection, modelUUID string) (int, error) {
 }
 
 func removeModelLogs(session *mgo.Session, modelUUID string) error {
-	logsColl := session.DB(logsDB).C(logsC)
+	logsDB := session.DB(logsDB)
+	logsColl := logsDB.C(logsC)
 	_, err := logsColl.RemoveAll(bson.M{"e": modelUUID})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Also remove the tracked high-water times.
+	trackersColl := logsDB.C(forwardedC)
+	_, err = trackersColl.RemoveAll(bson.M{"model-uuid": modelUUID})
 	return errors.Trace(err)
 }

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -474,6 +474,11 @@ func (w *Worker) transferLogs(targetInfo coremigration.TargetInfo, modelUUID str
 	if err != nil {
 		return errors.Annotate(err, "getting log start time")
 	}
+
+	if latestLogTime != utcZero {
+		w.logger.Debugf("log transfer was interrupted - restarting from %s", latestLogTime)
+	}
+
 	throwWrench := latestLogTime == utcZero && wrench.IsActive("migrationmaster", "die-after-500-log-messages")
 
 	logSource, err := w.config.Facade.StreamModelLog(latestLogTime)

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -94,6 +94,12 @@ var (
 			params.ModelArgs{ModelTag: modelTag.String()},
 		},
 	}
+	latestLogTimeCall = jujutesting.StubCall{
+		"MigrationTarget.LatestLogTime",
+		[]interface{}{
+			params.ModelArgs{ModelTag: modelTag.String()},
+		},
+	}
 	apiCloseCall = jujutesting.StubCall{"Connection.Close", nil}
 	abortCall    = jujutesting.StubCall{
 		"MigrationTarget.Abort",
@@ -238,8 +244,9 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 			{"facade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
 
 			// LOGTRANSFER
-			{"StreamModelLog", nil},
 			apiOpenControllerCall,
+			latestLogTimeCall,
+			{"StreamModelLog", []interface{}{time.Time{}}},
 			openDestLogStreamCall,
 			{"facade.SetPhase", []interface{}{coremigration.REAP}},
 
@@ -262,8 +269,9 @@ func (s *Suite) TestMigrationResume(c *gc.C) {
 			{"facade.WatchMinionReports", nil},
 			{"facade.MinionReports", nil},
 			{"facade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
-			{"StreamModelLog", nil},
 			apiOpenControllerCall,
+			latestLogTimeCall,
+			{"StreamModelLog", []interface{}{time.Time{}}},
 			openDestLogStreamCall,
 			{"facade.SetPhase", []interface{}{coremigration.REAP}},
 			{"facade.Reap", nil},
@@ -535,8 +543,9 @@ func (s *Suite) TestSUCCESSMinionWaitFailedMachine(c *gc.C) {
 			{"facade.WatchMinionReports", nil},
 			{"facade.MinionReports", nil},
 			{"facade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
-			{"StreamModelLog", nil},
 			apiOpenControllerCall,
+			latestLogTimeCall,
+			{"StreamModelLog", []interface{}{time.Time{}}},
 			openDestLogStreamCall,
 			{"facade.SetPhase", []interface{}{coremigration.REAP}},
 			{"facade.Reap", nil},
@@ -561,8 +570,9 @@ func (s *Suite) TestSUCCESSMinionWaitFailedUnit(c *gc.C) {
 			{"facade.WatchMinionReports", nil},
 			{"facade.MinionReports", nil},
 			{"facade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
-			{"StreamModelLog", nil},
 			apiOpenControllerCall,
+			latestLogTimeCall,
+			{"StreamModelLog", []interface{}{time.Time{}}},
 			openDestLogStreamCall,
 			{"facade.SetPhase", []interface{}{coremigration.REAP}},
 			{"facade.Reap", nil},
@@ -598,8 +608,9 @@ func (s *Suite) TestSUCCESSMinionWaitTimeout(c *gc.C) {
 		[]jujutesting.StubCall{
 			{"facade.WatchMinionReports", nil},
 			{"facade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
-			{"StreamModelLog", nil},
 			apiOpenControllerCall,
+			latestLogTimeCall,
+			{"StreamModelLog", []interface{}{time.Time{}}},
 			openDestLogStreamCall,
 			{"facade.SetPhase", []interface{}{coremigration.REAP}},
 			{"facade.Reap", nil},
@@ -714,19 +725,6 @@ func (s *Suite) TestExternalControlABORT(c *gc.C) {
 	))
 }
 
-func (s *Suite) TestLogTransferErrorOpeningLogSource(c *gc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
-	s.facade.streamErr = errors.New("chicken bones")
-
-	s.checkWorkerReturns(c, s.facade.streamErr)
-	s.stub.CheckCalls(c, joinCalls(
-		watchStatusLockdownCalls,
-		[]jujutesting.StubCall{
-			{"StreamModelLog", nil},
-		},
-	))
-}
-
 func (s *Suite) TestLogTransferErrorOpeningTargetAPI(c *gc.C) {
 	s.facade.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
 	s.connectionErr = errors.New("people of earth")
@@ -735,8 +733,36 @@ func (s *Suite) TestLogTransferErrorOpeningTargetAPI(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
-			{"StreamModelLog", nil},
 			apiOpenControllerCall,
+		},
+	))
+}
+
+func (s *Suite) TestLogTransferErrorGettingStartTime(c *gc.C) {
+	s.facade.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
+	s.connection.latestLogErr = errors.New("tender vittles")
+
+	s.checkWorkerReturns(c, s.connection.latestLogErr)
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{
+			apiOpenControllerCall,
+			latestLogTimeCall,
+		},
+	))
+}
+
+func (s *Suite) TestLogTransferErrorOpeningLogSource(c *gc.C) {
+	s.facade.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
+	s.facade.streamErr = errors.New("chicken bones")
+
+	s.checkWorkerReturns(c, s.facade.streamErr)
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{
+			apiOpenControllerCall,
+			latestLogTimeCall,
+			{"StreamModelLog", []interface{}{time.Time{}}},
 		},
 	))
 }
@@ -749,8 +775,9 @@ func (s *Suite) TestLogTransferErrorOpeningLogDest(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
-			{"StreamModelLog", nil},
 			apiOpenControllerCall,
+			latestLogTimeCall,
+			{"StreamModelLog", []interface{}{time.Time{}}},
 			openDestLogStreamCall,
 		},
 	))
@@ -766,8 +793,9 @@ func (s *Suite) TestLogTransferErrorWriting(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
-			{"StreamModelLog", nil},
 			apiOpenControllerCall,
+			latestLogTimeCall,
+			{"StreamModelLog", []interface{}{time.Time{}}},
 			openDestLogStreamCall,
 		},
 	))
@@ -800,8 +828,9 @@ func (s *Suite) TestLogTransferSendsRecords(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
-			{"StreamModelLog", nil},
 			apiOpenControllerCall,
+			latestLogTimeCall,
+			{"StreamModelLog", []interface{}{time.Time{}}},
 			openDestLogStreamCall,
 			{"facade.SetPhase", []interface{}{coremigration.REAP}},
 			{"facade.Reap", nil},
@@ -851,6 +880,26 @@ func (s *Suite) TestLogTransferReportsProgress(c *gc.C) {
 		"successful, transferring logs to target controller \\(2 sent\\)",
 		"successful, transferred logs to target controller \\(3 sent\\)",
 	})
+}
+
+func (s *Suite) TestLogTransfer_ChecksLatestTime(c *gc.C) {
+	s.facade.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
+	t := time.Date(2016, 12, 2, 10, 39, 10, 20, time.UTC)
+	s.connection.latestLogTime = t
+
+	s.checkWorkerReturns(c, migrationmaster.ErrMigrated)
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{
+			apiOpenControllerCall,
+			latestLogTimeCall,
+			{"StreamModelLog", []interface{}{t}},
+			openDestLogStreamCall,
+			{"facade.SetPhase", []interface{}{coremigration.REAP}},
+			{"facade.Reap", nil},
+			{"facade.SetPhase", []interface{}{coremigration.DONE}},
+		},
+	))
 }
 
 func safeSend(c *gc.C, d chan<- common.LogMessage, message common.LogMessage) {
@@ -1083,8 +1132,8 @@ func (f *stubMasterFacade) Reap() error {
 	return nil
 }
 
-func (f *stubMasterFacade) StreamModelLog() (<-chan common.LogMessage, error) {
-	f.stub.AddCall("StreamModelLog")
+func (f *stubMasterFacade) StreamModelLog(start time.Time) (<-chan common.LogMessage, error) {
+	f.stub.AddCall("StreamModelLog", start)
 	if f.streamErr != nil {
 		return nil, f.streamErr
 	}
@@ -1125,6 +1174,9 @@ type stubConnection struct {
 
 	streamErr error
 	logStream *mockStream
+
+	latestLogErr  error
+	latestLogTime time.Time
 }
 
 func (c *stubConnection) BestFacadeVersion(string) int {
@@ -1142,6 +1194,10 @@ func (c *stubConnection) APICall(objType string, version int, id, request string
 			return c.importErr
 		case "Activate":
 			return nil
+		case "LatestLogTime":
+			responseTime := response.(*time.Time)
+			*responseTime = c.latestLogTime
+			return c.latestLogErr
 		}
 	}
 	return errors.New("unexpected API call")

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -1196,7 +1196,9 @@ func (c *stubConnection) APICall(objType string, version int, id, request string
 			return nil
 		case "LatestLogTime":
 			responseTime := response.(*time.Time)
-			*responseTime = c.latestLogTime
+			// This is needed because even if a zero time comes back
+			// from the API it will have a timezone attached.
+			*responseTime = c.latestLogTime.In(time.UTC)
 			return c.latestLogErr
 		}
 	}


### PR DESCRIPTION
Use target model LatestLogTime as the start time for the debug-log stream. This means that migration log transfer will restart with minimal duplication if it's interrupted.

During testing I realised that we also need to clear the last seen log times when removing a model, otherwise when you try to migrate back to that model it will only send the log messages after that.

Testing the restarting manually is tricky - you need to generate enough log messages that it takes a long enough time that you have a chance to kill the controller during logtransfer - so I've added a wrench point that can trigger an error to stop the transfer after 500 messages. The dependency engine automatically restarts the migration master. The worker will log when it restarts sending messages after an interruption so you can see the log time it's starting from (although it logs the message start time in UTC rather than the local time that debug-log displays).

QA steps:
* bootstrap two controllers A and B
* create model m on A
* deploy ubuntu to m (to generate log messages)
* set the wrench to activate on controller A by creating the /var/lib/juju/wrench/migrationmaster on A:controller machine 0 - containing the line:
```
die-after-500-log-messages
```
Or use this command:
```
juju run -m A:controller --machine 0 "sudo bash -c \"mkdir /var/lib/juju/wrench; echo die-after-500-log-messages > /var/lib/juju/wrench/migrationmaster\""
```
* check the number of log messages for A:m - `juju debug-log --replay -m A:m | wc -l`
* save the first ~700 messages and to a file for comparison
* `juju migrate -c A m B`
* look in the A:controller logs to confirm that the wrench error was thrown - search for "wrench in the works"
* note the time that log transfer started from when the migration master worker restarted
* check that you don't see any duplicate messages in the log at that time (after converting it to local time)
* check the number of log messages for B:m. It'll be higher, because of messages logged during the import, but it shouldn't be 500 higher.
* check that the B:m logs start with the same ~700 messages as the saved A:m logs - if the restarting wasn't working you'd expect to see lots of duplicates at the start of the B:m logs that weren't present in the A:m logs.