### PR TITLE
Fix 1640535 HA tests fail after the leader is deleted

### DIFF
--- a/apiserver/observer/metricobserver/metricobserver.go
+++ b/apiserver/observer/metricobserver/metricobserver.go
@@ -75,9 +75,12 @@ func NewObserverFactory(config Config) (observer.ObserverFactory, error) {
 		Help:      "Latency of Juju API requests in seconds.",
 	}, metricLabelNames)
 
+	config.PrometheusRegisterer.Unregister(apiRequestsTotal)
 	if err := config.PrometheusRegisterer.Register(apiRequestsTotal); err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	config.PrometheusRegisterer.Unregister(apiRequestDuration)
 	if err := config.PrometheusRegisterer.Register(apiRequestDuration); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/observer/metricobserver/observerfactory_test.go
+++ b/apiserver/observer/metricobserver/observerfactory_test.go
@@ -62,3 +62,7 @@ func (r *fakePrometheusRegisterer) Register(c prometheus.Collector) error {
 	r.MethodCall(r, "Register", c)
 	return r.NextErr()
 }
+
+func (r *fakePrometheusRegisterer) Unregister(c prometheus.Collector) bool {
+	return true
+}


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/juju/+bug/1640535

The problem is that Prometheus does not allow to re-register the same observer so we now are unregistering before registering, there is no pre-check required as this is an idempotent operation.

### QA 
* Run the aforementioned test "assess_recovery.py" you should obtain a pass