### PR TITLE
provider/maas: conditionally run ifdown/up

### DIFF
--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -370,25 +370,21 @@ def print_stanzas(stanzas, stream=sys.stdout):
             print(file=stream)
 
 
-def shell_cmd(s):
-    p = subprocess.Popen(s, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = p.communicate()
-    return [out, err, p.returncode]
-
-
-def print_shell_cmd(s, verbose=True, exit_on_error=False, dryrun=False):
+def shell_cmd(s, verbose=True, exit_on_error=False, dryrun=False):
     if dryrun:
         print(s)
         return
     if verbose:
         print(s)
-    out, err, retcode = shell_cmd(s)
+    p = subprocess.Popen(s, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = p.communicate()
     if out and len(out) > 0:
         print(out.decode().rstrip('\n'))
     if err and len(err) > 0:
         print(err.decode().rstrip('\n'))
     if exit_on_error and retcode != 0:
         exit(1)
+    return p.returncode
 
 
 def arg_parser():
@@ -440,9 +436,9 @@ def main(args):
     ifquery = "$(ifquery --interfaces={} --exclude=lo --list)".format(args.filename)
 
     print("**** Original configuration")
-    print_shell_cmd("cat {}".format(args.filename), dryrun=args.dryrun)
-    print_shell_cmd("ifconfig -a", dryrun=args.dryrun)
-    print_shell_cmd("ifdown --exclude=lo --interfaces={} {}".format(args.filename, ifquery), dryrun=args.dryrun)
+    shell_cmd("cat {}".format(args.filename), dryrun=args.dryrun)
+    shell_cmd("ifconfig -a", dryrun=args.dryrun)
+    shell_cmd("ifdown --exclude=lo --interfaces={} {}".format(args.filename, ifquery), dryrun=args.dryrun)
 
     print("**** Activating new configuration")
 
@@ -463,15 +459,15 @@ def main(args):
         if s.is_logical_interface and s.iface.is_bonded:
             print("working around https://bugs.launchpad.net/ubuntu/+source/ifenslave/+bug/1269921")
             print("working around https://bugs.launchpad.net/juju-core/+bug/1594855")
-            print_shell_cmd("sleep 3", dryrun=args.dryrun)
+            shell_cmd("sleep 3", dryrun=args.dryrun)
             break
 
-    print_shell_cmd("cat {}".format(args.filename), dryrun=args.dryrun)
-    print_shell_cmd("ifup --exclude=lo --interfaces={} {}".format(args.filename, ifquery), dryrun=args.dryrun)
-    print_shell_cmd("ip link show up", dryrun=args.dryrun)
-    print_shell_cmd("ifconfig -a", dryrun=args.dryrun)
-    print_shell_cmd("ip route show", dryrun=args.dryrun)
-    print_shell_cmd("brctl show", dryrun=args.dryrun)
+    shell_cmd("cat {}".format(args.filename), dryrun=args.dryrun)
+    shell_cmd("ifup --exclude=lo --interfaces={} {}".format(args.filename, ifquery), dryrun=args.dryrun)
+    shell_cmd("ip link show up", dryrun=args.dryrun)
+    shell_cmd("ifconfig -a", dryrun=args.dryrun)
+    shell_cmd("ip route show", dryrun=args.dryrun)
+    shell_cmd("brctl show", dryrun=args.dryrun)
 
 # This script re-renders an interfaces(5) file to add a bridge to
 # either all active interfaces, or a specific interface.

--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -395,7 +395,6 @@ def arg_parser():
     parser.add_argument('--interfaces-to-bridge', help="interfaces to bridge; space delimited", type=str, required=True)
     parser.add_argument('--dryrun', help="dry run, no activation", action='store_true', default=False, required=False)
     parser.add_argument('--bridge-name', help="bridge name", type=str, required=False)
-    parser.add_argument('--bond-sleep-duration', help="duration to sleep between ifdown/up", type=int, required=False)
     parser.add_argument('filename', help="interfaces(5) based filename")
     return parser
 

--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -370,8 +370,8 @@ def print_stanzas(stanzas, stream=sys.stdout):
             print(file=stream)
 
 
-def shell_cmd(s, verbose=True, exit_on_error=False, dryrun=False):
-    if dryrun:
+def shell_cmd(s, verbose=True, exit_on_error=False, dry_run=False):
+    if dry_run:
         print(s)
         return
     if verbose:
@@ -393,7 +393,7 @@ def arg_parser():
     parser.add_argument('--one-time-backup', help='A one time backup of filename', action='store_true', default=True, required=False)
     parser.add_argument('--activate', help='activate new configuration', action='store_true', default=False, required=False)
     parser.add_argument('--interfaces-to-bridge', help="interfaces to bridge; space delimited", type=str, required=True)
-    parser.add_argument('--dryrun', help="dry run, no activation", action='store_true', default=False, required=False)
+    parser.add_argument('--dry-run', help="dry run, no activation", action='store_true', default=False, required=False)
     parser.add_argument('--bridge-name', help="bridge name", type=str, required=False)
     parser.add_argument('filename', help="interfaces(5) based filename")
     return parser
@@ -427,7 +427,7 @@ def main(args):
         print("already bridged, or nothing to do.")
         exit(0)
 
-    if not args.dryrun and args.one_time_backup:
+    if not args.dry_run and args.one_time_backup:
         backup_file = "{}-before-add-juju-bridge".format(args.filename)
         if not os.path.isfile(backup_file):
             shutil.copy2(args.filename, backup_file)
@@ -435,13 +435,13 @@ def main(args):
     ifquery = "$(ifquery --interfaces={} --exclude=lo --list)".format(args.filename)
 
     print("**** Original configuration")
-    shell_cmd("cat {}".format(args.filename), dryrun=args.dryrun)
-    shell_cmd("ifconfig -a", dryrun=args.dryrun)
-    shell_cmd("ifdown --exclude=lo --interfaces={} {}".format(args.filename, ifquery), dryrun=args.dryrun)
+    shell_cmd("cat {}".format(args.filename), dry_run=args.dry_run)
+    shell_cmd("ifconfig -a", dry_run=args.dry_run)
+    shell_cmd("ifdown --exclude=lo --interfaces={} {}".format(args.filename, ifquery), dry_run=args.dry_run)
 
     print("**** Activating new configuration")
 
-    if not args.dryrun:
+    if not args.dry_run:
         with open(args.filename, 'w') as f:
             print_stanzas(stanzas, f)
             f.close()
@@ -458,15 +458,15 @@ def main(args):
         if s.is_logical_interface and s.iface.is_bonded:
             print("working around https://bugs.launchpad.net/ubuntu/+source/ifenslave/+bug/1269921")
             print("working around https://bugs.launchpad.net/juju-core/+bug/1594855")
-            shell_cmd("sleep 3", dryrun=args.dryrun)
+            shell_cmd("sleep 3", dry_run=args.dry_run)
             break
 
-    shell_cmd("cat {}".format(args.filename), dryrun=args.dryrun)
-    shell_cmd("ifup --exclude=lo --interfaces={} {}".format(args.filename, ifquery), dryrun=args.dryrun)
-    shell_cmd("ip link show up", dryrun=args.dryrun)
-    shell_cmd("ifconfig -a", dryrun=args.dryrun)
-    shell_cmd("ip route show", dryrun=args.dryrun)
-    shell_cmd("brctl show", dryrun=args.dryrun)
+    shell_cmd("cat {}".format(args.filename), dry_run=args.dry_run)
+    shell_cmd("ifup --exclude=lo --interfaces={} {}".format(args.filename, ifquery), dry_run=args.dry_run)
+    shell_cmd("ip link show up", dry_run=args.dry_run)
+    shell_cmd("ifconfig -a", dry_run=args.dry_run)
+    shell_cmd("ip route show", dry_run=args.dry_run)
+    shell_cmd("brctl show", dry_run=args.dry_run)
 
 # This script re-renders an interfaces(5) file to add a bridge to
 # either all active interfaces, or a specific interface.

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -376,25 +376,21 @@ def print_stanzas(stanzas, stream=sys.stdout):
             print(file=stream)
 
 
-def shell_cmd(s):
-    p = subprocess.Popen(s, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = p.communicate()
-    return [out, err, p.returncode]
-
-
-def print_shell_cmd(s, verbose=True, exit_on_error=False, dryrun=False):
+def shell_cmd(s, verbose=True, exit_on_error=False, dryrun=False):
     if dryrun:
         print(s)
         return
     if verbose:
         print(s)
-    out, err, retcode = shell_cmd(s)
+    p = subprocess.Popen(s, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = p.communicate()
     if out and len(out) > 0:
         print(out.decode().rstrip('\n'))
     if err and len(err) > 0:
         print(err.decode().rstrip('\n'))
     if exit_on_error and retcode != 0:
         exit(1)
+    return p.returncode
 
 
 def arg_parser():
@@ -446,9 +442,9 @@ def main(args):
     ifquery = "$(ifquery --interfaces={} --exclude=lo --list)".format(args.filename)
 
     print("**** Original configuration")
-    print_shell_cmd("cat {}".format(args.filename), dryrun=args.dryrun)
-    print_shell_cmd("ifconfig -a", dryrun=args.dryrun)
-    print_shell_cmd("ifdown --exclude=lo --interfaces={} {}".format(args.filename, ifquery), dryrun=args.dryrun)
+    shell_cmd("cat {}".format(args.filename), dryrun=args.dryrun)
+    shell_cmd("ifconfig -a", dryrun=args.dryrun)
+    shell_cmd("ifdown --exclude=lo --interfaces={} {}".format(args.filename, ifquery), dryrun=args.dryrun)
 
     print("**** Activating new configuration")
 
@@ -469,15 +465,15 @@ def main(args):
         if s.is_logical_interface and s.iface.is_bonded:
             print("working around https://bugs.launchpad.net/ubuntu/+source/ifenslave/+bug/1269921")
             print("working around https://bugs.launchpad.net/juju-core/+bug/1594855")
-            print_shell_cmd("sleep 3", dryrun=args.dryrun)
+            shell_cmd("sleep 3", dryrun=args.dryrun)
             break
 
-    print_shell_cmd("cat {}".format(args.filename), dryrun=args.dryrun)
-    print_shell_cmd("ifup --exclude=lo --interfaces={} {}".format(args.filename, ifquery), dryrun=args.dryrun)
-    print_shell_cmd("ip link show up", dryrun=args.dryrun)
-    print_shell_cmd("ifconfig -a", dryrun=args.dryrun)
-    print_shell_cmd("ip route show", dryrun=args.dryrun)
-    print_shell_cmd("brctl show", dryrun=args.dryrun)
+    shell_cmd("cat {}".format(args.filename), dryrun=args.dryrun)
+    shell_cmd("ifup --exclude=lo --interfaces={} {}".format(args.filename, ifquery), dryrun=args.dryrun)
+    shell_cmd("ip link show up", dryrun=args.dryrun)
+    shell_cmd("ifconfig -a", dryrun=args.dryrun)
+    shell_cmd("ip route show", dryrun=args.dryrun)
+    shell_cmd("brctl show", dryrun=args.dryrun)
 
 # This script re-renders an interfaces(5) file to add a bridge to
 # either all active interfaces, or a specific interface.

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -14,12 +14,20 @@ const bridgeScriptPython = `#!/usr/bin/env python
 #
 
 from __future__ import print_function
+
 import argparse
 import os
 import re
 import shutil
 import subprocess
 import sys
+
+# StringIO: accommodate Python2 & Python3
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 # These options are to be removed from a sub-interface and applied to
 # the new bridged interface.
@@ -374,7 +382,10 @@ def shell_cmd(s):
     return [out, err, p.returncode]
 
 
-def print_shell_cmd(s, verbose=True, exit_on_error=False):
+def print_shell_cmd(s, verbose=True, exit_on_error=False, dryrun=False):
+    if dryrun:
+        print(s)
+        return
     if verbose:
         print(s)
     out, err, retcode = shell_cmd(s)
@@ -386,22 +397,15 @@ def print_shell_cmd(s, verbose=True, exit_on_error=False):
         exit(1)
 
 
-def check_shell_cmd(s, verbose=False):
-    if verbose:
-        print(s)
-    output = subprocess.check_output(s, shell=True, stderr=subprocess.STDOUT).strip().decode("utf-8")
-    if verbose:
-        print(output.rstrip('\n'))
-    return output
-
-
 def arg_parser():
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--bridge-prefix', help="bridge prefix", type=str, required=False, default='br-')
     parser.add_argument('--one-time-backup', help='A one time backup of filename', action='store_true', default=True, required=False)
     parser.add_argument('--activate', help='activate new configuration', action='store_true', default=False, required=False)
     parser.add_argument('--interfaces-to-bridge', help="interfaces to bridge; space delimited", type=str, required=True)
+    parser.add_argument('--dryrun', help="dry run, no activation", action='store_true', default=False, required=False)
     parser.add_argument('--bridge-name', help="bridge name", type=str, required=False)
+    parser.add_argument('--bond-sleep-duration', help="duration to sleep between ifdown/up", type=int, required=False)
     parser.add_argument('filename', help="interfaces(5) based filename")
     return parser
 
@@ -424,7 +428,17 @@ def main(args):
         print_stanzas(stanzas)
         exit(0)
 
-    if args.one_time_backup:
+    # Dump stanzas to cur/new in-memory strings
+    cur = StringIO()
+    new = StringIO()
+    print_stanzas(stanzas, new)
+    print_stanzas(parser.stanzas(), cur)
+
+    if cur.getvalue() == new.getvalue():
+        print("already bridged, or nothing to do.")
+        exit(0)
+
+    if not args.dryrun and args.one_time_backup:
         backup_file = "{}-before-add-juju-bridge".format(args.filename)
         if not os.path.isfile(backup_file):
             shutil.copy2(args.filename, backup_file)
@@ -432,15 +446,16 @@ def main(args):
     ifquery = "$(ifquery --interfaces={} --exclude=lo --list)".format(args.filename)
 
     print("**** Original configuration")
-    print_shell_cmd("cat {}".format(args.filename))
-    print_shell_cmd("ifconfig -a")
-    print_shell_cmd("ifdown --exclude=lo --interfaces={} {}".format(args.filename, ifquery))
+    print_shell_cmd("cat {}".format(args.filename), dryrun=args.dryrun)
+    print_shell_cmd("ifconfig -a", dryrun=args.dryrun)
+    print_shell_cmd("ifdown --exclude=lo --interfaces={} {}".format(args.filename, ifquery), dryrun=args.dryrun)
 
     print("**** Activating new configuration")
 
-    with open(args.filename, 'w') as f:
-        print_stanzas(stanzas, f)
-        f.close()
+    if not args.dryrun:
+        with open(args.filename, 'w') as f:
+            print_stanzas(stanzas, f)
+            f.close()
 
     # On configurations that have bonds in 802.3ad mode there is a
     # race condition betweeen an immediate ifdown then ifup.
@@ -454,15 +469,15 @@ def main(args):
         if s.is_logical_interface and s.iface.is_bonded:
             print("working around https://bugs.launchpad.net/ubuntu/+source/ifenslave/+bug/1269921")
             print("working around https://bugs.launchpad.net/juju-core/+bug/1594855")
-            print_shell_cmd("sleep 3")
+            print_shell_cmd("sleep 3", dryrun=args.dryrun)
             break
 
-    print_shell_cmd("cat {}".format(args.filename))
-    print_shell_cmd("ifup --exclude=lo --interfaces={} {}".format(args.filename, ifquery))
-    print_shell_cmd("ip link show up")
-    print_shell_cmd("ifconfig -a")
-    print_shell_cmd("ip route show")
-    print_shell_cmd("brctl show")
+    print_shell_cmd("cat {}".format(args.filename), dryrun=args.dryrun)
+    print_shell_cmd("ifup --exclude=lo --interfaces={} {}".format(args.filename, ifquery), dryrun=args.dryrun)
+    print_shell_cmd("ip link show up", dryrun=args.dryrun)
+    print_shell_cmd("ifconfig -a", dryrun=args.dryrun)
+    print_shell_cmd("ip route show", dryrun=args.dryrun)
+    print_shell_cmd("brctl show", dryrun=args.dryrun)
 
 # This script re-renders an interfaces(5) file to add a bridge to
 # either all active interfaces, or a specific interface.

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -401,7 +401,6 @@ def arg_parser():
     parser.add_argument('--interfaces-to-bridge', help="interfaces to bridge; space delimited", type=str, required=True)
     parser.add_argument('--dryrun', help="dry run, no activation", action='store_true', default=False, required=False)
     parser.add_argument('--bridge-name', help="bridge name", type=str, required=False)
-    parser.add_argument('--bond-sleep-duration', help="duration to sleep between ifdown/up", type=int, required=False)
     parser.add_argument('filename', help="interfaces(5) based filename")
     return parser
 

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -376,8 +376,8 @@ def print_stanzas(stanzas, stream=sys.stdout):
             print(file=stream)
 
 
-def shell_cmd(s, verbose=True, exit_on_error=False, dryrun=False):
-    if dryrun:
+def shell_cmd(s, verbose=True, exit_on_error=False, dry_run=False):
+    if dry_run:
         print(s)
         return
     if verbose:
@@ -399,7 +399,7 @@ def arg_parser():
     parser.add_argument('--one-time-backup', help='A one time backup of filename', action='store_true', default=True, required=False)
     parser.add_argument('--activate', help='activate new configuration', action='store_true', default=False, required=False)
     parser.add_argument('--interfaces-to-bridge', help="interfaces to bridge; space delimited", type=str, required=True)
-    parser.add_argument('--dryrun', help="dry run, no activation", action='store_true', default=False, required=False)
+    parser.add_argument('--dry-run', help="dry run, no activation", action='store_true', default=False, required=False)
     parser.add_argument('--bridge-name', help="bridge name", type=str, required=False)
     parser.add_argument('filename', help="interfaces(5) based filename")
     return parser
@@ -433,7 +433,7 @@ def main(args):
         print("already bridged, or nothing to do.")
         exit(0)
 
-    if not args.dryrun and args.one_time_backup:
+    if not args.dry_run and args.one_time_backup:
         backup_file = "{}-before-add-juju-bridge".format(args.filename)
         if not os.path.isfile(backup_file):
             shutil.copy2(args.filename, backup_file)
@@ -441,13 +441,13 @@ def main(args):
     ifquery = "$(ifquery --interfaces={} --exclude=lo --list)".format(args.filename)
 
     print("**** Original configuration")
-    shell_cmd("cat {}".format(args.filename), dryrun=args.dryrun)
-    shell_cmd("ifconfig -a", dryrun=args.dryrun)
-    shell_cmd("ifdown --exclude=lo --interfaces={} {}".format(args.filename, ifquery), dryrun=args.dryrun)
+    shell_cmd("cat {}".format(args.filename), dry_run=args.dry_run)
+    shell_cmd("ifconfig -a", dry_run=args.dry_run)
+    shell_cmd("ifdown --exclude=lo --interfaces={} {}".format(args.filename, ifquery), dry_run=args.dry_run)
 
     print("**** Activating new configuration")
 
-    if not args.dryrun:
+    if not args.dry_run:
         with open(args.filename, 'w') as f:
             print_stanzas(stanzas, f)
             f.close()
@@ -464,15 +464,15 @@ def main(args):
         if s.is_logical_interface and s.iface.is_bonded:
             print("working around https://bugs.launchpad.net/ubuntu/+source/ifenslave/+bug/1269921")
             print("working around https://bugs.launchpad.net/juju-core/+bug/1594855")
-            shell_cmd("sleep 3", dryrun=args.dryrun)
+            shell_cmd("sleep 3", dry_run=args.dry_run)
             break
 
-    shell_cmd("cat {}".format(args.filename), dryrun=args.dryrun)
-    shell_cmd("ifup --exclude=lo --interfaces={} {}".format(args.filename, ifquery), dryrun=args.dryrun)
-    shell_cmd("ip link show up", dryrun=args.dryrun)
-    shell_cmd("ifconfig -a", dryrun=args.dryrun)
-    shell_cmd("ip route show", dryrun=args.dryrun)
-    shell_cmd("brctl show", dryrun=args.dryrun)
+    shell_cmd("cat {}".format(args.filename), dry_run=args.dry_run)
+    shell_cmd("ifup --exclude=lo --interfaces={} {}".format(args.filename, ifquery), dry_run=args.dry_run)
+    shell_cmd("ip link show up", dry_run=args.dry_run)
+    shell_cmd("ifconfig -a", dry_run=args.dry_run)
+    shell_cmd("ip route show", dry_run=args.dry_run)
+    shell_cmd("brctl show", dry_run=args.dry_run)
 
 # This script re-renders an interfaces(5) file to add a bridge to
 # either all active interfaces, or a specific interface.

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -202,7 +202,7 @@ func (s *bridgeConfigSuite) runScriptWithActivationAndDryRun(c *gc.C, pythonBina
 		bridgePrefix = fmt.Sprintf("--bridge-prefix=%q", bridgePrefix)
 	}
 
-	script := fmt.Sprintf("%q %q --activate --dryrun %s %s --interfaces-to-bridge=%q",
+	script := fmt.Sprintf("%q %q --activate --dry-run %s %s --interfaces-to-bridge=%q",
 		pythonBinary, s.testPythonScript, bridgePrefix, s.testConfigPath, strings.Join(interfacesToBridge, " "))
 	c.Log(script)
 	result, err := exec.RunCommands(exec.RunParams{Commands: script})

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -246,36 +246,36 @@ func (s *bridgeConfigSuite) dryRunExpectedOutputHelper(isBonded, isAlreadyBridge
 	return output
 }
 
-func (s *bridgeConfigSuite) TestBashBridgeScriptWithoutBondedInterfaceSingle(c *gc.C) {
-	bridgePrefix := "TestBashBridgeScriptWithoutBondedInterfaceSingle"
+func (s *bridgeConfigSuite) TestBridgeScriptWithoutBondedInterfaceSingle(c *gc.C) {
+	bridgePrefix := "TestBridgeScriptWithoutBondedInterfaceSingle"
 	interfacesToBridge := []string{"eth0"}
 	expectedOutput := s.dryRunExpectedOutputHelper(false, false, bridgePrefix, interfacesToBridge)
 	s.assertScriptWithActivationAndDryRun(c, networkDHCPInitial, expectedOutput, bridgePrefix, interfacesToBridge)
 }
 
-func (s *bridgeConfigSuite) TestBashBridgeScriptWithoutBondedInterfaceMultiple(c *gc.C) {
-	bridgePrefix := "TestBashBridgeScriptWithoutBondedInterfaceMultiple"
+func (s *bridgeConfigSuite) TestBridgeScriptWithoutBondedInterfaceMultiple(c *gc.C) {
+	bridgePrefix := "TestBridgeScriptWithoutBondedInterfaceMultiple"
 	interfacesToBridge := []string{"eth0", "eth1"}
 	expectedOutput := s.dryRunExpectedOutputHelper(false, false, bridgePrefix, interfacesToBridge)
 	s.assertScriptWithActivationAndDryRun(c, networkDHCPInitial, expectedOutput, bridgePrefix, interfacesToBridge)
 }
 
-func (s *bridgeConfigSuite) TestBashBridgeScriptWithBondedInterfaceSingle(c *gc.C) {
-	bridgePrefix := "TestBashBridgeScriptWithBondedInterfaceSingle"
+func (s *bridgeConfigSuite) TestBridgeScriptWithBondedInterfaceSingle(c *gc.C) {
+	bridgePrefix := "TestBridgeScriptWithBondedInterfaceSingle"
 	interfacesToBridge := []string{"bond0"}
 	expectedOutput := s.dryRunExpectedOutputHelper(true, false, bridgePrefix, interfacesToBridge)
 	s.assertScriptWithActivationAndDryRun(c, networkDHCPWithBondInitial, expectedOutput, bridgePrefix, interfacesToBridge)
 }
 
-func (s *bridgeConfigSuite) TestBashBridgeScriptWithBondedInterfaceMultiple(c *gc.C) {
-	bridgePrefix := "TestBashBridgeScriptWithBondedInterfaceMultiple"
+func (s *bridgeConfigSuite) TestBridgeScriptWithBondedInterfaceMultiple(c *gc.C) {
+	bridgePrefix := "TestBridgeScriptWithBondedInterfaceMultiple"
 	interfacesToBridge := []string{"bond0", "bond1"}
 	expectedOutput := s.dryRunExpectedOutputHelper(true, false, bridgePrefix, interfacesToBridge)
 	s.assertScriptWithActivationAndDryRun(c, networkDHCPWithBondInitial, expectedOutput, bridgePrefix, interfacesToBridge)
 }
 
-func (s *bridgeConfigSuite) TestBashBridgeScriptWithBondedInterfaceAlreadyBridged(c *gc.C) {
-	bridgePrefix := "TestBashBridgeScriptWithBondedInterfaceAlreadyBridged"
+func (s *bridgeConfigSuite) TestBridgeScriptWithBondedInterfaceAlreadyBridged(c *gc.C) {
+	bridgePrefix := "TestBridgeScriptWithBondedInterfaceAlreadyBridged"
 	interfacesToBridge := []string{"br-eth1"}
 	expectedOutput := []string{"already bridged, or nothing to do."}
 	s.assertScriptWithActivationAndDryRun(c, networkPartiallyBridgedInitial, expectedOutput, bridgePrefix, interfacesToBridge)


### PR DESCRIPTION
If the nett result of bridging interfaces results in nothing-to-do,
because they are already bridged, then don't run ifdown/up
unnecessarily.

This state can exist in MAAS 2.1 because you now have the option of
bridging interfaces ahead of deployment or bootstrap. And as we move
to dynamic bridging in Juju we want to invoke this script on an
interface on an ad-hoc basis but don't want it to do anything if that
interface is already bridged.

QA steps:

On a machine run:

 $ sudo ./add-juju-bridge.py /etc/network/interfaces \
     --activate \
     --interfaces-to-bridge=enp1s0f2

And note that enp1s0f2 gets bridged.

Verify with:

 $ brctl show

Run the add-juju-bridge.py script again with the same arguments and
now you'll see no action taken as it is already bridged as
br-enp1s0f2.

I also configured a node in MAAS 2.1 that had two bridged NICs;
bootstrapping a node doesn't additionally run ifdown/up because
there's nothing to do.