### PR TITLE
Correct bad error message when releasing state back to the pool

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -618,7 +618,7 @@ func (srv *Server) serveConn(wsConn *websocket.Conn, modelUUID string, apiObserv
 		defer func() {
 			err := srv.statePool.Release(resolvedModelUUID)
 			if err != nil {
-				logger.Errorf("error releasing %v back into the state pool:", err)
+				logger.Errorf("error releasing %v back into the state pool: %v", resolvedModelUUID, err)
 			}
 		}()
 		h, err = newAPIHandler(srv, st, conn, modelUUID, host)


### PR DESCRIPTION
It should report the model uuid as well as the error.