### PR TITLE
Add the central hub to the apiserver.

### DIFF
--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/juju/pubsub"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
@@ -212,6 +213,7 @@ func (s *legacySuite) TestAPIServerCanShutdownWithOutstandingNext(c *gc.C) {
 		Cert:        testing.ServerCert,
 		Key:         testing.ServerKey,
 		Tag:         names.NewMachineTag("0"),
+		Hub:         pubsub.NewStructuredHub(nil),
 		DataDir:     c.MkDir(),
 		LogDir:      c.MkDir(),
 		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/observer/fakeobserver"
+	"github.com/juju/juju/pubsub/centralhub"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	coretesting "github.com/juju/juju/testing"
@@ -40,12 +41,14 @@ func (s *apiserverBaseSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *apiserverBaseSuite) sampleConfig(c *gc.C) apiserver.ServerConfig {
+	machineTag := names.NewMachineTag("0")
 	return apiserver.ServerConfig{
 		Clock:       clock.WallClock,
 		Cert:        coretesting.ServerCert,
 		Key:         coretesting.ServerKey,
-		Tag:         names.NewMachineTag("0"),
+		Tag:         machineTag,
 		LogDir:      c.MkDir(),
+		Hub:         centralhub.New(machineTag),
 		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
 		AutocertURL: "https://0.1.2.3/no-autocert-here",
 	}

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -803,6 +803,13 @@ type LogRecord struct {
 	Entity   string    `json:"e,omitempty"`
 }
 
+// PubSubMessage is used to propagate pubsub messages from one api server to the
+// others.
+type PubSubMessage struct {
+	Topic string                 `json:"topic"`
+	Data  map[string]interface{} `json:"data"`
+}
+
 // BundleChangesParams holds parameters for making Bundle.GetChanges calls.
 type BundleChangesParams struct {
 	// BundleDataYAML is the YAML-encoded charm bundle data

--- a/apiserver/pubsub.go
+++ b/apiserver/pubsub.go
@@ -1,0 +1,132 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/juju/errors"
+	"github.com/juju/pubsub"
+	"golang.org/x/net/websocket"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+// Hub defines the publish method that the handler uses to publish
+// messages on the centralhub of the apiserver.
+type Hub interface {
+	Publish(pubsub.Topic, interface{}) (<-chan struct{}, error)
+}
+
+func newPubSubHandler(h httpContext, hub Hub) http.Handler {
+	return &pubsubHandler{
+		ctxt: h,
+		hub:  hub,
+	}
+}
+
+type pubsubHandler struct {
+	ctxt httpContext
+	hub  Hub
+}
+
+func (h *pubsubHandler) authenticate(req *http.Request) error {
+	// We authenticate against the controller state instance that is held
+	// by Server.
+	st, entity, err := h.ctxt.stateForRequestAuthenticated(req)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// We don't actually use the state for anything except authentication.
+	defer h.ctxt.release(st)
+
+	switch machine := entity.(type) {
+	case *state.Machine:
+		// Only machines have machine tags.
+		for _, job := range machine.Jobs() {
+			if job == state.JobManageModel {
+				return nil
+			}
+		}
+	default:
+		logger.Errorf("attempt to log in as a machine agent by %v", entity.Tag())
+	}
+	return errors.Trace(common.ErrPerm)
+}
+
+// ServeHTTP implements the http.Handler interface.
+func (h *pubsubHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	server := websocket.Server{
+		Handler: func(socket *websocket.Conn) {
+			logger.Debugf("start of *pubsubHandler.ServeHTTP")
+			defer socket.Close()
+
+			if err := h.authenticate(req); err != nil {
+				h.sendError(socket, req, err)
+				return
+			}
+
+			// If we get to here, no more errors to report, so we report a nil
+			// error.  This way the first line of the socket is always a json
+			// formatted simple error.
+			h.sendError(socket, req, nil)
+
+			messageCh := h.receiveMessages(socket)
+			for {
+				select {
+				case <-h.ctxt.stop():
+					return
+				case m := <-messageCh:
+					logger.Tracef("topic: %q, data: %v", m.Topic, m.Data)
+					_, err := h.hub.Publish(pubsub.Topic(m.Topic), m.Data)
+					if err != nil {
+						logger.Errorf("publish failed: %v", err)
+					}
+				}
+			}
+		},
+	}
+	server.ServeHTTP(w, req)
+}
+
+func (h *pubsubHandler) receiveMessages(socket *websocket.Conn) <-chan params.PubSubMessage {
+	messageCh := make(chan params.PubSubMessage)
+
+	go func() {
+		for {
+			// The message needs to be new each time through the loop to ensure
+			// the map is not reused.
+			var m params.PubSubMessage
+			// Receive() blocks until data arrives but will also be
+			// unblocked when the API handler calls socket.Close as it
+			// finishes.
+			if err := websocket.JSON.Receive(socket, &m); err != nil {
+				logger.Errorf("pubsub receive error: %v", err)
+				return
+			}
+
+			// Send the log message.
+			select {
+			case <-h.ctxt.stop():
+				return
+			case messageCh <- m:
+			}
+		}
+	}()
+
+	return messageCh
+}
+
+// sendError sends a JSON-encoded error response.
+func (h *pubsubHandler) sendError(w io.Writer, req *http.Request, err error) {
+	if err != nil {
+		logger.Errorf("returning error from %s %s: %s", req.Method, req.URL.Path, errors.Details(err))
+	}
+	sendJSON(w, &params.ErrorResult{
+		Error: common.ServerError(err),
+	})
+}

--- a/apiserver/pubsub_test.go
+++ b/apiserver/pubsub_test.go
@@ -1,0 +1,177 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	"golang.org/x/net/websocket"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
+)
+
+type pubsubSuite struct {
+	statetesting.StateSuite
+	machineTag names.Tag
+	password   string
+	nonce      string
+	hub        *pubsub.StructuredHub
+	server     *apiserver.Server
+	pubsubURL  string
+}
+
+var _ = gc.Suite(&pubsubSuite{})
+
+func (s *pubsubSuite) SetUpTest(c *gc.C) {
+	s.StateSuite.SetUpTest(c)
+	s.nonce = "nonce"
+	m, password := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{
+		Nonce: s.nonce,
+		Jobs:  []state.MachineJob{state.JobManageModel},
+	})
+	s.machineTag = m.Tag()
+	s.password = password
+	s.hub = pubsub.NewStructuredHub(nil)
+	_, s.server = newServerWithHub(c, s.State, s.hub)
+	s.AddCleanup(func(*gc.C) { s.server.Stop() })
+
+	// A net.TCPAddr cannot be directly stringified into a valid hostname.
+	address := fmt.Sprintf("localhost:%d", s.server.Addr().Port)
+	path := fmt.Sprintf("/model/%s/pubsub", s.State.ModelUUID())
+	pubsubURL := &url.URL{
+		Scheme: "wss",
+		Host:   address,
+		Path:   path,
+	}
+	s.pubsubURL = pubsubURL.String()
+}
+
+func (s *pubsubSuite) TestNoAuth(c *gc.C) {
+	s.checkAuthFails(c, nil, "no credentials provided")
+}
+
+func (s *pubsubSuite) TestRejectsUserLogins(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{Password: "sekrit"})
+	header := utils.BasicAuthHeader(user.Tag().String(), "sekrit")
+	s.checkAuthFails(c, header, "permission denied")
+}
+
+func (s *pubsubSuite) TestRejectsNonServerMachineLogins(c *gc.C) {
+	m, password := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{
+		Nonce: "a-nonce",
+		Jobs:  []state.MachineJob{state.JobHostUnits},
+	})
+	header := utils.BasicAuthHeader(m.Tag().String(), password)
+	header.Add(params.MachineNonceHeader, "a-nonce")
+	s.checkAuthFails(c, header, "permission denied")
+}
+
+func (s *pubsubSuite) TestRejectsBadPassword(c *gc.C) {
+	header := utils.BasicAuthHeader(s.machineTag.String(), "wrong")
+	header.Add(params.MachineNonceHeader, s.nonce)
+	s.checkAuthFails(c, header, "invalid entity name or password")
+}
+
+func (s *pubsubSuite) TestRejectsIncorrectNonce(c *gc.C) {
+	header := utils.BasicAuthHeader(s.machineTag.String(), s.password)
+	header.Add(params.MachineNonceHeader, "wrong")
+	s.checkAuthFails(c, header, "machine 0 not provisioned")
+}
+
+func (s *pubsubSuite) checkAuthFails(c *gc.C, header http.Header, message string) {
+	conn := s.dialWebsocketInternal(c, header)
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+	assertJSONError(c, reader, message)
+	assertWebsocketClosed(c, reader)
+}
+
+func (s *pubsubSuite) TestMessage(c *gc.C) {
+	messages := []params.PubSubMessage{}
+	done := make(chan struct{})
+	loggo.GetLogger("pubsub").SetLogLevel(loggo.TRACE)
+	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
+	_, err := s.hub.Subscribe(pubsub.MatchAll, func(topic pubsub.Topic, data map[string]interface{}) {
+		c.Logf("topic: %q, data: %v", topic, data)
+		messages = append(messages, params.PubSubMessage{
+			Topic: string(topic),
+			Data:  data,
+		})
+		done <- struct{}{}
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	conn := s.dialWebsocket(c)
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+
+	// Read back the nil error, indicating that all is well.
+	errResult := readJSONErrorLine(c, reader)
+	c.Assert(errResult.Error, gc.IsNil)
+
+	message1 := params.PubSubMessage{
+		Topic: "first",
+		Data: map[string]interface{}{
+			"origin":  "other",
+			"message": "first message",
+		}}
+	err = websocket.JSON.Send(conn, &message1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	message2 := params.PubSubMessage{
+		Topic: "second",
+		Data: map[string]interface{}{
+			"origin": "other",
+			"value":  false,
+		}}
+	err = websocket.JSON.Send(conn, &message2)
+	c.Assert(err, jc.ErrorIsNil)
+
+	select {
+	case <-done:
+	case <-time.After(coretesting.ShortWait):
+		c.Fatalf("no first message")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(coretesting.ShortWait):
+		c.Fatalf("no second message")
+	}
+
+	// Close connection.
+	err = conn.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(messages, jc.DeepEquals, []params.PubSubMessage{message1, message2})
+}
+
+func (s *pubsubSuite) dialWebsocket(c *gc.C) *websocket.Conn {
+	return s.dialWebsocketInternal(c, s.makeAuthHeader())
+}
+
+func (s *pubsubSuite) dialWebsocketInternal(c *gc.C, header http.Header) *websocket.Conn {
+	return dialWebsocketFromURL(c, s.pubsubURL, header)
+}
+
+func (s *pubsubSuite) makeAuthHeader() http.Header {
+	header := utils.BasicAuthHeader(s.machineTag.String(), s.password)
+	header.Add(params.MachineNonceHeader, s.nonce)
+	return header
+}

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -57,6 +57,7 @@ import (
 	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
+	"github.com/juju/juju/pubsub/centralhub"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/stateenvirons"
@@ -809,14 +810,16 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 
 			estate.apiStatePool = state.NewStatePool(st)
 
+			machineTag := names.NewMachineTag("0")
 			estate.apiServer, err = apiserver.NewServer(st, estate.apiListener, apiserver.ServerConfig{
 				Clock:       clock.WallClock,
 				Cert:        testing.ServerCert,
 				Key:         testing.ServerKey,
-				Tag:         names.NewMachineTag("0"),
+				Tag:         machineTag,
 				DataDir:     DataDir,
 				LogDir:      LogDir,
 				StatePool:   estate.apiStatePool,
+				Hub:         centralhub.New(machineTag),
 				NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
 				// Should never be used but prevent external access just in case.
 				AutocertURL: "https://0.1.2.3/no-autocert-here",


### PR DESCRIPTION
Adds pubsub websocket endpoint for receiving messages from other controllers and republishing on the local central hub.