### PR TITLE
Use Model Status

### DIFF
--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -172,6 +172,10 @@ var scenarioStatus = &params.FullStatus{
 		CloudTag:    "cloud-dummy",
 		CloudRegion: "dummy-region",
 		Version:     "1.2.3",
+		ModelStatus: params.DetailedStatus{
+			Status: "available",
+			Data:   map[string]interface{}{},
+		},
 	},
 	Machines: map[string]params.MachineStatus{
 		"0": {

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -405,6 +405,7 @@ func clearSinceTimes(status *params.FullStatus) {
 		machine.InstanceStatus.Since = nil
 		status.Machines[id] = machine
 	}
+	status.Model.ModelStatus.Since = nil
 }
 
 func (s *clientSuite) TestClientStatus(c *gc.C) {

--- a/apiserver/client/status_test.go
+++ b/apiserver/client/status_test.go
@@ -321,7 +321,10 @@ func (s *statusUnitTestSuite) TestMigrationInProgress(c *gc.C) {
 	checkMigStatus := func(expected string) {
 		status, err := client.Status(nil)
 		c.Assert(err, jc.ErrorIsNil)
-		c.Check(status.Model.Migration, gc.Equals, expected)
+		if expected != "" {
+			expected = "migrating: " + expected
+		}
+		c.Check(status.Model.ModelStatus.Info, gc.Equals, expected)
 	}
 
 	// Migration status should be empty when no migration is happening.

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -30,12 +30,12 @@ type FullStatus struct {
 
 // ModelStatusInfo holds status information about the model itself.
 type ModelStatusInfo struct {
-	Name             string `json:"name"`
-	CloudTag         string `json:"cloud-tag"`
-	CloudRegion      string `json:"region,omitempty"`
-	Version          string `json:"version"`
-	AvailableVersion string `json:"available-version"`
-	Migration        string `json:"migration,omitempty"`
+	Name             string         `json:"name"`
+	CloudTag         string         `json:"cloud-tag"`
+	CloudRegion      string         `json:"region,omitempty"`
+	Version          string         `json:"version"`
+	AvailableVersion string         `json:"available-version"`
+	ModelStatus      DetailedStatus `json:"model-status"`
 }
 
 // MachineStatus holds status info about a machine.

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -30,13 +30,13 @@ type errorStatus struct {
 }
 
 type modelStatus struct {
-	Name             string `json:"name" yaml:"name"`
-	Controller       string `json:"controller" yaml:"controller"`
-	Cloud            string `json:"cloud" yaml:"cloud"`
-	CloudRegion      string `json:"region,omitempty" yaml:"region,omitempty"`
-	Version          string `json:"version" yaml:"version"`
-	AvailableVersion string `json:"upgrade-available,omitempty" yaml:"upgrade-available,omitempty"`
-	Migration        string `json:"migration,omitempty" yaml:"migration,omitempty"`
+	Name             string             `json:"name" yaml:"name"`
+	Controller       string             `json:"controller" yaml:"controller"`
+	Cloud            string             `json:"cloud" yaml:"cloud"`
+	CloudRegion      string             `json:"region,omitempty" yaml:"region,omitempty"`
+	Version          string             `json:"version" yaml:"version"`
+	AvailableVersion string             `json:"upgrade-available,omitempty" yaml:"upgrade-available,omitempty"`
+	Status           statusInfoContents `json:"model-status,omitempty" yaml:"model-status,omitempty"`
 }
 
 type machineStatus struct {

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -58,7 +58,7 @@ func (sf *statusFormatter) format() (formattedStatus, error) {
 			CloudRegion:      sf.status.Model.CloudRegion,
 			Version:          sf.status.Model.Version,
 			AvailableVersion: sf.status.Model.AvailableVersion,
-			Migration:        sf.status.Model.Migration,
+			Status:           sf.getStatusInfoContents(sf.status.Model.ModelStatus),
 		},
 		Machines:           make(map[string]machineStatus),
 		Applications:       make(map[string]applicationStatus),

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -271,8 +271,8 @@ func fromMeterStatusColor(msColor string) *ansiterm.Context {
 func getModelMessage(model modelStatus) string {
 	// Select the most important message about the model (if any).
 	switch {
-	case model.Migration != "":
-		return "migrating: " + model.Migration
+	case model.Status.Message != "":
+		return model.Status.Message
 	case model.AvailableVersion != "":
 		return "upgrade available: " + model.AvailableVersion
 	default:

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -164,6 +164,10 @@ var (
 		"cloud":      "dummy",
 		"region":     "dummy-region",
 		"version":    "1.2.3",
+		"model-status": M{
+			"current": "available",
+			"since":   "01 Apr 15 01:23+10:00",
+		},
 	}
 
 	machine0 = M{
@@ -2432,6 +2436,10 @@ var statusTests = []testCase{
 					"region":            "dummy-region",
 					"version":           "1.2.3",
 					"upgrade-available": "1.2.4",
+					"model-status": M{
+						"current": "available",
+						"since":   "01 Apr 15 01:23+10:00",
+					},
 				},
 				"machines":     M{},
 				"applications": M{},
@@ -3418,7 +3426,11 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 			"cloud":      "dummy",
 			"region":     "dummy-region",
 			"version":    "1.2.3",
-			"migration":  "foo bar",
+			"model-status": M{
+				"current": "busy",
+				"since":   "01 Apr 15 01:23+10:00",
+				"message": "migrating: foo bar",
+			},
 		},
 		"machines":     M{},
 		"applications": M{},
@@ -3428,6 +3440,8 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 		code, stdout, stderr := runStatus(c, "-m", "hosted", "--format", format.name)
 		c.Check(code, gc.Equals, 0)
 		c.Assert(stderr, gc.HasLen, 0, gc.Commentf("status failed: %s", stderr))
+
+		stdout = substituteFakeSinceTime(c, stdout, false)
 
 		// Roundtrip expected through format so that types will match.
 		buf, err := format.marshal(expected)
@@ -4079,6 +4093,9 @@ func (s *StatusSuite) TestFilterToContainer(c *gc.C) {
 		"  cloud: dummy\n" +
 		"  region: dummy-region\n" +
 		"  version: 1.2.3\n" +
+		"  model-status:\n" +
+		"    current: available\n" +
+		"    since: 01 Apr 15 01:23+10:00\n" +
 		"machines:\n" +
 		"  \"0\":\n" +
 		"    juju-status:\n" +
@@ -4374,6 +4391,10 @@ var statusTimeTest = test(
 				"cloud":      "dummy",
 				"region":     "dummy-region",
 				"version":    "1.2.3",
+				"model-status": M{
+					"current": "available",
+					"since":   "01 Apr 15 01:23+10:00",
+				},
 			},
 			"machines": M{
 				"0": machine0,

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -562,7 +562,11 @@ func PrimeUnitStatusHistory(
 		StatusData: data,
 		Updated:    clock.Now().UnixNano(),
 	}
-	buildTxn := updateStatusSource(unit.st, globalKey, doc)
+
+	var buildTxn jujutxn.TransactionSource = func(int) ([]txn.Op, error) {
+		return statusSetOps(unit.st, doc, globalKey)
+	}
+
 	err := unit.st.run(buildTxn)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/status/status.go
+++ b/status/status.go
@@ -174,6 +174,13 @@ const (
 
 	// Available indicates that the model is available for use.
 	Available Status = "available"
+
+	// Busy indicates that the model is not available for use because it is
+	// running a process that must take the model offline, such as a migration,
+	// upgrade, or backup.  This is a spinning state, it is not an error state,
+	// and it should be expected that the model will eventually go back to
+	// available.
+	Busy Status = "busy"
 )
 
 const (
@@ -275,6 +282,7 @@ func ValidModelStatus(status Status) bool {
 	switch status {
 	case
 		Available,
+		Busy,
 		Destroying:
 		return true
 	default:

--- a/status/status_history.go
+++ b/status/status_history.go
@@ -48,15 +48,15 @@ type InstanceStatusHistoryGetter interface {
 
 // DetailedStatus holds status info about a machine or unit agent.
 type DetailedStatus struct {
-	Status  Status
-	Info    string
-	Data    map[string]interface{}
-	Since   *time.Time
-	Kind    HistoryKind
-	Version string
+	Status Status
+	Info   string
+	Data   map[string]interface{}
+	Since  *time.Time
+	Kind   HistoryKind
 	// TODO(perrito666) make sure this is not used and remove.
-	Life string
-	Err  error
+	Version string
+	Life    string
+	Err     error
 }
 
 // History holds many DetailedStatus,
@@ -154,13 +154,13 @@ const (
 	// KindWorkload represents a charm workload status history entry.
 	KindWorkload HistoryKind = "workload"
 	// KindMachineInstance represents an entry for a machine instance.
-	KindMachineInstance = "machine"
+	KindMachineInstance HistoryKind = "machine"
 	// KindMachine represents an entry for a machine agent.
-	KindMachine = "juju-machine"
+	KindMachine HistoryKind = "juju-machine"
 	// KindContainerInstance represents an entry for a container instance.
-	KindContainerInstance = "container"
+	KindContainerInstance HistoryKind = "container"
 	// KindContainer represents an entry for a container agent.
-	KindContainer = "juju-container"
+	KindContainer HistoryKind = "juju-container"
 )
 
 // String returns a string representation of the HistoryKind.


### PR DESCRIPTION
This code starts us on the path to actually using status on models.
This first commit just adds code to set status, and transmit that
to juju status as needed.  The only thing to currently set status
is migration, which sets status to busy, and instead of setting
its message in a special migration field, now sets the message
in the status message.

QA: 
bootstrap 2 LXD providers
remove the default model on one of them
migrate the default model from one to the other.
while migrating, watch juju status --format=yaml  - you should see migration status under model-status.  make sure to set the watch refresh status to be short or you  may miss the updates for small models.