### PR TITLE
Override controller cert generation during tests

### DIFF
--- a/controller/config.go
+++ b/controller/config.go
@@ -284,9 +284,22 @@ func Validate(c Config) error {
 	return nil
 }
 
+var overriddenCert, overriddenKey string
+
+// OverrideControllerCertAndKey prevents the generation of new certs during
+// testing by using the given caCert and caKey instead.
+func OverrideControllerCertAndKey(caCert, caKey string) {
+	overriddenCert = caCert
+	overriddenKey = caKey
+}
+
 // GenerateControllerCertAndKey makes sure that the config has a CACert and
 // CAPrivateKey, generates and returns new certificate and key.
 func GenerateControllerCertAndKey(caCert, caKey string, hostAddresses []string) (string, string, error) {
+	if overriddenCert != "" && overriddenKey != "" {
+		logger.Warningf("Using overridden cert and key rather than generating")
+		return overriddenCert, overriddenKey, nil
+	}
 	return cert.NewDefaultServer(caCert, caKey, hostAddresses)
 }
 

--- a/testing/cert.go
+++ b/testing/cert.go
@@ -14,6 +14,7 @@ import (
 	utilscert "github.com/juju/utils/cert"
 
 	"github.com/juju/juju/cert"
+	"github.com/juju/juju/controller"
 )
 
 func init() {
@@ -81,6 +82,7 @@ func mustParseCertAndKey(certPEM, keyPEM string) (*x509.Certificate, *rsa.Privat
 }
 
 func serverCerts() *gitjujutesting.Certs {
+	controller.OverrideControllerCertAndKey(ServerCert, ServerKey)
 	serverCert, serverKey := mustParseCertAndKey(ServerCert, ServerKey)
 	return &gitjujutesting.Certs{
 		CACert:     CACertX509,


### PR DESCRIPTION
Add hook point in controller cert generation function so that
fake certs can be injected during testing.

Without a fast path, cert generation takes ~9s on our arm64 test
machine. Even on an amd64 machine it can take ~500ms per test.

QA steps
----
* `cd $GOPATH/src/github.com/juju/juju/apiserver`
* `go test -i`
* `go test -check.vv -check.f ".*serverSuite\.TestStop"|grep -F "WARNING juju.controller"` - should have warning about overriding certs
* `go test -test.cpuprofile cpu.prof -check.f ".*serverSuite\.TestStop"`
* `go tool pprof apiserver.test cpu.prof`
* `(pprof) tree` - validate `controller.GenerateControllerCertAndKey` does not dominate