### PR TITLE
Migration of resource binaries

### DIFF
--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -259,10 +259,11 @@ func (c *Client) MinionReports() (migration.MinionReports, error) {
 	return out, nil
 }
 
-func (c *Client) StreamModelLog() (<-chan common.LogMessage, error) {
+func (c *Client) StreamModelLog(start time.Time) (<-chan common.LogMessage, error) {
 	return common.StreamDebugLog(c.caller.RawAPICaller(), common.DebugLogParams{
-		Replay: true,
-		NoTail: true,
+		Replay:    true,
+		NoTail:    true,
+		StartTime: start,
 	})
 }
 
@@ -285,14 +286,6 @@ func groupTagIds(tagStrs []string) ([]string, []string, error) {
 		}
 	}
 	return machines, units, nil
-}
-
-func (c *Client) StreamModelLog(start time.Time) (<-chan common.LogMessage, error) {
-	return common.StreamDebugLog(c.caller.RawAPICaller(), common.DebugLogParams{
-		Replay:    true,
-		NoTail:    true,
-		StartTime: start,
-	})
 }
 
 func convertResources(in []params.SerializedModelResource) ([]migration.SerializedModelResource, error) {

--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -259,6 +259,10 @@ func (c *Client) MinionReports() (migration.MinionReports, error) {
 	return out, nil
 }
 
+// StreamModelLog takes a starting time and returns a channel that
+// will yield the logs on or after that time - these are the logs that
+// need to be transferred to the target after the migration is
+// successful.
 func (c *Client) StreamModelLog(start time.Time) (<-chan common.LogMessage, error) {
 	return common.StreamDebugLog(c.caller.RawAPICaller(), common.DebugLogParams{
 		Replay:    true,

--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -190,8 +190,7 @@ func (c *Client) Export() (migration.SerializedModel, error) {
 	}, nil
 }
 
-// XXX needs tests
-// XXX
+// OpenResource downloads the named resource for an application.
 func (c *Client) OpenResource(application, name string) (io.ReadCloser, error) {
 	httpClient, err := c.httpClientFactory()
 	if err != nil {

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -46,7 +46,8 @@ func (s *ClientSuite) TestWatch(c *gc.C) {
 		c.Check(result, jc.DeepEquals, params.NotifyWatchResult{NotifyWatcherId: "123"})
 		return expectWatch
 	}
-	client := migrationmaster.NewClient(apiCaller, newWatcher)
+	client, err := migrationmaster.NewClient(apiCaller, newWatcher)
+	c.Assert(err, jc.ErrorIsNil)
 
 	w, err := client.Watch()
 	c.Check(err, jc.ErrorIsNil)
@@ -58,8 +59,9 @@ func (s *ClientSuite) TestWatchCallError(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		return errors.New("boom")
 	})
-	client := migrationmaster.NewClient(apiCaller, nil)
-	_, err := client.Watch()
+	client, err := migrationmaster.NewClient(apiCaller, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = client.Watch()
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
@@ -95,7 +97,8 @@ func (s *ClientSuite) TestMigrationStatus(c *gc.C) {
 		}
 		return nil
 	})
-	client := migrationmaster.NewClient(apiCaller, nil)
+	client, err := migrationmaster.NewClient(apiCaller, nil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	status, err := client.MigrationStatus()
 	c.Assert(err, jc.ErrorIsNil)
@@ -122,8 +125,9 @@ func (s *ClientSuite) TestSetPhase(c *gc.C) {
 		stub.AddCall(objType+"."+request, id, arg)
 		return nil
 	})
-	client := migrationmaster.NewClient(apiCaller, nil)
-	err := client.SetPhase(migration.QUIESCE)
+	client, err := migrationmaster.NewClient(apiCaller, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = client.SetPhase(migration.QUIESCE)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedArg := params.SetMigrationPhaseArgs{Phase: "QUIESCE"}
 	stub.CheckCalls(c, []jujutesting.StubCall{
@@ -135,8 +139,9 @@ func (s *ClientSuite) TestSetPhaseError(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(string, int, string, string, interface{}, interface{}) error {
 		return errors.New("boom")
 	})
-	client := migrationmaster.NewClient(apiCaller, nil)
-	err := client.SetPhase(migration.QUIESCE)
+	client, err := migrationmaster.NewClient(apiCaller, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = client.SetPhase(migration.QUIESCE)
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
@@ -146,8 +151,9 @@ func (s *ClientSuite) TestSetStatusMessage(c *gc.C) {
 		stub.AddCall(objType+"."+request, id, arg)
 		return nil
 	})
-	client := migrationmaster.NewClient(apiCaller, nil)
-	err := client.SetStatusMessage("foo")
+	client, err := migrationmaster.NewClient(apiCaller, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = client.SetStatusMessage("foo")
 	c.Assert(err, jc.ErrorIsNil)
 	expectedArg := params.SetMigrationStatusMessageArgs{Message: "foo"}
 	stub.CheckCalls(c, []jujutesting.StubCall{
@@ -159,8 +165,9 @@ func (s *ClientSuite) TestSetStatusMessageError(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(string, int, string, string, interface{}, interface{}) error {
 		return errors.New("boom")
 	})
-	client := migrationmaster.NewClient(apiCaller, nil)
-	err := client.SetStatusMessage("foo")
+	client, err := migrationmaster.NewClient(apiCaller, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = client.SetStatusMessage("foo")
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
@@ -177,7 +184,8 @@ func (s *ClientSuite) TestModelInfo(c *gc.C) {
 		}
 		return nil
 	})
-	client := migrationmaster.NewClient(apiCaller, nil)
+	client, err := migrationmaster.NewClient(apiCaller, nil)
+	c.Assert(err, jc.ErrorIsNil)
 	model, err := client.ModelInfo()
 	stub.CheckCalls(c, []jujutesting.StubCall{
 		{"MigrationMaster.ModelInfo", []interface{}{"", nil}},
@@ -197,8 +205,9 @@ func (s *ClientSuite) TestPrechecks(c *gc.C) {
 		stub.AddCall(objType+"."+request, id, arg)
 		return errors.New("blam")
 	})
-	client := migrationmaster.NewClient(apiCaller, nil)
-	err := client.Prechecks()
+	client, err := migrationmaster.NewClient(apiCaller, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = client.Prechecks()
 	c.Check(err, gc.ErrorMatches, "blam")
 	stub.CheckCalls(c, []jujutesting.StubCall{
 		{"MigrationMaster.Prechecks", []interface{}{"", nil}},
@@ -220,7 +229,8 @@ func (s *ClientSuite) TestExport(c *gc.C) {
 		}
 		return nil
 	})
-	client := migrationmaster.NewClient(apiCaller, nil)
+	client, err := migrationmaster.NewClient(apiCaller, nil)
+	c.Assert(err, jc.ErrorIsNil)
 	out, err := client.Export()
 	c.Assert(err, jc.ErrorIsNil)
 	stub.CheckCalls(c, []jujutesting.StubCall{
@@ -239,8 +249,9 @@ func (s *ClientSuite) TestExportError(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(string, int, string, string, interface{}, interface{}) error {
 		return errors.New("blam")
 	})
-	client := migrationmaster.NewClient(apiCaller, nil)
-	_, err := client.Export()
+	client, err := migrationmaster.NewClient(apiCaller, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = client.Export()
 	c.Assert(err, gc.ErrorMatches, "blam")
 }
 
@@ -250,8 +261,9 @@ func (s *ClientSuite) TestReap(c *gc.C) {
 		stub.AddCall(objType+"."+request, id, arg)
 		return nil
 	})
-	client := migrationmaster.NewClient(apiCaller, nil)
-	err := client.Reap()
+	client, err := migrationmaster.NewClient(apiCaller, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = client.Reap()
 	c.Check(err, jc.ErrorIsNil)
 	stub.CheckCalls(c, []jujutesting.StubCall{
 		{"MigrationMaster.Reap", []interface{}{"", nil}},
@@ -262,8 +274,9 @@ func (s *ClientSuite) TestReapError(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(string, int, string, string, interface{}, interface{}) error {
 		return errors.New("blam")
 	})
-	client := migrationmaster.NewClient(apiCaller, nil)
-	err := client.Reap()
+	client, err := migrationmaster.NewClient(apiCaller, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = client.Reap()
 	c.Assert(err, gc.ErrorMatches, "blam")
 }
 
@@ -283,7 +296,8 @@ func (s *ClientSuite) TestWatchMinionReports(c *gc.C) {
 		c.Check(result, jc.DeepEquals, params.NotifyWatchResult{NotifyWatcherId: "123"})
 		return expectWatch
 	}
-	client := migrationmaster.NewClient(apiCaller, newWatcher)
+	client, err := migrationmaster.NewClient(apiCaller, newWatcher)
+	c.Assert(err, jc.ErrorIsNil)
 
 	w, err := client.WatchMinionReports()
 	c.Check(err, jc.ErrorIsNil)
@@ -295,8 +309,9 @@ func (s *ClientSuite) TestWatchMinionReportsError(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		return errors.New("boom")
 	})
-	client := migrationmaster.NewClient(apiCaller, nil)
-	_, err := client.WatchMinionReports()
+	client, err := migrationmaster.NewClient(apiCaller, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = client.WatchMinionReports()
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
@@ -323,7 +338,8 @@ func (s *ClientSuite) TestMinionReports(c *gc.C) {
 		}
 		return nil
 	})
-	client := migrationmaster.NewClient(apiCaller, nil)
+	client, err := migrationmaster.NewClient(apiCaller, nil)
+	c.Assert(err, jc.ErrorIsNil)
 	out, err := client.MinionReports()
 	c.Assert(err, jc.ErrorIsNil)
 	stub.CheckCalls(c, []jujutesting.StubCall{
@@ -345,8 +361,9 @@ func (s *ClientSuite) TestMinionReportsFailedCall(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(string, int, string, string, interface{}, interface{}) error {
 		return errors.New("blam")
 	})
-	client := migrationmaster.NewClient(apiCaller, nil)
-	_, err := client.MinionReports()
+	client, err := migrationmaster.NewClient(apiCaller, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = client.MinionReports()
 	c.Assert(err, gc.ErrorMatches, "blam")
 }
 
@@ -358,8 +375,9 @@ func (s *ClientSuite) TestMinionReportsInvalidPhase(c *gc.C) {
 		}
 		return nil
 	})
-	client := migrationmaster.NewClient(apiCaller, nil)
-	_, err := client.MinionReports()
+	client, err := migrationmaster.NewClient(apiCaller, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = client.MinionReports()
 	c.Assert(err, gc.ErrorMatches, `invalid phase: "BLARGH"`)
 }
 
@@ -372,8 +390,9 @@ func (s *ClientSuite) TestMinionReportsBadUnknownTag(c *gc.C) {
 		}
 		return nil
 	})
-	client := migrationmaster.NewClient(apiCaller, nil)
-	_, err := client.MinionReports()
+	client, err := migrationmaster.NewClient(apiCaller, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = client.MinionReports()
 	c.Assert(err, gc.ErrorMatches, `processing unknown agents: "carl" is not a valid tag`)
 }
 
@@ -386,8 +405,9 @@ func (s *ClientSuite) TestMinionReportsBadFailedTag(c *gc.C) {
 		}
 		return nil
 	})
-	client := migrationmaster.NewClient(apiCaller, nil)
-	_, err := client.MinionReports()
+	client, err := migrationmaster.NewClient(apiCaller, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = client.MinionReports()
 	c.Assert(err, gc.ErrorMatches, `processing failed agents: "dave" is not a valid tag`)
 }
 

--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -16,12 +16,12 @@ import (
 	"github.com/juju/httprequest"
 	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6-unstable"
-	"gopkg.in/juju/charm.v6-unstable/resource"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 	coremigration "github.com/juju/juju/core/migration"
+	"github.com/juju/juju/resource"
 	"github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -114,6 +114,8 @@ func (c *Client) UploadTools(modelUUID string, r io.ReadSeeker, vers version.Bin
 // XXX
 func (c *Client) UploadResource(modelUUID string, res resource.Resource, r io.ReadSeeker) error {
 	args := url.Values{}
+	args.Add("application", res.ApplicationID)
+	args.Add("user", res.Username)
 	args.Add("name", res.Name)
 	args.Add("type", res.Type.String())
 	args.Add("path", res.Path)

--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/httprequest"
 	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6-unstable/resource"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
@@ -107,6 +108,24 @@ func (c *Client) UploadTools(modelUUID string, r io.ReadSeeker, vers version.Bin
 		return nil, errors.Trace(err)
 	}
 	return resp.ToolsList, nil
+}
+
+// XXX needs tests
+// XXX
+func (c *Client) UploadResource(modelUUID string, res resource.Resource, r io.ReadSeeker) error {
+	args := url.Values{}
+	args.Add("name", res.Name)
+	args.Add("type", res.Type.String())
+	args.Add("path", res.Path)
+	args.Add("description", res.Description)
+	args.Add("origin", res.Origin.String())
+	args.Add("revision", fmt.Sprintf("%d", res.Revision))
+	args.Add("size", fmt.Sprintf("%d", res.Size))
+	args.Add("fingerprint", res.Fingerprint.Hex())
+	uri := "/migrate/resources?" + args.Encode()
+	contentType := "application/octet-stream"
+	err := c.httpPost(modelUUID, r, uri, contentType, nil)
+	return errors.Trace(err)
 }
 
 func (c *Client) httpPost(modelUUID string, content io.ReadSeeker, endpoint, contentType string, response interface{}) error {

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -417,7 +417,7 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 	add("/migrate/resources",
 		&resourceUploadHandler{
 			ctxt:          httpCtxt,
-			stateAuthFunc: httpCtxt.stateForMigration,
+			stateAuthFunc: httpCtxt.stateForMigrationImporting,
 		},
 	)
 	add("/model/:modeluuid/tools/:version",

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -414,6 +414,12 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 			stateAuthFunc: httpCtxt.stateForMigrationImporting,
 		},
 	)
+	add("/migrate/resources",
+		&resourceUploadHandler{
+			ctxt:          httpCtxt,
+			stateAuthFunc: httpCtxt.stateForMigration,
+		},
+	)
 	add("/model/:modeluuid/tools/:version",
 		&toolsDownloadHandler{
 			ctxt: httpCtxt,

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -503,27 +503,11 @@ func (srv *Server) newHandlerArgs(spec apihttp.HandlerConstraints) apihttp.NewHa
 		strictValidation:    spec.StrictValidation,
 		controllerModelOnly: spec.ControllerModelOnly,
 	}
-
-	var args apihttp.NewHandlerArgs
-	switch spec.AuthKind {
-	case names.UserTagKind:
-		args.Connect = ctxt.stateAndEntityForRequestAuthenticatedUser
-	case names.UnitTagKind:
-		args.Connect = ctxt.stateForRequestAuthenticatedAgent
-	case "":
-		logger.Tracef(`no access level specified; proceeding with "unauthenticated"`)
-		args.Connect = func(req *http.Request) (*state.State, state.Entity, error) {
-			st, err := ctxt.stateForRequestUnauthenticated(req)
-			return st, nil, err
-		}
-	default:
-		logger.Infof(`unrecognized access level %q; proceeding with "unauthenticated"`, spec.AuthKind)
-		args.Connect = func(req *http.Request) (*state.State, state.Entity, error) {
-			st, err := ctxt.stateForRequestUnauthenticated(req)
-			return st, nil, err
-		}
+	return apihttp.NewHandlerArgs{
+		Connect: func(req *http.Request) (*state.State, state.Entity, error) {
+			return ctxt.stateForRequestAuthenticatedTag(req, spec.AuthKinds...)
+		},
 	}
-	return args
 }
 
 // trackRequests wraps a http.Handler, incrementing and decrementing

--- a/apiserver/common/apihttp/handler.go
+++ b/apiserver/common/apihttp/handler.go
@@ -20,11 +20,11 @@ type NewHandlerArgs struct {
 // HandlerConstraints describes conditions under which a handler
 // may operate.
 type HandlerConstraints struct {
-	// AuthKind defines the kind of authenticated "user" that the
+	// AuthKinds defines the kinds of authenticated "user" that the
 	// handler supports. This correlates directly to entities, as
-	// identified by tag kinds (e.g. names.UserTagKind). The empty
-	// string indicates support for unauthenticated requests.
-	AuthKind string
+	// identified by tag kinds (e.g. names.UserTagKind). An empty list
+	// will block all authentication.
+	AuthKinds []string
 
 	// StrictValidation is the value that will be used for the handler's
 	// httpContext (see apiserver/httpcontext.go).

--- a/apiserver/migrationmaster/facade.go
+++ b/apiserver/migrationmaster/facade.go
@@ -312,38 +312,27 @@ func addToolsVersionForMachine(machine description.Machine, usedVersions map[ver
 }
 
 // XXX needs tests - but wait until I know what's actually required here.
-func getUsedResources(model description.Model) []params.SerializedModelResources {
-	var out []params.SerializedModelResources
-
+func getUsedResources(model description.Model) []params.SerializedModelResource {
+	var out []params.SerializedModelResource
 	for _, app := range model.Applications() {
-		resources := app.Resources()
-		if len(resources) == 0 {
-			continue
+		for _, resource := range app.Resources() {
+			out = append(out, resourceToSerialized(app.Name(), resource))
 		}
-
-		outAppResources := params.SerializedModelResources{
-			Application: app.Name(),
-		}
-		for _, resource := range resources {
-			outAppResources.Resources = append(outAppResources.Resources, resourceDesc2Serialized(resource))
-		}
-		out = append(out, outAppResources)
 	}
-
 	return out
 }
 
-func resourceDesc2Serialized(desc description.Resource) (out params.SerializedModelResource) {
-	out.Name = desc.Name()
-	out.Revision = desc.Revision()
-	out.CharmStoreRevision = desc.CharmStoreRevision()
-	for _, revision := range desc.Revisions() {
-		out.Revisions = append(out.Revisions, revisionDesc2Serialized(revision))
+func resourceToSerialized(app string, desc description.Resource) params.SerializedModelResource {
+	return params.SerializedModelResource{
+		Application:         app,
+		Name:                desc.Name(),
+		ApplicationRevision: revisionToSerialized(desc.ApplicationRevision()),
+		CharmStoreRevision:  revisionToSerialized(desc.CharmStoreRevision()),
+		// TODO(menn0) - unit revisions
 	}
-	return
 }
 
-func revisionDesc2Serialized(desc description.ResourceRevision) (out params.SerializedModelResourceRevision) {
+func revisionToSerialized(desc description.ResourceRevision) (out params.SerializedModelResourceRevision) {
 	out.Revision = desc.Revision()
 	out.Type = desc.Type()
 	out.Path = desc.Path()

--- a/apiserver/migrationmaster/facade.go
+++ b/apiserver/migrationmaster/facade.go
@@ -311,7 +311,6 @@ func addToolsVersionForMachine(machine description.Machine, usedVersions map[ver
 	}
 }
 
-// XXX needs tests - but wait until I know what's actually required here.
 func getUsedResources(model description.Model) []params.SerializedModelResource {
 	var out []params.SerializedModelResource
 	for _, app := range model.Applications() {
@@ -332,16 +331,19 @@ func resourceToSerialized(app string, desc description.Resource) params.Serializ
 	}
 }
 
-func revisionToSerialized(desc description.ResourceRevision) (out params.SerializedModelResourceRevision) {
-	out.Revision = desc.Revision()
-	out.Type = desc.Type()
-	out.Path = desc.Path()
-	out.Description = desc.Description()
-	out.Origin = desc.Origin()
-	out.FingerprintHex = desc.FingerprintHex()
-	out.Size = desc.Size()
-	// XXX
-	//out.Timestamp = desc.Timestamp()
-	out.Username = desc.Username()
-	return
+func revisionToSerialized(rr description.ResourceRevision) params.SerializedModelResourceRevision {
+	if rr == nil {
+		return params.SerializedModelResourceRevision{}
+	}
+	return params.SerializedModelResourceRevision{
+		Revision:       rr.Revision(),
+		Type:           rr.Type(),
+		Path:           rr.Path(),
+		Description:    rr.Description(),
+		Origin:         rr.Origin(),
+		FingerprintHex: rr.FingerprintHex(),
+		Size:           rr.Size(),
+		Timestamp:      rr.Timestamp(),
+		Username:       rr.Username(),
+	}
 }

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -722,3 +722,16 @@ type LogMessage struct {
 	Location  string    `json:"loc"`
 	Message   string    `json:"msg"`
 }
+
+// ResourceUploadResult is used to return some details about an
+// uploaded resource.
+type ResourceUploadResult struct {
+	// Error will contain details about a failed upload attempt.
+	Error *Error `json:"error,omitempty"`
+
+	// ID uniquely identifies a resource-application pair within the model.
+	ID string `json:"id"`
+
+	// Timestamp indicates when the resource was added to the model.
+	Timestamp time.Time `json:"timestamp"`
+}

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -107,15 +107,14 @@ type SerializedModelResource struct {
 
 // XXX
 type SerializedModelResourceRevision struct {
-	Revision       int        `json:"revision"`
-	Type           string     `json:"type"`
-	Path           string     `json:"path"`
-	Description    string     `json:"description"`
-	Origin         string     `json:"origin"`
-	FingerprintHex string     `json:"fingerprint"`
-	Size           int64      `json:"size"`
-	Timestamp      *time.Time `json:"timestamp,omitempty"`
-	Username       string     `json:"username,omitempty"`
+	Revision       int    `json:"revision"`
+	Type           string `json:"type"`
+	Path           string `json:"path"`
+	Description    string `json:"description"`
+	Origin         string `json:"origin"`
+	FingerprintHex string `json:"fingerprint"`
+	Size           int64  `json:"size"`
+	Username       string `json:"username,omitempty"`
 }
 
 // ModelArgs wraps a simple model tag.

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -91,7 +91,8 @@ type SerializedModelTools struct {
 	URI string `json:"uri"`
 }
 
-// XXX
+// SerializedModelResource holds the details for a single resource for
+// an application in a serialized model.
 type SerializedModelResource struct {
 	Application         string                          `json:"application"`
 	Name                string                          `json:"name"`
@@ -99,16 +100,18 @@ type SerializedModelResource struct {
 	CharmStoreRevision  SerializedModelResourceRevision `json:"charmstore-revision"`
 }
 
-// XXX
+// SerializedModelResourceRevision holds the details for a single
+// resource revision for an application in a serialized model.
 type SerializedModelResourceRevision struct {
-	Revision       int    `json:"revision"`
-	Type           string `json:"type"`
-	Path           string `json:"path"`
-	Description    string `json:"description"`
-	Origin         string `json:"origin"`
-	FingerprintHex string `json:"fingerprint"`
-	Size           int64  `json:"size"`
-	Username       string `json:"username,omitempty"`
+	Revision       int       `json:"revision"`
+	Type           string    `json:"type"`
+	Path           string    `json:"path"`
+	Description    string    `json:"description"`
+	Origin         string    `json:"origin"`
+	FingerprintHex string    `json:"fingerprint"`
+	Size           int64     `json:"size"`
+	Timestamp      time.Time `json:"timestamp"`
+	Username       string    `json:"username,omitempty"`
 }
 
 // ModelArgs wraps a simple model tag.

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -73,9 +73,10 @@ type SetMigrationStatusMessageArgs struct {
 // SerializedModel wraps a buffer contain a serialised Juju model. It
 // also contains lists of the charms and tools used in the model.
 type SerializedModel struct {
-	Bytes  []byte                 `json:"bytes"`
-	Charms []string               `json:"charms"`
-	Tools  []SerializedModelTools `json:"tools"`
+	Bytes     []byte                     `json:"bytes"`
+	Charms    []string                   `json:"charms"`
+	Tools     []SerializedModelTools     `json:"tools"`
+	Resources []SerializedModelResources `json:"resources"`
 }
 
 // SerializedModelTools holds the version and URI for a given tools
@@ -88,6 +89,33 @@ type SerializedModelTools struct {
 	// with the API server scheme, address and model prefix before it
 	// can be used.
 	URI string `json:"uri"`
+}
+
+// XXX
+type SerializedModelResources struct {
+	Application string                    `json:"application"`
+	Resources   []SerializedModelResource `json:"resources"`
+}
+
+// XXX
+type SerializedModelResource struct {
+	Name               string                            `json:"name"`
+	Revision           int                               `json:"application-revision"`
+	CharmStoreRevision int                               `json:"charmstore-revision"`
+	Revisions          []SerializedModelResourceRevision `json:"revisions"`
+}
+
+// XXX
+type SerializedModelResourceRevision struct {
+	Revision       int        `json:"revision"`
+	Type           string     `json:"type"`
+	Path           string     `json:"path"`
+	Description    string     `json:"description"`
+	Origin         string     `json:"origin"`
+	FingerprintHex string     `json:"fingerprint"`
+	Size           int64      `json:"size"`
+	Timestamp      *time.Time `json:"timestamp,omitempty"`
+	Username       string     `json:"username,omitempty"`
 }
 
 // ModelArgs wraps a simple model tag.

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -73,10 +73,10 @@ type SetMigrationStatusMessageArgs struct {
 // SerializedModel wraps a buffer contain a serialised Juju model. It
 // also contains lists of the charms and tools used in the model.
 type SerializedModel struct {
-	Bytes     []byte                     `json:"bytes"`
-	Charms    []string                   `json:"charms"`
-	Tools     []SerializedModelTools     `json:"tools"`
-	Resources []SerializedModelResources `json:"resources"`
+	Bytes     []byte                    `json:"bytes"`
+	Charms    []string                  `json:"charms"`
+	Tools     []SerializedModelTools    `json:"tools"`
+	Resources []SerializedModelResource `json:"resources"`
 }
 
 // SerializedModelTools holds the version and URI for a given tools
@@ -92,17 +92,11 @@ type SerializedModelTools struct {
 }
 
 // XXX
-type SerializedModelResources struct {
-	Application string                    `json:"application"`
-	Resources   []SerializedModelResource `json:"resources"`
-}
-
-// XXX
 type SerializedModelResource struct {
-	Name               string                            `json:"name"`
-	Revision           int                               `json:"application-revision"`
-	CharmStoreRevision int                               `json:"charmstore-revision"`
-	Revisions          []SerializedModelResourceRevision `json:"revisions"`
+	Application         string                          `json:"application"`
+	Name                string                          `json:"name"`
+	ApplicationRevision SerializedModelResourceRevision `json:"application-revision"`
+	CharmStoreRevision  SerializedModelResourceRevision `json:"charmstore-revision"`
 }
 
 // XXX

--- a/apiserver/resources.go
+++ b/apiserver/resources.go
@@ -59,10 +59,7 @@ func (h *resourceUploadHandler) processPost(r *http.Request, st *state.State) er
 	if applicationID == "" {
 		return errors.NotValidf("missing application")
 	}
-	userID := query.Get("user")
-	if userID == "" {
-		return errors.NotValidf("missing user")
-	}
+	userID := query.Get("user") // Is allowed to be blank
 	res, err := queryToResource(query)
 	if err != nil {
 		return errors.Trace(err)

--- a/apiserver/resources.go
+++ b/apiserver/resources.go
@@ -1,0 +1,119 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/juju/errors"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+
+	"github.com/juju/juju/state"
+)
+
+// XXX needs tests
+
+// resourceUploadHandler handles resources uploads for model migrations.
+type resourceUploadHandler struct {
+	ctxt          httpContext
+	stateAuthFunc func(*http.Request) (*state.State, error)
+}
+
+func (h *resourceUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Validate before authenticate because the authentication is dependent
+	// on the state connection that is determined during the validation.
+	st, err := h.stateAuthFunc(r)
+	if err != nil {
+		if err := sendError(w, err); err != nil {
+			logger.Errorf("%v", err)
+		}
+		return
+	}
+	defer h.ctxt.release(st)
+
+	switch r.Method {
+	case "POST":
+		if err := h.processPost(r, st); err != nil {
+			if err := sendError(w, err); err != nil {
+				logger.Errorf("%v", err)
+			}
+			return
+		}
+		// XXX this should send a JSON result (resource/api.CharmResource)
+		w.WriteHeader(http.StatusOK)
+	default:
+		if err := sendError(w, errors.MethodNotAllowedf("unsupported method: %q", r.Method)); err != nil {
+			logger.Errorf("%v", err)
+		}
+	}
+}
+
+// processPost handles a tools upload POST request after authentication.
+func (h *resourceUploadHandler) processPost(r *http.Request, st *state.State) error {
+	query := r.URL.Query()
+
+	applicationID := query.Get("application")
+	if applicationID != "" {
+		return errors.NotValidf("missing application")
+	}
+	userID := query.Get("user")
+	if userID != "" {
+		return errors.NotValidf("missing userID")
+	}
+	res, err := queryToResource(query)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	rSt, err := st.Resources()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	_, err = rSt.SetResource(applicationID, userID, res, r.Body)
+	return errors.Annotate(err, "resource upload failed")
+}
+
+func queryToResource(query url.Values) (charmresource.Resource, error) {
+	var err error
+	empty := charmresource.Resource{}
+
+	res := charmresource.Resource{
+		Meta: charmresource.Meta{
+			Name:        query.Get("name"),
+			Path:        query.Get("path"),
+			Description: query.Get("description"),
+		},
+	}
+	if res.Name == "" {
+		return empty, errors.NotValidf("missing name")
+	}
+	if res.Path == "" {
+		return empty, errors.NotValidf("missing path")
+	}
+	if res.Description == "" {
+		return empty, errors.NotValidf("missing description")
+	}
+	res.Type, err = charmresource.ParseType(query.Get("type"))
+	if err != nil {
+		return empty, errors.NotValidf("type")
+	}
+	res.Origin, err = charmresource.ParseOrigin(query.Get("origin"))
+	if err != nil {
+		return empty, errors.NotValidf("origin")
+	}
+	res.Revision, err = strconv.Atoi(query.Get("revision"))
+	if err != nil {
+		return empty, errors.NotValidf("revision")
+	}
+	res.Size, err = strconv.ParseInt(query.Get("size"), 10, 64)
+	if err != nil {
+		return empty, errors.Trace(err)
+	}
+	res.Fingerprint, err = charmresource.ParseFingerprint(query.Get("fingerprint"))
+	if err != nil {
+		return empty, errors.Annotate(err, "invalid fingerprint")
+	}
+	return res, nil
+}

--- a/apiserver/resources.go
+++ b/apiserver/resources.go
@@ -56,12 +56,12 @@ func (h *resourceUploadHandler) processPost(r *http.Request, st *state.State) er
 	query := r.URL.Query()
 
 	applicationID := query.Get("application")
-	if applicationID != "" {
+	if applicationID == "" {
 		return errors.NotValidf("missing application")
 	}
 	userID := query.Get("user")
-	if userID != "" {
-		return errors.NotValidf("missing userID")
+	if userID == "" {
+		return errors.NotValidf("missing user")
 	}
 	res, err := queryToResource(query)
 	if err != nil {

--- a/apiserver/resources_test.go
+++ b/apiserver/resources_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package apiserver_test

--- a/apiserver/resources_test.go
+++ b/apiserver/resources_test.go
@@ -1,0 +1,246 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/component/all"
+	"github.com/juju/juju/permission"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing/factory"
+)
+
+type resourceUploadSuite struct {
+	authHTTPSuite
+	appName        string
+	importingState *state.State
+	importingModel *state.Model
+}
+
+var _ = gc.Suite(&resourceUploadSuite{})
+
+func (s *resourceUploadSuite) SetUpSuite(c *gc.C) {
+	s.authHTTPSuite.SetUpSuite(c)
+	all.RegisterForServer()
+}
+
+func (s *resourceUploadSuite) SetUpTest(c *gc.C) {
+	s.authHTTPSuite.SetUpTest(c)
+
+	// Make the user a controller admin (required for migrations).
+	controllerTag := names.NewControllerTag(s.ControllerConfig.ControllerUUID())
+	_, err := s.State.SetUserAccess(s.userTag, controllerTag, permission.SuperuserAccess)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Create an importing model to work with.
+	s.importingState = s.Factory.MakeModel(c, nil)
+	s.AddCleanup(func(*gc.C) { s.importingState.Close() })
+	s.importingModel, err = s.importingState.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	newFactory := factory.NewFactory(s.importingState)
+	app := newFactory.MakeApplication(c, nil)
+	s.appName = app.Name()
+
+	err = s.importingModel.SetMigrationMode(state.MigrationModeImporting)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.extraHeaders = map[string]string{
+		params.MigrationModelHTTPHeader: s.importingModel.UUID(),
+	}
+}
+
+func (s *resourceUploadSuite) TestServedSecurely(c *gc.C) {
+	url := s.resourcesURL(c, "")
+	url.Scheme = "http"
+	s.sendRequest(c, httpRequestParams{
+		method:      "GET",
+		url:         url.String(),
+		expectError: `.*malformed HTTP response.*`,
+	})
+}
+
+func (s *resourceUploadSuite) TestGETUnsupported(c *gc.C) {
+	resp := s.authRequest(c, httpRequestParams{method: "GET", url: s.resourcesURI(c, "")})
+	s.assertErrorResponse(c, resp, http.StatusMethodNotAllowed, `unsupported method: "GET"`)
+}
+
+func (s *resourceUploadSuite) TestPUTUnsupported(c *gc.C) {
+	resp := s.authRequest(c, httpRequestParams{method: "PUT", url: s.resourcesURI(c, "")})
+	s.assertErrorResponse(c, resp, http.StatusMethodNotAllowed, `unsupported method: "PUT"`)
+}
+
+func (s *resourceUploadSuite) TestPOSTRequiresAuth(c *gc.C) {
+	resp := s.sendRequest(c, httpRequestParams{method: "POST", url: s.resourcesURI(c, "")})
+	s.assertErrorResponse(c, resp, http.StatusUnauthorized, ".*no credentials provided$")
+}
+
+func (s *resourceUploadSuite) TestPOSTRequiresUserAuth(c *gc.C) {
+	// Add a machine and try to login.
+	machine, password := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{
+		Nonce: "noncy",
+	})
+	resp := s.sendRequest(c, httpRequestParams{
+		tag:         machine.Tag().String(),
+		password:    password,
+		method:      "POST",
+		url:         s.resourcesURI(c, ""),
+		nonce:       "noncy",
+		contentType: "foo/bar",
+	})
+	s.assertErrorResponse(c, resp, http.StatusInternalServerError, ".*tag kind machine not valid$")
+
+	// Now try a user login.
+	resp = s.authRequest(c, httpRequestParams{method: "POST", url: s.resourcesURI(c, "")})
+	s.assertErrorResponse(c, resp, http.StatusBadRequest, "missing application")
+}
+
+func (s *resourceUploadSuite) TestRejectsInvalidModel(c *gc.C) {
+	s.extraHeaders[params.MigrationModelHTTPHeader] = "dead-beef-123456"
+	resp := s.authRequest(c, httpRequestParams{method: "POST", url: s.resourcesURI(c, "")})
+	s.assertErrorResponse(c, resp, http.StatusNotFound, `.*unknown model: "dead-beef-123456"$`)
+}
+
+const content = "stuff"
+
+func (s *resourceUploadSuite) makeUploadArgs(c *gc.C) url.Values {
+	fp, err := charmresource.GenerateFingerprint(strings.NewReader(content))
+	c.Assert(err, jc.ErrorIsNil)
+	q := make(url.Values)
+	q.Add("application", s.appName)
+	q.Add("user", "napolean")
+	q.Add("name", "bin")
+	q.Add("path", "blob.zip")
+	q.Add("description", "hmm")
+	q.Add("type", "file")
+	q.Add("origin", "store")
+	q.Add("revision", "3")
+	q.Add("size", fmt.Sprint(len(content)))
+	q.Add("fingerprint", fp.Hex())
+	return q
+}
+
+func (s *resourceUploadSuite) TestUpload(c *gc.C) {
+	q := s.makeUploadArgs(c)
+	resp := s.authRequest(c, httpRequestParams{
+		method:      "POST",
+		url:         s.resourcesURI(c, q.Encode()),
+		contentType: "application/octet-stream",
+		body:        strings.NewReader(content),
+	})
+	outResp := s.assertResponse(c, resp, http.StatusOK)
+	c.Check(outResp.ID, gc.Not(gc.Equals), "")
+	c.Check(outResp.Timestamp.IsZero(), jc.IsFalse)
+
+	rSt, err := s.importingState.Resources()
+	c.Assert(err, jc.ErrorIsNil)
+	res, reader, err := rSt.OpenResource(s.appName, "bin")
+	c.Assert(err, jc.ErrorIsNil)
+	defer reader.Close()
+	readContent, err := ioutil.ReadAll(reader)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(readContent), gc.Equals, content)
+	c.Assert(res.ID, gc.Equals, outResp.ID)
+}
+
+func (s *resourceUploadSuite) TestArgValidation(c *gc.C) {
+	checkBadRequest := func(q url.Values, expected string) {
+		resp := s.authRequest(c, httpRequestParams{
+			method: "POST",
+			url:    s.resourcesURI(c, q.Encode()),
+		})
+		s.assertErrorResponse(c, resp, http.StatusBadRequest, expected)
+	}
+
+	q := s.makeUploadArgs(c)
+	q.Del("application")
+	checkBadRequest(q, "missing application")
+
+	q = s.makeUploadArgs(c)
+	q.Del("name")
+	checkBadRequest(q, "missing name")
+
+	q = s.makeUploadArgs(c)
+	q.Del("path")
+	checkBadRequest(q, "missing path")
+
+	q = s.makeUploadArgs(c)
+	q.Del("description")
+	checkBadRequest(q, "missing description")
+
+	q = s.makeUploadArgs(c)
+	q.Set("type", "fooo")
+	checkBadRequest(q, "invalid type")
+
+	q = s.makeUploadArgs(c)
+	q.Set("origin", "fooo")
+	checkBadRequest(q, "invalid origin")
+
+	q = s.makeUploadArgs(c)
+	q.Set("revision", "fooo")
+	checkBadRequest(q, "invalid revision")
+
+	q = s.makeUploadArgs(c)
+	q.Set("size", "fooo")
+	checkBadRequest(q, "invalid size")
+
+	q = s.makeUploadArgs(c)
+	q.Set("fingerprint", "zzz")
+	checkBadRequest(q, "invalid fingerprint")
+}
+
+func (s *resourceUploadSuite) TestFailsWhenModelNotImporting(c *gc.C) {
+	err := s.importingModel.SetMigrationMode(state.MigrationModeNone)
+	c.Assert(err, jc.ErrorIsNil)
+
+	q := s.makeUploadArgs(c)
+	resp := s.authRequest(c, httpRequestParams{
+		method:      "POST",
+		url:         s.resourcesURI(c, q.Encode()),
+		contentType: "application/octet-stream",
+		body:        strings.NewReader(content),
+	})
+	s.assertResponse(c, resp, http.StatusBadRequest)
+}
+
+func (s *resourceUploadSuite) resourcesURI(c *gc.C, query string) string {
+	if query != "" && query[0] == '?' {
+		query = query[1:]
+	}
+	return s.resourcesURL(c, query).String()
+}
+
+func (s *resourceUploadSuite) resourcesURL(c *gc.C, query string) *url.URL {
+	uri := s.baseURL(c)
+	uri.Path = "/migrate/resources"
+	uri.RawQuery = query
+	return uri
+}
+
+func (s *resourceUploadSuite) assertErrorResponse(c *gc.C, resp *http.Response, expStatus int, expError string) {
+	outResp := s.assertResponse(c, resp, expStatus)
+	err := outResp.Error
+	c.Assert(err, gc.NotNil)
+	c.Check(err.Message, gc.Matches, expError)
+}
+
+func (s *resourceUploadSuite) assertResponse(c *gc.C, resp *http.Response, expStatus int) params.ResourceUploadResult {
+	body := assertResponse(c, resp, expStatus, params.ContentTypeJSON)
+	var outResp params.ResourceUploadResult
+	err := json.Unmarshal(body, &outResp)
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf("body: %s", body))
+	return outResp
+}

--- a/component/all/resource.go
+++ b/component/all/resource.go
@@ -75,11 +75,11 @@ func (r resources) registerPublicFacade() {
 
 	common.RegisterAPIModelEndpoint(api.HTTPEndpointPattern, apihttp.HandlerSpec{
 		Constraints: apihttp.HandlerConstraints{
-			AuthKinds:           []string{names.UserTagKind},
+			AuthKinds:           []string{names.UserTagKind, names.MachineTagKind},
 			StrictValidation:    true,
 			ControllerModelOnly: false,
 		},
-		NewHandler: resourceadapters.NewUploadHandler,
+		NewHandler: resourceadapters.NewApplicationHandler,
 	})
 }
 

--- a/component/all/resource.go
+++ b/component/all/resource.go
@@ -174,6 +174,7 @@ func (r resources) registerHookContext() {
 
 	r.registerHookContextCommands()
 	r.registerHookContextFacade()
+	r.registerUnitDownloadEndpoint()
 }
 
 func (r resources) registerHookContextCommands() {
@@ -205,6 +206,9 @@ func (r resources) registerHookContextFacade() {
 		reflect.TypeOf(&internalserver.UnitFacade{}),
 	)
 
+}
+
+func (r resources) registerUnitDownloadEndpoint() {
 	common.RegisterAPIModelEndpoint(internalapi.HTTPEndpointPattern, apihttp.HandlerSpec{
 		Constraints: apihttp.HandlerConstraints{
 			AuthKind:            names.UnitTagKind,

--- a/component/all/resource.go
+++ b/component/all/resource.go
@@ -22,7 +22,7 @@ import (
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/api"
 	"github.com/juju/juju/resource/api/client"
-	internalapi "github.com/juju/juju/resource/api/private"
+	privateapi "github.com/juju/juju/resource/api/private"
 	internalclient "github.com/juju/juju/resource/api/private/client"
 	internalserver "github.com/juju/juju/resource/api/private/server"
 	"github.com/juju/juju/resource/api/server"
@@ -75,7 +75,7 @@ func (r resources) registerPublicFacade() {
 
 	common.RegisterAPIModelEndpoint(api.HTTPEndpointPattern, apihttp.HandlerSpec{
 		Constraints: apihttp.HandlerConstraints{
-			AuthKind:            names.UserTagKind,
+			AuthKinds:           []string{names.UserTagKind},
 			StrictValidation:    true,
 			ControllerModelOnly: false,
 		},
@@ -209,9 +209,9 @@ func (r resources) registerHookContextFacade() {
 }
 
 func (r resources) registerUnitDownloadEndpoint() {
-	common.RegisterAPIModelEndpoint(internalapi.HTTPEndpointPattern, apihttp.HandlerSpec{
+	common.RegisterAPIModelEndpoint(privateapi.HTTPEndpointPattern, apihttp.HandlerSpec{
 		Constraints: apihttp.HandlerConstraints{
-			AuthKind:            names.UnitTagKind,
+			AuthKinds:           []string{names.UnitTagKind},
 			StrictValidation:    true,
 			ControllerModelOnly: false,
 		},

--- a/core/description/resource.go
+++ b/core/description/resource.go
@@ -103,6 +103,9 @@ func (r *resource) SetApplicationRevision(args ResourceRevisionArgs) ResourceRev
 
 // ApplicationRevision implements Resource.
 func (r *resource) ApplicationRevision() ResourceRevision {
+	if r.ApplicationRevision_ == nil {
+		return nil // Return untyped nil when not set
+	}
 	return r.ApplicationRevision_
 }
 
@@ -114,6 +117,9 @@ func (r *resource) SetCharmStoreRevision(args ResourceRevisionArgs) ResourceRevi
 
 // CharmStoreRevision implements Resource.
 func (r *resource) CharmStoreRevision() ResourceRevision {
+	if r.CharmStoreRevision_ == nil {
+		return nil // Return untyped nil when not set
+	}
 	return r.CharmStoreRevision_
 }
 

--- a/core/description/resource.go
+++ b/core/description/resource.go
@@ -57,6 +57,8 @@ type ResourceArgs struct {
 	Name string
 }
 
+// newResource returns a new *resource (which implements the Resource
+// interface).
 func newResource(args ResourceArgs) *resource {
 	return &resource{
 		Name_: args.Name,

--- a/core/description/resource_test.go
+++ b/core/description/resource_test.go
@@ -100,6 +100,12 @@ func (s *ResourceSuite) TestNew(c *gc.C) {
 	c.Check(csRev.Username(), gc.Equals, "")
 }
 
+func (s *ResourceSuite) TestNilRevisions(c *gc.C) {
+	r := newResource(ResourceArgs{"z"})
+	c.Check(r.ApplicationRevision(), gc.Equals, nil)
+	c.Check(r.CharmStoreRevision(), gc.Equals, nil)
+}
+
 func (s *ResourceSuite) TestMinimalValid(c *gc.C) {
 	r := minimalResource()
 	c.Assert(r.Validate(), jc.ErrorIsNil)

--- a/core/description/resource_test.go
+++ b/core/description/resource_test.go
@@ -140,21 +140,6 @@ func (s *ResourceSuite) TestRoundTrip(c *gc.C) {
 	c.Assert(rOut, jc.DeepEquals, rIn)
 }
 
-func (s *ResourceSuite) TestRoundTripWithCharmStoreRev(c *gc.C) {
-	rIn := minimalResource()
-	rIn.SetCharmStoreRevision(ResourceRevisionArgs{
-		Revision:       4,
-		Type:           "file",
-		Path:           "file.tar.gz",
-		Description:    "description",
-		Origin:         "store",
-		FingerprintHex: "bbbbbbbb",
-		Size:           222,
-	})
-	rOut := s.exportImport(c, rIn)
-	c.Assert(rOut, jc.DeepEquals, rIn)
-}
-
 func (s *ResourceSuite) exportImport(c *gc.C, resourceIn *resource) *resource {
 	resourcesIn := &resources{
 		Version:    1,

--- a/core/description/resource_test.go
+++ b/core/description/resource_test.go
@@ -102,8 +102,8 @@ func (s *ResourceSuite) TestNew(c *gc.C) {
 
 func (s *ResourceSuite) TestNilRevisions(c *gc.C) {
 	r := newResource(ResourceArgs{"z"})
-	c.Check(r.ApplicationRevision(), gc.Equals, nil)
-	c.Check(r.CharmStoreRevision(), gc.Equals, nil)
+	c.Check(r.ApplicationRevision(), gc.IsNil)
+	c.Check(r.CharmStoreRevision(), gc.IsNil)
 }
 
 func (s *ResourceSuite) TestMinimalValid(c *gc.C) {

--- a/core/migration/migration.go
+++ b/core/migration/migration.go
@@ -7,10 +7,9 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/resource"
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
-
-	"github.com/juju/juju/core/description"
 )
 
 // MigrationStatus returns the details for a migration as needed by
@@ -54,9 +53,7 @@ type SerializedModel struct {
 	Tools map[version.Binary]string // version -> tools URI
 
 	// Resources represents all the resources in use in the model.
-	// The map key is application name. The values are slices of
-	// Resources used by an application.
-	Resources map[string][]description.Resource
+	Resources []resource.Resource
 }
 
 // ModelInfo is used to report basic details about a model.

--- a/core/migration/migration.go
+++ b/core/migration/migration.go
@@ -53,7 +53,15 @@ type SerializedModel struct {
 	Tools map[version.Binary]string // version -> tools URI
 
 	// Resources represents all the resources in use in the model.
-	Resources []resource.Resource
+	Resources []SerializedModelResource
+}
+
+// SerializedModelResource defines the resource revisions for a
+// specific application resource.
+type SerializedModelResource struct {
+	ApplicationRevision resource.Resource
+	CharmStoreRevision  resource.Resource
+	// TODO(menn0) - unit revisions
 }
 
 // ModelInfo is used to report basic details about a model.

--- a/core/migration/migration.go
+++ b/core/migration/migration.go
@@ -9,6 +9,8 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/core/description"
 )
 
 // MigrationStatus returns the details for a migration as needed by
@@ -50,6 +52,11 @@ type SerializedModel struct {
 	// their URIs. The URIs can be used to download the tools from the
 	// source controller.
 	Tools map[version.Binary]string // version -> tools URI
+
+	// Resources represents all the resources in use in the model.
+	// The map key is application name. The values are slices of
+	// Resources used by an application.
+	Resources map[string][]description.Resource
 }
 
 // ModelInfo is used to report basic details about a model.

--- a/core/migration/migration.go
+++ b/core/migration/migration.go
@@ -7,9 +7,10 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/resource"
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/resource"
 )
 
 // MigrationStatus returns the details for a migration as needed by

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -102,7 +102,7 @@ type UploadBinariesConfig struct {
 	ToolsDownloader ToolsDownloader
 	ToolsUploader   ToolsUploader
 
-	Resources          map[string]string
+	Resources          map[string][]string
 	ResourceDownloader ResourceDownloader
 }
 
@@ -219,17 +219,19 @@ func uploadTools(config UploadBinariesConfig) error {
 
 func uploadResources(config UploadBinariesConfig) error {
 	// XXX unfinished
-	for application, name := range config.Resources {
-		logger.Debugf("opening resource for %s: %s", application, name)
-		reader, err := config.ResourceDownloader.OpenResource(application, name)
-		if err != nil {
-			return errors.Annotate(err, "cannot open resource")
-		}
-		defer reader.Close()
+	for application, names := range config.Resources {
+		for _, name := range names {
+			logger.Debugf("opening resource for %s: %s", application, name)
+			reader, err := config.ResourceDownloader.OpenResource(application, name)
+			if err != nil {
+				return errors.Annotate(err, "cannot open resource")
+			}
+			defer reader.Close()
 
-		// XXX temporary
-		if err := writeResource(application, name, reader); err != nil {
-			return err
+			// XXX temporary
+			if err := writeResource(application, name, reader); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -86,12 +86,14 @@ type ToolsUploader interface {
 	UploadTools(io.ReadSeeker, version.Binary, ...string) (tools.List, error)
 }
 
-// XXX
+// ResourceDownloader defines the interface for downloading resources
+// from the source controller during a migration.
 type ResourceDownloader interface {
 	OpenResource(string, string) (io.ReadCloser, error)
 }
 
-// XXX
+// ResourceUploader defines the interface for uploading resources into
+// the target controller during a migration.
 type ResourceUploader interface {
 	UploadResource(resource.Resource, io.ReadSeeker) error
 }
@@ -127,7 +129,12 @@ func (c *UploadBinariesConfig) Validate() error {
 	if c.ToolsUploader == nil {
 		return errors.NotValidf("missing ToolsUploader")
 	}
-	// XXX validate ResourceDownloader & Uploader
+	if c.ResourceDownloader == nil {
+		return errors.NotValidf("missing ResourceDownloader")
+	}
+	if c.ResourceUploader == nil {
+		return errors.NotValidf("missing ResourceUploader")
+	}
 	return nil
 }
 
@@ -224,7 +231,6 @@ func uploadTools(config UploadBinariesConfig) error {
 	return nil
 }
 
-// XXX tests
 func uploadResources(config UploadBinariesConfig) error {
 	for _, res := range config.Resources {
 		err := uploadAppResource(config, res.ApplicationRevision)

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -13,11 +13,9 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6-unstable"
-	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/core/description"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/binarystorage"
 	"github.com/juju/juju/tools"
 )
 
@@ -66,16 +64,6 @@ func ImportModel(st *state.State, bytes []byte) (*state.Model, *state.State, err
 // charm from the source controller in a migration.
 type CharmDownloader interface {
 	OpenCharm(*charm.URL) (io.ReadCloser, error)
-}
-
-// UploadBackend define the methods on *state.State that are needed for
-// uploading the tools and charms from the current controller to a different
-// controller.
-type UploadBackend interface {
-	Charm(*charm.URL) (*state.Charm, error)
-	ModelUUID() string
-	MongoSession() *mgo.Session
-	ToolsStorage() (binarystorage.StorageCloser, error)
 }
 
 // CharmUploader defines a single method that is used to upload a

--- a/resource/api/private/server/handler.go
+++ b/resource/api/private/server/handler.go
@@ -15,9 +15,6 @@ import (
 	"github.com/juju/juju/resource/api"
 )
 
-// TODO(ericsnow) Define the HTTPHandlerConstraints here? Perhaps
-// even the HTTPHandlerSpec?
-
 // LegacyHTTPHandler is the HTTP handler for the resources
 // endpoint. We use it rather having a separate handler for each HTTP
 // method since registered API handlers must handle *all* HTTP methods

--- a/resource/api/private/server/handler.go
+++ b/resource/api/private/server/handler.go
@@ -15,23 +15,23 @@ import (
 	"github.com/juju/juju/resource/api"
 )
 
-// LegacyHTTPHandler is the HTTP handler for the resources
+// HTTPHandler is the HTTP handler for the resources
 // endpoint. We use it rather having a separate handler for each HTTP
 // method since registered API handlers must handle *all* HTTP methods
 // currently.
-type LegacyHTTPHandler struct {
-	LegacyHTTPHandlerDeps
+type HTTPHandler struct {
+	HTTPHandlerDeps
 }
 
-// NewLegacyHTTPHandler creates a new http.Handler for the resources endpoint.
-func NewLegacyHTTPHandler(deps LegacyHTTPHandlerDeps) *LegacyHTTPHandler {
-	return &LegacyHTTPHandler{
-		LegacyHTTPHandlerDeps: deps,
+// NewHTTPHandler creates a new http.Handler for the resources endpoint.
+func NewHTTPHandler(deps HTTPHandlerDeps) *HTTPHandler {
+	return &HTTPHandler{
+		HTTPHandlerDeps: deps,
 	}
 }
 
 // ServeHTTP implements http.Handler.
-func (h *LegacyHTTPHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+func (h *HTTPHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	opener, err := h.NewResourceOpener(req)
 	if err != nil {
 		h.SendHTTPError(resp, err)
@@ -68,20 +68,20 @@ func (h *LegacyHTTPHandler) ServeHTTP(resp http.ResponseWriter, req *http.Reques
 	}
 }
 
-// LegacyHTTPHandlerDeps exposes the external dependencies
-// of LegacyHTTPHandler.
-type LegacyHTTPHandlerDeps interface {
-	baseLegacyHTTPHandlerDeps
+// HTTPHandlerDeps exposes the external dependencies
+// of HTTPHandler.
+type HTTPHandlerDeps interface {
+	baseHTTPHandlerDeps
 	ExtraDeps
 }
 
-//ExtraDeps exposes the non-superficial dependencies of LegacyHTTPHandler.
+//ExtraDeps exposes the non-superficial dependencies of HTTPHandler.
 type ExtraDeps interface {
 	// NewResourceOpener returns a new opener for the request.
 	NewResourceOpener(*http.Request) (resource.Opener, error)
 }
 
-type baseLegacyHTTPHandlerDeps interface {
+type baseHTTPHandlerDeps interface {
 	// UpdateDownloadResponse updates the HTTP response with the info
 	// from the resource.
 	UpdateDownloadResponse(http.ResponseWriter, resource.Resource)
@@ -96,8 +96,8 @@ type baseLegacyHTTPHandlerDeps interface {
 	Copy(io.Writer, io.Reader) error
 }
 
-// NewLegacyHTTPHandlerDeps returns an implementation of LegacyHTTPHandlerDeps.
-func NewLegacyHTTPHandlerDeps(extraDeps ExtraDeps) LegacyHTTPHandlerDeps {
+// NewHTTPHandlerDeps returns an implementation of HTTPHandlerDeps.
+func NewHTTPHandlerDeps(extraDeps ExtraDeps) HTTPHandlerDeps {
 	return &legacyHTTPHandlerDeps{
 		ExtraDeps: extraDeps,
 	}
@@ -108,23 +108,23 @@ type legacyHTTPHandlerDeps struct {
 	ExtraDeps
 }
 
-// SendHTTPError implements LegacyHTTPHandlerDeps.
+// SendHTTPError implements HTTPHandlerDeps.
 func (deps legacyHTTPHandlerDeps) SendHTTPError(resp http.ResponseWriter, err error) {
 	api.SendHTTPError(resp, err)
 }
 
-// UpdateDownloadResponse implements LegacyHTTPHandlerDeps.
+// UpdateDownloadResponse implements HTTPHandlerDeps.
 func (deps legacyHTTPHandlerDeps) UpdateDownloadResponse(resp http.ResponseWriter, info resource.Resource) {
 	api.UpdateDownloadResponse(resp, info)
 }
 
-// HandleDownload implements LegacyHTTPHandlerDeps.
+// HandleDownload implements HTTPHandlerDeps.
 func (deps legacyHTTPHandlerDeps) HandleDownload(opener resource.Opener, req *http.Request) (resource.Opened, error) {
 	name := api.ExtractDownloadRequest(req)
 	return opener.OpenResource(name)
 }
 
-// Copy implements LegacyHTTPHandlerDeps.
+// Copy implements HTTPHandlerDeps.
 func (deps legacyHTTPHandlerDeps) Copy(w io.Writer, r io.Reader) error {
 	_, err := io.Copy(w, r)
 	return err

--- a/resource/api/server/base_test.go
+++ b/resource/api/server/base_test.go
@@ -83,6 +83,14 @@ type stubDataStore struct {
 	ReturnUpdatePendingResource resource.Resource
 }
 
+func (s *stubDataStore) OpenResource(application, name string) (resource.Resource, io.ReadCloser, error) {
+	s.stub.AddCall("OpenResource", application, name)
+	if err := s.stub.NextErr(); err != nil {
+		return resource.Resource{}, nil, errors.Trace(err)
+	}
+	return s.ReturnGetResource, nil, nil
+}
+
 func (s *stubDataStore) ListResources(service string) (resource.ServiceResources, error) {
 	s.stub.AddCall("ListResources", service)
 	if err := s.stub.NextErr(); err != nil {

--- a/resource/api/server/download.go
+++ b/resource/api/server/download.go
@@ -1,0 +1,40 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package server
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/resource"
+)
+
+// XXX tests
+
+// DownloadDataStore describes the the portion of Juju's "state"
+// needed for handling resource download requests.
+type DownloadDataStore interface {
+	// OpenResource returns the identified resource and its content.
+	OpenResource(applicationID, name string) (resource.Resource, io.ReadCloser, error)
+}
+
+// DownloadHandler provides the functionality to handle download requests.
+type DownloadHandler struct {
+	// Store is the data store from the resource will be retrieved.
+	Store DownloadDataStore
+}
+
+// HandleRequest handles a resource download request.
+func (dh DownloadHandler) HandleRequest(req *http.Request) (io.ReadCloser, error) {
+	defer req.Body.Close()
+
+	query := req.URL.Query()
+	application := query.Get(":application")
+	resource := query.Get(":resource")
+
+	_, reader, err := dh.Store.OpenResource(application, resource)
+	return reader, errors.Trace(err)
+}

--- a/resource/api/server/download.go
+++ b/resource/api/server/download.go
@@ -28,13 +28,13 @@ type DownloadHandler struct {
 }
 
 // HandleRequest handles a resource download request.
-func (dh DownloadHandler) HandleRequest(req *http.Request) (io.ReadCloser, error) {
+func (dh DownloadHandler) HandleRequest(req *http.Request) (io.ReadCloser, int64, error) {
 	defer req.Body.Close()
 
 	query := req.URL.Query()
 	application := query.Get(":application")
-	resource := query.Get(":resource")
+	name := query.Get(":resource")
 
-	_, reader, err := dh.Store.OpenResource(application, resource)
-	return reader, errors.Trace(err)
+	resource, reader, err := dh.Store.OpenResource(application, name)
+	return reader, resource.Size, errors.Trace(err)
 }

--- a/resource/api/server/download.go
+++ b/resource/api/server/download.go
@@ -12,8 +12,6 @@ import (
 	"github.com/juju/juju/resource"
 )
 
-// XXX tests
-
 // DownloadDataStore describes the the portion of Juju's "state"
 // needed for handling resource download requests.
 type DownloadDataStore interface {

--- a/resource/api/server/handler.go
+++ b/resource/api/server/handler.go
@@ -4,11 +4,13 @@
 package server
 
 import (
+	"io"
 	"net/http"
 
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/resource/api"
 )
 
@@ -19,16 +21,26 @@ type HTTPHandler struct {
 	// Connect opens a connection to state resources.
 	Connect func(*http.Request) (DataStore, names.Tag, error)
 
+	// HandleDownload provides the download functionality.
+	HandleDownload func(st DataStore, req *http.Request) (io.ReadCloser, error)
+
 	// HandleUpload provides the upload functionality.
 	HandleUpload func(username string, st DataStore, req *http.Request) (*api.UploadResult, error)
 }
 
 // TODO(ericsnow) Can username be extracted from the request?
 
-// NewHTTPHandler creates a new http.Handler for the resources endpoint.
+// NewHTTPHandler creates a new http.Handler for the application
+// resources endpoint.
 func NewHTTPHandler(connect func(*http.Request) (DataStore, names.Tag, error)) *HTTPHandler {
 	return &HTTPHandler{
 		Connect: connect,
+		HandleDownload: func(st DataStore, req *http.Request) (io.ReadCloser, error) {
+			dh := DownloadHandler{
+				Store: st,
+			}
+			return dh.HandleRequest(req)
+		},
 		HandleUpload: func(username string, st DataStore, req *http.Request) (*api.UploadResult, error) {
 			uh := UploadHandler{
 				Username: username,
@@ -47,28 +59,36 @@ func (h *HTTPHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	var username string
-	switch tag := tag.(type) {
-	case *names.UserTag:
-		username = tag.Name()
-	default:
-		// TODO(ericsnow) Fail?
-		username = tag.Id()
-	}
-
-	// We do this *after* authorization, etc. (in h.Connect) in order
-	// to prioritize errors that may originate there.
 	switch req.Method {
+	case "GET":
+		reader, err := h.HandleDownload(st, req)
+		if err != nil {
+			api.SendHTTPError(resp, err)
+			return
+		}
+		defer reader.Close()
+		resp.Header().Set("Content-Type", params.ContentTypeRaw)
+		// XXX should really set Content-Length
+		io.Copy(resp, reader)
 	case "PUT":
-		logger.Infof("handling resource upload request")
-		response, err := h.HandleUpload(username, st, req)
+		logger.Debugf("handling resource upload request")
+		response, err := h.HandleUpload(tagToUsername(tag), st, req)
 		if err != nil {
 			api.SendHTTPError(resp, err)
 			return
 		}
 		api.SendHTTPStatusAndJSON(resp, http.StatusOK, &response)
-		logger.Infof("resource upload request successful")
+		logger.Debugf("resource upload request successful")
 	default:
 		api.SendHTTPError(resp, errors.MethodNotAllowedf("unsupported method: %q", req.Method))
+	}
+}
+
+func tagToUsername(tag names.Tag) string {
+	switch tag := tag.(type) {
+	case *names.UserTag:
+		return tag.Name()
+	default:
+		return ""
 	}
 }

--- a/resource/api/server/handler.go
+++ b/resource/api/server/handler.go
@@ -12,10 +12,10 @@ import (
 	"github.com/juju/juju/resource/api"
 )
 
-// LegacyHTTPHandler is the HTTP handler for the resources endpoint. We
-// use it rather having a separate handler for each HTTP method since
+// HTTPHandler is the HTTP handler for the resources endpoint. We use
+// it rather having a separate handler for each HTTP method since
 // registered API handlers must handle *all* HTTP methods currently.
-type LegacyHTTPHandler struct {
+type HTTPHandler struct {
 	// Connect opens a connection to state resources.
 	Connect func(*http.Request) (DataStore, names.Tag, error)
 
@@ -25,9 +25,9 @@ type LegacyHTTPHandler struct {
 
 // TODO(ericsnow) Can username be extracted from the request?
 
-// NewLegacyHTTPHandler creates a new http.Handler for the resources endpoint.
-func NewLegacyHTTPHandler(connect func(*http.Request) (DataStore, names.Tag, error)) *LegacyHTTPHandler {
-	return &LegacyHTTPHandler{
+// NewHTTPHandler creates a new http.Handler for the resources endpoint.
+func NewHTTPHandler(connect func(*http.Request) (DataStore, names.Tag, error)) *HTTPHandler {
+	return &HTTPHandler{
 		Connect: connect,
 		HandleUpload: func(username string, st DataStore, req *http.Request) (*api.UploadResult, error) {
 			uh := UploadHandler{
@@ -40,7 +40,7 @@ func NewLegacyHTTPHandler(connect func(*http.Request) (DataStore, names.Tag, err
 }
 
 // ServeHTTP implements http.Handler.
-func (h *LegacyHTTPHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+func (h *HTTPHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	st, tag, err := h.Connect(req)
 	if err != nil {
 		api.SendHTTPError(resp, err)

--- a/resource/api/server/handler.go
+++ b/resource/api/server/handler.go
@@ -29,8 +29,6 @@ type HTTPHandler struct {
 	HandleUpload func(username string, st DataStore, req *http.Request) (*api.UploadResult, error)
 }
 
-// TODO(ericsnow) Can username be extracted from the request?
-
 // NewHTTPHandler creates a new http.Handler for the application
 // resources endpoint.
 func NewHTTPHandler(connect func(*http.Request) (DataStore, names.Tag, error)) *HTTPHandler {

--- a/resource/api/server/handler.go
+++ b/resource/api/server/handler.go
@@ -69,7 +69,7 @@ func (h *HTTPHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		defer reader.Close()
 		resp.Header().Set("Content-Type", params.ContentTypeRaw)
 		// XXX should really set Content-Length
-		io.Copy(resp, reader)
+		io.Copy(resp, reader) // XXX check error
 	case "PUT":
 		logger.Debugf("handling resource upload request")
 		response, err := h.HandleUpload(tagToUsername(tag), st, req)

--- a/resource/api/server/handler_test.go
+++ b/resource/api/server/handler_test.go
@@ -33,6 +33,8 @@ type HTTPHandlerSuite struct {
 
 var _ = gc.Suite(&HTTPHandlerSuite{})
 
+// XXX download tests
+
 func (s *HTTPHandlerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 

--- a/resource/api/server/handler_test.go
+++ b/resource/api/server/handler_test.go
@@ -83,13 +83,17 @@ func (s *HTTPHandlerSuite) handleUpload(username string, st server.DataStore, re
 	return s.uploadResult, nil
 }
 
+func (s *HTTPHandlerSuite) copyRequest() *http.Request {
+	copy := *s.req
+	return &copy
+}
+
 func (s *HTTPHandlerSuite) TestServeHTTPConnectFailure(c *gc.C) {
 	s.username = "youknowwho"
 	handler := server.HTTPHandler{
 		Connect: s.connect,
 	}
-	copied := *s.req
-	req := &copied
+	req := s.copyRequest()
 	failure, expected := apiFailure(c, "<failure>", "")
 	s.stub.SetErrors(failure)
 
@@ -118,8 +122,7 @@ func (s *HTTPHandlerSuite) TestServeHTTPUnsupportedMethod(c *gc.C) {
 		Connect: s.connect,
 	}
 	s.req.Method = "POST"
-	copied := *s.req
-	req := &copied
+	req := s.copyRequest()
 	_, expected := apiFailure(c, `unsupported method: "POST"`, params.CodeMethodNotAllowed)
 
 	handler.ServeHTTP(s.resp, req)
@@ -146,10 +149,8 @@ func (s *HTTPHandlerSuite) TestServeHTTPGetSuccess(c *gc.C) {
 		Connect:        s.connect,
 		HandleDownload: s.handleDownload,
 	}
-	// XXX extract
 	s.req.Method = "GET"
-	copied := *s.req
-	req := &copied
+	req := s.copyRequest()
 
 	handler.ServeHTTP(s.resp, req)
 
@@ -177,8 +178,7 @@ func (s *HTTPHandlerSuite) TestServeHTTPPutSuccess(c *gc.C) {
 		HandleUpload: s.handleUpload,
 	}
 	s.req.Method = "PUT"
-	copied := *s.req
-	req := &copied
+	req := s.copyRequest()
 
 	handler.ServeHTTP(s.resp, req)
 
@@ -208,8 +208,7 @@ func (s *HTTPHandlerSuite) TestServeHTTPPutHandleUploadFailure(c *gc.C) {
 		HandleUpload: s.handleUpload,
 	}
 	s.req.Method = "PUT"
-	copied := *s.req
-	req := &copied
+	req := s.copyRequest()
 	failure, expected := apiFailure(c, "<failure>", "")
 	s.stub.SetErrors(nil, failure)
 

--- a/resource/api/server/handler_test.go
+++ b/resource/api/server/handler_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/juju/juju/resource/api/server"
 )
 
-type LegacyHTTPHandlerSuite struct {
+type HTTPHandlerSuite struct {
 	BaseSuite
 
 	username string
@@ -31,9 +31,9 @@ type LegacyHTTPHandlerSuite struct {
 	result   *api.UploadResult
 }
 
-var _ = gc.Suite(&LegacyHTTPHandlerSuite{})
+var _ = gc.Suite(&HTTPHandlerSuite{})
 
-func (s *LegacyHTTPHandlerSuite) SetUpTest(c *gc.C) {
+func (s *HTTPHandlerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
 	method := "..."
@@ -51,7 +51,7 @@ func (s *LegacyHTTPHandlerSuite) SetUpTest(c *gc.C) {
 	s.result = &api.UploadResult{}
 }
 
-func (s *LegacyHTTPHandlerSuite) connect(req *http.Request) (server.DataStore, names.Tag, error) {
+func (s *HTTPHandlerSuite) connect(req *http.Request) (server.DataStore, names.Tag, error) {
 	s.stub.AddCall("Connect", req)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, nil, errors.Trace(err)
@@ -61,7 +61,7 @@ func (s *LegacyHTTPHandlerSuite) connect(req *http.Request) (server.DataStore, n
 	return s.data, tag, nil
 }
 
-func (s *LegacyHTTPHandlerSuite) handleUpload(username string, st server.DataStore, req *http.Request) (*api.UploadResult, error) {
+func (s *HTTPHandlerSuite) handleUpload(username string, st server.DataStore, req *http.Request) (*api.UploadResult, error) {
 	s.stub.AddCall("HandleUpload", username, st, req)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)
@@ -70,9 +70,9 @@ func (s *LegacyHTTPHandlerSuite) handleUpload(username string, st server.DataSto
 	return s.result, nil
 }
 
-func (s *LegacyHTTPHandlerSuite) TestServeHTTPConnectFailure(c *gc.C) {
+func (s *HTTPHandlerSuite) TestServeHTTPConnectFailure(c *gc.C) {
 	s.username = "youknowwho"
-	handler := server.LegacyHTTPHandler{
+	handler := server.HTTPHandler{
 		Connect:      s.connect,
 		HandleUpload: s.handleUpload,
 	}
@@ -100,9 +100,9 @@ func (s *LegacyHTTPHandlerSuite) TestServeHTTPConnectFailure(c *gc.C) {
 	})
 }
 
-func (s *LegacyHTTPHandlerSuite) TestServeHTTPUnsupportedMethod(c *gc.C) {
+func (s *HTTPHandlerSuite) TestServeHTTPUnsupportedMethod(c *gc.C) {
 	s.username = "youknowwho"
-	handler := server.LegacyHTTPHandler{
+	handler := server.HTTPHandler{
 		Connect:      s.connect,
 		HandleUpload: s.handleUpload,
 	}
@@ -130,12 +130,12 @@ func (s *LegacyHTTPHandlerSuite) TestServeHTTPUnsupportedMethod(c *gc.C) {
 	})
 }
 
-func (s *LegacyHTTPHandlerSuite) TestServeHTTPPutSuccess(c *gc.C) {
+func (s *HTTPHandlerSuite) TestServeHTTPPutSuccess(c *gc.C) {
 	s.result.Resource.Name = "spam"
 	expected, err := json.Marshal(s.result)
 	c.Assert(err, jc.ErrorIsNil)
 	s.username = "youknowwho"
-	handler := server.LegacyHTTPHandler{
+	handler := server.HTTPHandler{
 		Connect:      s.connect,
 		HandleUpload: s.handleUpload,
 	}
@@ -164,9 +164,9 @@ func (s *LegacyHTTPHandlerSuite) TestServeHTTPPutSuccess(c *gc.C) {
 	})
 }
 
-func (s *LegacyHTTPHandlerSuite) TestServeHTTPPutHandleUploadFailure(c *gc.C) {
+func (s *HTTPHandlerSuite) TestServeHTTPPutHandleUploadFailure(c *gc.C) {
 	s.username = "youknowwho"
-	handler := server.LegacyHTTPHandler{
+	handler := server.HTTPHandler{
 		Connect:      s.connect,
 		HandleUpload: s.handleUpload,
 	}

--- a/resource/api/server/server.go
+++ b/resource/api/server/server.go
@@ -31,6 +31,7 @@ const (
 // DataStore is the functionality of Juju's state needed for the resources API.
 type DataStore interface {
 	resourceInfoStore
+	DownloadDataStore
 	UploadDataStore
 }
 

--- a/resource/resourceadapters/apiserver.go
+++ b/resource/resourceadapters/apiserver.go
@@ -39,8 +39,9 @@ func NewPublicFacade(st *corestate.State, _ facade.Resources, authorizer facade.
 	return facade, nil
 }
 
-// NewUploadHandler returns a new HTTP handler for the given args.
-func NewUploadHandler(args apihttp.NewHandlerArgs) http.Handler {
+// NewApplicationHandler returns a new HTTP handler for application
+// level resource uploads and downloads.
+func NewApplicationHandler(args apihttp.NewHandlerArgs) http.Handler {
 	return server.NewHTTPHandler(
 		func(req *http.Request) (server.DataStore, names.Tag, error) {
 			st, entity, err := args.Connect(req)

--- a/resource/resourceadapters/apiserver.go
+++ b/resource/resourceadapters/apiserver.go
@@ -41,7 +41,7 @@ func NewPublicFacade(st *corestate.State, _ facade.Resources, authorizer facade.
 
 // NewUploadHandler returns a new HTTP handler for the given args.
 func NewUploadHandler(args apihttp.NewHandlerArgs) http.Handler {
-	return server.NewLegacyHTTPHandler(
+	return server.NewHTTPHandler(
 		func(req *http.Request) (server.DataStore, names.Tag, error) {
 			st, entity, err := args.Connect(req)
 			if err != nil {
@@ -62,8 +62,8 @@ func NewDownloadHandler(args apihttp.NewHandlerArgs) http.Handler {
 	extractor := &httpDownloadRequestExtractor{
 		connect: args.Connect,
 	}
-	deps := internalserver.NewLegacyHTTPHandlerDeps(extractor)
-	return internalserver.NewLegacyHTTPHandler(deps)
+	deps := internalserver.NewHTTPHandlerDeps(extractor)
+	return internalserver.NewHTTPHandler(deps)
 }
 
 // stateConnector exposes ways to connect to Juju's state.

--- a/worker/migrationmaster/shim.go
+++ b/worker/migrationmaster/shim.go
@@ -12,8 +12,8 @@ import (
 )
 
 func NewFacade(apiCaller base.APICaller) (Facade, error) {
-	facade := migrationmaster.NewClient(apiCaller, watcher.NewNotifyWatcher)
-	return facade, nil
+	facade, err := migrationmaster.NewClient(apiCaller, watcher.NewNotifyWatcher)
+	return facade, errors.Trace(err)
 }
 
 func NewWorker(config Config) (worker.Worker, error) {

--- a/worker/migrationmaster/shim.go
+++ b/worker/migrationmaster/shim.go
@@ -12,8 +12,8 @@ import (
 )
 
 func NewFacade(apiCaller base.APICaller) (Facade, error) {
-	facade, err := migrationmaster.NewClient(apiCaller, watcher.NewNotifyWatcher)
-	return facade, errors.Trace(err)
+	facade := migrationmaster.NewClient(apiCaller, watcher.NewNotifyWatcher)
+	return facade, nil
 }
 
 func NewWorker(config Config) (worker.Worker, error) {

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -89,7 +89,7 @@ type Facade interface {
 	// associated with the API connection.
 	Export() (coremigration.SerializedModel, error)
 
-	// XXX
+	// OpenResource downloads a single resource for an application.
 	OpenResource(string, string) (io.ReadCloser, error)
 
 	// Reap removes all documents of the model associated with the API
@@ -120,8 +120,7 @@ type Config struct {
 	UploadBinaries  func(migration.UploadBinariesConfig) error
 	CharmDownloader migration.CharmDownloader
 	ToolsDownloader migration.ToolsDownloader
-	// XXX ResourceDownloader
-	Clock clock.Clock
+	Clock           clock.Clock
 }
 
 // Validate returns an error if config cannot drive a Worker.


### PR DESCRIPTION
This PR adds APIs, updates the migration binary import/export functionality and the migrationmaster worker to support migration of resources.

The new download API uses the preexisting component architecture approach. The upload API is implemented as /migrate/resources using the same approach as is used for tools and charms migration uploads.

### QA

Migrated a resource using model between 2 controllers and confirmed that the application level resource was correctly migrated using `juju dump-model` and inspection of the DB.
