### PR TITLE
Have the peergrouper publish the apiservers over the central hub.

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -980,7 +980,7 @@ func (a *MachineAgent) startStateWorkers(st *state.State) (worker.Worker, error)
 					return nil, errors.Annotate(err, "getting environ from state")
 				}
 				supportsSpaces := environs.SupportsSpaces(env)
-				w, err := peergrouperNew(st, supportsSpaces)
+				w, err := peergrouperNew(st, clock.WallClock, supportsSpaces, a.centralHub)
 				if err != nil {
 					return nil, errors.Annotate(err, "cannot start peergrouper worker")
 				}

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/cert"
+	"github.com/juju/utils/clock"
 	"github.com/juju/utils/series"
 	"github.com/juju/utils/set"
 	"github.com/juju/utils/ssh"
@@ -60,6 +61,7 @@ import (
 	"github.com/juju/juju/worker/machiner"
 	"github.com/juju/juju/worker/migrationmaster"
 	"github.com/juju/juju/worker/mongoupgrader"
+	"github.com/juju/juju/worker/peergrouper"
 	"github.com/juju/juju/worker/storageprovisioner"
 	"github.com/juju/juju/worker/upgrader"
 	"github.com/juju/juju/worker/workertest"
@@ -420,7 +422,7 @@ func (s *MachineSuite) TestManageModelRunsInstancePoller(c *gc.C) {
 
 func (s *MachineSuite) TestManageModelRunsPeergrouper(c *gc.C) {
 	started := newSignal()
-	s.AgentSuite.PatchValue(&peergrouperNew, func(st *state.State, _ bool) (worker.Worker, error) {
+	s.AgentSuite.PatchValue(&peergrouperNew, func(st *state.State, _ clock.Clock, _ bool, _ peergrouper.Hub) (worker.Worker, error) {
 		c.Check(st, gc.NotNil)
 		started.trigger()
 		return newDummyWorker(), nil

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
+	"github.com/juju/utils/clock"
 	"github.com/juju/utils/series"
 	"github.com/juju/utils/set"
 	"github.com/juju/version"
@@ -42,6 +43,7 @@ import (
 	"github.com/juju/juju/worker/authenticationworker"
 	"github.com/juju/juju/worker/deployer"
 	"github.com/juju/juju/worker/logsender"
+	"github.com/juju/juju/worker/peergrouper"
 	"github.com/juju/juju/worker/singular"
 )
 
@@ -89,7 +91,7 @@ func (s *commonMachineSuite) SetUpTest(c *gc.C) {
 
 	s.singularRecord = newSingularRunnerRecord()
 	s.AgentSuite.PatchValue(&newSingularRunner, s.singularRecord.newSingularRunner)
-	s.AgentSuite.PatchValue(&peergrouperNew, func(*state.State, bool) (worker.Worker, error) {
+	s.AgentSuite.PatchValue(&peergrouperNew, func(*state.State, clock.Clock, bool, peergrouper.Hub) (worker.Worker, error) {
 		return newDummyWorker(), nil
 	})
 

--- a/pubsub/apiserver/messages.go
+++ b/pubsub/apiserver/messages.go
@@ -1,0 +1,21 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+// DetailsTopic is the topic name for the published message when the details of
+// the api servers change. This message is normally published by the peergrouper
+// when the set of API servers changes.
+const DetailsTopic = "apiserver.details"
+
+// APIServer defines a single api server machine.
+type APIServer struct {
+	Id        string   `yaml:"id"`
+	Addresses []string `yaml:"addresses"`
+}
+
+// Details defines the message structure for the apiserver.details topic.
+type Details struct {
+	Servers   []APIServer `yaml:"servers"`
+	LocalOnly bool        `yaml:"local-only"`
+}

--- a/pubsub/apiserver/messages.go
+++ b/pubsub/apiserver/messages.go
@@ -3,19 +3,23 @@
 
 package apiserver
 
-// DetailsTopic is the topic name for the published message when the details of
-// the api servers change. This message is normally published by the peergrouper
-// when the set of API servers changes.
-const DetailsTopic = "apiserver.details"
+import "github.com/juju/pubsub"
 
-// APIServer defines a single api server machine.
+// DetailsTopic is the topic name for the published message when the details
+// of the api servers change. This message is normally published by the
+// peergrouper when the set of API servers changes.
+const DetailsTopic pubsub.Topic = "apiserver.details"
+
+// APIServer contains the machine id and addresses of a single API server machine.
 type APIServer struct {
-	Id        string   `yaml:"id"`
+	ID        string   `yaml:"id"`
 	Addresses []string `yaml:"addresses"`
 }
 
-// Details defines the message structure for the apiserver.details topic.
+// Details contains the ids and addresses of all the current API server
+// machines.
 type Details struct {
-	Servers   []APIServer `yaml:"servers"`
-	LocalOnly bool        `yaml:"local-only"`
+	// Servers is a map of machine ID to the details for that server.
+	Servers   map[string]APIServer `yaml:"servers"`
+	LocalOnly bool                 `yaml:"local-only"`
 }

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -336,12 +336,15 @@ func inStrings(t string, ss []string) bool {
 }
 
 func (w *pgWorker) apiPublishInfo() ([][]network.HostPort, []instance.Id, error) {
-	details := apiserver.Details{LocalOnly: true}
+	details := apiserver.Details{
+		Servers:   make(map[string]apiserver.APIServer),
+		LocalOnly: true,
+	}
 	servers := make([][]network.HostPort, 0, len(w.machineTrackers))
 	instanceIds := make([]instance.Id, 0, len(w.machineTrackers))
 	for _, m := range w.machineTrackers {
 		hostPorts := m.APIHostPorts()
-		server := apiserver.APIServer{Id: m.Id()}
+		server := apiserver.APIServer{ID: m.Id()}
 		if len(hostPorts) == 0 {
 			continue
 		}
@@ -355,7 +358,7 @@ func (w *pgWorker) apiPublishInfo() ([][]network.HostPort, []instance.Id, error)
 		}
 		instanceIds = append(instanceIds, instanceId)
 		servers = append(servers, m.APIHostPorts())
-		details.Servers = append(details.Servers, server)
+		details.Servers[server.ID] = server
 	}
 	w.hub.Publish(apiserver.DetailsTopic, details)
 	return servers, instanceIds, nil

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -112,7 +112,7 @@ type pgWorker struct {
 
 	providerSupportsSpaces bool
 
-	// hub is the central hub of the apiserver, and is used to pusblish the
+	// hub is the central hub of the apiserver, and is used to publish the
 	// details of the api servers.
 	hub Hub
 }


### PR DESCRIPTION
Also refactors the peergrouper to use clock.Clock interface rather than time directly.