### PR TITLE
remote relations worker registers relations

### DIFF
--- a/api/remoterelations/remoterelations.go
+++ b/api/remoterelations/remoterelations.go
@@ -118,12 +118,12 @@ func (c *Client) RelationUnitSettings(relationUnits []params.RelationUnit) ([]pa
 
 // Relations returns information about the cross-model relations with the specified keys
 // in the local model.
-func (c *Client) Relations(keys []string) ([]params.RelationResult, error) {
+func (c *Client) Relations(keys []string) ([]params.RemoteRelationResult, error) {
 	args := params.Entities{Entities: make([]params.Entity, len(keys))}
 	for i, key := range keys {
 		args.Entities[i].Tag = names.NewRelationTag(key).String()
 	}
-	var results params.RelationResults
+	var results params.RemoteRelationResults
 	err := c.facade.FacadeCall("Relations", args, &results)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/api/remoterelations/remoterelations_test.go
+++ b/api/remoterelations/remoterelations_test.go
@@ -243,9 +243,9 @@ func (s *remoteRelationsSuite) TestRelations(c *gc.C) {
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "Relations")
 		c.Check(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "relation-foo.db#bar.db"}}})
-		c.Assert(result, gc.FitsTypeOf, &params.RelationResults{})
-		*(result.(*params.RelationResults)) = params.RelationResults{
-			Results: []params.RelationResult{{
+		c.Assert(result, gc.FitsTypeOf, &params.RemoteRelationResults{})
+		*(result.(*params.RemoteRelationResults)) = params.RemoteRelationResults{
+			Results: []params.RemoteRelationResult{{
 				Error: &params.Error{Message: "FAIL"},
 			}},
 		}
@@ -262,8 +262,8 @@ func (s *remoteRelationsSuite) TestRelations(c *gc.C) {
 
 func (s *remoteRelationsSuite) TestRelationsResultsCount(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		*(result.(*params.RelationResults)) = params.RelationResults{
-			Results: []params.RelationResult{
+		*(result.(*params.RemoteRelationResults)) = params.RemoteRelationResults{
+			Results: []params.RemoteRelationResult{
 				{Error: &params.Error{Message: "FAIL"}},
 				{Error: &params.Error{Message: "FAIL"}},
 			},

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -246,19 +246,23 @@ type RemoteEntityIdResults struct {
 // RemoteRelation describes the current state of a cross-model relation from
 // the perspective of the local model.
 type RemoteRelation struct {
-	Id   RemoteEntityId `json:"id"`
-	Life Life           `json:"life"`
+	Life               Life           `json:"life"`
+	Id                 int            `json:"id"`
+	Key                string         `json:"key"`
+	LocalEndpoint      RemoteEndpoint `json:"local-endpoint"`
+	RemoteEndpointName string         `json:"remote-endpoint-name"`
 }
 
 // RemoteRelationResult holds a remote relation and an error.
 type RemoteRelationResult struct {
-	Result *RemoteRelation `json:"result,omitempty"`
 	Error  *Error          `json:"error,omitempty"`
+	Result *RemoteRelation `json:"result,omitempty"`
 }
 
-// RemoteRelationResults holds a set of remote relation results.
+// RemoteRelationResults holds the result of an API call that returns
+// information about multiple remote relations.
 type RemoteRelationResults struct {
-	Results []RemoteRelationResult `json:"results,omitempty"`
+	Results []RemoteRelationResult `json:"results"`
 }
 
 // RemoteApplication describes the current state of an application involved in a cross-
@@ -275,6 +279,10 @@ type RemoteApplication struct {
 
 	// ModelUUID is the UUId of the model hosting the application.
 	ModelUUID string `json:"model-uuid"`
+
+	// Registered returns the application is created
+	// from a registration operation by a consuming model.
+	Registered bool `json:"registered"`
 }
 
 // RemoteApplicationResult holds a remote application and an error.

--- a/apiserver/remoterelations/state.go
+++ b/apiserver/remoterelations/state.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
 )
@@ -66,6 +67,9 @@ type RemoteRelationsState interface {
 	// GetToken returns the token associated with the entity with the given tag
 	// and model.
 	GetToken(names.ModelTag, names.Tag) (string, error)
+
+	// ListOffers returns the application offers matching any one of the filter terms.
+	ListOffers(filter ...crossmodel.OfferedApplicationFilter) ([]crossmodel.OfferedApplication, error)
 }
 
 // Relation provides access a relation in global state.
@@ -137,6 +141,10 @@ type RemoteApplication interface {
 	// SourceModel returns the tag of the model hosting the remote application.
 	SourceModel() names.ModelTag
 
+	// Registered returns the application is created
+	// from a registration operation by a consuming model.
+	Registered() bool
+
 	// URL returns the remote application URL, at which it is offered.
 	URL() (string, bool)
 
@@ -158,6 +166,11 @@ type Application interface {
 
 type stateShim struct {
 	*state.State
+}
+
+func (st stateShim) ListOffers(filter ...crossmodel.OfferedApplicationFilter) ([]crossmodel.OfferedApplication, error) {
+	oa := state.NewOfferedApplications(st.State)
+	return oa.ListOffers(filter...)
 }
 
 func (st stateShim) ExportLocalEntity(entity names.Tag) (string, error) {

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -36,6 +36,7 @@ type remoteApplicationDoc struct {
 	Endpoints       []remoteEndpointDoc `bson:"endpoints"`
 	Life            Life                `bson:"life"`
 	RelationCount   int                 `bson:"relationcount"`
+	Registered      bool                `bson:"registered"`
 }
 
 // remoteEndpointDoc represents the internal state of a remote application endpoint in MongoDB.
@@ -74,6 +75,12 @@ func (s *RemoteApplication) IsRemote() bool {
 // SourceModel returns the tag of the model to which the application belongs.
 func (s *RemoteApplication) SourceModel() names.ModelTag {
 	return names.NewModelTag(s.doc.SourceModelUUID)
+}
+
+// Registered returns the application is created
+// from a registration operation by a consuming model.
+func (s *RemoteApplication) Registered() bool {
+	return s.doc.Registered
 }
 
 // Name returns the application name.
@@ -324,6 +331,10 @@ type AddRemoteApplicationParams struct {
 
 	// Endpoints describes the endpoints that the remote application implements.
 	Endpoints []charm.Relation
+
+	// Registered is true when a remote application is created as a result
+	// of a registration operation from a remote model.
+	Registered bool
 }
 
 // Validate returns an error if there's a problem with the
@@ -369,6 +380,7 @@ func (st *State) AddRemoteApplication(args AddRemoteApplicationParams) (_ *Remot
 		SourceModelUUID: args.SourceModel.Id(),
 		URL:             args.URL,
 		Life:            Alive,
+		Registered:      args.Registered,
 	}
 	eps := make([]remoteEndpointDoc, len(args.Endpoints))
 	for i, ep := range args.Endpoints {

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -264,10 +264,23 @@ func (s *remoteApplicationSuite) TestAddRemoteApplication(c *gc.C) {
 		Name: "foo", URL: "local:/u/me/foo", SourceModel: s.State.ModelTag()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(foo.Name(), gc.Equals, "foo")
+	c.Assert(foo.Registered(), jc.IsFalse)
 	foo, err = s.State.RemoteApplication("foo")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(foo.Name(), gc.Equals, "foo")
+	c.Assert(foo.Registered(), jc.IsFalse)
 	c.Assert(foo.SourceModel().Id(), gc.Equals, s.State.ModelTag().Id())
+}
+
+func (s *remoteApplicationSuite) TestAddRemoteApplicationRegistered(c *gc.C) {
+	foo, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name: "foo", URL: "local:/u/me/foo", SourceModel: s.State.ModelTag(), Registered: true})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(foo.Registered(), jc.IsTrue)
+	foo, err = s.State.RemoteApplication("foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(foo.Name(), gc.Equals, "foo")
+	c.Assert(foo.Registered(), jc.IsTrue)
 }
 
 func (s *remoteApplicationSuite) TestAddRemoteRelationWrongScope(c *gc.C) {

--- a/worker/remoterelations/shim.go
+++ b/worker/remoterelations/shim.go
@@ -81,5 +81,5 @@ type publisherCloser struct {
 }
 
 func (p *publisherCloser) Close() error {
-	return p.Close()
+	return p.conn.Close()
 }


### PR DESCRIPTION
The remote relations worker will notice a new relation to a report app in a consuming model and notify the offering model that the relation has been created. It does this by registering the relation on the offering model.

The remote relations facade Relations() result was changed to supply the necessary data.