### PR TITLE
Remove juju-mongo in manual clean-up

### DIFF
--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -242,12 +242,13 @@ touch %s
 # If jujud is running, we then wait for a while for it to stop.
 stopped=0
 if pkill -%d jujud; then
-    for i in ` + "`seq 1 30`" + `; do
+    for i in {1..30}; do
         if pgrep jujud > /dev/null ; then
             sleep 1
         else
             echo "jujud stopped"
             stopped=1
+            logger --id jujud stopped on attempt $i
             break
         fi
     done
@@ -256,7 +257,10 @@ if [ $stopped -ne 1 ]; then
     # If jujud didn't stop nicely, we kill it hard here.
     %spkill -9 jujud
     service %s stop
+    logger --id killed jujud and stopped %s
 fi
+apt-get -y purge juju-mongo*
+apt-get -y autoremove
 rm -f /etc/init/juju*
 rm -f /etc/systemd/system{,/multi-user.target.wants}/juju*
 rm -fr %s %s
@@ -282,6 +286,7 @@ exit 0
 		)),
 		terminationworker.TerminationSignal,
 		diagnostics,
+		mongo.ServiceName,
 		mongo.ServiceName,
 		utils.ShQuote(agent.DefaultPaths.DataDir),
 		utils.ShQuote(agent.DefaultPaths.LogDir),

--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -87,12 +87,13 @@ touch '/var/lib/juju/uninstall-agent'
 # If jujud is running, we then wait for a while for it to stop.
 stopped=0
 if pkill -6 jujud; then
-    for i in `+"`seq 1 30`"+`; do
+    for i in {1..30}; do
         if pgrep jujud > /dev/null ; then
             sleep 1
         else
             echo "jujud stopped"
             stopped=1
+            logger --id jujud stopped on attempt $i
             break
         fi
     done
@@ -101,7 +102,10 @@ if [ $stopped -ne 1 ]; then
     # If jujud didn't stop nicely, we kill it hard here.
     pkill -9 jujud
     service juju-db stop
+    logger --id killed jujud and stopped juju-db
 fi
+apt-get -y purge juju-mongo*
+apt-get -y autoremove
 rm -f /etc/init/juju*
 rm -f /etc/systemd/system{,/multi-user.target.wants}/juju*
 rm -fr '/var/lib/juju' '/var/log/juju'


### PR DESCRIPTION
In the manual provider bootstrap instance clean-up script, remove all
juju-mongo packages after juju-db has been stopped.

QA steps:
 * `bootstrap` with the manual provider
 * `destroy-controller`
 * On the bootstrap instance
   - `dpkg -l juju-mongo*` to see that none of the juju-mongo packages is still installed
   - `grep jujud.*stopped /var/log/syslog` to see some new logger output (hopefully the success case)