### PR TITLE
Implement the publish method on the remote relations facade

### DIFF
--- a/api/remoterelations/remoterelations.go
+++ b/api/remoterelations/remoterelations.go
@@ -84,6 +84,26 @@ func (c *Client) ExportEntities(tags []names.Tag) ([]params.RemoteEntityIdResult
 	return results.Results, nil
 }
 
+// GetToken returns the token associated with the entity with the given tag for the specified model.
+func (c *Client) GetToken(sourceModelUUID string, tag names.Tag) (string, error) {
+	args := params.GetTokenArgs{Args: []params.GetTokenArg{
+		{ModelTag: names.NewModelTag(sourceModelUUID).String(), Tag: tag.String()}},
+	}
+	var results params.StringResults
+	err := c.facade.FacadeCall("GetTokens", args, &results)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		return "", errors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return "", errors.Trace(result.Error)
+	}
+	return result.Result, nil
+}
+
 // RegisterRemoteRelation sets up the local model to participate in the specified relation.
 func (c *Client) RegisterRemoteRelation(rel params.RegisterRemoteRelation) error {
 	args := params.RegisterRemoteRelations{Relations: []params.RegisterRemoteRelation{rel}}

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -285,6 +285,20 @@ type RemoteApplication struct {
 	Registered bool `json:"registered"`
 }
 
+// GetTokenArgs holds the arguments to a GetTokens API call.
+type GetTokenArgs struct {
+	Args []GetTokenArg
+}
+
+// GetTokenArg holds the model and entity for which we want a token.
+type GetTokenArg struct {
+	// ModelTag is the tag of the model hosting the entity.
+	ModelTag string `json:"model-tag"`
+
+	// Tag is the tag of the entity for which we want the token.
+	Tag string `json:"tag"`
+}
+
 // RemoteApplicationResult holds a remote application and an error.
 type RemoteApplicationResult struct {
 	Result *RemoteApplication `json:"result,omitempty"`
@@ -385,7 +399,7 @@ type RemoteRelationChange struct {
 // which has occurred in a remote model.
 type RemoteRelationUnitChange struct {
 	// UnitId uniquely identifies the remote unit.
-	UnitId RemoteEntityId `json:"unit-id"`
+	UnitId int `json:"unit-id"`
 
 	// Settings is the current settings for the relation unit.
 	Settings map[string]interface{} `json:"settings,omitempty"`
@@ -400,12 +414,15 @@ type RemoteRelationChangeEvent struct {
 	// Life is the current lifecycle state of the relation.
 	Life Life `json:"life"`
 
+	// ApplicationId is the application id on the remote model.
+	ApplicationId RemoteEntityId `json:"application-id"`
+
 	// ChangedUnits maps unit tokens to relation unit changes.
 	ChangedUnits []RemoteRelationUnitChange `json:"changed-units,omitempty"`
 
-	// DepartedUnits contains the remote ids of units that have departed
+	// DepartedUnits contains the ids of units that have departed
 	// the relation since the last change.
-	DepartedUnits []RemoteEntityId `json:"departed-units,omitempty"`
+	DepartedUnits []int `json:"departed-units,omitempty"`
 }
 
 // RegisterRemoteRelation holds attributes used to register a remote relation.

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -122,6 +122,14 @@ func (m *mockRelationsFacade) ExportEntities(entities []names.Tag) ([]params.Rem
 	return result, nil
 }
 
+func (m *mockRelationsFacade) GetToken(modelUUID string, entity names.Tag) (string, error) {
+	m.stub.MethodCall(m, "GetToken", modelUUID, entity)
+	if err := m.stub.NextErr(); err != nil {
+		return "", err
+	}
+	return "token-" + entity.Id(), nil
+}
+
 func (m *mockRelationsFacade) RelationUnitSettings(relationUnits []params.RelationUnit) ([]params.SettingsResult, error) {
 	m.stub.MethodCall(m, "RelationUnitSettings", relationUnits)
 	if err := m.stub.NextErr(); err != nil {


### PR DESCRIPTION
The remote relations facade has the publish method implemented. Also adds a required GetToken() API that the worker uses.

QA:
bootstrap
juju switch controller
juju deploy mysql
juju offer mysql:db local:/u/ian/mysql
juju switch default
juju deploy wordpress
juju expose wordpress
juju relate wordpress local:/u/ian/mysql

profit
