### PR TITLE
migrations: don't start model workers while a model is importing

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -736,7 +736,7 @@ func serverError(err error) error {
 }
 
 func (srv *Server) processModelRemovals() error {
-	w := srv.state.WatchModels()
+	w := srv.state.WatchModelLives()
 	defer w.Stop()
 	for {
 		select {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -965,7 +965,7 @@ func (a *MachineAgent) startStateWorkers(st *state.State) (worker.Worker, error)
 			a.startWorkerAfterUpgrade(runner, "model worker manager", func() (worker.Worker, error) {
 				w, err := modelworkermanager.New(modelworkermanager.Config{
 					ControllerUUID: st.ControllerUUID(),
-					Backend:        st,
+					Backend:        modelworkermanager.BackendShim{st},
 					NewWorker:      a.startModelWorkers,
 					ErrorDelay:     worker.RestartDelay,
 				})

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -655,7 +655,7 @@ func (s *ActionSuite) TestMergeIds(c *gc.C) {
 		expected := sliceify("", test.expected)
 
 		c.Log(fmt.Sprintf("test number %d %#v", ix, test))
-		err := state.WatcherMergeIds(s.State, &changes, updates, state.ActionNotificationIdToActionId)
+		err := state.WatcherMergeIds(s.State, &changes, updates, state.MakeActionIdConverter(s.State))
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(changes, jc.SameContents, expected)
 	}
@@ -675,7 +675,7 @@ func (s *ActionSuite) TestMergeIdsErrors(c *gc.C) {
 	for _, test := range tests {
 		changes, updates := []string{}, map[interface{}]bool{}
 		updates[test.key] = true
-		err := state.WatcherMergeIds(s.State, &changes, updates, state.ActionNotificationIdToActionId)
+		err := state.WatcherMergeIds(s.State, &changes, updates, state.MakeActionIdConverter(s.State))
 		c.Assert(err, gc.ErrorMatches, "id is not of type string, got "+test.name)
 	}
 }

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -289,7 +289,7 @@ func CheckUserExists(st *State, name string) (bool, error) {
 	return st.checkUserExists(name)
 }
 
-func WatcherMergeIds(st *State, changeset *[]string, updates map[interface{}]bool, idconv func(string) string) error {
+func WatcherMergeIds(st *State, changeset *[]string, updates map[interface{}]bool, idconv func(string) (string, error)) error {
 	return mergeIds(st, changeset, updates, idconv)
 }
 
@@ -466,7 +466,15 @@ func IsManagerMachineError(err error) bool {
 	return errors.Cause(err) == managerMachineError
 }
 
-var ActionNotificationIdToActionId = actionNotificationIdToActionId
+func MakeActionIdConverter(st *State) func(string) (string, error) {
+	return func(id string) (string, error) {
+		id, err := st.strictLocalID(id)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		return actionNotificationIdToActionId(id), err
+	}
+}
 
 func UpdateModelUserLastConnection(st *State, e permission.UserAccess, when time.Time) error {
 	return st.updateLastModelConnection(e.UserTag, when)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2000,7 +2000,7 @@ func (s *StateSuite) TestWatchModelsBulkEvents(c *gc.C) {
 
 func (s *StateSuite) TestWatchModelsLifecycle(c *gc.C) {
 	// Initial event reports the controller model.
-	w := s.State.WatchModels()
+	w := s.State.WatchModelLives()
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, s.State, w)
 	wc.AssertChange(s.State.ModelUUID())

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -214,9 +214,22 @@ func collFactory(st *State, collName string) func() (mongo.Collection, func()) {
 	}
 }
 
-// WatchModels returns a StringsWatcher that notifies of changes
-// to the lifecycles of all models.
+// WatchModels returns a StringsWatcher that notifies of changes to
+// any models. If a model is removed this *won't* signal that the
+// model has gone away - it's based on a collectionWatcher which omits
+// these events.
 func (st *State) WatchModels() StringsWatcher {
+	return newcollectionWatcher(st, colWCfg{
+		col:    modelsC,
+		global: true,
+	})
+}
+
+// WatchModelLives returns a StringsWatcher that notifies of changes
+// to any model life values. The most important difference between
+// this and WatchModels is that this will signal one last time if a
+// model is removed.
+func (st *State) WatchModelLives() StringsWatcher {
 	return newLifecycleWatcher(st, modelsC, nil, nil, nil)
 }
 
@@ -1957,23 +1970,34 @@ type colWCfg struct {
 	col    string
 	filter func(interface{}) bool
 	idconv func(string) string
+
+	// If global is true the watcher won't be limited to this model.
+	global bool
 }
 
 // newcollectionWatcher starts and returns a new StringsWatcher configured
 // with the given collection and filter function
 func newcollectionWatcher(st *State, cfg colWCfg) StringsWatcher {
-	// Always ensure that there is at least filtering on the
-	// model in place.
-	backstop := isLocalID(st)
-	if cfg.filter == nil {
-		cfg.filter = backstop
-	} else {
-		innerFilter := cfg.filter
-		cfg.filter = func(id interface{}) bool {
-			if !backstop(id) {
-				return false
+	if cfg.global {
+		if cfg.filter == nil {
+			cfg.filter = func(x interface{}) bool {
+				return true
 			}
-			return innerFilter(id)
+		}
+	} else {
+		// Always ensure that there is at least filtering on the
+		// model in place.
+		backstop := isLocalID(st)
+		if cfg.filter == nil {
+			cfg.filter = backstop
+		} else {
+			innerFilter := cfg.filter
+			cfg.filter = func(id interface{}) bool {
+				if !backstop(id) {
+					return false
+				}
+				return innerFilter(id)
+			}
 		}
 	}
 
@@ -2099,25 +2123,37 @@ func (w *collectionWatcher) initial() ([]string, error) {
 // Additionally, mergeIds strips the model UUID prefix from the id
 // before emitting it through the watcher.
 func (w *collectionWatcher) mergeIds(changes *[]string, updates map[interface{}]bool) error {
-	return mergeIds(w.st, changes, updates, w.idconv)
+	return mergeIds(w.st, changes, updates, w.convertId)
 }
 
-func mergeIds(st modelBackend, changes *[]string, updates map[interface{}]bool, idconv func(string) string) error {
+func (w *collectionWatcher) convertId(id string) (string, error) {
+	// Strip off the env UUID prefix.
+	if w.colWCfg.global {
+		id = w.st.localID(id)
+	} else {
+		// We only expect ids for a single model.
+		var err error
+		id, err = w.st.strictLocalID(id)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+	}
+	if w.idconv != nil {
+		id = w.idconv(id)
+	}
+	return id, nil
+}
+
+func mergeIds(st modelBackend, changes *[]string, updates map[interface{}]bool, idconv func(string) (string, error)) error {
 	for val, idExists := range updates {
 		id, ok := val.(string)
 		if !ok {
 			return errors.Errorf("id is not of type string, got %T", val)
 		}
 
-		// Strip off the env UUID prefix. We only expect ids for a
-		// single model.
-		id, err := st.strictLocalID(id)
+		id, err := idconv(id)
 		if err != nil {
 			return errors.Annotatef(err, "collection watcher")
-		}
-
-		if idconv != nil {
-			id = idconv(id)
 		}
 
 		chIx, idAlreadyInChangeset := indexOf(id, *changes)

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2104,7 +2104,10 @@ func (w *collectionWatcher) initial() ([]string, error) {
 	iter := coll.Find(nil).Iter()
 	for iter.Next(&doc) {
 		if w.filter == nil || w.filter(doc.DocId) {
-			id := w.st.localID(doc.DocId)
+			id := doc.DocId
+			if !w.colWCfg.global {
+				id = w.st.localID(id)
+			}
 			if w.idconv != nil {
 				id = w.idconv(id)
 			}
@@ -2127,10 +2130,8 @@ func (w *collectionWatcher) mergeIds(changes *[]string, updates map[interface{}]
 }
 
 func (w *collectionWatcher) convertId(id string) (string, error) {
-	// Strip off the env UUID prefix.
-	if w.colWCfg.global {
-		id = w.st.localID(id)
-	} else {
+	if !w.colWCfg.global {
+		// Strip off the env UUID prefix.
 		// We only expect ids for a single model.
 		var err error
 		id, err = w.st.strictLocalID(id)

--- a/worker/modelworkermanager/shim.go
+++ b/worker/modelworkermanager/shim.go
@@ -1,0 +1,23 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelworkermanager
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/state"
+)
+
+type BackendShim struct {
+	*state.State
+}
+
+func (s BackendShim) GetModel(tag names.ModelTag) (BackendModel, error) {
+	m, err := s.State.GetModel(tag)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return m, nil
+}


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/juju/+bug/1646310

Starting the migration master while the model was being imported back
into a controller that it had previously migrated out of caused it to
uninstall itself from the engine (thinking that it was finished
processing the old migration), which blocked any workers that depended
on `ifNotMigrating`. To fix this we wait until the model `MigrationMode` 
has changed to `MigrationModeNone` - this means the watcher needs to 
signal on any changes to models, rather than just life.

Add a `global` flag to the `collectionWatcher` config - this lets the watcher return
ids for any model, rather than just the current one.

The apiserver code to remove state objects from the pool still needs to
watch life specifically. If the model becomes Dead and is then
removed within the event coalescence time then the collection watcher
won't report any event, but a lifecycle watcher will.

QA steps:
* bootstrap two controllers A and B
* create a model m in A with an application deployed
* migrate it to B
* migrate it back to A
* check the debug log has no dependency engine messages saying "fortress operation aborted" - these show the workers that are prevented from running because the migration master has exited
* migrate it back to B - this would have failed before this fix, because the previous migration left the model workers in a bad state

