### PR TITLE
Restrict the api calls available to users during a model's migration.

### DIFF
--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -120,6 +120,13 @@ func TestingUpgradingRoot(st *state.State) rpc.Root {
 	return restrictRoot(r, upgradeMethodsOnly)
 }
 
+// TestingMigratingRoot returns a resricted srvRoot in a migration
+// scenario.
+func TestingMigratingRoot(st *state.State) rpc.Root {
+	r := TestingAPIRoot(st)
+	return restrictRoot(r, migrationClientMethodsOnly)
+}
+
 // TestingControllerOnlyRoot returns a restricted srvRoot as if
 // logged in to the root of the API path.
 func TestingControllerOnlyRoot() rpc.Root {

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -13,6 +13,9 @@ import (
 // UpgradeInProgressError signifies an upgrade is in progress.
 var UpgradeInProgressError = errors.New(CodeUpgradeInProgress)
 
+// MigrationInProgressError signifies a migration is in progress.
+var MigrationInProgressError = errors.New(CodeMigrationInProgress)
+
 // Error is the type of error returned by any call to the state API.
 type Error struct {
 	Message string     `json:"message"`
@@ -79,6 +82,7 @@ const (
 	CodeNotImplemented            = "not implemented" // asserted to match rpc.codeNotImplemented in rpc/rpc_test.go
 	CodeAlreadyExists             = "already exists"
 	CodeUpgradeInProgress         = "upgrade in progress"
+	CodeMigrationInProgress       = "model migration in progress"
 	CodeActionNotAvailable        = "action no longer available"
 	CodeOperationBlocked          = "operation is blocked"
 	CodeLeadershipClaimDenied     = "leadership claim denied"

--- a/apiserver/restrict_migrations.go
+++ b/apiserver/restrict_migrations.go
@@ -1,0 +1,44 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"github.com/juju/utils/set"
+
+	"github.com/juju/juju/apiserver/params"
+)
+
+func migrationClientMethodsOnly(facadeName, methodName string) error {
+	if !IsMethodAllowedDuringMigration(facadeName, methodName) {
+		return params.MigrationInProgressError
+	}
+	return nil
+}
+
+func IsMethodAllowedDuringMigration(facadeName, methodName string) bool {
+	methods, ok := allowedMethodsDuringMigration[facadeName]
+	if !ok {
+		return false
+	}
+	return methods.Contains(methodName)
+}
+
+// allowedMethodsDuringUpgrades stores api calls that are not blocked for user
+// logins during the migration of the model from one controller to another.
+var allowedMethodsDuringMigration = map[string]set.Strings{
+	"Client": set.NewStrings(
+		"FullStatus", // for "juju status"
+	),
+	"SSHClient": set.NewStrings( // allow all SSH client related calls
+		"PublicAddress",
+		"PrivateAddress",
+		"BestAPIVersion",
+		"AllAddresses",
+		"PublicKeys",
+		"Proxy",
+	),
+	"Pinger": set.NewStrings(
+		"Ping",
+	),
+}

--- a/apiserver/restrict_migrations_test.go
+++ b/apiserver/restrict_migrations_test.go
@@ -1,0 +1,40 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/testing"
+)
+
+type restrictMigrationsSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&restrictMigrationsSuite{})
+
+func (r *restrictMigrationsSuite) TestAllowedMethods(c *gc.C) {
+	root := apiserver.TestingMigratingRoot(nil)
+	checkAllowed := func(facade, method string) {
+		caller, err := root.FindMethod(facade, 1, method)
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(caller, gc.NotNil)
+	}
+	checkAllowed("Client", "FullStatus")
+	checkAllowed("SSHClient", "PublicAddress")
+	checkAllowed("SSHClient", "Proxy")
+	checkAllowed("Pinger", "Ping")
+}
+
+func (r *restrictMigrationsSuite) TestFindDisallowedMethod(c *gc.C) {
+	root := apiserver.TestingMigratingRoot(nil)
+	caller, err := root.FindMethod("Client", 1, "ModelSet")
+	c.Assert(errors.Cause(err), gc.Equals, params.MigrationInProgressError)
+	c.Assert(caller, gc.IsNil)
+}


### PR DESCRIPTION
## QA

* bootstrap two controllers, and add a model in the first to move
* in one terminal run 'watch -n1 juju status'
* in another terminal run 'watch -n1 juju model-config logging-config=juju=debug'
* initiate the migration for the model

The second command is a write operation, even if nothing is actually changing. The command shows an error with "model migration in progress" when the model is marked as exporting.
