### PR TITLE
Support migration of unit resources

### DIFF
--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -340,9 +340,18 @@ func convertAppResource(in params.SerializedModelResource) (migration.Serialized
 	if err != nil {
 		return empty, errors.Annotate(err, "charmstore revision")
 	}
+	unitRevs := make(map[string]resource.Resource)
+	for unitName, inUnitRev := range in.UnitRevisions {
+		unitRev, err := convertResourceRevision(in.Application, in.Name, inUnitRev)
+		if err != nil {
+			return empty, errors.Annotate(err, "unit revision")
+		}
+		unitRevs[unitName] = unitRev
+	}
 	return migration.SerializedModelResource{
 		ApplicationRevision: appRev,
 		CharmStoreRevision:  csRev,
+		UnitRevisions:       unitRevs,
 	}, nil
 }
 

--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -192,34 +192,12 @@ func (c *Client) Export() (migration.SerializedModel, error) {
 
 // OpenResource downloads the named resource for an application.
 func (c *Client) OpenResource(application, name string) (io.ReadCloser, error) {
-	uri := fmt.Sprintf("/applications/%s/resources/%s", application, name)
-	r, err := c.openResource(uri)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return r, nil
-}
-
-// OpenUnitResource downloads the named resource for a specific
-// unit. The revision of a resource in use by a unit might be
-// different from the application.
-func (c *Client) OpenUnitResource(unit, name string) (io.ReadCloser, error) {
-	// It's awful that the unit tag string is part of the URL but
-	// what's done is done and it's too hard to change now.
-	unitTag := names.NewUnitTag(unit)
-	uri := fmt.Sprintf("/units/%s/resources/%s", unitTag.String(), name)
-	r, err := c.openResource(uri)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return r, nil
-}
-
-func (c *Client) openResource(uri string) (io.ReadCloser, error) {
 	httpClient, err := c.httpClientFactory()
 	if err != nil {
 		return nil, errors.Annotate(err, "unable to create HTTP client")
 	}
+
+	uri := fmt.Sprintf("/applications/%s/resources/%s", application, name)
 	var resp *http.Response
 	if err := httpClient.Get(uri, &resp); err != nil {
 		return nil, errors.Annotate(err, "unable to retrieve resource")

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -216,9 +216,11 @@ func (s *ClientSuite) TestExport(c *gc.C) {
 	fpHash := charmresource.NewFingerprintHash()
 	appFp := fpHash.Fingerprint()
 	csFp := fpHash.Fingerprint()
+	unitFp := fpHash.Fingerprint()
 
 	appTs := time.Now()
 	csTs := appTs.Add(time.Hour)
+	unitTs := appTs.Add(time.Hour)
 
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		stub.AddCall(objType+"."+request, id, arg)
@@ -254,6 +256,19 @@ func (s *ClientSuite) TestExport(c *gc.C) {
 					Size:           321,
 					Timestamp:      csTs,
 					Username:       "xena",
+				},
+				UnitRevisions: map[string]params.SerializedModelResourceRevision{
+					"fooapp/0": params.SerializedModelResourceRevision{
+						Revision:       1,
+						Type:           "file",
+						Path:           "blink.tar.gz",
+						Description:    "bo knows",
+						Origin:         "store",
+						FingerprintHex: unitFp.Hex(),
+						Size:           222,
+						Timestamp:      unitTs,
+						Username:       "bambam",
+					},
 				},
 			}},
 		}
@@ -305,6 +320,25 @@ func (s *ClientSuite) TestExport(c *gc.C) {
 				ApplicationID: "fooapp",
 				Username:      "xena",
 				Timestamp:     csTs,
+			},
+			UnitRevisions: map[string]resource.Resource{
+				"fooapp/0": resource.Resource{
+					Resource: charmresource.Resource{
+						Meta: charmresource.Meta{
+							Name:        "bin",
+							Type:        charmresource.TypeFile,
+							Path:        "blink.tar.gz",
+							Description: "bo knows",
+						},
+						Origin:      charmresource.OriginStore,
+						Revision:    1,
+						Fingerprint: unitFp,
+						Size:        222,
+					},
+					ApplicationID: "fooapp",
+					Username:      "bambam",
+					Timestamp:     unitTs,
+				},
 			},
 		}},
 	})

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -379,15 +379,6 @@ func (s *ClientSuite) TestOpenResource(c *gc.C) {
 	c.Check(doer.url, gc.Equals, "/applications/app/resources/blob")
 }
 
-func (s *ClientSuite) TestOpenUnitResource(c *gc.C) {
-	client, doer := setupFakeHTTP()
-	r, err := client.OpenUnitResource("app/2", "blob")
-	c.Assert(err, jc.ErrorIsNil)
-	checkReader(c, r, "resourceful")
-	c.Check(doer.method, gc.Equals, "GET")
-	c.Check(doer.url, gc.Equals, "/units/unit-app-2/resources/blob") // Yuck
-}
-
 func (s *ClientSuite) TestReap(c *gc.C) {
 	var stub jujutesting.Stub
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {

--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -106,10 +106,31 @@ func (c *Client) UploadTools(modelUUID string, r io.ReadSeeker, vers version.Bin
 	return resp.ToolsList, nil
 }
 
-// UploadResource uploads a migration to the resource migration endpoint.
+// UploadResource uploads a resource to the migration endpoint.
 func (c *Client) UploadResource(modelUUID string, res resource.Resource, r io.ReadSeeker) error {
-	args := url.Values{}
+	args := makeResourceArgs(res)
 	args.Add("application", res.ApplicationID)
+	err := c.resourceUpload(modelUUID, args, r)
+	return errors.Trace(err)
+}
+
+// UploadUnitResource uploads a unit resource to the resource migration endpoint.
+func (c *Client) UploadUnitResource(modelUUID, unit string, res resource.Resource, r io.ReadSeeker) error {
+	args := makeResourceArgs(res)
+	args.Add("unit", unit)
+	err := c.resourceUpload(modelUUID, args, r)
+	return errors.Trace(err)
+}
+
+func (c *Client) resourceUpload(modelUUID string, args url.Values, r io.ReadSeeker) error {
+	uri := "/migrate/resources?" + args.Encode()
+	contentType := "application/octet-stream"
+	err := c.httpPost(modelUUID, r, uri, contentType, nil)
+	return errors.Trace(err)
+}
+
+func makeResourceArgs(res resource.Resource) url.Values {
+	args := url.Values{}
 	args.Add("user", res.Username)
 	args.Add("name", res.Name)
 	args.Add("type", res.Type.String())
@@ -119,10 +140,7 @@ func (c *Client) UploadResource(modelUUID string, res resource.Resource, r io.Re
 	args.Add("revision", fmt.Sprintf("%d", res.Revision))
 	args.Add("size", fmt.Sprintf("%d", res.Size))
 	args.Add("fingerprint", res.Fingerprint.Hex())
-	uri := "/migrate/resources?" + args.Encode()
-	contentType := "application/octet-stream"
-	err := c.httpPost(modelUUID, r, uri, contentType, nil)
-	return errors.Trace(err)
+	return args
 }
 
 func (c *Client) httpPost(modelUUID string, content io.ReadSeeker, endpoint, contentType string, response interface{}) error {

--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -110,19 +110,19 @@ func (c *Client) UploadTools(modelUUID string, r io.ReadSeeker, vers version.Bin
 func (c *Client) UploadResource(modelUUID string, res resource.Resource, r io.ReadSeeker) error {
 	args := makeResourceArgs(res)
 	args.Add("application", res.ApplicationID)
-	err := c.resourceUpload(modelUUID, args, r)
+	err := c.resourcePost(modelUUID, args, r)
 	return errors.Trace(err)
 }
 
-// UploadUnitResource uploads a unit resource to the resource migration endpoint.
-func (c *Client) UploadUnitResource(modelUUID, unit string, res resource.Resource, r io.ReadSeeker) error {
+// SetUnitResource sets the metadata for a particular unit resource.
+func (c *Client) SetUnitResource(modelUUID, unit string, res resource.Resource) error {
 	args := makeResourceArgs(res)
 	args.Add("unit", unit)
-	err := c.resourceUpload(modelUUID, args, r)
+	err := c.resourcePost(modelUUID, args, strings.NewReader(""))
 	return errors.Trace(err)
 }
 
-func (c *Client) resourceUpload(modelUUID string, args url.Values, r io.ReadSeeker) error {
+func (c *Client) resourcePost(modelUUID string, args url.Values, r io.ReadSeeker) error {
 	uri := "/migrate/resources?" + args.Encode()
 	contentType := "application/octet-stream"
 	err := c.httpPost(modelUUID, r, uri, contentType, nil)

--- a/api/migrationtarget/client_test.go
+++ b/api/migrationtarget/client_test.go
@@ -207,7 +207,7 @@ func (s *ClientSuite) TestUploadResource(c *gc.C) {
 	c.Assert(doer.body, gc.Equals, resourceBody)
 }
 
-func (s *ClientSuite) TestUploadUnitResource(c *gc.C) {
+func (s *ClientSuite) TestSetUnitResource(c *gc.C) {
 	const resourceBody = "resourceful"
 	doer := newFakeDoer(c, "")
 	caller := &fakeHTTPCaller{
@@ -221,12 +221,12 @@ func (s *ClientSuite) TestUploadUnitResource(c *gc.C) {
 	res.Size = 123
 	res.Username = "bob"
 	res.Fingerprint = fp
-	err := client.UploadUnitResource("uuid", "app/0", res, strings.NewReader(resourceBody))
+	err := client.SetUnitResource("uuid", "app/0", res)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(doer.method, gc.Equals, "POST")
 	expectedURL := fmt.Sprintf("/migrate/resources?description=blob+description&fingerprint=%s&name=blob&origin=upload&path=blob.tgz&revision=2&size=123&type=file&unit=app%%2F0&user=bob", fp.Hex())
 	c.Assert(doer.url, gc.Equals, expectedURL)
-	c.Assert(doer.body, gc.Equals, resourceBody)
+	c.Assert(doer.body, gc.Equals, "")
 }
 
 func (s *ClientSuite) AssertModelCall(c *gc.C, stub *jujutesting.Stub, tag names.ModelTag, call string, err error, expectError bool) {

--- a/apiserver/migrationmaster/facade.go
+++ b/apiserver/migrationmaster/facade.go
@@ -315,8 +315,24 @@ func getUsedResources(model description.Model) []params.SerializedModelResource 
 	var out []params.SerializedModelResource
 	for _, app := range model.Applications() {
 		for _, resource := range app.Resources() {
-			out = append(out, resourceToSerialized(app.Name(), resource))
+			outRes := resourceToSerialized(app.Name(), resource)
+
+			// Hunt through the application's units and look for
+			// revisions of this resource. This is particularly
+			// efficient or clever but will be fine even with 1000's
+			// of units and 10's of resources.
+			outRes.UnitRevisions = make(map[string]params.SerializedModelResourceRevision)
+			for _, unit := range app.Units() {
+				for _, unitResource := range unit.Resources() {
+					if unitResource.Name() == resource.Name() {
+						outRes.UnitRevisions[unit.Name()] = revisionToSerialized(unitResource.Revision())
+					}
+				}
+			}
+
+			out = append(out, outRes)
 		}
+
 	}
 	return out
 }
@@ -327,7 +343,6 @@ func resourceToSerialized(app string, desc description.Resource) params.Serializ
 		Name:                desc.Name(),
 		ApplicationRevision: revisionToSerialized(desc.ApplicationRevision()),
 		CharmStoreRevision:  revisionToSerialized(desc.CharmStoreRevision()),
-		// TODO(menn0) - unit revisions
 	}
 }
 

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -94,10 +94,11 @@ type SerializedModelTools struct {
 // SerializedModelResource holds the details for a single resource for
 // an application in a serialized model.
 type SerializedModelResource struct {
-	Application         string                          `json:"application"`
-	Name                string                          `json:"name"`
-	ApplicationRevision SerializedModelResourceRevision `json:"application-revision"`
-	CharmStoreRevision  SerializedModelResourceRevision `json:"charmstore-revision"`
+	Application         string                                     `json:"application"`
+	Name                string                                     `json:"name"`
+	ApplicationRevision SerializedModelResourceRevision            `json:"application-revision"`
+	CharmStoreRevision  SerializedModelResourceRevision            `json:"charmstore-revision"`
+	UnitRevisions       map[string]SerializedModelResourceRevision `json:"unit-revisions"`
 }
 
 // SerializedModelResourceRevision holds the details for a single

--- a/apiserver/resources.go
+++ b/apiserver/resources.go
@@ -4,6 +4,7 @@
 package apiserver
 
 import (
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -77,15 +78,21 @@ func (h *resourceUploadHandler) processPost(r *http.Request, st *state.State) (r
 		return empty, errors.Trace(err)
 	}
 
-	setter := rSt.SetResource
-	if isUnit {
-		setter = rSt.SetUnitResource
-	}
-	outRes, err := setter(target, userID, res, r.Body)
+	outRes, err := setResource(isUnit, target, userID, res, r.Body, rSt)
 	if err != nil {
 		return empty, errors.Annotate(err, "resource upload failed")
 	}
 	return outRes, nil
+}
+
+func setResource(isUnit bool, target, user string, res charmresource.Resource, r io.Reader, rSt state.Resources) (
+	resource.Resource, error,
+) {
+	if isUnit {
+		return rSt.SetUnitResource(target, user, res)
+	}
+	return rSt.SetResource(target, user, res, r)
+
 }
 
 func getUploadTarget(query url.Values) (string, bool, error) {

--- a/component/all/resource.go
+++ b/component/all/resource.go
@@ -210,9 +210,7 @@ func (r resources) registerHookContextFacade() {
 func (r resources) registerUnitDownloadEndpoint() {
 	common.RegisterAPIModelEndpoint(privateapi.HTTPEndpointPattern, apihttp.HandlerSpec{
 		Constraints: apihttp.HandlerConstraints{
-			// Machines are allowed too so that unit resources can be
-			// retrieved for model migrations.
-			AuthKinds:           []string{names.UnitTagKind, names.MachineTagKind},
+			AuthKinds:           []string{names.UnitTagKind},
 			StrictValidation:    true,
 			ControllerModelOnly: false,
 		},

--- a/component/all/resource.go
+++ b/component/all/resource.go
@@ -4,7 +4,6 @@
 package all
 
 import (
-	"io"
 	"os"
 	"reflect"
 
@@ -229,16 +228,6 @@ type resourcesUnitDataStore struct {
 // ListResources implements resource/api/private/server.UnitDataStore.
 func (ds *resourcesUnitDataStore) ListResources() (resource.ServiceResources, error) {
 	return ds.resources.ListResources(ds.unit.ApplicationName())
-}
-
-// GetResource implements resource/api/private/server.UnitDataStore.
-func (ds *resourcesUnitDataStore) GetResource(name string) (resource.Resource, error) {
-	return ds.resources.GetResource(ds.unit.ApplicationName(), name)
-}
-
-// OpenResource implements resource/api/private/server.UnitDataStore.
-func (ds *resourcesUnitDataStore) OpenResource(name string) (resource.Resource, io.ReadCloser, error) {
-	return ds.resources.OpenResourceForUniter(ds.unit, name)
 }
 
 func (r resources) newHookContextFacade(st *corestate.State, unit *corestate.Unit) (interface{}, error) {

--- a/component/all/resource.go
+++ b/component/all/resource.go
@@ -210,7 +210,9 @@ func (r resources) registerHookContextFacade() {
 func (r resources) registerUnitDownloadEndpoint() {
 	common.RegisterAPIModelEndpoint(privateapi.HTTPEndpointPattern, apihttp.HandlerSpec{
 		Constraints: apihttp.HandlerConstraints{
-			AuthKinds:           []string{names.UnitTagKind},
+			// Machines are allowed too so that unit resources can be
+			// retrieved for model migrations.
+			AuthKinds:           []string{names.UnitTagKind, names.MachineTagKind},
 			StrictValidation:    true,
 			ControllerModelOnly: false,
 		},

--- a/core/migration/migration.go
+++ b/core/migration/migration.go
@@ -58,11 +58,11 @@ type SerializedModel struct {
 }
 
 // SerializedModelResource defines the resource revisions for a
-// specific application resource.
+// specific application and its units.
 type SerializedModelResource struct {
 	ApplicationRevision resource.Resource
 	CharmStoreRevision  resource.Resource
-	// TODO(menn0) - unit revisions
+	UnitRevisions       map[string]resource.Resource
 }
 
 // ModelInfo is used to report basic details about a model.

--- a/resource/state/resource_test.go
+++ b/resource/state/resource_test.go
@@ -350,26 +350,18 @@ func (s *ResourceSuite) TestSetUnitResource(c *gc.C) {
 	expected := newUploadResource(c, "spam", "spamspamspam")
 	expected.Timestamp = s.timestamp
 	chRes := expected.Resource
-	hash := chRes.Fingerprint.String()
-	path := "application-a-application/resources/spam"
-	file := &stubReader{stub: s.stub}
 	st := NewState(s.raw)
 	st.currentTimestamp = s.now
 	s.stub.ResetCalls()
 
-	res, err := st.SetUnitResource("a-application/0", "a-user", chRes, file)
+	res, err := st.SetUnitResource("a-application/0", "a-user", chRes)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c,
 		"currentTimestamp",
-		"StageResource",
-		"PutAndCheckHash",
-		"ActivateWithoutVersionInc",
 		"SetUnitResource",
 	)
-	s.stub.CheckCall(c, 1, "StageResource", expected, path)
-	s.stub.CheckCall(c, 2, "PutAndCheckHash", path, file, res.Size, hash)
-	s.stub.CheckCall(c, 4, "SetUnitResource", "a-application/0", res)
+	s.stub.CheckCall(c, 1, "SetUnitResource", "a-application/0", res)
 	c.Check(res, jc.DeepEquals, resource.Resource{
 		Resource:      chRes,
 		ID:            "a-application/" + res.Name,

--- a/resource/state/stub_test.go
+++ b/resource/state/stub_test.go
@@ -170,7 +170,6 @@ func (s *stubStagedResource) Unstage() error {
 	if err := s.stub.NextErr(); err != nil {
 		return errors.Trace(err)
 	}
-
 	return nil
 }
 
@@ -179,7 +178,14 @@ func (s *stubStagedResource) Activate() error {
 	if err := s.stub.NextErr(); err != nil {
 		return errors.Trace(err)
 	}
+	return nil
+}
 
+func (s *stubStagedResource) ActivateWithoutVersionInc() error {
+	s.stub.AddCall("ActivateWithoutVersionInc")
+	if err := s.stub.NextErr(); err != nil {
+		return errors.Trace(err)
+	}
 	return nil
 }
 

--- a/resource/state/stub_test.go
+++ b/resource/state/stub_test.go
@@ -181,14 +181,6 @@ func (s *stubStagedResource) Activate() error {
 	return nil
 }
 
-func (s *stubStagedResource) ActivateWithoutVersionInc() error {
-	s.stub.AddCall("ActivateWithoutVersionInc")
-	if err := s.stub.NextErr(); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
-}
-
 type stubStorage struct {
 	stub *testing.Stub
 

--- a/state/resources.go
+++ b/state/resources.go
@@ -34,6 +34,9 @@ type Resources interface {
 	// SetResource adds the resource to blob storage and updates the metadata.
 	SetResource(applicationID, userID string, res charmresource.Resource, r io.Reader) (resource.Resource, error)
 
+	// SetUnitResource sets a resource for a specific unit (primarily to support model migrations).
+	SetUnitResource(unitName, userID string, res charmresource.Resource, r io.Reader) (resource.Resource, error)
+
 	// UpdatePendingResource adds the resource to blob storage and updates the metadata.
 	UpdatePendingResource(applicationID, pendingID, userID string, res charmresource.Resource, r io.Reader) (resource.Resource, error)
 

--- a/state/resources.go
+++ b/state/resources.go
@@ -34,8 +34,8 @@ type Resources interface {
 	// SetResource adds the resource to blob storage and updates the metadata.
 	SetResource(applicationID, userID string, res charmresource.Resource, r io.Reader) (resource.Resource, error)
 
-	// SetUnitResource sets a resource for a specific unit (primarily to support model migrations).
-	SetUnitResource(unitName, userID string, res charmresource.Resource, r io.Reader) (resource.Resource, error)
+	// SetUnitResource sets the resource metadata for a specific unit.
+	SetUnitResource(unitName, userID string, res charmresource.Resource) (resource.Resource, error)
 
 	// UpdatePendingResource adds the resource to blob storage and updates the metadata.
 	UpdatePendingResource(applicationID, pendingID, userID string, res charmresource.Resource, r io.Reader) (resource.Resource, error)

--- a/state/resources_persistence_staged.go
+++ b/state/resources_persistence_staged.go
@@ -65,17 +65,6 @@ func (staged StagedResource) Unstage() error {
 
 // Activate makes the staged resource the active resource.
 func (staged StagedResource) Activate() error {
-	return errors.Trace(staged.activate(true))
-}
-
-// ActivateWithoutVersionInc makes a staged resource active without
-// incrementing CharmModifiedVersion. This is useful for settings
-// resources for a unit during model migrations.
-func (staged StagedResource) ActivateWithoutVersionInc() error {
-	return errors.Trace(staged.activate(false))
-}
-
-func (staged StagedResource) activate(incVersion bool) error {
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		// This is an "upsert".
 		var ops []txn.Op
@@ -97,7 +86,7 @@ func (staged StagedResource) activate(incVersion bool) error {
 		// If we are changing the bytes for a resource, we increment the
 		// CharmModifiedVersion on the service, since resources are integral to
 		// the high level "version" of the charm.
-		if incVersion && staged.stored.PendingID == "" {
+		if staged.stored.PendingID == "" {
 			hasNewBytes, err := staged.hasNewBytes()
 			if err != nil {
 				logger.Errorf("can't read existing resource during activate: %v", errors.Details(err))

--- a/state/resources_persistence_staged_test.go
+++ b/state/resources_persistence_staged_test.go
@@ -186,3 +186,28 @@ func (s *StagedResourceSuite) TestActivateExists(c *gc.C) {
 		Remove: true,
 	}})
 }
+
+func (s *StagedResourceSuite) TestActivateWithoutVersionInc(c *gc.C) {
+	staged, doc := s.newStagedResource(c, "a-application", "spam")
+	ignoredErr := errors.New("<never reached>")
+	s.stub.SetErrors(nil, nil, nil, nil, nil, ignoredErr)
+
+	err := staged.ActivateWithoutVersionInc()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.stub.CheckCallNames(c, "Run", "ApplicationExistsOps", "RunTransaction")
+	s.stub.CheckCall(c, 2, "RunTransaction", []txn.Op{{
+		C:      "resources",
+		Id:     "resource#a-application/spam",
+		Assert: txn.DocMissing,
+		Insert: &doc,
+	}, {
+		C:      "application",
+		Id:     "a-application",
+		Assert: txn.DocExists,
+	}, {
+		C:      "resources",
+		Id:     "resource#a-application/spam#staged",
+		Remove: true,
+	}})
+}

--- a/state/resources_persistence_staged_test.go
+++ b/state/resources_persistence_staged_test.go
@@ -186,28 +186,3 @@ func (s *StagedResourceSuite) TestActivateExists(c *gc.C) {
 		Remove: true,
 	}})
 }
-
-func (s *StagedResourceSuite) TestActivateWithoutVersionInc(c *gc.C) {
-	staged, doc := s.newStagedResource(c, "a-application", "spam")
-	ignoredErr := errors.New("<never reached>")
-	s.stub.SetErrors(nil, nil, nil, nil, nil, ignoredErr)
-
-	err := staged.ActivateWithoutVersionInc()
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.stub.CheckCallNames(c, "Run", "ApplicationExistsOps", "RunTransaction")
-	s.stub.CheckCall(c, 2, "RunTransaction", []txn.Op{{
-		C:      "resources",
-		Id:     "resource#a-application/spam",
-		Assert: txn.DocMissing,
-		Insert: &doc,
-	}, {
-		C:      "application",
-		Id:     "a-application",
-		Assert: txn.DocExists,
-	}, {
-		C:      "resources",
-		Id:     "resource#a-application/spam#staged",
-		Remove: true,
-	}})
-}

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -92,6 +92,9 @@ type Facade interface {
 	// OpenResource downloads a single resource for an application.
 	OpenResource(string, string) (io.ReadCloser, error)
 
+	// OpenUnitResource downloads a single resource for a unit.
+	OpenUnitResource(string, string) (io.ReadCloser, error)
+
 	// Reap removes all documents of the model associated with the API
 	// connection.
 	Reap() error
@@ -377,6 +380,11 @@ func (w *uploadWrapper) UploadCharm(curl *charm.URL, content io.ReadSeeker) (*ch
 // UploadResource prepends the model UUID to the args passed to the migration client.
 func (w *uploadWrapper) UploadResource(res resource.Resource, content io.ReadSeeker) error {
 	return w.client.UploadResource(w.modelUUID, res, content)
+}
+
+// UploadUnitResource prepends the model UUID to the args passed to the migration client.
+func (w *uploadWrapper) UploadUnitResource(unitName string, res resource.Resource, content io.ReadSeeker) error {
+	return w.client.UploadUnitResource(w.modelUUID, unitName, res, content)
 }
 
 func (w *Worker) transferModel(targetInfo coremigration.TargetInfo, modelUUID string) error {

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -92,9 +92,6 @@ type Facade interface {
 	// OpenResource downloads a single resource for an application.
 	OpenResource(string, string) (io.ReadCloser, error)
 
-	// OpenUnitResource downloads a single resource for a unit.
-	OpenUnitResource(string, string) (io.ReadCloser, error)
-
 	// Reap removes all documents of the model associated with the API
 	// connection.
 	Reap() error
@@ -382,9 +379,9 @@ func (w *uploadWrapper) UploadResource(res resource.Resource, content io.ReadSee
 	return w.client.UploadResource(w.modelUUID, res, content)
 }
 
-// UploadUnitResource prepends the model UUID to the args passed to the migration client.
-func (w *uploadWrapper) UploadUnitResource(unitName string, res resource.Resource, content io.ReadSeeker) error {
-	return w.client.UploadUnitResource(w.modelUUID, unitName, res, content)
+// SetUnitResource prepends the model UUID to the args passed to the migration client.
+func (w *uploadWrapper) SetUnitResource(unitName string, res resource.Resource) error {
+	return w.client.SetUnitResource(w.modelUUID, unitName, res)
 }
 
 func (w *Worker) transferModel(targetInfo coremigration.TargetInfo, modelUUID string) error {


### PR DESCRIPTION
Units may have different resource revisions to the application and as such need to be migrated separately.

This PR adds API support for unit resources and updates the binaries migration functionality to support them.

### QA

* Migrate a resource using model and confirm the resources collection matches up such that the unit resource is recorded. Also checked gridfs and blobstore metadata.
* Migrate a resource using model where the application resource is different to a unit resource and inspect the DB is correct post-migration. Run add-unit on the application.