### PR TITLE
Add a test to show deletion of importing models.

### DIFF
--- a/apiserver/common/modeldestroy_test.go
+++ b/apiserver/common/modeldestroy_test.go
@@ -141,6 +141,20 @@ func (s *destroyModelSuite) TestDestroyModel(c *gc.C) {
 	c.Assert(model.Life(), gc.Not(gc.Equals), state.Alive)
 }
 
+func (s *destroyModelSuite) TestDestroyImportingModel(c *gc.C) {
+	modelSt := s.Factory.MakeModel(c, nil)
+	defer modelSt.Close()
+
+	model, err := modelSt.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = model.SetMigrationMode(state.MigrationModeImporting)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = common.DestroyModel(s.modelManager, model.ModelTag())
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func assertLife(c *gc.C, entity state.Living, life state.Life) {
 	err := entity.Refresh()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
It was incorrectly assumed that one would not be able to delete a model that is being imported.

Added a test to show that this can be done.