### PR TITLE
Track Machine Spaces

### DIFF
--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -635,6 +635,11 @@ func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(args params.Entities
 			continue
 		}
 
+		// XXX(jam): this looks to be the point where we need to know the collection
+		// of endpoint bindings and space constraints for this container
+		// By the time we've gotten here, we've probably already done the work for
+		// StartInstance to have EndpointBindings described, but that information
+		// hasn't been passed back to us.
 		if err := hostMachine.SetContainerLinkLayerDevices(container); err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -634,6 +634,249 @@ func (s *linkLayerDevicesStateSuite) TestMachineRemoveAllLinkLayerDevicesNoError
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *linkLayerDevicesStateSuite) setupMachineWithOneNIC(c *gc.C) {
+	_, err := s.State.AddSubnet(state.SubnetInfo{
+		CIDR:      "10.0.0.0/24",
+		SpaceName: "default",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSubnet(state.SubnetInfo{
+		CIDR:      "10.10.0.0/24",
+		SpaceName: "dmz",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.SetLinkLayerDevices(
+		state.LinkLayerDeviceArgs{
+			Name:       "eth0",
+			Type:       state.EthernetDevice,
+			MACAddress: "01:23:45:67:89:ab:cd:ef",
+			IsUp:       true,
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.SetDevicesAddresses(
+		state.LinkLayerDeviceAddress{
+			DeviceName:   "eth0",
+			CIDRAddress:  "10.0.0.20/24",
+			ConfigMethod: state.StaticAddress,
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *linkLayerDevicesStateSuite) setupMachineWithOneNICAndBridge(c *gc.C) {
+	_, err := s.State.AddSubnet(state.SubnetInfo{
+		CIDR:      "10.0.0.0/24",
+		SpaceName: "default",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSubnet(state.SubnetInfo{
+		CIDR:      "10.10.0.0/24",
+		SpaceName: "dmz",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.SetLinkLayerDevices(
+		state.LinkLayerDeviceArgs{
+			Name:       "br-eth0",
+			Type:       state.BridgeDevice,
+			ParentName: "",
+			MACAddress: "01:23:45:67:89:ab:cd:ef", // Same as primary device
+			IsUp:       true,
+		},
+	)
+	err = s.machine.SetLinkLayerDevices(
+		state.LinkLayerDeviceArgs{
+			Name:       "eth0",
+			Type:       state.EthernetDevice,
+			MACAddress: "01:23:45:67:89:ab:cd:ef",
+			ParentName: "br-eth0",
+			IsUp:       true,
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.SetDevicesAddresses(
+		state.LinkLayerDeviceAddress{
+			DeviceName:   "br-eth0",
+			CIDRAddress:  "10.0.0.20/24",
+			ConfigMethod: state.StaticAddress,
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *linkLayerDevicesStateSuite) TestLinkLayerDevicesForSpaces(c *gc.C) {
+	s.setupMachineWithOneNICAndBridge(c)
+	res, err := s.machine.LinkLayerDevicesForSpaces([]string{"default"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(res, gc.HasLen, 1)
+	devices, ok := res["default"]
+	c.Check(ok, jc.IsTrue)
+	// TODO(jam): 2016-12-13 Eventually we should probably notice that 'eth0'
+	// *is* part of the right space, possibly just because its parent device
+	// is in the space
+	c.Check(devices, gc.HasLen, 1)
+	c.Check(devices[0].Name(), gc.Equals, "br-eth0")
+	c.Check(devices[0].Type(), gc.Equals, state.BridgeDevice)
+}
+
+func (s *linkLayerDevicesStateSuite) TestLinkLayerDevicesForSpacesNoSuchSpace(c *gc.C) {
+	s.setupMachineWithOneNICAndBridge(c)
+	res, err := s.machine.LinkLayerDevicesForSpaces([]string{"dmz"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(res, gc.HasLen, 0)
+}
+
+func (s *linkLayerDevicesStateSuite) TestLinkLayerDevicesForSpacesNoBridge(c *gc.C) {
+	s.setupMachineWithOneNIC(c)
+	res, err := s.machine.LinkLayerDevicesForSpaces([]string{"default"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(res, gc.HasLen, 1)
+	devices, ok := res["default"]
+	c.Check(ok, jc.IsTrue)
+	c.Check(devices, gc.HasLen, 1)
+	c.Check(devices[0].Name(), gc.Equals, "eth0")
+	c.Check(devices[0].Type(), gc.Equals, state.EthernetDevice)
+}
+
+func (s *linkLayerDevicesStateSuite) TestLinkLayerDevicesForSpacesMultipleSpaces(c *gc.C) {
+	s.setupMachineWithOneNICAndBridge(c)
+	// Now add a NIC in the dmz space, but without a bridge
+	err := s.machine.SetLinkLayerDevices(
+		state.LinkLayerDeviceArgs{
+			Name:       "eth1",
+			Type:       state.EthernetDevice,
+			MACAddress: "11:23:45:67:89:ab:cd:ef",
+			IsUp:       true,
+		},
+	)
+	err = s.machine.SetDevicesAddresses(
+		state.LinkLayerDeviceAddress{
+			DeviceName:   "eth1",
+			CIDRAddress:  "10.10.0.20/24",
+			ConfigMethod: state.StaticAddress,
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	res, err := s.machine.LinkLayerDevicesForSpaces([]string{"default", "dmz"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(res, gc.HasLen, 2)
+	defaultDevices, ok := res["default"]
+	c.Check(ok, jc.IsTrue)
+	c.Check(defaultDevices, gc.HasLen, 1)
+	c.Check(defaultDevices[0].Name(), gc.Equals, "br-eth0")
+	dmzDevices, ok := res["dmz"]
+	c.Check(ok, jc.IsTrue)
+	c.Check(dmzDevices, gc.HasLen, 1)
+	c.Check(dmzDevices[0].Name(), gc.Equals, "eth1")
+}
+
+func (s *linkLayerDevicesStateSuite) TestLinkLayerDevicesForSpacesSortOrder(c *gc.C) {
+	s.setupMachineWithOneNICAndBridge(c)
+	// Add more devices to the "default" space, to make sure the result comes
+	// back in NaturallySorted order
+	devices := []state.LinkLayerDeviceArgs{{
+		Name:       "eth1",
+		Type:       state.EthernetDevice,
+		MACAddress: "11:23:45:67:89:ab:cd:ef",
+		ParentName: "br-eth1",
+		IsUp:       true,
+	}, {
+		Name:       "br-eth1",
+		Type:       state.BridgeDevice,
+		MACAddress: "11:23:45:67:89:ab:cd:ef",
+		IsUp:       true,
+	}, {
+		Name:       "eth1.1",
+		Type:       state.EthernetDevice,
+		MACAddress: "22:23:45:67:89:ab:cd:ef",
+		ParentName: "br-eth1.1",
+		IsUp:       true,
+	}, {
+		Name:       "br-eth1.1",
+		Type:       state.BridgeDevice,
+		MACAddress: "22:23:45:67:89:ab:cd:ef",
+		IsUp:       true,
+	}, {
+		Name:       "eth1:1",
+		Type:       state.EthernetDevice,
+		MACAddress: "32:23:45:67:89:ab:cd:ef",
+		ParentName: "br-eth1:1",
+		IsUp:       true,
+	}, {
+		Name:       "br-eth1:1",
+		Type:       state.BridgeDevice,
+		MACAddress: "32:23:45:67:89:ab:cd:ef",
+		IsUp:       true,
+	}, {
+		Name:       "eth10",
+		Type:       state.EthernetDevice,
+		MACAddress: "42:23:45:67:89:ab:cd:ef",
+		ParentName: "br-eth10",
+		IsUp:       true,
+	}, {
+		Name:       "br-eth10",
+		Type:       state.BridgeDevice,
+		MACAddress: "42:23:45:67:89:ab:cd:ef",
+		IsUp:       true,
+	}, {
+		Name:       "eth10.2",
+		Type:       state.EthernetDevice,
+		MACAddress: "52:23:45:67:89:ab:cd:ef",
+		ParentName: "br-eth10.2",
+		IsUp:       true,
+	}, {
+		Name:       "br-eth10.2",
+		Type:       state.BridgeDevice,
+		MACAddress: "52:23:45:67:89:ab:cd:ef",
+		IsUp:       true,
+	}, {
+		Name:       "eth2",
+		Type:       state.EthernetDevice,
+		MACAddress: "61:23:45:67:89:ab:cd:ef",
+		IsUp:       true,
+	}, {
+		Name:       "eth20",
+		Type:       state.EthernetDevice,
+		MACAddress: "61:23:45:67:89:ab:cd:ef",
+		IsUp:       true,
+	}, {
+		Name:       "eth3",
+		Type:       state.EthernetDevice,
+		MACAddress: "61:23:45:67:89:ab:cd:ef",
+		IsUp:       true,
+	}}
+	err := s.machine.SetParentLinkLayerDevicesBeforeTheirChildren(devices)
+	c.Assert(err, jc.ErrorIsNil)
+	addresses := make([]state.LinkLayerDeviceAddress, 0, len(devices))
+	for i, device := range devices {
+		if device.ParentName != "" {
+			// Devices *on* the bridge do not end up with IP addresses, only
+			// the Bridge device has an address.
+			continue
+		}
+		addresses = append(addresses, state.LinkLayerDeviceAddress{
+			DeviceName:   device.Name,
+			CIDRAddress:  fmt.Sprintf("10.0.0.1%02d/24", i),
+			ConfigMethod: state.StaticAddress,
+		})
+	}
+	err = s.machine.SetDevicesAddresses(addresses...)
+	c.Assert(err, jc.ErrorIsNil)
+	res, err := s.machine.LinkLayerDevicesForSpaces([]string{"default"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(res, gc.HasLen, 1)
+	defaultDevices, ok := res["default"]
+	c.Check(ok, jc.IsTrue)
+	names := make([]string, 0, len(defaultDevices))
+	for _, dev := range defaultDevices {
+		names = append(names, dev.Name())
+	}
+	c.Check(names, gc.DeepEquals, []string{
+		"br-eth0", "br-eth1", "br-eth1.1", "br-eth1:1", "br-eth10", "br-eth10.2",
+		"eth2", "eth3", "eth20",
+	})
+}
+
 func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesWithLightStateChurn(c *gc.C) {
 	childArgs, churnHook := s.prepareSetLinkLayerDevicesWithStateChurn(c)
 	defer state.SetTestHooks(c, s.State, churnHook).Check()

--- a/state/machine.go
+++ b/state/machine.go
@@ -1065,6 +1065,70 @@ func (m *Machine) Units() (units []*Unit, err error) {
 	return units, nil
 }
 
+// XXX(jam): 2016-12-09 These are just copied from
+// provider/maas/constraints.go, but they should be tied to machine
+// constraints, *not* tied to provider/maas constraints.
+// convertSpacesFromConstraints extracts spaces from constraints and converts
+// them to two lists of positive and negative spaces.
+func convertSpacesFromConstraints(spaces *[]string) ([]string, []string) {
+	if spaces == nil || len(*spaces) == 0 {
+		return nil, nil
+	}
+	return parseDelimitedValues(*spaces)
+}
+
+// parseDelimitedValues parses a slice of raw values coming from constraints
+// (Tags or Spaces). The result is split into two slices - positives and
+// negatives (prefixed with "^"). Empty values are ignored.
+func parseDelimitedValues(rawValues []string) (positives, negatives []string) {
+	for _, value := range rawValues {
+		if value == "" || value == "^" {
+			// Neither of these cases should happen in practise, as constraints
+			// are validated before setting them and empty names for spaces or
+			// tags are not allowed.
+			continue
+		}
+		if strings.HasPrefix(value, "^") {
+			negatives = append(negatives, strings.TrimPrefix(value, "^"))
+		} else {
+			positives = append(positives, value)
+		}
+	}
+	return positives, negatives
+}
+
+// AllSpaces returns the name of all spaces that this machine needs access to.
+// This is the combined value of all of the direct constraints for the machine,
+// as well as the spaces listed for all bindings of units being deployed to
+// that machine.
+func (m *Machine) AllSpaces() (set.Strings, error) {
+	spaces := set.NewStrings()
+	units, err := m.Units()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	constraints, err := m.Constraints()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	positiveSpaces, _ := convertSpacesFromConstraints(constraints.Spaces)
+	// XXX(jam): what to do about negativeSpaces ?
+	for _, space := range positiveSpaces {
+		spaces.Add(space)
+	}
+	for _, unit := range units {
+		app, err := unit.Application()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		endpointBindings, err := app.EndpointBindings()
+		for _, space := range endpointBindings {
+			spaces.Add(space)
+		}
+	}
+	return spaces, nil
+}
+
 // SetProvisioned sets the provider specific machine id, nonce and also metadata for
 // this machine. Once set, the instance id cannot be changed.
 //

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -859,7 +859,74 @@ func (m *Machine) AllNetworkAddresses() ([]network.Address, error) {
 	for i := range stateAddresses {
 		networkAddresses[i] = stateAddresses[i].NetworkAddress()
 	}
+	// TODO(jam): 20161130 NetworkAddress object has a SpaceName attribute.
+	// However, we are not filling in that information here.
 	return networkAddresses, nil
+}
+
+// deviceMapToSortedList takes a map from device name to LinkLayerDevice
+// object, and returns the list of LinkLayerDevice object using
+// NaturallySortDeviceNames
+func deviceMapToSortedList(deviceMap map[string]*LinkLayerDevice) []*LinkLayerDevice {
+	names := make([]string, 0, len(deviceMap))
+	for name, _ := range deviceMap {
+		// name must == device.Name()
+		names = append(names, name)
+	}
+	sortedNames := network.NaturallySortDeviceNames(names...)
+	result := make([]*LinkLayerDevice, len(sortedNames))
+	for i, name := range sortedNames {
+		result[i] = deviceMap[name]
+	}
+	return result
+}
+
+// LinkLayerDevicesForSpaces takes a list of spaces, and returns the devices on
+// this machine that are in that space.
+func (m *Machine) LinkLayerDevicesForSpaces(spaces []string) (map[string][]*LinkLayerDevice, error) {
+	addresses, err := m.AllAddresses()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	requestedSpaces := set.NewStrings(spaces...)
+	spaceToDevices := make(map[string]map[string]*LinkLayerDevice, 0)
+	// TODO(jam): 2016-12-08 We look up each subnet one-by-one, and then look
+	// up each Link-Layer-Device one-by-one, it feels like we should
+	// 'aggregate all subnet CIDR' and then grab them in one pass, and then
+	// filter them to find the link layer devices we care about, and ask for
+	// them in a single pass again.
+	// Further, we should be tracking this more by Layer 2 connections, rather
+	// than requiring CIDR. Eventually we want to get rid of host network
+	// devices from having an IP address at all, so that only the containers
+	// have Layer 3 addresses.
+	for _, addr := range addresses {
+		subnet, err := addr.Subnet()
+		if err != nil {
+			// XXX should we be omitting all other good records because this one was bad?
+			return nil, errors.Trace(err)
+		}
+		spaceName := subnet.SpaceName()
+		if !requestedSpaces.Contains(spaceName) {
+			continue
+		}
+		device, err := addr.Device()
+		if err != nil {
+			// XXX should we be omitting all other good records because this one was bad?
+			return nil, errors.Trace(err)
+		}
+		spaceInfo, ok := spaceToDevices[spaceName]
+		if !ok {
+			spaceInfo = make(map[string]*LinkLayerDevice)
+			spaceToDevices[spaceName] = spaceInfo
+		}
+		// TODO(jam): handle seeing a device with the same name twice?
+		spaceInfo[device.Name()] = device
+	}
+	result := make(map[string][]*LinkLayerDevice, len(spaceToDevices))
+	for spaceName, deviceMap := range spaceToDevices {
+		result[spaceName] = deviceMapToSortedList(deviceMap)
+	}
+	return result, nil
 }
 
 // SetParentLinkLayerDevicesBeforeTheirChildren splits the given devicesArgs

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -748,6 +748,63 @@ func (s *MachineSuite) TestMachineInstanceIdBlank(c *gc.C) {
 	c.Assert(string(iid), gc.Equals, "")
 }
 
+func (s *MachineSuite) TestAllSpacesNone(c *gc.C) {
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	spaces, err := machine.AllSpaces()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(spaces.SortedValues(), gc.DeepEquals, []string{})
+}
+
+func (s *MachineSuite) TestAllSpacesSimpleConstraints(c *gc.C) {
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine.SetConstraints(constraints.Value{
+		Spaces: &[]string{"foo", "bar", "^baz"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	spaces, err := machine.AllSpaces()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(spaces.SortedValues(), gc.DeepEquals, []string{"bar", "foo"})
+}
+
+func (s *MachineSuite) TestAllSpacesEndpoints(c *gc.C) {
+	_, err := s.State.AddSpace("db", "", nil, true)
+	c.Assert(err, jc.ErrorIsNil)
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	svc := s.AddTestingServiceWithBindings(c, "mysql",
+		s.AddTestingCharm(c, "mysql"), map[string]string{"server": "db"})
+	unit, err := svc.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(machine)
+	c.Assert(err, jc.ErrorIsNil)
+	spaces, err := machine.AllSpaces()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(spaces.SortedValues(), gc.DeepEquals, []string{"db"})
+}
+
+func (s *MachineSuite) TestAllSpacesEndpointsAndConstraints(c *gc.C) {
+	_, err := s.State.AddSpace("foo", "", nil, true)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSpace("db", "", nil, true)
+	c.Assert(err, jc.ErrorIsNil)
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine.SetConstraints(constraints.Value{
+		Spaces: &[]string{"foo"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	svc := s.AddTestingServiceWithBindings(c, "mysql",
+		s.AddTestingCharm(c, "mysql"), map[string]string{"server": "db"})
+	unit, err := svc.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(machine)
+	c.Assert(err, jc.ErrorIsNil)
+	spaces, err := machine.AllSpaces()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(spaces.SortedValues(), gc.DeepEquals, []string{"db", "foo"})
+}
+
 func (s *MachineSuite) TestMachineSetProvisionedUpdatesCharacteristics(c *gc.C) {
 	// Before provisioning, there is no hardware characteristics.
 	_, err := s.machine.HardwareCharacteristics()


### PR DESCRIPTION
This provides 2 key functions on Machine that I think will be necessary for our work on changing how containers are getting network devices on their host machine's bridges.

Machine.AllSpaces() combines the spaces that are specified in constraints with the endpoint bindings that are part of the active primary units on the machine.

Machine.LinkLayerDevicesForSpaces() filter's the link layer devices we know about for the machine, and sorts them into what space they are associated with. Between the two functions we are able to map the desired spaces for a new container onto the host's devices. This both lets us know if we have a bridge to use, and lets us create network devices only for the right ones.