### PR TITLE
migration: Support placeholder resources

### DIFF
--- a/api/migrationtarget/client_test.go
+++ b/api/migrationtarget/client_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
-	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
@@ -193,16 +192,13 @@ func (s *ClientSuite) TestUploadResource(c *gc.C) {
 	}
 	client := migrationtarget.NewClient(caller)
 
-	fp := charmresource.NewFingerprintHash().Fingerprint()
-	res := resourcetesting.NewPlaceholderResource(c, "blob", "app")
-	res.Revision = 2
-	res.Size = 123
-	res.Username = "bob"
-	res.Fingerprint = fp
+	res := resourcetesting.NewResource(c, nil, "blob", "app", resourceBody).Resource
+	res.Revision = 1
+
 	err := client.UploadResource("uuid", res, strings.NewReader(resourceBody))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(doer.method, gc.Equals, "POST")
-	expectedURL := fmt.Sprintf("/migrate/resources?application=app&description=blob+description&fingerprint=%s&name=blob&origin=upload&path=blob.tgz&revision=2&size=123&type=file&user=bob", fp.Hex())
+	expectedURL := fmt.Sprintf("/migrate/resources?application=app&description=blob+description&fingerprint=%s&name=blob&origin=upload&path=blob.tgz&revision=1&size=11&timestamp=%d&type=file&user=a-user", res.Fingerprint.Hex(), res.Timestamp.UnixNano())
 	c.Assert(doer.url, gc.Equals, expectedURL)
 	c.Assert(doer.body, gc.Equals, resourceBody)
 }
@@ -215,16 +211,32 @@ func (s *ClientSuite) TestSetUnitResource(c *gc.C) {
 	}
 	client := migrationtarget.NewClient(caller)
 
-	fp := charmresource.NewFingerprintHash().Fingerprint()
-	res := resourcetesting.NewPlaceholderResource(c, "blob", "app")
+	res := resourcetesting.NewResource(c, nil, "blob", "app", resourceBody).Resource
 	res.Revision = 2
-	res.Size = 123
-	res.Username = "bob"
-	res.Fingerprint = fp
+
 	err := client.SetUnitResource("uuid", "app/0", res)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(doer.method, gc.Equals, "POST")
-	expectedURL := fmt.Sprintf("/migrate/resources?description=blob+description&fingerprint=%s&name=blob&origin=upload&path=blob.tgz&revision=2&size=123&type=file&unit=app%%2F0&user=bob", fp.Hex())
+	expectedURL := fmt.Sprintf("/migrate/resources?description=blob+description&fingerprint=%s&name=blob&origin=upload&path=blob.tgz&revision=2&size=11&timestamp=%d&type=file&unit=app%%2F0&user=a-user", res.Fingerprint.Hex(), res.Timestamp.UnixNano())
+	c.Assert(doer.url, gc.Equals, expectedURL)
+	c.Assert(doer.body, gc.Equals, "")
+}
+
+func (s *ClientSuite) TestPlaceholderResource(c *gc.C) {
+	doer := newFakeDoer(c, "")
+	caller := &fakeHTTPCaller{
+		httpClient: &httprequest.Client{Doer: doer},
+	}
+	client := migrationtarget.NewClient(caller)
+
+	res := resourcetesting.NewPlaceholderResource(c, "blob", "app")
+	res.Revision = 3
+	res.Size = 123
+
+	err := client.SetPlaceholderResource("uuid", res)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(doer.method, gc.Equals, "POST")
+	expectedURL := fmt.Sprintf("/migrate/resources?application=app&description=blob+description&fingerprint=%s&name=blob&origin=upload&path=blob.tgz&revision=3&size=123&type=file", res.Fingerprint.Hex())
 	c.Assert(doer.url, gc.Equals, expectedURL)
 	c.Assert(doer.body, gc.Equals, "")
 }

--- a/apiserver/resources.go
+++ b/apiserver/resources.go
@@ -78,7 +78,14 @@ func (h *resourceUploadHandler) processPost(r *http.Request, st *state.State) (r
 		return empty, errors.Trace(err)
 	}
 
-	outRes, err := setResource(isUnit, target, userID, res, r.Body, rSt)
+	reader := r.Body
+
+	// Don't associate content with a placeholder resource.
+	if isPlaceholder(query) {
+		reader = nil
+	}
+
+	outRes, err := setResource(isUnit, target, userID, res, reader, rSt)
 	if err != nil {
 		return empty, errors.Annotate(err, "resource upload failed")
 	}
@@ -92,7 +99,10 @@ func setResource(isUnit bool, target, user string, res charmresource.Resource, r
 		return rSt.SetUnitResource(target, user, res)
 	}
 	return rSt.SetResource(target, user, res, r)
+}
 
+func isPlaceholder(query url.Values) bool {
+	return query.Get("timestamp") == ""
 }
 
 func getUploadTarget(query url.Values) (string, bool, error) {

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -130,12 +130,14 @@ func (s *ImportSuite) TestBinariesMigration(c *gc.C) {
 	app1Res := resourcetesting.NewResource(c, nil, "blob1", "app1", "blob1").Resource
 	app1UnitRes := app1Res
 	app1UnitRes.Revision = 1
+	app2Res := resourcetesting.NewPlaceholderResource(c, "blob2", "app2")
 	resources := []coremigration.SerializedModelResource{
 		{ApplicationRevision: app0Res},
 		{
 			ApplicationRevision: app1Res,
 			UnitRevisions:       map[string]resource.Resource{"app1/99": app1UnitRes},
 		},
+		{ApplicationRevision: app2Res},
 	}
 
 	config := migration.UploadBinariesConfig{
@@ -174,6 +176,7 @@ func (s *ImportSuite) TestBinariesMigration(c *gc.C) {
 	c.Assert(uploader.resources, jc.DeepEquals, map[string]string{
 		"app0/blob0": "blob0",
 		"app1/blob1": "blob1",
+		"app2/blob2": "<placeholder>",
 	})
 	c.Assert(uploader.unitResources, jc.SameContents, []string{"app1/99-blob1"})
 }
@@ -238,6 +241,11 @@ func (f *fakeUploader) UploadResource(res resource.Resource, r io.ReadSeeker) er
 		return errors.Trace(err)
 	}
 	f.resources[res.ApplicationID+"/"+res.Name] = string(body)
+	return nil
+}
+
+func (f *fakeUploader) SetPlaceholderResource(res resource.Resource) error {
+	f.resources[res.ApplicationID+"/"+res.Name] = "<placeholder>"
 	return nil
 }
 

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -379,6 +379,11 @@ func (w *uploadWrapper) UploadResource(res resource.Resource, content io.ReadSee
 	return w.client.UploadResource(w.modelUUID, res, content)
 }
 
+// SetPlaceholderResource prepends the model UUID to the args passed to the migration client.
+func (w *uploadWrapper) SetPlaceholderResource(res resource.Resource) error {
+	return w.client.SetPlaceholderResource(w.modelUUID, res)
+}
+
 // SetUnitResource prepends the model UUID to the args passed to the migration client.
 func (w *uploadWrapper) SetUnitResource(unitName string, res resource.Resource) error {
 	return w.client.SetUnitResource(w.modelUUID, unitName, res)


### PR DESCRIPTION
Placeholder resources are those which are defined by a charm but have not yet been requested by any unit and are therefore not stored in the controller yet. They need special handling because they have no content and can't be opened by OpenResource.

### QA 

Migrated a model with the etcd charm deployed. This charm starts with a placeholder "snapshot" resource which would previously cause migrations to fail. Compared the resources collection before and after the migration to ensure correct migration. Ran `juju-run etcd/0 "resource-get snapshot"` on the etcd/0 host after migration to ensure resource download was possible after migration.
