### PR TITLE
Fixes lp#1597830 on 2.1: worker should not restart agent. 

### DIFF
--- a/worker/conv2state/converter_test.go
+++ b/worker/conv2state/converter_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/juju/errors"
-	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 

--- a/worker/conv2state/fakes_test.go
+++ b/worker/conv2state/fakes_test.go
@@ -53,14 +53,7 @@ func (fakeWatcher) Wait() error {
 }
 
 type fakeAgent struct {
-	tag        names.Tag
-	restartErr error
-	didRestart bool
-}
-
-func (f *fakeAgent) Restart() error {
-	f.didRestart = true
-	return f.restartErr
+	tag names.Tag
 }
 
 func (f fakeAgent) Tag() names.Tag {


### PR DESCRIPTION
Xenial machines with units would hang when trying to convert to state servers under HA after new revisions of systemd and dbus were introduced.

It was discovered that the conv2state worker would explicitly restart an agent. This proposal changes the behavior to throw an error instead to ensure that proper infrastructure restarts the agent cleanly.