### PR TITLE
Wait for machines on controller kill and destroy commands

### DIFF
--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -160,6 +160,56 @@ func (s *KillSuite) TestKillWaitForModels_ActuallyWaits(c *gc.C) {
 	c.Assert(coretesting.Stderr(ctx), gc.Equals, expect)
 }
 
+func (s *KillSuite) TestKillWaitForModels_WaitsForControllerMachines(c *gc.C) {
+	s.resetAPIModels(c)
+	wrapped, inner := s.newKillCommandBoth()
+	err := coretesting.InitCommand(wrapped, []string{"test1", "--timeout=1m"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx := coretesting.Context(c)
+	result := make(chan error)
+	go func() {
+		err := controller.KillWaitForModels(inner, ctx, s.api, test1UUID)
+		result <- err
+	}()
+
+	s.setModelStatus(base.ModelStatus{
+		UUID:               test1UUID,
+		Life:               string(params.Dying),
+		Owner:              "admin",
+		HostedMachineCount: 2,
+	})
+	s.syncClockAlarm(c)
+	s.setModelStatus(base.ModelStatus{
+		UUID:               test1UUID,
+		Life:               string(params.Dying),
+		Owner:              "admin",
+		HostedMachineCount: 1,
+	})
+	s.clock.Advance(5 * time.Second)
+	s.syncClockAlarm(c)
+	s.setModelStatus(base.ModelStatus{
+		UUID:               test1UUID,
+		Life:               string(params.Dying),
+		Owner:              "admin",
+		HostedMachineCount: 0,
+	})
+	s.clock.Advance(5 * time.Second)
+
+	select {
+	case err := <-result:
+		c.Assert(err, jc.ErrorIsNil)
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for result")
+	}
+	expect := "" +
+		"Waiting on 0 model, 2 machines\n" +
+		"Waiting on 0 model, 1 machine\n" +
+		"All hosted models reclaimed, cleaning up controller machines\n"
+
+	c.Assert(coretesting.Stderr(ctx), gc.Equals, expect)
+}
+
 func (s *KillSuite) TestKillWaitForModels_TimeoutResetsWithChange(c *gc.C) {
 	s.resetAPIModels(c)
 	s.addModel("model-1", base.ModelStatus{


### PR DESCRIPTION
Wait for machines on controller kill and destroy commands

`kill-controller` and `destroy-controller` now also wait on machines yet
to be removed as well as the previous behaviour of waiting on models yet
to be destroyed. This fixes a bug in which machines in the controller
model were not given time to complete their removal before the
controller itself was destroyed.

Fixes lp:1642295

QA steps:
 * Best seen in a manual environment, as per the bug
 * `bootstrap`, then `add-machine` to the controller model
 * `destroy-controller` and observe the destroy procedure continue until the machine in the controller model is removed, which will happen after the default model is destroyed
```
$ juju destroy-controller -y manual
Destroying controller
Waiting for hosted model resources to be reclaimed
Waiting on 0 model, 1 machine
Waiting on 0 model, 1 machine
Waiting on 0 model, 1 machine
All hosted models reclaimed, cleaning up controller machines
```
 * Repeat testing `kill-controller`