### PR TITLE
Don't schedule placeholder resource cleanup 

### DIFF
--- a/resource/resourceadapters/state.go
+++ b/resource/resourceadapters/state.go
@@ -103,6 +103,11 @@ func NewResourcePersistence(persist corestate.Persistence) corestate.ResourcesPe
 
 // CleanUpBlob is a cleanup handler that will be used in state cleanup.
 func CleanUpBlob(st *corestate.State, persist corestate.Persistence, storagePath string) error {
+	// Ignore attempts to clean up a placeholder resource.
+	if storagePath == "" {
+		return nil
+	}
+
 	// TODO(ericsnow) Move this to state.RemoveResource().
 	storage := persist.NewStorage()
 	return storage.Remove(storagePath)

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -6,6 +6,7 @@ package state_test
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -18,6 +19,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/resource/resourcetesting"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
 	"github.com/juju/juju/status"
@@ -43,6 +45,18 @@ func (s *ApplicationSuite) SetUpTest(c *gc.C) {
 	}
 	s.charm = s.AddTestingCharm(c, "mysql")
 	s.mysql = s.AddTestingService(c, "mysql", s.charm)
+}
+
+func (s *ApplicationSuite) assertNeedsCleanup(c *gc.C) {
+	dirty, err := s.State.NeedsCleanup()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(dirty, jc.IsTrue)
+}
+
+func (s *ApplicationSuite) assertNoCleanup(c *gc.C) {
+	dirty, err := s.State.NeedsCleanup()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(dirty, jc.IsFalse)
 }
 
 func (s *ApplicationSuite) TestSetCharm(c *gc.C) {
@@ -1727,22 +1741,16 @@ func (s *ApplicationSuite) TestDestroyQueuesUnitCleanup(c *gc.C) {
 		}
 	}
 
-	// Check state is clean.
-	dirty, err := s.State.NeedsCleanup()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dirty, jc.IsFalse)
+	s.assertNoCleanup(c)
 
 	// Destroy mysql, and check units are not touched.
-	err = s.mysql.Destroy()
+	err := s.mysql.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	for _, unit := range units {
 		assertLife(c, unit, state.Alive)
 	}
 
-	// Check a cleanup doc was added.
-	dirty, err = s.State.NeedsCleanup()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dirty, jc.IsTrue)
+	s.assertNeedsCleanup(c)
 
 	// Run the cleanup and check the units.
 	err = s.State.Cleanup()
@@ -1756,16 +1764,12 @@ func (s *ApplicationSuite) TestDestroyQueuesUnitCleanup(c *gc.C) {
 	}
 
 	// Check for queued unit cleanups, and run them.
-	dirty, err = s.State.NeedsCleanup()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dirty, jc.IsTrue)
+	s.assertNeedsCleanup(c)
 	err = s.State.Cleanup()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check we're now clean.
-	dirty, err = s.State.NeedsCleanup()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dirty, jc.IsFalse)
+	s.assertNoCleanup(c)
 }
 
 func (s *ApplicationSuite) TestRemoveServiceMachine(c *gc.C) {
@@ -1786,17 +1790,12 @@ func (s *ApplicationSuite) TestRemoveServiceMachine(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestRemoveQueuesLocalCharmCleanup(c *gc.C) {
-	// Check state is clean.
-	dirty, err := s.State.NeedsCleanup()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dirty, jc.IsFalse)
+	s.assertNoCleanup(c)
 
-	err = s.mysql.Destroy()
+	err := s.mysql.Destroy()
 
 	// Check a cleanup doc was added.
-	dirty, err = s.State.NeedsCleanup()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dirty, jc.IsTrue)
+	s.assertNeedsCleanup(c)
 
 	// Run the cleanup
 	err = s.State.Cleanup()
@@ -1807,9 +1806,37 @@ func (s *ApplicationSuite) TestRemoveQueuesLocalCharmCleanup(c *gc.C) {
 	c.Check(err, jc.Satisfies, errors.IsNotFound)
 
 	// Check we're now clean.
-	dirty, err = s.State.NeedsCleanup()
+	s.assertNoCleanup(c)
+}
+
+func (s *ApplicationSuite) TestDestroyQueuesResourcesCleanup(c *gc.C) {
+	s.assertNoCleanup(c)
+
+	// Add a resource to the application, ensuring it is stored.
+	rSt, err := s.State.Resources()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dirty, jc.IsFalse)
+	const content = "abc"
+	res := resourcetesting.NewCharmResource(c, "blob", content)
+	outRes, err := rSt.SetResource(s.mysql.Name(), "user", res, strings.NewReader(content))
+	c.Assert(err, jc.ErrorIsNil)
+	storagePath := state.ResourceStoragePath(c, s.State, outRes.ID)
+	c.Assert(state.IsBlobStored(c, s.State, storagePath), jc.IsTrue)
+
+	// Detroy the application.
+	err = s.mysql.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Cleanup should be registered but not yet run.
+	s.assertNeedsCleanup(c)
+	c.Assert(state.IsBlobStored(c, s.State, storagePath), jc.IsTrue)
+
+	// Run the cleanup.
+	err = s.State.Cleanup()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check we're now clean.
+	s.assertNoCleanup(c)
+	c.Assert(state.IsBlobStored(c, s.State, storagePath), jc.IsFalse)
 }
 
 func (s *ApplicationSuite) TestReadUnitWithChangingState(c *gc.C) {

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -1839,6 +1839,25 @@ func (s *ApplicationSuite) TestDestroyQueuesResourcesCleanup(c *gc.C) {
 	c.Assert(state.IsBlobStored(c, s.State, storagePath), jc.IsFalse)
 }
 
+func (s *ApplicationSuite) TestDestroyWithPlaceholderResources(c *gc.C) {
+	s.assertNoCleanup(c)
+
+	// Add a placeholder resource to the application.
+	rSt, err := s.State.Resources()
+	c.Assert(err, jc.ErrorIsNil)
+	res := resourcetesting.NewPlaceholderResource(c, "blob", s.mysql.Name())
+	outRes, err := rSt.SetResource(s.mysql.Name(), "user", res.Resource, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(outRes.IsPlaceholder(), jc.IsTrue)
+
+	// Detroy the application.
+	err = s.mysql.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// No cleanup required for placeholder resources.
+	state.AssertNoCleanups(c, s.State, state.CleanupKindResourceBlob)
+}
+
 func (s *ApplicationSuite) TestReadUnitWithChangingState(c *gc.C) {
 	// Check that reading a unit after removing the service
 	// fails nicely.

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -596,15 +596,15 @@ func ResourceStoragePath(c *gc.C, st *State, id string) string {
 func IsBlobStored(c *gc.C, st *State, storagePath string) bool {
 	stor := storage.NewStorage(st.ModelUUID(), st.MongoSession())
 	r, _, err := stor.Get(storagePath)
-	if err == nil {
-		r.Close()
-		return true
-	} else if errors.IsNotFound(err) {
-		return false
-	} else {
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false
+		}
 		c.Fatalf("Get failed: %v", err)
 		return false
 	}
+	r.Close()
+	return true
 }
 
 // AssertNoCleanups checks that there are no cleanups scheduled of a

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -606,3 +606,18 @@ func IsBlobStored(c *gc.C, st *State, storagePath string) bool {
 		return false
 	}
 }
+
+// AssertNoCleanups checks that there are no cleanups scheduled of a
+// given kind.
+func AssertNoCleanups(c *gc.C, st *State, kind cleanupKind) {
+	var docs []cleanupDoc
+	cleanups, closer := st.getCollection(cleanupsC)
+	defer closer()
+	err := cleanups.Find(nil).All(&docs)
+	c.Assert(err, jc.ErrorIsNil)
+	for _, doc := range docs {
+		if doc.Kind == kind {
+			c.Fatalf("found cleanup of kind %q", kind)
+		}
+	}
+}

--- a/state/resources_persistence.go
+++ b/state/resources_persistence.go
@@ -393,7 +393,9 @@ func (p ResourcePersistence) NewRemoveResourcesOps(applicationID string) ([]txn.
 
 	ops := newRemoveResourcesOps(docs)
 	for _, doc := range docs {
-		ops = append(ops, p.base.NewCleanupOp(CleanupKindResourceBlob, doc.StoragePath))
+		if doc.StoragePath != "" { // Don't schedule cleanups for placeholder resources.
+			ops = append(ops, p.base.NewCleanupOp(CleanupKindResourceBlob, doc.StoragePath))
+		}
 	}
 	return ops, nil
 }


### PR DESCRIPTION
Placeholder resources aren't stored in the blobstore and therefore don't need cleaning up. The fix has been made in two ways:

1. Cleanups are no longer scheduled for placeholder resources.
2. The resource cleanup code now ignores cleanups without a storage path set. This is a useful backstop but also fixes stray cleanups in existing deployments.

Fixes https://bugs.launchpad.net/juju/+bug/1649179

There was no testing at all for resource cleanup so this has also been rectified.

### QA

Deployed the etcd charm as this uses a placeholder resource, and then removed it. Previously this would result in errors in the logs as the cleaner worker attempted to remove a resource which wasn't stored.
