### PR TITLE
Ensure resource HTTP handlers release state

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -526,6 +526,9 @@ func (srv *Server) newHandlerArgs(spec apihttp.HandlerConstraints) apihttp.NewHa
 		Connect: func(req *http.Request) (*state.State, state.Entity, error) {
 			return ctxt.stateForRequestAuthenticatedTag(req, spec.AuthKinds...)
 		},
+		Release: func(st *state.State) error {
+			return ctxt.release(st)
+		},
 	}
 }
 

--- a/apiserver/common/apihttp/handler.go
+++ b/apiserver/common/apihttp/handler.go
@@ -15,6 +15,10 @@ type NewHandlerArgs struct {
 	// Connect is the function that is used to connect to Juju's state
 	// for the given HTTP request.
 	Connect func(*http.Request) (*state.State, state.Entity, error)
+
+	// Release indicates that the state is finished with and should be
+	// closed.
+	Release func(*state.State) error
 }
 
 // HandlerConstraints describes conditions under which a handler

--- a/resource/opened.go
+++ b/resource/opened.go
@@ -7,12 +7,46 @@ package resource
 
 import (
 	"io"
+	"strings"
+
+	"github.com/juju/errors"
 )
+
+type multiError []error
+
+func (m multiError) Error() string {
+	messages := make([]string, len(m))
+	for i, err := range m {
+		messages[i] = err.Error()
+	}
+	return strings.Join(messages, ", and also ")
+}
+
+// CombineErrors converts a set of errors (which might be nil) into
+// one. If there are no errors, this returns an untyped nil, and if
+// there's one error it's passed through directly.
+func CombineErrors(errs ...error) error {
+	merr := make(multiError, 0, len(errs))
+	for _, err := range errs {
+		if err != nil {
+			merr = append(merr, err)
+		}
+	}
+	if len(merr) == 0 {
+		return nil
+	}
+	if len(merr) == 1 {
+		return merr[0]
+	}
+	return merr
+}
 
 // Opened provides both the resource info and content.
 type Opened struct {
 	Resource
 	io.ReadCloser
+
+	Closer func() error
 }
 
 // Content returns the "content" for the opened resource.
@@ -22,6 +56,15 @@ func (o Opened) Content() Content {
 		Size:        o.Size,
 		Fingerprint: o.Fingerprint,
 	}
+}
+
+func (o Opened) Close() error {
+	var err1 error
+	if o.Closer != nil {
+		err1 = errors.Trace(o.Closer())
+	}
+	err2 := errors.Trace(o.ReadCloser.Close())
+	return CombineErrors(err1, err2)
 }
 
 // Opener exposes the functionality for opening a resource.

--- a/resource/resourceadapters/apiserver.go
+++ b/resource/resourceadapters/apiserver.go
@@ -48,14 +48,15 @@ func NewApplicationHandler(args apihttp.NewHandlerArgs) http.Handler {
 			if err != nil {
 				return nil, nil, nil, errors.Trace(err)
 			}
-			resources, err := st.Resources()
-			if err != nil {
-				return nil, nil, nil, errors.Trace(err)
-			}
-
 			closer := func() error {
 				return args.Release(st)
 			}
+			resources, err := st.Resources()
+			if err != nil {
+				closer()
+				return nil, nil, nil, errors.Trace(err)
+			}
+
 			return resources, closer, entity.Tag(), nil
 		},
 	)
@@ -65,6 +66,7 @@ func NewApplicationHandler(args apihttp.NewHandlerArgs) http.Handler {
 func NewDownloadHandler(args apihttp.NewHandlerArgs) http.Handler {
 	extractor := &httpDownloadRequestExtractor{
 		connect: args.Connect,
+		release: args.Release,
 	}
 	deps := internalserver.NewHTTPHandlerDeps(extractor)
 	return internalserver.NewHTTPHandler(deps)
@@ -79,15 +81,26 @@ type stateConnector interface {
 // handle a resource download HTTP request.
 type httpDownloadRequestExtractor struct {
 	connect func(*http.Request) (*corestate.State, corestate.Entity, error)
+	release func(*corestate.State) error
 }
 
 // NewResourceOpener returns a new resource.Opener for the given
 // HTTP request.
-func (ex *httpDownloadRequestExtractor) NewResourceOpener(req *http.Request) (resource.Opener, error) {
+func (ex *httpDownloadRequestExtractor) NewResourceOpener(req *http.Request) (opener resource.Opener, err error) {
 	st, _, err := ex.connect(req)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	closer := func() error {
+		return ex.release(st)
+	}
+
+	defer func() {
+		if err != nil {
+			closer()
+		}
+	}()
 
 	unitTagStr := req.URL.Query().Get(":unit")
 	unitTag, err := names.ParseUnitTag(unitTagStr)
@@ -104,11 +117,12 @@ func (ex *httpDownloadRequestExtractor) NewResourceOpener(req *http.Request) (re
 		return nil, errors.Trace(err)
 	}
 
-	opener := &resourceOpener{
+	opener = &resourceOpener{
 		st:     st,
 		res:    resources,
 		userID: unitTag,
 		unit:   unit,
+		closer: closer,
 	}
 	return opener, nil
 }


### PR DESCRIPTION
The resource HTTP handler didn't release the state back into the state 
pool - this would mean that it would stick around in the pool even after 
the model was migrated away, preventing the same model from being 
migrated back. (It would also leak the state if the model was destroyed.)

Thread the call to httpContext.release through so it can be called from
the right place in the resource HTTP handler.

This is the last piece of fixing https://bugs.launchpad.net/juju/+bug/1641824

QA steps:
* bootstrap 2 controllers A and B
* create model m in A
* download the Mattermost binary from https://releases.mattermost.com/3.5.1/mattermost-team-3.5.1-linux-amd64.tar.gz
* deploy Mattermost using that binary distribution
```juju deploy -m A:m cs:~cmars/mattermost --resource bdist=<path to binary distribution>```
* migrate the model to b: `juju migrate -c A m B`
* then migrate it back: `juju migrate -c B m A`
* the migration should be successful