### PR TITLE
Fix application id hack in remote relations worker

### DIFF
--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -249,7 +249,8 @@ type RemoteRelation struct {
 	Life               Life           `json:"life"`
 	Id                 int            `json:"id"`
 	Key                string         `json:"key"`
-	LocalEndpoint      RemoteEndpoint `json:"local-endpoint"`
+	ApplicationName    string         `json:"application-name"`
+	Endpoint           RemoteEndpoint `json:"endpoint"`
 	RemoteEndpointName string         `json:"remote-endpoint-name"`
 }
 
@@ -297,6 +298,23 @@ type GetTokenArg struct {
 
 	// Tag is the tag of the entity for which we want the token.
 	Tag string `json:"tag"`
+}
+
+// ImportEntityArgs holds the arguments to an ImportRemoteEntity API call.
+type ImportEntityArgs struct {
+	Args []ImportEntityArg
+}
+
+// ImportEntityArg holds the model, entity and token to be imported.
+type ImportEntityArg struct {
+	// ModelTag is the tag of the model hosting the entity.
+	ModelTag string `json:"model-tag"`
+
+	// Tag is the tag of the entity for which are importing the token.
+	Tag string `json:"tag"`
+
+	// Token is the token of the entity to be imported.
+	Token string `json:"token"`
 }
 
 // RemoteApplicationResult holds a remote application and an error.

--- a/apiserver/remoterelations/state.go
+++ b/apiserver/remoterelations/state.go
@@ -157,6 +157,9 @@ type RemoteApplication interface {
 
 // Application represents the state of a application hosted in the local model.
 type Application interface {
+	// Name is the name of the application.
+	Name() string
+
 	// Life returns the lifecycle state of the application.
 	Life() state.Life
 

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -401,9 +401,6 @@ func (st *State) AddRemoteApplication(args AddRemoteApplicationParams) (_ *Remot
 		Updated:    time.Now().UnixNano(),
 	}
 
-	importRemoteEntityOps := st.RemoteEntities().importRemoteEntityOps(
-		args.SourceModel, app.Tag(), args.Token,
-	)
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		// If we've tried once already and failed, check that
 		// model may have been destroyed.
@@ -438,7 +435,13 @@ func (st *State) AddRemoteApplication(args AddRemoteApplicationParams) (_ *Remot
 				Assert: txn.DocMissing,
 			},
 		}
-		ops = append(ops, importRemoteEntityOps...)
+		// If we know the token, import it.
+		if args.Token != "" {
+			importRemoteEntityOps := st.RemoteEntities().importRemoteEntityOps(
+				args.SourceModel, app.Tag(), args.Token,
+			)
+			ops = append(ops, importRemoteEntityOps...)
+		}
 		return ops, nil
 	}
 	if err = st.run(buildTxn); err != nil {

--- a/state/remoteentities.go
+++ b/state/remoteentities.go
@@ -112,6 +112,9 @@ func (r *RemoteEntities) ExportLocalEntity(entity names.Tag) (string, error) {
 func (r *RemoteEntities) ImportRemoteEntity(
 	sourceModel names.ModelTag, entity names.Tag, token string,
 ) error {
+	if token == "" {
+		return errors.NotValidf("empty token for %v in model %v", entity.Id(), sourceModel.Id())
+	}
 	ops := r.importRemoteEntityOps(sourceModel, entity, token)
 	err := r.st.runTransaction(ops)
 	if err == txn.ErrAborted {

--- a/state/remoteentities_test.go
+++ b/state/remoteentities_test.go
@@ -94,3 +94,10 @@ func (s *RemoteEntitiesSuite) TestImportRemoteEntity(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(entity, gc.Equals, expected)
 }
+
+func (s *RemoteEntitiesSuite) TestImportRemoteEntityEmptyToken(c *gc.C) {
+	re := s.State.RemoteEntities()
+	entity := names.NewApplicationTag("mysql")
+	err := re.ImportRemoteEntity(s.State.ModelTag(), entity, "")
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+}

--- a/worker/remoterelations/manifold.go
+++ b/worker/remoterelations/manifold.go
@@ -67,6 +67,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		return nil, errors.Trace(err)
 	}
 	w, err := config.NewWorker(Config{
+		ModelUUID:                agent.CurrentConfig().Model().Id(),
 		RelationsFacade:          facade,
 		NewPublisherForModelFunc: relationChangePublisherForModelFunc(apiConnForModelFunc),
 	})

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -122,6 +122,14 @@ func (m *mockRelationsFacade) ExportEntities(entities []names.Tag) ([]params.Rem
 	return result, nil
 }
 
+func (m *mockRelationsFacade) ImportRemoteEntity(sourceModelUUID string, entity names.Tag, token string) error {
+	m.stub.MethodCall(m, "ImportRemoteEntity", sourceModelUUID, entity, token)
+	if err := m.stub.NextErr(); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (m *mockRelationsFacade) GetToken(modelUUID string, entity names.Tag) (string, error) {
 	m.stub.MethodCall(m, "GetToken", modelUUID, entity)
 	if err := m.stub.NextErr(); err != nil {
@@ -152,12 +160,19 @@ func (m *mockRelationsFacade) PublishLocalRelationChange(change params.RemoteRel
 	return nil
 }
 
-func (m *mockRelationsFacade) RegisterRemoteRelation(rel params.RegisterRemoteRelation) error {
-	m.stub.MethodCall(m, "RegisterRemoteRelation", rel)
+func (m *mockRelationsFacade) RegisterRemoteRelations(relations ...params.RegisterRemoteRelation) ([]params.RemoteEntityIdResult, error) {
+	m.stub.MethodCall(m, "RegisterRemoteRelations", relations)
 	if err := m.stub.NextErr(); err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	result := make([]params.RemoteEntityIdResult, len(relations))
+	for i, rel := range relations {
+		result[i].Result = &params.RemoteEntityId{
+			ModelUUID: "source-model-uuid",
+			Token:     "token-" + rel.OfferedApplicationName,
+		}
+	}
+	return result, nil
 }
 
 func (m *mockRelationsFacade) RemoteApplications(names []string) ([]params.RemoteApplicationResult, error) {
@@ -210,7 +225,8 @@ func (m *mockRelationsFacade) Relations(keys []string) ([]params.RemoteRelationR
 			}
 			if epInfo, ok := m.relationsEndpoints[key]; ok {
 				result[i].Result.RemoteEndpointName = epInfo.remoteEndpointName
-				result[i].Result.LocalEndpoint = epInfo.localEndpoint
+				result[i].Result.Endpoint = epInfo.localEndpoint
+				result[i].Result.ApplicationName = epInfo.localApplicationName
 			}
 		} else {
 			result[i].Error = common.ServerError(errors.NotFoundf(key))


### PR DESCRIPTION
Fixes a TODO in remote relations worker. The RegisterRelation call now returns the exported application id of the offered application, which is imported into the consuming model. The remote relations facade needed to gain the ImportRemoteEntity API.

The worker in the consuming model was also incorrectly exporting the remote application, not the local one; the worker has been restructured to properly register the remote relation at the right time in the lifecycle.

Finally, the export mutex is no longer needed so was deleted.

QA: bootstrap and setup a relation between wordpress and mysql in different models