### PR TITLE
Prevent unit failing when starting model migration

### DIFF
--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -226,6 +226,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			LeadershipTrackerName: leadershipTrackerName,
 			CharmDirName:          charmDirName,
 			HookRetryStrategyName: hookRetryStrategyName,
+			TranslateResolverErr:  uniter.TranslateFortressErrors,
 		})),
 
 		// TODO (mattyw) should be added to machine agent.

--- a/worker/fortress/fortress.go
+++ b/worker/fortress/fortress.go
@@ -6,7 +6,6 @@ package fortress
 import (
 	"sync"
 
-	"github.com/juju/errors"
 	"gopkg.in/tomb.v1"
 )
 
@@ -57,7 +56,7 @@ func (f *fortress) Visit(visit Visit, abort Abort) error {
 	result := make(chan error)
 	select {
 	case <-f.tomb.Dying():
-		return errors.New("fortress worker shutting down")
+		return ErrShutdown
 	case <-abort:
 		return ErrAborted
 	case f.guestTickets <- guestTicket{visit, result}:
@@ -70,7 +69,7 @@ func (f *fortress) allowGuests(allowGuests bool, abort Abort) error {
 	result := make(chan error)
 	select {
 	case <-f.tomb.Dying():
-		return errors.New("fortress worker shutting down")
+		return ErrShutdown
 	case f.guardTickets <- guardTicket{allowGuests, abort, result}:
 		return <-result
 	}

--- a/worker/fortress/interface.go
+++ b/worker/fortress/interface.go
@@ -56,3 +56,16 @@ type Abort <-chan struct{}
 
 // ErrAborted is used to confirm clean termination of a blocking operation.
 var ErrAborted = errors.New("fortress operation aborted")
+
+// ErrShutdown is used to report that the fortress worker is shutting down.
+var ErrShutdown = errors.New("fortress worker shutting down")
+
+// IsFortressError returns true if the error provided is fortress related.
+func IsFortressError(err error) bool {
+	switch errors.Cause(err) {
+	case ErrAborted, ErrShutdown:
+		return true
+	default:
+		return false
+	}
+}

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -218,6 +218,9 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 		[]jujutesting.StubCall{
 			{"facade.WatchMinionReports", nil},
 			{"facade.MinionReports", nil},
+		},
+		prechecksCalls,
+		[]jujutesting.StubCall{
 			{"facade.SetPhase", []interface{}{coremigration.IMPORT}},
 
 			//IMPORT

--- a/worker/migrationminion/worker.go
+++ b/worker/migrationminion/worker.go
@@ -205,6 +205,7 @@ func (w *Worker) doSUCCESS(status watcher.MigrationStatus) error {
 }
 
 func (w *Worker) report(status watcher.MigrationStatus, success bool) error {
+	logger.Debugf("reporting back for phase %s: %v", status.Phase, success)
 	err := w.config.Facade.Report(status.MigrationId, status.Phase, success)
 	return errors.Annotate(err, "failed to report phase progress")
 }

--- a/worker/uniter/agent.go
+++ b/worker/uniter/agent.go
@@ -25,6 +25,7 @@ func reportAgentError(u *Uniter, userMessage string, err error) {
 	if err == nil {
 		return
 	}
+	logger.Errorf("%s: %v", userMessage, err)
 	err2 := setAgentStatus(u, status.Failed, userMessage, nil)
 	if err2 != nil {
 		logger.Errorf("updating agent status: %v", err2)

--- a/worker/uniter/manifold.go
+++ b/worker/uniter/manifold.go
@@ -29,6 +29,7 @@ type ManifoldConfig struct {
 	LeadershipTrackerName string
 	CharmDirName          string
 	HookRetryStrategyName string
+	TranslateResolverErr  func(error) error
 }
 
 // Manifold returns a dependency manifold that runs a uniter worker,
@@ -98,6 +99,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				UpdateStatusSignal:   NewUpdateStatusTimer(),
 				HookRetryStrategy:    hookRetryStrategy,
 				NewOperationExecutor: operation.NewExecutor,
+				TranslateResolverErr: config.TranslateResolverErr,
 				Clock:                manifoldConfig.Clock,
 			})
 			if err != nil {

--- a/worker/uniter/manifold.go
+++ b/worker/uniter/manifold.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/uniter/operation"
+	"github.com/juju/juju/worker/uniter/resolver"
 )
 
 // ManifoldConfig defines the names of the manifolds on which a
@@ -108,4 +109,15 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			return uniter, nil
 		},
 	}
+}
+
+// TranslateFortressErrors turns errors returned by dependent
+// manifolds due to fortress lockdown (i.e. model migration) into an
+// error which causes the resolver loop to be restarted. When this
+// happens the uniter is about to be shut down anyway.
+func TranslateFortressErrors(err error) error {
+	if fortress.IsFortressError(err) {
+		return resolver.ErrRestart
+	}
+	return err
 }


### PR DESCRIPTION
When the model migration fortress was locked down some of the manifolds used by the uniter could return a "fortress shutting down" error which was returned to the uniter resolver loop. This would cause the unit to be put into error before the uniter shut down, causing prechecks failures. The problem is somewhat timing dependent which is why it was being seen intermittently.

There are a number of fixes here:

1. The unit agent now logs unclassified resolver loop errors instead of swallowing them.
2. The migrationminion now logs when it is reporting back to the master.
3. The uniter now takes an optional function to support translation of resolver loop errors.
4. The fortress shutdown error is now exported.
5. Using the above fortress errors coming out of the resolver loop now cause the resolver to restart instead of causing a unit error.
6. The migrationmaster now runs prechecks twice in the QUIECSE phase: before minions have reported back to avoid long waits for an agent that will never be able to report and again after minions have reported, to ensure that the model is truly ok to migrate.

### QA

Using a charm with a long sleep in its config-changed hook, tested multiple migrations which were triggered while the hook was executing. Previously this would reliably trigger a precheck failure.

Fixes https://bugs.launchpad.net/juju/+bug/1620438