### PR TITLE
Backport state pool leak fixes to 2.0 branch

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -475,7 +475,11 @@ func (srv *Server) newHandlerArgs(spec apihttp.HandlerConstraints) apihttp.NewHa
 		controllerModelOnly: spec.ControllerModelOnly,
 	}
 
-	var args apihttp.NewHandlerArgs
+	args := apihttp.NewHandlerArgs{
+		Release: func(st *state.State) error {
+			return ctxt.release(st)
+		},
+	}
 	switch spec.AuthKind {
 	case names.UserTagKind:
 		args.Connect = ctxt.stateForRequestAuthenticatedUser

--- a/apiserver/backup.go
+++ b/apiserver/backup.go
@@ -37,6 +37,7 @@ func (h *backupHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		h.sendError(resp, err)
 		return
 	}
+	defer h.ctxt.release(st)
 
 	backups, closer := newBackups(st)
 	defer closer.Close()

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -91,6 +91,8 @@ func (h *charmsHandler) ServePost(w http.ResponseWriter, r *http.Request) error 
 	if err != nil {
 		return errors.Trace(err)
 	}
+	defer h.ctxt.release(st)
+
 	// Add a charm to the store provider.
 	charmURL, err := h.processPost(r, st)
 	if err != nil {
@@ -108,6 +110,8 @@ func (h *charmsHandler) ServeGet(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	h.ctxt.release(st)
+
 	// Retrieve or list charm files.
 	// Requires "url" (charm URL) and an optional "file" (the path to the
 	// charm file) to be included in the query. Optionally also receives an

--- a/apiserver/common/apihttp/handler.go
+++ b/apiserver/common/apihttp/handler.go
@@ -15,6 +15,10 @@ type NewHandlerArgs struct {
 	// Connect is the function that is used to connect to Juju's state
 	// for the given HTTP request.
 	Connect func(*http.Request) (*state.State, state.Entity, error)
+
+	// Release indicates that the state is finished with and should be
+	// closed.
+	Release func(*state.State) error
 }
 
 // HandlerConstraints describes conditions under which a handler

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -80,6 +80,8 @@ func (h *debugLogHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 				socket.sendError(err)
 				return
 			}
+			defer h.ctxt.release(st)
+
 			params, err := readDebugLogParams(req.URL.Query())
 			if err != nil {
 				socket.sendError(err)

--- a/apiserver/gui.go
+++ b/apiserver/gui.go
@@ -140,6 +140,7 @@ func (gr *guiRouter) ensureFiles(req *http.Request) (rootDir string, hash string
 	if err != nil {
 		return "", "", errors.Annotate(err, "cannot open state")
 	}
+	defer gr.ctxt.release(st)
 	storage, err := st.GUIStorage()
 	if err != nil {
 		return "", "", errors.Annotate(err, "cannot open GUI storage")
@@ -418,6 +419,7 @@ func (h *guiArchiveHandler) handleGet(w http.ResponseWriter, req *http.Request) 
 	if err != nil {
 		return errors.Annotate(err, "cannot open state")
 	}
+	defer h.ctxt.release(st)
 	storage, err := st.GUIStorage()
 	if err != nil {
 		return errors.Annotate(err, "cannot open GUI storage")
@@ -485,6 +487,7 @@ func (h *guiArchiveHandler) handlePost(w http.ResponseWriter, req *http.Request)
 	if err != nil {
 		return errors.Annotate(err, "cannot open state")
 	}
+	defer h.ctxt.release(st)
 	storage, err := st.GUIStorage()
 	if err != nil {
 		return errors.Annotate(err, "cannot open GUI storage")
@@ -560,6 +563,7 @@ func (h *guiVersionHandler) handlePut(w http.ResponseWriter, req *http.Request) 
 	if err != nil {
 		return errors.Annotate(err, "cannot open state")
 	}
+	defer h.ctxt.release(st)
 
 	var selected params.GUIVersionRequest
 	decoder := json.NewDecoder(req.Body)

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -173,6 +173,12 @@ func (ctxt *httpContext) loginRequest(r *http.Request) (params.LoginRequest, err
 	}, nil
 }
 
+// release indicates that the client doesn't need this State anymore,
+// so it can be removed from the pool if it needs to be.
+func (ctxt *httpContext) release(st *state.State) error {
+	return ctxt.srv.statePool.Release(st.ModelUUID())
+}
+
 // stop returns a channel which will be closed when a handler should
 // exit.
 func (ctxt *httpContext) stop() <-chan struct{} {

--- a/apiserver/logstream_test.go
+++ b/apiserver/logstream_test.go
@@ -258,13 +258,17 @@ type stubSource struct {
 	ReturnNewTailer state.LogTailer
 }
 
-func (s *stubSource) newSource(req *http.Request) (logStreamSource, error) {
+func (s *stubSource) newSource(req *http.Request) (logStreamSource, closerFunc, error) {
 	s.stub.AddCall("newSource", req)
 	if err := s.stub.NextErr(); err != nil {
-		return nil, errors.Trace(err)
+		return nil, nil, errors.Trace(err)
 	}
 
-	return s, nil
+	closer := func() error {
+		s.stub.AddCall("close")
+		return s.stub.NextErr()
+	}
+	return s, closer, nil
 }
 
 func (s *stubSource) getStart(sink string, allModels bool) (time.Time, error) {

--- a/apiserver/registration.go
+++ b/apiserver/registration.go
@@ -47,6 +47,7 @@ func (h *registerUserHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 		}
 		return
 	}
+	defer h.ctxt.release(st)
 	userTag, response, err := h.processPost(req, st)
 	if err != nil {
 		if err := sendError(w, err); err != nil {

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -45,6 +45,7 @@ func (h *toolsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		}
 		return
 	}
+	defer h.ctxt.release(st)
 
 	switch r.Method {
 	case "GET":
@@ -76,6 +77,7 @@ func (h *toolsUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	defer h.ctxt.release(st)
 
 	switch r.Method {
 	case "POST":

--- a/resource/opened.go
+++ b/resource/opened.go
@@ -7,12 +7,46 @@ package resource
 
 import (
 	"io"
+	"strings"
+
+	"github.com/juju/errors"
 )
+
+type multiError []error
+
+func (m multiError) Error() string {
+	messages := make([]string, len(m))
+	for i, err := range m {
+		messages[i] = err.Error()
+	}
+	return strings.Join(messages, ", and also ")
+}
+
+// CombineErrors converts a set of errors (which might be nil) into
+// one. If there are no errors, this returns an untyped nil, and if
+// there's one error it's passed through directly.
+func CombineErrors(errs ...error) error {
+	merr := make(multiError, 0, len(errs))
+	for _, err := range errs {
+		if err != nil {
+			merr = append(merr, err)
+		}
+	}
+	if len(merr) == 0 {
+		return nil
+	}
+	if len(merr) == 1 {
+		return merr[0]
+	}
+	return merr
+}
 
 // Opened provides both the resource info and content.
 type Opened struct {
 	Resource
 	io.ReadCloser
+
+	Closer func() error
 }
 
 // Content returns the "content" for the opened resource.
@@ -22,6 +56,15 @@ func (o Opened) Content() Content {
 		Size:        o.Size,
 		Fingerprint: o.Fingerprint,
 	}
+}
+
+func (o Opened) Close() error {
+	var err1 error
+	if o.Closer != nil {
+		err1 = errors.Trace(o.Closer())
+	}
+	err2 := errors.Trace(o.ReadCloser.Close())
+	return CombineErrors(err1, err2)
 }
 
 // Opener exposes the functionality for opening a resource.

--- a/resource/resourceadapters/apiserver.go
+++ b/resource/resourceadapters/apiserver.go
@@ -47,14 +47,15 @@ func NewUploadHandler(args apihttp.NewHandlerArgs) http.Handler {
 			if err != nil {
 				return nil, nil, nil, errors.Trace(err)
 			}
-			resources, err := st.Resources()
-			if err != nil {
-				return nil, nil, nil, errors.Trace(err)
-			}
-
 			closer := func() error {
 				return args.Release(st)
 			}
+			resources, err := st.Resources()
+			if err != nil {
+				closer()
+				return nil, nil, nil, errors.Trace(err)
+			}
+
 			return resources, closer, entity.Tag(), nil
 		},
 	)
@@ -64,6 +65,7 @@ func NewUploadHandler(args apihttp.NewHandlerArgs) http.Handler {
 func NewDownloadHandler(args apihttp.NewHandlerArgs) http.Handler {
 	extractor := &httpDownloadRequestExtractor{
 		connect: args.Connect,
+		release: args.Release,
 	}
 	deps := internalserver.NewLegacyHTTPHandlerDeps(extractor)
 	return internalserver.NewLegacyHTTPHandler(deps)
@@ -78,15 +80,27 @@ type stateConnector interface {
 // handle a resource download HTTP request.
 type httpDownloadRequestExtractor struct {
 	connect func(*http.Request) (*corestate.State, corestate.Entity, error)
+	release func(*corestate.State) error
 }
 
 // NewResourceOpener returns a new resource.Opener for the given
 // HTTP request.
-func (ex *httpDownloadRequestExtractor) NewResourceOpener(req *http.Request) (resource.Opener, error) {
+func (ex *httpDownloadRequestExtractor) NewResourceOpener(req *http.Request) (opener resource.Opener, err error) {
 	st, ent, err := ex.connect(req)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	closer := func() error {
+		return ex.release(st)
+	}
+
+	defer func() {
+		if err != nil {
+			closer()
+		}
+	}()
+
 	unit, ok := ent.(*corestate.Unit)
 	if !ok {
 		logger.Errorf("unexpected type: %T", ent)
@@ -98,11 +112,12 @@ func (ex *httpDownloadRequestExtractor) NewResourceOpener(req *http.Request) (re
 		return nil, errors.Trace(err)
 	}
 
-	opener := &resourceOpener{
+	opener = &resourceOpener{
 		st:     st,
 		res:    resources,
 		userID: unit.Tag(),
 		unit:   unit,
+		closer: closer,
 	}
 	return opener, nil
 }

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1218,6 +1218,7 @@ func (b *allModelWatcherStateBacking) Changed(all *multiwatcherStore, change wat
 		}
 		return errors.Trace(err)
 	}
+	defer b.stPool.Release(modelUUID)
 
 	col, closer := st.getCollection(c.name)
 	defer closer()


### PR DESCRIPTION
Fix state pool leaks (gets without corresponding releases) from code using the httpContext methods to get a state object. Backports of #6566 and #6703 to the 2.0 branch.

Fixes https://bugs.launchpad.net/juju/+bug/1641824 - although migrations aren't available in 2.0, the state pool would also leak when models are destroyed.