### PR TITLE
Migration precheck for pending resources 

### DIFF
--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -490,7 +490,11 @@ func (c *ControllerAPI) ModifyControllerAccess(args params.ModifyControllerAcces
 
 var runMigrationPrechecks = func(st *state.State, targetInfo coremigration.TargetInfo) error {
 	// Check model and source controller.
-	if err := migration.SourcePrecheck(migration.PrecheckShim(st)); err != nil {
+	backend, err := migration.PrecheckShim(st)
+	if err != nil {
+		return errors.Annotate(err, "creating backend")
+	}
+	if err := migration.SourcePrecheck(backend); err != nil {
 		return errors.Annotate(err, "source prechecks failed")
 	}
 

--- a/apiserver/migrationmaster/shim.go
+++ b/apiserver/migrationmaster/shim.go
@@ -19,7 +19,11 @@ func newAPIForRegistration(
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*API, error) {
-	return NewAPI(&backendShim{st}, migration.PrecheckShim(st), resources, authorizer)
+	precheckBackend, err := migration.PrecheckShim(st)
+	if err != nil {
+		return nil, errors.Annotate(err, "creating precheck backend")
+	}
+	return NewAPI(&backendShim{st}, precheckBackend, resources, authorizer)
 }
 
 // backendShim wraps a *state.State to implement Backend. It is

--- a/apiserver/migrationtarget/migrationtarget.go
+++ b/apiserver/migrationtarget/migrationtarget.go
@@ -67,8 +67,12 @@ func (api *API) Prechecks(model params.MigrationModelInfo) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	backend, err := migration.PrecheckShim(api.state)
+	if err != nil {
+		return errors.Annotate(err, "creating backend")
+	}
 	return migration.TargetPrecheck(
-		migration.PrecheckShim(api.state),
+		backend,
 		coremigration.ModelInfo{
 			UUID:         model.UUID,
 			Name:         model.Name,

--- a/cmd/jujud/agent/package_test.go
+++ b/cmd/jujud/agent/package_test.go
@@ -6,8 +6,16 @@ package agent // not agent_test for no good reason
 import (
 	stdtesting "testing"
 
+	"github.com/juju/juju/component/all"
 	coretesting "github.com/juju/juju/testing"
 )
+
+func init() {
+	// Required for resources support.
+	if err := all.RegisterForServer(); err != nil {
+		panic(err)
+	}
+}
 
 func TestPackage(t *stdtesting.T) {
 	// TODO(waigani) 2014-03-19 bug 1294458

--- a/migration/precheck_shim.go
+++ b/migration/precheck_shim.go
@@ -7,18 +7,27 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/version"
 
+	"github.com/juju/juju/resource"
 	"github.com/juju/juju/state"
 )
 
 // PrecheckShim wraps a *state.State to implement PrecheckBackend.
-func PrecheckShim(st *state.State) PrecheckBackend {
-	return &precheckShim{st}
+func PrecheckShim(st *state.State) (PrecheckBackend, error) {
+	rSt, err := st.Resources()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &precheckShim{
+		State:       st,
+		resourcesSt: rSt,
+	}, nil
 }
 
 // precheckShim is untested, but is simple enough to be verified by
 // inspection.
 type precheckShim struct {
 	*state.State
+	resourcesSt state.Resources
 }
 
 // Model implements PrecheckBackend.
@@ -87,6 +96,15 @@ func (s *precheckShim) AllApplications() ([]PrecheckApplication, error) {
 	return out, nil
 }
 
+// ListPendingResources implements PrecheckBackend.
+func (s *precheckShim) ListPendingResources(app string) ([]resource.Resource, error) {
+	resources, err := s.resourcesSt.ListPendingResources(app)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return resources, nil
+}
+
 // ControllerBackend implements PrecheckBackend.
 func (s *precheckShim) ControllerBackend() (PrecheckBackendCloser, error) {
 	model, err := s.State.ControllerModel()
@@ -97,7 +115,15 @@ func (s *precheckShim) ControllerBackend() (PrecheckBackendCloser, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &precheckShim{st}, nil
+	rSt, err := st.Resources()
+	if err != nil {
+		st.Close()
+		return nil, errors.Trace(err)
+	}
+	return &precheckShim{
+		State:       st,
+		resourcesSt: rSt,
+	}, nil
 }
 
 // precheckAppShim implements PrecheckApplication.

--- a/resource/state/resource.go
+++ b/resource/state/resource.go
@@ -138,6 +138,16 @@ func (st resourceState) ListResources(applicationID string) (resource.ServiceRes
 	return resources, nil
 }
 
+// ListPendinglResources returns the resource data for the given
+// application ID for pending resources only.
+func (st resourceState) ListPendingResources(applicationID string) ([]resource.Resource, error) {
+	resources, err := st.persist.ListPendingResources(applicationID)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return resources, err
+}
+
 // GetResource returns the resource data for the identified resource.
 func (st resourceState) GetResource(applicationID, name string) (resource.Resource, error) {
 	id := newResourceID(applicationID, name)

--- a/resource/state/resource_test.go
+++ b/resource/state/resource_test.go
@@ -129,6 +129,20 @@ func (s *ResourceSuite) TestListResourcesError(c *gc.C) {
 	s.stub.CheckCallNames(c, "ListResources", "VerifyService")
 }
 
+func (s *ResourceSuite) TestListPendingResources(c *gc.C) {
+	resources := newUploadResources(c, "spam", "eggs")
+	s.persist.ReturnListPendingResources = resources
+	st := NewState(s.raw)
+	s.stub.ResetCalls()
+
+	outResources, err := st.ListPendingResources("a-application")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(outResources, jc.DeepEquals, resources)
+	s.stub.CheckCallNames(c, "ListPendingResources")
+	s.stub.CheckCall(c, 0, "ListPendingResources", "a-application")
+}
+
 func (s *ResourceSuite) TestGetPendingResource(c *gc.C) {
 	resources := newUploadResources(c, "spam", "eggs")
 	resources[0].PendingID = "some-unique-id"

--- a/state/resources.go
+++ b/state/resources.go
@@ -19,6 +19,10 @@ type Resources interface {
 	// ListResources returns the list of resources for the given application.
 	ListResources(applicationID string) (resource.ServiceResources, error)
 
+	// ListPendingResources returns the list of pending resources for
+	// the given application.
+	ListPendingResources(applicationID string) ([]resource.Resource, error)
+
 	// AddPendingResource adds the resource to the data store in a
 	// "pending" state. It will stay pending (and unavailable) until
 	// it is resolved. The returned ID is used to identify the pending

--- a/state/resources_persistence.go
+++ b/state/resources_persistence.go
@@ -384,7 +384,7 @@ func (p ResourcePersistence) NewRemoveUnitResourcesOps(unitID string) ([]txn.Op,
 }
 
 // NewRemoveResourcesOps returns mgo transaction operations that
-// remove all the service's resources from state.
+// remove all the applications's resources from state.
 func (p ResourcePersistence) NewRemoveResourcesOps(applicationID string) ([]txn.Op, error) {
 	docs, err := p.resources(applicationID)
 	if err != nil {


### PR DESCRIPTION
Don't allow a migration to proceed if a resource is pending. A resource is pending if it is in the process of being added or downloaded (i.e. immediately after deploy or is being downloaded). The pending state is typically short-lived.

This is a forward port of #6695.
