### PR TITLE
migration: Controller version precheck

### DIFF
--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -143,10 +143,11 @@ func (c *Client) ModelInfo() (migration.ModelInfo, error) {
 		return migration.ModelInfo{}, errors.Trace(err)
 	}
 	return migration.ModelInfo{
-		UUID:         info.UUID,
-		Name:         info.Name,
-		Owner:        owner,
-		AgentVersion: info.AgentVersion,
+		UUID:                   info.UUID,
+		Name:                   info.Name,
+		Owner:                  owner,
+		AgentVersion:           info.AgentVersion,
+		ControllerAgentVersion: info.ControllerAgentVersion,
 	}, nil
 }
 

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -175,10 +175,11 @@ func (s *ClientSuite) TestModelInfo(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(objType string, v int, id, request string, arg, result interface{}) error {
 		stub.AddCall(objType+"."+request, id, arg)
 		*(result.(*params.MigrationModelInfo)) = params.MigrationModelInfo{
-			UUID:         "uuid",
-			Name:         "name",
-			OwnerTag:     owner.String(),
-			AgentVersion: version.MustParse("1.2.3"),
+			UUID:                   "uuid",
+			Name:                   "name",
+			OwnerTag:               owner.String(),
+			AgentVersion:           version.MustParse("1.2.3"),
+			ControllerAgentVersion: version.MustParse("1.2.4"),
 		}
 		return nil
 	})
@@ -189,10 +190,11 @@ func (s *ClientSuite) TestModelInfo(c *gc.C) {
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(model, jc.DeepEquals, migration.ModelInfo{
-		UUID:         "uuid",
-		Name:         "name",
-		Owner:        owner,
-		AgentVersion: version.MustParse("1.2.3"),
+		UUID:                   "uuid",
+		Name:                   "name",
+		Owner:                  owner,
+		AgentVersion:           version.MustParse("1.2.3"),
+		ControllerAgentVersion: version.MustParse("1.2.4"),
 	})
 }
 

--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -44,10 +44,11 @@ type Client struct {
 
 func (c *Client) Prechecks(model coremigration.ModelInfo) error {
 	args := params.MigrationModelInfo{
-		UUID:         model.UUID,
-		Name:         model.Name,
-		OwnerTag:     model.Owner.String(),
-		AgentVersion: model.AgentVersion,
+		UUID:                   model.UUID,
+		Name:                   model.Name,
+		OwnerTag:               model.Owner.String(),
+		AgentVersion:           model.AgentVersion,
+		ControllerAgentVersion: model.ControllerAgentVersion,
 	}
 	return c.caller.FacadeCall("Prechecks", args, nil)
 }

--- a/api/migrationtarget/client_test.go
+++ b/api/migrationtarget/client_test.go
@@ -54,20 +54,23 @@ func (s *ClientSuite) TestPrechecks(c *gc.C) {
 
 	ownerTag := names.NewUserTag("owner")
 	vers := version.MustParse("1.2.3")
+	controllerVers := version.MustParse("1.2.5")
 
 	err := client.Prechecks(coremigration.ModelInfo{
-		UUID:         "uuid",
-		Owner:        ownerTag,
-		Name:         "name",
-		AgentVersion: vers,
+		UUID:                   "uuid",
+		Owner:                  ownerTag,
+		Name:                   "name",
+		AgentVersion:           vers,
+		ControllerAgentVersion: controllerVers,
 	})
 	c.Assert(err, gc.ErrorMatches, "boom")
 
 	expectedArg := params.MigrationModelInfo{
-		UUID:         "uuid",
-		Name:         "name",
-		OwnerTag:     ownerTag.String(),
-		AgentVersion: vers,
+		UUID:                   "uuid",
+		Name:                   "name",
+		OwnerTag:               ownerTag.String(),
+		AgentVersion:           vers,
+		ControllerAgentVersion: controllerVers,
 	}
 	stub.CheckCalls(c, []jujutesting.StubCall{
 		{"MigrationTarget.Prechecks", []interface{}{"", expectedArg}},

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -519,16 +519,31 @@ func makeModelInfo(st *state.State) (coremigration.ModelInfo, error) {
 	if err != nil {
 		return empty, errors.Trace(err)
 	}
+
+	// Retrieve agent version for the model.
 	conf, err := st.ModelConfig()
 	if err != nil {
 		return empty, errors.Trace(err)
 	}
 	agentVersion, _ := conf.AgentVersion()
+
+	// Retrieve agent version for the controller.
+	controllerModel, err := st.ControllerModel()
+	if err != nil {
+		return empty, errors.Trace(err)
+	}
+	controllerConfig, err := controllerModel.Config()
+	if err != nil {
+		return empty, errors.Trace(err)
+	}
+	controllerVersion, _ := controllerConfig.AgentVersion()
+
 	return coremigration.ModelInfo{
-		UUID:         model.UUID(),
-		Name:         model.Name(),
-		Owner:        model.Owner(),
-		AgentVersion: agentVersion,
+		UUID:                   model.UUID(),
+		Name:                   model.Name(),
+		Owner:                  model.Owner(),
+		AgentVersion:           agentVersion,
+		ControllerAgentVersion: controllerVersion,
 	}, nil
 }
 

--- a/apiserver/migrationtarget/migrationtarget.go
+++ b/apiserver/migrationtarget/migrationtarget.go
@@ -74,10 +74,11 @@ func (api *API) Prechecks(model params.MigrationModelInfo) error {
 	return migration.TargetPrecheck(
 		backend,
 		coremigration.ModelInfo{
-			UUID:         model.UUID,
-			Name:         model.Name,
-			Owner:        ownerTag,
-			AgentVersion: model.AgentVersion,
+			UUID:                   model.UUID,
+			Name:                   model.Name,
+			Owner:                  ownerTag,
+			AgentVersion:           model.AgentVersion,
+			ControllerAgentVersion: model.ControllerAgentVersion,
 		},
 	)
 }

--- a/apiserver/migrationtarget/migrationtarget_test.go
+++ b/apiserver/migrationtarget/migrationtarget_test.go
@@ -86,10 +86,11 @@ func (s *Suite) importModel(c *gc.C, api *migrationtarget.API) names.ModelTag {
 func (s *Suite) TestPrechecks(c *gc.C) {
 	api := s.mustNewAPI(c)
 	args := params.MigrationModelInfo{
-		UUID:         "uuid",
-		Name:         "some-model",
-		OwnerTag:     names.NewUserTag("someone").String(),
-		AgentVersion: s.controllerVersion(c),
+		UUID:                   "uuid",
+		Name:                   "some-model",
+		OwnerTag:               names.NewUserTag("someone").String(),
+		AgentVersion:           s.controllerVersion(c),
+		ControllerAgentVersion: s.controllerVersion(c),
 	}
 	err := api.Prechecks(args)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -133,10 +133,11 @@ type MasterMigrationStatus struct {
 // MigrationModelInfo is used to report basic model information to the
 // migrationmaster worker.
 type MigrationModelInfo struct {
-	UUID         string         `json:"uuid"`
-	Name         string         `json:"name"`
-	OwnerTag     string         `json:"owner-tag"`
-	AgentVersion version.Number `json:"agent-version"`
+	UUID                   string         `json:"uuid"`
+	Name                   string         `json:"name"`
+	OwnerTag               string         `json:"owner-tag"`
+	AgentVersion           version.Number `json:"agent-version"`
+	ControllerAgentVersion version.Number `json:"controller-agent-version"`
 }
 
 // MigrationStatus reports the current status of a model migration.

--- a/core/migration/migration.go
+++ b/core/migration/migration.go
@@ -67,10 +67,11 @@ type SerializedModelResource struct {
 
 // ModelInfo is used to report basic details about a model.
 type ModelInfo struct {
-	UUID         string
-	Owner        names.UserTag
-	Name         string
-	AgentVersion version.Number
+	UUID                   string
+	Owner                  names.UserTag
+	Name                   string
+	AgentVersion           version.Number
+	ControllerAgentVersion version.Number
 }
 
 func (i *ModelInfo) Validate() error {

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -341,12 +341,73 @@ func (s *TargetPrecheckSuite) TestSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *TargetPrecheckSuite) TestVersionLessThanSource(c *gc.C) {
+func (s *TargetPrecheckSuite) TestModelVersionAheadOfTarget(c *gc.C) {
 	backend := newFakeBackend()
-	s.modelInfo.AgentVersion = version.MustParse("1.2.4")
+
+	sourceVersion := backendVersion
+	sourceVersion.Patch++
+	s.modelInfo.AgentVersion = sourceVersion
+
 	err := migration.TargetPrecheck(backend, s.modelInfo)
 	c.Assert(err.Error(), gc.Equals,
 		`model has higher version than target controller (1.2.4 > 1.2.3)`)
+}
+
+func (s *TargetPrecheckSuite) TestSourceControllerMajorAhead(c *gc.C) {
+	backend := newFakeBackend()
+
+	sourceVersion := backendVersion
+	sourceVersion.Major++
+	sourceVersion.Minor = 0
+	sourceVersion.Patch = 0
+	s.modelInfo.ControllerAgentVersion = sourceVersion
+
+	err := migration.TargetPrecheck(backend, s.modelInfo)
+	c.Assert(err.Error(), gc.Equals,
+		`source controller has higher version than target controller (2.0.0 > 1.2.3)`)
+}
+
+func (s *TargetPrecheckSuite) TestSourceControllerMinorAhead(c *gc.C) {
+	backend := newFakeBackend()
+
+	sourceVersion := backendVersion
+	sourceVersion.Minor++
+	sourceVersion.Patch = 0
+	s.modelInfo.ControllerAgentVersion = sourceVersion
+
+	err := migration.TargetPrecheck(backend, s.modelInfo)
+	c.Assert(err.Error(), gc.Equals,
+		`source controller has higher version than target controller (1.3.0 > 1.2.3)`)
+}
+
+func (s *TargetPrecheckSuite) TestSourceControllerPatchAhead(c *gc.C) {
+	backend := newFakeBackend()
+
+	sourceVersion := backendVersion
+	sourceVersion.Patch++
+	s.modelInfo.ControllerAgentVersion = sourceVersion
+
+	c.Assert(migration.TargetPrecheck(backend, s.modelInfo), jc.ErrorIsNil)
+}
+
+func (s *TargetPrecheckSuite) TestSourceControllerBuildAhead(c *gc.C) {
+	backend := newFakeBackend()
+
+	sourceVersion := backendVersion
+	sourceVersion.Build++
+	s.modelInfo.ControllerAgentVersion = sourceVersion
+
+	c.Assert(migration.TargetPrecheck(backend, s.modelInfo), jc.ErrorIsNil)
+}
+
+func (s *TargetPrecheckSuite) TestSourceControllerTagMismatch(c *gc.C) {
+	backend := newFakeBackend()
+
+	sourceVersion := backendVersion
+	sourceVersion.Tag = "alpha"
+	s.modelInfo.ControllerAgentVersion = sourceVersion
+
+	c.Assert(migration.TargetPrecheck(backend, s.modelInfo), jc.ErrorIsNil)
 }
 
 func (s *TargetPrecheckSuite) TestDying(c *gc.C) {


### PR DESCRIPTION
As well as checking the source model version against the target controller version, the source controller verison needs to be checked.

A migration is allowed as long as the major.minor of the target controller is greater than or equal to the major.minor of the source controller. This offers the possibility of migration back to the original controller as long as the versions are close together (i.e. have compatible migration APIs).

Forward port of #6705.