### PR TITLE
Handle when one of the subnets is unknown.

### DIFF
--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -902,7 +902,15 @@ func (m *Machine) LinkLayerDevicesForSpaces(spaces []string) (map[string][]*Link
 	for _, addr := range addresses {
 		subnet, err := addr.Subnet()
 		if err != nil {
-			// XXX should we be omitting all other good records because this one was bad?
+			if errors.IsNotFound(err) {
+				// We record all addresses that we find on the
+				// machine. However, some devices may have IP
+				// addresses that are not in known subnets or spaces.
+				// (loopback devices aren't in a space, arbitrary
+				// application based addresses, etc.)
+				continue
+			}
+			// We don't understand the error, so error out for now
 			return nil, errors.Trace(err)
 		}
 		spaceName := subnet.SpaceName()


### PR DESCRIPTION
It seems that address.Subnet() can fail with NotFound but this should be handled as an expected condition. (I audited the other call sites for Subnet() and they all handle the NotFoundError.)

So we just need to also do this in LinkLayerDevicesForSpaces().

Added a test, I will merge this into my other branch and verify it fixes the current problem.