### PR TITLE
Improve manual provider controller clean-up resilience

### DIFF
--- a/cmd/juju/interact/pollster.go
+++ b/cmd/juju/interact/pollster.go
@@ -29,7 +29,7 @@ type Pollster struct {
 	scanner    *bufio.Scanner
 	out        io.Writer
 	errOut     io.Writer
-	in      io.Reader
+	in         io.Reader
 }
 
 // New returns a Pollster that wraps the given reader and writer.

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -268,6 +268,7 @@ wait_for_jujud
 }
 [[ $stopped -ne 1 ]] && {
     echo jujud removal failed
+    logger --id $(ps -o pid,cmd,state -p $(pgrep jujud) | awk 'NR != 1 {printf("Process %%d (%%s) has state %%s\n", $1, $2, $3)}')
     exit 1
 }
 service %[5]s stop && logger --id stopped %[5]s

--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -82,12 +82,13 @@ func (s *environSuite) TestDestroyController(c *gc.C) {
 		c.Assert(host, gc.Equals, "ubuntu@hostname")
 		c.Assert(command, gc.DeepEquals, []string{"sudo", "/bin/bash"})
 		c.Assert(stdin, gc.Equals, `
+# Signal the jujud process to stop, then check it has done so before cleaning-up
+# after it.
 set -x
 touch '/var/lib/juju/uninstall-agent'
 
 stopped=0
 function wait_for_jujud {
-    # Give jujud a chance to stop after pkill.
     for i in {1..30}; do
         if pgrep jujud > /dev/null ; then
             sleep 1
@@ -101,7 +102,7 @@ function wait_for_jujud {
 }
 
 # There might be no jujud at all (for example, after a failed deployment) so
-# don't require pkill to succeed before checking jujud is dead.
+# don't require pkill to succeed before looking for a jujud process.
 pkill -6 jujud
 wait_for_jujud
 

--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -84,26 +84,36 @@ func (s *environSuite) TestDestroyController(c *gc.C) {
 		c.Assert(stdin, gc.Equals, `
 set -x
 touch '/var/lib/juju/uninstall-agent'
-# If jujud is running, we then wait for a while for it to stop.
+
 stopped=0
-if pkill -6 jujud; then
+function wait_for_jujud {
+    # Give jujud a chance to stop after pkill.
     for i in {1..30}; do
         if pgrep jujud > /dev/null ; then
             sleep 1
         else
-            echo "jujud stopped"
+            echo jujud stopped
             stopped=1
             logger --id jujud stopped on attempt $i
             break
         fi
     done
-fi
-if [ $stopped -ne 1 ]; then
+}
+
+# There might be no jujud at all (for example, after a failed deployment) so
+# don't require pkill to succeed before checking jujud is dead.
+pkill -6 jujud
+wait_for_jujud
+
+[[ $stopped -ne 1 ]] && {
     # If jujud didn't stop nicely, we kill it hard here.
-    pkill -9 jujud
-    service juju-db stop
-    logger --id killed jujud and stopped juju-db
-fi
+    pkill -9 jujud && wait_for_jujud
+}
+[[ $stopped -ne 1 ]] && {
+    echo jujud removal failed
+    exit 1
+}
+service juju-db stop && logger --id stopped juju-db
 apt-get -y purge juju-mongo*
 apt-get -y autoremove
 rm -f /etc/init/juju*

--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -112,6 +112,7 @@ wait_for_jujud
 }
 [[ $stopped -ne 1 ]] && {
     echo jujud removal failed
+    logger --id $(ps -o pid,cmd,state -p $(pgrep jujud) | awk 'NR != 1 {printf("Process %d (%s) has state %s\n", $1, $2, $3)}')
     exit 1
 }
 service juju-db stop && logger --id stopped juju-db

--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -103,12 +103,14 @@ function wait_for_jujud {
 
 # There might be no jujud at all (for example, after a failed deployment) so
 # don't require pkill to succeed before looking for a jujud process.
-pkill -6 jujud
+# SIGABRT not SIGTERM, as abort lets the worker know it should uninstall itself,
+# rather than terminate normally.
+pkill -SIGABRT jujud
 wait_for_jujud
 
 [[ $stopped -ne 1 ]] && {
     # If jujud didn't stop nicely, we kill it hard here.
-    pkill -9 jujud && wait_for_jujud
+    pkill -SIGKILL jujud && wait_for_jujud
 }
 [[ $stopped -ne 1 ]] && {
     echo jujud removal failed


### PR DESCRIPTION
Updates to the manual provider clean-up script to improve the checks for
the jujud process kill before proceeding.

This will not fix lp:1642295, but may help and will improve logging.