### PR TITLE
Restrict Containers to only use host bridges for desired spaces

### DIFF
--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -12,6 +12,7 @@ import (
 	jujutxn "github.com/juju/txn"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
@@ -634,30 +635,74 @@ func (s *linkLayerDevicesStateSuite) TestMachineRemoveAllLinkLayerDevicesNoError
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *linkLayerDevicesStateSuite) setupMachineWithOneNIC(c *gc.C) {
-	_, err := s.State.AddSubnet(state.SubnetInfo{
-		CIDR:      "10.0.0.0/24",
-		SpaceName: "default",
-	})
+func (s *linkLayerDevicesStateSuite) createSpaceAndSubnet(c *gc.C, spaceName, CIDR string) {
+	_, err := s.State.AddSpace(spaceName, network.Id(spaceName), nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddSubnet(state.SubnetInfo{
-		CIDR:      "10.10.0.0/24",
-		SpaceName: "dmz",
+		CIDR:      CIDR,
+		SpaceName: spaceName,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machine.SetLinkLayerDevices(
+}
+
+// setupTwoSpaces creates a 'default' and a 'dmz' space, each with a single
+// registered subnet. 10.0.0.0/24 for 'default', and '10.10.0.0/24' for 'dmz'
+func (s *linkLayerDevicesStateSuite) setupTwoSpaces(c *gc.C) {
+	s.createSpaceAndSubnet(c, "default", "10.0.0.0/24")
+	s.createSpaceAndSubnet(c, "dmz", "10.10.0.0/24")
+}
+
+func (s *linkLayerDevicesStateSuite) setupMachineWithOneNIC(c *gc.C) {
+	s.setupTwoSpaces(c)
+	// In the default space
+	s.createNICWithIP(c, s.machine, "eth0", "10.0.0.20/24")
+}
+
+func (s *linkLayerDevicesStateSuite) createNICWithIP(c *gc.C, machine *state.Machine, deviceName, cidrAddress string) {
+	err := machine.SetLinkLayerDevices(
 		state.LinkLayerDeviceArgs{
-			Name:       "eth0",
+			Name:       deviceName,
 			Type:       state.EthernetDevice,
-			MACAddress: "01:23:45:67:89:ab:cd:ef",
+			ParentName: "",
 			IsUp:       true,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machine.SetDevicesAddresses(
+	err = machine.SetDevicesAddresses(
 		state.LinkLayerDeviceAddress{
-			DeviceName:   "eth0",
-			CIDRAddress:  "10.0.0.20/24",
+			DeviceName:   deviceName,
+			CIDRAddress:  cidrAddress,
+			ConfigMethod: state.StaticAddress,
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+// createNICAndBridgeWithIP creates a network interface and a bridge on the
+// machine, and assigns the requested CIDRAddress to the bridge.
+func (s *linkLayerDevicesStateSuite) createNICAndBridgeWithIP(c *gc.C, machine *state.Machine, deviceName, bridgeName, cidrAddress string) {
+	err := machine.SetLinkLayerDevices(
+		state.LinkLayerDeviceArgs{
+			Name:       bridgeName,
+			Type:       state.BridgeDevice,
+			ParentName: "",
+			IsUp:       true,
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine.SetLinkLayerDevices(
+		state.LinkLayerDeviceArgs{
+			Name:       deviceName,
+			Type:       state.EthernetDevice,
+			ParentName: bridgeName,
+			IsUp:       true,
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine.SetDevicesAddresses(
+		state.LinkLayerDeviceAddress{
+			DeviceName:   bridgeName,
+			CIDRAddress:  cidrAddress,
 			ConfigMethod: state.StaticAddress,
 		},
 	)
@@ -665,43 +710,15 @@ func (s *linkLayerDevicesStateSuite) setupMachineWithOneNIC(c *gc.C) {
 }
 
 func (s *linkLayerDevicesStateSuite) setupMachineWithOneNICAndBridge(c *gc.C) {
-	_, err := s.State.AddSubnet(state.SubnetInfo{
-		CIDR:      "10.0.0.0/24",
-		SpaceName: "default",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.AddSubnet(state.SubnetInfo{
-		CIDR:      "10.10.0.0/24",
-		SpaceName: "dmz",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.machine.SetLinkLayerDevices(
-		state.LinkLayerDeviceArgs{
-			Name:       "br-eth0",
-			Type:       state.BridgeDevice,
-			ParentName: "",
-			MACAddress: "01:23:45:67:89:ab:cd:ef", // Same as primary device
-			IsUp:       true,
-		},
-	)
-	err = s.machine.SetLinkLayerDevices(
-		state.LinkLayerDeviceArgs{
-			Name:       "eth0",
-			Type:       state.EthernetDevice,
-			MACAddress: "01:23:45:67:89:ab:cd:ef",
-			ParentName: "br-eth0",
-			IsUp:       true,
-		},
-	)
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.machine.SetDevicesAddresses(
-		state.LinkLayerDeviceAddress{
-			DeviceName:   "br-eth0",
-			CIDRAddress:  "10.0.0.20/24",
-			ConfigMethod: state.StaticAddress,
-		},
-	)
-	c.Assert(err, jc.ErrorIsNil)
+	s.setupTwoSpaces(c)
+	// Is put into the 'default' space
+	s.createNICAndBridgeWithIP(c, s.machine, "eth0", "br-eth0", "10.0.0.20/24")
+}
+
+func (s *linkLayerDevicesStateSuite) setupMachineInTwoSpaces(c *gc.C) {
+	s.setupTwoSpaces(c)
+	s.createNICAndBridgeWithIP(c, s.machine, "ens33", "br-ens33", "10.0.0.20/24")
+	s.createNICAndBridgeWithIP(c, s.machine, "ens0p10", "br-ens0p10", "10.10.0.20/24")
 }
 
 func (s *linkLayerDevicesStateSuite) TestLinkLayerDevicesForSpaces(c *gc.C) {
@@ -741,22 +758,7 @@ func (s *linkLayerDevicesStateSuite) TestLinkLayerDevicesForSpacesNoBridge(c *gc
 func (s *linkLayerDevicesStateSuite) TestLinkLayerDevicesForSpacesMultipleSpaces(c *gc.C) {
 	s.setupMachineWithOneNICAndBridge(c)
 	// Now add a NIC in the dmz space, but without a bridge
-	err := s.machine.SetLinkLayerDevices(
-		state.LinkLayerDeviceArgs{
-			Name:       "eth1",
-			Type:       state.EthernetDevice,
-			MACAddress: "11:23:45:67:89:ab:cd:ef",
-			IsUp:       true,
-		},
-	)
-	err = s.machine.SetDevicesAddresses(
-		state.LinkLayerDeviceAddress{
-			DeviceName:   "eth1",
-			CIDRAddress:  "10.10.0.20/24",
-			ConfigMethod: state.StaticAddress,
-		},
-	)
-	c.Assert(err, jc.ErrorIsNil)
+	s.createNICWithIP(c, s.machine, "eth1", "10.10.0.20/24")
 	res, err := s.machine.LinkLayerDevicesForSpaces([]string{"default", "dmz"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(res, gc.HasLen, 2)
@@ -776,33 +778,8 @@ func (s *linkLayerDevicesStateSuite) TestLinkLayerDevicesForSpacesWithExtraAddre
 	// find. One of them is always the loopback, but we could find any
 	// other addresses that someone created on the machine that we
 	// don't know what they are.
-	// Now add a NIC in the dmz space, but without a bridge
-	err := s.machine.SetLinkLayerDevices(
-		[]state.LinkLayerDeviceArgs{{
-			Name:       "lo",
-			Type:       state.LoopbackDevice,
-			MACAddress: "99:23:45:67:89:ab:cd:ef",
-			IsUp:       true,
-		}, {
-			Name:       "eth1",
-			Type:       state.EthernetDevice,
-			MACAddress: "11:23:45:67:89:ab:cd:ef",
-			IsUp:       true,
-		}}...
-	)
-	err = s.machine.SetDevicesAddresses(
-		[]state.LinkLayerDeviceAddress{{
-			DeviceName:   "eth1",
-			// Not one of the subnets we know about
-			CIDRAddress:  "172.99.0.20/24",
-			ConfigMethod: state.StaticAddress,
-		}, {
-			DeviceName:   "lo",
-			CIDRAddress:  "127.0.0.1/24",
-			ConfigMethod: state.StaticAddress,
-		}}...
-	)
-	c.Assert(err, jc.ErrorIsNil)
+	s.createNICWithIP(c, s.machine, "lo", "127.0.0.1/24")
+	s.createNICWithIP(c, s.machine, "ens5", "172.99.0.24/24")
 	res, err := s.machine.LinkLayerDevicesForSpaces([]string{"default"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(res, gc.HasLen, 1)
@@ -1321,30 +1298,6 @@ func (s *linkLayerDevicesStateSuite) testMachineSetParentLinkLayerDevicesBeforeT
 	}
 }
 
-func (s *linkLayerDevicesStateSuite) TestSetContainerLinkLayerDevices(c *gc.C) {
-	err := s.machine.SetParentLinkLayerDevicesBeforeTheirChildren(nestedDevicesArgs)
-	c.Assert(err, jc.ErrorIsNil)
-	s.addContainerMachine(c)
-	s.assertNoDevicesOnMachine(c, s.containerMachine)
-
-	err = s.machine.SetContainerLinkLayerDevices(s.containerMachine)
-	c.Assert(err, jc.ErrorIsNil)
-
-	containerDevices, err := s.containerMachine.AllLinkLayerDevices()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(containerDevices, gc.HasLen, 3)
-
-	for i, containerDevice := range containerDevices {
-		c.Check(containerDevice.Name(), gc.Matches, "eth"+strconv.Itoa(i))
-		c.Check(containerDevice.Type(), gc.Equals, state.EthernetDevice)
-		c.Check(containerDevice.MTU(), gc.Equals, uint(0)) // inherited from the parent device.
-		c.Check(containerDevice.MACAddress(), gc.Matches, "00:16:3e(:[0-9a-f]{2}){3}")
-		c.Check(containerDevice.IsUp(), jc.IsTrue)
-		c.Check(containerDevice.IsAutoStart(), jc.IsTrue)
-		c.Check(containerDevice.ParentName(), gc.Matches, `m#0#d#br-bond0(|\.12|\.34)`)
-	}
-}
-
 func (s *linkLayerDevicesStateSuite) TestSetContainerLinkLayerDevicesCorrectlyPaired(c *gc.C) {
 	// The device names chosen and the order are very explicit. We
 	// need to ensure that we have a list that does not sort well
@@ -1383,6 +1336,25 @@ func (s *linkLayerDevicesStateSuite) TestSetContainerLinkLayerDevicesCorrectlyPa
 			Type: state.BridgeDevice,
 		},
 	}
+	// Put each of those bridges into a different subnet that is part
+	// of the same space.
+	_, err := s.State.AddSpace("default", "default", nil, true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	devAddresses := make([]state.LinkLayerDeviceAddress, len(devicesArgs))
+	for i, devArg := range devicesArgs {
+		subnet := i*10 + 1
+		subnetCIDR := fmt.Sprintf("10.%d.0.0/24", subnet)
+		_, err = s.State.AddSubnet(state.SubnetInfo{
+			CIDR:      subnetCIDR,
+			SpaceName: "default",
+		})
+		devAddresses[i] = state.LinkLayerDeviceAddress{
+			DeviceName:   devArg.Name,
+			CIDRAddress:  fmt.Sprintf("10.%d.0.10/24", subnet),
+			ConfigMethod: state.StaticAddress,
+		}
+	}
 
 	expectedParents := []string{
 		"br-eth0",
@@ -1394,10 +1366,16 @@ func (s *linkLayerDevicesStateSuite) TestSetContainerLinkLayerDevicesCorrectlyPa
 		"br-eth10.100",
 	}
 
-	err := s.machine.SetParentLinkLayerDevicesBeforeTheirChildren(devicesArgs[:])
+	err = s.machine.SetParentLinkLayerDevicesBeforeTheirChildren(devicesArgs[:])
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.SetDevicesAddresses(devAddresses...)
 	c.Assert(err, jc.ErrorIsNil)
 	s.addContainerMachine(c)
 	s.assertNoDevicesOnMachine(c, s.containerMachine)
+	err = s.containerMachine.SetConstraints(constraints.Value{
+		Spaces: &[]string{"default"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.machine.SetContainerLinkLayerDevices(s.containerMachine)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1415,4 +1393,221 @@ func (s *linkLayerDevicesStateSuite) TestSetContainerLinkLayerDevicesCorrectlyPa
 		c.Check(containerDevice.IsAutoStart(), jc.IsTrue)
 		c.Check(containerDevice.ParentName(), gc.Equals, fmt.Sprintf("m#0#d#%s", expectedParents[i]))
 	}
+}
+
+func (s *linkLayerDevicesStateSuite) TestSetContainerLinkLayerDevicesConstraintsBindOnlyOne(c *gc.C) {
+	s.setupMachineInTwoSpaces(c)
+	s.addContainerMachine(c)
+	s.assertNoDevicesOnMachine(c, s.containerMachine)
+	err := s.containerMachine.SetConstraints(constraints.Value{
+		Spaces: &[]string{"dmz"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	spaces, err := s.containerMachine.DesiredSpaces()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(spaces.SortedValues(), gc.DeepEquals, []string{"dmz"})
+
+	err = s.machine.SetContainerLinkLayerDevices(s.containerMachine)
+	c.Assert(err, jc.ErrorIsNil)
+
+	containerDevices, err := s.containerMachine.AllLinkLayerDevices()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(containerDevices, gc.HasLen, 1)
+
+	containerDevice := containerDevices[0]
+	c.Check(containerDevice.Name(), gc.Matches, "eth0")
+	c.Check(containerDevice.Type(), gc.Equals, state.EthernetDevice)
+	c.Check(containerDevice.MTU(), gc.Equals, uint(0)) // inherited from the parent device.
+	c.Check(containerDevice.MACAddress(), gc.Matches, "00:16:3e(:[0-9a-f]{2}){3}")
+	c.Check(containerDevice.IsUp(), jc.IsTrue)
+	c.Check(containerDevice.IsAutoStart(), jc.IsTrue)
+	// br-ens0p10 on the host machine is in space dmz, while br-ens33 is in space default
+	c.Check(containerDevice.ParentName(), gc.Equals, `m#0#d#br-ens0p10`)
+}
+
+func (s *linkLayerDevicesStateSuite) TestSetContainerLinkLayerDevicesUnitBindingBindOnlyOne(c *gc.C) {
+	s.setupMachineInTwoSpaces(c)
+	s.addContainerMachine(c)
+	s.assertNoDevicesOnMachine(c, s.containerMachine)
+	svc := s.AddTestingServiceWithBindings(c, "mysql",
+		s.AddTestingCharm(c, "mysql"), map[string]string{"server": "default"})
+	unit, err := svc.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(s.containerMachine)
+	c.Assert(err, jc.ErrorIsNil)
+	spaces, err := s.containerMachine.DesiredSpaces()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(spaces.SortedValues(), gc.DeepEquals, []string{"default"})
+
+	err = s.machine.SetContainerLinkLayerDevices(s.containerMachine)
+	c.Assert(err, jc.ErrorIsNil)
+
+	containerDevices, err := s.containerMachine.AllLinkLayerDevices()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(containerDevices, gc.HasLen, 1)
+
+	containerDevice := containerDevices[0]
+	c.Check(containerDevice.Name(), gc.Matches, "eth0")
+	c.Check(containerDevice.Type(), gc.Equals, state.EthernetDevice)
+	c.Check(containerDevice.MTU(), gc.Equals, uint(0)) // inherited from the parent device.
+	c.Check(containerDevice.MACAddress(), gc.Matches, "00:16:3e(:[0-9a-f]{2}){3}")
+	c.Check(containerDevice.IsUp(), jc.IsTrue)
+	c.Check(containerDevice.IsAutoStart(), jc.IsTrue)
+	// br-ens0p10 on the host machine is in space dmz, while br-ens33 is in space default
+	c.Check(containerDevice.ParentName(), gc.Equals, `m#0#d#br-ens33`)
+}
+
+func (s *linkLayerDevicesStateSuite) TestSetContainerLinkLayerDevicesHostOneSpace(c *gc.C) {
+	s.setupMachineWithOneNICAndBridge(c)
+	// We change the machine to be in 'dmz' instead of 'default', but it is
+	// still in a single space. Adding a container to a machine that is in a
+	// single space puts that container into the same space.
+	err := s.machine.RemoveAllAddresses()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.SetDevicesAddresses(
+		state.LinkLayerDeviceAddress{
+			DeviceName: "br-eth0",
+			// In the DMZ subnet
+			CIDRAddress:  "10.10.0.20/24",
+			ConfigMethod: state.StaticAddress,
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	s.addContainerMachine(c)
+	s.assertNoDevicesOnMachine(c, s.containerMachine)
+
+	err = s.machine.SetContainerLinkLayerDevices(s.containerMachine)
+	c.Assert(err, jc.ErrorIsNil)
+
+	containerDevices, err := s.containerMachine.AllLinkLayerDevices()
+	c.Assert(err, jc.ErrorIsNil)
+	// c.Assert(containerDevices, gc.HasLen, 0)
+	// c.Skip("known failure, we don't handle containers no bindings and no constraints")
+	// Ideally we would get a single container device that matches to
+	// the 'default' space.
+	c.Assert(containerDevices, gc.HasLen, 1)
+
+	containerDevice := containerDevices[0]
+	c.Check(containerDevice.Name(), gc.Matches, "eth0")
+	c.Check(containerDevice.Type(), gc.Equals, state.EthernetDevice)
+	c.Check(containerDevice.MTU(), gc.Equals, uint(0)) // inherited from the parent device.
+	c.Check(containerDevice.MACAddress(), gc.Matches, "00:16:3e(:[0-9a-f]{2}){3}")
+	c.Check(containerDevice.IsUp(), jc.IsTrue)
+	c.Check(containerDevice.IsAutoStart(), jc.IsTrue)
+	c.Check(containerDevice.ParentName(), gc.Equals, `m#0#d#br-eth0`)
+}
+
+func (s *linkLayerDevicesStateSuite) TestSetContainerLinkLayerDevicesDefaultSpace(c *gc.C) {
+	// The host machine is in both 'default' and 'dmz', and the container is
+	// not requested to be in any particular space. But because we have
+	// access to the 'default' space, we go ahead and use that for the
+	// container.
+	s.setupMachineInTwoSpaces(c)
+	s.addContainerMachine(c)
+	s.assertNoDevicesOnMachine(c, s.containerMachine)
+
+	err := s.machine.SetContainerLinkLayerDevices(s.containerMachine)
+	c.Assert(err, jc.ErrorIsNil)
+
+	containerDevices, err := s.containerMachine.AllLinkLayerDevices()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(containerDevices, gc.HasLen, 1)
+
+	containerDevice := containerDevices[0]
+	c.Check(containerDevice.Name(), gc.Matches, "eth0")
+	c.Check(containerDevice.Type(), gc.Equals, state.EthernetDevice)
+	c.Check(containerDevice.MTU(), gc.Equals, uint(0)) // inherited from the parent device.
+	c.Check(containerDevice.MACAddress(), gc.Matches, "00:16:3e(:[0-9a-f]{2}){3}")
+	c.Check(containerDevice.IsUp(), jc.IsTrue)
+	c.Check(containerDevice.IsAutoStart(), jc.IsTrue)
+	// br-ens33 is the one in 'default' space
+	c.Check(containerDevice.ParentName(), gc.Equals, `m#0#d#br-ens33`)
+}
+
+func (s *linkLayerDevicesStateSuite) TestSetContainerLinkLayerDevicesNoValidSpace(c *gc.C) {
+	// The host machine will be in 2 spaces, but neither one is 'default',
+	// thus we are unable to find a valid space to put the container in.
+	s.setupMachineWithOneNICAndBridge(c)
+	// We change br-eth0 to be in 'dmz' instead of 'default'
+	err := s.machine.RemoveAllAddresses()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.SetDevicesAddresses(
+		state.LinkLayerDeviceAddress{
+			DeviceName: "br-eth0",
+			// In the DMZ subnet
+			CIDRAddress:  "10.10.0.20/24",
+			ConfigMethod: state.StaticAddress,
+		},
+	)
+	// Second bridge is in the 'db' space
+	s.createSpaceAndSubnet(c, "db", "10.20.0.0/24")
+	s.createNICAndBridgeWithIP(c, s.machine, "ens4", "br-ens4", "10.20.0.10/24")
+	s.addContainerMachine(c)
+	s.assertNoDevicesOnMachine(c, s.containerMachine)
+
+	err = s.machine.SetContainerLinkLayerDevices(s.containerMachine)
+	c.Assert(err, gc.ErrorMatches, `no obvious space for container "0/lxd/0", host machine has spaces: .*`)
+
+	s.assertNoDevicesOnMachine(c, s.containerMachine)
+}
+
+func (s *linkLayerDevicesStateSuite) TestSetContainerLinkLayerDevicesMismatchConstraints(c *gc.C) {
+	// Machine is in 'default' but container wants to be in 'dmz'
+	s.setupMachineWithOneNICAndBridge(c)
+	s.addContainerMachine(c)
+	s.assertNoDevicesOnMachine(c, s.containerMachine)
+	err := s.containerMachine.SetConstraints(constraints.Value{
+		Spaces: &[]string{"dmz"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.SetContainerLinkLayerDevices(s.containerMachine)
+	c.Assert(err.Error(), gc.Equals, `unable to find host bridge for spaces [dmz] for container "0/lxd/0"`)
+
+	s.assertNoDevicesOnMachine(c, s.containerMachine)
+}
+
+func (s *linkLayerDevicesStateSuite) TestSetContainerLinkLayerDevicesMissingBridge(c *gc.C) {
+	// Machine is in 'default' and 'dmz' but doesn't have a bridge for 'dmz'
+	s.setupMachineWithOneNICAndBridge(c)
+	s.createNICWithIP(c, s.machine, "ens5", "10.20.0.10/24")
+	s.addContainerMachine(c)
+	s.assertNoDevicesOnMachine(c, s.containerMachine)
+	err := s.containerMachine.SetConstraints(constraints.Value{
+		Spaces: &[]string{"dmz"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	// TODO(jam): 2016-12-19 Eventually this should not be an error.
+	err = s.machine.SetContainerLinkLayerDevices(s.containerMachine)
+	c.Assert(err.Error(), gc.Equals, `unable to find host bridge for spaces [dmz] for container "0/lxd/0"`)
+
+	s.assertNoDevicesOnMachine(c, s.containerMachine)
+}
+
+func (s *linkLayerDevicesStateSuite) TestSetContainerLinkLayerDevices(c *gc.C) {
+	// The host machine will be in 2 spaces, but neither one is 'default',
+	// thus we are unable to find a valid space to put the container in.
+	s.setupMachineWithOneNICAndBridge(c)
+	// We change br-eth0 to be in 'dmz' instead of 'default'
+	err := s.machine.RemoveAllAddresses()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.SetDevicesAddresses(
+		state.LinkLayerDeviceAddress{
+			DeviceName: "br-eth0",
+			// In the DMZ subnet
+			CIDRAddress:  "10.10.0.20/24",
+			ConfigMethod: state.StaticAddress,
+		},
+	)
+	// Second bridge is in the 'db' space
+	s.createSpaceAndSubnet(c, "db", "10.20.0.0/24")
+	s.createNICAndBridgeWithIP(c, s.machine, "ens4", "br-ens4", "10.20.0.10/24")
+	s.addContainerMachine(c)
+	s.assertNoDevicesOnMachine(c, s.containerMachine)
+
+	err = s.machine.SetContainerLinkLayerDevices(s.containerMachine)
+	c.Assert(err, gc.ErrorMatches, `no obvious space for container "0/lxd/0", host machine has spaces: .*`)
+
+	containerDevices, err := s.containerMachine.AllLinkLayerDevices()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(containerDevices, gc.HasLen, 0)
 }

--- a/state/machine.go
+++ b/state/machine.go
@@ -1097,11 +1097,11 @@ func parseDelimitedValues(rawValues []string) (positives, negatives []string) {
 	return positives, negatives
 }
 
-// AllSpaces returns the name of all spaces that this machine needs access to.
-// This is the combined value of all of the direct constraints for the machine,
-// as well as the spaces listed for all bindings of units being deployed to
-// that machine.
-func (m *Machine) AllSpaces() (set.Strings, error) {
+// DesiredSpaces returns the name of all spaces that this machine needs
+// access to.  This is the combined value of all of the direct constraints
+// for the machine, as well as the spaces listed for all bindings of units
+// being deployed to that machine.
+func (m *Machine) DesiredSpaces() (set.Strings, error) {
 	spaces := set.NewStrings()
 	units, err := m.Units()
 	if err != nil {

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -748,26 +748,26 @@ func (s *MachineSuite) TestMachineInstanceIdBlank(c *gc.C) {
 	c.Assert(string(iid), gc.Equals, "")
 }
 
-func (s *MachineSuite) TestAllSpacesNone(c *gc.C) {
+func (s *MachineSuite) TestDesiredSpacesNone(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
-	spaces, err := machine.AllSpaces()
+	spaces, err := machine.DesiredSpaces()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(spaces.SortedValues(), gc.DeepEquals, []string{})
 }
 
-func (s *MachineSuite) TestAllSpacesSimpleConstraints(c *gc.C) {
+func (s *MachineSuite) TestDesiredSpacesSimpleConstraints(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetConstraints(constraints.Value{
 		Spaces: &[]string{"foo", "bar", "^baz"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	spaces, err := machine.AllSpaces()
+	spaces, err := machine.DesiredSpaces()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(spaces.SortedValues(), gc.DeepEquals, []string{"bar", "foo"})
 }
 
-func (s *MachineSuite) TestAllSpacesEndpoints(c *gc.C) {
+func (s *MachineSuite) TestDesiredSpacesEndpoints(c *gc.C) {
 	_, err := s.State.AddSpace("db", "", nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
@@ -778,12 +778,12 @@ func (s *MachineSuite) TestAllSpacesEndpoints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
-	spaces, err := machine.AllSpaces()
+	spaces, err := machine.DesiredSpaces()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(spaces.SortedValues(), gc.DeepEquals, []string{"db"})
 }
 
-func (s *MachineSuite) TestAllSpacesEndpointsAndConstraints(c *gc.C) {
+func (s *MachineSuite) TestDesiredSpacesEndpointsAndConstraints(c *gc.C) {
 	_, err := s.State.AddSpace("foo", "", nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddSpace("db", "", nil, true)
@@ -800,7 +800,7 @@ func (s *MachineSuite) TestAllSpacesEndpointsAndConstraints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
-	spaces, err := machine.AllSpaces()
+	spaces, err := machine.DesiredSpaces()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(spaces.SortedValues(), gc.DeepEquals, []string{"db", "foo"})
 }


### PR DESCRIPTION
This code changes our container device policy so that instead of creating a network interface for a container on every bridge on the host machine, instead we only create devices for bridges that the container will actually want.

A few changes of note:
 rename machine.AllSpaces to machine.DesiredSpaces to clarify that these were the spaces that the machine *should* have based on constraints and units.
 create a new machine.AllSpaces that returns the actual spaces a machine is in. (So even if you create a machine with no constraints, but it comes back with 5 NICs, you see the 5 spaces.)
 SetContainerLinkLayerDevices is where most of the changes are located. It now filters devices by space before setting them as possible targets.

There will be more work to follow up on this code, so that if the host machine has a valid device, but not a bridge, we will ask for the bridge to be created as part of provisioning.