### PR TITLE
Specify a default cloud name in lxd provider

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -83,6 +83,9 @@ type RegionConfig map[string]Attrs
 
 // Cloud is a cloud definition.
 type Cloud struct {
+	// Name of the cloud.
+	Name string
+
 	// Type is the type of cloud, eg ec2, openstack etc.
 	// This is one of the provider names registered with
 	// environs.RegisterProvider.
@@ -192,6 +195,7 @@ const DefaultLXD = "localhost"
 // BuiltInClouds work out of the box.
 var BuiltInClouds = map[string]Cloud{
 	DefaultLXD: {
+		Name:        DefaultLXD,
 		Type:        lxdnames.ProviderType,
 		AuthTypes:   []AuthType{EmptyAuthType},
 		Regions:     []Region{{Name: lxdnames.DefaultRegion}},
@@ -299,6 +303,7 @@ func ParseCloudMetadata(data []byte) (map[string]Cloud, error) {
 	clouds := make(map[string]Cloud)
 	for name, cloud := range metadata.Clouds {
 		details := cloudFromInternal(cloud)
+		details.Name = name
 		if details.Description == "" {
 			var ok bool
 			if details.Description, ok = defaultCloudDescription[name]; !ok {

--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -75,6 +75,7 @@ func (s *cloudSuite) TestParseCloudsConfig(c *gc.C) {
 	c.Assert(clouds, gc.HasLen, 1)
 	testingCloud := clouds["testing"]
 	c.Assert(testingCloud, jc.DeepEquals, cloud.Cloud{
+		Name: "testing",
 		Type: "dummy",
 		Config: map[string]interface{}{
 			"k1": "v1",
@@ -102,6 +103,7 @@ func (s *cloudSuite) TestParseCloudsRegionConfig(c *gc.C) {
 	c.Assert(clouds, gc.HasLen, 1)
 	testingCloud := clouds["testing"]
 	c.Assert(testingCloud, jc.DeepEquals, cloud.Cloud{
+		Name: "testing",
 		Type: "dummy",
 		Config: map[string]interface{}{
 			"k1": "v1",
@@ -150,6 +152,7 @@ clouds:
 	c.Assert(fallbackUsed, jc.IsFalse)
 	c.Assert(clouds, jc.DeepEquals, map[string]cloud.Cloud{
 		"aws-me": cloud.Cloud{
+			Name:        "aws-me",
 			Type:        "aws",
 			Description: "Amazon Web Services",
 			AuthTypes:   []cloud.AuthType{"userpass"},
@@ -170,6 +173,7 @@ func (s *cloudSuite) TestGeneratedPublicCloudInfo(c *gc.C) {
 func (s *cloudSuite) TestWritePublicCloudsMetadata(c *gc.C) {
 	clouds := map[string]cloud.Cloud{
 		"aws-me": cloud.Cloud{
+			Name:        "aws-me",
 			Type:        "aws",
 			Description: "Amazon Web Services",
 			AuthTypes:   []cloud.AuthType{"userpass"},

--- a/cloud/personalclouds_test.go
+++ b/cloud/personalclouds_test.go
@@ -95,6 +95,7 @@ func (s *personalCloudSuite) TestReadUserSpecifiedClouds(c *gc.C) {
 func (s *personalCloudSuite) assertPersonalClouds(c *gc.C, clouds map[string]cloud.Cloud) {
 	c.Assert(clouds, jc.DeepEquals, map[string]cloud.Cloud{
 		"homestack": cloud.Cloud{
+			Name:        "homestack",
 			Type:        "openstack",
 			Description: "Openstack Cloud",
 			AuthTypes:   []cloud.AuthType{"userpass", "access-key"},
@@ -104,6 +105,7 @@ func (s *personalCloudSuite) assertPersonalClouds(c *gc.C, clouds map[string]clo
 			},
 		},
 		"azurestack": cloud.Cloud{
+			Name:             "azurestack",
 			Type:             "azure",
 			Description:      "Microsoft Azure",
 			AuthTypes:        []cloud.AuthType{"userpass"},

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1352,6 +1352,7 @@ func (s *BootstrapSuite) TestBootstrapProviderDetectRegions(c *gc.C) {
 	c.Assert(bootstrap.args.CloudCredentialName, gc.Equals, "default")
 	sort.Sort(bootstrap.args.Cloud.AuthTypes)
 	c.Assert(bootstrap.args.Cloud, jc.DeepEquals, cloud.Cloud{
+		Name:      "dummy",
 		Type:      "dummy",
 		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
 		Regions:   []cloud.Region{{Name: "bruce", Endpoint: "endpoint"}},
@@ -1374,6 +1375,7 @@ func (s *BootstrapSuite) TestBootstrapProviderDetectNoRegions(c *gc.C) {
 	c.Assert(bootstrap.args.CloudRegion, gc.Equals, "")
 	sort.Sort(bootstrap.args.Cloud.AuthTypes)
 	c.Assert(bootstrap.args.Cloud, jc.DeepEquals, cloud.Cloud{
+		Name:      "dummy",
 		Type:      "dummy",
 		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
 	})

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -149,6 +149,14 @@ type CloudRegionDetector interface {
 	DetectRegions() ([]cloud.Region, error)
 }
 
+// DefaultCloudNamer is an interface that a provider implements to
+// specify what an implicitly-created cloud ahould be named.
+type DefaultCloudNamer interface {
+	// DefaultCloudName returns the name that should be used for the
+	// cloud instead of falling back to the provider name.
+	DefaultCloudName() string
+}
+
 // ModelConfigUpgrader is an interface that an EnvironProvider may
 // implement in order to modify environment configuration on agent upgrade.
 type ModelConfigUpgrader interface {

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -100,3 +100,10 @@ func (p environProvider) ConfigSchema() schema.Fields {
 func (p environProvider) ConfigDefaults() schema.Defaults {
 	return configDefaults
 }
+
+// DefaultCloudName specifies what name should be used for the cloud
+// implicitly created when the provider is specified directly at
+// bootstrap time. Implements environs.DefaultCloudNamer.
+func (p environProvider) DefaultCloudName() string {
+	return cloud.DefaultLXD
+}

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -62,6 +62,13 @@ func (s *providerSuite) TestDetectRegions(c *gc.C) {
 	c.Assert(regions, jc.DeepEquals, []cloud.Region{{Name: lxdnames.DefaultRegion}})
 }
 
+func (s *providerSuite) TestDefaultCloudName(c *gc.C) {
+	c.Assert(s.provider, gc.Implements, new(environs.DefaultCloudNamer))
+	name := s.provider.(environs.DefaultCloudNamer).DefaultCloudName()
+	c.Assert(name, gc.Equals, "localhost")
+	c.Assert(cloud.BuiltInClouds[name].Type, gc.Equals, "lxd")
+}
+
 func (s *providerSuite) TestRegistered(c *gc.C) {
 	c.Check(s.provider, gc.Equals, lxd.Provider)
 }


### PR DESCRIPTION
This means that even if the controller is bootstrapped using the
provider name "lxd" rather than the built-in cloud name "localhost", the
cloud will be created with the name localhost. Migrating between controllers
 where one was bootstrapped with "lxd" and the other with "localhost" works.

Fixes https://bugs.launchpad.net/juju/+bug/1650251

QA steps:
* Bootstrap one controller specifying `localhost` as the cloud.
* Bootstrap another with `lxd`.
* Migrate a model from one to the other.
* The model should be successfully migrated.