### PR TITLE
Send discharged macaroons when connecting to a stream

### DIFF
--- a/api/export_test.go
+++ b/api/export_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/utils/clock"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon.v1"
 )
 
 var (
@@ -113,4 +115,12 @@ func (f *resultCaller) RawAPICaller() base.APICaller {
 func IsMinVersionError(err error) bool {
 	_, ok := errors.Cause(err).(minJujuVersionErr)
 	return ok
+}
+
+func ExtractMacaroons(conn Connection) ([]macaroon.Slice, error) {
+	st, ok := conn.(*state)
+	if !ok {
+		return nil, errors.Errorf("conn must be a real connection")
+	}
+	return httpbakery.MacaroonsForURL(st.bakeryClient.Client.Jar, st.cookieURL), nil
 }

--- a/api/testing/macaroonsuite.go
+++ b/api/testing/macaroonsuite.go
@@ -42,6 +42,7 @@ type MacaroonSuite struct {
 }
 
 func (s *MacaroonSuite) SetUpTest(c *gc.C) {
+	s.DischargerLogin = nil
 	s.discharger = bakerytest.NewDischarger(nil, func(req *http.Request, cond, arg string) ([]checkers.Caveat, error) {
 		if cond != "is-authenticated-user" {
 			return nil, errors.New("unknown caveat")


### PR DESCRIPTION
If the macaroons passed in to an API client connection already include
discharge macaroons, the discharge request dance doesn't need to be
done, so the macaroons won't be in the cookie jar. In this case make
sure they're still sent along when making a websocket connection. (This
is analogous to the code in api.state.Login that adds macaroons from the
bakery client jar to the login request.)

Includes a drive-by fix to MacaroonSuite - the DischargerLogin function
wasn't reset in setup so the function set in one test could be called
accidentally from another test.

Fixes https://bugs.launchpad.net/juju/+bug/1650451