### PR TITLE
Fix an exported function

### DIFF
--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -147,23 +147,10 @@ func (*environSuite) TestNewCloudinitConfig(c *gc.C) {
 	env, err := maas.NewEnviron(getSimpleCloudSpec(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	script := expectedCloudinitConfig
-	cloudcfg, err := maas.NewCloudinitConfig(env, "testing.invalid", "quantal", []string{"eth0", "eth1"})
+	cloudcfg, err := maas.NewCloudinitConfig(env, "testing.invalid", "quantal")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudcfg.SystemUpdate(), jc.IsTrue)
 	c.Assert(cloudcfg.RunCmds(), jc.DeepEquals, script)
-}
-
-func (*environSuite) TestNewCloudinitConfigWithDisabledNetworkManagement(c *gc.C) {
-	attrs := coretesting.Attrs{
-		"disable-network-management": true,
-	}
-	cfg := getSimpleTestConfig(c, attrs)
-	env, err := maas.NewEnviron(getSimpleCloudSpec(), cfg)
-	c.Assert(err, jc.ErrorIsNil)
-	cloudcfg, err := maas.NewCloudinitConfig(env, "testing.invalid", "quantal", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cloudcfg.SystemUpdate(), jc.IsTrue)
-	c.Assert(cloudcfg.RunCmds(), jc.DeepEquals, expectedCloudinitConfig)
 }
 
 type badEndpointSuite struct {

--- a/provider/maas/export_test.go
+++ b/provider/maas/export_test.go
@@ -18,6 +18,6 @@ func GetMAASClient(env environs.Environ) *gomaasapi.MAASObject {
 	return env.(*maasEnviron).getMAASClient()
 }
 
-func NewCloudinitConfig(env environs.Environ, hostname, series string, interfacesToBridge []string) (cloudinit.CloudConfig, error) {
-	return env.(*maasEnviron).newCloudinitConfig(hostname, series, interfacesToBridge)
+func NewCloudinitConfig(env environs.Environ, hostname, series string) (cloudinit.CloudConfig, error) {
+	return env.(*maasEnviron).newCloudinitConfig(hostname, series)
 }


### PR DESCRIPTION
Since we no longer do bridging during cloud-init, we don't have to test what happens when it is enabled vs disabled.