### PR TITLE
Removed the default allocation value on deploy.

### DIFF
--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -920,7 +920,7 @@ func (s *DeployCharmStoreSuite) TestAddMetricCredentials(c *gc.C) {
 			CharmURL:        "cs:quantal/metered-1",
 			ApplicationName: "metered",
 			PlanURL:         "someplan",
-			Budget:          "personal",
+			Budget:          "",
 			Limit:           "0",
 		}},
 	}})
@@ -969,7 +969,7 @@ func (s *DeployCharmStoreSuite) TestAddMetricCredentialsDefaultPlan(c *gc.C) {
 			CharmURL:        "cs:quantal/metered-1",
 			ApplicationName: "metered",
 			PlanURL:         "thisplan",
-			Budget:          "personal",
+			Budget:          "",
 			Limit:           "0",
 		}},
 	}})
@@ -1100,7 +1100,7 @@ summary: summary
 			CharmURL:        "cs:~user/quantal/metered-0",
 			ApplicationName: "metered",
 			PlanURL:         "someplan",
-			Budget:          "personal",
+			Budget:          "",
 			Limit:           "0",
 		}},
 	}})

--- a/cmd/juju/application/register.go
+++ b/cmd/juju/application/register.go
@@ -18,7 +18,10 @@ import (
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 )
 
-var budgetWithLimitRe = regexp.MustCompile(`^[a-zA-Z0-9\-]+:[0-9]+$`)
+var (
+	budgetWithLimitRe    = regexp.MustCompile(`^[a-zA-Z0-9\-]+:[0-9]+$`)
+	limitWithoutBudgetRe = regexp.MustCompile(`:[0-9]+$`)
+)
 
 type metricRegistrationPost struct {
 	ModelUUID       string `json:"env-uuid"`
@@ -41,7 +44,7 @@ type RegisterMeteredCharm struct {
 }
 
 func (r *RegisterMeteredCharm) SetFlags(f *gnuflag.FlagSet) {
-	f.StringVar(&r.AllocationSpec, "budget", "personal:0", "budget and allocation limit")
+	f.StringVar(&r.AllocationSpec, "budget", ":0", "budget and allocation limit")
 	f.StringVar(&r.Plan, "plan", "", "plan to deploy charm under")
 }
 
@@ -271,7 +274,8 @@ func (r *RegisterMeteredCharm) registerMetrics(modelUUID, charmURL, serviceName,
 }
 
 func parseBudgetWithLimit(bl string) (string, string, error) {
-	if !budgetWithLimitRe.MatchString(bl) {
+	if !budgetWithLimitRe.MatchString(bl) && !limitWithoutBudgetRe.MatchString(bl) {
+
 		return "", "", errors.New("invalid allocation, expecting <budget>:<limit>")
 	}
 	parts := strings.Split(bl, ":")


### PR DESCRIPTION
We can no longer assume the default budget is called "personal". This change means that not specifying a budget name will send :n to the server, in which case the server will interpret n as being the limit and no budget specification meaning <use the default>.