### PR TITLE
Add logging messages for space information.

### DIFF
--- a/state/machine.go
+++ b/state/machine.go
@@ -1111,11 +1111,12 @@ func (m *Machine) DesiredSpaces() (set.Strings, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	// We ignore negative spaces as it doesn't change what spaces we do want.
 	positiveSpaces, _ := convertSpacesFromConstraints(constraints.Spaces)
-	// XXX(jam): what to do about negativeSpaces ?
 	for _, space := range positiveSpaces {
 		spaces.Add(space)
 	}
+	bindings := set.NewStrings()
 	for _, unit := range units {
 		app, err := unit.Application()
 		if err != nil {
@@ -1123,10 +1124,12 @@ func (m *Machine) DesiredSpaces() (set.Strings, error) {
 		}
 		endpointBindings, err := app.EndpointBindings()
 		for _, space := range endpointBindings {
-			spaces.Add(space)
+			bindings.Add(space)
 		}
 	}
-	return spaces, nil
+	logger.Tracef("machine %q found constraints %v and bindings %v",
+		m.Id(), spaces.SortedValues(), bindings.SortedValues())
+	return spaces.Union(bindings), nil
 }
 
 // SetProvisioned sets the provider specific machine id, nonce and also metadata for

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -877,6 +877,8 @@ func (m *Machine) AllSpaces() (set.Strings, error) {
 			spaces.Add(spaceName)
 		}
 	}
+	logger.Tracef("machine %q found AllSpaces() = %v",
+		m.Id(), spaces.SortedValues())
 	return spaces, nil
 }
 


### PR DESCRIPTION
A little bit more information that should help us diagnose if we find spaces available to use for containers.