### PR TITLE
Add remote application URL support to reference other controller models directly

### DIFF
--- a/apiserver/crossmodel/crossmodel_test.go
+++ b/apiserver/crossmodel/crossmodel_test.go
@@ -235,7 +235,7 @@ func (s *crossmodelSuite) TestShowNotFound(c *gc.C) {
 }
 
 func (s *crossmodelSuite) TestShowErrorMsgMultipleURLs(c *gc.C) {
-	urls := []string{"local:/u/fred/prod/foo/hosted-db2", "local:/u/fred/hosted-db2"}
+	urls := []string{"local:/u/fred/prod/hosted-db2", "local:/u/fred/hosted-db2"}
 	filter := params.ApplicationURLs{urls}
 
 	s.applicationDirectory.listOffers = func(filter params.OfferFilters) (params.ApplicationOfferResults, error) {
@@ -245,7 +245,7 @@ func (s *crossmodelSuite) TestShowErrorMsgMultipleURLs(c *gc.C) {
 	found, err := s.api.ApplicationOffers(filter)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 2)
-	c.Assert(found.Results[0].Error.Error(), gc.Matches, fmt.Sprintf(`application URL has invalid form: %q`, urls[0]))
+	c.Assert(found.Results[0].Error.Error(), gc.Matches, fmt.Sprintf(`application URL has too many parts: %q`, urls[0]))
 	c.Assert(found.Results[1].Error.Error(), gc.Matches, fmt.Sprintf(`offer for remote application url %v not found`, urls[1]))
 	s.applicationDirectory.CheckCallNames(c, listOffersBackendCall)
 }

--- a/apiserver/crossmodel/offersapifactory.go
+++ b/apiserver/crossmodel/offersapifactory.go
@@ -58,7 +58,7 @@ func (s *applicationOffersAPIFactory) Stop() error {
 // ApplicationOffersAPIFactoryResource is a function which returns the application offer api factory
 // which can be used as an facade resource.
 func ApplicationOffersAPIFactoryResource(st *state.State) (facade.Resource, error) {
-	controllerModelStata := st
+	controllerModelState := st
 	controllerModel, err := st.ControllerModel()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -67,14 +67,14 @@ func ApplicationOffersAPIFactoryResource(st *state.State) (facade.Resource, erro
 	if st.ModelTag() != controllerModel.ModelTag() {
 		// We are not using the state server environment, so get one.
 		logger.Debugf("getting a controller connection, current model: %s", st.ModelTag())
-		controllerModelStata, err = st.ForModel(controllerModel.ModelTag())
+		controllerModelState, err = st.ForModel(controllerModel.ModelTag())
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		closer = controllerModelStata
+		closer = controllerModelState
 	}
 	return newServiceAPIFactory(
 		func() crossmodel.ApplicationDirectory {
-			return state.NewApplicationDirectory(controllerModelStata)
+			return state.NewApplicationDirectory(controllerModelState)
 		}, closer)
 }

--- a/cmd/juju/application/addrelation.go
+++ b/cmd/juju/application/addrelation.go
@@ -29,6 +29,13 @@ Service endpoints can be identified either by:
     <application name>[:<relation name>]
         where application name supplied without relation will be internally expanded to be well-formed
 or
+    <model name>.<application name>[:<relation name>]
+        where the application is hosted in another model in the same controller
+or
+    <user name>/<model name>.<application name>[:<relation name>]
+        where model name is another model in the same controller and in this case has been disambiguated
+        by prefixing with the model owner
+or
     <remote endpoint url>
 
 Examples:

--- a/cmd/juju/crossmodel/offer_test.go
+++ b/cmd/juju/crossmodel/offer_test.go
@@ -70,25 +70,25 @@ func (s *offerSuite) runOffer(c *gc.C, args ...string) (*cmd.Context, error) {
 }
 
 func (s *offerSuite) TestOfferCallErred(c *gc.C) {
-	s.args = []string{"tst:db", "local:/u/bob/testing/tst"}
+	s.args = []string{"tst:db", "local:/u/bob/tst"}
 	s.mockAPI.errCall = true
 	s.assertOfferErrorOutput(c, ".*aborted.*")
 }
 
 func (s *offerSuite) TestOfferDataErred(c *gc.C) {
-	s.args = []string{"tst:db", "local:/u/bob/testing/tst"}
+	s.args = []string{"tst:db", "local:/u/bob/tst"}
 	s.mockAPI.errData = true
 	s.assertOfferErrorOutput(c, ".*failed.*")
 }
 
 func (s *offerSuite) TestOfferValid(c *gc.C) {
-	s.args = []string{"tst:db", "local:/u/bob/testing/tst"}
-	s.assertOfferOutput(c, "test", "tst", []string{"db"}, "local:/u/bob/testing/tst")
+	s.args = []string{"tst:db", "local:/u/bob/tst"}
+	s.assertOfferOutput(c, "test", "tst", []string{"db"}, "local:/u/bob/tst")
 }
 
 func (s *offerSuite) TestOfferExplicitModel(c *gc.C) {
-	s.args = []string{"prod.tst:db", "local:/u/bob/testing/tst"}
-	s.assertOfferOutput(c, "prod", "tst", []string{"db"}, "local:/u/bob/testing/tst")
+	s.args = []string{"prod.tst:db", "local:/u/bob/tst"}
+	s.assertOfferOutput(c, "prod", "tst", []string{"db"}, "local:/u/bob/tst")
 }
 
 func (s *offerSuite) TestOfferWithURL(c *gc.C) {
@@ -97,8 +97,8 @@ func (s *offerSuite) TestOfferWithURL(c *gc.C) {
 }
 
 func (s *offerSuite) TestOfferMultipleEndpoints(c *gc.C) {
-	s.args = []string{"tst:db,admin", "local:/u/bob/testing/tst"}
-	s.assertOfferOutput(c, "test", "tst", []string{"db", "admin"}, "local:/u/bob/testing/tst")
+	s.args = []string{"tst:db,admin", "local:/u/bob/tst"}
+	s.assertOfferOutput(c, "test", "tst", []string{"db", "admin"}, "local:/u/bob/tst")
 }
 
 func (s *offerSuite) assertOfferOutput(c *gc.C, expectedModel, expectedApplication string, endpoints []string, url string) {

--- a/cmd/juju/crossmodel/show_test.go
+++ b/cmd/juju/crossmodel/show_test.go
@@ -46,7 +46,7 @@ func (s *showSuite) TestShowApiError(c *gc.C) {
 
 func (s *showSuite) TestShowURLError(c *gc.C) {
 	s.mockAPI.serviceTag = "invalid_tag"
-	s.assertShowError(c, []string{"local:/u/fred/prod/foo/db2"}, ".*invalid.*")
+	s.assertShowError(c, []string{"local:/u/fred/foo/db2"}, ".*too many parts.*")
 }
 
 func (s *showSuite) TestShowYaml(c *gc.C) {

--- a/core/crossmodel/applicationurl.go
+++ b/core/crossmodel/applicationurl.go
@@ -6,6 +6,7 @@ package crossmodel
 import (
 	"fmt"
 	gourl "net/url"
+	"regexp"
 	"strings"
 
 	"github.com/juju/errors"
@@ -16,13 +17,15 @@ import (
 // associated exported endpoints.
 type ApplicationURL struct {
 	// Directory represents where the offer is hosted.
-	Directory string // "local" or "<vendor>"
+	// If empty, the model is another model in the same controller.
+	Directory string // "local" or "<vendor>" or ""
 
 	// User is the user whose namespace in which the offer is made.
 	User string
 
 	// ModelName is the name of the model providing the exported endpoints.
-	// It is only used for local URLs.
+	// It is only used for local URLs or for specifying models in the same
+	// controller.
 	ModelName string
 
 	// ApplicationName is the name of the application providing the exported endpoints.
@@ -31,6 +34,13 @@ type ApplicationURL struct {
 
 // Path returns the path component of the URL.
 func (u *ApplicationURL) Path() string {
+	if u.Directory == "" {
+		model := u.ModelName
+		if u.User != "" {
+			model = fmt.Sprintf("%s/%s", u.User, u.ModelName)
+		}
+		return fmt.Sprintf("%s.%s", model, u.ApplicationName)
+	}
 	var parts []string
 	if u.User != "" {
 		parts = append(parts, "u", u.User)
@@ -43,71 +53,94 @@ func (u *ApplicationURL) Path() string {
 }
 
 func (u *ApplicationURL) String() string {
+	if u.Directory == "" {
+		return u.Path()
+	}
 	return fmt.Sprintf("%s:/%s", u.Directory, u.Path())
 }
 
-var supportedURLDirectories = []string{
-	// TODO(wallyworld): just support local for now.
-	"local", // for applications hosted by a local application directory
-}
+// modelApplicationRegexp parses urls of the form user/model.application[:relname]
+var modelApplicationRegexp = regexp.MustCompile(`((?P<user>[^/]*)/)?(?P<model>[^.^/]*)\.(?P<application>[^:]*(:.*)?)`)
+
+// applicationURLRegexp parses urls of the form local:/u/user/application
+var applicationURLRegexp = regexp.MustCompile(`(u/(?P<user>[^/]*)/?)?(?P<application>.*)`)
 
 // ParseApplicationURL parses the specified URL string into a ApplicationURL.
 // The URL string is of one of the forms:
-//  local:/u/<user>/<applicationname>
-//  local:/u/<user>/<envname>/<applicationname>
-//  <vendor>:/u/<user>/<applicationname>
+//  <model-name>.<application-name>
+//  <model-name>.<application-name>:<relation-name>
+//  <user>/<model-name>.<application-name>
+//  <user>/<model-name>.<application-name>:<relation-name>
+//  local:/u/<user>/<application-name>
+//  local:/u/<user>/<model-name>/<application-name>
+//  <vendor>:/u/<user>/<application-name>
 func ParseApplicationURL(urlStr string) (*ApplicationURL, error) {
-	url, err := gourl.Parse(urlStr)
+	urlParts, err := parseApplicationURLParts(urlStr, false)
 	if err != nil {
-		return nil, errors.Errorf("cannot parse application URL: %q", urlStr)
+		return nil, err
 	}
-	if url.RawQuery != "" || url.Fragment != "" || url.User != nil {
-		return nil, errors.Errorf("application URL %q has unrecognized parts", urlStr)
+	if urlParts.ModelName == "" && urlParts.Directory == "" {
+		urlParts.Directory = "local"
 	}
+	url := ApplicationURL(*urlParts)
+	return &url, nil
+}
 
-	var result ApplicationURL
-	if url.Scheme == "" {
-		url.Scheme = "local"
-	}
-	if url.Scheme != "" {
-		result.Directory = url.Scheme
-	}
-	urlPath := strings.Trim(url.Path, "/")
-	parts := strings.Split(urlPath, "/")
-	if len(parts) < 1 || len(parts) > 4 {
-		return nil, fmt.Errorf("application URL has invalid form: %q", urlStr)
-	}
+// ApplicationURLParts contains various attributes of a URL.
+type ApplicationURLParts ApplicationURL
 
-	// User
-	if parts[0] != "u" {
-		return nil, fmt.Errorf("application URL has invalid form, missing %q: %q", "/u/<user>", urlStr)
-	}
-	if !names.IsValidUser(parts[1]) {
-		return nil, errors.NotValidf("user name %q", parts[1])
-	}
-	result.User = parts[1]
+// ParseApplicationURLParts parses a partial URL, filling out what parts are supplied.
+// This method is used to generate a filter used to query matching application URLs.
+func ParseApplicationURLParts(urlStr string) (*ApplicationURLParts, error) {
+	return parseApplicationURLParts(urlStr, true)
+}
 
-	// Application name
-	if len(parts) < 3 {
-		return nil, fmt.Errorf("application URL has invalid form, missing application name: %q", urlStr)
-	}
+func parseApplicationURLParts(urlStr string, allowIncomplete bool) (*ApplicationURLParts, error) {
+	var result ApplicationURLParts
+	if modelApplicationRegexp.MatchString(urlStr) {
+		result.User = modelApplicationRegexp.ReplaceAllString(urlStr, "$user")
+		result.ModelName = modelApplicationRegexp.ReplaceAllString(urlStr, "$model")
+		result.ApplicationName = modelApplicationRegexp.ReplaceAllString(urlStr, "$application")
+	} else {
+		url, err := gourl.Parse(urlStr)
+		if err != nil {
+			return nil, errors.Errorf("cannot parse application URL: %q", urlStr)
+		}
+		if url.RawQuery != "" || url.Fragment != "" || url.User != nil {
+			return nil, errors.Errorf("application URL %q has unrecognized parts", urlStr)
+		}
 
-	// Figure out what URL parts we have.
-	envPart := -1
-	applicationPart := 2
-	if len(parts) == 4 {
-		envPart = 2
-		applicationPart = 3
+		urlPath := strings.Trim(url.Path, "/")
+		if applicationURLRegexp.MatchString(urlPath) {
+			result.Directory = url.Scheme
+			result.User = applicationURLRegexp.ReplaceAllString(urlPath, "$user")
+			result.ApplicationName = applicationURLRegexp.ReplaceAllString(urlPath, "$application")
+			if result.User == "" && !allowIncomplete {
+				return nil, errors.Errorf("application URL has invalid form, missing %q: %q", "/u/<user>", urlStr)
+			}
+			if result.ApplicationName == "" && !allowIncomplete {
+				return nil, errors.Errorf("application URL has invalid form, missing application name: %q", urlStr)
+			}
+		} else {
+			return nil, errors.Errorf("application URL has invalid form: %q", urlStr)
+		}
+		if strings.Index(result.ApplicationName, "/") > 0 {
+			return nil, errors.Errorf("application URL has too many parts: %q", urlStr)
+		}
 	}
-
-	if envPart > 0 {
-		result.ModelName = parts[envPart]
+	// Validate the resulting URL part values.
+	if result.User != "" && !names.IsValidUser(result.User) {
+		return nil, errors.NotValidf("user name %q", result.User)
 	}
-
-	if !names.IsValidApplication(parts[applicationPart]) {
-		return nil, errors.NotValidf("application name %q", parts[applicationPart])
+	if result.ModelName != "" && !names.IsValidModelName(result.ModelName) {
+		return nil, errors.NotValidf("model name %q", result.ModelName)
 	}
-	result.ApplicationName = parts[applicationPart]
+	// Application name part may contain a relation name part, so strip that bit out
+	// before validating the name.
+	appName := strings.Split(result.ApplicationName, ":")[0]
+	if appName != "" && !names.IsValidApplication(appName) {
+		return nil, errors.NotValidf("application name %q", appName)
+	}
 	return &result, nil
 }
 
@@ -119,70 +152,4 @@ func ApplicationDirectoryForURL(urlStr string) (string, error) {
 		return "", err
 	}
 	return url.Directory, nil
-}
-
-// ApplicationURLParts contains various attributes of a URL.
-type ApplicationURLParts ApplicationURL
-
-// ParseApplicationURLParts parses a partial URL, filling out what parts are supplied.
-// TODO(wallyworld) update ParseApplicationURL to use this method and perform additional validation on top.
-func ParseApplicationURLParts(urlStr string) (*ApplicationURLParts, error) {
-	url, err := gourl.Parse(urlStr)
-	if err != nil {
-		return nil, errors.Errorf("cannot parse application URL: %q", urlStr)
-	}
-	if url.RawQuery != "" || url.Fragment != "" || url.User != nil {
-		return nil, errors.Errorf("application URL %q has unrecognized parts", urlStr)
-	}
-
-	var result ApplicationURLParts
-	if url.Scheme != "" {
-		result.Directory = url.Scheme
-	}
-	urlPath := strings.Trim(url.Path, "/")
-	parts := strings.Split(urlPath, "/")
-
-	if len(parts) < 2 {
-		switch len(parts) {
-		case 1:
-			result.ApplicationName = parts[0]
-		}
-		return &result, nil
-	}
-
-	if parts[0] == "u" {
-		if !names.IsValidUser(parts[1]) {
-			return nil, errors.NotValidf("user name %q", parts[1])
-		}
-		result.User = parts[1]
-	} else {
-		if len(parts) > 2 {
-			return nil, fmt.Errorf("application URL has too many parts: %q", urlStr)
-		}
-		result.ModelName = parts[0]
-		result.ApplicationName = parts[1]
-		return &result, nil
-	}
-
-	if len(parts) == 2 {
-		return &result, nil
-	}
-
-	// Figure out what other URL parts we have.
-	envPart := -1
-	applicationPart := 2
-	if len(parts) == 4 {
-		envPart = 2
-		applicationPart = 3
-	}
-
-	if envPart > 0 {
-		result.ModelName = parts[envPart]
-	}
-
-	if !names.IsValidApplication(parts[applicationPart]) {
-		return nil, errors.NotValidf("application name %q", parts[applicationPart])
-	}
-	result.ApplicationName = parts[applicationPart]
-	return &result, nil
 }

--- a/core/crossmodel/applicationurl_test.go
+++ b/core/crossmodel/applicationurl_test.go
@@ -30,9 +30,25 @@ var urlTests = []struct {
 	url:   &crossmodel.ApplicationURL{"local", "user", "", "applicationname"},
 	exact: "local:/u/user/applicationname",
 }, {
-	s:     "u/user/prod/applicationname",
-	url:   &crossmodel.ApplicationURL{"local", "user", "prod", "applicationname"},
-	exact: "local:/u/user/prod/applicationname",
+	s:   "modelname.applicationname",
+	url: &crossmodel.ApplicationURL{"", "", "modelname", "applicationname"},
+}, {
+	s:   "modelname.applicationname:rel",
+	url: &crossmodel.ApplicationURL{"", "", "modelname", "applicationname:rel"},
+}, {
+	s:   "user/modelname.applicationname:rel",
+	url: &crossmodel.ApplicationURL{"", "user", "modelname", "applicationname:rel"},
+}, {
+	s:     "/modelname.applicationname",
+	url:   &crossmodel.ApplicationURL{"", "", "modelname", "applicationname"},
+	exact: "modelname.applicationname",
+}, {
+	s:     "/modelname.applicationname:rel",
+	url:   &crossmodel.ApplicationURL{"", "", "modelname", "applicationname:rel"},
+	exact: "modelname.applicationname:rel",
+}, {
+	s:   "user/modelname.applicationname",
+	url: &crossmodel.ApplicationURL{"", "user", "modelname", "applicationname"},
 }, {
 	s:   "local:application",
 	err: `application URL has invalid form, missing "/u/<user>": $URL`,
@@ -52,17 +68,26 @@ var urlTests = []struct {
 	s:   "/u/user",
 	err: `application URL has invalid form, missing application name: $URL`,
 }, {
-	s:   "local:/u/user/application.bad",
-	err: `application name "application.bad" not valid`,
+	s:   "local:/u/user/application@bad",
+	err: `application name "application@bad" not valid`,
 }, {
 	s:   "local:/u/user[bad/application",
 	err: `user name "user\[bad" not valid`,
 }, {
+	s:   "model.application@bad",
+	err: `application name "application@bad" not valid`,
+}, {
+	s:   "user[bad/model.application",
+	err: `user name "user\[bad" not valid`,
+}, {
+	s:   "user/[badmodel.application",
+	err: `model name "\[badmodel" not valid`,
+}, {
 	s:   ":foo",
 	err: `cannot parse application URL: $URL`,
 }, {
-	s:   "local:/u/fred/prod/foo/db2",
-	err: `application URL has invalid form: $URL`,
+	s:   "local:/u/fred/application/extra",
+	err: `application URL has too many parts: $URL`,
 }}
 
 func (s *ApplicationURLSuite) TestParseURL(c *gc.C) {
@@ -76,13 +101,13 @@ func (s *ApplicationURLSuite) TestParseURL(c *gc.C) {
 		}
 		if t.url != nil {
 			c.Assert(err, gc.IsNil)
-			c.Assert(url, gc.DeepEquals, t.url)
+			c.Check(url, gc.DeepEquals, t.url)
 			c.Check(url.String(), gc.Equals, match)
 		}
 		if t.err != "" {
 			t.err = strings.Replace(t.err, "$URL", regexp.QuoteMeta(fmt.Sprintf("%q", t.s)), -1)
-			c.Assert(err, gc.ErrorMatches, t.err)
-			c.Assert(url, gc.IsNil)
+			c.Check(err, gc.ErrorMatches, t.err)
+			c.Check(url, gc.IsNil)
 		}
 	}
 }
@@ -108,17 +133,11 @@ var urlPartsTests = []struct {
 	s:   "u/user/applicationname",
 	url: &crossmodel.ApplicationURLParts{"", "user", "", "applicationname"},
 }, {
-	s:   "u/user/prod/applicationname",
-	url: &crossmodel.ApplicationURLParts{"", "user", "prod", "applicationname"},
-}, {
 	s:   "u/user",
 	url: &crossmodel.ApplicationURLParts{"", "user", "", ""},
 }, {
 	s:   "application",
 	url: &crossmodel.ApplicationURLParts{"", "", "", "application"},
-}, {
-	s:   "prod/application",
-	url: &crossmodel.ApplicationURLParts{"", "", "prod", "application"},
 }, {
 	s:   "local:/application",
 	url: &crossmodel.ApplicationURLParts{"local", "", "", "application"},
@@ -126,11 +145,17 @@ var urlPartsTests = []struct {
 	s:   "",
 	url: &crossmodel.ApplicationURLParts{},
 }, {
+	s:   "prod/application",
+	err: "application URL has too many parts: $URL",
+}, {
+	s:   "u/user/prod/applicationname",
+	err: "application URL has too many parts: $URL",
+}, {
 	s:   "a/b/c",
 	err: `application URL has too many parts: "a/b/c"`,
 }, {
-	s:   "local:/u/user/application.bad",
-	err: `application name "application.bad" not valid`,
+	s:   "local:/u/user/application@bad",
+	err: `application name "application@bad" not valid`,
 }, {
 	s:   "local:/u/user[bad/application",
 	err: `user name "user\[bad" not valid`,

--- a/featuretests/cmd_juju_crossmodel_test.go
+++ b/featuretests/cmd_juju_crossmodel_test.go
@@ -5,15 +5,20 @@ package featuretests
 
 import (
 	"bytes"
+	"fmt"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charmrepo.v2-unstable"
 
 	"github.com/juju/juju/cmd/juju/crossmodel"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
 )
 
 type crossmodelSuite struct {
@@ -109,7 +114,7 @@ local:/u/me/varnish:
 `[1:])
 }
 
-func (s *crossmodelSuite) TestAddRelation(c *gc.C) {
+func (s *crossmodelSuite) TestAddRelationFromURL(c *gc.C) {
 	ch := s.AddTestingCharm(c, "wordpress")
 	s.AddTestingService(c, "wordpress", ch)
 	ch = s.AddTestingCharm(c, "mysql")
@@ -143,4 +148,113 @@ func (s *crossmodelSuite) TestAddRelation(c *gc.C) {
 				Scope:     "global"},
 		},
 	})
+}
+
+func (s *crossmodelSuite) assertAddRelationSameControllerSuccess(c *gc.C, otherModeluser string) {
+	_, err := runJujuCommand(c, "add-relation", "wordpress", otherModeluser+"/othermodel.mysql")
+	c.Assert(err, jc.ErrorIsNil)
+	svc, err := s.State.RemoteApplication(otherModeluser + "-othermodel-mysql")
+	c.Assert(err, jc.ErrorIsNil)
+	rel, err := svc.Relations()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rel, gc.HasLen, 1)
+	c.Assert(rel[0].Endpoints(), jc.SameContents, []state.Endpoint{
+		{
+			ApplicationName: "wordpress",
+			Relation: charm.Relation{
+				Name:      "db",
+				Role:      "requirer",
+				Interface: "mysql",
+				Limit:     1,
+				Scope:     "global",
+			},
+		}, {
+			ApplicationName: otherModeluser + "-othermodel-mysql",
+			Relation: charm.Relation{Name: "server",
+				Role:      "provider",
+				Interface: "mysql",
+				Scope:     "global"},
+		},
+	})
+}
+
+func (s *crossmodelSuite) TestAddRelationSameControllerSameOwner(c *gc.C) {
+	ch := s.AddTestingCharm(c, "wordpress")
+	s.AddTestingService(c, "wordpress", ch)
+
+	otherModel := s.Factory.MakeModel(c, &factory.ModelParams{Name: "othermodel"})
+	s.AddCleanup(func(*gc.C) { otherModel.Close() })
+
+	mysql := testcharms.Repo.CharmDir("mysql")
+	ident := fmt.Sprintf("%s-%d", mysql.Meta().Name, mysql.Revision())
+	curl := charm.MustParseURL("local:quantal/" + ident)
+	repo, err := charmrepo.InferRepository(
+		curl,
+		charmrepo.NewCharmStoreParams{},
+		testcharms.Repo.Path())
+	c.Assert(err, jc.ErrorIsNil)
+	ch, err = jujutesting.PutCharm(otherModel, curl, repo, false)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = otherModel.AddApplication(state.AddApplicationArgs{
+		Name:  "mysql",
+		Charm: ch,
+	})
+	s.assertAddRelationSameControllerSuccess(c, "admin")
+}
+
+func (s *crossmodelSuite) TestAddRelationSameControllerPermissionDenied(c *gc.C) {
+	ch := s.AddTestingCharm(c, "wordpress")
+	s.AddTestingService(c, "wordpress", ch)
+
+	otherOwner := s.Factory.MakeUser(c, &factory.UserParams{Name: "otheruser"})
+	otherModel := s.Factory.MakeModel(c, &factory.ModelParams{Name: "othermodel", Owner: otherOwner.Tag()})
+	s.AddCleanup(func(*gc.C) { otherModel.Close() })
+
+	mysql := testcharms.Repo.CharmDir("mysql")
+	ident := fmt.Sprintf("%s-%d", mysql.Meta().Name, mysql.Revision())
+	curl := charm.MustParseURL("local:quantal/" + ident)
+	repo, err := charmrepo.InferRepository(
+		curl,
+		charmrepo.NewCharmStoreParams{},
+		testcharms.Repo.Path())
+	c.Assert(err, jc.ErrorIsNil)
+	ch, err = jujutesting.PutCharm(otherModel, curl, repo, false)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = otherModel.AddApplication(state.AddApplicationArgs{
+		Name:  "mysql",
+		Charm: ch,
+	})
+
+	context, err := runJujuCommand(c, "add-relation", "wordpress", "otheruser/othermodel.mysql")
+	c.Assert(err, gc.NotNil)
+	c.Assert(testing.Stderr(context), jc.Contains, "You do not have permission to add a relation")
+}
+
+func (s *crossmodelSuite) TestAddRelationSameControllerPermissionAllowed(c *gc.C) {
+	ch := s.AddTestingCharm(c, "wordpress")
+	s.AddTestingService(c, "wordpress", ch)
+
+	otherOwner := s.Factory.MakeUser(c, &factory.UserParams{Name: "otheruser"})
+	otherModel := s.Factory.MakeModel(c, &factory.ModelParams{Name: "othermodel", Owner: otherOwner.Tag()})
+	s.AddCleanup(func(*gc.C) { otherModel.Close() })
+
+	// Users with write permission to the model can add relations.
+	otherFactory := factory.NewFactory(otherModel)
+	otherFactory.MakeModelUser(c, &factory.ModelUserParams{User: "admin", Access: permission.WriteAccess})
+
+	mysql := testcharms.Repo.CharmDir("mysql")
+	ident := fmt.Sprintf("%s-%d", mysql.Meta().Name, mysql.Revision())
+	curl := charm.MustParseURL("local:quantal/" + ident)
+	repo, err := charmrepo.InferRepository(
+		curl,
+		charmrepo.NewCharmStoreParams{},
+		testcharms.Repo.Path())
+	c.Assert(err, jc.ErrorIsNil)
+	ch, err = jujutesting.PutCharm(otherModel, curl, repo, false)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = otherModel.AddApplication(state.AddApplicationArgs{
+		Name:  "mysql",
+		Charm: ch,
+	})
+	s.assertAddRelationSameControllerSuccess(c, "otheruser")
 }


### PR DESCRIPTION
The remote application url parsing now supports the new syntax for specifying applications in other models on the same controller. The old syntax local:/u/me/model/app is removed.
Applications in another model are now referenced using syntax model.application.
There are now 2 url syntaxes to handle: from an application directory and the new controller model one.

QA:
juju bootstrap
juju deploy mysql
juju switch controller
juju deploy wordpress
juju relate wordpress default.mysql