### PR TITLE
network: fix quoting in bridgescript invocation

### DIFF
--- a/network/add-juju-bridge.py
+++ b/network/add-juju-bridge.py
@@ -13,6 +13,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 
 # StringIO: accommodate Python2 & Python3
 
@@ -463,4 +464,7 @@ def main(args):
 # either all active interfaces, or a specific interface.
 
 if __name__ == '__main__':
+    sleep_preamble = os.getenv("ADD_JUJU_BRIDGE_SLEEP_PREAMBLE_FOR_TESTING", 0)
+    if int(sleep_preamble) > 0:
+        time.sleep(int(sleep_preamble))
     main(arg_parser().parse_args())

--- a/network/bridge.go
+++ b/network/bridge.go
@@ -64,23 +64,22 @@ func bestPythonVersion() string {
 }
 
 func (b *etcNetworkInterfacesBridger) Bridge(deviceNames []string) error {
-	args := make([]string, 0, 4)
-	args = append(args, fmt.Sprintf("--interfaces-to-bridge=%q", deviceNames))
-	args = append(args, fmt.Sprintf("--activate"))
+	prefix := ""
 	if b.BridgePrefix != "" {
-		args = append(args, fmt.Sprintf("--bridge-prefix=%s", b.BridgePrefix))
+		prefix = fmt.Sprintf("--bridge-prefix=%s", b.BridgePrefix)
 	}
-	args = append(args, b.Filename)
-	cmd := fmt.Sprintf(`
-%s - %s <<'EOF'
+	cmd := fmt.Sprintf(`%s - --interfaces-to-bridge=%q --activate %s %s <<'EOF'
 %s
 EOF
 `,
 		bestPythonVersion(),
-		strings.Join(args, " "),
+		strings.Join(deviceNames, " "),
+		prefix,
+		b.Filename,
 		BridgeScriptPythonContent)
 
 	result, err := RunCommand(cmd, os.Environ(), b.Clock, b.Timeout)
+	logger.Infof("bridgescript command=%s", cmd)
 	logger.Infof("bridgescript result=%v, timeout=%v", result.Code, result.TimedOut)
 	if result.Code != 0 {
 		logger.Errorf("bridgescript stdout\n%s\n", result.Stdout)

--- a/network/bridge.go
+++ b/network/bridge.go
@@ -11,25 +11,21 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/clock"
-	"github.com/juju/utils/exec"
 )
 
+// Bridger creates network bridges to support addressable containers.
 type Bridger interface {
+	// Turns existing devices into bridged devices.
 	Bridge(deviceNames []string) error
 }
 
-type ScriptResult struct {
-	Stdout   []byte
-	Stderr   []byte
-	Code     int
-	TimedOut bool
-}
-
 type etcNetworkInterfacesBridger struct {
-	Clock        clock.Clock
-	Timeout      time.Duration
 	BridgePrefix string
+	Clock        clock.Clock
+	DryRun       bool
+	Environ      []string
 	Filename     string
+	Timeout      time.Duration
 }
 
 var _ Bridger = (*etcNetworkInterfacesBridger)(nil)
@@ -64,72 +60,61 @@ func bestPythonVersion() string {
 }
 
 func (b *etcNetworkInterfacesBridger) Bridge(deviceNames []string) error {
-	prefix := ""
-	if b.BridgePrefix != "" {
-		prefix = fmt.Sprintf("--bridge-prefix=%s", b.BridgePrefix)
+	cmd := bridgeCmd(deviceNames, b.BridgePrefix, b.Filename, BridgeScriptPythonContent, b.DryRun)
+	logger.Debugf("bridgescript command=%s", cmd)
+	result, err := runCommand(cmd, b.Environ, b.Clock, b.Timeout)
+	if err != nil {
+		return errors.Errorf("script invocation error: %s", err)
 	}
-	cmd := fmt.Sprintf(`%s - --interfaces-to-bridge=%q --activate %s %s <<'EOF'
-%s
-EOF
-`,
-		bestPythonVersion(),
-		strings.Join(deviceNames, " "),
-		prefix,
-		b.Filename,
-		BridgeScriptPythonContent)
-
-	result, err := RunCommand(cmd, os.Environ(), b.Clock, b.Timeout)
-	logger.Infof("bridgescript command=%s", cmd)
 	logger.Infof("bridgescript result=%v, timeout=%v", result.Code, result.TimedOut)
-	if result.Code != 0 {
-		logger.Errorf("bridgescript stdout\n%s\n", result.Stdout)
-		logger.Errorf("bridgescript stderr\n%s\n", result.Stderr)
-	}
 	if result.TimedOut {
 		return errors.Errorf("bridgescript timed out after %v", b.Timeout)
 	}
-	return err
+	if result.Code != 0 {
+		logger.Errorf("bridgescript stdout\n%s\n", result.Stdout)
+		logger.Errorf("bridgescript stderr\n%s\n", result.Stderr)
+		return errors.Errorf("bridgescript failed: %s", string(result.Stderr))
+	}
+	return nil
 }
 
-func NewEtcNetworkInterfacesBridger(clock clock.Clock, timeout time.Duration, bridgePrefix, filename string) Bridger {
+func bridgeCmd(deviceNames []string, bridgePrefix, filename, pythonScript string, dryRun bool) string {
+	dryRunOption := ""
+
+	if bridgePrefix != "" {
+		bridgePrefix = fmt.Sprintf("--bridge-prefix=%s", bridgePrefix)
+	}
+
+	if dryRun {
+		dryRunOption = "--dry-run"
+	}
+
+	return fmt.Sprintf(`
+%s - --interfaces-to-bridge=%q --activate %s %s %s <<'EOF'
+%s
+EOF
+`[1:],
+		bestPythonVersion(),
+		strings.Join(deviceNames, " "),
+		bridgePrefix,
+		dryRunOption,
+		filename,
+		pythonScript)
+}
+
+// NewEtcNetworkInterfacesBridger returns a Bridger that can parse
+// /etc/network/interfaces and create new stanzas to bridge existing
+// interfaces.
+//
+// TODO(frobware): We shouldn't expose DryRun; once we implement the
+// Python-based bridge script in Go this interface can change.
+func NewEtcNetworkInterfacesBridger(environ []string, clock clock.Clock, timeout time.Duration, bridgePrefix, filename string, dryRun bool) Bridger {
 	return &etcNetworkInterfacesBridger{
-		Clock:        clock,
-		Timeout:      timeout,
 		BridgePrefix: bridgePrefix,
+		Clock:        clock,
+		DryRun:       dryRun,
+		Environ:      environ,
 		Filename:     filename,
+		Timeout:      timeout,
 	}
-}
-
-func RunCommand(command string, environ []string, clock clock.Clock, timeout time.Duration) (*ScriptResult, error) {
-	cmd := exec.RunParams{
-		Commands:    command,
-		Environment: environ,
-		Clock:       clock,
-	}
-
-	err := cmd.Run()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	var cancel chan struct{}
-	timedOut := false
-
-	if timeout != 0 {
-		cancel = make(chan struct{})
-		go func() {
-			<-clock.After(timeout)
-			timedOut = true
-			close(cancel)
-		}()
-	}
-
-	result, err := cmd.WaitWithCancel(cancel)
-
-	return &ScriptResult{
-		Stdout:   result.Stdout,
-		Stderr:   result.Stderr,
-		Code:     result.Code,
-		TimedOut: timedOut,
-	}, nil
 }

--- a/network/bridge_test.go
+++ b/network/bridge_test.go
@@ -14,6 +14,13 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
+// A note regarding the use of clock.WallClock in these unit tests.
+//
+// All the tests pass 0 for a timeout, which means indefinite, and
+// therefore no timer/clock is used. There is one test that checks for
+// timeout and passes 0.5s as its timeout value. Because of this it's
+// not clear why the 'testing clock' would be a better choice.
+
 type BridgeSuite struct {
 	testing.IsolationSuite
 }
@@ -109,10 +116,10 @@ func (*BridgeSuite) TestENIBridgerWithTimeout(c *gc.C) {
 	environ := os.Environ()
 	environ = append(environ, "ADD_JUJU_BRIDGE_SLEEP_PREAMBLE_FOR_TESTING=10")
 	deviceNames := []string{"ens3", "ens4", "bond0"}
-	bridger := network.NewEtcNetworkInterfacesBridger(environ, clock.WallClock, 1*time.Second, "", "testdata/non-existent-file", true)
+	bridger := network.NewEtcNetworkInterfacesBridger(environ, clock.WallClock, 500*time.Millisecond, "", "testdata/non-existent-file", true)
 	err := bridger.Bridge(deviceNames)
 	c.Assert(err, gc.NotNil)
-	c.Check(err, gc.ErrorMatches, `bridgescript timed out after 1s`)
+	c.Check(err, gc.ErrorMatches, `bridgescript timed out after 500ms`)
 }
 
 func (*BridgeSuite) TestENIBridgerWithDryRun(c *gc.C) {

--- a/network/bridge_test.go
+++ b/network/bridge_test.go
@@ -116,7 +116,7 @@ func (*BridgeSuite) TestENIBridgerWithTimeout(c *gc.C) {
 }
 
 func (*BridgeSuite) TestENIBridgerWithDryRun(c *gc.C) {
-	bridger := network.NewEtcNetworkInterfacesBridger(os.Environ(), clock.WallClock, 1*time.Second, "", "testdata/interfaces", true)
+	bridger := network.NewEtcNetworkInterfacesBridger(os.Environ(), clock.WallClock, 0, "", "testdata/interfaces", true)
 	err := bridger.Bridge([]string{"ens123"})
 	c.Assert(err, gc.IsNil)
 }

--- a/network/bridgescript.go
+++ b/network/bridgescript.go
@@ -17,6 +17,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 
 # StringIO: accommodate Python2 & Python3
 
@@ -467,5 +468,8 @@ def main(args):
 # either all active interfaces, or a specific interface.
 
 if __name__ == '__main__':
+    sleep_preamble = os.getenv("ADD_JUJU_BRIDGE_SLEEP_PREAMBLE_FOR_TESTING", 0)
+    if int(sleep_preamble) > 0:
+        time.sleep(int(sleep_preamble))
     main(arg_parser().parse_args())
 `

--- a/network/export_test.go
+++ b/network/export_test.go
@@ -6,4 +6,6 @@ package network
 var (
 	NetLookupIP = &netLookupIP
 	NetListen   = &netListen
+	RunCommand  = runCommand
+	BridgeCmd   = bridgeCmd
 )

--- a/network/scriptrunner.go
+++ b/network/scriptrunner.go
@@ -1,0 +1,53 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/clock"
+	"github.com/juju/utils/exec"
+)
+
+type ScriptResult struct {
+	Stdout   []byte
+	Stderr   []byte
+	Code     int
+	TimedOut bool
+}
+
+func runCommand(command string, environ []string, clock clock.Clock, timeout time.Duration) (*ScriptResult, error) {
+	cmd := exec.RunParams{
+		Commands:    command,
+		Environment: environ,
+		Clock:       clock,
+	}
+
+	err := cmd.Run()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var cancel chan struct{}
+	timedOut := false
+
+	if timeout != 0 {
+		cancel = make(chan struct{})
+		go func() {
+			<-clock.After(timeout)
+			timedOut = true
+			close(cancel)
+		}()
+	}
+
+	result, err := cmd.WaitWithCancel(cancel)
+
+	return &ScriptResult{
+		Stdout:   result.Stdout,
+		Stderr:   result.Stderr,
+		Code:     result.Code,
+		TimedOut: timedOut,
+	}, nil
+}

--- a/network/scriptrunner_test.go
+++ b/network/scriptrunner_test.go
@@ -1,0 +1,73 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network_test
+
+import (
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/juju/juju/network"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
+	gc "gopkg.in/check.v1"
+)
+
+type ScriptRunnerSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ScriptRunnerSuite{})
+
+func (s *ScriptRunnerSuite) SetUpSuite(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("skipping ScriptRunnerSuite tests on windows")
+	}
+	s.IsolationSuite.SetUpSuite(c)
+}
+
+func (*ScriptRunnerSuite) TestScriptRunnerFails(c *gc.C) {
+	clock := testing.NewClock(coretesting.ZeroTime())
+	result, err := network.RunCommand("exit 1", os.Environ(), clock, 0)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.TimedOut, gc.Equals, false)
+	c.Assert(result.Code, gc.Equals, 1)
+}
+
+func (*ScriptRunnerSuite) TestScriptRunnerSucceeds(c *gc.C) {
+	clock := testing.NewClock(coretesting.ZeroTime())
+	result, err := network.RunCommand("exit 0", os.Environ(), clock, 0)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.TimedOut, gc.Equals, false)
+	c.Assert(result.Code, gc.Equals, 0)
+}
+
+func (*ScriptRunnerSuite) TestScriptRunnerCheckStdout(c *gc.C) {
+	clock := testing.NewClock(coretesting.ZeroTime())
+	result, err := network.RunCommand("echo -n 42", os.Environ(), clock, 0)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.TimedOut, gc.Equals, false)
+	c.Assert(result.Code, gc.Equals, 0)
+	c.Check(string(result.Stdout), gc.Equals, "42")
+	c.Check(string(result.Stderr), gc.Equals, "")
+}
+
+func (*ScriptRunnerSuite) TestScriptRunnerCheckStderr(c *gc.C) {
+	clock := testing.NewClock(coretesting.ZeroTime())
+	result, err := network.RunCommand(">&2 echo -n 3.141", os.Environ(), clock, 0)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.TimedOut, gc.Equals, false)
+	c.Assert(result.Code, gc.Equals, 0)
+	c.Check(string(result.Stdout), gc.Equals, "")
+	c.Check(string(result.Stderr), gc.Equals, "3.141")
+}
+
+func (*ScriptRunnerSuite) TestScriptRunnerTimeout(c *gc.C) {
+	result, err := network.RunCommand("sleep 6", os.Environ(), clock.WallClock, 500*time.Microsecond)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.TimedOut, gc.Equals, true)
+	c.Assert(result.Code, gc.Equals, 0)
+}

--- a/network/testdata/interfaces
+++ b/network/testdata/interfaces
@@ -1,0 +1,2 @@
+auto ens123
+iface ens123 inet dhcp

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -5,6 +5,7 @@ package provisioner
 
 import (
 	"fmt"
+	"os"
 	"sync/atomic"
 	"time"
 
@@ -207,7 +208,7 @@ func (cs *ContainerSetup) getContainerArtifacts(
 		return nil, nil, nil, err
 	}
 
-	bridger := network.NewEtcNetworkInterfacesBridger(clock.WallClock, activateBridgesTimeout, instancecfg.DefaultBridgePrefix, systemNetworkInterfacesFile)
+	bridger := network.NewEtcNetworkInterfacesBridger(os.Environ(), clock.WallClock, activateBridgesTimeout, instancecfg.DefaultBridgePrefix, systemNetworkInterfacesFile, false)
 
 	switch containerType {
 	case instance.KVM:


### PR DESCRIPTION
The deviceNames to bridge were being quoted as "[ens4 ens5]", when
they should have been just "ens4 ens5". This commit simplifies the
arguments passed to the invocation of the bridgescript.