### PR TITLE
Fix namespacing of lxd config

### DIFF
--- a/tools/lxdclient/instance.go
+++ b/tools/lxdclient/instance.go
@@ -8,7 +8,6 @@ package lxdclient
 import (
 	"fmt"
 	"math"
-	"strings"
 	"time"
 
 	"github.com/juju/errors"
@@ -31,14 +30,6 @@ const (
 
 	megabyte = 1024 * 1024
 )
-
-func splitConfigKey(key string) (string, string) {
-	parts := strings.SplitN(key, ".", 2)
-	if len(parts) == 1 {
-		return "", parts[0]
-	}
-	return parts[0], parts[1]
-}
 
 // AliveStatuses are the LXD statuses that indicate a container is "alive".
 var AliveStatuses = []string{

--- a/tools/lxdclient/instance.go
+++ b/tools/lxdclient/instance.go
@@ -22,7 +22,7 @@ const (
 	// http://bazaar.launchpad.net/~cloud-init-dev/cloud-init/trunk/view/head:/cloudinit/sources/
 	// http://cloudinit.readthedocs.org/en/latest/
 	// Also see https://github.com/lxc/lxd/blob/master/specs/configuration.md.
-	UserdataKey = "user-data"
+	UserdataKey = "user.user-data"
 
 	// CertificateFingerprintKey is a key that we define to associate
 	// a certificate fingerprint with an instance. We use this to clean

--- a/tools/lxdclient/instance.go
+++ b/tools/lxdclient/instance.go
@@ -26,7 +26,7 @@ const (
 	// CertificateFingerprintKey is a key that we define to associate
 	// a certificate fingerprint with an instance. We use this to clean
 	// up certificates when removing controller instances.
-	CertificateFingerprintKey = "certificate-fingerprint"
+	CertificateFingerprintKey = "user.certificate-fingerprint"
 
 	megabyte = 1024 * 1024
 )

--- a/tools/lxdclient/instance.go
+++ b/tools/lxdclient/instance.go
@@ -18,8 +18,6 @@ import (
 
 // Constants related to user metadata.
 const (
-	MetadataNamespace = "user"
-
 	// This is defined by the cloud-init code:
 	// http://bazaar.launchpad.net/~cloud-init-dev/cloud-init/trunk/view/head:/cloudinit/sources/
 	// http://cloudinit.readthedocs.org/en/latest/
@@ -258,8 +256,7 @@ func resolveMetadata(metadata map[string]string) map[string]string {
 	config := make(map[string]string)
 
 	for name, val := range metadata {
-		key := resolveConfigKey(name, MetadataNamespace)
-		config[key] = val
+		config[name] = val
 	}
 
 	return config
@@ -269,11 +266,7 @@ func extractMetadata(config map[string]string) map[string]string {
 	metadata := make(map[string]string)
 
 	for key, val := range config {
-		namespace, name := splitConfigKey(key)
-		if namespace != MetadataNamespace {
-			continue
-		}
-		metadata[name] = val
+		metadata[key] = val
 	}
 
 	return metadata

--- a/tools/lxdclient/instance.go
+++ b/tools/lxdclient/instance.go
@@ -32,11 +32,6 @@ const (
 	megabyte = 1024 * 1024
 )
 
-func resolveConfigKey(name string, namespace ...string) string {
-	parts := append(namespace, name)
-	return strings.Join(parts, ".")
-}
-
 func splitConfigKey(key string) (string, string) {
 	parts := strings.SplitN(key, ".", 2)
 	if len(parts) == 1 {

--- a/tools/lxdclient/instance_test.go
+++ b/tools/lxdclient/instance_test.go
@@ -54,7 +54,7 @@ func (s *instanceSuite) TestNewInstanceSummaryTemplate(c *gc.C) {
 	c.Check(summary.Hardware.MemoryMB, gc.Equals, uint(256))
 	// NotImplemented yet
 	c.Check(summary.Hardware.RootDiskMB, gc.Equals, uint64(0))
-	c.Check(summary.Metadata, gc.DeepEquals, map[string]string{"something": "something value"})
+	c.Check(summary.Metadata, gc.DeepEquals, map[string]string{"limits.cpu": "2", "limits.memory": "256MB", "user.something": "something value"})
 }
 
 func infoWithMemory(mem string) *lxdshared.ContainerInfo {


### PR DESCRIPTION
No longer auto-prefix keys in the lxd config with the "user." namespace. This was wrong in some places and can be done manually in the one place it is needed. 

Fixes bug #1631254.

To QA
The specific bug being fixed is that LXD containers would not autostart. To verify this is fixed:

* Bootstrap 
* Either switch to the controller model or add a new machine so you have a machine 0)
* juju add-machine lxd:0
* juju ssh 0 sudo lxc list
* Using container-id from this: juju ssh 0 sudo lxc stop juju-CONTAINER-ID
* juju ssh 0 sudo reboot

After the reboot is completed the container should be running again, having restarted correctly. 
