### PR TITLE
Add Busy status to models when upgrading

### DIFF
--- a/state/upgrade.go
+++ b/state/upgrade.go
@@ -36,9 +36,11 @@ changed to UpgradeComplete and the upgradeInfo document is archived.
 package state
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/status"
 	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils/set"
 	"github.com/juju/version"
@@ -210,6 +212,37 @@ func (info *UpgradeInfo) isModelUUIDUpgradeDone() (bool, error) {
 	return n > 0, nil
 }
 
+// upgradeStatusHistoryAndOps sets the model's status history and returns ops for
+// setting model status according to the UpgradeStatus.
+func upgradeStatusHistoryAndOps(st *State, upgradeStatus UpgradeStatus, now time.Time) ([]txn.Op, error) {
+	var modelStatus status.Status
+	var msg string
+	switch upgradeStatus {
+	case UpgradeComplete:
+		modelStatus = status.Available
+		msg = fmt.Sprintf("upgraded on %q", now.UTC().Format(time.RFC3339))
+	case UpgradeRunning:
+		modelStatus = status.Busy
+		msg = fmt.Sprintf("upgrade in progress since %q", now.UTC().Format(time.RFC3339))
+	case UpgradeAborted:
+		modelStatus = status.Available
+		msg = fmt.Sprintf("last upgrade aborted on %q", now.UTC().Format(time.RFC3339))
+	default:
+		return []txn.Op{}, nil
+	}
+	doc := statusDoc{
+		Status:     modelStatus,
+		StatusInfo: msg,
+		Updated:    now.UnixNano(),
+	}
+	ops, err := statusSetOps(st, doc, modelGlobalKey)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	probablyUpdateStatusHistory(st, modelGlobalKey, doc)
+	return ops, nil
+}
+
 // SetStatus sets the status of the current upgrade. Checks are made
 // to ensure that status changes are performed in the correct order.
 func (info *UpgradeInfo) SetStatus(status UpgradeStatus) error {
@@ -242,7 +275,15 @@ func (info *UpgradeInfo) SetStatus(status UpgradeStatus) error {
 		}}, assertSane...),
 		Update: bson.D{{"$set", bson.D{{"status", status}}}},
 	}}
-	err := info.st.runTransaction(ops)
+
+	extraOps, err := upgradeStatusHistoryAndOps(info.st, status, info.st.clock.Now())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(extraOps) > 0 {
+		ops = append(ops, extraOps...)
+	}
+	err = info.st.runTransaction(ops)
 	if err == txn.ErrAborted {
 		return errors.Errorf("cannot set upgrade status to %q: Another "+
 			"status change may have occurred concurrently", status)
@@ -401,7 +442,17 @@ func (info *UpgradeInfo) SetControllerDone(machineId string) error {
 			// This is the last controller. Archive the current
 			// upgradeInfo document.
 			doc.ControllersDone = controllersDone.SortedValues()
-			return info.makeArchiveOps(doc, UpgradeComplete), nil
+
+			ops := info.makeArchiveOps(doc, UpgradeComplete)
+			extraOps, err := upgradeStatusHistoryAndOps(info.st, UpgradeComplete, info.st.clock.Now())
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if len(extraOps) > 0 {
+				ops = append(ops, extraOps...)
+			}
+
+			return ops, nil
 		}
 
 		return []txn.Op{{
@@ -429,7 +480,16 @@ func (info *UpgradeInfo) Abort() error {
 		} else if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return info.makeArchiveOps(doc, UpgradeAborted), nil
+		ops := info.makeArchiveOps(doc, UpgradeAborted)
+		extraOps, err := upgradeStatusHistoryAndOps(info.st, UpgradeAborted, info.st.clock.Now())
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if len(extraOps) > 0 {
+			ops = append(ops, extraOps...)
+		}
+
+		return ops, nil
 	}
 	err := info.st.run(buildTxn)
 	return errors.Annotate(err, "cannot abort upgrade")

--- a/state/upgrade_test.go
+++ b/state/upgrade_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/status"
 )
 
 type UpgradeSuite struct {
@@ -400,6 +401,43 @@ func (s *UpgradeSuite) TestAllProvisionedControllersReady(c *gc.C) {
 	info, err = s.State.EnsureUpgradeInfo(serverIdC, v111, v123)
 	c.Assert(err, jc.ErrorIsNil)
 	assertReady(true)
+}
+
+func (s *UpgradeSuite) TestSetStatusSetsModelStatus(c *gc.C) {
+	v123 := vers("1.2.3")
+	v234 := vers("2.3.4")
+	info, err := s.State.EnsureUpgradeInfo(s.serverIdA, v123, v234)
+	c.Assert(err, jc.ErrorIsNil)
+
+	assertStatus := func(expect state.UpgradeStatus) {
+		info, err := s.State.EnsureUpgradeInfo(s.serverIdA, v123, v234)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(info.Status(), gc.Equals, expect)
+	}
+
+	m, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	st, err := m.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(st.Status, gc.Equals, status.Available)
+	c.Assert(st.Message, gc.Equals, "")
+
+	err = info.SetStatus(state.UpgradeRunning)
+	c.Assert(err, jc.ErrorIsNil)
+	assertStatus(state.UpgradeRunning)
+	st, err = m.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(st.Status, gc.Equals, status.Busy)
+	c.Assert(st.Message, jc.HasPrefix, "upgrade in progress since")
+
+	err = info.SetStatus(state.UpgradeFinishing)
+	c.Assert(err, jc.ErrorIsNil)
+	err = info.SetControllerDone(s.serverIdA)
+	c.Assert(err, jc.ErrorIsNil)
+	st, err = m.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(st.Status, gc.Equals, status.Available)
+	c.Assert(st.Message, jc.HasPrefix, "upgraded on")
 }
 
 func (s *UpgradeSuite) TestSetStatus(c *gc.C) {


### PR DESCRIPTION
Model Status now holds upgrading information, useful
for automation scripts that require to wait on
juju until upgrade is complete.

### QA Steps
Deploy this version of juju and upgrade
Run juju status and model status should be busy with a message indicating that the upgrade is taking place or available with a message indicating that upgrade just took place.

