### PR TITLE
Fix handling of empty bindings

### DIFF
--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -1652,7 +1652,7 @@ func (s *linkLayerDevicesStateSuite) TestSetContainerLinkLayerDevicesMismatchCon
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.machine.SetContainerLinkLayerDevices(s.containerMachine)
-	c.Assert(err.Error(), gc.Equals, `unable to find host bridge for spaces [dmz] for container "0/lxd/0"`)
+	c.Assert(err.Error(), gc.Equals, `unable to find host bridge for spaces ["dmz"] for container "0/lxd/0"`)
 
 	s.assertNoDevicesOnMachine(c, s.containerMachine)
 }
@@ -1669,7 +1669,7 @@ func (s *linkLayerDevicesStateSuite) TestSetContainerLinkLayerDevicesMissingBrid
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.machine.SetContainerLinkLayerDevices(s.containerMachine)
-	c.Assert(err.Error(), gc.Equals, `unable to find host bridge for spaces [dmz] for container "0/lxd/0"`)
+	c.Assert(err.Error(), gc.Equals, `unable to find host bridge for spaces ["dmz"] for container "0/lxd/0"`)
 
 	s.assertNoDevicesOnMachine(c, s.containerMachine)
 }
@@ -1824,7 +1824,7 @@ func (s *linkLayerDevicesStateSuite) TestFindMissingBridgesForContainerNoHostDev
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.machine.FindMissingBridgesForContainer(s.containerMachine)
-	c.Assert(err.Error(), gc.Equals, `container "0/lxd/0" wants spaces [dmz], but host machine "0" has no device in spaces [dmz]`)
+	c.Assert(err.Error(), gc.Equals, `container "0/lxd/0" wants spaces ["dmz"], but host machine "0" has no device in spaces ["dmz"]`)
 }
 
 func (s *linkLayerDevicesStateSuite) TestFindMissingBridgesForContainerTwoSpacesOneMissing(c *gc.C) {
@@ -1837,7 +1837,7 @@ func (s *linkLayerDevicesStateSuite) TestFindMissingBridgesForContainerTwoSpaces
 	})
 	_, err = s.machine.FindMissingBridgesForContainer(s.containerMachine)
 	// both default and dmz are needed, but default is missing
-	c.Assert(err.Error(), gc.Equals, `container "0/lxd/0" wants spaces [default dmz], but host machine "0" has no device in spaces [default]`)
+	c.Assert(err.Error(), gc.Equals, `container "0/lxd/0" wants spaces ["default", "dmz"], but host machine "0" has no device in spaces ["default"]`)
 }
 
 func (s *linkLayerDevicesStateSuite) TestFindMissingBridgesForContainerNoSpaces(c *gc.C) {
@@ -1878,8 +1878,8 @@ func (s *linkLayerDevicesStateSuite) TestFindMissingBridgesForContainerUnknownWi
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.machine.FindMissingBridgesForContainer(s.containerMachine)
 	c.Assert(err.Error(), gc.Equals,
-		`container "0/lxd/0" wants spaces [default], but host machine "0" `+
-			`has no device in spaces [default]`)
+		`container "0/lxd/0" wants spaces ["default"], but host machine "0" `+
+			`has no device in spaces ["default"]`)
 }
 
 func (s *linkLayerDevicesStateSuite) TestFindMissingBridgesForContainerUnknownAndDefault(c *gc.C) {

--- a/state/machine.go
+++ b/state/machine.go
@@ -1124,11 +1124,13 @@ func (m *Machine) DesiredSpaces() (set.Strings, error) {
 		}
 		endpointBindings, err := app.EndpointBindings()
 		for _, space := range endpointBindings {
-			bindings.Add(space)
+			if space != "" {
+				bindings.Add(space)
+			}
 		}
 	}
-	logger.Tracef("machine %q found constraints %v and bindings %v",
-		m.Id(), spaces.SortedValues(), bindings.SortedValues())
+	logger.Tracef("machine %q found constraints %s and bindings %s",
+		m.Id(), quoteSpaces(spaces), quoteSpaces(bindings))
 	return spaces.Union(bindings), nil
 }
 


### PR DESCRIPTION
So if you add an application that has endpoints, but no actual bindings, all of those bindings come back as requesting space "". However, that is not actually a space request.

This patch does 2 things:
1) Fix our reporting of desired spaces because fmt.Sprintf("%v", []string{""}) shows up as "[]" not "[""]". This should fix that problem.
2) Change our DesiredSpaces code to notice that "" is not a desired space. This comes with a unit test for it.

I don't know that this is sufficient to fix the issues we're seeing in the maas-2.1-bundle-deploy-test, but it should be a significant step in the right direction.
