### PR TITLE
Raise all network interfaces, post bridging a single interface

### DIFF
--- a/network/add-juju-bridge.py
+++ b/network/add-juju-bridge.py
@@ -452,9 +452,8 @@ def main(args):
             shell_cmd("sleep 3", dry_run=args.dry_run)
             break
 
-    bridged_names = [ args.bridge_prefix + x for x in interfaces ]
     shell_cmd("cat {}".format(args.filename), dry_run=args.dry_run)
-    shell_cmd("ifup --exclude=lo --interfaces={} {}".format(args.filename, " ".join(bridged_names)), dry_run=args.dry_run)
+    shell_cmd("ifup --exclude=lo --interfaces={} -a".format(args.filename), dry_run=args.dry_run)
     shell_cmd("ip link show up", dry_run=args.dry_run)
     shell_cmd("ifconfig -a", dry_run=args.dry_run)
     shell_cmd("ip route show", dry_run=args.dry_run)

--- a/network/bridgescript.go
+++ b/network/bridgescript.go
@@ -456,9 +456,8 @@ def main(args):
             shell_cmd("sleep 3", dry_run=args.dry_run)
             break
 
-    bridged_names = [ args.bridge_prefix + x for x in interfaces ]
     shell_cmd("cat {}".format(args.filename), dry_run=args.dry_run)
-    shell_cmd("ifup --exclude=lo --interfaces={} {}".format(args.filename, " ".join(bridged_names)), dry_run=args.dry_run)
+    shell_cmd("ifup --exclude=lo --interfaces={} -a".format(args.filename), dry_run=args.dry_run)
     shell_cmd("ip link show up", dry_run=args.dry_run)
     shell_cmd("ifconfig -a", dry_run=args.dry_run)
     shell_cmd("ip route show", dry_run=args.dry_run)

--- a/network/bridgescript_test.go
+++ b/network/bridgescript_test.go
@@ -248,7 +248,7 @@ func (s *bridgeConfigSuite) dryRunExpectedOutputHelper(isBonded, isAlreadyBridge
 			output = append(output, "sleep 3")
 		}
 		output = append(output, fmt.Sprintf("cat %s", s.testConfigPath))
-		output = append(output, fmt.Sprintf("ifup --exclude=lo --interfaces=%[1]s %s", s.testConfigPath, strings.Join(bridgedNames, " ")))
+		output = append(output, fmt.Sprintf("ifup --exclude=lo --interfaces=%[1]s -a", s.testConfigPath))
 		output = append(output, "ip link show up")
 		output = append(output, "ifconfig -a")
 		output = append(output, "ip route show")


### PR DESCRIPTION
In dynamic bridging we were taking down ens5.100, turning that into a
bridge, then bringing up br-ens5.100. This is not enough. We also need
to bring the physical device back up too. Rather than list the
interfaces to bring back up as "ens5.100 br-ens5.100" rely on ifup's
-a option (all interfaces marked auto) to work out what needs to be
brought back up. This divorces us from having to walk the dependencies
of VLAN's on a bond on a physical device, et al.