### PR TITLE
Fix remote relation register

### DIFF
--- a/container/kvm/run_linux.go
+++ b/container/kvm/run_linux.go
@@ -2,7 +2,7 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build linux
-// +build amd64 arm64 ppc64el
+// +build amd64 arm64 ppc64le
 
 package kvm
 


### PR DESCRIPTION
The name of the remote application as recorded in the consuming model is set to user-model-appname.
But when we register with the offering model, we need to pass in the app name from the offering side.

Also fixup some error handing in the remote relation worker.

QA: bootstrap and add a remote relation