### PR TITLE
Cross-model relations: consume command

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -327,8 +327,8 @@ func (c *Client) DestroyRelation(endpoints ...string) error {
 // Consume adds a remote application to the model.
 func (c *Client) Consume(remoteApplication string) (string, error) {
 	var consumeRes params.ConsumeApplicationResults
-	params := params.ConsumeApplications{
-		Applications: []string{remoteApplication},
+	params := params.ApplicationURLs{
+		ApplicationURLs: []string{remoteApplication},
 	}
 	err := c.facade.FacadeCall("Consume", params, &consumeRes)
 	if err != nil {

--- a/api/application/client.go
+++ b/api/application/client.go
@@ -326,5 +326,19 @@ func (c *Client) DestroyRelation(endpoints ...string) error {
 
 // Consume adds a remote application to the model.
 func (c *Client) Consume(remoteApplication string) (string, error) {
-	return "", nil
+	var consumeRes params.ConsumeApplicationResults
+	params := params.ConsumeApplications{
+		Applications: []string{remoteApplication},
+	}
+	err := c.facade.FacadeCall("Consume", params, &consumeRes)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if resultLen := len(consumeRes.Results); resultLen != 1 {
+		return "", errors.Errorf("expected 1 result, got %d", resultLen)
+	}
+	if err := consumeRes.Results[0].Error; err != nil {
+		return "", errors.Trace(err)
+	}
+	return consumeRes.Results[0].LocalName, nil
 }

--- a/api/application/client.go
+++ b/api/application/client.go
@@ -323,3 +323,8 @@ func (c *Client) DestroyRelation(endpoints ...string) error {
 	params := params.DestroyRelation{Endpoints: endpoints}
 	return c.facade.FacadeCall("DestroyRelation", params, nil)
 }
+
+// Consume adds a remote application to the model.
+func (c *Client) Consume(remoteApplication string) (string, error) {
+	return "", nil
+}

--- a/apiserver/application/application.go
+++ b/apiserver/application/application.go
@@ -1110,6 +1110,9 @@ func (api *API) consumeOne(possibleURL string) (string, error) {
 	if err != nil {
 		return "", errors.Trace(err)
 	}
+	if url.HasEndpoint() {
+		return "", errors.New("remote application shouldn't include endpoint")
+	}
 	remoteApp, err := api.processRemoteApplication(*url)
 	if err != nil {
 		return "", errors.Trace(err)

--- a/apiserver/application/application.go
+++ b/apiserver/application/application.go
@@ -1079,6 +1079,44 @@ func (api *API) charmIcon(backend Backend, curl *charm.URL) ([]byte, error) {
 	return common.CharmArchiveEntry(charmPath, "icon.svg", true)
 }
 
+// Consume adds remote applications to the model without
+func (api *API) Consume(args params.ApplicationURLs) (params.ConsumeApplicationResults, error) {
+	var consumeResults params.ConsumeApplicationResults
+	if err := api.checkCanWrite(); err != nil {
+		return consumeResults, err
+	}
+	if err := api.check.ChangeAllowed(); err != nil {
+		return consumeResults, errors.Trace(err)
+	}
+	if !featureflag.Enabled(feature.CrossModelRelations) {
+		err := errors.Errorf(
+			"set %q feature flag to enable consuming remote applications",
+			feature.CrossModelRelations,
+		)
+		return consumeResults, err
+	}
+	results := make([]params.ConsumeApplicationResult, len(args.ApplicationURLs))
+	for i, applicationURL := range args.ApplicationURLs {
+		localName, err := api.consumeOne(applicationURL)
+		results[i].LocalName = localName
+		results[i].Error = common.ServerError(err)
+	}
+	consumeResults.Results = results
+	return consumeResults, nil
+}
+
+func (api *API) consumeOne(possibleURL string) (string, error) {
+	url, err := jujucrossmodel.ParseApplicationURL(possibleURL)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	remoteApp, err := api.processRemoteApplication(*url)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return remoteApp.Name(), nil
+}
+
 // DestroyRelation removes the relation between the specified endpoints.
 func (api *API) DestroyRelation(args params.DestroyRelation) error {
 	if err := api.checkCanWrite(); err != nil {

--- a/apiserver/application/application.go
+++ b/apiserver/application/application.go
@@ -1079,7 +1079,8 @@ func (api *API) charmIcon(backend Backend, curl *charm.URL) ([]byte, error) {
 	return common.CharmArchiveEntry(charmPath, "icon.svg", true)
 }
 
-// Consume adds remote applications to the model without
+// Consume adds remote applications to the model without creating any
+// relations.
 func (api *API) Consume(args params.ApplicationURLs) (params.ConsumeApplicationResults, error) {
 	var consumeResults params.ConsumeApplicationResults
 	if err := api.checkCanWrite(); err != nil {
@@ -1111,7 +1112,7 @@ func (api *API) consumeOne(possibleURL string) (string, error) {
 		return "", errors.Trace(err)
 	}
 	if url.HasEndpoint() {
-		return "", errors.New("remote application shouldn't include endpoint")
+		return "", errors.Errorf("remote application %q shouldn't include endpoint", url)
 	}
 	remoteApp, err := api.processRemoteApplication(*url)
 	if err != nil {

--- a/apiserver/application/application_test.go
+++ b/apiserver/application/application_test.go
@@ -2859,7 +2859,7 @@ func (s *serviceSuite) TestConsumeRejectsEndpoints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error != nil, jc.IsTrue)
-	c.Assert(results.Results[0].Error.Message, gc.Equals, "remote application shouldn't include endpoint")
+	c.Assert(results.Results[0].Error.Message, gc.Equals, `remote application "othermodel.application:db" shouldn't include endpoint`)
 }
 
 func (s *serviceSuite) TestConsumeRequiresFeatureFlag(c *gc.C) {

--- a/apiserver/application/application_test.go
+++ b/apiserver/application/application_test.go
@@ -2852,6 +2852,73 @@ func (s *serviceSuite) TestBlockDestroyDestroyRelation(c *gc.C) {
 	s.assertDestroyRelation(c, endpoints)
 }
 
+func (s *serviceSuite) TestConsumeRejectsEndpoints(c *gc.C) {
+	results, err := s.applicationAPI.Consume(params.ApplicationURLs{
+		ApplicationURLs: []string{"othermodel.application:db"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error != nil, jc.IsTrue)
+	c.Assert(results.Results[0].Error.Message, gc.Equals, "remote application shouldn't include endpoint")
+}
+
+func (s *serviceSuite) TestConsumeRequiresFeatureFlag(c *gc.C) {
+	s.SetFeatureFlags()
+	_, err := s.applicationAPI.Consume(params.ApplicationURLs{
+		ApplicationURLs: []string{"othermodel.application:db"},
+	})
+	c.Assert(err, gc.ErrorMatches, `set "cross-model" feature flag to enable consuming remote applications`)
+}
+
+func (s *serviceSuite) TestConsumeDirectAndURL(c *gc.C) {
+	_, err := s.otherModel.AddApplication(state.AddApplicationArgs{
+		Name:  "mysql",
+		Charm: s.addTestingCharmOtherModel(c, "mysql"),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.otherModel.AddApplication(state.AddApplicationArgs{
+		Name:  "riak",
+		Charm: s.addTestingCharmOtherModel(c, "riak"),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Offer mysql via the directory.
+	s.offersApiFactory.offers = remoteOffers()
+
+	results, err := s.applicationAPI.Consume(params.ApplicationURLs{
+		ApplicationURLs: []string{"othermodel.riak", "local:/u/me/hosted-mysql"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.ConsumeApplicationResults{
+		Results: []params.ConsumeApplicationResult{
+			{LocalName: "admin-othermodel-riak"},
+			{LocalName: "hosted-mysql"},
+		},
+	})
+
+	// Check that the remote applications were created.
+	_, err = s.State.RemoteApplication("admin-othermodel-riak")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.RemoteApplication("hosted-mysql")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *serviceSuite) TestConsumingAndAddingRelation(c *gc.C) {
+	_, err := s.otherModel.AddApplication(state.AddApplicationArgs{
+		Name:  "mysql",
+		Charm: s.addTestingCharmOtherModel(c, "mysql"),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.offersApiFactory.offers = remoteOffers()
+	_, err = s.applicationAPI.Consume(params.ApplicationURLs{
+		ApplicationURLs: []string{"local:/u/me/hosted-mysql"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// There's already a wordpress in the scenario this assertion sets up.
+	s.assertAddRelation(c, []string{"wordpress", "hosted-mysql"})
+}
+
 type mockStorageProvider struct {
 	storage.Provider
 	kind storage.StorageKind

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -450,5 +450,23 @@ type RemoteApplicationInfoResult struct {
 
 // RemoteApplicationInfoResults represents the result of a RemoteApplicationInfo call.
 type RemoteApplicationInfoResults struct {
-	Results []RemoteApplicationInfoResult
+	Results []RemoteApplicationInfoResult `json:"results"`
+}
+
+// ConsumeApplications represents a request to add remote applications
+// to the model.
+type ConsumeApplications struct {
+	Applications []string `json:"applications"`
+}
+
+// ConsumeApplicationResult is the response for one request to consume
+// a remote application.
+type ConsumeApplicationResult struct {
+	LocalName string `json:"local-name,omitempty"`
+	Error     *Error `json:"error,omitempty"`
+}
+
+// ConsumeApplicationResults is the result of a Consume call.
+type ConsumeApplicationResults struct {
+	Results []ConsumeApplicationResult `json:"results"`
 }

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -126,7 +126,7 @@ type ApplicationOffersResults struct {
 	Results []ApplicationOfferResult `json:"results,omitempty"`
 }
 
-// ApplicationURLs is a filter used to select remote applications via show call.
+// ApplicationURLs is a collection of remote application URLs
 type ApplicationURLs struct {
 	// ApplicationURLs contains collection of urls for applications that are to be shown.
 	ApplicationURLs []string `json:"application-urls,omitempty"`
@@ -451,12 +451,6 @@ type RemoteApplicationInfoResult struct {
 // RemoteApplicationInfoResults represents the result of a RemoteApplicationInfo call.
 type RemoteApplicationInfoResults struct {
 	Results []RemoteApplicationInfoResult `json:"results"`
-}
-
-// ConsumeApplications represents a request to add remote applications
-// to the model.
-type ConsumeApplications struct {
-	Applications []string `json:"applications"`
 }
 
 // ConsumeApplicationResult is the response for one request to consume

--- a/cmd/juju/application/consume.go
+++ b/cmd/juju/application/consume.go
@@ -1,0 +1,79 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/application"
+	"github.com/juju/juju/cmd/juju/block"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+var usageConsumeSummary = `
+Add a remote application to the model.`[1:]
+
+var usageExposeDetails = `
+Adjusts the firewall rules and any relevant security mechanisms of the
+cloud to allow public access to the application.
+
+Examples:
+    juju expose wordpress
+
+See also: 
+    unexpose`[1:]
+
+// NewExposeCommand returns a command to expose services.
+func NewExposeCommand() cmd.Command {
+	return modelcmd.Wrap(&exposeCommand{})
+}
+
+// exposeCommand is responsible exposing services.
+type exposeCommand struct {
+	modelcmd.ModelCommandBase
+	ApplicationName string
+}
+
+func (c *exposeCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "expose",
+		Args:    "<application name>",
+		Purpose: usageExposeSummary,
+		Doc:     usageExposeDetails,
+	}
+}
+
+func (c *exposeCommand) Init(args []string) error {
+	if len(args) == 0 {
+		return errors.New("no application name specified")
+	}
+	c.ApplicationName = args[0]
+	return cmd.CheckEmpty(args[1:])
+}
+
+type serviceExposeAPI interface {
+	Close() error
+	Expose(serviceName string) error
+	Unexpose(serviceName string) error
+}
+
+func (c *exposeCommand) getAPI() (serviceExposeAPI, error) {
+	root, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return application.NewClient(root), nil
+}
+
+// Run changes the juju-managed firewall to expose any
+// ports that were also explicitly marked by units as open.
+func (c *exposeCommand) Run(_ *cmd.Context) error {
+	client, err := c.getAPI()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+	return block.ProcessBlockedError(client.Expose(c.ApplicationName), block.BlockChange)
+}

--- a/cmd/juju/application/consume.go
+++ b/cmd/juju/application/consume.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/crossmodel"
 )
 
 var usageConsumeSummary = `
@@ -63,6 +64,13 @@ func (c *consumeCommand) Init(args []string) error {
 		return errors.New("no remote application specified")
 	}
 	c.remoteApplication = args[0]
+	url, err := crossmodel.ParseApplicationURL(c.remoteApplication)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if url.HasEndpoint() {
+		return errors.New("remote application shouldn't include an endpoint")
+	}
 	return cmd.CheckEmpty(args[1:])
 }
 

--- a/cmd/juju/application/consume.go
+++ b/cmd/juju/application/consume.go
@@ -69,7 +69,7 @@ func (c *consumeCommand) Init(args []string) error {
 		return errors.Trace(err)
 	}
 	if url.HasEndpoint() {
-		return errors.New("remote application shouldn't include an endpoint")
+		return errors.New("remote application shouldn't include endpoint")
 	}
 	return cmd.CheckEmpty(args[1:])
 }

--- a/cmd/juju/application/consume.go
+++ b/cmd/juju/application/consume.go
@@ -44,7 +44,7 @@ func NewConsumeCommand() cmd.Command {
 // relating them to other applications.
 type consumeCommand struct {
 	modelcmd.ModelCommandBase
-	api               serviceConsumeAPI
+	api               applicationConsumeAPI
 	remoteApplication string
 }
 
@@ -69,12 +69,12 @@ func (c *consumeCommand) Init(args []string) error {
 		return errors.Trace(err)
 	}
 	if url.HasEndpoint() {
-		return errors.New("remote application shouldn't include endpoint")
+		return errors.Errorf("remote application %q shouldn't include endpoint", c.remoteApplication)
 	}
 	return cmd.CheckEmpty(args[1:])
 }
 
-func (c *consumeCommand) getAPI() (serviceConsumeAPI, error) {
+func (c *consumeCommand) getAPI() (applicationConsumeAPI, error) {
 	if c.api != nil {
 		return c.api, nil
 	}
@@ -101,7 +101,7 @@ func (c *consumeCommand) Run(ctx *cmd.Context) error {
 	return nil
 }
 
-type serviceConsumeAPI interface {
+type applicationConsumeAPI interface {
 	Close() error
 	Consume(remoteApplication string) (string, error)
 }

--- a/cmd/juju/application/consume_test.go
+++ b/cmd/juju/application/consume_test.go
@@ -1,0 +1,82 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application_test
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/application"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type ConsumeSuite struct {
+	testing.IsolationSuite
+	mockAPI *mockConsumeAPI
+}
+
+var _ = gc.Suite(&ConsumeSuite{})
+
+func (s *ConsumeSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.mockAPI = &mockConsumeAPI{Stub: &testing.Stub{}}
+}
+
+func (s *ConsumeSuite) runConsume(c *gc.C, args ...string) (*cmd.Context, error) {
+	return coretesting.RunCommand(c, application.NewConsumeCommandForTest(s.mockAPI), args...)
+}
+
+func (s *ConsumeSuite) TestNoArguments(c *gc.C) {
+	_, err := s.runConsume(c)
+	c.Assert(err, gc.ErrorMatches, "no remote application specified")
+}
+
+func (s *ConsumeSuite) TestTooManyArguments(c *gc.C) {
+	_, err := s.runConsume(c, "model.application", "something else")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["something else"\]`)
+}
+
+func (s *ConsumeSuite) TestInvalidRemoteApplication(c *gc.C) {
+
+	c.Fatalf("writeme")
+}
+
+func (s *ConsumeSuite) TestErrorFromAPI(c *gc.C) {
+	s.mockAPI.SetErrors(errors.New("infirmary"))
+	_, err := s.runConsume(c, "model.application")
+	c.Assert(err, gc.ErrorMatches, "infirmary")
+}
+
+func (s *ConsumeSuite) TestSuccessUrl(c *gc.C) {
+	s.mockAPI.localName = "careless-love"
+	ctx, err := s.runConsume(c, "local:/u/james/hill")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(coretesting.Stderr(ctx), gc.Equals, "Added local:/u/james/hill as careless-love\n")
+}
+
+func (s *ConsumeSuite) TestSuccessModelDotApplication(c *gc.C) {
+	s.mockAPI.localName = "mary-weep"
+	ctx, err := s.runConsume(c, "booster.uke")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(coretesting.Stderr(ctx), gc.Equals, "Added booster.uke as mary-weep\n")
+}
+
+type mockConsumeAPI struct {
+	*testing.Stub
+
+	localName string
+}
+
+func (a *mockConsumeAPI) Close() error {
+	a.MethodCall(a, "Close")
+	return a.NextErr()
+}
+
+func (a *mockConsumeAPI) Consume(remoteApplication string) (string, error) {
+	a.MethodCall(a, "Consume", remoteApplication)
+	return a.localName, a.NextErr()
+}

--- a/cmd/juju/application/consume_test.go
+++ b/cmd/juju/application/consume_test.go
@@ -41,8 +41,17 @@ func (s *ConsumeSuite) TestTooManyArguments(c *gc.C) {
 }
 
 func (s *ConsumeSuite) TestInvalidRemoteApplication(c *gc.C) {
-
-	c.Fatalf("writeme")
+	badApplications := []string{
+		"application",
+		"user/model.application:endpoint",
+		"user/model",
+		"unknown:/wherever",
+	}
+	for _, bad := range badApplications {
+		c.Logf(bad)
+		_, err := s.runConsume(c, bad)
+		c.Check(err != nil, jc.IsTrue)
+	}
 }
 
 func (s *ConsumeSuite) TestErrorFromAPI(c *gc.C) {

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -69,6 +69,11 @@ func NewRemoveRelationCommandForTest(api ApplicationDestroyRelationAPI) cmd.Comm
 	return modelcmd.Wrap(cmd)
 }
 
+// NewConsumeCommandForTest returns a ConsumeCommand with the specified api.
+func NewConsumeCommandForTest(api serviceConsumeAPI) cmd.Command {
+	return modelcmd.Wrap(&consumeCommand{api: api})
+}
+
 type Patcher interface {
 	PatchValue(dest, value interface{})
 }

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -70,7 +70,7 @@ func NewRemoveRelationCommandForTest(api ApplicationDestroyRelationAPI) cmd.Comm
 }
 
 // NewConsumeCommandForTest returns a ConsumeCommand with the specified api.
-func NewConsumeCommandForTest(api serviceConsumeAPI) cmd.Command {
+func NewConsumeCommandForTest(api applicationConsumeAPI) cmd.Command {
 	return modelcmd.Wrap(&consumeCommand{api: api})
 }
 

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -255,6 +255,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 		r.Register(crossmodel.NewShowOfferedEndpointCommand())
 		r.Register(crossmodel.NewListEndpointsCommand())
 		r.Register(crossmodel.NewFindEndpointsCommand())
+		r.Register(application.NewConsumeCommand())
 	}
 
 	// Destruction commands.
@@ -355,9 +356,6 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(application.NewUnexposeCommand())
 	r.Register(application.NewServiceGetConstraintsCommand())
 	r.Register(application.NewServiceSetConstraintsCommand())
-	if featureflag.Enabled(feature.CrossModelRelations) {
-		r.Register(application.NewConsumeCommand())
-	}
 
 	// Operation protection commands
 	r.Register(block.NewDisableCommand())

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -355,7 +355,9 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(application.NewUnexposeCommand())
 	r.Register(application.NewServiceGetConstraintsCommand())
 	r.Register(application.NewServiceSetConstraintsCommand())
-	r.Register(application.NewConsumeCommand())
+	if featureflag.Enabled(feature.CrossModelRelations) {
+		r.Register(application.NewConsumeCommand())
+	}
 
 	// Operation protection commands
 	r.Register(block.NewDisableCommand())

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -355,6 +355,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(application.NewUnexposeCommand())
 	r.Register(application.NewServiceGetConstraintsCommand())
 	r.Register(application.NewServiceSetConstraintsCommand())
+	r.Register(application.NewConsumeCommand())
 
 	// Operation protection commands
 	r.Register(block.NewDisableCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -535,6 +535,7 @@ var devFeatures = []string{feature.CrossModelRelations}
 
 // These are the commands that are behind the `devFeatures`.
 var commandNamesBehindFlags = set.NewStrings(
+	"consume",
 	"find-endpoints",
 	"list-offers",
 	"offer",

--- a/core/crossmodel/applicationurl.go
+++ b/core/crossmodel/applicationurl.go
@@ -59,6 +59,8 @@ func (u *ApplicationURL) String() string {
 	return fmt.Sprintf("%s:/%s", u.Directory, u.Path())
 }
 
+// HasEndpoint returns whether this application URL includes an
+// endpoint name in the application name.
 func (u *ApplicationURL) HasEndpoint() bool {
 	return strings.Contains(u.ApplicationName, ":")
 }

--- a/core/crossmodel/applicationurl.go
+++ b/core/crossmodel/applicationurl.go
@@ -59,6 +59,10 @@ func (u *ApplicationURL) String() string {
 	return fmt.Sprintf("%s:/%s", u.Directory, u.Path())
 }
 
+func (u *ApplicationURL) HasEndpoint() bool {
+	return strings.Contains(u.ApplicationName, ":")
+}
+
 // modelApplicationRegexp parses urls of the form user/model.application[:relname]
 var modelApplicationRegexp = regexp.MustCompile(`((?P<user>[^/]*)/)?(?P<model>[^.^/]*)\.(?P<application>[^:]*(:.*)?)`)
 

--- a/core/crossmodel/applicationurl_test.go
+++ b/core/crossmodel/applicationurl_test.go
@@ -180,3 +180,18 @@ func (s *ApplicationURLSuite) TestParseURLParts(c *gc.C) {
 		}
 	}
 }
+
+func (s *ApplicationURLSuite) TestHasEndpoint(c *gc.C) {
+	url, err := crossmodel.ParseApplicationURL("model.application:endpoint")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(url.HasEndpoint(), jc.IsTrue)
+	url, err = crossmodel.ParseApplicationURL("model.application")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(url.HasEndpoint(), jc.IsFalse)
+	url, err = crossmodel.ParseApplicationURL("local:/u/blah/application:thing")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(url.HasEndpoint(), jc.IsTrue)
+	url, err = crossmodel.ParseApplicationURL("local:/u/blah/application")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(url.HasEndpoint(), jc.IsFalse)
+}


### PR DESCRIPTION
Consume adds a remote application to the model without creating any relations to it.
```
juju consume othermodel.mysql
```
The remote application can also be specified by URL.

At the moment the command takes no more options than the normal model command options - in the future there will also be a way to specify the local name for the application in this model.

QA steps:
* Bootstrap and create 2 models, a and b.
* Deploy mysql to a.
* Deploy wordpress to b.
* In b run `juju consume a.mysql` - it will show the local name for the application.
* Confirm that you see the remote mysql in status.
* Connect wordpress to the remote mysql (using the local name).
* Expose wordpress.
* Check that it works!