### PR TITLE
lp:1654589 -- broken 390x build

### DIFF
--- a/container/kvm/run_linux.go
+++ b/container/kvm/run_linux.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build linux
-// +build amd64 arm64 ppc64le
 
 package kvm
 

--- a/container/kvm/run_other.go
+++ b/container/kvm/run_other.go
@@ -8,9 +8,9 @@ package kvm
 import "github.com/juju/errors"
 
 func runAsLibvirt(commands string, args ...string) (string, error) {
-	return "", errors.New("kvm support is only available on linux amd64, arm64, and ppc64el")
+	return "", errors.New("kvm is only supported on linux amd64, arm64, and ppc64el")
 }
 
 func getUserUIDGID(_ string) (int, int, error) {
-	return -1, -1, errors.New("kvm support is only available on linux amd64, arm64, and ppc64el")
+	return -1, -1, errors.New("kvm is only supported on linux amd64, arm64, and ppc64el")
 }


### PR DESCRIPTION
Since we only support kvm on arm64, amd64, and pp64el, it seems ideal
to not biuld it elsewhere. However, why punish others where it might
just work.

Is it better to not build and explicitly state it isn't
supported on other arches or to let it build and then maybe not work?

Fixes: https://bugs.launchpad.net/bugs/1654589