### PR TITLE
Store separate migration attempt number

### DIFF
--- a/apiserver/migrationmaster/facade_test.go
+++ b/apiserver/migrationmaster/facade_test.go
@@ -478,10 +478,6 @@ func (m *stubMigration) PhaseChangedTime() time.Time {
 	return time.Date(2016, 6, 22, 16, 38, 0, 0, time.UTC)
 }
 
-func (m *stubMigration) Attempt() (int, error) {
-	return 1, nil
-}
-
 func (m *stubMigration) ModelUUID() string {
 	return modelUUID
 }

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -492,11 +492,6 @@ func (w *srvMigrationStatusWatcher) Next() (params.MigrationStatus, error) {
 		return empty, errors.Annotate(err, "migration lookup")
 	}
 
-	attempt, err := mig.Attempt()
-	if err != nil {
-		return empty, errors.Annotate(err, "retrieving migration attempt")
-	}
-
 	phase, err := mig.Phase()
 	if err != nil {
 		return empty, errors.Annotate(err, "retrieving migration phase")
@@ -519,7 +514,7 @@ func (w *srvMigrationStatusWatcher) Next() (params.MigrationStatus, error) {
 
 	return params.MigrationStatus{
 		MigrationId:    mig.Id(),
-		Attempt:        attempt,
+		Attempt:        mig.Attempt(),
 		Phase:          phase.String(),
 		SourceAPIAddrs: sourceAddrs,
 		SourceCACert:   sourceCACert,

--- a/apiserver/watcher_test.go
+++ b/apiserver/watcher_test.go
@@ -251,8 +251,8 @@ func (m *fakeModelMigration) Id() string {
 	return "id"
 }
 
-func (m *fakeModelMigration) Attempt() (int, error) {
-	return 2, nil
+func (m *fakeModelMigration) Attempt() int {
+	return 2
 }
 
 func (m *fakeModelMigration) Phase() (migration.Phase, error) {

--- a/upgrades/steps_21.go
+++ b/upgrades/steps_21.go
@@ -17,5 +17,12 @@ func stateStepsFor21() []Step {
 				return state.DropOldLogIndex(context.State())
 			},
 		},
+		&upgradeStep{
+			description: "add attempt to migration docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddMigrationAttempt(context.State())
+			},
+		},
 	}
 }

--- a/upgrades/steps_21_test.go
+++ b/upgrades/steps_21_test.go
@@ -1,0 +1,33 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v210 = version.MustParse("2.1.0")
+
+type steps21Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps21Suite{})
+
+func (s *steps21Suite) TestDropOldLogIndex(c *gc.C) {
+	step := findStateStep(c, v210, "drop old log index")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}
+
+func (s *steps21Suite) TestAddMigrationAttempt(c *gc.C) {
+	step := findStateStep(c, v210, "add attempt to migration docs")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}


### PR DESCRIPTION
This is a forward port of #6715.

In order to allow correct sorting of migration documents when there's been 10 or more attempts (note: 2 digits), the attempt number is now stored in a separate document field. This also simplifies the Attempt()
API, negating the need for an error return.

Upgrade step for preexisting migration documents included.

### QA 

Ran a migration and confirmed by DB inspection that an attempt field was on the migration document. Then manually removed the field, modified the upgradedToVersion in the controller's agent.conf and restarted the controller agent to trigger upgrade steps to run. Inspecting the DB again showed that the correct attempt field had been added.
