### PR TITLE
better error msgs

### DIFF
--- a/container/kvm/container.go
+++ b/container/kvm/container.go
@@ -67,7 +67,7 @@ func (c *kvmContainer) Start(params StartParams) error {
 			return err
 		}
 	}
-	logger.Debugf("Create the machine %s", c.name)
+	logger.Debugf("create the machine %s", c.name)
 	if err := CreateMachine(CreateMachineParams{
 		Hostname:      c.name,
 		Series:        params.Series,

--- a/container/kvm/kvm.go
+++ b/container/kvm/kvm.go
@@ -184,7 +184,9 @@ func (manager *containerManager) CreateContainer(
 	logger.Tracef("create the container, constraints: %v", cons)
 	if err := kvmContainer.Start(startParams); err != nil {
 		err = errors.Annotate(err, "kvm container creation failed")
-		logger.Infof(err.Error())
+		// Logged as debug here because it is logged as an error in
+		// worker/provisioner.
+		logger.Debugf(err.Error())
 		return nil, nil, err
 	}
 	logger.Tracef("kvm container created")

--- a/container/kvm/kvm.go
+++ b/container/kvm/kvm.go
@@ -184,9 +184,6 @@ func (manager *containerManager) CreateContainer(
 	logger.Tracef("create the container, constraints: %v", cons)
 	if err := kvmContainer.Start(startParams); err != nil {
 		err = errors.Annotate(err, "kvm container creation failed")
-		// Logged as debug here because it is logged as an error in
-		// worker/provisioner.
-		logger.Debugf(err.Error())
 		return nil, nil, err
 	}
 	logger.Tracef("kvm container created")

--- a/container/kvm/wrappedcmds_test.go
+++ b/container/kvm/wrappedcmds_test.go
@@ -203,7 +203,7 @@ func (commandWrapperSuite) TestAutostartMachineFails(c *gc.C) {
 	container := NewTestContainer("aname", stub.Run, nil)
 	err := AutostartMachine(container)
 	c.Assert(stub.Calls(), jc.DeepEquals, []string{"virsh autostart aname"})
-	c.Assert(err, gc.ErrorMatches, "Boom")
+	c.Check(err, gc.ErrorMatches, "failed to autostart domain \"aname\": Boom")
 }
 
 func (commandWrapperSuite) TestListMachinesSuccess(c *gc.C) {

--- a/container/kvm/wrappedcmds_test.go
+++ b/container/kvm/wrappedcmds_test.go
@@ -203,7 +203,7 @@ func (commandWrapperSuite) TestAutostartMachineFails(c *gc.C) {
 	container := NewTestContainer("aname", stub.Run, nil)
 	err := AutostartMachine(container)
 	c.Assert(stub.Calls(), jc.DeepEquals, []string{"virsh autostart aname"})
-	c.Check(err, gc.ErrorMatches, "failed to autostart domain \"aname\": Boom")
+	c.Check(err, gc.ErrorMatches, `failed to autostart domain "aname": Boom`)
 }
 
 func (commandWrapperSuite) TestListMachinesSuccess(c *gc.C) {

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -70,7 +70,7 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	if err != nil {
 		// It's not fatal (yet) if we couldn't pre-allocate addresses for the
 		// container.
-		logger.Debugf("failed to prepare container %q network config: %v", machineId, err)
+		logger.Infof("failed to prepare container %q network config: %v", machineId, err)
 	} else {
 		args.NetworkInfo = preparedInfo
 	}

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -70,7 +70,7 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	if err != nil {
 		// It's not fatal (yet) if we couldn't pre-allocate addresses for the
 		// container.
-		logger.Warningf("failed to prepare container %q network config: %v", machineId, err)
+		logger.Debugf("failed to prepare container %q network config: %v", machineId, err)
 	} else {
 		args.NetworkInfo = preparedInfo
 	}


### PR DESCRIPTION
Add annotations to error messages from shelling out so  we get informative error
messages. It currently reports  "exit 1". Also change a couple logging statments Debug as the
caller logs an error and they just duplicate the information noisily.

QA:  (This currently fails on develop but when the network code @jameinel and @frobware are working on lands, it won't fail anymore.)
1. Setup a maas
2. go install github.com/juju/juju/... 
3. juju bootstrap vmaas21 kvm/purego --build-agent --constraints mem=2G
4. juju add-machine
5. juju add-machine --series trusty
6. juju deploy mysql --to kvm:0
7. juju deploy postgresql --to kvm:1 --series xenial
8. juju deploy wordpress --to kvm:1
9. juju deploy ubuntu --to kvm:0 --constraints mem=1G
10 .juju add-relation wordpress mysql

Check the logs and ensure we don't have a bunch of duplicate failure messages and that there is reasonable information regarding the failure. 
juju debug-log --level DEBUG --replay  --include machine-1
juju debug-log --level DEBUG --replay  --include machine-0

Cleanup: juju kill-controller kvm/purego -y 

