### PR TITLE
Make required packages variable and non-global

### DIFF
--- a/container/kvm/initialisation.go
+++ b/container/kvm/initialisation.go
@@ -5,24 +5,16 @@ package kvm
 
 import (
 	"os"
+	"runtime"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/arch"
 	"github.com/juju/utils/packaging/manager"
 	"github.com/juju/utils/series"
 
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/juju/paths"
 )
-
-var requiredPackages = []string{
-	// `qemu-kvm` must be installed before `libvirt-bin` on trusty. It appears
-	// that upstart doesn't reload libvirtd if installed after, and we see
-	// errors related to `qemu-kvm` not being installed.
-	"qemu-kvm",
-	"genisoimage",
-	"libvirt-bin",
-	"qemu-utils",
-}
 
 type containerInitialiser struct{}
 
@@ -73,13 +65,31 @@ func ensureDependencies() error {
 		return err
 	}
 
-	for _, pack := range requiredPackages {
+	for _, pack := range getRequiredPackages(runtime.GOARCH) {
 		if err := pacman.Install(pack); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func getRequiredPackages(a string) []string {
+	var requiredPackages = []string{
+		// `qemu-kvm` must be installed before `libvirt-bin` on trusty. It appears
+		// that upstart doesn't reload libvirtd if installed after, and we see
+		// errors related to `qemu-kvm` not being installed.
+		"qemu-kvm",
+		"genisoimage",
+		"libvirt-bin",
+		"qemu-utils",
+	}
+	if a == arch.ARM64 {
+		// ARM64 doesn't support legacy BIOS so it requires Extensible Firmware
+		// Interface.
+		requiredPackages = append(requiredPackages, "qemu-efi")
+	}
+	return requiredPackages
 }
 
 // createPool creates the libvirt storage pool directory. runCmd and chownFunc

--- a/container/kvm/initialisation.go
+++ b/container/kvm/initialisation.go
@@ -80,14 +80,14 @@ func getRequiredPackages(a string) []string {
 		// that upstart doesn't reload libvirtd if installed after, and we see
 		// errors related to `qemu-kvm` not being installed.
 		"qemu-kvm",
+		"qemu-utils",
 		"genisoimage",
 		"libvirt-bin",
-		"qemu-utils",
 	}
 	if a == arch.ARM64 {
 		// ARM64 doesn't support legacy BIOS so it requires Extensible Firmware
 		// Interface.
-		requiredPackages = append(requiredPackages, "qemu-efi")
+		requiredPackages = append([]string{"qemu-efi"}, requiredPackages...)
 	}
 	return requiredPackages
 }

--- a/container/kvm/initialisation_internal_test.go
+++ b/container/kvm/initialisation_internal_test.go
@@ -44,3 +44,13 @@ func (initialisationInternalSuite) TestCreatePool(c *gc.C) {
 		"virsh pool-autostart juju-pool",
 	})
 }
+
+func (initialisationInternalSuite) TestRequiredPackagesAMD64(c *gc.C) {
+	got := getRequiredPackages("amd64")
+	c.Assert(got, jc.DeepEquals, []string{"qemu-kvm", "genisoimage", "libvirt-bin", "qemu-utils"})
+}
+
+func (initialisationInternalSuite) TestRequiredPackagesARM64(c *gc.C) {
+	got := getRequiredPackages("arm64")
+	c.Assert(got, jc.DeepEquals, []string{"qemu-kvm", "genisoimage", "libvirt-bin", "qemu-utils", "qemu-efi"})
+}

--- a/container/kvm/initialisation_internal_test.go
+++ b/container/kvm/initialisation_internal_test.go
@@ -47,10 +47,10 @@ func (initialisationInternalSuite) TestCreatePool(c *gc.C) {
 
 func (initialisationInternalSuite) TestRequiredPackagesAMD64(c *gc.C) {
 	got := getRequiredPackages("amd64")
-	c.Assert(got, jc.DeepEquals, []string{"qemu-kvm", "genisoimage", "libvirt-bin", "qemu-utils"})
+	c.Assert(got, jc.DeepEquals, []string{"qemu-kvm", "qemu-utils", "genisoimage", "libvirt-bin"})
 }
 
 func (initialisationInternalSuite) TestRequiredPackagesARM64(c *gc.C) {
 	got := getRequiredPackages("arm64")
-	c.Assert(got, jc.DeepEquals, []string{"qemu-kvm", "genisoimage", "libvirt-bin", "qemu-utils", "qemu-efi"})
+	c.Assert(got, jc.DeepEquals, []string{"qemu-efi", "qemu-kvm", "qemu-utils", "genisoimage", "libvirt-bin"})
 }

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -374,7 +374,7 @@ func getContainerInstance() (cont []ContainerInstance, err error) {
 		{"genisoimage"},
 		{"libvirt-bin"},
 	}
-	if runtime.GOARCH == arch.ARM64 {
+	if arch.HostArch() == arch.ARM64 {
 		pkgs = append([][]string{{"qemu-efi"}}, pkgs...)
 	}
 	cont = []ContainerInstance{

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -368,13 +368,17 @@ func (t toolsFinderFunc) FindTools(v version.Number, series string, arch string)
 }
 
 func getContainerInstance() (cont []ContainerInstance, err error) {
+	pkgs := [][]string{
+		{"qemu-kvm"},
+		{"qemu-utils"},
+		{"genisoimage"},
+		{"libvirt-bin"},
+	}
+	if runtime.GOARCH == arch.ARM64 {
+		pkgs = append([][]string{{"qemu-efi"}}, pkgs...)
+	}
 	cont = []ContainerInstance{
-		{instance.KVM, [][]string{
-			{"qemu-kvm"},
-			{"genisoimage"},
-			{"libvirt-bin"},
-			{"qemu-utils"},
-		}},
+		{instance.KVM, pkgs},
 	}
 	return cont, nil
 }


### PR DESCRIPTION
ARM64 requires UEFI to run under KVM as there is no support for legacy
BIOS on the platform. This commint ensures the correct package is added
to the "require packages" on that architecture.

QA: I don't yet have access to an arm system to live test on. But there's unit test coverage. So make sure the tests pass in container/kvm.