### PR TITLE
remove video from domain xml

### DIFF
--- a/container/kvm/libvirt/domainxml.go
+++ b/container/kvm/libvirt/domainxml.go
@@ -102,29 +102,6 @@ func NewDomain(p domainParams) (Domain, error) {
 			Input{Type: "mouse", Bus: "ps2"},
 			Input{Type: "keyboard", Bus: "ps2"},
 		},
-		Graphics: Graphics{
-			Type:     "vnc",
-			Port:     "-1",
-			Autoport: "yes",
-			Listen:   "localhost",
-			GraphicsListen: GraphicsListen{
-				Type:    "address",
-				Address: "localhost",
-			},
-		},
-		Video: Video{
-			Model: Model{
-				Type:  "cirrus",
-				VRAM:  "9216",
-				Heads: "1",
-			},
-			Address: Address{
-				Type:     "pci",
-				Domain:   "0x0000",
-				Bus:      "0x00",
-				Slot:     "0x02",
-				Function: "0x0"},
-		},
 		Interface:     []Interface{},
 		Name:          p.Host(),
 		VCPU:          p.CPUs(),
@@ -192,8 +169,6 @@ type Domain struct {
 	Serial        Serial       `xml:"devices>serial,omitempty"`
 	Console       []Console    `xml:"devices>console"`
 	Input         []Input      `xml:"devices>input"`
-	Graphics      Graphics     `xml:"devices>graphics"`
-	Video         Video        `xml:"devices>video"`
 	Interface     []Interface  `xml:"devices>interface"`
 	Disk          []Disk       `xml:"devices>disk"`
 	Name          string       `xml:"name"`
@@ -288,30 +263,6 @@ type SerialTarget struct {
 type Input struct {
 	Type string `xml:"type,attr"`
 	Bus  string `xml:"bus,attr"`
-}
-
-// Graphics is static. We generate a generic vnc server by default.
-// See: https://libvirt.org/formatdomain.html#elementsGraphics
-type Graphics struct {
-	Type           string         `xml:"type,attr"`
-	Port           string         `xml:"port,attr"`
-	Autoport       string         `xml:"autoport,attr"`
-	Listen         string         `xml:"listen,attr"`
-	GraphicsListen GraphicsListen `xml:"listen"`
-}
-
-// GraphicsListen is an element in Graphics.
-// See: Graphics
-type GraphicsListen struct {
-	Type    string `xml:"type,attr"`
-	Address string `xml:"address,attr"`
-}
-
-// Video is static. We generate a generic default value.
-// See: https://libvirt.org/formatdomain.html#elementsVideo
-type Video struct {
-	Model   Model   `xml:"model"`
-	Address Address `xml:"address"`
 }
 
 // Interface is dynamic. It represents a network interface. We generate it from

--- a/container/kvm/libvirt/domainxml_test.go
+++ b/container/kvm/libvirt/domainxml_test.go
@@ -47,13 +47,6 @@ var wantDomainStr = `
         </console>
         <input type="mouse" bus="ps2"></input>
         <input type="keyboard" bus="ps2"></input>
-        <graphics type="vnc" port="-1" autoport="yes" listen="localhost">
-            <listen type="address" address="localhost"></listen>
-        </graphics>
-        <video>
-            <model type="cirrus" vram="9216" heads="1"></model>
-            <address type="pci" domain="0x0000" bus="0x00" slot="0x02" function="0x0"></address>
-        </video>
         <interface type="bridge">
             <mac address="00:00:00:00:00:00"></mac>
             <model type="virtio"></model>


### PR DESCRIPTION
This was included because it was in our original code. As it turns out
it is unnecessary and unsupported on ARM 64.

QA: 
1. make sure the unit tests all pass
2. juju bootstrap vmaas21 kvm/purego --build-agent --constraints mem=2G
3. juju add-machine
4. juju add-machine --series trusty
5. juju deploy mysql --to kvm:0
6. juju deploy postgresql --to kvm:1 --series xenial
7. juju deploy wordpress --to kvm:1
8. juju deploy ubuntu --to kvm:0 --constraints mem=1G
9. juju add-relation wordpress mysql

Make sure all 6 machines start as expected.
Cleanup:  juju kill-controller kvm/purego -y 

