### PR TITLE
worker/migrationmaster: ABORT failure not status

### DIFF
--- a/apiserver/migrationtarget/migrationtarget.go
+++ b/apiserver/migrationtarget/migrationtarget.go
@@ -137,8 +137,9 @@ func (api *API) Abort(args params.ModelArgs) error {
 	return st.RemoveImportingModelDocs()
 }
 
-// Activate sets the migration mode of the model to "active". It is an error to
-// attempt to Abort a model that has a migration mode other than importing.
+// Activate sets the migration mode of the model to "none", meaning it
+// is ready for use. It is an error to attempt to Abort a model that
+// has a migration mode other than importing.
 func (api *API) Activate(args params.ModelArgs) error {
 	model, err := api.getImportingModel(args)
 	if err != nil {

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -280,10 +280,6 @@ func (w *Worker) setInfoStatus(s string, a ...interface{}) {
 	w.setStatusAndLog(w.logger.Infof, s, a...)
 }
 
-func (w *Worker) setWarningStatus(s string, a ...interface{}) {
-	w.setStatusAndLog(w.logger.Warningf, s, a...)
-}
-
 func (w *Worker) setErrorStatus(s string, a ...interface{}) {
 	w.setStatusAndLog(w.logger.Errorf, s, a...)
 }
@@ -576,7 +572,7 @@ func (w *Worker) doABORT(targetInfo coremigration.TargetInfo, modelUUID string) 
 	if err := w.removeImportedModel(targetInfo, modelUUID); err != nil {
 		// This isn't fatal. Removing the imported model is a best
 		// efforts attempt so just report the error and proceed.
-		w.setWarningStatus("failed to remove model from target controller, %v", err)
+		w.logger.Warningf("failed to remove model from target controller, %v", err)
 	}
 	return coremigration.ABORTDONE, nil
 }


### PR DESCRIPTION
This is a forward port of #6718.

A failure to remove the model from the target controller during ABORT is often completely normal (i.e. the migration never got to importing it). Don't record this failure to a migration status update as it obscures the real reason for the abort.

Drive-by: Correct docstring for MigrationTarget.Activate.