### PR TITLE
2.1 dynamic bridges log script output

### DIFF
--- a/network/add-juju-bridge.py
+++ b/network/add-juju-bridge.py
@@ -428,6 +428,7 @@ def main(args):
     print("**** Original configuration")
     shell_cmd("cat {}".format(args.filename), dry_run=args.dry_run)
     shell_cmd("ifconfig -a", dry_run=args.dry_run)
+    shell_cmd("ip route show", dry_run=args.dry_run)
     shell_cmd("ifdown --exclude=lo --interfaces={} {}".format(args.filename, " ".join(interfaces)), dry_run=args.dry_run)
 
     print("**** Activating new configuration")

--- a/network/add-juju-bridge.py
+++ b/network/add-juju-bridge.py
@@ -427,8 +427,9 @@ def main(args):
 
     print("**** Original configuration")
     shell_cmd("cat {}".format(args.filename), dry_run=args.dry_run)
-    shell_cmd("ifconfig -a", dry_run=args.dry_run)
+    shell_cmd("ip -d link show", dry_run=args.dry_run)
     shell_cmd("ip route show", dry_run=args.dry_run)
+    shell_cmd("brctl show", dry_run=args.dry_run)
     shell_cmd("ifdown --exclude=lo --interfaces={} {}".format(args.filename, " ".join(interfaces)), dry_run=args.dry_run)
 
     print("**** Activating new configuration")
@@ -455,8 +456,7 @@ def main(args):
 
     shell_cmd("cat {}".format(args.filename), dry_run=args.dry_run)
     shell_cmd("ifup --exclude=lo --interfaces={} -a".format(args.filename), dry_run=args.dry_run)
-    shell_cmd("ip link show up", dry_run=args.dry_run)
-    shell_cmd("ifconfig -a", dry_run=args.dry_run)
+    shell_cmd("ip -d link show", dry_run=args.dry_run)
     shell_cmd("ip route show", dry_run=args.dry_run)
     shell_cmd("brctl show", dry_run=args.dry_run)
 

--- a/network/bridge.go
+++ b/network/bridge.go
@@ -61,7 +61,7 @@ func bestPythonVersion() string {
 
 func (b *etcNetworkInterfacesBridger) Bridge(deviceNames []string) error {
 	cmd := bridgeCmd(deviceNames, b.BridgePrefix, b.Filename, BridgeScriptPythonContent, b.DryRun)
-	logger.Debugf("bridgescript command=%s", cmd)
+	logger.Tracef("bridgescript command=%s", cmd)
 	result, err := runCommand(cmd, b.Environ, b.Clock, b.Timeout)
 	if err != nil {
 		return errors.Errorf("script invocation error: %s", err)
@@ -75,6 +75,8 @@ func (b *etcNetworkInterfacesBridger) Bridge(deviceNames []string) error {
 		logger.Errorf("bridgescript stderr\n%s\n", result.Stderr)
 		return errors.Errorf("bridgescript failed: %s", string(result.Stderr))
 	}
+	logger.Tracef("bridgescript stdout\n%s\n", result.Stdout)
+	logger.Tracef("bridgescript stderr\n%s\n", result.Stderr)
 	return nil
 }
 

--- a/network/bridge.go
+++ b/network/bridge.go
@@ -62,7 +62,7 @@ func bestPythonVersion() string {
 func (b *etcNetworkInterfacesBridger) Bridge(deviceNames []string) error {
 	cmd := bridgeCmd(deviceNames, b.BridgePrefix, b.Filename, BridgeScriptPythonContent, b.DryRun)
 	debugCmd := bridgeCmd(deviceNames, b.BridgePrefix, b.Filename, "<script-redacted>", b.DryRun)
-	logger.Debugf("bridgescript command=%s", debugCmd)
+	logger.Infof("bridgescript command=%s", debugCmd)
 	result, err := runCommand(cmd, b.Environ, b.Clock, b.Timeout)
 	if err != nil {
 		return errors.Errorf("script invocation error: %s", err)
@@ -76,8 +76,8 @@ func (b *etcNetworkInterfacesBridger) Bridge(deviceNames []string) error {
 		logger.Errorf("bridgescript stderr\n%s\n", result.Stderr)
 		return errors.Errorf("bridgescript failed: %s", string(result.Stderr))
 	}
-	logger.Debugf("bridgescript stdout\n%s\n", result.Stdout)
-	logger.Debugf("bridgescript stderr\n%s\n", result.Stderr)
+	logger.Tracef("bridgescript stdout\n%s\n", result.Stdout)
+	logger.Tracef("bridgescript stderr\n%s\n", result.Stderr)
 	return nil
 }
 

--- a/network/bridge.go
+++ b/network/bridge.go
@@ -61,8 +61,8 @@ func bestPythonVersion() string {
 
 func (b *etcNetworkInterfacesBridger) Bridge(deviceNames []string) error {
 	cmd := bridgeCmd(deviceNames, b.BridgePrefix, b.Filename, BridgeScriptPythonContent, b.DryRun)
-	debugCmd := bridgeCmd(deviceNames, b.BridgePrefix, b.Filename, "<script-redacted>", b.DryRun)
-	logger.Infof("bridgescript command=%s", debugCmd)
+	infoCmd := bridgeCmd(deviceNames, b.BridgePrefix, b.Filename, "<script-redacted>", b.DryRun)
+	logger.Infof("bridgescript command=%s", infoCmd)
 	result, err := runCommand(cmd, b.Environ, b.Clock, b.Timeout)
 	if err != nil {
 		return errors.Errorf("script invocation error: %s", err)

--- a/network/bridge.go
+++ b/network/bridge.go
@@ -61,7 +61,7 @@ func bestPythonVersion() string {
 
 func (b *etcNetworkInterfacesBridger) Bridge(deviceNames []string) error {
 	cmd := bridgeCmd(deviceNames, b.BridgePrefix, b.Filename, BridgeScriptPythonContent, b.DryRun)
-	logger.Tracef("bridgescript command=%s", cmd)
+	logger.Debugf("bridgescript command=%s", cmd)
 	result, err := runCommand(cmd, b.Environ, b.Clock, b.Timeout)
 	if err != nil {
 		return errors.Errorf("script invocation error: %s", err)
@@ -75,8 +75,8 @@ func (b *etcNetworkInterfacesBridger) Bridge(deviceNames []string) error {
 		logger.Errorf("bridgescript stderr\n%s\n", result.Stderr)
 		return errors.Errorf("bridgescript failed: %s", string(result.Stderr))
 	}
-	logger.Tracef("bridgescript stdout\n%s\n", result.Stdout)
-	logger.Tracef("bridgescript stderr\n%s\n", result.Stderr)
+	logger.Debugf("bridgescript stdout\n%s\n", result.Stdout)
+	logger.Debugf("bridgescript stderr\n%s\n", result.Stderr)
 	return nil
 }
 

--- a/network/bridge.go
+++ b/network/bridge.go
@@ -61,7 +61,8 @@ func bestPythonVersion() string {
 
 func (b *etcNetworkInterfacesBridger) Bridge(deviceNames []string) error {
 	cmd := bridgeCmd(deviceNames, b.BridgePrefix, b.Filename, BridgeScriptPythonContent, b.DryRun)
-	logger.Debugf("bridgescript command=%s", cmd)
+	debugCmd := bridgeCmd(deviceNames, b.BridgePrefix, b.Filename, "<script-redacted>", b.DryRun)
+	logger.Debugf("bridgescript command=%s", debugCmd)
 	result, err := runCommand(cmd, b.Environ, b.Clock, b.Timeout)
 	if err != nil {
 		return errors.Errorf("script invocation error: %s", err)

--- a/network/bridgescript.go
+++ b/network/bridgescript.go
@@ -432,6 +432,7 @@ def main(args):
     print("**** Original configuration")
     shell_cmd("cat {}".format(args.filename), dry_run=args.dry_run)
     shell_cmd("ifconfig -a", dry_run=args.dry_run)
+    shell_cmd("ip route show", dry_run=args.dry_run)
     shell_cmd("ifdown --exclude=lo --interfaces={} {}".format(args.filename, " ".join(interfaces)), dry_run=args.dry_run)
 
     print("**** Activating new configuration")

--- a/network/bridgescript.go
+++ b/network/bridgescript.go
@@ -431,8 +431,9 @@ def main(args):
 
     print("**** Original configuration")
     shell_cmd("cat {}".format(args.filename), dry_run=args.dry_run)
-    shell_cmd("ifconfig -a", dry_run=args.dry_run)
+    shell_cmd("ip -d link show", dry_run=args.dry_run)
     shell_cmd("ip route show", dry_run=args.dry_run)
+    shell_cmd("brctl show", dry_run=args.dry_run)
     shell_cmd("ifdown --exclude=lo --interfaces={} {}".format(args.filename, " ".join(interfaces)), dry_run=args.dry_run)
 
     print("**** Activating new configuration")
@@ -459,8 +460,7 @@ def main(args):
 
     shell_cmd("cat {}".format(args.filename), dry_run=args.dry_run)
     shell_cmd("ifup --exclude=lo --interfaces={} -a".format(args.filename), dry_run=args.dry_run)
-    shell_cmd("ip link show up", dry_run=args.dry_run)
-    shell_cmd("ifconfig -a", dry_run=args.dry_run)
+    shell_cmd("ip -d link show", dry_run=args.dry_run)
     shell_cmd("ip route show", dry_run=args.dry_run)
     shell_cmd("brctl show", dry_run=args.dry_run)
 

--- a/network/bridgescript_test.go
+++ b/network/bridgescript_test.go
@@ -240,6 +240,7 @@ func (s *bridgeConfigSuite) dryRunExpectedOutputHelper(isBonded, isAlreadyBridge
 		output = append(output, "**** Original configuration")
 		output = append(output, fmt.Sprintf("cat %s", s.testConfigPath))
 		output = append(output, "ifconfig -a")
+		output = append(output, "ip route show")
 		output = append(output, fmt.Sprintf("ifdown --exclude=lo --interfaces=%[1]s %s", s.testConfigPath, strings.Join(interfacesToBridge, " ")))
 		output = append(output, "**** Activating new configuration")
 		if isBonded {

--- a/network/bridgescript_test.go
+++ b/network/bridgescript_test.go
@@ -239,8 +239,9 @@ func (s *bridgeConfigSuite) dryRunExpectedOutputHelper(isBonded, isAlreadyBridge
 	} else {
 		output = append(output, "**** Original configuration")
 		output = append(output, fmt.Sprintf("cat %s", s.testConfigPath))
-		output = append(output, "ifconfig -a")
+		output = append(output, "ip -d link show")
 		output = append(output, "ip route show")
+		output = append(output, "brctl show")
 		output = append(output, fmt.Sprintf("ifdown --exclude=lo --interfaces=%[1]s %s", s.testConfigPath, strings.Join(interfacesToBridge, " ")))
 		output = append(output, "**** Activating new configuration")
 		if isBonded {
@@ -250,8 +251,7 @@ func (s *bridgeConfigSuite) dryRunExpectedOutputHelper(isBonded, isAlreadyBridge
 		}
 		output = append(output, fmt.Sprintf("cat %s", s.testConfigPath))
 		output = append(output, fmt.Sprintf("ifup --exclude=lo --interfaces=%[1]s -a", s.testConfigPath))
-		output = append(output, "ip link show up")
-		output = append(output, "ifconfig -a")
+		output = append(output, "ip -d link show")
 		output = append(output, "ip route show")
 		output = append(output, "brctl show")
 	}


### PR DESCRIPTION
We currently log the bridge script output only if there is an error. If there is no error, we still capture the output, but at trace level. It is useful to see the before/after configuration of routing and bridging when debugging problems.