### PR TITLE
Stop creating extra state instances for every api connection.

### DIFF
--- a/apiserver/crossmodel/applicationdirectory_test.go
+++ b/apiserver/crossmodel/applicationdirectory_test.go
@@ -66,11 +66,10 @@ func (s *applicationdirectorySuite) SetUpTest(c *gc.C) {
 	s.applicationdirectory = s.constructApplicationDirectory()
 
 	var err error
-	serviceAPIFactory, err := crossmodel.NewServiceAPIFactory(
+	serviceAPIFactory := crossmodel.NewServiceAPIFactory(
 		func() jujucrossmodel.ApplicationDirectory { return s.applicationdirectory },
 		nil,
 	)
-	c.Assert(err, jc.ErrorIsNil)
 	s.api, err = crossmodel.CreateApplicationOffersAPI(serviceAPIFactory, s.authoriser)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/apiserver/crossmodel/offersapifactory.go
+++ b/apiserver/crossmodel/offersapifactory.go
@@ -33,8 +33,8 @@ type applicationOffersAPIFactory struct {
 
 // newServiceAPIFactory creates a ApplicationOffersAPIFactory instance which
 // is used to provide access to services for specified directories eg "local" or "vendor".
-func newServiceAPIFactory(createFunc createApplicationDirectoryFunc, closer closer) (ApplicationOffersAPIFactory, error) {
-	return &applicationOffersAPIFactory{createFunc, closer}, nil
+func newServiceAPIFactory(createFunc createApplicationDirectoryFunc, closer closer) ApplicationOffersAPIFactory {
+	return &applicationOffersAPIFactory{createFunc, closer}
 }
 
 // ApplicationOffers returns a application directory used to look up services
@@ -57,24 +57,11 @@ func (s *applicationOffersAPIFactory) Stop() error {
 
 // ApplicationOffersAPIFactoryResource is a function which returns the application offer api factory
 // which can be used as an facade resource.
-func ApplicationOffersAPIFactoryResource(st *state.State) (facade.Resource, error) {
-	controllerModelStata := st
-	controllerModel, err := st.ControllerModel()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	var closer closer
-	if st.ModelTag() != controllerModel.ModelTag() {
-		// We are not using the state server environment, so get one.
-		logger.Debugf("getting a controller connection, current model: %s", st.ModelTag())
-		controllerModelStata, err = st.ForModel(controllerModel.ModelTag())
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		closer = controllerModelStata
-	}
+func ApplicationOffersAPIFactoryResource(st *state.State) facade.Resource {
+	// This method is only passed the state of the controller model.
+	// Further cleanup can be done as future CRM work.
 	return newServiceAPIFactory(
 		func() crossmodel.ApplicationDirectory {
-			return state.NewApplicationDirectory(controllerModelStata)
-		}, closer)
+			return state.NewApplicationDirectory(st)
+		}, nil)
 }

--- a/apiserver/crossmodel/offersapifactory_test.go
+++ b/apiserver/crossmodel/offersapifactory_test.go
@@ -21,19 +21,17 @@ type applicationURLSuite struct {
 var _ = gc.Suite(&applicationURLSuite{})
 
 func (s *applicationURLSuite) TestUnsupportedURL(c *gc.C) {
-	f, err := crossmodel.NewServiceAPIFactory(nil, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = f.ApplicationOffers("unsupported")
+	f := crossmodel.NewServiceAPIFactory(nil, nil)
+	_, err := f.ApplicationOffers("unsupported")
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
 
 func (s *applicationURLSuite) TestLocalURL(c *gc.C) {
 	var st *state.State
-	f, err := crossmodel.NewServiceAPIFactory(
+	f := crossmodel.NewServiceAPIFactory(
 		func() jujucrossmodel.ApplicationDirectory { return state.NewApplicationDirectory(st) },
 		nil,
 	)
-	c.Assert(err, jc.ErrorIsNil)
 	api, err := f.ApplicationOffers("local")
 	c.Assert(err, jc.ErrorIsNil)
 	_, ok := api.(crossmodel.ApplicationOffersAPI)
@@ -52,12 +50,11 @@ func (c *closer) Close() error {
 func (s *applicationURLSuite) TestStop(c *gc.C) {
 	var st *state.State
 	closer := &closer{}
-	f, err := crossmodel.NewServiceAPIFactory(
+	f := crossmodel.NewServiceAPIFactory(
 		func() jujucrossmodel.ApplicationDirectory { return state.NewApplicationDirectory(st) },
 		closer,
 	)
-	c.Assert(err, jc.ErrorIsNil)
-	err = f.Stop()
+	err := f.Stop()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(closer.called, jc.IsTrue)
 }

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -81,10 +81,7 @@ func newAPIHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID st
 	if err := r.resources.RegisterNamed("logDir", common.StringResource(srv.logDir)); err != nil {
 		return nil, errors.Trace(err)
 	}
-	apiFactory, err := crossmodel.ApplicationOffersAPIFactoryResource(st)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+	apiFactory := crossmodel.ApplicationOffersAPIFactoryResource(srv.state)
 	if err := r.resources.RegisterNamed("applicationOffersApiFactory", apiFactory); err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
The way the cross model api factory was being created was causing an extra state instance to be created for every api call that was not to the controller model.

There is further cleanup that could be done, but I'm leaving it mostly the same for now.