### PR TITLE
Add alias support to juju consume

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -325,12 +325,15 @@ func (c *Client) DestroyRelation(endpoints ...string) error {
 }
 
 // Consume adds a remote application to the model.
-func (c *Client) Consume(remoteApplication string) (string, error) {
+func (c *Client) Consume(remoteApplication, alias string) (string, error) {
 	var consumeRes params.ConsumeApplicationResults
-	params := params.ApplicationURLs{
-		ApplicationURLs: []string{remoteApplication},
+	args := params.ConsumeApplicationArgs{
+		Args: []params.ConsumeApplicationArg{{
+			ApplicationURL:   remoteApplication,
+			ApplicationAlias: alias,
+		}},
 	}
-	err := c.facade.FacadeCall("Consume", params, &consumeRes)
+	err := c.facade.FacadeCall("Consume", args, &consumeRes)
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -132,6 +132,20 @@ type ApplicationURLs struct {
 	ApplicationURLs []string `json:"application-urls,omitempty"`
 }
 
+// ConsumeApplicationArg holds the arguments for consuming a remote application.
+type ConsumeApplicationArg struct {
+	// ApplicationURLs contains collection of urls for applications that are to be shown.
+	ApplicationURL string `json:"application-url"`
+
+	// ApplicationAlias is the name of the alias to use for the application name.
+	ApplicationAlias string `json:"application-alias,omitempty"`
+}
+
+// ConsumeApplicationArgs is a collection of arg for consuming applications.
+type ConsumeApplicationArgs struct {
+	Args []ConsumeApplicationArg `json:"args,omitempty"`
+}
+
 // OfferedApplication represents attributes for an offered application.
 type OfferedApplication struct {
 	ApplicationURL  string            `json:"application-url"`
@@ -271,6 +285,9 @@ type RemoteRelationResults struct {
 type RemoteApplication struct {
 	// Name is the name of the application.
 	Name string `json:"name"`
+
+	// OfferName is the name of the application on the offering side.
+	OfferName string `json:"offer-name"`
 
 	// Life is the current lifecycle state of the application.
 	Life Life `json:"life"`

--- a/apiserver/remoterelations/mock_test.go
+++ b/apiserver/remoterelations/mock_test.go
@@ -268,6 +268,7 @@ func (r *mockRelation) WatchUnits(applicationName string) (state.RelationUnitsWa
 type mockRemoteApplication struct {
 	testing.Stub
 	name       string
+	alias      string
 	url        string
 	life       state.Life
 	status     status.Status
@@ -277,13 +278,18 @@ type mockRemoteApplication struct {
 
 func newMockRemoteApplication(name, url string) *mockRemoteApplication {
 	return &mockRemoteApplication{
-		name: name, url: url, life: state.Alive,
+		name: name, alias: name + "-alias", url: url, life: state.Alive,
 	}
 }
 
 func (r *mockRemoteApplication) Name() string {
 	r.MethodCall(r, "Name")
 	return r.name
+}
+
+func (r *mockRemoteApplication) OfferName() string {
+	r.MethodCall(r, "OfferName")
+	return r.alias
 }
 
 func (r *mockRemoteApplication) Tag() names.Tag {

--- a/apiserver/remoterelations/remoterelations.go
+++ b/apiserver/remoterelations/remoterelations.go
@@ -263,6 +263,7 @@ func (api *RemoteRelationsAPI) RemoteApplications(entities params.Entities) (par
 		}
 		return &params.RemoteApplication{
 			Name:       remoteApp.Name(),
+			OfferName:  remoteApp.OfferName(),
 			Life:       params.Life(remoteApp.Life().String()),
 			Status:     status.Status.String(),
 			ModelUUID:  remoteApp.SourceModel().Id(),

--- a/apiserver/remoterelations/remoterelations_test.go
+++ b/apiserver/remoterelations/remoterelations_test.go
@@ -290,7 +290,7 @@ func (s *remoteRelationsSuite) TestRemoteApplications(c *gc.C) {
 	result, err := s.api.RemoteApplications(params.Entities{Entities: []params.Entity{{Tag: "application-django"}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, jc.DeepEquals, []params.RemoteApplicationResult{{
-		Result: &params.RemoteApplication{Name: "django", Life: "alive", ModelUUID: "model-uuid"}}})
+		Result: &params.RemoteApplication{Name: "django", OfferName: "django-alias", Life: "alive", ModelUUID: "model-uuid"}}})
 	s.st.CheckCalls(c, []testing.StubCall{
 		{"RemoteApplication", []interface{}{"django"}},
 	})

--- a/apiserver/remoterelations/state.go
+++ b/apiserver/remoterelations/state.go
@@ -135,6 +135,9 @@ type RemoteApplication interface {
 	// Name returns the name of the remote application.
 	Name() string
 
+	// OfferName returns the name the offering side has given to the remote application..
+	OfferName() string
+
 	// Tag returns the remote applications's tag.
 	Tag() names.Tag
 

--- a/featuretests/cmd_juju_crossmodel_test.go
+++ b/featuretests/cmd_juju_crossmodel_test.go
@@ -153,7 +153,7 @@ func (s *crossmodelSuite) TestAddRelationFromURL(c *gc.C) {
 func (s *crossmodelSuite) assertAddRelationSameControllerSuccess(c *gc.C, otherModeluser string) {
 	_, err := runJujuCommand(c, "add-relation", "wordpress", otherModeluser+"/othermodel.mysql")
 	c.Assert(err, jc.ErrorIsNil)
-	svc, err := s.State.RemoteApplication(otherModeluser + "-othermodel-mysql")
+	svc, err := s.State.RemoteApplication("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	rel, err := svc.Relations()
 	c.Assert(err, jc.ErrorIsNil)
@@ -169,7 +169,7 @@ func (s *crossmodelSuite) assertAddRelationSameControllerSuccess(c *gc.C, otherM
 				Scope:     "global",
 			},
 		}, {
-			ApplicationName: otherModeluser + "-othermodel-mysql",
+			ApplicationName: "mysql",
 			Relation: charm.Relation{Name: "server",
 				Role:      "provider",
 				Interface: "mysql",

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -31,6 +31,7 @@ type RemoteApplication struct {
 type remoteApplicationDoc struct {
 	DocID           string              `bson:"_id"`
 	Name            string              `bson:"name"`
+	OfferName       string              `bson:"offer-name"`
 	URL             string              `bson:"url,omitempty"`
 	SourceModelUUID string              `bson:"source-model-uuid"`
 	Endpoints       []remoteEndpointDoc `bson:"endpoints"`
@@ -86,6 +87,11 @@ func (s *RemoteApplication) Registered() bool {
 // Name returns the application name.
 func (s *RemoteApplication) Name() string {
 	return s.doc.Name
+}
+
+// OfferName returns the name on te offering side.
+func (s *RemoteApplication) OfferName() string {
+	return s.doc.OfferName
 }
 
 // URL returns the remote service URL, and a boolean indicating whether or not
@@ -318,6 +324,9 @@ type AddRemoteApplicationParams struct {
 	// match the application name in the URL, or the name in the remote model.
 	Name string
 
+	// OfferName is the name the offering side has given to the remote application.
+	OfferName string
+
 	// URL is either empty, or the URL that the remote application was offered
 	// with.
 	URL string
@@ -377,6 +386,7 @@ func (st *State) AddRemoteApplication(args AddRemoteApplicationParams) (_ *Remot
 	appDoc := &remoteApplicationDoc{
 		DocID:           applicationID,
 		Name:            args.Name,
+		OfferName:       args.OfferName,
 		SourceModelUUID: args.SourceModel.Id(),
 		URL:             args.URL,
 		Life:            Alive,

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -261,13 +261,14 @@ func (s *remoteApplicationSuite) TestAddRemoteApplicationErrors(c *gc.C) {
 
 func (s *remoteApplicationSuite) TestAddRemoteApplication(c *gc.C) {
 	foo, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "foo", URL: "local:/u/me/foo", SourceModel: s.State.ModelTag()})
+		Name: "foo", OfferName: "bar", URL: "local:/u/me/foo", SourceModel: s.State.ModelTag()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(foo.Name(), gc.Equals, "foo")
 	c.Assert(foo.Registered(), jc.IsFalse)
 	foo, err = s.State.RemoteApplication("foo")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(foo.Name(), gc.Equals, "foo")
+	c.Assert(foo.OfferName(), gc.Equals, "bar")
 	c.Assert(foo.Registered(), jc.IsFalse)
 	c.Assert(foo.SourceModel().Id(), gc.Equals, s.State.ModelTag().Id())
 }

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -188,6 +188,7 @@ func (m *mockRelationsFacade) RemoteApplications(names []string) ([]params.Remot
 			result[i] = params.RemoteApplicationResult{
 				Result: &params.RemoteApplication{
 					Name:       app.name,
+					OfferName:  app.offername,
 					Life:       app.life,
 					Status:     app.status,
 					ModelUUID:  app.modelUUID,
@@ -300,6 +301,7 @@ func (w *mockStringsWatcher) Changes() watcher.StringsChannel {
 type mockRemoteApplication struct {
 	testing.Stub
 	name       string
+	offername  string
 	url        string
 	life       params.Life
 	status     string
@@ -327,7 +329,7 @@ func (w *mockRelationUnitsWatcher) Changes() watcher.RelationUnitsChannel {
 
 func newMockRemoteApplication(name, url string) *mockRemoteApplication {
 	return &mockRemoteApplication{
-		name: name, url: url, life: params.Alive,
+		name: name, url: url, life: params.Alive, offername: "offer-" + name,
 		modelUUID: "remote-model-uuid",
 	}
 }

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -66,17 +66,17 @@ func waitForStubCalls(c *gc.C, stub *jujutesting.Stub, expected []jujutesting.St
 func (s *remoteRelationsSuite) assertRemoteApplicationWorkers(c *gc.C) worker.Worker {
 	// Checks that the main worker loop responds to remote application events
 	// by starting relevant relation watchers.
-	s.relationsFacade.remoteApplications["user-model-db2"] = newMockRemoteApplication("user-model-db2", "db2url")
+	s.relationsFacade.remoteApplications["db2"] = newMockRemoteApplication("db2", "db2url")
 	s.relationsFacade.remoteApplications["mysql"] = newMockRemoteApplication("mysql", "mysqlurl")
-	applicationNames := []string{"user-model-db2", "mysql"}
+	applicationNames := []string{"db2", "mysql"}
 	s.relationsFacade.remoteApplicationsWatcher.changes <- applicationNames
 
 	w, err := remoterelations.New(s.config)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := []jujutesting.StubCall{
 		{"WatchRemoteApplications", nil},
-		{"RemoteApplications", []interface{}{[]string{"user-model-db2", "mysql"}}},
-		{"WatchRemoteApplicationRelations", []interface{}{"user-model-db2"}},
+		{"RemoteApplications", []interface{}{[]string{"db2", "mysql"}}},
+		{"WatchRemoteApplicationRelations", []interface{}{"db2"}},
 		{"WatchRemoteApplicationRelations", []interface{}{"mysql"}},
 	}
 	s.waitForWorkerStubCalls(c, expected)
@@ -95,7 +95,7 @@ func (s *remoteRelationsSuite) TestRemoteApplicationWorkers(c *gc.C) {
 	workertest.CleanKill(c, w)
 
 	// Check that relation watchers are stopped with the worker.
-	applicationNames := []string{"user-model-db2", "mysql"}
+	applicationNames := []string{"db2", "mysql"}
 	for _, app := range applicationNames {
 		w, ok := s.relationsFacade.remoteApplicationRelationsWatcher(app)
 		c.Check(ok, jc.IsTrue)
@@ -127,11 +127,11 @@ func (s *remoteRelationsSuite) TestRemoteApplicationRemoved(c *gc.C) {
 }
 
 func (s *remoteRelationsSuite) assertRemoteRelationsWorkers(c *gc.C) worker.Worker {
-	s.relationsFacade.relations["user-model-db2:db django:db"] = newMockRelation(123)
+	s.relationsFacade.relations["db2:db django:db"] = newMockRelation(123)
 	w := s.assertRemoteApplicationWorkers(c)
 	s.stub.ResetCalls()
 
-	s.relationsFacade.relationsEndpoints["user-model-db2:db django:db"] = &relationEndpointInfo{
+	s.relationsFacade.relationsEndpoints["db2:db django:db"] = &relationEndpointInfo{
 		localApplicationName: "django",
 		localEndpoint: params.RemoteEndpoint{
 			Name:      "db2",
@@ -143,16 +143,16 @@ func (s *remoteRelationsSuite) assertRemoteRelationsWorkers(c *gc.C) worker.Work
 		remoteEndpointName: "data",
 	}
 
-	relWatcher, _ := s.relationsFacade.remoteApplicationRelationsWatcher("user-model-db2")
-	relWatcher.changes <- []string{"user-model-db2:db django:db"}
+	relWatcher, _ := s.relationsFacade.remoteApplicationRelationsWatcher("db2")
+	relWatcher.changes <- []string{"db2:db django:db"}
 
 	expected := []jujutesting.StubCall{
-		{"Relations", []interface{}{[]string{"user-model-db2:db django:db"}}},
+		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
 		{"ExportEntities", []interface{}{
-			[]names.Tag{names.NewApplicationTag("django"), names.NewRelationTag("user-model-db2:db django:db")}}},
+			[]names.Tag{names.NewApplicationTag("django"), names.NewRelationTag("db2:db django:db")}}},
 		{"RegisterRemoteRelations", []interface{}{[]params.RegisterRemoteRelation{{
 			ApplicationId: params.RemoteEntityId{ModelUUID: "model-uuid", Token: "token-django"},
-			RelationId:    params.RemoteEntityId{ModelUUID: "model-uuid", Token: "token-user-model-db2:db django:db"},
+			RelationId:    params.RemoteEntityId{ModelUUID: "model-uuid", Token: "token-db2:db django:db"},
 			RemoteEndpoint: params.RemoteEndpoint{
 				Name:      "db2",
 				Role:      "requires",
@@ -160,15 +160,15 @@ func (s *remoteRelationsSuite) assertRemoteRelationsWorkers(c *gc.C) worker.Work
 				Limit:     1,
 				Scope:     "global",
 			},
-			OfferedApplicationName: "db2",
+			OfferedApplicationName: "offer-db2",
 			LocalEndpointName:      "data",
 		}}}},
-		{"ImportRemoteEntity", []interface{}{"source-model-uuid", names.NewApplicationTag("user-model-db2"), "token-db2"}},
-		{"WatchLocalRelationUnits", []interface{}{"user-model-db2:db django:db"}},
+		{"ImportRemoteEntity", []interface{}{"source-model-uuid", names.NewApplicationTag("db2"), "token-offer-db2"}},
+		{"WatchLocalRelationUnits", []interface{}{"db2:db django:db"}},
 	}
 	s.waitForWorkerStubCalls(c, expected)
 
-	unitWatcher, ok := s.relationsFacade.relationsUnitsWatcher("user-model-db2:db django:db")
+	unitWatcher, ok := s.relationsFacade.relationsUnitsWatcher("db2:db django:db")
 	c.Check(ok, jc.IsTrue)
 	waitForStubCalls(c, &unitWatcher.Stub, []jujutesting.StubCall{
 		{"Changes", nil},
@@ -181,7 +181,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationsWorkers(c *gc.C) {
 	workertest.CleanKill(c, w)
 
 	// Check that relation unit watchers are stopped with the worker.
-	relWatcher, ok := s.relationsFacade.relationsUnitsWatchers["user-model-db2:db django:db"]
+	relWatcher, ok := s.relationsFacade.relationsUnitsWatchers["db2:db django:db"]
 	c.Check(ok, jc.IsTrue)
 	c.Check(relWatcher.killed(), jc.IsTrue)
 }
@@ -193,18 +193,18 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDead(c *gc.C) {
 	defer workertest.CleanKill(c, w)
 	s.stub.ResetCalls()
 
-	unitsWatcher, _ := s.relationsFacade.updateRelationLife("user-model-db2:db django:db", params.Dead)
-	relWatcher, _ := s.relationsFacade.remoteApplicationRelationsWatcher("user-model-db2")
-	relWatcher.changes <- []string{"user-model-db2:db django:db"}
+	unitsWatcher, _ := s.relationsFacade.updateRelationLife("db2:db django:db", params.Dead)
+	relWatcher, _ := s.relationsFacade.remoteApplicationRelationsWatcher("db2")
+	relWatcher.changes <- []string{"db2:db django:db"}
 	for a := coretesting.LongAttempt.Start(); a.Next(); {
-		_, ok := s.relationsFacade.relationsUnitsWatcher("user-model-db2:db django:db")
+		_, ok := s.relationsFacade.relationsUnitsWatcher("db2:db django:db")
 		if !ok {
 			break
 		}
 	}
 	c.Assert(unitsWatcher.killed(), jc.IsTrue)
 	expected := []jujutesting.StubCall{
-		{"Relations", []interface{}{[]string{"user-model-db2:db django:db"}}},
+		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
 	}
 	s.waitForWorkerStubCalls(c, expected)
 }
@@ -216,18 +216,18 @@ func (s *remoteRelationsSuite) TestRemoteRelationsRemoved(c *gc.C) {
 	defer workertest.CleanKill(c, w)
 	s.stub.ResetCalls()
 
-	unitsWatcher, _ := s.relationsFacade.removeRelation("user-model-db2:db django:db")
-	relWatcher, _ := s.relationsFacade.remoteApplicationRelationsWatcher("user-model-db2")
-	relWatcher.changes <- []string{"user-model-db2:db django:db"}
+	unitsWatcher, _ := s.relationsFacade.removeRelation("db2:db django:db")
+	relWatcher, _ := s.relationsFacade.remoteApplicationRelationsWatcher("db2")
+	relWatcher.changes <- []string{"db2:db django:db"}
 	for a := coretesting.LongAttempt.Start(); a.Next(); {
-		_, ok := s.relationsFacade.relationsUnitsWatcher("user-model-db2:db django:db")
+		_, ok := s.relationsFacade.relationsUnitsWatcher("db2:db django:db")
 		if !ok {
 			break
 		}
 	}
 	c.Assert(unitsWatcher.killed(), jc.IsTrue)
 	expected := []jujutesting.StubCall{
-		{"Relations", []interface{}{[]string{"user-model-db2:db django:db"}}},
+		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
 	}
 	s.waitForWorkerStubCalls(c, expected)
 }
@@ -237,7 +237,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationsChangedNotifies(c *gc.C) {
 	defer workertest.CleanKill(c, w)
 	s.stub.ResetCalls()
 
-	unitsWatcher, _ := s.relationsFacade.relationsUnitsWatcher("user-model-db2:db django:db")
+	unitsWatcher, _ := s.relationsFacade.relationsUnitsWatcher("db2:db django:db")
 	unitsWatcher.changes <- watcher.RelationUnitsChange{
 		Changed:  map[string]watcher.UnitSettings{"unit/1": {Version: 2}},
 		Departed: []string{"unit/2"},
@@ -246,7 +246,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationsChangedNotifies(c *gc.C) {
 	expected := []jujutesting.StubCall{
 		{"RelationUnitSettings", []interface{}{
 			[]params.RelationUnit{{
-				Relation: "relation-user-model-db2.db#django.db",
+				Relation: "relation-db2.db#django.db",
 				Unit:     "unit-unit-1"}}}},
 		{"PublishLocalRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
@@ -256,7 +256,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationsChangedNotifies(c *gc.C) {
 					Token:     "token-django"},
 				RelationId: params.RemoteEntityId{
 					ModelUUID: "model-uuid",
-					Token:     "token-user-model-db2:db django:db"},
+					Token:     "token-db2:db django:db"},
 				ChangedUnits: []params.RemoteRelationUnitChange{{
 					UnitId:   1,
 					Settings: map[string]interface{}{"foo": "bar"},
@@ -275,7 +275,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationsChangedError(c *gc.C) {
 	s.stub.ResetCalls()
 
 	s.stub.SetErrors(errors.New("failed"))
-	unitsWatcher, _ := s.relationsFacade.relationsUnitsWatcher("user-model-db2:db django:db")
+	unitsWatcher, _ := s.relationsFacade.relationsUnitsWatcher("db2:db django:db")
 	unitsWatcher.changes <- watcher.RelationUnitsChange{
 		Departed: []string{"unit/1"},
 	}


### PR DESCRIPTION
When a remote app is consumed, the consume CLI supports specifying an alias to avoid name collisions similarly to what is supported for deploy.
We extend the RemoteApplication doc to record the offer name, ie the application name on the offering side so that the alias is used locally and the offer name when communicating with the remote model.
The auto naming of the remote application is now removed - if there's a clash, we fail early and the user needs to use an alias.

QA
juju bootstrap
juju deploy mysql
juju switch controller
juju deploy mediawiki
juju consume default.mysql mysqlalias
juju relate mediawiki:db mysqlalias
