### PR TITLE
Fix lxd namespacing

### DIFF
--- a/tools/lxdclient/instance.go
+++ b/tools/lxdclient/instance.go
@@ -35,11 +35,30 @@ const (
 )
 
 func resolveConfigKey(name string, namespace ...string) string {
-	parts := append(namespace, name)
-	return strings.Join(parts, ".")
+	prefix := strings.Join(namespace, ".") + "."
+	if !shouldNamespace(name, prefix) {
+		return name
+	}
+	return prefix + name
 }
 
-func splitConfigKey(key string) (string, string) {
+func shouldNamespace(name, prefix string) bool {
+	// already in namespace
+	if strings.HasPrefix(name, prefix) {
+		return false
+	}
+	// never namespace lxd limit configuration
+	if strings.HasPrefix(name, "limits.") {
+		return false
+	}
+	// never namespace boot config
+	if name == "boot.autostart" {
+		return false
+	}
+	return true
+}
+
+func splitConfigKey(key string) (namespace, name string) {
 	parts := strings.SplitN(key, ".", 2)
 	if len(parts) == 1 {
 		return "", parts[0]

--- a/tools/lxdclient/instance_test.go
+++ b/tools/lxdclient/instance_test.go
@@ -100,3 +100,20 @@ func (s *instanceSuite) TestNewInstanceSummaryArchitectures(c *gc.C) {
 	summary = lxdclient.NewInstanceSummary(&info)
 	c.Check(summary.Hardware.Architecture, gc.Equals, "unknown")
 }
+
+func (*instanceSuite) TestNamespaceMetadata(c *gc.C) {
+	spec := lxdclient.InstanceSpec{
+		Metadata: map[string]string{
+			"user.foo":       "bar",
+			"boot.autostart": "true",
+			"limits.memory":  "1024MB",
+			"baz":            "boo",
+		},
+	}
+
+	sum := spec.Summary("abc")
+	c.Assert(sum.Metadata, gc.DeepEquals, map[string]string{
+		"foo": "bar",
+		"baz": "boo",
+	})
+}


### PR DESCRIPTION
This patch ensuires that we only namespace lxd metadata
with 'user.' if it doesn't already have that namespace.
It also special cases anything with the limits namespace
and boot.autostart. This fixes
http://pad.lv/1631254

QA:

**Test Autostart:**
Create an lxd container on a juju machine.  
ssh into the host machine and then `lxc exec <containername>  -- sudo shutdown`
now reboot the host, and the container should be started when the host reboots.
you can also test on the host by running `lxc config get <containername> boot.autostart` which should return true
