### PR TITLE
state: make storage persistent by default

### DIFF
--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -180,8 +180,6 @@ func (f *filesystem) validate() error {
 		}
 		switch tag.(type) {
 		case names.ModelTag:
-			// TODO(axw) support binding to model
-			return errors.NotSupportedf("binding to model")
 		case names.MachineTag:
 		case names.StorageTag:
 		default:
@@ -467,12 +465,15 @@ func (st *State) removeMachineFilesystemsOps(machine names.MachineTag) ([]txn.Op
 		if !canRemove {
 			return nil, errors.Errorf("machine has non-machine bound filesystem %v", filesystemTag.Id())
 		}
-		ops = append(ops, txn.Op{
-			C:      filesystemsC,
-			Id:     filesystemTag.Id(),
-			Assert: txn.DocExists,
-			Remove: true,
-		})
+		ops = append(ops,
+			txn.Op{
+				C:      filesystemsC,
+				Id:     filesystemTag.Id(),
+				Assert: txn.DocExists,
+				Remove: true,
+			},
+			removeModelFilesystemRefOp(st, filesystemTag.Id()),
+		)
 	}
 	return ops, nil
 }
@@ -481,6 +482,16 @@ func (st *State) removeMachineFilesystemsOps(machine names.MachineTag) ([]txn.Op
 // with the specified tag is inherently bound to the lifetime of the machine,
 // and will be removed along with it, leaving no resources dangling.
 func isFilesystemInherentlyMachineBound(st *State, tag names.FilesystemTag) (bool, error) {
+	// TODO(axw) when we have support for persistent filesystems,
+	// e.g. NFS shares, then we need to check the filesystem info
+	// to decide whether or not to remove.
+	return true, nil
+}
+
+// isFilesystemParamsInherentlyMachineBound reports whether or not the given
+// filesystem params will create a filesystem inherently bound to the lifetime
+// of a machine, and will be removed along with it, leaving no resources dangling.
+func isFilesystemParamsInherentlyMachineBound(st *State, params FilesystemParams) (bool, error) {
 	// TODO(axw) when we have support for persistent filesystems,
 	// e.g. NFS shares, then we need to check the filesystem info
 	// to decide whether or not to remove.
@@ -588,12 +599,19 @@ func removeFilesystemAttachmentOps(m names.MachineTag, f *filesystem) []txn.Op {
 // DestroyFilesystem ensures that the filesystem and any attachments to it will
 // be destroyed and removed from state at some point in the future.
 func (st *State) DestroyFilesystem(tag names.FilesystemTag) (err error) {
+	defer errors.DeferredAnnotatef(&err, "destroying filesystem %s", tag.Id())
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		filesystem, err := st.filesystemByTag(tag)
 		if errors.IsNotFound(err) {
 			return nil, jujutxn.ErrNoOperations
 		} else if err != nil {
 			return nil, errors.Trace(err)
+		}
+		if filesystem.doc.StorageId != "" {
+			return nil, errors.Errorf(
+				"filesystem is assigned to %s",
+				names.ReadableString(names.NewStorageTag(filesystem.doc.StorageId)),
+			)
 		}
 		if filesystem.doc.Life != Alive {
 			return nil, jujutxn.ErrNoOperations
@@ -604,12 +622,17 @@ func (st *State) DestroyFilesystem(tag names.FilesystemTag) (err error) {
 }
 
 func destroyFilesystemOps(st *State, f *filesystem) []txn.Op {
+	hasNoStorageAssignment := bson.D{{"$or", []bson.D{
+		{{"storageid", ""}},
+		{{"storageid", bson.D{{"$exists", false}}}},
+	}}}
+	baseAssert := append(hasNoStorageAssignment, isAliveDoc...)
 	if f.doc.AttachmentCount == 0 {
 		hasNoAttachments := bson.D{{"attachmentcount", 0}}
 		return []txn.Op{{
 			C:      filesystemsC,
 			Id:     f.doc.FilesystemId,
-			Assert: append(hasNoAttachments, isAliveDoc...),
+			Assert: append(hasNoAttachments, baseAssert...),
 			Update: bson.D{{"$set", bson.D{{"life", Dead}}}},
 		}}
 	}
@@ -618,7 +641,7 @@ func destroyFilesystemOps(st *State, f *filesystem) []txn.Op {
 	return []txn.Op{{
 		C:      filesystemsC,
 		Id:     f.doc.FilesystemId,
-		Assert: append(hasAttachments, isAliveDoc...),
+		Assert: append(hasAttachments, baseAssert...),
 		Update: bson.D{{"$set", bson.D{{"life", Dying}}}},
 	}, cleanupOp}
 }
@@ -652,6 +675,7 @@ func removeFilesystemOps(st *State, filesystem Filesystem) ([]txn.Op, error) {
 			Assert: txn.DocExists,
 			Remove: true,
 		},
+		removeModelFilesystemRefOp(st, filesystem.Tag().Id()),
 		removeStatusOp(st, filesystem.globalKey()),
 	}
 	// If the filesystem is backed by a volume, the volume should
@@ -711,10 +735,13 @@ func newFilesystemId(st *State, machineId string) (string, error) {
 // directly, a volume will be created and Juju will manage a filesystem
 // on it.
 func (st *State) addFilesystemOps(params FilesystemParams, machineId string) ([]txn.Op, names.FilesystemTag, names.VolumeTag, error) {
-	if params.binding == nil {
-		params.binding = names.NewMachineTag(machineId)
-	}
-	params, err := st.filesystemParamsWithDefaults(params)
+	// TODO(axw) the scope of a volume-backed filesystem should be the
+	// same as the volume. Machine storage provisioners would be
+	// responsible for managing filesystems backed by volumes attached
+	// to that machine. Making this change will enable persistent
+	// filesystems; until then, destroying a volume-backed filesystem
+	// always destroys the volume.
+	params, err := st.filesystemParamsWithDefaults(params, machineId)
 	if err != nil {
 		return nil, names.FilesystemTag{}, names.VolumeTag{}, errors.Trace(err)
 	}
@@ -741,7 +768,7 @@ func (st *State) addFilesystemOps(params FilesystemParams, machineId string) ([]
 		var volumeOps []txn.Op
 		volumeParams := VolumeParams{
 			params.storage,
-			filesystemTag, // volume is bound to filesystem
+			filesystemTag,
 			params.Pool,
 			params.Size,
 		}
@@ -782,24 +809,34 @@ func (st *State) newFilesystemOps(doc filesystemDoc, status statusDoc) []txn.Op 
 	}
 }
 
-func (st *State) filesystemParamsWithDefaults(params FilesystemParams) (FilesystemParams, error) {
-	if params.Pool != "" {
-		return params, nil
+func (st *State) filesystemParamsWithDefaults(params FilesystemParams, machineId string) (FilesystemParams, error) {
+	if params.Pool == "" {
+		modelConfig, err := st.ModelConfig()
+		if err != nil {
+			return FilesystemParams{}, errors.Trace(err)
+		}
+		cons := StorageConstraints{
+			Pool:  params.Pool,
+			Size:  params.Size,
+			Count: 1,
+		}
+		poolName, err := defaultStoragePool(modelConfig, storage.StorageKindFilesystem, cons)
+		if err != nil {
+			return FilesystemParams{}, errors.Annotate(err, "getting default filesystem storage pool")
+		}
+		params.Pool = poolName
 	}
-	envConfig, err := st.ModelConfig()
-	if err != nil {
-		return FilesystemParams{}, errors.Trace(err)
+	if params.binding == nil {
+		machineBound, err := isFilesystemParamsInherentlyMachineBound(st, params)
+		if err != nil {
+			return FilesystemParams{}, errors.Trace(err)
+		}
+		if machineBound {
+			params.binding = names.NewMachineTag(machineId)
+		} else {
+			params.binding = st.ModelTag()
+		}
 	}
-	cons := StorageConstraints{
-		Pool:  params.Pool,
-		Size:  params.Size,
-		Count: 1,
-	}
-	poolName, err := defaultStoragePool(envConfig, storage.StorageKindFilesystem, cons)
-	if err != nil {
-		return FilesystemParams{}, errors.Annotate(err, "getting default filesystem storage pool")
-	}
-	params.Pool = poolName
 	return params, nil
 }
 

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -524,13 +524,27 @@ func (s *FilesystemStateSuite) TestSetFilesystemInfoVolumeAttachmentNotProvision
 func (s *FilesystemStateSuite) TestDestroyFilesystem(c *gc.C) {
 	filesystem, _ := s.setupFilesystemAttachment(c, "rootfs")
 	assertDestroy := func() {
-		err := s.State.DestroyFilesystem(filesystem.FilesystemTag())
-		c.Assert(err, jc.ErrorIsNil)
-		filesystem = s.filesystem(c, filesystem.FilesystemTag())
-		c.Assert(filesystem.Life(), gc.Equals, state.Dying)
+		s.assertDestroyFilesystem(c, filesystem.FilesystemTag(), state.Dying)
 	}
 	defer state.SetBeforeHooks(c, s.State, assertDestroy).Check()
 	assertDestroy()
+}
+
+func (s *FilesystemStateSuite) TestDestroyFilesystemStorageAssigned(c *gc.C) {
+	// Create a filesystem-type storage instance, and show that we
+	// cannot destroy the filesystem while there is storage assigned.
+	_, u, storageTag := s.setupSingleStorage(c, "filesystem", "rootfs")
+	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = u.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	filesystem := s.storageInstanceFilesystem(c, storageTag)
+
+	err = s.State.DestroyFilesystem(filesystem.FilesystemTag())
+	c.Assert(err, gc.ErrorMatches, "destroying filesystem 0/0: filesystem is assigned to storage data/0")
+
+	removeStorageInstance(c, s.State, storageTag)
+	s.assertDestroyFilesystem(c, filesystem.FilesystemTag(), state.Dying)
 }
 
 func (s *FilesystemStateSuite) TestDestroyFilesystemNoAttachments(c *gc.C) {
@@ -545,20 +559,15 @@ func (s *FilesystemStateSuite) TestDestroyFilesystemNoAttachments(c *gc.C) {
 		assertMachineStorageRefs(c, s.State, machine.MachineTag())
 	}).Check()
 
-	err = s.State.DestroyFilesystem(filesystem.FilesystemTag())
-	c.Assert(err, jc.ErrorIsNil)
-	filesystem = s.filesystem(c, filesystem.FilesystemTag())
-
 	// There are no more attachments, so the filesystem should
-	// have been progressed directly to Dead.
-	c.Assert(filesystem.Life(), gc.Equals, state.Dead)
+	// be progressed directly to Dead.
+	s.assertDestroyFilesystem(c, filesystem.FilesystemTag(), state.Dead)
 }
 
 func (s *FilesystemStateSuite) TestRemoveFilesystem(c *gc.C) {
 	filesystem, machine := s.setupFilesystemAttachment(c, "rootfs")
-	err := s.State.DestroyFilesystem(filesystem.FilesystemTag())
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.DetachFilesystem(machine.MachineTag(), filesystem.FilesystemTag())
+	s.assertDestroyFilesystem(c, filesystem.FilesystemTag(), state.Dying)
+	err := s.State.DetachFilesystem(machine.MachineTag(), filesystem.FilesystemTag())
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.RemoveFilesystemAttachment(machine.MachineTag(), filesystem.FilesystemTag())
 	c.Assert(err, jc.ErrorIsNil)
@@ -584,14 +593,13 @@ func (s *FilesystemStateSuite) TestRemoveFilesystemVolumeBacked(c *gc.C) {
 		c.Assert(attachment.Life(), gc.Equals, life)
 	}
 
-	err := s.State.DestroyFilesystem(filesystem.FilesystemTag())
-	c.Assert(err, jc.ErrorIsNil)
+	s.assertDestroyFilesystem(c, filesystem.FilesystemTag(), state.Dying)
 	// Destroying the filesystem does not trigger destruction
 	// of the volume. It cannot be destroyed until all remnants
 	// of the filesystem are gone.
 	assertVolumeLife(state.Alive)
 
-	err = s.State.DetachFilesystem(machine.MachineTag(), filesystem.FilesystemTag())
+	err := s.State.DetachFilesystem(machine.MachineTag(), filesystem.FilesystemTag())
 	c.Assert(err, jc.ErrorIsNil)
 	// Likewise for the volume attachment.
 	assertVolumeAttachmentLife(state.Alive)
@@ -615,9 +623,8 @@ func (s *FilesystemStateSuite) TestFilesystemVolumeBackedDestroyDetachVolumeFail
 	filesystem, machine := s.setupFilesystemAttachment(c, "loop")
 	volume := s.filesystemVolume(c, filesystem.FilesystemTag())
 
-	err := s.State.DestroyFilesystem(filesystem.FilesystemTag())
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.DetachFilesystem(machine.MachineTag(), filesystem.FilesystemTag())
+	s.assertDestroyFilesystem(c, filesystem.FilesystemTag(), state.Dying)
+	err := s.State.DetachFilesystem(machine.MachineTag(), filesystem.FilesystemTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Can't destroy (detach) volume until the filesystem (attachment) is removed.
@@ -649,8 +656,7 @@ func (s *FilesystemStateSuite) TestRemoveFilesystemNotDead(c *gc.C) {
 	filesystem, _ := s.setupFilesystemAttachment(c, "rootfs")
 	err := s.State.RemoveFilesystem(filesystem.FilesystemTag())
 	c.Assert(err, gc.ErrorMatches, "removing filesystem 0/0: filesystem is not dead")
-	err = s.State.DestroyFilesystem(filesystem.FilesystemTag())
-	c.Assert(err, jc.ErrorIsNil)
+	s.assertDestroyFilesystem(c, filesystem.FilesystemTag(), state.Dying)
 	err = s.State.RemoveFilesystem(filesystem.FilesystemTag())
 	c.Assert(err, gc.ErrorMatches, "removing filesystem 0/0: filesystem is not dead")
 }
@@ -676,12 +682,8 @@ func (s *FilesystemStateSuite) TestRemoveLastFilesystemAttachment(c *gc.C) {
 	err = s.State.RemoveFilesystemAttachment(machine.MachineTag(), filesystem.FilesystemTag())
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.State.DestroyFilesystem(filesystem.FilesystemTag())
-	c.Assert(err, jc.ErrorIsNil)
-	filesystem = s.filesystem(c, filesystem.FilesystemTag())
-	// The filesystem had no attachments when it was destroyed,
-	// so it should be Dead.
-	c.Assert(filesystem.Life(), gc.Equals, state.Dead)
+	// The filesystem has no attachments, so it should go straight to Dead.
+	s.assertDestroyFilesystem(c, filesystem.FilesystemTag(), state.Dead)
 	assertMachineStorageRefs(c, s.State, machine.MachineTag())
 }
 
@@ -692,10 +694,7 @@ func (s *FilesystemStateSuite) TestRemoveLastFilesystemAttachmentConcurrently(c 
 	c.Assert(err, jc.ErrorIsNil)
 
 	defer state.SetBeforeHooks(c, s.State, func() {
-		err := s.State.DestroyFilesystem(filesystem.FilesystemTag())
-		c.Assert(err, jc.ErrorIsNil)
-		filesystem := s.filesystem(c, filesystem.FilesystemTag())
-		c.Assert(filesystem.Life(), gc.Equals, state.Dying)
+		s.assertDestroyFilesystem(c, filesystem.FilesystemTag(), state.Dying)
 	}).Check()
 
 	err = s.State.RemoveFilesystemAttachment(machine.MachineTag(), filesystem.FilesystemTag())
@@ -761,38 +760,24 @@ func (s *FilesystemStateSuite) TestFilesystemBindingMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	filesystem = s.filesystem(c, filesystem.FilesystemTag())
 	c.Assert(filesystem.Life(), gc.Equals, state.Dead)
-
-	// TODO(axw) when we can assign storage to an existing filesystem, we
-	// should test that a machine-bound filesystem is not destroyed when
-	// its assigned storage instance is removed.
 }
 
 func (s *FilesystemStateSuite) TestFilesystemBindingStorage(c *gc.C) {
 	// Filesystems created assigned to a storage instance are bound
-	// to the storage instance.
+	// to the machine/model, and not the storage. i.e. storage is
+	// persistent by default.
 	_, u, storageTag := s.setupSingleStorage(c, "filesystem", "rootfs")
 	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
+	machineId, err := u.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
 	filesystem := s.storageInstanceFilesystem(c, storageTag)
-	c.Assert(filesystem.LifeBinding(), gc.Equals, storageTag)
+	c.Assert(filesystem.LifeBinding(), gc.Equals, names.NewMachineTag(machineId))
 
-	err = s.State.DestroyStorageInstance(storageTag)
-	c.Assert(err, jc.ErrorIsNil)
-	attachments, err := s.State.StorageAttachments(storageTag)
-	c.Assert(err, jc.ErrorIsNil)
-	for _, a := range attachments {
-		err = s.State.DestroyStorageAttachment(storageTag, a.Unit())
-		c.Assert(err, jc.ErrorIsNil)
-		err = s.State.RemoveStorageAttachment(storageTag, a.Unit())
-		c.Assert(err, jc.ErrorIsNil)
-	}
-
-	// The storage instance should be removed,
-	// and the filesystem should be Dying.
-	_, err = s.State.StorageInstance(storageTag)
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	// The filesystem should remain Alive when the storage is removed.
+	removeStorageInstance(c, s.State, storageTag)
 	filesystem = s.filesystem(c, filesystem.FilesystemTag())
-	c.Assert(filesystem.Life(), gc.Equals, state.Dying)
+	c.Assert(filesystem.Life(), gc.Equals, state.Alive)
 }
 
 func (s *FilesystemStateSuite) TestFilesystemVolumeBinding(c *gc.C) {
@@ -1030,4 +1015,11 @@ func (s *FilesystemStateSuite) setupFilesystemAttachment(c *gc.C, pool string) (
 	c.Assert(err, jc.ErrorIsNil)
 	assertMachineStorageRefs(c, s.State, machine.MachineTag())
 	return s.filesystem(c, attachments[0].Filesystem()), machine
+}
+
+func (s *FilesystemStateSuite) assertDestroyFilesystem(c *gc.C, tag names.FilesystemTag, life state.Life) {
+	err := s.State.DestroyFilesystem(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	filesystem := s.filesystem(c, tag)
+	c.Assert(filesystem.Life(), gc.Equals, life)
 }

--- a/state/model.go
+++ b/state/model.go
@@ -95,6 +95,12 @@ type modelEntityRefsDoc struct {
 
 	// Applicatons contains the names of the applications in the model.
 	Applications []string `bson:"applications"`
+
+	// Volumes contains the IDs of the volumes in the model.
+	Volumes []string `bson:"volumes"`
+
+	// Filesystems contains the IDs of the filesystems in the model.
+	Filesystems []string `bson:"filesystems"`
 }
 
 // ControllerModel returns the model that was bootstrapped.
@@ -858,15 +864,22 @@ func (m *Model) destroyOps(ensureNoHostedModels, ensureEmpty bool) ([]txn.Op, er
 		ops = append(ops, cleanupOp)
 	}
 	if !isEmpty {
-		// We only need to destroy machines and models if the model is
-		// non-empty. It wouldn't normally be harmful to enqueue the
-		// cleanups otherwise, except for when we're destroying an empty
+		// We only need to destroy resources if the model is non-empty.
+		// It wouldn't normally be harmful to enqueue the cleanups
+		// otherwise, except for when we're destroying an empty
 		// hosted model in the course of destroying the controller. In
 		// that case we'll get errors if we try to enqueue hosted-model
 		// cleanups, because the cleanups collection is non-global.
 		cleanupMachinesOp := newCleanupOp(cleanupMachinesForDyingModel, modelUUID)
-		cleanupServicesOp := newCleanupOp(cleanupServicesForDyingModel, modelUUID)
-		ops = append(ops, cleanupMachinesOp, cleanupServicesOp)
+		cleanupApplicationsOp := newCleanupOp(cleanupApplicationsForDyingModel, modelUUID)
+		cleanupVolumesOp := newCleanupOp(cleanupVolumesForDyingModel, modelUUID)
+		cleanupFilesystemsOp := newCleanupOp(cleanupFilesystemsForDyingModel, modelUUID)
+		ops = append(ops,
+			cleanupMachinesOp,
+			cleanupApplicationsOp,
+			cleanupVolumesOp,
+			cleanupFilesystemsOp,
+		)
 	}
 	return append(prereqOps, ops...), nil
 }
@@ -895,42 +908,63 @@ func (m *Model) checkEmpty() error {
 		return errors.Errorf("model not empty, found %d machine(s)", n)
 	}
 	if n := len(doc.Applications); n > 0 {
-		return errors.Errorf("model not empty, found %d applications(s)", n)
+		return errors.Errorf("model not empty, found %d application(s)", n)
+	}
+	if n := len(doc.Volumes); n > 0 {
+		return errors.Errorf("model not empty, found %d volume(s)", n)
+	}
+	if n := len(doc.Filesystems); n > 0 {
+		return errors.Errorf("model not empty, found %d filesystem(s)", n)
 	}
 	return nil
 }
 
 func addModelMachineRefOp(st *State, machineId string) txn.Op {
-	return txn.Op{
-		C:      modelEntityRefsC,
-		Id:     st.ModelUUID(),
-		Assert: txn.DocExists,
-		Update: bson.D{{"$addToSet", bson.D{{"machines", machineId}}}},
-	}
+	return addModelEntityRefOp(st, "machines", machineId)
 }
 
 func removeModelMachineRefOp(st *State, machineId string) txn.Op {
-	return txn.Op{
-		C:      modelEntityRefsC,
-		Id:     st.ModelUUID(),
-		Update: bson.D{{"$pull", bson.D{{"machines", machineId}}}},
-	}
+	return removeModelEntityRefOp(st, "machines", machineId)
 }
 
 func addModelApplicationRefOp(st *State, applicationname string) txn.Op {
+	return addModelEntityRefOp(st, "applications", applicationname)
+}
+
+func removeModelApplicationRefOp(st *State, applicationname string) txn.Op {
+	return removeModelEntityRefOp(st, "applications", applicationname)
+}
+
+func addModelVolumeRefOp(st *State, volumeId string) txn.Op {
+	return addModelEntityRefOp(st, "volumes", volumeId)
+}
+
+func removeModelVolumeRefOp(st *State, volumeId string) txn.Op {
+	return removeModelEntityRefOp(st, "volumes", volumeId)
+}
+
+func addModelFilesystemRefOp(st *State, filesystemId string) txn.Op {
+	return addModelEntityRefOp(st, "filesystems", filesystemId)
+}
+
+func removeModelFilesystemRefOp(st *State, filesystemId string) txn.Op {
+	return removeModelEntityRefOp(st, "filesystems", filesystemId)
+}
+
+func addModelEntityRefOp(st *State, entityField, entityId string) txn.Op {
 	return txn.Op{
 		C:      modelEntityRefsC,
 		Id:     st.ModelUUID(),
 		Assert: txn.DocExists,
-		Update: bson.D{{"$addToSet", bson.D{{"applications", applicationname}}}},
+		Update: bson.D{{"$addToSet", bson.D{{entityField, entityId}}}},
 	}
 }
 
-func removeModelApplicationRefOp(st *State, applicationname string) txn.Op {
+func removeModelEntityRefOp(st *State, entityField, entityId string) txn.Op {
 	return txn.Op{
 		C:      modelEntityRefsC,
 		Id:     st.ModelUUID(),
-		Update: bson.D{{"$pull", bson.D{{"applications", applicationname}}}},
+		Update: bson.D{{"$pull", bson.D{{entityField, entityId}}}},
 	}
 }
 

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -576,16 +576,16 @@ func (s *ModelSuite) TestDestroyModelEmpty(c *gc.C) {
 }
 
 func (s *ModelSuite) TestProcessDyingServerEnvironTransitionDyingToDead(c *gc.C) {
-	s.assertDyingEnvironTransitionDyingToDead(c, s.State)
+	s.assertDyingModelTransitionDyingToDead(c, s.State)
 }
 
 func (s *ModelSuite) TestProcessDyingHostedEnvironTransitionDyingToDead(c *gc.C) {
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
-	s.assertDyingEnvironTransitionDyingToDead(c, st)
+	s.assertDyingModelTransitionDyingToDead(c, st)
 }
 
-func (s *ModelSuite) assertDyingEnvironTransitionDyingToDead(c *gc.C, st *state.State) {
+func (s *ModelSuite) assertDyingModelTransitionDyingToDead(c *gc.C, st *state.State) {
 	// Add a service to prevent the model from transitioning directly to Dead.
 	// Add the service before getting the Model, otherwise we'll have to run
 	// the transaction twice, and hit the hook point too early.
@@ -612,7 +612,7 @@ func (s *ModelSuite) assertDyingEnvironTransitionDyingToDead(c *gc.C, st *state.
 	c.Assert(env.Destroy(), jc.ErrorIsNil)
 }
 
-func (s *ModelSuite) TestProcessDyingEnvironWithMachinesAndServicesNoOp(c *gc.C) {
+func (s *ModelSuite) TestProcessDyingModelWithMachinesAndServicesNoOp(c *gc.C) {
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
 
@@ -659,6 +659,84 @@ func (s *ModelSuite) TestProcessDyingEnvironWithMachinesAndServicesNoOp(c *gc.C)
 
 	c.Assert(env.Refresh(), jc.ErrorIsNil)
 	c.Assert(env.Destroy(), jc.ErrorIsNil)
+}
+
+func (s *ModelSuite) TestProcessDyingModelWithVolumeBackedFilesystems(c *gc.C) {
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	machine, err := st.AddOneMachine(state.MachineTemplate{
+		Series: "quantal",
+		Jobs:   []state.MachineJob{state.JobHostUnits},
+		Filesystems: []state.MachineFilesystemParams{{
+			Filesystem: state.FilesystemParams{
+				Pool: "environscoped-block",
+				Size: 123,
+			},
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	filesystems, err := st.AllFilesystems()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(filesystems, gc.HasLen, 1)
+
+	c.Assert(model.Destroy(), jc.ErrorIsNil)
+	err = st.DetachFilesystem(machine.MachineTag(), names.NewFilesystemTag("0/0"))
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.RemoveFilesystemAttachment(machine.MachineTag(), names.NewFilesystemTag("0/0"))
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.DetachVolume(machine.MachineTag(), names.NewVolumeTag("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.RemoveVolumeAttachment(machine.MachineTag(), names.NewVolumeTag("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machine.EnsureDead(), jc.ErrorIsNil)
+	c.Assert(machine.Remove(), jc.ErrorIsNil)
+
+	// The filesystem will be gone, but the volume is persistent and should
+	// not have been removed.
+	err = st.ProcessDyingModel()
+	c.Assert(err, gc.ErrorMatches, `model not empty, found 1 volume\(s\)`)
+}
+
+func (s *ModelSuite) TestProcessDyingModelWithVolumes(c *gc.C) {
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	machine, err := st.AddOneMachine(state.MachineTemplate{
+		Series: "quantal",
+		Jobs:   []state.MachineJob{state.JobHostUnits},
+		Volumes: []state.MachineVolumeParams{{
+			Volume: state.VolumeParams{
+				Pool: "environscoped",
+				Size: 123,
+			},
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	volumes, err := st.AllVolumes()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(volumes, gc.HasLen, 1)
+
+	c.Assert(model.Destroy(), jc.ErrorIsNil)
+	err = st.DetachVolume(machine.MachineTag(), names.NewVolumeTag("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.RemoveVolumeAttachment(machine.MachineTag(), names.NewVolumeTag("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machine.EnsureDead(), jc.ErrorIsNil)
+	c.Assert(machine.Remove(), jc.ErrorIsNil)
+
+	// The volume is persistent and should not have been removed along with
+	// the machine it was attached to.
+	err = st.ProcessDyingModel()
+	c.Assert(err, gc.ErrorMatches, `model not empty, found 1 volume\(s\)`)
 }
 
 func (s *ModelSuite) TestProcessDyingControllerEnvironWithHostedEnvsNoOp(c *gc.C) {

--- a/state/storage.go
+++ b/state/storage.go
@@ -307,7 +307,7 @@ func removeStorageInstanceOps(
 			C:      c,
 			Id:     id,
 			Assert: bson.D{{"storageid", tag.Id()}},
-			Update: bson.D{{"$set", bson.D{{"storageid", ""}}}},
+			Update: bson.D{{"$unset", bson.D{{"storageid", nil}}}},
 		}
 	}
 

--- a/state/unit.go
+++ b/state/unit.go
@@ -1386,14 +1386,14 @@ func validateDynamicMachineStorageParams(m *Machine, params *machineStorageParam
 func machineStoragePools(st *State, params *machineStorageParams) (set.Strings, error) {
 	pools := make(set.Strings)
 	for _, v := range params.volumes {
-		v, err := st.volumeParamsWithDefaults(v.Volume)
+		v, err := st.volumeParamsWithDefaults(v.Volume, "")
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		pools.Add(v.Pool)
 	}
 	for _, f := range params.filesystems {
-		f, err := st.filesystemParamsWithDefaults(f.Filesystem)
+		f, err := st.filesystemParamsWithDefaults(f.Filesystem, "")
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1836,7 +1836,6 @@ func machineStorageParamsForStorageInstance(
 			cons := allCons[storage.StorageName()]
 			volumeParams := VolumeParams{
 				storage: storage.StorageTag(),
-				binding: storage.StorageTag(),
 				Pool:    cons.Pool,
 				Size:    cons.Size,
 			}
@@ -1872,7 +1871,6 @@ func machineStorageParamsForStorageInstance(
 			cons := allCons[storage.StorageName()]
 			filesystemParams := FilesystemParams{
 				storage: storage.StorageTag(),
-				binding: storage.StorageTag(),
 				Pool:    cons.Pool,
 				Size:    cons.Size,
 			}

--- a/storage/provider/managedfs.go
+++ b/storage/provider/managedfs.go
@@ -50,9 +50,10 @@ func NewManagedFilesystemSource(
 
 // ValidateFilesystemParams is defined on storage.FilesystemSource.
 func (s *managedFilesystemSource) ValidateFilesystemParams(arg storage.FilesystemParams) error {
-	if _, err := s.backingVolumeBlockDevice(arg.Volume); err != nil {
-		return errors.Trace(err)
-	}
+	// NOTE(axw) the parameters may be for destroying a filesystem, which
+	// may be called when the backing volume is detached from the machine.
+	// We must not perform any validation here that would fail if the
+	// volume is detached.
 	return nil
 }
 


### PR DESCRIPTION
Volumes and filesystems will not default to
being bound to the model, or machine, depending
on whether or not the storage can be persistent.

This is the minimal change. Volume-backed
filesystems are currently always considered
machine-scoped, which leads to undesirable
behaviour: the filesystem cannot be detached
from the machine it is initially attached to
(or doing so will cause the volume to be
destroyed). We will need to make further
changes so that volume-backed filesystems
are not scoped or bound to a single machine.