### PR TITLE
Leadership renewal is too noisy to be useful at Info level

### DIFF
--- a/worker/leadership/tracker.go
+++ b/worker/leadership/tracker.go
@@ -181,7 +181,7 @@ func (t *Tracker) refresh() error {
 func (t *Tracker) setLeader(untilTime time.Time) error {
 	logger.Debugf("%s confirmed for %s leadership until %s", t.unitName, t.applicationName, untilTime)
 	renewTime := untilTime.Add(-t.duration)
-	logger.Infof("%s will renew %s leadership at %s", t.unitName, t.applicationName, renewTime)
+	logger.Debugf("%s will renew %s leadership at %s", t.unitName, t.applicationName, renewTime)
 	t.isMinion = false
 	t.claimLease = nil
 	t.renewLease = t.clock.After(renewTime.Sub(t.clock.Now()))

--- a/worker/leadership/tracker.go
+++ b/worker/leadership/tracker.go
@@ -55,6 +55,7 @@ func NewTracker(tag names.UnitTag, claimer leadership.Claimer, clock clock.Clock
 		claimTickets:      make(chan chan bool),
 		waitLeaderTickets: make(chan chan bool),
 		waitMinionTickets: make(chan chan bool),
+		isMinion:		   true,
 	}
 	go func() {
 		defer t.tomb.Done()
@@ -179,6 +180,10 @@ func (t *Tracker) refresh() error {
 
 // setLeader arranges for lease renewal.
 func (t *Tracker) setLeader(untilTime time.Time) error {
+	if t.isMinion {
+		// If we were a minion, we're now the leader, so we can record the transition.
+		logger.Infof("%s promoted to leadership of %s", t.unitName, t.applicationName)
+	}
 	logger.Debugf("%s confirmed for %s leadership until %s", t.unitName, t.applicationName, untilTime)
 	renewTime := untilTime.Add(-t.duration)
 	logger.Debugf("%s will renew %s leadership at %s", t.unitName, t.applicationName, renewTime)


### PR DESCRIPTION
This just changes the "will renew leadership" message that triggers every 30s to be at Debug level, so that it isn't shown by default.