### PR TITLE
Generate LXD https host strings.

### DIFF
--- a/cert/cert.go
+++ b/cert/cert.go
@@ -58,6 +58,21 @@ func ParseCertAndKey(certPEM, keyPEM string) (*x509.Certificate, *rsa.PrivateKey
 	return cert, key, nil
 }
 
+// Generate public key from keyPEM string
+func ComputePublicKey(certPEM string) (string, error){
+	cert, err := ParseCert(certPEM)
+	if err != nil {
+		return "", err
+	}
+	pubKey := cert.PublicKey.(interface {})
+	marshalledPubKey, _ := x509.MarshalPKIXPublicKey(pubKey)
+	keyPEMData := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PUBLIC KEY",
+		Bytes: marshalledPubKey,
+	})
+	return string(keyPEMData), nil
+}
+
 // Verify verifies that the given server certificate is valid with
 // respect to the given CA certificate at the given time.
 func Verify(srvCertPEM, caCertPEM string, when time.Time) error {

--- a/juju/home.go
+++ b/juju/home.go
@@ -4,10 +4,16 @@
 package juju
 
 import (
+	"os"
+	"time"
+	"io/ioutil"
+
 	"github.com/juju/errors"
+	"github.com/juju/utils"
 	"github.com/juju/utils/ssh"
 	"gopkg.in/juju/charmrepo.v2-unstable"
 
+	"github.com/juju/juju/cert"
 	"github.com/juju/juju/juju/osenv"
 )
 
@@ -22,6 +28,22 @@ func InitJujuXDGDataHome() error {
 	charmrepo.CacheDir = osenv.JujuXDGDataHomePath("charmcache")
 	if err := ssh.LoadClientKeys(osenv.JujuXDGDataHomePath("ssh")); err != nil {
 		return errors.Annotate(err, "cannot load ssh client keys")
+	}
+	expiry := time.Now().UTC().AddDate(10, 0, 0)
+	uuid, _ := utils.NewUUID()
+	certdir := osenv.JujuXDGDataHomePath("x509")
+	if certdir != "" {
+		err := os.MkdirAll(certdir, 0700)
+		if err == nil {
+			pem, key, err := cert.NewCA("client", uuid.String(), expiry)
+			public, err := cert.ComputePublicKey(pem)
+			err = ioutil.WriteFile(certdir + "/juju-cert.pem", []byte(pem), 0600)
+			err = ioutil.WriteFile(certdir + "/juju-cert.key", []byte(key), 0600)
+			err = ioutil.WriteFile(certdir + "/juju-cert.pub", []byte(public), 0600)
+			if err != nil {
+				return errors.Annotate(err, "cannot write x509 certificate")
+			}
+		}
 	}
 	return nil
 }

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -69,9 +69,6 @@ func validateCloudSpec(spec environs.CloudSpec) error {
 	if err := spec.Validate(); err != nil {
 		return errors.Trace(err)
 	}
-	if spec.Endpoint != "" {
-		return errors.NotValidf("non-empty endpoint %q", spec.Endpoint)
-	}
 	if spec.Credential != nil {
 		if authType := spec.Credential.AuthType(); authType != cloud.EmptyAuthType {
 			return errors.NotSupportedf("%q auth-type", authType)

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -127,14 +127,3 @@ func (s *ProviderFunctionalSuite) TestPrepareConfigUnsupportedAuthType(c *gc.C) 
 	})
 	c.Assert(err, gc.ErrorMatches, `validating cloud spec: "certificate" auth-type not supported`)
 }
-
-func (s *ProviderFunctionalSuite) TestPrepareConfigNonEmptyEndpoint(c *gc.C) {
-	_, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
-		Cloud: environs.CloudSpec{
-			Type:     "lxd",
-			Name:     "remotehost",
-			Endpoint: "1.2.3.4",
-		},
-	})
-	c.Assert(err, gc.ErrorMatches, `validating cloud spec: non-empty endpoint "1.2.3.4" not valid`)
-}

--- a/tools/lxdclient/client_network.go
+++ b/tools/lxdclient/client_network.go
@@ -55,7 +55,7 @@ func checkBridgeConfig(client rawNetworkClient, bridge string) error {
 		return err
 	}
 
-	if n.Config["ipv6.address"] != "none" {
+	if n.Managed && n.Config["ipv6.address"] != "none" {
 		return errors.Errorf(`juju doesn't support ipv6. Please disable LXD's IPV6:
 
 	$ lxc network set %s ipv6.address none

--- a/tools/lxdclient/client_test.go
+++ b/tools/lxdclient/client_test.go
@@ -15,6 +15,7 @@ import (
 	jujuos "github.com/juju/utils/os"
 	"github.com/lxc/lxd"
 	gc "gopkg.in/check.v1"
+	"strings"
 )
 
 type ConnectSuite struct {
@@ -241,4 +242,25 @@ var testerr = errors.Errorf("boo!")
 
 func fakeNewClientFromInfo(info lxd.ConnectInfo) (*lxd.Client, error) {
 	return nil, testerr
+}
+
+func (cs *ConnectSuite) TestIsLocalhost(c *gc.C) {
+	out, err := isLocalhost("127.0.0.1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out, gc.Equals, true)
+}
+
+func (cs *ConnectSuite) TestIsNotLocalhost(c *gc.C) {
+	out, err := isLocalhost("8.8.8.8")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out, gc.Equals, true)
+}
+
+func (cs *ConnectSuite) TestGenerateUnixHostString(c *gc.C){
+	host := generateHostString(remoteLocalName, "127.0.0.1")
+	c.Assert(strings.HasPrefix(host, "unix://"), gc.Equals, true)
+}
+func (cs *ConnectSuite) TestGenerateHTTPSHostString(c *gc.C){
+	host := generateHostString(remoteLocalName, "8.8.8.8")
+	c.Assert(strings.HasPrefix(host, "https://"), gc.Equals, true)
 }


### PR DESCRIPTION
The added commit to this series of patches modify the behaviour of the function that
generates the unix host string to be able to generate an https host string. This is continuing
the work to allow juju LXD provider work with configured LXD remotes. Test cases added to
the new code.