### PR TITLE
state/metricsmanager: Fixed a txn that could return not found if being called concurrently

### DIFF
--- a/state/metricsmanager_test.go
+++ b/state/metricsmanager_test.go
@@ -28,6 +28,18 @@ func (s *metricsManagerSuite) TestDefaultsWritten(c *gc.C) {
 	c.Assert(mm.GracePeriod(), gc.Equals, 24*7*time.Hour)
 }
 
+func (s *metricsManagerSuite) TestNewMetricsManager(c *gc.C) {
+	state.SetBeforeHooks(c, s.State, func() {
+		_, err := s.State.MetricsManager()
+		c.Assert(err, jc.ErrorIsNil)
+	})
+	mm, err := s.State.MetricsManager()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mm.LastSuccessfulSend(), gc.DeepEquals, time.Time{})
+	c.Assert(mm.ConsecutiveErrors(), gc.Equals, 0)
+	c.Assert(mm.GracePeriod(), gc.Equals, 24*7*time.Hour)
+}
+
 func (s *metricsManagerSuite) TestMetricsManagerCreatesThenReturns(c *gc.C) {
 	mm, err := s.State.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
When the controller starts we create a new metrics manager. But there was the potential for this to be a bit racey which would result in the following appearing in the controller log:
```
failed to send metrics failed to send metrics for model-xxx: metrics manager not found - will retry later in a model with fresh model
```
(You can confirm this by bootstrapping then checking the controller machine-0 log)

This branch fixes that bug
