### PR TITLE
[api/watcher] ensure watched units, not necessarily separate

### DIFF
--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -136,21 +136,16 @@ func (s *watcherSuite) TestWatchUnitsKeepsEvents(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Now, without reading any changes advance the lifecycle of both
-	// units, inducing an update server-side after each two changes to
-	// ensure they're reported as separate events over the API.
+	// units.
 	err = subordinate.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
-	s.BackingState.StartSync()
 	err = subordinate.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 	err = principal.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
-	s.BackingState.StartSync()
 
-	// Expect these changes as 2 separate events, so that
-	// nothing gets lost.
-	wc.AssertChange("logging/0")
-	wc.AssertChange("mysql/0")
+	// Expect both changes are passed back.
+	wc.AssertChange("mysql/0", "logging/0")
 	wc.AssertNoChange()
 }
 


### PR DESCRIPTION
The test was trying to assert that the two lifecycle events of the units came through as separate events. This cannot be enforced without additional synchronisation between the transaction log watcher and the test. 

Fixes lp:1656375 - the StartSync calls are not sufficient to ensure the events are actually captured. There is a race between the test and the goroutine that is watching the transaction log. Most of the time the transaction log is processed between the StartSync calls, but this cannot be guaranteed.

Nor is it actually necessary. The deployer code has to handle multiple values coming through in a single event anyway. The test is updated just to ensure that the values to come through.