### PR TITLE
update dependencies

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -47,7 +47,7 @@ github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-0
 github.com/juju/testing	git	5ea77166c8c6a8f56f258565288c4714aa399283	2016-11-24T00:43:14Z
 github.com/juju/txn	git	28898197906200d603394d8e4ce537436529f1c5	2016-11-16T04:07:55Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils	git	165eeede6fceeb359be7f5ef790c16368dc2bc9f	2016-11-22T15:00:28Z
+github.com/juju/utils	git	e5eb4d99a51c3ded8e4e8bdfe527260ceeec997d	2017-01-16T11:32:47Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z


### PR DESCRIPTION
In a slight oversight, I neglected to add the Windows Hyper-V Server 2016 and windows storage server series 2016 into juju/utils. This PR updates the utils dependency to a version that properly detects both versions of the newly released windows server operating system.

The new series that was added is win2016hv corresponding to the Windows Hyper-V Server 2016, and for storage server, the returned series is win2016. If there is a need to have a distinct series for storage server, another PR will be created.

After this PR is merged, juju should be able to acquire and deploy machines using the new series, and also successfully detect Windows Storage Server 2016.