### PR TITLE
migrations: Add do-nothing MoveInstancesToController methods

### DIFF
--- a/provider/cloudsigma/environ.go
+++ b/provider/cloudsigma/environ.go
@@ -98,8 +98,15 @@ func (env *environ) BootstrapMessage() string {
 	return ""
 }
 
+// ControllerInstances is part of the Environ interface.
 func (e *environ) ControllerInstances(controllerUUID string) ([]instance.Id, error) {
 	return e.client.getControllerIds()
+}
+
+// MoveInstancesToController is part of the Environ interface.
+func (e *environ) MoveInstancesToController([]instance.Id, string) error {
+	// This provider doesn't track instance -> controller.
+	return nil
 }
 
 // Destroy shuts down all known machines and destroys the

--- a/provider/cloudsigma/environ.go
+++ b/provider/cloudsigma/environ.go
@@ -104,7 +104,7 @@ func (e *environ) ControllerInstances(controllerUUID string) ([]instance.Id, err
 }
 
 // MoveInstancesToController is part of the Environ interface.
-func (e *environ) MoveInstancesToController([]instance.Id, string) error {
+func (e *environ) MoveInstancesToController(ids []instance.Id, controllerUUID string) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -886,6 +886,12 @@ func (e *environ) SetConfig(cfg *config.Config) error {
 	return nil
 }
 
+// MoveInstancesToController is part of the Environ interface.
+func (e *environ) MoveInstancesToController([]instance.Id, string) error {
+	// This provider doesn't track instance -> controller.
+	return nil
+}
+
 func (e *environ) Destroy() (res error) {
 	defer delay()
 	estate, err := e.state()

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -887,7 +887,7 @@ func (e *environ) SetConfig(cfg *config.Config) error {
 }
 
 // MoveInstancesToController is part of the Environ interface.
-func (e *environ) MoveInstancesToController([]instance.Id, string) error {
+func (e *environ) MoveInstancesToController(ids []instance.Id, controllerUUID string) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }

--- a/provider/joyent/environ.go
+++ b/provider/joyent/environ.go
@@ -143,7 +143,7 @@ func (env *joyentEnviron) ControllerInstances(controllerUUID string) ([]instance
 }
 
 // MoveInstancesToController is part of the Environ interface.
-func (env *joyentEnviron) MoveInstancesToController([]instance.Id, string) error {
+func (env *joyentEnviron) MoveInstancesToController(ids []instance.Id, controllerUUID string) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }

--- a/provider/joyent/environ.go
+++ b/provider/joyent/environ.go
@@ -142,6 +142,12 @@ func (env *joyentEnviron) ControllerInstances(controllerUUID string) ([]instance
 	return instanceIds, nil
 }
 
+// MoveInstancesToController is part of the Environ interface.
+func (env *joyentEnviron) MoveInstancesToController([]instance.Id, string) error {
+	// This provider doesn't track instance -> controller.
+	return nil
+}
+
 func (env *joyentEnviron) Destroy() error {
 	return errors.Trace(common.Destroy(env))
 }

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -179,7 +179,7 @@ func (e *manualEnviron) verifyBootstrapHost() error {
 }
 
 // MoveInstancesToController implements environs.Environ.
-func (e *manualEnviron) MoveInstancesToController([]instance.Id, string) error {
+func (e *manualEnviron) MoveInstancesToController(ids []instance.Id, controllerUUID string) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -178,6 +178,12 @@ func (e *manualEnviron) verifyBootstrapHost() error {
 	return nil
 }
 
+// MoveInstancesToController implements environs.Environ.
+func (e *manualEnviron) MoveInstancesToController([]instance.Id, string) error {
+	// This provider doesn't track instance -> controller.
+	return nil
+}
+
 func (e *manualEnviron) SetConfig(cfg *config.Config) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -175,6 +175,11 @@ func (e *fakeEnviron) ControllerInstances(_ string) ([]instance.Id, error) {
 	return nil, nil
 }
 
+func (e *fakeEnviron) MoveInstancesToController([]instance.Id, string) error {
+	e.Push("MoveInstancesToController")
+	return nil
+}
+
 func (e *fakeEnviron) Destroy() error {
 	e.Push("Destroy")
 	return nil

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -175,7 +175,7 @@ func (e *fakeEnviron) ControllerInstances(_ string) ([]instance.Id, error) {
 	return nil, nil
 }
 
-func (e *fakeEnviron) MoveInstancesToController([]instance.Id, string) error {
+func (e *fakeEnviron) MoveInstancesToController(ids []instance.Id, controllerUUID string) error {
 	e.Push("MoveInstancesToController")
 	return nil
 }

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -122,7 +122,7 @@ func (env *environ) BootstrapMessage() string {
 var DestroyEnv = common.Destroy
 
 // MoveInstancesToController is part of the Environ interface.
-func (env *environ) MoveInstancesToController([]instance.Id, string) error {
+func (env *environ) MoveInstancesToController(ids []instance.Id, controllerUUID string) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -121,6 +121,12 @@ func (env *environ) BootstrapMessage() string {
 //this variable is exported, because it has to be rewritten in external unit tests
 var DestroyEnv = common.Destroy
 
+// MoveInstancesToController is part of the Environ interface.
+func (env *environ) MoveInstancesToController([]instance.Id, string) error {
+	// This provider doesn't track instance -> controller.
+	return nil
+}
+
 // Destroy shuts down all known machines and destroys the rest of the
 // known environment.
 func (env *environ) Destroy() error {

--- a/worker/leadership/tracker.go
+++ b/worker/leadership/tracker.go
@@ -55,7 +55,7 @@ func NewTracker(tag names.UnitTag, claimer leadership.Claimer, clock clock.Clock
 		claimTickets:      make(chan chan bool),
 		waitLeaderTickets: make(chan chan bool),
 		waitMinionTickets: make(chan chan bool),
-		isMinion:		   true,
+		isMinion:          true,
 	}
 	go func() {
 		defer t.tomb.Done()


### PR DESCRIPTION
Part of https://bugs.launchpad.net/juju/+bug/1648063

The provider Environ interface needs a new MoveInstancesToController method so that the migration master can update instance tags to refer to the new controller. I'll do this in phases - implement the method in each provider, then add it to the interface and use it from the migration master. This first step adds a do-nothing implementation to the providers that don't tag the instances with the controller.