### PR TITLE
[apiserver] Use existing certs for base tests.

### DIFF
--- a/apiserver/authhttp_test.go
+++ b/apiserver/authhttp_test.go
@@ -24,6 +24,7 @@ import (
 
 	apitesting "github.com/juju/juju/api/testing"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cert"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
@@ -53,6 +54,17 @@ type authHTTPSuite struct {
 	userTag      names.UserTag
 	password     string
 	extraHeaders map[string]string
+}
+
+func (s *authHTTPSuite) SetUpSuite(c *gc.C) {
+	if s.macaroonAuthEnabled {
+		s.MacaroonSuite.SetUpSuite(c)
+	} else {
+		// No macaroons, so don't enable them.
+		s.JujuConnSuite.SetUpSuite(c)
+	}
+	s.PatchValue(&cert.NewCA, testing.NewCA)
+	s.PatchValue(&cert.NewLeafKeyBits, 512)
 }
 
 func (s *authHTTPSuite) SetUpTest(c *gc.C) {

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/observer/fakeobserver"
 	"github.com/juju/juju/apiserver/params"
+	corecert "github.com/juju/juju/cert"
 	"github.com/juju/juju/controller"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
@@ -52,6 +53,12 @@ type serverSuite struct {
 }
 
 var _ = gc.Suite(&serverSuite{})
+
+func (s *serverSuite) SetUpSuite(c *gc.C) {
+	s.JujuConnSuite.SetUpSuite(c)
+	s.PatchValue(&corecert.NewCA, coretesting.NewCA)
+	s.PatchValue(&corecert.NewLeafKeyBits, 512)
+}
 
 func (s *serverSuite) TestStop(c *gc.C) {
 	// Start our own instance of the server so we have


### PR DESCRIPTION
Occasional timeouts with the race build. Smaller keys makes the generation much less CPU intensive.
