### PR TITLE
migrations: Add MoveInstancesToController to gce provider

### DIFF
--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -28,6 +28,7 @@ type gceConnection interface {
 	Instances(prefix string, statuses ...string) ([]google.Instance, error)
 	AddInstance(spec google.InstanceSpec, zones ...string) (*google.Instance, error)
 	RemoveInstances(prefix string, ids ...string) error
+	UpdateMetadata(key, value string, ids ...string) error
 
 	Ports(fwname string) ([]network.PortRange, error)
 	OpenPorts(fwname string, ports ...network.PortRange) error

--- a/provider/gce/environ_instance.go
+++ b/provider/gce/environ_instance.go
@@ -68,14 +68,19 @@ var getInstances = func(env *environ) ([]instance.Instance, error) {
 	return env.instances()
 }
 
+func (env *environ) gceInstances() ([]google.Instance, error) {
+	prefix := env.namespace.Prefix()
+	instances, err := env.gce.Instances(prefix, instStatuses...)
+	return instances, errors.Trace(err)
+}
+
 // instances returns a list of all "alive" instances in the environment.
 // This means only instances where the IDs match
 // "juju-<env name>-machine-*". This is important because otherwise juju
 // will see they are not tracked in state, assume they're stale/rogue,
 // and shut them down.
 func (env *environ) instances() ([]instance.Instance, error) {
-	prefix := env.namespace.Prefix()
-	instances, err := env.gce.Instances(prefix, instStatuses...)
+	instances, err := env.gceInstances()
 	err = errors.Trace(err)
 
 	// Turn google.Instance values into *environInstance values,
@@ -95,8 +100,7 @@ func (env *environ) instances() ([]instance.Instance, error) {
 // ControllerInstances returns the IDs of the instances corresponding
 // to juju controllers.
 func (env *environ) ControllerInstances(controllerUUID string) ([]instance.Id, error) {
-	prefix := env.namespace.Prefix()
-	instances, err := env.gce.Instances(prefix, instStatuses...)
+	instances, err := env.gceInstances()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -116,6 +120,15 @@ func (env *environ) ControllerInstances(controllerUUID string) ([]instance.Id, e
 		return nil, environs.ErrNotBootstrapped
 	}
 	return results, nil
+}
+
+// MoveInstancesToController is part of the environs.Environ interface.
+func (env *environ) MoveInstancesToController(ids []instance.Id, controllerUUID string) error {
+	stringIds := make([]string, len(ids))
+	for i, id := range ids {
+		stringIds[i] = string(id)
+	}
+	return errors.Trace(env.gce.UpdateMetadata(tags.JujuController, controllerUUID, stringIds...))
 }
 
 // TODO(ericsnow) Turn into an interface.

--- a/provider/gce/environ_instance_test.go
+++ b/provider/gce/environ_instance_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/gce"
 	"github.com/juju/juju/provider/gce/google"
@@ -199,4 +200,15 @@ func (s *environInstSuite) TestListMachineTypes(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(types.InstanceTypes, gc.HasLen, 1)
 
+}
+
+func (s *environInstSuite) TestMoveInstancesToController(c *gc.C) {
+	err := s.Env.MoveInstancesToController([]instance.Id{"john", "misty"}, "other-uuid")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.FakeConn.Calls, gc.HasLen, 1)
+	call := s.FakeConn.Calls[0]
+	c.Check(call.FuncName, gc.Equals, "UpdateMetadata")
+	c.Check(call.IDs, gc.DeepEquals, []string{"john", "misty"})
+	c.Check(call.Key, gc.Equals, tags.JujuController)
+	c.Check(call.Value, gc.Equals, "other-uuid")
 }

--- a/provider/gce/export_test.go
+++ b/provider/gce/export_test.go
@@ -22,8 +22,8 @@ var (
 	WindowsImageBasePath                              = windowsImageBasePath
 )
 
-func ExposeInstBase(inst *environInstance) *google.Instance {
-	return inst.base
+func ExposeInstBase(inst instance.Instance) *google.Instance {
+	return inst.(*environInstance).base
 }
 
 func ExposeInstEnv(inst *environInstance) *environ {

--- a/provider/gce/google/conn.go
+++ b/provider/gce/google/conn.go
@@ -31,6 +31,10 @@ type rawConnectionWrapper interface {
 	// with the provided ID (in the specified zone). The call blocks until
 	// the instance is removed (or the request fails).
 	RemoveInstance(projectID, id, zone string) error
+	// SetMetadata sends a request to the GCE API to update one
+	// instance's metadata. The call blocks until the request is
+	// completed or fails.
+	SetMetadata(projectID, zone, instanceID string, metadata *compute.Metadata) error
 	// GetFirewall sends an API request to GCE for the information about
 	// the named firewall and returns it. If the firewall is not found,
 	// errors.NotFound is returned.

--- a/provider/gce/google/raw.go
+++ b/provider/gce/google/raw.go
@@ -367,3 +367,13 @@ func (rc *rawConn) ListMachineTypes(projectID, zone string) (*compute.MachineTyp
 	}
 	return machines, nil
 }
+
+func (rc *rawConn) SetMetadata(projectID, zone, instanceID string, metadata *compute.Metadata) error {
+	call := rc.Instances.SetMetadata(projectID, zone, instanceID, metadata)
+	op, err := call.Do()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = rc.waitOperation(projectID, op, attemptsLong)
+	return errors.Trace(err)
+}

--- a/provider/gce/google/testing_test.go
+++ b/provider/gce/google/testing_test.go
@@ -97,10 +97,13 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 		Type:  network.IPv4Address,
 		Scope: network.ScopeCloudLocal,
 	}}
-	s.RawMetadata = compute.Metadata{Items: []*compute.MetadataItems{{
-		Key:   "eggs",
-		Value: "steak",
-	}}}
+	s.RawMetadata = compute.Metadata{
+		Items: []*compute.MetadataItems{{
+			Key:   "eggs",
+			Value: "steak",
+		}},
+		Fingerprint: "heymumwatchthis",
+	}
 	s.Metadata = map[string]string{
 		"eggs": "steak",
 	}
@@ -158,6 +161,7 @@ type fakeCall struct {
 	AttachedDisk *compute.AttachedDisk
 	DeviceName   string
 	ComputeDisk  *compute.Disk
+	Metadata     *compute.Metadata
 }
 
 type fakeConn struct {
@@ -458,4 +462,21 @@ func (rc *fakeConn) ListMachineTypes(projectID, zone string) (*compute.MachineTy
 	}
 	return &machineType, nil
 
+}
+
+func (rc *fakeConn) SetMetadata(projectID, zone, instanceID string, metadata *compute.Metadata) error {
+	call := fakeCall{
+		FuncName:   "SetMetadata",
+		ProjectID:  projectID,
+		ZoneName:   zone,
+		InstanceId: instanceID,
+		Metadata:   metadata,
+	}
+	rc.Calls = append(rc.Calls, call)
+
+	err := rc.Err
+	if len(rc.Calls) != rc.FailOnCall+1 {
+		err = nil
+	}
+	return err
 }

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -465,6 +465,8 @@ type fakeConnCall struct {
 	VolumeName   string
 	InstanceId   string
 	Mode         string
+	Key          string
+	Value        string
 }
 
 type fakeConn struct {
@@ -529,6 +531,16 @@ func (fc *fakeConn) RemoveInstances(prefix string, ids ...string) error {
 	fc.Calls = append(fc.Calls, fakeConnCall{
 		FuncName: "RemoveInstances",
 		Prefix:   prefix,
+		IDs:      ids,
+	})
+	return fc.err()
+}
+
+func (fc *fakeConn) UpdateMetadata(key, value string, ids ...string) error {
+	fc.Calls = append(fc.Calls, fakeConnCall{
+		FuncName: "UpdateMetadata",
+		Key:      key,
+		Value:    value,
 		IDs:      ids,
 	})
 	return fc.err()


### PR DESCRIPTION
Part of https://bugs.launchpad.net/juju/+bug/1648063

Implement MoveInstancesToController in the GCE provider using the GCE setMetadata method.
https://cloud.google.com/compute/docs/reference/latest/instances/setMetadata

QA steps - none, this code isn't runnable until the migration master is updated.