### PR TITLE
Serve the remote app icon URL, not the icon

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -393,6 +393,16 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 	logTransferHandler := newLogSinkHandler(httpCtxt, ioutil.Discard, newMigrationLoggingStrategy)
 	add("/migrate/logtransfer", srv.trackRequests(logTransferHandler))
 
+	modelRestHandler := &modelRestHandler{
+		ctxt:          httpCtxt,
+		dataDir:       srv.dataDir,
+		stateAuthFunc: httpCtxt.stateForRequestAuthenticatedUser,
+	}
+	modelRestServer := &RestHTTPHandler{
+		GetHandler: modelRestHandler.ServeGet,
+	}
+	add("/model/:modeluuid/rest/1.0/:entity/:name/:attribute", modelRestServer)
+
 	modelCharmsHandler := &charmsHandler{
 		ctxt:          httpCtxt,
 		dataDir:       srv.dataDir,

--- a/apiserver/application/application.go
+++ b/apiserver/application/application.go
@@ -7,6 +7,7 @@
 package application
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/juju/errors"
@@ -992,8 +993,7 @@ func (api *API) oneRemoteApplicationInfo(urlStr string) (*params.RemoteApplicati
 		ApplicationURL:   urlStr,
 		SourceModelLabel: offer.SourceLabel,
 		Endpoints:        offer.Endpoints,
-		// TODO(wallyworld)
-		Icon: []byte(common.DefaultCharmIcon),
+		IconURLPath:      fmt.Sprintf("rest/1.0/remote-application/%s/icon", url.ApplicationName),
 	}, nil
 }
 
@@ -1049,10 +1049,6 @@ func (api *API) sameControllerRemoteApplicationInfo(url jujucrossmodel.Applicati
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	icon, err := api.charmIcon(NewStateBackend(st), ch.URL())
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	return &params.RemoteApplicationInfo{
 		ModelTag:         sourceModelTag.String(),
 		Name:             application.Name(),
@@ -1060,7 +1056,7 @@ func (api *API) sameControllerRemoteApplicationInfo(url jujucrossmodel.Applicati
 		ApplicationURL:   url.String(),
 		SourceModelLabel: model.Name(),
 		Endpoints:        endpoints,
-		Icon:             icon,
+		IconURLPath:      fmt.Sprintf("rest/1.0/remote-application/%s/icon", url.ApplicationName),
 	}, nil
 }
 

--- a/apiserver/application/application_test.go
+++ b/apiserver/application/application_test.go
@@ -6,8 +6,6 @@ package application_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
-	"path/filepath"
 	"regexp"
 	"sync"
 	"time"
@@ -3054,9 +3052,6 @@ func (s *serviceSuite) TestRemoteApplicationInfo(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 3)
-	chpath := testcharms.Repo.CharmDirPath("mysql")
-	mysqlIcon, err := ioutil.ReadFile(filepath.Join(chpath, "icon.svg"))
-	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, jc.DeepEquals, []params.RemoteApplicationInfoResult{
 		{Result: &params.RemoteApplicationInfo{
 			ModelTag:         coretesting.ModelTag.String(),
@@ -3064,9 +3059,9 @@ func (s *serviceSuite) TestRemoteApplicationInfo(c *gc.C) {
 			Description:      "a database",
 			ApplicationURL:   "local:/u/me/hosted-mysql",
 			SourceModelLabel: "",
-			Icon:             []byte(common.DefaultCharmIcon),
 			Endpoints: []params.RemoteEndpoint{
 				{Name: "server", Role: "provider", Interface: "mysql", Limit: 0, Scope: "global"}},
+			IconURLPath: "rest/1.0/remote-application/hosted-mysql/icon",
 		}},
 		{Result: &params.RemoteApplicationInfo{
 			ModelTag:         s.otherModel.ModelTag().String(),
@@ -3074,7 +3069,7 @@ func (s *serviceSuite) TestRemoteApplicationInfo(c *gc.C) {
 			Description:      "A pretty popular database",
 			ApplicationURL:   "othermodel.mysql",
 			SourceModelLabel: "othermodel",
-			Icon:             mysqlIcon,
+			IconURLPath:      "rest/1.0/remote-application/mysql/icon",
 			Endpoints: []params.RemoteEndpoint{
 				{Name: "juju-info", Role: "provider", Interface: "juju-info", Limit: 0, Scope: "global"},
 				{Name: "server", Role: "provider", Interface: "mysql", Limit: 0, Scope: "global"}},

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -455,7 +455,8 @@ type RemoteApplicationInfo struct {
 	// rather than via an offer URL.
 	SourceModelLabel string           `json:"source-model-label,omitempty"`
 	Endpoints        []RemoteEndpoint `json:"endpoints"`
-	Icon             []byte           `json:"icon"`
+	// IconURLPath is relative to the model api endpoint
+	IconURLPath string `json:"icon-url-path"`
 }
 
 // RemoteApplicationInfoResult holds the result of loading

--- a/apiserver/rest.go
+++ b/apiserver/rest.go
@@ -1,0 +1,144 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"bytes"
+	"io"
+	"mime"
+	"net/http"
+	"strconv"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/storage"
+)
+
+// RestHTTPHandler creates is a http.Handler which serves ReST requests.
+type RestHTTPHandler struct {
+	GetHandler FailableHandlerFunc
+}
+
+// ServeHTTP is defined on handler.Handler.
+func (h *RestHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var err error
+	switch r.Method {
+	case "GET":
+		err = errors.Annotate(h.GetHandler(w, r), "cannot retrieve model data")
+	default:
+		err = emitUnsupportedMethodErr(r.Method)
+	}
+
+	if err != nil {
+		if err := sendJSONError(w, r, errors.Trace(err)); err != nil {
+			logger.Errorf("%v", errors.Annotate(err, "cannot return error to user"))
+		}
+	}
+}
+
+// modelRestHandler handles ReST requests through HTTPS in the API server.
+type modelRestHandler struct {
+	ctxt          httpContext
+	dataDir       string
+	stateAuthFunc func(*http.Request) (*state.State, error)
+}
+
+// ServeGet handles http GET requests.
+func (h *modelRestHandler) ServeGet(w http.ResponseWriter, r *http.Request) error {
+	if r.Method != "GET" {
+		return errors.Trace(emitUnsupportedMethodErr(r.Method))
+	}
+
+	st, _, err := h.ctxt.stateForRequestAuthenticated(r)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer h.ctxt.release(st)
+
+	return errors.Trace(h.processGet(r, w, st))
+}
+
+// processGet handles a ReST GET request after authentication.
+func (h *modelRestHandler) processGet(r *http.Request, w http.ResponseWriter, st *state.State) error {
+	query := r.URL.Query()
+	entity := query.Get(":entity")
+	// TODO(wallyworld) - support more than just "remote-application"
+	switch entity {
+	case "remote-application":
+		return h.processRemoteApplication(r, w, st)
+	default:
+		return errors.NotSupportedf("entity %v", entity)
+	}
+}
+
+// processRemoteApplication handles a request for attributes on remote applications.
+func (h *modelRestHandler) processRemoteApplication(r *http.Request, w http.ResponseWriter, st *state.State) error {
+	query := r.URL.Query()
+	name := query.Get(":name")
+	remoteApp, err := st.RemoteApplication(name)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	attribute := query.Get(":attribute")
+	// TODO(wallyworld) - support more than just "icon"
+	if attribute != "icon" {
+		return errors.NotSupportedf("attribute %v on entity %v", attribute, name)
+	}
+
+	// TODO(wallyworld) - for now, offername corresponds to the remoteApp name in the source model
+	// Get the backend state for the source model so we can lookup the app in that model to get the charm details.
+	offer := remoteApp.OfferName()
+	sourceModelUUID := remoteApp.SourceModel().Id()
+	sourceSt, err := h.ctxt.srv.statePool.Get(sourceModelUUID)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer h.ctxt.srv.statePool.Release(sourceModelUUID)
+
+	app, err := sourceSt.Application(offer)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	ch, _, err := app.Charm()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	store := storage.NewStorage(sourceSt.ModelUUID(), sourceSt.MongoSession())
+	// Use the storage to retrieve and save the charm archive.
+	charmPath, err := common.ReadCharmFromStorage(store, h.dataDir, ch.StoragePath())
+	if errors.IsNotFound(err) {
+		return h.byteSender(w, ".svg", []byte(common.DefaultCharmIcon))
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+	iconContents, err := common.CharmArchiveEntry(charmPath, "icon.svg", true)
+	if errors.IsNotFound(err) {
+		return h.byteSender(w, ".svg", []byte(common.DefaultCharmIcon))
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return h.byteSender(w, ".svg", iconContents)
+}
+
+func (h *modelRestHandler) byteSender(w http.ResponseWriter, ext string, contents []byte) error {
+	ctype := mime.TypeByExtension(ext)
+	if ctype != "" {
+		// Older mime.types may map .js to x-javascript.
+		// Map it to javascript for consistency.
+		if ctype == params.ContentTypeXJS {
+			ctype = params.ContentTypeJS
+		}
+		w.Header().Set("Content-Type", ctype)
+	}
+	w.Header().Set("Content-Length", strconv.Itoa(len(contents)))
+	w.WriteHeader(http.StatusOK)
+	io.Copy(w, bytes.NewReader(contents))
+	return nil
+}

--- a/apiserver/rest_test.go
+++ b/apiserver/rest_test.go
@@ -1,0 +1,233 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"mime"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"runtime"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testcharms"
+	jujuFactory "github.com/juju/juju/testing/factory"
+)
+
+// restCommonSuite wraps authHTTPSuite and adds
+// some helper methods suitable for working with the
+// charms endpoint.
+type restCommonSuite struct {
+	authHTTPSuite
+}
+
+func (s *restCommonSuite) restURL(c *gc.C, path string) *url.URL {
+	uri := s.baseURL(c)
+	uri.Path = fmt.Sprintf("/model/%s/rest/1.0/%s", s.modelUUID, path)
+	return uri
+}
+
+func (s *restCommonSuite) restURI(c *gc.C, path string) string {
+	return s.restURL(c, path).String()
+}
+
+func (s *restCommonSuite) assertGetFileResponse(c *gc.C, resp *http.Response, expBody, expContentType string) {
+	body := assertResponse(c, resp, http.StatusOK, expContentType)
+	c.Check(string(body), gc.Equals, expBody)
+}
+
+func (s *restCommonSuite) assertErrorResponse(c *gc.C, resp *http.Response, expCode int, expError string) {
+	charmResponse := s.assertResponse(c, resp, expCode)
+	c.Check(charmResponse.Error, gc.Matches, expError)
+}
+
+func (s *restCommonSuite) assertResponse(c *gc.C, resp *http.Response, expStatus int) params.CharmsResponse {
+	body := assertResponse(c, resp, expStatus, params.ContentTypeJSON)
+	var charmResponse params.CharmsResponse
+	err := json.Unmarshal(body, &charmResponse)
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf("body: %s", body))
+	return charmResponse
+}
+
+type restSuite struct {
+	restCommonSuite
+}
+
+var _ = gc.Suite(&restSuite{})
+
+func (s *restSuite) SetUpSuite(c *gc.C) {
+	if runtime.GOOS != "linux" {
+		c.Skip("apiservers only run on linux")
+	}
+	s.restCommonSuite.SetUpSuite(c)
+}
+
+func (s *restSuite) TestRestServedSecurely(c *gc.C) {
+	info := s.APIInfo(c)
+	uri := "http://" + info.Addrs[0] + "/rest"
+	s.sendRequest(c, httpRequestParams{
+		method:      "GET",
+		url:         uri,
+		expectError: `.*malformed HTTP response.*`,
+	})
+}
+
+func (s *restSuite) TestGETRequiresAuth(c *gc.C) {
+	resp := s.sendRequest(c, httpRequestParams{method: "GET", url: s.restURI(c, "entity/name/attribute")})
+	s.assertErrorResponse(c, resp, http.StatusUnauthorized, ".*no credentials provided$")
+}
+
+func (s *restSuite) TestRequiresGET(c *gc.C) {
+	resp := s.authRequest(c, httpRequestParams{method: "POST", url: s.restURI(c, "entity/name/attribute")})
+	s.assertErrorResponse(c, resp, http.StatusMethodNotAllowed, `unsupported method: "POST"`)
+}
+
+func (s *restSuite) TestGetReturnsNotFoundWhenMissing(c *gc.C) {
+	uri := s.restURI(c, "remote-application/foo/attribute")
+	resp := s.authRequest(c, httpRequestParams{method: "GET", url: uri})
+	s.assertErrorResponse(
+		c, resp, http.StatusNotFound,
+		`cannot retrieve model data: remote application "foo" not found`,
+	)
+}
+
+func (s *restSuite) charmsURI(c *gc.C, query string) string {
+	uri := s.baseURL(c)
+	uri.Path = fmt.Sprintf("/model/%s/charms", s.modelUUID)
+	uri.RawQuery = query
+	return uri.String()
+}
+
+func (s *restSuite) TestGetRemoteApplicationIcon(c *gc.C) {
+	// Setup the charm and mysql application in the default model.
+	ch := testcharms.Repo.CharmArchive(c.MkDir(), "mysql")
+	s.uploadRequest(c, s.charmsURI(c, "series=quantal"), "application/zip", ch.Path)
+	curl, err := charm.ParseURL(fmt.Sprintf("local:quantal/%s-%d", ch.Meta().Name, ch.Revision()))
+	c.Assert(err, jc.ErrorIsNil)
+	mysqlCh, err := s.State.Charm(curl)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddApplication(state.AddApplicationArgs{
+		Name:  "mysql",
+		Charm: mysqlCh,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	// Set up a charm entry for dummy app with no charm in storage.
+	factory := jujuFactory.NewFactory(s.State)
+	dummyCh := factory.MakeCharm(c, &jujuFactory.CharmParams{
+		Name: "dummy",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddApplication(state.AddApplicationArgs{
+		Name:  "dummy",
+		Charm: dummyCh,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Add remote applications to other model which we will query below.
+	otherModelState := s.setupOtherModel(c)
+	_, err = otherModelState.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "remote-app",
+		SourceModel: s.State.ModelTag(),
+		OfferName:   "mysql",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = otherModelState.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "notfound-remote-app",
+		SourceModel: s.State.ModelTag(),
+		OfferName:   "dummy",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Prepare the tests.
+	svgMimeType := mime.TypeByExtension(".svg")
+	iconPath := filepath.Join(testcharms.Repo.CharmDirPath("mysql"), "icon.svg")
+	icon, err := ioutil.ReadFile(iconPath)
+	c.Assert(err, jc.ErrorIsNil)
+	tests := []struct {
+		about      string
+		query      string
+		expectType string
+		expectBody string
+	}{{
+		about:      "icon found",
+		query:      "remote-application/remote-app/icon",
+		expectBody: string(icon),
+	}, {
+		about:      "icon not found",
+		query:      "remote-application/notfound-remote-app/icon",
+		expectBody: common.DefaultCharmIcon,
+	}}
+
+	for i, test := range tests {
+		c.Logf("\ntest %d: %s", i, test.about)
+		uri := s.restURI(c, test.query)
+		resp := s.authRequest(c, httpRequestParams{method: "GET", url: uri})
+		if test.expectType == "" {
+			test.expectType = svgMimeType
+		}
+		s.assertGetFileResponse(c, resp, test.expectBody, test.expectType)
+	}
+}
+
+func (s *restSuite) TestGetRejectsWrongModelUUIDPath(c *gc.C) {
+	url := s.restURL(c, "")
+	url.Path = "/model/dead-beef-123456/rest/1.0/remote-application/foo/icon"
+	resp := s.authRequest(c, httpRequestParams{method: "GET", url: url.String()})
+	s.assertErrorResponse(c, resp, http.StatusNotFound, `.*unknown model: "dead-beef-123456"$`)
+}
+
+type restWithMacaroonsSuite struct {
+	restCommonSuite
+}
+
+var _ = gc.Suite(&restWithMacaroonsSuite{})
+
+func (s *restWithMacaroonsSuite) SetUpTest(c *gc.C) {
+	s.macaroonAuthEnabled = true
+	s.authHTTPSuite.SetUpTest(c)
+}
+
+func (s *restWithMacaroonsSuite) TestWithNoBasicAuthReturnsDischargeRequiredError(c *gc.C) {
+	resp := s.sendRequest(c, httpRequestParams{
+		method: "GET",
+		url:    s.restURI(c, "remote-application/foo/icon"),
+	})
+
+	restResponse := s.assertResponse(c, resp, http.StatusUnauthorized)
+	c.Assert(restResponse.Error, gc.Matches, ".*verification failed: no macaroons$")
+	c.Assert(restResponse.ErrorCode, gc.Equals, params.CodeDischargeRequired)
+	c.Assert(restResponse.ErrorInfo, gc.NotNil)
+	c.Assert(restResponse.ErrorInfo.Macaroon, gc.NotNil)
+}
+
+func (s *restWithMacaroonsSuite) TestGetWithDischargedMacaroon(c *gc.C) {
+	checkCount := 0
+	s.DischargerLogin = func() string {
+		checkCount++
+		return s.userTag.Id()
+	}
+	resp := s.sendRequest(c, httpRequestParams{
+		do:          s.doer(),
+		method:      "GET",
+		url:         s.restURI(c, "remote-application/foo/icon"),
+		contentType: "foo/bar",
+	})
+	s.assertErrorResponse(c, resp, http.StatusNotFound, `cannot retrieve model data: remote application "foo" not found`)
+	c.Assert(checkCount, gc.Equals, 1)
+}
+
+// doer returns a Do function that can make a bakery request
+// appropriate for a charms endpoint.
+func (s *restWithMacaroonsSuite) doer() func(*http.Request) (*http.Response, error) {
+	return bakeryDo(nil, charmsBakeryGetError)
+}


### PR DESCRIPTION
The Application facade RemoteApplicationInfo call is changed to provide a relative URL for the application icon, not the icon itself. This is due to limitations in the GUI.

To allow the GUI to query the URL and get the icon, we provide a new authenticated http endpoint on the controller: "/rest/1.0/...". We have the future possibility to support a ReST API on the controller, but for now we just support what's needed for retrieving remote application icons. The full URL path will be:
<apiserver>/model/:uuid/rest/1.0/remote-application/:name/icon

QA: smoke test bootstrap. The RemoteApplicationInfo API is not used anywhere in production.
