### PR TITLE
Generate LXD https host strings and default x509 certificates.

### DIFF
--- a/cert/cert.go
+++ b/cert/cert.go
@@ -58,6 +58,21 @@ func ParseCertAndKey(certPEM, keyPEM string) (*x509.Certificate, *rsa.PrivateKey
 	return cert, key, nil
 }
 
+// Generate public key from keyPEM string
+func ComputePublicKey(certPEM string) (string, error){
+	cert, err := ParseCert(certPEM)
+	if err != nil {
+		return "", err
+	}
+	pubKey := cert.PublicKey.(interface {})
+	marshalledPubKey, _ := x509.MarshalPKIXPublicKey(pubKey)
+	keyPEMData := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PUBLIC KEY",
+		Bytes: marshalledPubKey,
+	})
+	return string(keyPEMData), nil
+}
+
 // Verify verifies that the given server certificate is valid with
 // respect to the given CA certificate at the given time.
 func Verify(srvCertPEM, caCertPEM string, when time.Time) error {

--- a/juju/home.go
+++ b/juju/home.go
@@ -4,10 +4,16 @@
 package juju
 
 import (
+	"os"
+	"time"
+	"io/ioutil"
+
 	"github.com/juju/errors"
+	"github.com/juju/utils"
 	"github.com/juju/utils/ssh"
 	"gopkg.in/juju/charmrepo.v2-unstable"
 
+	"github.com/juju/juju/cert"
 	"github.com/juju/juju/juju/osenv"
 )
 
@@ -22,6 +28,22 @@ func InitJujuXDGDataHome() error {
 	charmrepo.CacheDir = osenv.JujuXDGDataHomePath("charmcache")
 	if err := ssh.LoadClientKeys(osenv.JujuXDGDataHomePath("ssh")); err != nil {
 		return errors.Annotate(err, "cannot load ssh client keys")
+	}
+	expiry := time.Now().UTC().AddDate(10, 0, 0)
+	uuid, _ := utils.NewUUID()
+	certdir := osenv.JujuXDGDataHomePath("x509")
+	if certdir != "" {
+		err := os.MkdirAll(certdir, 0700)
+		if err == nil {
+			pem, key, err := cert.NewCA("client", uuid.String(), expiry)
+			public, err := cert.ComputePublicKey(pem)
+			err = ioutil.WriteFile(certdir + "/juju-cert.pem", []byte(pem), 0600)
+			err = ioutil.WriteFile(certdir + "/juju-cert.key", []byte(key), 0600)
+			err = ioutil.WriteFile(certdir + "/juju-cert.pub", []byte(public), 0600)
+			if err != nil {
+				return errors.Annotate(err, "cannot write x509 certificate")
+			}
+		}
 	}
 	return nil
 }

--- a/tools/lxdclient/client_test.go
+++ b/tools/lxdclient/client_test.go
@@ -15,6 +15,7 @@ import (
 	jujuos "github.com/juju/utils/os"
 	"github.com/lxc/lxd"
 	gc "gopkg.in/check.v1"
+	"strings"
 )
 
 type ConnectSuite struct {
@@ -241,4 +242,25 @@ var testerr = errors.Errorf("boo!")
 
 func fakeNewClientFromInfo(info lxd.ConnectInfo) (*lxd.Client, error) {
 	return nil, testerr
+}
+
+func (cs *ConnectSuite) TestIsLocalhost(c *gc.C) {
+	out, err := isLocalhost("127.0.0.1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out, gc.Equals, true)
+}
+
+func (cs *ConnectSuite) TestIsNotLocalhost(c *gc.C) {
+	out, err := isLocalhost("8.8.8.8")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out, gc.Equals, true)
+}
+
+func (cs *ConnectSuite) TestGenerateUnixHostString(c *gc.C){
+	host := generateHostString(remoteLocalName, "127.0.0.1")
+	c.Assert(strings.HasPrefix(host, "unix://"), gc.Equals, true)
+}
+func (cs *ConnectSuite) TestGenerateHTTPSHostString(c *gc.C){
+	host := generateHostString(remoteLocalName, "8.8.8.8")
+	c.Assert(strings.HasPrefix(host, "https://"), gc.Equals, true)
 }


### PR DESCRIPTION
These two commits opens the way to setup https remote strings in LXD, as well as dumping
a default x509 certificate in the config folder to be able to be able to use it afterwards.