### PR TITLE
Use the fast certs in the JujuConnSuite.

### DIFF
--- a/apiserver/authhttp_test.go
+++ b/apiserver/authhttp_test.go
@@ -24,7 +24,6 @@ import (
 
 	apitesting "github.com/juju/juju/api/testing"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/cert"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
@@ -54,17 +53,6 @@ type authHTTPSuite struct {
 	userTag      names.UserTag
 	password     string
 	extraHeaders map[string]string
-}
-
-func (s *authHTTPSuite) SetUpSuite(c *gc.C) {
-	if s.macaroonAuthEnabled {
-		s.MacaroonSuite.SetUpSuite(c)
-	} else {
-		// No macaroons, so don't enable them.
-		s.JujuConnSuite.SetUpSuite(c)
-	}
-	s.PatchValue(&cert.NewCA, testing.NewCA)
-	s.PatchValue(&cert.NewLeafKeyBits, 512)
 }
 
 func (s *authHTTPSuite) SetUpTest(c *gc.C) {

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/observer/fakeobserver"
 	"github.com/juju/juju/apiserver/params"
-	corecert "github.com/juju/juju/cert"
 	"github.com/juju/juju/controller"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
@@ -53,12 +52,6 @@ type serverSuite struct {
 }
 
 var _ = gc.Suite(&serverSuite{})
-
-func (s *serverSuite) SetUpSuite(c *gc.C) {
-	s.JujuConnSuite.SetUpSuite(c)
-	s.PatchValue(&corecert.NewCA, coretesting.NewCA)
-	s.PatchValue(&corecert.NewLeafKeyBits, 512)
-}
 
 func (s *serverSuite) TestStop(c *gc.C) {
 	// Start our own instance of the server so we have

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	apideployer "github.com/juju/juju/api/deployer"
-	"github.com/juju/juju/cert"
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/environs"
@@ -67,8 +66,6 @@ func (s *commonMachineSuite) SetUpSuite(c *gc.C) {
 	s.AgentSuite.SetUpSuite(c)
 	s.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	s.PatchValue(&stateWorkerDialOpts, mongotest.DialOpts())
-	s.PatchValue(&cert.NewCA, coretesting.NewCA)
-	s.PatchValue(&cert.NewLeafKeyBits, 512)
 }
 
 func (s *commonMachineSuite) TearDownSuite(c *gc.C) {

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/cert"
 	agentcmd "github.com/juju/juju/cmd/jujud/agent"
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
@@ -57,12 +56,6 @@ var ShortAttempt = &utils.AttemptStrategy{
 type upgradeSuite struct {
 	agenttest.AgentSuite
 	oldVersion version.Binary
-}
-
-func (s *upgradeSuite) SetUpSuite(c *gc.C) {
-	s.AgentSuite.SetUpSuite(c)
-	s.PatchValue(&cert.NewCA, coretesting.NewCA)
-	s.PatchValue(&cert.NewLeafKeyBits, 512)
 }
 
 func (s *upgradeSuite) SetUpTest(c *gc.C) {

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/cert"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/controller"
@@ -112,6 +113,8 @@ func (s *JujuConnSuite) SetUpSuite(c *gc.C) {
 	s.MgoSuite.SetUpSuite(c)
 	s.FakeJujuXDGDataHomeSuite.SetUpSuite(c)
 	s.PatchValue(&utils.OutgoingAccessAllowed, false)
+	s.PatchValue(&cert.NewCA, testing.NewCA)
+	s.PatchValue(&cert.NewLeafKeyBits, 512)
 }
 
 func (s *JujuConnSuite) TearDownSuite(c *gc.C) {


### PR DESCRIPTION
Make all JujuConnSuite tests use the pregenerated CACerts and smaller server keys.