### PR TITLE
provider/azure: create common resources once only

### DIFF
--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	"github.com/Azure/azure-sdk-for-go/arm/network"
@@ -20,6 +21,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/os"
 	jujuseries "github.com/juju/utils/series"
@@ -97,11 +99,12 @@ type azureEnviron struct {
 	storageClient      azurestorage.Client
 	storageAccountName string
 
-	mu                sync.Mutex
-	config            *azureModelConfig
-	instanceTypes     map[string]instances.InstanceType
-	storageAccount    *storage.Account
-	storageAccountKey *storage.AccountKey
+	mu                     sync.Mutex
+	config                 *azureModelConfig
+	instanceTypes          map[string]instances.InstanceType
+	storageAccount         *storage.Account
+	storageAccountKey      *storage.AccountKey
+	commonResourcesCreated bool
 }
 
 var _ environs.Environ = (*azureEnviron)(nil)
@@ -207,7 +210,7 @@ func (env *azureEnviron) Create(args environs.CreateParams) error {
 	if err := verifyCredentials(env); err != nil {
 		return errors.Trace(err)
 	}
-	return errors.Trace(env.initResourceGroup(args.ControllerUUID))
+	return errors.Trace(env.initResourceGroup(args.ControllerUUID, false))
 }
 
 // Bootstrap is part of the Environ interface.
@@ -215,7 +218,7 @@ func (env *azureEnviron) Bootstrap(
 	ctx environs.BootstrapContext,
 	args environs.BootstrapParams,
 ) (*environs.BootstrapResult, error) {
-	if err := env.initResourceGroup(args.ControllerConfig.ControllerUUID()); err != nil {
+	if err := env.initResourceGroup(args.ControllerConfig.ControllerUUID(), true); err != nil {
 		return nil, errors.Annotate(err, "creating controller resource group")
 	}
 	result, err := common.Bootstrap(ctx, env, args)
@@ -235,8 +238,7 @@ func (env *azureEnviron) BootstrapMessage() string {
 }
 
 // initResourceGroup creates a resource group for this environment.
-func (env *azureEnviron) initResourceGroup(controllerUUID string) error {
-	location := env.location
+func (env *azureEnviron) initResourceGroup(controllerUUID string, controller bool) error {
 	resourceGroupsClient := resources.GroupsClient{env.resources}
 
 	env.mu.Lock()
@@ -245,17 +247,72 @@ func (env *azureEnviron) initResourceGroup(controllerUUID string) error {
 		names.NewControllerTag(controllerUUID),
 		env.config,
 	)
+	storageAccountType := env.config.storageAccountType
 	env.mu.Unlock()
 
 	logger.Debugf("creating resource group %q", env.resourceGroup)
 	err := env.callAPI(func() (autorest.Response, error) {
 		group, err := resourceGroupsClient.CreateOrUpdate(env.resourceGroup, resources.ResourceGroup{
-			Location: to.StringPtr(location),
+			Location: to.StringPtr(env.location),
 			Tags:     to.StringMapPtr(tags),
 		})
 		return group.Response, err
 	})
-	return errors.Annotate(err, "creating resource group")
+	if err != nil {
+		return errors.Annotate(err, "creating resource group")
+	}
+
+	if !controller {
+		// When we create a resource group for a non-controller model,
+		// we must create the common resources up-front. This is so
+		// that parallel deployments do not affect dynamic changes,
+		// e.g. those made by the firewaller. For the controller model,
+		// we fold the creation of these resources into the bootstrap
+		// machine's deployment.
+		if err := env.createCommonResourceDeployment(
+			tags, storageAccountType, nil,
+		); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+func (env *azureEnviron) createCommonResourceDeployment(
+	tags map[string]string,
+	storageAccountType string,
+	rules []network.SecurityRule,
+) error {
+	const apiPort = -1
+	commonResources := networkTemplateResources(
+		env.location, tags, apiPort, rules,
+	)
+	commonResources = append(commonResources, storageAccountTemplateResource(
+		env.location, tags,
+		env.storageAccountName,
+		storageAccountType,
+	))
+
+	// We perform this deployment asynchronously, to avoid blocking
+	// the "juju add-model" command; Create is called synchronously.
+	// Eventually we should have Create called asynchronously, but
+	// until then we do this, and ensure that the deployment has
+	// completed before we schedule additional deployments.
+	deploymentsClient := resources.DeploymentsClient{env.resources}
+	deploymentsClient.ResponseInspector = asyncCreationRespondDecorator(
+		deploymentsClient.ResponseInspector,
+	)
+	template := armtemplates.Template{Resources: commonResources}
+	if err := createDeployment(
+		env.callAPI,
+		deploymentsClient,
+		env.resourceGroup,
+		"common", // deployment name
+		template,
+	); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 // ControllerInstances is specified in the Environ interface.
@@ -516,11 +573,35 @@ func (env *azureEnviron) createVirtualMachine(
 		}
 		apiPort = apiPorts[0]
 	}
-	resources := networkTemplateResources(env.location, envTags, apiPort)
-	resources = append(resources, storageAccountTemplateResource(
-		env.location, envTags,
-		env.storageAccountName, storageAccountType,
-	))
+
+	var nicDependsOn, vmDependsOn []string
+	var resources []armtemplates.Resource
+	createCommonResources := instanceConfig.Bootstrap != nil
+	if createCommonResources {
+		// We're starting the bootstrap machine, so we will create the
+		// common resources in the same deployment.
+		commonResources := networkTemplateResources(env.location, envTags, apiPort, nil)
+		commonResources = append(commonResources, storageAccountTemplateResource(
+			env.location, envTags,
+			env.storageAccountName, storageAccountType,
+		))
+		resources = append(resources, commonResources...)
+		nicDependsOn = append(nicDependsOn, fmt.Sprintf(
+			`[resourceId('Microsoft.Network/virtualNetworks', '%s')]`,
+			internalNetworkName,
+		))
+		vmDependsOn = append(vmDependsOn, fmt.Sprintf(
+			`[resourceId('Microsoft.Storage/storageAccounts', '%s')]`,
+			env.storageAccountName,
+		))
+	} else {
+		// Wait for the common resource deployment to complete.
+		if err := env.waitCommonResourcesCreated(); err != nil {
+			return errors.Annotate(
+				err, "waiting for common resources to be created",
+			)
+		}
+	}
 
 	osProfile, seriesOS, err := newOSProfile(
 		vmName, instanceConfig,
@@ -534,7 +615,6 @@ func (env *azureEnviron) createVirtualMachine(
 		return errors.Annotate(err, "creating storage profile")
 	}
 
-	var vmDependsOn []string
 	var availabilitySetSubResource *compute.SubResource
 	availabilitySetName, err := availabilitySetName(
 		vmName, vmTags, instanceConfig.Controller != nil,
@@ -593,6 +673,7 @@ func (env *azureEnviron) createVirtualMachine(
 	}
 	nicName := vmName + "-primary"
 	nicId := fmt.Sprintf(`[resourceId('Microsoft.Network/networkInterfaces', '%s')]`, nicName)
+	nicDependsOn = append(nicDependsOn, publicIPAddressId)
 	ipConfigurations := []network.InterfaceIPConfiguration{{
 		Name: to.StringPtr("primary"),
 		Properties: &network.InterfaceIPConfigurationPropertiesFormat{
@@ -614,13 +695,7 @@ func (env *azureEnviron) createVirtualMachine(
 		Properties: &network.InterfacePropertiesFormat{
 			IPConfigurations: &ipConfigurations,
 		},
-		DependsOn: []string{
-			publicIPAddressId,
-			fmt.Sprintf(
-				`[resourceId('Microsoft.Network/virtualNetworks', '%s')]`,
-				internalNetworkName,
-			),
-		},
+		DependsOn: nicDependsOn,
 	})
 
 	nics := []compute.NetworkInterfaceReference{{
@@ -630,10 +705,6 @@ func (env *azureEnviron) createVirtualMachine(
 		},
 	}}
 	vmDependsOn = append(vmDependsOn, nicId)
-	vmDependsOn = append(vmDependsOn, fmt.Sprintf(
-		`[resourceId('Microsoft.Storage/storageAccounts', '%s')]`,
-		env.storageAccountName,
-	))
 	resources = append(resources, armtemplates.Resource{
 		APIVersion: compute.APIVersion,
 		Type:       "Microsoft.Compute/virtualMachines",
@@ -696,6 +767,69 @@ func (env *azureEnviron) createVirtualMachine(
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+// waitCommonResourcesCreated waits for the "common" deployment to complete.
+func (env *azureEnviron) waitCommonResourcesCreated() error {
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	if env.commonResourcesCreated {
+		return nil
+	}
+	if err := env.waitCommonResourcesCreatedLocked(); err != nil {
+		return errors.Trace(err)
+	}
+	env.commonResourcesCreated = true
+	return nil
+}
+
+func (env *azureEnviron) waitCommonResourcesCreatedLocked() error {
+	deploymentsClient := resources.DeploymentsClient{env.resources}
+
+	// Release the lock while we're waiting, to avoid blocking others.
+	env.mu.Unlock()
+	defer env.mu.Lock()
+
+	// Wait for up to 5 minutes, with a 5 second polling interval,
+	// for the "common" deployment to be in one of the terminal
+	// states. The deployment typically takes only around 30 seconds,
+	// but we allow for a longer duration to be defensive.
+	attempt := utils.AttemptStrategy{
+		Total: 5 * time.Minute,
+		Delay: 5 * time.Second,
+	}
+	for a := attempt.Start(); a.Next(); {
+		var result resources.DeploymentExtended
+		if err := env.callAPI(func() (autorest.Response, error) {
+			var err error
+			result, err = deploymentsClient.Get(env.resourceGroup, "common")
+			return result.Response, err
+		}); err != nil {
+			if result.StatusCode == http.StatusNotFound {
+				// The controller model does not have a "common"
+				// deployment, as its common resources are created
+				// in the machine-0 deployment to keep bootstrap times
+				// optimal. Treat lack of a common deployment as an
+				// indication that the model is the controller model.
+				return nil
+			}
+			return errors.Annotate(err, "querying common deployment")
+		}
+		if result.Properties == nil {
+			continue
+		}
+		switch state := to.String(result.Properties.ProvisioningState); state {
+		case "Succeeded":
+			// The deployment has succeeded, so the resources are
+			// ready for use.
+			return nil
+		case "Canceled", "Failed", "Deleted":
+			return errors.Errorf(
+				"common resource deployment status is %q", state,
+			)
+		}
+	}
+	return errors.Errorf("timed out waiting for common resources to be created")
 }
 
 // createAvailabilitySet creates the availability set for a machine to use

--- a/provider/azure/upgrades.go
+++ b/provider/azure/upgrades.go
@@ -1,0 +1,115 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azure
+
+import (
+	"github.com/Azure/azure-sdk-for-go/arm/compute"
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/juju/errors"
+	"github.com/juju/version"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/tags"
+)
+
+// UpgradeOperations is part of the upgrades.OperationSource interface.
+func (env *azureEnviron) UpgradeOperations() []environs.UpgradeOperation {
+	return []environs.UpgradeOperation{{
+		version.MustParse("2.2-alpha1"),
+		[]environs.UpgradeStep{
+			commonDeploymentUpgradeStep{env},
+		},
+	}}
+}
+
+// commonDeploymentUpgradeStep adds a "common" deployment to each
+// Environ corresponding to non-controller models.
+type commonDeploymentUpgradeStep struct {
+	env *azureEnviron
+}
+
+// Description is part of the environs.UpgradeStep interface.
+func (commonDeploymentUpgradeStep) Description() string {
+	return "Create common resource deployment"
+}
+
+// Run is part of the environs.UpgradeStep interface.
+func (step commonDeploymentUpgradeStep) Run() error {
+	env := step.env
+	isControllerEnviron, err := isControllerEnviron(env)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if isControllerEnviron {
+		// We only need to create the deployment for
+		// non-controller Environs.
+		return nil
+	}
+
+	// Identify the network security rules that exist already.
+	// We will add these, excluding the SSH/API rules, to the
+	// network security group template created in the deployment
+	// below.
+	nsgClient := network.SecurityGroupsClient{env.network}
+	allRules, err := networkSecurityRules(
+		nsgClient, env.callAPI, env.resourceGroup,
+	)
+	if errors.IsNotFound(err) {
+		allRules = nil
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+	var rules []network.SecurityRule
+	for _, rule := range allRules {
+		switch to.String(rule.Name) {
+		case to.String(sshSecurityRule.Name):
+		case to.String(apiSecurityRule.Name):
+		default:
+			rules = append(rules, rule)
+		}
+	}
+
+	env.mu.Lock()
+	storageAccountType := env.config.storageAccountType
+	env.mu.Unlock()
+	return env.createCommonResourceDeployment(
+		nil, storageAccountType, rules,
+	)
+}
+
+func isControllerEnviron(env *azureEnviron) (bool, error) {
+	if env.envName != "controller" {
+		// At the time of writing, the controller model name is
+		// hard-coded to "controller". If/when this changes, we
+		// must drop this check.
+		return false, nil
+	}
+
+	// Look for a machine with the "juju-is-controller" tag set to "true".
+	client := compute.VirtualMachinesClient{env.compute}
+	var result compute.VirtualMachineListResult
+	if err := env.callAPI(func() (autorest.Response, error) {
+		var err error
+		result, err = client.List(env.resourceGroup)
+		return result.Response, err
+	}); err != nil {
+		return false, errors.Annotate(err, "listing virtual machines")
+	}
+
+	if result.Value == nil {
+		// No machines implies this is not the controller model, as
+		// there must be a controller machine for the upgrades to be
+		// running!
+		return false, nil
+	}
+
+	for _, vm := range *result.Value {
+		if toTags(vm.Tags)[tags.JujuIsController] == "true" {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/provider/azure/upgrades.go
+++ b/provider/azure/upgrades.go
@@ -81,13 +81,6 @@ func (step commonDeploymentUpgradeStep) Run() error {
 }
 
 func isControllerEnviron(env *azureEnviron) (bool, error) {
-	if env.envName != "controller" {
-		// At the time of writing, the controller model name is
-		// hard-coded to "controller". If/when this changes, we
-		// must drop this check.
-		return false, nil
-	}
-
 	// Look for a machine with the "juju-is-controller" tag set to "true".
 	client := compute.VirtualMachinesClient{env.compute}
 	var result compute.VirtualMachineListResult

--- a/provider/azure/upgrades_test.go
+++ b/provider/azure/upgrades_test.go
@@ -101,13 +101,15 @@ func (s *environUpgradeSuite) TestEnvironUpgradeOperationCreateCommonDeployment(
 		},
 	}
 
+	vmListSender := azuretesting.NewSenderWithValue(&compute.VirtualMachineListResult{})
+	vmListSender.PathPattern = ".*/virtualMachines"
 	nsgSender := azuretesting.NewSenderWithValue(&nsg)
 	nsgSender.PathPattern = ".*/networkSecurityGroups/juju-internal-nsg"
 	deploymentSender := azuretesting.NewSenderWithValue(&resources.Deployment{})
 	deploymentSender.PathPattern = ".*/deployments/common"
-	s.sender = append(s.sender, nsgSender, deploymentSender)
+	s.sender = append(s.sender, vmListSender, nsgSender, deploymentSender)
 	c.Assert(op0.Steps[0].Run(), jc.ErrorIsNil)
-	c.Assert(s.requests, gc.HasLen, 2)
+	c.Assert(s.requests, gc.HasLen, 3)
 
 	expectedSecurityRules := []network.SecurityRule{{
 		Name: to.StringPtr("SSHInbound"),
@@ -171,7 +173,7 @@ func (s *environUpgradeSuite) TestEnvironUpgradeOperationCreateCommonDeployment(
 	}}
 
 	var actual resources.Deployment
-	unmarshalRequestBody(c, s.requests[1], &actual)
+	unmarshalRequestBody(c, s.requests[2], &actual)
 	c.Assert(actual.Properties, gc.NotNil)
 	c.Assert(actual.Properties.Template, gc.NotNil)
 	resources := (*actual.Properties.Template)["resources"].([]interface{})

--- a/provider/azure/upgrades_test.go
+++ b/provider/azure/upgrades_test.go
@@ -1,0 +1,203 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azure_test
+
+import (
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/arm/compute"
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/Azure/azure-sdk-for-go/arm/resources/resources"
+	"github.com/Azure/azure-sdk-for-go/arm/storage"
+	"github.com/Azure/go-autorest/autorest/to"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/provider/azure"
+	"github.com/juju/juju/provider/azure/internal/armtemplates"
+	"github.com/juju/juju/provider/azure/internal/azuretesting"
+	"github.com/juju/juju/testing"
+	"github.com/juju/version"
+)
+
+type environUpgradeSuite struct {
+	testing.BaseSuite
+
+	requests []*http.Request
+	sender   azuretesting.Senders
+	provider environs.EnvironProvider
+	env      environs.Environ
+}
+
+var _ = gc.Suite(&environUpgradeSuite{})
+
+func (s *environUpgradeSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.sender = nil
+	s.requests = nil
+
+	s.provider = newProvider(c, azure.ProviderConfig{
+		Sender:                     azuretesting.NewSerialSender(&s.sender),
+		RequestInspector:           azuretesting.RequestRecorder(&s.requests),
+		RandomWindowsAdminPassword: func() string { return "sorandom" },
+	})
+	s.env = openEnviron(c, s.provider, &s.sender)
+}
+
+func (s *environUpgradeSuite) TestEnvironImplementsUpgrader(c *gc.C) {
+	c.Assert(s.env, gc.Implements, new(environs.Upgrader))
+}
+
+func (s *environUpgradeSuite) TestEnvironUpgradeOperations(c *gc.C) {
+	upgrader := s.env.(environs.Upgrader)
+	ops := upgrader.UpgradeOperations()
+	c.Assert(ops, gc.HasLen, 1)
+	c.Assert(ops[0].TargetVersion, gc.Equals, version.MustParse("2.2-alpha1"))
+	c.Assert(ops[0].Steps, gc.HasLen, 1)
+	c.Assert(ops[0].Steps[0].Description(), gc.Equals, "Create common resource deployment")
+}
+
+func (s *environUpgradeSuite) TestEnvironUpgradeOperationCreateCommonDeployment(c *gc.C) {
+	upgrader := s.env.(environs.Upgrader)
+	op0 := upgrader.UpgradeOperations()[0]
+
+	// The existing NSG has two rules: one for Juju API traffic,
+	// and an application-specific rule. Only the latter should
+	// be preserved; we will recreate the "builtin" SSH rule,
+	// and the API rule is not needed for non-controller models.
+	customRule := network.SecurityRule{
+		Name: to.StringPtr("machine-0-tcp-1234"),
+		Properties: &network.SecurityRulePropertiesFormat{
+			Description:              to.StringPtr("custom rule"),
+			Protocol:                 network.TCP,
+			SourceAddressPrefix:      to.StringPtr("*"),
+			SourcePortRange:          to.StringPtr("*"),
+			DestinationAddressPrefix: to.StringPtr("*"),
+			DestinationPortRange:     to.StringPtr("1234"),
+			Access:                   network.Allow,
+			Priority:                 to.Int32Ptr(102),
+			Direction:                network.Inbound,
+		},
+	}
+	securityRules := []network.SecurityRule{{
+		Name: to.StringPtr("JujuAPIInbound"),
+		Properties: &network.SecurityRulePropertiesFormat{
+			Description:              to.StringPtr("Allow API connections to controller machines"),
+			Protocol:                 network.TCP,
+			SourceAddressPrefix:      to.StringPtr("*"),
+			SourcePortRange:          to.StringPtr("*"),
+			DestinationAddressPrefix: to.StringPtr("192.168.16.0/20"),
+			DestinationPortRange:     to.StringPtr("17777"),
+			Access:                   network.Allow,
+			Priority:                 to.Int32Ptr(101),
+			Direction:                network.Inbound,
+		},
+	}, customRule}
+	nsg := network.SecurityGroup{
+		Properties: &network.SecurityGroupPropertiesFormat{
+			SecurityRules: &securityRules,
+		},
+	}
+
+	nsgSender := azuretesting.NewSenderWithValue(&nsg)
+	nsgSender.PathPattern = ".*/networkSecurityGroups/juju-internal-nsg"
+	deploymentSender := azuretesting.NewSenderWithValue(&resources.Deployment{})
+	deploymentSender.PathPattern = ".*/deployments/common"
+	s.sender = append(s.sender, nsgSender, deploymentSender)
+	c.Assert(op0.Steps[0].Run(), jc.ErrorIsNil)
+	c.Assert(s.requests, gc.HasLen, 2)
+
+	expectedSecurityRules := []network.SecurityRule{{
+		Name: to.StringPtr("SSHInbound"),
+		Properties: &network.SecurityRulePropertiesFormat{
+			Description:              to.StringPtr("Allow SSH access to all machines"),
+			Protocol:                 network.TCP,
+			SourceAddressPrefix:      to.StringPtr("*"),
+			SourcePortRange:          to.StringPtr("*"),
+			DestinationAddressPrefix: to.StringPtr("*"),
+			DestinationPortRange:     to.StringPtr("22"),
+			Access:                   network.Allow,
+			Priority:                 to.Int32Ptr(100),
+			Direction:                network.Inbound,
+		},
+	}, customRule}
+	nsgId := `[resourceId('Microsoft.Network/networkSecurityGroups', 'juju-internal-nsg')]`
+	subnets := []network.Subnet{{
+		Name: to.StringPtr("juju-internal-subnet"),
+		Properties: &network.SubnetPropertiesFormat{
+			AddressPrefix: to.StringPtr("192.168.0.0/20"),
+			NetworkSecurityGroup: &network.SecurityGroup{
+				ID: to.StringPtr(nsgId),
+			},
+		},
+	}, {
+		Name: to.StringPtr("juju-controller-subnet"),
+		Properties: &network.SubnetPropertiesFormat{
+			AddressPrefix: to.StringPtr("192.168.16.0/20"),
+			NetworkSecurityGroup: &network.SecurityGroup{
+				ID: to.StringPtr(nsgId),
+			},
+		},
+	}}
+	addressPrefixes := []string{"192.168.0.0/20", "192.168.16.0/20"}
+	templateResources := []armtemplates.Resource{{
+		APIVersion: network.APIVersion,
+		Type:       "Microsoft.Network/networkSecurityGroups",
+		Name:       "juju-internal-nsg",
+		Location:   "westus",
+		Properties: &network.SecurityGroupPropertiesFormat{
+			SecurityRules: &expectedSecurityRules,
+		},
+	}, {
+		APIVersion: network.APIVersion,
+		Type:       "Microsoft.Network/virtualNetworks",
+		Name:       "juju-internal-network",
+		Location:   "westus",
+		Properties: &network.VirtualNetworkPropertiesFormat{
+			AddressSpace: &network.AddressSpace{&addressPrefixes},
+			Subnets:      &subnets,
+		},
+		DependsOn: []string{nsgId},
+	}, {
+		APIVersion: storage.APIVersion,
+		Type:       "Microsoft.Storage/storageAccounts",
+		Name:       storageAccountName,
+		Location:   "westus",
+		StorageSku: &storage.Sku{
+			Name: storage.SkuName("Standard_LRS"),
+		},
+	}}
+
+	var actual resources.Deployment
+	unmarshalRequestBody(c, s.requests[1], &actual)
+	c.Assert(actual.Properties, gc.NotNil)
+	c.Assert(actual.Properties.Template, gc.NotNil)
+	resources := (*actual.Properties.Template)["resources"].([]interface{})
+	c.Assert(resources, gc.HasLen, len(templateResources))
+}
+
+func (s *environUpgradeSuite) TestEnvironUpgradeOperationCreateCommonDeploymentControllerModel(c *gc.C) {
+	s.sender = nil
+	s.requests = nil
+	env := openEnviron(c, s.provider, &s.sender, testing.Attrs{"name": "controller"})
+	upgrader := env.(environs.Upgrader)
+
+	controllerTags := make(map[string]*string)
+	trueString := "true"
+	controllerTags["juju-is-controller"] = &trueString
+	vms := []compute.VirtualMachine{{
+		Tags: nil,
+	}, {
+		Tags: &controllerTags,
+	}}
+	vmListSender := azuretesting.NewSenderWithValue(&compute.VirtualMachineListResult{
+		Value: &vms,
+	})
+	vmListSender.PathPattern = ".*/virtualMachines"
+	s.sender = append(s.sender, vmListSender)
+
+	op0 := upgrader.UpgradeOperations()[0]
+	c.Assert(op0.Steps[0].Run(), jc.ErrorIsNil)
+}


### PR DESCRIPTION
Create common resources (storage account, vnet, nsg)
once only, when creating the model. For bootstrap,
we do this along with the bootstrap machine as we
already did. For non-controller models, we create
a deployment for the common resources at model
creation time. Because deployments can take a while,
and model creation is synchronous, we do the common
resource creation asynchronously and wait for its
completion before starting any machines.

There is an Environ upgrade step added that creates
a common resource deployment in non-controller
models. The upgrade step will preserve application-
specific network security rules.

Requires https://github.com/juju/juju/pull/6818

Fixes https://bugs.launchpad.net/juju/+bug/1656723