### PR TITLE
migrations: Add AdoptInstances to lxd provider

### DIFF
--- a/container/lxd/initialisation_linux.go
+++ b/container/lxd/initialisation_linux.go
@@ -120,19 +120,19 @@ func getConfigSetterConnect() (configSetter, error) {
 }
 
 type configSetter interface {
-	SetConfig(key, value string) error
+	SetServerConfig(key, value string) error
 }
 
 func configureLXDProxies(setter configSetter, proxies proxy.Settings) error {
-	err := setter.SetConfig("core.proxy_http", proxies.Http)
+	err := setter.SetServerConfig("core.proxy_http", proxies.Http)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	err = setter.SetConfig("core.proxy_https", proxies.Https)
+	err = setter.SetServerConfig("core.proxy_https", proxies.Https)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	err = setter.SetConfig("core.proxy_ignore_hosts", proxies.NoProxy)
+	err = setter.SetServerConfig("core.proxy_ignore_hosts", proxies.NoProxy)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/container/lxd/initialisation_test.go
+++ b/container/lxd/initialisation_test.go
@@ -167,7 +167,7 @@ type mockConfigSetter struct {
 	values []string
 }
 
-func (m *mockConfigSetter) SetConfig(key, value string) error {
+func (m *mockConfigSetter) SetServerConfig(key, value string) error {
 	m.keys = append(m.keys, key)
 	m.values = append(m.values, value)
 	return nil

--- a/provider/cloudsigma/environ.go
+++ b/provider/cloudsigma/environ.go
@@ -103,8 +103,8 @@ func (e *environ) ControllerInstances(controllerUUID string) ([]instance.Id, err
 	return e.client.getControllerIds()
 }
 
-// MoveInstancesToController is part of the Environ interface.
-func (e *environ) MoveInstancesToController(ids []instance.Id, controllerUUID string) error {
+// AdoptInstances is part of the Environ interface.
+func (e *environ) AdoptInstances(ids []instance.Id, controllerUUID string) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -886,8 +886,8 @@ func (e *environ) SetConfig(cfg *config.Config) error {
 	return nil
 }
 
-// MoveInstancesToController is part of the Environ interface.
-func (e *environ) MoveInstancesToController(ids []instance.Id, controllerUUID string) error {
+// AdoptInstances is part of the Environ interface.
+func (e *environ) AdoptInstances(ids []instance.Id, controllerUUID string) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }

--- a/provider/gce/environ_instance.go
+++ b/provider/gce/environ_instance.go
@@ -122,8 +122,8 @@ func (env *environ) ControllerInstances(controllerUUID string) ([]instance.Id, e
 	return results, nil
 }
 
-// MoveInstancesToController is part of the environs.Environ interface.
-func (env *environ) MoveInstancesToController(ids []instance.Id, controllerUUID string) error {
+// AdoptInstances is part of the environs.Environ interface.
+func (env *environ) AdoptInstances(ids []instance.Id, controllerUUID string) error {
 	stringIds := make([]string, len(ids))
 	for i, id := range ids {
 		stringIds[i] = string(id)

--- a/provider/gce/environ_instance_test.go
+++ b/provider/gce/environ_instance_test.go
@@ -202,8 +202,8 @@ func (s *environInstSuite) TestListMachineTypes(c *gc.C) {
 
 }
 
-func (s *environInstSuite) TestMoveInstancesToController(c *gc.C) {
-	err := s.Env.MoveInstancesToController([]instance.Id{"john", "misty"}, "other-uuid")
+func (s *environInstSuite) TestAdoptInstances(c *gc.C) {
+	err := s.Env.AdoptInstances([]instance.Id{"john", "misty"}, "other-uuid")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.FakeConn.Calls, gc.HasLen, 1)
 	call := s.FakeConn.Calls[0]

--- a/provider/joyent/environ.go
+++ b/provider/joyent/environ.go
@@ -142,8 +142,8 @@ func (env *joyentEnviron) ControllerInstances(controllerUUID string) ([]instance
 	return instanceIds, nil
 }
 
-// MoveInstancesToController is part of the Environ interface.
-func (env *joyentEnviron) MoveInstancesToController(ids []instance.Id, controllerUUID string) error {
+// AdoptInstances is part of the Environ interface.
+func (env *joyentEnviron) AdoptInstances(ids []instance.Id, controllerUUID string) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }

--- a/provider/lxd/environ_instance.go
+++ b/provider/lxd/environ_instance.go
@@ -124,10 +124,10 @@ func (env *environ) parsePlacement(placement string) (*instPlacement, error) {
 	return nil, errors.Errorf("unknown placement directive: %v", placement)
 }
 
-// MoveInstancesToController updates the controller tags on the
-// specified instances to have the new controller id. It's part of the
-// Environ interface.
-func (env *environ) MoveInstancesToController(ids []instance.Id, controllerUUID string) error {
+// AdoptInstances updates the controller tags on the specified
+// instances to have the new controller id. It's part of the Environ
+// interface.
+func (env *environ) AdoptInstances(ids []instance.Id, controllerUUID string) error {
 	var failed []instance.Id
 	for _, id := range ids {
 		qualifiedKey := lxdclient.ResolveConfigKey(tags.JujuController, lxdclient.MetadataNamespace)

--- a/provider/lxd/environ_instance.go
+++ b/provider/lxd/environ_instance.go
@@ -123,3 +123,22 @@ func (env *environ) parsePlacement(placement string) (*instPlacement, error) {
 
 	return nil, errors.Errorf("unknown placement directive: %v", placement)
 }
+
+// MoveInstancesToController updates the controller tags on the
+// specified instances to have the new controller id. It's part of the
+// Environ interface.
+func (env *environ) MoveInstancesToController(ids []instance.Id, controllerUUID string) error {
+	var failed []instance.Id
+	for _, id := range ids {
+		qualifiedKey := lxdclient.ResolveConfigKey(tags.JujuController, lxdclient.MetadataNamespace)
+		err := env.raw.SetContainerConfig(string(id), qualifiedKey, controllerUUID)
+		if err != nil {
+			logger.Errorf("error setting controller uuid tag for %q: %v", id, err)
+			failed = append(failed, id)
+		}
+	}
+	if len(failed) != 0 {
+		return errors.Errorf("failed to update controller for some instances: %v", failed)
+	}
+	return nil
+}

--- a/provider/lxd/environ_instance_test.go
+++ b/provider/lxd/environ_instance_test.go
@@ -124,3 +124,22 @@ func (s *environInstSuite) TestControllerInstancesMixed(c *gc.C) {
 
 	c.Check(ids, jc.DeepEquals, []instance.Id{"spam"})
 }
+
+func (s *environInstSuite) TestMoveInstancesToController(c *gc.C) {
+	err := s.Env.MoveInstancesToController([]instance.Id{"smoosh", "guild-league", "tall-dwarfs"}, "target-uuid")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.BaseSuite.Client.Calls(), gc.HasLen, 3)
+	s.BaseSuite.Client.CheckCall(c, 0, "SetContainerConfig", "smoosh", "user.juju-controller-uuid", "target-uuid")
+	s.BaseSuite.Client.CheckCall(c, 1, "SetContainerConfig", "guild-league", "user.juju-controller-uuid", "target-uuid")
+	s.BaseSuite.Client.CheckCall(c, 2, "SetContainerConfig", "tall-dwarfs", "user.juju-controller-uuid", "target-uuid")
+}
+
+func (s *environInstSuite) TestMoveInstancesToControllerError(c *gc.C) {
+	s.BaseSuite.Client.SetErrors(nil, errors.New("blammo"))
+	err := s.Env.MoveInstancesToController([]instance.Id{"smoosh", "guild-league", "tall-dwarfs"}, "target-uuid")
+	c.Assert(err, gc.ErrorMatches, `failed to update controller for some instances: \[guild-league\]`)
+	c.Assert(s.BaseSuite.Client.Calls(), gc.HasLen, 3)
+	s.BaseSuite.Client.CheckCall(c, 0, "SetContainerConfig", "smoosh", "user.juju-controller-uuid", "target-uuid")
+	s.BaseSuite.Client.CheckCall(c, 1, "SetContainerConfig", "guild-league", "user.juju-controller-uuid", "target-uuid")
+	s.BaseSuite.Client.CheckCall(c, 2, "SetContainerConfig", "tall-dwarfs", "user.juju-controller-uuid", "target-uuid")
+}

--- a/provider/lxd/environ_instance_test.go
+++ b/provider/lxd/environ_instance_test.go
@@ -125,8 +125,8 @@ func (s *environInstSuite) TestControllerInstancesMixed(c *gc.C) {
 	c.Check(ids, jc.DeepEquals, []instance.Id{"spam"})
 }
 
-func (s *environInstSuite) TestMoveInstancesToController(c *gc.C) {
-	err := s.Env.MoveInstancesToController([]instance.Id{"smoosh", "guild-league", "tall-dwarfs"}, "target-uuid")
+func (s *environInstSuite) TestAdoptInstances(c *gc.C) {
+	err := s.Env.AdoptInstances([]instance.Id{"smoosh", "guild-league", "tall-dwarfs"}, "target-uuid")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.BaseSuite.Client.Calls(), gc.HasLen, 3)
 	s.BaseSuite.Client.CheckCall(c, 0, "SetContainerConfig", "smoosh", "user.juju-controller-uuid", "target-uuid")
@@ -134,9 +134,9 @@ func (s *environInstSuite) TestMoveInstancesToController(c *gc.C) {
 	s.BaseSuite.Client.CheckCall(c, 2, "SetContainerConfig", "tall-dwarfs", "user.juju-controller-uuid", "target-uuid")
 }
 
-func (s *environInstSuite) TestMoveInstancesToControllerError(c *gc.C) {
+func (s *environInstSuite) TestAdoptInstancesError(c *gc.C) {
 	s.BaseSuite.Client.SetErrors(nil, errors.New("blammo"))
-	err := s.Env.MoveInstancesToController([]instance.Id{"smoosh", "guild-league", "tall-dwarfs"}, "target-uuid")
+	err := s.Env.AdoptInstances([]instance.Id{"smoosh", "guild-league", "tall-dwarfs"}, "target-uuid")
 	c.Assert(err, gc.ErrorMatches, `failed to update controller for some instances: \[guild-league\]`)
 	c.Assert(s.BaseSuite.Client.Calls(), gc.HasLen, 3)
 	s.BaseSuite.Client.CheckCall(c, 0, "SetContainerConfig", "smoosh", "user.juju-controller-uuid", "target-uuid")

--- a/provider/lxd/environ_raw.go
+++ b/provider/lxd/environ_raw.go
@@ -46,7 +46,7 @@ type lxdCerts interface {
 
 type lxdConfig interface {
 	ServerStatus() (*lxdshared.ServerState, error)
-	SetConfig(k, v string) error
+	SetServerConfig(k, v string) error
 }
 
 type lxdInstances interface {

--- a/provider/lxd/environ_raw.go
+++ b/provider/lxd/environ_raw.go
@@ -47,6 +47,7 @@ type lxdCerts interface {
 type lxdConfig interface {
 	ServerStatus() (*lxdshared.ServerState, error)
 	SetServerConfig(k, v string) error
+	SetContainerConfig(container, key, value string) error
 }
 
 type lxdInstances interface {

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -157,6 +157,6 @@ func (s *environSuite) TestPrepareForBootstrap(c *gc.C) {
 	err := s.Env.PrepareForBootstrap(envtesting.BootstrapContext(c))
 	c.Assert(err, jc.ErrorIsNil)
 	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
-		{"SetConfig", []interface{}{"core.https_address", "[::]"}},
+		{"SetServerConfig", []interface{}{"core.https_address", "[::]"}},
 	})
 }

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -483,7 +483,12 @@ func (conn *StubClient) ServerStatus() (*shared.ServerState, error) {
 }
 
 func (conn *StubClient) SetServerConfig(k, v string) error {
-	conn.AddCall("SetConfig", k, v)
+	conn.AddCall("SetServerConfig", k, v)
+	return conn.NextErr()
+}
+
+func (conn *StubClient) SetContainerConfig(container, k, v string) error {
+	conn.AddCall("SetContainerConfig", container, k, v)
 	return conn.NextErr()
 }
 

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -482,7 +482,7 @@ func (conn *StubClient) ServerStatus() (*shared.ServerState, error) {
 	}, nil
 }
 
-func (conn *StubClient) SetConfig(k, v string) error {
+func (conn *StubClient) SetServerConfig(k, v string) error {
 	conn.AddCall("SetConfig", k, v)
 	return conn.NextErr()
 }

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -178,8 +178,8 @@ func (e *manualEnviron) verifyBootstrapHost() error {
 	return nil
 }
 
-// MoveInstancesToController implements environs.Environ.
-func (e *manualEnviron) MoveInstancesToController(ids []instance.Id, controllerUUID string) error {
+// AdoptInstances implements environs.Environ.
+func (e *manualEnviron) AdoptInstances(ids []instance.Id, controllerUUID string) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -175,8 +175,8 @@ func (e *fakeEnviron) ControllerInstances(_ string) ([]instance.Id, error) {
 	return nil, nil
 }
 
-func (e *fakeEnviron) MoveInstancesToController(ids []instance.Id, controllerUUID string) error {
-	e.Push("MoveInstancesToController")
+func (e *fakeEnviron) AdoptInstances(ids []instance.Id, controllerUUID string) error {
+	e.Push("AdoptInstances")
 	return nil
 }
 

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -121,8 +121,8 @@ func (env *environ) BootstrapMessage() string {
 //this variable is exported, because it has to be rewritten in external unit tests
 var DestroyEnv = common.Destroy
 
-// MoveInstancesToController is part of the Environ interface.
-func (env *environ) MoveInstancesToController(ids []instance.Id, controllerUUID string) error {
+// AdoptInstances is part of the Environ interface.
+func (env *environ) AdoptInstances(ids []instance.Id, controllerUUID string) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }

--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -92,7 +92,7 @@ const LXDBridgeFile = "/etc/default/lxd-bridge"
 
 // Client is a high-level wrapper around the LXD API client.
 type Client struct {
-	*serverConfigClient
+	*configClient
 	*certClient
 	*profileClient
 	*instanceClient
@@ -148,7 +148,7 @@ func Connect(cfg Config, verifyBridgeConfig bool) (*Client, error) {
 	}
 
 	conn := &Client{
-		serverConfigClient:       &serverConfigClient{raw},
+		configClient:             &configClient{raw},
 		certClient:               &certClient{raw},
 		profileClient:            &profileClient{raw},
 		instanceClient:           &instanceClient{raw, remoteID},

--- a/tools/lxdclient/client_config.go
+++ b/tools/lxdclient/client_config.go
@@ -12,7 +12,8 @@ import (
 )
 
 type rawConfigClient interface {
-	SetServerConfig(key string, value string) (*lxd.Response, error)
+	SetServerConfig(key, value string) (*lxd.Response, error)
+	SetContainerConfig(container, key, value string) error
 
 	WaitForSuccess(waitURL string) error
 	ServerStatus() (*shared.ServerState, error)
@@ -22,7 +23,7 @@ type configClient struct {
 	raw rawConfigClient
 }
 
-// SetConfig sets the given value in the server's config.
+// SetServerConfig sets the given value in the server's config.
 func (c configClient) SetServerConfig(key, value string) error {
 	resp, err := c.raw.SetServerConfig(key, value)
 	if err != nil {
@@ -40,6 +41,13 @@ func (c configClient) SetServerConfig(key, value string) error {
 	return nil
 }
 
+// SetContainerConfig sets the given config value for the specified
+// container.
+func (c configClient) SetContainerConfig(container, key, value string) error {
+	return errors.Trace(c.raw.SetContainerConfig(container, key, value))
+}
+
+// ServerStatus reports the state of the server.
 func (c configClient) ServerStatus() (*shared.ServerState, error) {
 	return c.raw.ServerStatus()
 }

--- a/tools/lxdclient/client_serverconfig.go
+++ b/tools/lxdclient/client_serverconfig.go
@@ -11,19 +11,19 @@ import (
 	"github.com/lxc/lxd/shared"
 )
 
-type rawServerConfigClient interface {
+type rawConfigClient interface {
 	SetServerConfig(key string, value string) (*lxd.Response, error)
 
 	WaitForSuccess(waitURL string) error
 	ServerStatus() (*shared.ServerState, error)
 }
 
-type serverConfigClient struct {
-	raw rawServerConfigClient
+type configClient struct {
+	raw rawConfigClient
 }
 
 // SetConfig sets the given value in the server's config.
-func (c serverConfigClient) SetConfig(key, value string) error {
+func (c configClient) SetServerConfig(key, value string) error {
 	resp, err := c.raw.SetServerConfig(key, value)
 	if err != nil {
 		return errors.Trace(err)
@@ -40,6 +40,6 @@ func (c serverConfigClient) SetConfig(key, value string) error {
 	return nil
 }
 
-func (c serverConfigClient) ServerStatus() (*shared.ServerState, error) {
+func (c configClient) ServerStatus() (*shared.ServerState, error) {
 	return c.raw.ServerStatus()
 }

--- a/tools/lxdclient/instance.go
+++ b/tools/lxdclient/instance.go
@@ -34,7 +34,9 @@ const (
 	megabyte = 1024 * 1024
 )
 
-func resolveConfigKey(name string, namespace ...string) string {
+// ResolveConfigKey applies the specified namespaces to the config key
+// name to return the fully-qualified key.
+func ResolveConfigKey(name string, namespace ...string) string {
 	parts := append(namespace, name)
 	return strings.Join(parts, ".")
 }
@@ -258,7 +260,7 @@ func resolveMetadata(metadata map[string]string) map[string]string {
 	config := make(map[string]string)
 
 	for name, val := range metadata {
-		key := resolveConfigKey(name, MetadataNamespace)
+		key := ResolveConfigKey(name, MetadataNamespace)
 		config[key] = val
 	}
 

--- a/tools/lxdclient/utils.go
+++ b/tools/lxdclient/utils.go
@@ -68,7 +68,7 @@ func IsRunningLocally() (bool, error) {
 // EnableHTTPSListener configures LXD to listen for HTTPS requests,
 // rather than only via the Unix socket.
 func EnableHTTPSListener(client interface {
-	SetConfig(k, v string) error
+	SetServerConfig(k, v string) error
 }) error {
 	// Make sure the LXD service is configured to listen to local https
 	// requests, rather than only via the Unix socket.
@@ -76,7 +76,7 @@ func EnableHTTPSListener(client interface {
 	//      which does expose the LXD to outside requests. It would
 	//      probably be better to only tell LXD to listen for requests on
 	//      the loopback and LXC bridges that we are using.
-	if err := client.SetConfig("core.https_address", "[::]"); err != nil {
+	if err := client.SetServerConfig("core.https_address", "[::]"); err != nil {
 		return errors.Trace(err)
 	}
 	return nil

--- a/tools/lxdclient/utils_test.go
+++ b/tools/lxdclient/utils_test.go
@@ -27,7 +27,7 @@ func (s *utilsSuite) TestEnableHTTPSListener(c *gc.C) {
 	var client mockConfigSetter
 	err := lxdclient.EnableHTTPSListener(&client)
 	c.Assert(err, jc.ErrorIsNil)
-	client.CheckCall(c, 0, "SetConfig", "core.https_address", "[::]")
+	client.CheckCall(c, 0, "SetServerConfig", "core.https_address", "[::]")
 }
 
 func (s *utilsSuite) TestEnableHTTPSListenerError(c *gc.C) {
@@ -41,7 +41,7 @@ type mockConfigSetter struct {
 	testing.Stub
 }
 
-func (m *mockConfigSetter) SetConfig(k, v string) error {
-	m.MethodCall(m, "SetConfig", k, v)
+func (m *mockConfigSetter) SetServerConfig(k, v string) error {
+	m.MethodCall(m, "SetServerConfig", k, v)
 	return m.NextErr()
 }


### PR DESCRIPTION
Part of https://bugs.launchpad.net/juju/+bug/1648063

Implement AdoptInstances in the lxd provider using client.SetContainerConfig.

QA steps - none, this code isn't runnable until the migration master is updated.