### PR TITLE
migrations: Add AdoptInstances to maas provider

### DIFF
--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -2445,7 +2445,10 @@ func (env *maasEnviron) AdoptInstances(ids []instance.Id, controllerUUID string)
 			// This should never happen.
 			return errors.Errorf("instance %q wasn't a maas2Instance", instance.Id())
 		}
-		// SetOwnerData will update the existing tags with this data.
+		// From the MAAS docs: "[SetOwnerData] will not remove any
+		// previous keys unless explicitly passed with an empty
+		// string." So not passing all of the keys here is fine.
+		// https://maas.ubuntu.com/docs2.0/api.html#machine
 		err := maas2Instance.machine.SetOwnerData(map[string]string{tags.JujuController: controllerUUID})
 		if err != nil {
 			logger.Errorf("error setting controller uuid tag for %q: %v", instance.Id(), err)

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1093,3 +1093,11 @@ func (s *environSuite) TestReleaseContainerAddresses_HandlesDupes(c *gc.C) {
 	}
 	c.Assert(systemIds, gc.DeepEquals, []string{"device3"})
 }
+
+func (s *environSuite) TestAdoptInstances(c *gc.C) {
+	id := s.addNode(allocatedNode)
+	env := s.makeEnviron()
+	// Shouldn't do anything in MAAS1.
+	err := env.AdoptInstances([]instance.Id{id}, "other-controller")
+	c.Assert(err, jc.ErrorIsNil)
+}


### PR DESCRIPTION
Part of https://bugs.launchpad.net/juju/+bug/1648063

Implement AdoptInstances in the maas provider using machine.SetOwnerData.

QA steps - none, this code isn't runnable until the migration master is updated.