### PR TITLE
apiclient: don't log at error level when dialing

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -278,7 +278,7 @@ func (s *apiclientSuite) TestOpenWithNoCACert(c *gc.C) {
 		Timeout:    20 * time.Second,
 		RetryDelay: 2 * time.Second,
 	})
-	c.Assert(err, gc.ErrorMatches, `X509 certficate error on API: websocket.Dial wss://.*/api: x509: certificate signed by unknown authority`)
+	c.Assert(err, gc.ErrorMatches, `unable to connect to API: websocket.Dial wss://.*/api: x509: certificate signed by unknown authority`)
 
 	if time.Since(t0) > 5*time.Second {
 		c.Errorf("looks like API is retrying on connection when there is an X509 error")


### PR DESCRIPTION
PR #6620 changed the client logging so that it logs an
error when it can't connect to an API address.
It is common for these errors to occur when connecting
even though the actual connect succeeds, so this
PR changes the logging to debug level - it's part
of the implementation but not something that users
should always see.