### PR TITLE
Initialize default x509 certificate and allow https host strings.

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -136,13 +136,13 @@ func (m main) Run(args []string) int {
 	// since it relies on detecting the lack of said directory.
 	newInstall := m.maybeWarnJuju1x()
 
-	if err = juju.InitJujuXDGDataHome(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %s\n", err)
-		return 2
-	}
-
 	if newInstall {
-		fmt.Fprintf(ctx.Stderr, "Since Juju %v is being run for the first time, downloading latest cloud information.\n", jujuversion.Current.Major)
+		fmt.Fprintf(ctx.Stderr, "Since Juju %v is being run for the first time, initializing config.\n", jujuversion.Current.Major)
+		if err = juju.InitJujuXDGDataHome(); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %s\n", err)
+			return 2
+		}
+		fmt.Fprint(ctx.Stderr, "Downloading latest cloud information.\n")
 		updateCmd := cloud.NewUpdateCloudsCommand()
 		if err := updateCmd.Run(ctx); err != nil {
 			fmt.Fprintf(ctx.Stderr, "error: %v\n", err)

--- a/juju/home.go
+++ b/juju/home.go
@@ -4,8 +4,13 @@
 package juju
 
 import (
+	"os"
+	"time"
+
 	"github.com/juju/errors"
+	"github.com/juju/utils"
 	"github.com/juju/utils/ssh"
+	"github.com/juju/utils/cert"
 	"gopkg.in/juju/charmrepo.v2-unstable"
 
 	"github.com/juju/juju/juju/osenv"
@@ -22,6 +27,33 @@ func InitJujuXDGDataHome() error {
 	charmrepo.CacheDir = osenv.JujuXDGDataHomePath("charmcache")
 	if err := ssh.LoadClientKeys(osenv.JujuXDGDataHomePath("ssh")); err != nil {
 		return errors.Annotate(err, "cannot load ssh client keys")
+	}
+	if err := InitJujuX509Certificate(); err != nil{
+		return errors.Annotate(err, "cannot create x509 certificate")
+	}
+	return nil
+}
+
+// InitJujuX509Certificate initializes a default x509 certificate to be stored
+// in the config folder this certificate can be used by any provider that requires
+// encryption through this kind of certificates, for instance, LXD.
+func InitJujuX509Certificate() (error) {
+	expiry := time.Now().UTC().AddDate(10, 0, 0)
+	uuid, _ := utils.NewUUID()
+	certdir := osenv.JujuXDGDataHomePath("x509")
+	if certdir != "" {
+		err := os.MkdirAll(certdir, 0700)
+		if err == nil {
+			pem, key, err := cert.NewCA("client", uuid.String(), expiry, 2048)
+			if err != nil {
+				return errors.Annotate(err, "failed to create new certificate")
+			}
+			public, err := cert.ComputePublicKey(pem)
+			if err != nil {
+				return errors.Annotate(err, "failed to compute x509 public key")
+			}
+			return cert.StoreDefaultX509Cert(certdir, pem, key, public)
+		}
 	}
 	return nil
 }

--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -185,18 +185,9 @@ func isSupportedAPIVersion(version string) bool {
 
 // newRawClient connects to the LXD host that is defined in Config.
 func newRawClient(remote Remote) (*lxd.Client, error) {
-	host := remote.Host
-
-	if remote.ID() == remoteIDForLocal && host == "" {
-		host = "unix://" + lxdshared.VarPath("unix.socket")
-	} else if !strings.HasPrefix(host, "unix://") {
-		_, _, err := net.SplitHostPort(host)
-		if err != nil {
-			// There is no port here
-			host = net.JoinHostPort(host, lxdshared.DefaultPort)
-		}
-	}
-	logger.Debugf("connecting to LXD remote %q: %q", remote.ID(), host)
+	remoteID := remote.ID()
+	host := generateHostString(remoteID, remote.Host)
+	logger.Debugf("connecting to LXD remote %q: %q", remoteID, host)
 
 	clientCert := ""
 	if remote.Cert != nil && remote.Cert.CertPEM != nil {
@@ -216,7 +207,7 @@ func newRawClient(remote Remote) (*lxd.Client, error) {
 	}
 
 	client, err := lxdNewClientFromInfo(lxd.ConnectInfo{
-		Name: remote.ID(),
+		Name: remoteID,
 		RemoteConfig: lxd.RemoteConfig{
 			Addr:     host,
 			Static:   static,
@@ -228,7 +219,7 @@ func newRawClient(remote Remote) (*lxd.Client, error) {
 		ServerPEMCert: remote.ServerPEMCert,
 	})
 	if err != nil {
-		if remote.ID() == remoteIDForLocal {
+		if remoteID == remoteIDForLocal {
 			err = hoistLocalConnectErr(err)
 			return nil, errors.Annotate(err, "can't connect to the local LXD server")
 		}
@@ -249,6 +240,47 @@ func newRawClient(remote Remote) (*lxd.Client, error) {
 	}
 
 	return client, nil
+}
+
+// generateHostString generates host string from remote.ID and remote.Host
+func generateHostString(id string, host string) (string) {
+	if host != "" {
+		isLocalhost, err := isLocalhost(host)
+		// this code assumes we are localhost in case of something going wrong checking it.
+		if isLocalhost || err != nil {
+			return "unix://" + lxdshared.VarPath("unix.socket")
+		} else {
+			return net.JoinHostPort(host, lxdshared.DefaultPort)
+		}
+	} else if id == remoteIDForLocal && host == "" {
+		return "unix://" + lxdshared.VarPath("unix.socket")
+	} else if !strings.HasPrefix(host, "unix://") {
+		_, _, err := net.SplitHostPort(host)
+		if err != nil {
+			// There is no port here
+			return net.JoinHostPort(host, lxdshared.DefaultPort)
+		}
+	}
+	return host
+}
+
+// isLocalhost checks if the remote host is pointing to a local ip
+// address configured in our interfaces.
+func isLocalhost(host string) (bool, error) {
+	addresses, err := net.InterfaceAddrs()
+
+	// As default, we assume that we are on localhost
+	if err != nil {
+		return true, errors.Trace(err)
+	}
+
+	for _, address := range addresses {
+		if strings.Contains(host, address.String()) {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 // verifyDefaultProfileBridgeConfig takes a LXD API client and extracts the

--- a/tools/lxdclient/client_test.go
+++ b/tools/lxdclient/client_test.go
@@ -8,6 +8,7 @@ package lxdclient
 import (
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/testing"
@@ -241,4 +242,25 @@ var testerr = errors.Errorf("boo!")
 
 func fakeNewClientFromInfo(info lxd.ConnectInfo) (*lxd.Client, error) {
 	return nil, testerr
+}
+
+func (cs *ConnectSuite) TestIsLocalhost(c *gc.C) {
+	out, err := isLocalhost("127.0.0.1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out, gc.Equals, true)
+}
+
+func (cs *ConnectSuite) TestIsNotLocalhost(c *gc.C) {
+	out, err := isLocalhost("8.8.8.8")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out, gc.Equals, true)
+}
+
+func (cs *ConnectSuite) TestGenerateUnixHostString(c *gc.C){
+	host := generateHostString(remoteLocalName, "127.0.0.1")
+	c.Assert(strings.HasPrefix(host, "unix://"), gc.Equals, true)
+}
+func (cs *ConnectSuite) TestGenerateHTTPSHostString(c *gc.C){
+	host := generateHostString(remoteLocalName, "8.8.8.8")
+	c.Assert(strings.HasPrefix(host, "https://"), gc.Equals, true)
 }


### PR DESCRIPTION
These commits open the way to create https host strings in LXD provider as well as creating
a default x509 certificate to use against the https remotes.

This depends on the following merge in juju/utils: https://github.com/juju/utils/pull/261