### PR TITLE
Fix typo in add-relation message

### DIFF
--- a/cmd/juju/application/addrelation.go
+++ b/cmd/juju/application/addrelation.go
@@ -117,7 +117,7 @@ func (c *addRelationCommand) Run(ctx *cmd.Context) error {
 	if params.IsCodeUnauthorized(err) {
 		common.PermissionsMessage(ctx.Stderr, "add a relation")
 	}
-	if err == nil {
+	if err == nil && c.remoteEndpoint != "" {
 		ctx.Infof("Note: this beta version of Juju has automatically exposed the endpoint at %s to enable cross model communications", c.remoteEndpoint)
 	}
 	return block.ProcessBlockedError(err, block.BlockChange)


### PR DESCRIPTION
Fix typo in info message after add-relation. This message will be removed when security groups are fixed properly for cross model relations.