### PR TITLE
Fix the peergrouper intermittent failing test.

### DIFF
--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -128,7 +128,7 @@ func possiblePeerGroupChanges(
 				logger.Debugf("machine %q is a potential voter", m.Id())
 				toAddVote = append(toAddVote, m)
 			} else {
-				logger.Debugf("machine %q is not ready (has status: %v)", m.Id(), ok)
+				logger.Debugf("machine %q is not ready (status: %v, healthy: %v)", m.Id(), status.State, status.Healthy)
 				toKeep = append(toKeep, m)
 			}
 		case !wantsVote && isVoting:

--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -97,7 +97,9 @@ func (e *errorPatterns) errorFor(name string, args ...interface{}) error {
 		}
 	}
 	err := f()
-	logger.Errorf("errorFor %q -> %v", s, err)
+	if err != nil {
+		logger.Errorf("errorFor %q -> %v", s, err)
+	}
 	return err
 }
 
@@ -477,10 +479,10 @@ func (session *fakeMongoSession) setStatus(members []replicaset.MemberStatus) {
 // Set implements mongoSession.Set
 func (session *fakeMongoSession) Set(members []replicaset.Member) error {
 	if err := session.errors.errorFor("Session.Set"); err != nil {
-		logger.Infof("not setting replicaset members to %#v", members)
+		logger.Infof("NOT setting replicaset members to \n%s", prettyReplicaSetMembers(members))
 		return err
 	}
-	logger.Infof("setting replicaset members to %#v", members)
+	logger.Infof("setting replicaset members to \n%s", prettyReplicaSetMembers(members))
 	session.members.Set(deepCopy(members))
 	if session.InstantlyReady {
 		statuses := make([]replicaset.MemberStatus, len(members))


### PR DESCRIPTION
Due to the number of watcher goroutines and the way in which the time based checking of the peer group works, there is no definitive controlled way to advance the testing clock such that it always works. So, don't do that.

Other parts of this PR relate to the output that is shown when the test runs. It is much easier to follow now.