### PR TITLE
provider/azure: strip off UTF-8 BOM from responses

### DIFF
--- a/provider/azure/internal/azureauth/interactive_test.go
+++ b/provider/azure/internal/azureauth/interactive_test.go
@@ -81,9 +81,13 @@ func createServicePrincipalSender() autorest.Sender {
 	})
 }
 
-func createServicePrincipalAlreadyExistsSender() autorest.Sender {
+func createServicePrincipalAlreadyExistsSender(withUTF8BOM bool) autorest.Sender {
 	sender := mocks.NewSender()
-	body := mocks.NewBody(`{"odata.error":{"code":"Request_MultipleObjectsWithSameKeyValue"}}`)
+	bodyData := `{"odata.error":{"code":"Request_MultipleObjectsWithSameKeyValue"}}`
+	if withUTF8BOM {
+		bodyData = "\ufeff" + bodyData
+	}
+	body := mocks.NewBody(bodyData)
 	sender.AppendResponse(mocks.NewResponseWithBodyAndStatus(body, http.StatusConflict, ""))
 	return sender
 }
@@ -242,6 +246,18 @@ func (s *InteractiveSuite) TestInteractiveRoleAssignmentAlreadyExists(c *gc.C) {
 }
 
 func (s *InteractiveSuite) TestInteractiveServicePrincipalAlreadyExists(c *gc.C) {
+	s.testInteractiveServicePrincipalAlreadyExists(c, false)
+}
+
+func (s *InteractiveSuite) TestInteractiveServicePrincipalAlreadyExistsWithUTF8BOM(c *gc.C) {
+	// We have observed that Azure sometimes responds with UTF-8 BOMs in
+	// JSON-encoded responses. Go's JSON decoder does not like this, so
+	// we have to strip it off. See:
+	//     https://bugs.launchpad.net/juju/+bug/1657448
+	s.testInteractiveServicePrincipalAlreadyExists(c, true)
+}
+
+func (s *InteractiveSuite) testInteractiveServicePrincipalAlreadyExists(c *gc.C, withUTF8BOM bool) {
 	var requests []*http.Request
 	senders := azuretesting.Senders{
 		oauthConfigSender(),
@@ -250,7 +266,7 @@ func (s *InteractiveSuite) TestInteractiveServicePrincipalAlreadyExists(c *gc.C)
 		tokenSender(),
 		tokenSender(),
 		currentUserSender(),
-		createServicePrincipalAlreadyExistsSender(),
+		createServicePrincipalAlreadyExistsSender(withUTF8BOM),
 		servicePrincipalListSender(),
 		passwordCredentialsListSender(),
 		updatePasswordCredentialsSender(),


### PR DESCRIPTION
When handling responses from the AAD REST endpoint,
strip off the UTF-8 BOM, if any, from JSON responses.
These are only sometimes returned.

Fixes https://bugs.launchpad.net/juju/+bug/1657448