### PR TITLE
Tweaked system and mongod to scale better

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1365,20 +1365,13 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) (err error) {
 		}
 	}()
 
-	mongoInstalled, err := mongo.IsServiceInstalled()
+	// EnsureMongoServer installs/upgrades the init config as necessary.
+	ensureServerParams, err := cmdutil.NewEnsureServerParams(agentConfig)
 	if err != nil {
-		return errors.Annotate(err, "error while checking if mongodb service is installed")
+		return err
 	}
-
-	if !mongoInstalled {
-		// EnsureMongoServer installs/upgrades the init config as necessary.
-		ensureServerParams, err := cmdutil.NewEnsureServerParams(agentConfig)
-		if err != nil {
-			return err
-		}
-		if err := cmdutil.EnsureMongoServer(ensureServerParams); err != nil {
-			return err
-		}
+	if err := cmdutil.EnsureMongoServer(ensureServerParams); err != nil {
+		return err
 	}
 	logger.Debugf("mongodb service is installed")
 

--- a/mongo/export_test.go
+++ b/mongo/export_test.go
@@ -41,3 +41,7 @@ func PatchService(patchValue func(interface{}, interface{}), data *svctesting.Fa
 		return svc, nil
 	})
 }
+
+func SysctlEditableEnsureServer(args EnsureServerParams, sysctlFiles map[string]string) error {
+	return ensureServer(args, sysctlFiles)
+}

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -351,6 +351,27 @@ func mongoPath(version Version, stat func(string) (os.FileInfo, error), lookPath
 
 }
 
+/*
+Values set as per bug:
+https://bugs.launchpad.net/juju/+bug/1656430
+net.ipv4.tcp_max_syn_backlog = 4096
+net.core.somaxconn = 16384
+net.core.netdev_max_backlog = 1000
+net.ipv4.tcp_fin_timeout = 30
+
+Values set as per mongod recommendation (see syslog on default mongod run)
+/sys/kernel/mm/transparent_hugepage/enabled 'always' > 'never'
+/sys/kernel/mm/transparent_hugepage/defrag 'always' > 'never'
+*/
+var editableSysctlFiles = map[string]string{
+	"/sys/kernel/mm/transparent_hugepage/enabled": "never",
+	"/sys/kernel/mm/transparent_hugepage/defrag":  "never",
+	"/proc/sys/net/ipv4/tcp_max_syn_backlog":      "4096",
+	"/proc/sys/net/core/somaxconn":                "16384",
+	"/proc/sys/net/core/netdev_max_backlog":       "1000",
+	"/proc/sys/net/ipv4/tcp_fin_timeout":          "30",
+}
+
 // EnsureServerParams is a parameter struct for EnsureServer.
 type EnsureServerParams struct {
 	// APIPort is the port to connect to the api server.
@@ -398,6 +419,11 @@ type EnsureServerParams struct {
 // This method will remove old versions of the mongo init service as necessary
 // before installing the new version.
 func EnsureServer(args EnsureServerParams) error {
+	return ensureServer(args, editableSysctlFiles)
+}
+
+func ensureServer(args EnsureServerParams, sysctlFiles map[string]string) error {
+	tweakSysctlForMongo(sysctlFiles)
 	logger.Infof(
 		"Ensuring mongo server is running; data directory %s; port %d",
 		args.DataDir, args.StatePort,
@@ -500,10 +526,33 @@ func EnsureServer(args EnsureServerParams) error {
 	if err := preallocOplog(dbDir, oplogSizeMB); err != nil {
 		return fmt.Errorf("error creating oplog files: %v", err)
 	}
+
 	if err := service.InstallAndStart(svc); err != nil {
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+func truncateAndWriteIfExists(procFile, value string) error {
+	if _, err := os.Stat(procFile); os.IsNotExist(err) {
+		logger.Debugf("%q does not exist, will not set %q", procFile, value)
+		return errors.Errorf("%q does not exist, will not set %q", procFile, value)
+	}
+	f, err := os.OpenFile(procFile, os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer f.Close()
+	_, err = f.WriteString(value)
+	return errors.Trace(err)
+}
+
+func tweakSysctlForMongo(editables map[string]string) {
+	for editableFile, value := range editables {
+		if err := truncateAndWriteIfExists(editableFile, value); err != nil {
+			logger.Errorf("could not set the value of %q to %q because of: %v\n", editableFile, value, err)
+		}
+	}
 }
 
 // UpdateSSLKey writes a new SSL key used by mongo to validate connections from Juju controller(s)

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -259,6 +259,34 @@ func (s *MongoSuite) TestEnsureServerServerExistsAndRunning(c *gc.C) {
 	s.data.CheckCallNames(c, "Installed", "Exists", "Running")
 }
 
+func (s *MongoSuite) TestEnsureServerSetsSysctlValues(c *gc.C) {
+	dataDir := c.MkDir()
+	dataFilePath := filepath.Join(dataDir, "editablesysctlfile")
+	dataFile, err := os.Create(dataFilePath)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = dataFile.WriteString("original value")
+	c.Assert(err, jc.ErrorIsNil)
+	dataFile.Close()
+
+	pm, err := coretesting.GetPackageManager()
+	c.Assert(err, jc.ErrorIsNil)
+	testing.PatchExecutableAsEchoArgs(c, s, pm.PackageManager)
+
+	s.data.SetStatus(mongo.ServiceName, "running")
+
+	contents, err := ioutil.ReadFile(dataFilePath)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(contents), gc.Equals, "original value")
+
+	err = mongo.SysctlEditableEnsureServer(makeEnsureServerParams(dataDir),
+		map[string]string{dataFilePath: "new value"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	contents, err = ioutil.ReadFile(dataFilePath)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(contents), gc.Equals, "new value")
+}
+
 func (s *MongoSuite) TestEnsureServerServerExistsNotRunningIsStarted(c *gc.C) {
 	dataDir := c.MkDir()
 

--- a/mongo/service.go
+++ b/mongo/service.go
@@ -30,6 +30,10 @@ const (
 	// ReplicaSetName is the name of the replica set that juju uses for its
 	// controllers.
 	ReplicaSetName = "juju"
+
+	// DefaultCacheSize expressed in GB sets the max value Mongo WiredTiger cache can
+	// reach.
+	DefaultCacheSize = 1
 )
 
 var (
@@ -183,7 +187,10 @@ func newConf(args ConfigArgs) common.Conf {
 			" --smallfiles"
 	} else {
 		mongoCmd = mongoCmd +
-			" --storageEngine wiredTiger"
+			" --storageEngine wiredTiger" +
+			// TODO(perrito666) make DefaultCacheSize 0,25 when mongo version goes
+			// to 3.4
+			" --wiredTigerCacheSizeGB " + fmt.Sprint(DefaultCacheSize)
 	}
 	extraScript := ""
 	if args.WantNUMACtl {


### PR DESCRIPTION
Mongod requiers some tweaks in sysctl and in its parameters to
scale properly without consumin excessive memory and resources.
The cache size has been limited and a few sysctl values have
been tweaked to better suit the controller.

There is a follow up patch to be sent after this one that makes the memory allocation policy configurable.

### QA 
* Bootstrap juju.
* ps should show you a mongod running with --wiredTigerCacheSizeGB 1 among its parameters.
* Syslog should not show suggestions by mongod to change transparent hughe pages settings.
* The following settings should be set in proc:
  * net.ipv4.tcp_max_syn_backlog = 4096
  * net.core.somaxconn = 16384
  * net.core.netdev_max_backlog = 1000
  * net.ipv4.tcp_fin_timeout = 30
as indicated in https://bugs.launchpad.net/juju/+bug/1656430