### PR TITLE
state: Add support for sequences with a minimum

### DIFF
--- a/state/export_test.go
+++ b/state/export_test.go
@@ -369,6 +369,10 @@ func Sequence(st *State, name string) (int, error) {
 	return st.sequence(name)
 }
 
+func SequenceWithMin(st *State, name string, minVal int) (int, error) {
+	return st.sequenceWithMin(name, minVal)
+}
+
 func SetModelLifeDead(st *State, modelUUID string) error {
 	ops := []txn.Op{{
 		C:      modelsC,

--- a/state/sequence.go
+++ b/state/sequence.go
@@ -6,6 +6,9 @@ package state
 import (
 	"fmt"
 
+	"github.com/juju/errors"
+	"github.com/juju/juju/mongo"
+
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -14,18 +17,20 @@ type sequenceDoc struct {
 	DocID     string `bson:"_id"`
 	Name      string `bson:"name"`
 	ModelUUID string `bson:"model-uuid"`
-	Counter   int
+	Counter   int    // This stores the *next* value to return.
 }
 
-func (s *State) sequence(name string) (int, error) {
-	sequences, closer := s.getCollection(sequenceC)
+// sequence safely increments a database backed sequence, returning
+// the next value.
+func (st *State) sequence(name string) (int, error) {
+	sequences, closer := st.getCollection(sequenceC)
 	defer closer()
 	query := sequences.FindId(name)
 	inc := mgo.Change{
 		Update: bson.M{
 			"$set": bson.M{
 				"name":       name,
-				"model-uuid": s.ModelUUID(),
+				"model-uuid": st.ModelUUID(),
 			},
 			"$inc": bson.M{"counter": 1},
 		},
@@ -37,4 +42,144 @@ func (s *State) sequence(name string) (int, error) {
 		return -1, fmt.Errorf("cannot increment %q sequence number: %v", name, err)
 	}
 	return result.Counter, nil
+}
+
+// sequenceWithMin safely increments a database backed sequence,
+// allowing for a minimum value for the sequence to be specified. The
+// minimum value is used as an initial value for the first use of a
+// particular sequence. The minimum value will also cause a sequence
+// value to jump ahead if the minimum is provided that is higher than
+// the current sequence value.
+//
+// The data manipulated by `sequence` and `sequenceWithMin` is the
+// same. It is safe to mix the 2 methods for the same sequence.
+//
+// `sequence` is more efficient than `sequenceWithMin` and should be
+// preferred if there is no minimum value requirement.
+func (st *State) sequenceWithMin(name string, minVal int) (int, error) {
+	sequences, closer := st.getCollection(sequenceC)
+	defer closer()
+	updater := &dbSeqUpdater{
+		coll: sequences,
+		id:   st.docID(name),
+		name: name,
+	}
+	return updateSeqWithMin(updater, minVal)
+}
+
+// seqUpdater abstracts away the database operations required for
+// updating a sequence.
+type seqUpdater interface {
+	// read returns the current value of the sequence. If the sequence
+	// doesn't exist yet it returns 0.
+	read() (int, error)
+
+	// create attempts to create a new sequence with the initial value
+	// provided. It returns (true, nil) on success, (false, nil) if
+	// the sequence already existed and (false, <some error>) if any
+	// other error occurred.
+	create(value int) (bool, error)
+
+	// set attempts to update the sequence value to a new value. It
+	// takes the expected current value of the sequence as well as the
+	// new value to set it to. (true, nil) is returned if the value
+	// was updated successfully. (false, nil) is returned if the
+	// sequence was not at the expected value (indicating a concurrent
+	// update). (false, <some error>) is returned for any other
+	// problem.
+	set(expected, next int) (bool, error)
+}
+
+const maxSeqRetries = 20
+
+// updateSeqWithMin implements the abstract logic for incrementing a
+// database backed sequence in a concurrency aware way.
+//
+// It is complicated because MongoDB's atomic update primitives don't
+// provide a way to upsert a counter while also providing an initial
+// value.  Instead, a number of database operations are used for each
+// sequence update, relying on the atomicity guarantees that MongoDB
+// offers. Optimistic database updates are attempted with retries when
+// contention is observed.
+func updateSeqWithMin(sequence seqUpdater, minVal int) (int, error) {
+	for try := 0; try < maxSeqRetries; try++ {
+		curVal, err := sequence.read()
+		if err != nil {
+			return -1, errors.Annotate(err, "could not read sequence")
+		}
+		if curVal == 0 {
+			// No sequence document exists, create one.
+			ok, err := sequence.create(minVal + 1)
+			if err != nil {
+				return -1, errors.Annotate(err, "could not create sequence")
+			}
+			if ok {
+				return minVal, nil
+			}
+			// Someone else created the sequence document at the same
+			// time, try again.
+		} else {
+			// Increment an existing sequence document, respecting the
+			// minimum value provided.
+			nextVal := curVal + 1
+			if nextVal < minVal {
+				nextVal = minVal + 1
+			}
+			ok, err := sequence.set(curVal, nextVal)
+			if err != nil {
+				return -1, errors.Annotate(err, "could not set sequence")
+			}
+			if ok {
+				return nextVal - 1, nil
+			}
+			// Someone else incremented the sequence at the same time,
+			// try again.
+		}
+	}
+	return -1, errors.New("too much contention while updating sequence")
+}
+
+// dbSeqUpdater implements seqUpdater.
+type dbSeqUpdater struct {
+	coll mongo.Collection
+	id   string
+	name string
+}
+
+func (su *dbSeqUpdater) read() (int, error) {
+	var doc bson.M
+	err := su.coll.FindId(su.id).One(&doc)
+	if errors.Cause(err) == mgo.ErrNotFound {
+		return 0, nil
+	} else if err != nil {
+		return -1, errors.Trace(err)
+	}
+	return doc["counter"].(int), nil
+}
+
+func (su *dbSeqUpdater) create(value int) (bool, error) {
+	err := su.coll.Writeable().Insert(bson.M{
+		"_id":     su.id,
+		"name":    su.name,
+		"counter": value,
+	})
+	if mgo.IsDup(errors.Cause(err)) {
+		return false, nil
+	} else if err != nil {
+		return false, errors.Trace(err)
+	}
+	return true, nil
+}
+
+func (su *dbSeqUpdater) set(expected, next int) (bool, error) {
+	err := su.coll.Writeable().Update(
+		bson.M{"_id": su.id, "counter": expected},
+		bson.M{"$set": bson.M{"counter": next}},
+	)
+	if errors.Cause(err) == mgo.ErrNotFound {
+		return false, nil
+	} else if err != nil {
+		return false, errors.Trace(err)
+	}
+	return true, nil
 }

--- a/state/sequence_internal_test.go
+++ b/state/sequence_internal_test.go
@@ -1,0 +1,191 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	jc "github.com/juju/testing/checkers"
+)
+
+var _ = gc.Suite(&sequenceMinSuite{})
+
+type sequenceMinSuite struct {
+	testing.IsolationSuite
+}
+
+func (s *sequenceMinSuite) TestNew(c *gc.C) {
+	updater := &fakeSequenceUpdater{
+		readResults:   []interface{}{0},
+		createResults: []interface{}{true},
+	}
+
+	value, err := updateSeqWithMin(updater, 42)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(value, gc.Equals, 42)
+	updater.stub.CheckCalls(c, []testing.StubCall{
+		{"read", nil},
+		{"create", []interface{}{43}},
+	})
+}
+
+func (s *sequenceMinSuite) TestReadError(c *gc.C) {
+	updater := &fakeSequenceUpdater{
+		readResults: []interface{}{errors.New("boom")},
+	}
+	value, err := updateSeqWithMin(updater, 42)
+	c.Check(value, gc.Equals, -1)
+	c.Check(err, gc.ErrorMatches, "could not read sequence: boom")
+}
+
+func (s *sequenceMinSuite) TestCreateError(c *gc.C) {
+	updater := &fakeSequenceUpdater{
+		readResults:   []interface{}{0},
+		createResults: []interface{}{errors.New("boom")},
+	}
+	value, err := updateSeqWithMin(updater, 42)
+	c.Check(value, gc.Equals, -1)
+	c.Check(err, gc.ErrorMatches, "could not create sequence: boom")
+}
+
+func (s *sequenceMinSuite) TestIncrement(c *gc.C) {
+	updater := &fakeSequenceUpdater{
+		readResults: []interface{}{3},
+		setResults:  []interface{}{true},
+	}
+
+	value, err := updateSeqWithMin(updater, 1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(value, gc.Equals, 3)
+	updater.stub.CheckCalls(c, []testing.StubCall{
+		{"read", nil},
+		{"set", []interface{}{3, 4}},
+	})
+}
+
+func (s *sequenceMinSuite) TestSetError(c *gc.C) {
+	updater := &fakeSequenceUpdater{
+		readResults: []interface{}{3},
+		setResults:  []interface{}{errors.New("boom")},
+	}
+	value, err := updateSeqWithMin(updater, 1)
+	c.Check(value, gc.Equals, -1)
+	c.Check(err, gc.ErrorMatches, "could not set sequence: boom")
+}
+
+func (s *sequenceMinSuite) TestJumpDueToMin(c *gc.C) {
+	updater := &fakeSequenceUpdater{
+		readResults: []interface{}{3},
+		setResults:  []interface{}{true},
+	}
+
+	value, err := updateSeqWithMin(updater, 99)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(value, gc.Equals, 99)
+	updater.stub.CheckCalls(c, []testing.StubCall{
+		{"read", nil},
+		{"set", []interface{}{3, 100}},
+	})
+}
+
+func (s *sequenceMinSuite) TestCreateContention(c *gc.C) {
+	updater := &fakeSequenceUpdater{
+		readResults:   []interface{}{0, 3},
+		createResults: []interface{}{false},
+		setResults:    []interface{}{true},
+	}
+
+	value, err := updateSeqWithMin(updater, 2)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(value, gc.Equals, 3)
+	updater.stub.CheckCalls(c, []testing.StubCall{
+		{"read", nil},
+		{"create", []interface{}{3}},
+		{"read", nil},
+		{"set", []interface{}{3, 4}},
+	})
+}
+
+func (s *sequenceMinSuite) TestSetContention(c *gc.C) {
+	updater := &fakeSequenceUpdater{
+		readResults: []interface{}{3, 5},
+		setResults:  []interface{}{false, true},
+	}
+
+	value, err := updateSeqWithMin(updater, 1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(value, gc.Equals, 5)
+	updater.stub.CheckCalls(c, []testing.StubCall{
+		{"read", nil},
+		{"set", []interface{}{3, 4}},
+		{"read", nil},
+		{"set", []interface{}{5, 6}},
+	})
+}
+
+func (s *sequenceMinSuite) TestTooMuchContention(c *gc.C) {
+	updater := new(fakeSequenceUpdater)
+	for i := 0; i < maxSeqRetries; i++ {
+		updater.readResults = append(updater.readResults, i+3)
+		updater.setResults = append(updater.setResults, false)
+	}
+
+	value, err := updateSeqWithMin(updater, 1)
+	c.Check(value, gc.Equals, -1)
+	c.Check(err, gc.ErrorMatches, "too much contention while updating sequence")
+}
+
+type fakeSequenceUpdater struct {
+	stub          testing.Stub
+	readResults   []interface{}
+	createResults []interface{}
+	setResults    []interface{}
+}
+
+func (su *fakeSequenceUpdater) read() (int, error) {
+	su.stub.AddCall("read")
+	out, err := su.pop(&su.readResults)
+	if err != nil {
+		return -1, err
+	}
+	return out.(int), nil
+}
+
+func (su *fakeSequenceUpdater) create(value int) (bool, error) {
+	su.stub.AddCall("create", value)
+	out, err := su.pop(&su.createResults)
+	if err != nil {
+		return false, err
+	}
+	return out.(bool), nil
+}
+
+func (su *fakeSequenceUpdater) set(expected, next int) (bool, error) {
+	su.stub.AddCall("set", expected, next)
+	out, err := su.pop(&su.setResults)
+	if err != nil {
+		return false, err
+	}
+	return out.(bool), nil
+}
+
+func (su *fakeSequenceUpdater) pop(resultsp *[]interface{}) (interface{}, error) {
+	results := *resultsp
+	if len(results) == 0 {
+		panic("no more results left")
+	}
+	out := results[0]
+	*resultsp = results[1:]
+	if err, ok := out.(error); ok {
+		return nil, err
+	}
+	return out, nil
+}


### PR DESCRIPTION
Added State.sequenceWithMin() and the infrastructure to support it. This
is like State.sequence() but allows a minimum value for a sequence to be
specified. This is surprisingly complicated to implement due to there
being no atomic way to provide initial values for an upserted counter in
MongoDB.

This is preparation for supporting tracking of which local charm URLs
have been used without having to keep dead charm documents.
See https://bugs.launchpad.net/juju/+bug/1657614

### QA

This functionality isn't wired up yet but the unit tests, which include a live contention test, have been run under the stress tested on 2 machines for over an hour.