### PR TITLE
provider/azure: fix centos

### DIFF
--- a/cloudconfig/cloudinit/progress.go
+++ b/cloudconfig/cloudinit/progress.go
@@ -9,25 +9,26 @@ import (
 	"github.com/juju/utils"
 )
 
-// progressFd is the file descriptor to which progress is logged.
-// This is necessary so that we can redirect all non-progress
-// related stderr away.
-//
-// Note, from the Bash manual:
-//   "Redirections using file descriptors greater than 9 should be
-//   used with care, as they may conflict with file descriptors the
-//   shell uses internally."
-const progressFd = 9
+// progressFdEnvVar is the name of the environment variable set for
+// the duration of the cloud-init script, identifying the file
+// descriptor to which progress is logged. This is necessary so that
+// we can redirect all non-progress related stderr away for interactive
+// sessions (bootstrap, manual add-machine).
+const progressFdEnvVar = "JUJU_PROGRESS_FD"
 
 // InitProgressCmd will return a command to initialise progress
 // reporting, sending messages to stderr. If LogProgressCmd is
 // used in a script, InitProgressCmd MUST be executed beforehand.
 //
-// The returned command is idempotent; this is important, to
+// The returned commands are idempotent; this is important, to
 // allow a script to be embedded in another with stderr redirected,
 // in which case InitProgressCmd must precede the redirection.
 func InitProgressCmd() string {
-	return fmt.Sprintf("test -e /proc/self/fd/%d || exec %d>&2", progressFd, progressFd)
+	return fmt.Sprintf(
+		`test -n "$%s" || exec {%s}>&2`,
+		progressFdEnvVar,
+		progressFdEnvVar,
+	)
 }
 
 // LogProgressCmd will return a command to log the specified progress
@@ -39,5 +40,5 @@ func InitProgressCmd() string {
 // InitProgressCmd.
 func LogProgressCmd(format string, args ...interface{}) string {
 	msg := utils.ShQuote(fmt.Sprintf(format, args...))
-	return fmt.Sprintf("echo %s >&%d", msg, progressFd)
+	return fmt.Sprintf("echo %s >&$%s", msg, progressFdEnvVar)
 }

--- a/cloudconfig/cloudinit/progress.go
+++ b/cloudconfig/cloudinit/progress.go
@@ -24,8 +24,16 @@ const progressFdEnvVar = "JUJU_PROGRESS_FD"
 // allow a script to be embedded in another with stderr redirected,
 // in which case InitProgressCmd must precede the redirection.
 func InitProgressCmd() string {
+	// This command may be run by either bash or /bin/sh, the
+	// latter of which does not support named file descriptors.
+	// When running under /bin/sh we don't care about progress
+	// logging, so we can allow it to go to FD 2.
 	return fmt.Sprintf(
-		`test -n "$%s" || exec {%s}>&2`,
+		`test -n "$%s" || `+
+			`(exec {%s}>&2) 2>/dev/null && exec {%s}>&2 || `+
+			`%s=2`,
+		progressFdEnvVar,
+		progressFdEnvVar,
 		progressFdEnvVar,
 		progressFdEnvVar,
 	)

--- a/cloudconfig/cloudinit/progress_test.go
+++ b/cloudconfig/cloudinit/progress_test.go
@@ -15,7 +15,10 @@ var _ = gc.Suite(&progressSuite{})
 
 func (*progressSuite) TestProgressCmds(c *gc.C) {
 	initCmd := cloudinit.InitProgressCmd()
-	c.Assert(initCmd, gc.Equals, `test -n "$JUJU_PROGRESS_FD" || exec {JUJU_PROGRESS_FD}>&2`)
+	c.Assert(initCmd, gc.Equals,
+		`test -n "$JUJU_PROGRESS_FD" || `+
+			`(exec {JUJU_PROGRESS_FD}>&2) 2>/dev/null && exec {JUJU_PROGRESS_FD}>&2 || `+
+			`JUJU_PROGRESS_FD=2`)
 	logCmd := cloudinit.LogProgressCmd("he'llo\"!")
 	c.Assert(logCmd, gc.Equals, `echo 'he'"'"'llo"!' >&$JUJU_PROGRESS_FD`)
 }

--- a/cloudconfig/cloudinit/progress_test.go
+++ b/cloudconfig/cloudinit/progress_test.go
@@ -4,8 +4,6 @@
 package cloudinit_test
 
 import (
-	"regexp"
-
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
@@ -17,11 +15,7 @@ var _ = gc.Suite(&progressSuite{})
 
 func (*progressSuite) TestProgressCmds(c *gc.C) {
 	initCmd := cloudinit.InitProgressCmd()
-	re := regexp.MustCompile(`test -e /proc/self/fd/([0-9]+) \|\| exec ([0-9]+)>&2`)
-	submatch := re.FindStringSubmatch(initCmd)
-	c.Assert(submatch, gc.HasLen, 3)
-	c.Assert(submatch[0], gc.Equals, initCmd)
-	c.Assert(submatch[1], gc.Equals, submatch[2])
+	c.Assert(initCmd, gc.Equals, `test -n "$JUJU_PROGRESS_FD" || exec {JUJU_PROGRESS_FD}>&2`)
 	logCmd := cloudinit.LogProgressCmd("he'llo\"!")
-	c.Assert(logCmd, gc.Equals, `echo 'he'"'"'llo"!' >&`+submatch[1])
+	c.Assert(logCmd, gc.Equals, `echo 'he'"'"'llo"!' >&$JUJU_PROGRESS_FD`)
 }

--- a/cloudconfig/cloudinit/renderscript_test.go
+++ b/cloudconfig/cloudinit/renderscript_test.go
@@ -220,7 +220,7 @@ func (s *configureSuite) TestAptUpgrade(c *gc.C) {
 
 func (s *configureSuite) TestAptMirrorWrapper(c *gc.C) {
 	expectedCommands := regexp.QuoteMeta(`
-echo 'Changing apt mirror to http://woat.com' >&9
+echo 'Changing apt mirror to http://woat.com' >&$JUJU_PROGRESS_FD
 old_mirror=$(awk "/^deb .* $(lsb_release -sc) .*main.*\$/{print \$2;exit}" /etc/apt/sources.list)
 new_mirror=http://woat.com
 sed -i s,$old_mirror,$new_mirror, /etc/apt/sources.list

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -329,7 +329,7 @@ install -D -m 644 /dev/null '/etc/init/juju-clean-shutdown\.conf'
 printf '%s\\n' '.*"Stop all network interfaces.*' > '/etc/init/juju-clean-shutdown\.conf'
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
 printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
-test -n "\$JUJU_PROGRESS_FD" \|\| exec \{JUJU_PROGRESS_FD\}>&2
+test -n "\$JUJU_PROGRESS_FD" \|\| \(exec \{JUJU_PROGRESS_FD\}>&2\) 2>/dev/null && exec \{JUJU_PROGRESS_FD\}>&2 \|\| JUJU_PROGRESS_FD=2
 \(\[ ! -e /home/ubuntu/.profile \] \|\| grep -q '.juju-proxy' /home/ubuntu/.profile\) \|\| printf .* >> /home/ubuntu/.profile
 mkdir -p /var/lib/juju/locks
 \(id ubuntu &> /dev/null\) && chown ubuntu:ubuntu /var/lib/juju/locks
@@ -386,7 +386,7 @@ install -D -m 644 /dev/null '/etc/init/juju-clean-shutdown\.conf'
 printf '%s\\n' '.*"Stop all network interfaces on shutdown".*' > '/etc/init/juju-clean-shutdown\.conf'
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
 printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
-test -n "\$JUJU_PROGRESS_FD" \|\| exec \{JUJU_PROGRESS_FD\}>&2
+test -n "\$JUJU_PROGRESS_FD" \|\| \(exec \{JUJU_PROGRESS_FD\}>&2\) 2>/dev/null && exec \{JUJU_PROGRESS_FD\}>&2 \|\| JUJU_PROGRESS_FD=2
 \(\[ ! -e /home/ubuntu/\.profile \] \|\| grep -q '.juju-proxy' /home/ubuntu/.profile\) \|\| printf .* >> /home/ubuntu/.profile
 mkdir -p /var/lib/juju/locks
 \(id ubuntu &> /dev/null\) && chown ubuntu:ubuntu /var/lib/juju/locks

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -329,7 +329,7 @@ install -D -m 644 /dev/null '/etc/init/juju-clean-shutdown\.conf'
 printf '%s\\n' '.*"Stop all network interfaces.*' > '/etc/init/juju-clean-shutdown\.conf'
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
 printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
-test -e /proc/self/fd/9 \|\| exec 9>&2
+test -n "\$JUJU_PROGRESS_FD" \|\| exec \{JUJU_PROGRESS_FD\}>&2
 \(\[ ! -e /home/ubuntu/.profile \] \|\| grep -q '.juju-proxy' /home/ubuntu/.profile\) \|\| printf .* >> /home/ubuntu/.profile
 mkdir -p /var/lib/juju/locks
 \(id ubuntu &> /dev/null\) && chown ubuntu:ubuntu /var/lib/juju/locks
@@ -386,7 +386,7 @@ install -D -m 644 /dev/null '/etc/init/juju-clean-shutdown\.conf'
 printf '%s\\n' '.*"Stop all network interfaces on shutdown".*' > '/etc/init/juju-clean-shutdown\.conf'
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
 printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
-test -e /proc/self/fd/9 \|\| exec 9>&2
+test -n "\$JUJU_PROGRESS_FD" \|\| exec \{JUJU_PROGRESS_FD\}>&2
 \(\[ ! -e /home/ubuntu/\.profile \] \|\| grep -q '.juju-proxy' /home/ubuntu/.profile\) \|\| printf .* >> /home/ubuntu/.profile
 mkdir -p /var/lib/juju/locks
 \(id ubuntu &> /dev/null\) && chown ubuntu:ubuntu /var/lib/juju/locks

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -68,7 +68,7 @@ var (
 	centos7ImageReference = compute.ImageReference{
 		Publisher: to.StringPtr("OpenLogic"),
 		Offer:     to.StringPtr("CentOS"),
-		Sku:       to.StringPtr("7.1"),
+		Sku:       to.StringPtr("7.3"),
 		Version:   to.StringPtr("latest"),
 	}
 

--- a/provider/azure/internal/imageutils/images.go
+++ b/provider/azure/internal/imageutils/images.go
@@ -91,7 +91,7 @@ func SeriesImage(
 		offering = centOSOffering
 		switch series {
 		case "centos7":
-			sku = "7.1"
+			sku = "7.3"
 		default:
 			return nil, errors.NotSupportedf("deploying %s", series)
 		}

--- a/provider/azure/internal/imageutils/images_test.go
+++ b/provider/azure/internal/imageutils/images_test.go
@@ -67,7 +67,7 @@ func (s *imageutilsSuite) TestSeriesImageWindows(c *gc.C) {
 }
 
 func (s *imageutilsSuite) TestSeriesImageCentOS(c *gc.C) {
-	s.assertImageId(c, "centos7", "released", "OpenLogic:CentOS:7.1:latest")
+	s.assertImageId(c, "centos7", "released", "OpenLogic:CentOS:7.3:latest")
 }
 
 func (s *imageutilsSuite) TestSeriesImageGenericLinux(c *gc.C) {


### PR DESCRIPTION
This PR makes two changes to get CentOS working on Azure again:
- update to CentOS 7.3, which includes a newer version of the Azure Linux agent. This is needed to fix a bug that was preventing the CustomData file from being written out.
- stop assuming we can use FD 9 for the progress logging in the cloud-init scripts; use a named file descriptor instead.

https://bugs.launchpad.net/juju/+bug/1571982