### PR TITLE
Change location of the meter status worker state file.

### DIFF
--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -32,6 +32,7 @@ var stateUpgradeOperations = func() []Operation {
 var upgradeOperations = func() []Operation {
 	steps := []Operation{
 		upgradeToVersion{version.MustParse("2.0.0"), stepsFor20()},
+		upgradeToVersion{version.MustParse("2.2.0"), stepsFor22()},
 	}
 	return steps
 }

--- a/upgrades/steps_22.go
+++ b/upgrades/steps_22.go
@@ -3,6 +3,11 @@
 
 package upgrades
 
+import (
+	"os"
+	"path/filepath"
+)
+
 // stateStepsFor22 returns upgrade steps for Juju 2.2 that manipulate state directly.
 func stateStepsFor22() []Step {
 	return []Step{
@@ -21,4 +26,22 @@ func stateStepsFor22() []Step {
 			},
 		},
 	}
+}
+
+// stepsFor22 returns upgrade steps for Juju 2.2 that only need the API.
+func stepsFor22() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "remove meter status file",
+			targets:     []Target{AllMachines},
+			run:         removeMeterStatusFile,
+		},
+	}
+}
+
+// removeMeterStatusFile removes the meter status file from the agent data directory.
+func removeMeterStatusFile(context Context) error {
+	dataDir := context.AgentConfig().DataDir()
+	meterStatusFile := filepath.Join(dataDir, "meter-status.yaml")
+	return os.RemoveAll(meterStatusFile)
 }

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -721,7 +721,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.UpgradeOperations)())
 	c.Assert(versions, gc.DeepEquals, []string{
-		"2.0.0",
+		"2.0.0", "2.2.0",
 	})
 }
 


### PR DESCRIPTION
The meter status worker keeps a local file to cache the currently known value of meter status in case connection to the controller is lost. This PR changes the location of that state file, moving it to the agent directory.