### PR TITLE
kvm enable arm64 xenial

### DIFF
--- a/container/kvm/container.go
+++ b/container/kvm/container.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/arch"
 
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/kvm/libvirt"
@@ -40,10 +41,15 @@ func (c *kvmContainer) Start(params StartParams) error {
 			return imagedownloads.NewDataSource(params.ImageDownloadURL)
 		}
 	}
+	var ftype = BIOSFType
+	if params.Arch == arch.ARM64 {
+		ftype = UEFIFType
+	}
+
 	sp := syncParams{
 		arch:    params.Arch,
 		series:  params.Series,
-		ftype:   FType,
+		ftype:   ftype,
 		srcFunc: srcFunc,
 	}
 	logger.Debugf("synchronise images for %s %s %s", sp.arch, sp.series, params.ImageDownloadURL)
@@ -71,7 +77,6 @@ func (c *kvmContainer) Start(params StartParams) error {
 	if err := CreateMachine(CreateMachineParams{
 		Hostname:      c.name,
 		Series:        params.Series,
-		Arch:          params.Arch,
 		UserDataFile:  params.UserDataFile,
 		NetworkBridge: bridge,
 		Memory:        params.Memory,

--- a/container/kvm/container_internal_test.go
+++ b/container/kvm/container_internal_test.go
@@ -17,7 +17,7 @@ type containerInternalSuite struct {
 
 var _ = gc.Suite(&containerInternalSuite{})
 
-func (_ containerInternalSuite) TestInterfaceInfo(c *gc.C) {
+func (containerInternalSuite) TestInterfaceInfo(c *gc.C) {
 	i := interfaceInfo{config: network.InterfaceInfo{
 		MACAddress: "mac", ParentInterfaceName: "piname", InterfaceName: "iname"}}
 	c.Check(i.InterfaceName(), gc.Equals, "iname")

--- a/container/kvm/export_test.go
+++ b/container/kvm/export_test.go
@@ -9,23 +9,29 @@ import "strings"
 // can utilize them to mock behavior.
 
 var (
+	// KVMPath is exported for use in tests.
 	KVMPath = &kvmPath
 
 	// Used to export the parameters used to call Start on the KVM Container
 	TestStartParams = &startParams
 )
 
-func MakeCreateMachineParamsTestable(params *CreateMachineParams, pathfinder func(string) (string, error), runCmd runFunc) {
+// MakeCreateMachineParamsTestable adds test values to non exported values on
+// CreateMachineParams.
+func MakeCreateMachineParamsTestable(params *CreateMachineParams, pathfinder func(string) (string, error), runCmd runFunc, arch string) {
 	params.findPath = pathfinder
 	params.runCmd = runCmd
 	params.runCmdAsRoot = runCmd
+	params.arch = arch
 	return
 }
 
+// NewEmptyKvmContainer returns an empty kvmContainer for testing.
 func NewEmptyKvmContainer() *kvmContainer {
 	return &kvmContainer{}
 }
 
+// NewTestContainer returns a new container for testing.
 func NewTestContainer(name string, runCmd runFunc, pathfinder func(string) (string, error)) *kvmContainer {
 	return &kvmContainer{name: name, runCmd: runCmd, pathfinder: pathfinder}
 }
@@ -41,6 +47,7 @@ type runStub struct {
 	calls  []string
 }
 
+// Run fakes running commands, instead recording calls made for use in testing.
 func (s *runStub) Run(cmd string, args ...string) (string, error) {
 	call := []string{cmd}
 	call = append(call, args...)
@@ -51,6 +58,7 @@ func (s *runStub) Run(cmd string, args ...string) (string, error) {
 	return s.output, nil
 }
 
+// Calls returns the calls made on a runStub.
 func (s *runStub) Calls() []string {
 	return s.calls
 }

--- a/container/kvm/kvm_test.go
+++ b/container/kvm/kvm_test.go
@@ -332,6 +332,7 @@ func (s *KVMSuite) TestIsKVMSupportedOnlyPath(c *gc.C) {
 	// developers without kvm-ok.
 	tmpDir := c.MkDir()
 	err := ioutil.WriteFile(filepath.Join(tmpDir, "kvm-ok"), []byte("#!/bin/bash"), 0777)
+	c.Check(err, jc.ErrorIsNil)
 	s.PatchEnvironment("PATH", tmpDir)
 
 	supported, err := kvm.IsKVMSupported()

--- a/container/kvm/libvirt/domainxml.go
+++ b/container/kvm/libvirt/domainxml.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/arch"
 )
 
 // Details of the domain XML format are at: https://libvirt.org/formatdomain.html
@@ -34,14 +35,22 @@ type InterfaceInfo interface {
 }
 
 type domainParams interface {
+	// Arch returns the arch for which we want to generate the domainXML.
+	Arch() string
 	// CPUs returns the number of CPUs to use.
 	CPUs() uint64
 	// DiskInfo returns the disk information for the domain.
 	DiskInfo() []DiskInfo
 	// Host returns the host name.
 	Host() string
+	// Loader returns the path to the EFI firmware blob to UEFI boot into an
+	// image. This is a read-only "pflash" drive.
+	Loader() string
 	// NetworkInfo contains the network interfaces to create in the domain.
 	NetworkInfo() []InterfaceInfo
+	// NVRAM returns the path to the UEFI variable storage drive. This is a
+	// "pflash" drive where UEFI stores variables used for booting an image.
+	NVRAM() string
 	// RAM returns the amount of RAM to use.
 	RAM() uint64
 	// ValidateDomainParams returns nil if the domainParams are valid.
@@ -56,27 +65,16 @@ func NewDomain(p domainParams) (Domain, error) {
 	}
 
 	d := Domain{
-		Type:     "kvm",
-		OS:       OS{Type: "hvm"},
-		Features: Features{},
-		Disk:     []Disk{},
-		Controller: []Controller{
-			Controller{
-				Type:  "usb",
-				Index: 0,
-				Address: &Address{
-					Type:     "pci",
-					Domain:   "0x0000",
-					Bus:      "0x00",
-					Slot:     "0x01",
-					Function: "0x2"},
-			},
-			Controller{
-				Type:  "pci",
-				Index: 0,
-				Model: "pci-root",
-			},
-		},
+		Type:          "kvm",
+		Name:          p.Host(),
+		VCPU:          p.CPUs(),
+		CurrentMemory: Memory{Unit: "MiB", Text: p.RAM()},
+		Memory:        Memory{Unit: "MiB", Text: p.RAM()},
+		OS:            generateOSElement(p),
+		Features:      generateFeaturesElement(p),
+		CPU:           generateCPU(p),
+		Disk:          []Disk{},
+		Interface:     []Interface{},
 		Serial: Serial{
 			Type: "pty",
 			Source: SerialSource{
@@ -98,15 +96,6 @@ func NewDomain(p domainParams) (Domain, error) {
 				},
 			},
 		},
-		Input: []Input{
-			Input{Type: "mouse", Bus: "ps2"},
-			Input{Type: "keyboard", Bus: "ps2"},
-		},
-		Interface:     []Interface{},
-		Name:          p.Host(),
-		VCPU:          p.CPUs(),
-		CurrentMemory: Memory{Unit: "MiB", Text: p.RAM()},
-		Memory:        Memory{Unit: "MiB", Text: p.RAM()},
 	}
 	for i, diskInfo := range p.DiskInfo() {
 		devID, err := deviceID(i)
@@ -147,6 +136,54 @@ func NewDomain(p domainParams) (Domain, error) {
 	return d, nil
 }
 
+// generateOSElement creates the architecture appropriate element details.
+func generateOSElement(p domainParams) OS {
+	switch p.Arch() {
+	case arch.ARM64:
+		return OS{
+			Type: OSType{
+				Arch:    "aarch64",
+				Machine: "virt",
+				Text:    "hvm",
+			},
+
+			Loader: &NVRAMCode{
+				Text:     p.Loader(),
+				ReadOnly: "yes",
+				Type:     "pflash",
+			},
+
+			NVRAMVars: p.NVRAM(),
+		}
+	default:
+		return OS{Type: OSType{Text: "hvm"}}
+	}
+}
+
+// generateFeaturesElement generates the appropriate features element based on
+// the architecture.
+func generateFeaturesElement(p domainParams) *Features {
+	if p.Arch() == arch.ARM64 {
+		return &Features{GIC: &GIC{Version: "host"}}
+	}
+	return nil
+}
+
+// generateCPU infor generates any model/fallback related settings. These are
+// typically to allow for better compatibility across versions of libvirt/qemu AFAIU.
+func generateCPU(p domainParams) *CPU {
+	if p.Arch() == arch.ARM64 {
+		return &CPU{
+			Mode:  "custom",
+			Match: "exact",
+			Model: Model{
+				Fallback: "allow",
+				Text:     "cortex-a53"},
+		}
+	}
+	return nil
+}
+
 // deviceID generates a device id from and int. The limit of 26 is arbitrary,
 // but it seems unlikely we'll need more than a couple for our use case.
 func deviceID(i int) (string, error) {
@@ -161,46 +198,86 @@ func deviceID(i int) (string, error) {
 // See: https://libvirt.org/formatdomain.html where we only care about kvm
 // specific details.
 type Domain struct {
-	XMLName       xml.Name     `xml:"domain"`
-	Type          string       `xml:"type,attr"`
-	OS            OS           `xml:"os"`
-	Features      Features     `xml:"features"`
-	Controller    []Controller `xml:"devices>controller"`
-	Serial        Serial       `xml:"devices>serial,omitempty"`
-	Console       []Console    `xml:"devices>console"`
-	Input         []Input      `xml:"devices>input"`
-	Interface     []Interface  `xml:"devices>interface"`
-	Disk          []Disk       `xml:"devices>disk"`
-	Name          string       `xml:"name"`
-	VCPU          uint64       `xml:"vcpu"`
-	CurrentMemory Memory       `xml:"currentMemory"`
-	Memory        Memory       `xml:"memory"`
+	XMLName       xml.Name    `xml:"domain"`
+	Type          string      `xml:"type,attr"`
+	Name          string      `xml:"name"`
+	VCPU          uint64      `xml:"vcpu"`
+	CurrentMemory Memory      `xml:"currentMemory"`
+	Memory        Memory      `xml:"memory"`
+	OS            OS          `xml:"os"`
+	Features      *Features   `xml:"features,omitempty"`
+	CPU           *CPU        `xml:"cpu,omitempty"`
+	Disk          []Disk      `xml:"devices>disk"`
+	Interface     []Interface `xml:"devices>interface"`
+	Serial        Serial      `xml:"devices>serial,omitempty"`
+	Console       []Console   `xml:"devices>console"`
 }
 
 // OS is static. We generate a default value (kvm) for it.
 // See: https://libvirt.org/formatdomain.html#elementsOSBIOS
 // See also: https://libvirt.org/formatcaps.html#elementGuest
 type OS struct {
-	Type string `xml:"type"`
+	Type OSType `xml:"type"`
+	// Loader is a pointer so it is omitted if empty.
+	Loader *NVRAMCode `xml:"loader,omitempty"`
+	// NVRAMVars is the writable storage for UEFI to store variables.
+	// See: https://libvirt.org/formatdomain.html#elementsOS
+	NVRAMVars string `xml:"nvram,omitempty"`
 }
 
-// Features is static. We generate empty elements for the members of this
-// struct.
-// See: https://libvirt.org/formatcaps.html#elementGuest
+// OSType provides details that are required on certain architectures, e.g.
+// ARM64.
+// See: https://libvirt.org/formatdomain.html#elementsOS
+type OSType struct {
+	Text    string `xml:",chardata"`
+	Arch    string `xml:"arch,attr,omitempty"`
+	Machine string `xml:"machine,attr,omitempty"`
+}
+
+// NVRAMCode represents the "firmware blob". In our case that is the UEFI code
+// which is of type pflash.
+// See: https://libvirt.org/formatdomain.html#elementsOS
+type NVRAMCode struct {
+	Text     string `xml:",chardata"`
+	ReadOnly string `xml:"readonly,attr,omitempty"`
+	Type     string `xml:"type,attr,omitempty"`
+}
+
+// Features is only generated for ARM64 at the time of this writing. This is
+// because GIC is required for ARM64.
+// See: https://libvirt.org/formatdomain.html#elementsFeatures
 type Features struct {
-	ACPI string `xml:"acpi"`
-	APIC string `xml:"apic"`
-	PAE  string `xml:"pae"`
+	GIC *GIC `xml:"gic,omitempty"`
 }
 
-// Controller is static. We generate a default value for it.
-// See: https://libvirt.org/formatdomain.html#elementsControllers
-type Controller struct {
-	Type  string `xml:"type,attr"`
-	Index int    `xml:"index,attr"`
-	Model string `xml:"model,attr,omitempty"`
-	// Address is a pointer here so we can omit an empty value.
-	Address *Address `xml:"address,omitempty"`
+// GIC is the Generic Interrupt Controller and is required to UEFI boot on
+// ARM64.
+//
+// NB: Dann Frazier (irc:dannf) reports:
+// To deploy trusty, we'll either need to use a GICv2 host, or use the HWE
+// kernel in your guest. There are no official cloud images w/ HWE kernel
+// preinstalled AFAIK.
+// The systems we have in our #hyperscale lab are GICv3 (requiring an HWE
+// kernel) - but the system Juju QA has had for a while (McDivitt) is GICv2, so
+// it should be able to boot a standard trusty EFI cloud image.  Either way,
+// you'll need a xenial *host*, at least to have a new enough version of
+// qemu-efi and so libvirt can parse the gic_version=host xml.
+//
+// TODO(ro) 2017-01-20 Determine if we can provide details to reliably boot
+// trusty, or if we should exit on error if we are trying to boot trusty on
+// arm64.
+//
+// See: https://libvirt.org/formatdomain.html#elementsFeatures
+type GIC struct {
+	Version string `xml:"version,attr,omitempty"`
+}
+
+// CPU defines CPU topology and model requirements.
+// See: https://libvirt.org/formatdomain.html#elementsCPU
+type CPU struct {
+	Mode  string `xml:"mode,attr,omitempty"`
+	Match string `xml:"match,attr,omitempty"`
+	Model Model  `xml:"model,omitempty"`
 }
 
 // Address is static. We generate a default value for it.
@@ -256,13 +333,6 @@ type SerialSource struct {
 // See: Serial
 type SerialTarget struct {
 	Port int `xml:"port,attr"`
-}
-
-// Input is static. We generate default values for keyboard and mouse.
-// See: https://libvirt.org/formatdomain.html#elementsInput
-type Input struct {
-	Type string `xml:"type,attr"`
-	Bus  string `xml:"bus,attr"`
 }
 
 // Interface is dynamic. It represents a network interface. We generate it from
@@ -342,10 +412,10 @@ type Memory struct {
 	Text uint64 `xml:",chardata"`
 }
 
-// Model is used as an element in Video and Interface.
-// See: Video, Interface
+// Model is used as an element in CPU and Interface.
+// See: CPU, Interface
 type Model struct {
-	Type  string `xml:"type,attr"`
-	VRAM  string `xml:"vram,attr,omitempty"`
-	Heads string `xml:"heads,attr,omitempty"`
+	Fallback string `xml:"fallback,attr,omitempty"`
+	Text     string `xml:",chardata"`
+	Type     string `xml:"type,attr,omitempty"`
 }

--- a/container/kvm/sync.go
+++ b/container/kvm/sync.go
@@ -21,8 +21,13 @@ import (
 	"github.com/juju/juju/juju/paths"
 )
 
-// FType is the file type we want to fetch and use for kvm instances.
-const FType = "disk1.img"
+// BIOSFType is the file type we want to fetch and use for kvm instances which
+// boot using a legacy BIOS boot loader.
+const BIOSFType = "disk1.img"
+
+// UEFIFType is teh file type we want to fetch and use for kvm instances which
+// boot using UEFI. In our case this is ARM64.
+const UEFIFType = "uefi1.img"
 
 // Oner gets the one matching item from simplestreams.
 type Oner interface {


### PR DESCRIPTION
This enables kvm on ARM. It also removes a bit of XML which it turns out are defaults, and therefore unnecessary. It also reorders the generated XML to be ordered like that which is output by virsh dumpxml ...

This could use a couple more tests and a bit more polish, but I can do that after we figure out what we are going to do about trusty on arm64 and get ppc64el enabled.

I'm not sure how to have others reproduce QA.
But I:

1. verified all unit tests pass
2. Bootsrtapped on and ARM64 MAAS
3. juju add-machine
4. juju deploy ubuntu --to kvm:0
