### PR TITLE
Filter virbr0 when finding addresses for a machine

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -85,6 +85,9 @@ LXC_BRIDGE="ignored"`[1:])
 				&net.IPAddr{IP: net.IPv4(10, 0, 4, 1)},
 				&net.IPAddr{IP: net.IPv4(10, 0, 4, 4)},
 			}, nil
+		} else if name == network.DefaultKVMBridge {
+			// claim we don't have a virbr0 bridge
+			return nil, nil
 		}
 		c.Fatalf("unknown bridge in testing: %v", name)
 		return nil, nil

--- a/network/network.go
+++ b/network/network.go
@@ -338,77 +338,90 @@ var InterfaceByNameAddrs = func(name string) ([]net.Addr, error) {
 	return iface.Addrs()
 }
 
-// filterAddrs looks at all of the addresses in allAddresses and removes ones
-// that line up with removeAddresses. Note that net.Addr may be just an IP or
-// may be a CIDR.
-func filterAddrs(bridgeName string, allAddresses []Address, removeAddresses []net.Addr) []Address {
-	filtered := make([]Address, 0, len(allAddresses))
-	// TODO(jam) ips could be turned into a map[string]bool rather than
-	// iterating over all of them, as we only compare against ip.String()
-	ips := make([]net.IP, 0, len(removeAddresses))
-	ipNets := make([]*net.IPNet, 0, len(removeAddresses))
-	for _, ifaceAddr := range removeAddresses {
-		// First check if this is a CIDR, as
-		// net.InterfaceAddrs might return this instead of
-		// a plain IP.
-		ip, ipNet, err := net.ParseCIDR(ifaceAddr.String())
-		if err != nil {
-			// It's not a CIDR, try parsing as IP.
-			ip = net.ParseIP(ifaceAddr.String())
-		}
-		if ip == nil {
-			logger.Debugf("cannot parse %q as IP, ignoring", ifaceAddr)
-			continue
-		}
-		ips = append(ips, ip)
-		if ipNet != nil {
-			ipNets = append(ipNets, ipNet)
+type ipNetAndName struct {
+	ipnet *net.IPNet
+	name string
+}
+
+func addrMapToIPNetAndName(bridgeToAddrs map[string][]net.Addr) []ipNetAndName {
+	ipNets := make([]ipNetAndName, 0, len(bridgeToAddrs))
+	for bridgeName, addrList := range bridgeToAddrs {
+		for _, ifaceAddr := range addrList {
+			ip, ipNet, err := net.ParseCIDR(ifaceAddr.String())
+			if err != nil {
+				// Not a valid CIDR, check as an IP
+				ip = net.ParseIP(ifaceAddr.String())
+			}
+			if ip == nil {
+				logger.Debugf("cannot parse %q as IP, ignoring", ifaceAddr)
+				continue
+			}
+			if ipNet == nil {
+				// convert the IP into an IPNet
+				if ip.To4() != nil {
+					_, ipNet, err = net.ParseCIDR(ip.String() + "/32")
+					if err != nil {
+						logger.Debugf("error creating a /32 CIDR for %q", ifaceAddr)
+					}
+				} else if ip.To16() != nil {
+					_, ipNet, err = net.ParseCIDR(ip.String() + "/128")
+					if err != nil {
+						logger.Debugf("error creating a /128 CIDR for %q", ifaceAddr)
+					}
+				} else {
+					logger.Debugf("failed to convert %q to a v4 or v6 address, ignoring", ifaceAddr)
+				}
+			}
+			ipNets = append(ipNets, ipNetAndName{ipnet: ipNet, name: bridgeName})
 		}
 	}
+	return ipNets
+}
+
+// filterAddrs looks at all of the addresses in allAddresses and removes ones
+// that line up with removeAddresses. Note that net.Addr may be just an IP or
+// may be a CIDR.  removeAddresses should be a map of 'bridge name' to list of
+// addresses, so that we can report why the address was filtered.
+func filterAddrs(allAddresses []Address, removeAddresses map[string][]net.Addr) []Address {
+	filtered := make([]Address, 0, len(allAddresses))
+	// Convert all 
+	ipNets := addrMapToIPNetAndName(removeAddresses)
 	for _, addr := range allAddresses {
-		found := false
-		// Filter all known IPs
-		for _, ip := range ips {
-			if ip.String() == addr.Value {
-				found = true
+		bridgeName := ""
+		// Then check if it is in one of the CIDRs
+		ip := net.ParseIP(addr.Value)
+		if ip == nil {
+			logger.Debugf("invalid IP: %q", addr.Value)
+			continue
+		}
+		for _, ipNetName := range ipNets {
+			if ipNetName.ipnet.Contains(ip) {
+				bridgeName = ipNetName.name
 				break
 			}
 		}
-		if !found {
-			// Then check if it is in one of the CIDRs
-			for _, ipNet := range ipNets {
-				if ipNet.Contains(net.ParseIP(addr.Value)) {
-					found = true
-					break
-				}
-			}
-		}
-		if found {
-			logger.Debugf("filtering %q address %s for machine", bridgeName, addr.String())
-		} else {
-			logger.Debugf("not filtering address %s for machine", addr)
+		if bridgeName == "" {
+			logger.Debugf("including address %v for machine", addr)
 			filtered = append(filtered, addr)
+		} else {
+			logger.Debugf("filtering %q address %s for machine", bridgeName, addr.String())
 		}
 	}
-	logger.Debugf("addresses after filtering: %v", filtered)
 	return filtered
 }
 
-// filterLXCAddresses tries to discover the default lxc bridge name
-// and all of its addresses, then filters those addresses out of the
-// given ones and returns the result. Any errors encountered during
-// this process are logged, but not considered fatal. See LP bug
-// #1416928.
-func filterLXCAddresses(addresses []Address) []Address {
+// gatherLXCAddresses tries to discover the default lxc bridge name
+// and all of its addresses. See LP bug #1416928.
+func gatherLXCAddresses(toRemove map[string][]net.Addr) {
 	file, err := os.Open(LXCNetDefaultConfig)
 	if os.IsNotExist(err) {
 		// No lxc-net config found, nothing to do.
 		logger.Debugf("no lxc bridge addresses to filter for machine")
-		return addresses
+		return
 	} else if err != nil {
 		// Just log it, as it's not fatal.
 		logger.Errorf("cannot open %q: %v", LXCNetDefaultConfig, err)
-		return addresses
+		return
 	}
 	defer file.Close()
 
@@ -426,44 +439,25 @@ func filterLXCAddresses(addresses []Address) []Address {
 				continue
 			}
 			bridgeName := strings.TrimSpace(parts[1])
-			// Discover all addresses of bridgeName interface.
-			addrs, err := InterfaceByNameAddrs(bridgeName)
-			if err != nil {
-				logger.Debugf("cannot get %q addresses: %v (ignoring)", bridgeName, err)
-				continue
-			}
-			logger.Debugf("%q has addresses %v", bridgeName, addrs)
-			return filterAddrs(bridgeName, addresses, addrs)
+			gatherBridgeAddresses(bridgeName, toRemove)
+			return
 		}
 	}
 	if err := scanner.Err(); err != nil {
 		logger.Debugf("failed to read %q: %v (ignoring)", LXCNetDefaultConfig, err)
 	}
-	return addresses
+	return
 }
 
-func filterBridgeAddresses(bridgeName string, addresses []Address) []Address {
-	// Should we be getting this from LXD instead?
+func gatherBridgeAddresses(bridgeName string, toRemove map[string][]net.Addr) {
 	addrs, err := InterfaceByNameAddrs(bridgeName)
 	if err != nil {
 		logger.Debugf("cannot get %q addresses: %v (ignoring)", bridgeName, err)
-		return addresses
+		return
 	}
 	logger.Debugf("%q has addresses %v", bridgeName, addrs)
-	return filterAddrs(bridgeName, addresses, addrs)
-
-}
-
-// filterLXDAddresses removes addresses on the LXD bridge from the list to be
-// considered.
-func filterLXDAddresses(addresses []Address) []Address {
-	return filterBridgeAddresses(DefaultLXDBridge, addresses)
-}
-
-// filterKVMAddresses removes addresses on the default KVM bridge from the list
-// to be considered.
-func filterKVMAddresses(addresses []Address) []Address {
-	return filterBridgeAddresses(DefaultKVMBridge, addresses)
+	toRemove[bridgeName] = addrs
+	return
 
 }
 
@@ -471,8 +465,11 @@ func filterKVMAddresses(addresses []Address) []Address {
 // address used only to connect to local containers), rather than a remote
 // accessible address.
 func FilterBridgeAddresses(addresses []Address) []Address {
-	addresses = filterLXCAddresses(addresses)
-	addresses = filterLXDAddresses(addresses)
-	addresses = filterKVMAddresses(addresses)
-	return addresses
+	addressesToRemove := make(map[string][]net.Addr)
+	gatherLXCAddresses(addressesToRemove)
+	gatherBridgeAddresses(DefaultLXDBridge, addressesToRemove)
+	gatherBridgeAddresses(DefaultKVMBridge, addressesToRemove)
+	filtered := filterAddrs(addresses, addressesToRemove)
+	logger.Debugf("addresses after filtering: %v", filtered)
+	return filtered
 }

--- a/network/network.go
+++ b/network/network.go
@@ -340,7 +340,7 @@ var InterfaceByNameAddrs = func(name string) ([]net.Addr, error) {
 
 type ipNetAndName struct {
 	ipnet *net.IPNet
-	name string
+	name  string
 }
 
 func addrMapToIPNetAndName(bridgeToAddrs map[string][]net.Addr) []ipNetAndName {
@@ -384,20 +384,20 @@ func addrMapToIPNetAndName(bridgeToAddrs map[string][]net.Addr) []ipNetAndName {
 // addresses, so that we can report why the address was filtered.
 func filterAddrs(allAddresses []Address, removeAddresses map[string][]net.Addr) []Address {
 	filtered := make([]Address, 0, len(allAddresses))
-	// Convert all 
+	// Convert all
 	ipNets := addrMapToIPNetAndName(removeAddresses)
 	for _, addr := range allAddresses {
 		bridgeName := ""
 		// Then check if it is in one of the CIDRs
 		ip := net.ParseIP(addr.Value)
 		if ip == nil {
-			logger.Debugf("invalid IP: %q", addr.Value)
-			continue
-		}
-		for _, ipNetName := range ipNets {
-			if ipNetName.ipnet.Contains(ip) {
-				bridgeName = ipNetName.name
-				break
+			logger.Debugf("not filtering invalid IP: %q", addr.Value)
+		} else {
+			for _, ipNetName := range ipNets {
+				if ipNetName.ipnet.Contains(ip) {
+					bridgeName = ipNetName.name
+					break
+				}
 			}
 		}
 		if bridgeName == "" {

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -118,6 +118,7 @@ func (s *NetworkSuite) TestFilterBridgeAddresses(c *gc.C) {
 	// 10.0.3.4 and 10.0.3.5/24 on that bridge.
 	// We also put 10.0.4.1 and 10.0.5.1/24 onto whatever bridge LXD is
 	// configured to use.
+	// And 192.168.122.1 on virbr0
 	netConf := []byte(`
   # comments ignored
 LXC_BR= ignored
@@ -141,6 +142,10 @@ LXC_BRIDGE="ignored"`[1:])
 				// Try a CIDR 10.0.5.1/24 as well.
 				&net.IPNet{IP: net.IPv4(10, 0, 5, 1), Mask: net.IPv4Mask(255, 255, 255, 0)},
 			}, nil
+		} else if name == network.DefaultKVMBridge {
+			return []net.Addr{
+				&net.IPAddr{IP: net.IPv4(192, 168, 122, 1)},
+			}, nil
 		}
 		c.Fatalf("unknown bridge name: %q", name)
 		return nil, nil
@@ -151,13 +156,14 @@ LXC_BRIDGE="ignored"`[1:])
 		"127.0.0.1",
 		"2001:db8::1",
 		"10.0.0.1",
-		"10.0.3.1",  // filtered (directly as IP)
-		"10.0.3.3",  // filtered (by the 10.0.3.5/24 CIDR)
-		"10.0.3.5",  // filtered (directly)
-		"10.0.3.4",  // filtered (directly)
-		"10.0.4.1",  // filtered (directly from LXD bridge)
-		"10.0.5.10", // filtered (from LXD bridge, 10.0.5.1/24)
-		"10.0.6.10", // unfiltered
+		"10.0.3.1",      // filtered (directly as IP)
+		"10.0.3.3",      // filtered (by the 10.0.3.5/24 CIDR)
+		"10.0.3.5",      // filtered (directly)
+		"10.0.3.4",      // filtered (directly)
+		"10.0.4.1",      // filtered (directly from LXD bridge)
+		"10.0.5.10",     // filtered (from LXD bridge, 10.0.5.1/24)
+		"10.0.6.10",     // unfiltered
+		"192.168.122.1", // filtered (from virbr0 bridge, 192.168.122.1)
 		"192.168.123.42",
 	)
 	filteredAddresses := network.NewAddresses(

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -165,6 +165,7 @@ LXC_BRIDGE="ignored"`[1:])
 		"10.0.6.10",     // unfiltered
 		"192.168.122.1", // filtered (from virbr0 bridge, 192.168.122.1)
 		"192.168.123.42",
+		"localhost", // unfiltered because it isn't an IP address
 	)
 	filteredAddresses := network.NewAddresses(
 		"127.0.0.1",
@@ -172,6 +173,7 @@ LXC_BRIDGE="ignored"`[1:])
 		"10.0.0.1",
 		"10.0.6.10",
 		"192.168.123.42",
+		"localhost",
 	)
 	c.Assert(network.FilterBridgeAddresses(inputAddresses), jc.DeepEquals, filteredAddresses)
 }

--- a/worker/apiaddressupdater/apiaddressupdater_test.go
+++ b/worker/apiaddressupdater/apiaddressupdater_test.go
@@ -132,6 +132,10 @@ LXC_BRIDGE="ignored"`[1:])
 				&net.IPAddr{IP: net.IPv4(10, 0, 4, 1)},
 				&net.IPAddr{IP: net.IPv4(10, 0, 4, 4)},
 			}, nil
+		} else if name == network.DefaultKVMBridge {
+			return []net.Addr{
+				&net.IPAddr{IP: net.IPv4(192, 168, 122, 1)},
+			}, nil
 		}
 		c.Fatalf("unknown bridge in testing: %v", name)
 		return nil, nil
@@ -142,10 +146,11 @@ LXC_BRIDGE="ignored"`[1:])
 		network.NewHostPorts(1234, "localhost", "127.0.0.1"),
 		network.NewHostPorts(
 			4321,
-			"10.0.3.1", // filtered
-			"10.0.3.3", // not filtered (not a lxc bridge address)
-			"10.0.4.1", // filtered lxd bridge address
-			"10.0.4.2", // not filtered
+			"10.0.3.1",      // filtered
+			"10.0.3.3",      // not filtered (not a lxc bridge address)
+			"10.0.4.1",      // filtered lxd bridge address
+			"10.0.4.2",      // not filtered
+			"192.168.122.1", // filtered default virbr0
 		),
 		network.NewHostPorts(4242, "10.0.3.4"), // filtered
 	}

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -484,6 +484,10 @@ LXC_BRIDGE="ignored"`[1:])
 				&net.IPAddr{IP: net.IPv4(10, 0, 4, 1)},
 				&net.IPAddr{IP: net.IPv4(10, 0, 4, 4)},
 			}, nil
+		} else if name == network.DefaultKVMBridge {
+			return []net.Addr{
+				&net.IPAddr{IP: net.IPv4(192, 168, 1, 1)},
+			}, nil
 		}
 		c.Fatalf("unknown bridge in testing: %v", name)
 		return nil, nil
@@ -494,7 +498,16 @@ LXC_BRIDGE="ignored"`[1:])
 	defer worker.Stop(mr)
 	c.Assert(s.machine.Destroy(), jc.ErrorIsNil)
 	s.State.StartSync()
-	c.Assert(mr.Wait(), gc.Equals, worker.ErrTerminateAgent)
+	errCh := make(chan error, 0)
+	go func() {
+		errCh <-mr.Wait()
+	}()
+	select {
+	case err = <-errCh:
+		c.Assert(mr.Wait(), gc.Equals, worker.ErrTerminateAgent)
+	case <-time.After(coretesting.ShortWait):
+		c.Fatalf("Machiner failed to terminate.")
+	}
 	c.Assert(s.machine.Refresh(), jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
Without filtering virbr0 we run into things where 'bootstrap' tries to use
the virbr0 address which exists both remotely and locally.
We were already filtering lxc and lxdbr0, this just includes virbr0
to be omitted as well.
This also cleans up the logging output by aggregating the addresses for all bridges in the beginning, and then filtering them all at once, instead of doing them one-by-one. Without this, each IP address that we kept would have 3 entries in the log file that we were keeping it.

Should help with bug #1644429.

To test this, you'll want to bootstrap and install libvirt-bin both locally and on the controller machine. At which point, juju should *not* think one of the remote machine's valid addresses is 192.168.122.1 (the default virbr0 address.) You can test this using lxd using the following cheats:
Something like these steps:

  $ sudo apt install libvirt-bin
  $ juju bootstrap lxd test-lxd
  $ juju switch controller
  $ juju ssh 0
  $$ sudo apt install libvirt-bin
  $$ sudo brctl addbr virbr0
  $$ sudo ip addr add 192.168.122.1 dev virbr0
  $$ service restart jujud-machine-0
  $$ ^D
  $ juju show-machine 0

This patch may not be fully sufficient to filter the virbr0 for 'lxd', because lxd itself reports 'virbr0' as one of the valid interfaces to contact the machine, and the above only filters our "machine addresses" not the addresses that the Provider reports. However, MAAS and AWS shouldn't report virbr0 as one of the known-to-the-provider addresses, which is what this patch helps with.
I did dump the database with and without this patch and saw that the new way does suppress virbr0 just like we suppress other bridge ip addresses.