### PR TITLE
[apiserver/metricsmanager] Close state objects opened.

### DIFF
--- a/apiserver/metricsmanager/metricsmanager.go
+++ b/apiserver/metricsmanager/metricsmanager.go
@@ -116,6 +116,7 @@ func (api *MetricsManagerAPI) CleanupOldMetrics(args params.Entities) (params.Er
 				result.Results[i].Error = common.ServerError(err)
 				continue
 			}
+			defer modelState.Close()
 		}
 
 		err = modelState.CleanupOldMetrics()
@@ -157,6 +158,7 @@ func (api *MetricsManagerAPI) SendMetrics(args params.Entities) (params.ErrorRes
 				result.Results[i].Error = common.ServerError(err)
 				continue
 			}
+			defer modelState.Close()
 		}
 		txVendorMetrics, err := transmitVendorMetrics(modelState)
 		if err != nil {


### PR DESCRIPTION
The metrics manager api methods for CleanupOldMetrics and SendMetrics would open a State object with ForModel, and not close it.