### PR TITLE
ARM test time tweaks.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,13 @@ else
 	INSTALL_FLAGS := -gccgoflags=-static-libgo
 endif
 
+# Allow the tests to take longer on arm platforms.
+ifeq ($(shell uname -p | sed -r 's/.*(armel|armhf|aarch64).*/golang/'), golang)
+	TEST_TIMEOUT := 2400s
+else
+	TEST_TIMEOUT := 1500s
+endif
+
 define DEPENDENCIES
   ca-certificates
   bzip2
@@ -49,7 +56,7 @@ build: godeps
 	go build $(PROJECT)/...
 
 check: godeps
-	go test -v -test.timeout=1500s $(PROJECT)/... -check.v
+	go test -v -test.timeout=$(TEST_TIMEOUT) $(PROJECT)/... -check.v
 
 install: godeps
 	go install $(INSTALL_FLAGS) -v $(PROJECT)/...

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -5,12 +5,14 @@ package state_test
 
 import (
 	"fmt"
+	"runtime"
 	"sort"
 	"strconv"
 	"time" // Only used to Sleep().
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/txn"
+	"github.com/juju/utils/arch"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
@@ -1253,7 +1255,10 @@ func (s *assignCleanSuite) TestAssignUnitPolicyConcurrently(c *gc.C) {
 	_, err := s.State.AddMachine("quantal", state.JobManageModel) // bootstrap machine
 	c.Assert(err, jc.ErrorIsNil)
 	unitCount := 50
-	if raceDetector {
+	// On arm with 50 concurrent attempts, this test takes over 90s.
+	if arch.NormaliseArch(runtime.GOARCH) == arch.ARM {
+		unitCount = 5
+	} else if raceDetector {
 		unitCount = 10
 	}
 	us := make([]*state.Unit, unitCount)


### PR DESCRIPTION
The concurrent assignment tests on ARM take around 90s each.

Also, until we get good times, allow test runs on ARM to take longer.