### PR TITLE
Add support to azure provider for security group source CIDRs, and also other related drive by fixes

### DIFF
--- a/environs/interface.go
+++ b/environs/interface.go
@@ -333,6 +333,9 @@ type Firewaller interface {
 	// IngressRules returns the ingress rules applied to the whole environment.
 	// Must only be used if the environment was setup with the
 	// FwGlobal firewall mode.
+	// It is expected that there be only one ingress rule result for a given
+	// port range - the rule's SourceCIDRs will contain all applicable source
+	// address rules for that port range.
 	IngressRules() ([]network.IngressRule, error)
 }
 

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -51,6 +51,9 @@ type Instance interface {
 	// IngressRules returns the set of ingress rules for the instance,
 	// which should have been applied to the given machine id. The
 	// rules are returned as sorted by network.SortIngressRules().
+	// It is expected that there be only one ingress rule result for a given
+	// port range - the rule's SourceCIDRs will contain all applicable source
+	// address rules for that port range.
 	IngressRules(machineId string) ([]network.IngressRule, error)
 }
 

--- a/network/firewall.go
+++ b/network/firewall.go
@@ -68,8 +68,9 @@ func NewOpenIngressRule(protocol string, from, to int) IngressRule {
 // String is the string representation of IngressRule.
 func (r IngressRule) String() string {
 	source := ""
-	if len(r.SourceCIDRs) > 0 {
-		source = " from " + strings.Join(r.SourceCIDRs, ",")
+	from := strings.Join(r.SourceCIDRs, ",")
+	if from != "" && from != "0.0.0.0/0" {
+		source = " from " + from
 	}
 	if r.FromPort == r.ToPort {
 		return fmt.Sprintf("%d/%s%s", r.FromPort, strings.ToLower(r.Protocol), source)

--- a/network/firewall_test.go
+++ b/network/firewall_test.go
@@ -18,44 +18,21 @@ type FirewallSuite struct {
 var _ = gc.Suite(&FirewallSuite{})
 
 func (*FirewallSuite) TestStrings(c *gc.C) {
-	rule, err := network.NewIngressRule("tcp", 80, 80)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(
-		rule.String(),
-		gc.Equals,
-		"80/tcp",
-	)
-	c.Assert(
-		rule.GoString(),
-		gc.Equals,
-		"80/tcp",
-	)
+	rule := network.MustNewIngressRule("tcp", 80, 80)
+	c.Assert(rule.String(), gc.Equals, "80/tcp")
+	c.Assert(rule.GoString(), gc.Equals, "80/tcp")
 
-	rule, err = network.NewIngressRule("tcp", 80, 100)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(
-		rule.String(),
-		gc.Equals,
-		"80-100/tcp",
-	)
-	c.Assert(
-		rule.GoString(),
-		gc.Equals,
-		"80-100/tcp",
-	)
+	rule = network.MustNewIngressRule("tcp", 80, 80, "0.0.0.0/0")
+	c.Assert(rule.String(), gc.Equals, "80/tcp")
+	c.Assert(rule.GoString(), gc.Equals, "80/tcp")
 
-	rule, err = network.NewIngressRule("tcp", 80, 100, "0.0.0.0/0", "192.168.1.0/24")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(
-		rule.String(),
-		gc.Equals,
-		"80-100/tcp from 0.0.0.0/0,192.168.1.0/24",
-	)
-	c.Assert(
-		rule.GoString(),
-		gc.Equals,
-		"80-100/tcp from 0.0.0.0/0,192.168.1.0/24",
-	)
+	rule = network.MustNewIngressRule("tcp", 80, 100)
+	c.Assert(rule.String(), gc.Equals, "80-100/tcp")
+	c.Assert(rule.GoString(), gc.Equals, "80-100/tcp")
+
+	rule = network.MustNewIngressRule("tcp", 80, 100, "0.0.0.0/0", "192.168.1.0/24")
+	c.Assert(rule.String(), gc.Equals, "80-100/tcp from 0.0.0.0/0,192.168.1.0/24")
+	c.Assert(rule.GoString(), gc.Equals, "80-100/tcp from 0.0.0.0/0,192.168.1.0/24")
 }
 
 func (*FirewallSuite) TestSortIngressRules(c *gc.C) {

--- a/provider/azure/instance_test.go
+++ b/provider/azure/instance_test.go
@@ -275,7 +275,7 @@ func (s *instanceSuite) TestMultipleInstanceAddresses(c *gc.C) {
 	))
 }
 
-func (s *instanceSuite) TestInstancePortsEmpty(c *gc.C) {
+func (s *instanceSuite) TestIngressRulesEmpty(c *gc.C) {
 	inst := s.getInstance(c)
 	nsgSender := networkSecurityGroupSender(nil)
 	s.sender = azuretesting.Senders{nsgSender}
@@ -284,7 +284,7 @@ func (s *instanceSuite) TestInstancePortsEmpty(c *gc.C) {
 	c.Assert(rules, gc.HasLen, 0)
 }
 
-func (s *instanceSuite) TestInstancePorts(c *gc.C) {
+func (s *instanceSuite) TestIngressRules(c *gc.C) {
 	inst := s.getInstance(c)
 	nsgSender := networkSecurityGroupSender([]network.SecurityRule{{
 		Name: to.StringPtr("machine-0-xyzzy"),
@@ -296,10 +296,31 @@ func (s *instanceSuite) TestInstancePorts(c *gc.C) {
 			Direction:            network.Inbound,
 		},
 	}, {
-		Name: to.StringPtr("machine-0-tcpcp"),
+		Name: to.StringPtr("machine-0-tcpcp-1"),
 		Properties: &network.SecurityRulePropertiesFormat{
 			Protocol:             network.TCP,
 			DestinationPortRange: to.StringPtr("1000-2000"),
+			SourceAddressPrefix:  to.StringPtr("*"),
+			Access:               network.Allow,
+			Priority:             to.Int32Ptr(201),
+			Direction:            network.Inbound,
+		},
+	}, {
+		Name: to.StringPtr("machine-0-tcpcp-2"),
+		Properties: &network.SecurityRulePropertiesFormat{
+			Protocol:             network.TCP,
+			DestinationPortRange: to.StringPtr("1000-2000"),
+			SourceAddressPrefix:  to.StringPtr("192.168.1.0/24"),
+			Access:               network.Allow,
+			Priority:             to.Int32Ptr(201),
+			Direction:            network.Inbound,
+		},
+	}, {
+		Name: to.StringPtr("machine-0-tcpcp-3"),
+		Properties: &network.SecurityRulePropertiesFormat{
+			Protocol:             network.TCP,
+			DestinationPortRange: to.StringPtr("1000-2000"),
+			SourceAddressPrefix:  to.StringPtr("10.0.0.0/24"),
 			Access:               network.Allow,
 			Priority:             to.Int32Ptr(201),
 			Direction:            network.Inbound,
@@ -354,23 +375,12 @@ func (s *instanceSuite) TestInstancePorts(c *gc.C) {
 
 	rules, err := inst.IngressRules("0")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(rules, jc.DeepEquals, jujunetwork.RulesFromPortRanges([]jujunetwork.PortRange{{
-		FromPort: 0,
-		ToPort:   65535,
-		Protocol: "udp",
-	}, {
-		FromPort: 1000,
-		ToPort:   2000,
-		Protocol: "tcp",
-	}, {
-		FromPort: 80,
-		ToPort:   80,
-		Protocol: "tcp",
-	}, {
-		FromPort: 80,
-		ToPort:   80,
-		Protocol: "udp",
-	}}...))
+	c.Assert(rules, jc.DeepEquals, []jujunetwork.IngressRule{
+		jujunetwork.MustNewIngressRule("tcp", 80, 80, "0.0.0.0/0"),
+		jujunetwork.MustNewIngressRule("tcp", 1000, 2000, "0.0.0.0/0", "192.168.1.0/24", "10.0.0.0/24"),
+		jujunetwork.MustNewIngressRule("udp", 0, 65535, "0.0.0.0/0"),
+		jujunetwork.MustNewIngressRule("udp", 80, 80, "0.0.0.0/0"),
+	})
 }
 
 func (s *instanceSuite) TestInstanceClosePorts(c *gc.C) {
@@ -380,24 +390,24 @@ func (s *instanceSuite) TestInstanceClosePorts(c *gc.C) {
 	notFoundSender.AppendResponse(mocks.NewResponseWithStatus(
 		"rule not found", http.StatusNotFound,
 	))
-	s.sender = azuretesting.Senders{sender, notFoundSender}
+	s.sender = azuretesting.Senders{sender, notFoundSender, notFoundSender, notFoundSender}
 
-	err := inst.ClosePorts("0", jujunetwork.RulesFromPortRanges([]jujunetwork.PortRange{{
-		Protocol: "tcp",
-		FromPort: 1000,
-		ToPort:   1000,
-	}, {
-		Protocol: "udp",
-		FromPort: 1000,
-		ToPort:   2000,
-	}}...))
+	err := inst.ClosePorts("0", []jujunetwork.IngressRule{
+		jujunetwork.MustNewIngressRule("tcp", 1000, 1000),
+		jujunetwork.MustNewIngressRule("udp", 1000, 2000),
+		jujunetwork.MustNewIngressRule("udp", 1000, 2000, "192.168.1.0/24", "10.0.0.0/24"),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(s.requests, gc.HasLen, 2)
+	c.Assert(s.requests, gc.HasLen, 4)
 	c.Assert(s.requests[0].Method, gc.Equals, "DELETE")
 	c.Assert(s.requests[0].URL.Path, gc.Equals, securityRulePath("machine-0-tcp-1000"))
 	c.Assert(s.requests[1].Method, gc.Equals, "DELETE")
 	c.Assert(s.requests[1].URL.Path, gc.Equals, securityRulePath("machine-0-udp-1000-2000"))
+	c.Assert(s.requests[2].Method, gc.Equals, "DELETE")
+	c.Assert(s.requests[2].URL.Path, gc.Equals, securityRulePath("machine-0-udp-1000-2000-cidr-192-168-1-0-24"))
+	c.Assert(s.requests[3].Method, gc.Equals, "DELETE")
+	c.Assert(s.requests[3].URL.Path, gc.Equals, securityRulePath("machine-0-udp-1000-2000-cidr-10-0-0-0-24"))
 }
 
 func (s *instanceSuite) TestInstanceOpenPorts(c *gc.C) {
@@ -423,27 +433,23 @@ func (s *instanceSuite) TestInstanceOpenPorts(c *gc.C) {
 	okSender := mocks.NewSender()
 	okSender.AppendResponse(mocks.NewResponseWithContent("{}"))
 	nsgSender := networkSecurityGroupSender(nil)
-	s.sender = azuretesting.Senders{nsgSender, okSender, okSender}
+	s.sender = azuretesting.Senders{nsgSender, okSender, okSender, okSender, okSender}
 
-	err := inst.OpenPorts("0", jujunetwork.RulesFromPortRanges([]jujunetwork.PortRange{{
-		Protocol: "tcp",
-		FromPort: 1000,
-		ToPort:   1000,
-	}, {
-		Protocol: "udp",
-		FromPort: 1000,
-		ToPort:   2000,
-	}}...))
+	err := inst.OpenPorts("0", []jujunetwork.IngressRule{
+		jujunetwork.MustNewIngressRule("tcp", 1000, 1000),
+		jujunetwork.MustNewIngressRule("udp", 1000, 2000),
+		jujunetwork.MustNewIngressRule("tcp", 1000, 2000, "192.168.1.0/24", "10.0.0.0/24"),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(s.requests, gc.HasLen, 3)
+	c.Assert(s.requests, gc.HasLen, 5)
 	c.Assert(s.requests[0].Method, gc.Equals, "GET")
 	c.Assert(s.requests[0].URL.Path, gc.Equals, internalSecurityGroupPath)
 	c.Assert(s.requests[1].Method, gc.Equals, "PUT")
 	c.Assert(s.requests[1].URL.Path, gc.Equals, securityRulePath("machine-0-tcp-1000"))
 	assertRequestBody(c, s.requests[1], &network.SecurityRule{
 		Properties: &network.SecurityRulePropertiesFormat{
-			Description:              to.StringPtr("1000/tcp"),
+			Description:              to.StringPtr("1000/tcp from *"),
 			Protocol:                 network.TCP,
 			SourcePortRange:          to.StringPtr("*"),
 			SourceAddressPrefix:      to.StringPtr("*"),
@@ -458,7 +464,7 @@ func (s *instanceSuite) TestInstanceOpenPorts(c *gc.C) {
 	c.Assert(s.requests[2].URL.Path, gc.Equals, securityRulePath("machine-0-udp-1000-2000"))
 	assertRequestBody(c, s.requests[2], &network.SecurityRule{
 		Properties: &network.SecurityRulePropertiesFormat{
-			Description:              to.StringPtr("1000-2000/udp"),
+			Description:              to.StringPtr("1000-2000/udp from *"),
 			Protocol:                 network.UDP,
 			SourcePortRange:          to.StringPtr("*"),
 			SourceAddressPrefix:      to.StringPtr("*"),
@@ -466,6 +472,36 @@ func (s *instanceSuite) TestInstanceOpenPorts(c *gc.C) {
 			DestinationAddressPrefix: to.StringPtr("10.0.0.4"),
 			Access:    network.Allow,
 			Priority:  to.Int32Ptr(201),
+			Direction: network.Inbound,
+		},
+	})
+	c.Assert(s.requests[3].Method, gc.Equals, "PUT")
+	c.Assert(s.requests[3].URL.Path, gc.Equals, securityRulePath("machine-0-tcp-1000-2000-cidr-192-168-1-0-24"))
+	assertRequestBody(c, s.requests[3], &network.SecurityRule{
+		Properties: &network.SecurityRulePropertiesFormat{
+			Description:              to.StringPtr("1000-2000/tcp from 192.168.1.0/24"),
+			Protocol:                 network.TCP,
+			SourcePortRange:          to.StringPtr("*"),
+			SourceAddressPrefix:      to.StringPtr("192.168.1.0/24"),
+			DestinationPortRange:     to.StringPtr("1000-2000"),
+			DestinationAddressPrefix: to.StringPtr("10.0.0.4"),
+			Access:    network.Allow,
+			Priority:  to.Int32Ptr(202),
+			Direction: network.Inbound,
+		},
+	})
+	c.Assert(s.requests[4].Method, gc.Equals, "PUT")
+	c.Assert(s.requests[4].URL.Path, gc.Equals, securityRulePath("machine-0-tcp-1000-2000-cidr-10-0-0-0-24"))
+	assertRequestBody(c, s.requests[4], &network.SecurityRule{
+		Properties: &network.SecurityRulePropertiesFormat{
+			Description:              to.StringPtr("1000-2000/tcp from 10.0.0.0/24"),
+			Protocol:                 network.TCP,
+			SourcePortRange:          to.StringPtr("*"),
+			SourceAddressPrefix:      to.StringPtr("10.0.0.0/24"),
+			DestinationPortRange:     to.StringPtr("1000-2000"),
+			DestinationAddressPrefix: to.StringPtr("10.0.0.4"),
+			Access:    network.Allow,
+			Priority:  to.Int32Ptr(203),
 			Direction: network.Inbound,
 		},
 	})
@@ -505,15 +541,10 @@ func (s *instanceSuite) TestInstanceOpenPortsAlreadyOpen(c *gc.C) {
 	}})
 	s.sender = azuretesting.Senders{nsgSender, okSender, okSender}
 
-	err := inst.OpenPorts("0", jujunetwork.RulesFromPortRanges([]jujunetwork.PortRange{{
-		Protocol: "tcp",
-		FromPort: 1000,
-		ToPort:   1000,
-	}, {
-		Protocol: "udp",
-		FromPort: 1000,
-		ToPort:   2000,
-	}}...))
+	err := inst.OpenPorts("0", []jujunetwork.IngressRule{
+		jujunetwork.MustNewIngressRule("tcp", 1000, 1000),
+		jujunetwork.MustNewIngressRule("udp", 1000, 2000),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(s.requests, gc.HasLen, 2)
@@ -523,7 +554,7 @@ func (s *instanceSuite) TestInstanceOpenPortsAlreadyOpen(c *gc.C) {
 	c.Assert(s.requests[1].URL.Path, gc.Equals, securityRulePath("machine-0-udp-1000-2000"))
 	assertRequestBody(c, s.requests[1], &network.SecurityRule{
 		Properties: &network.SecurityRulePropertiesFormat{
-			Description:              to.StringPtr("1000-2000/udp"),
+			Description:              to.StringPtr("1000-2000/udp from *"),
 			Protocol:                 network.UDP,
 			SourcePortRange:          to.StringPtr("*"),
 			SourceAddressPrefix:      to.StringPtr("*"),

--- a/provider/cloudsigma/instance.go
+++ b/provider/cloudsigma/instance.go
@@ -87,9 +87,9 @@ func (i sigmaInstance) ClosePorts(machineID string, ports []network.IngressRule)
 
 // IngressRules returns the set of ports open on the instance, which
 // should have been started with the given machine id.
-// The ports are returned as sorted by SortPorts.
+// The rules are returned as sorted by SortInstanceRules.
 func (i sigmaInstance) IngressRules(machineID string) ([]network.IngressRule, error) {
-	return nil, errors.NotImplementedf("Ports")
+	return nil, errors.NotImplementedf("InstanceRules")
 }
 
 func (i sigmaInstance) findIPv4() string {

--- a/provider/cloudsigma/instance_test.go
+++ b/provider/cloudsigma/instance_test.go
@@ -88,12 +88,12 @@ func (s *instanceSuite) TestInstanceAddresses(c *gc.C) {
 	c.Check(len(addrs), gc.Equals, 0)
 }
 
-func (s *instanceSuite) TestInstancePorts(c *gc.C) {
+func (s *instanceSuite) TestIngressRules(c *gc.C) {
 	c.Check(s.inst.OpenPorts("", nil), gc.ErrorMatches, "OpenPorts not implemented")
 	c.Check(s.inst.ClosePorts("", nil), gc.ErrorMatches, "ClosePorts not implemented")
 
 	_, err := s.inst.IngressRules("")
-	c.Check(err, gc.ErrorMatches, "Ports not implemented")
+	c.Check(err, gc.ErrorMatches, "InstanceRules not implemented")
 }
 
 func (s *instanceSuite) TestInstanceHardware(c *gc.C) {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1395,6 +1395,9 @@ func (e *environ) OpenPorts(rules []network.IngressRule) error {
 	estate.mu.Lock()
 	defer estate.mu.Unlock()
 	for _, r := range rules {
+		if len(r.SourceCIDRs) == 0 {
+			r.SourceCIDRs = []string{"0.0.0.0/0"}
+		}
 		found := false
 		for _, rule := range estate.globalRules {
 			if r.String() == rule.String() {
@@ -1556,6 +1559,9 @@ func (inst *dummyInstance) OpenPorts(machineId string, rules []network.IngressRu
 		Rules:      rules,
 	}
 	for _, r := range rules {
+		if len(r.SourceCIDRs) == 0 {
+			r.SourceCIDRs = []string{"0.0.0.0/0"}
+		}
 		found := false
 		for _, rule := range inst.rules {
 			if r.String() == rule.String() {
@@ -1610,7 +1616,7 @@ func (inst *dummyInstance) IngressRules(machineId string) (rules []network.Ingre
 	}
 	inst.state.mu.Lock()
 	defer inst.state.mu.Unlock()
-	if err := inst.checkBroken("Ports"); err != nil {
+	if err := inst.checkBroken("IngressRules"); err != nil {
 		return nil, err
 	}
 	for _, r := range inst.rules {

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1187,8 +1187,8 @@ func (e *environ) ingressRulesInGroup(name string) (rules []network.IngressRule,
 	}
 	for _, p := range group.IPPerms {
 		ips := p.SourceIPs
-		if len(ips) == 1 && ips[0] == defaultRouteCIDRBlock {
-			ips = nil
+		if len(ips) == 0 {
+			ips = []string{defaultRouteCIDRBlock}
 		}
 		rule, err := network.NewIngressRule(p.Protocol, p.FromPort, p.ToPort, ips...)
 		if err != nil {

--- a/provider/gce/google/conn_network.go
+++ b/provider/gce/google/conn_network.go
@@ -28,8 +28,8 @@ func (gce Connection) IngressRules(fwname string) ([]network.IngressRule, error)
 			if err != nil {
 				return rules, errors.Annotate(err, "bad ports from GCE")
 			}
-			portRange.Protocol = allowed.IPProtocol
-			rules = append(rules, network.RulesFromPortRanges(portRange)...)
+			rule, _ := network.NewIngressRule(allowed.IPProtocol, portRange.FromPort, portRange.ToPort, "0.0.0.0/0")
+			rules = append(rules, rule)
 		}
 	}
 

--- a/provider/gce/google/conn_network_test.go
+++ b/provider/gce/google/conn_network_test.go
@@ -27,8 +27,9 @@ func (s *connSuite) TestConnectionPorts(c *gc.C) {
 
 	ports, err := s.Conn.IngressRules("spam")
 	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(ports, jc.DeepEquals, []network.IngressRule{network.MustNewIngressRule("tcp", 80, 81)})
+	c.Check(
+		ports, jc.DeepEquals,
+		[]network.IngressRule{network.MustNewIngressRule("tcp", 80, 81, "0.0.0.0/0")})
 }
 
 func (s *connSuite) TestConnectionPortsAPI(c *gc.C) {

--- a/provider/gce/google/network_test.go
+++ b/provider/gce/google/network_test.go
@@ -57,12 +57,12 @@ func (s ByIPProtocol) Less(i, j int) bool {
 }
 
 func (s *networkSuite) TestFirewallSpec(c *gc.C) {
-	ports := network.NewRuleSet(
-		network.RulesFromPortRanges(network.MustParsePortRange("80-81/tcp"),
-			network.MustParsePortRange("8888/tcp"),
-			network.MustParsePortRange("1234/udp"))...,
+	rules := network.NewRuleSet(
+		network.MustNewIngressRule("tcp", 80, 81),
+		network.MustNewIngressRule("tcp", 8888, 8888),
+		network.MustNewIngressRule("udp", 1234, 1234),
 	)
-	fw := google.FirewallSpec("spam", ports)
+	fw := google.FirewallSpec("spam", rules)
 
 	allowed := []*compute.FirewallAllowed{{
 		IPProtocol: "tcp",

--- a/provider/joyent/environ_firewall_test.go
+++ b/provider/joyent/environ_firewall_test.go
@@ -15,7 +15,7 @@ type FirewallSuite struct{}
 
 var _ = gc.Suite(&FirewallSuite{})
 
-func (s *FirewallSuite) TestGetPorts(c *gc.C) {
+func (s *FirewallSuite) TestGetIngressRules(c *gc.C) {
 	testCases := []struct {
 		about    string
 		envName  string
@@ -30,7 +30,7 @@ func (s *FirewallSuite) TestGetPorts(c *gc.C) {
 				true,
 				"FROM tag switch TO tag juju ALLOW tcp PORT 80",
 			}},
-			[]network.IngressRule{network.MustNewIngressRule("tcp", 80, 80)},
+			[]network.IngressRule{network.MustNewIngressRule("tcp", 80, 80, "0.0.0.0/0")},
 		},
 		{
 			"port range model rule",
@@ -40,7 +40,7 @@ func (s *FirewallSuite) TestGetPorts(c *gc.C) {
 				true,
 				"FROM tag switch TO tag juju ALLOW tcp (PORT 80 AND PORT 81 AND PORT 82 AND PORT 83)",
 			}},
-			[]network.IngressRule{network.MustNewIngressRule("tcp", 80, 83)},
+			[]network.IngressRule{network.MustNewIngressRule("tcp", 80, 83, "0.0.0.0/0")},
 		},
 	}
 	for i, t := range testCases {

--- a/provider/joyent/export_test.go
+++ b/provider/joyent/export_test.go
@@ -206,7 +206,7 @@ func MakeCredentials(c *gc.C, endpoint string, cloudCredential cloud.Credential)
 	return creds
 }
 
-var GetPorts = getPorts
+var GetPorts = getRules
 
 var CreateFirewallRuleAll = createFirewallRuleAll
 

--- a/provider/joyent/instance_firewall.go
+++ b/provider/joyent/instance_firewall.go
@@ -111,5 +111,5 @@ func (inst *joyentInstance) IngressRules(machineId string) ([]network.IngressRul
 		return nil, fmt.Errorf("cannot get firewall rules: %v", err)
 	}
 
-	return getPorts(inst.env.Config().Name(), fwRules)
+	return getRules(inst.env.Config().Name(), fwRules)
 }

--- a/provider/joyent/instance_firewall_test.go
+++ b/provider/joyent/instance_firewall_test.go
@@ -30,7 +30,7 @@ func (s *InstanceFirewallSuite) TestGetPorts(c *gc.C) {
 				true,
 				"FROM tag switch TO vm machine ALLOW tcp PORT 80",
 			}},
-			[]network.IngressRule{network.MustNewIngressRule("tcp", 80, 80)},
+			[]network.IngressRule{network.MustNewIngressRule("tcp", 80, 80, "0.0.0.0/0")},
 		},
 		{
 			"port range instance rule",
@@ -40,7 +40,7 @@ func (s *InstanceFirewallSuite) TestGetPorts(c *gc.C) {
 				true,
 				"FROM tag switch TO vm machine ALLOW tcp (PORT 80 AND PORT 81 AND PORT 82 AND PORT 83)",
 			}},
-			[]network.IngressRule{network.MustNewIngressRule("tcp", 80, 83)},
+			[]network.IngressRule{network.MustNewIngressRule("tcp", 80, 83, "0.0.0.0/0")},
 		},
 	}
 	for i, t := range testCases {

--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -201,11 +201,7 @@ func (*localTests) TestPortsToRuleInfo(c *gc.C) {
 		expected []neutron.RuleInfoV2
 	}{{
 		about: "single port",
-		rules: network.RulesFromPortRanges([]network.PortRange{{
-			FromPort: 80,
-			ToPort:   80,
-			Protocol: "tcp",
-		}}...),
+		rules: []network.IngressRule{network.MustNewIngressRule("tcp", 80, 80)},
 		expected: []neutron.RuleInfoV2{{
 			Direction:      "ingress",
 			IPProtocol:     "tcp",
@@ -216,11 +212,7 @@ func (*localTests) TestPortsToRuleInfo(c *gc.C) {
 		}},
 	}, {
 		about: "multiple ports",
-		rules: network.RulesFromPortRanges([]network.PortRange{{
-			FromPort: 80,
-			ToPort:   82,
-			Protocol: "tcp",
-		}}...),
+		rules: []network.IngressRule{network.MustNewIngressRule("tcp", 80, 82)},
 		expected: []neutron.RuleInfoV2{{
 			Direction:      "ingress",
 			IPProtocol:     "tcp",
@@ -231,15 +223,10 @@ func (*localTests) TestPortsToRuleInfo(c *gc.C) {
 		}},
 	}, {
 		about: "multiple port ranges",
-		rules: network.RulesFromPortRanges([]network.PortRange{{
-			FromPort: 80,
-			ToPort:   82,
-			Protocol: "tcp",
-		}, {
-			FromPort: 100,
-			ToPort:   120,
-			Protocol: "tcp",
-		}}...),
+		rules: []network.IngressRule{
+			network.MustNewIngressRule("tcp", 80, 82),
+			network.MustNewIngressRule("tcp", 100, 120),
+		},
 		expected: []neutron.RuleInfoV2{{
 			Direction:      "ingress",
 			IPProtocol:     "tcp",


### PR DESCRIPTION
This PR adds support in the Azure provider for opening/closing ports with CIDR rules.
There's also cleanup from work landed previously.
The existing Juju firewaller does not yet know about handling the new source CIDR rules so the user visible functionality remains as it is now - ports are opened to the world.

QA - smoke test on AWS