### PR TITLE
kvm arm64 auto manage nvram

### DIFF
--- a/container/kvm/libvirt/domainxml.go
+++ b/container/kvm/libvirt/domainxml.go
@@ -48,9 +48,6 @@ type domainParams interface {
 	Loader() string
 	// NetworkInfo contains the network interfaces to create in the domain.
 	NetworkInfo() []InterfaceInfo
-	// NVRAM returns the path to the UEFI variable storage drive. This is a
-	// "pflash" drive where UEFI stores variables used for booting an image.
-	NVRAM() string
 	// RAM returns the amount of RAM to use.
 	RAM() uint64
 	// ValidateDomainParams returns nil if the domainParams are valid.
@@ -152,8 +149,6 @@ func generateOSElement(p domainParams) OS {
 				ReadOnly: "yes",
 				Type:     "pflash",
 			},
-
-			NVRAMVars: p.NVRAM(),
 		}
 	default:
 		return OS{Type: OSType{Text: "hvm"}}
@@ -220,9 +215,6 @@ type OS struct {
 	Type OSType `xml:"type"`
 	// Loader is a pointer so it is omitted if empty.
 	Loader *NVRAMCode `xml:"loader,omitempty"`
-	// NVRAMVars is the writable storage for UEFI to store variables.
-	// See: https://libvirt.org/formatdomain.html#elementsOS
-	NVRAMVars string `xml:"nvram,omitempty"`
 }
 
 // OSType provides details that are required on certain architectures, e.g.

--- a/container/kvm/libvirt/domainxml_test.go
+++ b/container/kvm/libvirt/domainxml_test.go
@@ -68,7 +68,6 @@ var arm64DomainStr = `
     <os>
         <type arch="aarch64" machine="virt">hvm</type>
         <loader readonly="yes" type="pflash">/shared/readonly.fd</loader>
-        <nvram>/private/writable.fd</nvram>
     </os>
     <features>
         <gic version="host"></gic>
@@ -125,7 +124,6 @@ func (domainXMLSuite) TestNewDomain(c *gc.C) {
 		params := dummyParams{ifaceInfo: ifaces, diskInfo: disks, memory: 1024, cpuCores: 2, hostname: "juju-someid", arch: test.arch}
 
 		if test.arch == "arm64" {
-			params.nvram = "/private/writable.fd"
 			params.loader = "/shared/readonly.fd"
 		}
 

--- a/container/kvm/wrappedcmds_internal_test.go
+++ b/container/kvm/wrappedcmds_internal_test.go
@@ -4,9 +4,7 @@
 package kvm
 
 import (
-	"crypto/sha256"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -114,36 +112,6 @@ func (libvirtInternalSuite) TestWriteDomainXMLMissingBothDisk(c *gc.C) {
 	got, err := writeDomainXML(d, p)
 	c.Assert(err, gc.ErrorMatches, "got 0 disks, need at least 2")
 	c.Assert(got, gc.Matches, "")
-}
-
-func (libvirtInternalSuite) TestCreateNVRAMOnARM64(c *gc.C) {
-	d := c.MkDir()
-
-	err := os.MkdirAll(filepath.Join(d, "kvm", "guests"), 0755)
-	c.Check(err, jc.ErrorIsNil)
-	p := CreateMachineParams{
-		Hostname: "host00",
-		arch:     "arm64",
-		findPath: func(string) (string, error) { return d, nil },
-	}
-	err = createNVRAM(p)
-	c.Check(err, jc.ErrorIsNil)
-	data, err := ioutil.ReadFile(filepath.Join(d, "kvm", "guests", "host00-VARS.fd"))
-	c.Check(err, jc.ErrorIsNil)
-	got := fmt.Sprintf("%x", sha256.Sum256(data))
-	c.Assert(got, gc.Equals, "3b6a07d0d404fab4e23b6d34bc6696a6a312dd92821332385e5af7c01c421351")
-}
-
-func (libvirtInternalSuite) TestCreateNVRAMOnAMD64(c *gc.C) {
-	d := c.MkDir()
-
-	p := CreateMachineParams{
-		Hostname: "host00",
-		arch:     "amd64",
-		findPath: func(string) (string, error) { return d, nil },
-	}
-	err := createNVRAM(p)
-	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (libvirtInternalSuite) TestWriteDomainXMLNoHostname(c *gc.C) {

--- a/container/kvm/wrappedcmds_test.go
+++ b/container/kvm/wrappedcmds_test.go
@@ -186,7 +186,7 @@ func (commandWrapperSuite) TestDestroyMachineFails(c *gc.C) {
 	})
 	log := c.GetTestLog()
 	c.Check(log, jc.Contains, "`virsh destroy aname` failed")
-	c.Check(log, jc.Contains, "`virsh undefine aname` failed")
+	c.Check(log, jc.Contains, "`virsh undefine --nvram aname` failed")
 	c.Assert(err, jc.ErrorIsNil)
 
 }


### PR DESCRIPTION
This let's libvirt manage qemu's UEFI VARS NVRAM drive.  All our docs say we need to create it our selves, but the version of libvirt and qemu that xenial ships with will auto create an nvram disk and remove it when undefined if the --nvram flag is provided.

QA: Get an ARM machine...
1. Run the test suite and ensure then pass
2. juju bootstrap arm64-maas kvm/armtest --build-agent
3. juju add-machine
4. juju add-machine
5. juju deploy ubuntu --to kvm:0
6. juju deploy postgresql  --to kvm:0 --constraints "cores=12 mem=4G"
7. juju add-unit postgresql --to kvm:1
-- ensure everything starts up
8. juju remove application ubuntu
9. juju remove application postgresql
-- ensure no nvram files were left behind and all the vms were removed without error.
10. juju destroy-controller -y --destroy-all-models kvm/armtest
