### PR TITLE
cmd/modelcmd: support JUJU_USER_DOMAIN

### DIFF
--- a/cmd/juju/commands/migrate.go
+++ b/cmd/juju/commands/migrate.go
@@ -206,5 +206,5 @@ func (c *migrateCommand) getTargetControllerMacaroons() ([]macaroon.Slice, error
 		return nil, errors.Annotate(err, "connecting to target controller")
 	}
 	defer api.Close()
-	return httpbakery.MacaroonsForURL(apiContext.Jar, api.CookieURL()), nil
+	return httpbakery.MacaroonsForURL(apiContext.CookieJar(), api.CookieURL()), nil
 }

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -501,7 +501,7 @@ func (c *registerCommand) secretKeyLogin(addrs []string, request params.SecretKe
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpClient := utils.GetNonValidatingHTTPClient()
-	httpClient.Jar = apiContext.Jar
+	httpClient.Jar = apiContext.CookieJar()
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/cmd/modelcmd/apicontext_test.go
+++ b/cmd/modelcmd/apicontext_test.go
@@ -1,0 +1,92 @@
+package modelcmd_test
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
+
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+type APIContextSuite struct {
+	testing.IsolationSuite
+}
+
+func (s *APIContextSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	testing.MakeFakeHome(c)
+}
+
+var _ = gc.Suite(&APIContextSuite{})
+
+func (s *APIContextSuite) TestNewAPIContext(c *gc.C) {
+	ctx, err := modelcmd.NewAPIContext(nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	handler := func(w http.ResponseWriter, req *http.Request) {
+		// Set a cookie so we can check that cookies are
+		// saved.
+		http.SetCookie(w, &http.Cookie{
+			Name:   "cook",
+			Value:  "val",
+			MaxAge: 1000,
+		})
+		w.Write([]byte("hello"))
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		handler(w, req)
+	}))
+	defer srv.Close()
+	// Check that we can use the client.
+	assertClientGet(c, ctx.NewBakeryClient(), srv.URL, "hello")
+
+	// Close the context, which should save the cookies.
+	err = ctx.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Make another APIContext which should
+	// get the cookies just saved.
+	ctx, err = modelcmd.NewAPIContext(nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	handler = func(w http.ResponseWriter, req *http.Request) {
+		c.Check(req.Cookies(), jc.DeepEquals, []*http.Cookie{{
+			Name:  "cook",
+			Value: "val",
+		}})
+		w.Write([]byte("goodbye"))
+	}
+	assertClientGet(c, ctx.NewBakeryClient(), srv.URL, "goodbye")
+}
+
+func (s *APIContextSuite) TestDomainCookie(c *gc.C) {
+	s.PatchEnvironment("JUJU_USER_DOMAIN", "something")
+	ctx, err := modelcmd.NewAPIContext(nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		c.Check(req.Cookies(), jc.DeepEquals, []*http.Cookie{{
+			Name:  "domain",
+			Value: "something",
+		}})
+		w.Write([]byte("hello"))
+	}))
+	defer srv.Close()
+	// Check that we can use the client.
+	assertClientGet(c, ctx.NewBakeryClient(), srv.URL, "hello")
+}
+
+func assertClientGet(c *gc.C, client *httpbakery.Client, url string, expectBody string) {
+	req, err := http.NewRequest("GET", url, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	resp, err := client.Do(req)
+	c.Assert(err, jc.ErrorIsNil)
+	defer resp.Body.Close()
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
+	data, _ := ioutil.ReadAll(resp.Body)
+	c.Assert(string(data), gc.Equals, expectBody)
+}

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -285,10 +285,7 @@ func (c *JujuCommandBase) ClearControllerMacaroons(endpoints []string) error {
 		return errors.Trace(err)
 	}
 	for _, s := range endpoints {
-		apictx.Jar.RemoveAllHost(s)
-	}
-	if err := apictx.Jar.Save(); err != nil {
-		return errors.Annotate(err, "can't remove cached authentication cookie")
+		apictx.jar.RemoveAllHost(s)
 	}
 	return nil
 }

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -6,26 +6,26 @@ package modelcmd_test
 import (
 	"strings"
 
+	"github.com/juju/errors"
+	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
-	"github.com/juju/juju/testing"
 )
 
 type BaseCommandSuite struct {
-	testing.FakeJujuXDGDataHomeSuite
+	testing.IsolationSuite
 	store *jujuclienttesting.MemStore
 }
 
 var _ = gc.Suite(&BaseCommandSuite{})
 
 func (s *BaseCommandSuite) SetUpTest(c *gc.C) {
-	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	s.IsolationSuite.SetUpTest(c)
 
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = "foo"

--- a/cmd/modelcmd/controller_test.go
+++ b/cmd/modelcmd/controller_test.go
@@ -7,17 +7,17 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
-	"github.com/juju/juju/testing"
 )
 
 type ControllerCommandSuite struct {
-	testing.FakeJujuXDGDataHomeSuite
+	testing.IsolationSuite
 }
 
 var _ = gc.Suite(&ControllerCommandSuite{})

--- a/cmd/modelcmd/credentials_test.go
+++ b/cmd/modelcmd/credentials_test.go
@@ -5,19 +5,19 @@ package modelcmd_test
 
 import (
 	"fmt"
-
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
-
 	"io/ioutil"
 	"path/filepath"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	_ "github.com/juju/juju/provider/dummy"
-	"github.com/juju/juju/testing"
+	jujutesting "github.com/juju/juju/testing"
 )
 
 func init() {
@@ -68,7 +68,7 @@ func (mockProvider) FinalizeCredential(
 }
 
 type credentialsSuite struct {
-	testing.FakeJujuXDGDataHomeSuite
+	testing.IsolationSuite
 	cloud cloud.Cloud
 	store *jujuclienttesting.MemStore
 }
@@ -76,7 +76,7 @@ type credentialsSuite struct {
 var _ = gc.Suite(&credentialsSuite{})
 
 func (s *credentialsSuite) SetUpTest(c *gc.C) {
-	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	s.IsolationSuite.SetUpTest(c)
 	s.cloud = cloud.Cloud{
 		Type: "fake",
 		Regions: []cloud.Region{
@@ -108,7 +108,7 @@ func (s *credentialsSuite) SetUpTest(c *gc.C) {
 
 func (s *credentialsSuite) assertGetCredentials(c *gc.C, cred, region string) {
 	credential, credentialName, regionName, err := modelcmd.GetCredentials(
-		testing.Context(c), s.store, modelcmd.GetCredentialsParams{
+		jujutesting.Context(c), s.store, modelcmd.GetCredentialsParams{
 			Cloud:          s.cloud,
 			CloudName:      "cloud",
 			CloudRegion:    region,

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -19,16 +20,15 @@ import (
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/permission"
-	"github.com/juju/juju/testing"
 )
 
 type ModelCommandSuite struct {
-	testing.FakeJujuXDGDataHomeSuite
+	testing.IsolationSuite
 	store *jujuclienttesting.MemStore
 }
 
 func (s *ModelCommandSuite) SetUpTest(c *gc.C) {
-	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	s.IsolationSuite.SetUpTest(c)
 	s.PatchEnvironment("JUJU_CLI_VERSION", "")
 
 	s.store = jujuclienttesting.NewMemStore()

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -500,7 +500,7 @@ LXC_BRIDGE="ignored"`[1:])
 	s.State.StartSync()
 	errCh := make(chan error, 0)
 	go func() {
-		errCh <-mr.Wait()
+		errCh <- mr.Wait()
 	}()
 	select {
 	case err = <-errCh:


### PR DESCRIPTION
This can be used to select an alternative authentication
domain when authenticating using an external identity
manager.

We also clean up the tests a little by using IsolationSuite
instead of the deprecated FakeJujuXDGDataHomeSuite,
and unexport some fields from APIContext that aren't
used.