### PR TITLE
migrations: add Environ.AdoptResources to update controller tags

### DIFF
--- a/environs/interface.go
+++ b/environs/interface.go
@@ -6,9 +6,10 @@ package environs
 import (
 	"io"
 
+	"github.com/juju/jsonschema"
+	"github.com/juju/version"
 	"gopkg.in/juju/environschema.v1"
 
-	"github.com/juju/jsonschema"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
@@ -232,14 +233,18 @@ type Environ interface {
 	// the Bootstrap method's job to create the controller model.
 	Create(CreateParams) error
 
-	// UpdateController is called when the model is moved from one controller
-	// to another using model migration. Some providers tag instances, disks,
-	// and cloud storage with the controller UUID to aid in clean destruction.
-	// All things that the provider has tagged with the controller UUID need
-	// to be updated in this method to use the new controller UUID. For
-	// providers that do not track the controller UUID, a simple method
-	// returning nil will suffice.
-	UpdateController(controllerUUID string) error
+	// AdoptResources is called when the model is moved from one
+	// controller to another using model migration. Some providers tag
+	// instances, disks, and cloud storage with the controller UUID to
+	// aid in clean destruction. This method will be called on the
+	// environ for the target controller so it can update the
+	// controller tags for all of those things. For providers that do
+	// not track the controller UUID, a simple method returning nil
+	// will suffice. The version number of the source controller is
+	// provided for backwards compatibility - if the technique used to
+	// tag items changes, the version number can be used to decide how
+	// to remove the old tags correctly.
+	AdoptResources(controllerUUID string, fromVersion version.Number) error
 
 	// InstanceBroker defines methods for starting and stopping
 	// instances.

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -232,6 +232,15 @@ type Environ interface {
 	// the Bootstrap method's job to create the controller model.
 	Create(CreateParams) error
 
+	// UpdateController is called when the model is moved from one controller
+	// to another using model migration. Some providers tag instances, disks,
+	// and cloud storage with the controller UUID to aid in clean destruction.
+	// All things that the provider has tagged with the controller UUID need
+	// to be updated in this method to use the new controller UUID. For
+	// providers that do not track the controller UUID, a simple method
+	// returning nil will suffice.
+	UpdateController(controllerUUID string) error
+
 	// InstanceBroker defines methods for starting and stopping
 	// instances.
 	InstanceBroker

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -1071,6 +1071,11 @@ func (env *azureEnviron) instances(
 	return matching, nil
 }
 
+// UpdateController is part of the Environ interface.
+func (env *azureEnviron) UpdateController(controllerUUID string) error {
+	return errors.NotImplementedf("UpdateController")
+}
+
 // AllInstances is specified in the InstanceBroker interface.
 func (env *azureEnviron) AllInstances() ([]instance.Instance, error) {
 	return env.allInstances(env.resourceGroup, true /* refresh addresses */, false /* all instances */)

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/os"
 	jujuseries "github.com/juju/utils/series"
+	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/cloudconfig/instancecfg"
@@ -1071,9 +1072,9 @@ func (env *azureEnviron) instances(
 	return matching, nil
 }
 
-// UpdateController is part of the Environ interface.
-func (env *azureEnviron) UpdateController(controllerUUID string) error {
-	return errors.NotImplementedf("UpdateController")
+// AdoptResources is part of the Environ interface.
+func (env *azureEnviron) AdoptResources(controllerUUID string, fromVersion version.Number) error {
+	return errors.NotImplementedf("AdoptResources")
 }
 
 // AllInstances is specified in the InstanceBroker interface.

--- a/provider/cloudsigma/environ.go
+++ b/provider/cloudsigma/environ.go
@@ -103,8 +103,8 @@ func (e *environ) ControllerInstances(controllerUUID string) ([]instance.Id, err
 	return e.client.getControllerIds()
 }
 
-// AdoptInstances is part of the Environ interface.
-func (e *environ) AdoptInstances(ids []instance.Id, controllerUUID string) error {
+// UpdateController is part of the Environ interface.
+func (e *environ) UpdateController(controllerUUID string) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }

--- a/provider/cloudsigma/environ.go
+++ b/provider/cloudsigma/environ.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/altoros/gosigma"
 	"github.com/juju/errors"
+	"github.com/juju/version"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
@@ -103,8 +104,8 @@ func (e *environ) ControllerInstances(controllerUUID string) ([]instance.Id, err
 	return e.client.getControllerIds()
 }
 
-// UpdateController is part of the Environ interface.
-func (e *environ) UpdateController(controllerUUID string) error {
+// AdoptResources is part of the Environ interface.
+func (e *environ) AdoptResources(controllerUUID string, fromVersion version.Number) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -38,6 +38,7 @@ import (
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/clock"
 	"github.com/juju/utils/series"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/environschema.v1"
 	"gopkg.in/juju/names.v2"
@@ -886,8 +887,8 @@ func (e *environ) SetConfig(cfg *config.Config) error {
 	return nil
 }
 
-// UpdateController is part of the Environ interface.
-func (e *environ) UpdateController(controllerUUID string) error {
+// AdoptResources is part of the Environ interface.
+func (e *environ) AdoptResources(controllerUUID string, fromVersion version.Number) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -886,8 +886,8 @@ func (e *environ) SetConfig(cfg *config.Config) error {
 	return nil
 }
 
-// AdoptInstances is part of the Environ interface.
-func (e *environ) AdoptInstances(ids []instance.Id, controllerUUID string) error {
+// UpdateController is part of the Environ interface.
+func (e *environ) UpdateController(controllerUUID string) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/retry"
 	"github.com/juju/utils"
 	"github.com/juju/utils/clock"
+	"github.com/juju/version"
 	"gopkg.in/amz.v3/aws"
 	"gopkg.in/amz.v3/ec2"
 	"gopkg.in/juju/names.v2"
@@ -943,9 +944,9 @@ func (e *environ) Subnets(instId instance.Id, subnetIds []network.Id) ([]network
 	return results, nil
 }
 
-// UpdateController is part of the Environ interface.
-func (e *environ) UpdateController(controllerUUID string) error {
-	return errors.NotImplementedf("UpdateController")
+// AdoptResources is part of the Environ interface.
+func (e *environ) AdoptResources(controllerUUID string, fromVersion version.Number) error {
+	return errors.NotImplementedf("AdoptResources")
 }
 
 // AllInstances is part of the environs.InstanceBroker interface.

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -943,6 +943,11 @@ func (e *environ) Subnets(instId instance.Id, subnetIds []network.Id) ([]network
 	return results, nil
 }
 
+// UpdateController is part of the Environ interface.
+func (e *environ) UpdateController(controllerUUID string) error {
+	return errors.NotImplementedf("UpdateController")
+}
+
 // AllInstances is part of the environs.InstanceBroker interface.
 func (e *environ) AllInstances() ([]instance.Instance, error) {
 	return e.AllInstancesByState("pending", "running")

--- a/provider/gce/environ_instance.go
+++ b/provider/gce/environ_instance.go
@@ -122,11 +122,16 @@ func (env *environ) ControllerInstances(controllerUUID string) ([]instance.Id, e
 	return results, nil
 }
 
-// AdoptInstances is part of the environs.Environ interface.
-func (env *environ) AdoptInstances(ids []instance.Id, controllerUUID string) error {
-	stringIds := make([]string, len(ids))
-	for i, id := range ids {
-		stringIds[i] = string(id)
+// UpdateController is part of the Environ interface.
+func (env *environ) UpdateController(controllerUUID string) error {
+	instances, err := env.AllInstances()
+	if err != nil {
+		return errors.Annotate(err, "all instances")
+	}
+
+	var stringIds []string
+	for _, id := range instances {
+		stringIds = append(stringIds, string(id.Id()))
 	}
 	return errors.Trace(env.gce.UpdateMetadata(tags.JujuController, controllerUUID, stringIds...))
 }

--- a/provider/gce/environ_instance.go
+++ b/provider/gce/environ_instance.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/version"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
@@ -122,8 +123,8 @@ func (env *environ) ControllerInstances(controllerUUID string) ([]instance.Id, e
 	return results, nil
 }
 
-// UpdateController is part of the Environ interface.
-func (env *environ) UpdateController(controllerUUID string) error {
+// AdoptResources is part of the Environ interface.
+func (env *environ) AdoptResources(controllerUUID string, fromVersion version.Number) error {
 	instances, err := env.AllInstances()
 	if err != nil {
 		return errors.Annotate(err, "all instances")

--- a/provider/gce/environ_instance_test.go
+++ b/provider/gce/environ_instance_test.go
@@ -202,8 +202,12 @@ func (s *environInstSuite) TestListMachineTypes(c *gc.C) {
 
 }
 
-func (s *environInstSuite) TestAdoptInstances(c *gc.C) {
-	err := s.Env.AdoptInstances([]instance.Id{"john", "misty"}, "other-uuid")
+func (s *environInstSuite) TestUpdateController(c *gc.C) {
+	john := s.NewInstance(c, "john")
+	misty := s.NewInstance(c, "misty")
+	s.FakeEnviron.Insts = []instance.Instance{john, misty}
+
+	err := s.Env.UpdateController("other-uuid")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.FakeConn.Calls, gc.HasLen, 1)
 	call := s.FakeConn.Calls[0]

--- a/provider/gce/environ_instance_test.go
+++ b/provider/gce/environ_instance_test.go
@@ -6,6 +6,7 @@ package gce_test
 import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/constraints"
@@ -202,12 +203,12 @@ func (s *environInstSuite) TestListMachineTypes(c *gc.C) {
 
 }
 
-func (s *environInstSuite) TestUpdateController(c *gc.C) {
+func (s *environInstSuite) TestAdoptResources(c *gc.C) {
 	john := s.NewInstance(c, "john")
 	misty := s.NewInstance(c, "misty")
 	s.FakeEnviron.Insts = []instance.Instance{john, misty}
 
-	err := s.Env.UpdateController("other-uuid")
+	err := s.Env.AdoptResources("other-uuid", version.MustParse("1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.FakeConn.Calls, gc.HasLen, 1)
 	call := s.FakeConn.Calls[0]

--- a/provider/joyent/environ.go
+++ b/provider/joyent/environ.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/joyent/gosdc/cloudapi"
 	"github.com/juju/errors"
+	"github.com/juju/version"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
@@ -142,8 +143,8 @@ func (env *joyentEnviron) ControllerInstances(controllerUUID string) ([]instance
 	return instanceIds, nil
 }
 
-// UpdateController is part of the Environ interface.
-func (env *joyentEnviron) UpdateController(controllerUUID string) error {
+// AdoptResources is part of the Environ interface.
+func (env *joyentEnviron) AdoptResources(controllerUUID string, fromVersion version.Number) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }

--- a/provider/joyent/environ.go
+++ b/provider/joyent/environ.go
@@ -142,8 +142,8 @@ func (env *joyentEnviron) ControllerInstances(controllerUUID string) ([]instance
 	return instanceIds, nil
 }
 
-// AdoptInstances is part of the Environ interface.
-func (env *joyentEnviron) AdoptInstances(ids []instance.Id, controllerUUID string) error {
+// UpdateController is part of the Environ interface.
+func (env *joyentEnviron) UpdateController(controllerUUID string) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }

--- a/provider/lxd/environ_instance.go
+++ b/provider/lxd/environ_instance.go
@@ -124,13 +124,18 @@ func (env *environ) parsePlacement(placement string) (*instPlacement, error) {
 	return nil, errors.Errorf("unknown placement directive: %v", placement)
 }
 
-// AdoptInstances updates the controller tags on the specified
-// instances to have the new controller id. It's part of the Environ
-// interface.
-func (env *environ) AdoptInstances(ids []instance.Id, controllerUUID string) error {
+// UpdateController updates the controller tags on all instances to have the
+// new controller id. It's part of the Environ interface.
+func (env *environ) UpdateController(controllerUUID string) error {
+	instances, err := env.AllInstances()
+	if err != nil {
+		return errors.Annotate(err, "all instances")
+	}
+
 	var failed []instance.Id
-	for _, id := range ids {
-		qualifiedKey := lxdclient.ResolveConfigKey(tags.JujuController, lxdclient.MetadataNamespace)
+	qualifiedKey := lxdclient.ResolveConfigKey(tags.JujuController, lxdclient.MetadataNamespace)
+	for _, instance := range instances {
+		id := instance.Id()
 		err := env.raw.SetContainerConfig(string(id), qualifiedKey, controllerUUID)
 		if err != nil {
 			logger.Errorf("error setting controller uuid tag for %q: %v", id, err)

--- a/provider/lxd/environ_instance.go
+++ b/provider/lxd/environ_instance.go
@@ -7,6 +7,7 @@ package lxd
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/version"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/tags"
@@ -124,9 +125,9 @@ func (env *environ) parsePlacement(placement string) (*instPlacement, error) {
 	return nil, errors.Errorf("unknown placement directive: %v", placement)
 }
 
-// UpdateController updates the controller tags on all instances to have the
+// AdoptResources updates the controller tags on all instances to have the
 // new controller id. It's part of the Environ interface.
-func (env *environ) UpdateController(controllerUUID string) error {
+func (env *environ) AdoptResources(controllerUUID string, fromVersion version.Number) error {
 	instances, err := env.AllInstances()
 	if err != nil {
 		return errors.Annotate(err, "all instances")

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -2426,15 +2426,15 @@ func bridgeScriptPathForSeries(series string) (string, error) {
 	return path.Join(dataDir, bridgeScriptName), nil
 }
 
-// AdoptInstances updates the instances to indicate they
-// are now associated with the specified controller. Part of the
-// Environ interface.
-func (env *maasEnviron) AdoptInstances(ids []instance.Id, controllerUUID string) error {
+// UpdateController updates all the instances to indicate they
+// are now associated with the specified controller.
+func (env *maasEnviron) UpdateController(controllerUUID string) error {
 	if !env.usingMAAS2() {
 		// We don't track instance -> controller for MAAS1.
 		return nil
 	}
-	instances, err := env.Instances(ids)
+
+	instances, err := env.AllInstances()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/utils/os"
 	"github.com/juju/utils/series"
 	"github.com/juju/utils/set"
+	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
@@ -2426,9 +2427,9 @@ func bridgeScriptPathForSeries(series string) (string, error) {
 	return path.Join(dataDir, bridgeScriptName), nil
 }
 
-// UpdateController updates all the instances to indicate they
+// AdoptResources updates all the instances to indicate they
 // are now associated with the specified controller.
-func (env *maasEnviron) UpdateController(controllerUUID string) error {
+func (env *maasEnviron) AdoptResources(controllerUUID string, fromVersion version.Number) error {
 	if !env.usingMAAS2() {
 		// We don't track instance -> controller for MAAS1.
 		return nil

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1094,10 +1094,10 @@ func (s *environSuite) TestReleaseContainerAddresses_HandlesDupes(c *gc.C) {
 	c.Assert(systemIds, gc.DeepEquals, []string{"device3"})
 }
 
-func (s *environSuite) TestAdoptInstances(c *gc.C) {
-	id := s.addNode(allocatedNode)
+func (s *environSuite) TestUpdateController(c *gc.C) {
+	s.addNode(allocatedNode)
 	env := s.makeEnviron()
 	// Shouldn't do anything in MAAS1.
-	err := env.AdoptInstances([]instance.Id{id}, "other-controller")
+	err := env.UpdateController("other-controller")
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1094,10 +1094,10 @@ func (s *environSuite) TestReleaseContainerAddresses_HandlesDupes(c *gc.C) {
 	c.Assert(systemIds, gc.DeepEquals, []string{"device3"})
 }
 
-func (s *environSuite) TestUpdateController(c *gc.C) {
+func (s *environSuite) TestAdoptResources(c *gc.C) {
 	s.addNode(allocatedNode)
 	env := s.makeEnviron()
 	// Shouldn't do anything in MAAS1.
-	err := env.UpdateController("other-controller")
+	err := env.AdoptResources("other-controller", version.MustParse("3.2.1"))
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -1837,7 +1837,7 @@ func (suite *maas2EnvironSuite) TestReleaseContainerAddressesErrorDeletingDevice
 	dev1.CheckCallNames(c, "Delete")
 }
 
-func (suite *maas2EnvironSuite) TestUpdateController(c *gc.C) {
+func (suite *maas2EnvironSuite) TestAdoptResources(c *gc.C) {
 	machine1 := newFakeMachine("big-fig-wasp", "gaudi", "good")
 	machine2 := newFakeMachine("robot-stop", "hundertwasser", "fine")
 	machine3 := newFakeMachine("gamma-knife", "von-neumann", "acceptable")
@@ -1845,7 +1845,7 @@ func (suite *maas2EnvironSuite) TestUpdateController(c *gc.C) {
 	controller.machines = append(controller.machines, machine1, machine3)
 	env := suite.makeEnviron(c, controller)
 
-	err := env.UpdateController("some-other-controller")
+	err := env.AdoptResources("some-other-controller", version.MustParse("1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	machine1.CheckCallNames(c, "SetOwnerData")
@@ -1859,7 +1859,7 @@ func (suite *maas2EnvironSuite) TestUpdateController(c *gc.C) {
 	})
 }
 
-func (suite *maas2EnvironSuite) TestUpdateControllerError(c *gc.C) {
+func (suite *maas2EnvironSuite) TestAdoptResourcesError(c *gc.C) {
 	machine1 := newFakeMachine("evil-death-roll", "frank-lloyd-wright", "ok")
 	machine2 := newFakeMachine("people-vultures", "gehry", "adequate")
 	controller := newFakeController()
@@ -1868,7 +1868,7 @@ func (suite *maas2EnvironSuite) TestUpdateControllerError(c *gc.C) {
 
 	machine1.SetErrors(errors.New("blorp"))
 
-	err := env.UpdateController("some-other-controller")
+	err := env.AdoptResources("some-other-controller", version.MustParse("3.2.1"))
 	c.Assert(err, gc.ErrorMatches, `failed to update controller for some instances: \[evil-death-roll\]`)
 
 	machine1.CheckCallNames(c, "SetOwnerData")

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -1837,15 +1837,15 @@ func (suite *maas2EnvironSuite) TestReleaseContainerAddressesErrorDeletingDevice
 	dev1.CheckCallNames(c, "Delete")
 }
 
-func (suite *maas2EnvironSuite) TestAdoptInstances(c *gc.C) {
+func (suite *maas2EnvironSuite) TestUpdateController(c *gc.C) {
 	machine1 := newFakeMachine("big-fig-wasp", "gaudi", "good")
 	machine2 := newFakeMachine("robot-stop", "hundertwasser", "fine")
 	machine3 := newFakeMachine("gamma-knife", "von-neumann", "acceptable")
 	controller := newFakeController()
-	controller.machines = append(controller.machines, machine1, machine2, machine3)
+	controller.machines = append(controller.machines, machine1, machine3)
 	env := suite.makeEnviron(c, controller)
 
-	err := env.AdoptInstances([]instance.Id{"big-fig-wasp", "gamma-knife"}, "some-other-controller")
+	err := env.UpdateController("some-other-controller")
 	c.Assert(err, jc.ErrorIsNil)
 
 	machine1.CheckCallNames(c, "SetOwnerData")
@@ -1859,7 +1859,7 @@ func (suite *maas2EnvironSuite) TestAdoptInstances(c *gc.C) {
 	})
 }
 
-func (suite *maas2EnvironSuite) TestAdoptInstancesError(c *gc.C) {
+func (suite *maas2EnvironSuite) TestUpdateControllerError(c *gc.C) {
 	machine1 := newFakeMachine("evil-death-roll", "frank-lloyd-wright", "ok")
 	machine2 := newFakeMachine("people-vultures", "gehry", "adequate")
 	controller := newFakeController()
@@ -1868,7 +1868,7 @@ func (suite *maas2EnvironSuite) TestAdoptInstancesError(c *gc.C) {
 
 	machine1.SetErrors(errors.New("blorp"))
 
-	err := env.AdoptInstances([]instance.Id{"evil-death-roll", "people-vultures"}, "some-other-controller")
+	err := env.UpdateController("some-other-controller")
 	c.Assert(err, gc.ErrorMatches, `failed to update controller for some instances: \[evil-death-roll\]`)
 
 	machine1.CheckCallNames(c, "SetOwnerData")

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -178,8 +178,8 @@ func (e *manualEnviron) verifyBootstrapHost() error {
 	return nil
 }
 
-// AdoptInstances implements environs.Environ.
-func (e *manualEnviron) AdoptInstances(ids []instance.Id, controllerUUID string) error {
+// UpdateController is part of the Environ interface.
+func (e *manualEnviron) UpdateController(controllerUUID string) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/ssh"
+	"github.com/juju/version"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cloudconfig/instancecfg"
@@ -178,8 +179,8 @@ func (e *manualEnviron) verifyBootstrapHost() error {
 	return nil
 }
 
-// UpdateController is part of the Environ interface.
-func (e *manualEnviron) UpdateController(controllerUUID string) error {
+// AdoptResources is part of the Environ interface.
+func (e *manualEnviron) AdoptResources(controllerUUID string, fromVersion version.Number) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1259,6 +1259,11 @@ func (e *Environ) Instances(ids []instance.Id) ([]instance.Instance, error) {
 	return insts, err
 }
 
+// UpdateController is part of the Environ interface.
+func (e *Environ) UpdateController(controllerUUID string) error {
+	return errors.NotImplementedf("UpdateController")
+}
+
 // AllInstances returns all instances in this environment.
 func (e *Environ) AllInstances() ([]instance.Instance, error) {
 	tagFilter := tagValue{tags.JujuModel, e.ecfg().UUID()}

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1259,9 +1259,9 @@ func (e *Environ) Instances(ids []instance.Id) ([]instance.Instance, error) {
 	return insts, err
 }
 
-// UpdateController is part of the Environ interface.
-func (e *Environ) UpdateController(controllerUUID string) error {
-	return errors.NotImplementedf("UpdateController")
+// AdoptResources is part of the Environ interface.
+func (e *Environ) AdoptResources(controllerUUID string, fromVersion version.Number) error {
+	return errors.NotImplementedf("AdoptResources")
 }
 
 // AllInstances returns all instances in this environment.

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -175,8 +175,8 @@ func (e *fakeEnviron) ControllerInstances(_ string) ([]instance.Id, error) {
 	return nil, nil
 }
 
-func (e *fakeEnviron) UpdateController(controllerUUID string) error {
-	e.Push("UpdateController")
+func (e *fakeEnviron) AdoptResources(controllerUUID string, fromVersion version.Number) error {
+	e.Push("AdoptResources")
 	return nil
 }
 

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -175,8 +175,8 @@ func (e *fakeEnviron) ControllerInstances(_ string) ([]instance.Id, error) {
 	return nil, nil
 }
 
-func (e *fakeEnviron) AdoptInstances(ids []instance.Id, controllerUUID string) error {
-	e.Push("AdoptInstances")
+func (e *fakeEnviron) UpdateController(controllerUUID string) error {
+	e.Push("UpdateController")
 	return nil
 }
 

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -121,8 +121,8 @@ func (env *environ) BootstrapMessage() string {
 //this variable is exported, because it has to be rewritten in external unit tests
 var DestroyEnv = common.Destroy
 
-// AdoptInstances is part of the Environ interface.
-func (env *environ) AdoptInstances(ids []instance.Id, controllerUUID string) error {
+// UpdateController is part of the Environ interface.
+func (env *environ) UpdateController(controllerUUID string) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/juju/errors"
+	"github.com/juju/version"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -121,8 +122,8 @@ func (env *environ) BootstrapMessage() string {
 //this variable is exported, because it has to be rewritten in external unit tests
 var DestroyEnv = common.Destroy
 
-// UpdateController is part of the Environ interface.
-func (env *environ) UpdateController(controllerUUID string) error {
+// AdoptResources is part of the Environ interface.
+func (env *environ) AdoptResources(controllerUUID string, fromVersion version.Number) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }


### PR DESCRIPTION
This is part of the fix for https://bugs.launchpad.net/juju/+bug/1648063

The migration master will need to call AdoptResources on the target controller provider so that instances, volumes and filesystems can have their controller tags updated to the new controller after migration.

Implemented for the gce, maas and lxd providers so far, implementations for azure, ec2 and openstack to follow.

QA steps - none at the moment, the code to call this provider method isn't implemented.
