### PR TITLE
Use sequences to track used charm URLs

### DIFF
--- a/api/metricsdebug/client_test.go
+++ b/api/metricsdebug/client_test.go
@@ -247,7 +247,7 @@ func assertSameMetric(c *gc.C, a params.MetricResult, b *state.MetricBatch) {
 }
 
 func (s *metricsdebugSuite) TestFeatureGetMetrics(c *gc.C) {
-	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	metric := s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit})
@@ -258,7 +258,7 @@ func (s *metricsdebugSuite) TestFeatureGetMetrics(c *gc.C) {
 }
 
 func (s *metricsdebugSuite) TestFeatureGetMultipleMetrics(c *gc.C) {
-	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: meteredCharm,
 	})
@@ -288,7 +288,7 @@ func (s *metricsdebugSuite) TestFeatureGetMultipleMetrics(c *gc.C) {
 }
 
 func (s *metricsdebugSuite) TestFeatureGetMetricsForModel(c *gc.C) {
-	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: meteredCharm,
 	})
@@ -310,7 +310,7 @@ func (s *metricsdebugSuite) TestFeatureGetMetricsForModel(c *gc.C) {
 }
 
 func (s *metricsdebugSuite) TestFeatureGetMultipleMetricsWithService(c *gc.C) {
-	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: meteredCharm,
 	})
@@ -332,12 +332,12 @@ func (s *metricsdebugSuite) TestFeatureGetMultipleMetricsWithService(c *gc.C) {
 }
 
 func (s *metricsdebugSuite) TestSetMeterStatus(c *gc.C) {
-	testCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	testCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	testService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: testCharm})
 	testUnit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: testService, SetCharmURL: true})
 	testUnit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: testService, SetCharmURL: true})
 
-	csCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})
+	csCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered-1"})
 	csService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Name: "cs-service", Charm: csCharm})
 	csUnit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: csService, SetCharmURL: true})
 

--- a/apiserver/metricsdebug/metricsdebug_test.go
+++ b/apiserver/metricsdebug/metricsdebug_test.go
@@ -38,12 +38,12 @@ func (s *metricsDebugSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *metricsDebugSuite) TestSetMeterStatus(c *gc.C) {
-	testCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	testCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	testService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: testCharm})
 	testUnit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: testService, SetCharmURL: true})
 	testUnit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: testService, SetCharmURL: true})
 
-	csCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})
+	csCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered-1"})
 	csService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Name: "cs-service", Charm: csCharm})
 	csUnit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: csService, SetCharmURL: true})
 
@@ -170,7 +170,7 @@ func (s *metricsDebugSuite) TestSetMeterStatus(c *gc.C) {
 }
 
 func (s *metricsDebugSuite) TestGetMetrics(c *gc.C) {
-	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	t0 := time.Now().Round(time.Second)
@@ -200,7 +200,7 @@ func (s *metricsDebugSuite) TestGetMetrics(c *gc.C) {
 }
 
 func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectly(c *gc.C) {
-	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
 	unit0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
@@ -241,7 +241,7 @@ func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectly(c *gc.C) {
 }
 
 func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectlyWhenNotAllMetricsInEachBatch(c *gc.C) {
-	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
 	unit0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
@@ -277,7 +277,7 @@ func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectlyWhenNotAllMetricsInEac
 }
 
 func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectlyWithMultipleBatchesPerUnit(c *gc.C) {
-	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
 	unit0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
@@ -314,7 +314,7 @@ func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectlyWithMultipleBatchesPer
 }
 
 func (s *metricsDebugSuite) TestGetMultipleMetricsNoMocks(c *gc.C) {
-	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: meteredCharm,
 	})
@@ -351,7 +351,7 @@ func (s *metricsDebugSuite) TestGetMultipleMetricsNoMocks(c *gc.C) {
 }
 
 func (s *metricsDebugSuite) TestGetMultipleMetricsNoMocksWithService(c *gc.C) {
-	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: meteredCharm,
 	})
@@ -383,7 +383,7 @@ func (s *metricsDebugSuite) TestGetMultipleMetricsNoMocksWithService(c *gc.C) {
 }
 
 func (s *metricsDebugSuite) TestGetModelNoMocks(c *gc.C) {
-	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: meteredCharm,
 	})

--- a/cmd/juju/setmeterstatus/setmeterstatus_test.go
+++ b/cmd/juju/setmeterstatus/setmeterstatus_test.go
@@ -81,7 +81,7 @@ func (s *DebugMetricsCommandSuite) TestDebugNoArgs(c *gc.C) {
 }
 
 func (s *DebugMetricsCommandSuite) TestUnits(c *gc.C) {
-	charm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "mysql", URL: "local:quantal/mysql"})
+	charm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "mysql", URL: "local:quantal/mysql-1"})
 	service := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: charm})
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: service, SetCharmURL: true})
 	_, err := coretesting.RunCommand(c, setmeterstatus.New(), unit.Name(), "RED", "--info", "foobar")
@@ -93,7 +93,7 @@ func (s *DebugMetricsCommandSuite) TestUnits(c *gc.C) {
 }
 
 func (s *DebugMetricsCommandSuite) TestService(c *gc.C) {
-	charm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "mysql", URL: "local:quantal/mysql"})
+	charm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "mysql", URL: "local:quantal/mysql-1"})
 	service := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: charm})
 	unit0, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)

--- a/featuretests/cmd_juju_metrics.go
+++ b/featuretests/cmd_juju_metrics.go
@@ -51,7 +51,7 @@ func formatTabular(metrics ...metric) string {
 }
 
 func (s *cmdMetricsCommandSuite) TestUnits(c *gc.C) {
-	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
@@ -85,7 +85,7 @@ func (s *cmdMetricsCommandSuite) TestUnits(c *gc.C) {
 }
 
 func (s *cmdMetricsCommandSuite) TestAll(c *gc.C) {
-	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
@@ -113,7 +113,7 @@ func (s *cmdMetricsCommandSuite) TestAll(c *gc.C) {
 }
 
 func (s *cmdMetricsCommandSuite) TestFormatJSON(c *gc.C) {
-	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
@@ -135,7 +135,7 @@ func (s *cmdMetricsCommandSuite) TestFormatJSON(c *gc.C) {
 }
 
 func (s *cmdMetricsCommandSuite) TestFormatYAML(c *gc.C) {
-	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
@@ -157,7 +157,7 @@ func (s *cmdMetricsCommandSuite) TestFormatYAML(c *gc.C) {
 }
 
 func (s *cmdMetricsCommandSuite) TestNoMetrics(c *gc.C) {
-	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
 	s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	ctx, err := coretesting.RunCommand(c, metricsdebug.New(), "metered")

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
@@ -22,7 +21,6 @@ import (
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/status"
-	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
 )
 
@@ -48,22 +46,6 @@ options:
 
 type allWatcherBaseSuite struct {
 	internalStateSuite
-	modelCount int
-}
-
-func (s *allWatcherBaseSuite) newState(c *gc.C) *State {
-	s.modelCount++
-	cfg := testing.CustomModelConfig(c, testing.Attrs{
-		"name": fmt.Sprintf("testenv%d", s.modelCount),
-		"uuid": utils.MustNewUUID().String(),
-	})
-	_, st, err := s.state.NewModel(ModelArgs{
-		CloudName: "dummy", CloudRegion: "dummy-region", Config: cfg, Owner: s.owner,
-		StorageProviderRegistry: storage.StaticProviderRegistry{},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	s.AddCleanup(func(*gc.C) { st.Close() })
-	return st
 }
 
 // setUpScenario adds some entities to the state so that

--- a/state/charm.go
+++ b/state/charm.go
@@ -52,14 +52,7 @@ type charmDoc struct {
 
 	// Life manages charm lifetime in the usual way, but only local
 	// charms can actually be "destroyed"; store charms are
-	// immortal. When a local charm is removed, its document is left
-	// in place, with Life set to Dead, to ensure we don't
-	// accidentally reuse the charm URL, which must be unique within
-	// a model.
-	//
-	// Note that this aligns with the existing contract implied by
-	// Dead: that most clients should see it as not existing at all.
-	// Nothing strictly obliges us to clean up the doc.
+	// immortal.
 	Life Life `bson:"life"`
 
 	// These fields are flags; if any of them is set, the charm
@@ -535,18 +528,25 @@ func (st *State) AddCharm(info CharmInfo) (stch *Charm, err error) {
 		return nil, errors.Trace(err)
 	}
 
-	query := charms.FindId(info.ID.String()).Select(bson.D{{"placeholder", 1}})
+	query := charms.FindId(info.ID.String()).Select(bson.M{"placeholder": 1})
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
-		var placeholderDoc struct {
+		var doc struct {
 			Placeholder bool `bson:"placeholder"`
 		}
-		if err := query.One(&placeholderDoc); err == mgo.ErrNotFound {
-
+		if err := query.One(&doc); err == mgo.ErrNotFound {
+			if info.ID.Schema == "local" {
+				curl, err := st.PrepareLocalCharmUpload(info.ID)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				info.ID = curl
+				return updateCharmOps(st, info, stillPending)
+			}
 			return insertCharmOps(st, info)
 		} else if err != nil {
 			return nil, errors.Trace(err)
-		} else if placeholderDoc.Placeholder {
+		} else if doc.Placeholder {
 			return updateCharmOps(st, info, stillPlaceholder)
 		}
 		return nil, errors.AlreadyExistsf("charm %q", info.ID)
@@ -651,42 +651,23 @@ func (st *State) PrepareLocalCharmUpload(curl *charm.URL) (chosenURL *charm.URL,
 	if curl.Revision < 0 {
 		return nil, errors.Errorf("expected charm URL with revision, got %q", curl)
 	}
-	// Get a regex with the charm URL and no revision.
-	noRevURL := curl.WithRevision(-1)
-	curlRegex := "^" + regexp.QuoteMeta(st.docID(noRevURL.String()))
 
-	charms, closer := st.getCollection(charmsC)
-	defer closer()
-
-	buildTxn := func(attempt int) ([]txn.Op, error) {
-		// Find the highest revision of that charm in state.
-		var docs []charmDoc
-		query := bson.D{{"_id", bson.D{{"$regex", curlRegex}}}}
-		err = charms.Find(query).Select(bson.D{{"_id", 1}, {"url", 1}}).All(&docs)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		// Find the highest revision.
-		maxRevision := -1
-		for _, doc := range docs {
-			if doc.URL.Revision > maxRevision {
-				maxRevision = doc.URL.Revision
-			}
-		}
-
-		// Respect the local charm's revision first.
-		chosenRevision := curl.Revision
-		if maxRevision >= chosenRevision {
-			// More recent revision exists in state, pick the next.
-			chosenRevision = maxRevision + 1
-		}
-		chosenURL = curl.WithRevision(chosenRevision)
-		return insertPendingCharmOps(st, chosenURL)
+	revisionSeq := "charmrev-" + curl.WithRevision(-1).String()
+	revision, err := st.sequenceWithMin(revisionSeq, curl.Revision)
+	if err != nil {
+		return nil, errors.Annotate(err, "unable to allocate charm revision")
 	}
-	if err = st.run(buildTxn); err == nil {
-		return chosenURL, nil
+	allocatedURL := curl.WithRevision(revision)
+
+	ops, err := insertPendingCharmOps(st, allocatedURL)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	return nil, errors.Trace(err)
+
+	if err := st.runTransaction(ops); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return allocatedURL, nil
 }
 
 // PrepareStoreCharmUpload must be called before a charm store charm

--- a/state/charm.go
+++ b/state/charm.go
@@ -652,7 +652,7 @@ func (st *State) PrepareLocalCharmUpload(curl *charm.URL) (chosenURL *charm.URL,
 		return nil, errors.Errorf("expected charm URL with revision, got %q", curl)
 	}
 
-	revisionSeq := "charmrev-" + curl.WithRevision(-1).String()
+	revisionSeq := charmRevSeqName(curl.WithRevision(-1).String())
 	revision, err := st.sequenceWithMin(revisionSeq, curl.Revision)
 	if err != nil {
 		return nil, errors.Annotate(err, "unable to allocate charm revision")
@@ -668,6 +668,10 @@ func (st *State) PrepareLocalCharmUpload(curl *charm.URL) (chosenURL *charm.URL,
 		return nil, errors.Trace(err)
 	}
 	return allocatedURL, nil
+}
+
+func charmRevSeqName(baseURL string) string {
+	return "charmrev-" + baseURL
 }
 
 // PrepareStoreCharmUpload must be called before a charm store charm

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -52,6 +52,13 @@ func (s *CharmSuite) checkRemoved(c *gc.C) {
 	_, err := s.State.Charm(s.curl)
 	c.Check(err, gc.ErrorMatches, `charm ".*" not found`)
 	c.Check(err, jc.Satisfies, errors.IsNotFound)
+
+	// Ensure the document is actually gone.
+	coll, closer := state.GetCollection(s.State, "charms")
+	defer closer()
+	count, err := coll.FindId(s.curl.String()).Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(count, gc.Equals, 0)
 }
 
 func (s *CharmSuite) TestAliveCharm(c *gc.C) {

--- a/state/charmref.go
+++ b/state/charmref.go
@@ -154,17 +154,16 @@ func charmDestroyOps(st modelBackend, curl *charm.URL) ([]txn.Op, error) {
 
 // charmRemoveOps implements the logic of charm.Remove.
 func charmRemoveOps(st modelBackend, curl *charm.URL) ([]txn.Op, error) {
-
 	charms, closer := st.getCollection(charmsC)
 	defer closer()
 
-	// NOTE: we don't actually remove the charm document.  The
-	// "remove" terminology refers to the client's view of the change
-	// (after which the charm really will be inaccessible).
 	charmKey := curl.String()
-	charmOp, err := nsLife.dieOp(charms, charmKey, nil)
+
+	// Remove the charm document as long as the charm is dying.
+	charmOp, err := nsLife.dyingOp(charms, charmKey)
 	if err != nil {
 		return nil, errors.Annotate(err, "charm")
 	}
+	charmOp.Remove = true
 	return []txn.Op{charmOp}, nil
 }

--- a/state/charmref.go
+++ b/state/charmref.go
@@ -120,10 +120,6 @@ func finalAppCharmRemoveOps(appName string, curl *charm.URL) []txn.Op {
 func charmDestroyOps(st modelBackend, curl *charm.URL) ([]txn.Op, error) {
 
 	if curl.Schema != "local" {
-		// local charms keep a document around to prevent reuse
-		// of charm URLs, which several components believe to be
-		// unique keys (this is always true within a model).
-		//
 		// it's not so much that it's bad to delete store
 		// charms; but we don't have a way to reinstate them
 		// once purged, so we don't allow removal in the first
@@ -162,10 +158,9 @@ func charmRemoveOps(st modelBackend, curl *charm.URL) ([]txn.Op, error) {
 	charms, closer := st.getCollection(charmsC)
 	defer closer()
 
-	// NOTE: we do *not* actually remove the charm document, to
-	// prevent its URL from being recycled, and breaking caches.
-	// The "remove" terminology refers to the client's view of the
-	// change (after which the charm really will be inaccessible).
+	// NOTE: we don't actually remove the charm document.  The
+	// "remove" terminology refers to the client's view of the change
+	// (after which the charm really will be inaccessible).
 	charmKey := curl.String()
 	charmOp, err := nsLife.dieOp(charms, charmKey, nil)
 	if err != nil {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -373,6 +373,13 @@ func SequenceWithMin(st *State, name string, minVal int) (int, error) {
 	return st.sequenceWithMin(name, minVal)
 }
 
+func SequenceEnsure(st *State, name string, nextVal int) error {
+	sequences, closer := st.getRawCollection(sequenceC)
+	defer closer()
+	updater := newDbSeqUpdater(sequences, st.ModelUUID(), name)
+	return updater.ensure(nextVal)
+}
+
 func SetModelLifeDead(st *State, modelUUID string) error {
 	ops := []txn.Op{{
 		C:      modelsC,

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -4,9 +4,12 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -31,8 +34,9 @@ var _ = gc.Suite(&internalStateSuite{})
 type internalStateSuite struct {
 	jujutesting.MgoSuite
 	testing.BaseSuite
-	state *State
-	owner names.UserTag
+	state      *State
+	owner      names.UserTag
+	modelCount int
 }
 
 func (s *internalStateSuite) SetUpSuite(c *gc.C) {
@@ -94,6 +98,24 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 func (s *internalStateSuite) TearDownTest(c *gc.C) {
 	s.BaseSuite.TearDownTest(c)
 	s.MgoSuite.TearDownTest(c)
+}
+
+func (s *internalStateSuite) newState(c *gc.C) *State {
+	s.modelCount++
+	cfg := testing.CustomModelConfig(c, testing.Attrs{
+		"name": fmt.Sprintf("testmodel%d", s.modelCount),
+		"uuid": utils.MustNewUUID().String(),
+	})
+	_, st, err := s.state.NewModel(ModelArgs{
+		CloudName:   "dummy",
+		CloudRegion: "dummy-region",
+		Config:      cfg,
+		Owner:       s.owner,
+		StorageProviderRegistry: storage.StaticProviderRegistry{},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(*gc.C) { st.Close() })
+	return st
 }
 
 type internalStatePolicy struct{}

--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -28,7 +28,7 @@ var _ = gc.Suite(&MetricSuite{})
 
 func (s *MetricSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
-	s.meteredCharm = s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})
+	s.meteredCharm = s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered-1"})
 	s.application = s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: s.meteredCharm})
 	s.unit = s.Factory.MakeUnit(c, &factory.UnitParams{Application: s.application, SetCharmURL: true})
 }
@@ -72,7 +72,7 @@ func (s *MetricSuite) TestAddMetric(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metricBatch.Unit(), gc.Equals, "metered/0")
 	c.Assert(metricBatch.ModelUUID(), gc.Equals, modelUUID)
-	c.Assert(metricBatch.CharmURL(), gc.Equals, "cs:quantal/metered")
+	c.Assert(metricBatch.CharmURL(), gc.Equals, "cs:quantal/metered-1")
 	c.Assert(metricBatch.Sent(), jc.IsFalse)
 	c.Assert(metricBatch.Created(), gc.Equals, now)
 	c.Assert(metricBatch.Metrics(), gc.HasLen, 1)
@@ -85,7 +85,7 @@ func (s *MetricSuite) TestAddMetric(c *gc.C) {
 	saved, err := s.State.MetricBatch(metricBatch.UUID())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(saved.Unit(), gc.Equals, "metered/0")
-	c.Assert(metricBatch.CharmURL(), gc.Equals, "cs:quantal/metered")
+	c.Assert(metricBatch.CharmURL(), gc.Equals, "cs:quantal/metered-1")
 	c.Assert(saved.Sent(), jc.IsFalse)
 	c.Assert(saved.Metrics(), gc.HasLen, 1)
 	metric = saved.Metrics()[0]
@@ -262,7 +262,7 @@ func (s *MetricSuite) TestAllMetricBatches(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metricBatches, gc.HasLen, 1)
 	c.Assert(metricBatches[0].Unit(), gc.Equals, "metered/0")
-	c.Assert(metricBatches[0].CharmURL(), gc.Equals, "cs:quantal/metered")
+	c.Assert(metricBatches[0].CharmURL(), gc.Equals, "cs:quantal/metered-1")
 	c.Assert(metricBatches[0].Sent(), jc.IsFalse)
 	c.Assert(metricBatches[0].Metrics(), gc.HasLen, 1)
 }
@@ -271,7 +271,7 @@ func (s *MetricSuite) TestAllMetricBatchesCustomCharmURLAndUUID(c *gc.C) {
 	now := s.State.NowToTheSecond()
 	m := state.Metric{"pings", "5", now}
 	uuid := utils.MustNewUUID().String()
-	charmURL := "cs:quantal/metered"
+	charmURL := "cs:quantal/metered-1"
 	_, err := s.State.AddMetrics(
 		state.BatchParam{
 			UUID:     uuid,
@@ -530,7 +530,7 @@ func (s *MetricSuite) TestAddBuiltInMetric(c *gc.C) {
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(metricBatch.Unit(), gc.Equals, "metered/0")
 			c.Assert(metricBatch.ModelUUID(), gc.Equals, modelUUID)
-			c.Assert(metricBatch.CharmURL(), gc.Equals, "cs:quantal/metered")
+			c.Assert(metricBatch.CharmURL(), gc.Equals, "cs:quantal/metered-1")
 			c.Assert(metricBatch.Sent(), jc.IsFalse)
 			c.Assert(metricBatch.Created(), gc.Equals, now)
 			c.Assert(metricBatch.Metrics(), gc.HasLen, 1)
@@ -543,7 +543,7 @@ func (s *MetricSuite) TestAddBuiltInMetric(c *gc.C) {
 			saved, err := s.State.MetricBatch(metricBatch.UUID())
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(saved.Unit(), gc.Equals, "metered/0")
-			c.Assert(metricBatch.CharmURL(), gc.Equals, "cs:quantal/metered")
+			c.Assert(metricBatch.CharmURL(), gc.Equals, "cs:quantal/metered-1")
 			c.Assert(saved.Sent(), jc.IsFalse)
 			c.Assert(saved.Metrics(), gc.HasLen, 1)
 			metric = saved.Metrics()[0]
@@ -569,7 +569,7 @@ func (s *MetricSuite) TestUnitMetricBatchesMatchesAllCharms(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	localMeteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	localMeteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	application := s.Factory.MakeApplication(c, &factory.ApplicationParams{Name: "localmetered", Charm: localMeteredCharm})
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: application, SetCharmURL: true})
 	_, err = s.State.AddMetrics(
@@ -610,7 +610,7 @@ var _ = gc.Suite(&MetricLocalCharmSuite{})
 
 func (s *MetricLocalCharmSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
-	s.meteredCharm = s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered"})
+	s.meteredCharm = s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	s.application = s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: s.meteredCharm})
 	s.unit = s.Factory.MakeUnit(c, &factory.UnitParams{Application: s.application, SetCharmURL: true})
 }
@@ -646,7 +646,7 @@ func (s *MetricLocalCharmSuite) TestUnitMetricBatches(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metricBatches, gc.HasLen, 1)
 	c.Check(metricBatches[0].Unit(), gc.Equals, "metered/0")
-	c.Check(metricBatches[0].CharmURL(), gc.Equals, "local:quantal/metered")
+	c.Check(metricBatches[0].CharmURL(), gc.Equals, "local:quantal/metered-1")
 	c.Check(metricBatches[0].Sent(), jc.IsFalse)
 	c.Assert(metricBatches[0].Metrics(), gc.HasLen, 1)
 	c.Check(metricBatches[0].Metrics()[0].Value, gc.Equals, "5")
@@ -655,7 +655,7 @@ func (s *MetricLocalCharmSuite) TestUnitMetricBatches(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metricBatches, gc.HasLen, 1)
 	c.Check(metricBatches[0].Unit(), gc.Equals, "metered/1")
-	c.Check(metricBatches[0].CharmURL(), gc.Equals, "local:quantal/metered")
+	c.Check(metricBatches[0].CharmURL(), gc.Equals, "local:quantal/metered-1")
 	c.Check(metricBatches[0].Sent(), jc.IsFalse)
 	c.Assert(metricBatches[0].Metrics(), gc.HasLen, 1)
 	c.Check(metricBatches[0].Metrics()[0].Value, gc.Equals, "10")
@@ -693,13 +693,13 @@ func (s *MetricLocalCharmSuite) TestApplicationMetricBatches(c *gc.C) {
 	c.Assert(metricBatches, gc.HasLen, 2)
 
 	c.Check(metricBatches[0].Unit(), gc.Equals, "metered/0")
-	c.Check(metricBatches[0].CharmURL(), gc.Equals, "local:quantal/metered")
+	c.Check(metricBatches[0].CharmURL(), gc.Equals, "local:quantal/metered-1")
 	c.Check(metricBatches[0].Sent(), jc.IsFalse)
 	c.Assert(metricBatches[0].Metrics(), gc.HasLen, 1)
 	c.Check(metricBatches[0].Metrics()[0].Value, gc.Equals, "5")
 
 	c.Check(metricBatches[1].Unit(), gc.Equals, "metered/1")
-	c.Check(metricBatches[1].CharmURL(), gc.Equals, "local:quantal/metered")
+	c.Check(metricBatches[1].CharmURL(), gc.Equals, "local:quantal/metered-1")
 	c.Check(metricBatches[1].Sent(), jc.IsFalse)
 	c.Assert(metricBatches[1].Metrics(), gc.HasLen, 1)
 	c.Check(metricBatches[1].Metrics()[0].Value, gc.Equals, "10")
@@ -737,7 +737,7 @@ func (s *MetricLocalCharmSuite) TestModelMetricBatches(c *gc.C) {
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
 	f := factory.NewFactory(st)
-	meteredCharm := f.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})
+	meteredCharm := f.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered-1"})
 	service := f.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
 	unit := f.MakeUnit(c, &factory.UnitParams{Application: service, SetCharmURL: true})
 	_, err = st.AddMetrics(
@@ -769,14 +769,14 @@ func (s *MetricLocalCharmSuite) TestModelMetricBatches(c *gc.C) {
 	c.Assert(second, gc.NotNil)
 
 	c.Check(first.Unit(), gc.Equals, "metered/0")
-	c.Check(first.CharmURL(), gc.Equals, "local:quantal/metered")
+	c.Check(first.CharmURL(), gc.Equals, "local:quantal/metered-1")
 	c.Check(first.ModelUUID(), gc.Equals, s.State.ModelUUID())
 	c.Check(first.Sent(), jc.IsFalse)
 	c.Assert(first.Metrics(), gc.HasLen, 1)
 	c.Check(first.Metrics()[0].Value, gc.Equals, "5")
 
 	c.Check(second.Unit(), gc.Equals, "metered/1")
-	c.Check(second.CharmURL(), gc.Equals, "local:quantal/metered")
+	c.Check(second.CharmURL(), gc.Equals, "local:quantal/metered-1")
 	c.Check(second.ModelUUID(), gc.Equals, s.State.ModelUUID())
 	c.Check(second.Sent(), jc.IsFalse)
 	c.Assert(second.Metrics(), gc.HasLen, 1)
@@ -870,7 +870,7 @@ func (s *MetricLocalCharmSuite) TestUnitMetricBatchesReturnsAllCharms(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	csMeteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})
+	csMeteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered-1"})
 	application := s.Factory.MakeApplication(c, &factory.ApplicationParams{Name: "csmetered", Charm: csMeteredCharm})
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: application, SetCharmURL: true})
 	_, err = s.State.AddMetrics(
@@ -961,7 +961,7 @@ func mustCreateMeteredModel(c *gc.C, stateFactory *factory.Factory) (modelData, 
 	st := stateFactory.MakeModel(c, nil)
 	localFactory := factory.NewFactory(st)
 
-	meteredCharm := localFactory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})
+	meteredCharm := localFactory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered-1"})
 	application := localFactory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
 	unit := localFactory.MakeUnit(c, &factory.UnitParams{Application: application, SetCharmURL: true})
 	cleanup := func(*gc.C) { st.Close() }

--- a/state/sequence.go
+++ b/state/sequence.go
@@ -207,7 +207,7 @@ func (su *dbSeqUpdater) ensure(next int) error {
 		ok, err = su.set(curVal, next)
 	}
 	if !ok {
-		return errors.New("unexpected contention")
+		return errors.New("unexpected contention while updating sequence")
 	}
 	return errors.Trace(err)
 }

--- a/state/sequence_test.go
+++ b/state/sequence_test.go
@@ -153,6 +153,30 @@ func (s *sequenceSuite) TestContention(c *gc.C) {
 	}
 }
 
+func (s *sequenceSuite) TestEnsureCreate(c *gc.C) {
+	err := state.SequenceEnsure(s.State, "foo", 3)
+	c.Assert(err, jc.ErrorIsNil)
+	s.incAndCheck(c, s.State, "foo", 3)
+}
+
+func (s *sequenceSuite) TestEnsureSet(c *gc.C) {
+	s.incAndCheck(c, s.State, "foo", 0)
+	err := state.SequenceEnsure(s.State, "foo", 5)
+	c.Assert(err, jc.ErrorIsNil)
+	s.incAndCheck(c, s.State, "foo", 5)
+}
+
+func (s *sequenceSuite) TestEnsureBackwards(c *gc.C) {
+	s.incAndCheck(c, s.State, "foo", 0)
+	s.incAndCheck(c, s.State, "foo", 1)
+	s.incAndCheck(c, s.State, "foo", 2)
+
+	err := state.SequenceEnsure(s.State, "foo", 1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.incAndCheck(c, s.State, "foo", 3)
+}
+
 func (s *sequenceSuite) incAndCheck(c *gc.C, st *state.State, name string, expectedCount int) {
 	value, err := state.Sequence(st, name)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -256,7 +257,7 @@ func AddMigrationAttempt(st *State) error {
 		id := doc["_id"]
 		attempt, err := extractMigrationAttempt(id)
 		if err != nil {
-			logger.Warningf("%s (skipping)", err)
+			upgradesLogger.Warningf("%s (skipping)", err)
 			continue
 		}
 
@@ -291,4 +292,65 @@ func extractMigrationAttempt(id interface{}) (int, error) {
 	}
 
 	return attempt, nil
+}
+
+// AddLocalCharmSequences creates any missing sequences in the
+// database for tracking already used local charm revisions.
+func AddLocalCharmSequences(st *State) error {
+	charmsColl, closer := st.getRawCollection(charmsC)
+	defer closer()
+
+	query := bson.M{
+		"url": bson.M{"$regex": "^local:"},
+	}
+	var docs []bson.M
+	err := charmsColl.Find(query).Select(bson.M{"_id": 1}).All(&docs)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// model UUID -> charm URL base -> max revision
+	maxRevs := make(map[string]map[string]int)
+	for _, doc := range docs {
+		id, ok := doc["_id"].(string)
+		if !ok {
+			upgradesLogger.Errorf("invalid charm id: %v", doc["_id"])
+			continue
+		}
+		modelUUID, urlStr, ok := splitDocID(id)
+		if !ok {
+			upgradesLogger.Errorf("unable to split charm _id: %v", id)
+			continue
+		}
+		url, err := charm.ParseURL(urlStr)
+		if err != nil {
+			upgradesLogger.Errorf("unable to parse charm URL: %v", err)
+			continue
+		}
+
+		if _, ok := maxRevs[modelUUID]; !ok {
+			maxRevs[modelUUID] = make(map[string]int)
+		}
+
+		baseURL := url.WithRevision(-1).String()
+		curRev := maxRevs[modelUUID][baseURL]
+		if url.Revision > curRev {
+			maxRevs[modelUUID][baseURL] = url.Revision
+		}
+	}
+
+	sequences, closer := st.getRawCollection(sequenceC)
+	defer closer()
+	for modelUUID, modelRevs := range maxRevs {
+		for baseURL, maxRevision := range modelRevs {
+			name := charmRevSeqName(baseURL)
+			updater := newDbSeqUpdater(sequences, modelUUID, name)
+			err := updater.ensure(maxRevision + 1)
+			if err != nil {
+				return errors.Annotatef(err, "setting sequence %s", name)
+			}
+		}
+
+	}
+	return nil
 }

--- a/upgrades/steps_21.go
+++ b/upgrades/steps_21.go
@@ -24,5 +24,12 @@ func stateStepsFor21() []Step {
 				return state.AddMigrationAttempt(context.State())
 			},
 		},
+		&upgradeStep{
+			description: "add sequences to track used local charm revisions",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddLocalCharmSequences(context.State())
+			},
+		},
 	}
 }

--- a/upgrades/steps_21_test.go
+++ b/upgrades/steps_21_test.go
@@ -31,3 +31,9 @@ func (s *steps21Suite) TestAddMigrationAttempt(c *gc.C) {
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
+
+func (s *steps21Suite) TestAddLocalCharmSequences(c *gc.C) {
+	step := findStateStep(c, v210, "add sequences to track used local charm revisions")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}


### PR DESCRIPTION
Instead of relying on "dead" charm documents, which doesn't work well with migrations, local charm revisions are now tracked using a sequence. Dead charm documents are now removed.

An upgrade step is also included which adds any required sequences for pre-existing charms.

This PR also includes a fix for an unrelated gofmt issue in worker/machiner.

## QA steps

* Deploy using 2.1 branch
* Deploy a local charm
* Remove the local charm
* juju upgrade-juju to the code in this PR.
* Observe the the DB now contains the appropriate sequence & that the dead charm doc for the previous deploy is removed.
* Redeploy the local charm, observing the next charm revision is used.
* Deploy another application using the same local charm URL.
* Remove both applications, observing the charm is removed from the charms collection and the blobstore only once *both* applications are gone.
* Redeploy the local charm and observe that correct sequence is used.

## Bug reference

This is the final fix for https://bugs.launchpad.net/juju/+bug/1657614

