### PR TITLE
Move builtin clouds to providers

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -18,7 +18,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/juju/osenv"
-	"github.com/juju/juju/provider/lxd/lxdnames"
 )
 
 //go:generate go run ../generate/filetoconst/filetoconst.go fallbackPublicCloudInfo fallback-public-cloud.yaml fallback_public_cloud.go 2015 cloud
@@ -189,20 +188,6 @@ type region struct {
 	StorageEndpoint  string `yaml:"storage-endpoint,omitempty"`
 }
 
-//DefaultLXD is the name of the default lxd cloud.
-const DefaultLXD = "localhost"
-
-// BuiltInClouds work out of the box.
-var BuiltInClouds = map[string]Cloud{
-	DefaultLXD: {
-		Name:        DefaultLXD,
-		Type:        lxdnames.ProviderType,
-		AuthTypes:   []AuthType{EmptyAuthType},
-		Regions:     []Region{{Name: lxdnames.DefaultRegion}},
-		Description: defaultCloudDescription[lxdnames.ProviderType],
-	},
-}
-
 // CloudByName returns the cloud with the specified name.
 // If there exists no cloud with the specified name, an
 // error satisfying errors.IsNotFound will be returned.
@@ -222,9 +207,6 @@ func CloudByName(name string) (*Cloud, error) {
 		return nil, errors.Trace(err)
 	}
 	if cloud, ok := clouds[name]; ok {
-		return &cloud, nil
-	}
-	if cloud, ok := BuiltInClouds[name]; ok {
 		return &cloud, nil
 	}
 	return nil, errors.NotFoundf("cloud %s", name)
@@ -313,6 +295,12 @@ func ParseCloudMetadata(data []byte) (map[string]Cloud, error) {
 		clouds[name] = details
 	}
 	return clouds, nil
+}
+
+// DefaultCloudDescription returns the description for the specified cloud
+// type, or an empty string if the cloud type is unknown.
+func DefaultCloudDescription(cloudType string) string {
+	return defaultCloudDescription[cloudType]
 }
 
 var defaultCloudDescription = map[string]string{

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -230,7 +230,10 @@ func queryName(
 			cloudName = ""
 			continue
 		}
-		msg := nameExists(cloudName, public)
+		msg, err := nameExists(cloudName, public)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
 		if msg == "" {
 			return cloudName, nil
 		}
@@ -306,7 +309,11 @@ func (c *AddCloudCommand) verifyName(name string) error {
 	if _, ok := personal[name]; ok {
 		return errors.Errorf("%q already exists; use --replace to replace this existing cloud", name)
 	}
-	if msg := nameExists(name, public); msg != "" {
+	msg, err := nameExists(name, public)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if msg != "" {
 		return errors.Errorf(msg + "; use --replace to override this definition")
 	}
 	return nil
@@ -314,14 +321,18 @@ func (c *AddCloudCommand) verifyName(name string) error {
 
 // nameExists returns either an empty string if the name does not exist, or a
 // non-empty string with an error message if it does exist.
-func nameExists(name string, public map[string]cloud.Cloud) string {
+func nameExists(name string, public map[string]cloud.Cloud) (string, error) {
 	if _, ok := public[name]; ok {
-		return fmt.Sprintf("%q is the name of a public cloud", name)
+		return fmt.Sprintf("%q is the name of a public cloud", name), nil
 	}
-	if _, ok := common.BuiltInClouds()[name]; ok {
-		return fmt.Sprintf("%q is the name of a built-in cloud", name)
+	builtin, err := common.BuiltInClouds()
+	if err != nil {
+		return "", errors.Trace(err)
 	}
-	return ""
+	if _, ok := builtin[name]; ok {
+		return fmt.Sprintf("%q is the name of a built-in cloud", name), nil
+	}
+	return "", nil
 }
 
 func addCloud(cloudMetadataStore CloudMetadataStore, name string, newCloud cloud.Cloud) error {

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -134,7 +134,11 @@ func listCloudDetails() (*cloudList, error) {
 	}
 
 	// Add in built in clouds like localhost (lxd).
-	for name, cloud := range common.BuiltInClouds() {
+	builtinClouds, err := common.BuiltInClouds()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for name, cloud := range builtinClouds {
 		cloudDetails := makeCloudDetails(cloud)
 		cloudDetails.Source = "built-in"
 		details.builtin[name] = cloudDetails

--- a/cmd/juju/commands/bootstrap_clouds.go
+++ b/cmd/juju/commands/bootstrap_clouds.go
@@ -98,7 +98,11 @@ func printClouds(ctx *cmd.Context, credStore jujuclient.CredentialStore) error {
 		clouds.public = append(clouds.public, name)
 	}
 	// Add in built in clouds like localhost (lxd).
-	for name := range common.BuiltInClouds() {
+	builtin, err := common.BuiltInClouds()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for name := range builtin {
 		clouds.builtin = append(clouds.builtin, name)
 	}
 	for name := range personalClouds {

--- a/cmd/juju/commands/bootstrap_interactive.go
+++ b/cmd/juju/commands/bootstrap_interactive.go
@@ -28,7 +28,12 @@ func assembleClouds() ([]string, error) {
 		return nil, errors.Trace(err)
 	}
 
-	return sortClouds(public, common.BuiltInClouds(), personal), nil
+	builtin, err := common.BuiltInClouds()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return sortClouds(public, builtin, personal), nil
 }
 
 // queryCloud asks the user to choose a cloud.

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -73,7 +73,6 @@ func init() {
 	environs.RegisterProvider("no-cloud-regions", noCloudRegionsProvider{dummyProvider})
 	environs.RegisterProvider("no-credentials", noCredentialsProvider{})
 	environs.RegisterProvider("many-credentials", manyCredentialsProvider{dummyProvider})
-	environs.RegisterProvider("default-cloud-name", defaultCloudNameProvider{})
 }
 
 func (s *BootstrapSuite) SetUpSuite(c *gc.C) {
@@ -1338,6 +1337,36 @@ func (s *BootstrapSuite) TestManyAvailableCredentialsNoneSpecified(c *gc.C) {
 	c.Assert(msg, gc.Matches, "more than one credential is available.*")
 }
 
+func (s *BootstrapSuite) TestBootstrapProviderDetectCloud(c *gc.C) {
+	resetJujuXDGDataHome(c)
+
+	var bootstrap fakeBootstrapFuncs
+	bootstrap.cloudDetector = cloudDetectorFunc(func() ([]cloud.Cloud, error) {
+		return []cloud.Cloud{{
+			Name:      "bruce",
+			Type:      "dummy",
+			AuthTypes: []cloud.AuthType{cloud.CertificateAuthType},
+			Regions:   []cloud.Region{{Name: "gazza", Endpoint: "endpoint"}},
+		}}, nil
+	})
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return &bootstrap
+	})
+
+	s.patchVersionAndSeries(c, "raring")
+	coretesting.RunCommand(c, s.newBootstrapCommand(), "bruce", "ctrl")
+	c.Assert(bootstrap.args.CloudName, gc.Equals, "bruce")
+	c.Assert(bootstrap.args.CloudRegion, gc.Equals, "gazza")
+	c.Assert(bootstrap.args.CloudCredentialName, gc.Equals, "default")
+	sort.Sort(bootstrap.args.Cloud.AuthTypes)
+	c.Assert(bootstrap.args.Cloud, jc.DeepEquals, cloud.Cloud{
+		Name:      "bruce",
+		Type:      "dummy",
+		AuthTypes: []cloud.AuthType{cloud.CertificateAuthType},
+		Regions:   []cloud.Region{{Name: "gazza", Endpoint: "endpoint"}},
+	})
+}
+
 func (s *BootstrapSuite) TestBootstrapProviderDetectRegions(c *gc.C) {
 	resetJujuXDGDataHome(c)
 
@@ -1382,24 +1411,6 @@ func (s *BootstrapSuite) TestBootstrapProviderDetectNoRegions(c *gc.C) {
 		Type:      "dummy",
 		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
 	})
-}
-
-func (s *BootstrapSuite) TestBootstrapProviderUsesDefaultCloudName(c *gc.C) {
-	s.patchVersionAndSeries(c, "xenial")
-
-	var prepareParams bootstrap.PrepareParams
-	s.PatchValue(&bootstrapPrepare, func(
-		ctx environs.BootstrapContext,
-		stor jujuclient.ClientStore,
-		params bootstrap.PrepareParams,
-	) (environs.Environ, error) {
-		prepareParams = params
-		return nil, errors.New("mock-prepare")
-	})
-
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "default-cloud-name", "ctrl")
-	c.Assert(err, gc.ErrorMatches, "mock-prepare")
-	c.Assert(prepareParams.Cloud.Name, gc.Equals, "mykonos")
 }
 
 func (s *BootstrapSuite) TestBootstrapProviderCaseInsensitiveRegionCheck(c *gc.C) {
@@ -1767,12 +1778,18 @@ func joinBinaryVersions(versions ...[]version.Binary) []version.Binary {
 // file which execute large amounts of external functionality.
 type fakeBootstrapFuncs struct {
 	args                bootstrap.BootstrapParams
+	cloudDetector       environs.CloudDetector
 	cloudRegionDetector environs.CloudRegionDetector
 }
 
 func (fake *fakeBootstrapFuncs) Bootstrap(ctx environs.BootstrapContext, env environs.Environ, args bootstrap.BootstrapParams) error {
 	fake.args = args
 	return nil
+}
+
+func (fake *fakeBootstrapFuncs) CloudDetector(environs.EnvironProvider) (environs.CloudDetector, bool) {
+	detector := fake.cloudDetector
+	return detector, detector != nil
 }
 
 func (fake *fakeBootstrapFuncs) CloudRegionDetector(environs.EnvironProvider) (environs.CloudRegionDetector, bool) {
@@ -1783,10 +1800,6 @@ func (fake *fakeBootstrapFuncs) CloudRegionDetector(environs.EnvironProvider) (e
 		})
 	}
 	return detector, true
-}
-
-func (fake *fakeBootstrapFuncs) DefaultCloudName(environs.EnvironProvider) (string, bool) {
-	return "", false
 }
 
 type noCloudRegionDetectionProvider struct {
@@ -1842,24 +1855,27 @@ func (manyCredentialsProvider) CredentialSchemas() map[cloud.AuthType]cloud.Cred
 	return map[cloud.AuthType]cloud.CredentialSchema{"one": {}, "two": {}}
 }
 
+type cloudDetectorFunc func() ([]cloud.Cloud, error)
+
+func (c cloudDetectorFunc) DetectCloud(name string) (cloud.Cloud, error) {
+	clouds, err := c.DetectClouds()
+	if err != nil {
+		return cloud.Cloud{}, err
+	}
+	for _, cloud := range clouds {
+		if cloud.Name == name {
+			return cloud, nil
+		}
+	}
+	return cloud.Cloud{}, errors.NotFoundf("cloud %s", name)
+}
+
+func (c cloudDetectorFunc) DetectClouds() ([]cloud.Cloud, error) {
+	return c()
+}
+
 type cloudRegionDetectorFunc func() ([]cloud.Region, error)
 
 func (c cloudRegionDetectorFunc) DetectRegions() ([]cloud.Region, error) {
 	return c()
-}
-
-type defaultCloudNameProvider struct {
-	manyCredentialsProvider
-}
-
-func (defaultCloudNameProvider) DefaultCloudName() string {
-	return "mykonos"
-}
-
-func (defaultCloudNameProvider) DetectCredentials() (*cloud.CloudCredential, error) {
-	return &cloud.CloudCredential{
-		AuthCredentials: map[string]cloud.Credential{
-			"one": cloud.NewCredential("one", nil),
-		},
-	}, nil
 }

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -121,7 +121,7 @@ type FinalizeCredentialContext interface {
 // FinalizeCredentialParams contains the parameters for
 // ProviderCredentials.FinalizeCredential.
 type FinalizeCredentialParams struct {
-	// Credential is the credential that the provider should finalize.`
+	// Credential is the credential that the provider should finalize.
 	Credential cloud.Credential
 
 	// CloudEndpoint is the endpoint for the cloud that the credentials are
@@ -135,10 +135,32 @@ type FinalizeCredentialParams struct {
 	CloudIdentityEndpoint string
 }
 
+// CloudDetector is an interface that an EnvironProvider implements
+// in order to automatically detect clouds from the environment.
+type CloudDetector interface {
+	// DetectCloud attempts to detect a cloud with the given name
+	// from the environment. This may involve, for example,
+	// inspecting environment variables, or returning special
+	// hard-coded regions (e.g. "localhost" for lxd).
+	//
+	// If no cloud can be detected, DetectCloud should return
+	// an error satisfying errors.IsNotFound.
+	//
+	// DetectCloud should be used in preference to DetectClouds
+	// when a specific cloud is identified, as this may be more
+	// efficient.
+	DetectCloud(name string) (cloud.Cloud, error)
+
+	// DetectClouds detects clouds from the environment. This may
+	// involve, for example, inspecting environment variables, or
+	// returning special hard-coded regions (e.g. "localhost" for lxd).
+	DetectClouds() ([]cloud.Cloud, error)
+}
+
 // CloudRegionDetector is an interface that an EnvironProvider implements
 // in order to automatically detect cloud regions from the environment.
 type CloudRegionDetector interface {
-	// DetectRetions automatically detects one or more regions
+	// DetectRegions automatically detects one or more regions
 	// from the environment. This may involve, for example, inspecting
 	// environment variables, or returning special hard-coded regions
 	// (e.g. "localhost" for lxd). The first item in the list will be
@@ -148,14 +170,6 @@ type CloudRegionDetector interface {
 	// If no regions can be detected, DetectRegions should return
 	// an error satisfying errors.IsNotFound.
 	DetectRegions() ([]cloud.Region, error)
-}
-
-// DefaultCloudNamer is an interface that a provider implements to
-// specify what an implicitly-created cloud ahould be named.
-type DefaultCloudNamer interface {
-	// DefaultCloudName returns the name that should be used for the
-	// cloud instead of falling back to the provider name.
-	DefaultCloudName() string
 }
 
 // ModelConfigUpgrader is an interface that an EnvironProvider may

--- a/provider/lxd/lxdnames/names.go
+++ b/provider/lxd/lxdnames/names.go
@@ -7,6 +7,10 @@ package lxdnames
 // NOTE: this package exists to get around circular imports from cloud and
 // provider/lxd.
 
+// DefaultCloud is the name of the default lxd cloud, which corresponds to
+// the local lxd daemon.
+const DefaultCloud = "localhost"
+
 // DefaultRegion is the name of the only "region" we support in lxd currently,
 // which corresponds to the local lxd daemon.
 const DefaultRegion = "localhost"

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -28,7 +28,6 @@ func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) 
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}
-	// TODO(ericsnow) verify prerequisites (see provider/local/prereq.go)?
 	env, err := newEnviron(args.Cloud, args.Config, newRawProvider)
 	return env, errors.Trace(err)
 }
@@ -58,6 +57,41 @@ func (environProvider) Validate(cfg, old *config.Config) (valid *config.Config, 
 		return nil, errors.Annotate(err, "invalid base config")
 	}
 	return cfg, nil
+}
+
+// DetectClouds implements environs.CloudDetector.
+func (environProvider) DetectClouds() ([]cloud.Cloud, error) {
+	localhostCloud, err := localhostCloud()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return []cloud.Cloud{localhostCloud}, nil
+}
+
+// DetectCloud implements environs.CloudDetector.
+func (environProvider) DetectCloud(name string) (cloud.Cloud, error) {
+	// For now we just return a hard-coded "localhost" cloud,
+	// i.e. the local LXD daemon. We may later want to detect
+	// locally-configured remotes.
+	switch name {
+	case "lxd", "localhost":
+		return localhostCloud()
+	}
+	return cloud.Cloud{}, errors.NotFoundf("cloud %s", name)
+}
+
+func localhostCloud() (cloud.Cloud, error) {
+	return cloud.Cloud{
+		Name: lxdnames.DefaultCloud,
+		Type: lxdnames.ProviderType,
+		AuthTypes: []cloud.AuthType{
+			cloud.EmptyAuthType,
+		},
+		Regions: []cloud.Region{{
+			Name: lxdnames.DefaultRegion,
+		}},
+		Description: cloud.DefaultCloudDescription(lxdnames.ProviderType),
+	}, nil
 }
 
 // DetectRegions implements environs.CloudRegionDetector.
@@ -99,11 +133,4 @@ func (p environProvider) ConfigSchema() schema.Fields {
 // provider specific config attributes.
 func (p environProvider) ConfigDefaults() schema.Defaults {
 	return configDefaults
-}
-
-// DefaultCloudName specifies what name should be used for the cloud
-// implicitly created when the provider is specified directly at
-// bootstrap time. Implements environs.DefaultCloudNamer.
-func (p environProvider) DefaultCloudName() string {
-	return cloud.DefaultLXD
 }


### PR DESCRIPTION
## Description of change

Remove the builtin cloud definitions from
the cloud package, and add an interface
that providers can implement to "detect"
clouds. For now this is just implemented
by LXD to return the localhost cloud, but
it could also be used to detect cloud
definitions based on client-side config
such as novarc files, etc.

Also, finalize detected credentials.

These changes will be used in a followup
to have the localhost cloud definition include
the LXD host address included in the cloud
endpoint; and injecting credentials via
cloud credentials, rather than by injecting
files into the containers via cloud-init.

## QA steps

1. juju bootstrap --clouds (shows localhost in list)
2. juju bootstrap (shows localhost in list, is default selection)
3. juju bootstrap localhost (bootstraps successfully)
4. juju bootstrap lxd (bootstraps successfully, cloud is called "localhost")

## Documentation changes

No functional changes.

Does it affect current user workflow? CLI? API?

## Bug reference

This PR does not fix any bugs. A followup will be made to fix https://bugs.launchpad.net/juju/+bug/1633788.