### PR TITLE
Make juju run on machines use the ubuntu user

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -47,7 +47,7 @@ github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-0
 github.com/juju/testing	git	5ea77166c8c6a8f56f258565288c4714aa399283	2016-11-24T00:43:14Z
 github.com/juju/txn	git	28898197906200d603394d8e4ce537436529f1c5	2016-11-16T04:07:55Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils	git	165eeede6fceeb359be7f5ef790c16368dc2bc9f	2016-11-22T15:00:28Z
+github.com/juju/utils	git	80bc95efca7ea0c6cba2c3b61d9baed02f0d9bb4	2017-01-25T23:33:01Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z

--- a/worker/machineactions/handleactions.go
+++ b/worker/machineactions/handleactions.go
@@ -43,7 +43,7 @@ func HandleAction(name string, params map[string]interface{}) (results map[strin
 func handleJujuRunAction(params map[string]interface{}) (results map[string]interface{}, err error) {
 	// The spec checks that the parameters are available so we don't need to check again here
 	command, _ := params["command"].(string)
-	logger.Debugf("juju run %q", command)
+	logger.Tracef("juju run %q", command)
 
 	// The timeout is passed in in nanoseconds(which are represented in go as int64)
 	// But due to serialization it comes out as float64

--- a/worker/machineactions/handleactions.go
+++ b/worker/machineactions/handleactions.go
@@ -40,6 +40,7 @@ func HandleAction(name string, params map[string]interface{}) (results map[strin
 func handleJujuRunAction(params map[string]interface{}) (results map[string]interface{}, err error) {
 	// The spec checks that the parameters are available so we don't need to check again here
 	command, _ := params["command"].(string)
+	logger.Debugf("juju run %q", command)
 
 	// The timeout is passed in in nanoseconds(which are represented in go as int64)
 	// But due to serialization it comes out as float64
@@ -63,6 +64,7 @@ func runCommandWithTimeout(command string, timeout time.Duration, clock clock.Cl
 		Commands:    command,
 		Environment: os.Environ(),
 		Clock:       clock,
+		User:        "ubuntu",
 	}
 
 	err := cmd.Run()

--- a/worker/machineactions/handleactions.go
+++ b/worker/machineactions/handleactions.go
@@ -18,6 +18,9 @@ import (
 	"github.com/juju/juju/core/actions"
 )
 
+// RunAsUser is the user that the machine juju-run action is executed as.
+var RunAsUser = "ubuntu"
+
 // HandleAction receives a name and a map of parameters for a given machine action.
 // It will handle that action in a specific way and return a results map suitable for ActionFinish.
 func HandleAction(name string, params map[string]interface{}) (results map[string]interface{}, err error) {
@@ -64,7 +67,7 @@ func runCommandWithTimeout(command string, timeout time.Duration, clock clock.Cl
 		Commands:    command,
 		Environment: os.Environ(),
 		Clock:       clock,
-		User:        "ubuntu",
+		User:        RunAsUser,
 	}
 
 	err := cmd.Run()

--- a/worker/machineactions/handleactions_test.go
+++ b/worker/machineactions/handleactions_test.go
@@ -22,6 +22,13 @@ type HandleSuite struct {
 
 var _ = gc.Suite(&HandleSuite{})
 
+func (s *HandleSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	// For testing purposes, don't set the user to run as.
+	// Most developers don't have rights to use 'su'.
+	s.PatchValue(&machineactions.RunAsUser, "")
+}
+
 func (s *HandleSuite) TestInvalidAction(c *gc.C) {
 	results, err := machineactions.HandleAction("invalid", nil)
 	c.Assert(err, gc.ErrorMatches, "unexpected action invalid")

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -500,7 +500,7 @@ LXC_BRIDGE="ignored"`[1:])
 	s.State.StartSync()
 	errCh := make(chan error, 0)
 	go func() {
-		errCh <-mr.Wait()
+		errCh <- mr.Wait()
 	}()
 	select {
 	case err = <-errCh:

--- a/worker/uniter/operation/executor.go
+++ b/worker/uniter/operation/executor.go
@@ -65,7 +65,7 @@ func (x *executor) State() State {
 }
 
 // Run is part of the Executor interface.
-func (x *executor) Run(op Operation) (runErr error) {
+func (x *executor) Run(op Operation) error {
 	logger.Debugf("running operation %v", op)
 
 	if op.NeedsGlobalMachineLock() {

--- a/worker/uniter/operation/runcommands.go
+++ b/worker/uniter/operation/runcommands.go
@@ -61,7 +61,7 @@ func (rc *runCommands) Prepare(state State) (*State, error) {
 // state change.
 // Execute is part of the Operation interface.
 func (rc *runCommands) Execute(state State) (*State, error) {
-	logger.Debugf("run commands: %s", rc)
+	logger.Tracef("run commands: %s", rc)
 	if err := rc.callbacks.SetExecutingStatus("running commands"); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/uniter/operation/runcommands.go
+++ b/worker/uniter/operation/runcommands.go
@@ -61,6 +61,7 @@ func (rc *runCommands) Prepare(state State) (*State, error) {
 // state change.
 // Execute is part of the Operation interface.
 func (rc *runCommands) Execute(state State) (*State, error) {
+	logger.Debugf("run commands: %s", rc)
 	if err := rc.callbacks.SetExecutingStatus("running commands"); err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
With the 2.0 change to how 'juju run' was processed to use the actions infrastructure rather than ssh from the controllers, the machine execution changed from running using the ubuntu user to being executed as root without some login environment variables processed.

## QA steps

  $ juju run --machine 0 env
  $ juju run --machine 0 juju-goroutines

## Bug reference

Fixes lp:1655124
