### PR TITLE
Add extra-info as official string config value for models.

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -129,6 +129,10 @@ const (
 	// metrics collected in this model for anonymized aggregate analytics.
 	TransmitVendorMetricsKey = "transmit-vendor-metrics"
 
+	// ExtraInfoKey is the key for arbitrary user specified string data that
+	// is stored against the model.
+	ExtraInfoKey = "extra-info"
+
 	//
 	// Deprecated Settings Attributes
 	//
@@ -933,6 +937,7 @@ var fields = func() schema.Fields {
 var alwaysOptional = schema.Defaults{
 	AgentVersionKey:   schema.Omit,
 	AuthorizedKeysKey: schema.Omit,
+	ExtraInfoKey:      schema.Omit,
 
 	LogForwardEnabled:      schema.Omit,
 	LogFwdSyslogHost:       schema.Omit,
@@ -1183,6 +1188,11 @@ var configSchema = environschema.Fields{
 	"enable-os-upgrade": {
 		Description: `Whether newly provisioned instances should run their respective OS's upgrade capability.`,
 		Type:        environschema.Tbool,
+		Group:       environschema.EnvironGroup,
+	},
+	ExtraInfoKey: {
+		Description: "Arbitrary user specified string data that is stored against the model.",
+		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},
 	"firewall-mode": {

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -848,11 +848,12 @@ func (s *ConfigSuite) addJujuFiles(c *gc.C) {
 func (s *ConfigSuite) TestValidateUnknownAttrs(c *gc.C) {
 	s.addJujuFiles(c)
 	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
-		"name":    "myenv",
-		"type":    "other",
-		"uuid":    testing.ModelTag.Id(),
-		"known":   "this",
-		"unknown": "that",
+		"name":       "myenv",
+		"type":       "other",
+		"uuid":       testing.ModelTag.Id(),
+		"extra-info": "official extra user data",
+		"known":      "this",
+		"unknown":    "that",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
This work adds a model config value 'extra-info' as an official string value to allow users to store arbitrary data against a model. This has been requested by conjure-up.

## QA steps

$ juju model-config extra-info="---\nname: this is more yaml\n"
$ juju model-config extra-info
'---\nname: this is more yaml\n'

## Bug reference

Fixes lp:1659444.
