### PR TITLE
cmd/juju: update add-model to detect creds

### DIFF
--- a/cmd/juju/common/cloud.go
+++ b/cmd/juju/common/cloud.go
@@ -7,14 +7,25 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
-	"github.com/juju/juju/cloud"
+	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 )
 
 var logger = loggo.GetLogger("juju.cmd.juju.common")
 
+type chooseCloudRegionError struct {
+	error
+}
+
+// IsChooseCloudRegionError reports whether or not the given
+// error was returned from ChooseCloudRegion.
+func IsChooseCloudRegionError(err error) bool {
+	_, ok := errors.Cause(err).(chooseCloudRegionError)
+	return ok
+}
+
 // CloudOrProvider finds and returns cloud or provider.
-func CloudOrProvider(cloudName string, cloudByNameFunc func(string) (*cloud.Cloud, error)) (cloud *cloud.Cloud, err error) {
+func CloudOrProvider(cloudName string, cloudByNameFunc func(string) (*jujucloud.Cloud, error)) (cloud *jujucloud.Cloud, err error) {
 	if cloud, err = cloudByNameFunc(cloudName); err != nil {
 		if !errors.IsNotFound(err) {
 			return nil, err
@@ -32,10 +43,34 @@ func CloudOrProvider(cloudName string, cloudByNameFunc func(string) (*cloud.Clou
 	return cloud, nil
 }
 
+// ChooseCloudRegion returns the cloud.Region to use, based on the specified
+// region name. If no region name is specified, and there is at least one
+// region, we use the first region in the list. If there are no regions, then
+// we return a region with no name, having the same endpoints as the cloud.
+func ChooseCloudRegion(cloud jujucloud.Cloud, regionName string) (jujucloud.Region, error) {
+	if regionName != "" {
+		region, err := jujucloud.RegionByName(cloud.Regions, regionName)
+		if err != nil {
+			return jujucloud.Region{}, errors.Trace(chooseCloudRegionError{err})
+		}
+		return *region, nil
+	}
+	if len(cloud.Regions) > 0 {
+		// No region was specified, use the first region in the list.
+		return cloud.Regions[0], nil
+	}
+	return jujucloud.Region{
+		"", // no region name
+		cloud.Endpoint,
+		cloud.IdentityEndpoint,
+		cloud.StorageEndpoint,
+	}, nil
+}
+
 // BuiltInClouds returns cloud information for those
 // providers which are built in to Juju.
-func BuiltInClouds() (map[string]cloud.Cloud, error) {
-	allClouds := make(map[string]cloud.Cloud)
+func BuiltInClouds() (map[string]jujucloud.Cloud, error) {
+	allClouds := make(map[string]jujucloud.Cloud)
 	for _, providerType := range environs.RegisteredProviders() {
 		p, err := environs.Provider(providerType)
 		if err != nil {

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/jujuclient"
 )
@@ -36,15 +37,17 @@ func NewAddModelCommand() cmd.Command {
 		newCloudAPI: func(caller base.APICallCloser) CloudAPI {
 			return cloudapi.NewClient(caller)
 		},
+		providerRegistry: environs.GlobalProviderRegistry(),
 	})
 }
 
 // addModelCommand calls the API to add a new model.
 type addModelCommand struct {
 	modelcmd.ControllerCommandBase
-	apiRoot        api.Connection
-	newAddModelAPI func(base.APICallCloser) AddModelAPI
-	newCloudAPI    func(base.APICallCloser) CloudAPI
+	apiRoot          api.Connection
+	newAddModelAPI   func(base.APICallCloser) AddModelAPI
+	newCloudAPI      func(base.APICallCloser) CloudAPI
+	providerRegistry environs.ProviderRegistry
 
 	Name           string
 	Owner          string
@@ -195,22 +198,21 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
+	} else {
+		if cloudTag, cloud, err = defaultCloud(cloudClient); err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	// If the user has specified a credential, then we will upload it if
 	// it doesn't already exist in the controller, and it exists locally.
-	var credentialTag names.CloudCredentialTag
-	if c.CredentialName != "" {
-		var err error
-		if c.CloudRegion == "" {
-			if cloudTag, cloud, err = defaultCloud(cloudClient); err != nil {
-				return errors.Trace(err)
-			}
-		}
-		credentialTag, err = c.maybeUploadCredential(ctx, cloudClient, cloudTag, cloudRegion, cloud, modelOwner)
-		if err != nil {
-			return errors.Trace(err)
-		}
+	//
+	// If no credential is specified, but there is exactly one on the
+	// client, then we use that; otherwise we attempt to detect one from
+	// the environment.
+	credentialTag, err := c.maybeUploadCredential(ctx, cloudClient, cloudTag, cloudRegion, cloud, modelOwner)
+	if err != nil {
+		return errors.Trace(err)
 	}
 
 	addModelClient := c.newAddModelAPI(api)
@@ -396,6 +398,23 @@ there is no default cloud defined, please specify one using:
 	return cloudTag, cloud, nil
 }
 
+var ambiguousDetectedCredentialError = errors.New(`
+more than one credential detected. Add all detected credentials
+to the client with:
+
+    juju autoload-credentials
+
+and then run the add-model command again with the --credential flag.`[1:],
+)
+
+var ambiguousCredentialError = errors.New(`
+more than one credential is available. List credentials with:
+
+    juju credentials
+
+and then run the add-model command again with the --credential flag.`[1:],
+)
+
 func (c *addModelCommand) maybeUploadCredential(
 	ctx *cmd.Context,
 	cloudClient CloudAPI,
@@ -405,48 +424,81 @@ func (c *addModelCommand) maybeUploadCredential(
 	modelOwner string,
 ) (names.CloudCredentialTag, error) {
 
-	modelOwnerTag := names.NewUserTag(modelOwner)
-	credentialTag, err := common.ResolveCloudCredentialTag(
-		modelOwnerTag, cloudTag, c.CredentialName,
-	)
-	if err != nil {
-		return names.CloudCredentialTag{}, errors.Trace(err)
+	// If the user has not specified a credential, and the cloud advertises
+	// itself as supporting the "empty" auth-type, then return immediately.
+	if c.CredentialName == "" {
+		for _, authType := range cloud.AuthTypes {
+			if authType == jujucloud.EmptyAuthType {
+				return names.CloudCredentialTag{}, nil
+			}
+		}
 	}
 
 	// Check if the credential is already in the controller.
-	//
-	// TODO(axw) consider implementing a call that can check
-	// that the credential exists without fetching all of the
-	// names.
+	modelOwnerTag := names.NewUserTag(modelOwner)
 	credentialTags, err := cloudClient.UserCredentials(modelOwnerTag, cloudTag)
 	if err != nil {
 		return names.CloudCredentialTag{}, errors.Trace(err)
 	}
-	credentialId := credentialTag.Id()
-	for _, tag := range credentialTags {
-		if tag.Id() != credentialId {
-			continue
+	if c.CredentialName != "" {
+		credentialTag, err := common.ResolveCloudCredentialTag(
+			modelOwnerTag, cloudTag, c.CredentialName,
+		)
+		if err != nil {
+			return names.CloudCredentialTag{}, errors.Trace(err)
 		}
-		ctx.Infof("Using credential '%s' cached in controller", c.CredentialName)
-		return credentialTag, nil
+		credentialId := credentialTag.Id()
+		for _, tag := range credentialTags {
+			if tag.Id() != credentialId {
+				continue
+			}
+			ctx.Infof("Using credential '%s' cached in controller", c.CredentialName)
+			return credentialTag, nil
+		}
+		if credentialTag.Owner().Id() != modelOwner {
+			// Another user's credential was specified, so
+			// we cannot automatically upload.
+			return names.CloudCredentialTag{}, errors.NotFoundf(
+				"credential '%s'", c.CredentialName,
+			)
+		}
 	}
 
-	if credentialTag.Owner().Id() != modelOwner {
-		// Another user's credential was specified, so
-		// we cannot automatically upload.
-		return names.CloudCredentialTag{}, errors.NotFoundf(
-			"credential '%s'", c.CredentialName,
-		)
+	// The user has either not specified a credential, or if they have, it
+	// is not cached in the controller, and isn't qualified with another
+	// user name.
+
+	if c.CredentialName == "" && len(credentialTags) == 1 {
+		tag := credentialTags[0]
+		ctx.Infof("Using credential '%s' cached in controller", tag.Name())
+		return tag, nil
 	}
 
 	// Upload the credential from the client, if it exists locally.
-	credential, _, _, err := modelcmd.GetCredentials(
-		ctx, c.ClientStore(), modelcmd.GetCredentialsParams{
+	provider, err := c.providerRegistry.Provider(cloud.Type)
+	if err != nil {
+		return names.CloudCredentialTag{}, errors.Trace(err)
+	}
+	credential, credentialName, _, _, err := common.GetOrDetectCredential(
+		ctx, c.ClientStore(), provider, modelcmd.GetCredentialsParams{
 			Cloud:          cloud,
 			CloudName:      cloudTag.Id(),
 			CloudRegion:    cloudRegion,
-			CredentialName: credentialTag.Name(),
+			CredentialName: c.CredentialName,
 		},
+	)
+	switch errors.Cause(err) {
+	case nil:
+	case modelcmd.ErrMultipleCredentials:
+		return names.CloudCredentialTag{}, ambiguousCredentialError
+	case common.ErrMultipleDetectedCredentials:
+		return names.CloudCredentialTag{}, ambiguousDetectedCredentialError
+	default:
+		return names.CloudCredentialTag{}, errors.Trace(err)
+	}
+
+	credentialTag, err := common.ResolveCloudCredentialTag(
+		modelOwnerTag, cloudTag, credentialName,
 	)
 	if err != nil {
 		return names.CloudCredentialTag{}, errors.Trace(err)

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/controller"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	_ "github.com/juju/juju/provider/ec2"
@@ -30,9 +31,11 @@ import (
 
 type AddModelSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
-	fakeAddModelAPI *fakeAddClient
-	fakeCloudAPI    *fakeCloudAPI
-	store           *jujuclienttesting.MemStore
+	fakeAddModelAPI      *fakeAddClient
+	fakeCloudAPI         *fakeCloudAPI
+	fakeProvider         *fakeProvider
+	fakeProviderRegistry *fakeProviderRegistry
+	store                *jujuclienttesting.MemStore
 }
 
 var _ = gc.Suite(&AddModelSuite{})
@@ -46,7 +49,22 @@ func (s *AddModelSuite) SetUpTest(c *gc.C) {
 			Owner: "ignored-for-now",
 		},
 	}
-	s.fakeCloudAPI = &fakeCloudAPI{}
+	s.fakeCloudAPI = &fakeCloudAPI{
+		authTypes: []cloud.AuthType{
+			cloud.EmptyAuthType,
+			cloud.AccessKeyAuthType,
+		},
+		credentials: []names.CloudCredentialTag{
+			names.NewCloudCredentialTag("cloud/admin/default"),
+			names.NewCloudCredentialTag("aws/other/secrets"),
+		},
+	}
+	s.fakeProvider = &fakeProvider{
+		detected: cloud.NewEmptyCloudCredential(),
+	}
+	s.fakeProviderRegistry = &fakeProviderRegistry{
+		provider: s.fakeProvider,
+	}
 
 	// Set up the current controller, and write just enough info
 	// so we don't try to refresh
@@ -76,7 +94,13 @@ func (*fakeAPIConnection) Close() error {
 }
 
 func (s *AddModelSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
-	command, _ := controller.NewAddModelCommandForTest(&fakeAPIConnection{}, s.fakeAddModelAPI, s.fakeCloudAPI, s.store)
+	command, _ := controller.NewAddModelCommandForTest(
+		&fakeAPIConnection{},
+		s.fakeAddModelAPI,
+		s.fakeCloudAPI,
+		s.store,
+		s.fakeProviderRegistry,
+	)
 	return testing.RunCommand(c, command, args...)
 }
 
@@ -131,7 +155,7 @@ func (s *AddModelSuite) TestInit(c *gc.C) {
 		},
 	} {
 		c.Logf("test %d", i)
-		wrappedCommand, command := controller.NewAddModelCommandForTest(nil, nil, nil, s.store)
+		wrappedCommand, command := controller.NewAddModelCommandForTest(nil, nil, nil, s.store, nil)
 		err := testing.InitCommand(wrappedCommand, test.args)
 		if test.err != "" {
 			c.Assert(err, gc.ErrorMatches, test.err)
@@ -201,12 +225,93 @@ func (s *AddModelSuite) TestCredentialsOtherUserPassedThroughWhenCloud(c *gc.C) 
 	c.Assert(s.fakeAddModelAPI.cloudCredential, gc.Equals, names.NewCloudCredentialTag("aws/other/secrets"))
 }
 
+func (s *AddModelSuite) TestCredentialsOtherUserCredentialNotFound(c *gc.C) {
+	// Have the API respond with no credentials.
+	s.PatchValue(&s.fakeCloudAPI.credentials, []names.CloudCredentialTag{})
+
+	_, err := s.run(c, "test", "--credential", "other/secrets")
+	c.Assert(err, gc.ErrorMatches, "credential 'other/secrets' not found")
+
+	// There should be no detection or UpdateCredentials call.
+	s.fakeCloudAPI.CheckCallNames(c, "DefaultCloud", "Cloud", "UserCredentials")
+}
+
 func (s *AddModelSuite) TestCredentialsNoDefaultCloud(c *gc.C) {
 	s.fakeCloudAPI.SetErrors(&params.Error{Code: params.CodeNotFound})
 	_, err := s.run(c, "test", "--credential", "secrets")
 	c.Assert(err, gc.ErrorMatches, `there is no default cloud defined, please specify one using:
 
     juju add-model \[flags\] \<model-name\> cloud\[/region\]`)
+}
+
+func (s *AddModelSuite) TestCredentialsOneCached(c *gc.C) {
+	// Disable empty auth and clear the local credentials,
+	// forcing a check for credentials in the controller.
+	s.PatchValue(&s.fakeCloudAPI.authTypes, []cloud.AuthType{cloud.AccessKeyAuthType})
+	delete(s.store.Credentials, "aws")
+
+	// Cache just a single credential in the controller,
+	// so it is selected automatically.
+	credentialTag := names.NewCloudCredentialTag("aws/foo/secrets")
+	s.PatchValue(&s.fakeCloudAPI.credentials, []names.CloudCredentialTag{credentialTag})
+
+	_, err := s.run(c, "test")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.fakeAddModelAPI.cloudCredential, gc.Equals, credentialTag)
+}
+
+func (s *AddModelSuite) TestCredentialsDetected(c *gc.C) {
+	// Disable empty auth and clear the local credentials,
+	// forcing a check for credentials in the controller.
+	// There are multiple credentials in the controller,
+	// so none of them will be chosen by default.
+	s.PatchValue(&s.fakeCloudAPI.authTypes, []cloud.AuthType{cloud.AccessKeyAuthType})
+
+	// Delete all local credentials, so we don't choose
+	// any of them to upload. This will force credential
+	// detection.
+	delete(s.store.Credentials, "aws")
+
+	_, err := s.run(c, "test")
+	c.Assert(err, jc.ErrorIsNil)
+
+	credentialTag := names.NewCloudCredentialTag("aws/bob/default")
+	credential := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{})
+	credential.Label = "finalized"
+
+	c.Assert(s.fakeAddModelAPI.cloudCredential, gc.Equals, credentialTag)
+	s.fakeCloudAPI.CheckCallNames(c, "DefaultCloud", "Cloud", "UserCredentials", "UpdateCredential")
+	s.fakeCloudAPI.CheckCall(c, 3, "UpdateCredential", credentialTag, credential)
+}
+
+func (s *AddModelSuite) TestCredentialsDetectedAmbiguous(c *gc.C) {
+	// Disable empty auth and clear the local credentials,
+	// forcing a check for credentials in the controller.
+	// There are multiple credentials in the controller,
+	// so none of them will be chosen by default.
+	s.PatchValue(&s.fakeCloudAPI.authTypes, []cloud.AuthType{cloud.AccessKeyAuthType})
+
+	// Delete all local credentials, so we don't choose
+	// any of them to upload. This will force credential
+	// detection.
+	delete(s.store.Credentials, "aws")
+
+	s.PatchValue(&s.fakeProvider.detected, &cloud.CloudCredential{
+		AuthCredentials: map[string]cloud.Credential{
+			"one": {},
+			"two": {},
+		},
+	})
+
+	_, err := s.run(c, "test")
+	c.Assert(err, gc.ErrorMatches, `
+more than one credential detected. Add all detected credentials
+to the client with:
+
+    juju autoload-credentials
+
+and then run the add-model command again with the --credential flag.`[1:])
 }
 
 func (s *AddModelSuite) TestCloudRegionPassedThrough(c *gc.C) {
@@ -221,8 +326,8 @@ func (s *AddModelSuite) TestDefaultCloudPassedThrough(c *gc.C) {
 	_, err := s.run(c, "test")
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.fakeCloudAPI.CheckCallNames(c /*none*/)
-	c.Assert(s.fakeAddModelAPI.cloudName, gc.Equals, "")
+	s.fakeCloudAPI.CheckCallNames(c, "DefaultCloud", "Cloud")
+	c.Assert(s.fakeAddModelAPI.cloudName, gc.Equals, "aws")
 	c.Assert(s.fakeAddModelAPI.cloudRegion, gc.Equals, "")
 }
 
@@ -445,6 +550,8 @@ func (f *fakeAddClient) CreateModel(name, owner, cloudName, cloudRegion string, 
 type fakeCloudAPI struct {
 	controller.CloudAPI
 	gitjujutesting.Stub
+	authTypes   []cloud.AuthType
+	credentials []names.CloudCredentialTag
 }
 
 func (c *fakeCloudAPI) DefaultCloud() (names.CloudTag, error) {
@@ -456,6 +563,7 @@ func (c *fakeCloudAPI) Clouds() (map[names.CloudTag]cloud.Cloud, error) {
 	c.MethodCall(c, "Clouds")
 	return map[names.CloudTag]cloud.Cloud{
 		names.NewCloudTag("aws"): {
+			AuthTypes: c.authTypes,
 			Regions: []cloud.Region{
 				{Name: "us-east-1"},
 				{Name: "us-west-1"},
@@ -472,7 +580,7 @@ func (c *fakeCloudAPI) Cloud(tag names.CloudTag) (cloud.Cloud, error) {
 	}
 	return cloud.Cloud{
 		Type:      "ec2",
-		AuthTypes: []cloud.AuthType{cloud.AccessKeyAuthType},
+		AuthTypes: c.authTypes,
 		Regions: []cloud.Region{
 			{Name: "us-east-1"},
 			{Name: "us-west-1"},
@@ -482,13 +590,42 @@ func (c *fakeCloudAPI) Cloud(tag names.CloudTag) (cloud.Cloud, error) {
 
 func (c *fakeCloudAPI) UserCredentials(user names.UserTag, cloud names.CloudTag) ([]names.CloudCredentialTag, error) {
 	c.MethodCall(c, "UserCredentials", user, cloud)
-	return []names.CloudCredentialTag{
-		names.NewCloudCredentialTag("cloud/admin/default"),
-		names.NewCloudCredentialTag("aws/other/secrets"),
-	}, c.NextErr()
+	return c.credentials, c.NextErr()
 }
 
 func (c *fakeCloudAPI) UpdateCredential(credentialTag names.CloudCredentialTag, credential cloud.Credential) error {
 	c.MethodCall(c, "UpdateCredential", credentialTag, credential)
 	return c.NextErr()
+}
+
+type fakeProviderRegistry struct {
+	gitjujutesting.Stub
+	environs.ProviderRegistry
+	provider environs.EnvironProvider
+}
+
+func (r *fakeProviderRegistry) Provider(providerType string) (environs.EnvironProvider, error) {
+	r.MethodCall(r, "Provider", providerType)
+	return r.provider, r.NextErr()
+}
+
+type fakeProvider struct {
+	gitjujutesting.Stub
+	environs.EnvironProvider
+	detected *cloud.CloudCredential
+}
+
+func (p *fakeProvider) DetectCredentials() (*cloud.CloudCredential, error) {
+	p.MethodCall(p, "DetectCredentials")
+	return p.detected, p.NextErr()
+}
+
+func (p *fakeProvider) FinalizeCredential(
+	ctx environs.FinalizeCredentialContext,
+	args environs.FinalizeCredentialParams,
+) (*cloud.Credential, error) {
+	p.MethodCall(p, "FinalizeCredential", ctx, args)
+	out := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{})
+	out.Label = "finalized"
+	return &out, p.NextErr()
 }

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -46,6 +47,7 @@ func NewAddModelCommandForTest(
 	api AddModelAPI,
 	cloudAPI CloudAPI,
 	store jujuclient.ClientStore,
+	providerRegistry environs.ProviderRegistry,
 ) (cmd.Command, *AddModelCommand) {
 	c := &addModelCommand{
 		apiRoot: apiRoot,
@@ -55,6 +57,7 @@ func NewAddModelCommandForTest(
 		newCloudAPI: func(base.APICallCloser) CloudAPI {
 			return cloudAPI
 		},
+		providerRegistry: providerRegistry,
 	}
 	c.SetClientStore(store)
 	return modelcmd.WrapController(c), &AddModelCommand{c}

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -435,10 +435,11 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 		}
 	} else {
 		// The credential was auto-detected; run auto-detection again.
-		cloudCredential, err := DetectCredential(
-			bootstrapConfig.Cloud,
-			bootstrapConfig.CloudType,
-		)
+		provider, err := environs.Provider(bootstrapConfig.CloudType)
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		cloudCredential, err := DetectCredential(bootstrapConfig.Cloud, provider)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}

--- a/cmd/modelcmd/credentials.go
+++ b/cmd/modelcmd/credentials.go
@@ -164,11 +164,7 @@ func credentialByName(
 // If no credentials are detected, an error satisfying errors.IsNotFound will
 // be returned. If more than one credential is detected, ErrMultipleCredentials
 // will be returned.
-func DetectCredential(cloudName, cloudType string) (*cloud.CloudCredential, error) {
-	provider, err := environs.Provider(cloudType)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+func DetectCredential(cloudName string, provider environs.EnvironProvider) (*cloud.CloudCredential, error) {
 	detected, err := provider.DetectCredentials()
 	if err != nil {
 		return nil, errors.Annotatef(


### PR DESCRIPTION
## Description of change

When running add-model, perform credential
detection just as we do during bootstrap if
the user does not have credentials available
already. This is necessary for upcoming
changes to the LXD provider.

## QA steps

1. juju bootstrap lxd
2. juju add-model foo
3. juju bootstrap aws
4. juju add-model foo
5. juju add-model bar --credential=default

## Documentation changes

No changes.

## Bug reference

Does not directly fix any bugs. Required for an upcoming branch that fixes https://bugs.launchpad.net/juju/+bug/1633788.