### PR TITLE
Track the locations of reference sources for the state pool.

### DIFF
--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -226,6 +226,7 @@ func (s *legacySuite) TestAPIServerCanShutdownWithOutstandingNext(c *gc.C) {
 		LogDir:      c.MkDir(),
 		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
 		AutocertURL: "https://0.1.2.3/no-autocert-here",
+		StatePool:   state.NewStatePool(s.State),
 	})
 	c.Assert(err, gc.IsNil)
 

--- a/api/pubsub/pubsub_test.go
+++ b/api/pubsub/pubsub_test.go
@@ -236,6 +236,7 @@ func newServerWithHub(c *gc.C, st *state.State, hub *pubsub.StructuredHub) (*api
 		LogDir:      c.MkDir(),
 		Hub:         hub,
 		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
+		StatePool:   state.NewStatePool(st),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	port := listener.Addr().(*net.TCPAddr).Port

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -252,9 +252,10 @@ type migrationSuite struct {
 var _ = gc.Suite(&migrationSuite{})
 
 func (s *migrationSuite) startSync(c *gc.C, st *state.State) {
-	backingSt, err := s.BackingStatePool.Get(st.ModelUUID())
+	backingSt, releaser, err := s.BackingStatePool.Get(st.ModelUUID())
 	c.Assert(err, jc.ErrorIsNil)
 	backingSt.StartSync()
+	releaser()
 }
 
 func (s *migrationSuite) TestMigrationStatusWatcher(c *gc.C) {

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -516,7 +516,7 @@ func (s *loginSuite) TestLoginValidationDuringUpgrade(c *gc.C) {
 }
 
 func (s *loginSuite) TestFailedLoginDuringMaintenance(c *gc.C) {
-	cfg := defaultServerConfig(c)
+	cfg := defaultServerConfig(c, s.State)
 	cfg.Validator = func(params.LoginRequest) error {
 		return errors.New("something")
 	}
@@ -536,7 +536,7 @@ func (s *loginSuite) TestFailedLoginDuringMaintenance(c *gc.C) {
 type validationChecker func(c *gc.C, err error, st api.Connection)
 
 func (s *baseLoginSuite) checkLoginWithValidator(c *gc.C, validator apiserver.LoginValidator, checker validationChecker) {
-	cfg := defaultServerConfig(c)
+	cfg := defaultServerConfig(c, s.State)
 	cfg.Validator = validator
 	info, srv := newServerWithConfig(c, s.State, cfg)
 	defer assertStop(c, srv)
@@ -1004,7 +1004,7 @@ func (s *macaroonLoginSuite) TestRemoteUserLoginToModelWithExplicitAccessAndAllo
 }
 
 func (s *macaroonLoginSuite) testRemoteUserLoginToModelWithExplicitAccess(c *gc.C, allowModelAccess bool) {
-	cfg := defaultServerConfig(c)
+	cfg := defaultServerConfig(c, s.State)
 	cfg.AllowModelAccess = allowModelAccess
 
 	info, srv := newServerWithConfig(c, s.State, cfg)

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -126,14 +126,14 @@ type ServerConfig struct {
 	// notified of key events during API requests.
 	NewObserver observer.ObserverFactory
 
+	// StatePool is created by the machine agent and passed in.
+	StatePool *state.StatePool
+
 	// RegisterIntrospectionHandlers is a function that will
 	// call a function with (path, http.Handler) tuples. This
 	// is to support registering the handlers underneath the
 	// "/introspection" prefix.
 	RegisterIntrospectionHandlers func(func(string, http.Handler))
-
-	// StatePool only exists to support testing.
-	StatePool *state.StatePool
 }
 
 func (c *ServerConfig) Validate() error {
@@ -145,6 +145,9 @@ func (c *ServerConfig) Validate() error {
 	}
 	if c.NewObserver == nil {
 		return errors.NotValidf("missing NewObserver")
+	}
+	if c.StatePool == nil {
+		return errors.NotValidf("missing StatePool")
 	}
 
 	return nil
@@ -570,11 +573,8 @@ func (srv *Server) newHandlerArgs(spec apihttp.HandlerConstraints) apihttp.NewHa
 		controllerModelOnly: spec.ControllerModelOnly,
 	}
 	return apihttp.NewHandlerArgs{
-		Connect: func(req *http.Request) (*state.State, state.Entity, error) {
+		Connect: func(req *http.Request) (*state.State, func(), state.Entity, error) {
 			return ctxt.stateForRequestAuthenticatedTag(req, spec.AuthKinds...)
-		},
-		Release: func(st *state.State) error {
-			return ctxt.release(st)
 		},
 	}
 }
@@ -660,20 +660,16 @@ func (srv *Server) serveConn(wsConn *websocket.Conn, modelUUID string, apiObserv
 		modelUUID: modelUUID,
 	})
 	var (
-		st *state.State
-		h  *apiHandler
+		st       *state.State
+		h        *apiHandler
+		releaser func()
 	)
 	if err == nil {
-		st, err = srv.statePool.Get(resolvedModelUUID)
+		st, releaser, err = srv.statePool.Get(resolvedModelUUID)
 	}
 
 	if err == nil {
-		defer func() {
-			err := srv.statePool.Release(resolvedModelUUID)
-			if err != nil {
-				logger.Errorf("error releasing %v back into the state pool: %v", resolvedModelUUID, err)
-			}
-		}()
+		defer releaser()
 		h, err = newAPIHandler(srv, st, conn, modelUUID, host)
 	}
 

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -51,6 +51,7 @@ func (s *apiserverBaseSuite) sampleConfig(c *gc.C) apiserver.ServerConfig {
 		Hub:         centralhub.New(machineTag),
 		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
 		AutocertURL: "https://0.1.2.3/no-autocert-here",
+		StatePool:   state.NewStatePool(s.State),
 	}
 }
 

--- a/apiserver/backup.go
+++ b/apiserver/backup.go
@@ -32,12 +32,12 @@ type backupHandler struct {
 func (h *backupHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	// Validate before authenticate because the authentication is dependent
 	// on the state connection that is determined during the validation.
-	st, err := h.ctxt.stateForRequestAuthenticatedUser(req)
+	st, releaser, err := h.ctxt.stateForRequestAuthenticatedUser(req)
 	if err != nil {
 		h.sendError(resp, err)
 		return
 	}
-	defer h.ctxt.release(st)
+	defer releaser()
 
 	backups, closer := newBackups(st)
 	defer closer.Close()

--- a/apiserver/common/apihttp/handler.go
+++ b/apiserver/common/apihttp/handler.go
@@ -13,12 +13,10 @@ import (
 // field of HandlerSpec.
 type NewHandlerArgs struct {
 	// Connect is the function that is used to connect to Juju's state
-	// for the given HTTP request.
-	Connect func(*http.Request) (*state.State, state.Entity, error)
-
-	// Release indicates that the state is finished with and should be
-	// closed.
-	Release func(*state.State) error
+	// for the given HTTP request. It is the caller's responsibility
+	// to call the release function returned. If the error arg is nil
+	// the release function will always be a valid function.
+	Connect func(*http.Request) (*state.State, func(), state.Entity, error)
 }
 
 // HandlerConstraints describes conditions under which a handler

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -74,12 +74,12 @@ func (h *debugLogHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			socket := &debugLogSocketImpl{conn}
 			defer conn.Close()
 
-			st, _, err := h.ctxt.stateForRequestAuthenticatedTag(req, names.MachineTagKind, names.UserTagKind)
+			st, releaser, _, err := h.ctxt.stateForRequestAuthenticatedTag(req, names.MachineTagKind, names.UserTagKind)
 			if err != nil {
 				socket.sendError(err)
 				return
 			}
-			defer h.ctxt.release(st)
+			defer releaser()
 
 			params, err := readDebugLogParams(req.URL.Query())
 			if err != nil {

--- a/apiserver/gui.go
+++ b/apiserver/gui.go
@@ -136,11 +136,11 @@ func (gr *guiRouter) ensureFileHandler(h func(gh *guiHandler, w http.ResponseWri
 // and archive hash.
 func (gr *guiRouter) ensureFiles(req *http.Request) (rootDir string, hash string, err error) {
 	// Retrieve the Juju GUI info from the GUI storage.
-	st, err := gr.ctxt.stateForRequestUnauthenticated(req)
+	st, releaser, err := gr.ctxt.stateForRequestUnauthenticated(req)
 	if err != nil {
 		return "", "", errors.Annotate(err, "cannot open state")
 	}
-	defer gr.ctxt.release(st)
+	defer releaser()
 	storage, err := st.GUIStorage()
 	if err != nil {
 		return "", "", errors.Annotate(err, "cannot open GUI storage")
@@ -415,11 +415,11 @@ func (h *guiArchiveHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) 
 // handleGet returns information on Juju GUI archives in the controller.
 func (h *guiArchiveHandler) handleGet(w http.ResponseWriter, req *http.Request) error {
 	// Open the GUI archive storage.
-	st, err := h.ctxt.stateForRequestUnauthenticated(req)
+	st, releaser, err := h.ctxt.stateForRequestUnauthenticated(req)
 	if err != nil {
 		return errors.Annotate(err, "cannot open state")
 	}
-	defer h.ctxt.release(st)
+	defer releaser()
 	storage, err := st.GUIStorage()
 	if err != nil {
 		return errors.Annotate(err, "cannot open GUI storage")
@@ -483,11 +483,11 @@ func (h *guiArchiveHandler) handlePost(w http.ResponseWriter, req *http.Request)
 	}
 
 	// Open the GUI archive storage.
-	st, err := h.ctxt.stateForRequestAuthenticatedUser(req)
+	st, releaser, err := h.ctxt.stateForRequestAuthenticatedUser(req)
 	if err != nil {
 		return errors.Annotate(err, "cannot open state")
 	}
-	defer h.ctxt.release(st)
+	defer releaser()
 	storage, err := st.GUIStorage()
 	if err != nil {
 		return errors.Annotate(err, "cannot open GUI storage")
@@ -559,11 +559,11 @@ func (h *guiVersionHandler) handlePut(w http.ResponseWriter, req *http.Request) 
 	}
 
 	// Authenticate the request and retrieve the Juju state.
-	st, err := h.ctxt.stateForRequestAuthenticatedUser(req)
+	st, releaser, err := h.ctxt.stateForRequestAuthenticatedUser(req)
 	if err != nil {
 		return errors.Annotate(err, "cannot open state")
 	}
-	defer h.ctxt.release(st)
+	defer releaser()
 
 	var selected params.GUIVersionRequest
 	decoder := json.NewDecoder(req.Body)

--- a/apiserver/introspection.go
+++ b/apiserver/introspection.go
@@ -31,11 +31,11 @@ func (h introspectionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 }
 
 func (h introspectionHandler) checkAuth(r *http.Request) error {
-	st, entity, err := h.ctx.stateAndEntityForRequestAuthenticatedUser(r)
+	st, releaser, entity, err := h.ctx.stateAndEntityForRequestAuthenticatedUser(r)
 	if err != nil {
 		return err
 	}
-	defer h.ctx.release(st)
+	defer releaser()
 
 	// Users with "superuser" access on the controller,
 	// or "read" access on the controller model, can

--- a/apiserver/logstream_test.go
+++ b/apiserver/logstream_test.go
@@ -264,9 +264,8 @@ func (s *stubSource) newSource(req *http.Request) (logStreamSource, closerFunc, 
 		return nil, nil, errors.Trace(err)
 	}
 
-	closer := func() error {
+	closer := func() {
 		s.stub.AddCall("close")
-		return s.stub.NextErr()
 	}
 	return s, closer, nil
 }

--- a/apiserver/pubsub.go
+++ b/apiserver/pubsub.go
@@ -37,12 +37,12 @@ type pubsubHandler struct {
 func (h *pubsubHandler) authenticate(req *http.Request) error {
 	// We authenticate against the controller state instance that is held
 	// by Server.
-	st, entity, err := h.ctxt.stateForRequestAuthenticated(req)
+	_, releaser, entity, err := h.ctxt.stateForRequestAuthenticated(req)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	// We don't actually use the state for anything except authentication.
-	defer h.ctxt.release(st)
+	defer releaser()
 
 	switch machine := entity.(type) {
 	case *state.Machine:

--- a/apiserver/registration.go
+++ b/apiserver/registration.go
@@ -40,14 +40,14 @@ func (h *registerUserHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 		}
 		return
 	}
-	st, err := h.ctxt.stateForRequestUnauthenticated(req)
+	st, releaser, err := h.ctxt.stateForRequestUnauthenticated(req)
 	if err != nil {
 		if err := sendError(w, err); err != nil {
 			logger.Errorf("%v", err)
 		}
 		return
 	}
-	defer h.ctxt.release(st)
+	defer releaser()
 	userTag, response, err := h.processPost(req, st)
 	if err != nil {
 		if err := sendError(w, err); err != nil {

--- a/apiserver/resources.go
+++ b/apiserver/resources.go
@@ -20,20 +20,20 @@ import (
 // resourceUploadHandler handles resources uploads for model migrations.
 type resourceUploadHandler struct {
 	ctxt          httpContext
-	stateAuthFunc func(*http.Request) (*state.State, error)
+	stateAuthFunc func(*http.Request) (*state.State, func(), error)
 }
 
 func (h *resourceUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Validate before authenticate because the authentication is dependent
 	// on the state connection that is determined during the validation.
-	st, err := h.stateAuthFunc(r)
+	st, releaser, err := h.stateAuthFunc(r)
 	if err != nil {
 		if err := sendError(w, err); err != nil {
 			logger.Errorf("%v", err)
 		}
 		return
 	}
-	defer h.ctxt.release(st)
+	defer releaser()
 
 	switch r.Method {
 	case "POST":

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -30,7 +30,7 @@ import (
 // toolsHandler handles tool upload through HTTPS in the API server.
 type toolsUploadHandler struct {
 	ctxt          httpContext
-	stateAuthFunc func(*http.Request) (*state.State, error)
+	stateAuthFunc func(*http.Request) (*state.State, func(), error)
 }
 
 // toolsHandler handles tool download through HTTPS in the API server.
@@ -39,14 +39,14 @@ type toolsDownloadHandler struct {
 }
 
 func (h *toolsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	st, err := h.ctxt.stateForRequestUnauthenticated(r)
+	st, releaser, err := h.ctxt.stateForRequestUnauthenticated(r)
 	if err != nil {
 		if err := sendError(w, err); err != nil {
 			logger.Errorf("%v", err)
 		}
 		return
 	}
-	defer h.ctxt.release(st)
+	defer releaser()
 
 	switch r.Method {
 	case "GET":
@@ -71,14 +71,14 @@ func (h *toolsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 func (h *toolsUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Validate before authenticate because the authentication is dependent
 	// on the state connection that is determined during the validation.
-	st, err := h.stateAuthFunc(r)
+	st, releaser, err := h.stateAuthFunc(r)
 	if err != nil {
 		if err := sendError(w, err); err != nil {
 			logger.Errorf("%v", err)
 		}
 		return
 	}
-	defer h.ctxt.release(st)
+	defer releaser()
 
 	switch r.Method {
 	case "POST":

--- a/cmd/jujud/agent/introspection.go
+++ b/cmd/jujud/agent/introspection.go
@@ -30,6 +30,7 @@ func DefaultIntrospectionSocketName(entityTag names.Tag) string {
 type introspectionConfig struct {
 	Agent              agent.Agent
 	Engine             *dependency.Engine
+	StatePoolReporter  introspection.IntrospectionReporter
 	PrometheusGatherer prometheus.Gatherer
 	NewSocketName      func(names.Tag) string
 	WorkerFunc         func(config introspection.Config) (worker.Worker, error)
@@ -50,7 +51,8 @@ func startIntrospection(cfg introspectionConfig) error {
 	socketName := cfg.NewSocketName(cfg.Agent.CurrentConfig().Tag())
 	w, err := cfg.WorkerFunc(introspection.Config{
 		SocketName:         socketName,
-		Reporter:           cfg.Engine,
+		DepEngine:          cfg.Engine,
+		StatePool:          cfg.StatePoolReporter,
 		PrometheusGatherer: cfg.PrometheusGatherer,
 	})
 	if err != nil {
@@ -80,4 +82,11 @@ func newPrometheusRegistry() (*prometheus.Registry, error) {
 		return nil, errors.Trace(err)
 	}
 	return r, nil
+}
+
+func (h *statePoolHolder) IntrospectionReport() string {
+	if h.pool == nil {
+		return "agent has no pool set"
+	}
+	return h.pool.IntrospectionReport()
 }

--- a/cmd/jujud/agent/introspection_test.go
+++ b/cmd/jujud/agent/introspection_test.go
@@ -90,7 +90,7 @@ func (s *introspectionSuite) TestStartSuccess(c *gc.C) {
 	err = startIntrospection(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(fake.config.Reporter, gc.Equals, engine)
+	c.Check(fake.config.DepEngine, gc.Equals, engine)
 	c.Check(fake.config.SocketName, gc.Equals, "bananas")
 
 	// Stopping the engine causes the introspection worker to stop.

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -301,6 +301,7 @@ func NewMachineAgent(
 		newIntrospectionSocketName:  newIntrospectionSocketName,
 		prometheusRegistry:          prometheusRegistry,
 		txnmetricsCollector:         txnmetrics.New(),
+		statePool:                   &statePoolHolder{},
 	}
 	if err := a.prometheusRegistry.Register(
 		logsendermetrics.BufferedLogWriterMetrics{bufferedLogger},
@@ -349,6 +350,17 @@ type MachineAgent struct {
 	// Only API servers have hubs. This is temporary until the apiserver and
 	// peergrouper have manifolds.
 	centralHub *pubsub.StructuredHub
+
+	// The statePool holder holds a reference to the current state pool.
+	// The statePool is created by the machine agent and passed to the
+	// apiserver. This object adds a level of indirection so the introspection
+	// worker can have a single thing to hold that can report on the state pool.
+	// The content of the state pool holder is updated as the pool changes.
+	statePool *statePoolHolder
+}
+
+type statePoolHolder struct {
+	pool *state.StatePool
 }
 
 // IsRestorePreparing returns bool representing if we are in restore mode
@@ -535,6 +547,7 @@ func (a *MachineAgent) makeEngineCreator(previousAgentVersion version.Number) fu
 		if err := startIntrospection(introspectionConfig{
 			Agent:              a,
 			Engine:             engine,
+			StatePoolReporter:  a.statePool,
 			NewSocketName:      a.newIntrospectionSocketName,
 			PrometheusGatherer: a.prometheusRegistry,
 			WorkerFunc:         introspection.NewWorker,
@@ -1189,13 +1202,16 @@ func (a *MachineAgent) newAPIserverWorker(
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot create RPC observer factory")
 	}
+	statePool := state.NewStatePool(st)
+	a.statePool.pool = statePool
 
 	registerIntrospectionHandlers := func(f func(string, http.Handler)) {
 		introspection.RegisterHTTPHandlers(
-			dependencyReporter,
-			a.prometheusRegistry,
-			f,
-		)
+			introspection.ReportSources{
+				DependencyEngine:   dependencyReporter,
+				StatePool:          statePool,
+				PrometheusGatherer: a.prometheusRegistry,
+			}, f)
 	}
 
 	server, err := apiserver.NewServer(st, listener, apiserver.ServerConfig{
@@ -1212,6 +1228,7 @@ func (a *MachineAgent) newAPIserverWorker(
 		AutocertDNSName:               controllerConfig.AutocertDNSName(),
 		AllowModelAccess:              controllerConfig.AllowModelAccess(),
 		NewObserver:                   newObserver,
+		StatePool:                     statePool,
 		RegisterIntrospectionHandlers: registerIntrospectionHandlers,
 	})
 	if err != nil {

--- a/worker/introspection/script.go
+++ b/worker/introspection/script.go
@@ -77,10 +77,15 @@ juju-engine-report () {
   jujuMachineOrUnit depengine/ $@
 }
 
+juju-statepool-report () {
+  jujuMachineOrUnit statepool/ $@
+}
+
 export -f jujuAgentCall
 export -f jujuMachineAgentName
 export -f jujuMachineOrUnit
 export -f juju-goroutines
 export -f juju-heap-profile
 export -f juju-engine-report
+export -f juju-statepool-report
 `

--- a/worker/introspection/socket.go
+++ b/worker/introspection/socket.go
@@ -29,10 +29,17 @@ type DepEngineReporter interface {
 	Report() map[string]interface{}
 }
 
+// IntrospectionReporter provides a simple method that the introspection
+// worker will output for the entity.
+type IntrospectionReporter interface {
+	IntrospectionReport() string
+}
+
 // Config describes the arguments required to create the introspection worker.
 type Config struct {
 	SocketName         string
-	Reporter           DepEngineReporter
+	DepEngine          DepEngineReporter
+	StatePool          IntrospectionReporter
 	PrometheusGatherer prometheus.Gatherer
 }
 
@@ -51,7 +58,8 @@ func (c *Config) Validate() error {
 type socketListener struct {
 	tomb               tomb.Tomb
 	listener           *net.UnixListener
-	reporter           DepEngineReporter
+	depEngine          DepEngineReporter
+	statePool          IntrospectionReporter
 	prometheusGatherer prometheus.Gatherer
 	done               chan struct{}
 }
@@ -80,7 +88,8 @@ func NewWorker(config Config) (worker.Worker, error) {
 
 	w := &socketListener{
 		listener:           l,
-		reporter:           config.Reporter,
+		depEngine:          config.DepEngine,
+		statePool:          config.StatePool,
 		prometheusGatherer: config.PrometheusGatherer,
 		done:               make(chan struct{}),
 	}
@@ -91,7 +100,12 @@ func NewWorker(config Config) (worker.Worker, error) {
 
 func (w *socketListener) serve() {
 	mux := http.NewServeMux()
-	RegisterHTTPHandlers(w.reporter, w.prometheusGatherer, mux.Handle)
+	RegisterHTTPHandlers(
+		ReportSources{
+			DependencyEngine:   w.depEngine,
+			StatePool:          w.statePool,
+			PrometheusGatherer: w.prometheusGatherer,
+		}, mux.Handle)
 
 	srv := http.Server{Handler: mux}
 	logger.Debugf("stats worker now serving")
@@ -120,21 +134,32 @@ func (w *socketListener) Wait() error {
 	return w.tomb.Wait()
 }
 
+// ReportSources are the various information sources that are exposed
+// through the introspection facility.
+type ReportSources struct {
+	DependencyEngine   DepEngineReporter
+	StatePool          IntrospectionReporter
+	PrometheusGatherer prometheus.Gatherer
+}
+
 // AddHandlers calls the given function with http.Handlers
 // that serve agent introspection requests. The function will
 // be called with a path; the function may alter the path
 // as it sees fit.
 func RegisterHTTPHandlers(
-	reporter DepEngineReporter,
-	prometheusGatherer prometheus.Gatherer,
+	sources ReportSources,
 	handle func(path string, h http.Handler),
 ) {
 	handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
 	handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
 	handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
 	handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
-	handle("/depengine/", depengineHandler{reporter})
-	handle("/metrics", promhttp.HandlerFor(prometheusGatherer, promhttp.HandlerOpts{}))
+	handle("/depengine/", depengineHandler{sources.DependencyEngine})
+	handle("/statepool/", introspectionReporterHandler{
+		name:     "State Pool Report",
+		reporter: sources.StatePool,
+	})
+	handle("/metrics", promhttp.HandlerFor(sources.PrometheusGatherer, promhttp.HandlerOpts{}))
 }
 
 type depengineHandler struct {
@@ -145,7 +170,7 @@ type depengineHandler struct {
 func (h depengineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if h.reporter == nil {
 		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprintln(w, "missing reporter")
+		fmt.Fprintln(w, "missing dependency engine reporter")
 		return
 	}
 	bytes, err := yaml.Marshal(h.reporter.Report())
@@ -159,4 +184,23 @@ func (h depengineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	fmt.Fprint(w, "Dependency Engine Report\n\n")
 	w.Write(bytes)
+}
+
+type introspectionReporterHandler struct {
+	name     string
+	reporter IntrospectionReporter
+}
+
+// ServeHTTP is part of the http.Handler interface.
+func (h introspectionReporterHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.reporter == nil {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprintf(w, "%s: missing reporter\n", h.name)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+
+	fmt.Fprintf(w, "%s:\n\n", h.name)
+	fmt.Fprint(w, h.reporter.IntrospectionReport())
 }

--- a/worker/introspection/socket_test.go
+++ b/worker/introspection/socket_test.go
@@ -74,7 +74,7 @@ func (s *introspectionSuite) startWorker(c *gc.C) {
 	s.name = fmt.Sprintf("introspection-test-%d", os.Getpid())
 	w, err := introspection.NewWorker(introspection.Config{
 		SocketName:         s.name,
-		Reporter:           s.reporter,
+		DepEngine:          s.reporter,
 		PrometheusGatherer: s.gatherer,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -110,10 +110,16 @@ func (s *introspectionSuite) TestGoroutineProfile(c *gc.C) {
 	matches(c, buf, `^goroutine profile: total \d+`)
 }
 
-func (s *introspectionSuite) TestMissingReporter(c *gc.C) {
+func (s *introspectionSuite) TestMissingDepEngineReporter(c *gc.C) {
 	buf := s.call(c, "/depengine/")
 	matches(c, buf, "404 Not Found")
-	matches(c, buf, "missing reporter")
+	matches(c, buf, "missing dependency engine reporter")
+}
+
+func (s *introspectionSuite) TestMissingStatePoolReporter(c *gc.C) {
+	buf := s.call(c, "/statepool/")
+	matches(c, buf, "404 Not Found")
+	matches(c, buf, "State Pool Report: missing reporter")
 }
 
 func (s *introspectionSuite) TestEngineReporter(c *gc.C) {


### PR DESCRIPTION
In the continuing saga of tracking memory leaks this branch adds introspection into the state pool that is used by the apiserver.

The state pool now records the stack whenever the Get method is called, and clears that stack when the releaser is called.

## QA steps

- bootstrap a lxd provider
- juju ssh -m controller 0
- juju-statepool-report
