### PR TITLE
provider/lxd: use CloudSpec.Endpoint/Credentials (WIP)

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -366,16 +366,15 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	}
 
 	credentials, regionName, err := c.credentialsAndRegionName(ctx, provider, cloud)
-	if err != nil {
-		if err == cmd.ErrSilent {
-			return err
-		}
+	if common.IsChooseCloudRegionError(err) {
+		return handleChooseCloudRegionError(ctx, err)
+	} else if err != nil {
 		return errors.Trace(err)
 	}
 
-	region, err := getRegion(cloud, regionName)
+	region, err := common.ChooseCloudRegion(*cloud, regionName)
 	if err != nil {
-		return handleGetRegionError(ctx, err)
+		return handleChooseCloudRegionError(ctx, err)
 	}
 	if c.controllerName == "" {
 		c.controllerName = defaultControllerName(cloud.Name, region.Name)
@@ -728,65 +727,34 @@ func (c *bootstrapCommand) credentialsAndRegionName(
 	regionName string,
 	err error,
 ) {
+	var detected bool
 	store := c.ClientStore()
-	creds.credential, creds.name, regionName, err = modelcmd.GetCredentials(
-		ctx, store, modelcmd.GetCredentialsParams{
+	creds.credential, creds.name, regionName, detected, err = common.GetOrDetectCredential(
+		ctx, store, provider, modelcmd.GetCredentialsParams{
 			Cloud:          *cloud,
 			CloudName:      c.Cloud,
 			CloudRegion:    c.Region,
 			CredentialName: c.CredentialName,
 		},
 	)
-	if errors.Cause(err) == modelcmd.ErrMultipleCredentials {
+	switch errors.Cause(err) {
+	case nil:
+	case modelcmd.ErrMultipleCredentials:
 		return bootstrapCredentials{}, "", ambiguousCredentialError
-	}
-	if errors.IsNotFound(err) && c.CredentialName == "" {
-		// No credential was explicitly specified, and no credential
-		// was found in credentials.yaml; have the provider detect
-		// credentials from the environment.
-		ctx.Verbosef("no credentials found, checking environment")
-		detected, err := modelcmd.DetectCredential(c.Cloud, cloud.Type)
-		if errors.Cause(err) == modelcmd.ErrMultipleCredentials {
-			return bootstrapCredentials{}, "", ambiguousDetectedCredentialError
-		} else if err != nil {
-			return bootstrapCredentials{}, "", errors.Trace(err)
-		}
-
-		// We have one credential so extract it from the map.
-		var oneCredential jujucloud.Credential
-		for creds.detectedName, oneCredential = range detected.AuthCredentials {
-		}
-		creds.credential = &oneCredential
-		regionName = c.Region
-		if regionName == "" {
-			regionName = detected.DefaultRegion
-		}
-
-		// Finalize the credential against the cloud/region.
-		region, err := getRegion(cloud, regionName)
-		if err != nil {
-			return bootstrapCredentials{}, "", handleGetRegionError(ctx, err)
-		}
-		creds.credential, err = provider.FinalizeCredential(
-			ctx, environs.FinalizeCredentialParams{
-				Credential:            oneCredential,
-				CloudEndpoint:         region.Endpoint,
-				CloudIdentityEndpoint: region.IdentityEndpoint,
-			},
-		)
-		if err != nil {
-			return bootstrapCredentials{}, "", errors.Trace(err)
-		}
-
-		logger.Debugf(
-			"authenticating with region %q and credential %q (%v)",
-			regionName, creds.detectedName, creds.credential.Label,
-		)
-		logger.Tracef("credential: %v", creds.credential)
-	} else if err != nil {
+	case common.ErrMultipleDetectedCredentials:
+		return bootstrapCredentials{}, "", ambiguousDetectedCredentialError
+	default:
 		return bootstrapCredentials{}, "", errors.Trace(err)
 	}
-
+	logger.Debugf(
+		"authenticating with region %q and credential %q (%v)",
+		regionName, creds.name, creds.credential.Label,
+	)
+	if detected {
+		creds.detectedName = creds.name
+		creds.name = ""
+	}
+	logger.Tracef("credential: %v", creds.credential)
 	return creds, regionName, nil
 }
 
@@ -1034,29 +1002,6 @@ func (c *bootstrapCommand) runInteractive(ctx *cmd.Context) error {
 	return nil
 }
 
-// getRegion returns the cloud.Region to use, based on the specified
-// region name.  If no region name is specified, and there is at least
-// one region, we use the first region in the list.
-func getRegion(cloud *jujucloud.Cloud, regionName string) (jujucloud.Region, error) {
-	if regionName != "" {
-		region, err := jujucloud.RegionByName(cloud.Regions, regionName)
-		if err != nil {
-			return jujucloud.Region{}, errors.Trace(err)
-		}
-		return *region, nil
-	}
-	if len(cloud.Regions) > 0 {
-		// No region was specified, use the first region in the list.
-		return cloud.Regions[0], nil
-	}
-	return jujucloud.Region{
-		"", // no region name
-		cloud.Endpoint,
-		cloud.IdentityEndpoint,
-		cloud.StorageEndpoint,
-	}, nil
-}
-
 // checkProviderType ensures the provider type is okay.
 func checkProviderType(envType string) error {
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
@@ -1084,7 +1029,7 @@ func handleBootstrapError(ctx *cmd.Context, err error, cleanup func() error) {
 	}
 }
 
-func handleGetRegionError(ctx *cmd.Context, err error) error {
+func handleChooseCloudRegionError(ctx *cmd.Context, err error) error {
 	fmt.Fprintf(ctx.GetStderr(),
 		"%s\n\nSpecify an alternative region, or try %q.\n",
 		err, "juju update-clouds",

--- a/cmd/juju/common/cloud.go
+++ b/cmd/juju/common/cloud.go
@@ -7,14 +7,25 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
-	"github.com/juju/juju/cloud"
+	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 )
 
 var logger = loggo.GetLogger("juju.cmd.juju.common")
 
+type chooseCloudRegionError struct {
+	error
+}
+
+// IsChooseCloudRegionError reports whether or not the given
+// error was returned from ChooseCloudRegion.
+func IsChooseCloudRegionError(err error) bool {
+	_, ok := errors.Cause(err).(chooseCloudRegionError)
+	return ok
+}
+
 // CloudOrProvider finds and returns cloud or provider.
-func CloudOrProvider(cloudName string, cloudByNameFunc func(string) (*cloud.Cloud, error)) (cloud *cloud.Cloud, err error) {
+func CloudOrProvider(cloudName string, cloudByNameFunc func(string) (*jujucloud.Cloud, error)) (cloud *jujucloud.Cloud, err error) {
 	if cloud, err = cloudByNameFunc(cloudName); err != nil {
 		if !errors.IsNotFound(err) {
 			return nil, err
@@ -32,10 +43,34 @@ func CloudOrProvider(cloudName string, cloudByNameFunc func(string) (*cloud.Clou
 	return cloud, nil
 }
 
+// ChooseCloudRegion returns the cloud.Region to use, based on the specified
+// region name. If no region name is specified, and there is at least one
+// region, we use the first region in the list. If there are no regions, then
+// we return a region with no name, having the same endpoints as the cloud.
+func ChooseCloudRegion(cloud jujucloud.Cloud, regionName string) (jujucloud.Region, error) {
+	if regionName != "" {
+		region, err := jujucloud.RegionByName(cloud.Regions, regionName)
+		if err != nil {
+			return jujucloud.Region{}, errors.Trace(chooseCloudRegionError{err})
+		}
+		return *region, nil
+	}
+	if len(cloud.Regions) > 0 {
+		// No region was specified, use the first region in the list.
+		return cloud.Regions[0], nil
+	}
+	return jujucloud.Region{
+		"", // no region name
+		cloud.Endpoint,
+		cloud.IdentityEndpoint,
+		cloud.StorageEndpoint,
+	}, nil
+}
+
 // BuiltInClouds returns cloud information for those
 // providers which are built in to Juju.
-func BuiltInClouds() (map[string]cloud.Cloud, error) {
-	allClouds := make(map[string]cloud.Cloud)
+func BuiltInClouds() (map[string]jujucloud.Cloud, error) {
+	allClouds := make(map[string]jujucloud.Cloud)
 	for _, providerType := range environs.RegisteredProviders() {
 		p, err := environs.Provider(providerType)
 		if err != nil {

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/jujuclient"
 )
@@ -36,15 +37,17 @@ func NewAddModelCommand() cmd.Command {
 		newCloudAPI: func(caller base.APICallCloser) CloudAPI {
 			return cloudapi.NewClient(caller)
 		},
+		providerRegistry: environs.GlobalProviderRegistry(),
 	})
 }
 
 // addModelCommand calls the API to add a new model.
 type addModelCommand struct {
 	modelcmd.ControllerCommandBase
-	apiRoot        api.Connection
-	newAddModelAPI func(base.APICallCloser) AddModelAPI
-	newCloudAPI    func(base.APICallCloser) CloudAPI
+	apiRoot          api.Connection
+	newAddModelAPI   func(base.APICallCloser) AddModelAPI
+	newCloudAPI      func(base.APICallCloser) CloudAPI
+	providerRegistry environs.ProviderRegistry
 
 	Name           string
 	Owner          string
@@ -195,22 +198,21 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
+	} else {
+		if cloudTag, cloud, err = defaultCloud(cloudClient); err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	// If the user has specified a credential, then we will upload it if
 	// it doesn't already exist in the controller, and it exists locally.
-	var credentialTag names.CloudCredentialTag
-	if c.CredentialName != "" {
-		var err error
-		if c.CloudRegion == "" {
-			if cloudTag, cloud, err = defaultCloud(cloudClient); err != nil {
-				return errors.Trace(err)
-			}
-		}
-		credentialTag, err = c.maybeUploadCredential(ctx, cloudClient, cloudTag, cloudRegion, cloud, modelOwner)
-		if err != nil {
-			return errors.Trace(err)
-		}
+	//
+	// If no credential is specified, but there is exactly one on the
+	// client, then we use that; otherwise we attempt to detect one from
+	// the environment.
+	credentialTag, err := c.maybeUploadCredential(ctx, cloudClient, cloudTag, cloudRegion, cloud, modelOwner)
+	if err != nil {
+		return errors.Trace(err)
 	}
 
 	addModelClient := c.newAddModelAPI(api)
@@ -396,6 +398,16 @@ there is no default cloud defined, please specify one using:
 	return cloudTag, cloud, nil
 }
 
+var ambiguousDetectedCredentialError = errors.New(`
+more than one credential detected
+run juju autoload-credentials and specify a credential using the --credential argument`[1:],
+)
+
+var ambiguousCredentialError = errors.New(`
+more than one credential is available
+specify a credential using the --credential argument`[1:],
+)
+
 func (c *addModelCommand) maybeUploadCredential(
 	ctx *cmd.Context,
 	cloudClient CloudAPI,
@@ -405,48 +417,81 @@ func (c *addModelCommand) maybeUploadCredential(
 	modelOwner string,
 ) (names.CloudCredentialTag, error) {
 
-	modelOwnerTag := names.NewUserTag(modelOwner)
-	credentialTag, err := common.ResolveCloudCredentialTag(
-		modelOwnerTag, cloudTag, c.CredentialName,
-	)
-	if err != nil {
-		return names.CloudCredentialTag{}, errors.Trace(err)
+	// If the user has not specified a credential, and the cloud advertises
+	// itself as supporting the "empty" auth-type, then return immediately.
+	if c.CredentialName == "" {
+		for _, authType := range cloud.AuthTypes {
+			if authType == jujucloud.EmptyAuthType {
+				return names.CloudCredentialTag{}, nil
+			}
+		}
 	}
 
 	// Check if the credential is already in the controller.
-	//
-	// TODO(axw) consider implementing a call that can check
-	// that the credential exists without fetching all of the
-	// names.
+	modelOwnerTag := names.NewUserTag(modelOwner)
 	credentialTags, err := cloudClient.UserCredentials(modelOwnerTag, cloudTag)
 	if err != nil {
 		return names.CloudCredentialTag{}, errors.Trace(err)
 	}
-	credentialId := credentialTag.Id()
-	for _, tag := range credentialTags {
-		if tag.Id() != credentialId {
-			continue
+	if c.CredentialName != "" {
+		credentialTag, err := common.ResolveCloudCredentialTag(
+			modelOwnerTag, cloudTag, c.CredentialName,
+		)
+		if err != nil {
+			return names.CloudCredentialTag{}, errors.Trace(err)
 		}
-		ctx.Infof("Using credential '%s' cached in controller", c.CredentialName)
-		return credentialTag, nil
+		credentialId := credentialTag.Id()
+		for _, tag := range credentialTags {
+			if tag.Id() != credentialId {
+				continue
+			}
+			ctx.Infof("Using credential '%s' cached in controller", c.CredentialName)
+			return credentialTag, nil
+		}
+		if credentialTag.Owner().Id() != modelOwner {
+			// Another user's credential was specified, so
+			// we cannot automatically upload.
+			return names.CloudCredentialTag{}, errors.NotFoundf(
+				"credential '%s'", c.CredentialName,
+			)
+		}
 	}
 
-	if credentialTag.Owner().Id() != modelOwner {
-		// Another user's credential was specified, so
-		// we cannot automatically upload.
-		return names.CloudCredentialTag{}, errors.NotFoundf(
-			"credential '%s'", c.CredentialName,
-		)
+	// The user has either not specified a credential, or if they have, it
+	// is not cached in the controller, and isn't qualified with another
+	// user name.
+
+	if c.CredentialName == "" && len(credentialTags) == 1 {
+		tag := credentialTags[0]
+		ctx.Infof("Using credential '%s' cached in controller", tag.Name())
+		return tag, nil
 	}
 
 	// Upload the credential from the client, if it exists locally.
-	credential, _, _, err := modelcmd.GetCredentials(
-		ctx, c.ClientStore(), modelcmd.GetCredentialsParams{
+	provider, err := c.providerRegistry.Provider(cloud.Type)
+	if err != nil {
+		return names.CloudCredentialTag{}, errors.Trace(err)
+	}
+	credential, credentialName, _, _, err := common.GetOrDetectCredential(
+		ctx, c.ClientStore(), provider, modelcmd.GetCredentialsParams{
 			Cloud:          cloud,
 			CloudName:      cloudTag.Id(),
 			CloudRegion:    cloudRegion,
-			CredentialName: credentialTag.Name(),
+			CredentialName: c.CredentialName,
 		},
+	)
+	switch errors.Cause(err) {
+	case nil:
+	case modelcmd.ErrMultipleCredentials:
+		return names.CloudCredentialTag{}, ambiguousCredentialError
+	case common.ErrMultipleDetectedCredentials:
+		return names.CloudCredentialTag{}, ambiguousDetectedCredentialError
+	default:
+		return names.CloudCredentialTag{}, errors.Trace(err)
+	}
+
+	credentialTag, err := common.ResolveCloudCredentialTag(
+		modelOwnerTag, cloudTag, credentialName,
 	)
 	if err != nil {
 		return names.CloudCredentialTag{}, errors.Trace(err)

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/controller"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	_ "github.com/juju/juju/provider/ec2"
@@ -30,9 +31,11 @@ import (
 
 type AddModelSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
-	fakeAddModelAPI *fakeAddClient
-	fakeCloudAPI    *fakeCloudAPI
-	store           *jujuclienttesting.MemStore
+	fakeAddModelAPI      *fakeAddClient
+	fakeCloudAPI         *fakeCloudAPI
+	fakeProvider         *fakeProvider
+	fakeProviderRegistry *fakeProviderRegistry
+	store                *jujuclienttesting.MemStore
 }
 
 var _ = gc.Suite(&AddModelSuite{})
@@ -46,7 +49,20 @@ func (s *AddModelSuite) SetUpTest(c *gc.C) {
 			Owner: "ignored-for-now",
 		},
 	}
-	s.fakeCloudAPI = &fakeCloudAPI{}
+	s.fakeCloudAPI = &fakeCloudAPI{
+		authTypes: []cloud.AuthType{
+			cloud.EmptyAuthType,
+			cloud.AccessKeyAuthType,
+		},
+		credentials: []names.CloudCredentialTag{
+			names.NewCloudCredentialTag("cloud/admin/default"),
+			names.NewCloudCredentialTag("aws/other/secrets"),
+		},
+	}
+	s.fakeProvider = &fakeProvider{}
+	s.fakeProviderRegistry = &fakeProviderRegistry{
+		provider: s.fakeProvider,
+	}
 
 	// Set up the current controller, and write just enough info
 	// so we don't try to refresh
@@ -76,7 +92,13 @@ func (*fakeAPIConnection) Close() error {
 }
 
 func (s *AddModelSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
-	command, _ := controller.NewAddModelCommandForTest(&fakeAPIConnection{}, s.fakeAddModelAPI, s.fakeCloudAPI, s.store)
+	command, _ := controller.NewAddModelCommandForTest(
+		&fakeAPIConnection{},
+		s.fakeAddModelAPI,
+		s.fakeCloudAPI,
+		s.store,
+		s.fakeProviderRegistry,
+	)
 	return testing.RunCommand(c, command, args...)
 }
 
@@ -131,7 +153,7 @@ func (s *AddModelSuite) TestInit(c *gc.C) {
 		},
 	} {
 		c.Logf("test %d", i)
-		wrappedCommand, command := controller.NewAddModelCommandForTest(nil, nil, nil, s.store)
+		wrappedCommand, command := controller.NewAddModelCommandForTest(nil, nil, nil, s.store, nil)
 		err := testing.InitCommand(wrappedCommand, test.args)
 		if test.err != "" {
 			c.Assert(err, gc.ErrorMatches, test.err)
@@ -209,6 +231,47 @@ func (s *AddModelSuite) TestCredentialsNoDefaultCloud(c *gc.C) {
     juju add-model \[flags\] \<model-name\> cloud\[/region\]`)
 }
 
+func (s *AddModelSuite) TestCredentialsOneCached(c *gc.C) {
+	// Disable empty auth and clear the local credentials,
+	// forcing a check for credentials in the controller.
+	s.PatchValue(&s.fakeCloudAPI.authTypes, []cloud.AuthType{cloud.AccessKeyAuthType})
+	delete(s.store.Credentials, "aws")
+
+	// Cache just a single credential in the controller,
+	// so it is selected automatically.
+	credentialTag := names.NewCloudCredentialTag("aws/foo/secrets")
+	s.PatchValue(&s.fakeCloudAPI.credentials, []names.CloudCredentialTag{credentialTag})
+
+	_, err := s.run(c, "test")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.fakeAddModelAPI.cloudCredential, gc.Equals, credentialTag)
+}
+
+func (s *AddModelSuite) TestCredentialsDetected(c *gc.C) {
+	// Disable empty auth and clear the local credentials,
+	// forcing a check for credentials in the controller.
+	// There are multiple credentials in the controller,
+	// so none of them will be chosen by default.
+	s.PatchValue(&s.fakeCloudAPI.authTypes, []cloud.AuthType{cloud.AccessKeyAuthType})
+
+	// Delete all local credentials, so we don't choose
+	// any of them to upload. This will force credential
+	// detection.
+	delete(s.store.Credentials, "aws")
+
+	_, err := s.run(c, "test")
+	c.Assert(err, jc.ErrorIsNil)
+
+	credentialTag := names.NewCloudCredentialTag("aws/bob/default")
+	credential := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{})
+	credential.Label = "finalized"
+
+	c.Assert(s.fakeAddModelAPI.cloudCredential, gc.Equals, credentialTag)
+	s.fakeCloudAPI.CheckCallNames(c, "DefaultCloud", "Cloud", "UserCredentials", "UpdateCredential")
+	s.fakeCloudAPI.CheckCall(c, 3, "UpdateCredential", credentialTag, credential)
+}
+
 func (s *AddModelSuite) TestCloudRegionPassedThrough(c *gc.C) {
 	_, err := s.run(c, "test", "aws/us-west-1")
 	c.Assert(err, jc.ErrorIsNil)
@@ -221,8 +284,8 @@ func (s *AddModelSuite) TestDefaultCloudPassedThrough(c *gc.C) {
 	_, err := s.run(c, "test")
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.fakeCloudAPI.CheckCallNames(c /*none*/)
-	c.Assert(s.fakeAddModelAPI.cloudName, gc.Equals, "")
+	s.fakeCloudAPI.CheckCallNames(c, "DefaultCloud", "Cloud")
+	c.Assert(s.fakeAddModelAPI.cloudName, gc.Equals, "aws")
 	c.Assert(s.fakeAddModelAPI.cloudRegion, gc.Equals, "")
 }
 
@@ -445,6 +508,8 @@ func (f *fakeAddClient) CreateModel(name, owner, cloudName, cloudRegion string, 
 type fakeCloudAPI struct {
 	controller.CloudAPI
 	gitjujutesting.Stub
+	authTypes   []cloud.AuthType
+	credentials []names.CloudCredentialTag
 }
 
 func (c *fakeCloudAPI) DefaultCloud() (names.CloudTag, error) {
@@ -456,6 +521,7 @@ func (c *fakeCloudAPI) Clouds() (map[names.CloudTag]cloud.Cloud, error) {
 	c.MethodCall(c, "Clouds")
 	return map[names.CloudTag]cloud.Cloud{
 		names.NewCloudTag("aws"): {
+			AuthTypes: c.authTypes,
 			Regions: []cloud.Region{
 				{Name: "us-east-1"},
 				{Name: "us-west-1"},
@@ -472,7 +538,7 @@ func (c *fakeCloudAPI) Cloud(tag names.CloudTag) (cloud.Cloud, error) {
 	}
 	return cloud.Cloud{
 		Type:      "ec2",
-		AuthTypes: []cloud.AuthType{cloud.AccessKeyAuthType},
+		AuthTypes: c.authTypes,
 		Regions: []cloud.Region{
 			{Name: "us-east-1"},
 			{Name: "us-west-1"},
@@ -482,13 +548,41 @@ func (c *fakeCloudAPI) Cloud(tag names.CloudTag) (cloud.Cloud, error) {
 
 func (c *fakeCloudAPI) UserCredentials(user names.UserTag, cloud names.CloudTag) ([]names.CloudCredentialTag, error) {
 	c.MethodCall(c, "UserCredentials", user, cloud)
-	return []names.CloudCredentialTag{
-		names.NewCloudCredentialTag("cloud/admin/default"),
-		names.NewCloudCredentialTag("aws/other/secrets"),
-	}, c.NextErr()
+	return c.credentials, c.NextErr()
 }
 
 func (c *fakeCloudAPI) UpdateCredential(credentialTag names.CloudCredentialTag, credential cloud.Credential) error {
 	c.MethodCall(c, "UpdateCredential", credentialTag, credential)
 	return c.NextErr()
+}
+
+type fakeProviderRegistry struct {
+	gitjujutesting.Stub
+	environs.ProviderRegistry
+	provider environs.EnvironProvider
+}
+
+func (r *fakeProviderRegistry) Provider(providerType string) (environs.EnvironProvider, error) {
+	r.MethodCall(r, "Provider", providerType)
+	return r.provider, r.NextErr()
+}
+
+type fakeProvider struct {
+	gitjujutesting.Stub
+	environs.EnvironProvider
+}
+
+func (p *fakeProvider) DetectCredentials() (*cloud.CloudCredential, error) {
+	p.MethodCall(p, "DetectCredentials")
+	return cloud.NewEmptyCloudCredential(), p.NextErr()
+}
+
+func (p *fakeProvider) FinalizeCredential(
+	ctx environs.FinalizeCredentialContext,
+	args environs.FinalizeCredentialParams,
+) (*cloud.Credential, error) {
+	p.MethodCall(p, "FinalizeCredential", ctx, args)
+	out := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{})
+	out.Label = "finalized"
+	return &out, p.NextErr()
 }

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -46,6 +47,7 @@ func NewAddModelCommandForTest(
 	api AddModelAPI,
 	cloudAPI CloudAPI,
 	store jujuclient.ClientStore,
+	providerRegistry environs.ProviderRegistry,
 ) (cmd.Command, *AddModelCommand) {
 	c := &addModelCommand{
 		apiRoot: apiRoot,
@@ -55,6 +57,7 @@ func NewAddModelCommandForTest(
 		newCloudAPI: func(base.APICallCloser) CloudAPI {
 			return cloudAPI
 		},
+		providerRegistry: providerRegistry,
 	}
 	c.SetClientStore(store)
 	return modelcmd.WrapController(c), &AddModelCommand{c}

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -435,10 +435,11 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 		}
 	} else {
 		// The credential was auto-detected; run auto-detection again.
-		cloudCredential, err := DetectCredential(
-			bootstrapConfig.Cloud,
-			bootstrapConfig.CloudType,
-		)
+		provider, err := environs.Provider(bootstrapConfig.CloudType)
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		cloudCredential, err := DetectCredential(bootstrapConfig.Cloud, provider)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}

--- a/cmd/modelcmd/credentials.go
+++ b/cmd/modelcmd/credentials.go
@@ -164,11 +164,7 @@ func credentialByName(
 // If no credentials are detected, an error satisfying errors.IsNotFound will
 // be returned. If more than one credential is detected, ErrMultipleCredentials
 // will be returned.
-func DetectCredential(cloudName, cloudType string) (*cloud.CloudCredential, error) {
-	provider, err := environs.Provider(cloudType)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+func DetectCredential(cloudName string, provider environs.EnvironProvider) (*cloud.CloudCredential, error) {
 	detected, err := provider.DetectCredentials()
 	if err != nil {
 		return nil, errors.Annotatef(

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -6,18 +6,44 @@
 package lxd
 
 import (
+	"net"
+
+	"github.com/juju/errors"
+	lxdshared "github.com/lxc/lxd/shared"
+
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/tools/lxdclient"
+)
+
+const (
+	credAttrServerCert = "server-cert"
+	credAttrClientCert = "client-cert"
+	credAttrClientKey  = "client-key"
 )
 
 type environProviderCredentials struct{}
 
 // CredentialSchemas is part of the environs.ProviderCredentials interface.
 func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
-	// TODO (anastasiamac 2016-04-14) When/If this value changes,
-	// verify that juju/juju/cloud/clouds.go#BuiltInClouds
-	// with lxd type are up to-date.
-	return map[cloud.AuthType]cloud.CredentialSchema{cloud.EmptyAuthType: {}}
+	return map[cloud.AuthType]cloud.CredentialSchema{
+		cloud.CertificateAuthType: {{
+			credAttrServerCert,
+			cloud.CredentialAttr{
+				Description: "The LXD server certificate, PEM-encoded.",
+			},
+		}, {
+			credAttrClientCert,
+			cloud.CredentialAttr{
+				Description: "The LXD client certificate, PEM-encoded.",
+			},
+		}, {
+			credAttrClientKey,
+			cloud.CredentialAttr{
+				Description: "The LXD client key, PEM-encoded.",
+			},
+		}},
+	}
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
@@ -27,5 +53,86 @@ func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, e
 
 // FinalizeCredential is part of the environs.ProviderCredentials interface.
 func (environProviderCredentials) FinalizeCredential(_ environs.FinalizeCredentialContext, args environs.FinalizeCredentialParams) (*cloud.Credential, error) {
-	return &args.Credential, nil
+	if args.Credential.AuthType() != cloud.EmptyAuthType {
+		return &args.Credential, nil
+	}
+
+	isLocalEndpoint, err := isLocalEndpoint(args.CloudEndpoint)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if !isLocalEndpoint {
+		// The endpoint is not local, so we cannot generate a
+		// certificate credential.
+		return &args.Credential, nil
+	}
+	raw, err := newLocalRawProvider()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Generate a certificate pair, upload to the server, and then create a
+	// new "certificate" credential with them and the server's certificate.
+	//
+	// We must upload here to cater for the esoteric case of automatic
+	// credential generation in "juju add-model". We *also* upload during
+	// bootstrap, in case the user does a "rebootstrap" with the *same*
+	// credentials (e.g. juju restore-backup).
+	certPEM, keyPEM, err := lxdshared.GenerateMemCert(true)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := raw.AddCert(lxdclient.Cert{
+		Name:    "juju",
+		CertPEM: certPEM,
+		KeyPEM:  keyPEM,
+	}); err != nil {
+		return nil, errors.Annotate(err, "adding certificate")
+	}
+	serverState, err := raw.ServerStatus()
+	if err != nil {
+		return nil, errors.Annotate(err, "getting server status")
+	}
+
+	out := cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
+		credAttrServerCert: serverState.Environment.Certificate,
+		credAttrClientCert: string(certPEM),
+		credAttrClientKey:  string(keyPEM),
+	})
+	out.Label = args.Credential.Label
+	return &out, nil
+}
+
+func isLocalEndpoint(endpoint string) (bool, error) {
+	endpointAddrs, err := net.LookupHost(endpoint)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	localAddrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	return addrsContainsAny(localAddrs, endpointAddrs), nil
+}
+
+func addrsContainsAny(haystack []net.Addr, needles []string) bool {
+	for _, needle := range needles {
+		if addrsContains(haystack, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func addrsContains(haystack []net.Addr, needle string) bool {
+	ip := net.ParseIP(needle)
+	if ip == nil {
+		return false
+	}
+	for _, addr := range haystack {
+		if addr, ok := addr.(*net.IPNet); ok && addr.IP.Equal(ip) {
+			return true
+		}
+	}
+	return false
 }

--- a/provider/lxd/credentials_test.go
+++ b/provider/lxd/credentials_test.go
@@ -4,36 +4,60 @@
 package lxd_test
 
 import (
+	"net"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/provider/lxd"
 )
 
 type credentialsSuite struct {
-	testing.BaseSuite
-	provider environs.EnvironProvider
+	lxd.BaseSuite
 }
 
 var _ = gc.Suite(&credentialsSuite{})
 
-func (s *credentialsSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
-
-	var err error
-	s.provider, err = environs.Provider("lxd")
-	c.Assert(err, jc.ErrorIsNil)
-}
-
 func (s *credentialsSuite) TestCredentialSchemas(c *gc.C) {
-	envtesting.AssertProviderAuthTypes(c, s.provider, "empty")
+	envtesting.AssertProviderAuthTypes(c, s.Provider, "certificate")
 }
 
 func (s *credentialsSuite) TestDetectCredentials(c *gc.C) {
-	credentials, err := s.provider.DetectCredentials()
+	credentials, err := s.Provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, jc.DeepEquals, cloud.NewEmptyCloudCredential())
+}
+
+func (s *credentialsSuite) TestFinalizeCredential(c *gc.C) {
+	out, err := s.Provider.FinalizeCredential(nil, environs.FinalizeCredentialParams{
+		CloudEndpoint: "",
+		Credential:    cloud.NewEmptyCredential(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(out.AuthType(), gc.Equals, cloud.CertificateAuthType)
+	c.Assert(out.Attributes(), jc.DeepEquals, map[string]string{
+		"client-cert": "client.crt",
+		"client-key":  "client.key",
+		"server-cert": "server-cert",
+	})
+	s.Stub.CheckCallNames(c,
+		"LookupHost", "InterfaceAddrs",
+		"GenerateMemCert", "AddCert", "ServerStatus",
+	)
+}
+
+func (s *credentialsSuite) TestFinalizeCredentialNonLocal(c *gc.C) {
+	// Patch the interface addresses for the calling machine, so
+	// it appears that we're not on the LXD server host.
+	s.PatchValue(&s.InterfaceAddrs, []net.Addr{&net.IPNet{IP: net.ParseIP("8.8.8.8")}})
+	out, err := s.Provider.FinalizeCredential(nil, environs.FinalizeCredentialParams{
+		CloudEndpoint: "",
+		Credential:    cloud.NewEmptyCredential(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out.AuthType(), gc.Equals, cloud.EmptyAuthType)
 }

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -6,14 +6,12 @@
 package lxd_test
 
 import (
-	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/provider/lxd"
-	"github.com/juju/juju/tools/lxdclient"
 )
 
 type environBrokerSuite struct {
@@ -54,41 +52,12 @@ func (s *environBrokerSuite) TestStopInstances(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{{
-		FuncName: "Instances",
-		Args: []interface{}{
-			"juju-f75cba-",
-			[]string(nil),
-		},
-	}, {
 		FuncName: "RemoveInstances",
 		Args: []interface{}{
 			"juju-f75cba-",
 			[]string{"spam"},
 		},
 	}})
-}
-
-func (s *environBrokerSuite) TestStopInstancesRemoveCertificate(c *gc.C) {
-	s.RawInstance.InstanceSummary.Metadata[lxdclient.CertificateFingerprintKey] = "foo"
-	s.Client.Insts = []lxdclient.Instance{*s.RawInstance}
-
-	err := s.Env.StopInstances(s.Instance.Id())
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.Stub.CheckCallNames(c, "Instances", "RemoveCertByFingerprint", "RemoveInstances")
-	s.Stub.CheckCall(c, 1, "RemoveCertByFingerprint", "foo")
-}
-
-func (s *environBrokerSuite) TestStopInstancesRemoveCertificateNotFound(c *gc.C) {
-	s.RawInstance.InstanceSummary.Metadata[lxdclient.CertificateFingerprintKey] = "foo"
-	s.Client.Insts = []lxdclient.Instance{*s.RawInstance}
-
-	s.Stub.SetErrors(nil, errors.NotFoundf("certificate"))
-	err := s.Env.StopInstances(s.Instance.Id())
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.Stub.CheckCallNames(c, "Instances", "RemoveCertByFingerprint", "RemoveInstances")
-	s.Stub.CheckCall(c, 1, "RemoveCertByFingerprint", "foo")
 }
 
 func (s *environBrokerSuite) TestImageMetadataURL(c *gc.C) {

--- a/provider/lxd/environ_raw.go
+++ b/provider/lxd/environ_raw.go
@@ -108,6 +108,9 @@ func getRemoteConfig(spec environs.CloudSpec) (*lxdclient.Config, error) {
 }
 
 func getCerts(spec environs.CloudSpec) (client *lxdclient.Cert, server string, ok bool) {
+	if spec.Credential == nil {
+		return nil, "", false
+	}
 	credAttrs := spec.Credential.Attributes()
 	clientCertPEM, ok := credAttrs[credAttrClientCert]
 	if !ok {

--- a/provider/lxd/environ_raw_test.go
+++ b/provider/lxd/environ_raw_test.go
@@ -20,9 +20,7 @@ import (
 type environRawSuite struct {
 	testing.IsolationSuite
 	testing.Stub
-	readFile   readFileFunc
-	runCommand runCommandFunc
-	spec       environs.CloudSpec
+	spec environs.CloudSpec
 }
 
 var _ = gc.Suite(&environRawSuite{})
@@ -30,20 +28,6 @@ var _ = gc.Suite(&environRawSuite{})
 func (s *environRawSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.Stub.ResetCalls()
-	s.readFile = func(path string) ([]byte, error) {
-		s.AddCall("readFile", path)
-		if err := s.NextErr(); err != nil {
-			return nil, err
-		}
-		return []byte("content:" + path), nil
-	}
-	s.runCommand = func(command string, args ...string) (string, error) {
-		s.AddCall("runCommand", command, args)
-		if err := s.NextErr(); err != nil {
-			return "", err
-		}
-		return "default via 10.0.8.1 dev eth0", nil
-	}
 	s.spec = environs.CloudSpec{
 		Type: "lxd",
 		Name: "localhost",

--- a/provider/lxd/environ_raw_test.go
+++ b/provider/lxd/environ_raw_test.go
@@ -6,13 +6,11 @@
 package lxd
 
 import (
-	"os"
-
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/tools/lxdclient"
 )
@@ -28,14 +26,22 @@ var _ = gc.Suite(&environRawSuite{})
 func (s *environRawSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.Stub.ResetCalls()
+
+	cred := cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
+		"client-cert": "client.crt",
+		"client-key":  "client.key",
+		"server-cert": "server.crt",
+	})
 	s.spec = environs.CloudSpec{
-		Type: "lxd",
-		Name: "localhost",
+		Type:       "lxd",
+		Name:       "localhost",
+		Endpoint:   "10.0.8.1",
+		Credential: &cred,
 	}
 }
 
 func (s *environRawSuite) TestGetRemoteConfig(c *gc.C) {
-	cfg, err := getRemoteConfig(s.readFile, s.runCommand, s.spec)
+	cfg, err := getRemoteConfig(s.spec)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg, jc.DeepEquals, &lxdclient.Config{
 		Remote: lxdclient.Remote{
@@ -43,64 +49,11 @@ func (s *environRawSuite) TestGetRemoteConfig(c *gc.C) {
 			Host:     "10.0.8.1",
 			Protocol: "lxd",
 			Cert: &lxdclient.Cert{
-				CertPEM: []byte("content:/etc/juju/lxd-client.crt"),
-				KeyPEM:  []byte("content:/etc/juju/lxd-client.key"),
+				Name:    "juju",
+				CertPEM: []byte("client.crt"),
+				KeyPEM:  []byte("client.key"),
 			},
-			ServerPEMCert: "content:/etc/juju/lxd-server.crt",
-		},
-	})
-	s.Stub.CheckCalls(c, []testing.StubCall{
-		{"readFile", []interface{}{"/etc/juju/lxd-client.crt"}},
-		{"readFile", []interface{}{"/etc/juju/lxd-client.key"}},
-		{"readFile", []interface{}{"/etc/juju/lxd-server.crt"}},
-		{"runCommand", []interface{}{"ip", []string{"route", "list", "match", "0/0"}}},
-	})
-}
-
-func (s *environRawSuite) TestGetRemoteConfigFileNotExist(c *gc.C) {
-	s.SetErrors(os.ErrNotExist)
-	_, err := getRemoteConfig(s.readFile, s.runCommand, s.spec)
-	// os.IsNotExist is translated to errors.IsNotFound
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Assert(err, gc.ErrorMatches, "reading client certificate: /etc/juju/lxd-client.crt not found")
-}
-
-func (s *environRawSuite) TestGetRemoteConfigFileError(c *gc.C) {
-	s.SetErrors(nil, errors.New("i/o error"))
-	_, err := getRemoteConfig(s.readFile, s.runCommand, s.spec)
-	c.Assert(err, gc.ErrorMatches, "reading client key: i/o error")
-}
-
-func (s *environRawSuite) TestGetRemoteConfigIPRouteFormatError(c *gc.C) {
-	s.runCommand = func(string, ...string) (string, error) {
-		return "this is not the prefix you're looking for", nil
-	}
-	_, err := getRemoteConfig(s.readFile, s.runCommand, s.spec)
-	c.Assert(err, gc.ErrorMatches,
-		`getting gateway address: unexpected output from "ip route": this is not the prefix you're looking for`)
-}
-
-func (s *environRawSuite) TestGetRemoteConfigIPRouteCommandError(c *gc.C) {
-	s.SetErrors(nil, nil, nil, errors.New("buh bow"))
-	_, err := getRemoteConfig(s.readFile, s.runCommand, s.spec)
-	c.Assert(err, gc.ErrorMatches, `getting gateway address: buh bow`)
-}
-
-func (s *environRawSuite) TestGetRemoteConfigWithEndpoint(c *gc.C) {
-	spec := s.spec
-	spec.Endpoint = "1.2.3.4"
-	cfg, err := getRemoteConfig(s.readFile, s.runCommand, spec)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg, jc.DeepEquals, &lxdclient.Config{
-		Remote: lxdclient.Remote{
-			Name:     "remote",
-			Host:     "1.2.3.4",
-			Protocol: "lxd",
-			Cert: &lxdclient.Cert{
-				CertPEM: []byte("content:/etc/juju/lxd-client.crt"),
-				KeyPEM:  []byte("content:/etc/juju/lxd-client.key"),
-			},
-			ServerPEMCert: "content:/etc/juju/lxd-server.crt",
+			ServerPEMCert: "server.crt",
 		},
 	})
 }

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -6,6 +6,7 @@
 package lxd_test
 
 import (
+	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -32,9 +33,7 @@ func (s *environSuite) TestName(c *gc.C) {
 }
 
 func (s *environSuite) TestProvider(c *gc.C) {
-	provider := s.Env.Provider()
-
-	c.Check(provider, gc.Equals, lxd.Provider)
+	c.Assert(s.Env.Provider(), gc.Equals, s.Provider)
 }
 
 func (s *environSuite) TestSetConfigOkay(c *gc.C) {
@@ -81,6 +80,54 @@ func (s *environSuite) TestBootstrapOkay(c *gc.C) {
 }
 
 func (s *environSuite) TestBootstrapAPI(c *gc.C) {
+	ctx := envtesting.BootstrapContext(c)
+	params := environs.BootstrapParams{
+		ControllerConfig: coretesting.FakeControllerConfig(),
+	}
+	_, err := s.Env.Bootstrap(ctx, params)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, fingerprint := s.TestingCert(c)
+	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "CertByFingerprint",
+		Args: []interface{}{
+			fingerprint,
+		},
+	}, {
+		FuncName: "Bootstrap",
+		Args: []interface{}{
+			ctx,
+			params,
+		},
+	}})
+}
+
+func (s *environSuite) TestBootstrapAddsCertLocal(c *gc.C) {
+	s.Stub.SetErrors(errors.NotFoundf("cert"), errors.New("upload fails"))
+	ctx := envtesting.BootstrapContext(c)
+	params := environs.BootstrapParams{
+		ControllerConfig: coretesting.FakeControllerConfig(),
+	}
+	_, err := s.Env.Bootstrap(ctx, params)
+	c.Assert(err, gc.ErrorMatches, `adding certificate "juju": upload fails`)
+
+	cert, fingerprint := s.TestingCert(c)
+	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "CertByFingerprint",
+		Args: []interface{}{
+			fingerprint,
+		},
+	}, {
+		FuncName: "AddCert",
+		Args: []interface{}{
+			cert,
+		},
+	}})
+}
+
+func (s *environSuite) TestBootstrapAddsCertNonLocal(c *gc.C) {
+	// non-local never attempts to upload the cert
+	s.SetEnvironLocal(false)
 	ctx := envtesting.BootstrapContext(c)
 	params := environs.BootstrapParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
@@ -143,13 +190,28 @@ func (s *environSuite) TestDestroyHostedModels(c *gc.C) {
 	err := s.Env.DestroyController(s.Config.UUID())
 	c.Assert(err, jc.ErrorIsNil)
 
+	_, fingerprint := s.TestingCert(c)
 	fwname := common.EnvFullName(s.Env.Config().UUID())
 	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
 		{"Ports", []interface{}{fwname}},
 		{"Destroy", nil},
 		{"Instances", []interface{}{"juju-", lxdclient.AliveStatuses}},
-		{"Instances", []interface{}{"juju-", []string{}}},
 		{"RemoveInstances", []interface{}{"juju-", []string{machine1.Name}}},
+		{"RemoveCertByFingerprint", []interface{}{fingerprint}},
+	})
+}
+
+func (s *environSuite) TestDestroyControllerNonLocal(c *gc.C) {
+	// non-local never attempts to remove the cert
+	s.SetEnvironLocal(false)
+	err := s.Env.DestroyController(s.Config.UUID())
+	c.Assert(err, jc.ErrorIsNil)
+
+	fwname := common.EnvFullName(s.Env.Config().UUID())
+	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+		{"Ports", []interface{}{fwname}},
+		{"Destroy", nil},
+		{"Instances", []interface{}{"juju-", lxdclient.AliveStatuses}},
 	})
 }
 

--- a/provider/lxd/export_test.go
+++ b/provider/lxd/export_test.go
@@ -5,15 +5,11 @@
 
 package lxd
 
-import (
-	"github.com/juju/juju/environs"
-	"github.com/juju/juju/tools/lxdclient"
-)
+import "github.com/juju/juju/tools/lxdclient"
 
 var (
-	Provider           environs.EnvironProvider = providerInstance
-	GlobalFirewallName                          = (*environ).globalFirewallName
-	NewInstance                                 = newInstance
+	GlobalFirewallName = (*environ).globalFirewallName
+	NewInstance        = newInstance
 )
 
 func ExposeInstRaw(inst *environInstance) *lxdclient.Instance {

--- a/provider/lxd/init.go
+++ b/provider/lxd/init.go
@@ -11,5 +11,5 @@ import (
 )
 
 func init() {
-	environs.RegisterProvider(lxdnames.ProviderType, providerInstance)
+	environs.RegisterProvider(lxdnames.ProviderType, NewProvider())
 }

--- a/provider/lxd/lxd.go
+++ b/provider/lxd/lxd.go
@@ -13,8 +13,7 @@ import (
 
 // The metadata keys used when creating new instances.
 const (
-	metadataKeyCloudInit              = lxdclient.UserdataKey
-	metadataKeyCertificateFingerprint = lxdclient.CertificateFingerprintKey
+	metadataKeyCloudInit = lxdclient.UserdataKey
 )
 
 var (

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -49,59 +49,51 @@ type providerSuite struct {
 
 func (s *providerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-
-	provider, err := environs.Provider("lxd")
-	c.Assert(err, jc.ErrorIsNil)
-	s.provider = provider
 }
 
 func (s *providerSuite) TestDetectClouds(c *gc.C) {
-	c.Assert(s.provider, gc.Implements, new(environs.CloudDetector))
-	clouds, err := s.provider.(environs.CloudDetector).DetectClouds()
+	clouds, err := s.Provider.DetectClouds()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(clouds, gc.HasLen, 1)
 	s.assertLocalhostCloud(c, clouds[0])
 }
 
 func (s *providerSuite) TestDetectCloud(c *gc.C) {
-	detector := s.provider.(environs.CloudDetector)
-	cloud, err := detector.DetectCloud("localhost")
+	cloud, err := s.Provider.DetectCloud("localhost")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertLocalhostCloud(c, cloud)
-	cloud, err = detector.DetectCloud("lxd")
+	cloud, err = s.Provider.DetectCloud("lxd")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertLocalhostCloud(c, cloud)
 }
 
 func (s *providerSuite) TestDetectCloudError(c *gc.C) {
-	detector := s.provider.(environs.CloudDetector)
-	_, err := detector.DetectCloud("foo")
+	_, err := s.Provider.DetectCloud("foo")
 	c.Assert(err, gc.ErrorMatches, `cloud foo not found`)
 }
 
 func (s *providerSuite) assertLocalhostCloud(c *gc.C, found cloud.Cloud) {
 	c.Assert(found, jc.DeepEquals, cloud.Cloud{
-		Name:        "localhost",
-		Type:        "lxd",
-		AuthTypes:   []cloud.AuthType{cloud.EmptyAuthType},
-		Regions:     []cloud.Region{{Name: "localhost"}},
+		Name:      "localhost",
+		Type:      "lxd",
+		AuthTypes: []cloud.AuthType{cloud.CertificateAuthType},
+		Endpoint:  "1.2.3.4",
+		Regions: []cloud.Region{{
+			Name:     "localhost",
+			Endpoint: "1.2.3.4",
+		}},
 		Description: "LXD Container Hypervisor",
 	})
 }
 
 func (s *providerSuite) TestDetectRegions(c *gc.C) {
-	c.Assert(s.provider, gc.Implements, new(environs.CloudRegionDetector))
-	regions, err := s.provider.(environs.CloudRegionDetector).DetectRegions()
+	regions, err := s.Provider.DetectRegions()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(regions, jc.DeepEquals, []cloud.Region{{Name: lxdnames.DefaultRegion}})
 }
 
-func (s *providerSuite) TestRegistered(c *gc.C) {
-	c.Check(s.provider, gc.Equals, lxd.Provider)
-}
-
 func (s *providerSuite) TestValidate(c *gc.C) {
-	validCfg, err := s.provider.Validate(s.Config, nil)
+	validCfg, err := s.Provider.Validate(s.Config, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	validAttrs := validCfg.AllAttrs()
 
@@ -151,7 +143,7 @@ func (s *ProviderFunctionalSuite) TestPrepareConfig(c *gc.C) {
 }
 
 func (s *ProviderFunctionalSuite) TestPrepareConfigUnsupportedAuthType(c *gc.C) {
-	cred := cloud.NewCredential(cloud.CertificateAuthType, nil)
+	cred := cloud.NewCredential("foo", nil)
 	_, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
 		Cloud: environs.CloudSpec{
 			Type:       "lxd",
@@ -159,5 +151,30 @@ func (s *ProviderFunctionalSuite) TestPrepareConfigUnsupportedAuthType(c *gc.C) 
 			Credential: &cred,
 		},
 	})
-	c.Assert(err, gc.ErrorMatches, `validating cloud spec: "certificate" auth-type not supported`)
+	c.Assert(err, gc.ErrorMatches, `validating cloud spec: "foo" auth-type not supported`)
+}
+
+func (s *ProviderFunctionalSuite) TestPrepareConfigInvalidCertificateAttrs(c *gc.C) {
+	cred := cloud.NewCredential(cloud.CertificateAuthType, map[string]string{})
+	_, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
+		Cloud: environs.CloudSpec{
+			Type:       "lxd",
+			Name:       "remotehost",
+			Credential: &cred,
+		},
+	})
+	c.Assert(err, gc.ErrorMatches, `validating cloud spec: certificate credentials not valid`)
+}
+
+func (s *ProviderFunctionalSuite) TestPrepareConfigEmptyAuthNonLocal(c *gc.C) {
+	cred := cloud.NewEmptyCredential()
+	_, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
+		Cloud: environs.CloudSpec{
+			Type:       "lxd",
+			Name:       "remotehost",
+			Endpoint:   "8.8.8.8",
+			Credential: &cred,
+		},
+	})
+	c.Assert(err, gc.ErrorMatches, `validating cloud spec: "empty" auth-type for non-local LXD not supported`)
 }

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -6,6 +6,7 @@
 package lxd
 
 import (
+	"net"
 	"os"
 
 	"github.com/juju/errors"
@@ -15,6 +16,7 @@ import (
 	"github.com/lxc/lxd/shared"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cloudconfig/providerinit"
 	"github.com/juju/juju/constraints"
@@ -93,6 +95,7 @@ type BaseSuiteUnpatched struct {
 
 	Config    *config.Config
 	EnvConfig *environConfig
+	Provider  *environProvider
 	Env       *environ
 
 	Addresses     []network.Address
@@ -104,6 +107,9 @@ type BaseSuiteUnpatched struct {
 	Metadata      map[string]string
 	StartInstArgs environs.StartInstanceParams
 	//InstanceType  instances.InstanceType
+
+	EndpointAddrs  []string
+	InterfaceAddrs []net.Addr
 
 	Rules []network.IngressRule
 }
@@ -124,17 +130,43 @@ func (s *BaseSuiteUnpatched) SetUpSuite(c *gc.C) {
 func (s *BaseSuiteUnpatched) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 
+	s.initProvider(c)
 	s.initEnv(c)
 	s.initInst(c)
 	s.initNet(c)
 }
 
+func (s *BaseSuiteUnpatched) initProvider(c *gc.C) {
+	s.Provider = &environProvider{}
+	s.EndpointAddrs = []string{"1.2.3.4"}
+	s.InterfaceAddrs = []net.Addr{
+		&net.IPNet{IP: net.ParseIP("127.0.0.1")},
+		&net.IPNet{IP: net.ParseIP("1.2.3.4")},
+	}
+}
+
 func (s *BaseSuiteUnpatched) initEnv(c *gc.C) {
+	certCred := cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
+		"client-cert": testing.CACert,
+		"client-key":  testing.CAKey,
+		"server-cert": testing.ServerCert,
+	})
 	s.Env = &environ{
-		name: "lxd",
+		local: true,
+		cloud: environs.CloudSpec{
+			Name:       "localhost",
+			Type:       "lxd",
+			Credential: &certCred,
+		},
+		provider: s.Provider,
+		name:     "lxd",
 	}
 	cfg := s.NewConfig(c, nil)
 	s.setConfig(c, cfg)
+}
+
+func (s *BaseSuiteUnpatched) SetEnvironLocal(local bool) {
+	s.Env.local = local
 }
 
 func (s *BaseSuiteUnpatched) Prefix() string {
@@ -303,14 +335,53 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.Common = &stubCommon{stub: s.Stub}
 
 	// Patch out all expensive external deps.
-	s.Env.raw = &rawProvider{
+	raw := &rawProvider{
 		lxdCerts:     s.Client,
 		lxdConfig:    s.Client,
 		lxdInstances: s.Client,
+		lxdProfiles:  s.Client,
 		lxdImages:    s.Client,
 		Firewaller:   s.Firewaller,
+		remote: lxdclient.Remote{
+			Cert: &lxdclient.Cert{
+				Name:    "juju",
+				CertPEM: []byte(testing.CACert),
+				KeyPEM:  []byte(testing.CAKey),
+			},
+		},
+	}
+	s.Env.raw = raw
+	s.Provider.generateMemCert = func(client bool) (cert, key []byte, _ error) {
+		s.Stub.AddCall("GenerateMemCert", client)
+		return []byte("client.crt"), []byte("client.key"), s.Stub.NextErr()
+	}
+	s.Provider.newLocalRawProvider = func() (*rawProvider, error) {
+		return raw, nil
+	}
+	s.Provider.lookupHost = func(host string) ([]string, error) {
+		s.Stub.AddCall("LookupHost", host)
+		return s.EndpointAddrs, s.Stub.NextErr()
+	}
+	s.Provider.interfaceAddress = func(iface string) (string, error) {
+		s.Stub.AddCall("InterfaceAddress", iface)
+		return "1.2.3.4", s.Stub.NextErr()
+	}
+	s.Provider.interfaceAddrs = func() ([]net.Addr, error) {
+		s.Stub.AddCall("InterfaceAddrs")
+		return s.InterfaceAddrs, s.Stub.NextErr()
 	}
 	s.Env.base = s.Common
+}
+
+func (s *BaseSuite) TestingCert(c *gc.C) (lxdclient.Cert, string) {
+	cert := lxdclient.Cert{
+		Name:    "juju",
+		CertPEM: []byte(testing.CACert),
+		KeyPEM:  []byte(testing.CAKey),
+	}
+	fingerprint, err := cert.Fingerprint()
+	c.Assert(err, jc.ErrorIsNil)
+	return cert, fingerprint
 }
 
 func (s *BaseSuite) CheckNoAPI(c *gc.C) {
@@ -466,6 +537,11 @@ func (conn *StubClient) RemoveCertByFingerprint(fingerprint string) error {
 	return conn.NextErr()
 }
 
+func (conn *StubClient) CertByFingerprint(fingerprint string) (shared.CertInfo, error) {
+	conn.AddCall("CertByFingerprint", fingerprint)
+	return shared.CertInfo{}, conn.NextErr()
+}
+
 func (conn *StubClient) ServerStatus() (*shared.ServerState, error) {
 	conn.AddCall("ServerStatus")
 	if err := conn.NextErr(); err != nil {
@@ -481,6 +557,21 @@ func (conn *StubClient) ServerStatus() (*shared.ServerState, error) {
 func (conn *StubClient) SetConfig(k, v string) error {
 	conn.AddCall("SetConfig", k, v)
 	return conn.NextErr()
+}
+
+func (conn *StubClient) DefaultProfileBridgeName() string {
+	conn.AddCall("DefaultProfileBridgeName")
+	return "test-bridge"
+}
+
+func (conn *StubClient) CreateProfile(name string, attrs map[string]string) error {
+	conn.AddCall("CreateProfile", name, attrs)
+	return conn.NextErr()
+}
+
+func (conn *StubClient) HasProfile(name string) (bool, error) {
+	conn.AddCall("HasProfile", name)
+	return false, conn.NextErr()
 }
 
 // TODO(ericsnow) Move stubFirewaller to environs/testing or provider/common/testing.

--- a/provider/lxd/upgrades.go
+++ b/provider/lxd/upgrades.go
@@ -1,0 +1,59 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build go1.3
+
+package lxd
+
+import (
+	"os"
+	"path"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/series"
+
+	"github.com/juju/juju/cloud"
+	jujupaths "github.com/juju/juju/juju/paths"
+)
+
+// ReadLegacyCloudCredentials reads cloud credentials off disk for an old
+// LXD controller, and returns them as a cloud.Credential with the
+// certificate auth-type.
+//
+// If the credential files are missing from the filesystem, an error
+// satisfying errors.IsNotFound will be returned.
+func ReadLegacyCloudCredentials(readFile func(string) ([]byte, error)) (cloud.Credential, error) {
+	var (
+		jujuConfDir    = jujupaths.MustSucceed(jujupaths.ConfDir(series.LatestLts()))
+		clientCertPath = path.Join(jujuConfDir, "lxd-client.crt")
+		clientKeyPath  = path.Join(jujuConfDir, "lxd-client.key")
+		serverCertPath = path.Join(jujuConfDir, "lxd-server.crt")
+	)
+	readFileString := func(path string) (string, error) {
+		data, err := readFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				err = errors.NotFoundf("%s", path)
+			}
+			return "", err
+		}
+		return string(data), nil
+	}
+	clientCert, err := readFileString(clientCertPath)
+	if err != nil {
+		return cloud.Credential{}, errors.Annotate(err, "reading client certificate")
+	}
+	clientKey, err := readFileString(clientKeyPath)
+	if err != nil {
+		return cloud.Credential{}, errors.Annotate(err, "reading client key")
+	}
+	serverCert, err := readFileString(serverCertPath)
+	if err != nil {
+		return cloud.Credential{}, errors.Annotate(err, "reading server certificate")
+	}
+	return cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
+		credAttrServerCert: serverCert,
+		credAttrClientCert: clientCert,
+		credAttrClientKey:  clientKey,
+	}), nil
+}

--- a/provider/lxd/upgrades_test.go
+++ b/provider/lxd/upgrades_test.go
@@ -1,0 +1,52 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build go1.3
+
+package lxd_test
+
+import (
+	"os"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/provider/lxd"
+)
+
+type upgradesSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&upgradesSuite{})
+
+func (s *upgradesSuite) TestReadLegacyCloudCredentials(c *gc.C) {
+	var paths []string
+	readFile := func(path string) ([]byte, error) {
+		paths = append(paths, path)
+		return []byte("content: " + path), nil
+	}
+	cred, err := lxd.ReadLegacyCloudCredentials(readFile)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cred, jc.DeepEquals, cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
+		"client-cert": "content: /etc/juju/lxd-client.crt",
+		"client-key":  "content: /etc/juju/lxd-client.key",
+		"server-cert": "content: /etc/juju/lxd-server.crt",
+	}))
+	c.Assert(paths, jc.DeepEquals, []string{
+		"/etc/juju/lxd-client.crt",
+		"/etc/juju/lxd-client.key",
+		"/etc/juju/lxd-server.crt",
+	})
+}
+
+func (s *upgradesSuite) TestReadLegacyCloudCredentialsFileNotExist(c *gc.C) {
+	readFile := func(path string) ([]byte, error) {
+		return nil, os.ErrNotExist
+	}
+	_, err := lxd.ReadLegacyCloudCredentials(readFile)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}

--- a/state/cloud.go
+++ b/state/cloud.go
@@ -88,6 +88,7 @@ func (d cloudDoc) toCloud() cloud.Cloud {
 		}
 	}
 	return cloud.Cloud{
+		Name:             d.Name,
 		Type:             d.Type,
 		AuthTypes:        authTypes,
 		Endpoint:         d.Endpoint,
@@ -149,6 +150,9 @@ func (st *State) AddCloud(name string, c cloud.Cloud) error {
 
 // validateCloud checks that the supplied cloud is valid.
 func validateCloud(cloud cloud.Cloud) error {
+	if cloud.Name == "" {
+		return errors.NotValidf("empty Name")
+	}
 	if cloud.Type == "" {
 		return errors.NotValidf("empty Type")
 	}

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -72,6 +72,7 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 		},
 		CloudName: "dummy",
 		Cloud: cloud.Cloud{
+			Name:      "dummy",
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 			Regions: []cloud.Region{

--- a/tools/lxdclient/client_cert.go
+++ b/tools/lxdclient/client_cert.go
@@ -48,3 +48,19 @@ func (c certClient) RemoveCertByFingerprint(fingerprint string) error {
 	}
 	return nil
 }
+
+// CertByFingerprint returns information about a certificate with the
+// matching fingerprint. If there is no such certificate, an errors
+// satisfying errors.IsNotFound is returned.
+func (c certClient) CertByFingerprint(fingerprint string) (shared.CertInfo, error) {
+	certs, err := c.raw.CertificateList()
+	if err != nil {
+		return shared.CertInfo{}, errors.Trace(err)
+	}
+	for _, cert := range certs {
+		if cert.Fingerprint == fingerprint {
+			return cert, nil
+		}
+	}
+	return shared.CertInfo{}, errors.NotFoundf("certificate with fingerprint %q", fingerprint)
+}

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -5,6 +5,7 @@ package upgrades
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
@@ -19,6 +20,7 @@ type StateBackend interface {
 	RenameAddModelPermission() error
 	DropOldLogIndex() error
 	AddMigrationAttempt() error
+	UpdateLegacyLXDCloudCredentials(string, cloud.Credential) error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -63,6 +65,10 @@ func (s stateBackend) DropOldLogIndex() error {
 
 func (s stateBackend) AddMigrationAttempt() error {
 	return state.AddMigrationAttempt(s.st)
+}
+
+func (s stateBackend) UpdateLegacyLXDCloudCredentials(endpoint string, cred cloud.Credential) error {
+	return state.UpdateLegacyLXDCloudCredentials(s.st, endpoint, cred)
 }
 
 type modelShim struct {

--- a/upgrades/lxd.go
+++ b/upgrades/lxd.go
@@ -1,0 +1,44 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build go1.3
+
+package upgrades
+
+import (
+	"io/ioutil"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+
+	"github.com/juju/juju/provider/lxd"
+)
+
+func updateLXDCloudCredentials(st StateBackend) error {
+	creds, err := lxd.ReadLegacyCloudCredentials(ioutil.ReadFile)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Not running a LXD controller.
+			return nil
+		}
+		return errors.Annotate(err, "reading credentials from disk")
+	}
+	gatewayAddress, err := getDefaultGateway()
+	if err != nil {
+		return errors.Annotate(err, "reading gateway address")
+	}
+	return st.UpdateLegacyLXDCloudCredentials(gatewayAddress, creds)
+}
+
+func getDefaultGateway() (string, error) {
+	out, err := utils.RunCommand("ip", "route", "list", "match", "0/0")
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if !strings.HasPrefix(string(out), "default via") {
+		return "", errors.Errorf(`unexpected output from "ip route": %s`, out)
+	}
+	fields := strings.Fields(string(out))
+	return fields[2], nil
+}

--- a/upgrades/lxd_go12.go
+++ b/upgrades/lxd_go12.go
@@ -1,0 +1,13 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build !go1.3
+
+package upgrades
+
+func updateLXDCloudCredentials(st StateBackend) error {
+	// The LXD provider is compiled out when Juju is
+	// built with Go 1.2 or earlier, so there is nothing
+	// to do.
+	return nil
+}

--- a/upgrades/steps_21.go
+++ b/upgrades/steps_21.go
@@ -20,5 +20,12 @@ func stateStepsFor21() []Step {
 				return context.State().AddMigrationAttempt()
 			},
 		},
+		&upgradeStep{
+			description: "update lxd cloud/credentials",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return updateLXDCloudCredentials(context.State())
+			},
+		},
 	}
 }


### PR DESCRIPTION
## Description of change

We change the way the LXD provider conveys the
host address and credentials to the controller, by
using the existing environs.CloudSpec structure.

The lxd provider now reports a "localhost" cloud
with the endpoint filled in, equal to the address of
the LXD host on the LXD bridge interface.

An upgrade step is added that rewrites the cloud
and credential definitions in the state database.

Requires https://github.com/juju/juju/pull/6878

## QA steps

Scenario 1: fresh bootstrap (with standard lxdbr0)
1. juju bootstrap localhost
2. juju add-user billie
3. juju grant billie add-model
(as billie below)
4. juju register ...
5. juju add-model foo

Scenario 2: same as above, but with custom bridge to physical network

Scenario 3: upgrade from 2.0 (with standard lxdbr0)
1. juju bootstrap localhost (using juju 2.0)
2. juju upgrade-juju (using this branch)
3. juju add-model foo

## Documentation changes

Without further changes (this is still WIP), any users that have entered a custom "lxd" entry in ~/.local/share/juju/clouds.yaml will have to modify the file before they can use it, adding the endpoint field to point at the LXD bridge address of the host.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1633788