### PR TITLE
Revert restarting mongo

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -222,7 +222,8 @@ func InstallAndStart(svc ServiceActions) error {
 		if err != nil {
 			logger.Errorf("retrying start request (%v)", errors.Cause(err))
 		}
-		if err = restartOrStart(svc); err == nil {
+
+		if err = svc.Start(); err == nil {
 			break
 		}
 	}
@@ -246,26 +247,6 @@ func Restart(name string) error {
 		return errors.Annotatef(err, "failed to restart service %q", name)
 	}
 	return nil
-}
-
-func restartOrStart(svc ServiceActions) error {
-	// Use the Restart method, if there is one.
-	if svc, ok := svc.(RestartableService); ok {
-		if err := svc.Restart(); err != nil {
-			return errors.Trace(err)
-		}
-		return nil
-	}
-
-	// Otherwise explicitly stop and start the service.
-	if err := svc.Stop(); err != nil {
-		logger.Errorf("could not stop service: %v", err)
-	}
-	if err := svc.Start(); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
-
 }
 
 func restart(svc Service) error {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -104,7 +104,7 @@ func (s *serviceSuite) TestInstallAndStartOkay(c *gc.C) {
 	err := service.InstallAndStart(s.Service)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.Service.CheckCallNames(c, "Install", "Stop", "Start")
+	s.Service.CheckCallNames(c, "Install", "Start")
 }
 
 func (s *serviceSuite) TestInstallAndStartRetry(c *gc.C) {
@@ -114,17 +114,17 @@ func (s *serviceSuite) TestInstallAndStartRetry(c *gc.C) {
 	err := service.InstallAndStart(s.Service)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.Service.CheckCallNames(c, "Install", "Stop", "Start", "Stop", "Start")
+	s.Service.CheckCallNames(c, "Install", "Start", "Start", "Start")
 }
 
 func (s *serviceSuite) TestInstallAndStartFail(c *gc.C) {
 	s.PatchAttempts(3)
-	s.Service.SetErrors(nil, s.Failure, s.Failure, s.Failure, s.Failure, s.Failure, s.Failure)
+	s.Service.SetErrors(nil, s.Failure, s.Failure, s.Failure)
 
 	err := service.InstallAndStart(s.Service)
 
 	s.CheckFailure(c, err)
-	s.Service.CheckCallNames(c, "Install", "Stop", "Start", "Stop", "Start", "Stop", "Start")
+	s.Service.CheckCallNames(c, "Install", "Start", "Start", "Start")
 }
 
 type restartSuite struct {


### PR DESCRIPTION
## Description of change

The patch this is reverting broke trusty deployments

## QA steps

Bootstrap on trusty

## Bug reference

https://bugs.launchpad.net/juju/+bug/1659866
