### PR TITLE
Ensure cloud.Name is set and used everywhere

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -98,7 +98,7 @@ func InitializeState(
 	if args.ControllerCloudCredential != nil && args.ControllerCloudCredentialName != "" {
 		cloudCredentialTag = names.NewCloudCredentialTag(fmt.Sprintf(
 			"%s/%s/%s",
-			args.ControllerCloudName,
+			args.ControllerCloud.Name,
 			adminUser.Id(),
 			args.ControllerCloudCredentialName,
 		))
@@ -112,12 +112,11 @@ func InitializeState(
 			Owner:                   adminUser,
 			Config:                  args.ControllerModelConfig,
 			Constraints:             args.ModelConstraints,
-			CloudName:               args.ControllerCloudName,
+			CloudName:               args.ControllerCloud.Name,
 			CloudRegion:             args.ControllerCloudRegion,
 			CloudCredential:         cloudCredentialTag,
 			StorageProviderRegistry: args.StorageProviderRegistry,
 		},
-		CloudName:                 args.ControllerCloudName,
 		Cloud:                     args.ControllerCloud,
 		CloudCredentials:          cloudCredentials,
 		ControllerConfig:          args.ControllerConfig,
@@ -167,7 +166,6 @@ func InitializeState(
 	// Construct a CloudSpec to pass on to NewModelConfig below.
 	cloudSpec, err := environs.MakeCloudSpec(
 		args.ControllerCloud,
-		args.ControllerCloudName,
 		args.ControllerCloudRegion,
 		args.ControllerCloudCredential,
 	)
@@ -204,7 +202,7 @@ func InitializeState(
 		Owner:                   adminUser,
 		Config:                  hostedModelConfig,
 		Constraints:             args.ModelConstraints,
-		CloudName:               args.ControllerCloudName,
+		CloudName:               args.ControllerCloud.Name,
 		CloudRegion:             args.ControllerCloudRegion,
 		CloudCredential:         cloudCredentialTag,
 		StorageProviderRegistry: args.StorageProviderRegistry,

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -167,12 +167,12 @@ LXC_BRIDGE="ignored"`[1:])
 			BootstrapMachineInstanceId:              "i-bootstrap",
 			BootstrapMachineHardwareCharacteristics: &expectHW,
 			ControllerCloud: cloud.Cloud{
+				Name:         "dummy",
 				Type:         "dummy",
 				AuthTypes:    []cloud.AuthType{cloud.EmptyAuthType},
 				Regions:      []cloud.Region{{Name: "dummy-region"}},
 				RegionConfig: regionConfig,
 			},
-			ControllerCloudName:       "dummy",
 			ControllerCloudRegion:     "dummy-region",
 			ControllerConfig:          controllerCfg,
 			ControllerModelConfig:     modelCfg,
@@ -395,10 +395,10 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 		StateInitializationParams: instancecfg.StateInitializationParams{
 			BootstrapMachineInstanceId: "i-bootstrap",
 			ControllerCloud: cloud.Cloud{
+				Name:      "dummy",
 				Type:      "dummy",
 				AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 			},
-			ControllerCloudName:   "dummy",
 			ControllerConfig:      testing.FakeControllerConfig(),
 			ControllerModelConfig: modelCfg,
 			HostedModelConfig:     hostedModelConfigAttrs,

--- a/api/cloud/cloud.go
+++ b/api/cloud/cloud.go
@@ -38,7 +38,7 @@ func (c *Client) Clouds() (map[names.CloudTag]jujucloud.Cloud, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		clouds[tag] = cloudFromParams(cloud)
+		clouds[tag] = cloudFromParams(tag.Id(), cloud)
 	}
 	return clouds, nil
 }
@@ -56,10 +56,10 @@ func (c *Client) Cloud(tag names.CloudTag) (jujucloud.Cloud, error) {
 	if results.Results[0].Error != nil {
 		return jujucloud.Cloud{}, results.Results[0].Error
 	}
-	return cloudFromParams(*results.Results[0].Cloud), nil
+	return cloudFromParams(tag.Id(), *results.Results[0].Cloud), nil
 }
 
-func cloudFromParams(p params.Cloud) jujucloud.Cloud {
+func cloudFromParams(cloudName string, p params.Cloud) jujucloud.Cloud {
 	authTypes := make([]jujucloud.AuthType, len(p.AuthTypes))
 	for i, authType := range p.AuthTypes {
 		authTypes[i] = jujucloud.AuthType(authType)
@@ -74,6 +74,7 @@ func cloudFromParams(p params.Cloud) jujucloud.Cloud {
 		}
 	}
 	return jujucloud.Cloud{
+		Name:             cloudName,
 		Type:             p.Type,
 		AuthTypes:        authTypes,
 		Endpoint:         p.Endpoint,

--- a/api/cloud/cloud_test.go
+++ b/api/cloud/cloud_test.go
@@ -51,6 +51,7 @@ func (s *cloudSuite) TestCloud(c *gc.C) {
 	result, err := client.Cloud(names.NewCloudTag("foo"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, cloud.Cloud{
+		Name:      "foo",
 		Type:      "dummy",
 		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
 		Regions:   []cloud.Region{{Name: "nether", Endpoint: "endpoint"}},
@@ -89,9 +90,11 @@ func (s *cloudSuite) TestClouds(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(clouds, jc.DeepEquals, map[names.CloudTag]cloud.Cloud{
 		names.NewCloudTag("foo"): {
+			Name: "foo",
 			Type: "bar",
 		},
 		names.NewCloudTag("baz"): {
+			Name:      "baz",
 			Type:      "qux",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
 			Regions:   []cloud.Region{{Name: "nether", Endpoint: "endpoint"}},

--- a/apiserver/cloud/cloud_test.go
+++ b/apiserver/cloud/cloud_test.go
@@ -34,6 +34,7 @@ func (s *cloudSuite) SetUpTest(c *gc.C) {
 	}
 	s.backend = mockBackend{
 		cloud: cloud.Cloud{
+			Name:      "dummy",
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
 			Regions:   []cloud.Region{{Name: "nether", Endpoint: "endpoint"}},

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -283,7 +283,7 @@ func (m *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Model
 		credential = &credentialValue
 	}
 
-	cloudSpec, err := environs.MakeCloudSpec(cloud, cloudTag.Id(), cloudRegionName, credential)
+	cloudSpec, err := environs.MakeCloudSpec(cloud, cloudRegionName, credential)
 	if err != nil {
 		return result, errors.Trace(err)
 	}

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -156,6 +156,7 @@ type cloudSet struct {
 
 // cloud is equivalent to Cloud, for marshalling and unmarshalling.
 type cloud struct {
+	Name             string                 `yaml:"name,omitempty"`
 	Type             string                 `yaml:"type"`
 	Description      string                 `yaml:"description,omitempty"`
 	AuthTypes        []AuthType             `yaml:"auth-types,omitempty,flow"`
@@ -359,7 +360,7 @@ func IsSameCloudMetadata(meta1, meta2 map[string]Cloud) (bool, error) {
 func marshalCloudMetadata(cloudsMap map[string]Cloud) ([]byte, error) {
 	clouds := cloudSet{make(map[string]*cloud)}
 	for name, metadata := range cloudsMap {
-		clouds.Clouds[name] = cloudToInternal(metadata)
+		clouds.Clouds[name] = cloudToInternal(metadata, false)
 	}
 	data, err := yaml.Marshal(clouds)
 	if err != nil {
@@ -370,7 +371,7 @@ func marshalCloudMetadata(cloudsMap map[string]Cloud) ([]byte, error) {
 
 // MarshalCloud marshals a Cloud to an opaque byte array.
 func MarshalCloud(cloud Cloud) ([]byte, error) {
-	return yaml.Marshal(cloudToInternal(cloud))
+	return yaml.Marshal(cloudToInternal(cloud, true))
 }
 
 // UnmarshalCloud unmarshals a Cloud from a byte array produced by MarshalCloud.
@@ -382,7 +383,7 @@ func UnmarshalCloud(in []byte) (Cloud, error) {
 	return cloudFromInternal(&internal), nil
 }
 
-func cloudToInternal(in Cloud) *cloud {
+func cloudToInternal(in Cloud, withName bool) *cloud {
 	var regions regions
 	for _, r := range in.Regions {
 		regions.Slice = append(regions.Slice, yaml.MapItem{
@@ -393,7 +394,12 @@ func cloudToInternal(in Cloud) *cloud {
 			},
 		})
 	}
+	name := in.Name
+	if !withName {
+		name = ""
+	}
 	return &cloud{
+		Name:             name,
 		Type:             in.Type,
 		AuthTypes:        in.AuthTypes,
 		Endpoint:         in.Endpoint,
@@ -426,6 +432,7 @@ func cloudFromInternal(in *cloud) Cloud {
 		}
 	}
 	meta := Cloud{
+		Name:             in.Name,
 		Type:             in.Type,
 		AuthTypes:        in.AuthTypes,
 		Endpoint:         in.Endpoint,

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -200,10 +200,6 @@ type StateInitializationParams struct {
 	// ControllerModelConfig holds the initial controller model configuration.
 	ControllerModelConfig *config.Config
 
-	// ControllerCloudName is the name of the cloud that Juju will be
-	// bootstrapped in.
-	ControllerCloudName string
-
 	// ControllerCloud contains the properties of the cloud that Juju will
 	// be bootstrapped in.
 	ControllerCloud cloud.Cloud
@@ -270,7 +266,6 @@ type stateInitializationParamsInternal struct {
 	BootstrapMachineHardwareCharacteristics *instance.HardwareCharacteristics `yaml:"bootstrap-machine-hardware,omitempty"`
 	ModelConstraints                        constraints.Value                 `yaml:"model-constraints"`
 	CustomImageMetadataJSON                 string                            `yaml:"custom-image-metadata,omitempty"`
-	ControllerCloudName                     string                            `yaml:"controller-cloud-name"`
 	ControllerCloud                         string                            `yaml:"controller-cloud"`
 	ControllerCloudRegion                   string                            `yaml:"controller-cloud-region"`
 	ControllerCloudCredentialName           string                            `yaml:"controller-cloud-credential-name,omitempty"`
@@ -298,7 +293,6 @@ func (p *StateInitializationParams) Marshal() ([]byte, error) {
 		p.BootstrapMachineHardwareCharacteristics,
 		p.ModelConstraints,
 		string(customImageMetadataJSON),
-		p.ControllerCloudName,
 		string(controllerCloud),
 		p.ControllerCloudRegion,
 		p.ControllerCloudCredentialName,
@@ -337,7 +331,6 @@ func (p *StateInitializationParams) Unmarshal(data []byte) error {
 		BootstrapMachineHardwareCharacteristics: internal.BootstrapMachineHardwareCharacteristics,
 		ModelConstraints:                        internal.ModelConstraints,
 		CustomImageMetadata:                     imageMetadata,
-		ControllerCloudName:                     internal.ControllerCloudName,
 		ControllerCloud:                         controllerCloud,
 		ControllerCloudRegion:                   internal.ControllerCloudRegion,
 		ControllerCloudCredentialName:           internal.ControllerCloudCredentialName,

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -255,6 +255,7 @@ func (c *restoreCommand) rebootstrap(ctx *cmd.Context, meta *params.BackupsMetad
 			authTypes = append(authTypes, authType)
 		}
 		cloudParam = &cloud.Cloud{
+			Name:      params.Cloud.Name,
 			Type:      params.Cloud.Type,
 			AuthTypes: authTypes,
 			Endpoint:  cloudEndpoint,
@@ -315,7 +316,6 @@ func (c *restoreCommand) rebootstrap(ctx *cmd.Context, meta *params.BackupsMetad
 	bootVers := version.Current
 	args := bootstrap.BootstrapParams{
 		Cloud:               *cloudParam,
-		CloudName:           params.Cloud.Name,
 		CloudRegion:         params.Cloud.Region,
 		CloudCredentialName: params.CredentialName,
 		CloudCredential:     params.Cloud.Credential,

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -281,6 +281,7 @@ func (s *restoreSuite) TestRestoreReboostrapBuiltInProvider(c *gc.C) {
 		boostrapped = true
 		sort.Sort(args.Cloud.AuthTypes)
 		c.Assert(args.Cloud, jc.DeepEquals, cloud.Cloud{
+			Name:      "lxd",
 			Type:      "lxd",
 			AuthTypes: []cloud.AuthType{"empty"},
 			Regions:   []cloud.Region{{Name: "localhost"}},

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -127,7 +127,7 @@ func (c *addCloudCommand) Run(ctxt *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	return addCloud(c.cloudMetadataStore, c.Cloud, newCloud)
+	return addCloud(c.cloudMetadataStore, newCloud)
 }
 
 func (c *addCloudCommand) runInteractive(ctxt *cmd.Context) error {
@@ -161,8 +161,9 @@ func (c *addCloudCommand) runInteractive(ctxt *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	newCloud.Name = name
 	newCloud.Type = cloudType
-	if err := addCloud(c.cloudMetadataStore, name, newCloud); err != nil {
+	if err := addCloud(c.cloudMetadataStore, newCloud); err != nil {
 		return errors.Trace(err)
 	}
 	ctxt.Infof("Cloud %q successfully added", name)
@@ -295,7 +296,7 @@ func nameExists(name string, public map[string]cloud.Cloud) string {
 	return ""
 }
 
-func addCloud(cloudMetadataStore CloudMetadataStore, name string, newCloud cloud.Cloud) error {
+func addCloud(cloudMetadataStore CloudMetadataStore, newCloud cloud.Cloud) error {
 	personalClouds, err := cloudMetadataStore.PersonalCloudMetadata()
 	if err != nil {
 		return err
@@ -303,6 +304,6 @@ func addCloud(cloudMetadataStore CloudMetadataStore, name string, newCloud cloud
 	if personalClouds == nil {
 		personalClouds = make(map[string]cloud.Cloud)
 	}
-	personalClouds[name] = newCloud
+	personalClouds[newCloud.Name] = newCloud
 	return cloudMetadataStore.WritePersonalCloudMetadata(personalClouds)
 }

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -68,6 +68,7 @@ func (s *addSuite) TestAddBadArgs(c *gc.C) {
 
 var (
 	homestackCloud = cloudfile.Cloud{
+		Name:      "homestack",
 		Type:      "openstack",
 		AuthTypes: []cloudfile.AuthType{"userpass", "access-key"},
 		Endpoint:  "http://homestack",
@@ -78,8 +79,12 @@ var (
 			},
 		},
 	}
-	localhostCloud = cloudfile.Cloud{Type: "lxd"}
-	awsCloud       = cloudfile.Cloud{
+	localhostCloud = cloudfile.Cloud{
+		Name: "localhost",
+		Type: "lxd",
+	}
+	awsCloud = cloudfile.Cloud{
+		Name:      "aws",
 		Type:      "ec2",
 		AuthTypes: []cloudfile.AuthType{"acccess-key"},
 		Regions: []cloudfile.Region{
@@ -90,12 +95,14 @@ var (
 		},
 	}
 	garageMAASCloud = cloudfile.Cloud{
+		Name:      "garage-maas",
 		Type:      "maas",
 		AuthTypes: []cloudfile.AuthType{"oauth"},
 		Endpoint:  "http://garagemaas",
 	}
 
 	manualCloud = cloudfile.Cloud{
+		Name:      "manual",
 		Type:      "manual",
 		AuthTypes: []cloudfile.AuthType{"manual"},
 		Endpoint:  "192.168.1.6",
@@ -236,6 +243,7 @@ func (*addSuite) TestInteractiveOpenstack(c *gc.C) {
 	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]cloudfile.Cloud{}, false, nil)
 	fake.Call("PersonalCloudMetadata").Returns(map[string]cloudfile.Cloud{}, nil)
 	myOpenstack := cloudfile.Cloud{
+		Name:      "os1",
 		Type:      "openstack",
 		AuthTypes: []cloudfile.AuthType{"userpass", "access-key"},
 		Endpoint:  "http://myopenstack",
@@ -291,7 +299,9 @@ func (*addSuite) TestInteractiveMaas(c *gc.C) {
 		"- oauth1\n" +
 		"endpoint: http://mymaas\n"
 	fake.Call("ParseOneCloud", []byte(expectedYAMLarg)).Returns(garageMAASCloud, nil)
-	m1Metadata := map[string]cloudfile.Cloud{"m1": garageMAASCloud}
+	m1Cloud := garageMAASCloud
+	m1Cloud.Name = "m1"
+	m1Metadata := map[string]cloudfile.Cloud{"m1": m1Cloud}
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", m1Metadata).Returns(nil)
 
 	command := cloud.NewAddCloudCommand(fake)
@@ -315,11 +325,13 @@ func (*addSuite) TestInteractiveMaas(c *gc.C) {
 }
 
 func (*addSuite) TestInteractiveManual(c *gc.C) {
+	manCloud := manualCloud
+	manCloud.Name = "man"
 	fake := newFakeCloudMetadataStore()
 	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]cloudfile.Cloud{}, false, nil)
 	fake.Call("PersonalCloudMetadata").Returns(map[string]cloudfile.Cloud{}, nil)
-	fake.Call("ParseOneCloud", []byte("endpoint: 192.168.1.6\n")).Returns(manualCloud, nil)
-	manMetadata := map[string]cloudfile.Cloud{"man": manualCloud}
+	fake.Call("ParseOneCloud", []byte("endpoint: 192.168.1.6\n")).Returns(manCloud, nil)
+	manMetadata := map[string]cloudfile.Cloud{"man": manCloud}
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", manMetadata).Returns(nil)
 
 	command := cloud.NewAddCloudCommand(fake)
@@ -347,6 +359,7 @@ func (*addSuite) TestInteractiveVSphere(c *gc.C) {
 	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]cloudfile.Cloud{}, false, nil)
 	fake.Call("PersonalCloudMetadata").Returns(map[string]cloudfile.Cloud{}, nil)
 	vsphereCloud := cloudfile.Cloud{
+		Name:      "mvs",
 		Type:      "vsphere",
 		AuthTypes: []cloudfile.AuthType{"userpass", "access-key"},
 		Endpoint:  "192.168.1.6",
@@ -397,6 +410,9 @@ func (*addSuite) TestInteractiveVSphere(c *gc.C) {
 }
 
 func (*addSuite) TestInteractiveExistingNameOverride(c *gc.C) {
+	manualCloud := manualCloud
+	manualCloud.Name = "homestack"
+
 	fake := newFakeCloudMetadataStore()
 	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]cloudfile.Cloud{}, false, nil)
 	fake.Call("PersonalCloudMetadata").Returns(homestackMetadata(), nil)
@@ -430,6 +446,7 @@ func (*addSuite) TestInteractiveExistingNameNoOverride(c *gc.C) {
 	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]cloudfile.Cloud{}, false, nil)
 	fake.Call("PersonalCloudMetadata").Returns(homestackMetadata(), nil)
 	homestack2Cloud := cloudfile.Cloud{
+		Name:     "homestack2",
 		Type:     "manual",
 		Endpoint: "192.168.1.6",
 	}

--- a/cmd/juju/cloud/updateclouds_internal_test.go
+++ b/cmd/juju/cloud/updateclouds_internal_test.go
@@ -82,7 +82,7 @@ var diffCloudsTests = []struct {
 	}, {
 		description: "added 1 cloud",
 		old:         map[string]jujucloud.Cloud{},
-		new:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{}},
+		new:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{Name: "one"}},
 		expected: `
 1 cloud added:
 
@@ -92,8 +92,8 @@ var diffCloudsTests = []struct {
 		description: "added 2 cloud",
 		old:         map[string]jujucloud.Cloud{},
 		new: map[string]jujucloud.Cloud{
-			"one": jujucloud.Cloud{},
-			"two": jujucloud.Cloud{},
+			"one": jujucloud.Cloud{Name: "one"},
+			"two": jujucloud.Cloud{Name: "two"},
 		},
 		expected: `
 2 clouds added:
@@ -103,7 +103,7 @@ var diffCloudsTests = []struct {
         - two`[1:],
 	}, {
 		description: "deleted 1 cloud",
-		old:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{}},
+		old:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{Name: "one"}},
 		new:         map[string]jujucloud.Cloud{},
 		expected: `
 1 cloud deleted:
@@ -113,8 +113,8 @@ var diffCloudsTests = []struct {
 	}, {
 		description: "deleted 2 cloud",
 		old: map[string]jujucloud.Cloud{
-			"one": jujucloud.Cloud{},
-			"two": jujucloud.Cloud{},
+			"one": jujucloud.Cloud{Name: "one"},
+			"two": jujucloud.Cloud{Name: "two"},
 		},
 		new: map[string]jujucloud.Cloud{},
 		expected: `
@@ -125,8 +125,13 @@ var diffCloudsTests = []struct {
         - two`[1:],
 	}, {
 		description: "cloud attributes change: endpoint",
-		old:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{}},
-		new:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{Endpoint: "old_endpoint"}},
+		old: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name: "one",
+		}},
+		new: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:     "one",
+			Endpoint: "old_endpoint",
+		}},
 		expected: `
 1 cloud attribute changed:
 
@@ -134,8 +139,13 @@ var diffCloudsTests = []struct {
         - one`[1:],
 	}, {
 		description: "cloud attributes change: identity endpoint",
-		old:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{}},
-		new:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{IdentityEndpoint: "old_endpoint"}},
+		old: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name: "one",
+		}},
+		new: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:             "one",
+			IdentityEndpoint: "old_endpoint"},
+		},
 		expected: `
 1 cloud attribute changed:
 
@@ -143,8 +153,13 @@ var diffCloudsTests = []struct {
         - one`[1:],
 	}, {
 		description: "cloud attributes change: storage endpoint",
-		old:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{}},
-		new:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{StorageEndpoint: "old_endpoint"}},
+		old: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name: "one",
+		}},
+		new: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:            "one",
+			StorageEndpoint: "old_endpoint"},
+		},
 		expected: `
 1 cloud attribute changed:
 
@@ -152,8 +167,13 @@ var diffCloudsTests = []struct {
         - one`[1:],
 	}, {
 		description: "cloud attributes change: type",
-		old:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{}},
-		new:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{Type: "type"}},
+		old: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name: "one",
+		}},
+		new: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name: "one",
+			Type: "type",
+		}},
 		expected: `
 1 cloud attribute changed:
 
@@ -161,8 +181,13 @@ var diffCloudsTests = []struct {
         - one`[1:],
 	}, {
 		description: "cloud attributes change: auth type added",
-		old:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{}},
-		new:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{AuthTypes: []jujucloud.AuthType{jujucloud.AccessKeyAuthType}}},
+		old: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name: "one",
+		}},
+		new: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:      "one",
+			AuthTypes: []jujucloud.AuthType{jujucloud.AccessKeyAuthType}},
+		},
 		expected: `
 1 cloud attribute changed:
 
@@ -170,8 +195,13 @@ var diffCloudsTests = []struct {
         - one`[1:],
 	}, {
 		description: "cloud attributes change: auth type deleted",
-		old:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{AuthTypes: []jujucloud.AuthType{jujucloud.AccessKeyAuthType}}},
-		new:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{}},
+		old: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:      "one",
+			AuthTypes: []jujucloud.AuthType{jujucloud.AccessKeyAuthType}},
+		},
+		new: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name: "one",
+		}},
 		expected: `
 1 cloud attribute changed:
 
@@ -179,8 +209,14 @@ var diffCloudsTests = []struct {
         - one`[1:],
 	}, {
 		description: "cloud attributes change: auth type changed",
-		old:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{AuthTypes: []jujucloud.AuthType{jujucloud.AccessKeyAuthType}}},
-		new:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{AuthTypes: []jujucloud.AuthType{jujucloud.JSONFileAuthType}}},
+		old: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:      "one",
+			AuthTypes: []jujucloud.AuthType{jujucloud.AccessKeyAuthType}},
+		},
+		new: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:      "one",
+			AuthTypes: []jujucloud.AuthType{jujucloud.JSONFileAuthType}},
+		},
 		expected: `
 1 cloud attribute changed:
 
@@ -188,8 +224,13 @@ var diffCloudsTests = []struct {
         - one`[1:],
 	}, {
 		description: "cloud attributes change: region added",
-		old:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{}},
-		new:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{Regions: []jujucloud.Region{jujucloud.Region{Name: "a"}}}},
+		old: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name: "one",
+		}},
+		new: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:    "one",
+			Regions: []jujucloud.Region{jujucloud.Region{Name: "a"}}},
+		},
 		expected: `
 1 cloud region added:
 
@@ -197,8 +238,13 @@ var diffCloudsTests = []struct {
         - one/a`[1:],
 	}, {
 		description: "cloud attributes change: region deleted",
-		old:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{Regions: []jujucloud.Region{jujucloud.Region{Name: "a"}}}},
-		new:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{}},
+		old: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:    "one",
+			Regions: []jujucloud.Region{jujucloud.Region{Name: "a"}}},
+		},
+		new: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name: "one",
+		}},
 		expected: `
 1 cloud region deleted:
 
@@ -206,8 +252,14 @@ var diffCloudsTests = []struct {
         - one/a`[1:],
 	}, {
 		description: "cloud attributes change: region changed",
-		old:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{Regions: []jujucloud.Region{jujucloud.Region{Name: "a"}}}},
-		new:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{Regions: []jujucloud.Region{jujucloud.Region{Name: "a", Endpoint: "old_endpoint"}}}},
+		old: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:    "one",
+			Regions: []jujucloud.Region{jujucloud.Region{Name: "a"}}},
+		},
+		new: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:    "one",
+			Regions: []jujucloud.Region{jujucloud.Region{Name: "a", Endpoint: "old_endpoint"}}},
+		},
 		expected: `
 1 cloud region changed:
 
@@ -215,8 +267,14 @@ var diffCloudsTests = []struct {
         - one/a`[1:],
 	}, {
 		description: "cloud attributes change: region changed",
-		old:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{Regions: []jujucloud.Region{jujucloud.Region{Name: "a", Endpoint: "old_endpoint"}}}},
-		new:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{Regions: []jujucloud.Region{jujucloud.Region{Name: "a"}}}},
+		old: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:    "one",
+			Regions: []jujucloud.Region{jujucloud.Region{Name: "a", Endpoint: "old_endpoint"}}},
+		},
+		new: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:    "one",
+			Regions: []jujucloud.Region{jujucloud.Region{Name: "a"}}},
+		},
 		expected: `
 1 cloud region changed:
 
@@ -224,8 +282,14 @@ var diffCloudsTests = []struct {
         - one/a`[1:],
 	}, {
 		description: "cloud attributes change: region changed",
-		old:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{Regions: []jujucloud.Region{jujucloud.Region{Name: "a", Endpoint: "old_endpoint"}}}},
-		new:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{Regions: []jujucloud.Region{jujucloud.Region{Name: "a", Endpoint: "new_endpoint"}}}},
+		old: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:    "one",
+			Regions: []jujucloud.Region{jujucloud.Region{Name: "a", Endpoint: "old_endpoint"}}},
+		},
+		new: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:    "one",
+			Regions: []jujucloud.Region{jujucloud.Region{Name: "a", Endpoint: "new_endpoint"}}},
+		},
 		expected: `
 1 cloud region changed:
 
@@ -233,8 +297,14 @@ var diffCloudsTests = []struct {
         - one/a`[1:],
 	}, {
 		description: "cloud attributes change: region changed",
-		old:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{Regions: []jujucloud.Region{jujucloud.Region{Name: "a"}}}},
-		new:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{Regions: []jujucloud.Region{jujucloud.Region{Name: "a", StorageEndpoint: "old_endpoint"}}}},
+		old: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:    "one",
+			Regions: []jujucloud.Region{jujucloud.Region{Name: "a"}}},
+		},
+		new: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:    "one",
+			Regions: []jujucloud.Region{jujucloud.Region{Name: "a", StorageEndpoint: "old_endpoint"}}},
+		},
 		expected: `
 1 cloud region changed:
 
@@ -242,8 +312,14 @@ var diffCloudsTests = []struct {
         - one/a`[1:],
 	}, {
 		description: "cloud attributes change: region changed",
-		old:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{Regions: []jujucloud.Region{jujucloud.Region{Name: "a", StorageEndpoint: "old_endpoint"}}}},
-		new:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{Regions: []jujucloud.Region{jujucloud.Region{Name: "a"}}}},
+		old: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:    "one",
+			Regions: []jujucloud.Region{jujucloud.Region{Name: "a", StorageEndpoint: "old_endpoint"}}},
+		},
+		new: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:    "one",
+			Regions: []jujucloud.Region{jujucloud.Region{Name: "a"}}},
+		},
 		expected: `
 1 cloud region changed:
 
@@ -251,8 +327,14 @@ var diffCloudsTests = []struct {
         - one/a`[1:],
 	}, {
 		description: "cloud attributes change: region changed",
-		old:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{Regions: []jujucloud.Region{jujucloud.Region{Name: "a", StorageEndpoint: "old_endpoint"}}}},
-		new:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{Regions: []jujucloud.Region{jujucloud.Region{Name: "a", StorageEndpoint: "new_endpoint"}}}},
+		old: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:    "one",
+			Regions: []jujucloud.Region{jujucloud.Region{Name: "a", StorageEndpoint: "old_endpoint"}}},
+		},
+		new: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name:    "one",
+			Regions: []jujucloud.Region{jujucloud.Region{Name: "a", StorageEndpoint: "new_endpoint"}}},
+		},
 		expected: `
 1 cloud region changed:
 
@@ -260,8 +342,13 @@ var diffCloudsTests = []struct {
         - one/a`[1:],
 	}, {
 		description: "cloud details changed",
-		old:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{Type: "type", Regions: []jujucloud.Region{jujucloud.Region{Name: "a"}}}},
-		new:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{}},
+		old: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name: "one",
+			Type: "type", Regions: []jujucloud.Region{jujucloud.Region{Name: "a"}}},
+		},
+		new: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name: "one",
+		}},
 		expected: `
 1 cloud attribute changed as well as 1 cloud region deleted:
 
@@ -271,8 +358,13 @@ var diffCloudsTests = []struct {
         - one/a`[1:],
 	}, {
 		description: "cloud details changed, another way",
-		old:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{}},
-		new:         map[string]jujucloud.Cloud{"one": jujucloud.Cloud{Type: "type", Regions: []jujucloud.Region{jujucloud.Region{Name: "a"}}}},
+		old: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name: "one",
+		}},
+		new: map[string]jujucloud.Cloud{"one": jujucloud.Cloud{
+			Name: "one",
+			Type: "type", Regions: []jujucloud.Region{jujucloud.Region{Name: "a"}}},
+		},
 		expected: `
 1 cloud region added as well as 1 cloud attribute changed:
 
@@ -283,12 +375,15 @@ var diffCloudsTests = []struct {
 	}, {
 		description: "all cloud change types",
 		old: map[string]jujucloud.Cloud{
-			"one":   jujucloud.Cloud{Type: "type", Regions: []jujucloud.Region{jujucloud.Region{Name: "a"}}},
-			"three": jujucloud.Cloud{}, // deleting
+			"one": jujucloud.Cloud{
+				Name: "one",
+				Type: "type", Regions: []jujucloud.Region{jujucloud.Region{Name: "a"}},
+			},
+			"three": jujucloud.Cloud{Name: "three"}, // deleting
 		},
 		new: map[string]jujucloud.Cloud{
-			"one": jujucloud.Cloud{}, // updating
-			"two": jujucloud.Cloud{}, // adding
+			"one": jujucloud.Cloud{Name: "one"}, // updating
+			"two": jujucloud.Cloud{Name: "two"}, // adding
 		},
 		expected: `
 1 cloud added; 1 cloud attribute changed as well as 1 cloud and 1 cloud region deleted:
@@ -304,12 +399,18 @@ var diffCloudsTests = []struct {
 	}, {
 		description: "all cloud change types, another way",
 		old: map[string]jujucloud.Cloud{
-			"one": jujucloud.Cloud{}, // updating
-			"two": jujucloud.Cloud{}, // deleting
+			"one": jujucloud.Cloud{Name: "one"}, // updating
+			"two": jujucloud.Cloud{Name: "two"}, // deleting
 		},
 		new: map[string]jujucloud.Cloud{
-			"one":   jujucloud.Cloud{Type: "type", Regions: []jujucloud.Region{jujucloud.Region{Name: "a"}}},
-			"three": jujucloud.Cloud{}, // adding
+			"one": jujucloud.Cloud{
+				Name:    "three",
+				Type:    "type",
+				Regions: []jujucloud.Region{jujucloud.Region{Name: "a"}},
+			},
+			"three": jujucloud.Cloud{
+				Name: "three",
+			}, // adding
 		},
 		expected: `
 1 cloud and 1 cloud region added; 1 cloud attribute changed as well as 1 cloud deleted:

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -544,7 +544,6 @@ See `[1:] + "`juju kill-controller`" + `.`)
 		AgentVersion:              c.AgentVersion,
 		MetadataDir:               metadataDir,
 		Cloud:                     *cloud,
-		CloudName:                 cloud.Name,
 		CloudRegion:               region.Name,
 		CloudCredential:           credentials.credential,
 		CloudCredentialName:       credentials.name,
@@ -706,7 +705,6 @@ func (c *bootstrapCommand) credentialsAndRegionName(
 	creds.credential, creds.name, regionName, err = modelcmd.GetCredentials(
 		ctx, store, modelcmd.GetCredentialsParams{
 			Cloud:          *cloud,
-			CloudName:      c.Cloud,
 			CloudRegion:    c.Region,
 			CredentialName: c.CredentialName,
 		},

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -443,7 +443,6 @@ func (c *addModelCommand) maybeUploadCredential(
 	credential, _, _, err := modelcmd.GetCredentials(
 		ctx, c.ClientStore(), modelcmd.GetCredentialsParams{
 			Cloud:          cloud,
-			CloudName:      cloudTag.Id(),
 			CloudRegion:    cloudRegion,
 			CredentialName: credentialTag.Name(),
 		},

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -456,6 +456,7 @@ func (c *fakeCloudAPI) Clouds() (map[names.CloudTag]cloud.Cloud, error) {
 	c.MethodCall(c, "Clouds")
 	return map[names.CloudTag]cloud.Cloud{
 		names.NewCloudTag("aws"): {
+			Name: "aws",
 			Regions: []cloud.Region{
 				{Name: "us-east-1"},
 				{Name: "us-west-1"},
@@ -471,6 +472,7 @@ func (c *fakeCloudAPI) Cloud(tag names.CloudTag) (cloud.Cloud, error) {
 		return cloud.Cloud{}, &params.Error{Code: params.CodeNotFound}
 	}
 	return cloud.Cloud{
+		Name:      "aws",
 		Type:      "ec2",
 		AuthTypes: []cloud.AuthType{cloud.AccessKeyAuthType},
 		Regions: []cloud.Region{

--- a/cmd/juju/model/fakeenv_test.go
+++ b/cmd/juju/model/fakeenv_test.go
@@ -107,6 +107,7 @@ func (s *fakeModelDefaultEnvSuite) SetUpTest(c *gc.C) {
 	s.fakeCloudAPI = &fakeCloudAPI{
 		clouds: map[string]jujucloud.Cloud{
 			"cloud-dummy": {
+				Name: "dummy",
 				Type: "dummy-cloud",
 				Regions: []jujucloud.Region{
 					{Name: "dummy-region"},

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -129,7 +129,6 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 	// Get the bootstrap machine's addresses from the provider.
 	cloudSpec, err := environs.MakeCloudSpec(
 		args.ControllerCloud,
-		args.ControllerCloudName,
 		args.ControllerCloudRegion,
 		args.ControllerCloudCredential,
 	)

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -915,8 +915,8 @@ func (s *BootstrapSuite) makeTestModel(c *gc.C) {
 		"name": "hosted-model",
 		"uuid": s.hostedModelUUID,
 	}
-	args.ControllerCloudName = "dummy"
 	args.ControllerCloud = cloud.Cloud{
+		Name:      "dummy",
 		Type:      "dummy",
 		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 	}

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -410,6 +410,7 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 	var credential *cloud.Credential
 	if bootstrapConfig.Credential != "" {
 		bootstrapCloud := cloud.Cloud{
+			Name:             bootstrapConfig.Cloud,
 			Type:             bootstrapConfig.CloudType,
 			Endpoint:         bootstrapConfig.CloudEndpoint,
 			IdentityEndpoint: bootstrapConfig.CloudIdentityEndpoint,
@@ -425,7 +426,6 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 			g.ctx, g.store,
 			GetCredentialsParams{
 				Cloud:          bootstrapCloud,
-				CloudName:      bootstrapConfig.Cloud,
 				CloudRegion:    bootstrapConfig.CloudRegion,
 				CredentialName: bootstrapConfig.Credential,
 			},

--- a/cmd/modelcmd/credentials.go
+++ b/cmd/modelcmd/credentials.go
@@ -26,10 +26,6 @@ type GetCredentialsParams struct {
 	// Cloud is the cloud definition.
 	Cloud cloud.Cloud
 
-	// CloudName is the name of the cloud for which credentials are being
-	// obtained.
-	CloudName string
-
 	// CloudRegion is the name of the region that the user has specified.
 	// If this is empty, then GetCredentials will determine the default
 	// region, and return that. The default region is the one set by the
@@ -52,7 +48,7 @@ func GetCredentials(
 ) (_ *cloud.Credential, chosenCredentialName, regionName string, _ error) {
 
 	credential, credentialName, defaultRegion, err := credentialByName(
-		store, args.CloudName, args.CredentialName,
+		store, args.Cloud.Name, args.CredentialName,
 	)
 	if err != nil {
 		return nil, "", "", errors.Trace(err)
@@ -99,7 +95,7 @@ func GetCredentials(
 	if err != nil {
 		return nil, "", "", errors.Annotatef(
 			err, "finalizing %q credential for cloud %q",
-			credentialName, args.CloudName,
+			credentialName, args.Cloud.Name,
 		)
 	}
 
@@ -113,7 +109,7 @@ func GetCredentials(
 	if err != nil {
 		return nil, "", "", errors.Annotatef(
 			err, "finalizing %q credential for cloud %q",
-			credentialName, args.CloudName,
+			credentialName, args.Cloud.Name,
 		)
 	}
 

--- a/cmd/modelcmd/credentials_test.go
+++ b/cmd/modelcmd/credentials_test.go
@@ -78,6 +78,7 @@ var _ = gc.Suite(&credentialsSuite{})
 func (s *credentialsSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.cloud = cloud.Cloud{
+		Name: "cloud",
 		Type: "fake",
 		Regions: []cloud.Region{
 			{Name: "first-region"},
@@ -110,7 +111,6 @@ func (s *credentialsSuite) assertGetCredentials(c *gc.C, cred, region string) {
 	credential, credentialName, regionName, err := modelcmd.GetCredentials(
 		testing.Context(c), s.store, modelcmd.GetCredentialsParams{
 			Cloud:          s.cloud,
-			CloudName:      "cloud",
 			CloudRegion:    region,
 			CredentialName: cred,
 		},

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -70,9 +70,6 @@ type BootstrapParams struct {
 	// initial bootstrap machine.
 	BootstrapImage string
 
-	// CloudName is the name of the cloud that Juju will be bootstrapped in.
-	CloudName string
-
 	// Cloud contains the properties of the cloud that Juju will be
 	// bootstrapped in.
 	Cloud cloud.Cloud
@@ -360,7 +357,7 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	ctx.Verbosef("Starting new instance for initial controller")
 
 	result, err := environ.Bootstrap(ctx, environs.BootstrapParams{
-		CloudName:            args.CloudName,
+		CloudName:            args.Cloud.Name,
 		CloudRegion:          args.CloudRegion,
 		ControllerConfig:     args.ControllerConfig,
 		ModelConstraints:     args.ModelConstraints,
@@ -470,7 +467,6 @@ func finalizeInstanceBootstrapConfig(
 
 	icfg.Bootstrap.ControllerModelConfig = cfg
 	icfg.Bootstrap.CustomImageMetadata = customImageMetadata
-	icfg.Bootstrap.ControllerCloudName = args.CloudName
 	icfg.Bootstrap.ControllerCloud = args.Cloud
 	icfg.Bootstrap.ControllerCloudRegion = args.CloudRegion
 	icfg.Bootstrap.ControllerCloudCredential = args.CloudCredential

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -939,11 +939,11 @@ func (s *bootstrapSuite) TestBootstrapCloudCredential(c *gc.C) {
 		AdminSecret:      "admin-secret",
 		CAPrivateKey:     coretesting.CAKey,
 		Cloud: cloud.Cloud{
+			Name:      "cloud-name",
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 			Regions:   []cloud.Region{{Name: "region-name"}},
 		},
-		CloudName:           "cloud-name",
 		CloudRegion:         "region-name",
 		CloudCredentialName: "credential-name",
 		CloudCredential:     &credential,
@@ -953,7 +953,6 @@ func (s *bootstrapSuite) TestBootstrapCloudCredential(c *gc.C) {
 	c.Assert(env.bootstrapCount, gc.Equals, 1)
 	c.Assert(env.instanceConfig, gc.NotNil)
 	c.Assert(env.instanceConfig.Bootstrap.ControllerCloud, jc.DeepEquals, args.Cloud)
-	c.Assert(env.instanceConfig.Bootstrap.ControllerCloudName, jc.DeepEquals, args.CloudName)
 	c.Assert(env.instanceConfig.Bootstrap.ControllerCloudRegion, jc.DeepEquals, args.CloudRegion)
 	c.Assert(env.instanceConfig.Bootstrap.ControllerCloudCredential, jc.DeepEquals, args.CloudCredential)
 	c.Assert(env.instanceConfig.Bootstrap.ControllerCloudCredentialName, jc.DeepEquals, args.CloudCredentialName)
@@ -981,8 +980,8 @@ func (s *bootstrapSuite) TestFinishBootstrapConfig(c *gc.C) {
 
 	password := "lisboan-pork"
 
-	cloudName := "dummy"
 	dummyCloud := cloud.Cloud{
+		Name: "dummy",
 		RegionConfig: cloud.RegionConfig{
 			"a-region": cloud.Attrs{
 				"a-key": "a-value",
@@ -997,10 +996,9 @@ func (s *bootstrapSuite) TestFinishBootstrapConfig(c *gc.C) {
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
 		ControllerConfig:          coretesting.FakeControllerConfig(),
 		ControllerInheritedConfig: map[string]interface{}{"ftp-proxy": "http://proxy"},
-		CloudName:                 cloudName,
-		Cloud:                     dummyCloud,
-		AdminSecret:               password,
-		CAPrivateKey:              coretesting.CAKey,
+		Cloud:        dummyCloud,
+		AdminSecret:  password,
+		CAPrivateKey: coretesting.CAKey,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	icfg := env.instanceConfig

--- a/environs/cloudspec.go
+++ b/environs/cloudspec.go
@@ -52,10 +52,10 @@ func (cs CloudSpec) Validate() error {
 
 // MakeCloudSpec returns a CloudSpec from the given
 // Cloud, cloud and region names, and credential.
-func MakeCloudSpec(cloud jujucloud.Cloud, cloudName, cloudRegionName string, credential *jujucloud.Credential) (CloudSpec, error) {
+func MakeCloudSpec(cloud jujucloud.Cloud, cloudRegionName string, credential *jujucloud.Credential) (CloudSpec, error) {
 	cloudSpec := CloudSpec{
 		Type:             cloud.Type,
-		Name:             cloudName,
+		Name:             cloud.Name,
 		Region:           cloudRegionName,
 		Endpoint:         cloud.Endpoint,
 		IdentityEndpoint: cloud.IdentityEndpoint,

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -186,8 +186,8 @@ func (t *LiveTests) bootstrapParams() bootstrap.BootstrapParams {
 	}
 	return bootstrap.BootstrapParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
-		CloudName:        t.TestConfig["type"].(string),
 		Cloud: cloud.Cloud{
+			Name:      t.TestConfig["type"].(string),
 			Type:      t.TestConfig["type"].(string),
 			AuthTypes: []cloud.AuthType{credential.AuthType()},
 			Regions:   regions,

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -192,8 +192,8 @@ func (t *Tests) TestBootstrap(c *gc.C) {
 
 	args := bootstrap.BootstrapParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
-		CloudName:        t.TestConfig["type"].(string),
 		Cloud: cloud.Cloud{
+			Name:      t.TestConfig["type"].(string),
 			Type:      t.TestConfig["type"].(string),
 			AuthTypes: []cloud.AuthType{credential.AuthType()},
 			Regions:   regions,

--- a/featuretests/api_cloud_test.go
+++ b/featuretests/api_cloud_test.go
@@ -39,6 +39,7 @@ func (s *CloudAPISuite) TestCloudAPI(c *gc.C) {
 	result, err := s.client.Cloud(names.NewCloudTag("dummy"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, cloud.Cloud{
+		Name:      "dummy",
 		Type:      "dummy",
 		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
 		Regions: []cloud.Region{

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -104,8 +104,8 @@ func (s *NewAPIClientSuite) bootstrapModel(c *gc.C) (environs.Environ, jujuclien
 
 	err = bootstrap.Bootstrap(ctx, env, bootstrap.BootstrapParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
-		CloudName:        "dummy",
 		Cloud: cloud.Cloud{
+			Name:      "dummy",
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 		},

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -364,9 +364,9 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	s.ControllerConfig["api-port"] = apiPort
 	err = bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), environ, bootstrap.BootstrapParams{
 		ControllerConfig: s.ControllerConfig,
-		CloudName:        cloudSpec.Name,
 		CloudRegion:      "dummy-region",
 		Cloud: cloud.Cloud{
+			Name:             cloudSpec.Name,
 			Type:             cloudSpec.Type,
 			AuthTypes:        []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
 			Endpoint:         cloudSpec.Endpoint,

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -748,7 +748,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 			if icfg.Bootstrap.ControllerCloudCredentialName != "" {
 				cloudCredentialTag = names.NewCloudCredentialTag(fmt.Sprintf(
 					"%s/%s/%s",
-					icfg.Bootstrap.ControllerCloudName,
+					icfg.Bootstrap.ControllerCloud.Name,
 					adminUser.Id(),
 					icfg.Bootstrap.ControllerCloudCredentialName,
 				))
@@ -771,13 +771,12 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 					Owner:                   adminUser,
 					Config:                  icfg.Bootstrap.ControllerModelConfig,
 					Constraints:             icfg.Bootstrap.BootstrapMachineConstraints,
-					CloudName:               icfg.Bootstrap.ControllerCloudName,
+					CloudName:               icfg.Bootstrap.ControllerCloud.Name,
 					CloudRegion:             icfg.Bootstrap.ControllerCloudRegion,
 					CloudCredential:         cloudCredentialTag,
 					StorageProviderRegistry: e,
 				},
 				Cloud:            icfg.Bootstrap.ControllerCloud,
-				CloudName:        icfg.Bootstrap.ControllerCloudName,
 				CloudCredentials: cloudCredentials,
 				MongoInfo:        info,
 				MongoDialOpts:    mongotest.DialOpts(),

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -132,8 +132,8 @@ func (s *suite) bootstrapTestEnviron(c *gc.C) environs.NetworkingEnviron {
 
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), netenv, bootstrap.BootstrapParams{
 		ControllerConfig: testing.FakeControllerConfig(),
-		CloudName:        "dummy",
 		Cloud: cloud.Cloud{
+			Name:      "dummy",
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 		},

--- a/state/cloud_test.go
+++ b/state/cloud_test.go
@@ -19,6 +19,7 @@ type CloudSuite struct {
 var _ = gc.Suite(&CloudSuite{})
 
 var lowCloud = cloud.Cloud{
+	Name:             "stratus",
 	Type:             "low",
 	AuthTypes:        cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
 	Endpoint:         "global-endpoint",
@@ -47,7 +48,7 @@ func (s *CloudSuite) TestCloudNotFound(c *gc.C) {
 func (s *CloudSuite) TestClouds(c *gc.C) {
 	dummyCloud, err := s.State.Cloud("dummy")
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.AddCloud("stratus", lowCloud)
+	err = s.State.AddCloud(lowCloud)
 	c.Assert(err, jc.ErrorIsNil)
 
 	clouds, err := s.State.Clouds()
@@ -59,7 +60,7 @@ func (s *CloudSuite) TestClouds(c *gc.C) {
 }
 
 func (s *CloudSuite) TestAddCloud(c *gc.C) {
-	err := s.State.AddCloud("stratus", lowCloud)
+	err := s.State.AddCloud(lowCloud)
 	c.Assert(err, jc.ErrorIsNil)
 	cloud, err := s.State.Cloud("stratus")
 	c.Assert(err, jc.ErrorIsNil)
@@ -67,12 +68,14 @@ func (s *CloudSuite) TestAddCloud(c *gc.C) {
 }
 
 func (s *CloudSuite) TestAddCloudDuplicate(c *gc.C) {
-	err := s.State.AddCloud("stratus", cloud.Cloud{
+	err := s.State.AddCloud(cloud.Cloud{
+		Name:      "stratus",
 		Type:      "low",
 		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.AddCloud("stratus", cloud.Cloud{
+	err = s.State.AddCloud(cloud.Cloud{
+		Name:      "stratus",
 		Type:      "low",
 		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
 	})
@@ -80,15 +83,24 @@ func (s *CloudSuite) TestAddCloudDuplicate(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
 }
 
+func (s *CloudSuite) TestAddCloudNoName(c *gc.C) {
+	err := s.State.AddCloud(cloud.Cloud{
+		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
+	})
+	c.Assert(err, gc.ErrorMatches, `invalid cloud: empty Name not valid`)
+}
+
 func (s *CloudSuite) TestAddCloudNoType(c *gc.C) {
-	err := s.State.AddCloud("stratus", cloud.Cloud{
+	err := s.State.AddCloud(cloud.Cloud{
+		Name:      "stratus",
 		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
 	})
 	c.Assert(err, gc.ErrorMatches, `invalid cloud: empty Type not valid`)
 }
 
 func (s *CloudSuite) TestAddCloudNoAuthTypes(c *gc.C) {
-	err := s.State.AddCloud("stratus", cloud.Cloud{
+	err := s.State.AddCloud(cloud.Cloud{
+		Name: "stratus",
 		Type: "foo",
 	})
 	c.Assert(err, gc.ErrorMatches, `invalid cloud: empty auth-types not valid`)

--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -21,7 +21,8 @@ type CloudCredentialsSuite struct {
 var _ = gc.Suite(&CloudCredentialsSuite{})
 
 func (s *CloudCredentialsSuite) TestUpdateCloudCredentialNew(c *gc.C) {
-	err := s.State.AddCloud("stratus", cloud.Cloud{
+	err := s.State.AddCloud(cloud.Cloud{
+		Name:      "stratus",
 		Type:      "low",
 		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
 	})
@@ -45,7 +46,8 @@ func (s *CloudCredentialsSuite) TestUpdateCloudCredentialNew(c *gc.C) {
 }
 
 func (s *CloudCredentialsSuite) TestUpdateCloudCredentialsExisting(c *gc.C) {
-	err := s.State.AddCloud("stratus", cloud.Cloud{
+	err := s.State.AddCloud(cloud.Cloud{
+		Name:      "stratus",
 		Type:      "low",
 		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
 	})
@@ -77,7 +79,8 @@ func (s *CloudCredentialsSuite) TestUpdateCloudCredentialsExisting(c *gc.C) {
 }
 
 func (s *CloudCredentialsSuite) TestUpdateCloudCredentialInvalidAuthType(c *gc.C) {
-	err := s.State.AddCloud("stratus", cloud.Cloud{
+	err := s.State.AddCloud(cloud.Cloud{
+		Name:      "stratus",
 		Type:      "low",
 		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType},
 	})
@@ -94,7 +97,8 @@ func (s *CloudCredentialsSuite) TestCloudCredentialsEmpty(c *gc.C) {
 }
 
 func (s *CloudCredentialsSuite) TestCloudCredentials(c *gc.C) {
-	err := s.State.AddCloud("stratus", cloud.Cloud{
+	err := s.State.AddCloud(cloud.Cloud{
+		Name:      "stratus",
 		Type:      "low",
 		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
 	})
@@ -135,7 +139,8 @@ func (s *CloudCredentialsSuite) TestCloudCredentials(c *gc.C) {
 
 func (s *CloudCredentialsSuite) TestRemoveCredentials(c *gc.C) {
 	// Create it.
-	err := s.State.AddCloud("stratus", cloud.Cloud{
+	err := s.State.AddCloud(cloud.Cloud{
+		Name:      "stratus",
 		Type:      "low",
 		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
 	})

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -104,8 +104,8 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 			CloudCredential:         userPassCredentialTag,
 			StorageProviderRegistry: storage.StaticProviderRegistry{},
 		},
-		CloudName: "dummy",
 		Cloud: cloud.Cloud{
+			Name: "dummy",
 			Type: "dummy",
 			AuthTypes: []cloud.AuthType{
 				cloud.EmptyAuthType, cloud.UserPassAuthType,
@@ -195,8 +195,8 @@ func (s *InitializeSuite) TestInitializeWithInvalidCredentialType(c *gc.C) {
 			Config:                  modelCfg,
 			StorageProviderRegistry: storage.StaticProviderRegistry{},
 		},
-		CloudName: "dummy",
 		Cloud: cloud.Cloud{
+			Name: "dummy",
 			Type: "dummy",
 			AuthTypes: []cloud.AuthType{
 				cloud.AccessKeyAuthType, cloud.OAuth1AuthType,
@@ -232,8 +232,8 @@ func (s *InitializeSuite) TestInitializeWithControllerInheritedConfig(c *gc.C) {
 			Config:                  cfg,
 			StorageProviderRegistry: storage.StaticProviderRegistry{},
 		},
-		CloudName: "dummy",
 		Cloud: cloud.Cloud{
+			Name:      "dummy",
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 		},
@@ -284,8 +284,8 @@ func (s *InitializeSuite) TestDoubleInitializeConfig(c *gc.C) {
 			Config:                  cfg,
 			StorageProviderRegistry: storage.StaticProviderRegistry{},
 		},
-		CloudName: "dummy",
 		Cloud: cloud.Cloud{
+			Name:      "dummy",
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 		},
@@ -343,8 +343,8 @@ func (s *InitializeSuite) testBadModelConfig(c *gc.C, update map[string]interfac
 			Config:                  bad,
 			StorageProviderRegistry: storage.StaticProviderRegistry{},
 		},
-		CloudName: "dummy",
 		Cloud: cloud.Cloud{
+			Name:      "dummy",
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 			Regions:   []cloud.Region{{Name: "dummy-region"}},
@@ -393,8 +393,8 @@ func (s *InitializeSuite) TestCloudConfigWithForbiddenValues(c *gc.C) {
 			Config:                  modelCfg,
 			StorageProviderRegistry: storage.StaticProviderRegistry{},
 		},
-		CloudName: "dummy",
 		Cloud: cloud.Cloud{
+			Name:      "dummy",
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 		},
@@ -435,8 +435,8 @@ func (s *InitializeSuite) TestInitializeWithCloudRegionConfig(c *gc.C) {
 			Config:                  cfg,
 			StorageProviderRegistry: storage.StaticProviderRegistry{},
 		},
-		CloudName: "dummy",
 		Cloud: cloud.Cloud{
+			Name:         "dummy",
 			Type:         "dummy",
 			AuthTypes:    []cloud.AuthType{cloud.EmptyAuthType},
 			RegionConfig: regionInheritedConfigIn, // Init with phony region-config
@@ -493,8 +493,8 @@ func (s *InitializeSuite) TestInitializeWithCloudRegionMisses(c *gc.C) {
 			Config:                  cfg,
 			StorageProviderRegistry: storage.StaticProviderRegistry{},
 		},
-		CloudName: "dummy",
 		Cloud: cloud.Cloud{
+			Name:         "dummy",
 			Type:         "dummy",
 			AuthTypes:    []cloud.AuthType{cloud.EmptyAuthType},
 			RegionConfig: regionInheritedConfigIn, // Init with phony region-config
@@ -547,8 +547,8 @@ func (s *InitializeSuite) TestInitializeWithCloudRegionHits(c *gc.C) {
 			Config:                  cfg,
 			StorageProviderRegistry: storage.StaticProviderRegistry{},
 		},
-		CloudName: "dummy",
 		Cloud: cloud.Cloud{
+			Name:         "dummy",
 			Type:         "dummy",
 			AuthTypes:    []cloud.AuthType{cloud.EmptyAuthType},
 			RegionConfig: regionInheritedConfigIn, // Init with phony region-config

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -74,8 +74,8 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 			Config:                  modelCfg,
 			StorageProviderRegistry: provider.CommonStorageProviders(),
 		},
-		CloudName: "dummy",
 		Cloud: cloud.Cloud{
+			Name:      "dummy",
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 			Regions: []cloud.Region{

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -983,8 +983,8 @@ func (s *ModelCloudValidationSuite) initializeState(
 			CloudCredential:         controllerCredential,
 			StorageProviderRegistry: storage.StaticProviderRegistry{},
 		},
-		CloudName: "dummy",
 		Cloud: cloud.Cloud{
+			Name:      "dummy",
 			Type:      "dummy",
 			AuthTypes: authTypes,
 			Regions:   regions,

--- a/state/open.go
+++ b/state/open.go
@@ -161,10 +161,6 @@ type InitializeParams struct {
 	// the controller model.
 	ControllerModelArgs ModelArgs
 
-	// CloudName is the name of the cloud that the controller
-	// runs in.
-	CloudName string
-
 	// Cloud contains the properties of the cloud that the
 	// controller runs in.
 	Cloud cloud.Cloud
@@ -217,19 +213,13 @@ func (p InitializeParams) Validate() error {
 	if p.MongoInfo == nil {
 		return errors.NotValidf("nil MongoInfo")
 	}
-	if p.CloudName == "" {
-		return errors.NotValidf("empty CloudName")
-	}
-	if p.Cloud.Type == "" {
-		return errors.NotValidf("empty Cloud")
-	}
 	if err := validateCloud(p.Cloud); err != nil {
 		return errors.Annotate(err, "validating cloud")
 	}
-	if _, err := validateCloudRegion(p.Cloud, p.CloudName, p.ControllerModelArgs.CloudRegion); err != nil {
+	if _, err := validateCloudRegion(p.Cloud, p.ControllerModelArgs.CloudRegion); err != nil {
 		return errors.Annotate(err, "validating controller model cloud region")
 	}
-	if _, err := validateCloudCredentials(p.Cloud, p.CloudName, p.CloudCredentials); err != nil {
+	if _, err := validateCloudCredentials(p.Cloud, p.CloudCredentials); err != nil {
 		return errors.Annotate(err, "validating cloud credentials")
 	}
 	creds := make(map[string]cloud.Credential, len(p.CloudCredentials))
@@ -238,7 +228,6 @@ func (p InitializeParams) Validate() error {
 	}
 	if _, err := validateCloudCredential(
 		p.Cloud,
-		p.CloudName,
 		creds,
 		p.ControllerModelArgs.CloudCredential,
 	); err != nil {
@@ -312,11 +301,11 @@ func Initialize(args InitializeParams) (_ *State, err error) {
 			Id:     modelGlobalKey,
 			Assert: txn.DocMissing,
 			Insert: &controllersDoc{
-				CloudName: args.CloudName,
+				CloudName: args.Cloud.Name,
 				ModelUUID: st.ModelUUID(),
 			},
 		},
-		createCloudOp(args.Cloud, args.CloudName),
+		createCloudOp(args.Cloud),
 		txn.Op{
 			C:      controllersC,
 			Id:     apiHostPortsKey,
@@ -342,7 +331,7 @@ func Initialize(args InitializeParams) (_ *State, err error) {
 		// Create an entry keyed on cloudname#<key>, value for each region in
 		// region-config. The values here are themselves
 		// map[string]interface{}.
-		ops = append(ops, createSettingsOp(globalSettingsC, regionSettingsGlobalKey(args.CloudName, k), v))
+		ops = append(ops, createSettingsOp(globalSettingsC, regionSettingsGlobalKey(args.Cloud.Name, k), v))
 	}
 
 	for tag, cred := range args.CloudCredentials {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4494,8 +4494,8 @@ func (s *SetAdminMongoPasswordSuite) TestSetAdminMongoPassword(c *gc.C) {
 			Config:                  cfg,
 			StorageProviderRegistry: storage.StaticProviderRegistry{},
 		},
-		CloudName: "dummy",
 		Cloud: cloud.Cloud{
+			Name:      "dummy",
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 		},

--- a/state/stateenvirons/config.go
+++ b/state/stateenvirons/config.go
@@ -51,7 +51,7 @@ func CloudSpec(
 		credential = &credentialValue
 	}
 
-	return environs.MakeCloudSpec(modelCloud, cloudName, regionName, credential)
+	return environs.MakeCloudSpec(modelCloud, regionName, credential)
 }
 
 // NewEnvironFunc defines the type of a function that, given a state.State,

--- a/state/testing/conn.go
+++ b/state/testing/conn.go
@@ -68,8 +68,8 @@ func InitializeWithArgs(c *gc.C, args InitializeArgs) *state.State {
 			StorageProviderRegistry: StorageProviders(),
 		},
 		ControllerInheritedConfig: args.ControllerInheritedConfig,
-		CloudName:                 "dummy",
 		Cloud: cloud.Cloud{
+			Name:      "dummy",
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 			Regions: []cloud.Region{


### PR DESCRIPTION
A recent change introduced the Name field to
cloud.Cloud. In several parts of the code
base we were not setting it properly. This
branch ensures that it is always filled in,
introduces additional validation in state,
and updates various bits of code to stop
passing around the cloud name separately.

## QA steps

1. juju bootstrap localhost
2. juju bootstrap aws
3. juju add-model foo
4. juju add-credential aws
5. juju add-cloud