### PR TITLE
cmd/juju: update add-model to detect creds

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -18,7 +18,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/juju/osenv"
-	"github.com/juju/juju/provider/lxd/lxdnames"
 )
 
 //go:generate go run ../generate/filetoconst/filetoconst.go fallbackPublicCloudInfo fallback-public-cloud.yaml fallback_public_cloud.go 2015 cloud
@@ -190,20 +189,6 @@ type region struct {
 	StorageEndpoint  string `yaml:"storage-endpoint,omitempty"`
 }
 
-//DefaultLXD is the name of the default lxd cloud.
-const DefaultLXD = "localhost"
-
-// BuiltInClouds work out of the box.
-var BuiltInClouds = map[string]Cloud{
-	DefaultLXD: {
-		Name:        DefaultLXD,
-		Type:        lxdnames.ProviderType,
-		AuthTypes:   []AuthType{EmptyAuthType},
-		Regions:     []Region{{Name: lxdnames.DefaultRegion}},
-		Description: defaultCloudDescription[lxdnames.ProviderType],
-	},
-}
-
 // CloudByName returns the cloud with the specified name.
 // If there exists no cloud with the specified name, an
 // error satisfying errors.IsNotFound will be returned.
@@ -223,9 +208,6 @@ func CloudByName(name string) (*Cloud, error) {
 		return nil, errors.Trace(err)
 	}
 	if cloud, ok := clouds[name]; ok {
-		return &cloud, nil
-	}
-	if cloud, ok := BuiltInClouds[name]; ok {
 		return &cloud, nil
 	}
 	return nil, errors.NotFoundf("cloud %s", name)
@@ -314,6 +296,12 @@ func ParseCloudMetadata(data []byte) (map[string]Cloud, error) {
 		clouds[name] = details
 	}
 	return clouds, nil
+}
+
+// DefaultCloudDescription returns the description for the specified cloud
+// type, or an empty string if the cloud type is unknown.
+func DefaultCloudDescription(cloudType string) string {
+	return defaultCloudDescription[cloudType]
 }
 
 var defaultCloudDescription = map[string]string{

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -134,7 +134,11 @@ func listCloudDetails() (*cloudList, error) {
 	}
 
 	// Add in built in clouds like localhost (lxd).
-	for name, cloud := range common.BuiltInClouds() {
+	builtinClouds, err := common.BuiltInClouds()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for name, cloud := range builtinClouds {
 		cloudDetails := makeCloudDetails(cloud)
 		cloudDetails.Source = "built-in"
 		details.builtin[name] = cloudDetails

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -32,6 +32,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/provider/lxd/lxdnames"
 	jujuversion "github.com/juju/juju/version"
 )
 
@@ -247,9 +248,16 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 
 // BootstrapInterface provides bootstrap functionality that Run calls to support cleaner testing.
 type BootstrapInterface interface {
+	// Bootstrap bootstraps a controller.
 	Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args bootstrap.BootstrapParams) error
+
+	// CloudDetector returns a CloudDetector for the given provider,
+	// if the provider supports it.
+	CloudDetector(environs.EnvironProvider) (environs.CloudDetector, bool)
+
+	// CloudRegionDetector returns a CloudRegionDetector for the given provider,
+	// if the provider supports it.
 	CloudRegionDetector(environs.EnvironProvider) (environs.CloudRegionDetector, bool)
-	DefaultCloudName(environs.EnvironProvider) (string, bool)
 }
 
 type bootstrapFuncs struct{}
@@ -258,17 +266,14 @@ func (b bootstrapFuncs) Bootstrap(ctx environs.BootstrapContext, env environs.En
 	return bootstrap.Bootstrap(ctx, env, args)
 }
 
-func (b bootstrapFuncs) CloudRegionDetector(provider environs.EnvironProvider) (environs.CloudRegionDetector, bool) {
-	detector, ok := provider.(environs.CloudRegionDetector)
+func (b bootstrapFuncs) CloudDetector(provider environs.EnvironProvider) (environs.CloudDetector, bool) {
+	detector, ok := provider.(environs.CloudDetector)
 	return detector, ok
 }
 
-func (b bootstrapFuncs) DefaultCloudName(provider environs.EnvironProvider) (string, bool) {
-	namer, ok := provider.(environs.DefaultCloudNamer)
-	if !ok {
-		return "", false
-	}
-	return namer.DefaultCloudName(), true
+func (b bootstrapFuncs) CloudRegionDetector(provider environs.EnvironProvider) (environs.CloudRegionDetector, bool) {
+	detector, ok := provider.(environs.CloudRegionDetector)
+	return detector, ok
 }
 
 var getBootstrapFuncs = func() BootstrapInterface {
@@ -360,18 +365,17 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		}
 	}
 
-	credentials, regionName, err := c.credentialsAndRegionName(ctx, cloud)
+	credentials, regionName, err := c.credentialsAndRegionName(ctx, provider, cloud)
 	if err != nil {
+		if err == cmd.ErrSilent {
+			return err
+		}
 		return errors.Trace(err)
 	}
 
 	region, err := getRegion(cloud, regionName)
 	if err != nil {
-		fmt.Fprintf(ctx.GetStderr(),
-			"%s\n\nSpecify an alternative region, or try %q.\n",
-			err, "juju update-clouds",
-		)
-		return cmd.ErrSilent
+		return handleGetRegionError(ctx, err)
 	}
 	if c.controllerName == "" {
 		c.controllerName = defaultControllerName(cloud.Name, region.Name)
@@ -610,68 +614,16 @@ func (c *bootstrapCommand) cloud(ctx *cmd.Context) (*jujucloud.Cloud, error) {
 	bootstrapFuncs := getBootstrapFuncs()
 
 	// Get the cloud definition identified by c.Cloud. If c.Cloud does not
-	// identify a cloud in clouds.yaml, but is the name of a provider, and
-	// that provider implements environs.CloudRegionDetector, we'll
-	// synthesise a Cloud structure with the detected regions and no auth-
-	// types.
+	// identify a cloud in clouds.yaml, then we check if any of the
+	// providers can detect a cloud with the given name. Otherwise, if the
+	// cloud name identifies a provider *type* (e.g. "openstack"), then we
+	// check if that provider can detect cloud regions, and synthesise a
+	// cloud with those regions.
 	cloud, err := jujucloud.CloudByName(c.Cloud)
 	if errors.IsNotFound(err) {
-		ctx.Verbosef("cloud %q not found, trying as a provider name", c.Cloud)
-		provider, err := environs.Provider(c.Cloud)
-		if errors.IsNotFound(err) {
-			return nil, errors.NewNotFound(nil, fmt.Sprintf("unknown cloud %q, please try %q", c.Cloud, "juju update-clouds"))
-		} else if err != nil {
+		cloud, err = c.detectCloud(ctx, bootstrapFuncs)
+		if err != nil {
 			return nil, errors.Trace(err)
-		}
-		detector, ok := bootstrapFuncs.CloudRegionDetector(provider)
-		if !ok {
-			ctx.Verbosef(
-				"provider %q does not support detecting regions",
-				c.Cloud,
-			)
-			return nil, errors.NewNotFound(nil, fmt.Sprintf("unknown cloud %q, please try %q", c.Cloud, "juju update-clouds"))
-		}
-		var cloudEndpoint string
-		regions, err := detector.DetectRegions()
-		if errors.IsNotFound(err) {
-			// It's not an error to have no regions. If the
-			// provider does not support regions, then we
-			// reinterpret the supplied region name as the
-			// cloud's endpoint. This enables the user to
-			// supply, for example, maas/<IP> or manual/<IP>.
-			if c.Region != "" {
-				ctx.Verbosef("interpreting %q as the cloud endpoint", c.Region)
-				cloudEndpoint = c.Region
-				c.Region = ""
-			}
-		} else if err != nil {
-			return nil, errors.Annotatef(err,
-				"detecting regions for %q cloud provider",
-				c.Cloud,
-			)
-		}
-		schemas := provider.CredentialSchemas()
-		authTypes := make([]jujucloud.AuthType, 0, len(schemas))
-		for authType := range schemas {
-			authTypes = append(authTypes, authType)
-		}
-
-		// Give the provider a chance to specify what the cloud name should be.
-		cloudName := c.Cloud
-		if defaultName, ok := bootstrapFuncs.DefaultCloudName(provider); ok {
-			ctx.Verbosef("using default cloud name %q from %s provider", defaultName, c.Cloud)
-			cloudName = defaultName
-		}
-
-		// Since we are iterating over a map, lets sort the authTypes so
-		// they are always in a consistent order.
-		sort.Sort(jujucloud.AuthTypes(authTypes))
-		cloud = &jujucloud.Cloud{
-			Name:      cloudName,
-			Type:      c.Cloud,
-			AuthTypes: authTypes,
-			Endpoint:  cloudEndpoint,
-			Regions:   regions,
 		}
 	} else if err != nil {
 		return nil, errors.Trace(err)
@@ -685,6 +637,80 @@ func (c *bootstrapCommand) cloud(ctx *cmd.Context) (*jujucloud.Cloud, error) {
 	return cloud, nil
 }
 
+func (c *bootstrapCommand) detectCloud(ctx *cmd.Context, bootstrapFuncs BootstrapInterface) (*jujucloud.Cloud, error) {
+	// Check if any of the registered providers can give us a cloud with
+	// the specified name. The first one wins.
+	for _, providerType := range environs.RegisteredProviders() {
+		provider, err := environs.Provider(providerType)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		cloudDetector, ok := bootstrapFuncs.CloudDetector(provider)
+		if !ok {
+			continue
+		}
+		cloud, err := cloudDetector.DetectCloud(c.Cloud)
+		if errors.IsNotFound(err) {
+			continue
+		} else if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return &cloud, nil
+	}
+
+	ctx.Verbosef("cloud %q not found, trying as a provider name", c.Cloud)
+	provider, err := environs.Provider(c.Cloud)
+	if errors.IsNotFound(err) {
+		return nil, errors.NewNotFound(nil, fmt.Sprintf("unknown cloud %q, please try %q", c.Cloud, "juju update-clouds"))
+	} else if err != nil {
+		return nil, errors.Trace(err)
+	}
+	regionDetector, ok := bootstrapFuncs.CloudRegionDetector(provider)
+	if !ok {
+		ctx.Verbosef(
+			"provider %q does not support detecting regions",
+			c.Cloud,
+		)
+		return nil, errors.NewNotFound(nil, fmt.Sprintf("unknown cloud %q, please try %q", c.Cloud, "juju update-clouds"))
+	}
+
+	var cloudEndpoint string
+	regions, err := regionDetector.DetectRegions()
+	if errors.IsNotFound(err) {
+		// It's not an error to have no regions. If the
+		// provider does not support regions, then we
+		// reinterpret the supplied region name as the
+		// cloud's endpoint. This enables the user to
+		// supply, for example, maas/<IP> or manual/<IP>.
+		if c.Region != "" {
+			ctx.Verbosef("interpreting %q as the cloud endpoint", c.Region)
+			cloudEndpoint = c.Region
+			c.Region = ""
+		}
+	} else if err != nil {
+		return nil, errors.Annotatef(err,
+			"detecting regions for %q cloud provider",
+			c.Cloud,
+		)
+	}
+	schemas := provider.CredentialSchemas()
+	authTypes := make([]jujucloud.AuthType, 0, len(schemas))
+	for authType := range schemas {
+		authTypes = append(authTypes, authType)
+	}
+
+	// Since we are iterating over a map, lets sort the authTypes so
+	// they are always in a consistent order.
+	sort.Sort(jujucloud.AuthTypes(authTypes))
+	return &jujucloud.Cloud{
+		Name:      c.Cloud,
+		Type:      c.Cloud,
+		AuthTypes: authTypes,
+		Endpoint:  cloudEndpoint,
+		Regions:   regions,
+	}, nil
+}
+
 type bootstrapCredentials struct {
 	credential   *jujucloud.Credential
 	name         string
@@ -694,13 +720,13 @@ type bootstrapCredentials struct {
 // Get the credentials and region name.
 func (c *bootstrapCommand) credentialsAndRegionName(
 	ctx *cmd.Context,
+	provider environs.EnvironProvider,
 	cloud *jujucloud.Cloud,
 ) (
 	creds bootstrapCredentials,
 	regionName string,
 	err error,
 ) {
-
 	store := c.ClientStore()
 	creds.credential, creds.name, regionName, err = modelcmd.GetCredentials(
 		ctx, store, modelcmd.GetCredentialsParams{
@@ -723,6 +749,7 @@ func (c *bootstrapCommand) credentialsAndRegionName(
 		} else if err != nil {
 			return bootstrapCredentials{}, "", errors.Trace(err)
 		}
+
 		// We have one credential so extract it from the map.
 		var oneCredential jujucloud.Credential
 		for creds.detectedName, oneCredential = range detected.AuthCredentials {
@@ -732,6 +759,23 @@ func (c *bootstrapCommand) credentialsAndRegionName(
 		if regionName == "" {
 			regionName = detected.DefaultRegion
 		}
+
+		// Finalize the credential against the cloud/region.
+		region, err := getRegion(cloud, regionName)
+		if err != nil {
+			return bootstrapCredentials{}, "", handleGetRegionError(ctx, err)
+		}
+		creds.credential, err = provider.FinalizeCredential(
+			ctx, environs.FinalizeCredentialParams{
+				Credential:            oneCredential,
+				CloudEndpoint:         region.Endpoint,
+				CloudIdentityEndpoint: region.IdentityEndpoint,
+			},
+		)
+		if err != nil {
+			return bootstrapCredentials{}, "", errors.Trace(err)
+		}
+
 		logger.Debugf(
 			"authenticating with region %q and credential %q (%v)",
 			regionName, creds.detectedName, creds.credential.Label,
@@ -957,7 +1001,7 @@ func (c *bootstrapCommand) runInteractive(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	c.Cloud, err = queryCloud(clouds, jujucloud.DefaultLXD, scanner, ctx.Stdout)
+	c.Cloud, err = queryCloud(clouds, lxdnames.DefaultCloud, scanner, ctx.Stdout)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1036,4 +1080,12 @@ func handleBootstrapError(ctx *cmd.Context, err error, cleanup func() error) {
 	if err := cleanup(); err != nil {
 		logger.Errorf("error cleaning up: %v", err)
 	}
+}
+
+func handleGetRegionError(ctx *cmd.Context, err error) error {
+	fmt.Fprintf(ctx.GetStderr(),
+		"%s\n\nSpecify an alternative region, or try %q.\n",
+		err, "juju update-clouds",
+	)
+	return cmd.ErrSilent
 }

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -326,6 +326,10 @@ func (c *bootstrapCommand) parseConstraints(ctx *cmd.Context) (err error) {
 // a juju in that environment if none already exists. If there is as yet no environments.yaml file,
 // the user is informed how to create one.
 func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
+	defer func() {
+		resultErr = handleChooseCloudRegionError(ctx, resultErr)
+	}()
+
 	if err := c.parseConstraints(ctx); err != nil {
 		return err
 	}
@@ -367,15 +371,12 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 
 	credentials, regionName, err := c.credentialsAndRegionName(ctx, provider, cloud)
 	if err != nil {
-		if err == cmd.ErrSilent {
-			return err
-		}
 		return errors.Trace(err)
 	}
 
-	region, err := getRegion(cloud, regionName)
+	region, err := common.ChooseCloudRegion(*cloud, regionName)
 	if err != nil {
-		return handleGetRegionError(ctx, err)
+		return errors.Trace(err)
 	}
 	if c.controllerName == "" {
 		c.controllerName = defaultControllerName(cloud.Name, region.Name)
@@ -727,64 +728,33 @@ func (c *bootstrapCommand) credentialsAndRegionName(
 	regionName string,
 	err error,
 ) {
+	var detected bool
 	store := c.ClientStore()
-	creds.credential, creds.name, regionName, err = modelcmd.GetCredentials(
-		ctx, store, modelcmd.GetCredentialsParams{
+	creds.credential, creds.name, regionName, detected, err = common.GetOrDetectCredential(
+		ctx, store, provider, modelcmd.GetCredentialsParams{
 			Cloud:          *cloud,
 			CloudRegion:    c.Region,
 			CredentialName: c.CredentialName,
 		},
 	)
-	if errors.Cause(err) == modelcmd.ErrMultipleCredentials {
+	switch errors.Cause(err) {
+	case nil:
+	case modelcmd.ErrMultipleCredentials:
 		return bootstrapCredentials{}, "", ambiguousCredentialError
-	}
-	if errors.IsNotFound(err) && c.CredentialName == "" {
-		// No credential was explicitly specified, and no credential
-		// was found in credentials.yaml; have the provider detect
-		// credentials from the environment.
-		ctx.Verbosef("no credentials found, checking environment")
-		detected, err := modelcmd.DetectCredential(c.Cloud, cloud.Type)
-		if errors.Cause(err) == modelcmd.ErrMultipleCredentials {
-			return bootstrapCredentials{}, "", ambiguousDetectedCredentialError
-		} else if err != nil {
-			return bootstrapCredentials{}, "", errors.Trace(err)
-		}
-
-		// We have one credential so extract it from the map.
-		var oneCredential jujucloud.Credential
-		for creds.detectedName, oneCredential = range detected.AuthCredentials {
-		}
-		creds.credential = &oneCredential
-		regionName = c.Region
-		if regionName == "" {
-			regionName = detected.DefaultRegion
-		}
-
-		// Finalize the credential against the cloud/region.
-		region, err := getRegion(cloud, regionName)
-		if err != nil {
-			return bootstrapCredentials{}, "", handleGetRegionError(ctx, err)
-		}
-		creds.credential, err = provider.FinalizeCredential(
-			ctx, environs.FinalizeCredentialParams{
-				Credential:            oneCredential,
-				CloudEndpoint:         region.Endpoint,
-				CloudIdentityEndpoint: region.IdentityEndpoint,
-			},
-		)
-		if err != nil {
-			return bootstrapCredentials{}, "", errors.Trace(err)
-		}
-
-		logger.Debugf(
-			"authenticating with region %q and credential %q (%v)",
-			regionName, creds.detectedName, creds.credential.Label,
-		)
-		logger.Tracef("credential: %v", creds.credential)
-	} else if err != nil {
+	case common.ErrMultipleDetectedCredentials:
+		return bootstrapCredentials{}, "", ambiguousDetectedCredentialError
+	default:
 		return bootstrapCredentials{}, "", errors.Trace(err)
 	}
-
+	logger.Debugf(
+		"authenticating with region %q and credential %q (%v)",
+		regionName, creds.name, creds.credential.Label,
+	)
+	if detected {
+		creds.detectedName = creds.name
+		creds.name = ""
+	}
+	logger.Tracef("credential: %v", creds.credential)
 	return creds, regionName, nil
 }
 
@@ -1032,29 +1002,6 @@ func (c *bootstrapCommand) runInteractive(ctx *cmd.Context) error {
 	return nil
 }
 
-// getRegion returns the cloud.Region to use, based on the specified
-// region name.  If no region name is specified, and there is at least
-// one region, we use the first region in the list.
-func getRegion(cloud *jujucloud.Cloud, regionName string) (jujucloud.Region, error) {
-	if regionName != "" {
-		region, err := jujucloud.RegionByName(cloud.Regions, regionName)
-		if err != nil {
-			return jujucloud.Region{}, errors.Trace(err)
-		}
-		return *region, nil
-	}
-	if len(cloud.Regions) > 0 {
-		// No region was specified, use the first region in the list.
-		return cloud.Regions[0], nil
-	}
-	return jujucloud.Region{
-		"", // no region name
-		cloud.Endpoint,
-		cloud.IdentityEndpoint,
-		cloud.StorageEndpoint,
-	}, nil
-}
-
 // checkProviderType ensures the provider type is okay.
 func checkProviderType(envType string) error {
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
@@ -1082,7 +1029,10 @@ func handleBootstrapError(ctx *cmd.Context, err error, cleanup func() error) {
 	}
 }
 
-func handleGetRegionError(ctx *cmd.Context, err error) error {
+func handleChooseCloudRegionError(ctx *cmd.Context, err error) error {
+	if !common.IsChooseCloudRegionError(err) {
+		return err
+	}
 	fmt.Fprintf(ctx.GetStderr(),
 		"%s\n\nSpecify an alternative region, or try %q.\n",
 		err, "juju update-clouds",

--- a/cmd/juju/commands/bootstrap_clouds.go
+++ b/cmd/juju/commands/bootstrap_clouds.go
@@ -98,7 +98,11 @@ func printClouds(ctx *cmd.Context, credStore jujuclient.CredentialStore) error {
 		clouds.public = append(clouds.public, name)
 	}
 	// Add in built in clouds like localhost (lxd).
-	for name := range common.BuiltInClouds() {
+	builtin, err := common.BuiltInClouds()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for name := range builtin {
 		clouds.builtin = append(clouds.builtin, name)
 	}
 	for name := range personalClouds {

--- a/cmd/juju/commands/bootstrap_interactive.go
+++ b/cmd/juju/commands/bootstrap_interactive.go
@@ -28,7 +28,12 @@ func assembleClouds() ([]string, error) {
 		return nil, errors.Trace(err)
 	}
 
-	return sortClouds(public, common.BuiltInClouds(), personal), nil
+	builtin, err := common.BuiltInClouds()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return sortClouds(public, builtin, personal), nil
 }
 
 // queryCloud asks the user to choose a cloud.

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -73,7 +73,6 @@ func init() {
 	environs.RegisterProvider("no-cloud-regions", noCloudRegionsProvider{dummyProvider})
 	environs.RegisterProvider("no-credentials", noCredentialsProvider{})
 	environs.RegisterProvider("many-credentials", manyCredentialsProvider{dummyProvider})
-	environs.RegisterProvider("default-cloud-name", defaultCloudNameProvider{})
 }
 
 func (s *BootstrapSuite) SetUpSuite(c *gc.C) {
@@ -1338,6 +1337,36 @@ func (s *BootstrapSuite) TestManyAvailableCredentialsNoneSpecified(c *gc.C) {
 	c.Assert(msg, gc.Matches, "more than one credential is available.*")
 }
 
+func (s *BootstrapSuite) TestBootstrapProviderDetectCloud(c *gc.C) {
+	resetJujuXDGDataHome(c)
+
+	var bootstrap fakeBootstrapFuncs
+	bootstrap.cloudDetector = cloudDetectorFunc(func() ([]cloud.Cloud, error) {
+		return []cloud.Cloud{{
+			Name:      "bruce",
+			Type:      "dummy",
+			AuthTypes: []cloud.AuthType{cloud.CertificateAuthType},
+			Regions:   []cloud.Region{{Name: "gazza", Endpoint: "endpoint"}},
+		}}, nil
+	})
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return &bootstrap
+	})
+
+	s.patchVersionAndSeries(c, "raring")
+	coretesting.RunCommand(c, s.newBootstrapCommand(), "bruce", "ctrl")
+	c.Assert(bootstrap.args.CloudName, gc.Equals, "bruce")
+	c.Assert(bootstrap.args.CloudRegion, gc.Equals, "gazza")
+	c.Assert(bootstrap.args.CloudCredentialName, gc.Equals, "default")
+	sort.Sort(bootstrap.args.Cloud.AuthTypes)
+	c.Assert(bootstrap.args.Cloud, jc.DeepEquals, cloud.Cloud{
+		Name:      "bruce",
+		Type:      "dummy",
+		AuthTypes: []cloud.AuthType{cloud.CertificateAuthType},
+		Regions:   []cloud.Region{{Name: "gazza", Endpoint: "endpoint"}},
+	})
+}
+
 func (s *BootstrapSuite) TestBootstrapProviderDetectRegions(c *gc.C) {
 	resetJujuXDGDataHome(c)
 
@@ -1382,24 +1411,6 @@ func (s *BootstrapSuite) TestBootstrapProviderDetectNoRegions(c *gc.C) {
 		Type:      "dummy",
 		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
 	})
-}
-
-func (s *BootstrapSuite) TestBootstrapProviderUsesDefaultCloudName(c *gc.C) {
-	s.patchVersionAndSeries(c, "xenial")
-
-	var prepareParams bootstrap.PrepareParams
-	s.PatchValue(&bootstrapPrepare, func(
-		ctx environs.BootstrapContext,
-		stor jujuclient.ClientStore,
-		params bootstrap.PrepareParams,
-	) (environs.Environ, error) {
-		prepareParams = params
-		return nil, errors.New("mock-prepare")
-	})
-
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "default-cloud-name", "ctrl")
-	c.Assert(err, gc.ErrorMatches, "mock-prepare")
-	c.Assert(prepareParams.Cloud.Name, gc.Equals, "mykonos")
 }
 
 func (s *BootstrapSuite) TestBootstrapProviderCaseInsensitiveRegionCheck(c *gc.C) {
@@ -1765,12 +1776,18 @@ func joinBinaryVersions(versions ...[]version.Binary) []version.Binary {
 // file which execute large amounts of external functionality.
 type fakeBootstrapFuncs struct {
 	args                bootstrap.BootstrapParams
+	cloudDetector       environs.CloudDetector
 	cloudRegionDetector environs.CloudRegionDetector
 }
 
 func (fake *fakeBootstrapFuncs) Bootstrap(ctx environs.BootstrapContext, env environs.Environ, args bootstrap.BootstrapParams) error {
 	fake.args = args
 	return nil
+}
+
+func (fake *fakeBootstrapFuncs) CloudDetector(environs.EnvironProvider) (environs.CloudDetector, bool) {
+	detector := fake.cloudDetector
+	return detector, detector != nil
 }
 
 func (fake *fakeBootstrapFuncs) CloudRegionDetector(environs.EnvironProvider) (environs.CloudRegionDetector, bool) {
@@ -1781,10 +1798,6 @@ func (fake *fakeBootstrapFuncs) CloudRegionDetector(environs.EnvironProvider) (e
 		})
 	}
 	return detector, true
-}
-
-func (fake *fakeBootstrapFuncs) DefaultCloudName(environs.EnvironProvider) (string, bool) {
-	return "", false
 }
 
 type noCloudRegionDetectionProvider struct {
@@ -1840,24 +1853,27 @@ func (manyCredentialsProvider) CredentialSchemas() map[cloud.AuthType]cloud.Cred
 	return map[cloud.AuthType]cloud.CredentialSchema{"one": {}, "two": {}}
 }
 
+type cloudDetectorFunc func() ([]cloud.Cloud, error)
+
+func (c cloudDetectorFunc) DetectCloud(name string) (cloud.Cloud, error) {
+	clouds, err := c.DetectClouds()
+	if err != nil {
+		return cloud.Cloud{}, err
+	}
+	for _, cloud := range clouds {
+		if cloud.Name == name {
+			return cloud, nil
+		}
+	}
+	return cloud.Cloud{}, errors.NotFoundf("cloud %s", name)
+}
+
+func (c cloudDetectorFunc) DetectClouds() ([]cloud.Cloud, error) {
+	return c()
+}
+
 type cloudRegionDetectorFunc func() ([]cloud.Region, error)
 
 func (c cloudRegionDetectorFunc) DetectRegions() ([]cloud.Region, error) {
 	return c()
-}
-
-type defaultCloudNameProvider struct {
-	manyCredentialsProvider
-}
-
-func (defaultCloudNameProvider) DefaultCloudName() string {
-	return "mykonos"
-}
-
-func (defaultCloudNameProvider) DetectCredentials() (*cloud.CloudCredential, error) {
-	return &cloud.CloudCredential{
-		AuthCredentials: map[string]cloud.Credential{
-			"one": cloud.NewCredential("one", nil),
-		},
-	}, nil
 }

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1355,7 +1355,6 @@ func (s *BootstrapSuite) TestBootstrapProviderDetectCloud(c *gc.C) {
 
 	s.patchVersionAndSeries(c, "raring")
 	coretesting.RunCommand(c, s.newBootstrapCommand(), "bruce", "ctrl")
-	c.Assert(bootstrap.args.CloudName, gc.Equals, "bruce")
 	c.Assert(bootstrap.args.CloudRegion, gc.Equals, "gazza")
 	c.Assert(bootstrap.args.CloudCredentialName, gc.Equals, "default")
 	sort.Sort(bootstrap.args.Cloud.AuthTypes)

--- a/cmd/juju/common/cloud.go
+++ b/cmd/juju/common/cloud.go
@@ -7,14 +7,25 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
-	"github.com/juju/juju/cloud"
+	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 )
 
 var logger = loggo.GetLogger("juju.cmd.juju.common")
 
+type chooseCloudRegionError struct {
+	error
+}
+
+// IsChooseCloudRegionError reports whether or not the given
+// error was returned from ChooseCloudRegion.
+func IsChooseCloudRegionError(err error) bool {
+	_, ok := errors.Cause(err).(chooseCloudRegionError)
+	return ok
+}
+
 // CloudOrProvider finds and returns cloud or provider.
-func CloudOrProvider(cloudName string, cloudByNameFunc func(string) (*cloud.Cloud, error)) (cloud *cloud.Cloud, err error) {
+func CloudOrProvider(cloudName string, cloudByNameFunc func(string) (*jujucloud.Cloud, error)) (cloud *jujucloud.Cloud, err error) {
 	if cloud, err = cloudByNameFunc(cloudName); err != nil {
 		if !errors.IsNotFound(err) {
 			return nil, err
@@ -32,10 +43,34 @@ func CloudOrProvider(cloudName string, cloudByNameFunc func(string) (*cloud.Clou
 	return cloud, nil
 }
 
+// ChooseCloudRegion returns the cloud.Region to use, based on the specified
+// region name. If no region name is specified, and there is at least one
+// region, we use the first region in the list. If there are no regions, then
+// we return a region with no name, having the same endpoints as the cloud.
+func ChooseCloudRegion(cloud jujucloud.Cloud, regionName string) (jujucloud.Region, error) {
+	if regionName != "" {
+		region, err := jujucloud.RegionByName(cloud.Regions, regionName)
+		if err != nil {
+			return jujucloud.Region{}, errors.Trace(chooseCloudRegionError{err})
+		}
+		return *region, nil
+	}
+	if len(cloud.Regions) > 0 {
+		// No region was specified, use the first region in the list.
+		return cloud.Regions[0], nil
+	}
+	return jujucloud.Region{
+		"", // no region name
+		cloud.Endpoint,
+		cloud.IdentityEndpoint,
+		cloud.StorageEndpoint,
+	}, nil
+}
+
 // BuiltInClouds returns cloud information for those
 // providers which are built in to Juju.
-func BuiltInClouds() (map[string]cloud.Cloud, error) {
-	allClouds := make(map[string]cloud.Cloud)
+func BuiltInClouds() (map[string]jujucloud.Cloud, error) {
+	allClouds := make(map[string]jujucloud.Cloud)
 	for _, providerType := range environs.RegisteredProviders() {
 		p, err := environs.Provider(providerType)
 		if err != nil {

--- a/cmd/juju/common/cloudcredential.go
+++ b/cmd/juju/common/cloudcredential.go
@@ -7,10 +7,82 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/juju/cmd"
 	"github.com/juju/errors"
-
 	"gopkg.in/juju/names.v2"
+
+	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/jujuclient"
 )
+
+// ErrMultipleCredentialsDetected is the error returned by
+// GetOrDetectCredential when multiple credentials are
+// detected, meaning Juju cannot choose one automatically.
+var ErrMultipleDetectedCredentials = errors.New("multiple detected credentials")
+
+// GetOrDetectCredential returns a credential to use for given cloud. This
+// function first calls modelcmd.GetCredentials, and returns its results if it
+// finds credentials. If modelcmd.GetCredentials cannot find a credential, and a
+// credential has not been specified by name, then this function will attempt to
+// detect credentials from the environment.
+//
+// If multiple credentials are found in the client store, then
+// modelcmd.ErrMultipleCredentials is returned. If multiple credentials are
+// detected by the provider, then ErrMultipleDetectedCredentials is returned.
+func GetOrDetectCredential(
+	ctx *cmd.Context,
+	store jujuclient.CredentialGetter,
+	provider environs.EnvironProvider,
+	args modelcmd.GetCredentialsParams,
+) (_ *jujucloud.Credential, chosenCredentialName, regionName string, isDetected bool, _ error) {
+	fail := func(err error) (*jujucloud.Credential, string, string, bool, error) {
+		return nil, "", "", false, err
+	}
+	credential, chosenCredentialName, regionName, err := modelcmd.GetCredentials(ctx, store, args)
+	if !errors.IsNotFound(err) || args.CredentialName != "" {
+		return credential, chosenCredentialName, regionName, false, err
+	}
+
+	// No credential was explicitly specified, and no credential was found
+	// in the credential store; have the provider detect credentials from
+	// the environment.
+	ctx.Verbosef("no credentials found, checking environment")
+
+	detected, err := modelcmd.DetectCredential(args.Cloud.Name, provider)
+	if errors.Cause(err) == modelcmd.ErrMultipleCredentials {
+		return fail(ErrMultipleDetectedCredentials)
+	} else if err != nil {
+		return fail(errors.Trace(err))
+	}
+
+	// We have one credential so extract it from the map.
+	var oneCredential jujucloud.Credential
+	for chosenCredentialName, oneCredential = range detected.AuthCredentials {
+	}
+	regionName = args.CloudRegion
+	if regionName == "" {
+		regionName = detected.DefaultRegion
+	}
+
+	// Finalize the credential against the cloud/region.
+	region, err := ChooseCloudRegion(args.Cloud, regionName)
+	if err != nil {
+		return fail(err)
+	}
+	credential, err = provider.FinalizeCredential(
+		ctx, environs.FinalizeCredentialParams{
+			Credential:            oneCredential,
+			CloudEndpoint:         region.Endpoint,
+			CloudIdentityEndpoint: region.IdentityEndpoint,
+		},
+	)
+	if err != nil {
+		return fail(errors.Trace(err))
+	}
+	return credential, chosenCredentialName, regionName, true, nil
+}
 
 // ResolveCloudCredentialTag takes a string which is of either the format
 // "<credential>" or "<user>/<credential>". If the string does not include

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -46,6 +47,7 @@ func NewAddModelCommandForTest(
 	api AddModelAPI,
 	cloudAPI CloudAPI,
 	store jujuclient.ClientStore,
+	providerRegistry environs.ProviderRegistry,
 ) (cmd.Command, *AddModelCommand) {
 	c := &addModelCommand{
 		apiRoot: apiRoot,
@@ -55,6 +57,7 @@ func NewAddModelCommandForTest(
 		newCloudAPI: func(base.APICallCloser) CloudAPI {
 			return cloudAPI
 		},
+		providerRegistry: providerRegistry,
 	}
 	c.SetClientStore(store)
 	return modelcmd.WrapController(c), &AddModelCommand{c}

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -435,10 +435,11 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 		}
 	} else {
 		// The credential was auto-detected; run auto-detection again.
-		cloudCredential, err := DetectCredential(
-			bootstrapConfig.Cloud,
-			bootstrapConfig.CloudType,
-		)
+		provider, err := environs.Provider(bootstrapConfig.CloudType)
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		cloudCredential, err := DetectCredential(bootstrapConfig.Cloud, provider)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}

--- a/cmd/modelcmd/credentials.go
+++ b/cmd/modelcmd/credentials.go
@@ -160,11 +160,7 @@ func credentialByName(
 // If no credentials are detected, an error satisfying errors.IsNotFound will
 // be returned. If more than one credential is detected, ErrMultipleCredentials
 // will be returned.
-func DetectCredential(cloudName, cloudType string) (*cloud.CloudCredential, error) {
-	provider, err := environs.Provider(cloudType)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+func DetectCredential(cloudName string, provider environs.EnvironProvider) (*cloud.CloudCredential, error) {
 	detected, err := provider.DetectCredentials()
 	if err != nil {
 		return nil, errors.Annotatef(

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -118,7 +118,7 @@ type FinalizeCredentialContext interface {
 // FinalizeCredentialParams contains the parameters for
 // ProviderCredentials.FinalizeCredential.
 type FinalizeCredentialParams struct {
-	// Credential is the credential that the provider should finalize.`
+	// Credential is the credential that the provider should finalize.
 	Credential cloud.Credential
 
 	// CloudEndpoint is the endpoint for the cloud that the credentials are
@@ -132,10 +132,32 @@ type FinalizeCredentialParams struct {
 	CloudIdentityEndpoint string
 }
 
+// CloudDetector is an interface that an EnvironProvider implements
+// in order to automatically detect clouds from the environment.
+type CloudDetector interface {
+	// DetectCloud attempts to detect a cloud with the given name
+	// from the environment. This may involve, for example,
+	// inspecting environment variables, or returning special
+	// hard-coded regions (e.g. "localhost" for lxd).
+	//
+	// If no cloud can be detected, DetectCloud should return
+	// an error satisfying errors.IsNotFound.
+	//
+	// DetectCloud should be used in preference to DetectClouds
+	// when a specific cloud is identified, as this may be more
+	// efficient.
+	DetectCloud(name string) (cloud.Cloud, error)
+
+	// DetectClouds detects clouds from the environment. This may
+	// involve, for example, inspecting environment variables, or
+	// returning special hard-coded regions (e.g. "localhost" for lxd).
+	DetectClouds() ([]cloud.Cloud, error)
+}
+
 // CloudRegionDetector is an interface that an EnvironProvider implements
 // in order to automatically detect cloud regions from the environment.
 type CloudRegionDetector interface {
-	// DetectRetions automatically detects one or more regions
+	// DetectRegions automatically detects one or more regions
 	// from the environment. This may involve, for example, inspecting
 	// environment variables, or returning special hard-coded regions
 	// (e.g. "localhost" for lxd). The first item in the list will be
@@ -145,14 +167,6 @@ type CloudRegionDetector interface {
 	// If no regions can be detected, DetectRegions should return
 	// an error satisfying errors.IsNotFound.
 	DetectRegions() ([]cloud.Region, error)
-}
-
-// DefaultCloudNamer is an interface that a provider implements to
-// specify what an implicitly-created cloud ahould be named.
-type DefaultCloudNamer interface {
-	// DefaultCloudName returns the name that should be used for the
-	// cloud instead of falling back to the provider name.
-	DefaultCloudName() string
 }
 
 // ModelConfigUpgrader is an interface that an EnvironProvider may

--- a/provider/lxd/lxdnames/names.go
+++ b/provider/lxd/lxdnames/names.go
@@ -7,6 +7,10 @@ package lxdnames
 // NOTE: this package exists to get around circular imports from cloud and
 // provider/lxd.
 
+// DefaultCloud is the name of the default lxd cloud, which corresponds to
+// the local lxd daemon.
+const DefaultCloud = "localhost"
+
 // DefaultRegion is the name of the only "region" we support in lxd currently,
 // which corresponds to the local lxd daemon.
 const DefaultRegion = "localhost"


### PR DESCRIPTION
## Description of change

When running add-model, perform credential
detection just as we do during bootstrap if
the user does not have credentials available
already. This is necessary for upcoming
changes to the LXD provider.

Reviewed in https://github.com/juju/juju/pull/6878. Will land this and then merge into develop.

## QA steps

juju bootstrap lxd
juju add-model foo
juju bootstrap aws
juju add-model foo
juju add-model bar --credential=default

## Documentation changes

No changes.

## Bug reference

Does not directly fix any bugs. Required for an upcoming branch that fixes https://bugs.launchpad.net/juju/+bug/1633788.