### PR TITLE
provider/lxd: use CloudSpec.Endpoint/Credentials

### DIFF
--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -283,7 +283,7 @@ func (s *restoreSuite) TestRestoreReboostrapBuiltInProvider(c *gc.C) {
 		c.Assert(args.Cloud, jc.DeepEquals, cloud.Cloud{
 			Name:      "lxd",
 			Type:      "lxd",
-			AuthTypes: []cloud.AuthType{"empty"},
+			AuthTypes: []cloud.AuthType{"certificate"},
 			Regions:   []cloud.Region{{Name: "localhost"}},
 		})
 		return nil

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -607,7 +607,7 @@ func checkConfigs(
 	ctx *cmd.Context, cloud *cloud.Cloud, provider environs.EnvironProvider,
 	expect map[string]map[string]interface{}) {
 
-	configs, err := bootstrapCmd.bootstrapConfigs(ctx, cloud, provider)
+	configs, err := bootstrapCmd.bootstrapConfigs(ctx, *cloud, provider)
 
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1340,28 +1340,36 @@ func (s *BootstrapSuite) TestManyAvailableCredentialsNoneSpecified(c *gc.C) {
 func (s *BootstrapSuite) TestBootstrapProviderDetectCloud(c *gc.C) {
 	resetJujuXDGDataHome(c)
 
+	dummyProvider, err := environs.Provider("dummy")
+	c.Assert(err, jc.ErrorIsNil)
+
 	var bootstrap fakeBootstrapFuncs
-	bootstrap.cloudDetector = cloudDetectorFunc(func() ([]cloud.Cloud, error) {
-		return []cloud.Cloud{{
-			Name:      "bruce",
-			Type:      "dummy",
-			AuthTypes: []cloud.AuthType{cloud.CertificateAuthType},
-			Regions:   []cloud.Region{{Name: "gazza", Endpoint: "endpoint"}},
-		}}, nil
-	})
+	bootstrap.newCloudDetector = func(p environs.EnvironProvider) (environs.CloudDetector, bool) {
+		if p != dummyProvider {
+			return nil, false
+		}
+		return cloudDetectorFunc(func() ([]cloud.Cloud, error) {
+			return []cloud.Cloud{{
+				Name:      "bruce",
+				Type:      "dummy",
+				AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
+				Regions:   []cloud.Region{{Name: "gazza", Endpoint: "endpoint"}},
+			}}, nil
+		}), true
+	}
 	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
 		return &bootstrap
 	})
 
 	s.patchVersionAndSeries(c, "raring")
 	coretesting.RunCommand(c, s.newBootstrapCommand(), "bruce", "ctrl")
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(bootstrap.args.CloudRegion, gc.Equals, "gazza")
 	c.Assert(bootstrap.args.CloudCredentialName, gc.Equals, "default")
-	sort.Sort(bootstrap.args.Cloud.AuthTypes)
 	c.Assert(bootstrap.args.Cloud, jc.DeepEquals, cloud.Cloud{
 		Name:      "bruce",
 		Type:      "dummy",
-		AuthTypes: []cloud.AuthType{cloud.CertificateAuthType},
+		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 		Regions:   []cloud.Region{{Name: "gazza", Endpoint: "endpoint"}},
 	})
 }
@@ -1409,6 +1417,32 @@ func (s *BootstrapSuite) TestBootstrapProviderDetectNoRegions(c *gc.C) {
 		Name:      "dummy",
 		Type:      "dummy",
 		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
+	})
+}
+
+func (s *BootstrapSuite) TestBootstrapProviderFinalizeCloud(c *gc.C) {
+	resetJujuXDGDataHome(c)
+
+	var bootstrap fakeBootstrapFuncs
+	bootstrap.cloudFinalizer = cloudFinalizerFunc(func(ctx environs.FinalizeCloudContext, in cloud.Cloud) (cloud.Cloud, error) {
+		c.Assert(in, jc.DeepEquals, cloud.Cloud{
+			Name:      "dummy",
+			Type:      "dummy",
+			AuthTypes: []cloud.AuthType{"empty", "userpass"},
+		})
+		in.Name = "override"
+		return in, nil
+	})
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return &bootstrap
+	})
+
+	s.patchVersionAndSeries(c, "raring")
+	coretesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "ctrl")
+	c.Assert(bootstrap.args.Cloud, jc.DeepEquals, cloud.Cloud{
+		Name:      "override",
+		Type:      "dummy",
+		AuthTypes: []cloud.AuthType{"empty", "userpass"},
 	})
 }
 
@@ -1775,8 +1809,9 @@ func joinBinaryVersions(versions ...[]version.Binary) []version.Binary {
 // file which execute large amounts of external functionality.
 type fakeBootstrapFuncs struct {
 	args                bootstrap.BootstrapParams
-	cloudDetector       environs.CloudDetector
+	newCloudDetector    func(environs.EnvironProvider) (environs.CloudDetector, bool)
 	cloudRegionDetector environs.CloudRegionDetector
+	cloudFinalizer      environs.CloudFinalizer
 }
 
 func (fake *fakeBootstrapFuncs) Bootstrap(ctx environs.BootstrapContext, env environs.Environ, args bootstrap.BootstrapParams) error {
@@ -1784,9 +1819,11 @@ func (fake *fakeBootstrapFuncs) Bootstrap(ctx environs.BootstrapContext, env env
 	return nil
 }
 
-func (fake *fakeBootstrapFuncs) CloudDetector(environs.EnvironProvider) (environs.CloudDetector, bool) {
-	detector := fake.cloudDetector
-	return detector, detector != nil
+func (fake *fakeBootstrapFuncs) CloudDetector(p environs.EnvironProvider) (environs.CloudDetector, bool) {
+	if fake.newCloudDetector != nil {
+		return fake.newCloudDetector(p)
+	}
+	return nil, false
 }
 
 func (fake *fakeBootstrapFuncs) CloudRegionDetector(environs.EnvironProvider) (environs.CloudRegionDetector, bool) {
@@ -1797,6 +1834,11 @@ func (fake *fakeBootstrapFuncs) CloudRegionDetector(environs.EnvironProvider) (e
 		})
 	}
 	return detector, true
+}
+
+func (fake *fakeBootstrapFuncs) CloudFinalizer(environs.EnvironProvider) (environs.CloudFinalizer, bool) {
+	finalizer := fake.cloudFinalizer
+	return finalizer, finalizer != nil
 }
 
 type noCloudRegionDetectionProvider struct {
@@ -1875,4 +1917,10 @@ type cloudRegionDetectorFunc func() ([]cloud.Region, error)
 
 func (c cloudRegionDetectorFunc) DetectRegions() ([]cloud.Region, error) {
 	return c()
+}
+
+type cloudFinalizerFunc func(environs.FinalizeCloudContext, cloud.Cloud) (cloud.Cloud, error)
+
+func (c cloudFinalizerFunc) FinalizeCloud(ctx environs.FinalizeCloudContext, in cloud.Cloud) (cloud.Cloud, error) {
+	return c(ctx, in)
 }

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -132,6 +132,23 @@ type FinalizeCredentialParams struct {
 	CloudIdentityEndpoint string
 }
 
+// FinalizeCloudContext is an interface passed into FinalizeCloud
+// to provide a means of interacting with the user when finalizing
+// a cloud definition.
+type FinalizeCloudContext interface {
+	// Verbosef will write the formatted string to Stderr if the
+	// verbose flag is true, and to the logger if not.
+	Verbosef(string, ...interface{})
+}
+
+// CloudFinalizer is an interface that an EnvironProvider implements
+// in order to finalize a cloud.Cloud definition before bootstrapping.
+type CloudFinalizer interface {
+	// FinalizeCloud finalizes a cloud definition, updating any attributes
+	// as necessary. This is always done client-side, before bootstrapping.
+	FinalizeCloud(FinalizeCloudContext, cloud.Cloud) (cloud.Cloud, error)
+}
+
 // CloudDetector is an interface that an EnvironProvider implements
 // in order to automatically detect clouds from the environment.
 type CloudDetector interface {

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -6,26 +6,144 @@
 package lxd
 
 import (
+	"net"
+
+	"github.com/juju/errors"
+
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/tools/lxdclient"
 )
 
-type environProviderCredentials struct{}
+const (
+	credAttrServerCert = "server-cert"
+	credAttrClientCert = "client-cert"
+	credAttrClientKey  = "client-key"
+)
+
+// environProviderCredentials implements environs.ProviderCredentials.
+type environProviderCredentials struct {
+	generateMemCert     func(bool) ([]byte, []byte, error)
+	newLocalRawProvider func() (*rawProvider, error)
+	lookupHost          func(string) ([]string, error)
+	interfaceAddrs      func() ([]net.Addr, error)
+}
 
 // CredentialSchemas is part of the environs.ProviderCredentials interface.
 func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
-	// TODO (anastasiamac 2016-04-14) When/If this value changes,
-	// verify that juju/juju/cloud/clouds.go#BuiltInClouds
-	// with lxd type are up to-date.
-	return map[cloud.AuthType]cloud.CredentialSchema{cloud.EmptyAuthType: {}}
+	return map[cloud.AuthType]cloud.CredentialSchema{
+		cloud.CertificateAuthType: {{
+			credAttrServerCert,
+			cloud.CredentialAttr{
+				Description: "The LXD server certificate, PEM-encoded.",
+			},
+		}, {
+			credAttrClientCert,
+			cloud.CredentialAttr{
+				Description: "The LXD client certificate, PEM-encoded.",
+			},
+		}, {
+			credAttrClientKey,
+			cloud.CredentialAttr{
+				Description: "The LXD client key, PEM-encoded.",
+			},
+		}},
+	}
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
 func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
+	// We return an "empty" credential that will be translated
+	// to a certificate credential below.
 	return cloud.NewEmptyCloudCredential(), nil
 }
 
 // FinalizeCredential is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) FinalizeCredential(_ environs.FinalizeCredentialContext, args environs.FinalizeCredentialParams) (*cloud.Credential, error) {
-	return &args.Credential, nil
+func (p environProviderCredentials) FinalizeCredential(_ environs.FinalizeCredentialContext, args environs.FinalizeCredentialParams) (*cloud.Credential, error) {
+	// For an "empty" credential we will generate a certificate if
+	// the LXD is local to this host, and upload the certificate
+	// to LXD. For any other credential, we leave it alone.
+
+	if args.Credential.AuthType() != cloud.EmptyAuthType {
+		return &args.Credential, nil
+	}
+
+	isLocalEndpoint, err := p.isLocalEndpoint(args.CloudEndpoint)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if !isLocalEndpoint {
+		// The endpoint is not local, so we cannot generate a
+		// certificate credential.
+		return &args.Credential, nil
+	}
+	raw, err := p.newLocalRawProvider()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Generate a certificate pair, upload to the server, and then create a
+	// new "certificate" credential with them and the server's certificate.
+	//
+	// We must upload here to cater for the esoteric case of automatic
+	// credential generation in "juju add-model". We *also* upload during
+	// bootstrap, in case the user does a "rebootstrap" with the *same*
+	// credentials (e.g. juju restore-backup).
+	certPEM, keyPEM, err := p.generateMemCert(true)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := raw.AddCert(lxdclient.Cert{
+		Name:    "juju",
+		CertPEM: certPEM,
+		KeyPEM:  keyPEM,
+	}); err != nil {
+		return nil, errors.Annotate(err, "adding certificate")
+	}
+	serverState, err := raw.ServerStatus()
+	if err != nil {
+		return nil, errors.Annotate(err, "getting server status")
+	}
+
+	out := cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
+		credAttrServerCert: serverState.Environment.Certificate,
+		credAttrClientCert: string(certPEM),
+		credAttrClientKey:  string(keyPEM),
+	})
+	out.Label = args.Credential.Label
+	return &out, nil
+}
+
+func (p environProviderCredentials) isLocalEndpoint(endpoint string) (bool, error) {
+	endpointAddrs, err := p.lookupHost(endpoint)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	localAddrs, err := p.interfaceAddrs()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	return addrsContainsAny(localAddrs, endpointAddrs), nil
+}
+
+func addrsContainsAny(haystack []net.Addr, needles []string) bool {
+	for _, needle := range needles {
+		if addrsContains(haystack, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func addrsContains(haystack []net.Addr, needle string) bool {
+	ip := net.ParseIP(needle)
+	if ip == nil {
+		return false
+	}
+	for _, addr := range haystack {
+		if addr, ok := addr.(*net.IPNet); ok && addr.IP.Equal(ip) {
+			return true
+		}
+	}
+	return false
 }

--- a/provider/lxd/credentials_test.go
+++ b/provider/lxd/credentials_test.go
@@ -4,36 +4,60 @@
 package lxd_test
 
 import (
+	"net"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/provider/lxd"
 )
 
 type credentialsSuite struct {
-	testing.BaseSuite
-	provider environs.EnvironProvider
+	lxd.BaseSuite
 }
 
 var _ = gc.Suite(&credentialsSuite{})
 
-func (s *credentialsSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
-
-	var err error
-	s.provider, err = environs.Provider("lxd")
-	c.Assert(err, jc.ErrorIsNil)
-}
-
 func (s *credentialsSuite) TestCredentialSchemas(c *gc.C) {
-	envtesting.AssertProviderAuthTypes(c, s.provider, "empty")
+	envtesting.AssertProviderAuthTypes(c, s.Provider, "certificate")
 }
 
 func (s *credentialsSuite) TestDetectCredentials(c *gc.C) {
-	credentials, err := s.provider.DetectCredentials()
+	credentials, err := s.Provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, jc.DeepEquals, cloud.NewEmptyCloudCredential())
+}
+
+func (s *credentialsSuite) TestFinalizeCredential(c *gc.C) {
+	out, err := s.Provider.FinalizeCredential(nil, environs.FinalizeCredentialParams{
+		CloudEndpoint: "",
+		Credential:    cloud.NewEmptyCredential(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(out.AuthType(), gc.Equals, cloud.CertificateAuthType)
+	c.Assert(out.Attributes(), jc.DeepEquals, map[string]string{
+		"client-cert": "client.crt",
+		"client-key":  "client.key",
+		"server-cert": "server-cert",
+	})
+	s.Stub.CheckCallNames(c,
+		"LookupHost", "InterfaceAddrs",
+		"GenerateMemCert", "AddCert", "ServerStatus",
+	)
+}
+
+func (s *credentialsSuite) TestFinalizeCredentialNonLocal(c *gc.C) {
+	// Patch the interface addresses for the calling machine, so
+	// it appears that we're not on the LXD server host.
+	s.PatchValue(&s.InterfaceAddrs, []net.Addr{&net.IPNet{IP: net.ParseIP("8.8.8.8")}})
+	out, err := s.Provider.FinalizeCredential(nil, environs.FinalizeCredentialParams{
+		CloudEndpoint: "",
+		Credential:    cloud.NewEmptyCredential(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out.AuthType(), gc.Equals, cloud.EmptyAuthType)
 }

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -29,6 +29,13 @@ type baseProvider interface {
 }
 
 type environ struct {
+	cloud    environs.CloudSpec
+	provider *environProvider
+
+	// local records whether or not the LXD is local to the host running
+	// this process.
+	local bool
+
 	name string
 	uuid string
 	raw  *rawProvider
@@ -41,9 +48,15 @@ type environ struct {
 	ecfg *environConfig
 }
 
-type newRawProviderFunc func(environs.CloudSpec) (*rawProvider, error)
+type newRawProviderFunc func(environs.CloudSpec, bool) (*rawProvider, error)
 
-func newEnviron(spec environs.CloudSpec, cfg *config.Config, newRawProvider newRawProviderFunc) (*environ, error) {
+func newEnviron(
+	provider *environProvider,
+	local bool,
+	spec environs.CloudSpec,
+	cfg *config.Config,
+	newRawProvider newRawProviderFunc,
+) (*environ, error) {
 	ecfg, err := newValidConfig(cfg)
 	if err != nil {
 		return nil, errors.Annotate(err, "invalid config")
@@ -54,12 +67,14 @@ func newEnviron(spec environs.CloudSpec, cfg *config.Config, newRawProvider newR
 		return nil, errors.Trace(err)
 	}
 
-	raw, err := newRawProvider(spec)
+	raw, err := newRawProvider(spec, local)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	env := &environ{
+		cloud:     spec,
+		local:     local,
 		name:      ecfg.Name(),
 		uuid:      ecfg.UUID(),
 		raw:       raw,
@@ -104,8 +119,8 @@ func (env *environ) Name() string {
 }
 
 // Provider returns the environment provider that created this env.
-func (*environ) Provider() environs.EnvironProvider {
-	return providerInstance
+func (env *environ) Provider() environs.EnvironProvider {
+	return env.provider
 }
 
 // SetConfig updates the env's configuration.
@@ -143,9 +158,31 @@ func (env *environ) Create(environs.CreateParams) error {
 
 // Bootstrap implements environs.Environ.
 func (env *environ) Bootstrap(ctx environs.BootstrapContext, params environs.BootstrapParams) (*environs.BootstrapResult, error) {
-	// Using the Bootstrap func from provider/common should be fine.
-	// Local provider does its own thing because it has to deal directly
-	// with localhost rather than using SSH.
+	if env.local {
+		// Add the client certificate to the LXD server, so the
+		// controller containers can authenticate. We can only
+		// do this for local LXD. For non-local, the user must
+		// do this themselves, until we support using trust
+		// passwords.
+		clientCert, _, ok := getCerts(env.cloud)
+		if !ok {
+			return nil, errors.New("cannot bootstrap without client certificate")
+		}
+		fingerprint, err := clientCert.Fingerprint()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		_, err = env.raw.CertByFingerprint(fingerprint)
+		if errors.IsNotFound(err) {
+			if err := env.raw.AddCert(*clientCert); err != nil {
+				return nil, errors.Annotatef(
+					err, "adding certificate %q", clientCert.Name,
+				)
+			}
+		} else if err != nil {
+			return nil, errors.Annotate(err, "querying certificates")
+		}
+	}
 	return env.base.BootstrapEnv(ctx, params)
 }
 
@@ -177,7 +214,19 @@ func (env *environ) DestroyController(controllerUUID string) error {
 	if err := env.Destroy(); err != nil {
 		return errors.Trace(err)
 	}
-	return env.destroyHostedModelResources(controllerUUID)
+	if err := env.destroyHostedModelResources(controllerUUID); err != nil {
+		return errors.Trace(err)
+	}
+	if env.local {
+		// When we're running locally to the LXD host, remove the
+		// certificate from LXD. It will get added back in at
+		// bootstrap time as necessary. For remote LXD, the user
+		// needs to have added the certificate to LXD themselves.
+		if err := env.removeCertificate(); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
 }
 
 func (env *environ) destroyHostedModelResources(controllerUUID string) error {
@@ -200,8 +249,25 @@ func (env *environ) destroyHostedModelResources(controllerUUID string) error {
 		}
 		names = append(names, string(inst.Id()))
 	}
-	if err := removeInstances(env.raw, prefix, names); err != nil {
-		return errors.Annotate(err, "removing hosted model instances")
+	if len(names) > 0 {
+		if err := env.raw.RemoveInstances(prefix, names...); err != nil {
+			return errors.Annotate(err, "removing hosted model instances")
+		}
+	}
+	return nil
+}
+
+func (env *environ) removeCertificate() error {
+	if env.raw.remote.Cert == nil {
+		return nil
+	}
+	fingerprint, err := env.raw.remote.Cert.Fingerprint()
+	if err != nil {
+		return errors.Annotate(err, "generating certificate fingerprint")
+	}
+	err = env.raw.RemoveCertByFingerprint(fingerprint)
+	if err != nil && !errors.IsNotFound(err) {
+		return errors.Annotate(err, "removing certificate")
 	}
 	return nil
 }

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -6,14 +6,12 @@
 package lxd_test
 
 import (
-	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/provider/lxd"
-	"github.com/juju/juju/tools/lxdclient"
 )
 
 type environBrokerSuite struct {
@@ -54,41 +52,12 @@ func (s *environBrokerSuite) TestStopInstances(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{{
-		FuncName: "Instances",
-		Args: []interface{}{
-			"juju-f75cba-",
-			[]string(nil),
-		},
-	}, {
 		FuncName: "RemoveInstances",
 		Args: []interface{}{
 			"juju-f75cba-",
 			[]string{"spam"},
 		},
 	}})
-}
-
-func (s *environBrokerSuite) TestStopInstancesRemoveCertificate(c *gc.C) {
-	s.RawInstance.InstanceSummary.Metadata[lxdclient.CertificateFingerprintKey] = "foo"
-	s.Client.Insts = []lxdclient.Instance{*s.RawInstance}
-
-	err := s.Env.StopInstances(s.Instance.Id())
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.Stub.CheckCallNames(c, "Instances", "RemoveCertByFingerprint", "RemoveInstances")
-	s.Stub.CheckCall(c, 1, "RemoveCertByFingerprint", "foo")
-}
-
-func (s *environBrokerSuite) TestStopInstancesRemoveCertificateNotFound(c *gc.C) {
-	s.RawInstance.InstanceSummary.Metadata[lxdclient.CertificateFingerprintKey] = "foo"
-	s.Client.Insts = []lxdclient.Instance{*s.RawInstance}
-
-	s.Stub.SetErrors(nil, errors.NotFoundf("certificate"))
-	err := s.Env.StopInstances(s.Instance.Id())
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.Stub.CheckCallNames(c, "Instances", "RemoveCertByFingerprint", "RemoveInstances")
-	s.Stub.CheckCall(c, 1, "RemoveCertByFingerprint", "foo")
 }
 
 func (s *environBrokerSuite) TestImageMetadataURL(c *gc.C) {

--- a/provider/lxd/environ_raw.go
+++ b/provider/lxd/environ_raw.go
@@ -6,28 +6,13 @@
 package lxd
 
 import (
-	"io/ioutil"
-	"os"
-	"path"
-	"strings"
-
 	"github.com/juju/errors"
-	"github.com/juju/utils"
-	"github.com/juju/utils/series"
 	lxdshared "github.com/lxc/lxd/shared"
 
 	"github.com/juju/juju/environs"
-	jujupaths "github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/tools/lxdclient"
-)
-
-var (
-	jujuConfDir    = jujupaths.MustSucceed(jujupaths.ConfDir(series.LatestLts()))
-	clientCertPath = path.Join(jujuConfDir, "lxd-client.crt")
-	clientKeyPath  = path.Join(jujuConfDir, "lxd-client.key")
-	serverCertPath = path.Join(jujuConfDir, "lxd-server.crt")
 )
 
 type rawProvider struct {
@@ -37,10 +22,13 @@ type rawProvider struct {
 	lxdProfiles
 	lxdImages
 	common.Firewaller
+
+	remote lxdclient.Remote
 }
 
 type lxdCerts interface {
 	AddCert(lxdclient.Cert) error
+	CertByFingerprint(string) (lxdshared.CertInfo, error)
 	RemoveCertByFingerprint(string) error
 }
 
@@ -58,6 +46,7 @@ type lxdInstances interface {
 }
 
 type lxdProfiles interface {
+	DefaultProfileBridgeName() string
 	CreateProfile(string, map[string]string) error
 	HasProfile(string) (bool, error)
 }
@@ -66,103 +55,80 @@ type lxdImages interface {
 	EnsureImageExists(series string, sources []lxdclient.Remote, copyProgressHandler func(string)) error
 }
 
-func newRawProvider(spec environs.CloudSpec) (*rawProvider, error) {
-	client, err := newClient(spec, ioutil.ReadFile, utils.RunCommand)
-	if err != nil {
-		return nil, errors.Annotate(err, "creating LXD client")
+func newRawProvider(spec environs.CloudSpec, local bool) (*rawProvider, error) {
+	if local {
+		return newLocalRawProvider()
 	}
+	return newRemoteRawProvider(spec)
+}
 
-	raw := &rawProvider{
+func newLocalRawProvider() (*rawProvider, error) {
+	config := lxdclient.Config{Remote: lxdclient.Local}
+	return newRawProviderFromConfig(config)
+}
+
+func newRemoteRawProvider(spec environs.CloudSpec) (*rawProvider, error) {
+	config, err := getRemoteConfig(spec)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return newRawProviderFromConfig(*config)
+}
+
+func newRawProviderFromConfig(config lxdclient.Config) (*rawProvider, error) {
+	client, err := lxdclient.Connect(config, true)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &rawProvider{
 		lxdCerts:     client,
 		lxdConfig:    client,
 		lxdInstances: client,
 		lxdProfiles:  client,
 		lxdImages:    client,
 		Firewaller:   common.NewFirewaller(),
-	}
-	return raw, nil
+		remote:       config.Remote,
+	}, nil
 }
 
-type readFileFunc func(string) ([]byte, error)
-type runCommandFunc func(string, ...string) (string, error)
-
-func newClient(
-	spec environs.CloudSpec,
-	readFile readFileFunc,
-	runCommand runCommandFunc,
-) (*lxdclient.Client, error) {
-	config, err := getRemoteConfig(readFile, runCommand, spec)
-	if errors.IsNotFound(err) {
-		config = &lxdclient.Config{Remote: lxdclient.Local}
-	} else if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	client, err := lxdclient.Connect(*config, true)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return client, nil
-}
-
-// getRemoteConfig returns a lxdclient.Config using a TCP-based remote
-// if called from within an instance started by the LXD provider. Otherwise,
-// it returns an errors satisfying errors.IsNotFound.
-func getRemoteConfig(readFile readFileFunc, runCommand runCommandFunc, spec environs.CloudSpec) (*lxdclient.Config, error) {
-	readFileOrig := readFile
-	readFile = func(path string) ([]byte, error) {
-		data, err := readFileOrig(path)
-		if err != nil {
-			if os.IsNotExist(err) {
-				err = errors.NotFoundf("%s", path)
-			}
-			return nil, err
-		}
-		return data, nil
-	}
-	clientCert, err := readFile(clientCertPath)
-	if err != nil {
-		return nil, errors.Annotate(err, "reading client certificate")
-	}
-	clientKey, err := readFile(clientKeyPath)
-	if err != nil {
-		return nil, errors.Annotate(err, "reading client key")
-	}
-	serverCert, err := readFile(serverCertPath)
-	if err != nil {
-		return nil, errors.Annotate(err, "reading server certificate")
-	}
-	cert := lxdclient.NewCert(clientCert, clientKey)
-	if err != nil {
-		return nil, errors.Annotate(err, "getting gateway address")
-	}
-	hostAddress := spec.Endpoint
-	if hostAddress == "" {
-		var err error
-		hostAddress, err = getDefaultGateway(runCommand)
-		if err != nil {
-			return nil, errors.Annotate(err, "getting gateway address")
-		}
+// getRemoteConfig returns a lxdclient.Config using a TCP-based remote.
+func getRemoteConfig(spec environs.CloudSpec) (*lxdclient.Config, error) {
+	clientCert, serverCert, ok := getCerts(spec)
+	if !ok {
+		return nil, errors.NotValidf("credentials")
 	}
 	return &lxdclient.Config{
 		lxdclient.Remote{
 			Name:          "remote",
-			Host:          hostAddress,
+			Host:          spec.Endpoint,
 			Protocol:      lxdclient.LXDProtocol,
-			Cert:          &cert,
-			ServerPEMCert: string(serverCert),
+			Cert:          clientCert,
+			ServerPEMCert: serverCert,
 		},
 	}, nil
 }
 
-func getDefaultGateway(runCommand runCommandFunc) (string, error) {
-	out, err := runCommand("ip", "route", "list", "match", "0/0")
-	if err != nil {
-		return "", errors.Trace(err)
+func getCerts(spec environs.CloudSpec) (client *lxdclient.Cert, server string, ok bool) {
+	if spec.Credential == nil {
+		return nil, "", false
 	}
-	if !strings.HasPrefix(string(out), "default via") {
-		return "", errors.Errorf(`unexpected output from "ip route": %s`, out)
+	credAttrs := spec.Credential.Attributes()
+	clientCertPEM, ok := credAttrs[credAttrClientCert]
+	if !ok {
+		return nil, "", false
 	}
-	fields := strings.Fields(string(out))
-	return fields[2], nil
+	clientKeyPEM, ok := credAttrs[credAttrClientKey]
+	if !ok {
+		return nil, "", false
+	}
+	serverCertPEM, ok := credAttrs[credAttrServerCert]
+	if !ok {
+		return nil, "", false
+	}
+	clientCert := &lxdclient.Cert{
+		Name:    "juju",
+		CertPEM: []byte(clientCertPEM),
+		KeyPEM:  []byte(clientKeyPEM),
+	}
+	return clientCert, serverCertPEM, true
 }

--- a/provider/lxd/environ_raw_test.go
+++ b/provider/lxd/environ_raw_test.go
@@ -6,13 +6,11 @@
 package lxd
 
 import (
-	"os"
-
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/tools/lxdclient"
 )
@@ -20,9 +18,7 @@ import (
 type environRawSuite struct {
 	testing.IsolationSuite
 	testing.Stub
-	readFile   readFileFunc
-	runCommand runCommandFunc
-	spec       environs.CloudSpec
+	spec environs.CloudSpec
 }
 
 var _ = gc.Suite(&environRawSuite{})
@@ -30,28 +26,22 @@ var _ = gc.Suite(&environRawSuite{})
 func (s *environRawSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.Stub.ResetCalls()
-	s.readFile = func(path string) ([]byte, error) {
-		s.AddCall("readFile", path)
-		if err := s.NextErr(); err != nil {
-			return nil, err
-		}
-		return []byte("content:" + path), nil
-	}
-	s.runCommand = func(command string, args ...string) (string, error) {
-		s.AddCall("runCommand", command, args)
-		if err := s.NextErr(); err != nil {
-			return "", err
-		}
-		return "default via 10.0.8.1 dev eth0", nil
-	}
+
+	cred := cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
+		"client-cert": "client.crt",
+		"client-key":  "client.key",
+		"server-cert": "server.crt",
+	})
 	s.spec = environs.CloudSpec{
-		Type: "lxd",
-		Name: "localhost",
+		Type:       "lxd",
+		Name:       "localhost",
+		Endpoint:   "10.0.8.1",
+		Credential: &cred,
 	}
 }
 
 func (s *environRawSuite) TestGetRemoteConfig(c *gc.C) {
-	cfg, err := getRemoteConfig(s.readFile, s.runCommand, s.spec)
+	cfg, err := getRemoteConfig(s.spec)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg, jc.DeepEquals, &lxdclient.Config{
 		Remote: lxdclient.Remote{
@@ -59,64 +49,11 @@ func (s *environRawSuite) TestGetRemoteConfig(c *gc.C) {
 			Host:     "10.0.8.1",
 			Protocol: "lxd",
 			Cert: &lxdclient.Cert{
-				CertPEM: []byte("content:/etc/juju/lxd-client.crt"),
-				KeyPEM:  []byte("content:/etc/juju/lxd-client.key"),
+				Name:    "juju",
+				CertPEM: []byte("client.crt"),
+				KeyPEM:  []byte("client.key"),
 			},
-			ServerPEMCert: "content:/etc/juju/lxd-server.crt",
-		},
-	})
-	s.Stub.CheckCalls(c, []testing.StubCall{
-		{"readFile", []interface{}{"/etc/juju/lxd-client.crt"}},
-		{"readFile", []interface{}{"/etc/juju/lxd-client.key"}},
-		{"readFile", []interface{}{"/etc/juju/lxd-server.crt"}},
-		{"runCommand", []interface{}{"ip", []string{"route", "list", "match", "0/0"}}},
-	})
-}
-
-func (s *environRawSuite) TestGetRemoteConfigFileNotExist(c *gc.C) {
-	s.SetErrors(os.ErrNotExist)
-	_, err := getRemoteConfig(s.readFile, s.runCommand, s.spec)
-	// os.IsNotExist is translated to errors.IsNotFound
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Assert(err, gc.ErrorMatches, "reading client certificate: /etc/juju/lxd-client.crt not found")
-}
-
-func (s *environRawSuite) TestGetRemoteConfigFileError(c *gc.C) {
-	s.SetErrors(nil, errors.New("i/o error"))
-	_, err := getRemoteConfig(s.readFile, s.runCommand, s.spec)
-	c.Assert(err, gc.ErrorMatches, "reading client key: i/o error")
-}
-
-func (s *environRawSuite) TestGetRemoteConfigIPRouteFormatError(c *gc.C) {
-	s.runCommand = func(string, ...string) (string, error) {
-		return "this is not the prefix you're looking for", nil
-	}
-	_, err := getRemoteConfig(s.readFile, s.runCommand, s.spec)
-	c.Assert(err, gc.ErrorMatches,
-		`getting gateway address: unexpected output from "ip route": this is not the prefix you're looking for`)
-}
-
-func (s *environRawSuite) TestGetRemoteConfigIPRouteCommandError(c *gc.C) {
-	s.SetErrors(nil, nil, nil, errors.New("buh bow"))
-	_, err := getRemoteConfig(s.readFile, s.runCommand, s.spec)
-	c.Assert(err, gc.ErrorMatches, `getting gateway address: buh bow`)
-}
-
-func (s *environRawSuite) TestGetRemoteConfigWithEndpoint(c *gc.C) {
-	spec := s.spec
-	spec.Endpoint = "1.2.3.4"
-	cfg, err := getRemoteConfig(s.readFile, s.runCommand, spec)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg, jc.DeepEquals, &lxdclient.Config{
-		Remote: lxdclient.Remote{
-			Name:     "remote",
-			Host:     "1.2.3.4",
-			Protocol: "lxd",
-			Cert: &lxdclient.Cert{
-				CertPEM: []byte("content:/etc/juju/lxd-client.crt"),
-				KeyPEM:  []byte("content:/etc/juju/lxd-client.key"),
-			},
-			ServerPEMCert: "content:/etc/juju/lxd-server.crt",
+			ServerPEMCert: "server.crt",
 		},
 	})
 }

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -6,6 +6,7 @@
 package lxd_test
 
 import (
+	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -32,9 +33,7 @@ func (s *environSuite) TestName(c *gc.C) {
 }
 
 func (s *environSuite) TestProvider(c *gc.C) {
-	provider := s.Env.Provider()
-
-	c.Check(provider, gc.Equals, lxd.Provider)
+	c.Assert(s.Env.Provider(), gc.Equals, s.Provider)
 }
 
 func (s *environSuite) TestSetConfigOkay(c *gc.C) {
@@ -81,6 +80,54 @@ func (s *environSuite) TestBootstrapOkay(c *gc.C) {
 }
 
 func (s *environSuite) TestBootstrapAPI(c *gc.C) {
+	ctx := envtesting.BootstrapContext(c)
+	params := environs.BootstrapParams{
+		ControllerConfig: coretesting.FakeControllerConfig(),
+	}
+	_, err := s.Env.Bootstrap(ctx, params)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, fingerprint := s.TestingCert(c)
+	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "CertByFingerprint",
+		Args: []interface{}{
+			fingerprint,
+		},
+	}, {
+		FuncName: "Bootstrap",
+		Args: []interface{}{
+			ctx,
+			params,
+		},
+	}})
+}
+
+func (s *environSuite) TestBootstrapAddsCertLocal(c *gc.C) {
+	s.Stub.SetErrors(errors.NotFoundf("cert"), errors.New("upload fails"))
+	ctx := envtesting.BootstrapContext(c)
+	params := environs.BootstrapParams{
+		ControllerConfig: coretesting.FakeControllerConfig(),
+	}
+	_, err := s.Env.Bootstrap(ctx, params)
+	c.Assert(err, gc.ErrorMatches, `adding certificate "juju": upload fails`)
+
+	cert, fingerprint := s.TestingCert(c)
+	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "CertByFingerprint",
+		Args: []interface{}{
+			fingerprint,
+		},
+	}, {
+		FuncName: "AddCert",
+		Args: []interface{}{
+			cert,
+		},
+	}})
+}
+
+func (s *environSuite) TestBootstrapAddsCertNonLocal(c *gc.C) {
+	// non-local never attempts to upload the cert
+	s.SetEnvironLocal(false)
 	ctx := envtesting.BootstrapContext(c)
 	params := environs.BootstrapParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
@@ -143,13 +190,28 @@ func (s *environSuite) TestDestroyHostedModels(c *gc.C) {
 	err := s.Env.DestroyController(s.Config.UUID())
 	c.Assert(err, jc.ErrorIsNil)
 
+	_, fingerprint := s.TestingCert(c)
 	fwname := common.EnvFullName(s.Env.Config().UUID())
 	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
 		{"Ports", []interface{}{fwname}},
 		{"Destroy", nil},
 		{"Instances", []interface{}{"juju-", lxdclient.AliveStatuses}},
-		{"Instances", []interface{}{"juju-", []string{}}},
 		{"RemoveInstances", []interface{}{"juju-", []string{machine1.Name}}},
+		{"RemoveCertByFingerprint", []interface{}{fingerprint}},
+	})
+}
+
+func (s *environSuite) TestDestroyControllerNonLocal(c *gc.C) {
+	// non-local never attempts to remove the cert
+	s.SetEnvironLocal(false)
+	err := s.Env.DestroyController(s.Config.UUID())
+	c.Assert(err, jc.ErrorIsNil)
+
+	fwname := common.EnvFullName(s.Env.Config().UUID())
+	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+		{"Ports", []interface{}{fwname}},
+		{"Destroy", nil},
+		{"Instances", []interface{}{"juju-", lxdclient.AliveStatuses}},
 	})
 }
 

--- a/provider/lxd/export_test.go
+++ b/provider/lxd/export_test.go
@@ -5,15 +5,11 @@
 
 package lxd
 
-import (
-	"github.com/juju/juju/environs"
-	"github.com/juju/juju/tools/lxdclient"
-)
+import "github.com/juju/juju/tools/lxdclient"
 
 var (
-	Provider           environs.EnvironProvider = providerInstance
-	GlobalFirewallName                          = (*environ).globalFirewallName
-	NewInstance                                 = newInstance
+	GlobalFirewallName = (*environ).globalFirewallName
+	NewInstance        = newInstance
 )
 
 func ExposeInstRaw(inst *environInstance) *lxdclient.Instance {

--- a/provider/lxd/init.go
+++ b/provider/lxd/init.go
@@ -11,5 +11,5 @@ import (
 )
 
 func init() {
-	environs.RegisterProvider(lxdnames.ProviderType, providerInstance)
+	environs.RegisterProvider(lxdnames.ProviderType, NewProvider())
 }

--- a/provider/lxd/lxd.go
+++ b/provider/lxd/lxd.go
@@ -13,8 +13,7 @@ import (
 
 // The metadata keys used when creating new instances.
 const (
-	metadataKeyCloudInit              = lxdclient.UserdataKey
-	metadataKeyCertificateFingerprint = lxdclient.CertificateFingerprintKey
+	metadataKeyCloudInit = lxdclient.UserdataKey
 )
 
 var (

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -6,9 +6,13 @@
 package lxd
 
 import (
+	"net"
+
 	"github.com/juju/errors"
 	"github.com/juju/jsonschema"
 	"github.com/juju/schema"
+	"github.com/juju/utils"
+	"github.com/lxc/lxd/shared"
 	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/cloud"
@@ -19,35 +23,55 @@ import (
 
 type environProvider struct {
 	environProviderCredentials
+	interfaceAddress func(string) (string, error)
 }
 
-var providerInstance environProvider
+// NewProvider returns a new LXD EnvironProvider.
+func NewProvider() environs.EnvironProvider {
+	return &environProvider{
+		environProviderCredentials: environProviderCredentials{
+			generateMemCert:     shared.GenerateMemCert,
+			newLocalRawProvider: newLocalRawProvider,
+			lookupHost:          net.LookupHost,
+			interfaceAddrs:      net.InterfaceAddrs,
+		},
+		interfaceAddress: utils.GetAddressForInterface,
+	}
+}
 
 // Open implements environs.EnvironProvider.
-func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
-	if err := validateCloudSpec(args.Cloud); err != nil {
+func (p *environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+	local, err := p.validateCloudSpec(args.Cloud)
+	if err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}
-	env, err := newEnviron(args.Cloud, args.Config, newRawProvider)
+	env, err := newEnviron(
+		p,
+		local,
+		args.Cloud,
+		args.Config,
+		newRawProvider,
+	)
 	return env, errors.Trace(err)
 }
 
 // CloudSchema returns the schema used to validate input for add-cloud.  Since
 // this provider does not support custom clouds, this always returns nil.
-func (p environProvider) CloudSchema() *jsonschema.Schema {
+func (p *environProvider) CloudSchema() *jsonschema.Schema {
 	return nil
 }
 
 // PrepareConfig implements environs.EnvironProvider.
-func (p environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
-	if err := validateCloudSpec(args.Cloud); err != nil {
+func (p *environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
+	_, err := p.validateCloudSpec(args.Cloud)
+	if err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}
 	return args.Config, nil
 }
 
 // Validate implements environs.EnvironProvider.
-func (environProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {
+func (*environProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {
 	if _, err := newValidConfig(cfg); err != nil {
 		return nil, errors.Annotate(err, "invalid base config")
 	}
@@ -55,42 +79,91 @@ func (environProvider) Validate(cfg, old *config.Config) (valid *config.Config, 
 }
 
 // DetectClouds implements environs.CloudDetector.
-func (environProvider) DetectClouds() ([]cloud.Cloud, error) {
-	localhostCloud, err := localhostCloud()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+func (p *environProvider) DetectClouds() ([]cloud.Cloud, error) {
 	return []cloud.Cloud{localhostCloud}, nil
 }
 
 // DetectCloud implements environs.CloudDetector.
-func (environProvider) DetectCloud(name string) (cloud.Cloud, error) {
+func (p *environProvider) DetectCloud(name string) (cloud.Cloud, error) {
 	// For now we just return a hard-coded "localhost" cloud,
 	// i.e. the local LXD daemon. We may later want to detect
 	// locally-configured remotes.
 	switch name {
 	case "lxd", "localhost":
-		return localhostCloud()
+		return localhostCloud, nil
 	}
 	return cloud.Cloud{}, errors.NotFoundf("cloud %s", name)
 }
 
-func localhostCloud() (cloud.Cloud, error) {
-	return cloud.Cloud{
-		Name: lxdnames.DefaultCloud,
-		Type: lxdnames.ProviderType,
-		AuthTypes: []cloud.AuthType{
-			cloud.EmptyAuthType,
-		},
-		Regions: []cloud.Region{{
-			Name: lxdnames.DefaultRegion,
-		}},
-		Description: cloud.DefaultCloudDescription(lxdnames.ProviderType),
-	}, nil
+// FinalizeCloud is part of the environs.CloudFinalizer interface.
+func (p *environProvider) FinalizeCloud(
+	ctx environs.FinalizeCloudContext,
+	in cloud.Cloud,
+) (cloud.Cloud, error) {
+
+	var hostAddress string
+	getHostAddress := func() (string, error) {
+		raw, err := p.newLocalRawProvider()
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		bridgeName := raw.DefaultProfileBridgeName()
+		hostAddress, err = p.interfaceAddress(bridgeName)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		ctx.Verbosef(
+			"Resolved LXD host address on bridge %s: %s",
+			bridgeName, hostAddress,
+		)
+		return hostAddress, nil
+	}
+	resolveEndpoint := func(ep *string) error {
+		if *ep != "" {
+			return nil
+		}
+		if hostAddress == "" {
+			var err error
+			hostAddress, err = getHostAddress()
+			if err != nil {
+				return err
+			}
+		}
+		*ep = hostAddress
+		return nil
+	}
+
+	if err := resolveEndpoint(&in.Endpoint); err != nil {
+		return cloud.Cloud{}, errors.Trace(err)
+	}
+	for i := range in.Regions {
+		if err := resolveEndpoint(&in.Regions[i].Endpoint); err != nil {
+			return cloud.Cloud{}, errors.Trace(err)
+		}
+	}
+	return in, nil
+}
+
+// localhostCloud is the predefined "localhost" LXD cloud. We leave the
+// endpoints empty to indicate that LXD is on the local host. When the
+// cloud is finalized (see FinalizeCloud), we resolve the bridge address
+// of the LXD host, and use that as the endpoint.
+var localhostCloud = cloud.Cloud{
+	Name: lxdnames.DefaultCloud,
+	Type: lxdnames.ProviderType,
+	AuthTypes: []cloud.AuthType{
+		cloud.CertificateAuthType,
+	},
+	Endpoint: "",
+	Regions: []cloud.Region{{
+		Name:     lxdnames.DefaultRegion,
+		Endpoint: "",
+	}},
+	Description: cloud.DefaultCloudDescription(lxdnames.ProviderType),
 }
 
 // DetectRegions implements environs.CloudRegionDetector.
-func (environProvider) DetectRegions() ([]cloud.Region, error) {
+func (*environProvider) DetectRegions() ([]cloud.Region, error) {
 	// For now we just return a hard-coded "localhost" region,
 	// i.e. the local LXD daemon. We may later want to detect
 	// locally-configured remotes.
@@ -98,7 +171,7 @@ func (environProvider) DetectRegions() ([]cloud.Region, error) {
 }
 
 // Schema returns the configuration schema for an environment.
-func (environProvider) Schema() environschema.Fields {
+func (*environProvider) Schema() environschema.Fields {
 	fields, err := config.Schema(configSchema)
 	if err != nil {
 		panic(err)
@@ -106,26 +179,51 @@ func (environProvider) Schema() environschema.Fields {
 	return fields
 }
 
-func validateCloudSpec(spec environs.CloudSpec) error {
+func (p *environProvider) validateCloudSpec(spec environs.CloudSpec) (local bool, _ error) {
 	if err := spec.Validate(); err != nil {
-		return errors.Trace(err)
+		return false, errors.Trace(err)
 	}
-	if spec.Credential != nil {
-		if authType := spec.Credential.AuthType(); authType != cloud.EmptyAuthType {
-			return errors.NotSupportedf("%q auth-type", authType)
+	if spec.Credential == nil {
+		return false, errors.NotValidf("missing credential")
+	}
+	if spec.Endpoint != "" {
+		var err error
+		local, err = p.isLocalEndpoint(spec.Endpoint)
+		if err != nil {
+			return false, errors.Trace(err)
 		}
+	} else {
+		// No endpoint specified, so assume we're local. This
+		// will happen, for example, when destroying a 2.0
+		// LXD controller.
+		local = true
 	}
-	return nil
+	switch authType := spec.Credential.AuthType(); authType {
+	case cloud.EmptyAuthType:
+		if !local {
+			// The empty auth-type is only valid
+			// when the endpoint is local to the
+			// machine running this process.
+			return false, errors.NotSupportedf("%q auth-type for non-local LXD", authType)
+		}
+	case cloud.CertificateAuthType:
+		if _, _, ok := getCerts(spec); !ok {
+			return false, errors.NotValidf("certificate credentials")
+		}
+	default:
+		return false, errors.NotSupportedf("%q auth-type", authType)
+	}
+	return local, nil
 }
 
 // ConfigSchema returns extra config attributes specific
 // to this provider only.
-func (p environProvider) ConfigSchema() schema.Fields {
+func (p *environProvider) ConfigSchema() schema.Fields {
 	return configFields
 }
 
 // ConfigDefaults returns the default values for the
 // provider specific config attributes.
-func (p environProvider) ConfigDefaults() schema.Defaults {
+func (p *environProvider) ConfigDefaults() schema.Defaults {
 	return configDefaults
 }

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -8,6 +8,7 @@ package lxd_test
 import (
 	"fmt"
 
+	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
@@ -49,59 +50,80 @@ type providerSuite struct {
 
 func (s *providerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-
-	provider, err := environs.Provider("lxd")
-	c.Assert(err, jc.ErrorIsNil)
-	s.provider = provider
 }
 
 func (s *providerSuite) TestDetectClouds(c *gc.C) {
-	c.Assert(s.provider, gc.Implements, new(environs.CloudDetector))
-	clouds, err := s.provider.(environs.CloudDetector).DetectClouds()
+	clouds, err := s.Provider.DetectClouds()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(clouds, gc.HasLen, 1)
 	s.assertLocalhostCloud(c, clouds[0])
 }
 
 func (s *providerSuite) TestDetectCloud(c *gc.C) {
-	detector := s.provider.(environs.CloudDetector)
-	cloud, err := detector.DetectCloud("localhost")
+	cloud, err := s.Provider.DetectCloud("localhost")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertLocalhostCloud(c, cloud)
-	cloud, err = detector.DetectCloud("lxd")
+	cloud, err = s.Provider.DetectCloud("lxd")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertLocalhostCloud(c, cloud)
 }
 
 func (s *providerSuite) TestDetectCloudError(c *gc.C) {
-	detector := s.provider.(environs.CloudDetector)
-	_, err := detector.DetectCloud("foo")
+	_, err := s.Provider.DetectCloud("foo")
 	c.Assert(err, gc.ErrorMatches, `cloud foo not found`)
 }
 
 func (s *providerSuite) assertLocalhostCloud(c *gc.C, found cloud.Cloud) {
 	c.Assert(found, jc.DeepEquals, cloud.Cloud{
-		Name:        "localhost",
-		Type:        "lxd",
-		AuthTypes:   []cloud.AuthType{cloud.EmptyAuthType},
-		Regions:     []cloud.Region{{Name: "localhost"}},
+		Name:      "localhost",
+		Type:      "lxd",
+		AuthTypes: []cloud.AuthType{cloud.CertificateAuthType},
+		Regions: []cloud.Region{{
+			Name: "localhost",
+		}},
 		Description: "LXD Container Hypervisor",
 	})
 }
 
+func (s *providerSuite) TestFinalizeCloud(c *gc.C) {
+	in := cloud.Cloud{
+		Name:      "foo",
+		Type:      "lxd",
+		AuthTypes: []cloud.AuthType{cloud.CertificateAuthType},
+		Regions: []cloud.Region{{
+			Name: "bar",
+		}},
+	}
+
+	var ctx mockContext
+	out, err := s.Provider.FinalizeCloud(&ctx, in)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(out, jc.DeepEquals, cloud.Cloud{
+		Name:      "foo",
+		Type:      "lxd",
+		AuthTypes: []cloud.AuthType{cloud.CertificateAuthType},
+		Endpoint:  "1.2.3.4",
+		Regions: []cloud.Region{{
+			Name:     "bar",
+			Endpoint: "1.2.3.4",
+		}},
+	})
+	ctx.CheckCallNames(c, "Verbosef")
+	ctx.CheckCall(
+		c, 0, "Verbosef", "Resolved LXD host address on bridge %s: %s",
+		[]interface{}{"test-bridge", "1.2.3.4"},
+	)
+}
+
 func (s *providerSuite) TestDetectRegions(c *gc.C) {
-	c.Assert(s.provider, gc.Implements, new(environs.CloudRegionDetector))
-	regions, err := s.provider.(environs.CloudRegionDetector).DetectRegions()
+	regions, err := s.Provider.DetectRegions()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(regions, jc.DeepEquals, []cloud.Region{{Name: lxdnames.DefaultRegion}})
 }
 
-func (s *providerSuite) TestRegistered(c *gc.C) {
-	c.Check(s.provider, gc.Equals, lxd.Provider)
-}
-
 func (s *providerSuite) TestValidate(c *gc.C) {
-	validCfg, err := s.provider.Validate(s.Config, nil)
+	validCfg, err := s.Provider.Validate(s.Config, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	validAttrs := validCfg.AllAttrs()
 
@@ -151,7 +173,7 @@ func (s *ProviderFunctionalSuite) TestPrepareConfig(c *gc.C) {
 }
 
 func (s *ProviderFunctionalSuite) TestPrepareConfigUnsupportedAuthType(c *gc.C) {
-	cred := cloud.NewCredential(cloud.CertificateAuthType, nil)
+	cred := cloud.NewCredential("foo", nil)
 	_, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
 		Cloud: environs.CloudSpec{
 			Type:       "lxd",
@@ -159,5 +181,38 @@ func (s *ProviderFunctionalSuite) TestPrepareConfigUnsupportedAuthType(c *gc.C) 
 			Credential: &cred,
 		},
 	})
-	c.Assert(err, gc.ErrorMatches, `validating cloud spec: "certificate" auth-type not supported`)
+	c.Assert(err, gc.ErrorMatches, `validating cloud spec: "foo" auth-type not supported`)
+}
+
+func (s *ProviderFunctionalSuite) TestPrepareConfigInvalidCertificateAttrs(c *gc.C) {
+	cred := cloud.NewCredential(cloud.CertificateAuthType, map[string]string{})
+	_, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
+		Cloud: environs.CloudSpec{
+			Type:       "lxd",
+			Name:       "remotehost",
+			Credential: &cred,
+		},
+	})
+	c.Assert(err, gc.ErrorMatches, `validating cloud spec: certificate credentials not valid`)
+}
+
+func (s *ProviderFunctionalSuite) TestPrepareConfigEmptyAuthNonLocal(c *gc.C) {
+	cred := cloud.NewEmptyCredential()
+	_, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
+		Cloud: environs.CloudSpec{
+			Type:       "lxd",
+			Name:       "remotehost",
+			Endpoint:   "8.8.8.8",
+			Credential: &cred,
+		},
+	})
+	c.Assert(err, gc.ErrorMatches, `validating cloud spec: "empty" auth-type for non-local LXD not supported`)
+}
+
+type mockContext struct {
+	gitjujutesting.Stub
+}
+
+func (c *mockContext) Verbosef(f string, args ...interface{}) {
+	c.MethodCall(c, "Verbosef", f, args)
 }

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -6,6 +6,7 @@
 package lxd
 
 import (
+	"net"
 	"os"
 
 	"github.com/juju/errors"
@@ -15,6 +16,7 @@ import (
 	"github.com/lxc/lxd/shared"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cloudconfig/providerinit"
 	"github.com/juju/juju/constraints"
@@ -93,6 +95,7 @@ type BaseSuiteUnpatched struct {
 
 	Config    *config.Config
 	EnvConfig *environConfig
+	Provider  *environProvider
 	Env       *environ
 
 	Addresses     []network.Address
@@ -105,7 +108,9 @@ type BaseSuiteUnpatched struct {
 	StartInstArgs environs.StartInstanceParams
 	//InstanceType  instances.InstanceType
 
-	Ports []network.PortRange
+	Ports          []network.PortRange
+	EndpointAddrs  []string
+	InterfaceAddrs []net.Addr
 }
 
 func (s *BaseSuiteUnpatched) SetUpSuite(c *gc.C) {
@@ -124,17 +129,43 @@ func (s *BaseSuiteUnpatched) SetUpSuite(c *gc.C) {
 func (s *BaseSuiteUnpatched) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 
+	s.initProvider(c)
 	s.initEnv(c)
 	s.initInst(c)
 	s.initNet(c)
 }
 
+func (s *BaseSuiteUnpatched) initProvider(c *gc.C) {
+	s.Provider = &environProvider{}
+	s.EndpointAddrs = []string{"1.2.3.4"}
+	s.InterfaceAddrs = []net.Addr{
+		&net.IPNet{IP: net.ParseIP("127.0.0.1")},
+		&net.IPNet{IP: net.ParseIP("1.2.3.4")},
+	}
+}
+
 func (s *BaseSuiteUnpatched) initEnv(c *gc.C) {
+	certCred := cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
+		"client-cert": testing.CACert,
+		"client-key":  testing.CAKey,
+		"server-cert": testing.ServerCert,
+	})
 	s.Env = &environ{
-		name: "lxd",
+		local: true,
+		cloud: environs.CloudSpec{
+			Name:       "localhost",
+			Type:       "lxd",
+			Credential: &certCred,
+		},
+		provider: s.Provider,
+		name:     "lxd",
 	}
 	cfg := s.NewConfig(c, nil)
 	s.setConfig(c, cfg)
+}
+
+func (s *BaseSuiteUnpatched) SetEnvironLocal(local bool) {
+	s.Env.local = local
 }
 
 func (s *BaseSuiteUnpatched) Prefix() string {
@@ -307,14 +338,53 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.Common = &stubCommon{stub: s.Stub}
 
 	// Patch out all expensive external deps.
-	s.Env.raw = &rawProvider{
+	raw := &rawProvider{
 		lxdCerts:     s.Client,
 		lxdConfig:    s.Client,
 		lxdInstances: s.Client,
+		lxdProfiles:  s.Client,
 		lxdImages:    s.Client,
 		Firewaller:   s.Firewaller,
+		remote: lxdclient.Remote{
+			Cert: &lxdclient.Cert{
+				Name:    "juju",
+				CertPEM: []byte(testing.CACert),
+				KeyPEM:  []byte(testing.CAKey),
+			},
+		},
+	}
+	s.Env.raw = raw
+	s.Provider.generateMemCert = func(client bool) (cert, key []byte, _ error) {
+		s.Stub.AddCall("GenerateMemCert", client)
+		return []byte("client.crt"), []byte("client.key"), s.Stub.NextErr()
+	}
+	s.Provider.newLocalRawProvider = func() (*rawProvider, error) {
+		return raw, nil
+	}
+	s.Provider.lookupHost = func(host string) ([]string, error) {
+		s.Stub.AddCall("LookupHost", host)
+		return s.EndpointAddrs, s.Stub.NextErr()
+	}
+	s.Provider.interfaceAddress = func(iface string) (string, error) {
+		s.Stub.AddCall("InterfaceAddress", iface)
+		return "1.2.3.4", s.Stub.NextErr()
+	}
+	s.Provider.interfaceAddrs = func() ([]net.Addr, error) {
+		s.Stub.AddCall("InterfaceAddrs")
+		return s.InterfaceAddrs, s.Stub.NextErr()
 	}
 	s.Env.base = s.Common
+}
+
+func (s *BaseSuite) TestingCert(c *gc.C) (lxdclient.Cert, string) {
+	cert := lxdclient.Cert{
+		Name:    "juju",
+		CertPEM: []byte(testing.CACert),
+		KeyPEM:  []byte(testing.CAKey),
+	}
+	fingerprint, err := cert.Fingerprint()
+	c.Assert(err, jc.ErrorIsNil)
+	return cert, fingerprint
 }
 
 func (s *BaseSuite) CheckNoAPI(c *gc.C) {
@@ -470,6 +540,11 @@ func (conn *StubClient) RemoveCertByFingerprint(fingerprint string) error {
 	return conn.NextErr()
 }
 
+func (conn *StubClient) CertByFingerprint(fingerprint string) (shared.CertInfo, error) {
+	conn.AddCall("CertByFingerprint", fingerprint)
+	return shared.CertInfo{}, conn.NextErr()
+}
+
 func (conn *StubClient) ServerStatus() (*shared.ServerState, error) {
 	conn.AddCall("ServerStatus")
 	if err := conn.NextErr(); err != nil {
@@ -490,6 +565,21 @@ func (conn *StubClient) SetServerConfig(k, v string) error {
 func (conn *StubClient) SetContainerConfig(container, k, v string) error {
 	conn.AddCall("SetContainerConfig", container, k, v)
 	return conn.NextErr()
+}
+
+func (conn *StubClient) DefaultProfileBridgeName() string {
+	conn.AddCall("DefaultProfileBridgeName")
+	return "test-bridge"
+}
+
+func (conn *StubClient) CreateProfile(name string, attrs map[string]string) error {
+	conn.AddCall("CreateProfile", name, attrs)
+	return conn.NextErr()
+}
+
+func (conn *StubClient) HasProfile(name string) (bool, error) {
+	conn.AddCall("HasProfile", name)
+	return false, conn.NextErr()
 }
 
 // TODO(ericsnow) Move stubFirewaller to environs/testing or provider/common/testing.

--- a/provider/lxd/upgrades.go
+++ b/provider/lxd/upgrades.go
@@ -1,0 +1,59 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build go1.3
+
+package lxd
+
+import (
+	"os"
+	"path"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/series"
+
+	"github.com/juju/juju/cloud"
+	jujupaths "github.com/juju/juju/juju/paths"
+)
+
+// ReadLegacyCloudCredentials reads cloud credentials off disk for an old
+// LXD controller, and returns them as a cloud.Credential with the
+// certificate auth-type.
+//
+// If the credential files are missing from the filesystem, an error
+// satisfying errors.IsNotFound will be returned.
+func ReadLegacyCloudCredentials(readFile func(string) ([]byte, error)) (cloud.Credential, error) {
+	var (
+		jujuConfDir    = jujupaths.MustSucceed(jujupaths.ConfDir(series.LatestLts()))
+		clientCertPath = path.Join(jujuConfDir, "lxd-client.crt")
+		clientKeyPath  = path.Join(jujuConfDir, "lxd-client.key")
+		serverCertPath = path.Join(jujuConfDir, "lxd-server.crt")
+	)
+	readFileString := func(path string) (string, error) {
+		data, err := readFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				err = errors.NotFoundf("%s", path)
+			}
+			return "", err
+		}
+		return string(data), nil
+	}
+	clientCert, err := readFileString(clientCertPath)
+	if err != nil {
+		return cloud.Credential{}, errors.Annotate(err, "reading client certificate")
+	}
+	clientKey, err := readFileString(clientKeyPath)
+	if err != nil {
+		return cloud.Credential{}, errors.Annotate(err, "reading client key")
+	}
+	serverCert, err := readFileString(serverCertPath)
+	if err != nil {
+		return cloud.Credential{}, errors.Annotate(err, "reading server certificate")
+	}
+	return cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
+		credAttrServerCert: serverCert,
+		credAttrClientCert: clientCert,
+		credAttrClientKey:  clientKey,
+	}), nil
+}

--- a/provider/lxd/upgrades_test.go
+++ b/provider/lxd/upgrades_test.go
@@ -1,0 +1,52 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build go1.3
+
+package lxd_test
+
+import (
+	"os"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/provider/lxd"
+)
+
+type upgradesSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&upgradesSuite{})
+
+func (s *upgradesSuite) TestReadLegacyCloudCredentials(c *gc.C) {
+	var paths []string
+	readFile := func(path string) ([]byte, error) {
+		paths = append(paths, path)
+		return []byte("content: " + path), nil
+	}
+	cred, err := lxd.ReadLegacyCloudCredentials(readFile)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cred, jc.DeepEquals, cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
+		"client-cert": "content: /etc/juju/lxd-client.crt",
+		"client-key":  "content: /etc/juju/lxd-client.key",
+		"server-cert": "content: /etc/juju/lxd-server.crt",
+	}))
+	c.Assert(paths, jc.DeepEquals, []string{
+		"/etc/juju/lxd-client.crt",
+		"/etc/juju/lxd-client.key",
+		"/etc/juju/lxd-server.crt",
+	})
+}
+
+func (s *upgradesSuite) TestReadLegacyCloudCredentialsFileNotExist(c *gc.C) {
+	readFile := func(path string) ([]byte, error) {
+		return nil, os.ErrNotExist
+	}
+	_, err := lxd.ReadLegacyCloudCredentials(readFile)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -14,6 +14,8 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/cloud"
 )
 
 var upgradesLogger = loggo.GetLogger("juju.state.upgrade")
@@ -376,4 +378,86 @@ func AddLocalCharmSequences(st *State) error {
 	}
 	err = st.runRawTransaction(ops)
 	return errors.Annotate(err, "removing dead charms")
+}
+
+// UpdateLegacyLXDCloudCredentials updates the cloud credentials for the
+// LXD-based controller, and updates the cloud endpoint with the given
+// value.
+func UpdateLegacyLXDCloudCredentials(
+	st *State,
+	endpoint string,
+	credential cloud.Credential,
+) error {
+	cloudOps, err := updateLegacyLXDCloudsOps(st, endpoint)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	credOps, err := updateLegacyLXDCredentialsOps(st, credential)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return st.runTransaction(append(cloudOps, credOps...))
+}
+
+func updateLegacyLXDCloudsOps(st *State, endpoint string) ([]txn.Op, error) {
+	clouds, err := st.Clouds()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var ops []txn.Op
+	for _, c := range clouds {
+		if c.Type != "lxd" {
+			continue
+		}
+		authTypes := []string{string(cloud.CertificateAuthType)}
+		set := bson.D{{"auth-types", authTypes}}
+		if c.Endpoint == "" {
+			set = append(set, bson.DocElem{"endpoint", endpoint})
+		}
+		for _, region := range c.Regions {
+			if region.Endpoint == "" {
+				set = append(set, bson.DocElem{
+					"regions." + region.Name + ".endpoint",
+					endpoint,
+				})
+			}
+		}
+		upgradesLogger.Infof("updating cloud %q: %v", c.Name, set)
+		ops = append(ops, txn.Op{
+			C:      cloudsC,
+			Id:     c.Name,
+			Assert: txn.DocExists,
+			Update: bson.D{{"$set", set}},
+		})
+	}
+	return ops, nil
+}
+
+func updateLegacyLXDCredentialsOps(st *State, cred cloud.Credential) ([]txn.Op, error) {
+	var ops []txn.Op
+	coll, closer := st.getRawCollection(cloudCredentialsC)
+	defer closer()
+	iter := coll.Find(bson.M{"auth-type": "empty"}).Iter()
+	var doc cloudCredentialDoc
+	for iter.Next(&doc) {
+		cloudCredentialTag, err := doc.cloudCredentialTag()
+		if err != nil {
+			upgradesLogger.Debugf("%v", err)
+			continue
+		}
+		c, err := st.Cloud(doc.Cloud)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if c.Type != "lxd" {
+			continue
+		}
+		op := updateCloudCredentialOp(cloudCredentialTag, cred)
+		upgradesLogger.Infof("updating credential %q: %v", cloudCredentialTag, op)
+		ops = append(ops, op)
+	}
+	if err := iter.Err(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return ops, nil
 }

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/juju/juju/cloud"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
@@ -295,25 +296,32 @@ func (s *upgradesSuite) TestStripLocalUserDomainLastConnection(c *gc.C) {
 }
 
 func (s *upgradesSuite) assertStrippedUserData(c *gc.C, coll *mgo.Collection, expected []bson.M) {
-	s.assertUpgradedData(c, StripLocalUserDomain, coll, expected)
+	s.assertUpgradedData(c, StripLocalUserDomain, expectUpgradedData{coll, expected})
 }
 
-func (s *upgradesSuite) assertUpgradedData(c *gc.C, upgrade func(*State) error, coll *mgo.Collection, expected []bson.M) {
+type expectUpgradedData struct {
+	coll     *mgo.Collection
+	expected []bson.M
+}
+
+func (s *upgradesSuite) assertUpgradedData(c *gc.C, upgrade func(*State) error, expect ...expectUpgradedData) {
 	// Two rounds to check idempotency.
 	for i := 0; i < 2; i++ {
 		err := upgrade(s.state)
 		c.Assert(err, jc.ErrorIsNil)
 
-		var docs []bson.M
-		err = coll.Find(nil).Sort("_id").All(&docs)
-		c.Assert(err, jc.ErrorIsNil)
-		for i, d := range docs {
-			doc := d
-			delete(doc, "txn-queue")
-			delete(doc, "txn-revno")
-			docs[i] = doc
+		for _, expect := range expect {
+			var docs []bson.M
+			err = expect.coll.Find(nil).Sort("_id").All(&docs)
+			c.Assert(err, jc.ErrorIsNil)
+			for i, d := range docs {
+				doc := d
+				delete(doc, "txn-queue")
+				delete(doc, "txn-revno")
+				docs[i] = doc
+			}
+			c.Assert(docs, jc.DeepEquals, expect.expected)
 		}
-		c.Assert(docs, jc.DeepEquals, expected)
 	}
 }
 
@@ -360,7 +368,7 @@ func (s *upgradesSuite) TestRenameAddModelPermission(c *gc.C) {
 		"subject-global-key": "mary@external",
 		"access":             "add-model",
 	}}
-	s.assertUpgradedData(c, RenameAddModelPermission, coll, expected)
+	s.assertUpgradedData(c, RenameAddModelPermission, expectUpgradedData{coll, expected})
 }
 
 func (s *upgradesSuite) TestDropOldLogIndex(c *gc.C) {
@@ -417,7 +425,7 @@ func (s *upgradesSuite) TestAddMigrationAttempt(c *gc.C) {
 			"attempt": 2,
 		},
 	}
-	s.assertUpgradedData(c, AddMigrationAttempt, coll, expected)
+	s.assertUpgradedData(c, AddMigrationAttempt, expectUpgradedData{coll, expected})
 }
 
 func (s *upgradesSuite) TestAddLocalCharmSequences(c *gc.C) {
@@ -469,7 +477,10 @@ func (s *upgradesSuite) TestAddLocalCharmSequences(c *gc.C) {
 		mkExpected(uuid1, "local:trusty/aaa", 4),
 		mkExpected(uuid1, "local:xenial/bbb", 6),
 	}
-	s.assertUpgradedData(c, AddLocalCharmSequences, sequences, expected)
+	s.assertUpgradedData(
+		c, AddLocalCharmSequences,
+		expectUpgradedData{sequences, expected},
+	)
 
 	// Expect Dead charm documents to be removed.
 	var docs []bson.M
@@ -500,4 +511,180 @@ func hasIndex(coll *mgo.Collection, key []string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func (s *upgradesSuite) TestUpdateLegacyLXDCloud(c *gc.C) {
+	cloudColl, cloudCloser := s.state.getRawCollection(cloudsC)
+	defer cloudCloser()
+	cloudCredColl, cloudCredCloser := s.state.getRawCollection(cloudCredentialsC)
+	defer cloudCredCloser()
+
+	_, err := cloudColl.RemoveAll(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = cloudCredColl.RemoveAll(nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = cloudColl.Insert(bson.M{
+		"_id":        "localhost",
+		"name":       "localhost",
+		"type":       "lxd",
+		"auth-types": []string{"empty"},
+		"endpoint":   "",
+		"regions": bson.M{
+			"localhost": bson.M{
+				"endpoint": "",
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = cloudCredColl.Insert(bson.M{
+		"_id":       "localhost#admin#streetcred",
+		"owner":     "admin",
+		"cloud":     "localhost",
+		"name":      "streetcred",
+		"revoked":   false,
+		"auth-type": "empty",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedClouds := []bson.M{{
+		"_id":        "localhost",
+		"name":       "localhost",
+		"type":       "lxd",
+		"auth-types": []interface{}{"certificate"},
+		"endpoint":   "foo",
+		"regions": bson.M{
+			"localhost": bson.M{
+				"endpoint": "foo",
+			},
+		},
+	}}
+
+	expectedCloudCreds := []bson.M{{
+		"_id":       "localhost#admin#streetcred",
+		"owner":     "admin",
+		"cloud":     "localhost",
+		"name":      "streetcred",
+		"revoked":   false,
+		"auth-type": "certificate",
+		"attributes": bson.M{
+			"foo": "bar",
+			"baz": "qux",
+		},
+	}}
+
+	newCred := cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
+		"foo": "bar",
+		"baz": "qux",
+	})
+	f := func(st *State) error {
+		return UpdateLegacyLXDCloudCredentials(st, "foo", newCred)
+	}
+	s.assertUpgradedData(c, f,
+		expectUpgradedData{cloudColl, expectedClouds},
+		expectUpgradedData{cloudCredColl, expectedCloudCreds},
+	)
+}
+
+func (s *upgradesSuite) TestUpdateLegacyLXDCloudUnchanged(c *gc.C) {
+	cloudColl, cloudCloser := s.state.getRawCollection(cloudsC)
+	defer cloudCloser()
+	cloudCredColl, cloudCredCloser := s.state.getRawCollection(cloudCredentialsC)
+	defer cloudCredCloser()
+
+	_, err := cloudColl.RemoveAll(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = cloudCredColl.RemoveAll(nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = cloudColl.Insert(bson.M{
+		// Non-LXD clouds should be altogether unchanged.
+		"_id":        "foo",
+		"name":       "foo",
+		"type":       "dummy",
+		"auth-types": []string{"empty"},
+		"endpoint":   "unchanged",
+	}, bson.M{
+		// A LXD cloud with endpoints already set should
+		// only have its auth-types updated.
+		"_id":        "localhost",
+		"name":       "localhost",
+		"type":       "lxd",
+		"auth-types": []string{"empty"},
+		"endpoint":   "unchanged",
+		"regions": bson.M{
+			"localhost": bson.M{
+				"endpoint": "unchanged",
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = cloudCredColl.Insert(bson.M{
+		// Credentials for non-LXD clouds should be unchanged.
+		"_id":       "foo#admin#default",
+		"owner":     "admin",
+		"cloud":     "foo",
+		"name":      "default",
+		"revoked":   false,
+		"auth-type": "empty",
+	}, bson.M{
+		// LXD credentials with an auth-type other than
+		// "empty" should be unchanged.
+		"_id":       "localhost#admin#streetcred",
+		"owner":     "admin",
+		"cloud":     "localhost",
+		"name":      "streetcred",
+		"revoked":   false,
+		"auth-type": "unchanged",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedClouds := []bson.M{{
+		"_id":        "foo",
+		"name":       "foo",
+		"type":       "dummy",
+		"auth-types": []interface{}{"empty"},
+		"endpoint":   "unchanged",
+	}, {
+		"_id":        "localhost",
+		"name":       "localhost",
+		"type":       "lxd",
+		"auth-types": []interface{}{"certificate"},
+		"endpoint":   "unchanged",
+		"regions": bson.M{
+			"localhost": bson.M{
+				"endpoint": "unchanged",
+			},
+		},
+	}}
+
+	expectedCloudCreds := []bson.M{{
+		"_id":       "foo#admin#default",
+		"owner":     "admin",
+		"cloud":     "foo",
+		"name":      "default",
+		"revoked":   false,
+		"auth-type": "empty",
+	}, {
+		"_id":       "localhost#admin#streetcred",
+		"owner":     "admin",
+		"cloud":     "localhost",
+		"name":      "streetcred",
+		"revoked":   false,
+		"auth-type": "unchanged",
+	}}
+
+	newCred := cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
+		"foo": "bar",
+		"baz": "qux",
+	})
+	f := func(st *State) error {
+		return UpdateLegacyLXDCloudCredentials(st, "foo", newCred)
+	}
+	s.assertUpgradedData(c, f,
+		expectUpgradedData{cloudColl, expectedClouds},
+		expectUpgradedData{cloudCredColl, expectedCloudCreds},
+	)
 }

--- a/tools/lxdclient/client_cert.go
+++ b/tools/lxdclient/client_cert.go
@@ -48,3 +48,19 @@ func (c certClient) RemoveCertByFingerprint(fingerprint string) error {
 	}
 	return nil
 }
+
+// CertByFingerprint returns information about a certificate with the
+// matching fingerprint. If there is no such certificate, an error
+// satisfying errors.IsNotFound is returned.
+func (c certClient) CertByFingerprint(fingerprint string) (shared.CertInfo, error) {
+	certs, err := c.raw.CertificateList()
+	if err != nil {
+		return shared.CertInfo{}, errors.Trace(err)
+	}
+	for _, cert := range certs {
+		if cert.Fingerprint == fingerprint {
+			return cert, nil
+		}
+	}
+	return shared.CertInfo{}, errors.NotFoundf("certificate with fingerprint %q", fingerprint)
+}

--- a/upgrades/lxd.go
+++ b/upgrades/lxd.go
@@ -1,0 +1,45 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build go1.3
+
+package upgrades
+
+import (
+	"io/ioutil"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+
+	"github.com/juju/juju/provider/lxd"
+	"github.com/juju/juju/state"
+)
+
+func updateLXDCloudCredentials(st *state.State) error {
+	creds, err := lxd.ReadLegacyCloudCredentials(ioutil.ReadFile)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Not running a LXD controller.
+			return nil
+		}
+		return errors.Annotate(err, "reading credentials from disk")
+	}
+	gatewayAddress, err := getDefaultGateway()
+	if err != nil {
+		return errors.Annotate(err, "reading gateway address")
+	}
+	return state.UpdateLegacyLXDCloudCredentials(st, gatewayAddress, creds)
+}
+
+func getDefaultGateway() (string, error) {
+	out, err := utils.RunCommand("ip", "route", "list", "match", "0/0")
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if !strings.HasPrefix(string(out), "default via") {
+		return "", errors.Errorf(`unexpected output from "ip route": %s`, out)
+	}
+	fields := strings.Fields(string(out))
+	return fields[2], nil
+}

--- a/upgrades/lxd_go12.go
+++ b/upgrades/lxd_go12.go
@@ -1,0 +1,15 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build !go1.3
+
+package upgrades
+
+import "github.com/juju/juju/state"
+
+func updateLXDCloudCredentials(st *state.State) error {
+	// The LXD provider is compiled out when Juju is
+	// built with Go 1.2 or earlier, so there is nothing
+	// to do.
+	return nil
+}

--- a/upgrades/steps_21.go
+++ b/upgrades/steps_21.go
@@ -31,5 +31,12 @@ func stateStepsFor21() []Step {
 				return state.AddLocalCharmSequences(context.State())
 			},
 		},
+		&upgradeStep{
+			description: "update lxd cloud/credentials",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return updateLXDCloudCredentials(context.State())
+			},
+		},
 	}
 }


### PR DESCRIPTION
## Description of change

We change the way the LXD provider conveys the
host address and credentials to the controller, by
using the existing environs.CloudSpec structure.

The lxd provider now reports a "localhost" cloud,
and its (new) FinalizeCloud method will fill in the
empty endpoints, equal to the address of the LXD
host on the LXD bridge interface.

An upgrade step is added that rewrites the cloud
and credential definitions in the state database.

Requires https://github.com/juju/juju/pull/6878

## QA steps

Scenario 1: fresh bootstrap (with standard lxdbr0)
1. juju bootstrap localhost
2. juju add-user billie
3. juju grant billie add-model
(as billie below)
4. juju register ...
5. juju add-model foo

Scenario 2: same as above, but with custom bridge to physical network

Scenario 3: upgrade from 2.0 (with standard lxdbr0)
1. juju bootstrap localhost (using juju 2.0)
2. juju upgrade-juju (using this branch)
3. juju add-model foo

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1633788