### PR TITLE
Add network interfaces to show-machine

### DIFF
--- a/apiserver/client/backend.go
+++ b/apiserver/client/backend.go
@@ -42,6 +42,8 @@ type Backend interface {
 	AllApplications() ([]*state.Application, error)
 	AllRemoteApplications() ([]*state.RemoteApplication, error)
 	AllMachines() ([]*state.Machine, error)
+	AllIPAddresses() ([]*state.Address, error)
+	AllLinkLayerDevices() ([]*state.LinkLayerDevice, error)
 	AllModels() ([]*state.Model, error)
 	AllRelations() ([]*state.Relation, error)
 	Annotations(state.GlobalEntity) (map[string]string, error)
@@ -67,6 +69,7 @@ type Backend interface {
 	SetAnnotations(state.GlobalEntity, map[string]string) error
 	SetModelAgentVersion(version.Number) error
 	SetModelConstraints(constraints.Value) error
+	Subnet(string) (*state.Subnet, error)
 	Unit(string) (Unit, error)
 	UpdateModelConfig(map[string]interface{}, []string, state.ValidateConfigFunc) error
 	Watch() *state.Multiwatcher

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -639,7 +639,21 @@ func makeMachineStatus(
 			logger.Debugf("error fetching public address: %q", err)
 		}
 		status.DNSName = addr.Value
-
+		mAddrs := machine.Addresses()
+		if len(mAddrs) == 0 {
+			logger.Debugf("no IP addresses fetched for machine %q", instid)
+			// At least give it the newly created DNSName address, if it exists.
+			if addr.Value != "" {
+				mAddrs = append(mAddrs, addr)
+			}
+		}
+		for _, mAddr := range mAddrs {
+			switch mAddr.Scope {
+			case network.ScopeMachineLocal, network.ScopeLinkLocal:
+				continue
+			}
+			status.IPAddresses = append(status.IPAddresses, mAddr.Value)
+		}
 		status.NetworkInterfaces = make(map[string]params.NetworkInterface, len(linkLayerDevices))
 		for _, llDev := range linkLayerDevices {
 			device := llDev.Name()

--- a/apiserver/client/status_test.go
+++ b/apiserver/client/status_test.go
@@ -84,10 +84,12 @@ func (s *statusUnitTestSuite) TestProcessMachinesWithOneMachineAndOneContainer(c
 		host.Id(): {host, container},
 	}
 
-	statuses := client.ProcessMachines(machines)
+	// TODO(macgreagoir) Pass in more than nil
+	statuses := client.ProcessMachines(machines, nil, nil, nil)
 	c.Assert(statuses, gc.Not(gc.IsNil))
 
-	containerStatus := client.MakeMachineStatus(container)
+	// TODO(macgreagoir) Pass in more than nil
+	containerStatus := client.MakeMachineStatus(container, nil, nil, nil)
 	c.Check(statuses[host.Id()].Containers[container.Id()].Id, gc.Equals, containerStatus.Id)
 }
 
@@ -103,7 +105,8 @@ func (s *statusUnitTestSuite) TestProcessMachinesWithEmbeddedContainers(c *gc.C)
 		},
 	}
 
-	statuses := client.ProcessMachines(machines)
+	// TODO(macgreagoir) Pass in more than nil
+	statuses := client.ProcessMachines(machines, nil, nil, nil)
 	c.Assert(statuses, gc.Not(gc.IsNil))
 
 	hostContainer := statuses[host.Id()].Containers

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -42,17 +42,17 @@ type ModelStatusInfo struct {
 // space name for any device with at least one associated IP address.
 type NetworkInterface struct {
 	// IPAddresses holds the IP addresses bound to this machine.
-	IPAddresses    []string `json:"ip-addresses" yaml:"ip-addresses"`
-	MACAddress     string   `json:"mac-address" yaml:"mac-address"`
-	Gateway        string   `json:"gateway,omitempty" yaml:"gateway,omitempty"`
-	DNSNameservers []string `json:"dns-nameservers,omitempty" yaml:"dns-nameservers,omitempty"`
+	IPAddresses    []string `json:"ip-addresses"`
+	MACAddress     string   `json:"mac-address"`
+	Gateway        string   `json:"gateway,omitempty"`
+	DNSNameservers []string `json:"dns-nameservers,omitempty"`
 
 	// Space holds the name of a space in which this devices IP addr's
 	// subnet belongs.
-	Space string `json:"space,omitempty" yaml:"space,omitempty"`
+	Space string `json:"space,omitempty"`
 
 	// Is this interface up?
-	IsUp bool `json:"is-up" yaml:"is-up"`
+	IsUp bool `json:"is-up"`
 }
 
 // MachineStatus holds status info about a machine.
@@ -60,6 +60,13 @@ type MachineStatus struct {
 	AgentStatus    DetailedStatus `json:"agent-status"`
 	InstanceStatus DetailedStatus `json:"instance-status"`
 	DNSName        string         `json:"dns-name"`
+
+	// IPAddresses holds the IP addresses known for this machine. It is
+	// here for backwards compatibility. It should be similar to its
+	// namesakes in NetworkInterfaces, but may also include any
+	// public/floating IP addresses not actually bound to the machine but
+	// known to the provider.
+	IPAddresses []string `json:"ip-addresses,omitempty"`
 
 	// InstanceId holds the unique identifier for this machine, based on
 	// what is supplied by the provider.
@@ -73,7 +80,7 @@ type MachineStatus struct {
 	Id string `json:"id"`
 
 	// NetworkInterfaces holds a map of NetworkInterface for this machine.
-	NetworkInterfaces map[string]NetworkInterface `json:"network-interfaces,omitempty" yaml:"network-interfaces,omitempty"`
+	NetworkInterfaces map[string]NetworkInterface `json:"network-interfaces,omitempty"`
 
 	// Containers holds the MachineStatus of any containers hosted on this
 	// machine.

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -38,15 +38,28 @@ type ModelStatusInfo struct {
 	ModelStatus      DetailedStatus `json:"model-status"`
 }
 
+// NetworkInterfaceStatus holds a /etc/network/interfaces-type data and the
+// space name for any device with at least one associated IP address.
+type NetworkInterface struct {
+	// IPAddresses holds the IP addresses bound to this machine.
+	IPAddresses    []string `json:"ip-addresses" yaml:"ip-addresses"`
+	MACAddress     string   `json:"mac-address" yaml:"mac-address"`
+	Gateway        string   `json:"gateway,omitempty" yaml:"gateway,omitempty"`
+	DNSNameservers []string `json:"dns-nameservers,omitempty" yaml:"dns-nameservers,omitempty"`
+
+	// Space holds the name of a space in which this devices IP addr's
+	// subnet belongs.
+	Space string `json:"space,omitempty" yaml:"space,omitempty"`
+
+	// Is this interface up?
+	IsUp bool `json:"is-up" yaml:"is-up"`
+}
+
 // MachineStatus holds status info about a machine.
 type MachineStatus struct {
 	AgentStatus    DetailedStatus `json:"agent-status"`
 	InstanceStatus DetailedStatus `json:"instance-status"`
-
-	DNSName string `json:"dns-name"`
-
-	// IPAddresses holds the IP addresses bound to this machine.
-	IPAddresses []string `json:"ip-addresses"`
+	DNSName        string         `json:"dns-name"`
 
 	// InstanceId holds the unique identifier for this machine, based on
 	// what is supplied by the provider.
@@ -59,6 +72,9 @@ type MachineStatus struct {
 	// Id is the Juju identifier for this machine in this model.
 	Id string `json:"id"`
 
+	// NetworkInterfaces holds a map of NetworkInterface for this machine.
+	NetworkInterfaces map[string]NetworkInterface `json:"network-interfaces,omitempty" yaml:"network-interfaces,omitempty"`
+
 	// Containers holds the MachineStatus of any containers hosted on this
 	// machine.
 	Containers map[string]MachineStatus `json:"containers"`
@@ -67,7 +83,7 @@ type MachineStatus struct {
 	// each constraint datum.
 	Constraints string `json:"constraints"`
 
-	// Hardware holds a string of space-separated key=value pairs of
+	// Hardware holds a string of space-separated key=value pairs for each
 	// hardware specification datum.
 	Hardware string `json:"hardware"`
 

--- a/cmd/juju/machine/list_test.go
+++ b/cmd/juju/machine/list_test.go
@@ -37,13 +37,19 @@ func (*fakeStatusAPI) Status(c []string) (*params.FullStatus, error) {
 				AgentStatus: params.DetailedStatus{
 					Status: "started",
 				},
-				DNSName: "10.0.0.1",
-				IPAddresses: []string{
-					"10.0.0.1",
-					"10.0.1.1",
+				DNSName:    "10.0.0.1",
+				InstanceId: "juju-badd06-0",
+				Series:     "trusty",
+				NetworkInterfaces: map[string]params.NetworkInterface{
+					"eth0": params.NetworkInterface{
+						IPAddresses: []string{
+							"10.0.0.1",
+							"10.0.1.1",
+						},
+						MACAddress: "aa:bb:cc:dd:ee:ff",
+						IsUp:       true,
+					},
 				},
-				InstanceId:  "juju-badd06-0",
-				Series:      "trusty",
 				Constraints: "mem=3584M",
 				Hardware:    "availability-zone=us-east-1",
 			},
@@ -52,26 +58,38 @@ func (*fakeStatusAPI) Status(c []string) (*params.FullStatus, error) {
 				AgentStatus: params.DetailedStatus{
 					Status: "started",
 				},
-				DNSName: "10.0.0.2",
-				IPAddresses: []string{
-					"10.0.0.2",
-					"10.0.1.2",
-				},
+				DNSName:    "10.0.0.2",
 				InstanceId: "juju-badd06-1",
 				Series:     "trusty",
+				NetworkInterfaces: map[string]params.NetworkInterface{
+					"eth0": params.NetworkInterface{
+						IPAddresses: []string{
+							"10.0.0.2",
+							"10.0.1.2",
+						},
+						MACAddress: "aa:bb:cc:dd:ee:ff",
+						IsUp:       true,
+					},
+				},
 				Containers: map[string]params.MachineStatus{
 					"1/lxd/0": {
 						Id: "1/lxd/0",
 						AgentStatus: params.DetailedStatus{
 							Status: "pending",
 						},
-						DNSName: "10.0.0.3",
-						IPAddresses: []string{
-							"10.0.0.3",
-							"10.0.1.3",
-						},
+						DNSName:    "10.0.0.3",
 						InstanceId: "juju-badd06-1-lxd-0",
 						Series:     "trusty",
+						NetworkInterfaces: map[string]params.NetworkInterface{
+							"eth0": params.NetworkInterface{
+								IPAddresses: []string{
+									"10.0.0.3",
+									"10.0.1.3",
+								},
+								MACAddress: "aa:bb:cc:dd:ee:ff",
+								IsUp:       true,
+							},
+						},
 					},
 				},
 			},
@@ -109,39 +127,51 @@ func (s *MachineListCommandSuite) TestListMachineYaml(c *gc.C) {
 		"    juju-status:\n"+
 		"      current: started\n"+
 		"    dns-name: 10.0.0.1\n"+
-		"    ip-addresses:\n"+
-		"    - 10.0.0.1\n"+
-		"    - 10.0.1.1\n"+
 		"    instance-id: juju-badd06-0\n"+
 		"    series: trusty\n"+
+		"    network-interfaces:\n"+
+		"      eth0:\n"+
+		"        ip-addresses:\n"+
+		"        - 10.0.0.1\n"+
+		"        - 10.0.1.1\n"+
+		"        mac-address: aa:bb:cc:dd:ee:ff\n"+
+		"        is-up: true\n"+
 		"    constraints: mem=3584M\n"+
 		"    hardware: availability-zone=us-east-1\n"+
 		"  \"1\":\n"+
 		"    juju-status:\n"+
 		"      current: started\n"+
 		"    dns-name: 10.0.0.2\n"+
-		"    ip-addresses:\n"+
-		"    - 10.0.0.2\n"+
-		"    - 10.0.1.2\n"+
 		"    instance-id: juju-badd06-1\n"+
 		"    series: trusty\n"+
+		"    network-interfaces:\n"+
+		"      eth0:\n"+
+		"        ip-addresses:\n"+
+		"        - 10.0.0.2\n"+
+		"        - 10.0.1.2\n"+
+		"        mac-address: aa:bb:cc:dd:ee:ff\n"+
+		"        is-up: true\n"+
 		"    containers:\n"+
 		"      1/lxd/0:\n"+
 		"        juju-status:\n"+
 		"          current: pending\n"+
 		"        dns-name: 10.0.0.3\n"+
-		"        ip-addresses:\n"+
-		"        - 10.0.0.3\n"+
-		"        - 10.0.1.3\n"+
 		"        instance-id: juju-badd06-1-lxd-0\n"+
-		"        series: trusty\n")
+		"        series: trusty\n"+
+		"        network-interfaces:\n"+
+		"          eth0:\n"+
+		"            ip-addresses:\n"+
+		"            - 10.0.0.3\n"+
+		"            - 10.0.1.3\n"+
+		"            mac-address: aa:bb:cc:dd:ee:ff\n"+
+		"            is-up: true\n")
 }
 
 func (s *MachineListCommandSuite) TestListMachineJson(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineListCommand(), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"{\"model\":\"dummyenv\",\"machines\":{\"0\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.1\",\"ip-addresses\":[\"10.0.0.1\",\"10.0.1.1\"],\"instance-id\":\"juju-badd06-0\",\"machine-status\":{},\"series\":\"trusty\",\"constraints\":\"mem=3584M\",\"hardware\":\"availability-zone=us-east-1\"},\"1\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.2\",\"ip-addresses\":[\"10.0.0.2\",\"10.0.1.2\"],\"instance-id\":\"juju-badd06-1\",\"machine-status\":{},\"series\":\"trusty\",\"containers\":{\"1/lxd/0\":{\"juju-status\":{\"current\":\"pending\"},\"dns-name\":\"10.0.0.3\",\"ip-addresses\":[\"10.0.0.3\",\"10.0.1.3\"],\"instance-id\":\"juju-badd06-1-lxd-0\",\"machine-status\":{},\"series\":\"trusty\"}}}}}\n")
+		"{\"model\":\"dummyenv\",\"machines\":{\"0\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.1\",\"instance-id\":\"juju-badd06-0\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.1\",\"10.0.1.1\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}},\"constraints\":\"mem=3584M\",\"hardware\":\"availability-zone=us-east-1\"},\"1\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.2\",\"instance-id\":\"juju-badd06-1\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.2\",\"10.0.1.2\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}},\"containers\":{\"1/lxd/0\":{\"juju-status\":{\"current\":\"pending\"},\"dns-name\":\"10.0.0.3\",\"instance-id\":\"juju-badd06-1-lxd-0\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.3\",\"10.0.1.3\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}}}}}}}\n")
 }
 
 func (s *MachineListCommandSuite) TestListMachineArgsError(c *gc.C) {

--- a/cmd/juju/machine/list_test.go
+++ b/cmd/juju/machine/list_test.go
@@ -37,7 +37,11 @@ func (*fakeStatusAPI) Status(c []string) (*params.FullStatus, error) {
 				AgentStatus: params.DetailedStatus{
 					Status: "started",
 				},
-				DNSName:    "10.0.0.1",
+				DNSName: "10.0.0.1",
+				IPAddresses: []string{
+					"10.0.0.1",
+					"10.0.1.1",
+				},
 				InstanceId: "juju-badd06-0",
 				Series:     "trusty",
 				NetworkInterfaces: map[string]params.NetworkInterface{
@@ -58,7 +62,11 @@ func (*fakeStatusAPI) Status(c []string) (*params.FullStatus, error) {
 				AgentStatus: params.DetailedStatus{
 					Status: "started",
 				},
-				DNSName:    "10.0.0.2",
+				DNSName: "10.0.0.2",
+				IPAddresses: []string{
+					"10.0.0.2",
+					"10.0.1.2",
+				},
 				InstanceId: "juju-badd06-1",
 				Series:     "trusty",
 				NetworkInterfaces: map[string]params.NetworkInterface{
@@ -77,7 +85,11 @@ func (*fakeStatusAPI) Status(c []string) (*params.FullStatus, error) {
 						AgentStatus: params.DetailedStatus{
 							Status: "pending",
 						},
-						DNSName:    "10.0.0.3",
+						DNSName: "10.0.0.3",
+						IPAddresses: []string{
+							"10.0.0.3",
+							"10.0.1.3",
+						},
 						InstanceId: "juju-badd06-1-lxd-0",
 						Series:     "trusty",
 						NetworkInterfaces: map[string]params.NetworkInterface{
@@ -127,6 +139,9 @@ func (s *MachineListCommandSuite) TestListMachineYaml(c *gc.C) {
 		"    juju-status:\n"+
 		"      current: started\n"+
 		"    dns-name: 10.0.0.1\n"+
+		"    ip-addresses:\n"+
+		"    - 10.0.0.1\n"+
+		"    - 10.0.1.1\n"+
 		"    instance-id: juju-badd06-0\n"+
 		"    series: trusty\n"+
 		"    network-interfaces:\n"+
@@ -142,6 +157,9 @@ func (s *MachineListCommandSuite) TestListMachineYaml(c *gc.C) {
 		"    juju-status:\n"+
 		"      current: started\n"+
 		"    dns-name: 10.0.0.2\n"+
+		"    ip-addresses:\n"+
+		"    - 10.0.0.2\n"+
+		"    - 10.0.1.2\n"+
 		"    instance-id: juju-badd06-1\n"+
 		"    series: trusty\n"+
 		"    network-interfaces:\n"+
@@ -156,6 +174,9 @@ func (s *MachineListCommandSuite) TestListMachineYaml(c *gc.C) {
 		"        juju-status:\n"+
 		"          current: pending\n"+
 		"        dns-name: 10.0.0.3\n"+
+		"        ip-addresses:\n"+
+		"        - 10.0.0.3\n"+
+		"        - 10.0.1.3\n"+
 		"        instance-id: juju-badd06-1-lxd-0\n"+
 		"        series: trusty\n"+
 		"        network-interfaces:\n"+
@@ -171,7 +192,7 @@ func (s *MachineListCommandSuite) TestListMachineJson(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineListCommand(), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"{\"model\":\"dummyenv\",\"machines\":{\"0\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.1\",\"instance-id\":\"juju-badd06-0\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.1\",\"10.0.1.1\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}},\"constraints\":\"mem=3584M\",\"hardware\":\"availability-zone=us-east-1\"},\"1\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.2\",\"instance-id\":\"juju-badd06-1\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.2\",\"10.0.1.2\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}},\"containers\":{\"1/lxd/0\":{\"juju-status\":{\"current\":\"pending\"},\"dns-name\":\"10.0.0.3\",\"instance-id\":\"juju-badd06-1-lxd-0\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.3\",\"10.0.1.3\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}}}}}}}\n")
+		"{\"model\":\"dummyenv\",\"machines\":{\"0\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.1\",\"ip-addresses\":[\"10.0.0.1\",\"10.0.1.1\"],\"instance-id\":\"juju-badd06-0\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.1\",\"10.0.1.1\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}},\"constraints\":\"mem=3584M\",\"hardware\":\"availability-zone=us-east-1\"},\"1\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.2\",\"ip-addresses\":[\"10.0.0.2\",\"10.0.1.2\"],\"instance-id\":\"juju-badd06-1\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.2\",\"10.0.1.2\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}},\"containers\":{\"1/lxd/0\":{\"juju-status\":{\"current\":\"pending\"},\"dns-name\":\"10.0.0.3\",\"ip-addresses\":[\"10.0.0.3\",\"10.0.1.3\"],\"instance-id\":\"juju-badd06-1-lxd-0\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.3\",\"10.0.1.3\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}}}}}}}\n")
 }
 
 func (s *MachineListCommandSuite) TestListMachineArgsError(c *gc.C) {

--- a/cmd/juju/machine/show_test.go
+++ b/cmd/juju/machine/show_test.go
@@ -29,7 +29,7 @@ func (s *MachineShowCommandSuite) SetUpTest(c *gc.C) {
 func (s *MachineShowCommandSuite) TestShowMachine(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineShowCommand())
 	c.Assert(err, jc.ErrorIsNil)
-	// TODO(macgreagoir) MAC addrs? Spaces in dummyenv?
+	// TODO(macgreagoir) Spaces in dummyenv?
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
 		"model: dummyenv\n"+
 		"machines:\n"+
@@ -37,6 +37,9 @@ func (s *MachineShowCommandSuite) TestShowMachine(c *gc.C) {
 		"    juju-status:\n"+
 		"      current: started\n"+
 		"    dns-name: 10.0.0.1\n"+
+		"    ip-addresses:\n"+
+		"    - 10.0.0.1\n"+
+		"    - 10.0.1.1\n"+
 		"    instance-id: juju-badd06-0\n"+
 		"    series: trusty\n"+
 		"    network-interfaces:\n"+
@@ -52,6 +55,9 @@ func (s *MachineShowCommandSuite) TestShowMachine(c *gc.C) {
 		"    juju-status:\n"+
 		"      current: started\n"+
 		"    dns-name: 10.0.0.2\n"+
+		"    ip-addresses:\n"+
+		"    - 10.0.0.2\n"+
+		"    - 10.0.1.2\n"+
 		"    instance-id: juju-badd06-1\n"+
 		"    series: trusty\n"+
 		"    network-interfaces:\n"+
@@ -66,6 +72,9 @@ func (s *MachineShowCommandSuite) TestShowMachine(c *gc.C) {
 		"        juju-status:\n"+
 		"          current: pending\n"+
 		"        dns-name: 10.0.0.3\n"+
+		"        ip-addresses:\n"+
+		"        - 10.0.0.3\n"+
+		"        - 10.0.1.3\n"+
 		"        instance-id: juju-badd06-1-lxd-0\n"+
 		"        series: trusty\n"+
 		"        network-interfaces:\n"+
@@ -79,7 +88,7 @@ func (s *MachineShowCommandSuite) TestShowMachine(c *gc.C) {
 func (s *MachineShowCommandSuite) TestShowSingleMachine(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineShowCommand(), "0")
 	c.Assert(err, jc.ErrorIsNil)
-	// TODO(macgreagoir) MAC addrs? Spaces in dummyenv?
+	// TODO(macgreagoir) Spaces in dummyenv?
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
 		"model: dummyenv\n"+
 		"machines:\n"+
@@ -87,6 +96,9 @@ func (s *MachineShowCommandSuite) TestShowSingleMachine(c *gc.C) {
 		"    juju-status:\n"+
 		"      current: started\n"+
 		"    dns-name: 10.0.0.1\n"+
+		"    ip-addresses:\n"+
+		"    - 10.0.0.1\n"+
+		"    - 10.0.1.1\n"+
 		"    instance-id: juju-badd06-0\n"+
 		"    series: trusty\n"+
 		"    network-interfaces:\n"+
@@ -114,7 +126,7 @@ func (s *MachineShowCommandSuite) TestShowTabularMachine(c *gc.C) {
 func (s *MachineShowCommandSuite) TestShowJsonMachine(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineShowCommand(), "--format", "json", "0", "1")
 	c.Assert(err, jc.ErrorIsNil)
-	// TODO(macgreagoir) MAC addrs? Spaces in dummyenv?
+	// TODO(macgreagoir) Spaces in dummyenv?
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"{\"model\":\"dummyenv\",\"machines\":{\"0\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.1\",\"instance-id\":\"juju-badd06-0\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.1\",\"10.0.1.1\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}},\"constraints\":\"mem=3584M\",\"hardware\":\"availability-zone=us-east-1\"},\"1\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.2\",\"instance-id\":\"juju-badd06-1\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.2\",\"10.0.1.2\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}},\"containers\":{\"1/lxd/0\":{\"juju-status\":{\"current\":\"pending\"},\"dns-name\":\"10.0.0.3\",\"instance-id\":\"juju-badd06-1-lxd-0\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.3\",\"10.0.1.3\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}}}}}}}\n")
+		"{\"model\":\"dummyenv\",\"machines\":{\"0\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.1\",\"ip-addresses\":[\"10.0.0.1\",\"10.0.1.1\"],\"instance-id\":\"juju-badd06-0\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.1\",\"10.0.1.1\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}},\"constraints\":\"mem=3584M\",\"hardware\":\"availability-zone=us-east-1\"},\"1\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.2\",\"ip-addresses\":[\"10.0.0.2\",\"10.0.1.2\"],\"instance-id\":\"juju-badd06-1\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.2\",\"10.0.1.2\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}},\"containers\":{\"1/lxd/0\":{\"juju-status\":{\"current\":\"pending\"},\"dns-name\":\"10.0.0.3\",\"ip-addresses\":[\"10.0.0.3\",\"10.0.1.3\"],\"instance-id\":\"juju-badd06-1-lxd-0\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.3\",\"10.0.1.3\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}}}}}}}\n")
 }

--- a/cmd/juju/machine/show_test.go
+++ b/cmd/juju/machine/show_test.go
@@ -29,6 +29,7 @@ func (s *MachineShowCommandSuite) SetUpTest(c *gc.C) {
 func (s *MachineShowCommandSuite) TestShowMachine(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineShowCommand())
 	c.Assert(err, jc.ErrorIsNil)
+	// TODO(macgreagoir) MAC addrs? Spaces in dummyenv?
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
 		"model: dummyenv\n"+
 		"machines:\n"+
@@ -36,36 +37,49 @@ func (s *MachineShowCommandSuite) TestShowMachine(c *gc.C) {
 		"    juju-status:\n"+
 		"      current: started\n"+
 		"    dns-name: 10.0.0.1\n"+
-		"    ip-addresses:\n"+
-		"    - 10.0.0.1\n"+
-		"    - 10.0.1.1\n"+
 		"    instance-id: juju-badd06-0\n"+
 		"    series: trusty\n"+
+		"    network-interfaces:\n"+
+		"      eth0:\n"+
+		"        ip-addresses:\n"+
+		"        - 10.0.0.1\n"+
+		"        - 10.0.1.1\n"+
+		"        mac-address: aa:bb:cc:dd:ee:ff\n"+
+		"        is-up: true\n"+
 		"    constraints: mem=3584M\n"+
 		"    hardware: availability-zone=us-east-1\n"+
 		"  \"1\":\n"+
 		"    juju-status:\n"+
 		"      current: started\n"+
 		"    dns-name: 10.0.0.2\n"+
-		"    ip-addresses:\n"+
-		"    - 10.0.0.2\n"+
-		"    - 10.0.1.2\n"+
 		"    instance-id: juju-badd06-1\n"+
 		"    series: trusty\n"+
+		"    network-interfaces:\n"+
+		"      eth0:\n"+
+		"        ip-addresses:\n"+
+		"        - 10.0.0.2\n"+
+		"        - 10.0.1.2\n"+
+		"        mac-address: aa:bb:cc:dd:ee:ff\n"+
+		"        is-up: true\n"+
 		"    containers:\n"+
 		"      1/lxd/0:\n"+
 		"        juju-status:\n"+
 		"          current: pending\n"+
 		"        dns-name: 10.0.0.3\n"+
-		"        ip-addresses:\n"+
-		"        - 10.0.0.3\n"+
-		"        - 10.0.1.3\n"+
 		"        instance-id: juju-badd06-1-lxd-0\n"+
-		"        series: trusty\n")
+		"        series: trusty\n"+
+		"        network-interfaces:\n"+
+		"          eth0:\n"+
+		"            ip-addresses:\n"+
+		"            - 10.0.0.3\n"+
+		"            - 10.0.1.3\n"+
+		"            mac-address: aa:bb:cc:dd:ee:ff\n"+
+		"            is-up: true\n")
 }
 func (s *MachineShowCommandSuite) TestShowSingleMachine(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineShowCommand(), "0")
 	c.Assert(err, jc.ErrorIsNil)
+	// TODO(macgreagoir) MAC addrs? Spaces in dummyenv?
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
 		"model: dummyenv\n"+
 		"machines:\n"+
@@ -73,11 +87,15 @@ func (s *MachineShowCommandSuite) TestShowSingleMachine(c *gc.C) {
 		"    juju-status:\n"+
 		"      current: started\n"+
 		"    dns-name: 10.0.0.1\n"+
-		"    ip-addresses:\n"+
-		"    - 10.0.0.1\n"+
-		"    - 10.0.1.1\n"+
 		"    instance-id: juju-badd06-0\n"+
 		"    series: trusty\n"+
+		"    network-interfaces:\n"+
+		"      eth0:\n"+
+		"        ip-addresses:\n"+
+		"        - 10.0.0.1\n"+
+		"        - 10.0.1.1\n"+
+		"        mac-address: aa:bb:cc:dd:ee:ff\n"+
+		"        is-up: true\n"+
 		"    constraints: mem=3584M\n"+
 		"    hardware: availability-zone=us-east-1\n")
 }
@@ -96,6 +114,7 @@ func (s *MachineShowCommandSuite) TestShowTabularMachine(c *gc.C) {
 func (s *MachineShowCommandSuite) TestShowJsonMachine(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineShowCommand(), "--format", "json", "0", "1")
 	c.Assert(err, jc.ErrorIsNil)
+	// TODO(macgreagoir) MAC addrs? Spaces in dummyenv?
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"{\"model\":\"dummyenv\",\"machines\":{\"0\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.1\",\"ip-addresses\":[\"10.0.0.1\",\"10.0.1.1\"],\"instance-id\":\"juju-badd06-0\",\"machine-status\":{},\"series\":\"trusty\",\"constraints\":\"mem=3584M\",\"hardware\":\"availability-zone=us-east-1\"},\"1\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.2\",\"ip-addresses\":[\"10.0.0.2\",\"10.0.1.2\"],\"instance-id\":\"juju-badd06-1\",\"machine-status\":{},\"series\":\"trusty\",\"containers\":{\"1/lxd/0\":{\"juju-status\":{\"current\":\"pending\"},\"dns-name\":\"10.0.0.3\",\"ip-addresses\":[\"10.0.0.3\",\"10.0.1.3\"],\"instance-id\":\"juju-badd06-1-lxd-0\",\"machine-status\":{},\"series\":\"trusty\"}}}}}\n")
+		"{\"model\":\"dummyenv\",\"machines\":{\"0\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.1\",\"instance-id\":\"juju-badd06-0\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.1\",\"10.0.1.1\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}},\"constraints\":\"mem=3584M\",\"hardware\":\"availability-zone=us-east-1\"},\"1\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.2\",\"instance-id\":\"juju-badd06-1\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.2\",\"10.0.1.2\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}},\"containers\":{\"1/lxd/0\":{\"juju-status\":{\"current\":\"pending\"},\"dns-name\":\"10.0.0.3\",\"instance-id\":\"juju-badd06-1-lxd-0\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.3\",\"10.0.1.3\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}}}}}}}\n")
 }

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -52,6 +52,7 @@ type machineStatus struct {
 	Err               error                       `json:"-" yaml:",omitempty"`
 	JujuStatus        statusInfoContents          `json:"juju-status,omitempty" yaml:"juju-status,omitempty"`
 	DNSName           string                      `json:"dns-name,omitempty" yaml:"dns-name,omitempty"`
+	IPAddresses       []string                    `json:"ip-addresses,omitempty" yaml:"ip-addresses,omitempty"`
 	InstanceId        instance.Id                 `json:"instance-id,omitempty" yaml:"instance-id,omitempty"`
 	MachineStatus     statusInfoContents          `json:"machine-status,omitempty" yaml:"machine-status,omitempty"`
 	Series            string                      `json:"series,omitempty" yaml:"series,omitempty"`

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -39,19 +39,28 @@ type modelStatus struct {
 	Status           statusInfoContents `json:"model-status,omitempty" yaml:"model-status,omitempty"`
 }
 
+type networkInterface struct {
+	IPAddresses    []string `json:"ip-addresses" yaml:"ip-addresses"`
+	MACAddress     string   `json:"mac-address" yaml:"mac-address"`
+	Gateway        string   `json:"gateway,omitempty" yaml:"gateway,omitempty"`
+	DNSNameservers []string `json:"dns-nameservers,omitempty" yaml:"dns-nameservers,omitempty"`
+	Space          string   `json:"space,omitempty" yaml:"space,omitempty"`
+	IsUp           bool     `json:"is-up" yaml:"is-up"`
+}
+
 type machineStatus struct {
-	Err           error                    `json:"-" yaml:",omitempty"`
-	JujuStatus    statusInfoContents       `json:"juju-status,omitempty" yaml:"juju-status,omitempty"`
-	DNSName       string                   `json:"dns-name,omitempty" yaml:"dns-name,omitempty"`
-	IPAddresses   []string                 `json:"ip-addresses,omitempty" yaml:"ip-addresses,omitempty"`
-	InstanceId    instance.Id              `json:"instance-id,omitempty" yaml:"instance-id,omitempty"`
-	MachineStatus statusInfoContents       `json:"machine-status,omitempty" yaml:"machine-status,omitempty"`
-	Series        string                   `json:"series,omitempty" yaml:"series,omitempty"`
-	Id            string                   `json:"-" yaml:"-"`
-	Containers    map[string]machineStatus `json:"containers,omitempty" yaml:"containers,omitempty"`
-	Constraints   string                   `json:"constraints,omitempty" yaml:"constraints,omitempty"`
-	Hardware      string                   `json:"hardware,omitempty" yaml:"hardware,omitempty"`
-	HAStatus      string                   `json:"controller-member-status,omitempty" yaml:"controller-member-status,omitempty"`
+	Err               error                       `json:"-" yaml:",omitempty"`
+	JujuStatus        statusInfoContents          `json:"juju-status,omitempty" yaml:"juju-status,omitempty"`
+	DNSName           string                      `json:"dns-name,omitempty" yaml:"dns-name,omitempty"`
+	InstanceId        instance.Id                 `json:"instance-id,omitempty" yaml:"instance-id,omitempty"`
+	MachineStatus     statusInfoContents          `json:"machine-status,omitempty" yaml:"machine-status,omitempty"`
+	Series            string                      `json:"series,omitempty" yaml:"series,omitempty"`
+	Id                string                      `json:"-" yaml:"-"`
+	NetworkInterfaces map[string]networkInterface `json:"network-interfaces,omitempty" yaml:"network-interfaces,omitempty"`
+	Containers        map[string]machineStatus    `json:"containers,omitempty" yaml:"containers,omitempty"`
+	Constraints       string                      `json:"constraints,omitempty" yaml:"constraints,omitempty"`
+	Hardware          string                      `json:"hardware,omitempty" yaml:"hardware,omitempty"`
+	HAStatus          string                      `json:"controller-member-status,omitempty" yaml:"controller-member-status,omitempty"`
 }
 
 // A goyaml bug means we can't declare these types

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -103,18 +103,28 @@ func (sf *statusFormatter) formatMachine(machine params.MachineStatus) machineSt
 	var out machineStatus
 
 	out = machineStatus{
-		JujuStatus:    sf.getStatusInfoContents(machine.AgentStatus),
-		DNSName:       machine.DNSName,
-		IPAddresses:   machine.IPAddresses,
-		InstanceId:    machine.InstanceId,
-		MachineStatus: sf.getStatusInfoContents(machine.InstanceStatus),
-		Series:        machine.Series,
-		Id:            machine.Id,
-		Containers:    make(map[string]machineStatus),
-		Constraints:   machine.Constraints,
-		Hardware:      machine.Hardware,
+		JujuStatus:        sf.getStatusInfoContents(machine.AgentStatus),
+		DNSName:           machine.DNSName,
+		InstanceId:        machine.InstanceId,
+		MachineStatus:     sf.getStatusInfoContents(machine.InstanceStatus),
+		Series:            machine.Series,
+		Id:                machine.Id,
+		NetworkInterfaces: make(map[string]networkInterface),
+		Containers:        make(map[string]machineStatus),
+		Constraints:       machine.Constraints,
+		Hardware:          machine.Hardware,
 	}
 
+	for k, d := range machine.NetworkInterfaces {
+		out.NetworkInterfaces[k] = networkInterface{
+			IPAddresses:    d.IPAddresses,
+			MACAddress:     d.MACAddress,
+			Gateway:        d.Gateway,
+			DNSNameservers: d.DNSNameservers,
+			Space:          d.Space,
+			IsUp:           d.IsUp,
+		}
+	}
 	for k, m := range machine.Containers {
 		out.Containers[k] = sf.formatMachine(m)
 	}

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -105,6 +105,7 @@ func (sf *statusFormatter) formatMachine(machine params.MachineStatus) machineSt
 	out = machineStatus{
 		JujuStatus:        sf.getStatusInfoContents(machine.AgentStatus),
 		DNSName:           machine.DNSName,
+		IPAddresses:       machine.IPAddresses,
 		InstanceId:        machine.InstanceId,
 		MachineStatus:     sf.getStatusInfoContents(machine.InstanceStatus),
 		Series:            machine.Series,

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -175,14 +175,20 @@ var (
 			"current": "started",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
-		"dns-name":     "10.0.0.1",
-		"ip-addresses": []string{"10.0.0.1"},
-		"instance-id":  "controller-0",
+		"dns-name":    "10.0.0.1",
+		"instance-id": "controller-0",
 		"machine-status": M{
 			"current": "pending",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
-		"series":                   "quantal",
+		"series": "quantal",
+		"network-interfaces": M{
+			"eth0": M{
+				"ip-addresses": []string{"10.0.0.1"},
+				"mac-address":  "aa:bb:cc:dd:ee:ff",
+				"is-up":        true,
+			},
+		},
 		"hardware":                 "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 		"controller-member-status": "adding-vote",
 	}
@@ -191,14 +197,20 @@ var (
 			"current": "started",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
-		"dns-name":     "10.0.1.1",
-		"ip-addresses": []string{"10.0.1.1"},
-		"instance-id":  "controller-1",
+		"dns-name":    "10.0.1.1",
+		"instance-id": "controller-1",
 		"machine-status": M{
 			"current": "pending",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
-		"series":   "quantal",
+		"series": "quantal",
+		"network-interfaces": M{
+			"eth0": M{
+				"ip-addresses": []string{"10.0.1.1"},
+				"mac-address":  "aa:bb:cc:dd:ee:ff",
+				"is-up":        true,
+			},
+		},
 		"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 	}
 	machine2 = M{
@@ -206,14 +218,20 @@ var (
 			"current": "started",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
-		"dns-name":     "10.0.2.1",
-		"ip-addresses": []string{"10.0.2.1"},
-		"instance-id":  "controller-2",
+		"dns-name":    "10.0.2.1",
+		"instance-id": "controller-2",
 		"machine-status": M{
 			"current": "pending",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
-		"series":   "quantal",
+		"series": "quantal",
+		"network-interfaces": M{
+			"eth0": M{
+				"ip-addresses": []string{"10.0.2.1"},
+				"mac-address":  "aa:bb:cc:dd:ee:ff",
+				"is-up":        true,
+			},
+		},
 		"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 	}
 	machine3 = M{
@@ -221,14 +239,20 @@ var (
 			"current": "started",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
-		"dns-name":     "10.0.3.1",
-		"ip-addresses": []string{"10.0.3.1"},
-		"instance-id":  "controller-3",
+		"dns-name":    "10.0.3.1",
+		"instance-id": "controller-3",
 		"machine-status": M{
 			"current": "pending",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
-		"series":   "quantal",
+		"series": "quantal",
+		"network-interfaces": M{
+			"eth0": M{
+				"ip-addresses": []string{"10.0.3.1"},
+				"mac-address":  "aa:bb:cc:dd:ee:ff",
+				"is-up":        true,
+			},
+		},
 		"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 	}
 	machine4 = M{
@@ -236,14 +260,20 @@ var (
 			"current": "started",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
-		"dns-name":     "10.0.4.1",
-		"ip-addresses": []string{"10.0.4.1"},
-		"instance-id":  "controller-4",
+		"dns-name":    "10.0.4.1",
+		"instance-id": "controller-4",
 		"machine-status": M{
 			"current": "pending",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
-		"series":   "quantal",
+		"series": "quantal",
+		"network-interfaces": M{
+			"eth0": M{
+				"ip-addresses": []string{"10.0.4.1"},
+				"mac-address":  "aa:bb:cc:dd:ee:ff",
+				"is-up":        true,
+			},
+		},
 		"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 	}
 	machine1WithContainers = M{
@@ -263,24 +293,36 @@ var (
 							"current": "started",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
-						"dns-name":     "10.0.3.1",
-						"ip-addresses": []string{"10.0.3.1"},
-						"instance-id":  "controller-3",
+						"dns-name":    "10.0.3.1",
+						"instance-id": "controller-3",
 						"machine-status": M{
 							"current": "pending",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
 						"series": "quantal",
+						"network-interfaces": M{
+							"eth0": M{
+								"ip-addresses": []string{"10.0.3.1"},
+								"mac-address":  "aa:bb:cc:dd:ee:ff",
+								"is-up":        true,
+							},
+						},
 					},
 				},
-				"dns-name":     "10.0.2.1",
-				"ip-addresses": []string{"10.0.2.1"},
-				"instance-id":  "controller-2",
+				"dns-name":    "10.0.2.1",
+				"instance-id": "controller-2",
 				"machine-status": M{
 					"current": "pending",
 					"since":   "01 Apr 15 01:23+10:00",
 				},
 				"series": "quantal",
+				"network-interfaces": M{
+					"eth0": M{
+						"ip-addresses": []string{"10.0.2.1"},
+						"mac-address":  "aa:bb:cc:dd:ee:ff",
+						"is-up":        true,
+					},
+				},
 			},
 			"1/lxd/1": M{
 				"juju-status": M{
@@ -295,15 +337,20 @@ var (
 				"series": "quantal",
 			},
 		},
-		"dns-name":     "10.0.1.1",
-		"ip-addresses": []string{"10.0.1.1"},
-		"instance-id":  "controller-1",
+		"dns-name":    "10.0.1.1",
+		"instance-id": "controller-1",
 		"machine-status": M{
 			"current": "pending",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
-
-		"series":   "quantal",
+		"series": "quantal",
+		"network-interfaces": M{
+			"eth0": M{
+				"ip-addresses": []string{"10.0.1.1"},
+				"mac-address":  "aa:bb:cc:dd:ee:ff",
+				"is-up":        true,
+			},
+		},
 		"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 	}
 	unexposedService = dummyCharm(M{
@@ -388,8 +435,8 @@ var statusTests = []testCase{
 
 		startAliveMachine{"0"},
 		setAddresses{"0", []network.Address{
-			network.NewAddress("10.0.0.2"),
 			network.NewScopedAddress("10.0.0.1", network.ScopePublic),
+			network.NewAddress("10.0.0.2"),
 		}},
 		expect{
 			"simulate the PA starting an instance in response to the state change",
@@ -401,14 +448,25 @@ var statusTests = []testCase{
 							"current": "pending",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
-						"dns-name":     "10.0.0.1",
-						"ip-addresses": []string{"10.0.0.1", "10.0.0.2"},
-						"instance-id":  "controller-0",
+						"dns-name":    "10.0.0.1",
+						"instance-id": "controller-0",
 						"machine-status": M{
 							"current": "pending",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
-						"series":                   "quantal",
+						"series": "quantal",
+						"network-interfaces": M{
+							"eth0": M{
+								"ip-addresses": []string{"10.0.0.1"},
+								"mac-address":  "aa:bb:cc:dd:ee:ff",
+								"is-up":        true,
+							},
+							"eth1": M{
+								"ip-addresses": []string{"10.0.0.2"},
+								"mac-address":  "aa:bb:cc:dd:ee:ff",
+								"is-up":        true,
+							},
+						},
 						"hardware":                 "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 						"controller-member-status": "adding-vote",
 					},
@@ -428,14 +486,25 @@ var statusTests = []testCase{
 							"current": "started",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
-						"dns-name":     "10.0.0.1",
-						"ip-addresses": []string{"10.0.0.1", "10.0.0.2"},
-						"instance-id":  "controller-0",
+						"dns-name":    "10.0.0.1",
+						"instance-id": "controller-0",
 						"machine-status": M{
 							"current": "pending",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
-						"series":                   "quantal",
+						"series": "quantal",
+						"network-interfaces": M{
+							"eth0": M{
+								"ip-addresses": []string{"10.0.0.1"},
+								"mac-address":  "aa:bb:cc:dd:ee:ff",
+								"is-up":        true,
+							},
+							"eth1": M{
+								"ip-addresses": []string{"10.0.0.2"},
+								"mac-address":  "aa:bb:cc:dd:ee:ff",
+								"is-up":        true,
+							},
+						},
 						"hardware":                 "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 						"controller-member-status": "adding-vote",
 					},
@@ -451,9 +520,8 @@ var statusTests = []testCase{
 				"model": model,
 				"machines": M{
 					"0": M{
-						"dns-name":     "10.0.0.1",
-						"ip-addresses": []string{"10.0.0.1", "10.0.0.2"},
-						"instance-id":  "controller-0",
+						"dns-name":    "10.0.0.1",
+						"instance-id": "controller-0",
 						"machine-status": M{
 							"current": "pending",
 							"since":   "01 Apr 15 01:23+10:00",
@@ -463,7 +531,19 @@ var statusTests = []testCase{
 							"since":   "01 Apr 15 01:23+10:00",
 							"version": "1.2.3",
 						},
-						"series":                   "quantal",
+						"series": "quantal",
+						"network-interfaces": M{
+							"eth0": M{
+								"ip-addresses": []string{"10.0.0.1"},
+								"mac-address":  "aa:bb:cc:dd:ee:ff",
+								"is-up":        true,
+							},
+							"eth1": M{
+								"ip-addresses": []string{"10.0.0.2"},
+								"mac-address":  "aa:bb:cc:dd:ee:ff",
+								"is-up":        true,
+							},
+						},
 						"hardware":                 "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 						"controller-member-status": "adding-vote",
 					},
@@ -476,8 +556,8 @@ var statusTests = []testCase{
 		"instance with different hardware characteristics",
 		addMachine{machineId: "0", cons: machineCons, job: state.JobManageModel},
 		setAddresses{"0", []network.Address{
-			network.NewAddress("10.0.0.2"),
 			network.NewScopedAddress("10.0.0.1", network.ScopePublic),
+			network.NewAddress("10.0.0.2"),
 		}},
 		startAliveMachine{"0"},
 		setMachineStatus{"0", status.Started, ""},
@@ -491,14 +571,25 @@ var statusTests = []testCase{
 							"current": "started",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
-						"dns-name":     "10.0.0.1",
-						"ip-addresses": []string{"10.0.0.1", "10.0.0.2"},
-						"instance-id":  "controller-0",
+						"dns-name":    "10.0.0.1",
+						"instance-id": "controller-0",
 						"machine-status": M{
 							"current": "pending",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
-						"series":                   "quantal",
+						"series": "quantal",
+						"network-interfaces": M{
+							"eth0": M{
+								"ip-addresses": []string{"10.0.0.1"},
+								"mac-address":  "aa:bb:cc:dd:ee:ff",
+								"is-up":        true,
+							},
+							"eth1": M{
+								"ip-addresses": []string{"10.0.0.2"},
+								"mac-address":  "aa:bb:cc:dd:ee:ff",
+								"is-up":        true,
+							},
+						},
 						"constraints":              "cores=2 mem=8192M root-disk=8192M",
 						"hardware":                 "arch=amd64 cores=2 mem=8192M root-disk=8192M",
 						"controller-member-status": "adding-vote",
@@ -753,9 +844,8 @@ var statusTests = []testCase{
 					"1": machine1,
 					"2": machine2,
 					"3": M{
-						"dns-name":     "10.0.3.1",
-						"ip-addresses": []string{"10.0.3.1"},
-						"instance-id":  "controller-3",
+						"dns-name":    "10.0.3.1",
+						"instance-id": "controller-3",
 						"machine-status": M{
 							"current": "pending",
 							"since":   "01 Apr 15 01:23+10:00",
@@ -765,13 +855,19 @@ var statusTests = []testCase{
 							"message": "Really?",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
-						"series":   "quantal",
+						"series": "quantal",
+						"network-interfaces": M{
+							"eth0": M{
+								"ip-addresses": []string{"10.0.3.1"},
+								"mac-address":  "aa:bb:cc:dd:ee:ff",
+								"is-up":        true,
+							},
+						},
 						"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 					},
 					"4": M{
-						"dns-name":     "10.0.4.1",
-						"ip-addresses": []string{"10.0.4.1"},
-						"instance-id":  "controller-4",
+						"dns-name":    "10.0.4.1",
+						"instance-id": "controller-4",
 						"machine-status": M{
 							"current": "pending",
 							"since":   "01 Apr 15 01:23+10:00",
@@ -781,7 +877,14 @@ var statusTests = []testCase{
 							"message": "Beware the red toys",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
-						"series":   "quantal",
+						"series": "quantal",
+						"network-interfaces": M{
+							"eth0": M{
+								"ip-addresses": []string{"10.0.4.1"},
+								"mac-address":  "aa:bb:cc:dd:ee:ff",
+								"is-up":        true,
+							},
+						},
 						"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 					},
 					"5": M{
@@ -2012,26 +2115,38 @@ var statusTests = []testCase{
 									"current": "started",
 									"since":   "01 Apr 15 01:23+10:00",
 								},
-								"dns-name":     "10.0.2.1",
-								"ip-addresses": []string{"10.0.2.1"},
-								"instance-id":  "controller-2",
+								"dns-name":    "10.0.2.1",
+								"instance-id": "controller-2",
 								"machine-status": M{
 									"current": "pending",
 									"since":   "01 Apr 15 01:23+10:00",
 								},
 
 								"series": "quantal",
+								"network-interfaces": M{
+									"eth0": M{
+										"ip-addresses": []string{"10.0.2.1"},
+										"mac-address":  "aa:bb:cc:dd:ee:ff",
+										"is-up":        true,
+									},
+								},
 							},
 						},
-						"dns-name":     "10.0.1.1",
-						"ip-addresses": []string{"10.0.1.1"},
-						"instance-id":  "controller-1",
+						"dns-name":    "10.0.1.1",
+						"instance-id": "controller-1",
 						"machine-status": M{
 							"current": "pending",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
 
-						"series":   "quantal",
+						"series": "quantal",
+						"network-interfaces": M{
+							"eth0": M{
+								"ip-addresses": []string{"10.0.1.1"},
+								"mac-address":  "aa:bb:cc:dd:ee:ff",
+								"is-up":        true,
+							},
+						},
 						"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 					},
 				},
@@ -2577,11 +2692,14 @@ var statusTests = []testCase{
 	),
 	test( // 21
 		"instance with localhost addresses",
-		addMachine{machineId: "0", cons: machineCons, job: state.JobManageModel},
+		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", []network.Address{
+			network.NewScopedAddress("10.0.0.1", network.ScopeCloudLocal),
 			network.NewScopedAddress("127.0.0.1", network.ScopeMachineLocal),
-			network.NewScopedAddress("::1", network.ScopeMachineLocal),
-			network.NewScopedAddress("10.0.0.2", network.ScopeCloudLocal),
+			// TODO(macgreagoir) setAddresses step method needs to
+			// set netmask correctly before we can test IPv6
+			// loopback.
+			// network.NewScopedAddress("::1", network.ScopeMachineLocal),
 		}},
 		startAliveMachine{"0"},
 		setMachineStatus{"0", status.Started, ""},
@@ -2590,23 +2708,7 @@ var statusTests = []testCase{
 			M{
 				"model": model,
 				"machines": M{
-					"0": M{
-						"juju-status": M{
-							"current": "started",
-							"since":   "01 Apr 15 01:23+10:00",
-						},
-						"dns-name":     "10.0.0.2",
-						"ip-addresses": []string{"10.0.0.2"},
-						"instance-id":  "controller-0",
-						"machine-status": M{
-							"current": "pending",
-							"since":   "01 Apr 15 01:23+10:00",
-						},
-						"series":                   "quantal",
-						"constraints":              "cores=2 mem=8192M root-disk=8192M",
-						"hardware":                 "arch=amd64 cores=2 mem=8192M root-disk=8192M",
-						"controller-member-status": "adding-vote",
-					},
+					"0": machine0,
 				},
 				"applications": M{},
 			},
@@ -2616,8 +2718,11 @@ var statusTests = []testCase{
 		"instance with IPv6 addresses",
 		addMachine{machineId: "0", cons: machineCons, job: state.JobManageModel},
 		setAddresses{"0", []network.Address{
-			network.NewScopedAddress("::1", network.ScopeMachineLocal),
-			network.NewScopedAddress("2001:db8::0:1", network.ScopeCloudLocal),
+			network.NewScopedAddress("2001:db8::1", network.ScopeCloudLocal),
+			// TODO(macgreagoir) setAddresses step method needs to
+			// set netmask correctly before we can test IPv6
+			// loopback.
+			// network.NewScopedAddress("::1", network.ScopeMachineLocal),
 		}},
 		startAliveMachine{"0"},
 		setMachineStatus{"0", status.Started, ""},
@@ -2631,14 +2736,20 @@ var statusTests = []testCase{
 							"current": "started",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
-						"dns-name":     "2001:db8::0:1",
-						"ip-addresses": []string{"2001:db8::0:1"},
-						"instance-id":  "controller-0",
+						"dns-name":    "2001:db8::1",
+						"instance-id": "controller-0",
 						"machine-status": M{
 							"current": "pending",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
-						"series":                   "quantal",
+						"series": "quantal",
+						"network-interfaces": M{
+							"eth0": M{
+								"ip-addresses": []string{"2001:db8::1"},
+								"mac-address":  "aa:bb:cc:dd:ee:ff",
+								"is-up":        true,
+							},
+						},
 						"constraints":              "cores=2 mem=8192M root-disk=8192M",
 						"hardware":                 "arch=amd64 cores=2 mem=8192M root-disk=8192M",
 						"controller-member-status": "adding-vote",
@@ -2912,6 +3023,41 @@ func (sa setAddresses) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = m.SetProviderAddresses(sa.addresses...)
 	c.Assert(err, jc.ErrorIsNil)
+	addrs := make([]state.LinkLayerDeviceAddress, len(sa.addresses))
+	lldevs := make([]state.LinkLayerDeviceArgs, len(sa.addresses))
+	for i, address := range sa.addresses {
+		devName := fmt.Sprintf("eth%d", i)
+		macAddr := "aa:bb:cc:dd:ee:ff"
+		configMethod := state.StaticAddress
+		devType := state.EthernetDevice
+		if address.Scope == network.ScopeMachineLocal ||
+			address.Value == "localhost" {
+			devName = "lo"
+			macAddr = "00:00:00:00:00:00"
+			configMethod = state.LoopbackAddress
+			devType = state.LoopbackDevice
+		}
+		lldevs[i] = state.LinkLayerDeviceArgs{
+			Name:       devName,
+			MACAddress: macAddr, // TODO(macgreagoir) Enough for first pass
+			IsUp:       true,
+			Type:       devType,
+		}
+		addrs[i] = state.LinkLayerDeviceAddress{
+			DeviceName:   devName,
+			ConfigMethod: configMethod,
+			// TODO(macgreagoir) Enough for first pass, but
+			// incorrect for IPv4 loopback, and breaks IPv6
+			// loopback.
+			CIDRAddress: fmt.Sprintf("%s/24", address.Value)}
+	}
+	// TODO(macgreagoir) Let these go for now, before this turns into a test for setting lldevs and addrs.
+	// err = m.SetLinkLayerDevices(lldevs...)
+	// c.Assert(err, jc.ErrorIsNil)
+	_ = m.SetLinkLayerDevices(lldevs...)
+	// err = m.SetDevicesAddresses(addrs...)
+	// c.Assert(err, jc.ErrorIsNil)
+	_ = m.SetDevicesAddresses(addrs...)
 }
 
 type setTools struct {
@@ -3575,7 +3721,7 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
-		setAddresses{"2", network.NewAddresses("10.0.0.2")},
+		setAddresses{"2", network.NewAddresses("10.0.2.1")},
 		startAliveMachine{"2"},
 		setMachineStatus{"2", status.Started, ""},
 		addAliveUnit{"mysql", "2"},
@@ -3600,7 +3746,7 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	c.Assert(string(stdout), gc.Equals, `
-Running on subnets:  127.0.0.1/8, 10.0.0.2/8  
+Running on subnets:  127.0.0.1/8, 10.0.2.1/8  
  Utilizing ports:                             
       # Machines:  (3)
          started:   3 
@@ -4106,13 +4252,17 @@ func (s *StatusSuite) TestFilterToContainer(c *gc.C) {
 		"      current: started\n" +
 		"      since: 01 Apr 15 01:23+10:00\n" +
 		"    dns-name: 10.0.0.1\n" +
-		"    ip-addresses:\n" +
-		"    - 10.0.0.1\n" +
 		"    instance-id: controller-0\n" +
 		"    machine-status:\n" +
 		"      current: pending\n" +
 		"      since: 01 Apr 15 01:23+10:00\n" +
 		"    series: quantal\n" +
+		"    network-interfaces:\n" +
+		"      eth0:\n" +
+		"        ip-addresses:\n" +
+		"        - 10.0.0.1\n" +
+		"        mac-address: aa:bb:cc:dd:ee:ff\n" +
+		"        is-up: true\n" +
 		"    containers:\n" +
 		"      0/lxd/0:\n" +
 		"        juju-status:\n" +
@@ -4215,8 +4365,8 @@ func (s *StatusSuite) TestFilterOnSubnet(c *gc.C) {
 
 	// Given the address for machine "1" is "localhost"
 	setAddresses{"1", network.NewAddresses("localhost", "127.0.0.1")}.step(c, ctx)
-	// And the address for machine "2" is "10.0.0.2"
-	setAddresses{"2", network.NewAddresses("10.0.0.2")}.step(c, ctx)
+	// And the address for machine "2" is "10.0.2.1"
+	setAddresses{"2", network.NewAddresses("10.0.2.1")}.step(c, ctx)
 	// When I run juju status --format oneline 127.0.0.1
 	_, stdout, stderr := runStatus(c, "--format", "oneline", "127.0.0.1")
 	c.Assert(stderr, gc.IsNil)
@@ -4236,8 +4386,8 @@ func (s *StatusSuite) TestFilterOnPorts(c *gc.C) {
 
 	// Given the address for machine "1" is "localhost"
 	setAddresses{"1", network.NewAddresses("localhost")}.step(c, ctx)
-	// And the address for machine "2" is "10.0.0.2"
-	setAddresses{"2", network.NewAddresses("10.0.0.2")}.step(c, ctx)
+	// And the address for machine "2" is "10.0.2.1"
+	setAddresses{"2", network.NewAddresses("10.0.2.1")}.step(c, ctx)
 	openUnitPort{"wordpress/0", "tcp", 80}.step(c, ctx)
 	// When I run juju status --format oneline 80/tcp
 	_, stdout, stderr := runStatus(c, "--format", "oneline", "80/tcp")
@@ -4471,11 +4621,12 @@ func (s *StatusSuite) TestFormatProvisioningError(c *gc.C) {
 		},
 		Machines: map[string]machineStatus{
 			"1": {
-				JujuStatus: statusInfoContents{Current: "error", Message: "<error while provisioning>"},
-				InstanceId: "pending",
-				Series:     "trusty",
-				Id:         "1",
-				Containers: map[string]machineStatus{},
+				JujuStatus:        statusInfoContents{Current: "error", Message: "<error while provisioning>"},
+				InstanceId:        "pending",
+				Series:            "trusty",
+				Id:                "1",
+				Containers:        map[string]machineStatus{},
+				NetworkInterfaces: map[string]networkInterface{},
 			},
 		},
 		Applications:       map[string]applicationStatus{},

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -175,8 +175,9 @@ var (
 			"current": "started",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
-		"dns-name":    "10.0.0.1",
-		"instance-id": "controller-0",
+		"dns-name":     "10.0.0.1",
+		"ip-addresses": []string{"10.0.0.1"},
+		"instance-id":  "controller-0",
 		"machine-status": M{
 			"current": "pending",
 			"since":   "01 Apr 15 01:23+10:00",
@@ -197,8 +198,9 @@ var (
 			"current": "started",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
-		"dns-name":    "10.0.1.1",
-		"instance-id": "controller-1",
+		"dns-name":     "10.0.1.1",
+		"ip-addresses": []string{"10.0.1.1"},
+		"instance-id":  "controller-1",
 		"machine-status": M{
 			"current": "pending",
 			"since":   "01 Apr 15 01:23+10:00",
@@ -218,8 +220,9 @@ var (
 			"current": "started",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
-		"dns-name":    "10.0.2.1",
-		"instance-id": "controller-2",
+		"dns-name":     "10.0.2.1",
+		"ip-addresses": []string{"10.0.2.1"},
+		"instance-id":  "controller-2",
 		"machine-status": M{
 			"current": "pending",
 			"since":   "01 Apr 15 01:23+10:00",
@@ -239,8 +242,9 @@ var (
 			"current": "started",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
-		"dns-name":    "10.0.3.1",
-		"instance-id": "controller-3",
+		"dns-name":     "10.0.3.1",
+		"ip-addresses": []string{"10.0.3.1"},
+		"instance-id":  "controller-3",
 		"machine-status": M{
 			"current": "pending",
 			"since":   "01 Apr 15 01:23+10:00",
@@ -260,8 +264,9 @@ var (
 			"current": "started",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
-		"dns-name":    "10.0.4.1",
-		"instance-id": "controller-4",
+		"dns-name":     "10.0.4.1",
+		"ip-addresses": []string{"10.0.4.1"},
+		"instance-id":  "controller-4",
 		"machine-status": M{
 			"current": "pending",
 			"since":   "01 Apr 15 01:23+10:00",
@@ -293,8 +298,9 @@ var (
 							"current": "started",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
-						"dns-name":    "10.0.3.1",
-						"instance-id": "controller-3",
+						"dns-name":     "10.0.3.1",
+						"ip-addresses": []string{"10.0.3.1"},
+						"instance-id":  "controller-3",
 						"machine-status": M{
 							"current": "pending",
 							"since":   "01 Apr 15 01:23+10:00",
@@ -309,8 +315,9 @@ var (
 						},
 					},
 				},
-				"dns-name":    "10.0.2.1",
-				"instance-id": "controller-2",
+				"dns-name":     "10.0.2.1",
+				"ip-addresses": []string{"10.0.2.1"},
+				"instance-id":  "controller-2",
 				"machine-status": M{
 					"current": "pending",
 					"since":   "01 Apr 15 01:23+10:00",
@@ -337,8 +344,9 @@ var (
 				"series": "quantal",
 			},
 		},
-		"dns-name":    "10.0.1.1",
-		"instance-id": "controller-1",
+		"dns-name":     "10.0.1.1",
+		"ip-addresses": []string{"10.0.1.1"},
+		"instance-id":  "controller-1",
 		"machine-status": M{
 			"current": "pending",
 			"since":   "01 Apr 15 01:23+10:00",
@@ -448,8 +456,9 @@ var statusTests = []testCase{
 							"current": "pending",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
-						"dns-name":    "10.0.0.1",
-						"instance-id": "controller-0",
+						"dns-name":     "10.0.0.1",
+						"ip-addresses": []string{"10.0.0.1", "10.0.0.2"},
+						"instance-id":  "controller-0",
 						"machine-status": M{
 							"current": "pending",
 							"since":   "01 Apr 15 01:23+10:00",
@@ -486,8 +495,9 @@ var statusTests = []testCase{
 							"current": "started",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
-						"dns-name":    "10.0.0.1",
-						"instance-id": "controller-0",
+						"dns-name":     "10.0.0.1",
+						"ip-addresses": []string{"10.0.0.1", "10.0.0.2"},
+						"instance-id":  "controller-0",
 						"machine-status": M{
 							"current": "pending",
 							"since":   "01 Apr 15 01:23+10:00",
@@ -520,8 +530,9 @@ var statusTests = []testCase{
 				"model": model,
 				"machines": M{
 					"0": M{
-						"dns-name":    "10.0.0.1",
-						"instance-id": "controller-0",
+						"dns-name":     "10.0.0.1",
+						"ip-addresses": []string{"10.0.0.1", "10.0.0.2"},
+						"instance-id":  "controller-0",
 						"machine-status": M{
 							"current": "pending",
 							"since":   "01 Apr 15 01:23+10:00",
@@ -571,8 +582,9 @@ var statusTests = []testCase{
 							"current": "started",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
-						"dns-name":    "10.0.0.1",
-						"instance-id": "controller-0",
+						"dns-name":     "10.0.0.1",
+						"ip-addresses": []string{"10.0.0.1", "10.0.0.2"},
+						"instance-id":  "controller-0",
 						"machine-status": M{
 							"current": "pending",
 							"since":   "01 Apr 15 01:23+10:00",
@@ -844,8 +856,9 @@ var statusTests = []testCase{
 					"1": machine1,
 					"2": machine2,
 					"3": M{
-						"dns-name":    "10.0.3.1",
-						"instance-id": "controller-3",
+						"dns-name":     "10.0.3.1",
+						"ip-addresses": []string{"10.0.3.1"},
+						"instance-id":  "controller-3",
 						"machine-status": M{
 							"current": "pending",
 							"since":   "01 Apr 15 01:23+10:00",
@@ -866,8 +879,9 @@ var statusTests = []testCase{
 						"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 					},
 					"4": M{
-						"dns-name":    "10.0.4.1",
-						"instance-id": "controller-4",
+						"dns-name":     "10.0.4.1",
+						"ip-addresses": []string{"10.0.4.1"},
+						"instance-id":  "controller-4",
 						"machine-status": M{
 							"current": "pending",
 							"since":   "01 Apr 15 01:23+10:00",
@@ -2115,8 +2129,9 @@ var statusTests = []testCase{
 									"current": "started",
 									"since":   "01 Apr 15 01:23+10:00",
 								},
-								"dns-name":    "10.0.2.1",
-								"instance-id": "controller-2",
+								"dns-name":     "10.0.2.1",
+								"ip-addresses": []string{"10.0.2.1"},
+								"instance-id":  "controller-2",
 								"machine-status": M{
 									"current": "pending",
 									"since":   "01 Apr 15 01:23+10:00",
@@ -2132,8 +2147,9 @@ var statusTests = []testCase{
 								},
 							},
 						},
-						"dns-name":    "10.0.1.1",
-						"instance-id": "controller-1",
+						"dns-name":     "10.0.1.1",
+						"ip-addresses": []string{"10.0.1.1"},
+						"instance-id":  "controller-1",
 						"machine-status": M{
 							"current": "pending",
 							"since":   "01 Apr 15 01:23+10:00",
@@ -2736,8 +2752,9 @@ var statusTests = []testCase{
 							"current": "started",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
-						"dns-name":    "2001:db8::1",
-						"instance-id": "controller-0",
+						"dns-name":     "2001:db8::1",
+						"ip-addresses": []string{"2001:db8::1"},
+						"instance-id":  "controller-0",
 						"machine-status": M{
 							"current": "pending",
 							"since":   "01 Apr 15 01:23+10:00",
@@ -4252,6 +4269,8 @@ func (s *StatusSuite) TestFilterToContainer(c *gc.C) {
 		"      current: started\n" +
 		"      since: 01 Apr 15 01:23+10:00\n" +
 		"    dns-name: 10.0.0.1\n" +
+		"    ip-addresses:\n" +
+		"    - 10.0.0.1\n" +
 		"    instance-id: controller-0\n" +
 		"    machine-status:\n" +
 		"      current: pending\n" +

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -152,6 +152,11 @@ func (dev *LinkLayerDevice) Type() LinkLayerDeviceType {
 	return dev.doc.Type
 }
 
+// IsLoopbackDevice returns whether this is a loopback device.
+func (dev *LinkLayerDevice) IsLoopbackDevice() bool {
+	return dev.doc.Type == LoopbackDevice
+}
+
 // MACAddress returns the media access control (MAC) address of the device.
 func (dev *LinkLayerDevice) MACAddress() string {
 	return dev.doc.MACAddress

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -157,6 +157,12 @@ func (addr *Address) ConfigMethod() AddressConfigMethod {
 	return addr.doc.ConfigMethod
 }
 
+// LoopbackConfigMethod returns whether AddressConfigMethod used for this IP
+// address was loopback.
+func (addr *Address) LoopbackConfigMethod() bool {
+	return addr.doc.ConfigMethod == LoopbackAddress
+}
+
 // Value returns the value of this IP address.
 func (addr *Address) Value() string {
 	return addr.doc.Value


### PR DESCRIPTION
Replace ip-addresses list with network-interfaces hash in status and show-machine output

----

## Description of change

This change adds more networking-related output to show-machine.

The network-interfaces hash include the following elements per machine:
 * addresses
 * gateway
 * nameservers
 * space

## Note on tests

Existing tests have been updated and pass. Tests where improvement is required in a next iteration are noted as TODO items. Under the circumstances of getting this out before 2017-02-10, I'm submitting the PR as-is, with the intention that tests should be expanded.

## QA steps

 * `juju status --format yaml` and `juju show-machine <id>`
 * Add more IP addresses to a NIC and see them appear in output
 * Use a space and see it appear in output

## Documentation changes

`juju status --format [yaml|json]` and `juju show-machine` now have a network-interfaces hash, which includes the existing ip-addresses list.

## Bug reference

lp:1653997
