### PR TITLE
Restore original pinger test timeouts (maxping * 2)

### DIFF
--- a/apiserver/pinger_test.go
+++ b/apiserver/pinger_test.go
@@ -97,7 +97,7 @@ func (s *pingerSuite) TestAgentConnectionShutsDownWithNoPing(c *gc.C) {
 	server, clock := s.newServerWithTestClock(c)
 	conn, _ := s.OpenAPIAsNewMachine(c, server)
 
-	waitAndAdvance(c, clock, apiserver.MaxClientPingInterval)
+	waitAndAdvance(c, clock, apiserver.MaxClientPingInterval * 2)
 	checkConnectionDies(c, conn)
 }
 
@@ -113,7 +113,7 @@ func (s *pingerSuite) TestAgentConnectionDelaysShutdownWithPing(c *gc.C) {
 	}
 
 	// However, once we stop pinging for too long, the connection dies
-	waitAndAdvance(c, clock, apiserver.MaxClientPingInterval)
+	waitAndAdvance(c, clock, apiserver.MaxClientPingInterval * 2)
 	checkConnectionDies(c, conn)
 }
 

--- a/apiserver/pinger_test.go
+++ b/apiserver/pinger_test.go
@@ -97,7 +97,7 @@ func (s *pingerSuite) TestAgentConnectionShutsDownWithNoPing(c *gc.C) {
 	server, clock := s.newServerWithTestClock(c)
 	conn, _ := s.OpenAPIAsNewMachine(c, server)
 
-	waitAndAdvance(c, clock, apiserver.MaxClientPingInterval * 2)
+	waitAndAdvance(c, clock, apiserver.MaxClientPingInterval*2)
 	checkConnectionDies(c, conn)
 }
 
@@ -113,7 +113,7 @@ func (s *pingerSuite) TestAgentConnectionDelaysShutdownWithPing(c *gc.C) {
 	}
 
 	// However, once we stop pinging for too long, the connection dies
-	waitAndAdvance(c, clock, apiserver.MaxClientPingInterval * 2)
+	waitAndAdvance(c, clock, apiserver.MaxClientPingInterval*2)
 	checkConnectionDies(c, conn)
 }
 


### PR DESCRIPTION
This PR attempts to fix lp:1627086 and lp:1632485 by restoring the original pinger test timeouts