### PR TITLE
tools/lxdclient: translate LXD Debug to Trace

### DIFF
--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -65,7 +65,11 @@ func (p *lxdLogProxy) render(msg string, ctx []interface{}) string {
 }
 
 func (p *lxdLogProxy) Debug(msg string, ctx ...interface{}) {
-	p.logger.Debugf(p.render(msg, ctx))
+	// NOTE(axw) the LXD client logs a lot of detail at
+	// "debug" level, which is its highest level of logging.
+	// We transform this to Trace, to avoid spamming our
+	// logs with too much information.
+	p.logger.Tracef(p.render(msg, ctx))
 }
 
 func (p *lxdLogProxy) Info(msg string, ctx ...interface{}) {


### PR DESCRIPTION
## Description of change

The LXD debug logs are too noisy for debugging Juju
issues, so we log them at Trace level. Users can
enable those logs by setting the "lxd=TRACE" in their
logging config.

## QA steps

1. juju bootstrap localhost --debug, observe no log messages about "Raw response"
2. juju bootstrap localhost --debug --logging-config '<root>=TRACE', observe log messages about "Raw response"

## Documentation changes

Not necessary.

## Bug reference

Fixes the logging part of https://bugs.launchpad.net/juju/+bug/1656243. The full solution requires https://github.com/juju/juju/pull/6887.
