### PR TITLE
made memory profiles configurable

### DIFF
--- a/agent/format-2.0.go
+++ b/agent/format-2.0.go
@@ -48,14 +48,15 @@ type format_2_0Serialization struct {
 	Values      map[string]string `yaml:"values"`
 
 	// Only controller machines have these next items set.
-	ControllerCert string `yaml:"controllercert,omitempty"`
-	ControllerKey  string `yaml:"controllerkey,omitempty"`
-	CAPrivateKey   string `yaml:"caprivatekey,omitempty"`
-	APIPort        int    `yaml:"apiport,omitempty"`
-	StatePort      int    `yaml:"stateport,omitempty"`
-	SharedSecret   string `yaml:"sharedsecret,omitempty"`
-	SystemIdentity string `yaml:"systemidentity,omitempty"`
-	MongoVersion   string `yaml:"mongoversion,omitempty"`
+	ControllerCert     string `yaml:"controllercert,omitempty"`
+	ControllerKey      string `yaml:"controllerkey,omitempty"`
+	CAPrivateKey       string `yaml:"caprivatekey,omitempty"`
+	APIPort            int    `yaml:"apiport,omitempty"`
+	StatePort          int    `yaml:"stateport,omitempty"`
+	SharedSecret       string `yaml:"sharedsecret,omitempty"`
+	SystemIdentity     string `yaml:"systemidentity,omitempty"`
+	MongoVersion       string `yaml:"mongoversion,omitempty"`
+	MongoMemoryProfile string `yaml:"mongomemoryprofile,omitempty"`
 }
 
 func init() {
@@ -151,6 +152,9 @@ func (formatter_2_0) unmarshal(data []byte) (*configInternal, error) {
 		// Mongo version is set, we might be running a version other than default.
 		config.mongoVersion = format.MongoVersion
 	}
+	if format.MongoMemoryProfile != "" {
+		config.mongoMemoryProfile = format.MongoMemoryProfile
+	}
 	return config, nil
 }
 
@@ -194,6 +198,9 @@ func (formatter_2_0) marshal(config *configInternal) ([]byte, error) {
 	}
 	if config.mongoVersion != "" {
 		format.MongoVersion = string(config.mongoVersion)
+	}
+	if config.mongoMemoryProfile != "" {
+		format.MongoMemoryProfile = config.mongoMemoryProfile
 	}
 	return goyaml.Marshal(format)
 }

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -216,6 +216,12 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 	info.SystemIdentity = privateKey
 	err = c.ChangeConfig(func(agentConfig agent.ConfigSetter) error {
 		agentConfig.SetStateServingInfo(info)
+		mmprof, err := mongo.NewMemoryProfile(args.ControllerConfig.MongoMemoryProfile())
+		if err != nil {
+			logger.Errorf("could not set requested memory profile: %v", err)
+		} else {
+			agentConfig.SetMongoMemoryProfile(mmprof)
+		}
 		return nil
 	})
 	if err != nil {

--- a/cmd/jujud/upgrade_mongo.go
+++ b/cmd/jujud/upgrade_mongo.go
@@ -98,7 +98,7 @@ type dialAndLogger func(*mongo.MongoInfo, retry.CallArgs) (mgoSession, mgoDb, er
 type requisitesSatisfier func(string) error
 
 type mongoService func() error
-type mongoEnsureService func(string, int, int, bool, mongo.Version, bool) error
+type mongoEnsureService func(string, int, int, bool, mongo.Version, bool, mongo.MemoryProfile) error
 type mongoDialInfo func(mongo.Info, mongo.DialOpts) (*mgo.DialInfo, error)
 
 type initiateMongoServerFunc func(peergrouper.InitiateMongoParams) error
@@ -358,7 +358,8 @@ func (u *UpgradeMongoCommand) UpdateService(auth bool) error {
 		oplogSize,
 		numaCtlPolicy,
 		u.agentConfig.MongoVersion(),
-		auth)
+		auth,
+		mongo.MemoryProfileLow)
 	return errors.Annotate(err, "cannot ensure mongodb service script is properly installed")
 }
 

--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -223,6 +223,8 @@ func NewEnsureServerParams(agentConfig agent.Config) (mongo.EnsureServerParams, 
 		DataDir:              agentConfig.DataDir(),
 		OplogSize:            oplogSize,
 		SetNUMAControlPolicy: numaCtlPolicy,
+
+		MemoryProfile: agentConfig.MongoMemoryProfile(),
 	}
 	return params, nil
 }

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -372,6 +372,37 @@ var editableSysctlFiles = map[string]string{
 	"/proc/sys/net/ipv4/tcp_fin_timeout":          "30",
 }
 
+// NewMemoryProfile returns a Memory Profile from the passed value.
+func NewMemoryProfile(m string) (MemoryProfile, error) {
+	mp := MemoryProfile(m)
+	if err := mp.Validate(); err != nil {
+		return MemoryProfile(""), err
+	}
+	return mp, nil
+}
+
+// MemoryProfile represents a type of meory configuration for Mongo.
+type MemoryProfile string
+
+// String returns a string representation of this profile value.
+func (m MemoryProfile) String() string {
+	return string(m)
+}
+
+func (m MemoryProfile) Validate() error {
+	if m != MemoryProfileLow && m != MemoryProfileDefault {
+		return errors.NotValidf("memory profile %q", m)
+	}
+	return nil
+}
+
+const (
+	// MemoryProfileLow will use as little memory as possible in mongo.
+	MemoryProfileLow MemoryProfile = "low"
+	// MemoryProfileDefault will use mongo config ootb.
+	MemoryProfileDefault = "default"
+)
+
 // EnsureServerParams is a parameter struct for EnsureServer.
 type EnsureServerParams struct {
 	// APIPort is the port to connect to the api server.
@@ -411,6 +442,10 @@ type EnsureServerParams struct {
 	// SetNUMAControlPolicy preference - whether the user
 	// wants to set the numa control policy when starting mongo.
 	SetNUMAControlPolicy bool
+
+	// MemoryProfile determines which value is going to be used by
+	// the cache and future memory tweaks.
+	MemoryProfile MemoryProfile
 }
 
 // EnsureServer ensures that the MongoDB server is installed,
@@ -481,15 +516,16 @@ func ensureServer(args EnsureServerParams, sysctlFiles map[string]string) error 
 	}
 
 	svcConf := newConf(ConfigArgs{
-		DataDir:     args.DataDir,
-		DBDir:       dbDir,
-		MongoPath:   mongoPath,
-		Port:        args.StatePort,
-		OplogSizeMB: oplogSizeMB,
-		WantNUMACtl: args.SetNUMAControlPolicy,
-		Version:     mgoVersion,
-		Auth:        true,
-		IPv6:        network.SupportsIPv6(),
+		DataDir:       args.DataDir,
+		DBDir:         dbDir,
+		MongoPath:     mongoPath,
+		Port:          args.StatePort,
+		OplogSizeMB:   oplogSizeMB,
+		WantNUMACtl:   args.SetNUMAControlPolicy,
+		Version:       mgoVersion,
+		Auth:          true,
+		IPv6:          network.SupportsIPv6(),
+		MemoryProfile: args.MemoryProfile,
 	})
 	svc, err := newService(ServiceName, svcConf)
 	if err != nil {

--- a/state/backups/backups_linux.go
+++ b/state/backups/backups_linux.go
@@ -50,6 +50,7 @@ func ensureMongoService(agentConfig agent.Config) error {
 		numaCtlPolicy,
 		agentConfig.MongoVersion(),
 		true,
+		mongo.MemoryProfileDefault,
 	); err != nil {
 		return errors.Annotate(err, "cannot ensure that mongo service start/stop scripts are in place")
 	}

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -29,6 +29,7 @@ func (s *ControllerConfigSuite) TestControllerAndModelConfigInitialisation(c *gc
 		controller.AutocertURLKey:      true,
 		controller.AutocertDNSNameKey:  true,
 		controller.AllowModelAccessKey: true,
+		controller.MongoMemoryProfile:  true,
 	}
 	for _, controllerAttr := range controller.ControllerOnlyConfigAttributes {
 		v, ok := controllerSettings.Get(controllerAttr)


### PR DESCRIPTION
Bootstrap ocnfig now supports a mongo-memory-profile conf that sets mongo memory usage.

## QA steps

Bottstrap with --config="mongo-memory-profile=low" or --config="mongo-memory-profile=low" then ssh into the client, on the first case mongod should be called with a wired tiger cache flag.

