### PR TITLE
always record machine network config.

### DIFF
--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -87,7 +87,7 @@ func (mr *Machiner) SetUp() (watcher.NotifyWatcher, error) {
 	mr.machine = m
 
 	if mr.config.ClearMachineAddressesOnStart {
-		logger.Debugf("machine addresses ignored on start - resetting machine addresses")
+		logger.Debugf("machiner configured to reset machine %q addresses to empty", mr.config.Tag)
 		if err := m.SetMachineAddresses(nil); err != nil {
 			return nil, errors.Annotate(err, "reseting machine addresses")
 		}
@@ -139,11 +139,12 @@ func setMachineAddresses(tag names.MachineTag, m Machine) error {
 	}
 	// Filter out any LXC or LXD bridge addresses.
 	hostAddresses = network.FilterBridgeAddresses(hostAddresses)
-	logger.Infof("setting addresses for %v to %q", tag, hostAddresses)
+	logger.Infof("setting addresses for %q to %v", tag, hostAddresses)
 	return m.SetMachineAddresses(hostAddresses)
 }
 
 func (mr *Machiner) Handle(_ <-chan struct{}) error {
+	logger.Infof("got a Machiner.Handle() event")
 	if err := mr.machine.Refresh(); params.IsCodeNotFoundOrCodeUnauthorized(err) {
 		// NOTE(axw) we can distinguish between NotFound and CodeUnauthorized,
 		// so we could call NotifyMachineDead here in case the agent failed to
@@ -168,7 +169,7 @@ func (mr *Machiner) Handle(_ <-chan struct{}) error {
 				return errors.Annotate(err, "cannot update observed network config")
 			}
 		}
-		logger.Debugf("observed network config updated")
+		logger.Debugf("observed network config updated for %q to %v", mr.config.Tag, observedConfig)
 
 		return nil
 	}


### PR DESCRIPTION
## Description of change

We were only recording it if we had provider config to merge with it.
However, this will be useful to have everywhere and it lets us move forward
with some of our explicit decisions on how we want to do bridging, etc.
Note that containers now start 'properly' on AWS, but only because
of a sequence of failures and fallbacks that gets us to invoke old
code paths.

Namely, we see the machine, we trigger the 'fallback' to bridge all
interfaces, which says 'create br-eth0'. The bridge script runs, but
fails to actually create br-eth0 because the definition of eth0 is
actually in /e/n/interfaces.d/50cloud.cfg, and it doesn't read it.
However, the call to 'prepareHost' already succeeded, so we continue
with the next step. It then asks what devices to create for the
container it is starting, which comes back with 'I dont know',
which it then says, 'well then, I'll fall back to lxdbr0', and thus
starts a container in the old way.

## QA steps

"juju bootstrap" on any cloud that isn't MAAS and inspect the database to notice `db.linklayerdevices.find().pretty()` returns actual values. (without this patch there are no records.)

## Bug reference

This is part of fixing https://pad.lv/1657449 but doesn't fully address that yet.