### PR TITLE
2.1 containerizer config 1657449

### DIFF
--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -681,7 +681,7 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(env environs.Environ, idx in
 	supportContainerAddresses := environs.SupportsContainerAddresses(env)
 	bridgePolicy := containerizer.BridgePolicy{
 		NetBondReconfigureDelay: env.Config().NetBondReconfigureDelay(),
-		UseLocalBridges: !supportContainerAddresses,
+		UseLocalBridges:         !supportContainerAddresses,
 	}
 
 	// TODO(jam): 2017-01-31 PopulateContainerLinkLayerDevices should really

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -601,12 +601,12 @@ type perContainerHandler interface {
 	// ProcessOneContainer is called once we've assured ourselves that all of
 	// the access permissions are correct and the container is ready to be
 	// processed.
-	// netEnv is the Environment you are working, idx is the index for this
+	// env is the Environment you are working, idx is the index for this
 	// container (used for deciding where to store results), host is the
 	// machine that is hosting the container.
 	// Any errors that are returned from ProcessOneContainer will be turned
 	// into ServerError and handed to SetError
-	ProcessOneContainer(netEnv environs.NetworkingEnviron, idx int, host, container *state.Machine) error
+	ProcessOneContainer(env environs.Environ, idx int, host, container *state.Machine) error
 	// SetError will be called whenever there is a problem with the a given
 	// request. Generally this just does result.Results[i].Error = error
 	// but the Result type is opaque so we can't do it ourselves.
@@ -614,7 +614,7 @@ type perContainerHandler interface {
 }
 
 func (p *ProvisionerAPI) processEachContainer(args params.Entities, handler perContainerHandler) error {
-	netEnviron, hostMachine, canAccess, err := p.prepareContainerAccessEnvironment()
+	env, hostMachine, canAccess, err := p.prepareContainerAccessEnvironment()
 	if err != nil {
 		// Overall error
 		return errors.Trace(err)
@@ -646,7 +646,7 @@ func (p *ProvisionerAPI) processEachContainer(args params.Entities, handler perC
 			continue
 		}
 
-		if err := handler.ProcessOneContainer(netEnviron, i, hostMachine, container); err != nil {
+		if err := handler.ProcessOneContainer(env, i, hostMachine, container); err != nil {
 			handler.SetError(i, common.ServerError(err))
 			continue
 		}
@@ -663,7 +663,7 @@ func (ctx *prepareOrGetContext) SetError(idx int, err *params.Error) {
 	ctx.result.Results[idx].Error = err
 }
 
-func (ctx *prepareOrGetContext) ProcessOneContainer(netEnv environs.NetworkingEnviron, idx int, host, container *state.Machine) error {
+func (ctx *prepareOrGetContext) ProcessOneContainer(env environs.Environ, idx int, host, container *state.Machine) error {
 	containerId, err := container.InstanceId()
 	if ctx.maintain {
 		if err == nil {
@@ -678,7 +678,11 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(netEnv environs.NetworkingEn
 		return err
 	}
 
-	bridgePolicy := containerizer.BridgePolicy{}
+	supportContainerAddresses := environs.SupportsContainerAddresses(env)
+	bridgePolicy := containerizer.BridgePolicy{
+		NetBondReconfigureDelay: env.Config().NetBondReconfigureDelay(),
+		UseLocalBridges: !supportContainerAddresses,
+	}
 
 	// TODO(jam): 2017-01-31 PopulateContainerLinkLayerDevices should really
 	// just be returning the ones we'd like to exist, and then we turn those
@@ -720,19 +724,25 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(netEnv environs.NetworkingEn
 
 		if len(parentAddrs) > 0 {
 			logger.Infof("host machine device %q has addresses %v", parentDevice.Name(), parentAddrs)
-
 			firstAddress := parentAddrs[0]
-			parentDeviceSubnet, err := firstAddress.Subnet()
-			if err != nil {
-				return errors.Annotatef(err,
-					"cannot get subnet %q used by address %q of host machine device %q",
-					firstAddress.SubnetCIDR(), firstAddress.Value(), parentDevice.Name(),
-				)
+			if supportContainerAddresses {
+				parentDeviceSubnet, err := firstAddress.Subnet()
+				if err != nil {
+					return errors.Annotatef(err,
+						"cannot get subnet %q used by address %q of host machine device %q",
+						firstAddress.SubnetCIDR(), firstAddress.Value(), parentDevice.Name(),
+					)
+				}
+				info.ConfigType = network.ConfigStatic
+				info.CIDR = parentDeviceSubnet.CIDR()
+				info.ProviderSubnetId = parentDeviceSubnet.ProviderId()
+				info.VLANTag = parentDeviceSubnet.VLANTag()
+			} else {
+				info.ConfigType = network.ConfigDHCP
+				info.CIDR = firstAddress.SubnetCIDR()
+				info.ProviderSubnetId = ""
+				info.VLANTag = 0
 			}
-			info.ConfigType = network.ConfigStatic
-			info.CIDR = parentDeviceSubnet.CIDR()
-			info.ProviderSubnetId = parentDeviceSubnet.ProviderId()
-			info.VLANTag = parentDeviceSubnet.VLANTag()
 		} else {
 			logger.Infof("host machine device %q has no addresses %v", parentDevice.Name(), parentAddrs)
 		}
@@ -746,11 +756,16 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(netEnv environs.NetworkingEn
 		// this should have already been checked in the processEachContainer helper
 		return err
 	}
-	allocatedInfo, err := netEnv.AllocateContainerAddresses(hostInstanceId, container.MachineTag(), preparedInfo)
-	if err != nil {
-		return err
+	allocatedInfo := preparedInfo
+	if supportContainerAddresses {
+		// supportContainerAddresses already checks that we can cast to an environ.Networking
+		networking := env.(environs.Networking)
+		allocatedInfo, err = networking.AllocateContainerAddresses(hostInstanceId, container.MachineTag(), preparedInfo)
+		if err != nil {
+			return err
+		}
+		logger.Debugf("got allocated info from provider: %+v", allocatedInfo)
 	}
-	logger.Debugf("got allocated info from provider: %+v", allocatedInfo)
 
 	allocatedConfig := networkingcommon.NetworkConfigFromInterfaceInfo(allocatedInfo)
 	logger.Tracef("allocated network config: %+v", allocatedConfig)
@@ -774,10 +789,14 @@ func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(args params.Entities
 
 // prepareContainerAccessEnvironment retrieves the environment, host machine, and access
 // for working with containers.
-func (p *ProvisionerAPI) prepareContainerAccessEnvironment() (environs.NetworkingEnviron, *state.Machine, common.AuthFunc, error) {
-	netEnviron, err := networkingcommon.NetworkingEnvironFromModelConfig(p.configGetter)
+func (p *ProvisionerAPI) prepareContainerAccessEnvironment() (environs.Environ, *state.Machine, common.AuthFunc, error) {
+	env, err := environs.GetEnviron(p.configGetter, environs.New)
 	if err != nil {
 		return nil, nil, nil, errors.Trace(err)
+	}
+	// TODO(jam): 2017-02-01 NetworkingEnvironFromModelConfig used to do this, but it doesn't feel good
+	if env.Config().Type() == "dummy" {
+		return nil, nil, nil, errors.NotSupportedf("dummy provider network config")
 	}
 
 	canAccess, err := p.getAuthFunc()
@@ -796,15 +815,15 @@ func (p *ProvisionerAPI) prepareContainerAccessEnvironment() (environs.Networkin
 	if err != nil {
 		return nil, nil, nil, errors.Trace(err)
 	}
-	return netEnviron, host, canAccess, nil
+	return env, host, canAccess, nil
 }
 
 type hostChangesContext struct {
 	result params.HostNetworkChangeResults
 }
 
-func (ctx *hostChangesContext) ProcessOneContainer(netEnv environs.NetworkingEnviron, idx int, host, container *state.Machine) error {
-	netBondReconfigureDelay := netEnv.Config().NetBondReconfigureDelay()
+func (ctx *hostChangesContext) ProcessOneContainer(env environs.Environ, idx int, host, container *state.Machine) error {
+	netBondReconfigureDelay := env.Config().NetBondReconfigureDelay()
 	bridgePolicy := containerizer.BridgePolicy{
 		NetBondReconfigureDelay: netBondReconfigureDelay,
 	}
@@ -1050,9 +1069,7 @@ func (p *ProvisionerAPI) getOneMachineProviderNetworkConfig(m *state.Machine) ([
 		return nil, errors.Trace(err)
 	}
 
-	netEnviron, err := networkingcommon.NetworkingEnvironFromModelConfig(
-		stateenvirons.EnvironConfigGetter{p.st},
-	)
+	netEnviron, err := networkingcommon.NetworkingEnvironFromModelConfig(p.configGetter)
 	if errors.IsNotSupported(err) {
 		logger.Infof("not updating provider network config: %v", err)
 		return nil, nil

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -823,9 +823,8 @@ type hostChangesContext struct {
 }
 
 func (ctx *hostChangesContext) ProcessOneContainer(env environs.Environ, idx int, host, container *state.Machine) error {
-	netBondReconfigureDelay := env.Config().NetBondReconfigureDelay()
 	bridgePolicy := containerizer.BridgePolicy{
-		NetBondReconfigureDelay: netBondReconfigureDelay,
+		NetBondReconfigureDelay: env.Config().NetBondReconfigureDelay(),
 	}
 	bridges, reconfigureDelay, err := bridgePolicy.FindMissingBridgesForContainer(host, container)
 	if err != nil {

--- a/network/containerizer/bridgepolicy.go
+++ b/network/containerizer/bridgepolicy.go
@@ -12,8 +12,8 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils/set"
 
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
 	// Used for some constants and things like LinkLayerDevice[Args]
 	"github.com/juju/juju/state"
 )
@@ -177,16 +177,16 @@ func formatDeviceMap(spacesToDevices map[string][]*state.LinkLayerDevice) string
 		for i, name := range deviceNames {
 			quotedNames[i] = fmt.Sprintf("%q", name)
 		}
-		out = append(out, start + strings.Join(quotedNames, ",") + "]")
+		out = append(out, start+strings.Join(quotedNames, ",")+"]")
 	}
 	return "map{" + strings.Join(out, ", ") + "}"
 }
 
 var skippedDeviceNames = set.NewStrings(
-		network.DefaultLXCBridge,
-		network.DefaultLXDBridge,
-		network.DefaultKVMBridge,
-	)
+	network.DefaultLXCBridge,
+	network.DefaultLXDBridge,
+	network.DefaultKVMBridge,
+)
 
 // FindMissingBridgesForContainer looks at the spaces that the container
 // wants to be in, and sees if there are any host devices that should be

--- a/network/containerizer/bridgepolicy.go
+++ b/network/containerizer/bridgepolicy.go
@@ -5,6 +5,8 @@ package containerizer
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -27,6 +29,9 @@ type BridgePolicy struct {
 	// one of the devices being bridged is a BondDevice. This exists because of
 	// https://bugs.launchpad.net/juju/+bug/1657579
 	NetBondReconfigureDelay int
+	// UseLocalBridges decides if we should use local-only bridges ("lxdbr0", "virbr0"),
+	// to handle unnamed space requests.
+	UseLocalBridges bool
 }
 
 // Machine describes either a host machine, or a container machine. Either way
@@ -120,7 +125,7 @@ func (p *BridgePolicy) findSpacesAndDevicesForContainer(m Machine, containerMach
 
 func possibleBridgeTarget(dev *state.LinkLayerDevice) (bool, error) {
 	// LoopbackDevices can never be bridged
-	if dev.Type() == state.LoopbackDevice {
+	if dev.Type() == state.LoopbackDevice || dev.Type() == state.BridgeDevice {
 		return false, nil
 	}
 	// Devices that have no parent entry are direct host devices that can be
@@ -149,6 +154,38 @@ func possibleBridgeTarget(dev *state.LinkLayerDevice) (bool, error) {
 	return false, nil
 }
 
+func formatDeviceMap(spacesToDevices map[string][]*state.LinkLayerDevice) string {
+	spaceNames := make([]string, len(spacesToDevices))
+	i := 0
+	for spaceName := range spacesToDevices {
+		spaceNames[i] = spaceName
+		i++
+	}
+	sort.Strings(spaceNames)
+	out := []string{}
+	for _, name := range spaceNames {
+		start := fmt.Sprintf("%q:[", name)
+		devices := spacesToDevices[name]
+		deviceNames := make([]string, len(devices))
+		for i, dev := range devices {
+			deviceNames[i] = dev.Name()
+		}
+		deviceNames = network.NaturallySortDeviceNames(deviceNames...)
+		quotedNames := make([]string, len(deviceNames))
+		for i, name := range deviceNames {
+			quotedNames[i] = fmt.Sprintf("%q", name)
+		}
+		out = append(out, start + strings.Join(quotedNames, ",") + "]")
+	}
+	return "map{" + strings.Join(out, ", ") + "}"
+}
+
+var skippedDeviceNames = set.NewStrings(
+		network.DefaultLXCBridge,
+		network.DefaultLXDBridge,
+		network.DefaultKVMBridge,
+	)
+
 // FindMissingBridgesForContainer looks at the spaces that the container
 // wants to be in, and sees if there are any host devices that should be
 // bridged.
@@ -161,11 +198,15 @@ func (b *BridgePolicy) FindMissingBridgesForContainer(m Machine, containerMachin
 		return nil, 0, errors.Trace(err)
 	}
 	logger.Debugf("FindMissingBridgesForContainer(%q) spaces %s devices %v",
-		containerMachine.Id(), network.QuoteSpaceSet(containerSpaces), devicesPerSpace)
+		containerMachine.Id(), network.QuoteSpaceSet(containerSpaces),
+		formatDeviceMap(devicesPerSpace))
 	spacesFound := set.NewStrings()
 	for spaceName, devices := range devicesPerSpace {
 		for _, device := range devices {
 			if device.Type() == state.BridgeDevice {
+				if skippedDeviceNames.Contains(device.Name()) {
+					continue
+				}
 				spacesFound.Add(spaceName)
 			}
 		}
@@ -258,7 +299,7 @@ func (p *BridgePolicy) PopulateContainerLinkLayerDevices(m Machine, containerMac
 		return errors.Trace(err)
 	}
 	logger.Debugf("for container %q, found host devices spaces: %s",
-		containerMachine.Id(), devicesPerSpace)
+		containerMachine.Id(), formatDeviceMap(devicesPerSpace))
 
 	spacesFound := set.NewStrings()
 	devicesByName := make(map[string]*state.LinkLayerDevice)
@@ -267,7 +308,7 @@ func (p *BridgePolicy) PopulateContainerLinkLayerDevices(m Machine, containerMac
 	for spaceName, hostDevices := range devicesPerSpace {
 		for _, hostDevice := range hostDevices {
 			deviceType, name := hostDevice.Type(), hostDevice.Name()
-			if deviceType == state.BridgeDevice {
+			if deviceType == state.BridgeDevice && !skippedDeviceNames.Contains(name) {
 				devicesByName[name] = hostDevice
 				bridgeDeviceNames = append(bridgeDeviceNames, name)
 				spacesFound.Add(spaceName)
@@ -284,8 +325,8 @@ func (p *BridgePolicy) PopulateContainerLinkLayerDevices(m Machine, containerMac
 	}
 
 	sortedBridgeDeviceNames := network.NaturallySortDeviceNames(bridgeDeviceNames...)
-	logger.Debugf("for container %q using host machine %q bridge devices: %v",
-		containerMachine.Id(), m.Id(), sortedBridgeDeviceNames)
+	logger.Debugf("for container %q using host machine %q bridge devices: %s",
+		containerMachine.Id(), m.Id(), network.QuoteSpaces(sortedBridgeDeviceNames))
 	containerDevicesArgs := make([]state.LinkLayerDeviceArgs, len(bridgeDeviceNames))
 
 	for i, hostBridgeName := range sortedBridgeDeviceNames {

--- a/network/containerizer/bridgepolicy_test.go
+++ b/network/containerizer/bridgepolicy_test.go
@@ -75,7 +75,7 @@ func (s *bridgePolicyStateSuite) SetUpTest(c *gc.C) {
 
 	s.bridgePolicy = &containerizer.BridgePolicy{
 		NetBondReconfigureDelay: 13,
-		UseLocalBridges: false,
+		UseLocalBridges:         false,
 	}
 }
 
@@ -602,7 +602,7 @@ func (s *bridgePolicyStateSuite) TestPopulateContainerLinkLayerDevicesNoLocal(c 
 
 	bridgePolicy := &containerizer.BridgePolicy{
 		NetBondReconfigureDelay: 13,
-		UseLocalBridges: false,
+		UseLocalBridges:         false,
 	}
 	err := bridgePolicy.PopulateContainerLinkLayerDevices(s.machine, s.containerMachine)
 	c.Assert(err.Error(), gc.Equals, `unable to find host bridge for space(s) "" for container "0/lxd/0"`)
@@ -620,7 +620,7 @@ func (s *bridgePolicyStateSuite) TestPopulateContainerLinkLayerDevicesUseLocal(c
 
 	bridgePolicy := &containerizer.BridgePolicy{
 		NetBondReconfigureDelay: 13,
-		UseLocalBridges: true,
+		UseLocalBridges:         true,
 	}
 	err := bridgePolicy.PopulateContainerLinkLayerDevices(s.machine, s.containerMachine)
 	c.Assert(err, jc.ErrorIsNil)
@@ -727,7 +727,7 @@ func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerUseLocalBridg
 	s.addContainerMachine(c)
 	bridgePolicy := &containerizer.BridgePolicy{
 		NetBondReconfigureDelay: 13,
-		UseLocalBridges: true,
+		UseLocalBridges:         true,
 	}
 	// No defined spaces for the container, no *known* spaces for the host
 	// machine. Triggers the fallback code to have us bridge all devices.
@@ -736,7 +736,6 @@ func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerUseLocalBridg
 	c.Check(missing, jc.DeepEquals, []network.DeviceToBridge{})
 	c.Check(reconfigureDelay, gc.Equals, 0)
 }
-
 
 func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerUnknownWithConstraint(c *gc.C) {
 	// If we have a host machine where we don't understand its spaces, but

--- a/network/containerizer/bridgepolicy_test.go
+++ b/network/containerizer/bridgepolicy_test.go
@@ -75,6 +75,7 @@ func (s *bridgePolicyStateSuite) SetUpTest(c *gc.C) {
 
 	s.bridgePolicy = &containerizer.BridgePolicy{
 		NetBondReconfigureDelay: 13,
+		UseLocalBridges: false,
 	}
 }
 
@@ -590,6 +591,49 @@ func (s *bridgePolicyStateSuite) TestPopulateContainerLinkLayerDevicesTwoBridges
 	c.Check(containerDevice.ParentName(), gc.Equals, `m#0#d#br-ens4`)
 }
 
+func (s *bridgePolicyStateSuite) TestPopulateContainerLinkLayerDevicesNoLocal(c *gc.C) {
+	// The host machine has 1 network device and only local bridges, but none of them
+	// are in a known space. The container also has no requested space.
+	s.setupTwoSpaces(c)
+	s.createNICWithIP(c, s.machine, "ens3", "172.12.1.10/24")
+	s.createAllDefaultDevices(c, s.machine)
+	s.addContainerMachine(c)
+	s.assertNoDevicesOnMachine(c, s.containerMachine)
+
+	bridgePolicy := &containerizer.BridgePolicy{
+		NetBondReconfigureDelay: 13,
+		UseLocalBridges: false,
+	}
+	err := bridgePolicy.PopulateContainerLinkLayerDevices(s.machine, s.containerMachine)
+	c.Assert(err.Error(), gc.Equals, `unable to find host bridge for space(s) "" for container "0/lxd/0"`)
+	s.assertNoDevicesOnMachine(c, s.containerMachine)
+}
+
+func (s *bridgePolicyStateSuite) TestPopulateContainerLinkLayerDevicesUseLocal(c *gc.C) {
+	// The host machine has 1 network device and only local bridges, but none of them
+	// are in a known space. The container also has no requested space.
+	s.setupTwoSpaces(c)
+	s.createNICWithIP(c, s.machine, "ens3", "172.12.1.10/24")
+	s.createAllDefaultDevices(c, s.machine)
+	s.addContainerMachine(c)
+	s.assertNoDevicesOnMachine(c, s.containerMachine)
+
+	bridgePolicy := &containerizer.BridgePolicy{
+		NetBondReconfigureDelay: 13,
+		UseLocalBridges: true,
+	}
+	err := bridgePolicy.PopulateContainerLinkLayerDevices(s.machine, s.containerMachine)
+	c.Assert(err, jc.ErrorIsNil)
+
+	containerDevices, err := s.containerMachine.AllLinkLayerDevices()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(containerDevices, gc.HasLen, 1)
+
+	containerDevice := containerDevices[0]
+	c.Check(containerDevice.Name(), gc.Matches, "eth0")
+	c.Check(containerDevice.ParentName(), gc.Equals, `m#0#d#lxdbr0`)
+}
+
 func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerNoneMissing(c *gc.C) {
 	s.setupTwoSpaces(c)
 	s.createNICAndBridgeWithIP(c, s.machine, "eth0", "br-eth0", "10.0.0.20/24")
@@ -671,6 +715,28 @@ func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerNoSpaces(c *g
 	}})
 	c.Check(reconfigureDelay, gc.Equals, 0)
 }
+
+func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerUseLocalBridges(c *gc.C) {
+	// There is a "default" and "dmz" space, our machine has 1 network
+	// interface, but is not part of a known space. We have UseLocalBridges
+	// set, which means we should fall back to using 'lxdbr0' instead of
+	// bridging the host device.
+	s.setupTwoSpaces(c)
+	s.createNICWithIP(c, s.machine, "ens3", "172.12.0.10/24")
+	s.createAllDefaultDevices(c, s.machine)
+	s.addContainerMachine(c)
+	bridgePolicy := &containerizer.BridgePolicy{
+		NetBondReconfigureDelay: 13,
+		UseLocalBridges: true,
+	}
+	// No defined spaces for the container, no *known* spaces for the host
+	// machine. Triggers the fallback code to have us bridge all devices.
+	missing, reconfigureDelay, err := bridgePolicy.FindMissingBridgesForContainer(s.machine, s.containerMachine)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(missing, jc.DeepEquals, []network.DeviceToBridge{})
+	c.Check(reconfigureDelay, gc.Equals, 0)
+}
+
 
 func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerUnknownWithConstraint(c *gc.C) {
 	// If we have a host machine where we don't understand its spaces, but
@@ -996,3 +1062,7 @@ func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerVLANOnBond(c 
 	}})
 	c.Check(reconfigureDelay, gc.Equals, 13)
 }
+
+// TODO(jam): 2017-01-31 Make sure KVM guests default to virbr0, and LXD guests use lxdbr0
+// Add tests for UseLocal = True, but we have named spaces
+// Add tests for UseLocal = True, but the host device is bridged

--- a/network/network.go
+++ b/network/network.go
@@ -55,6 +55,9 @@ const AnySubnet Id = ""
 // UnknownId can be used whenever an Id is needed but not known.
 const UnknownId = ""
 
+// DefaultLXCBridge is the bridge that gets used for LXC containers
+const DefaultLXCBridge = "lxcbr0"
+
 // DefaultLXDBridge is the bridge that gets used for LXD containers
 const DefaultLXDBridge = "lxdbr0"
 

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1164,6 +1164,11 @@ func (env *environ) SupportsSpaceDiscovery() (bool, error) {
 	return true, nil
 }
 
+// SupportsContainerAddresses is specified on environs.Networking.
+func (env *environ) SupportsContainerAddresses() (bool, error) {
+	return false, errors.NotSupportedf("container addresses")
+}
+
 // Spaces is specified on environs.Networking.
 func (env *environ) Spaces() ([]network.SpaceInfo, error) {
 	if err := env.checkBroken("Spaces"); err != nil {

--- a/provider/dummy/environs_whitebox_test.go
+++ b/provider/dummy/environs_whitebox_test.go
@@ -19,7 +19,7 @@ var (
 
 var _ = gc.Suite(&environWhiteboxSuite{})
 
-type environWhiteboxSuite struct {}
+type environWhiteboxSuite struct{}
 
 func (s *environWhiteboxSuite) TestSupportsContainerAddresses(c *gc.C) {
 	// For now this is a static method so we can use a nil environ

--- a/provider/dummy/environs_whitebox_test.go
+++ b/provider/dummy/environs_whitebox_test.go
@@ -1,0 +1,31 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dummy
+
+import (
+	// stdtesting "testing"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs"
+)
+
+var (
+	_ environs.NetworkingEnviron = (*environ)(nil)
+)
+
+var _ = gc.Suite(&environWhiteboxSuite{})
+
+type environWhiteboxSuite struct {}
+
+func (s *environWhiteboxSuite) TestSupportsContainerAddresses(c *gc.C) {
+	// For now this is a static method so we can use a nil environ
+	var env *environ
+	supported, err := env.SupportsContainerAddresses()
+	c.Check(err, jc.Satisfies, errors.IsNotSupported)
+	c.Check(supported, jc.IsFalse)
+	c.Check(env, gc.Not(jc.Satisfies), environs.SupportsContainerAddresses)
+}

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -143,6 +143,11 @@ func (e *environ) SupportsSpaces() (bool, error) {
 	return true, nil
 }
 
+// SupportsContainerAddresses is specified on environs.Networking.
+func (e *environ) SupportsContainerAddresses() (bool, error) {
+	return false, errors.NotSupportedf("container address allocation")
+}
+
 // SupportsSpaceDiscovery is specified on environs.Networking.
 func (e *environ) SupportsSpaceDiscovery() (bool, error) {
 	return false, nil

--- a/provider/ec2/environ_test.go
+++ b/provider/ec2/environ_test.go
@@ -4,6 +4,8 @@
 package ec2
 
 import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
 	amzec2 "gopkg.in/amz.v3/ec2"
 	gc "gopkg.in/check.v1"
 
@@ -166,4 +168,39 @@ func (*Suite) TestPortsToIPPerms(c *gc.C) {
 		ipperms := portsToIPPerms(t.ports)
 		c.Assert(ipperms, gc.DeepEquals, t.expected)
 	}
+}
+
+// These Support checks are currently valid with a 'nil' environ pointer. If
+// that changes, the tests will need to be updated. (we know statically what is
+// supported.)
+func (*Suite) TestSupportsNetworking(c *gc.C) {
+	var env *environ
+	_, supported := environs.SupportsNetworking(env)
+	c.Assert(supported, jc.IsTrue)
+}
+
+func (*Suite) TestSupportsSpaces(c *gc.C) {
+	var env *environ
+	supported, err := env.SupportsSpaces()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(supported, jc.IsTrue)
+	c.Check(env, jc.Satisfies, environs.SupportsSpaces)
+}
+
+func (*Suite) TestSupportsSpaceDiscovery(c *gc.C) {
+	var env *environ
+	supported, err := env.SupportsSpaceDiscovery()
+	// TODO(jam): 2016-02-01 the comment on the interface says the error should
+	// conform to IsNotSupported, but all of the implementations just return
+	// nil for error and 'false' for supported.
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(supported, jc.IsFalse)
+}
+
+func (*Suite) TestSupportsContainerAddresses(c *gc.C) {
+	var env *environ
+	supported, err := env.SupportsContainerAddresses()
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+	c.Assert(supported, jc.IsFalse)
+	c.Check(env, gc.Not(jc.Satisfies), environs.SupportsContainerAddresses)
 }

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -315,6 +315,11 @@ func (env *maasEnviron) SupportsSpaceDiscovery() (bool, error) {
 	return true, nil
 }
 
+// SupportsContainerAddresses is specified on environs.Networking.
+func (env *maasEnviron) SupportsContainerAddresses() (bool, error) {
+	return true, nil
+}
+
 // allArchitectures2 uses the MAAS2 controller to get architectures from boot
 // resources.
 func (env *maasEnviron) allArchitectures2() ([]string, error) {

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -480,7 +480,6 @@ func (suite *environSuite) TestSupportsContainerAddresses(c *gc.C) {
 	c.Check(env, jc.Satisfies, environs.SupportsContainerAddresses)
 }
 
-
 func (suite *environSuite) TestSubnetsWithInstanceIdAndSubnetIds(c *gc.C) {
 	server := suite.testMAASObject.TestServer
 	var subnetIDs []network.Id

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -37,6 +37,13 @@ import (
 	coretesting "github.com/juju/juju/testing"
 )
 
+// ensure we conform to the right interfaces
+var (
+	_ environs.NetworkingEnviron = (*maasEnviron)(nil)
+	// Should maasEnviron implement this? It needs ConfigDefaults
+	// _ config.ConfigSchemaSource  = (*maasEnviron)(nil)
+)
+
 type environSuite struct {
 	providerSuite
 }
@@ -455,6 +462,7 @@ func (suite *environSuite) TestSupportsSpaces(c *gc.C) {
 	supported, err := env.SupportsSpaces()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(supported, jc.IsTrue)
+	c.Check(env, jc.Satisfies, environs.SupportsSpaces)
 }
 
 func (suite *environSuite) TestSupportsSpaceDiscovery(c *gc.C) {
@@ -463,6 +471,15 @@ func (suite *environSuite) TestSupportsSpaceDiscovery(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(supported, jc.IsTrue)
 }
+
+func (suite *environSuite) TestSupportsContainerAddresses(c *gc.C) {
+	env := suite.makeEnviron()
+	supported, err := env.SupportsContainerAddresses()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(supported, jc.IsTrue)
+	c.Check(env, jc.Satisfies, environs.SupportsContainerAddresses)
+}
+
 
 func (suite *environSuite) TestSubnetsWithInstanceIdAndSubnetIds(c *gc.C) {
 	server := suite.testMAASObject.TestServer

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -980,10 +980,7 @@ func (s *linkLayerDevicesStateSuite) TestLinkLayerDevicesForSpacesWithUnknown(c 
 	c.Check(devices[0].Type(), gc.Equals, state.BridgeDevice)
 }
 
-func (s *linkLayerDevicesStateSuite) TestLinkLayerDevicesForSpacesUnknownIgnoresLoopAndKnownBridges(c *gc.C) {
-	// When we ask for unknown devices, we still skip lxdbr0 and virbr0,
-	// because we don't want to put containers there as they won't be
-	// routable.
+func (s *linkLayerDevicesStateSuite) TestLinkLayerDevicesForSpacesUnknownIgnoresLoopAndIncludesKnownBridges(c *gc.C) {
 	// TODO(jam): 2016-12-28 arguably we should also be aware of Docker
 	// devices, possibly the better plan is to look at whether there are
 	// routes from the given bridge out into the rest of the world.
@@ -1001,7 +998,7 @@ func (s *linkLayerDevicesStateSuite) TestLinkLayerDevicesForSpacesUnknownIgnores
 	for i, dev := range devices {
 		names[i] = dev.Name()
 	}
-	c.Check(names, gc.DeepEquals, []string{"br-ens4", "ens3"})
+	c.Check(names, gc.DeepEquals, []string{"br-ens4", "ens3", "lxcbr0", "lxdbr0", "virbr0"})
 }
 
 func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesWithLightStateChurn(c *gc.C) {


### PR DESCRIPTION
## Description of change

Along with my change to always record all host machine devices, this should enable the original "lxdbr0" functionality that we had in 2.0.

This adds a method on Environments (providers) that we can introspect to see if we think bridging to the host device will be useful. When we would be unable to allocate a Provider level IP address for the containers, we fall back to doing DHCP on the 'lxdbr0' bridge for that container.

## QA steps

```
  $ juju bootstrap aws # or gce or azure
  $ juju switch controller
  $ juju add-machine lxd:0
  $ juju show-machine 0
```

You should end up with a container that has a valid (if local) IP address (most likely 10.0.0.*).

## Bug reference

https://pad.lv/1657449
