### PR TITLE
Make mongo restart v2

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -222,6 +222,8 @@ func InstallAndStart(svc ServiceActions) error {
 		if err != nil {
 			logger.Errorf("retrying start request (%v)", errors.Cause(err))
 		}
+		// we attempt restart if the service is running in case daemon parameters
+		// have changed, if its not running a regular start will happen.
 		if err = restartOrStart(svc); err == nil {
 			break
 		}
@@ -249,14 +251,7 @@ func Restart(name string) error {
 }
 
 func restartOrStart(svc ServiceActions) error {
-	// Use the Restart method, if there is one.
-	if svc, ok := svc.(RestartableService); ok {
-		if err := svc.Restart(); err != nil {
-			return errors.Trace(err)
-		}
-		return nil
-	}
-
+	// Explicitly omit Restart as it is not properly supported on trusty.
 	// Otherwise explicitly stop and start the service.
 	if err := svc.Stop(); err != nil {
 		logger.Errorf("could not stop service: %v", err)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -104,7 +104,7 @@ func (s *serviceSuite) TestInstallAndStartOkay(c *gc.C) {
 	err := service.InstallAndStart(s.Service)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.Service.CheckCallNames(c, "Install", "Start")
+	s.Service.CheckCallNames(c, "Install", "Stop", "Start")
 }
 
 func (s *serviceSuite) TestInstallAndStartRetry(c *gc.C) {
@@ -114,17 +114,17 @@ func (s *serviceSuite) TestInstallAndStartRetry(c *gc.C) {
 	err := service.InstallAndStart(s.Service)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.Service.CheckCallNames(c, "Install", "Start", "Start", "Start")
+	s.Service.CheckCallNames(c, "Install", "Stop", "Start", "Stop", "Start")
 }
 
 func (s *serviceSuite) TestInstallAndStartFail(c *gc.C) {
 	s.PatchAttempts(3)
-	s.Service.SetErrors(nil, s.Failure, s.Failure, s.Failure)
+	s.Service.SetErrors(nil, s.Failure, s.Failure, s.Failure, s.Failure, s.Failure, s.Failure)
 
 	err := service.InstallAndStart(s.Service)
 
 	s.CheckFailure(c, err)
-	s.Service.CheckCallNames(c, "Install", "Start", "Start", "Start")
+	s.Service.CheckCallNames(c, "Install", "Stop", "Start", "Stop", "Start", "Stop", "Start")
 }
 
 type restartSuite struct {


### PR DESCRIPTION
Make mongo restart when the service script is regenerated, in this case I dont use Restart as previously since this is not compatible with trusty and previous.

## QA steps

Bootstrap juju, all should start correctly.