### PR TITLE
migrations: Implement AdoptResources for the ec2 provider

### DIFF
--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -376,10 +376,10 @@ func (v *ebsVolumeSource) createVolume(p storage.VolumeParams, instances instanc
 func (v *ebsVolumeSource) ListVolumes() ([]string, error) {
 	filter := ec2.NewFilter()
 	filter.Add("tag:"+tags.JujuModel, v.modelUUID)
-	return listVolumes(v.env.ec2, filter)
+	return listVolumes(v.env.ec2, filter, false)
 }
 
-func listVolumes(client *ec2.EC2, filter *ec2.Filter) ([]string, error) {
+func listVolumes(client *ec2.EC2, filter *ec2.Filter, includeRootDisks bool) ([]string, error) {
 	resp, err := client.Volumes(nil, filter)
 	if err != nil {
 		return nil, err
@@ -393,7 +393,7 @@ func listVolumes(client *ec2.EC2, filter *ec2.Filter) ([]string, error) {
 				break
 			}
 		}
-		if isRootDisk {
+		if isRootDisk && !includeRootDisks {
 			// We don't want to list root disks in the output.
 			// These are managed by the instance provisioning
 			// code; they will be created and destroyed with

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -45,6 +45,14 @@ func InstanceSecurityGroups(e environs.Environ, ids []instance.Id, states ...str
 	return e.(*environ).instanceSecurityGroups(ids, states...)
 }
 
+func AllModelVolumes(e environs.Environ) ([]string, error) {
+	return e.(*environ).allModelVolumes(true)
+}
+
+func AllModelGroups(e environs.Environ) ([]string, error) {
+	return e.(*environ).modelSecurityGroupIDs()
+}
+
 var (
 	EC2AvailabilityZones        = &ec2AvailabilityZones
 	AvailabilityZoneAllocations = &availabilityZoneAllocations

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/utils/series"
 	"github.com/juju/utils/set"
 	"github.com/juju/utils/ssh"
+	"github.com/juju/version"
 	"gopkg.in/amz.v3/aws"
 	amzec2 "gopkg.in/amz.v3/ec2"
 	"gopkg.in/amz.v3/ec2/ec2test"
@@ -1496,6 +1497,134 @@ func (s *localServerSuite) TestBootstrapInstanceConstraints(c *gc.C) {
 	// Controllers should be started with a burstable
 	// instance if possible, and a 32 GiB disk.
 	c.Assert(ec2inst.InstanceType, gc.Equals, "t2.medium")
+}
+
+func controllerTag(allTags []amzec2.Tag) string {
+	for _, tag := range allTags {
+		if tag.Key == tags.JujuController {
+			return tag.Value
+		}
+	}
+	return ""
+}
+
+func makeFilter(key string, values ...string) *amzec2.Filter {
+	result := amzec2.NewFilter()
+	result.Add(key, values...)
+	return result
+}
+
+func (s *localServerSuite) TestAdoptResources(c *gc.C) {
+	controllerEnv := s.prepareAndBootstrap(c)
+	controllerInsts, err := controllerEnv.AllInstances()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(controllerInsts, gc.HasLen, 1)
+
+	controllerVolumes, err := ec2.AllModelVolumes(controllerEnv)
+	c.Assert(err, jc.ErrorIsNil)
+
+	controllerGroups, err := ec2.AllModelGroups(controllerEnv)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Create a hosted model environment with an instance and a volume.
+	hostedModelUUID := "7e386e08-cba7-44a4-a76e-7c1633584210"
+	s.srv.ec2srv.SetInitialInstanceState(ec2test.Running)
+	cfg, err := controllerEnv.Config().Apply(map[string]interface{}{
+		"uuid":          hostedModelUUID,
+		"firewall-mode": "global",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	env, err := environs.New(environs.OpenParams{
+		Cloud:  s.CloudSpec(),
+		Config: cfg,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	inst, _ := testing.AssertStartInstance(c, env, s.ControllerUUID, "0")
+	c.Assert(err, jc.ErrorIsNil)
+	ebsProvider, err := env.StorageProvider(ec2.EBS_ProviderType)
+	c.Assert(err, jc.ErrorIsNil)
+	vs, err := ebsProvider.VolumeSource(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	volumeResults, err := vs.CreateVolumes([]storage.VolumeParams{{
+		Tag:      names.NewVolumeTag("0"),
+		Size:     1024,
+		Provider: ec2.EBS_ProviderType,
+		ResourceTags: map[string]string{
+			tags.JujuController: s.ControllerUUID,
+			tags.JujuModel:      hostedModelUUID,
+		},
+		Attachment: &storage.VolumeAttachmentParams{
+			AttachmentParams: storage.AttachmentParams{
+				InstanceId: inst.Id(),
+			},
+		},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(volumeResults, gc.HasLen, 1)
+	c.Assert(volumeResults[0].Error, jc.ErrorIsNil)
+
+	modelVolumes, err := ec2.AllModelVolumes(env)
+	c.Assert(err, jc.ErrorIsNil)
+	allVolumes := append([]string{}, controllerVolumes...)
+	allVolumes = append(allVolumes, modelVolumes...)
+
+	modelGroups, err := ec2.AllModelGroups(env)
+	c.Assert(err, jc.ErrorIsNil)
+	allGroups := append([]string{}, controllerGroups...)
+	allGroups = append(allGroups, modelGroups...)
+
+	ec2conn := ec2.EnvironEC2(env)
+
+	origController := coretesting.ControllerTag.Id()
+
+	checkInstanceTags := func(controllerUUID string, expectedIds ...string) {
+		resp, err := ec2conn.Instances(
+			nil, makeFilter("tag:"+tags.JujuController, controllerUUID))
+		c.Assert(err, jc.ErrorIsNil)
+		actualIds := set.NewStrings()
+		for _, reservation := range resp.Reservations {
+			for _, instance := range reservation.Instances {
+				actualIds.Add(instance.InstanceId)
+			}
+		}
+		c.Check(actualIds, gc.DeepEquals, set.NewStrings(expectedIds...))
+	}
+
+	checkVolumeTags := func(controllerUUID string, expectedIds ...string) {
+		resp, err := ec2conn.Volumes(
+			nil, makeFilter("tag:"+tags.JujuController, controllerUUID))
+		c.Assert(err, jc.ErrorIsNil)
+		actualIds := set.NewStrings()
+		for _, vol := range resp.Volumes {
+			actualIds.Add(vol.Id)
+		}
+		c.Check(actualIds, gc.DeepEquals, set.NewStrings(expectedIds...))
+	}
+
+	checkGroupTags := func(controllerUUID string, expectedIds ...string) {
+		resp, err := ec2conn.SecurityGroups(
+			nil, makeFilter("tag:"+tags.JujuController, controllerUUID))
+		c.Assert(err, jc.ErrorIsNil)
+		actualIds := set.NewStrings()
+		for _, group := range resp.Groups {
+			actualIds.Add(group.Id)
+		}
+		c.Check(actualIds, gc.DeepEquals, set.NewStrings(expectedIds...))
+	}
+
+	checkInstanceTags(origController, string(inst.Id()), string(controllerInsts[0].Id()))
+	checkVolumeTags(origController, allVolumes...)
+	checkGroupTags(origController, allGroups...)
+
+	err = env.AdoptResources("new-controller", version.MustParse("0.0.1"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	checkInstanceTags("new-controller", string(inst.Id()))
+	checkInstanceTags(origController, string(controllerInsts[0].Id()))
+	checkVolumeTags("new-controller", modelVolumes...)
+	checkVolumeTags(origController, controllerVolumes...)
+	checkGroupTags("new-controller", modelGroups...)
+	checkGroupTags(origController, controllerGroups...)
 }
 
 // localNonUSEastSuite is similar to localServerSuite but the S3 mock server


### PR DESCRIPTION
## Description of change
The AdoptResources environ method will be used at the end of a model migration to update the controller tag for all of the resources used by the model, so that if the source controller is subsequently destroyed then these resources won't be cleaned up with it.

In the ec2 provider we tag volumes, instances and security groups with the controller UUID. We collect all of the resource IDs from these and call CreateTags in the ec2 API (which will overwrite tags, and leave tags in place if they aren't specified).

## QA steps
None yet - this method isn't called from the migration master yet.

## Documentation changes
N/A

## Bug reference
This is part of the fix for https://bugs.launchpad.net/juju/+bug/1648063