### PR TITLE
migrations: Correct handling of local charm URLs

### DIFF
--- a/state/charm.go
+++ b/state/charm.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
@@ -666,8 +667,14 @@ func (st *State) PrepareLocalCharmUpload(curl *charm.URL) (chosenURL *charm.URL,
 	return allocatedURL, nil
 }
 
+const charmRevSeqPrefix = "charmrev-"
+
 func charmRevSeqName(baseURL string) string {
-	return "charmrev-" + baseURL
+	return charmRevSeqPrefix + baseURL
+}
+
+func isCharmRevSeqName(name string) bool {
+	return strings.HasPrefix(name, charmRevSeqPrefix)
 }
 
 // PrepareStoreCharmUpload must be called before a charm store charm

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -230,11 +230,16 @@ func (i *importer) sequences() error {
 	sequenceValues := i.model.Sequences()
 	docs := make([]interface{}, 0, len(sequenceValues))
 	for key, value := range sequenceValues {
-		docs = append(docs, sequenceDoc{
-			DocID:   key,
-			Name:    key,
-			Counter: value,
-		})
+		// The sequences which track charm revisions aren't imported
+		// here because they get set when charm binaries are imported
+		// later. Importing them here means the wrong values get used.
+		if !isCharmRevSeqName(key) {
+			docs = append(docs, sequenceDoc{
+				DocID:   key,
+				Name:    key,
+				Counter: value,
+			})
+		}
 	}
 
 	// In reality, we will almost always have sequences to migrate.


### PR DESCRIPTION
## Description of change

There was a recent change to how charm URLs are tracked but migrations weren't updated to correctly support it.

Charms are now uploaded in order. This is important to ensure charm URLs are correctly assigned in the target. The charm URL used in the target is now also checked to ensure the correct value was used.

Charm revision sequences are now not directly migrated. Charm revision sequences shouldn't be explicitly set during the migration process. They get set when the charm binaries are uploaded.

## QA steps

Bootstrap 2 controllers. In a model in the source controller, deploy three revisions of the same local charm. Each revision sets a slightly different status message.

```
$ juju deploy ~/ubuntu-debug first
# Edit status message
$ juju deploy ~/ubuntu-debug second
# Edit status message
$ juju deploy ~/ubuntu-debug second

# Observe that each charm is deployed and has reports a unique status message.

# Migrate
$ juju migrate default B

# Now check the target
$ juju switch B:default
$ juju status

# Observe that the units are still reporting the expected status messages.

# Now check that the charms are definitely assigned correctly.
$ juju add-unit first
$ juju add-unit second
$ juju add-unit third
```

Once the new units are up, confirmed that the status messages reported match their charm revisions.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1660877