### PR TITLE
provider/lxd: cache certs in juju/lxd dir

### DIFF
--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -159,7 +159,9 @@ func (c *restoreCommand) getRebootstrapParams(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	config, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(ctx, store)(controllerName)
+	config, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(
+		ctx, store, environs.GlobalProviderRegistry(),
+	)(controllerName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1040,7 +1040,7 @@ func (s *BootstrapSuite) TestAutoSyncLocalSource(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	bootstrapConfig, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(
-		coretesting.Context(c), s.store,
+		coretesting.Context(c), s.store, environs.GlobalProviderRegistry(),
 	)("devcontroller")
 	c.Assert(err, jc.ErrorIsNil)
 	provider, err := environs.Provider(bootstrapConfig.CloudType)

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -331,7 +331,9 @@ func (c *destroyCommandBase) getControllerEnvironFromStore(
 	store jujuclient.ClientStore,
 	controllerName string,
 ) (environs.Environ, error) {
-	bootstrapConfig, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(ctx, store)(controllerName)
+	bootstrapConfig, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(
+		ctx, store, environs.GlobalProviderRegistry(),
+	)(controllerName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -377,13 +377,18 @@ func newAPIConnectionParams(
 
 // NewGetBootstrapConfigParamsFunc returns a function that, given a controller name,
 // returns the params needed to bootstrap a fresh copy of that controller in the given client store.
-func NewGetBootstrapConfigParamsFunc(ctx *cmd.Context, store jujuclient.ClientStore) func(string) (*jujuclient.BootstrapConfig, *environs.PrepareConfigParams, error) {
-	return bootstrapConfigGetter{ctx, store}.getBootstrapConfigParams
+func NewGetBootstrapConfigParamsFunc(
+	ctx *cmd.Context,
+	store jujuclient.ClientStore,
+	providerRegistry environs.ProviderRegistry,
+) func(string) (*jujuclient.BootstrapConfig, *environs.PrepareConfigParams, error) {
+	return bootstrapConfigGetter{ctx, store, providerRegistry}.getBootstrapConfigParams
 }
 
 type bootstrapConfigGetter struct {
-	ctx   *cmd.Context
-	store jujuclient.ClientStore
+	ctx      *cmd.Context
+	store    jujuclient.ClientStore
+	registry environs.ProviderRegistry
 }
 
 func (g bootstrapConfigGetter) getBootstrapConfig(controllerName string) (*config.Config, error) {
@@ -391,7 +396,7 @@ func (g bootstrapConfigGetter) getBootstrapConfig(controllerName string) (*confi
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	provider, err := environs.Provider(bootstrapConfig.CloudType)
+	provider, err := g.registry.Provider(bootstrapConfig.CloudType)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -399,7 +404,8 @@ func (g bootstrapConfigGetter) getBootstrapConfig(controllerName string) (*confi
 }
 
 func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (*jujuclient.BootstrapConfig, *environs.PrepareConfigParams, error) {
-	if _, err := g.store.ControllerByName(controllerName); err != nil {
+	controllerDetails, err := g.store.ControllerByName(controllerName)
+	if err != nil {
 		return nil, nil, errors.Annotate(err, "resolving controller name")
 	}
 	bootstrapConfig, err := g.store.BootstrapConfigForController(controllerName)
@@ -435,7 +441,7 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 		}
 	} else {
 		// The credential was auto-detected; run auto-detection again.
-		provider, err := environs.Provider(bootstrapConfig.CloudType)
+		provider, err := g.registry.Provider(bootstrapConfig.CloudType)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}
@@ -448,13 +454,19 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 		for _, one := range cloudCredential.AuthCredentials {
 			credential = &one
 		}
+		credential, err = provider.FinalizeCredential(
+			g.ctx, environs.FinalizeCredentialParams{
+				Credential:            *credential,
+				CloudEndpoint:         bootstrapConfig.CloudEndpoint,
+				CloudIdentityEndpoint: bootstrapConfig.CloudIdentityEndpoint,
+			},
+		)
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
 	}
 
 	// Add attributes from the controller details.
-	controllerDetails, err := g.store.ControllerByName(controllerName)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
 
 	// TODO(wallyworld) - remove after beta18
 	controllerModelUUID := bootstrapConfig.ControllerModelUUID

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -9,16 +9,21 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
-	"github.com/juju/juju/testing"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type BaseCommandSuite struct {
-	testing.FakeJujuXDGDataHomeSuite
+	coretesting.FakeJujuXDGDataHomeSuite
 	store *jujuclienttesting.MemStore
 }
 
@@ -66,4 +71,59 @@ func (s *BaseCommandSuite) TestUnknownModel(c *gc.C) {
 
 func (s *BaseCommandSuite) TestUnknownModelNotCurrent(c *gc.C) {
 	s.assertUnknownModel(c, "admin/goodmodel", "admin/goodmodel")
+}
+
+type NewGetBootstrapConfigParamsFuncSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&NewGetBootstrapConfigParamsFuncSuite{})
+
+func (NewGetBootstrapConfigParamsFuncSuite) TestDetectCredentials(c *gc.C) {
+	clientStore := jujuclienttesting.NewMemStore()
+	clientStore.Controllers["foo"] = jujuclient.ControllerDetails{}
+	clientStore.BootstrapConfig["foo"] = jujuclient.BootstrapConfig{
+		Cloud:               "cloud",
+		CloudType:           "cloud-type",
+		ControllerModelUUID: coretesting.ModelTag.Id(),
+		Config: map[string]interface{}{
+			"name": "foo",
+			"type": "cloud-type",
+		},
+	}
+	var registry mockProviderRegistry
+
+	f := modelcmd.NewGetBootstrapConfigParamsFunc(
+		coretesting.Context(c),
+		clientStore,
+		&registry,
+	)
+	_, params, err := f("foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(params.Cloud.Credential.Label, gc.Equals, "finalized")
+}
+
+type mockProviderRegistry struct {
+	environs.ProviderRegistry
+}
+
+func (r *mockProviderRegistry) Provider(t string) (environs.EnvironProvider, error) {
+	return &mockEnvironProvider{}, nil
+}
+
+type mockEnvironProvider struct {
+	environs.EnvironProvider
+}
+
+func (p *mockEnvironProvider) DetectCredentials() (*cloud.CloudCredential, error) {
+	return cloud.NewEmptyCloudCredential(), nil
+}
+
+func (p *mockEnvironProvider) FinalizeCredential(
+	_ environs.FinalizeCredentialContext,
+	args environs.FinalizeCredentialParams,
+) (*cloud.Credential, error) {
+	out := args.Credential
+	out.Label = "finalized"
+	return &out, nil
 }

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -31,7 +31,9 @@ func (c *imageMetadataCommandBase) prepare(context *cmd.Context) (environs.Envir
 	// NOTE(axw) this is a work-around for the TODO below. This
 	// means that the command will only work if you've bootstrapped
 	// the specified environment.
-	bootstrapConfig, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(context, c.ClientStore())(c.ControllerName())
+	bootstrapConfig, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(
+		context, c.ClientStore(), environs.GlobalProviderRegistry(),
+	)(c.ControllerName())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -6,12 +6,17 @@
 package lxd
 
 import (
+	"io/ioutil"
 	"net"
+	"os"
+	"path/filepath"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/tools/lxdclient"
 )
 
@@ -52,20 +57,108 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
-	// We return an "empty" credential that will be translated
-	// to a certificate credential below.
-	return cloud.NewEmptyCloudCredential(), nil
+func (p environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
+	certPEM, keyPEM, err := p.readOrGenerateCert()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	certCredential := cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
+		credAttrClientCert: string(certPEM),
+		credAttrClientKey:  string(keyPEM),
+	})
+	return &cloud.CloudCredential{
+		AuthCredentials: map[string]cloud.Credential{"default": certCredential},
+	}, nil
+}
+
+func (p environProviderCredentials) readOrGenerateCert() (certPEM, keyPEM []byte, _ error) {
+	// First look in the Juju XDG_DATA dir. This allows the user
+	// to explicitly override the certificates used by the lxc
+	// client if they wish.
+	jujuLXDDir := osenv.JujuXDGDataHomePath("lxd")
+	certPEM, keyPEM, err := readCert(jujuLXDDir)
+	if err == nil {
+		return certPEM, keyPEM, nil
+	} else if !os.IsNotExist(err) {
+		return nil, nil, errors.Trace(err)
+	}
+
+	// Next we look in the LXD config dir, in case the user has
+	// a client certificate/key pair for use with the "lxc" client
+	// application.
+	lxdConfigDir := filepath.Join(utils.Home(), ".config", "lxc")
+	certPEM, keyPEM, err = readCert(lxdConfigDir)
+	if err == nil {
+		return certPEM, keyPEM, nil
+	} else if !os.IsNotExist(err) {
+		return nil, nil, errors.Trace(err)
+	}
+
+	// No certs were found, so generate one and cache it in the
+	// Juju XDG_DATA dir. We cache the certificate so that we
+	// avoid uploading a new certificate each time we bootstrap.
+	certPEM, keyPEM, err = p.generateMemCert(true)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	if err := writeCert(jujuLXDDir, certPEM, keyPEM); err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	return certPEM, keyPEM, nil
+}
+
+func readCert(dir string) (certPEM, keyPEM []byte, _ error) {
+	clientCertPath := filepath.Join(dir, "client.crt")
+	clientKeyPath := filepath.Join(dir, "client.key")
+	certPEM, err := ioutil.ReadFile(clientCertPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyPEM, err = ioutil.ReadFile(clientKeyPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	return certPEM, keyPEM, nil
+}
+
+func writeCert(dir string, certPEM, keyPEM []byte) error {
+	clientCertPath := filepath.Join(dir, "client.crt")
+	clientKeyPath := filepath.Join(dir, "client.key")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return errors.Trace(err)
+	}
+	if err := ioutil.WriteFile(clientCertPath, certPEM, 0600); err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(clientKeyPath, keyPEM, 0600); err != nil {
+		return err
+	}
+	return nil
 }
 
 // FinalizeCredential is part of the environs.ProviderCredentials interface.
-func (p environProviderCredentials) FinalizeCredential(_ environs.FinalizeCredentialContext, args environs.FinalizeCredentialParams) (*cloud.Credential, error) {
-	// For an "empty" credential we will generate a certificate if
-	// the LXD is local to this host, and upload the certificate
-	// to LXD. For any other credential, we leave it alone.
+func (p environProviderCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, args environs.FinalizeCredentialParams) (*cloud.Credential, error) {
+	// Credential detection yields a partial certificate containing just
+	// the client certificate and key. We check if we have a partial
+	// credential, and fill in the server certificate if we can.
 
-	if args.Credential.AuthType() != cloud.EmptyAuthType {
+	if args.Credential.AuthType() != cloud.CertificateAuthType {
 		return &args.Credential, nil
+	}
+
+	credAttrs := args.Credential.Attributes()
+	if credAttrs[credAttrServerCert] != "" {
+		// The credential is fully formed, so we assume the client
+		// certificate is uploaded to the server already.
+		return &args.Credential, nil
+	}
+	certPEM := credAttrs[credAttrClientCert]
+	keyPEM := credAttrs[credAttrClientKey]
+	if certPEM == "" {
+		return nil, errors.NotValidf("missing or empty %q attribute", credAttrClientCert)
+	}
+	if keyPEM == "" {
+		return nil, errors.NotValidf("missing or empty %q attribute", credAttrClientKey)
 	}
 
 	isLocalEndpoint, err := p.isLocalEndpoint(args.CloudEndpoint)
@@ -75,6 +168,16 @@ func (p environProviderCredentials) FinalizeCredential(_ environs.FinalizeCreden
 	if !isLocalEndpoint {
 		// The endpoint is not local, so we cannot generate a
 		// certificate credential.
+		//
+		// TODO(axw) we could look in the $HOME/.config/lxc/servercerts
+		// directory for a server certificate. We would need to read
+		// $HOME/.config/lxc/config.yml to identify the remote by its
+		// endpoint.
+		//
+		// We may later want to add an "interactive" auth-type
+		// that users can select when adding credentials to
+		// go through the interactive server certificate fingerprint
+		// verification flow.
 		return &args.Credential, nil
 	}
 	raw, err := p.newLocalRawProvider()
@@ -82,39 +185,44 @@ func (p environProviderCredentials) FinalizeCredential(_ environs.FinalizeCreden
 		return nil, errors.Trace(err)
 	}
 
-	// Generate a certificate pair, upload to the server, and then create a
-	// new "certificate" credential with them and the server's certificate.
-	//
-	// We must upload here to cater for the esoteric case of automatic
-	// credential generation in "juju add-model". We *also* upload during
-	// bootstrap, in case the user does a "rebootstrap" with the *same*
-	// credentials (e.g. juju restore-backup).
-	certPEM, keyPEM, err := p.generateMemCert(true)
+	// Upload the certificate to the server if necessary.
+	clientCert := lxdclient.Cert{
+		Name:    "juju",
+		CertPEM: []byte(certPEM),
+		KeyPEM:  []byte(keyPEM),
+	}
+	fingerprint, err := clientCert.Fingerprint()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := raw.AddCert(lxdclient.Cert{
-		Name:    "juju",
-		CertPEM: certPEM,
-		KeyPEM:  keyPEM,
-	}); err != nil {
-		return nil, errors.Annotate(err, "adding certificate")
+	if _, err := raw.CertByFingerprint(fingerprint); errors.IsNotFound(err) {
+		if err := raw.AddCert(clientCert); err != nil {
+			return nil, errors.Annotatef(
+				err, "adding certificate %q", clientCert.Name,
+			)
+		}
+	} else if err != nil {
+		return nil, errors.Annotate(err, "querying certificates")
 	}
+
+	// Store the server's certificate in the credential.
 	serverState, err := raw.ServerStatus()
 	if err != nil {
 		return nil, errors.Annotate(err, "getting server status")
 	}
-
-	out := cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
-		credAttrServerCert: serverState.Environment.Certificate,
-		credAttrClientCert: string(certPEM),
-		credAttrClientKey:  string(keyPEM),
-	})
+	credAttrs[credAttrServerCert] = serverState.Environment.Certificate
+	out := cloud.NewCredential(cloud.CertificateAuthType, credAttrs)
 	out.Label = args.Credential.Label
 	return &out, nil
 }
 
 func (p environProviderCredentials) isLocalEndpoint(endpoint string) (bool, error) {
+	if endpoint == "" {
+		// No endpoint specified, so assume we're local. This
+		// will happen, for example, when destroying a 2.0
+		// LXD controller.
+		return true, nil
+	}
 	endpointAddrs, err := p.lookupHost(endpoint)
 	if err != nil {
 		return false, errors.Trace(err)

--- a/provider/lxd/credentials_test.go
+++ b/provider/lxd/credentials_test.go
@@ -4,14 +4,20 @@
 package lxd_test
 
 import (
+	"io/ioutil"
 	"net"
+	"os"
+	"path/filepath"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/provider/lxd"
 )
 
@@ -25,28 +31,135 @@ func (s *credentialsSuite) TestCredentialSchemas(c *gc.C) {
 	envtesting.AssertProviderAuthTypes(c, s.Provider, "certificate")
 }
 
-func (s *credentialsSuite) TestDetectCredentials(c *gc.C) {
+func (s *credentialsSuite) TestDetectCredentialsUsesLXCCert(c *gc.C) {
+	home := c.MkDir()
+	utils.SetHome(home)
+	s.writeFile(c, filepath.Join(home, ".config/lxc/client.crt"), "client-cert-data")
+	s.writeFile(c, filepath.Join(home, ".config/lxc/client.key"), "client-key-data")
+
 	credentials, err := s.Provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(credentials, jc.DeepEquals, cloud.NewEmptyCloudCredential())
+	c.Assert(credentials, jc.DeepEquals, &cloud.CloudCredential{
+		AuthCredentials: map[string]cloud.Credential{
+			"default": cloud.NewCredential(
+				cloud.CertificateAuthType,
+				map[string]string{
+					"client-cert": "client-cert-data",
+					"client-key":  "client-key-data",
+				},
+			),
+		},
+	})
+	s.Stub.CheckCallNames(c)
 }
 
-func (s *credentialsSuite) TestFinalizeCredential(c *gc.C) {
+func (s *credentialsSuite) TestDetectCredentialsUsesJujuLXDCert(c *gc.C) {
+	// If there's a keypair for both the LXC client and Juju, we will
+	// always pick the Juju one.
+	home := c.MkDir()
+	utils.SetHome(home)
+	xdg := osenv.JujuXDGDataHomeDir()
+	s.writeFile(c, filepath.Join(home, ".config/lxc/client.crt"), "lxc-client-cert-data")
+	s.writeFile(c, filepath.Join(home, ".config/lxc/client.key"), "lxc-client-key-data")
+	s.writeFile(c, filepath.Join(xdg, "lxd/client.crt"), "juju-client-cert-data")
+	s.writeFile(c, filepath.Join(xdg, "lxd/client.key"), "juju-client-key-data")
+
+	credentials, err := s.Provider.DetectCredentials()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(credentials, jc.DeepEquals, &cloud.CloudCredential{
+		AuthCredentials: map[string]cloud.Credential{
+			"default": cloud.NewCredential(
+				cloud.CertificateAuthType,
+				map[string]string{
+					"client-cert": "juju-client-cert-data",
+					"client-key":  "juju-client-key-data",
+				},
+			),
+		},
+	})
+	s.Stub.CheckCallNames(c)
+}
+
+func (S *credentialsSuite) writeFile(c *gc.C, path, content string) {
+	err := os.MkdirAll(filepath.Dir(path), 0755)
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(path, []byte(content), 0600)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *credentialsSuite) TestDetectCredentialsGeneratesCert(c *gc.C) {
+	credentials, err := s.Provider.DetectCredentials()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(credentials, jc.DeepEquals, &cloud.CloudCredential{
+		AuthCredentials: map[string]cloud.Credential{
+			"default": cloud.NewCredential(
+				cloud.CertificateAuthType,
+				map[string]string{
+					"client-cert": "client.crt",
+					"client-key":  "client.key",
+				},
+			),
+		},
+	})
+	s.Stub.CheckCallNames(c, "GenerateMemCert")
+
+	// The cert/key pair should have been cached in the juju/lxd dir.
+	xdg := osenv.JujuXDGDataHomeDir()
+	content, err := ioutil.ReadFile(filepath.Join(xdg, "lxd/client.crt"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(content), gc.Equals, "client.crt")
+	content, err = ioutil.ReadFile(filepath.Join(xdg, "lxd/client.key"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(content), gc.Equals, "client.key")
+}
+
+func (s *credentialsSuite) TestFinalizeCredentialLocal(c *gc.C) {
+	cert, _ := s.TestingCert(c)
 	out, err := s.Provider.FinalizeCredential(nil, environs.FinalizeCredentialParams{
-		CloudEndpoint: "",
-		Credential:    cloud.NewEmptyCredential(),
+		CloudEndpoint: "1.2.3.4",
+		Credential: cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
+			"client-cert": string(cert.CertPEM),
+			"client-key":  string(cert.KeyPEM),
+		}),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(out.AuthType(), gc.Equals, cloud.CertificateAuthType)
 	c.Assert(out.Attributes(), jc.DeepEquals, map[string]string{
-		"client-cert": "client.crt",
-		"client-key":  "client.key",
+		"client-cert": string(cert.CertPEM),
+		"client-key":  string(cert.KeyPEM),
 		"server-cert": "server-cert",
 	})
 	s.Stub.CheckCallNames(c,
-		"LookupHost", "InterfaceAddrs",
-		"GenerateMemCert", "AddCert", "ServerStatus",
+		"LookupHost",
+		"InterfaceAddrs",
+		"CertByFingerprint",
+		"ServerStatus",
+	)
+}
+
+func (s *credentialsSuite) TestFinalizeCredentialLocalAddCert(c *gc.C) {
+	s.Stub.SetErrors(errors.NotFoundf("certificate"))
+	cert, _ := s.TestingCert(c)
+	out, err := s.Provider.FinalizeCredential(nil, environs.FinalizeCredentialParams{
+		CloudEndpoint: "", // skips host lookup
+		Credential: cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
+			"client-cert": string(cert.CertPEM),
+			"client-key":  string(cert.KeyPEM),
+		}),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(out.AuthType(), gc.Equals, cloud.CertificateAuthType)
+	c.Assert(out.Attributes(), jc.DeepEquals, map[string]string{
+		"client-cert": string(cert.CertPEM),
+		"client-key":  string(cert.KeyPEM),
+		"server-cert": "server-cert",
+	})
+	s.Stub.CheckCallNames(c,
+		"CertByFingerprint",
+		"AddCert",
+		"ServerStatus",
 	)
 }
 
@@ -54,10 +167,14 @@ func (s *credentialsSuite) TestFinalizeCredentialNonLocal(c *gc.C) {
 	// Patch the interface addresses for the calling machine, so
 	// it appears that we're not on the LXD server host.
 	s.PatchValue(&s.InterfaceAddrs, []net.Addr{&net.IPNet{IP: net.ParseIP("8.8.8.8")}})
+	in := cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
+		"client-cert": "foo",
+		"client-key":  "bar",
+	})
 	out, err := s.Provider.FinalizeCredential(nil, environs.FinalizeCredentialParams{
-		CloudEndpoint: "",
-		Credential:    cloud.NewEmptyCredential(),
+		CloudEndpoint: "8.8.8.8",
+		Credential:    in,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(out.AuthType(), gc.Equals, cloud.EmptyAuthType)
+	c.Assert(out, jc.DeepEquals, &in)
 }

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -32,10 +32,6 @@ type environ struct {
 	cloud    environs.CloudSpec
 	provider *environProvider
 
-	// local records whether or not the LXD is local to the host running
-	// this process.
-	local bool
-
 	name string
 	uuid string
 	raw  *rawProvider
@@ -74,7 +70,6 @@ func newEnviron(
 
 	env := &environ{
 		cloud:     spec,
-		local:     local,
 		name:      ecfg.Name(),
 		uuid:      ecfg.UUID(),
 		raw:       raw,
@@ -158,31 +153,6 @@ func (env *environ) Create(environs.CreateParams) error {
 
 // Bootstrap implements environs.Environ.
 func (env *environ) Bootstrap(ctx environs.BootstrapContext, params environs.BootstrapParams) (*environs.BootstrapResult, error) {
-	if env.local {
-		// Add the client certificate to the LXD server, so the
-		// controller containers can authenticate. We can only
-		// do this for local LXD. For non-local, the user must
-		// do this themselves, until we support using trust
-		// passwords.
-		clientCert, _, ok := getCerts(env.cloud)
-		if !ok {
-			return nil, errors.New("cannot bootstrap without client certificate")
-		}
-		fingerprint, err := clientCert.Fingerprint()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		_, err = env.raw.CertByFingerprint(fingerprint)
-		if errors.IsNotFound(err) {
-			if err := env.raw.AddCert(*clientCert); err != nil {
-				return nil, errors.Annotatef(
-					err, "adding certificate %q", clientCert.Name,
-				)
-			}
-		} else if err != nil {
-			return nil, errors.Annotate(err, "querying certificates")
-		}
-	}
 	return env.base.BootstrapEnv(ctx, params)
 }
 
@@ -217,15 +187,6 @@ func (env *environ) DestroyController(controllerUUID string) error {
 	if err := env.destroyHostedModelResources(controllerUUID); err != nil {
 		return errors.Trace(err)
 	}
-	if env.local {
-		// When we're running locally to the LXD host, remove the
-		// certificate from LXD. It will get added back in at
-		// bootstrap time as necessary. For remote LXD, the user
-		// needs to have added the certificate to LXD themselves.
-		if err := env.removeCertificate(); err != nil {
-			return errors.Trace(err)
-		}
-	}
 	return nil
 }
 
@@ -253,21 +214,6 @@ func (env *environ) destroyHostedModelResources(controllerUUID string) error {
 		if err := env.raw.RemoveInstances(prefix, names...); err != nil {
 			return errors.Annotate(err, "removing hosted model instances")
 		}
-	}
-	return nil
-}
-
-func (env *environ) removeCertificate() error {
-	if env.raw.remote.Cert == nil {
-		return nil
-	}
-	fingerprint, err := env.raw.remote.Cert.Fingerprint()
-	if err != nil {
-		return errors.Annotate(err, "generating certificate fingerprint")
-	}
-	err = env.raw.RemoveCertByFingerprint(fingerprint)
-	if err != nil && !errors.IsNotFound(err) {
-		return errors.Annotate(err, "removing certificate")
 	}
 	return nil
 }

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -186,26 +186,11 @@ func (p *environProvider) validateCloudSpec(spec environs.CloudSpec) (local bool
 	if spec.Credential == nil {
 		return false, errors.NotValidf("missing credential")
 	}
-	if spec.Endpoint != "" {
-		var err error
-		local, err = p.isLocalEndpoint(spec.Endpoint)
-		if err != nil {
-			return false, errors.Trace(err)
-		}
-	} else {
-		// No endpoint specified, so assume we're local. This
-		// will happen, for example, when destroying a 2.0
-		// LXD controller.
-		local = true
+	local, err := p.isLocalEndpoint(spec.Endpoint)
+	if err != nil {
+		return false, errors.Trace(err)
 	}
 	switch authType := spec.Credential.AuthType(); authType {
-	case cloud.EmptyAuthType:
-		if !local {
-			// The empty auth-type is only valid
-			// when the endpoint is local to the
-			// machine running this process.
-			return false, errors.NotSupportedf("%q auth-type for non-local LXD", authType)
-		}
 	case cloud.CertificateAuthType:
 		if _, _, ok := getCerts(spec); !ok {
 			return false, errors.NotValidf("certificate credentials")

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -206,7 +206,7 @@ func (s *ProviderFunctionalSuite) TestPrepareConfigEmptyAuthNonLocal(c *gc.C) {
 			Credential: &cred,
 		},
 	})
-	c.Assert(err, gc.ErrorMatches, `validating cloud spec: "empty" auth-type for non-local LXD not supported`)
+	c.Assert(err, gc.ErrorMatches, `validating cloud spec: "empty" auth-type not supported`)
 }
 
 type mockContext struct {

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -89,7 +89,7 @@ var (
 )
 
 type BaseSuiteUnpatched struct {
-	gitjujutesting.IsolationSuite
+	testing.BaseSuite
 
 	osPathOrig string
 
@@ -117,17 +117,17 @@ func (s *BaseSuiteUnpatched) SetUpSuite(c *gc.C) {
 	s.osPathOrig = os.Getenv("PATH")
 	if s.osPathOrig == "" {
 		// TODO(ericsnow) This shouldn't happen. However, an undiagnosed
-		// bug in testing.IsolationSuite is causing $PATH to remain unset
+		// bug in testing.BaseSuite is causing $PATH to remain unset
 		// sometimes.  Once that is cleared up this special-case can go
 		// away.
 		s.osPathOrig =
 			"/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
 	}
-	s.IsolationSuite.SetUpSuite(c)
+	s.BaseSuite.SetUpSuite(c)
 }
 
 func (s *BaseSuiteUnpatched) SetUpTest(c *gc.C) {
-	s.IsolationSuite.SetUpTest(c)
+	s.BaseSuite.SetUpTest(c)
 
 	s.initProvider(c)
 	s.initEnv(c)
@@ -151,7 +151,6 @@ func (s *BaseSuiteUnpatched) initEnv(c *gc.C) {
 		"server-cert": testing.ServerCert,
 	})
 	s.Env = &environ{
-		local: true,
 		cloud: environs.CloudSpec{
 			Name:       "localhost",
 			Type:       "lxd",
@@ -162,10 +161,6 @@ func (s *BaseSuiteUnpatched) initEnv(c *gc.C) {
 	}
 	cfg := s.NewConfig(c, nil)
 	s.setConfig(c, cfg)
-}
-
-func (s *BaseSuiteUnpatched) SetEnvironLocal(local bool) {
-	s.Env.local = local
 }
 
 func (s *BaseSuiteUnpatched) Prefix() string {


### PR DESCRIPTION
## Description of change

When bootstrapping LXD, we will now cache the generated credential in ~/.local/share/juju/lxd. This allows us to use the same certificates each time we bootstrap, rather than a fresh one each time. Since we'll only generate one, and upload it once, we no longer need to remove certs on controller destruction.

## QA steps

juju bootstrap localhost b
juju bootstrap localhost a
juju add-model foo
juju migrate foo b
(confirm model migrated)
juju destroy-controller -y a
juju destroy-controller -y b

juju bootstrap localhost (with juju 2.0)
juju destroy-controller -y localhost-localhost (with this branch)

juju bootstrap localhost (with juju 2.0)
juju upgrade-juju -m controller (with this branch)
juju destroy-controller -y localhost-localhost (with this branch)

## Documentation changes

No change.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1661091