### PR TITLE
Find lxdbr0 even when it doesn't have an address.

### DIFF
--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -825,6 +825,7 @@ type hostChangesContext struct {
 func (ctx *hostChangesContext) ProcessOneContainer(env environs.Environ, idx int, host, container *state.Machine) error {
 	bridgePolicy := containerizer.BridgePolicy{
 		NetBondReconfigureDelay: env.Config().NetBondReconfigureDelay(),
+		UseLocalBridges:         !environs.SupportsContainerAddresses(env),
 	}
 	bridges, reconfigureDelay, err := bridgePolicy.FindMissingBridgesForContainer(host, container)
 	if err != nil {

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -144,7 +144,6 @@ func setMachineAddresses(tag names.MachineTag, m Machine) error {
 }
 
 func (mr *Machiner) Handle(_ <-chan struct{}) error {
-	logger.Infof("got a Machiner.Handle() event")
 	if err := mr.machine.Refresh(); params.IsCodeNotFoundOrCodeUnauthorized(err) {
 		// NOTE(axw) we can distinguish between NotFound and CodeUnauthorized,
 		// so we could call NotifyMachineDead here in case the agent failed to


### PR DESCRIPTION
When looking on the host machine for how we might want to
configure a container, we actually weren't finding 'lxdbr0'
because it didn't have an address. This changes the
machine.LinkLayerDevicesForSpaces so that it first builds
up devices based on their addresses, and then does a
pass to create the devices based on what they are
connected to.

This properly connects things together for places like
AWS that only have the local bridge.

## QA steps
```
  $ juju bootstrap ?
  $ juju switch controller
  $ juju add-machine lxd:0
  $ juju debug-log ...
```

Without this patch, you'll see lines like:
```
machine-0: 11:44:07 DEBUG juju.network.containerizer for container "0/lxd/0", found desired spaces: <none>
machine-0: 11:44:07 DEBUG juju.network.containerizer container "0/lxd/0" not qualified to a space, host machine "0" is using spaces <none>
machine-0: 11:44:07 DEBUG juju.network.containerizer container has no desired spaces, and host has no known spaces, triggering fallback to bridge
machine-0: 11:44:07 DEBUG juju.network.containerizer FindMissingBridgesForContainer("0/lxd/0") spaces "" devices map{"":["ens4"]}
machine-0: 11:44:07 INFO juju.network bridgescript command=/usr/bin/python2 - --interfaces-to-bridge="ens4" --activate --bridge-prefix=br-  --rec
```

Which indicates it was trying to use the host device (it fails so the later fallback to use lxdbr0 when the one we wanted fails makes it ultimately succeed by accident.)

With this patch, you'll see
```
machine-0: 13:12:15 DEBUG juju.network.containerizer FindMissingBridgesForContainer("0/lxd/2") spaces "" devices map{"":["ens4","lxdbr0"]}
machine-0: 13:12:15 DEBUG juju.provisioner.lxd using multi-bridge networking for container "0/lxd/2"
machine-0: 13:12:15 DEBUG juju.network.containerizer for container "0/lxd/2", found desired spaces: <none>
machine-0: 13:12:15 DEBUG juju.network.containerizer container "0/lxd/2" not qualified to a space, host machine "0" is using spaces <none>
machine-0: 13:12:15 DEBUG juju.network.containerizer container has no desired spaces, and host has no known spaces, triggering fallback to bridge
machine-0: 13:12:15 DEBUG juju.network.containerizer for container "0/lxd/2", found host devices spaces: map{"":["ens4","lxdbr0"]}
machine-0: 13:12:15 DEBUG juju.network.containerizer for container "0/lxd/2" using host machine "0" bridge devices: "lxdbr0"
machine-0: 13:12:15 DEBUG juju.network.containerizer prepared container "0/lxd/2" network config: [{Name:eth0 MTU:1500 ProviderID: Type:ethernet
:true IsUp:true ParentName:m#0#d#lxdbr0}]
```

Which means that we correctly identified that 'lxdbr0' should be used (there should be no call to the bridging script.)

## Documentation changes

This is fixing containers under the covers, so no doc changes.

## Bug reference

This is all part of doing https://bugs.launchpad.net/juju/+bug/1657449 correctly.
It also is a step along the path for https://bugs.launchpad.net/juju/+bug/1656326 because by directly requesting 'lxdbr0' we can remove the code that 'falls back' to lxdbr0.