### PR TITLE
On Windows c.Skip() before SetUpSuite() causes panics.

### DIFF
--- a/network/bridge_test.go
+++ b/network/bridge_test.go
@@ -33,10 +33,10 @@ for arg in sys.argv[1:]: print(arg)
 `
 
 func (s *BridgeSuite) SetUpSuite(c *gc.C) {
+	s.IsolationSuite.SetUpSuite(c)
 	if runtime.GOOS == "windows" {
 		c.Skip("skipping BridgeSuite tests on windows")
 	}
-	s.IsolationSuite.SetUpSuite(c)
 }
 
 func assertCmdResult(c *gc.C, cmd, expected string) {

--- a/network/bridgescript_test.go
+++ b/network/bridgescript_test.go
@@ -31,10 +31,10 @@ type bridgeConfigSuite struct {
 var _ = gc.Suite(&bridgeConfigSuite{})
 
 func (s *bridgeConfigSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
 	if runtime.GOOS == "windows" {
 		c.Skip("Skipping bridge config tests on windows")
 	}
-	s.BaseSuite.SetUpSuite(c)
 
 	for _, version := range []string{
 		"/usr/bin/python2",
@@ -48,6 +48,7 @@ func (s *bridgeConfigSuite) SetUpSuite(c *gc.C) {
 }
 
 func (s *bridgeConfigSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
 	// We need at least one Python package installed.
 	c.Assert(s.pythonVersions, gc.Not(gc.HasLen), 0)
 


### PR DESCRIPTION
Bonus points for the fact it doesn't panic the *current* test, it causes the
*next* test to panic.  While there is probably some source issue in
IsolationSuite, not poking the bear is an easy fix.

## QA steps

On a Windows machine:
```
 cd network
 go test
```
## Bug reference

https://pad.lv/1661285
