### PR TITLE
apiserver: add /introspection/... endpoints

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -79,6 +80,12 @@ type Server struct {
 
 	// certDNSNames holds the DNS names associated with cert.
 	certDNSNames []string
+
+	// registerIntrospectionHandlers is a function that will
+	// call a function with (path, http.Handler) tuples. This
+	// is to support registering the handlers underneath the
+	// "/introspection" prefix.
+	registerIntrospectionHandlers func(func(string, http.Handler))
 }
 
 // LoginValidator functions are used to decide whether login requests
@@ -118,6 +125,12 @@ type ServerConfig struct {
 	// is used per-connection to instantiate a new observer to be
 	// notified of key events during API requests.
 	NewObserver observer.ObserverFactory
+
+	// RegisterIntrospectionHandlers is a function that will
+	// call a function with (path, http.Handler) tuples. This
+	// is to support registering the handlers underneath the
+	// "/introspection" prefix.
+	RegisterIntrospectionHandlers func(func(string, http.Handler))
 
 	// StatePool only exists to support testing.
 	StatePool *state.StatePool
@@ -189,9 +202,10 @@ func newServer(s *state.State, lis net.Listener, cfg ServerConfig) (_ *Server, e
 		adminAPIFactories: map[int]adminAPIFactory{
 			3: newAdminAPIV3,
 		},
-		centralHub:       cfg.Hub,
-		certChanged:      cfg.CertChanged,
-		allowModelAccess: cfg.AllowModelAccess,
+		centralHub:                    cfg.Hub,
+		certChanged:                   cfg.CertChanged,
+		allowModelAccess:              cfg.AllowModelAccess,
+		registerIntrospectionHandlers: cfg.RegisterIntrospectionHandlers,
 	}
 
 	srv.tlsConfig = srv.newTLSConfig(cfg)
@@ -498,6 +512,19 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 	// pat muxer special-cases / so that it does not serve all
 	// possible endpoints, but only / itself.
 	add("/", mainAPIHandler)
+
+	// Register the introspection endpoints.
+	if srv.registerIntrospectionHandlers != nil {
+		handle := func(subpath string, handler http.Handler) {
+			add(path.Join("/introspection/", subpath),
+				introspectionHandler{
+					httpCtxt,
+					handler,
+				},
+			)
+		}
+		srv.registerIntrospectionHandlers(handle)
+	}
 
 	// Add HTTP handlers for local-user macaroon authentication.
 	localLoginHandlers := &localLoginHandlers{srv.authCtxt, srv.state}

--- a/apiserver/introspection.go
+++ b/apiserver/introspection.go
@@ -1,0 +1,78 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"net/http"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/permission"
+)
+
+// introspectionHandler is an http.Handler that wraps an http.Handler
+// from the worker/introspection package, adding authentication.
+type introspectionHandler struct {
+	ctx     httpContext
+	handler http.Handler
+}
+
+// ServeHTTP is part of the http.Handler interface.
+func (h introspectionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if err := h.checkAuth(r); err != nil {
+		if err := sendError(w, err); err != nil {
+			logger.Debugf("%v", err)
+		}
+		return
+	}
+	h.handler.ServeHTTP(w, r)
+}
+
+func (h introspectionHandler) checkAuth(r *http.Request) error {
+	st, entity, err := h.ctx.stateAndEntityForRequestAuthenticatedUser(r)
+	if err != nil {
+		return err
+	}
+	defer h.ctx.release(st)
+
+	// Users with "superuser" access on the controller,
+	// or "read" access on the controller model, can
+	// access these endpoints.
+
+	ok, err := common.HasPermission(
+		st.UserAccess,
+		entity.Tag(),
+		permission.SuperuserAccess,
+		st.ControllerTag(),
+	)
+	if err != nil {
+		return err
+	}
+	if ok {
+		return nil
+	}
+
+	controllerModel, err := st.ControllerModel()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	ok, err = common.HasPermission(
+		st.UserAccess,
+		entity.Tag(),
+		permission.ReadAccess,
+		controllerModel.ModelTag(),
+	)
+	if err != nil {
+		return err
+	}
+	if ok {
+		return nil
+	}
+
+	return &params.Error{
+		Code:    params.CodeForbidden,
+		Message: "access denied",
+	}
+}

--- a/apiserver/introspection_test.go
+++ b/apiserver/introspection_test.go
@@ -1,0 +1,76 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/permission"
+	"github.com/juju/juju/state"
+)
+
+type introspectionSuite struct {
+	authHTTPSuite
+	bob *state.User
+}
+
+var _ = gc.Suite(&introspectionSuite{})
+
+func (s *introspectionSuite) SetUpTest(c *gc.C) {
+	s.authHTTPSuite.SetUpTest(c)
+	bob, err := s.BackingState.AddUser("bob", "", "hunter2", "admin")
+	c.Assert(err, jc.ErrorIsNil)
+	s.bob = bob
+}
+
+func (s *introspectionSuite) url(c *gc.C) string {
+	url := s.baseURL(c)
+	url.Path = "/introspection/navel"
+	return url.String()
+}
+
+func (s *introspectionSuite) TestAccess(c *gc.C) {
+	s.testAccess(c, "user-admin", "dummy-secret")
+
+	_, err := s.BackingState.AddModelUser(
+		s.BackingState.ModelTag().Id(),
+		state.UserAccessSpec{
+			User:      names.NewUserTag("bob"),
+			CreatedBy: names.NewUserTag("admin"),
+			Access:    permission.ReadAccess,
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	s.testAccess(c, "user-bob", "hunter2")
+}
+
+func (s *introspectionSuite) testAccess(c *gc.C, tag, password string) {
+	resp := s.sendRequest(c, httpRequestParams{
+		method:   "GET",
+		url:      s.url(c),
+		tag:      tag,
+		password: password,
+	})
+	defer resp.Body.Close()
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
+	content, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(content), gc.Equals, "gazing")
+}
+
+func (s *introspectionSuite) TestAccessDenied(c *gc.C) {
+	resp := s.sendRequest(c, httpRequestParams{
+		method:   "GET",
+		url:      s.url(c),
+		tag:      "user-bob",
+		password: "hunter2",
+	})
+	defer resp.Body.Close()
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusForbidden)
+}

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -131,6 +131,9 @@ type ManifoldsConfig struct {
 	// PrometheusRegisterer is a prometheus.Registerer that may be used
 	// by workers to register Prometheus metric collectors.
 	PrometheusRegisterer prometheus.Registerer
+
+	// DepEngineReporter is a dependency engine reporter.
+	DepEngineReporter dependency.Reporter
 }
 
 // Manifolds returns a set of co-configured manifolds covering the

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -20,7 +20,9 @@ package dummy
 
 import (
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"os"
 	"runtime"
 	"strconv"
@@ -823,6 +825,11 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 				NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
 				// Should never be used but prevent external access just in case.
 				AutocertURL: "https://0.1.2.3/no-autocert-here",
+				RegisterIntrospectionHandlers: func(f func(path string, h http.Handler)) {
+					f("navel", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						io.WriteString(w, "gazing")
+					}))
+				},
 			})
 			if err != nil {
 				panic(err)


### PR DESCRIPTION
## Description of change

Expose the introspection socket endpoints under
the "/introspection/" prefix in the API server.
Only users with controller superuser access, or
read access to the controller model, may access
these endpoints.

## QA steps

1. juju bootstrap localhost
2. open browser to https://\<controller-address\>:17070/introspection/metrics
3. enter "user-admin" as username, admin password as password (obtain using `juju gui --show-credentials`)
4. juju add-user prometheus
5. juju change-user-password prometheus
6. juju grant prometheus read controller
7. set up prometheus:

```bash
$ sudo snap install prometheus
$ sudo bash -c "juju controller-config ca-cert | tail -n +2 | sed 's/^\s*//' > /var/snap/prometheus/current/juju.ca"
$ sudo vim /var/snap/prometheus/current/prometheus.yml, add the following scrape config:
```

```yaml
scrape_configs:
  - job_name: 'juju'
    metrics_path: '/introspection/metrics'    
    scheme: 'https'                           
    static_configs:                           
      - targets: ['<controller-address>:17070']      
    basic_auth:                               
      username: 'user-prometheus'
      password: '<prometheus-password>'
    tls_config:
      ca_file: /var/snap/prometheus/current/juju.ca
```

8. Reload prometheus (e.g. sudo snap disable/enable prometheus)
8. Open up prometheus GUI and verify the target is being scraped OK (http://localhost:9090/targets)

## Documentation changes

We should add web documentation on how to set up Prometheus, as described above.