### PR TITLE
Fix lxd ipv6

### DIFF
--- a/tools/lxdclient/client_network.go
+++ b/tools/lxdclient/client_network.go
@@ -54,8 +54,8 @@ func checkBridgeConfig(client rawNetworkClient, bridge string) error {
 	if err != nil {
 		return err
 	}
-
-	if n.Managed && n.Config["ipv6.address"] != "none" {
+	ipv6AddressConfig := n.Config["ipv6.address"]
+	if n.Managed && ipv6AddressConfig != "none" && ipv6AddressConfig != "" {
 		return errors.Errorf(`juju doesn't support ipv6. Please disable LXD's IPV6:
 
 	$ lxc network set %s ipv6.address none

--- a/tools/lxdclient/utils.go
+++ b/tools/lxdclient/utils.go
@@ -7,7 +7,7 @@ package lxdclient
 
 import (
 	"bytes"
-	"regexp"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/series"
@@ -66,7 +66,9 @@ func IsRunningLocally() (bool, error) {
 	return running, nil
 }
 
-const errIPV6NotSupported = `cannot listen on https socket: listen tcp \[::\]:\d*: socket: address family not supported by protocol`
+// errIPV6NotSupported is the error returned by glibc for attempts at unsupported
+// protocols.
+const errIPV6NotSupported = `socket: address family not supported by protocol`
 
 // EnableHTTPSListener configures LXD to listen for HTTPS requests,
 // rather than only via the Unix socket.
@@ -82,15 +84,11 @@ func EnableHTTPSListener(client interface {
 	err := client.SetServerConfig("core.https_address", "[::]")
 
 	if err != nil {
-		// if the error hints that the problem might be a protocol unsopported
+		// if the error hints that the problem might be a protocol unsupported
 		// such as what happens when IPV6 is disabled in kernel, we try IPV4
 		// as a fallback.
 		cause := errors.Cause(err)
-		matched, merr := regexp.MatchString(errIPV6NotSupported, cause.Error())
-		if merr != nil {
-			logger.Errorf("cant match error: %v", merr)
-		}
-		if matched {
+		if strings.HasSuffix(cause.Error(), errIPV6NotSupported) {
 			return errors.Trace(client.SetServerConfig("core.https_address", "0.0.0.0"))
 		}
 		return errors.Trace(err)

--- a/tools/lxdclient/utils_test.go
+++ b/tools/lxdclient/utils_test.go
@@ -37,6 +37,15 @@ func (s *utilsSuite) TestEnableHTTPSListenerError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "uh oh")
 }
 
+func (s *utilsSuite) TestEnableHTTPSListenerIPV4Fallback(c *gc.C) {
+	var client mockConfigSetter
+	client.SetErrors(errors.New("any error string added by lxd: socket: address family not supported by protocol"))
+	err := lxdclient.EnableHTTPSListener(&client)
+	c.Assert(err, jc.ErrorIsNil)
+	client.CheckCall(c, 0, "SetServerConfig", "core.https_address", "[::]")
+	client.CheckCall(c, 1, "SetServerConfig", "core.https_address", "0.0.0.0")
+}
+
 type mockConfigSetter struct {
 	testing.Stub
 }


### PR DESCRIPTION
Detect when IPV6.address is empty in lxd config and fallback to IPV4 when 6 is disabled in kernel.

This change prevents juju lxd provider from failing when running in a machine with ipv6 disabled in different possible ways.

## QA steps

Try reproduction steps in bugs:
* https://bugs.launchpad.net/juju/+bug/1656205
* https://bugs.launchpad.net/juju/+bug/1633362

## Bug reference

https://bugs.launchpad.net/juju/+bug/1656205
https://bugs.launchpad.net/juju/+bug/1633362
