### PR TITLE
ignore the snap build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ tags
 !tags/
 TAGS
 !TAGS/
+parts/
+prime/
+stage/
+*.snap
 .emacs.desktop
 .emacs.desktop.lock
 *.test


### PR DESCRIPTION
Small tweak to .gitignore so that the temporary files produced by 'snapcraft' aren't ever accidentally committed.
