### PR TITLE
2.1 remove unit help

### DIFF
--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -36,14 +36,14 @@ Juju will also remove the machine if the removed unit was the only unit left
 on that machine (including units in containers).
 
 Removing all units of a service is not equivalent to removing the service
-itself; for that, the ` + "`juju remove-service`" + ` command is used.
+itself; for that, the ` + "`juju remove-application`" + ` command is used.
 
 Examples:
 
     juju remove-unit wordpress/2 wordpress/3 wordpress/4
 
 See also:
-    remove-service
+    remove-application
 `
 
 func (c *removeUnitCommand) Info() *cmd.Info {

--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -27,7 +27,7 @@ type removeUnitCommand struct {
 const removeUnitDoc = `
 Remove application units from the model.
 
-Units of a service are numbered in sequence upon creation. For example, the
+Units of a application are numbered in sequence upon creation. For example, the
 fourth unit of wordpress will be designated "wordpress/3". These identifiers
 can be supplied in a space delimited list to remove unwanted units from the
 model.
@@ -35,8 +35,9 @@ model.
 Juju will also remove the machine if the removed unit was the only unit left
 on that machine (including units in containers).
 
-Removing all units of a service is not equivalent to removing the service
-itself; for that, the ` + "`juju remove-application`" + ` command is used.
+Removing all units of a application is not equivalent to removing the
+application itself; for that, the ` + "`juju remove-application`" + ` command
+is used.
 
 Examples:
 


### PR DESCRIPTION
This is a cherry pick of issue #6904 with a couple of tweaks to fix more of the help text.

## Description of change

`remove-unit` was referring to "service" when it should have been referring to "application".

## QA steps

`juju help remove-unit`
