### PR TITLE
be strict about binding names

### DIFF
--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -414,6 +414,34 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleInvalidSeries(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot add unit for application "django": adding new machine to host unit "django/0": cannot assign unit "django/0" to machine 0: series does not match`)
 }
 
+func (s *BundleDeployCharmStoreSuite) TestDeployBundleInvalidBinding(c *gc.C) {
+	testcharms.UploadCharm(c, s.client, "xenial/wordpress-42", "wordpress")
+	_, err := s.DeployBundleYAML(c, `
+        applications:
+            wp:
+                charm: xenial/wordpress-42
+                num_units: 1
+                bindings:
+                  noturl: public
+    `)
+	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot deploy application "wp": invalid binding\(s\) supplied "noturl", valid binding names are "admin-api",.* "url"`)
+}
+
+func (s *BundleDeployCharmStoreSuite) TestDeployBundleInvalidSpace(c *gc.C) {
+	testcharms.UploadCharm(c, s.client, "xenial/wordpress-42", "wordpress")
+	_, err := s.DeployBundleYAML(c, `
+        applications:
+            wp:
+                charm: xenial/wordpress-42
+                num_units: 1
+                bindings:
+                  url: public
+    `)
+	// TODO(jam): 2017-02-05 double repeating "cannot deploy application" and "cannot add application" is a bit ugly
+	// https://pad.lv/1661937
+	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot deploy application "wp": cannot add application "wp": unknown space "public" not valid`)
+}
+
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleWatcherTimeout(c *gc.C) {
 	// Inject an "AllWatcher" that never delivers a result.
 	ch := make(chan struct{})

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1119,6 +1119,7 @@ func (s *DeployCharmStoreSuite) TestDeployCharmWithSomeEndpointBindingsSpecified
 	s.assertDeployedServiceBindings(c, map[string]serviceInfo{
 		"wordpress-extra-bindings": {
 			endpointBindings: map[string]string{
+				"":                "public",
 				"cache":           "public",
 				"url":             "public",
 				"logging-dir":     "public",

--- a/juju/deploy.go
+++ b/juju/deploy.go
@@ -5,6 +5,9 @@ package juju
 
 import (
 	"fmt"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v6-unstable"
@@ -52,7 +55,7 @@ type UnitAdder interface {
 func DeployApplication(st ApplicationDeployer, args DeployApplicationParams) (*state.Application, error) {
 	settings, err := args.Charm.Config().ValidateSettings(args.ConfigSettings)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	if args.Charm.Meta().Subordinate {
 		if args.NumUnits != 0 {
@@ -65,7 +68,10 @@ func DeployApplication(st ApplicationDeployer, args DeployApplicationParams) (*s
 	// TODO(fwereade): transactional State.AddApplication including settings, constraints
 	// (minimumUnitCount, initialMachineIds?).
 
-	effectiveBindings := getEffectiveBindingsForCharmMeta(args.Charm.Meta(), args.EndpointBindings)
+	effectiveBindings, err := getEffectiveBindingsForCharmMeta(args.Charm.Meta(), args.EndpointBindings)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	asa := state.AddApplicationArgs{
 		Name:             args.ApplicationName,
@@ -87,17 +93,58 @@ func DeployApplication(st ApplicationDeployer, args DeployApplicationParams) (*s
 	return st.AddApplication(asa)
 }
 
-func getEffectiveBindingsForCharmMeta(charmMeta *charm.Meta, givenBindings map[string]string) map[string]string {
+func quoteStrings(vals []string) string {
+	out := make([]string, len(vals))
+	for i, val := range vals {
+		out[i] = strconv.Quote(val)
+	}
+	return strings.Join(out, ", ")
+}
+
+func validateGivenBindings(givenBindings map[string]string, defaultBindings map[string]string) error {
+	invalidBindings := make([]string, 0)
+	for name, _ := range givenBindings {
+		if name == "" {
+			continue
+		}
+		if _, ok := defaultBindings[name]; !ok {
+			invalidBindings = append(invalidBindings, name)
+		}
+	}
+	if len(invalidBindings) == 0 {
+		return nil
+	}
+	possibleBindings := make([]string, 0)
+	for name, _ := range defaultBindings {
+		if name == "" {
+			continue
+		}
+		possibleBindings = append(possibleBindings, name)
+	}
+	sort.Strings(invalidBindings)
+	sort.Strings(possibleBindings)
+	return errors.Errorf("invalid binding(s) supplied %s, valid binding names are %s",
+		quoteStrings(invalidBindings), quoteStrings(possibleBindings))
+}
+
+func getEffectiveBindingsForCharmMeta(charmMeta *charm.Meta, givenBindings map[string]string) (map[string]string, error) {
 	// defaultBindings contains all bindable endpoints for charmMeta as keys and
 	// empty space names as values, so we use defaultBindings as fallback.
 	defaultBindings := state.DefaultEndpointBindingsForCharm(charmMeta)
 	if givenBindings == nil {
 		givenBindings = make(map[string]string, len(defaultBindings))
 	}
+	if err := validateGivenBindings(givenBindings, defaultBindings); err != nil {
+		return nil, err
+	}
 
 	// Get the application-level default binding for all unspecified endpoint, if
 	// set, otherwise use the empty default.
-	applicationDefaultSpace, _ := givenBindings[""]
+	applicationDefaultSpace, defaultSupplied := givenBindings[""]
+	if defaultSupplied {
+		// Record that a default binding was requested
+		defaultBindings[""] = applicationDefaultSpace
+	}
 
 	effectiveBindings := make(map[string]string, len(defaultBindings))
 	for endpoint, _ := range defaultBindings {
@@ -107,7 +154,7 @@ func getEffectiveBindingsForCharmMeta(charmMeta *charm.Meta, givenBindings map[s
 			effectiveBindings[endpoint] = applicationDefaultSpace
 		}
 	}
-	return effectiveBindings
+	return effectiveBindings, nil
 }
 
 // AddUnits starts n units of the given application using the specified placement

--- a/juju/deploy.go
+++ b/juju/deploy.go
@@ -138,8 +138,8 @@ func getEffectiveBindingsForCharmMeta(charmMeta *charm.Meta, givenBindings map[s
 		return nil, err
 	}
 
-	// Get the application-level default binding for all unspecified endpoint, if
-	// set, otherwise use the empty default.
+	// Get the application-level default binding for all unspecified endpoints, if
+	// set. Otherwise use the empty default.
 	applicationDefaultSpace, defaultSupplied := givenBindings[""]
 	if defaultSupplied {
 		// Record that a default binding was requested

--- a/juju/deploy_test.go
+++ b/juju/deploy_test.go
@@ -54,16 +54,16 @@ func (s *DeployLocalSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployMinimal(c *gc.C) {
-	service, err := juju.DeployApplication(s.State,
+	app, err := juju.DeployApplication(s.State,
 		juju.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertCharm(c, service, s.charm.URL())
-	s.assertSettings(c, service, charm.Settings{})
-	s.assertConstraints(c, service, constraints.Value{})
-	s.assertMachines(c, service, constraints.Value{})
+	s.assertCharm(c, app, s.charm.URL())
+	s.assertSettings(c, app, charm.Settings{})
+	s.assertConstraints(c, app, constraints.Value{})
+	s.assertMachines(c, app, constraints.Value{})
 }
 
 func (s *DeployLocalSuite) TestDeploySeries(c *gc.C) {
@@ -85,7 +85,7 @@ func (s *DeployLocalSuite) TestDeploySeries(c *gc.C) {
 func (s *DeployLocalSuite) TestDeployWithImplicitBindings(c *gc.C) {
 	wordpressCharm := s.addWordpressCharmWithExtraBindings(c)
 
-	service, err := juju.DeployApplication(s.State,
+	app, err := juju.DeployApplication(s.State,
 		juju.DeployApplicationParams{
 			ApplicationName:  "bob",
 			Charm:            wordpressCharm,
@@ -93,7 +93,7 @@ func (s *DeployLocalSuite) TestDeployWithImplicitBindings(c *gc.C) {
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertBindings(c, service, map[string]string{
+	s.assertBindings(c, app, map[string]string{
 		// relation names
 		"url":             "",
 		"logging-dir":     "",
@@ -124,8 +124,8 @@ func (s *DeployLocalSuite) addWordpressCharmFromURL(c *gc.C, charmURL *charm.URL
 	return wordpressCharm
 }
 
-func (s *DeployLocalSuite) assertBindings(c *gc.C, service *state.Application, expected map[string]string) {
-	bindings, err := service.EndpointBindings()
+func (s *DeployLocalSuite) assertBindings(c *gc.C, app *state.Application, expected map[string]string) {
+	bindings, err := app.EndpointBindings()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(bindings, jc.DeepEquals, expected)
 }
@@ -137,7 +137,7 @@ func (s *DeployLocalSuite) TestDeployWithSomeSpecifiedBindings(c *gc.C) {
 	_, err = s.State.AddSpace("public", "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	service, err := juju.DeployApplication(s.State,
+	app, err := juju.DeployApplication(s.State,
 		juju.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           wordpressCharm,
@@ -148,7 +148,7 @@ func (s *DeployLocalSuite) TestDeployWithSomeSpecifiedBindings(c *gc.C) {
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertBindings(c, service, map[string]string{
+	s.assertBindings(c, app, map[string]string{
 		// default binding
 		"": "public",
 		// relation names
@@ -173,7 +173,7 @@ func (s *DeployLocalSuite) TestDeployWithBoundRelationNamesAndExtraBindingsNames
 	_, err = s.State.AddSpace("internal", "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	service, err := juju.DeployApplication(s.State,
+	app, err := juju.DeployApplication(s.State,
 		juju.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           wordpressCharm,
@@ -186,7 +186,7 @@ func (s *DeployLocalSuite) TestDeployWithBoundRelationNamesAndExtraBindingsNames
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertBindings(c, service, map[string]string{
+	s.assertBindings(c, app, map[string]string{
 		"":                "public",
 		"url":             "public",
 		"logging-dir":     "public",
@@ -210,7 +210,7 @@ func (s *DeployLocalSuite) TestDeployWithInvalidSpace(c *gc.C) {
 	_, err = s.State.AddSpace("internal", "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	service, err := juju.DeployApplication(s.State,
+	app, err := juju.DeployApplication(s.State,
 		juju.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           wordpressCharm,
@@ -220,8 +220,8 @@ func (s *DeployLocalSuite) TestDeployWithInvalidSpace(c *gc.C) {
 			},
 		})
 	c.Assert(err, gc.ErrorMatches, `cannot add application "bob": unknown space "intranel" not valid`)
-	c.Check(service, gc.IsNil)
-	// The service should not have been added
+	c.Check(app, gc.IsNil)
+	// The application should not have been added
 	_, err = s.State.Application("bob")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
@@ -236,7 +236,7 @@ func (s *DeployLocalSuite) TestDeployWithInvalidBinding(c *gc.C) {
 	_, err = s.State.AddSpace("internal", "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	service, err := juju.DeployApplication(s.State,
+	app, err := juju.DeployApplication(s.State,
 		juju.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           wordpressCharm,
@@ -248,8 +248,8 @@ func (s *DeployLocalSuite) TestDeployWithInvalidBinding(c *gc.C) {
 		})
 	c.Assert(err, gc.ErrorMatches,
 		`invalid binding\(s\) supplied "bd", "pubic", valid binding names are "admin-api", .* "url"`)
-	c.Check(service, gc.IsNil)
-	// The service should not have been added
+	c.Check(app, gc.IsNil)
+	// The application should not have been added
 	_, err = s.State.Application("bob")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
@@ -275,7 +275,7 @@ func (s *DeployLocalSuite) TestDeployResources(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeploySettings(c *gc.C) {
-	service, err := juju.DeployApplication(s.State,
+	app, err := juju.DeployApplication(s.State,
 		juju.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
@@ -285,7 +285,7 @@ func (s *DeployLocalSuite) TestDeploySettings(c *gc.C) {
 			},
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertSettings(c, service, charm.Settings{
+	s.assertSettings(c, app, charm.Settings{
 		"title":       "banana cupcakes",
 		"skill-level": int64(9901),
 	})
@@ -309,14 +309,14 @@ func (s *DeployLocalSuite) TestDeployConstraints(c *gc.C) {
 	err := s.State.SetModelConstraints(constraints.MustParse("mem=2G"))
 	c.Assert(err, jc.ErrorIsNil)
 	serviceCons := constraints.MustParse("cores=2")
-	service, err := juju.DeployApplication(s.State,
+	app, err := juju.DeployApplication(s.State,
 		juju.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
 			Constraints:     serviceCons,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertConstraints(c, service, serviceCons)
+	s.assertConstraints(c, app, serviceCons)
 }
 
 func (s *DeployLocalSuite) TestDeployNumUnits(c *gc.C) {
@@ -438,26 +438,26 @@ func (s *DeployLocalSuite) assertAssignedUnit(c *gc.C, u *state.Unit, mId string
 	c.Assert(machineCons, gc.DeepEquals, cons)
 }
 
-func (s *DeployLocalSuite) assertCharm(c *gc.C, service *state.Application, expect *charm.URL) {
-	curl, force := service.CharmURL()
+func (s *DeployLocalSuite) assertCharm(c *gc.C, app *state.Application, expect *charm.URL) {
+	curl, force := app.CharmURL()
 	c.Assert(curl, gc.DeepEquals, expect)
 	c.Assert(force, jc.IsFalse)
 }
 
-func (s *DeployLocalSuite) assertSettings(c *gc.C, service *state.Application, expect charm.Settings) {
-	settings, err := service.ConfigSettings()
+func (s *DeployLocalSuite) assertSettings(c *gc.C, app *state.Application, expect charm.Settings) {
+	settings, err := app.ConfigSettings()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settings, gc.DeepEquals, expect)
 }
 
-func (s *DeployLocalSuite) assertConstraints(c *gc.C, service *state.Application, expect constraints.Value) {
-	cons, err := service.Constraints()
+func (s *DeployLocalSuite) assertConstraints(c *gc.C, app *state.Application, expect constraints.Value) {
+	cons, err := app.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cons, gc.DeepEquals, expect)
 }
 
-func (s *DeployLocalSuite) assertMachines(c *gc.C, service *state.Application, expectCons constraints.Value, expectIds ...string) {
-	units, err := service.AllUnits()
+func (s *DeployLocalSuite) assertMachines(c *gc.C, app *state.Application, expectCons constraints.Value, expectIds ...string) {
+	units, err := app.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, len(expectIds))
 	// first manually tell state to assign all the units
@@ -470,7 +470,7 @@ func (s *DeployLocalSuite) assertMachines(c *gc.C, service *state.Application, e
 	}
 
 	// refresh the list of units from state
-	units, err = service.AllUnits()
+	units, err = app.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, len(expectIds))
 	unseenIds := set.NewStrings(expectIds...)

--- a/state/endpoint_bindings.go
+++ b/state/endpoint_bindings.go
@@ -261,7 +261,7 @@ func validateEndpointBindingsForCharm(st *State, bindings map[string]string, cha
 	// in bindings. In follow-up, this will be enforced by using refcounts on
 	// spaces.
 	for endpoint, space := range bindings {
-		if !endpointsNamesSet.Contains(endpoint) {
+		if endpoint != "" && !endpointsNamesSet.Contains(endpoint) {
 			return errors.NotValidf("unknown endpoint %q", endpoint)
 		}
 		if space != "" && !spacesNamesSet.Contains(space) {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1590,11 +1590,7 @@ func (s *StateSuite) TestAddServiceWithInvalidBindings(c *gc.C) {
 	}, {
 		about:         "empty endpoint bound to unknown space",
 		bindings:      map[string]string{"": "anything"},
-		expectedError: `unknown endpoint "" not valid`,
-	}, {
-		about:         "empty endpoint not bound to a space",
-		bindings:      map[string]string{"": ""},
-		expectedError: `unknown endpoint "" not valid`,
+		expectedError: `unknown space "anything" not valid`,
 	}, {
 		about:         "known endpoint bound to unknown space",
 		bindings:      map[string]string{"server": "invalid"},


### PR DESCRIPTION
## Description of change

When deploying an application, you're allowed to bind endpoints to spaces.
However, we would allow any endpoint name to be supplied, which meant that
typos would not be caught.
(https://pad.lv/1661929)

Further, when deploying an application and only supplying the default binding,
if that application did not have any relations at all, it wouldn't be put
into the preferred space. We now record the default binding request along
with the other endpoint bindings. (https://pad.lv/1654952)

## QA steps

For the first half, use a provider that supports spaces (MAAS or AWS), and try to deploy an application but supply an invalid endpoint name. For example:
```
  $ juju deploy mysql --bind NOTdb=space
```
The old Juju would silently ignore your request, the new Juju will give an error that "NOTdb" is not a valid binding.

For the second half, find a charm that doesn't have any relations (ubuntu being the canonical example), and then try to deploy it into a space. This is most obvious if you deploy into a container on a host that has multiple spaces
```
  $ juju deploy ubuntu --bind space --to lxd:0
```
The old Juju would treat it as though you supplied nothing, rather than trying to allocate a machine with access to 'space'.

## Documentation changes

This only gives errors in cases where you were using the CLI incorrectly. I'm not sure we need explicit documentation of that. It is possible that some bundles that used to deploy will start failing, because they were not doing what they thought they were doing anyway.

## Bug reference

[lp:1661929](https://pad.lv/1661929)
[lp:1654952](https://pad.lv/1654952)