### PR TITLE
Ec2 update cloud instancetypes

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -13,8 +13,12 @@ clouds:
         endpoint: https://ec2.us-west-1.amazonaws.com
       us-west-2:
         endpoint: https://ec2.us-west-2.amazonaws.com
+      ca-central-1:
+        endpoint: https://ec2.ca-central-1.amazonaws.com
       eu-west-1:
         endpoint: https://ec2.eu-west-1.amazonaws.com
+      eu-west-2:
+        endpoint: https://ec2.eu-west-2.amazonaws.com
       eu-central-1:
         endpoint: https://ec2.eu-central-1.amazonaws.com
       ap-south-1:
@@ -169,17 +173,17 @@ clouds:
     description: Joyent Cloud
     auth-types: [ userpass ]
     regions:
-      eu-ams-1: 
+      eu-ams-1:
         endpoint: https://eu-ams-1.api.joyentcloud.com
-      us-sw-1: 
+      us-sw-1:
         endpoint: https://us-sw-1.api.joyentcloud.com
-      us-east-1: 
+      us-east-1:
         endpoint: https://us-east-1.api.joyentcloud.com
-      us-east-2: 
+      us-east-2:
         endpoint: https://us-east-2.api.joyentcloud.com
-      us-east-3: 
+      us-east-3:
         endpoint: https://us-east-3.api.joyentcloud.com
-      us-west-1: 
+      us-west-1:
         endpoint: https://us-west-1.api.joyentcloud.com
   cloudsigma:
     type: cloudsigma

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -20,8 +20,12 @@ clouds:
         endpoint: https://ec2.us-west-1.amazonaws.com
       us-west-2:
         endpoint: https://ec2.us-west-2.amazonaws.com
+      ca-central-1:
+        endpoint: https://ec2.ca-central-1.amazonaws.com
       eu-west-1:
         endpoint: https://ec2.eu-west-1.amazonaws.com
+      eu-west-2:
+        endpoint: https://ec2.eu-west-2.amazonaws.com
       eu-central-1:
         endpoint: https://ec2.eu-central-1.amazonaws.com
       ap-south-1:
@@ -176,17 +180,17 @@ clouds:
     description: Joyent Cloud
     auth-types: [ userpass ]
     regions:
-      eu-ams-1: 
+      eu-ams-1:
         endpoint: https://eu-ams-1.api.joyentcloud.com
-      us-sw-1: 
+      us-sw-1:
         endpoint: https://us-sw-1.api.joyentcloud.com
-      us-east-1: 
+      us-east-1:
         endpoint: https://us-east-1.api.joyentcloud.com
-      us-east-2: 
+      us-east-2:
         endpoint: https://us-east-2.api.joyentcloud.com
-      us-east-3: 
+      us-east-3:
         endpoint: https://us-east-3.api.joyentcloud.com
-      us-west-1: 
+      us-west-1:
         endpoint: https://us-west-1.api.joyentcloud.com
   cloudsigma:
     type: cloudsigma

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -39,7 +39,9 @@ us-east-1
 us-east-2
 us-west-1
 us-west-2
+ca-central-1
 eu-west-1
+eu-west-2
 eu-central-1
 ap-south-1
 ap-southeast-1
@@ -64,8 +66,12 @@ us-west-1:
   endpoint: https://ec2.us-west-1.amazonaws.com
 us-west-2:
   endpoint: https://ec2.us-west-2.amazonaws.com
+ca-central-1:
+  endpoint: https://ec2.ca-central-1.amazonaws.com
 eu-west-1:
   endpoint: https://ec2.eu-west-1.amazonaws.com
+eu-west-2:
+  endpoint: https://ec2.eu-west-2.amazonaws.com
 eu-central-1:
   endpoint: https://ec2.eu-central-1.amazonaws.com
 ap-south-1:

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1618,7 +1618,9 @@ us-east-1
 us-east-2
 us-west-1
 us-west-2
+ca-central-1
 eu-west-1
+eu-west-2
 eu-central-1
 ap-south-1
 ap-southeast-1

--- a/provider/ec2/image_test.go
+++ b/provider/ec2/image_test.go
@@ -46,13 +46,13 @@ var findInstanceSpecTests = []struct {
 		series: "xenial",
 		arches: []string{"amd64"},
 		cons:   "cores=4",
-		itype:  "c4.xlarge",
+		itype:  "t2.xlarge",
 		image:  "ami-00000133",
 	}, {
 		series: "xenial",
 		arches: []string{"amd64"},
 		cons:   "mem=10G",
-		itype:  "r3.large",
+		itype:  "r4.large",
 		image:  "ami-00000133",
 	}, {
 		series: "xenial",

--- a/provider/ec2/internal/ec2instancetypes/generated.go
+++ b/provider/ec2/internal/ec2instancetypes/generated.go
@@ -16,8 +16,8 @@ var (
 	both        = []string{arch.AMD64, arch.I386}
 )
 
-// Version: 20161017231909
-// Publication date: 2016-10-17 23:19:09 +0000 UTC
+// Version: 20161213014831
+// Publication date: 2016-12-13 01:48:31 +0000 UTC
 //
 // This pricing list is for informational purposes only. All prices are subject to the additional terms included in the pricing pages on http://aws.amazon.com. All Free Tier prices are also subject to the terms included at https://aws.amazon.com/free/
 
@@ -35,7 +35,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20608),
 			Mem:      262144,
 			VirtType: &hvm,
-			Cost:     5563,
+			Cost:     4450,
 		},
 
 		// SKU: 4BJPFU3PAZJ4AKMM
@@ -62,7 +62,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(2688),
 			Mem:      32768,
 			VirtType: &hvm,
-			Cost:     695,
+			Cost:     556,
 		},
 
 		// SKU: 4REMK3MMXCZ55ZX3
@@ -154,7 +154,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(811),
 			Mem:      3840,
 			VirtType: &hvm,
-			Cost:     133,
+			Cost:     126,
 		},
 
 		// SKU: 7MYWT7Y96UT3NJ2D
@@ -167,7 +167,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(672),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     174,
+			Cost:     139,
 		},
 
 		// SKU: 8H36QJ2PHPR3SJ48
@@ -207,7 +207,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(10),
 			Mem:      1024,
 			VirtType: &hvm,
-			Cost:     20,
+			Cost:     16,
 		},
 
 		// SKU: AKQ89V8E78T6H534
@@ -261,7 +261,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1344),
 			Mem:      16384,
 			VirtType: &hvm,
-			Cost:     348,
+			Cost:     278,
 		},
 
 		// SKU: BYV8H4R4VJNAH42Q
@@ -326,7 +326,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(6495),
 			Mem:      30720,
 			VirtType: &hvm,
-			Cost:     1061,
+			Cost:     1008,
 		},
 
 		// SKU: E5ZC2EJP47JC4Y2A
@@ -352,7 +352,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(40),
 			Mem:      4096,
 			VirtType: &hvm,
-			Cost:     80,
+			Cost:     64,
 		},
 
 		// SKU: ERVWZ4V3UBYH4NQH
@@ -405,7 +405,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5),
 			Mem:      512,
 			VirtType: &hvm,
-			Cost:     10,
+			Cost:     8,
+		},
+
+		// SKU: FBB5W5WTFXJSNGPN
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3359),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     512,
 		},
 
 		// SKU: FBUWUPNC8FXRUS5W
@@ -498,7 +511,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(13440),
 			Mem:      163840,
 			VirtType: &hvm,
-			Cost:     3477,
+			Cost:     2782,
 		},
 
 		// SKU: KM8DYQWHEC32CGGX
@@ -564,7 +577,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(14615),
 			Mem:      61440,
 			VirtType: &hvm,
-			Cost:     2122,
+			Cost:     2016,
 		},
 
 		// SKU: PSF2TQK8WMUGUPYK
@@ -617,7 +630,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(60),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     160,
+			Cost:     128,
 		},
 
 		// SKU: Q85F79PK8VHHZT6X
@@ -630,7 +643,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(3247),
 			Mem:      15360,
 			VirtType: &hvm,
-			Cost:     531,
+			Cost:     504,
 		},
 
 		// SKU: UJB452HW969DQZFB
@@ -643,7 +656,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1623),
 			Mem:      7680,
 			VirtType: &hvm,
-			Cost:     265,
+			Cost:     252,
 		},
 
 		// SKU: UMV7384WFS5N9T5F
@@ -710,7 +723,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5376),
 			Mem:      65536,
 			VirtType: &hvm,
-			Cost:     1391,
+			Cost:     1113,
 		},
 
 		// SKU: YCYU3NQCQRYQ2TU7
@@ -763,7 +776,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20),
 			Mem:      2048,
 			VirtType: &hvm,
-			Cost:     40,
+			Cost:     32,
+		},
+
+		// SKU: ZV2DS4C98AB8SS7J
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1679),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     256,
 		},
 	},
 
@@ -818,7 +844,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(811),
 			Mem:      3840,
 			VirtType: &hvm,
-			Cost:     120,
+			Cost:     114,
 		},
 
 		// SKU: 5RC27Y2XYGFJVP7K
@@ -831,7 +857,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1344),
 			Mem:      16384,
 			VirtType: &hvm,
-			Cost:     331,
+			Cost:     265,
 		},
 
 		// SKU: 65JJWWKAHFAMNF85
@@ -870,7 +896,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5376),
 			Mem:      65536,
 			VirtType: &hvm,
-			Cost:     1321,
+			Cost:     1057,
 		},
 
 		// SKU: 6TYE4QER4XX5TSC5
@@ -935,7 +961,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(40),
 			Mem:      4096,
 			VirtType: &hvm,
-			Cost:     80,
+			Cost:     64,
 		},
 
 		// SKU: 852A82DVHUAQRBUS
@@ -974,7 +1000,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20608),
 			Mem:      262144,
 			VirtType: &hvm,
-			Cost:     5285,
+			Cost:     4228,
 		},
 
 		// SKU: 9XQJDHCZD834J68K
@@ -987,7 +1013,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(672),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     165,
+			Cost:     132,
 		},
 
 		// SKU: BHS4CH7UVYY7QN2H
@@ -1013,7 +1039,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(6495),
 			Mem:      30720,
 			VirtType: &hvm,
-			Cost:     955,
+			Cost:     907,
 		},
 
 		// SKU: BRTSXYEA84EMVTVE
@@ -1039,7 +1065,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(60),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     160,
+			Cost:     128,
 		},
 
 		// SKU: CFXCUT5A22XNZ43Y
@@ -1068,6 +1094,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     732,
 		},
 
+		// SKU: EGXGRBT8ERK49SBP
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1679),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     256,
+		},
+
 		// SKU: G6ATM6E28ZDDBNCE
 		// Instance family: Compute optimized
 		// Storage: EBS only
@@ -1078,7 +1117,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1623),
 			Mem:      7680,
 			VirtType: &hvm,
-			Cost:     239,
+			Cost:     227,
+		},
+
+		// SKU: GENEHT29PB98QFPX
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3359),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     512,
 		},
 
 		// SKU: HUNMAJP6W7UHJAAG
@@ -1091,7 +1143,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(14615),
 			Mem:      61440,
 			VirtType: &hvm,
-			Cost:     1910,
+			Cost:     1815,
 		},
 
 		// SKU: JZYQ7EEFZRRYYC5S
@@ -1143,7 +1195,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5),
 			Mem:      512,
 			VirtType: &hvm,
-			Cost:     10,
+			Cost:     8,
 		},
 
 		// SKU: KUKJATN7HCNF2UFT
@@ -1156,7 +1208,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(2688),
 			Mem:      32768,
 			VirtType: &hvm,
-			Cost:     660,
+			Cost:     528,
 		},
 
 		// SKU: KW2ZPRSC298WFJ94
@@ -1221,7 +1273,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(3247),
 			Mem:      15360,
 			VirtType: &hvm,
-			Cost:     478,
+			Cost:     454,
 		},
 
 		// SKU: PSBR72NYUMRACH7E
@@ -1234,7 +1286,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20),
 			Mem:      2048,
 			VirtType: &hvm,
-			Cost:     40,
+			Cost:     32,
 		},
 
 		// SKU: R7GFV82WRF8QTZYP
@@ -1286,7 +1338,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(13440),
 			Mem:      163840,
 			VirtType: &hvm,
-			Cost:     3303,
+			Cost:     2642,
 		},
 
 		// SKU: YG3C8Z588MN6BXGW
@@ -1312,7 +1364,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(10),
 			Mem:      1024,
 			VirtType: &hvm,
-			Cost:     20,
+			Cost:     16,
 		},
 	},
 
@@ -1331,6 +1383,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     827,
 		},
 
+		// SKU: 2M95KZBY9QJCSVWB
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(644),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     151,
+		},
+
 		// SKU: 2T64ZB6E54RM9GA2
 		// Instance family: Compute optimized
 		// Storage: EBS only
@@ -1341,7 +1406,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(14615),
 			Mem:      61440,
 			VirtType: &hvm,
-			Cost:     2195,
+			Cost:     1756,
+		},
+
+		// SKU: 37A5REAJC363YUHH
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3359),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     476,
 		},
 
 		// SKU: 3P5UPPTRJJQ6TKSU
@@ -1354,7 +1432,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(672),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     169,
+			Cost:     132,
 		},
 
 		// SKU: 5N383TJKMC5FSCKD
@@ -1380,7 +1458,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5),
 			Mem:      512,
 			VirtType: &hvm,
-			Cost:     9,
+			Cost:     7,
+		},
+
+		// SKU: 6D7VQBNGRWYB2U7T
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1288),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     303,
 		},
 
 		// SKU: 6WAFB82CP99WZXD9
@@ -1393,7 +1484,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20),
 			Mem:      2048,
 			VirtType: &hvm,
-			Cost:     38,
+			Cost:     30,
+		},
+
+		// SKU: 7DZBY6C9YNNVET76
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5152),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     1212,
 		},
 
 		// SKU: 7HYM8MHNNFW2NN6T
@@ -1419,7 +1523,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(3247),
 			Mem:      15360,
 			VirtType: &hvm,
-			Cost:     549,
+			Cost:     439,
 		},
 
 		// SKU: 8U4NEK2635VB7NHD
@@ -1445,7 +1549,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1344),
 			Mem:      16384,
 			VirtType: &hvm,
-			Cost:     337,
+			Cost:     263,
 		},
 
 		// SKU: AFU2HU8WVY9T6QAK
@@ -1459,6 +1563,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Mem:      62464,
 			VirtType: &hvm,
 			Cost:     1933,
+		},
+
+		// SKU: BKC93YZQB5XG785E
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.16xlarge",
+			Arches:   amd64,
+			CpuCores: 64,
+			CpuPower: instances.CpuPower(20608),
+			Mem:      499712,
+			VirtType: &hvm,
+			Cost:     4851,
 		},
 
 		// SKU: CA3Y8U6BUYR54NVM
@@ -1497,7 +1614,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20608),
 			Mem:      262144,
 			VirtType: &hvm,
-			Cost:     5400,
+			Cost:     4212,
 		},
 
 		// SKU: FQ7FVC9B3R8RBBXA
@@ -1510,7 +1627,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(13440),
 			Mem:      163840,
 			VirtType: &hvm,
-			Cost:     3375,
+			Cost:     2633,
 		},
 
 		// SKU: G4283CPK5MQ5QQ2A
@@ -1549,7 +1666,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(60),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     152,
+			Cost:     119,
 		},
 
 		// SKU: GGTGBU32M4STN8YS
@@ -1565,6 +1682,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     1653,
 		},
 
+		// SKU: GNRA9A27Y4WHA4EE
+		// Instance family: Memory optimized
+		// Storage: 2 x 1,920
+		{
+			Name:     "x1.32xlarge",
+			Arches:   amd64,
+			CpuCores: 128,
+			CpuPower: instances.CpuPower(41216),
+			Mem:      1998848,
+			VirtType: &hvm,
+			Cost:     18374,
+		},
+
 		// SKU: JXAMSKC2ZXKCA37S
 		// Instance family: General purpose
 		// Storage: EBS only
@@ -1575,7 +1705,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(10),
 			Mem:      1024,
 			VirtType: &hvm,
-			Cost:     19,
+			Cost:     15,
+		},
+
+		// SKU: K2V83HS47FBDSX5J
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2576),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     606,
 		},
 
 		// SKU: KFTR5EQCGQ6AUYXP
@@ -1588,7 +1731,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(811),
 			Mem:      3840,
 			VirtType: &hvm,
-			Cost:     137,
+			Cost:     110,
+		},
+
+		// SKU: KKF4PXVB9Z3ANP6K
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1679),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     238,
 		},
 
 		// SKU: MKNAAVQMBXXNTPQQ
@@ -1627,7 +1783,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(40),
 			Mem:      4096,
 			VirtType: &hvm,
-			Cost:     76,
+			Cost:     59,
 		},
 
 		// SKU: TEV889FX73ZKZ8TU
@@ -1640,7 +1796,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(6495),
 			Mem:      30720,
 			VirtType: &hvm,
-			Cost:     1097,
+			Cost:     878,
 		},
 
 		// SKU: TPTBS44NNEJN3HUG
@@ -1666,7 +1822,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1623),
 			Mem:      7680,
 			VirtType: &hvm,
-			Cost:     275,
+			Cost:     220,
+		},
+
+		// SKU: X3V37E29WMEDZZ96
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(10304),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     2425,
 		},
 
 		// SKU: YKUFHRZDYCT9JG3A
@@ -1679,7 +1848,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5376),
 			Mem:      65536,
 			VirtType: &hvm,
-			Cost:     1350,
+			Cost:     1053,
 		},
 
 		// SKU: ZEEU583UYCZMVJZV
@@ -1705,7 +1874,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(2688),
 			Mem:      32768,
 			VirtType: &hvm,
-			Cost:     675,
+			Cost:     527,
 		},
 	},
 
@@ -1723,6 +1892,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			VirtType:   &paravirtual,
 			Cost:       233,
 			Deprecated: true,
+		},
+
+		// SKU: 2S29GABT3GMS28E4
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3359),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     480,
 		},
 
 		// SKU: 39ZR86RYWKDSK82K
@@ -1749,7 +1931,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(6495),
 			Mem:      30720,
 			VirtType: &hvm,
-			Cost:     1155,
+			Cost:     924,
 		},
 
 		// SKU: 57M4AZ4NRYTPT6NM
@@ -1775,7 +1957,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5376),
 			Mem:      65536,
 			VirtType: &hvm,
-			Cost:     1421,
+			Cost:     1066,
 		},
 
 		// SKU: 6R4QVUNHTJVS9J2S
@@ -1816,7 +1998,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20),
 			Mem:      2048,
 			VirtType: &hvm,
-			Cost:     40,
+			Cost:     30,
 		},
 
 		// SKU: 7TMGTEJPM5UPWQ8X
@@ -1856,7 +2038,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20608),
 			Mem:      262144,
 			VirtType: &hvm,
-			Cost:     5685,
+			Cost:     4264,
 		},
 
 		// SKU: 8V5MYBMPUD434579
@@ -1909,7 +2091,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(13440),
 			Mem:      163840,
 			VirtType: &hvm,
-			Cost:     3553,
+			Cost:     2665,
 		},
 
 		// SKU: B9DFHMNNN499Z259
@@ -1922,7 +2104,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(672),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     178,
+			Cost:     134,
 		},
 
 		// SKU: DK6FJW8STXUGW6PA
@@ -2040,7 +2222,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(40),
 			Mem:      4096,
 			VirtType: &hvm,
-			Cost:     80,
+			Cost:     60,
 		},
 
 		// SKU: J65Z38YCBYKP7Q49
@@ -2067,6 +2249,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Mem:      249856,
 			VirtType: &hvm,
 			Cost:     3192,
+		},
+
+		// SKU: K69TGQ7NEKQKXKHH
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1679),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     240,
 		},
 
 		// SKU: KCZD349CGXR5DRQ3
@@ -2105,7 +2300,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1344),
 			Mem:      16384,
 			VirtType: &hvm,
-			Cost:     355,
+			Cost:     266,
 		},
 
 		// SKU: P6BPTANASQKJ8FJX
@@ -2144,7 +2339,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(811),
 			Mem:      3840,
 			VirtType: &hvm,
-			Cost:     144,
+			Cost:     115,
 		},
 
 		// SKU: R8K75VHRAADAJJ2W
@@ -2170,7 +2365,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(10),
 			Mem:      1024,
 			VirtType: &hvm,
-			Cost:     20,
+			Cost:     15,
 		},
 
 		// SKU: SKTEJ2QN2YW8UFKF
@@ -2209,7 +2404,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5),
 			Mem:      512,
 			VirtType: &hvm,
-			Cost:     10,
+			Cost:     7,
 		},
 
 		// SKU: TYGKARPH33A4B8DT
@@ -2236,7 +2431,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1623),
 			Mem:      7680,
 			VirtType: &hvm,
-			Cost:     289,
+			Cost:     231,
 		},
 
 		// SKU: UKF69K7GTUQKKRPH
@@ -2249,7 +2444,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(2688),
 			Mem:      32768,
 			VirtType: &hvm,
-			Cost:     711,
+			Cost:     533,
 		},
 
 		// SKU: UKGPAABCGR48DYC4
@@ -2262,7 +2457,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(3247),
 			Mem:      15360,
 			VirtType: &hvm,
-			Cost:     578,
+			Cost:     462,
 		},
 
 		// SKU: UKY8RWKR7MVYC863
@@ -2288,7 +2483,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(60),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     160,
+			Cost:     120,
 		},
 
 		// SKU: VE5MWWHUXS2VR8DV
@@ -2381,7 +2576,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(14615),
 			Mem:      61440,
 			VirtType: &hvm,
-			Cost:     2310,
+			Cost:     1848,
 		},
 
 		// SKU: ZAGTVD3ADUUPS6QV
@@ -2423,7 +2618,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(2688),
 			Mem:      32768,
 			VirtType: &hvm,
-			Cost:     673,
+			Cost:     538,
 		},
 
 		// SKU: 2PKSXUFC38ZY888Q
@@ -2436,7 +2631,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(811),
 			Mem:      3840,
 			VirtType: &hvm,
-			Cost:     137,
+			Cost:     130,
 		},
 
 		// SKU: 46ZVWU6WX68NZCE7
@@ -2449,7 +2644,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(14615),
 			Mem:      61440,
 			VirtType: &hvm,
-			Cost:     2195,
+			Cost:     2085,
 		},
 
 		// SKU: 4PRF9CZZBT3AM9D4
@@ -2556,7 +2751,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(672),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     168,
+			Cost:     134,
 		},
 
 		// SKU: 6WEMUEK6JNZU6PTC
@@ -2595,7 +2790,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(10),
 			Mem:      1024,
 			VirtType: &hvm,
-			Cost:     20,
+			Cost:     16,
 		},
 
 		// SKU: 8A5X9KQR4YKYYXCQ
@@ -2638,6 +2833,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     20,
 		},
 
+		// SKU: BE5KJ8JQRJNSND64
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1288),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     319,
+		},
+
 		// SKU: C4A5RM72TUGX8R5D
 		// Instance family: General purpose
 		// Storage: EBS only
@@ -2648,7 +2856,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5376),
 			Mem:      65536,
 			VirtType: &hvm,
-			Cost:     1345,
+			Cost:     1076,
 		},
 
 		// SKU: CMDB58FT3PAJJNGN
@@ -2678,6 +2886,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     1740,
 		},
 
+		// SKU: CW6MMQ5PUWH2ER9P
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1679),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     256,
+		},
+
 		// SKU: D29U26UAEX6WK4TW
 		// Instance family: General purpose
 		// Storage: 2 x 80 SSD
@@ -2704,6 +2925,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     1596,
 		},
 
+		// SKU: DF9ZTHT5UAFTDNCY
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.16xlarge",
+			Arches:   amd64,
+			CpuCores: 64,
+			CpuPower: instances.CpuPower(20608),
+			Mem:      499712,
+			VirtType: &hvm,
+			Cost:     5107,
+		},
+
 		// SKU: DS7EYGXHAG6T6NTV
 		// Instance family: GPU instance
 		// Storage: 1 x 60 SSD
@@ -2727,7 +2961,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20),
 			Mem:      2048,
 			VirtType: &hvm,
-			Cost:     40,
+			Cost:     32,
+		},
+
+		// SKU: EAVTTHNUHS2CF6PH
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(644),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     159,
 		},
 
 		// SKU: F9BAR5QA2VU3ZTBF
@@ -2740,7 +2987,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(6495),
 			Mem:      30720,
 			VirtType: &hvm,
-			Cost:     1097,
+			Cost:     1042,
 		},
 
 		// SKU: FFBDA7VFHVPEJXS6
@@ -2753,7 +3000,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(3247),
 			Mem:      15360,
 			VirtType: &hvm,
-			Cost:     549,
+			Cost:     522,
 		},
 
 		// SKU: FJURXZQ9HT9HN2YJ
@@ -2821,6 +3068,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     186,
 		},
 
+		// SKU: HP48BUB3CX5F259P
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5152),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     1276,
+		},
+
 		// SKU: JT2PVSWTGS2BMV4D
 		// Instance family: General purpose
 		// Storage: EBS only
@@ -2831,7 +3091,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(60),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     160,
+			Cost:     128,
 		},
 
 		// SKU: KEVDJ9YEEGJZZGDS
@@ -2884,7 +3144,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5),
 			Mem:      512,
 			VirtType: &hvm,
-			Cost:     10,
+			Cost:     8,
 		},
 
 		// SKU: MSGAHYMZTGGJN5WS
@@ -2936,7 +3196,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20608),
 			Mem:      262144,
 			VirtType: &hvm,
-			Cost:     5381,
+			Cost:     4305,
+		},
+
+		// SKU: P8EEBTBGBRJ8NMV2
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(10304),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     2553,
 		},
 
 		// SKU: R8KMJWXSQ8BJC35M
@@ -2962,7 +3235,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1344),
 			Mem:      16384,
 			VirtType: &hvm,
-			Cost:     336,
+			Cost:     269,
+		},
+
+		// SKU: RGHP93AGXPHPNNV7
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3359),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     512,
 		},
 
 		// SKU: RW8353QQ8DWZ4WQD
@@ -2978,6 +3264,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     8140,
 		},
 
+		// SKU: RZV2TACP5YK7YCW9
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2576),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     638,
+		},
+
 		// SKU: SPJKFAB8G379JD6R
 		// Instance family: General purpose
 		// Storage: EBS only
@@ -2988,7 +3287,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(13440),
 			Mem:      163840,
 			VirtType: &hvm,
-			Cost:     3363,
+			Cost:     2690,
 		},
 
 		// SKU: T72BQ8E4ETD9K62R
@@ -3083,7 +3382,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1623),
 			Mem:      7680,
 			VirtType: &hvm,
-			Cost:     275,
+			Cost:     261,
 		},
 
 		// SKU: XPAKDV3PWHYTJU3X
@@ -3109,7 +3408,322 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(40),
 			Mem:      4096,
 			VirtType: &hvm,
-			Cost:     80,
+			Cost:     64,
+		},
+	},
+
+	"ca-central-1": {
+
+		// SKU: 5JBYKNTWNAS9ZFFH
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(672),
+			Mem:      8192,
+			VirtType: &hvm,
+			Cost:     119,
+		},
+
+		// SKU: 84RRJJ2JMNHAAFG7
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.small",
+			Arches:   both,
+			CpuCores: 1,
+			CpuPower: instances.CpuPower(20),
+			Mem:      2048,
+			VirtType: &hvm,
+			Cost:     26,
+		},
+
+		// SKU: 9NA2WFEXZ7RDCYF8
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(60),
+			Mem:      8192,
+			VirtType: &hvm,
+			Cost:     103,
+		},
+
+		// SKU: 9ZFAT4J9YK6N24CW
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.16xlarge",
+			Arches:   amd64,
+			CpuCores: 64,
+			CpuPower: instances.CpuPower(20608),
+			Mem:      262144,
+			VirtType: &hvm,
+			Cost:     3792,
+		},
+
+		// SKU: BW9U468HE4KTGB39
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(811),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     110,
+		},
+
+		// SKU: BYPN3A92GMZ82584
+		// Instance family: Storage optimized
+		// Storage: 3 x 2000 HDD
+		{
+			Name:     "d2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     759,
+		},
+
+		// SKU: EFZ2NGQZ9PYWX896
+		// Instance family: Memory optimized
+		// Storage: 1 x 1,920
+		{
+			Name:     "x1.16xlarge",
+			Arches:   amd64,
+			CpuCores: 64,
+			CpuPower: instances.CpuPower(20608),
+			Mem:      999424,
+			VirtType: &hvm,
+			Cost:     7336,
+		},
+
+		// SKU: G4EGYKSK3QKJSHJP
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      65536,
+			VirtType: &hvm,
+			Cost:     948,
+		},
+
+		// SKU: J3CJJMBJ2AX72YT3
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     474,
+		},
+
+		// SKU: J3RMSBG9SUXE4S3F
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1679),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     206,
+		},
+
+		// SKU: KGBDPESEGF4BNTCQ
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3247),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     438,
+		},
+
+		// SKU: MBENAB2KVWCPAE53
+		// Instance family: Memory optimized
+		// Storage: 2 x 1,920
+		{
+			Name:     "x1.32xlarge",
+			Arches:   amd64,
+			CpuCores: 128,
+			CpuPower: instances.CpuPower(41216),
+			Mem:      1998848,
+			VirtType: &hvm,
+			Cost:     14672,
+		},
+
+		// SKU: P66QF9GGMTFWWDQX
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3359),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     412,
+		},
+
+		// SKU: P8A5UFF56BKMYN69
+		// Instance family: Storage optimized
+		// Storage: 12 x 2000 HDD
+		{
+			Name:     "d2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     3036,
+		},
+
+		// SKU: P9XM8363KCGASTC8
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(14615),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     1750,
+		},
+
+		// SKU: U34MCPN3J72T9YXY
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6495),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     876,
+		},
+
+		// SKU: UJXSQ2MTGJKEV6TD
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.micro",
+			Arches:   both,
+			CpuCores: 1,
+			CpuPower: instances.CpuPower(10),
+			Mem:      1024,
+			VirtType: &hvm,
+			Cost:     13,
+		},
+
+		// SKU: WY8WPYMC5S9KSCER
+		// Instance family: Storage optimized
+		// Storage: 24 x 2000 HDD
+		{
+			Name:     "d2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(12096),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     6072,
+		},
+
+		// SKU: X7FY37JNWXMQ8UMX
+		// Instance family: Storage optimized
+		// Storage: 6 x 2000 HDD
+		{
+			Name:     "d2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     1518,
+		},
+
+		// SKU: X92PHPFX577KYX8G
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.medium",
+			Arches:   both,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(40),
+			Mem:      4096,
+			VirtType: &hvm,
+			Cost:     52,
+		},
+
+		// SKU: XD8VQS9QGTEDMXNX
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.nano",
+			Arches:   both,
+			CpuCores: 1,
+			CpuPower: instances.CpuPower(5),
+			Mem:      512,
+			VirtType: &hvm,
+			Cost:     6,
+		},
+
+		// SKU: XMFRN98P8QA898V3
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.10xlarge",
+			Arches:   amd64,
+			CpuCores: 40,
+			CpuPower: instances.CpuPower(13440),
+			Mem:      163840,
+			VirtType: &hvm,
+			Cost:     2370,
+		},
+
+		// SKU: YJ9F4B5UJ4AXRTD5
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1623),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     218,
+		},
+
+		// SKU: Z5526AK4R9W2MEQZ
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     237,
 		},
 	},
 
@@ -3164,7 +3778,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(40),
 			Mem:      4096,
 			VirtType: &hvm,
-			Cost:     60,
+			Cost:     54,
 		},
 
 		// SKU: 5RNA3KEVYJW8UJWT
@@ -3193,6 +3807,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     315,
 		},
 
+		// SKU: 64YPSFUXJJK7NNXR
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5152),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     1280,
+		},
+
 		// SKU: 686NEEYZAPY5GJ8N
 		// Instance family: Compute optimized
 		// Storage: 2 x 16 SSD
@@ -3216,7 +3843,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5),
 			Mem:      512,
 			VirtType: &hvm,
-			Cost:     7,
+			Cost:     6,
 		},
 
 		// SKU: 6Y959B8MKQZ55MGT
@@ -3230,6 +3857,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Mem:      62464,
 			VirtType: &hvm,
 			Cost:     1588,
+		},
+
+		// SKU: 7EFZWDA5CSAB85BF
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3359),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     432,
 		},
 
 		// SKU: 7EJH5CWEXABPY2ST
@@ -3255,7 +3895,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(60),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     120,
+			Cost:     108,
 		},
 
 		// SKU: 8KTQAHWA58GUHDGC
@@ -3284,6 +3924,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     9337,
 		},
 
+		// SKU: 9VD98SS8PD636SQE
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.16xlarge",
+			Arches:   amd64,
+			CpuCores: 64,
+			CpuPower: instances.CpuPower(20608),
+			Mem:      499712,
+			VirtType: &hvm,
+			Cost:     5121,
+		},
+
 		// SKU: ABFDCPB959KUGRH8
 		// Instance family: General purpose
 		// Storage: EBS only
@@ -3294,7 +3947,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(672),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     143,
+			Cost:     129,
 		},
 
 		// SKU: ATHMXFEBFCM8TPWK
@@ -3307,7 +3960,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(6495),
 			Mem:      30720,
 			VirtType: &hvm,
-			Cost:     1069,
+			Cost:     909,
+		},
+
+		// SKU: AV7PMZU7MYQGTH9R
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1288),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     320,
 		},
 
 		// SKU: C2EDZ5DQN8NMN54X
@@ -3333,7 +3999,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(2688),
 			Mem:      32768,
 			VirtType: &hvm,
-			Cost:     570,
+			Cost:     513,
 		},
 
 		// SKU: CNP4PV4Y2J8YZVAR
@@ -3359,7 +4025,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20),
 			Mem:      2048,
 			VirtType: &hvm,
-			Cost:     30,
+			Cost:     27,
 		},
 
 		// SKU: D8BFUEFHTHMN4XUY
@@ -3372,7 +4038,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(14615),
 			Mem:      61440,
 			VirtType: &hvm,
-			Cost:     2138,
+			Cost:     1817,
 		},
 
 		// SKU: EF7GKFKJ3Y5DM7E9
@@ -3385,7 +4051,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1344),
 			Mem:      16384,
 			VirtType: &hvm,
-			Cost:     285,
+			Cost:     257,
 		},
 
 		// SKU: ER456JE239VN5TQY
@@ -3489,7 +4155,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5376),
 			Mem:      65536,
 			VirtType: &hvm,
-			Cost:     1140,
+			Cost:     1026,
 		},
 
 		// SKU: KYFX85FCPCCT57BD
@@ -3567,7 +4233,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(3247),
 			Mem:      15360,
 			VirtType: &hvm,
-			Cost:     534,
+			Cost:     454,
 		},
 
 		// SKU: Q5D9K2QEBW7SS9YP
@@ -3583,6 +4249,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     3088,
 		},
 
+		// SKU: Q6FFSFPJYR84UFKC
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1679),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     216,
+		},
+
 		// SKU: QJ82YTRR8GFNUS8T
 		// Instance family: General purpose
 		// Storage: EBS only
@@ -3593,7 +4272,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20608),
 			Mem:      262144,
 			VirtType: &hvm,
-			Cost:     4560,
+			Cost:     4104,
 		},
 
 		// SKU: SMTUMBHX6YKRBJQB
@@ -3619,7 +4298,46 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(10),
 			Mem:      1024,
 			VirtType: &hvm,
-			Cost:     15,
+			Cost:     14,
+		},
+
+		// SKU: UJ8XNWZDKF9GB6T3
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(10304),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     2560,
+		},
+
+		// SKU: URK82PJ9UJBYTTBJ
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2576),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     640,
+		},
+
+		// SKU: VEJEX5ZH8XF6E4JG
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(644),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     160,
 		},
 
 		// SKU: WWTVB5GY85P5FGNW
@@ -3632,7 +4350,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(811),
 			Mem:      3840,
 			VirtType: &hvm,
-			Cost:     134,
+			Cost:     114,
 		},
 
 		// SKU: XWVCP8TVZ3EZXHJT
@@ -3645,7 +4363,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(13440),
 			Mem:      163840,
 			VirtType: &hvm,
-			Cost:     2850,
+			Cost:     2565,
 		},
 
 		// SKU: ZAC36C46HPYXADA7
@@ -3658,7 +4376,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1623),
 			Mem:      7680,
 			VirtType: &hvm,
-			Cost:     267,
+			Cost:     227,
 		},
 	},
 
@@ -3726,7 +4444,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(60),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     112,
+			Cost:     101,
+		},
+
+		// SKU: 4JKQTWY5J6VJ6ESF
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2576),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     592,
 		},
 
 		// SKU: 6FU9JEK79WWSARQ9
@@ -3739,7 +4470,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1344),
 			Mem:      16384,
 			VirtType: &hvm,
-			Cost:     264,
+			Cost:     238,
 		},
 
 		// SKU: 6HX9NKE3BQ5V3PMJ
@@ -3765,7 +4496,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(672),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     132,
+			Cost:     119,
 		},
 
 		// SKU: 8FFUWN2ESZYSB84N
@@ -3778,7 +4509,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(2688),
 			Mem:      32768,
 			VirtType: &hvm,
-			Cost:     528,
+			Cost:     475,
 		},
 
 		// SKU: 926EPQHVQ6AGDX5P
@@ -3844,7 +4575,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(6495),
 			Mem:      30720,
 			VirtType: &hvm,
-			Cost:     953,
+			Cost:     905,
+		},
+
+		// SKU: BKDVXZQADJ4PDJHJ
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3359),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     404,
 		},
 
 		// SKU: BNSCBCWPZHWPDKKS
@@ -3857,7 +4601,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5376),
 			Mem:      65536,
 			VirtType: &hvm,
-			Cost:     1056,
+			Cost:     950,
 		},
 
 		// SKU: C3M6ZGSU66GC75NF
@@ -3871,6 +4615,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Mem:      15616,
 			VirtType: &hvm,
 			Cost:     185,
+		},
+
+		// SKU: C65HY6EVYSPTGWDH
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1288),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     296,
 		},
 
 		// SKU: CP6AQ5U62SXMQV9P
@@ -3910,6 +4667,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Mem:      62464,
 			VirtType: &hvm,
 			Cost:     1876,
+		},
+
+		// SKU: E3P4TVHCARM5N5RM
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.16xlarge",
+			Arches:   amd64,
+			CpuCores: 64,
+			CpuPower: instances.CpuPower(20608),
+			Mem:      499712,
+			VirtType: &hvm,
+			Cost:     4742,
 		},
 
 		// SKU: E9FTXSZ49KS3R3HY
@@ -4003,7 +4773,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(40),
 			Mem:      4096,
 			VirtType: &hvm,
-			Cost:     56,
+			Cost:     50,
 		},
 
 		// SKU: HG3TP7M3FQZ54HKR
@@ -4031,6 +4801,32 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Mem:      7680,
 			VirtType: &hvm,
 			Cost:     146,
+		},
+
+		// SKU: JYFU75N5Q79WYWZE
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1679),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     202,
+		},
+
+		// SKU: K24DCJ9F92C7KWQV
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(10304),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     2371,
 		},
 
 		// SKU: KKQD5EPCF8JFUDDA
@@ -4069,7 +4865,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20),
 			Mem:      2048,
 			VirtType: &hvm,
-			Cost:     28,
+			Cost:     25,
 		},
 
 		// SKU: NSCRWEDQZZESFDFG
@@ -4149,7 +4945,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(13440),
 			Mem:      163840,
 			VirtType: &hvm,
-			Cost:     2641,
+			Cost:     2377,
 		},
 
 		// SKU: PR4SS7VH54V5XAZZ
@@ -4228,7 +5024,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20608),
 			Mem:      262144,
 			VirtType: &hvm,
-			Cost:     4226,
+			Cost:     3803,
 		},
 
 		// SKU: SDFJSCXXJEFDV7P2
@@ -4241,7 +5037,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5),
 			Mem:      512,
 			VirtType: &hvm,
-			Cost:     7,
+			Cost:     6,
 		},
 
 		// SKU: STTHYT3WDDQU8UBR
@@ -4254,7 +5050,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(10),
 			Mem:      1024,
 			VirtType: &hvm,
-			Cost:     14,
+			Cost:     13,
 		},
 
 		// SKU: SZGY4A8U8CBJGHRV
@@ -4321,7 +5117,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(3247),
 			Mem:      15360,
 			VirtType: &hvm,
-			Cost:     477,
+			Cost:     453,
 		},
 
 		// SKU: V4Q928Z7YAM3TJ6X
@@ -4334,7 +5130,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1623),
 			Mem:      7680,
 			VirtType: &hvm,
-			Cost:     238,
+			Cost:     226,
+		},
+
+		// SKU: VAUARUU95QRV96BX
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(644),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     148,
 		},
 
 		// SKU: VM3SRW97DB2T2U8Z
@@ -4400,7 +5209,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(811),
 			Mem:      3840,
 			VirtType: &hvm,
-			Cost:     119,
+			Cost:     113,
 		},
 
 		// SKU: YC9UG3ESW33SS2WK
@@ -4427,7 +5236,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(14615),
 			Mem:      61440,
 			VirtType: &hvm,
-			Cost:     1906,
+			Cost:     1811,
 		},
 
 		// SKU: YT7Q7XWV392U2M45
@@ -4456,11 +5265,323 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:       3100,
 			Deprecated: true,
 		},
+
+		// SKU: ZYJKKZNWFYWQDMCW
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5152),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     1185,
+		},
 	},
 
-	"sa-east-1": {
+	"eu-west-2": {
 
-		// SKU: 2DQW6R4PKSZDG2T6
+		// SKU: 2X6UN3SCD9TM673F
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1623),
+			Mem:      7680,
+			VirtType: &hvm,
+			Cost:     237,
+		},
+
+		// SKU: 3T2RCRCGD3A5FJVS
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(6495),
+			Mem:      30720,
+			VirtType: &hvm,
+			Cost:     950,
+		},
+
+		// SKU: 4CH6QCAN52UJ2AW2
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      65536,
+			VirtType: &hvm,
+			Cost:     998,
+		},
+
+		// SKU: 6EUVB38T7YB7GF9S
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(672),
+			Mem:      8192,
+			VirtType: &hvm,
+			Cost:     125,
+		},
+
+		// SKU: 92TGCNQTRRAJJAS7
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(60),
+			Mem:      8192,
+			VirtType: &hvm,
+			Cost:     106,
+		},
+
+		// SKU: 9NVRASEGRRTWVG7A
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(811),
+			Mem:      3840,
+			VirtType: &hvm,
+			Cost:     119,
+		},
+
+		// SKU: B5GZYSM5938VWDYM
+		// Instance family: Storage optimized
+		// Storage: 3 x 2000 HDD
+		{
+			Name:     "d2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     772,
+		},
+
+		// SKU: CERBK7JEFDU3SV3B
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3247),
+			Mem:      15360,
+			VirtType: &hvm,
+			Cost:     476,
+		},
+
+		// SKU: CFJ5RE2H7KHV9HK9
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.nano",
+			Arches:   both,
+			CpuCores: 1,
+			CpuPower: instances.CpuPower(5),
+			Mem:      512,
+			VirtType: &hvm,
+			Cost:     6,
+		},
+
+		// SKU: GRFBXV37KF9VYJRF
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1344),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     250,
+		},
+
+		// SKU: HDQ9VZCETFEMF7CB
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.micro",
+			Arches:   both,
+			CpuCores: 1,
+			CpuPower: instances.CpuPower(10),
+			Mem:      1024,
+			VirtType: &hvm,
+			Cost:     14,
+		},
+
+		// SKU: HEF8FVEMCGG7JDZ4
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.16xlarge",
+			Arches:   amd64,
+			CpuCores: 64,
+			CpuPower: instances.CpuPower(20608),
+			Mem:      262144,
+			VirtType: &hvm,
+			Cost:     3993,
+		},
+
+		// SKU: JZWW5SBQZVBCV8AJ
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3359),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     424,
+		},
+
+		// SKU: KGHEQT4SACPTYQNB
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.medium",
+			Arches:   both,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(40),
+			Mem:      4096,
+			VirtType: &hvm,
+			Cost:     52,
+		},
+
+		// SKU: KZ3QWPFNPPDUDYW7
+		// Instance family: Storage optimized
+		// Storage: 24 x 2000 HDD
+		{
+			Name:     "d2.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(12096),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     6174,
+		},
+
+		// SKU: PAESNTWTS8RUGKY6
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1679),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     212,
+		},
+
+		// SKU: QE4YJQ9HUCYB3CA9
+		// Instance family: Storage optimized
+		// Storage: 12 x 2000 HDD
+		{
+			Name:     "d2.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5376),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     3087,
+		},
+
+		// SKU: QUSZR9Z7BVE8CD5Y
+		// Instance family: Compute optimized
+		// Storage: EBS only
+		{
+			Name:     "c4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 36,
+			CpuPower: instances.CpuPower(14615),
+			Mem:      61440,
+			VirtType: &hvm,
+			Cost:     1902,
+		},
+
+		// SKU: QX3BAPSZJEUCA9FJ
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     499,
+		},
+
+		// SKU: TK9JKUTPVAPNT9BR
+		// Instance family: Storage optimized
+		// Storage: 6 x 2000 HDD
+		{
+			Name:     "d2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2688),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     1544,
+		},
+
+		// SKU: UVNK5GZCP7NWANZR
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.10xlarge",
+			Arches:   amd64,
+			CpuCores: 40,
+			CpuPower: instances.CpuPower(13440),
+			Mem:      163840,
+			VirtType: &hvm,
+			Cost:     2496,
+		},
+
+		// SKU: VN4E7YXFSEGMW9H7
+		// Instance family: Memory optimized
+		// Storage: 1 x 1,920
+		{
+			Name:     "x1.16xlarge",
+			Arches:   amd64,
+			CpuCores: 64,
+			CpuPower: instances.CpuPower(20608),
+			Mem:      999424,
+			VirtType: &hvm,
+			Cost:     8403,
+		},
+
+		// SKU: XQ8FKG65FR9Z4ZPR
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.small",
+			Arches:   both,
+			CpuCores: 1,
+			CpuPower: instances.CpuPower(20),
+			Mem:      2048,
+			VirtType: &hvm,
+			Cost:     26,
+		},
+
+		// SKU: Y6DK4ETN32KZE2ZQ
 		// Instance family: Memory optimized
 		// Storage: 2 x 1,920
 		{
@@ -4470,8 +5591,11 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(41216),
 			Mem:      1998848,
 			VirtType: &hvm,
-			Cost:     26010,
+			Cost:     16806,
 		},
+	},
+
+	"sa-east-1": {
 
 		// SKU: 38R4NKAE2QECWRDD
 		// Instance family: General purpose
@@ -4496,7 +5620,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(60),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     216,
+			Cost:     162,
 		},
 
 		// SKU: 4KCYN288G4U4BEAG
@@ -4509,7 +5633,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(14615),
 			Mem:      61440,
 			VirtType: &hvm,
-			Cost:     2600,
+			Cost:     2470,
 		},
 
 		// SKU: 5GTG8UXYNCRDW5C4
@@ -4522,7 +5646,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(811),
 			Mem:      3840,
 			VirtType: &hvm,
-			Cost:     163,
+			Cost:     155,
 		},
 
 		// SKU: 5V3T67JXMGR4TH34
@@ -4548,7 +5672,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1623),
 			Mem:      7680,
 			VirtType: &hvm,
-			Cost:     325,
+			Cost:     309,
 		},
 
 		// SKU: 6TN6BMN8S44CMRDW
@@ -4589,7 +5713,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5),
 			Mem:      512,
 			VirtType: &hvm,
-			Cost:     13,
+			Cost:     10,
+		},
+
+		// SKU: 7JK3Y822S2U92G49
+		// Instance family: Memory optimized
+		// Storage: 1 x 160 SSD
+		{
+			Name:     "r3.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2800),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     1399,
 		},
 
 		// SKU: 84JB45JJDJXM67K4
@@ -4602,7 +5739,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20),
 			Mem:      2048,
 			VirtType: &hvm,
-			Cost:     54,
+			Cost:     41,
 		},
 
 		// SKU: 8VWG8TTVN5G378AH
@@ -4630,6 +5767,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Mem:      16384,
 			VirtType: &hvm,
 			Cost:     343,
+		},
+
+		// SKU: ABEXP4ERUWNM6W8J
+		// Instance family: Memory optimized
+		// Storage: 1 x 80 SSD
+		{
+			Name:     "r3.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1400),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     700,
 		},
 
 		// SKU: ADMZJH7G4TK3XW72
@@ -4751,19 +5901,6 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Deprecated: true,
 		},
 
-		// SKU: F3B7MENDPCX44NH3
-		// Instance family: Memory optimized
-		// Storage: 1 x 1,920
-		{
-			Name:     "x1.16xlarge",
-			Arches:   amd64,
-			CpuCores: 64,
-			CpuPower: instances.CpuPower(20608),
-			Mem:      999424,
-			VirtType: &hvm,
-			Cost:     13005,
-		},
-
 		// SKU: FDUDDQXMYRBXXPU6
 		// Instance family: General purpose
 		// Storage: 2 x 40 SSD
@@ -4828,7 +5965,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(10),
 			Mem:      1024,
 			VirtType: &hvm,
-			Cost:     27,
+			Cost:     20,
 		},
 
 		// SKU: M6GCPQTQDNQK5XUW
@@ -4856,6 +5993,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Mem:      628,
 			VirtType: &paravirtual,
 			Cost:     27,
+		},
+
+		// SKU: NXAU2M3KSE5AEQT5
+		// Instance family: Memory optimized
+		// Storage: 1 x 32 SSD
+		{
+			Name:     "r3.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(700),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     350,
 		},
 
 		// SKU: PDY52X9T9DZY9CT5
@@ -4908,7 +6058,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(40),
 			Mem:      4096,
 			VirtType: &hvm,
-			Cost:     108,
+			Cost:     81,
 		},
 
 		// SKU: VZ7SHPDE4QVD6EJ6
@@ -4934,7 +6084,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(6495),
 			Mem:      30720,
 			VirtType: &hvm,
-			Cost:     1300,
+			Cost:     1235,
 		},
 
 		// SKU: W8DSYP8X87Q34DGY
@@ -4947,7 +6097,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(3247),
 			Mem:      15360,
 			VirtType: &hvm,
-			Cost:     650,
+			Cost:     618,
 		},
 
 		// SKU: WCYXWR44SF5RDQSK
@@ -4975,6 +6125,32 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			VirtType: &hvm,
 			Cost:     5597,
 		},
+
+		// SKU: YXVD4WXRCSQ2W2JA
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3359),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     648,
+		},
+
+		// SKU: ZGFYE9BANAUE5GK2
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1679),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     324,
+		},
 	},
 
 	"us-east-1": {
@@ -4993,6 +6169,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Deprecated: true,
 		},
 
+		// SKU: 2S47E3PRB8XVH9QV
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3359),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     376,
+		},
+
 		// SKU: 39748UVFEUKY3MVQ
 		// Instance family: Compute optimized
 		// Storage: EBS only
@@ -5003,7 +6192,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(3247),
 			Mem:      15360,
 			VirtType: &hvm,
-			Cost:     419,
+			Cost:     398,
 		},
 
 		// SKU: 3DX9M63484ZSZFJV
@@ -5044,7 +6233,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5376),
 			Mem:      65536,
 			VirtType: &hvm,
-			Cost:     958,
+			Cost:     862,
 		},
 
 		// SKU: 47GP959QAF69YPG5
@@ -5057,7 +6246,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1344),
 			Mem:      16384,
 			VirtType: &hvm,
-			Cost:     239,
+			Cost:     215,
 		},
 
 		// SKU: 48VURD6MVAZ3M5JX
@@ -5083,7 +6272,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(811),
 			Mem:      3840,
 			VirtType: &hvm,
-			Cost:     105,
+			Cost:     100,
 		},
 
 		// SKU: 4J62B76AXGGMHG57
@@ -5096,7 +6285,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1623),
 			Mem:      7680,
 			VirtType: &hvm,
-			Cost:     209,
+			Cost:     199,
 		},
 
 		// SKU: 4TCUDNKW7PMPSUT2
@@ -5188,7 +6377,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(672),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     120,
+			Cost:     108,
 		},
 
 		// SKU: 9G23QA9CK3NU3BRY
@@ -5201,7 +6390,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(14615),
 			Mem:      61440,
 			VirtType: &hvm,
-			Cost:     1675,
+			Cost:     1591,
 		},
 
 		// SKU: A67CJDV9B3YBP6N6
@@ -5240,7 +6429,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5),
 			Mem:      512,
 			VirtType: &hvm,
-			Cost:     6,
+			Cost:     5,
 		},
 
 		// SKU: ARPJFM962U4P5HAT
@@ -5253,7 +6442,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(6495),
 			Mem:      30720,
 			VirtType: &hvm,
-			Cost:     838,
+			Cost:     796,
 		},
 
 		// SKU: ASDZTDFMC5425T7P
@@ -5280,6 +6469,32 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Mem:      30720,
 			VirtType: &hvm,
 			Cost:     840,
+		},
+
+		// SKU: CGJXHFUSGE546RV6
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(644),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     133,
+		},
+
+		// SKU: CR9BJ8YMV2HGWRBH
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2576),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     532,
 		},
 
 		// SKU: CRRB3H2DYHU6K9FV
@@ -5309,6 +6524,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     665,
 		},
 
+		// SKU: DPCWVHKZ3AJBNM43
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1679),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     188,
+		},
+
 		// SKU: ECM8RSBXMC7F4WAS
 		// Instance family: General purpose
 		// Storage: EBS only
@@ -5319,7 +6547,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20608),
 			Mem:      262144,
 			VirtType: &hvm,
-			Cost:     3830,
+			Cost:     3447,
 		},
 
 		// SKU: EYGMRBWWFGSQBSBZ
@@ -5385,7 +6613,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(10),
 			Mem:      1024,
 			VirtType: &hvm,
-			Cost:     13,
+			Cost:     12,
 		},
 
 		// SKU: J4T9ZF4AJ2DXE7SA
@@ -5398,7 +6626,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(13440),
 			Mem:      163840,
 			VirtType: &hvm,
-			Cost:     2394,
+			Cost:     2155,
 		},
 
 		// SKU: J5XXRJGFYZHJVQZJ
@@ -5440,6 +6668,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			VirtType:   &paravirtual,
 			Cost:       175,
 			Deprecated: true,
+		},
+
+		// SKU: MGQXS8Z3TAKPMGUM
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5152),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     1064,
 		},
 
 		// SKU: MU4QGTJYWR6T73MZ
@@ -5518,7 +6759,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(60),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     104,
+			Cost:     94,
+		},
+
+		// SKU: QMW9CSCFTNV2H99M
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1288),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     266,
 		},
 
 		// SKU: QSNKQ8P78YXPTAH8
@@ -5544,7 +6798,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(40),
 			Mem:      4096,
 			VirtType: &hvm,
-			Cost:     52,
+			Cost:     47,
 		},
 
 		// SKU: RJZ63YZJGC58TPTS
@@ -5588,6 +6842,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     1330,
 		},
 
+		// SKU: TJCB42XUUBBP8KKF
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.16xlarge",
+			Arches:   amd64,
+			CpuCores: 64,
+			CpuPower: instances.CpuPower(20608),
+			Mem:      499712,
+			VirtType: &hvm,
+			Cost:     4256,
+		},
+
 		// SKU: U3KDJRF6FGANNG5Z
 		// Instance family: Memory optimized
 		// Storage: 1 x 32 SSD
@@ -5624,7 +6891,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20),
 			Mem:      2048,
 			VirtType: &hvm,
-			Cost:     26,
+			Cost:     23,
 		},
 
 		// SKU: VHC3YWSZ6ZFZPJN4
@@ -5637,7 +6904,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(2688),
 			Mem:      32768,
 			VirtType: &hvm,
-			Cost:     479,
+			Cost:     431,
 		},
 
 		// SKU: WAWEH2Q4B3BTK68V
@@ -5733,6 +7000,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Deprecated: true,
 		},
 
+		// SKU: Z73VPF4R8N955QMR
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(10304),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     2128,
+		},
+
 		// SKU: ZA47RH8PF27SDZKP
 		// Instance family: Compute optimized
 		// Storage: 2 x 80 SSD
@@ -5785,7 +7065,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(40),
 			Mem:      4096,
 			VirtType: &hvm,
-			Cost:     52,
+			Cost:     47,
 		},
 
 		// SKU: 34ZEJZENQ3WGN6MA
@@ -5814,6 +7094,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     2660,
 		},
 
+		// SKU: 5G4M46QWK9ZC9QDT
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1679),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     188,
+		},
+
 		// SKU: 65YDGPXVA9GTBYCA
 		// Instance family: Storage optimized
 		// Storage: 3 x 2000 HDD
@@ -5825,6 +7118,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Mem:      31232,
 			VirtType: &hvm,
 			Cost:     690,
+		},
+
+		// SKU: 93HAYG7AFZGMJKJY
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "m4.16xlarge",
+			Arches:   amd64,
+			CpuCores: 64,
+			CpuPower: instances.CpuPower(20608),
+			Mem:      262144,
+			VirtType: &hvm,
+			Cost:     3447,
 		},
 
 		// SKU: 9DMUVQNHGNHC7R92
@@ -5840,6 +7146,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     333,
 		},
 
+		// SKU: 9F2Q74QEE8HZE6A8
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1288),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     266,
+		},
+
 		// SKU: 9F7GGKJQGM6J387N
 		// Instance family: Compute optimized
 		// Storage: EBS only
@@ -5850,7 +7169,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(811),
 			Mem:      3840,
 			VirtType: &hvm,
-			Cost:     105,
+			Cost:     100,
 		},
 
 		// SKU: 9MXQF8NSPZESJJUW
@@ -5889,7 +7208,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(60),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     104,
+			Cost:     94,
 		},
 
 		// SKU: C2XHT7MUVASJ7UQ3
@@ -5902,7 +7221,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(13440),
 			Mem:      163840,
 			VirtType: &hvm,
-			Cost:     2394,
+			Cost:     2155,
 		},
 
 		// SKU: DJPGFVCZAKBSEZ3N
@@ -5941,7 +7260,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(10),
 			Mem:      1024,
 			VirtType: &hvm,
-			Cost:     13,
+			Cost:     12,
 		},
 
 		// SKU: GSMN37GEEUV2CC27
@@ -5954,7 +7273,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5376),
 			Mem:      65536,
 			VirtType: &hvm,
-			Cost:     958,
+			Cost:     862,
 		},
 
 		// SKU: GWP38ESW2CNEVPUS
@@ -5980,7 +7299,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1344),
 			Mem:      16384,
 			VirtType: &hvm,
-			Cost:     239,
+			Cost:     215,
 		},
 
 		// SKU: JNBD8ZZ5JSFMNNYR
@@ -5993,7 +7312,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5),
 			Mem:      512,
 			VirtType: &hvm,
-			Cost:     6,
+			Cost:     5,
 		},
 
 		// SKU: JVT8Z9JR8H2KTMEY
@@ -6006,7 +7325,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(14615),
 			Mem:      61440,
 			VirtType: &hvm,
-			Cost:     1675,
+			Cost:     1591,
 		},
 
 		// SKU: M6S6AKBD4WYEHANV
@@ -6032,7 +7351,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(3247),
 			Mem:      15360,
 			VirtType: &hvm,
-			Cost:     419,
+			Cost:     398,
 		},
 
 		// SKU: P3R3B44DZXKTKMYR
@@ -6084,7 +7403,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(672),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     120,
+			Cost:     108,
+		},
+
+		// SKU: R4CKBWU7M6GSC7QB
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2576),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     532,
 		},
 
 		// SKU: R99FC88U7735H9RR
@@ -6097,7 +7429,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1623),
 			Mem:      7680,
 			VirtType: &hvm,
-			Cost:     209,
+			Cost:     199,
 		},
 
 		// SKU: RGU9HRNUAS2TX83W
@@ -6110,7 +7442,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(6495),
 			Mem:      30720,
 			VirtType: &hvm,
-			Cost:     838,
+			Cost:     796,
 		},
 
 		// SKU: RHW8EAZNVJA4KSWC
@@ -6123,7 +7455,33 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(2688),
 			Mem:      32768,
 			VirtType: &hvm,
-			Cost:     479,
+			Cost:     431,
+		},
+
+		// SKU: RWY5P9FB6JQYYM78
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(10304),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     2128,
+		},
+
+		// SKU: RXYEZ3QXT2GWNMRK
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5152),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     1064,
 		},
 
 		// SKU: URPTCUXU96S8XJUV
@@ -6139,6 +7497,32 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     665,
 		},
 
+		// SKU: VU6WDT5USNCYBZEU
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3359),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     376,
+		},
+
+		// SKU: W4ZRFQ4Q6W3P22C4
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.16xlarge",
+			Arches:   amd64,
+			CpuCores: 64,
+			CpuPower: instances.CpuPower(20608),
+			Mem:      499712,
+			VirtType: &hvm,
+			Cost:     4256,
+		},
+
 		// SKU: Y9Z92WYATPYKXSM2
 		// Instance family: Storage optimized
 		// Storage: 1 x 800 SSD
@@ -6152,6 +7536,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     853,
 		},
 
+		// SKU: YQZKQQ43X7CBE4ZD
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(644),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     133,
+		},
+
 		// SKU: ZZNXUPSQ9BSA2M88
 		// Instance family: General purpose
 		// Storage: EBS only
@@ -6162,7 +7559,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20),
 			Mem:      2048,
 			VirtType: &hvm,
-			Cost:     26,
+			Cost:     23,
 		},
 	},
 
@@ -6180,6 +7577,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			VirtType:   &paravirtual,
 			Cost:       293,
 			Deprecated: true,
+		},
+
+		// SKU: 2DKYMP8CF8F43GMZ
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(644),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     159,
 		},
 
 		// SKU: 6CVNTPV3HMNBWRCF
@@ -6245,7 +7655,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(6495),
 			Mem:      30720,
 			VirtType: &hvm,
-			Cost:     1008,
+			Cost:     958,
 		},
 
 		// SKU: 6VTUAGVX6J37U9GQ
@@ -6259,6 +7669,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Mem:      30720,
 			VirtType: &hvm,
 			Cost:     1008,
+		},
+
+		// SKU: 7AB3REVQH3BB3B5F
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3359),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     448,
 		},
 
 		// SKU: 7BBW4T3J39FZV85H
@@ -6298,7 +7721,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(672),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     151,
+			Cost:     136,
 		},
 
 		// SKU: 98882H5A8BVY29GC
@@ -6338,7 +7761,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(60),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     124,
+			Cost:     112,
 		},
 
 		// SKU: BXAR9D46EJJXYWD9
@@ -6395,6 +7818,32 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     168,
 		},
 
+		// SKU: D8J594N2J5BEEN7U
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1288),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     319,
+		},
+
+		// SKU: DGRA5487A6WJRREE
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.16xlarge",
+			Arches:   amd64,
+			CpuCores: 64,
+			CpuPower: instances.CpuPower(20608),
+			Mem:      499712,
+			VirtType: &hvm,
+			Cost:     5107,
+		},
+
 		// SKU: EFPYDPDNRQTJBP3V
 		// Instance family: Memory optimized
 		// Storage: 2 x 1,920
@@ -6431,7 +7880,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(3247),
 			Mem:      15360,
 			VirtType: &hvm,
-			Cost:     504,
+			Cost:     479,
+		},
+
+		// SKU: FBKCPG7Y9BT98V6X
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(10304),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     2553,
 		},
 
 		// SKU: FUTAFX3ARUD9RJJQ
@@ -6485,7 +7947,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20608),
 			Mem:      262144,
 			VirtType: &hvm,
-			Cost:     4840,
+			Cost:     4356,
 		},
 
 		// SKU: J9DSB6BXY5KQK7F9
@@ -6498,7 +7960,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(2688),
 			Mem:      32768,
 			VirtType: &hvm,
-			Cost:     605,
+			Cost:     545,
 		},
 
 		// SKU: K5CWXN5HSW7SME2R
@@ -6537,7 +7999,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5376),
 			Mem:      65536,
 			VirtType: &hvm,
-			Cost:     1210,
+			Cost:     1089,
+		},
+
+		// SKU: MS9288AGUM9ZHPZ3
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1679),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     224,
 		},
 
 		// SKU: N5HCW4AX6C3QWS7P
@@ -6550,7 +8025,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(10),
 			Mem:      1024,
 			VirtType: &hvm,
-			Cost:     15,
+			Cost:     14,
 		},
 
 		// SKU: P76AN6DXWYCD69GD
@@ -6576,7 +8051,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(13440),
 			Mem:      163840,
 			VirtType: &hvm,
-			Cost:     3025,
+			Cost:     2723,
 		},
 
 		// SKU: PKQU74FNEQGYH8AN
@@ -6602,7 +8077,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1623),
 			Mem:      7680,
 			VirtType: &hvm,
-			Cost:     252,
+			Cost:     239,
 		},
 
 		// SKU: QFVQE44FY9YSYTTR
@@ -6615,7 +8090,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(14615),
 			Mem:      61440,
 			VirtType: &hvm,
-			Cost:     2016,
+			Cost:     1915,
 		},
 
 		// SKU: R75SXSFUFBHZPRSS
@@ -6628,7 +8103,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5),
 			Mem:      512,
 			VirtType: &hvm,
-			Cost:     7,
+			Cost:     6,
 		},
 
 		// SKU: RG9GWJUK8NQBF57M
@@ -6685,6 +8160,32 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Deprecated: true,
 		},
 
+		// SKU: SZ4U6UEUN6MP8R7D
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5152),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     1276,
+		},
+
+		// SKU: U4DXFARHKHZQGSHP
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2576),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     638,
+		},
+
 		// SKU: UF55C3729FAEBSYW
 		// Instance family: Storage optimized
 		// Storage: 8 x 800 SSD
@@ -6708,7 +8209,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20),
 			Mem:      2048,
 			VirtType: &hvm,
-			Cost:     31,
+			Cost:     28,
 		},
 
 		// SKU: VXKKRPEQERAMFSFJ
@@ -6747,7 +8248,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1344),
 			Mem:      16384,
 			VirtType: &hvm,
-			Cost:     303,
+			Cost:     273,
 		},
 
 		// SKU: XBS8PBKJMH9G6SDB
@@ -6774,7 +8275,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(811),
 			Mem:      3840,
 			VirtType: &hvm,
-			Cost:     126,
+			Cost:     120,
 		},
 
 		// SKU: YYGVB3MJTV4Q348E
@@ -6787,7 +8288,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(40),
 			Mem:      4096,
 			VirtType: &hvm,
-			Cost:     62,
+			Cost:     56,
 		},
 
 		// SKU: ZZTR42B59D85VUCY
@@ -6816,7 +8317,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1344),
 			Mem:      16384,
 			VirtType: &hvm,
-			Cost:     279,
+			Cost:     251,
 		},
 
 		// SKU: 2M44JQQN3ZP9874A
@@ -6855,7 +8356,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(672),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     140,
+			Cost:     126,
 		},
 
 		// SKU: 4GAV6VD5FWD8W8B4
@@ -6894,7 +8395,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(2688),
 			Mem:      32768,
 			VirtType: &hvm,
-			Cost:     559,
+			Cost:     503,
 		},
 
 		// SKU: 6H5EA7PH345UPBVC
@@ -6909,6 +8410,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			VirtType:   &paravirtual,
 			Cost:       1100,
 			Deprecated: true,
+		},
+
+		// SKU: 76F5CX9DPY2B39T5
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1679),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     244,
 		},
 
 		// SKU: 7AJJ9ANNCNNX5WY6
@@ -6948,7 +8462,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(40),
 			Mem:      4096,
 			VirtType: &hvm,
-			Cost:     68,
+			Cost:     61,
 		},
 
 		// SKU: 87ZU79BG86PYWTSG
@@ -6990,19 +8504,6 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     3751,
 		},
 
-		// SKU: A78J2XTXBB29NGT4
-		// Instance family: Memory optimized
-		// Storage: 2 x 1,920
-		{
-			Name:     "x1.32xlarge",
-			Arches:   amd64,
-			CpuCores: 128,
-			CpuPower: instances.CpuPower(41216),
-			Mem:      1998848,
-			VirtType: &hvm,
-			Cost:     17340,
-		},
-
 		// SKU: CTG879VYY65QE94C
 		// Instance family: General purpose
 		// Storage: 2 x 80 SSD
@@ -7039,7 +8540,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(60),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     136,
+			Cost:     122,
 		},
 
 		// SKU: EVYB78ZE853DF3CC
@@ -7078,7 +8579,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5376),
 			Mem:      65536,
 			VirtType: &hvm,
-			Cost:     1117,
+			Cost:     1004,
 		},
 
 		// SKU: FA7B379WCHNBVMNU
@@ -7091,7 +8592,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(6495),
 			Mem:      30720,
 			VirtType: &hvm,
-			Cost:     1049,
+			Cost:     997,
 		},
 
 		// SKU: G3EQX8J7UNTWEVC7
@@ -7104,7 +8605,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(3247),
 			Mem:      15360,
 			VirtType: &hvm,
-			Cost:     524,
+			Cost:     498,
 		},
 
 		// SKU: GRGVZYA9QN53ASFB
@@ -7131,7 +8632,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5),
 			Mem:      512,
 			VirtType: &hvm,
-			Cost:     8,
+			Cost:     7,
 		},
 
 		// SKU: GSN36ZXJH466ES5F
@@ -7144,7 +8645,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(14615),
 			Mem:      61440,
 			VirtType: &hvm,
-			Cost:     2098,
+			Cost:     1993,
 		},
 
 		// SKU: H8QFMXWT89NGP6VU
@@ -7158,6 +8659,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Mem:      3840,
 			VirtType: &hvm,
 			Cost:     120,
+		},
+
+		// SKU: HQXQHXXJPTDD2HW7
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(10304),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     2371,
 		},
 
 		// SKU: J5UNF2XTPQCS5N59
@@ -7183,7 +8697,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(10),
 			Mem:      1024,
 			VirtType: &hvm,
-			Cost:     17,
+			Cost:     15,
 		},
 
 		// SKU: JHV4BKWFVMXQ2T6R
@@ -7196,7 +8710,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20),
 			Mem:      2048,
 			VirtType: &hvm,
-			Cost:     34,
+			Cost:     31,
 		},
 
 		// SKU: JJRB8PAXGN6JTB3D
@@ -7223,20 +8737,46 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1623),
 			Mem:      7680,
 			VirtType: &hvm,
-			Cost:     262,
+			Cost:     249,
 		},
 
-		// SKU: N63KE7N2NCMCYWXC
+		// SKU: MMX6UFM34E65AQDY
 		// Instance family: Memory optimized
-		// Storage: 1 x 1,920
+		// Storage: EBS only
 		{
-			Name:     "x1.16xlarge",
+			Name:     "r4.16xlarge",
 			Arches:   amd64,
 			CpuCores: 64,
 			CpuPower: instances.CpuPower(20608),
-			Mem:      999424,
+			Mem:      499712,
 			VirtType: &hvm,
-			Cost:     8670,
+			Cost:     4742,
+		},
+
+		// SKU: MSDZGAVV7DCFG86R
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2576),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     592,
+		},
+
+		// SKU: MSR496BA8MMSSHES
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1288),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     296,
 		},
 
 		// SKU: P5VFWENV9YDAQVFH
@@ -7276,7 +8816,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(811),
 			Mem:      3840,
 			VirtType: &hvm,
-			Cost:     131,
+			Cost:     124,
+		},
+
+		// SKU: R33YWMGU2UZNZRG5
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(644),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     148,
 		},
 
 		// SKU: RMARGSE4CA952UDV
@@ -7328,7 +8881,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(13440),
 			Mem:      163840,
 			VirtType: &hvm,
-			Cost:     2793,
+			Cost:     2514,
 		},
 
 		// SKU: TMYBBH8MNS5KCXDG
@@ -7367,7 +8920,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20608),
 			Mem:      262144,
 			VirtType: &hvm,
-			Cost:     4469,
+			Cost:     4022,
 		},
 
 		// SKU: VZ7V29X35F98VENC
@@ -7451,6 +9004,32 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Deprecated: true,
 		},
 
+		// SKU: XN66GCWSFVKQP8UD
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5152),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     1185,
+		},
+
+		// SKU: YPK2GJ5Z9TMRRSK7
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3359),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     488,
+		},
+
 		// SKU: YY26V92H8QNEPQER
 		// Instance family: Memory optimized
 		// Storage: 1 x 32 SSD
@@ -7504,7 +9083,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(40),
 			Mem:      4096,
 			VirtType: &hvm,
-			Cost:     52,
+			Cost:     47,
 		},
 
 		// SKU: 2J3G8CUM4UVYVFJH
@@ -7517,7 +9096,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5),
 			Mem:      512,
 			VirtType: &hvm,
-			Cost:     6,
+			Cost:     5,
 		},
 
 		// SKU: 2JUMD5V8V9V6D9JC
@@ -7532,6 +9111,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			VirtType:   &paravirtual,
 			Cost:       87,
 			Deprecated: true,
+		},
+
+		// SKU: 2K68UGQ7NNMG757D
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.large",
+			Arches:   amd64,
+			CpuCores: 2,
+			CpuPower: instances.CpuPower(644),
+			Mem:      15616,
+			VirtType: &hvm,
+			Cost:     133,
 		},
 
 		// SKU: 34G9YZGUJNTY6HG9
@@ -7557,7 +9149,20 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(6495),
 			Mem:      30720,
 			VirtType: &hvm,
-			Cost:     838,
+			Cost:     796,
+		},
+
+		// SKU: 3U96RB67X35NC337
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(3359),
+			Mem:      32768,
+			VirtType: &hvm,
+			Cost:     376,
 		},
 
 		// SKU: 4SCSPCTHFCXYY6GT
@@ -7584,7 +9189,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1623),
 			Mem:      7680,
 			VirtType: &hvm,
-			Cost:     209,
+			Cost:     199,
 		},
 
 		// SKU: 5EPUM8UK2RTQKW5E
@@ -7668,6 +9273,32 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     166,
 		},
 
+		// SKU: 83KC74WNYCKW5CYN
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.2xlarge",
+			Arches:   amd64,
+			CpuCores: 8,
+			CpuPower: instances.CpuPower(2576),
+			Mem:      62464,
+			VirtType: &hvm,
+			Cost:     532,
+		},
+
+		// SKU: 8ZTRUHSHU2GT4CDF
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.8xlarge",
+			Arches:   amd64,
+			CpuCores: 32,
+			CpuPower: instances.CpuPower(10304),
+			Mem:      249856,
+			VirtType: &hvm,
+			Cost:     2128,
+		},
+
 		// SKU: 9GHZN7VCNV2MGV4N
 		// Instance family: Compute optimized
 		// Storage: 2 x 160 SSD
@@ -7743,7 +9374,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(672),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     120,
+			Cost:     108,
 		},
 
 		// SKU: BMEYUTP658QKQRTP
@@ -7756,7 +9387,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(5376),
 			Mem:      65536,
 			VirtType: &hvm,
-			Cost:     958,
+			Cost:     862,
 		},
 
 		// SKU: BNBBBYA6WNXQ3TZV
@@ -7853,6 +9484,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Cost:     133,
 		},
 
+		// SKU: F649UJZP8WARX37N
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.16xlarge",
+			Arches:   amd64,
+			CpuCores: 64,
+			CpuPower: instances.CpuPower(20608),
+			Mem:      499712,
+			VirtType: &hvm,
+			Cost:     4256,
+		},
+
 		// SKU: F6544RN8RCJHYC5Z
 		// Instance family: Compute optimized
 		// Storage: 2 x 80 SSD
@@ -7864,6 +9508,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Mem:      15360,
 			VirtType: &hvm,
 			Cost:     420,
+		},
+
+		// SKU: FQBEE3KF5TRFG5ZF
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1288),
+			Mem:      31232,
+			VirtType: &hvm,
+			Cost:     266,
 		},
 
 		// SKU: GMTWE5CTY4FEUYDN
@@ -7889,7 +9546,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(2688),
 			Mem:      32768,
 			VirtType: &hvm,
-			Cost:     479,
+			Cost:     431,
 		},
 
 		// SKU: JH68FQ55JWMC4CG9
@@ -7928,7 +9585,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(811),
 			Mem:      3840,
 			VirtType: &hvm,
-			Cost:     105,
+			Cost:     100,
 		},
 
 		// SKU: K5MSZ8JUCECB23H9
@@ -7995,7 +9652,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(13440),
 			Mem:      163840,
 			VirtType: &hvm,
-			Cost:     2394,
+			Cost:     2155,
 		},
 
 		// SKU: N4D3MGNKSH7Q9KT3
@@ -8008,7 +9665,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(10),
 			Mem:      1024,
 			VirtType: &hvm,
-			Cost:     13,
+			Cost:     12,
 		},
 
 		// SKU: N5F93UFYUKWKB8KE
@@ -8105,6 +9762,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Deprecated: true,
 		},
 
+		// SKU: T3BJKYM5NU9B6XGY
+		// Instance family: Memory optimized
+		// Storage: EBS only
+		{
+			Name:     "r4.4xlarge",
+			Arches:   amd64,
+			CpuCores: 16,
+			CpuPower: instances.CpuPower(5152),
+			Mem:      124928,
+			VirtType: &hvm,
+			Cost:     1064,
+		},
+
 		// SKU: TKYAD5H42TYVUTMG
 		// Instance family: General purpose
 		// Storage: EBS only
@@ -8115,7 +9785,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20608),
 			Mem:      262144,
 			VirtType: &hvm,
-			Cost:     3830,
+			Cost:     3447,
 		},
 
 		// SKU: UNB4R4KS4XXHQFD2
@@ -8128,7 +9798,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(14615),
 			Mem:      61440,
 			VirtType: &hvm,
-			Cost:     1675,
+			Cost:     1591,
 		},
 
 		// SKU: VBKTV5SAFT4WNV9X
@@ -8154,7 +9824,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(60),
 			Mem:      8192,
 			VirtType: &hvm,
-			Cost:     104,
+			Cost:     94,
 		},
 
 		// SKU: X5NPE8XF7KHV7AAD
@@ -8167,7 +9837,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(1344),
 			Mem:      16384,
 			VirtType: &hvm,
-			Cost:     239,
+			Cost:     215,
 		},
 
 		// SKU: XK9YF9AJ9EBH7W4U
@@ -8180,7 +9850,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(20),
 			Mem:      2048,
 			VirtType: &hvm,
-			Cost:     26,
+			Cost:     23,
 		},
 
 		// SKU: XUTTHNZ5B5VJKKDE
@@ -8206,7 +9876,7 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			CpuPower: instances.CpuPower(3247),
 			Mem:      15360,
 			VirtType: &hvm,
-			Cost:     419,
+			Cost:     398,
 		},
 
 		// SKU: YKQ7DN6CCEDVB8Q2
@@ -8259,6 +9929,19 @@ var allInstanceTypes = map[string][]instances.InstanceType{
 			Mem:      999424,
 			VirtType: &hvm,
 			Cost:     6669,
+		},
+
+		// SKU: Z2A6DZ9V9QZ363BC
+		// Instance family: General purpose
+		// Storage: EBS only
+		{
+			Name:     "t2.xlarge",
+			Arches:   amd64,
+			CpuCores: 4,
+			CpuPower: instances.CpuPower(1679),
+			Mem:      16384,
+			VirtType: &hvm,
+			Cost:     188,
 		},
 
 		// SKU: ZKYE77DHMC32Y9BK

--- a/provider/ec2/internal/ec2instancetypes/instancetypes_test.go
+++ b/provider/ec2/internal/ec2instancetypes/instancetypes_test.go
@@ -72,6 +72,7 @@ func (s *InstanceTypesSuite) TestRegionInstanceTypesAvailability(c *gc.C) {
 		[]string{
 			"cc2.8xlarge", "cg1.4xlarge", "cr1.8xlarge", "hi1.4xlarge",
 			"hs1.8xlarge", "p2.16xlarge", "p2.8xlarge", "p2.xlarge",
+			"x1.16xlarge", "x1.32xlarge",
 		},
 	)
 }

--- a/provider/ec2/internal/ec2instancetypes/process_cost_data.go
+++ b/provider/ec2/internal/ec2instancetypes/process_cost_data.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
@@ -279,7 +280,10 @@ func calculateCPUPower(info productInfo) (uint64, error) {
 	// to estimate the ECUs. The pricing information does not
 	// include the ECUs, but they're only estimates anyway.
 	// Amazon moved to "vCPUs" quite some time ago.
-	clock, err := strconv.ParseFloat(strings.Fields(info.ClockSpeed)[0], 64)
+	// To date, info.ClockSpeed can have the form "Up to <float> GHz" or
+	// "<float> GHz", so look for a float match.
+	validSpeed := regexp.MustCompile(`[0-9]+\.?[0-9]*`)
+	clock, err := strconv.ParseFloat(validSpeed.FindString(info.ClockSpeed), 64)
 	if err != nil {
 		return 0, errors.Annotate(err, "parsing clock speed")
 	}
@@ -306,8 +310,10 @@ func locationToRegion(loc string) (string, bool) {
 		"Asia Pacific (Singapore)":  "ap-southeast-1",
 		"Asia Pacific (Sydney)":     "ap-southeast-2",
 		"Asia Pacific (Tokyo)":      "ap-northeast-1",
+		"Canada (Central)":          "ca-central-1",
 		"EU (Frankfurt)":            "eu-central-1",
 		"EU (Ireland)":              "eu-west-1",
+		"EU (London)":               "eu-west-2",
 		"South America (Sao Paulo)": "sa-east-1",
 		"AWS GovCloud (US)":         "us-gov-west-1",
 

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1380,17 +1380,15 @@ func (t *localServerSuite) TestSubnetsWithInstanceIdMissingSubnet(c *gc.C) {
 }
 
 func (t *localServerSuite) TestInstanceInformation(c *gc.C) {
-	// TODO(macgreagoir) Where do these magic length numbers come from?
-	c.Skip("Hard-coded InstanceTypes counts without explanation")
 	env := t.prepareEnviron(c)
 	types, err := env.InstanceTypes(constraints.Value{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(types.InstanceTypes, gc.HasLen, 45)
+	c.Assert(types.InstanceTypes, gc.HasLen, 53)
 
 	cons := constraints.MustParse("mem=4G")
 	types, err = env.InstanceTypes(cons)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(types.InstanceTypes, gc.HasLen, 40)
+	c.Assert(types.InstanceTypes, gc.HasLen, 48)
 }
 
 func validateSubnets(c *gc.C, subnets []network.SubnetInfo) {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1385,7 +1385,6 @@ func (t *localServerSuite) TestInstanceInformation(c *gc.C) {
 	env := t.prepareEnviron(c)
 	types, err := env.InstanceTypes(constraints.Value{})
 	c.Assert(err, jc.ErrorIsNil)
-	fmt.Printf("instance types: %d", len(types.InstanceTypes))
 	c.Check(types.InstanceTypes, gc.HasLen, 45)
 
 	cons := constraints.MustParse("mem=4G")

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1380,10 +1380,13 @@ func (t *localServerSuite) TestSubnetsWithInstanceIdMissingSubnet(c *gc.C) {
 }
 
 func (t *localServerSuite) TestInstanceInformation(c *gc.C) {
+	// TODO(macgreagoir) Where do these magic length numbers come from?
+	c.Skip("Hard-coded InstanceTypes counts without explanation")
 	env := t.prepareEnviron(c)
 	types, err := env.InstanceTypes(constraints.Value{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(types.InstanceTypes, gc.HasLen, 45)
+	fmt.Printf("instance types: %d", len(types.InstanceTypes))
+	c.Check(types.InstanceTypes, gc.HasLen, 45)
 
 	cons := constraints.MustParse("mem=4G")
 	types, err = env.InstanceTypes(cons)

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1385,7 +1385,7 @@ func (t *localServerSuite) TestInstanceInformation(c *gc.C) {
 	env := t.prepareEnviron(c)
 	types, err := env.InstanceTypes(constraints.Value{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(types.InstanceTypes, gc.HasLen, 45)
+	c.Assert(types.InstanceTypes, gc.HasLen, 45)
 
 	cons := constraints.MustParse("mem=4G")
 	types, err = env.InstanceTypes(cons)


### PR DESCRIPTION
## Description of change

Add eu-west-2 and ca-central-1 to fallback-public-clouds.yaml, and regenerate instance type data to include those regions.

## QA steps

juju bootstrap aws/eu-west-2
juju bootstrap aws/ca-canada-1 --bootstrap-series=yakkety

It is not currently possible to add xenial machines in ca-canada-1 due to https://bugs.launchpad.net/cloud-images/+bug/1662040.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1661722