### PR TITLE
provider/azure: handle empty authorized-keys

### DIFF
--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -41,6 +41,10 @@ type ProviderConfig struct {
 	// a random password for the Windows admin user.
 	RandomWindowsAdminPassword func() string
 
+	// GneerateSSHKey is a functio nused to generate a new SSH
+	// key pair for provisioning Linux machines.
+	GenerateSSHKey func(comment string) (private, public string, _ error)
+
 	// InteractiveCreateServicePrincipal is a function used to
 	// interactively create/update service principals with
 	// password credentials.
@@ -57,6 +61,9 @@ func (cfg ProviderConfig) Validate() error {
 	}
 	if cfg.RandomWindowsAdminPassword == nil {
 		return errors.NotValidf("nil RandomWindowsAdminPassword")
+	}
+	if cfg.GenerateSSHKey == nil {
+		return errors.NotValidf("nil GenerateSSHKey")
 	}
 	if cfg.InteractiveCreateServicePrincipal == nil {
 		return errors.NotValidf("nil InteractiveCreateServicePrincipal")

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -112,6 +112,9 @@ func newProvider(c *gc.C, config azure.ProviderConfig) environs.EnvironProvider 
 		config.InteractiveCreateServicePrincipal = azureauth.InteractiveCreateServicePrincipal
 	}
 	config.RandomWindowsAdminPassword = func() string { return "sorandom" }
+	config.GenerateSSHKey = func(string) (string, string, error) {
+		return "private", "public", nil
+	}
 	environProvider, err := azure.NewProvider(config)
 	c.Assert(err, jc.ErrorIsNil)
 	return environProvider

--- a/provider/azure/init.go
+++ b/provider/azure/init.go
@@ -6,6 +6,7 @@ package azure
 import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/clock"
+	"github.com/juju/utils/ssh"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/azure/internal/azureauth"
@@ -31,6 +32,7 @@ func init() {
 		NewStorageClient:                  azurestorage.NewClient,
 		RetryClock:                        &clock.WallClock,
 		RandomWindowsAdminPassword:        randomAdminPassword,
+		GenerateSSHKey:                    ssh.GenerateKey,
 		InteractiveCreateServicePrincipal: azureauth.InteractiveCreateServicePrincipal,
 	})
 	if err != nil {


### PR DESCRIPTION
## Description of change

Azure requires that a machine have either a
password or an SSH authorised key set for a
machine. If authorized-keys is empty in the
config, generate a key pair. We will pass
the public key into Azure, and throw away
the private key.

## QA steps

1. juju bootstrap azure
2. hack juju add-model CLI code to not add public SSH keys to config
3. juju add-model foo
4. juju add-machine, confirm machine is provisioned successfully

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1658830