### PR TITLE
Add sysctl network values to cloud init

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1391,20 +1391,13 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) (err error) {
 		}
 	}()
 
-	mongoInstalled, err := mongo.IsServiceInstalled()
+	// EnsureMongoServer installs/upgrades the init config as necessary.
+	ensureServerParams, err := cmdutil.NewEnsureServerParams(agentConfig)
 	if err != nil {
-		return errors.Annotate(err, "error while checking if mongodb service is installed")
+		return err
 	}
-
-	if !mongoInstalled {
-		// EnsureMongoServer installs/upgrades the init config as necessary.
-		ensureServerParams, err := cmdutil.NewEnsureServerParams(agentConfig)
-		if err != nil {
-			return err
-		}
-		if err := cmdutil.EnsureMongoServer(ensureServerParams); err != nil {
-			return err
-		}
+	if err := cmdutil.EnsureMongoServer(ensureServerParams); err != nil {
+		return err
 	}
 	logger.Debugf("mongodb service is installed")
 

--- a/mongo/export_test.go
+++ b/mongo/export_test.go
@@ -41,3 +41,7 @@ func PatchService(patchValue func(interface{}, interface{}), data *svctesting.Fa
 		return svc, nil
 	})
 }
+
+func SysctlEditableEnsureServer(args EnsureServerParams, sysctlFiles map[string]string) error {
+	return ensureServer(args, sysctlFiles)
+}


### PR DESCRIPTION
## Description of change

For controllers, we tune various network related kernel options to avoid network timeeout issues on deployments with large numbers of agents. 4 kernel parameters are tuned:
net.ipv4.tcp_max_syn_backlog = 4096
net.core.somaxconn = 16384
net.core.netdev_max_backlog = 1000
net.ipv4.tcp_fin_timeout = 30

And also

/sys/kernel/mm/transparent_hugepage/enabled -> never
/sys/kernel/mm/transparent_hugepage/defrag -> never

## QA steps

Bootstrap aws
ssh into controller
cat /proc/sys/net/ipv4/tcp_max_syn_backlog
4096

## Bug reference

https://bugs.launchpad.net/juju/+bug/1656430
