### PR TITLE
add SNAP bin path to bash completion

### DIFF
--- a/etc/bash_completion.d/juju-2
+++ b/etc/bash_completion.d/juju-2
@@ -341,6 +341,9 @@ export _JUJU_2_cache_TTL=2
 # Detect juju built from source (highest priority)
 if [ -x "$GOPATH/bin/juju" ]; then 
     export _juju_cmd_JUJU_2="$GOPATH/bin/juju"
+# Snap version of juju
+elif [ -x "/snap/bin/juju" ]; then
+    export _juju_cmd_JUJU_2="/snap/bin/juju"
 # Detect installed juju-2 binary (next highest priority)
 elif [ -x "/usr/bin/juju-2" ]; then
     export _juju_cmd_JUJU_2="/usr/bin/juju-2"

--- a/etc/bash_completion.d/juju-2
+++ b/etc/bash_completion.d/juju-2
@@ -341,12 +341,12 @@ export _JUJU_2_cache_TTL=2
 # Detect juju built from source (highest priority)
 if [ -x "$GOPATH/bin/juju" ]; then 
     export _juju_cmd_JUJU_2="$GOPATH/bin/juju"
-# Snap version of juju
-elif [ -x "/snap/bin/juju" ]; then
-    export _juju_cmd_JUJU_2="/snap/bin/juju"
 # Detect installed juju-2 binary (next highest priority)
 elif [ -x "/usr/bin/juju-2" ]; then
     export _juju_cmd_JUJU_2="/usr/bin/juju-2"
+# Snap version of juju
+elif [ -x "/snap/bin/juju" ]; then
+    export _juju_cmd_JUJU_2="/snap/bin/juju"
 # Use /usr/bin/juju as a last resort.
 else
     export _juju_cmd_JUJU_2="/usr/bin/juju"


### PR DESCRIPTION
For snapped versions of Juju which reside in /snap/bin/juju we need to make bash
completion aware of this additional binary path.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>

## Please provide the following details to expedite Pull Request review:

----

## Description of change

This change is needed to support an additional $PATH for snapped version of Juju.

## QA steps

A new snap version of Juju or conjure-up needs to be built and then you can juju <tab> to verify completion still works.

## Documentation changes

This does not require additional documentation.

## Bug reference

No bug exists for this addition.
