### PR TITLE
cmd/...: fix single-key config commands

### DIFF
--- a/cmd/juju/controller/getconfig_test.go
+++ b/cmd/juju/controller/getconfig_test.go
@@ -44,11 +44,11 @@ func (s *GetConfigSuite) TestInit(c *gc.C) {
 }
 
 func (s *GetConfigSuite) TestSingleValue(c *gc.C) {
-	context, err := s.run(c, "controller-uuid")
+	context, err := s.run(c, "ca-cert")
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := strings.TrimSpace(testing.Stdout(context))
-	c.Assert(output, gc.Equals, "uuid")
+	c.Assert(output, gc.Equals, "multi\nline")
 }
 
 func (s *GetConfigSuite) TestSingleValueJSON(c *gc.C) {
@@ -64,9 +64,13 @@ func (s *GetConfigSuite) TestAllValues(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := strings.TrimSpace(testing.Stdout(context))
-	expected := "" +
-		"api-port: 1234\n" +
-		"controller-uuid: uuid"
+	expected := `
+Attribute  Value
+api-port   1234
+ca-cert    |-
+  multi
+  line
+controller-uuid  uuid`[1:]
 	c.Assert(output, gc.Equals, expected)
 }
 
@@ -75,7 +79,7 @@ func (s *GetConfigSuite) TestAllValuesJSON(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := strings.TrimSpace(testing.Stdout(context))
-	expected := `{"api-port":1234,"controller-uuid":"uuid"}`
+	expected := `{"api-port":1234,"ca-cert":"multi\nline","controller-uuid":"uuid"}`
 	c.Assert(output, gc.Equals, expected)
 }
 
@@ -100,5 +104,6 @@ func (f *fakeControllerAPI) ControllerConfig() (jujucontroller.Config, error) {
 	return map[string]interface{}{
 		"controller-uuid": "uuid",
 		"api-port":        1234,
+		"ca-cert":         "multi\nline",
 	}, nil
 }

--- a/cmd/juju/model/configcommand.go
+++ b/cmd/juju/model/configcommand.go
@@ -289,7 +289,14 @@ func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) err
 		key := c.keys[0]
 		if value, found := attrs[key]; found {
 			if c.out.Name() == "tabular" {
-				return cmd.FormatYaml(ctx.Stdout, value.Value)
+				// The user has not specified that they want
+				// YAML or JSON formatting, so we print out
+				// the value unadorned.
+				return c.out.WriteFormatter(
+					ctx,
+					cmd.FormatSmart,
+					value.Value,
+				)
 			}
 			attrs = config.ConfigValues{
 				key: config.ConfigValue{

--- a/cmd/juju/model/configcommand_test.go
+++ b/cmd/juju/model/configcommand_test.go
@@ -3,6 +3,9 @@
 package model_test
 
 import (
+	"io/ioutil"
+	"path/filepath"
+
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -91,11 +94,25 @@ func (s *ConfigCommandSuite) TestInit(c *gc.C) {
 }
 
 func (s *ConfigCommandSuite) TestSingleValue(c *gc.C) {
+	s.fake.values["special"] = "multi\nline"
+
 	context, err := s.run(c, "special")
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := testing.Stdout(context)
-	c.Assert(output, gc.Equals, "special value\n")
+	c.Assert(output, gc.Equals, "multi\nline\n")
+}
+
+func (s *ConfigCommandSuite) TestSingleValueOutputFile(c *gc.C) {
+	s.fake.values["special"] = "multi\nline"
+
+	outpath := filepath.Join(c.MkDir(), "out")
+	_, err := s.run(c, "--output", outpath, "special")
+	c.Assert(err, jc.ErrorIsNil)
+
+	output, err := ioutil.ReadFile(outpath)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(output), gc.Equals, "multi\nline\n")
 }
 
 func (s *ConfigCommandSuite) TestGetUnknownValue(c *gc.C) {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -20,7 +20,7 @@ github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24
 github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07T23:45:32Z
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	7725027b95e0d54635e0fb11efc2debdcdf19f75	2016-12-15T16:06:52Z
-github.com/juju/cmd	git	1c6973d59b804e4d3c293fbf240f067e73436bc9	2016-08-23T10:31:14Z
+github.com/juju/cmd	git	0f05ac592d6925a1b8ca0f77524d3348fafa66cc	2017-02-07T03:13:09Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/jsonschema	git	a0ef8b74ebcffeeff9fc374854deb4af388f037e	2016-11-02T18:19:19Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z


### PR DESCRIPTION
## Description of change

Fix controller-config and model-config commands
so that when a single key is specified, by
default we will format the value in its raw
form. Internally, we use the "smart" formatter
to do this.

To do this in a way that users can still get
YAML/JSON formatting of single keys as needed,
we introduce and default to tabular formatting
of controller config as we do for model config.

Also, fix the model-config command to honour
the -o/--output flag when a single key is
specified.

## QA steps

1. juju bootstrap localhost
2. juju controller-config ca-cert (should print ca-cert without YAML multi-line prefix)
3. juju controller-config --format=yaml ca-cert (should print ca-cert *with* YAML multi-line prefix)
4. juju controller-config (should print attributes in tabular format)
5. juju model-config http-proxy="abc
def"
5. juju model-config --output=/tmp/config.txt http-proxy (contents of /tmp/config.txt should be:
```
abc
def
```

## Documentation changes

Default format of controller-config has changed, and for single-key format of model-config. We do not guarantee stability of the default formats, you must specify YAML/JSON for that.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1661506