### PR TITLE
juju run: honour --timeout when entity is pending

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -268,7 +268,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(status.NewStatusHistoryCommand())
 
 	// Error resolution and debugging commands.
-	r.Register(newRunCommand())
+	r.Register(newDefaultRunCommand())
 	r.Register(newSCPCommand(nil))
 	r.Register(newSSHCommand(nil))
 	r.Register(newResolvedCommand())


### PR DESCRIPTION
## Description of change

Previously, "juju run"'s --timeout flag would only
take effect from the point at which the command
starts running in the machine/unit agent. That means
it never times out if the machine/unit remains
pending.

We change the command to apply the timeout to the
entire wait phase of juju run. We will print out
any results we received after the timeout, and
return an error indicating which entities did not
complete running their actions.

## QA steps

1. juju bootstrap localhost
2. juju add-machine, wait for machine to be "started"
3. juju add-machine
4. juju run --all /bin/true --timeout=10s, should print out:
```
- MachineId: "0"
  Stdout: ""
- MachineId: "1"
  Stdout: ""

ERROR timed out waiting for result from: machine 2
```
5. juju add-machine
6. repeat juju run command as above, should print out:
```
- MachineId: "0"
  Stdout: ""
- MachineId: "1"
  Stdout: ""

ERROR timed out waiting for result from: machine 2, machine 3
```

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1638332