### PR TITLE
juju run: accept multiple args for command

### DIFF
--- a/cmd/juju/commands/run.go
+++ b/cmd/juju/commands/run.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils"
 	"gopkg.in/juju/names.v2"
 
 	actionapi "github.com/juju/juju/api/action"
@@ -39,7 +40,7 @@ type runCommand struct {
 }
 
 const runDoc = `
-Run the commands on the specified targets. Only admin users of a model
+Run a shell command on the specified targets. Only admin users of a model
 are able to use this command.
 
 Targets are specified using either machine ids, application names or unit
@@ -67,6 +68,12 @@ targets.
 
 Since juju run creates actions, you can query for the status of commands
 started with juju run by calling "juju show-action-status --name juju-run".
+
+If you need to pass flags to the command being run, you must precede the
+command and its arguments with "--", to tell "juju run" to stop processing
+those arguments. For example:
+
+    juju run --all -- hostname -f
 `
 
 func (c *runCommand) Info() *cmd.Info {
@@ -97,7 +104,16 @@ func (c *runCommand) Init(args []string) error {
 	if len(args) == 0 {
 		return errors.Errorf("no commands specified")
 	}
-	c.commands, args = args[0], args[1:]
+	if len(args) == 1 {
+		// If just one argument is specified, we don't pass it through
+		// utils.CommandString in case it contains multiple arguments
+		// (e.g. juju run --all "sudo whatever"). Passing it through
+		// utils.CommandString would quote the string, which the backend
+		// does not expect.
+		c.commands = args[0]
+	} else {
+		c.commands = utils.CommandString(args...)
+	}
 
 	if c.all {
 		if len(c.machines) != 0 {
@@ -136,7 +152,7 @@ func (c *runCommand) Init(args []string) error {
 			strings.Join(nameErrors, "\n"))
 	}
 
-	return cmd.CheckEmpty(args)
+	return nil
 }
 
 // ConvertActionResults takes the results from the api and creates a map

--- a/cmd/juju/commands/run_test.go
+++ b/cmd/juju/commands/run_test.go
@@ -47,14 +47,15 @@ func (*RunSuite) TestTargetArgParsing(c *gc.C) {
 		args:     []string{"sudo reboot"},
 		errMatch: "You must specify a target, either through --all, --machine, --application or --unit",
 	}, {
-		message:  "too many args",
-		args:     []string{"--all", "sudo reboot", "oops"},
-		errMatch: `unrecognized args: \["oops"\]`,
-	}, {
 		message:  "command to all machines",
 		args:     []string{"--all", "sudo reboot"},
 		all:      true,
 		commands: "sudo reboot",
+	}, {
+		message:  "multiple args",
+		args:     []string{"--all", "echo", "la lia"},
+		all:      true,
+		commands: `echo "la lia"`,
 	}, {
 		message:  "all and defined machines",
 		args:     []string{"--all", "--machine=1,2", "sudo reboot"},


### PR DESCRIPTION
## Description of change

Update the "juju run" command so that it accepts
multiple positional arguments, and combines them
into a command for the remote targets to run.
Update the help text to explain how to run a
command that takes flags.

## QA steps

1. juju bootstrap localhost
2. juju switch controller
3. juju run --all 'hostname -f'
4. juju run --all -- hostname -f
Both commands should run successfully, and print out the FQDN of the controller instance.

## Documentation changes

No change to existing usage.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1637819