### PR TITLE
Fix lxd ipv6 2.1

### DIFF
--- a/tools/lxdclient/client_network.go
+++ b/tools/lxdclient/client_network.go
@@ -54,8 +54,8 @@ func checkBridgeConfig(client rawNetworkClient, bridge string) error {
 	if err != nil {
 		return err
 	}
-
-	if n.Managed && n.Config["ipv6.address"] != "none" {
+	ipv6AddressConfig := n.Config["ipv6.address"]
+	if n.Managed && ipv6AddressConfig != "none" && ipv6AddressConfig != "" {
 		return errors.Errorf(`juju doesn't support ipv6. Please disable LXD's IPV6:
 
 	$ lxc network set %s ipv6.address none

--- a/tools/lxdclient/utils_test.go
+++ b/tools/lxdclient/utils_test.go
@@ -37,6 +37,15 @@ func (s *utilsSuite) TestEnableHTTPSListenerError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "uh oh")
 }
 
+func (s *utilsSuite) TestEnableHTTPSListenerIPV4Fallback(c *gc.C) {
+	var client mockConfigSetter
+	client.SetErrors(errors.New("any error string added by lxd: socket: address family not supported by protocol"))
+	err := lxdclient.EnableHTTPSListener(&client)
+	c.Assert(err, jc.ErrorIsNil)
+	client.CheckCall(c, 0, "SetServerConfig", "core.https_address", "[::]")
+	client.CheckCall(c, 1, "SetServerConfig", "core.https_address", "0.0.0.0")
+}
+
 type mockConfigSetter struct {
 	testing.Stub
 }


### PR DESCRIPTION
Detect when IPV6.address is empty in lxd config and fallback to IPV4 when 6 is disabled in kernel.

This change prevents juju lxd provider from failing when running in a machine with ipv6 disabled in different possible ways.

## QA steps

Try reproduction steps in bugs:
* https://bugs.launchpad.net/juju/+bug/1656205
* https://bugs.launchpad.net/juju/+bug/1633362

## Bug reference

https://bugs.launchpad.net/juju/+bug/1656205
https://bugs.launchpad.net/juju/+bug/1633362
