### PR TITLE
2.1 don't fallback on error

### DIFF
--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -723,7 +723,7 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(env environs.Environ, idx in
 		}
 
 		if len(parentAddrs) > 0 {
-			logger.Infof("host machine device %q has addresses %v", parentDevice.Name(), parentAddrs)
+			logger.Debugf("host machine device %q has addresses %v", parentDevice.Name(), parentAddrs)
 			firstAddress := parentAddrs[0]
 			if supportContainerAddresses {
 				parentDeviceSubnet, err := firstAddress.Subnet()
@@ -744,7 +744,10 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(env environs.Environ, idx in
 				info.VLANTag = 0
 			}
 		} else {
-			logger.Infof("host machine device %q has no addresses %v", parentDevice.Name(), parentAddrs)
+			logger.Debugf("host machine device %q has no addresses %v", parentDevice.Name(), parentAddrs)
+			info.ConfigType = network.ConfigDHCP
+			info.ProviderSubnetId = ""
+			info.VLANTag = 0
 		}
 
 		logger.Tracef("prepared info for container interface %q: %+v", info.InterfaceName, info)
@@ -765,10 +768,12 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(env environs.Environ, idx in
 			return err
 		}
 		logger.Debugf("got allocated info from provider: %+v", allocatedInfo)
+	} else {
+		logger.Debugf("using dhcp allocated addresses")
 	}
 
 	allocatedConfig := networkingcommon.NetworkConfigFromInterfaceInfo(allocatedInfo)
-	logger.Tracef("allocated network config: %+v", allocatedConfig)
+	logger.Debugf("allocated network config: %+v", allocatedConfig)
 	ctx.result.Results[idx].Config = allocatedConfig
 	return nil
 }

--- a/container/kvm/libvirt.go
+++ b/container/kvm/libvirt.go
@@ -93,20 +93,18 @@ func CreateMachine(params CreateMachineParams) error {
 	if params.RootDisk != 0 {
 		args = append(args, "--disk", fmt.Sprint(params.RootDisk))
 	}
-	if params.NetworkBridge != "" {
-		if len(params.Interfaces) != 0 {
-			templateDir := filepath.Dir(params.UserDataFile)
+	if len(params.Interfaces) != 0 {
+		templateDir := filepath.Dir(params.UserDataFile)
 
-			templatePath := filepath.Join(templateDir, "kvm-template.xml")
-			err := WriteTemplate(templatePath, params)
-			if err != nil {
-				return errors.Trace(err)
-			}
-
-			args = append(args, "--template", templatePath)
-		} else {
-			args = append(args, "--bridge", params.NetworkBridge)
+		templatePath := filepath.Join(templateDir, "kvm-template.xml")
+		err := WriteTemplate(templatePath, params)
+		if err != nil {
+			return errors.Trace(err)
 		}
+
+		args = append(args, "--template", templatePath)
+	} else if params.NetworkBridge != "" {
+		args = append(args, "--bridge", params.NetworkBridge)
 	}
 
 	args = append(args, params.Hostname)

--- a/container/kvm/template.go
+++ b/container/kvm/template.go
@@ -44,7 +44,7 @@ var kvmTemplate = `
       <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
     </video>
 
-    {{$bridge := .NetworkBridge}}{{range $nic := .Interfaces}}
+    {{range $nic := .Interfaces}}
     <interface type='bridge'>
       <mac address='{{$nic.MACAddress}}'/>
       <model type='virtio'/>

--- a/container/network.go
+++ b/container/network.go
@@ -49,12 +49,3 @@ func BridgeNetworkConfig(device string, mtu int, interfaces []network.InterfaceI
 	}
 	return &NetworkConfig{BridgeNetwork, device, mtu, interfaces}
 }
-
-// PhysicalNetworkConfig returns a valid NetworkConfig to use the
-// specified device as the network device for the container. It also
-// allows passing in specific configuration for the container's
-// network interfaces and default MTU to use. If interfaces is nil the
-// default configuration is used for the respective container type.
-func PhysicalNetworkConfig(device string, mtu int, interfaces []network.InterfaceInfo) *NetworkConfig {
-	return &NetworkConfig{PhysicalNetwork, device, mtu, interfaces}
-}

--- a/worker/provisioner/broker.go
+++ b/worker/provisioner/broker.go
@@ -86,7 +86,6 @@ func prepareHost(bridger network.Bridger, hostMachineID string, containerTag nam
 func prepareOrGetContainerInterfaceInfo(
 	api APICalls,
 	machineID string,
-	bridgeDevice string,
 	allocateOrMaintain bool,
 	log loggo.Logger,
 ) ([]network.InterfaceInfo, error) {

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -71,19 +71,24 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		kvmLogger,
 	)
 	if err != nil {
-		// It's not fatal (yet) if we couldn't pre-allocate addresses for the
-		// container.
-		logger.Warningf("failed to prepare container %q network config: %v", containerMachineID, err)
-	} else {
-		args.NetworkInfo = preparedInfo
+		return nil, errors.Trace(err)
 	}
 
-	network := container.BridgeNetworkConfig(bridgeDevice, 0, args.NetworkInfo)
-	interfaces, err := finishNetworkConfig(bridgeDevice, args.NetworkInfo)
+	// Something to fallback to if there are no devices given in args.NetworkInfo
+	// TODO(jam): 2017-02-07, this feels like something that should never need
+	// to be invoked, because either StartInstance or
+	// prepareOrGetContainerInterfaceInfo should always return a value. The
+	// test suite currently doesn't think so, and I'm hesitant to munge it too
+	// much.
+	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
+	if bridgeDevice == "" {
+		bridgeDevice = container.DefaultKvmBridge
+	}
+	interfaces, err := finishNetworkConfig(bridgeDevice, preparedInfo)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	network.Interfaces = interfaces
+	network := container.BridgeNetworkConfig(bridgeDevice, 0, interfaces)
 
 	// The provisioner worker will provide all tools it knows about
 	// (after applying explicitly specified constraints), which may
@@ -143,17 +148,10 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 func (broker *kvmBroker) MaintainInstance(args environs.StartInstanceParams) error {
 	machineID := args.InstanceConfig.MachineId
 
-	// Default to using the host network until we can configure.
-	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
-	if bridgeDevice == "" {
-		bridgeDevice = container.DefaultKvmBridge
-	}
-
 	// There's no InterfaceInfo we expect to get below.
 	_, err := prepareOrGetContainerInterfaceInfo(
 		broker.api,
 		machineID,
-		bridgeDevice,
 		false, // maintain, do not allocate.
 		kvmLogger,
 	)

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -53,14 +53,6 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	containerMachineID := args.InstanceConfig.MachineId
 	kvmLogger.Infof("starting kvm container for containerMachineID: %s", containerMachineID)
 
-	// TODO: Default to using the host network until we can configure.  Yes,
-	// this is using the LxcBridge value, we should put it in the api call for
-	// container config.
-	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
-	if bridgeDevice == "" {
-		bridgeDevice = container.DefaultKvmBridge
-	}
-
 	config, err := broker.api.ContainerConfig()
 	if err != nil {
 		kvmLogger.Errorf("failed to get container config: %v", err)
@@ -75,7 +67,6 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	preparedInfo, err := prepareOrGetContainerInterfaceInfo(
 		broker.api,
 		containerMachineID,
-		bridgeDevice,
 		true, // allocate if possible, do not maintain existing.
 		kvmLogger,
 	)

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -302,18 +302,8 @@ func (s *kvmBrokerSuite) TestStartInstancePopulatesFallbackNetworkInfo(c *gc.C) 
 		nil, // HostChangesForContainer succeeds
 		errors.NotSupportedf("container address allocation"),
 	)
-	result, err := s.startInstance(c, broker, "1/kvm/2")
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(result.NetworkInfo, jc.DeepEquals, []network.InterfaceInfo{{
-		DeviceIndex:         0,
-		InterfaceName:       "eth0",
-		InterfaceType:       network.EthernetInterface,
-		ConfigType:          network.ConfigDHCP,
-		ParentInterfaceName: "virbr0",
-		DNSServers:          network.NewAddresses("ns1.dummy", "ns2.dummy"),
-		DNSSearchDomains:    []string{"dummy", "invalid"},
-	}})
+	_, err := s.startInstance(c, broker, "1/kvm/2")
+	c.Assert(err, gc.ErrorMatches, "container address allocation not supported")
 }
 
 type kvmProvisionerSuite struct {

--- a/worker/provisioner/lxd-broker_test.go
+++ b/worker/provisioner/lxd-broker_test.go
@@ -204,18 +204,8 @@ func (s *lxdBrokerSuite) TestStartInstancePopulatesFallbackNetworkInfo(c *gc.C) 
 		nil, // HostChangesForContainer succeeds
 		errors.NotSupportedf("container address allocation"),
 	)
-	result, err := s.startInstance(c, broker, "1/lxd/0")
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(result.NetworkInfo, jc.DeepEquals, []network.InterfaceInfo{{
-		DeviceIndex:         0,
-		InterfaceName:       "eth0",
-		InterfaceType:       network.EthernetInterface,
-		ConfigType:          network.ConfigDHCP,
-		ParentInterfaceName: "lxdbr0",
-		DNSServers:          network.NewAddresses("ns1.dummy", "ns2.dummy"),
-		DNSSearchDomains:    []string{"dummy", "invalid"},
-	}})
+	_, err := s.startInstance(c, broker, "1/lxd/0")
+	c.Assert(err, gc.ErrorMatches, "container address allocation not supported")
 }
 
 func (s *lxdBrokerSuite) TestStartInstanceNoHostArchTools(c *gc.C) {


### PR DESCRIPTION
## Description of change

We've had a number of bugs over time about containers ending up on the wrong bridge. One reason for this is that we have code that if there is an error while setting up a container, it falls back to using 'lxdbr0'. It did this because that was the only way to get containers on places where we were unable to ask the provider for extra IP addresses. We've since fixed the code to be more logical about it, and explicitly request 'lxdbr0' instead of falling back to it.

This removes the 'on error fallback' code, and finds one more edge case where the fallback was triggering. Namely on AWS we'll see lxdbr0 but we may not see an IP address on the bridge. Which was causing us to not create a DHCP allocated address for eth0.

## QA steps

This should only really trigger when there is an error, but we should be sure that:
```bash
 $ juju bootstrap aws
 $ juju switch controller
 $ juju deploy ubuntu --to lxd:0
 $ juju status
 $ juju show-machine 0
```

Should show the container come up and get a 10.0.0.* address.

## Documentation changes

Not directly user facing.

## Bug reference

https://pad.lv/1656326
