### PR TITLE
2.1 into develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ tags
 !tags/
 TAGS
 !TAGS/
+parts/
+prime/
+stage/
+*.snap
 .emacs.desktop
 .emacs.desktop.lock
 *.test

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -414,6 +414,34 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleInvalidSeries(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot add unit for application "django": adding new machine to host unit "django/0": cannot assign unit "django/0" to machine 0: series does not match`)
 }
 
+func (s *BundleDeployCharmStoreSuite) TestDeployBundleInvalidBinding(c *gc.C) {
+	testcharms.UploadCharm(c, s.client, "xenial/wordpress-42", "wordpress")
+	_, err := s.DeployBundleYAML(c, `
+        applications:
+            wp:
+                charm: xenial/wordpress-42
+                num_units: 1
+                bindings:
+                  noturl: public
+    `)
+	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot deploy application "wp": invalid binding\(s\) supplied "noturl", valid binding names are "admin-api",.* "url"`)
+}
+
+func (s *BundleDeployCharmStoreSuite) TestDeployBundleInvalidSpace(c *gc.C) {
+	testcharms.UploadCharm(c, s.client, "xenial/wordpress-42", "wordpress")
+	_, err := s.DeployBundleYAML(c, `
+        applications:
+            wp:
+                charm: xenial/wordpress-42
+                num_units: 1
+                bindings:
+                  url: public
+    `)
+	// TODO(jam): 2017-02-05 double repeating "cannot deploy application" and "cannot add application" is a bit ugly
+	// https://pad.lv/1661937
+	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot deploy application "wp": cannot add application "wp": unknown space "public" not valid`)
+}
+
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleWatcherTimeout(c *gc.C) {
 	// Inject an "AllWatcher" that never delivers a result.
 	ch := make(chan struct{})

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1119,6 +1119,7 @@ func (s *DeployCharmStoreSuite) TestDeployCharmWithSomeEndpointBindingsSpecified
 	s.assertDeployedServiceBindings(c, map[string]serviceInfo{
 		"wordpress-extra-bindings": {
 			endpointBindings: map[string]string{
+				"":                "public",
 				"cache":           "public",
 				"url":             "public",
 				"logging-dir":     "public",

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -269,7 +269,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(status.NewStatusHistoryCommand())
 
 	// Error resolution and debugging commands.
-	r.Register(newRunCommand())
+	r.Register(newDefaultRunCommand())
 	r.Register(newSCPCommand(nil))
 	r.Register(newSSHCommand(nil))
 	r.Register(newResolvedCommand())

--- a/cmd/juju/commands/run.go
+++ b/cmd/juju/commands/run.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils"
 	"gopkg.in/juju/names.v2"
 
 	actionapi "github.com/juju/juju/api/action"
@@ -22,24 +23,31 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
-func newRunCommand() cmd.Command {
-	return modelcmd.Wrap(&runCommand{})
+func newDefaultRunCommand() cmd.Command {
+	return newRunCommand(time.After)
+}
+
+func newRunCommand(timeAfter func(time.Duration) <-chan time.Time) cmd.Command {
+	return modelcmd.Wrap(&runCommand{
+		timeAfter: timeAfter,
+	})
 }
 
 // runCommand is responsible for running arbitrary commands on remote machines.
 type runCommand struct {
 	modelcmd.ModelCommandBase
-	out      cmd.Output
-	all      bool
-	timeout  time.Duration
-	machines []string
-	services []string
-	units    []string
-	commands string
+	out       cmd.Output
+	all       bool
+	timeout   time.Duration
+	machines  []string
+	services  []string
+	units     []string
+	commands  string
+	timeAfter func(time.Duration) <-chan time.Time
 }
 
 const runDoc = `
-Run the commands on the specified targets. Only admin users of a model
+Run a shell command on the specified targets. Only admin users of a model
 are able to use this command.
 
 Targets are specified using either machine ids, application names or unit
@@ -67,6 +75,12 @@ targets.
 
 Since juju run creates actions, you can query for the status of commands
 started with juju run by calling "juju show-action-status --name juju-run".
+
+If you need to pass flags to the command being run, you must precede the
+command and its arguments with "--", to tell "juju run" to stop processing
+those arguments. For example:
+
+    juju run --all -- hostname -f
 `
 
 func (c *runCommand) Info() *cmd.Info {
@@ -97,7 +111,16 @@ func (c *runCommand) Init(args []string) error {
 	if len(args) == 0 {
 		return errors.Errorf("no commands specified")
 	}
-	c.commands, args = args[0], args[1:]
+	if len(args) == 1 {
+		// If just one argument is specified, we don't pass it through
+		// utils.CommandString in case it contains multiple arguments
+		// (e.g. juju run --all "sudo whatever"). Passing it through
+		// utils.CommandString would quote the string, which the backend
+		// does not expect.
+		c.commands = args[0]
+	} else {
+		c.commands = utils.CommandString(args...)
+	}
 
 	if c.all {
 		if len(c.machines) != 0 {
@@ -136,7 +159,7 @@ func (c *runCommand) Init(args []string) error {
 			strings.Join(nameErrors, "\n"))
 	}
 
-	return cmd.CheckEmpty(args)
+	return nil
 }
 
 // ConvertActionResults takes the results from the api and creates a map
@@ -250,6 +273,7 @@ func (c *runCommand) Run(ctx *cmd.Context) error {
 		return errors.New("no actions were successfully enqueued, aborting")
 	}
 
+	timeout := c.timeAfter(c.timeout)
 	values := []interface{}{}
 	for len(actionsToQuery) > 0 {
 		actionResults, err := client.Actions(entities(actionsToQuery))
@@ -269,17 +293,28 @@ func (c *runCommand) Run(ctx *cmd.Context) error {
 
 			values = append(values, ConvertActionResults(result, actionsToQuery[i]))
 		}
-
 		actionsToQuery = newActionsToQuery
 
-		// TODO: use a watcher instead of sleeping
-		// this should be easier once we implement action grouping
-		<-afterFunc(1 * time.Second)
+		if len(actionsToQuery) > 0 {
+			var timedOut bool
+			select {
+			case <-timeout:
+				timedOut = true
+			case <-c.timeAfter(1 * time.Second):
+				// TODO(axw) 2017-02-07 #1662451
+				// use a watcher instead of polling.
+				// this should be easier once we implement
+				// action grouping
+			}
+			if timedOut {
+				break
+			}
+		}
 	}
 
 	// If we are just dealing with one result, AND we are using the default
 	// format, then pretend we were running it locally.
-	if len(values) == 1 && c.out.Name() == "default" {
+	if len(actionsToQuery) == 0 && len(values) == 1 && c.out.Name() == "default" {
 		result, ok := values[0].(map[string]interface{})
 		if !ok {
 			return errors.New("couldn't read action output")
@@ -300,7 +335,28 @@ func (c *runCommand) Run(ctx *cmd.Context) error {
 		return nil
 	}
 
-	return c.out.Write(ctx, values)
+	if len(values) > 0 {
+		if err := c.out.Write(ctx, values); err != nil {
+			return err
+		}
+	}
+
+	if n := len(actionsToQuery); n > 0 {
+		// There are action results remaining, so return an error.
+		suffix := ""
+		if n > 1 {
+			suffix = "s"
+		}
+		receivers := make([]string, n)
+		for i, actionToQuery := range actionsToQuery {
+			receivers[i] = names.ReadableString(actionToQuery.receiver.tag)
+		}
+		return errors.Errorf(
+			"timed out waiting for result%s from: %s",
+			suffix, strings.Join(receivers, ", "),
+		)
+	}
+	return nil
 }
 
 type actionReceiver struct {
@@ -333,10 +389,6 @@ var getRunAPIClient = func(c *runCommand) (RunClient, error) {
 // getActionResult abstracts over the action CLI function that we use here to fetch results
 var getActionResult = func(c RunClient, actionId string, wait *time.Timer) (params.ActionResult, error) {
 	return action.GetActionResult(c, actionId, wait)
-}
-
-var afterFunc = func(d time.Duration) <-chan time.Time {
-	return time.After(d)
 }
 
 // entities is a convenience constructor for params.Entities.

--- a/cmd/juju/commands/run_test.go
+++ b/cmd/juju/commands/run_test.go
@@ -10,8 +10,10 @@ import (
 	"time"
 
 	"github.com/juju/cmd"
+	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/clock"
 	"github.com/juju/utils/exec"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -28,6 +30,10 @@ type RunSuite struct {
 }
 
 var _ = gc.Suite(&RunSuite{})
+
+func newTestRunCommand(clock clock.Clock) cmd.Command {
+	return newRunCommand(clock.After)
+}
 
 func (*RunSuite) TestTargetArgParsing(c *gc.C) {
 	for i, test := range []struct {
@@ -47,14 +53,15 @@ func (*RunSuite) TestTargetArgParsing(c *gc.C) {
 		args:     []string{"sudo reboot"},
 		errMatch: "You must specify a target, either through --all, --machine, --application or --unit",
 	}, {
-		message:  "too many args",
-		args:     []string{"--all", "sudo reboot", "oops"},
-		errMatch: `unrecognized args: \["oops"\]`,
-	}, {
 		message:  "command to all machines",
 		args:     []string{"--all", "sudo reboot"},
 		all:      true,
 		commands: "sudo reboot",
+	}, {
+		message:  "multiple args",
+		args:     []string{"--all", "echo", "la lia"},
+		all:      true,
+		commands: `echo "la lia"`,
 	}, {
 		message:  "all and defined machines",
 		args:     []string{"--all", "--machine=1,2", "sudo reboot"},
@@ -258,7 +265,7 @@ func (s *RunSuite) TestRunForMachineAndUnit(c *gc.C) {
 	err := cmd.FormatJson(buff, unformatted)
 	c.Assert(err, jc.ErrorIsNil)
 
-	context, err := testing.RunCommand(c, newRunCommand(),
+	context, err := testing.RunCommand(c, newTestRunCommand(&mockClock{}),
 		"--format=json", "--machine=0", "--unit=unit/0", "hostname",
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -270,7 +277,7 @@ func (s *RunSuite) TestBlockRunForMachineAndUnit(c *gc.C) {
 	mock := s.setupMockAPI()
 	// Block operation
 	mock.block = true
-	_, err := testing.RunCommand(c, newRunCommand(),
+	_, err := testing.RunCommand(c, newTestRunCommand(&mockClock{}),
 		"--format=json", "--machine=0", "--unit=unit/0", "hostname",
 	)
 	testing.AssertOperationWasBlocked(c, err, ".*To enable changes.*")
@@ -318,18 +325,102 @@ func (s *RunSuite) TestAllMachines(c *gc.C) {
 	err := cmd.FormatJson(buff, unformatted)
 	c.Assert(err, jc.ErrorIsNil)
 
-	context, err := testing.RunCommand(c, newRunCommand(), "--format=json", "--all", "hostname")
+	context, err := testing.RunCommand(c, newTestRunCommand(&mockClock{}), "--format=json", "--all", "hostname")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(testing.Stdout(context), gc.Equals, buff.String())
 	c.Check(testing.Stderr(context), gc.Equals, "")
 }
 
+func (s *RunSuite) TestTimeout(c *gc.C) {
+	mock := s.setupMockAPI()
+	mock.setMachinesAlive("0", "1", "2")
+	response0 := mockResponse{
+		stdout:     "megatron\n",
+		machineTag: "machine-0",
+	}
+	response1 := mockResponse{
+		machineTag: "machine-1",
+		status:     params.ActionPending,
+	}
+	response2 := mockResponse{
+		machineTag: "machine-2",
+		status:     params.ActionRunning,
+	}
+	mock.setResponse("0", response0)
+	mock.setResponse("1", response1)
+	mock.setResponse("2", response2)
+
+	machine0Result := mock.runResponses["0"]
+	machine1Result := mock.runResponses["1"]
+	machine2Result := mock.runResponses["1"]
+	mock.actionResponses = map[string]params.ActionResult{
+		mock.receiverIdMap["0"]: machine0Result,
+		mock.receiverIdMap["1"]: machine1Result,
+		mock.receiverIdMap["2"]: machine2Result,
+	}
+
+	machine0Query := makeActionQuery(mock.receiverIdMap["0"], "MachineId", names.NewMachineTag("0"))
+
+	var buf bytes.Buffer
+	err := cmd.FormatJson(&buf, []interface{}{
+		ConvertActionResults(machine0Result, machine0Query),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	var clock mockClock
+	context, err := testing.RunCommand(
+		c, newTestRunCommand(&clock),
+		"--format=json", "--all", "hostname", "--timeout", "99s",
+	)
+	c.Assert(err, gc.ErrorMatches, "timed out waiting for results from: machine 1, machine 2")
+
+	c.Check(testing.Stdout(context), gc.Equals, buf.String())
+	c.Check(testing.Stderr(context), gc.Equals, "")
+	clock.CheckCalls(c, []gitjujutesting.StubCall{
+		{"After", []interface{}{99 * time.Second}},
+		{"After", []interface{}{1 * time.Second}},
+		{"After", []interface{}{1 * time.Second}},
+	})
+}
+
+type mockClock struct {
+	gitjujutesting.Stub
+	clock.Clock
+	timeoutCh chan time.Time
+}
+
+func (c *mockClock) After(d time.Duration) <-chan time.Time {
+	c.MethodCall(c, "After", d)
+	ch := make(chan time.Time)
+	if d == time.Second {
+		// This is a sleepy sleep call, while we're waiting
+		// for actions to be run. We simulate sleeping a
+		// couple of times, and then close the timeout
+		// channel.
+		if len(c.Calls()) >= 3 {
+			close(c.timeoutCh)
+		} else {
+			close(ch)
+		}
+	} else {
+		// This is the initial time.After call for the timeout.
+		// Once we've gone through the loop waiting for results
+		// a couple of times, we'll close this to indicate that
+		// a timeout occurred.
+		if c.timeoutCh != nil {
+			panic("time.After called for timeout multiple times")
+		}
+		c.timeoutCh = ch
+	}
+	return ch
+}
+
 func (s *RunSuite) TestBlockAllMachines(c *gc.C) {
 	mock := s.setupMockAPI()
 	// Block operation
 	mock.block = true
-	_, err := testing.RunCommand(c, newRunCommand(), "--format=json", "--all", "hostname")
+	_, err := testing.RunCommand(c, newTestRunCommand(&mockClock{}), "--format=json", "--all", "hostname")
 	testing.AssertOperationWasBlocked(c, err, ".*To enable changes.*")
 }
 
@@ -388,7 +479,7 @@ func (s *RunSuite) TestSingleResponse(c *gc.C) {
 			args = append(args, "--format", test.format)
 		}
 		args = append(args, "--all", "ignored")
-		context, err := testing.RunCommand(c, newRunCommand(), args...)
+		context, err := testing.RunCommand(c, newTestRunCommand(&mockClock{}), args...)
 		if test.errorMatch != "" {
 			c.Check(err, gc.ErrorMatches, test.errorMatch)
 		} else {
@@ -428,6 +519,7 @@ type mockResponse struct {
 	message    string
 	machineTag string
 	unitTag    string
+	status     string
 }
 
 var _ RunClient = (*mockRunAPI)(nil)
@@ -467,6 +559,7 @@ func makeActionResult(mock mockResponse, actionTag string) params.ActionResult {
 			Receiver: receiverTag,
 		},
 		Message: mock.message,
+		Status:  mock.status,
 		Error:   mock.error,
 		Output: map[string]interface{}{
 			"Stdout": mock.stdout,

--- a/cmd/juju/controller/getconfig_test.go
+++ b/cmd/juju/controller/getconfig_test.go
@@ -44,11 +44,11 @@ func (s *GetConfigSuite) TestInit(c *gc.C) {
 }
 
 func (s *GetConfigSuite) TestSingleValue(c *gc.C) {
-	context, err := s.run(c, "controller-uuid")
+	context, err := s.run(c, "ca-cert")
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := strings.TrimSpace(testing.Stdout(context))
-	c.Assert(output, gc.Equals, "uuid")
+	c.Assert(output, gc.Equals, "multi\nline")
 }
 
 func (s *GetConfigSuite) TestSingleValueJSON(c *gc.C) {
@@ -64,9 +64,13 @@ func (s *GetConfigSuite) TestAllValues(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := strings.TrimSpace(testing.Stdout(context))
-	expected := "" +
-		"api-port: 1234\n" +
-		"controller-uuid: uuid"
+	expected := `
+Attribute  Value
+api-port   1234
+ca-cert    |-
+  multi
+  line
+controller-uuid  uuid`[1:]
 	c.Assert(output, gc.Equals, expected)
 }
 
@@ -75,7 +79,7 @@ func (s *GetConfigSuite) TestAllValuesJSON(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := strings.TrimSpace(testing.Stdout(context))
-	expected := `{"api-port":1234,"controller-uuid":"uuid"}`
+	expected := `{"api-port":1234,"ca-cert":"multi\nline","controller-uuid":"uuid"}`
 	c.Assert(output, gc.Equals, expected)
 }
 
@@ -100,5 +104,6 @@ func (f *fakeControllerAPI) ControllerConfig() (jujucontroller.Config, error) {
 	return map[string]interface{}{
 		"controller-uuid": "uuid",
 		"api-port":        1234,
+		"ca-cert":         "multi\nline",
 	}, nil
 }

--- a/cmd/juju/model/configcommand.go
+++ b/cmd/juju/model/configcommand.go
@@ -289,7 +289,14 @@ func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) err
 		key := c.keys[0]
 		if value, found := attrs[key]; found {
 			if c.out.Name() == "tabular" {
-				return cmd.FormatYaml(ctx.Stdout, value.Value)
+				// The user has not specified that they want
+				// YAML or JSON formatting, so we print out
+				// the value unadorned.
+				return c.out.WriteFormatter(
+					ctx,
+					cmd.FormatSmart,
+					value.Value,
+				)
 			}
 			attrs = config.ConfigValues{
 				key: config.ConfigValue{

--- a/cmd/juju/model/configcommand_test.go
+++ b/cmd/juju/model/configcommand_test.go
@@ -3,6 +3,9 @@
 package model_test
 
 import (
+	"io/ioutil"
+	"path/filepath"
+
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -91,11 +94,25 @@ func (s *ConfigCommandSuite) TestInit(c *gc.C) {
 }
 
 func (s *ConfigCommandSuite) TestSingleValue(c *gc.C) {
+	s.fake.values["special"] = "multi\nline"
+
 	context, err := s.run(c, "special")
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := testing.Stdout(context)
-	c.Assert(output, gc.Equals, "special value\n")
+	c.Assert(output, gc.Equals, "multi\nline\n")
+}
+
+func (s *ConfigCommandSuite) TestSingleValueOutputFile(c *gc.C) {
+	s.fake.values["special"] = "multi\nline"
+
+	outpath := filepath.Join(c.MkDir(), "out")
+	_, err := s.run(c, "--output", outpath, "special")
+	c.Assert(err, jc.ErrorIsNil)
+
+	output, err := ioutil.ReadFile(outpath)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(output), gc.Equals, "multi\nline\n")
 }
 
 func (s *ConfigCommandSuite) TestGetUnknownValue(c *gc.C) {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -20,7 +20,7 @@ github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24
 github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07T23:45:32Z
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	7725027b95e0d54635e0fb11efc2debdcdf19f75	2016-12-15T16:06:52Z
-github.com/juju/cmd	git	1c6973d59b804e4d3c293fbf240f067e73436bc9	2016-08-23T10:31:14Z
+github.com/juju/cmd	git	0f05ac592d6925a1b8ca0f77524d3348fafa66cc	2017-02-07T03:13:09Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/jsonschema	git	a0ef8b74ebcffeeff9fc374854deb4af388f037e	2016-11-02T18:19:19Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z

--- a/juju/deploy_test.go
+++ b/juju/deploy_test.go
@@ -54,16 +54,16 @@ func (s *DeployLocalSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployMinimal(c *gc.C) {
-	service, err := juju.DeployApplication(s.State,
+	app, err := juju.DeployApplication(s.State,
 		juju.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertCharm(c, service, s.charm.URL())
-	s.assertSettings(c, service, charm.Settings{})
-	s.assertConstraints(c, service, constraints.Value{})
-	s.assertMachines(c, service, constraints.Value{})
+	s.assertCharm(c, app, s.charm.URL())
+	s.assertSettings(c, app, charm.Settings{})
+	s.assertConstraints(c, app, constraints.Value{})
+	s.assertMachines(c, app, constraints.Value{})
 }
 
 func (s *DeployLocalSuite) TestDeploySeries(c *gc.C) {
@@ -85,7 +85,7 @@ func (s *DeployLocalSuite) TestDeploySeries(c *gc.C) {
 func (s *DeployLocalSuite) TestDeployWithImplicitBindings(c *gc.C) {
 	wordpressCharm := s.addWordpressCharmWithExtraBindings(c)
 
-	service, err := juju.DeployApplication(s.State,
+	app, err := juju.DeployApplication(s.State,
 		juju.DeployApplicationParams{
 			ApplicationName:  "bob",
 			Charm:            wordpressCharm,
@@ -93,7 +93,7 @@ func (s *DeployLocalSuite) TestDeployWithImplicitBindings(c *gc.C) {
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertBindings(c, service, map[string]string{
+	s.assertBindings(c, app, map[string]string{
 		// relation names
 		"url":             "",
 		"logging-dir":     "",
@@ -124,8 +124,8 @@ func (s *DeployLocalSuite) addWordpressCharmFromURL(c *gc.C, charmURL *charm.URL
 	return wordpressCharm
 }
 
-func (s *DeployLocalSuite) assertBindings(c *gc.C, service *state.Application, expected map[string]string) {
-	bindings, err := service.EndpointBindings()
+func (s *DeployLocalSuite) assertBindings(c *gc.C, app *state.Application, expected map[string]string) {
+	bindings, err := app.EndpointBindings()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(bindings, jc.DeepEquals, expected)
 }
@@ -137,7 +137,7 @@ func (s *DeployLocalSuite) TestDeployWithSomeSpecifiedBindings(c *gc.C) {
 	_, err = s.State.AddSpace("public", "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	service, err := juju.DeployApplication(s.State,
+	app, err := juju.DeployApplication(s.State,
 		juju.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           wordpressCharm,
@@ -148,7 +148,9 @@ func (s *DeployLocalSuite) TestDeployWithSomeSpecifiedBindings(c *gc.C) {
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertBindings(c, service, map[string]string{
+	s.assertBindings(c, app, map[string]string{
+		// default binding
+		"": "public",
 		// relation names
 		"url":             "public",
 		"logging-dir":     "public",
@@ -171,7 +173,7 @@ func (s *DeployLocalSuite) TestDeployWithBoundRelationNamesAndExtraBindingsNames
 	_, err = s.State.AddSpace("internal", "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	service, err := juju.DeployApplication(s.State,
+	app, err := juju.DeployApplication(s.State,
 		juju.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           wordpressCharm,
@@ -184,7 +186,8 @@ func (s *DeployLocalSuite) TestDeployWithBoundRelationNamesAndExtraBindingsNames
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertBindings(c, service, map[string]string{
+	s.assertBindings(c, app, map[string]string{
+		"":                "public",
 		"url":             "public",
 		"logging-dir":     "public",
 		"monitoring-port": "public",
@@ -195,6 +198,61 @@ func (s *DeployLocalSuite) TestDeployWithBoundRelationNamesAndExtraBindingsNames
 		"cluster":         "public",
 		"foo-bar":         "public", // like for relations, uses the application-default.
 	})
+
+}
+
+func (s *DeployLocalSuite) TestDeployWithInvalidSpace(c *gc.C) {
+	wordpressCharm := s.addWordpressCharm(c)
+	_, err := s.State.AddSpace("db", "", nil, false)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSpace("public", "", nil, false)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSpace("internal", "", nil, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	app, err := juju.DeployApplication(s.State,
+		juju.DeployApplicationParams{
+			ApplicationName: "bob",
+			Charm:           wordpressCharm,
+			EndpointBindings: map[string]string{
+				"":   "public",
+				"db": "intranel", //typo 'intranel'
+			},
+		})
+	c.Assert(err, gc.ErrorMatches, `cannot add application "bob": unknown space "intranel" not valid`)
+	c.Check(app, gc.IsNil)
+	// The application should not have been added
+	_, err = s.State.Application("bob")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+}
+
+func (s *DeployLocalSuite) TestDeployWithInvalidBinding(c *gc.C) {
+	wordpressCharm := s.addWordpressCharm(c)
+	_, err := s.State.AddSpace("db", "", nil, false)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSpace("public", "", nil, false)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSpace("internal", "", nil, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	app, err := juju.DeployApplication(s.State,
+		juju.DeployApplicationParams{
+			ApplicationName: "bob",
+			Charm:           wordpressCharm,
+			EndpointBindings: map[string]string{
+				"":      "public",
+				"bd":    "internal", // typo 'bd'
+				"pubic": "public",   // typo 'pubic'
+			},
+		})
+	c.Assert(err, gc.ErrorMatches,
+		`invalid binding\(s\) supplied "bd", "pubic", valid binding names are "admin-api", .* "url"`)
+	c.Check(app, gc.IsNil)
+	// The application should not have been added
+	_, err = s.State.Application("bob")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
 }
 
 func (s *DeployLocalSuite) TestDeployResources(c *gc.C) {
@@ -205,8 +263,7 @@ func (s *DeployLocalSuite) TestDeployResources(c *gc.C) {
 			ApplicationName: "bob",
 			Charm:           s.charm,
 			EndpointBindings: map[string]string{
-				"":   "public",
-				"db": "db",
+				"": "public",
 			},
 			Resources: map[string]string{"foo": "bar"},
 		})
@@ -218,7 +275,7 @@ func (s *DeployLocalSuite) TestDeployResources(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeploySettings(c *gc.C) {
-	service, err := juju.DeployApplication(s.State,
+	app, err := juju.DeployApplication(s.State,
 		juju.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
@@ -228,7 +285,7 @@ func (s *DeployLocalSuite) TestDeploySettings(c *gc.C) {
 			},
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertSettings(c, service, charm.Settings{
+	s.assertSettings(c, app, charm.Settings{
 		"title":       "banana cupcakes",
 		"skill-level": int64(9901),
 	})
@@ -252,14 +309,14 @@ func (s *DeployLocalSuite) TestDeployConstraints(c *gc.C) {
 	err := s.State.SetModelConstraints(constraints.MustParse("mem=2G"))
 	c.Assert(err, jc.ErrorIsNil)
 	serviceCons := constraints.MustParse("cores=2")
-	service, err := juju.DeployApplication(s.State,
+	app, err := juju.DeployApplication(s.State,
 		juju.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
 			Constraints:     serviceCons,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertConstraints(c, service, serviceCons)
+	s.assertConstraints(c, app, serviceCons)
 }
 
 func (s *DeployLocalSuite) TestDeployNumUnits(c *gc.C) {
@@ -381,26 +438,26 @@ func (s *DeployLocalSuite) assertAssignedUnit(c *gc.C, u *state.Unit, mId string
 	c.Assert(machineCons, gc.DeepEquals, cons)
 }
 
-func (s *DeployLocalSuite) assertCharm(c *gc.C, service *state.Application, expect *charm.URL) {
-	curl, force := service.CharmURL()
+func (s *DeployLocalSuite) assertCharm(c *gc.C, app *state.Application, expect *charm.URL) {
+	curl, force := app.CharmURL()
 	c.Assert(curl, gc.DeepEquals, expect)
 	c.Assert(force, jc.IsFalse)
 }
 
-func (s *DeployLocalSuite) assertSettings(c *gc.C, service *state.Application, expect charm.Settings) {
-	settings, err := service.ConfigSettings()
+func (s *DeployLocalSuite) assertSettings(c *gc.C, app *state.Application, expect charm.Settings) {
+	settings, err := app.ConfigSettings()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settings, gc.DeepEquals, expect)
 }
 
-func (s *DeployLocalSuite) assertConstraints(c *gc.C, service *state.Application, expect constraints.Value) {
-	cons, err := service.Constraints()
+func (s *DeployLocalSuite) assertConstraints(c *gc.C, app *state.Application, expect constraints.Value) {
+	cons, err := app.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cons, gc.DeepEquals, expect)
 }
 
-func (s *DeployLocalSuite) assertMachines(c *gc.C, service *state.Application, expectCons constraints.Value, expectIds ...string) {
-	units, err := service.AllUnits()
+func (s *DeployLocalSuite) assertMachines(c *gc.C, app *state.Application, expectCons constraints.Value, expectIds ...string) {
+	units, err := app.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, len(expectIds))
 	// first manually tell state to assign all the units
@@ -413,7 +470,7 @@ func (s *DeployLocalSuite) assertMachines(c *gc.C, service *state.Application, e
 	}
 
 	// refresh the list of units from state
-	units, err = service.AllUnits()
+	units, err = app.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, len(expectIds))
 	unseenIds := set.NewStrings(expectIds...)

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -363,7 +363,7 @@ Values set as per mongod recommendation (see syslog on default mongod run)
 /sys/kernel/mm/transparent_hugepage/enabled 'always' > 'never'
 /sys/kernel/mm/transparent_hugepage/defrag 'always' > 'never'
 */
-var editableSysctlFiles = map[string]string{
+var mongoKernelTweaks = map[string]string{
 	"/sys/kernel/mm/transparent_hugepage/enabled": "never",
 	"/sys/kernel/mm/transparent_hugepage/defrag":  "never",
 	"/proc/sys/net/ipv4/tcp_max_syn_backlog":      "4096",
@@ -454,11 +454,11 @@ type EnsureServerParams struct {
 // This method will remove old versions of the mongo init service as necessary
 // before installing the new version.
 func EnsureServer(args EnsureServerParams) error {
-	return ensureServer(args, editableSysctlFiles)
+	return ensureServer(args, mongoKernelTweaks)
 }
 
-func ensureServer(args EnsureServerParams, sysctlFiles map[string]string) error {
-	tweakSysctlForMongo(sysctlFiles)
+func ensureServer(args EnsureServerParams, mongoKernelTweaks map[string]string) error {
+	tweakSysctlForMongo(mongoKernelTweaks)
 	logger.Infof(
 		"Ensuring mongo server is running; data directory %s; port %d",
 		args.DataDir, args.StatePort,

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -261,7 +261,7 @@ func (s *MongoSuite) TestEnsureServerServerExistsAndRunning(c *gc.C) {
 
 func (s *MongoSuite) TestEnsureServerSetsSysctlValues(c *gc.C) {
 	dataDir := c.MkDir()
-	dataFilePath := filepath.Join(dataDir, "editablesysctlfile")
+	dataFilePath := filepath.Join(dataDir, "mongoKernelTweaks")
 	dataFile, err := os.Create(dataFilePath)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = dataFile.WriteString("original value")

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -607,6 +607,7 @@ func (env *azureEnviron) createVirtualMachine(
 	osProfile, seriesOS, err := newOSProfile(
 		vmName, instanceConfig,
 		env.provider.config.RandomWindowsAdminPassword,
+		env.provider.config.GenerateSSHKey,
 	)
 	if err != nil {
 		return errors.Annotate(err, "creating OS profile")
@@ -940,6 +941,7 @@ func newOSProfile(
 	vmName string,
 	instanceConfig *instancecfg.InstanceConfig,
 	randomAdminPassword func() string,
+	generateSSHKey func(string) (string, string, error),
 ) (*compute.OSProfile, os.OSType, error) {
 	logger.Debugf("creating OS profile for %q", vmName)
 
@@ -962,9 +964,24 @@ func newOSProfile(
 		// SSH keys are handled by custom data, but must also be
 		// specified in order to forego providing a password, and
 		// disable password authentication.
+		authorizedKeys := instanceConfig.AuthorizedKeys
+		if len(authorizedKeys) == 0 {
+			// Azure requires that machines be provisioned with
+			// either a password or at least one SSH key. We
+			// generate a key-pair to make Azure happy, but throw
+			// away the private key so that nobody will be able
+			// to log into the machine directly unless the keys
+			// are updated with one that Juju tracks.
+			_, public, err := generateSSHKey("")
+			if err != nil {
+				return nil, os.Unknown, errors.Trace(err)
+			}
+			authorizedKeys = public
+		}
+
 		publicKeys := []compute.SSHPublicKey{{
 			Path:    to.StringPtr("/home/ubuntu/.ssh/authorized_keys"),
-			KeyData: to.StringPtr(instanceConfig.AuthorizedKeys),
+			KeyData: to.StringPtr(authorizedKeys),
 		}}
 		osProfile.AdminUsername = to.StringPtr("ubuntu")
 		osProfile.LinuxConfiguration = &compute.LinuxConfiguration{

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -72,21 +72,6 @@ var (
 		Version:   to.StringPtr("latest"),
 	}
 
-	sshPublicKeys = []compute.SSHPublicKey{{
-		Path:    to.StringPtr("/home/ubuntu/.ssh/authorized_keys"),
-		KeyData: to.StringPtr(testing.FakeAuthKeys),
-	}}
-	linuxOsProfile = compute.OSProfile{
-		ComputerName:  to.StringPtr("machine-0"),
-		CustomData:    to.StringPtr("<juju-goes-here>"),
-		AdminUsername: to.StringPtr("ubuntu"),
-		LinuxConfiguration: &compute.LinuxConfiguration{
-			DisablePasswordAuthentication: to.BoolPtr(true),
-			SSH: &compute.SSHConfiguration{
-				PublicKeys: &sshPublicKeys,
-			},
-		},
-	}
 	windowsOsProfile = compute.OSProfile{
 		ComputerName:  to.StringPtr("machine-0"),
 		CustomData:    to.StringPtr("<juju-goes-here>"),
@@ -119,6 +104,8 @@ type environSuite struct {
 	ubuntuServerSKUs   []compute.VirtualMachineImageResource
 	commonDeployment   *resources.DeploymentExtended
 	deployment         *resources.Deployment
+	sshPublicKeys      []compute.SSHPublicKey
+	linuxOsProfile     compute.OSProfile
 }
 
 var _ = gc.Suite(&environSuite{})
@@ -221,6 +208,22 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.deployment = nil
+
+	s.sshPublicKeys = []compute.SSHPublicKey{{
+		Path:    to.StringPtr("/home/ubuntu/.ssh/authorized_keys"),
+		KeyData: to.StringPtr(testing.FakeAuthKeys),
+	}}
+	s.linuxOsProfile = compute.OSProfile{
+		ComputerName:  to.StringPtr("machine-0"),
+		CustomData:    to.StringPtr("<juju-goes-here>"),
+		AdminUsername: to.StringPtr("ubuntu"),
+		LinuxConfiguration: &compute.LinuxConfiguration{
+			DisablePasswordAuthentication: to.BoolPtr(true),
+			SSH: &compute.SSHConfiguration{
+				PublicKeys: &s.sshPublicKeys,
+			},
+		},
+	}
 }
 
 func (s *environSuite) openEnviron(c *gc.C, attrs ...testing.Attrs) environs.Environ {
@@ -489,7 +492,31 @@ func (s *environSuite) TestStartInstance(c *gc.C) {
 	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
 		imageReference: &quantalImageReference,
 		diskSizeGB:     32,
-		osProfile:      &linuxOsProfile,
+		osProfile:      &s.linuxOsProfile,
+		instanceType:   "Standard_A1",
+	})
+}
+
+func (s *environSuite) TestStartInstanceNoAuthorizedKeys(c *gc.C) {
+	env := s.openEnviron(c)
+	cfg, err := env.Config().Remove([]string{"authorized-keys"})
+	c.Assert(err, jc.ErrorIsNil)
+	err = env.SetConfig(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.sender = s.startInstanceSenders(false)
+	s.requests = nil
+	_, err = env.StartInstance(makeStartInstanceParams(c, s.controllerUUID, "quantal"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.PatchValue(&s.sshPublicKeys, []compute.SSHPublicKey{{
+		Path:    to.StringPtr("/home/ubuntu/.ssh/authorized_keys"),
+		KeyData: to.StringPtr("public"),
+	}})
+	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
+		imageReference: &quantalImageReference,
+		diskSizeGB:     32,
+		osProfile:      &s.linuxOsProfile,
 		instanceType:   "Standard_A1",
 	})
 }
@@ -568,7 +595,7 @@ func (s *environSuite) TestStartInstanceCentOS(c *gc.C) {
 			AutoUpgradeMinorVersion: to.BoolPtr(true),
 			Settings:                &vmExtensionSettings,
 		},
-		osProfile:    &linuxOsProfile,
+		osProfile:    &s.linuxOsProfile,
 		instanceType: "Standard_A1",
 	})
 }
@@ -604,7 +631,7 @@ func (s *environSuite) TestStartInstanceTooManyRequests(c *gc.C) {
 	s.assertStartInstanceRequests(c, s.requests[:numExpectedStartInstanceRequests], assertStartInstanceRequestsParams{
 		imageReference: &quantalImageReference,
 		diskSizeGB:     32,
-		osProfile:      &linuxOsProfile,
+		osProfile:      &s.linuxOsProfile,
 		instanceType:   "Standard_A1",
 	})
 
@@ -734,7 +761,7 @@ func (s *environSuite) TestStartInstanceServiceAvailabilitySet(c *gc.C) {
 		availabilitySetName: "mysql",
 		imageReference:      &quantalImageReference,
 		diskSizeGB:          32,
-		osProfile:           &linuxOsProfile,
+		osProfile:           &s.linuxOsProfile,
 		instanceType:        "Standard_A1",
 	})
 }
@@ -1078,7 +1105,7 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 		availabilitySetName: "juju-controller",
 		imageReference:      &quantalImageReference,
 		diskSizeGB:          32,
-		osProfile:           &linuxOsProfile,
+		osProfile:           &s.linuxOsProfile,
 		instanceType:        "Standard_D1",
 	})
 }
@@ -1127,7 +1154,7 @@ func (s *environSuite) TestBootstrapInstanceConstraints(c *gc.C) {
 		availabilitySetName: "juju-controller",
 		imageReference:      &quantalImageReference,
 		diskSizeGB:          32,
-		osProfile:           &linuxOsProfile,
+		osProfile:           &s.linuxOsProfile,
 		needsProviderInit:   true,
 		instanceType:        "Standard_D1",
 	})

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -41,6 +41,10 @@ type ProviderConfig struct {
 	// a random password for the Windows admin user.
 	RandomWindowsAdminPassword func() string
 
+	// GneerateSSHKey is a functio nused to generate a new SSH
+	// key pair for provisioning Linux machines.
+	GenerateSSHKey func(comment string) (private, public string, _ error)
+
 	// InteractiveCreateServicePrincipal is a function used to
 	// interactively create/update service principals with
 	// password credentials.
@@ -57,6 +61,9 @@ func (cfg ProviderConfig) Validate() error {
 	}
 	if cfg.RandomWindowsAdminPassword == nil {
 		return errors.NotValidf("nil RandomWindowsAdminPassword")
+	}
+	if cfg.GenerateSSHKey == nil {
+		return errors.NotValidf("nil GenerateSSHKey")
 	}
 	if cfg.InteractiveCreateServicePrincipal == nil {
 		return errors.NotValidf("nil InteractiveCreateServicePrincipal")

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -112,6 +112,9 @@ func newProvider(c *gc.C, config azure.ProviderConfig) environs.EnvironProvider 
 		config.InteractiveCreateServicePrincipal = azureauth.InteractiveCreateServicePrincipal
 	}
 	config.RandomWindowsAdminPassword = func() string { return "sorandom" }
+	config.GenerateSSHKey = func(string) (string, string, error) {
+		return "private", "public", nil
+	}
 	environProvider, err := azure.NewProvider(config)
 	c.Assert(err, jc.ErrorIsNil)
 	return environProvider

--- a/provider/azure/init.go
+++ b/provider/azure/init.go
@@ -6,6 +6,7 @@ package azure
 import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/clock"
+	"github.com/juju/utils/ssh"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/azure/internal/azureauth"
@@ -31,6 +32,7 @@ func init() {
 		NewStorageClient:                  azurestorage.NewClient,
 		RetryClock:                        &clock.WallClock,
 		RandomWindowsAdminPassword:        randomAdminPassword,
+		GenerateSSHKey:                    ssh.GenerateKey,
 		InteractiveCreateServicePrincipal: azureauth.InteractiveCreateServicePrincipal,
 	})
 	if err != nil {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1385,12 +1385,12 @@ func (t *localServerSuite) TestInstanceInformation(c *gc.C) {
 	env := t.prepareEnviron(c)
 	types, err := env.InstanceTypes(constraints.Value{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(types.InstanceTypes, gc.HasLen, 45)
+	c.Assert(types.InstanceTypes, gc.HasLen, 53)
 
 	cons := constraints.MustParse("mem=4G")
 	types, err = env.InstanceTypes(cons)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(types.InstanceTypes, gc.HasLen, 40)
+	c.Assert(types.InstanceTypes, gc.HasLen, 48)
 }
 
 func validateSubnets(c *gc.C, subnets []network.SubnetInfo) {

--- a/state/endpoint_bindings.go
+++ b/state/endpoint_bindings.go
@@ -261,7 +261,7 @@ func validateEndpointBindingsForCharm(st *State, bindings map[string]string, cha
 	// in bindings. In follow-up, this will be enforced by using refcounts on
 	// spaces.
 	for endpoint, space := range bindings {
-		if !endpointsNamesSet.Contains(endpoint) {
+		if endpoint != "" && !endpointsNamesSet.Contains(endpoint) {
 			return errors.NotValidf("unknown endpoint %q", endpoint)
 		}
 		if space != "" && !spacesNamesSet.Contains(space) {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1597,11 +1597,7 @@ func (s *StateSuite) TestAddServiceWithInvalidBindings(c *gc.C) {
 	}, {
 		about:         "empty endpoint bound to unknown space",
 		bindings:      map[string]string{"": "anything"},
-		expectedError: `unknown endpoint "" not valid`,
-	}, {
-		about:         "empty endpoint not bound to a space",
-		bindings:      map[string]string{"": ""},
-		expectedError: `unknown endpoint "" not valid`,
+		expectedError: `unknown space "anything" not valid`,
 	}, {
 		about:         "known endpoint bound to unknown space",
 		bindings:      map[string]string{"server": "invalid"},


### PR DESCRIPTION
Merge recent changes to 2.1 into develop. Brings in:

- Ignore snap artifacts
- Strict binding names (refuse deploy if binding an unknown endpoint)
- Azure fixes for empty authorized-keys
- Decrease log level for x509 certificate errors
- Add AWS instance types
- Add sysctl values for mongo configuration
- Honor 'juju run --timeout'
- Fix IPv6 discovery for containers
- Fix Model listing for administrators