### PR TITLE
Add missing GCE regions

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -56,9 +56,13 @@ clouds:
         endpoint: https://www.googleapis.com
       us-central1:
         endpoint: https://www.googleapis.com
+      us-west1:
+        endpoint: https://www.googleapis.com
       europe-west1:
         endpoint: https://www.googleapis.com
       asia-east1:
+        endpoint: https://www.googleapis.com
+      asia-northeast1:
         endpoint: https://www.googleapis.com
   azure:
     type: azure

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -63,9 +63,13 @@ clouds:
         endpoint: https://www.googleapis.com
       us-central1:
         endpoint: https://www.googleapis.com
+      us-west1:
+        endpoint: https://www.googleapis.com
       europe-west1:
         endpoint: https://www.googleapis.com
       asia-east1:
+        endpoint: https://www.googleapis.com
+      asia-northeast1:
         endpoint: https://www.googleapis.com
   azure:
     type: azure

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -89,6 +89,41 @@ sa-east-1:
 `[1:])
 }
 
+func (s *regionsSuite) TestListGCERegions(c *gc.C) {
+	ctx, err := testing.RunCommand(c, cloud.NewListRegionsCommand(), "google")
+	c.Assert(err, jc.ErrorIsNil)
+	out := testing.Stdout(ctx)
+	c.Assert(out, jc.DeepEquals, `
+us-east1
+us-central1
+us-west1
+europe-west1
+asia-east1
+asia-northeast1
+
+`[1:])
+}
+
+func (s *regionsSuite) TestListGCERegionsYaml(c *gc.C) {
+	ctx, err := testing.RunCommand(c, cloud.NewListRegionsCommand(), "google", "--format", "yaml")
+	c.Assert(err, jc.ErrorIsNil)
+	out := testing.Stdout(ctx)
+	c.Assert(out, jc.DeepEquals, `
+us-east1:
+  endpoint: https://www.googleapis.com
+us-central1:
+  endpoint: https://www.googleapis.com
+us-west1:
+  endpoint: https://www.googleapis.com
+europe-west1:
+  endpoint: https://www.googleapis.com
+asia-east1:
+  endpoint: https://www.googleapis.com
+asia-northeast1:
+  endpoint: https://www.googleapis.com
+`[1:])
+}
+
 type regionDetails struct {
 	Endpoint         string `json:"endpoint"`
 	IdentityEndpoint string `json:"identity-endpoint"`


### PR DESCRIPTION
## Description of change

This PR adds the US West  and Asia Northeast regions to GCE.

Why is this change needed?
Because they are newish and missing. 

## QA steps
1. run the unit tests. ($juju/cloud & $JUJU/cmd/juju/cloud specifically changed)

How do we verify that the change works?
Get validation from QA

## Documentation changes
N/A 
Does it affect current user workflow? CLI? API?
No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1662449

