### PR TITLE
WatchAllModels now gets passed a state pool

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -54,7 +54,7 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 	}
 
 	// apiRoot is the API root exposed to the client after authentication.
-	var apiRoot rpc.Root = newAPIRoot(a.root.state, a.root.resources, a.root)
+	var apiRoot rpc.Root = newAPIRoot(a.root.state, a.srv.statePool, a.root.resources, a.root)
 
 	// Use the login validation function, if one was specified.
 	if a.srv.validator != nil {

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/controller"
+	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/instance"
@@ -44,7 +45,12 @@ func (s *modelStatusSuite) SetUpTest(c *gc.C) {
 		AdminTag: s.Owner,
 	}
 
-	controller, err := controller.NewControllerAPI(s.State, s.resources, s.authorizer)
+	controller, err := controller.NewControllerAPI(
+		facadetest.Context{
+			State_:     s.State,
+			Resources_: s.resources,
+			Auth_:      s.authorizer,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	s.controller = controller
 
@@ -57,7 +63,12 @@ func (s *modelStatusSuite) TestModelStatusNonAuth(c *gc.C) {
 	anAuthoriser := apiservertesting.FakeAuthorizer{
 		Tag: user.Tag(),
 	}
-	endpoint, err := controller.NewControllerAPI(s.State, s.resources, anAuthoriser)
+	endpoint, err := controller.NewControllerAPI(
+		facadetest.Context{
+			State_:     s.State,
+			Resources_: s.resources,
+			Auth_:      anAuthoriser,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	controllerModelTag := s.State.ModelTag().String()
 
@@ -76,7 +87,12 @@ func (s *modelStatusSuite) TestModelStatusOwnerAllowed(c *gc.C) {
 	}
 	st := s.Factory.MakeModel(c, &factory.ModelParams{Owner: owner.Tag()})
 	defer st.Close()
-	endpoint, err := controller.NewControllerAPI(s.State, s.resources, anAuthoriser)
+	endpoint, err := controller.NewControllerAPI(
+		facadetest.Context{
+			State_:     s.State,
+			Resources_: s.resources,
+			Auth_:      anAuthoriser,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 
 	req := params.Entities{

--- a/apiserver/common/registry.go
+++ b/apiserver/common/registry.go
@@ -49,30 +49,50 @@ func RegisterFacadeForFeature(name string, version int, factory facade.Factory, 
 
 // validateNewFacade ensures that the facade factory we have has the right
 // input and output parameters for being used as a NewFoo function.
-func validateNewFacade(funcValue reflect.Value) error {
+func validateNewFacade(funcValue reflect.Value) (bool, error) {
 	if !funcValue.IsValid() {
-		return fmt.Errorf("cannot wrap nil")
+		return false, fmt.Errorf("cannot wrap nil")
 	}
 	if funcValue.Kind() != reflect.Func {
-		return fmt.Errorf("wrong type %q is not a function", funcValue.Kind())
+		return false, fmt.Errorf("wrong type %q is not a function", funcValue.Kind())
 	}
 	funcType := funcValue.Type()
 	funcName := runtime.FuncForPC(funcValue.Pointer()).Name()
-	if funcType.NumIn() != 3 || funcType.NumOut() != 2 {
-		return fmt.Errorf("function %q does not take 3 parameters and return 2",
-			funcName)
+
+	badSigError := errors.Errorf(""+
+		"function %q does not have the signature func "+
+		"(facace.Context) (*Type, error), or "+
+		"(*state.State, facade.Resources, facade.Authorizer) (*Type, error)", funcName)
+
+	if funcType.NumOut() != 2 {
+		return false, errors.Trace(badSigError)
+	}
+	var (
+		facadeType reflect.Type
+		nice       bool
+	)
+	inArgCount := funcType.NumIn()
+
+	switch inArgCount {
+	case 1:
+		type niceFactory func(facade.Context) (interface{}, error)
+		facadeType = reflect.TypeOf((*niceFactory)(nil)).Elem()
+		nice = true
+	case 3:
+		type nastyFactory func(
+			st *state.State,
+			resources facade.Resources,
+			authorizer facade.Authorizer,
+		) (
+			interface{}, error,
+		)
+		facadeType = reflect.TypeOf((*nastyFactory)(nil)).Elem()
+	default:
+		return false, errors.Trace(badSigError)
 	}
 
-	type nastyFactory func(
-		st *state.State,
-		resources facade.Resources,
-		authorizer facade.Authorizer,
-	) (
-		interface{}, error,
-	)
-	facadeType := reflect.TypeOf((*nastyFactory)(nil)).Elem()
 	isSame := true
-	for i := 0; i < 3; i++ {
+	for i := 0; i < inArgCount; i++ {
 		if funcType.In(i) != facadeType.In(i) {
 			isSame = false
 			break
@@ -82,44 +102,60 @@ func validateNewFacade(funcValue reflect.Value) error {
 		isSame = false
 	}
 	if !isSame {
-		return fmt.Errorf("function %q does not have the signature func (*state.State, facade.Resources, facade.Authorizer) (*Type, error)",
-			funcName)
+		return false, errors.Trace(badSigError)
 	}
-	return nil
+	return nice, nil
 }
 
 // wrapNewFacade turns a given NewFoo(st, resources, authorizer) (*Instance, error)
 // function and wraps it into a proper facade.Factory function.
 func wrapNewFacade(newFunc interface{}) (facade.Factory, reflect.Type, error) {
 	funcValue := reflect.ValueOf(newFunc)
-	err := validateNewFacade(funcValue)
+	nice, err := validateNewFacade(funcValue)
 	if err != nil {
 		return nil, reflect.TypeOf(nil), err
 	}
-	// So we know newFunc is a func with the right args in and out, so
-	// wrap it into a helper function that matches the facade.Factory.
-	wrapped := func(context facade.Context) (facade.Facade, error) {
-		if context.ID() != "" {
-			return nil, ErrBadId
+	var wrapped facade.Factory
+	if nice {
+		wrapped = func(context facade.Context) (facade.Facade, error) {
+			if context.ID() != "" {
+				return nil, ErrBadId
+			}
+			in := []reflect.Value{reflect.ValueOf(context)}
+			out := funcValue.Call(in)
+			if out[1].Interface() != nil {
+				err := out[1].Interface().(error)
+				return nil, err
+			}
+			return out[0].Interface(), nil
 		}
-		st := context.State()
-		auth := context.Auth()
-		resources := context.Resources()
-		// st, resources, or auth is nil, then reflect.Call dies
-		// because reflect.ValueOf(anynil) is the Zero Value.
-		// So we use &obj.Elem() which gives us a concrete Value object
-		// that can refer to nil.
-		in := []reflect.Value{
-			reflect.ValueOf(&st).Elem(),
-			reflect.ValueOf(&resources).Elem(),
-			reflect.ValueOf(&auth).Elem(),
+	} else {
+		// So we know newFunc is a func with the right args in and out, so
+		// wrap it into a helper function that matches the facade.Factory.
+		wrapped = func(context facade.Context) (facade.Facade, error) {
+			if context.ID() != "" {
+				return nil, ErrBadId
+			}
+			st := context.State()
+			auth := context.Auth()
+			resources := context.Resources()
+			// st, resources, or auth is nil, then reflect.Call dies
+			// because reflect.ValueOf(anynil) is the Zero Value.
+			// So we use &obj.Elem() which gives us a concrete Value object
+			// that can refer to nil.
+			in := []reflect.Value{
+				reflect.ValueOf(&st).Elem(),
+				reflect.ValueOf(&resources).Elem(),
+				reflect.ValueOf(&auth).Elem(),
+			}
+			out := funcValue.Call(in)
+			if out[1].Interface() != nil {
+				err := out[1].Interface().(error)
+				return nil, err
+			}
+			return out[0].Interface(), nil
 		}
-		out := funcValue.Call(in)
-		if out[1].Interface() != nil {
-			err := out[1].Interface().(error)
-			return nil, err
-		}
-		return out[0].Interface(), nil
+
 	}
 	return wrapped, funcValue.Type().Out(0), nil
 }

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -58,7 +58,12 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 		AdminTag: s.Owner,
 	}
 
-	controller, err := controller.NewControllerAPI(s.State, s.resources, s.authorizer)
+	controller, err := controller.NewControllerAPI(
+		facadetest.Context{
+			State_:     s.State,
+			Resources_: s.resources,
+			Auth_:      s.authorizer,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	s.controller = controller
 
@@ -69,7 +74,12 @@ func (s *controllerSuite) TestNewAPIRefusesNonClient(c *gc.C) {
 	anAuthoriser := apiservertesting.FakeAuthorizer{
 		Tag: names.NewUnitTag("mysql/0"),
 	}
-	endPoint, err := controller.NewControllerAPI(s.State, s.resources, anAuthoriser)
+	endPoint, err := controller.NewControllerAPI(
+		facadetest.Context{
+			State_:     s.State,
+			Resources_: s.resources,
+			Auth_:      anAuthoriser,
+		})
 	c.Assert(endPoint, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
@@ -240,7 +250,13 @@ func (s *controllerSuite) TestModelConfigFromNonController(c *gc.C) {
 		Tag:      s.Owner,
 		AdminTag: s.Owner,
 	}
-	controller, err := controller.NewControllerAPI(st, common.NewResources(), authorizer)
+	controller, err := controller.NewControllerAPI(
+		facadetest.Context{
+			State_:     st,
+			Resources_: common.NewResources(),
+			Auth_:      authorizer,
+		})
+
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := controller.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
@@ -263,7 +279,12 @@ func (s *controllerSuite) TestControllerConfigFromNonController(c *gc.C) {
 	defer st.Close()
 
 	authorizer := &apiservertesting.FakeAuthorizer{Tag: s.Owner}
-	controller, err := controller.NewControllerAPI(st, common.NewResources(), authorizer)
+	controller, err := controller.NewControllerAPI(
+		facadetest.Context{
+			State_:     st,
+			Resources_: common.NewResources(),
+			Auth_:      authorizer,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := controller.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
@@ -789,7 +810,12 @@ func (s *controllerSuite) TestGetControllerAccessPermissions(c *gc.C) {
 	anAuthoriser := apiservertesting.FakeAuthorizer{
 		Tag: user.Tag(),
 	}
-	endpoint, err := controller.NewControllerAPI(s.State, s.resources, anAuthoriser)
+	endpoint, err := controller.NewControllerAPI(
+		facadetest.Context{
+			State_:     s.State,
+			Resources_: s.resources,
+			Auth_:      anAuthoriser,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.ModifyControllerAccessRequest{
 		Changes: []params.ModifyControllerAccess{{

--- a/apiserver/controller/destroy_test.go
+++ b/apiserver/controller/destroy_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	commontesting "github.com/juju/juju/apiserver/common/testing"
 	"github.com/juju/juju/apiserver/controller"
+	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -51,7 +52,12 @@ func (s *destroyControllerSuite) SetUpTest(c *gc.C) {
 	authoriser := apiservertesting.FakeAuthorizer{
 		Tag: s.AdminUserTag(c),
 	}
-	controller, err := controller.NewControllerAPI(s.State, resources, authoriser)
+	controller, err := controller.NewControllerAPI(
+		facadetest.Context{
+			State_:     s.State,
+			Resources_: resources,
+			Auth_:      authoriser,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	s.controller = controller
 

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -86,7 +86,7 @@ func NewErrRoot(err error) *errRoot {
 // *barely* connected to anything.  Just enough to let you probe some
 // of the interfaces, but not enough to actually do any RPC calls.
 func TestingAPIRoot(st *state.State) rpc.Root {
-	return newAPIRoot(st, common.NewResources(), nil)
+	return newAPIRoot(st, state.NewStatePool(st), common.NewResources(), nil)
 }
 
 // TestingAPIHandler gives you an APIHandler that isn't connected to

--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -16,6 +16,9 @@ type Context struct {
 	Resources_ facade.Resources
 	State_     *state.State
 	ID_        string
+	// Identity is not part of the facade.Context interface, but is instead
+	// used to make sure that the context objects are the same.
+	Identity string
 }
 
 // Abort is part of the facade.Context interface.
@@ -41,6 +44,11 @@ func (context Context) Resources() facade.Resources {
 // State is part of the facade.Context interface.
 func (context Context) State() *state.State {
 	return context.State_
+}
+
+// StatePool is part of of the facade.Context interface.
+func (context Context) StatePool() *state.StatePool {
+	return state.NewStatePool(context.State_)
 }
 
 // ID is part of the facade.Context interface.

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -62,6 +62,10 @@ type Context interface {
 	// capabilities will migrate towards access via Resources.
 	State() *state.State
 
+	// StatePool returns the state pool used by the apiserver to minimise the
+	// creation of the expensive *State instances.
+	StatePool() *state.StatePool
+
 	// ID returns a string that should almost always be "", unless
 	// this is a watcher facade, in which case it exists in lieu of
 	// actual arguments in the Next() call, and is used as a key

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -137,6 +137,7 @@ func (s *srvCaller) Call(objId string, arg reflect.Value) (reflect.Value, error)
 // apiRoot implements basic method dispatching to the facade registry.
 type apiRoot struct {
 	state       *state.State
+	pool        *state.StatePool
 	resources   *common.Resources
 	authorizer  facade.Authorizer
 	objectMutex sync.RWMutex
@@ -144,9 +145,10 @@ type apiRoot struct {
 }
 
 // newAPIRoot returns a new apiRoot.
-func newAPIRoot(st *state.State, resources *common.Resources, authorizer facade.Authorizer) *apiRoot {
+func newAPIRoot(st *state.State, pool *state.StatePool, resources *common.Resources, authorizer facade.Authorizer) *apiRoot {
 	r := &apiRoot{
 		state:       st,
+		pool:        pool,
 		resources:   resources,
 		authorizer:  authorizer,
 		objectCache: make(map[objectKey]reflect.Value),
@@ -264,6 +266,11 @@ func (ctx *facadeContext) Resources() facade.Resources {
 // State is part of of the facade.Context interface.
 func (ctx *facadeContext) State() *state.State {
 	return ctx.r.state
+}
+
+// StatePool is part of of the facade.Context interface.
+func (ctx *facadeContext) StatePool() *state.StatePool {
+	return ctx.r.pool
 }
 
 // ID is part of of the facade.Context interface.

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1168,7 +1168,7 @@ func (b *allWatcherStateBacking) Release() error {
 	return nil
 }
 
-func NewAllModelWatcherStateBacking(st *State) Backing {
+func NewAllModelWatcherStateBacking(st *State, pool *StatePool) Backing {
 	collections := makeAllWatcherCollectionInfo(
 		modelsC,
 		machinesC,
@@ -1190,7 +1190,7 @@ func NewAllModelWatcherStateBacking(st *State) Backing {
 	return &allModelWatcherStateBacking{
 		st:               st,
 		watcher:          st.workers.TxnLogWatcher(),
-		stPool:           NewStatePool(st),
+		stPool:           pool,
 		collectionByName: collections,
 	}
 }

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -1165,6 +1165,10 @@ func (s *allModelWatcherStateSuite) Reset(c *gc.C) {
 	s.SetUpTest(c)
 }
 
+func (s *allModelWatcherStateSuite) NewAllModelWatcherStateBacking() Backing {
+	return NewAllModelWatcherStateBacking(s.state, NewStatePool(s.state))
+}
+
 // performChangeTestCases runs a passed number of test cases for changes.
 func (s *allModelWatcherStateSuite) performChangeTestCases(c *gc.C, changeTestFuncs []changeTestFunc) {
 	for i, changeTestFunc := range changeTestFuncs {
@@ -1174,7 +1178,7 @@ func (s *allModelWatcherStateSuite) performChangeTestCases(c *gc.C, changeTestFu
 			test0 := changeTestFunc(c, s.state)
 
 			c.Logf("test %d. %s", i, test0.about)
-			b := NewAllModelWatcherStateBacking(s.state)
+			b := s.NewAllModelWatcherStateBacking()
 			defer b.Release()
 			all := newStore()
 
@@ -1378,7 +1382,7 @@ func (s *allModelWatcherStateSuite) TestChangeForDeadModel(c *gc.C) {
 	// Ensure an entity is removed when a change is seen but
 	// the model the entity belonged to has already died.
 
-	b := NewAllModelWatcherStateBacking(s.state)
+	b := s.NewAllModelWatcherStateBacking()
 	defer b.Release()
 	all := newStore()
 
@@ -1451,7 +1455,7 @@ func (s *allModelWatcherStateSuite) TestGetAll(c *gc.C) {
 		},
 	)
 
-	b := NewAllModelWatcherStateBacking(s.state)
+	b := s.NewAllModelWatcherStateBacking()
 	all := newStore()
 	err = b.GetAll(all)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1464,7 +1468,7 @@ func (s *allModelWatcherStateSuite) TestGetAll(c *gc.C) {
 
 func (s *allModelWatcherStateSuite) TestModelSettings(c *gc.C) {
 	// Init the test model.
-	b := NewAllModelWatcherStateBacking(s.state)
+	b := s.NewAllModelWatcherStateBacking()
 	all := newStore()
 	setModelConfigAttr(c, s.state, "http-proxy", "http://invalid")
 	setModelConfigAttr(c, s.state, "foo", "bar")
@@ -3334,7 +3338,7 @@ func newTestAllWatcher(st *State, c *gc.C) *testWatcher {
 }
 
 func newTestAllModelWatcher(st *State, c *gc.C) *testWatcher {
-	return newTestWatcher(NewAllModelWatcherStateBacking(st), st, c)
+	return newTestWatcher(NewAllModelWatcherStateBacking(st, NewStatePool(st)), st, c)
 }
 
 type testWatcher struct {

--- a/state/state.go
+++ b/state/state.go
@@ -552,10 +552,10 @@ func (st *State) Watch() *Multiwatcher {
 	return NewMultiwatcher(st.allManager)
 }
 
-func (st *State) WatchAllModels() *Multiwatcher {
+func (st *State) WatchAllModels(pool *StatePool) *Multiwatcher {
 	st.mu.Lock()
 	if st.allModelManager == nil {
-		st.allModelWatcherBacking = NewAllModelWatcherStateBacking(st)
+		st.allModelWatcherBacking = NewAllModelWatcherStateBacking(st, pool)
 		st.allModelManager = newStoreManager(st.allModelWatcherBacking)
 	}
 	st.mu.Unlock()

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -257,7 +257,7 @@ func (s *StateSuite) TestWatchAllModels(c *gc.C) {
 	// elsewhere. This just ensures things are hooked up correctly in
 	// State.WatchAllModels()
 
-	w := s.State.WatchAllModels()
+	w := s.State.WatchAllModels(state.NewStatePool(s.State))
 	defer w.Stop()
 	deltasC := makeMultiwatcherOutput(w)
 


### PR DESCRIPTION
Currently each Juju GUI that connects to the controller will ask for something to watch all the models. Each of these watchers was creating its own state pool. So in a controller with many models with many GUI connections, we'd have many extra state.State instances being created for very little use.

This change also allows an additional facade creation signature to be used with the RegisterStandardFacade function.

## QA steps

Bootstrap and log into the GUI.

## Documentation changes

There are no user facing changes with this at all.

## Bug reference

Part of the fix for https://bugs.launchpad.net/juju/+bug/1649719
