### PR TITLE
Update command in help test to match current name

### DIFF
--- a/cmd/juju/subnet/add.go
+++ b/cmd/juju/subnet/add.go
@@ -34,7 +34,7 @@ type addCommand struct {
 
 const addCommandDoc = `
 Adds an existing subnet to Juju, making it available for use. Unlike
-"juju create-subnet", this command does not create a new subnet, so it
+"juju add-subnet", this command does not create a new subnet, so it
 is supported on a wider variety of clouds (where SDN features are not
 available, e.g. MAAS). The subnet will be associated with the given
 existing Juju network space.


### PR DESCRIPTION
## Description of change
Spell-o.

Why is this change needed?
The command was renamed.

## QA steps
1. build the pr branch
2. $ juju help add-subnet

How do we verify that the change works?
3. Make sure it doesn't say `create-subnet`

## Documentation changes
The help text is updated.

Does it affect current user workflow? CLI? API?
N/A

## Bug reference
https://bugs.launchpad.net/juju/+bug/1636347
