### PR TITLE
Use monotonic clock in lease manager skew calculations

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -47,7 +47,7 @@ github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-0
 github.com/juju/testing	git	5ea77166c8c6a8f56f258565288c4714aa399283	2016-11-24T00:43:14Z
 github.com/juju/txn	git	28898197906200d603394d8e4ce537436529f1c5	2016-11-16T04:07:55Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils	git	80bc95efca7ea0c6cba2c3b61d9baed02f0d9bb4	2017-01-25T23:33:01Z
+github.com/juju/utils	git	2c7a521b0a6ba1b4d0c29a1670a1d92bbdc23610	2017-02-08T11:46:50Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z

--- a/state/lease/client_persistence_test.go
+++ b/state/lease/client_persistence_test.go
@@ -8,6 +8,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/clock"
+	"github.com/juju/utils/clock/monotonic"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2/bson"
 
@@ -25,11 +26,12 @@ var _ = gc.Suite(&ClientPersistenceSuite{})
 
 func (s *ClientPersistenceSuite) TestNewClientInvalidClockDoc(c *gc.C) {
 	config := lease.ClientConfig{
-		Id:         "client",
-		Namespace:  "namespace",
-		Collection: "collection",
-		Mongo:      NewMongo(s.db),
-		Clock:      clock.WallClock,
+		Id:           "client",
+		Namespace:    "namespace",
+		Collection:   "collection",
+		Mongo:        NewMongo(s.db),
+		Clock:        clock.WallClock,
+		MonotonicNow: monotonic.Now,
 	}
 	dbKey := "clock#namespace#"
 	err := s.db.C("collection").Insert(bson.M{"_id": dbKey})
@@ -42,11 +44,12 @@ func (s *ClientPersistenceSuite) TestNewClientInvalidClockDoc(c *gc.C) {
 
 func (s *ClientPersistenceSuite) TestNewClientInvalidLeaseDoc(c *gc.C) {
 	config := lease.ClientConfig{
-		Id:         "client",
-		Namespace:  "namespace",
-		Collection: "collection",
-		Mongo:      NewMongo(s.db),
-		Clock:      clock.WallClock,
+		Id:           "client",
+		Namespace:    "namespace",
+		Collection:   "collection",
+		Mongo:        NewMongo(s.db),
+		Clock:        clock.WallClock,
+		MonotonicNow: monotonic.Now,
 	}
 	err := s.db.C("collection").Insert(bson.M{
 		"_id":       "snagglepuss",

--- a/state/lease/client_validation_test.go
+++ b/state/lease/client_validation_test.go
@@ -54,6 +54,13 @@ func (s *ClientValidationSuite) TestNewClientClock(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, "missing clock")
 }
 
+func (s *ClientValidationSuite) TestNewMonotonicClock(c *gc.C) {
+	fix := s.EasyFixture(c)
+	fix.Config.MonotonicNow = nil
+	_, err := lease.NewClient(fix.Config)
+	c.Check(err, gc.ErrorMatches, "missing monotonic clock")
+}
+
 func (s *ClientValidationSuite) TestClaimLeaseName(c *gc.C) {
 	fix := s.EasyFixture(c)
 	err := fix.Client.ClaimLease("$name", corelease.Request{"holder", time.Minute})

--- a/state/lease/config.go
+++ b/state/lease/config.go
@@ -4,6 +4,8 @@
 package lease
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils/clock"
@@ -21,6 +23,9 @@ type Mongo interface {
 	// GetCollection should probably call the mongo.CollectionFromName func.
 	GetCollection(name string) (collection mongo.Collection, closer func())
 }
+
+// MonotonicNow exposes monotonic clock Now() for use by the lease manager.
+type MonotonicClockFunc func() time.Duration
 
 // ClientConfig contains the resources and information required to create
 // a Client. Multiple clients can collaborate if they share a collection and
@@ -44,6 +49,9 @@ type ClientConfig struct {
 
 	// Clock exposes the wall-clock time to a Client.
 	Clock clock.Clock
+
+	// MonotonicNow exposes the monotonic clock Now() func to a client.
+	MonotonicNow MonotonicClockFunc
 }
 
 // validate returns an error if the supplied config is not valid.
@@ -62,6 +70,9 @@ func (config ClientConfig) validate() error {
 	}
 	if config.Clock == nil {
 		return errors.New("missing clock")
+	}
+	if config.MonotonicNow == nil {
+		return errors.New("missing monotonic clock")
 	}
 	return nil
 }

--- a/state/lease/fixture_test.go
+++ b/state/lease/fixture_test.go
@@ -61,12 +61,14 @@ func NewFixture(c *gc.C, database *mgo.Database, params FixtureParams) *Fixture 
 		clockStart = defaultClockStart
 	}
 	clock := NewClock(clockStart, params.ClockStep)
+	monotonic := newMonotonicClock(params.ClockStep)
 	config := lease.ClientConfig{
-		Id:         or(params.Id, "default-client"),
-		Namespace:  or(params.Namespace, "default-namespace"),
-		Collection: or(params.Collection, "default-collection"),
-		Mongo:      mongo,
-		Clock:      clock,
+		Id:           or(params.Id, "default-client"),
+		Namespace:    or(params.Namespace, "default-namespace"),
+		Collection:   or(params.Collection, "default-collection"),
+		Mongo:        mongo,
+		Clock:        clock,
+		MonotonicNow: monotonic.Now,
 	}
 	client, err := lease.NewClient(config)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/lease/schema.go
+++ b/state/lease/schema.go
@@ -168,18 +168,6 @@ func (doc clockDoc) skews(beginning, end time.Time) (map[string]Skew, error) {
 	if err := doc.validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	// beginning is expected to be earlier than end.
-	// If it isn't, it could be ntp rolling the clock back slowly, so we add
-	// a little wiggle room here.
-	if end.Before(beginning) {
-		// A later time, subtract an earlier time will give a positive duration.
-		difference := beginning.Sub(end)
-		if difference > 10*time.Millisecond {
-			return nil, errors.Errorf("end of read window preceded beginning (%s)", difference)
-
-		}
-		beginning = end
-	}
 	skews := make(map[string]Skew)
 	for writer, written := range doc.Writers {
 		skews[writer] = Skew{

--- a/state/lease/util_test.go
+++ b/state/lease/util_test.go
@@ -47,6 +47,23 @@ func (clock *Clock) Advance(duration time.Duration) {
 	clock.now = clock.now.Add(duration)
 }
 
+type monotonicClock struct {
+	now  time.Duration
+	step time.Duration
+}
+
+func (m *monotonicClock) Now() time.Duration {
+	m.now += m.step
+	return m.now
+}
+
+// newMonotonicClock returns a monotonic clock instance whose
+// Now() method returns a duration advance by step each time
+// it is called.
+func newMonotonicClock(step time.Duration) *monotonicClock {
+	return &monotonicClock{step: step}
+}
+
 // Mongo exposes database operations. It uses a real database -- we can't mock
 // mongo out, we need to check it really actually works -- but it's good to
 // have the runner accessible for adversarial transaction tests.

--- a/state/state.go
+++ b/state/state.go
@@ -47,6 +47,7 @@ import (
 	"github.com/juju/juju/state/workers"
 	"github.com/juju/juju/status"
 	jujuversion "github.com/juju/juju/version"
+	"github.com/juju/utils/clock/monotonic"
 )
 
 var logger = loggo.GetLogger("juju.state")
@@ -421,11 +422,12 @@ func (st *State) ApplicationLeaders() (map[string]string, error) {
 
 func (st *State) getLeadershipLeaseClient() (lease.Client, error) {
 	client, err := statelease.NewClient(statelease.ClientConfig{
-		Id:         st.leaseClientId,
-		Namespace:  applicationLeadershipNamespace,
-		Collection: leasesC,
-		Mongo:      &environMongo{st},
-		Clock:      st.clock,
+		Id:           st.leaseClientId,
+		Namespace:    applicationLeadershipNamespace,
+		Collection:   leasesC,
+		Mongo:        &environMongo{st},
+		Clock:        st.clock,
+		MonotonicNow: monotonic.Now,
 	})
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot create leadership lease client")
@@ -435,11 +437,12 @@ func (st *State) getLeadershipLeaseClient() (lease.Client, error) {
 
 func (st *State) getSingularLeaseClient() (lease.Client, error) {
 	client, err := statelease.NewClient(statelease.ClientConfig{
-		Id:         st.leaseClientId,
-		Namespace:  singularControllerNamespace,
-		Collection: leasesC,
-		Mongo:      &environMongo{st},
-		Clock:      st.clock,
+		Id:           st.leaseClientId,
+		Namespace:    singularControllerNamespace,
+		Collection:   leasesC,
+		Mongo:        &environMongo{st},
+		Clock:        st.clock,
+		MonotonicNow: monotonic.Now,
 	})
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot create singular lease client")


### PR DESCRIPTION
## Description of change

A monotonic clock is introduced to the lease manager so that when it calculates skew, there is no possibility of time going backwards and causing an error.

## QA steps

bootstrap and run list-models to smoke test

## Bug reference

https://bugs.launchpad.net/juju/+bug/1662202
