### PR TITLE
provider/lxd: add interactive auth-type

### DIFF
--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -283,7 +283,7 @@ func (s *restoreSuite) TestRestoreReboostrapBuiltInProvider(c *gc.C) {
 		c.Assert(args.Cloud, jc.DeepEquals, cloud.Cloud{
 			Name:      "lxd",
 			Type:      "lxd",
-			AuthTypes: []cloud.AuthType{"certificate"},
+			AuthTypes: []cloud.AuthType{"certificate", "interactive"},
 			Regions:   []cloud.Region{{Name: "localhost"}},
 		})
 		return nil

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -152,6 +152,7 @@ var localhostCloud = cloud.Cloud{
 	Name: lxdnames.DefaultCloud,
 	Type: lxdnames.ProviderType,
 	AuthTypes: []cloud.AuthType{
+		interactiveAuthType,
 		cloud.CertificateAuthType,
 	},
 	Endpoint: "",

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -75,9 +75,12 @@ func (s *providerSuite) TestDetectCloudError(c *gc.C) {
 
 func (s *providerSuite) assertLocalhostCloud(c *gc.C, found cloud.Cloud) {
 	c.Assert(found, jc.DeepEquals, cloud.Cloud{
-		Name:      "localhost",
-		Type:      "lxd",
-		AuthTypes: []cloud.AuthType{cloud.CertificateAuthType},
+		Name: "localhost",
+		Type: "lxd",
+		AuthTypes: []cloud.AuthType{
+			"interactive",
+			cloud.CertificateAuthType,
+		},
 		Regions: []cloud.Region{{
 			Name: "localhost",
 		}},

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -351,7 +351,9 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.Env.raw = raw
 	s.Provider.generateMemCert = func(client bool) (cert, key []byte, _ error) {
 		s.Stub.AddCall("GenerateMemCert", client)
-		return []byte("client.crt"), []byte("client.key"), s.Stub.NextErr()
+		cert = []byte(testing.CACert + "generated")
+		key = []byte(testing.CAKey + "generated")
+		return cert, key, s.Stub.NextErr()
 	}
 	s.Provider.newLocalRawProvider = func() (*rawProvider, error) {
 		return raw, nil


### PR DESCRIPTION
## Description of change

Add the "interactive" auth-type for LXD, which is
used in add-credential for interactively adding a
credential for a LXD cloud. Currently we only
support generating credentials for local LXD;
later we will extend this to support generating
credentials for remote, untrusted LXD by prompting
the user to verify the certificate fingerprint and
enter a trust password.

## QA steps

1. juju add-credential localhost
```
Enter credential name: foo
Auth Types
interactive*
certificate

Select auth-type: 
Loaded client cert/key from "/home/andrew/.config/lxc"
Credentials added for cloud localhost.
```
2. juju bootstrap localhost
3. juju add-user bob
4. juju grant bob add-model
5. lxc launch ubuntu-xenial x
6. lxc file push \`which juju\` x/tmp/juju
7. lxc exec x /tmp/juju register ...
8. lxc exec x /tmp/juju add-model foo
```
ERROR cannot auto-generate credential for remote LXD

Until support is added for verifying and authenticating to remote LXD hosts,
you must generate the credential by hand, adding the certificate to LXD using
the "lxc config trust" command.
```
9. juju credentials --format=yaml localhost > /tmp/localhost-credentials.yaml
10. lxc file push /tmp/localhost-credentials.yaml x/root/.local/share/juju/credentials.yaml
11. lxc exec x /tmp/juju add-model foo
```
Uploading credential 'localhost/bob/foo' to controller
Added 'foo' model on localhost/localhost with credential 'foo' for user 'bob'
```

## Documentation changes

There is a change in workflow, but probably unusual enough that it doesn't need documenting?

## Bug reference

Does not fix any bugs, but hopefully alleviates some of the pain caused by https://bugs.launchpad.net/juju/+bug/1662587.