### PR TITLE
2.1 network uses lock 1662586

### DIFF
--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -27,6 +27,11 @@ func (m *Machine) Tag() names.Tag {
 	return m.tag
 }
 
+// MachineTag returns the identifier for the machine as the most specific type
+func (m *Machine) MachineTag() names.MachineTag {
+	return m.tag
+}
+
 // Id returns the machine id.
 func (m *Machine) Id() string {
 	return m.tag.Id()

--- a/api/provisioner/provisioner.go
+++ b/api/provisioner/provisioner.go
@@ -240,9 +240,9 @@ func (st *State) prepareOrGetContainerInterfaceInfo(
 
 // SetHostMachineNetworkConfig sets the network configuration of the
 // machine with netConfig
-func (st *State) SetHostMachineNetworkConfig(hostMachineID string, netConfig []params.NetworkConfig) error {
+func (st *State) SetHostMachineNetworkConfig(hostMachineTag names.MachineTag, netConfig []params.NetworkConfig) error {
 	args := params.SetMachineNetworkConfig{
-		Tag:    hostMachineID,
+		Tag:    hostMachineTag.String(),
 		Config: netConfig,
 	}
 	err := st.facade.FacadeCall("SetHostMachineNetworkConfig", args, nil)

--- a/worker/provisioner/broker.go
+++ b/worker/provisioner/broker.go
@@ -23,7 +23,7 @@ type APICalls interface {
 	PrepareContainerInterfaceInfo(names.MachineTag) ([]network.InterfaceInfo, error)
 	GetContainerInterfaceInfo(names.MachineTag) ([]network.InterfaceInfo, error)
 	ReleaseContainerAddresses(names.MachineTag) error
-	SetHostMachineNetworkConfig(string, []params.NetworkConfig) error
+	SetHostMachineNetworkConfig(names.MachineTag, []params.NetworkConfig) error
 	HostChangesForContainer(containerTag names.MachineTag) ([]network.DeviceToBridge, int, error)
 }
 
@@ -43,7 +43,12 @@ var resolvConf = "/etc/resolv.conf"
 
 var getObservedNetworkConfig = common.GetObservedNetworkConfig
 
-func prepareHost(bridger network.Bridger, hostMachineID string, containerTag names.MachineTag, api APICalls, log loggo.Logger) error {
+// prepareHost makes changes to the host's configuration (bridging network
+// interfaces, etc) in preparation for a container.
+// TODO(jam): 2017-02-08 This arguably should be passed into the broker as a
+// callback from the Host object, rather than have StartInstance directly be
+// responsible for how to set up the host.
+func prepareHost(bridger network.Bridger, hostMachineTag names.MachineTag, containerTag names.MachineTag, api APICalls, log loggo.Logger) error {
 	devicesToBridge, reconfigureDelay, err := api.HostChangesForContainer(containerTag)
 
 	if err != nil {
@@ -55,7 +60,7 @@ func prepareHost(bridger network.Bridger, hostMachineID string, containerTag nam
 		return nil
 	}
 
-	log.Tracef("Bridging %+v devices on host %q with delay=%v", devicesToBridge, hostMachineID, reconfigureDelay)
+	log.Tracef("Bridging %+v devices on host %q with delay=%v", devicesToBridge, hostMachineTag.String(), reconfigureDelay)
 
 	err = bridger.Bridge(devicesToBridge, reconfigureDelay)
 
@@ -73,7 +78,7 @@ func prepareHost(bridger network.Bridger, hostMachineID string, containerTag nam
 	}
 
 	if len(observedConfig) > 0 {
-		err := api.SetHostMachineNetworkConfig(hostMachineID, observedConfig)
+		err := api.SetHostMachineNetworkConfig(hostMachineTag, observedConfig)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/worker/provisioner/broker_test.go
+++ b/worker/provisioner/broker_test.go
@@ -119,8 +119,8 @@ func (f *fakeAPI) ReleaseContainerAddresses(tag names.MachineTag) error {
 	return nil
 }
 
-func (f *fakeAPI) SetHostMachineNetworkConfig(hostMachineID string, netConfig []params.NetworkConfig) error {
-	f.MethodCall(f, "SetHostMachineNetworkConfig", hostMachineID, netConfig)
+func (f *fakeAPI) SetHostMachineNetworkConfig(hostMachineTag names.MachineTag, netConfig []params.NetworkConfig) error {
+	f.MethodCall(f, "SetHostMachineNetworkConfig", hostMachineTag.String(), netConfig)
 	if err := f.NextErr(); err != nil {
 		return err
 	}

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -46,17 +46,17 @@ func NewKVMBroker(
 ) (environs.InstanceBroker, error) {
 	return &kvmBroker{
 		prepareHost: prepareHost,
-		manager:       manager,
-		api:           api,
-		agentConfig:   agentConfig,
+		manager:     manager,
+		api:         api,
+		agentConfig: agentConfig,
 	}, nil
 }
 
 type kvmBroker struct {
-	prepareHost   PrepareHostFunc
-	manager       container.Manager
-	api           APICalls
-	agentConfig   agent.Config
+	prepareHost PrepareHostFunc
+	manager     container.Manager
+	api         APICalls
+	agentConfig agent.Config
 }
 
 // StartInstance is specified in the Broker interface.

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -21,7 +21,7 @@ var kvmLogger = loggo.GetLogger("juju.provisioner.kvm")
 
 func NewKvmBroker(
 	bridger network.Bridger,
-	hostMachineID string,
+	hostMachineTag names.MachineTag,
 	api APICalls,
 	agentConfig agent.Config,
 	managerConfig container.ManagerConfig,
@@ -32,7 +32,7 @@ func NewKvmBroker(
 	}
 	return &kvmBroker{
 		bridger:       bridger,
-		hostMachineID: hostMachineID,
+		hostMachineTag: hostMachineTag,
 		manager:       manager,
 		api:           api,
 		agentConfig:   agentConfig,
@@ -41,7 +41,7 @@ func NewKvmBroker(
 
 type kvmBroker struct {
 	bridger       network.Bridger
-	hostMachineID string
+	hostMachineTag names.MachineTag
 	manager       container.Manager
 	api           APICalls
 	agentConfig   agent.Config
@@ -59,7 +59,7 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		return nil, err
 	}
 
-	err = prepareHost(broker.bridger, broker.hostMachineID, names.NewMachineTag(containerMachineID), broker.api, kvmLogger)
+	err = prepareHost(broker.bridger, broker.hostMachineTag, names.NewMachineTag(containerMachineID), broker.api, kvmLogger)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -97,7 +97,9 @@ func (s *kvmBrokerSuite) startInstance(c *gc.C, broker environs.InstanceBroker, 
 
 func (s *kvmBrokerSuite) newKVMBroker(c *gc.C, bridger network.Bridger) (environs.InstanceBroker, error) {
 	managerConfig := container.ManagerConfig{container.ConfigModelUUID: coretesting.ModelTag.Id()}
-	return provisioner.NewKvmBroker(bridger, "machine-1", s.api, s.agentConfig, managerConfig)
+	tag, err := names.ParseMachineTag("machine-1")
+	c.Assert(err, jc.ErrorIsNil)
+	return provisioner.NewKvmBroker(bridger, tag, s.api, s.agentConfig, managerConfig)
 }
 
 func (s *kvmBrokerSuite) maintainInstance(c *gc.C, broker environs.InstanceBroker, machineId string) {
@@ -381,7 +383,9 @@ func (s *kvmProvisionerSuite) newKvmProvisioner(c *gc.C) provisioner.Provisioner
 	machineTag := names.NewMachineTag("0")
 	agentConfig := s.AgentConfigForTag(c, machineTag)
 	managerConfig := container.ManagerConfig{container.ConfigModelUUID: coretesting.ModelTag.Id()}
-	broker, brokerErr := provisioner.NewKvmBroker(newFakeBridgerNeverErrors(), "machine-0", s.provisioner, agentConfig, managerConfig)
+	tag, err := names.ParseMachineTag("machine-0")
+	c.Assert(err, jc.ErrorIsNil)
+	broker, brokerErr := provisioner.NewKvmBroker(newFakeBridgerNeverErrors(), tag, s.provisioner, agentConfig, managerConfig)
 	c.Assert(brokerErr, jc.ErrorIsNil)
 	toolsFinder := (*provisioner.GetToolsFinder)(s.provisioner)
 	w, err := provisioner.NewContainerProvisioner(instance.KVM, s.provisioner, agentConfig, broker, toolsFinder)

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -49,20 +49,20 @@ func NewLXDBroker(
 	api APICalls,
 	manager container.Manager,
 	agentConfig agent.Config,
- ) (environs.InstanceBroker, error) {
+) (environs.InstanceBroker, error) {
 	return &lxdBroker{
 		prepareHost: prepareHost,
-		manager:       manager,
-		api:           api,
-		agentConfig:   agentConfig,
+		manager:     manager,
+		api:         api,
+		agentConfig: agentConfig,
 	}, nil
 }
 
 type lxdBroker struct {
-	prepareHost	  PrepareHostFunc
-	manager       container.Manager
-	api           APICalls
-	agentConfig   agent.Config
+	prepareHost PrepareHostFunc
+	manager     container.Manager
+	api         APICalls
+	agentConfig agent.Config
 }
 
 func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -20,6 +20,7 @@ var lxdLogger = loggo.GetLogger("juju.provisioner.lxd")
 
 type PrepareHostFunc func(containerTag names.MachineTag, log loggo.Logger) error
 
+// TODO(jam): 2017-02-08 should be removed, only here for legacy testing, etc.
 func NewLxdBroker(
 	bridger network.Bridger,
 	hostMachineTag names.MachineTag,
@@ -33,6 +34,16 @@ func NewLxdBroker(
 	return NewLXDBroker(prepareWrapper, api, manager, agentConfig)
 }
 
+// NewLXDBroker creates a Broker that can be used to start LXD containers in a
+// similar fashion to normal StartInstance requests.
+// prepareHost is a callback that will be called when a new container is about
+// to be started. It provides the intersection point where the host can update
+// itself to be ready for whatever changes are necessary to have a functioning
+// container. (such as bridging host devices.)
+// manager is the infrastructure to actually launch the container.
+// agentConfig is currently only used to find out the 'default' bridge to use
+// when a specific network device is not specified in StartInstanceParams. This
+// should be deprecated. And hopefully removed in the future.
 func NewLXDBroker(
 	prepareHost PrepareHostFunc,
 	api APICalls,
@@ -63,7 +74,7 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		return nil, err
 	}
 
-	err = broker.prepareHost(names.NewMachineTag(containerMachineID), logger)
+	err = broker.prepareHost(names.NewMachineTag(containerMachineID), lxdLogger)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/provisioner/lxd-broker_test.go
+++ b/worker/provisioner/lxd-broker_test.go
@@ -70,7 +70,9 @@ func (s *lxdBrokerSuite) startInstance(c *gc.C, broker environs.InstanceBroker, 
 }
 
 func (s *lxdBrokerSuite) newLXDBroker(c *gc.C, bridger network.Bridger) (environs.InstanceBroker, error) {
-	return provisioner.NewLxdBroker(bridger, "machine-1", s.api, s.manager, s.agentConfig)
+	tag, err := names.ParseMachineTag("machine-1")
+	c.Assert(err, jc.ErrorIsNil)
+	return provisioner.NewLxdBroker(bridger, tag, s.api, s.manager, s.agentConfig)
 }
 
 func (s *lxdBrokerSuite) TestStartInstanceGetObservedNetworkConfigFails(c *gc.C) {

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -652,6 +652,12 @@ func (task *provisionerTask) maintainMachines(machines []*apiprovisioner.Machine
 
 func (task *provisionerTask) startMachines(machines []*apiprovisioner.Machine) error {
 	for _, m := range machines {
+		// Make sure we shouldn't be stopping before we start the next machine
+		select {
+		case <-task.catacomb.Dying():
+			return task.catacomb.ErrDying()
+		default:
+		}
 
 		pInfo, err := m.ProvisioningInfo()
 		if err != nil {


### PR DESCRIPTION
## Description of change

Change the Bridging code to use the machine-lock while executing.

## QA steps

I tried to create a charm that would exercise the network while another charm was deployed, but I wasn't successful in reproducing this. The associated bug does have some examples of it happening in the wild. There are a few hypothetical issues:
- You have to be doing something significant over the network that takes enough time during the install hook.
- Your *first* container does wait for the lock, because it needs the lock to 'apt install lxd' etc. So either the container initialization has to happen first, and then release the lock, or somehow the ordering has to be just right.
- My test was trying to do something with a local service that I could ensure would take a long time, but its possible that even though I was connecting to the IP address that was being brought down and back up again, sockets are smart enough to not die if the downtime is short enough.

It might be possible to "juju deploy $SOMETHING --to lxd:0" and then "juju deploy $ELSE --to 0", and have the lxd initialization trigger, but while it is downloading the container image, the ELSE starts doing its thing and ends up racing with the container image finally downloading and triggering us wanting to change networking with the install hook downloading something. (I'm not entirely sure that we wait for the image to be downloaded before we reconfigure bridging, though, I'm not 100% sure when the image is downloaded vs when the bridging is done.)

## Documentation changes

No specific CLI/API changes.

## Bug reference

https://pad.lv/1662586
