### PR TITLE
Revert "Merge pull request #6933 from jameinel/2.1-no-fallback-1656326"

### DIFF
--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -723,7 +723,7 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(env environs.Environ, idx in
 		}
 
 		if len(parentAddrs) > 0 {
-			logger.Debugf("host machine device %q has addresses %v", parentDevice.Name(), parentAddrs)
+			logger.Infof("host machine device %q has addresses %v", parentDevice.Name(), parentAddrs)
 			firstAddress := parentAddrs[0]
 			if supportContainerAddresses {
 				parentDeviceSubnet, err := firstAddress.Subnet()
@@ -744,10 +744,7 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(env environs.Environ, idx in
 				info.VLANTag = 0
 			}
 		} else {
-			logger.Debugf("host machine device %q has no addresses %v", parentDevice.Name(), parentAddrs)
-			info.ConfigType = network.ConfigDHCP
-			info.ProviderSubnetId = ""
-			info.VLANTag = 0
+			logger.Infof("host machine device %q has no addresses %v", parentDevice.Name(), parentAddrs)
 		}
 
 		logger.Tracef("prepared info for container interface %q: %+v", info.InterfaceName, info)
@@ -768,12 +765,10 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(env environs.Environ, idx in
 			return err
 		}
 		logger.Debugf("got allocated info from provider: %+v", allocatedInfo)
-	} else {
-		logger.Debugf("using dhcp allocated addresses")
 	}
 
 	allocatedConfig := networkingcommon.NetworkConfigFromInterfaceInfo(allocatedInfo)
-	logger.Debugf("allocated network config: %+v", allocatedConfig)
+	logger.Tracef("allocated network config: %+v", allocatedConfig)
 	ctx.result.Results[idx].Config = allocatedConfig
 	return nil
 }

--- a/container/kvm/libvirt.go
+++ b/container/kvm/libvirt.go
@@ -93,18 +93,20 @@ func CreateMachine(params CreateMachineParams) error {
 	if params.RootDisk != 0 {
 		args = append(args, "--disk", fmt.Sprint(params.RootDisk))
 	}
-	if len(params.Interfaces) != 0 {
-		templateDir := filepath.Dir(params.UserDataFile)
+	if params.NetworkBridge != "" {
+		if len(params.Interfaces) != 0 {
+			templateDir := filepath.Dir(params.UserDataFile)
 
-		templatePath := filepath.Join(templateDir, "kvm-template.xml")
-		err := WriteTemplate(templatePath, params)
-		if err != nil {
-			return errors.Trace(err)
+			templatePath := filepath.Join(templateDir, "kvm-template.xml")
+			err := WriteTemplate(templatePath, params)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			args = append(args, "--template", templatePath)
+		} else {
+			args = append(args, "--bridge", params.NetworkBridge)
 		}
-
-		args = append(args, "--template", templatePath)
-	} else if params.NetworkBridge != "" {
-		args = append(args, "--bridge", params.NetworkBridge)
 	}
 
 	args = append(args, params.Hostname)

--- a/container/kvm/template.go
+++ b/container/kvm/template.go
@@ -44,7 +44,7 @@ var kvmTemplate = `
       <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
     </video>
 
-    {{range $nic := .Interfaces}}
+    {{$bridge := .NetworkBridge}}{{range $nic := .Interfaces}}
     <interface type='bridge'>
       <mac address='{{$nic.MACAddress}}'/>
       <model type='virtio'/>

--- a/container/network.go
+++ b/container/network.go
@@ -49,3 +49,12 @@ func BridgeNetworkConfig(device string, mtu int, interfaces []network.InterfaceI
 	}
 	return &NetworkConfig{BridgeNetwork, device, mtu, interfaces}
 }
+
+// PhysicalNetworkConfig returns a valid NetworkConfig to use the
+// specified device as the network device for the container. It also
+// allows passing in specific configuration for the container's
+// network interfaces and default MTU to use. If interfaces is nil the
+// default configuration is used for the respective container type.
+func PhysicalNetworkConfig(device string, mtu int, interfaces []network.InterfaceInfo) *NetworkConfig {
+	return &NetworkConfig{PhysicalNetwork, device, mtu, interfaces}
+}

--- a/worker/provisioner/broker.go
+++ b/worker/provisioner/broker.go
@@ -86,6 +86,7 @@ func prepareHost(bridger network.Bridger, hostMachineID string, containerTag nam
 func prepareOrGetContainerInterfaceInfo(
 	api APICalls,
 	machineID string,
+	bridgeDevice string,
 	allocateOrMaintain bool,
 	log loggo.Logger,
 ) ([]network.InterfaceInfo, error) {

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -53,6 +53,14 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	containerMachineID := args.InstanceConfig.MachineId
 	kvmLogger.Infof("starting kvm container for containerMachineID: %s", containerMachineID)
 
+	// TODO: Default to using the host network until we can configure.  Yes,
+	// this is using the LxcBridge value, we should put it in the api call for
+	// container config.
+	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
+	if bridgeDevice == "" {
+		bridgeDevice = container.DefaultKvmBridge
+	}
+
 	config, err := broker.api.ContainerConfig()
 	if err != nil {
 		kvmLogger.Errorf("failed to get container config: %v", err)
@@ -67,28 +75,24 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	preparedInfo, err := prepareOrGetContainerInterfaceInfo(
 		broker.api,
 		containerMachineID,
+		bridgeDevice,
 		true, // allocate if possible, do not maintain existing.
 		kvmLogger,
 	)
 	if err != nil {
-		return nil, errors.Trace(err)
+		// It's not fatal (yet) if we couldn't pre-allocate addresses for the
+		// container.
+		logger.Warningf("failed to prepare container %q network config: %v", containerMachineID, err)
+	} else {
+		args.NetworkInfo = preparedInfo
 	}
 
-	// Something to fallback to if there are no devices given in args.NetworkInfo
-	// TODO(jam): 2017-02-07, this feels like something that should never need
-	// to be invoked, because either StartInstance or
-	// prepareOrGetContainerInterfaceInfo should always return a value. The
-	// test suite currently doesn't think so, and I'm hesitant to munge it too
-	// much.
-	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
-	if bridgeDevice == "" {
-		bridgeDevice = container.DefaultKvmBridge
-	}
-	interfaces, err := finishNetworkConfig(bridgeDevice, preparedInfo)
+	network := container.BridgeNetworkConfig(bridgeDevice, 0, args.NetworkInfo)
+	interfaces, err := finishNetworkConfig(bridgeDevice, args.NetworkInfo)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	network := container.BridgeNetworkConfig(bridgeDevice, 0, interfaces)
+	network.Interfaces = interfaces
 
 	// The provisioner worker will provide all tools it knows about
 	// (after applying explicitly specified constraints), which may
@@ -148,10 +152,17 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 func (broker *kvmBroker) MaintainInstance(args environs.StartInstanceParams) error {
 	machineID := args.InstanceConfig.MachineId
 
+	// Default to using the host network until we can configure.
+	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
+	if bridgeDevice == "" {
+		bridgeDevice = container.DefaultKvmBridge
+	}
+
 	// There's no InterfaceInfo we expect to get below.
 	_, err := prepareOrGetContainerInterfaceInfo(
 		broker.api,
 		machineID,
+		bridgeDevice,
 		false, // maintain, do not allocate.
 		kvmLogger,
 	)

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -302,8 +302,18 @@ func (s *kvmBrokerSuite) TestStartInstancePopulatesFallbackNetworkInfo(c *gc.C) 
 		nil, // HostChangesForContainer succeeds
 		errors.NotSupportedf("container address allocation"),
 	)
-	_, err := s.startInstance(c, broker, "1/kvm/2")
-	c.Assert(err, gc.ErrorMatches, "container address allocation not supported")
+	result, err := s.startInstance(c, broker, "1/kvm/2")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(result.NetworkInfo, jc.DeepEquals, []network.InterfaceInfo{{
+		DeviceIndex:         0,
+		InterfaceName:       "eth0",
+		InterfaceType:       network.EthernetInterface,
+		ConfigType:          network.ConfigDHCP,
+		ParentInterfaceName: "virbr0",
+		DNSServers:          network.NewAddresses("ns1.dummy", "ns2.dummy"),
+		DNSSearchDomains:    []string{"dummy", "invalid"},
+	}})
 }
 
 type kvmProvisionerSuite struct {

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -44,6 +44,10 @@ type lxdBroker struct {
 
 func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	containerMachineID := args.InstanceConfig.MachineId
+	bridgeDevice := broker.agentConfig.Value(agent.LxdBridge)
+	if bridgeDevice == "" {
+		bridgeDevice = network.DefaultLXDBridge
+	}
 
 	config, err := broker.api.ContainerConfig()
 	if err != nil {
@@ -59,27 +63,24 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	preparedInfo, err := prepareOrGetContainerInterfaceInfo(
 		broker.api,
 		containerMachineID,
+		bridgeDevice,
 		true, // allocate if possible, do not maintain existing.
 		lxdLogger,
 	)
 	if err != nil {
-		return nil, errors.Trace(err)
+		// It's not fatal (yet) if we couldn't pre-allocate addresses for the
+		// container.
+		logger.Warningf("failed to prepare container %q network config: %v", containerMachineID, err)
+	} else {
+		args.NetworkInfo = preparedInfo
 	}
-	// Something to fallback to if there are no devices given in args.NetworkInfo
-	// TODO(jam): 2017-02-07, this feels like something that should never need
-	// to be invoked, because either StartInstance or
-	// prepareOrGetContainerInterfaceInfo should always return a value. The
-	// test suite currently doesn't think so, and I'm hesitant to munge it too
-	// much.
-	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
-	if bridgeDevice == "" {
-		bridgeDevice = container.DefaultLxdBridge
-	}
-	interfaces, err := finishNetworkConfig(bridgeDevice, preparedInfo)
+
+	network := container.BridgeNetworkConfig(bridgeDevice, 0, args.NetworkInfo)
+	interfaces, err := finishNetworkConfig(bridgeDevice, args.NetworkInfo)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	network := container.BridgeNetworkConfig(bridgeDevice, 0, interfaces)
+	network.Interfaces = interfaces
 
 	// The provisioner worker will provide all tools it knows about
 	// (after applying explicitly specified constraints), which may
@@ -151,10 +152,17 @@ func (broker *lxdBroker) AllInstances() (result []instance.Instance, err error) 
 func (broker *lxdBroker) MaintainInstance(args environs.StartInstanceParams) error {
 	machineID := args.InstanceConfig.MachineId
 
+	// Default to using the host network until we can configure.
+	bridgeDevice := broker.agentConfig.Value(agent.LxdBridge)
+	if bridgeDevice == "" {
+		bridgeDevice = network.DefaultLXDBridge
+	}
+
 	// There's no InterfaceInfo we expect to get below.
 	_, err := prepareOrGetContainerInterfaceInfo(
 		broker.api,
 		machineID,
+		bridgeDevice,
 		false, // maintain, do not allocate.
 		lxdLogger,
 	)

--- a/worker/provisioner/lxd-broker_test.go
+++ b/worker/provisioner/lxd-broker_test.go
@@ -204,8 +204,18 @@ func (s *lxdBrokerSuite) TestStartInstancePopulatesFallbackNetworkInfo(c *gc.C) 
 		nil, // HostChangesForContainer succeeds
 		errors.NotSupportedf("container address allocation"),
 	)
-	_, err := s.startInstance(c, broker, "1/lxd/0")
-	c.Assert(err, gc.ErrorMatches, "container address allocation not supported")
+	result, err := s.startInstance(c, broker, "1/lxd/0")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(result.NetworkInfo, jc.DeepEquals, []network.InterfaceInfo{{
+		DeviceIndex:         0,
+		InterfaceName:       "eth0",
+		InterfaceType:       network.EthernetInterface,
+		ConfigType:          network.ConfigDHCP,
+		ParentInterfaceName: "lxdbr0",
+		DNSServers:          network.NewAddresses("ns1.dummy", "ns2.dummy"),
+		DNSSearchDomains:    []string{"dummy", "invalid"},
+	}})
 }
 
 func (s *lxdBrokerSuite) TestStartInstanceNoHostArchTools(c *gc.C) {


### PR DESCRIPTION
This reverts commit 7fc39387bf740fd2e738cc3644b74b44bb9efc3f, reversing
changes made to 49316b23b7d1eadbb1119372e02081468ad6ab5a.

CI found that not all clouds act like my expectation, so just reverting to unblock next 2.1 release. They still are succeeding for the 'wrong' reasons, but that's life.

https://pad.lv/1662947 to revert the "fix" for https://pad.lv/1656326