### PR TITLE
Add a global state tracker to help find leaks.

### DIFF
--- a/cmd/jujud/agent/introspection.go
+++ b/cmd/jujud/agent/introspection.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/introspection"
@@ -53,6 +54,7 @@ func startIntrospection(cfg introspectionConfig) error {
 		SocketName:         socketName,
 		DepEngine:          cfg.Engine,
 		StatePool:          cfg.StatePoolReporter,
+		StateTracker:       state.GlobalTracker,
 		PrometheusGatherer: cfg.PrometheusGatherer,
 	})
 	if err != nil {

--- a/state/open.go
+++ b/state/open.go
@@ -548,6 +548,8 @@ func newState(
 	if newPolicy != nil {
 		st.policy = newPolicy(st)
 	}
+	// Record this State instance with the global tracker.
+	GlobalTracker.Add(st)
 	return st, nil
 }
 
@@ -595,5 +597,6 @@ func (st *State) Close() (err error) {
 		return errs[0]
 	}
 	logger.Debugf("closed state without error")
+	GlobalTracker.RecordClosed(st)
 	return nil
 }

--- a/state/tracker.go
+++ b/state/tracker.go
@@ -1,0 +1,157 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/juju/loggo"
+)
+
+// GlobalTracker tracks the locations of all the State instances
+// created through the various paths. Both ForModel and Open end up
+// going through the internal newState method.
+var GlobalTracker = newTracker()
+
+type trackerStack struct {
+	uuid string
+	// Where was this State object created.
+	stack string
+	// Has the state been closed.
+	closed bool
+	// When the object was added, and closed
+	whenAdded  time.Time
+	whenClosed time.Time
+}
+
+// Tracker records the locations of all the active *State instances.
+type Tracker struct {
+	mu         sync.Mutex
+	references map[string]*trackerStack
+	logger     loggo.Logger
+}
+
+func newTracker() *Tracker {
+	return &Tracker{
+		references: make(map[string]*trackerStack),
+		logger:     loggo.GetLogger("juju.state.tracker"),
+	}
+}
+
+// We always use a uint64 as a key rather than the pointer itself
+// as to not hold a reference to the object.
+func (t *Tracker) key(s *State) string {
+	return fmt.Sprintf("%p", s)
+}
+
+// Add records the stack and uses the address of the State object
+// as a key to the internal map to record the location that the instance
+// was created from.
+func (t *Tracker) Add(s *State) {
+	stack := debug.Stack()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Use the pointer of the State as a key into the map.
+	key := t.key(s)
+
+	item := &trackerStack{
+		uuid:      s.ModelUUID(),
+		stack:     string(stack),
+		whenAdded: time.Now(),
+	}
+	t.logger.Debugf("[%p] adding key %v for %s", t, key, item.uuid)
+	t.references[key] = item
+
+	removeRef := func(st *State) {
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		key := t.key(st)
+		delete(t.references, key)
+		t.logger.Debugf("[%p] removing key %v for %s", t, key, item.uuid)
+	}
+
+	runtime.SetFinalizer(s, removeRef)
+}
+
+// RecordClosed marks the State instance as closed for reporting purposes.
+func (t *Tracker) RecordClosed(s *State) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	key := t.key(s)
+	if item, found := t.references[key]; found {
+		t.logger.Tracef("marking closed key %v for %s", key, item.uuid)
+		item.closed = true
+		item.whenClosed = time.Now()
+	} else {
+		t.logger.Debugf("missing state reference for %s", s.ModelUUID())
+	}
+}
+
+// count is used for testing only.
+func (t *Tracker) count() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.references)
+}
+
+// IntrospectionReport is used by the introspection worker to output
+// the information for the user.
+func (t *Tracker) IntrospectionReport() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	var (
+		now    = time.Now().Round(time.Second)
+		buff   = &bytes.Buffer{}
+		open   []*trackerStack
+		closed []*trackerStack
+	)
+
+	for _, item := range t.references {
+		if item.closed {
+			closed = append(closed, item)
+		} else {
+			open = append(open, item)
+		}
+	}
+
+	sort.Sort(oldestFirst(open))
+	sort.Sort(oldestFirst(closed))
+
+	outputItem := func(item *trackerStack) {
+		fmt.Fprintf(buff, "\nModel: %s\n", item.uuid)
+		d := now.Sub(item.whenAdded.Round(time.Second))
+		fmt.Fprintf(buff, "  Added: %s (%s ago)\n", item.whenAdded.Format(time.RFC1123), d)
+		if item.closed {
+			d := item.whenClosed.Sub(item.whenAdded)
+			fmt.Fprintf(buff, "  Closed: %s (open for %s)\n", item.whenClosed.Format(time.RFC1123), d)
+		}
+		fmt.Fprintf(buff, "  Location: \n%s\n", item.stack)
+	}
+
+	for _, item := range open {
+		outputItem(item)
+	}
+	for _, item := range closed {
+		outputItem(item)
+	}
+
+	return fmt.Sprintf(""+
+		"Total count: %d\n"+
+		"Closed count: %d\n"+
+		"\n%s", len(t.references), len(closed), buff)
+}
+
+type oldestFirst []*trackerStack
+
+func (d oldestFirst) Len() int           { return len(d) }
+func (d oldestFirst) Swap(i, j int)      { d[i], d[j] = d[j], d[i] }
+func (d oldestFirst) Less(i, j int) bool { return d[i].whenAdded.Before(d[j].whenAdded) }

--- a/state/tracker_test.go
+++ b/state/tracker_test.go
@@ -1,0 +1,41 @@
+package state
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type TrackerSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&TrackerSuite{})
+
+var _ = jc.Satisfies
+
+func (*TrackerSuite) TestAddsReference(c *gc.C) {
+	tracker := newTracker()
+	tracker.Add(&State{})
+	c.Assert(tracker.count(), gc.Equals, 1)
+}
+
+// Unfortunately there is no deterministic way to test the finalizer as the GC
+// will just schedule it to run at some arbitrary time after obj becomes
+// unreachable.
+
+func (*TrackerSuite) TestReport(c *gc.C) {
+	tracker := newTracker()
+	tracker.Add(&State{})
+	closed := &State{}
+	tracker.Add(closed)
+	tracker.RecordClosed(closed)
+	tracker.Add(&State{})
+
+	report := tracker.IntrospectionReport()
+	// The closed models are at the end.
+	c.Assert(report, gc.Matches, `(?ms)Total count: 3.Closed count: 1.`+
+		`.*Model:.*`+
+		`.*Model:.*`+
+		`.*Model:.*Closed: .*`)
+}

--- a/worker/introspection/script.go
+++ b/worker/introspection/script.go
@@ -81,6 +81,10 @@ juju-statepool-report () {
   jujuMachineOrUnit statepool/ $@
 }
 
+juju-statetracker-report () {
+  jujuMachineOrUnit statetracker/ $@
+}
+
 export -f jujuAgentCall
 export -f jujuMachineAgentName
 export -f jujuMachineOrUnit
@@ -88,4 +92,5 @@ export -f juju-goroutines
 export -f juju-heap-profile
 export -f juju-engine-report
 export -f juju-statepool-report
+export -f juju-statetracker-report
 `

--- a/worker/introspection/socket_test.go
+++ b/worker/introspection/socket_test.go
@@ -122,6 +122,12 @@ func (s *introspectionSuite) TestMissingStatePoolReporter(c *gc.C) {
 	matches(c, buf, "State Pool Report: missing reporter")
 }
 
+func (s *introspectionSuite) TestMissingStateTrackerReporter(c *gc.C) {
+	buf := s.call(c, "/statetracker/")
+	matches(c, buf, "404 Not Found")
+	matches(c, buf, "State Instance Report: missing reporter")
+}
+
 func (s *introspectionSuite) TestEngineReporter(c *gc.C) {
 	// We need to make sure the existing worker is shut down
 	// so we can connect to the socket.


### PR DESCRIPTION
We have a strong suspicion that the key memory leaks are due to excessive and unnecessary *state.State instances. This branch adds a global reference map that stores an item for each new state object along with the stack trace. The state close method also lets the tracker know that at least the object thinks it is closed.

This will hopefully shed light on why we have so many state instances leaking.

## QA steps

bootstrap a controller
juju ssh -m controller 0
juju-statetracker-report

