### PR TITLE
migrations: Add AdoptResources to the migrationtarget facade

### DIFF
--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -15,6 +15,7 @@ type Context struct {
 	Dispose_   func()
 	Resources_ facade.Resources
 	State_     *state.State
+	StatePool_ *state.StatePool
 	ID_        string
 	// Identity is not part of the facade.Context interface, but is instead
 	// used to make sure that the context objects are the same.
@@ -48,7 +49,7 @@ func (context Context) State() *state.State {
 
 // StatePool is part of of the facade.Context interface.
 func (context Context) StatePool() *state.StatePool {
-	return state.NewStatePool(context.State_)
+	return context.StatePool_
 }
 
 // ID is part of the facade.Context interface.

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -209,3 +209,18 @@ type MinionReports struct {
 	// failed to complete a given migration phase.
 	Failed []string `json:"failed"`
 }
+
+// AdoptResourcesArgs holds the information required to ask the
+// provider to update the controller tags for a model's
+// resources.
+type AdoptResourcesArgs struct {
+	// ModelTag identifies the model that owns the resources.
+	ModelTag string `json:"model-tag"`
+
+	// SourceControllerVersion indicates the version of the calling
+	// controller. This is needed in case the way the resources are
+	// tagged has changed between versions - the provider should
+	// ensure it looks for the original tags in the correct format for
+	// that version.
+	SourceControllerVersion version.Number `json:"source-controller-version"`
+}


### PR DESCRIPTION
## Description of change
This updates the provider tags for all cloud resources to indicate the
new controller uuid, so that they won't be cleaned up if the old
controller is destroyed. It will be called from the migrationmaster
worker when the migration is complete.

## QA steps

No QA steps yet - the code to call this during migration will be in a 
subsequent PR.

## Bug reference
Part of the fix for https://bugs.launchpad.net/juju/+bug/1648063