### PR TITLE
Add proper authorisation on the key manager facade

### DIFF
--- a/apiserver/agent/agent.go
+++ b/apiserver/agent/agent.go
@@ -104,7 +104,7 @@ func (api *AgentAPIV2) getEntity(tag names.Tag) (result params.AgentGetEntitiesR
 }
 
 func (api *AgentAPIV2) StateServingInfo() (result params.StateServingInfo, err error) {
-	if !api.auth.AuthModelManager() {
+	if !api.auth.AuthController() {
 		err = common.ErrPerm
 		return
 	}
@@ -131,7 +131,7 @@ func (api *AgentAPIV2) StateServingInfo() (result params.StateServingInfo, err e
 var MongoIsMaster = mongo.IsMaster
 
 func (api *AgentAPIV2) IsMaster() (params.IsMasterResult, error) {
-	if !api.auth.AuthModelManager() {
+	if !api.auth.AuthController() {
 		return params.IsMasterResult{}, common.ErrPerm
 	}
 
@@ -160,7 +160,7 @@ func stateJobsToAPIParamsJobs(jobs []state.MachineJob) []multiwatcher.MachineJob
 
 // WatchCredentials watches for changes to the specified credentials.
 func (api *AgentAPIV2) WatchCredentials(args params.Entities) (params.NotifyWatchResults, error) {
-	if !api.auth.AuthModelManager() {
+	if !api.auth.AuthController() {
 		return params.NotifyWatchResults{}, common.ErrPerm
 	}
 

--- a/apiserver/agent/agent_test.go
+++ b/apiserver/agent/agent_test.go
@@ -243,8 +243,8 @@ func (s *agentSuite) TestClearReboot(c *gc.C) {
 
 func (s *agentSuite) TestWatchCredentials(c *gc.C) {
 	authorizer := apiservertesting.FakeAuthorizer{
-		Tag:            names.NewMachineTag("0"),
-		EnvironManager: true,
+		Tag:        names.NewMachineTag("0"),
+		Controller: true,
 	}
 	api, err := agent.NewAgentAPIV2(s.State, s.resources, authorizer)
 	c.Assert(err, jc.ErrorIsNil)
@@ -267,8 +267,8 @@ func (s *agentSuite) TestWatchCredentials(c *gc.C) {
 
 func (s *agentSuite) TestWatchAuthError(c *gc.C) {
 	authorizer := apiservertesting.FakeAuthorizer{
-		Tag:            names.NewMachineTag("1"),
-		EnvironManager: false,
+		Tag:        names.NewMachineTag("1"),
+		Controller: false,
 	}
 	api, err := agent.NewAgentAPIV2(s.State, s.resources, authorizer)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/agenttools/agenttools.go
+++ b/apiserver/agenttools/agenttools.go
@@ -137,7 +137,7 @@ func updateToolsAvailability(modelGetter ModelGetter, newEnviron newEnvironFunc,
 // UpdateToolsAvailable invokes a lookup and further update in environ
 // for new patches of the current tool versions.
 func (api *AgentToolsAPI) UpdateToolsAvailable() error {
-	if !api.authorizer.AuthModelManager() {
+	if !api.authorizer.AuthController() {
 		return common.ErrPerm
 	}
 	return updateToolsAvailability(api.modelGetter, api.newEnviron, api.findTools, api.envVersionUpdate)

--- a/apiserver/applicationscaler/facade.go
+++ b/apiserver/applicationscaler/facade.go
@@ -33,7 +33,7 @@ type Facade struct {
 
 // NewFacade creates a new authorized Facade.
 func NewFacade(backend Backend, res facade.Resources, auth facade.Authorizer) (*Facade, error) {
-	if !auth.AuthModelManager() {
+	if !auth.AuthController() {
 		return nil, common.ErrPerm
 	}
 	return &Facade{

--- a/apiserver/applicationscaler/util_test.go
+++ b/apiserver/applicationscaler/util_test.go
@@ -21,7 +21,7 @@ type mockAuth struct {
 	modelManager bool
 }
 
-func (mock mockAuth) AuthModelManager() bool {
+func (mock mockAuth) AuthController() bool {
 	return mock.modelManager
 }
 

--- a/apiserver/block/client_test.go
+++ b/apiserver/block/client_test.go
@@ -28,8 +28,8 @@ func (s *blockSuite) SetUpTest(c *gc.C) {
 
 	var err error
 	auth := testing.FakeAuthorizer{
-		Tag:            s.AdminUserTag(c),
-		EnvironManager: true,
+		Tag:        s.AdminUserTag(c),
+		Controller: true,
 	}
 	s.api, err = block.NewAPI(s.State, common.NewResources(), auth)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/charmrevisionupdater/updater.go
+++ b/apiserver/charmrevisionupdater/updater.go
@@ -41,7 +41,7 @@ func NewCharmRevisionUpdaterAPI(
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*CharmRevisionUpdaterAPI, error) {
-	if !authorizer.AuthMachineAgent() && !authorizer.AuthModelManager() {
+	if !authorizer.AuthMachineAgent() && !authorizer.AuthController() {
 		return nil, common.ErrPerm
 	}
 	return &CharmRevisionUpdaterAPI{

--- a/apiserver/charmrevisionupdater/updater_test.go
+++ b/apiserver/charmrevisionupdater/updater_test.go
@@ -51,7 +51,7 @@ func (s *charmVersionSuite) SetUpTest(c *gc.C) {
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 	s.authoriser = apiservertesting.FakeAuthorizer{
-		EnvironManager: true,
+		Controller: true,
 	}
 	var err error
 	s.charmrevisionupdater, err = charmrevisionupdater.NewCharmRevisionUpdaterAPI(s.State, s.resources, s.authoriser)
@@ -71,7 +71,7 @@ func (s *charmVersionSuite) TestNewCharmRevisionUpdaterAPIAcceptsStateManager(c 
 
 func (s *charmVersionSuite) TestNewCharmRevisionUpdaterAPIRefusesNonStateManager(c *gc.C) {
 	anAuthoriser := s.authoriser
-	anAuthoriser.EnvironManager = false
+	anAuthoriser.Controller = false
 	endPoint, err := charmrevisionupdater.NewCharmRevisionUpdaterAPI(s.State, s.resources, anAuthoriser)
 	c.Assert(endPoint, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "permission denied")

--- a/apiserver/charms/client_test.go
+++ b/apiserver/charms/client_test.go
@@ -28,8 +28,8 @@ func (s *charmsSuite) SetUpTest(c *gc.C) {
 
 	var err error
 	auth := testing.FakeAuthorizer{
-		Tag:            s.AdminUserTag(c),
-		EnvironManager: true,
+		Tag:        s.AdminUserTag(c),
+		Controller: true,
 	}
 	s.api, err = charms.NewAPI(s.State, common.NewResources(), auth)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/cleaner/cleaner.go
+++ b/apiserver/cleaner/cleaner.go
@@ -30,7 +30,7 @@ func NewCleanerAPI(
 	res facade.Resources,
 	authorizer facade.Authorizer,
 ) (*CleanerAPI, error) {
-	if !authorizer.AuthModelManager() {
+	if !authorizer.AuthController() {
 		return nil, common.ErrPerm
 	}
 	return &CleanerAPI{

--- a/apiserver/cleaner/cleaner_test.go
+++ b/apiserver/cleaner/cleaner_test.go
@@ -31,7 +31,7 @@ func (s *CleanerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
 	s.authoriser = apiservertesting.FakeAuthorizer{
-		EnvironManager: true,
+		Controller: true,
 	}
 	s.st = &mockState{&testing.Stub{}, false}
 	cleaner.PatchState(s, s.st)
@@ -44,7 +44,7 @@ func (s *CleanerSuite) SetUpTest(c *gc.C) {
 
 func (s *CleanerSuite) TestNewCleanerAPIRequiresEnvironManager(c *gc.C) {
 	anAuthoriser := s.authoriser
-	anAuthoriser.EnvironManager = false
+	anAuthoriser.Controller = false
 	api, err := cleaner.NewCleanerAPI(nil, nil, anAuthoriser)
 	c.Assert(api, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "permission denied")

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -63,8 +63,8 @@ func (s *serverSuite) SetUpTest(c *gc.C) {
 
 func (s *serverSuite) clientForState(c *gc.C, st *state.State) *client.Client {
 	auth := testing.FakeAuthorizer{
-		Tag:            s.AdminUserTag(c),
-		EnvironManager: true,
+		Tag:        s.AdminUserTag(c),
+		Controller: true,
 	}
 	urlGetter := common.NewToolsURLGetter(st.ModelUUID(), st)
 	configGetter := stateenvirons.EnvironConfigGetter{st}

--- a/apiserver/client/status_test.go
+++ b/apiserver/client/status_test.go
@@ -380,7 +380,7 @@ func (s *statusUpgradeUnitSuite) SetUpTest(c *gc.C) {
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 	s.authoriser = apiservertesting.FakeAuthorizer{
-		EnvironManager: true,
+		Controller: true,
 	}
 	var err error
 	s.charmrevisionupdater, err = charmrevisionupdater.NewCharmRevisionUpdaterAPI(s.State, s.resources, s.authoriser)

--- a/apiserver/cloud/instance_information_test.go
+++ b/apiserver/cloud/instance_information_test.go
@@ -32,7 +32,7 @@ func (p *instanceTypesSuite) TestInstanceTypes(c *gc.C) {
 		cloudSpec: environs.CloudSpec{},
 	}
 	authorizer := testing.FakeAuthorizer{Tag: names.NewUserTag("admin"),
-		EnvironManager: true}
+		Controller: true}
 	itCons := constraints.Value{CpuCores: &over9kCPUCores}
 	failureCons := constraints.Value{}
 	env := mockEnviron{

--- a/apiserver/common/modelmachineswatcher.go
+++ b/apiserver/common/modelmachineswatcher.go
@@ -36,7 +36,7 @@ func NewModelMachinesWatcher(st state.ModelMachinesWatcher, resources facade.Res
 // model.
 func (e *ModelMachinesWatcher) WatchModelMachines() (params.StringsWatchResult, error) {
 	result := params.StringsWatchResult{}
-	if !e.authorizer.AuthModelManager() {
+	if !e.authorizer.AuthController() {
 		return result, ErrPerm
 	}
 	watch := e.st.WatchModelMachines()

--- a/apiserver/common/modelmachineswatcher_test.go
+++ b/apiserver/common/modelmachineswatcher_test.go
@@ -35,8 +35,8 @@ func (f *fakeModelMachinesWatcher) WatchModelMachines() state.StringsWatcher {
 
 func (s *modelMachinesWatcherSuite) TestWatchModelMachines(c *gc.C) {
 	authorizer := apiservertesting.FakeAuthorizer{
-		Tag:            names.NewMachineTag("0"),
-		EnvironManager: true,
+		Tag:        names.NewMachineTag("0"),
+		Controller: true,
 	}
 	resources := common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { resources.StopAll() })
@@ -53,8 +53,8 @@ func (s *modelMachinesWatcherSuite) TestWatchModelMachines(c *gc.C) {
 
 func (s *modelMachinesWatcherSuite) TestWatchAuthError(c *gc.C) {
 	authorizer := apiservertesting.FakeAuthorizer{
-		Tag:            names.NewMachineTag("1"),
-		EnvironManager: false,
+		Tag:        names.NewMachineTag("1"),
+		Controller: false,
 	}
 	resources := common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { resources.StopAll() })

--- a/apiserver/common/modelwatcher_test.go
+++ b/apiserver/common/modelwatcher_test.go
@@ -67,8 +67,8 @@ func (s *environWatcherSuite) TestWatchSuccess(c *gc.C) {
 
 func (*environWatcherSuite) TestModelConfigSuccess(c *gc.C) {
 	authorizer := apiservertesting.FakeAuthorizer{
-		Tag:            names.NewMachineTag("0"),
-		EnvironManager: true,
+		Tag:        names.NewMachineTag("0"),
+		Controller: true,
 	}
 	testingEnvConfig := testingEnvConfig(c)
 	e := common.NewModelWatcher(
@@ -85,8 +85,8 @@ func (*environWatcherSuite) TestModelConfigSuccess(c *gc.C) {
 
 func (*environWatcherSuite) TestModelConfigFetchError(c *gc.C) {
 	authorizer := apiservertesting.FakeAuthorizer{
-		Tag:            names.NewMachineTag("0"),
-		EnvironManager: true,
+		Tag:        names.NewMachineTag("0"),
+		Controller: true,
 	}
 	e := common.NewModelWatcher(
 		&fakeModelAccessor{

--- a/apiserver/crossmodel/base_test.go
+++ b/apiserver/crossmodel/base_test.go
@@ -52,7 +52,7 @@ func (s *baseCrossmodelSuite) addApplication(c *gc.C, name string) jujucrossmode
 func (s *baseCrossmodelSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.resources = common.NewResources()
-	s.authorizer = testing.FakeAuthorizer{Tag: names.NewUserTag("testuser"), EnvironManager: true}
+	s.authorizer = testing.FakeAuthorizer{Tag: names.NewUserTag("testuser"), Controller: true}
 
 	s.applicationDirectory = &mockApplicationOffersAPI{}
 

--- a/apiserver/crossmodel/offeredapplications.go
+++ b/apiserver/crossmodel/offeredapplications.go
@@ -40,7 +40,7 @@ func createOfferedApplicationAPI(
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*OfferedApplicationAPI, error) {
-	if !authorizer.AuthModelManager() {
+	if !authorizer.AuthController() {
 		return nil, common.ErrPerm
 	}
 

--- a/apiserver/crossmodel/offeredapplications_test.go
+++ b/apiserver/crossmodel/offeredapplications_test.go
@@ -35,7 +35,7 @@ var _ = gc.Suite(&offeredApplicationsSuite{})
 func (s *offeredApplicationsSuite) SetUpTest(c *gc.C) {
 	s.SetInitialFeatureFlags(feature.CrossModelRelations)
 	s.authoriser = testing.FakeAuthorizer{
-		EnvironManager: true,
+		Controller: true,
 	}
 	s.resources = common.NewResources()
 	s.AddCleanup(func(*gc.C) { s.resources.StopAll() })
@@ -51,7 +51,7 @@ func (s *offeredApplicationsSuite) SetUpTest(c *gc.C) {
 
 func (s *offeredApplicationsSuite) TestUnauthorised(c *gc.C) {
 	s.authoriser = testing.FakeAuthorizer{
-		EnvironManager: false,
+		Controller: false,
 	}
 	_, err := crossmodel.CreateOfferedApplicationAPI(&mockState{}, s.offerLister, s.resources, s.authoriser)
 	c.Assert(err, gc.Equals, common.ErrPerm)
@@ -59,7 +59,7 @@ func (s *offeredApplicationsSuite) TestUnauthorised(c *gc.C) {
 
 func (s *offeredApplicationsSuite) TestWatchOfferedApplications(c *gc.C) {
 	authoriser := testing.FakeAuthorizer{
-		EnvironManager: true,
+		Controller: true,
 	}
 	resources := common.NewResources()
 	defer resources.StopAll()

--- a/apiserver/discoverspaces/discoverspaces.go
+++ b/apiserver/discoverspaces/discoverspaces.go
@@ -29,7 +29,7 @@ func NewDiscoverSpacesAPI(st *state.State, resources facade.Resources, authorize
 }
 
 func NewDiscoverSpacesAPIWithBacking(st networkingcommon.NetworkBacking, resources facade.Resources, authorizer facade.Authorizer) (*DiscoverSpacesAPI, error) {
-	if !authorizer.AuthModelManager() {
+	if !authorizer.AuthController() {
 		return nil, common.ErrPerm
 	}
 	return &DiscoverSpacesAPI{

--- a/apiserver/discoverspaces/discoverspaces_test.go
+++ b/apiserver/discoverspaces/discoverspaces_test.go
@@ -48,8 +48,8 @@ func (s *DiscoverSpacesSuite) SetUpTest(c *gc.C) {
 
 	s.resources = common.NewResources()
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		Tag:            names.NewUserTag("admin"),
-		EnvironManager: true,
+		Tag:        names.NewUserTag("admin"),
+		Controller: true,
 	}
 
 	var err error

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -80,12 +80,12 @@ type Authorizer interface {
 	// GetAuthTag returns the entity's tag.
 	GetAuthTag() names.Tag
 
-	// AuthModelManager returns whether the authenticated entity is
-	// a machine running the environment manager job. Can't be
-	// removed from this interface without introducing a dependency
-	// on something else to look up that property: it's not inherent
-	// in the result of GetAuthTag, as the other methods all are.
-	AuthModelManager() bool
+	// AuthController returns whether the authenticated entity is
+	// a machine acting as a controller. Can't be removed from this
+	// interface without introducing a dependency on something else
+	// to look up that property: it's not inherent in the result of
+	// GetAuthTag, as the other methods all are.
+	AuthController() bool
 
 	// AuthMachineAgent returns true if the entity is a machine
 	// agent. Doesn't need to be on this interface, should be a

--- a/apiserver/firewaller/firewaller.go
+++ b/apiserver/firewaller/firewaller.go
@@ -47,7 +47,7 @@ func NewFirewallerAPI(
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*FirewallerAPI, error) {
-	if !authorizer.AuthModelManager() {
+	if !authorizer.AuthController() {
 		// Firewaller must run as environment manager.
 		return nil, common.ErrPerm
 	}

--- a/apiserver/firewaller/firewaller_base_test.go
+++ b/apiserver/firewaller/firewaller_base_test.go
@@ -62,7 +62,7 @@ func (s *firewallerBaseSuite) setUpTest(c *gc.C) {
 	// Create a FakeAuthorizer so we can check permissions,
 	// set up assuming we logged in as the environment manager.
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		EnvironManager: true,
+		Controller: true,
 	}
 
 	// Create the resource registry separately to track invocations to
@@ -75,7 +75,7 @@ func (s *firewallerBaseSuite) testFirewallerFailsWithNonEnvironManagerUser(
 	factory func(_ *state.State, _ facade.Resources, _ facade.Authorizer) error,
 ) {
 	anAuthorizer := s.authorizer
-	anAuthorizer.EnvironManager = false
+	anAuthorizer.Controller = false
 	err := factory(s.State, s.resources, anAuthorizer)
 	c.Assert(err, gc.NotNil)
 	c.Assert(err, gc.ErrorMatches, "permission denied")

--- a/apiserver/highavailability/highavailability.go
+++ b/apiserver/highavailability/highavailability.go
@@ -44,7 +44,7 @@ var _ HighAvailability = (*HighAvailabilityAPI)(nil)
 // NewHighAvailabilityAPI creates a new server-side highavailability API end point.
 func NewHighAvailabilityAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*HighAvailabilityAPI, error) {
 	// Only clients and model managers can access the high availability facade.
-	if !authorizer.AuthClient() && !authorizer.AuthModelManager() {
+	if !authorizer.AuthClient() && !authorizer.AuthController() {
 		return nil, common.ErrPerm
 	}
 	return &HighAvailabilityAPI{

--- a/apiserver/highavailability/highavailability_test.go
+++ b/apiserver/highavailability/highavailability_test.go
@@ -60,8 +60,8 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
 	s.authoriser = apiservertesting.FakeAuthorizer{
-		Tag:            s.AdminUserTag(c),
-		EnvironManager: true,
+		Tag:        s.AdminUserTag(c),
+		Controller: true,
 	}
 
 	var err error

--- a/apiserver/imagemanager/imagemanager_test.go
+++ b/apiserver/imagemanager/imagemanager_test.go
@@ -58,7 +58,7 @@ func (s *imageManagerSuite) TestNewImageManagerAPIAcceptsClient(c *gc.C) {
 func (s *imageManagerSuite) TestNewImageManagerAPIRefusesNonClient(c *gc.C) {
 	anAuthoriser := s.authoriser
 	anAuthoriser.Tag = names.NewUnitTag("mysql/0")
-	anAuthoriser.EnvironManager = false
+	anAuthoriser.Controller = false
 	endPoint, err := imagemanager.NewImageManagerAPI(s.State, s.resources, anAuthoriser)
 	c.Assert(endPoint, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "permission denied")

--- a/apiserver/imagemetadata/metadata.go
+++ b/apiserver/imagemetadata/metadata.go
@@ -45,7 +45,7 @@ func createAPI(
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*API, error) {
-	if !authorizer.AuthClient() && !authorizer.AuthModelManager() {
+	if !authorizer.AuthClient() && !authorizer.AuthController() {
 		return nil, common.ErrPerm
 	}
 

--- a/apiserver/imagemetadata/package_test.go
+++ b/apiserver/imagemetadata/package_test.go
@@ -43,7 +43,7 @@ func (s *baseImageMetadataSuite) SetUpSuite(c *gc.C) {
 func (s *baseImageMetadataSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.resources = common.NewResources()
-	s.authorizer = testing.FakeAuthorizer{Tag: names.NewUserTag("testuser"), EnvironManager: true, AdminTag: names.NewUserTag("testuser")}
+	s.authorizer = testing.FakeAuthorizer{Tag: names.NewUserTag("testuser"), Controller: true, AdminTag: names.NewUserTag("testuser")}
 
 	s.state = s.constructState(testConfig(c), &mockModel{"meep"})
 

--- a/apiserver/instancepoller/instancepoller.go
+++ b/apiserver/instancepoller/instancepoller.go
@@ -53,7 +53,7 @@ func NewInstancePollerAPI(
 	clock clock.Clock,
 ) (*InstancePollerAPI, error) {
 
-	if !authorizer.AuthModelManager() {
+	if !authorizer.AuthController() {
 		// InstancePoller must run as environment manager.
 		return nil, common.ErrPerm
 	}

--- a/apiserver/instancepoller/instancepoller_test.go
+++ b/apiserver/instancepoller/instancepoller_test.go
@@ -46,7 +46,7 @@ func (s *InstancePollerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
 	s.authoriser = apiservertesting.FakeAuthorizer{
-		EnvironManager: true,
+		Controller: true,
 	}
 	s.resources = common.NewResources()
 	s.AddCleanup(func(*gc.C) { s.resources.StopAll() })
@@ -98,7 +98,7 @@ func (s *InstancePollerSuite) SetUpTest(c *gc.C) {
 
 func (s *InstancePollerSuite) TestNewInstancePollerAPIRequiresEnvironManager(c *gc.C) {
 	anAuthoriser := s.authoriser
-	anAuthoriser.EnvironManager = false
+	anAuthoriser.Controller = false
 	api, err := instancepoller.NewInstancePollerAPI(nil, s.resources, anAuthoriser, s.clock)
 	c.Assert(api, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "permission denied")

--- a/apiserver/lifeflag/facade.go
+++ b/apiserver/lifeflag/facade.go
@@ -17,7 +17,7 @@ type Backend interface {
 }
 
 func NewFacade(backend Backend, resources facade.Resources, authorizer facade.Authorizer) (*Facade, error) {
-	if !authorizer.AuthModelManager() {
+	if !authorizer.AuthController() {
 		return nil, common.ErrPerm
 	}
 	expect := names.NewModelTag(backend.ModelUUID())

--- a/apiserver/lifeflag/util_test.go
+++ b/apiserver/lifeflag/util_test.go
@@ -19,7 +19,7 @@ type mockAuth struct {
 	modelManager bool
 }
 
-func (mock mockAuth) AuthModelManager() bool {
+func (mock mockAuth) AuthController() bool {
 	return mock.modelManager
 }
 

--- a/apiserver/machinemanager/instance_information_test.go
+++ b/apiserver/machinemanager/instance_information_test.go
@@ -32,7 +32,7 @@ func (p *instanceTypesSuite) TestInstanceTypes(c *gc.C) {
 		cloudSpec: environs.CloudSpec{},
 	}
 	authorizer := testing.FakeAuthorizer{Tag: names.NewUserTag("admin"),
-		EnvironManager: true}
+		Controller: true}
 	itCons := constraints.Value{CpuCores: &over9kCPUCores}
 	failureCons := constraints.Value{}
 	env := mockEnviron{

--- a/apiserver/machineundertaker/undertaker.go
+++ b/apiserver/machineundertaker/undertaker.go
@@ -33,7 +33,7 @@ type API struct {
 // find out what provider-level resources need to be cleaned up when a
 // machine goes away.
 func NewAPI(backend Backend, resources facade.Resources, authorizer facade.Authorizer) (*API, error) {
-	if !authorizer.AuthModelManager() {
+	if !authorizer.AuthController() {
 		return nil, errors.Trace(common.ErrPerm)
 	}
 

--- a/apiserver/machineundertaker/undertaker_test.go
+++ b/apiserver/machineundertaker/undertaker_test.go
@@ -35,13 +35,13 @@ func (*undertakerSuite) TestRequiresModelManager(c *gc.C) {
 	_, err := machineundertaker.NewAPI(
 		backend,
 		nil,
-		apiservertesting.FakeAuthorizer{EnvironManager: false},
+		apiservertesting.FakeAuthorizer{Controller: false},
 	)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	_, err = machineundertaker.NewAPI(
 		backend,
 		nil,
-		apiservertesting.FakeAuthorizer{EnvironManager: true},
+		apiservertesting.FakeAuthorizer{Controller: true},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -225,8 +225,8 @@ func makeAPI(c *gc.C, modelUUID string) (*mockBackend, *common.Resources, *machi
 		backend,
 		res,
 		apiservertesting.FakeAuthorizer{
-			EnvironManager: true,
-			ModelUUID:      modelUUID,
+			Controller: true,
+			ModelUUID:  modelUUID,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/metricsadder/metricsadder_test.go
+++ b/apiserver/metricsadder/metricsadder_test.go
@@ -226,7 +226,7 @@ func (s *metricsAdderSuite) TestNewMetricsAdderAPIRefusesNonAgent(c *gc.C) {
 		c.Logf("test %d", i)
 
 		anAuthoriser := s.authorizer
-		anAuthoriser.EnvironManager = test.environManager
+		anAuthoriser.Controller = test.environManager
 		anAuthoriser.Tag = test.tag
 		endPoint, err := metricsadder.NewMetricsAdderAPI(s.State, nil, anAuthoriser)
 		if test.expectedError == "" {

--- a/apiserver/metricsmanager/metricsmanager.go
+++ b/apiserver/metricsmanager/metricsmanager.go
@@ -62,7 +62,7 @@ func NewMetricsManagerAPI(
 	authorizer facade.Authorizer,
 	clock clock.Clock,
 ) (*MetricsManagerAPI, error) {
-	if !(authorizer.AuthMachineAgent() && authorizer.AuthModelManager()) {
+	if !(authorizer.AuthMachineAgent() && authorizer.AuthController()) {
 		return nil, common.ErrPerm
 	}
 

--- a/apiserver/metricsmanager/metricsmanager_test.go
+++ b/apiserver/metricsmanager/metricsmanager_test.go
@@ -37,8 +37,8 @@ var _ = gc.Suite(&metricsManagerSuite{})
 func (s *metricsManagerSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		Tag:            names.NewMachineTag("0"),
-		EnvironManager: true,
+		Tag:        names.NewMachineTag("0"),
+		Controller: true,
 	}
 	s.clock = jujutesting.NewClock(time.Now())
 	manager, err := metricsmanager.NewMetricsManagerAPI(s.State, nil, s.authorizer, s.clock)
@@ -64,7 +64,7 @@ func (s *metricsManagerSuite) TestNewMetricsManagerAPIRefusesNonMachine(c *gc.C)
 		c.Logf("test %d", i)
 
 		anAuthoriser := s.authorizer
-		anAuthoriser.EnvironManager = test.environManager
+		anAuthoriser.Controller = test.environManager
 		anAuthoriser.Tag = test.tag
 		endPoint, err := metricsmanager.NewMetricsManagerAPI(s.State, nil, anAuthoriser, jujutesting.NewClock(time.Now()))
 		if test.expectedError == "" {

--- a/apiserver/migrationmaster/facade.go
+++ b/apiserver/migrationmaster/facade.go
@@ -42,7 +42,7 @@ func NewAPI(
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*API, error) {
-	if !authorizer.AuthModelManager() {
+	if !authorizer.AuthController() {
 		return nil, common.ErrPerm
 	}
 	return &API{

--- a/apiserver/migrationmaster/facade_test.go
+++ b/apiserver/migrationmaster/facade_test.go
@@ -59,12 +59,12 @@ func (s *Suite) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(*gc.C) { s.resources.StopAll() })
 
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		EnvironManager: true,
+		Controller: true,
 	}
 }
 
 func (s *Suite) TestNotEnvironManager(c *gc.C) {
-	s.authorizer.EnvironManager = false
+	s.authorizer.Controller = false
 
 	api, err := s.makeAPI()
 	c.Assert(api, gc.IsNil)

--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -44,7 +44,7 @@ func (s *containerProvisionerSuite) TestPrepareContainerInterfaceInfoPermission(
 	addContainerToMachine(c, s.State, s.machines[2])
 
 	anAuthorizer := s.authorizer
-	anAuthorizer.EnvironManager = false
+	anAuthorizer.Controller = false
 	anAuthorizer.Tag = s.machines[1].Tag()
 	aProvisioner, err := provisioner.NewProvisionerAPI(s.State, s.resources, anAuthorizer)
 	c.Assert(err, jc.ErrorIsNil)
@@ -92,7 +92,7 @@ func (s *containerProvisionerSuite) TestHostChangesForContainersPermission(c *gc
 	addContainerToMachine(c, s.State, s.machines[2])
 
 	anAuthorizer := s.authorizer
-	anAuthorizer.EnvironManager = false
+	anAuthorizer.Controller = false
 	anAuthorizer.Tag = s.machines[1].Tag()
 	aProvisioner, err := provisioner.NewProvisionerAPI(s.State, s.resources, anAuthorizer)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -65,11 +65,11 @@ type ProvisionerAPI struct {
 
 // NewProvisionerAPI creates a new server-side ProvisionerAPI facade.
 func NewProvisionerAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*ProvisionerAPI, error) {
-	if !authorizer.AuthMachineAgent() && !authorizer.AuthModelManager() {
+	if !authorizer.AuthMachineAgent() && !authorizer.AuthController() {
 		return nil, common.ErrPerm
 	}
 	getAuthFunc := func() (common.AuthFunc, error) {
-		isModelManager := authorizer.AuthModelManager()
+		isModelManager := authorizer.AuthController()
 		isMachineAgent := authorizer.AuthMachineAgent()
 		authEntityTag := authorizer.GetAuthTag()
 
@@ -515,7 +515,7 @@ func (p *ProvisionerAPI) SetInstanceInfo(args params.InstancesInfo) (params.Erro
 // the provisioner should retry provisioning machines with transient errors.
 func (p *ProvisionerAPI) WatchMachineErrorRetry() (params.NotifyWatchResult, error) {
 	result := params.NotifyWatchResult{}
-	if !p.authorizer.AuthModelManager() {
+	if !p.authorizer.AuthController() {
 		return result, common.ErrPerm
 	}
 	watch := newWatchMachineErrorRetry()

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -75,7 +75,7 @@ func (s *provisionerSuite) setUpTest(c *gc.C, withController bool) {
 	// Create a FakeAuthorizer so we can check permissions,
 	// set up assuming we logged in as the environment manager.
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		EnvironManager: true,
+		Controller: true,
 	}
 
 	// Create the resource registry separately to track invocations to
@@ -106,14 +106,14 @@ func (s *withoutControllerSuite) SetUpTest(c *gc.C) {
 
 func (s *withoutControllerSuite) TestProvisionerFailsWithNonMachineAgentNonManagerUser(c *gc.C) {
 	anAuthorizer := s.authorizer
-	anAuthorizer.EnvironManager = true
+	anAuthorizer.Controller = true
 	// Works with an environment manager, which is not a machine agent.
 	aProvisioner, err := provisioner.NewProvisionerAPI(s.State, s.resources, anAuthorizer)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(aProvisioner, gc.NotNil)
 
 	// But fails with neither a machine agent or an environment manager.
-	anAuthorizer.EnvironManager = false
+	anAuthorizer.Controller = false
 	aProvisioner, err = provisioner.NewProvisionerAPI(s.State, s.resources, anAuthorizer)
 	c.Assert(err, gc.NotNil)
 	c.Assert(aProvisioner, gc.IsNil)
@@ -183,7 +183,7 @@ func (s *withoutControllerSuite) TestLifeAsMachineAgent(c *gc.C) {
 
 	// Login as a machine agent for machine 0.
 	anAuthorizer := s.authorizer
-	anAuthorizer.EnvironManager = false
+	anAuthorizer.Controller = false
 	anAuthorizer.Tag = s.machines[0].Tag()
 	aProvisioner, err := provisioner.NewProvisionerAPI(s.State, s.resources, anAuthorizer)
 	c.Assert(err, jc.ErrorIsNil)
@@ -484,7 +484,7 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrors(c *gc.C) {
 func (s *withoutControllerSuite) TestMachinesWithTransientErrorsPermission(c *gc.C) {
 	// Machines where there's permission issues are omitted.
 	anAuthorizer := s.authorizer
-	anAuthorizer.EnvironManager = false
+	anAuthorizer.Controller = false
 	anAuthorizer.Tag = names.NewMachineTag("1")
 	aProvisioner, err := provisioner.NewProvisionerAPI(s.State, s.resources,
 		anAuthorizer)
@@ -671,7 +671,7 @@ func (s *withoutControllerSuite) TestModelConfigNonManager(c *gc.C) {
 	// the secret attributes are masked.
 	anAuthorizer := s.authorizer
 	anAuthorizer.Tag = names.NewMachineTag("1")
-	anAuthorizer.EnvironManager = false
+	anAuthorizer.Controller = false
 	aProvisioner, err := provisioner.NewProvisionerAPI(s.State, s.resources,
 		anAuthorizer)
 	c.Assert(err, jc.ErrorIsNil)
@@ -916,7 +916,7 @@ func (s *withoutControllerSuite) TestDistributionGroupEnvironManagerAuth(c *gc.C
 func (s *withoutControllerSuite) TestDistributionGroupMachineAgentAuth(c *gc.C) {
 	anAuthorizer := s.authorizer
 	anAuthorizer.Tag = names.NewMachineTag("1")
-	anAuthorizer.EnvironManager = false
+	anAuthorizer.Controller = false
 	provisioner, err := provisioner.NewProvisionerAPI(s.State, s.resources, anAuthorizer)
 	c.Check(err, jc.ErrorIsNil)
 	args := params.Entities{Entities: []params.Entity{
@@ -1143,7 +1143,7 @@ func (s *withoutControllerSuite) TestWatchModelMachines(c *gc.C) {
 	// Make sure WatchModelMachines fails with a machine agent login.
 	anAuthorizer := s.authorizer
 	anAuthorizer.Tag = names.NewMachineTag("1")
-	anAuthorizer.EnvironManager = false
+	anAuthorizer.Controller = false
 	aProvisioner, err := provisioner.NewProvisionerAPI(s.State, s.resources, anAuthorizer)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1218,7 +1218,7 @@ func (s *withoutControllerSuite) TestSetSupportedContainers(c *gc.C) {
 func (s *withoutControllerSuite) TestSetSupportedContainersPermissions(c *gc.C) {
 	// Login as a machine agent for machine 0.
 	anAuthorizer := s.authorizer
-	anAuthorizer.EnvironManager = false
+	anAuthorizer.Controller = false
 	anAuthorizer.Tag = s.machines[0].Tag()
 	aProvisioner, err := provisioner.NewProvisionerAPI(s.State, s.resources, anAuthorizer)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1334,7 +1334,7 @@ func (s *withoutControllerSuite) TestWatchMachineErrorRetry(c *gc.C) {
 	// Make sure WatchMachineErrorRetry fails with a machine agent login.
 	anAuthorizer := s.authorizer
 	anAuthorizer.Tag = names.NewMachineTag("1")
-	anAuthorizer.EnvironManager = false
+	anAuthorizer.Controller = false
 	aProvisioner, err := provisioner.NewProvisionerAPI(s.State, s.resources, anAuthorizer)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/provisioner/provisioninginfo_test.go
+++ b/apiserver/provisioner/provisioninginfo_test.go
@@ -327,7 +327,7 @@ func (s *withoutControllerSuite) TestStorageProviderFallbackToType(c *gc.C) {
 func (s *withoutControllerSuite) TestProvisioningInfoPermissions(c *gc.C) {
 	// Login as a machine agent for machine 0.
 	anAuthorizer := s.authorizer
-	anAuthorizer.EnvironManager = false
+	anAuthorizer.Controller = false
 	anAuthorizer.Tag = s.machines[0].Tag()
 	aProvisioner, err := provisioner.NewProvisionerAPI(s.State, s.resources, anAuthorizer)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/proxyupdater/proxyupdater_test.go
+++ b/apiserver/proxyupdater/proxyupdater_test.go
@@ -45,8 +45,8 @@ func (s *ProxyUpdaterSuite) SetUpTest(c *gc.C) {
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		Tag:            names.NewMachineTag("1"),
-		EnvironManager: false,
+		Tag:        names.NewMachineTag("1"),
+		Controller: false,
 	}
 	s.tag = names.NewMachineTag("1")
 	s.state = &stubBackend{}

--- a/apiserver/remoterelations/remoterelations.go
+++ b/apiserver/remoterelations/remoterelations.go
@@ -51,7 +51,7 @@ func NewRemoteRelationsAPI(
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*RemoteRelationsAPI, error) {
-	if !authorizer.AuthModelManager() {
+	if !authorizer.AuthController() {
 		return nil, common.ErrPerm
 	}
 	return &RemoteRelationsAPI{

--- a/apiserver/remoterelations/remoterelations_test.go
+++ b/apiserver/remoterelations/remoterelations_test.go
@@ -38,8 +38,8 @@ func (s *remoteRelationsSuite) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
 	s.authorizer = &apiservertesting.FakeAuthorizer{
-		Tag:            names.NewMachineTag("0"),
-		EnvironManager: true,
+		Tag:        names.NewMachineTag("0"),
+		Controller: true,
 	}
 
 	s.st = newMockState()

--- a/apiserver/resumer/resumer.go
+++ b/apiserver/resumer/resumer.go
@@ -23,7 +23,7 @@ type ResumerAPI struct {
 
 // NewResumerAPI creates a new instance of the Resumer API.
 func NewResumerAPI(st *state.State, _ facade.Resources, authorizer facade.Authorizer) (*ResumerAPI, error) {
-	if !authorizer.AuthModelManager() {
+	if !authorizer.AuthController() {
 		return nil, common.ErrPerm
 	}
 	return &ResumerAPI{

--- a/apiserver/resumer/resumer_test.go
+++ b/apiserver/resumer/resumer_test.go
@@ -29,7 +29,7 @@ func (s *ResumerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
 	s.authoriser = apiservertesting.FakeAuthorizer{
-		EnvironManager: true,
+		Controller: true,
 	}
 	s.st = &mockState{&testing.Stub{}}
 	resumer.PatchState(s, s.st)
@@ -40,7 +40,7 @@ func (s *ResumerSuite) SetUpTest(c *gc.C) {
 
 func (s *ResumerSuite) TestNewResumerAPIRequiresEnvironManager(c *gc.C) {
 	anAuthoriser := s.authoriser
-	anAuthoriser.EnvironManager = false
+	anAuthoriser.Controller = false
 	api, err := resumer.NewResumerAPI(nil, nil, anAuthoriser)
 	c.Assert(api, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "permission denied")

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -357,7 +357,7 @@ func (r *apiHandler) AuthOwner(tag names.Tag) bool {
 
 // AuthModelManager returns whether the authenticated user is a
 // machine with running the ManageEnviron job.
-func (r *apiHandler) AuthModelManager() bool {
+func (r *apiHandler) AuthController() bool {
 	return isMachineWithJob(r.entity, state.JobManageModel)
 }
 

--- a/apiserver/singular/fixture_test.go
+++ b/apiserver/singular/fixture_test.go
@@ -21,7 +21,7 @@ type mockAuth struct {
 }
 
 // AuthModelManager is part of the facade.Authorizer interface.
-func (mock mockAuth) AuthModelManager() bool {
+func (mock mockAuth) AuthController() bool {
 	return !mock.nonManager
 }
 

--- a/apiserver/singular/singular.go
+++ b/apiserver/singular/singular.go
@@ -37,7 +37,7 @@ type Backend interface {
 // NewFacade returns a singular-controller API facade, backed by the supplied
 // state, so long as the authorizer represents a controller machine.
 func NewFacade(backend Backend, auth facade.Authorizer) (*Facade, error) {
-	if !auth.AuthModelManager() {
+	if !auth.AuthController() {
 		return nil, common.ErrPerm
 	}
 	return &Facade{

--- a/apiserver/spaces/spaces_test.go
+++ b/apiserver/spaces/spaces_test.go
@@ -45,8 +45,8 @@ func (s *SpacesSuite) SetUpTest(c *gc.C) {
 
 	s.resources = common.NewResources()
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		Tag:            names.NewUserTag("admin"),
-		EnvironManager: false,
+		Tag:        names.NewUserTag("admin"),
+		Controller: false,
 	}
 
 	var err error

--- a/apiserver/statushistory/pruner.go
+++ b/apiserver/statushistory/pruner.go
@@ -32,7 +32,7 @@ func NewAPI(st *state.State, _ facade.Resources, auth facade.Authorizer) (*API, 
 // only the ones newer than now - p.MaxHistoryTime remain and
 // the history is smaller than p.MaxHistoryMB.
 func (api *API) Prune(p params.StatusHistoryPruneArgs) error {
-	if !api.authorizer.AuthModelManager() {
+	if !api.authorizer.AuthController() {
 		return common.ErrPerm
 	}
 	return state.PruneStatusHistory(api.st, p.MaxHistoryTime, p.MaxHistoryMB)

--- a/apiserver/storage/base_test.go
+++ b/apiserver/storage/base_test.go
@@ -50,7 +50,7 @@ type baseStorageSuite struct {
 func (s *baseStorageSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.resources = common.NewResources()
-	s.authorizer = testing.FakeAuthorizer{Tag: names.NewUserTag("admin"), EnvironManager: true}
+	s.authorizer = testing.FakeAuthorizer{Tag: names.NewUserTag("admin"), Controller: true}
 	s.calls = []string{}
 	s.state = s.constructState()
 

--- a/apiserver/storageprovisioner/storageprovisioner.go
+++ b/apiserver/storageprovisioner/storageprovisioner.go
@@ -59,7 +59,7 @@ func NewStorageProvisionerAPI(
 		}
 		parentId := state.ParentId(tag.Id())
 		if parentId == "" {
-			return allowEnvironManager && authorizer.AuthModelManager()
+			return allowEnvironManager && authorizer.AuthController()
 		}
 		// All containers with the authenticated
 		// machine as a parent are accessible by it.
@@ -71,7 +71,7 @@ func NewStorageProvisionerAPI(
 			case names.ModelTag:
 				// Environment managers can access all volumes
 				// and filesystems scoped to the environment.
-				isModelManager := authorizer.AuthModelManager()
+				isModelManager := authorizer.AuthController()
 				return isModelManager && tag == st.ModelTag()
 			case names.MachineTag:
 				return canAccessStorageMachine(tag, false)
@@ -87,13 +87,13 @@ func NewStorageProvisionerAPI(
 			if ok {
 				return canAccessStorageMachine(machineTag, false)
 			}
-			return authorizer.AuthModelManager()
+			return authorizer.AuthController()
 		case names.FilesystemTag:
 			machineTag, ok := names.FilesystemMachine(tag)
 			if ok {
 				return canAccessStorageMachine(machineTag, false)
 			}
-			return authorizer.AuthModelManager()
+			return authorizer.AuthController()
 		case names.MachineTag:
 			return allowMachines && canAccessStorageMachine(tag, true)
 		default:
@@ -124,7 +124,7 @@ func NewStorageProvisionerAPI(
 			// volumes and volumes scoped to their own machines.
 			// Other machine agents can access volumes regardless
 			// of their scope.
-			if !authorizer.AuthModelManager() {
+			if !authorizer.AuthController() {
 				return true
 			}
 			var machineScope names.MachineTag

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -55,8 +55,8 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 	pm := poolmanager.New(state.NewStateSettings(s.State), registry)
 
 	s.authorizer = &apiservertesting.FakeAuthorizer{
-		Tag:            names.NewMachineTag("0"),
-		EnvironManager: true,
+		Tag:        names.NewMachineTag("0"),
+		Controller: true,
 	}
 	backend := storageprovisioner.NewStateBackend(s.State)
 	s.api, err = storageprovisioner.NewStorageProvisionerAPI(backend, s.resources, s.authorizer, registry, pm)
@@ -163,7 +163,7 @@ func (s *provisionerSuite) setupFilesystems(c *gc.C) {
 
 func (s *provisionerSuite) TestVolumesMachine(c *gc.C) {
 	s.setupVolumes(c)
-	s.authorizer.EnvironManager = false
+	s.authorizer.Controller = false
 
 	results, err := s.api.Volumes(params.Entities{
 		Entities: []params.Entity{{"volume-0-0"}, {"volume-1"}, {"volume-42"}},
@@ -253,7 +253,7 @@ func (s *provisionerSuite) TestFilesystems(c *gc.C) {
 
 func (s *provisionerSuite) TestVolumeAttachments(c *gc.C) {
 	s.setupVolumes(c)
-	s.authorizer.EnvironManager = false
+	s.authorizer.Controller = false
 
 	err := s.State.SetVolumeAttachmentInfo(
 		names.NewMachineTag("0"),
@@ -295,7 +295,7 @@ func (s *provisionerSuite) TestVolumeAttachments(c *gc.C) {
 
 func (s *provisionerSuite) TestFilesystemAttachments(c *gc.C) {
 	s.setupFilesystems(c)
-	s.authorizer.EnvironManager = false
+	s.authorizer.Controller = false
 
 	err := s.State.SetFilesystemAttachmentInfo(
 		names.NewMachineTag("0"),
@@ -1081,7 +1081,7 @@ func (s *provisionerSuite) TestRemoveFilesystemsEnvironManager(c *gc.C) {
 
 func (s *provisionerSuite) TestRemoveVolumesMachineAgent(c *gc.C) {
 	s.setupVolumes(c)
-	s.authorizer.EnvironManager = false
+	s.authorizer.Controller = false
 	args := params.Entities{Entities: []params.Entity{
 		{"volume-0-0"}, {"volume-0-42"}, {"volume-42"},
 		{"volume-invalid"}, {"machine-0"},
@@ -1109,7 +1109,7 @@ func (s *provisionerSuite) TestRemoveVolumesMachineAgent(c *gc.C) {
 
 func (s *provisionerSuite) TestRemoveFilesystemsMachineAgent(c *gc.C) {
 	s.setupFilesystems(c)
-	s.authorizer.EnvironManager = false
+	s.authorizer.Controller = false
 	args := params.Entities{Entities: []params.Entity{
 		{"filesystem-0-0"}, {"filesystem-0-42"}, {"filesystem-42"},
 		{"filesystem-invalid"}, {"machine-0"},
@@ -1137,7 +1137,7 @@ func (s *provisionerSuite) TestRemoveFilesystemsMachineAgent(c *gc.C) {
 
 func (s *provisionerSuite) TestRemoveVolumeAttachments(c *gc.C) {
 	s.setupVolumes(c)
-	s.authorizer.EnvironManager = false
+	s.authorizer.Controller = false
 
 	err := s.State.DetachVolume(names.NewMachineTag("0"), names.NewVolumeTag("1"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -1170,7 +1170,7 @@ func (s *provisionerSuite) TestRemoveVolumeAttachments(c *gc.C) {
 
 func (s *provisionerSuite) TestRemoveFilesystemAttachments(c *gc.C) {
 	s.setupFilesystems(c)
-	s.authorizer.EnvironManager = false
+	s.authorizer.Controller = false
 
 	err := s.State.DetachFilesystem(names.NewMachineTag("0"), names.NewFilesystemTag("1"))
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/subnets/subnets_test.go
+++ b/apiserver/subnets/subnets_test.go
@@ -47,8 +47,8 @@ func (s *SubnetsSuite) SetUpTest(c *gc.C) {
 
 	s.resources = common.NewResources()
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		Tag:            names.NewUserTag("admin"),
-		EnvironManager: false,
+		Tag:        names.NewUserTag("admin"),
+		Controller: false,
 	}
 
 	var err error

--- a/apiserver/testing/fakeauthorizer.go
+++ b/apiserver/testing/fakeauthorizer.go
@@ -13,19 +13,19 @@ import (
 
 // FakeAuthorizer implements the facade.Authorizer interface.
 type FakeAuthorizer struct {
-	Tag            names.Tag
-	EnvironManager bool
-	ModelUUID      string
-	AdminTag       names.UserTag
-	HasWriteTag    names.UserTag
+	Tag         names.Tag
+	Controller  bool
+	ModelUUID   string
+	AdminTag    names.UserTag
+	HasWriteTag names.UserTag
 }
 
 func (fa FakeAuthorizer) AuthOwner(tag names.Tag) bool {
 	return fa.Tag == tag
 }
 
-func (fa FakeAuthorizer) AuthModelManager() bool {
-	return fa.EnvironManager
+func (fa FakeAuthorizer) AuthController() bool {
+	return fa.Controller
 }
 
 // AuthMachineAgent returns whether the current client is a machine agent.

--- a/apiserver/undertaker/undertaker.go
+++ b/apiserver/undertaker/undertaker.go
@@ -31,7 +31,7 @@ func NewUndertakerAPI(st *state.State, resources facade.Resources, authorizer fa
 }
 
 func newUndertakerAPI(st State, resources facade.Resources, authorizer facade.Authorizer) (*UndertakerAPI, error) {
-	if !authorizer.AuthMachineAgent() || !authorizer.AuthModelManager() {
+	if !authorizer.AuthMachineAgent() || !authorizer.AuthController() {
 		return nil, common.ErrPerm
 	}
 	model, err := st.Model()

--- a/apiserver/undertaker/undertaker_test.go
+++ b/apiserver/undertaker/undertaker_test.go
@@ -29,8 +29,8 @@ func (s *undertakerSuite) setupStateAndAPI(c *gc.C, isSystem bool, envName strin
 	}
 
 	authorizer := apiservertesting.FakeAuthorizer{
-		Tag:            names.NewMachineTag(machineNo),
-		EnvironManager: true,
+		Tag:        names.NewMachineTag(machineNo),
+		Controller: true,
 	}
 
 	st := newMockState(names.NewUserTag("admin"), envName, isSystem)
@@ -41,12 +41,12 @@ func (s *undertakerSuite) setupStateAndAPI(c *gc.C, isSystem bool, envName strin
 
 func (s *undertakerSuite) TestNoPerms(c *gc.C) {
 	for _, authorizer := range []apiservertesting.FakeAuthorizer{
-		apiservertesting.FakeAuthorizer{
+		{
 			Tag: names.NewMachineTag("0"),
 		},
-		apiservertesting.FakeAuthorizer{
-			Tag:            names.NewUserTag("bob"),
-			EnvironManager: true,
+		{
+			Tag:        names.NewUserTag("bob"),
+			Controller: true,
 		},
 	} {
 		st := newMockState(names.NewUserTag("admin"), "admin", true)

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -277,7 +277,7 @@ func newRemoteApplicationWatcher(context facade.Context) (facade.Facade, error) 
 	resources := context.Resources()
 	auth := context.Auth()
 
-	if !auth.AuthModelManager() {
+	if !auth.AuthController() {
 		return nil, common.ErrPerm
 	}
 	watcher, ok := resources.Get(id).(state.RemoteApplicationWatcher)
@@ -330,7 +330,7 @@ func newRemoteRelationsWatcher(context facade.Context) (facade.Facade, error) {
 	resources := context.Resources()
 	auth := context.Auth()
 
-	if !auth.AuthModelManager() {
+	if !auth.AuthController() {
 		return nil, common.ErrPerm
 	}
 	watcher, ok := resources.Get(id).(state.RemoteRelationsWatcher)

--- a/apiserver/watcher_test.go
+++ b/apiserver/watcher_test.go
@@ -106,7 +106,7 @@ func (s *watcherSuite) TestFilesystemAttachmentsWatcher(c *gc.C) {
 func (s *watcherSuite) TestRemoteApplicationWatcher(c *gc.C) {
 	ch := make(chan params.RemoteApplicationChange, 1)
 	id := s.resources.Register(&fakeRemoteApplicationWatcher{ch: ch})
-	s.authorizer.EnvironManager = true
+	s.authorizer.Controller = true
 
 	ch <- params.RemoteApplicationChange{
 		ApplicationTag: names.NewApplicationTag("foo").String(),
@@ -150,7 +150,7 @@ func (w *fakeRemoteApplicationWatcher) Stop() error {
 func (s *watcherSuite) TestRemoteRelationsWatcher(c *gc.C) {
 	ch := make(chan params.RemoteRelationsChange, 1)
 	id := s.resources.Register(&fakeRemoteRelationsWatcher{ch: ch})
-	s.authorizer.EnvironManager = true
+	s.authorizer.Controller = true
 
 	ch <- params.RemoteRelationsChange{
 		RemovedRelations: []int{1, 2, 3},
@@ -168,7 +168,7 @@ func (s *watcherSuite) TestRemoteRelationsWatcher(c *gc.C) {
 
 func (s *watcherSuite) TestStopDiscards(c *gc.C) {
 	id := s.resources.Register(&fakeRemoteRelationsWatcher{})
-	s.authorizer.EnvironManager = true
+	s.authorizer.Controller = true
 	var disposed bool
 	facade := s.getFacade(c, "RemoteRelationsWatcher", 1, id, func() {
 		disposed = true


### PR DESCRIPTION
## Description of change

The facade to manipulate ssh keys in the Juju was not checking permissions properly. Specifically, model admins or controller superusers could not import, add, delete keys. This has been fixed.

As a driveby, the fake authorizer has EnvironManager renamed to Controller.

## QA steps

bootstrap
create a user and login as that user
juju ssh-import-id -> fail
as controller admin, grant that user admin on the model
juju ssh-import-id -> success

repeat above with superuser access granted

## Bug reference

https://bugs.launchpad.net/juju/+bug/1663035
