### PR TITLE
migrations: Call AdoptResources from migrationmaster worker

### DIFF
--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -208,3 +208,15 @@ func (c *Client) LatestLogTime(modelUUID string) (time.Time, error) {
 	}
 	return result, nil
 }
+
+// AdoptResources asks the cloud provider to update the controller
+// tags for a model's resources. This prevents the resources from
+// being destroyed if the source controller is destroyed after the
+// model is migrated away.
+func (c *Client) AdoptResources(modelUUID string) error {
+	args := params.AdoptResourcesArgs{
+		ModelTag:                names.NewModelTag(modelUUID).String(),
+		SourceControllerVersion: jujuversion.Current,
+	}
+	return errors.Trace(c.caller.FacadeCall("AdoptResources", args, nil))
+}

--- a/api/migrationtarget/client_test.go
+++ b/api/migrationtarget/client_test.go
@@ -144,6 +144,16 @@ func (s *ClientSuite) TestLatestLogTimeError(c *gc.C) {
 	s.AssertModelCall(c, stub, names.NewModelTag("fake"), "LatestLogTime", err, true)
 }
 
+func (s *ClientSuite) TestAdoptResources(c *gc.C) {
+	client, stub := s.getClientAndStub(c)
+	err := client.AdoptResources("the-model")
+	c.Assert(err, gc.ErrorMatches, "boom")
+	stub.CheckCall(c, 0, "MigrationTarget.AdoptResources", "", params.AdoptResourcesArgs{
+		ModelTag:                "model-the-model",
+		SourceControllerVersion: jujuversion.Current,
+	})
+}
+
 func (s *ClientSuite) TestUploadCharm(c *gc.C) {
 	const charmBody = "charming"
 	curl := charm.MustParseURL("cs:~user/foo-2")

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -479,7 +479,7 @@ func (w *Worker) doSUCCESS(status coremigration.MigrationStatus) (coremigration.
 }
 
 func (w *Worker) transferResources(targetInfo coremigration.TargetInfo, modelUUID string) error {
-	w.setInfoStatus("transferring cloud resources to target controller")
+	w.setInfoStatus("transferring ownership of cloud resources to target controller")
 	conn, err := w.openAPIConn(targetInfo)
 	if err != nil {
 		return errors.Trace(err)

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -95,6 +95,15 @@ var (
 			params.ModelArgs{ModelTag: modelTag.String()},
 		},
 	}
+	adoptResourcesCall = jujutesting.StubCall{
+		"MigrationTarget.AdoptResources",
+		[]interface{}{
+			params.AdoptResourcesArgs{
+				ModelTag:                modelTag.String(),
+				SourceControllerVersion: jujuversion.Current,
+			},
+		},
+	}
 	latestLogTimeCall = jujutesting.StubCall{
 		"MigrationTarget.LatestLogTime",
 		[]interface{}{
@@ -251,6 +260,9 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 			// SUCCESS
 			{"facade.WatchMinionReports", nil},
 			{"facade.MinionReports", nil},
+			apiOpenControllerCall,
+			adoptResourcesCall,
+			apiCloseCall,
 			{"facade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
 
 			// LOGTRANSFER
@@ -278,6 +290,9 @@ func (s *Suite) TestMigrationResume(c *gc.C) {
 		[]jujutesting.StubCall{
 			{"facade.WatchMinionReports", nil},
 			{"facade.MinionReports", nil},
+			apiOpenControllerCall,
+			adoptResourcesCall,
+			apiCloseCall,
 			{"facade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
 			apiOpenControllerCall,
 			latestLogTimeCall,
@@ -552,6 +567,9 @@ func (s *Suite) TestSUCCESSMinionWaitFailedMachine(c *gc.C) {
 		[]jujutesting.StubCall{
 			{"facade.WatchMinionReports", nil},
 			{"facade.MinionReports", nil},
+			apiOpenControllerCall,
+			adoptResourcesCall,
+			apiCloseCall,
 			{"facade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
 			apiOpenControllerCall,
 			latestLogTimeCall,
@@ -579,6 +597,9 @@ func (s *Suite) TestSUCCESSMinionWaitFailedUnit(c *gc.C) {
 		[]jujutesting.StubCall{
 			{"facade.WatchMinionReports", nil},
 			{"facade.MinionReports", nil},
+			apiOpenControllerCall,
+			adoptResourcesCall,
+			apiCloseCall,
 			{"facade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
 			apiOpenControllerCall,
 			latestLogTimeCall,
@@ -617,6 +638,9 @@ func (s *Suite) TestSUCCESSMinionWaitTimeout(c *gc.C) {
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
 			{"facade.WatchMinionReports", nil},
+			apiOpenControllerCall,
+			adoptResourcesCall,
+			apiCloseCall,
 			{"facade.SetPhase", []interface{}{coremigration.LOGTRANSFER}},
 			apiOpenControllerCall,
 			latestLogTimeCall,
@@ -1208,7 +1232,7 @@ func (c *stubConnection) APICall(objType string, version int, id, request string
 			return c.prechecksErr
 		case "Import":
 			return c.importErr
-		case "Activate":
+		case "Activate", "AdoptResources":
 			return nil
 		case "LatestLogTime":
 			responseTime := response.(*time.Time)


### PR DESCRIPTION
## Description of change
Once the migration is successful we call AdoptResources on the target controller to mark all of the resources used by the model as managed by the target controller. This prevents the source controller from incorrectly cleaning those resources up if it's destroyed.

Which resources are transferred depends on the cloud hosting the model, but it generally includes things like instances, volumes, and security groups.

## QA steps
(Should be done for all clouds, but especially ec2, gce, azure, rackspace, maas, lxd and openstack, since they handle resource tagging and cleanup when a controller is destroyed.)
* bootstrap two controllers, A and B
* add a model on A
* deploy an application the model
* migrate the model to B
* once the migration is complete and the model is running on B, destroy controller A
* the model should continue running on B

## Bug reference
Fixes https://bugs.launchpad.net/juju/+bug/1648063
