### PR TITLE
2.1 into develop

### DIFF
--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -226,6 +226,7 @@ func (s *legacySuite) TestAPIServerCanShutdownWithOutstandingNext(c *gc.C) {
 		LogDir:      c.MkDir(),
 		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
 		AutocertURL: "https://0.1.2.3/no-autocert-here",
+		StatePool:   state.NewStatePool(s.State),
 	})
 	c.Assert(err, gc.IsNil)
 

--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -27,6 +27,11 @@ func (m *Machine) Tag() names.Tag {
 	return m.tag
 }
 
+// MachineTag returns the identifier for the machine as the most specific type
+func (m *Machine) MachineTag() names.MachineTag {
+	return m.tag
+}
+
 // Id returns the machine id.
 func (m *Machine) Id() string {
 	return m.tag.Id()

--- a/api/provisioner/provisioner.go
+++ b/api/provisioner/provisioner.go
@@ -240,9 +240,9 @@ func (st *State) prepareOrGetContainerInterfaceInfo(
 
 // SetHostMachineNetworkConfig sets the network configuration of the
 // machine with netConfig
-func (st *State) SetHostMachineNetworkConfig(hostMachineID string, netConfig []params.NetworkConfig) error {
+func (st *State) SetHostMachineNetworkConfig(hostMachineTag names.MachineTag, netConfig []params.NetworkConfig) error {
 	args := params.SetMachineNetworkConfig{
-		Tag:    hostMachineID,
+		Tag:    hostMachineTag.String(),
 		Config: netConfig,
 	}
 	err := st.facade.FacadeCall("SetHostMachineNetworkConfig", args, nil)

--- a/api/pubsub/pubsub_test.go
+++ b/api/pubsub/pubsub_test.go
@@ -236,6 +236,7 @@ func newServerWithHub(c *gc.C, st *state.State, hub *pubsub.StructuredHub) (*api
 		LogDir:      c.MkDir(),
 		Hub:         hub,
 		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
+		StatePool:   state.NewStatePool(st),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	port := listener.Addr().(*net.TCPAddr).Port

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -252,9 +252,10 @@ type migrationSuite struct {
 var _ = gc.Suite(&migrationSuite{})
 
 func (s *migrationSuite) startSync(c *gc.C, st *state.State) {
-	backingSt, err := s.BackingStatePool.Get(st.ModelUUID())
+	backingSt, releaser, err := s.BackingStatePool.Get(st.ModelUUID())
 	c.Assert(err, jc.ErrorIsNil)
 	backingSt.StartSync()
+	releaser()
 }
 
 func (s *migrationSuite) TestMigrationStatusWatcher(c *gc.C) {

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -54,7 +54,7 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 	}
 
 	// apiRoot is the API root exposed to the client after authentication.
-	var apiRoot rpc.Root = newAPIRoot(a.root.state, a.root.resources, a.root)
+	var apiRoot rpc.Root = newAPIRoot(a.root.state, a.srv.statePool, a.root.resources, a.root)
 
 	// Use the login validation function, if one was specified.
 	if a.srv.validator != nil {

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -516,7 +516,7 @@ func (s *loginSuite) TestLoginValidationDuringUpgrade(c *gc.C) {
 }
 
 func (s *loginSuite) TestFailedLoginDuringMaintenance(c *gc.C) {
-	cfg := defaultServerConfig(c)
+	cfg := defaultServerConfig(c, s.State)
 	cfg.Validator = func(params.LoginRequest) error {
 		return errors.New("something")
 	}
@@ -536,7 +536,7 @@ func (s *loginSuite) TestFailedLoginDuringMaintenance(c *gc.C) {
 type validationChecker func(c *gc.C, err error, st api.Connection)
 
 func (s *baseLoginSuite) checkLoginWithValidator(c *gc.C, validator apiserver.LoginValidator, checker validationChecker) {
-	cfg := defaultServerConfig(c)
+	cfg := defaultServerConfig(c, s.State)
 	cfg.Validator = validator
 	info, srv := newServerWithConfig(c, s.State, cfg)
 	defer assertStop(c, srv)
@@ -1004,7 +1004,7 @@ func (s *macaroonLoginSuite) TestRemoteUserLoginToModelWithExplicitAccessAndAllo
 }
 
 func (s *macaroonLoginSuite) testRemoteUserLoginToModelWithExplicitAccess(c *gc.C, allowModelAccess bool) {
-	cfg := defaultServerConfig(c)
+	cfg := defaultServerConfig(c, s.State)
 	cfg.AllowModelAccess = allowModelAccess
 
 	info, srv := newServerWithConfig(c, s.State, cfg)

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -51,6 +51,7 @@ func (s *apiserverBaseSuite) sampleConfig(c *gc.C) apiserver.ServerConfig {
 		Hub:         centralhub.New(machineTag),
 		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
 		AutocertURL: "https://0.1.2.3/no-autocert-here",
+		StatePool:   state.NewStatePool(s.State),
 	}
 }
 

--- a/apiserver/backup.go
+++ b/apiserver/backup.go
@@ -32,12 +32,12 @@ type backupHandler struct {
 func (h *backupHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	// Validate before authenticate because the authentication is dependent
 	// on the state connection that is determined during the validation.
-	st, err := h.ctxt.stateForRequestAuthenticatedUser(req)
+	st, releaser, err := h.ctxt.stateForRequestAuthenticatedUser(req)
 	if err != nil {
 		h.sendError(resp, err)
 		return
 	}
-	defer h.ctxt.release(st)
+	defer releaser()
 
 	backups, closer := newBackups(st)
 	defer closer.Close()

--- a/apiserver/common/apihttp/handler.go
+++ b/apiserver/common/apihttp/handler.go
@@ -13,12 +13,10 @@ import (
 // field of HandlerSpec.
 type NewHandlerArgs struct {
 	// Connect is the function that is used to connect to Juju's state
-	// for the given HTTP request.
-	Connect func(*http.Request) (*state.State, state.Entity, error)
-
-	// Release indicates that the state is finished with and should be
-	// closed.
-	Release func(*state.State) error
+	// for the given HTTP request. It is the caller's responsibility
+	// to call the release function returned. If the error arg is nil
+	// the release function will always be a valid function.
+	Connect func(*http.Request) (*state.State, func(), state.Entity, error)
 }
 
 // HandlerConstraints describes conditions under which a handler

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/controller"
+	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/instance"
@@ -44,7 +45,12 @@ func (s *modelStatusSuite) SetUpTest(c *gc.C) {
 		AdminTag: s.Owner,
 	}
 
-	controller, err := controller.NewControllerAPI(s.State, s.resources, s.authorizer)
+	controller, err := controller.NewControllerAPI(
+		facadetest.Context{
+			State_:     s.State,
+			Resources_: s.resources,
+			Auth_:      s.authorizer,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	s.controller = controller
 
@@ -57,7 +63,12 @@ func (s *modelStatusSuite) TestModelStatusNonAuth(c *gc.C) {
 	anAuthoriser := apiservertesting.FakeAuthorizer{
 		Tag: user.Tag(),
 	}
-	endpoint, err := controller.NewControllerAPI(s.State, s.resources, anAuthoriser)
+	endpoint, err := controller.NewControllerAPI(
+		facadetest.Context{
+			State_:     s.State,
+			Resources_: s.resources,
+			Auth_:      anAuthoriser,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	controllerModelTag := s.State.ModelTag().String()
 
@@ -76,7 +87,12 @@ func (s *modelStatusSuite) TestModelStatusOwnerAllowed(c *gc.C) {
 	}
 	st := s.Factory.MakeModel(c, &factory.ModelParams{Owner: owner.Tag()})
 	defer st.Close()
-	endpoint, err := controller.NewControllerAPI(s.State, s.resources, anAuthoriser)
+	endpoint, err := controller.NewControllerAPI(
+		facadetest.Context{
+			State_:     s.State,
+			Resources_: s.resources,
+			Auth_:      anAuthoriser,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 
 	req := params.Entities{

--- a/apiserver/common/registry_test.go
+++ b/apiserver/common/registry_test.go
@@ -62,22 +62,34 @@ func (s *facadeRegistrySuite) TestRegisterFacadePanicsOnDoubleRegistry(c *gc.C) 
 }
 
 func (*facadeRegistrySuite) TestValidateNewFacade(c *gc.C) {
+	badSigErrorRegex := "does not have the signature " +
+		`func \(facade.Context\) \(\*Type, error\), or ` +
+		`func \(\*state.State, facade.Resources, facade.Authorizer\) \(\*Type, error\)`
+
 	checkValidateNewFacadeFailsWith(c, nil,
 		`cannot wrap nil`)
 	checkValidateNewFacadeFailsWith(c, "notafunc",
 		`wrong type "string" is not a function`)
 	checkValidateNewFacadeFailsWith(c, noArgs,
-		`function ".*noArgs" does not take 3 parameters and return 2`)
+		`function ".*noArgs" `+badSigErrorRegex)
 	checkValidateNewFacadeFailsWith(c, badCountIn,
-		`function ".*badCountIn" does not take 3 parameters and return 2`)
+		`function ".*badCountIn" `+badSigErrorRegex)
 	checkValidateNewFacadeFailsWith(c, badCountOut,
-		`function ".*badCountOut" does not take 3 parameters and return 2`)
+		`function ".*badCountOut" `+badSigErrorRegex)
 	checkValidateNewFacadeFailsWith(c, wrongIn,
-		`function ".*wrongIn" does not have the signature func \(\*state.State, facade.Resources, facade.Authorizer\) \(\*Type, error\)`)
+		`function ".*wrongIn" `+badSigErrorRegex)
 	checkValidateNewFacadeFailsWith(c, wrongOut,
-		`function ".*wrongOut" does not have the signature func \(\*state.State, facade.Resources, facade.Authorizer\) \(\*Type, error\)`)
-	err := common.ValidateNewFacade(reflect.ValueOf(validFactory))
+		`function ".*wrongOut" `+badSigErrorRegex)
+	checkValidateNewFacadeFailsWith(c, oneArgNotContext,
+		`function ".*oneArgNotContext" `+badSigErrorRegex)
+
+	nice, err := common.ValidateNewFacade(reflect.ValueOf(validFactory))
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(nice, jc.IsFalse)
+
+	nice, err = common.ValidateNewFacade(reflect.ValueOf(validContextFactory))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(nice, jc.IsTrue)
 }
 
 func (*facadeRegistrySuite) TestWrapNewFacadeFailure(c *gc.C) {
@@ -96,11 +108,13 @@ func (*facadeRegistrySuite) TestWrapNewFacadeHandlesId(c *gc.C) {
 }
 
 func (*facadeRegistrySuite) TestWrapNewFacadeCallsFunc(c *gc.C) {
-	wrapped, _, err := common.WrapNewFacade(validFactory)
-	c.Assert(err, jc.ErrorIsNil)
-	val, err := wrapped(facadetest.Context{})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(*(val.(*int)), gc.Equals, 100)
+	for _, function := range []interface{}{validFactory, validContextFactory} {
+		wrapped, _, err := common.WrapNewFacade(function)
+		c.Assert(err, jc.ErrorIsNil)
+		val, err := wrapped(facadetest.Context{})
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(*(val.(*int)), gc.Equals, 100)
+	}
 }
 
 func (*facadeRegistrySuite) TestWrapNewFacadeCallsWithRightParams(c *gc.C) {
@@ -128,6 +142,23 @@ func (*facadeRegistrySuite) TestWrapNewFacadeCallsWithRightParams(c *gc.C) {
 	c.Check(asResult.auth, gc.Equals, authorizer)
 }
 
+func (s *facadeRegistrySuite) TestRegisteredFuncGetsContext(c *gc.C) {
+	common.SanitizeFacades(s)
+
+	testFunc := func(ctx facade.Context) (facadetest.Context, error) {
+		return ctx.(facadetest.Context), nil
+	}
+	common.RegisterStandardFacade("testing", 1, testFunc)
+
+	wrapped, err := common.Facades.GetFactory("testing", 1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx := facadetest.Context{Identity: "special"}
+	val, err := wrapped(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(val.(facadetest.Context).Identity, gc.Equals, "special")
+}
+
 func (s *facadeRegistrySuite) TestRegisterStandardFacade(c *gc.C) {
 	common.SanitizeFacades(s)
 	common.RegisterStandardFacade("testing", 0, validFactory)
@@ -143,7 +174,7 @@ func (s *facadeRegistrySuite) TestRegisterStandardFacadePanic(c *gc.C) {
 	c.Assert(
 		func() { common.RegisterStandardFacade("badtest", 0, noArgs) },
 		gc.PanicMatches,
-		`function ".*noArgs" does not take 3 parameters and return 2`)
+		`function ".*noArgs" does not have the signature .* or .*`)
 	_, err := common.Facades.GetFactory("badtest", 0)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(err, gc.ErrorMatches, `badtest\(0\) not found`)
@@ -178,7 +209,7 @@ type myResult struct {
 }
 
 func checkValidateNewFacadeFailsWith(c *gc.C, obj interface{}, errMsg string) {
-	err := common.ValidateNewFacade(reflect.ValueOf(obj))
+	_, err := common.ValidateNewFacade(reflect.ValueOf(obj))
 	c.Check(err, gc.NotNil)
 	c.Check(err, gc.ErrorMatches, errMsg)
 }
@@ -203,6 +234,15 @@ func wrongOut(*state.State, facade.Resources, facade.Authorizer) (error, *int) {
 }
 
 func validFactory(*state.State, facade.Resources, facade.Authorizer) (*int, error) {
+	var i = 100
+	return &i, nil
+}
+
+func oneArgNotContext(string) (*int, error) {
+	return nil, nil
+}
+
+func validContextFactory(facade.Context) (*int, error) {
 	var i = 100
 	return &i, nil
 }

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -58,7 +58,12 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 		AdminTag: s.Owner,
 	}
 
-	controller, err := controller.NewControllerAPI(s.State, s.resources, s.authorizer)
+	controller, err := controller.NewControllerAPI(
+		facadetest.Context{
+			State_:     s.State,
+			Resources_: s.resources,
+			Auth_:      s.authorizer,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	s.controller = controller
 
@@ -69,7 +74,12 @@ func (s *controllerSuite) TestNewAPIRefusesNonClient(c *gc.C) {
 	anAuthoriser := apiservertesting.FakeAuthorizer{
 		Tag: names.NewUnitTag("mysql/0"),
 	}
-	endPoint, err := controller.NewControllerAPI(s.State, s.resources, anAuthoriser)
+	endPoint, err := controller.NewControllerAPI(
+		facadetest.Context{
+			State_:     s.State,
+			Resources_: s.resources,
+			Auth_:      anAuthoriser,
+		})
 	c.Assert(endPoint, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
@@ -240,7 +250,13 @@ func (s *controllerSuite) TestModelConfigFromNonController(c *gc.C) {
 		Tag:      s.Owner,
 		AdminTag: s.Owner,
 	}
-	controller, err := controller.NewControllerAPI(st, common.NewResources(), authorizer)
+	controller, err := controller.NewControllerAPI(
+		facadetest.Context{
+			State_:     st,
+			Resources_: common.NewResources(),
+			Auth_:      authorizer,
+		})
+
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := controller.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
@@ -263,7 +279,12 @@ func (s *controllerSuite) TestControllerConfigFromNonController(c *gc.C) {
 	defer st.Close()
 
 	authorizer := &apiservertesting.FakeAuthorizer{Tag: s.Owner}
-	controller, err := controller.NewControllerAPI(st, common.NewResources(), authorizer)
+	controller, err := controller.NewControllerAPI(
+		facadetest.Context{
+			State_:     st,
+			Resources_: common.NewResources(),
+			Auth_:      authorizer,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := controller.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
@@ -789,7 +810,12 @@ func (s *controllerSuite) TestGetControllerAccessPermissions(c *gc.C) {
 	anAuthoriser := apiservertesting.FakeAuthorizer{
 		Tag: user.Tag(),
 	}
-	endpoint, err := controller.NewControllerAPI(s.State, s.resources, anAuthoriser)
+	endpoint, err := controller.NewControllerAPI(
+		facadetest.Context{
+			State_:     s.State,
+			Resources_: s.resources,
+			Auth_:      anAuthoriser,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.ModifyControllerAccessRequest{
 		Changes: []params.ModifyControllerAccess{{

--- a/apiserver/controller/destroy_test.go
+++ b/apiserver/controller/destroy_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	commontesting "github.com/juju/juju/apiserver/common/testing"
 	"github.com/juju/juju/apiserver/controller"
+	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -51,7 +52,12 @@ func (s *destroyControllerSuite) SetUpTest(c *gc.C) {
 	authoriser := apiservertesting.FakeAuthorizer{
 		Tag: s.AdminUserTag(c),
 	}
-	controller, err := controller.NewControllerAPI(s.State, resources, authoriser)
+	controller, err := controller.NewControllerAPI(
+		facadetest.Context{
+			State_:     s.State,
+			Resources_: resources,
+			Auth_:      authoriser,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	s.controller = controller
 

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -74,12 +74,12 @@ func (h *debugLogHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			socket := &debugLogSocketImpl{conn}
 			defer conn.Close()
 
-			st, _, err := h.ctxt.stateForRequestAuthenticatedTag(req, names.MachineTagKind, names.UserTagKind)
+			st, releaser, _, err := h.ctxt.stateForRequestAuthenticatedTag(req, names.MachineTagKind, names.UserTagKind)
 			if err != nil {
 				socket.sendError(err)
 				return
 			}
-			defer h.ctxt.release(st)
+			defer releaser()
 
 			params, err := readDebugLogParams(req.URL.Query())
 			if err != nil {

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -85,7 +85,7 @@ func NewErrRoot(err error) *errRoot {
 // *barely* connected to anything.  Just enough to let you probe some
 // of the interfaces, but not enough to actually do any RPC calls.
 func TestingAPIRoot(st *state.State) rpc.Root {
-	return newAPIRoot(st, common.NewResources(), nil)
+	return newAPIRoot(st, state.NewStatePool(st), common.NewResources(), nil)
 }
 
 // TestingAPIHandler gives you an APIHandler that isn't connected to

--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -15,7 +15,11 @@ type Context struct {
 	Dispose_   func()
 	Resources_ facade.Resources
 	State_     *state.State
+	StatePool_ *state.StatePool
 	ID_        string
+	// Identity is not part of the facade.Context interface, but is instead
+	// used to make sure that the context objects are the same.
+	Identity string
 }
 
 // Abort is part of the facade.Context interface.
@@ -41,6 +45,11 @@ func (context Context) Resources() facade.Resources {
 // State is part of the facade.Context interface.
 func (context Context) State() *state.State {
 	return context.State_
+}
+
+// StatePool is part of of the facade.Context interface.
+func (context Context) StatePool() *state.StatePool {
+	return context.StatePool_
 }
 
 // ID is part of the facade.Context interface.

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -62,6 +62,10 @@ type Context interface {
 	// capabilities will migrate towards access via Resources.
 	State() *state.State
 
+	// StatePool returns the state pool used by the apiserver to minimise the
+	// creation of the expensive *State instances.
+	StatePool() *state.StatePool
+
 	// ID returns a string that should almost always be "", unless
 	// this is a watcher facade, in which case it exists in lieu of
 	// actual arguments in the Next() call, and is used as a key

--- a/apiserver/gui.go
+++ b/apiserver/gui.go
@@ -136,11 +136,11 @@ func (gr *guiRouter) ensureFileHandler(h func(gh *guiHandler, w http.ResponseWri
 // and archive hash.
 func (gr *guiRouter) ensureFiles(req *http.Request) (rootDir string, hash string, err error) {
 	// Retrieve the Juju GUI info from the GUI storage.
-	st, err := gr.ctxt.stateForRequestUnauthenticated(req)
+	st, releaser, err := gr.ctxt.stateForRequestUnauthenticated(req)
 	if err != nil {
 		return "", "", errors.Annotate(err, "cannot open state")
 	}
-	defer gr.ctxt.release(st)
+	defer releaser()
 	storage, err := st.GUIStorage()
 	if err != nil {
 		return "", "", errors.Annotate(err, "cannot open GUI storage")
@@ -415,11 +415,11 @@ func (h *guiArchiveHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) 
 // handleGet returns information on Juju GUI archives in the controller.
 func (h *guiArchiveHandler) handleGet(w http.ResponseWriter, req *http.Request) error {
 	// Open the GUI archive storage.
-	st, err := h.ctxt.stateForRequestUnauthenticated(req)
+	st, releaser, err := h.ctxt.stateForRequestUnauthenticated(req)
 	if err != nil {
 		return errors.Annotate(err, "cannot open state")
 	}
-	defer h.ctxt.release(st)
+	defer releaser()
 	storage, err := st.GUIStorage()
 	if err != nil {
 		return errors.Annotate(err, "cannot open GUI storage")
@@ -483,11 +483,11 @@ func (h *guiArchiveHandler) handlePost(w http.ResponseWriter, req *http.Request)
 	}
 
 	// Open the GUI archive storage.
-	st, err := h.ctxt.stateForRequestAuthenticatedUser(req)
+	st, releaser, err := h.ctxt.stateForRequestAuthenticatedUser(req)
 	if err != nil {
 		return errors.Annotate(err, "cannot open state")
 	}
-	defer h.ctxt.release(st)
+	defer releaser()
 	storage, err := st.GUIStorage()
 	if err != nil {
 		return errors.Annotate(err, "cannot open GUI storage")
@@ -559,11 +559,11 @@ func (h *guiVersionHandler) handlePut(w http.ResponseWriter, req *http.Request) 
 	}
 
 	// Authenticate the request and retrieve the Juju state.
-	st, err := h.ctxt.stateForRequestAuthenticatedUser(req)
+	st, releaser, err := h.ctxt.stateForRequestAuthenticatedUser(req)
 	if err != nil {
 		return errors.Annotate(err, "cannot open state")
 	}
-	defer h.ctxt.release(st)
+	defer releaser()
 
 	var selected params.GUIVersionRequest
 	decoder := json.NewDecoder(req.Body)

--- a/apiserver/introspection.go
+++ b/apiserver/introspection.go
@@ -31,11 +31,11 @@ func (h introspectionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 }
 
 func (h introspectionHandler) checkAuth(r *http.Request) error {
-	st, entity, err := h.ctx.stateAndEntityForRequestAuthenticatedUser(r)
+	st, releaser, entity, err := h.ctx.stateAndEntityForRequestAuthenticatedUser(r)
 	if err != nil {
 		return err
 	}
-	defer h.ctx.release(st)
+	defer releaser()
 
 	// Users with "superuser" access on the controller,
 	// or "read" access on the controller model, can

--- a/apiserver/logstream_test.go
+++ b/apiserver/logstream_test.go
@@ -264,9 +264,8 @@ func (s *stubSource) newSource(req *http.Request) (logStreamSource, closerFunc, 
 		return nil, nil, errors.Trace(err)
 	}
 
-	closer := func() error {
+	closer := func() {
 		s.stub.AddCall("close")
-		return s.stub.NextErr()
 	}
 	return s, closer, nil
 }

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -209,3 +209,18 @@ type MinionReports struct {
 	// failed to complete a given migration phase.
 	Failed []string `json:"failed"`
 }
+
+// AdoptResourcesArgs holds the information required to ask the
+// provider to update the controller tags for a model's
+// resources.
+type AdoptResourcesArgs struct {
+	// ModelTag identifies the model that owns the resources.
+	ModelTag string `json:"model-tag"`
+
+	// SourceControllerVersion indicates the version of the calling
+	// controller. This is needed in case the way the resources are
+	// tagged has changed between versions - the provider should
+	// ensure it looks for the original tags in the correct format for
+	// that version.
+	SourceControllerVersion version.Number `json:"source-controller-version"`
+}

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -723,7 +723,7 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(env environs.Environ, idx in
 		}
 
 		if len(parentAddrs) > 0 {
-			logger.Debugf("host machine device %q has addresses %v", parentDevice.Name(), parentAddrs)
+			logger.Infof("host machine device %q has addresses %v", parentDevice.Name(), parentAddrs)
 			firstAddress := parentAddrs[0]
 			if supportContainerAddresses {
 				parentDeviceSubnet, err := firstAddress.Subnet()
@@ -744,10 +744,7 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(env environs.Environ, idx in
 				info.VLANTag = 0
 			}
 		} else {
-			logger.Debugf("host machine device %q has no addresses %v", parentDevice.Name(), parentAddrs)
-			info.ConfigType = network.ConfigDHCP
-			info.ProviderSubnetId = ""
-			info.VLANTag = 0
+			logger.Infof("host machine device %q has no addresses %v", parentDevice.Name(), parentAddrs)
 		}
 
 		logger.Tracef("prepared info for container interface %q: %+v", info.InterfaceName, info)
@@ -768,12 +765,10 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(env environs.Environ, idx in
 			return err
 		}
 		logger.Debugf("got allocated info from provider: %+v", allocatedInfo)
-	} else {
-		logger.Debugf("using dhcp allocated addresses")
 	}
 
 	allocatedConfig := networkingcommon.NetworkConfigFromInterfaceInfo(allocatedInfo)
-	logger.Debugf("allocated network config: %+v", allocatedConfig)
+	logger.Tracef("allocated network config: %+v", allocatedConfig)
 	ctx.result.Results[idx].Config = allocatedConfig
 	return nil
 }

--- a/apiserver/pubsub.go
+++ b/apiserver/pubsub.go
@@ -37,12 +37,12 @@ type pubsubHandler struct {
 func (h *pubsubHandler) authenticate(req *http.Request) error {
 	// We authenticate against the controller state instance that is held
 	// by Server.
-	st, entity, err := h.ctxt.stateForRequestAuthenticated(req)
+	_, releaser, entity, err := h.ctxt.stateForRequestAuthenticated(req)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	// We don't actually use the state for anything except authentication.
-	defer h.ctxt.release(st)
+	defer releaser()
 
 	switch machine := entity.(type) {
 	case *state.Machine:

--- a/apiserver/registration.go
+++ b/apiserver/registration.go
@@ -40,14 +40,14 @@ func (h *registerUserHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 		}
 		return
 	}
-	st, err := h.ctxt.stateForRequestUnauthenticated(req)
+	st, releaser, err := h.ctxt.stateForRequestUnauthenticated(req)
 	if err != nil {
 		if err := sendError(w, err); err != nil {
 			logger.Errorf("%v", err)
 		}
 		return
 	}
-	defer h.ctxt.release(st)
+	defer releaser()
 	userTag, response, err := h.processPost(req, st)
 	if err != nil {
 		if err := sendError(w, err); err != nil {

--- a/apiserver/resources.go
+++ b/apiserver/resources.go
@@ -20,20 +20,20 @@ import (
 // resourceUploadHandler handles resources uploads for model migrations.
 type resourceUploadHandler struct {
 	ctxt          httpContext
-	stateAuthFunc func(*http.Request) (*state.State, error)
+	stateAuthFunc func(*http.Request) (*state.State, func(), error)
 }
 
 func (h *resourceUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Validate before authenticate because the authentication is dependent
 	// on the state connection that is determined during the validation.
-	st, err := h.stateAuthFunc(r)
+	st, releaser, err := h.stateAuthFunc(r)
 	if err != nil {
 		if err := sendError(w, err); err != nil {
 			logger.Errorf("%v", err)
 		}
 		return
 	}
-	defer h.ctxt.release(st)
+	defer releaser()
 
 	switch r.Method {
 	case "POST":

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -137,6 +137,7 @@ func (s *srvCaller) Call(objId string, arg reflect.Value) (reflect.Value, error)
 // apiRoot implements basic method dispatching to the facade registry.
 type apiRoot struct {
 	state       *state.State
+	pool        *state.StatePool
 	resources   *common.Resources
 	authorizer  facade.Authorizer
 	objectMutex sync.RWMutex
@@ -144,9 +145,10 @@ type apiRoot struct {
 }
 
 // newAPIRoot returns a new apiRoot.
-func newAPIRoot(st *state.State, resources *common.Resources, authorizer facade.Authorizer) *apiRoot {
+func newAPIRoot(st *state.State, pool *state.StatePool, resources *common.Resources, authorizer facade.Authorizer) *apiRoot {
 	r := &apiRoot{
 		state:       st,
+		pool:        pool,
 		resources:   resources,
 		authorizer:  authorizer,
 		objectCache: make(map[objectKey]reflect.Value),
@@ -264,6 +266,11 @@ func (ctx *facadeContext) Resources() facade.Resources {
 // State is part of of the facade.Context interface.
 func (ctx *facadeContext) State() *state.State {
 	return ctx.r.state
+}
+
+// StatePool is part of of the facade.Context interface.
+func (ctx *facadeContext) StatePool() *state.StatePool {
+	return ctx.r.pool
 }
 
 // ID is part of of the facade.Context interface.

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -30,7 +30,7 @@ import (
 // toolsHandler handles tool upload through HTTPS in the API server.
 type toolsUploadHandler struct {
 	ctxt          httpContext
-	stateAuthFunc func(*http.Request) (*state.State, error)
+	stateAuthFunc func(*http.Request) (*state.State, func(), error)
 }
 
 // toolsHandler handles tool download through HTTPS in the API server.
@@ -39,14 +39,14 @@ type toolsDownloadHandler struct {
 }
 
 func (h *toolsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	st, err := h.ctxt.stateForRequestUnauthenticated(r)
+	st, releaser, err := h.ctxt.stateForRequestUnauthenticated(r)
 	if err != nil {
 		if err := sendError(w, err); err != nil {
 			logger.Errorf("%v", err)
 		}
 		return
 	}
-	defer h.ctxt.release(st)
+	defer releaser()
 
 	switch r.Method {
 	case "GET":
@@ -71,14 +71,14 @@ func (h *toolsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 func (h *toolsUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Validate before authenticate because the authentication is dependent
 	// on the state connection that is determined during the validation.
-	st, err := h.stateAuthFunc(r)
+	st, releaser, err := h.stateAuthFunc(r)
 	if err != nil {
 		if err := sendError(w, err); err != nil {
 			logger.Errorf("%v", err)
 		}
 		return
 	}
-	defer h.ctxt.release(st)
+	defer releaser()
 
 	switch r.Method {
 	case "POST":

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -283,7 +283,7 @@ func (s *restoreSuite) TestRestoreReboostrapBuiltInProvider(c *gc.C) {
 		c.Assert(args.Cloud, jc.DeepEquals, cloud.Cloud{
 			Name:      "lxd",
 			Type:      "lxd",
-			AuthTypes: []cloud.AuthType{"certificate"},
+			AuthTypes: []cloud.AuthType{"certificate", "interactive"},
 			Regions:   []cloud.Region{{Name: "localhost"}},
 		})
 		return nil

--- a/cmd/jujud/agent/introspection_test.go
+++ b/cmd/jujud/agent/introspection_test.go
@@ -90,7 +90,7 @@ func (s *introspectionSuite) TestStartSuccess(c *gc.C) {
 	err = startIntrospection(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(fake.config.Reporter, gc.Equals, engine)
+	c.Check(fake.config.DepEngine, gc.Equals, engine)
 	c.Check(fake.config.SocketName, gc.Equals, "bananas")
 
 	// Stopping the engine causes the introspection worker to stop.

--- a/container/network.go
+++ b/container/network.go
@@ -49,3 +49,12 @@ func BridgeNetworkConfig(device string, mtu int, interfaces []network.InterfaceI
 	}
 	return &NetworkConfig{BridgeNetwork, device, mtu, interfaces}
 }
+
+// PhysicalNetworkConfig returns a valid NetworkConfig to use the
+// specified device as the network device for the container. It also
+// allows passing in specific configuration for the container's
+// network interfaces and default MTU to use. If interfaces is nil the
+// default configuration is used for the respective container type.
+func PhysicalNetworkConfig(device string, mtu int, interfaces []network.InterfaceInfo) *NetworkConfig {
+	return &NetworkConfig{PhysicalNetwork, device, mtu, interfaces}
+}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -47,7 +47,7 @@ github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-0
 github.com/juju/testing	git	5ea77166c8c6a8f56f258565288c4714aa399283	2016-11-24T00:43:14Z
 github.com/juju/txn	git	28898197906200d603394d8e4ce537436529f1c5	2016-11-16T04:07:55Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils	git	80bc95efca7ea0c6cba2c3b61d9baed02f0d9bb4	2017-01-25T23:33:01Z
+github.com/juju/utils	git	2c7a521b0a6ba1b4d0c29a1670a1d92bbdc23610	2017-02-08T11:46:50Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
@@ -79,7 +79,7 @@ google.golang.org/cloud	git	f20d6dcccb44ed49de45ae3703312cb46e627db1	2015-03-19T
 gopkg.in/amz.v3	git	8c3190dff075bf5442c9eedbf8f8ed6144a099e7	2016-12-15T013:08:49Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
-gopkg.in/goose.v1	git	8f055ce635d660f9b7827a1ff398c360715df261	2016-11-30T14:51:16Z
+gopkg.in/goose.v1	git	51ccf4fff13c89a1afb0a23873ca07bb5c12534a	2017-02-06T22:56:19Z
 gopkg.in/ini.v1	git	776aa739ce9373377cd16f526cdf06cb4c89b40f	2016-02-22T23:24:41Z
 gopkg.in/juju/blobstore.v2	git	51fa6e26128d74e445c72d3a91af555151cc3654	2016-01-25T02:37:03Z
 gopkg.in/juju/charm.v6-unstable	git	83771c4919d6810bce5b7e63f46bea5fbfed0b93	2016-10-03T20:31:18Z

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -157,6 +157,7 @@ var localhostCloud = cloud.Cloud{
 	Name: lxdnames.DefaultCloud,
 	Type: lxdnames.ProviderType,
 	AuthTypes: []cloud.AuthType{
+		interactiveAuthType,
 		cloud.CertificateAuthType,
 	},
 	Endpoint: "",

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -75,9 +75,12 @@ func (s *providerSuite) TestDetectCloudError(c *gc.C) {
 
 func (s *providerSuite) assertLocalhostCloud(c *gc.C, found cloud.Cloud) {
 	c.Assert(found, jc.DeepEquals, cloud.Cloud{
-		Name:      "localhost",
-		Type:      "lxd",
-		AuthTypes: []cloud.AuthType{cloud.CertificateAuthType},
+		Name: "localhost",
+		Type: "lxd",
+		AuthTypes: []cloud.AuthType{
+			"interactive",
+			cloud.CertificateAuthType,
+		},
 		Regions: []cloud.Region{{
 			Name: "localhost",
 		}},

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -347,7 +347,9 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.Env.raw = raw
 	s.Provider.generateMemCert = func(client bool) (cert, key []byte, _ error) {
 		s.Stub.AddCall("GenerateMemCert", client)
-		return []byte("client.crt"), []byte("client.key"), s.Stub.NextErr()
+		cert = []byte(testing.CACert + "generated")
+		key = []byte(testing.CAKey + "generated")
+		return cert, key, s.Stub.NextErr()
 	}
 	s.Provider.newLocalRawProvider = func() (*rawProvider, error) {
 		return raw, nil

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -481,6 +481,7 @@ type OpenstackStorage interface {
 	AttachVolume(serverId, volumeId, mountPoint string) (*nova.VolumeAttachment, error)
 	DetachVolume(serverId, attachmentId string) error
 	ListVolumeAttachments(serverId string) ([]nova.VolumeAttachment, error)
+	SetVolumeMetadata(volumeId string, metadata map[string]string) (map[string]string, error)
 }
 
 type endpointResolver interface {
@@ -546,4 +547,9 @@ func (ga *openstackStorageAdapter) GetVolume(volumeId string) (*cinder.Volume, e
 		return nil, err
 	}
 	return &resp.Volume, nil
+}
+
+// SetVolumeMetadata is part of the OpenstackStorage interface.
+func (ga *openstackStorageAdapter) SetVolumeMetadata(volumeId string, metadata map[string]string) (map[string]string, error) {
+	return ga.cinderClient.SetVolumeMetadata(volumeId, metadata)
 }

--- a/provider/openstack/cinder_test.go
+++ b/provider/openstack/cinder_test.go
@@ -473,6 +473,7 @@ type mockAdapter struct {
 	volumeStatusNotifier  func(string, string, int, time.Duration) <-chan error
 	detachVolume          func(string, string) error
 	listVolumeAttachments func(string) ([]nova.VolumeAttachment, error)
+	setVolumeMetadata     func(string, map[string]string) (map[string]string, error)
 }
 
 func (ma *mockAdapter) GetVolume(volumeId string) (*cinder.Volume, error) {
@@ -530,6 +531,14 @@ func (ma *mockAdapter) ListVolumeAttachments(serverId string) ([]nova.VolumeAtta
 	ma.MethodCall(ma, "ListVolumeAttachments", serverId)
 	if ma.listVolumeAttachments != nil {
 		return ma.listVolumeAttachments(serverId)
+	}
+	return nil, nil
+}
+
+func (ma *mockAdapter) SetVolumeMetadata(volumeId string, metadata map[string]string) (map[string]string, error) {
+	ma.MethodCall(ma, "SetVolumeMetadata", volumeId, metadata)
+	if ma.setVolumeMetadata != nil {
+		return ma.setVolumeMetadata(volumeId, metadata)
 	}
 	return nil, nil
 }

--- a/provider/openstack/firewaller.go
+++ b/provider/openstack/firewaller.go
@@ -21,6 +21,13 @@ import (
 	"github.com/juju/juju/network"
 )
 
+const (
+	validUUID              = `[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`
+	GroupControllerPattern = `^(?P<prefix>juju-)(?P<controllerUUID>` + validUUID + `)(?P<suffix>-.*)$`
+)
+
+var extractControllerRe = regexp.MustCompile(GroupControllerPattern)
+
 //factory for obtaining firawaller object.
 type FirewallerFactory interface {
 	GetFirewaller(env environs.Environ) Firewaller
@@ -41,18 +48,25 @@ type Firewaller interface {
 	// address rules for that port range.
 	IngressRules() ([]network.IngressRule, error)
 
-	// Implementations are expected to delete all security groups for the
-	// environment.
+	// DeleteAllModelGroups deletes all security groups for the
+	// model.
 	DeleteAllModelGroups() error
 
-	// Implementations are expected to delete all security groups for the
+	// DeleteAllControllerGroups deletes all security groups for the
 	// controller, ie those for all hosted models.
 	DeleteAllControllerGroups(controllerUUID string) error
 
 	// DeleteGroups deletes the security groups with the specified names.
 	DeleteGroups(names ...string) error
 
-	// Implementations should return list of security groups, that belong to given instances.
+	// UpdateGroupController updates all of the security groups for
+	// this model to refer to the specified controller, such that
+	// DeleteAllControllerGroups will remove them only when called
+	// with the specified controller ID.
+	UpdateGroupController(controllerUUID string) error
+
+	// GetSecurityGroups returns a list of the security groups that
+	// belong to given instances.
 	GetSecurityGroups(ids ...instance.Id) ([]string, error)
 
 	// SetUpGroups sets up initial security groups, if any, and returns
@@ -147,6 +161,13 @@ func (f *switchingFirewaller) DeleteGroups(names ...string) error {
 		return errors.Trace(err)
 	}
 	return f.fw.DeleteGroups(names...)
+}
+
+func (f *switchingFirewaller) UpdateGroupController(controllerUUID string) error {
+	if err := f.initFirewaller(); err != nil {
+		return errors.Trace(err)
+	}
+	return f.fw.UpdateGroupController(controllerUUID)
 }
 
 func (f *switchingFirewaller) GetSecurityGroups(ids ...instance.Id) ([]string, error) {
@@ -649,6 +670,45 @@ func (c *neutronFirewaller) DeleteAllModelGroups() error {
 	return deleteSecurityGroupsMatchingName(c.deleteSecurityGroups, c.jujuGroupRegexp())
 }
 
+// UpdateGroupController implements Firewaller interface.
+func (c *neutronFirewaller) UpdateGroupController(controllerUUID string) error {
+	neutronClient := c.environ.neutron()
+	groups, err := neutronClient.ListSecurityGroupsV2()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	re, err := regexp.Compile(c.jujuGroupRegexp())
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	var failed []string
+	for _, group := range groups {
+		if !re.MatchString(group.Name) {
+			continue
+		}
+		err := c.updateGroupControllerUUID(&group, controllerUUID)
+		if err != nil {
+			logger.Errorf("error updating controller for security group %s: %v", group.Id, err)
+			failed = append(failed, group.Id)
+		}
+	}
+	if len(failed) != 0 {
+		return errors.Errorf("errors updating controller for security groups: %v", failed)
+	}
+	return nil
+}
+
+func (c *neutronFirewaller) updateGroupControllerUUID(group *neutron.SecurityGroupV2, controllerUUID string) error {
+	newName, err := replaceControllerUUID(group.Name, controllerUUID)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	client := c.environ.neutron()
+	_, err = client.UpdateSecurityGroupV2(group.Id, newName, group.Description)
+	return errors.Trace(err)
+}
+
 // OpenPorts implements Firewaller interface.
 func (c *neutronFirewaller) OpenPorts(rules []network.IngressRule) error {
 	return c.openPorts(c.openPortsInGroup, rules)
@@ -817,4 +877,15 @@ func (c *neutronFirewaller) ingressRulesInGroup(nameRegexp string) (rules []netw
 	}
 	network.SortIngressRules(rules)
 	return rules, nil
+}
+
+func replaceControllerUUID(oldName, controllerUUID string) (string, error) {
+	if !extractControllerRe.MatchString(oldName) {
+		return "", errors.Errorf("unexpected security group name format for %q", oldName)
+	}
+	newName := extractControllerRe.ReplaceAllString(
+		oldName,
+		"${prefix}"+controllerUUID+"${suffix}",
+	)
+	return newName, nil
 }

--- a/provider/openstack/legacy_firewaller.go
+++ b/provider/openstack/legacy_firewaller.go
@@ -169,6 +169,37 @@ func (c *legacyNovaFirewaller) DeleteGroups(names ...string) error {
 	return deleteSecurityGroupsOneOfNames(c.deleteSecurityGroups, names...)
 }
 
+// UpdateGroupController implements Firewaller interface.
+func (c *legacyNovaFirewaller) UpdateGroupController(controllerUUID string) error {
+	novaClient := c.environ.nova()
+	groups, err := novaClient.ListSecurityGroups()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	var failed []string
+	for _, group := range groups {
+		err := c.updateGroupControllerUUID(&group, controllerUUID)
+		if err != nil {
+			logger.Errorf("error updating controller for security group %s: %v", group.Id, err)
+			failed = append(failed, group.Id)
+		}
+	}
+	if len(failed) != 0 {
+		return errors.Errorf("errors updating controller for security groups: %v", failed)
+	}
+	return nil
+}
+
+func (c *legacyNovaFirewaller) updateGroupControllerUUID(group *nova.SecurityGroup, controllerUUID string) error {
+	newName, err := replaceControllerUUID(group.Name, controllerUUID)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	client := c.environ.nova()
+	_, err = client.UpdateSecurityGroup(group.Id, newName, group.Description)
+	return errors.Trace(err)
+}
+
 // OpenPorts implements Firewaller interface.
 func (c *legacyNovaFirewaller) OpenPorts(rules []network.IngressRule) error {
 	return c.openPorts(c.openPortsInGroup, rules)

--- a/provider/rackspace/firewaller.go
+++ b/provider/rackspace/firewaller.go
@@ -59,6 +59,10 @@ func (c *rackspaceFirewaller) DeleteAllControllerGroups(controllerUUID string) e
 	return nil
 }
 
+func (c *rackspaceFirewaller) UpdateGroupController(controllerUUID string) error {
+	return nil
+}
+
 // GetSecurityGroups implements OpenstackFirewaller interface.
 func (c *rackspaceFirewaller) GetSecurityGroups(ids ...instance.Id) ([]string, error) {
 	return nil, nil

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1168,7 +1168,7 @@ func (b *allWatcherStateBacking) Release() error {
 	return nil
 }
 
-func NewAllModelWatcherStateBacking(st *State) Backing {
+func NewAllModelWatcherStateBacking(st *State, pool *StatePool) Backing {
 	collections := makeAllWatcherCollectionInfo(
 		modelsC,
 		machinesC,
@@ -1190,7 +1190,7 @@ func NewAllModelWatcherStateBacking(st *State) Backing {
 	return &allModelWatcherStateBacking{
 		st:               st,
 		watcher:          st.workers.TxnLogWatcher(),
-		stPool:           NewStatePool(st),
+		stPool:           pool,
 		collectionByName: collections,
 	}
 }
@@ -1252,7 +1252,7 @@ func (b *allModelWatcherStateBacking) Changed(all *multiwatcherStore, change wat
 
 	doc := reflect.New(c.docType).Interface().(backingEntityDoc)
 
-	st, err := b.getState(modelUUID)
+	st, releaser, err := b.getState(modelUUID)
 	if err != nil {
 		_, modelErr := b.st.GetModel(names.NewModelTag(modelUUID))
 		if errors.IsNotFound(modelErr) {
@@ -1263,7 +1263,7 @@ func (b *allModelWatcherStateBacking) Changed(all *multiwatcherStore, change wat
 		}
 		return errors.Trace(err)
 	}
-	defer b.stPool.Release(modelUUID)
+	defer releaser()
 
 	col, closer := st.getCollection(c.name)
 	defer closer()
@@ -1293,22 +1293,18 @@ func (b *allModelWatcherStateBacking) idForChange(change watcher.Change) (string
 	return modelUUID, id, nil
 }
 
-func (b *allModelWatcherStateBacking) getState(modelUUID string) (*State, error) {
-	if b.st.ModelUUID() == modelUUID {
-		return b.st, nil
-	}
-
-	st, err := b.stPool.Get(modelUUID)
+func (b *allModelWatcherStateBacking) getState(modelUUID string) (*State, func(), error) {
+	st, releaser, err := b.stPool.Get(modelUUID)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, nil, errors.Trace(err)
 	}
-	return st, nil
+	return st, releaser, nil
 }
 
 // Release implements the Backing interface.
 func (b *allModelWatcherStateBacking) Release() error {
-	err := b.stPool.Close()
-	return errors.Trace(err)
+	// Nothing to release.
+	return nil
 }
 
 func loadAllWatcherEntities(st *State, collectionByName map[string]allWatcherStateCollection, all *multiwatcherStore) error {

--- a/state/lease/client_persistence_test.go
+++ b/state/lease/client_persistence_test.go
@@ -8,6 +8,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/clock"
+	"github.com/juju/utils/clock/monotonic"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2/bson"
 
@@ -25,11 +26,12 @@ var _ = gc.Suite(&ClientPersistenceSuite{})
 
 func (s *ClientPersistenceSuite) TestNewClientInvalidClockDoc(c *gc.C) {
 	config := lease.ClientConfig{
-		Id:         "client",
-		Namespace:  "namespace",
-		Collection: "collection",
-		Mongo:      NewMongo(s.db),
-		Clock:      clock.WallClock,
+		Id:           "client",
+		Namespace:    "namespace",
+		Collection:   "collection",
+		Mongo:        NewMongo(s.db),
+		Clock:        clock.WallClock,
+		MonotonicNow: monotonic.Now,
 	}
 	dbKey := "clock#namespace#"
 	err := s.db.C("collection").Insert(bson.M{"_id": dbKey})
@@ -42,11 +44,12 @@ func (s *ClientPersistenceSuite) TestNewClientInvalidClockDoc(c *gc.C) {
 
 func (s *ClientPersistenceSuite) TestNewClientInvalidLeaseDoc(c *gc.C) {
 	config := lease.ClientConfig{
-		Id:         "client",
-		Namespace:  "namespace",
-		Collection: "collection",
-		Mongo:      NewMongo(s.db),
-		Clock:      clock.WallClock,
+		Id:           "client",
+		Namespace:    "namespace",
+		Collection:   "collection",
+		Mongo:        NewMongo(s.db),
+		Clock:        clock.WallClock,
+		MonotonicNow: monotonic.Now,
 	}
 	err := s.db.C("collection").Insert(bson.M{
 		"_id":       "snagglepuss",

--- a/state/lease/client_validation_test.go
+++ b/state/lease/client_validation_test.go
@@ -54,6 +54,13 @@ func (s *ClientValidationSuite) TestNewClientClock(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, "missing clock")
 }
 
+func (s *ClientValidationSuite) TestNewMonotonicClock(c *gc.C) {
+	fix := s.EasyFixture(c)
+	fix.Config.MonotonicNow = nil
+	_, err := lease.NewClient(fix.Config)
+	c.Check(err, gc.ErrorMatches, "missing monotonic clock")
+}
+
 func (s *ClientValidationSuite) TestClaimLeaseName(c *gc.C) {
 	fix := s.EasyFixture(c)
 	err := fix.Client.ClaimLease("$name", corelease.Request{"holder", time.Minute})

--- a/state/lease/config.go
+++ b/state/lease/config.go
@@ -4,6 +4,8 @@
 package lease
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils/clock"
@@ -21,6 +23,9 @@ type Mongo interface {
 	// GetCollection should probably call the mongo.CollectionFromName func.
 	GetCollection(name string) (collection mongo.Collection, closer func())
 }
+
+// MonotonicNow exposes monotonic clock Now() for use by the lease manager.
+type MonotonicClockFunc func() time.Duration
 
 // ClientConfig contains the resources and information required to create
 // a Client. Multiple clients can collaborate if they share a collection and
@@ -44,6 +49,9 @@ type ClientConfig struct {
 
 	// Clock exposes the wall-clock time to a Client.
 	Clock clock.Clock
+
+	// MonotonicNow exposes the monotonic clock Now() func to a client.
+	MonotonicNow MonotonicClockFunc
 }
 
 // validate returns an error if the supplied config is not valid.
@@ -62,6 +70,9 @@ func (config ClientConfig) validate() error {
 	}
 	if config.Clock == nil {
 		return errors.New("missing clock")
+	}
+	if config.MonotonicNow == nil {
+		return errors.New("missing monotonic clock")
 	}
 	return nil
 }

--- a/state/lease/fixture_test.go
+++ b/state/lease/fixture_test.go
@@ -61,12 +61,14 @@ func NewFixture(c *gc.C, database *mgo.Database, params FixtureParams) *Fixture 
 		clockStart = defaultClockStart
 	}
 	clock := NewClock(clockStart, params.ClockStep)
+	monotonic := newMonotonicClock(params.ClockStep)
 	config := lease.ClientConfig{
-		Id:         or(params.Id, "default-client"),
-		Namespace:  or(params.Namespace, "default-namespace"),
-		Collection: or(params.Collection, "default-collection"),
-		Mongo:      mongo,
-		Clock:      clock,
+		Id:           or(params.Id, "default-client"),
+		Namespace:    or(params.Namespace, "default-namespace"),
+		Collection:   or(params.Collection, "default-collection"),
+		Mongo:        mongo,
+		Clock:        clock,
+		MonotonicNow: monotonic.Now,
 	}
 	client, err := lease.NewClient(config)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/lease/schema.go
+++ b/state/lease/schema.go
@@ -168,18 +168,6 @@ func (doc clockDoc) skews(beginning, end time.Time) (map[string]Skew, error) {
 	if err := doc.validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	// beginning is expected to be earlier than end.
-	// If it isn't, it could be ntp rolling the clock back slowly, so we add
-	// a little wiggle room here.
-	if end.Before(beginning) {
-		// A later time, subtract an earlier time will give a positive duration.
-		difference := beginning.Sub(end)
-		if difference > 10*time.Millisecond {
-			return nil, errors.Errorf("end of read window preceded beginning (%s)", difference)
-
-		}
-		beginning = end
-	}
 	skews := make(map[string]Skew)
 	for writer, written := range doc.Writers {
 		skews[writer] = Skew{

--- a/state/lease/util_test.go
+++ b/state/lease/util_test.go
@@ -47,6 +47,23 @@ func (clock *Clock) Advance(duration time.Duration) {
 	clock.now = clock.now.Add(duration)
 }
 
+type monotonicClock struct {
+	now  time.Duration
+	step time.Duration
+}
+
+func (m *monotonicClock) Now() time.Duration {
+	m.now += m.step
+	return m.now
+}
+
+// newMonotonicClock returns a monotonic clock instance whose
+// Now() method returns a duration advance by step each time
+// it is called.
+func newMonotonicClock(step time.Duration) *monotonicClock {
+	return &monotonicClock{step: step}
+}
+
 // Mongo exposes database operations. It uses a real database -- we can't mock
 // mongo out, we need to check it really actually works -- but it's good to
 // have the runner accessible for adversarial transaction tests.

--- a/state/open.go
+++ b/state/open.go
@@ -548,6 +548,8 @@ func newState(
 	if newPolicy != nil {
 		st.policy = newPolicy(st)
 	}
+	// Record this State instance with the global tracker.
+	GlobalTracker.Add(st)
 	return st, nil
 }
 
@@ -595,5 +597,6 @@ func (st *State) Close() (err error) {
 		return errs[0]
 	}
 	logger.Debugf("closed state without error")
+	GlobalTracker.RecordClosed(st)
 	return nil
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -256,8 +256,9 @@ func (s *StateSuite) TestWatchAllModels(c *gc.C) {
 	// The allModelWatcher infrastructure is comprehensively tested
 	// elsewhere. This just ensures things are hooked up correctly in
 	// State.WatchAllModels()
-
-	w := s.State.WatchAllModels()
+	pool := state.NewStatePool(s.State)
+	defer pool.Close()
+	w := s.State.WatchAllModels(pool)
 	defer w.Stop()
 	deltasC := makeMultiwatcherOutput(w)
 

--- a/state/tracker.go
+++ b/state/tracker.go
@@ -1,0 +1,157 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/juju/loggo"
+)
+
+// GlobalTracker tracks the locations of all the State instances
+// created through the various paths. Both ForModel and Open end up
+// going through the internal newState method.
+var GlobalTracker = newTracker()
+
+type trackerStack struct {
+	uuid string
+	// Where was this State object created.
+	stack string
+	// Has the state been closed.
+	closed bool
+	// When the object was added, and closed
+	whenAdded  time.Time
+	whenClosed time.Time
+}
+
+// Tracker records the locations of all the active *State instances.
+type Tracker struct {
+	mu         sync.Mutex
+	references map[string]*trackerStack
+	logger     loggo.Logger
+}
+
+func newTracker() *Tracker {
+	return &Tracker{
+		references: make(map[string]*trackerStack),
+		logger:     loggo.GetLogger("juju.state.tracker"),
+	}
+}
+
+// We always use a uint64 as a key rather than the pointer itself
+// as to not hold a reference to the object.
+func (t *Tracker) key(s *State) string {
+	return fmt.Sprintf("%p", s)
+}
+
+// Add records the stack and uses the address of the State object
+// as a key to the internal map to record the location that the instance
+// was created from.
+func (t *Tracker) Add(s *State) {
+	stack := debug.Stack()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Use the pointer of the State as a key into the map.
+	key := t.key(s)
+
+	item := &trackerStack{
+		uuid:      s.ModelUUID(),
+		stack:     string(stack),
+		whenAdded: time.Now(),
+	}
+	t.logger.Debugf("[%p] adding key %v for %s", t, key, item.uuid)
+	t.references[key] = item
+
+	removeRef := func(st *State) {
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		key := t.key(st)
+		delete(t.references, key)
+		t.logger.Debugf("[%p] removing key %v for %s", t, key, item.uuid)
+	}
+
+	runtime.SetFinalizer(s, removeRef)
+}
+
+// RecordClosed marks the State instance as closed for reporting purposes.
+func (t *Tracker) RecordClosed(s *State) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	key := t.key(s)
+	if item, found := t.references[key]; found {
+		t.logger.Tracef("marking closed key %v for %s", key, item.uuid)
+		item.closed = true
+		item.whenClosed = time.Now()
+	} else {
+		t.logger.Debugf("missing state reference for %s", s.ModelUUID())
+	}
+}
+
+// count is used for testing only.
+func (t *Tracker) count() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.references)
+}
+
+// IntrospectionReport is used by the introspection worker to output
+// the information for the user.
+func (t *Tracker) IntrospectionReport() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	var (
+		now    = time.Now().Round(time.Second)
+		buff   = &bytes.Buffer{}
+		open   []*trackerStack
+		closed []*trackerStack
+	)
+
+	for _, item := range t.references {
+		if item.closed {
+			closed = append(closed, item)
+		} else {
+			open = append(open, item)
+		}
+	}
+
+	sort.Sort(oldestFirst(open))
+	sort.Sort(oldestFirst(closed))
+
+	outputItem := func(item *trackerStack) {
+		fmt.Fprintf(buff, "\nModel: %s\n", item.uuid)
+		d := now.Sub(item.whenAdded.Round(time.Second))
+		fmt.Fprintf(buff, "  Added: %s (%s ago)\n", item.whenAdded.Format(time.RFC1123), d)
+		if item.closed {
+			d := item.whenClosed.Sub(item.whenAdded)
+			fmt.Fprintf(buff, "  Closed: %s (open for %s)\n", item.whenClosed.Format(time.RFC1123), d)
+		}
+		fmt.Fprintf(buff, "  Location: \n%s\n", item.stack)
+	}
+
+	for _, item := range open {
+		outputItem(item)
+	}
+	for _, item := range closed {
+		outputItem(item)
+	}
+
+	return fmt.Sprintf(""+
+		"Total count: %d\n"+
+		"Closed count: %d\n"+
+		"\n%s", len(t.references), len(closed), buff)
+}
+
+type oldestFirst []*trackerStack
+
+func (d oldestFirst) Len() int           { return len(d) }
+func (d oldestFirst) Swap(i, j int)      { d[i], d[j] = d[j], d[i] }
+func (d oldestFirst) Less(i, j int) bool { return d[i].whenAdded.Before(d[j].whenAdded) }

--- a/state/tracker_test.go
+++ b/state/tracker_test.go
@@ -1,0 +1,41 @@
+package state
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type TrackerSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&TrackerSuite{})
+
+var _ = jc.Satisfies
+
+func (*TrackerSuite) TestAddsReference(c *gc.C) {
+	tracker := newTracker()
+	tracker.Add(&State{})
+	c.Assert(tracker.count(), gc.Equals, 1)
+}
+
+// Unfortunately there is no deterministic way to test the finalizer as the GC
+// will just schedule it to run at some arbitrary time after obj becomes
+// unreachable.
+
+func (*TrackerSuite) TestReport(c *gc.C) {
+	tracker := newTracker()
+	tracker.Add(&State{})
+	closed := &State{}
+	tracker.Add(closed)
+	tracker.RecordClosed(closed)
+	tracker.Add(&State{})
+
+	report := tracker.IntrospectionReport()
+	// The closed models are at the end.
+	c.Assert(report, gc.Matches, `(?ms)Total count: 3.Closed count: 1.`+
+		`.*Model:.*`+
+		`.*Model:.*`+
+		`.*Model:.*Closed: .*`)
+}

--- a/worker/introspection/script.go
+++ b/worker/introspection/script.go
@@ -77,10 +77,20 @@ juju-engine-report () {
   jujuMachineOrUnit depengine/ $@
 }
 
+juju-statepool-report () {
+  jujuMachineOrUnit statepool/ $@
+}
+
+juju-statetracker-report () {
+  jujuMachineOrUnit statetracker/ $@
+}
+
 export -f jujuAgentCall
 export -f jujuMachineAgentName
 export -f jujuMachineOrUnit
 export -f juju-goroutines
 export -f juju-heap-profile
 export -f juju-engine-report
+export -f juju-statepool-report
+export -f juju-statetracker-report
 `

--- a/worker/introspection/socket_test.go
+++ b/worker/introspection/socket_test.go
@@ -74,7 +74,7 @@ func (s *introspectionSuite) startWorker(c *gc.C) {
 	s.name = fmt.Sprintf("introspection-test-%d", os.Getpid())
 	w, err := introspection.NewWorker(introspection.Config{
 		SocketName:         s.name,
-		Reporter:           s.reporter,
+		DepEngine:          s.reporter,
 		PrometheusGatherer: s.gatherer,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -110,10 +110,22 @@ func (s *introspectionSuite) TestGoroutineProfile(c *gc.C) {
 	matches(c, buf, `^goroutine profile: total \d+`)
 }
 
-func (s *introspectionSuite) TestMissingReporter(c *gc.C) {
+func (s *introspectionSuite) TestMissingDepEngineReporter(c *gc.C) {
 	buf := s.call(c, "/depengine/")
 	matches(c, buf, "404 Not Found")
-	matches(c, buf, "missing reporter")
+	matches(c, buf, "missing dependency engine reporter")
+}
+
+func (s *introspectionSuite) TestMissingStatePoolReporter(c *gc.C) {
+	buf := s.call(c, "/statepool/")
+	matches(c, buf, "404 Not Found")
+	matches(c, buf, "State Pool Report: missing reporter")
+}
+
+func (s *introspectionSuite) TestMissingStateTrackerReporter(c *gc.C) {
+	buf := s.call(c, "/statetracker/")
+	matches(c, buf, "404 Not Found")
+	matches(c, buf, "State Instance Report: missing reporter")
 }
 
 func (s *introspectionSuite) TestEngineReporter(c *gc.C) {

--- a/worker/provisioner/broker.go
+++ b/worker/provisioner/broker.go
@@ -23,7 +23,7 @@ type APICalls interface {
 	PrepareContainerInterfaceInfo(names.MachineTag) ([]network.InterfaceInfo, error)
 	GetContainerInterfaceInfo(names.MachineTag) ([]network.InterfaceInfo, error)
 	ReleaseContainerAddresses(names.MachineTag) error
-	SetHostMachineNetworkConfig(string, []params.NetworkConfig) error
+	SetHostMachineNetworkConfig(names.MachineTag, []params.NetworkConfig) error
 	HostChangesForContainer(containerTag names.MachineTag) ([]network.DeviceToBridge, int, error)
 }
 
@@ -43,7 +43,12 @@ var resolvConf = "/etc/resolv.conf"
 
 var getObservedNetworkConfig = common.GetObservedNetworkConfig
 
-func prepareHost(bridger network.Bridger, hostMachineID string, containerTag names.MachineTag, api APICalls, log loggo.Logger) error {
+// prepareHost makes changes to the host's configuration (bridging network
+// interfaces, etc) in preparation for a container.
+// TODO(jam): 2017-02-08 This arguably should be passed into the broker as a
+// callback from the Host object, rather than have StartInstance directly be
+// responsible for how to set up the host.
+func prepareHost(bridger network.Bridger, hostMachineTag names.MachineTag, containerTag names.MachineTag, api APICalls, log loggo.Logger) error {
 	devicesToBridge, reconfigureDelay, err := api.HostChangesForContainer(containerTag)
 
 	if err != nil {
@@ -55,7 +60,7 @@ func prepareHost(bridger network.Bridger, hostMachineID string, containerTag nam
 		return nil
 	}
 
-	log.Tracef("Bridging %+v devices on host %q with delay=%v", devicesToBridge, hostMachineID, reconfigureDelay)
+	log.Tracef("Bridging %+v devices on host %q with delay=%v", devicesToBridge, hostMachineTag.String(), reconfigureDelay)
 
 	err = bridger.Bridge(devicesToBridge, reconfigureDelay)
 
@@ -73,7 +78,7 @@ func prepareHost(bridger network.Bridger, hostMachineID string, containerTag nam
 	}
 
 	if len(observedConfig) > 0 {
-		err := api.SetHostMachineNetworkConfig(hostMachineID, observedConfig)
+		err := api.SetHostMachineNetworkConfig(hostMachineTag, observedConfig)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -86,6 +91,7 @@ func prepareHost(bridger network.Bridger, hostMachineID string, containerTag nam
 func prepareOrGetContainerInterfaceInfo(
 	api APICalls,
 	machineID string,
+	bridgeDevice string,
 	allocateOrMaintain bool,
 	log loggo.Logger,
 ) ([]network.InterfaceInfo, error) {

--- a/worker/provisioner/broker_test.go
+++ b/worker/provisioner/broker_test.go
@@ -119,8 +119,8 @@ func (f *fakeAPI) ReleaseContainerAddresses(tag names.MachineTag) error {
 	return nil
 }
 
-func (f *fakeAPI) SetHostMachineNetworkConfig(hostMachineID string, netConfig []params.NetworkConfig) error {
-	f.MethodCall(f, "SetHostMachineNetworkConfig", hostMachineID, netConfig)
+func (f *fakeAPI) SetHostMachineNetworkConfig(hostMachineTag names.MachineTag, netConfig []params.NetworkConfig) error {
+	f.MethodCall(f, "SetHostMachineNetworkConfig", hostMachineTag.String(), netConfig)
 	if err := f.NextErr(); err != nil {
 		return err
 	}

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -9,10 +9,13 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/mutex"
 	"github.com/juju/utils/clock"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/common"
 	apiprovisioner "github.com/juju/juju/api/provisioner"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloudconfig/instancecfg"
@@ -153,19 +156,24 @@ func (cs *ContainerSetup) initialiseAndStartProvisioner(abort <-chan struct{}, c
 	return StartProvisioner(cs.runner, containerType, cs.provisioner, cs.config, broker, toolsFinder)
 }
 
-// runInitialiser runs the container initialiser with the initialisation hook held.
-func (cs *ContainerSetup) runInitialiser(abort <-chan struct{}, containerType instance.ContainerType, initialiser container.Initialiser) error {
-	logger.Debugf("running initialiser for %s containers", containerType)
+// acquireLock tries to grab the machine lock (initLockName), and either
+// returns it in a locked state, or returns an error.
+func (cs *ContainerSetup) acquireLock(abort <-chan struct{}) (mutex.Releaser, error) {
 	spec := mutex.Spec{
 		Name:  cs.initLockName,
 		Clock: clock.WallClock,
-		// If we don't get the lock straigh away, there is no point trying multiple
+		// If we don't get the lock straight away, there is no point trying multiple
 		// times per second for an operation that is likelty to take multiple seconds.
 		Delay:  time.Second,
 		Cancel: abort,
 	}
-	logger.Debugf("acquire lock %q for container initialisation", cs.initLockName)
-	releaser, err := mutex.Acquire(spec)
+	return mutex.Acquire(spec)
+}
+
+// runInitialiser runs the container initialiser with the initialisation hook held.
+func (cs *ContainerSetup) runInitialiser(abort <-chan struct{}, containerType instance.ContainerType, initialiser container.Initialiser) error {
+	logger.Debugf("running initialiser for %s containers, acquiring lock %q", containerType, cs.initLockName)
+	releaser, err := cs.acquireLock(abort)
 	if err != nil {
 		return errors.Annotate(err, "failed to acquire initialization lock")
 	}
@@ -183,6 +191,56 @@ func (cs *ContainerSetup) runInitialiser(abort <-chan struct{}, containerType in
 // TearDown is defined on the StringsWatchHandler interface.
 func (cs *ContainerSetup) TearDown() error {
 	// Nothing to do here.
+	return nil
+}
+
+func (cs *ContainerSetup) prepareHost(containerTag names.MachineTag, log loggo.Logger) error {
+	devicesToBridge, reconfigureDelay, err := cs.provisioner.HostChangesForContainer(containerTag)
+	if err != nil {
+		return errors.Annotate(err, "unable to setup network")
+	}
+
+	if len(devicesToBridge) == 0 {
+		log.Debugf("container %q requires no additional bridges", containerTag)
+		return nil
+	}
+
+	bridger, err := network.DefaultEtcNetworkInterfacesBridger(activateBridgesTimeout, instancecfg.DefaultBridgePrefix, systemNetworkInterfacesFile)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	log.Debugf("Bridging %+v devices on host %q with delay=%v, acquiring lock %q",
+		devicesToBridge, cs.machine.MachineTag().String(), reconfigureDelay, cs.initLockName)
+	// TODO(jam): 2017-02-08 figure out how to thread catacomb.Dying() into
+	// this function, so that we can stop trying to acquire the lock if we are
+	// stopping.
+	releaser, err := cs.acquireLock(nil)
+	if err != nil {
+		return errors.Annotatef(err, "failed to acquire lock %q for bridging", cs.initLockName)
+	}
+	defer log.Debugf("releasing lock %q for bridging", cs.initLockName)
+	defer releaser.Release()
+	err = bridger.Bridge(devicesToBridge, reconfigureDelay)
+	if err != nil {
+		return errors.Annotate(err, "failed to bridge devices")
+	}
+
+	// We just changed the hosts' network setup so discover new
+	// interfaces/devices and propagate to state.
+	observedConfig, err := getObservedNetworkConfig(common.DefaultNetworkConfigSource())
+	if err != nil {
+		return errors.Annotate(err, "cannot discover observed network config")
+	}
+
+	if len(observedConfig) > 0 {
+		err := cs.provisioner.SetHostMachineNetworkConfig(cs.machine.MachineTag(), observedConfig)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		logger.Debugf("observed network config updated")
+	}
+
 	return nil
 }
 
@@ -216,7 +274,7 @@ func (cs *ContainerSetup) getContainerArtifacts(
 	case instance.KVM:
 		broker, err = NewKvmBroker(
 			bridger,
-			cs.machine.Tag().String(),
+			cs.machine.MachineTag(),
 			cs.provisioner,
 			cs.config,
 			managerConfig,
@@ -235,9 +293,8 @@ func (cs *ContainerSetup) getContainerArtifacts(
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		broker, err = NewLxdBroker(
-			bridger,
-			cs.machine.Tag().String(),
+		broker, err = NewLXDBroker(
+			cs.prepareHost,
 			cs.provisioner,
 			manager,
 			cs.config,

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -18,32 +18,59 @@ import (
 
 var lxdLogger = loggo.GetLogger("juju.provisioner.lxd")
 
-var NewLxdBroker = func(
+type PrepareHostFunc func(containerTag names.MachineTag, log loggo.Logger) error
+
+// TODO(jam): 2017-02-08 should be removed, only here for legacy testing, etc.
+func NewLxdBroker(
 	bridger network.Bridger,
-	hostMachineID string,
+	hostMachineTag names.MachineTag,
+	api APICalls,
+	manager container.Manager,
+	agentConfig agent.Config,
+) (environs.InstanceBroker, error) {
+	prepareWrapper := func(containerTag names.MachineTag, log loggo.Logger) error {
+		return prepareHost(bridger, hostMachineTag, containerTag, api, log)
+	}
+	return NewLXDBroker(prepareWrapper, api, manager, agentConfig)
+}
+
+// NewLXDBroker creates a Broker that can be used to start LXD containers in a
+// similar fashion to normal StartInstance requests.
+// prepareHost is a callback that will be called when a new container is about
+// to be started. It provides the intersection point where the host can update
+// itself to be ready for whatever changes are necessary to have a functioning
+// container. (such as bridging host devices.)
+// manager is the infrastructure to actually launch the container.
+// agentConfig is currently only used to find out the 'default' bridge to use
+// when a specific network device is not specified in StartInstanceParams. This
+// should be deprecated. And hopefully removed in the future.
+func NewLXDBroker(
+	prepareHost PrepareHostFunc,
 	api APICalls,
 	manager container.Manager,
 	agentConfig agent.Config,
 ) (environs.InstanceBroker, error) {
 	return &lxdBroker{
-		bridger:       bridger,
-		hostMachineID: hostMachineID,
-		manager:       manager,
-		api:           api,
-		agentConfig:   agentConfig,
+		prepareHost: prepareHost,
+		manager:     manager,
+		api:         api,
+		agentConfig: agentConfig,
 	}, nil
 }
 
 type lxdBroker struct {
-	bridger       network.Bridger
-	hostMachineID string
-	manager       container.Manager
-	api           APICalls
-	agentConfig   agent.Config
+	prepareHost PrepareHostFunc
+	manager     container.Manager
+	api         APICalls
+	agentConfig agent.Config
 }
 
 func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	containerMachineID := args.InstanceConfig.MachineId
+	bridgeDevice := broker.agentConfig.Value(agent.LxdBridge)
+	if bridgeDevice == "" {
+		bridgeDevice = network.DefaultLXDBridge
+	}
 
 	config, err := broker.api.ContainerConfig()
 	if err != nil {
@@ -51,7 +78,7 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		return nil, err
 	}
 
-	err = prepareHost(broker.bridger, broker.hostMachineID, names.NewMachineTag(containerMachineID), broker.api, kvmLogger)
+	err = broker.prepareHost(names.NewMachineTag(containerMachineID), lxdLogger)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -59,27 +86,24 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	preparedInfo, err := prepareOrGetContainerInterfaceInfo(
 		broker.api,
 		containerMachineID,
+		bridgeDevice,
 		true, // allocate if possible, do not maintain existing.
 		lxdLogger,
 	)
 	if err != nil {
-		return nil, errors.Trace(err)
+		// It's not fatal (yet) if we couldn't pre-allocate addresses for the
+		// container.
+		logger.Warningf("failed to prepare container %q network config: %v", containerMachineID, err)
+	} else {
+		args.NetworkInfo = preparedInfo
 	}
-	// Something to fallback to if there are no devices given in args.NetworkInfo
-	// TODO(jam): 2017-02-07, this feels like something that should never need
-	// to be invoked, because either StartInstance or
-	// prepareOrGetContainerInterfaceInfo should always return a value. The
-	// test suite currently doesn't think so, and I'm hesitant to munge it too
-	// much.
-	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
-	if bridgeDevice == "" {
-		bridgeDevice = container.DefaultLxdBridge
-	}
-	interfaces, err := finishNetworkConfig(bridgeDevice, preparedInfo)
+
+	network := container.BridgeNetworkConfig(bridgeDevice, 0, args.NetworkInfo)
+	interfaces, err := finishNetworkConfig(bridgeDevice, args.NetworkInfo)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	network := container.BridgeNetworkConfig(bridgeDevice, 0, interfaces)
+	network.Interfaces = interfaces
 
 	// The provisioner worker will provide all tools it knows about
 	// (after applying explicitly specified constraints), which may
@@ -151,10 +175,17 @@ func (broker *lxdBroker) AllInstances() (result []instance.Instance, err error) 
 func (broker *lxdBroker) MaintainInstance(args environs.StartInstanceParams) error {
 	machineID := args.InstanceConfig.MachineId
 
+	// Default to using the host network until we can configure.
+	bridgeDevice := broker.agentConfig.Value(agent.LxdBridge)
+	if bridgeDevice == "" {
+		bridgeDevice = network.DefaultLXDBridge
+	}
+
 	// There's no InterfaceInfo we expect to get below.
 	_, err := prepareOrGetContainerInterfaceInfo(
 		broker.api,
 		machineID,
+		bridgeDevice,
 		false, // maintain, do not allocate.
 		lxdLogger,
 	)

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -652,6 +652,12 @@ func (task *provisionerTask) maintainMachines(machines []*apiprovisioner.Machine
 
 func (task *provisionerTask) startMachines(machines []*apiprovisioner.Machine) error {
 	for _, m := range machines {
+		// Make sure we shouldn't be stopping before we start the next machine
+		select {
+		case <-task.catacomb.Dying():
+			return task.catacomb.ErrDying()
+		default:
+		}
 
 		pInfo, err := m.ProvisioningInfo()
 		if err != nil {


### PR DESCRIPTION
Merge the latest 2.1 work into develop.

Including:
- Track uses of StatePool to help find memory leaks
- More work on AdoptResources
- Update host bridging changes to use the machine lock while making changes, so as to not do network changes while a hook is executing.
- Allow for clock skew for lease manager
- Add interactive auth for 'lxd' provider