### PR TITLE
environs/manual: CentOS 7 manual provisioning

### DIFF
--- a/environs/manual/sshprovisioner/sshprovisioner.go
+++ b/environs/manual/sshprovisioner/sshprovisioner.go
@@ -185,7 +185,13 @@ func checkProvisioned(host string) (bool, error) {
 // detect the OS series and hardware characteristics.
 const detectionScript = `#!/bin/bash
 set -e
-lsb_release -cs
+os_id=$(grep '^ID=' /etc/os-release | tr -d '"' | cut -d= -f2)
+if [ "$os_id" = 'centos' ]; then
+  os_version=$(grep '^VERSION_ID=' /etc/os-release | tr -d '"' | cut -d= -f2)
+  echo "centos$os_version"
+else
+  lsb_release -cs
+fi
 uname -m
 grep MemTotal /proc/meminfo
 cat /proc/cpuinfo`


### PR DESCRIPTION
## Description of change

Update the series detection script in manual
provisioning to support CentOS 7. With this
change it is possible to manually provision
a "centos/7" image in LXD.

## QA steps

1. lxc launch images:centos/7 c7
2. lxc exec c7 bash
 - yum install sudo openssh-server redhat-lsb-core
 - passwd # otherwise upon SSH login you will be prompted to reset your password
 - systemctl start sshd
 - copy SSH public key to /root/.ssh/authorized_keys in container, chown root:root

4. juju bootstrap localhost

(using github.com/axw/tools plugin)
5. juju tools build 2.1.0.1-centos7-amd64
6. juju tools upload 2.1.0.1-centos7-amd64.tgz

7. lxc launch ubuntu-xenial x
8. copy SSH public key to /home/ubuntu/.ssh/authorized_keys in x, chown ubuntu:ubuntu

9. juju add-machine ssh:root@<address-of-c7>
10. juju add-machine ssh:ubuntu@<address-of-x>
11. juju run --all cat /etc/os-release

## Documentation changes

Documentation should be updated with instructions on setting up CentOS 7 in LXD as above.

## Bug reference

This was done as a response to https://bugs.launchpad.net/juju/+bug/1495978. That bug really calls for the LXD provider to handle provisioning CentOS 7 machines, which is not currently feasible. Fixing that requires that we have CentOS images with cloud-init, or at least user-data script execution.