### PR TITLE
Back to rc1.

### DIFF
--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Juju"
-#define MyAppVersion "2.1.0"
+#define MyAppVersion "2.1-rc1"
 #define MyAppPublisher "Canonical, Ltd"
 #define MyAppURL "http://jujucharms.com/"
 #define MyAppExeName "juju.exe"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: juju
-version: 2.1.0
+version: 2.1-rc1
 summary: juju client
 description: Through the use of charms, juju provides you with shareable, re-usable, and repeatable expressions of devops best practices.
 confinement: devmode

--- a/version/version.go
+++ b/version/version.go
@@ -19,7 +19,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "2.1.0"
+const version = "2.1-rc1"
 
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = semversion.MustParse("1.19.9")


### PR DESCRIPTION
## Description of change

We have decided to return to the 2.1-rc1 name because we do not want to use the 2.1.0 version until we are certain stakeholders will adopt it. This version will be released to the devel agent-stream which Juju will automatically select when it detects the letters in its version. We will manually copy the clients to the proposed ppa.

## QA steps

juju version will report 2.1-rc1 in the version string.
CI will confirm the snap and windows version.

## Documentation changes

None

## Bug reference

None
